### PR TITLE
feat(Studies/RudolphKocurek2024): ground modifiers and conditional

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -147,6 +147,7 @@ import Linglib.Core.Logic.FirstOrder.Binders
 import Linglib.Core.Logic.FirstOrder.EhrenfeuchtFraisse
 import Linglib.Core.Logic.FirstOrder.EhrenfeuchtFraisseGame
 import Linglib.Core.Logic.FirstOrder.Kripke
+import Linglib.Core.Logic.FirstOrder.TotalPreorder
 import Linglib.Core.Logic.FirstOrder.Lindstrom
 import Linglib.Core.Logic.FirstOrder.QuantifierRank
 import Linglib.Core.Logic.Modal.BSML.Bisimulation

--- a/Linglib/Core/Logic/FirstOrder/TotalPreorder.lean
+++ b/Linglib/Core/Logic/FirstOrder/TotalPreorder.lean
@@ -1,0 +1,83 @@
+import Mathlib.ModelTheory.Order
+import Linglib.Core.Order.TotalPreorder
+
+/-!
+# The model theory of total preorders
+
+The theory of total preorders in mathlib's `Language.order` — `preorderTheory`
+plus the totality sentence, one antisymmetry axiom short of
+`linearOrderTheory` — and the round-trip between its models and the working
+bundle `Core.Order.TotalPreorder`. The canonical semantic-ordering object is
+the model-theoretic one (a `Language.order.Structure` satisfying this theory,
+the same shape as every other model in the first-order substrate); the bundle
+is its decidable, proof-transparent presentation, and `toStructure`/`ofModel`
+exchange the two.
+-/
+
+namespace FirstOrder.Language
+
+variable (L : Language) [IsOrdered L]
+
+/-- The theory of total preorders: `preorderTheory` plus totality. Sits
+strictly between `preorderTheory` and `linearOrderTheory` (antisymmetry). -/
+def totalPreorderTheory : L.Theory :=
+  insert leSymb.total L.preorderTheory
+
+variable {L} {M : Type*}
+
+instance [L.Structure M] [h : M ⊨ L.totalPreorderTheory] :
+    M ⊨ L.preorderTheory :=
+  h.mono (Set.subset_insert _ _)
+
+end FirstOrder.Language
+
+namespace Core.Order.TotalPreorder
+
+open FirstOrder FirstOrder.Language
+
+variable {α : Type*}
+
+/-- The `Language.order`-structure a bundle presents: `leSymb` is `ord.le`. -/
+@[implicit_reducible] def toStructure (ord : Core.Order.TotalPreorder α) :
+    Language.order.Structure α :=
+  @orderStructure α ⟨ord.le⟩
+
+/-- The presented structure models the total-preorder theory: the bundle is a
+decidable presentation of the model-theoretic object. -/
+theorem toStructure_model (ord : Core.Order.TotalPreorder α) :
+    letI := ord.toStructure
+    α ⊨ Language.order.totalPreorderTheory := by
+  letI := ord.toStructure
+  refine Theory.model_iff _ |>.mpr fun φ hφ => ?_
+  simp only [Language.totalPreorderTheory, Language.preorderTheory,
+    Set.mem_insert_iff, Set.mem_singleton_iff] at hφ
+  rcases hφ with rfl | rfl | rfl
+  · rw [Relations.realize_total]
+    exact ⟨fun a b => ord.le_total a b⟩
+  · rw [Relations.realize_reflexive]
+    exact ⟨ord.le_refl⟩
+  · rw [Relations.realize_transitive]
+    exact ⟨fun a b c => ord.le_trans a b c⟩
+
+/-- A decidable model of the total-preorder theory presents a bundle: the two
+presentations round-trip. -/
+def ofModel [Language.order.Structure α]
+    [h : α ⊨ Language.order.totalPreorderTheory]
+    [DecidableRel (fun a b : α =>
+      Structure.RelMap (leSymb : Language.order.Relations 2) ![a, b])] :
+    Core.Order.TotalPreorder α where
+  le a b := Structure.RelMap (leSymb : Language.order.Relations 2) ![a, b]
+  isPreorder :=
+    { refl := (Relations.realize_reflexive.mp <|
+        Theory.model_iff _ |>.mp
+          (inferInstance : α ⊨ Language.order.preorderTheory) _ <|
+          by simp [Language.preorderTheory]).refl
+      trans := (Relations.realize_transitive.mp <|
+        Theory.model_iff _ |>.mp
+          (inferInstance : α ⊨ Language.order.preorderTheory) _ <|
+          by simp [Language.preorderTheory]).trans }
+  total := Relations.realize_total.mp <|
+    Theory.model_iff _ |>.mp h _ <| by simp [Language.totalPreorderTheory]
+  decRel := inferInstance
+
+end Core.Order.TotalPreorder

--- a/Linglib/Core/Order/TotalPreorder.lean
+++ b/Linglib/Core/Order/TotalPreorder.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Order.Antisymmetrization
 import Mathlib.Order.Defs.Unbundled
 
 /-!
@@ -18,7 +19,17 @@ must be first-class data.
   from a Boolean table, for finite models).
 * `IsMaximal`, `AcceptedAt` — top-ranked points, and truth of a predicate
   throughout them (Stalnaker-style acceptance on a plausibility frame).
--/
+
+## Implementation notes
+
+Mathlib has no bundled order-on-a-carrier object (its `Preord` bundles a
+*type* with one order); its two idioms for an-order-as-data are a raw relation
+with unbundled relation classes — the founding used here — or a term
+`p : Preorder α` consumed via `letI`. The alternative `extends Preorder α`
+shape would transport the `Preorder` API but makes `lt` an opaque field,
+where consumers need the transparent `le a b ∧ ¬ le b a` for `decide` and for
+destructuring. Same-rank equivalence is mathlib's `AntisymmRel` rather than a
+new definition. -/
 
 namespace Core.Order
 
@@ -57,8 +68,9 @@ def lt (a b : α) : Prop := ord.le a b ∧ ¬ ord.le b a
 instance decRelLt : DecidableRel ord.lt := fun _ _ =>
   inferInstanceAs (Decidable (_ ∧ _))
 
-/-- Equivalence: a and b are ranked at the same level. -/
-def equiv (a b : α) : Prop := ord.le a b ∧ ord.le b a
+/-- Equivalence: a and b are ranked at the same level — mathlib's
+`AntisymmRel` (whose `AntisymmRel.setoid` is the level-quotient). -/
+abbrev equiv (a b : α) : Prop := AntisymmRel ord.le a b
 
 instance decRelEquiv : DecidableRel ord.equiv := fun _ _ =>
   inferInstanceAs (Decidable (_ ∧ _))

--- a/Linglib/Core/Order/TotalPreorder.lean
+++ b/Linglib/Core/Order/TotalPreorder.lean
@@ -22,14 +22,18 @@ must be first-class data.
 
 ## Implementation notes
 
-Mathlib has no bundled order-on-a-carrier object (its `Preord` bundles a
-*type* with one order); its two idioms for an-order-as-data are a raw relation
-with unbundled relation classes — the founding used here — or a term
-`p : Preorder α` consumed via `letI`. The alternative `extends Preorder α`
-shape would transport the `Preorder` API but makes `lt` an opaque field,
-where consumers need the transparent `le a b ∧ ¬ le b a` for `decide` and for
-destructuring. Same-rank equivalence is mathlib's `AntisymmRel` rather than a
-new definition. -/
+The canonical form of an ordering-as-data is the model-theoretic one: a
+`Language.order.Structure` modeling the total-preorder theory
+(`Core/Logic/FirstOrder/TotalPreorder.lean`, where `toStructure`/`ofModel`
+exchange the two presentations). This bundle is that object's decidable,
+proof-transparent working presentation. Mathlib has no bundled
+order-on-a-carrier object (its `Preord` bundles a *type* with one order);
+among term-level presentations, a raw relation with unbundled relation
+classes — the founding used here — beats `extends Preorder α`, which would
+transport the `Preorder` API but makes `lt` an opaque field where consumers
+need the transparent `le a b ∧ ¬ le b a` for `decide` and destructuring.
+Same-rank equivalence is mathlib's `AntisymmRel` rather than a new
+definition. -/
 
 namespace Core.Order
 

--- a/Linglib/Studies/RudolphKocurek2024.lean
+++ b/Linglib/Studies/RudolphKocurek2024.lean
@@ -80,6 +80,15 @@ def MFormula.me {Pred Entity : Type*} (A B : MFormula Pred Entity) :
     MFormula Pred Entity :=
   .conj (.neg (.mc A B)) (.neg (.mc B A))
 
+/-- Formulas free of the metalinguistic comparative: the fragment whose truth
+does not consult the ordering (`evalGen_congr_of_mcFree`). -/
+def MFormula.MCFree {Pred Entity : Type*} : MFormula Pred Entity → Prop
+  | .atom _ _ => True
+  | .neg A => A.MCFree
+  | .conj A B => A.MCFree ∧ B.MCFree
+  | .disj A B => A.MCFree ∧ B.MCFree
+  | .mc _ _ => False
+
 /-! ### Semantics (§4.2 of the paper) -/
 
 section Semantics
@@ -165,6 +174,22 @@ theorem eval_mc_iff_strict_dominationLift (A B : MFormula Pred Entity)
   · rintro ⟨x, ⟨h1, h2, h3⟩, hdom⟩
     exact ⟨x, h1, h2, h3, fun b hb1 hb2 hb3 => hdom b ⟨hb1, hb2, hb3⟩⟩
 
+/-- MC-free formulas are ordering-invariant: only ≻ consults the ordering. -/
+theorem evalGen_congr_of_mcFree :
+    ∀ (φ : MFormula Pred Entity), φ.MCFree →
+      ∀ (le le' : I → I → Prop) (i : I) (w : W),
+      (EvalGen interpFn φ le i w ↔ EvalGen interpFn φ le' i w)
+  | .atom _ _, _, _, _, _, _ => Iff.rfl
+  | .neg A, h, le, le', i, w =>
+      not_congr (evalGen_congr_of_mcFree A h le le' i w)
+  | .conj A B, h, le, le', i, w =>
+      and_congr (evalGen_congr_of_mcFree A h.1 le le' i w)
+        (evalGen_congr_of_mcFree B h.2 le le' i w)
+  | .disj A B, h, le, le', i, w =>
+      or_congr (evalGen_congr_of_mcFree A h.1 le le' i w)
+        (evalGen_congr_of_mcFree B h.2 le le' i w)
+  | .mc _ _, h, _, _, _, _ => h.elim
+
 /-! ### General entailment facts
 
 Of the supplement's Fact 3 entailment patterns, those that follow directly from
@@ -237,6 +262,22 @@ instance {I : Type*} (ord : SemanticOrdering I) (d : DistanceFunction I ord) :
     DecidableRel (FarBelow ord d) := fun _ _ =>
   inferInstanceAs (Decidable (_ ∧ _))
 
+/-- Two points cannot be far below each other: centeredness plus
+noncontractivity force mutually-≤ points to be close. -/
+theorem FarBelow.asymm {I : Type*} {ord : SemanticOrdering I}
+    (d : DistanceFunction I ord) {a b : I} (h : FarBelow ord d a b) :
+    ¬ FarBelow ord d b a :=
+  fun h' => h'.2 (d.noncontractive b b a (d.centered b) h'.1 h.1)
+
+/-- The "not far below" relation is total — the totality that lets the
+strict l-lifting characterization apply to ≫. -/
+theorem not_farBelow_total {I : Type*} {ord : SemanticOrdering I}
+    (d : DistanceFunction I ord) (a b : I) :
+    ¬ FarBelow ord d a b ∨ ¬ FarBelow ord d b a := by
+  by_cases h : FarBelow ord d a b
+  · exact Or.inr (FarBelow.asymm d h)
+  · exact Or.inl h
+
 section Modifiers
 
 variable {I W Pred Entity : Type*} [Fintype I]
@@ -281,6 +322,54 @@ instance (φ : MFormula Pred Entity) (ord : SemanticOrdering I)
   unfold EvalMostly; infer_instance
 
 end Modifiers
+
+section ModifierGroundings
+
+variable {I W Pred Entity : Type*}
+  (interpFn : I → Interpretation W Pred Entity)
+
+/-- **Grounding**: ≫ is the strict l-lifting under the *coarser* total
+preorder "not far below" — the distance-function axioms are exactly what
+make that relation total, so [holliday-icard-2013]'s lift machinery applies
+with ≪ in the role of <. -/
+theorem evalMuchMore_iff_strict_dominationLift (φ ψ : MFormula Pred Entity)
+    (ord : SemanticOrdering I) (d : DistanceFunction I ord) (i : I) (w : W) :
+    EvalMuchMore interpFn φ ψ ord d i w ↔
+    ComparativeProbability.Strict
+      (ComparativeProbability.dominationLift (fun a b => ¬ FarBelow ord d a b))
+      {x | ord.le x i ∧ Eval interpFn φ ord x w ∧ ¬ Eval interpFn ψ ord x w}
+      {x | ord.le x i ∧ Eval interpFn ψ ord x w ∧ ¬ Eval interpFn φ ord x w} := by
+  rw [ComparativeProbability.strict_dominationLift_iff
+    (fun a b => not_farBelow_total d a b)]
+  constructor
+  · rintro ⟨x, h1, h2, h3, hdom⟩
+    refine ⟨x, ⟨h1, h2, h3⟩, fun b ⟨hb1, hb2, hb3⟩ => ?_⟩
+    have hfb := hdom b hb1 hb2 hb3
+    exact ⟨FarBelow.asymm d hfb, not_not_intro hfb⟩
+  · rintro ⟨x, ⟨h1, h2, h3⟩, hdom⟩
+    exact ⟨x, h1, h2, h3, fun b hb1 hb2 hb3 =>
+      not_not.mp (hdom b ⟨hb1, hb2, hb3⟩).2⟩
+
+/-- **Grounding**: *mostly* is the strict l-lifting comparing φ-uniform
+*levels* (`ord.equiv`-classes, mathlib's `AntisymmRel.setoid`): some
+reasonably-high all-φ level strictly below the index dominates every
+all-¬φ level below it. -/
+theorem evalMostly_iff_strict_dominationLift (φ : MFormula Pred Entity)
+    (ord : SemanticOrdering I) (d : DistanceFunction I ord) (i : I) (w : W) :
+    EvalMostly interpFn φ ord d i w ↔
+    ComparativeProbability.Strict
+      (ComparativeProbability.dominationLift (fun a b => ord.le b a))
+      {x | ord.lt x i ∧ d.close i x ∧ ∀ j, ord.equiv j x → Eval interpFn φ ord j w}
+      {x | ord.lt x i ∧ ∀ j, ord.equiv j x → ¬ Eval interpFn φ ord j w} := by
+  rw [ComparativeProbability.strict_dominationLift_iff
+    (fun a b => ord.le_total b a)]
+  constructor
+  · rintro ⟨x, h1, h2, h3, hdom⟩
+    exact ⟨x, ⟨h1, h2, h3⟩, fun b ⟨hb1, hb2⟩ => hdom b hb1 hb2⟩
+  · rintro ⟨x, ⟨h1, h2, h3⟩, hdom⟩
+    exact ⟨x, h1, h2, h3, fun b hb1 hb2 => hdom b ⟨hb1, hb2⟩⟩
+
+end ModifierGroundings
 
 /-! ### No Reversal and the delineation bridge ([klein-1980], §7) -/
 
@@ -471,6 +560,25 @@ def EvalMCond (A B : MFormula Pred Entity) (ord : SemanticOrdering I)
 instance (A B : MFormula Pred Entity) (ord : SemanticOrdering I) (i : I) (w : W) :
     Decidable (EvalMCond interpFn A B ord i w) := by
   unfold EvalMCond; infer_instance
+
+omit [Fintype I] in
+/-- **Grounding in the common-ground substrate**: for an MC-free consequent —
+strictly weaker than the paper's reduction, which also assumes the antecedent
+MC-free — the metalinguistic conditional is Stalnakerian entailment
+(`ContextSet.entails`) of the consequent by the ranked antecedent-cone. The
+antecedent may contain ≻ freely: it is always evaluated at the full ordering,
+and an MC-free consequent never consults the restricted one. -/
+theorem evalMCond_iff_entails (A B : MFormula Pred Entity) (hB : B.MCFree)
+    (ord : SemanticOrdering I) (i : I) (w : W) :
+    EvalMCond interpFn A B ord i w ↔
+    CommonGround.ContextSet.entails
+      {x | ord.le x i ∧ EvalGen interpFn A ord.le x w}
+      {x | EvalGen interpFn B ord.le x w} := by
+  constructor
+  · rintro h x ⟨hx1, hx2⟩
+    exact (evalGen_congr_of_mcFree interpFn B hB _ _ x w).mp (h x hx1 hx2)
+  · intro h x hx hAx
+    exact (evalGen_congr_of_mcFree interpFn B hB _ _ x w).mpr (h ⟨hx, hAx⟩)
 
 end MCond
 


### PR DESCRIPTION
Follow-up to #1046: *mostly*, ≫, and the metalinguistic conditional get their lifting backings, and `TotalPreorder` gets its model-theoretic canonical form.

**Groundings:**
- **`evalMuchMore_iff_strict_dominationLift`** — ≫ is the strict l-lifting under the coarser "not far below" preorder; the distance-function axioms (centered + noncontractive) are exactly what make that relation total (`FarBelow.asymm`, `not_farBelow_total`). Covers *very*/*sorta* as instances.
- **`evalMostly_iff_strict_dominationLift`** — *mostly* is the strict l-lifting comparing φ-uniform *levels* (`ord.equiv`-classes; `equiv` deduplicated to mathlib's `AntisymmRel`).
- **`evalMCond_iff_entails`** — for an MC-free consequent (strictly weaker than the paper's reduction: the antecedent may contain ≻ freely), the conditional is Stalnakerian `ContextSet.entails` of the consequent by the ranked antecedent-cone, via the ordering-invariance lemma `evalGen_congr_of_mcFree` on the new `MFormula.MCFree` fragment.

**Model theory** (new `Core/Logic/FirstOrder/TotalPreorder.lean`): the canonical semantic-ordering object is model-theoretic — `Language.order.totalPreorderTheory` (`preorderTheory` + totality, one antisymmetry axiom short of mathlib's `linearOrderTheory`), with the round-trip `TotalPreorder.toStructure`/`toStructure_model`/`ofModel` exchanging models and the decidable working bundle (mathlib's own `orderStructure`/`OrderedStructure` pattern). The bundle's implementation notes are corrected accordingly: bundling isn't *forced*, it's the proof-transparent presentation of the model.