### PR TITLE
style(Core/RootedTree): post-migration naming and docstring polish

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
@@ -13,7 +13,7 @@ splits a syntactic object into a *crown forest* `p.1` (the extracted
 subtrees) and a *trunk* `p.2` (the contraction quotient, carrying one
 trace-marker leaf per cut). The two primitive conservation laws are:
 
-* **weight** (`cutSummandsCN_weight`): `Σ #V(crown) + #V(trunk) = #V(T) + #cuts`
+* **weight** (`cutSummandsCN_numNodes`): `Σ #V(crown) + #V(trunk) = #V(T) + #cuts`
   — extracting a subtree removes its vertices but leaves one replacement
   trace leaf per cut.
 * **trace leaves** (`cutSummandsCN_traceLeafCount`): `Σ #trace(crown) + #trace(trunk)
@@ -30,7 +30,7 @@ and `cut_leafCount_conservation`.
 
 * `ConnesKreimer.cutSummandsG_traceLeafCount` — trace-leaf conservation at
   the planar level (mutual with the list/per-child auxiliaries).
-* `cutSummandsCN_traceLeafCount`, `cutSummandsCN_weight` — descended to
+* `cutSummandsCN_traceLeafCount`, `cutSummandsCN_numNodes` — descended to
   `Nonplanar`.
 * `cutSummandsCN_lexical_conservation` — exact non-trace-vertex conservation.
 * `Cut.numContractions` — `#cuts = card` of the crown forest.
@@ -245,7 +245,7 @@ private theorem extractC_traceLeafCount_sum_one (τ : RoseTree (α ⊕ β) → �
     | inr b => rw [extractC_inr] at h; exact absurd h (by simp)
 
 /-- The Δ^c node-count conservation (tree level), specializing the generic
-    `cutSummandsG_weight` to `extractC`. -/
+    `cutSummandsG_numNodes` to `extractC`. -/
 private theorem extractC_numNodes_sum_one (τ : RoseTree (α ⊕ β) → β) :
     ∀ t r, extractC τ t = some r → (r.map RoseTree.numNodes).sum = 1 := by
   intro t r h
@@ -288,7 +288,7 @@ theorem cutSummandsCN_traceLeafCount (τ : Nonplanar (α ⊕ β) → β)
 /-- **Weight (vertex) conservation** for the nonplanar Δ^c cuts: crown
     vertices plus trunk vertices recover the tree vertices plus one
     replacement trace leaf per cut (MCB Lemma 1.6.3). -/
-theorem cutSummandsCN_weight (τ : Nonplanar (α ⊕ β) → β)
+theorem cutSummandsCN_numNodes (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) :
     ∀ p ∈ cutSummandsCN τ T,
       (p.1.map Nonplanar.numNodes).sum + p.2.numNodes =
@@ -298,7 +298,7 @@ theorem cutSummandsCN_weight (τ : Nonplanar (α ⊕ β) → β)
   intro p hp
   rw [cutSummandsCN_mk, ConnesKreimer.cutSummandsCP_def] at hp
   obtain ⟨q, hq, rfl⟩ := Multiset.mem_map.mp hp
-  have hcons := ConnesKreimer.cutSummandsG_weight _
+  have hcons := ConnesKreimer.cutSummandsG_numNodes _
     (ConnesKreimer.extractC_numNodes_sum_one (τ ∘ Nonplanar.mk)) T₀ q hq
   show ((q.1.map Nonplanar.mk).map Nonplanar.numNodes).sum +
       (Nonplanar.mk q.2).numNodes =
@@ -335,7 +335,7 @@ theorem cutSummandsCN_lexical_conservation (τ : Nonplanar (α ⊕ β) → β)
       (p.1.map Nonplanar.traceLeafCount).sum + p.2.traceLeafCount + T.numNodes =
         (p.1.map Nonplanar.numNodes).sum + p.2.numNodes + T.traceLeafCount := by
   intro p hp
-  have hw := cutSummandsCN_weight τ T p hp
+  have hw := cutSummandsCN_numNodes τ T p hp
   have ht := cutSummandsCN_traceLeafCount τ T p hp
   omega
 
@@ -493,7 +493,7 @@ variable {α β : Type*}
 
 /-- A lexical-rooted (`Sum.inl`) nonplanar tree has a non-trace vertex
     (its root), so its trace leaves number strictly fewer than its vertices. -/
-theorem traceLeafCount_lt_weight_of_rootInl (t : Nonplanar (α ⊕ β)) (a : α)
+theorem traceLeafCount_lt_numNodes_of_rootInl (t : Nonplanar (α ⊕ β)) (a : α)
     (h : t.rootValue = Sum.inl a) : t.traceLeafCount < t.numNodes := by
   obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
     ⟨t.out, (Quotient.out_eq t).symm⟩
@@ -527,7 +527,7 @@ variable {α β : Type*}
 
 /-- Crown components of a Δ^c cut are lexical-rooted, hence have strictly
     more vertices than trace leaves. -/
-theorem cutSummandsCN_crown_traceLeafCount_lt_weight (τ : Nonplanar (α ⊕ β) → β)
+theorem cutSummandsCN_crown_traceLeafCount_lt_numNodes (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) :
     ∀ p ∈ cutSummandsCN τ T, ∀ Tv ∈ p.1, Tv.traceLeafCount < Tv.numNodes := by
   obtain ⟨T₀, rfl⟩ : ∃ T₀ : RoseTree (α ⊕ β), T = Nonplanar.mk T₀ :=
@@ -571,17 +571,17 @@ theorem cutSummandsCN_accCountC_single (τ : Nonplanar (α ⊕ β) → β)
     (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
     (Tv : Nonplanar (α ⊕ β)) (hcard : p.1 = {Tv}) :
     T.accCountC = Tv.accCountC + p.2.accCountC + 1 := by
-  have hw := cutSummandsCN_weight τ T p hp
+  have hw := cutSummandsCN_numNodes τ T p hp
   have hl := cutSummandsCN_traceLeafCount τ T p hp
   have hTv_lt : Tv.traceLeafCount < Tv.numNodes :=
-    cutSummandsCN_crown_traceLeafCount_lt_weight τ T p hp Tv
+    cutSummandsCN_crown_traceLeafCount_lt_numNodes τ T p hp Tv
       (by rw [hcard]; exact Multiset.mem_singleton_self Tv)
   have hT_root : T.rootValue = Sum.inl a₀ := by
     rw [hT, Nonplanar.rootValue_node]
   have hT_lt : T.traceLeafCount < T.numNodes :=
-    Nonplanar.traceLeafCount_lt_weight_of_rootInl T a₀ hT_root
+    Nonplanar.traceLeafCount_lt_numNodes_of_rootInl T a₀ hT_root
   have hp2_lt : p.2.traceLeafCount < p.2.numNodes :=
-    Nonplanar.traceLeafCount_lt_weight_of_rootInl p.2 a₀
+    Nonplanar.traceLeafCount_lt_numNodes_of_rootInl p.2 a₀
       ((cutSummandsCN_trunk_rootValue τ T p hp).trans hT_root)
   rw [hcard] at hw hl
   simp only [Multiset.map_singleton, Multiset.sum_singleton, Multiset.card_singleton] at hw hl
@@ -597,20 +597,20 @@ theorem cutSummandsCN_accCountC_pair (τ : Nonplanar (α ⊕ β) → β)
     (p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β)) (hp : p ∈ cutSummandsCN τ T)
     (Tv Tw : Nonplanar (α ⊕ β)) (hcard : p.1 = {Tv, Tw}) :
     T.accCountC = Tv.accCountC + Tw.accCountC + p.2.accCountC + 2 := by
-  have hw := cutSummandsCN_weight τ T p hp
+  have hw := cutSummandsCN_numNodes τ T p hp
   have hl := cutSummandsCN_traceLeafCount τ T p hp
   have hTv_lt : Tv.traceLeafCount < Tv.numNodes :=
-    cutSummandsCN_crown_traceLeafCount_lt_weight τ T p hp Tv
+    cutSummandsCN_crown_traceLeafCount_lt_numNodes τ T p hp Tv
       (by rw [hcard]; exact Multiset.mem_cons_self Tv {Tw})
   have hTw_lt : Tw.traceLeafCount < Tw.numNodes :=
-    cutSummandsCN_crown_traceLeafCount_lt_weight τ T p hp Tw
+    cutSummandsCN_crown_traceLeafCount_lt_numNodes τ T p hp Tw
       (by rw [hcard]; exact Multiset.mem_cons_of_mem (Multiset.mem_singleton_self Tw))
   have hT_root : T.rootValue = Sum.inl a₀ := by
     rw [hT, Nonplanar.rootValue_node]
   have hT_lt : T.traceLeafCount < T.numNodes :=
-    Nonplanar.traceLeafCount_lt_weight_of_rootInl T a₀ hT_root
+    Nonplanar.traceLeafCount_lt_numNodes_of_rootInl T a₀ hT_root
   have hp2_lt : p.2.traceLeafCount < p.2.numNodes :=
-    Nonplanar.traceLeafCount_lt_weight_of_rootInl p.2 a₀
+    Nonplanar.traceLeafCount_lt_numNodes_of_rootInl p.2 a₀
       ((cutSummandsCN_trunk_rootValue τ T p hp).trans hT_root)
   rw [hcard] at hw hl
   simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Defs.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Defs.lean
@@ -163,7 +163,7 @@ mutual
 /-- Cut summands conserve node count (tree level): crown node count plus
     trunk node count equals the tree node count plus one replacement
     vertex per crown component. Requires single-node replacement entries. -/
-theorem cutSummandsG_weight
+theorem cutSummandsG_numNodes
     (extract : RoseTree α → Option (List (RoseTree α)))
     (hext : ∀ t r, extract t = some r → (r.map RoseTree.numNodes).sum = 1) :
     ∀ (t : RoseTree α), ∀ p ∈ cutSummandsG extract t,
@@ -173,12 +173,12 @@ theorem cutSummandsG_weight
     intro p hp
     rw [cutSummandsG_node] at hp
     obtain ⟨q, hq, rfl⟩ := Multiset.mem_map.mp hp
-    have h := cutListSummandsG_weight extract hext cs q hq
+    have h := cutListSummandsG_numNodes extract hext cs q hq
     simp only [RoseTree.numNodes_node]
     omega
 
 /-- Mutual aux: node-count conservation for children-list cut summands. -/
-theorem cutListSummandsG_weight
+theorem cutListSummandsG_numNodes
     (extract : RoseTree α → Option (List (RoseTree α)))
     (hext : ∀ t r, extract t = some r → (r.map RoseTree.numNodes).sum = 1) :
     ∀ (cs : List (RoseTree α)), ∀ q ∈ cutListSummandsG extract cs,
@@ -194,14 +194,14 @@ theorem cutListSummandsG_weight
     rw [cutListSummandsG_cons] at hq
     obtain ⟨pr, hpr, rfl⟩ := Multiset.mem_map.mp hq
     obtain ⟨ha, hq'⟩ := Multiset.mem_product.mp hpr
-    have h1 := augActionG_weight extract hext t pr.1 ha
-    have h2 := cutListSummandsG_weight extract hext ts pr.2 hq'
+    have h1 := augActionG_numNodes extract hext t pr.1 ha
+    have h2 := cutListSummandsG_numNodes extract hext ts pr.2 hq'
     rw [Multiset.map_add, Multiset.sum_add, List.map_append, List.sum_append,
         Multiset.card_add, List.map_cons, List.sum_cons]
     omega
 
 /-- Mutual aux: node-count conservation for per-child actions. -/
-theorem augActionG_weight
+theorem augActionG_numNodes
     (extract : RoseTree α → Option (List (RoseTree α)))
     (hext : ∀ t r, extract t = some r → (r.map RoseTree.numNodes).sum = 1) :
     ∀ (t : RoseTree α), ∀ a ∈ augActionG extract t,
@@ -222,7 +222,7 @@ theorem augActionG_weight
         rw [Multiset.map_singleton, Multiset.sum_singleton, hr,
             Multiset.card_singleton]
     · obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp h
-      have h := cutSummandsG_weight extract hext t p hp
+      have h := cutSummandsG_numNodes extract hext t p hp
       simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil]
       omega
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
@@ -147,36 +147,36 @@ end
                    (cutSummandsP t).map (fun p => (p.1, Option.some p.2)) := by
   conv_lhs => unfold augActionP
 
-/-! ### comulTreePlanarP — tree-level Δ^ρ
+/-! ### comulTreeP — tree-level Δ^ρ
 
 Sum the cut summands as tensors, plus the explicit `T ⊗ 1` term. -/
 
 /-- The **tree-level Δ^ρ** coproduct: explicit `T ⊗ 1` term plus
     the sum of cut-summand tensors. -/
-noncomputable def comulTreePlanarP (T : RoseTree α) :
+noncomputable def comulTreeP (T : RoseTree α) :
     ConnesKreimer R (RoseTree α) ⊗[R] ConnesKreimer R (RoseTree α) :=
   ofTree T ⊗ₜ[R] (1 : ConnesKreimer R (RoseTree α))
   + ((cutSummandsP T).map (fun p => of' (R := R) p.1 ⊗ₜ[R] ofTree p.2)).sum
 
-/-! ### comulForestPlanarP — forest-level Δ^ρ
+/-! ### comulForestP — forest-level Δ^ρ
 
 Multiplicative extension over the disjoint-union product on forests:
 Δ(F + G) = Δ(F) · Δ(G). -/
 
 /-- The **forest-level Δ^ρ**: multiplicative product of tree-level
     coproducts over the components of the forest. -/
-noncomputable def comulForestPlanarP (F : Forest (RoseTree α)) :
+noncomputable def comulForestP (F : Forest (RoseTree α)) :
     ConnesKreimer R (RoseTree α) ⊗[R] ConnesKreimer R (RoseTree α) :=
-  (F.map (comulTreePlanarP (R := R))).prod
+  (F.map (comulTreeP (R := R))).prod
 
-@[simp] theorem comulForestPlanarP_zero :
-    comulForestPlanarP (R := R) (0 : Forest (RoseTree α)) = 1 := by
-  simp only [comulForestPlanarP, Multiset.map_zero, Multiset.prod_zero]
+@[simp] theorem comulForestP_zero :
+    comulForestP (R := R) (0 : Forest (RoseTree α)) = 1 := by
+  simp only [comulForestP, Multiset.map_zero, Multiset.prod_zero]
 
-@[simp] theorem comulForestPlanarP_add (F G : Forest (RoseTree α)) :
-    comulForestPlanarP (R := R) (F + G) =
-      comulForestPlanarP (R := R) F * comulForestPlanarP (R := R) G := by
-  unfold comulForestPlanarP
+@[simp] theorem comulForestP_add (F G : Forest (RoseTree α)) :
+    comulForestP (R := R) (F + G) =
+      comulForestP (R := R) F * comulForestP (R := R) G := by
+  unfold comulForestP
   rw [Multiset.map_add, Multiset.prod_add]
 
 /-! ### comulMonoidHom and comulAlgHom
@@ -184,13 +184,13 @@ noncomputable def comulForestPlanarP (F : Forest (RoseTree α)) :
 Package the multiplicative extension as a `MonoidHom`, then lift to the
 full `AlgHom` via `AddMonoidAlgebra.lift`. -/
 
-/-- comulForestPlanarP as a monoid hom from `Multiplicative (Forest (RoseTree α))`. -/
+/-- comulForestP as a monoid hom from `Multiplicative (Forest (RoseTree α))`. -/
 noncomputable def comulMonoidHomP :
     Multiplicative (Forest (RoseTree α)) →*
       (ConnesKreimer R (RoseTree α) ⊗[R] ConnesKreimer R (RoseTree α)) where
-  toFun F := comulForestPlanarP (R := R) F.toAdd
-  map_one' := comulForestPlanarP_zero
-  map_mul' F G := comulForestPlanarP_add F.toAdd G.toAdd
+  toFun F := comulForestP (R := R) F.toAdd
+  map_one' := comulForestP_zero
+  map_mul' F G := comulForestP_add F.toAdd G.toAdd
 
 /-- The **Δ^ρ coproduct on `ConnesKreimer R (RoseTree α)`** as an algebra hom. -/
 noncomputable def comulAlgHomP :
@@ -201,16 +201,16 @@ noncomputable def comulAlgHomP :
     (Forest (RoseTree α)) comulMonoidHomP
 
 @[simp] theorem comulAlgHomP_apply_of' (F : Forest (RoseTree α)) :
-    comulAlgHomP (R := R) (α := α) (of' F) = comulForestPlanarP F := by
+    comulAlgHomP (R := R) (α := α) (of' F) = comulForestP F := by
   show AddMonoidAlgebra.lift R _ _ comulMonoidHomP (Finsupp.single F 1) = _
   rw [AddMonoidAlgebra.lift_single, one_smul]
   rfl
 
 @[simp] theorem comulAlgHomP_apply_ofTree (T : RoseTree α) :
-    comulAlgHomP (R := R) (α := α) (ofTree T) = comulTreePlanarP T := by
+    comulAlgHomP (R := R) (α := α) (ofTree T) = comulTreeP T := by
   unfold ofTree
   rw [comulAlgHomP_apply_of']
-  unfold comulForestPlanarP
+  unfold comulForestP
   simp only [Multiset.map_singleton, Multiset.prod_singleton]
 
 end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -1817,7 +1817,7 @@ forests, sets up the graded subspaces, and packages MCB Lemma 1.2.10
 as a theorem combining the Δ^c bialgebra structure (`bialgebraC`, for
 trace-coherent encoders) with grading compatibility. Both grading
 halves are fully proved (edge conservation through the trace cut
-machinery: `cutSummandsCN_weight`). -/
+machinery: `cutSummandsCN_numNodes`). -/
 
 section MCBLemma1_2_10
 variable {R'' : Type*} [CommRing R''] {α'' β'' : Type*}
@@ -1856,7 +1856,7 @@ private theorem edgeCount_singleton {X : Type*} (T : Nonplanar X) :
   rw [Multiset.map_singleton, Multiset.sum_singleton]
 
 /-- `Σ (wᵢ − 1) + card = Σ wᵢ` for tree-level forests (each `wᵢ ≥ 1`). -/
-private theorem sum_map_weight_sub_one_add_card {γ : Type*}
+private theorem sum_map_numNodes_sub_one_add_card {γ : Type*}
     (F : Multiset (RoseTree γ)) :
     ((F.map (fun t => RoseTree.numNodes t - 1)).sum + Multiset.card F =
       (F.map RoseTree.numNodes).sum) := by
@@ -1871,8 +1871,8 @@ private theorem sum_map_weight_sub_one_add_card {γ : Type*}
 /-- **Edge conservation for Δ^c cut summands**: the trace marker replaces
     the cut subtree by a unit-weight leaf, so crown edges plus trunk
     weight recover the tree weight exactly. Descends
-    `cutSummandsG_weight` (`Coproduct/Defs.lean`) through `Nonplanar.mk`. -/
-private theorem cutSummandsCN_weight (τ : Nonplanar (α'' ⊕ β'') → β'')
+    `cutSummandsG_numNodes` (`Coproduct/Defs.lean`) through `Nonplanar.mk`. -/
+private theorem cutSummandsCN_numNodes (τ : Nonplanar (α'' ⊕ β'') → β'')
     (T : Nonplanar (α'' ⊕ β'')) :
     ∀ p ∈ cutSummandsCN τ T,
       Forest.edgeCount p.1 + p.2.numNodes = T.numNodes := by
@@ -1898,8 +1898,8 @@ private theorem cutSummandsCN_weight (τ : Nonplanar (α'' ⊕ β'') → β'')
       | inr b =>
         rw [ConnesKreimer.extractC_inr] at h
         exact absurd h (by simp)
-  have h := ConnesKreimer.cutSummandsG_weight _ hext T₀ q hq
-  have hsub := sum_map_weight_sub_one_add_card q.1
+  have h := ConnesKreimer.cutSummandsG_numNodes _ hext T₀ q hq
+  have hsub := sum_map_numNodes_sub_one_add_card q.1
   show Forest.edgeCount (q.1.map Nonplanar.mk) +
       (Nonplanar.mk q.2).numNodes = (Nonplanar.mk T₀).numNodes
   rw [Nonplanar.numNodes_mk, Nonplanar.numNodes_mk]
@@ -1965,7 +1965,7 @@ private theorem comulCTreeN_mem (τ : Nonplanar (α'' ⊕ β'') → β'')
   · refine multiset_sum_mem _ ?_
     intro c hc
     obtain ⟨p, hp, rfl⟩ := Multiset.mem_map.mp hc
-    have hcons := cutSummandsCN_weight τ T p hp
+    have hcons := cutSummandsCN_numNodes τ T p hp
     have hpos := Nonplanar.numNodes_pos p.2
     refine Submodule.subset_span ⟨p.1, {p.2}, ?_, rfl⟩
     rw [edgeCount_singleton]
@@ -2043,7 +2043,7 @@ theorem mcb_lemma_1_2_10
   refine ⟨edgeCount_add, ?_⟩
   · -- Δ^c preserves grading exactly: each cut summand splits the edges
     -- (the trace marker replaces the cut subtree by a unit-weight leaf,
-    -- `cutSummandsCN_weight`), and the homogeneous tensor spans multiply
+    -- `cutSummandsCN_numNodes`), and the homogeneous tensor spans multiply
     -- additively (`gradedTensorSpan_mul`).
     intro n F hF
     rw [comulCAlgHomN_apply_of']

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
@@ -69,7 +69,7 @@ For trees `T₁, T₂ : Nonplanar α`:
   `feedback_inserttree_does_not_commute.md`). The correct definition
   is `F • G_forest = Σ_{f : G_forest → V(F)} of' (F with each T ∈ G
   grafted at f(T))`, implemented as `RoseTree.Pathed.insertionForest` in
-  `MultiGraft.lean` and lifted to `H` as `insertion` below.
+  `PreLie/Insertion.lean` and lifted to `H` as `insertion` below.
 
 The Grossman-Larson product is given by Foissy 2021 Theorem 5.1:
 ```
@@ -179,7 +179,7 @@ multiplicity), sum over each grafting summand `S' ∈ Nonplanar.insertSum
 S T` (`S` host, `T` graft, summed over vertices of `S`) the basis
 vector for the resulting forest `S ::ₘ F.erase S` with `S` replaced by
 `S'`. The convention `Nonplanar.insertSum T_host T_graft` is fixed by
-`PreLie/Defs.lean` (verified against test + `card_insertSum_eq_weight`). -/
+`PreLie/InsertSum.lean` (verified against test + `card_insertSum_eq_numNodes`). -/
 
 /-- Forest-level single-tree insertion: graft `T` at one vertex of one
     tree of `F`, summed over (tree, vertex). -/
@@ -303,13 +303,13 @@ that defined `insertForest` via `Multiset.foldr` of `insertTree` was
 based on this misreading and has been removed.
 
 **Implementation status**: defined via Foissy 2021 Theorem 5.1's
-combinatorial formula at the `RoseTree` level (`PreLie/MultiGraft.lean`'s
+combinatorial formula at the `RoseTree` level (`PreLie/Insertion.lean`'s
 `RoseTree.Pathed.insertionForest`), descended through `Nonplanar.mk`
 (`Nonplanar.insertionMultiset`), then bilinear-extended via
 `Finsupp.linearCombination`. The substrate invariance theorems
-(PermEquiv on host/guest, Perm on multiset arguments) are stated
-as `sorry`'d theorems in `MultiGraftNonplanar.lean`. Closing those
-substrate sorries unblocks all of R.5.3/4/5 + R.6 + R.7. -/
+(PermEquiv on host/guest, Perm on multiset arguments) are proved
+sorry-free in `PreLie/Insertion.lean` and
+`Combinatorics/RootedTree/Nonplanar/Insertion.lean`. -/
 
 /-- Basis-level multi-graft on Multiset forests: each pair `(F_basis,
     G_basis)` produces a multiset of grafted forests, summed as basis

--- a/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
@@ -41,7 +41,7 @@ file is a candidate factoring of Foissy's specific recursion.
 - **Auxiliary depth lemma** (`cutSummandsN_subtree_depth_lt`): every tree
   appearing in a cut forest of `T` has strictly smaller depth than `T`.
   Lifted from a tree-level mutual structural-induction proof.
-- **Auxiliary weight lemma** (`cutSummandsN_rem_weight_lt`): for nontrivial
+- **Auxiliary weight lemma** (`cutSummandsN_rem_numNodes_lt`): for nontrivial
   cuts, the remainder has strictly smaller weight than the source. Substrate
   for the `weight`-recursive right antipode.
 - **Multiplicity-1 uniqueness** (`cutSummandsN_filter_card_zero`): the empty
@@ -214,7 +214,7 @@ which recurses on `cf` (depth strictly decreases). -/
 mutual
 
 /-- Vertex conservation for cuts of tree-level trees: `cf.weight_sum + rem.numNodes = T.numNodes`. -/
-private theorem cutSummandsP_weight_eq :
+private theorem cutSummandsP_numNodes_eq :
     ∀ (T : RoseTree α) (cf : Forest (RoseTree α)) (rem : RoseTree α),
       (cf, rem) ∈ cutSummandsP T → (cf.map RoseTree.numNodes).sum + rem.numNodes = T.numNodes
   | .node a children, cf, rem, h_mem => by
@@ -224,12 +224,12 @@ private theorem cutSummandsP_weight_eq :
     have h_rem : (RoseTree.node a rem' : RoseTree α) = rem := congrArg Prod.snd h_eq
     rw [← h_cf, ← h_rem]
     -- (cf', rem') ∈ cutListSummandsP children, weight conservation by IH.
-    have hc := cutListSummandsP_weight_eq children cf' rem' h_mem'
+    have hc := cutListSummandsP_numNodes_eq children cf' rem' h_mem'
     rw [RoseTree.numNodes_node, RoseTree.numNodes_node]
     omega
 
 /-- Vertex conservation for cuts of tree-level lists. -/
-private theorem cutListSummandsP_weight_eq :
+private theorem cutListSummandsP_numNodes_eq :
     ∀ (cs : List (RoseTree α)) (cf : Forest (RoseTree α)) (rem_list : List (RoseTree α)),
       (cf, rem_list) ∈ cutListSummandsP cs →
         (cf.map RoseTree.numNodes).sum + (rem_list.map RoseTree.numNodes).sum =
@@ -265,7 +265,7 @@ private theorem cutListSummandsP_weight_eq :
     rw [List.map_cons, List.sum_cons]
     -- Goal: ... = c.numNodes + (cs'.map RoseTree.numNodes).sum
     -- IH on cs': (cf_cs'.map weight).sum + (rem_cs'.map weight).sum = (cs'.map weight).sum.
-    have ih_cs' := cutListSummandsP_weight_eq cs' cf_cs' rem_cs' h_cf_cs'
+    have ih_cs' := cutListSummandsP_numNodes_eq cs' cf_cs' rem_cs' h_cf_cs'
     rw [augActionP_eq, Multiset.mem_cons] at h_aug
     rcases h_aug with h_aug | h_aug
     · -- aug = ({c}, none). aug_F = {c}, aug_opt = none, rem_list = rem_cs'.
@@ -289,7 +289,7 @@ private theorem cutListSummandsP_weight_eq :
         exact (congrArg Prod.snd h_eq).symm
       rw [← h_aug_F, h_rem_list]
       -- IH on cutSummandsP c: (s.1.map weight).sum + s.2.numNodes = c.numNodes.
-      have ih_c := cutSummandsP_weight_eq c s.1 s.2 h_s_mem
+      have ih_c := cutSummandsP_numNodes_eq c s.1 s.2 h_s_mem
       simp [List.map_cons, List.sum_cons]
       omega
 
@@ -298,7 +298,7 @@ end
 /-- For nontrivial cuts (cf nonempty), the remainder has strictly smaller
     weight than the source tree. Substrate for the right-antipode
     well-founded recursion. -/
-private theorem cutSummandsN_rem_weight_lt (T : Nonplanar α)
+private theorem cutSummandsN_rem_numNodes_lt (T : Nonplanar α)
     (cf : Forest (Nonplanar α)) (rem : Nonplanar α)
     (h_mem : (cf, rem) ∈ cutSummandsN T) (h_nonempty : cf ≠ 0) :
     rem.numNodes < T.numNodes := by
@@ -314,7 +314,7 @@ private theorem cutSummandsN_rem_weight_lt (T : Nonplanar α)
   rw [Nonplanar.numNodes_mk, ← h_rem, Nonplanar.numNodes_mk]
   -- Goal: rem_p.numNodes < T₀.numNodes.
   -- Use tree-level conservation: cf_p.numNodes + rem_p.numNodes = T₀.numNodes (where cf_p.numNodes = sum).
-  have h_eq := cutSummandsP_weight_eq T₀ cf_p rem_p h_mem_p
+  have h_eq := cutSummandsP_numNodes_eq T₀ cf_p rem_p h_mem_p
   -- Need cf_p ≠ 0 (from cf ≠ 0, since cf = cf_p.map mk).
   have h_cf_p_ne : cf_p ≠ 0 := by
     intro h_zero
@@ -503,12 +503,12 @@ the monoid `left_inv_eq_right_inv` argument in the convolution algebra
 `WithConv (H →ₗ[R] H)`. See §5 below.
 
 The right antipode recurses on `rem` (which has strictly smaller weight for
-nontrivial cuts, by `cutSummandsN_rem_weight_lt`) instead of on `cf`. -/
+nontrivial cuts, by `cutSummandsN_rem_numNodes_lt`) instead of on `cf`. -/
 
 set_option linter.unusedVariables false in
 /-- The **right antipode on a single nonplanar tree**: defined to satisfy the
     lTensor axiom by direct cancellation. Recurses on `rem` for nontrivial
-    cuts (well-founded by `cutSummandsN_rem_weight_lt`). -/
+    cuts (well-founded by `cutSummandsN_rem_numNodes_lt`). -/
 noncomputable def antipodeRightTreeN (T : Nonplanar α) :
     ConnesKreimer R (Nonplanar α) :=
   -ofTree T - ((cutSummandsN T).attach.map (fun ⟨pf, h_mem⟩ =>
@@ -517,7 +517,7 @@ noncomputable def antipodeRightTreeN (T : Nonplanar α) :
     else 0)).sum
 termination_by T.numNodes
 decreasing_by
-  apply cutSummandsN_rem_weight_lt T pf.1 pf.2 h_mem
+  apply cutSummandsN_rem_numNodes_lt T pf.1 pf.2 h_mem
   rwa [ne_eq, ← Multiset.card_eq_zero]
 
 /-! ### Multiplicative extension to forests for R -/

--- a/Linglib/Core/Algebra/RootedTree/PreLie/Graft.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/Graft.lean
@@ -3795,7 +3795,6 @@ private theorem absorbInnerPair_prepend_structure :
         | cons head_pair tail =>
           obtain ⟨q, T⟩ := head_pair
           exact ⟨(i - rootPrependCount X) :: q, T, rfl⟩
-termination_by _ p _ _ => p
 
 /-- The key lemma: descent-to-j of `liftBackToOuter` equals `modified`. -/
 private theorem liftBackToOuter_descentToChild_self

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -160,9 +160,9 @@ theorem im_pair_size_deltas_contraction_of_cut (lbl a₀ : α)
       ∧ Forest.sigmaC ({Nonplanar.node (Sum.inl lbl) {β_t, p.2}} : Forest (Nonplanar (α ⊕ β)))
         = Forest.sigmaC ({Nonplanar.node (Sum.inl a₀) F₀} : Forest (Nonplanar (α ⊕ β))) + 1 :=
   im_pair_size_deltas_contraction lbl
-    (cutSummandsCN_crown_traceLeafCount_lt_weight τ _ p hp β_t
+    (cutSummandsCN_crown_traceLeafCount_lt_numNodes τ _ p hp β_t
       (by rw [hcard]; exact Multiset.mem_singleton_self β_t))
-    (Nonplanar.traceLeafCount_lt_weight_of_rootInl p.2 a₀
+    (Nonplanar.traceLeafCount_lt_numNodes_of_rootInl p.2 a₀
       ((cutSummandsCN_trunk_rootValue τ _ p hp).trans (by rw [Nonplanar.rootValue_node])))
     (cutSummandsCN_accCountC_single τ _ a₀ F₀ rfl p hp β_t hcard)
 


### PR DESCRIPTION
Follow-up to #1045: `comulTree/ForestPlanarP`→`comulTree/ForestP` (the `P` suffix already marks the ordered-level pruning family), declaration names `*_weight`→`*_numNodes` to match statement content (MCB's conceptual "weight" stays in prose), drop Graft's unused `termination_by`, and de-rot GrossmanLarson docstring pointers to files that no longer exist.