### PR TITLE
refactor(Core/RootedTree): ConnesKreimer def to structure

### DIFF
--- a/Linglib/Core/Algebra/ConnesKreimer/Shuffle.lean
+++ b/Linglib/Core/Algebra/ConnesKreimer/Shuffle.lean
@@ -63,18 +63,19 @@ variable {R : Type*} [CommSemiring R] {T : Type*}
     Extends linearly via `Finsupp.lsum` to the full algebra. -/
 noncomputable def comulShuffle [DecidableEq T] :
     ConnesKreimer R T →ₗ[R] ConnesKreimer R T ⊗[R] ConnesKreimer R T :=
-  Finsupp.lsum R (fun F : Forest T =>
+  (Finsupp.lsum R (fun F : Forest T =>
     { toFun := fun r => r • (F.powerset.map fun F₁ =>
         (of' (R := R) F₁) ⊗ₜ[R] (of' (R := R) (F - F₁))).sum
       map_add' := fun r₁ r₂ => by simp [add_smul]
-      map_smul' := fun c r => by simp [mul_smul] })
+      map_smul' := fun c r => by simp [mul_smul] })).comp
+    toFinsuppAlgEquiv.toLinearMap
 
 @[simp] theorem comulShuffle_of' [DecidableEq T] (F : Forest T) :
     comulShuffle (R := R) (of' F) =
       (F.powerset.map fun F₁ =>
         (of' (R := R) F₁) ⊗ₜ[R] (of' (R := R) (F - F₁))).sum := by
-  show Finsupp.lsum R _ (Finsupp.single F (1 : R)) = _
-  rw [Finsupp.lsum_single]
+  show Finsupp.lsum R _ ((of' (R := R) F).toFinsupp) = _
+  rw [toFinsupp_of', Finsupp.lsum_single]
   show (1 : R) • (F.powerset.map fun F₁ =>
         (of' (R := R) F₁) ⊗ₜ[R] (of' (R := R) (F - F₁))).sum = _
   rw [one_smul]
@@ -218,27 +219,27 @@ private noncomputable def comulShuffleMulRHom [DecidableEq T] (G : ConnesKreimer
 /-- The shuffle coproduct is an algebra hom on `ConnesKreimer R T`:
     `Δ(F · G) = Δ(F) · Δ(G)` in the tensor algebra
     `ConnesKreimer R T ⊗[R] ConnesKreimer R T`. Bilinear lift of
-    `comulShuffle_mul_of'` via two nested `Finsupp.addHom_ext` reductions to
+    `comulShuffle_mul_of'` via two nested `addHom_ext` reductions to
     basis singletons (mirrors `assoc_symm` in `PreLie/Basic.lean`). -/
 theorem comulShuffle_mul [DecidableEq T] (F G : ConnesKreimer R T) :
     comulShuffle (R := R) (F * G) =
       comulShuffle (R := R) F * comulShuffle (R := R) G := by
-  -- Outer: reduce F to `Finsupp.single F₀ r` via addHom_ext.
+  -- Outer: reduce F to `single F₀ r` via addHom_ext.
   have hF : comulShuffleMulLHom (R := R) G = comulShuffleMulRHom (R := R) G := by
-    refine Finsupp.addHom_ext fun F₀ r => ?_
-    set sF : ConnesKreimer R T := Finsupp.single F₀ r with sF_def
+    refine addHom_ext fun F₀ r => ?_
+    set sF : ConnesKreimer R T := single F₀ r with sF_def
     show comulShuffleMulLHom G sF = comulShuffleMulRHom G sF
     rw [comulShuffleMulLHom_apply, comulShuffleMulRHom_apply]
-    -- Inner: reduce G to `Finsupp.single G₀ s` via addHom_ext on the
+    -- Inner: reduce G to `single G₀ s` via addHom_ext on the
     -- AddMonoidHom `G ↦ comulShuffle (sF * G)` vs `G ↦ comulShuffle sF * comulShuffle G`.
     have hG : (comulShuffle (R := R)).toAddMonoidHom.comp (AddMonoidHom.mulLeft sF) =
               (AddMonoidHom.mulLeft (comulShuffle (R := R) sF)).comp
                 (comulShuffle (R := R)).toAddMonoidHom := by
-      refine Finsupp.addHom_ext fun G₀ s => ?_
-      set sG : ConnesKreimer R T := Finsupp.single G₀ s with sG_def
+      refine addHom_ext fun G₀ s => ?_
+      set sG : ConnesKreimer R T := single G₀ s with sG_def
       show comulShuffle (sF * sG) = comulShuffle sF * comulShuffle sG
-      rw [show sF = r • of' (R := R) F₀ from (Finsupp.smul_single_one F₀ r).symm,
-          show sG = s • of' (R := R) G₀ from (Finsupp.smul_single_one G₀ s).symm]
+      rw [show sF = r • of' (R := R) F₀ from smul_single_one F₀ r,
+          show sG = s • of' (R := R) G₀ from smul_single_one G₀ s]
       rw [smul_mul_smul_comm, LinearMap.map_smul, LinearMap.map_smul, LinearMap.map_smul,
           smul_mul_smul_comm]
       congr 1
@@ -342,7 +343,7 @@ private theorem swap_comulShuffle_powerset [DecidableEq T] (F : Forest T) :
 
 /-- Cocommutativity of `comulShuffle`: `swap ∘ Δ = Δ` where `swap` is
     the tensor-product flip. Lifted from basis form `comulShuffle_comm_multiset`
-    via single-variable `Finsupp.addHom_ext` reduction. -/
+    via single-variable `addHom_ext` reduction. -/
 theorem comulShuffle_comm [DecidableEq T] :
     (TensorProduct.comm R (ConnesKreimer R T) (ConnesKreimer R T)).toLinearMap.comp
       (comulShuffle (R := R)) = comulShuffle (R := R) := by
@@ -352,11 +353,11 @@ theorem comulShuffle_comm [DecidableEq T] :
   have h : ((TensorProduct.comm R (ConnesKreimer R T) (ConnesKreimer R T)).toLinearMap.comp
               (comulShuffle (R := R))).toAddMonoidHom =
             (comulShuffle (R := R)).toAddMonoidHom := by
-    refine Finsupp.addHom_ext fun F₀ r => ?_
-    set sF : ConnesKreimer R T := Finsupp.single F₀ r with sF_def
+    refine addHom_ext fun F₀ r => ?_
+    set sF : ConnesKreimer R T := single F₀ r with sF_def
     show (TensorProduct.comm R (ConnesKreimer R T) (ConnesKreimer R T))
           (comulShuffle (R := R) sF) = comulShuffle (R := R) sF
-    rw [show sF = r • of' (R := R) F₀ from (Finsupp.smul_single_one F₀ r).symm]
+    rw [show sF = r • of' (R := R) F₀ from smul_single_one F₀ r]
     rw [LinearMap.map_smul, map_smul]
     congr 1
     rw [comulShuffle_of']
@@ -612,7 +613,7 @@ private theorem assocHom_double_sum [DecidableEq T]
 /-- LinearMap form of `comulShuffle` coassociativity, as required by
     the `Coalgebra` typeclass: `(Δ ⊗ id) ∘ Δ = (id ⊗ Δ) ∘ Δ` (up to
     associator). Lifted from basis form `comulShuffle_coassoc_basis`
-    via single-variable `Finsupp.addHom_ext` reduction; the powerset
+    via single-variable `addHom_ext` reduction; the powerset
     sum is pushed through `assoc`/`rTensor`/`lTensor` via
     `AddMonoidHom.map_multiset_sum`. -/
 theorem comulShuffle_coassoc [DecidableEq T] :
@@ -624,19 +625,19 @@ theorem comulShuffle_coassoc [DecidableEq T] :
   show (TensorProduct.assoc R (ConnesKreimer R T) (ConnesKreimer R T) (ConnesKreimer R T))
         ((comulShuffle (R := R)).rTensor _ (comulShuffle (R := R) F)) =
        (comulShuffle (R := R)).lTensor _ (comulShuffle (R := R) F)
-  -- Reduce arbitrary `F` to basis singleton via `Finsupp.addHom_ext`.
+  -- Reduce arbitrary `F` to basis singleton via `addHom_ext`.
   have h : (((TensorProduct.assoc R (ConnesKreimer R T) (ConnesKreimer R T)
                 (ConnesKreimer R T)).toLinearMap.comp
                 ((comulShuffle (R := R)).rTensor (ConnesKreimer R T))).comp
                 (comulShuffle (R := R))).toAddMonoidHom =
             (((comulShuffle (R := R)).lTensor (ConnesKreimer R T)).comp
                 (comulShuffle (R := R))).toAddMonoidHom := by
-    refine Finsupp.addHom_ext fun F₀ r => ?_
-    set sF : ConnesKreimer R T := Finsupp.single F₀ r with sF_def
+    refine addHom_ext fun F₀ r => ?_
+    set sF : ConnesKreimer R T := single F₀ r with sF_def
     show (TensorProduct.assoc R (ConnesKreimer R T) (ConnesKreimer R T) (ConnesKreimer R T))
           ((comulShuffle (R := R)).rTensor _ (comulShuffle (R := R) sF)) =
          (comulShuffle (R := R)).lTensor _ (comulShuffle (R := R) sF)
-    rw [show sF = r • of' (R := R) F₀ from (Finsupp.smul_single_one F₀ r).symm]
+    rw [show sF = r • of' (R := R) F₀ from smul_single_one F₀ r]
     simp only [map_smul]
     congr 1
     -- Reduced goal on `of' F₀`. AddMonoidHom abbreviations for distributing.

--- a/Linglib/Core/Algebra/ConnesKreimer/ShuffleBialgebra.lean
+++ b/Linglib/Core/Algebra/ConnesKreimer/ShuffleBialgebra.lean
@@ -18,7 +18,7 @@ tree is primitive: `Δ(of' {t}) = of' {t} ⊗ 1 + 1 ⊗ of' {t}`) and the existi
 
 This is **distinct** from mathlib's default `AddMonoidAlgebra.instBialgebra`
 (which uses the group-like coproduct `single g r ↦ single g r ⊗ single g r`).
-The `def`-vs-`abbrev` discipline on `ConnesKreimer R T` keeps the two
+The one-field structure wrapper on `ConnesKreimer R T` keeps the two
 unambiguous: typeclass synthesis on `ConnesKreimer R T` finds the shuffle
 Bialgebra instance, while `AddMonoidAlgebra R (Forest T)` retains the
 group-like one.
@@ -170,7 +170,7 @@ theorem rTensor_counit_comulShuffle [DecidableEq T] :
     (counit (R := R)).toLinearMap.rTensor (ConnesKreimer R T) ∘ₗ
         (comulShuffle (R := R)) =
       TensorProduct.mk R R (ConnesKreimer R T) 1 := by
-  -- Reduce arbitrary `x` to basis singleton via `Finsupp.addHom_ext`.
+  -- Reduce arbitrary `x` to basis singleton via `addHom_ext`.
   ext x
   show (counit (R := R)).toLinearMap.rTensor (ConnesKreimer R T)
         (comulShuffle (R := R) x) =
@@ -179,12 +179,12 @@ theorem rTensor_counit_comulShuffle [DecidableEq T] :
               (comulShuffle (R := R))).toAddMonoidHom =
            (TensorProduct.mk R R (ConnesKreimer R T) 1 :
               ConnesKreimer R T →ₗ[R] R ⊗[R] ConnesKreimer R T).toAddMonoidHom := by
-    refine Finsupp.addHom_ext fun F₀ r => ?_
-    set sF : ConnesKreimer R T := Finsupp.single F₀ r with sF_def
+    refine addHom_ext fun F₀ r => ?_
+    set sF : ConnesKreimer R T := single F₀ r with sF_def
     show (counit (R := R)).toLinearMap.rTensor (ConnesKreimer R T)
           (comulShuffle (R := R) sF) =
          TensorProduct.mk R R (ConnesKreimer R T) 1 sF
-    rw [show sF = r • of' (R := R) F₀ from (Finsupp.smul_single_one F₀ r).symm]
+    rw [show sF = r • of' (R := R) F₀ from smul_single_one F₀ r]
     rw [LinearMap.map_smul, LinearMap.map_smul,
         rTensor_counit_comulShuffle_basis (R := R) F₀]
     show r • ((1 : R) ⊗ₜ[R] of' (R := R) F₀) =
@@ -206,12 +206,12 @@ theorem lTensor_counit_comulShuffle [DecidableEq T] :
               (comulShuffle (R := R))).toAddMonoidHom =
            ((TensorProduct.mk R (ConnesKreimer R T) R).flip 1 :
               ConnesKreimer R T →ₗ[R] ConnesKreimer R T ⊗[R] R).toAddMonoidHom := by
-    refine Finsupp.addHom_ext fun F₀ r => ?_
-    set sF : ConnesKreimer R T := Finsupp.single F₀ r with sF_def
+    refine addHom_ext fun F₀ r => ?_
+    set sF : ConnesKreimer R T := single F₀ r with sF_def
     show (counit (R := R)).toLinearMap.lTensor (ConnesKreimer R T)
           (comulShuffle (R := R) sF) =
          (TensorProduct.mk R (ConnesKreimer R T) R).flip 1 sF
-    rw [show sF = r • of' (R := R) F₀ from (Finsupp.smul_single_one F₀ r).symm]
+    rw [show sF = r • of' (R := R) F₀ from smul_single_one F₀ r]
     rw [LinearMap.map_smul, LinearMap.map_smul,
         lTensor_counit_comulShuffle_basis (R := R) F₀]
     show r • (of' (R := R) F₀ ⊗ₜ[R] (1 : R)) =

--- a/Linglib/Core/Algebra/RootedTree/BMinus.lean
+++ b/Linglib/Core/Algebra/RootedTree/BMinus.lean
@@ -135,12 +135,12 @@ noncomputable def bMinusBasis (a : α) (F : Forest (Nonplanar α)) :
 /-- The B-_a linear map: linear extension of `bMinusBasis` via `Finsupp.lift`. -/
 noncomputable def bMinusLin (a : α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  Finsupp.lift _ R (Forest (Nonplanar α)) (bMinusBasis (R := R) a)
+  ConnesKreimer.linearLift (bMinusBasis (R := R) a)
 
 @[simp] theorem bMinusLin_of' (a : α) (F : Forest (Nonplanar α)) :
     bMinusLin (R := R) a (of' F) = bMinusBasis (R := R) a F := by
-  show Finsupp.lift _ R _ _ (Finsupp.single F 1) = _
-  rw [Finsupp.lift_apply, Finsupp.sum_single_index] <;> simp
+  show ConnesKreimer.linearLift (bMinusBasis (R := R) a) (ConnesKreimer.of' F) = _
+  rw [ConnesKreimer.linearLift_of']
 
 /-! ### B+/B- pairing adjoint -/
 
@@ -251,7 +251,7 @@ theorem bMinusLin_pairing_adjoint (a : α)
     (x y : ConnesKreimer R (Nonplanar α)) :
     pairing (R := R) (bMinusLin (R := R) a x) y =
     pairing (R := R) x (bPlusLin (R := R) a y) := by
-  refine Finsupp.induction_linear x ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
   · -- x = 0
     show pairing (R := R) (bMinusLin (R := R) a
           (0 : ConnesKreimer R (Nonplanar α))) y =
@@ -271,9 +271,9 @@ theorem bMinusLin_pairing_adjoint (a : α)
     rfl
   · -- x = single F r
     intro F r
-    refine Finsupp.induction_linear y ?_ ?_ ?_
+    refine ConnesKreimer.induction_linear y ?_ ?_ ?_
     · -- y = 0
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
       show pairing (R := R) (bMinusLin (R := R) a x_single)
             (0 : ConnesKreimer R (Nonplanar α)) =
           pairing (R := R) x_single (bPlusLin (R := R) a
@@ -285,7 +285,7 @@ theorem bMinusLin_pairing_adjoint (a : α)
       rw [pairing_zero_right]
     · -- y = y₁ + y₂
       intro y₁ y₂ ih₁ ih₂
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
       let y₁' : ConnesKreimer R (Nonplanar α) := y₁
       let y₂' : ConnesKreimer R (Nonplanar α) := y₂
       show pairing (R := R) (bMinusLin (R := R) a x_single) (y₁' + y₂') =
@@ -293,18 +293,18 @@ theorem bMinusLin_pairing_adjoint (a : α)
       rw [LinearMap.map_add, LinearMap.map_add, LinearMap.map_add, ih₁, ih₂]
     · -- y = single G s
       intro G s
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-      let y_single : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
+      let y_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single G s
       show pairing (R := R) (bMinusLin (R := R) a x_single) y_single =
           pairing (R := R) x_single (bPlusLin (R := R) a y_single)
       have hx : x_single = r • (of' (R := R) F) := by
-        show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-              r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one F r).symm
+        show (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) =
+              r • (ConnesKreimer.single F 1 : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one F r
       have hy : y_single = s • (of' (R := R) G) := by
-        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
-              s • (Finsupp.single G 1 : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one G s).symm
+        show (ConnesKreimer.single G s : ConnesKreimer R (Nonplanar α)) =
+              s • (ConnesKreimer.single G 1 : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one G s
       rw [hx, hy]
       -- Goal: pairing (bMinusLin a (r • of' F)) (s • of' G) =
       --       pairing (r • of' F) (bPlusLin a (s • of' G))
@@ -838,7 +838,7 @@ private theorem bMinusBasis_singleton_node_add (a : α)
     extends linearly to all `Y`), and `0` otherwise (the product has each
     basis summand of cardinality `≥ 2`, so `bMinusLin` kills it).
 
-    Reduces by `Finsupp.induction_linear` on `Y` to the basis case via
+    Reduces by `ConnesKreimer.induction_linear` on `Y` to the basis case via
     `bMinusBasis_singleton_node_add`. -/
 private theorem bMinusLin_bPlusLin_mul_of' (a : α)
     (Y : ConnesKreimer R (Nonplanar α)) (G : Forest (Nonplanar α)) :
@@ -848,7 +848,7 @@ private theorem bMinusLin_bPlusLin_mul_of' (a : α)
       (letI : Decidable (G = 0) := Classical.dec _
        if G = 0 then Y else 0) := by
   letI : Decidable (G = 0) := Classical.dec _
-  refine Finsupp.induction_linear Y ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear Y ?_ ?_ ?_
   · -- Y = 0
     show bMinusLin (R := R) a
         (ConnesKreimer.bPlusLin (R := R) a (0 : ConnesKreimer R (Nonplanar α)) *
@@ -869,14 +869,14 @@ private theorem bMinusLin_bPlusLin_mul_of' (a : α)
   · -- Y = single F r = r • of' F
     intro F r
     -- Compute bPlusLin a (single F r) = r • of' {node a F}.
-    have h_bPlus : ConnesKreimer.bPlusLin (R := R) a (Finsupp.single F r) =
+    have h_bPlus : ConnesKreimer.bPlusLin (R := R) a (ConnesKreimer.single F r) =
         r • ConnesKreimer.of' (R := R) ({Nonplanar.node a F} : Forest _) := by
-      show Finsupp.lift _ R _ _ (Finsupp.single F r) = _
-      rw [Finsupp.lift_apply, Finsupp.sum_single_index]
-      · rfl
-      · simp
+      show ConnesKreimer.linearLift (fun F => ConnesKreimer.ofTree (Nonplanar.node a F))
+            (ConnesKreimer.single F r) = _
+      rw [ConnesKreimer.linearLift_single]
+      rfl
     show bMinusLin (R := R) a
-        (ConnesKreimer.bPlusLin (R := R) a (Finsupp.single F r) *
+        (ConnesKreimer.bPlusLin (R := R) a (ConnesKreimer.single F r) *
           ConnesKreimer.of' (R := R) G) = _
     rw [h_bPlus, smul_mul_assoc, ← of'_add, (bMinusLin (R := R) a).map_smul]
     -- Now: r • bMinusLin a (of' ({node a F} + G)) = if G = 0 then single F r else 0
@@ -890,11 +890,8 @@ private theorem bMinusLin_bPlusLin_mul_of' (a : α)
     · -- G = 0: r • of' F = single F r
       subst hG
       show r • ConnesKreimer.of' (R := R) F =
-        (Finsupp.single F r : ConnesKreimer R (Nonplanar α))
-      show r • Finsupp.single F (1 : R) =
-        (Finsupp.single F r : ConnesKreimer R (Nonplanar α))
-      rw [Finsupp.smul_single]
-      simp
+        (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α))
+      exact (ConnesKreimer.smul_single_one F r).symm
     · rw [smul_zero]
 
 /-- Combinatorial helper: summing a `B - B₁ = 0` indicator over `B.powerset`
@@ -1315,7 +1312,7 @@ private theorem bMinusLin_gl_mul_basis (a : α) (A B : Forest (Nonplanar α)) :
     with respect to the GL product:
     `B-_a (x *_GL y) = ε(x) • B-_a y + B-_a x *_GL y`.
 
-    Reduces by `Finsupp.induction_linear` (twice) to the basis case
+    Reduces by `ConnesKreimer.induction_linear` (twice) to the basis case
     `bMinusLin_gl_mul_basis`. -/
 theorem bMinusLin_gl_mul (a : α)
     (x y : ConnesKreimer R (Nonplanar α)) :
@@ -1326,7 +1323,7 @@ theorem bMinusLin_gl_mul (a : α)
       GrossmanLarson.unop
         ((GrossmanLarson.op (bMinusLin (R := R) a x)) *
           GrossmanLarson.op y) := by
-  refine Finsupp.induction_linear x ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
   · -- x = 0
     change bMinusLin (R := R) a
         ((0 : GrossmanLarson R α) * GrossmanLarson.op y) =
@@ -1393,9 +1390,9 @@ theorem bMinusLin_gl_mul (a : α)
     abel
   · -- x = single F r
     intro F r
-    refine Finsupp.induction_linear y ?_ ?_ ?_
+    refine ConnesKreimer.induction_linear y ?_ ?_ ?_
     · -- y = 0
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
       show bMinusLin (R := R) a
           ((GrossmanLarson.op x_single : GrossmanLarson R α) *
             GrossmanLarson.op (0 : ConnesKreimer R (Nonplanar α))) =
@@ -1422,7 +1419,7 @@ theorem bMinusLin_gl_mul (a : α)
       exact (bMinusLin (R := R) a).map_zero
     · -- y = y₁ + y₂
       intro y₁ y₂ ih₁ ih₂
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
       let y₁' : ConnesKreimer R (Nonplanar α) := y₁
       let y₂' : ConnesKreimer R (Nonplanar α) := y₂
       show bMinusLin (R := R) a
@@ -1461,8 +1458,8 @@ theorem bMinusLin_gl_mul (a : α)
       abel
     · -- y = single G s: factor out r, s, then apply bMinusLin_gl_mul_basis F G.
       intro G s
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-      let y_single : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
+      let y_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single G s
       show bMinusLin (R := R) a
           ((GrossmanLarson.op x_single : GrossmanLarson R α) *
             GrossmanLarson.op y_single) =
@@ -1472,13 +1469,13 @@ theorem bMinusLin_gl_mul (a : α)
           ((GrossmanLarson.op (bMinusLin (R := R) a x_single)) *
             GrossmanLarson.op y_single)
       have hx : x_single = r • (ConnesKreimer.of' (R := R) F) := by
-        show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-            r • (Finsupp.single F (1 : R) : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one F r).symm
+        show (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) =
+            r • (ConnesKreimer.single F (1 : R) : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one F r
       have hy : y_single = s • (ConnesKreimer.of' (R := R) G) := by
-        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
-            s • (Finsupp.single G (1 : R) : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one G s).symm
+        show (ConnesKreimer.single G s : ConnesKreimer R (Nonplanar α)) =
+            s • (ConnesKreimer.single G (1 : R) : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one G s
       rw [hx, hy]
       -- Pull r, s through op (op is linear, rfl since op = id).
       rw [show (GrossmanLarson.op (r • ConnesKreimer.of' (R := R) F) :

--- a/Linglib/Core/Algebra/RootedTree/BirkhoffFactorization.lean
+++ b/Linglib/Core/Algebra/RootedTree/BirkhoffFactorization.lean
@@ -83,16 +83,15 @@ noncomputable def birkhoffMinusMonoidHom :
     rw [Multiset.map_add, Multiset.prod_add]
 
 /-- **`φ₋` as an algebra hom** `H →ₐ[R] ℛ`, lifting `birkhoffMinusMonoidHom` via
-    `AddMonoidAlgebra.lift`. Mirrors `antipodeAlgHomN`. -/
+    `ConnesKreimer.lift`. Mirrors `antipodeAlgHomN`. -/
 noncomputable def birkhoffMinus : ConnesKreimer R (Nonplanar α) →ₐ[R] ℛ :=
-  AddMonoidAlgebra.lift R ℛ (Forest (Nonplanar α)) (birkhoffMinusMonoidHom φ RB)
+  ConnesKreimer.lift (birkhoffMinusMonoidHom φ RB)
 
 /-- `φ₋` on a forest basis element is the product of `φ₋` over its trees. Mirrors
     `antipodeAlgHomN_apply_of'`. -/
 @[simp] theorem birkhoffMinus_apply_of' (F : Forest (Nonplanar α)) :
     birkhoffMinus φ RB (of' F) = (F.map (birkhoffMinusTree φ RB)).prod := by
-  show AddMonoidAlgebra.lift R _ _ (birkhoffMinusMonoidHom φ RB) (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [birkhoffMinus, ConnesKreimer.lift_of']
   rfl
 
 /-- `φ₋` on a single tree generator agrees with `birkhoffMinusTree`. Mirrors
@@ -167,14 +166,13 @@ noncomputable def birkhoffPlusMonoidHom :
     `birkhoffMinus`; the multiplicative extension of `birkhoffPlusTree` is automatically an
     algebra hom, so this is the renormalized character `φ₊`. -/
 noncomputable def birkhoffPlus : ConnesKreimer R (Nonplanar α) →ₐ[R] ℛ :=
-  AddMonoidAlgebra.lift R ℛ (Forest (Nonplanar α)) (birkhoffPlusMonoidHom φ RB)
+  ConnesKreimer.lift (birkhoffPlusMonoidHom φ RB)
 
 /-- `φ₊` on a forest basis element is the product of `φ₊` over its trees. Mirrors
     `birkhoffMinus_apply_of'`. -/
 @[simp] theorem birkhoffPlus_apply_of' (F : Forest (Nonplanar α)) :
     birkhoffPlus φ RB (of' F) = (F.map (birkhoffPlusTree φ RB)).prod := by
-  show AddMonoidAlgebra.lift R _ _ (birkhoffPlusMonoidHom φ RB) (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [birkhoffPlus, ConnesKreimer.lift_of']
   rfl
 
 /-- `φ₊` on a single tree generator agrees with `birkhoffPlusTree`. Mirrors
@@ -241,11 +239,11 @@ decreasing_by exact cutSummandsN_subtree_depth_lt T p.1 p.2 hp T_i hT_i
 /-- **`R = id`, `φ = id` recovers the antipode as an algebra hom.** The forest-level Bogolyubov
     negative part `φ₋` of the identity character under `RotaBaxter.id` is the Hopf antipode
     `antipodeAlgHomN`. Lifts `birkhoffMinusTree_id_eq_antipodeTreeN` through the shared
-    `AddMonoidAlgebra.lift`. -/
+    `ConnesKreimer.lift`. -/
 theorem birkhoffMinus_id_eq_antipodeAlgHomN :
     birkhoffMinus (LinearMap.id : ConnesKreimer R (Nonplanar α) →ₗ[R] _) RotaBaxter.id
       = antipodeAlgHomN := by
-  refine AddMonoidAlgebra.algHom_ext (fun F => ?_)
+  refine ConnesKreimer.algHom_ext (fun F => ?_)
   show birkhoffMinus _ _ (of' F) = antipodeAlgHomN (of' F)
   rw [birkhoffMinus_apply_of', antipodeAlgHomN_apply_of']
   exact congrArg Multiset.prod (Multiset.map_congr rfl
@@ -317,7 +315,7 @@ theorem birkhoffPlus_eq_convMul (φ : ConnesKreimer R (Nonplanar α) →ₐ[R] �
     WithConv.toConv (birkhoffMinus φ.toLinearMap RB) * WithConv.toConv φ
       = WithConv.toConv (birkhoffPlus φ.toLinearMap RB) := by
   apply WithConv.ofConv_injective
-  refine AddMonoidAlgebra.algHom_ext (fun F => ?_)
+  refine ConnesKreimer.algHom_ext (fun F => ?_)
   show (WithConv.toConv (birkhoffMinus φ.toLinearMap RB) * WithConv.toConv φ).ofConv (of' F)
      = birkhoffPlus φ.toLinearMap RB (of' F)
   induction F using Multiset.induction with

--- a/Linglib/Core/Algebra/RootedTree/BirkhoffFactorizationSemiring.lean
+++ b/Linglib/Core/Algebra/RootedTree/BirkhoffFactorizationSemiring.lean
@@ -78,12 +78,11 @@ noncomputable def birkhoffMinusMonoidHom :
 /-- **`φ₋` as an algebra hom** `H →ₐ[R] ℛ`, lifting `birkhoffMinusMonoidHom`. Mirrors the ring
     `birkhoffMinus`. -/
 noncomputable def birkhoffMinus : ConnesKreimer R (Nonplanar α) →ₐ[R] ℛ :=
-  AddMonoidAlgebra.lift R ℛ (Forest (Nonplanar α)) (birkhoffMinusMonoidHom φ RB)
+  ConnesKreimer.lift (birkhoffMinusMonoidHom φ RB)
 
 @[simp] theorem birkhoffMinus_apply_of' (F : Forest (Nonplanar α)) :
     birkhoffMinus φ RB (of' F) = (F.map (birkhoffMinusTree φ RB)).prod := by
-  show AddMonoidAlgebra.lift R _ _ (birkhoffMinusMonoidHom φ RB) (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [birkhoffMinus, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem birkhoffMinus_apply_ofTree (T : Nonplanar α) :

--- a/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
+++ b/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.MonoidAlgebra.Basic
+import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Data.Multiset.Basic
 
@@ -28,6 +29,32 @@ forests are multisets, multiset addition is commutative (Hopf
 algebra is commutative). The coproduct depends on the cut substrate
 of T; see sibling files for specific instantiations.
 
+## The one-field structure (`Polynomial` playbook)
+
+`ConnesKreimer R T` wraps `AddMonoidAlgebra R (Forest T)` as a one-field
+structure rather than a `def`-synonym, for the same reason mathlib's
+`Polynomial R` wraps `AddMonoidAlgebra R ℕ`:
+
+- the admissible-cut `Bialgebra` cannot live on the bare carrier —
+  mathlib's group-like `AddMonoidAlgebra.instBialgebra` already occupies it;
+- a `def`-synonym's forwarded instances leave the parent type's instance
+  paths reachable, which produced a genuine `SMul ℤ` diamond (two routes:
+  `Algebra ℤ → Module ℤ → SMul ℤ` vs `AddCommGroup → SubNegMonoid → zsmul`),
+  previously worked around by a `noncomputable def addCommGroupOf` registered
+  via `attribute [local instance]` at three consumer sites.
+
+With the structure, all operations are defined on the `toFinsupp` field and
+the instance stack is built by injective transport from a **single** bottom
+instance (`instCommSemiring`; a separate `AddCommMonoid` bottom would itself
+be a parallel path). The `CommRing`/`AddCommGroup` instance is now a safe
+**global** instance — its `zsmul` is the pulled-back structural operation and
+no alternative path exists, so the diamond is gone by construction.
+
+Consumers should speak the self-contained API — `of'`, `ofTree`, `single`,
+`lift`, `algHom_ext`, `addHom_ext`, `counit` — and never name
+`AddMonoidAlgebra`/`Finsupp` on `ConnesKreimer` values; `toFinsuppAlgEquiv`
+is the sanctioned escape hatch.
+
 ## Layer status
 
 `[UPSTREAM]` candidate. No sorries.
@@ -50,13 +77,7 @@ T parameterized.
 Type: `RootedTree.ConnesKreimer R T` with eponymous namespace
 `RootedTree.ConnesKreimer`. Eponymous-type-and-namespace pattern matches
 mathlib idiom (`Polynomial`, `WittVector`, `PowerSeries`, etc.) — no
-abbreviation. The legacy `open ConnesKreimer` statements in soon-to-be-
-rebuilt consumer files (Adger2025, Merge/*, etc.) referred to the now-
-deleted top-level `ConnesKreimer.{TraceTree, Hc, ...}` and won't compile
-against the new substrate anyway, so the silent re-binding hazard is
-moot — those files need full Phase D rewrites.
-
-The eventual upstream-mathlib home would be
+abbreviation. The eventual upstream-mathlib home would be
 `Mathlib.RingTheory.HopfAlgebra.RootedTree.ConnesKreimer` or similar.
 -/
 
@@ -72,105 +93,188 @@ abbrev Forest (T : Type*) : Type _ := Multiset T
 
 /-! ## §2: The Connes-Kreimer Hopf algebra carrier -/
 
-/-- The **Connes-Kreimer Hopf algebra** on tree type T:
-    `AddMonoidAlgebra R (Forest T)`. As an algebra: product = forest
+/-- The **Connes-Kreimer Hopf algebra** on tree type T: a one-field wrapper
+    around `AddMonoidAlgebra R (Forest T)`. As an algebra: product = forest
     disjoint union (commutative), unit = empty forest. The Bialgebra
     structure (coproduct + coassoc + counit laws) is in sibling files. -/
-def ConnesKreimer (R : Type*) [CommSemiring R] (T : Type*) : Type _ :=
-  AddMonoidAlgebra R (Forest T)
+structure ConnesKreimer (R : Type*) [CommSemiring R] (T : Type*) where
+  /-- Wrap an `AddMonoidAlgebra` as a Connes-Kreimer element. -/
+  ofFinsupp ::
+  /-- The underlying forest-indexed `Finsupp`. -/
+  toFinsupp : AddMonoidAlgebra R (Forest T)
 
 namespace ConnesKreimer
 
-/-! ## §3: Forwarded mathlib instances
-
-`ConnesKreimer R T` is a `def`, not `abbrev`, isolating its eventual
-Bialgebra structure from mathlib's default `AddMonoidAlgebra.instBialgebra`
-(group-like coproduct). Forward `CommSemiring`, `Algebra`, and `FunLike`
-explicitly. -/
-
 variable {R : Type*} [CommSemiring R] {T : Type*}
 
+theorem toFinsupp_injective :
+    Function.Injective (toFinsupp : ConnesKreimer R T → AddMonoidAlgebra R (Forest T)) :=
+  fun ⟨_⟩ ⟨_⟩ h => congrArg ofFinsupp h
+
+@[simp] theorem toFinsupp_inj {p q : ConnesKreimer R T} :
+    p.toFinsupp = q.toFinsupp ↔ p = q := toFinsupp_injective.eq_iff
+
+@[ext] theorem ext {p q : ConnesKreimer R T} (h : p.toFinsupp = q.toFinsupp) : p = q :=
+  toFinsupp_injective h
+
+@[simp] theorem ofFinsupp_toFinsupp (p : ConnesKreimer R T) : ⟨p.toFinsupp⟩ = p := rfl
+
+/-! ### Structural operations
+
+Each operation is defined on the `toFinsupp` field; the `toFinsupp_*`
+pushforward lemmas are all `rfl` and form the simp normal form. -/
+
+noncomputable instance : Zero (ConnesKreimer R T) := ⟨⟨0⟩⟩
+noncomputable instance : One (ConnesKreimer R T) := ⟨⟨1⟩⟩
+noncomputable instance : Add (ConnesKreimer R T) :=
+  ⟨fun p q => ⟨p.toFinsupp + q.toFinsupp⟩⟩
+noncomputable instance : Mul (ConnesKreimer R T) :=
+  ⟨fun p q => ⟨p.toFinsupp * q.toFinsupp⟩⟩
+noncomputable instance smulZeroClass {S : Type*}
+    [SMulZeroClass S (AddMonoidAlgebra R (Forest T))] :
+    SMulZeroClass S (ConnesKreimer R T) where
+  smul s p := ⟨s • p.toFinsupp⟩
+  smul_zero s := ext (smul_zero s)
+noncomputable instance : NatCast (ConnesKreimer R T) :=
+  ⟨fun n => ⟨(n : AddMonoidAlgebra R (Forest T))⟩⟩
+noncomputable instance : Pow (ConnesKreimer R T) ℕ := ⟨fun p n => ⟨p.toFinsupp ^ n⟩⟩
+
+@[simp] theorem toFinsupp_zero : (0 : ConnesKreimer R T).toFinsupp = 0 := rfl
+@[simp] theorem toFinsupp_one : (1 : ConnesKreimer R T).toFinsupp = 1 := rfl
+@[simp] theorem toFinsupp_add (p q : ConnesKreimer R T) :
+    (p + q).toFinsupp = p.toFinsupp + q.toFinsupp := rfl
+@[simp] theorem toFinsupp_mul (p q : ConnesKreimer R T) :
+    (p * q).toFinsupp = p.toFinsupp * q.toFinsupp := rfl
+@[simp] theorem toFinsupp_smul {S : Type*}
+    [SMulZeroClass S (AddMonoidAlgebra R (Forest T))] (s : S) (p : ConnesKreimer R T) :
+    (s • p).toFinsupp = s • p.toFinsupp := rfl
+@[simp] theorem toFinsupp_pow (p : ConnesKreimer R T) (n : ℕ) :
+    (p ^ n).toFinsupp = p.toFinsupp ^ n := rfl
+
+/-! ### The instance stack
+
+Built by injective transport from the single bottom `instCommSemiring`. -/
+
 noncomputable instance instCommSemiring : CommSemiring (ConnesKreimer R T) :=
-  inferInstanceAs (CommSemiring (AddMonoidAlgebra R (Forest T)))
+  fast_instance% toFinsupp_injective.commSemiring _ toFinsupp_zero toFinsupp_one
+    toFinsupp_add toFinsupp_mul (fun n p => toFinsupp_smul n p) toFinsupp_pow
+    (fun _ => rfl)
 
-noncomputable instance instAlgebra : Algebra R (ConnesKreimer R T) :=
-  inferInstanceAs (Algebra R (AddMonoidAlgebra R (Forest T)))
+/-- `toFinsupp` bundled as an `AddMonoidHom` (transport vehicle). -/
+noncomputable def toFinsuppAddHom :
+    ConnesKreimer R T →+ AddMonoidAlgebra R (Forest T) where
+  toFun := toFinsupp
+  map_zero' := toFinsupp_zero
+  map_add' := toFinsupp_add
 
-instance instFunLike : FunLike (ConnesKreimer R T) (Forest T) R :=
-  inferInstanceAs (FunLike (Forest T →₀ R) (Forest T) R)
+noncomputable instance instModule : Module R (ConnesKreimer R T) :=
+  fast_instance% toFinsupp_injective.module R toFinsuppAddHom toFinsupp_smul
 
-/-! ### Field-coherent `AddCommGroup` for `[CommRing R]`
+noncomputable instance instAlgebra : Algebra R (ConnesKreimer R T) where
+  algebraMap :=
+    { toFun := fun r => ⟨algebraMap R (AddMonoidAlgebra R (Forest T)) r⟩
+      map_one' := ext (map_one _)
+      map_mul' := fun r s => ext (map_mul _ r s)
+      map_zero' := ext (map_zero _)
+      map_add' := fun r s => ext (map_add _ r s) }
+  commutes' r x := ext (Algebra.commutes r x.toFinsupp)
+  smul_def' r x := ext (Algebra.smul_def r x.toFinsupp)
 
-Constructed manually as `{ instAddCommMonoid with ... }` — fields typed
-`CK → CK → CK`, not `Finsupp → Finsupp → Finsupp`. This avoids the kernel
-mismatch that `inferInstanceAs (AddCommGroup (Forest T →₀ R))` triggers:
-that form's `_aux_1_*` fields carry Finsupp types and reject when used as
-`AddCommGroup CK`.
+@[simp] theorem toFinsupp_algebraMap (r : R) :
+    (algebraMap R (ConnesKreimer R T) r).toFinsupp
+      = algebraMap R (AddMonoidAlgebra R (Forest T)) r := rfl
 
-The `neg`/`sub`/`zsmul` fields delegate to the underlying Finsupp
-operations via the identity coercion (CK = AddMonoidAlgebra R (Forest T) =
-Forest T →₀ R as defs). They agree definitionally with the operations
-coming through `Algebra ℤ CK → Module ℤ CK → SMul ℤ CK`, so no SMul ℤ
-diamond arises at downstream call sites. -/
+/-- Coefficient lookup: a Connes-Kreimer element is a function from forests
+    to coefficients. -/
+noncomputable instance instFunLike : FunLike (ConnesKreimer R T) (Forest T) R where
+  coe p := (p.toFinsupp : Forest T →₀ R)
+  coe_injective := fun _ _ h => ext (DFunLike.coe_injective (F := Forest T →₀ R) h)
 
-/-! ### AddCommGroup helper (NOT a global instance — use `attribute [local instance]`)
+@[simp] theorem coe_apply (p : ConnesKreimer R T) (F : Forest T) :
+    p F = p.toFinsupp F := rfl
 
-**Diamond verdict (2026-05-19, task #12 deep-dive)**: registering `AddCommGroup CK`
-globally creates a `SMul ℤ CK` diamond. Two paths to `SMul ℤ CK`:
-- `Algebra ℤ CK → Module ℤ CK → SMul ℤ CK` (existing, via instAlgebra)
-- `AddCommGroup CK → SubNegMonoid → SubNegMonoid.toZSMul → SMul ℤ CK` (new)
+/-! ### Global ring instance (the diamond killer)
 
-Lean's typeclass elaboration picks one OR the other depending on context.
-At `op_smul := rfl` sites in `PreLie/OudomGuinBridge.lean`, the LHS (CK-side
-`r • x`) may pick SubNeg while the RHS (GL-side `r • op x` via GL's frozen
-`instModule = inferInstanceAs (Module R CK)`) is locked to Algebra-derived.
+`zsmul` is the pulled-back structural operation; no parent-type path to
+`SMul ℤ` exists, so the former `addCommGroupOf` local-instance hack is
+unnecessary — and deleted. -/
 
-**Structural fix would be**: refactor CK from `def` to `structure` (mathlib's
-pattern for `Polynomial`, `WittVector`). This isolates all instances — no
-parent-type alternative paths exist. Large refactor (hundreds of call sites).
+section Ring
+variable {R : Type*} [CommRing R] {T : Type*}
 
-**Tactical fix**: provide AddCommGroup as a `def` (not an instance), and use
-`attribute [local instance]` at the consumer site so other files don't pick
-it up. -/
+noncomputable instance instNeg : Neg (ConnesKreimer R T) := ⟨fun p => ⟨-p.toFinsupp⟩⟩
+noncomputable instance instSub : Sub (ConnesKreimer R T) :=
+  ⟨fun p q => ⟨p.toFinsupp - q.toFinsupp⟩⟩
+noncomputable instance instIntCast : IntCast (ConnesKreimer R T) :=
+  ⟨fun z => ⟨(z : AddMonoidAlgebra R (Forest T))⟩⟩
 
-/-- `AddCommGroup` on `ConnesKreimer R T` (not a global instance). Register
-    locally in consumer files via `attribute [local instance] addCommGroupOf`.
+@[simp] theorem toFinsupp_neg (p : ConnesKreimer R T) :
+    (-p).toFinsupp = -p.toFinsupp := rfl
+@[simp] theorem toFinsupp_sub (p q : ConnesKreimer R T) :
+    (p - q).toFinsupp = p.toFinsupp - q.toFinsupp := rfl
+noncomputable instance instCommRing : CommRing (ConnesKreimer R T) :=
+  fast_instance% toFinsupp_injective.commRing _ toFinsupp_zero toFinsupp_one
+    toFinsupp_add toFinsupp_mul toFinsupp_neg toFinsupp_sub
+    (fun n p => toFinsupp_smul n p) (fun z p => toFinsupp_smul z p)
+    toFinsupp_pow (fun _ => rfl) (fun _ => rfl)
 
-    Takes both `[CommSemiring R]` and `[CommRing R]` to avoid a typeclass-instance
-    diamond at consumer sites where the section variable has `[CommSemiring R]`
-    and the theorem adds `[CommRing R]` (Lean treats these as separate hypotheses
-    even though `CommRing` extends `CommSemiring`). -/
-@[reducible] noncomputable def addCommGroupOf {R : Type*}
-    [CommRing R] {T : Type*} :
-    AddCommGroup (ConnesKreimer R T) :=
-  inferInstanceAs (AddCommGroup (AddMonoidAlgebra R (Forest T)))
+end Ring
 
-/-! ## §4: Basis embeddings — `of'`, `ofTree`
+/-! ### The algebra equivalence to the bare carrier -/
 
-The natural inclusions of basis elements (forests, single trees) into
-the algebra. Mirrors mathlib's `MonoidAlgebra.of'` (bare function form)
-and `MonoidAlgebra.of` (`MonoidHom` form). -/
+/-- `toFinsupp` as an `R`-algebra equivalence — the sanctioned bridge between
+    the wrapper and the bare `AddMonoidAlgebra`. -/
+noncomputable def toFinsuppAlgEquiv :
+    ConnesKreimer R T ≃ₐ[R] AddMonoidAlgebra R (Forest T) where
+  toFun := toFinsupp
+  invFun := ofFinsupp
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_mul' := toFinsupp_mul
+  map_add' := toFinsupp_add
+  commutes' _ := rfl
 
-/-- **Bare embedding**: a forest as the basis vector `Finsupp.single F 1`. -/
-noncomputable def of' (F : Forest T) : ConnesKreimer R T :=
-  Finsupp.single F (1 : R)
+@[simp] theorem toFinsuppAlgEquiv_apply (p : ConnesKreimer R T) :
+    toFinsuppAlgEquiv p = p.toFinsupp := rfl
+
+@[simp] theorem toFinsuppAlgEquiv_symm_apply (x : AddMonoidAlgebra R (Forest T)) :
+    (toFinsuppAlgEquiv (R := R) (T := T)).symm x = ⟨x⟩ := rfl
+
+/-! ## §3: Basis embeddings — `single`, `of'`, `ofTree` -/
+
+/-- Basis vector: coefficient `r` on the forest `F`. -/
+noncomputable def single (F : Forest T) (r : R) : ConnesKreimer R T :=
+  ⟨Finsupp.single F r⟩
+
+@[simp] theorem toFinsupp_single (F : Forest T) (r : R) :
+    (single F r).toFinsupp = Finsupp.single F r := rfl
+
+theorem smul_single_one (F : Forest T) (r : R) :
+    single F r = r • single F (1 : R) := by
+  ext; simp
+
+/-- Linear induction: prove `p` at `0`, under `+`, and on every `single`. -/
+@[elab_as_elim]
+theorem induction_linear {p : ConnesKreimer R T → Prop} (x : ConnesKreimer R T)
+    (zero : p 0) (add : ∀ f g, p f → p g → p (f + g))
+    (single : ∀ (F : Forest T) (r : R), p (ConnesKreimer.single F r)) : p x := by
+  have h : ∀ y : AddMonoidAlgebra R (Forest T), p ⟨y⟩ := fun y =>
+    Finsupp.induction_linear y zero (fun f g hf hg => add ⟨f⟩ ⟨g⟩ hf hg) single
+  exact h x.toFinsupp
+
+/-- **Bare embedding**: a forest as the basis vector `single F 1`. -/
+noncomputable def of' (F : Forest T) : ConnesKreimer R T := single F 1
 
 /-- **MonoidHom embedding**: `Multiplicative (Forest T) →* ConnesKreimer R T`. -/
 noncomputable def of : Multiplicative (Forest T) →* ConnesKreimer R T where
   toFun F := of' (R := R) F.toAdd
-  map_one' := by
-    show (of' (R := R) (1 : Multiplicative (Forest T)).toAdd : ConnesKreimer R T) = 1
-    show (Finsupp.single (0 : Forest T) (1 : R)
-            : AddMonoidAlgebra R (Forest T))
-       = (1 : AddMonoidAlgebra R (Forest T))
-    exact AddMonoidAlgebra.one_def.symm
-  map_mul' F G := by
-    show of' (R := R) (F * G).toAdd = of' (R := R) F.toAdd * of' (R := R) G.toAdd
-    show of' (R := R) (F.toAdd + G.toAdd) = of' (R := R) F.toAdd * of' (R := R) G.toAdd
-    unfold of'
-    exact (AddMonoidAlgebra.single_mul_single
-      (R := R) (M := Forest T) F.toAdd G.toAdd 1 1
-      |>.trans (by rw [mul_one])).symm
+  map_one' := ext AddMonoidAlgebra.one_def.symm
+  map_mul' F G := ext <| by
+    show AddMonoidAlgebra.single (F.toAdd + G.toAdd) (1 : R)
+      = AddMonoidAlgebra.single (R := R) (M := Forest T) F.toAdd 1
+        * AddMonoidAlgebra.single (R := R) (M := Forest T) G.toAdd 1
+    exact (AddMonoidAlgebra.single_mul_single (R := R) (M := Forest T)
+      F.toAdd G.toAdd 1 1 |>.trans (by rw [mul_one])).symm
 
 /-- Embed a single tree as a singleton-forest basis vector. -/
 noncomputable def ofTree (t : T) : ConnesKreimer R T :=
@@ -179,8 +283,8 @@ noncomputable def ofTree (t : T) : ConnesKreimer R T :=
 theorem of_apply (F : Multiplicative (Forest T)) :
     (of (R := R) F : ConnesKreimer R T) = of' F.toAdd := rfl
 
-theorem of'_apply (F : Forest T) :
-    (of' (R := R) F : ConnesKreimer R T) = Finsupp.single F 1 := rfl
+theorem toFinsupp_of' (F : Forest T) :
+    (of' (R := R) F : ConnesKreimer R T).toFinsupp = Finsupp.single F 1 := rfl
 
 @[simp] theorem of'_zero :
     (of' (R := R) (0 : Forest T) : ConnesKreimer R T) = 1 :=
@@ -194,6 +298,112 @@ theorem of'_apply (F : Forest T) :
 
 @[simp] theorem of'_singleton (t : T) :
     (of' (R := R) ({t} : Forest T) : ConnesKreimer R T) = ofTree t := rfl
+
+/-! ## §4: `lift`, `algHom_ext`, `addHom_ext` — the self-contained hom API
+
+Consumers use these instead of reaching for `AddMonoidAlgebra.lift` /
+`Finsupp.addHom_ext` on the bare carrier. -/
+
+section Lift
+variable {A : Type*} [CommSemiring A] [Algebra R A]
+
+/-- Lift a monoid hom off the forest monoid to an algebra hom off the
+    Connes-Kreimer algebra (the wrapper-native `AddMonoidAlgebra.lift`). -/
+noncomputable def lift (f : Multiplicative (Forest T) →* A) :
+    ConnesKreimer R T →ₐ[R] A :=
+  (AddMonoidAlgebra.lift R A (Forest T) f).comp toFinsuppAlgEquiv.toAlgHom
+
+@[simp] theorem lift_of' (f : Multiplicative (Forest T) →* A) (F : Forest T) :
+    lift f (of' (R := R) F) = f (Multiplicative.ofAdd F) := by
+  show AddMonoidAlgebra.lift R A (Forest T) f (Finsupp.single F 1) = _
+  rw [AddMonoidAlgebra.lift_single, one_smul]
+
+/-- Algebra homs off `ConnesKreimer` agree if they agree on `of'`. -/
+theorem algHom_ext {φ ψ : ConnesKreimer R T →ₐ[R] A}
+    (h : ∀ F : Forest T, φ (of' F) = ψ (of' F)) : φ = ψ := by
+  have key : φ.comp toFinsuppAlgEquiv.symm.toAlgHom
+      = ψ.comp toFinsuppAlgEquiv.symm.toAlgHom :=
+    AddMonoidAlgebra.algHom_ext fun F => h F
+  ext p
+  simpa using DFunLike.congr_fun key p.toFinsupp
+
+end Lift
+
+/-- `ofFinsupp` as an `AddMonoidHom` (transport vehicle for `addHom_ext`). -/
+noncomputable def ofFinsuppAddHom :
+    AddMonoidAlgebra R (Forest T) →+ ConnesKreimer R T where
+  toFun := ofFinsupp
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+/-- Additive homs off `ConnesKreimer` agree if they agree on `single`. -/
+theorem addHom_ext {M : Type*} [AddZeroClass M] {f g : ConnesKreimer R T →+ M}
+    (h : ∀ (F : Forest T) (r : R), f (single F r) = g (single F r)) : f = g := by
+  have key : f.comp ofFinsuppAddHom = g.comp ofFinsuppAddHom :=
+    Finsupp.addHom_ext h
+  ext p
+  exact DFunLike.congr_fun key p.toFinsupp
+
+section LinearApi
+variable {M : Type*} [AddCommMonoid M] [Module R M]
+
+/-- Linear maps off `ConnesKreimer` agree if they agree on `single`. -/
+theorem lhom_ext {f g : ConnesKreimer R T →ₗ[R] M}
+    (h : ∀ (F : Forest T) (r : R), f (single F r) = g (single F r)) : f = g :=
+  LinearMap.toAddMonoidHom_injective (addHom_ext h)
+
+/-- Linear maps off `ConnesKreimer` agree if they agree on the basis `of'`. -/
+theorem lhom_ext' {f g : ConnesKreimer R T →ₗ[R] M}
+    (h : ∀ F : Forest T, f (of' F) = g (of' F)) : f = g :=
+  lhom_ext fun F r => by
+    rw [smul_single_one, map_smul, map_smul]
+    exact congrArg (r • ·) (h F)
+
+/-- Linearly extend a function off the forest basis
+    (wrapper-native `Finsupp.lift`). -/
+noncomputable def linearLift (f : Forest T → M) : ConnesKreimer R T →ₗ[R] M :=
+  (Finsupp.lift M R (Forest T) f).comp
+    (toFinsuppAlgEquiv (R := R) (T := T)).toLinearEquiv.toLinearMap
+
+@[simp] theorem linearLift_single (f : Forest T → M) (F : Forest T) (r : R) :
+    linearLift f (single F r) = r • f F := by
+  show Finsupp.lift M R (Forest T) f (Finsupp.single F r) = r • f F
+  rw [Finsupp.lift_apply, Finsupp.sum_single_index (by simp)]
+
+@[simp] theorem linearLift_of' (f : Forest T → M) (F : Forest T) :
+    linearLift f (of' (R := R) F) = f F := by
+  rw [of', linearLift_single, one_smul]
+
+end LinearApi
+
+/-- Transport a forest-monoid hom to an algebra hom between Connes-Kreimer
+    algebras (wrapper-native `AddMonoidAlgebra.mapDomainAlgHom`). -/
+noncomputable def mapDomainAlgHom {T' : Type*} (f : Forest T →+ Forest T') :
+    ConnesKreimer R T →ₐ[R] ConnesKreimer R T' :=
+  ((toFinsuppAlgEquiv (R := R) (T := T')).symm.toAlgHom.comp
+    (AddMonoidAlgebra.mapDomainAlgHom R R f)).comp
+    (toFinsuppAlgEquiv (R := R) (T := T)).toAlgHom
+
+@[simp] theorem mapDomainAlgHom_of' {T' : Type*} (f : Forest T →+ Forest T')
+    (F : Forest T) :
+    mapDomainAlgHom (R := R) f (of' F) = of' (f F) := by
+  refine ext ?_
+  show Finsupp.mapDomain f (Finsupp.single F 1) = Finsupp.single (f F) 1
+  rw [Finsupp.mapDomain_single]
+
+/-! ### The forest basis -/
+
+/-- The forests, via `of'`, as an `R`-basis of the Connes-Kreimer algebra
+    (`Polynomial.basisMonomials` analogue). -/
+noncomputable def basisSingleOne :
+    Module.Basis (Forest T) R (ConnesKreimer R T) :=
+  Module.Basis.map Finsupp.basisSingleOne
+    (toFinsuppAlgEquiv (R := R) (T := T)).symm.toLinearEquiv
+
+@[simp] theorem basisSingleOne_apply (F : Forest T) :
+    (basisSingleOne : Module.Basis (Forest T) R (ConnesKreimer R T)) F = of' F := by
+  simp only [basisSingleOne, Module.Basis.map_apply, Finsupp.coe_basisSingleOne]
+  rfl
 
 /-! ## §5: Counit
 
@@ -227,16 +437,14 @@ noncomputable def counitMonoidHom :
 
 /-- The **counit** on `ConnesKreimer R T` as an algebra hom. -/
 noncomputable def counit : ConnesKreimer R T →ₐ[R] R :=
-  AddMonoidAlgebra.lift R R (Forest T) counitMonoidHom
+  lift counitMonoidHom
 
 /-- `counit (of' F) = if F.card = 0 then 1 else 0`. The `card`
     formulation avoids needing `DecidableEq T`. -/
 @[simp] theorem counit_of' (F : Forest T) :
     (counit : ConnesKreimer R T →ₐ[R] R) (of' F)
       = (if F.card = 0 then 1 else 0 : R) := by
-  show AddMonoidAlgebra.lift R R (Forest T) counitMonoidHom
-        (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [counit, lift_of']
   rfl
 
 @[simp] theorem counit_one :

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
@@ -276,17 +276,15 @@ The trace-strip algebra hom `Π_{d,c}` in MCB's notation. -/
 
 /-- The **trace-strip algebra hom** `Π_{d,c}` —
     `ConnesKreimer R (Nonplanar (α ⊕ β)) →ₐ[R] ConnesKreimer R (Nonplanar α)`
-    induced by `stripTraceForestAddHom` via `AddMonoidAlgebra.mapDomainAlgHom`. -/
+    induced by `stripTraceForestAddHom` via `ConnesKreimer.mapDomainAlgHom`. -/
 noncomputable def stripTraceAlgHom :
     ConnesKreimer R (Nonplanar (α ⊕ β)) →ₐ[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.mapDomainAlgHom R R (stripTraceForestAddHom (α := α) (β := β))
+  ConnesKreimer.mapDomainAlgHom (stripTraceForestAddHom (α := α) (β := β))
 
 @[simp] theorem stripTraceAlgHom_of' (F : Forest (Nonplanar (α ⊕ β))) :
     stripTraceAlgHom (R := R) (of' F) =
       of' (R := R) (F.filterMap Nonplanar.stripTrace) := by
-  show Finsupp.mapDomain (stripTraceForestAddHom (α := α) (β := β))
-        (Finsupp.single F 1) = Finsupp.single _ 1
-  rw [Finsupp.mapDomain_single]
+  rw [stripTraceAlgHom, ConnesKreimer.mapDomainAlgHom_of']
   rfl
 
 /-! ## Sum.inl embedding
@@ -306,17 +304,15 @@ noncomputable def embedInlForestAddHom :
 
 /-- The **Sum.inl embedding algebra hom**
     `ConnesKreimer R (Nonplanar α) →ₐ[R] ConnesKreimer R (Nonplanar (α ⊕ β))`
-    induced by `Nonplanar.embedInl` via `AddMonoidAlgebra.mapDomainAlgHom`. -/
+    induced by `Nonplanar.embedInl` via `ConnesKreimer.mapDomainAlgHom`. -/
 noncomputable def embedInlAlgHom :
     ConnesKreimer R (Nonplanar α) →ₐ[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  AddMonoidAlgebra.mapDomainAlgHom R R (embedInlForestAddHom (α := α) (β := β))
+  ConnesKreimer.mapDomainAlgHom (embedInlForestAddHom (α := α) (β := β))
 
 @[simp] theorem embedInlAlgHom_of' (F : Forest (Nonplanar α)) :
     embedInlAlgHom (R := R) (β := β) (of' F) =
       of' (R := R) (F.map Nonplanar.embedInl) := by
-  show Finsupp.mapDomain (embedInlForestAddHom (α := α) (β := β))
-        (Finsupp.single F 1) = Finsupp.single _ 1
-  rw [Finsupp.mapDomain_single]
+  rw [embedInlAlgHom, ConnesKreimer.mapDomainAlgHom_of']
   rfl
 
 /-! ### Strip inverts embed
@@ -383,7 +379,7 @@ theorem stripTraceAlgHom_comp_embedInlAlgHom :
   apply AlgHom.ext
   intro x
   show stripTraceAlgHom (embedInlAlgHom x) = x
-  refine Finsupp.induction_linear x ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
   · show stripTraceAlgHom (embedInlAlgHom (0 : ConnesKreimer R (Nonplanar α))) = 0
     rw [map_zero, map_zero]
   · intro a b ha hb
@@ -394,10 +390,10 @@ theorem stripTraceAlgHom_comp_embedInlAlgHom :
     show stripTraceAlgHom (embedInlAlgHom (a' + b')) = a' + b'
     rw [map_add, map_add, ha', hb']
   · intro F r
-    show stripTraceAlgHom (embedInlAlgHom (Finsupp.single F r)) = Finsupp.single F r
-    have hsingle : (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
+    show stripTraceAlgHom (embedInlAlgHom (ConnesKreimer.single F r)) = ConnesKreimer.single F r
+    have hsingle : (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) =
         r • (of' (R := R) F : ConnesKreimer R (Nonplanar α)) :=
-      (Finsupp.smul_single_one F r).symm
+      ConnesKreimer.smul_single_one F r
     rw [hsingle, map_smul, map_smul, embedInlAlgHom_of', stripTraceAlgHom_of',
         stripTrace_embedInl_filterMap]
 
@@ -1060,7 +1056,7 @@ private theorem strip_comulCForestN_embedInl
 
     `comulDN ∘ embed_{Sum.inl} = comulAlgHomN`
 
-    Closed via: (a) AlgHom extensionality + `Finsupp.induction_linear` reduces
+    Closed via: (a) AlgHom extensionality + `ConnesKreimer.induction_linear` reduces
     to per-basis `of' F`; (b) Multiset multiplicativity of `comulCForestN`,
     `comulForestN`, and `(stripTraceAlgHom ⊗ stripTraceAlgHom)` reduces to
     per-tree; (c) `Quotient.inductionOn` reduces per-tree to tree-level; (d)
@@ -1074,7 +1070,7 @@ theorem comulDN_embedInl_eq_comulAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
   show (Algebra.TensorProduct.map (stripTraceAlgHom (R := R))
           stripTraceAlgHom) (comulCAlgHomN τ (embedInlAlgHom x)) =
        comulAlgHomN x
-  refine Finsupp.induction_linear x ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
   · show (Algebra.TensorProduct.map (stripTraceAlgHom (R := R)) stripTraceAlgHom)
           (comulCAlgHomN τ (embedInlAlgHom
               (0 : ConnesKreimer R (Nonplanar α)))) =
@@ -1092,11 +1088,11 @@ theorem comulDN_embedInl_eq_comulAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
     rw [map_add, map_add, map_add, map_add, ha', hb']
   · intro F r
     show (Algebra.TensorProduct.map (stripTraceAlgHom (R := R)) stripTraceAlgHom)
-          (comulCAlgHomN τ (embedInlAlgHom (Finsupp.single F r))) =
-         comulAlgHomN (Finsupp.single F r)
-    have hsingle : (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
+          (comulCAlgHomN τ (embedInlAlgHom (ConnesKreimer.single F r))) =
+         comulAlgHomN (ConnesKreimer.single F r)
+    have hsingle : (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) =
         r • (of' (R := R) F : ConnesKreimer R (Nonplanar α)) :=
-      (Finsupp.smul_single_one F r).symm
+      ConnesKreimer.smul_single_one F r
     rw [hsingle, map_smul, map_smul, map_smul, map_smul, embedInlAlgHom_of',
         comulCAlgHomN_apply_of', comulAlgHomN_apply_of']
     congr 1

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/GenericNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/GenericNonplanar.lean
@@ -87,16 +87,13 @@ noncomputable def comulAlgHomNG
     (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α)) :
     ConnesKreimer R (Nonplanar α) →ₐ[R]
       ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.lift R
-    ((ConnesKreimer R (Nonplanar α)) ⊗[R] (ConnesKreimer R (Nonplanar α)))
-    (Forest (Nonplanar α)) (comulMonoidHomNG cuts)
+  ConnesKreimer.lift (comulMonoidHomNG cuts)
 
 @[simp] theorem comulAlgHomNG_apply_of'
     (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
     (F : Forest (Nonplanar α)) :
     comulAlgHomNG (R := R) cuts (of' F) = comulForestNG cuts F := by
-  show AddMonoidAlgebra.lift R _ _ (comulMonoidHomNG cuts) (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [comulAlgHomNG, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem comulAlgHomNG_apply_ofTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
@@ -182,7 +182,7 @@ noncomputable def comulForestP (F : Forest (RoseTree α)) :
 /-! ### comulMonoidHom and comulAlgHom
 
 Package the multiplicative extension as a `MonoidHom`, then lift to the
-full `AlgHom` via `AddMonoidAlgebra.lift`. -/
+full `AlgHom` via `ConnesKreimer.lift`. -/
 
 /-- comulForestP as a monoid hom from `Multiplicative (Forest (RoseTree α))`. -/
 noncomputable def comulMonoidHomP :
@@ -196,14 +196,11 @@ noncomputable def comulMonoidHomP :
 noncomputable def comulAlgHomP :
     ConnesKreimer R (RoseTree α) →ₐ[R]
       ConnesKreimer R (RoseTree α) ⊗[R] ConnesKreimer R (RoseTree α) :=
-  AddMonoidAlgebra.lift R
-    ((ConnesKreimer R (RoseTree α)) ⊗[R] (ConnesKreimer R (RoseTree α)))
-    (Forest (RoseTree α)) comulMonoidHomP
+  ConnesKreimer.lift comulMonoidHomP
 
 @[simp] theorem comulAlgHomP_apply_of' (F : Forest (RoseTree α)) :
     comulAlgHomP (R := R) (α := α) (of' F) = comulForestP F := by
-  show AddMonoidAlgebra.lift R _ _ comulMonoidHomP (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [comulAlgHomP, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem comulAlgHomP_apply_ofTree (T : RoseTree α) :

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -3,6 +3,10 @@ import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 
 set_option autoImplicit false
+-- The structure-wrapped `ConnesKreimer` needs one extra pending step when
+-- synthesizing instances on nested tensor squares `CK ⊗ (CK ⊗ CK)` (the
+-- def-synonym's fall-through to `AddMonoidAlgebra` instances is gone).
+set_option maxSynthPendingDepth 2
 
 /-!
 # GL/CK duality for Δ^ρ and coassociativity of the pruning coproduct
@@ -90,7 +94,7 @@ private lemma pairing₂_lTensor_bPlusLin (a : α)
 private lemma pairing_apply_one (w : ConnesKreimer R (Nonplanar α)) :
     GrossmanLarson.pairing (R := R) w (1 : ConnesKreimer R (Nonplanar α)) =
       (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) w := by
-  refine Finsupp.induction_linear w ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear w ?_ ?_ ?_
   · show GrossmanLarson.pairing (R := R)
         (0 : ConnesKreimer R (Nonplanar α)) 1 =
       (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
@@ -104,11 +108,11 @@ private lemma pairing_apply_one (w : ConnesKreimer R (Nonplanar α)) :
     rw [map_add, LinearMap.add_apply, map_add]
     exact congrArg₂ (· + ·) iha ihb
   · intro F r
-    let w' : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+    let w' : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
     have hsingle : w' = r • (ConnesKreimer.of' (R := R) F) := by
-      show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-          r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
-      exact (Finsupp.smul_single_one F r).symm
+      show (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) =
+          r • (ConnesKreimer.single F 1 : ConnesKreimer R (Nonplanar α))
+      exact ConnesKreimer.smul_single_one F r
     show GrossmanLarson.pairing (R := R) w' 1 =
       (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) w'
     rw [hsingle, map_smul, LinearMap.smul_apply, map_smul, smul_eq_mul,
@@ -300,7 +304,7 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
           (GrossmanLarson.product x y) (ConnesKreimer.of' C) =
         pairing₂ (R := R) (y ⊗ₜ[R] x)
           (comulAlgHomN (R := R) (ConnesKreimer.of' C)) by
-    refine Finsupp.induction_linear z ?_ ?_ ?_
+    refine ConnesKreimer.induction_linear z ?_ ?_ ?_
     · show GrossmanLarson.pairing (R := R) (GrossmanLarson.product x y)
           (0 : ConnesKreimer R (Nonplanar α)) =
         pairing₂ (R := R) (y ⊗ₜ[R] x)
@@ -315,11 +319,11 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
       rw [map_add, map_add, map_add]
       exact congrArg₂ (· + ·) iha ihb
     · intro C r
-      let z' : ConnesKreimer R (Nonplanar α) := Finsupp.single C r
+      let z' : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single C r
       have hsingle : z' = r • (ConnesKreimer.of' (R := R) C) := by
-        show (Finsupp.single C r : ConnesKreimer R (Nonplanar α)) =
-            r • (Finsupp.single C 1 : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one C r).symm
+        show (ConnesKreimer.single C r : ConnesKreimer R (Nonplanar α)) =
+            r • (ConnesKreimer.single C 1 : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one C r
       show GrossmanLarson.pairing (R := R) (GrossmanLarson.product x y) z' =
         pairing₂ (R := R) (y ⊗ₜ[R] x) (comulAlgHomN (R := R) z')
       rw [hsingle, map_smul, map_smul, map_smul]
@@ -434,7 +438,7 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
           omega
         have hC'lt : (C'.map Nonplanar.numNodes).sum < n := by omega
         -- Reduce x, y to basis vectors (both sides are bilinear in (x, y)).
-        refine Finsupp.induction_linear x ?_ ?_ ?_
+        refine ConnesKreimer.induction_linear x ?_ ?_ ?_
         · show GrossmanLarson.pairing (R := R)
               (GrossmanLarson.product (0 : ConnesKreimer R (Nonplanar α)) y)
               (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
@@ -454,11 +458,11 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
               map_add, LinearMap.add_apply]
           exact congrArg₂ (· + ·) iha ihb
         · intro A rA
-          let xA : ConnesKreimer R (Nonplanar α) := Finsupp.single A rA
+          let xA : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single A rA
           have hxA : xA = rA • (ConnesKreimer.of' (R := R) A) := by
-            show (Finsupp.single A rA : ConnesKreimer R (Nonplanar α)) =
-                rA • (Finsupp.single A 1 : ConnesKreimer R (Nonplanar α))
-            exact (Finsupp.smul_single_one A rA).symm
+            show (ConnesKreimer.single A rA : ConnesKreimer R (Nonplanar α)) =
+                rA • (ConnesKreimer.single A 1 : ConnesKreimer R (Nonplanar α))
+            exact ConnesKreimer.smul_single_one A rA
           show GrossmanLarson.pairing (R := R)
               (GrossmanLarson.product xA y)
               (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
@@ -468,7 +472,7 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
           simp only [pairing_product_smul_left, TensorProduct.tmul_smul,
               map_smul, LinearMap.smul_apply]
           refine congrArg (rA • ·) ?_
-          refine Finsupp.induction_linear y ?_ ?_ ?_
+          refine ConnesKreimer.induction_linear y ?_ ?_ ?_
           · show GrossmanLarson.pairing (R := R)
                 (GrossmanLarson.product (ConnesKreimer.of' A)
                   (0 : ConnesKreimer R (Nonplanar α)))
@@ -489,11 +493,11 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
                 map_add, LinearMap.add_apply]
             exact congrArg₂ (· + ·) iha ihb
           · intro B rB
-            let yB : ConnesKreimer R (Nonplanar α) := Finsupp.single B rB
+            let yB : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single B rB
             have hyB : yB = rB • (ConnesKreimer.of' (R := R) B) := by
-              show (Finsupp.single B rB : ConnesKreimer R (Nonplanar α)) =
-                  rB • (Finsupp.single B 1 : ConnesKreimer R (Nonplanar α))
-              exact (Finsupp.smul_single_one B rB).symm
+              show (ConnesKreimer.single B rB : ConnesKreimer R (Nonplanar α)) =
+                  rB • (ConnesKreimer.single B 1 : ConnesKreimer R (Nonplanar α))
+              exact ConnesKreimer.smul_single_one B rB
             show GrossmanLarson.pairing (R := R)
                 (GrossmanLarson.product (ConnesKreimer.of' A) yB)
                 (ConnesKreimer.of' (T ::ₘ C')) = pairing₂ (R := R)
@@ -637,8 +641,6 @@ theorem comulRhoN_coassoc [CharZero R'] [NoZeroDivisors R'] :
       (comulAlgHomN (R := R')).toLinearMap =
     (comulAlgHomN (R := R')).toLinearMap.lTensor _ ∘ₗ
       (comulAlgHomN (R := R')).toLinearMap := by
-  letI : AddCommGroup (ConnesKreimer R' (Nonplanar α')) :=
-    ConnesKreimer.addCommGroupOf
   ext z
   apply pairing₃_unique
   intro t
@@ -669,8 +671,9 @@ theorem comulAlgHomN_coassoc_algHom [CharZero R'] [NoZeroDivisors R'] :
         (ConnesKreimer R' (Nonplanar α'))
         (ConnesKreimer R' (Nonplanar α'))).toAlgHom.comp
       ((Algebra.TensorProduct.map (comulAlgHomN (R := R') (α := α'))
-        (AlgHom.id R' _)).comp comulAlgHomN) =
-    (Algebra.TensorProduct.map (AlgHom.id R' _) comulAlgHomN).comp comulAlgHomN := by
+        (AlgHom.id R' (ConnesKreimer R' (Nonplanar α')))).comp comulAlgHomN) =
+    (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar α')))
+      (comulAlgHomN (R := R') (α := α'))).comp comulAlgHomN := by
   apply AlgHom.toLinearMap_injective
   exact comulRhoN_coassoc
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
@@ -75,16 +75,14 @@ noncomputable def forestProjAddHom :
     ConnesKreimer R (Nonplanar α)` induced by `Nonplanar.mk`. -/
 noncomputable def planarToNonplanarAlg :
     ConnesKreimer R (RoseTree α) →ₐ[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.mapDomainAlgHom R R (forestProjAddHom (α := α))
+  ConnesKreimer.mapDomainAlgHom (forestProjAddHom (α := α))
 
 /-! ## API lemmas — action on `of'` and `ofTree` -/
 
 @[simp] theorem planarToNonplanarAlg_of' (F : Forest (RoseTree α)) :
     planarToNonplanarAlg (R := R) (of' F) =
       of' (R := R) (F.map Nonplanar.mk) := by
-  show Finsupp.mapDomain (forestProjAddHom (α := α)) (Finsupp.single F 1) =
-       Finsupp.single (F.map Nonplanar.mk) 1
-  rw [Finsupp.mapDomain_single]
+  rw [planarToNonplanarAlg, ConnesKreimer.mapDomainAlgHom_of']
   rfl
 
 @[simp] theorem planarToNonplanarAlg_ofTree (t : RoseTree α) :
@@ -578,14 +576,11 @@ noncomputable def comulMonoidHomN :
 noncomputable def comulAlgHomN :
     ConnesKreimer R (Nonplanar α) →ₐ[R]
       ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.lift R
-    ((ConnesKreimer R (Nonplanar α)) ⊗[R] (ConnesKreimer R (Nonplanar α)))
-    (Forest (Nonplanar α)) comulMonoidHomN
+  ConnesKreimer.lift comulMonoidHomN
 
 @[simp] theorem comulAlgHomN_apply_of' (F : Forest (Nonplanar α)) :
     comulAlgHomN (R := R) (α := α) (of' F) = comulForestN F := by
-  show AddMonoidAlgebra.lift R _ _ comulMonoidHomN (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [comulAlgHomN, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem comulAlgHomN_apply_ofTree (T : Nonplanar α) :
@@ -629,13 +624,11 @@ noncomputable def bPlus (a : α) (F : Forest (Nonplanar α)) :
     sending the basis element `of' F` to `ofTree (Nonplanar.node a F)`. -/
 noncomputable def bPlusLin (a : α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  Finsupp.lift _ R (Forest (Nonplanar α))
-    (fun F => ofTree (Nonplanar.node a F))
+  ConnesKreimer.linearLift (fun F => ofTree (Nonplanar.node a F))
 
 @[simp] theorem bPlusLin_of' (a : α) (F : Forest (Nonplanar α)) :
     bPlusLin (R := R) a (of' F) = ofTree (Nonplanar.node a F) := by
-  show Finsupp.lift _ R _ _ (Finsupp.single F 1) = _
-  rw [Finsupp.lift_apply, Finsupp.sum_single_index] <;> simp
+  rw [bPlusLin, ConnesKreimer.linearLift_of']
 
 @[simp] theorem bPlusLin_one (a : α) :
     bPlusLin (R := R) a (1 : ConnesKreimer R (Nonplanar α)) =
@@ -931,7 +924,7 @@ theorem comulAlgHomN_bPlusLin_cocycle (a : α) (F : Forest (Nonplanar α)) :
 /-! ## Phase A.7-δ — Counit laws + coassoc via GL/CK duality + `Bialgebra`
 
 Counit laws follow by reducing to the tree case via
-`AddMonoidAlgebra.algHom_ext` + multiplicativity (the empty-cut summand
+`ConnesKreimer.algHom_ext` + multiplicativity (the empty-cut summand
 contributes `1 ⊗ of' F`; all others are killed by `counit`).
 
 Coassociativity uses GL/CK duality: `comulRhoN_coassoc` (LinearMap form)
@@ -1152,21 +1145,20 @@ private theorem comulTreeN_counit_rTensor (T : Nonplanar α) :
 /-- `counit ∘ B+_a = 0` as a linear map. The image of `B+_a` lies in the
     span of `ofTree`s on non-leaf trees, all of which have card-1 forests
     so counit kills them. Proven by reducing the linear-map equality to
-    basis vectors via `Finsupp.lhom_ext`, then computing on `of' F`. -/
+    basis vectors via `ConnesKreimer.lhom_ext`, then computing on `of' F`. -/
 private theorem counit_bPlusLin (a : α) (y : ConnesKreimer R (Nonplanar α)) :
     counit (R := R) (bPlusLin (R := R) a y) = 0 := by
   -- Both maps are R-linear; reduce to checking equality of the composite with 0
   -- as a LinearMap, then evaluate at y.
   have h : ((counit (R := R)).toLinearMap.comp (bPlusLin (R := R) a) :
            ConnesKreimer R (Nonplanar α) →ₗ[R] R) = 0 := by
-    apply Finsupp.lhom_ext
+    apply ConnesKreimer.lhom_ext
     intro F r
-    show counit (bPlusLin a (Finsupp.single F r)) = (0 : R)
+    show counit (bPlusLin a (ConnesKreimer.single F r)) = (0 : R)
     -- Convert `single F r` to `r • of' F`, then push through linearity.
-    have hr : (Finsupp.single F r : ConnesKreimer R (Nonplanar α))
-              = (r : R) • (of' F : ConnesKreimer R (Nonplanar α)) := by
-      show Finsupp.single F r = r • Finsupp.single F (1 : R)
-      rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+    have hr : (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α))
+              = (r : R) • (of' F : ConnesKreimer R (Nonplanar α)) :=
+      ConnesKreimer.smul_single_one F r
     rw [hr]
     -- Force re-elaboration through Module-flavored smul.
     change counit (R := R) (bPlusLin a ((r : R) • (of' F : ConnesKreimer R (Nonplanar α)))) =
@@ -1227,7 +1219,7 @@ private theorem comulTreeN_counit_lTensor (T : Nonplanar α) :
 
 /-! ### Counit laws (algebra-hom level)
 
-Strategy: reduce to `of' F` via `AddMonoidAlgebra.algHom_ext`. For each `F`, expand
+Strategy: reduce to `of' F` via `ConnesKreimer.algHom_ext`. For each `F`, expand
 `comulAlgHomN (of' F) = comulForestN F` via `comulForestN_eq_sum`, then identify
 the unique cut summand `(0, F) ∈ cutForestSummandsN F` (the "all empty cuts"
 tuple). Other summands have `pf.1.card > 0`, so `counit (of' pf.1) = 0` and
@@ -1243,7 +1235,7 @@ Helper lemmas needed (substantive):
 theorem counit_rTensor_comulAlgHomN :
     (Algebra.TensorProduct.map (counit (R := R)) (AlgHom.id R _)).comp comulAlgHomN =
       (Algebra.TensorProduct.lid R (ConnesKreimer R (Nonplanar α))).symm.toAlgHom := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   show (Algebra.TensorProduct.map (counit (R := R))
           (AlgHom.id R (ConnesKreimer R (Nonplanar α)))) (comulAlgHomN (of' F)) =
@@ -1254,7 +1246,7 @@ theorem counit_rTensor_comulAlgHomN :
 theorem counit_lTensor_comulAlgHomN :
     (Algebra.TensorProduct.map (AlgHom.id R _) (counit (R := R))).comp comulAlgHomN =
       (Algebra.TensorProduct.rid R R (ConnesKreimer R (Nonplanar α))).symm.toAlgHom := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   show (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
           (counit (R := R))) (comulAlgHomN (of' F)) =

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Trace.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Trace.lean
@@ -192,17 +192,12 @@ noncomputable def comulCAlgHomP (τ : RoseTree (α ⊕ β) → β) :
     ConnesKreimer R (RoseTree (α ⊕ β)) →ₐ[R]
       ConnesKreimer R (RoseTree (α ⊕ β)) ⊗[R]
         ConnesKreimer R (RoseTree (α ⊕ β)) :=
-  AddMonoidAlgebra.lift R
-    ((ConnesKreimer R (RoseTree (α ⊕ β))) ⊗[R]
-      (ConnesKreimer R (RoseTree (α ⊕ β))))
-    (Forest (RoseTree (α ⊕ β))) (comulCMonoidHomP τ)
+  ConnesKreimer.lift (comulCMonoidHomP τ)
 
 @[simp] theorem comulCAlgHomP_apply_of' (τ : RoseTree (α ⊕ β) → β)
     (F : Forest (RoseTree (α ⊕ β))) :
     comulCAlgHomP (R := R) τ (of' F) = comulCForestPlanar τ F := by
-  show AddMonoidAlgebra.lift R _ _ (comulCMonoidHomP τ)
-        (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [comulCAlgHomP, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem comulCAlgHomP_apply_ofTree (τ : RoseTree (α ⊕ β) → β)

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -12,6 +12,10 @@ import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 
 set_option autoImplicit false
+-- The structure-wrapped `ConnesKreimer` needs one extra pending step when
+-- synthesizing instances on nested tensor squares `CK ⊗ (CK ⊗ CK)` (the
+-- def-synonym's fall-through to `AddMonoidAlgebra` instances is gone).
+set_option maxSynthPendingDepth 2
 
 /-!
 # Δ^c on `ConnesKreimer R (Nonplanar (α ⊕ β))` via descent + duality
@@ -542,17 +546,12 @@ noncomputable def comulCAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
     ConnesKreimer R (Nonplanar (α ⊕ β)) →ₐ[R]
       ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R]
         ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  AddMonoidAlgebra.lift R
-    ((ConnesKreimer R (Nonplanar (α ⊕ β))) ⊗[R]
-      (ConnesKreimer R (Nonplanar (α ⊕ β))))
-    (Forest (Nonplanar (α ⊕ β))) (comulCMonoidHomN τ)
+  ConnesKreimer.lift (comulCMonoidHomN τ)
 
 @[simp] theorem comulCAlgHomN_apply_of' (τ : Nonplanar (α ⊕ β) → β)
     (F : Forest (Nonplanar (α ⊕ β))) :
     comulCAlgHomN (R := R) τ (ConnesKreimer.of' F) = comulCForestN τ F := by
-  show AddMonoidAlgebra.lift R _ _ (comulCMonoidHomN τ)
-        (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [comulCAlgHomN, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem comulCAlgHomN_apply_ofTree (τ : Nonplanar (α ⊕ β) → β)
@@ -794,12 +793,13 @@ private theorem pairing₂_nondegenerate
       pairing₂ (R := R) (x ⊗ₜ[R] y) U = 0) : U = 0 := by
   classical
   let ℬ : Module.Basis (Forest (Nonplanar α)) R (ConnesKreimer R (Nonplanar α)) :=
-    Finsupp.basisSingleOne
+    ConnesKreimer.basisSingleOne
   obtain ⟨c, hc⟩ : ∃ c : Forest (Nonplanar α) →₀ ConnesKreimer R (Nonplanar α),
       c.sum (fun F U_F => ℬ F ⊗ₜ[R] U_F) = U :=
     TensorProduct.eq_repr_basis_left ℬ U
   have hℬ : ∀ G : Forest (Nonplanar α),
-      (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G := fun _ => rfl
+      (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G := fun _ =>
+    ConnesKreimer.basisSingleOne_apply _
   have hc_zero : ∀ F, c F = 0 := by
     intro F
     apply GrossmanLarson.pairing_nondegenerate (c F)
@@ -839,7 +839,7 @@ theorem pairing₃_nondegenerate
   classical
   let ℬ : Module.Basis (Forest (Nonplanar α)) R
         (ConnesKreimer R (Nonplanar α)) :=
-    Finsupp.basisSingleOne
+    ConnesKreimer.basisSingleOne
   obtain ⟨c, hc⟩ : ∃ c : Forest (Nonplanar α) →₀
         (ConnesKreimer R (Nonplanar α) ⊗[R]
           ConnesKreimer R (Nonplanar α)),
@@ -847,7 +847,7 @@ theorem pairing₃_nondegenerate
     TensorProduct.eq_repr_basis_left ℬ U
   have hℬ : ∀ G : Forest (Nonplanar α),
       (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G :=
-    fun _ => rfl
+    fun _ => ConnesKreimer.basisSingleOne_apply _
   have hc_zero : ∀ F, c F = 0 := by
     intro F
     apply pairing₂_nondegenerate (c F)
@@ -875,13 +875,11 @@ theorem pairing₃_nondegenerate
 vector are equal. Follows from `pairing₃_nondegenerate` via
 `U = V ↔ U - V = 0`, requiring `AddCommGroup` on the triple tensor.
 
-**The CommSemiring/CommRing diamond fix**: this theorem lives in its own
-section with `[CommRing R₁]` only (NOT [CommSemiring R] from the file's
-top section + [CommRing R] added on top — those create two CommSemiring R
-instances that don't unify). With a single CommRing hypothesis, `CK R₁ T`
-uses `CommRing.toCommSemiring` uniformly, and `addCommGroupOf` (which
-also returns CK with CommRing-derived CommSemiring) matches without
-diamond. -/
+**Single ring hypothesis**: this theorem lives in its own section with
+`[CommRing R₁]` only (NOT [CommSemiring R] from the file's top section +
+[CommRing R] added on top — those create two CommSemiring R instances
+that don't unify). The `AddCommGroup` on the wrapper comes from the
+global `ConnesKreimer.instCommRing`. -/
 
 section PairingUnique
 variable {R₁ : Type*} [CommRing R₁] {α₁ : Type*}
@@ -891,8 +889,6 @@ theorem pairing₃_unique [CharZero R₁] [NoZeroDivisors R₁]
           (ConnesKreimer R₁ (Nonplanar α₁) ⊗[R₁]
             ConnesKreimer R₁ (Nonplanar α₁)))
     (h : ∀ t, pairing₃ (R := R₁) t U = pairing₃ (R := R₁) t V) : U = V := by
-  letI : AddCommGroup (ConnesKreimer R₁ (Nonplanar α₁)) :=
-    ConnesKreimer.addCommGroupOf
   rw [← sub_eq_zero]
   apply pairing₃_nondegenerate
   intro t
@@ -1317,7 +1313,7 @@ theorem comulCN_coassoc
           (comulCAlgHomN (R := R') τ (ConnesKreimer.ofTree T))
       rw [comulCAlgHomN_apply_ofTree]
       exact comulCN_coassoc_tree τ hτ T
-  exact AddMonoidAlgebra.algHom_ext (fun F => key F)
+  exact ConnesKreimer.algHom_ext (fun F => key F)
 
 end CoassocCommRing
 
@@ -1749,7 +1745,7 @@ theorem counit_rTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
         (AlgHom.id R' _)).comp (comulCAlgHomN (R := R') τ) =
       (Algebra.TensorProduct.lid R'
         (ConnesKreimer R' (Nonplanar (α' ⊕ β')))).symm.toAlgHom := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   show (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
           ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
@@ -1767,7 +1763,7 @@ theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
           ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')).comp (comulCAlgHomN (R := R') τ) =
       (Algebra.TensorProduct.rid R' R'
         (ConnesKreimer R' (Nonplanar (α' ⊕ β')))).symm.toAlgHom := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   show (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
           ((ConnesKreimer.counit (R := R')) :
@@ -2035,7 +2031,7 @@ theorem mcb_lemma_1_2_10
     (∀ (n : ℕ) (F : Forest (Nonplanar (α'' ⊕ β''))),
       Forest.edgeCount F = n →
       comulCAlgHomN (R := R'') τ (ConnesKreimer.of' F) ∈
-        Submodule.span R'' {y | ∃ (i j : ℕ) (hi : i + j = n)
+        Submodule.span R'' {y | ∃ (i j : ℕ) (_hi : i + j = n)
           (xi yi : ConnesKreimer R'' (Nonplanar (α'' ⊕ β''))),
           xi ∈ gradedPiece (α'' ⊕ β'') i ∧
           yi ∈ gradedPiece (α'' ⊕ β'') j ∧

--- a/Linglib/Core/Algebra/RootedTree/DysonSchwinger.lean
+++ b/Linglib/Core/Algebra/RootedTree/DysonSchwinger.lean
@@ -137,7 +137,7 @@ theorem dsMap_add
     (P Q : ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α))
     (a : α) :
     dsMap (P + Q) a = dsMap P a + dsMap Q a := by
-  ext X
+  refine LinearMap.ext fun X => ?_
   show bPlusLin (R := R) a ((P + Q) X) =
        bPlusLin (R := R) a (P X) + bPlusLin (R := R) a (Q X)
   rw [LinearMap.add_apply, map_add]
@@ -147,7 +147,7 @@ theorem dsMap_smul (r : R)
     (P : ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α))
     (a : α) :
     dsMap (r • P) a = r • dsMap P a := by
-  ext X
+  refine LinearMap.ext fun X => ?_
   show bPlusLin (R := R) a ((r • P) X) = r • bPlusLin (R := R) a (P X)
   rw [LinearMap.smul_apply, map_smul]
 
@@ -155,7 +155,7 @@ theorem dsMap_smul (r : R)
 @[simp] theorem dsMap_zero (a : α) :
     dsMap (0 : ConnesKreimer R (Nonplanar α) →ₗ[R]
                 ConnesKreimer R (Nonplanar α)) a = 0 := by
-  ext X
+  refine LinearMap.ext fun X => ?_
   show bPlusLin (R := R) a ((0 : ConnesKreimer R (Nonplanar α) →ₗ[R] _) X) = 0
   rw [LinearMap.zero_apply, map_zero]
 
@@ -197,7 +197,7 @@ example (a : α) :
     dsMap (LinearMap.id : ConnesKreimer R (Nonplanar α) →ₗ[R]
               ConnesKreimer R (Nonplanar α)) a =
       bPlusLin (R := R) a := by
-  ext X
+  refine LinearMap.ext fun X => ?_
   show bPlusLin (R := R) a
         ((LinearMap.id : ConnesKreimer R (Nonplanar α) →ₗ[R] _) X) =
        bPlusLin (R := R) a X

--- a/Linglib/Core/Algebra/RootedTree/FormSet.lean
+++ b/Linglib/Core/Algebra/RootedTree/FormSet.lean
@@ -142,14 +142,11 @@ noncomputable def comulPrimMonoidHom :
 noncomputable def comulPrim :
     ConnesKreimer R (Nonplanar α) →ₐ[R]
       ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.lift R
-    ((ConnesKreimer R (Nonplanar α)) ⊗[R] (ConnesKreimer R (Nonplanar α)))
-    (Forest (Nonplanar α)) comulPrimMonoidHom
+  ConnesKreimer.lift comulPrimMonoidHom
 
 @[simp] theorem comulPrim_apply_of' (F : Forest (Nonplanar α)) :
     comulPrim (R := R) (α := α) (of' F) = comulPrimForest F := by
-  show AddMonoidAlgebra.lift R _ _ comulPrimMonoidHom (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [comulPrim, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem comulPrim_apply_ofTree (T : Nonplanar α) :
@@ -173,21 +170,18 @@ on the left channel of the coproduct output. -/
     on basis `of' F`, returns `of' F` if `F.card = k`, else 0. -/
 noncomputable def projectKComponent (k : ℕ) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
-  Finsupp.lift _ R (Forest (Nonplanar α))
+  ConnesKreimer.linearLift
     (fun F => if F.card = k then (of' F : ConnesKreimer R (Nonplanar α)) else 0)
 
 @[simp] theorem projectKComponent_of'_eq (k : ℕ) (F : Forest (Nonplanar α))
     (h : F.card = k) :
     projectKComponent (R := R) k (of' F) = of' F := by
-  show Finsupp.lift _ R _ _ (Finsupp.single F 1) = _
-  rw [Finsupp.lift_apply, Finsupp.sum_single_index] <;> simp [h]
+  rw [projectKComponent, ConnesKreimer.linearLift_of', if_pos h]
 
 @[simp] theorem projectKComponent_of'_ne (k : ℕ) (F : Forest (Nonplanar α))
     (h : F.card ≠ k) :
     projectKComponent (R := R) k (of' F) = 0 := by
-  show Finsupp.lift _ R _ _ (Finsupp.single F 1) = _
-  rw [Finsupp.lift_apply, Finsupp.sum_single_index] <;> simp [h]
+  rw [projectKComponent, ConnesKreimer.linearLift_of', if_neg h]
 
 /-! ## §4: The FormSet operator `FS^(k)` (MCB Def 1.16.1)
 

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
@@ -171,6 +171,50 @@ noncomputable def ofTree (t : Nonplanar α) : GrossmanLarson R α :=
     (of' (R := R) (0 : Forest (Nonplanar α)) : GrossmanLarson R α) = 1 :=
   ConnesKreimer.of'_zero
 
+/-! ### Basis extension over the Connes-Kreimer carrier
+
+`basisLift f` is the `R`-linear extension of a basis function
+`f : Forest → M` to all of `GrossmanLarson R α`, routed through the
+structure's `toFinsuppAlgEquiv` (the sanctioned escape hatch to the bare
+`AddMonoidAlgebra`). It replaces the former direct use of
+`Finsupp.linearCombination` on the `def`-synonym carrier. -/
+
+/-- `R`-linear extension of a basis function to `GrossmanLarson R α`. -/
+private noncomputable def basisLift {M : Type*} [AddCommMonoid M] [Module R M]
+    (f : Forest (Nonplanar α) → M) : GrossmanLarson R α →ₗ[R] M :=
+  (Finsupp.linearCombination R f).comp
+    (ConnesKreimer.toFinsuppAlgEquiv (R := R) (T := Nonplanar α)).toLinearMap
+
+private theorem basisLift_single {M : Type*} [AddCommMonoid M] [Module R M]
+    (f : Forest (Nonplanar α) → M) (F : Forest (Nonplanar α)) (r : R) :
+    basisLift f (ConnesKreimer.single F r) = r • f F := by
+  show Finsupp.linearCombination R f (ConnesKreimer.single F r).toFinsupp = r • f F
+  rw [ConnesKreimer.toFinsupp_single, Finsupp.linearCombination_single]
+
+private theorem basisLift_of' {M : Type*} [AddCommMonoid M] [Module R M]
+    (f : Forest (Nonplanar α) → M) (F : Forest (Nonplanar α)) :
+    basisLift f (of' (R := R) F) = f F :=
+  (basisLift_single f F 1).trans (one_smul _ _)
+
+private theorem basisLift_one {M : Type*} [AddCommMonoid M] [Module R M]
+    (f : Forest (Nonplanar α) → M) :
+    basisLift f (1 : GrossmanLarson R α) = f 0 := by
+  rw [← of'_zero (R := R) (α := α)]; exact basisLift_of' f 0
+
+/-- The basis extension of the embedding `of'` is the identity: the
+    transported form of `Finsupp.sum_single`. -/
+private theorem basisLift_of'_apply (x : GrossmanLarson R α) :
+    basisLift (of' (R := R) (α := α)) x = x := by
+  have key : (basisLift (of' (R := R) (α := α))).toAddMonoidHom
+      = (LinearMap.id : GrossmanLarson R α →ₗ[R] GrossmanLarson R α).toAddMonoidHom := by
+    apply ConnesKreimer.addHom_ext
+    intro F r
+    show basisLift (of' (R := R) (α := α)) (ConnesKreimer.single F r)
+        = ConnesKreimer.single F r
+    rw [basisLift_single]
+    exact (ConnesKreimer.smul_single_one F r).symm
+  simpa using DFunLike.congr_fun key x
+
 /-! ### Single-tree insertion
 
 `insertTreeForest T F : GrossmanLarson R α` is the basis-level
@@ -196,12 +240,11 @@ noncomputable def insertTreeForest (T : Nonplanar α) (F : Forest (Nonplanar α)
 /-- ℤ-linear extension of `insertTreeForest T` to `GrossmanLarson R α`. -/
 noncomputable def insertTree (T : Nonplanar α) :
     GrossmanLarson R α →ₗ[R] GrossmanLarson R α :=
-  Finsupp.linearCombination R (insertTreeForest T)
+  basisLift (insertTreeForest T)
 
 @[simp] theorem insertTree_of' (T : Nonplanar α) (F : Forest (Nonplanar α)) :
-    insertTree (R := R) T (of' F) = insertTreeForest T F := by
-  show Finsupp.linearCombination R (insertTreeForest T) (Finsupp.single F 1) = _
-  rw [Finsupp.linearCombination_single, one_smul]
+    insertTree (R := R) T (of' F) = insertTreeForest T F :=
+  basisLift_of' (insertTreeForest T) F
 
 /-- **Leibniz cons decomposition for `insertTreeForest`** (CK-level form).
 
@@ -322,7 +365,11 @@ noncomputable def insertionBasis (F_basis G_basis : Forest (Nonplanar α)) :
 /-- Internal: `insertionBasis`-bundled-as-LinearMap-in-F. -/
 private noncomputable def insertionBasisLin (G_basis : Forest (Nonplanar α)) :
     GrossmanLarson R α →ₗ[R] GrossmanLarson R α :=
-  Finsupp.linearCombination R (fun F_basis => insertionBasis (R := R) F_basis G_basis)
+  basisLift (fun F_basis => insertionBasis (R := R) F_basis G_basis)
+
+private theorem insertionBasisLin_of' (G_basis F_basis : Forest (Nonplanar α)) :
+    insertionBasisLin (R := R) G_basis (of' F_basis) = insertionBasis F_basis G_basis :=
+  basisLift_of' _ F_basis
 
 /-- The bilinear insertion operator `F • G : GrossmanLarson R α`.
     Defined as the bilinear extension of `insertionBasis` via
@@ -330,22 +377,14 @@ private noncomputable def insertionBasisLin (G_basis : Forest (Nonplanar α)) :
     F's via `insertionBasisLin`). -/
 noncomputable def insertion :
     GrossmanLarson R α →ₗ[R] GrossmanLarson R α →ₗ[R] GrossmanLarson R α :=
-  (Finsupp.linearCombination R (insertionBasisLin (R := R) (α := α))).flip
+  (basisLift (insertionBasisLin (R := R) (α := α))).flip
 
 /-- Bridge: on basis vectors, `insertion (of' F) (of' G) = insertionBasis F G`.
     Unfolds the bilinear extension on both basis arguments. -/
 theorem insertion_of'_of' (F G : Forest (Nonplanar α)) :
     insertion (R := R) (of' F) (of' G) = insertionBasis F G := by
-  show ((insertion (R := R)).flip (of' G)) (of' F) = _
-  show ((Finsupp.linearCombination R (insertionBasisLin (R := R) (α := α)))
-          (of' G)) (of' F) = _
-  show ((Finsupp.linearCombination R (insertionBasisLin (R := R) (α := α)))
-          (Finsupp.single G 1)) (Finsupp.single F 1) = _
-  rw [Finsupp.linearCombination_single, one_smul]
-  show ((Finsupp.linearCombination R
-          (fun F_basis => insertionBasis (R := R) F_basis G))
-        (Finsupp.single F 1)) = _
-  rw [Finsupp.linearCombination_single, one_smul]
+  show (basisLift (insertionBasisLin (R := R) (α := α))).flip (of' F) (of' G) = _
+  rw [LinearMap.flip_apply, basisLift_of', insertionBasisLin_of']
 
 /-! ### Grossman-Larson product
 
@@ -453,7 +492,7 @@ private noncomputable def productForestLin (G : Forest (Nonplanar α)) :
     bilinear in both arguments. -/
 noncomputable def product :
     GrossmanLarson R α →ₗ[R] GrossmanLarson R α →ₗ[R] GrossmanLarson R α :=
-  (Finsupp.linearCombination R (productForestLin (R := R) (α := α))).flip
+  (basisLift (productForestLin (R := R) (α := α))).flip
 
 /-! ### Multiplicative structure
 
@@ -516,13 +555,9 @@ theorem mul_smul_gl (s : R) (a b : GrossmanLarson R α) :
     powerset-sum formula. -/
 theorem of'_mul_of' (F G : Forest (Nonplanar α)) :
     (of' F : GrossmanLarson R α) * of' G = productForest (of' F) G := by
-  show product (of' F) (of' G) = productForest (of' F) G
-  show ((Finsupp.linearCombination R (productForestLin (R := R) (α := α))).flip
-          (of' F)) (of' G) = productForest (of' F) G
-  rw [LinearMap.flip_apply]
-  show ((Finsupp.linearCombination R (productForestLin (R := R) (α := α)))
-          (Finsupp.single G (1 : R))) (of' F) = productForest (of' F) G
-  rw [Finsupp.linearCombination_single, one_smul]
+  show (basisLift (productForestLin (R := R) (α := α))).flip (of' F) (of' G)
+      = productForest (of' F) G
+  rw [LinearMap.flip_apply, basisLift_of']
   rfl
 
 /-! ### Unit lemmas
@@ -555,44 +590,20 @@ private theorem insertionBasis_zero_left_of_ne_zero
   rw [Nonplanar.insertionMultiset_zero_left_of_ne_zero G_basis h,
       Multiset.map_zero, Multiset.sum_zero]
 
-/-- `insertion F 1 = F`. The bilinear extension at the unit
-    of H reduces to summing `insertionBasis F_basis 0 = of' F_basis`
-    over F's basis decomposition, which equals F by `Finsupp.sum_single`. -/
+/-- `insertion F 1 = F`. The bilinear extension at the unit of H reduces
+    to summing `insertionBasis F_basis 0 = of' F_basis` over F's basis
+    decomposition, which equals F by `basisLift_of'_apply`. -/
 theorem insertion_one_right (F : GrossmanLarson R α) :
     insertion F (1 : GrossmanLarson R α) = F := by
-  -- Unfold (1 : GrossmanLarson R α) = AddMonoidAlgebra.one_def = single 0 1
-  show insertion F (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = F
-  -- insertion.flip F : H →ₗ H. Apply on single 0 1.
-  show (insertion (R := R) (α := α)).flip.flip F
-    (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = F
-  rw [LinearMap.flip_flip]
-  -- Goal: insertion F (single 0 1) = F. Use flip_apply to get
-  -- (insertion).flip (single 0 1) F = F.
-  -- Actually let's evaluate via insertion's def.
-  show ((Finsupp.linearCombination R insertionBasisLin).flip F)
-    (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = F
-  rw [LinearMap.flip_apply]
-  show ((Finsupp.linearCombination R (insertionBasisLin (R := R) (α := α)))
-    (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R))) F = F
-  rw [Finsupp.linearCombination_single, one_smul]
-  -- insertionBasisLin 0 F = (linearCombination (fun F_b => insertionBasis F_b 0)) F
-  show (Finsupp.linearCombination R
-        (fun F_basis : Forest (Nonplanar α) =>
-          insertionBasis (R := R) F_basis (0 : Forest (Nonplanar α)))) F = F
+  show (basisLift (insertionBasisLin (R := R) (α := α))).flip F 1 = F
+  rw [LinearMap.flip_apply, basisLift_one]
+  -- Goal: `insertionBasisLin 0 F = F`; the basis map is `of'`, extended to `id`.
+  show basisLift (fun F_basis : Forest (Nonplanar α) =>
+      insertionBasis (R := R) F_basis (0 : Forest (Nonplanar α))) F = F
   rw [show (fun F_basis : Forest (Nonplanar α) =>
-        insertionBasis (R := R) F_basis (0 : Forest (Nonplanar α))) =
-      (fun F_basis : Forest (Nonplanar α) =>
-        of' (R := R) F_basis) from
-    funext fun F_basis => insertionBasis_zero_right F_basis]
-  rw [Finsupp.linearCombination_apply]
-  show (F.sum fun F_basis r => r • of' (R := R) F_basis) = F
-  rw [show (fun F_basis r => r • of' (R := R) F_basis) =
-      (fun F_basis (r : R) => (Finsupp.single F_basis r : GrossmanLarson R α))
-      from funext fun F_basis => funext fun r => by
-        show r • (Finsupp.single F_basis (1 : R) : GrossmanLarson R α) =
-            Finsupp.single F_basis r
-        rw [Finsupp.smul_single, smul_eq_mul, mul_one]]
-  exact Finsupp.sum_single F
+        insertionBasis (R := R) F_basis (0 : Forest (Nonplanar α)))
+      = of' (R := R) (α := α) from funext insertionBasis_zero_right]
+  exact basisLift_of'_apply F
 
 /-- **Right unit**. `mul_one` for the GL product. The powerset
     `(0:Multiset).powerset = {0}` collapses to a single summand, which
@@ -600,12 +611,8 @@ theorem insertion_one_right (F : GrossmanLarson R α) :
 theorem mul_one (F : GrossmanLarson R α) : F * 1 = F := by
   letI : DecidableEq (Nonplanar α) := Classical.decEq _
   show product F 1 = F
-  show ((Finsupp.linearCombination R productForestLin).flip F)
-       (1 : GrossmanLarson R α) = F
-  rw [LinearMap.flip_apply]
-  show ((Finsupp.linearCombination R (productForestLin (R := R) (α := α)))
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R))) F = F
-  rw [Finsupp.linearCombination_single, one_smul]
+  show (basisLift (productForestLin (R := R) (α := α))).flip F 1 = F
+  rw [LinearMap.flip_apply, basisLift_one]
   show productForest F 0 = F
   show ((((0 : Forest (Nonplanar α)).powerset).map fun G₁ =>
         op (unop (insertion F (of' (R := R) G₁)) *
@@ -628,43 +635,16 @@ private theorem insertion_one_of'_zero :
     insertion (1 : GrossmanLarson R α)
         (of' (R := R) (0 : Forest (Nonplanar α))) =
       (1 : GrossmanLarson R α) := by
-  show ((Finsupp.linearCombination R insertionBasisLin).flip
-        (1 : GrossmanLarson R α))
-       (of' (R := R) (0 : Forest (Nonplanar α))) = _
-  rw [LinearMap.flip_apply]
-  show ((Finsupp.linearCombination R (insertionBasisLin (R := R) (α := α)))
-        (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)))
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = _
-  rw [Finsupp.linearCombination_single, one_smul]
-  show insertionBasisLin (R := R) (α := α) 0
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = _
-  show (Finsupp.linearCombination R
-        (fun F_basis : Forest (Nonplanar α) =>
-          insertionBasis (R := R) F_basis 0))
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = _
-  rw [Finsupp.linearCombination_single, one_smul]
-  exact insertionBasis_zero_zero
+  conv_lhs => rw [← of'_zero (R := R) (α := α)]
+  rw [insertion_of'_of', insertionBasis_zero_zero]
 
 /-- `insertion 1 (of' G₁) = 0` for non-empty G₁. -/
 theorem insertion_one_of'_ne_zero (G₁ : Forest (Nonplanar α))
     (h : G₁ ≠ 0) :
     insertion (1 : GrossmanLarson R α) (of' (R := R) G₁) =
       (0 : GrossmanLarson R α) := by
-  show ((Finsupp.linearCombination R insertionBasisLin).flip
-        (1 : GrossmanLarson R α)) (of' (R := R) G₁) = _
-  rw [LinearMap.flip_apply]
-  show ((Finsupp.linearCombination R (insertionBasisLin (R := R) (α := α)))
-        (Finsupp.single G₁ (1 : R)))
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = _
-  rw [Finsupp.linearCombination_single, one_smul]
-  show insertionBasisLin (R := R) (α := α) G₁
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = _
-  show (Finsupp.linearCombination R
-        (fun F_basis : Forest (Nonplanar α) =>
-          insertionBasis (R := R) F_basis G₁))
-       (Finsupp.single (0 : Forest (Nonplanar α)) (1 : R)) = _
-  rw [Finsupp.linearCombination_single, one_smul]
-  exact insertionBasis_zero_left_of_ne_zero G₁ h
+  conv_lhs => rw [← of'_zero (R := R) (α := α)]
+  rw [insertion_of'_of', insertionBasis_zero_left_of_ne_zero G₁ h]
 
 /-- `Multiset.count 0 s.powerset = 1`: the empty submultiset appears
     exactly once in the powerset of any multiset. By induction on `s`:
@@ -726,34 +706,23 @@ private theorem productForest_one_left (G_basis : Forest (Nonplanar α)) :
     rw [zero_mul]; rfl
   rw [hf0, hrest, add_zero]
 
-/-- **Left unit**. `one_mul` for the GL product. The powerset sum
-    in `productForest 1 G_basis` collapses to a single non-zero summand
-    at `G₁ = 0` (via `productForest_one_left`), giving `of' G_basis`.
-    The outer `linearCombination` then reduces to `F.sum single = F`. -/
+/-- **Left unit**. `one_mul` for the GL product. On each basis vector
+    `single G r`, `productForest 1 G = of' G` (via `productForest_one_left`)
+    forces `product 1` to agree with the identity, established through
+    `ConnesKreimer.addHom_ext`. -/
 theorem one_mul (F : GrossmanLarson R α) : (1 : GrossmanLarson R α) * F = F := by
-  show product 1 F = F
-  show ((Finsupp.linearCombination R productForestLin).flip
-        (1 : GrossmanLarson R α)) F = F
-  rw [LinearMap.flip_apply]
-  show ((Finsupp.linearCombination R (productForestLin (R := R) (α := α))) F)
-       (1 : GrossmanLarson R α) = F
-  rw [Finsupp.linearCombination_apply, LinearMap.finsupp_sum_apply]
-  -- Goal: F.sum (fun G_basis r => (r • productForestLin G_basis) 1) = F
-  -- Push smul through apply, then unfold productForestLin and use the helper
-  rw [show (fun G_basis r =>
-              (r • productForestLin (R := R) (α := α) G_basis)
-                (1 : GrossmanLarson R α)) =
-        (fun G_basis (r : R) =>
-          (Finsupp.single G_basis r : GrossmanLarson R α)) from ?_]
-  · exact Finsupp.sum_single F
-  · funext G_basis r
-    rw [LinearMap.smul_apply]
-    show r • productForest (1 : GrossmanLarson R α) G_basis =
-        Finsupp.single G_basis r
-    rw [productForest_one_left]
-    show r • (Finsupp.single G_basis (1 : R) : GrossmanLarson R α) =
-        Finsupp.single G_basis r
-    rw [Finsupp.smul_single, smul_eq_mul, _root_.mul_one]
+  suffices h : (product (R := R) (α := α)) 1 = LinearMap.id by
+    show product 1 F = F
+    rw [h, LinearMap.id_apply]
+  apply LinearMap.toAddMonoidHom_injective
+  apply ConnesKreimer.addHom_ext
+  intro G r
+  show product (R := R) 1 (ConnesKreimer.single G r) = ConnesKreimer.single G r
+  show (basisLift (productForestLin (R := R) (α := α))).flip 1 (ConnesKreimer.single G r) = _
+  rw [LinearMap.flip_apply, basisLift_single, LinearMap.smul_apply]
+  show r • productForest (1 : GrossmanLarson R α) G = ConnesKreimer.single G r
+  rw [productForest_one_left]
+  exact (ConnesKreimer.smul_single_one G r).symm
 
 /-! ### Associativity
 

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
@@ -770,7 +770,7 @@ vectors (the output of `insertion`, a sum-over-partition, ...). To keep
 the chain's rewrites compositional, we lift two basis-form identities to
 LinearMap-general form via standard linearity arguments.
 
-The lifts are routine `Finsupp.induction_linear` (zero / additive /
+The lifts are routine `ConnesKreimer.induction_linear` (zero / additive /
 scalar-of-basis) reductions to the basis form. -/
 
 /-- Push `X * of' G` to the explicit powerset sum form for ANY `X`.
@@ -786,7 +786,7 @@ theorem product_of'_sum_form (X : GrossmanLarson R α) (G : Forest (Nonplanar α
         op (unop (insertion X (of' G₁)) *
             unop (of' (G - G₁)))).sum := by
   letI : DecidableEq (Nonplanar α) := Classical.decEq _
-  refine Finsupp.induction_linear (M := R) X ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear X ?_ ?_ ?_
   · -- X = 0
     have h_prod_zero : (product : GrossmanLarson R α →ₗ[R] _) 0 (of' G) =
         (0 : GrossmanLarson R α) := by
@@ -848,11 +848,11 @@ theorem product_of'_sum_form (X : GrossmanLarson R α) (G : Forest (Nonplanar α
     rw [add_mul]; rfl
   · -- single basis: reduce to of'_mul_of'.
     intro A c
-    -- Single A c = c • (single A 1) = c • of' A (via Finsupp.smul_single_one).
-    show product ((Finsupp.single A c : GrossmanLarson R α)) (of' G) = _
-    rw [show ((Finsupp.single A c : Forest (Nonplanar α) →₀ R) :
-            GrossmanLarson R α) = c • (of' A : GrossmanLarson R α)
-        from (Finsupp.smul_single_one A c).symm]
+    -- Single A c = c • (single A 1) = c • of' A (via ConnesKreimer.smul_single_one).
+    show product ((ConnesKreimer.single A c : GrossmanLarson R α)) (of' G) = _
+    rw [show (ConnesKreimer.single A c : GrossmanLarson R α)
+          = c • (of' A : GrossmanLarson R α)
+        from ConnesKreimer.smul_single_one A c]
     rw [product.map_smul, LinearMap.smul_apply]
     -- Goal: c • product (of' A) (of' G) = (sum form with c • of' A)
     show c • ((of' A : GrossmanLarson R α) * of' G) = _
@@ -960,7 +960,7 @@ theorem insertion_mul_distrib_gen
         op (unop (insertion X (of' C₁)) *
             unop (insertion (of' Y) (of' (C - C₁))))).sum := by
   letI : DecidableEq (Nonplanar α) := Classical.decEq _
-  refine Finsupp.induction_linear X ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear X ?_ ?_ ?_
   · -- X = 0 case: both sides reduce to 0.
     -- LHS = insertion (op (0 * unop (of' Y))) (of' C) = insertion 0 (of' C) = 0
     -- RHS = each summand `op(0 * ...) = 0`, hence sum = 0.
@@ -1024,8 +1024,9 @@ theorem insertion_mul_distrib_gen
     rw [add_mul]; rfl
   · -- single A c basis case
     intro A c
-    rw [show (Finsupp.single A c : GrossmanLarson R α) = c • (of' A : GrossmanLarson R α)
-        from (Finsupp.smul_single_one A c).symm]
+    rw [show (ConnesKreimer.single A c : GrossmanLarson R α)
+          = c • (of' A : GrossmanLarson R α)
+        from ConnesKreimer.smul_single_one A c]
     rw [show unop (c • (of' A : GrossmanLarson R α)) =
             c • unop (of' (R := R) A) from rfl]
     rw [smul_mul_assoc]

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
@@ -34,7 +34,7 @@ injectivity), and that R-free equality re-applies for any R.
 * `mul_assoc_basis` (R-generic) : `(of' F₁ * of' F₂) * of' F₃ =
   of' F₁ * (of' F₂ * of' F₃)` on basis vectors.
 * `mul_assoc` (R-generic) : full associativity, by triple
-  `Finsupp.addHom_ext`.
+  `ConnesKreimer.addHom_ext`.
 * `instSemigroup`, `instMonoid` instances.
 
 ## Status
@@ -198,7 +198,7 @@ theorem mul_assoc_basis {R : Type*} [CommSemiring R]
   rw [lhs_eq_sum_of' (R := R), rhs_eq_sum_of' (R := R),
       sum_of'_congr (lhsMultiset_eq_rhsMultiset F₁ F₂ F₃)]
 
-/-! ### Full `mul_assoc` via triple `Finsupp.addHom_ext` -/
+/-! ### Full `mul_assoc` via triple `ConnesKreimer.addHom_ext` -/
 
 /-- Right multiplication by `y` as an `AddMonoidHom`, additive in `x`. -/
 private noncomputable def mulRightHom
@@ -316,26 +316,29 @@ theorem mul_assoc {R : Type*} [CommSemiring R]
     (F₁ F₂ F₃ : GrossmanLarson R α) :
     F₁ * F₂ * F₃ = F₁ * (F₂ * F₃) := by
   have h₁ : assocLHSHom F₂ F₃ = assocRHSHom F₂ F₃ := by
-    refine Finsupp.addHom_ext fun T₁ a₁ => ?_
-    set s₁ : GrossmanLarson R α := Finsupp.single T₁ a₁ with s₁_def
+    refine ConnesKreimer.addHom_ext (T := Nonplanar α)
+      (M := GrossmanLarson R α) fun T₁ a₁ => ?_
+    set s₁ : GrossmanLarson R α := ConnesKreimer.single T₁ a₁ with s₁_def
     show assocLHSHom F₂ F₃ s₁ = assocRHSHom F₂ F₃ s₁
     rw [assocLHSHom_apply, assocRHSHom_apply]
     have h₂ : assocLHSHomY s₁ F₃ = assocRHSHomY s₁ F₃ := by
-      refine Finsupp.addHom_ext fun T₂ a₂ => ?_
-      set s₂ : GrossmanLarson R α := Finsupp.single T₂ a₂ with s₂_def
+      refine ConnesKreimer.addHom_ext (T := Nonplanar α)
+        (M := GrossmanLarson R α) fun T₂ a₂ => ?_
+      set s₂ : GrossmanLarson R α := ConnesKreimer.single T₂ a₂ with s₂_def
       show assocLHSHomY s₁ F₃ s₂ = assocRHSHomY s₁ F₃ s₂
       rw [assocLHSHomY_apply, assocRHSHomY_apply]
       have h₃ : assocLHSHomZ s₁ s₂ = assocRHSHomZ s₁ s₂ := by
-        refine Finsupp.addHom_ext fun T₃ a₃ => ?_
-        set s₃ : GrossmanLarson R α := Finsupp.single T₃ a₃ with s₃_def
+        refine ConnesKreimer.addHom_ext (T := Nonplanar α)
+          (M := GrossmanLarson R α) fun T₃ a₃ => ?_
+        set s₃ : GrossmanLarson R α := ConnesKreimer.single T₃ a₃ with s₃_def
         show assocLHSHomZ s₁ s₂ s₃ = assocRHSHomZ s₁ s₂ s₃
         rw [assocLHSHomZ_apply, assocRHSHomZ_apply]
         rw [show s₁ = a₁ • (of' T₁ : GrossmanLarson R α) from
-              (Finsupp.smul_single_one T₁ a₁).symm,
+              ConnesKreimer.smul_single_one T₁ a₁,
             show s₂ = a₂ • (of' T₂ : GrossmanLarson R α) from
-              (Finsupp.smul_single_one T₂ a₂).symm,
+              ConnesKreimer.smul_single_one T₂ a₂,
             show s₃ = a₃ • (of' T₃ : GrossmanLarson R α) from
-              (Finsupp.smul_single_one T₃ a₃).symm]
+              ConnesKreimer.smul_single_one T₃ a₃]
         simp only [smul_mul_left, mul_smul_right]
         rw [mul_assoc_basis T₁ T₂ T₃]
       have h₃App := DFunLike.congr_fun h₃ F₃

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -88,27 +88,25 @@ noncomputable def forestAutCard (F : Forest (Nonplanar α)) : ℕ :=
 
 /-! ### The bilinear pairing -/
 
-/-- The **symmetry-weighted pairing** `⟨·, ·⟩ : H × H → R`. On basis
-    elements, `⟨of' F, of' G⟩ = if F = G then forestAutCard F else 0`
-    (in `R`, via `Nat.cast`). Bilinearly extended via `Finsupp.lift`. -/
-noncomputable def pairing :
-    ConnesKreimer R (Nonplanar α) →ₗ[R]
-      ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
+/-- Finsupp-level symmetry-weighted pairing on the bare forest basis. The
+    public `pairing` is this transported through the Connes-Kreimer
+    structure's `toFinsuppAlgEquiv`. -/
+private noncomputable def pairingAux :
+    (Forest (Nonplanar α) →₀ R) →ₗ[R] (Forest (Nonplanar α) →₀ R) →ₗ[R] R :=
   letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
   Finsupp.lift _ R (Forest (Nonplanar α)) (fun F =>
     Finsupp.lift R R (Forest (Nonplanar α)) (fun G =>
       if F = G then (forestAutCard F : R) else 0))
 
-@[simp] theorem pairing_of'_of' (F G : Forest (Nonplanar α)) :
-    pairing (R := R) (ConnesKreimer.of' (R := R) F)
-                     (ConnesKreimer.of' (R := R) G) =
+private theorem pairingAux_single_single (F G : Forest (Nonplanar α)) :
+    pairingAux (R := R) (Finsupp.single F 1) (Finsupp.single G 1) =
       (letI : Decidable (F = G) := Classical.dec _
        if F = G then (forestAutCard F : R) else 0) := by
   letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
   show (Finsupp.lift _ R (Forest (Nonplanar α)) (fun F' =>
     Finsupp.lift R R (Forest (Nonplanar α)) (fun G' =>
       if F' = G' then (forestAutCard F' : R) else 0)))
-    (Finsupp.single F 1 : Forest (Nonplanar α) →₀ R) (ConnesKreimer.of' G) = _
+    (Finsupp.single F 1 : Forest (Nonplanar α) →₀ R) (Finsupp.single G 1) = _
   rw [Finsupp.lift_apply, Finsupp.sum_single_index]
   · rw [one_smul]
     show (Finsupp.lift R R (Forest (Nonplanar α)) (fun G' =>
@@ -119,45 +117,47 @@ noncomputable def pairing :
     · simp
   · simp
 
+/-- The **symmetry-weighted pairing** `⟨·, ·⟩ : H × H → R`. On basis
+    elements, `⟨of' F, of' G⟩ = if F = G then forestAutCard F else 0`
+    (in `R`, via `Nat.cast`). Bilinearly extended, transported from the
+    forest-basis `pairingAux` through `ConnesKreimer.toFinsuppAlgEquiv`. -/
+noncomputable def pairing :
+    ConnesKreimer R (Nonplanar α) →ₗ[R]
+      ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
+  pairingAux.compl₁₂
+    (ConnesKreimer.toFinsuppAlgEquiv (R := R) (T := Nonplanar α)).toLinearMap
+    (ConnesKreimer.toFinsuppAlgEquiv (R := R) (T := Nonplanar α)).toLinearMap
+
+private theorem pairing_apply (x y : ConnesKreimer R (Nonplanar α)) :
+    pairing (R := R) x y = pairingAux x.toFinsupp y.toFinsupp := rfl
+
+@[simp] theorem pairing_of'_of' (F G : Forest (Nonplanar α)) :
+    pairing (R := R) (ConnesKreimer.of' (R := R) F)
+                     (ConnesKreimer.of' (R := R) G) =
+      (letI : Decidable (F = G) := Classical.dec _
+       if F = G then (forestAutCard F : R) else 0) := by
+  rw [pairing_apply, ConnesKreimer.toFinsupp_of', ConnesKreimer.toFinsupp_of']
+  exact pairingAux_single_single F G
+
 /-- The pairing is symmetric. Reduces by bilinearity to the basis case,
     where `pairing_of'_of'` shows both sides are `if F = G then
     forestAutCard F else 0` — same value (the `F = G` case forces it). -/
 theorem pairing_symm (x y : ConnesKreimer R (Nonplanar α)) :
     pairing (R := R) x y = pairing y x := by
-  refine Finsupp.induction_linear x ?_ ?_ ?_
-  · show pairing (R := R) (0 : ConnesKreimer R (Nonplanar α)) y =
-        pairing y (0 : ConnesKreimer R (Nonplanar α))
-    rw [LinearMap.map_zero, LinearMap.zero_apply, LinearMap.map_zero]
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
+  · rw [LinearMap.map_zero, LinearMap.zero_apply, LinearMap.map_zero]
   · intro x₁ x₂ ih₁ ih₂
-    let x₁' : ConnesKreimer R (Nonplanar α) := x₁
-    let x₂' : ConnesKreimer R (Nonplanar α) := x₂
-    show pairing (R := R) (x₁' + x₂') y = pairing y (x₁' + x₂')
     rw [map_add, LinearMap.add_apply, ih₁, ih₂, map_add]
   · intro F r
-    refine Finsupp.induction_linear y ?_ ?_ ?_
-    · let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-      show pairing (R := R) x_single (0 : ConnesKreimer R (Nonplanar α)) =
-          pairing (0 : ConnesKreimer R (Nonplanar α)) x_single
-      rw [LinearMap.map_zero, LinearMap.map_zero, LinearMap.zero_apply]
+    refine ConnesKreimer.induction_linear y ?_ ?_ ?_
+    · rw [LinearMap.map_zero, LinearMap.map_zero, LinearMap.zero_apply]
     · intro y₁ y₂ ih₁ ih₂
-      let y₁' : ConnesKreimer R (Nonplanar α) := y₁
-      let y₂' : ConnesKreimer R (Nonplanar α) := y₂
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-      show pairing (R := R) x_single (y₁' + y₂') = pairing (y₁' + y₂') x_single
       rw [map_add, LinearMap.map_add, LinearMap.add_apply, ih₁, ih₂]
     · intro G s
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-      let y_single : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
-      show pairing (R := R) x_single y_single = pairing y_single x_single
-      have hx : x_single = r • (ConnesKreimer.of' (R := R) F) := by
-        show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-              r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one F r).symm
-      have hy : y_single = s • (ConnesKreimer.of' (R := R) G) := by
-        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
-              s • (Finsupp.single G 1 : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one G s).symm
-      rw [hx, hy]
+      rw [show ConnesKreimer.single F r = r • ConnesKreimer.of' (R := R) F
+            from ConnesKreimer.smul_single_one F r,
+          show ConnesKreimer.single G s = s • ConnesKreimer.of' (R := R) G
+            from ConnesKreimer.smul_single_one G s]
       simp only [LinearMap.map_smul, LinearMap.smul_apply, pairing_of'_of']
       by_cases h : F = G
       · subst h; ring
@@ -180,32 +180,19 @@ theorem pairing_symm (x y : ConnesKreimer R (Nonplanar α)) :
 theorem pairing_apply_of' (x : ConnesKreimer R (Nonplanar α))
     (G : Forest (Nonplanar α)) :
     pairing (R := R) x (ConnesKreimer.of' G) =
-      (x : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R) := by
-  refine Finsupp.induction_linear x ?_ ?_ ?_
-  · show pairing (R := R) (0 : ConnesKreimer R (Nonplanar α))
-                          (ConnesKreimer.of' G) =
-        (0 : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R)
-    rw [pairing_zero_left, Finsupp.zero_apply, zero_mul]
+      x.toFinsupp G * (forestAutCard G : R) := by
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
+  · rw [pairing_zero_left]
+    show (0 : R) = (0 : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R)
+    simp
   · intro x₁ x₂ ih₁ ih₂
-    let x₁' : ConnesKreimer R (Nonplanar α) := x₁
-    let x₂' : ConnesKreimer R (Nonplanar α) := x₂
-    show pairing (R := R) (x₁' + x₂') (ConnesKreimer.of' G) =
-        (((x₁' + x₂') : ConnesKreimer R (Nonplanar α)) :
-          Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R)
-    rw [map_add, LinearMap.add_apply, ih₁, ih₂]
-    show (x₁' : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R) +
-        (x₂' : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R) =
-        ((x₁' + x₂') : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R)
-    show x₁ G * (forestAutCard G : R) + x₂ G * (forestAutCard G : R) =
-        (x₁ + x₂) G * (forestAutCard G : R)
-    rw [Finsupp.add_apply, add_mul]
+    rw [map_add, LinearMap.add_apply, ih₁, ih₂, ConnesKreimer.toFinsupp_add]
+    show _ = (x₁.toFinsupp + x₂.toFinsupp : Forest (Nonplanar α) →₀ R) G *
+      (forestAutCard G : R)
+    simp [add_mul]
   · intro F r
-    have hx : (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-              r • (ConnesKreimer.of' (R := R) F) := by
-      show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-            r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
-      exact (Finsupp.smul_single_one F r).symm
-    rw [hx]
+    rw [show ConnesKreimer.single F r = r • ConnesKreimer.of' (R := R) F
+          from ConnesKreimer.smul_single_one F r]
     simp only [LinearMap.map_smul, LinearMap.smul_apply, pairing_of'_of']
     letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
     by_cases h : F = G
@@ -217,7 +204,7 @@ theorem pairing_apply_of' (x : ConnesKreimer R (Nonplanar α))
       rw [Finsupp.smul_apply, Finsupp.single_eq_same]
       ring
     · rw [if_neg h, smul_zero]
-      show 0 =
+      show (0 : R) =
           (r • (Finsupp.single F 1 : Forest (Nonplanar α) →₀ R)) G *
             (forestAutCard G : R)
       rw [Finsupp.smul_apply, Finsupp.single_apply, if_neg h, smul_zero, zero_mul]
@@ -233,13 +220,13 @@ theorem pairing_apply_of' (x : ConnesKreimer R (Nonplanar α))
 theorem pairing_nondegenerate
     [CharZero R] [NoZeroDivisors R] (x : ConnesKreimer R (Nonplanar α))
     (h : ∀ y, pairing (R := R) x y = 0) : x = 0 := by
-  apply Finsupp.ext (M := R)
-  intro G
+  refine ConnesKreimer.ext ?_
+  rw [ConnesKreimer.toFinsupp_zero]
+  refine Finsupp.ext fun G => ?_
   have hG : pairing (R := R) x (ConnesKreimer.of' G) = 0 := h _
   rw [pairing_apply_of'] at hG
   have hauts_ne : (Nonplanar.forestAutCard G : R) ≠ 0 :=
     Nat.cast_ne_zero.mpr (Nonplanar.forestAutCard_pos G).ne'
-  show (x : Forest (Nonplanar α) →₀ R) G = 0
   rcases mul_eq_zero.mp hG with hx | hx
   · exact hx
   · exact absurd hx hauts_ne
@@ -392,7 +379,7 @@ theorem pairing_of'_mul (W : Forest (Nonplanar α))
           pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
           pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum := by
     intro C₁ z₂
-    refine Finsupp.induction_linear z₂ ?_ ?_ ?_
+    refine ConnesKreimer.induction_linear z₂ ?_ ?_ ?_
     · show pairing (R := R) (ConnesKreimer.of' W)
           (ConnesKreimer.of' C₁ * (0 : ConnesKreimer R (Nonplanar α))) =
         ((Multiset.antidiagonal W).map (fun p =>
@@ -425,17 +412,9 @@ theorem pairing_of'_mul (W : Forest (Nonplanar α))
             pairing (R := R) (ConnesKreimer.of' p.2) b' = _
       rw [map_add, mul_add]
     · intro G s
-      let g' : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
-      have hsingle : g' = s • (ConnesKreimer.of' (R := R) G) := by
-        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
-            s • (Finsupp.single G 1 : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one G s).symm
-      show pairing (R := R) (ConnesKreimer.of' W)
-          (ConnesKreimer.of' C₁ * g') =
-        ((Multiset.antidiagonal W).map (fun p =>
-          pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
-          pairing (R := R) (ConnesKreimer.of' p.2) g')).sum
-      rw [hsingle, mul_smul_comm, map_smul, smul_eq_mul,
+      rw [show ConnesKreimer.single G s = s • ConnesKreimer.of' (R := R) G
+            from ConnesKreimer.smul_single_one G s,
+          mul_smul_comm, map_smul, smul_eq_mul,
           pairing_of'_mul_of' W C₁ G]
       rw [show ((Multiset.antidiagonal W).map (fun p =>
             pairing (R := R) (ConnesKreimer.of' p.1) (ConnesKreimer.of' C₁) *
@@ -446,7 +425,7 @@ theorem pairing_of'_mul (W : Forest (Nonplanar α))
              pairing (R := R) (ConnesKreimer.of' p.2) (ConnesKreimer.of' G)))) from
         Multiset.map_congr rfl fun p _ => by rw [map_smul, smul_eq_mul]; ring]
       rw [Multiset.sum_map_mul_left]
-  refine Finsupp.induction_linear z₁ ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear z₁ ?_ ?_ ?_
   · show pairing (R := R) (ConnesKreimer.of' W)
         ((0 : ConnesKreimer R (Nonplanar α)) * z₂) =
       ((Multiset.antidiagonal W).map (fun p =>
@@ -476,16 +455,9 @@ theorem pairing_of'_mul (W : Forest (Nonplanar α))
           pairing (R := R) (ConnesKreimer.of' p.2) z₂ = _
     rw [map_add, add_mul]
   · intro F r
-    let f' : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-    have hsingle : f' = r • (ConnesKreimer.of' (R := R) F) := by
-      show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-          r • (Finsupp.single F 1 : ConnesKreimer R (Nonplanar α))
-      exact (Finsupp.smul_single_one F r).symm
-    show pairing (R := R) (ConnesKreimer.of' W) (f' * z₂) =
-      ((Multiset.antidiagonal W).map (fun p =>
-        pairing (R := R) (ConnesKreimer.of' p.1) f' *
-        pairing (R := R) (ConnesKreimer.of' p.2) z₂)).sum
-    rw [hsingle, smul_mul_assoc, map_smul, smul_eq_mul, aux F z₂]
+    rw [show ConnesKreimer.single F r = r • ConnesKreimer.of' (R := R) F
+          from ConnesKreimer.smul_single_one F r,
+        smul_mul_assoc, map_smul, smul_eq_mul, aux F z₂]
     rw [show ((Multiset.antidiagonal W).map (fun p =>
           pairing (R := R) (ConnesKreimer.of' p.1)
             (r • ConnesKreimer.of' (R := R) F) *

--- a/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
@@ -76,13 +76,6 @@ open scoped TensorProduct
 
 variable {R : Type*} [CommRing R] {α : Type*}
 
-/-- `ConnesKreimer R T` inherits the `CommRing` structure from
-    `AddMonoidAlgebra R (Forest T)` when `R` is a commutative ring. The
-    `Bialgebra` substrate only needed `CommSemiring`; the antipode formula
-    needs negation, hence `CommRing`. -/
-noncomputable instance : CommRing (ConnesKreimer R (Nonplanar α)) :=
-  inferInstanceAs (CommRing (AddMonoidAlgebra R (Forest (Nonplanar α))))
-
 /-! ## §1: Subtree depth bound on cut summands
 
 Substrate for the well-founded antipode definition. The depth of any tree
@@ -490,8 +483,7 @@ noncomputable def antipodeMonoidHomN :
     commutative, the antipode is a (not anti-)algebra hom. -/
 noncomputable def antipodeAlgHomN :
     ConnesKreimer R (Nonplanar α) →ₐ[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.lift R (ConnesKreimer R (Nonplanar α)) (Forest (Nonplanar α))
-    antipodeMonoidHomN
+  ConnesKreimer.lift antipodeMonoidHomN
 
 /-! ### Right antipode (lTensor recursion)
 
@@ -537,14 +529,12 @@ noncomputable def antipodeRightMonoidHomN :
 /-- The **right antipode as an algebra hom** `R : H →ₐ[R] H`. -/
 noncomputable def antipodeRightAlgHomN :
     ConnesKreimer R (Nonplanar α) →ₐ[R] ConnesKreimer R (Nonplanar α) :=
-  AddMonoidAlgebra.lift R (ConnesKreimer R (Nonplanar α)) (Forest (Nonplanar α))
-    antipodeRightMonoidHomN
+  ConnesKreimer.lift antipodeRightMonoidHomN
 
 @[simp] theorem antipodeRightAlgHomN_apply_of' (F : Forest (Nonplanar α)) :
     antipodeRightAlgHomN (R := R) (of' F) =
       (F.map (antipodeRightTreeN (R := R))).prod := by
-  show AddMonoidAlgebra.lift R _ _ antipodeRightMonoidHomN (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [antipodeRightAlgHomN, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem antipodeRightAlgHomN_apply_ofTree (T : Nonplanar α) :
@@ -554,8 +544,7 @@ noncomputable def antipodeRightAlgHomN :
 
 @[simp] theorem antipodeAlgHomN_apply_of' (F : Forest (Nonplanar α)) :
     antipodeAlgHomN (R := R) (of' F) = (F.map (antipodeTreeN (R := R))).prod := by
-  show AddMonoidAlgebra.lift R _ _ antipodeMonoidHomN (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [antipodeAlgHomN, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem antipodeAlgHomN_apply_ofTree (T : Nonplanar α) :
@@ -763,7 +752,7 @@ private theorem antipodeAlgHomN_axiom_forest (F : Forest (Nonplanar α)) :
 
 Lift the forest-level statement (a per-element identity for `of' F`) to the
 algebra-hom equality `HopfAlgebra.ofAlgHom` consumes. Reduces via
-`AddMonoidAlgebra.algHom_ext`. -/
+`ConnesKreimer.algHom_ext`. -/
 
 /-- Wrapper of `antipodeAlgHomN_axiom_forest` stated at `comulAlgHomN (of' F)`
     instead of `comulForestN F`. The two are equal by `comulAlgHomN_apply_of'`. -/
@@ -782,7 +771,7 @@ private theorem antipode_rTensor_axiom [CharZero R] [NoZeroDivisors R] :
       (Bialgebra.comulAlgHom R (ConnesKreimer R (Nonplanar α))) =
     (Algebra.ofId R (ConnesKreimer R (Nonplanar α))).comp
       (Bialgebra.counitAlgHom R (ConnesKreimer R (Nonplanar α))) := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   -- Defeq: comp.apply, Bialgebra.comulAlgHom = AlgHom.ofLinearMap comul = comulAlgHomN,
   -- Bialgebra.counitAlgHom = AlgHom.ofLinearMap counit = counit, Algebra.ofId = algebraMap.
@@ -822,7 +811,7 @@ private theorem antipodeRight_lTensor_axiom [CharZero R] [NoZeroDivisors R] :
       (Bialgebra.comulAlgHom R (ConnesKreimer R (Nonplanar α))) =
     (Algebra.ofId R (ConnesKreimer R (Nonplanar α))).comp
       (Bialgebra.counitAlgHom R (ConnesKreimer R (Nonplanar α))) := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   exact antipodeRightAlgHomN_axiom_at_of' F
 
@@ -902,7 +891,7 @@ private theorem antipode_lTensor_axiom [CharZero R] [NoZeroDivisors R] :
       (Bialgebra.comulAlgHom R (ConnesKreimer R (Nonplanar α))) =
     (Algebra.ofId R (ConnesKreimer R (Nonplanar α))).comp
       (Bialgebra.counitAlgHom R (ConnesKreimer R (Nonplanar α))) := by
-  apply AddMonoidAlgebra.algHom_ext
+  apply ConnesKreimer.algHom_ext
   intro F
   exact antipodeAlgHomN_axiom_at_of'_lTensor F
 

--- a/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
@@ -340,22 +340,23 @@ variable {R : Type*} [CommRing R] [CharZero R] [NoZeroDivisors R] {α : Type*}
     Connes-Kreimer element. -/
 noncomputable def deltaSingleton (T : Nonplanar α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
-  Finsupp.lapply ({T} : Forest (Nonplanar α))
+  (Finsupp.lapply ({T} : Forest (Nonplanar α))).comp
+    (toFinsuppAlgEquiv (R := R) (T := Nonplanar α)).toLinearEquiv.toLinearMap
 
 set_option linter.unusedSectionVars false in
 @[simp] theorem deltaSingleton_of'_self (T : Nonplanar α) :
     deltaSingleton (R := R) T (of' ({T} : Forest (Nonplanar α))) = 1 := by
-  show Finsupp.lapply ({T} : Forest (Nonplanar α))
-        (Finsupp.single ({T} : Forest (Nonplanar α)) 1) = 1
-  rw [Finsupp.lapply_apply, Finsupp.single_eq_same]
+  simp only [deltaSingleton, LinearMap.comp_apply, Finsupp.lapply_apply]
+  exact Finsupp.single_eq_same
 
 set_option linter.unusedSectionVars false in
 theorem deltaSingleton_of'_other (T : Nonplanar α)
     (F : Forest (Nonplanar α)) (hF : F ≠ {T}) :
     deltaSingleton (R := R) T (of' F) = 0 := by
   classical
-  show Finsupp.lapply ({T} : Forest (Nonplanar α)) (Finsupp.single F 1) = 0
-  rw [Finsupp.lapply_apply, Finsupp.single_apply]
+  simp only [deltaSingleton, LinearMap.comp_apply, Finsupp.lapply_apply]
+  show (Finsupp.single F (1 : R) : Forest (Nonplanar α) →₀ R) {T} = 0
+  rw [Finsupp.single_apply]
   exact if_neg hF
 
 /-- The delta functional on a single tree is a **dual primitive** —
@@ -381,7 +382,7 @@ theorem deltaSingleton_isDualPrimitive (T : Nonplanar α) :
         counit (r • of' F : ConnesKreimer R (Nonplanar α)) *
           deltaSingleton T (s • of' G : ConnesKreimer R (Nonplanar α)) by
     intro x y
-    refine Finsupp.induction_linear x ?_ ?_ ?_
+    refine ConnesKreimer.induction_linear x ?_ ?_ ?_
     · -- x = 0
       show deltaSingleton T ((0 : ConnesKreimer R (Nonplanar α)) * y) =
            deltaSingleton T (0 : ConnesKreimer R (Nonplanar α)) * counit y +
@@ -405,16 +406,16 @@ theorem deltaSingleton_isDualPrimitive (T : Nonplanar α) :
       ring
     · -- x = single F r
       intro F r
-      refine Finsupp.induction_linear y ?_ ?_ ?_
+      refine ConnesKreimer.induction_linear y ?_ ?_ ?_
       · -- y = 0
-        let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+        let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
         show deltaSingleton T (x_single * (0 : ConnesKreimer R (Nonplanar α))) =
              deltaSingleton T x_single * counit (0 : ConnesKreimer R (Nonplanar α)) +
              counit x_single * deltaSingleton T (0 : ConnesKreimer R (Nonplanar α))
         simp
       · -- y = y₁ + y₂
         intro y₁ y₂ ih₁ ih₂
-        let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+        let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
         let y₁' : ConnesKreimer R (Nonplanar α) := y₁
         let y₂' : ConnesKreimer R (Nonplanar α) := y₂
         show deltaSingleton T (x_single * (y₁' + y₂')) =
@@ -428,15 +429,15 @@ theorem deltaSingleton_isDualPrimitive (T : Nonplanar α) :
         ring
       · -- y = single G s
         intro G s
-        let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-        let y_single : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
+        let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
+        let y_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single G s
         show deltaSingleton T (x_single * y_single) =
              deltaSingleton T x_single * counit y_single +
              counit x_single * deltaSingleton T y_single
         have hx : x_single = r • (of' (R := R) F) :=
-          (Finsupp.smul_single_one F r).symm
+          ConnesKreimer.smul_single_one F r
         have hy : y_single = s • (of' (R := R) G) :=
-          (Finsupp.smul_single_one G s).symm
+          ConnesKreimer.smul_single_one G s
         rw [hx, hy]
         exact h F G r s
   -- Step 2: scalars factor out; reduce to the unscaled basis identity.

--- a/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/BMinusSL.lean
@@ -741,7 +741,7 @@ private theorem bMinusLin_mul_eps [DecidableEq (Nonplanar α)] (a : α)
             bMinusLin (R := ℤ) a Z +
           counit Z • bMinusLin (R := ℤ) a (ConnesKreimer.of' F) by
     -- Bilinear extension: extend over X via Finsupp.induction_linear on X.
-    induction X using Finsupp.induction_linear with
+    induction X using ConnesKreimer.induction_linear with
     | zero =>
       -- LHS: bMinusLin a (0 * Y) = bMinusLin a 0 = 0.
       -- RHS: counit 0 • _ + counit Y • bMinusLin a 0 = 0 • _ + counit Y • 0 = 0.
@@ -769,10 +769,8 @@ private theorem bMinusLin_mul_eps [DecidableEq (Nonplanar α)] (a : α)
       abel
     | single F r =>
       -- Reduce single F r = r • of' F, then apply h on of' F.
-      have hX : (Finsupp.single F r : ConnesKreimer ℤ (Nonplanar α)) =
-                r • ConnesKreimer.of' F := by
-        show Finsupp.single F r = r • Finsupp.single F (1 : ℤ)
-        rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+      have hX : (ConnesKreimer.single F r : ConnesKreimer ℤ (Nonplanar α)) =
+                r • ConnesKreimer.of' F := ConnesKreimer.smul_single_one F r
       rw [hX]
       show bMinusLin (R := ℤ) a ((r • ConnesKreimer.of' F) * Y) =
            counit ((r • ConnesKreimer.of' F : ConnesKreimer ℤ (Nonplanar α))) •
@@ -787,7 +785,7 @@ private theorem bMinusLin_mul_eps [DecidableEq (Nonplanar α)] (a : α)
       rw [smul_smul, smul_eq_mul]
   -- Now prove h: for fixed of' F, the identity holds for all Z.
   intro F Z
-  induction Z using Finsupp.induction_linear with
+  induction Z using ConnesKreimer.induction_linear with
   | zero =>
     show bMinusLin (R := ℤ) a
           (ConnesKreimer.of' F * (0 : ConnesKreimer ℤ (Nonplanar α))) = _
@@ -814,10 +812,8 @@ private theorem bMinusLin_mul_eps [DecidableEq (Nonplanar α)] (a : α)
     rw [ih₁, ih₂, LinearMap.map_add, smul_add, _root_.map_add, add_smul]
     abel
   | single G s =>
-    have hY : (Finsupp.single G s : ConnesKreimer ℤ (Nonplanar α)) =
-              s • ConnesKreimer.of' G := by
-      show Finsupp.single G s = s • Finsupp.single G (1 : ℤ)
-      rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+    have hY : (ConnesKreimer.single G s : ConnesKreimer ℤ (Nonplanar α)) =
+              s • ConnesKreimer.of' G := ConnesKreimer.smul_single_one G s
     rw [hY]
     show bMinusLin (R := ℤ) a
             (ConnesKreimer.of' F * s • ConnesKreimer.of' G) =

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
@@ -75,13 +75,16 @@ arbitrary `R` after `InsertionAlgebra` is generalized (deferred). -/
     which is definitionally `AddMonoidAlgebra ℤ (Nonplanar α →₀ ℕ)`. Then
     `AddMonoidAlgebra.domCongr` via the additive equiv
     `(Nonplanar α →₀ ℕ) ≃+ Multiset (Nonplanar α)` (= `Multiset.toFinsupp.symm`)
-    lands in `AddMonoidAlgebra ℤ (Multiset (Nonplanar α)) = ConnesKreimer ℤ _`. -/
+    lands in `AddMonoidAlgebra ℤ (Multiset (Nonplanar α))`; the final
+    `ConnesKreimer.toFinsuppAlgEquiv.symm` wraps that bare carrier into the
+    `ConnesKreimer` structure. -/
 noncomputable def ckIsoSymmetricAlgebra :
     SymmetricAlgebra ℤ (InsertionAlgebra α) ≃ₐ[ℤ] ConnesKreimer ℤ (Nonplanar α) :=
   (SymmetricAlgebra.equivMvPolynomial
       (Finsupp.basisSingleOne (R := ℤ) (ι := Nonplanar α) :
         Module.Basis (Nonplanar α) ℤ (InsertionAlgebra α))).trans
-    (AddMonoidAlgebra.domCongr ℤ ℤ (Multiset.toFinsupp (α := Nonplanar α)).symm)
+    ((AddMonoidAlgebra.domCongr ℤ ℤ (Multiset.toFinsupp (α := Nonplanar α)).symm).trans
+      ConnesKreimer.toFinsuppAlgEquiv.symm)
 
 /-! ## §1b: Basis identification
 
@@ -95,11 +98,12 @@ theorem ckIsoSymmetricAlgebra_ι_single (t : Nonplanar α) :
     ckIsoSymmetricAlgebra
         (SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (Finsupp.single t (1 : ℤ))) =
       ConnesKreimer.of' (R := ℤ) ({t} : Multiset (Nonplanar α)) := by
-  show (AddMonoidAlgebra.domCongr ℤ ℤ Multiset.toFinsupp.symm)
-        ((SymmetricAlgebra.equivMvPolynomial
-            (Finsupp.basisSingleOne (R := ℤ) (ι := Nonplanar α) :
-              Module.Basis (Nonplanar α) ℤ (InsertionAlgebra α)))
-          ((SymmetricAlgebra.ι ℤ (InsertionAlgebra α)) (Finsupp.single t 1))) = _
+  show ConnesKreimer.toFinsuppAlgEquiv.symm
+        ((AddMonoidAlgebra.domCongr ℤ ℤ Multiset.toFinsupp.symm)
+          ((SymmetricAlgebra.equivMvPolynomial
+              (Finsupp.basisSingleOne (R := ℤ) (ι := Nonplanar α) :
+                Module.Basis (Nonplanar α) ℤ (InsertionAlgebra α)))
+            ((SymmetricAlgebra.ι ℤ (InsertionAlgebra α)) (Finsupp.single t 1)))) = _
   -- Step 1: equivMvPolynomial sends ι (basisSingleOne t) to MvPolynomial.X t.
   have h1 : SymmetricAlgebra.equivMvPolynomial
       (Finsupp.basisSingleOne (R := ℤ) (ι := Nonplanar α) :
@@ -112,9 +116,10 @@ theorem ckIsoSymmetricAlgebra_ι_single (t : Nonplanar α) :
     exact SymmetricAlgebra.equivMvPolynomial_ι_apply _ t
   rw [h1]
   -- Step 2: MvPolynomial.X t = single (single t 1) 1.
-  show (AddMonoidAlgebra.domCongr ℤ ℤ Multiset.toFinsupp.symm)
-      (AddMonoidAlgebra.single (Finsupp.single t 1) 1 :
-        AddMonoidAlgebra ℤ (Nonplanar α →₀ ℕ)) = _
+  show ConnesKreimer.toFinsuppAlgEquiv.symm
+      ((AddMonoidAlgebra.domCongr ℤ ℤ Multiset.toFinsupp.symm)
+        (AddMonoidAlgebra.single (Finsupp.single t 1) 1 :
+          AddMonoidAlgebra ℤ (Nonplanar α →₀ ℕ))) = _
   rw [AddMonoidAlgebra.domCongr_single]
   -- Multiset.toFinsupp.symm (single t 1) = {t}
   have h2 : (Multiset.toFinsupp (α := Nonplanar α)).symm (Finsupp.single t 1) =
@@ -379,7 +384,7 @@ private theorem GL_insertion_leibniz_basis_form
 omit [DecidableEq (Nonplanar α)] in
 /-- **Helper for 1.3**: Leibniz rule with right argument forced to be a
     Forest-basis element. Bilinear-in-A extension of the basis form via
-    `Finsupp.induction_linear` on A (following `insertion_mul_distrib_gen`'s
+    `ConnesKreimer.induction_linear` on A (following `insertion_mul_distrib_gen`'s
     pattern of explicit `show` casts to navigate type-alias unfolding). -/
 private theorem GL_insertion_leibniz_basis_right
     (A : ConnesKreimer ℤ (Nonplanar α)) (F_B : Forest (Nonplanar α))
@@ -395,7 +400,7 @@ private theorem GL_insertion_leibniz_basis_right
         (A * GrossmanLarson.unop (GrossmanLarson.insertion
           (GrossmanLarson.op (ConnesKreimer.of' F_B : ConnesKreimer ℤ _))
           (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))))) := by
-  refine Finsupp.induction_linear A ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear A ?_ ?_ ?_
   · -- A = 0: every term has a `0 *` or `* 0` or `unop 0`/`op 0` that
     -- reduces to 0 of the appropriate type.
     show GrossmanLarson.insertion
@@ -417,8 +422,8 @@ private theorem GL_insertion_leibniz_basis_right
                LinearMap.zero_apply, add_zero]
   · -- additive
     intro A₁ A₂ ih₁ ih₂
-    -- A₁, A₂ are typed as `Forest →₀ ℤ` by `Finsupp.induction_linear`.
-    -- Cast each to `ConnesKreimer ℤ (Nonplanar α)` via `let`.
+    -- A₁, A₂ are `ConnesKreimer ℤ (Nonplanar α)` from `ConnesKreimer.induction_linear`.
+    -- Alias each via `let` for the `show` below.
     let A₁' : ConnesKreimer ℤ (Nonplanar α) := A₁
     let A₂' : ConnesKreimer ℤ (Nonplanar α) := A₂
     show GrossmanLarson.insertion
@@ -447,8 +452,8 @@ private theorem GL_insertion_leibniz_basis_right
     ring
   · -- single F_A r
     intro F_A r
-    -- Cast `Finsupp.single F_A r` from Finsupp to CK type explicitly.
-    let A_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single F_A r
+    -- Basis case: `A = ConnesKreimer.single F_A r`.
+    let A_single : ConnesKreimer ℤ (Nonplanar α) := ConnesKreimer.single F_A r
     show GrossmanLarson.insertion
         (GrossmanLarson.op (A_single * (ConnesKreimer.of' F_B : ConnesKreimer ℤ _)))
         (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
@@ -460,11 +465,8 @@ private theorem GL_insertion_leibniz_basis_right
             (GrossmanLarson.op (ConnesKreimer.of' F_B : ConnesKreimer ℤ _))
             (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)))))
     -- Unfold A_single = r • of' F_A.
-    have hA : A_single = r • (ConnesKreimer.of' F_A : ConnesKreimer ℤ (Nonplanar α)) := by
-      show (Finsupp.single F_A r : ConnesKreimer ℤ (Nonplanar α)) =
-            r • (ConnesKreimer.of' F_A : ConnesKreimer ℤ _)
-      rw [ConnesKreimer.of'_apply]
-      exact (Finsupp.smul_single_one F_A r).symm
+    have hA : A_single = r • (ConnesKreimer.of' F_A : ConnesKreimer ℤ (Nonplanar α)) :=
+      ConnesKreimer.smul_single_one F_A r
     rw [hA]
     rw [smul_mul_assoc, ← ConnesKreimer.of'_add, op_smul,
         (GrossmanLarson.insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
@@ -496,7 +498,7 @@ private theorem GL_insertion_leibniz_left_singleton_guest
       GrossmanLarson.op
         (A * GrossmanLarson.unop (GrossmanLarson.insertion (GrossmanLarson.op B)
           (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset (Nonplanar α)))))) := by
-  refine Finsupp.induction_linear B ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear B ?_ ?_ ?_
   · -- B = 0
     show GrossmanLarson.insertion
         (GrossmanLarson.op (A * (0 : ConnesKreimer ℤ (Nonplanar α))))
@@ -539,7 +541,7 @@ private theorem GL_insertion_leibniz_left_singleton_guest
     ring
   · -- B = single F_B r
     intro F_B r
-    let B_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single F_B r
+    let B_single : ConnesKreimer ℤ (Nonplanar α) := ConnesKreimer.single F_B r
     show GrossmanLarson.insertion
         (GrossmanLarson.op (A * B_single))
         (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
@@ -550,11 +552,8 @@ private theorem GL_insertion_leibniz_left_singleton_guest
         (A * GrossmanLarson.unop (GrossmanLarson.insertion
           (GrossmanLarson.op B_single)
           (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _)))))
-    have hB : B_single = r • (ConnesKreimer.of' F_B : ConnesKreimer ℤ (Nonplanar α)) := by
-      show (Finsupp.single F_B r : ConnesKreimer ℤ (Nonplanar α)) =
-            r • (ConnesKreimer.of' F_B : ConnesKreimer ℤ _)
-      rw [ConnesKreimer.of'_apply]
-      exact (Finsupp.smul_single_one F_B r).symm
+    have hB : B_single = r • (ConnesKreimer.of' F_B : ConnesKreimer ℤ (Nonplanar α)) :=
+      ConnesKreimer.smul_single_one F_B r
     rw [hB]
     -- A * (r • of' F_B) = r • (A * of' F_B). Then op + insertion scale out.
     rw [mul_smul_comm, op_smul,
@@ -622,10 +621,15 @@ private theorem ckIso_circ_intertwine_basis_v
         (GrossmanLarson.op (ckIsoSymmetricAlgebra
           (algebraMap ℤ (SymmetricAlgebra ℤ (InsertionAlgebra α)) r)))
         (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _))))
-    rw [AlgEquiv.commutes, Algebra.algebraMap_eq_smul_one, op_smul,
-        show GrossmanLarson.op (1 : ConnesKreimer ℤ (Nonplanar α)) =
-            (1 : GrossmanLarson ℤ α) from rfl,
-        (GrossmanLarson.insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
+    rw [AlgEquiv.commutes, Algebra.algebraMap_eq_smul_one]
+    -- `op (r • 1)` and `r • (1 : GrossmanLarson)` are both `⟨r • 1⟩`; normalize
+    -- the smul to the GL unit by defeq (avoids a `SMul ℤ` instance mismatch
+    -- between `Algebra.toSMul` and the structural `SMul ℤ`).
+    show (0 : ConnesKreimer ℤ (Nonplanar α)) =
+      GrossmanLarson.unop (GrossmanLarson.insertion
+        (r • (1 : GrossmanLarson ℤ α))
+        (GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset _))))
+    rw [(GrossmanLarson.insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
         LinearMap.smul_apply]
     -- Goal: 0 = (r • insertion 1 (op (of' {t}))).unop
     rw [show GrossmanLarson.op (ConnesKreimer.of' ({t} : Multiset (Nonplanar α))) =
@@ -952,7 +956,7 @@ private theorem GL_iterated_insertion_singleton_v
   set ins : GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α →ₗ[ℤ] GrossmanLarson ℤ α :=
     GrossmanLarson.insertion with hins
   -- Linearize F. Both sides are F-linear by bilinearity of `insertion`.
-  refine Finsupp.induction_linear F ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear F ?_ ?_ ?_
   · -- F = 0: both sides reduce to 0.
     show ins (ins 0 (ConnesKreimer.of' C))
           (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
@@ -1012,20 +1016,15 @@ private theorem GL_iterated_insertion_singleton_v
     abel
   · -- F = single A r — basis case.
     intro A r
-    let F_single : GrossmanLarson ℤ α := Finsupp.single A r
+    let F_single : GrossmanLarson ℤ α := ConnesKreimer.single A r
     show ins (ins F_single (ConnesKreimer.of' C))
           (GrossmanLarson.op (ConnesKreimer.of' ({v} : Multiset _))) =
         ins F_single (ConnesKreimer.of' (C + {v})) +
         ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
           (fun Y => ins F_single (ConnesKreimer.of' Y))).sum
     -- ins is bilinear; reduce F_single = r • of' A.
-    have hF : F_single = r • (GrossmanLarson.of' A : GrossmanLarson ℤ α) := by
-      show (Finsupp.single A r : GrossmanLarson ℤ α) =
-            r • (GrossmanLarson.of' A : GrossmanLarson ℤ α)
-      show (Finsupp.single A r : ConnesKreimer ℤ (Nonplanar α)) =
-            r • (ConnesKreimer.of' A : ConnesKreimer ℤ _)
-      rw [ConnesKreimer.of'_apply]
-      exact (Finsupp.smul_single_one A r).symm
+    have hF : F_single = r • (GrossmanLarson.of' A : GrossmanLarson ℤ α) :=
+      ConnesKreimer.smul_single_one A r
     rw [hF]
     -- Helper: insertion respects smul in first arg.
     have hins_smul_left : ∀ (X Z : GrossmanLarson ℤ α),
@@ -1578,9 +1577,9 @@ private theorem GL_product_split_mul_ι
   letI : DecidableEq (Nonplanar α) := Classical.decEq _
   -- Step 1: linearize G to basis. Use the underlying ℤ-linearity of
   -- both sides in G (each of T1, T2, T3, T4 is a ℤ-linear function of G).
-  -- This standard Finsupp.induction_linear pattern follows
+  -- This standard ConnesKreimer.induction_linear pattern follows
   -- `insertion_mul_distrib_gen`/`GL_insertion_leibniz_basis_right`.
-  refine Finsupp.induction_linear G ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear G ?_ ?_ ?_
   · -- G = 0 case: T1=T2=T3=T4=0.
     show F * GrossmanLarson.op
         ((0 : ConnesKreimer ℤ (Nonplanar α)) * ConnesKreimer.of' {v}) +
@@ -1737,7 +1736,7 @@ private theorem GL_product_split_mul_ι
     abel
   · -- G = single B r: scale out r, reduce to basis G = of' B.
     intro B r
-    let G_single : ConnesKreimer ℤ (Nonplanar α) := Finsupp.single B r
+    let G_single : ConnesKreimer ℤ (Nonplanar α) := ConnesKreimer.single B r
     show F * GrossmanLarson.op (G_single * ConnesKreimer.of' {v}) +
         F * GrossmanLarson.insertion (GrossmanLarson.op G_single)
             (GrossmanLarson.op (ConnesKreimer.of' {v})) =
@@ -1745,11 +1744,8 @@ private theorem GL_product_split_mul_ι
         (GrossmanLarson.op (ConnesKreimer.of' {v})) +
       GrossmanLarson.op
         (GrossmanLarson.unop (F * GrossmanLarson.op G_single) * ConnesKreimer.of' {v})
-    have hG : G_single = r • (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) := by
-      show (Finsupp.single B r : ConnesKreimer ℤ (Nonplanar α)) =
-            r • (ConnesKreimer.of' B : ConnesKreimer ℤ _)
-      rw [ConnesKreimer.of'_apply]
-      exact (Finsupp.smul_single_one B r).symm
+    have hG : G_single = r • (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) :=
+      ConnesKreimer.smul_single_one B r
     rw [hG]
     -- Push r through each term using smul_mul_assoc, op_smul, etc.
     have h_ins_smul_first :
@@ -2124,9 +2120,9 @@ private theorem GL_product_split_mul_ι
     `oudomGuinCirc_algHomL_tprod_ι` + `ckIso_circ_intertwine_insertion` +
     `GL_product_split_mul_ι`. The `m+1` case v-linearizes via
     `Finsupp.induction_linear`; the basis case `v = ofTree t` chains all
-    substrate. Coercion discipline: work in CK (with the local
-    `AddCommGroup`) for additive rearrangements; transport to GL via
-    `op`/`unop` (which are the identity coercion). -/
+    substrate. Coercion discipline: work in CK (whose global `CommRing`
+    instance supplies the `AddCommGroup`) for additive rearrangements;
+    transport to GL via `op`/`unop` (which are the identity coercion). -/
 private theorem gl_product_eq_oudomGuinStar_tprod
     (X : SymmetricAlgebra ℤ (InsertionAlgebra α)) :
     ∀ (m : ℕ) (a : Fin m → InsertionAlgebra α),
@@ -2158,8 +2154,6 @@ private theorem gl_product_eq_oudomGuinStar_tprod
     rfl
   | succ m ih =>
     intro a
-    -- Local AddCommGroup instance for CK to enable map_sub/map_neg.
-    letI : AddCommGroup (ConnesKreimer ℤ (Nonplanar α)) := ConnesKreimer.addCommGroupOf
     -- Set up tprod (m+1) split + algHomL split.
     have h_a_eq : a = Fin.snoc (Fin.init a) (a (Fin.last m)) :=
       (Fin.snoc_init_self a).symm

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
@@ -265,7 +265,7 @@ theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
         (GrossmanLarson.unop
           ((GrossmanLarson.op x : GrossmanLarson R α) * GrossmanLarson.op y)) =
       (counit x) * (counit y) := by
-  refine Finsupp.induction_linear x ?_ ?_ ?_
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
   · -- x = 0
     change (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
         (GrossmanLarson.unop
@@ -310,9 +310,9 @@ theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
     ring
   · -- x = single F r
     intro F r
-    refine Finsupp.induction_linear y ?_ ?_ ?_
+    refine ConnesKreimer.induction_linear y ?_ ?_ ?_
     · -- y = 0
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
       change (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop
             ((GrossmanLarson.op x_single : GrossmanLarson R α) *
@@ -325,7 +325,7 @@ theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
           map_zero, mul_zero]
     · -- y = y₁ + y₂
       intro y₁ y₂ ih₁ ih₂
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
       let y₁' : ConnesKreimer R (Nonplanar α) := y₁
       let y₂' : ConnesKreimer R (Nonplanar α) := y₂
       show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
@@ -360,8 +360,8 @@ theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
       ring
     · -- y = single G s: factor r, s, apply counit_gl_mul_basis F G
       intro G s
-      let x_single : ConnesKreimer R (Nonplanar α) := Finsupp.single F r
-      let y_single : ConnesKreimer R (Nonplanar α) := Finsupp.single G s
+      let x_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single F r
+      let y_single : ConnesKreimer R (Nonplanar α) := ConnesKreimer.single G s
       show (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R)
           (GrossmanLarson.unop
             ((GrossmanLarson.op x_single : GrossmanLarson R α) *
@@ -369,13 +369,13 @@ theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
         (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) x_single *
           (counit : ConnesKreimer R (Nonplanar α) →ₐ[R] R) y_single
       have hx : x_single = r • (ConnesKreimer.of' (R := R) F) := by
-        show (Finsupp.single F r : ConnesKreimer R (Nonplanar α)) =
-            r • (Finsupp.single F (1 : R) : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one F r).symm
+        show (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) =
+            r • (ConnesKreimer.single F (1 : R) : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one F r
       have hy : y_single = s • (ConnesKreimer.of' (R := R) G) := by
-        show (Finsupp.single G s : ConnesKreimer R (Nonplanar α)) =
-            s • (Finsupp.single G (1 : R) : ConnesKreimer R (Nonplanar α))
-        exact (Finsupp.smul_single_one G s).symm
+        show (ConnesKreimer.single G s : ConnesKreimer R (Nonplanar α)) =
+            s • (ConnesKreimer.single G (1 : R) : ConnesKreimer R (Nonplanar α))
+        exact ConnesKreimer.smul_single_one G s
       rw [hx, hy]
       -- Pull r, s through op and *.
       rw [show (GrossmanLarson.op (r • ConnesKreimer.of' (R := R) F) :
@@ -420,6 +420,7 @@ theorem counit_gl_mul (x y : ConnesKreimer R (Nonplanar α)) :
 
 /-! ### Phase D's pairing-side recurrence -/
 
+omit [DecidableEq (Nonplanar α)] in
 /-- Phase D RHS recurrence: `⟨unop (op X * op Y), bPlusLin a z⟩` unfolds
     via B+/B- adjoint + Phase C `bMinusLin_gl_mul`.
 

--- a/Linglib/Syntax/Minimalist/Agree/Consistency.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Consistency.lean
@@ -171,13 +171,12 @@ def headProbeMonoidHom (Υ : LIToken → Consistency) :
     whose Birkhoff renormalization is the consistency map. -/
 noncomputable def headProbeChar (Υ : LIToken → Consistency) :
     ConnesKreimer ℕ (Nonplanar SOLabel) →ₐ[ℕ] Consistency :=
-  AddMonoidAlgebra.lift ℕ Consistency (Forest (Nonplanar SOLabel)) (headProbeMonoidHom Υ)
+  ConnesKreimer.lift (headProbeMonoidHom Υ)
 
 @[simp] theorem headProbeChar_apply_of' (Υ : LIToken → Consistency)
     (F : Forest (Nonplanar SOLabel)) :
     headProbeChar Υ (of' F) = (F.map (headProbeTree Υ)).prod := by
-  show AddMonoidAlgebra.lift ℕ _ _ (headProbeMonoidHom Υ) (Finsupp.single F 1) = _
-  rw [AddMonoidAlgebra.lift_single, one_smul]
+  rw [headProbeChar, ConnesKreimer.lift_of']
   rfl
 
 @[simp] theorem headProbeChar_apply_ofTree (Υ : LIToken → Consistency) (T : Nonplanar SOLabel) :

--- a/Linglib/Syntax/Minimalist/Merge/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Basic.lean
@@ -1,5 +1,4 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
-import Mathlib.LinearAlgebra.Finsupp.Defs
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.RingTheory.TensorProduct.Maps
 
@@ -58,15 +57,15 @@ element `of' {S, S'}`:
 
   gammaMatch S S' (of' F) = if F = {S, S'} then of' F else 0
 
-Built as `Finsupp.lsingle ∘ Finsupp.lapply` on the matching forest. -/
+Built as a `ConnesKreimer.linearLift` that maps the `{S, S'}` basis vector to
+itself and every other basis vector to zero. -/
 
 /-- The matching projection γ_{S,S'} (M-C-B Def 1.3.1): keeps the coefficient
     of the `{S, S'}` basis element, sends everything else to zero. -/
 noncomputable def gammaMatch (S S' : Nonplanar α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  let target : Forest (Nonplanar α) := ({S, S'} : Multiset (Nonplanar α))
-  show (Forest (Nonplanar α) →₀ R) →ₗ[R] (Forest (Nonplanar α) →₀ R) from
-    (Finsupp.lsingle target).comp (Finsupp.lapply target)
+  ConnesKreimer.linearLift
+    (fun F => if F = ({S, S'} : Forest (Nonplanar α)) then of' F else 0)
 
 /-- **γ_{S,S'} acts as a basis-vector projection**: on the basis element
     `of' F`, it returns `of' F` if `F = {S, S'}` and `0` otherwise.
@@ -75,15 +74,7 @@ theorem gammaMatch_apply_singleton (S S' : Nonplanar α)
     (F : Forest (Nonplanar α)) :
     gammaMatch (R := R) S S' (of' F) =
       if F = ({S, S'} : Forest (Nonplanar α)) then of' F else 0 := by
-  show (Finsupp.lsingle ({S, S'} : Forest (Nonplanar α))).comp
-        (Finsupp.lapply ({S, S'} : Forest (Nonplanar α)))
-        (Finsupp.single F (1 : R))
-      = _
-  rw [LinearMap.comp_apply, Finsupp.lapply_apply, Finsupp.lsingle_apply,
-    Finsupp.single_apply]
-  split_ifs with h
-  · subst h; rfl
-  · exact Finsupp.single_zero _
+  rw [gammaMatch, ConnesKreimer.linearLift_of']
 
 /-! ## §2: δ_{S,S'} matching on the left tensor channel (M-C-B Def 1.3.1)
 
@@ -114,11 +105,9 @@ head). -/
     other basis elements to zero. M-C-B Lemma 1.3.3 for binary Merge. -/
 noncomputable def graftBinaryAt (lbl : α) (S S' : Nonplanar α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  let source : Forest (Nonplanar α) := ({S, S'} : Multiset (Nonplanar α))
-  let target : Forest (Nonplanar α) :=
-    ({Nonplanar.node lbl {S, S'}} : Multiset (Nonplanar α))
-  show (Forest (Nonplanar α) →₀ R) →ₗ[R] (Forest (Nonplanar α) →₀ R) from
-    (Finsupp.lsingle target).comp (Finsupp.lapply source)
+  ConnesKreimer.linearLift
+    (fun F => if F = ({S, S'} : Forest (Nonplanar α))
+      then of' ({Nonplanar.node lbl {S, S'}} : Forest (Nonplanar α)) else 0)
 
 /-- **B grafts on basis vectors**: on `of' F`, returns
     `of' {Nonplanar.node lbl {S, S'}}` if `F = {S, S'}`, and `0` otherwise.
@@ -129,15 +118,7 @@ theorem graftBinaryAt_apply_singleton (lbl : α) (S S' : Nonplanar α)
       if F = ({S, S'} : Forest (Nonplanar α))
         then of' ({Nonplanar.node lbl {S, S'}} : Forest (Nonplanar α))
         else 0 := by
-  show (Finsupp.lsingle ({Nonplanar.node lbl {S, S'}} : Forest (Nonplanar α))).comp
-        (Finsupp.lapply ({S, S'} : Forest (Nonplanar α)))
-        (Finsupp.single F (1 : R))
-      = _
-  rw [LinearMap.comp_apply, Finsupp.lapply_apply, Finsupp.lsingle_apply,
-    Finsupp.single_apply]
-  split_ifs with h
-  · subst h; rfl
-  · exact Finsupp.single_zero _
+  rw [graftBinaryAt, ConnesKreimer.linearLift_of']
 
 /-! ## §4: Merge operator (M-C-B Def 1.3.4)
 
@@ -206,33 +187,37 @@ theorem mergePost_basis_tensor (lbl : α) (S S' : Nonplanar α)
     simp only [map_zero]
 
 omit [DecidableEq (Nonplanar α)] in
+/-- Left-multiplying a `single` basis vector by `of' F` concatenates forests:
+    `of' F * single G r = single (F + G) r`. -/
+private theorem of'_mul_single (F G : Forest (Nonplanar α)) (r : R) :
+    of' (R := R) F * single G r = single (F + G) r := by
+  rw [smul_single_one G r, mul_smul_comm]
+  change r • (of' (R := R) F * of' G) = single (F + G) r
+  rw [← of'_add]
+  exact (smul_single_one (F + G) r).symm
+
 /-- **General γ_{S,S'}-vanishing on a left-multiplied forest**: if `F` is NOT a
     sub-multiset of `{S, S'}`, then `γ_{S,S'}(of' F * a) = 0` for any `a`.
 
     The hypothesis `¬ F ≤ ({S, S'} : Forest (Nonplanar α))` says `F` cannot
-    embed into `{S, S'}` as a sub-multiset, equivalently (by
-    `Multiset.le_iff_exists_add`) `F` is not a left-divisor of `{S, S'}`. -/
+    embed into `{S, S'}` as a sub-multiset: since `F ≤ F + G` always, every
+    forest `F + G` produced by left-multiplication misses the `{S, S'}` basis
+    element that `γ_{S,S'}` reads. -/
 theorem gammaMatch_mul_eq_zero_of_not_le (S S' : Nonplanar α)
     (F : Forest (Nonplanar α))
     (hF : ¬ F ≤ ({S, S'} : Forest (Nonplanar α)))
     (a : ConnesKreimer R (Nonplanar α)) :
     gammaMatch (R := R) S S' (of' F * a) = 0 := by
-  have h_no_decomp : ¬ ∃ d : Forest (Nonplanar α),
-                        ({S, S'} : Forest (Nonplanar α)) = F + d := by
-    intro ⟨d, hd⟩
-    exact hF (Multiset.le_iff_exists_add.mpr ⟨d, hd⟩)
-  show ((Finsupp.lsingle ({S, S'} : Forest (Nonplanar α))).comp
-        (Finsupp.lapply ({S, S'} : Forest (Nonplanar α))))
-      (of' (R := R) F * a) = 0
-  rw [LinearMap.comp_apply, Finsupp.lapply_apply, Finsupp.lsingle_apply]
-  show Finsupp.single ({S, S'} : Forest (Nonplanar α))
-        ((of' (R := R) F * a) ({S, S'} : Forest (Nonplanar α))) = 0
-  rw [show (of' (R := R) F * a) ({S, S'} : Forest (Nonplanar α)) = 0 from
-    AddMonoidAlgebra.single_mul_apply_of_not_exists_add (M := Forest (Nonplanar α))
-      (R := R) (1 : R) a h_no_decomp]
-  exact Finsupp.single_zero _
+  induction a using ConnesKreimer.induction_linear with
+  | zero => rw [mul_zero, map_zero]
+  | add g h hg hh => rw [mul_add, map_add, hg, hh, add_zero]
+  | single G r =>
+    have hne : F + G ≠ ({S, S'} : Forest (Nonplanar α)) :=
+      fun heq => hF (heq ▸ Multiset.le_add_right F G)
+    rw [of'_mul_single, gammaMatch]
+    simp only [ConnesKreimer.linearLift_single]
+    rw [if_neg hne, smul_zero]
 
-omit [DecidableEq (Nonplanar α)] in
 /-- **Disjoint-singleton vanishing of γ_{S,S'}** (corollary): if `T ≠ S` and
     `T ≠ S'`, then `γ_{S,S'}(of' {T} * a) = 0`. -/
 theorem gammaMatch_singleton_mul_eq_zero (S S' T : Nonplanar α)
@@ -250,7 +235,6 @@ theorem gammaMatch_singleton_mul_eq_zero (S S' T : Nonplanar α)
   · exact hT_ne_S h
   · exact hT_ne_S' h
 
-omit [DecidableEq (Nonplanar α)] in
 /-- **Vanishing of mergePost on left-multiplied disjoint factors**: if `F` is NOT
     a sub-multiset of `{S, S'}` and `b` is arbitrary, then for any `z`:
 
@@ -278,7 +262,6 @@ theorem mergePost_left_mul_eq_zero_of_not_le (lbl : α) (S S' : Nonplanar α)
     simp only [map_add]
     rw [ih1, ih2, add_zero]
 
-omit [DecidableEq (Nonplanar α)] in
 /-- **Right-multiplicativity of the post-coproduct chain** by a "pure
     right-channel" factor `1 ⊗ y`. For any `z` and any `y`:
 
@@ -338,9 +321,8 @@ manipulation; that name does NOT signal a stand-alone Merge. -/
     `gammaMatch` but with a singleton target. -/
 noncomputable def gammaMatchSingle (β : Nonplanar α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  let target : Forest (Nonplanar α) := ({β} : Multiset (Nonplanar α))
-  show (Forest (Nonplanar α) →₀ R) →ₗ[R] (Forest (Nonplanar α) →₀ R) from
-    (Finsupp.lsingle target).comp (Finsupp.lapply target)
+  ConnesKreimer.linearLift
+    (fun F => if F = ({β} : Forest (Nonplanar α)) then of' F else 0)
 
 /-- **`γ_{β, 1}` acts as a basis-vector projection**: on `of' F`, returns `of' F`
     if `F = {β}`, and `0` otherwise. Singleton counterpart of
@@ -349,15 +331,7 @@ theorem gammaMatchSingle_apply_singleton (β : Nonplanar α)
     (F : Forest (Nonplanar α)) :
     gammaMatchSingle (R := R) β (of' F) =
       if F = ({β} : Forest (Nonplanar α)) then of' F else 0 := by
-  show (Finsupp.lsingle ({β} : Forest (Nonplanar α))).comp
-        (Finsupp.lapply ({β} : Forest (Nonplanar α)))
-        (Finsupp.single F (1 : R))
-      = _
-  rw [LinearMap.comp_apply, Finsupp.lapply_apply, Finsupp.lsingle_apply,
-    Finsupp.single_apply]
-  split_ifs with h
-  · subst h; rfl
-  · exact Finsupp.single_zero _
+  rw [gammaMatchSingle, ConnesKreimer.linearLift_of']
 
 /-- The matching operator `δ_{β, 1}` on tensored coproduct output: applies
     `gammaMatchSingle β` to the left channel, identity to the right. -/

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
@@ -69,13 +69,11 @@ noncomputable def gradingMonoidHom :
 /-- **The Minimal-Yield character** `ϕt : H →ₐ[R] DM[t⁻¹][[t]]` (MCB Prop. 3.5.3, eq. 3.5.6) in the
     lean t-grading model. -/
 noncomputable def gradingChar : ConnesKreimer R (Nonplanar α) →ₐ[R] LaurentSeries R :=
-  AddMonoidAlgebra.lift R (LaurentSeries R) (Forest (Nonplanar α)) gradingMonoidHom
+  ConnesKreimer.lift gradingMonoidHom
 
 @[simp] theorem gradingChar_apply_of' (F : Forest (Nonplanar α)) :
     gradingChar (R := R) (of' F) = (F.map (gradingMonomialTree (R := R))).prod := by
-  show AddMonoidAlgebra.lift R (LaurentSeries R) (Forest (Nonplanar α)) gradingMonoidHom
-      (AddMonoidAlgebra.of R (Forest (Nonplanar α)) (Multiplicative.ofAdd F)) = _
-  rw [AddMonoidAlgebra.lift_of]
+  rw [gradingChar, ConnesKreimer.lift_of']
   rfl
 
 /-- `ϕt(F) = t^{α(F)}`: the forest value is the single grading monomial at the accessible-term


### PR DESCRIPTION
Reland of #1050 (stranded when it merged into the already-merged rosetree-polish branch). Wraps `ConnesKreimer R T` as a one-field structure over `AddMonoidAlgebra R (Forest T)` (the `Polynomial` playbook) and migrates all ~20 consumer files onto a self-contained API (`single`/`of'`/`lift`/`linearLift`/`algHom_ext`/`addHom_ext`/`lhom_ext`/`induction_linear`/`mapDomainAlgHom`/`basisSingleOne`). Spec: scratch/connes-kreimer-structure-spec.md.

- Kills the `SMul ℤ` diamond structurally: `CommRing` is now a safe global instance (`fast_instance%`; single generic `SMulZeroClass` action) and `addCommGroupOf` + its three `attribute [local instance]` sites are deleted. The OudomGuinBridge `op_smul := rfl` gate holds.
- Existing `Bialgebra`(Δ^ρ)/`HopfAlgebra` instance bodies unchanged; consumer files no longer name `AddMonoidAlgebra`/`Finsupp` on CK values (remaining Finsupp uses are other carriers: `InsertionAlgebra`, MvPolynomial exponents).
- Two files need file-level `set_option maxSynthPendingDepth 2` for instance synthesis on nested tensor squares — the structure loses the def-synonym's fall-through to `AddMonoidAlgebra` instances.