### PR TITLE
feat(Core/RootedTree): ConnesKreimer coeff API + granular actions

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
+++ b/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
@@ -167,8 +167,42 @@ noncomputable def toFinsuppAddHom :
   map_zero' := toFinsupp_zero
   map_add' := toFinsupp_add
 
-noncomputable instance instModule : Module R (ConnesKreimer R T) :=
-  fast_instance% toFinsupp_injective.module R toFinsuppAddHom toFinsupp_smul
+/-! Granular action instances (mirroring `Polynomial`): keeping these one
+synthesis step away from the underlying carrier lets nested-tensor goals
+(`CK ⊗ (CK ⊗ CK)`) resolve without deep pending chains. -/
+
+noncomputable instance distribSMul {S : Type*}
+    [DistribSMul S (AddMonoidAlgebra R (Forest T))] :
+    DistribSMul S (ConnesKreimer R T) where
+  smul_add s p q := ext (smul_add s p.toFinsupp q.toFinsupp)
+
+noncomputable instance distribMulAction {S : Type*} [Monoid S]
+    [DistribMulAction S (AddMonoidAlgebra R (Forest T))] :
+    DistribMulAction S (ConnesKreimer R T) where
+  one_smul p := ext (one_smul S p.toFinsupp)
+  mul_smul s t p := ext (mul_smul s t p.toFinsupp)
+  smul_zero s := ext (smul_zero s)
+  smul_add s p q := ext (smul_add s p.toFinsupp q.toFinsupp)
+
+noncomputable instance instModule {S : Type*} [Semiring S]
+    [Module S (AddMonoidAlgebra R (Forest T))] :
+    Module S (ConnesKreimer R T) where
+  add_smul s t p := ext (add_smul s t p.toFinsupp)
+  zero_smul p := ext (zero_smul S p.toFinsupp)
+
+instance smulCommClass {S₁ S₂ : Type*}
+    [SMulZeroClass S₁ (AddMonoidAlgebra R (Forest T))]
+    [SMulZeroClass S₂ (AddMonoidAlgebra R (Forest T))]
+    [SMulCommClass S₁ S₂ (AddMonoidAlgebra R (Forest T))] :
+    SMulCommClass S₁ S₂ (ConnesKreimer R T) :=
+  ⟨fun s t p => ext (smul_comm s t p.toFinsupp)⟩
+
+instance isScalarTower {S₁ S₂ : Type*} [SMul S₁ S₂]
+    [SMulZeroClass S₁ (AddMonoidAlgebra R (Forest T))]
+    [SMulZeroClass S₂ (AddMonoidAlgebra R (Forest T))]
+    [IsScalarTower S₁ S₂ (AddMonoidAlgebra R (Forest T))] :
+    IsScalarTower S₁ S₂ (ConnesKreimer R T) :=
+  ⟨fun s t p => ext (smul_assoc s t p.toFinsupp)⟩
 
 noncomputable instance instAlgebra : Algebra R (ConnesKreimer R T) where
   algebraMap :=
@@ -189,9 +223,6 @@ noncomputable instance instAlgebra : Algebra R (ConnesKreimer R T) where
 noncomputable instance instFunLike : FunLike (ConnesKreimer R T) (Forest T) R where
   coe p := (p.toFinsupp : Forest T →₀ R)
   coe_injective := fun _ _ h => ext (DFunLike.coe_injective (F := Forest T →₀ R) h)
-
-@[simp] theorem coe_apply (p : ConnesKreimer R T) (F : Forest T) :
-    p F = p.toFinsupp F := rfl
 
 /-! ### Global ring instance (the diamond killer)
 
@@ -298,6 +329,55 @@ theorem toFinsupp_of' (F : Forest T) :
 
 @[simp] theorem of'_singleton (t : T) :
     (of' (R := R) ({t} : Forest T) : ConnesKreimer R T) = ofTree t := rfl
+
+/-! ### Coefficients
+
+`coeff` is the simp-normal spelling of coefficient extraction
+(`Polynomial.coeff` analogue); the `FunLike` application `p F` reduces to it. -/
+
+/-- The coefficient of the forest `F`. -/
+noncomputable def coeff (p : ConnesKreimer R T) (F : Forest T) : R := p.toFinsupp F
+
+@[simp] theorem coe_apply (p : ConnesKreimer R T) (F : Forest T) :
+    p F = p.coeff F := rfl
+
+theorem coeff_def (p : ConnesKreimer R T) (F : Forest T) :
+    p.coeff F = p.toFinsupp F := rfl
+
+@[simp] theorem coeff_zero (F : Forest T) : (0 : ConnesKreimer R T).coeff F = 0 := rfl
+
+@[simp] theorem coeff_add (p q : ConnesKreimer R T) (F : Forest T) :
+    (p + q).coeff F = p.coeff F + q.coeff F :=
+  Finsupp.add_apply p.toFinsupp q.toFinsupp F
+
+@[simp] theorem coeff_smul {S : Type*} [SMulZeroClass S R] (s : S)
+    (p : ConnesKreimer R T) (F : Forest T) :
+    (s • p).coeff F = s • p.coeff F :=
+  Finsupp.smul_apply s p.toFinsupp F
+
+theorem coeff_single (F G : Forest T) (r : R) [Decidable (F = G)] :
+    (single F r).coeff G = if F = G then r else 0 := by
+  rw [coeff_def, toFinsupp_single, Finsupp.single_apply]
+
+@[simp] theorem coeff_single_same (F : Forest T) (r : R) :
+    (single F r).coeff F = r := Finsupp.single_eq_same
+
+theorem coeff_of' (F G : Forest T) [Decidable (F = G)] :
+    (of' (R := R) F).coeff G = if F = G then 1 else 0 := coeff_single F G 1
+
+/-- Elements agreeing coefficientwise are equal. -/
+theorem ext_coeff {p q : ConnesKreimer R T} (h : ∀ F, p.coeff F = q.coeff F) : p = q :=
+  ext (Finsupp.ext h)
+
+/-- `coeff` bundled as a linear functional (`Polynomial.lcoeff` analogue). -/
+noncomputable def lcoeff (F : Forest T) : ConnesKreimer R T →ₗ[R] R where
+  toFun p := p.coeff F
+  map_add' p q := coeff_add p q F
+  map_smul' s p := coeff_smul s p F
+
+@[simp] theorem lcoeff_apply (F : Forest T) (p : ConnesKreimer R T) :
+    lcoeff F p = p.coeff F := rfl
+
 
 /-! ## §4: `lift`, `algHom_ext`, `addHom_ext` — the self-contained hom API
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -3,9 +3,10 @@ import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 
 set_option autoImplicit false
--- The structure-wrapped `ConnesKreimer` needs one extra pending step when
--- synthesizing instances on nested tensor squares `CK ⊗ (CK ⊗ CK)` (the
--- def-synonym's fall-through to `AddMonoidAlgebra` instances is gone).
+-- Nested tensor squares `CK ⊗ (CK ⊗ CK)` need one extra pending step during
+-- instance synthesis: the chain `Semiring (CK ⊗ (CK ⊗ CK)) → Algebra R (CK ⊗ CK)
+-- → Semiring (CK ⊗ CK) → …` nests pending subgoals past the default limit
+-- (verified still required with the full granular instance set on the wrapper).
 set_option maxSynthPendingDepth 2
 
 /-!

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -12,9 +12,10 @@ import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 
 set_option autoImplicit false
--- The structure-wrapped `ConnesKreimer` needs one extra pending step when
--- synthesizing instances on nested tensor squares `CK ⊗ (CK ⊗ CK)` (the
--- def-synonym's fall-through to `AddMonoidAlgebra` instances is gone).
+-- Nested tensor squares `CK ⊗ (CK ⊗ CK)` need one extra pending step during
+-- instance synthesis: the chain `Semiring (CK ⊗ (CK ⊗ CK)) → Algebra R (CK ⊗ CK)
+-- → Semiring (CK ⊗ CK) → …` nests pending subgoals past the default limit
+-- (verified still required with the full granular instance set on the wrapper).
 set_option maxSynthPendingDepth 2
 
 /-!

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -180,34 +180,22 @@ theorem pairing_symm (x y : ConnesKreimer R (Nonplanar α)) :
 theorem pairing_apply_of' (x : ConnesKreimer R (Nonplanar α))
     (G : Forest (Nonplanar α)) :
     pairing (R := R) x (ConnesKreimer.of' G) =
-      x.toFinsupp G * (forestAutCard G : R) := by
+      x.coeff G * (forestAutCard G : R) := by
   refine ConnesKreimer.induction_linear x ?_ ?_ ?_
-  · rw [pairing_zero_left]
-    show (0 : R) = (0 : Forest (Nonplanar α) →₀ R) G * (forestAutCard G : R)
-    simp
+  · simp [pairing_zero_left]
   · intro x₁ x₂ ih₁ ih₂
-    rw [map_add, LinearMap.add_apply, ih₁, ih₂, ConnesKreimer.toFinsupp_add]
-    show _ = (x₁.toFinsupp + x₂.toFinsupp : Forest (Nonplanar α) →₀ R) G *
-      (forestAutCard G : R)
-    simp [add_mul]
+    rw [map_add, LinearMap.add_apply, ih₁, ih₂, ConnesKreimer.coeff_add, add_mul]
   · intro F r
     rw [show ConnesKreimer.single F r = r • ConnesKreimer.of' (R := R) F
           from ConnesKreimer.smul_single_one F r]
-    simp only [LinearMap.map_smul, LinearMap.smul_apply, pairing_of'_of']
+    simp only [LinearMap.map_smul, LinearMap.smul_apply, pairing_of'_of',
+      ConnesKreimer.coeff_smul]
     letI : DecidableEq (Forest (Nonplanar α)) := Classical.decEq _
+    rw [ConnesKreimer.coeff_of']
     by_cases h : F = G
     · subst h
-      rw [if_pos rfl, smul_eq_mul]
-      show r * (forestAutCard F : R) =
-          (r • (Finsupp.single F 1 : Forest (Nonplanar α) →₀ R)) F *
-            (forestAutCard F : R)
-      rw [Finsupp.smul_apply, Finsupp.single_eq_same]
-      ring
-    · rw [if_neg h, smul_zero]
-      show (0 : R) =
-          (r • (Finsupp.single F 1 : Forest (Nonplanar α) →₀ R)) G *
-            (forestAutCard G : R)
-      rw [Finsupp.smul_apply, Finsupp.single_apply, if_neg h, smul_zero, zero_mul]
+      simp [smul_eq_mul]
+    · simp [if_neg h]
 
 /-- **Non-degeneracy** of the pairing over `CharZero R` with no zero
     divisors. If `pairing x y = 0` for all `y`, then `x = 0`. Uses
@@ -220,9 +208,8 @@ theorem pairing_apply_of' (x : ConnesKreimer R (Nonplanar α))
 theorem pairing_nondegenerate
     [CharZero R] [NoZeroDivisors R] (x : ConnesKreimer R (Nonplanar α))
     (h : ∀ y, pairing (R := R) x y = 0) : x = 0 := by
-  refine ConnesKreimer.ext ?_
-  rw [ConnesKreimer.toFinsupp_zero]
-  refine Finsupp.ext fun G => ?_
+  refine ConnesKreimer.ext_coeff fun G => ?_
+  rw [ConnesKreimer.coeff_zero]
   have hG : pairing (R := R) x (ConnesKreimer.of' G) = 0 := h _
   rw [pairing_apply_of'] at hG
   have hauts_ne : (Nonplanar.forestAutCard G : R) ≠ 0 :=

--- a/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
@@ -340,24 +340,19 @@ variable {R : Type*} [CommRing R] [CharZero R] [NoZeroDivisors R] {α : Type*}
     Connes-Kreimer element. -/
 noncomputable def deltaSingleton (T : Nonplanar α) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
-  (Finsupp.lapply ({T} : Forest (Nonplanar α))).comp
-    (toFinsuppAlgEquiv (R := R) (T := Nonplanar α)).toLinearEquiv.toLinearMap
+  lcoeff ({T} : Forest (Nonplanar α))
 
 set_option linter.unusedSectionVars false in
 @[simp] theorem deltaSingleton_of'_self (T : Nonplanar α) :
     deltaSingleton (R := R) T (of' ({T} : Forest (Nonplanar α))) = 1 := by
-  simp only [deltaSingleton, LinearMap.comp_apply, Finsupp.lapply_apply]
-  exact Finsupp.single_eq_same
+  rw [deltaSingleton, lcoeff_apply, of', coeff_single_same]
 
 set_option linter.unusedSectionVars false in
 theorem deltaSingleton_of'_other (T : Nonplanar α)
     (F : Forest (Nonplanar α)) (hF : F ≠ {T}) :
     deltaSingleton (R := R) T (of' F) = 0 := by
   classical
-  simp only [deltaSingleton, LinearMap.comp_apply, Finsupp.lapply_apply]
-  show (Finsupp.single F (1 : R) : Forest (Nonplanar α) →₀ R) {T} = 0
-  rw [Finsupp.single_apply]
-  exact if_neg hF
+  rw [deltaSingleton, lcoeff_apply, coeff_of', if_neg hF]
 
 /-- The delta functional on a single tree is a **dual primitive** —
     i.e., it satisfies `δ_T(x * y) = δ_T(x) · ε(y) + ε(x) · δ_T(y)`.


### PR DESCRIPTION
Follow-up to #1052, completing the wrapper API:

- `coeff`/`lcoeff` (the `Polynomial.coeff`/`lcoeff` analogues) with a `coeff_zero/add/smul/single/of'` simp set and `ext_coeff`; `FunLike` application now normalizes to `coeff`. Deletes the `show`-retype shims in GrossmanLarsonPairing (`pairing_apply_of'` now states `x.coeff G * autCard`) and InsertionLieDuality (`deltaSingleton := lcoeff {T}`).
- Granular action instances mirroring `Polynomial` (`distribSMul`, `distribMulAction`, generic `Module S`, `smulCommClass`, `isScalarTower`) for shallower instance resolution.
- The two `maxSynthPendingDepth 2` pragmas remain — verified still required (the pending chain nests through the tensor product's instances, not the wrapper's); their comment now documents the exact chain.