### PR TITLE
feat(Studies/Jardine2016Tone): (43) decomposition + fused plateau (7)

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -154,6 +154,47 @@ theorem transferEquiv_runAux (B : Bimachine L R α β) (eL : L ≃ L') (eR : R �
     (B.transferEquiv eL eR).run = B.run := by
   funext xs; exact transferEquiv_runAux B eL eR B.lInit xs
 
+/-! ### Flag bimachines
+
+The recurring two-sided-trigger shape: each side's automaton is the one-bit "some symbol
+on my side satisfies `p`" flag, so `lState`/`rState` compute `List.any` and the cell sees
+exactly the two flags. Conjunctive spreads (`conjBM` in `Hierarchy.lean`) and unbounded
+tonal plateauing ([jardine-2016]) are instances. -/
+
+/-- The bimachine whose side states are "a symbol satisfying `pL`/`pR` occurred on my
+side" flags. -/
+def ofFlags (pL pR : α → Bool) (out : Bool → α → Bool → β) : Bimachine Bool Bool α β where
+  lInit := false
+  lStep l a := l || pL a
+  rInit := false
+  rStep r a := r || pR a
+  out := out
+
+@[simp] theorem ofFlags_lState (pL pR : α → Bool) (out : Bool → α → Bool → β)
+    (xs : List α) : (ofFlags pL pR out).lState xs = xs.any pL := by
+  show xs.foldl (fun l a => l || pL a) false = _
+  have key : ∀ (acc : Bool) (ys : List α),
+      ys.foldl (fun l a => l || pL a) acc = (acc || ys.any pL) := by
+    intro acc ys
+    induction ys generalizing acc with
+    | nil => simp
+    | cons y ys ih => simp [ih, Bool.or_assoc]
+  simpa using key false xs
+
+@[simp] theorem ofFlags_rState (pL pR : α → Bool) (out : Bool → α → Bool → β)
+    (xs : List α) : (ofFlags pL pR out).rState xs = xs.any pR := by
+  show xs.foldr (fun a r => r || pR a) false = _
+  induction xs <;> simp_all [Bool.or_comm]
+
+/-- Coordinate characterization of a flag bimachine: output `i` sees the input symbol and
+the two window-`any` flags. -/
+theorem ofFlags_run_getElem? (pL pR : α → Bool) (out : Bool → α → Bool → β)
+    (x : List α) (i : ℕ) :
+    ((ofFlags pL pR out).run x)[i]?
+      = (x[i]?).map fun a => out ((x.take i).any pL) a ((x.drop (i + 1)).any pR) := by
+  simp only [run_getElem?, ofFlags_lState, ofFlags_rState]
+  rfl
+
 end Bimachine
 
 /-! ### Weak determinism -/
@@ -222,6 +263,20 @@ def RequiresBothSides (f : List α → List α) : Prop :=
       uL[i]? = base[i]? ∧ (f uL)[i]? = uL[i]?) ∧
     (∃ uR : List α, uR.length = base.length ∧ AgreeUpto base uR (i + d) ∧
       uR[i]? = base[i]? ∧ (f uR)[i]? = uR[i]?)
+
+omit [DecidableEq α] in
+/-- Requiring both sides is the *conjunctive* strengthening of unbounded circumambience:
+the target is changed on the base, and each far perturbation *reverts* it — in particular
+each perturbation flips the output, which is all circumambience asks. The converse fails
+(a two-sided union is circumambient but reverts under neither side alone). -/
+theorem RequiresBothSides.isUnboundedCircumambient {f : List α → List α}
+    (hf : RequiresBothSides f) : IsUnboundedCircumambient f := by
+  intro d
+  obtain ⟨base, i, hi, hchange, ⟨uL, hLlen, hLag, hLsym, hLrev⟩,
+    ⟨uR, hRlen, hRag, hRsym, hRrev⟩⟩ := hf d
+  exact ⟨base, i, hi,
+    ⟨uL, hLlen, hLag, fun h => hchange (h.trans (hLrev.trans hLsym))⟩,
+    ⟨uR, hRlen, hRag, fun h => hchange (h.trans (hRrev.trans hRsym))⟩⟩
 
 /-- **Unbounded interaction ⟹ not weakly deterministic.** At the witness, the base changes
 but each far perturbation reverts: the right perturbation keeps the left state, forcing `ωL`

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -41,6 +41,40 @@ trivial, so its cell output is a *one-sided* rule — non-interacting.
 
 namespace Subregular
 
+/-! ### Synchronous ⊆ block subsequential
+
+A `Mealy` machine is an `SFST` emitting singleton blocks with an empty final flush, so
+the synchronous class embeds in the block class scanning the same direction. -/
+
+section MealyBlock
+
+variable {σ α β : Type*}
+
+/-- View a synchronous transducer as a block `SFST`: singleton outputs, empty flush. -/
+def Mealy.toSFST (T : Mealy σ α β) : SFST α β σ where
+  start := T.initial
+  step s x := ((T.step s x).1, [(T.step s x).2])
+  finalOutput _ := []
+
+@[simp] theorem Mealy.toSFST_run (T : Mealy σ α β) : T.toSFST.run = T.run := by
+  suffices h : ∀ (s : σ) (xs : List α), T.toSFST.runFrom s xs = T.runFrom s xs from
+    funext fun xs => h T.initial xs
+  intro s xs
+  induction xs generalizing s with
+  | nil => rfl
+  | cons x xs ih =>
+    rw [SFST.runFrom_cons, Mealy.runFrom_cons,
+      show T.toSFST.step s x = ((T.step s x).1, [(T.step s x).2]) from rfl, ih]
+    rfl
+
+/-- **Synchronous ⊆ block**: a letter-left-subsequential function is left-subsequential. -/
+theorem IsLetterLeftSubsequential.isLeftSubsequential {f : List α → List β}
+    (hf : IsLetterLeftSubsequential f) : IsLeftSubsequential f := by
+  obtain ⟨σ, _, T, rfl⟩ := hf
+  exact T.toSFST_run ▸ T.toSFST.isLeftSubsequential
+
+end MealyBlock
+
 variable {α : Type*} [DecidableEq α]
 
 private theorem unite_default_right (cL a : α) : unite cL a a = cL := by
@@ -96,29 +130,11 @@ inductive ConjSym | trig | tgt | raised
 
 instance : Fintype ConjSym := ⟨{.trig, .tgt, .raised}, fun x => by cases x <;> simp⟩
 
-/-- A target raises iff a trigger occurs on **both** sides — left/right states track a
-trigger seen on each side, and the cell genuinely needs both (`l && r`). -/
-def conjBM : Bimachine Bool Bool ConjSym ConjSym where
-  lInit := false
-  lStep l s := l || (s == .trig)
-  rInit := false
-  rStep r s := r || (s == .trig)
-  out l s r := if (l && r) && s == .tgt then .raised else s
-
-private theorem conjBM_lState (xs : List ConjSym) :
-    conjBM.lState xs = xs.any (· == .trig) := by
-  show xs.foldl (fun l s => l || (s == .trig)) false = _
-  have key : ∀ (acc : Bool) (ys : List ConjSym),
-      ys.foldl (fun l s => l || (s == .trig)) acc = (acc || ys.any (· == .trig)) := by
-    intro acc ys; induction ys generalizing acc with
-    | nil => simp
-    | cons y ys ih => simp [ih, Bool.or_assoc]
-  simpa using key false xs
-
-private theorem conjBM_rState (xs : List ConjSym) :
-    conjBM.rState xs = xs.any (· == .trig) := by
-  show xs.foldr (fun s r => r || (s == .trig)) false = _
-  induction xs <;> simp_all [Bool.or_comm]
+/-- A target raises iff a trigger occurs on **both** sides — a flag bimachine
+(`Bimachine.ofFlags`) tracking a trigger on each side, whose cell genuinely needs both
+flags (`l && r`). -/
+def conjBM : Bimachine Bool Bool ConjSym ConjSym :=
+  .ofFlags (· == .trig) (· == .trig) fun l s r => if (l && r) && s == .tgt then .raised else s
 
 /-- Output of `conjBM` at a `.tgt` position: `.raised` iff a trigger appears on both the
 left prefix and the right suffix, else `.tgt`. -/
@@ -126,7 +142,7 @@ private theorem conjBM_run_at {w : List ConjSym} {i : ℕ} (h : w[i]? = some .tg
     (conjBM.run w)[i]?
       = some (if (w.take i).any (· == .trig) && (w.drop (i + 1)).any (· == .trig)
           then .raised else .tgt) := by
-  rw [conjBM.run_getElem?, h, conjBM_lState, conjBM_rState]; simp [conjBM]
+  rw [conjBM, Bimachine.ofFlags_run_getElem?, h]; simp
 
 /-- Witness word at distance `d`: a medial `.tgt` flanked by `d` neutral fillers and a
 `.trig` on each end. The two perturbations replace one end's `.trig` with a filler. -/

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -333,6 +333,26 @@ theorem IsLeftSubsequential.bounded_delay {f : List α → List β}
       T.runFrom_append T.start u v,
       Finset.le_sup (f := fun s => (T.finalOutput s).length) (Finset.mem_univ _)⟩⟩
 
+/-- **Divergence criterion**: `f` is not left-subsequential if, for every candidate delay
+bound `N`, some input `u` and continuation `v` have images disagreeing at a position more
+than `N` symbols above the end of `f u` — inside the prefix a bounded-delay machine must
+already have emitted. The working form of `bounded_delay` for impossibility proofs
+(unbounded tonal plateauing [jardine-2016], sour-grapes harmony [heinz-lai-2013]). -/
+theorem not_isLeftSubsequential_of_diverging {f : List α → List β}
+    (h : ∀ N, ∃ (u v : List α) (i : ℕ),
+      i + N < (f u).length ∧ (f u)[i]? ≠ (f (u ++ v))[i]?) :
+    ¬ IsLeftSubsequential f := by
+  intro hf
+  obtain ⟨N, hN⟩ := hf.bounded_delay
+  obtain ⟨u, v, i, hi, hne⟩ := h N
+  obtain ⟨p, su, sv, hu, huv, hsu⟩ := hN u v
+  have hip : i < p.length := by
+    have := congrArg List.length hu
+    rw [List.length_append] at this
+    omega
+  rw [hu, huv, List.getElem?_append_left hip, List.getElem?_append_left hip] at hne
+  exact hne rfl
+
 /-- Subsequential functions are closed under composition ([mohri-1997],
 originally Schützenberger and Choffrut) — the load-bearing fact that makes
 the weakly-deterministic class (composition of two subsequential functions

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -99,6 +99,15 @@ theorem runIdx_lt_collapse_length (xs : List α) {k : ℕ} (hk : k < xs.length) 
     exact hne h
   omega
 
+/-- On a constant tier every position lies in the single run: `runIdx` is `0`. -/
+@[simp] theorem runIdx_replicate (n : ℕ) (a : α) (k : ℕ) :
+    runIdx (List.replicate n a) k = 0 := by
+  unfold runIdx
+  rw [List.take_replicate]
+  cases hm : min (k + 1) n with
+  | zero => simp
+  | succ m => rw [collapse_replicate, List.length_singleton]
+
 /-! ### Run-index and concatenation
 
 The defining property of `concat` for the OCP quotient: `runIdx` commutes with the

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -91,4 +91,144 @@ theorem realize_lower_toList (g₀ : S → AR α β) (w : List S) :
       map_mul, lowerProj_of]
     rfl
 
+/-! ### Linearization: the association-state string of an AR
+
+The inverse direction of the bridge. Where `realize` builds an AR from a string,
+`linearize` reads the **association-state string** off an AR: per timing-tier position,
+its label together with the labels of the melody nodes linked to it, in tier order. This
+is the linearisation phonologists use implicitly when writing a tonal input as a string of
+TBU symbols — [jardine-2016] §4.4: each string symbol records one timing unit's
+associations, so transducer look-ahead is measured on the timing tier. Like `realize`, it
+is a monoid homomorphism into `(List, ++)` (`AR.linearize_concat`), so the linearization
+of a realization is the concatenation of the per-symbol association profiles
+(`linearize_realize`). -/
+
+/-- The labels of the upper (melody) nodes linked to lower position `j`, in tier order. -/
+def Graph.linkedLabels (A : Graph α β) (j : ℕ) : List α :=
+  ((List.range A.upper.len).filter fun i => decide ((i, j) ∈ A.links)).filterMap A.upper.get?
+
+/-- Left half of the linearization hom law: positions inside `A` see only `A`'s links
+(the shifted `B` links live entirely to the right; stray out-of-bounds `A` uppers are
+excluded by `hA`). -/
+theorem Graph.linkedLabels_concat_left {A B : Graph α β} (hA : A.InBounds) {j : ℕ}
+    (hj : j < A.lower.len) :
+    (A.concat B).linkedLabels j = A.linkedLabels j := by
+  unfold Graph.linkedLabels
+  rw [Graph.upper_concat, LabeledTuple.concat_len, List.range_add, List.filter_append,
+    List.filterMap_append]
+  have h₂ : ((List.range B.upper.len).map (A.upper.len + ·)).filter
+      (fun i => decide ((i, j) ∈ (A.concat B).links)) = [] := by
+    rw [List.filter_eq_nil_iff]
+    rintro i hi
+    simp only [List.mem_map, List.mem_range] at hi
+    obtain ⟨i', -, rfl⟩ := hi
+    simp only [Graph.links_concat, Finset.mem_union, Finset.mem_image, shiftLink_apply,
+      Prod.mk.injEq, decide_eq_true_eq, not_or, not_exists]
+    constructor
+    · intro hmem
+      exact absurd (hA _ hmem).1 (by omega)
+    · rintro ⟨p1, p2⟩ ⟨hp, h1, h2⟩
+      omega
+  have h₁ : (List.range A.upper.len).filter (fun i => decide ((i, j) ∈ (A.concat B).links))
+      = (List.range A.upper.len).filter (fun i => decide ((i, j) ∈ A.links)) := by
+    refine List.filter_congr fun i hi => ?_
+    simp only [List.mem_range] at hi
+    simp only [decide_eq_decide, Graph.links_concat, Finset.mem_union, Finset.mem_image,
+      shiftLink_apply, Prod.mk.injEq]
+    constructor
+    · rintro (h | ⟨p, hp, h1, h2⟩)
+      · exact h
+      · omega
+    · exact Or.inl
+  rw [h₁, h₂, List.filterMap_nil, List.append_nil]
+  exact List.filterMap_congr fun i hi => by
+    have hilt : i < A.upper.len := by
+      simp only [List.mem_filter, List.mem_range] at hi
+      exact hi.1
+    exact LabeledTuple.get?_concat_left hilt
+
+/-- Right half of the linearization hom law: positions past `A` see exactly `B`'s links,
+shifted. -/
+theorem Graph.linkedLabels_concat_right {A B : Graph α β} (hA : A.InBounds) {j : ℕ}
+    (hj : A.lower.len ≤ j) :
+    (A.concat B).linkedLabels j = B.linkedLabels (j - A.lower.len) := by
+  unfold Graph.linkedLabels
+  rw [Graph.upper_concat, LabeledTuple.concat_len, List.range_add, List.filter_append,
+    List.filterMap_append]
+  have h₁ : (List.range A.upper.len).filter
+      (fun i => decide ((i, j) ∈ (A.concat B).links)) = [] := by
+    rw [List.filter_eq_nil_iff]
+    rintro i hi
+    simp only [List.mem_range] at hi
+    simp only [Graph.links_concat, Finset.mem_union, Finset.mem_image, shiftLink_apply,
+      Prod.mk.injEq, decide_eq_true_eq, not_or, not_exists]
+    constructor
+    · intro hmem
+      exact absurd (hA _ hmem).2 (by omega)
+    · rintro ⟨p1, p2⟩ ⟨hp, h1, h2⟩
+      omega
+  rw [h₁, List.filterMap_nil, List.nil_append, List.filter_map, List.filterMap_map]
+  have h₂ : (List.range B.upper.len).filter
+      ((fun i => decide ((i, j) ∈ (A.concat B).links)) ∘ (A.upper.len + ·))
+      = (List.range B.upper.len).filter
+          (fun i => decide ((i, j - A.lower.len) ∈ B.links)) := by
+    refine List.filter_congr fun i hi => ?_
+    simp only [Function.comp_apply, decide_eq_decide, Graph.links_concat, Finset.mem_union,
+      Finset.mem_image, shiftLink_apply, Prod.mk.injEq]
+    constructor
+    · rintro (h | ⟨⟨p1, p2⟩, hp, h1, h2⟩)
+      · exact absurd (hA _ h).1 (by omega)
+      · obtain rfl : p1 = i := by omega
+        obtain rfl : p2 = j - A.lower.len := by omega
+        exact hp
+    · intro h
+      exact Or.inr ⟨(i, j - A.lower.len), h, by omega, by omega⟩
+  rw [h₂]
+  exact List.filterMap_congr fun i hi => by
+    rw [Function.comp_apply]
+    exact LabeledTuple.get?_concat_right A.upper B.upper i
+
+/-- **Linearize** an AR into its association-state string ([jardine-2016] (40)): position
+`j` carries the timing-unit label and the linked melody labels. -/
+def AR.linearize (A : AR α β) : List (β × List α) :=
+  A.lower.toList.mapIdx fun j b => (b, A.toGraph.linkedLabels j)
+
+@[simp] theorem AR.linearize_length (A : AR α β) : A.linearize.length = A.lower.len := by
+  simp [AR.linearize]
+
+theorem AR.linearize_getElem? (A : AR α β) (j : ℕ) :
+    A.linearize[j]? = (A.lower.get? j).map fun b => (b, A.toGraph.linkedLabels j) := by
+  simp [AR.linearize, List.getElem?_mapIdx, LabeledTuple.get?_eq_getElem?]
+
+@[simp] theorem AR.linearize_empty : (AR.empty : AR α β).linearize = [] := by
+  have h : (AR.empty : AR α β).lower.toList = [] :=
+    List.eq_nil_of_length_eq_zero (by simp [AR.empty, Graph.empty])
+  simp [AR.linearize, h]
+
+/-- **The linearization is a monoid homomorphism**: it sends concatenation of ARs to
+concatenation of association-state strings (in-bounds is what keeps each side's links on
+its own positions). -/
+theorem AR.linearize_concat (A B : AR α β) :
+    (A.concat B).linearize = A.linearize ++ B.linearize := by
+  refine List.ext_getElem? fun j => ?_
+  rw [AR.linearize_getElem?]
+  rcases Nat.lt_or_ge j A.lower.len with hj | hj
+  · rw [List.getElem?_append_left (by rw [AR.linearize_length]; exact hj),
+      AR.linearize_getElem?, AR.concat_lower, LabeledTuple.get?_concat_left hj,
+      AR.concat_toGraph, Graph.linkedLabels_concat_left A.inBounds hj]
+  · rw [List.getElem?_append_right (by rw [AR.linearize_length]; exact hj),
+      AR.linearize_getElem?, AR.linearize_length, AR.concat_lower, AR.concat_toGraph,
+      Graph.linkedLabels_concat_right A.inBounds hj,
+      show j = A.lower.len + (j - A.lower.len) from by omega,
+      LabeledTuple.get?_concat_right, Nat.add_sub_cancel_left]
+
+/-- **Linearizing a realization** yields the concatenation of the per-symbol association
+profiles — the general form of [jardine-2016]'s (40) translation between strings and
+autosegmental representations. -/
+theorem linearize_realize (g₀ : S → AR α β) (w : List S) :
+    (realize g₀ w).linearize = w.flatMap fun a => (g₀ a).linearize := by
+  induction w with
+  | nil => simp
+  | cons a w ih => rw [realize_cons, AR.linearize_concat, ih, List.flatMap_cons]
+
 end Autosegmental

--- a/Linglib/Phonology/OCP.lean
+++ b/Linglib/Phonology/OCP.lean
@@ -87,6 +87,16 @@ theorem collapse_eq_destutter (xs : List α) : collapse xs = xs.destutter (· �
 
 @[simp] theorem collapse_singleton (x : α) : collapse [x] = [x] := by simp [collapse]
 
+/-- `collapse` fuses a constant run into its single autosegment. -/
+@[simp] theorem collapse_replicate (n : ℕ) (a : α) :
+    collapse (List.replicate (n + 1) a) = [a] := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [List.replicate_succ, List.replicate_succ, collapse_eq_destutter,
+      List.destutter_cons_cons, if_neg (fun h => h rfl), ← List.destutter_cons',
+      ← List.replicate_succ, ← collapse_eq_destutter, ih]
+
 /-- `collapse` lands in the OCP-clean set. -/
 theorem collapse_clean (xs : List α) : IsClean (collapse xs) :=
   List.isChain_destutter _ xs

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -5,7 +5,11 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
 import Linglib.Core.Computability.Subregular.Function.Bimachine
+import Linglib.Core.Computability.Subregular.Function.Hierarchy
+import Linglib.Phonology.Autosegmental.Realization
+import Linglib.Phonology.Tone.Basic
 
 /-!
 # Jardine (2016): Computationally, tone is different
@@ -44,6 +48,14 @@ This file formalizes the paper's formal skeleton over its string-based represent
   (`IsBimachineWeaklyDeterministic`, `Core/Computability/Subregular/Function/Bimachine`),
   and under it the claim is a theorem: UTP `RequiresBothSides` — perturbing either far
   trigger reverts the target — which no union of one-sided rules can express.
+* `utp_markup_decomposition` — the paper's (43): over the alphabet enlarged with the mark
+  `?`, UTP *is* a right-subsequential map after a left-subsequential map. Weak
+  determinism forbids exactly this enlargement, so (43) and the impossibility theorem
+  together locate UTP precisely.
+* `readTBU_linearize_realize` — §4.4's defense of the string-based representation, via
+  the substrate's `Autosegmental.AR.linearize`: the (40) translation `toAR` realizes a
+  TBU string as an autosegmental representation whose association-state string *is* the
+  input ((37a)), so string-measured look-ahead is timing-tier look-ahead ((37b)).
 * `utp_fullyRegular` — the paper's thesis (§7) in one statement: UTP is *fully regular*,
   i.e. regular but neither subsequential in either direction nor weakly deterministic.
   Tone thereby exceeds the complexity bound that segmental phonology respects.
@@ -92,8 +104,8 @@ theorem utp_getElem? (w : List TBU) (i : ℕ) :
     (utp w)[i]? = w[i]?.map fun _ => if SurfacesH w i then TBU.H else TBU.O := by
   simp [utp, List.getElem?_mapIdx]
 
-private theorem H_mem_take_iff {w : List TBU} {k : ℕ} :
-    TBU.H ∈ w.take k ↔ ∃ j < k, w[j]? = some .H := by
+private theorem mem_take_iff {α : Type*} {a : α} {w : List α} {k : ℕ} :
+    a ∈ w.take k ↔ ∃ j < k, w[j]? = some a := by
   rw [List.mem_iff_getElem?]
   constructor
   · rintro ⟨j, hj⟩
@@ -105,8 +117,8 @@ private theorem H_mem_take_iff {w : List TBU} {k : ℕ} :
   · rintro ⟨j, hjk, hj⟩
     exact ⟨j, by rwa [List.getElem?_take_of_lt hjk]⟩
 
-private theorem H_mem_drop_iff {w : List TBU} {k : ℕ} :
-    TBU.H ∈ w.drop k ↔ ∃ j, k ≤ j ∧ w[j]? = some .H := by
+private theorem mem_drop_iff {α : Type*} {a : α} {w : List α} {k : ℕ} :
+    a ∈ w.drop k ↔ ∃ j, k ≤ j ∧ w[j]? = some a := by
   rw [List.mem_iff_getElem?]
   constructor
   · rintro ⟨t, ht⟩
@@ -117,8 +129,34 @@ private theorem H_mem_drop_iff {w : List TBU} {k : ℕ} :
 /-- Positionwise reading of `SurfacesH`: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
 theorem surfacesH_iff {w : List TBU} {i : ℕ} :
     SurfacesH w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j, i ≤ j ∧ w[j]? = some .H := by
-  rw [SurfacesH, H_mem_take_iff, H_mem_drop_iff]
+  rw [SurfacesH, mem_take_iff, mem_drop_iff]
   simp [Nat.lt_succ_iff]
+
+/-- Splitting off the position itself: given the symbol at `i`, TBU `i` surfaces H iff it
+is itself a H or is strictly flanked. -/
+private theorem surfacesH_split {w : List TBU} {i : ℕ} {a : TBU} (h : w[i]? = some a) :
+    SurfacesH w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
+  rw [surfacesH_iff]
+  constructor
+  · rintro ⟨⟨j₁, hj₁, h₁⟩, ⟨j₂, hj₂, h₂⟩⟩
+    by_cases ha : a = TBU.H
+    · exact Or.inl ha
+    · refine Or.inr ⟨mem_take_iff.mpr ⟨j₁, ?_, h₁⟩, mem_drop_iff.mpr ⟨j₂, ?_, h₂⟩⟩
+      · rcases Nat.lt_or_ge j₁ i with hlt | hge
+        · exact hlt
+        · obtain rfl : j₁ = i := by omega
+          rw [h] at h₁
+          exact absurd (Option.some.inj h₁) ha
+      · rcases Nat.lt_or_ge i j₂ with hlt | hge
+        · omega
+        · obtain rfl : j₂ = i := by omega
+          rw [h] at h₂
+          exact absurd (Option.some.inj h₂) ha
+  · rintro (rfl | ⟨h₁, h₂⟩)
+    · exact ⟨⟨i, le_rfl, h⟩, ⟨i, le_rfl, h⟩⟩
+    · obtain ⟨j₁, hj₁, hh₁⟩ := mem_take_iff.mp h₁
+      obtain ⟨j₂, hj₂, hh₂⟩ := mem_drop_iff.mp h₂
+      exact ⟨⟨j₁, by omega, hh₁⟩, ⟨j₂, by omega, hh₂⟩⟩
 
 /-! ### The rule set (36)
 
@@ -287,67 +325,24 @@ the substrate: UTP is computed by a **bimachine** — one deterministic pass per
 each tracking "H seen on my side", conjoined at the cell. Regularity is thus witnessed
 without nondeterminism; what fails (below) is *one-directional* determinism. -/
 
-/-- The UTP bimachine: each side's automaton records whether a H occurs on that side, and
-a toneless cell surfaces H exactly when both flags are set. -/
-def utpBM : Bimachine Bool Bool TBU TBU where
-  lInit := false
-  lStep l a := l || (a == .H)
-  rInit := false
-  rStep r a := r || (a == .H)
-  out l a r := if a == .H || (l && r) then .H else .O
-
-private theorem utpBM_lState (xs : List TBU) : utpBM.lState xs = xs.any (· == .H) := by
-  show xs.foldl (fun l a => l || (a == .H)) false = _
-  have key : ∀ (acc : Bool) (ys : List TBU),
-      ys.foldl (fun l a => l || (a == .H)) acc = (acc || ys.any (· == .H)) := by
-    intro acc ys
-    induction ys generalizing acc with
-    | nil => simp
-    | cons y ys ih => simp [ih, Bool.or_assoc]
-  simpa using key false xs
-
-private theorem utpBM_rState (xs : List TBU) : utpBM.rState xs = xs.any (· == .H) := by
-  show xs.foldr (fun a r => r || (a == .H)) false = _
-  induction xs <;> simp_all [Bool.or_comm]
+/-- The UTP bimachine: a flag bimachine (`Bimachine.ofFlags`) whose sides record whether
+a H occurs on that side; a toneless cell surfaces H exactly when both flags are set. -/
+def utpBM : Bimachine Bool Bool TBU TBU :=
+  .ofFlags (· == .H) (· == .H) fun l a r => if a == .H || (l && r) then .H else .O
 
 /-- The bimachine computes UTP. -/
 theorem utpBM_run : utpBM.run = utp := by
   funext w
   refine List.ext_getElem? fun i => ?_
-  rw [Bimachine.run_getElem?, utp_getElem?]
+  rw [utpBM, Bimachine.ofFlags_run_getElem?, utp_getElem?]
   cases h : w[i]? with
   | none => rfl
   | some a =>
     simp only [Option.map_some]
     congr 1
-    show (if a == .H || (utpBM.lState (w.take i) && utpBM.rState (w.drop (i + 1)))
-        then TBU.H else TBU.O) = _
-    rw [utpBM_lState, utpBM_rState]
-    have hsplit : SurfacesH w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
-      rw [surfacesH_iff]
-      constructor
-      · rintro ⟨⟨j₁, hj₁, h₁⟩, ⟨j₂, hj₂, h₂⟩⟩
-        by_cases ha : a = TBU.H
-        · exact Or.inl ha
-        · refine Or.inr ⟨H_mem_take_iff.mpr ⟨j₁, ?_, h₁⟩, H_mem_drop_iff.mpr ⟨j₂, ?_, h₂⟩⟩
-          · rcases Nat.lt_or_ge j₁ i with hlt | hge
-            · exact hlt
-            · obtain rfl : j₁ = i := by omega
-              rw [h] at h₁
-              exact absurd (Option.some.inj h₁) ha
-          · rcases Nat.lt_or_ge i j₂ with hlt | hge
-            · omega
-            · obtain rfl : j₂ = i := by omega
-              rw [h] at h₂
-              exact absurd (Option.some.inj h₂) ha
-      · rintro (rfl | ⟨h₁, h₂⟩)
-        · exact ⟨⟨i, le_rfl, h⟩, ⟨i, le_rfl, h⟩⟩
-        · obtain ⟨j₁, hj₁, hh₁⟩ := H_mem_take_iff.mp h₁
-          obtain ⟨j₂, hj₂, hh₂⟩ := H_mem_drop_iff.mp h₂
-          exact ⟨⟨j₁, by omega, hh₁⟩, ⟨j₂, by omega, hh₂⟩⟩
     have hb : (a == TBU.H || ((w.take i).any (· == .H) && (w.drop (i + 1)).any (· == .H)))
         = true ↔ SurfacesH w i := by
-      rw [hsplit]
+      rw [surfacesH_split h]
       simp [List.any_eq_true]
     by_cases hs : SurfacesH w i
     · rw [if_pos (hb.mpr hs), if_pos hs]
@@ -433,19 +428,25 @@ private theorem utp_right_perturbed (d : ℕ) :
     · omega
     · exact hj0 rfl
 
+/-- UTP requires both sides ([heinz-lai-2013]'s interaction structure): the plateau
+target changes, yet deleting *either* flanking H reverts it to the identity. -/
+theorem utp_requiresBothSides : RequiresBothSides utp := by
+  intro d
+  refine ⟨plateauBase d, d + 1, by simp only [plateauBase_length]; omega, ?_, ?_, ?_⟩
+  · rw [utp_plateauBase_mid, plateauBase_getElem?_mid]
+    simp
+  · refine ⟨(plateauBase d).set 0 .O, by simp,
+      fun k hk => (List.getElem?_set_ne (by omega)).symm, List.getElem?_set_ne (by omega), ?_⟩
+    rw [utp_left_perturbed, List.getElem?_set_ne (by omega), plateauBase_getElem?_mid]
+  · refine ⟨(plateauBase d).set (2 * d + 3) .O, by simp,
+      fun k hk => (List.getElem?_set_ne (by omega)).symm, List.getElem?_set_ne (by omega), ?_⟩
+    rw [utp_right_perturbed, List.getElem?_set_ne (by omega), plateauBase_getElem?_mid]
+
 /-- **UTP is an unbounded circumambient process** — [jardine-2016]'s definition (2): for
 every distance `d`, some plateau target flips under a far-left and a far-right
-perturbation. -/
-theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp := by
-  intro d
-  refine ⟨plateauBase d, d + 1, by simp only [plateauBase_length]; omega, ?_, ?_⟩
-  · refine ⟨(plateauBase d).set 0 .O, by simp, fun k hk => (List.getElem?_set_ne (by omega)).symm, ?_⟩
-    rw [utp_plateauBase_mid, utp_left_perturbed]
-    simp
-  · refine ⟨(plateauBase d).set (2 * d + 3) .O, by simp,
-      fun k hk => (List.getElem?_set_ne (by omega)).symm, ?_⟩
-    rw [utp_plateauBase_mid, utp_right_perturbed]
-    simp
+perturbation. Derived: requiring both sides is the conjunctive strengthening. -/
+theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp :=
+  utp_requiresBothSides.isUnboundedCircumambient
 
 /-! ### UTP is not subsequential
 
@@ -454,36 +455,29 @@ is the bounded-delay one: a left machine reading `H Øⁿ` has emitted at most t
 prefix of `utp (H Øⁿ) = H Øⁿ` and `utp (H Øⁿ H) = H^(n+2)` — a single symbol — so its
 final output must carry the withheld `n` symbols, exceeding any finite-state bound. -/
 
-/-- **UTP is not left-subsequential** ([jardine-2016] §4.2, appendix). -/
+/-- **UTP is not left-subsequential** ([jardine-2016] §4.2, appendix). At every delay
+bound `N`, the images of `H Ø^(N+1)` and `H Ø^(N+1) H` disagree already at position 1. -/
 theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp := by
-  intro hf
-  obtain ⟨N, hN⟩ := hf.bounded_delay
-  obtain ⟨p, su, sv, hu, huv, hlen⟩ := hN (.H :: List.replicate (N + 1) .O) [.H]
-  -- image of `H Ø^(N+1)`: itself, by (36b)
-  rw [show (TBU.H :: List.replicate (N + 1) TBU.O)
-        = List.replicate 0 TBU.O ++ TBU.H :: List.replicate (N + 1) TBU.O by simp,
-    utp_single] at hu
-  -- image of `H Ø^(N+1) H`: a total plateau, by (36c)
-  rw [show (TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]
-        = List.replicate 0 TBU.O ++ TBU.H :: (List.replicate (N + 1) TBU.O
-            ++ TBU.H :: List.replicate 0 TBU.O) by simp,
-    utp_plateau] at huv
-  simp only [List.nil_append, List.replicate_zero, List.append_nil, List.length_replicate] at hu huv
-  -- the shared prefix `p` must reach position 1, where the two images disagree
-  have hp2 : 2 ≤ p.length := by
-    have := congrArg List.length hu
-    simp at this
+  refine not_isLeftSubsequential_of_diverging fun N =>
+    ⟨.H :: List.replicate (N + 1) .O, [.H], 1, ?_, ?_⟩
+  · simp only [utp_length, List.length_cons, List.length_replicate]
     omega
-  have h1u : p[1]? = some TBU.O := by
-    have h := List.getElem?_append_left (l₁ := p) (l₂ := su) (by omega : 1 < p.length)
-    rw [← hu, List.getElem?_cons_succ, List.getElem?_replicate, if_pos (by omega)] at h
-    exact h.symm
-  have h1v : p[1]? = some TBU.H := by
-    have h := List.getElem?_append_left (l₁ := p) (l₂ := sv) (by omega : 1 < p.length)
-    rw [← huv, List.getElem?_replicate, if_pos (by omega)] at h
-    exact h.symm
-  rw [h1u] at h1v
-  exact TBU.noConfusion (Option.some.inj h1v)
+  · -- image of `H Ø^(N+1)`: itself, by (36b); of `H Ø^(N+1) H`: a total plateau, by (36c)
+    have h1 : (utp (TBU.H :: List.replicate (N + 1) TBU.O))[1]? = some TBU.O := by
+      rw [show (TBU.H :: List.replicate (N + 1) TBU.O)
+            = List.replicate 0 TBU.O ++ TBU.H :: List.replicate (N + 1) TBU.O by simp,
+        utp_single]
+      simp only [List.replicate_zero, List.nil_append]
+      rw [List.getElem?_cons_succ, List.getElem?_replicate, if_pos (by omega)]
+    have h2 : (utp ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H := by
+      rw [show (TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]
+            = List.replicate 0 TBU.O ++ TBU.H :: (List.replicate (N + 1) TBU.O
+                ++ TBU.H :: List.replicate 0 TBU.O) by simp,
+        utp_plateau]
+      simp only [List.replicate_zero, List.nil_append, List.append_nil, List.length_replicate]
+      rw [List.getElem?_replicate, if_pos (by omega)]
+    rw [h1, h2]
+    simp
 
 /-- Plateauing is symmetric under string reversal — the formal content of "the position of
 the first triggering H is just as arbitrarily far to the right as the second is to the
@@ -540,23 +534,260 @@ project-canonical non-interacting-bimachine rendering of weak determinism, the c
 theorem: UTP `RequiresBothSides`, the conjunctive-trigger structure no union of one-sided
 rules can express. -/
 
-/-- UTP requires both sides: the plateau target changes, yet deleting *either* flanking H
-reverts it to the identity. -/
-theorem utp_requiresBothSides : RequiresBothSides utp := by
-  intro d
-  refine ⟨plateauBase d, d + 1, by simp only [plateauBase_length]; omega, ?_, ?_, ?_⟩
-  · rw [utp_plateauBase_mid, plateauBase_getElem?_mid]
-    simp
-  · refine ⟨(plateauBase d).set 0 .O, by simp,
-      fun k hk => (List.getElem?_set_ne (by omega)).symm, List.getElem?_set_ne (by omega), ?_⟩
-    rw [utp_left_perturbed, List.getElem?_set_ne (by omega), plateauBase_getElem?_mid]
-  · refine ⟨(plateauBase d).set (2 * d + 3) .O, by simp,
-      fun k hk => (List.getElem?_set_ne (by omega)).symm, List.getElem?_set_ne (by omega), ?_⟩
-    rw [utp_right_perturbed, List.getElem?_set_ne (by omega), plateauBase_getElem?_mid]
-
 /-- **UTP is not weakly deterministic** ([jardine-2016] §5.2). -/
 theorem utp_not_isBimachineWeaklyDeterministic : ¬ IsBimachineWeaklyDeterministic utp :=
   not_isBimachineWeaklyDeterministic_of_requiresBothSides utp_requiresBothSides
+
+/-! ### The (43) mark-up decomposition
+
+With one extra symbol the two-pass decomposition *does* exist ([jardine-2016] (43)): a
+left pass marks every toneless TBU after a H with `?`; a right pass resolves `?` to H
+when a H follows and to Ø otherwise. The intermediate `?` carries "a H appears to the
+left" across unboundedly many TBUs — precisely the Elgot–Mezei-style mark-up that
+[heinz-lai-2013]'s weak determinism disallows. Together with
+`utp_not_isBimachineWeaklyDeterministic`, this locates UTP exactly: subsequential in
+neither direction, weakly deterministic only *with* alphabet enlargement. -/
+
+/-- The mark-up alphabet of (43): `Q` is the paper's `?`. -/
+inductive Mark
+  | H
+  | O
+  | Q
+  deriving DecidableEq, Repr
+
+/-- Left pass of (43): mark every toneless TBU after a H with `?`. -/
+def markLeft : Mealy Bool TBU Mark where
+  initial := false
+  step l a :=
+    match a with
+    | .H => (true, .H)
+    | .O => (l, if l then .Q else .O)
+
+/-- Right pass of (43), scanning right-to-left: resolve `?` to H when a H follows,
+else to Ø. -/
+def resolveRight : Mealy Bool Mark TBU where
+  initial := false
+  step r a :=
+    match a with
+    | .H => (true, .H)
+    | .O => (r, .O)
+    | .Q => (r, if r then .H else .O)
+
+/-- The right pass as a right-to-left string function: reverse, run, reverse. -/
+def resolve (x : List Mark) : List TBU := (resolveRight.run x.reverse).reverse
+
+private theorem markLeft_stateAfter (b : Bool) (pre : List TBU) :
+    markLeft.stateAfter b pre = (b || pre.any (· == .H)) := by
+  induction pre generalizing b with
+  | nil => simp
+  | cons x xs ih =>
+    rw [Mealy.stateAfter_cons]
+    cases x with
+    | H => rw [show (markLeft.step b .H).1 = true from rfl, ih]; simp
+    | O =>
+      rw [show (markLeft.step b .O).1 = b from rfl, ih]
+      simp only [List.any_cons, show (TBU.O == TBU.H) = false from rfl, Bool.false_or]
+
+private theorem resolveRight_stateAfter (b : Bool) (pre : List Mark) :
+    resolveRight.stateAfter b pre = (b || pre.any (· == .H)) := by
+  induction pre generalizing b with
+  | nil => simp
+  | cons x xs ih =>
+    rw [Mealy.stateAfter_cons]
+    cases x with
+    | H => rw [show (resolveRight.step b .H).1 = true from rfl, ih]; simp
+    | O =>
+      rw [show (resolveRight.step b .O).1 = b from rfl, ih]
+      simp only [List.any_cons, show (Mark.O == Mark.H) = false from rfl, Bool.false_or]
+    | Q =>
+      rw [show (resolveRight.step b .Q).1 = b from rfl, ih]
+      simp only [List.any_cons, show (Mark.Q == Mark.H) = false from rfl, Bool.false_or]
+
+/-- Coordinate characterization of the marking pass. -/
+private theorem markLeft_run_getElem? (w : List TBU) (i : ℕ) :
+    (markLeft.run w)[i]?
+      = w[i]?.map fun a =>
+          match a with
+          | .H => Mark.H
+          | .O => if (w.take i).any (· == .H) then Mark.Q else Mark.O := by
+  rw [show markLeft.run w = markLeft.runFrom markLeft.initial w from rfl,
+    Mealy.runFrom_getElem?]
+  cases h : w[i]? with
+  | none => rfl
+  | some a =>
+    simp only [Option.map_some]
+    congr 1
+    cases a with
+    | H => rfl
+    | O =>
+      show (if markLeft.stateAfter markLeft.initial (w.take i) = true
+          then Mark.Q else Mark.O) = _
+      rw [markLeft_stateAfter, show markLeft.initial = false from rfl]
+      simp
+
+/-- Marking neither creates nor destroys H-toned TBUs. -/
+private theorem markLeft_run_H_iff (w : List TBU) (j : ℕ) :
+    (markLeft.run w)[j]? = some Mark.H ↔ w[j]? = some TBU.H := by
+  rw [markLeft_run_getElem?]
+  cases h : w[j]? with
+  | none => simp
+  | some a =>
+    cases a with
+    | H => simp
+    | O =>
+      simp only [Option.map_some]
+      constructor
+      · intro hc
+        exfalso
+        split at hc <;> exact Mark.noConfusion (Option.some.inj hc)
+      · intro hc
+        exact absurd (Option.some.inj hc) (by simp)
+
+@[simp] private theorem markLeft_run_length (w : List TBU) :
+    (markLeft.run w).length = w.length := markLeft.run_length w
+
+/-- **The (43) decomposition computes UTP**: resolving the marked string right-to-left
+recovers the plateau. -/
+theorem utp_eq_resolve_mark (w : List TBU) : utp w = resolve (markLeft.run w) := by
+  refine List.ext_getElem? fun i => ?_
+  by_cases hi : i < w.length
+  · have hn : (markLeft.run w).reverse.length = w.length := by simp
+    rw [utp_getElem?, resolve,
+      List.getElem?_reverse (by rw [resolveRight.run_length]; simpa using hi),
+      resolveRight.run_length, hn,
+      show resolveRight.run (markLeft.run w).reverse
+        = resolveRight.runFrom resolveRight.initial (markLeft.run w).reverse from rfl,
+      Mealy.runFrom_getElem?, resolveRight_stateAfter,
+      List.getElem?_reverse (by rw [hn] at *; simp; omega)]
+    have hidx : (markLeft.run w).length - 1 - (w.length - 1 - i) = i := by
+      rw [markLeft_run_length]; omega
+    rw [hidx, markLeft_run_getElem?]
+    -- the right flag of the resolving pass = "a H-toned TBU occurs strictly after `i`"
+    have hflag : (((markLeft.run w).reverse.take (w.length - 1 - i)).any (· == Mark.H))
+        = ((w.drop (i + 1)).any (· == TBU.H)) := by
+      have htk : (markLeft.run w).reverse.take (w.length - 1 - i)
+          = ((markLeft.run w).drop (i + 1)).reverse := by
+        rw [List.take_reverse, markLeft_run_length,
+          show w.length - (w.length - 1 - i) = i + 1 from by omega]
+      rw [htk, List.any_reverse, Bool.eq_iff_iff]
+      simp only [List.any_eq_true, beq_iff_eq]
+      constructor
+      · rintro ⟨x, hx, rfl⟩
+        obtain ⟨j, hj, hxj⟩ := mem_drop_iff.mp hx
+        exact ⟨.H, mem_drop_iff.mpr ⟨j, hj, (markLeft_run_H_iff w j).mp hxj⟩, rfl⟩
+      · rintro ⟨x, hx, rfl⟩
+        obtain ⟨j, hj, hxj⟩ := mem_drop_iff.mp hx
+        exact ⟨.H, mem_drop_iff.mpr ⟨j, hj, (markLeft_run_H_iff w j).mpr hxj⟩, rfl⟩
+    rw [hflag]
+    obtain ⟨a, ha⟩ : ∃ a, w[i]? = some a := ⟨w[i], List.getElem?_eq_getElem hi⟩
+    rw [ha]
+    simp only [Option.map_some]
+    congr 1
+    have hsp := surfacesH_split ha
+    cases a with
+    | H => simp [surfacesH_iff.mpr ⟨⟨i, le_rfl, ha⟩, ⟨i, le_rfl, ha⟩⟩, resolveRight]
+    | O =>
+      by_cases hL : (w.take i).any (· == TBU.H) = true
+      · have hLm : TBU.H ∈ w.take i := by
+          simp only [List.any_eq_true, beq_iff_eq] at hL
+          obtain ⟨x, hx, rfl⟩ := hL
+          exact hx
+        by_cases hR : (w.drop (i + 1)).any (· == TBU.H) = true
+        · have hRm : TBU.H ∈ w.drop (i + 1) := by
+            simp only [List.any_eq_true, beq_iff_eq] at hR
+            obtain ⟨x, hx, rfl⟩ := hR
+            exact hx
+          simp [hsp.mpr (Or.inr ⟨hLm, hRm⟩), hL, hR, resolveRight]
+        · have hs : ¬ SurfacesH w i := fun hs => by
+            rcases hsp.mp hs with h' | ⟨-, hRm⟩
+            · exact TBU.noConfusion h'
+            · exact hR (by
+                obtain ⟨j, hj, hjH⟩ := mem_drop_iff.mp hRm
+                simp only [List.any_eq_true, beq_iff_eq]
+                exact ⟨.H, mem_drop_iff.mpr ⟨j, hj, hjH⟩, rfl⟩)
+          simp [hs, hL, hR, resolveRight]
+      · have hs : ¬ SurfacesH w i := fun hs => by
+          rcases hsp.mp hs with h' | ⟨hLm, -⟩
+          · exact TBU.noConfusion h'
+          · exact hL (by
+              obtain ⟨j, hj, hjH⟩ := mem_take_iff.mp hLm
+              simp only [List.any_eq_true, beq_iff_eq]
+              exact ⟨.H, mem_take_iff.mpr ⟨j, hj, hjH⟩, rfl⟩)
+        simp [hs, hL, resolveRight]
+  · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by
+      rw [resolve, List.length_reverse, resolveRight.run_length]
+      simp
+      omega)]
+
+/-- **The (43) mark-up decomposition** ([jardine-2016] §5.2): over the alphabet enlarged
+with `?`, UTP is a right-subsequential map after a left-subsequential map. Weak
+determinism forbids exactly this enlargement — UTP is Elgot–Mezei-decomposable but not
+weakly deterministic. -/
+theorem utp_markup_decomposition :
+    IsLeftSubsequential markLeft.run ∧ IsRightSubsequential resolve
+      ∧ utp = resolve ∘ markLeft.run := by
+  refine ⟨markLeft.isLetterLeftSubsequential.isLeftSubsequential, ?_,
+    funext utp_eq_resolve_mark⟩
+  rw [isRightSubsequential_iff_left_reverse]
+  have heq : (fun xs : List Mark => (resolve xs.reverse).reverse) = resolveRight.run := by
+    funext xs
+    rw [resolve, List.reverse_reverse, List.reverse_reverse]
+  exact heq ▸ resolveRight.isLetterLeftSubsequential.isLeftSubsequential
+
+/-! ### The autosegmental grounding ((40), §4.4)
+
+The string-based representation is not a rival of the autosegmental one but its
+linearisation: each TBU symbol records one timing unit's association state. `toAR` is
+the paper's (40) translation — a H-toned TBU is one `Tone.TRN.H` melody node linked to
+its timing unit, a toneless TBU a bare timing unit — and by the substrate hom law
+`Autosegmental.linearize_realize`, the association-state string of the realized AR is
+the input string, symbol by symbol. So the TBU string is recoverable from the AR
+((37a)), and look-ahead measured on the string is look-ahead measured on the timing
+tier ((37b)). -/
+
+section AutosegmentalGrounding
+
+open Autosegmental
+
+/-- The (40) translation: a H-toned TBU realizes as one H melody node (`Tone.TRN.H`)
+linked to its timing unit; a toneless TBU is a bare timing unit. -/
+def toAR : TBU → AR Tone.TRN Unit
+  | .H => ⟨⟨LabeledTuple.ofList [Tone.TRN.H], LabeledTuple.ofList [()], {(0, 0)}⟩, by
+      intro p hp
+      simp only [Finset.mem_singleton] at hp
+      subst hp
+      exact ⟨by simp, by simp⟩⟩
+  | .O => ⟨⟨LabeledTuple.empty, LabeledTuple.ofList [()], ∅⟩, by
+      intro p hp
+      simp at hp⟩
+
+private theorem linearize_toAR (a : TBU) :
+    (toAR a).linearize = [((), if a = .H then [Tone.TRN.H] else [])] := by
+  cases a <;> decide
+
+/-- (40): linearizing the realized AR returns the TBU string's association profiles. -/
+theorem linearize_realize_toAR (w : List TBU) :
+    (realize toAR w).linearize
+      = w.map fun a => ((), if a = .H then [Tone.TRN.H] else []) := by
+  rw [linearize_realize]
+  induction w with
+  | nil => rfl
+  | cons a w ih => rw [List.flatMap_cons, List.map_cons, ih, linearize_toAR a]; rfl
+
+/-- Read a timing unit's association state back as a TBU symbol. -/
+def readTBU (s : Unit × List Tone.TRN) : TBU := if s.2.isEmpty then .O else .H
+
+/-- **(37a)**: the TBU string is recoverable from the realized autosegmental
+representation — the string carries exactly the timing-tier association information, so
+the complexity results transfer to the autosegmental analysis. -/
+theorem readTBU_linearize_realize (w : List TBU) :
+    ((realize toAR w).linearize).map readTBU = w := by
+  rw [linearize_realize_toAR, List.map_map]
+  conv_rhs => rw [← List.map_id w]
+  refine List.map_congr_left fun a ha => ?_
+  cases a <;> rfl
+
+end AutosegmentalGrounding
 
 /-- **Computationally, tone is different** ([jardine-2016] §7): UTP is *fully regular* —
 regular (bimachine-computable) but neither left- nor right-subsequential nor weakly

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -59,11 +59,11 @@ This file formalizes the paper's formal skeleton over its string-based represent
   the substrate's `Autosegmental.AR.linearize`: the (40) translation `toAR` realizes a
   TBU string as an autosegmental representation whose association-state string *is* the
   input ((37a)), so string-measured look-ahead is timing-tier look-ahead ((37b)).
-* `realizeMerged_utp_plateau` — the autosegmental output: composed with the substrate's
-  OCP-merging realization (`Autosegmental.realizeMerged`), the UTP output is a *single*
-  H autosegment multiply linked across the plateau interval — [hyman-katamba-2010]'s
-  plateauing representation (7), tying the string function back to the AR-level
-  analysis.
+* `links_realizeMerged_utp` / `upper_realizeMerged_utp` — the autosegmental output:
+  composed with the substrate's OCP-merging realization (`Autosegmental.realizeMerged`),
+  the UTP output is a *single* H autosegment multiply linked to exactly the `plateau`,
+  an interval (`plateau_eq_Icc`) — [hyman-katamba-2010]'s plateauing representation (7),
+  tying the string function back to the AR-level analysis.
 * `utp_fullyRegular` — the paper's thesis (§7) in one statement: UTP is *fully regular*,
   i.e. regular but neither subsequential in either direction nor weakly deterministic.
   Tone thereby exceeds the complexity bound that segmental phonology respects.
@@ -176,6 +176,38 @@ theorem utp_getElem?_H_iff {w : List TBU} {j : ℕ} :
       exact TBU.noConfusion h
     · intro hs
       rw [if_pos hs]
+
+/-- The **plateau** of `w`: the finite set of positions that surface H. -/
+def plateau (w : List TBU) : Finset ℕ := (Finset.range w.length).filter (SurfacesH w)
+
+@[simp] theorem mem_plateau {w : List TBU} {j : ℕ} : j ∈ plateau w ↔ SurfacesH w j := by
+  unfold plateau
+  rw [Finset.mem_filter, Finset.mem_range]
+  exact ⟨fun h => h.2, fun h => ⟨h.lt_length, h⟩⟩
+
+@[simp] theorem plateau_nonempty {w : List TBU} : (plateau w).Nonempty ↔ .H ∈ w := by
+  constructor
+  · rintro ⟨j, hj⟩
+    obtain ⟨⟨j₁, -, h₁⟩, -⟩ := surfacesH_iff.mp (mem_plateau.mp hj)
+    exact List.mem_iff_getElem?.mpr ⟨j₁, h₁⟩
+  · intro hw
+    obtain ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
+    exact ⟨i, mem_plateau.mpr (surfacesH_of_getElem?_H hi)⟩
+
+/-- **The plateau is an interval** — the set form of (36c): nonempty
+(`plateau_nonempty`) and convex (`SurfacesH.of_le_of_le`), it runs from the first
+trigger to the last. -/
+theorem plateau_eq_Icc {w : List TBU} (hne : (plateau w).Nonempty) :
+    plateau w = Finset.Icc ((plateau w).min' hne) ((plateau w).max' hne) := by
+  ext j
+  rw [Finset.mem_Icc]
+  constructor
+  · intro hj
+    exact ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩
+  · rintro ⟨h₁, h₂⟩
+    exact mem_plateau.mpr (SurfacesH.of_le_of_le
+      (mem_plateau.mp ((plateau w).min'_mem hne))
+      (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)
 
 /-- Splitting off the position itself: given the symbol at `i`, TBU `i` surfaces H iff it
 is itself a H or is strictly flanked. -/
@@ -837,9 +869,10 @@ theorem readTBU_linearize_realize (w : List TBU) :
 `realize toAR` keeps one H melody node per surface H TBU; the substrate's OCP-merging
 realization `Autosegmental.realizeMerged` fuses the plateau's run of H nodes into one.
 The result is [hyman-katamba-2010]'s plateauing representation (7): a *single* H
-autosegment multiply linked to every TBU from the first trigger to the last, so the
-string function `utp`, the bimachine, and autosegmental spreading-plus-fusion compute
-the same output object. -/
+autosegment (`upper_realizeMerged_utp`) multiply linked to exactly the `plateau`
+(`links_realizeMerged_utp`) — an interval by `plateau_eq_Icc` — over an unchanged
+timing tier (`lower_realizeMerged_utp`). So the string function `utp`, the bimachine,
+and autosegmental spreading-plus-fusion compute the same output object. -/
 
 /-- Every melody node the realization creates is a H tone. -/
 private theorem mem_upper_realize_toAR (v : List TBU) :
@@ -965,52 +998,38 @@ theorem mem_links_realizeMerged_utp (w : List TBU) (p : ℕ × ℕ) :
     obtain ⟨q₁, hq⟩ := (isLinkedLower_realize_toAR (utp w) j).mpr (utp_getElem?_H_iff.mpr hS)
     exact ⟨q₁, j, hq, rfl, rfl⟩
 
-/-- **The fused plateau** — [hyman-katamba-2010]'s plateauing representation (7). For a
-word with at least one H, the OCP-merging realization of the UTP output is a *single* H
-melody node multiply linked to exactly the TBUs of the plateau interval: the string
-function `utp`, the bimachine `utpBM`, and autosegmental spreading-plus-fusion agree on
-one output object. -/
-theorem realizeMerged_utp_plateau (w : List TBU) (hw : .H ∈ w) :
-    ∃ lo hi, lo ≤ hi ∧ hi < w.length ∧ (∀ j, SurfacesH w j ↔ lo ≤ j ∧ j ≤ hi) ∧
-      (realizeMerged toAR (utp w)).upper.toList = [Tone.TRN.H] ∧
-      (realizeMerged toAR (utp w)).lower.toList = List.replicate w.length () ∧
-      (realizeMerged toAR (utp w)).links
-        = (Finset.Icc lo hi).image fun j => ((0 : ℕ), j) := by
-  obtain ⟨i₀, hi₀⟩ := List.mem_iff_getElem?.mp hw
-  have hS₀ : SurfacesH w i₀ := surfacesH_of_getElem?_H hi₀
-  set S : Finset ℕ := (Finset.range w.length).filter (SurfacesH w) with hSdef
-  have hmemS : ∀ j, j ∈ S ↔ SurfacesH w j := fun j => by
-    rw [hSdef, Finset.mem_filter, Finset.mem_range]
-    exact ⟨fun h => h.2, fun h => ⟨h.lt_length, h⟩⟩
-  have hne : S.Nonempty := ⟨i₀, (hmemS i₀).mpr hS₀⟩
-  have hiff : ∀ j, SurfacesH w j ↔ S.min' hne ≤ j ∧ j ≤ S.max' hne := fun j => by
-    constructor
-    · intro h
-      exact ⟨S.min'_le j ((hmemS j).mpr h), S.le_max' j ((hmemS j).mpr h)⟩
-    · rintro ⟨h₁, h₂⟩
-      exact SurfacesH.of_le_of_le ((hmemS _).mp (S.min'_mem hne))
-        ((hmemS _).mp (S.max'_mem hne)) h₁ h₂
-  refine ⟨S.min' hne, S.max' hne, S.min'_le_max' hne,
-    ((hmemS _).mp (S.max'_mem hne)).lt_length, hiff, ?_, ?_, ?_⟩
-  · -- the fused single H on the melody tier
-    have hn : 0 < (realize toAR (utp w)).upper.len := by
-      obtain ⟨q₁, hq⟩ := (isLinkedLower_realize_toAR (utp w) i₀).mpr
-        (utp_getElem?_H_iff.mpr hS₀)
-      exact Nat.lt_of_le_of_lt (Nat.zero_le q₁) ((realize toAR (utp w)).inBounds _ hq).1
-    obtain ⟨m, hm⟩ : ∃ m, (realize toAR (utp w)).upper.len = m + 1 :=
-      ⟨(realize toAR (utp w)).upper.len - 1, by omega⟩
-    rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR, hm, OCP.collapse_replicate]
-  · -- the timing tier survives the merge unchanged
-    rw [realizeMerged_def, collapseAR_lower, lower_realize_toAR, utp_length]
-  · -- the multiple association spans the plateau interval
-    ext ⟨k, j⟩
-    rw [mem_links_realizeMerged_utp]
-    simp only [Finset.mem_image, Finset.mem_Icc, Prod.mk.injEq]
-    constructor
-    · rintro ⟨rfl, hS⟩
-      exact ⟨j, (hiff j).mp hS, rfl, rfl⟩
-    · rintro ⟨j', ⟨h₁, h₂⟩, rfl, rfl⟩
-      exact ⟨rfl, (hiff j').mpr ⟨h₁, h₂⟩⟩
+/-- **Multiple association** ([hyman-katamba-2010] (7)): the merged realization links its
+melody node `0` to exactly the `plateau` — an interval, by `plateau_eq_Icc`.
+Unconditional: a toneless word has an empty plateau and no lines. -/
+theorem links_realizeMerged_utp (w : List TBU) :
+    (realizeMerged toAR (utp w)).links = (plateau w).image fun j => ((0 : ℕ), j) := by
+  ext ⟨k, j⟩
+  rw [mem_links_realizeMerged_utp]
+  simp only [Finset.mem_image, mem_plateau, Prod.mk.injEq]
+  constructor
+  · rintro ⟨rfl, hS⟩
+    exact ⟨j, hS, rfl, rfl⟩
+  · rintro ⟨j', hS, rfl, rfl⟩
+    exact ⟨rfl, hS⟩
+
+/-- The timing tier survives realization and merge unchanged: one slot per input TBU. -/
+theorem lower_realizeMerged_utp (w : List TBU) :
+    (realizeMerged toAR (utp w)).lower.toList = List.replicate w.length () := by
+  rw [realizeMerged_def, collapseAR_lower, lower_realize_toAR, utp_length]
+
+/-- **The fused plateau** ([hyman-katamba-2010] (7)): with at least one H, the merged
+melody tier is a *single* H autosegment — the run of surface H nodes collapses to one,
+which `links_realizeMerged_utp` links across the whole plateau. -/
+theorem upper_realizeMerged_utp (w : List TBU) (hw : .H ∈ w) :
+    (realizeMerged toAR (utp w)).upper.toList = [Tone.TRN.H] := by
+  have hn : 0 < (realize toAR (utp w)).upper.len := by
+    obtain ⟨i₀, hi₀⟩ := List.mem_iff_getElem?.mp hw
+    obtain ⟨q₁, hq⟩ := (isLinkedLower_realize_toAR (utp w) i₀).mpr
+      (utp_getElem?_H_iff.mpr (surfacesH_of_getElem?_H hi₀))
+    exact Nat.lt_of_le_of_lt (Nat.zero_le q₁) ((realize toAR (utp w)).inBounds _ hq).1
+  obtain ⟨m, hm⟩ : ∃ m, (realize toAR (utp w)).upper.len = m + 1 :=
+    ⟨(realize toAR (utp w)).upper.len - 1, by omega⟩
+  rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR, hm, OCP.collapse_replicate]
 
 /-- (7) concretely: `H Ø Ø H` realizes, after UTP and OCP-fusion, as one H linked to all
 four TBUs. -/

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -3,12 +3,15 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Data.Finset.Max
+import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 import Linglib.Core.Computability.Subregular.Function.Hierarchy
 import Linglib.Phonology.Autosegmental.Realization
+import Linglib.Phonology.Autosegmental.Collapse
 import Linglib.Phonology.Tone.Basic
 
 /-!
@@ -56,6 +59,11 @@ This file formalizes the paper's formal skeleton over its string-based represent
   the substrate's `Autosegmental.AR.linearize`: the (40) translation `toAR` realizes a
   TBU string as an autosegmental representation whose association-state string *is* the
   input ((37a)), so string-measured look-ahead is timing-tier look-ahead ((37b)).
+* `realizeMerged_utp_plateau` — the autosegmental output: composed with the substrate's
+  OCP-merging realization (`Autosegmental.realizeMerged`), the UTP output is a *single*
+  H autosegment multiply linked across the plateau interval — [hyman-katamba-2010]'s
+  plateauing representation (7), tying the string function back to the AR-level
+  analysis.
 * `utp_fullyRegular` — the paper's thesis (§7) in one statement: UTP is *fully regular*,
   i.e. regular but neither subsequential in either direction nor weakly deterministic.
   Tone thereby exceeds the complexity bound that segmental phonology respects.
@@ -131,6 +139,43 @@ theorem surfacesH_iff {w : List TBU} {i : ℕ} :
     SurfacesH w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j, i ≤ j ∧ w[j]? = some .H := by
   rw [SurfacesH, mem_take_iff, mem_drop_iff]
   simp [Nat.lt_succ_iff]
+
+/-- A surfacing position is in bounds: some H lies at or beyond it. -/
+theorem SurfacesH.lt_length {w : List TBU} {i : ℕ} (h : SurfacesH w i) : i < w.length := by
+  obtain ⟨-, j, hij, hj⟩ := surfacesH_iff.mp h
+  obtain ⟨hlt, -⟩ := List.getElem?_eq_some_iff.mp hj
+  omega
+
+/-- The plateau is convex: a position between two surfacing positions surfaces. -/
+theorem SurfacesH.of_le_of_le {w : List TBU} {i j k : ℕ} (hi : SurfacesH w i)
+    (hk : SurfacesH w k) (hij : i ≤ j) (hjk : j ≤ k) : SurfacesH w j := by
+  obtain ⟨⟨j₁, hj₁, h₁⟩, -⟩ := surfacesH_iff.mp hi
+  obtain ⟨-, j₂, hj₂, h₂⟩ := surfacesH_iff.mp hk
+  exact surfacesH_iff.mpr ⟨⟨j₁, by omega, h₁⟩, ⟨j₂, by omega, h₂⟩⟩
+
+/-- An underlyingly H-toned TBU surfaces H: it flanks itself. -/
+theorem surfacesH_of_getElem?_H {w : List TBU} {i : ℕ} (h : w[i]? = some .H) :
+    SurfacesH w i :=
+  surfacesH_iff.mpr ⟨⟨i, le_rfl, h⟩, ⟨i, le_rfl, h⟩⟩
+
+/-- The output of UTP carries a H exactly at the surfacing positions. -/
+theorem utp_getElem?_H_iff {w : List TBU} {j : ℕ} :
+    (utp w)[j]? = some .H ↔ SurfacesH w j := by
+  rw [utp_getElem?]
+  cases hw : w[j]? with
+  | none =>
+    refine iff_of_false (by simp) fun hs => ?_
+    rw [List.getElem?_eq_none_iff] at hw
+    exact absurd hs.lt_length (by omega)
+  | some a =>
+    simp only [Option.map_some, Option.some.injEq]
+    constructor
+    · intro h
+      by_contra hs
+      rw [if_neg hs] at h
+      exact TBU.noConfusion h
+    · intro hs
+      rw [if_pos hs]
 
 /-- Splitting off the position itself: given the symbol at `i`, TBU `i` surfaces H iff it
 is itself a H or is strictly flanked. -/
@@ -786,6 +831,192 @@ theorem readTBU_linearize_realize (w : List TBU) :
   conv_rhs => rw [← List.map_id w]
   refine List.map_congr_left fun a ha => ?_
   cases a <;> rfl
+
+/-! #### The fused plateau ([hyman-katamba-2010] (7))
+
+`realize toAR` keeps one H melody node per surface H TBU; the substrate's OCP-merging
+realization `Autosegmental.realizeMerged` fuses the plateau's run of H nodes into one.
+The result is [hyman-katamba-2010]'s plateauing representation (7): a *single* H
+autosegment multiply linked to every TBU from the first trigger to the last, so the
+string function `utp`, the bimachine, and autosegmental spreading-plus-fusion compute
+the same output object. -/
+
+/-- Every melody node the realization creates is a H tone. -/
+private theorem mem_upper_realize_toAR (v : List TBU) :
+    ∀ b ∈ (realize toAR v).upper.toList, b = Tone.TRN.H := by
+  induction v with
+  | nil =>
+    have h : (realize toAR ([] : List TBU)).upper.toList = [] :=
+      List.eq_nil_of_length_eq_zero (by simp [realize_nil, AR.empty, Graph.empty])
+    rw [h]
+    intro b hb
+    simp at hb
+  | cons a v ih =>
+    intro b hb
+    rw [realize_cons, AR.concat_upper, LabeledTuple.toList_concat, List.mem_append] at hb
+    rcases hb with hb | hb
+    · cases a with
+      | H =>
+        rw [show (toAR TBU.H).upper = LabeledTuple.ofList [Tone.TRN.H] from rfl,
+          LabeledTuple.toList_ofList] at hb
+        simpa using hb
+      | O =>
+        rw [show (toAR TBU.O).upper = LabeledTuple.empty from rfl,
+          show (LabeledTuple.empty : LabeledTuple Tone.TRN).toList = [] from
+            List.eq_nil_of_length_eq_zero (by simp)] at hb
+        simp at hb
+    · exact ih b hb
+
+/-- The melody tier of the realization is a constant H run. -/
+private theorem upper_realize_toAR (v : List TBU) :
+    (realize toAR v).upper.toList
+      = List.replicate (realize toAR v).upper.len Tone.TRN.H := by
+  have h := List.eq_replicate_of_mem (mem_upper_realize_toAR v)
+  rwa [LabeledTuple.toList_length] at h
+
+/-- The timing tier of the realization has one slot per TBU. -/
+private theorem lower_realize_toAR (v : List TBU) :
+    (realize toAR v).lower.toList = List.replicate v.length () := by
+  have hlen : (realize toAR v).lower.len = v.length := by
+    rw [← AR.linearize_length, linearize_realize_toAR, List.length_map]
+  have h := List.eq_replicate_of_mem
+    (l := (realize toAR v).lower.toList) (a := ()) fun _ _ => rfl
+  rwa [LabeledTuple.toList_length, hlen] at h
+
+/-- A timing slot of the realization is linked iff its TBU is H-toned. -/
+private theorem isLinkedLower_realize_toAR (v : List TBU) (j : ℕ) :
+    (∃ k, (k, j) ∈ (realize toAR v).links) ↔ v[j]? = some .H := by
+  induction v generalizing j with
+  | nil =>
+    refine iff_of_false ?_ (by simp)
+    rintro ⟨k, hk⟩
+    rw [realize_nil] at hk
+    simp [AR.empty, Graph.empty] at hk
+  | cons a v ih =>
+    cases a with
+    | H =>
+      rw [realize_cons, AR.links_concat,
+        show (toAR TBU.H).upper.len = 1 from rfl,
+        show (toAR TBU.H).lower.len = 1 from rfl,
+        show (toAR TBU.H).links = {((0 : ℕ), (0 : ℕ))} from rfl]
+      cases j with
+      | zero =>
+        simp only [List.getElem?_cons_zero]
+        exact iff_of_true ⟨0, Finset.mem_union_left _ (Finset.mem_singleton_self _)⟩ trivial
+      | succ t =>
+        rw [List.getElem?_cons_succ, ← ih t]
+        constructor
+        · rintro ⟨k, hk⟩
+          rcases Finset.mem_union.mp hk with hk | hk
+          · rw [Finset.mem_singleton, Prod.mk.injEq] at hk
+            exact absurd hk.2 (by omega)
+          · obtain ⟨⟨q₁, q₂⟩, hq, hqe⟩ := Finset.mem_image.mp hk
+            simp only [shiftLink_apply, Prod.mk.injEq] at hqe
+            obtain rfl : q₂ = t := by omega
+            exact ⟨q₁, hq⟩
+        · rintro ⟨k, hk⟩
+          exact ⟨k + 1, Finset.mem_union_right _
+            (Finset.mem_image.mpr ⟨(k, t), hk, by rw [shiftLink_apply]⟩)⟩
+    | O =>
+      rw [realize_cons, AR.links_concat,
+        show (toAR TBU.O).upper.len = 0 from rfl,
+        show (toAR TBU.O).lower.len = 1 from rfl,
+        show (toAR TBU.O).links = (∅ : Finset (ℕ × ℕ)) from rfl]
+      cases j with
+      | zero =>
+        simp only [List.getElem?_cons_zero]
+        refine iff_of_false ?_ (by simp)
+        rintro ⟨k, hk⟩
+        rcases Finset.mem_union.mp hk with hk | hk
+        · exact absurd hk (Finset.notMem_empty _)
+        · obtain ⟨⟨q₁, q₂⟩, hq, hqe⟩ := Finset.mem_image.mp hk
+          simp only [shiftLink_apply, Prod.mk.injEq] at hqe
+          omega
+      | succ t =>
+        rw [List.getElem?_cons_succ, ← ih t]
+        constructor
+        · rintro ⟨k, hk⟩
+          rcases Finset.mem_union.mp hk with hk | hk
+          · exact absurd hk (Finset.notMem_empty _)
+          · obtain ⟨⟨q₁, q₂⟩, hq, hqe⟩ := Finset.mem_image.mp hk
+            simp only [shiftLink_apply, Prod.mk.injEq] at hqe
+            obtain rfl : q₂ = t := by omega
+            exact ⟨q₁, hq⟩
+        · rintro ⟨k, hk⟩
+          exact ⟨k, Finset.mem_union_right _
+            (Finset.mem_image.mpr ⟨(k, t), hk, by simp [shiftLink_apply]⟩)⟩
+
+/-- The association lines of the OCP-merged plateau: all lines point at melody node `0`,
+one per surfacing TBU. -/
+theorem mem_links_realizeMerged_utp (w : List TBU) (p : ℕ × ℕ) :
+    p ∈ (realizeMerged toAR (utp w)).links ↔ p.1 = 0 ∧ SurfacesH w p.2 := by
+  obtain ⟨k, j⟩ := p
+  rw [realizeMerged_def,
+    show (collapseAR (realize toAR (utp w))).links
+        = ((realize toAR (utp w)).links).image
+            (Prod.map (runIdx ((realize toAR (utp w)).upper.toList)) id) from rfl,
+    upper_realize_toAR]
+  simp only [Finset.mem_image, Prod.exists, Prod.map_apply, id_eq, runIdx_replicate,
+    Prod.mk.injEq]
+  constructor
+  · rintro ⟨q₁, q₂, hq, rfl, rfl⟩
+    exact ⟨rfl, utp_getElem?_H_iff.mp ((isLinkedLower_realize_toAR (utp w) q₂).mp ⟨q₁, hq⟩)⟩
+  · rintro ⟨rfl, hS⟩
+    obtain ⟨q₁, hq⟩ := (isLinkedLower_realize_toAR (utp w) j).mpr (utp_getElem?_H_iff.mpr hS)
+    exact ⟨q₁, j, hq, rfl, rfl⟩
+
+/-- **The fused plateau** — [hyman-katamba-2010]'s plateauing representation (7). For a
+word with at least one H, the OCP-merging realization of the UTP output is a *single* H
+melody node multiply linked to exactly the TBUs of the plateau interval: the string
+function `utp`, the bimachine `utpBM`, and autosegmental spreading-plus-fusion agree on
+one output object. -/
+theorem realizeMerged_utp_plateau (w : List TBU) (hw : .H ∈ w) :
+    ∃ lo hi, lo ≤ hi ∧ hi < w.length ∧ (∀ j, SurfacesH w j ↔ lo ≤ j ∧ j ≤ hi) ∧
+      (realizeMerged toAR (utp w)).upper.toList = [Tone.TRN.H] ∧
+      (realizeMerged toAR (utp w)).lower.toList = List.replicate w.length () ∧
+      (realizeMerged toAR (utp w)).links
+        = (Finset.Icc lo hi).image fun j => ((0 : ℕ), j) := by
+  obtain ⟨i₀, hi₀⟩ := List.mem_iff_getElem?.mp hw
+  have hS₀ : SurfacesH w i₀ := surfacesH_of_getElem?_H hi₀
+  set S : Finset ℕ := (Finset.range w.length).filter (SurfacesH w) with hSdef
+  have hmemS : ∀ j, j ∈ S ↔ SurfacesH w j := fun j => by
+    rw [hSdef, Finset.mem_filter, Finset.mem_range]
+    exact ⟨fun h => h.2, fun h => ⟨h.lt_length, h⟩⟩
+  have hne : S.Nonempty := ⟨i₀, (hmemS i₀).mpr hS₀⟩
+  have hiff : ∀ j, SurfacesH w j ↔ S.min' hne ≤ j ∧ j ≤ S.max' hne := fun j => by
+    constructor
+    · intro h
+      exact ⟨S.min'_le j ((hmemS j).mpr h), S.le_max' j ((hmemS j).mpr h)⟩
+    · rintro ⟨h₁, h₂⟩
+      exact SurfacesH.of_le_of_le ((hmemS _).mp (S.min'_mem hne))
+        ((hmemS _).mp (S.max'_mem hne)) h₁ h₂
+  refine ⟨S.min' hne, S.max' hne, S.min'_le_max' hne,
+    ((hmemS _).mp (S.max'_mem hne)).lt_length, hiff, ?_, ?_, ?_⟩
+  · -- the fused single H on the melody tier
+    have hn : 0 < (realize toAR (utp w)).upper.len := by
+      obtain ⟨q₁, hq⟩ := (isLinkedLower_realize_toAR (utp w) i₀).mpr
+        (utp_getElem?_H_iff.mpr hS₀)
+      exact Nat.lt_of_le_of_lt (Nat.zero_le q₁) ((realize toAR (utp w)).inBounds _ hq).1
+    obtain ⟨m, hm⟩ : ∃ m, (realize toAR (utp w)).upper.len = m + 1 :=
+      ⟨(realize toAR (utp w)).upper.len - 1, by omega⟩
+    rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR, hm, OCP.collapse_replicate]
+  · -- the timing tier survives the merge unchanged
+    rw [realizeMerged_def, collapseAR_lower, lower_realize_toAR, utp_length]
+  · -- the multiple association spans the plateau interval
+    ext ⟨k, j⟩
+    rw [mem_links_realizeMerged_utp]
+    simp only [Finset.mem_image, Finset.mem_Icc, Prod.mk.injEq]
+    constructor
+    · rintro ⟨rfl, hS⟩
+      exact ⟨j, (hiff j).mp hS, rfl, rfl⟩
+    · rintro ⟨j', ⟨h₁, h₂⟩, rfl, rfl⟩
+      exact ⟨rfl, (hiff j').mpr ⟨h₁, h₂⟩⟩
+
+/-- (7) concretely: `H Ø Ø H` realizes, after UTP and OCP-fusion, as one H linked to all
+four TBUs. -/
+example :
+    (realizeMerged toAR (utp [.H, .O, .O, .H])).links
+      = {(0, 0), (0, 1), (0, 2), (0, 3)} := by decide
 
 end AutosegmentalGrounding
 


### PR DESCRIPTION
Re-lands the two commits stranded when #1051 merged mid-push, plus a mathlib-shape refactor of the headline. Completes the Jardine 2016 formalization: the (43) mark-up decomposition (`utp = resolve ∘ markLeft.run` over the `?`-enlarged alphabet, both passes certified subsequential), the §4.4 autosegmental grounding via the new `AR.linearize` (monoid hom; TBU string recoverable from the realized AR), and the fused plateau: `realizeMerged toAR (utp w)` is a single H melody node linked to exactly `plateau w` (`links_realizeMerged_utp`, unconditional), an interval by `plateau_eq_Icc` — Hyman & Katamba's (7).

- `Bimachine.lean`: `RequiresBothSides.isUnboundedCircumambient`; `Bimachine.ofFlags` (refactors `conjBM`, `utpBM`).
- `Hierarchy.lean`: `Mealy.toSFST` — the synchronous ⊆ block-subsequential inclusion.
- `Realization.lean`: `AR.linearize`, `linearize_concat`, `linearize_realize`. `OCP.lean`/`Collapse.lean`: `collapse_replicate`, `runIdx_replicate`.
- All kernel-clean; no `sorry`, no `native_decide`.