### PR TITLE
feat(Syntax/Complementizer): complementizer core + Buryat re-founding

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2790,6 +2790,7 @@ import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Clause.Chaining
 import Linglib.Syntax.Clause.Complementation
 import Linglib.Syntax.Comparative
+import Linglib.Syntax.Complementizer.Basic
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Syntax.ConstructionGrammar.Basic
 import Linglib.Syntax.ConstructionGrammar.GrammarDist

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -5,106 +5,71 @@ import Linglib.Data.UD.Basic
 # Buryat Complementizers and Clause-Embedding Verbs
 [bondarenko-2022] [bondarenko-2020] [bondarenko-2019]
 
-Modern Barguzin Buryat (Mongolic; Russian Federation) — the clause-typing
-morphemes of embedded clauses and the matrix verbs that select bare
-vs. nominalized complements.
-
-## Three clause-typing morphemes
-
+This file records the clause-typing morphemes of Barguzin Buryat
+(Mongolic) embedded clauses and the matrix verbs that select them.
 Embedded clauses show three surface shapes ([bondarenko-2022] §4.3.1
-ex. 30–32; [bondarenko-2020]):
+ex. 30–32): bare `[… V-TENSE gɘ-žɘ]`, nominalized `[… V-PART-CASE]`,
+and nominalized with the say-root `[… V-TENSE g-ɘːš-CASE]`.
 
-- bare CP: `[… V-TENSE gɘ-žɘ]` — the grammaticalized say-root *gɘ*
-  (from *gɘxɘ* 'say', [bondarenko-2020] fn. 21) plus the converb suffix
-  *-žA*; the complex is standardly cited as the complementizer *gɘžɘ*;
-- nominalized clause without *gɘ*: `[… V-PART-CASE]`;
-- nominalized clause with *gɘ*: `[… V-TENSE g-ɘːš-CASE]` — say-root plus
-  the participial suffix *-Aːša* plus nominal morphology (case, optional
-  possessive marking) and genitive subject.
+## Main definitions
 
-*-Aːša* is the agentive participle (actor noun) and *-žA* the
-imperfective converb ([skribnik-2003]). Capital letters mark
-vowel-harmony archiphonemes (-aːša ~ -ɘːšɘ ~ -oːšo). *-Aːša* appears
-when the clause complex combines with a nominal projection, *-žA* when
-it combines directly with a verb ([bondarenko-2022] §4.3.1).
+- `Buryat.Complementizer` — the say-root *gɘ*, the agentive participle
+  *-Aːša*, and the imperfective converb *-žA* ([skribnik-2003]), with
+  projections `form`, `verbForm`, and `host`
+- `Buryat.hanaxa`, `Buryat.medexe`, `Buryat.xelexe`, `Buryat.duulaxa` —
+  clause-embedding verbs; all four alternate between the finite-CP and
+  nominalized (`.gerund`) frames (ex. 35–36, 50–51)
 
-## Scope of this Fragment file
+## Implementation notes
 
-Per the Fragment-discipline rule (textbook-consensus metadata only),
-this file records the morpheme inventory and its surface distribution.
-[bondarenko-2022]'s head assignment — *gɘ* expones a Cont head, the two
-suffixes are allomorphs of one Comp head — is paper-specific and lives
-as Studies-local projections in `Studies/Bondarenko2022.lean`
-(`buryatContExponent`, `buryatCompAllomorph`). Other treatments of
-Mongolic say-complementizers ([knyazev-2016] on the categorial status
-of Kalmyk *giž*; the areal SAY-grammaticalization pattern of
-[matic-pakendorf-2013]) carve the morphology differently; the inventory
-here is neutral between them.
-
-## Matrix verbs
-
-The clause-embedding verbs anchoring [bondarenko-2019],
-[bondarenko-2020], and [bondarenko-2022] §4.4.3. All four are attested
-in both frames ([bondarenko-2020]: nominalized frame at ex. 35–36,
-50–51; bare gɘžɘ-CPs passim):
-
-- *hanaxa* 'think ~ remember' — the headline alternating verb: bare CP
-  = 'think' (non-veridical), nominalized complement = 'remember'
-  (veridical via a pre-existence presupposition);
-- *mɘdɘxɘ* 'know' — factive; also embeds polar questions;
-- *xɘlɘxɘ* 'say' — speech-act verb;
-- *duːlaxa* 'hear' — hearsay perception verb.
-
-Constructor and definition names are ASCII romanizations (ɘ → e,
-ː → vowel doubling, ž → zh, š → sh); `Complementizer.form` and
-`Verb.form` carry the faithful transliterations.
+Bondarenko's head assignment (*gɘ* expones Cont, the suffixes are Comp
+allomorphs) is paper-specific and lives in `Studies/Bondarenko2022.lean`;
+rival carvings of Mongolic say-complementizers: [knyazev-2016],
+[matic-pakendorf-2013]. Bare `§`-references are to [bondarenko-2022],
+bare `ex.`/`fn.` references to [bondarenko-2020]. Identifiers are ASCII
+romanizations (ɘ → e, ː → doubling, ž → zh, š → sh); `form` fields carry
+the faithful transliterations, with capitals marking vowel-harmony
+archiphonemes.
 -/
 
 namespace Buryat
 
 /-- The three clause-typing morphemes of the Barguzin Buryat embedded
-clause ([bondarenko-2022] §4.3.1 ex. 30–32; [bondarenko-2020]). -/
+clause (§4.3.1 ex. 30–32). -/
 inductive Complementizer where
-  /-- *gɘ* — grammaticalized root of *gɘxɘ* 'say' ([bondarenko-2020]
-  fn. 21: under verbs like 'hear' or 'see', gɘžɘ-clauses entail no
-  speech act by the subject). -/
+  /-- *gɘ* — grammaticalized root of *gɘxɘ* 'say' (fn. 21: no speech act
+  entailed under 'hear' or 'see'). -/
   | ge
-  /-- *-Aːša* — agentive participle ([skribnik-2003]); appears when the
-  clause complex combines with a nominal projection. -/
+  /-- *-Aːša* — agentive participle ([skribnik-2003]); appears next to
+  nominal projections. -/
   | aasha
-  /-- *-žA* — imperfective converb ([skribnik-2003]); appears when the
-  clause combines directly with a verb (also found in analytical verb
-  forms and sentential adjuncts, [bondarenko-2020] ex. 30). -/
+  /-- *-žA* — imperfective converb ([skribnik-2003]); appears next to
+  verbs, also in analytical verb forms and sentential adjuncts (ex. 30). -/
   | zha
   deriving DecidableEq, Fintype, Repr
 
 namespace Complementizer
 
-/-- Surface form in Bondarenko's transliteration (capital letters mark
-vowel-harmony archiphonemes). Display only. -/
+/-- Surface form in Bondarenko's transliteration. Display only. -/
 def form : Complementizer → String
   | .ge    => "gɘ"
   | .aasha => "-Aːša"
   | .zha   => "-žA"
 
-/-- The verb form each suffix derives on its host — participle for
-*-Aːša*, converb for *-žA* (UD `VerbForm` cells); `none` for *gɘ*,
-which is a verb root rather than a suffix. -/
+/-- The verb form each suffix derives: participle for *-Aːša*, converb
+for *-žA*; `none` for the root *gɘ*, which is not a suffix. -/
 def verbForm : Complementizer → Option UD.VerbForm
   | .ge    => none
   | .aasha => some .Part
   | .zha   => some .Conv
 
-/-- Category of the adjacent projection licensing each suffix
-([bondarenko-2022] §4.3.1): *-Aːša* combines with nominal projections,
-*-žA* with verbs. -/
+/-- Category of the adjacent projection licensing each suffix (§4.3.1). -/
 inductive Host where
   | nominal
   | verbal
   deriving DecidableEq, Fintype, Repr
 
-/-- Surface distribution: the licensing host of each suffix; `none`
-for the root *gɘ*. -/
+/-- Licensing host of each suffix; `none` for the root *gɘ*. -/
 def host : Complementizer → Option Host
   | .ge    => none
   | .aasha => some .nominal
@@ -114,18 +79,13 @@ end Complementizer
 
 /-! ### Clause-embedding verbs
 
-Vendler class is left unset throughout, per the
-`Verb.Aspect.vendlerClass` convention (`none` for clause-embedding
-verbs). -/
+Vendler class stays unset (`Verb.Aspect.vendlerClass` convention for
+clause-embedding verbs). -/
 
-/-- *hanaxa* 'think ~ remember'. The headline alternating verb of
-[bondarenko-2019], [bondarenko-2020], and [bondarenko-2022] §4.4.3:
-with a bare gɘžɘ-CP it is 'think'; with a nominalized participial
-complement it is 'remember'. The `attitude` and `opaqueContext` values
-record the bare-CP frame; the nominalized frame carries a pre-existence
-presupposition (veridical 'remember'), a frame-conditioned meaning
-tracked at the theory layer (`Semantics/Attitudes/PreExistence.lean`)
-rather than in this entry. -/
+/-- *hanaxa* 'think ~ remember': 'think' with a bare gɘžɘ-CP, 'remember'
+with a nominalized complement (§4.4.3). `attitude` and `opaqueContext`
+record the bare-CP frame; the nominalized frame's pre-existence
+presupposition is tracked in `Semantics/Attitudes/PreExistence.lean`. -/
 def hanaxa : Verb where
   form := "hanaxa"
   complementType := .finiteClause
@@ -133,9 +93,8 @@ def hanaxa : Verb where
   attitude := some (.doxastic .nonVeridical)
   opaqueContext := true
 
-/-- *mɘdɘxɘ* 'know'. Factive doxastic in both frames ([bondarenko-2020]
-ex. 36 for the nominalized frame); embeds polar questions
-(*gü gɘžɘ* 'whether', [bondarenko-2020] ex. 3). -/
+/-- *mɘdɘxɘ* 'know' — factive in both frames (ex. 36); embeds polar
+questions (ex. 3). -/
 def medexe : Verb where
   form := "mɘdɘxɘ"
   complementType := .finiteClause
@@ -143,19 +102,16 @@ def medexe : Verb where
   attitude := some (.doxastic .veridical)
   takesQuestionBase := true
 
-/-- *xɘlɘxɘ* 'say'. Non-factive with bare CPs; nominalized complements
-are existence-entailing ([bondarenko-2020] ex. 51; its fn. 30 notes
-speaker variation on the nominalized frame). -/
+/-- *xɘlɘxɘ* 'say' — non-factive with bare CPs; nominalized complements
+are existence-entailing (ex. 51; speaker variation per fn. 30). -/
 def xelexe : Verb where
   form := "xɘlɘxɘ"
   complementType := .finiteClause
   altComplementType := some .gerund
   speechActVerb := true
 
-/-- *duːlaxa* 'hear'. Hearsay perception verb: non-factive with bare
-CPs, existence-entailing with nominalized complements
-([bondarenko-2020] ex. 50; fn. 21 uses gɘžɘ-CPs under 'hear' as the
-grammaticalization diagnostic for *gɘ*). -/
+/-- *duːlaxa* 'hear' — non-factive with bare CPs, existence-entailing
+with nominalized complements (ex. 50). -/
 def duulaxa : Verb where
   form := "duːlaxa"
   complementType := .finiteClause

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -1,167 +1,164 @@
 import Linglib.Semantics.Verb.Basic
+import Linglib.Data.UD.Basic
 
 /-!
 # Buryat Complementizers and Clause-Embedding Verbs
-[bondarenko-2022] [bondarenko-2020] [bondarenko-2017]
+[bondarenko-2022] [bondarenko-2020] [bondarenko-2019]
 
-Modern Barguzin Buryat (Mongolic; Russian Federation) — clause-typing
-morphology and the matrix verbs that select bare vs. nominalized
-embedded clauses ([bondarenko-2022] §4.3.1).
+Modern Barguzin Buryat (Mongolic; Russian Federation) — the clause-typing
+morphemes of embedded clauses and the matrix verbs that select bare
+vs. nominalized complements.
 
 ## Three clause-typing morphemes
 
-- **gɔ** 'say' — verbal source; [bondarenko-2022] §4.3.1 analyses
-  it as the overt exponent of ContP (the projection introducing the
-  CONT function at the left periphery of Cont-CPs). When *gɔ* is
-  present, the embedded clause is a Cont-CP.
-- **-Aːša** / **-žA** — Comp allomorphs of the participial nominaliser
-  (vowel harmony / aspect-conditioned). Closes off a non-finite
-  embedded clause; co-occurs with both Cont-CPs (alongside *gɔ*) and
-  Sit-CPs (without *gɔ*).
-- The contrast (Cont-CP = with *gɔ*; Sit-CP = without *gɔ*) is what
-  makes Buryat the chapter's headline language for the bare/
-  nominalized cut.
+Embedded clauses show three surface shapes ([bondarenko-2022] §4.3.1
+ex. 30–32; [bondarenko-2020]):
+
+- bare CP: `[… V-TENSE gɘ-žɘ]` — the grammaticalized say-root *gɘ*
+  (from *gɘxɘ* 'say', [bondarenko-2020] fn. 21) plus the converb suffix
+  *-žA*; the complex is standardly cited as the complementizer *gɘžɘ*;
+- nominalized clause without *gɘ*: `[… V-PART-CASE]`;
+- nominalized clause with *gɘ*: `[… V-TENSE g-ɘːš-CASE]` — say-root plus
+  the participial suffix *-Aːša* plus nominal morphology (case, optional
+  possessive marking) and genitive subject.
+
+*-Aːša* is the agentive participle (actor noun) and *-žA* the
+imperfective converb ([skribnik-2003]). Capital letters mark
+vowel-harmony archiphonemes (-aːša ~ -ɘːšɘ ~ -oːšo). *-Aːša* appears
+when the clause complex combines with a nominal projection, *-žA* when
+it combines directly with a verb ([bondarenko-2022] §4.3.1).
 
 ## Scope of this Fragment file
 
-Per the project Fragment-discipline rule (textbook-consensus
-metadata only): this file exposes only the **morphological inventory
-and surface co-occurrence facts**. The Bondarenko-specific
-ContP-bearing projection (`bearsContP`) lives as a Studies-local
-projection in `Studies/Bondarenko2022.lean`,
-not as a field of the morpheme record. Alternative analyses
-(Knyazev's spanning-complementiser account, Stassen's serial-verb
-analysis of *gɔ*) treat the morphology differently; this fragment
-stays neutral.
+Per the Fragment-discipline rule (textbook-consensus metadata only),
+this file records the morpheme inventory and its surface distribution.
+[bondarenko-2022]'s head assignment — *gɘ* expones a Cont head, the two
+suffixes are allomorphs of one Comp head — is paper-specific and lives
+as Studies-local projections in `Studies/Bondarenko2022.lean`
+(`buryatContExponent`, `buryatCompAllomorph`). Other treatments of
+Mongolic say-complementizers ([knyazev-2016] on the categorial status
+of Kalmyk *giž*; the areal SAY-grammaticalization pattern of
+[matic-pakendorf-2013]) carve the morphology differently; the inventory
+here is neutral between them.
 
 ## Matrix verbs
 
-The verbs that anchor Bondarenko's bare-vs-nominalized arguments:
+The clause-embedding verbs anchoring [bondarenko-2019],
+[bondarenko-2020], and [bondarenko-2022] §4.4.3. All four are attested
+in both frames ([bondarenko-2020]: nominalized frame at ex. 35–36,
+50–51; bare gɘžɘ-CPs passim):
 
-- *xanaxa* 'think / remember' — polysemous attitude verb; bare
-  complement = thinking (Cont reading), nominalized complement =
-  remembering (DP-argument reading). Anchors §4.4.3 about-argument.
-- *boloxo* 'happen / become' — change-of-state verb taking situation
-  arguments; bare complement reading.
-- *medexe* 'know' — factive doxastic.
-- *xelexe* 'say' — speech act verb; selects bare *gɔ*-marked
-  complement.
+- *hanaxa* 'think ~ remember' — the headline alternating verb: bare CP
+  = 'think' (non-veridical), nominalized complement = 'remember'
+  (veridical via a pre-existence presupposition);
+- *mɘdɘxɘ* 'know' — factive; also embeds polar questions;
+- *xɘlɘxɘ* 'say' — speech-act verb;
+- *duːlaxa* 'hear' — hearsay perception verb.
 
+Constructor and definition names are ASCII romanizations (ɘ → e,
+ː → vowel doubling, ž → zh, š → sh); `Complementizer.form` and
+`Verb.form` carry the faithful transliterations.
 -/
 
-namespace Buryat.Complementizers
+namespace Buryat
 
+/-- The three clause-typing morphemes of the Barguzin Buryat embedded
+clause ([bondarenko-2022] §4.3.1 ex. 30–32; [bondarenko-2020]). -/
+inductive Complementizer where
+  /-- *gɘ* — grammaticalized root of *gɘxɘ* 'say' ([bondarenko-2020]
+  fn. 21: under verbs like 'hear' or 'see', gɘžɘ-clauses entail no
+  speech act by the subject). -/
+  | ge
+  /-- *-Aːša* — agentive participle ([skribnik-2003]); appears when the
+  clause complex combines with a nominal projection. -/
+  | aasha
+  /-- *-žA* — imperfective converb ([skribnik-2003]); appears when the
+  clause combines directly with a verb (also found in analytical verb
+  forms and sentential adjuncts, [bondarenko-2020] ex. 30). -/
+  | zha
+  deriving DecidableEq, Fintype, Repr
 
--- ════════════════════════════════════════════════════════════════
--- § 1. Clause-typing morpheme inventory
--- ════════════════════════════════════════════════════════════════
+namespace Complementizer
 
-/-- The three clause-typing morphemes covered here. *Aːša* / *žA* are
-    treated as separate morphemes by their phonological/aspectual
-    distribution; some accounts unify them as allomorphs of a single
-    Comp head. -/
-inductive BuryatComplementizer where
-  /-- *gɔ* — verbal "say"-source; overt exponent of ContP per
-      [bondarenko-2022] §4.3.1. ASCII identifier `gO` for kernel-
-      reducer compatibility; the form string preserves the unicode. -/
-  | gO
-  /-- *-Aːša* — participial nominaliser (imperfective/non-future).
-      ASCII identifier `aSha` for kernel-reducer compatibility. -/
-  | aSha
-  /-- *-žA* — participial nominaliser (perfective/factive).
-      ASCII identifier `zhA` for kernel-reducer compatibility. -/
-  | zhA
-  deriving DecidableEq, Repr
+/-- Surface form in Bondarenko's transliteration (capital letters mark
+vowel-harmony archiphonemes). Display only. -/
+def form : Complementizer → String
+  | .ge    => "gɘ"
+  | .aasha => "-Aːša"
+  | .zha   => "-žA"
 
-/-- Phonological form (rough Latinisation; vowel-harmony variants
-    abstracted away for citation purposes). -/
-def BuryatComplementizer.form : BuryatComplementizer → String
-  | .gO   => "gɔ"
-  | .aSha => "-Aːša"
-  | .zhA   => "-žA"
+/-- The verb form each suffix derives on its host — participle for
+*-Aːša*, converb for *-žA* (UD `VerbForm` cells); `none` for *gɘ*,
+which is a verb root rather than a suffix. -/
+def verbForm : Complementizer → Option UD.VerbForm
+  | .ge    => none
+  | .aasha => some .Part
+  | .zha   => some .Conv
 
-/-- Whether the morpheme is verbally sourced (vs. nominal/participial).
-    *gɔ* is verbally sourced (from "say"); the participial nominalisers
-    are not. -/
-def BuryatComplementizer.isVerbal : BuryatComplementizer → Bool
-  | .gO => true
-  | _   => false
+/-- Category of the adjacent projection licensing each suffix
+([bondarenko-2022] §4.3.1): *-Aːša* combines with nominal projections,
+*-žA* with verbs. -/
+inductive Host where
+  | nominal
+  | verbal
+  deriving DecidableEq, Fintype, Repr
 
-/-- Whether the morpheme is a participial nominaliser. The split into
-    *Aːša* / *žA* by the participial allomorphy follows
-    [bondarenko-2022] §4.3.1. -/
-def BuryatComplementizer.isParticipial : BuryatComplementizer → Bool
-  | .aSha => true
-  | .zhA   => true
-  | .gO   => false
+/-- Surface distribution: the licensing host of each suffix; `none`
+for the root *gɘ*. -/
+def host : Complementizer → Option Host
+  | .ge    => none
+  | .aasha => some .nominal
+  | .zha   => some .verbal
 
-/-- Sanity check: the verbal/participial axes partition the inventory. -/
-theorem verbal_xor_participial (c : BuryatComplementizer) :
-    c.isVerbal = !c.isParticipial := by cases c <;> decide
+end Complementizer
 
--- ════════════════════════════════════════════════════════════════
--- § 2. Matrix verb entries
--- ════════════════════════════════════════════════════════════════
+/-! ### Clause-embedding verbs
 
-/-- *xanaxa* — 'think / remember'. Bondarenko's anchor verb for the
-    bare-vs-nominalized argument-structure alternation
-    ([bondarenko-2022] §4.4.3). With bare complement → thinking
-    (Cont reading); with nominalized complement → remembering
-    (DP-argument reading + about-presupposition).
+Vendler class is left unset throughout, per the
+`Verb.Aspect.vendlerClass` convention (`none` for clause-embedding
+verbs). -/
 
-    Citation form is the eventive/cognition sense; the
-    polysemy is tracked via `altComplementType`. -/
-def xanaxa : Verb where
-  form := "xanaxa"
+/-- *hanaxa* 'think ~ remember'. The headline alternating verb of
+[bondarenko-2019], [bondarenko-2020], and [bondarenko-2022] §4.4.3:
+with a bare gɘžɘ-CP it is 'think'; with a nominalized participial
+complement it is 'remember'. The `attitude` and `opaqueContext` values
+record the bare-CP frame; the nominalized frame carries a pre-existence
+presupposition (veridical 'remember'), a frame-conditioned meaning
+tracked at the theory layer (`Semantics/Attitudes/PreExistence.lean`)
+rather than in this entry. -/
+def hanaxa : Verb where
+  form := "hanaxa"
   complementType := .finiteClause
-  altComplementType := some .finiteClause
+  altComplementType := some .gerund
   attitude := some (.doxastic .nonVeridical)
-  vendlerClass := some .activity
   opaqueContext := true
 
-/-- *boloxo* — 'happen / become'. Eventive change-of-state verb.
-    Selects situation-typed argument; relevant to §4.3.3 cross-
-    linguistic-occurrence-verb generalization. -/
-def boloxo : Verb where
-  form := "boloxo"
-  complementType := .finiteClause
-  vendlerClass := some .achievement
-  unaccusative := true
-
-/-- *medexe* — 'know'. Factive doxastic; stative. -/
+/-- *mɘdɘxɘ* 'know'. Factive doxastic in both frames ([bondarenko-2020]
+ex. 36 for the nominalized frame); embeds polar questions
+(*gü gɘžɘ* 'whether', [bondarenko-2020] ex. 3). -/
 def medexe : Verb where
-  form := "medexe"
+  form := "mɘdɘxɘ"
   complementType := .finiteClause
+  altComplementType := some .gerund
   attitude := some (.doxastic .veridical)
-  vendlerClass := some .state
+  takesQuestionBase := true
 
-/-- *xelexe* — 'say'. Speech-act verb; selects bare *gɔ*-marked
-    complement per [bondarenko-2022] §4.3.1. -/
+/-- *xɘlɘxɘ* 'say'. Non-factive with bare CPs; nominalized complements
+are existence-entailing ([bondarenko-2020] ex. 51; its fn. 30 notes
+speaker variation on the nominalized frame). -/
 def xelexe : Verb where
-  form := "xelexe"
+  form := "xɘlɘxɘ"
   complementType := .finiteClause
+  altComplementType := some .gerund
   speechActVerb := true
-  vendlerClass := some .activity
 
--- ════════════════════════════════════════════════════════════════
--- § 3. Theorems
--- ════════════════════════════════════════════════════════════════
+/-- *duːlaxa* 'hear'. Hearsay perception verb: non-factive with bare
+CPs, existence-entailing with nominalized complements
+([bondarenko-2020] ex. 50; fn. 21 uses gɘžɘ-CPs under 'hear' as the
+grammaticalization diagnostic for *gɘ*). -/
+def duulaxa : Verb where
+  form := "duːlaxa"
+  complementType := .finiteClause
+  altComplementType := some .gerund
 
-/-- *xanaxa* and *boloxo* are non-stative; *medexe* is stative.
-    Consensus stativity per Vendler. -/
-theorem stativity_split :
-    xanaxa.vendlerClass = some .activity ∧
-    boloxo.vendlerClass = some .achievement ∧
-    medexe.vendlerClass = some .state ∧
-    xelexe.vendlerClass = some .activity := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- *xanaxa* is the only verb here with two complement frames
-    available (the bare-vs-nominalized alternation Bondarenko exploits
-    in §4.4.3). -/
-theorem only_xanaxa_alternates :
-    xanaxa.altComplementType.isSome = true ∧
-    boloxo.altComplementType.isSome = false ∧
-    medexe.altComplementType.isSome = false ∧
-    xelexe.altComplementType.isSome = false := ⟨rfl, rfl, rfl, rfl⟩
-
-end Buryat.Complementizers
+end Buryat

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -13,10 +13,10 @@ and nominalized with the say-root `[… V-TENSE g-ɘːš-CASE]`.
 
 ## Main definitions
 
-- `Buryat.Complementizer` — index of the say-root *gɘ*, the agentive
-  participle *-Aːša*, and the imperfective converb *-žA*
-  ([skribnik-2003]); the feature rows are `Complementizer.entry`
-  values of the root `Complementizer` schema
+- `Buryat.ge`, `Buryat.aasha`, `Buryat.zha` — the say-root *gɘ*, the
+  agentive participle *-Aːša*, and the imperfective converb *-žA*
+  ([skribnik-2003]), as root `Complementizer` entries; the closed
+  inventory is `Buryat.complementizers`
 - `Buryat.hanaxa`, `Buryat.medexe`, `Buryat.xelexe`, `Buryat.duulaxa` —
   clause-embedding verbs; all four alternate between the finite-CP and
   nominalized (`.gerund`) frames (ex. 35–36, 50–51)
@@ -35,33 +35,34 @@ archiphonemes.
 
 namespace Buryat
 
-/-- Index of the three clause-typing morphemes of the Barguzin Buryat
-embedded clause (§4.3.1 ex. 30–32). Feature rows: `Complementizer.entry`. -/
-inductive Complementizer where
-  /-- *gɘ* — grammaticalized root of *gɘxɘ* 'say' (fn. 21: no speech act
-  entailed under 'hear' or 'see'). -/
-  | ge
-  /-- *-Aːša* — agentive participle ([skribnik-2003]); appears next to
-  nominal projections. -/
-  | aasha
-  /-- *-žA* — imperfective converb ([skribnik-2003]); appears next to
-  verbs, also in analytical verb forms and sentential adjuncts (ex. 30). -/
-  | zha
-  deriving DecidableEq, Fintype, Repr
+/-- *gɘ* — grammaticalized root of *gɘxɘ* 'say' (fn. 21: no speech act
+entailed under 'hear' or 'see'). Never surfaces unsuffixed (gɘ-žɘ,
+g-ɘːšɘ), so its attachment is left unrecorded. -/
+def ge : Complementizer where
+  form := "gɘ"
 
-/-- The lexical entry of each morpheme, in Bondarenko's transliteration.
-The root *gɘ* never surfaces unsuffixed (gɘ-žɘ, g-ɘːšɘ), so its
-attachment is left unrecorded; the *-Aːša* complement is
-Noonan-nominalized (case-marked, genitive subject) while the morpheme
-itself is a participle — two axes, two fields. -/
-def Complementizer.entry : Complementizer → _root_.Complementizer
-  | .ge    => { form := "gɘ" }
-  | .aasha => { form := "-Aːša", position := some .postfixed,
-                noonanType := some .nominalized,
-                verbForm := some .Part, host := some .nominal }
-  | .zha   => { form := "-žA", position := some .postfixed,
-                noonanType := some .indicative,
-                verbForm := some .Conv, host := some .verbal }
+/-- *-Aːša* — agentive participle ([skribnik-2003]); appears next to
+nominal projections. The complement it types is Noonan-nominalized
+(case-marked, genitive subject) while the morpheme itself is a
+participle — two axes, two fields. -/
+def aasha : Complementizer where
+  form := "-Aːša"
+  position := some .postfixed
+  noonanType := some .nominalized
+  verbForm := some .Part
+  host := some .nominal
+
+/-- *-žA* — imperfective converb ([skribnik-2003]); appears next to
+verbs, also in analytical verb forms and sentential adjuncts (ex. 30). -/
+def zha : Complementizer where
+  form := "-žA"
+  position := some .postfixed
+  noonanType := some .indicative
+  verbForm := some .Conv
+  host := some .verbal
+
+/-- The clause-typing inventory — closed per §4.3.1 ex. 30–32. -/
+def complementizers : List Complementizer := [ge, aasha, zha]
 
 /-! ### Clause-embedding verbs
 

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Verb.Basic
-import Linglib.Data.UD.Basic
+import Linglib.Syntax.Complementizer.Basic
 
 /-!
 # Buryat Complementizers and Clause-Embedding Verbs
@@ -13,9 +13,10 @@ and nominalized with the say-root `[… V-TENSE g-ɘːš-CASE]`.
 
 ## Main definitions
 
-- `Buryat.Complementizer` — the say-root *gɘ*, the agentive participle
-  *-Aːša*, and the imperfective converb *-žA* ([skribnik-2003]), with
-  projections `form`, `verbForm`, and `host`
+- `Buryat.Complementizer` — index of the say-root *gɘ*, the agentive
+  participle *-Aːša*, and the imperfective converb *-žA*
+  ([skribnik-2003]); the feature rows are `Complementizer.entry`
+  values of the root `Complementizer` schema
 - `Buryat.hanaxa`, `Buryat.medexe`, `Buryat.xelexe`, `Buryat.duulaxa` —
   clause-embedding verbs; all four alternate between the finite-CP and
   nominalized (`.gerund`) frames (ex. 35–36, 50–51)
@@ -34,8 +35,8 @@ archiphonemes.
 
 namespace Buryat
 
-/-- The three clause-typing morphemes of the Barguzin Buryat embedded
-clause (§4.3.1 ex. 30–32). -/
+/-- Index of the three clause-typing morphemes of the Barguzin Buryat
+embedded clause (§4.3.1 ex. 30–32). Feature rows: `Complementizer.entry`. -/
 inductive Complementizer where
   /-- *gɘ* — grammaticalized root of *gɘxɘ* 'say' (fn. 21: no speech act
   entailed under 'hear' or 'see'). -/
@@ -48,34 +49,19 @@ inductive Complementizer where
   | zha
   deriving DecidableEq, Fintype, Repr
 
-namespace Complementizer
-
-/-- Surface form in Bondarenko's transliteration. Display only. -/
-def form : Complementizer → String
-  | .ge    => "gɘ"
-  | .aasha => "-Aːša"
-  | .zha   => "-žA"
-
-/-- The verb form each suffix derives: participle for *-Aːša*, converb
-for *-žA*; `none` for the root *gɘ*, which is not a suffix. -/
-def verbForm : Complementizer → Option UD.VerbForm
-  | .ge    => none
-  | .aasha => some .Part
-  | .zha   => some .Conv
-
-/-- Category of the adjacent projection licensing each suffix (§4.3.1). -/
-inductive Host where
-  | nominal
-  | verbal
-  deriving DecidableEq, Fintype, Repr
-
-/-- Licensing host of each suffix; `none` for the root *gɘ*. -/
-def host : Complementizer → Option Host
-  | .ge    => none
-  | .aasha => some .nominal
-  | .zha   => some .verbal
-
-end Complementizer
+/-- The lexical entry of each morpheme, in Bondarenko's transliteration.
+The root *gɘ* never surfaces unsuffixed (gɘ-žɘ, g-ɘːšɘ), so its
+attachment is left unrecorded; the *-Aːša* complement is
+Noonan-nominalized (case-marked, genitive subject) while the morpheme
+itself is a participle — two axes, two fields. -/
+def Complementizer.entry : Complementizer → _root_.Complementizer
+  | .ge    => { form := "gɘ" }
+  | .aasha => { form := "-Aːša", position := some .postfixed,
+                noonanType := some .nominalized,
+                verbForm := some .Part, host := some .nominal }
+  | .zha   => { form := "-žA", position := some .postfixed,
+                noonanType := some .indicative,
+                verbForm := some .Conv, host := some .verbal }
 
 /-! ### Clause-embedding verbs
 

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -1,5 +1,8 @@
 import Linglib.Semantics.Attitudes.ClauseDenotation.Content
 import Linglib.Semantics.Attitudes.ClauseDenotation.Situation
+import Linglib.Fragments.Buryat.Complementizers
+import Linglib.Fragments.Korean.Complementizers
+import Linglib.Fragments.Tigrinya.ClausePrefixes
 
 /-!
 # Bondarenko 2022: Anatomy of an Attitude [bondarenko-2022]
@@ -39,7 +42,7 @@ syntactic distinction in the left periphery (§1.1.1, paper ex. 1):
   predicate on minimal situations (Kratzer 1989). Lacks ContP.
 
 In some languages ContP is overtly exposed (Korean -ta declarative;
-Buryat gɔ 'say'); in others (English, Russian) it is null.
+Buryat gɘ 'say'); in others (English, Russian) it is null.
 
 ## Three substantive claims this file formalizes
 
@@ -83,9 +86,10 @@ Buryat gɔ 'say'); in others (English, Russian) it is null.
   + the L-analyticity argument. Worth its own file when the
   L-analyticity substrate is in place.
 - Buryat/Korean/Russian morphological exposition (ContP overt vs
-  null): would belong in per-language fragment files
-  (Fragments/Buryat, Fragments/Korean, Fragments/Russian) once
-  those exist.
+  null): lives in the per-language fragment files
+  (`Fragments/Buryat/Complementizers.lean`,
+  `Fragments/Korean/Complementizers.lean`; Russian has none yet),
+  consumed by the §12 exponence projections below.
 -/
 
 namespace Bondarenko2022
@@ -470,11 +474,13 @@ inductive SemType where
     compatible framing. -/
 inductive ClauseType where
   /-- Nominalized CP: type ⟨e⟩, refers to an individual (typically
-      with propositional content via CONT). Buryat *gɔ*-marked clause
-      with a participial nominaliser; Korean *-nun + kes* clause. -/
+      with propositional content via CONT). Buryat participial
+      nominalization — with or without the say-root *gɘ*
+      ([bondarenko-2022] §4.3.1 ex. 31–32); Korean *-nun + kes*
+      clause. -/
   | predicateOfIndividuals
   /-- Bare CP: type ⟨e,t⟩, predicate over (minimal) situations.
-      Buryat clause without *gɔ*; Korean *-ta* declarative; Russian
+      Buryat *gɘžɘ*-clause; Korean *-ta* declarative; Russian
       bare *čto*-clause. -/
   | predicateOfSituations
   deriving DecidableEq, Repr
@@ -647,22 +653,58 @@ theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
             fun _ => trivial⟩
 
 -- ════════════════════════════════════════════════════════════════
--- § 12. Cross-linguistic ContP-exponent paradigm
+-- § 12. Cross-linguistic ContP exponence
 -- ════════════════════════════════════════════════════════════════
 --
--- Per cross-framework auditor: Tigrinya *kemzi* (Cacchioli2025),
--- Buryat *gɔ* (Fragments/Buryat/Complementizers), Korean *-ta*
--- (Fragments/Korean/Complementizers) form a paradigm of overt ContP
--- exponents that Bondarenko's analysis predicts cross-linguistically.
--- This list is grep-discoverable for downstream typology work.
+-- Per-language overt Cont exponents under [bondarenko-2022]'s
+-- analysis, typed over the fragment morpheme inventories (imported,
+-- not re-stipulated): Buryat *gɘ* (§4.3.1), Korean *-ta* (§4.3.2,
+-- following [bogal-allbritten-moulton-2018]), extended with Tigrinya
+-- *kemzi* ([cacchioli-2025]). `none` is null exponence (English,
+-- Russian). The typed values ARE the paradigm; the former pooled
+-- `List (String × String)` display table was consumer-free and its
+-- rows had drifted from the fragments, so it was deleted.
 
-/-- Cross-linguistic overt exponents of ContP per
-    [bondarenko-2022]'s analysis (§4.3.1 Buryat, §4.3.2 Korean)
-    extended with Tigrinya *kemzi* ([cacchioli-2025]). -/
-def overtContPExponents : List (String × String) :=
-  [ ("Tigrinya",  "kemzi"),  -- [cacchioli-2025] factive
-    ("Buryat",    "gɔ"),     -- [bondarenko-2022] §4.3.1
-    ("Korean",    "-ta") ]   -- [bogal-allbritten-moulton-2018] / Bondarenko §4.3.2
+/-- Buryat: the say-root *gɘ* expones Cont ([bondarenko-2022] §4.3.1
+    ex. 33). This is the Studies-local projection the fragment's
+    scope note defers to. -/
+def buryatContExponent : Option Buryat.Complementizer := some .ge
+
+/-- Korean: *-ta* expones Cont ([bondarenko-2022] §4.3.2, following
+    [bogal-allbritten-moulton-2018]). -/
+def koreanContExponent : Option Korean.Complementizers.KoreanClauseSuffix :=
+  some .ta
+
+/-- Tigrinya: *kemzi* ([cacchioli-2025]). -/
+def tigrinyaContExponent : Option Tigrinya.ClausePrefixes.ClausePrefixEntry :=
+  some Tigrinya.ClausePrefixes.kemzi
+
+/-- [bondarenko-2022]'s Cont/Comp assignment coincides with the
+    fragment's root-vs-suffix datum: the Cont exponent is exactly the
+    non-suffixal (say-root) morpheme. -/
+theorem mem_buryatContExponent_iff (c : Buryat.Complementizer) :
+    c ∈ buryatContExponent ↔ c.verbForm = none := by
+  cases c <;> decide
+
+/-- The Comp head realized by adjacency-conditioned allomorphy
+    ([bondarenko-2022] §4.3.1 ex. 33): one head, two allomorphs —
+    participial *-Aːša* next to nominal projections, converbial *-žA*
+    next to verbs. -/
+def buryatCompAllomorph : Buryat.Complementizer.Host → Buryat.Complementizer
+  | .nominal => .aasha
+  | .verbal  => .zha
+
+/-- The allomorph selected for a host has exactly that surface
+    distribution — the analysis reproduces the fragment's datum. -/
+theorem host_buryatCompAllomorph (h : Buryat.Complementizer.Host) :
+    (buryatCompAllomorph h).host = some h := by
+  cases h <;> rfl
+
+/-- The head assignment is exhaustive: every clause-typing morpheme is
+    either the Cont exponent or a Comp allomorph. -/
+theorem contP_comp_cover (c : Buryat.Complementizer) :
+    c ∈ buryatContExponent ∨ ∃ h, buryatCompAllomorph h = c := by
+  cases c <;> decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13. Chapter 2 §2.2.3: noun-predicate co-occurrence diagnostics

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -664,7 +664,7 @@ theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
 
 /-- Buryat: the say-root *gɘ* expones Cont ([bondarenko-2022] §4.3.1
     ex. 33). -/
-def buryatContExponent : Option Buryat.Complementizer := some .ge
+def buryatContExponent : Option Complementizer := some Buryat.ge
 
 /-- Korean: *-ta* expones Cont ([bondarenko-2022] §4.3.2, following
     [bogal-allbritten-moulton-2018]). -/
@@ -678,29 +678,31 @@ def tigrinyaContExponent : Option Tigrinya.ClausePrefixes.ClausePrefixEntry :=
 /-- [bondarenko-2022]'s Cont/Comp assignment coincides with the
     fragment's root-vs-suffix datum: the Cont exponent is exactly the
     non-suffixal (say-root) morpheme. -/
-theorem mem_buryatContExponent_iff (c : Buryat.Complementizer) :
-    c ∈ buryatContExponent ↔ c.entry.verbForm = none := by
-  cases c <;> decide
+theorem mem_buryatContExponent_iff :
+    ∀ c ∈ Buryat.complementizers,
+      (c ∈ buryatContExponent ↔ c.verbForm = none) := by
+  decide
 
 /-- The Comp head realized by adjacency-conditioned allomorphy
     ([bondarenko-2022] §4.3.1 ex. 33): one head, two allomorphs —
     participial *-Aːša* next to nominal projections, converbial *-žA*
     next to verbs. -/
-def buryatCompAllomorph : Complementizer.Host → Buryat.Complementizer
-  | .nominal => .aasha
-  | .verbal  => .zha
+def buryatCompAllomorph : Complementizer.Host → Complementizer
+  | .nominal => Buryat.aasha
+  | .verbal  => Buryat.zha
 
 /-- The allomorph selected for a host has exactly that surface
     distribution — the analysis reproduces the fragment's datum. -/
 theorem host_buryatCompAllomorph (h : Complementizer.Host) :
-    (buryatCompAllomorph h).entry.host = some h := by
+    (buryatCompAllomorph h).host = some h := by
   cases h <;> rfl
 
-/-- The head assignment is exhaustive: every clause-typing morpheme is
-    either the Cont exponent or a Comp allomorph. -/
-theorem contP_comp_cover (c : Buryat.Complementizer) :
-    c ∈ buryatContExponent ∨ ∃ h, buryatCompAllomorph h = c := by
-  cases c <;> decide
+/-- The head assignment is exhaustive: every morpheme in the inventory
+    is either the Cont exponent or a Comp allomorph. -/
+theorem contP_comp_cover :
+    ∀ c ∈ Buryat.complementizers,
+      c ∈ buryatContExponent ∨ ∃ h, buryatCompAllomorph h = c := by
+  decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13. Chapter 2 §2.2.3: noun-predicate co-occurrence diagnostics

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -657,17 +657,13 @@ theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
 -- ════════════════════════════════════════════════════════════════
 --
 -- Per-language overt Cont exponents under [bondarenko-2022]'s
--- analysis, typed over the fragment morpheme inventories (imported,
--- not re-stipulated): Buryat *gɘ* (§4.3.1), Korean *-ta* (§4.3.2,
--- following [bogal-allbritten-moulton-2018]), extended with Tigrinya
--- *kemzi* ([cacchioli-2025]). `none` is null exponence (English,
--- Russian). The typed values ARE the paradigm; the former pooled
--- `List (String × String)` display table was consumer-free and its
--- rows had drifted from the fragments, so it was deleted.
+-- analysis, typed over the fragment morpheme inventories: Buryat *gɘ*
+-- (§4.3.1), Korean *-ta* (§4.3.2, following
+-- [bogal-allbritten-moulton-2018]), extended with Tigrinya *kemzi*
+-- ([cacchioli-2025]). `none` is null exponence (English, Russian).
 
 /-- Buryat: the say-root *gɘ* expones Cont ([bondarenko-2022] §4.3.1
-    ex. 33). This is the Studies-local projection the fragment's
-    scope note defers to. -/
+    ex. 33). -/
 def buryatContExponent : Option Buryat.Complementizer := some .ge
 
 /-- Korean: *-ta* expones Cont ([bondarenko-2022] §4.3.2, following

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -679,21 +679,21 @@ def tigrinyaContExponent : Option Tigrinya.ClausePrefixes.ClausePrefixEntry :=
     fragment's root-vs-suffix datum: the Cont exponent is exactly the
     non-suffixal (say-root) morpheme. -/
 theorem mem_buryatContExponent_iff (c : Buryat.Complementizer) :
-    c ∈ buryatContExponent ↔ c.verbForm = none := by
+    c ∈ buryatContExponent ↔ c.entry.verbForm = none := by
   cases c <;> decide
 
 /-- The Comp head realized by adjacency-conditioned allomorphy
     ([bondarenko-2022] §4.3.1 ex. 33): one head, two allomorphs —
     participial *-Aːša* next to nominal projections, converbial *-žA*
     next to verbs. -/
-def buryatCompAllomorph : Buryat.Complementizer.Host → Buryat.Complementizer
+def buryatCompAllomorph : Complementizer.Host → Buryat.Complementizer
   | .nominal => .aasha
   | .verbal  => .zha
 
 /-- The allomorph selected for a host has exactly that surface
     distribution — the analysis reproduces the fragment's datum. -/
-theorem host_buryatCompAllomorph (h : Buryat.Complementizer.Host) :
-    (buryatCompAllomorph h).host = some h := by
+theorem host_buryatCompAllomorph (h : Complementizer.Host) :
+    (buryatCompAllomorph h).entry.host = some h := by
   cases h <;> rfl
 
 /-- The head assignment is exhaustive: every clause-typing morpheme is

--- a/Linglib/Syntax/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Complementizer/Basic.lean
@@ -1,0 +1,85 @@
+import Linglib.Data.UD.Basic
+import Linglib.Features.ClauseForm
+import Linglib.Morphology.MorphRule
+import Linglib.Morphology.Word
+import Linglib.Syntax.Clause.Complementation
+
+/-!
+# Complementizer
+
+The lexical core of the complementizer (clause-typing morpheme) as a
+grammatical object, modeled on `Syntax/Pronoun/`: surface form plus the
+consensus clause-typing axes, each drawn from existing substrate —
+morphological attachment (`Morphology.FormativePosition`), the
+[noonan-2007] type of the clause it types, its `Features.ClauseForm`,
+the verb form an affixal clause-typer derives on its host (UD), the
+licensing host category, and factivity.
+
+Framework-specific head assignments (a cartographic Force/Fin split, a
+ContP-exponence claim, an [n]-feature) are not fields; they live as
+Studies-local projections over these entries (cf. `Adjective`'s deferred
+degree semantics).
+
+## Main declarations
+
+- `Complementizer` — the general complementizer object; per-language
+  fragments instantiate it (free subordinators like *that* and *oti*,
+  affixal clause-typers like Buryat *-žA* and Tigrinya *zɨ-*,
+  grammaticalized say-roots like Buryat *gɘ*)
+- `Complementizer.Host` — adnominal vs adverbal licensing category
+- `Complementizer.IsBound` — affixal status, derived from `position`
+- `Complementizer.toWord` — the `SCONJ` word a free complementizer
+  projects
+-/
+
+open Clause.Complementation (NoonanCompType)
+
+/-- Category of the projection an affixal clause-typer is licensed by:
+adnominal (Buryat *-Aːša*, Korean *-nun*) vs adverbal (Buryat *-žA*). -/
+inductive Complementizer.Host where
+  | nominal
+  | verbal
+  deriving DecidableEq, Fintype, Repr
+
+/-- The general complementizer object: the morphosyntactic core shared by
+clause-typing morphemes. Carries no denotation and no framework's head
+assignment (cf. `Pronoun`, `Adjective`). -/
+structure Complementizer where
+  /-- Surface form (romanization; affixes hyphenated). -/
+  form : String
+  /-- Native script form, when distinct. -/
+  script : Option String := none
+  /-- Morphological attachment: `.detached` for free subordinators,
+  `.praefixed` and `.postfixed` for affixal clause-typers. -/
+  position : Option Morphology.FormativePosition := none
+  /-- [noonan-2007] type of the complement clause this morpheme types. -/
+  noonanType : Option NoonanCompType := none
+  /-- Surface clause form typed (declarative vs embedded question). -/
+  clauseForm : Option Features.ClauseForm := none
+  /-- Verb form an affixal clause-typer derives on its host (UD `.Part`,
+  `.Conv`, `.Fin`, …). -/
+  verbForm : Option UD.VerbForm := none
+  /-- Licensing host category, for adjacency-conditioned clause-typers. -/
+  host : Option Complementizer.Host := none
+  /-- Factive presupposition; `none` = unrecorded. -/
+  factive : Option Bool := none
+  deriving Repr, BEq, DecidableEq
+
+namespace Complementizer
+
+/-- Bound (affixal) complementizer: recorded attachment other than
+`.detached`. Derived, not stored (cf. `Adjective.IsGradable`). -/
+def IsBound (c : Complementizer) : Prop :=
+  c.position ≠ none ∧ c.position ≠ some .detached
+
+instance : DecidablePred IsBound := fun c => by
+  unfold IsBound; infer_instance
+
+/-- Free complementizers project a `SCONJ` word (cf. `Pronoun.toWord`);
+affixal clause-typers project no word of their own. -/
+def toWord (c : Complementizer) : Option Word :=
+  if c.position = some .detached then
+    some { form := c.form, cat := .SCONJ }
+  else none
+
+end Complementizer

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -33653,10 +33653,64 @@
   volume    = {5},
   number    = {1},
   pages     = {1--35},
-  doi       = {10.5334/gjgl.1108},
+  doi       = {10.5334/gjgl.1196},
   subfield  = {syntax},
   role      = {cited},
   sources   = {Fragments/Buryat/Complementizers.lean;Phenomena/Complementation/Studies/Bondarenko2022.lean}
+}
+
+@inproceedings{bondarenko-2019,
+  author    = {Bondarenko, Tatiana},
+  year      = {2019},
+  title     = {From think to remember: {H}ow {CP}s and {NP}s combine with attitudes in {B}uryat},
+  booktitle = {Proceedings of {SALT} 29},
+  pages     = {509--528},
+  doi       = {10.3765/salt.v29i0.4605},
+  subfield  = {semantics},
+  role      = {cited},
+  sources   = {Fragments/Buryat/Complementizers.lean}
+}
+
+@incollection{knyazev-2016,
+  author    = {Knyazev, Mikhail},
+  year      = {2016},
+  title     = {Complementizers in {K}almyk},
+  booktitle = {Complementizer Semantics in European Languages},
+  editor    = {Boye, Kasper and Kehayov, Petar},
+  pages     = {665--689},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  doi       = {10.1515/9783110416619-019},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Fragments/Buryat/Complementizers.lean}
+}
+
+@article{matic-pakendorf-2013,
+  author    = {Mati{\'c}, Dejan and Pakendorf, Brigitte},
+  year      = {2013},
+  title     = {Non-canonical {SAY} in {S}iberia: {A}real and genealogical patterns},
+  journal   = {Studies in Language},
+  volume    = {37},
+  number    = {2},
+  pages     = {356--412},
+  doi       = {10.1075/sl.37.2.04mat},
+  subfield  = {typology},
+  role      = {cited},
+  sources   = {Fragments/Buryat/Complementizers.lean}
+}
+
+@incollection{skribnik-2003,
+  author    = {Skribnik, Elena},
+  year      = {2003},
+  title     = {Buryat},
+  booktitle = {The Mongolic Languages},
+  editor    = {Janhunen, Juha},
+  publisher = {Routledge},
+  address   = {London},
+  subfield  = {typology},
+  role      = {cited},
+  sources   = {Fragments/Buryat/Complementizers.lean}
 }
 
 @article{barwise-1981,


### PR DESCRIPTION
Random-file audit of the Buryat complementizer fragment (vs the Bondarenko 2022 dissertation + 2020 Glossa paper) found the morphology garbled and the headline theorem false to the source; the fix grew the missing lexical API.

- New `Syntax/Complementizer/Basic.lean`: root `Complementizer` entry schema on the `Pronoun`/`Adjective` pattern — form, `Morphology.FormativePosition`, `NoonanCompType`, `Features.ClauseForm`, UD `verbForm`, licensing `Host`, factivity; derived `IsBound`, `toWord`. Framework-specific head assignments stay Studies-local.
- Buryat fragment rewritten on verified facts: say-root *gɘ* (not "gɔ"), *hanaxa* (not "xanaxa"); *-Aːša* ~ *-žA* are Comp allomorphs by N- vs V-adjacency (agentive participle vs imperfective converb, Skribnik 2003), not aspect-split "participial nominalisers"; fabricated *boloxo* replaced by attested *duːlaxa*; all four verbs carry the real finite-CP ~ nominalized alternation (killing the false `only_xanaxa_alternates`). Inventory = index enum + `Complementizer.entry` rows of the root schema.
- `Studies/Bondarenko2022.lean` §12 imports the Buryat/Korean/Tigrinya fragments: Option-typed Cont-exponent projections + three decide-theorems tying the analysis to fragment data, replacing the consumer-free string table whose rows had drifted; fixes the backwards bare-CP docstring.
- `references.bib`: wrong bondarenko-2020 DOI fixed (gjgl.1108 → gjgl.1196); verified bondarenko-2019, knyazev-2016, matic-pakendorf-2013, skribnik-2003 added; fabricated "Stassen" attribution and phantom `[bondarenko-2017]` key removed.

Follow-up PR planned: migrate Korean/Greek/Tigrinya/English fragments onto the core.