### PR TITLE
feat(Studies/Angelopoulos2026): oti/pu reversed selection + sibling migrations

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1977,6 +1977,7 @@ import Linglib.Studies.Amato2025Auxiliary
 import Linglib.Studies.AnandHacquard2013
 import Linglib.Studies.AnandHardtMcCloskey2021
 import Linglib.Studies.AnandNevins2004
+import Linglib.Studies.Angelopoulos2026
 import Linglib.Studies.Anderson2006
 import Linglib.Studies.Anderson2021
 import Linglib.Studies.AndersonJM2006

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -50,7 +50,7 @@ def aasha : Complementizer where
   position := some .postfixed
   noonanType := some .nominalized
   verbForm := some .Part
-  host := some .nominal
+  licenser := some .nominal
 
 /-- *-žA* — imperfective converb ([skribnik-2003]); appears next to
 verbs, also in analytical verb forms and sentential adjuncts (ex. 30). -/
@@ -59,7 +59,7 @@ def zha : Complementizer where
   position := some .postfixed
   noonanType := some .indicative
   verbForm := some .Conv
-  host := some .verbal
+  licenser := some .verbal
 
 /-- The clause-typing inventory — closed per §4.3.1 ex. 30–32. -/
 def complementizers : List Complementizer := [ge, aasha, zha]

--- a/Linglib/Fragments/English/Complementizers.lean
+++ b/Linglib/Fragments/English/Complementizers.lean
@@ -1,43 +1,54 @@
-import Linglib.Data.UD.Basic
-import Linglib.Morphology.Word
+import Linglib.Syntax.Complementizer.Basic
 
 /-!
 # English Complementizers Lexicon Fragment
 
-Lexical entries for English subordinating complementizers: `that`,
-`if`, `whether`, `because`, `although`, `while`. Surface-form
-classification (question-introducing, conditional-introducing,
-optional) only — semantic clauses live in the relevant Theory or
-Study files.
+Lexical entries for the English complementizers *that*, *if*, *whether*,
+as root `Complementizer` entries extended with the English-specific
+flags (`conditional`, `optional`). *if* is split between conditional and
+embedded-question uses; the single entry carries both.
 
-`if` is split between conditional and embedded-question uses; the
-single Fragment entry carries both flags. The morphologically distinct
-preposition *to* and the infinitival particle *to* live in
+The adverbial subordinators *because*, *although*, *while* are not
+complementizers (adverbial subordination is outside complementation,
+[noonan-2007]); they are plain `SCONJ` words below. The morphologically
+distinct preposition *to* and the infinitival particle *to* live in
 `Auxiliaries.lean` and `FunctionWords.lean` respectively.
 -/
 
 namespace English.Complementizers
 
-structure CompEntry where
-  form : String
-  /-- Introduces a question? -/
-  question : Bool := false
-  /-- Introduces a conditional? -/
+/-- An English complementizer entry: the root schema plus the
+English-specific flags. -/
+structure CompEntry extends Complementizer where
+  /-- Introduces a conditional protasis (*if*)? -/
   conditional : Bool := false
-  /-- Can be omitted? -/
+  /-- Can be omitted (that-drop)? -/
   optional : Bool := false
-  deriving Repr, BEq
+  deriving Repr, BEq, DecidableEq
 
-def that : CompEntry := { form := "that", optional := true }
-def if_ : CompEntry := { form := "if", question := true, conditional := true }
-def whether : CompEntry := { form := "whether", question := true }
-def because : CompEntry := { form := "because" }
-def although : CompEntry := { form := "although" }
-def while_ : CompEntry := { form := "while" }
+def that : CompEntry :=
+  { form := "that", position := some .detached,
+    noonanType := some .indicative, clauseForm := some .declarative,
+    optional := true }
 
-def allComplementizers : List CompEntry := [that, if_, whether, because, although, while_]
+def if_ : CompEntry :=
+  { form := "if", position := some .detached,
+    clauseForm := some .embeddedQuestion, conditional := true }
 
-def CompEntry.toWord (c : CompEntry) : Word :=
-  { form := c.form, cat := .SCONJ, features := {} }
+def whether : CompEntry :=
+  { form := "whether", position := some .detached,
+    clauseForm := some .embeddedQuestion }
+
+/-- The complementizer inventory (adverbial subordinators excluded). -/
+def allComplementizers : List CompEntry := [that, if_, whether]
+
+/-! ### Adverbial subordinators
+
+Not complementizers ([noonan-2007] excludes adverbial subordination);
+recorded as plain subordinating-conjunction words. -/
+
+def because : Word := { form := "because", cat := .SCONJ }
+def although : Word := { form := "although", cat := .SCONJ }
+def while_ : Word := { form := "while", cat := .SCONJ }
 
 end English.Complementizers

--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -1,84 +1,50 @@
 import Linglib.Semantics.Verb.Basic
+import Linglib.Syntax.Complementizer.Basic
 
 /-!
 # Modern Greek Complementizers [christidis-1982] [roussou-2010]
 [roussou-2019] [angelopoulos-2026]
 
-The three Modern Greek complementizers and a small inventory of
-matrix verbs that select them. Consensus-only metadata: form, mood
-(indicative / subjunctive / factive), categorial [n]-feature, and
-the stativity / attitude classification of the matrix verbs.
+The three Modern Greek complementizers, as root `Complementizer`
+entries, and the matrix verbs that select them (with the attitude and
+stativity metadata [angelopoulos-2026]'s data turns on).
 
-## Scope
-
-This file exposes ONLY consensus typological metadata. The
-content/situation typing of the matrix-verb selection that
-[angelopoulos-2026] introduces (following [bondarenko-2022])
-is paper-specific apparatus and lives in
-`Studies/Angelopoulos2026.lean` as a
-projection over these `Verb` entries — it does not pollute the
-fragment schema.
-
-## Three complementizers
-
-- *oti* — indicative declarative ([christidis-1982],
-  [roussou-2010]). Combines with verbs of saying / belief /
-  knowledge. Bears an uninterpretable [n]-feature checked by a
-  light noun in its specifier per [angelopoulos-2026] §3.1.
-- *pu* — factive declarative ([christidis-1982],
-  [roussou-2019]). Combines with emotive factives and
-  doubles as adverbial / relative / interrogative pronoun *where*.
-  Bears the same [n]-feature as *oti*.
-- *na* — subjunctive ([grano-2024]). Already covered in
-  `Greek.StandardModern.MoodChoice`; referenced here
-  for completeness, not redefined.
+[angelopoulos-2026]-specific apparatus — the [n]-feature/light-noun
+selection (§3.1), the content/situation typing, and the stativity
+generalizations — lives in `Studies/Angelopoulos2026.lean` as
+projections over these entries.
 -/
 
 namespace Greek.StandardModern.Complementizers
 
+/-- *oti* — indicative declarative complementizer ([christidis-1982],
+    [roussou-2010]); selected by verbs of saying / belief / knowledge. -/
+def oti : Complementizer where
+  form := "oti"
+  position := some .detached
+  noonanType := some .indicative
+  clauseForm := some .declarative
+  factive := some false
 
--- ════════════════════════════════════════════════════════════════
--- § 1. Complementizer Inventory
--- ════════════════════════════════════════════════════════════════
+/-- *pu* — factive complementizer ([christidis-1982], [roussou-2019]);
+    selected by emotive factives. Doubles as adverbial / relative /
+    interrogative *where*; the entry records the complement use. -/
+def pu : Complementizer where
+  form := "pu"
+  position := some .detached
+  noonanType := some .indicative
+  clauseForm := some .declarative
+  factive := some true
 
-/-- The three Modern Greek complementizers covered here. *na* is
-    in `MoodChoice.lean`; `GreekComplementizer.na` is exposed for
-    cross-reference but the substantive entries live there. -/
-inductive GreekComplementizer where
-  | oti
-  | pu
-  | na
-  deriving DecidableEq, Repr
+/-- *na* — subjunctive ([grano-2024]); the substantive mood entries are
+    in `MoodChoice.lean`, exposed here for inventory completeness. -/
+def na : Complementizer where
+  form := "na"
+  position := some .detached
+  noonanType := some .subjunctive
 
-/-- Phonological form. -/
-def GreekComplementizer.form : GreekComplementizer → String
-  | .oti => "oti"
-  | .pu  => "pu"
-  | .na  => "na"
-
-/-- Bears an uninterpretable [n]-feature checked by a light noun
-    in Spec,CP per [angelopoulos-2026] §3.1.  *na* does not
-    bear [n]; its checking machinery is mood-driven ([grano-2024]). -/
-def GreekComplementizer.bearsN : GreekComplementizer → Bool
-  | .oti => true
-  | .pu  => true
-  | .na  => false
-
-/-- Factive presupposition (consensus across [christidis-1982],
-    [roussou-2010], [roussou-2019], [angelopoulos-2026]). -/
-def GreekComplementizer.isFactive : GreekComplementizer → Bool
-  | .pu => true
-  | _   => false
-
-/-- All three are finite. -/
-theorem all_finite (c : GreekComplementizer) : c.form.length > 0 := by
-  cases c <;> decide
-
-/-- *oti* and *pu* both bear the [n]-feature; *na* does not. -/
-theorem n_bearing_complementizers :
-    GreekComplementizer.oti.bearsN = true ∧
-    GreekComplementizer.pu.bearsN  = true ∧
-    GreekComplementizer.na.bearsN  = false := ⟨rfl, rfl, rfl⟩
+/-- The complementizer inventory. -/
+def complementizers : List Complementizer := [oti, pu, na]
 
 -- ════════════════════════════════════════════════════════════════
 -- § 2. Matrix Verbs Selecting *oti*
@@ -187,7 +153,6 @@ def xerome : Verb where
 def thimame : Verb where
   form := "thimáme"
   complementType := .finiteClause
-  altComplementType := some .finiteClause  -- pu-complement available
   attitude := some (.doxastic .veridical)
   vendlerClass := some .achievement  -- eventive (perception) sense
 
@@ -197,29 +162,7 @@ def thimame : Verb where
 def thimono : Verb where
   form := "thimóno"
   complementType := .finiteClause
-  altComplementType := some .finiteClause
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .achievement
-
--- ════════════════════════════════════════════════════════════════
--- § 5. Theorems on consensus stativity
--- ════════════════════════════════════════════════════════════════
-
-/-- The *pu*-only verbs are all stative. This is the consensus
-    pattern ([angelopoulos-2026] §2.3, restating the diagnostic
-    from [roussou-2019]). -/
-theorem pu_only_verbs_stative :
-    metaniono.vendlerClass = some .state ∧
-    areso.vendlerClass     = some .state ∧
-    xerome.vendlerClass    = some .state := ⟨rfl, rfl, rfl⟩
-
-/-- The *oti*-only verbs span eventive and stative classes:
-    *léo*, *katalavéno*, *sinidhitopió*, *eksigó* are eventive;
-    *pistévo* and *kséro* are stative. -/
-theorem oti_verbs_stativity_split :
-    leo.vendlerClass = some .activity ∧
-    katalaveno.vendlerClass = some .achievement ∧
-    pistevo.vendlerClass = some .state ∧
-    ksero.vendlerClass = some .state := ⟨rfl, rfl, rfl, rfl⟩
 
 end Greek.StandardModern.Complementizers

--- a/Linglib/Fragments/Korean/Complementizers.lean
+++ b/Linglib/Fragments/Korean/Complementizers.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Verb.Basic
+import Linglib.Syntax.Complementizer.Basic
 
 /-!
 # Korean Complementizers and Clause-Embedding Verbs
@@ -54,41 +55,34 @@ namespace Korean.Complementizers
 -- § 1. Clause-typing morpheme inventory
 -- ════════════════════════════════════════════════════════════════
 
-/-- The three clause-typing morphemes covered here. -/
-inductive KoreanClauseSuffix where
-  /-- *-ta* — declarative ending. Bondarenko-specific decomposition
-      treats it as overt ContP per [bogal-allbritten-moulton-2018];
-      the consensus view (Shim & Ihsane 2015, M.-J. Kim 2009) treats
-      it as a clause-typing morpheme without that specific structural
-      decomposition. -/
-  | ta
-  /-- *-nun* — adnominal ending; turns a clause into a noun modifier
-      (typically followed by *kes* "thing" in nominalized clauses). -/
-  | nun
-  /-- *-ko* — connective / quotative complementizer. -/
-  | ko
-  deriving DecidableEq, Repr
+/-- *-ta* — declarative ending. [bondarenko-2022] §4.3.2 (following
+    [bogal-allbritten-moulton-2018]) analyses it as the overt ContP
+    exponent — that decomposition is Studies-local
+    (`Bondarenko2022.koreanContExponent`); the consensus view
+    (Shim & Ihsane 2015, [kim-min-joo-2009]) treats it as a
+    clause-typing morpheme without that structural decomposition. -/
+def ta : Complementizer where
+  form := "-ta"
+  position := some .postfixed
+  verbForm := some .Fin
+  clauseForm := some .declarative
 
-/-- Phonological form. -/
-def KoreanClauseSuffix.form : KoreanClauseSuffix → String
-  | .ta  => "-ta"
-  | .nun => "-nun"
-  | .ko  => "-ko"
+/-- *-nun* — adnominal ending; turns a clause into a noun modifier
+    (typically followed by *kes* 'thing' in nominalized clauses). -/
+def nun : Complementizer where
+  form := "-nun"
+  position := some .postfixed
+  verbForm := some .Part
+  licenser := some .nominal
 
-/-- Whether the suffix typically appears in nominalized clauses
-    (consensus across analyses, including Bondarenko, M.-J. Kim,
-    Shim & Ihsane). The adnominal *-nun* is the canonical
-    nominalization morpheme; *-ta* and *-ko* are not. -/
-def KoreanClauseSuffix.isAdnominal : KoreanClauseSuffix → Bool
-  | .nun => true
-  | _    => false
+/-- *-ko* — connective / quotative complementizer. -/
+def ko : Complementizer where
+  form := "-ko"
+  position := some .postfixed
+  verbForm := some .Conv
 
-/-- The three suffixes are pairwise distinct. -/
-theorem suffixes_distinct :
-    KoreanClauseSuffix.ta ≠ .nun ∧
-    KoreanClauseSuffix.ta ≠ .ko ∧
-    KoreanClauseSuffix.nun ≠ .ko := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+/-- The clause-typing inventory. -/
+def complementizers : List Complementizer := [ta, nun, ko]
 
 -- ════════════════════════════════════════════════════════════════
 -- § 2. The lexical noun *kes*
@@ -97,8 +91,7 @@ theorem suffixes_distinct :
 /-- *kes* — 'thing'. Light noun analysed by [kim-min-joo-2009]
     as null-D + N. Combines with an adnominal *-nun*-marked clause
     to yield a nominalized DP that can saturate argument slots. -/
-def kes : { form : String // form = "kes" } :=
-  ⟨"kes", rfl⟩
+def kes : Word := { form := "kes", cat := .NOUN }
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3. Matrix verb entries
@@ -142,19 +135,5 @@ def selmyenghata : Verb where
   form := "selmyengha-ta"
   complementType := .finiteClause
   vendlerClass := some .accomplishment
-
--- ════════════════════════════════════════════════════════════════
--- § 4. Theorems
--- ════════════════════════════════════════════════════════════════
-
-/-- Stativity split: *yukamsulewehay-ta* and *mit-ta* are stative;
-    *sayngkakha-ta*, *haysekha-ta*, *selmyengha-ta* are eventive. -/
-theorem stativity_split :
-    yukamsulewehayta.vendlerClass = some .state ∧
-    mitta.vendlerClass = some .state ∧
-    sayngkakhata.vendlerClass = some .activity ∧
-    haysekhata.vendlerClass = some .activity ∧
-    selmyenghata.vendlerClass = some .accomplishment :=
-  ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 end Korean.Complementizers

--- a/Linglib/Fragments/Tigrinya/ClausePrefixes.lean
+++ b/Linglib/Fragments/Tigrinya/ClausePrefixes.lean
@@ -1,21 +1,22 @@
-import Linglib.Syntax.Minimalist.SyntacticObject.Build
+import Linglib.Syntax.Complementizer.Basic
 import Linglib.Morphology.MorphWord
 
 /-!
 # Tigrinya Clausal Prefixes [cacchioli-2025]
 [pollock-1989] [rizzi-1997]
 
-Lexical entries for Tigrinya's four clause-initial morphemes, analyzed as
-spell-outs of distinct heads in a cartographic left periphery.
+Lexical entries for Tigrinya's four clause-initial morphemes, as
+`Complementizer`-schema entries with the Tigrinya-specific fields
+(`gloss`, `clauseType`, circumfixal `suffix_`).
 
 ## The four prefixes
 
-| Prefix | Gloss | Head | Clause type |
-|--------|-------|------|-------------|
-| zɨ-    | REL   | Rel  | relative / general subordination |
-| kɨ-    | SBJV  | Fin  | subjunctive / irrealis |
-| kəmzi- | COMP  | Force | factive complementizer |
-| ʔay-...-n | NEG | Neg  | negative (circumfix) |
+| Prefix | Gloss | Clause type |
+|--------|-------|-------------|
+| zɨ-    | REL   | relative / general subordination |
+| kɨ-    | SBJV  | subjunctive / irrealis |
+| kəmzi- | COMP  | factive complementizer |
+| ʔay-...-n | NEG | negative (circumfix) |
 
 ## Key empirical facts
 
@@ -27,16 +28,14 @@ spell-outs of distinct heads in a cartographic left periphery.
 5. **Selection**: Matrix verb class determines which prefix appears
    (knowledge → kəmzi-, desiderative → kɨ-, etc.)
 
+[cacchioli-2025]'s cartographic head assignment (zɨ- = Rel, kɨ- = Fin,
+kəmzi- = Force, ʔay- = Neg in a [rizzi-1997] split CP) is paper-specific
+and lives as the `headCat` projection in `Studies/Cacchioli2025.lean`.
 -/
 
 namespace Tigrinya.ClausePrefixes
 
-open Minimalist
 open Morphology.Circumfix
-
--- ============================================================================
--- Clause type
--- ============================================================================
 
 /-- Clause types in Tigrinya, determined by the clausal prefix. -/
 inductive TigrinyaClauseType where
@@ -47,91 +46,66 @@ inductive TigrinyaClauseType where
   | matrix         -- unmarked: root declarative
   deriving DecidableEq, Repr
 
--- ============================================================================
--- Clausal prefix entry
--- ============================================================================
-
-/-- A Tigrinya clausal prefix lexical entry. -/
-structure ClausePrefixEntry where
-  /-- Surface form of the prefix -/
-  prefix_ : String
+/-- A Tigrinya clausal prefix lexical entry: the root `Complementizer`
+schema plus the Tigrinya-specific fields. The form is the prefix half;
+the discontinuous negative also sets `suffix_`. -/
+structure ClausePrefixEntry extends Complementizer where
   /-- Gloss -/
   gloss : String
-  /-- Syntactic head this prefix spells out -/
-  headCat : Cat
   /-- Clause type selected -/
   clauseType : TigrinyaClauseType
-  /-- Whether the prefix takes an agreement suffix -/
-  takesAgreementSuffix : Bool
-  /-- Whether the exponence is discontinuous (circumfix) -/
-  isDiscontinuous : Bool := false
   /-- Suffix form for circumfixes (empty if not discontinuous) -/
   suffix_ : String := ""
-  deriving Repr, BEq
+  deriving Repr, BEq, DecidableEq
 
--- ============================================================================
--- Lexical entries
--- ============================================================================
-
-/-- zɨ- : relativizer / general subordinator.
-    Spells out Rel. Does not take agreement.
+/-- zɨ- : relativizer / general subordinator. Does not take agreement.
     "zɨ-mäs'ə" = REL-come = "who came" -/
 def zi : ClausePrefixEntry where
-  prefix_ := "zɨ-"
+  form := "zɨ-"
+  position := some .praefixed
+  agrees := some false
   gloss := "REL"
-  headCat := .Rel
   clauseType := .relative
-  takesAgreementSuffix := false
 
-/-- kɨ- : subjunctive / irrealis marker.
-    Spells out Fin with [-finite].
+/-- kɨ- : subjunctive / irrealis marker. Takes an agreement suffix.
     Selected by desiderative/manipulative verbs.
     "kɨ-mäs'ə" = SBJV-come = "to come" -/
 def ki : ClausePrefixEntry where
-  prefix_ := "kɨ-"
+  form := "kɨ-"
+  position := some .praefixed
+  noonanType := some .subjunctive
+  agrees := some true
   gloss := "SBJV"
-  headCat := .Fin
   clauseType := .subjunctive
-  takesAgreementSuffix := true
 
-/-- kəmzi- : factive complementizer.
-    Spells out Force ([rizzi-1997] split-CP).
-    Selected by knowledge/commentative verbs.
-    "kəmzi-mäs'ə" = COMP-come = "that (he) came" (factive) -/
+/-- kəmzi- : factive complementizer. Selected by knowledge/commentative
+    verbs. "kəmzi-mäs'ə" = COMP-come = "that (he) came" (factive) -/
 def kemzi : ClausePrefixEntry where
-  prefix_ := "kəmzi-"
+  form := "kəmzi-"
+  position := some .praefixed
+  noonanType := some .indicative
+  agrees := some false
+  factive := some true
   gloss := "COMP.FACT"
-  headCat := .Force
   clauseType := .factive
-  takesAgreementSuffix := false
 
-/-- ʔay-...-n : negative circumfix.
-    Spells out Neg.
-    The verbal stem is wrapped: ʔay-mäs'ə-n = NEG-come-NEG = "did not come".
-    Discontinuous exponence derived from V-to-Neg head movement. -/
+/-- ʔay-...-n : negative circumfix. The verbal stem is wrapped:
+    ʔay-mäs'ə-n = NEG-come-NEG = "did not come". Discontinuous exponence
+    derived from V-to-Neg head movement. -/
 def ay_n : ClausePrefixEntry where
-  prefix_ := "ʔay-"
+  form := "ʔay-"
+  position := some .circumfixed
+  agrees := some true
   gloss := "NEG"
-  headCat := .Neg
   clauseType := .negative
-  takesAgreementSuffix := true
-  isDiscontinuous := true
   suffix_ := "-n"
-
--- ============================================================================
--- Collections
--- ============================================================================
 
 /-- All four clausal prefix entries. -/
 def allPrefixes : List ClausePrefixEntry := [zi, ki, kemzi, ay_n]
 
--- ============================================================================
--- Circumfix construction
--- ============================================================================
-
 /-- Construct a `CircumfixExponence` from the negative circumfix entry. -/
 def negCircumfix (verbStem : String) : CircumfixExponence where
-  prefix_ := ay_n.prefix_
+  prefix_ := ay_n.form
   suffix_ := ay_n.suffix_
   stem := verbStem
   gloss := ay_n.gloss
@@ -139,19 +113,5 @@ def negCircumfix (verbStem : String) : CircumfixExponence where
 /-- The negative circumfix surfaces correctly. -/
 theorem neg_circumfix_example :
     (negCircumfix "mäs'ə").realize = "ʔay-mäs'ə-n" := rfl
-
--- ============================================================================
--- Per-entry verification theorems
--- ============================================================================
-
-theorem zi_targets_rel : zi.headCat = .Rel := rfl
-theorem ki_targets_fin : ki.headCat = .Fin := rfl
-theorem kemzi_targets_force : kemzi.headCat = .Force := rfl
-theorem ay_targets_neg : ay_n.headCat = .Neg := rfl
-
-theorem zi_no_agreement : zi.takesAgreementSuffix = false := rfl
-theorem ki_has_agreement : ki.takesAgreementSuffix = true := rfl
-theorem ay_is_discontinuous : ay_n.isDiscontinuous = true := rfl
-theorem ki_is_continuous : ki.isDiscontinuous = false := rfl
 
 end Tigrinya.ClausePrefixes

--- a/Linglib/Semantics/Attitudes/ClauseDenotation/Content.lean
+++ b/Linglib/Semantics/Attitudes/ClauseDenotation/Content.lean
@@ -42,7 +42,6 @@ closure:
 ## Cross-Linguistic Variation
 
 - English *that*-clauses: predicates (type ⟨e,st⟩), combine by PM
-- Korean *ko*-clauses: saturators (type e), function-apply directly
 - German *dass*-clauses: position from V2/cluster, not from CP-as-argument
 
 -/

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -1,0 +1,223 @@
+import Linglib.Studies.Bondarenko2022
+import Linglib.Fragments.Greek.StandardModern.Complementizers
+
+/-!
+# Angelopoulos 2026: On clausal complementation, once more
+[angelopoulos-2026]
+
+Greek *oti*- and *pu*-clauses present three puzzles (§1): near-
+complementary distribution after verbs (*oti* with saying/belief, *pu*
+with emotive factives, ex. 1); freedom as internal arguments and
+derived subjects but a ban from external-argument position (§2.2); and
+a novel stativity restriction on complement *pu*-clauses (§2.3).
+
+The analysis reverses selection (§3.1): *oti* and *pu* bear an
+uninterpretable [n]-feature checked by a light noun merged in their
+specifier (partly adopting Arsenijević 2009; the paper is neutral on
+the categorial status of *oti* and *pu*, fn. 3). The noun must
+incorporate into a lexical verbal head — possible from complement
+position, impossible from Spec,vP (nearest head T) or under P — which
+derives the argument asymmetry and the P-ban (§3.1 ex. 27–32). The
+*oti* ~ *pu* distribution follows from the content/situation dichotomy
+(§3.2, adopting [bondarenko-2022]); the stativity restriction from
+aspectual-head selection (§4.1: vState selects both otiP and puP,
+vEvent only otiP). §7.1 extends the adjunct-selection account to
+Uyghur *dep* (= *de* 'say' + converb *-ip*, per Major 2024) — the
+structural parallel of Buryat *gɘ-žɘ*.
+
+§7.3 departs from [bondarenko-2022]'s transparent syntax–semantics
+mapping: bare *oti*-clauses are merged in COMPLEMENT position (the §2
+argumenthood diagnostics: clitic doubling, passivization, derived
+subjects) while composing via Predicate Modification (the explanans
+reading, [elliott-2020-embedding]) — the same syntactic position
+yields either composition mode.
+
+## Main declarations
+
+- `bearsN` — the §3.1 [n]-feature datum over the fragment entries
+- `NounHost`, `ClausePosition`, `licensedIn` — the incorporation
+  mechanism and the derived argument-position asymmetry
+- `selectsClause`, `pu_requires_stative` — the §4.1 stativity locus
+- `clauseSort` — *oti* = content, *pu* = situation, consuming
+  `Bondarenko2022.NominalSort` (§3.2 ex. 33–34)
+- `bareOtiAttested`, `transparency_conflates_axes` — the §7.3
+  counterclaim against `Bondarenko2022.transparentSSMapping`
+-/
+
+namespace Angelopoulos2026
+
+open Greek.StandardModern.Complementizers
+open Bondarenko2022 (NominalSort)
+
+/-! ### Reversed selection: the [n]-feature (§3.1) -/
+
+/-- *oti* and *pu* bear an uninterpretable [n]-feature checked by a
+light noun merged in their specifier (§3.1); *na* does not (its
+licensing is mood-driven). Paper-specific datum projected over the
+fragment entries; the paper is neutral on the category of *oti* and
+*pu* (fn. 3). -/
+def bearsN (c : Complementizer) : Prop := c = oti ∨ c = pu
+
+instance : DecidablePred bearsN := fun c => by
+  unfold bearsN; infer_instance
+
+/-! ### Incorporation licensing and the argument asymmetry (§3.1) -/
+
+/-- Heads adjacent to a clause's light noun. Only a lexical verbal
+head licenses noun incorporation ([hale-keyser-1993]); functional T
+and P do not (§3.1 ex. 29–32). -/
+inductive NounHost where
+  | vLex
+  | t
+  | p
+  deriving DecidableEq, Fintype, Repr
+
+/-- Whether a host licenses light-noun incorporation. -/
+def NounHost.licenses : NounHost → Prop
+  | .vLex => True
+  | .t    => False
+  | .p    => False
+
+/-- Positions a bare oti/pu-clause can occupy, each with the nearest
+potential incorporation host: internal arguments sit under an
+aspectual v; incorporation precedes movement for derived subjects;
+the nearest head above Spec,vP is T; P cannot host (§3.1 ex. 27–32). -/
+inductive ClausePosition where
+  | internalArgument
+  | derivedSubject
+  | externalArgument
+  | pComplement
+  deriving DecidableEq, Fintype, Repr
+
+/-- The nearest potential incorporation host from each position. -/
+def ClausePosition.nearestHost : ClausePosition → NounHost
+  | .internalArgument => .vLex
+  | .derivedSubject   => .vLex
+  | .externalArgument => .t
+  | .pComplement      => .p
+
+/-- A bare oti/pu-clause is licensed in a position iff the nearest
+host licenses light-noun incorporation — the paper's derivation of
+the distribution, not a stipulated table. -/
+def licensedIn (pos : ClausePosition) : Prop := pos.nearestHost.licenses
+
+/-- Internal arguments and derived subjects are licensed (§2.1–2.2). -/
+theorem internal_and_derived_subject_licensed :
+    licensedIn .internalArgument ∧ licensedIn .derivedSubject :=
+  ⟨trivial, trivial⟩
+
+/-- The external-argument ban (§2.2): T cannot host incorporation. -/
+theorem external_argument_banned : ¬ licensedIn .externalArgument :=
+  fun h => h
+
+/-- Bare clauses are excluded after P (ex. 31c, 32c). -/
+theorem p_complement_banned : ¬ licensedIn .pComplement :=
+  fun h => h
+
+/-! ### The stativity locus (§4.1) -/
+
+/-- Aspectual heads introducing internal arguments (§4.1, following
+Borer and Merchant as cited there). -/
+inductive AspectualHead where
+  | vState
+  | vEvent
+  deriving DecidableEq, Fintype, Repr
+
+/-- §4.1: vState selects both otiP and puP as its complement; vEvent
+selects only otiP. -/
+def selectsClause : AspectualHead → Complementizer → Prop
+  | .vState, c => c = oti ∨ c = pu
+  | .vEvent, c => c = oti
+
+/-- The stativity restriction (§2.3), derived: a *pu*-complement
+forces the stative aspectual head. -/
+theorem pu_requires_stative (h : AspectualHead)
+    (hp : selectsClause h pu) : h = .vState := by
+  cases h
+  · rfl
+  · exact absurd (show pu = oti from hp) (by decide)
+
+/-- The verb-level reflex over the fragment sample: the *pu*-only
+matrix verbs (ex. 1b, 13–14, 20) are all stative. -/
+theorem pu_only_verbs_stative :
+    ∀ v ∈ [metaniono, areso, xerome], v.vendlerClass = some .state := by
+  decide
+
+/-! ### Content vs situation (§3.2) -/
+
+/-- The sort of clause each complementizer introduces — *oti* content,
+*pu* situation — which must match the incorporating noun's sort
+(§3.2). The sorts and their diagnostics ('true'/'mistaken' vs
+'happen', ex. 33–34) are [bondarenko-2022]'s (`Bondarenko2022.NominalSort`,
+§2.2.3); *na* is outside the dichotomy. -/
+def clauseSort (c : Complementizer) : Option NominalSort :=
+  if c = oti then some .content
+  else if c = pu then some .situation
+  else none
+
+/-- The assigned sorts pass the §3.2 diagnostics: *oti*'s sort is
+truth-evaluable, *pu*'s occurrence-compatible (ex. 33–34, matching
+[bondarenko-2022] §2.2.3). -/
+theorem clauseSort_matches_diagnostics :
+    clauseSort oti = some .content ∧
+    NominalSort.truthEvaluable .content ∧
+    clauseSort pu = some .situation ∧
+    NominalSort.occurrenceCompatible .situation :=
+  ⟨by decide, trivial, by decide, trivial⟩
+
+/-! ### Against the transparent syntax–semantics mapping (§7.3) -/
+
+/-- Syntactic position of an embedded clause — one of the two axes
+[bondarenko-2022]'s `ClauseStructurePath` conflates. -/
+inductive SynPosition where
+  | complement
+  | adjunct
+  deriving DecidableEq, Repr
+
+/-- Composition mode — the other axis. -/
+inductive CompMode where
+  | pm
+  | fa
+  deriving DecidableEq, Repr
+
+/-- The paper's claim for bare *oti*-clauses (§2 diagnostics + §7.3):
+complement position composing via PM is attested (the explanans
+reading); FA requires the nominalizing D (§7.3 ex. 57), so bare
+clauses never compose via FA from either position. -/
+def bareOtiAttested : SynPosition → CompMode → Prop
+  | .complement, .pm => True
+  | .complement, .fa => False
+  | .adjunct,    .pm => True
+  | .adjunct,    .fa => False
+
+/-- [bondarenko-2022]'s transparent mapping restated on the split
+axes: a bare clause composing via PM must be a syntactic adjunct
+(the composition path is reflected in syntax). -/
+def transparentBare : SynPosition → CompMode → Prop
+  | .adjunct, .pm => True
+  | _, _ => False
+
+/-- The §7.3 divergence: bare *oti*-clauses occupy complement position
+while composing via PM — attested here, excluded by the transparent
+mapping. Conditional on the paper's premises: the clauses are BARE
+(no covert nominal shell — the analysis rejects Arsenijević's DP
+layer and Faure's case-less-DP treatment, §3.1) and are internal
+ARGUMENTS (clitic doubling, passivization, derived subjects,
+§2.1–2.2). [bondarenko-2022] can deny either premise. -/
+theorem diverges_from_transparent_mapping :
+    bareOtiAttested .complement .pm ∧
+    ¬ transparentBare .complement .pm :=
+  ⟨trivial, fun h => h⟩
+
+/-- Against `Bondarenko2022.transparentSSMapping` directly: Bondarenko
+predicts the (bare, argument) cell empty
+(`Bondarenko2022.bare_argument_predicted_impossible`), identifying
+argument position with the FA path; Greek realizes syntactic
+argumenthood for bare clauses WITHOUT FA — the identification of the
+two axes is what fails. -/
+theorem transparency_conflates_axes :
+    ¬ Bondarenko2022.transparentSSMapping .bareArgument ∧
+    bareOtiAttested .complement .pm :=
+  ⟨Bondarenko2022.bare_argument_predicted_impossible, trivial⟩
+
+end Angelopoulos2026

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -36,10 +36,11 @@ Embedded CPs receive **two kinds of denotations** corresponding to a
 syntactic distinction in the left periphery (§1.1.1, paper ex. 1):
 
 - **Cont-CP** ≔ λx. CONT(x) = {s : φ(s)}  — predicate on content
-  individuals (Kratzer 2006; Moulton 2009, 2015; Elliott 2020). Has an
-  extra **ContP** projection that introduces the CONT function.
+  individuals ([kratzer-2006]; [moulton-2009]; [moulton-2015];
+  [elliott-2020-embedding]). Has an extra **ContP** projection that
+  introduces the CONT function.
 - **Sit-CP** ≔ λs'. s' is a minimal situation exemplifying φ —
-  predicate on minimal situations (Kratzer 1989). Lacks ContP.
+  predicate on minimal situations ([kratzer-1989]). Lacks ContP.
 
 In some languages ContP is overtly exposed (Korean -ta declarative;
 Buryat gɘ 'say'); in others (English, Russian) it is null.
@@ -51,7 +52,7 @@ Buryat gɘ 'say'); in others (English, Russian) it is null.
    Cont-CP denotes equality with the embedded proposition, so CONT
    is a function rather than a downward-closed relation. Three
    arguments converge: (i) nominal CP interpretation (paper §2.4),
-   (ii) impossibility of CP conjunction (Bassi & Bondarenko 2021),
+   (ii) impossibility of CP conjunction ([bassi-bondarenko-2021]),
    (iii) Russian NPI subjunctive distribution (paper ch. 5).
 
 2. **Sit-CPs are referentially transparent; Cont-CPs are opaque.**
@@ -69,11 +70,12 @@ Buryat gɘ 'say'); in others (English, Russian) it is null.
    (bare, FA-argument) and (nominalized, PM-modifier) cells are
    ruled out by the structural correlation.
 
-   This is the thesis [angelopoulos-2026] attacks (autonomy of
-   syntax: same syntactic position can yield either composition
-   mode at LF). The conditional refutation theorem in
-   `Angelopoulos2026` cites the
-   `transparentSSMapping` definition below as its premise.
+   This is the thesis [angelopoulos-2026] later attacks (autonomy
+   of syntax: the same syntactic position can yield either
+   composition mode at LF); per the chronology rule the comparison
+   lives in `Studies/Angelopoulos2026.lean`
+   (`transparency_conflates_axes`), which targets the
+   `transparentSSMapping` definition below.
 
 ## Out of scope
 
@@ -162,7 +164,7 @@ theorem equality_implies_existential {W : Type*}
   exact ⟨w, hw, heq ▸ hw⟩
 
 -- ════════════════════════════════════════════════════════════════
--- § 3. CP Conjunction Impossibility (Bassi & Bondarenko 2021)
+-- § 3. CP Conjunction Impossibility ([bassi-bondarenko-2021])
 -- ════════════════════════════════════════════════════════════════
 --
 -- Paper §1.1.1.2 argues the equality semantics predicts true CP
@@ -174,7 +176,7 @@ theorem equality_implies_existential {W : Type*}
     under equality semantics AND `x` has content `p2` under
     equality semantics, then `p1 = p2`.
 
-    Bassi & Bondarenko 2021 derive the impossibility of true CP
+    [bassi-bondarenko-2021] derive the impossibility of true CP
     conjunction from this functionality (paper §1.1.1.2). -/
 theorem cont_function_blocks_conjunction {W : Type*}
     (xc : ContentIndividual W) (p1 p2 : W → Prop) :
@@ -273,8 +275,8 @@ theorem sit_cp_transparentAt {S : Type*} (s : S) :
     *the queen*) coextensional at the evaluation world but
     diverging across content-related worlds. The DP-level reading
     requires a binding-theoretic encoding of de dicto vs de re
-    (Moltmann 2020/2021 actuality-condition apparatus, Elliott
-    2020 CONT-as-content-restrictor) that is NOT yet a linglib
+    (an actuality-condition-style apparatus;
+    [elliott-2020-embedding]'s CONT-as-content-restrictor) that is NOT yet a linglib
     substrate primitive. The theorem below establishes the
     operator-level intensionality that *underwrites* the DP-level
     de dicto reading; the DP-level theorem itself is queued. -/
@@ -668,12 +670,12 @@ def buryatContExponent : Option Complementizer := some Buryat.ge
 
 /-- Korean: *-ta* expones Cont ([bondarenko-2022] §4.3.2, following
     [bogal-allbritten-moulton-2018]). -/
-def koreanContExponent : Option Korean.Complementizers.KoreanClauseSuffix :=
-  some .ta
+def koreanContExponent : Option Complementizer :=
+  some Korean.Complementizers.ta
 
 /-- Tigrinya: *kemzi* ([cacchioli-2025]). -/
-def tigrinyaContExponent : Option Tigrinya.ClausePrefixes.ClausePrefixEntry :=
-  some Tigrinya.ClausePrefixes.kemzi
+def tigrinyaContExponent : Option Complementizer :=
+  some Tigrinya.ClausePrefixes.kemzi.toComplementizer
 
 /-- [bondarenko-2022]'s Cont/Comp assignment coincides with the
     fragment's root-vs-suffix datum: the Cont exponent is exactly the
@@ -687,14 +689,14 @@ theorem mem_buryatContExponent_iff :
     ([bondarenko-2022] §4.3.1 ex. 33): one head, two allomorphs —
     participial *-Aːša* next to nominal projections, converbial *-žA*
     next to verbs. -/
-def buryatCompAllomorph : Complementizer.Host → Complementizer
+def buryatCompAllomorph : Complementizer.Licenser → Complementizer
   | .nominal => Buryat.aasha
   | .verbal  => Buryat.zha
 
-/-- The allomorph selected for a host has exactly that surface
+/-- The allomorph selected for a licenser has exactly that surface
     distribution — the analysis reproduces the fragment's datum. -/
-theorem host_buryatCompAllomorph (h : Complementizer.Host) :
-    (buryatCompAllomorph h).host = some h := by
+theorem licenser_buryatCompAllomorph (h : Complementizer.Licenser) :
+    (buryatCompAllomorph h).licenser = some h := by
   cases h <;> rfl
 
 /-- The head assignment is exhaustive: every morpheme in the inventory
@@ -780,7 +782,7 @@ instance : DecidablePred NominalSort.occurrenceCompatible
 -- **Substantiation status (per syntax expert S6).** The
 -- *justification* for the equality shape of Cont (vs subset
 -- `entails` or existential) lives partly in §3 above
--- (`cont_function_blocks_conjunction` — Bassi & Bondarenko 2021
+-- (`cont_function_blocks_conjunction` — [bassi-bondarenko-2021]
 -- argument) and partly in [bondarenko-2022] §2.4 (deferred:
 -- the nominal-CP-interpretation argument). One of three §2.4
 -- arguments is therefore already present in this file.

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -222,38 +222,48 @@ theorem phasal_violates_realis_finite_correspondence :
 
 open Tigrinya.ClausePrefixes
 
+/-- [cacchioli-2025]'s cartographic head assignment for the four
+    prefixes ([rizzi-1997] split CP): zɨ- spells out Rel, kɨ- Fin,
+    kəmzi- Force, ʔay- Neg. Paper-specific analysis projected over the
+    framework-neutral fragment entries. -/
+def headCat (e : ClausePrefixEntry) : Cat :=
+  if e = kemzi then .Force
+  else if e = ki then .Fin
+  else if e = zi then .Rel
+  else .Neg
+
 /-- zɨ- (Rel) is at the same fValue level as Top (topic field, F5). -/
-theorem zi_fvalue_topic_field : fValue zi.headCat = fValue .Top := by decide
+theorem zi_fvalue_topic_field : fValue (headCat zi) = fValue .Top := by decide
 
 /-- kɨ- (Fin) is at the IP/CP boundary (F3). -/
-theorem ki_fvalue_boundary : fValue ki.headCat = 3 := by decide
+theorem ki_fvalue_boundary : fValue (headCat ki) = 3 := by decide
 
 /-- kəmzi- (Force) is at the clause-typing level (F6). -/
-theorem kemzi_fvalue_clause_typing : fValue kemzi.headCat = 6 := by decide
+theorem kemzi_fvalue_clause_typing : fValue (headCat kemzi) = 6 := by decide
 
 /-- ʔay-...-n (Neg) is in the inflectional domain (F2). -/
-theorem ay_fvalue_inflectional : fValue ay_n.headCat = 2 := by decide
+theorem ay_fvalue_inflectional : fValue (headCat ay_n) = 2 := by decide
 
 /-- The four prefixes target four distinct F-levels:
     Neg(2) < Fin(3) < Rel(5) < Force(6). -/
 theorem prefixes_distinct_flevels :
-    fValue ay_n.headCat < fValue ki.headCat ∧
-    fValue ki.headCat < fValue zi.headCat ∧
-    fValue zi.headCat < fValue kemzi.headCat := by decide
+    fValue (headCat ay_n) < fValue (headCat ki) ∧
+    fValue (headCat ki) < fValue (headCat zi) ∧
+    fValue (headCat zi) < fValue (headCat kemzi) := by decide
 
 /-- Fragment agreement field matches empirical data for each prefix. -/
 theorem agreement_matches_data_bridge :
-    zi.takesAgreementSuffix = false ∧
-    ki.takesAgreementSuffix = true ∧
-    kemzi.takesAgreementSuffix = false ∧
-    ay_n.takesAgreementSuffix = true := ⟨rfl, rfl, rfl, rfl⟩
+    zi.agrees = some false ∧
+    ki.agrees = some true ∧
+    kemzi.agrees = some false ∧
+    ay_n.agrees = some true := ⟨rfl, rfl, rfl, rfl⟩
 
-/-- Only ʔay-...-n is discontinuous. -/
+/-- Only ʔay-...-n is discontinuous (circumfixal position). -/
 theorem only_neg_discontinuous :
-    zi.isDiscontinuous = false ∧
-    ki.isDiscontinuous = false ∧
-    kemzi.isDiscontinuous = false ∧
-    ay_n.isDiscontinuous = true := ⟨rfl, rfl, rfl, rfl⟩
+    zi.position = some .praefixed ∧
+    ki.position = some .praefixed ∧
+    kemzi.position = some .praefixed ∧
+    ay_n.position = some .circumfixed := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- Knowledge verbs select [+finite] → predicts kəmzi- (factive). -/
 theorem knowledge_selects_kemzi :
@@ -281,9 +291,9 @@ theorem neg_circumfix_from_neg :
 
 /-- All four prefix heads are in the verbal extended projection. -/
 theorem all_prefixes_verbal :
-    catFamily zi.headCat = .verbal ∧
-    catFamily ki.headCat = .verbal ∧
-    catFamily kemzi.headCat = .verbal ∧
-    catFamily ay_n.headCat = .verbal := by decide
+    catFamily (headCat zi) = .verbal ∧
+    catFamily (headCat ki) = .verbal ∧
+    catFamily (headCat kemzi) = .verbal ∧
+    catFamily (headCat ay_n) = .verbal := by decide
 
 end Cacchioli2025

--- a/Linglib/Syntax/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Complementizer/Basic.lean
@@ -26,7 +26,7 @@ degree semantics).
   fragments instantiate it (free subordinators like *that* and *oti*,
   affixal clause-typers like Buryat *-žA* and Tigrinya *zɨ-*,
   grammaticalized say-roots like Buryat *gɘ*)
-- `Complementizer.Host` — adnominal vs adverbal licensing category
+- `Complementizer.Licenser` — adnominal vs adverbal licensing category
 - `Complementizer.IsBound` — affixal status, derived from `position`
 - `Complementizer.toWord` — the `SCONJ` word a free complementizer
   projects
@@ -34,9 +34,12 @@ degree semantics).
 
 open Clause.Complementation (NoonanCompType)
 
-/-- Category of the projection an affixal clause-typer is licensed by:
-adnominal (Buryat *-Aːša*, Korean *-nun*) vs adverbal (Buryat *-žA*). -/
-inductive Complementizer.Host where
+/-- Category of the adjacent projection an affixal clause-typer is
+licensed by: adnominal (Buryat *-Aːša*, Korean *-nun*) vs adverbal
+(Buryat *-žA*). Named for the licensing projection, not the
+morphological host stem (which for a postfixed clause-typer is the
+verb it attaches to). -/
+inductive Complementizer.Licenser where
   | nominal
   | verbal
   deriving DecidableEq, Fintype, Repr
@@ -50,18 +53,29 @@ structure Complementizer where
   /-- Native script form, when distinct. -/
   script : Option String := none
   /-- Morphological attachment: `.detached` for free subordinators,
-  `.praefixed` and `.postfixed` for affixal clause-typers. -/
+  `.praefixed` and `.postfixed` for affixal clause-typers. `none` =
+  unrecorded, or a bound root with no fixed attachment of its own
+  (Buryat *gɘ*, which surfaces only suffixed). -/
   position : Option Morphology.FormativePosition := none
   /-- [noonan-2007] type of the complement clause this morpheme types. -/
   noonanType : Option NoonanCompType := none
-  /-- Surface clause form typed (declarative vs embedded question). -/
+  /-- Surface clause form typed. Only `.declarative` and
+  `.embeddedQuestion` are sensible values for an embedded-clause typer. -/
   clauseForm : Option Features.ClauseForm := none
   /-- Verb form an affixal clause-typer derives on its host (UD `.Part`,
   `.Conv`, `.Fin`, …). -/
   verbForm : Option UD.VerbForm := none
-  /-- Licensing host category, for adjacency-conditioned clause-typers. -/
-  host : Option Complementizer.Host := none
-  /-- Factive presupposition; `none` = unrecorded. -/
+  /-- Category of the adjacent licensing projection, for
+  adjacency-conditioned clause-typers. -/
+  licenser : Option Complementizer.Licenser := none
+  /-- Does the morpheme carry φ-agreement with an argument of its clause?
+  (Tigrinya *kɨ-* and *ʔay-…-n* take agreement suffixes; West Germanic
+  complementizer agreement.) `none` = unrecorded. -/
+  agrees : Option Bool := none
+  /-- Lexical factive presupposition conventionally carried by the
+  morpheme itself (Greek *pu*, Tigrinya *kəmzi-*). Leave `none` when
+  factivity tracks the verb or the construction (Buryat, Washo) —
+  construction-level factivity is derived in Studies, never stored. -/
   factive : Option Bool := none
   deriving Repr, BEq, DecidableEq
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -33257,12 +33257,35 @@
   title     = {On clausal complementation, once more},
   journal   = {Natural Language \& Linguistic Theory},
   volume    = {44},
-  number    = {26},
+  number    = {2},
+  pages     = {26},
   doi       = {10.1007/s11049-026-09711-w},
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Phenomena/Complementation/Studies/Angelopoulos2026.lean;Fragments/Greek/StandardModern/Complementizers.lean;Phenomena/Complementation/Studies/Deal2026.lean}
+  sources   = {Studies/Angelopoulos2026.lean;Fragments/Greek/StandardModern/Complementizers.lean;Studies/Bondarenko2022.lean}
+}
+
+@inproceedings{bassi-bondarenko-2021,
+  author    = {Bassi, Itai and Bondarenko, Tatiana},
+  year      = {2021},
+  title     = {Composing {CP}s: {E}vidence from disjunction and conjunction},
+  booktitle = {Proceedings of {SALT} 30},
+  url       = {https://journals.linguisticsociety.org/proceedings/index.php/SALT/article/view/30.583},
+  subfield  = {semantics},
+  role      = {cited},
+  sources   = {Studies/Bondarenko2022.lean}
+}
+
+@phdthesis{elliott-2020-embedding,
+  author    = {Elliott, Patrick D.},
+  year      = {2020},
+  title     = {Elements of Clausal Embedding},
+  school    = {University College London},
+  url       = {https://discovery.ucl.ac.uk/id/eprint/10091030/},
+  subfield  = {semantics},
+  role      = {cited},
+  sources   = {Studies/Bondarenko2022.lean}
 }
 
 @phdthesis{angelopoulos-2019,


### PR DESCRIPTION
Executes the complementizer-arc roadmap (PR 0 + A + first of F) on top of #1057.

- New `Studies/Angelopoulos2026.lean` (from the published NLLT paper): the three puzzles, §3.1 light-noun reversed selection with the incorporation-licensing derivation of the internal/external asymmetry and the P-ban, §4.1 stativity locus (`pu_requires_stative` + the fragment-verb reflex), §3.2 content/situation sorts consuming `Bondarenko2022.NominalSort` diagnostics, and the §7.3 counterclaim against `Bondarenko2022.transparentSSMapping` (`transparency_conflates_axes`, split position/composition axes).
- Sibling migrations onto the root `Complementizer` schema: Korean (entries + `kes` as plain `Word`), Greek (entries; `bearsN` moved to the Angelopoulos study; dead theorems cut), Tigrinya (`ClausePrefixEntry extends Complementizer`; Cacchioli's cartographic `headCat` moved to `Studies/Cacchioli2025` as a projection), English (`CompEntry extends Complementizer`; adverbial subordinators demoted to plain SCONJ words per Noonan).
- Schema amendments from the 3-expert panel: `Host` → `Licenser` (morphological-host collision), new `agrees` field (Tigrinya agreement data would otherwise be lost; West Germanic C-agreement target), narrowed `factive`/`clauseForm`/`position` docstrings.
- Hygiene: Bondarenko2022 raw citations keyed (`bassi-bondarenko-2021`, `elliott-2020-embedding` added — the existing `elliott-2020` key is a different paper); phantom present-tense Angelopoulos reference now true and chronology-correct; wrong `angelopoulos-2026` issue number fixed; unsourced Korean-*ko* claim removed from `ClauseDenotation/Content.lean`.