### PR TITLE
refactor(Complementation): witness records + CTPDatum dissolution

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -281,6 +281,8 @@ import Linglib.Core.Probability.Softmax
 import Linglib.Core.Probability.SoftmaxTheory
 import Linglib.Core.Relation.ReflTransGen
 import Linglib.Core.RingTheory.HopfAlgebra.SymmetricAlgebra
+import Linglib.Data.Complementation.Noonan2007
+import Linglib.Data.Complementation.Schema
 import Linglib.Data.Examples.Abusch1997
 import Linglib.Data.Examples.AghaJeretic2022
 import Linglib.Data.Examples.AhnZhu2025

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1251,6 +1251,7 @@ import Linglib.Fragments.Tuyuca.Evidentiality
 import Linglib.Fragments.Tzotzil.Adposition
 import Linglib.Fragments.Tzotzil.WordOrder
 import Linglib.Fragments.Urdu.CausativeSystem
+import Linglib.Fragments.Uyghur.Complementizers
 import Linglib.Fragments.Vietnamese.TenseAspect
 import Linglib.Fragments.Wambaya.Reciprocals
 import Linglib.Fragments.Wan.Reciprocals
@@ -2474,6 +2475,7 @@ import Linglib.Studies.Magri2025
 import Linglib.Studies.Maier2014
 import Linglib.Studies.Maier2015
 import Linglib.Studies.MajidBosterBowerman2008
+import Linglib.Studies.Major2024
 import Linglib.Studies.Mandelkern2019
 import Linglib.Studies.Mandelkern2022
 import Linglib.Studies.Marantz1991

--- a/Linglib/Data/Complementation/Noonan2007.json
+++ b/Linglib/Data/Complementation/Noonan2007.json
@@ -1,0 +1,304 @@
+{
+ "english": [
+  {
+   "name": "english_say",
+   "verb": "say",
+   "ctpClass": "utterance",
+   "compTypes": ["indicative", "paratactic"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_tell",
+   "verb": "tell",
+   "ctpClass": "utterance",
+   "compTypes": ["indicative", "infinitive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_believe",
+   "verb": "believe",
+   "ctpClass": "propAttitude",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": true
+  },
+  {
+   "name": "english_think",
+   "verb": "think",
+   "ctpClass": "propAttitude",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": true
+  },
+  {
+   "name": "english_regret",
+   "verb": "regret",
+   "ctpClass": "commentative",
+   "compTypes": ["indicative", "nominalized"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_know",
+   "verb": "know",
+   "ctpClass": "knowledge",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_realize",
+   "verb": "realize",
+   "ctpClass": "knowledge",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_see",
+   "verb": "see",
+   "ctpClass": "perception",
+   "compTypes": ["indicative", "infinitive", "participle"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_want",
+   "verb": "want",
+   "ctpClass": "desiderative",
+   "compTypes": ["infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": true
+  },
+  {
+   "name": "english_hope",
+   "verb": "hope",
+   "ctpClass": "desiderative",
+   "compTypes": ["indicative", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": true
+  },
+  {
+   "name": "english_wish",
+   "verb": "wish",
+   "ctpClass": "desiderative",
+   "compTypes": ["indicative", "subjunctive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_make",
+   "verb": "make",
+   "ctpClass": "manipulative",
+   "compTypes": ["infinitive", "paratactic"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_persuade",
+   "verb": "persuade",
+   "ctpClass": "manipulative",
+   "compTypes": ["infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_manage",
+   "verb": "manage",
+   "ctpClass": "achievement",
+   "compTypes": ["infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_stop",
+   "verb": "stop",
+   "ctpClass": "phasal",
+   "compTypes": ["nominalized"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_start",
+   "verb": "start",
+   "ctpClass": "phasal",
+   "compTypes": ["nominalized", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "english_continue",
+   "verb": "continue",
+   "ctpClass": "phasal",
+   "compTypes": ["nominalized", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  }
+ ],
+ "latin": [
+  {
+   "name": "latin_dicere",
+   "verb": "dicere",
+   "ctpClass": "utterance",
+   "compTypes": ["indicative", "infinitive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "latin_credere",
+   "verb": "credere",
+   "ctpClass": "propAttitude",
+   "compTypes": ["infinitive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "latin_velle",
+   "verb": "velle",
+   "ctpClass": "desiderative",
+   "compTypes": ["subjunctive", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "latin_iubere",
+   "verb": "iubere",
+   "ctpClass": "manipulative",
+   "compTypes": ["subjunctive", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  }
+ ],
+ "turkish": [
+  {
+   "name": "turkish_sanmak",
+   "verb": "sanmak",
+   "ctpClass": "propAttitude",
+   "compTypes": ["nominalized", "indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "turkish_istemek",
+   "verb": "istemek",
+   "ctpClass": "desiderative",
+   "compTypes": ["nominalized", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "turkish_baslamak",
+   "verb": "başlamak",
+   "ctpClass": "phasal",
+   "compTypes": ["nominalized", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  }
+ ],
+ "irish": [
+  {
+   "name": "irish_abair",
+   "verb": "abair",
+   "ctpClass": "utterance",
+   "compTypes": ["indicative", "subjunctive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "irish_ceap",
+   "verb": "ceap",
+   "ctpClass": "propAttitude",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  }
+ ],
+ "persian": [
+  {
+   "name": "persian_goftan",
+   "verb": "goftan",
+   "ctpClass": "utterance",
+   "compTypes": ["indicative", "subjunctive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "persian_khastan",
+   "verb": "khastan",
+   "ctpClass": "desiderative",
+   "compTypes": ["subjunctive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "persian_danestan",
+   "verb": "danestan",
+   "ctpClass": "knowledge",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  }
+ ],
+ "hindiUrdu": [
+  {
+   "name": "hindi_urdu_sochna",
+   "verb": "sochna",
+   "ctpClass": "propAttitude",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "hindi_urdu_jaanna",
+   "verb": "jaanna",
+   "ctpClass": "knowledge",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "hindi_urdu_chaahna",
+   "verb": "chaahna",
+   "ctpClass": "desiderative",
+   "compTypes": ["subjunctive"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  }
+ ],
+ "japanese": [
+  {
+   "name": "japanese_omou",
+   "verb": "omou",
+   "ctpClass": "propAttitude",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "japanese_shiru",
+   "verb": "shiru",
+   "ctpClass": "knowledge",
+   "compTypes": ["indicative"],
+   "hasEquiDeletion": false,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "japanese_hoshii",
+   "verb": "hoshii",
+   "ctpClass": "desiderative",
+   "compTypes": ["nominalized"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  },
+  {
+   "name": "japanese_hajimeru",
+   "verb": "hajimeru",
+   "ctpClass": "phasal",
+   "compTypes": ["nominalized", "infinitive"],
+   "hasEquiDeletion": true,
+   "hasNegativeRaising": false
+  }
+ ]
+}

--- a/Linglib/Data/Complementation/Noonan2007.lean
+++ b/Linglib/Data/Complementation/Noonan2007.lean
@@ -1,0 +1,161 @@
+import Linglib.Data.Complementation.Schema
+
+/-!
+# Noonan2007 — complement-taking-predicate sample (generated)
+[noonan-2007]
+
+Auto-generated from `Linglib/Data/Complementation/Noonan2007.json` by
+`scripts/gen_complementation.py`. **Do not edit by hand** — edit the JSON and
+re-run the generator. The 36 CTP rows of [noonan-2007]'s 7-language
+sample: per-row CTP class, attested complement types, equi-deletion, and
+negative raising.
+-/
+
+namespace Data.Complementation.Noonan2007
+
+def english_say : Datum :=
+  ⟨"say", .utterance, [.indicative, .paratactic], false, false⟩
+
+def english_tell : Datum :=
+  ⟨"tell", .utterance, [.indicative, .infinitive], false, false⟩
+
+def english_believe : Datum :=
+  ⟨"believe", .propAttitude, [.indicative], false, true⟩
+
+def english_think : Datum :=
+  ⟨"think", .propAttitude, [.indicative], false, true⟩
+
+def english_regret : Datum :=
+  ⟨"regret", .commentative, [.indicative, .nominalized], false, false⟩
+
+def english_know : Datum :=
+  ⟨"know", .knowledge, [.indicative], false, false⟩
+
+def english_realize : Datum :=
+  ⟨"realize", .knowledge, [.indicative], false, false⟩
+
+def english_see : Datum :=
+  ⟨"see", .perception, [.indicative, .infinitive, .participle], false, false⟩
+
+def english_want : Datum :=
+  ⟨"want", .desiderative, [.infinitive], true, true⟩
+
+def english_hope : Datum :=
+  ⟨"hope", .desiderative, [.indicative, .infinitive], true, true⟩
+
+def english_wish : Datum :=
+  ⟨"wish", .desiderative, [.indicative, .subjunctive], false, false⟩
+
+def english_make : Datum :=
+  ⟨"make", .manipulative, [.infinitive, .paratactic], false, false⟩
+
+def english_persuade : Datum :=
+  ⟨"persuade", .manipulative, [.infinitive], true, false⟩
+
+def english_manage : Datum :=
+  ⟨"manage", .achievement, [.infinitive], true, false⟩
+
+def english_stop : Datum :=
+  ⟨"stop", .phasal, [.nominalized], true, false⟩
+
+def english_start : Datum :=
+  ⟨"start", .phasal, [.nominalized, .infinitive], true, false⟩
+
+def english_continue : Datum :=
+  ⟨"continue", .phasal, [.nominalized, .infinitive], true, false⟩
+
+/-- The `english` rows of the sample (17 rows). -/
+def english : List Datum :=
+  [english_say, english_tell, english_believe, english_think, english_regret, english_know,
+   english_realize, english_see, english_want, english_hope, english_wish, english_make,
+   english_persuade, english_manage, english_stop, english_start, english_continue]
+
+def latin_dicere : Datum :=
+  ⟨"dicere", .utterance, [.indicative, .infinitive], false, false⟩
+
+def latin_credere : Datum :=
+  ⟨"credere", .propAttitude, [.infinitive], false, false⟩
+
+def latin_velle : Datum :=
+  ⟨"velle", .desiderative, [.subjunctive, .infinitive], true, false⟩
+
+def latin_iubere : Datum :=
+  ⟨"iubere", .manipulative, [.subjunctive, .infinitive], true, false⟩
+
+/-- The `latin` rows of the sample (4 rows). -/
+def latin : List Datum :=
+  [latin_dicere, latin_credere, latin_velle, latin_iubere]
+
+def turkish_sanmak : Datum :=
+  ⟨"sanmak", .propAttitude, [.nominalized, .indicative], false, false⟩
+
+def turkish_istemek : Datum :=
+  ⟨"istemek", .desiderative, [.nominalized, .infinitive], true, false⟩
+
+def turkish_baslamak : Datum :=
+  ⟨"başlamak", .phasal, [.nominalized, .infinitive], true, false⟩
+
+/-- The `turkish` rows of the sample (3 rows). -/
+def turkish : List Datum :=
+  [turkish_sanmak, turkish_istemek, turkish_baslamak]
+
+def irish_abair : Datum :=
+  ⟨"abair", .utterance, [.indicative, .subjunctive], false, false⟩
+
+def irish_ceap : Datum :=
+  ⟨"ceap", .propAttitude, [.indicative], false, false⟩
+
+/-- The `irish` rows of the sample (2 rows). -/
+def irish : List Datum :=
+  [irish_abair, irish_ceap]
+
+def persian_goftan : Datum :=
+  ⟨"goftan", .utterance, [.indicative, .subjunctive], false, false⟩
+
+def persian_khastan : Datum :=
+  ⟨"khastan", .desiderative, [.subjunctive], false, false⟩
+
+def persian_danestan : Datum :=
+  ⟨"danestan", .knowledge, [.indicative], false, false⟩
+
+/-- The `persian` rows of the sample (3 rows). -/
+def persian : List Datum :=
+  [persian_goftan, persian_khastan, persian_danestan]
+
+def hindi_urdu_sochna : Datum :=
+  ⟨"sochna", .propAttitude, [.indicative], false, false⟩
+
+def hindi_urdu_jaanna : Datum :=
+  ⟨"jaanna", .knowledge, [.indicative], false, false⟩
+
+def hindi_urdu_chaahna : Datum :=
+  ⟨"chaahna", .desiderative, [.subjunctive], false, false⟩
+
+/-- The `hindiUrdu` rows of the sample (3 rows). -/
+def hindiUrdu : List Datum :=
+  [hindi_urdu_sochna, hindi_urdu_jaanna, hindi_urdu_chaahna]
+
+def japanese_omou : Datum :=
+  ⟨"omou", .propAttitude, [.indicative], false, false⟩
+
+def japanese_shiru : Datum :=
+  ⟨"shiru", .knowledge, [.indicative], false, false⟩
+
+def japanese_hoshii : Datum :=
+  ⟨"hoshii", .desiderative, [.nominalized], true, false⟩
+
+def japanese_hajimeru : Datum :=
+  ⟨"hajimeru", .phasal, [.nominalized, .infinitive], true, false⟩
+
+/-- The `japanese` rows of the sample (4 rows). -/
+def japanese : List Datum :=
+  [japanese_omou, japanese_shiru, japanese_hoshii, japanese_hajimeru]
+
+/-- The 7-language sample, one row list per language. -/
+def sample : List (List Datum) :=
+  [english, latin, turkish, irish, persian, hindiUrdu, japanese]
+
+/-- All 36 rows of the sample, pooled. -/
+def all : List Datum := sample.flatten
+
+end Data.Complementation.Noonan2007

--- a/Linglib/Data/Complementation/Schema.lean
+++ b/Linglib/Data/Complementation/Schema.lean
@@ -1,0 +1,41 @@
+import Linglib.Features.Complementation
+
+/-!
+# Complementation data schema
+
+Typed schema for cross-linguistic complement-taking-predicate (CTP) rows,
+the home of the canonical sample behind [noonan-2007]. Generated rows live in
+`Data/Complementation/<Paper>.lean`, emitted from the canonical `<Paper>.json`
+by `scripts/gen_complementation.py`.
+
+This is substrate: it imports `Features/Complementation.lean` only. Consumers
+(the paper's study file, bridge studies) import the generated module.
+
+## Main definitions
+* `Datum` — one CTP row: verb, CTP class, attested complement types,
+  equi-deletion, negative raising.
+-/
+
+namespace Data.Complementation
+
+/-- One row of [noonan-2007]'s CTP sample: a complement-taking predicate in
+    one language, with its CTP class, the complement types it is attested
+    with, and its equi-deletion / negative-raising behavior.
+
+    `verb` is citation provenance, not identity — rows are identified by
+    their generated def names and grouped into per-language lists.
+
+    Dropped relative to the older `CTPDatum`: `language` (identity is the
+    per-language grouping list), `realityStatus` (derivable as
+    `ctpRealityStatus ctpClass`; the sample has zero overrides, as the old
+    file's own `reality_status_consistent` theorem proved), and `hasRaising`
+    (zero consumers). -/
+structure Datum where
+  verb : String
+  ctpClass : CTPClass
+  compTypes : List NoonanCompType
+  hasEquiDeletion : Bool := false
+  hasNegativeRaising : Bool := false
+  deriving DecidableEq, Repr
+
+end Data.Complementation

--- a/Linglib/Features/Complementation.lean
+++ b/Linglib/Features/Complementation.lean
@@ -8,9 +8,11 @@ Per-entry complementation features: which complement type a predicate selects
 (`ControlType`). Composed into lexical-core structures as fields
 (`Verb.ArgStructure.complementType`), Pronoun-pattern style.
 
-The cross-linguistic complementation typology lives in
-`Typology/Complementation.lean` (Noonan's six complement types); the bridge
-between the two (`ComplementType ↔ NoonanCompType`) is paper-anchored in
+The cross-linguistic complementation typology also lives here:
+[noonan-2007]'s six complement-clause types (`NoonanCompType`) and twelve
+complement-taking-predicate classes (`CTPClass`) with their default reality
+status (`RealityStatus`, `ctpRealityStatus`). The bridge between the two
+inventories (`ComplementType ↔ NoonanCompType`) is paper-anchored in
 `Studies/Noonan2007.lean`.
 
 ## Main declarations
@@ -18,6 +20,9 @@ between the two (`ComplementType ↔ NoonanCompType`) is paper-anchored in
 * `ComplementType` — complement frame a predicate selects (English-leaning
   inventory: NP, double object, clausal, …)
 * `ControlType` — subject/object control vs raising for infinitival complements
+* `NoonanCompType` + `isReduced` — [noonan-2007]'s complement-clause types
+* `CTPClass`, `RealityStatus`, `ctpRealityStatus` — [noonan-2007]'s CTP
+  classification and realis/irrealis defaults
 -/
 
 /--
@@ -78,3 +83,77 @@ inductive ControlType where
   | raising         -- "John seems to be happy" (no theta role for matrix subject)
   | none            -- Not applicable
   deriving DecidableEq, Repr
+
+/-! ### Noonan complement typology -/
+
+/-- The six major complement types attested cross-linguistically.
+    Ordered roughly from most to least "finite" (Noonan's "balanced" to
+    "deranked"). -/
+inductive NoonanCompType where
+  | indicative     -- Finite clause with indicative mood marking
+  | subjunctive    -- Finite clause with subjunctive/irrealis marking
+  | paratactic     -- Juxtaposed clause, no subordinator
+  | infinitive     -- Non-finite with "to" or equivalent
+  | nominalized    -- Gerund / action nominal
+  | participle     -- Participial complement
+  deriving DecidableEq, Repr, BEq
+
+/-- Is this complement type "reduced" (non-finite)? -/
+def NoonanCompType.isReduced : NoonanCompType → Bool
+  | .infinitive  => true
+  | .nominalized => true
+  | .participle  => true
+  | _            => false
+
+/-- Noonan's twelve CTP classes, organized by semantic contribution.
+
+    The ordering follows [noonan-2007] Table 2.1 from most to least
+    "assertive":
+    - Utterance/propAttitude/pretence: report/judge propositional content
+    - Commentative/knowledge: evaluate/know propositional content
+    - Perception: direct experience
+    - Desiderative/manipulative/modal: irrealis orientation
+    - Achievement/phasal: aspectual
+    - Negative: negation as CTP -/
+inductive CTPClass where
+  | utterance       -- say, tell, report
+  | propAttitude    -- believe, think, suppose
+  | pretence        -- pretend, act as if
+  | commentative    -- regret, be sorry
+  | knowledge       -- know, realize, discover
+  | perception      -- see, hear, feel
+  | desiderative    -- want, wish, hope
+  | manipulative    -- make, cause, persuade, order
+  | modal           -- can, must, should
+  | achievement     -- positive: manage, dare; negative: try, forget to, avoid (§3.2.10)
+  | phasal          -- start, stop, continue
+  /-- A CTP whose sole semantic content is sentential negation
+      ([noonan-2007] §3.2.13). Typologically rare; canonical examples
+      are Fijian *sega* and Shuswap negative predicates. English `avoid`,
+      `refrain`, `prevent` are NOT in this class — they are *negative
+      achievement* predicates (§3.2.10). -/
+  | negative
+  deriving DecidableEq, Repr, BEq
+
+/-- The fundamental realis/irrealis split that predicts complement type
+    selection. Realis CTPs tend toward indicative; irrealis toward
+    subjunctive/infinitive ([noonan-2007] §2.3). -/
+inductive RealityStatus where
+  | realis    -- CTP asserts or presupposes complement truth
+  | irrealis  -- CTP does not commit to complement truth
+  deriving DecidableEq, Repr
+
+/-- Default reality status of each CTP class ([noonan-2007] Table 2.3). -/
+def ctpRealityStatus : CTPClass → RealityStatus
+  | .utterance    => .realis
+  | .propAttitude => .realis
+  | .pretence     => .irrealis
+  | .commentative => .realis
+  | .knowledge    => .realis
+  | .perception   => .realis
+  | .desiderative => .irrealis
+  | .manipulative => .irrealis
+  | .modal        => .irrealis
+  | .achievement  => .irrealis
+  | .phasal       => .realis
+  | .negative     => .irrealis

--- a/Linglib/Fragments/Cantonese/Predicates.lean
+++ b/Linglib/Fragments/Cantonese/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Features.Complementation
 
 /-!
 # Cantonese Complement-Taking Predicates
@@ -18,8 +18,6 @@ by the Studies file, not by the Fragment.
 -/
 
 namespace Cantonese.Predicates
-
-open Clause.Complementation (CTPClass)
 
 /-- The size of the complement clause a Cantonese predicate selects, per
     [liu-yip-2026] §5–6's classification: vP (Aspect Restructuring,

--- a/Linglib/Fragments/Korean/Complementizers.lean
+++ b/Linglib/Fragments/Korean/Complementizers.lean
@@ -58,7 +58,7 @@ namespace Korean.Complementizers
 /-- *-ta* — declarative ending. [bondarenko-2022] §4.3.2 (following
     [bogal-allbritten-moulton-2018]) analyses it as the overt ContP
     exponent — that decomposition is Studies-local
-    (`Bondarenko2022.koreanContExponent`); the consensus view
+    (`Bondarenko2022.koreanAnalysis`); the consensus view
     (Shim & Ihsane 2015, [kim-min-joo-2009]) treats it as a
     clause-typing morpheme without that structural decomposition. -/
 def ta : Complementizer where

--- a/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
+++ b/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Features.Complementation
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
 
@@ -44,8 +44,6 @@ Relative-pronoun paradigm is from [deal-2016a] (Table 22 reproduced in
 -/
 
 namespace NezPerce.ClausalEmbedding
-
-open Clause.Complementation (CTPClass)
 
 -- ============================================================================
 -- §1. Predicate Schema

--- a/Linglib/Fragments/Uyghur/Complementizers.lean
+++ b/Linglib/Fragments/Uyghur/Complementizers.lean
@@ -1,0 +1,109 @@
+import Linglib.Semantics.Verb.Basic
+import Linglib.Syntax.Complementizer.Basic
+
+/-!
+# Uyghur Clause-Linking Morphemes and the Say-Complex
+[major-2024] [major-2021]
+
+This file records the morphemes implicated in Uyghur (Southeastern
+Turkic) clausal embedding per [major-2024]: the verb root *de* 'say',
+the converbial suffix -(I)p, and the complementizer *-lik* of the
+nominalized (participial) embedding strategy. The apparent
+complementizer *dep* is deliberately not an entry: [major-2024] (his
+2–3) decomposes it as *de* + -(I)p; the decomposition and its
+consequences (adjunction at VP or TP, the argument-position ban) live
+in `Studies/Major2024.lean`.
+
+## Main definitions
+
+- `Uyghur.de`, `Uyghur.ip`, `Uyghur.lik` — the say-root, the converb,
+  and the nominalized-clause typer, as root `Complementizer` entries;
+  the inventory is `Uyghur.complementizers`
+- `Uyghur.deVerb`, `Uyghur.oyla`, `Uyghur.warqira` — 'say', 'think',
+  'scream': the main verbs whose frames drive [major-2024]'s §3
+  argumentation
+
+## Implementation notes
+
+Bare `his (N)` references are to [major-2024]'s example numbers; the
+bare -(I)p data of his §2 build on [sugar-2019] and [major-2021].
+Forms use the paper's standard-Uyghur Latin transcription; capital `I`
+in -(I)p marks the harmonizing high vowel. Verb entries are keyed by
+bare stem and their `form` fields carry the stem with a final hyphen
+(*de* surfaces as *dé* before the past-tense suffix, his 1).
+-/
+
+namespace Uyghur
+
+/-- *de* — the verb root 'say'. A verb root, not an affix: it never
+surfaces bare — inflected as a main verb (*dé-d-i* 'say-PST-3', his 1)
+or converb-suffixed as a clause-linker (*de-p*, his 2) — so no
+attachment of its own is recorded. Main-verb argument structure:
+`Uyghur.deVerb`. -/
+def de : Complementizer where
+  form := "de"
+
+/-- -(I)p — the general-purpose converbial suffix (glossed CNV),
+deriving converb clauses that adjoin at VP or TP (his 4; [sugar-2019],
+[major-2021]). Not a clause-typing complementizer under [major-2024]:
+the same suffix links ordinary serial events ('jump', 'fall', his 3)
+and the say-complex *de-p*. -/
+def ip : Complementizer where
+  form := "-(I)p"
+  position := some .postfixed
+  verbForm := some .Conv
+
+/-- *-lik* — complementizer of the nominalized embedding strategy,
+`V-PTPL-lik-POSS-CASE` (his 40a): case-marked, possessive agreement,
+genitive subject — Noonan-nominalized. Participial clauses are
+Uyghur's genuine clausal arguments ([major-2024] §3.2): grammatical
+subjects (his 49a) and factive complements (his 61a). -/
+def lik : Complementizer where
+  form := "-lik"
+  position := some .postfixed
+  noonanType := some .nominalized
+
+/-- The clause-linking morphemes at issue in [major-2024]: the two
+pieces of the say-complex plus the rival argument strategy's typer.
+Not an exhaustive inventory of Uyghur subordination. -/
+def complementizers : List Complementizer := [de, ip, lik]
+
+/-! ### Main verbs
+
+Vendler class stays unset (`Verb.Aspect.vendlerClass` convention for
+clause-embedding verbs); `voiceType` stays unset on *de-* because the
+paper argues 'say' alternates between an agentive activity and a
+subjectless stative description (his §3.3, 66–72). -/
+
+/-- *de-* 'say' as a main verb: transitive with an obligatory internal
+argument — bare finite CP (his 1), DP (his 39a: *(birnémi-ler-ni)
+dé-d-i*), or participial clause (his 40a). The bare-CP complement must
+stay adjacent to the verb, like a bare object, so it merges as
+complement to V (his 73). Under [major-2024] this same entry,
+converb-suffixed, heads dep clauses (`Studies/Major2024.lean`). -/
+def deVerb : Verb where
+  form := "de-"
+  complementType := .finiteClause
+  altComplementType := some .np
+  speechActVerb := true
+
+/-- *oyla-* 'think' (his 58–59): takes DP objects (*u xewer-ni* 'that
+news-ACC', his 59b) and participial complements (his 59a). No finite
+frame is recorded: the apparent finite-CP frame (his 37a) is
+[major-2024]'s re-analysis target — the dep clause is a VP adjunct
+answering *qandaq* 'how' (his 58b, 60), not a complement. -/
+def oyla : Verb where
+  form := "oyla-"
+  complementType := .np
+  altComplementType := some .gerund
+  attitude := some (.doxastic .nonVeridical)
+
+/-- *warqira-* 'scream': unergative, no complement frame — neither DP
+(his 39b) nor participial clause (his 40b). With a dep adjunct it is
+coerced into a verb of speech (his 38; §3.1). -/
+def warqira : Verb where
+  form := "warqira-"
+  complementType := .none
+  voiceType := some .agentive
+
+end Uyghur

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -2,7 +2,7 @@ import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Fragments.Ga.Predicates
 import Linglib.Syntax.NullSubject
 import Linglib.Studies.Landau2015
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Features.Complementation
 
 /-!
 # Allotey (2021): Overt Pronouns of Infinitival Predicates in Gã
@@ -315,8 +315,6 @@ theorem ga_prodrop_would_exclude_overt_pro
 -- ════════════════════════════════════════════════════════════════
 -- § 9: Noonan Complementation Bridge
 -- ════════════════════════════════════════════════════════════════
-
-open Clause.Complementation
 
 /-- Map Gã clause types to [noonan-2007]'s complement typology.
 

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -2,7 +2,6 @@ import Linglib.Semantics.Attitudes.ClauseDenotation.Content
 import Linglib.Semantics.Attitudes.ClauseDenotation.Situation
 import Linglib.Fragments.Buryat.Complementizers
 import Linglib.Fragments.Korean.Complementizers
-import Linglib.Fragments.Tigrinya.ClausePrefixes
 
 /-!
 # Bondarenko 2022: Anatomy of an Attitude [bondarenko-2022]
@@ -658,52 +657,78 @@ theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
 -- § 12. Cross-linguistic ContP exponence
 -- ════════════════════════════════════════════════════════════════
 --
--- Per-language overt Cont exponents under [bondarenko-2022]'s
--- analysis, typed over the fragment morpheme inventories: Buryat *gɘ*
--- (§4.3.1), Korean *-ta* (§4.3.2, following
--- [bogal-allbritten-moulton-2018]), extended with Tigrinya *kemzi*
--- ([cacchioli-2025]). `none` is null exponence (English, Russian).
+-- Per-language Cont-exponence analyses under [bondarenko-2022],
+-- bundled with the laws tying them to the fragment inventories —
+-- construction obligations discharged by `decide`, RingHom-style.
+-- Buryat additionally carries the licenser-conditioned Comp
+-- allomorphy (§4.3.1 ex. 33); the dissertation gives no such rule
+-- for Korean, so its witness stays at `ContAnalysis`.
+-- [cacchioli-2025]'s Tigrinya extension lives in
+-- `Studies/Cacchioli2025.lean` per the chronology rule.
 
-/-- Buryat: the say-root *gɘ* expones Cont ([bondarenko-2022] §4.3.1
-    ex. 33). -/
-def buryatContExponent : Option Complementizer := some Buryat.ge
+/-- A Cont-exponence analysis of one language's clause-typing
+    inventory ([bondarenko-2022] ch. 4): which morpheme, if any,
+    overtly expones Cont, tied by law to the fragment inventory
+    (`none` = null exponence: English, Russian). A structure, not a
+    class — rival frameworks construct rival witnesses. -/
+structure ContAnalysis where
+  /-- The fragment inventory analyzed. -/
+  inventory : List Complementizer
+  /-- The overt Cont exponent, if any. -/
+  contExponent : Option Complementizer
+  /-- The exponent is drawn from the inventory. -/
+  contExponent_mem : ∀ c ∈ contExponent, c ∈ inventory
 
-/-- Korean: *-ta* expones Cont ([bondarenko-2022] §4.3.2, following
-    [bogal-allbritten-moulton-2018]). -/
-def koreanContExponent : Option Complementizer :=
-  some Korean.Complementizers.ta
+/-- A full Cont/Comp head assignment: `ContAnalysis` plus the
+    licenser-conditioned Comp allomorphy and its laws. -/
+structure ContCompAnalysis extends ContAnalysis where
+  /-- Comp allomorph selected by the licensing category. -/
+  compAllomorph : Complementizer.Licenser → Complementizer
+  compAllomorph_mem : ∀ l, compAllomorph l ∈ inventory
+  /-- The selected allomorph reproduces the fragment's distribution
+      datum. -/
+  licenser_compAllomorph : ∀ l, (compAllomorph l).licenser = some l
+  /-- Head assignment is exhaustive over the inventory. -/
+  cover : ∀ c ∈ inventory, c ∈ contExponent ∨ ∃ l, compAllomorph l = c
 
-/-- Tigrinya: *kemzi* ([cacchioli-2025]). -/
-def tigrinyaContExponent : Option Complementizer :=
-  some Tigrinya.ClausePrefixes.kemzi.toComplementizer
+/-- Buryat (§4.3.1 ex. 33): *gɘ* expones Cont; the suffixes are Comp
+    allomorphs — participial *-Aːša* next to nominal projections,
+    converbial *-žA* next to verbs. -/
+def buryatAnalysis : ContCompAnalysis where
+  inventory := Buryat.complementizers
+  contExponent := some Buryat.ge
+  contExponent_mem := fun _ hc => by cases hc; exact .head _
+  compAllomorph
+    | .nominal => Buryat.aasha
+    | .verbal  => Buryat.zha
+  compAllomorph_mem := by
+    intro l
+    cases l
+    · exact .tail _ (.head _)
+    · exact .tail _ (.tail _ (.head _))
+  licenser_compAllomorph := by intro l; cases l <;> rfl
+  cover := by
+    intro c hc
+    fin_cases hc
+    · exact Or.inl rfl
+    · exact Or.inr ⟨.nominal, rfl⟩
+    · exact Or.inr ⟨.verbal, rfl⟩
 
-/-- [bondarenko-2022]'s Cont/Comp assignment coincides with the
-    fragment's root-vs-suffix datum: the Cont exponent is exactly the
-    non-suffixal (say-root) morpheme. -/
+/-- Korean (§4.3.2, following [bogal-allbritten-moulton-2018]): *-ta*
+    expones Cont. No Comp allomorphy rule is given for Korean, so the
+    witness stays at `ContAnalysis`. -/
+def koreanAnalysis : ContAnalysis where
+  inventory := Korean.Complementizers.complementizers
+  contExponent := some Korean.Complementizers.ta
+  contExponent_mem := fun _ hc => by cases hc; exact .head _
+
+/-- Buryat-specific alignment, NOT a `ContAnalysis` law — Korean's
+    Cont exponent *-ta* is itself a suffix (`verbForm = some .Fin`):
+    in Buryat, the Cont exponent is exactly the non-suffixal
+    say-root. -/
 theorem mem_buryatContExponent_iff :
     ∀ c ∈ Buryat.complementizers,
-      (c ∈ buryatContExponent ↔ c.verbForm = none) := by
-  decide
-
-/-- The Comp head realized by adjacency-conditioned allomorphy
-    ([bondarenko-2022] §4.3.1 ex. 33): one head, two allomorphs —
-    participial *-Aːša* next to nominal projections, converbial *-žA*
-    next to verbs. -/
-def buryatCompAllomorph : Complementizer.Licenser → Complementizer
-  | .nominal => Buryat.aasha
-  | .verbal  => Buryat.zha
-
-/-- The allomorph selected for a licenser has exactly that surface
-    distribution — the analysis reproduces the fragment's datum. -/
-theorem licenser_buryatCompAllomorph (h : Complementizer.Licenser) :
-    (buryatCompAllomorph h).licenser = some h := by
-  cases h <;> rfl
-
-/-- The head assignment is exhaustive: every morpheme in the inventory
-    is either the Cont exponent or a Comp allomorph. -/
-theorem contP_comp_cover :
-    ∀ c ∈ Buryat.complementizers,
-      c ∈ buryatContExponent ∨ ∃ h, buryatCompAllomorph h = c := by
+      (c ∈ buryatAnalysis.contExponent ↔ c.verbForm = none) := by
   decide
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -1,6 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Syntax.Minimalist.Agree.Basic
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Features.Complementation
 import Linglib.Fragments.Tigrinya.ClausePrefixes
 import Linglib.Studies.Bondarenko2022
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
@@ -123,7 +123,6 @@ def agreementData : List AgreementDatum := [
 -- ============================================================================
 
 open Minimalist
-open Clause.Complementation
 
 /-- Map CTP reality status to [±finite] selection.
 

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -2,6 +2,7 @@ import Linglib.Data.UD.Basic
 import Linglib.Syntax.Minimalist.Agree.Basic
 import Linglib.Syntax.Clause.Complementation
 import Linglib.Fragments.Tigrinya.ClausePrefixes
+import Linglib.Studies.Bondarenko2022
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 
 /-!
@@ -295,5 +296,14 @@ theorem all_prefixes_verbal :
     catFamily (headCat ki) = .verbal ∧
     catFamily (headCat kemzi) = .verbal ∧
     catFamily (headCat ay_n) = .verbal := by decide
+
+/-- [cacchioli-2025]'s extension of [bondarenko-2022]'s Cont-exponence
+    paradigm: *kemzi* as Tigrinya's overt Cont exponent (the 2025
+    comparison, so it lives here per the chronology rule). -/
+def tigrinyaAnalysis : Bondarenko2022.ContAnalysis where
+  inventory := Tigrinya.ClausePrefixes.allPrefixes.map (·.toComplementizer)
+  contExponent := some Tigrinya.ClausePrefixes.kemzi.toComplementizer
+  contExponent_mem := fun _ hc => by
+    cases hc; exact .tail _ (.tail _ (.head _))
 
 end Cacchioli2025

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -51,7 +51,7 @@ functional projection above TP*. Three primary conclusions:
   formalisation requires updating `HPSG/RelativeClauses.lean` to
   parameterise its currently-hardcoded `MOD NP` analysis.
 - A `commentative`-emitting fix to `deriveCTPClass` in
-  `Studies/Noonan2007.lean:570`: blocked on
+  `Studies/Noonan2007.lean`: blocked on
   VerbEntry schema (regret and know have identical features in
   `Fragments/English/Predicates/Verbal.lean`).
 

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -1,8 +1,7 @@
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Semantics.Verb.Basic
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Data.Complementation.Noonan2007
 import Linglib.Fragments.English.Predicates.Verbal
-import Linglib.Studies.Noonan2007
 
 /-!
 # Landau (2015): A Two-Tiered Theory of Control
@@ -800,8 +799,6 @@ end VerbVerification
 -- § 14: Noonan CTP → Landau Tier Bridge
 -- ════════════════════════════════════════════════════════════════
 
-open Clause.Complementation
-
 /-- Map [noonan-2007]'s CTP classes to [landau-2015]'s
     control tiers.
 
@@ -879,7 +876,7 @@ theorem ctp_tier_consistent (c : CTPClass)
     and Landau's `ctpToControlTier .achievement = some .predicative` holds
     by `rfl`. The bridge theorem makes the consilience kernel-checked. -/
 
-open Noonan2007 (english_manage)
+open Data.Complementation.Noonan2007 (english_manage)
 
 /-- Cross-paper consilience: Noonan-equi on the achievement class
     coincides with Landau's predicative tier. Witnessed by `manage`. -/

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -86,7 +86,7 @@ explicit in §10 as a refutation theorem candidate.
 namespace LiuYip2026
 
 open Minimalist (AspFlavor AspHead Probe.Profile ClauseSpine ComplementSize Cat fValue)
-open Clause.Complementation (CTPClass ComplementClauseStructure)
+open Clause.Complementation (ComplementClauseStructure)
 
 -- ============================================================================
 -- §1. Three Chinese clause types as ComplementSize instances

--- a/Linglib/Studies/Major2024.lean
+++ b/Linglib/Studies/Major2024.lean
@@ -1,0 +1,314 @@
+import Linglib.Fragments.Uyghur.Complementizers
+
+/-!
+# Major 2024: Re-analyzing 'say' complementation
+[major-2024]
+
+Uyghur *dep* clauses look like complementizer-headed CP complements
+but are converbial adjunct clauses headed by the verb *de* 'say' plus
+the converb -(I)p, merging at VP or TP (his 4, 9). Because the linker
+contains the verb 'say', main-verb properties of *de-* persist inside
+dep clauses (his 39–41), and because the linker is a converb, dep
+clauses are banned from argument positions: they cannot be grammatical
+subjects (his 49b) and "are never internal arguments" (§3.2). The
+paper's methodological point — "taking the morphology at face value
+(i.e. dep is 'say' + CNV)" (§1) — is rendered literally here:
+`mergeMode` reads a morpheme's merge behavior off its recorded
+morphology (`verbForm`, `noonanType`), and the ban is derived, not
+stipulated per position. The Washo parallel is [bochnak-hanink-2021]'s
+modifier analysis of non-factive embedding, which Major extends with
+the verb 'say' inside the linker.
+
+The case-theoretic payoff (his §§4–6) is out of scope here: the same
+decomposition holds of Sakha *dien* = *die* 'say' + converb -(E)n, so
+[baker-vinokurova-2010]'s accusative subjects under *dien* reduce to
+ECM by the v of 'say', resurrecting Case-by-Agree where B&V argued
+for Dependent Case Theory.
+
+## Main declarations
+
+- `ClausePosition`, `MergeMode`, `mergeMode`, `licensedIn` — merge
+  behavior read off the fragment entries' morphology
+- `SayConverbAnalysis` — witness record for the re-analysis (cf.
+  `Bondarenko2022.ContAnalysis` for the rival carving); `depAnalysis`
+  is the Uyghur witness, and `SayConverbAnalysis.argument_ban` derives
+  the ban for any witness
+- `dep_never_argument`, `participial_licensed_iff_argument` — the
+  argument-position asymmetry (his 49, 59, 61)
+- `coerced_speech_reading` — unergative 'scream' + dep (his 38–41)
+- `dep_nci_diagnoses_height` — the VP/TP height contrast (his 54)
+- `dep_never_feeds_factivity` — the factivity alternation as a
+  corollary of the ban (his 61–65)
+
+## The rival carving (docstring-only, per the chronology rule)
+
+[bondarenko-2022] assigns the structurally parallel Buryat say-complex
+*gɘ-žɘ* to functional heads: the say-root expones Cont and the converb
+is a Comp allomorph (`Bondarenko2022.buryatAnalysis`), so the complex
+heads a selected complement. Major's carving keeps both pieces
+lexical — verb plus adjunct-forming converb — and denies complement
+status altogether. Major does not engage that analysis (he cites only
+[bondarenko-2020] among factivity-alternation accounts, §3.2), so no
+divergence theorem is stated here; the two witnesses coexist as rival
+records over their respective fragment inventories.
+-/
+
+namespace Major2024
+
+/-! ### Merge modes read off the morphology (§2)
+
+Converbial -(I)p clauses adjoin at two heights (his 4): VP-level
+-(I)p is a manner modifier interpreted under matrix aspect (his
+10–13), answers *qandaq* 'how' (his 15–16), and sits below the matrix
+accusative position (his 19); TP-level -(I)p precedes the whole matrix
+clause (his 29), tolerates aspect and voice mismatches (his 12, 30),
+and merges at (at least) TP (his 31). Dep clauses replicate both
+profiles (his 37–38, 52–56). -/
+
+/-- Structural positions at issue for an embedded clause: the two
+converb adjunction heights (his 4) and the two argument positions the
+paper tests — complement of V (his 59a, 61a, 73) and grammatical
+subject (his 49). -/
+inductive ClausePosition where
+  | complementOfV
+  | subject
+  | vpAdjunct
+  | tpAdjunct
+  deriving DecidableEq, Fintype, Repr
+
+/-- Argument positions: those saturating a θ-position of the matrix
+predicate. -/
+def ClausePosition.isArgument : ClausePosition → Prop
+  | .complementOfV | .subject => True
+  | .vpAdjunct | .tpAdjunct => False
+
+instance : DecidablePred ClausePosition.isArgument
+  | .complementOfV => isTrue trivial
+  | .subject       => isTrue trivial
+  | .vpAdjunct     => isFalse id
+  | .tpAdjunct     => isFalse id
+
+/-- How a clause-forming morpheme merges the clause it heads: a
+converb builds an adjunct to a verbal projection (his 4); a
+nominalizer builds a case-bearing nominal that saturates an argument
+position (his 49a, 59a). -/
+inductive MergeMode where
+  | converbAdjunction
+  | nominalArgument
+  deriving DecidableEq, Repr
+
+/-- Converbial adjuncts modify, never saturate ("dep clauses are never
+internal arguments", §3.2; subject ban his 49b); nominalized clauses
+saturate. Oblique case-marked participial adjuncts (his 50b) go
+through case morphology, outside this position set. -/
+def MergeMode.admits : MergeMode → ClausePosition → Prop
+  | .converbAdjunction, pos => ¬ pos.isArgument
+  | .nominalArgument,   pos => pos.isArgument
+
+instance (m : MergeMode) (pos : ClausePosition) : Decidable (m.admits pos) :=
+  match m with
+  | .converbAdjunction => inferInstanceAs (Decidable ¬pos.isArgument)
+  | .nominalArgument   => inferInstanceAs (Decidable pos.isArgument)
+
+/-- The merge mode of a clause-forming morpheme, read off its recorded
+morphology — the paper's "morphology at face value" (§1): a converbial
+suffix (`verbForm = .Conv`) builds adjuncts; a nominalizing
+clause-typer (`noonanType = .nominalized`) builds arguments. `none`
+for morphemes heading no clause of their own. -/
+def mergeMode (c : Complementizer) : Option MergeMode :=
+  if c.verbForm = some .Conv then some .converbAdjunction
+  else if c.noonanType = some .nominalized then some .nominalArgument
+  else none
+
+/-- A clause headed by `c` is licensed in `pos` iff `c`'s merge mode
+admits it. No matrix-verb parameter: dep clauses appear regardless of
+matrix transitivity (his 44a *söz qil-* vs. unaccusative 44b *söz
+bol-*) and with unaccusative 'be surprised' (his 50c). -/
+def licensedIn (c : Complementizer) (pos : ClausePosition) : Prop :=
+  match mergeMode c with
+  | some m => m.admits pos
+  | none   => False
+
+instance (c : Complementizer) (pos : ClausePosition) : Decidable (licensedIn c pos) :=
+  match hm : mergeMode c with
+  | some m => decidable_of_iff (m.admits pos) (by unfold licensedIn; rw [hm])
+  | none   => decidable_of_iff False (by unfold licensedIn; rw [hm])
+
+/-- The say-root heads no clause of its own — the linker is the
+converb, not 'say' (his 2–3). -/
+theorem de_no_mergeMode : mergeMode Uyghur.de = none := rfl
+
+/-! ### The say-converb witness (his 2–3, 9) -/
+
+/-- A say-converb re-analysis of an apparent complementizer
+([major-2024]; cf. `Bondarenko2022.ContAnalysis` for the rival
+Cont-exponence carving): the linker decomposes into a say-root and a
+converbial suffix drawn from the language's inventory, and the
+say-root is the independently attested main verb 'say' — one lexical
+item, so main-verb properties persist inside the adjunct by
+construction (his 39–41). A structure, not a class: rival frameworks
+construct rival witnesses. -/
+structure SayConverbAnalysis where
+  /-- The fragment inventory analyzed. -/
+  inventory : List Complementizer
+  /-- The apparent complementizer being decomposed (*dep*; Sakha *dien*). -/
+  surface : String
+  /-- The say-root inside the complex linker. -/
+  sayRoot : Complementizer
+  /-- The converbial suffix heading the adjunct clause. -/
+  converb : Complementizer
+  /-- The main verb 'say' — the same lexical item as `sayRoot`. -/
+  say : Verb
+  sayRoot_mem : sayRoot ∈ inventory
+  converb_mem : converb ∈ inventory
+  /-- Morphology at face value: the linker is a converb. -/
+  converb_conv : converb.verbForm = some UD.VerbForm.Conv
+  /-- 'say' is transitive with an obligatory internal argument
+      (his 39a, 40a), a requirement that persists inside the adjunct
+      (his 41: `*(birnémi-ler-ni) de-p warqiri-di`). -/
+  say_transitive : say.complementType ≠ ComplementType.none ∧ say.implicitObj = none
+
+/-- Any say-converb analysis fixes adjunction as the linker's merge
+mode. -/
+theorem SayConverbAnalysis.mergeMode_converb (a : SayConverbAnalysis) :
+    mergeMode a.converb = some .converbAdjunction := by
+  simp [mergeMode, a.converb_conv]
+
+/-- Any say-converb analysis licenses the say-clause at both
+adjunction heights (his 4, 51, 56). -/
+theorem SayConverbAnalysis.adjoins (a : SayConverbAnalysis) :
+    licensedIn a.converb .vpAdjunct ∧ licensedIn a.converb .tpAdjunct := by
+  unfold licensedIn
+  rw [a.mergeMode_converb]
+  exact ⟨fun h => h, fun h => h⟩
+
+/-- The argument-position ban, derived for any witness: the converb
+morphology fixes adjunction, and adjuncts never saturate. -/
+theorem SayConverbAnalysis.argument_ban (a : SayConverbAnalysis)
+    (pos : ClausePosition) (h : pos.isArgument) :
+    ¬ licensedIn a.converb pos := by
+  unfold licensedIn
+  rw [a.mergeMode_converb]
+  exact fun hn => hn h
+
+/-- The Uyghur witness: *dep* = *de* 'say' + -(I)p (his 2–3), over the
+fragment inventory. -/
+def depAnalysis : SayConverbAnalysis where
+  inventory := Uyghur.complementizers
+  surface := "dep"
+  sayRoot := Uyghur.de
+  converb := Uyghur.ip
+  say := Uyghur.deVerb
+  sayRoot_mem := .head _
+  converb_mem := .tail _ (.head _)
+  converb_conv := rfl
+  say_transitive := ⟨by decide, rfl⟩
+
+/-- Dep clauses adjoin at VP and TP (his 4, 37, 51, 56). -/
+theorem dep_adjoins_vp_and_tp :
+    licensedIn Uyghur.ip .vpAdjunct ∧ licensedIn Uyghur.ip .tpAdjunct :=
+  depAnalysis.adjoins
+
+/-- The argument ban (subject: his 49b; internal argument: §3.2):
+derived from -(I)p's converb morphology, and independent of the matrix
+verb — dep clauses occur in clearly unselected environments, as
+reasons or excuses (his 5, 53). -/
+theorem dep_never_argument (pos : ClausePosition) (h : pos.isArgument) :
+    ¬ licensedIn Uyghur.ip pos :=
+  depAnalysis.argument_ban pos h
+
+/-- His (49b): a dep clause cannot be the grammatical subject of
+'make surprised' — unlike the participial clause (his 49a). -/
+theorem dep_not_subject : ¬ licensedIn Uyghur.ip .subject :=
+  dep_never_argument .subject trivial
+
+/-- The participial strategy is the mirror image: nominalized clauses
+are licensed exactly in argument positions — subject (his 49a) and
+complement of V (his 59a, 61a) — never at the converb adjunction
+sites. Dep clauses also fail N-complement constituency: the head noun
+scrambles away from a dep clause (his 45–46) but never from a genuine
+N-complement (his 47–48). -/
+theorem participial_licensed_iff_argument :
+    ∀ pos, licensedIn Uyghur.lik pos ↔ pos.isArgument := by decide
+
+/-! ### Say-properties persist: coerced speech readings (§3.1)
+
+The persistence claim is carried by `depAnalysis` housing the single
+lexical entry `Uyghur.deVerb`: whatever the fragment records of
+main-verb 'say' holds of 'say' inside dep clauses. The same holds of
+any converb-suffixed verb — 'think' imposes its own frame inside an
+adjunct (his 42) — so the persistence is converbial, not dep-magic. -/
+
+/-- His (38)–(41): *warqira-* 'scream' has no complement frame (his
+39b, 40b), yet 'scream' + dep reports propositional content — the
+content sits in the obligatory complement of *de-* inside the
+VP-adjoined say-clause, which "coerces it into a verb of speech"
+(§3.1). No hidden frame of 'scream' is needed. -/
+theorem coerced_speech_reading :
+    Uyghur.warqira.complementType = .none ∧
+    Uyghur.deVerb.complementType ≠ .none ∧
+    licensedIn Uyghur.ip .vpAdjunct :=
+  ⟨rfl, depAnalysis.say_transitive.1, dep_adjoins_vp_and_tp.1⟩
+
+/-! ### The two heights diagnosed (his 54–55) -/
+
+/-- Positions inside the matrix clausemate domain for NCI licensing:
+Uyghur *héch-* items need clausemate negation (his 20). Everything
+merged below matrix T is in the domain; the TP-adjunct, which precedes
+the entire matrix clause (his 29, 31), is outside. -/
+def ClausePosition.clausemateWithMatrixNeg : ClausePosition → Prop
+  | .tpAdjunct => False
+  | _ => True
+
+instance : DecidablePred ClausePosition.clausemateWithMatrixNeg
+  | .complementOfV => isTrue trivial
+  | .subject       => isTrue trivial
+  | .vpAdjunct     => isTrue trivial
+  | .tpAdjunct     => isFalse id
+
+/-- His (54): matrix negation licenses an NCI inside a dep clause
+exactly at the VP site — replicating the bare -(I)p contrast (his
+22–26) — so NCI licensing diagnoses a dep clause's attachment height.
+The *shundaq*-anaphora contrast (his 55) draws the same line. -/
+theorem dep_nci_diagnoses_height :
+    ∀ pos, licensedIn Uyghur.ip pos →
+      (pos.clausemateWithMatrixNeg ↔ pos = .vpAdjunct) := by decide
+
+/-! ### The factivity alternation, derived (his 61–65) -/
+
+/-- Positions feeding a factive predicate's presupposition: only its
+complement — "factive interpretations arise from predicates taking a
+nominal complement, while non-factive interpretations arise via
+adjunction", the adjunction site being "outside the scope of the
+factive predicate" (§3.2). -/
+def ClausePosition.feedsFactivity : ClausePosition → Prop
+  | .complementOfV => True
+  | _ => False
+
+instance : DecidablePred ClausePosition.feedsFactivity
+  | .complementOfV => isTrue trivial
+  | .subject       => isFalse id
+  | .vpAdjunct     => isFalse id
+  | .tpAdjunct     => isFalse id
+
+/-- Factive scope is a subrelation of argumenthood. -/
+theorem feedsFactivity_isArgument :
+    ∀ pos : ClausePosition, pos.feedsFactivity → pos.isArgument := by decide
+
+/-- 'know' + dep is non-factive (his 61b) across the whole factive
+class (his 63), and 'forget' + dep loses the forget-that reading (his
+65): a dep clause can occupy no factivity-feeding position — a
+corollary of the argument ban, contra a per-verb homophony account the
+paper rejects (§3.2; 'know' stays presuppositional about its own
+object even with dep present, his 62). -/
+theorem dep_never_feeds_factivity (pos : ClausePosition)
+    (h : licensedIn Uyghur.ip pos) : ¬ pos.feedsFactivity :=
+  fun hf => dep_never_argument pos (feedsFactivity_isArgument pos hf) h
+
+/-- The participial contrast (his 61a, 63a–b): the nominalized clause
+sits in complement position, where factivity is fed. -/
+theorem participial_feeds_factivity :
+    licensedIn Uyghur.lik .complementOfV ∧
+    ClausePosition.feedsFactivity .complementOfV := by decide
+
+end Major2024

--- a/Linglib/Studies/Noonan2007.lean
+++ b/Linglib/Studies/Noonan2007.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Data.Complementation.Noonan2007
 import Linglib.Syntax.Minimalist.LeftPeriphery
 import Linglib.Semantics.Mood.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
@@ -11,15 +11,22 @@ realis/irrealis split, equi-deletion restriction, indicative implicational
 hierarchy) plus interconnection theorems linking it to existing linglib
 infrastructure.
 
-## Part I: Per-language CTP data + Noonan's verified generalizations
+## Part I: Noonan's generalizations over the generated CTP sample
 
-7-language CTPDatum sample (English/Latin/Turkish/Irish/Persian/Hindi-Urdu/
-Japanese) testing four Noonan generalizations:
+Data rows are generated from `Data/Complementation/Noonan2007.json`
+(module `Data.Complementation.Noonan2007`): a 7-language sample
+(English §1.1 / Latin §1.3 / Turkish §1.4 / Irish §1.5 / Persian §2.3 /
+Hindi-Urdu §2.3 / Japanese) testing three Noonan generalizations:
 
-- G1: Realis/irrealis split ([noonan-2007] Table 2.3)
 - G2: Equi-deletion restricted to reduced complement types (§2.1)
 - G3: Negative raising restricted to propAttitude/desiderative (gap-filler)
 - G4: Per-language indicative-desiderative implies indicative-propAttitude (§2.4)
+
+Analytic caveats carried over from the hand-typed rows: Persian *khastan* and
+Hindi-Urdu *chaahna* have `hasEquiDeletion := false` because their subjunctive
+subject omission is pro-drop, not Noonan-equi; English *hope* has
+`hasNegativeRaising := true` per §2.7's restriction of NR to
+{propAttitude, desiderative, modal} (Horn 1989).
 
 ## Part II: Bridge theorems
 
@@ -34,466 +41,24 @@ Five bridges connecting CTPClass to existing infrastructure:
 
 namespace Noonan2007
 
-open Clause.Complementation
+open Data.Complementation Data.Complementation.Noonan2007
 open English.Predicates.Verbal
 open Minimalist.LeftPeriphery
 open Semantics.Mood
 
 -- ============================================================================
--- Part I: Per-language CTP Data
+-- Part I: Noonan's generalizations over the generated CTP sample
 -- ============================================================================
-
-/-! ### English ([noonan-2007] §1.1) attests all six complement types. -/
-
-def english_say : CTPDatum where
-  language := "English"
-  verb := "say"
-  ctpClass := .utterance
-  allowedCompTypes := [.indicative, .paratactic]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_tell : CTPDatum where
-  language := "English"
-  verb := "tell"
-  ctpClass := .utterance
-  allowedCompTypes := [.indicative, .infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_believe : CTPDatum where
-  language := "English"
-  verb := "believe"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := true
-  hasNegativeRaising := true
-
-def english_think : CTPDatum where
-  language := "English"
-  verb := "think"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := true
-
-def english_regret : CTPDatum where
-  language := "English"
-  verb := "regret"
-  ctpClass := .commentative
-  allowedCompTypes := [.indicative, .nominalized]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_know : CTPDatum where
-  language := "English"
-  verb := "know"
-  ctpClass := .knowledge
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_realize : CTPDatum where
-  language := "English"
-  verb := "realize"
-  ctpClass := .knowledge
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_see : CTPDatum where
-  language := "English"
-  verb := "see"
-  ctpClass := .perception
-  allowedCompTypes := [.indicative, .infinitive, .participle]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_want : CTPDatum where
-  language := "English"
-  verb := "want"
-  ctpClass := .desiderative
-  allowedCompTypes := [.infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := true
-  hasNegativeRaising := true
-
-def english_hope : CTPDatum where
-  language := "English"
-  verb := "hope"
-  ctpClass := .desiderative
-  allowedCompTypes := [.indicative, .infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  -- Per [noonan-2007] §2.7, NR is restricted to {propAttitude,
-  -- desiderative, modal}. Hope is desiderative and is in the standard NR
-  -- class (Horn 1989).
-  hasNegativeRaising := true
-
-def english_wish : CTPDatum where
-  language := "English"
-  verb := "wish"
-  ctpClass := .desiderative
-  allowedCompTypes := [.indicative, .subjunctive]
-  realityStatus := .irrealis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_make : CTPDatum where
-  language := "English"
-  verb := "make"
-  ctpClass := .manipulative
-  allowedCompTypes := [.infinitive, .paratactic]
-  realityStatus := .irrealis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_persuade : CTPDatum where
-  language := "English"
-  verb := "persuade"
-  ctpClass := .manipulative
-  allowedCompTypes := [.infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_manage : CTPDatum where
-  language := "English"
-  verb := "manage"
-  ctpClass := .achievement
-  allowedCompTypes := [.infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_stop : CTPDatum where
-  language := "English"
-  verb := "stop"
-  ctpClass := .phasal
-  allowedCompTypes := [.nominalized]
-  realityStatus := .realis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_start : CTPDatum where
-  language := "English"
-  verb := "start"
-  ctpClass := .phasal
-  allowedCompTypes := [.nominalized, .infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def english_continue : CTPDatum where
-  language := "English"
-  verb := "continue"
-  ctpClass := .phasal
-  allowedCompTypes := [.nominalized, .infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-/-! ### Latin uses indicative/subjunctive split along realis/irrealis lines
-    ([noonan-2007] §1.3). -/
-
-def latin_dicere : CTPDatum where
-  language := "Latin"
-  verb := "dicere"
-  ctpClass := .utterance
-  allowedCompTypes := [.indicative, .infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := true
-  hasNegativeRaising := false
-
-def latin_credere : CTPDatum where
-  language := "Latin"
-  verb := "credere"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := true
-  hasNegativeRaising := false
-
-def latin_velle : CTPDatum where
-  language := "Latin"
-  verb := "velle"
-  ctpClass := .desiderative
-  allowedCompTypes := [.subjunctive, .infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def latin_iubere : CTPDatum where
-  language := "Latin"
-  verb := "iubere"
-  ctpClass := .manipulative
-  allowedCompTypes := [.subjunctive, .infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-/-! ### Turkish strongly favors nominalized complements
-    ([noonan-2007] §1.4). -/
-
-def turkish_sanmak : CTPDatum where
-  language := "Turkish"
-  verb := "sanmak"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.nominalized, .indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def turkish_istemek : CTPDatum where
-  language := "Turkish"
-  verb := "istemek"
-  ctpClass := .desiderative
-  allowedCompTypes := [.nominalized, .infinitive]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def turkish_baslamak : CTPDatum where
-  language := "Turkish"
-  verb := "başlamak"
-  ctpClass := .phasal
-  allowedCompTypes := [.nominalized, .infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-/-! ### Irish: finite/non-finite split with paratactic patterns
-    ([noonan-2007] §1.5). -/
-
-def irish_abair : CTPDatum where
-  language := "Irish"
-  verb := "abair"
-  ctpClass := .utterance
-  allowedCompTypes := [.indicative, .subjunctive]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def irish_ceap : CTPDatum where
-  language := "Irish"
-  verb := "ceap"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-/-! ### Persian: clear subjunctive/indicative split along CTP lines
-    ([noonan-2007] §2.3). -/
-
-def persian_goftan : CTPDatum where
-  language := "Persian"
-  verb := "goftan"
-  ctpClass := .utterance
-  allowedCompTypes := [.indicative, .subjunctive]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def persian_khastan : CTPDatum where
-  language := "Persian"
-  verb := "khastan"
-  ctpClass := .desiderative
-  allowedCompTypes := [.subjunctive]
-  realityStatus := .irrealis
-  -- Persian SUBJ pro-drop, not Noonan-equi
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def persian_danestan : CTPDatum where
-  language := "Persian"
-  verb := "danestan"
-  ctpClass := .knowledge
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-/-! ### Hindi-Urdu: subjunctive complement with desideratives
-    ([noonan-2007] §2.3). -/
-
-def hindi_urdu_sochna : CTPDatum where
-  language := "Hindi-Urdu"
-  verb := "sochna"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def hindi_urdu_jaanna : CTPDatum where
-  language := "Hindi-Urdu"
-  verb := "jaanna"
-  ctpClass := .knowledge
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def hindi_urdu_chaahna : CTPDatum where
-  language := "Hindi-Urdu"
-  verb := "chaahna"
-  ctpClass := .desiderative
-  allowedCompTypes := [.subjunctive]
-  realityStatus := .irrealis
-  -- Hindi-Urdu has PRO-drop in SUBJ, not Noonan-equi
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-/-! ### Japanese: extensive nominalized complements. -/
-
-def japanese_omou : CTPDatum where
-  language := "Japanese"
-  verb := "omou"
-  ctpClass := .propAttitude
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def japanese_shiru : CTPDatum where
-  language := "Japanese"
-  verb := "shiru"
-  ctpClass := .knowledge
-  allowedCompTypes := [.indicative]
-  realityStatus := .realis
-  hasEquiDeletion := false
-  hasRaising := false
-  hasNegativeRaising := false
-
-def japanese_hoshii : CTPDatum where
-  language := "Japanese"
-  verb := "hoshii"
-  ctpClass := .desiderative
-  allowedCompTypes := [.nominalized]
-  realityStatus := .irrealis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
-def japanese_hajimeru : CTPDatum where
-  language := "Japanese"
-  verb := "hajimeru"
-  ctpClass := .phasal
-  allowedCompTypes := [.nominalized, .infinitive]
-  realityStatus := .realis
-  hasEquiDeletion := true
-  hasRaising := false
-  hasNegativeRaising := false
-
--- ============================================================================
--- Data collections
--- ============================================================================
-
-def allEnglishCTPData : List CTPDatum := [
-  english_say, english_tell, english_believe, english_think,
-  english_regret, english_know, english_realize, english_see,
-  english_want, english_hope, english_wish,
-  english_make, english_persuade, english_manage,
-  english_stop, english_start, english_continue ]
-
-def allLatinCTPData : List CTPDatum := [
-  latin_dicere, latin_credere, latin_velle, latin_iubere ]
-
-def allTurkishCTPData : List CTPDatum := [
-  turkish_sanmak, turkish_istemek, turkish_baslamak ]
-
-def allIrishCTPData : List CTPDatum := [
-  irish_abair, irish_ceap ]
-
-def allPersianCTPData : List CTPDatum := [
-  persian_goftan, persian_khastan, persian_danestan ]
-
-def allHindiUrduCTPData : List CTPDatum := [
-  hindi_urdu_sochna, hindi_urdu_jaanna, hindi_urdu_chaahna ]
-
-def allJapaneseCTPData : List CTPDatum := [
-  japanese_omou, japanese_shiru, japanese_hoshii, japanese_hajimeru ]
-
-def allCTPData : List CTPDatum :=
-  allEnglishCTPData ++ allLatinCTPData ++ allTurkishCTPData ++
-  allIrishCTPData ++ allPersianCTPData ++ allHindiUrduCTPData ++
-  allJapaneseCTPData
-
--- ============================================================================
--- G1: Realis/irrealis split ([noonan-2007] Table 2.3)
--- ============================================================================
-
-theorem realis_classes :
-    ctpRealityStatus .utterance = .realis ∧
-    ctpRealityStatus .propAttitude = .realis ∧
-    ctpRealityStatus .commentative = .realis ∧
-    ctpRealityStatus .knowledge = .realis ∧
-    ctpRealityStatus .perception = .realis ∧
-    ctpRealityStatus .phasal = .realis := by decide
-
-theorem irrealis_classes :
-    ctpRealityStatus .desiderative = .irrealis ∧
-    ctpRealityStatus .manipulative = .irrealis ∧
-    ctpRealityStatus .modal = .irrealis ∧
-    ctpRealityStatus .achievement = .irrealis ∧
-    ctpRealityStatus .pretence = .irrealis ∧
-    ctpRealityStatus .negative = .irrealis := by decide
-
-/-- Each datum's reality status matches the CTP class's default. -/
-theorem reality_status_consistent :
-    ∀ d ∈ allCTPData, d.realityStatus = ctpRealityStatus d.ctpClass := by decide
 
 -- ============================================================================
 -- G2: Equi-deletion restriction ([noonan-2007] §2.1)
 -- ============================================================================
 
-/-- Equi-deletion only occurs when some allowed complement type is reduced. -/
+/-- Equi-deletion only occurs when some attested complement type is reduced. -/
 theorem equi_requires_reduced :
-    ∀ d ∈ allCTPData,
+    ∀ d ∈ all,
       d.hasEquiDeletion = true →
-      d.allowedCompTypes.any NoonanCompType.isReduced = true := by decide
+      d.compTypes.any NoonanCompType.isReduced = true := by decide
 
 -- ============================================================================
 -- G3: Negative raising data (fills a gap in linglib)
@@ -501,45 +66,36 @@ theorem equi_requires_reduced :
 
 /-- Negative raising verbs are exclusively propAttitude or desiderative. -/
 theorem negative_raising_class_restriction :
-    ∀ d ∈ allCTPData,
+    ∀ d ∈ all,
       d.hasNegativeRaising = true →
       d.ctpClass = .propAttitude ∨ d.ctpClass = .desiderative := by decide
 
 /-- Knowledge CTPs never support negative raising. -/
 theorem knowledge_no_negative_raising :
-    ∀ d ∈ allCTPData,
+    ∀ d ∈ all,
       d.ctpClass = .knowledge → d.hasNegativeRaising = false := by decide
 
 -- ============================================================================
 -- G4: Per-language indicative implicational hierarchy ([noonan-2007] §2.4)
 -- ============================================================================
 
-/-- Does this language use indicative with desideratives? -/
-def languageHasIndicativeDesiderative (data : List CTPDatum) (lang : String) : Bool :=
-  data.any fun d =>
-    d.language == lang && d.ctpClass == .desiderative &&
-    d.allowedCompTypes.any (· == .indicative)
+/-- Does some row of this language's list attest an indicative complement
+    for CTP class `cls`? -/
+def hasIndicativeFor (rows : List Datum) (cls : CTPClass) : Bool :=
+  rows.any fun d => d.ctpClass == cls && d.compTypes.any (· == .indicative)
 
-/-- Does this language use indicative with propAttitudes? -/
-def languageHasIndicativePropAttitude (data : List CTPDatum) (lang : String) : Bool :=
-  data.any fun d =>
-    d.language == lang && d.ctpClass == .propAttitude &&
-    d.allowedCompTypes.any (· == .indicative)
-
-/-- Implicational hierarchy per-language ([noonan-2007] §2.4): if a
-    language uses indicative for desiderative CTPs, it also uses indicative
-    for propositional-attitude CTPs.
+/-- [noonan-2007] §2.4: any sampled language using indicative with
+    desideratives also uses it with propositional attitudes.
 
     English is the only language in the sample with indicative-desiderative
     (`hope` and `wish`), so English is the only place this implication has
-    nontrivial content. The 6 other-language theorems were vacuously true
-    (false antecedent) and have been deleted. To extend this generalization
-    further, add a language with indicative-desiderative attestation
-    (Modern Greek *thélo na + indicative-mood form*; Bulgarian
-    *iskam da + present-indicative form*). -/
-theorem indicative_hierarchy_english :
-    languageHasIndicativeDesiderative allCTPData "English" = true →
-    languageHasIndicativePropAttitude allCTPData "English" = true := by native_decide
+    nontrivial content. To extend this generalization further, add a
+    language with indicative-desiderative attestation (Modern Greek
+    *thélo na + indicative-mood form*; Bulgarian *iskam da +
+    present-indicative form*). -/
+theorem indicative_hierarchy :
+    ∀ rows ∈ sample, hasIndicativeFor rows .desiderative →
+      hasIndicativeFor rows .propAttitude := by decide
 
 -- ============================================================================
 -- Part II: Bridge Theorems

--- a/Linglib/Studies/Osborne2019Control.lean
+++ b/Linglib/Studies/Osborne2019Control.lean
@@ -2,8 +2,7 @@ import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.English.Auxiliaries
 import Linglib.Syntax.DependencyGrammar.Formal.EnhancedDependencies
-import Linglib.Syntax.Clause.Complementation
-import Linglib.Studies.Noonan2007
+import Linglib.Data.Complementation.Noonan2007
 
 /-!
 # DG Control/Raising Bridge: [osborne-2019]
@@ -40,7 +39,7 @@ hasUnrepresentedArg = true ← basic tree loses embedded subject
     ↓
 classifyEnhancement =.controlSubject ← enhanced edge classified
     ↓
-CTPDatum.hasEquiDeletion ← matches [noonan-2007]'s observations
+Datum.hasEquiDeletion ← matches [noonan-2007]'s observations
 ```
 
 -/
@@ -236,20 +235,20 @@ theorem control_raising_same_enhancement :
     subjControlEnhanced.deps.length = raisingEnhanced.deps.length := rfl
 
 -- ============================================================================
--- §8: Bridge to CTPDatum — Fragment controlType predicts equi-deletion
+-- §8: Bridge to the Noonan CTP rows — Fragment controlType predicts equi-deletion
 -- ============================================================================
 
-open Clause.Complementation
-open Noonan2007
+open Data.Complementation.Noonan2007
 open English.Predicates.Verbal (manage persuade want hope stop start continue_ seem)
 
-/-- Control verbs in the Fragment have corresponding CTPDatum entries
-    with hasEquiDeletion = true ([noonan-2007] §2.1).
+/-- Control verbs in the Fragment have corresponding rows in
+    `Data.Complementation.Noonan2007` with hasEquiDeletion = true
+    ([noonan-2007] §2.1).
 
     This connects three independently specified data sources:
     1. Fragment controlType / altControlType (lexical annotation)
     2. DG enhanced dependencies (structural analysis)
-    3. CTPDatum hasEquiDeletion (typological observation)
+    3. `Datum.hasEquiDeletion` (typological observation)
 
     Note: "hope" has complementType =.finiteClause (primary frame) but
     altComplementType =.infinitival with altControlType =.subjectControl.
@@ -263,7 +262,7 @@ theorem control_predicts_equi_deletion :
     stop.controlType = .subjectControl ∧
     start.controlType = .subjectControl ∧
     continue_.controlType = .subjectControl ∧
-    -- CTPDatum says these have equi-deletion
+    -- The Noonan rows say these have equi-deletion
     english_manage.hasEquiDeletion = true ∧
     english_persuade.hasEquiDeletion = true ∧
     english_want.hasEquiDeletion = true ∧
@@ -274,8 +273,9 @@ theorem control_predicts_equi_deletion :
   ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- The raising verb "seem" is NOT marked for equi-deletion in the typology.
-    seem does not appear in allEnglishCTPData — it's a purely syntactic
-    phenomenon, not a CTP in Noonan's semantic classification. -/
+    seem does not appear in `Data.Complementation.Noonan2007.english` — it's a
+    purely syntactic phenomenon, not a CTP in Noonan's semantic
+    classification. -/
 theorem seem_is_raising_not_ctp :
     seem.controlType = .raising := rfl
 
@@ -291,11 +291,11 @@ theorem seem_is_raising_not_ctp :
     3. Basic tree LOSES John as argument of sleep ✓
     4. Enhanced graph RECOVERS John as nsubj of sleep ✓
     5. Enhanced edge classified as controlSubject ✓
-    6. CTPDatum english_manage.hasEquiDeletion = true ✓
+    6. Noonan row english_manage.hasEquiDeletion = true ✓
 
     The chain is cumulative: changing manage's controlType in the Fragment
     breaks the grounding theorem; changing the tree structure breaks the
-    information-loss proof; changing the CTPDatum breaks the bridge. -/
+    information-loss proof; changing the Noonan row breaks the bridge. -/
 theorem control_derivation_chain :
     -- Fragment grounding
     manage.controlType = .subjectControl ∧
@@ -318,7 +318,7 @@ theorem control_derivation_chain :
     3. Basic tree LOSES Mary as argument of run ✓
     4. Enhanced graph RECOVERS Mary as nsubj of run ✓
     5. Enhanced edge classified as controlSubject ✓
-    6. CTPDatum english_persuade.hasEquiDeletion = true ✓ -/
+    6. Noonan row english_persuade.hasEquiDeletion = true ✓ -/
 theorem object_control_derivation_chain :
     persuade.controlType = .objectControl ∧
     hasUniqueHeads objControlBasic = true ∧

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -3,7 +3,7 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Fragments.Mixtec.SMPM.Basic
 import Linglib.Syntax.NullSubject
 import Linglib.Studies.Landau2015
-import Linglib.Syntax.Clause.Complementation
+import Linglib.Features.Complementation
 
 /-!
 # Ostrove (2026): Obligatorily Overt PRO in San Martín Peras Mixtec
@@ -462,8 +462,6 @@ theorem buli_classified : buliProfile.classify = .overtPRONoProDrop := by decide
 -- ════════════════════════════════════════════════════════════════
 -- § 11: Complementation Typology Bridge
 -- ════════════════════════════════════════════════════════════════
-
-open Clause.Complementation
 
 /-- SMPM clause types map to [noonan-2007]'s complement typology.
 

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -1,18 +1,20 @@
 /-!
-# Clause complementation: complement-clause typology
+# Clause complementation: complement-clause surface typology
 
-[noonan-2007] [deal-2026]
+[deal-2026]
 
-[noonan-2007]'s complement-clause types and complement-taking-predicate (CTP)
-classes, plus [deal-2026]'s notional-complement surface structures and CP
-external-shell inventory. Graduated from the dissolved `Typology/` drawer; the
-unconsumed WALS subordination + Cristofaro complementation typology (and its
+[deal-2026]'s notional-complement surface structures and CP external-shell
+inventory. Graduated from the dissolved `Typology/` drawer; the unconsumed
+WALS subordination + Cristofaro complementation typology (and its
 `native_decide` distribution theorems) was dropped.
+
+[noonan-2007]'s complement-clause types and complement-taking-predicate
+classification (`NoonanCompType`, `CTPClass`, `RealityStatus`,
+`ctpRealityStatus`) live in `Features/Complementation.lean`; the generated
+CTP sample rows live in `Data/Complementation/`.
 
 ## Main definitions
 
-* `NoonanCompType` + `isReduced` — Noonan's complement-clause types.
-* `CTPClass`, `RealityStatus`, `ctpRealityStatus`, `CTPDatum` — CTP classification.
 * `ComplementClauseStructure` — surface complement-clause structure ([deal-2026]).
 * `CPShell` / `CPShellInventory` / `isAttestedShell` — CP external-shell cartography ([deal-2026]).
 -/
@@ -20,103 +22,7 @@ unconsumed WALS subordination + Cristofaro complementation typology (and its
 namespace Clause.Complementation
 
 -- ============================================================================
--- §1. Noonan Complement Typology
--- ============================================================================
-
-/-- The six major complement types attested cross-linguistically.
-    Ordered roughly from most to least "finite" (Noonan's "balanced" to
-    "deranked"). -/
-inductive NoonanCompType where
-  | indicative     -- Finite clause with indicative mood marking
-  | subjunctive    -- Finite clause with subjunctive/irrealis marking
-  | paratactic     -- Juxtaposed clause, no subordinator
-  | infinitive     -- Non-finite with "to" or equivalent
-  | nominalized    -- Gerund / action nominal
-  | participle     -- Participial complement
-  deriving DecidableEq, Repr
-
-/-- Is this complement type "reduced" (non-finite)? -/
-def NoonanCompType.isReduced : NoonanCompType → Bool
-  | .infinitive  => true
-  | .nominalized => true
-  | .participle  => true
-  | _            => false
-
-/-- Noonan's twelve CTP classes, organized by semantic contribution.
-
-    The ordering follows [noonan-2007] Table 2.1 from most to least
-    "assertive":
-    - Utterance/propAttitude/pretence: report/judge propositional content
-    - Commentative/knowledge: evaluate/know propositional content
-    - Perception: direct experience
-    - Desiderative/manipulative/modal: irrealis orientation
-    - Achievement/phasal: aspectual
-    - Negative: negation as CTP -/
-inductive CTPClass where
-  | utterance       -- say, tell, report
-  | propAttitude    -- believe, think, suppose
-  | pretence        -- pretend, act as if
-  | commentative    -- regret, be sorry
-  | knowledge       -- know, realize, discover
-  | perception      -- see, hear, feel
-  | desiderative    -- want, wish, hope
-  | manipulative    -- make, cause, persuade, order
-  | modal           -- can, must, should
-  | achievement     -- positive: manage, dare; negative: try, forget to, avoid (§3.2.10)
-  | phasal          -- start, stop, continue
-  /-- A CTP whose sole semantic content is sentential negation
-      ([noonan-2007] §3.2.13). Typologically rare; canonical examples
-      are Fijian *sega* and Shuswap negative predicates. English `avoid`,
-      `refrain`, `prevent` are NOT in this class — they are *negative
-      achievement* predicates (§3.2.10). -/
-  | negative
-  deriving DecidableEq, Repr
-
-/-- The fundamental realis/irrealis split that predicts complement type
-    selection. Realis CTPs tend toward indicative; irrealis toward
-    subjunctive/infinitive ([noonan-2007] §2.3). -/
-inductive RealityStatus where
-  | realis    -- CTP asserts or presupposes complement truth
-  | irrealis  -- CTP does not commit to complement truth
-  deriving DecidableEq, Repr
-
-/-- Default reality status of each CTP class ([noonan-2007] Table 2.3). -/
-def ctpRealityStatus : CTPClass → RealityStatus
-  | .utterance    => .realis
-  | .propAttitude => .realis
-  | .pretence     => .irrealis
-  | .commentative => .realis
-  | .knowledge    => .realis
-  | .perception   => .realis
-  | .desiderative => .irrealis
-  | .manipulative => .irrealis
-  | .modal        => .irrealis
-  | .achievement  => .irrealis
-  | .phasal       => .realis
-  | .negative     => .irrealis
-
-/-- A cross-linguistic datum about a complement-taking predicate.
-
-    Each datum records:
-    - Language and verb identification
-    - CTP class (Noonan Table 2.1)
-    - Which complement types this verb allows in this language
-    - Reality status (defaults to `ctpRealityStatus ctpClass`, but
-      overridable for exceptions)
-    - Control/raising properties ([noonan-2007] §2.1--2.2)
-    - Negative raising -/
-structure CTPDatum where
-  language : String
-  verb : String
-  ctpClass : CTPClass
-  allowedCompTypes : List NoonanCompType
-  realityStatus : RealityStatus
-  hasEquiDeletion : Bool
-  hasRaising : Bool
-  hasNegativeRaising : Bool
-  deriving DecidableEq, Repr
-
--- §8. Notional-Complement Surface Structure ([deal-2026])
+-- Notional-Complement Surface Structure ([deal-2026])
 -- ============================================================================
 
 /-! ### Theory-neutral surface enum
@@ -164,7 +70,7 @@ inductive ComplementClauseStructure where
   deriving DecidableEq, Repr
 
 -- ============================================================================
--- §9. CP External Shell Inventory ([deal-2026] Table 79)
+-- CP External Shell Inventory ([deal-2026] Table 79)
 -- ============================================================================
 
 /-! ### CP-external wrapping shells

--- a/Linglib/Syntax/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Complementizer/Basic.lean
@@ -1,8 +1,8 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.ClauseForm
+import Linglib.Features.Complementation
 import Linglib.Morphology.MorphRule
 import Linglib.Morphology.Word
-import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Complementizer
@@ -31,8 +31,6 @@ degree semantics).
 - `Complementizer.toWord` — the `SCONJ` word a free complementizer
   projects
 -/
-
-open Clause.Complementation (NoonanCompType)
 
 /-- Category of the adjacent projection an affixal clause-typer is
 licensed by: adnominal (Buryat *-Aːša*, Korean *-nun*) vs adverbal

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -33385,10 +33385,21 @@
   journal   = {Natural Language \& Linguistic Theory},
   volume    = {42},
   pages     = {1125--1190},
-  doi       = {10.1007/s11049-023-09603-3},
+  doi       = {10.1007/s11049-023-09594-1},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Studies/Major2024.lean;Fragments/Uyghur/Complementizers.lean;Studies/Angelopoulos2026.lean}
+}
+
+@phdthesis{sugar-2019,
+  author    = {Sugar, Alexander},
+  year      = {2019},
+  title     = {Verb-linking and events in syntax: {T}he case of {U}yghur -(i)p constructions},
+  school    = {University of Washington},
   subfield  = {syntax},
   role      = {cited},
-  sources   = {Phenomena/Complementation/Studies/Angelopoulos2026.lean}
+  sources   = {Fragments/Uyghur/Complementizers.lean}
 }
 
 @incollection{faure-2022,

--- a/scripts/gen_complementation.py
+++ b/scripts/gen_complementation.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate typed `Datum` literals from canonical complementation JSON.
+
+The complement-taking-predicate sample of a complementation study is canonical
+JSON at `Linglib/Data/Complementation/<Paper>.json` (an object mapping language
+keys to row arrays); this emits the kernel-reducible typed Lean module
+`Linglib/Data/Complementation/<Paper>.lean` (per-row defs, per-language lists,
+`sample`, `all` in `namespace Data.Complementation.<Paper>`). Mirrors
+`gen_wals.py`: the generated Lean is never hand-edited — edit the JSON and
+re-run. The `Linglib.lean` root import is kept in sync automatically.
+
+    python3 scripts/gen_complementation.py Noonan2007         # (re)generate
+    python3 scripts/gen_complementation.py --check [<Paper>]  # verify, no writes (CI)
+    python3 scripts/gen_complementation.py --all              # every JSON
+"""
+import sys, json, re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "Linglib" / "Data" / "Complementation"
+
+BIB_KEY = {"Noonan2007": "noonan-2007"}
+
+
+def datum_def(r: dict) -> str:
+    comps = ", ".join(f".{c}" for c in r["compTypes"])
+    verb = json.dumps(r["verb"], ensure_ascii=False)
+    flags = f"{str(r['hasEquiDeletion']).lower()}, {str(r['hasNegativeRaising']).lower()}"
+    return (
+        f"def {r['name']} : Datum :=\n"
+        f"  ⟨{verb}, .{r['ctpClass']}, [{comps}], {flags}⟩"
+    )
+
+
+def name_list(names: list, indent: str = "  ") -> str:
+    """Render `[a, b, …]` wrapped at ~96 columns."""
+    lines, cur = [], indent + "["
+    for i, n in enumerate(names):
+        item = n + ("]" if i == len(names) - 1 else ",")
+        if len(cur) + len(item) + 1 > 96 and cur.strip() != "[":
+            lines.append(cur.rstrip())
+            cur = indent + " " + item
+        else:
+            cur += (" " if cur.strip() != "[" and not cur.endswith("[") else "") + item
+    lines.append(cur)
+    return "\n".join(lines)
+
+
+def render(paper: str, data: dict) -> str:
+    key = BIB_KEY.get(paper, paper)
+    langs = list(data.keys())
+    total = sum(len(rows) for rows in data.values())
+    blocks = []
+    for lang in langs:
+        rows = data[lang]
+        defs = "\n\n".join(datum_def(r) for r in rows)
+        lst = name_list([r["name"] for r in rows])
+        blocks.append(
+            f"{defs}\n\n"
+            f"/-- The `{lang}` rows of the sample ({len(rows)} rows). -/\n"
+            f"def {lang} : List Datum :=\n{lst}"
+        )
+    body = "\n\n".join(blocks)
+    sample = name_list(langs)
+    return f"""import Linglib.Data.Complementation.Schema
+
+/-!
+# {paper} — complement-taking-predicate sample (generated)
+[{key}]
+
+Auto-generated from `Linglib/Data/Complementation/{paper}.json` by
+`scripts/gen_complementation.py`. **Do not edit by hand** — edit the JSON and
+re-run the generator. The {total} CTP rows of [{key}]'s {len(langs)}-language
+sample: per-row CTP class, attested complement types, equi-deletion, and
+negative raising.
+-/
+
+namespace Data.Complementation.{paper}
+
+{body}
+
+/-- The {len(langs)}-language sample, one row list per language. -/
+def sample : List (List Datum) :=
+{sample}
+
+/-- All {total} rows of the sample, pooled. -/
+def all : List Datum := sample.flatten
+
+end Data.Complementation.{paper}
+"""
+
+
+def ensure_import(file_path: Path, module: str) -> bool:
+    body = file_path.read_text(encoding="utf-8")
+    stmt = f"import {module}"
+    if re.search(rf"^{re.escape(stmt)}\s*$", body, flags=re.M):
+        return False
+    lines = body.splitlines(keepends=True)
+    last = max((i for i, l in enumerate(lines) if l.startswith("import ")), default=-1)
+    lines.insert(last + 1, stmt + "\n")
+    file_path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def process(paper: str, check: bool) -> bool:
+    json_path = DATA_DIR / f"{paper}.json"
+    if not json_path.exists():
+        sys.stderr.write(f"FATAL: JSON not found at {json_path.relative_to(ROOT)}\n")
+        sys.exit(1)
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    content = render(paper, data)
+    out = DATA_DIR / f"{paper}.lean"
+    total = sum(len(rows) for rows in data.values())
+    if check:
+        cur = out.read_text(encoding="utf-8") if out.exists() else ""
+        if cur != content:
+            sys.stderr.write(f"[check] DRIFT: {out.relative_to(ROOT)} out of sync with JSON\n")
+            return False
+        root = (ROOT / "Linglib.lean").read_text(encoding="utf-8")
+        for mod in (f"Linglib.Data.Complementation.{paper}",
+                    "Linglib.Data.Complementation.Schema"):
+            if f"import {mod}" not in root:
+                sys.stderr.write(f"[check] DRIFT: {mod} missing from Linglib.lean\n")
+                return False
+        sys.stdout.write(f"[check] {out.relative_to(ROOT)} in sync ({total} rows)\n")
+        return True
+    out.write_text(content, encoding="utf-8")
+    sys.stdout.write(f"[gen] {out.relative_to(ROOT)} ← {json_path.relative_to(ROOT)} ({total} rows)\n")
+    ensure_import(ROOT / "Linglib.lean", "Linglib.Data.Complementation.Schema")
+    if ensure_import(ROOT / "Linglib.lean", f"Linglib.Data.Complementation.{paper}"):
+        sys.stdout.write(f"[gen] added Linglib.Data.Complementation.{paper} import to Linglib.lean\n")
+    return True
+
+
+def main():
+    args = sys.argv[1:]
+    check = "--check" in args
+    args = [a for a in args if a != "--check"]
+    if args == ["--all"] or (not args and check):
+        papers = sorted(p.stem for p in DATA_DIR.glob("*.json"))
+    elif len(args) == 1:
+        papers = args
+    else:
+        sys.stderr.write(__doc__)
+        sys.exit(2)
+    ok = all(process(p, check) for p in papers)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Roadmap B+C of the complementizer arc (design: fourth mathlib-reviewer consult).

- **B**: `ContAnalysis` / `ContCompAnalysis extends` witness records in `Studies/Bondarenko2022.lean` — laws as construction obligations (membership, distribution-faithfulness, coverage), replacing §12's three ad-hoc theorems; `koreanAnalysis` stays at the base level (no Comp-allomorphy rule given for Korean); Tigrinya witness moved to `Studies/Cacchioli2025.lean`, fixing the 2022-cites-2025 chronology wart. The Buryat-only root-vs-suffix alignment is kept as a standalone theorem with a docstring explaining why it must not be a law (Korean's Cont exponent is itself a suffix).
- **C**: `CTPDatum` deleted. Two of its eight columns were provably dead (`hasRaising`: zero readers; `realityStatus`: redundancy proven by its own consumer theorem). Noonan enums relocated to `Features/Complementation.lean`; the 36-row sample now lives as `Data/Complementation/Noonan2007.json` + generated typed rows (`scripts/gen_complementation.py`, WALS-conventions, `--check` in CI-style sync); `Studies/Noonan2007.lean` keeps G2/G3 over the generated lists and gains a de-stringed, native_decide-free `indicative_hierarchy` over per-language row lists; ten consumer files retargeted.

Follow-up (named): Noonan2007 Part II native_decide pile; `realizes` selection relation into `Syntax/Clause/Complementation.lean`.