### PR TITLE
feat(Core): BMRS + modal μ-calculus substrate and SCiL 2026 study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -101,7 +101,9 @@ import Linglib.Core.Computability.Subregular.Language.PiecewiseTestable
 import Linglib.Core.Computability.Subregular.Language.StrictlyLocal
 import Linglib.Core.Computability.Subregular.Language.StrictlyPiecewise
 import Linglib.Core.Computability.Subregular.Language.TierStrictlyLocal
+import Linglib.Core.Computability.Subregular.Logic.BMRS
 import Linglib.Core.Computability.Subregular.Logic.LocalityBridge
+import Linglib.Core.Computability.Subregular.Logic.ModalMu
 import Linglib.Core.Computability.Subregular.Logic.QFLogic
 import Linglib.Core.Computability.Subregular.Logic.Transduction
 import Linglib.Core.Computability.Subregular.Logic.TreeModel
@@ -219,6 +221,7 @@ import Linglib.Core.Order.Comparison
 import Linglib.Core.Order.Flat
 import Linglib.Core.Order.FourierMotzkin
 import Linglib.Core.Order.Interval
+import Linglib.Core.Order.IterateFixedPoint
 import Linglib.Core.Order.IntervalContent
 import Linglib.Core.Order.LeftLinear
 import Linglib.Core.Order.Markedness

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2746,6 +2746,7 @@ import Linglib.Studies.Yalcin2007
 import Linglib.Studies.Yan2023
 import Linglib.Studies.Yang2016
 import Linglib.Studies.YingEtAl2025
+import Linglib.Studies.Yolyan2025
 import Linglib.Studies.YolyanComer2026
 import Linglib.Studies.YoonEtAl2020
 import Linglib.Studies.ZaniCiardelliSanfelici2026

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2746,6 +2746,7 @@ import Linglib.Studies.Yalcin2007
 import Linglib.Studies.Yan2023
 import Linglib.Studies.Yang2016
 import Linglib.Studies.YingEtAl2025
+import Linglib.Studies.YolyanComer2026
 import Linglib.Studies.YoonEtAl2020
 import Linglib.Studies.ZaniCiardelliSanfelici2026
 import Linglib.Studies.ZaslavskyEtAl2019

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -81,6 +81,55 @@ def Expr.or (e₁ e₂ : Expr α F) : Expr α F := .ite e₁ .tru e₂
 /-- Negation as `if…then…else` ([yolyan-2025] (3.8)). -/
 def Expr.not (e : Expr α F) : Expr α F := .ite e .fls .tru
 
+/-- Substitute a term for the variable throughout an expression: `e.subst u` is
+`e[u/x]`, the operation the μ-calculus translation writes `tr(φ)[s(x)]`. -/
+def Expr.subst : Expr α F → Term Unit → Expr α F
+  | .tru, _ => .tru
+  | .fls, _ => .fls
+  | .initial t, u => .initial (t.comp u)
+  | .final t, u => .final (t.comp u)
+  | .label s t, u => .label s (t.comp u)
+  | .call f t, u => .call f (t.comp u)
+  | .ite c e₁ e₂, u => .ite (c.subst u) (e₁.subst u) (e₂.subst u)
+
+/-- Backward expressions: every term is backward. -/
+def Expr.Backward : Expr α F → Prop
+  | .tru | .fls => True
+  | .initial t | .final t => t.Backward
+  | .label _ t => t.Backward
+  | .call _ t => t.Backward
+  | .ite c e₁ e₂ => c.Backward ∧ e₁.Backward ∧ e₂.Backward
+
+/-- Forward expressions. -/
+def Expr.Forward : Expr α F → Prop
+  | .tru | .fls => True
+  | .initial t | .final t => t.Forward
+  | .label _ t => t.Forward
+  | .call _ t => t.Forward
+  | .ite c e₁ e₂ => c.Forward ∧ e₁.Forward ∧ e₂.Forward
+
+instance Expr.instDecidableBackward : ∀ e : Expr α F, Decidable e.Backward
+  | .tru | .fls => .isTrue trivial
+  | .initial t | .final t => inferInstanceAs (Decidable t.Backward)
+  | .label _ t | .call _ t => inferInstanceAs (Decidable t.Backward)
+  | .ite c e₁ e₂ =>
+      @instDecidableAnd _ _ (Expr.instDecidableBackward c)
+        (@instDecidableAnd _ _ (Expr.instDecidableBackward e₁) (Expr.instDecidableBackward e₂))
+
+instance Expr.instDecidableForward : ∀ e : Expr α F, Decidable e.Forward
+  | .tru | .fls => .isTrue trivial
+  | .initial t | .final t => inferInstanceAs (Decidable t.Forward)
+  | .label _ t | .call _ t => inferInstanceAs (Decidable t.Forward)
+  | .ite c e₁ e₂ =>
+      @instDecidableAnd _ _ (Expr.instDecidableForward c)
+        (@instDecidableAnd _ _ (Expr.instDecidableForward e₁) (Expr.instDecidableForward e₂))
+
+/-- `BMRSᵖ`: every rule body is backward (hereditarily, through calls). -/
+def Program.Backward (P : Program α F) : Prop := ∀ f, (P f).Backward
+
+/-- `BMRSˢ`: every rule body is forward. -/
+def Program.Forward (P : Program α F) : Prop := ∀ f, (P f).Forward
+
 /-! ### Term denotation -/
 
 /-- Denotation of a BMRS term at index `i` (the judgment `w, i ⊢ T → v`). -/
@@ -318,17 +367,6 @@ theorem eval_iff_evalFuel [DecidableEq α] :
 
 /-! ### Substitution -/
 
-/-- Substitute a term for the variable throughout an expression: `e.subst u` is
-`e[u/x]`, the operation the μ-calculus translation writes `tr(φ)[s(x)]`. -/
-def Expr.subst : Expr α F → Term Unit → Expr α F
-  | .tru, _ => .tru
-  | .fls, _ => .fls
-  | .initial t, u => .initial (t.comp u)
-  | .final t, u => .final (t.comp u)
-  | .label s t, u => .label s (t.comp u)
-  | .call f t, u => .call f (t.comp u)
-  | .ite c e₁ e₂, u => .ite (c.subst u) (e₁.subst u) (e₂.subst u)
-
 /-- Term denotations sequence through composition. -/
 private theorem tden_comp_of {z : ℕ} (hu : tden w i u = some v)
     (h : tden w v t = some z) :
@@ -360,44 +398,6 @@ theorem Eval.subst (hu : tden w i u = some v) (h : Eval P w v e b) :
 locality lemmas below are what those inclusions rest on and are the engine of
 [yolyan-2025]'s negative results: the flags of a one-sided program cannot see across
 the target. Equal length is load-bearing — `min`/`max` atoms read `w.length`. -/
-
-/-- Backward expressions: every term is backward. -/
-def Expr.Backward : Expr α F → Prop
-  | .tru | .fls => True
-  | .initial t | .final t => t.Backward
-  | .label _ t => t.Backward
-  | .call _ t => t.Backward
-  | .ite c e₁ e₂ => c.Backward ∧ e₁.Backward ∧ e₂.Backward
-
-/-- Forward expressions. -/
-def Expr.Forward : Expr α F → Prop
-  | .tru | .fls => True
-  | .initial t | .final t => t.Forward
-  | .label _ t => t.Forward
-  | .call _ t => t.Forward
-  | .ite c e₁ e₂ => c.Forward ∧ e₁.Forward ∧ e₂.Forward
-
-instance Expr.instDecidableBackward : ∀ e : Expr α F, Decidable e.Backward
-  | .tru | .fls => .isTrue trivial
-  | .initial t | .final t => inferInstanceAs (Decidable t.Backward)
-  | .label _ t | .call _ t => inferInstanceAs (Decidable t.Backward)
-  | .ite c e₁ e₂ =>
-      @instDecidableAnd _ _ (Expr.instDecidableBackward c)
-        (@instDecidableAnd _ _ (Expr.instDecidableBackward e₁) (Expr.instDecidableBackward e₂))
-
-instance Expr.instDecidableForward : ∀ e : Expr α F, Decidable e.Forward
-  | .tru | .fls => .isTrue trivial
-  | .initial t | .final t => inferInstanceAs (Decidable t.Forward)
-  | .label _ t | .call _ t => inferInstanceAs (Decidable t.Forward)
-  | .ite c e₁ e₂ =>
-      @instDecidableAnd _ _ (Expr.instDecidableForward c)
-        (@instDecidableAnd _ _ (Expr.instDecidableForward e₁) (Expr.instDecidableForward e₂))
-
-/-- `BMRSᵖ`: every rule body is backward (hereditarily, through calls). -/
-def Program.Backward (P : Program α F) : Prop := ∀ f, (P f).Backward
-
-/-- `BMRSˢ`: every rule body is forward. -/
-def Program.Forward (P : Program α F) : Prop := ∀ f, (P f).Forward
 
 /-- Backward terms only move left. -/
 theorem tden_le_of_backward :

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -330,6 +330,15 @@ theorem evalFuel_sound [DecidableEq α] (h : evalFuel P w n i e = some b) :
       | true => exact .ite_true (ih hbc) (ih (by simpa using hbr))
       | false => exact .ite_false (ih hbc) (ih (by simpa using hbr))
 
+/-- Recombine a guard run and the selected branch run under one `max` fuel. -/
+private theorem evalFuel_ite_of [DecidableEq α] {c e₁ e₂ : Expr α F} {bc : Bool}
+    (hc : evalFuel P w n i c = some bc)
+    (hb : evalFuel P w m i (if bc then e₁ else e₂) = some b) :
+    evalFuel P w (max n m + 1) i (.ite c e₁ e₂) = some b := by
+  simp only [evalFuel, Option.bind_eq_some_iff]
+  exact ⟨bc, evalFuel_mono (le_max_left _ _) hc, by
+    cases bc <;> simpa using evalFuel_mono (le_max_right _ _) hb⟩
+
 /-- Completeness: every derivation is reached at some fuel. -/
 theorem evalFuel_complete [DecidableEq α] (h : Eval P w i e b) :
     ∃ n, evalFuel P w n i e = some b := by
@@ -348,17 +357,11 @@ theorem evalFuel_complete [DecidableEq α] (h : Eval P w i e b) :
   | ite_true hc h₁ ihc ih₁ =>
     obtain ⟨n₁, hn₁⟩ := ihc
     obtain ⟨n₂, hn₂⟩ := ih₁
-    exact ⟨max n₁ n₂ + 1, by
-      simp only [evalFuel, Option.bind_eq_some_iff]
-      exact ⟨true, evalFuel_mono (le_max_left _ _) hn₁, by
-        simpa using evalFuel_mono (le_max_right _ _) hn₂⟩⟩
+    exact ⟨_, evalFuel_ite_of hn₁ hn₂⟩
   | ite_false hc h₂ ihc ih₂ =>
     obtain ⟨n₁, hn₁⟩ := ihc
     obtain ⟨n₂, hn₂⟩ := ih₂
-    exact ⟨max n₁ n₂ + 1, by
-      simp only [evalFuel, Option.bind_eq_some_iff]
-      exact ⟨false, evalFuel_mono (le_max_left _ _) hn₁, by
-        simpa using evalFuel_mono (le_max_right _ _) hn₂⟩⟩
+    exact ⟨_, evalFuel_ite_of hn₁ hn₂⟩
 
 /-- **Adequacy**: the derivation system and the fuel evaluator define the same values. -/
 theorem eval_iff_evalFuel [DecidableEq α] :

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -140,8 +140,8 @@ theorem tden_comp {w : WordModel α} {i : ℕ} :
     cases hu : tden w i u with
     | none => simp [Term.comp, hu]
     | some v => simp [Term.comp, hu, tden_var (tden_lt hu)]
-  | .succ t, u => by rw [Term.comp, tden_succ, tden_comp t u, Option.bind_assoc]; rfl
-  | .pred t, u => by rw [Term.comp, tden_pred, tden_comp t u, Option.bind_assoc]; rfl
+  | .succ t, u => by simp only [Term.comp, tden_succ, tden_comp t u, Option.bind_assoc]
+  | .pred t, u => by simp only [Term.comp, tden_pred, tden_comp t u, Option.bind_assoc]
 
 end TermDenotation
 

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -86,41 +86,52 @@ def Expr.not (e : Expr α F) : Expr α F := .ite e .fls .tru
 /-- Denotation of a BMRS term at index `i` (the judgment `w, i ⊢ T → v`). -/
 def tden (w : WordModel α) (i : ℕ) (t : Term Unit) : Option ℕ := t.eval w fun _ => i
 
+section TermDenotation
+
+variable {w : WordModel α} {i v : ℕ}
+
+@[simp] theorem tden_succ {t : Term Unit} :
+    tden w i t.succ = (tden w i t).bind w.succ? := rfl
+
+@[simp] theorem tden_pred {t : Term Unit} :
+    tden w i t.pred = (tden w i t).bind w.pred? := rfl
+
+theorem tden_var_eq_some_iff : tden w i (.var ()) = some v ↔ v = i ∧ i < w.length := by
+  rw [tden, Term.eval]
+  split
+  · simp_all [WordModel.mem_iff, eq_comm]
+  · simp_all [WordModel.mem_iff]
+
 /-- Term denotations are in-domain. -/
-theorem tden_lt {w : WordModel α} {i : ℕ} :
-    ∀ {t : Term Unit} {v : ℕ}, tden w i t = some v → v < w.length
-  | .var _, v, h => by
-    rw [tden, Term.eval] at h
-    split at h <;> simp_all [WordModel.mem_iff]
-  | .succ t, v, h => by
-    simp only [tden, Term.eval, Option.bind_eq_some_iff,
-      WordModel.succ?_eq_some_iff] at h
-    obtain ⟨u, -, rfl, h⟩ := h
-    exact h
-  | .pred t, v, h => by
-    simp only [tden, Term.eval, Option.bind_eq_some_iff,
-      WordModel.pred?_eq_some_iff] at h
-    obtain ⟨u, -, -, h⟩ := h
-    exact h
+theorem tden_lt : ∀ {t : Term Unit} {v : ℕ}, tden w i t = some v → v < w.length
+  | .var _, _, h => by
+    obtain ⟨rfl, hlt⟩ := tden_var_eq_some_iff.mp h
+    exact hlt
+  | .succ t, _, h => by
+    obtain ⟨u, -, hu⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨rfl, hlt⟩ := WordModel.succ?_eq_some_iff.mp hu
+    exact hlt
+  | .pred t, _, h => by
+    obtain ⟨u, -, hu⟩ := Option.bind_eq_some_iff.mp h
+    exact (WordModel.pred?_eq_some_iff.mp hu).2
 
 /-- The variable denotes its own in-domain position. -/
-@[simp] theorem tden_var {w : WordModel α} {i : ℕ} (h : i < w.length) :
-    tden w i (.var ()) = some i := if_pos h
+@[simp] theorem tden_var (h : i < w.length) : tden w i (.var ()) = some i := if_pos h
 
 /-- A one-step successor term denotes the successor position. -/
-@[simp] theorem tden_succ_var {w : WordModel α} {i : ℕ} :
-    tden w i ((Term.var ()).succ) = w.succ? i := by
-  by_cases h : i < w.length
-  · simp [tden, Term.eval, WordModel.Mem, h]
-  · simp only [tden, Term.eval, WordModel.Mem]
-    rw [if_neg h, WordModel.succ?, if_neg (by omega)]
-    rfl
+@[simp] theorem tden_succ_var : tden w i ((Term.var ()).succ) = w.succ? i := by
+  rcases lt_or_ge i w.length with h | h
+  · rw [tden_succ, tden_var h, Option.bind_some]
+  · rw [tden_succ, tden, Term.eval, if_neg (by simpa [WordModel.Mem] using h),
+      Option.bind_none, eq_comm, Option.eq_none_iff_forall_ne_some]
+    intro m hm
+    have := (WordModel.succ?_eq_some_iff.mp hm).2
+    omega
 
 /-- A one-step predecessor term denotes the predecessor position (in-domain: off the
 right edge `pred?` is still defined at `w.length` but the variable is not). -/
-theorem tden_pred_var {w : WordModel α} {i : ℕ} (h : i < w.length) :
-    tden w i ((Term.var ()).pred) = w.pred? i := by
-  simp [tden, Term.eval, WordModel.Mem, h]
+theorem tden_pred_var (h : i < w.length) : tden w i ((Term.var ()).pred) = w.pred? i := by
+  rw [tden_pred, tden_var h, Option.bind_some]
 
 /-- Composed terms denote sequenced denotations. -/
 theorem tden_comp {w : WordModel α} {i : ℕ} :
@@ -129,14 +140,10 @@ theorem tden_comp {w : WordModel α} {i : ℕ} :
     cases hu : tden w i u with
     | none => simp [Term.comp, hu]
     | some v => simp [Term.comp, hu, tden_var (tden_lt hu)]
-  | .succ t, u => by
-    show (tden w i (t.comp u)).bind w.succ? = _
-    rw [tden_comp t u, Option.bind_assoc]
-    rfl
-  | .pred t, u => by
-    show (tden w i (t.comp u)).bind w.pred? = _
-    rw [tden_comp t u, Option.bind_assoc]
-    rfl
+  | .succ t, u => by rw [Term.comp, tden_succ, tden_comp t u, Option.bind_assoc]; rfl
+  | .pred t, u => by rw [Term.comp, tden_pred, tden_comp t u, Option.bind_assoc]; rfl
+
+end TermDenotation
 
 /-! ### The derivation system -/
 
@@ -401,26 +408,18 @@ def Program.Forward (P : Program α F) : Prop := ∀ f, (P f).Forward
 /-- Backward terms only move left. -/
 theorem tden_le_of_backward {w : WordModel α} {i : ℕ} :
     ∀ {t : Term Unit}, t.Backward → ∀ {v}, tden w i t = some v → v ≤ i
-  | .var _, _, v, h => by
-    rw [tden, Term.eval] at h
-    split at h <;> simp_all
+  | .var _, _, v, h => (tden_var_eq_some_iff.mp h).1.le
   | .pred t, ht, v, h => by
-    rw [show tden w i t.pred = (tden w i t).bind w.pred? from rfl,
-      Option.bind_eq_some_iff] at h
-    obtain ⟨u, hu, huv⟩ := h
+    obtain ⟨u, hu, huv⟩ := Option.bind_eq_some_iff.mp h
     obtain ⟨rfl, -⟩ := WordModel.pred?_eq_some_iff.mp huv
     exact Nat.le_of_succ_le (tden_le_of_backward (t := t) ht hu)
 
 /-- Forward terms only move right. -/
 theorem le_tden_of_forward {w : WordModel α} {i : ℕ} :
     ∀ {t : Term Unit}, t.Forward → ∀ {v}, tden w i t = some v → i ≤ v
-  | .var _, _, v, h => by
-    rw [tden, Term.eval] at h
-    split at h <;> simp_all
+  | .var _, _, v, h => (tden_var_eq_some_iff.mp h).1.ge
   | .succ t, ht, v, h => by
-    rw [show tden w i t.succ = (tden w i t).bind w.succ? from rfl,
-      Option.bind_eq_some_iff] at h
-    obtain ⟨u, hu, huv⟩ := h
+    obtain ⟨u, hu, huv⟩ := Option.bind_eq_some_iff.mp h
     obtain ⟨rfl, -⟩ := WordModel.succ?_eq_some_iff.mp huv
     exact (le_tden_of_forward (t := t) ht hu).trans (Nat.le_succ u)
 
@@ -429,12 +428,8 @@ words. -/
 theorem tden_congr {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} :
     ∀ t : Term Unit, tden w i t = tden w' i t
   | .var _ => by simp [tden, Term.eval, WordModel.Mem, hlen]
-  | .succ t => by
-    show (tden w i t).bind w.succ? = (tden w' i t).bind w'.succ?
-    rw [tden_congr hlen t, WordModel.succ?_congr hlen]
-  | .pred t => by
-    show (tden w i t).bind w.pred? = (tden w' i t).bind w'.pred?
-    rw [tden_congr hlen t, WordModel.pred?_congr hlen]
+  | .succ t => by rw [tden_succ, tden_succ, tden_congr hlen t, WordModel.succ?_congr hlen]
+  | .pred t => by rw [tden_pred, tden_pred, tden_congr hlen t, WordModel.pred?_congr hlen]
 
 /-- **One-sided locality (left)**: a successor-free program evaluated at `i` reads only
 positions `≤ i`, so equal-length words agreeing up to `i` evaluate identically. -/

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -1,0 +1,538 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.Subregular.Logic.QFLogic
+import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Boolean Monadic Recursive Schemes
+
+BMRS ([bhaskar-jardine-chandlee-oakden-2020]; [bhaskar-chandlee-jardine-2023];
+phonological modelling in [chandlee-jardine-2021]): programs of mutually recursive
+Boolean-valued unary predicates over word models, built from `if…then…else`, the
+edge tests `min`/`max`, input-label tests, and recursive calls. Terms are the
+quantifier-free terms of `Logic/QFLogic.lean` at a single index variable.
+
+Two symbol types dissolve the literature's `sig(P)` bookkeeping: input labels `α` get
+the lookup rule, rule heads `F` get the unfolding rule, and a `Program` is a total map
+`F → Expr α F`.
+
+Semantics is the derivation system of [yolyan-comer-2026] (Fig. 6–7), an inductive
+judgment `Eval` — faithful to partiality: a non-halting program (`f := g, g := f`)
+derives nothing. `evalFuel` is its computable face, related by `eval_iff_evalFuel`.
+
+## Main definitions
+
+* `BMRS.Expr`, `BMRS.Program` — syntax; `BMRS.tden` — term denotation at an index.
+* `BMRS.Eval` — the derivation system; `BMRS.evalFuel` — the fuel-bounded evaluator.
+* `Expr.SuccFree` / `Program.SuccFree` (dually `PredFree`) — the one-sided fragments
+  `BMRSᵖ` / `BMRSˢ` of [bhaskar-jardine-chandlee-oakden-2020].
+* `BMRS.combine` / `BMRS.combineC` — the value combinators of simultaneous application
+  (⊙, [yolyan-2025] Def. 4.1) and its conjunctive dual (⊘, Def. 6.5).
+
+## Main results
+
+* `Eval.deterministic` — an expression has at most one value.
+* `eval_iff_evalFuel` — adequacy of the fuel evaluator.
+* `Eval.congr_agreeUpto` / `Eval.congr_agreeFrom` — **one-sided locality**: a
+  successor-free program evaluated at `i` reads only positions `≤ i`, so equal-length
+  words agreeing there evaluate identically (dually for predecessor-free). The engine
+  of [yolyan-2025]'s negative results (Thm. 5.2–5.5).
+* `combine_comm`, `combine_assoc`, `combine_id` — the ⊙-algebra
+  ([yolyan-2025] Prop. 4.4), extensionally at the value level.
+-/
+
+namespace Subregular.Logic.BMRS
+
+open Subregular (AgreeUpto AgreeFrom)
+
+variable {α F : Type*}
+
+/-! ### Syntax -/
+
+/-- BMRS expressions: edge tests `initial`/`final` (the literature's `min(T)`/`max(T)`),
+input **class tests** `label` (the lookup rule; a `Finset` of symbols, so featural
+predicates like V or N over a segment alphabet are single atoms — a symbol test is the
+singleton case), rule-head calls `call` (the unfolding rule), and `if…then…else`.
+Terms are the single-variable quantifier-free terms of `Logic/QFLogic.lean`. -/
+inductive Expr (α F : Type*) where
+  | tru
+  | fls
+  | initial (t : Term Unit)
+  | final (t : Term Unit)
+  | label (s : Finset α) (t : Term Unit)
+  | call (f : F) (t : Term Unit)
+  | ite (c e₁ e₂ : Expr α F)
+  deriving DecidableEq
+
+/-- A BMRS program: one defining expression per rule head. -/
+def Program (α F : Type*) := F → Expr α F
+
+/-- Conjunction as `if…then…else` ([yolyan-2025] (3.6)). -/
+def Expr.and (e₁ e₂ : Expr α F) : Expr α F := .ite e₁ e₂ .fls
+
+/-- Disjunction as `if…then…else` ([yolyan-2025] (3.7)). -/
+def Expr.or (e₁ e₂ : Expr α F) : Expr α F := .ite e₁ .tru e₂
+
+/-- Negation as `if…then…else` ([yolyan-2025] (3.8)). -/
+def Expr.not (e : Expr α F) : Expr α F := .ite e .fls .tru
+
+/-! ### Term denotation -/
+
+/-- Denotation of a BMRS term at index `i` (the judgment `w, i ⊢ T → v`). -/
+def tden (w : WordModel α) (i : ℕ) (t : Term Unit) : Option ℕ := t.eval w fun _ => i
+
+/-- Term denotations are in-domain. -/
+theorem tden_lt {w : WordModel α} {i : ℕ} :
+    ∀ {t : Term Unit} {v : ℕ}, tden w i t = some v → v < w.length
+  | .var _, v, h => by
+    simp only [tden, Term.eval] at h
+    split at h
+    · exact (Option.some.inj h) ▸ ‹w.Mem i›
+    · exact absurd h (by simp)
+  | .succ t, v, h => by
+    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
+    obtain ⟨u, -, hu⟩ := h
+    unfold WordModel.succ? at hu
+    split at hu
+    · exact (Option.some.inj hu) ▸ ‹_›
+    · exact absurd hu (by simp)
+  | .pred t, v, h => by
+    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
+    obtain ⟨u, -, hu⟩ := h
+    cases u with
+    | zero => exact absurd hu (by simp [WordModel.pred?])
+    | succ u =>
+      simp only [WordModel.pred?] at hu
+      split at hu
+      · exact (Option.some.inj hu) ▸ Nat.lt_of_le_of_lt (Nat.le_refl _) ‹_›
+      · exact absurd hu (by simp)
+
+/-! ### The derivation system -/
+
+/-- The derivation system for BMRS expressions ([yolyan-comer-2026] Fig. 7):
+`Eval P w i e b` is `w, i ⊢_P e → b`. Partial by design: a non-halting program
+derives nothing. -/
+inductive Eval (P : Program α F) (w : WordModel α) : ℕ → Expr α F → Bool → Prop
+  | tru {i} : Eval P w i .tru true
+  | fls {i} : Eval P w i .fls false
+  | initial_true {i t} (h : tden w i t = some 0) : Eval P w i (.initial t) true
+  | initial_false {i t v} (h : tden w i t = some v) (hv : 0 < v) :
+      Eval P w i (.initial t) false
+  | final_true {i t} (h : tden w i t = some (w.length - 1)) : Eval P w i (.final t) true
+  | final_false {i t v} (h : tden w i t = some v) (hv : v < w.length - 1) :
+      Eval P w i (.final t) false
+  | label_true {i s t v a} (h : tden w i t = some v) (hl : w[v]? = some a) (has : a ∈ s) :
+      Eval P w i (.label s t) true
+  | label_false {i s t v a} (h : tden w i t = some v) (hl : w[v]? = some a) (has : a ∉ s) :
+      Eval P w i (.label s t) false
+  | call {i f t v b} (h : tden w i t = some v) (he : Eval P w v (P f) b) :
+      Eval P w i (.call f t) b
+  | ite_true {i c e₁ e₂ b} (hc : Eval P w i c true) (h₁ : Eval P w i e₁ b) :
+      Eval P w i (.ite c e₁ e₂) b
+  | ite_false {i c e₁ e₂ b} (hc : Eval P w i c false) (h₂ : Eval P w i e₂ b) :
+      Eval P w i (.ite c e₁ e₂) b
+
+/-- The derivation system is deterministic: an expression has at most one value. -/
+theorem Eval.deterministic {P : Program α F} {w : WordModel α} {i : ℕ} {e : Expr α F}
+    {b b' : Bool} (h : Eval P w i e b) (h' : Eval P w i e b') : b = b' := by
+  induction h generalizing b' with
+  | tru => cases h'; rfl
+  | fls => cases h'; rfl
+  | initial_true h => cases h' with
+    | initial_true => rfl
+    | initial_false h₂ hv => rw [h] at h₂; injection h₂ with h₂; omega
+  | initial_false h hv => cases h' with
+    | initial_true h₂ => rw [h] at h₂; injection h₂ with h₂; omega
+    | initial_false => rfl
+  | final_true h => cases h' with
+    | final_true => rfl
+    | final_false h₂ hv => rw [h] at h₂; injection h₂ with h₂; omega
+  | final_false h hv => cases h' with
+    | final_true h₂ => rw [h] at h₂; injection h₂ with h₂; omega
+    | final_false => rfl
+  | label_true h hl has => cases h' with
+    | label_true => rfl
+    | label_false h₂ hl₂ has₂ =>
+      cases h.symm.trans h₂
+      cases hl.symm.trans hl₂
+      exact absurd has has₂
+  | label_false h hl has => cases h' with
+    | label_true h₂ hl₂ has₂ =>
+      cases h.symm.trans h₂
+      cases hl.symm.trans hl₂
+      exact absurd has₂ has
+    | label_false => rfl
+  | call h he ih => cases h' with
+    | call h₂ he₂ => rw [h] at h₂; cases h₂; exact ih he₂
+  | ite_true hc h₁ ihc ih₁ => cases h' with
+    | ite_true hc₂ h₂ => exact ih₁ h₂
+    | ite_false hc₂ h₂ => exact absurd (ihc hc₂) (by simp)
+  | ite_false hc h₂ ihc ih₂ => cases h' with
+    | ite_true hc₂ h₁ => exact absurd (ihc hc₂) (by simp)
+    | ite_false hc₂ h₁ => exact ih₂ h₁
+
+/-- A program is **total on `w`** when every rule head is defined at every position. -/
+def Program.TotalOn (P : Program α F) (w : WordModel α) : Prop :=
+  ∀ f, ∀ i < w.length, ∃ b, Eval P w i (.call f (.var ())) b
+
+/-! ### The fuel evaluator -/
+
+/-- Fuel-bounded evaluator: the computable face of `Eval`. -/
+def evalFuel [DecidableEq α] (P : Program α F) (w : WordModel α) :
+    ℕ → ℕ → Expr α F → Option Bool
+  | 0, _, _ => none
+  | _ + 1, _, .tru => some true
+  | _ + 1, _, .fls => some false
+  | _ + 1, i, .initial t => (tden w i t).map (· == 0)
+  | _ + 1, i, .final t => (tden w i t).map (· == w.length - 1)
+  | _ + 1, i, .label s t => (tden w i t).bind fun v => (w[v]?).map fun a => decide (a ∈ s)
+  | fuel + 1, i, .call f t => (tden w i t).bind fun v => evalFuel P w fuel v (P f)
+  | fuel + 1, i, .ite c e₁ e₂ =>
+      (evalFuel P w fuel i c).bind fun b =>
+        if b then evalFuel P w fuel i e₁ else evalFuel P w fuel i e₂
+
+/-- More fuel never changes a defined answer. -/
+theorem evalFuel_mono [DecidableEq α] {P : Program α F} {w : WordModel α}
+    {n m i : ℕ} {e : Expr α F} {b : Bool} (hnm : n ≤ m)
+    (h : evalFuel P w n i e = some b) : evalFuel P w m i e = some b := by
+  induction n generalizing m i e b with
+  | zero => simp [evalFuel] at h
+  | succ n ih =>
+    obtain ⟨m, rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
+    cases e with
+    | tru => exact h
+    | fls => exact h
+    | initial t => exact h
+    | final t => exact h
+    | label s t => exact h
+    | call f t =>
+      simp only [evalFuel, Option.bind_eq_some_iff] at h ⊢
+      obtain ⟨v, hv, hrec⟩ := h
+      exact ⟨v, hv, ih (by omega) hrec⟩
+    | ite c e₁ e₂ =>
+      simp only [evalFuel, Option.bind_eq_some_iff] at h ⊢
+      obtain ⟨bc, hbc, hbr⟩ := h
+      refine ⟨bc, ih (by omega) hbc, ?_⟩
+      cases bc with
+      | true => simpa using ih (by omega) (by simpa using hbr)
+      | false => simpa using ih (by omega) (by simpa using hbr)
+
+/-- Soundness of the fuel evaluator against the derivation system. -/
+theorem evalFuel_sound [DecidableEq α] {P : Program α F} {w : WordModel α}
+    {n i : ℕ} {e : Expr α F} {b : Bool} (h : evalFuel P w n i e = some b) :
+    Eval P w i e b := by
+  induction n generalizing i e b with
+  | zero => simp [evalFuel] at h
+  | succ n ih =>
+    cases e with
+    | tru => simp [evalFuel] at h; exact h ▸ .tru
+    | fls => simp [evalFuel] at h; exact h ▸ .fls
+    | initial t =>
+      simp only [evalFuel, Option.map_eq_some_iff] at h
+      obtain ⟨v, hv, rfl⟩ := h
+      rcases Nat.eq_zero_or_pos v with rfl | hpos
+      · exact .initial_true hv
+      · rw [show (v == 0) = false by simp; omega]
+        exact .initial_false hv hpos
+    | final t =>
+      simp only [evalFuel, Option.map_eq_some_iff] at h
+      obtain ⟨v, hv, rfl⟩ := h
+      rcases eq_or_ne v (w.length - 1) with rfl | hne
+      · rw [show (w.length - 1 == w.length - 1) = true by simp]
+        exact .final_true hv
+      · have hlt : v < w.length - 1 := by have := tden_lt hv; omega
+        rw [show (v == w.length - 1) = false by simp [hne]]
+        exact .final_false hv hlt
+    | label s t =>
+      simp only [evalFuel, Option.bind_eq_some_iff, Option.map_eq_some_iff] at h
+      obtain ⟨v, hv, a, ha, rfl⟩ := h
+      by_cases has : a ∈ s
+      · rw [show decide (a ∈ s) = true by simp [has]]
+        exact .label_true hv ha has
+      · rw [show decide (a ∈ s) = false by simp [has]]
+        exact .label_false hv ha has
+    | call f t =>
+      simp only [evalFuel, Option.bind_eq_some_iff] at h
+      obtain ⟨v, hv, hrec⟩ := h
+      exact .call hv (ih hrec)
+    | ite c e₁ e₂ =>
+      simp only [evalFuel, Option.bind_eq_some_iff] at h
+      obtain ⟨bc, hbc, hbr⟩ := h
+      cases bc with
+      | true => exact .ite_true (ih hbc) (ih (by simpa using hbr))
+      | false => exact .ite_false (ih hbc) (ih (by simpa using hbr))
+
+/-- Completeness: every derivation is reached at some fuel. -/
+theorem evalFuel_complete [DecidableEq α] {P : Program α F} {w : WordModel α}
+    {i : ℕ} {e : Expr α F} {b : Bool} (h : Eval P w i e b) :
+    ∃ n, evalFuel P w n i e = some b := by
+  induction h with
+  | tru => exact ⟨1, rfl⟩
+  | fls => exact ⟨1, rfl⟩
+  | initial_true h => exact ⟨1, by simp [evalFuel, h]⟩
+  | initial_false h hv => exact ⟨1, by simp [evalFuel, h]; omega⟩
+  | final_true h => exact ⟨1, by simp [evalFuel, h]⟩
+  | final_false h hv => exact ⟨1, by simp [evalFuel, h]; omega⟩
+  | label_true h hl has => exact ⟨1, by simp [evalFuel, h, hl, has]⟩
+  | label_false h hl has => exact ⟨1, by simp [evalFuel, h, hl, has]⟩
+  | call h he ih =>
+    obtain ⟨n, hn⟩ := ih
+    exact ⟨n + 1, by simp [evalFuel, h, hn]⟩
+  | ite_true hc h₁ ihc ih₁ =>
+    obtain ⟨n₁, hn₁⟩ := ihc
+    obtain ⟨n₂, hn₂⟩ := ih₁
+    exact ⟨max n₁ n₂ + 1, by
+      simp only [evalFuel, Option.bind_eq_some_iff]
+      exact ⟨true, evalFuel_mono (le_max_left _ _) hn₁, by
+        simpa using evalFuel_mono (le_max_right _ _) hn₂⟩⟩
+  | ite_false hc h₂ ihc ih₂ =>
+    obtain ⟨n₁, hn₁⟩ := ihc
+    obtain ⟨n₂, hn₂⟩ := ih₂
+    exact ⟨max n₁ n₂ + 1, by
+      simp only [evalFuel, Option.bind_eq_some_iff]
+      exact ⟨false, evalFuel_mono (le_max_left _ _) hn₁, by
+        simpa using evalFuel_mono (le_max_right _ _) hn₂⟩⟩
+
+/-- **Adequacy**: the derivation system and the fuel evaluator define the same values. -/
+theorem eval_iff_evalFuel [DecidableEq α] {P : Program α F} {w : WordModel α}
+    {i : ℕ} {e : Expr α F} {b : Bool} :
+    Eval P w i e b ↔ ∃ n, evalFuel P w n i e = some b :=
+  ⟨evalFuel_complete, fun ⟨_, hn⟩ => evalFuel_sound hn⟩
+
+/-! ### One-sided fragments and locality
+
+`BMRSᵖ`-programs (successor-free) compute left-subsequentially, `BMRSˢ`-programs
+(predecessor-free) right-subsequentially ([bhaskar-jardine-chandlee-oakden-2020]). The
+locality lemmas below are what those inclusions rest on and are the engine of
+[yolyan-2025]'s negative results: the flags of a one-sided program cannot see across
+the target. Equal length is load-bearing — `min`/`max` atoms read `w.length`. -/
+
+/-- Successor-free terms: built from the variable by `pred` alone. -/
+def _root_.Subregular.Logic.Term.SuccFree : Term Unit → Prop
+  | .var _ => True
+  | .succ _ => False
+  | .pred t => Term.SuccFree t
+
+/-- Predecessor-free terms: built from the variable by `succ` alone. -/
+def _root_.Subregular.Logic.Term.PredFree : Term Unit → Prop
+  | .var _ => True
+  | .succ t => Term.PredFree t
+  | .pred _ => False
+
+/-- Successor-free expressions: every term is successor-free. -/
+def Expr.SuccFree : Expr α F → Prop
+  | .tru | .fls => True
+  | .initial t | .final t => t.SuccFree
+  | .label _ t => t.SuccFree
+  | .call _ t => t.SuccFree
+  | .ite c e₁ e₂ => c.SuccFree ∧ e₁.SuccFree ∧ e₂.SuccFree
+
+/-- Predecessor-free expressions. -/
+def Expr.PredFree : Expr α F → Prop
+  | .tru | .fls => True
+  | .initial t | .final t => t.PredFree
+  | .label _ t => t.PredFree
+  | .call _ t => t.PredFree
+  | .ite c e₁ e₂ => c.PredFree ∧ e₁.PredFree ∧ e₂.PredFree
+
+instance Term.instDecidableSuccFree : ∀ t : Term Unit, Decidable t.SuccFree
+  | .var _ => .isTrue trivial
+  | .succ _ => .isFalse not_false
+  | .pred t => Term.instDecidableSuccFree t
+
+instance Term.instDecidablePredFree : ∀ t : Term Unit, Decidable t.PredFree
+  | .var _ => .isTrue trivial
+  | .succ t => Term.instDecidablePredFree t
+  | .pred _ => .isFalse not_false
+
+instance Expr.instDecidableSuccFree : ∀ e : Expr α F, Decidable e.SuccFree
+  | .tru | .fls => .isTrue trivial
+  | .initial t | .final t => inferInstanceAs (Decidable t.SuccFree)
+  | .label _ t | .call _ t => inferInstanceAs (Decidable t.SuccFree)
+  | .ite c e₁ e₂ =>
+      @instDecidableAnd _ _ (Expr.instDecidableSuccFree c)
+        (@instDecidableAnd _ _ (Expr.instDecidableSuccFree e₁) (Expr.instDecidableSuccFree e₂))
+
+instance Expr.instDecidablePredFree : ∀ e : Expr α F, Decidable e.PredFree
+  | .tru | .fls => .isTrue trivial
+  | .initial t | .final t => inferInstanceAs (Decidable t.PredFree)
+  | .label _ t | .call _ t => inferInstanceAs (Decidable t.PredFree)
+  | .ite c e₁ e₂ =>
+      @instDecidableAnd _ _ (Expr.instDecidablePredFree c)
+        (@instDecidableAnd _ _ (Expr.instDecidablePredFree e₁) (Expr.instDecidablePredFree e₂))
+
+/-- `BMRSᵖ`: every rule body is successor-free (hereditarily, through calls). -/
+def Program.SuccFree (P : Program α F) : Prop := ∀ f, (P f).SuccFree
+
+/-- `BMRSˢ`: every rule body is predecessor-free. -/
+def Program.PredFree (P : Program α F) : Prop := ∀ f, (P f).PredFree
+
+/-- Successor-free terms only move left. -/
+theorem tden_le_of_succFree {w : WordModel α} {i : ℕ} :
+    ∀ {t : Term Unit}, t.SuccFree → ∀ {v}, tden w i t = some v → v ≤ i
+  | .var _, _, v, h => by
+    simp only [tden, Term.eval] at h
+    split at h
+    · exact (Option.some.inj h) ▸ le_rfl
+    · exact absurd h (by simp)
+  | .pred t, ht, v, h => by
+    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
+    obtain ⟨u, hu, huv⟩ := h
+    have hle : u ≤ i := tden_le_of_succFree (t := t) ht hu
+    cases u with
+    | zero => exact absurd huv (by simp [WordModel.pred?])
+    | succ u =>
+      simp only [WordModel.pred?] at huv
+      split at huv
+      · exact (Option.some.inj huv) ▸ by omega
+      · exact absurd huv (by simp)
+
+/-- Predecessor-free terms only move right. -/
+theorem le_tden_of_predFree {w : WordModel α} {i : ℕ} :
+    ∀ {t : Term Unit}, t.PredFree → ∀ {v}, tden w i t = some v → i ≤ v
+  | .var _, _, v, h => by
+    simp only [tden, Term.eval] at h
+    split at h
+    · exact (Option.some.inj h) ▸ le_rfl
+    · exact absurd h (by simp)
+  | .succ t, ht, v, h => by
+    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
+    obtain ⟨u, hu, huv⟩ := h
+    have hle : i ≤ u := le_tden_of_predFree (t := t) ht hu
+    unfold WordModel.succ? at huv
+    split at huv
+    · exact (Option.some.inj huv) ▸ by omega
+    · exact absurd huv (by simp)
+
+/-- Term denotations read only the length, so they transport across equal-length
+words. -/
+theorem tden_congr {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} :
+    ∀ t : Term Unit, tden w i t = tden w' i t
+  | .var _ => by simp [tden, Term.eval, WordModel.Mem, hlen]
+  | .succ t => by
+    simp only [tden, Term.eval]
+    rw [show Term.eval w (fun _ => i) t = Term.eval w' (fun _ => i) t from tden_congr hlen t]
+    cases Term.eval w' (fun _ => i) t with
+    | none => rfl
+    | some u => simp [WordModel.succ?, hlen]
+  | .pred t => by
+    simp only [tden, Term.eval]
+    rw [show Term.eval w (fun _ => i) t = Term.eval w' (fun _ => i) t from tden_congr hlen t]
+    cases Term.eval w' (fun _ => i) t with
+    | none => rfl
+    | some u => cases u <;> simp [WordModel.pred?, hlen]
+
+/-- **One-sided locality (left)**: a successor-free program evaluated at `i` reads only
+positions `≤ i`, so equal-length words agreeing up to `i` evaluate identically. -/
+theorem Eval.congr_agreeUpto {P : Program α F} (hP : P.SuccFree)
+    {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} {e : Expr α F} {b : Bool}
+    (h : Eval P w i e b) :
+    e.SuccFree → AgreeUpto w w' i → Eval P w' i e b := by
+  induction h with
+  | tru => exact fun _ _ => .tru
+  | fls => exact fun _ _ => .fls
+  | initial_true h => exact fun he _ => .initial_true (tden_congr hlen _ ▸ h)
+  | initial_false h hv => exact fun he _ => .initial_false (tden_congr hlen _ ▸ h) hv
+  | final_true h =>
+    intro he _
+    exact .final_true (by rw [← tden_congr hlen, ← hlen]; exact h)
+  | final_false h hv =>
+    intro he _
+    exact .final_false (by rw [← tden_congr hlen]; exact h) (hlen ▸ hv)
+  | label_true h hl has =>
+    intro he hag
+    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_succFree he h) ▸ hl) has
+  | label_false h hl has =>
+    intro he hag
+    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_succFree he h) ▸ hl) has
+  | call h he' ih =>
+    intro he hag
+    exact .call (tden_congr hlen _ ▸ h)
+      (ih (hP _) fun k hk => hag k (hk.trans (tden_le_of_succFree he h)))
+  | ite_true hc h₁ ihc ih₁ =>
+    intro he hag
+    exact .ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
+  | ite_false hc h₂ ihc ih₂ =>
+    intro he hag
+    exact .ite_false (ihc he.1 hag) (ih₂ he.2.2 hag)
+
+/-- **One-sided locality (right)**: a predecessor-free program evaluated at `i` reads
+only positions `≥ i`, so equal-length words agreeing from `i` on evaluate identically. -/
+theorem Eval.congr_agreeFrom {P : Program α F} (hP : P.PredFree)
+    {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} {e : Expr α F} {b : Bool}
+    (h : Eval P w i e b) :
+    e.PredFree → AgreeFrom w w' i → Eval P w' i e b := by
+  induction h with
+  | tru => exact fun _ _ => .tru
+  | fls => exact fun _ _ => .fls
+  | initial_true h => exact fun he _ => .initial_true (tden_congr hlen _ ▸ h)
+  | initial_false h hv => exact fun he _ => .initial_false (tden_congr hlen _ ▸ h) hv
+  | final_true h =>
+    intro he _
+    exact .final_true (by rw [← tden_congr hlen, ← hlen]; exact h)
+  | final_false h hv =>
+    intro he _
+    exact .final_false (by rw [← tden_congr hlen]; exact h) (hlen ▸ hv)
+  | label_true h hl has =>
+    intro he hag
+    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_predFree he h) ▸ hl) has
+  | label_false h hl has =>
+    intro he hag
+    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_predFree he h) ▸ hl) has
+  | call h he' ih =>
+    intro he hag
+    exact .call (tden_congr hlen _ ▸ h)
+      (ih (hP _) fun k hk => hag k ((le_tden_of_predFree he h).trans hk))
+  | ite_true hc h₁ ihc ih₁ =>
+    intro he hag
+    exact .ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
+  | ite_false hc h₂ ihc ih₂ =>
+    intro he hag
+    exact .ite_false (ihc he.1 hag) (ih₂ he.2.2 hag)
+
+/-! ### Simultaneous application, at the value level
+
+[yolyan-2025] Def. 4.1 (⊙) and Def. 6.5 (⊘) act per input position on the input value
+and the two programs' output values; the program-level operators lift these pointwise.
+Stating the algebra ([yolyan-2025] Prop. 4.4) on values keeps it a finite `Bool`
+computation and spares the combined-head-space transport. -/
+
+/-- Simultaneous application ⊙ on values ([yolyan-2025] Def. 4.1): a change survives
+iff either program makes it. -/
+def combine (pin a b : Bool) : Bool := if pin then a && b else a || b
+
+/-- Conjunctive simultaneous application ⊘ on values ([yolyan-2025] Def. 6.5): a change
+survives iff both programs make it. -/
+def combineC (pin a b : Bool) : Bool := if pin then a || b else a && b
+
+/-- A ⊙-value differs from the input iff one of the components does
+([yolyan-2025] Prop. 4.2): the changes of the simultaneous application are the union
+of the changes. -/
+theorem combine_ne_iff (pin a b : Bool) :
+    combine pin a b ≠ pin ↔ a ≠ pin ∨ b ≠ pin := by decide +revert
+
+theorem combine_comm (pin a b : Bool) : combine pin a b = combine pin b a := by
+  decide +revert
+
+theorem combine_assoc (pin a b c : Bool) :
+    combine pin (combine pin a b) c = combine pin a (combine pin b c) := by decide +revert
+
+/-- The input itself is a ⊙-identity ([yolyan-2025] Prop. 4.4(iii)). -/
+theorem combine_id (pin a : Bool) : combine pin a pin = a := by decide +revert
+
+/-- ⊘ is the De Morgan dual of ⊙: negate the two output values, not the input. -/
+theorem combineC_eq_not_combine (pin a b : Bool) :
+    combineC pin a b = !combine pin (!a) (!b) := by decide +revert
+
+theorem combineC_comm (pin a b : Bool) : combineC pin a b = combineC pin b a := by
+  decide +revert
+
+theorem combineC_assoc (pin a b c : Bool) :
+    combineC pin (combineC pin a b) c = combineC pin a (combineC pin b c) := by
+  decide +revert
+
+end Subregular.Logic.BMRS

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -88,12 +88,12 @@ def tden (w : WordModel α) (i : ℕ) (t : Term Unit) : Option ℕ := t.eval w f
 
 section TermDenotation
 
-variable {w : WordModel α} {i v : ℕ}
+variable {w : WordModel α} {i v : ℕ} {t u : Term Unit}
 
-@[simp] theorem tden_succ {t : Term Unit} :
+@[simp] theorem tden_succ :
     tden w i t.succ = (tden w i t).bind w.succ? := rfl
 
-@[simp] theorem tden_pred {t : Term Unit} :
+@[simp] theorem tden_pred :
     tden w i t.pred = (tden w i t).bind w.pred? := rfl
 
 theorem tden_var_eq_some_iff : tden w i (.var ()) = some v ↔ v = i ∧ i < w.length := by
@@ -134,7 +134,7 @@ theorem tden_pred_var (h : i < w.length) : tden w i ((Term.var ()).pred) = w.pre
   rw [tden_pred, tden_var h, Option.bind_some]
 
 /-- Composed terms denote sequenced denotations. -/
-theorem tden_comp {w : WordModel α} {i : ℕ} :
+theorem tden_comp :
     ∀ t u : Term Unit, tden w i (t.comp u) = (tden w i u).bind fun v => tden w v t
   | .var _, u => by
     cases hu : tden w i u with
@@ -170,17 +170,18 @@ inductive Eval (P : Program α F) (w : WordModel α) : ℕ → Expr α F → Boo
   | ite_false {i c e₁ e₂ b} (hc : Eval P w i c false) (h₂ : Eval P w i e₂ b) :
       Eval P w i (.ite c e₁ e₂) b
 
+variable {P : Program α F} {w w' : WordModel α} {i v n m : ℕ} {t u : Term Unit}
+  {e : Expr α F} {b b' : Bool}
+
 /-- Boolean-form introduction for the edge test: the value is the comparison. -/
-theorem Eval.initial {P : Program α F} {w : WordModel α} {i v : ℕ} {t : Term Unit}
-    (h : tden w i t = some v) : Eval P w i (.initial t) (v == 0) := by
+theorem Eval.initial (h : tden w i t = some v) : Eval P w i (.initial t) (v == 0) := by
   rcases Nat.eq_zero_or_pos v with rfl | hv
   · exact .initial_true h
   · rw [beq_eq_false_iff_ne.mpr (by omega)]
     exact .initial_false h hv
 
 /-- Boolean-form introduction for the final test. -/
-theorem Eval.final {P : Program α F} {w : WordModel α} {i v : ℕ} {t : Term Unit}
-    (h : tden w i t = some v) : Eval P w i (.final t) (v == w.length - 1) := by
+theorem Eval.final (h : tden w i t = some v) : Eval P w i (.final t) (v == w.length - 1) := by
   rcases eq_or_ne v (w.length - 1) with rfl | hne
   · rw [beq_self_eq_true]
     exact .final_true h
@@ -188,8 +189,7 @@ theorem Eval.final {P : Program α F} {w : WordModel α} {i v : ℕ} {t : Term U
     exact .final_false h (by have := tden_lt h; omega)
 
 /-- Boolean-form introduction for the class test. -/
-theorem Eval.label [DecidableEq α] {P : Program α F} {w : WordModel α} {i v : ℕ}
-    {t : Term Unit} {s : Finset α} {a : α} (h : tden w i t = some v)
+theorem Eval.label [DecidableEq α] {s : Finset α} {a : α} (h : tden w i t = some v)
     (hl : w[v]? = some a) : Eval P w i (.label s t) (decide (a ∈ s)) := by
   by_cases has : a ∈ s
   · rw [decide_eq_true has]
@@ -198,8 +198,7 @@ theorem Eval.label [DecidableEq α] {P : Program α F} {w : WordModel α} {i v :
     exact .label_false h hl has
 
 /-- The derivation system is deterministic: an expression has at most one value. -/
-theorem Eval.deterministic {P : Program α F} {w : WordModel α} {i : ℕ} {e : Expr α F}
-    {b b' : Bool} (h : Eval P w i e b) (h' : Eval P w i e b') : b = b' := by
+theorem Eval.deterministic (h : Eval P w i e b) (h' : Eval P w i e b') : b = b' := by
   induction h generalizing b' with
   | call h he ih => cases h' with
     | call h₂ he₂ => rw [h] at h₂; cases h₂; exact ih he₂
@@ -232,8 +231,7 @@ def evalFuel [DecidableEq α] (P : Program α F) (w : WordModel α) :
         if b then evalFuel P w fuel i e₁ else evalFuel P w fuel i e₂
 
 /-- More fuel never changes a defined answer. -/
-theorem evalFuel_mono [DecidableEq α] {P : Program α F} {w : WordModel α}
-    {n m i : ℕ} {e : Expr α F} {b : Bool} (hnm : n ≤ m)
+theorem evalFuel_mono [DecidableEq α] (hnm : n ≤ m)
     (h : evalFuel P w n i e = some b) : evalFuel P w m i e = some b := by
   induction n generalizing m i e b with
   | zero => simp [evalFuel] at h
@@ -252,8 +250,7 @@ theorem evalFuel_mono [DecidableEq α] {P : Program α F} {w : WordModel α}
     | _ => exact h
 
 /-- Soundness of the fuel evaluator against the derivation system. -/
-theorem evalFuel_sound [DecidableEq α] {P : Program α F} {w : WordModel α}
-    {n i : ℕ} {e : Expr α F} {b : Bool} (h : evalFuel P w n i e = some b) :
+theorem evalFuel_sound [DecidableEq α] (h : evalFuel P w n i e = some b) :
     Eval P w i e b := by
   induction n generalizing i e b with
   | zero => simp [evalFuel] at h
@@ -285,8 +282,7 @@ theorem evalFuel_sound [DecidableEq α] {P : Program α F} {w : WordModel α}
       | false => exact .ite_false (ih hbc) (ih (by simpa using hbr))
 
 /-- Completeness: every derivation is reached at some fuel. -/
-theorem evalFuel_complete [DecidableEq α] {P : Program α F} {w : WordModel α}
-    {i : ℕ} {e : Expr α F} {b : Bool} (h : Eval P w i e b) :
+theorem evalFuel_complete [DecidableEq α] (h : Eval P w i e b) :
     ∃ n, evalFuel P w n i e = some b := by
   induction h with
   | tru => exact ⟨1, rfl⟩
@@ -316,8 +312,7 @@ theorem evalFuel_complete [DecidableEq α] {P : Program α F} {w : WordModel α}
         simpa using evalFuel_mono (le_max_right _ _) hn₂⟩⟩
 
 /-- **Adequacy**: the derivation system and the fuel evaluator define the same values. -/
-theorem eval_iff_evalFuel [DecidableEq α] {P : Program α F} {w : WordModel α}
-    {i : ℕ} {e : Expr α F} {b : Bool} :
+theorem eval_iff_evalFuel [DecidableEq α] :
     Eval P w i e b ↔ ∃ n, evalFuel P w n i e = some b :=
   ⟨evalFuel_complete, fun ⟨_, hn⟩ => evalFuel_sound hn⟩
 
@@ -335,16 +330,15 @@ def Expr.subst : Expr α F → Term Unit → Expr α F
   | .ite c e₁ e₂, u => .ite (c.subst u) (e₁.subst u) (e₂.subst u)
 
 /-- Term denotations sequence through composition. -/
-private theorem tden_comp_of {w : WordModel α} {u t : Term Unit} {i v z : ℕ}
-    (hu : tden w i u = some v) (h : tden w v t = some z) :
+private theorem tden_comp_of {z : ℕ} (hu : tden w i u = some v)
+    (h : tden w v t = some z) :
     tden w i (t.comp u) = some z := by
   rw [tden_comp, hu]
   exact h
 
 /-- Transport a derivation through substitution: evaluating `e[u/x]` at `i` is
 evaluating `e` at the position `u` denotes. -/
-theorem Eval.subst {P : Program α F} {w : WordModel α} {u : Term Unit} {i v : ℕ}
-    (hu : tden w i u = some v) {e : Expr α F} {b : Bool} (h : Eval P w v e b) :
+theorem Eval.subst (hu : tden w i u = some v) (h : Eval P w v e b) :
     Eval P w i (e.subst u) b := by
   induction h with
   | tru => exact .tru
@@ -406,7 +400,7 @@ def Program.Backward (P : Program α F) : Prop := ∀ f, (P f).Backward
 def Program.Forward (P : Program α F) : Prop := ∀ f, (P f).Forward
 
 /-- Backward terms only move left. -/
-theorem tden_le_of_backward {w : WordModel α} {i : ℕ} :
+theorem tden_le_of_backward :
     ∀ {t : Term Unit}, t.Backward → ∀ {v}, tden w i t = some v → v ≤ i
   | .var _, _, v, h => (tden_var_eq_some_iff.mp h).1.le
   | .pred t, ht, v, h => by
@@ -415,7 +409,7 @@ theorem tden_le_of_backward {w : WordModel α} {i : ℕ} :
     exact Nat.le_of_succ_le (tden_le_of_backward (t := t) ht hu)
 
 /-- Forward terms only move right. -/
-theorem le_tden_of_forward {w : WordModel α} {i : ℕ} :
+theorem le_tden_of_forward :
     ∀ {t : Term Unit}, t.Forward → ∀ {v}, tden w i t = some v → i ≤ v
   | .var _, _, v, h => (tden_var_eq_some_iff.mp h).1.ge
   | .succ t, ht, v, h => by
@@ -425,7 +419,7 @@ theorem le_tden_of_forward {w : WordModel α} {i : ℕ} :
 
 /-- Term denotations read only the length, so they transport across equal-length
 words. -/
-theorem tden_congr {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} :
+theorem tden_congr (hlen : w.length = w'.length) :
     ∀ t : Term Unit, tden w i t = tden w' i t
   | .var _ => by simp [tden, Term.eval, WordModel.Mem, hlen]
   | .succ t => by rw [tden_succ, tden_succ, tden_congr hlen t, WordModel.succ?_congr hlen]
@@ -433,71 +427,63 @@ theorem tden_congr {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ}
 
 /-- **One-sided locality (left)**: a successor-free program evaluated at `i` reads only
 positions `≤ i`, so equal-length words agreeing up to `i` evaluate identically. -/
-theorem Eval.congr_agreeUpto {P : Program α F} (hP : P.Backward)
-    {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} {e : Expr α F} {b : Bool}
+theorem Eval.congr_agreeUpto (hP : P.Backward) (hlen : w.length = w'.length)
     (h : Eval P w i e b) :
     e.Backward → AgreeUpto w w' i → Eval P w' i e b := by
   induction h with
   | tru => exact fun _ _ => .tru
   | fls => exact fun _ _ => .fls
-  | initial_true h => exact fun he _ => .initial_true (tden_congr hlen _ ▸ h)
-  | initial_false h hv => exact fun he _ => .initial_false (tden_congr hlen _ ▸ h) hv
+  | initial_true h =>
+    exact fun _ _ => Eval.initial_true ((tden_congr hlen _).symm.trans h)
+  | initial_false h hv =>
+    exact fun _ _ => Eval.initial_false ((tden_congr hlen _).symm.trans h) hv
   | final_true h =>
-    intro he _
-    exact .final_true (by rw [← tden_congr hlen, ← hlen]; exact h)
+    exact fun _ _ => Eval.final_true ((tden_congr hlen _).symm.trans (hlen ▸ h))
   | final_false h hv =>
-    intro he _
-    exact .final_false (by rw [← tden_congr hlen]; exact h) (hlen ▸ hv)
+    exact fun _ _ => Eval.final_false ((tden_congr hlen _).symm.trans h) (hlen ▸ hv)
   | label_true h hl has =>
-    intro he hag
-    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_backward he h) ▸ hl) has
+    exact fun he hag => Eval.label_true ((tden_congr hlen _).symm.trans h)
+      (hag _ (tden_le_of_backward he h) ▸ hl) has
   | label_false h hl has =>
-    intro he hag
-    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_backward he h) ▸ hl) has
+    exact fun he hag => Eval.label_false ((tden_congr hlen _).symm.trans h)
+      (hag _ (tden_le_of_backward he h) ▸ hl) has
   | call h he' ih =>
-    intro he hag
-    exact .call (tden_congr hlen _ ▸ h)
+    exact fun he hag => Eval.call ((tden_congr hlen _).symm.trans h)
       (ih (hP _) fun k hk => hag k (hk.trans (tden_le_of_backward he h)))
   | ite_true hc h₁ ihc ih₁ =>
-    intro he hag
-    exact .ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
+    exact fun he hag => Eval.ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
   | ite_false hc h₂ ihc ih₂ =>
-    intro he hag
-    exact .ite_false (ihc he.1 hag) (ih₂ he.2.2 hag)
+    exact fun he hag => Eval.ite_false (ihc he.1 hag) (ih₂ he.2.2 hag)
 
 /-- **One-sided locality (right)**: a predecessor-free program evaluated at `i` reads
 only positions `≥ i`, so equal-length words agreeing from `i` on evaluate identically. -/
-theorem Eval.congr_agreeFrom {P : Program α F} (hP : P.Forward)
-    {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} {e : Expr α F} {b : Bool}
+theorem Eval.congr_agreeFrom (hP : P.Forward) (hlen : w.length = w'.length)
     (h : Eval P w i e b) :
     e.Forward → AgreeFrom w w' i → Eval P w' i e b := by
   induction h with
   | tru => exact fun _ _ => .tru
   | fls => exact fun _ _ => .fls
-  | initial_true h => exact fun he _ => .initial_true (tden_congr hlen _ ▸ h)
-  | initial_false h hv => exact fun he _ => .initial_false (tden_congr hlen _ ▸ h) hv
+  | initial_true h =>
+    exact fun _ _ => Eval.initial_true ((tden_congr hlen _).symm.trans h)
+  | initial_false h hv =>
+    exact fun _ _ => Eval.initial_false ((tden_congr hlen _).symm.trans h) hv
   | final_true h =>
-    intro he _
-    exact .final_true (by rw [← tden_congr hlen, ← hlen]; exact h)
+    exact fun _ _ => Eval.final_true ((tden_congr hlen _).symm.trans (hlen ▸ h))
   | final_false h hv =>
-    intro he _
-    exact .final_false (by rw [← tden_congr hlen]; exact h) (hlen ▸ hv)
+    exact fun _ _ => Eval.final_false ((tden_congr hlen _).symm.trans h) (hlen ▸ hv)
   | label_true h hl has =>
-    intro he hag
-    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_forward he h) ▸ hl) has
+    exact fun he hag => Eval.label_true ((tden_congr hlen _).symm.trans h)
+      (hag _ (le_tden_of_forward he h) ▸ hl) has
   | label_false h hl has =>
-    intro he hag
-    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_forward he h) ▸ hl) has
+    exact fun he hag => Eval.label_false ((tden_congr hlen _).symm.trans h)
+      (hag _ (le_tden_of_forward he h) ▸ hl) has
   | call h he' ih =>
-    intro he hag
-    exact .call (tden_congr hlen _ ▸ h)
+    exact fun he hag => Eval.call ((tden_congr hlen _).symm.trans h)
       (ih (hP _) fun k hk => hag k ((le_tden_of_forward he h).trans hk))
   | ite_true hc h₁ ihc ih₁ =>
-    intro he hag
-    exact .ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
+    exact fun he hag => Eval.ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
   | ite_false hc h₂ ihc ih₂ =>
-    intro he hag
-    exact .ite_false (ihc he.1 hag) (ih₂ he.2.2 hag)
+    exact fun he hag => Eval.ite_false (ihc he.1 hag) (ih₂ he.2.2 hag)
 
 /-! ### Simultaneous application, at the value level
 

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -28,7 +28,7 @@ derives nothing. `evalFuel` is its computable face, related by `eval_iff_evalFue
 
 * `BMRS.Expr`, `BMRS.Program` — syntax; `BMRS.tden` — term denotation at an index.
 * `BMRS.Eval` — the derivation system; `BMRS.evalFuel` — the fuel-bounded evaluator.
-* `Expr.SuccFree` / `Program.SuccFree` (dually `PredFree`) — the one-sided fragments
+* `Expr.Backward` / `Program.Backward` (dually `PredFree`) — the one-sided fragments
   `BMRSᵖ` / `BMRSˢ` of [bhaskar-jardine-chandlee-oakden-2020].
 * `BMRS.combine` / `BMRS.combineC` — the value combinators of simultaneous application
   (⊙, [yolyan-2025] Def. 4.1) and its conjunctive dual (⊘, Def. 6.5).
@@ -69,7 +69,7 @@ inductive Expr (α F : Type*) where
   deriving DecidableEq
 
 /-- A BMRS program: one defining expression per rule head. -/
-def Program (α F : Type*) := F → Expr α F
+abbrev Program (α F : Type*) := F → Expr α F
 
 /-- Conjunction as `if…then…else` ([yolyan-2025] (3.6)). -/
 def Expr.and (e₁ e₂ : Expr α F) : Expr α F := .ite e₁ e₂ .fls
@@ -89,27 +89,53 @@ def tden (w : WordModel α) (i : ℕ) (t : Term Unit) : Option ℕ := t.eval w f
 theorem tden_lt {w : WordModel α} {i : ℕ} :
     ∀ {t : Term Unit} {v : ℕ}, tden w i t = some v → v < w.length
   | .var _, v, h => by
-    simp only [tden, Term.eval] at h
-    split at h
-    · exact (Option.some.inj h) ▸ ‹w.Mem i›
-    · exact absurd h (by simp)
+    rw [tden, Term.eval] at h
+    split at h <;> simp_all [WordModel.mem_iff]
   | .succ t, v, h => by
-    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
-    obtain ⟨u, -, hu⟩ := h
-    unfold WordModel.succ? at hu
-    split at hu
-    · exact (Option.some.inj hu) ▸ ‹_›
-    · exact absurd hu (by simp)
+    simp only [tden, Term.eval, Option.bind_eq_some_iff,
+      WordModel.succ?_eq_some_iff] at h
+    obtain ⟨u, -, rfl, h⟩ := h
+    exact h
   | .pred t, v, h => by
-    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
-    obtain ⟨u, -, hu⟩ := h
-    cases u with
-    | zero => exact absurd hu (by simp [WordModel.pred?])
-    | succ u =>
-      simp only [WordModel.pred?] at hu
-      split at hu
-      · exact (Option.some.inj hu) ▸ Nat.lt_of_le_of_lt (Nat.le_refl _) ‹_›
-      · exact absurd hu (by simp)
+    simp only [tden, Term.eval, Option.bind_eq_some_iff,
+      WordModel.pred?_eq_some_iff] at h
+    obtain ⟨u, -, -, h⟩ := h
+    exact h
+
+/-- The variable denotes its own in-domain position. -/
+@[simp] theorem tden_var {w : WordModel α} {i : ℕ} (h : i < w.length) :
+    tden w i (.var ()) = some i := if_pos h
+
+/-- A one-step successor term denotes the successor position. -/
+@[simp] theorem tden_succ_var {w : WordModel α} {i : ℕ} :
+    tden w i ((Term.var ()).succ) = w.succ? i := by
+  by_cases h : i < w.length
+  · simp [tden, Term.eval, WordModel.Mem, h]
+  · simp only [tden, Term.eval, WordModel.Mem]
+    rw [if_neg h, WordModel.succ?, if_neg (by omega)]
+    rfl
+
+/-- A one-step predecessor term denotes the predecessor position (in-domain: off the
+right edge `pred?` is still defined at `w.length` but the variable is not). -/
+theorem tden_pred_var {w : WordModel α} {i : ℕ} (h : i < w.length) :
+    tden w i ((Term.var ()).pred) = w.pred? i := by
+  simp [tden, Term.eval, WordModel.Mem, h]
+
+/-- Composed terms denote sequenced denotations. -/
+theorem tden_comp {w : WordModel α} {i : ℕ} :
+    ∀ t u : Term Unit, tden w i (t.comp u) = (tden w i u).bind fun v => tden w v t
+  | .var _, u => by
+    cases hu : tden w i u with
+    | none => simp [Term.comp, hu]
+    | some v => simp [Term.comp, hu, tden_var (tden_lt hu)]
+  | .succ t, u => by
+    show (tden w i (t.comp u)).bind w.succ? = _
+    rw [tden_comp t u, Option.bind_assoc]
+    rfl
+  | .pred t, u => by
+    show (tden w i (t.comp u)).bind w.pred? = _
+    rw [tden_comp t u, Option.bind_assoc]
+    rfl
 
 /-! ### The derivation system -/
 
@@ -303,6 +329,37 @@ theorem eval_iff_evalFuel [DecidableEq α] {P : Program α F} {w : WordModel α}
     Eval P w i e b ↔ ∃ n, evalFuel P w n i e = some b :=
   ⟨evalFuel_complete, fun ⟨_, hn⟩ => evalFuel_sound hn⟩
 
+/-! ### Substitution -/
+
+/-- Substitute a term for the variable throughout an expression: `e.subst u` is
+`e[u/x]`, the operation the μ-calculus translation writes `tr(φ)[s(x)]`. -/
+def Expr.subst : Expr α F → Term Unit → Expr α F
+  | .tru, _ => .tru
+  | .fls, _ => .fls
+  | .initial t, u => .initial (t.comp u)
+  | .final t, u => .final (t.comp u)
+  | .label s t, u => .label s (t.comp u)
+  | .call f t, u => .call f (t.comp u)
+  | .ite c e₁ e₂, u => .ite (c.subst u) (e₁.subst u) (e₂.subst u)
+
+/-- Transport a derivation through substitution: evaluating `e[u/x]` at `i` is
+evaluating `e` at the position `u` denotes. -/
+theorem Eval.subst {P : Program α F} {w : WordModel α} {u : Term Unit} {i v : ℕ}
+    (hu : tden w i u = some v) {e : Expr α F} {b : Bool} (h : Eval P w v e b) :
+    Eval P w i (e.subst u) b := by
+  induction h with
+  | tru => exact .tru
+  | fls => exact .fls
+  | initial_true h => exact .initial_true (by rw [tden_comp, hu]; exact h)
+  | initial_false h hv => exact .initial_false (by rw [tden_comp, hu]; exact h) hv
+  | final_true h => exact .final_true (by rw [tden_comp, hu]; exact h)
+  | final_false h hv => exact .final_false (by rw [tden_comp, hu]; exact h) hv
+  | label_true h hl has => exact .label_true (by rw [tden_comp, hu]; exact h) hl has
+  | label_false h hl has => exact .label_false (by rw [tden_comp, hu]; exact h) hl has
+  | call h he ih => exact .call (by rw [tden_comp, hu]; exact h) he
+  | ite_true hc h₁ ihc ih₁ => exact .ite_true (ihc hu) (ih₁ hu)
+  | ite_false hc h₂ ihc ih₂ => exact .ite_false (ihc hu) (ih₂ hu)
+
 /-! ### One-sided fragments and locality
 
 `BMRSᵖ`-programs (successor-free) compute left-subsequentially, `BMRSˢ`-programs
@@ -311,69 +368,47 @@ locality lemmas below are what those inclusions rest on and are the engine of
 [yolyan-2025]'s negative results: the flags of a one-sided program cannot see across
 the target. Equal length is load-bearing — `min`/`max` atoms read `w.length`. -/
 
-/-- Successor-free terms: built from the variable by `pred` alone. -/
-def _root_.Subregular.Logic.Term.SuccFree : Term Unit → Prop
-  | .var _ => True
-  | .succ _ => False
-  | .pred t => Term.SuccFree t
-
-/-- Predecessor-free terms: built from the variable by `succ` alone. -/
-def _root_.Subregular.Logic.Term.PredFree : Term Unit → Prop
-  | .var _ => True
-  | .succ t => Term.PredFree t
-  | .pred _ => False
-
-/-- Successor-free expressions: every term is successor-free. -/
-def Expr.SuccFree : Expr α F → Prop
+/-- Backward expressions: every term is backward. -/
+def Expr.Backward : Expr α F → Prop
   | .tru | .fls => True
-  | .initial t | .final t => t.SuccFree
-  | .label _ t => t.SuccFree
-  | .call _ t => t.SuccFree
-  | .ite c e₁ e₂ => c.SuccFree ∧ e₁.SuccFree ∧ e₂.SuccFree
+  | .initial t | .final t => t.Backward
+  | .label _ t => t.Backward
+  | .call _ t => t.Backward
+  | .ite c e₁ e₂ => c.Backward ∧ e₁.Backward ∧ e₂.Backward
 
-/-- Predecessor-free expressions. -/
-def Expr.PredFree : Expr α F → Prop
+/-- Forward expressions. -/
+def Expr.Forward : Expr α F → Prop
   | .tru | .fls => True
-  | .initial t | .final t => t.PredFree
-  | .label _ t => t.PredFree
-  | .call _ t => t.PredFree
-  | .ite c e₁ e₂ => c.PredFree ∧ e₁.PredFree ∧ e₂.PredFree
+  | .initial t | .final t => t.Forward
+  | .label _ t => t.Forward
+  | .call _ t => t.Forward
+  | .ite c e₁ e₂ => c.Forward ∧ e₁.Forward ∧ e₂.Forward
 
-instance Term.instDecidableSuccFree : ∀ t : Term Unit, Decidable t.SuccFree
-  | .var _ => .isTrue trivial
-  | .succ _ => .isFalse not_false
-  | .pred t => Term.instDecidableSuccFree t
-
-instance Term.instDecidablePredFree : ∀ t : Term Unit, Decidable t.PredFree
-  | .var _ => .isTrue trivial
-  | .succ t => Term.instDecidablePredFree t
-  | .pred _ => .isFalse not_false
-
-instance Expr.instDecidableSuccFree : ∀ e : Expr α F, Decidable e.SuccFree
+instance Expr.instDecidableBackward : ∀ e : Expr α F, Decidable e.Backward
   | .tru | .fls => .isTrue trivial
-  | .initial t | .final t => inferInstanceAs (Decidable t.SuccFree)
-  | .label _ t | .call _ t => inferInstanceAs (Decidable t.SuccFree)
+  | .initial t | .final t => inferInstanceAs (Decidable t.Backward)
+  | .label _ t | .call _ t => inferInstanceAs (Decidable t.Backward)
   | .ite c e₁ e₂ =>
-      @instDecidableAnd _ _ (Expr.instDecidableSuccFree c)
-        (@instDecidableAnd _ _ (Expr.instDecidableSuccFree e₁) (Expr.instDecidableSuccFree e₂))
+      @instDecidableAnd _ _ (Expr.instDecidableBackward c)
+        (@instDecidableAnd _ _ (Expr.instDecidableBackward e₁) (Expr.instDecidableBackward e₂))
 
-instance Expr.instDecidablePredFree : ∀ e : Expr α F, Decidable e.PredFree
+instance Expr.instDecidableForward : ∀ e : Expr α F, Decidable e.Forward
   | .tru | .fls => .isTrue trivial
-  | .initial t | .final t => inferInstanceAs (Decidable t.PredFree)
-  | .label _ t | .call _ t => inferInstanceAs (Decidable t.PredFree)
+  | .initial t | .final t => inferInstanceAs (Decidable t.Forward)
+  | .label _ t | .call _ t => inferInstanceAs (Decidable t.Forward)
   | .ite c e₁ e₂ =>
-      @instDecidableAnd _ _ (Expr.instDecidablePredFree c)
-        (@instDecidableAnd _ _ (Expr.instDecidablePredFree e₁) (Expr.instDecidablePredFree e₂))
+      @instDecidableAnd _ _ (Expr.instDecidableForward c)
+        (@instDecidableAnd _ _ (Expr.instDecidableForward e₁) (Expr.instDecidableForward e₂))
 
-/-- `BMRSᵖ`: every rule body is successor-free (hereditarily, through calls). -/
-def Program.SuccFree (P : Program α F) : Prop := ∀ f, (P f).SuccFree
+/-- `BMRSᵖ`: every rule body is backward (hereditarily, through calls). -/
+def Program.Backward (P : Program α F) : Prop := ∀ f, (P f).Backward
 
-/-- `BMRSˢ`: every rule body is predecessor-free. -/
-def Program.PredFree (P : Program α F) : Prop := ∀ f, (P f).PredFree
+/-- `BMRSˢ`: every rule body is forward. -/
+def Program.Forward (P : Program α F) : Prop := ∀ f, (P f).Forward
 
-/-- Successor-free terms only move left. -/
-theorem tden_le_of_succFree {w : WordModel α} {i : ℕ} :
-    ∀ {t : Term Unit}, t.SuccFree → ∀ {v}, tden w i t = some v → v ≤ i
+/-- Backward terms only move left. -/
+theorem tden_le_of_backward {w : WordModel α} {i : ℕ} :
+    ∀ {t : Term Unit}, t.Backward → ∀ {v}, tden w i t = some v → v ≤ i
   | .var _, _, v, h => by
     simp only [tden, Term.eval] at h
     split at h
@@ -382,7 +417,7 @@ theorem tden_le_of_succFree {w : WordModel α} {i : ℕ} :
   | .pred t, ht, v, h => by
     simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
     obtain ⟨u, hu, huv⟩ := h
-    have hle : u ≤ i := tden_le_of_succFree (t := t) ht hu
+    have hle : u ≤ i := tden_le_of_backward (t := t) ht hu
     cases u with
     | zero => exact absurd huv (by simp [WordModel.pred?])
     | succ u =>
@@ -391,9 +426,9 @@ theorem tden_le_of_succFree {w : WordModel α} {i : ℕ} :
       · exact (Option.some.inj huv) ▸ by omega
       · exact absurd huv (by simp)
 
-/-- Predecessor-free terms only move right. -/
-theorem le_tden_of_predFree {w : WordModel α} {i : ℕ} :
-    ∀ {t : Term Unit}, t.PredFree → ∀ {v}, tden w i t = some v → i ≤ v
+/-- Forward terms only move right. -/
+theorem le_tden_of_forward {w : WordModel α} {i : ℕ} :
+    ∀ {t : Term Unit}, t.Forward → ∀ {v}, tden w i t = some v → i ≤ v
   | .var _, _, v, h => by
     simp only [tden, Term.eval] at h
     split at h
@@ -402,7 +437,7 @@ theorem le_tden_of_predFree {w : WordModel α} {i : ℕ} :
   | .succ t, ht, v, h => by
     simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
     obtain ⟨u, hu, huv⟩ := h
-    have hle : i ≤ u := le_tden_of_predFree (t := t) ht hu
+    have hle : i ≤ u := le_tden_of_forward (t := t) ht hu
     unfold WordModel.succ? at huv
     split at huv
     · exact (Option.some.inj huv) ▸ by omega
@@ -428,10 +463,10 @@ theorem tden_congr {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ}
 
 /-- **One-sided locality (left)**: a successor-free program evaluated at `i` reads only
 positions `≤ i`, so equal-length words agreeing up to `i` evaluate identically. -/
-theorem Eval.congr_agreeUpto {P : Program α F} (hP : P.SuccFree)
+theorem Eval.congr_agreeUpto {P : Program α F} (hP : P.Backward)
     {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} {e : Expr α F} {b : Bool}
     (h : Eval P w i e b) :
-    e.SuccFree → AgreeUpto w w' i → Eval P w' i e b := by
+    e.Backward → AgreeUpto w w' i → Eval P w' i e b := by
   induction h with
   | tru => exact fun _ _ => .tru
   | fls => exact fun _ _ => .fls
@@ -445,14 +480,14 @@ theorem Eval.congr_agreeUpto {P : Program α F} (hP : P.SuccFree)
     exact .final_false (by rw [← tden_congr hlen]; exact h) (hlen ▸ hv)
   | label_true h hl has =>
     intro he hag
-    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_succFree he h) ▸ hl) has
+    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_backward he h) ▸ hl) has
   | label_false h hl has =>
     intro he hag
-    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_succFree he h) ▸ hl) has
+    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (tden_le_of_backward he h) ▸ hl) has
   | call h he' ih =>
     intro he hag
     exact .call (tden_congr hlen _ ▸ h)
-      (ih (hP _) fun k hk => hag k (hk.trans (tden_le_of_succFree he h)))
+      (ih (hP _) fun k hk => hag k (hk.trans (tden_le_of_backward he h)))
   | ite_true hc h₁ ihc ih₁ =>
     intro he hag
     exact .ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)
@@ -462,10 +497,10 @@ theorem Eval.congr_agreeUpto {P : Program α F} (hP : P.SuccFree)
 
 /-- **One-sided locality (right)**: a predecessor-free program evaluated at `i` reads
 only positions `≥ i`, so equal-length words agreeing from `i` on evaluate identically. -/
-theorem Eval.congr_agreeFrom {P : Program α F} (hP : P.PredFree)
+theorem Eval.congr_agreeFrom {P : Program α F} (hP : P.Forward)
     {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ} {e : Expr α F} {b : Bool}
     (h : Eval P w i e b) :
-    e.PredFree → AgreeFrom w w' i → Eval P w' i e b := by
+    e.Forward → AgreeFrom w w' i → Eval P w' i e b := by
   induction h with
   | tru => exact fun _ _ => .tru
   | fls => exact fun _ _ => .fls
@@ -479,14 +514,14 @@ theorem Eval.congr_agreeFrom {P : Program α F} (hP : P.PredFree)
     exact .final_false (by rw [← tden_congr hlen]; exact h) (hlen ▸ hv)
   | label_true h hl has =>
     intro he hag
-    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_predFree he h) ▸ hl) has
+    exact .label_true (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_forward he h) ▸ hl) has
   | label_false h hl has =>
     intro he hag
-    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_predFree he h) ▸ hl) has
+    exact .label_false (tden_congr hlen _ ▸ h) (hag _ (le_tden_of_forward he h) ▸ hl) has
   | call h he' ih =>
     intro he hag
     exact .call (tden_congr hlen _ ▸ h)
-      (ih (hP _) fun k hk => hag k ((le_tden_of_predFree he h).trans hk))
+      (ih (hP _) fun k hk => hag k ((le_tden_of_forward he h).trans hk))
   | ite_true hc h₁ ihc ih₁ =>
     intro he hag
     exact .ite_true (ihc he.1 hag) (ih₁ he.2.1 hag)

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -13,7 +13,8 @@ import Mathlib.Data.Finset.Basic
 BMRS ([bhaskar-jardine-chandlee-oakden-2020]; [bhaskar-chandlee-jardine-2023];
 phonological modelling in [chandlee-jardine-2021]): programs of mutually recursive
 Boolean-valued unary predicates over word models, built from `if…then…else`, the
-edge tests `min`/`max`, input-label tests, and recursive calls. Terms are the
+edge tests `initial`/`final` (the literature's `min`/`max`), input class tests, and
+recursive calls. Terms are the
 quantifier-free terms of `Logic/QFLogic.lean` at a single index variable.
 
 Two symbol types dissolve the literature's `sig(P)` bookkeeping: input labels `α` get
@@ -28,7 +29,7 @@ derives nothing. `evalFuel` is its computable face, related by `eval_iff_evalFue
 
 * `BMRS.Expr`, `BMRS.Program` — syntax; `BMRS.tden` — term denotation at an index.
 * `BMRS.Eval` — the derivation system; `BMRS.evalFuel` — the fuel-bounded evaluator.
-* `Expr.Backward` / `Program.Backward` (dually `PredFree`) — the one-sided fragments
+* `Expr.Backward` / `Program.Backward` (dually `Forward`) — the one-sided fragments
   `BMRSᵖ` / `BMRSˢ` of [bhaskar-jardine-chandlee-oakden-2020].
 * `BMRS.combine` / `BMRS.combineC` — the value combinators of simultaneous application
   (⊙, [yolyan-2025] Def. 4.1) and its conjunctive dual (⊘, Def. 6.5).
@@ -38,9 +39,9 @@ derives nothing. `evalFuel` is its computable face, related by `eval_iff_evalFue
 * `Eval.deterministic` — an expression has at most one value.
 * `eval_iff_evalFuel` — adequacy of the fuel evaluator.
 * `Eval.congr_agreeUpto` / `Eval.congr_agreeFrom` — **one-sided locality**: a
-  successor-free program evaluated at `i` reads only positions `≤ i`, so equal-length
-  words agreeing there evaluate identically (dually for predecessor-free). The engine
-  of [yolyan-2025]'s negative results (Thm. 5.2–5.5).
+  backward program evaluated at `i` reads only positions `≤ i`, so equal-length words
+  agreeing there evaluate identically (dually for forward). The engine of
+  [yolyan-2025]'s negative results (Thm. 5.2–5.5).
 * `combine_comm`, `combine_assoc`, `combine_id` — the ⊙-algebra
   ([yolyan-2025] Prop. 4.4), extensionally at the value level.
 -/
@@ -162,36 +163,37 @@ inductive Eval (P : Program α F) (w : WordModel α) : ℕ → Expr α F → Boo
   | ite_false {i c e₁ e₂ b} (hc : Eval P w i c false) (h₂ : Eval P w i e₂ b) :
       Eval P w i (.ite c e₁ e₂) b
 
+/-- Boolean-form introduction for the edge test: the value is the comparison. -/
+theorem Eval.initial {P : Program α F} {w : WordModel α} {i v : ℕ} {t : Term Unit}
+    (h : tden w i t = some v) : Eval P w i (.initial t) (v == 0) := by
+  rcases Nat.eq_zero_or_pos v with rfl | hv
+  · exact .initial_true h
+  · rw [beq_eq_false_iff_ne.mpr (by omega)]
+    exact .initial_false h hv
+
+/-- Boolean-form introduction for the final test. -/
+theorem Eval.final {P : Program α F} {w : WordModel α} {i v : ℕ} {t : Term Unit}
+    (h : tden w i t = some v) : Eval P w i (.final t) (v == w.length - 1) := by
+  rcases eq_or_ne v (w.length - 1) with rfl | hne
+  · rw [beq_self_eq_true]
+    exact .final_true h
+  · rw [beq_eq_false_iff_ne.mpr hne]
+    exact .final_false h (by have := tden_lt h; omega)
+
+/-- Boolean-form introduction for the class test. -/
+theorem Eval.label [DecidableEq α] {P : Program α F} {w : WordModel α} {i v : ℕ}
+    {t : Term Unit} {s : Finset α} {a : α} (h : tden w i t = some v)
+    (hl : w[v]? = some a) : Eval P w i (.label s t) (decide (a ∈ s)) := by
+  by_cases has : a ∈ s
+  · rw [decide_eq_true has]
+    exact .label_true h hl has
+  · rw [decide_eq_false has]
+    exact .label_false h hl has
+
 /-- The derivation system is deterministic: an expression has at most one value. -/
 theorem Eval.deterministic {P : Program α F} {w : WordModel α} {i : ℕ} {e : Expr α F}
     {b b' : Bool} (h : Eval P w i e b) (h' : Eval P w i e b') : b = b' := by
   induction h generalizing b' with
-  | tru => cases h'; rfl
-  | fls => cases h'; rfl
-  | initial_true h => cases h' with
-    | initial_true => rfl
-    | initial_false h₂ hv => rw [h] at h₂; injection h₂ with h₂; omega
-  | initial_false h hv => cases h' with
-    | initial_true h₂ => rw [h] at h₂; injection h₂ with h₂; omega
-    | initial_false => rfl
-  | final_true h => cases h' with
-    | final_true => rfl
-    | final_false h₂ hv => rw [h] at h₂; injection h₂ with h₂; omega
-  | final_false h hv => cases h' with
-    | final_true h₂ => rw [h] at h₂; injection h₂ with h₂; omega
-    | final_false => rfl
-  | label_true h hl has => cases h' with
-    | label_true => rfl
-    | label_false h₂ hl₂ has₂ =>
-      cases h.symm.trans h₂
-      cases hl.symm.trans hl₂
-      exact absurd has has₂
-  | label_false h hl has => cases h' with
-    | label_true h₂ hl₂ has₂ =>
-      cases h.symm.trans h₂
-      cases hl.symm.trans hl₂
-      exact absurd has₂ has
-    | label_false => rfl
   | call h he ih => cases h' with
     | call h₂ he₂ => rw [h] at h₂; cases h₂; exact ih he₂
   | ite_true hc h₁ ihc ih₁ => cases h' with
@@ -200,6 +202,7 @@ theorem Eval.deterministic {P : Program α F} {w : WordModel α} {i : ℕ} {e : 
   | ite_false hc h₂ ihc ih₂ => cases h' with
     | ite_true hc₂ h₁ => exact absurd (ihc hc₂) (by simp)
     | ite_false hc₂ h₁ => exact ih₂ h₁
+  | _ => cases h' <;> simp_all
 
 /-- A program is **total on `w`** when every rule head is defined at every position. -/
 def Program.TotalOn (P : Program α F) (w : WordModel α) : Prop :=
@@ -230,11 +233,6 @@ theorem evalFuel_mono [DecidableEq α] {P : Program α F} {w : WordModel α}
   | succ n ih =>
     obtain ⟨m, rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
     cases e with
-    | tru => exact h
-    | fls => exact h
-    | initial t => exact h
-    | final t => exact h
-    | label s t => exact h
     | call f t =>
       simp only [evalFuel, Option.bind_eq_some_iff] at h ⊢
       obtain ⟨v, hv, hrec⟩ := h
@@ -243,9 +241,8 @@ theorem evalFuel_mono [DecidableEq α] {P : Program α F} {w : WordModel α}
       simp only [evalFuel, Option.bind_eq_some_iff] at h ⊢
       obtain ⟨bc, hbc, hbr⟩ := h
       refine ⟨bc, ih (by omega) hbc, ?_⟩
-      cases bc with
-      | true => simpa using ih (by omega) (by simpa using hbr)
-      | false => simpa using ih (by omega) (by simpa using hbr)
+      cases bc <;> simpa using ih (by omega) (by simpa using hbr)
+    | _ => exact h
 
 /-- Soundness of the fuel evaluator against the derivation system. -/
 theorem evalFuel_sound [DecidableEq α] {P : Program α F} {w : WordModel α}
@@ -260,27 +257,15 @@ theorem evalFuel_sound [DecidableEq α] {P : Program α F} {w : WordModel α}
     | initial t =>
       simp only [evalFuel, Option.map_eq_some_iff] at h
       obtain ⟨v, hv, rfl⟩ := h
-      rcases Nat.eq_zero_or_pos v with rfl | hpos
-      · exact .initial_true hv
-      · rw [show (v == 0) = false by simp; omega]
-        exact .initial_false hv hpos
+      exact .initial hv
     | final t =>
       simp only [evalFuel, Option.map_eq_some_iff] at h
       obtain ⟨v, hv, rfl⟩ := h
-      rcases eq_or_ne v (w.length - 1) with rfl | hne
-      · rw [show (w.length - 1 == w.length - 1) = true by simp]
-        exact .final_true hv
-      · have hlt : v < w.length - 1 := by have := tden_lt hv; omega
-        rw [show (v == w.length - 1) = false by simp [hne]]
-        exact .final_false hv hlt
+      exact .final hv
     | label s t =>
       simp only [evalFuel, Option.bind_eq_some_iff, Option.map_eq_some_iff] at h
       obtain ⟨v, hv, a, ha, rfl⟩ := h
-      by_cases has : a ∈ s
-      · rw [show decide (a ∈ s) = true by simp [has]]
-        exact .label_true hv ha has
-      · rw [show decide (a ∈ s) = false by simp [has]]
-        exact .label_false hv ha has
+      exact .label hv ha
     | call f t =>
       simp only [evalFuel, Option.bind_eq_some_iff] at h
       obtain ⟨v, hv, hrec⟩ := h
@@ -342,6 +327,13 @@ def Expr.subst : Expr α F → Term Unit → Expr α F
   | .call f t, u => .call f (t.comp u)
   | .ite c e₁ e₂, u => .ite (c.subst u) (e₁.subst u) (e₂.subst u)
 
+/-- Term denotations sequence through composition. -/
+private theorem tden_comp_of {w : WordModel α} {u t : Term Unit} {i v z : ℕ}
+    (hu : tden w i u = some v) (h : tden w v t = some z) :
+    tden w i (t.comp u) = some z := by
+  rw [tden_comp, hu]
+  exact h
+
 /-- Transport a derivation through substitution: evaluating `e[u/x]` at `i` is
 evaluating `e` at the position `u` denotes. -/
 theorem Eval.subst {P : Program α F} {w : WordModel α} {u : Term Unit} {i v : ℕ}
@@ -350,13 +342,13 @@ theorem Eval.subst {P : Program α F} {w : WordModel α} {u : Term Unit} {i v : 
   induction h with
   | tru => exact .tru
   | fls => exact .fls
-  | initial_true h => exact .initial_true (by rw [tden_comp, hu]; exact h)
-  | initial_false h hv => exact .initial_false (by rw [tden_comp, hu]; exact h) hv
-  | final_true h => exact .final_true (by rw [tden_comp, hu]; exact h)
-  | final_false h hv => exact .final_false (by rw [tden_comp, hu]; exact h) hv
-  | label_true h hl has => exact .label_true (by rw [tden_comp, hu]; exact h) hl has
-  | label_false h hl has => exact .label_false (by rw [tden_comp, hu]; exact h) hl has
-  | call h he ih => exact .call (by rw [tden_comp, hu]; exact h) he
+  | initial_true h => exact .initial_true (tden_comp_of hu h)
+  | initial_false h hv => exact .initial_false (tden_comp_of hu h) hv
+  | final_true h => exact .final_true (tden_comp_of hu h)
+  | final_false h hv => exact .final_false (tden_comp_of hu h) hv
+  | label_true h hl has => exact .label_true (tden_comp_of hu h) hl has
+  | label_false h hl has => exact .label_false (tden_comp_of hu h) hl has
+  | call h he ih => exact .call (tden_comp_of hu h) he
   | ite_true hc h₁ ihc ih₁ => exact .ite_true (ihc hu) (ih₁ hu)
   | ite_false hc h₂ ihc ih₂ => exact .ite_false (ihc hu) (ih₂ hu)
 
@@ -410,38 +402,27 @@ def Program.Forward (P : Program α F) : Prop := ∀ f, (P f).Forward
 theorem tden_le_of_backward {w : WordModel α} {i : ℕ} :
     ∀ {t : Term Unit}, t.Backward → ∀ {v}, tden w i t = some v → v ≤ i
   | .var _, _, v, h => by
-    simp only [tden, Term.eval] at h
-    split at h
-    · exact (Option.some.inj h) ▸ le_rfl
-    · exact absurd h (by simp)
+    rw [tden, Term.eval] at h
+    split at h <;> simp_all
   | .pred t, ht, v, h => by
-    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
+    rw [show tden w i t.pred = (tden w i t).bind w.pred? from rfl,
+      Option.bind_eq_some_iff] at h
     obtain ⟨u, hu, huv⟩ := h
-    have hle : u ≤ i := tden_le_of_backward (t := t) ht hu
-    cases u with
-    | zero => exact absurd huv (by simp [WordModel.pred?])
-    | succ u =>
-      simp only [WordModel.pred?] at huv
-      split at huv
-      · exact (Option.some.inj huv) ▸ by omega
-      · exact absurd huv (by simp)
+    obtain ⟨rfl, -⟩ := WordModel.pred?_eq_some_iff.mp huv
+    exact Nat.le_of_succ_le (tden_le_of_backward (t := t) ht hu)
 
 /-- Forward terms only move right. -/
 theorem le_tden_of_forward {w : WordModel α} {i : ℕ} :
     ∀ {t : Term Unit}, t.Forward → ∀ {v}, tden w i t = some v → i ≤ v
   | .var _, _, v, h => by
-    simp only [tden, Term.eval] at h
-    split at h
-    · exact (Option.some.inj h) ▸ le_rfl
-    · exact absurd h (by simp)
+    rw [tden, Term.eval] at h
+    split at h <;> simp_all
   | .succ t, ht, v, h => by
-    simp only [tden, Term.eval, Option.bind_eq_some_iff] at h
+    rw [show tden w i t.succ = (tden w i t).bind w.succ? from rfl,
+      Option.bind_eq_some_iff] at h
     obtain ⟨u, hu, huv⟩ := h
-    have hle : i ≤ u := le_tden_of_forward (t := t) ht hu
-    unfold WordModel.succ? at huv
-    split at huv
-    · exact (Option.some.inj huv) ▸ by omega
-    · exact absurd huv (by simp)
+    obtain ⟨rfl, -⟩ := WordModel.succ?_eq_some_iff.mp huv
+    exact (le_tden_of_forward (t := t) ht hu).trans (Nat.le_succ u)
 
 /-- Term denotations read only the length, so they transport across equal-length
 words. -/
@@ -449,17 +430,11 @@ theorem tden_congr {w w' : WordModel α} (hlen : w.length = w'.length) {i : ℕ}
     ∀ t : Term Unit, tden w i t = tden w' i t
   | .var _ => by simp [tden, Term.eval, WordModel.Mem, hlen]
   | .succ t => by
-    simp only [tden, Term.eval]
-    rw [show Term.eval w (fun _ => i) t = Term.eval w' (fun _ => i) t from tden_congr hlen t]
-    cases Term.eval w' (fun _ => i) t with
-    | none => rfl
-    | some u => simp [WordModel.succ?, hlen]
+    show (tden w i t).bind w.succ? = (tden w' i t).bind w'.succ?
+    rw [tden_congr hlen t, WordModel.succ?_congr hlen]
   | .pred t => by
-    simp only [tden, Term.eval]
-    rw [show Term.eval w (fun _ => i) t = Term.eval w' (fun _ => i) t from tden_congr hlen t]
-    cases Term.eval w' (fun _ => i) t with
-    | none => rfl
-    | some u => cases u <;> simp [WordModel.pred?, hlen]
+    show (tden w i t).bind w.pred? = (tden w' i t).bind w'.pred?
+    rw [tden_congr hlen t, WordModel.pred?_congr hlen]
 
 /-- **One-sided locality (left)**: a successor-free program evaluated at `i` reads only
 positions `≤ i`, so equal-length words agreeing up to `i` evaluate identically. -/
@@ -543,6 +518,20 @@ def combine (pin a b : Bool) : Bool := if pin then a && b else a || b
 /-- Conjunctive simultaneous application ⊘ on values ([yolyan-2025] Def. 6.5): a change
 survives iff both programs make it. -/
 def combineC (pin a b : Bool) : Bool := if pin then a || b else a && b
+
+/-- On a true input, ⊙ is conjunction. -/
+@[simp] theorem combine_true (a b : Bool) : combine true a b = (a && b) := rfl
+
+/-- On a false input, ⊙ is disjunction — the collapse behind [yolyan-2025] (5.15):
+with no underlying stress the ⊙ of the two stress programs is their disjunction. -/
+@[simp] theorem combine_false (a b : Bool) : combine false a b = (a || b) := rfl
+
+/-- On a true input, ⊘ is disjunction. -/
+@[simp] theorem combineC_true (a b : Bool) : combineC true a b = (a || b) := rfl
+
+/-- On a false input, ⊘ is conjunction — the conjunctive licensing of
+[yolyan-2025] §6.3. -/
+@[simp] theorem combineC_false (a b : Bool) : combineC false a b = (a && b) := rfl
 
 /-- A ⊙-value differs from the input iff one of the components does
 ([yolyan-2025] Prop. 4.2): the changes of the simultaneous application are the union

--- a/Linglib/Core/Computability/Subregular/Logic/LocalityBridge.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/LocalityBridge.lean
@@ -38,22 +38,11 @@ private theorem pred?_pos {w : WordModel α} {m : ℕ} (h0 : 0 < m) (hm : m ≤ 
   have hm' : m' < w.length := by omega
   simp [WordModel.pred?, hm']
 
-/-! ### Backward terms -/
+/-! ### Backward terms
+
+`Term.Backward` and `Term.pdepth` live with the `Term` API in `Logic/QFLogic.lean`. -/
 
 namespace Term
-
-/-- A term is *backward* if it uses no successor — only the variable and predecessors, so it reads
-positions at or before its variable. -/
-def Backward : Term V → Prop
-  | .var _  => True
-  | .pred t => t.Backward
-  | .succ _ => False
-
-/-- The predecessor depth of a term: how far back it reaches. -/
-def pdepth : Term V → ℕ
-  | .var _  => 0
-  | .pred t => t.pdepth + 1
-  | .succ t => t.pdepth
 
 /-- A backward term of predecessor depth `j`, evaluated at position `n` (in range), reads exactly
 position `n - j` — defined iff `j ≤ n`. -/

--- a/Linglib/Core/Computability/Subregular/Logic/ModalMu.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/ModalMu.lean
@@ -118,6 +118,33 @@ variable {w : WordModel α} {U : Fin n → Set ℕ} {i : ℕ} {s : Finset α} {�
 
 end RealizeSimp
 
+instance Formula.instDecidableRealize [DecidableEq α] (w : WordModel α)
+    (U : Fin n → Set ℕ) [∀ X, DecidablePred (· ∈ U X)] :
+    ∀ (i : ℕ) (φ : Formula α n), Decidable (φ.Realize w U i)
+  | _, .tru => .isTrue trivial
+  | _, .fls => .isFalse not_false
+  | i, .initial => inferInstanceAs (Decidable (i = 0))
+  | i, .final => inferInstanceAs (Decidable (i + 1 = w.length))
+  | i, .label s => inferInstanceAs (Decidable (∃ a ∈ s, w[i]? = some a))
+  | i, .nlabel s => inferInstanceAs (Decidable (∀ a ∈ s, w[i]? ≠ some a))
+  | i, .var X => inferInstanceAs (Decidable (i ∈ U X))
+  | i, .and φ ψ =>
+      @instDecidableAnd _ _ (instDecidableRealize w U i φ) (instDecidableRealize w U i ψ)
+  | i, .or φ ψ =>
+      @instDecidableOr _ _ (instDecidableRealize w U i φ) (instDecidableRealize w U i ψ)
+  | i, .dia φ =>
+      match h : w.succ? i with
+      | none => .isFalse (by simp [Formula.realize_dia, h])
+      | some j =>
+          @decidable_of_iff _ _ (by simp [Formula.realize_dia, h])
+            (instDecidableRealize w U j φ)
+  | i, .bdia φ =>
+      match h : w.pred? i with
+      | none => .isFalse (by simp [Formula.realize_bdia, h])
+      | some j =>
+          @decidable_of_iff _ _ (by simp [Formula.realize_bdia, h])
+            (instDecidableRealize w U j φ)
+
 /-- Satisfaction is monotone in the valuation: recursion variables occur only
 positively. -/
 theorem Formula.Realize.mono {w : WordModel α} {U V : Fin n → Set ℕ} (hUV : U ≤ V) :

--- a/Linglib/Core/Computability/Subregular/Logic/ModalMu.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/ModalMu.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.Subregular.Logic.WordModel
+import Mathlib.Data.Finset.Basic
+import Linglib.Core.Order.IterateFixedPoint
+
+/-!
+# The vectorial modal μ-calculus on words
+
+The modal μ-calculus ([kozen-1983]) interpreted over word models, in the **vectorial**
+presentation of [yolyan-comer-2026] §4: a finite system of equations `Xⱼ = θⱼ` between
+quantifier-free modal formulas plus a designated variable, evaluated as the least fixed
+point of the induced monotone operator (Knaster–Tarski). By Bekić's theorem the
+vectorial form is equivalent to nested `μ`-binders; formalizing it directly avoids
+binder bookkeeping and matches the paper's own proofs.
+
+Formulas here are the negation-free fragment `μML꜀₊` — the ambient of
+[yolyan-comer-2026] Thm. 8 — extended with negated *label* atoms (`nlabel`), which keeps
+negation off recursion variables (so monotonicity is structural) while covering
+processes like Warao nasal spreading `N′ = μX.(N ∨ (¬T ∧ ♦X))`.
+
+`◇` (`dia`) is the forward modality reading the successor position, `♦` (`bdia`) the
+backward modality reading the predecessor.
+
+## Main definitions
+
+* `ModalMu.Formula` — quantifier-free modal formulas over labels `α` and `n` recursion
+  variables; `Formula.Realize` — satisfaction at a pointed word under a valuation.
+* `ModalMu.System` — a vectorial formula; `System.op` — its monotone operator on
+  valuations; `System.sem` — the least-fixed-point valuation; `System.Sat` — pointed
+  satisfaction of the designated variable.
+
+## Main results
+
+* `Formula.Realize.mono` — satisfaction is monotone in the valuation (negation-free).
+* `System.op_sem` — `sem` is a fixed point; `System.sem_eq_iterate` — the iteration
+  certificate (via `OrderHom.lfp_eq_iterate_bot`), the computable route to `sem`.
+-/
+
+namespace Subregular.Logic.ModalMu
+
+variable {α : Type*} {n : ℕ}
+
+/-- Quantifier-free modal formulas over labels `α` and `n` recursion variables: the
+negation-free fragment, with negation on **class atoms** only (`nlabel`) — so recursion
+variables occur only positively and monotonicity is structural. `label`/`nlabel` test
+the current position's symbol against a `Finset` class (featural predicates like V or N
+are single atoms; a symbol test is the singleton case). `initial`/`final` are the edge
+tests (the literature's `min`/`max`); `dia` (`◇`) reads the successor position, `bdia`
+(`♦`) the predecessor. -/
+inductive Formula (α : Type*) (n : ℕ) where
+  | tru
+  | fls
+  | initial
+  | final
+  | label (s : Finset α)
+  | nlabel (s : Finset α)
+  | var (X : Fin n)
+  | and (φ ψ : Formula α n)
+  | or (φ ψ : Formula α n)
+  | dia (φ : Formula α n)
+  | bdia (φ : Formula α n)
+  deriving DecidableEq
+
+/-- Satisfaction at a pointed word `(w, i)` under a valuation `U` of the recursion
+variables. -/
+def Formula.Realize (w : WordModel α) (U : Fin n → Set ℕ) : ℕ → Formula α n → Prop
+  | _, .tru => True
+  | _, .fls => False
+  | i, .initial => i = 0
+  | i, .final => i + 1 = w.length
+  | i, .label s => ∃ a ∈ s, w[i]? = some a
+  | i, .nlabel s => ∀ a ∈ s, w[i]? ≠ some a
+  | i, .var X => i ∈ U X
+  | i, .and φ ψ => φ.Realize w U i ∧ ψ.Realize w U i
+  | i, .or φ ψ => φ.Realize w U i ∨ ψ.Realize w U i
+  | i, .dia φ => ∃ j, w.succ? i = some j ∧ φ.Realize w U j
+  | i, .bdia φ => ∃ j, w.pred? i = some j ∧ φ.Realize w U j
+
+section RealizeSimp
+
+variable {w : WordModel α} {U : Fin n → Set ℕ} {i : ℕ} {s : Finset α} {φ ψ : Formula α n}
+
+@[simp] theorem Formula.realize_tru : (Formula.tru : Formula α n).Realize w U i := trivial
+
+@[simp] theorem Formula.realize_fls : ¬ (Formula.fls : Formula α n).Realize w U i :=
+  not_false
+
+@[simp] theorem Formula.realize_initial :
+    (Formula.initial : Formula α n).Realize w U i ↔ i = 0 := .rfl
+
+@[simp] theorem Formula.realize_final :
+    (Formula.final : Formula α n).Realize w U i ↔ i + 1 = w.length := .rfl
+
+@[simp] theorem Formula.realize_label :
+    (Formula.label s : Formula α n).Realize w U i ↔ ∃ a ∈ s, w[i]? = some a := .rfl
+
+@[simp] theorem Formula.realize_nlabel :
+    (Formula.nlabel s : Formula α n).Realize w U i ↔ ∀ a ∈ s, w[i]? ≠ some a := .rfl
+
+@[simp] theorem Formula.realize_var {X : Fin n} :
+    (Formula.var X : Formula α n).Realize w U i ↔ i ∈ U X := .rfl
+
+@[simp] theorem Formula.realize_and :
+    (φ.and ψ).Realize w U i ↔ φ.Realize w U i ∧ ψ.Realize w U i := .rfl
+
+@[simp] theorem Formula.realize_or :
+    (φ.or ψ).Realize w U i ↔ φ.Realize w U i ∨ ψ.Realize w U i := .rfl
+
+@[simp] theorem Formula.realize_dia :
+    φ.dia.Realize w U i ↔ ∃ j, w.succ? i = some j ∧ φ.Realize w U j := .rfl
+
+@[simp] theorem Formula.realize_bdia :
+    φ.bdia.Realize w U i ↔ ∃ j, w.pred? i = some j ∧ φ.Realize w U j := .rfl
+
+end RealizeSimp
+
+/-- Satisfaction is monotone in the valuation: recursion variables occur only
+positively. -/
+theorem Formula.Realize.mono {w : WordModel α} {U V : Fin n → Set ℕ} (hUV : U ≤ V) :
+    ∀ {φ : Formula α n} {i : ℕ}, φ.Realize w U i → φ.Realize w V i
+  | .tru, _, h => h
+  | .fls, _, h => h
+  | .initial, _, h => h
+  | .final, _, h => h
+  | .label _, _, h => h
+  | .nlabel _, _, h => h
+  | .var X, _, h => hUV X h
+  | .and _ _, _, h => ⟨h.1.mono hUV, h.2.mono hUV⟩
+  | .or _ _, _, h => h.imp (·.mono hUV) (·.mono hUV)
+  | .dia _, _, ⟨j, hj, h⟩ => ⟨j, hj, h.mono hUV⟩
+  | .bdia _, _, ⟨j, hj, h⟩ => ⟨j, hj, h.mono hUV⟩
+
+/-- A vectorial formula ([yolyan-comer-2026] §4): a finite system of equations
+`Xⱼ = θⱼ` plus a designated variable. -/
+structure System (α : Type*) (n : ℕ) where
+  /-- The right-hand side of each equation. -/
+  eqs : Fin n → Formula α n
+  /-- The designated variable whose satisfaction is the system's. -/
+  out : Fin n
+
+namespace System
+
+variable (χ : System α n) (w : WordModel α)
+
+/-- The monotone operator a system induces on valuations (the paper's `F_w^χ`). -/
+def op : (Fin n → Set ℕ) →o (Fin n → Set ℕ) where
+  toFun U X := {i | (χ.eqs X).Realize w U i}
+  monotone' _ _ hUV _ _ h := h.mono hUV
+
+@[simp] theorem mem_op {U : Fin n → Set ℕ} {X : Fin n} {i : ℕ} :
+    i ∈ χ.op w U X ↔ (χ.eqs X).Realize w U i := .rfl
+
+/-- The least-fixed-point valuation (Knaster–Tarski). -/
+noncomputable def sem : Fin n → Set ℕ := OrderHom.lfp (χ.op w)
+
+/-- `sem` is a fixed point of the system operator. -/
+theorem op_sem : χ.op w (χ.sem w) = χ.sem w := (χ.op w).map_lfp
+
+/-- `sem` is below every prefixed point. -/
+theorem sem_le {U : Fin n → Set ℕ} (hU : χ.op w U ≤ U) : χ.sem w ≤ U :=
+  (χ.op w).lfp_le hU
+
+/-- **Iteration certificate**: an iterate of `⊥` fixed by the operator is `sem`. The
+computable route to the least fixed point — no continuity needed. -/
+theorem sem_eq_iterate {k : ℕ} (h : χ.op w ((χ.op w)^[k] ⊥) = (χ.op w)^[k] ⊥) :
+    χ.sem w = (χ.op w)^[k] ⊥ :=
+  OrderHom.lfp_eq_iterate_bot _ h
+
+/-- `w, i ⊨ χ`: the designated variable holds at `i` in the least fixed point. -/
+def Sat (i : ℕ) : Prop := i ∈ χ.sem w χ.out
+
+end System
+
+end Subregular.Logic.ModalMu

--- a/Linglib/Core/Computability/Subregular/Logic/QFLogic.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/QFLogic.lean
@@ -49,6 +49,48 @@ def eval (w : WordModel α) (ρ : V → ℕ) : Term V → Option ℕ
 
 end Term
 
+/-! ### Directed terms and substitution -/
+
+namespace Term
+
+/-- A term is *backward* if it uses no successor — only the variable and predecessors, so it reads
+positions at or before its variable. -/
+def Backward : Term V → Prop
+  | .var _  => True
+  | .pred t => t.Backward
+  | .succ _ => False
+
+/-- A term is *forward* if it uses no predecessor, so it reads positions at or after its
+variable. -/
+def Forward : Term V → Prop
+  | .var _  => True
+  | .pred _ => False
+  | .succ t => t.Forward
+
+/-- The predecessor depth of a term: how far back it reaches. -/
+def pdepth : Term V → ℕ
+  | .var _  => 0
+  | .pred t => t.pdepth + 1
+  | .succ t => t.pdepth
+
+instance instDecidableBackward : ∀ t : Term V, Decidable t.Backward
+  | .var _ => .isTrue trivial
+  | .pred t => instDecidableBackward t
+  | .succ _ => .isFalse not_false
+
+instance instDecidableForward : ∀ t : Term V, Decidable t.Forward
+  | .var _ => .isTrue trivial
+  | .pred _ => .isFalse not_false
+  | .succ t => instDecidableForward t
+
+/-- Substitution into the single variable: `t.comp u` is `t[u/x]`. -/
+def comp : Term Unit → Term Unit → Term Unit
+  | .var _, u => u
+  | .succ t, u => .succ (t.comp u)
+  | .pred t, u => .pred (t.comp u)
+
+end Term
+
 /-- Atomic quantifier-free formulas: a label test, an equality of positions, or a
 definedness test on a term. -/
 inductive Atom (α V : Type*) where

--- a/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
@@ -57,6 +57,21 @@ def pred? (w : WordModel α) : ℕ → Option ℕ
 
 @[simp] theorem label?_eq_getElem? (w : WordModel α) (n : ℕ) : w.label? n = w[n]? := rfl
 
+theorem succ?_eq_some_iff {w : WordModel α} {n m : ℕ} :
+    w.succ? n = some m ↔ m = n + 1 ∧ n + 1 < w.length := by
+  unfold succ?
+  split <;> simp_all
+  all_goals omega
+
+theorem pred?_eq_some_iff {w : WordModel α} {n m : ℕ} :
+    w.pred? n = some m ↔ n = m + 1 ∧ m < w.length := by
+  cases n with
+  | zero => simp [pred?]
+  | succ k =>
+    unfold pred?
+    split <;> simp_all
+    all_goals omega
+
 @[simp] theorem mem_iff (w : WordModel α) (n : ℕ) : w.Mem n ↔ n < w.length := Iff.rfl
 
 end WordModel

--- a/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
@@ -63,6 +63,18 @@ theorem succ?_eq_some_iff {w : WordModel α} {n m : ℕ} :
   split <;> simp_all
   all_goals omega
 
+/-- The successor structure depends only on the length. -/
+theorem succ?_congr {w w' : WordModel α} (h : w.length = w'.length) :
+    w.succ? = w'.succ? := by
+  funext n
+  simp [succ?, h]
+
+/-- The predecessor structure depends only on the length. -/
+theorem pred?_congr {w w' : WordModel α} (h : w.length = w'.length) :
+    w.pred? = w'.pred? := by
+  funext n
+  cases n <;> simp [pred?, h]
+
 theorem pred?_eq_some_iff {w : WordModel α} {n m : ℕ} :
     w.pred? n = some m ↔ n = m + 1 ∧ m < w.length := by
   cases n with

--- a/Linglib/Core/Order/IterateFixedPoint.lean
+++ b/Linglib/Core/Order/IterateFixedPoint.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.FixedPoints
+import Mathlib.Data.Fintype.Card
+
+/-!
+# Least fixed points by bottom-up iteration
+
+`[UPSTREAM]` Kleene-style certificates for `OrderHom.lfp` without continuity
+hypotheses: the iterates `f^[k] ⊥` of a monotone map sit below every prefixed point,
+so as soon as one is a fixed point it *is* the least fixed point
+(`OrderHom.lfp_eq_iterate_bot`). In a finite lattice some iterate is always fixed —
+a monotone chain can rise at most `Fintype.card` times (`OrderHom.iterate_bot_fixed`).
+
+Together these give the computable face of Knaster–Tarski used by the recursive-scheme
+and modal-μ semantics (`Core/Computability/Subregular/Logic/`): compute `f^[k] ⊥`,
+check one more application, conclude `lfp`.
+-/
+
+namespace OrderHom
+
+variable {L : Type*}
+
+section CompleteLattice
+variable [CompleteLattice L] (f : L →o L)
+
+/-- Bottom-up iterates never overtake the least fixed point. -/
+theorem iterate_bot_le_lfp (k : ℕ) : f^[k] ⊥ ≤ lfp f := by
+  induction k with
+  | zero => exact bot_le
+  | succ k ih =>
+    rw [Function.iterate_succ_apply']
+    calc f (f^[k] ⊥) ≤ f (lfp f) := f.monotone ih
+      _ = lfp f := f.map_lfp
+
+/-- **Iteration certificate for `lfp`**: an iterate of `⊥` that `f` fixes is the least
+fixed point. The computable face of Knaster–Tarski: no continuity needed. -/
+theorem lfp_eq_iterate_bot {k : ℕ} (h : f (f^[k] ⊥) = f^[k] ⊥) : lfp f = f^[k] ⊥ :=
+  le_antisymm (f.lfp_le h.le) (iterate_bot_le_lfp f k)
+
+/-- The bottom-up chain is monotone in the iteration count. -/
+theorem iterate_bot_mono : Monotone fun k => f^[k] ⊥ := by
+  have hstep : ∀ k, f^[k] ⊥ ≤ f^[k + 1] ⊥ := by
+    intro k
+    induction k with
+    | zero => exact bot_le
+    | succ k ih =>
+      rw [Function.iterate_succ_apply', Function.iterate_succ_apply']
+      exact f.monotone ih
+    -- (each step applies `f` to the previous inequality)
+  exact monotone_nat_of_le_succ hstep
+
+end CompleteLattice
+
+section Fintype
+variable [CompleteLattice L] [Fintype L] (f : L →o L)
+
+/-- In a finite lattice the bottom-up chain reaches a fixed point within
+`Fintype.card L` steps: a monotone chain can rise at most `card` times. -/
+theorem iterate_bot_fixed : f (f^[Fintype.card L] ⊥) = f^[Fintype.card L] ⊥ := by
+  by_contra hne
+  -- if no iterate up to `card` were fixed, the chain would be strictly increasing,
+  -- giving an injection `Fin (card + 1) ↪ L`
+  have hstrict : ∀ k ≤ Fintype.card L, f^[k] ⊥ ≠ f^[k + 1] ⊥ := by
+    intro k hk hfix
+    -- once fixed, the chain is constant from `k` on, so `card` would be fixed too
+    have hconst : ∀ m, k ≤ m → f^[m] ⊥ = f^[k] ⊥ := by
+      intro m hm
+      induction m with
+      | zero =>
+        obtain rfl : k = 0 := by omega
+        rfl
+      | succ m ih =>
+        rcases Nat.lt_or_ge k (m + 1) with hlt | hge
+        · rw [Function.iterate_succ_apply', ih (by omega),
+            ← Function.iterate_succ_apply' (⇑f) k ⊥]
+          exact hfix.symm
+        · obtain rfl : k = m + 1 := by omega
+          rfl
+    exact hne (by
+      rw [← Function.iterate_succ_apply' (⇑f) (Fintype.card L) ⊥,
+        hconst (Fintype.card L + 1) (by omega), hconst (Fintype.card L) hk])
+  have hinj : Function.Injective fun k : Fin (Fintype.card L + 1) => f^[(k : ℕ)] ⊥ := by
+    intro a b hab
+    simp only at hab
+    by_contra hne'
+    wlog hlt : (a : ℕ) < (b : ℕ) generalizing a b
+    · exact this hab.symm (Ne.symm hne') (by omega)
+    have hle : f^[(a : ℕ) + 1] ⊥ ≤ f^[(b : ℕ)] ⊥ := iterate_bot_mono f (by omega)
+    have hge : f^[(a : ℕ)] ⊥ ≤ f^[(a : ℕ) + 1] ⊥ := iterate_bot_mono f (by omega)
+    exact hstrict a (by omega) (le_antisymm hge (by rw [← hab] at hle; exact hle))
+  have hcard := Fintype.card_le_of_injective _ hinj
+  simp only [Fintype.card_fin] at hcard
+  omega
+
+/-- In a finite lattice, `lfp` is computed by `Fintype.card`-fold iteration from `⊥`. -/
+theorem lfp_eq_iterate_bot_card : lfp f = f^[Fintype.card L] ⊥ :=
+  lfp_eq_iterate_bot f (iterate_bot_fixed f)
+
+end Fintype
+
+end OrderHom

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -1,0 +1,306 @@
+import Linglib.Core.Computability.Subregular.Function.Bimachine
+import Linglib.Core.Computability.Subregular.Logic.BMRS
+import Linglib.Studies.Jardine2016Tone
+import Linglib.Studies.McCollumEtAl2020
+
+/-!
+# Yolyan 2025: Weak Determinism as Simultaneous Application
+
+[yolyan-2025]: weakly deterministic functions are those expressible as the
+*simultaneous application* `P^L ⊙ P^R` of a backward and a forward BMRS program
+(Def. 5.1) — a definition inside the program formalism, which for the first time makes
+*non*-membership provable. `IsBmrsWeaklyDeterministic` renders it via the value-level
+⊙ of `Logic/BMRS.lean`: `SimulModels` asks each output symbol to be the ⊙-combination
+of the two programs' output predicates against the input (Defs. 4.1/4.3), sparing the
+combined-head-space construction.
+
+The engine is `not_isBmrsWeaklyDeterministic_of_requiresBothSides`: the paper's §5.3
+template (Thms. 5.2–5.5), consuming the same `Subregular.RequiresBothSides` witness
+that excludes the *bimachine* rendering of weak determinism
+(`not_isBimachineWeaklyDeterministic_of_requiresBothSides`). Whether the two
+definitions coincide is the paper's own open question (§6.3, against
+[meinhardt-mai-bakovic-mccollum-2024]); feeding both exclusions one witness object
+states it structurally without resolving it. The proof here streamlines the paper's:
+on either perturbation the input value is unchanged, so ⊙ collapses to conjunction and
+*both* one-sided outputs are forced true; each transports to the base word by one-sided
+locality (`Eval.congr_agreeUpto`/`congr_agreeFrom`), and recombining forces the base
+unchanged — no case-split through Prop. 4.2 needed. Only the `d = 0` instance of the
+witness is used: one-sidedness is global, not window-bounded.
+
+Instances: Sour Grapes harmony (Thm. 5.2 — the first proof of the [heinz-lai-2013]
+conjecture, via [padgett-1995]/[wilson-2003]'s pathology), and — through the shared
+witnesses already in the library — Tutrugbu ATR harmony (Prop. 5.5,
+[mccollum-bakovic-mai-meinhardt-2020]) and Luganda unbounded tonal plateauing
+([jardine-2016], the class the paper's Prop. 5.4 Bemba case exemplifies). The positive
+side: with no underlying stress the input predicate is constantly `⊥` and ⊙ collapses
+to disjunction — (5.15), recovering [koser-jardine-2020]'s LHOL program as the
+simultaneous application of its two one-sided halves. §6.3's conjunctive dual ⊘ is
+exact on Sour Grapes: `sourGrapes_conjunctive` shows the map *is* the ⊘ of its
+one-sided licensing conditions.
+-/
+
+namespace Yolyan2025
+
+open Subregular Subregular.Logic Subregular.Logic.BMRS
+
+/-- The single BMRS index variable. -/
+private abbrev x : Term Unit := .var ()
+
+variable {α : Type*} [DecidableEq α]
+
+/-! ### Weak determinism as simultaneous application (Defs. 4.1, 4.3, 5.1) -/
+
+/-- The value of the ⊙-combined output predicate for `σ` at `i` ([yolyan-2025]
+Def. 4.1): the two programs' output values combined against the input value. -/
+def SimulEval {L R : Type} (PL : Program α L) (PR : Program α R) (hL : L) (hR : R)
+    (w : WordModel α) (i : ℕ) (σ : α) (b : Bool) : Prop :=
+  ∃ bL bR, Eval PL w i (.call hL x) bL ∧ Eval PR w i (.call hR x) bR ∧
+    b = combine (decide (w[i]? = some σ)) bL bR
+
+/-- The simultaneous application `P^L ⊙ P^R` models `f` (Def. 4.3, restricted to the
+length-preserving maps of §5): each output symbol is the one whose ⊙-combined output
+predicate holds. -/
+def SimulModels {L R : Type} (PL : Program α L) (PR : Program α R)
+    (outL : α → L) (outR : α → R) (f : List α → List α) : Prop :=
+  ∀ w : WordModel α, (f w).length = w.length ∧
+    ∀ i < w.length, ∀ σ : α,
+      ((f w)[i]? = some σ ↔ SimulEval PL PR (outL σ) (outR σ) w i σ true)
+
+/-- **Def. 5.1**: `f` is weakly deterministic when it is the simultaneous application
+of a backward (`BMRSᵖ`) and a forward (`BMRSˢ`) program. Head types are unconstrained
+(the paper's are finite), which only strengthens the negative results below. -/
+def IsBmrsWeaklyDeterministic (f : List α → List α) : Prop :=
+  ∃ (L R : Type) (PL : Program α L) (PR : Program α R) (outL : α → L) (outR : α → R),
+    PL.Backward ∧ PR.Forward ∧ SimulModels PL PR outL outR f
+
+/-! ### The exclusion template (§5.3) -/
+
+/-- **The §5.3 template, proven once**: a map that requires both sides is not weakly
+deterministic. On the far-left perturbation the target is unchanged, so ⊙ is
+conjunction and both one-sided outputs are true; the forward one transports to the
+base by locality. Symmetrically the far-right perturbation delivers the backward one.
+Recombining in the base forces the target unchanged — contradiction. Thms. 5.2, 5.3
+and Props. 5.4, 5.5 are instances. -/
+theorem not_isBmrsWeaklyDeterministic_of_requiresBothSides {f : List α → List α}
+    (hf : RequiresBothSides f) : ¬ IsBmrsWeaklyDeterministic f := by
+  rintro ⟨L, R, PL, PR, outL, outR, hPL, hPR, hm⟩
+  obtain ⟨base, i, hi, hchange, ⟨uL, hLlen, hLag, hLsym, hLrev⟩,
+    ⟨uR, hRlen, hRag, hRsym, hRrev⟩⟩ := hf 0
+  simp only [Nat.sub_zero, Nat.add_zero] at hLag hRag
+  set σ := base[i]'hi with hσ
+  have hbase : base[i]? = some σ := List.getElem?_eq_getElem hi
+  -- the far-left run: the target is unchanged, so both components are forced true
+  have hLboth : Eval PL uL i (.call (outL σ) x) true ∧
+      Eval PR uL i (.call (outR σ) x) true := by
+    obtain ⟨bL, bR, hevL, hevR, hcomb⟩ :=
+      ((hm uL).2 i (hLlen ▸ hi) σ).mp (hLrev.trans (hLsym.trans hbase))
+    rw [decide_eq_true (hLsym.trans hbase), combine_true, eq_comm,
+      Bool.and_eq_true] at hcomb
+    exact ⟨hcomb.1 ▸ hevL, hcomb.2 ▸ hevR⟩
+  -- the far-right run, symmetrically
+  have hRboth : Eval PL uR i (.call (outL σ) x) true ∧
+      Eval PR uR i (.call (outR σ) x) true := by
+    obtain ⟨bL, bR, hevL, hevR, hcomb⟩ :=
+      ((hm uR).2 i (hRlen ▸ hi) σ).mp (hRrev.trans (hRsym.trans hbase))
+    rw [decide_eq_true (hRsym.trans hbase), combine_true, eq_comm,
+      Bool.and_eq_true] at hcomb
+    exact ⟨hcomb.1 ▸ hevL, hcomb.2 ▸ hevR⟩
+  -- transport each one-sided output to the base word and recombine
+  have hevL : Eval PL base i (.call (outL σ) x) true :=
+    hRboth.1.congr_agreeUpto hPL hRlen trivial fun k hk => (hRag k hk).symm
+  have hevR : Eval PR base i (.call (outR σ) x) true :=
+    hLboth.2.congr_agreeFrom hPR hLlen trivial fun k hk => (hLag k hk).symm
+  exact hchange ((((hm base).2 i hi σ).mpr
+    ⟨true, true, hevL, hevR, by rw [decide_eq_true hbase]; rfl⟩).trans hbase.symm)
+
+/-! ### Sour Grapes harmony is not weakly deterministic (Thm. 5.2)
+
+The pathology of [padgett-1995]/[wilson-2003]: `−` becomes `+` iff a `+` lies anywhere
+to its left and no blocker `⊟` anywhere to its right — spreading happens only when it
+can reach the end of the word. -/
+
+/-- The schematic Sour Grapes alphabet: trigger `+`, target `−`, blocker `⊟`. -/
+inductive SG
+  | plus | minus | blk
+  deriving DecidableEq, Repr
+
+/-- Sour Grapes harmony, by the paper's own characterization: a `−` surfaces `+` iff a
+trigger precedes it and no blocker follows it. -/
+def sourGrapes (w : List SG) : List SG :=
+  w.mapIdx fun i σ =>
+    if σ = .minus ∧ .plus ∈ w.take i ∧ .blk ∉ w.drop i then .plus else σ
+
+/-- The witness family: a mutable middle flanked by `d`-margins, with an editable head
+(trigger site) and tail (blocker site). -/
+private def sg (u v : SG) (d : ℕ) : List SG :=
+  u :: (List.replicate (2 * d + 1) .minus ++ [v])
+
+private theorem sg_length {u v : SG} {d : ℕ} : (sg u v d).length = 2 * d + 3 := by
+  simp [sg]
+
+private theorem sg_getElem? {u v : SG} {d k : ℕ} :
+    (sg u v d)[k]? = if k = 0 then some u else if k = 2 * d + 2 then some v
+      else if k < 2 * d + 2 then some .minus else none := by
+  rcases k with _ | k
+  · rfl
+  · simp only [sg, List.getElem?_cons_succ, List.getElem?_append, List.getElem?_replicate,
+      List.length_replicate, List.getElem?_cons, List.getElem?_nil]
+    split_ifs <;> first | rfl | omega | (exfalso; omega)
+
+/-- The head is the only trigger site: `+` precedes the middle iff the head is `+`. -/
+private theorem sg_plus_mem_take {u v : SG} {d : ℕ} :
+    .plus ∈ (sg u v d).take (d + 1) ↔ u = .plus := by
+  rw [sg, List.take_succ_cons, List.take_append_of_le_length (by simp; omega),
+    List.take_replicate]
+  simp [eq_comm, List.mem_replicate]
+
+/-- The tail is the only blocker site: `⊟` follows the middle iff the tail is `⊟`. -/
+private theorem sg_blk_mem_drop {u v : SG} {d : ℕ} :
+    .blk ∈ (sg u v d).drop (d + 1) ↔ v = .blk := by
+  rw [sg, List.drop_succ_cons, List.drop_append_of_le_length (by simp; omega),
+    List.drop_replicate]
+  simp [eq_comm, List.mem_replicate]
+
+/-- The middle of the witness: spreads iff the head triggers and the tail is clear. -/
+private theorem sourGrapes_sg_mid {u v : SG} {d : ℕ} :
+    (sourGrapes (sg u v d))[d + 1]? =
+      some (if u = .plus ∧ v ≠ .blk then .plus else .minus) := by
+  have hmid : (sg u v d)[d + 1]? = some .minus := by
+    rw [sg_getElem?]
+    split_ifs <;> first | rfl | omega | (exfalso; omega)
+  rw [sourGrapes, List.getElem?_mapIdx, hmid, Option.map_some]
+  by_cases h : u = .plus ∧ v ≠ .blk
+  · rw [if_pos h, if_pos ⟨rfl, sg_plus_mem_take.mpr h.1, fun hb => h.2 (sg_blk_mem_drop.mp hb)⟩]
+  · rw [if_neg h, if_neg fun ⟨_, ht, hd⟩ =>
+      h ⟨sg_plus_mem_take.mp ht, fun hv => hd (sg_blk_mem_drop.mpr hv)⟩]
+
+/-- Sour Grapes requires both sides: the middle of `+ −…− −` spreads, but neither the
+triggerless `− −…− −` (far-left perturbation) nor the blocked `+ −…− ⊟` (far-right)
+changes it. -/
+theorem sourGrapes_requiresBothSides : RequiresBothSides sourGrapes := by
+  intro d
+  have hlen : ∀ u v : SG, (sg u v d).length = 2 * d + 3 := fun _ _ => sg_length
+  refine ⟨sg .plus .minus d, d + 1, by rw [sg_length]; omega, ?_,
+    ⟨sg .minus .minus d, by rw [hlen, hlen], ?_, ?_, ?_⟩,
+    ⟨sg .plus .blk d, by rw [hlen, hlen], ?_, ?_, ?_⟩⟩
+  · rw [sourGrapes_sg_mid, if_pos ⟨rfl, by simp⟩, sg_getElem?]
+    split_ifs <;> simp_all
+  · intro k hk
+    rw [sg_getElem?, sg_getElem?]
+    split_ifs <;> first | rfl | omega
+  · rw [sg_getElem?, sg_getElem?]
+    split_ifs <;> first | rfl | omega | (exfalso; omega)
+  · rw [sourGrapes_sg_mid, if_neg (by simp), sg_getElem?]
+    split_ifs <;> first | rfl | omega
+  · intro k hk
+    rw [sg_getElem?, sg_getElem?]
+    split_ifs <;> first | rfl | omega
+  · rw [sg_getElem?, sg_getElem?]
+    split_ifs <;> first | rfl | omega
+  · rw [sourGrapes_sg_mid, if_neg (by simp), sg_getElem?]
+    split_ifs <;> first | rfl | omega | (exfalso; omega)
+
+/-- **Thm. 5.2** — the first proof of the [heinz-lai-2013] conjecture. -/
+theorem sourGrapes_not_bmrsWeaklyDeterministic :
+    ¬ IsBmrsWeaklyDeterministic sourGrapes :=
+  not_isBmrsWeaklyDeterministic_of_requiresBothSides sourGrapes_requiresBothSides
+
+/-- The same witness excludes the *bimachine* rendering of weak determinism — the two
+exclusions consume one object, which is the sharpest formal statement available of the
+paper's §6.3 open question (are the two definitions equivalent?). -/
+theorem sourGrapes_not_bimachineWeaklyDeterministic :
+    ¬ IsBimachineWeaklyDeterministic sourGrapes :=
+  not_isBimachineWeaklyDeterministic_of_requiresBothSides sourGrapes_requiresBothSides
+
+/-! ### The library's unbounded-circumambient maps, through the same template -/
+
+/-- **Prop. 5.5** (Tutrugbu ATR harmony is not weakly deterministic), riding the
+witness already formalized for the bimachine side in `Studies/McCollumEtAl2020`. -/
+theorem tutrugbu_not_bmrsWeaklyDeterministic :
+    ¬ IsBmrsWeaklyDeterministic McCollumEtAl2020.tutrugbuATR :=
+  not_isBmrsWeaklyDeterministic_of_requiresBothSides
+    McCollumEtAl2020.tutrugbu_requiresBothSides
+
+/-- Luganda unbounded tonal plateauing is not weakly deterministic: [jardine-2016]'s
+flagship pattern (the class of the paper's Prop. 5.4 Bemba case), through
+`Studies/Jardine2016Tone`'s witness. -/
+theorem utp_not_bmrsWeaklyDeterministic :
+    ¬ IsBmrsWeaklyDeterministic Jardine2016Tone.utp :=
+  not_isBmrsWeaklyDeterministic_of_requiresBothSides
+    Jardine2016Tone.utp_requiresBothSides
+
+/-! ### The positive side: LHOL stress as a simultaneous application (§5.2)
+
+Leftmost-heavy-otherwise-leftmost stress ([koser-jardine-2020]; Lushootseed): stress
+the leftmost heavy syllable, else the leftmost syllable. The backward program finds a
+heavy with no heavy to its left; the forward program stresses an initial light with no
+heavy to its right. No syllable is underlyingly stressed, so the input predicate is
+constantly `⊥` and ⊙ collapses to disjunction — (5.15), the Koser–Jardine program. -/
+
+/-- Syllable weight. -/
+inductive Syll
+  | H | L
+  deriving DecidableEq, Repr
+
+/-- Heads of the backward stress program: `noHL` = no heavy anywhere left (5.8). -/
+inductive LHead
+  | noHL | stressL
+  deriving DecidableEq
+
+/-- Heads of the forward stress program: `noHR` = no heavy anywhere right (5.9). -/
+inductive RHead
+  | noHR | stressR
+  deriving DecidableEq
+
+/-- (5.8), (5.12): stress a heavy with no heavy to its left. -/
+def lholL : Program Syll LHead
+  | .noHL => .ite (.initial x) .tru (.ite (.label {.H} x.pred) .fls (.call .noHL x.pred))
+  | .stressL => (Expr.label {.H} x).and (.call .noHL x)
+
+/-- (5.9), (5.11): stress an initial light with no heavy to its right. -/
+def lholR : Program Syll RHead
+  | .noHR => .ite (.final x) .tru (.ite (.label {.H} x.succ) .fls (.call .noHR x.succ))
+  | .stressR => (Expr.label {.L} x).and ((Expr.initial x).and (.call .noHR x))
+
+theorem lholL_backward : lholL.Backward := by
+  intro f
+  cases f <;> decide
+
+theorem lholR_forward : lholR.Forward := by
+  intro f
+  cases f <;> decide
+
+/-- With no underlying stress, ⊙ is the disjunction of the two programs — (5.15). On
+LHLLH the backward program stresses the leftmost heavy alone. -/
+theorem lhol_LHLLH :
+    (List.range 5).map (fun i =>
+      (evalFuel lholL [Syll.L, .H, .L, .L, .H] 32 i (.call .stressL x)).bind fun bL =>
+      (evalFuel lholR [Syll.L, .H, .L, .L, .H] 32 i (.call .stressR x)).map fun bR =>
+        combine false bL bR) =
+    [some false, some true, some false, some false, some false] := by
+  decide
+
+/-- On all-light LLLL the forward program stresses the initial syllable alone. -/
+theorem lhol_LLLL :
+    (List.range 4).map (fun i =>
+      (evalFuel lholL [Syll.L, .L, .L, .L] 32 i (.call .stressL x)).bind fun bL =>
+      (evalFuel lholR [Syll.L, .L, .L, .L] 32 i (.call .stressR x)).map fun bR =>
+        combine false bL bR) =
+    [some true, some false, some false, some false] := by
+  decide
+
+/-! ### §6.3: Sour Grapes is *conjunctively* simultaneous -/
+
+/-- Sour Grapes **is** the conjunctive simultaneous application ⊘ (Def. 6.5) of its
+two one-sided licensing conditions: at a target, spreading happens iff the backward
+condition (a trigger left) and the forward condition (no blocker right) *both* fire.
+The disjunctive ⊙ cannot express this (Thm. 5.2); ⊘ does so exactly — the paper's
+§6.3 route toward characterizing unbounded circumambience. -/
+theorem sourGrapes_conjunctive {w : List SG} {i : ℕ} (hm : w[i]? = some .minus) :
+    (sourGrapes w)[i]? = some (if combineC false
+      (decide (.plus ∈ w.take i)) (decide (.blk ∉ w.drop i)) then .plus else .minus) := by
+  rw [sourGrapes, List.getElem?_mapIdx, hm, Option.map_some, combineC_false]
+  by_cases hL : .plus ∈ w.take i <;> by_cases hR : .blk ∉ w.drop i <;>
+    simp [hL, hR]
+
+end Yolyan2025

--- a/Linglib/Studies/YolyanComer2026.lean
+++ b/Linglib/Studies/YolyanComer2026.lean
@@ -1,0 +1,329 @@
+import Linglib.Core.Computability.Subregular.Logic.BMRS
+import Linglib.Core.Computability.Subregular.Logic.ModalMu
+import Mathlib.Tactic.IntervalCases
+
+/-!
+# Yolyan & Comer 2026: Phonological Processes as Modal Transductions
+
+[yolyan-comer-2026]: total BMRS is expressively equivalent to the modal μ-calculus on
+words (Thm. 2), giving an alternative proof that order-preserving BMRS captures the
+rational functions. This file formalizes the constructive core: the translation `tr`
+(Def. 6) from vectorial modal formulas to BMRS expressions and its compositionality
+(`eval_tr`, Remark 7) — `tr φ` evaluates to the truth value of `φ` wherever rule-head
+calls agree with the recursion variables. Thm. 8 discharges that hypothesis for
+*directed* systems by SCC induction (TODO: the directedness machinery); Thm. 2's
+converse containment runs through MSO (out of scope until an MSO substrate exists).
+
+The paper's two worked examples ground both formalisms: vowel nasalization ((2)–(4),
+non-recursive) and progressive nasal spreading in Warao ((5)–(7), [osborn-1966]). The
+modal form `N′ = μX.(N ∨ (¬T ∧ ♦X))` recurses under the *backward* modality `♦` =
+`bdia` — a target inherits nasality from its predecessor. Both compute the Fig. 4/5
+columns on /naote/ → [nãõte], and the BMRS and modal results agree
+(`warao_agreement`); `warao_tr_agreement` runs Remark 7 end-to-end on the translated
+program, with the rule-head hypothesis discharged by direct computation — the concrete
+shape of Thm. 8's induction.
+-/
+
+namespace YolyanComer2026
+
+open Subregular.Logic Subregular.Logic.BMRS Subregular.Logic.ModalMu
+
+/-- The single BMRS index variable. -/
+private abbrev x : Term Unit := .var ()
+
+/-! ### Segments and feature classes
+
+The examples' segments, with the paper's overlapping feature predicates N, V, T as
+class tests (a nasalized vowel satisfies both V and N — a partition alphabet cannot
+represent the nasalization output, which is why `label` atoms are class tests). -/
+
+/-- Segments occurring in the paper's examples. -/
+inductive Seg
+  | n | a | o | t | e | b
+  deriving DecidableEq, Repr
+
+/-- N: nasal sounds. -/
+def nas : Finset Seg := {.n}
+
+/-- V: vowels. -/
+def vow : Finset Seg := {.a, .o, .e}
+
+/-- T: voiceless stops (the spreading blocker). -/
+def stop : Finset Seg := {.t}
+
+/-- /naote/, the Fig. 4 input. -/
+def naote : WordModel Seg := [.n, .a, .o, .t, .e]
+
+/-- /bæn/, the vowel-nasalization input. -/
+def baen : WordModel Seg := [.b, .a, .n]
+
+/-! ### Vowel nasalization ((2)–(4)): a vowel nasalizes before a nasal -/
+
+/-- Output predicates of the nasalization program. -/
+inductive NasHead
+  | V' | N'
+  deriving DecidableEq
+
+/-- (3): `V′(x) = V(x)`; `N′(x) = if V(x) then N(s(x)) else N(x)`. -/
+def nasalization : Program Seg NasHead
+  | .V' => .label vow x
+  | .N' => .ite (.label vow x) (.label nas x.succ) (.label nas x)
+
+/-- Fig. 3: on /bæn/ the output columns are V′ = ⊥⊤⊥ and N′ = ⊥⊤⊤ — [bæ̃n], the æ
+nasalized by the following n. -/
+theorem nasalization_columns :
+    ((List.range 3).map fun i => evalFuel nasalization baen 8 i (.call .V' x)) =
+        [some false, some true, some false] ∧
+      ((List.range 3).map fun i => evalFuel nasalization baen 8 i (.call .N' x)) =
+        [some false, some true, some true] := by
+  decide
+
+/-- (4): the modal form `N′ = (V ∧ ◇N) ∨ N` — non-recursive, so no fixed point is
+involved. -/
+def nasalizationChi : System Seg 1 where
+  eqs _ := ((Formula.label vow).and (.dia (.label nas))).or (.label nas)
+  out := 0
+
+/-- The modal (4) marks exactly positions 1 and 2 of /bæn/ nasal, agreeing with the
+BMRS N′ column. -/
+theorem nasalizationChi_sat : ∀ i, nasalizationChi.Sat baen i ↔ i = 1 ∨ i = 2 := by
+  intro i
+  simp only [System.Sat]
+  rw [← nasalizationChi.op_sem baen]
+  match i with
+  | 0 | 1 | 2 => simp [System.mem_op, nasalizationChi, vow, nas, baen, WordModel.succ?]
+  | k + 3 =>
+    have hnone : baen[k + 3]? = none := List.getElem?_eq_none (by simp [baen])
+    simp [System.mem_op, nasalizationChi, vow, nas, hnone,
+      WordModel.succ?_eq_some_iff]
+
+/-! ### Warao nasal spreading ((5)–(7)): nasality spreads rightward until a stop -/
+
+/-- The single output predicate of the spreading program. -/
+inductive WHead
+  | N'
+  deriving DecidableEq
+
+/-- (6): `N′(x) = if N(x) then ⊤ else if T(x) then ⊥ else if min(x) then ⊥ else
+N′(p(x))` — recursive through the predecessor: spreading is progressive. -/
+def warao : Program Seg WHead
+  | .N' => .ite (.label nas x) .tru
+      (.ite (.label stop x) .fls
+        (.ite (.initial x) .fls (.call .N' x.pred)))
+
+/-- Fig. 4: on /naote/ the output column is N′ = ⊤⊤⊤⊥⊥ — [nãõte], spreading blocked by
+the t. -/
+theorem warao_column :
+    ((List.range 5).map fun i => evalFuel warao naote 32 i (.call .N' x)) =
+      [some true, some true, some true, some false, some false] := by
+  decide
+
+/-- (7): the modal form `N′ = μX.(N ∨ (¬T ∧ ♦X))`. -/
+def waraoChi : System Seg 1 where
+  eqs _ := (Formula.label nas).or ((Formula.nlabel stop).and (.bdia (.var 0)))
+  out := 0
+
+/-- The least fixed point on /naote/: nasality holds exactly at positions 0, 1, 2. -/
+abbrev waraoU : Fin 1 → Set ℕ := fun _ => {i | i < 3}
+
+/-- `waraoU` is a prefixed point of the system operator. -/
+theorem warao_op_le : waraoChi.op naote waraoU ≤ waraoU := by
+  intro X i hi
+  obtain rfl : X = 0 := Subsingleton.elim X 0
+  simp only [System.mem_op, waraoChi, Formula.realize_or, Formula.realize_and,
+    Formula.realize_label, Formula.realize_nlabel, Formula.realize_bdia,
+    Formula.realize_var] at hi
+  rcases hi with ⟨sg, hsg, hw⟩ | ⟨hT, j, hj, hj3⟩
+  · obtain ⟨hlt, -⟩ := List.getElem?_eq_some_iff.mp hw
+    have hlt5 : i < 5 := by simpa [naote] using hlt
+    have : i = 0 := by
+      interval_cases i <;> simp_all [nas, naote]
+    simp [this]
+  · rw [WordModel.pred?_eq_some_iff] at hj
+    obtain ⟨rfl, hjlen⟩ := hj
+    have hj3 : j < 3 := hj3
+    rcases Nat.lt_or_ge j 2 with h2 | h2
+    · show j + 1 < 3
+      omega
+    · obtain rfl : j = 2 := by omega
+      exact absurd rfl (hT .t (by decide) : naote[3]? ≠ some Seg.t)
+
+/-- The three nasal positions are in the least fixed point (unfolding `op_sem` once per
+step of the spread). -/
+theorem warao_le_sem : waraoU ≤ waraoChi.sem naote := by
+  have hmem : ∀ i, waraoChi.sem naote 0 i =
+      (waraoChi.eqs 0).Realize naote (waraoChi.sem naote) i := fun i =>
+    congrFun (congrFun (waraoChi.op_sem naote).symm 0) i
+  have h0 : 0 ∈ waraoChi.sem naote 0 := by
+    show waraoChi.sem naote 0 0
+    rw [hmem]
+    exact Or.inl ⟨.n, by decide, rfl⟩
+  have h1 : 1 ∈ waraoChi.sem naote 0 := by
+    show waraoChi.sem naote 0 1
+    rw [hmem]
+    exact Or.inr ⟨show ∀ sg ∈ stop, naote[1]? ≠ some sg by decide, 0, by decide, h0⟩
+  have h2 : 2 ∈ waraoChi.sem naote 0 := by
+    show waraoChi.sem naote 0 2
+    rw [hmem]
+    exact Or.inr ⟨show ∀ sg ∈ stop, naote[2]? ≠ some sg by decide, 1, by decide, h1⟩
+  intro X i hi
+  obtain rfl : X = 0 := Subsingleton.elim X 0
+  have hi3 : i < 3 := hi
+  interval_cases i
+  exacts [h0, h1, h2]
+
+/-- The modal semantics on /naote/, exactly. -/
+theorem warao_sem : waraoChi.sem naote = waraoU :=
+  le_antisymm (waraoChi.sem_le naote warao_op_le) warao_le_sem
+
+/-- Fig. 5: the modal (7) marks exactly positions 0, 1, 2 of /naote/. -/
+theorem warao_sat {i : ℕ} : waraoChi.Sat naote i ↔ i < 3 := by
+  rw [System.Sat, warao_sem]
+  exact Iff.rfl
+
+/-- **Fig. 4/5 agreement**: the BMRS program (6) and the modal formula (7) compute the
+same nasality column on /naote/. -/
+theorem warao_agreement (i : ℕ) (hi : i < 5) :
+    evalFuel warao naote 32 i (.call .N' x) = some true ↔ waraoChi.Sat naote i := by
+  rw [warao_sat]
+  interval_cases i <;> decide
+
+/-! ### The translation (Def. 6) and its compositionality (Remark 7) -/
+
+variable {α : Type*} {n : ℕ}
+
+/-- Def. 6: translate a vectorial modal formula into a BMRS expression whose rule heads
+are the recursion variables. Modalities substitute a moved term into the translated
+body; class-negated atoms translate by (3.8)-negation (the evident extension of the
+paper's clauses, which cover positive atoms). -/
+def tr : Formula α n → Expr α (Fin n)
+  | .tru => .tru
+  | .fls => .fls
+  | .initial => .initial x
+  | .final => .final x
+  | .label s => .label s x
+  | .nlabel s => .ite (.label s x) .fls .tru
+  | .var X => .call X x
+  | .and φ ψ => .ite (tr φ) (tr ψ) .fls
+  | .or φ ψ => .ite (tr φ) .tru (tr ψ)
+  | .dia φ => .ite (.final x) .fls ((tr φ).subst x.succ)
+  | .bdia φ => .ite (.initial x) .fls ((tr φ).subst x.pred)
+
+/-- The translated program of a system: one rule per recursion variable. -/
+def _root_.Subregular.Logic.ModalMu.System.trProgram (χ : System α n) :
+    Program α (Fin n) := fun X => tr (χ.eqs X)
+
+/-- **Remark 7** (compositionality of the translation): wherever rule-head calls agree
+with the recursion variables, `tr φ` evaluates to the truth value of `φ`. Thm. 8's
+SCC induction discharges the hypothesis for directed systems. -/
+theorem eval_tr [DecidableEq α] {P : Program α (Fin n)} {w : WordModel α}
+    {U : Fin n → Set ℕ} [∀ X, DecidablePred (· ∈ U X)]
+    (hcall : ∀ X, ∀ j < w.length, Eval P w j (.call X x) (decide (j ∈ U X)))
+    (φ : Formula α n) :
+    ∀ {i : ℕ}, i < w.length → Eval P w i (tr φ) (decide (φ.Realize w U i)) := by
+  induction φ with
+  | tru =>
+    intro i hi
+    rw [decide_eq_true Formula.realize_tru]
+    exact .tru
+  | fls =>
+    intro i hi
+    rw [decide_eq_false Formula.realize_fls]
+    exact .fls
+  | initial =>
+    intro i hi
+    by_cases h : i = 0
+    · subst h
+      rw [decide_eq_true (Formula.realize_initial.mpr rfl)]
+      exact .initial_true (by rw [tden_var hi])
+    · rw [decide_eq_false (h ∘ Formula.realize_initial.mp)]
+      exact .initial_false (tden_var hi) (by omega)
+  | final =>
+    intro i hi
+    by_cases h : i + 1 = w.length
+    · rw [decide_eq_true (Formula.realize_final.mpr h)]
+      exact .final_true (by rw [tden_var hi]; congr 1; omega)
+    · rw [decide_eq_false (h ∘ Formula.realize_final.mp)]
+      exact .final_false (tden_var hi) (by omega)
+  | label s =>
+    intro i hi
+    by_cases h : ∃ a ∈ s, w[i]? = some a
+    · rw [decide_eq_true (Formula.realize_label.mpr h)]
+      obtain ⟨a, has, ha⟩ := h
+      exact .label_true (tden_var hi) ha has
+    · rw [decide_eq_false (h ∘ Formula.realize_label.mp)]
+      have hw : w[i]? = some (w[i]'hi) := List.getElem?_eq_getElem hi
+      exact .label_false (tden_var hi) hw fun has => h ⟨_, has, hw⟩
+  | nlabel s =>
+    intro i hi
+    by_cases h : ∃ a ∈ s, w[i]? = some a
+    · obtain ⟨a, has, ha⟩ := h
+      rw [decide_eq_false fun hall => hall a has ha]
+      exact .ite_true (.label_true (tden_var hi) ha has) .fls
+    · rw [decide_eq_true (p := (Formula.nlabel s).Realize w U i)
+        fun a has ha => h ⟨a, has, ha⟩]
+      have hw : w[i]? = some (w[i]'hi) := List.getElem?_eq_getElem hi
+      exact .ite_false (.label_false (tden_var hi) hw fun has => h ⟨_, has, hw⟩) .tru
+  | var X =>
+    intro i hi
+    have h := hcall X i hi
+    rwa [show decide (i ∈ U X) = decide ((Formula.var X).Realize w U i) from
+      decide_eq_decide.mpr Formula.realize_var.symm] at h
+  | and φ ψ ihφ ihψ =>
+    intro i hi
+    by_cases h : φ.Realize w U i
+    · rw [show decide ((φ.and ψ).Realize w U i) = decide (ψ.Realize w U i) from
+        decide_eq_decide.mpr (by simp [h])]
+      exact .ite_true (decide_eq_true h ▸ ihφ hi) (ihψ hi)
+    · rw [decide_eq_false fun hc => h hc.1]
+      exact .ite_false (decide_eq_false h ▸ ihφ hi) .fls
+  | or φ ψ ihφ ihψ =>
+    intro i hi
+    by_cases h : φ.Realize w U i
+    · rw [decide_eq_true (Formula.realize_or.mpr (Or.inl h))]
+      exact .ite_true (decide_eq_true h ▸ ihφ hi) .tru
+    · rw [show decide ((φ.or ψ).Realize w U i) = decide (ψ.Realize w U i) from
+        decide_eq_decide.mpr (by simp [h])]
+      exact .ite_false (decide_eq_false h ▸ ihφ hi) (ihψ hi)
+  | dia φ ih =>
+    intro i hi
+    by_cases h : i + 1 = w.length
+    · rw [decide_eq_false (by
+        simp only [Formula.realize_dia, WordModel.succ?_eq_some_iff]
+        rintro ⟨j, ⟨rfl, hj⟩, -⟩
+        omega)]
+      exact .ite_true (.final_true (by rw [tden_var hi]; congr 1; omega)) .fls
+    · have hsucc : i + 1 < w.length := by omega
+      rw [show decide (φ.dia.Realize w U i) = decide (φ.Realize w U (i + 1)) from
+        decide_eq_decide.mpr (by simp [WordModel.succ?_eq_some_iff, hsucc])]
+      exact .ite_false (.final_false (tden_var hi) (by omega))
+        (Eval.subst (by rw [tden_succ_var, WordModel.succ?, if_pos hsucc]) (ih hsucc))
+  | bdia φ ih =>
+    intro i hi
+    by_cases h : i = 0
+    · subst h
+      rw [decide_eq_false (by
+        simp only [Formula.realize_bdia, WordModel.pred?_eq_some_iff]
+        rintro ⟨j, ⟨hj, -⟩, -⟩
+        omega)]
+      exact .ite_true (.initial_true (by rw [tden_var hi])) .fls
+    · obtain ⟨j, rfl⟩ : ∃ j, i = j + 1 := ⟨i - 1, by omega⟩
+      have hj : j < w.length := by omega
+      rw [show decide (φ.bdia.Realize w U (j + 1)) = decide (φ.Realize w U j) from
+        decide_eq_decide.mpr (by simp [WordModel.pred?_eq_some_iff, hj])]
+      exact .ite_false (.initial_false (tden_var hi) (by omega))
+        (Eval.subst (by rw [tden_pred_var hi]; simp [WordModel.pred?, hj]) (ih hj))
+
+/-- Remark 7 run end-to-end on Warao: the translated program agrees with the modal
+semantics on /naote/ (`waraoU = waraoChi.sem naote` by `warao_sem`), the rule-head
+hypothesis discharged by direct computation — the concrete shape of Thm. 8. -/
+theorem warao_tr_agreement (i : ℕ) (hi : i < 5) :
+    Eval waraoChi.trProgram naote i (tr (waraoChi.eqs 0))
+      (decide ((waraoChi.eqs 0).Realize naote waraoU i)) := by
+  refine eval_tr (fun X j hj => ?_) _ hi
+  obtain rfl : X = 0 := Subsingleton.elim X 0
+  refine evalFuel_sound (n := 32) ?_
+  have hj5 : j < 5 := by simpa [naote] using hj
+  interval_cases j <;> decide
+
+end YolyanComer2026

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -34969,3 +34969,68 @@
 	role = {cited},
 	sources = {Studies/Prince1983.lean}
 }
+
+@article{bhaskar-chandlee-jardine-2023,
+  author    = {Bhaskar, Siddharth and Chandlee, Jane and Jardine, Adam},
+  year      = {2023},
+  title     = {Rational functions via recursive schemes},
+  journal   = {arXiv preprint},
+  note      = {arXiv:2302.03074},
+  url       = {https://arxiv.org/abs/2302.03074},
+  subfield  = {phonology/computational},
+  role      = {cited},
+  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+}
+
+@article{chandlee-jardine-2021,
+  author    = {Chandlee, Jane and Jardine, Adam},
+  year      = {2021},
+  title     = {Computational universals in linguistic theory: Using recursive programs for phonological analysis},
+  journal   = {Language},
+  volume    = {97},
+  number    = {3},
+  pages     = {485--519},
+  doi       = {10.1353/lan.2021.0045},
+  subfield  = {phonology/computational},
+  role      = {cited},
+  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+}
+
+@article{kozen-1983,
+  author    = {Kozen, Dexter},
+  year      = {1983},
+  title     = {Results on the propositional $\mu$-calculus},
+  journal   = {Theoretical Computer Science},
+  volume    = {27},
+  number    = {3},
+  pages     = {333--354},
+  doi       = {10.1016/0304-3975(82)90125-6},
+  subfield  = {logic},
+  role      = {cited},
+  sources   = {Core/Computability/Subregular/Logic/ModalMu.lean}
+}
+
+@article{yolyan-2025,
+  author    = {Yolyan, Tatevik},
+  year      = {2025},
+  title     = {A logical characterization of weak determinism as simultaneous application},
+  journal   = {Journal of Logic, Language and Information},
+  volume    = {34},
+  pages     = {89--153},
+  doi       = {10.1007/s10849-025-09429-9},
+  subfield  = {phonology/computational},
+  role      = {formalized},
+  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+}
+
+@inproceedings{yolyan-comer-2026,
+  author    = {Yolyan, Tatevik and Comer, Jesse},
+  year      = {2026},
+  title     = {Phonological processes as modal transductions},
+  booktitle = {Proceedings of the Society for Computation in Linguistics (SCiL) 2026},
+  pages     = {549--559},
+  publisher = {Association for Computational Linguistics},
+  subfield  = {phonology/computational},
+  role      = {formalized},
+  sources   = {Core/Computability/Subregular/Logic/BMRS.lean, Core/Computability/Subregular/Logic/ModalMu.lean}
+}

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -35034,3 +35034,14 @@
   role      = {formalized},
   sources   = {Core/Computability/Subregular/Logic/BMRS.lean, Core/Computability/Subregular/Logic/ModalMu.lean}
 }
+
+@inproceedings{koser-jardine-2020,
+  author    = {Koser, Nate and Jardine, Adam},
+  year      = {2020},
+  title     = {The computational nature of stress assignment},
+  booktitle = {Proceedings of the 2019 Annual Meeting on Phonology},
+  publisher = {Linguistic Society of America},
+  subfield  = {phonology/computational},
+  role      = {cited},
+  sources   = {Studies/Yolyan2025.lean}
+}


### PR DESCRIPTION
Boolean Monadic Recursive Schemes and the vectorial modal μ-calculus enter the subregular Logic leg, grounding Yolyan & Comer (SCiL 2026) and Yolyan (JoLLI 2025).

- `Logic/BMRS.lean`: syntax over QFLogic terms with Finset class-test atoms, derivation-system semantics (`Eval`) with determinism + fuel-evaluator adequacy, term composition/substitution with `Eval` transport, one-sided (Backward/Forward) fragments with the locality lemmas powering weak-determinism negative results, ⊙/⊘ value combinators with their algebra.
- `Logic/ModalMu.lean`: negation-free vectorial μ-formulas, monotone satisfaction with simp kit + decidability, `OrderHom.lfp` semantics with an iteration certificate.
- `Core/Order/IterateFixedPoint.lean`: [UPSTREAM] Kleene-style lfp certificates (fixed iterate = lfp; finite lattice reaches it by card-fold iteration).
- `Studies/YolyanComer2026.lean`: the Def. 6 translation `tr` + Remark 7 compositionality; nasalization and Warao spreading computed in both formalisms with the Fig. 4/5 agreement theorems (modal side certified against `OrderHom.lfp` via `op_sem`/`sem_le`, no native_decide).
- `Term.Backward`/`pdepth` consolidated from LocalityBridge into QFLogic (+ `Forward` dual); `succ?`/`pred?` gain `_eq_some_iff` characterizations.