### PR TITLE
feat(Syntax/Clause): realizes selection relation + toNoonan graduation

### DIFF
--- a/Linglib/Features/Complementation.lean
+++ b/Linglib/Features/Complementation.lean
@@ -11,9 +11,9 @@ Per-entry complementation features: which complement type a predicate selects
 The cross-linguistic complementation typology also lives here:
 [noonan-2007]'s six complement-clause types (`NoonanCompType`) and twelve
 complement-taking-predicate classes (`CTPClass`) with their default reality
-status (`RealityStatus`, `ctpRealityStatus`). The bridge between the two
-inventories (`ComplementType ↔ NoonanCompType`) is paper-anchored in
-`Studies/Noonan2007.lean`.
+status (`RealityStatus`, `ctpRealityStatus`). The adapter between the two
+inventories (`ComplementType.toNoonan`) lives in
+`Syntax/Clause/Complementation.lean`.
 
 ## Main declarations
 

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -667,6 +667,8 @@ theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
 -- [cacchioli-2025]'s Tigrinya extension lives in
 -- `Studies/Cacchioli2025.lean` per the chronology rule.
 
+open Buryat
+
 /-- A Cont-exponence analysis of one language's clause-typing
     inventory ([bondarenko-2022] ch. 4): which morpheme, if any,
     overtly expones Cont, tied by law to the fragment inventory
@@ -696,12 +698,12 @@ structure ContCompAnalysis extends ContAnalysis where
     allomorphs — participial *-Aːša* next to nominal projections,
     converbial *-žA* next to verbs. -/
 def buryatAnalysis : ContCompAnalysis where
-  inventory := Buryat.complementizers
-  contExponent := some Buryat.ge
+  inventory := complementizers
+  contExponent := some ge
   contExponent_mem := fun _ hc => by cases hc; exact .head _
   compAllomorph
-    | .nominal => Buryat.aasha
-    | .verbal  => Buryat.zha
+    | .nominal => aasha
+    | .verbal  => zha
   compAllomorph_mem := by
     intro l
     cases l
@@ -728,7 +730,7 @@ def koreanAnalysis : ContAnalysis where
     in Buryat, the Cont exponent is exactly the non-suffixal
     say-root. -/
 theorem mem_buryatContExponent_iff :
-    ∀ c ∈ Buryat.complementizers,
+    ∀ c ∈ complementizers,
       (c ∈ buryatAnalysis.contExponent ↔ c.verbForm = none) := by
   decide
 
@@ -738,9 +740,9 @@ theorem mem_buryatContExponent_iff :
     nominalized frame by participial *-Aːša* — while the say-root *gɘ*
     (no `noonanType` of its own) realizes neither. -/
 theorem hanaxa_frames_realized :
-    Buryat.hanaxa.realizes Buryat.zha ∧
-    Buryat.hanaxa.realizes Buryat.aasha ∧
-    ¬ Buryat.hanaxa.realizes Buryat.ge :=
+    hanaxa.realizes zha ∧
+    hanaxa.realizes aasha ∧
+    ¬ hanaxa.realizes ge :=
   ⟨⟨.finiteClause, .head _, rfl⟩, ⟨.gerund, .tail _ (.head _), rfl⟩,
     fun ⟨_, hf, h⟩ => by fin_cases hf <;> exact nomatch h⟩
 

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -5,93 +5,55 @@ import Linglib.Fragments.Korean.Complementizers
 import Linglib.Syntax.Clause.Complementation
 
 /-!
-# Bondarenko 2022: Anatomy of an Attitude [bondarenko-2022]
+# Bondarenko 2022: Anatomy of an Attitude
 
-Tatiana Bondarenko (2022). MIT PhD dissertation. Thesis advisors:
-P. Elliott, K. von Fintel, D. Fox, S. Iatridou, R. Schwarzschild.
+[bondarenko-2022]
 
-## Locator convention
+Embedded CPs receive two denotations, tracking a left-peripheral syntactic
+distinction (§1.1.1, ex. 1): a Cont-CP denotes a predicate on content
+individuals via CONT ([kratzer-2006]; [moulton-2009]; [moulton-2015];
+[elliott-2020-embedding]) and projects a ContP; a Sit-CP denotes a predicate
+on minimal exemplifying situations ([kratzer-1989]) and lacks one. ContP is
+overt in Korean (*-ta*) and Buryat (*gɘ* 'say'), null in English and Russian.
 
-The §-numbers below DO NOT track a single dissertation chapter;
-the file is paper-anchored as a whole and the sections were added
-across multiple phases:
+Formalized here: equality semantics for displacement (eq. 7) against subset
+(eq. 10) and existential (eq. 15), whence the impossibility of true CP
+conjunction ([bassi-bondarenko-2021]); Sit-CP transparency vs Cont-CP opacity
+(§1.1.1.1 ex. 5-6); and the transparent syntax-semantics mapping thesis
+(§1.1.2, ch. 4) — bare CPs compose only as modifiers, nominalized CPs only as
+arguments — later attacked by [angelopoulos-2026] (comparison in
+`Studies/Angelopoulos2026.lean`, per the chronology rule).
 
-- §§ 1-7: reference [bondarenko-2022] Chapter 1 brief summary
-  overview (locators verified at the chapter-1 level).
-- §§ 8-12: reference Chapter 4 substantive bare-vs-nominalized
-  treatment (Phase 2 type-theoretic refactor; §§4.2-4.5).
-- §§ 13-14: reference Chapter 2 substantive distinct-denotation
-  argument (Phase 3 §§2.2.3 noun-predicate co-occurrence + §2.3
-  Cont/Comp head denotations).
+## Main declarations
 
-Cross-chapter equivalence claims in the chapter-1 sections (e.g.
-"Table 1.1 ↔ Table 4.1"; "ex. 1 ↔ §4.2 ex. 1-2") were noted from
-context but not re-checked across chapters and carry implicit
-`UNVERIFIED:` status. References to chapters not yet read carry
-explicit `UNVERIFIED:` flags inline.
+- `ExistentialContent` — the rejected existential semantics (eq. 15)
+- `cont_function_blocks_conjunction` — equality forces CONT-functionality
+- `ReferentiallyTransparentAt`, `compC_not_transparentAt` — the weak
+  transparency contrast
+- `saturatesTheta`, `bareCP_satisfies_no_theta` — the ch. 4 type-mismatch
+  mechanism behind the Causer/Theme/About bans
+- `transparentSSMapping`, `transparentSSMapping_iff_typed` — the mapping table
+  and its type-theoretic derivation
+- `NominalSort.truthEvaluable`, `NominalSort.occurrenceCompatible` — the ch. 2
+  co-occurrence asymmetries
+- `ContAnalysis`, `buryatAnalysis`, `koreanAnalysis` — per-language ContP
+  exponence, tied by law to the fragment inventories
+- `compHead` — the Comp head denotation (§2.3 ex. 151)
 
-## Headline thesis
+## Implementation notes
 
-Embedded CPs receive **two kinds of denotations** corresponding to a
-syntactic distinction in the left periphery (§1.1.1, paper ex. 1):
+Bare `§`/`ex.`/`eq.` locators refer to the dissertation and were verified
+against its text. Sections track different chapters: nominal sorts through the
+BE2026 bridge follow the ch. 1 summary, the type-theoretic sections ch. 4
+(§§4.2-4.5), the co-occurrence and head-denotation sections ch. 2 (§2.2.3,
+§2.3). The ch. 1 summary repeats later material: Table 1.1 = Table 4.1, and
+ch. 1 ex. 1 = §4.2 ex. 1-2.
 
-- **Cont-CP** ≔ λx. CONT(x) = {s : φ(s)}  — predicate on content
-  individuals ([kratzer-2006]; [moulton-2009]; [moulton-2015];
-  [elliott-2020-embedding]). Has an extra **ContP** projection that
-  introduces the CONT function.
-- **Sit-CP** ≔ λs'. s' is a minimal situation exemplifying φ —
-  predicate on minimal situations ([kratzer-1989]). Lacks ContP.
-
-In some languages ContP is overtly exposed (Korean -ta declarative;
-Buryat gɘ 'say'); in others (English, Russian) it is null.
-
-## Three substantive claims this file formalizes
-
-1. **Equality semantics** for displacement (§1.1.1.2, paper eq. 7),
-   not subset semantics (eq. 10) or existential (eq. 15). The
-   Cont-CP denotes equality with the embedded proposition, so CONT
-   is a function rather than a downward-closed relation. Three
-   arguments converge: (i) nominal CP interpretation (paper §2.4),
-   (ii) impossibility of CP conjunction ([bassi-bondarenko-2021]),
-   (iii) Russian NPI subjunctive distribution (paper ch. 5).
-
-2. **Sit-CPs are referentially transparent; Cont-CPs are opaque.**
-   Paper §1.1.1.1 ex. 5 vs ex. 6: under a Sit-CP, embedded
-   expressions evaluate at the actual world (substitution preserves
-   truth). Under a Cont-CP, they evaluate at content-related worlds
-   (substitution may change truth value).
-
-3. **Transparent Syntax-Semantics mapping thesis** (§1.1.2, ch. 4):
-   bare CPs are *always* modifiers (PM via the situation argument
-   path); nominalized CPs are *always* arguments (FA via the DP
-   argument path). The syntactic structure of the CP determines
-   the composition path. The (Sit-CP, via DP argument) cell of
-   Table 1.1 is unattested by semantic triviality; the
-   (bare, FA-argument) and (nominalized, PM-modifier) cells are
-   ruled out by the structural correlation.
-
-   This is the thesis [angelopoulos-2026] later attacks (autonomy
-   of syntax: the same syntactic position can yield either
-   composition mode at LF); per the chronology rule the comparison
-   lives in `Studies/Angelopoulos2026.lean`
-   (`transparency_conflates_axes`), which targets the
-   `transparentSSMapping` definition below.
-
-## Out of scope
-
-- Chapter 3 (clausal conjunction & disjunction): the impossibility-
-  of-CP-conjunction theorem (`cont_function_blocks_conjunction`
-  below) is the only fragment from ch. 3 we land here. Korean -ta
-  and -ko-specific Conjunction Reduction analyses are paper-
-  specific and don't generalize.
-- Chapter 5 (polarity subjunctives): Russian NPI subjunctive data
-  + the L-analyticity argument. Worth its own file when the
-  L-analyticity substrate is in place.
-- Buryat/Korean/Russian morphological exposition (ContP overt vs
-  null): lives in the per-language fragment files
-  (`Fragments/Buryat/Complementizers.lean`,
-  `Fragments/Korean/Complementizers.lean`; Russian has none yet),
-  consumed by the §12 exponence projections below.
+Out of scope: ch. 3 clausal coordination (only the conjunction-impossibility
+theorem lands here), ch. 5 polarity subjunctives (Russian NPI data,
+L-analyticity), and the morphological exposition of ContP, which lives in
+`Fragments/Buryat/Complementizers.lean` and
+`Fragments/Korean/Complementizers.lean`.
 -/
 
 namespace Bondarenko2022
@@ -101,60 +63,39 @@ open Semantics.Attitudes.ClauseDenotation.Content (compC ContentNoun)
 open Semantics.Attitudes.ClauseDenotation.Situation
   (SituationIndividual SituationNoun compPu)
 
--- ════════════════════════════════════════════════════════════════
--- § 1. Nominal Sorts
--- ════════════════════════════════════════════════════════════════
+/-! ### Nominal sorts -/
 
-/-- Bondarenko's typology of noun sorts that combine with embedded
-    CPs. Studies-local enum per the typological-discipline rule:
-    the substrate (`ContentIndividual`, `SituationIndividual`) lives
-    in `Semantics/Attitudes/ClauseDenotation/`; the typology-
-    level tagging stays here.
-
-    Cross-linguistic robustness varies (English *the situation* vs
-    *the case*; Korean *sanghwang*; Russian *slučaj* / *situacija*).
-    This enum follows the paper's primary distinctions (§2.2). -/
+/-- The dissertation's typology of nouns combining with embedded CPs (§2.2).
+Studies-local: the substrate (`ContentIndividual`, `SituationIndividual`)
+lives in `Semantics/Attitudes/ClauseDenotation/`. -/
 inductive NominalSort where
-  /-- Content nouns: *claim*, *belief*, *rumor*, *idea*, *thought*,
-      *hypothesis*, non-eventive *fact*. -/
+  /-- Content nouns (§2.2): *idea*, *rumor*, *hypothesis*, *claim*, *fact*,
+      *lie*. -/
   | content
-  /-- Situation nouns: *situation*, *case*, *circumstance*, *event*,
-      eventive uses of *fact*. -/
+  /-- Situation nouns (§2.2): *situation*, *event*, *case*, *circumstance*,
+      *state of affairs*. -/
   | situation
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════════════════
--- § 2. Equality vs. Subset vs. Existential Semantics
--- ════════════════════════════════════════════════════════════════
---
--- Paper §1.1.1.2 states three candidate semantics for displacement
--- in attitude reports. The thesis argues for EQUALITY (paper eq. 7).
--- The substrate already exposes EQUALITY as `compC` and SUBSET as
--- `ContentIndividual.entails`; we DO NOT re-name them here (per
--- mathlib hygiene: thin aliases are bridge-lemma anti-pattern).
--- Only EXISTENTIAL is novel here — see `ExistentialContent` below.
+/-! ### Equality vs. subset vs. existential semantics
 
-/-- **Existential semantics** for Cont-CP (paper eq. 15).
-    `CONT(x) ∩ p ≠ ∅` — content of `x` is *compatible with* `p`.
+§1.1.1.2. The substrate exposes equality as `compC` and subset as
+`ContentIndividual.entails`; only the existential candidate is new here. -/
 
-    Distinct from `compC` (equality, paper eq. 7) and
-    `ContentIndividual.entails` (subset, paper eq. 10). The thesis
-    argues against this candidate (§1.1.1.2). -/
+/-- Existential semantics for a Cont-CP (eq. 15): `CONT(x) ∩ p ≠ ∅`. Rejected
+by the thesis in favor of equality (`compC`, eq. 7); subset is eq. 10. -/
 def ExistentialContent {W : Type*} (xc : ContentIndividual W)
     (p : W → Prop) : Prop :=
   ∃ w : W, xc.cont w ∧ p w
 
-/-- Equality (`compC`) is strictly stronger than subset
-    (`ContentIndividual.entails`) per paper §1.1.1.2. Re-export
-    of `ContentIndividual.eq_implies_entails` under the
-    paper-aligned name. -/
+/-- Equality is stronger than subset (§1.1.1.2); re-export of
+`ContentIndividual.eq_implies_entails`. -/
 theorem equality_implies_subset {W : Type*} (xc : ContentIndividual W)
     (p : W → Prop) : compC p xc → xc.entails p :=
   ContentIndividual.eq_implies_entails xc p
 
-/-- Equality (`compC`) implies existential, *provided* the content is
-    nonempty. The empty-content witness in `ContentIndividual` shows
-    this is a real proviso. -/
+/-- Equality implies existential for nonempty content; the empty-content
+witness in `ContentIndividual` shows the proviso is real. -/
 theorem equality_implies_existential {W : Type*}
     (xc : ContentIndividual W) (p : W → Prop)
     (hne : ∃ w, xc.cont w) :
@@ -163,36 +104,21 @@ theorem equality_implies_existential {W : Type*}
   obtain ⟨w, hw⟩ := hne
   exact ⟨w, hw, heq ▸ hw⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 3. CP Conjunction Impossibility ([bassi-bondarenko-2021])
--- ════════════════════════════════════════════════════════════════
---
--- Paper §1.1.1.2 argues the equality semantics predicts true CP
--- conjunction is impossible. Reasoning: if CONT is a function
--- (equality), then for any individual x, CONT(x) is a unique
--- proposition; CONT(x) = p1 AND CONT(x) = p2 forces p1 = p2.
+/-! ### CP conjunction impossibility
 
-/-- **Equality forces functionality**: if `x` has content `p1`
-    under equality semantics AND `x` has content `p2` under
-    equality semantics, then `p1 = p2`.
+Equality semantics makes CONT a function, so true CP conjunction is impossible
+([bassi-bondarenko-2021], §1.1.1.2). -/
 
-    [bassi-bondarenko-2021] derive the impossibility of true CP
-    conjunction from this functionality (paper §1.1.1.2). -/
+/-- Equality forces functionality: two contents assigned to the same
+individual coincide. -/
 theorem cont_function_blocks_conjunction {W : Type*}
     (xc : ContentIndividual W) (p1 p2 : W → Prop) :
     compC p1 xc → compC p2 xc → p1 = p2 := by
   intro h1 h2
   exact h1.symm.trans h2
 
-/-- Counterpart for subset semantics (`ContentIndividual.entails`):
-    subset does NOT force functionality. A *non-vacuous* content
-    individual can entail multiple distinct propositions (any
-    superset of the content) without being identified with them.
-
-    Witness: a content individual whose CONT holds at exactly
-    `{true}` (non-empty); it entails both `(· = true)` and
-    `(fun _ => True)` — these are distinct propositions yet
-    both satisfy subset semantics. -/
+/-- Subset does not force functionality: a non-vacuous content individual
+entails every superset of its content. Witness over `Bool`. -/
 theorem subset_does_not_force_functionality :
     ¬ ∀ (xc : ContentIndividual Bool) (p1 p2 : Bool → Prop),
       xc.entails p1 → xc.entails p2 → p1 = p2 := by
@@ -203,83 +129,34 @@ theorem subset_does_not_force_functionality :
   have h_p2 : xc.entails (fun _ => True) := fun _ _ => trivial
   have heq : (fun b : Bool => b = true) = (fun _ : Bool => True) :=
     h xc _ _ h_p1 h_p2
-  -- The propositions disagree at `false`: `false = true` is False,
-  -- but `(fun _ => True) false` is True.
+  -- The propositions disagree at `false`.
   exact (iff_of_eq (congr_fun heq false)).mpr trivial |> Bool.noConfusion
 
--- ════════════════════════════════════════════════════════════════
--- § 4. Sit-CP Transparency vs. Cont-CP Opacity
--- ════════════════════════════════════════════════════════════════
---
--- The central transparency-vs-opacity contrast (Russian and Korean
--- substitution-test data, paper Chapter 2 §2.2.3 ex. 120-122,
--- pp. 106-108; Chapter 1 ex. 5-6 is the brief-summary version).
---
--- The substitution test: under a Cont-NP like *slux* 'rumor',
--- (a) "Lena noticed a rumor that this woman arrived on a horse"
---   + (b) "this woman = the queen of Great Britain"
---   ⇏ (c) "Lena noticed a rumor that the queen arrived on a horse".
--- The DPs *this woman* and *the queen* are coextensional at the
--- evaluation world but the rumor's content may not connect the
--- two. Cont-CPs constitute a referentially opaque domain
--- ([barwise-1981], [higginbotham-1983]).
---
--- Under a Sit-NP like *slučaj* 'event', the same premises DO
--- entail the conclusion: all DPs inside the Sit-CP are evaluated
--- at the same world as the matrix verb.
---
--- **Two transparency notions**: STRONG transparency requires
--- coextensional-everywhere predicates to be substitutable; WEAK
--- transparency (`At`) only requires coextensionality at the
--- evaluation world. Strong transparency is trivial (it follows
--- from `funext` for any clause), so the substantive contrast is
--- in the WEAK form.
+/-! ### Sit-CP transparency vs. Cont-CP opacity
 
-/-- **Weak transparency** at evaluation world `s`: substitution
-    of predicates that agree AT s preserves clause truth. This is
-    the notion that distinguishes Sit-CPs (transparentAt) from
-    Cont-CPs (NOT transparentAt).
+The substitution test (§2.2.3 ex. 120-122; summarized at ch. 1 ex. 5-6):
+coextensional DPs substitute salva veritate under a Sit-NP but not under a
+Cont-NP — Cont-CPs are a referentially opaque domain ([barwise-1981],
+[higginbotham-1983]). Everywhere-coextensional transparency is
+`funext`-trivial; the substantive notion is transparency at the evaluation
+world. -/
 
-    The everywhere-quantified variant (`∀ s', p s' ↔ q s'`) is
-    `funext`+`propext`-trivial for any clause and carries no
-    empirical content; only `At` is the substantive notion. -/
+/-- Weak transparency at `s`: substituting predicates that agree at `s`
+preserves clause truth. -/
 def ReferentiallyTransparentAt {S : Type*}
     (clause : (S → Prop) → S → Prop) (s : S) : Prop :=
   ∀ p q : S → Prop, (p s ↔ q s) → (clause p s ↔ clause q s)
 
-/-- A Sit-CP (modeled as `fun p s' => p s'`) IS weak-transparent:
-    its evaluation is at the actual situation `s`, so
-    coextensional-at-s predicates yield the same value. -/
+/-- A Sit-CP evaluates at the actual situation, hence is weak-transparent. -/
 theorem sit_cp_transparentAt {S : Type*} (s : S) :
     ReferentiallyTransparentAt (fun p s' => p s') s := by
   intro p q hpq
   exact hpq
 
-/-- **`compC` is operator-level intensional** (NOT
-    weak-transparent): there exist two propositions `p, q`
-    coextensional at the evaluation world such that `compC p xc`
-    and `compC q xc` differ. Constructive witness via `W := Bool`:
-
-    * `xc.cont := (fun b => b = false)` (true only at `false`)
-    * `p := (fun b => b = false)` — agrees with `xc.cont`
-    * `q := (fun _ => True)` — disagrees at `b = true`
-
-    At evaluation world `false`, `p false ↔ q false` (both true);
-    but `compC p xc` HOLDS (= xc.cont) while `compC q xc` FAILS
-    (xc.cont differs from q at `true`).
-
-    **Caveat (per syntax expert):** this is the *propositional-
-    operator* shadow of Bondarenko's claim, not the full DP-level
-    de dicto reading. Bondarenko §2.2.3 ex. 120 is specifically
-    about substitution failure of two **DPs** (*this woman* /
-    *the queen*) coextensional at the evaluation world but
-    diverging across content-related worlds. The DP-level reading
-    requires a binding-theoretic encoding of de dicto vs de re
-    (an actuality-condition-style apparatus;
-    [elliott-2020-embedding]'s CONT-as-content-restrictor) that is NOT yet a linglib
-    substrate primitive. The theorem below establishes the
-    operator-level intensionality that *underwrites* the DP-level
-    de dicto reading; the DP-level theorem itself is queued. -/
+/-- `compC` is not weak-transparent (witness over `Bool`). This is the
+propositional-operator shadow of the §2.2.3 ex. 120 DP-level de dicto claim,
+whose binding-theoretic encoding ([elliott-2020-embedding]'s
+CONT-as-content-restrictor) is not yet substrate. -/
 theorem compC_not_transparentAt :
     ¬ ∀ (xc : ContentIndividual Bool) (w : Bool),
       ReferentiallyTransparentAt (fun p _ => compC p xc) w := by
@@ -295,29 +172,20 @@ theorem compC_not_transparentAt :
   have hp : compC p xc := rfl
   have hq : ¬ compC q xc := by
     intro heq
-    -- xc.cont and q differ at b = true: xc.cont true = (true = false) = False
-    -- but q true = True. Use congrFun + Bool.noConfusion.
+    -- xc.cont and q differ at `b = true`.
     have h_true : (fun b : Bool => b = false) true = (fun _ : Bool => True) true :=
       congrFun heq true
-    -- LHS reduces to `True = False` after rewriting `true = false ↔ False`.
     exact Bool.noConfusion <| (iff_of_eq h_true).mpr trivial
   exact hq (h_eq.mp hp)
 
--- ════════════════════════════════════════════════════════════════
--- § 5. Transparent Syntax-Semantics Mapping Thesis
--- ════════════════════════════════════════════════════════════════
---
--- Paper §1.1.2: only certain (CP-meaning, composition-path) pairs
--- are attested. The thesis argues this follows from a TIGHT
--- correlation between syntactic structure and integration path:
--- bare CPs MUST compose as modifiers (PM via the situation
--- argument); nominalized CPs MUST compose as arguments (FA via
--- the DP argument).
---
--- This is the thesis [angelopoulos-2026] §7.3 attacks.
+/-! ### The transparent syntax-semantics mapping thesis
+
+§1.1.2: bare CPs must compose as modifiers (PM via the situation argument),
+nominalized CPs as arguments (FA via the DP argument). [angelopoulos-2026]
+§7.3 attacks this thesis. -/
 
 /-- The four logically possible (clause shape, composition path)
-    combinations. -/
+combinations. -/
 inductive ClauseStructurePath where
   /-- Bare CP composing via Predicate Modification (modifier path). -/
   | bareModifier
@@ -329,198 +197,116 @@ inductive ClauseStructurePath where
   | nominalizedArgument
   deriving DecidableEq, Repr
 
-/-- Bondarenko's transparent Syntax-Semantics mapping thesis
-    (paper §1.1.2 + ch. 4): a bare CP composes ONLY via the
-    modifier path (PM via the situation argument); a nominalized
-    CP composes ONLY via the argument path (FA via the DP argument).
-
-    The two off-diagonal cells (bareArgument, nominalizedModifier)
-    are predicted impossible by this thesis.
-
-    [angelopoulos-2026] attacks the bareArgument cell with
-    Greek *oti*/*pu*: bare clauses pattern as internal arguments
-    (clitic doubling, passivization, extraction transparency)
-    while still composing via PM (the *explanans* reading).
-
-    **Caveat (mathlib audit).** This `def`-as-table encoding is the
-    paper-fidelity stub form — it lossily compresses Bondarenko's
-    distinction between *situation-argument* and *DP-argument*
-    composition paths into a single `bareArgument` cell. A
-    genuinely structural derivation would replace this with a
-    predicate `composes : ClauseShape → ArgumentSlot → Prop`
-    defined over actual derivations and prove the four-cell
-    pattern from a deeper claim (e.g., that bare CPs lack the
-    nominal projection required to saturate a DP argument slot).
-    The current encoding is honest as a paper-fidelity tag but
-    should not be mistaken for a derivation. TODO: structural
-    refactor when a `composes` predicate over `SyntacticObject`
-    derivations is available.  -/
+/-- The mapping thesis as a four-cell table (§1.1.2, ch. 4): the off-diagonal
+cells are impossible. Paper-fidelity bookkeeping —
+`transparentSSMapping_iff_typed` derives the cells from the type-theoretic
+apparatus; [angelopoulos-2026] attacks the `bareArgument` cell with Greek
+*oti*/*pu*. -/
 def transparentSSMapping : ClauseStructurePath → Prop
   | .bareModifier => True
   | .bareArgument => False
   | .nominalizedModifier => False
   | .nominalizedArgument => True
 
-/-- Bondarenko predicts the (bare, argument) cell is empty. This
-    is the EXACT cell [angelopoulos-2026] attacks. The proof
-    is by table-unfolding; the substantive refutation lives in
-    `Angelopoulos2026`. -/
+/-- The (bare, argument) cell is empty — the cell [angelopoulos-2026] attacks
+(see `Angelopoulos2026`). -/
 theorem bare_argument_predicted_impossible :
     ¬ transparentSSMapping .bareArgument := by
   intro h; exact h
 
-/-- Bondarenko predicts the (nominalized, modifier) cell is empty. -/
+/-- The (nominalized, modifier) cell is empty. -/
 theorem nominalized_modifier_predicted_impossible :
     ¬ transparentSSMapping .nominalizedModifier := by
   intro h; exact h
 
-/-- The diagonal cells are predicted available. -/
+/-- The diagonal cells are available. -/
 theorem diagonal_attested :
     transparentSSMapping .bareModifier ∧
     transparentSSMapping .nominalizedArgument :=
   ⟨trivial, trivial⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 6. Path-of-Composition Restriction (Table 1.1)
--- ════════════════════════════════════════════════════════════════
+/-! ### Composition paths (Table 1.1) -/
 
-/-- The two composition paths Bondarenko distinguishes (paper §1.1.2,
-    Table 1.1): clauses can either modify a verbal situation argument
-    by Predicate Modification (`viaSituation`) or saturate a DP
-    argument slot by Functional Application (`viaDPArgument`). -/
+/-- Table 1.1's two composition paths: PM with the verb's situation argument,
+or FA into a DP argument slot. -/
 inductive CompositionPath where
   | viaSituation
   | viaDPArgument
   deriving DecidableEq, Repr
 
-/-- Paper Table 1.1: combinations of CP meanings × composition paths.
-    Three of four cells are attested; the (Sit-CP, viaSituation)
-    cell is unattested by semantic triviality (a Sit-CP composing
-    intersectively with the situation argument always yields a
-    trivially false statement, as a situation cannot be both a
-    minimal exemplar of φ and the verb's situation argument). -/
+/-- Table 1.1 (attitude and speech verbs; occurrence verbs are exempt,
+§4.3.3): the (Sit-CP, `viaSituation`) cell is unattested — intersective
+combination yields always-trivially-false sentences. -/
 def attestedCombination : NominalSort → CompositionPath → Prop
   | .content, _              => True   -- Cont-CP via either path
   | .situation, .viaDPArgument => True -- Sit-CP via DP-argument path
   | .situation, .viaSituation  => False -- Sit-CP via Situation path: ✗
 
 /-- The (Sit-CP, viaSituation) cell is empty by semantic triviality
-    (paper §1.1.2). -/
+(§1.1.2). -/
 theorem sit_cp_via_situation_blocked :
     ¬ attestedCombination .situation .viaSituation := by
   intro h; exact h
 
--- ════════════════════════════════════════════════════════════════
--- § 7. Bridge to BondarenkoElliott2026
--- ════════════════════════════════════════════════════════════════
---
--- The mereological monotonicity apparatus in
--- `Studies/BondarenkoElliott2026.lean` (MSI,
--- MSO, TECM) presupposes the equality semantics defended here.
--- This bridge is informational; no formal dependency to chase.
+/-! ### Bridge to BondarenkoElliott2026 -/
 
-/-- Bondarenko & Elliott 2026 inherit the **equality** semantics
-    from this dissertation. The substantive bridge requires
-    referencing a specific equality-using definition from
-    `Studies/BondarenkoElliott2026.lean`
-    (their `MSI`/`MSO`/`TECM` apparatus presupposes `CONT(x) = ⟦S⟧`
-    rather than `CONT(x) ⊆ ⟦S⟧`). The full bridge is queued: this
-    file does not yet import BE2026, and the cross-file `Iff`
-    target needs to be a specific BE2026 lemma rather than the
-    `compC` substrate primitive. TODO: add bridge once BE2026
-    exposes a stable `equalityForm` lemma. -/
+/-- Bondarenko & Elliott 2026's MSI/MSO/TECM apparatus presupposes the
+equality semantics `CONT(x) = ⟦S⟧` defended here; the cross-file bridge awaits
+a stable BE2026 lemma (this file does not import BE2026). -/
 theorem be2026_inherits_equality_substrate {W : Type*}
     (xc : ContentIndividual W) (p : W → Prop) :
     compC p xc ↔ xc.cont = p := Iff.rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 8. Chapter 4: Type-theoretic apparatus (§4.2)
--- ════════════════════════════════════════════════════════════════
---
--- Per the syntax expert audit, Bondarenko's derivation of "bare CPs
--- cannot be Causer/Theme/About" is **type-theoretic**, not structural.
--- The mechanism:
---
---    bare CP     : type ⟨e,t⟩  (predicate over situations)
---    nominalized : type ⟨e⟩    (saturated DP)
---    Θ-heads     : require ⟨e⟩ argument
---    therefore   : only nominalized CP can saturate Θ
---
--- The N/D presence in nominalized CPs is the morphological *exponence*
--- of the type-shift, not the cause. The four-cell table at §5
--- (`transparentSSMapping`) is **derived** below from this type
--- mechanism via §11 — see `transparentSSMapping_iff_typed`.
---
--- Critical framing caveat (syntax expert S2): Bondarenko works in
--- Bare Phrase Structure where the X-bar argument/modifier distinction
--- is gone. The "modifier" claim is **semantic** (type incompatibility),
--- not structural. The §5 enum `ClauseStructurePath` (bareModifier vs
--- nominalizedArgument etc.) is paper-fidelity bookkeeping; the BPS-
--- compatible claim is the type-theoretic predicate.
+/-! ### Type-theoretic apparatus (§4.2)
 
-/-- Semantic types relevant for Bondarenko's type-mismatch derivation.
-    The two-element enum reflects only the cells the chapter exploits:
-    `individual` (saturated entity, type ⟨e⟩) and `predicate`
-    (unsaturated, type ⟨e,t⟩). Finer type-theoretic distinctions
-    (intensional types ⟨s,e⟩, generalized quantifiers ⟨⟨e,t⟩,t⟩, etc.)
-    are out of scope for this Studies file. -/
+The §4.4 bans are type-theoretic, not structural: bare CPs are ⟨e,t⟩,
+nominalized CPs ⟨e⟩, Θ-heads require ⟨e⟩; N/D presence is the exponence of the
+type-shift, not its cause. In Bare Phrase Structure the X-bar
+argument/modifier distinction is gone, so the "modifier" claim is semantic. -/
+
+/-- The two semantic types the derivation uses: saturated ⟨e⟩ vs unsaturated
+⟨e,t⟩. -/
 inductive SemType where
   | individual
   | predicate
   deriving DecidableEq, Repr
 
-/-- Embedded clause types per Bondarenko §4.2 (the bare-vs-nominalized
-    cut). Names emphasize the *semantic content* (predicate of
-    individuals vs predicate of situations) rather than the
-    morphological exponence (bare vs nominalized) — this is the BPS-
-    compatible framing. -/
+/-- The bare-vs-nominalized cut (§4.2), named by semantic content per Bare
+Phrase Structure. -/
 inductive ClauseType where
-  /-- Nominalized CP: type ⟨e⟩, refers to an individual (typically
-      with propositional content via CONT). Buryat participial
-      nominalization — with or without the say-root *gɘ*
-      ([bondarenko-2022] §4.3.1 ex. 31–32); Korean *-nun + kes*
+  /-- Nominalized CP: type ⟨e⟩. Buryat participial nominalization, with or
+      without the say-root *gɘ* (§4.3.1 ex. 31–32); Korean *-nun + kes*
       clause. -/
   | predicateOfIndividuals
-  /-- Bare CP: type ⟨e,t⟩, predicate over (minimal) situations.
-      Buryat *gɘžɘ*-clause; Korean *-ta* declarative; Russian
-      bare *čto*-clause. -/
+  /-- Bare CP: type ⟨e,t⟩, predicate over (minimal) situations. Buryat
+      *gɘžɘ*-clause; Korean *-ko*-clause; Russian bare *čto*-clause. -/
   | predicateOfSituations
   deriving DecidableEq, Repr
 
-/-- The semantic type of an embedded clause: nominalized → individual,
-    bare → predicate. This is the type-theoretic content the chapter
-    exploits. -/
+/-- Nominalized → individual, bare → predicate. -/
 def ClauseType.semanticType : ClauseType → SemType
   | .predicateOfIndividuals => .individual
   | .predicateOfSituations  => .predicate
 
-/-- Θ-heads relevant to Bondarenko §4.4. Per syntax expert S3, these
-    are NOT three independent stipulations — they share the
-    selectional restriction "requires individual argument." Per-Θ
-    presupposition flavor (Θ_About has pre-existence; §4.4.3) is
-    deferred to a future scope. -/
+/-- The Θ-heads of §4.4, all sharing one selectional restriction: an
+individual argument. Per-Θ presupposition flavor is deferred. -/
 inductive ThetaHead where
-  /-- Θ_Causer (Pylkkänen / Cuervo). §4.4.1. -/
+  /-- Θ_Causer. §4.4.1. -/
   | causer
-  /-- Θ_Theme (broad, internal-argument introducer). §4.4.2. -/
+  /-- Θ_Theme (internal-argument introducer). §4.4.2. -/
   | theme
-  /-- Θ_About (Bondarenko's own innovation, Pylkkänen-style refinement;
-      carries pre-existence presupposition not formalised here). §4.4.3. -/
+  /-- Θ_About: introduces the res-argument the attitude is about
+      ([quine-1956]; [cresswell-vonstechow-1982]); carries a pre-existence
+      presupposition not formalised here. §4.4.3. -/
   | aboutAttitude
   deriving DecidableEq, Repr
 
-/-- Every Θ-head requires an individual argument (type ⟨e⟩). This is
-    the central claim that drives the bare-vs-nominalized derivation;
-    it does NOT vary by Θ-head, despite per-Θ presupposition variation
-    (§4.4.3 Θ_About pre-existence). -/
+/-- Every Θ-head requires an individual argument. -/
 def ThetaHead.requiredType : ThetaHead → SemType
   | _ => .individual
 
-/-- A clause type **saturates** a Θ-head iff its semantic type
-    matches the head's required type. Per Bondarenko §4.2, this is
-    the central type-mismatch derivation. NOT a stipulation: the
-    `Prop` is just type-equality on the projection through
-    `semanticType` / `requiredType`. -/
+/-- A clause type saturates a Θ-head iff its semantic type matches the head's
+required type (§4.2). -/
 def saturatesTheta (ct : ClauseType) (θ : ThetaHead) : Prop :=
   ct.semanticType = θ.requiredType
 
@@ -528,78 +314,46 @@ instance : ∀ (ct : ClauseType) (θ : ThetaHead),
     Decidable (saturatesTheta ct θ) := fun ct θ => by
   unfold saturatesTheta; infer_instance
 
--- ════════════════════════════════════════════════════════════════
--- § 9. Causer / Theme / About derivations (§4.4.1-3)
--- ════════════════════════════════════════════════════════════════
---
--- Per syntax expert S3: the three negative claims (Causer / Theme /
--- About-cannot-be-bare) reduce to ONE mechanism. Each is one line
--- after the type-mismatch substrate above.
+/-! ### Causer, Theme, About (§4.4)
 
-/-- **Bondarenko §4.4.1**: Bare CPs cannot be Causers. Derived from
-    type-mismatch: bare CP delivers `.predicate`; Θ_Causer requires
-    `.individual`. -/
+The three bans are one type-mismatch mechanism, not three stipulations. -/
+
+/-- §4.4.1: bare CPs cannot be Causers. -/
 theorem bareCP_not_Causer :
     ¬ saturatesTheta .predicateOfSituations .causer := by
   intro h; exact SemType.noConfusion h
 
-/-- **Bondarenko §4.4.2**: Bare CPs cannot be Theme-arguments. Same
-    mechanism as Causer. The *explain*-class data
-    ([halpert-schueler-2013], [elliott-2016],
-    [roelofsen-uegaki-2021], [pietroski-2000]) is what makes
-    this derivation tight: when *explain* takes a bare clause vs a
-    nominalized clause, only the latter receives the Theme reading. -/
+/-- §4.4.2: bare CPs cannot be Theme-arguments; cf. the *explain*-class data
+([pietroski-2000], [halpert-schueler-2013], [elliott-2016],
+[roelofsen-uegaki-2021]). -/
 theorem bareCP_not_Theme :
     ¬ saturatesTheta .predicateOfSituations .theme := by
   intro h; exact SemType.noConfusion h
 
-/-- **Bondarenko §4.4.3**: Bare CPs cannot be About-arguments. Same
-    type-mismatch; per Bondarenko this Θ-head additionally introduces
-    a pre-existence presupposition (deferred). -/
+/-- §4.4.3: bare CPs cannot be About-arguments. -/
 theorem bareCP_not_About :
     ¬ saturatesTheta .predicateOfSituations .aboutAttitude := by
   intro h; exact SemType.noConfusion h
 
-/-- The unified Bondarenko §4.4 result: bare CPs satisfy NO Θ-head.
-    This is the single mechanism behind §4.4.1, §4.4.2, §4.4.3 — not
-    three independent stipulations (per syntax expert S3). -/
+/-- Bare CPs satisfy no Θ-head (§4.4). -/
 theorem bareCP_satisfies_no_theta :
     ∀ θ : ThetaHead, ¬ saturatesTheta .predicateOfSituations θ := by
   intro θ h; exact SemType.noConfusion h
 
-/-- Conversely, nominalized CPs satisfy every Θ-head (modulo per-Θ
-    presupposition flavor not formalized here). -/
+/-- Nominalized CPs satisfy every Θ-head. -/
 theorem nominalizedCP_satisfies_every_theta :
     ∀ θ : ThetaHead, saturatesTheta .predicateOfIndividuals θ := by
   intro θ; rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 10. Modifier path (§4.5): bare CPs as situation-modifiers
--- ════════════════════════════════════════════════════════════════
---
--- Per Layered Grounding obligation (cross-framework auditor):
--- consume `Modifier.intersective` (the intersective-modification
--- substrate) — DO NOT redefine PM here. The
--- substrate operates over `Frame.Denot (.e ⇒ .t)` typed-semantics
--- predicates; this Studies file states only the abstract
--- compositional fact (bare CP composes via PM with v's situation
--- argument). The Frame-typed instantiation is queued for when the
--- compositional layer of Bondarenko's analysis is formalised in
--- detail.
---
--- Critical framing caveat (syntax expert S2): Bondarenko's "modifier"
--- claim is SEMANTIC (type compatibility for PM), NOT structural
--- ("adjunct" in the X-bar sense). BPS does not have the X-bar
--- argument/modifier distinction. This file's `composesViaPM` predicate
--- tracks the SEMANTIC claim.
+/-! ### The modifier path (§4.5)
 
-/-- A clause can compose via Predicate Modification with a verbal
-    situation argument iff it has predicate type (⟨s,t⟩ after lifting
-    the individual variable in Bondarenko's lift; substantively, both
-    arguments are situation-predicates and intersect by PM). The
-    `Modifier.intersective` substrate at
-    `Semantics/Modification/Basic.lean` is the typed realisation; this
-    Studies-level predicate is its qualitative projection. -/
+Bare CPs compose with the verb's situation argument by Predicate Modification;
+`composesViaPM` is the qualitative projection of the `Modifier.intersective`
+substrate (`Semantics/Modification/Basic.lean`), whose Frame-typed
+instantiation is queued. -/
+
+/-- PM-compatibility with a verbal situation argument: bare CPs qualify,
+nominalized CPs do not. -/
 def composesViaPM : ClauseType → Prop
   | .predicateOfIndividuals => False  -- nominalised, no PM compatibility
   | .predicateOfSituations  => True   -- bare, PM-compatible
@@ -607,37 +361,24 @@ def composesViaPM : ClauseType → Prop
 instance : ∀ ct, Decidable (composesViaPM ct) := fun ct => by
   cases ct <;> (unfold composesViaPM; infer_instance)
 
-/-- **Bondarenko §4.5**: bare CPs are verbal modifiers. Stated as
-    PM-compatibility, derived from the type. -/
+/-- §4.5: bare CPs are verbal modifiers. -/
 theorem bareCP_composes_via_PM : composesViaPM .predicateOfSituations := trivial
 
-/-- Nominalized CPs are NOT modifiers via PM (Bondarenko §4.5
-    contrapositive — they compose via FA through the DP path). -/
+/-- Nominalized CPs compose via FA, not PM (§4.5). -/
 theorem nominalizedCP_not_PM_modifier : ¬ composesViaPM .predicateOfIndividuals :=
   fun h => h
 
--- ════════════════════════════════════════════════════════════════
--- § 11. Refactor: derive `transparentSSMapping` from §§ 8-10
--- ════════════════════════════════════════════════════════════════
---
--- Per mathlib audit critical caveat: the type-theoretic refactor is
--- only substantive if it actually replaces the def-as-table form
--- with a derivation. The four cells of the original §5 table
--- become projections of the type-mismatch + PM-compatibility
--- predicates above.
+/-! ### Deriving the mapping table -/
 
-/-- The cell value of the original `transparentSSMapping` table at
-    a given path, **derived** from the type-theoretic predicates. -/
+/-- The table's cell values, derived from the type-theoretic predicates. -/
 def transparentSSMappingDerived : ClauseStructurePath → Prop
   | .bareModifier         => composesViaPM .predicateOfSituations
   | .bareArgument         => ∃ θ, saturatesTheta .predicateOfSituations θ
   | .nominalizedModifier  => composesViaPM .predicateOfIndividuals
   | .nominalizedArgument  => ∃ θ, saturatesTheta .predicateOfIndividuals θ
 
-/-- The original `transparentSSMapping` (§5, def-as-table) **agrees**
-    with the type-theoretic derivation cell-by-cell. This is the
-    bridge mathlib audit demanded: the four-cell pattern is now
-    derived rather than stipulated. -/
+/-- The §1.1.2 table agrees cell-by-cell with the type-theoretic derivation:
+the four-cell pattern is derived, not stipulated. -/
 theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
     transparentSSMapping path ↔ transparentSSMappingDerived path := by
   cases path
@@ -654,26 +395,20 @@ theorem transparentSSMapping_iff_typed (path : ClauseStructurePath) :
     refine ⟨fun _ => ⟨.causer, nominalizedCP_satisfies_every_theta _⟩,
             fun _ => trivial⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 12. Cross-linguistic ContP exponence
--- ════════════════════════════════════════════════════════════════
---
--- Per-language Cont-exponence analyses under [bondarenko-2022],
--- bundled with the laws tying them to the fragment inventories —
--- construction obligations discharged by `decide`, RingHom-style.
--- Buryat additionally carries the licenser-conditioned Comp
--- allomorphy (§4.3.1 ex. 33); the dissertation gives no such rule
--- for Korean, so its witness stays at `ContAnalysis`.
--- [cacchioli-2025]'s Tigrinya extension lives in
--- `Studies/Cacchioli2025.lean` per the chronology rule.
+/-! ### Cross-linguistic ContP exponence
+
+Per-language Cont-exponence analyses (ch. 4), tied by law to the fragment
+inventories. Buryat carries the licenser-conditioned Comp allomorphy (§4.3.1
+ex. 33); Korean's parallel rule (§4.3.2 ex. 46) is not yet law-checked, so its
+witness stays at `ContAnalysis`. [cacchioli-2025]'s Tigrinya extension lives
+in `Studies/Cacchioli2025.lean` per the chronology rule. -/
 
 open Buryat
 
-/-- A Cont-exponence analysis of one language's clause-typing
-    inventory ([bondarenko-2022] ch. 4): which morpheme, if any,
-    overtly expones Cont, tied by law to the fragment inventory
-    (`none` = null exponence: English, Russian). A structure, not a
-    class — rival frameworks construct rival witnesses. -/
+/-- A Cont-exponence analysis of one language's clause-typing inventory
+(ch. 4): the morpheme, if any, overtly exponing Cont (`none` = null exponence:
+English, Russian). A structure, not a class — rival frameworks construct
+rival witnesses. -/
 structure ContAnalysis where
   /-- The fragment inventory analyzed. -/
   inventory : List Complementizer
@@ -683,7 +418,7 @@ structure ContAnalysis where
   contExponent_mem : ∀ c ∈ contExponent, c ∈ inventory
 
 /-- A full Cont/Comp head assignment: `ContAnalysis` plus the
-    licenser-conditioned Comp allomorphy and its laws. -/
+licenser-conditioned Comp allomorphy and its laws. -/
 structure ContCompAnalysis extends ContAnalysis where
   /-- Comp allomorph selected by the licensing category. -/
   compAllomorph : Complementizer.Licenser → Complementizer
@@ -695,8 +430,8 @@ structure ContCompAnalysis extends ContAnalysis where
   cover : ∀ c ∈ inventory, c ∈ contExponent ∨ ∃ l, compAllomorph l = c
 
 /-- Buryat (§4.3.1 ex. 33): *gɘ* expones Cont; the suffixes are Comp
-    allomorphs — participial *-Aːša* next to nominal projections,
-    converbial *-žA* next to verbs. -/
+allomorphs — participial *-Aːša* next to nominal projections, converbial
+*-žA* next to verbs. -/
 def buryatAnalysis : ContCompAnalysis where
   inventory := complementizers
   contExponent := some ge
@@ -717,28 +452,25 @@ def buryatAnalysis : ContCompAnalysis where
     · exact Or.inr ⟨.nominal, rfl⟩
     · exact Or.inr ⟨.verbal, rfl⟩
 
-/-- Korean (§4.3.2, following [bogal-allbritten-moulton-2018]): *-ta*
-    expones Cont. No Comp allomorphy rule is given for Korean, so the
-    witness stays at `ContAnalysis`. -/
+/-- Korean (§4.3.2 ex. 46; cf. [bogal-allbritten-moulton-2018]): *-ta*
+expones Cont. The fragment records a licenser only for *-nun*, so the
+Comp-allomorphy laws are not yet checkable. -/
 def koreanAnalysis : ContAnalysis where
   inventory := Korean.Complementizers.complementizers
   contExponent := some Korean.Complementizers.ta
   contExponent_mem := fun _ hc => by cases hc; exact .head _
 
-/-- Buryat-specific alignment, NOT a `ContAnalysis` law — Korean's
-    Cont exponent *-ta* is itself a suffix (`verbForm = some .Fin`):
-    in Buryat, the Cont exponent is exactly the non-suffixal
-    say-root. -/
+/-- In Buryat the Cont exponent is exactly the non-suffixal say-root — a
+Buryat-specific alignment, not a `ContAnalysis` law (Korean's *-ta* is itself
+a suffix). -/
 theorem mem_buryatContExponent_iff :
     ∀ c ∈ complementizers,
       (c ∈ buryatAnalysis.contExponent ↔ c.verbForm = none) := by
   decide
 
-/-- Positive-consistency check on the selection relation: each of
-    *hanaxa*'s two frames (§4.4.3) is realized by exactly one member
-    of the inventory — the bare-CP frame by converbial *-žA*, the
-    nominalized frame by participial *-Aːša* — while the say-root *gɘ*
-    (no `noonanType` of its own) realizes neither. -/
+/-- Each of *hanaxa*'s two frames (§4.4.3) is realized by exactly one
+clause-typer — bare by converbial *-žA*, nominalized by participial *-Aːša* —
+and the say-root *gɘ* realizes neither. -/
 theorem hanaxa_frames_realized :
     hanaxa.realizes zha ∧
     hanaxa.realizes aasha ∧
@@ -746,29 +478,14 @@ theorem hanaxa_frames_realized :
   ⟨⟨.finiteClause, .head _, rfl⟩, ⟨.gerund, .tail _ (.head _), rfl⟩,
     fun ⟨_, hf, h⟩ => by fin_cases hf <;> exact nomatch h⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 13. Chapter 2 §2.2.3: noun-predicate co-occurrence diagnostics
--- ════════════════════════════════════════════════════════════════
---
--- The chapter-2 substantive distinct-denotation argument relies on
--- two empirical predicate-class co-occurrence asymmetries
--- (§2.2.3 ex. 105-112, pp. 102-105):
---
---   - Cont-NPs combine with truth-evaluable predicates ('true',
---     'false', 'mistaken'); Sit-NPs do NOT (paper ex. 105-107).
---   - Sit-NPs combine with occurrence/happening predicates
---     (Russian *proizojti* / *slučitsja* 'occur/happen'; Korean
---     *ilena* 'occur'); Cont-NPs do NOT (paper ex. 108-112).
---
--- These are not three independent stipulations but reflect the
--- type-theoretic distinction encoded in `NominalSort`: content
--- individuals carry propositional content (and so can be
--- truth-evaluated); situations are points of evaluation (and so
--- can occur/happen but lack truth values). The two predicates
--- below project the asymmetry from the sort.
+/-! ### Noun-predicate co-occurrence (§2.2.3)
 
-/-- A nominal sort is *truth-evaluable* iff it can combine with
-    'true' / 'false' / 'mistaken' — paper §2.2.3 ex. 105-107. -/
+Cont-NPs combine with truth-evaluable predicates, Sit-NPs do not
+(ex. 105-107); Sit-NPs combine with occurrence predicates, Cont-NPs do not
+(ex. 108-112). Both asymmetries project the `NominalSort` distinction:
+contents are truth-evaluated, situations occur. -/
+
+/-- Combines with 'true' / 'false' / 'mistaken' (ex. 105-107). -/
 def NominalSort.truthEvaluable : NominalSort → Prop
   | .content   => True
   | .situation => False
@@ -777,12 +494,9 @@ instance : DecidablePred NominalSort.truthEvaluable
   | .content   => isTrue trivial
   | .situation => isFalse id
 
-/-- A nominal sort is *occurrence-compatible* iff it can combine
-    with 'occur' / 'happen' (Russian *proizojti*, *slučitsja*;
-    Korean *ilena*) — paper §2.2.3 ex. 108-112. The footnote-28
-    consultant comment ("*alachay* just does not sound good with
-    'claim'") is a weaker rejection than False; the binary
-    encoding here aggregates with the main paradigm. -/
+/-- Combines with 'occur' / 'happen' (Russian *proizojti*, *slučit'sja*;
+Korean *ilena*) — ex. 108-112. The footnote-28 hedge on *alachay* is
+aggregated with the main paradigm. -/
 def NominalSort.occurrenceCompatible : NominalSort → Prop
   | .content   => False
   | .situation => True
@@ -791,82 +505,31 @@ instance : DecidablePred NominalSort.occurrenceCompatible
   | .content   => isFalse id
   | .situation => isTrue trivial
 
--- The truth/occurrence partition is by-construction true (each is
--- a 2-cell `match`; the conjunction unfolds to four `rfl`s). The
--- substantive content lives in the projection definitions above,
--- not in a partition theorem; the audit-flagged
--- `truth_vs_occurrence_partition` rewrap was deleted as a vacuous
--- def-as-table tautology (mathlib + integration audit, Phase 3
--- re-audit).
+/-! ### Cont and Comp head denotations (§2.3)
 
--- ════════════════════════════════════════════════════════════════
--- § 14. Chapter 2 §2.3 Proposal: Cont and Comp head denotations
--- ════════════════════════════════════════════════════════════════
---
--- [bondarenko-2022] §2.3 ex. 150 proposes the Cont head
--- denotation; ex. 151 proposes the Comp head denotation. Both are
--- formalised below by consuming existing substrate (Layered
--- Grounding obligation per cross-framework audit).
---
--- **Cont head** (ex. 150): ⟦Cont⟧^{s,g,t} = λp_{st}.λx_e. CONT(x) = p
--- — IS the existing `compC` from
--- `Semantics/Attitudes/ClauseDenotation/Content.lean`.
---
--- **Comp head** (ex. 151): ⟦Comp⟧^{s,g,t} = λp_{et}.λx_e. x ⊑ s ∧ x ⊩_e p
--- — `x ⊑ s` is situation parthood (`Semantics/Intensional/
--- Situations.lean` `≼` / mathlib `≤`); `x ⊩_e p` is exact
--- exemplification (the bare verifier-membership `p x`,
--- distinguished from inexact exemplification `Truthmaker/Inexact.
--- lean inexactVer` which existentially closes over parts).
---
--- **Substantiation status (per syntax expert S6).** The
--- *justification* for the equality shape of Cont (vs subset
--- `entails` or existential) lives partly in §3 above
--- (`cont_function_blocks_conjunction` — [bassi-bondarenko-2021]
--- argument) and partly in [bondarenko-2022] §2.4 (deferred:
--- the nominal-CP-interpretation argument). One of three §2.4
--- arguments is therefore already present in this file.
---
--- **Note (per syntax expert S3).** The situation-parameter `s` in
--- ex. 150 is omitted in this Chapter-2 reduction; [bondarenko-2022]
--- footnote 37 anticipates it becoming consequential in §5.2.3
--- (clauses as restrictors of existential quantifiers). When
--- Chapter 5 is formalised, the parameter must be re-introduced.
+Ex. 150: ⟦Cont⟧ = λp.λx. CONT(x) = p — exactly the substrate `compC`.
+Ex. 151: ⟦Comp⟧ = λp.λx. x ⊑ s ∧ x ⊩ p — parthood plus exact exemplification.
+The dissertation's own abbreviation of ex. 151 drops the anchoring conjunct;
+its footnote 37 notes the anchoring matters in §5.2.3 (clauses as restrictors
+of existential quantifiers). `compHead` keeps it. -/
 
-/-- [bondarenko-2022] §2.3 ex. 150 Cont head denotation IS
-    the existing `compC` substrate. The denotational identity is
-    one-line — the substantive Layered-Grounding fact is that
-    Bondarenko's Chapter-2 proposal does NOT introduce new
-    machinery; it instantiates the Kratzer/Moulton CONT-equality
-    apparatus already in linglib. -/
+/-- Ex. 150 is the existing `compC` — the ch. 2 proposal introduces no new
+machinery. The equality shape is further defended in §2.4 (no-stacking,
+ex. 171; *the fact* definiteness, ex. 177-178; the complex-claim argument,
+ex. 183-184), unformalized. -/
 theorem cont_head_denotation_is_compC {W : Type*}
     (p : W → Prop) (xc : ContentIndividual W) :
     compC p xc ↔ (xc.cont = p) := Iff.rfl
 
-/-- [bondarenko-2022] §2.3 ex. 151 Comp head denotation,
-    consuming the Truthmaker substrate
-    (`Semantics/Truthmaker/Basic.lean` `attHolds`-style
-    parthood `s ≤ σ x`, `Semantics/Truthmaker/Inexact.lean`
-    `inexactVer` for the part-existential variant) and situation
-    parthood (`Semantics/Intensional/Situations.lean` `≼`).
-
-    `compHead p x evalSit` holds iff `x` is a situation that is
-    part of the evaluation situation AND `x` exactly verifies `p`
-    (verifier-membership; distinguished from inexact exemplification
-    where existential closure over parts is allowed).
-
-    Type signature follows Bondarenko's `⟨e,t⟩` shape with `S` as
-    the situation-typed-individual sort: `p : S → Prop` is the
-    propositional argument, `x : S` is the candidate verifier,
-    `evalSit : S` is the evaluation situation. -/
+/-- Ex. 151: `x` is part of the evaluation situation and exactly verifies `p`
+(verifier-membership, vs the part-existential `inexactVer` of
+`Semantics/Truthmaker/Inexact.lean`). -/
 def compHead {S : Type*} [Preorder S]
     (p : S → Prop) (x evalSit : S) : Prop :=
   x ≤ evalSit ∧ p x
 
-/-- Exact exemplification implies inexact exemplification (a
-    verifier is a part of itself). Substrate connection to
-    `Semantics/Truthmaker/Inexact.lean`'s
-    `inexactVer_of_exact`. -/
+/-- Exact exemplification implies inexact: a verifier is a part of itself
+(cf. `inexactVer_of_exact`). -/
 theorem compHead_implies_inexactVerifier {S : Type*} [Preorder S]
     (p : S → Prop) (x evalSit : S) (h : compHead p x evalSit) :
     ∃ u, u ≤ evalSit ∧ p u :=

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -2,6 +2,7 @@ import Linglib.Semantics.Attitudes.ClauseDenotation.Content
 import Linglib.Semantics.Attitudes.ClauseDenotation.Situation
 import Linglib.Fragments.Buryat.Complementizers
 import Linglib.Fragments.Korean.Complementizers
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Bondarenko 2022: Anatomy of an Attitude [bondarenko-2022]
@@ -730,6 +731,19 @@ theorem mem_buryatContExponent_iff :
     ∀ c ∈ Buryat.complementizers,
       (c ∈ buryatAnalysis.contExponent ↔ c.verbForm = none) := by
   decide
+
+open Clause.Complementation (realizes) in
+/-- Positive-consistency check on the selection relation: each of
+    *hanaxa*'s two frames (§4.4.3) is realized by exactly one member
+    of the inventory — the bare-CP frame by converbial *-žA*, the
+    nominalized frame by participial *-Aːša* — while the say-root *gɘ*
+    (no `noonanType` of its own) realizes neither. -/
+theorem hanaxa_frames_realized :
+    realizes Buryat.hanaxa Buryat.zha ∧
+    realizes Buryat.hanaxa Buryat.aasha ∧
+    ¬ realizes Buryat.hanaxa Buryat.ge :=
+  ⟨⟨.finiteClause, .head _, rfl⟩, ⟨.gerund, .tail _ (.head _), rfl⟩,
+    fun ⟨_, hf, h⟩ => by fin_cases hf <;> exact nomatch h⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13. Chapter 2 §2.2.3: noun-predicate co-occurrence diagnostics

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -732,16 +732,15 @@ theorem mem_buryatContExponent_iff :
       (c ∈ buryatAnalysis.contExponent ↔ c.verbForm = none) := by
   decide
 
-open Clause.Complementation (realizes) in
 /-- Positive-consistency check on the selection relation: each of
     *hanaxa*'s two frames (§4.4.3) is realized by exactly one member
     of the inventory — the bare-CP frame by converbial *-žA*, the
     nominalized frame by participial *-Aːša* — while the say-root *gɘ*
     (no `noonanType` of its own) realizes neither. -/
 theorem hanaxa_frames_realized :
-    realizes Buryat.hanaxa Buryat.zha ∧
-    realizes Buryat.hanaxa Buryat.aasha ∧
-    ¬ realizes Buryat.hanaxa Buryat.ge :=
+    Buryat.hanaxa.realizes Buryat.zha ∧
+    Buryat.hanaxa.realizes Buryat.aasha ∧
+    ¬ Buryat.hanaxa.realizes Buryat.ge :=
   ⟨⟨.finiteClause, .head _, rfl⟩, ⟨.gerund, .tail _ (.head _), rfl⟩,
     fun ⟨_, hf, h⟩ => by fin_cases hf <;> exact nomatch h⟩
 

--- a/Linglib/Studies/Noonan2007.lean
+++ b/Linglib/Studies/Noonan2007.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.Complementation.Noonan2007
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Syntax.Minimalist.LeftPeriphery
 import Linglib.Semantics.Mood.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
@@ -34,7 +35,8 @@ Five bridges connecting CTPClass to existing infrastructure:
 1. CTPClass ↔ VerbEntry (Verbal.lean) — derive CTP class from verb features
 2. CTPClass ↔ SelectionClass (LeftPeriphery.lean) — map CTP to question embedding
 3. CTPClass ↔ MoodSelector (Mood/Basic.lean) — map CTP to mood selection
-4. ComplementType ↔ NoonanCompType — map English-specific to typological categories
+4. ComplementType ↔ NoonanCompType — via the substrate adapter
+   `ComplementType.toNoonan` (`Syntax/Clause/Complementation.lean`)
 5. VerbEntry → MoodSelector — derive mood selection from verb features
 
 -/
@@ -352,27 +354,17 @@ theorem irrealis_not_indicative :
 -- ============================================================================
 
 /-! ## D1. Map linglib's English-specific complement types to Noonan's
-typological categories -/
+typological categories
 
-/-- Map English fragment complement types to Noonan's universal categories.
-    Returns `none` for types that don't correspond to a clausal complement. -/
-def englishToNoonan : ComplementType → Option NoonanCompType
-  | .finiteClause => some .indicative
-  | .infinitival => some .infinitive
-  | .gerund => some .nominalized
-  | .smallClause => some .paratactic
-  | .none => none           -- Not complement-taking
-  | .np => none             -- NP complement, not clausal
-  | .np_np => none          -- Ditransitive, not clausal
-  | .np_pp => none          -- NP+PP, not clausal
-  | .question => some .indicative  -- Embedded questions are finite in English
+The adapter itself is substrate: `ComplementType.toNoonan` in
+`Syntax/Clause/Complementation.lean`. The clausal-coverage check stays here. -/
 
 /-- Every English verb that takes a clausal complement maps to a Noonan type. -/
 theorem clausal_complements_have_noonan_type :
-    englishToNoonan .finiteClause ≠ none ∧
-    englishToNoonan .infinitival ≠ none ∧
-    englishToNoonan .gerund ≠ none ∧
-    englishToNoonan .smallClause ≠ none := by decide
+    ComplementType.toNoonan .finiteClause ≠ none ∧
+    ComplementType.toNoonan .infinitival ≠ none ∧
+    ComplementType.toNoonan .gerund ≠ none ∧
+    ComplementType.toNoonan .smallClause ≠ none := by decide
 
 -- ============================================================================
 -- E. Gap fix: VerbEntry → MoodSelector (derived function)

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -2,123 +2,95 @@ import Linglib.Semantics.Verb.Defs
 import Linglib.Syntax.Complementizer.Basic
 
 /-!
-# Clause complementation: complement-clause surface typology
+# Clause complementation: surface typology and selection
 
-[deal-2026]
+[deal-2026] [noonan-2007]
 
 [deal-2026]'s notional-complement surface structures and CP external-shell
-inventory. Graduated from the dissolved `Typology/` drawer; the unconsumed
-WALS subordination + Cristofaro complementation typology (and its
-`native_decide` distribution theorems) was dropped.
-
-[noonan-2007]'s complement-clause types and complement-taking-predicate
-classification (`NoonanCompType`, `CTPClass`, `RealityStatus`,
-`ctpRealityStatus`) live in `Features/Complementation.lean`; the generated
-CTP sample rows live in `Data/Complementation/`.
+inventory, plus the [noonan-2007]-anchored selection relation between verb
+frames and clause-typers.
 
 ## Main definitions
 
-* `ComplementClauseStructure` — surface complement-clause structure ([deal-2026]).
-* `CPShell` / `CPShellInventory` / `isAttestedShell` — CP external-shell cartography ([deal-2026]).
-* `ComplementType.toNoonan` / `Verb.frames` / `Verb.realizes` — [noonan-2007]-anchored
-  selection relation between a verb's complement frames and clause-typers.
+- `ComplementClauseStructure` — surface complement-clause shapes
+- `CPShell`, `CPShellInventory`, `isAttestedShell` — CP external shells
+  ([deal-2026] Table 79)
+- `ComplementType.toNoonan`, `Verb.frames`, `Verb.realizes` — the
+  selection relation
+
+## Implementation notes
+
+[noonan-2007]'s enums (`NoonanCompType`, `CTPClass`, `RealityStatus`) live
+in `Features/Complementation.lean`; the generated CTP sample rows in
+`Data/Complementation/`. Placement of individual languages in Table 79
+cells consumes Fragment data and lives in `Studies/Deal2026.lean`;
+consistency checks on the selection relation live in Studies
+(e.g. `Bondarenko2022.hanaxa_frames_realized`). Shell implicational
+generalisations ("P-shelling co-occurs with D-shelling") are proven on the
+named witnesses; the universal claims stay in Table 79 commentary.
 -/
 
 namespace Clause.Complementation
 
--- ============================================================================
--- Notional-Complement Surface Structure ([deal-2026])
--- ============================================================================
-
 /-! ### Theory-neutral surface enum
 
-Following the cross-framework reconciler discipline, `ComplementClauseStructure`
-describes the *surface pattern* a notional complement clause realises, without
-committing to one framework's internal analysis. Each Theory projects its native
-account into this enum: HPSG always projects `headExternalModifier` for true
-RCs; Minimalist (with [deal-2026]) projects `abarInternalCP` for Nez Perce
-relative-embeddings (REs) and `barePropositionalCP` for English `that`-clauses.
--/
+`ComplementClauseStructure` records the *surface pattern* a notional
+complement clause realises, without committing to a framework's internal
+analysis; each Theory projects its native account into it (HPSG projects
+`headExternalModifier` for true RCs; Minimalist with [deal-2026] projects
+`abarInternalCP` for Nez Perce REs, `barePropositionalCP` for English
+*that*-clauses). -/
 
-/-- Surface-pattern enumeration of notional-complement-clause shapes attested
-    cross-linguistically.
-
-    [deal-2026]'s typology dissolves the Kayne/Arsenij\'evi\'c ([kayne-2008],
-    [kayne-2014], [arsenijevic-2009]) universalist claim that all
-    clausal complementation is relativization. The *surface* options are
-    independent of any one framework's commitments about underlying structure.
-
-    The Kayne/Arsenij\'evi\'c universalist hypothesis is now a single decidable
-    statement: `∀ c : ComplementClauseStructure, c = .abarInternalCP`. Deal 2026
-    refutes it by exhibiting `.barePropositionalCP` as an attested cell
-    (Nez Perce simplex embeddings and English *think*-complementation). -/
+/-- Surface shapes of notional complement clauses. [deal-2026]'s typology
+refutes the Kayne/Arsenijević universalist claim ([kayne-2008],
+[kayne-2014], [arsenijevic-2009]) — now the single decidable statement
+`∀ c : ComplementClauseStructure, c = .abarInternalCP` — by exhibiting
+`.barePropositionalCP` as attested. -/
 inductive ComplementClauseStructure where
-  /-- CP with internal Ā-dependency from a high functional projection above TP.
-      Nez Perce REs ([deal-2026]), Adyghe REs ([caponigro-polinsky-2011]),
-      Bulgarian REs ([krapova-2010]). -/
+  /-- CP with internal Ā-dependency above TP: Nez Perce REs ([deal-2026]),
+      Adyghe ([caponigro-polinsky-2011]), Bulgarian ([krapova-2010]). -/
   | abarInternalCP
-  /-- Bare CP with no internal Ā-dependency. Nez Perce simplex embeddings and
+  /-- Bare CP, no internal Ā-dependency: Nez Perce simplex embeddings,
       English *think*-complementation ([deal-2026]). -/
   | barePropositionalCP
-  /-- CP wrapped in a nominal projection (D, possibly with N). Washo factive
-      complementation ([hanink-bochnak-2017], [bochnak-hanink-2021]),
-      Ndebele ([pietraszko-2019], with additional P shell). -/
+  /-- CP wrapped in a nominal projection: Washo factives
+      ([hanink-bochnak-2017], [bochnak-hanink-2021]), Ndebele
+      ([pietraszko-2019]). -/
   | nominalization
-  /-- True relative clause: an adjunct modifier of a head noun. The pattern
-      that Kayne/Arsenij\'evi\'c claim subsumes all others. -/
+  /-- True relative clause: adjunct modifier of a head noun — the pattern
+      Kayne/Arsenijević claim subsumes all others. -/
   | headExternalModifier
   /-- Internally-headed relative clause (Bambara, Navajo). -/
   | headInternalRelative
-  /-- High adjunct, not complementation at all. Amahuaca attitude reports
-      ([deal-2026] §3, citing Clem 2022 — needs separate bib entry). -/
+  /-- High adjunct, not complementation: Amahuaca attitude reports
+      ([deal-2026] §3). -/
   | adjunct
   deriving DecidableEq, Repr
 
--- ============================================================================
--- CP External Shell Inventory ([deal-2026] Table 79)
--- ============================================================================
-
 /-! ### CP-external wrapping shells
 
-Where `ComplementSize` and `ClauseSpine` (Syntax/Minimalist/) record
-*internal* clause height (vP/TP/CP/NmlzP), `CPShell` records what wraps the CP
-*externally*. Deal 2026's Table 79 cross-classifies the two axes; this file
-houses the external axis as Fragment-importable substrate.
+`ComplementSize` and `ClauseSpine` (Syntax/Minimalist/) record *internal*
+clause height; `CPShell` records what wraps the CP *externally*.
+[deal-2026] Table 79 cross-classifies the two axes. -/
 
-Anchored to [deal-2026] Table 79; placement of individual languages in
-Table 79 cells consumes per-language Fragment data and lives in
-`Studies/Deal2026.lean`. -/
-
-/-- A wrapping head category that may appear above a CP in a notional complement.
-    [deal-2026] Table 79 attests three: D (Washo, Adyghe), N (Adyghe),
-    P (Bulgarian, Ndebele). C is included as the base case to give a uniform
-    representation of `bareCP` as `[.C]`. -/
+/-- A wrapping head above a CP: [deal-2026] Table 79 attests D, N, and P;
+`c` is the base case, so `bareCP = [.c]`. -/
 inductive CPShell where
   /-- The CP itself (always present). -/
   | c
-  /-- D shell (determiner wrapping CP). -/
+  /-- D shell. -/
   | d
-  /-- N shell (nominal head between D and CP). -/
+  /-- N shell (between D and CP). -/
   | n
-  /-- P shell (preposition wrapping the CP-headed argument). -/
+  /-- P shell. -/
   | p
   deriving DecidableEq, Repr
 
-/-- An ordered shell list, innermost first.
-
-    Convention: head element is the C of the CP itself; subsequent elements
-    are progressively more peripheral wrappers. So `[.c, .d]` = `dCP` (D wraps
-    CP), `[.c, .n, .d]` = `dnCP` (D wraps N wraps CP), `[.c, .d, .p]` = `pdCP`
-    (P wraps D wraps CP). -/
+/-- An ordered shell list, innermost first: `[.c, .d]` = D wraps CP,
+`[.c, .n, .d]` = D wraps N wraps CP. -/
 abbrev CPShellInventory := List CPShell
 
-/-- Predicate: this shell inventory is attested in [deal-2026] Table 79.
-
-    Six attested shapes (one per cell), four shell-shapes:
-    - `[.c]`        = `bareCP` (V CP row)
-    - `[.c, .d]`    = `dCP`    (V D CP — Washo per [bochnak-hanink-2021])
-    - `[.c, .n, .d]` = `dnCP`  (V D N CP row — Adyghe)
-    - `[.c, .d, .p]` = `pdCP`  (V P D CP row — Bulgarian, Ndebele) -/
+/-- The shell inventory is a [deal-2026] Table 79 cell. -/
 def isAttestedShell : CPShellInventory → Bool
   | [.c] => true
   | [.c, .d] => true
@@ -126,83 +98,66 @@ def isAttestedShell : CPShellInventory → Bool
   | [.c, .d, .p] => true
   | _ => false
 
-/-- The bare-CP cell (Nez Perce REs and simplex; English *think*). -/
+/-- The bare-CP cell (Nez Perce; English *think*). -/
 def bareCP : CPShellInventory := [.c]
 
-/-- The V D CP cell (Washo per [bochnak-hanink-2021]). -/
+/-- The V D CP cell (Washo, [bochnak-hanink-2021]). -/
 def dCP : CPShellInventory := [.c, .d]
 
-/-- The V D N CP cell (Adyghe REs per [caponigro-polinsky-2011]). -/
+/-- The V D N CP cell (Adyghe, [caponigro-polinsky-2011]). -/
 def dnCP : CPShellInventory := [.c, .n, .d]
 
-/-- The V P D CP cell (Bulgarian REs per [krapova-2010];
-    Ndebele per [pietraszko-2019]). -/
+/-- The V P D CP cell (Bulgarian, [krapova-2010]; Ndebele,
+[pietraszko-2019]). -/
 def pdCP : CPShellInventory := [.c, .d, .p]
 
-/-! ### Concrete facts on the named witnesses
-
-The full implicational generalisations ("every attested inventory containing P
-also contains D") are folklore from inspection of the four named cells. We
-prove the consumed facts directly on the named shells; the universal claim is
-tracked in [deal-2026] Table 79 commentary, not as a Lean theorem
-(general `List.Mem` reasoning over `CPShellInventory` would be substantial
-boilerplate without proportionate payoff). -/
-
-/-- The four named witnesses are all attested (Deal 2026 Table 79). -/
+/-- The four named witnesses are all attested. -/
 theorem named_shells_attested :
     isAttestedShell bareCP = true ∧
     isAttestedShell dCP = true ∧
     isAttestedShell dnCP = true ∧
-    isAttestedShell pdCP = true := by
-  refine ⟨rfl, rfl, rfl, rfl⟩
+    isAttestedShell pdCP = true :=
+  ⟨rfl, rfl, rfl, rfl⟩
 
-/-- The pdCP cell contains both P and D — the empirical generalisation that
-    P-shelling co-occurs with D-shelling. -/
+/-- P-shelling co-occurs with D-shelling. -/
 theorem pdCP_contains_p_and_d : CPShell.p ∈ pdCP ∧ CPShell.d ∈ pdCP := by
-  refine ⟨?_, ?_⟩ <;> decide
+  decide
 
-/-- The dnCP cell contains both N and D — N appears only inside a D shell. -/
+/-- N appears only inside a D shell. -/
 theorem dnCP_contains_n_and_d : CPShell.n ∈ dnCP ∧ CPShell.d ∈ dnCP := by
-  refine ⟨?_, ?_⟩ <;> decide
+  decide
 
-/-- Every named shell contains C (the CP itself). -/
+/-- Every named shell contains C. -/
 theorem named_shells_contain_c :
     CPShell.c ∈ bareCP ∧ CPShell.c ∈ dCP ∧
     CPShell.c ∈ dnCP ∧ CPShell.c ∈ pdCP := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
+  decide
 
-/-- An unattested example: `V P CP` (P with no D shell) — [deal-2026]
-    Table 79 has no such cell. -/
+/-- `V P CP` (P with no D shell) is not a Table 79 cell. -/
 theorem pCP_not_attested : isAttestedShell [.c, .p] = false := rfl
 
-/-- Another unattested example: `V N CP` (N with no D shell). -/
+/-- `V N CP` (N with no D shell) is not a Table 79 cell. -/
 theorem nCP_not_attested : isAttestedShell [.c, .n] = false := rfl
 
 /-! ### Selection
 
-The [noonan-2007]-anchored selection relation between a verb's complement
-frames and a language's clause-typing morphemes: `ComplementType.toNoonan`
-maps fragment complement frames to Noonan's typological categories, and
-`realizes` matches a frame against a `Complementizer.noonanType`.
-Consistency checks on fragment inventories live in Studies
-(e.g. `Studies/Bondarenko2022.lean`). -/
+The [noonan-2007]-anchored relation between a verb's complement frames
+and a language's clause-typing morphemes. -/
 
-/-- Map English fragment complement types to [noonan-2007]'s universal
-    categories. Returns `none` for types that don't correspond to a
-    clausal complement. -/
+/-- The [noonan-2007] category of a complement frame; `none` for
+non-clausal frames. -/
 def _root_.ComplementType.toNoonan : ComplementType → Option NoonanCompType
   | .finiteClause => some .indicative
   | .infinitival => some .infinitive
   | .gerund => some .nominalized
   | .smallClause => some .paratactic
-  | .none => none           -- Not complement-taking
-  | .np => none             -- NP complement, not clausal
-  | .np_np => none          -- Ditransitive, not clausal
-  | .np_pp => none          -- NP+PP, not clausal
-  | .question => some .indicative  -- Embedded questions are finite in English
+  | .none => none
+  | .np => none
+  | .np_np => none
+  | .np_pp => none
+  | .question => some .indicative
 
-/-- A verb's complement frames: the main frame plus the alternate frame,
-    when present. -/
+/-- A verb's complement frames: main plus alternate, when present. -/
 def _root_.Verb.frames (v : Verb) : List ComplementType :=
   v.complementType :: v.altComplementType.toList
 

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -1,3 +1,6 @@
+import Linglib.Semantics.Verb.Defs
+import Linglib.Syntax.Complementizer.Basic
+
 /-!
 # Clause complementation: complement-clause surface typology
 
@@ -17,6 +20,8 @@ CTP sample rows live in `Data/Complementation/`.
 
 * `ComplementClauseStructure` — surface complement-clause structure ([deal-2026]).
 * `CPShell` / `CPShellInventory` / `isAttestedShell` — CP external-shell cartography ([deal-2026]).
+* `ComplementType.toNoonan` / `Verb.frames` / `realizes` — [noonan-2007]-anchored
+  selection relation between a verb's complement frames and clause-typers.
 -/
 
 namespace Clause.Complementation
@@ -172,5 +177,37 @@ theorem pCP_not_attested : isAttestedShell [.c, .p] = false := rfl
 
 /-- Another unattested example: `V N CP` (N with no D shell). -/
 theorem nCP_not_attested : isAttestedShell [.c, .n] = false := rfl
+
+/-! ### Selection
+
+The [noonan-2007]-anchored selection relation between a verb's complement
+frames and a language's clause-typing morphemes: `ComplementType.toNoonan`
+maps fragment complement frames to Noonan's typological categories, and
+`realizes` matches a frame against a `Complementizer.noonanType`.
+Consistency checks on fragment inventories live in Studies
+(e.g. `Studies/Bondarenko2022.lean`). -/
+
+/-- Map English fragment complement types to [noonan-2007]'s universal
+    categories. Returns `none` for types that don't correspond to a
+    clausal complement. -/
+def _root_.ComplementType.toNoonan : ComplementType → Option NoonanCompType
+  | .finiteClause => some .indicative
+  | .infinitival => some .infinitive
+  | .gerund => some .nominalized
+  | .smallClause => some .paratactic
+  | .none => none           -- Not complement-taking
+  | .np => none             -- NP complement, not clausal
+  | .np_np => none          -- Ditransitive, not clausal
+  | .np_pp => none          -- NP+PP, not clausal
+  | .question => some .indicative  -- Embedded questions are finite in English
+
+/-- A verb's complement frames: the main frame plus the alternate frame,
+    when present. -/
+def _root_.Verb.frames (v : Verb) : List ComplementType :=
+  v.complementType :: v.altComplementType.toList
+
+/-- `v`'s frame `f` is realized by clause-typer `c` ([noonan-2007]). -/
+def realizes (v : Verb) (c : Complementizer) : Prop :=
+  ∃ f ∈ v.frames, f.toNoonan = c.noonanType
 
 end Clause.Complementation

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -20,7 +20,7 @@ CTP sample rows live in `Data/Complementation/`.
 
 * `ComplementClauseStructure` — surface complement-clause structure ([deal-2026]).
 * `CPShell` / `CPShellInventory` / `isAttestedShell` — CP external-shell cartography ([deal-2026]).
-* `ComplementType.toNoonan` / `Verb.frames` / `realizes` — [noonan-2007]-anchored
+* `ComplementType.toNoonan` / `Verb.frames` / `Verb.realizes` — [noonan-2007]-anchored
   selection relation between a verb's complement frames and clause-typers.
 -/
 
@@ -207,7 +207,7 @@ def _root_.Verb.frames (v : Verb) : List ComplementType :=
   v.complementType :: v.altComplementType.toList
 
 /-- `v`'s frame `f` is realized by clause-typer `c` ([noonan-2007]). -/
-def realizes (v : Verb) (c : Complementizer) : Prop :=
+def _root_.Verb.realizes (v : Verb) (c : Complementizer) : Prop :=
   ∃ f ∈ v.frames, f.toNoonan = c.noonanType
 
 end Clause.Complementation

--- a/Linglib/Syntax/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Complementizer/Basic.lean
@@ -26,8 +26,9 @@ grammaticalized say-roots like Buryat *gɘ* and Uyghur *de*.
 
 Framework-specific head assignments (a cartographic Force/Fin split, a
 ContP-exponence claim, an [n]-feature) are not fields; they live as
-Studies-local projections over these entries (cf. `Adjective`'s
-deferred degree semantics). Field conventions:
+Studies-local projections over these entries, and the schema carries no
+denotation (cf. `Adjective`'s deferred degree semantics). Field
+conventions:
 
 - `position = none`: unrecorded, or a bound root with no fixed
   attachment of its own (Buryat *gɘ* surfaces only suffixed).
@@ -51,9 +52,7 @@ inductive Complementizer.Licenser where
   | verbal
   deriving DecidableEq, Fintype, Repr
 
-/-- The general complementizer object: the morphosyntactic core shared
-by clause-typing morphemes. Carries no denotation and no framework's
-head assignment (cf. `Pronoun`, `Adjective`). -/
+/-- A complementizer: surface form plus the consensus clause-typing axes. -/
 structure Complementizer where
   /-- Surface form (romanization; affixes hyphenated). -/
   form : String

--- a/Linglib/Syntax/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Complementizer/Basic.lean
@@ -9,86 +9,83 @@ import Linglib.Morphology.Word
 
 The lexical core of the complementizer (clause-typing morpheme) as a
 grammatical object, modeled on `Syntax/Pronoun/`: surface form plus the
-consensus clause-typing axes, each drawn from existing substrate —
-morphological attachment (`Morphology.FormativePosition`), the
-[noonan-2007] type of the clause it types, its `Features.ClauseForm`,
-the verb form an affixal clause-typer derives on its host (UD), the
-licensing host category, and factivity.
-
-Framework-specific head assignments (a cartographic Force/Fin split, a
-ContP-exponence claim, an [n]-feature) are not fields; they live as
-Studies-local projections over these entries (cf. `Adjective`'s deferred
-degree semantics).
+consensus clause-typing axes, each drawn from existing substrate.
+Per-language fragments instantiate it — free subordinators like *that*
+and *oti*, affixal clause-typers like Buryat *-žA* and Tigrinya *zɨ-*,
+grammaticalized say-roots like Buryat *gɘ* and Uyghur *de*.
 
 ## Main declarations
 
-- `Complementizer` — the general complementizer object; per-language
-  fragments instantiate it (free subordinators like *that* and *oti*,
-  affixal clause-typers like Buryat *-žA* and Tigrinya *zɨ-*,
-  grammaticalized say-roots like Buryat *gɘ*)
+- `Complementizer` — the general complementizer object
 - `Complementizer.Licenser` — adnominal vs adverbal licensing category
 - `Complementizer.IsBound` — affixal status, derived from `position`
 - `Complementizer.toWord` — the `SCONJ` word a free complementizer
   projects
+
+## Implementation notes
+
+Framework-specific head assignments (a cartographic Force/Fin split, a
+ContP-exponence claim, an [n]-feature) are not fields; they live as
+Studies-local projections over these entries (cf. `Adjective`'s
+deferred degree semantics). Field conventions:
+
+- `position = none`: unrecorded, or a bound root with no fixed
+  attachment of its own (Buryat *gɘ* surfaces only suffixed).
+- `clauseForm`: only `.declarative` and `.embeddedQuestion` are
+  sensible values for an embedded-clause typer.
+- `licenser` names the licensing projection, not the morphological
+  host stem (which for a postfixed clause-typer is the verb it
+  attaches to).
+- `agrees`: φ-agreement with a clause-internal argument (Tigrinya
+  *kɨ-* and *ʔay-…-n*; West Germanic complementizer agreement).
+- `factive` records only a lexical factive presupposition carried by
+  the morpheme itself (Greek *pu*, Tigrinya *kəmzi-*); leave `none`
+  when factivity tracks the verb or the construction — derived in
+  Studies, never stored.
 -/
 
-/-- Category of the adjacent projection an affixal clause-typer is
-licensed by: adnominal (Buryat *-Aːša*, Korean *-nun*) vs adverbal
-(Buryat *-žA*). Named for the licensing projection, not the
-morphological host stem (which for a postfixed clause-typer is the
-verb it attaches to). -/
+/-- Category of the adjacent projection licensing an affixal
+clause-typer: adnominal (Buryat *-Aːša*) vs adverbal (Buryat *-žA*). -/
 inductive Complementizer.Licenser where
   | nominal
   | verbal
   deriving DecidableEq, Fintype, Repr
 
-/-- The general complementizer object: the morphosyntactic core shared by
-clause-typing morphemes. Carries no denotation and no framework's head
-assignment (cf. `Pronoun`, `Adjective`). -/
+/-- The general complementizer object: the morphosyntactic core shared
+by clause-typing morphemes. Carries no denotation and no framework's
+head assignment (cf. `Pronoun`, `Adjective`). -/
 structure Complementizer where
   /-- Surface form (romanization; affixes hyphenated). -/
   form : String
   /-- Native script form, when distinct. -/
   script : Option String := none
-  /-- Morphological attachment: `.detached` for free subordinators,
-  `.praefixed` and `.postfixed` for affixal clause-typers. `none` =
-  unrecorded, or a bound root with no fixed attachment of its own
-  (Buryat *gɘ*, which surfaces only suffixed). -/
+  /-- Morphological attachment. -/
   position : Option Morphology.FormativePosition := none
-  /-- [noonan-2007] type of the complement clause this morpheme types. -/
+  /-- [noonan-2007] type of the clause this morpheme types. -/
   noonanType : Option NoonanCompType := none
-  /-- Surface clause form typed. Only `.declarative` and
-  `.embeddedQuestion` are sensible values for an embedded-clause typer. -/
+  /-- Surface clause form typed. -/
   clauseForm : Option Features.ClauseForm := none
-  /-- Verb form an affixal clause-typer derives on its host (UD `.Part`,
-  `.Conv`, `.Fin`, …). -/
+  /-- Verb form derived on the host (UD). -/
   verbForm : Option UD.VerbForm := none
-  /-- Category of the adjacent licensing projection, for
-  adjacency-conditioned clause-typers. -/
+  /-- Category of the adjacent licensing projection. -/
   licenser : Option Complementizer.Licenser := none
-  /-- Does the morpheme carry φ-agreement with an argument of its clause?
-  (Tigrinya *kɨ-* and *ʔay-…-n* take agreement suffixes; West Germanic
-  complementizer agreement.) `none` = unrecorded. -/
+  /-- Carries φ-agreement with a clause-internal argument? -/
   agrees : Option Bool := none
-  /-- Lexical factive presupposition conventionally carried by the
-  morpheme itself (Greek *pu*, Tigrinya *kəmzi-*). Leave `none` when
-  factivity tracks the verb or the construction (Buryat, Washo) —
-  construction-level factivity is derived in Studies, never stored. -/
+  /-- Lexical factive presupposition. -/
   factive : Option Bool := none
   deriving Repr, BEq, DecidableEq
 
 namespace Complementizer
 
-/-- Bound (affixal) complementizer: recorded attachment other than
-`.detached`. Derived, not stored (cf. `Adjective.IsGradable`). -/
+/-- Bound (affixal): recorded attachment other than `.detached`. -/
 def IsBound (c : Complementizer) : Prop :=
   c.position ≠ none ∧ c.position ≠ some .detached
 
 instance : DecidablePred IsBound := fun c => by
   unfold IsBound; infer_instance
 
-/-- Free complementizers project a `SCONJ` word (cf. `Pronoun.toWord`);
-affixal clause-typers project no word of their own. -/
+/-- The `SCONJ` word a free complementizer projects; `none` for
+affixal clause-typers. -/
 def toWord (c : Complementizer) : Option Word :=
   if c.position = some .detached then
     some { form := c.form, cat := .SCONJ }


### PR DESCRIPTION
Completes the selection-interface piece of the complementizer arc.

- `ComplementType.toNoonan` graduated out of Studies/Noonan2007 (bridge 4) into `Syntax/Clause/Complementation.lean` — second consumer bar met (Noonan2007 + Bondarenko2022); `Verb.frames` and the Noonan-anchored `realizes` relation land beside it. No theorems in the theory file.
- `Studies/Bondarenko2022.lean`: `hanaxa_frames_realized` — the positive-consistency theorem tying the loop (fragment verb → selection relation → complementizer entries): the finite-CP frame is realized by *-žA*, the nominalized frame by *-Aːša*, and no frame by the say-root *gɘ*. Proven with explicit witnesses.
- `Syntax/Complementizer/Basic.lean`: field docstrings tersened to the mathlib register (one-liners; caveats consolidated under Implementation notes).