### PR TITLE
feat(Studies/Bondarenko2022): Korean ContCompAnalysis via ex. 46 allomorphy

### DIFF
--- a/Linglib/Fragments/Korean/Complementizers.lean
+++ b/Linglib/Fragments/Korean/Complementizers.lean
@@ -75,11 +75,14 @@ def nun : Complementizer where
   verbForm := some .Part
   licenser := some .nominal
 
-/-- *-ko* — connective / quotative complementizer. -/
+/-- *-ko* — connective / quotative complementizer; verb-adjacent Comp
+    allomorph, paired with adnominal *-nun* (§4.3.2 ex. 46 of
+    [bondarenko-2022]). -/
 def ko : Complementizer where
   form := "-ko"
   position := some .postfixed
   verbForm := some .Conv
+  licenser := some .verbal
 
 /-- The clause-typing inventory. -/
 def complementizers : List Complementizer := [ta, nun, ko]

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -453,12 +453,27 @@ def buryatAnalysis : ContCompAnalysis where
     · exact Or.inr ⟨.verbal, rfl⟩
 
 /-- Korean (§4.3.2 ex. 46; cf. [bogal-allbritten-moulton-2018]): *-ta*
-expones Cont. The fragment records a licenser only for *-nun*, so the
-Comp-allomorphy laws are not yet checkable. -/
-def koreanAnalysis : ContAnalysis where
+expones Cont; adnominal *-nun* and adverbal *-ko* are the Comp
+allomorphs, parallel to Buryat ex. 33. -/
+def koreanAnalysis : ContCompAnalysis where
   inventory := Korean.Complementizers.complementizers
   contExponent := some Korean.Complementizers.ta
   contExponent_mem := fun _ hc => by cases hc; exact .head _
+  compAllomorph
+    | .nominal => Korean.Complementizers.nun
+    | .verbal  => Korean.Complementizers.ko
+  compAllomorph_mem := by
+    intro l
+    cases l
+    · exact .tail _ (.head _)
+    · exact .tail _ (.tail _ (.head _))
+  licenser_compAllomorph := by intro l; cases l <;> rfl
+  cover := by
+    intro c hc
+    fin_cases hc
+    · exact Or.inl rfl
+    · exact Or.inr ⟨.nominal, rfl⟩
+    · exact Or.inr ⟨.verbal, rfl⟩
 
 /-- In Buryat the Cont exponent is exactly the non-suffixal say-root — a
 Buryat-specific alignment, not a `ContAnalysis` law (Korean's *-ta* is itself


### PR DESCRIPTION
The dissertation-verification pass found §4.3.2 ex. 46 gives Korean the same Comp-allomorphy rule as Buryat's ex. 33 (-nun /_N, -ko /_V). This records the missing fragment datum (`ko.licenser := some .verbal`) and upgrades `koreanAnalysis` from `ContAnalysis` to the full `ContCompAnalysis` — all four law obligations discharged, parallel to `buryatAnalysis`.