### PR TITLE
refactor(Syntax/Clause): dissolve ComplementClauseStructure into axes

### DIFF
--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -59,7 +59,7 @@ functional projection above TP*. Three primary conclusions:
 
 [kayne-2008], [kayne-2014], [arsenijevic-2009]: universalist
 position (all complementation = relativization). Deal 2026 §7 refutes by
-exhibiting `barePropositionalCP` cells.
+exhibiting bare-CP cells with no internal Ā-dependency.
 
 [decuba-2017]: opposing position — complement clauses are *never*
 relatives. Compatible with Deal 2026 for English simplex; incompatible
@@ -173,65 +173,31 @@ theorem table79_membership :
        ("Adyghe",    "RE"), ("Bulgarian", "RE"),
        ("Ndebele",   "embedding"), ("Washo", "factive")] := by decide
 
-/-- Project a `NotionalComplementShape` onto the theory-neutral
-    `ComplementClauseStructure` enum from `Typology/Complementation.lean`.
-    The mapping is determined by the internal Ā-flag and the external shell:
-    bare CP + Ā = `abarInternalCP`; bare CP without Ā = `barePropositionalCP`;
-    any non-bare external shell = `nominalization` (subsumes V D CP, V D N CP,
-    V P D CP — they differ only in the depth of the nominal/prepositional
-    wrapper, not in the surface phenomenon being a nominalization). -/
-def NotionalComplementShape.surfacePattern (s : NotionalComplementShape) :
-    ComplementClauseStructure :=
-  if s.external = bareCP then
-    if s.hasInternalAbar then .abarInternalCP else .barePropositionalCP
-  else
-    .nominalization
-
-/-- A Table79 cell's surface pattern, derived from its shape. -/
-def Table79Cell.surfacePattern (c : Table79Cell) : ComplementClauseStructure :=
-  c.shape.surfacePattern
-
-/-- Nez Perce REs project as `abarInternalCP` (bare CP + Ā). -/
-theorem nezPerceRE_surface :
-    nezPerceREShape.surfacePattern = .abarInternalCP := rfl
-
-/-- Nez Perce simplex (and English *think*) project as `barePropositionalCP`. -/
-theorem nezPerceSimplex_surface :
-    nezPerceSimplexShape.surfacePattern = .barePropositionalCP := rfl
-
-/-- Adyghe REs project as `nominalization` (V D N CP). -/
-theorem adygheRE_surface :
-    adygheREShape.surfacePattern = .nominalization := rfl
-
-/-- Bulgarian REs project as `nominalization` (V P D CP). -/
-theorem bulgarianRE_surface :
-    bulgarianREShape.surfacePattern = .nominalization := rfl
-
-/-- Ndebele embedding projects as `nominalization` (V P D CP). -/
-theorem ndebele_surface :
-    ndebeleShape.surfacePattern = .nominalization := rfl
-
-/-- Washo factive embedding projects as `nominalization` (V D CP, no Ā). -/
-theorem washo_surface :
-    washoShape.surfacePattern = .nominalization := rfl
-
 /-- The Kayne-Arsenij\'evi\'c universalist hypothesis — that all clausal
-    complementation is relativization — is decidable on the Table 79 sample
-    as `∀ c ∈ table79, c.surfacePattern = .abarInternalCP`. Deal 2026 refutes
-    it: only one of six cells (Nez Perce REs) projects as `abarInternalCP`. -/
+    complementation is relativization — stated on the Ā-axis: not every
+    Table 79 cell carries an internal Ā-dependency. (The retired surface-enum
+    version undercounted — Adyghe/Bulgarian REs DO relativize, inside a
+    nominal shell, and are not counterexamples; the counterexamples are the
+    no-Ā cells: Nez Perce simplex, English *think*, Ndebele, Washo.) -/
 theorem kayne_universalism_refuted :
-    ¬ (table79.all (·.surfacePattern == .abarInternalCP) = true) := by decide
+    ¬ ∀ c ∈ table79, c.shape.hasInternalAbar = true := by decide
 
-/-- Deal 2026's positive contribution: at least one cell projects as
-    `abarInternalCP` (so REs are real); at least one cell projects as
-    `barePropositionalCP` (so not all complementation is relativization);
-    at least one cell projects as `nominalization` (consistent with prior
+/-- Deal 2026's positive contribution, on the two axes: bare CP + Ā attested
+    (REs are real); bare CP without Ā attested (not all complementation is
+    relativization); a nominal shell attested (consistent with prior
     nominalization analyses for some languages). -/
-theorem table79_three_surface_patterns_attested :
-    table79.any (·.surfacePattern == .abarInternalCP) = true ∧
-    table79.any (·.surfacePattern == .barePropositionalCP) = true ∧
-    table79.any (·.surfacePattern == .nominalization) = true := by
+theorem table79_axes_attested :
+    (∃ c ∈ table79, c.shape.external = bareCP ∧ c.shape.hasInternalAbar = true) ∧
+    (∃ c ∈ table79, c.shape.external = bareCP ∧ c.shape.hasInternalAbar = false) ∧
+    (∃ c ∈ table79, hasNominalShell c.shape.external) := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
+
+/-- The combination the surface enum could not express — claim 2: REs
+    vary in nominal superstructure (Adyghe V D N CP, Bulgarian V P D CP
+    carry Ā inside a nominal shell). -/
+theorem shelled_REs_attested :
+    ∃ c ∈ table79, hasNominalShell c.shape.external ∧
+      c.shape.hasInternalAbar = true := by decide
 
 -- ============================================================================
 -- §2.5. Greek extension (cross-reference to [angelopoulos-2026])
@@ -252,23 +218,17 @@ theorem table79_three_surface_patterns_attested :
 -- positions. The refutation theorem itself lives in
 -- `Studies/Angelopoulos2026.lean`
 -- (`angelopoulos_refutes_selection_argument_only`); this file just
--- exposes the Greek *pu*-complement shape as a `barePropositionalCP`
--- entry to make the typology connection explicit.
+-- exposes the Greek *pu*-complement shape as a bare-CP no-Ā entry
+-- to make the typology connection explicit.
 
 /-- Greek *pu*-complement shape per [angelopoulos-2026]: bare CP
-    with no internal Ā-dependency — projects as `barePropositionalCP`,
-    not `nominalization` (Greek lacks a silent situation noun, so
-    *pu* cannot nominalize per paper §5). The categorial [n]-feature
-    on C is checked structurally (light noun in Spec) rather than by
-    a nominal shell. -/
+    with no internal Ā-dependency and no nominal shell (Greek lacks
+    a silent situation noun, so *pu* cannot nominalize per paper §5).
+    The categorial [n]-feature on C is checked structurally (light
+    noun in Spec) rather than by a nominal shell — witnessing that
+    the (factive, bare-CP) combination is attested. -/
 def greekPuComplementShape : NotionalComplementShape :=
   ⟨ClauseSpine.cP, bareCP, false⟩
-
-/-- Greek *pu*-complement projects as `barePropositionalCP` —
-    a bare-CP cell consistent with Deal's typology, witnessing
-    that the (factive, bare-CP) combination is attested. -/
-theorem greekPu_surface :
-    greekPuComplementShape.surfacePattern = .barePropositionalCP := rfl
 
 -- ============================================================================
 -- §3. Cross-Classification: factivity ⊥ RE-structure
@@ -484,7 +444,7 @@ The Studies file integrates four independent substrate layers:
 - Fragment: per-verb consensus typology (CTPClass, factive)
 - Tonhauser projective content: ProjectiveClass (Semantics/Presupposition/)
 - Deal-internal: EmbeddingStrategy + NotionalComplementShape
-- Typology: ComplementClauseStructure surface enum
+- Shell/Ā axes: `CPShellInventory` + `hasNominalShell` (Syntax/Clause/)
 
 The bridge theorems below derive load-bearing predictions across these
 layers rather than stipulating them. -/
@@ -496,23 +456,13 @@ def EmbeddingStrategy.shape : EmbeddingStrategy → NotionalComplementShape
   | .re => nezPerceREShape
   | .simplex => nezPerceSimplexShape
 
-/-- Strategy-shape correspondence: every embedder's strategy projects to
-    the right shape, preserving the abarInternalCP / barePropositionalCP
-    distinction at the surface-pattern level. -/
-theorem strategy_shape_surface (v : NezPerceEmbedder) :
-    (nezPerceEmbedStrategy v).shape.surfacePattern =
-      if nezPerceEmbedStrategy v = .re then .abarInternalCP
-      else .barePropositionalCP := by
-  cases nezPerceEmbedStrategy v <;> simp [EmbeddingStrategy.shape]
-  all_goals rfl
-
-/-- Every RE-canonical predicate projects via shape to `abarInternalCP`. -/
-theorem reCanonical_surfacePattern_abar :
-    ∀ v ∈ reCanonical,
-      (nezPerceEmbedStrategy v).shape.surfacePattern = .abarInternalCP := by
-  intro v hv
-  rw [strategy_shape_surface]
-  simp [reCanonical_strategy v hv]
+/-- Strategy-shape correspondence on the Ā-axis: the shape an embedder's
+    strategy selects carries an internal Ā-dependency exactly when the
+    Fragment observable holds. -/
+theorem strategy_shape_abar (v : NezPerceEmbedder) :
+    (nezPerceEmbedStrategy v).shape.hasInternalAbar = v.requiresYoxKeEdge := by
+  unfold nezPerceEmbedStrategy
+  cases v.requiresYoxKeEdge <;> rfl
 
 /-- All three Table-79 RE cells (Nez Perce, Adyghe, Bulgarian) carry an
     internal Ā-dependency. The shared `hasInternalAbar = true` is the
@@ -530,14 +480,6 @@ theorem all_simplex_lack_internal_abar :
     ndebeleShape.hasInternalAbar = false ∧
     washoShape.hasInternalAbar = false := by
   refine ⟨rfl, rfl, rfl⟩
-
-/-- Table-79 cells partition into ±Ā: every cell either has it or lacks it
-    (a tautology over Bool, but documents the bipartition exhaustiveness
-    of the hasInternalAbar dimension). -/
-theorem table79_bipartite :
-    ∀ c ∈ table79, c.shape.hasInternalAbar = true ∨
-                   c.shape.hasInternalAbar = false := by
-  intro c _; cases c.shape.hasInternalAbar <;> tauto
 
 /-- The four-cell cross-classification of Tables 80–81 is exhaustively
     populated: every combination of (factive, hasInternalAbar) is attested

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -1,7 +1,6 @@
 import Linglib.Syntax.Minimalist.Verbal.Aspect
 import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
-import Linglib.Syntax.Clause.Complementation
 import Linglib.Features.Aktionsart
 import Linglib.Fragments.Mandarin.Predicates
 import Linglib.Fragments.Cantonese.Aspect
@@ -86,7 +85,6 @@ explicit in §10 as a refutation theorem candidate.
 namespace LiuYip2026
 
 open Minimalist (AspFlavor AspHead Probe.Profile ClauseSpine ComplementSize Cat fValue)
-open Clause.Complementation (ComplementClauseStructure)
 
 -- ============================================================================
 -- §1. Three Chinese clause types as ComplementSize instances
@@ -467,27 +465,19 @@ have Studies-level Chinese formalizations they currently lack):
   explicit prose noting the alternative locality model. -/
 
 -- ============================================================================
--- §12. Bridge to Clause.Complementation.ComplementClauseStructure
+-- §12. Size bridge to Minimalist.ComplementSize
 -- ============================================================================
 
-/-- The local `ComplementClass` projects to the existing theory-neutral
-    surface enum `Clause.Complementation.ComplementClauseStructure`.
-    This converts the planned ICH from a parallel third axis into a
-    projection over substrate that already serves [deal-2026],
-    [landau-2015], [cristofaro-2013], and [noonan-2007]
-    — the interconnection-density discipline CLAUDE.md describes.
-
-    Note: the projection collapses [wurmbrand-lohninger-2023]'s
-    three classes onto two surface patterns (`barePropositionalCP` for
-    proposition, `abarInternalCP` for situation/event). The collapse is
-    correct for Chinese but may not generalize. -/
-def toSurfacePattern : ComplementClass → ComplementClauseStructure
-  | .proposition => .barePropositionalCP
-  | .situation => .abarInternalCP
-  | .event => .abarInternalCP
-
-theorem proposition_surface :
-    toSurfacePattern .proposition = .barePropositionalCP := rfl
+/-- [wurmbrand-lohninger-2023] ICH classes track structural size —
+    proposition = CP, situation = TP, event = vP. Replaces the retired
+    projection onto the deleted surface enum, which forced
+    situation/event onto an Ā-dependency cell the ICH does not claim.
+    ([deal-2026]'s shell/Ā axes live in `Syntax/Clause/Complementation`;
+    the ICH makes no claim on either axis, so no bridge is stated.) -/
+def ComplementClass.size : ComplementClass → ComplementSize
+  | .proposition => .cP
+  | .situation => .tP
+  | .event => .vP
 
 -- ============================================================================
 -- §13. Open / deferred items

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -12,9 +12,8 @@ frames and clause-typers.
 
 ## Main definitions
 
-- `ComplementClauseStructure` — surface complement-clause shapes
-- `CPShell`, `CPShellInventory`, `isAttestedShell` — CP external shells
-  ([deal-2026] Table 79)
+- `CPShell`, `CPShellInventory`, `isAttestedShell`, `hasNominalShell` —
+  CP external shells ([deal-2026] Table 79)
 - `ComplementType.toNoonan`, `Verb.frames`, `Verb.realizes` — the
   selection relation
 
@@ -31,41 +30,6 @@ named witnesses; the universal claims stay in Table 79 commentary.
 -/
 
 namespace Clause.Complementation
-
-/-! ### Theory-neutral surface enum
-
-`ComplementClauseStructure` records the *surface pattern* a notional
-complement clause realises, without committing to a framework's internal
-analysis; each Theory projects its native account into it (HPSG projects
-`headExternalModifier` for true RCs; Minimalist with [deal-2026] projects
-`abarInternalCP` for Nez Perce REs, `barePropositionalCP` for English
-*that*-clauses). -/
-
-/-- Surface shapes of notional complement clauses. [deal-2026]'s typology
-refutes the Kayne/Arsenijević universalist claim ([kayne-2008],
-[kayne-2014], [arsenijevic-2009]) — now the single decidable statement
-`∀ c : ComplementClauseStructure, c = .abarInternalCP` — by exhibiting
-`.barePropositionalCP` as attested. -/
-inductive ComplementClauseStructure where
-  /-- CP with internal Ā-dependency above TP: Nez Perce REs ([deal-2026]),
-      Adyghe ([caponigro-polinsky-2011]), Bulgarian ([krapova-2010]). -/
-  | abarInternalCP
-  /-- Bare CP, no internal Ā-dependency: Nez Perce simplex embeddings,
-      English *think*-complementation ([deal-2026]). -/
-  | barePropositionalCP
-  /-- CP wrapped in a nominal projection: Washo factives
-      ([hanink-bochnak-2017], [bochnak-hanink-2021]), Ndebele
-      ([pietraszko-2019]). -/
-  | nominalization
-  /-- True relative clause: adjunct modifier of a head noun — the pattern
-      Kayne/Arsenijević claim subsumes all others. -/
-  | headExternalModifier
-  /-- Internally-headed relative clause (Bambara, Navajo). -/
-  | headInternalRelative
-  /-- High adjunct, not complementation: Amahuaca attitude reports
-      ([deal-2026] §3). -/
-  | adjunct
-  deriving DecidableEq, Repr
 
 /-! ### CP-external wrapping shells
 
@@ -138,6 +102,16 @@ theorem pCP_not_attested : isAttestedShell [.c, .p] = false := rfl
 
 /-- `V N CP` (N with no D shell) is not a Table 79 cell. -/
 theorem nCP_not_attested : isAttestedShell [.c, .n] = false := rfl
+
+/-- The clause complex is wrapped in a nominal projection: its shell
+    contains D (Washo `dCP`, Adyghe `dnCP`, Bulgarian/Ndebele `pdCP`;
+    `bareCP` is not). On [deal-2026]'s attested cells this coincides
+    with `≠ bareCP` (`pCP`/`nCP` are unattested); D-membership is the
+    definitional content, not the complement of a special case. -/
+def hasNominalShell (inv : CPShellInventory) : Prop := CPShell.d ∈ inv
+
+instance : DecidablePred hasNominalShell :=
+  λ inv => inferInstanceAs (Decidable (CPShell.d ∈ inv))
 
 /-! ### Selection
 


### PR DESCRIPTION
Dissolves the six-cell surface enum (fifth mathlib-reviewer consult): it flattened ≥3 orthogonal axes, and both consumers' projections into it were unfaithful — Deal's dropped the Ā-fact for shelled REs (counting Adyghe/Bulgarian as Kayne counterexamples *even though they relativize*), and LiuYip's forced ICH size classes onto an Ā-dependency cell the theory never claims.

- `hasNominalShell` derived from the shell inventory (D-membership) replaces the `.nominalization` cell; three enum cells had zero consumers and are simply gone.
- `Studies/Deal2026`: `kayne_universalism_refuted` restated on the Ā-axis directly (corrected witness set); `table79_axes_attested` per axis; NEW `shelled_REs_attested` — claim 2 (Ā inside a nominal shell), which the flattened enum could not express; ten projection-unfolding theorems deleted.
- `Studies/LiuYip2026`: honest `ComplementClass.size` bridge onto `Minimalist.ComplementSize` (proposition=CP, situation=TP, event=vP), per the constructors' own definitions.