### PR TITLE
feat(Data/Examples): complementation paradigm stimuli for three papers

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2936,5 +2936,8 @@ import Linglib.Data.Examples.RotterLiu2025
 import Linglib.Data.Examples.DegenTonhauser2021
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.Krifka1998
+import Linglib.Data.Examples.Bondarenko2022
+import Linglib.Data.Examples.Angelopoulos2026
+import Linglib.Data.Examples.Major2024
 
 

--- a/Linglib/Data/Examples/Angelopoulos2026.json
+++ b/Linglib/Data/Examples/Angelopoulos2026.json
@@ -1,0 +1,303 @@
+[
+  {
+    "id": "angelopoulos2026_1a",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (1a)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "I Elena ipe oti eçi episkefti tin Vrazilia.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["I", "the.F.SG.NOM"], ["Elena", "Elena.F.SG.NOM"], ["ipe", "said.3SG"], ["oti", "OTI"],
+      ["eçi", "have.3SG"], ["episkefti", "visited"], ["tin", "the.F.SG.ACC"],
+      ["Vrazilia", "Brazil.F.SG.ACC"]
+    ],
+    "translation": "Elena said that she has visited Brazil.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "I Elena ipe pu eçi episkefti tin Vrazilia.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["complementizer", "oti"],
+      ["verbClass", "saying"]
+    ],
+    "comment": "Paper prints 'oti/*pu' in one example; the pu variant is expanded into alternatives. OTI/PU are the paper's placeholder glosses for the complementizers (fn. 1). Verbs of saying and belief take oti, not pu.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_1b",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (1b)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "I Elena metanjose pu paretiθike.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["I", "the.F.SG.NOM"], ["Elena", "Elena.F.SG.NOM"], ["metanjose", "regretted.3SG"],
+      ["pu", "PU"], ["paretiθike", "quit.3SG"]
+    ],
+    "translation": "Elena regretted that she quit.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "I Elena metanjose oti paretiθike.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["complementizer", "pu"],
+      ["verbClass", "emotive-factive"]
+    ],
+    "comment": "Paper prints 'pu/*oti' in one example; the oti variant is expanded into alternatives. Emotive factive verbs take pu, not oti.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_31a",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (31a)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "δjafono me kati.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["δjafono", "disagree.1SG"], ["me", "with"], ["kati", "something.N.SG.ACC"]
+    ],
+    "translation": "I disagree with something.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "P-ban"],
+      ["verb", "δjafono 'disagree'"]
+    ],
+    "comment": "δjafono 'disagree' takes a PP complement headed by me 'with'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_31b",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (31b)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "δjafono oti prepi na kanume epenδisis.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["δjafono", "disagree.1SG"], ["oti", "OTI"], ["prepi", "must.3SG"], ["na", "na"],
+      ["kanume", "do.1PL"], ["epenδisis", "investments.F.PL.ACC"]
+    ],
+    "translation": "I disagree that we should invest.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "P-ban"],
+      ["verb", "δjafono 'disagree'"]
+    ],
+    "comment": "δjafono 'disagree' also takes a bare oti-clause complement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_31c",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (31c)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "δjafono me oti prepi na kanume epenδisis.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["δjafono", "disagree.1SG"], ["me", "with"], ["oti", "OTI"], ["prepi", "must.3SG"],
+      ["na", "na"], ["kanume", "do.1PL"], ["epenδisis", "investments.F.PL.ACC"]
+    ],
+    "translation": "I disagree with the idea that we should invest.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "P-ban"],
+      ["verb", "δjafono 'disagree'"]
+    ],
+    "comment": "Translation marked 'intended:' in the paper. The oti-clause cannot combine with the P me: like T, P cannot host light-noun incorporation.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_32a",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (32a)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Metanjono ja kati.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Metanjono", "regret.1SG"], ["ja", "for"], ["kati", "something.N.SG.ACC"]
+    ],
+    "translation": "I regret for something.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "P-ban"],
+      ["verb", "metanjono 'regret'"]
+    ],
+    "comment": "metanjono 'regret' takes a PP complement headed by ja 'for'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_32b",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (32b)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Metanjono pu paremina.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Metanjono", "regret.1SG"], ["pu", "PU"], ["paremina", "stayed.1SG"]
+    ],
+    "translation": "I regret that I stayed.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "P-ban"],
+      ["verb", "metanjono 'regret'"]
+    ],
+    "comment": "metanjono 'regret' also takes a bare pu-clause complement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_32c",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (32c)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Metanjono ja pu paremina.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Metanjono", "regret.1SG"], ["ja", "for"], ["pu", "PU"], ["paremina", "stayed.1SG"]
+    ],
+    "translation": "I regret for staying.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "P-ban"],
+      ["verb", "metanjono 'regret'"]
+    ],
+    "comment": "Translation marked 'intended:' in the paper. The pu-clause cannot combine with the P ja.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_33a",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (33a)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Afti i fimi ine aliθis.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Afti", "this.F.SG.NOM"], ["i", "the.F.SG.NOM"], ["fimi", "rumor.F.SG.NOM"],
+      ["ine", "be.3SG"], ["aliθis", "true.F.SG.NOM"]
+    ],
+    "translation": "This rumor is true/mistaken.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Afti i fimi ine lanθasmeni.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "truth-predicates"],
+      ["nounSort", "content"]
+    ],
+    "comment": "Paper prints 'aliθis/lanθasmeni' in one example; expanded here. Content nouns combine with 'true'/'mistaken'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_33b",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (33b)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Afti i katastasi ine aliθis.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Afti", "this.F.SG.NOM"], ["i", "the.F.SG.NOM"], ["katastasi", "situation.F.SG.NOM"],
+      ["ine", "be.3SG"], ["aliθis", "true.F.SG.NOM"]
+    ],
+    "translation": "This situation is true/mistaken.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [
+      {"form": "Afti i katastasi ine lanθasmeni.", "judgment": "unacceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "truth-predicates"],
+      ["nounSort", "situation"]
+    ],
+    "comment": "Marked # in the paper (scoping over both predicate variants): situation nouns do not combine with 'true'/'mistaken'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_34a",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (34a)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Tetjes fimes δen simvenun sixna.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Tetjes", "such.F.PL.NOM"], ["fimes", "rumors.F.PL.NOM"], ["δen", "not"],
+      ["simvenun", "occur.3PL"], ["sixna", "often"]
+    ],
+    "translation": "Such rumors/ideas/warnings/beliefs/hypotheses/theories do not happen often.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [
+      {"form": "Tetjes iδees δen simvenun sixna.", "judgment": "unacceptable"},
+      {"form": "Tetjes proiδopiisis δen simvenun sixna.", "judgment": "unacceptable"},
+      {"form": "Tetjes pepiθisis δen simvenun sixna.", "judgment": "unacceptable"},
+      {"form": "Tetjes ipoθesis δen simvenun sixna.", "judgment": "unacceptable"},
+      {"form": "Tetjes θeories δen simvenun sixna.", "judgment": "unacceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "occurrence-predicates"],
+      ["nounSort", "content"]
+    ],
+    "comment": "Marked # in the paper. Paper prints the six content nouns 'fimes/ iδees/ proiδopiisis/ pepiθisis/ ipoθesis/ θeories' (rumors/ideas/warnings/beliefs/hypotheses/theories) as one slash-list; expanded here. Content nouns do not combine with simveni 'happen'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "angelopoulos2026_34b",
+    "source": {"bibkey": "angelopoulos-2026", "paperLabel": "ex. (34b)"},
+    "reportedIn": null,
+    "language": "mode1248",
+    "primaryText": "Tetjes periptosis δen simvenun sixna.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Tetjes", "such.F.PL.NOM"], ["periptosis", "situations.F.PL.NOM"], ["δen", "not"],
+      ["simvenun", "occur.3PL"], ["sixna", "often"]
+    ],
+    "translation": "Such situations/cases do not happen often.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Tetjes katastasis δen simvenun sixna.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "occurrence-predicates"],
+      ["nounSort", "situation"]
+    ],
+    "comment": "Paper prints 'periptosis/ katastasis' glossed 'situations.F.PL.NOM/ cases.F.PL.NOM' — transcribed verbatim, though the gloss order looks swapped relative to (35b), where periptosi = 'case' and katastasi = 'situation'. Situation nouns combine with simveni 'happen'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Angelopoulos2026.lean
+++ b/Linglib/Data/Examples/Angelopoulos2026.lean
@@ -1,0 +1,234 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Angelopoulos2026` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Angelopoulos2026.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Angelopoulos2026.Examples`.
+-/
+
+namespace Angelopoulos2026.Examples
+
+open Data.Examples
+
+def ex_1a : LinguisticExample :=
+  { id := "angelopoulos2026_1a"
+    source := ⟨"angelopoulos-2026", "ex. (1a)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "I Elena ipe oti eçi episkefti tin Vrazilia."
+    discourseSegments := []
+    glossedTokens := [("I", "the.F.SG.NOM"), ("Elena", "Elena.F.SG.NOM"), ("ipe", "said.3SG"), ("oti", "OTI"), ("eçi", "have.3SG"), ("episkefti", "visited"), ("tin", "the.F.SG.ACC"), ("Vrazilia", "Brazil.F.SG.ACC")]
+    translation := "Elena said that she has visited Brazil."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("I Elena ipe pu eçi episkefti tin Vrazilia.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("complementizer", "oti"), ("verbClass", "saying")]
+    comment := "Paper prints 'oti/*pu' in one example; the pu variant is expanded into alternatives. OTI/PU are the paper's placeholder glosses for the complementizers (fn. 1). Verbs of saying and belief take oti, not pu."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_1b : LinguisticExample :=
+  { id := "angelopoulos2026_1b"
+    source := ⟨"angelopoulos-2026", "ex. (1b)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "I Elena metanjose pu paretiθike."
+    discourseSegments := []
+    glossedTokens := [("I", "the.F.SG.NOM"), ("Elena", "Elena.F.SG.NOM"), ("metanjose", "regretted.3SG"), ("pu", "PU"), ("paretiθike", "quit.3SG")]
+    translation := "Elena regretted that she quit."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("I Elena metanjose oti paretiθike.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("complementizer", "pu"), ("verbClass", "emotive-factive")]
+    comment := "Paper prints 'pu/*oti' in one example; the oti variant is expanded into alternatives. Emotive factive verbs take pu, not oti."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_31a : LinguisticExample :=
+  { id := "angelopoulos2026_31a"
+    source := ⟨"angelopoulos-2026", "ex. (31a)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "δjafono me kati."
+    discourseSegments := []
+    glossedTokens := [("δjafono", "disagree.1SG"), ("me", "with"), ("kati", "something.N.SG.ACC")]
+    translation := "I disagree with something."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "P-ban"), ("verb", "δjafono 'disagree'")]
+    comment := "δjafono 'disagree' takes a PP complement headed by me 'with'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_31b : LinguisticExample :=
+  { id := "angelopoulos2026_31b"
+    source := ⟨"angelopoulos-2026", "ex. (31b)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "δjafono oti prepi na kanume epenδisis."
+    discourseSegments := []
+    glossedTokens := [("δjafono", "disagree.1SG"), ("oti", "OTI"), ("prepi", "must.3SG"), ("na", "na"), ("kanume", "do.1PL"), ("epenδisis", "investments.F.PL.ACC")]
+    translation := "I disagree that we should invest."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "P-ban"), ("verb", "δjafono 'disagree'")]
+    comment := "δjafono 'disagree' also takes a bare oti-clause complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_31c : LinguisticExample :=
+  { id := "angelopoulos2026_31c"
+    source := ⟨"angelopoulos-2026", "ex. (31c)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "δjafono me oti prepi na kanume epenδisis."
+    discourseSegments := []
+    glossedTokens := [("δjafono", "disagree.1SG"), ("me", "with"), ("oti", "OTI"), ("prepi", "must.3SG"), ("na", "na"), ("kanume", "do.1PL"), ("epenδisis", "investments.F.PL.ACC")]
+    translation := "I disagree with the idea that we should invest."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "P-ban"), ("verb", "δjafono 'disagree'")]
+    comment := "Translation marked 'intended:' in the paper. The oti-clause cannot combine with the P me: like T, P cannot host light-noun incorporation."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_32a : LinguisticExample :=
+  { id := "angelopoulos2026_32a"
+    source := ⟨"angelopoulos-2026", "ex. (32a)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Metanjono ja kati."
+    discourseSegments := []
+    glossedTokens := [("Metanjono", "regret.1SG"), ("ja", "for"), ("kati", "something.N.SG.ACC")]
+    translation := "I regret for something."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "P-ban"), ("verb", "metanjono 'regret'")]
+    comment := "metanjono 'regret' takes a PP complement headed by ja 'for'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_32b : LinguisticExample :=
+  { id := "angelopoulos2026_32b"
+    source := ⟨"angelopoulos-2026", "ex. (32b)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Metanjono pu paremina."
+    discourseSegments := []
+    glossedTokens := [("Metanjono", "regret.1SG"), ("pu", "PU"), ("paremina", "stayed.1SG")]
+    translation := "I regret that I stayed."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "P-ban"), ("verb", "metanjono 'regret'")]
+    comment := "metanjono 'regret' also takes a bare pu-clause complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_32c : LinguisticExample :=
+  { id := "angelopoulos2026_32c"
+    source := ⟨"angelopoulos-2026", "ex. (32c)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Metanjono ja pu paremina."
+    discourseSegments := []
+    glossedTokens := [("Metanjono", "regret.1SG"), ("ja", "for"), ("pu", "PU"), ("paremina", "stayed.1SG")]
+    translation := "I regret for staying."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "P-ban"), ("verb", "metanjono 'regret'")]
+    comment := "Translation marked 'intended:' in the paper. The pu-clause cannot combine with the P ja."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_33a : LinguisticExample :=
+  { id := "angelopoulos2026_33a"
+    source := ⟨"angelopoulos-2026", "ex. (33a)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Afti i fimi ine aliθis."
+    discourseSegments := []
+    glossedTokens := [("Afti", "this.F.SG.NOM"), ("i", "the.F.SG.NOM"), ("fimi", "rumor.F.SG.NOM"), ("ine", "be.3SG"), ("aliθis", "true.F.SG.NOM")]
+    translation := "This rumor is true/mistaken."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Afti i fimi ine lanθasmeni.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "truth-predicates"), ("nounSort", "content")]
+    comment := "Paper prints 'aliθis/lanθasmeni' in one example; expanded here. Content nouns combine with 'true'/'mistaken'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_33b : LinguisticExample :=
+  { id := "angelopoulos2026_33b"
+    source := ⟨"angelopoulos-2026", "ex. (33b)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Afti i katastasi ine aliθis."
+    discourseSegments := []
+    glossedTokens := [("Afti", "this.F.SG.NOM"), ("i", "the.F.SG.NOM"), ("katastasi", "situation.F.SG.NOM"), ("ine", "be.3SG"), ("aliθis", "true.F.SG.NOM")]
+    translation := "This situation is true/mistaken."
+    context := ""
+    judgment := .unacceptable
+    alternatives := [("Afti i katastasi ine lanθasmeni.", .unacceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "truth-predicates"), ("nounSort", "situation")]
+    comment := "Marked # in the paper (scoping over both predicate variants): situation nouns do not combine with 'true'/'mistaken'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_34a : LinguisticExample :=
+  { id := "angelopoulos2026_34a"
+    source := ⟨"angelopoulos-2026", "ex. (34a)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Tetjes fimes δen simvenun sixna."
+    discourseSegments := []
+    glossedTokens := [("Tetjes", "such.F.PL.NOM"), ("fimes", "rumors.F.PL.NOM"), ("δen", "not"), ("simvenun", "occur.3PL"), ("sixna", "often")]
+    translation := "Such rumors/ideas/warnings/beliefs/hypotheses/theories do not happen often."
+    context := ""
+    judgment := .unacceptable
+    alternatives := [("Tetjes iδees δen simvenun sixna.", .unacceptable), ("Tetjes proiδopiisis δen simvenun sixna.", .unacceptable), ("Tetjes pepiθisis δen simvenun sixna.", .unacceptable), ("Tetjes ipoθesis δen simvenun sixna.", .unacceptable), ("Tetjes θeories δen simvenun sixna.", .unacceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "occurrence-predicates"), ("nounSort", "content")]
+    comment := "Marked # in the paper. Paper prints the six content nouns 'fimes/ iδees/ proiδopiisis/ pepiθisis/ ipoθesis/ θeories' (rumors/ideas/warnings/beliefs/hypotheses/theories) as one slash-list; expanded here. Content nouns do not combine with simveni 'happen'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_34b : LinguisticExample :=
+  { id := "angelopoulos2026_34b"
+    source := ⟨"angelopoulos-2026", "ex. (34b)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "Tetjes periptosis δen simvenun sixna."
+    discourseSegments := []
+    glossedTokens := [("Tetjes", "such.F.PL.NOM"), ("periptosis", "situations.F.PL.NOM"), ("δen", "not"), ("simvenun", "occur.3PL"), ("sixna", "often")]
+    translation := "Such situations/cases do not happen often."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Tetjes katastasis δen simvenun sixna.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "occurrence-predicates"), ("nounSort", "situation")]
+    comment := "Paper prints 'periptosis/ katastasis' glossed 'situations.F.PL.NOM/ cases.F.PL.NOM' — transcribed verbatim, though the gloss order looks swapped relative to (35b), where periptosi = 'case' and katastasi = 'situation'. Situation nouns combine with simveni 'happen'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def all : List LinguisticExample := [ex_1a, ex_1b, ex_31a, ex_31b, ex_31c, ex_32a, ex_32b, ex_32c, ex_33a, ex_33b, ex_34a, ex_34b]
+
+end Angelopoulos2026.Examples

--- a/Linglib/Data/Examples/Bondarenko2022.json
+++ b/Linglib/Data/Examples/Bondarenko2022.json
@@ -1,0 +1,512 @@
+[
+  {
+    "id": "bondarenko2022_ch2_105",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (105)"},
+    "reportedIn": null,
+    "language": "russ1263",
+    "primaryText": "Ideja čto grjadut reformy javljaetsja vernoj.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ideja", "idea"], ["čto", "COMP"], ["grjadut", "are.coming"], ["reformy", "reforms"],
+      ["javljaetsja", "is"], ["vernoj", "true"]
+    ],
+    "translation": "An idea / a situation that reforms are coming is true / mistaken.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Situacija čto grjadut reformy javljaetsja vernoj.", "judgment": "ungrammatical"},
+      {"form": "Ideja čto grjadut reformy javljaetsja ošibočnoj.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "truth-predicates"],
+      ["nounSort", "content"]
+    ],
+    "comment": "Paper prints the alternations 'Ideja /*situacija' and 'vernoj /ošibočnoj' inside one example; expanded here per the alternatives convention. Cont-NP 'idea' combines with 'true'/'mistaken', Sit-NP 'situation' does not. Bracketed [CP ...] markup dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_106",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (106)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-i kecis-i-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"],
+      ["phwul-ess-ta-nun", "solve-PST-DECL-ADN"], ["cwucang-i", "claim-NOM"],
+      ["kecis-i-ta", "falsehood-COP-DECL"]
+    ],
+    "translation": "The claim that Swuna solved the problem is false/true.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-i cham-i-ta.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "truth-predicates"],
+      ["nounSort", "content"]
+    ],
+    "comment": "Paper prints 'kecis-i-ta /cham-i-ta' (falsehood-COP-DECL /truth-COP-DECL) in one example; the cham- variant is expanded into alternatives. Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_107",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (107)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Swuna-ka mwuncey-lul phwul-un sanghwang-i kecis-i-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"], ["phwul-un", "solve-ADN"],
+      ["sanghwang-i", "situation-NOM"], ["kecis-i-ta", "falsehood-COP-DECL"]
+    ],
+    "translation": "The situation that Swuna solved the problem is false/true.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [
+      {"form": "Swuna-ka mwuncey-lul phwul-un sanghwang-i cham-i-ta.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "truth-predicates"],
+      ["nounSort", "situation"]
+    ],
+    "comment": "Star scopes over both predicate variants ('kecis-i-ta /cham-i-ta'). Extraction prints the gloss of phwul-un as 'solve--adn' (double hyphen artifact); normalized to solve-ADN per the same form in (110), (112), (122).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_108",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (108)"},
+    "reportedIn": null,
+    "language": "russ1263",
+    "primaryText": "Včera proizošla situacija čto moj zakaz zaderžali.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Včera", "yesterday"], ["proizošla", "occured"], ["situacija", "situation"],
+      ["čto", "COMP"], ["moj", "my"], ["zakaz", "order"], ["zaderžali", "delayed"]
+    ],
+    "translation": "Yesterday a situation/idea that my order was delayed happened/occurred.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Včera proizošla ideja čto moj zakaz zaderžali.", "judgment": "ungrammatical"},
+      {"form": "Včera slučilas’ situacija čto moj zakaz zaderžali.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "occurrence-predicates"],
+      ["nounSort", "situation"]
+    ],
+    "comment": "Paper prints 'proizošla /slučilas’ *ideja /situacija' in one example; expanded here. Occurrence verbs combine with Sit-NPs, not Cont-NPs. Gloss 'occured' is the paper's own spelling. Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_109",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (109)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-i ilena-ss-ta",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"],
+      ["phwul-ess-ta-nun", "solve-PST-DECL-ADN"], ["cwucang-i", "claim-NOM"],
+      ["ilena-ss-ta", "occur-PST-DECL"]
+    ],
+    "translation": "A claim that Swuna solved the problem occured.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "occurrence-predicates"],
+      ["nounSort", "content"]
+    ],
+    "comment": "Translation spelling 'occured' is the paper's own.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_110",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (110)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Swuna-ka mwuncey-lul phwul-un sanghwang-i ilena-ss-ta",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"], ["phwul-un", "solve-ADN"],
+      ["sanghwang-i", "situation-NOM"], ["ilena-ss-ta", "occur-PST-DECL"]
+    ],
+    "translation": "A situation that Swuna solved the problem occured.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "occurrence-predicates"],
+      ["nounSort", "situation"]
+    ],
+    "comment": "Translation spelling 'occured' is the paper's own.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_111",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (111)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Mina-ka Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-ul alachay-ss-ta",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mina-ka", "Mina-NOM"], ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"],
+      ["phwul-ess-ta-nun", "solve-PST-DECL-ADN"], ["cwucang-ul", "claim-ACC"],
+      ["alachay-ss-ta", "notice-PST-DECL"]
+    ],
+    "translation": "Mina noticed the claim that Swuna solved the problem.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "situation-only-predicate-notice"],
+      ["nounSort", "content"]
+    ],
+    "comment": "Consultant comment (fn. 28): 'This verb [alachay] just does not sound good with claim'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_112",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (112)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Mina-ka Swuna-ka mwuncey-lul phwul-un sanghwang-ul alachay-ss-ta",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mina-ka", "Mina-NOM"], ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"],
+      ["phwul-un", "solve-ADN"], ["sanghwang-ul", "situation-ACC"],
+      ["alachay-ss-ta", "notice-PST-DECL"]
+    ],
+    "translation": "Mina noticed the situation that Swuna solved the problem.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "situation-only-predicate-notice"],
+      ["nounSort", "situation"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_120a",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (120a)"},
+    "reportedIn": null,
+    "language": "russ1263",
+    "primaryText": "Lena zametila slux čto èta ženščina priexala na kone.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Lena", "Lena"], ["zametila", "noticed"], ["slux", "rumor"], ["čto", "COMP"],
+      ["èta", "this"], ["ženščina", "woman"], ["priexala", "arrived"], ["na", "on"],
+      ["kone", "horse"]
+    ],
+    "translation": "Lena noticed a rumor /an event that this woman arrived on a horse.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Lena zametila slučaj čto èta ženščina priexala na kone.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["role", "premise-a"]
+    ],
+    "comment": "Paper prints 'slux /slučaj' (rumor /event) in one example. Premise (a) of the (120) substitution triple: with Cont-NP slux, premises (a),(b) do not entail conclusion (c) (opacity); with Sit-NP slučaj they do (transparency). Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_120b",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (120b)"},
+    "reportedIn": null,
+    "language": "russ1263",
+    "primaryText": "èta ženščina — koroleva Velikobritanii.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["èta", "this"], ["ženščina", "woman"], ["koroleva", "queen"],
+      ["Velikobritanii", "Great.Britain"]
+    ],
+    "translation": "This woman is the queen of Great Britain.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["role", "premise-b"]
+    ],
+    "comment": "Identity premise (b) of the (120) substitution triple; the em dash is the Russian null copula.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_120c",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (120c)"},
+    "reportedIn": null,
+    "language": "russ1263",
+    "primaryText": "Lena zametila slux čto koroleva Velikobritanii priexala na kone.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Lena", "Lena"], ["zametila", "noticed"], ["slux", "rumor"], ["čto", "COMP"],
+      ["koroleva", "queen"], ["Velikobritanii", "Great.Britain"], ["priexala", "arrived"],
+      ["na", "on"], ["kone", "horse"]
+    ],
+    "translation": "Lena noticed a rumor /an event that the queen of Great Britain arrived on a horse.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Lena zametila slučaj čto koroleva Velikobritanii priexala na kone.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["role", "conclusion"]
+    ],
+    "comment": "Conclusion (c) of the (120) substitution triple: does not follow from (a),(b) with Cont-NP slux (opacity); follows with Sit-NP slučaj (transparency). Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_121a",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (121a)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Mina-ka Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-ul kiekhay-ss-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mina-ka", "Mina-NOM"], ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"],
+      ["phwul-ess-ta-nun", "solve-PST-DECL-ADN"], ["cwucang-ul", "claim-ACC"],
+      ["kiekhay-ss-ta", "remember-PST-DECL"]
+    ],
+    "translation": "Mina remembers that Swuna solved the problem.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["nounSort", "content"],
+      ["role", "premise-a"]
+    ],
+    "comment": "Premise (a) of the (121) opacity triple: with Cont-NP cwucang 'claim', premises (a),(b) do not entail conclusion (c).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_121b",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (121b)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Swuna-ka pan-eyse kacang khi-ga khu-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Swuna-ka", "Swuna-NOM"], ["pan-eyse", "class-LOC"], ["kacang", "most"],
+      ["khi-ga", "height-NOM"], ["khu-ta", "large-DECL"]
+    ],
+    "translation": "Swuna is the tallest in the class.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["role", "premise-b"]
+    ],
+    "comment": "Identity premise (b) of the (121) opacity triple.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_121c",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (121c)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Mina-ka pan-eyse kacang khi-ga khun sonye-ka mwuncey-lul phwul-ess-ta-nun cwucang-ul kiekhay-ss-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mina-ka", "Mina-NOM"], ["pan-eyse", "class-LOC"], ["kacang", "most"],
+      ["khi-ga", "height-NOM"], ["khun", "large"], ["sonye-ka", "girl-NOM"],
+      ["mwuncey-lul", "problem-ACC"], ["phwul-ess-ta-nun", "solve-PST-DECL-ADN"],
+      ["cwucang-ul", "claim-ACC"], ["kiekhay-ss-ta", "remember-PST-DECL"]
+    ],
+    "translation": "Mina remembers that the tallest girl in the class solved the problem.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["nounSort", "content"],
+      ["role", "conclusion"]
+    ],
+    "comment": "Conclusion (c) of the (121) opacity triple: does not follow from (a),(b) — Cont-CPs are referentially opaque.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_122a",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (122a)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Mina-ka Swuna-ka mwuncey-lul phwul-un sanghwang-ul kiekhay-ss-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mina-ka", "Mina-NOM"], ["Swuna-ka", "Swuna-NOM"], ["mwuncey-lul", "problem-ACC"],
+      ["phwul-un", "solve-ADN"], ["sanghwang-ul", "situation-ACC"],
+      ["kiekhay-ss-ta", "remember-PST-DECL"]
+    ],
+    "translation": "Mina remembers that Swuna solved the problem.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["nounSort", "situation"],
+      ["role", "premise-a"]
+    ],
+    "comment": "Premise (a) of the (122) transparency triple: with Sit-NP sanghwang 'situation', premises (a),(b) entail conclusion (c).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_122b",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (122b)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Swuna-ka pan-eyse kacang khi-ga khu-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Swuna-ka", "Swuna-NOM"], ["pan-eyse", "class-LOC"], ["kacang", "most"],
+      ["khi-ga", "height-NOM"], ["khu-ta", "large-DECL"]
+    ],
+    "translation": "Swuna is the tallest girl in the class.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["role", "premise-b"]
+    ],
+    "comment": "Identity premise (b) of the (122) transparency triple.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch2_122c",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§2.2.3 ex. (122c)"},
+    "reportedIn": null,
+    "language": "kore1280",
+    "primaryText": "Mina-ka pan-eyse kacang khi-ga khun sonye-ka mwuncey-lul phwul-un sanghwang-ul kiekhay-ss-ta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mina-ka", "Mina-NOM"], ["pan-eyse", "class-LOC"], ["kacang", "most"],
+      ["khi-ga", "height-NOM"], ["khun", "large"], ["sonye-ka", "girl-NOM"],
+      ["mwuncey-lul", "problem-ACC"], ["phwul-un", "solve-ADN"], ["sanghwang-ul", "situation-ACC"],
+      ["kiekhay-ss-ta", "remember-PST-DECL"]
+    ],
+    "translation": "Mina remembers that the tallest girl in the class solved the problem.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "substitution"],
+      ["nounSort", "situation"],
+      ["role", "conclusion"]
+    ],
+    "comment": "Conclusion (c) of the (122) transparency triple: follows from (a),(b) — Sit-CPs are referentially transparent.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch4_30",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§4.3.1 ex. (30)"},
+    "reportedIn": null,
+    "language": "russ1264",
+    "primaryText": "Dugar mi:sgɘi zagaha ɘdj-ɘ: gɘ-žɘ han-a:",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dugar", "Dugar.NOM"], ["mi:sgɘi", "cat.NOM"], ["zagaha", "fish"], ["ɘdj-ɘ:", "eat-PST"],
+      ["gɘ-žɘ", "say-CVB"], ["han-a:", "think-PST"]
+    ],
+    "translation": "Dugar thought that the cat ate the fish.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "Cont-CP"],
+      ["shape", "bare gɘ-žɘ clause"]
+    ],
+    "comment": "Barguzin Buryat. Bare CP: [... V-TENSE gɘ-žɘ] with the say-root gɘ plus converb -žɘ, combining directly with the verb. Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch4_31",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§4.3.1 ex. (31)"},
+    "reportedIn": null,
+    "language": "russ1264",
+    "primaryText": "Dugar mi:sgɘi-n zagaha ɘdj-ɘ:š-i:jɘ-(n’) han-a:",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dugar", "Dugar.NOM"], ["mi:sgɘi-n", "cat-GEN"], ["zagaha", "fish"],
+      ["ɘdj-ɘ:š-i:jɘ-(n’)", "eat-PART-ACC-(3)"], ["han-a:", "think-PST"]
+    ],
+    "translation": "Dugar remembered (an event of) the cat’s eating the fish.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "Sit-CP"],
+      ["shape", "nominalized participial clause"]
+    ],
+    "comment": "Barguzin Buryat. Nominalized Sit-CP: [... V-PART-CASE], genitive subject, participial -A:šA plus obligatory case and optional possessive marking. Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "bondarenko2022_ch4_32",
+    "source": {"bibkey": "bondarenko-2022", "paperLabel": "§4.3.1 ex. (32)"},
+    "reportedIn": null,
+    "language": "russ1264",
+    "primaryText": "Dugar mi:sgɘi-n zagaha ɘdj-ɘ: g-ɘ:š-i:jɘ-(n’) han-a:",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dugar", "Dugar.NOM"], ["mi:sgɘi-n", "cat-GEN"], ["zagaha", "fish"], ["ɘdj-ɘ:", "eat-PST"],
+      ["g-ɘ:š-i:jɘ-(n’)", "say-PART-ACC-(3)"], ["han-a:", "think-PST"]
+    ],
+    "translation": "Dugar remembers (a claim) that the cat ate the fish.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "Cont-CP"],
+      ["shape", "nominalized gɘ-participial clause"]
+    ],
+    "comment": "Barguzin Buryat. Nominalized Cont-CP: [... V-TENSE g-ɘ:š-CASE], the say-root gɘ plus participial -A:šA plus case (fn. 10: hiatus between gɘ and ɘ:šɘ resolved by vowel deletion in gɘ). Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Bondarenko2022.lean
+++ b/Linglib/Data/Examples/Bondarenko2022.lean
@@ -1,0 +1,378 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Bondarenko2022` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Bondarenko2022.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Bondarenko2022.Examples`.
+-/
+
+namespace Bondarenko2022.Examples
+
+open Data.Examples
+
+def ch2_105 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_105"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (105)"⟩
+    reportedIn := none
+    language := "russ1263"
+    primaryText := "Ideja čto grjadut reformy javljaetsja vernoj."
+    discourseSegments := []
+    glossedTokens := [("Ideja", "idea"), ("čto", "COMP"), ("grjadut", "are.coming"), ("reformy", "reforms"), ("javljaetsja", "is"), ("vernoj", "true")]
+    translation := "An idea / a situation that reforms are coming is true / mistaken."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Situacija čto grjadut reformy javljaetsja vernoj.", .ungrammatical), ("Ideja čto grjadut reformy javljaetsja ošibočnoj.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "truth-predicates"), ("nounSort", "content")]
+    comment := "Paper prints the alternations 'Ideja /*situacija' and 'vernoj /ošibočnoj' inside one example; expanded here per the alternatives convention. Cont-NP 'idea' combines with 'true'/'mistaken', Sit-NP 'situation' does not. Bracketed [CP ...] markup dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ch2_106 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_106"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (106)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-i kecis-i-ta."
+    discourseSegments := []
+    glossedTokens := [("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-ess-ta-nun", "solve-PST-DECL-ADN"), ("cwucang-i", "claim-NOM"), ("kecis-i-ta", "falsehood-COP-DECL")]
+    translation := "The claim that Swuna solved the problem is false/true."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-i cham-i-ta.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "truth-predicates"), ("nounSort", "content")]
+    comment := "Paper prints 'kecis-i-ta /cham-i-ta' (falsehood-COP-DECL /truth-COP-DECL) in one example; the cham- variant is expanded into alternatives. Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_107 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_107"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (107)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Swuna-ka mwuncey-lul phwul-un sanghwang-i kecis-i-ta."
+    discourseSegments := []
+    glossedTokens := [("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-un", "solve-ADN"), ("sanghwang-i", "situation-NOM"), ("kecis-i-ta", "falsehood-COP-DECL")]
+    translation := "The situation that Swuna solved the problem is false/true."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := [("Swuna-ka mwuncey-lul phwul-un sanghwang-i cham-i-ta.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "truth-predicates"), ("nounSort", "situation")]
+    comment := "Star scopes over both predicate variants ('kecis-i-ta /cham-i-ta'). Extraction prints the gloss of phwul-un as 'solve--adn' (double hyphen artifact); normalized to solve-ADN per the same form in (110), (112), (122)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_108 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_108"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (108)"⟩
+    reportedIn := none
+    language := "russ1263"
+    primaryText := "Včera proizošla situacija čto moj zakaz zaderžali."
+    discourseSegments := []
+    glossedTokens := [("Včera", "yesterday"), ("proizošla", "occured"), ("situacija", "situation"), ("čto", "COMP"), ("moj", "my"), ("zakaz", "order"), ("zaderžali", "delayed")]
+    translation := "Yesterday a situation/idea that my order was delayed happened/occurred."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Včera proizošla ideja čto moj zakaz zaderžali.", .ungrammatical), ("Včera slučilas’ situacija čto moj zakaz zaderžali.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "occurrence-predicates"), ("nounSort", "situation")]
+    comment := "Paper prints 'proizošla /slučilas’ *ideja /situacija' in one example; expanded here. Occurrence verbs combine with Sit-NPs, not Cont-NPs. Gloss 'occured' is the paper's own spelling. Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ch2_109 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_109"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (109)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-i ilena-ss-ta"
+    discourseSegments := []
+    glossedTokens := [("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-ess-ta-nun", "solve-PST-DECL-ADN"), ("cwucang-i", "claim-NOM"), ("ilena-ss-ta", "occur-PST-DECL")]
+    translation := "A claim that Swuna solved the problem occured."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "occurrence-predicates"), ("nounSort", "content")]
+    comment := "Translation spelling 'occured' is the paper's own."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_110 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_110"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (110)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Swuna-ka mwuncey-lul phwul-un sanghwang-i ilena-ss-ta"
+    discourseSegments := []
+    glossedTokens := [("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-un", "solve-ADN"), ("sanghwang-i", "situation-NOM"), ("ilena-ss-ta", "occur-PST-DECL")]
+    translation := "A situation that Swuna solved the problem occured."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "occurrence-predicates"), ("nounSort", "situation")]
+    comment := "Translation spelling 'occured' is the paper's own."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_111 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_111"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (111)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Mina-ka Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-ul alachay-ss-ta"
+    discourseSegments := []
+    glossedTokens := [("Mina-ka", "Mina-NOM"), ("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-ess-ta-nun", "solve-PST-DECL-ADN"), ("cwucang-ul", "claim-ACC"), ("alachay-ss-ta", "notice-PST-DECL")]
+    translation := "Mina noticed the claim that Swuna solved the problem."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "situation-only-predicate-notice"), ("nounSort", "content")]
+    comment := "Consultant comment (fn. 28): 'This verb [alachay] just does not sound good with claim'."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_112 : LinguisticExample :=
+  { id := "bondarenko2022_ch2_112"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (112)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Mina-ka Swuna-ka mwuncey-lul phwul-un sanghwang-ul alachay-ss-ta"
+    discourseSegments := []
+    glossedTokens := [("Mina-ka", "Mina-NOM"), ("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-un", "solve-ADN"), ("sanghwang-ul", "situation-ACC"), ("alachay-ss-ta", "notice-PST-DECL")]
+    translation := "Mina noticed the situation that Swuna solved the problem."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "situation-only-predicate-notice"), ("nounSort", "situation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_120a : LinguisticExample :=
+  { id := "bondarenko2022_ch2_120a"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (120a)"⟩
+    reportedIn := none
+    language := "russ1263"
+    primaryText := "Lena zametila slux čto èta ženščina priexala na kone."
+    discourseSegments := []
+    glossedTokens := [("Lena", "Lena"), ("zametila", "noticed"), ("slux", "rumor"), ("čto", "COMP"), ("èta", "this"), ("ženščina", "woman"), ("priexala", "arrived"), ("na", "on"), ("kone", "horse")]
+    translation := "Lena noticed a rumor /an event that this woman arrived on a horse."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Lena zametila slučaj čto èta ženščina priexala na kone.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("role", "premise-a")]
+    comment := "Paper prints 'slux /slučaj' (rumor /event) in one example. Premise (a) of the (120) substitution triple: with Cont-NP slux, premises (a),(b) do not entail conclusion (c) (opacity); with Sit-NP slučaj they do (transparency). Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ch2_120b : LinguisticExample :=
+  { id := "bondarenko2022_ch2_120b"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (120b)"⟩
+    reportedIn := none
+    language := "russ1263"
+    primaryText := "èta ženščina — koroleva Velikobritanii."
+    discourseSegments := []
+    glossedTokens := [("èta", "this"), ("ženščina", "woman"), ("koroleva", "queen"), ("Velikobritanii", "Great.Britain")]
+    translation := "This woman is the queen of Great Britain."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("role", "premise-b")]
+    comment := "Identity premise (b) of the (120) substitution triple; the em dash is the Russian null copula."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ch2_120c : LinguisticExample :=
+  { id := "bondarenko2022_ch2_120c"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (120c)"⟩
+    reportedIn := none
+    language := "russ1263"
+    primaryText := "Lena zametila slux čto koroleva Velikobritanii priexala na kone."
+    discourseSegments := []
+    glossedTokens := [("Lena", "Lena"), ("zametila", "noticed"), ("slux", "rumor"), ("čto", "COMP"), ("koroleva", "queen"), ("Velikobritanii", "Great.Britain"), ("priexala", "arrived"), ("na", "on"), ("kone", "horse")]
+    translation := "Lena noticed a rumor /an event that the queen of Great Britain arrived on a horse."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Lena zametila slučaj čto koroleva Velikobritanii priexala na kone.", .acceptable)]
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("role", "conclusion")]
+    comment := "Conclusion (c) of the (120) substitution triple: does not follow from (a),(b) with Cont-NP slux (opacity); follows with Sit-NP slučaj (transparency). Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ch2_121a : LinguisticExample :=
+  { id := "bondarenko2022_ch2_121a"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (121a)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Mina-ka Swuna-ka mwuncey-lul phwul-ess-ta-nun cwucang-ul kiekhay-ss-ta."
+    discourseSegments := []
+    glossedTokens := [("Mina-ka", "Mina-NOM"), ("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-ess-ta-nun", "solve-PST-DECL-ADN"), ("cwucang-ul", "claim-ACC"), ("kiekhay-ss-ta", "remember-PST-DECL")]
+    translation := "Mina remembers that Swuna solved the problem."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("nounSort", "content"), ("role", "premise-a")]
+    comment := "Premise (a) of the (121) opacity triple: with Cont-NP cwucang 'claim', premises (a),(b) do not entail conclusion (c)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_121b : LinguisticExample :=
+  { id := "bondarenko2022_ch2_121b"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (121b)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Swuna-ka pan-eyse kacang khi-ga khu-ta."
+    discourseSegments := []
+    glossedTokens := [("Swuna-ka", "Swuna-NOM"), ("pan-eyse", "class-LOC"), ("kacang", "most"), ("khi-ga", "height-NOM"), ("khu-ta", "large-DECL")]
+    translation := "Swuna is the tallest in the class."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("role", "premise-b")]
+    comment := "Identity premise (b) of the (121) opacity triple."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_121c : LinguisticExample :=
+  { id := "bondarenko2022_ch2_121c"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (121c)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Mina-ka pan-eyse kacang khi-ga khun sonye-ka mwuncey-lul phwul-ess-ta-nun cwucang-ul kiekhay-ss-ta."
+    discourseSegments := []
+    glossedTokens := [("Mina-ka", "Mina-NOM"), ("pan-eyse", "class-LOC"), ("kacang", "most"), ("khi-ga", "height-NOM"), ("khun", "large"), ("sonye-ka", "girl-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-ess-ta-nun", "solve-PST-DECL-ADN"), ("cwucang-ul", "claim-ACC"), ("kiekhay-ss-ta", "remember-PST-DECL")]
+    translation := "Mina remembers that the tallest girl in the class solved the problem."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("nounSort", "content"), ("role", "conclusion")]
+    comment := "Conclusion (c) of the (121) opacity triple: does not follow from (a),(b) — Cont-CPs are referentially opaque."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_122a : LinguisticExample :=
+  { id := "bondarenko2022_ch2_122a"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (122a)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Mina-ka Swuna-ka mwuncey-lul phwul-un sanghwang-ul kiekhay-ss-ta."
+    discourseSegments := []
+    glossedTokens := [("Mina-ka", "Mina-NOM"), ("Swuna-ka", "Swuna-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-un", "solve-ADN"), ("sanghwang-ul", "situation-ACC"), ("kiekhay-ss-ta", "remember-PST-DECL")]
+    translation := "Mina remembers that Swuna solved the problem."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("nounSort", "situation"), ("role", "premise-a")]
+    comment := "Premise (a) of the (122) transparency triple: with Sit-NP sanghwang 'situation', premises (a),(b) entail conclusion (c)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_122b : LinguisticExample :=
+  { id := "bondarenko2022_ch2_122b"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (122b)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Swuna-ka pan-eyse kacang khi-ga khu-ta."
+    discourseSegments := []
+    glossedTokens := [("Swuna-ka", "Swuna-NOM"), ("pan-eyse", "class-LOC"), ("kacang", "most"), ("khi-ga", "height-NOM"), ("khu-ta", "large-DECL")]
+    translation := "Swuna is the tallest girl in the class."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("role", "premise-b")]
+    comment := "Identity premise (b) of the (122) transparency triple."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch2_122c : LinguisticExample :=
+  { id := "bondarenko2022_ch2_122c"
+    source := ⟨"bondarenko-2022", "§2.2.3 ex. (122c)"⟩
+    reportedIn := none
+    language := "kore1280"
+    primaryText := "Mina-ka pan-eyse kacang khi-ga khun sonye-ka mwuncey-lul phwul-un sanghwang-ul kiekhay-ss-ta."
+    discourseSegments := []
+    glossedTokens := [("Mina-ka", "Mina-NOM"), ("pan-eyse", "class-LOC"), ("kacang", "most"), ("khi-ga", "height-NOM"), ("khun", "large"), ("sonye-ka", "girl-NOM"), ("mwuncey-lul", "problem-ACC"), ("phwul-un", "solve-ADN"), ("sanghwang-ul", "situation-ACC"), ("kiekhay-ss-ta", "remember-PST-DECL")]
+    translation := "Mina remembers that the tallest girl in the class solved the problem."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "substitution"), ("nounSort", "situation"), ("role", "conclusion")]
+    comment := "Conclusion (c) of the (122) transparency triple: follows from (a),(b) — Sit-CPs are referentially transparent."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch4_30 : LinguisticExample :=
+  { id := "bondarenko2022_ch4_30"
+    source := ⟨"bondarenko-2022", "§4.3.1 ex. (30)"⟩
+    reportedIn := none
+    language := "russ1264"
+    primaryText := "Dugar mi:sgɘi zagaha ɘdj-ɘ: gɘ-žɘ han-a:"
+    discourseSegments := []
+    glossedTokens := [("Dugar", "Dugar.NOM"), ("mi:sgɘi", "cat.NOM"), ("zagaha", "fish"), ("ɘdj-ɘ:", "eat-PST"), ("gɘ-žɘ", "say-CVB"), ("han-a:", "think-PST")]
+    translation := "Dugar thought that the cat ate the fish."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "Cont-CP"), ("shape", "bare gɘ-žɘ clause")]
+    comment := "Barguzin Buryat. Bare CP: [... V-TENSE gɘ-žɘ] with the say-root gɘ plus converb -žɘ, combining directly with the verb. Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch4_31 : LinguisticExample :=
+  { id := "bondarenko2022_ch4_31"
+    source := ⟨"bondarenko-2022", "§4.3.1 ex. (31)"⟩
+    reportedIn := none
+    language := "russ1264"
+    primaryText := "Dugar mi:sgɘi-n zagaha ɘdj-ɘ:š-i:jɘ-(n’) han-a:"
+    discourseSegments := []
+    glossedTokens := [("Dugar", "Dugar.NOM"), ("mi:sgɘi-n", "cat-GEN"), ("zagaha", "fish"), ("ɘdj-ɘ:š-i:jɘ-(n’)", "eat-PART-ACC-(3)"), ("han-a:", "think-PST")]
+    translation := "Dugar remembered (an event of) the cat’s eating the fish."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "Sit-CP"), ("shape", "nominalized participial clause")]
+    comment := "Barguzin Buryat. Nominalized Sit-CP: [... V-PART-CASE], genitive subject, participial -A:šA plus obligatory case and optional possessive marking. Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ch4_32 : LinguisticExample :=
+  { id := "bondarenko2022_ch4_32"
+    source := ⟨"bondarenko-2022", "§4.3.1 ex. (32)"⟩
+    reportedIn := none
+    language := "russ1264"
+    primaryText := "Dugar mi:sgɘi-n zagaha ɘdj-ɘ: g-ɘ:š-i:jɘ-(n’) han-a:"
+    discourseSegments := []
+    glossedTokens := [("Dugar", "Dugar.NOM"), ("mi:sgɘi-n", "cat-GEN"), ("zagaha", "fish"), ("ɘdj-ɘ:", "eat-PST"), ("g-ɘ:š-i:jɘ-(n’)", "say-PART-ACC-(3)"), ("han-a:", "think-PST")]
+    translation := "Dugar remembers (a claim) that the cat ate the fish."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "Cont-CP"), ("shape", "nominalized gɘ-participial clause")]
+    comment := "Barguzin Buryat. Nominalized Cont-CP: [... V-TENSE g-ɘ:š-CASE], the say-root gɘ plus participial -A:šA plus case (fn. 10: hiatus between gɘ and ɘ:šɘ resolved by vowel deletion in gɘ). Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def all : List LinguisticExample := [ch2_105, ch2_106, ch2_107, ch2_108, ch2_109, ch2_110, ch2_111, ch2_112, ch2_120a, ch2_120b, ch2_120c, ch2_121a, ch2_121b, ch2_121c, ch2_122a, ch2_122b, ch2_122c, ch4_30, ch4_31, ch4_32]
+
+end Bondarenko2022.Examples

--- a/Linglib/Data/Examples/Major2024.json
+++ b/Linglib/Data/Examples/Major2024.json
@@ -1,0 +1,254 @@
+[
+  {
+    "id": "major2024_2",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (2)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur Tursun-(ni) göshnan-ni et-t-i de-p oyla-y-du.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["Tursun-(ni)", "Tursun-ACC"], ["göshnan-ni", "meatbread-ACC"],
+      ["et-t-i", "make-PST-3"], ["de-p", "say-CNV"], ["oyla-y-du", "think-NONPST-3"]
+    ],
+    "translation": "Mahinur thinks that Tursun made meatbread.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "dep-clause"],
+      ["matrixVerb", "oyla- 'think'"]
+    ],
+    "comment": "Baseline dep complement. Paper adds the literal translation 'Mahinur thinks (something), saying Tursun made meatbread.' The parenthesized -(ni) marks the optional accusative on the embedded subject.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_38",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (38)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur Tursun-ni ket-t-i de-p warqiri-d-i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["Tursun-ni", "Tursun-ACC"], ["ket-t-i", "leave-PST-3"],
+      ["de-p", "say-CNV"], ["warqiri-d-i", "scream-PST-3"]
+    ],
+    "translation": "Mahinur screamed, saying that Tursun left.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "dep-clause"],
+      ["matrixVerb", "warqira- 'scream'"]
+    ],
+    "comment": "The dep clause modifies unergative 'scream' and coerces it into a verb of speech: the matrix clause is simply 'Mahinur screamed', the dep clause adds the communicative content. Bracketing dropped from primaryText.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_39a",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (39a)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur birnémi-ler-ni dé-d-i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["birnémi-ler-ni", "one.what-PL-ACC"], ["dé-d-i", "say-PST-3"]
+    ],
+    "translation": "Mahinur said something.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mahinur dé-d-i.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subcategorization"],
+      ["verb", "de- 'say'"]
+    ],
+    "comment": "Paper prints '*(birnémi-ler-ni)': omitting the DP is ungrammatical (expanded into alternatives) — main-verb 'say' obligatorily introduces a DP complement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_39b",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (39b)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur warqiri-di.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["warqiri-di", "scream-PST-3"]
+    ],
+    "translation": "Mahinur screamed (*something).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mahinur birnémi-ler-ni warqiri-di.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subcategorization"],
+      ["verb", "warqira- 'scream'"]
+    ],
+    "comment": "Paper prints '(*birnémi-ler-ni)': adding the DP is ungrammatical (expanded into alternatives) — 'scream' is incompatible with a complement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_40a",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (40a)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur Tursun-ning ket-ken-lik-i-ni dé-d-i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["Tursun-ning", "Tursun-GEN"],
+      ["ket-ken-lik-i-ni", "leave-PTPL-COMP-3POSS-ACC"], ["dé-d-i", "say-PST-3"]
+    ],
+    "translation": "Mahinur said that Tursun left.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mahinur dé-d-i.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subcategorization"],
+      ["verb", "de- 'say'"]
+    ],
+    "comment": "Paper prints '*(Tursun-ning ket-ken-lik-i-ni)': omission is ungrammatical (expanded into alternatives) — 'say' obligatorily takes a (here participial) complement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_40b",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (40b)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur warqiri-di.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["warqiri-di", "scream-PST-3"]
+    ],
+    "translation": "Mahinur screamed (*that Tursun left).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mahinur Tursun-ning ket-ken-lik-i-ni warqiri-di.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subcategorization"],
+      ["verb", "warqira- 'scream'"]
+    ],
+    "comment": "Paper prints '(*Tursun-ning ket-ken-lik-i-ni)': adding the participial clause is ungrammatical (expanded into alternatives) — 'scream' rejects a clausal complement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_41a",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (41a)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur birnémi-ler-ni de-p warqiri-di.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["birnémi-ler-ni", "one.what-PL-ACC"], ["de-p", "say-CNV"],
+      ["warqiri-di", "scream-PST-3"]
+    ],
+    "translation": "Mahinur screamed, saying *(something).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mahinur de-p warqiri-di.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subcategorization-persistence"],
+      ["construction", "dep + scream"]
+    ],
+    "comment": "Paper prints '*(birnémi-ler-ni)': the subcategorization requirement of de- 'say' persists inside the adjoined dep clause — 'say' obligatorily introduces an internal argument even under 'scream'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_41b",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (41b)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Mahinur Tursun-ning ket-ken-lik-i-ni de-p warqiri-di.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mahinur", "Mahinur"], ["Tursun-ning", "Tursun-GEN"],
+      ["ket-ken-lik-i-ni", "leave-PTPL-COMP-3POSS-ACC"], ["de-p", "say-CNV"],
+      ["warqiri-di", "scream-PST-3"]
+    ],
+    "translation": "Mahinur screamed, saying *(that Tursun left).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mahinur de-p warqiri-di.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subcategorization-persistence"],
+      ["construction", "dep + scream"]
+    ],
+    "comment": "Paper prints '*(Tursun-ning ket-ken-lik-i-ni)': same persistence as (41a) with a clausal DP complement of 'say' inside the dep clause.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_49a",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (49a)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Tursun-ning ket-ken-lik (xewir)-i méni hayran qal-dur-d-i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Tursun-ning", "Tursun-GEN"], ["ket-ken-lik", "leave-PTPL.PST-COMP"],
+      ["(xewir)-i", "(news)-3POSS"], ["méni", "1SG.ACC"], ["hayran", "surprise"],
+      ["qal-dur-d-i", "remain-CAUS-PST-3"]
+    ],
+    "translation": "(The news) that Tursun left surprised me.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subject-position"],
+      ["clauseType", "participial"]
+    ],
+    "comment": "The participial clause can serve as the grammatical subject (with nominative case) of the psych predicate 'make surprised', unlike dep clauses (49b).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "major2024_49b",
+    "source": {"bibkey": "major-2024", "paperLabel": "ex. (49b)"},
+    "reportedIn": null,
+    "language": "uigh1240",
+    "primaryText": "Tursun-(ni) ket-t-i de-p (xewer) méni hayran qal-dur-d-i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Tursun-(ni)", "Tursun-ACC"], ["ket-t-i", "leave-PST-3"], ["de-p", "say-CNV"],
+      ["(xewer)", "news"], ["méni", "1SG.ACC"], ["hayran", "surprise"],
+      ["qal-dur-d-i", "remain-CAUS-PST-3"]
+    ],
+    "translation": "(The news) that Tursun left surprised me.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "subject-position"],
+      ["clauseType", "dep"]
+    ],
+    "comment": "Translation marked 'Intended:' in the paper — dep clauses cannot function as grammatical subjects. Fn. 18: grammatical only under a pro-dropped-subject parse ('S/he surprised me, saying that Tursun left').",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Major2024.lean
+++ b/Linglib/Data/Examples/Major2024.lean
@@ -1,0 +1,198 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Major2024` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Major2024.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Major2024.Examples`.
+-/
+
+namespace Major2024.Examples
+
+open Data.Examples
+
+def ex_2 : LinguisticExample :=
+  { id := "major2024_2"
+    source := ⟨"major-2024", "ex. (2)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur Tursun-(ni) göshnan-ni et-t-i de-p oyla-y-du."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("Tursun-(ni)", "Tursun-ACC"), ("göshnan-ni", "meatbread-ACC"), ("et-t-i", "make-PST-3"), ("de-p", "say-CNV"), ("oyla-y-du", "think-NONPST-3")]
+    translation := "Mahinur thinks that Tursun made meatbread."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "dep-clause"), ("matrixVerb", "oyla- 'think'")]
+    comment := "Baseline dep complement. Paper adds the literal translation 'Mahinur thinks (something), saying Tursun made meatbread.' The parenthesized -(ni) marks the optional accusative on the embedded subject."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_38 : LinguisticExample :=
+  { id := "major2024_38"
+    source := ⟨"major-2024", "ex. (38)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur Tursun-ni ket-t-i de-p warqiri-d-i."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("Tursun-ni", "Tursun-ACC"), ("ket-t-i", "leave-PST-3"), ("de-p", "say-CNV"), ("warqiri-d-i", "scream-PST-3")]
+    translation := "Mahinur screamed, saying that Tursun left."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "dep-clause"), ("matrixVerb", "warqira- 'scream'")]
+    comment := "The dep clause modifies unergative 'scream' and coerces it into a verb of speech: the matrix clause is simply 'Mahinur screamed', the dep clause adds the communicative content. Bracketing dropped from primaryText."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_39a : LinguisticExample :=
+  { id := "major2024_39a"
+    source := ⟨"major-2024", "ex. (39a)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur birnémi-ler-ni dé-d-i."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("birnémi-ler-ni", "one.what-PL-ACC"), ("dé-d-i", "say-PST-3")]
+    translation := "Mahinur said something."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mahinur dé-d-i.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "subcategorization"), ("verb", "de- 'say'")]
+    comment := "Paper prints '*(birnémi-ler-ni)': omitting the DP is ungrammatical (expanded into alternatives) — main-verb 'say' obligatorily introduces a DP complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_39b : LinguisticExample :=
+  { id := "major2024_39b"
+    source := ⟨"major-2024", "ex. (39b)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur warqiri-di."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("warqiri-di", "scream-PST-3")]
+    translation := "Mahinur screamed (*something)."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mahinur birnémi-ler-ni warqiri-di.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "subcategorization"), ("verb", "warqira- 'scream'")]
+    comment := "Paper prints '(*birnémi-ler-ni)': adding the DP is ungrammatical (expanded into alternatives) — 'scream' is incompatible with a complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_40a : LinguisticExample :=
+  { id := "major2024_40a"
+    source := ⟨"major-2024", "ex. (40a)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur Tursun-ning ket-ken-lik-i-ni dé-d-i."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("Tursun-ning", "Tursun-GEN"), ("ket-ken-lik-i-ni", "leave-PTPL-COMP-3POSS-ACC"), ("dé-d-i", "say-PST-3")]
+    translation := "Mahinur said that Tursun left."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mahinur dé-d-i.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "subcategorization"), ("verb", "de- 'say'")]
+    comment := "Paper prints '*(Tursun-ning ket-ken-lik-i-ni)': omission is ungrammatical (expanded into alternatives) — 'say' obligatorily takes a (here participial) complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_40b : LinguisticExample :=
+  { id := "major2024_40b"
+    source := ⟨"major-2024", "ex. (40b)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur warqiri-di."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("warqiri-di", "scream-PST-3")]
+    translation := "Mahinur screamed (*that Tursun left)."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mahinur Tursun-ning ket-ken-lik-i-ni warqiri-di.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "subcategorization"), ("verb", "warqira- 'scream'")]
+    comment := "Paper prints '(*Tursun-ning ket-ken-lik-i-ni)': adding the participial clause is ungrammatical (expanded into alternatives) — 'scream' rejects a clausal complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_41a : LinguisticExample :=
+  { id := "major2024_41a"
+    source := ⟨"major-2024", "ex. (41a)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur birnémi-ler-ni de-p warqiri-di."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("birnémi-ler-ni", "one.what-PL-ACC"), ("de-p", "say-CNV"), ("warqiri-di", "scream-PST-3")]
+    translation := "Mahinur screamed, saying *(something)."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mahinur de-p warqiri-di.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "subcategorization-persistence"), ("construction", "dep + scream")]
+    comment := "Paper prints '*(birnémi-ler-ni)': the subcategorization requirement of de- 'say' persists inside the adjoined dep clause — 'say' obligatorily introduces an internal argument even under 'scream'."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_41b : LinguisticExample :=
+  { id := "major2024_41b"
+    source := ⟨"major-2024", "ex. (41b)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Mahinur Tursun-ning ket-ken-lik-i-ni de-p warqiri-di."
+    discourseSegments := []
+    glossedTokens := [("Mahinur", "Mahinur"), ("Tursun-ning", "Tursun-GEN"), ("ket-ken-lik-i-ni", "leave-PTPL-COMP-3POSS-ACC"), ("de-p", "say-CNV"), ("warqiri-di", "scream-PST-3")]
+    translation := "Mahinur screamed, saying *(that Tursun left)."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mahinur de-p warqiri-di.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("diagnostic", "subcategorization-persistence"), ("construction", "dep + scream")]
+    comment := "Paper prints '*(Tursun-ning ket-ken-lik-i-ni)': same persistence as (41a) with a clausal DP complement of 'say' inside the dep clause."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_49a : LinguisticExample :=
+  { id := "major2024_49a"
+    source := ⟨"major-2024", "ex. (49a)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Tursun-ning ket-ken-lik (xewir)-i méni hayran qal-dur-d-i."
+    discourseSegments := []
+    glossedTokens := [("Tursun-ning", "Tursun-GEN"), ("ket-ken-lik", "leave-PTPL.PST-COMP"), ("(xewir)-i", "(news)-3POSS"), ("méni", "1SG.ACC"), ("hayran", "surprise"), ("qal-dur-d-i", "remain-CAUS-PST-3")]
+    translation := "(The news) that Tursun left surprised me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "subject-position"), ("clauseType", "participial")]
+    comment := "The participial clause can serve as the grammatical subject (with nominative case) of the psych predicate 'make surprised', unlike dep clauses (49b)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_49b : LinguisticExample :=
+  { id := "major2024_49b"
+    source := ⟨"major-2024", "ex. (49b)"⟩
+    reportedIn := none
+    language := "uigh1240"
+    primaryText := "Tursun-(ni) ket-t-i de-p (xewer) méni hayran qal-dur-d-i."
+    discourseSegments := []
+    glossedTokens := [("Tursun-(ni)", "Tursun-ACC"), ("ket-t-i", "leave-PST-3"), ("de-p", "say-CNV"), ("(xewer)", "news"), ("méni", "1SG.ACC"), ("hayran", "surprise"), ("qal-dur-d-i", "remain-CAUS-PST-3")]
+    translation := "(The news) that Tursun left surprised me."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "subject-position"), ("clauseType", "dep")]
+    comment := "Translation marked 'Intended:' in the paper — dep clauses cannot function as grammatical subjects. Fn. 18: grammatical only under a pro-dropped-subject parse ('S/he surprised me, saying that Tursun left')."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def all : List LinguisticExample := [ex_2, ex_38, ex_39a, ex_39b, ex_40a, ex_40b, ex_41a, ex_41b, ex_49a, ex_49b]
+
+end Major2024.Examples

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -1,5 +1,6 @@
 import Linglib.Studies.Bondarenko2022
 import Linglib.Fragments.Greek.StandardModern.Complementizers
+import Linglib.Data.Examples.Angelopoulos2026
 
 /-!
 # Angelopoulos 2026: On clausal complementation, once more
@@ -42,6 +43,9 @@ yields either composition mode.
   `Bondarenko2022.NominalSort` (§3.2 ex. 33–34)
 - `bareOtiAttested`, `transparency_conflates_axes` — the §7.3
   counterclaim against `Bondarenko2022.transparentSSMapping`
+
+Typed paradigm sentences (ex. 1, 31–34) live in `Angelopoulos2026.Examples`,
+generated from `Data/Examples/Angelopoulos2026.json`.
 -/
 
 namespace Angelopoulos2026

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -3,6 +3,7 @@ import Linglib.Semantics.Attitudes.ClauseDenotation.Situation
 import Linglib.Fragments.Buryat.Complementizers
 import Linglib.Fragments.Korean.Complementizers
 import Linglib.Syntax.Clause.Complementation
+import Linglib.Data.Examples.Bondarenko2022
 
 /-!
 # Bondarenko 2022: Anatomy of an Attitude
@@ -54,6 +55,9 @@ theorem lands here), ch. 5 polarity subjunctives (Russian NPI data,
 L-analyticity), and the morphological exposition of ContP, which lives in
 `Fragments/Buryat/Complementizers.lean` and
 `Fragments/Korean/Complementizers.lean`.
+
+Typed paradigm sentences (§2.2.3 ex. 105–112, 120–122; §4.3.1 ex. 30–32) live
+in `Bondarenko2022.Examples`, generated from `Data/Examples/Bondarenko2022.json`.
 -/
 
 namespace Bondarenko2022

--- a/Linglib/Studies/Major2024.lean
+++ b/Linglib/Studies/Major2024.lean
@@ -1,4 +1,5 @@
 import Linglib.Fragments.Uyghur.Complementizers
+import Linglib.Data.Examples.Major2024
 
 /-!
 # Major 2024: Re-analyzing 'say' complementation
@@ -51,6 +52,9 @@ status altogether. Major does not engage that analysis (he cites only
 [bondarenko-2020] among factivity-alternation accounts, §3.2), so no
 divergence theorem is stated here; the two witnesses coexist as rival
 records over their respective fragment inventories.
+
+Typed paradigm sentences (his 2, 38–41, 49) live in `Major2024.Examples`,
+generated from `Data/Examples/Major2024.json`.
 -/
 
 namespace Major2024


### PR DESCRIPTION
JSON-ifies the complementation cluster's paradigm sentences via the gen_examples.py pipeline: 42 rows — Bondarenko2022 (20: §2.2.3 noun diagnostics ex. 105–112, DP-substitution triples ex. 120–122, the three Buryat clause shapes §4.3.1 ex. 30–32, ɘ restored), Angelopoulos2026 (12: ex. 1, P-ban ex. 31–32, noun diagnostics ex. 33–34), Major2024 (10: ex. 2, coercion/subcategorization ex. 38–41, subject ban ex. 49). Verbatim-only transcription; slash-alternations expanded per the Schwarz pattern; three judgment calls flagged in row comments (gloss artifact in ex. 107, possible gloss swap in Angelopoulos ex. 34b, paper's own 'occured' kept). Study files gain only the Examples import + docstring pointer.