### PR TITLE
refactor(Phonology/Tone): graduate UTP substrate to Tone/Plateauing

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2943,5 +2943,6 @@ import Linglib.Data.Examples.DegenTonhauser2021
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.Krifka1998
 import Linglib.Phonology.Tone.Plateauing
+import Linglib.Phonology.Tone.Surfacing
 
 

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2942,6 +2942,7 @@ import Linglib.Data.Examples.RotterLiu2025
 import Linglib.Data.Examples.DegenTonhauser2021
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.Krifka1998
+import Linglib.Phonology.Autosegmental.Hull
 import Linglib.Phonology.Tone.Plateauing
 import Linglib.Phonology.Tone.Surfacing
 

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -119,6 +119,7 @@ import Linglib.Core.Data.List.Chain
 import Linglib.Core.Data.List.Destutter
 import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Data.List.Factors
+import Linglib.Core.Data.List.TakeDrop
 import Linglib.Core.Data.RoseTree.Basic
 import Linglib.Core.Data.RoseTree.Get
 import Linglib.Core.Data.RoseTree.Traversable
@@ -2941,5 +2942,6 @@ import Linglib.Data.Examples.RotterLiu2025
 import Linglib.Data.Examples.DegenTonhauser2021
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.Krifka1998
+import Linglib.Phonology.Tone.Plateauing
 
 

--- a/Linglib/Core/Data/List/TakeDrop.lean
+++ b/Linglib/Core/Data/List/TakeDrop.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.TakeDrop
+
+/-!
+# Membership in `take` and `drop`, positionally
+
+`getElem?`-indexed characterizations of membership in a prefix or suffix. Candidates
+for `Mathlib/Data/List/TakeDrop.lean`.
+-/
+
+namespace List
+
+variable {α : Type*} {a : α} {w : List α} {k : ℕ}
+
+theorem mem_take_iff : a ∈ w.take k ↔ ∃ j < k, w[j]? = some a := by
+  simp [List.mem_iff_getElem?, List.getElem?_take]
+
+theorem mem_drop_iff : a ∈ w.drop k ↔ ∃ j ≥ k, w[j]? = some a := by
+  simp only [List.mem_iff_getElem?, List.getElem?_drop]
+  exact ⟨fun ⟨t, ht⟩ => ⟨k + t, Nat.le_add_right k t, ht⟩,
+    fun ⟨j, hkj, hj⟩ => ⟨j - k, by rwa [Nat.add_sub_cancel' hkj]⟩⟩
+
+end List

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -142,6 +142,20 @@ theorem isLinkedLower_iff {j : ℕ} : r.IsLinkedLower j ↔ ∃ i, (i, j) ∈ r.
   · rintro ⟨i, hi⟩
     exact ⟨(i, j), hi, rfl⟩
 
+/-- Lower node `j` **surfaces with** label `a`: some `a`-labeled upper node is linked
+to it — the labeled refinement of `IsLinkedLower`. -/
+def SurfacesWith (a : α) (j : ℕ) : Prop :=
+  ∃ i, (i, j) ∈ r.links ∧ r.upper.get? i = some a
+
+theorem SurfacesWith.isLinkedLower {a : α} {j : ℕ} (h : r.SurfacesWith a j) :
+    r.IsLinkedLower j :=
+  r.isLinkedLower_iff.mpr ⟨h.choose, h.choose_spec.1⟩
+
+instance [DecidableEq α] (a : α) (j : ℕ) : Decidable (r.SurfacesWith a j) :=
+  decidable_of_iff (∃ p ∈ r.links, p.2 = j ∧ r.upper.get? p.1 = some a)
+    ⟨fun ⟨⟨pi, pj⟩, hp, hj, ha⟩ => ⟨pi, by subst hj; exact hp, ha⟩,
+      fun ⟨i, hl, ha⟩ => ⟨(i, j), hl, rfl, ha⟩⟩
+
 /-- Upper index `i` is **floating**: in-bounds but unlinked. -/
 def IsFloatingUpper (i : ℕ) : Prop :=
   i < r.upper.len ∧ ¬ r.IsLinkedUpper i

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.AR
+
+/-!
+# The association hull
+
+`Graph.hull` closes each upper node's association set to its interval hull on the lower
+tier: `(k, j)` is a hull link iff `j` lies between two of `k`'s links. This is the
+representational content of tonal spreading-to-a-span: [hyman-katamba-2010]'s plateauing
+rule, applied after OCP-fusion, is exactly the hull of the fused H's associations
+(`Phonology/Tone/Plateauing`).
+
+Hull-closure of a multi-node melody can violate the no-crossing constraint (two
+interleaved hulls cross); the phonological operation applies to the fused
+representation, where the melody is a single node and the hull is planar.
+
+## Main results
+
+* `mem_hull_links` — hull membership as flanking, for in-bounds graphs.
+* `links_subset_hull` — the hull extends the link set.
+* `hull_convex` — per-node convexity: the defining property of the hull.
+* `AR.hull` — the operation on well-formed representations.
+-/
+
+namespace Autosegmental
+
+variable {α β : Type*}
+
+namespace Graph
+
+/-- Close each upper node's association set to its interval hull on the lower tier. -/
+def hull (r : Graph α β) : Graph α β where
+  upper := r.upper
+  lower := r.lower
+  links := (Finset.range r.upper.len ×ˢ Finset.range r.lower.len).filter fun p =>
+    (∃ q ∈ r.links, q.1 = p.1 ∧ q.2 ≤ p.2) ∧ ∃ q ∈ r.links, q.1 = p.1 ∧ p.2 ≤ q.2
+
+@[simp] theorem hull_upper (r : Graph α β) : r.hull.upper = r.upper := rfl
+
+@[simp] theorem hull_lower (r : Graph α β) : r.hull.lower = r.lower := rfl
+
+/-- Hull membership, on an in-bounds graph: `j` lies between two of `k`'s links. -/
+theorem mem_hull_links {r : Graph α β} (hr : r.InBounds) {k j : ℕ} :
+    (k, j) ∈ r.hull.links
+      ↔ ∃ j₁ j₂, (k, j₁) ∈ r.links ∧ (k, j₂) ∈ r.links ∧ j₁ ≤ j ∧ j ≤ j₂ := by
+  simp only [hull, Finset.mem_filter, Finset.mem_product, Finset.mem_range]
+  constructor
+  · rintro ⟨-, ⟨⟨k₁, j₁⟩, h₁, rfl, hle₁⟩, ⟨k₂, j₂⟩, h₂, hk₂, hle₂⟩
+    subst hk₂
+    exact ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩
+  · rintro ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩
+    exact ⟨⟨(hr _ h₁).1, lt_of_le_of_lt hle₂ (hr _ h₂).2⟩,
+      ⟨(k, j₁), h₁, rfl, hle₁⟩, ⟨(k, j₂), h₂, rfl, hle₂⟩⟩
+
+/-- The hull stays in bounds. -/
+theorem InBounds.hull {r : Graph α β} (hr : r.InBounds) : r.hull.InBounds := fun p hp => by
+  simpa [Finset.mem_product] using (Finset.mem_filter.mp hp).1
+
+/-- Links flank themselves: the hull extends the link set. -/
+theorem links_subset_hull {r : Graph α β} (hr : r.InBounds) : r.links ⊆ r.hull.links :=
+  fun ⟨k, j⟩ hp => (mem_hull_links hr).mpr ⟨j, j, hp, hp, le_rfl, le_rfl⟩
+
+/-- Per-node convexity: the defining property of the hull. -/
+theorem hull_convex {r : Graph α β} (hr : r.InBounds) {k j₁ j j₂ : ℕ}
+    (h₁ : (k, j₁) ∈ r.hull.links) (h₂ : (k, j₂) ∈ r.hull.links) (hle₁ : j₁ ≤ j)
+    (hle₂ : j ≤ j₂) : (k, j) ∈ r.hull.links := by
+  obtain ⟨a₁, -, ha₁, -, hle₃, -⟩ := (mem_hull_links hr).mp h₁
+  obtain ⟨-, a₂, -, ha₂, -, hle₄⟩ := (mem_hull_links hr).mp h₂
+  exact (mem_hull_links hr).mpr ⟨a₁, a₂, ha₁, ha₂, by omega, by omega⟩
+
+/-- Surfacing through the hull: a same-node flanking pair with the right label. -/
+theorem surfacesWith_hull {r : Graph α β} (hr : r.InBounds) {a : α} {j : ℕ} :
+    r.hull.SurfacesWith a j
+      ↔ ∃ i j₁ j₂, (i, j₁) ∈ r.links ∧ (i, j₂) ∈ r.links ∧ j₁ ≤ j ∧ j ≤ j₂
+          ∧ r.upper.get? i = some a := by
+  constructor
+  · rintro ⟨i, hlink, hlabel⟩
+    obtain ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩ := (mem_hull_links hr).mp hlink
+    exact ⟨i, j₁, j₂, h₁, h₂, hle₁, hle₂, hlabel⟩
+  · rintro ⟨i, j₁, j₂, h₁, h₂, hle₁, hle₂, hlabel⟩
+    exact ⟨i, (mem_hull_links hr).mpr ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩, hlabel⟩
+
+end Graph
+
+/-- The hull on well-formed representations. -/
+def AR.hull (A : AR α β) : AR α β where
+  toGraph := A.toGraph.hull
+  inBounds := A.inBounds.hull
+
+@[simp] theorem AR.hull_upper (A : AR α β) : A.hull.upper = A.upper := rfl
+
+@[simp] theorem AR.hull_lower (A : AR α β) : A.hull.lower = A.lower := rfl
+
+end Autosegmental

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Finset.Max
 import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Data.List.TakeDrop
 import Linglib.Core.Computability.Subregular.Function.Bimachine
+import Linglib.Phonology.Tone.Surfacing
 
 /-!
 # Unbounded tonal plateauing
@@ -14,8 +15,9 @@ import Linglib.Core.Computability.Subregular.Function.Bimachine
 [hyman-katamba-2010]'s plateauing rule for Luganda: every tone-bearing unit between two
 H-toned units surfaces H. Formalized over the string rendering of [jardine-2016]: a word
 over `TBU` records each timing unit's association state (`H` associated to a H tone, `O`
-unassociated), and `utp` rewrites it pointwise by `SurfacesH` — a position surfaces H iff
-some H lies at or before it and some H at or after it.
+unassociated), and `utp` — a `Tone.Surfacing` process — rewrites it pointwise by
+`SurfacesH`: a position surfaces H iff some H lies at or before it and some H at or
+after it. The map is `utp.map`, the surfacing set `plateau`.
 
 The map is the flagship *unbounded circumambient* process: whether a position changes
 depends on unboundedly distant material on **both** sides
@@ -29,7 +31,7 @@ rendering) and `Studies/Yolyan2025` (BMRS rendering).
 * `Tone.Plateauing.TBU` — the H/Ø string alphabet (association states; distinct from
   `Tone.TBUKind`, the phonological typology of timing units).
 * `Tone.Plateauing.SurfacesH` — position `i` of `w` surfaces with a H tone.
-* `Tone.Plateauing.utp` — the plateauing map.
+* `Tone.Plateauing.utp` — plateauing as a `Tone.Surfacing` process; `utp.map` the map.
 * `Tone.Plateauing.plateau` — the set of surfacing positions.
 
 ## Main results
@@ -103,59 +105,62 @@ theorem surfacesH_split {a : TBU} (h : w[i]? = some a) :
     rw [SurfacesH, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
     simp [ha, Ne.symm ha]
 
-/-! ### The plateauing map -/
+/-! ### The plateauing process -/
 
-/-- The unbounded tonal plateauing map: every TBU between two H-toned TBUs surfaces as
-H; everything else is unchanged. -/
-def utp (w : List TBU) : List TBU := w.mapIdx fun i _ => if SurfacesH w i then .H else .O
+/-- Unbounded tonal plateauing as a surfacing process: the marked tone `H` surfaces by
+`SurfacesH`; the map is `utp.map`. -/
+def utp : Surfacing TBU where
+  hi := .H
+  lo := .O
+  Surfaces := SurfacesH
+  hi_ne_lo := by decide
+  lt_length := SurfacesH.lt_length
+  surfaces_of_hi := surfacesH_of_getElem?_H
+  decSurfaces := fun _ _ => inferInstance
 
-@[simp] theorem utp_length : (utp w).length = w.length := by simp [utp]
+@[simp] theorem utp_hi : utp.hi = .H := rfl
+
+@[simp] theorem utp_lo : utp.lo = .O := rfl
+
+@[simp] theorem utp_Surfaces : utp.Surfaces = SurfacesH := rfl
 
 theorem utp_getElem? :
-    (utp w)[i]? = w[i]?.map fun _ => if SurfacesH w i then TBU.H else TBU.O := by
-  simp [utp, List.getElem?_mapIdx]
+    (utp.map w)[i]? = w[i]?.map fun _ => if SurfacesH w i then TBU.H else TBU.O :=
+  utp.map_getElem?
 
-theorem utp_getElem?_H_iff : (utp w)[j]? = some .H ↔ SurfacesH w j := by
-  rw [utp_getElem?, Option.map_eq_some_iff]
-  constructor
-  · rintro ⟨a, -, ha⟩; by_contra hs; rw [if_neg hs] at ha; exact TBU.noConfusion ha
-  · exact fun hs => ⟨w[j]'hs.lt_length, List.getElem?_eq_getElem hs.lt_length, if_pos hs⟩
+theorem utp_getElem?_H_iff : (utp.map w)[j]? = some .H ↔ SurfacesH w j :=
+  utp.map_getElem?_hi_iff
 
-theorem utp_getElem?_O_iff : (utp w)[j]? = some .O ↔ j < w.length ∧ ¬ SurfacesH w j := by
-  rw [utp_getElem?, Option.map_eq_some_iff]
-  constructor
-  · rintro ⟨a, ha, hout⟩
-    refine ⟨(List.getElem?_eq_some_iff.mp ha).1, fun hs => ?_⟩
-    rw [if_pos hs] at hout; exact TBU.noConfusion hout
-  · exact fun ⟨hj, hs⟩ => ⟨w[j], List.getElem?_eq_getElem hj, if_neg hs⟩
+theorem utp_getElem?_O_iff :
+    (utp.map w)[j]? = some .O ↔ j < w.length ∧ ¬ SurfacesH w j :=
+  utp.map_getElem?_lo_iff
 
 /-- Plateauing is symmetric under string reversal. -/
-theorem utp_reverse : utp w.reverse = (utp w).reverse := by
+theorem utp_reverse : utp.map w.reverse = (utp.map w).reverse := by
   refine List.ext_getElem? fun i => ?_
   by_cases hi : i < w.length
   · rw [utp_getElem?, List.getElem?_reverse (by simpa using hi),
-      List.getElem?_reverse (by simpa using hi), utp_length, utp_getElem?]
+      List.getElem?_reverse (by simpa using hi), Surfacing.map_length, utp_getElem?]
     simp only [surfacesH_reverse hi]
   · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by simp; omega)]
 
 /-! ### The plateau set -/
 
 /-- The plateau of `w`: the set of positions that surface H. -/
-def plateau (w : List TBU) : Finset ℕ := (Finset.range w.length).filter (SurfacesH w)
+def plateau (w : List TBU) : Finset ℕ := utp.support w
 
-@[simp] theorem mem_plateau : j ∈ plateau w ↔ SurfacesH w j := by
-  simp only [plateau, Finset.mem_filter, Finset.mem_range, and_iff_right_iff_imp]
-  exact SurfacesH.lt_length
+@[simp] theorem mem_plateau : j ∈ plateau w ↔ SurfacesH w j := utp.mem_support
 
 @[simp] theorem plateau_nonempty : (plateau w).Nonempty ↔ .H ∈ w :=
   ⟨fun ⟨_, hj⟩ => (mem_plateau.mp hj).H_mem, fun hw =>
     have ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     ⟨i, mem_plateau.mpr (surfacesH_of_getElem?_H hi)⟩⟩
 
-/-- `utp` writes the indicator word of its plateau. -/
+/-- `utp.map` writes the indicator word of its plateau. -/
 theorem utp_eq_plateau_indicator :
-    utp w = (List.range w.length).map fun i => if i ∈ plateau w then TBU.H else TBU.O :=
-  List.ext_getElem (by simp [utp]) fun i h₁ h₂ => by simp [utp, mem_plateau]
+    utp.map w
+      = (List.range w.length).map fun i => if i ∈ plateau w then TBU.H else TBU.O :=
+  utp.map_eq_indicator
 
 /-- Sandwich characterization: a word with Hs at `lo` and `hi` and none outside
 `[lo, hi]` has plateau exactly `Finset.Icc lo hi`. -/
@@ -184,11 +189,12 @@ Plateauing is a closure operator in the pointwise H-order: extensive
 engine is convexity: the output's Hs are the plateau, an interval, so plateauing the
 output surfaces nothing new (`surfacesH_utp`). -/
 
-@[simp] theorem utp_nil : utp [] = [] := rfl
+@[simp] theorem utp_nil : utp.map [] = [] := rfl
 
 /-- Extensivity: every H survives plateauing. -/
-theorem utp_getElem?_H_of_getElem?_H (h : w[i]? = some .H) : (utp w)[i]? = some .H :=
-  utp_getElem?_H_iff.mpr (surfacesH_of_getElem?_H h)
+theorem utp_getElem?_H_of_getElem?_H (h : w[i]? = some .H) :
+    (utp.map w)[i]? = some .H :=
+  utp.map_getElem?_hi_of_getElem?_hi h
 
 /-- Surfacing is monotone in the word's H-set. -/
 theorem SurfacesH.mono {w' : List TBU}
@@ -200,12 +206,12 @@ theorem SurfacesH.mono {w' : List TBU}
 /-- Monotonicity: pointwise more Hs in, pointwise more Hs out. -/
 theorem utp_mono {w' : List TBU}
     (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (j : ℕ)
-    (h : (utp w)[j]? = some TBU.H) : (utp w')[j]? = some TBU.H :=
+    (h : (utp.map w)[j]? = some TBU.H) : (utp.map w')[j]? = some TBU.H :=
   utp_getElem?_H_iff.mpr ((utp_getElem?_H_iff.mp h).mono hw)
 
 /-- Surfacing is invariant under plateauing: the output's Hs are the plateau, whose
 convexity flanks no new positions. -/
-theorem surfacesH_utp : SurfacesH (utp w) i ↔ SurfacesH w i := by
+theorem surfacesH_utp : SurfacesH (utp.map w) i ↔ SurfacesH w i := by
   constructor
   · intro h
     obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := surfacesH_iff.mp h
@@ -216,13 +222,13 @@ theorem surfacesH_utp : SurfacesH (utp w) i ↔ SurfacesH w i := by
   · exact fun h => surfacesH_iff.mpr ⟨⟨i, le_rfl, utp_getElem?_H_iff.mpr h⟩,
       i, le_rfl, utp_getElem?_H_iff.mpr h⟩
 
-@[simp] theorem plateau_utp : plateau (utp w) = plateau w := by
+@[simp] theorem plateau_utp : plateau (utp.map w) = plateau w := by
   ext j
   rw [mem_plateau, mem_plateau, surfacesH_utp]
 
 /-- Idempotence: a plateau is already closed. -/
-@[simp] theorem utp_utp : utp (utp w) = utp w := by
-  rw [utp_eq_plateau_indicator (w := utp w), plateau_utp, utp_length,
+@[simp] theorem utp_utp : utp.map (utp.map w) = utp.map w := by
+  rw [utp_eq_plateau_indicator (w := utp.map w), plateau_utp, Surfacing.map_length,
     ← utp_eq_plateau_indicator]
 
 /-! ### The plateauing rule
@@ -230,14 +236,14 @@ theorem surfacesH_utp : SurfacesH (utp w) i ↔ SurfacesH w i := by
 The rule schemata as theorems about `utp` rather than clauses of its definition. -/
 
 /-- A toneless word is unchanged. -/
-theorem utp_toneless (n : ℕ) : utp (List.replicate n .O) = List.replicate n .O := by
+theorem utp_toneless (n : ℕ) : utp.map (List.replicate n .O) = List.replicate n .O := by
   have h : plateau (List.replicate n TBU.O) = ∅ :=
     Finset.not_nonempty_iff_eq_empty.mp (by simp)
   simp [utp_eq_plateau_indicator, h, List.map_const']
 
 /-- A word with a single H is unchanged — one H cannot trigger a plateau. -/
 theorem utp_single (m n : ℕ) :
-    utp (List.replicate m .O ++ .H :: List.replicate n .O)
+    utp.map (List.replicate m .O ++ .H :: List.replicate n .O)
       = List.replicate m .O ++ .H :: List.replicate n .O := by
   have hH : ∀ j, (List.replicate m TBU.O ++ TBU.H :: List.replicate n TBU.O)[j]? = some TBU.H
       ↔ j = m := fun j => by
@@ -254,7 +260,7 @@ theorem utp_single (m n : ℕ) :
 /-- Everything between the outermost Hs surfaces H; the medial material `w` is
 arbitrary. -/
 theorem utp_plateau (m p : ℕ) (w : List TBU) :
-    utp (List.replicate m .O ++ .H :: (w ++ .H :: List.replicate p .O))
+    utp.map (List.replicate m .O ++ .H :: (w ++ .H :: List.replicate p .O))
       = List.replicate m .O ++ (List.replicate (w.length + 2) .H ++ List.replicate p .O) := by
   have hb : ∀ j, (List.replicate m TBU.O ++ TBU.H :: (w ++ TBU.H :: List.replicate p TBU.O))[j]?
       = some TBU.H → m ≤ j ∧ j ≤ m + 1 + w.length := fun j hj => by
@@ -271,9 +277,9 @@ theorem utp_plateau (m p : ℕ) (w : List TBU) :
   split_ifs <;> first | rfl | omega
 
 /-- No plateau without two Hs; `HØØH ↦ HHHH`. -/
-example : utp [.O, .O, .O, .H] = [.O, .O, .O, .H] := by decide
-example : utp [.H, .O, .O, .O] = [.H, .O, .O, .O] := by decide
-example : utp [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
+example : utp.map [.O, .O, .O, .H] = [.O, .O, .O, .H] := by decide
+example : utp.map [.H, .O, .O, .O] = [.H, .O, .O, .O] := by decide
+example : utp.map [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
 
 /-! ### Unbounded circumambience
 
@@ -311,12 +317,12 @@ private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
 
 /-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
 plateau target, at every distance. -/
-theorem utp_requiresBothSides : RequiresBothSides utp := by
+theorem utp_requiresBothSides : RequiresBothSides utp.map := by
   intro d
   have hmid : ∀ x y : TBU, (flanked d x y)[d + 1]? = some .O := fun x y => by
     rw [flanked_getElem?, if_neg (by omega : ¬(d + 1 = 0)),
       if_neg (by omega : ¬(d + 1 = 2 * d + 3)), if_pos (by omega : d + 1 < 2 * d + 4)]
-  have himg : ∀ x y : TBU, (utp (flanked d x y))[d + 1]?
+  have himg : ∀ x y : TBU, (utp.map (flanked d x y))[d + 1]?
       = if x = .H ∧ y = .H then some .H else some .O := fun x y => by
     split_ifs with h
     · exact utp_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
@@ -339,7 +345,7 @@ theorem utp_requiresBothSides : RequiresBothSides utp := by
 
 /-- UTP is an unbounded circumambient process: whether a position changes depends on
 unboundedly distant material on both sides. -/
-theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp :=
+theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp.map :=
   utp_requiresBothSides.isUnboundedCircumambient
 
 end Tone.Plateauing

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -1,0 +1,295 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Finset.Max
+import Mathlib.Order.Interval.Finset.Nat
+import Linglib.Core.Data.List.TakeDrop
+import Linglib.Core.Computability.Subregular.Function.Bimachine
+
+/-!
+# Unbounded tonal plateauing
+
+[hyman-katamba-2010]'s plateauing rule for Luganda: every tone-bearing unit between two
+H-toned units surfaces H. Formalized over the string rendering of [jardine-2016]: a word
+over `TBU` records each timing unit's association state (`H` associated to a H tone, `O`
+unassociated), and `utp` rewrites it pointwise by `SurfacesH` — a position surfaces H iff
+some H lies at or before it and some H at or after it.
+
+The map is the flagship *unbounded circumambient* process: whether a position changes
+depends on unboundedly distant material on **both** sides
+(`utp_isUnboundedCircumambient`), and in the strong witness form
+`utp_requiresBothSides` — perturbing either far side alone reverts the change — which
+feeds the weak-determinism exclusion theorems of `Studies/Jardine2016Tone` (bimachine
+rendering) and `Studies/Yolyan2025` (BMRS rendering).
+
+## Main definitions
+
+* `Tone.Plateauing.TBU` — the H/Ø string alphabet (association states; distinct from
+  `Tone.TBUKind`, the phonological typology of timing units).
+* `Tone.Plateauing.SurfacesH` — position `i` of `w` surfaces with a H tone.
+* `Tone.Plateauing.utp` — the plateauing map.
+* `Tone.Plateauing.plateau` — the set of surfacing positions.
+
+## Main results
+
+* `utp_getElem?_H_iff` / `utp_getElem?_O_iff` — pointwise characterization of the map.
+* `utp_eq_plateau_indicator`, `plateau_eq_Icc` — the output is the indicator word of an
+  interval, from the first trigger to the last.
+* `utp_toneless`, `utp_single`, `utp_plateau` — the rule schemata: toneless words and
+  lone Hs are unchanged; everything between the outermost Hs surfaces H.
+* `utp_requiresBothSides` — deleting either flanking H reverts the plateau target, at
+  every distance.
+-/
+
+namespace Tone.Plateauing
+
+open Subregular
+
+/-! ### The tone-bearing-unit alphabet -/
+
+/-- A tone-bearing unit's association state: `H` is a TBU associated to a H tone, `O` an
+unspecified TBU ([jardine-2016]'s Ø). -/
+inductive TBU | H | O
+  deriving DecidableEq, Repr
+
+/-! ### Surfacing -/
+
+/-- TBU `i` of `w` surfaces with a H tone: some H-toned TBU sits at a position `≤ i` and
+some at a position `≥ i` — [hyman-katamba-2010]'s plateauing rule, pointwise. -/
+def SurfacesH (w : List TBU) (i : ℕ) : Prop := .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i
+
+instance (w : List TBU) (i : ℕ) : Decidable (SurfacesH w i) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+variable {w : List TBU} {i j k : ℕ}
+
+/-- Positionwise reading of `SurfacesH`: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
+theorem surfacesH_iff :
+    SurfacesH w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j ≥ i, w[j]? = some .H := by
+  rw [SurfacesH, List.mem_take_iff, List.mem_drop_iff]; simp [Nat.lt_succ_iff]
+
+theorem SurfacesH.lt_length (h : SurfacesH w i) : i < w.length := by
+  have h₂ := List.length_pos_of_mem h.2; rw [List.length_drop] at h₂; omega
+
+/-- The surfacing set is convex: `take`/`drop` windows only widen. -/
+theorem SurfacesH.of_le_of_le (hi : SurfacesH w i) (hk : SurfacesH w k) (hij : i ≤ j)
+    (hjk : j ≤ k) : SurfacesH w j :=
+  ⟨w.take_subset_take_left (by omega) hi.1, w.drop_subset_drop_left (by omega) hk.2⟩
+
+/-- A H-toned TBU surfaces H: it flanks itself. -/
+theorem surfacesH_of_getElem?_H (h : w[i]? = some .H) : SurfacesH w i :=
+  surfacesH_iff.mpr ⟨⟨i, le_rfl, h⟩, ⟨i, le_rfl, h⟩⟩
+
+theorem SurfacesH.H_mem (h : SurfacesH w i) : .H ∈ w := List.take_subset _ _ h.1
+
+/-- Reversal symmetry: under `reverse` the `take` and `drop` windows swap. -/
+theorem surfacesH_reverse (hi : i < w.length) :
+    SurfacesH w.reverse i ↔ SurfacesH w (w.length - 1 - i) := by
+  rw [SurfacesH, SurfacesH, List.take_reverse, List.drop_reverse, List.mem_reverse,
+    List.mem_reverse, show w.length - (i + 1) = w.length - 1 - i from by omega,
+    show w.length - i = (w.length - 1 - i) + 1 from by omega, and_comm]
+
+/-- TBU `i` surfaces H iff it is itself a H or is strictly flanked: split the `take`
+window at its last slot and the `drop` window at its head. -/
+theorem surfacesH_split {a : TBU} (h : w[i]? = some a) :
+    SurfacesH w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
+  rcases eq_or_ne a .H with rfl | ha
+  · simp [surfacesH_of_getElem?_H h]
+  · obtain ⟨hi, hia⟩ := List.getElem?_eq_some_iff.mp h
+    rw [SurfacesH, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
+    simp [ha, Ne.symm ha]
+
+/-! ### The plateauing map -/
+
+/-- The unbounded tonal plateauing map: every TBU between two H-toned TBUs surfaces as
+H; everything else is unchanged. -/
+def utp (w : List TBU) : List TBU := w.mapIdx fun i _ => if SurfacesH w i then .H else .O
+
+@[simp] theorem utp_length : (utp w).length = w.length := by simp [utp]
+
+theorem utp_getElem? :
+    (utp w)[i]? = w[i]?.map fun _ => if SurfacesH w i then TBU.H else TBU.O := by
+  simp [utp, List.getElem?_mapIdx]
+
+theorem utp_getElem?_H_iff : (utp w)[j]? = some .H ↔ SurfacesH w j := by
+  rw [utp_getElem?, Option.map_eq_some_iff]
+  constructor
+  · rintro ⟨a, -, ha⟩; by_contra hs; rw [if_neg hs] at ha; exact TBU.noConfusion ha
+  · exact fun hs => ⟨w[j]'hs.lt_length, List.getElem?_eq_getElem hs.lt_length, if_pos hs⟩
+
+theorem utp_getElem?_O_iff : (utp w)[j]? = some .O ↔ j < w.length ∧ ¬ SurfacesH w j := by
+  rw [utp_getElem?, Option.map_eq_some_iff]
+  constructor
+  · rintro ⟨a, ha, hout⟩
+    refine ⟨(List.getElem?_eq_some_iff.mp ha).1, fun hs => ?_⟩
+    rw [if_pos hs] at hout; exact TBU.noConfusion hout
+  · exact fun ⟨hj, hs⟩ => ⟨w[j], List.getElem?_eq_getElem hj, if_neg hs⟩
+
+/-- Plateauing is symmetric under string reversal. -/
+theorem utp_reverse : utp w.reverse = (utp w).reverse := by
+  refine List.ext_getElem? fun i => ?_
+  by_cases hi : i < w.length
+  · rw [utp_getElem?, List.getElem?_reverse (by simpa using hi),
+      List.getElem?_reverse (by simpa using hi), utp_length, utp_getElem?]
+    simp only [surfacesH_reverse hi]
+  · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by simp; omega)]
+
+/-! ### The plateau set -/
+
+/-- The plateau of `w`: the set of positions that surface H. -/
+def plateau (w : List TBU) : Finset ℕ := (Finset.range w.length).filter (SurfacesH w)
+
+@[simp] theorem mem_plateau : j ∈ plateau w ↔ SurfacesH w j := by
+  simp only [plateau, Finset.mem_filter, Finset.mem_range, and_iff_right_iff_imp]
+  exact SurfacesH.lt_length
+
+@[simp] theorem plateau_nonempty : (plateau w).Nonempty ↔ .H ∈ w :=
+  ⟨fun ⟨_, hj⟩ => (mem_plateau.mp hj).H_mem, fun hw =>
+    have ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
+    ⟨i, mem_plateau.mpr (surfacesH_of_getElem?_H hi)⟩⟩
+
+/-- `utp` writes the indicator word of its plateau. -/
+theorem utp_eq_plateau_indicator :
+    utp w = (List.range w.length).map fun i => if i ∈ plateau w then TBU.H else TBU.O :=
+  List.ext_getElem (by simp [utp]) fun i h₁ h₂ => by simp [utp, mem_plateau]
+
+/-- Sandwich characterization: a word with Hs at `lo` and `hi` and none outside
+`[lo, hi]` has plateau exactly `Finset.Icc lo hi`. -/
+theorem plateau_eq_Icc_of {lo hi : ℕ} (hlo : w[lo]? = some .H) (hhi : w[hi]? = some .H)
+    (hb : ∀ j, w[j]? = some .H → lo ≤ j ∧ j ≤ hi) : plateau w = Finset.Icc lo hi := by
+  ext j
+  rw [mem_plateau, Finset.mem_Icc, surfacesH_iff]
+  constructor
+  · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
+    have hb₁ := hb j₁ h₁; have hb₂ := hb j₂ h₂; omega
+  · exact fun hj => ⟨⟨lo, hj.1, hlo⟩, hi, hj.2, hhi⟩
+
+/-- The plateau is an interval, from the first trigger to the last. -/
+theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
+    plateau w = Finset.Icc ((plateau w).min' hne) ((plateau w).max' hne) := by
+  ext j
+  rw [Finset.mem_Icc]
+  refine ⟨fun hj => ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩, fun ⟨h₁, h₂⟩ =>
+    mem_plateau.mpr (SurfacesH.of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
+      (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)⟩
+
+/-! ### The plateauing rule
+
+The rule schemata as theorems about `utp` rather than clauses of its definition. -/
+
+/-- A toneless word is unchanged. -/
+theorem utp_toneless (n : ℕ) : utp (List.replicate n .O) = List.replicate n .O := by
+  have h : plateau (List.replicate n TBU.O) = ∅ :=
+    Finset.not_nonempty_iff_eq_empty.mp (by simp)
+  simp [utp_eq_plateau_indicator, h, List.map_const']
+
+/-- A word with a single H is unchanged — one H cannot trigger a plateau. -/
+theorem utp_single (m n : ℕ) :
+    utp (List.replicate m .O ++ .H :: List.replicate n .O)
+      = List.replicate m .O ++ .H :: List.replicate n .O := by
+  have hH : ∀ j, (List.replicate m TBU.O ++ TBU.H :: List.replicate n TBU.O)[j]? = some TBU.H
+      ↔ j = m := fun j => by
+    simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
+      List.length_replicate]
+    split_ifs <;> simp_all <;> omega
+  rw [utp_eq_plateau_indicator, plateau_eq_Icc_of ((hH m).mpr rfl) ((hH m).mpr rfl)
+    fun j hj => by rw [hH j] at hj; omega]
+  refine List.ext_getElem (by simp) fun i h₁ h₂ => ?_
+  simp only [List.getElem_map, List.getElem_range, List.getElem_append, List.getElem_cons,
+    List.getElem_replicate, List.length_replicate, Finset.mem_Icc]
+  split_ifs <;> first | rfl | omega
+
+/-- Everything between the outermost Hs surfaces H; the medial material `w` is
+arbitrary. -/
+theorem utp_plateau (m p : ℕ) (w : List TBU) :
+    utp (List.replicate m .O ++ .H :: (w ++ .H :: List.replicate p .O))
+      = List.replicate m .O ++ (List.replicate (w.length + 2) .H ++ List.replicate p .O) := by
+  have hb : ∀ j, (List.replicate m TBU.O ++ TBU.H :: (w ++ TBU.H :: List.replicate p TBU.O))[j]?
+      = some TBU.H → m ≤ j ∧ j ≤ m + 1 + w.length := fun j hj => by
+    simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
+      List.length_replicate] at hj
+    split_ifs at hj <;> first | omega | simp_all
+  rw [utp_eq_plateau_indicator, plateau_eq_Icc_of (by simp) (by
+      simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
+        List.length_replicate]
+      split_ifs <;> first | rfl | omega) hb]
+  refine List.ext_getElem (by simp; omega) fun i h₁ h₂ => ?_
+  simp only [List.getElem_map, List.getElem_range, List.getElem_append,
+    List.getElem_replicate, List.length_replicate, Finset.mem_Icc]
+  split_ifs <;> first | rfl | omega
+
+/-- No plateau without two Hs; `HØØH ↦ HHHH`. -/
+example : utp [.O, .O, .O, .H] = [.O, .O, .O, .H] := by decide
+example : utp [.H, .O, .O, .O] = [.H, .O, .O, .O] := by decide
+example : utp [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
+
+/-! ### Unbounded circumambience
+
+The witness family at distance `d`: `flanked d x y` puts `x` and `y` around `2d+2`
+toneless TBUs. The base `flanked d .H .H` is the plateau word with target `d+1`;
+flipping either flank to `.O` is the far perturbation that reverts it. -/
+
+/-- The distance-`d` witness word: flanks `x`, `y` around `2d+2` toneless TBUs. -/
+private def flanked (d : ℕ) (x y : TBU) : List TBU :=
+  x :: (List.replicate (2 * d + 2) .O ++ [y])
+
+private theorem flanked_length (d : ℕ) (x y : TBU) : (flanked d x y).length = 2 * d + 4 := by
+  simp [flanked]
+
+private theorem flanked_getElem? (d : ℕ) (x y : TBU) (j : ℕ) :
+    (flanked d x y)[j]? = if j = 0 then some x else if j = 2 * d + 3 then some y
+      else if j < 2 * d + 4 then some .O else none := by
+  simp only [flanked, List.getElem?_cons, List.getElem?_append, List.getElem?_replicate,
+    List.length_replicate, List.getElem?_nil]
+  split_ifs <;> first | rfl | omega
+
+/-- The target surfaces iff both flanks are H: the toneless fill offers no other
+trigger on either side. -/
+private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
+    SurfacesH (flanked d x y) (d + 1) ↔ x = .H ∧ y = .H := by
+  rw [surfacesH_iff]
+  constructor
+  · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
+    rw [flanked_getElem?] at h₁ h₂
+    split_ifs at h₁ h₂ <;> simp_all
+    omega
+  · rintro ⟨rfl, rfl⟩
+    exact ⟨⟨0, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩,
+      2 * d + 3, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩
+
+/-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
+plateau target, at every distance. -/
+theorem utp_requiresBothSides : RequiresBothSides utp := by
+  intro d
+  have hmid : ∀ x y : TBU, (flanked d x y)[d + 1]? = some .O := fun x y => by
+    rw [flanked_getElem?, if_neg (by omega : ¬(d + 1 = 0)),
+      if_neg (by omega : ¬(d + 1 = 2 * d + 3)), if_pos (by omega : d + 1 < 2 * d + 4)]
+  have himg : ∀ x y : TBU, (utp (flanked d x y))[d + 1]?
+      = if x = .H ∧ y = .H then some .H else some .O := fun x y => by
+    split_ifs with h
+    · exact utp_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
+    · exact utp_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
+        fun hs => h ((surfacesH_flanked_mid d).mp hs)⟩
+  have hagreeL : ∀ (x x' y : TBU) (k : ℕ), k ≠ 0 →
+      (flanked d x y)[k]? = (flanked d x' y)[k]? := fun x x' y k h0 => by
+    rw [flanked_getElem?, flanked_getElem?]; split_ifs <;> first | rfl | omega
+  have hagreeR : ∀ (x y y' : TBU) (k : ℕ), k ≠ 2 * d + 3 →
+      (flanked d x y)[k]? = (flanked d x y')[k]? := fun x y y' k h3 => by
+    rw [flanked_getElem?, flanked_getElem?]; split_ifs <;> rfl
+  refine ⟨flanked d .H .H, d + 1, by rw [flanked_length]; omega, ?_, ?_, ?_⟩
+  · rw [himg, hmid]; simp
+  · exact ⟨flanked d .O .H, by rw [flanked_length, flanked_length],
+      fun k hk => hagreeL _ _ _ k (by omega), by rw [hmid, hmid],
+      by rw [himg, hmid]; simp⟩
+  · exact ⟨flanked d .H .O, by rw [flanked_length, flanked_length],
+      fun k hk => hagreeR _ _ _ k (by omega), by rw [hmid, hmid],
+      by rw [himg, hmid]; simp⟩
+
+/-- UTP is an unbounded circumambient process: whether a position changes depends on
+unboundedly distant material on both sides. -/
+theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp :=
+  utp_requiresBothSides.isUnboundedCircumambient
+
+end Tone.Plateauing

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -39,6 +39,8 @@ rendering) and `Studies/Yolyan2025` (BMRS rendering).
   interval, from the first trigger to the last.
 * `utp_toneless`, `utp_single`, `utp_plateau` — the rule schemata: toneless words and
   lone Hs are unchanged; everything between the outermost Hs surfaces H.
+* `utp_getElem?_H_of_getElem?_H`, `utp_mono`, `utp_utp` — plateauing is a closure
+  operator in the pointwise H-order: extensive, monotone, idempotent.
 * `utp_requiresBothSides` — deleting either flanking H reverts the plateau target, at
   every distance.
 -/
@@ -174,6 +176,54 @@ theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
   refine ⟨fun hj => ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩, fun ⟨h₁, h₂⟩ =>
     mem_plateau.mpr (SurfacesH.of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
       (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)⟩
+
+/-! ### Closure laws
+
+Plateauing is a closure operator in the pointwise H-order: extensive
+(`utp_getElem?_H_of_getElem?_H`), monotone (`utp_mono`), idempotent (`utp_utp`). The
+engine is convexity: the output's Hs are the plateau, an interval, so plateauing the
+output surfaces nothing new (`surfacesH_utp`). -/
+
+@[simp] theorem utp_nil : utp [] = [] := rfl
+
+/-- Extensivity: every H survives plateauing. -/
+theorem utp_getElem?_H_of_getElem?_H (h : w[i]? = some .H) : (utp w)[i]? = some .H :=
+  utp_getElem?_H_iff.mpr (surfacesH_of_getElem?_H h)
+
+/-- Surfacing is monotone in the word's H-set. -/
+theorem SurfacesH.mono {w' : List TBU}
+    (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (h : SurfacesH w i) :
+    SurfacesH w' i := by
+  obtain ⟨⟨l, hl, hlH⟩, r, hr, hrH⟩ := surfacesH_iff.mp h
+  exact surfacesH_iff.mpr ⟨⟨l, hl, hw l hlH⟩, r, hr, hw r hrH⟩
+
+/-- Monotonicity: pointwise more Hs in, pointwise more Hs out. -/
+theorem utp_mono {w' : List TBU}
+    (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (j : ℕ)
+    (h : (utp w)[j]? = some TBU.H) : (utp w')[j]? = some TBU.H :=
+  utp_getElem?_H_iff.mpr ((utp_getElem?_H_iff.mp h).mono hw)
+
+/-- Surfacing is invariant under plateauing: the output's Hs are the plateau, whose
+convexity flanks no new positions. -/
+theorem surfacesH_utp : SurfacesH (utp w) i ↔ SurfacesH w i := by
+  constructor
+  · intro h
+    obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := surfacesH_iff.mp h
+    rw [utp_getElem?_H_iff] at h₁ h₂
+    obtain ⟨⟨l, hl, hlH⟩, -⟩ := surfacesH_iff.mp h₁
+    obtain ⟨-, r, hr, hrH⟩ := surfacesH_iff.mp h₂
+    exact surfacesH_iff.mpr ⟨⟨l, by omega, hlH⟩, r, by omega, hrH⟩
+  · exact fun h => surfacesH_iff.mpr ⟨⟨i, le_rfl, utp_getElem?_H_iff.mpr h⟩,
+      i, le_rfl, utp_getElem?_H_iff.mpr h⟩
+
+@[simp] theorem plateau_utp : plateau (utp w) = plateau w := by
+  ext j
+  rw [mem_plateau, mem_plateau, surfacesH_utp]
+
+/-- Idempotence: a plateau is already closed. -/
+@[simp] theorem utp_utp : utp (utp w) = utp w := by
+  rw [utp_eq_plateau_indicator (w := utp w), plateau_utp, utp_length,
+    ← utp_eq_plateau_indicator]
 
 /-! ### The plateauing rule
 

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -7,6 +7,11 @@ import Mathlib.Data.Finset.Max
 import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Data.List.TakeDrop
 import Linglib.Core.Computability.Subregular.Function.Bimachine
+import Linglib.Phonology.Autosegmental.Realization
+import Linglib.Phonology.Autosegmental.Collapse
+import Linglib.Phonology.Autosegmental.Junction
+import Linglib.Phonology.Autosegmental.Hull
+import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Tone.Surfacing
 
 /-!
@@ -15,9 +20,11 @@ import Linglib.Phonology.Tone.Surfacing
 [hyman-katamba-2010]'s plateauing rule for Luganda: every tone-bearing unit between two
 H-toned units surfaces H. Formalized over the string rendering of [jardine-2016]: a word
 over `TBU` records each timing unit's association state (`H` associated to a H tone, `O`
-unassociated), and `utp` — a `Tone.Surfacing` process — rewrites it pointwise by
-`SurfacesH`: a position surfaces H iff some H lies at or before it and some H at or
-after it. The map is `utp.map`, the surfacing set `plateau`.
+unassociated), and `utp` — a `Tone.Surfacing` process — rewrites it pointwise by its
+surfacing predicate. What surfaces is the *representation*: `utp.Surfaces w i` is by
+definition H-linkedness of timing node `i` in the output representation `plateauAR w`
+(the OCP-merged input, hull-closed — fusion then spreading); the string reading is the
+derived `utp_surfaces_def`. The map is `utp.map`, the surfacing set `plateau`.
 
 The map is the flagship *unbounded circumambient* process: whether a position changes
 depends on unboundedly distant material on **both** sides
@@ -30,7 +37,9 @@ rendering) and `Studies/Yolyan2025` (BMRS rendering).
 
 * `Tone.Plateauing.TBU` — the H/Ø string alphabet (association states; distinct from
   `Tone.TBUKind`, the phonological typology of timing units).
-* `Tone.Plateauing.SurfacesH` — position `i` of `w` surfaces with a H tone.
+* `Tone.Plateauing.plateauAR` — the output representation (OCP-merged input,
+  hull-closed); `utp.Surfaces` is H-linkedness in it, via `Graph.SurfacesWith` and
+  `Graph.hull` (`Phonology/Autosegmental/Hull.lean`).
 * `Tone.Plateauing.utp` — plateauing as a `Tone.Surfacing` process; `utp.map` the map.
 * `Tone.Plateauing.plateau` — the set of surfacing positions.
 
@@ -58,81 +67,152 @@ unspecified TBU ([jardine-2016]'s Ø). -/
 inductive TBU | H | O
   deriving DecidableEq, Repr
 
-/-! ### Surfacing -/
+/-! ### The output representation
 
-/-- TBU `i` of `w` surfaces with a H tone: some H-toned TBU sits at a position `≤ i` and
-some at a position `≥ i` — [hyman-katamba-2010]'s plateauing rule, pointwise. -/
-def SurfacesH (w : List TBU) (i : ℕ) : Prop := .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i
+The string rendering embeds into autosegmental representations, and plateauing on
+representations is OCP-fusion followed by hull-closure of the association lines
+([hyman-katamba-2010]'s rule as an operation on structures). What surfaces is the
+representation: `utp.Surfaces` is *by definition* H-linkedness in the output
+representation `plateauAR w`; the string-level `take`/`drop` reading is the derived
+characterization `utp_surfaces_def`. -/
 
-instance (w : List TBU) (i : ℕ) : Decidable (SurfacesH w i) :=
-  inferInstanceAs (Decidable (_ ∧ _))
+open Autosegmental
 
-variable {w : List TBU} {i j k : ℕ}
+/-- A H-toned TBU is one H melody node linked to its timing unit; a toneless TBU a bare
+timing unit. -/
+def toAR : TBU → AR _root_.Tone.TRN Unit
+  | .H => .single _root_.Tone.TRN.H ()
+  | .O => .bare ()
 
-/-- Positionwise reading of `SurfacesH`: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
-theorem surfacesH_iff :
-    SurfacesH w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j ≥ i, w[j]? = some .H := by
-  rw [SurfacesH, List.mem_take_iff, List.mem_drop_iff]; simp [Nat.lt_succ_iff]
+theorem linearize_realize_toAR (w : List TBU) :
+    (realize toAR w).linearize
+      = w.map fun a => ((), if a = .H then [_root_.Tone.TRN.H] else []) := by
+  rw [linearize_realize]
+  induction w with
+  | nil => rfl
+  | cons a w ih => rw [List.flatMap_cons, List.map_cons, ih]; cases a <;> simp [toAR]
 
-theorem SurfacesH.lt_length (h : SurfacesH w i) : i < w.length := by
-  have h₂ := List.length_pos_of_mem h.2; rw [List.length_drop] at h₂; omega
+theorem upper_realize_toAR (v : List TBU) :
+    (realize toAR v).upper.toList = List.replicate (v.count .H) _root_.Tone.TRN.H := by
+  induction v with
+  | nil => rfl
+  | cons a v ih =>
+    rw [realize_cons, AR.concat_upper, LabeledTuple.toList_concat, ih]
+    cases a <;> simp [toAR, List.replicate_succ]
 
-/-- The surfacing set is convex: `take`/`drop` windows only widen. -/
-theorem SurfacesH.of_le_of_le (hi : SurfacesH w i) (hk : SurfacesH w k) (hij : i ≤ j)
-    (hjk : j ≤ k) : SurfacesH w j :=
-  ⟨w.take_subset_take_left (by omega) hi.1, w.drop_subset_drop_left (by omega) hk.2⟩
+/-- A timing node of the input representation is linked iff its TBU is H-toned. -/
+theorem isLinkedLower_realize_toAR {w : List TBU} {j : ℕ} :
+    (realize toAR w).toGraph.IsLinkedLower j ↔ w[j]? = some .H := by
+  rw [AR.isLinkedLower_iff_linearize, linearize_realize_toAR]
+  cases hv : w[j]? with
+  | none => simp [List.getElem?_map, hv]
+  | some a => cases a <;> simp [List.getElem?_map, hv]
 
-/-- A H-toned TBU surfaces H: it flanks itself. -/
-theorem surfacesH_of_getElem?_H (h : w[i]? = some .H) : SurfacesH w i :=
-  surfacesH_iff.mpr ⟨⟨i, le_rfl, h⟩, ⟨i, le_rfl, h⟩⟩
+/-- The merged input representation: one fused H, linked to exactly the H-positions. -/
+theorem mem_links_realizeMerged_toAR {w : List TBU} {p : ℕ × ℕ} :
+    p ∈ (realizeMerged toAR w).links ↔ p.1 = 0 ∧ w[p.2]? = some TBU.H := by
+  rw [realizeMerged_def, mem_links_collapseAR_of_upper_replicate (upper_realize_toAR w),
+    isLinkedLower_realize_toAR]
 
-theorem SurfacesH.H_mem (h : SurfacesH w i) : .H ∈ w := List.take_subset _ _ h.1
+/-- With any H present, the fused melody node is the H at index `0`. -/
+theorem upper_get?_realizeMerged_toAR {w : List TBU} (hw : .H ∈ w) :
+    (realizeMerged toAR w).upper.get? 0 = some _root_.Tone.TRN.H := by
+  obtain ⟨n, hn⟩ : ∃ n, w.count .H = n + 1 :=
+    ⟨w.count .H - 1, by have := List.count_pos_iff.mpr hw; omega⟩
+  rw [LabeledTuple.get?_eq_getElem?, realizeMerged_def, upper_collapseAR,
+    upper_realize_toAR, hn, OCP.collapse_replicate]
+  rfl
 
-/-- Reversal symmetry: under `reverse` the `take` and `drop` windows swap. -/
-theorem surfacesH_reverse (hi : i < w.length) :
-    SurfacesH w.reverse i ↔ SurfacesH w (w.length - 1 - i) := by
-  rw [SurfacesH, SurfacesH, List.take_reverse, List.drop_reverse, List.mem_reverse,
-    List.mem_reverse, show w.length - (i + 1) = w.length - 1 - i from by omega,
-    show w.length - i = (w.length - 1 - i) + 1 from by omega, and_comm]
+/-- The output representation: fuse, then spread — the merged input, hull-closed. -/
+def plateauAR (w : List TBU) : AR _root_.Tone.TRN Unit := (realizeMerged toAR w).hull
 
-/-- TBU `i` surfaces H iff it is itself a H or is strictly flanked: split the `take`
-window at its last slot and the `drop` window at its head. -/
-theorem surfacesH_split {a : TBU} (h : w[i]? = some a) :
-    SurfacesH w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
-  rcases eq_or_ne a .H with rfl | ha
-  · simp [surfacesH_of_getElem?_H h]
-  · obtain ⟨hi, hia⟩ := List.getElem?_eq_some_iff.mp h
-    rw [SurfacesH, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
-    simp [ha, Ne.symm ha]
+/-- **What surfaces is the representation**: `i` is H-linked in `plateauAR w` iff some
+H-toned TBU lies at or before `i` and some at or after it — the string-level reading. -/
+theorem surfacesWith_plateauAR {w : List TBU} {i : ℕ} :
+    (plateauAR w).SurfacesWith _root_.Tone.TRN.H i ↔ .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i := by
+  rw [List.mem_take_iff, List.mem_drop_iff]
+  constructor
+  · rintro ⟨k, hlink, -⟩
+    obtain ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩ :=
+      (Graph.mem_hull_links (realizeMerged toAR w).inBounds).mp hlink
+    exact ⟨⟨j₁, by omega, (mem_links_realizeMerged_toAR.mp h₁).2⟩,
+      j₂, hle₂, (mem_links_realizeMerged_toAR.mp h₂).2⟩
+  · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
+    refine ⟨0, (Graph.mem_hull_links (realizeMerged toAR w).inBounds).mpr
+      ⟨j₁, j₂, mem_links_realizeMerged_toAR.mpr ⟨rfl, h₁⟩,
+        mem_links_realizeMerged_toAR.mpr ⟨rfl, h₂⟩, by omega, hj₂⟩, ?_⟩
+    exact upper_get?_realizeMerged_toAR (List.mem_iff_getElem?.mpr ⟨j₁, h₁⟩)
 
 /-! ### The plateauing process -/
 
-/-- Unbounded tonal plateauing as a surfacing process: the marked tone `H` surfaces by
-`SurfacesH`; the map is `utp.map`. -/
+/-- Unbounded tonal plateauing as a surfacing process: a TBU surfaces the marked tone
+`H` iff its timing node is H-linked in the output representation. -/
 def utp : Surfacing TBU where
   hi := .H
   lo := .O
-  Surfaces := SurfacesH
+  Surfaces w i := (plateauAR w).SurfacesWith _root_.Tone.TRN.H i
   hi_ne_lo := by decide
-  lt_length := SurfacesH.lt_length
-  surfaces_of_hi := surfacesH_of_getElem?_H
-  decSurfaces := fun _ _ => inferInstance
+  lt_length h := by
+    have h₂ := List.length_pos_of_mem (surfacesWith_plateauAR.mp h).2
+    rw [List.length_drop] at h₂
+    omega
+  surfaces_of_hi h := surfacesWith_plateauAR.mpr
+    ⟨List.mem_take_iff.mpr ⟨_, Nat.lt_succ_self _, h⟩, List.mem_drop_iff.mpr ⟨_, le_rfl, h⟩⟩
+  decSurfaces w i := decidable_of_iff _ surfacesWith_plateauAR.symm
 
 @[simp] theorem utp_hi : utp.hi = .H := rfl
 
 @[simp] theorem utp_lo : utp.lo = .O := rfl
 
-@[simp] theorem utp_Surfaces : utp.Surfaces = SurfacesH := rfl
+/-- The string-level reading of surfacing: the windowed form, now derived. -/
+theorem utp_surfaces_def {w : List TBU} {i : ℕ} :
+    utp.Surfaces w i ↔ .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i :=
+  surfacesWith_plateauAR
+
+variable {w : List TBU} {i j k : ℕ}
+
+/-- Positionwise reading of surfacing: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
+theorem utp_surfaces_iff :
+    utp.Surfaces w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j ≥ i, w[j]? = some .H := by
+  rw [utp_surfaces_def, List.mem_take_iff, List.mem_drop_iff]
+  simp [Nat.lt_succ_iff]
+
+/-- The surfacing set is convex: the windows only widen. -/
+theorem utp_surfaces_of_le_of_le (hi : utp.Surfaces w i) (hk : utp.Surfaces w k)
+    (hij : i ≤ j) (hjk : j ≤ k) : utp.Surfaces w j :=
+  utp_surfaces_def.mpr
+    ⟨w.take_subset_take_left (by omega) (utp_surfaces_def.mp hi).1,
+      w.drop_subset_drop_left (by omega) (utp_surfaces_def.mp hk).2⟩
+
+theorem utp_surfaces_H_mem (h : utp.Surfaces w i) : .H ∈ w :=
+  List.take_subset _ _ (utp_surfaces_def.mp h).1
+
+/-- Reversal symmetry: under `reverse` the two windows swap. -/
+theorem utp_surfaces_reverse (hi : i < w.length) :
+    utp.Surfaces w.reverse i ↔ utp.Surfaces w (w.length - 1 - i) := by
+  rw [utp_surfaces_def, utp_surfaces_def, List.take_reverse, List.drop_reverse,
+    List.mem_reverse, List.mem_reverse,
+    show w.length - (i + 1) = w.length - 1 - i from by omega,
+    show w.length - i = (w.length - 1 - i) + 1 from by omega, and_comm]
+
+/-- TBU `i` surfaces iff it is itself a H or is strictly flanked. -/
+theorem utp_surfaces_split {a : TBU} (h : w[i]? = some a) :
+    utp.Surfaces w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
+  rcases eq_or_ne a .H with rfl | ha
+  · simp [utp.surfaces_of_hi h]
+  · obtain ⟨hi, hia⟩ := List.getElem?_eq_some_iff.mp h
+    rw [utp_surfaces_def, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
+    simp [ha, Ne.symm ha]
 
 theorem utp_getElem? :
-    (utp.map w)[i]? = w[i]?.map fun _ => if SurfacesH w i then TBU.H else TBU.O :=
+    (utp.map w)[i]? = w[i]?.map fun _ => if utp.Surfaces w i then TBU.H else TBU.O :=
   utp.map_getElem?
 
-theorem utp_getElem?_H_iff : (utp.map w)[j]? = some .H ↔ SurfacesH w j :=
+theorem utp_getElem?_H_iff : (utp.map w)[j]? = some .H ↔ utp.Surfaces w j :=
   utp.map_getElem?_hi_iff
 
 theorem utp_getElem?_O_iff :
-    (utp.map w)[j]? = some .O ↔ j < w.length ∧ ¬ SurfacesH w j :=
+    (utp.map w)[j]? = some .O ↔ j < w.length ∧ ¬ utp.Surfaces w j :=
   utp.map_getElem?_lo_iff
 
 /-- Plateauing is symmetric under string reversal. -/
@@ -141,7 +221,7 @@ theorem utp_reverse : utp.map w.reverse = (utp.map w).reverse := by
   by_cases hi : i < w.length
   · rw [utp_getElem?, List.getElem?_reverse (by simpa using hi),
       List.getElem?_reverse (by simpa using hi), Surfacing.map_length, utp_getElem?]
-    simp only [surfacesH_reverse hi]
+    simp only [utp_surfaces_reverse hi]
   · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by simp; omega)]
 
 /-! ### The plateau set -/
@@ -149,12 +229,12 @@ theorem utp_reverse : utp.map w.reverse = (utp.map w).reverse := by
 /-- The plateau of `w`: the set of positions that surface H. -/
 def plateau (w : List TBU) : Finset ℕ := utp.support w
 
-@[simp] theorem mem_plateau : j ∈ plateau w ↔ SurfacesH w j := utp.mem_support
+@[simp] theorem mem_plateau : j ∈ plateau w ↔ utp.Surfaces w j := utp.mem_support
 
 @[simp] theorem plateau_nonempty : (plateau w).Nonempty ↔ .H ∈ w :=
-  ⟨fun ⟨_, hj⟩ => (mem_plateau.mp hj).H_mem, fun hw =>
+  ⟨fun ⟨_, hj⟩ => utp_surfaces_H_mem (mem_plateau.mp hj), fun hw =>
     have ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
-    ⟨i, mem_plateau.mpr (surfacesH_of_getElem?_H hi)⟩⟩
+    ⟨i, mem_plateau.mpr (utp.surfaces_of_hi hi)⟩⟩
 
 /-- `utp.map` writes the indicator word of its plateau. -/
 theorem utp_eq_plateau_indicator :
@@ -167,7 +247,7 @@ theorem utp_eq_plateau_indicator :
 theorem plateau_eq_Icc_of {lo hi : ℕ} (hlo : w[lo]? = some .H) (hhi : w[hi]? = some .H)
     (hb : ∀ j, w[j]? = some .H → lo ≤ j ∧ j ≤ hi) : plateau w = Finset.Icc lo hi := by
   ext j
-  rw [mem_plateau, Finset.mem_Icc, surfacesH_iff]
+  rw [mem_plateau, Finset.mem_Icc, utp_surfaces_iff]
   constructor
   · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
     have hb₁ := hb j₁ h₁; have hb₂ := hb j₂ h₂; omega
@@ -179,7 +259,7 @@ theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
   ext j
   rw [Finset.mem_Icc]
   refine ⟨fun hj => ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩, fun ⟨h₁, h₂⟩ =>
-    mem_plateau.mpr (SurfacesH.of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
+    mem_plateau.mpr (utp_surfaces_of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
       (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)⟩
 
 /-! ### Closure laws
@@ -187,7 +267,7 @@ theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
 Plateauing is a closure operator in the pointwise H-order: extensive
 (`utp_getElem?_H_of_getElem?_H`), monotone (`utp_mono`), idempotent (`utp_utp`). The
 engine is convexity: the output's Hs are the plateau, an interval, so plateauing the
-output surfaces nothing new (`surfacesH_utp`). -/
+output surfaces nothing new (`utp_surfaces_map`). -/
 
 @[simp] theorem utp_nil : utp.map [] = [] := rfl
 
@@ -197,34 +277,34 @@ theorem utp_getElem?_H_of_getElem?_H (h : w[i]? = some .H) :
   utp.map_getElem?_hi_of_getElem?_hi h
 
 /-- Surfacing is monotone in the word's H-set. -/
-theorem SurfacesH.mono {w' : List TBU}
-    (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (h : SurfacesH w i) :
-    SurfacesH w' i := by
-  obtain ⟨⟨l, hl, hlH⟩, r, hr, hrH⟩ := surfacesH_iff.mp h
-  exact surfacesH_iff.mpr ⟨⟨l, hl, hw l hlH⟩, r, hr, hw r hrH⟩
+theorem utp_surfaces_mono {w' : List TBU}
+    (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (h : utp.Surfaces w i) :
+    utp.Surfaces w' i := by
+  obtain ⟨⟨l, hl, hlH⟩, r, hr, hrH⟩ := utp_surfaces_iff.mp h
+  exact utp_surfaces_iff.mpr ⟨⟨l, hl, hw l hlH⟩, r, hr, hw r hrH⟩
 
 /-- Monotonicity: pointwise more Hs in, pointwise more Hs out. -/
 theorem utp_mono {w' : List TBU}
     (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (j : ℕ)
     (h : (utp.map w)[j]? = some TBU.H) : (utp.map w')[j]? = some TBU.H :=
-  utp_getElem?_H_iff.mpr ((utp_getElem?_H_iff.mp h).mono hw)
+  utp_getElem?_H_iff.mpr (utp_surfaces_mono hw (utp_getElem?_H_iff.mp h))
 
 /-- Surfacing is invariant under plateauing: the output's Hs are the plateau, whose
 convexity flanks no new positions. -/
-theorem surfacesH_utp : SurfacesH (utp.map w) i ↔ SurfacesH w i := by
+theorem utp_surfaces_map : utp.Surfaces (utp.map w) i ↔ utp.Surfaces w i := by
   constructor
   · intro h
-    obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := surfacesH_iff.mp h
+    obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := utp_surfaces_iff.mp h
     rw [utp_getElem?_H_iff] at h₁ h₂
-    obtain ⟨⟨l, hl, hlH⟩, -⟩ := surfacesH_iff.mp h₁
-    obtain ⟨-, r, hr, hrH⟩ := surfacesH_iff.mp h₂
-    exact surfacesH_iff.mpr ⟨⟨l, by omega, hlH⟩, r, by omega, hrH⟩
-  · exact fun h => surfacesH_iff.mpr ⟨⟨i, le_rfl, utp_getElem?_H_iff.mpr h⟩,
+    obtain ⟨⟨l, hl, hlH⟩, -⟩ := utp_surfaces_iff.mp h₁
+    obtain ⟨-, r, hr, hrH⟩ := utp_surfaces_iff.mp h₂
+    exact utp_surfaces_iff.mpr ⟨⟨l, by omega, hlH⟩, r, by omega, hrH⟩
+  · exact fun h => utp_surfaces_iff.mpr ⟨⟨i, le_rfl, utp_getElem?_H_iff.mpr h⟩,
       i, le_rfl, utp_getElem?_H_iff.mpr h⟩
 
 @[simp] theorem plateau_utp : plateau (utp.map w) = plateau w := by
   ext j
-  rw [mem_plateau, mem_plateau, surfacesH_utp]
+  rw [mem_plateau, mem_plateau, utp_surfaces_map]
 
 /-- Idempotence: a plateau is already closed. -/
 @[simp] theorem utp_utp : utp.map (utp.map w) = utp.map w := by
@@ -304,8 +384,8 @@ private theorem flanked_getElem? (d : ℕ) (x y : TBU) (j : ℕ) :
 /-- The target surfaces iff both flanks are H: the toneless fill offers no other
 trigger on either side. -/
 private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
-    SurfacesH (flanked d x y) (d + 1) ↔ x = .H ∧ y = .H := by
-  rw [surfacesH_iff]
+    utp.Surfaces (flanked d x y) (d + 1) ↔ x = .H ∧ y = .H := by
+  rw [utp_surfaces_iff]
   constructor
   · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
     rw [flanked_getElem?] at h₁ h₂

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -87,6 +87,11 @@ theorem map_getElem?_hi_of_getElem?_hi (h : w[i]? = some P.hi) :
     (P.map w)[i]? = some P.hi :=
   P.map_getElem?_hi_iff.mpr (P.surfaces_of_hi h)
 
+/-- Hypothesis-dot form of the in-domain law: `h.lt_length` for `h : P.Surfaces w i`. -/
+theorem Surfaces.lt_length {P : Surfacing α} {w : List α} {i : ℕ}
+    (h : P.Surfaces w i) : i < w.length :=
+  P.lt_length h
+
 /-! ### The surfacing set -/
 
 /-- The surfacing positions of `w`, as a finite set. -/

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.List.TakeDrop
+
+/-!
+# Tonal surfacing processes
+
+A **surfacing process** bundles the analysis [jardine-2016] gives tone-string maps: a
+marked tone value, and a context predicate `Surfaces w i` saying position `i` of `w`
+surfaces with it. The induced rewrite `Surfacing.map` writes the marked tone exactly at
+the surfacing positions and the default elsewhere; `Surfacing.support` is the surfacing
+set. Owning the context predicate on the process is what lets rival processes coexist:
+unbounded tonal plateauing (`Tone.Plateauing.utp`) and Copperbelt Bemba high-tone
+spreading (`Studies/Yolyan2025`) instantiate the same structure with very different
+predicates — plateauing's is convex and its map a closure operator, spreading's is
+neither — so only the genuinely shared API lives here.
+
+The laws are the shared minimum: surfacing positions are in-domain (`lt_length`), the
+marked tone is faithful — an underlying marked tone always surfaces (`surfaces_of_hi`) —
+and the two written values are distinct (`hi_ne_lo`), which makes the pointwise
+characterizations (`map_getElem?_hi_iff`, `map_getElem?_lo_iff`) read the map exactly.
+-/
+
+namespace Tone
+
+/-- A tonal surfacing process over the alphabet `α`: a marked tone `hi`, a default `lo`,
+and the context predicate saying which positions of a word surface with the mark. -/
+structure Surfacing (α : Type*) where
+  /-- The marked (surfacing) tone value. -/
+  hi : α
+  /-- The default value written at non-surfacing positions. -/
+  lo : α
+  /-- Position `i` of `w` surfaces with the marked tone. -/
+  Surfaces : List α → ℕ → Prop
+  /-- The two written values are distinct. -/
+  hi_ne_lo : hi ≠ lo
+  /-- Surfacing positions are in-domain. -/
+  lt_length : ∀ {w : List α} {i : ℕ}, Surfaces w i → i < w.length
+  /-- Faithfulness: an underlying marked tone surfaces. -/
+  surfaces_of_hi : ∀ {w : List α} {i : ℕ}, w[i]? = some hi → Surfaces w i
+  /-- The context predicate is decidable, so the map computes. -/
+  decSurfaces : ∀ w i, Decidable (Surfaces w i)
+
+namespace Surfacing
+
+variable {α : Type*} (P : Surfacing α) {w : List α} {i j : ℕ}
+
+instance (w : List α) (i : ℕ) : Decidable (P.Surfaces w i) := P.decSurfaces w i
+
+/-- The induced rewrite: the marked tone exactly at the surfacing positions. -/
+def map (w : List α) : List α := w.mapIdx fun i _ => if P.Surfaces w i then P.hi else P.lo
+
+@[simp] theorem map_nil : P.map [] = [] := rfl
+
+@[simp] theorem map_length : (P.map w).length = w.length := by simp [map]
+
+theorem map_getElem? :
+    (P.map w)[i]? = w[i]?.map fun _ => if P.Surfaces w i then P.hi else P.lo := by
+  simp [map, List.getElem?_mapIdx]
+
+theorem map_getElem?_hi_iff : (P.map w)[j]? = some P.hi ↔ P.Surfaces w j := by
+  rw [map_getElem?, Option.map_eq_some_iff]
+  constructor
+  · rintro ⟨a, -, ha⟩
+    by_contra hs
+    rw [if_neg hs] at ha
+    exact P.hi_ne_lo ha.symm
+  · exact fun hs => ⟨w[j]'(P.lt_length hs), List.getElem?_eq_getElem (P.lt_length hs),
+      if_pos hs⟩
+
+theorem map_getElem?_lo_iff :
+    (P.map w)[j]? = some P.lo ↔ j < w.length ∧ ¬ P.Surfaces w j := by
+  rw [map_getElem?, Option.map_eq_some_iff]
+  constructor
+  · rintro ⟨a, ha, hout⟩
+    refine ⟨(List.getElem?_eq_some_iff.mp ha).1, fun hs => ?_⟩
+    rw [if_pos hs] at hout
+    exact P.hi_ne_lo hout
+  · exact fun ⟨hj, hs⟩ => ⟨w[j], List.getElem?_eq_getElem hj, if_neg hs⟩
+
+/-- Faithfulness at the map level: an underlying marked tone survives. -/
+theorem map_getElem?_hi_of_getElem?_hi (h : w[i]? = some P.hi) :
+    (P.map w)[i]? = some P.hi :=
+  P.map_getElem?_hi_iff.mpr (P.surfaces_of_hi h)
+
+/-! ### The surfacing set -/
+
+/-- The surfacing positions of `w`, as a finite set. -/
+def support (w : List α) : Finset ℕ := (Finset.range w.length).filter (P.Surfaces w)
+
+@[simp] theorem mem_support : j ∈ P.support w ↔ P.Surfaces w j := by
+  simp only [support, Finset.mem_filter, Finset.mem_range, and_iff_right_iff_imp]
+  exact P.lt_length
+
+/-- The map writes the indicator word of its support. -/
+theorem map_eq_indicator :
+    P.map w = (List.range w.length).map fun i => if i ∈ P.support w then P.hi else P.lo :=
+  List.ext_getElem (by simp [map]) fun i h₁ h₂ => by simp [map, mem_support]
+
+end Surfacing
+
+end Tone

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -73,7 +73,7 @@ def utpBM : Bimachine Bool Bool TBU TBU :=
   .ofFlags (· == .H) (· == .H) fun l a r => if a == .H || (l && r) then .H else .O
 
 /-- The bimachine computes UTP. -/
-theorem utpBM_run : utpBM.run = utp := by
+theorem utpBM_run : utpBM.run = utp.map := by
   funext w
   refine List.ext_getElem? fun i => ?_
   rw [utpBM, Bimachine.ofFlags_run_getElem?, utp_getElem?]
@@ -90,38 +90,38 @@ theorem utpBM_run : utpBM.run = utp := by
     · rw [if_neg (fun hbt => hs (hb.mp hbt)), if_neg hs]
 
 /-- UTP is regular (§4.2): computable by a finite bimachine. -/
-theorem utp_isBimachineComputable : IsBimachineComputable utp :=
+theorem utp_isBimachineComputable : IsBimachineComputable utp.map :=
   utpBM_run ▸ isBimachineComputable utpBM
 
 /-! ### UTP is not subsequential
 
 The paper's central theorem (§4.2, online appendix), by bounded delay: a left machine
-reading `H Øⁿ` has emitted at most one symbol (`utp (H Øⁿ) = H Øⁿ` and
-`utp (H Øⁿ H) = H^(n+2)` diverge at position 1), so it withholds `n` symbols. -/
+reading `H Øⁿ` has emitted at most one symbol (`utp.map (H Øⁿ) = H Øⁿ` and
+`utp.map (H Øⁿ H) = H^(n+2)` diverge at position 1), so it withholds `n` symbols. -/
 
 /-- UTP is not left-subsequential (§4.2, online appendix). -/
-theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp := by
+theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp.map := by
   refine not_isLeftSubsequential_of_diverging fun N =>
     ⟨.H :: List.replicate (N + 1) .O, [.H], 1, ?_, ?_⟩
-  · simp only [utp_length, List.length_cons, List.length_replicate]; omega
+  · simp only [Tone.Surfacing.map_length, List.length_cons, List.length_replicate]; omega
   · -- the images disagree at position 1: toneless there without the second H, plateau with it
-    have h1 : (utp (TBU.H :: List.replicate (N + 1) TBU.O))[1]? = some TBU.O :=
+    have h1 : (utp.map (TBU.H :: List.replicate (N + 1) TBU.O))[1]? = some TBU.O :=
       utp_getElem?_O_iff.mpr ⟨by simp, fun hs => by simpa using hs.2⟩
-    have h2 : (utp ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H :=
+    have h2 : (utp.map ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H :=
       utp_getElem?_H_iff.mpr ⟨by simp, by simp⟩
     rw [h1, h2]; simp
 
 /-- UTP is not right-subsequential: by the reversal symmetry, a right machine faces the
 mirror-image unbounded look-ahead. -/
-theorem utp_not_isRightSubsequential : ¬ IsRightSubsequential utp := by
+theorem utp_not_isRightSubsequential : ¬ IsRightSubsequential utp.map := by
   intro hf
   rw [isRightSubsequential_iff_left_reverse] at hf
-  have heq : (fun xs : List TBU => (utp xs.reverse).reverse) = utp := by
+  have heq : (fun xs : List TBU => (utp.map xs.reverse).reverse) = utp.map := by
     funext xs; rw [utp_reverse, List.reverse_reverse]
   exact utp_not_isLeftSubsequential (heq ▸ hf)
 
 /-- UTP is subsequential in neither direction. -/
-theorem utp_not_isSubsequential : ∀ d, ¬ IsSubsequential d utp
+theorem utp_not_isSubsequential : ∀ d, ¬ IsSubsequential d utp.map
   | .left => utp_not_isLeftSubsequential
   | .right => utp_not_isRightSubsequential
 
@@ -132,7 +132,7 @@ Under the non-interacting-bimachine rendering of [heinz-lai-2013]'s weak determi
 expresses. -/
 
 /-- UTP is not weakly deterministic (§5.2). -/
-theorem utp_not_isBimachineWeaklyDeterministic : ¬ IsBimachineWeaklyDeterministic utp :=
+theorem utp_not_isBimachineWeaklyDeterministic : ¬ IsBimachineWeaklyDeterministic utp.map :=
   not_isBimachineWeaklyDeterministic_of_requiresBothSides utp_requiresBothSides
 
 /-! ### The (43) mark-up decomposition
@@ -166,7 +166,7 @@ private theorem markLeft_run_H_iff (w : List TBU) (j : ℕ) :
   | some a => cases a <;> simp [ite_eq_iff]
 
 /-- The (43) decomposition computes UTP. -/
-theorem utp_eq_resolve_mark (w : List TBU) : utp w = resolve (markLeft.run w) := by
+theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w) := by
   have hmark : ∀ i : ℕ, Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) :=
     fun i => by simp only [List.mem_drop_iff, markLeft_run_H_iff]
   refine List.ext_getElem? fun i => ?_
@@ -189,7 +189,7 @@ theorem utp_eq_resolve_mark (w : List TBU) : utp w = resolve (markLeft.run w) :=
 right-subsequential map after a left-subsequential map. -/
 theorem utp_markup_decomposition :
     IsLeftSubsequential markLeft.run ∧ IsRightSubsequential resolve
-      ∧ utp = resolve ∘ markLeft.run := by
+      ∧ utp.map = resolve ∘ markLeft.run := by
   refine ⟨markLeft.isLetterLeftSubsequential.isLeftSubsequential, ?_,
     funext utp_eq_resolve_mark⟩
   rw [isRightSubsequential_iff_left_reverse]
@@ -248,44 +248,44 @@ private theorem upper_realize_toAR (v : List TBU) :
     cases a <;> simp [toAR, List.replicate_succ]
 
 theorem mem_links_realizeMerged_utp (p : ℕ × ℕ) :
-    p ∈ (realizeMerged toAR (utp w)).links ↔ p.1 = 0 ∧ SurfacesH w p.2 := by
-  have hL : ∀ j, (realize toAR (utp w)).toGraph.IsLinkedLower j ↔ SurfacesH w j := fun j => by
+    p ∈ (realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ SurfacesH w p.2 := by
+  have hL : ∀ j, (realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ SurfacesH w j := fun j => by
     rw [AR.isLinkedLower_iff_linearize, linearize_realize_toAR, ← utp_getElem?_H_iff]
-    cases hv : (utp w)[j]? with
+    cases hv : (utp.map w)[j]? with
     | none => simp [List.getElem?_map, hv]
     | some a => cases a <;> simp [List.getElem?_map, hv]
   rw [realizeMerged_def,
-    mem_links_collapseAR_of_upper_replicate (upper_realize_toAR (utp w)), hL]
+    mem_links_collapseAR_of_upper_replicate (upper_realize_toAR (utp.map w)), hL]
 
 /-- Multiple association ((7)): the merged realization links melody node `0` to exactly
 the `plateau`. Unconditional: a toneless word has an empty plateau and no lines. -/
 theorem links_realizeMerged_utp :
-    (realizeMerged toAR (utp w)).links = {0} ×ˢ plateau w := by
+    (realizeMerged toAR (utp.map w)).links = {0} ×ˢ plateau w := by
   ext ⟨k, j⟩; rw [mem_links_realizeMerged_utp]; simp [and_comm, eq_comm]
 
 /-- The timing tier survives the merge: one slot per input TBU. -/
 theorem lower_realizeMerged_utp :
-    (realizeMerged toAR (utp w)).lower.toList = List.replicate w.length () := by
+    (realizeMerged toAR (utp.map w)).lower.toList = List.replicate w.length () := by
   rw [realizeMerged_def, collapseAR_lower]
   have h := List.eq_replicate_of_mem
-    (l := (realize toAR (utp w)).lower.toList) (a := ()) fun _ _ => rfl
+    (l := (realize toAR (utp.map w)).lower.toList) (a := ()) fun _ _ => rfl
   rwa [LabeledTuple.toList_length, ← AR.linearize_length, linearize_realize_toAR,
-    List.length_map, utp_length] at h
+    List.length_map, Tone.Surfacing.map_length] at h
 
 /-- The fused plateau ((7)): with at least one H, the merged melody tier is a single H
 autosegment. -/
 theorem upper_realizeMerged_utp (hw : .H ∈ w) :
-    (realizeMerged toAR (utp w)).upper.toList = [Tone.TRN.H] := by
-  obtain ⟨m, hm⟩ : ∃ m, (utp w).count .H = m + 1 := by
+    (realizeMerged toAR (utp.map w)).upper.toList = [Tone.TRN.H] := by
+  obtain ⟨m, hm⟩ : ∃ m, ((utp.map w).count .H) = m + 1 := by
     obtain ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     have := List.count_pos_iff.mpr <| List.mem_iff_getElem?.mpr
       ⟨i, utp_getElem?_H_iff.mpr (surfacesH_of_getElem?_H hi)⟩
-    exact ⟨(utp w).count .H - 1, by omega⟩
+    exact ⟨(utp.map w).count .H - 1, by omega⟩
   rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR, hm, OCP.collapse_replicate]
 
 /-- (7) concretely: `HØØH` fuses to one H linked to all four TBUs. -/
 example :
-    (realizeMerged toAR (utp [.H, .O, .O, .H])).links
+    (realizeMerged toAR (utp.map [.H, .O, .O, .H])).links
       = {(0, 0), (0, 1), (0, 2), (0, 3)} := by decide
 
 end AutosegmentalGrounding
@@ -294,8 +294,8 @@ end AutosegmentalGrounding
 subsequential in either direction nor weakly deterministic, the bound segmental
 phonology respects. -/
 theorem utp_fullyRegular :
-    IsBimachineComputable utp ∧ (∀ d, ¬ IsSubsequential d utp)
-      ∧ ¬ IsBimachineWeaklyDeterministic utp :=
+    IsBimachineComputable utp.map ∧ (∀ d, ¬ IsSubsequential d utp.map)
+      ∧ ¬ IsBimachineWeaklyDeterministic utp.map :=
   ⟨utp_isBimachineComputable, utp_not_isSubsequential, utp_not_isBimachineWeaklyDeterministic⟩
 
 end Jardine2016Tone

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -3,8 +3,6 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Data.Finset.Max
-import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
@@ -14,6 +12,7 @@ import Linglib.Phonology.Autosegmental.Realization
 import Linglib.Phonology.Autosegmental.Collapse
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Tone.Basic
+import Linglib.Phonology.Tone.Plateauing
 
 /-!
 # Jardine (2016): Computationally, tone is different
@@ -26,17 +25,18 @@ they are exactly the attested maps exceeding weak determinism. The flagship witn
 TBUs surfaces H. This file formalizes the paper's formal skeleton over its string
 representation (§4.1: `H` a H-toned TBU, `O` the paper's Ø).
 
+The map itself and its plateau/circumambience API live in `Phonology/Tone/Plateauing`
+(the rule set (36) as `utp_toneless`/`utp_single`/`utp_plateau`; definition (2) as
+`utp_isUnboundedCircumambient`); this file keeps the paper's theorems about it.
+
 ## Main definitions
 
-* `utp` — the UTP map; `plateau w` — its set of surfacing positions.
 * `utpBM` — a bimachine computing UTP.
 * `markLeft`, `resolve` — the (43) two-pass decomposition over the `?`-enlarged alphabet.
 * `toAR` — the (40) translation into autosegmental representations.
 
 ## Main results
 
-* `utp_toneless`, `utp_single`, `utp_plateau` — the rule set (36), derived.
-* `utp_isUnboundedCircumambient` — the paper's definition (2), instantiated by UTP.
 * `utp_not_isSubsequential` — the central theorem (§4.2, online appendix): no
   deterministic FST computes UTP in either direction, via
   `IsLeftSubsequential.bounded_delay` and the reversal symmetry `utp_reverse`.
@@ -58,184 +58,9 @@ weakly deterministic; UTP's `RequiresBothSides` pushes it above that bound.
 
 namespace Jardine2016Tone
 
-open Subregular
-
-/-! ### The string-based representation
-
-Strings of timing-tier symbols, each recording one TBU's association state (§4.4). -/
-
-/-- A tone-bearing unit (§4.1): `H` is a TBU associated to a H tone, `O` an unspecified
-TBU (the paper's Ø). -/
-inductive TBU | H | O
-  deriving DecidableEq, Repr
-
-/-- TBU `i` of `w` surfaces with a H tone: some H-toned TBU sits at a position `≤ i` and
-some at a position `≥ i` — [hyman-katamba-2010]'s plateauing rule (7), pointwise. -/
-def SurfacesH (w : List TBU) (i : ℕ) : Prop := .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i
-
-instance (w : List TBU) (i : ℕ) : Decidable (SurfacesH w i) :=
-  inferInstanceAs (Decidable (_ ∧ _))
+open Subregular Tone.Plateauing
 
 variable {w : List TBU} {i j k : ℕ}
-
-/-- The unbounded tonal plateauing map (36): every TBU between two H-toned TBUs surfaces
-as H; everything else is unchanged. -/
-def utp (w : List TBU) : List TBU := w.mapIdx fun i _ => if SurfacesH w i then .H else .O
-
-@[simp] theorem utp_length : (utp w).length = w.length := by simp [utp]
-
-theorem utp_getElem? :
-    (utp w)[i]? = w[i]?.map fun _ => if SurfacesH w i then TBU.H else TBU.O := by
-  simp [utp, List.getElem?_mapIdx]
-
-private theorem mem_take_iff {α : Type*} {a : α} {w : List α} {k : ℕ} :
-    a ∈ w.take k ↔ ∃ j < k, w[j]? = some a := by
-  simp [List.mem_iff_getElem?, List.getElem?_take]
-
-private theorem mem_drop_iff {α : Type*} {a : α} {w : List α} {k : ℕ} :
-    a ∈ w.drop k ↔ ∃ j ≥ k, w[j]? = some a := by
-  simp only [List.mem_iff_getElem?, List.getElem?_drop]
-  exact ⟨fun ⟨t, ht⟩ => ⟨k + t, Nat.le_add_right k t, ht⟩,
-    fun ⟨j, hkj, hj⟩ => ⟨j - k, by rwa [Nat.add_sub_cancel' hkj]⟩⟩
-
-/-- Positionwise reading of `SurfacesH`: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
-theorem surfacesH_iff :
-    SurfacesH w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j ≥ i, w[j]? = some .H := by
-  rw [SurfacesH, mem_take_iff, mem_drop_iff]; simp [Nat.lt_succ_iff]
-
-theorem SurfacesH.lt_length (h : SurfacesH w i) : i < w.length := by
-  have h₂ := List.length_pos_of_mem h.2; rw [List.length_drop] at h₂; omega
-
-/-- The surfacing set is convex: `take`/`drop` windows only widen. -/
-theorem SurfacesH.of_le_of_le (hi : SurfacesH w i) (hk : SurfacesH w k) (hij : i ≤ j)
-    (hjk : j ≤ k) : SurfacesH w j :=
-  ⟨w.take_subset_take_left (by omega) hi.1, w.drop_subset_drop_left (by omega) hk.2⟩
-
-/-- A H-toned TBU surfaces H: it flanks itself. -/
-theorem surfacesH_of_getElem?_H (h : w[i]? = some .H) : SurfacesH w i :=
-  surfacesH_iff.mpr ⟨⟨i, le_rfl, h⟩, ⟨i, le_rfl, h⟩⟩
-
-theorem SurfacesH.H_mem (h : SurfacesH w i) : .H ∈ w := List.take_subset _ _ h.1
-
-/-- Reversal symmetry: under `reverse` the `take` and `drop` windows swap. -/
-theorem surfacesH_reverse (hi : i < w.length) :
-    SurfacesH w.reverse i ↔ SurfacesH w (w.length - 1 - i) := by
-  rw [SurfacesH, SurfacesH, List.take_reverse, List.drop_reverse, List.mem_reverse,
-    List.mem_reverse, show w.length - (i + 1) = w.length - 1 - i from by omega,
-    show w.length - i = (w.length - 1 - i) + 1 from by omega, and_comm]
-
-theorem utp_getElem?_H_iff : (utp w)[j]? = some .H ↔ SurfacesH w j := by
-  rw [utp_getElem?, Option.map_eq_some_iff]
-  constructor
-  · rintro ⟨a, -, ha⟩; by_contra hs; rw [if_neg hs] at ha; exact TBU.noConfusion ha
-  · exact fun hs => ⟨w[j]'hs.lt_length, List.getElem?_eq_getElem hs.lt_length, if_pos hs⟩
-
-theorem utp_getElem?_O_iff : (utp w)[j]? = some .O ↔ j < w.length ∧ ¬ SurfacesH w j := by
-  rw [utp_getElem?, Option.map_eq_some_iff]
-  constructor
-  · rintro ⟨a, ha, hout⟩
-    refine ⟨(List.getElem?_eq_some_iff.mp ha).1, fun hs => ?_⟩
-    rw [if_pos hs] at hout; exact TBU.noConfusion hout
-  · exact fun ⟨hj, hs⟩ => ⟨w[j], List.getElem?_eq_getElem hj, if_neg hs⟩
-
-/-- The plateau of `w`: the set of positions that surface H. -/
-def plateau (w : List TBU) : Finset ℕ := (Finset.range w.length).filter (SurfacesH w)
-
-@[simp] theorem mem_plateau : j ∈ plateau w ↔ SurfacesH w j := by
-  simp only [plateau, Finset.mem_filter, Finset.mem_range, and_iff_right_iff_imp]
-  exact SurfacesH.lt_length
-
-@[simp] theorem plateau_nonempty : (plateau w).Nonempty ↔ .H ∈ w :=
-  ⟨fun ⟨_, hj⟩ => (mem_plateau.mp hj).H_mem, fun hw =>
-    have ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
-    ⟨i, mem_plateau.mpr (surfacesH_of_getElem?_H hi)⟩⟩
-
-/-- `utp` writes the indicator word of its plateau. -/
-theorem utp_eq_plateau_indicator :
-    utp w = (List.range w.length).map fun i => if i ∈ plateau w then TBU.H else TBU.O :=
-  List.ext_getElem (by simp [utp]) fun i h₁ h₂ => by simp [utp, mem_plateau]
-
-/-- Sandwich characterization: a word with Hs at `lo` and `hi` and none outside
-`[lo, hi]` has plateau exactly `Finset.Icc lo hi`. -/
-theorem plateau_eq_Icc_of {lo hi : ℕ} (hlo : w[lo]? = some .H) (hhi : w[hi]? = some .H)
-    (hb : ∀ j, w[j]? = some .H → lo ≤ j ∧ j ≤ hi) : plateau w = Finset.Icc lo hi := by
-  ext j
-  rw [mem_plateau, Finset.mem_Icc, surfacesH_iff]
-  constructor
-  · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
-    have hb₁ := hb j₁ h₁; have hb₂ := hb j₂ h₂; omega
-  · exact fun hj => ⟨⟨lo, hj.1, hlo⟩, hi, hj.2, hhi⟩
-
-/-- The plateau is an interval, from the first trigger to the last: the set form of
-(36c). -/
-theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
-    plateau w = Finset.Icc ((plateau w).min' hne) ((plateau w).max' hne) := by
-  ext j
-  rw [Finset.mem_Icc]
-  refine ⟨fun hj => ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩, fun ⟨h₁, h₂⟩ =>
-    mem_plateau.mpr (SurfacesH.of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
-      (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)⟩
-
-/-- TBU `i` surfaces H iff it is itself a H or is strictly flanked: split the `take`
-window at its last slot and the `drop` window at its head. -/
-private theorem surfacesH_split {a : TBU} (h : w[i]? = some a) :
-    SurfacesH w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
-  rcases eq_or_ne a .H with rfl | ha
-  · simp [surfacesH_of_getElem?_H h]
-  · obtain ⟨hi, hia⟩ := List.getElem?_eq_some_iff.mp h
-    rw [SurfacesH, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
-    simp [ha, Ne.symm ha]
-
-/-! ### The rule set (36)
-
-The paper's three schemata for UTP, derived as theorems about `utp` rather than clauses
-of its definition. -/
-
-/-- (36a): a toneless word is unchanged. -/
-theorem utp_toneless (n : ℕ) : utp (List.replicate n .O) = List.replicate n .O := by
-  have h : plateau (List.replicate n TBU.O) = ∅ :=
-    Finset.not_nonempty_iff_eq_empty.mp (by simp)
-  simp [utp_eq_plateau_indicator, h, List.map_const']
-
-/-- (36b): a word with a single H is unchanged — one H cannot trigger a plateau. -/
-theorem utp_single (m n : ℕ) :
-    utp (List.replicate m .O ++ .H :: List.replicate n .O)
-      = List.replicate m .O ++ .H :: List.replicate n .O := by
-  have hH : ∀ j, (List.replicate m TBU.O ++ TBU.H :: List.replicate n TBU.O)[j]? = some TBU.H
-      ↔ j = m := fun j => by
-    simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
-      List.length_replicate]
-    split_ifs <;> simp_all <;> omega
-  rw [utp_eq_plateau_indicator, plateau_eq_Icc_of ((hH m).mpr rfl) ((hH m).mpr rfl)
-    fun j hj => by rw [hH j] at hj; omega]
-  refine List.ext_getElem (by simp) fun i h₁ h₂ => ?_
-  simp only [List.getElem_map, List.getElem_range, List.getElem_append, List.getElem_cons,
-    List.getElem_replicate, List.length_replicate, Finset.mem_Icc]
-  split_ifs <;> first | rfl | omega
-
-/-- (36c): everything between the outermost Hs surfaces H; the medial material `w` is
-arbitrary. -/
-theorem utp_plateau (m p : ℕ) (w : List TBU) :
-    utp (List.replicate m .O ++ .H :: (w ++ .H :: List.replicate p .O))
-      = List.replicate m .O ++ (List.replicate (w.length + 2) .H ++ List.replicate p .O) := by
-  have hb : ∀ j, (List.replicate m TBU.O ++ TBU.H :: (w ++ TBU.H :: List.replicate p TBU.O))[j]?
-      = some TBU.H → m ≤ j ∧ j ≤ m + 1 + w.length := fun j hj => by
-    simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
-      List.length_replicate] at hj
-    split_ifs at hj <;> first | omega | simp_all
-  rw [utp_eq_plateau_indicator, plateau_eq_Icc_of (by simp) (by
-      simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
-        List.length_replicate]
-      split_ifs <;> first | rfl | omega) hb]
-  refine List.ext_getElem (by simp; omega) fun i h₁ h₂ => ?_
-  simp only [List.getElem_map, List.getElem_range, List.getElem_append,
-    List.getElem_replicate, List.length_replicate, Finset.mem_Icc]
-  split_ifs <;> first | rfl | omega
-
-/-- The (43) sample rows: no plateau without two Hs; `HØØH ↦ HHHH`. -/
-example : utp [.O, .O, .O, .H] = [.O, .O, .O, .H] := by decide
-example : utp [.H, .O, .O, .O] = [.H, .O, .O, .O] := by decide
-example : utp [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
 
 /-! ### UTP is regular
 
@@ -268,72 +93,6 @@ theorem utpBM_run : utpBM.run = utp := by
 theorem utp_isBimachineComputable : IsBimachineComputable utp :=
   utpBM_run ▸ isBimachineComputable utpBM
 
-/-! ### UTP is unboundedly circumambient
-
-The witness family for definition (2), at distance `d`: `flanked d x y` puts `x` and `y`
-around `2d+2` toneless TBUs. The base `flanked d .H .H` is the plateau word with target
-`d+1`; flipping either flank to `.O` is the far perturbation that reverts it. -/
-
-/-- The distance-`d` witness word: flanks `x`, `y` around `2d+2` toneless TBUs. -/
-private def flanked (d : ℕ) (x y : TBU) : List TBU :=
-  x :: (List.replicate (2 * d + 2) .O ++ [y])
-
-private theorem flanked_length (d : ℕ) (x y : TBU) : (flanked d x y).length = 2 * d + 4 := by
-  simp [flanked]
-
-private theorem flanked_getElem? (d : ℕ) (x y : TBU) (j : ℕ) :
-    (flanked d x y)[j]? = if j = 0 then some x else if j = 2 * d + 3 then some y
-      else if j < 2 * d + 4 then some .O else none := by
-  simp only [flanked, List.getElem?_cons, List.getElem?_append, List.getElem?_replicate,
-    List.length_replicate, List.getElem?_nil]
-  split_ifs <;> first | rfl | omega
-
-/-- The target surfaces iff both flanks are H: the toneless fill offers no other
-trigger on either side. -/
-private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
-    SurfacesH (flanked d x y) (d + 1) ↔ x = .H ∧ y = .H := by
-  rw [surfacesH_iff]
-  constructor
-  · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
-    rw [flanked_getElem?] at h₁ h₂
-    split_ifs at h₁ h₂ <;> simp_all
-    omega
-  · rintro ⟨rfl, rfl⟩
-    exact ⟨⟨0, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩,
-      2 * d + 3, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩
-
-/-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
-plateau target. -/
-theorem utp_requiresBothSides : RequiresBothSides utp := by
-  intro d
-  have hmid : ∀ x y : TBU, (flanked d x y)[d + 1]? = some .O := fun x y => by
-    rw [flanked_getElem?, if_neg (by omega : ¬(d + 1 = 0)),
-      if_neg (by omega : ¬(d + 1 = 2 * d + 3)), if_pos (by omega : d + 1 < 2 * d + 4)]
-  have himg : ∀ x y : TBU, (utp (flanked d x y))[d + 1]?
-      = if x = .H ∧ y = .H then some .H else some .O := fun x y => by
-    split_ifs with h
-    · exact utp_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
-    · exact utp_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
-        fun hs => h ((surfacesH_flanked_mid d).mp hs)⟩
-  have hagreeL : ∀ (x x' y : TBU) (k : ℕ), k ≠ 0 →
-      (flanked d x y)[k]? = (flanked d x' y)[k]? := fun x x' y k h0 => by
-    rw [flanked_getElem?, flanked_getElem?]; split_ifs <;> first | rfl | omega
-  have hagreeR : ∀ (x y y' : TBU) (k : ℕ), k ≠ 2 * d + 3 →
-      (flanked d x y)[k]? = (flanked d x y')[k]? := fun x y y' k h3 => by
-    rw [flanked_getElem?, flanked_getElem?]; split_ifs <;> rfl
-  refine ⟨flanked d .H .H, d + 1, by rw [flanked_length]; omega, ?_, ?_, ?_⟩
-  · rw [himg, hmid]; simp
-  · exact ⟨flanked d .O .H, by rw [flanked_length, flanked_length],
-      fun k hk => hagreeL _ _ _ k (by omega), by rw [hmid, hmid],
-      by rw [himg, hmid]; simp⟩
-  · exact ⟨flanked d .H .O, by rw [flanked_length, flanked_length],
-      fun k hk => hagreeR _ _ _ k (by omega), by rw [hmid, hmid],
-      by rw [himg, hmid]; simp⟩
-
-/-- UTP is an unbounded circumambient process (definition (2)). -/
-theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp :=
-  utp_requiresBothSides.isUnboundedCircumambient
-
 /-! ### UTP is not subsequential
 
 The paper's central theorem (§4.2, online appendix), by bounded delay: a left machine
@@ -351,15 +110,6 @@ theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp := by
     have h2 : (utp ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H :=
       utp_getElem?_H_iff.mpr ⟨by simp, by simp⟩
     rw [h1, h2]; simp
-
-/-- Plateauing is symmetric under string reversal. -/
-theorem utp_reverse : utp w.reverse = (utp w).reverse := by
-  refine List.ext_getElem? fun i => ?_
-  by_cases hi : i < w.length
-  · rw [utp_getElem?, List.getElem?_reverse (by simpa using hi),
-      List.getElem?_reverse (by simpa using hi), utp_length, utp_getElem?]
-    simp only [surfacesH_reverse hi]
-  · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by simp; omega)]
 
 /-- UTP is not right-subsequential: by the reversal symmetry, a right machine faces the
 mirror-image unbounded look-ahead. -/
@@ -418,7 +168,7 @@ private theorem markLeft_run_H_iff (w : List TBU) (j : ℕ) :
 /-- The (43) decomposition computes UTP. -/
 theorem utp_eq_resolve_mark (w : List TBU) : utp w = resolve (markLeft.run w) := by
   have hmark : ∀ i : ℕ, Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) :=
-    fun i => by simp only [mem_drop_iff, markLeft_run_H_iff]
+    fun i => by simp only [List.mem_drop_iff, markLeft_run_H_iff]
   refine List.ext_getElem? fun i => ?_
   rw [utp_getElem?, resolve, resolveRight, Mealy.ofFlag_run_reverse_getElem?]
   simp only [List.any_beq', List.contains_eq_mem, decide_eq_decide.mpr (hmark i)]

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -83,9 +83,9 @@ theorem utpBM_run : utpBM.run = utp.map := by
     simp only [Option.map_some]
     congr 1
     have hb : (a == TBU.H || ((w.take i).any (· == .H) && (w.drop (i + 1)).any (· == .H)))
-        = true ↔ SurfacesH w i := by
-      rw [surfacesH_split h]; simp [List.any_eq_true]
-    by_cases hs : SurfacesH w i
+        = true ↔ utp.Surfaces w i := by
+      rw [utp_surfaces_split h]; simp [List.any_eq_true]
+    by_cases hs : utp.Surfaces w i
     · rw [if_pos (hb.mpr hs), if_pos hs]
     · rw [if_neg (fun hbt => hs (hb.mp hbt)), if_neg hs]
 
@@ -106,9 +106,9 @@ theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp.map := by
   · simp only [Tone.Surfacing.map_length, List.length_cons, List.length_replicate]; omega
   · -- the images disagree at position 1: toneless there without the second H, plateau with it
     have h1 : (utp.map (TBU.H :: List.replicate (N + 1) TBU.O))[1]? = some TBU.O :=
-      utp_getElem?_O_iff.mpr ⟨by simp, fun hs => by simpa using hs.2⟩
+      utp_getElem?_O_iff.mpr ⟨by simp, fun hs => by simpa using (utp_surfaces_def.mp hs).2⟩
     have h2 : (utp.map ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H :=
-      utp_getElem?_H_iff.mpr ⟨by simp, by simp⟩
+      utp_getElem?_H_iff.mpr (utp_surfaces_def.mpr ⟨by simp, by simp⟩)
     rw [h1, h2]; simp
 
 /-- UTP is not right-subsequential: by the reversal symmetry, a right machine faces the
@@ -180,10 +180,10 @@ theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w
     simp only [Option.map_some, Function.comp_apply]
     congr 1
     cases a with
-    | H => simp [surfacesH_of_getElem?_H ha]
+    | H => simp [utp.surfaces_of_hi ha]
     | O =>
       by_cases hL : TBU.H ∈ w.take i <;> by_cases hR : TBU.H ∈ w.drop (i + 1) <;>
-        simp [surfacesH_split ha, hL, hR]
+        simp [utp_surfaces_split ha, hL, hR]
 
 /-- The (43) mark-up decomposition (§5.2): over the `?`-enlarged alphabet, UTP is a
 right-subsequential map after a left-subsequential map. -/
@@ -208,20 +208,6 @@ section AutosegmentalGrounding
 
 open Autosegmental
 
-/-- The (40) translation: a H-toned TBU is one H melody node linked to its timing unit;
-a toneless TBU is a bare timing unit. -/
-def toAR : TBU → AR Tone.TRN Unit
-  | .H => .single Tone.TRN.H ()
-  | .O => .bare ()
-
-theorem linearize_realize_toAR (w : List TBU) :
-    (realize toAR w).linearize
-      = w.map fun a => ((), if a = .H then [Tone.TRN.H] else []) := by
-  rw [linearize_realize]
-  induction w with
-  | nil => rfl
-  | cons a w ih => rw [List.flatMap_cons, List.map_cons, ih]; cases a <;> simp [toAR]
-
 /-- Read a timing unit's association state back as a TBU symbol. -/
 def readTBU (s : Unit × List Tone.TRN) : TBU := if s.2.isEmpty then .O else .H
 
@@ -239,21 +225,10 @@ The OCP-merging realization `Autosegmental.realizeMerged` fuses the plateau's ru
 nodes into one, giving [hyman-katamba-2010]'s output representation (7): a single H
 autosegment multiply linked to exactly the `plateau`, over an unchanged timing tier. -/
 
-private theorem upper_realize_toAR (v : List TBU) :
-    (realize toAR v).upper.toList = List.replicate (v.count .H) Tone.TRN.H := by
-  induction v with
-  | nil => rfl
-  | cons a v ih =>
-    rw [realize_cons, AR.concat_upper, LabeledTuple.toList_concat, ih]
-    cases a <;> simp [toAR, List.replicate_succ]
-
 theorem mem_links_realizeMerged_utp (p : ℕ × ℕ) :
-    p ∈ (realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ SurfacesH w p.2 := by
-  have hL : ∀ j, (realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ SurfacesH w j := fun j => by
-    rw [AR.isLinkedLower_iff_linearize, linearize_realize_toAR, ← utp_getElem?_H_iff]
-    cases hv : (utp.map w)[j]? with
-    | none => simp [List.getElem?_map, hv]
-    | some a => cases a <;> simp [List.getElem?_map, hv]
+    p ∈ (realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ utp.Surfaces w p.2 := by
+  have hL : ∀ j, (realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ utp.Surfaces w j :=
+    fun j => by rw [isLinkedLower_realize_toAR, utp_getElem?_H_iff]
   rw [realizeMerged_def,
     mem_links_collapseAR_of_upper_replicate (upper_realize_toAR (utp.map w)), hL]
 
@@ -279,7 +254,7 @@ theorem upper_realizeMerged_utp (hw : .H ∈ w) :
   obtain ⟨m, hm⟩ : ∃ m, ((utp.map w).count .H) = m + 1 := by
     obtain ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     have := List.count_pos_iff.mpr <| List.mem_iff_getElem?.mpr
-      ⟨i, utp_getElem?_H_iff.mpr (surfacesH_of_getElem?_H hi)⟩
+      ⟨i, utp_getElem?_H_iff.mpr (utp.surfaces_of_hi hi)⟩
     exact ⟨(utp.map w).count .H - 1, by omega⟩
   rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR, hm, OCP.collapse_replicate]
 

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -1,6 +1,6 @@
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 import Linglib.Core.Computability.Subregular.Logic.BMRS
-import Linglib.Studies.Jardine2016Tone
+import Linglib.Phonology.Tone.Plateauing
 import Linglib.Studies.McCollumEtAl2020
 
 /-!
@@ -223,11 +223,11 @@ theorem tutrugbu_not_bmrsWeaklyDeterministic :
 
 /-- Luganda unbounded tonal plateauing is not weakly deterministic: [jardine-2016]'s
 flagship pattern (the class of the paper's Prop. 5.4 Bemba case), through
-`Studies/Jardine2016Tone`'s witness. -/
+`Phonology/Tone/Plateauing`'s witness. -/
 theorem utp_not_bmrsWeaklyDeterministic :
-    ¬ IsBmrsWeaklyDeterministic Jardine2016Tone.utp :=
+    ¬ IsBmrsWeaklyDeterministic Tone.Plateauing.utp :=
   not_isBmrsWeaklyDeterministic_of_requiresBothSides
-    Jardine2016Tone.utp_requiresBothSides
+    Tone.Plateauing.utp_requiresBothSides
 
 /-! ### The positive side: LHOL stress as a simultaneous application (§5.2)
 

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -30,8 +30,9 @@ witness is used: one-sidedness is global, not window-bounded.
 Instances: Sour Grapes harmony (Thm. 5.2 — the first proof of the [heinz-lai-2013]
 conjecture, via [padgett-1995]/[wilson-2003]'s pathology), and — through the shared
 witnesses already in the library — Tutrugbu ATR harmony (Prop. 5.5,
-[mccollum-bakovic-mai-meinhardt-2020]) and Luganda unbounded tonal plateauing
-([jardine-2016], the class the paper's Prop. 5.4 Bemba case exemplifies). The positive
+[mccollum-bakovic-mai-meinhardt-2020]), Luganda unbounded tonal plateauing
+([jardine-2016]), and Copperbelt Bemba high-tone spreading (Prop. 5.4), the latter
+formalized here as a second `Tone.Surfacing` instance. The positive
 side: with no underlying stress the input predicate is constantly `⊥` and ⊙ collapses
 to disjunction — (5.15), recovering [koser-jardine-2020]'s LHOL program as the
 simultaneous application of its two one-sided halves. §6.3's conjunctive dual ⊘ is
@@ -225,9 +226,132 @@ theorem tutrugbu_not_bmrsWeaklyDeterministic :
 flagship pattern (the class of the paper's Prop. 5.4 Bemba case), through
 `Phonology/Tone/Plateauing`'s witness. -/
 theorem utp_not_bmrsWeaklyDeterministic :
-    ¬ IsBmrsWeaklyDeterministic Tone.Plateauing.utp :=
+    ¬ IsBmrsWeaklyDeterministic Tone.Plateauing.utp.map :=
   not_isBmrsWeaklyDeterministic_of_requiresBothSides
     Tone.Plateauing.utp_requiresBothSides
+
+/-! ### Bemba high-tone spreading is not weakly deterministic (Prop. 5.4)
+
+Copperbelt Bemba ([jardine-2016]; the paper's bounded/unbounded spreading data): a high
+tone spreads to the end of the word when no high follows it, and only onto the next two
+TBUs when one does. A second `Tone.Surfacing` instance — and a cautionary one: unlike
+plateauing, the surface set is not convex and the map is neither monotone nor
+idempotent, so only the shared surfacing API transfers. -/
+
+/-- The Bemba tonal alphabet. -/
+inductive BTone
+  | H | L
+  deriving DecidableEq, Repr
+
+/-- Position `i` surfaces H: an underlying H, within the two-TBU bounded spread of a
+preceding H, or at-or-after the last H (unbounded spread to the word end). -/
+def bembaSurfaces (w : List BTone) (i : ℕ) : Prop :=
+  i < w.length ∧ (w[i]? = some .H
+    ∨ (∃ j < i, w[j]? = some .H ∧ i ≤ j + 2)
+    ∨ ∃ j ≤ i, w[j]? = some .H ∧ ∀ k < w.length, w[k]? = some .H → k ≤ j)
+
+instance (w : List BTone) (i : ℕ) : Decidable (bembaSurfaces w i) := by
+  unfold bembaSurfaces
+  infer_instance
+
+/-- Bemba high-tone spreading as a surfacing process. -/
+def bemba : Tone.Surfacing BTone where
+  hi := .H
+  lo := .L
+  Surfaces := bembaSurfaces
+  hi_ne_lo := by decide
+  lt_length h := h.1
+  surfaces_of_hi h := ⟨(List.getElem?_eq_some_iff.mp h).1, .inl h⟩
+  decSurfaces _ _ := inferInstance
+
+/-- The witness family: flanks `x`, `y` around a toneless fill wide enough that the
+bounded two-TBU spread never reaches the middle. -/
+private def bw (x y : BTone) (d : ℕ) : List BTone :=
+  x :: (List.replicate (2 * d + 4) .L ++ [y])
+
+private theorem bw_length {x y : BTone} {d : ℕ} : (bw x y d).length = 2 * d + 6 := by
+  simp [bw]
+
+private theorem bw_getElem? {x y : BTone} {d k : ℕ} :
+    (bw x y d)[k]? = if k = 0 then some x else if k = 2 * d + 5 then some y
+      else if k < 2 * d + 5 then some .L else none := by
+  rcases k with _ | k
+  · rfl
+  · simp only [bw, List.getElem?_cons_succ, List.getElem?_append, List.getElem?_replicate,
+      List.length_replicate, List.getElem?_cons, List.getElem?_nil]
+    split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+/-- In the lone-trigger word, the middle surfaces: the initial H is the last H, so the
+unbounded spread reaches it. -/
+private theorem bembaSurfaces_bw_HL {d : ℕ} : bembaSurfaces (bw .H .L d) (d + 3) := by
+  refine ⟨by rw [bw_length]; omega, .inr (.inr ⟨0, by omega, ?_, fun k hk hkH => ?_⟩)⟩
+  · rw [bw_getElem?]
+    split_ifs <;> first | rfl | omega
+  · rw [bw_length] at hk
+    rw [bw_getElem?] at hkH
+    split_ifs at hkH <;> first | omega | exact BTone.noConfusion (Option.some.inj hkH)
+
+/-- With a second H at the end, the middle does not surface: the bounded spread stops
+two TBUs in, and the unbounded spread now belongs to the final H. -/
+private theorem not_bembaSurfaces_bw_HH {d : ℕ} : ¬ bembaSurfaces (bw .H .H d) (d + 3) := by
+  rintro ⟨-, h | ⟨j, hj, hjH, hspread⟩ | ⟨j, hj, hjH, hlast⟩⟩
+  · rw [bw_getElem?] at h
+    split_ifs at h <;> first | omega | exact BTone.noConfusion (Option.some.inj h)
+  · rw [bw_getElem?] at hjH
+    split_ifs at hjH <;> first | omega | exact BTone.noConfusion (Option.some.inj hjH)
+  · have hj0 : j = 0 := by
+      rw [bw_getElem?] at hjH
+      split_ifs at hjH <;> first | omega | exact BTone.noConfusion (Option.some.inj hjH)
+    have := hlast (2 * d + 5) (by rw [bw_length]; omega) (by
+      rw [bw_getElem?]
+      split_ifs <;> first | rfl | omega)
+    omega
+
+/-- With no trigger at all, the middle does not surface. -/
+private theorem not_bembaSurfaces_bw_LL {d : ℕ} : ¬ bembaSurfaces (bw .L .L d) (d + 3) := by
+  have hnoH : ∀ k, (bw .L .L d)[k]? ≠ some BTone.H := fun k => by
+    rw [bw_getElem?]
+    split_ifs <;> first | exact fun h => BTone.noConfusion (Option.some.inj h) | simp
+  rintro ⟨-, h | ⟨j, -, hjH, -⟩ | ⟨j, -, hjH, -⟩⟩
+  exacts [hnoH _ h, hnoH _ hjH, hnoH _ hjH]
+
+private theorem bw_mid {x y : BTone} {d : ℕ} : (bw x y d)[d + 3]? = some BTone.L := by
+  rw [bw_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+/-- Bemba spreading requires both sides: the middle of `H L…L L` spreads (unbounded, no
+blocker), but neither the triggerless far-left flip nor the far-right H (which bounds
+the spread to two TBUs) changes it. -/
+theorem bemba_requiresBothSides : RequiresBothSides bemba.map := by
+  intro d
+  refine ⟨bw .H .L d, d + 3, by rw [bw_length]; omega, ?_,
+    ⟨bw .L .L d, by rw [bw_length, bw_length], ?_, ?_, ?_⟩,
+    ⟨bw .H .H d, by rw [bw_length, bw_length], ?_, ?_, ?_⟩⟩
+  · rw [bemba.map_getElem?_hi_iff.mpr bembaSurfaces_bw_HL, bw_mid]
+    decide
+  · intro k hk
+    rw [bw_getElem?, bw_getElem?]
+    split_ifs <;> first | rfl | omega
+  · rw [bw_mid, bw_mid]
+  · rw [bw_mid, bemba.map_getElem?_lo_iff.mpr
+      ⟨by rw [bw_length]; omega, not_bembaSurfaces_bw_LL⟩]
+    rfl
+  · intro k hk
+    rw [bw_getElem?, bw_getElem?]
+    split_ifs <;> first | rfl | omega
+  · rw [bw_mid, bw_mid]
+  · rw [bw_mid, bemba.map_getElem?_lo_iff.mpr
+      ⟨by rw [bw_length]; omega, not_bembaSurfaces_bw_HH⟩]
+    rfl
+
+/-- **Prop. 5.4**: Bemba high-tone spreading is not weakly deterministic. -/
+theorem bemba_not_bmrsWeaklyDeterministic : ¬ IsBmrsWeaklyDeterministic bemba.map :=
+  not_isBmrsWeaklyDeterministic_of_requiresBothSides bemba_requiresBothSides
+
+/-- The bimachine twin, off the same witness. -/
+theorem bemba_not_bimachineWeaklyDeterministic :
+    ¬ IsBimachineWeaklyDeterministic bemba.map :=
+  not_isBimachineWeaklyDeterministic_of_requiresBothSides bemba_requiresBothSides
 
 /-! ### The positive side: LHOL stress as a simultaneous application (§5.2)
 


### PR DESCRIPTION
Unbounded tonal plateauing graduates from `Studies/Jardine2016Tone` to `Phonology/Tone/Plateauing.lean` (second consumer: `Studies/Yolyan2025`), anchored on hyman-katamba-2010 with jardine-2016's string rendering — and the surfacing context now lives on the process object: `Tone.Surfacing` bundles marked tone + context predicate + in-domain/faithfulness laws, with the induced `map`, `support`, and pointwise characterizations generic.

- `utp : Tone.Surfacing TBU` — consumers say `utp.map`/`utp.Surfaces`; plateau-specific API (convexity, closure laws, Icc, rule schemata, `RequiresBothSides` witness) stays UTP-owned.
- Bemba high-tone spreading (Yolyan Prop. 5.4) lands as the second `Surfacing` instance with its own witness family — and it is deliberately the instance that disciplines the abstraction: its surface set is non-convex and its map non-monotone, non-idempotent, so only the genuinely shared API is generic.
- `List.mem_take_iff`/`mem_drop_iff` strays land in `Core/Data/List/TakeDrop.lean` (mathlib-mirror named; absent upstream).