### PR TITLE
style(Semantics/ArgumentStructure): mathlib polish of EntailmentProfile

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -25,7 +25,7 @@ open Semantics.Lexical
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Core.Order (Boundedness)
 open Semantics.Aspect.Incremental (VerbIncClass)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § English Morphophonological Rules

--- a/Linglib/Fragments/French/Predicates.lean
+++ b/Linglib/Fragments/French/Predicates.lean
@@ -18,8 +18,9 @@ namespace French.Predicates
 
 open Semantics.Lexical
 open Features (Causative)
-open Semantics.ArgumentStructure.EntailmentProfile
-  (EntailmentProfile kickSubjectProfile seeSubjectProfile runSubjectProfile)
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
+  (kickSubjectProfile seeSubjectProfile runSubjectProfile)
 
 /-- French verb entry: extends Verb with French inflectional paradigm. -/
 structure FrenchVerbEntry extends Verb where

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -30,7 +30,7 @@ namespace Spanish.Predicates
 
 open Minimalist
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 
 -- ============================================================================
 -- § 1: Anticausative Marking

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -65,7 +65,8 @@ you nothing about whether it entails change, and vice versa.
 -/
 
 open Semantics.Lexical.EventStructure
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Features.ChangeOfState
 open Features
 

--- a/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
@@ -71,7 +71,8 @@ composed meaning — not the root-level or surface-diagnostic level.
 
 namespace Semantics.ArgumentStructure.Affectedness.Profile
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § 1. Re-exports from Events/AffectednessHierarchy

--- a/Linglib/Semantics/ArgumentStructure/AgentivityLattice.lean
+++ b/Linglib/Semantics/ArgumentStructure/AgentivityLattice.lean
@@ -49,7 +49,8 @@ All ordering infrastructure uses Mathlib typeclasses:
 
 namespace Semantics.ArgumentStructure.AgentivityLattice
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 open Core
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -51,7 +51,8 @@ open Verb
 open Semantics.Lexical
 open Semantics.Lexical.EventStructure (Template)
 open Features.LevinClassProfiles
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 open Root.Kinds
 
 -- ════════════════════════════════════════════════════
@@ -300,7 +301,7 @@ def deriveEnriched (re : Root.Kinds) (mc : MeaningComponents) : Option ArgTempla
     | .activity =>
       if mc.contact then
         -- Transitive activity: subject gets C from causal interaction
-        some { subjectProfile := Semantics.ArgumentStructure.EntailmentProfile.accomplishmentSubjectProfile,
+        some { subjectProfile := ArgumentStructure.EntailmentProfile.accomplishmentSubjectProfile,
                objectProfile := some ⟨false, false, false, false, false, false, false, true, true, false⟩ }
       else
         some base

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -1,406 +1,330 @@
 /-!
-# Entailment Profiles and the Argument Selection Principle
+# Proto-role entailment profiles
 
-[dowty-1991] [davis-koenig-2000] [grimm-2011] [levin-2019]
-[beavers-2010]
+[dowty-1991] [grimm-2011] [davis-koenig-2000] [levin-2019]
 
-Entailment profiles encode the lexical entailments a verb imposes on each of
-its arguments, reflecting the modern consensus on proto-roles
-([levin-2019]). Proto-Agent and Proto-Patient are **cluster concepts**:
-each is a set of entailments, and an argument's "degree of agenthood/patienthood"
-is determined by which entailments it satisfies.
+An `EntailmentProfile` records which of [dowty-1991]'s ten proto-role
+entailments (pp.572–573) a verb imposes on one of its arguments. Proto-Agent
+and Proto-Patient are cluster concepts: each is a set of entailments, and an
+argument's degree of agenthood or patienthood is the set it satisfies. The
+Argument Selection Principle is stated lattice-theoretically ([grimm-2011]):
+subjecthood tracks strict superset dominance on Proto-Agent feature sets,
+with Proto-Patient dominance breaking ties.
 
-## Entailment structure
+## Main declarations
 
-The 10 entailments are not fully independent ([levin-2019] §2.1):
+- `EntailmentProfile` — the ten Boolean entailment fields
+- `EntailmentProfile.pAgentScore`, `EntailmentProfile.pPatientScore` —
+  flat feature counts
+- `PAgentDominates`, `PPatientDominates` — subset ordering on feature sets
+- `OutranksForSubject` — the lattice-based Argument Selection Principle
+- `PredictsUnaccusative`, `PredictsUnergative` — split-intransitivity
+  predictions
+- `kickSubjectProfile` … `accomplishmentObjectProfile` — canonical per-verb
+  and per-template profiles
 
-- **P-Agent pairing**: three P-Agent entailments are paired with P-Patient
-  entailments in asymmetric relations (causation↔changeOfState,
-  movement↔stationary, independentExistence↔dependentExistence).
-- **P-Agent dependency**: volition presupposes sentience.
-- **P-Agent priority**: causation outranks other P-Agent entailments for
-  subject selection ([davis-koenig-2000]).
-- **P-Patient implicational structure**: the affectedness-related entailments
-  (changeOfState, incrementalTheme, causallyAffected) form an implicational
-  hierarchy ([beavers-2010]).
+## Implementation notes
 
-These dependencies are exploited by the modern ASP (lattice comparison, §3–4)
-and formalized algebraically in `AgentivityLattice.lean`:
-- **P-Agent** → `AgentivityNode` (4 privative features on a lattice;
-  [grimm-2011])
-- **P-Patient** → `PersistenceLevel` (4 persistence dimensions;
-  [grimm-2011]), and `AffectednessDegree` (implicational hierarchy
-  of truth-conditional strength; [beavers-2010])
-
-## Argument Selection Principle (lattice-based)
-
-The ASP uses **lattice comparison** ([grimm-2011]): argument A outranks
-argument B for subjecthood iff A's P-Agent feature set dominates (is a superset of)
-B's. When P-Agent features are incomparable, P-Patient features break the tie.
-This naturally handles priority because feature-set inclusion respects the
-entailment dependencies.
-
-For unaccusativity, the priority-based approach checks whether the sole argument
-has core agentive features (volition/causation) rather than flat-counting.
-
-[dowty-1991]'s original flat-counting ASP is preserved in
-`Studies/Dowty1991.lean` for comparison.
+The ten entailments are not independent ([levin-2019] §2.1): volition
+presupposes sentience (`EntailmentProfile.WellFormedInternal`); causation,
+movement, and independent existence pair asymmetrically with Proto-Patient
+entailments (`WellFormedPair`); and the affectedness-related Proto-Patient
+entailments form an implicational hierarchy ([beavers-2010]). Their algebraic
+counterparts live in `AgentivityLattice.lean`. [dowty-1991]'s original
+flat-counting selection principle is preserved for comparison in
+`Studies/Dowty1991.lean`; the counting accessors here are informational only.
+Causation priority ([davis-koenig-2000]) needs no extra clause: it falls out
+of feature-set inclusion.
 -/
 
 namespace Semantics.ArgumentStructure.EntailmentProfile
 
--- ════════════════════════════════════════════════════
--- § 1. Entailment Profile ([dowty-1991] pp.572–573)
--- ════════════════════════════════════════════════════
-
-/-- The 10 entailments defining Proto-Agent and Proto-Patient
-    ([dowty-1991] pp.572–573).
-
-    Proto-Agent entailments (a)–(e):
-    - volition, sentience, causation, movement, independent existence
-
-    Proto-Patient entailments (a)–(e):
-    - change of state, incremental theme, causally affected, stationary,
-      dependent existence -/
+/-- The ten entailments defining the proto-roles ([dowty-1991] pp.572–573):
+the first five are Proto-Agent, the last five Proto-Patient. Fields default
+to `false`, so a profile lists only the entailments it imposes. -/
 structure EntailmentProfile where
-  -- Proto-Agent entailments
-  /-- (a) volitional involvement in the event -/
-  volition            : Bool
-  /-- (b) sentience/perception -/
-  sentience           : Bool
-  /-- (c) causing an event or change of state in another participant -/
-  causation           : Bool
-  /-- (d) movement (relative to another participant) -/
-  movement            : Bool
-  /-- (e) exists independently of the event named by the verb -/
-  independentExistence : Bool
-  -- Proto-Patient entailments
-  /-- (a) undergoes change of state -/
-  changeOfState       : Bool
-  /-- (b) incremental theme (Krifka's SINC) -/
-  incrementalTheme    : Bool
-  /-- (c) causally affected by another participant -/
-  causallyAffected    : Bool
-  /-- (d) stationary relative to another participant -/
-  stationary          : Bool
-  /-- (e) does not exist independently of the event -/
-  dependentExistence  : Bool
+  /-- Volitional involvement in the event. -/
+  volition : Bool := false
+  /-- Sentience or perception. -/
+  sentience : Bool := false
+  /-- Causes an event or change of state in another participant. -/
+  causation : Bool := false
+  /-- Movement relative to another participant. -/
+  movement : Bool := false
+  /-- Exists independently of the event named by the verb. -/
+  independentExistence : Bool := false
+  /-- Undergoes a change of state. -/
+  changeOfState : Bool := false
+  /-- Incremental theme: the argument measures out the event. -/
+  incrementalTheme : Bool := false
+  /-- Causally affected by another participant. -/
+  causallyAffected : Bool := false
+  /-- Stationary relative to another participant. -/
+  stationary : Bool := false
+  /-- Does not exist independently of the event. -/
+  dependentExistence : Bool := false
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 2. Feature Counting (informational, NOT used for ASP)
--- ════════════════════════════════════════════════════
+variable (p q subj obj : EntailmentProfile)
 
-/-- Count of Proto-Agent entailments. Informational — the modern ASP
-    uses lattice comparison, not counting. Retained for bridge theorems
-    and backward compatibility with study files. -/
-def EntailmentProfile.pAgentScore (p : EntailmentProfile) : Nat :=
+/-! ### Feature counting -/
+
+/-- Number of Proto-Agent entailments. Informational: the Argument Selection
+Principle uses lattice comparison ([grimm-2011]), not counting. -/
+def EntailmentProfile.pAgentScore : Nat :=
   p.volition.toNat + p.sentience.toNat + p.causation.toNat +
   p.movement.toNat + p.independentExistence.toNat
 
-/-- Count of Proto-Patient entailments. -/
-def EntailmentProfile.pPatientScore (p : EntailmentProfile) : Nat :=
+/-- Number of Proto-Patient entailments. -/
+def EntailmentProfile.pPatientScore : Nat :=
   p.changeOfState.toNat + p.incrementalTheme.toNat +
   p.causallyAffected.toNat + p.stationary.toNat +
   p.dependentExistence.toNat
 
--- ════════════════════════════════════════════════════
--- § 3. Lattice Comparison ([grimm-2011])
--- ════════════════════════════════════════════════════
+/-! ### Lattice comparison -/
 
-/-- P-Agent feature dominance: `p` has every P-Agent feature that `q` has.
-    This is the subset ordering on P-Agent feature sets. -/
-def PAgentDominates (p q : EntailmentProfile) : Prop :=
+/-- `p` has every Proto-Agent feature that `q` has: the subset ordering on
+Proto-Agent feature sets. -/
+def PAgentDominates : Prop :=
   (q.volition = true → p.volition = true) ∧
   (q.sentience = true → p.sentience = true) ∧
   (q.causation = true → p.causation = true) ∧
   (q.movement = true → p.movement = true) ∧
   (q.independentExistence = true → p.independentExistence = true)
 
-instance (p q : EntailmentProfile) : Decidable (PAgentDominates p q) := by
+instance : Decidable (PAgentDominates p q) := by
   unfold PAgentDominates; infer_instance
 
-/-- P-Patient feature dominance: `p` has every P-Patient feature that `q` has. -/
-def PPatientDominates (p q : EntailmentProfile) : Prop :=
+/-- `p` has every Proto-Patient feature that `q` has. -/
+def PPatientDominates : Prop :=
   (q.changeOfState = true → p.changeOfState = true) ∧
   (q.incrementalTheme = true → p.incrementalTheme = true) ∧
   (q.causallyAffected = true → p.causallyAffected = true) ∧
   (q.stationary = true → p.stationary = true) ∧
   (q.dependentExistence = true → p.dependentExistence = true)
 
-instance (p q : EntailmentProfile) : Decidable (PPatientDominates p q) := by
+instance : Decidable (PPatientDominates p q) := by
   unfold PPatientDominates; infer_instance
 
-/-- Strict P-Agent dominance: `p` dominates `q` but not vice versa.
-    Means `p` has a strict superset of `q`'s P-Agent features. -/
-def PAgentStrictlyDominates (p q : EntailmentProfile) : Prop :=
+/-- `p`'s Proto-Agent feature set is a strict superset of `q`'s. -/
+def PAgentStrictlyDominates : Prop :=
   PAgentDominates p q ∧ ¬ PAgentDominates q p
 
-instance (p q : EntailmentProfile) : Decidable (PAgentStrictlyDominates p q) := by
+instance : Decidable (PAgentStrictlyDominates p q) := by
   unfold PAgentStrictlyDominates; infer_instance
 
-/-- Strict P-Patient dominance. -/
-def PPatientStrictlyDominates (p q : EntailmentProfile) : Prop :=
+/-- `p`'s Proto-Patient feature set is a strict superset of `q`'s. -/
+def PPatientStrictlyDominates : Prop :=
   PPatientDominates p q ∧ ¬ PPatientDominates q p
 
-instance (p q : EntailmentProfile) : Decidable (PPatientStrictlyDominates p q) := by
+instance : Decidable (PPatientStrictlyDominates p q) := by
   unfold PPatientStrictlyDominates; infer_instance
 
--- ════════════════════════════════════════════════════
--- § 4. Argument Selection Principle (lattice-based)
--- ════════════════════════════════════════════════════
+theorem pAgentDominates_refl : PAgentDominates p p :=
+  ⟨id, id, id, id, id⟩
 
-/-- Modern ASP: `subj` outranks `obj` for subjecthood iff:
-    (1) `subj` strictly dominates `obj` on P-Agent features
-        (subj's P-Agent set ⊃ obj's P-Agent set), OR
-    (2) Neither strictly dominates the other on P-Agent, AND `obj`
-        strictly dominates `subj` on P-Patient (obj is a "better"
-        object, hence subj wins by exclusion).
+theorem pPatientDominates_refl : PPatientDominates p p :=
+  ⟨id, id, id, id, id⟩
 
-    This replaces [dowty-1991]'s flat counting with lattice
-    comparison ([grimm-2011], [davis-koenig-2000]). Priority
-    of causation is captured structurally: {causation, IE} ⊃ {IE} but
-    {causation, IE} ⊥ {sentience, IE} (incomparable). -/
-def OutranksForSubject (subj obj : EntailmentProfile) : Prop :=
+/-! ### Argument selection -/
+
+/-- The lattice-based Argument Selection Principle ([grimm-2011],
+[davis-koenig-2000]): `subj` outranks `obj` for subjecthood iff `subj`
+strictly Proto-Agent-dominates `obj`, or the two are Proto-Agent-incomparable
+and `obj` strictly Proto-Patient-dominates `subj`. Causation priority is
+structural: `{causation, IE}` strictly dominates `{IE}` yet is incomparable
+with `{sentience, IE}`. -/
+def OutranksForSubject : Prop :=
   PAgentStrictlyDominates subj obj ∨
   (¬ PAgentStrictlyDominates subj obj ∧ ¬ PAgentStrictlyDominates obj subj ∧
    PPatientStrictlyDominates obj subj)
 
-instance (subj obj : EntailmentProfile) : Decidable (OutranksForSubject subj obj) := by
+instance : Decidable (OutranksForSubject subj obj) := by
   unfold OutranksForSubject; infer_instance
 
-/-- Corollary 1 ([dowty-1991] p.579): Neither argument outranks
-    the other → alternation is possible (buy/sell, like/please). -/
-def AllowsAlternation (arg1 arg2 : EntailmentProfile) : Prop :=
-  ¬ OutranksForSubject arg1 arg2 ∧ ¬ OutranksForSubject arg2 arg1
+/-- [dowty-1991]'s Corollary 1 (p.579): neither argument outranks the other,
+so subject choice may alternate (*buy*/*sell*, *like*/*please*). -/
+def AllowsAlternation : Prop :=
+  ¬ OutranksForSubject p q ∧ ¬ OutranksForSubject q p
 
-instance (arg1 arg2 : EntailmentProfile) : Decidable (AllowsAlternation arg1 arg2) := by
+instance : Decidable (AllowsAlternation p q) := by
   unfold AllowsAlternation; infer_instance
 
--- ════════════════════════════════════════════════════
--- § 5. Unaccusativity (priority-based)
--- ════════════════════════════════════════════════════
+/-! ### Split intransitivity -/
 
-/-- Predicts unaccusativity for intransitive verbs.
-
-    An intransitive subject is unaccusative iff it lacks core agentive
-    features (volition AND causation) and has at least one P-Patient
-    feature. This matches [dowty-1991]'s Table 1 cell 4 and fixes
-    the `arrive` anomaly that flat counting gets wrong.
-
-    [davis-koenig-2000]: causation and volition are the priority
-    P-Agent entailments. Their absence signals non-agentivity. -/
-def PredictsUnaccusative (p : EntailmentProfile) : Prop :=
+/-- The sole argument lacks the priority Proto-Agent entailments — volition
+and causation ([davis-koenig-2000]) — and bears at least one Proto-Patient
+entailment ([dowty-1991] Table 1). Unlike flat counting, this classifies
+*arrive* as unaccusative. -/
+def PredictsUnaccusative : Prop :=
   p.volition = false ∧ p.causation = false ∧ p.pPatientScore > 0
 
-instance (p : EntailmentProfile) : Decidable (PredictsUnaccusative p) := by
+instance : DecidablePred PredictsUnaccusative := λ p => by
   unfold PredictsUnaccusative; infer_instance
 
-/-- Predicts unergative for intransitive verbs.
-
-    An intransitive subject is unergative iff it has at least one core
-    agentive feature (volition or causation) and no P-Patient features. -/
-def PredictsUnergative (p : EntailmentProfile) : Prop :=
+/-- The sole argument bears a priority Proto-Agent entailment (volition or
+causation) and no Proto-Patient entailment. -/
+def PredictsUnergative : Prop :=
   (p.volition = true ∨ p.causation = true) ∧ p.pPatientScore = 0
 
-instance (p : EntailmentProfile) : Decidable (PredictsUnergative p) := by
+instance : DecidablePred PredictsUnergative := λ p => by
   unfold PredictsUnergative; infer_instance
 
--- ════════════════════════════════════════════════════
--- § 6. Well-Formedness Constraints ([levin-2019], [davis-koenig-2000])
--- ════════════════════════════════════════════════════
+/-! ### Well-formedness -/
 
-/-- Intra-profile well-formedness: volition presupposes sentience.
-    Only sentient entities can be volitional ([dowty-1991] p.607,
-    [levin-2019] §2.1). -/
-def EntailmentProfile.WellFormedInternal (p : EntailmentProfile) : Prop :=
+/-- Volition presupposes sentience: only sentient entities can act
+volitionally ([dowty-1991] p.607, [levin-2019] §2.1). -/
+def EntailmentProfile.WellFormedInternal : Prop :=
   p.volition = true → p.sentience = true
 
-instance (p : EntailmentProfile) : Decidable p.WellFormedInternal := by
+instance : DecidablePred EntailmentProfile.WellFormedInternal := λ p => by
   unfold EntailmentProfile.WellFormedInternal; infer_instance
 
-/-- Inter-argument well-formedness ([davis-koenig-2000],
-    [primus-1999]): three P-Agent entailments are paired with
-    P-Patient entailments in asymmetric relations.
-
-    - causation (subject) → changeOfState (object)
-    - movement (subject) → stationary (object)
-    - independentExistence (subject) → dependentExistence (object) -/
-def WellFormedPair (subj obj : EntailmentProfile) : Prop :=
+/-- Three Proto-Agent entailments pair asymmetrically across a
+subject–object pair ([davis-koenig-2000], [primus-1999]): causation →
+changeOfState, movement → stationary, independentExistence →
+dependentExistence. -/
+def WellFormedPair : Prop :=
   (subj.causation = true → obj.changeOfState = true) ∧
   (subj.movement = true → obj.stationary = true) ∧
   (subj.independentExistence = true → obj.dependentExistence = true)
 
-instance (subj obj : EntailmentProfile) : Decidable (WellFormedPair subj obj) := by
+instance : Decidable (WellFormedPair subj obj) := by
   unfold WellFormedPair; infer_instance
 
--- ════════════════════════════════════════════════════
--- § 7. Do-Test ([cruse-1973] via [dowty-1991])
--- ════════════════════════════════════════════════════
+/-! ### The do-test -/
 
-/-- Source of do-test acceptability. -/
-inductive DoTestSource where
-  | semantic    -- Profile-based: verb entails volition/causation/movement
-  | pragmatic   -- Complement-based: complement evokes agentivity
-  deriving DecidableEq, Repr
-
-/-- The do-test passes (semantically) iff at least one of
-    {volition, causation, movement} holds. -/
-def PassesDoTestFromProfile (p : EntailmentProfile) : Prop :=
+/-- The *do*-test ([cruse-1973] via [dowty-1991]) passes on semantic grounds
+iff the profile entails volition, causation, or movement. -/
+def PassesDoTestFromProfile : Prop :=
   p.volition = true ∨ p.causation = true ∨ p.movement = true
 
-instance (p : EntailmentProfile) : Decidable (PassesDoTestFromProfile p) := by
+instance : DecidablePred PassesDoTestFromProfile := λ p => by
   unfold PassesDoTestFromProfile; infer_instance
 
--- ════════════════════════════════════════════════════
--- § 8. Effector / Force Recipient
--- ════════════════════════════════════════════════════
+/-! ### Effectors and force recipients -/
 
-/-- An effector ([van-valin-wilkins-1996]) is a self-energetic force
-    bearer: movement + independent existence. Realized as external argument. -/
-def IsEffector (p : EntailmentProfile) : Prop :=
+/-- A self-energetic force bearer ([van-valin-wilkins-1996]): movement plus
+independent existence, realized as external argument. -/
+def IsEffector : Prop :=
   p.movement = true ∧ p.independentExistence = true
 
-instance (p : EntailmentProfile) : Decidable (IsEffector p) := by
+instance : DecidablePred IsEffector := λ p => by
   unfold IsEffector; infer_instance
 
-/-- A force recipient is causally affected or stationary.
-    Realized as internal argument. -/
-def IsForceRecipient (p : EntailmentProfile) : Prop :=
+/-- Causally affected or stationary, realized as internal argument. -/
+def IsForceRecipient : Prop :=
   p.causallyAffected = true ∨ p.stationary = true
 
-instance (p : EntailmentProfile) : Decidable (IsForceRecipient p) := by
+instance : DecidablePred IsForceRecipient := λ p => by
   unfold IsForceRecipient; infer_instance
 
-/-- Effectors have at least 2 P-Agent entailments (movement + IE). -/
-theorem effector_has_pAgent (p : EntailmentProfile) (h : IsEffector p) :
-    p.pAgentScore ≥ 2 := by
-  obtain ⟨hm, hie⟩ := h
-  simp [EntailmentProfile.pAgentScore, hm, hie]
+/-- An effector carries at least two Proto-Agent entailments. -/
+theorem two_le_pAgentScore_of_isEffector (h : IsEffector p) :
+    2 ≤ p.pAgentScore := by
+  simp [EntailmentProfile.pAgentScore, h.1, h.2]
 
--- ════════════════════════════════════════════════════
--- § 9. Canonical Verb Profiles
--- ════════════════════════════════════════════════════
+/-! ### Canonical verb profiles
 
--- These profiles define the canonical entailment content for specific
--- verb senses. Used by EventStructure, RootTypology, and study files.
+Canonical entailment content for specific verb senses, consumed by
+`EventStructure.lean`, `Morphology/RootTypology.lean`, and study files. -/
 
-/-- "kick" subject: V+S+C+M+IE (prototypical agent, 5 P-Ag) -/
+/-- *kick* subject: prototypical agent (V+S+C+M+IE). -/
 def kickSubjectProfile : EntailmentProfile :=
-  ⟨true, true, true, true, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, causation := true, movement := true,
+    independentExistence := true }
 
-/-- "kick" object: CoS+CA+St (3 P-Pat) -/
+/-- *kick* object: CoS+CA+St. -/
 def kickObjectProfile : EntailmentProfile :=
-  ⟨false, false, false, false, false, true, false, true, true, false⟩
+  { changeOfState := true, causallyAffected := true, stationary := true }
 
-/-- "build" subject: V+S+C+M+IE (5 P-Ag) -/
+/-- *build* subject: V+S+C+M+IE. -/
 def buildSubjectProfile : EntailmentProfile :=
-  ⟨true, true, true, true, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, causation := true, movement := true,
+    independentExistence := true }
 
-/-- "build" object: CoS+IT+CA+DE (4 P-Pat, incremental theme, dependent existence) -/
+/-- *build* object: CoS+IT+CA+DE (incremental theme, dependent existence). -/
 def buildObjectProfile : EntailmentProfile :=
-  ⟨false, false, false, false, false, true, true, true, false, true⟩
+  { changeOfState := true, incrementalTheme := true, causallyAffected := true,
+    dependentExistence := true }
 
-/-- "see" subject: S+IE (experiencer, 2 P-Ag) -/
+/-- *see* subject: experiencer (S+IE). -/
 def seeSubjectProfile : EntailmentProfile :=
-  ⟨false, true, false, false, true, false, false, false, false, false⟩
+  { sentience := true, independentExistence := true }
 
-/-- "run" subject: V+S+M+IE (4 P-Ag, unergative) -/
+/-- *run* subject: V+S+M+IE (unergative). -/
 def runSubjectProfile : EntailmentProfile :=
-  ⟨true, true, false, true, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, movement := true,
+    independentExistence := true }
 
-/-- "arrive" subject: M+IE+CoS (2 P-Ag, 1 P-Pat — unaccusative) -/
+/-- *arrive* subject: M+IE+CoS (unaccusative). -/
 def arriveSubjectProfile : EntailmentProfile :=
-  ⟨false, false, false, true, true, true, false, false, false, false⟩
+  { movement := true, independentExistence := true, changeOfState := true }
 
-/-- "die" subject: CoS+CA+DE (0 P-Ag, 3 P-Pat — unaccusative) -/
+/-- *die* subject: CoS+CA+DE (unaccusative). -/
 def dieSubjectProfile : EntailmentProfile :=
-  ⟨false, false, false, false, false, true, false, true, false, true⟩
+  { changeOfState := true, causallyAffected := true, dependentExistence := true }
 
-/-- "eat" subject: V+S+C+M+IE (5 P-Ag) -/
+/-- *eat* subject: V+S+C+M+IE. -/
 def eatSubjectProfile : EntailmentProfile :=
-  ⟨true, true, true, true, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, causation := true, movement := true,
+    independentExistence := true }
 
-/-- "eat" object: CoS+IT+CA (3 P-Pat, incremental theme) -/
+/-- *eat* object: CoS+IT+CA (incremental theme). -/
 def eatObjectProfile : EntailmentProfile :=
-  ⟨false, false, false, false, false, true, true, true, false, false⟩
+  { changeOfState := true, incrementalTheme := true, causallyAffected := true }
 
-/-- "buy" subject: V+S+C+IE (4 P-Ag) -/
+/-- *buy* subject: V+S+C+IE. -/
 def buySubjectProfile : EntailmentProfile :=
-  ⟨true, true, true, false, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, causation := true,
+    independentExistence := true }
 
-/-- "sell" subject: V+S+C+IE (same as buy — 4 P-Ag) -/
+/-- *sell* subject: V+S+C+IE (same as *buy*). -/
 def sellSubjectProfile : EntailmentProfile :=
-  ⟨true, true, true, false, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, causation := true,
+    independentExistence := true }
 
-/-- "sweep" basic-sense subject: M+IE (movement + independent existence).
-    Underspecified for volition — agentivity is pragmatically resolved. -/
+/-- *sweep* basic-sense subject: M+IE only; underspecified for volition, so
+agentivity is pragmatically resolved. -/
 def sweepBasicSubjectProfile : EntailmentProfile :=
-  ⟨false, false, false, true, true, false, false, false, false, false⟩
+  { movement := true, independentExistence := true }
 
-/-- "sweep" broom-sense subject: V+S+C+M+IE (obligatory agent, 5 P-Ag).
-    Instrument lexicalization forces volition, sentience, causation. -/
+/-- *sweep* broom-sense subject: obligatory agent (V+S+C+M+IE); instrument
+lexicalization forces volition, sentience, causation. -/
 def sweepBroomSubjectProfile : EntailmentProfile :=
-  ⟨true, true, true, true, true, false, false, false, false, false⟩
+  { volition := true, sentience := true, causation := true, movement := true,
+    independentExistence := true }
 
-/-! ### Template-level proto-role defaults ([rappaport-hovav-levin-1998] + [dowty-1991])
+/-! ### Template-level proto-role defaults
 
-Per-template canonical subject/object profiles consumed by
-`Template.subjectProfile` / `Template.objectProfile` in `EventStructure.lean`
-and by Fragment-level verb entries. Named-field syntax. -/
+Per-template subject/object defaults ([rappaport-hovav-levin-1998] with
+[dowty-1991]'s entailments), consumed by `Template.subjectProfile` and
+`Template.objectProfile` in `EventStructure.lean` and by Fragment-level verb
+entries. -/
 
-/-- State template subject: S + IE only. Psych-state holder
-(*admire*, *want*). -/
+/-- State template subject: psych-state holder (*admire*, *want*) — S+IE. -/
 def stateSubjectProfile : EntailmentProfile :=
-  { volition := false, sentience := true, causation := false, movement := false,
-    independentExistence := true,
-    changeOfState := false, incrementalTheme := false, causallyAffected := false,
-    stationary := false, dependentExistence := false }
+  { sentience := true, independentExistence := true }
 
-/-- Activity template subject: V + S + M + IE (no causation; transitive
-activities like *hit* add C at the class level via root-contributed objects). -/
+/-- Activity template subject: V+S+M+IE. Transitive activities like *hit*
+add causation at the class level via root-contributed objects. -/
 def activitySubjectProfile : EntailmentProfile :=
-  { volition := true, sentience := true, causation := false, movement := true,
-    independentExistence := true,
-    changeOfState := false, incrementalTheme := false, causallyAffected := false,
-    stationary := false, dependentExistence := false }
+  { volition := true, sentience := true, movement := true,
+    independentExistence := true }
 
-/-- Achievement template subject: M + IE + CoS (undergoes change). -/
+/-- Achievement template subject: undergoes change (M+IE+CoS). -/
 def achievementSubjectProfile : EntailmentProfile :=
-  { volition := false, sentience := false, causation := false, movement := true,
-    independentExistence := true,
-    changeOfState := true, incrementalTheme := false, causallyAffected := false,
-    stationary := false, dependentExistence := false }
+  { movement := true, independentExistence := true, changeOfState := true }
 
-/-- Accomplishment template subject: V + S + C + M + IE (full proto-agent,
-5 P-Agent entailments per [dowty-1991]). -/
+/-- Accomplishment template subject: full proto-agent (V+S+C+M+IE). -/
 def accomplishmentSubjectProfile : EntailmentProfile :=
   { volition := true, sentience := true, causation := true, movement := true,
-    independentExistence := true,
-    changeOfState := false, incrementalTheme := false, causallyAffected := false,
-    stationary := false, dependentExistence := false }
+    independentExistence := true }
 
-/-- Accomplishment template object default: CoS + CA (result patient).
-IT (incremental theme) is NOT included — not all accomplishment objects
-measure the event. Verbs with IT (*eat*, *build*) add it per-verb. -/
+/-- Accomplishment template object: result patient (CoS+CA). Incremental
+themes (*eat*, *build*) add IT per-verb — not all accomplishment objects
+measure the event. -/
 def accomplishmentObjectProfile : EntailmentProfile :=
-  { volition := false, sentience := false, causation := false, movement := false,
-    independentExistence := false,
-    changeOfState := true, incrementalTheme := false, causallyAffected := true,
-    stationary := false, dependentExistence := false }
-
--- ════════════════════════════════════════════════════
--- § 10. Verification Theorems
--- ════════════════════════════════════════════════════
-
--- Dominance is reflexive
-
-theorem pAgentDominates_refl (p : EntailmentProfile) :
-    PAgentDominates p p :=
-  ⟨id, id, id, id, id⟩
-
-theorem pPatientDominates_refl (p : EntailmentProfile) :
-    PPatientDominates p p :=
-  ⟨id, id, id, id, id⟩
+  { changeOfState := true, causallyAffected := true }
 
 end Semantics.ArgumentStructure.EntailmentProfile

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -37,7 +37,7 @@ Causation priority ([davis-koenig-2000]) needs no extra clause: it falls out
 of feature-set inclusion.
 -/
 
-namespace Semantics.ArgumentStructure.EntailmentProfile
+namespace ArgumentStructure
 
 /-- The ten entailments defining the proto-roles ([dowty-1991] pp.572–573):
 the first five are Proto-Agent, the last five Proto-Patient. Fields default
@@ -65,18 +65,20 @@ structure EntailmentProfile where
   dependentExistence : Bool := false
   deriving DecidableEq, Repr
 
+namespace EntailmentProfile
+
 variable (p q subj obj : EntailmentProfile)
 
 /-! ### Feature counting -/
 
 /-- Number of Proto-Agent entailments. Informational: the Argument Selection
 Principle uses lattice comparison ([grimm-2011]), not counting. -/
-def EntailmentProfile.pAgentScore : Nat :=
+def pAgentScore : Nat :=
   p.volition.toNat + p.sentience.toNat + p.causation.toNat +
   p.movement.toNat + p.independentExistence.toNat
 
 /-- Number of Proto-Patient entailments. -/
-def EntailmentProfile.pPatientScore : Nat :=
+def pPatientScore : Nat :=
   p.changeOfState.toNat + p.incrementalTheme.toNat +
   p.causallyAffected.toNat + p.stationary.toNat +
   p.dependentExistence.toNat
@@ -174,11 +176,11 @@ instance : DecidablePred PredictsUnergative := λ p => by
 
 /-- Volition presupposes sentience: only sentient entities can act
 volitionally ([dowty-1991] p.607, [levin-2019] §2.1). -/
-def EntailmentProfile.WellFormedInternal : Prop :=
+def WellFormedInternal : Prop :=
   p.volition = true → p.sentience = true
 
-instance : DecidablePred EntailmentProfile.WellFormedInternal := λ p => by
-  unfold EntailmentProfile.WellFormedInternal; infer_instance
+instance : DecidablePred WellFormedInternal := λ p => by
+  unfold WellFormedInternal; infer_instance
 
 /-- Three Proto-Agent entailments pair asymmetrically across a
 subject–object pair ([davis-koenig-2000], [primus-1999]): causation →
@@ -222,7 +224,7 @@ instance : DecidablePred IsForceRecipient := λ p => by
 /-- An effector carries at least two Proto-Agent entailments. -/
 theorem two_le_pAgentScore_of_isEffector (h : IsEffector p) :
     2 ≤ p.pAgentScore := by
-  simp [EntailmentProfile.pAgentScore, h.1, h.2]
+  simp [pAgentScore, h.1, h.2]
 
 /-! ### Canonical verb profiles
 
@@ -327,4 +329,6 @@ measure the event. -/
 def accomplishmentObjectProfile : EntailmentProfile :=
   { changeOfState := true, causallyAffected := true }
 
-end Semantics.ArgumentStructure.EntailmentProfile
+end EntailmentProfile
+
+end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -62,7 +62,8 @@ Accounts expressible via this interface (non-exhaustive):
 
 -/
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 1. Theta Role Labels (derived convenience names)
@@ -92,7 +93,7 @@ inductive ThetaRole where
 -- § 2. EntailmentProfile → ThetaRole (canonical direction)
 -- ════════════════════════════════════════════════════════════════════════
 
-namespace Semantics.ArgumentStructure.EntailmentProfile
+namespace ArgumentStructure.EntailmentProfile
 
 /-- Derive a convenience theta-role label from an entailment profile.
 
@@ -112,7 +113,7 @@ namespace Semantics.ArgumentStructure.EntailmentProfile
     ({causation, IE}), as do goal and source ({IE}). The function
     defaults to stimulus and goal respectively. Disambiguation requires
     external context (e.g., `Verb.causalSource`). -/
-def EntailmentProfile.toRole (p : EntailmentProfile) : Option ThetaRole :=
+def toRole (p : EntailmentProfile) : Option ThetaRole :=
   if p.volition then some .agent
   else if p.sentience && !p.causation then some .experiencer
   else if p.causation && !p.sentience then some .stimulus
@@ -128,7 +129,7 @@ def EntailmentProfile.toRole (p : EntailmentProfile) : Option ThetaRole :=
     else none
   else none
 
-end Semantics.ArgumentStructure.EntailmentProfile
+end ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 3. ThetaRole → Canonical Profile (inverse direction)

--- a/Linglib/Semantics/Lexical/EventStructure.lean
+++ b/Linglib/Semantics/Lexical/EventStructure.lean
@@ -28,7 +28,8 @@ enriched two-predicate event structure for the wiping-verbs class
 namespace Semantics.Lexical.EventStructure
 
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 open Features
 
 /-! ### Event structure templates -/

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -31,7 +31,8 @@ Individual verbs can override class-level profiles via explicit
 namespace Features.LevinClassProfiles
 
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § 1. Argument Structure Templates
@@ -121,7 +122,8 @@ end Features.LevinClassProfiles
 
 namespace Semantics.Lexical
 open Features.LevinClassProfiles
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 
 /-- Map a Levin class to its argument structure template.
     Returns `none` for classes whose profiles haven't been determined yet. -/
@@ -176,7 +178,7 @@ end Semantics.Lexical
 
 namespace Features.LevinClassProfiles
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Verb
 open Verb.Root.Kinds
 

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -15,7 +15,7 @@ open Semantics.Lexical
 open Features.ChangeOfState
 open NaturalLogic (EntailmentSig)
 open Causation.Psych (CausalSource)
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)
 open Features.LevinClassProfiles

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -48,7 +48,7 @@ open Semantics.Lexical
 open Features.ChangeOfState
 open NaturalLogic (EntailmentSig)
 open Causation.Psych (CausalSource)
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)
 open Features.LevinClassProfiles

--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -44,7 +44,7 @@ participant roles.
 -/
 
 open Semantics.ArgumentStructure
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 
 /-! ### The theta-grid (derived from the proto-role profiles) -/
 

--- a/Linglib/Semantics/Verb/Root/Basic.lean
+++ b/Linglib/Semantics/Verb/Root/Basic.lean
@@ -36,7 +36,7 @@ namespace Verb
     Participant/proto-role entailments (volition, sentience, movement,
     affectedness, …) are deliberately *not* modeled here: they are an
     orthogonal, linking-relevant layer carried by
-    `Semantics.ArgumentStructure.EntailmentProfile`. -/
+    `ArgumentStructure.EntailmentProfile`. -/
 inductive LexEntailment where
   /-- Attributes a static property (state-kind atom). -/
   | hasState     (label : String)

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -61,7 +61,7 @@ two-feature simplification).
 namespace AndersonJM2006
 
 open Semantics.ArgumentStructure.Linking (LinkingTheory ArgPosition)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ============================================================================
@@ -224,7 +224,7 @@ theorem Case.acc_abs_same_relation :
 namespace AndersonJM2006
 
 open Semantics.ArgumentStructure.Linking (LinkingTheory ArgPosition)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ============================================================================

--- a/Linglib/Studies/Beavers2010.lean
+++ b/Linglib/Studies/Beavers2010.lean
@@ -35,7 +35,7 @@ through the MAP.
 
 namespace Beavers2010
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Semantics.ArgumentStructure.AgentivityLattice
 open Semantics.ArgumentStructure.Affectedness.Profile (AffectednessDegree profileToDegree)
 open Semantics.Lexical (DiathesisAlternation)

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -54,7 +54,7 @@ namespace Bhadra2024
 open Semantics.Lexical
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure (EventRel)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Semantics.ArgumentStructure.Affectedness.Profile
 
 /-! ### The compositional verb root (eqs. 53–60)

--- a/Linglib/Studies/Dowty1991.lean
+++ b/Linglib/Studies/Dowty1991.lean
@@ -29,7 +29,8 @@ succeed and where they diverge from the modern approach.
 namespace Dowty1991
 
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -37,7 +37,8 @@ object marking profiles in `Studies/Aissen2003.lean`.
 namespace Grimm2011
 
 open Semantics.ArgumentStructure.AgentivityLattice
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Features.Prominence
 open Aissen2003
 

--- a/Linglib/Studies/Kim2024_UPH.lean
+++ b/Linglib/Studies/Kim2024_UPH.lean
@@ -57,7 +57,7 @@ open English.Predicates.Verbal
 open Pesetsky1995.PsychVerbs
 open SolstadBott2022
   (stimExpSubjectProfile stimExpObjectProfile expStimSubjectProfile)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § 1. Consistency Predicates

--- a/Linglib/Studies/KoontzGarboden2009.lean
+++ b/Linglib/Studies/KoontzGarboden2009.lean
@@ -233,7 +233,8 @@ def reflexivizationYieldsAnticausative : CauserSpec → Bool
     would carry more structure than K-G's underspecification account
     predicts. -/
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 
 /-- Derive `CauserSpec` from a proto-role entailment profile.
     Volition is the discriminating feature:

--- a/Linglib/Studies/MartinSchaeferKastner2025.lean
+++ b/Linglib/Studies/MartinSchaeferKastner2025.lean
@@ -64,7 +64,8 @@ syncretism creates voice ambiguity that speakers must manage.
 namespace MartinSchaeferKastner2025
 
 open Minimalist (VoiceFlavor)
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile PredictsUnaccusative)
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile (PredictsUnaccusative)
 open Pragmatics.GriceanMaxims (MannerSubmaxim)
 open French.Predicates
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -1101,7 +1101,7 @@ when both arguments bind the same variable — a thematic-uniqueness
 contradiction.
 
 **Status of this formalization**: The composition predicate below uses
-`Semantics.ArgumentStructure.EntailmentProfile.pPatientScore` to check whether a verb
+`ArgumentStructure.EntailmentProfile.pPatientScore` to check whether a verb
 has theme-like Proto-Patient entailments. An unergative has either no
 object profile (`objectEntailments = none`) or an empty one
 (`pPatientScore = 0`). This `EntailmentProfile`-based predicate is the
@@ -1110,7 +1110,7 @@ clash is now wired in via `Semantics/ArgumentStructure/ArgumentIntroduction.lean
 and consumed in §15c below (`low_appl_blocks_unergative_denotational`,
 `low_external_arg_clash`). -/
 
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 
 /-- A verb has an unsaturated theme argument iff its object entailment
     profile (if any) carries Proto-Patient entailments. Unergatives have
@@ -1175,7 +1175,7 @@ def themeBearingProfile : EntailmentProfile :=
 
 theorem themeBearingProfile_has_unsaturated_theme :
     hasUnsaturatedTheme (some themeBearingProfile) := by
-  unfold hasUnsaturatedTheme themeBearingProfile EntailmentProfile.pPatientScore
+  unfold hasUnsaturatedTheme themeBearingProfile ArgumentStructure.EntailmentProfile.pPatientScore
   decide
 
 /-- Low recipient applicatives can combine with verbs providing a

--- a/Linglib/Studies/RappaportHovavLevin2024.lean
+++ b/Linglib/Studies/RappaportHovavLevin2024.lean
@@ -90,7 +90,7 @@ verbs ([levin-krejci-2019]), and *drown*.
 namespace RappaportHovavLevin2024
 
 open Semantics.Lexical.EventStructure
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Semantics.Lexical
 
 /-! ### Force-dynamic primitives -/

--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -39,7 +39,7 @@ embedding.
 namespace Siloni2012
 
 open Reciprocal
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Three-Way Reciprocal Classification (§2.4)

--- a/Linglib/Studies/SolstadBott2022.lean
+++ b/Linglib/Studies/SolstadBott2022.lean
@@ -58,7 +58,8 @@ of grammatical position.
 
 namespace SolstadBott2022
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Discourse.Coherence
 open English.Predicates.Verbal
 

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -58,7 +58,8 @@ open Intensional (WorldTimeIndex)
 
 open Semantics.Presupposition
 open French.Predicates
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Semantics.ArgumentStructure.Affectedness.Profile
 open Features
 open Semantics.Lexical
@@ -441,7 +442,7 @@ theorem active_implies_pAgent_ge_1 (p : EntailmentProfile)
     p.pAgentScore ≥ 1 := by
   obtain ⟨v, s, c, m, ie, cos, it, ca, st, de⟩ := p
   simp only [hasActiveAgentEntailment] at h
-  simp only [EntailmentProfile.pAgentScore]
+  simp only [pAgentScore]
   cases v <;> cases c <;> cases m <;> simp_all (config := { decide := false }) <;> omega
 
 /-- Converse fails: experiencer profiles have pAgentScore ≥ 1 but no


### PR DESCRIPTION
Full mathlib-register pass on the Dowty proto-role file (−77 lines, statements accessor-compatible, 3150-job cone green including all 30 direct + open-based consumers).

- 19 canonical profiles rewritten from 10-Boolean positional literals to named-field instances via `:= false` field defaults (defeq-preserving, every mapping verified against the originals).
- Variable block lifted; unary Decidable instances → `DecidablePred` one-liners; banners → `/-! ### -/`; module docstring to the DFA template; `DoTestSource` deleted (zero consumers); one conclusion-named theorem rename (zero consumers).
- Reported, not performed: the `…EntailmentProfile.EntailmentProfile` namespace doubling (~24 consumer files with `open` lines, over the rename threshold — needs its own sweep); two pre-existing unbacked bib keys (`davis-koenig-2000` ×5, `primus-1999`) need verified entries.