### PR TITLE
feat(Syntax/Clause): canonical Frame/Slot objects + frames migration

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2800,6 +2800,7 @@ import Linglib.Syntax.Case.Order
 import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Clause.Chaining
 import Linglib.Syntax.Clause.Complementation
+import Linglib.Syntax.Clause.Frame
 import Linglib.Syntax.Comparative
 import Linglib.Syntax.Complementizer.Basic
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure

--- a/Linglib/Features/Complementation.lean
+++ b/Linglib/Features/Complementation.lean
@@ -1,18 +1,22 @@
+import Mathlib.Order.Basic
+import Mathlib.Data.Nat.Basic
+
 /-!
 # Complementation — complement selection and control
 
 [noonan-2007]
 
-Per-entry complementation features: which complement type a predicate selects
-(`ComplementType`) and, for infinitival complements, its control type
-(`ControlType`). Composed into lexical-core structures as fields
-(`Verb.ArgStructure.complementType`), Pronoun-pattern style.
+Per-entry complementation features: the legacy complement-type enum
+(`ComplementType`, the flat view over the typed `Frame` of
+`Syntax/Clause/Frame.lean`) and, for infinitival complements, its control
+type (`ControlType`).
 
 The cross-linguistic complementation typology also lives here:
-[noonan-2007]'s six complement-clause types (`NoonanCompType`) and twelve
+[noonan-2007]'s six complement-clause types (`NoonanCompType`, linearly
+ordered from most to least finite via `rank`) and twelve
 complement-taking-predicate classes (`CTPClass`) with their default reality
 status (`RealityStatus`, `ctpRealityStatus`). The adapter between the two
-inventories (`ComplementType.toNoonan`) lives in
+enum inventories (`ComplementType.toNoonan`) lives in
 `Syntax/Clause/Complementation.lean`.
 
 ## Main declarations
@@ -20,7 +24,8 @@ inventories (`ComplementType.toNoonan`) lives in
 * `ComplementType` — complement frame a predicate selects (English-leaning
   inventory: NP, double object, clausal, …)
 * `ControlType` — subject/object control vs raising for infinitival complements
-* `NoonanCompType` + `isReduced` — [noonan-2007]'s complement-clause types
+* `NoonanCompType` + `isReduced` + `rank` — [noonan-2007]'s complement-clause
+  types with their finiteness order
 * `CTPClass`, `RealityStatus`, `ctpRealityStatus` — [noonan-2007]'s CTP
   classification and realis/irrealis defaults
 -/
@@ -104,6 +109,22 @@ def NoonanCompType.isReduced : NoonanCompType → Bool
   | .nominalized => true
   | .participle  => true
   | _            => false
+
+/-- [noonan-2007]'s balanced-to-deranked order as a numeric rank
+    (indicative most finite, participle most deranked). -/
+def NoonanCompType.rank : NoonanCompType → Nat
+  | .indicative  => 0
+  | .subjunctive => 1
+  | .paratactic  => 2
+  | .infinitive  => 3
+  | .nominalized => 4
+  | .participle  => 5
+
+/-- The balanced-to-deranked order: `t ≤ t'` iff `t` is at least as
+    finite as `t'`. -/
+instance : LinearOrder NoonanCompType :=
+  .lift' NoonanCompType.rank fun a b => by
+    cases a <;> cases b <;> simp [NoonanCompType.rank]
 
 /-- Noonan's twelve CTP classes, organized by semantic contribution.
 

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -19,7 +19,9 @@ and nominalized with the say-root `[… V-TENSE g-ɘːš-CASE]`.
   inventory is `Buryat.complementizers`
 - `Buryat.hanaxa`, `Buryat.medexe`, `Buryat.xelexe`, `Buryat.duulaxa` —
   clause-embedding verbs; all four alternate between the finite-CP and
-  nominalized (`.gerund`) frames (ex. 35–36, 50–51)
+  nominalized frames (ex. 35–36, 50–51). *hanaxa*'s frame-conditioned
+  think~remember readings ride on `Verb.Reading` rows keyed to
+  `Buryat.nominalizedFrame`
 
 ## Implementation notes
 
@@ -69,23 +71,34 @@ def complementizers : List Complementizer := [ge, aasha, zha]
 Vendler class stays unset (`Verb.Aspect.vendlerClass` convention for
 clause-embedding verbs). -/
 
+/-- The nominalized complement frame of the ex. 35–36 alternation:
+[noonan-2007]-nominalized coding with an overt genitive embedded subject
+(§4.3.1). Richer than the bare `Frame.gerund` cell: it records the
+embedded-subject case. -/
+def nominalizedFrame : Frame :=
+  [{ cat := .clausal, coding := some .nominalized,
+     embeddedSubject := some (.overt (some .gen)) }]
+
 /-- *hanaxa* 'think ~ remember': 'think' with a bare gɘžɘ-CP, 'remember'
-with a nominalized complement (§4.4.3). `attitude` and `opaqueContext`
-record the bare-CP frame; the nominalized frame's pre-existence
-presupposition is tracked in `Semantics/Attitudes/PreExistence.lean`. -/
+with a nominalized complement (§4.4.3). The `readings` rows carry the
+think~remember alternation — nonveridical/opaque on the bare CP,
+veridical/transparent on the nominalized frame; the nominalized frame's
+pre-existence presupposition is tracked in
+`Semantics/Attitudes/PreExistence.lean`. -/
 def hanaxa : Verb where
   form := "hanaxa"
-  complementType := .finiteClause
-  altComplementType := some .gerund
-  attitude := some (.doxastic .nonVeridical)
-  opaqueContext := true
+  frames := [Frame.finiteClause, nominalizedFrame]
+  readings := [
+    { frame := Frame.finiteClause, attitude := some (.doxastic .nonVeridical),
+      opaqueContext := some true },
+    { frame := nominalizedFrame, attitude := some (.doxastic .veridical),
+      opaqueContext := some false }]
 
 /-- *mɘdɘxɘ* 'know' — factive in both frames (ex. 36); embeds polar
 questions (ex. 3). -/
 def medexe : Verb where
   form := "mɘdɘxɘ"
-  complementType := .finiteClause
-  altComplementType := some .gerund
+  frames := [Frame.finiteClause, Frame.gerund]
   attitude := some (.doxastic .veridical)
   takesQuestionBase := true
 
@@ -93,15 +106,13 @@ def medexe : Verb where
 are existence-entailing (ex. 51; speaker variation per fn. 30). -/
 def xelexe : Verb where
   form := "xɘlɘxɘ"
-  complementType := .finiteClause
-  altComplementType := some .gerund
+  frames := [Frame.finiteClause, Frame.gerund]
   speechActVerb := true
 
 /-- *duːlaxa* 'hear' — non-factive with bare CPs, existence-entailing
 with nominalized complements (ex. 50). -/
 def duulaxa : Verb where
   form := "duːlaxa"
-  complementType := .finiteClause
-  altComplementType := some .gerund
+  frames := [Frame.finiteClause, Frame.gerund]
 
 end Buryat

--- a/Linglib/Fragments/English/Predicates/Copular.lean
+++ b/Linglib/Fragments/English/Predicates/Copular.lean
@@ -43,8 +43,8 @@ def beRight : ClauseEmbeddingAdj where
     `controlType`. Constructed as a direct `Verb` instead. -/
 def beAble : Verb where
   form := "be able"
-  complementType := .infinitival
-  controlType := .subjectControl
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
 
 end English.Predicates.Copular
 
@@ -60,7 +60,7 @@ open Semantics.Lexical in
 def Semantics.Gradability.ClauseEmbeddingAdj.toVerb
     (a : Semantics.Gradability.ClauseEmbeddingAdj) : Verb where
   form := "be " ++ a.adjForm
-  complementType := a.complementType
+  frames := [a.complementType.toFrame]
   presupType := a.presupType
   attitude := a.attitude
   opaqueContext := a.opaqueContext

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -92,7 +92,7 @@ structure VerbEntry extends Verb where
     Usage:
     ```
     def kick : VerbEntry :=.mkRegular {
-      form := "kick", complementType :=.np }
+      form := "kick", frames := [Frame.np] }
     ``` -/
 def VerbEntry.mkRegular (core : Verb) : VerbEntry :=
   { toVerb := core
@@ -113,7 +113,7 @@ def sleep : VerbEntry where
   formPast := "slept"
   formPastPart := "slept"
   formPresPart := "sleeping"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .state
 
@@ -124,7 +124,7 @@ def run : VerbEntry where
   formPast := "ran"
   formPastPart := "run"
   formPresPart := "running"
-  complementType := .none
+  frames := []
   subjectEntailments := some activitySubjectProfile
   passivizable := false
   vendlerClass := some .activity
@@ -138,7 +138,7 @@ def run : VerbEntry where
 /-- "arrive" — unaccusative intransitive -/
 def arrive : VerbEntry := .mkRegular {
   form := "arrive"
-  complementType := .none
+  frames := []
   subjectEntailments := some achievementSubjectProfile
   unaccusative := true
   passivizable := false
@@ -152,7 +152,7 @@ def eat : VerbEntry where
   formPast := "ate"
   formPastPart := "eaten"
   formPresPart := "eating"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some accomplishmentSubjectProfile
   objectEntailments := some ⟨false, false, false, false, false, true, true, true, false, false⟩
   implicitObj := some .indef
@@ -168,7 +168,7 @@ def eat : VerbEntry where
 /-- "kick" — transitive -/
 def kick : VerbEntry := .mkRegular {
   form := "kick"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some accomplishmentSubjectProfile
   objectEntailments := some ⟨false, false, false, false, false, true, false, true, true, false⟩
   vendlerClass := some .activity
@@ -189,8 +189,7 @@ def give : VerbEntry where
   formPast := "gave"
   formPastPart := "given"
   formPresPart := "giving"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .accomplishment
@@ -203,28 +202,28 @@ def put : VerbEntry where
   formPast := "put"
   formPastPart := "put"
   formPresPart := "putting"
-  complementType := .np_pp
+  frames := [Frame.np_pp]
   vendlerClass := some .achievement
   levinClass := some .put
 
 /-- "weigh" — measure predicate selecting for mass/weight. -/
 def weigh : VerbEntry := .mkRegular {
   form := "weigh"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .measure }
 
 /-- "cover" — motion/extent predicate selecting for distance. -/
 def cover : VerbEntry := .mkRegular {
   form := "cover"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc }
 
 /-- "measure" — general measurement predicate. -/
 def measure : VerbEntry := .mkRegular {
   form := "measure"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .measure }
 
@@ -235,7 +234,7 @@ def buy : VerbEntry where
   formPast := "bought"
   formPastPart := "bought"
   formPresPart := "buying"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some ⟨true, true, true, false, true, false, false, false, false, false⟩
   vendlerClass := some .accomplishment
 
@@ -246,7 +245,7 @@ def meet : VerbEntry where
   formPast := "met"
   formPastPart := "met"
   formPresPart := "meeting"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
 
 /-- "sell" — change of possession, alternates DOC/PP.
@@ -257,8 +256,7 @@ def sell : VerbEntry where
   formPast := "sold"
   formPastPart := "sold"
   formPresPart := "selling"
-  complementType := .np
-  altComplementType := some .np_pp
+  frames := [Frame.np, Frame.np_pp]
   subjectEntailments := some ⟨true, true, true, false, true, false, false, false, false, false⟩
   implicitObj := some .def
   implicitGoal := some .indef
@@ -271,7 +269,7 @@ def leave : VerbEntry where
   formPast := "left"
   formPastPart := "left"
   formPresPart := "leaving"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .leave
 
@@ -282,8 +280,7 @@ def see : VerbEntry where
   formPast := "saw"
   formPastPart := "seen"
   formPresPart := "seeing"
-  complementType := .np
-  altComplementType := some .finiteClause
+  frames := [Frame.np, Frame.finiteClause]
   subjectEntailments := some stateSubjectProfile
   vendlerClass := some .state
   attitude := some (.doxastic .veridical)
@@ -300,7 +297,7 @@ def know : VerbEntry where
   formPast := "knew"
   formPastPart := "known"
   formPresPart := "knowing"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
@@ -316,7 +313,7 @@ def regret : VerbEntry where
   formPast := "regretted"
   formPastPart := "regretted"
   formPresPart := "regretting"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
@@ -326,7 +323,7 @@ def regret : VerbEntry where
 /-- "realize" — factive, presupposes complement is true -/
 def realize : VerbEntry := .mkRegular {
   form := "realize"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement
   passivizable := false
   presupType := some .softTrigger
@@ -336,7 +333,7 @@ def realize : VerbEntry := .mkRegular {
 /-- "discover" — semifactive, weaker projection -/
 def discover : VerbEntry := .mkRegular {
   form := "discover"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement
   passivizable := false
   presupType := some .softTrigger
@@ -347,7 +344,7 @@ def discover : VerbEntry := .mkRegular {
 /-- "notice" — semifactive -/
 def notice : VerbEntry := .mkRegular {
   form := "notice"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement
   passivizable := false
   presupType := some .softTrigger
@@ -365,9 +362,9 @@ def stop : VerbEntry where
   formPast := "stopped"
   formPastPart := "stopped"
   formPresPart := "stopping"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   presupType := some .softTrigger
   projectionBehavior := some .hole
@@ -381,9 +378,9 @@ def quit : VerbEntry where
   formPast := "quit"
   formPastPart := "quit"
   formPresPart := "quitting"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   presupType := some .softTrigger
   cosType := some .cessation
@@ -392,9 +389,9 @@ def quit : VerbEntry where
 /-- "start" — CoS inception, presupposes activity wasn't happening -/
 def start : VerbEntry := .mkRegular {
   form := "start"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   presupType := some .softTrigger
   cosType := some .inception
@@ -407,9 +404,9 @@ def begin_ : VerbEntry where
   formPast := "began"
   formPastPart := "begun"
   formPresPart := "beginning"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   presupType := some .softTrigger
   cosType := some .inception
@@ -418,9 +415,9 @@ def begin_ : VerbEntry where
 /-- "continue" — CoS continuation, presupposes activity was happening -/
 def continue_ : VerbEntry := .mkRegular {
   form := "continue"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .subjectControl }]
   vendlerClass := some .activity
-  controlType := .subjectControl
   passivizable := false
   presupType := some .softTrigger
   cosType := some .continuation
@@ -433,9 +430,9 @@ def keep : VerbEntry where
   formPast := "kept"
   formPastPart := "kept"
   formPresPart := "keeping"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .subjectControl }]
   vendlerClass := some .activity
-  controlType := .subjectControl
   passivizable := false
   presupType := some .softTrigger
   cosType := some .continuation
@@ -450,9 +447,9 @@ def keep : VerbEntry where
     See also `manage_occasion` for the [solstad-bott-2024] analysis. -/
 def manage : VerbEntry := .mkRegular {
   form := "manage"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   projectionBehavior := some .hole
   presupType := some .prerequisiteSoft
@@ -461,9 +458,9 @@ def manage : VerbEntry := .mkRegular {
 /-- "fail" — negative implicative: "failed to VP" entails "not VP" -/
 def fail : VerbEntry := .mkRegular {
   form := "fail"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .negative }
 
@@ -474,9 +471,9 @@ def try_ : VerbEntry where
   formPast := "tried"
   formPastPart := "tried"
   formPresPart := "trying"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .activity
-  controlType := .subjectControl
   passivizable := false
 
 /-- "persuade" — object control: "persuade X to VP" (X = agent of VP).
@@ -484,9 +481,9 @@ def try_ : VerbEntry where
     Projects AUTHOR coordinate → obligatory *de se* ([landau-2015] table (36)). -/
 def persuade : VerbEntry := .mkRegular {
   form := "persuade"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   vendlerClass := some .accomplishment
-  controlType := .objectControl
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
 
@@ -495,9 +492,9 @@ def persuade : VerbEntry := .mkRegular {
     [landau-2015] (5c) classifies it as desiderative → logophoric control. -/
 def promise : VerbEntry := .mkRegular {
   form := "promise"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   projectionBehavior := some .plug
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
@@ -505,9 +502,9 @@ def promise : VerbEntry := .mkRegular {
 /-- "remember" — implicative with infinitival ("remember to call") -/
 def remember : VerbEntry := .mkRegular {
   form := "remember"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .positive }
 
@@ -518,9 +515,9 @@ def forget : VerbEntry where
   formPast := "forgot"
   formPastPart := "forgotten"
   formPresPart := "forgetting"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .negative
 
@@ -528,9 +525,9 @@ def forget : VerbEntry where
     "John neglected to lock his door" entails "John didn't lock his door." -/
 def neglect : VerbEntry := .mkRegular {
   form := "neglect"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .negative }
 
@@ -541,7 +538,7 @@ def neglect : VerbEntry := .mkRegular {
 /-- "believe" — doxastic attitude verb, creates opaque context -/
 def believe : VerbEntry := .mkRegular {
   form := "believe"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   projectionBehavior := some .hole
@@ -556,7 +553,7 @@ def think : VerbEntry where
   formPast := "thought"
   formPastPart := "thought"
   formPresPart := "thinking"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   opaqueContext := true
@@ -570,9 +567,9 @@ def think : VerbEntry where
 /-- "want" — preferential attitude verb with infinitival complement -/
 def want : VerbEntry := .mkRegular {
   form := "want"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .state
-  controlType := .subjectControl
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -586,9 +583,9 @@ def want : VerbEntry := .mkRegular {
     the complement's event argument). -/
 def intend : VerbEntry := .mkRegular {
   form := "intend"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .state
-  controlType := .subjectControl
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -601,10 +598,9 @@ def intend : VerbEntry := .mkRegular {
     ([fusco-sgrizzi-2026]). -/
 def decide_ : VerbEntry := .mkRegular {
   form := "decide"
-  complementType := .infinitival
+  frames := [Frame.infinitival, Frame.finiteClause]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
-  altComplementType := some .finiteClause
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
   levinClass := some .want }
@@ -614,10 +610,9 @@ def decide_ : VerbEntry := .mkRegular {
     Alternate frame: infinitival with subject control ("hope to leave"). -/
 def hope : VerbEntry := .mkRegular {
   form := "hope"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause, Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .state
-  altComplementType := some .infinitival
-  altControlType := .subjectControl
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
@@ -629,10 +624,9 @@ def hope : VerbEntry := .mkRegular {
     Alternate frame: infinitival with subject control ("pray to be saved"). -/
 def pray : VerbEntry := .mkRegular {
   form := "pray"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause, Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .state
-  altComplementType := some .infinitival
-  altControlType := .subjectControl
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
@@ -640,7 +634,7 @@ def pray : VerbEntry := .mkRegular {
 /-- "expect" — preferential attitude verb (Class 3: anti-rogative) -/
 def expect : VerbEntry := .mkRegular {
   form := "expect"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   opaqueContext := true
@@ -653,7 +647,7 @@ def wish : VerbEntry where
   formPast := "wished"
   formPastPart := "wished"
   formPresPart := "wishing"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   opaqueContext := true
@@ -663,7 +657,7 @@ def wish : VerbEntry where
 /-- "fear" — preferential attitude verb (Class 2: takes questions) -/
 def fear : VerbEntry := .mkRegular {
   form := "fear"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   opaqueContext := true
@@ -673,7 +667,7 @@ def fear : VerbEntry := .mkRegular {
 /-- "dread" — preferential attitude verb (Class 2: takes questions) -/
 def dread : VerbEntry := .mkRegular {
   form := "dread"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   opaqueContext := true
@@ -687,7 +681,7 @@ def worry : VerbEntry where
   formPast := "worried"
   formPastPart := "worried"
   formPresPart := "worrying"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   opaqueContext := true
@@ -700,9 +694,9 @@ def worry : VerbEntry where
 /-- "seem" — raising verb (no theta role for subject, unaccusative) -/
 def seem : VerbEntry := .mkRegular {
   form := "seem"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .raising }]
   vendlerClass := some .state
-  controlType := .raising
   passivizable := false
   unaccusative := true }
 
@@ -713,9 +707,9 @@ def seem : VerbEntry := .mkRegular {
 /-- "cause" — counterfactual dependence (necessity semantics) -/
 def cause : VerbEntry := .mkRegular {
   form := "cause"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   vendlerClass := some .accomplishment
-  controlType := .objectControl
   causative := some .cause
   levinClass := some .engender }
 
@@ -726,9 +720,9 @@ def make : VerbEntry where
   formPast := "made"
   formPastPart := "made"
   formPresPart := "making"
-  complementType := .smallClause
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   vendlerClass := some .accomplishment
-  controlType := .objectControl
   causative := some .make
 
 /-- "let" — permissive causative (barrier removal) -/
@@ -738,9 +732,9 @@ def let_ : VerbEntry where
   formPast := "let"
   formPastPart := "let"
   formPresPart := "letting"
-  complementType := .smallClause
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   vendlerClass := some .achievement
-  controlType := .objectControl
   causative := some .enable
 
 /-- "have" — causative use (directive causation) -/
@@ -750,9 +744,9 @@ def have_caus : VerbEntry where
   formPast := "had"
   formPastPart := "had"
   formPresPart := "having"
-  complementType := .smallClause
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   vendlerClass := some .achievement
-  controlType := .objectControl
   causative := some .make
   senseTag := .causative
 
@@ -763,18 +757,18 @@ def get_caus : VerbEntry where
   formPast := "got"
   formPastPart := "gotten"
   formPresPart := "getting"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   vendlerClass := some .accomplishment
-  controlType := .objectControl
   causative := some .make
   senseTag := .causative
 
 /-- "force" — coercive causative (overcome resistance) -/
 def force : VerbEntry := .mkRegular {
   form := "force"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   vendlerClass := some .accomplishment
-  controlType := .objectControl
   projectionBehavior := some .hole
   causative := some .force }
 
@@ -784,9 +778,9 @@ def force : VerbEntry := .mkRegular {
     [nadathur-lauer-2020]: `preventSem` (dual of `causeSem`). -/
 def prevent : VerbEntry := .mkRegular {
   form := "prevent"
-  complementType := .gerund
+  frames := [Frame.gerund]
+  readings := [{ frame := Frame.gerund, control := some .objectControl }]
   vendlerClass := some .accomplishment
-  controlType := .objectControl
   projectionBehavior := some .hole
   causative := some .prevent }
 
@@ -797,7 +791,7 @@ def prevent : VerbEntry := .mkRegular {
 /-- "kill" — thin lexical causative (kill = cause-to-die, COMPACT type). -/
 def kill : VerbEntry := .mkRegular {
   form := "kill"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .murder
@@ -816,7 +810,7 @@ def break_ : VerbEntry where
   formPast := "broke"
   formPastPart := "broken"
   formPresPart := "breaking"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := false
   vendlerClass := some .accomplishment
   causative := some .make
@@ -845,7 +839,7 @@ def tear_ : VerbEntry where
   formPast := "tore"
   formPastPart := "torn"
   formPresPart := "tearing"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := false
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
@@ -873,7 +867,7 @@ def tear_ : VerbEntry where
     does not reduce to scale boundedness alone. -/
 def crack : VerbEntry := .mkRegular {
   form := "crack"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := true
   vendlerClass := some .achievement
   degreeAchievementScale := some {
@@ -887,7 +881,7 @@ def crack : VerbEntry := .mkRegular {
     dented*, *badly dented*. -/
 def dent : VerbEntry := .mkRegular {
   form := "dent"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := true
   vendlerClass := some .achievement
   degreeAchievementScale := some {
@@ -903,7 +897,7 @@ def dent : VerbEntry := .mkRegular {
     the CoS reading formalized here. -/
 def scratch : VerbEntry := .mkRegular {
   form := "scratch"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := true
   vendlerClass := some .achievement
   degreeAchievementScale := some {
@@ -917,7 +911,7 @@ def scratch : VerbEntry := .mkRegular {
     #*shatter for two minutes*, ??*more shattered* ([tham-2025] (12)). -/
 def shatter : VerbEntry := .mkRegular {
   form := "shatter"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := true
   vendlerClass := some .achievement
   causative := some .make
@@ -926,7 +920,7 @@ def shatter : VerbEntry := .mkRegular {
 /-- "burn" — thick lexical causative (manner = by fire/heat). -/
 def burn : VerbEntry := .mkRegular {
   form := "burn"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   causative := some .make
@@ -942,7 +936,7 @@ def burn : VerbEntry := .mkRegular {
 /-- "destroy" — thin lexical causative (result-only, no manner). -/
 def destroy : VerbEntry := .mkRegular {
   form := "destroy"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .destroy
@@ -957,7 +951,7 @@ def destroy : VerbEntry := .mkRegular {
     Implicit obj is indefinite ("the ice cream melted" / "we're melting"). -/
 def melt : VerbEntry := .mkRegular {
   form := "melt"
-  complementType := .np
+  frames := [Frame.np]
   implicitObj := some .indef
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
@@ -982,35 +976,35 @@ def melt : VerbEntry := .mkRegular {
 /-- "activate" — thin causative, CoS without manner. -/
 def activate : VerbEntry := .mkRegular {
   form := "activate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .otherCoS }
 
 /-- "affect" — thin causative, general effect. -/
 def affect : VerbEntry := .mkRegular {
   form := "affect"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .destroy }
 
 /-- "change" — thin causative, transformation (§26.6). -/
 def change : VerbEntry := .mkRegular {
   form := "change"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .turn }
 
 /-- "damage" — thin causative, partial destruction. -/
 def damage : VerbEntry := .mkRegular {
   form := "damage"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .destroy }
 
 /-- "eliminate" — thin causative, removal/destruction. -/
 def eliminate : VerbEntry := .mkRegular {
   form := "eliminate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .destroy }
 
@@ -1021,49 +1015,49 @@ def hurt : VerbEntry where
   formPast := "hurt"
   formPastPart := "hurt"
   formPresPart := "hurting"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .destroy
 
 /-- "restore" — thin causative, reverse transformation (§26.6). -/
 def restore : VerbEntry := .mkRegular {
   form := "restore"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .turn }
 
 /-- "trigger" — thin causative, engender class (§27). -/
 def trigger : VerbEntry := .mkRegular {
   form := "trigger"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .engender }
 
 /-- "bury" — thick causative (state), concealment (§16). -/
 def bury : VerbEntry := .mkRegular {
   form := "bury"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .conceal }
 
 /-- "drop" — thick causative, caused falling (§45.4). -/
 def drop : VerbEntry := .mkRegular {
   form := "drop"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .otherCoS }
 
 /-- "lift" — thick causative, caused upward motion (§11.4 carry). -/
 def lift : VerbEntry := .mkRegular {
   form := "lift"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .carry }
 
 /-- "lock" — thick causative, caused secured state (§45.4). -/
 def lock : VerbEntry := .mkRegular {
   form := "lock"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .otherCoS }
 
@@ -1074,7 +1068,7 @@ def shut : VerbEntry where
   formPast := "shut"
   formPastPart := "shut"
   formPresPart := "shutting"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .otherCoS
 
@@ -1085,21 +1079,21 @@ def spread : VerbEntry where
   formPast := "spread"
   formPastPart := "spread"
   formPresPart := "spreading"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .sprayLoad
 
 /-- "stretch" — thick causative, bend class (§45.2). -/
 def stretch : VerbEntry := .mkRegular {
   form := "stretch"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .bend }
 
 /-- "switch" — thick causative, CoS (§45.4). -/
 def switch : VerbEntry := .mkRegular {
   form := "switch"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .otherCoS }
 
@@ -1110,7 +1104,7 @@ def switch : VerbEntry := .mkRegular {
 /-- "devour" — transitive, no presupposition -/
 def devour : VerbEntry := .mkRegular {
   form := "devour"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .devour
@@ -1127,7 +1121,7 @@ def read : VerbEntry where
   formPast := "read"
   formPastPart := "read"
   formPresPart := "reading"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .inc
 
@@ -1139,7 +1133,7 @@ def build : VerbEntry where
   formPast := "built"
   formPastPart := "built"
   formPresPart := "building"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some accomplishmentSubjectProfile
   objectEntailments := some ⟨false, false, false, false, false, true, true, true, false, true⟩
   implicitObj := some .indef
@@ -1156,8 +1150,7 @@ def write : VerbEntry where
   formPast := "wrote"
   formPastPart := "written"
   formPresPart := "writing"
-  complementType := .np
-  altComplementType := some .np_pp
+  frames := [Frame.np, Frame.np_pp]
   implicitObj := some .indef
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
@@ -1170,7 +1163,7 @@ def sweep : VerbEntry where
   formPast := "swept"
   formPastPart := "swept"
   formPresPart := "sweeping"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   subjectEntailments := some ⟨false, false, false, true, true, false, false, false, false, false⟩
   passivizable := true
@@ -1189,7 +1182,7 @@ def sweep_instr : VerbEntry where
   formPast := "swept"
   formPastPart := "swept"
   formPresPart := "sweeping"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   subjectEntailments := some accomplishmentSubjectProfile
   passivizable := true
@@ -1214,7 +1207,7 @@ def say : VerbEntry where
   formPastPart := "said"
   formPresPart := "saying"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement
   projectionBehavior := some .plug
   levinClass := some .say
@@ -1229,8 +1222,7 @@ def tell : VerbEntry where
   formPastPart := "told"
   formPresPart := "telling"
   speechActVerb := true
-  complementType := .finiteClause
-  altComplementType := some .np_np
+  frames := [Frame.finiteClause, Frame.np_np]
   implicitObj := some .def
   implicitGoal := some .indef
   vendlerClass := some .achievement
@@ -1241,7 +1233,7 @@ def tell : VerbEntry where
 def claim : VerbEntry := .mkRegular {
   form := "claim"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement
   projectionBehavior := some .plug
   levinClass := some .say }
@@ -1257,7 +1249,7 @@ def claim : VerbEntry := .mkRegular {
 /-- "reveal" — factive communication verb ([degen-tonhauser-2022]: canonically factive) -/
 def reveal : VerbEntry := .mkRegular {
   form := "reveal"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   presupType := some .softTrigger
@@ -1267,7 +1259,7 @@ def reveal : VerbEntry := .mkRegular {
 /-- "acknowledge" — optionally factive communication verb -/
 def acknowledge : VerbEntry := .mkRegular {
   form := "acknowledge"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   levinClass := some .say }
@@ -1279,7 +1271,7 @@ def admit : VerbEntry where
   formPast := "admitted"
   formPastPart := "admitted"
   formPresPart := "admitting"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   levinClass := some .say
@@ -1287,7 +1279,7 @@ def admit : VerbEntry where
 /-- "announce" — communication verb -/
 def announce : VerbEntry := .mkRegular {
   form := "announce"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   levinClass := some .say }
@@ -1295,7 +1287,7 @@ def announce : VerbEntry := .mkRegular {
 /-- "confess" — optionally factive communication verb -/
 def confess : VerbEntry := .mkRegular {
   form := "confess"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   levinClass := some .say }
@@ -1303,7 +1295,7 @@ def confess : VerbEntry := .mkRegular {
 /-- "inform" — optionally factive communication verb with recipient -/
 def inform : VerbEntry := .mkRegular {
   form := "inform"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   levinClass := some .tell }
@@ -1311,7 +1303,7 @@ def inform : VerbEntry := .mkRegular {
 /-- "suggest" — non-factive communication verb -/
 def suggest : VerbEntry := .mkRegular {
   form := "suggest"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .achievement
   levinClass := some .say }
@@ -1319,32 +1311,32 @@ def suggest : VerbEntry := .mkRegular {
 /-- "pretend" — anti-veridical attitude verb -/
 def pretend : VerbEntry := .mkRegular {
   form := "pretend"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   opaqueContext := true }
 
 /-- "confirm" — evidential verb -/
 def confirm : VerbEntry := .mkRegular {
   form := "confirm"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement }
 
 /-- "demonstrate" — evidential verb -/
 def demonstrate : VerbEntry := .mkRegular {
   form := "demonstrate"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement }
 
 /-- "establish" — evidential verb -/
 def establish : VerbEntry := .mkRegular {
   form := "establish"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement }
 
 /-- "prove" — evidential verb -/
 def prove : VerbEntry := .mkRegular {
   form := "prove"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .achievement }
 
 -- ════════════════════════════════════════════════════
@@ -1361,7 +1353,7 @@ def prove : VerbEntry := .mkRegular {
 def whisper : VerbEntry := .mkRegular {
   form := "whisper"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1370,7 +1362,7 @@ def whisper : VerbEntry := .mkRegular {
 def murmur : VerbEntry := .mkRegular {
   form := "murmur"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1379,7 +1371,7 @@ def murmur : VerbEntry := .mkRegular {
 def shout : VerbEntry := .mkRegular {
   form := "shout"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1388,7 +1380,7 @@ def shout : VerbEntry := .mkRegular {
 def cry : VerbEntry := .mkRegular {
   form := "cry"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1397,7 +1389,7 @@ def cry : VerbEntry := .mkRegular {
 def scream : VerbEntry := .mkRegular {
   form := "scream"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1406,7 +1398,7 @@ def scream : VerbEntry := .mkRegular {
 def mumble : VerbEntry := .mkRegular {
   form := "mumble"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1415,7 +1407,7 @@ def mumble : VerbEntry := .mkRegular {
 def mutter : VerbEntry := .mkRegular {
   form := "mutter"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1424,7 +1416,7 @@ def mutter : VerbEntry := .mkRegular {
 def shriek : VerbEntry := .mkRegular {
   form := "shriek"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1433,7 +1425,7 @@ def shriek : VerbEntry := .mkRegular {
 def yell : VerbEntry := .mkRegular {
   form := "yell"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1442,7 +1434,7 @@ def yell : VerbEntry := .mkRegular {
 def groan : VerbEntry := .mkRegular {
   form := "groan"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1451,7 +1443,7 @@ def groan : VerbEntry := .mkRegular {
 def grumble : VerbEntry := .mkRegular {
   form := "grumble"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1460,7 +1452,7 @@ def grumble : VerbEntry := .mkRegular {
 def hiss : VerbEntry := .mkRegular {
   form := "hiss"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1469,7 +1461,7 @@ def hiss : VerbEntry := .mkRegular {
 def sigh : VerbEntry := .mkRegular {
   form := "sigh"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1478,7 +1470,7 @@ def sigh : VerbEntry := .mkRegular {
 def whimper : VerbEntry := .mkRegular {
   form := "whimper"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1487,7 +1479,7 @@ def whimper : VerbEntry := .mkRegular {
 def snap : VerbEntry := .mkRegular {
   form := "snap"
   speechActVerb := true
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   unaccusative := true
   levinClass := some .mannerOfSpeaking }
@@ -1500,7 +1492,7 @@ def speak : VerbEntry where
   formPastPart := "spoken"
   formPresPart := "speaking"
   speechActVerb := true
-  complementType := .none
+  frames := []
   vendlerClass := some .activity
   passivizable := false
   levinClass := some .mannerOfSpeaking
@@ -1509,7 +1501,7 @@ def speak : VerbEntry where
 def talk : VerbEntry := .mkRegular {
   form := "talk"
   speechActVerb := true
-  complementType := .none
+  frames := []
   vendlerClass := some .activity
   passivizable := false
   levinClass := some .mannerOfSpeaking }
@@ -1521,7 +1513,7 @@ def talk : VerbEntry := .mkRegular {
 /-- "wonder" — embeds questions only -/
 def wonder : VerbEntry := .mkRegular {
   form := "wonder"
-  complementType := .question
+  frames := [Frame.question]
   vendlerClass := some .state
   takesQuestionBase := true
   opaqueContext := true }
@@ -1530,14 +1522,14 @@ def wonder : VerbEntry := .mkRegular {
 def ask : VerbEntry := .mkRegular {
   form := "ask"
   speechActVerb := true
-  complementType := .question
+  frames := [Frame.question]
   vendlerClass := some .achievement
   takesQuestionBase := true }
 
 /-- "investigate" — rogative, embeds interrogatives only -/
 def investigate : VerbEntry := .mkRegular {
   form := "investigate"
-  complementType := .question
+  frames := [Frame.question]
   vendlerClass := some .activity
   takesQuestionBase := true
   levinClass := some .search }
@@ -1549,14 +1541,14 @@ def depend_on : VerbEntry where
   formPast := "depended on"
   formPastPart := "depended on"
   formPresPart := "depending on"
-  complementType := .question
+  frames := [Frame.question]
   vendlerClass := some .state
   takesQuestionBase := true
 
 /-- "remember" in factive/question-embedding sense. -/
 def remember_rog : VerbEntry := .mkRegular {
   form := "remember"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
@@ -1571,7 +1563,7 @@ def forget_rog : VerbEntry where
   formPast := "forgot"
   formPastPart := "forgotten"
   formPresPart := "forgetting"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
@@ -1600,9 +1592,9 @@ def forget_rog : VerbEntry where
     volitional action, not because the matrix verb entails agentivity. -/
 def manage_occasion : VerbEntry := .mkRegular {
   form := "manage"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .positive
   presupType := some .prerequisiteSoft
@@ -1614,9 +1606,9 @@ def manage_occasion : VerbEntry := .mkRegular {
     realization ([nadathur-2023-implicatives] §5.2, ex. 3–4, 26). -/
 def dare : VerbEntry := .mkRegular {
   form := "dare"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   presupType := some .prerequisiteSoft
   implicative := some .positive }
@@ -1627,9 +1619,9 @@ def dare : VerbEntry := .mkRegular {
     ([nadathur-2023-implicatives] §2, ex. 10, 28). -/
 def bother : VerbEntry := .mkRegular {
   form := "bother"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   presupType := some .prerequisiteSoft
   implicative := some .positive }
@@ -1642,9 +1634,9 @@ def bother : VerbEntry := .mkRegular {
     ([nadathur-2023-implicatives] §6.4, ex. 45–47). -/
 def hesitate : VerbEntry := .mkRegular {
   form := "hesitate"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .activity
-  controlType := .subjectControl
   passivizable := false
   presupType := some .prerequisiteSoft
   implicative := some .negative }
@@ -1653,9 +1645,9 @@ def hesitate : VerbEntry := .mkRegular {
     "John ventured to speak" entails "John spoke." -/
 def venture : VerbEntry := .mkRegular {
   form := "venture"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .positive }
 
@@ -1663,9 +1655,9 @@ def venture : VerbEntry := .mkRegular {
     "John condescended to help" entails "John helped." -/
 def condescend : VerbEntry := .mkRegular {
   form := "condescend"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   vendlerClass := some .achievement
-  controlType := .subjectControl
   passivizable := false
   implicative := some .positive }
 
@@ -1674,8 +1666,8 @@ def condescend : VerbEntry := .mkRegular {
     Raising: "It happened to rain" — no theta role for matrix subject. -/
 def happen : VerbEntry := .mkRegular {
   form := "happen"
-  complementType := .infinitival
-  controlType := .raising
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .raising }]
   passivizable := false
   implicative := some .positive }
 
@@ -1689,35 +1681,35 @@ def happen : VerbEntry := .mkRegular {
 /-- "enjoy" — AgExp verb (experiencer-subject) -/
 def enjoy : VerbEntry := .mkRegular {
   form := "enjoy"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
 /-- "like" — AgExp verb (experiencer-subject) -/
 def like : VerbEntry := .mkRegular {
   form := "like"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
 /-- "love" — AgExp verb (experiencer-subject) -/
 def love : VerbEntry := .mkRegular {
   form := "love"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
 /-- "hate" — AgExp verb (experiencer-subject) -/
 def hate : VerbEntry := .mkRegular {
   form := "hate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
 /-- "admire" — AgExp verb (experiencer-subject) -/
 def admire : VerbEntry := .mkRegular {
   form := "admire"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
@@ -1726,8 +1718,7 @@ def admire : VerbEntry := .mkRegular {
     definite (familiar). Implicit second obj is indefinite. -/
 def envy : VerbEntry := .mkRegular {
   form := "envy"
-  complementType := .np
-  altComplementType := some .np_np
+  frames := [Frame.np, Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .state
@@ -1736,14 +1727,14 @@ def envy : VerbEntry := .mkRegular {
 /-- "respect" — AgExp verb (experiencer-subject) -/
 def respect : VerbEntry := .mkRegular {
   form := "respect"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
 /-- "value" — AgExp verb (experiencer-subject) -/
 def value : VerbEntry := .mkRegular {
   form := "value"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
@@ -1752,7 +1743,7 @@ def value : VerbEntry := .mkRegular {
     Note: `fear` (attitude verb, clausal complement) is defined separately. -/
 def fear_np : VerbEntry := .mkRegular {
   form := "fear"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
@@ -1760,7 +1751,7 @@ def fear_np : VerbEntry := .mkRegular {
     "John dreads exams." Note: `dread` (attitude, clausal) defined separately. -/
 def dread_np : VerbEntry := .mkRegular {
   form := "dread"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .admire }
 
@@ -1774,7 +1765,7 @@ def dread_np : VerbEntry := .mkRegular {
 /-- "frighten" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def frighten : VerbEntry := .mkRegular {
   form := "frighten"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1782,7 +1773,7 @@ def frighten : VerbEntry := .mkRegular {
 /-- "amuse" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def amuse : VerbEntry := .mkRegular {
   form := "amuse"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1790,7 +1781,7 @@ def amuse : VerbEntry := .mkRegular {
 /-- "fascinate" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def fascinate : VerbEntry := .mkRegular {
   form := "fascinate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1798,7 +1789,7 @@ def fascinate : VerbEntry := .mkRegular {
 /-- "irritate" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def irritate : VerbEntry := .mkRegular {
   form := "irritate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1806,7 +1797,7 @@ def irritate : VerbEntry := .mkRegular {
 /-- "annoy" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def annoy : VerbEntry := .mkRegular {
   form := "annoy"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1814,7 +1805,7 @@ def annoy : VerbEntry := .mkRegular {
 /-- "bore" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def bore : VerbEntry := .mkRegular {
   form := "bore"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1822,7 +1813,7 @@ def bore : VerbEntry := .mkRegular {
 /-- "charm" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def charm : VerbEntry := .mkRegular {
   form := "charm"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1830,7 +1821,7 @@ def charm : VerbEntry := .mkRegular {
 /-- "impress" — StimExp verb (stimulus-subject, eventive: [kim-2024] UPH) -/
 def impress : VerbEntry := .mkRegular {
   form := "impress"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1838,7 +1829,7 @@ def impress : VerbEntry := .mkRegular {
 /-- "concern" — stative Class II psych verb ([kim-2024] UPH, internal cause) -/
 def concern : VerbEntry := .mkRegular {
   form := "concern"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   causalSource := some .internal
   opaqueContext := true
@@ -1847,7 +1838,7 @@ def concern : VerbEntry := .mkRegular {
 /-- "interest" — stative Class II psych verb ([kim-2024] UPH, internal cause) -/
 def interest : VerbEntry := .mkRegular {
   form := "interest"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   causalSource := some .internal
   opaqueContext := true
@@ -1856,7 +1847,7 @@ def interest : VerbEntry := .mkRegular {
 /-- "surprise" — eventive Class II (Levin 31.1). "The news surprised John." -/
 def surprise : VerbEntry := .mkRegular {
   form := "surprise"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1864,7 +1855,7 @@ def surprise : VerbEntry := .mkRegular {
 /-- "scare" — eventive Class II (Levin 31.1). "The noise scared John." -/
 def scare : VerbEntry := .mkRegular {
   form := "scare"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1872,7 +1863,7 @@ def scare : VerbEntry := .mkRegular {
 /-- "delight" — eventive Class II (Levin 31.1). "The gift delighted Mary." -/
 def delight : VerbEntry := .mkRegular {
   form := "delight"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1880,7 +1871,7 @@ def delight : VerbEntry := .mkRegular {
 /-- "embarrass" — eventive Class II (Levin 31.1). "The remark embarrassed John." -/
 def embarrass : VerbEntry := .mkRegular {
   form := "embarrass"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1888,7 +1879,7 @@ def embarrass : VerbEntry := .mkRegular {
 /-- "upset" — eventive Class II (Levin 31.1). "The news upset Mary." -/
 def upset_psych : VerbEntry := .mkRegular {
   form := "upset"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1896,7 +1887,7 @@ def upset_psych : VerbEntry := .mkRegular {
 /-- "disgust" — eventive Class II (Levin 31.1). "The smell disgusted John." -/
 def disgust : VerbEntry := .mkRegular {
   form := "disgust"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1904,7 +1895,7 @@ def disgust : VerbEntry := .mkRegular {
 /-- "shock" — eventive Class II (Levin 31.1). "The revelation shocked everyone." -/
 def shock : VerbEntry := .mkRegular {
   form := "shock"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1912,7 +1903,7 @@ def shock : VerbEntry := .mkRegular {
 /-- "confuse" — eventive Class II (Levin 31.1). "The instructions confused John." -/
 def confuse : VerbEntry := .mkRegular {
   form := "confuse"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1920,7 +1911,7 @@ def confuse : VerbEntry := .mkRegular {
 /-- "disappoint" — eventive Class II (Levin 31.1). "The result disappointed Mary." -/
 def disappoint : VerbEntry := .mkRegular {
   form := "disappoint"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1929,7 +1920,7 @@ def disappoint : VerbEntry := .mkRegular {
     Note: `worry` (attitude, clausal) defined separately. -/
 def worry_eventive : VerbEntry := .mkRegular {
   form := "worry"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causalSource := some .external
   levinClass := some .amuse }
@@ -1938,7 +1929,7 @@ def worry_eventive : VerbEntry := .mkRegular {
     [kim-2024] UPH: same theta grid as worry_eventive, different causal source. -/
 def worry_stative : VerbEntry := .mkRegular {
   form := "worry"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   causalSource := some .internal
   opaqueContext := true
@@ -1948,7 +1939,7 @@ def worry_stative : VerbEntry := .mkRegular {
     "The idea pleases John." Related to B&R Class III It. *piacere*. -/
 def please_psych : VerbEntry := .mkRegular {
   form := "please"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   causalSource := some .internal
   opaqueContext := true
@@ -1958,7 +1949,7 @@ def please_psych : VerbEntry := .mkRegular {
     "The thought troubles John." -/
 def trouble : VerbEntry := .mkRegular {
   form := "trouble"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   causalSource := some .internal
   opaqueContext := true
@@ -1968,7 +1959,7 @@ def trouble : VerbEntry := .mkRegular {
     "The problem puzzles John." -/
 def puzzle : VerbEntry := .mkRegular {
   form := "puzzle"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   causalSource := some .internal
   opaqueContext := true
@@ -1984,7 +1975,7 @@ def puzzle : VerbEntry := .mkRegular {
 /-- "chase" — AgPat verb (Levin 51.6) -/
 def chase : VerbEntry := .mkRegular {
   form := "chase"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .chase }
@@ -1996,14 +1987,14 @@ def hit : VerbEntry where
   formPast := "hit"
   formPastPart := "hit"
   formPresPart := "hitting"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit
 
 /-- "push" — AgPat verb (Levin 12) -/
 def push : VerbEntry := .mkRegular {
   form := "push"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .pushPull }
@@ -2011,7 +2002,7 @@ def push : VerbEntry := .mkRegular {
 /-- "pull" — AgPat verb (Levin 12) -/
 def pull : VerbEntry := .mkRegular {
   form := "pull"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .pushPull }
@@ -2019,7 +2010,7 @@ def pull : VerbEntry := .mkRegular {
 /-- "shove" — verb of exerting force (Levin 12, [levin-2026] (31)) -/
 def shove : VerbEntry := .mkRegular {
   form := "shove"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .pushPull }
 
@@ -2030,28 +2021,28 @@ def tug : VerbEntry where
   formPast := "tugged"
   formPastPart := "tugged"
   formPresPart := "tugging"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .pushPull
 
 /-- "yank" — verb of exerting force (Levin 12, [levin-2026] (31)) -/
 def yank : VerbEntry := .mkRegular {
   form := "yank"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .pushPull }
 
 /-- "jerk" — verb of exerting force (Levin 12, [levin-2026] (31)) -/
 def jerk : VerbEntry := .mkRegular {
   form := "jerk"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .pushPull }
 
 /-- "wrench" — verb of exerting force (Levin 12, [levin-2026] (31)) -/
 def wrench : VerbEntry := .mkRegular {
   form := "wrench"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .pushPull }
 
@@ -2063,7 +2054,7 @@ def fling : VerbEntry where
   formPast := "flung"
   formPastPart := "flung"
   formPresPart := "flinging"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .pushPull
 
@@ -2075,7 +2066,7 @@ def slam : VerbEntry where
   formPast := "slammed"
   formPastPart := "slammed"
   formPresPart := "slamming"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit
 
@@ -2083,7 +2074,7 @@ def slam : VerbEntry where
     [levin-2026] (32a)) -/
 def punch : VerbEntry := .mkRegular {
   form := "punch"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit }
 
@@ -2091,7 +2082,7 @@ def punch : VerbEntry := .mkRegular {
     [levin-2026] (32a)) -/
 def smack : VerbEntry := .mkRegular {
   form := "smack"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit }
 
@@ -2099,7 +2090,7 @@ def smack : VerbEntry := .mkRegular {
     [levin-2026] (32a)) -/
 def thump : VerbEntry := .mkRegular {
   form := "thump"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit }
 
@@ -2107,7 +2098,7 @@ def thump : VerbEntry := .mkRegular {
     [levin-2026] (32a)) -/
 def bang : VerbEntry := .mkRegular {
   form := "bang"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit }
 
@@ -2115,7 +2106,7 @@ def bang : VerbEntry := .mkRegular {
     [levin-2026] (32a)) -/
 def thrash : VerbEntry := .mkRegular {
   form := "thrash"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .hit }
 
@@ -2124,7 +2115,7 @@ def thrash : VerbEntry := .mkRegular {
     surface-contact sense, not removing sense. -/
 def scrape : VerbEntry := .mkRegular {
   form := "scrape"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   levinClass := some .wipe }
 
@@ -2135,7 +2126,7 @@ def carry : VerbEntry where
   formPast := "carried"
   formPastPart := "carried"
   formPresPart := "carrying"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .carry
@@ -2147,7 +2138,7 @@ def drag : VerbEntry where
   formPast := "dragged"
   formPastPart := "dragged"
   formPresPart := "dragging"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .carry
@@ -2155,7 +2146,7 @@ def drag : VerbEntry where
 /-- "call" — AgPat verb (communication + agent-patient frame) -/
 def call : VerbEntry := .mkRegular {
   form := "call"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity }
 
 -- ════════════════════════════════════════════════════
@@ -2165,14 +2156,14 @@ def call : VerbEntry := .mkRegular {
 /-- "place" — Levin 9.1 Put verbs. Instantaneous placement. -/
 def place : VerbEntry := .mkRegular {
   form := "place"
-  complementType := .np_pp
+  frames := [Frame.np_pp]
   vendlerClass := some .achievement
   levinClass := some .put }
 
 /-- "pour" — Levin 9.5 Pour verbs. Manner of caused motion. -/
 def pour : VerbEntry := .mkRegular {
   form := "pour"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .pour }
@@ -2180,7 +2171,7 @@ def pour : VerbEntry := .mkRegular {
 /-- "spray" — Levin 9.7 Spray/Load verbs. Locative alternation. -/
 def spray : VerbEntry := .mkRegular {
   form := "spray"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .sprayLoad }
@@ -2188,7 +2179,7 @@ def spray : VerbEntry := .mkRegular {
 /-- "load" — Levin 9.7 Spray/Load verbs. Locative alternation. -/
 def load : VerbEntry := .mkRegular {
   form := "load"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .sprayLoad }
@@ -2200,7 +2191,7 @@ def load : VerbEntry := .mkRegular {
 /-- "remove" — Levin 10.1 Remove verbs. -/
 def remove : VerbEntry := .mkRegular {
   form := "remove"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .remove }
 
@@ -2208,7 +2199,7 @@ def remove : VerbEntry := .mkRegular {
     Also a degree achievement: closed scale (maximally clean). -/
 def clean : VerbEntry := .mkRegular {
   form := "clean"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
     dimension := .cleanliness,
@@ -2223,7 +2214,7 @@ def steal : VerbEntry where
   formPast := "stole"
   formPastPart := "stolen"
   formPresPart := "stealing"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .steal
 
@@ -2239,8 +2230,7 @@ def send : VerbEntry where
   formPast := "sent"
   formPastPart := "sent"
   formPresPart := "sending"
-  complementType := .np
-  altComplementType := some .np_np
+  frames := [Frame.np, Frame.np_np]
   implicitGoal := some .def
   vendlerClass := some .accomplishment
   levinClass := some .send
@@ -2252,7 +2242,7 @@ def drive : VerbEntry where
   formPast := "drove"
   formPastPart := "driven"
   formPresPart := "driving"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .drive
@@ -2264,21 +2254,21 @@ def drive : VerbEntry where
 /-- "donate" — Levin 13.2 Contribute verbs. -/
 def donate : VerbEntry := .mkRegular {
   form := "donate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .contribute }
 
 /-- "obtain" — Levin 13.5 Get verbs. -/
 def obtain : VerbEntry := .mkRegular {
   form := "obtain"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .getObtain }
 
 /-- "trade" — Levin 13.6 Exchange verbs. -/
 def trade : VerbEntry := .mkRegular {
   form := "trade"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .exchange }
 
@@ -2289,7 +2279,7 @@ def trade : VerbEntry := .mkRegular {
 /-- "learn" — Levin 14 Learn verbs. -/
 def learn : VerbEntry := .mkRegular {
   form := "learn"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .learn }
 
@@ -2300,7 +2290,7 @@ def hold : VerbEntry where
   formPast := "held"
   formPastPart := "held"
   formPresPart := "holding"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .hold
 
@@ -2311,7 +2301,7 @@ def hide : VerbEntry where
   formPast := "hid"
   formPastPart := "hidden"
   formPresPart := "hiding"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .conceal
 
@@ -2327,8 +2317,7 @@ def throw : VerbEntry where
   formPast := "threw"
   formPastPart := "thrown"
   formPresPart := "throwing"
-  complementType := .np
-  altComplementType := some .np_np
+  frames := [Frame.np, Frame.np_np]
   implicitObj := some .def
   implicitGoal := some .indef
   vendlerClass := some .achievement
@@ -2341,14 +2330,14 @@ def throw : VerbEntry where
 /-- "poke" — Levin 19 Poke verbs. Punctual contact. -/
 def poke : VerbEntry := .mkRegular {
   form := "poke"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .poke }
 
 /-- "touch" — Levin 20 Touch verbs. Surface contact. -/
 def touch : VerbEntry := .mkRegular {
   form := "touch"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .touch }
 
@@ -2365,7 +2354,7 @@ def cut : VerbEntry where
   formPast := "cut"
   formPastPart := "cut"
   formPresPart := "cutting"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .cut
@@ -2381,7 +2370,7 @@ def chop : VerbEntry where
   formPast := "chopped"
   formPastPart := "chopped"
   formPresPart := "chopping"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .carve
@@ -2393,7 +2382,7 @@ def chop : VerbEntry where
 /-- "mix" — Levin 22.1 Mix verbs. Incremental by proportion combined. -/
 def mix : VerbEntry := .mkRegular {
   form := "mix"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .mix }
@@ -2401,7 +2390,7 @@ def mix : VerbEntry := .mkRegular {
 /-- "separate" — Levin 23.1 Separate verbs. -/
 def separate : VerbEntry := .mkRegular {
   form := "separate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .separate }
 
@@ -2412,7 +2401,7 @@ def separate : VerbEntry := .mkRegular {
 /-- "paint" — Levin 24 Color verbs. Incremental by surface area. -/
 def paint : VerbEntry := .mkRegular {
   form := "paint"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .color }
@@ -2424,7 +2413,7 @@ def draw : VerbEntry where
   formPast := "drew"
   formPastPart := "drawn"
   formPresPart := "drawing"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .imageCreation
@@ -2436,7 +2425,7 @@ def draw : VerbEntry where
 /-- "create" — Levin 26.4 Create verbs. -/
 def create : VerbEntry := .mkRegular {
   form := "create"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .create }
 
@@ -2447,7 +2436,7 @@ def grow : VerbEntry where
   formPast := "grew"
   formPastPart := "grown"
   formPresPart := "growing"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .grow
@@ -2455,7 +2444,7 @@ def grow : VerbEntry where
 /-- "perform" — Levin 26.7 Performance verbs. -/
 def perform : VerbEntry := .mkRegular {
   form := "perform"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .performance }
 
@@ -2466,7 +2455,7 @@ def perform : VerbEntry := .mkRegular {
 /-- "appoint" — Levin 29.1 Appoint verbs. -/
 def appoint : VerbEntry := .mkRegular {
   form := "appoint"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .appoint }
 
@@ -2482,8 +2471,7 @@ def hear : VerbEntry where
   formPast := "heard"
   formPastPart := "heard"
   formPresPart := "hearing"
-  complementType := .np
-  altComplementType := some .finiteClause
+  frames := [Frame.np, Frame.finiteClause]
   vendlerClass := some .state
   levinClass := some .see
 
@@ -2494,7 +2482,7 @@ def hear : VerbEntry where
 /-- "blame" — Levin 33 Judgment verbs. -/
 def blame : VerbEntry := .mkRegular {
   form := "blame"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .judgment }
@@ -2502,7 +2490,7 @@ def blame : VerbEntry := .mkRegular {
 /-- "evaluate" — Levin 34 Assessment verbs. -/
 def evaluate : VerbEntry := .mkRegular {
   form := "evaluate"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   verbIncClass := some .cumOnly
   levinClass := some .assessment }
@@ -2518,7 +2506,7 @@ def marry : VerbEntry where
   formPast := "married"
   formPastPart := "married"
   formPresPart := "marrying"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   levinClass := some .socialInteraction
 
@@ -2529,7 +2517,7 @@ def marry : VerbEntry where
 /-- "bark" — Levin 38 Animal Sound verbs. -/
 def bark : VerbEntry := .mkRegular {
   form := "bark"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .animalSound }
@@ -2541,7 +2529,7 @@ def bark : VerbEntry := .mkRegular {
 /-- "breathe" — Levin 40.1 Body Process verbs. -/
 def breathe : VerbEntry := .mkRegular {
   form := "breathe"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .bodyProcess }
@@ -2550,7 +2538,7 @@ def breathe : VerbEntry := .mkRegular {
     Semelfactive: single involuntary event, no result state ([smith-1997] §2.4.3). -/
 def cough : VerbEntry := .mkRegular {
   form := "cough"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .semelfactive
   levinClass := some .bodyProcess }
@@ -2559,7 +2547,7 @@ def cough : VerbEntry := .mkRegular {
     Semelfactive: single involuntary body event ([smith-1997] §2.4.3). -/
 def hiccup : VerbEntry := .mkRegular {
   form := "hiccup"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .semelfactive
   levinClass := some .bodyProcess }
@@ -2568,7 +2556,7 @@ def hiccup : VerbEntry := .mkRegular {
     Semelfactive: single instantaneous eye movement ([smith-1997] §2.4.3). -/
 def blink : VerbEntry := .mkRegular {
   form := "blink"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .semelfactive
   levinClass := some .bodyProcess }
@@ -2578,7 +2566,7 @@ def blink : VerbEntry := .mkRegular {
     ([smith-1997] §2.4.3: "Guy knocked at the door"). -/
 def knock : VerbEntry := .mkRegular {
   form := "knock"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .semelfactive
   levinClass := some .hit }
@@ -2587,7 +2575,7 @@ def knock : VerbEntry := .mkRegular {
     Semelfactive: single light percussive contact event ([smith-1997] §2.4.3). -/
 def tap : VerbEntry := .mkRegular {
   form := "tap"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .semelfactive
   levinClass := some .hit }
@@ -2596,7 +2584,7 @@ def tap : VerbEntry := .mkRegular {
     Semelfactive: single instantaneous light event ([smith-1997] §2.4.3). -/
 def flash : VerbEntry := .mkRegular {
   form := "flash"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .semelfactive
   levinClass := some .lightEmission }
@@ -2604,7 +2592,7 @@ def flash : VerbEntry := .mkRegular {
 /-- "flinch" — Levin 40.5 Flinch verbs. Involuntary reaction. -/
 def flinch : VerbEntry := .mkRegular {
   form := "flinch"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .achievement
   levinClass := some .flinch }
@@ -2612,7 +2600,7 @@ def flinch : VerbEntry := .mkRegular {
 /-- "dress" — Levin 41.1 Dress verbs. -/
 def dress : VerbEntry := .mkRegular {
   form := "dress"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   levinClass := some .dress }
 
@@ -2623,7 +2611,7 @@ def dress : VerbEntry := .mkRegular {
 /-- "drown" — Levin 42.2 Poison verbs. Manner-of-killing. -/
 def drown : VerbEntry := .mkRegular {
   form := "drown"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .poison }
@@ -2635,7 +2623,7 @@ def drown : VerbEntry := .mkRegular {
 /-- "glow" — Levin 43.1 Light Emission verbs. -/
 def glow : VerbEntry := .mkRegular {
   form := "glow"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .state
   unaccusative := true
@@ -2644,7 +2632,7 @@ def glow : VerbEntry := .mkRegular {
 /-- "buzz" — Levin 43.2 Sound Emission verbs. -/
 def buzz : VerbEntry := .mkRegular {
   form := "buzz"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   unaccusative := true
@@ -2657,7 +2645,7 @@ def bleed : VerbEntry where
   formPast := "bled"
   formPastPart := "bled"
   formPresPart := "bleeding"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   unaccusative := true
@@ -2675,7 +2663,7 @@ def bend : VerbEntry where
   formPast := "bent"
   formPastPart := "bent"
   formPresPart := "bending"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
     dimension := .curvature }
@@ -2686,7 +2674,7 @@ def bend : VerbEntry where
     Degree achievement: closed scale (reaches boiling point). -/
 def boil : VerbEntry := .mkRegular {
   form := "boil"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
     dimension := .boiling,
@@ -2698,7 +2686,7 @@ def boil : VerbEntry := .mkRegular {
     Degree achievement: open scale (no maximum rustedness). -/
 def rust : VerbEntry := .mkRegular {
   form := "rust"
-  complementType := .none
+  frames := []
   passivizable := false
   unaccusative := true
   vendlerClass := some .activity
@@ -2710,7 +2698,7 @@ def rust : VerbEntry := .mkRegular {
     Degree achievement: open scale (no maximum quantity). -/
 def increase : VerbEntry := .mkRegular {
   form := "increase"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   degreeAchievementScale := some {
     dimension := .quantity }
@@ -2724,7 +2712,7 @@ def increase : VerbEntry := .mkRegular {
     Accomplishment: "straightened the wire in 10 seconds." -/
 def straighten : VerbEntry := .mkRegular {
   form := "straighten"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
     dimension := .straightness,
@@ -2735,7 +2723,7 @@ def straighten : VerbEntry := .mkRegular {
     Accomplishment: "flattened the dough in 2 minutes." -/
 def flatten : VerbEntry := .mkRegular {
   form := "flatten"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
     dimension := .flatness,
@@ -2746,7 +2734,7 @@ def flatten : VerbEntry := .mkRegular {
     Accomplishment: "opened the door in 3 seconds." -/
 def open_ : VerbEntry := .mkRegular {
   form := "open"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
   degreeAchievementScale := some {
     dimension := .openness,
@@ -2757,7 +2745,7 @@ def open_ : VerbEntry := .mkRegular {
     Activity: "lengthened the rope for hours." -/
 def lengthen : VerbEntry := .mkRegular {
   form := "lengthen"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   degreeAchievementScale := some {
     dimension := .length,
@@ -2768,7 +2756,7 @@ def lengthen : VerbEntry := .mkRegular {
     Activity: "widened the road for months." -/
 def widen : VerbEntry := .mkRegular {
   form := "widen"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   degreeAchievementScale := some {
     dimension := .width,
@@ -2779,7 +2767,7 @@ def widen : VerbEntry := .mkRegular {
     Activity: "cooled for an hour." -/
 def cool : VerbEntry := .mkRegular {
   form := "cool"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   degreeAchievementScale := some {
     dimension := .temperature,
@@ -2790,7 +2778,7 @@ def cool : VerbEntry := .mkRegular {
     Activity: "warmed for an hour." -/
 def warm : VerbEntry := .mkRegular {
   form := "warm"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
   degreeAchievementScale := some {
     dimension := .temperature,
@@ -2804,7 +2792,7 @@ def warm : VerbEntry := .mkRegular {
 /-- "exist" — Levin 47.1 Exist verbs. Pure state. -/
 def exist : VerbEntry := .mkRegular {
   form := "exist"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .state
   unaccusative := true
@@ -2813,7 +2801,7 @@ def exist : VerbEntry := .mkRegular {
 /-- "appear" — Levin 48.1 Appear verbs. Punctual emergence. -/
 def appear : VerbEntry := .mkRegular {
   form := "appear"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .achievement
   unaccusative := true
@@ -2822,7 +2810,7 @@ def appear : VerbEntry := .mkRegular {
 /-- "fidget" — Levin 49 Body-Internal Motion verbs. -/
 def fidget : VerbEntry := .mkRegular {
   form := "fidget"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .bodyInternalMotion }
@@ -2834,7 +2822,7 @@ def sit : VerbEntry where
   formPast := "sat"
   formPastPart := "sat"
   formPresPart := "sitting"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .state
   levinClass := some .assumePosition
@@ -2846,7 +2834,7 @@ def stand : VerbEntry where
   formPast := "stood"
   formPastPart := "stood"
   formPresPart := "standing"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .state
   levinClass := some .assumePosition
@@ -2858,7 +2846,7 @@ def stand : VerbEntry where
 /-- "walk" — Levin 51.3 Manner of Motion verbs. -/
 def walk : VerbEntry := .mkRegular {
   form := "walk"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .mannerOfMotion }
@@ -2870,7 +2858,7 @@ def swim : VerbEntry where
   formPast := "swam"
   formPastPart := "swum"
   formPresPart := "swimming"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .mannerOfMotion
@@ -2882,7 +2870,7 @@ def fly : VerbEntry where
   formPast := "flew"
   formPastPart := "flown"
   formPresPart := "flying"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .vehicleMotion
@@ -2894,14 +2882,14 @@ def fly : VerbEntry where
 /-- "avoid" — Levin 52 Avoid verbs. Stative. -/
 def avoid : VerbEntry := .mkRegular {
   form := "avoid"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .state
   levinClass := some .avoid }
 
 /-- "linger" — Levin 53.1 Linger verbs. -/
 def linger : VerbEntry := .mkRegular {
   form := "linger"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .linger }
@@ -2909,7 +2897,7 @@ def linger : VerbEntry := .mkRegular {
 /-- "rush" — Levin 53.2 Rush verbs. -/
 def rush : VerbEntry := .mkRegular {
   form := "rush"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .rush }
@@ -2921,7 +2909,7 @@ def rush : VerbEntry := .mkRegular {
 /-- "rain" — Levin 57 Weather verbs. Expletive subject. -/
 def rain : VerbEntry := .mkRegular {
   form := "rain"
-  complementType := .none
+  frames := []
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .weather }
@@ -2940,7 +2928,7 @@ def rain : VerbEntry := .mkRegular {
 /-- "charge" — DOC-only. Implicit second obj indef, implicit goal def (addressee). -/
 def charge : VerbEntry := .mkRegular {
   form := "charge"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
@@ -2948,7 +2936,7 @@ def charge : VerbEntry := .mkRegular {
 /-- "cost" — DOC-only. Implicit second obj indef, implicit goal def. -/
 def cost : VerbEntry := .mkRegular {
   form := "cost"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .state }
@@ -2956,7 +2944,7 @@ def cost : VerbEntry := .mkRegular {
 /-- "fine" — DOC-only. Implicit second obj indef, implicit goal def. -/
 def fine : VerbEntry := .mkRegular {
   form := "fine"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
@@ -2968,7 +2956,7 @@ def tip : VerbEntry where
   formPast := "tipped"
   formPastPart := "tipped"
   formPresPart := "tipping"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .accomplishment
@@ -2980,7 +2968,7 @@ def pay : VerbEntry where
   formPast := "paid"
   formPastPart := "paid"
   formPresPart := "paying"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .accomplishment
@@ -2992,7 +2980,7 @@ def strike_ : VerbEntry where
   formPast := "struck"
   formPastPart := "struck"
   formPresPart := "striking"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .achievement
@@ -3005,7 +2993,7 @@ def forgive : VerbEntry where
   formPast := "forgave"
   formPastPart := "forgiven"
   formPresPart := "forgiving"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .def
   implicitGoal := some .def
   vendlerClass := some .accomplishment
@@ -3013,7 +3001,7 @@ def forgive : VerbEntry where
 /-- "spare" — DOC-only. Implicit second obj def, no implicit goal. -/
 def spare : VerbEntry := .mkRegular {
   form := "spare"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitObj := some .def
   vendlerClass := some .accomplishment }
 
@@ -3025,7 +3013,7 @@ def deny : VerbEntry where
   formPast := "denied"
   formPastPart := "denied"
   formPresPart := "denying"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitGoal := some .def
   vendlerClass := some .accomplishment
 
@@ -3037,7 +3025,7 @@ def permit : VerbEntry where
   formPast := "permitted"
   formPastPart := "permitted"
   formPresPart := "permitting"
-  complementType := .np_np
+  frames := [Frame.np_np]
   implicitGoal := some .def
   vendlerClass := some .accomplishment
 
@@ -3045,8 +3033,7 @@ def permit : VerbEntry where
     obligatory (Pesetsky 1995:157 ex. (3a-c); [bruening-2021] Table 56 row 3). -/
 def assign : VerbEntry := .mkRegular {
   form := "assign"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
 
@@ -3055,7 +3042,7 @@ def assign : VerbEntry := .mkRegular {
 /-- "begrudge" — DOC-only. Neither object implicit. -/
 def begrudge : VerbEntry := .mkRegular {
   form := "begrudge"
-  complementType := .np_np
+  frames := [Frame.np_np]
   vendlerClass := some .state }
 
 /-- "bet" — DOC-only. Neither object implicit. -/
@@ -3065,7 +3052,7 @@ def bet : VerbEntry where
   formPast := "bet"
   formPastPart := "bet"
   formPresPart := "betting"
-  complementType := .np_np
+  frames := [Frame.np_np]
   vendlerClass := some .accomplishment
 
 -- Alternating verbs (both DOC and PP frame)
@@ -3074,8 +3061,7 @@ def bet : VerbEntry where
     Implicit goal def (PP). -/
 def serve : VerbEntry := .mkRegular {
   form := "serve"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitObj := some .indef
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
@@ -3088,8 +3074,7 @@ def teach : VerbEntry where
   formPast := "taught"
   formPastPart := "taught"
   formPresPart := "teaching"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitObj := some .indef
   implicitGoal := some .indef
   vendlerClass := some .activity
@@ -3102,8 +3087,7 @@ def feed : VerbEntry where
   formPast := "fed"
   formPastPart := "fed"
   formPresPart := "feeding"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitObj := some .indef
   vendlerClass := some .activity
 
@@ -3114,56 +3098,49 @@ def show_ : VerbEntry where
   formPast := "showed"
   formPastPart := "shown"
   formPresPart := "showing"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitObj := some .def
   vendlerClass := some .accomplishment
 
 /-- "award" — alternates DOC/PP. Implicit goal def (PP). -/
 def award : VerbEntry := .mkRegular {
   form := "award"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
 
 /-- "forward" — alternates DOC/PP. Implicit goal def (PP). -/
 def forward_ : VerbEntry := .mkRegular {
   form := "forward"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
 
 /-- "grant" — alternates DOC/PP. Implicit goal def (PP). -/
 def grant : VerbEntry := .mkRegular {
   form := "grant"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
 
 /-- "offer" — alternates DOC/PP. Implicit goal def (PP). -/
 def offer : VerbEntry := .mkRegular {
   form := "offer"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
 
 /-- "reserve" — alternates DOC/PP. Implicit goal def (PP). -/
 def reserve : VerbEntry := .mkRegular {
   form := "reserve"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   implicitGoal := some .def
   vendlerClass := some .accomplishment }
 
 /-- "pass" — alternates DOC/PP. Implicit DO def in PP frame only. -/
 def pass : VerbEntry := .mkRegular {
   form := "pass"
-  complementType := .np
-  altComplementType := some .np_pp
+  frames := [Frame.np, Frame.np_pp]
   implicitObj := some .def
   implicitGoal := some .indef
   vendlerClass := some .accomplishment
@@ -3174,8 +3151,7 @@ def pass : VerbEntry := .mkRegular {
 /-- "hand" — alternates DOC/PP. Neither argument implicit. -/
 def hand : VerbEntry := .mkRegular {
   form := "hand"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   vendlerClass := some .accomplishment
   levinClass := some .give }
 
@@ -3186,8 +3162,7 @@ def lend : VerbEntry where
   formPast := "lent"
   formPastPart := "lent"
   formPresPart := "lending"
-  complementType := .np_np
-  altComplementType := some .np_pp
+  frames := [Frame.np_np, Frame.np_pp]
   vendlerClass := some .accomplishment
   levinClass := some .give
 

--- a/Linglib/Fragments/French/Predicates.lean
+++ b/Linglib/Fragments/French/Predicates.lean
@@ -40,8 +40,8 @@ def faire : FrenchVerbEntry where
   formPasse := "fit"
   formPartPasse := "fait"
   formPartPres := "faisant"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .make
 
 /-- laisser — permissive causative ("let"). -/
@@ -51,8 +51,8 @@ def laisser : FrenchVerbEntry where
   formPasse := "laissa"
   formPartPasse := "laissé"
   formPartPres := "laissant"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .enable
 
 /-- French *faire* uses `.make` builder. -/
@@ -91,35 +91,35 @@ def cosSubjectProfile : EntailmentProfile where
 def brunir : FrenchVerbEntry where
   form := "brunir"; form3sg := "brunit"; formPasse := "brunit"
   formPartPasse := "bruni"; formPartPres := "brunissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 /-- noircir — 'blacken, darken'. Limited-control ±se AC-verb. -/
 def noircir : FrenchVerbEntry where
   form := "noircir"; form3sg := "noircit"; formPasse := "noircit"
   formPartPasse := "noirci"; formPartPres := "noircissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 /-- pâlir — 'get pale'. Limited-control ±se AC-verb. -/
 def palir : FrenchVerbEntry where
   form := "pâlir"; form3sg := "pâlit"; formPasse := "pâlit"
   formPartPasse := "pâli"; formPartPres := "pâlissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 /-- rajeunir — 'get young(er), rejuvenate'. Limited-control ±se AC-verb. -/
 def rajeunir : FrenchVerbEntry where
   form := "rajeunir"; form3sg := "rajeunit"; formPasse := "rajeunit"
   formPartPasse := "rajeuni"; formPartPres := "rajeunissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 /-- rougir — 'redden, blush'. Limited-control ±se AC-verb. -/
 def rougir : FrenchVerbEntry where
   form := "rougir"; form3sg := "rougit"; formPasse := "rougit"
   formPartPasse := "rougi"; formPartPres := "rougissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 -- ============================================================================
@@ -144,35 +144,35 @@ def motionCosSubjectProfile : EntailmentProfile where
 def approcher : FrenchVerbEntry where
   form := "approcher"; form3sg := "approche"; formPasse := "approcha"
   formPartPasse := "approché"; formPartPres := "approchant"
-  complementType := .none
+  frames := []
   subjectEntailments := some motionCosSubjectProfile
 
 /-- durcir — 'harden'. In-control ±se AC-verb (property-change). -/
 def durcir : FrenchVerbEntry where
   form := "durcir"; form3sg := "durcit"; formPasse := "durcit"
   formPartPasse := "durci"; formPartPres := "durcissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 /-- plier — 'bend, fold'. In-control ±se AC-verb (motion). -/
 def plier : FrenchVerbEntry where
   form := "plier"; form3sg := "plie"; formPasse := "plia"
   formPartPasse := "plié"; formPartPres := "pliant"
-  complementType := .none
+  frames := []
   subjectEntailments := some motionCosSubjectProfile
 
 /-- radoucir — 'get soft(er)'. In-control ±se AC-verb (property-change). -/
 def radoucir : FrenchVerbEntry where
   form := "radoucir"; form3sg := "radoucit"; formPasse := "radoucit"
   formPartPasse := "radouci"; formPartPres := "radoucissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 /-- refroidir — 'get cold(er)'. In-control ±se AC-verb (property-change). -/
 def refroidir : FrenchVerbEntry where
   form := "refroidir"; form3sg := "refroidit"; formPasse := "refroidit"
   formPartPasse := "refroidi"; formPartPres := "refroidissant"
-  complementType := .none
+  frames := []
   subjectEntailments := some cosSubjectProfile
 
 -- ============================================================================
@@ -244,7 +244,7 @@ def accompanySubjectProfile : EntailmentProfile where
 def laver : FrenchVerbEntry where
   form := "laver"; form3sg := "lave"; formPasse := "lava"
   formPartPasse := "lavé"; formPartPres := "lavant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some protoTransSubjectProfile
   objectEntailments := some protoTransObjectProfile
   vendlerClass := some .accomplishment
@@ -253,7 +253,7 @@ def laver : FrenchVerbEntry where
 def ecrire : FrenchVerbEntry where
   form := "écrire"; form3sg := "écrit"; formPasse := "écrivit"
   formPartPasse := "écrit"; formPartPres := "écrivant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some protoTransSubjectProfile
   objectEntailments := some { protoTransObjectProfile with
     incrementalTheme := true, dependentExistence := true }
@@ -263,7 +263,7 @@ def ecrire : FrenchVerbEntry where
 def construire : FrenchVerbEntry where
   form := "construire"; form3sg := "construit"; formPasse := "construisit"
   formPartPasse := "construit"; formPartPres := "construisant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some protoTransSubjectProfile
   objectEntailments := some { protoTransObjectProfile with
     incrementalTheme := true, dependentExistence := true }
@@ -273,7 +273,7 @@ def construire : FrenchVerbEntry where
 def tuer : FrenchVerbEntry where
   form := "tuer"; form3sg := "tue"; formPasse := "tua"
   formPartPasse := "tué"; formPartPres := "tuant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some protoTransSubjectProfile
   objectEntailments := some { protoTransObjectProfile with
     dependentExistence := true }
@@ -283,7 +283,7 @@ def tuer : FrenchVerbEntry where
 def aimer : FrenchVerbEntry where
   form := "aimer"; form3sg := "aime"; formPasse := "aima"
   formPartPasse := "aimé"; formPartPres := "aimant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some experiencerSubjectProfile
   objectEntailments := some minimalParticipantProfile
   vendlerClass := some .state
@@ -292,7 +292,7 @@ def aimer : FrenchVerbEntry where
 def adorer : FrenchVerbEntry where
   form := "adorer"; form3sg := "adore"; formPasse := "adora"
   formPartPasse := "adoré"; formPartPres := "adorant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some experiencerSubjectProfile
   objectEntailments := some minimalParticipantProfile
   vendlerClass := some .state
@@ -301,7 +301,7 @@ def adorer : FrenchVerbEntry where
 def respecter : FrenchVerbEntry where
   form := "respecter"; form3sg := "respecte"; formPasse := "respecta"
   formPartPasse := "respecté"; formPartPres := "respectant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some experiencerSubjectProfile
   objectEntailments := some minimalParticipantProfile
   vendlerClass := some .state
@@ -310,7 +310,7 @@ def respecter : FrenchVerbEntry where
 def accompagner : FrenchVerbEntry where
   form := "accompagner"; form3sg := "accompagne"; formPasse := "accompagna"
   formPartPasse := "accompagné"; formPartPres := "accompagnant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some accompanySubjectProfile
   objectEntailments := some minimalParticipantProfile
   vendlerClass := some .activity
@@ -319,7 +319,7 @@ def accompagner : FrenchVerbEntry where
 def suivreDyn : FrenchVerbEntry where
   form := "suivre"; form3sg := "suit"; formPasse := "suivit"
   formPartPasse := "suivi"; formPartPres := "suivant"
-  complementType := .np
+  frames := [Frame.np]
   senseTag := .default
   subjectEntailments := some dynamicFollowSubjectProfile
   objectEntailments := some minimalParticipantProfile
@@ -329,7 +329,7 @@ def suivreDyn : FrenchVerbEntry where
 def suivreStat : FrenchVerbEntry where
   form := "suivre"; form3sg := "suit"; formPasse := "suivit"
   formPartPasse := "suivi"; formPartPres := "suivant"
-  complementType := .np
+  frames := [Frame.np]
   senseTag := .stative
   subjectEntailments := some stativePositionalSubjectProfile
   objectEntailments := some minimalParticipantProfile
@@ -339,7 +339,7 @@ def suivreStat : FrenchVerbEntry where
 def preceder : FrenchVerbEntry where
   form := "précéder"; form3sg := "précède"; formPasse := "précéda"
   formPartPasse := "précédé"; formPartPres := "précédant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some stativePositionalSubjectProfile
   objectEntailments := some minimalParticipantProfile
   vendlerClass := some .state
@@ -348,7 +348,7 @@ def preceder : FrenchVerbEntry where
 def abandonner : FrenchVerbEntry where
   form := "abandonner"; form3sg := "abandonne"; formPasse := "abandonna"
   formPartPasse := "abandonné"; formPartPres := "abandonnant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some protoTransSubjectProfile
   objectEntailments := some protoTransObjectProfile
   vendlerClass := some .accomplishment
@@ -357,7 +357,7 @@ def abandonner : FrenchVerbEntry where
 def delaisser : FrenchVerbEntry where
   form := "délaisser"; form3sg := "délaisse"; formPasse := "délaissa"
   formPartPasse := "délaissé"; formPartPres := "délaissant"
-  complementType := .np
+  frames := [Frame.np]
   subjectEntailments := some protoTransSubjectProfile
   objectEntailments := some protoTransObjectProfile
   vendlerClass := some .accomplishment

--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -53,8 +53,8 @@ def lassen : GermanVerbEntry where
   form3sg := "lässt"
   formPast := "ließ"
   formPastPart := "gelassen"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .enable
 
 /-- *machen* — productive analytic causative.
@@ -64,8 +64,8 @@ def machen : GermanVerbEntry where
   form3sg := "macht"
   formPast := "machte"
   formPastPart := "gemacht"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .make
 
 /-- *töten* — lexical COMPACT causative ("kill" = tot + -en).
@@ -75,7 +75,7 @@ def toeten : GermanVerbEntry where
   form3sg := "tötet"
   formPast := "tötete"
   formPastPart := "getötet"
-  complementType := .np
+  frames := [Frame.np]
   causative := some .make
 
 /-- *zerbrechen* — lexical COMPACT causative ("break").
@@ -85,7 +85,7 @@ def zerbrechen : GermanVerbEntry where
   form3sg := "zerbricht"
   formPast := "zerbrach"
   formPastPart := "zerbrochen"
-  complementType := .np
+  frames := [Frame.np]
   causative := some .make
 
 -- ============================================================================
@@ -98,7 +98,7 @@ def hoffen : GermanVerbEntry where
   form3sg := "hofft"
   formPast := "hoffte"
   formPastPart := "gehofft"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -109,7 +109,7 @@ def fuerchten : GermanVerbEntry where
   form3sg := "fürchtet"
   formPast := "fürchtete"
   formPastPart := "gefürchtet"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .negative))
@@ -120,7 +120,7 @@ def befuerchten : GermanVerbEntry where
   form3sg := "befürchtet"
   formPast := "befürchtete"
   formPastPart := "befürchtet"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .negative))
@@ -131,7 +131,7 @@ def wuenschen : GermanVerbEntry where
   form3sg := "wünscht"
   formPast := "wünschte"
   formPastPart := "gewünscht"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -142,7 +142,7 @@ def sorgen : GermanVerbEntry where
   form3sg := "sorgt sich"
   formPast := "sorgte sich"
   formPastPart := "sich gesorgt"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential .uncertaintyBased)
@@ -164,7 +164,7 @@ def bestrafen : GermanVerbEntry where
   form3sg := "bestraft"
   formPast := "bestrafte"
   formPastPart := "bestraft"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -174,7 +174,7 @@ def belohnen : GermanVerbEntry where
   form3sg := "belohnt"
   formPast := "belohnte"
   formPastPart := "belohnt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -184,7 +184,7 @@ def loben : GermanVerbEntry where
   form3sg := "lobt"
   formPast := "lobte"
   formPastPart := "gelobt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -194,7 +194,7 @@ def kritisieren : GermanVerbEntry where
   form3sg := "kritisiert"
   formPast := "kritisierte"
   formPastPart := "kritisiert"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -204,7 +204,7 @@ def danken : GermanVerbEntry where
   form3sg := "dankt"
   formPast := "dankte"
   formPastPart := "gedankt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -214,7 +214,7 @@ def verklagen : GermanVerbEntry where
   form3sg := "verklagt"
   formPast := "verklagte"
   formPastPart := "verklagt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -224,7 +224,7 @@ def gratulieren : GermanVerbEntry where
   form3sg := "gratuliert"
   formPast := "gratulierte"
   formPastPart := "gratuliert"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -234,7 +234,7 @@ def zurechtweisen : GermanVerbEntry where
   form3sg := "weist zurecht"
   formPast := "wies zurecht"
   formPastPart := "zurechtgewiesen"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -244,7 +244,7 @@ def anzeigen : GermanVerbEntry where
   form3sg := "zeigt an"
   formPast := "zeigte an"
   formPastPart := "angezeigt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -254,7 +254,7 @@ def auszeichnen : GermanVerbEntry where
   form3sg := "zeichnet aus"
   formPast := "zeichnete aus"
   formPastPart := "ausgezeichnet"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -264,7 +264,7 @@ def belangen : GermanVerbEntry where
   form3sg := "belangt"
   formPast := "belangte"
   formPastPart := "belangt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -274,7 +274,7 @@ def ehren : GermanVerbEntry where
   form3sg := "ehrt"
   formPast := "ehrte"
   formPastPart := "geehrt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -285,7 +285,7 @@ def entlassen : GermanVerbEntry where
   form3sg := "entlässt"
   formPast := "entließ"
   formPastPart := "entlassen"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -296,7 +296,7 @@ def raechen : GermanVerbEntry where
   form3sg := "rächt sich"
   formPast := "rächte sich"
   formPastPart := "sich gerächt"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -307,7 +307,7 @@ def revanchieren : GermanVerbEntry where
   form3sg := "revanchiert sich"
   formPast := "revanchierte sich"
   formPastPart := "sich revanchiert"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -318,7 +318,7 @@ def zurVerantwortungZiehen : GermanVerbEntry where
   form3sg := "zieht zur Verantwortung"
   formPast := "zog zur Verantwortung"
   formPastPart := "zur Verantwortung gezogen"
-  complementType := .np
+  frames := [Frame.np]
   presupType := some .softTrigger
   senseTag := .occasion
 
@@ -339,7 +339,7 @@ def haemmern : GermanVerbEntry where
   form3sg := "hämmert"
   formPast := "hämmerte"
   formPastPart := "gehämmert"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
 
 /-- *malen* — "paint": activity. Contrast: **Mal-ung* vs *Be-mal-ung* ✓.
@@ -349,7 +349,7 @@ def malen : GermanVerbEntry where
   form3sg := "malt"
   formPast := "malte"
   formPastPart := "gemalt"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
 
 /-- *küssen* — "kiss": activity. Used in RSP examples (*wach-küssen*). -/
@@ -358,7 +358,7 @@ def kuessen : GermanVerbEntry where
   form3sg := "küsst"
   formPast := "küsste"
   formPastPart := "geküsst"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
 
 /-- *führen* — "lead": activity. Base for *ein-führen* (introduce).
@@ -369,7 +369,7 @@ def fuehren : GermanVerbEntry where
   form3sg := "führt"
   formPast := "führte"
   formPastPart := "geführt"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
 
 /-- *rauben* — "rob": activity. Contrast: **arm be-raubt* (RSP + prefix = blocked)
@@ -379,7 +379,7 @@ def rauben : GermanVerbEntry where
   form3sg := "raubt"
   formPast := "raubte"
   formPastPart := "geraubt"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .activity
 
 /-! ### Change-of-state verbs
@@ -396,7 +396,7 @@ def brechen : GermanVerbEntry where
   form3sg := "bricht"
   formPast := "brach"
   formPastPart := "gebrochen"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .achievement
   rootType := some .result
 
@@ -408,7 +408,7 @@ def frieren : GermanVerbEntry where
   form3sg := "friert"
   formPast := "fror"
   formPastPart := "gefroren"
-  complementType := .none
+  frames := []
   unaccusative := true
   vendlerClass := some .achievement
   rootType := some .propertyConcept
@@ -427,7 +427,7 @@ def beobachten : GermanVerbEntry where
   form3sg := "beobachtet"
   formPast := "beobachtete"
   formPastPart := "beobachtet"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
 
 /-- *einführen* — "introduce" (*ein-* particle): accomplishment.
@@ -439,7 +439,7 @@ def einfuehren : GermanVerbEntry where
   form3sg := "führt ein"
   formPast := "führte ein"
   formPastPart := "eingeführt"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
 
 /-- *verbinden* — "connect" (*ver-* prefix): accomplishment.
@@ -449,7 +449,7 @@ def verbinden : GermanVerbEntry where
   form3sg := "verbindet"
   formPast := "verband"
   formPastPart := "verbunden"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
 
 -- ============================================================================
@@ -475,7 +475,7 @@ def beenden : GermanVerbEntry where
   form3sg := "beendet"
   formPast := "beendete"
   formPastPart := "beendet"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
 
 /-- *streichen* — "cancel/delete": takes only DP complement.
@@ -486,7 +486,7 @@ def streichen : GermanVerbEntry where
   form3sg := "streicht"
   formPast := "strich"
   formPastPart := "gestrichen"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
 
 /-- *übereilen* — "(not) rush": takes only DP complement.
@@ -496,7 +496,7 @@ def uebereilen : GermanVerbEntry where
   form3sg := "übereilt"
   formPast := "übereilte"
   formPastPart := "übereilt"
-  complementType := .np
+  frames := [Frame.np]
 
 /-- *entwickeln* — "develop": takes only DP complement.
     "Die Stadt entwickelt [DP ein neues Konzept]." -/
@@ -505,7 +505,7 @@ def entwickeln : GermanVerbEntry where
   form3sg := "entwickelt"
   formPast := "entwickelte"
   formPastPart := "entwickelt"
-  complementType := .np
+  frames := [Frame.np]
   vendlerClass := some .accomplishment
 
 end NonCPSelecting
@@ -520,8 +520,7 @@ def veranlassen : GermanVerbEntry where
   form3sg := "veranlasst"
   formPast := "veranlasste"
   formPastPart := "veranlasst"
-  complementType := .np
-  altComplementType := some .finiteClause
+  frames := [Frame.np, Frame.finiteClause]
 
 /-- *vergessen* — "forget": takes DP or *dass*-clause.
     "Ich vergesse [DP den Termin]."
@@ -531,8 +530,7 @@ def vergessen : GermanVerbEntry where
   form3sg := "vergisst"
   formPast := "vergaß"
   formPastPart := "vergessen"
-  complementType := .np
-  altComplementType := some .finiteClause
+  frames := [Frame.np, Frame.finiteClause]
   opaqueContext := true
 
 /-- *erwarten* — "expect": takes DP or *dass*-clause.
@@ -543,8 +541,7 @@ def erwarten : GermanVerbEntry where
   form3sg := "erwartet"
   formPast := "erwartete"
   formPastPart := "erwartet"
-  complementType := .np
-  altComplementType := some .finiteClause
+  frames := [Frame.np, Frame.finiteClause]
   opaqueContext := true
 
 /-- *beschließen* — "decide": takes DP or *dass*-clause.
@@ -555,8 +552,7 @@ def beschliessen : GermanVerbEntry where
   form3sg := "beschließt"
   formPast := "beschloss"
   formPastPart := "beschlossen"
-  complementType := .np
-  altComplementType := some .finiteClause
+  frames := [Frame.np, Frame.finiteClause]
 
 end CPAndDPSelecting
 
@@ -671,7 +667,7 @@ theorem sorgen_is_uncertainty :
 -- ============================================================================
 
 /-- Non-CP-selecting verbs cannot take clausal complements.
-    Their `complementType` is `.np` with no `altComplementType`. -/
+    Their only frame is `Frame.np`. -/
 theorem nonCPSelecting_profile :
     beenden.toVerb.canTakeClausalComplement = false ∧
     streichen.toVerb.canTakeClausalComplement = false ∧
@@ -680,7 +676,7 @@ theorem nonCPSelecting_profile :
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-- CP-and-DP-selecting verbs can take clausal complements.
-    They have `altComplementType := some .finiteClause`. -/
+    Their `frames` include a `Frame.finiteClause` alternate. -/
 theorem cpSelecting_profile :
     veranlassen.toVerb.canTakeClausalComplement = true ∧
     vergessen.toVerb.canTakeClausalComplement = true ∧

--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -57,14 +57,14 @@ def complementizers : List Complementizer := [oti, pu, na]
     ex. 1a. Speech-act verb, eventive (activity). -/
 def leo : Verb where
   form := "léo"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   vendlerClass := some .activity
 
 /-- *pistévo* (πιστεύω) 'believe' — doxastic, stative. -/
 def pistevo : Verb where
   form := "pistévo"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .nonVeridical)
   vendlerClass := some .state
   passivizable := false
@@ -74,7 +74,7 @@ def pistevo : Verb where
     stative. Rejects manner adverbs ([angelopoulos-2026] ex. 21a). -/
 def ksero : Verb where
   form := "kséro"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .veridical)
   vendlerClass := some .state
   opaqueContext := false  -- factive ⇒ no opacity
@@ -84,7 +84,7 @@ def ksero : Verb where
     factive doxastic. -/
 def katalaveno : Verb where
   form := "katalavéno"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .veridical)
   vendlerClass := some .achievement
 
@@ -92,7 +92,7 @@ def katalaveno : Verb where
     factive doxastic ([angelopoulos-2026] ex. 21b). -/
 def sinidhitopio : Verb where
   form := "sinidhitopió"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .veridical)
   vendlerClass := some .achievement
 
@@ -100,7 +100,7 @@ def sinidhitopio : Verb where
     yielding *explanans* reading ([angelopoulos-2026] ex. 4a). -/
 def eksigo : Verb where
   form := "eksigó"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .accomplishment
 
 -- ════════════════════════════════════════════════════════════════
@@ -114,7 +114,7 @@ def eksigo : Verb where
     valence), stative. [angelopoulos-2026] ex. 1b, 20. -/
 def metaniono : Verb where
   form := "metanióno"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .state
 
@@ -122,7 +122,7 @@ def metaniono : Verb where
     stative ([angelopoulos-2026] ex. 13, 14; [landau-2009]). -/
 def areso : Verb where
   form := "aréso"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.preferential (.degreeComparison .positive))
   vendlerClass := some .state
   unaccusative := true
@@ -131,7 +131,7 @@ def areso : Verb where
     stative. -/
 def xerome : Verb where
   form := "xérome"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.preferential (.degreeComparison .positive))
   vendlerClass := some .state
 
@@ -152,7 +152,7 @@ def xerome : Verb where
     [angelopoulos-2026] ex. 22 contrasts the two. -/
 def thimame : Verb where
   form := "thimáme"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .veridical)
   vendlerClass := some .achievement  -- eventive (perception) sense
 
@@ -161,7 +161,7 @@ def thimame : Verb where
     ex. 19, 23). -/
 def thimono : Verb where
   form := "thimóno"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .achievement
 

--- a/Linglib/Fragments/Greek/StandardModern/MoodChoice.lean
+++ b/Linglib/Fragments/Greek/StandardModern/MoodChoice.lean
@@ -28,7 +28,7 @@ open Semantics.Lexical
     Cited from [giannakidou-mari-2021]. -/
 def thelo : Verb where
   form := "thélo"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -39,7 +39,7 @@ def thelo : Verb where
     Cited from [giannakidou-mari-2021]. -/
 def elpizo : Verb where
   form := "elpízo"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -49,7 +49,7 @@ def elpizo : Verb where
     Cited from [giannakidou-mari-2021]. -/
 def protithete : Verb where
   form := "protíthete"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -60,8 +60,8 @@ def protithete : Verb where
     Past tense form *évala* used in the paper's examples. -/
 def vazo : Verb where
   form := "vázo"
-  complementType := .finiteClause
-  controlType := .objectControl
+  frames := [Frame.finiteClause]
+  readings := [{ frame := Frame.finiteClause, control := some .objectControl }]
   causative := some .make
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Fragments/Hausa/VerbGrades.lean
+++ b/Linglib/Fragments/Hausa/VerbGrades.lean
@@ -230,7 +230,7 @@ instance (v : HausaVerb) : Decidable v.canonical :=
 def mkVerb (form : String) (g : StemTemplate)
     (lexTones : List TRN := []) : HausaVerb where
   form           := form
-  complementType := g.defaultCT
+  frames := [g.defaultCT.toFrame]
   voiceType      := some g.defaultVoice
   grade          := g
   lexTones       := lexTones
@@ -270,7 +270,7 @@ def lexicon : List HausaVerb :=
     canonicity — making the empirical claim "gr1 has an intransitive
     sub-use" *visible* in the type system rather than buried in prose. -/
 def gangara : HausaVerb :=
-  { mkVerb "gangarā" gr1 with complementType := .none }
+  { mkVerb "gangarā" gr1 with frames := [] }
 
 -- ============================================================================
 -- § 6: Universal Theorems About the Grade System
@@ -330,7 +330,8 @@ theorem gr7_nonThematic (v : HausaVerb)
 theorem mkVerb_is_canonical (form : String) (g : StemTemplate)
     (lexTones : List TRN := []) :
     (mkVerb form g lexTones).canonical :=
-  ⟨rfl, rfl⟩
+  ⟨by simp [mkVerb, HausaVerb.canonical, Verb.complementType,
+      toComplementType_toFrame], rfl⟩
 
 /-- **Grades 5 and 6 introduce an external argument.** The two H–H
     grades are both agentive at the `Verb` level. -/

--- a/Linglib/Fragments/Hungarian/Predicates.lean
+++ b/Linglib/Fragments/Hungarian/Predicates.lean
@@ -63,7 +63,7 @@ def lat : HungarianVerbEntry where
   formPresIndef := "lát"
   formPastDef := "látta"
   formPastIndef := "látott"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   levinClass := some .see
 
 /-- *hall* 'hear' — perception verb ([egressy-2026], exx. (5), (13), (17)).
@@ -76,7 +76,7 @@ def hall : HungarianVerbEntry where
   formPresIndef := "hall"
   formPastDef := "hallotta"
   formPastIndef := "hallott"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   levinClass := some .see
 
 /-- *álmodik* 'dream' — perception-in-a-dream ([egressy-2026], exx. (6), (10)).
@@ -84,7 +84,7 @@ def hall : HungarianVerbEntry where
 def almodik : HungarianVerbEntry where
   form := "álmodik"
   gloss := "dream"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -99,7 +99,7 @@ def gondol : HungarianVerbEntry where
   formPresIndef := "gondol"
   formPastDef := "gondolta"
   formPastIndef := "gondolt"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .nonVeridical)
   complementSig := some .mono
 
@@ -112,7 +112,7 @@ def hisz : HungarianVerbEntry where
   formPresIndef := "hisz"
   formPastDef := "hitte"
   formPastIndef := "hitt"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   opaqueContext := true
   attitude := some (.doxastic .nonVeridical)
   complementSig := some .mono
@@ -125,7 +125,7 @@ def tud : HungarianVerbEntry where
   formPresIndef := "tud"
   formPastDef := "tudta"
   formPastIndef := "tudott"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   presupType := some .softTrigger
   attitude := some (.doxastic .veridical)
   takesQuestionBase := true
@@ -136,7 +136,7 @@ def tud : HungarianVerbEntry where
 def aggaszt : HungarianVerbEntry where
   form := "aggaszt"
   gloss := "worry"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -151,7 +151,7 @@ def mond : HungarianVerbEntry where
   formPresIndef := "mond"
   formPastDef := "mondta"
   formPastIndef := "mondott"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   levinClass := some .say
 
@@ -159,7 +159,7 @@ def mond : HungarianVerbEntry where
 def rikolt : HungarianVerbEntry where
   form := "rikolt"
   gloss := "shout"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   levinClass := some .mannerOfSpeaking
 
@@ -169,7 +169,7 @@ def rikolt : HungarianVerbEntry where
 def morog : HungarianVerbEntry where
   form := "morog"
   gloss := "growl"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   speechActVerb := true
   levinClass := some .mannerOfSpeaking
 

--- a/Linglib/Fragments/Indonesian/Predicates.lean
+++ b/Linglib/Fragments/Indonesian/Predicates.lean
@@ -188,7 +188,7 @@ structure IndonesianVerbEntry extends Verb where
     reflexive incorporation (*ber-jual=diri* (26b)). -/
 def jual : IndonesianVerbEntry :=
   { form := "jual"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-jual"
   , formBer := some "ber-jual"
   , formDi := some "di-jual"
@@ -201,7 +201,7 @@ def jual : IndonesianVerbEntry :=
     (the paper's table (4)). -/
 def masak : IndonesianVerbEntry :=
   { form := "masak"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "me-masak"
   , formBer := some "ber-masak"
   , formDi := some "di-masak"
@@ -213,7 +213,7 @@ def masak : IndonesianVerbEntry :=
     (the paper's table (4) and (18)). -/
 def cuci : IndonesianVerbEntry :=
   { form := "cuci"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-cuci"
   , formBer := some "ber-cuci"
   , formDi := some "di-cuci"
@@ -228,7 +228,7 @@ def cuci : IndonesianVerbEntry :=
     (the paper's table (4)). -/
 def tambat : IndonesianVerbEntry :=
   { form := "tambat"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-tambat"
   , formBer := some "ber-tambat"
   , formDi := some "di-tambat"
@@ -243,7 +243,7 @@ def tambat : IndonesianVerbEntry :=
     (the paper's table (15)). -/
 def dandan : IndonesianVerbEntry :=
   { form := "dandan"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-dandan"
   , formBer := some "ber-dandan"
   , formDi := some "di-dandan"
@@ -254,7 +254,7 @@ def dandan : IndonesianVerbEntry :=
     (the paper's table (15)). -/
 def cukur : IndonesianVerbEntry :=
   { form := "cukur"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-cukur"
   , formBer := some "ber-cukur"
   , formDi := some "di-cukur"
@@ -266,7 +266,7 @@ def cukur : IndonesianVerbEntry :=
     ([sneddon-1996] §1.168; the paper's table (15)). -/
 def jemur : IndonesianVerbEntry :=
   { form := "jemur"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-jemur"
   , formBer := some "ber-jemur"
   , formDi := some "di-jemur"
@@ -278,7 +278,7 @@ def jemur : IndonesianVerbEntry :=
     (the paper's table (15)). -/
 def sisir : IndonesianVerbEntry :=
   { form := "sisir"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "meny-sisir"
   , formBer := some "ber-sisir"
   , formDi := some "di-sisir"
@@ -292,7 +292,7 @@ def sisir : IndonesianVerbEntry :=
     Change-of-state verb without entailed external cause. -/
 def buka : IndonesianVerbEntry :=
   { form := "buka"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "mem-buka"
   , formTer := some "ter-buka"
   , terClass := some .stative
@@ -305,7 +305,7 @@ def buka : IndonesianVerbEntry :=
     (the paper's §5, (67)–(68)). -/
 def pecah : IndonesianVerbEntry :=
   { form := "pecah"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "mem-pecah"
   , formTer := some "ter-pecah"
   , terClass := some .stative
@@ -325,7 +325,7 @@ def pecah : IndonesianVerbEntry :=
     ([sneddon-1996] §1.266). -/
 def tulis : IndonesianVerbEntry :=
   { form := "tulis"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-tulis"
   , formTer := some "ter-tulis"
   , terClass := some .stative
@@ -343,7 +343,7 @@ def tulis : IndonesianVerbEntry :=
     ([sneddon-1996] §1.269, §1.273). -/
 def bawa : IndonesianVerbEntry :=
   { form := "bawa"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "mem-bawa"
   , formTer := some "ter-bawa"
   , terClass := some .accidental
@@ -361,7 +361,7 @@ def bawa : IndonesianVerbEntry :=
     ([sneddon-1996] §1.272). -/
 def dengar : IndonesianVerbEntry :=
   { form := "dengar"
-  , complementType := .np
+  , frames := [Frame.np]
   , formMeN := some "men-dengar"
   , formTer := some "ter-dengar"
   , terClass := some .abilitative

--- a/Linglib/Fragments/Italian/Predicates.lean
+++ b/Linglib/Fragments/Italian/Predicates.lean
@@ -76,9 +76,8 @@ structure ItalianVerbEntry extends Verb where
     - (4b) Marco ha convinto Gianni a avere un figlio (intention) -/
 def convincere : ItalianVerbEntry :=
   { form := "convincere"
-    complementType := .infinitival
-    controlType := .objectControl
-    altComplementType := some .finiteClause
+    frames := [Frame.infinitival, Frame.finiteClause]
+    readings := [{ frame := Frame.infinitival, control := some .objectControl }]
     opaqueContext := true
     -- No fixed attitude: attitude type (belief vs intention)
     -- is determined by complement size, not lexically specified.
@@ -88,9 +87,8 @@ def convincere : ItalianVerbEntry :=
     Takes *di*-infinitives and *che*-finite clauses (belief only). -/
 def credere : ItalianVerbEntry :=
   { form := "credere"
-    complementType := .finiteClause
-    controlType := .subjectControl
-    altComplementType := some .infinitival
+    frames := [Frame.finiteClause, Frame.infinitival]
+    readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
     opaqueContext := true
     attitude := some (.doxastic .nonVeridical)
     infComplements := [.di] }
@@ -106,9 +104,8 @@ def credere : ItalianVerbEntry :=
     - (4b) Gianni vuole essere contento. (INF) -/
 def volere : ItalianVerbEntry :=
   { form := "volere"
-    complementType := .finiteClause
-    controlType := .subjectControl
-    altComplementType := some .infinitival
+    frames := [Frame.finiteClause, Frame.infinitival]
+    readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
     passivizable := false
     opaqueContext := true
     attitude := some (.preferential (.degreeComparison .positive))
@@ -124,9 +121,8 @@ def volere : ItalianVerbEntry :=
     *esperar*). -/
 def sperare : ItalianVerbEntry :=
   { form := "sperare"
-    complementType := .finiteClause
-    controlType := .subjectControl
-    altComplementType := some .infinitival
+    frames := [Frame.finiteClause, Frame.infinitival]
+    readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
     passivizable := false
     opaqueContext := true
     attitude := some (.preferential (.degreeComparison .positive))
@@ -142,8 +138,8 @@ def sperare : ItalianVerbEntry :=
     - (28) *Intendo che Giovanni vada/va al parco oggi. (rejected) -/
 def intendere : ItalianVerbEntry :=
   { form := "intendere"
-    complementType := .infinitival
-    controlType := .subjectControl
+    frames := [Frame.infinitival]
+    readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
     passivizable := false
     opaqueContext := true
     attitude := some (.preferential (.degreeComparison .positive))
@@ -158,8 +154,8 @@ def intendere : ItalianVerbEntry :=
     - (42a) Ho fatto sì che Giovanni *andasse*/*è andato al parco. (SBJV/*IND) -/
 def fare_caus : ItalianVerbEntry :=
   { form := "fare"
-    complementType := .infinitival
-    controlType := .objectControl
+    frames := [Frame.infinitival]
+    readings := [{ frame := Frame.infinitival, control := some .objectControl }]
     causative := some .make
     infComplements := [.a_] }
 

--- a/Linglib/Fragments/Japanese/Predicates.lean
+++ b/Linglib/Fragments/Japanese/Predicates.lean
@@ -34,7 +34,7 @@ def tanosimi : JapaneseVerbEntry where
   formPast := "tanosimi datta"
   formGerund := "tanosimi"
   formProgressive := "tanosimi"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.relevanceBased .positive))
@@ -46,7 +46,7 @@ def osore : JapaneseVerbEntry where
   formPast := "osoreta"
   formGerund := "osorete"
   formProgressive := "osoreteiru"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .negative))
@@ -58,7 +58,7 @@ def kitai : JapaneseVerbEntry where
   formPast := "kitai shita"
   formGerund := "kitai shite"
   formProgressive := "kitai shiteiru"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -70,7 +70,7 @@ def shinpai : JapaneseVerbEntry where
   formPast := "shinpai shita"
   formGerund := "shinpai shite"
   formProgressive := "shinpai shiteiru"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential .uncertaintyBased)
@@ -92,8 +92,8 @@ def ik_ase : JapaneseVerbEntry where
   formPast := "ik-ase-ta"
   formGerund := "ik-ase-te"
   formProgressive := "ik-ase-teiru"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .make
 
 /-- 食べさせる "tabe-sase-ru" — eat-CAUS (ACC causee = make reading). -/
@@ -103,8 +103,8 @@ def tabe_sase : JapaneseVerbEntry where
   formPast := "tabe-sase-ta"
   formGerund := "tabe-sase-te"
   formProgressive := "tabe-sase-teiru"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .make
 
 /-- Japanese causative -(s)ase uses `.make` builder (direct causation reading). -/
@@ -127,7 +127,7 @@ def hanareru : JapaneseVerbEntry where
   formPast := "hanareta"
   formGerund := "hanarete"
   formProgressive := "hanareteiru"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := true
   voiceType := some .nonThematic
   passivizable := false
@@ -142,7 +142,7 @@ def deru : JapaneseVerbEntry where
   formPast := "deta"
   formGerund := "dete"
   formProgressive := "deteiru"
-  complementType := .np
+  frames := [Frame.np]
   unaccusative := true
   voiceType := some .nonThematic
   passivizable := false

--- a/Linglib/Fragments/Korean/Complementizers.lean
+++ b/Linglib/Fragments/Korean/Complementizers.lean
@@ -104,14 +104,14 @@ def kes : Word := { form := "kes", cat := .NOUN }
     [bondarenko-2022] §4.3.2. -/
 def yukamsulewehayta : Verb where
   form := "yukamsulewehay-ta"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .state
 
 /-- *mit-ta* — 'believe'. Doxastic non-veridical, stative. -/
 def mitta : Verb where
   form := "mit-ta"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .nonVeridical)
   vendlerClass := some .state
   passivizable := false
@@ -120,7 +120,7 @@ def mitta : Verb where
 /-- *sayngkakha-ta* — 'think'. Doxastic non-veridical, activity. -/
 def sayngkakhata : Verb where
   form := "sayngkakha-ta"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   attitude := some (.doxastic .nonVeridical)
   vendlerClass := some .activity
   opaqueContext := true
@@ -128,7 +128,7 @@ def sayngkakhata : Verb where
 /-- *haysekha-ta* — 'interpret'. -/
 def haysekhata : Verb where
   form := "haysekha-ta"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .activity
   opaqueContext := true
 
@@ -136,7 +136,7 @@ def haysekhata : Verb where
     [bondarenko-2022] §4.4.2 theme-argument analysis. -/
 def selmyenghata : Verb where
   form := "selmyengha-ta"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   vendlerClass := some .accomplishment
 
 end Korean.Complementizers

--- a/Linglib/Fragments/Korean/Predicates.lean
+++ b/Linglib/Fragments/Korean/Predicates.lean
@@ -36,8 +36,8 @@ def wus_ke_ha : KoreanVerbEntry where
   formPast := "wus-ke ha-əss-ta"
   formAdnom := "wus-ke ha-n"
   formProgressive := "wus-ke ha-go itta"
-  complementType := .infinitival
-  controlType := .objectControl
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   causative := some .cause
 
 /-- 읽게 하다 "ilk-ke ha-da" — read-PURP do = "cause to read". -/
@@ -47,8 +47,8 @@ def ilk_ke_ha : KoreanVerbEntry where
   formPast := "ilk-ke ha-əss-ta"
   formAdnom := "ilk-ke ha-n"
   formProgressive := "ilk-ke ha-go itta"
-  complementType := .infinitival
-  controlType := .objectControl
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   causative := some .cause
 
 /-- 죽이다 "cwuk-i-da" — die-CAUS = "to kill" (lexical/morphological COMPACT). -/
@@ -58,7 +58,7 @@ def cwuk_i : KoreanVerbEntry where
   formPast := "cwuk-yəss-ta"
   formAdnom := "cwuk-i-n"
   formProgressive := "cwuk-i-go itta"
-  complementType := .np
+  frames := [Frame.np]
   causative := some .make
 
 /-- Korean PURP-type *-ke ha-* uses `.cause` builder. -/

--- a/Linglib/Fragments/Mandarin/Predicates.lean
+++ b/Linglib/Fragments/Mandarin/Predicates.lean
@@ -26,7 +26,7 @@ def MandarinVerbEntry.mk' (core : Verb) : MandarinVerbEntry :=
 /-- 期待 "qidai" — look forward to (Class 1: positive, non-C-distributive, takes questions). -/
 def qidai : MandarinVerbEntry := .mk' {
   form := "qidai"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.relevanceBased .positive)) }
@@ -34,7 +34,7 @@ def qidai : MandarinVerbEntry := .mk' {
 /-- 担心 "danxin" — worry (Class 1: negative, non-C-distributive). -/
 def danxin : MandarinVerbEntry := .mk' {
   form := "danxin"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential .uncertaintyBased) }
@@ -42,7 +42,7 @@ def danxin : MandarinVerbEntry := .mk' {
 /-- 希望 "xiwang" — hope (Class 3: positive, C-distributive, anti-rogative). -/
 def xiwang : MandarinVerbEntry := .mk' {
   form := "xiwang"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
@@ -50,7 +50,7 @@ def xiwang : MandarinVerbEntry := .mk' {
 /-- 害怕 "haipa" — fear (Class 2: negative, C-distributive, takes questions). -/
 def haipa : MandarinVerbEntry := .mk' {
   form := "haipa"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .negative)) }
@@ -62,7 +62,7 @@ contrafactive postsupposition (◇¬p, not derivable from veridicality alone);
 that paper-specific apparatus lives in `Glass2025`, not on this entry. -/
 def yiwei : MandarinVerbEntry := .mk' {
   form := "yiwei"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.doxastic .nonVeridical) }
@@ -80,7 +80,7 @@ projection per the audit's "derive don't stipulate" discipline. -/
 /-- 想 *xiang* 'want' — desiderative; nonfinite-taking. Liu & Yip 2026 (18). -/
 def xiang : MandarinVerbEntry := .mk' {
   form := "xiang"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
@@ -88,7 +88,7 @@ def xiang : MandarinVerbEntry := .mk' {
 /-- 让 *rang* 'let' — manipulative; nonfinite-taking. Liu & Yip 2026 (18). -/
 def rang : MandarinVerbEntry := .mk' {
   form := "rang"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
   passivizable := false
   opaqueContext := false }
 
@@ -96,7 +96,7 @@ def rang : MandarinVerbEntry := .mk' {
     (CP-only). Liu & Yip 2026 (19) — blocks *you*-skipping. -/
 def xiangxin : MandarinVerbEntry := .mk' {
   form := "xiangxin"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.doxastic .veridical) }
@@ -104,7 +104,7 @@ def xiangxin : MandarinVerbEntry := .mk' {
 /-- 劝 *quan* 'urge' — manipulative; nonfinite-taking. Liu & Yip 2026 (18). -/
 def quan : MandarinVerbEntry := .mk' {
   form := "quan"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
   passivizable := true
   opaqueContext := false }
 
@@ -112,7 +112,7 @@ def quan : MandarinVerbEntry := .mk' {
     (listed as *bi(po)*). -/
 def bi : MandarinVerbEntry := .mk' {
   form := "bi"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
   passivizable := true
   opaqueContext := false }
 
@@ -121,7 +121,7 @@ def bi : MandarinVerbEntry := .mk' {
     Type II (TP) and Type III (vP) selection. -/
 def dasuan : MandarinVerbEntry := .mk' {
   form := "dasuan"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive)) }
@@ -130,7 +130,7 @@ def dasuan : MandarinVerbEntry := .mk' {
     [noonan-2007] classifies 'try' under the achievement CTP class. -/
 def shefa : MandarinVerbEntry := .mk' {
   form := "shefa"
-  complementType := .infinitival
+  frames := [Frame.infinitival]
   passivizable := false
   opaqueContext := false }
 

--- a/Linglib/Fragments/Portuguese/MoodChoice.lean
+++ b/Linglib/Fragments/Portuguese/MoodChoice.lean
@@ -25,9 +25,8 @@ open Semantics.Lexical
     [grano-2024], (3a): SBJV required. -/
 def querer : Verb where
   form := "querer"
-  complementType := .finiteClause
-  controlType := .subjectControl
-  altComplementType := some .infinitival
+  frames := [Frame.finiteClause, Frame.infinitival]
+  readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -37,9 +36,8 @@ def querer : Verb where
     [grano-2024], (11): both IND and SBJV accepted. -/
 def esperar : Verb where
   form := "esperar"
-  complementType := .finiteClause
-  controlType := .subjectControl
-  altComplementType := some .infinitival
+  frames := [Frame.finiteClause, Frame.infinitival]
+  readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -48,8 +46,8 @@ def esperar : Verb where
     [grano-2024], (26): SBJV required, IND rejected. -/
 def pretender : Verb where
   form := "pretender"
-  complementType := .infinitival
-  controlType := .subjectControl
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -59,9 +57,8 @@ def pretender : Verb where
     [grano-2024], (41): SBJV required via *com que*, IND rejected. -/
 def fazer : Verb where
   form := "fazer"
-  complementType := .infinitival
-  controlType := .objectControl
-  altComplementType := some .finiteClause
+  frames := [Frame.infinitival, Frame.finiteClause]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   causative := some .make
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Fragments/Romanian/MoodChoice.lean
+++ b/Linglib/Fragments/Romanian/MoodChoice.lean
@@ -29,7 +29,7 @@ open Semantics.Lexical
     [grano-2024], (6): *să* (SBJV) required, *că* (IND) rejected. -/
 def a_vrea : Verb where
   form := "a vrea"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -39,7 +39,7 @@ def a_vrea : Verb where
     [grano-2024], (14): both *să* (SBJV) and *că* (IND) accepted. -/
 def a_spera : Verb where
   form := "a spera"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -48,7 +48,7 @@ def a_spera : Verb where
     [grano-2024], (23): *să* (SBJV) required, *că* (IND) rejected. -/
 def a_intentiona : Verb where
   form := "a intenționa"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -58,8 +58,8 @@ def a_intentiona : Verb where
     [grano-2024], (46): *să* (SBJV) required, *că* (IND) rejected. -/
 def a_face : Verb where
   form := "a face"
-  complementType := .finiteClause
-  controlType := .objectControl
+  frames := [Frame.finiteClause]
+  readings := [{ frame := Frame.finiteClause, control := some .objectControl }]
   causative := some .make
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Fragments/Spanish/MoodChoice.lean
+++ b/Linglib/Fragments/Spanish/MoodChoice.lean
@@ -25,9 +25,8 @@ open Semantics.Lexical
     [grano-2024], (1a): SBJV required, IND rejected. -/
 def querer : Verb where
   form := "querer"
-  complementType := .finiteClause
-  controlType := .subjectControl
-  altComplementType := some .infinitival
+  frames := [Frame.finiteClause, Frame.infinitival]
+  readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -37,9 +36,8 @@ def querer : Verb where
     [grano-2024], (9): SBJV required, IND rejected. -/
 def esperar : Verb where
   form := "esperar"
-  complementType := .finiteClause
-  controlType := .subjectControl
-  altComplementType := some .infinitival
+  frames := [Frame.finiteClause, Frame.infinitival]
+  readings := [{ frame := Frame.finiteClause, control := some .subjectControl }]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -49,8 +47,8 @@ def esperar : Verb where
     Periphrastic form (nominal predicate). -/
 def tener_la_intencion : Verb where
   form := "tener la intención"
-  complementType := .infinitival
-  controlType := .subjectControl
+  frames := [Frame.infinitival]
+  readings := [{ frame := Frame.infinitival, control := some .subjectControl }]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -61,9 +59,8 @@ def tener_la_intencion : Verb where
     Infinitival complements with object control. -/
 def hacer : Verb where
   form := "hacer"
-  complementType := .infinitival
-  controlType := .objectControl
-  altComplementType := some .finiteClause
+  frames := [Frame.infinitival, Frame.finiteClause]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   causative := some .make
 
 /-- *convencer* 'convince' — hybrid predicate (§6.2, (102)–(103)).
@@ -73,9 +70,8 @@ def hacer : Verb where
       diciendo la verdad" (IND) -/
 def convencer : Verb where
   form := "convencer"
-  complementType := .infinitival
-  controlType := .objectControl
-  altComplementType := some .finiteClause
+  frames := [Frame.infinitival, Frame.finiteClause]
+  readings := [{ frame := Frame.infinitival, control := some .objectControl }]
   opaqueContext := true
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -92,7 +92,7 @@ structure SpanishVerbEntry extends Verb where
     EFFECTOR causer: admits agents, instruments, natural forces
     ([koontz-garboden-2009] exx. 47–49). -/
 def abrir : SpanishVerbEntry :=
-  { form := "abrir", complementType := .np,
+  { form := "abrir", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true, causerSpec := some .effector,
@@ -103,7 +103,7 @@ def abrir : SpanishVerbEntry :=
     EFFECTOR causer: agents, instruments, natural forces, events
     ([koontz-garboden-2009] exx. 13–17). -/
 def romper : SpanishVerbEntry :=
-  { form := "romper", complementType := .np,
+  { form := "romper", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true, causerSpec := some .effector,
@@ -113,7 +113,7 @@ def romper : SpanishVerbEntry :=
 /-- *hundir* "sink" — marked anticausative, licenses stylistic LE.
     EFFECTOR causer ([koontz-garboden-2009] ex. 46). -/
 def hundir : SpanishVerbEntry :=
-  { form := "hundir", complementType := .np,
+  { form := "hundir", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true, causerSpec := some .effector,
@@ -123,7 +123,7 @@ def hundir : SpanishVerbEntry :=
 /-- *caer* "fall" — marked anticausative, licenses stylistic LE.
     (ex. 9, unaccusative) -/
 def caer : SpanishVerbEntry :=
-  { form := "caer", complementType := .none,
+  { form := "caer", frames := [],
     unaccusative := true,
     anticausativeMarking := .marked,
     causativeAlternation := false, verbHead := [.vCAUSE, .vGO, .vBE],
@@ -132,7 +132,7 @@ def caer : SpanishVerbEntry :=
 /-- *morir* "die" — marked anticausative, licenses stylistic LE.
     (ex. 10) -/
 def morir : SpanishVerbEntry :=
-  { form := "morir", complementType := .none,
+  { form := "morir", frames := [],
     unaccusative := true,
     anticausativeMarking := .marked,
     causativeAlternation := false, verbHead := [.vCAUSE, .vGO, .vBE],
@@ -142,7 +142,7 @@ def morir : SpanishVerbEntry :=
     in [munoz-perez-2026] exx. 15–19 (*me/te le cerró la ventana* OK,
     *le/nos/les le cerró la ventana* unacceptable). -/
 def cerrar : SpanishVerbEntry :=
-  { form := "cerrar", complementType := .np,
+  { form := "cerrar", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true }
@@ -150,7 +150,7 @@ def cerrar : SpanishVerbEntry :=
 /-- *quebrar* "crack" — marked anticausative, licenses stylistic LE.
     (exx. 38–39) -/
 def quebrar : SpanishVerbEntry :=
-  { form := "quebrar", complementType := .np,
+  { form := "quebrar", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true }
@@ -158,7 +158,7 @@ def quebrar : SpanishVerbEntry :=
 /-- *hervir* "boil" — optional SE marking, but still licenses stylistic LE.
     (exx. 41–44) -/
 def hervir : SpanishVerbEntry :=
-  { form := "hervir", complementType := .np,
+  { form := "hervir", frames := [Frame.np],
     anticausativeMarking := .optional,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true }
@@ -166,7 +166,7 @@ def hervir : SpanishVerbEntry :=
 /-- *olvidar* "forget" — marked anticausative, licenses stylistic LE.
     (ex. 11, psych verb) -/
 def olvidar : SpanishVerbEntry :=
-  { form := "olvidar", complementType := .np,
+  { form := "olvidar", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true }
@@ -174,7 +174,7 @@ def olvidar : SpanishVerbEntry :=
 /-- *ocurrir* "occur" — marked anticausative, licenses stylistic LE.
     (ex. 12) -/
 def ocurrir : SpanishVerbEntry :=
-  { form := "ocurrir", complementType := .none,
+  { form := "ocurrir", frames := [],
     unaccusative := true,
     anticausativeMarking := .marked,
     causativeAlternation := false, verbHead := [.vCAUSE, .vGO, .vBE],
@@ -183,7 +183,7 @@ def ocurrir : SpanishVerbEntry :=
 /-- *mejorar* "improve" — UNMARKED anticausative, does NOT license stylistic LE.
     (ex. 40b *Me le mejoró el sueldo) -/
 def mejorar : SpanishVerbEntry :=
-  { form := "mejorar", complementType := .np,
+  { form := "mejorar", frames := [Frame.np],
     anticausativeMarking := .unmarked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := false }
@@ -193,7 +193,7 @@ def mejorar : SpanishVerbEntry :=
     implies unidirectional (linear, gash-like) separation. Incompatible with
     careful controlled action. [spalek-mcnally-2026] (§3.2). -/
 def rasgar : SpanishVerbEntry :=
-  { form := "rasgar", complementType := .np,
+  { form := "rasgar", frames := [Frame.np],
     causative := some .make,
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
@@ -211,7 +211,7 @@ def rasgar : SpanishVerbEntry :=
     Reflexivization yields reflexive reading only (*El senador se asesinó*
     = 'The senator killed himself'). [koontz-garboden-2009] exx. 24–29. -/
 def asesinar : SpanishVerbEntry :=
-  { form := "asesinar", complementType := .np,
+  { form := "asesinar", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := false, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := false, causerSpec := some .agent,
@@ -220,7 +220,7 @@ def asesinar : SpanishVerbEntry :=
 /-- *cortar* "cut" — AGENT causer required. No anticausative.
     [koontz-garboden-2009] ex. 26. -/
 def cortar : SpanishVerbEntry :=
-  { form := "cortar", complementType := .np,
+  { form := "cortar", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := false, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := false, causerSpec := some .agent,
@@ -230,7 +230,7 @@ def cortar : SpanishVerbEntry :=
     are typical. Alternates: *ahogarse* is a derived inchoative.
     [koontz-garboden-2009] exx. 50–52. -/
 def ahogar : SpanishVerbEntry :=
-  { form := "ahogar", complementType := .np,
+  { form := "ahogar", frames := [Frame.np],
     anticausativeMarking := .marked,
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := false, causerSpec := some .effector,
@@ -240,7 +240,7 @@ def ahogar : SpanishVerbEntry :=
 /-- *empeorar* "worsen" — internally caused COS verb. No CAUSE in LSR.
     Rejects *por sí solo*. [koontz-garboden-2009] ex. 65a. -/
 def empeorar : SpanishVerbEntry :=
-  { form := "empeorar", complementType := .np,
+  { form := "empeorar", frames := [Frame.np],
     anticausativeMarking := .unmarked,
     causativeAlternation := true, verbHead := [.vGO, .vBE],
     licensesStylLE := false }
@@ -248,7 +248,7 @@ def empeorar : SpanishVerbEntry :=
 /-- *crecer* "grow" — internally caused COS verb. No CAUSE in LSR.
     Rejects *por sí solo*. [koontz-garboden-2009] ex. 65c. -/
 def crecer : SpanishVerbEntry :=
-  { form := "crecer", complementType := .none,
+  { form := "crecer", frames := [],
     unaccusative := true,
     anticausativeMarking := .unmarked,
     causativeAlternation := false, verbHead := [.vGO, .vBE],

--- a/Linglib/Fragments/Turkish/Predicates.lean
+++ b/Linglib/Fragments/Turkish/Predicates.lean
@@ -34,7 +34,7 @@ def kork : TurkishVerbEntry where
   formPast := "korktu"
   formEvidential := "korkmuş"
   formParticiple := "korkan"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .negative))
@@ -46,7 +46,7 @@ def um : TurkishVerbEntry where
   formPast := "umdu"
   formEvidential := "ummuş"
   formParticiple := "uman"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential (.degreeComparison .positive))
@@ -58,7 +58,7 @@ def merakEt : TurkishVerbEntry where
   formPast := "merak etti"
   formEvidential := "merak etmiş"
   formParticiple := "merak eden"
-  complementType := .question
+  frames := [Frame.question]
   passivizable := false
   opaqueContext := true
   takesQuestionBase := true
@@ -70,7 +70,7 @@ def endiselen : TurkishVerbEntry where
   formPast := "endişelendi"
   formEvidential := "endişelenmiş"
   formParticiple := "endişelenen"
-  complementType := .finiteClause
+  frames := [Frame.finiteClause]
   passivizable := false
   opaqueContext := true
   attitude := some (.preferential .uncertaintyBased)
@@ -88,7 +88,7 @@ def ol_dur : TurkishVerbEntry where
   formPast := "öldürdü"
   formEvidential := "öldürmüş"
   formParticiple := "öldüren"
-  complementType := .np
+  frames := [Frame.np]
   causative := some .make
 
 /-- yap-tır-mak — do-CAUS = "to make (someone) do" (productive causative). -/
@@ -98,8 +98,8 @@ def yap_tir : TurkishVerbEntry where
   formPast := "yaptırdı"
   formEvidential := "yaptırmış"
   formParticiple := "yaptıran"
-  complementType := .smallClause
-  controlType := .objectControl
+  frames := [Frame.smallClause]
+  readings := [{ frame := Frame.smallClause, control := some .objectControl }]
   causative := some .make
 
 /-- Turkish causative *-dür* uses `.make` builder. -/

--- a/Linglib/Fragments/Uyghur/Complementizers.lean
+++ b/Linglib/Fragments/Uyghur/Complementizers.lean
@@ -83,8 +83,7 @@ complement to V (his 73). Under [major-2024] this same entry,
 converb-suffixed, heads dep clauses (`Studies/Major2024.lean`). -/
 def deVerb : Verb where
   form := "de-"
-  complementType := .finiteClause
-  altComplementType := some .np
+  frames := [Frame.finiteClause, Frame.np]
   speechActVerb := true
 
 /-- *oyla-* 'think' (his 58–59): takes DP objects (*u xewer-ni* 'that
@@ -94,8 +93,7 @@ frame is recorded: the apparent finite-CP frame (his 37a) is
 answering *qandaq* 'how' (his 58b, 60), not a complement. -/
 def oyla : Verb where
   form := "oyla-"
-  complementType := .np
-  altComplementType := some .gerund
+  frames := [Frame.np, Frame.gerund]
   attitude := some (.doxastic .nonVeridical)
 
 /-- *warqira-* 'scream': unergative, no complement frame — neither DP
@@ -103,7 +101,7 @@ def oyla : Verb where
 coerced into a verb of speech (his 38; §3.1). -/
 def warqira : Verb where
   form := "warqira-"
-  complementType := .none
+  frames := []
   voiceType := some .agentive
 
 end Uyghur

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Frame
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Features.Aktionsart
@@ -27,8 +28,13 @@ semantic fields shared across languages.
 into facet structures under the `Verb` namespace — `Verb.ArgStructure`,
 `Verb.Aspect`, `Verb.Presupposition`, `Verb.Causation`, `Verb.Attitude`
 — which `Verb` composes via `extends`. Flat field access
-(`v.complementType`, `v.attitude`, …) is preserved by `extends`-flattening, and
+(`v.frames`, `v.attitude`, …) is preserved by `extends`-flattening, and
 language fragments extend `Verb` with their own inflectional paradigms.
+Complement selection is a list of typed `Frame`s
+(`Syntax/Clause/Frame.lean`); frame-conditioned
+attitude/opacity/control lives on `Verb.Reading` rows; the legacy flat
+readers (`v.complementType`, `v.controlType`, …) are derived accessors
+over `frames`/`readings`.
 
 Verb classification (factive, causative, attitude, …) is DERIVED from these
 primitive fields in `Semantics/Verb/Basic.lean`, not stipulated as an enum.
@@ -156,8 +162,11 @@ namespace Verb
 /-- Argument structure and realization: complement selection, control,
     proto-role entailments, voice, and implicit arguments. -/
 structure ArgStructure where
-  /-- What complement does the verb select? -/
-  complementType : ComplementType
+  /-- Complement frames, citation frame first. `[]` for intransitives.
+      The legacy `ComplementType` cells are the `Frame.np`,
+      `Frame.finiteClause`, … smart constructors
+      (`Syntax/Clause/Frame.lean`). -/
+  frames : List Frame
   /-- Proto-role entailment profile for the subject (external argument).
       The authoritative representation of argument semantics
       ([dowty-1991], [grimm-2011], [levin-2019]).
@@ -165,15 +174,6 @@ structure ArgStructure where
   subjectEntailments : Option EntailmentProfile := none
   /-- Proto-role entailment profile for the first object (internal argument). -/
   objectEntailments : Option EntailmentProfile := none
-  /-- Control type for infinitival complements -/
-  controlType : ControlType := .none
-  /-- Alternate complement frame, for verbs with two complement types.
-      E.g., "hope" primarily takes.finiteClause ("hope that...") but
-      also takes.infinitival ("hope to...") with subject control.
-      When set, `altControlType` specifies the control type for this frame. -/
-  altComplementType : Option ComplementType := none
-  /-- Control type for the alternate complement frame. -/
-  altControlType : ControlType := .none
   /-- Is the verb unaccusative? (subject is underlying object)
       When `voiceType` is present, prefer `derivedUnaccusative` which
       derives this from Voice selection ([kratzer-1996]). -/
@@ -237,6 +237,22 @@ structure Causation where
   causalSource : Option CausalSource := none
   deriving Repr, BEq
 
+/-- One frame-conditioned reading of a verb ([bondarenko-2022] §4.4.3
+    *hanaxa*; Greek *thimame*): per-frame overrides of the lexeme-level
+    attitude and opacity (`none` = inherit `Verb.attitude` /
+    `Verb.opaqueContext`), and the frame's control type. -/
+structure Reading where
+  /-- The frame this reading is conditioned on (one of the verb's
+      `frames`; `Verb.readingsWF`). -/
+  frame : Frame
+  /-- Frame-conditioned attitude override. -/
+  attitude : Option Features.Attitude := none
+  /-- Frame-conditioned opacity override. -/
+  opaqueContext : Option Bool := none
+  /-- Control type for this frame. -/
+  control : Option ControlType := none
+  deriving DecidableEq, Repr
+
 /-- Attitudinal and intensional properties: attitude classification, opacity,
     question-embedding, and complement monotonicity. -/
 structure Attitude where
@@ -245,6 +261,9 @@ structure Attitude where
   /-- Unified attitude classification covering doxastic and preferential attitudes.
       Theoretical properties (C-distributivity, parasitic, etc.) are DERIVED. -/
   attitude : Option Features.Attitude := none
+  /-- Frame-conditioned readings ([bondarenko-2022] §4.4.3): per-frame
+      attitude/opacity overrides and control, keyed to `frames` entries. -/
+  readings : List Reading := []
   /-- For non-preferential question-embedding verbs (know, wonder, ask) -/
   takesQuestionBase : Bool := false
   /-- Entailment signature of the complement position.
@@ -295,3 +314,45 @@ structure Verb extends
   deriving Repr, BEq
 
 end
+
+/-! ### Frame accessors
+
+Flat readers over `Verb.frames`/`Verb.readings`, preserving the legacy
+enum-based call syntax: the citation frame's complement/control type and
+the alternate frame's, when present. -/
+
+/-- The citation (first) frame's legacy `ComplementType` cell. -/
+def Verb.complementType (v : Verb) : ComplementType :=
+  (v.frames.head?.bind Frame.toComplementType).getD .none
+
+/-- The alternate (second) frame's legacy `ComplementType` cell. -/
+def Verb.altComplementType (v : Verb) : Option ComplementType :=
+  v.frames[1]?.bind Frame.toComplementType
+
+/-- The control type of the reading keyed to the citation frame. -/
+def Verb.controlType (v : Verb) : ControlType :=
+  (v.frames.head?.bind fun fr =>
+    (v.readings.find? (·.frame == fr)).bind (·.control)).getD .none
+
+/-- The control type of the reading keyed to the alternate frame. -/
+def Verb.altControlType (v : Verb) : ControlType :=
+  (v.frames[1]?.bind fun fr =>
+    (v.readings.find? (·.frame == fr)).bind (·.control)).getD .none
+
+/-- The effective attitude on frame `fr`: reading override, else lexeme
+    default. -/
+def Verb.attitudeOn (v : Verb) (fr : Frame) : Option Features.Attitude :=
+  ((v.readings.find? (·.frame == fr)).bind (·.attitude)).orElse
+    fun _ => v.attitude
+
+/-- Every reading is keyed to one of the verb's frames. -/
+def Verb.readingsWF (v : Verb) : Prop :=
+  ∀ r ∈ v.readings, r.frame ∈ v.frames
+
+/-- All [noonan-2007] codings across the verb's frames. -/
+def Verb.codings (v : Verb) : List NoonanCompType :=
+  v.frames.flatMap Frame.codings
+
+/-- Some frame of the verb records clause form `cf`. -/
+def Verb.takesClauseForm (v : Verb) (cf : Features.ClauseForm) : Prop :=
+  ∃ fr ∈ v.frames, fr.hasClauseForm cf

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -185,10 +185,10 @@ follows from the signature. √crack (`+cause+result`) entails a result state in
 any model; √jog (pure manner) does not — the *break*/*hit* contrast. -/
 
 /-- `crack` the change-of-state verb (`Mary cracked the vase`). -/
-def crackV : Verb := { form := "crack", complementType := .np, root := crack }
+def crackV : Verb := { form := "crack", frames := [Frame.np], root := crack }
 
 /-- `jog` the pure-manner activity verb (`Mary jogged`). -/
-def jogV : Verb := { form := "jog", complementType := .none, root := jog }
+def jogV : Verb := { form := "jog", frames := [], root := jog }
 
 /-- √crack carries `.result`, so in **any** model its denotation entails the
     result state — the non-cancelable result of [beavers-koontz-garboden-2020]

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -494,8 +494,17 @@ theorem hanaxa_frames_realized :
     hanaxa.realizes zha ∧
     hanaxa.realizes aasha ∧
     ¬ hanaxa.realizes ge :=
-  ⟨⟨.finiteClause, .head _, rfl⟩, ⟨.gerund, .tail _ (.head _), rfl⟩,
-    fun ⟨_, hf, h⟩ => by fin_cases hf <;> exact nomatch h⟩
+  ⟨⟨Frame.finiteClause, .head _, _, .head _, .indicative, rfl, rfl⟩,
+    ⟨nominalizedFrame, .tail _ (.head _), _, .head _, .nominalized, rfl, rfl⟩,
+    fun ⟨_, _, _, _, _, _, h⟩ => nomatch h⟩
+
+/-- *hanaxa* think~remember (§4.4.3): the attitude flips with the frame —
+    nonveridical/opaque on the bare CP, veridical on the nominalized
+    frame. Previously unstateable: `attitude` was per-lexeme. -/
+theorem hanaxa_frame_conditioned_attitude :
+    hanaxa.attitudeOn Frame.finiteClause = some (.doxastic .nonVeridical) ∧
+    hanaxa.attitudeOn nominalizedFrame = some (.doxastic .veridical) := by
+  decide
 
 /-! ### Noun-predicate co-occurrence (§2.2.3)
 

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -84,6 +84,7 @@ namespace Deal2026
 
 open NezPerce.ClausalEmbedding
 open Clause.Complementation
+open Slot.ShellInventory
 open Semantics.Presupposition.ProjectiveContent (ProjectiveClass)
 open Minimalist (Cat SatisfactionCond AbarDep keineĀProbe ClauseSpine
   hasValuedFeature FeatureBundle FeatureVal GramFeature ābar_is_Ā)
@@ -95,7 +96,7 @@ open Minimalist (Cat SatisfactionCond AbarDep keineĀProbe ClauseSpine
 /-- The full Deal-2026 description of a notional complement clause: internal
     spine + external shell + presence of internal Ā-dependency. Bundled here
     rather than in substrate to keep the per-axis primitives reusable
-    (`ClauseSpine`, `CPShellInventory`, `AbarDep`) for non-Deal accounts.
+    (`ClauseSpine`, `Slot.ShellInventory`, `AbarDep`) for non-Deal accounts.
 
     The three axes are independent in [deal-2026] Table 79: each cell
     in the 4×2 cross-classification (CP-superstructure × ±Ā) is filled or
@@ -104,7 +105,7 @@ structure NotionalComplementShape where
   /-- Internal spine of the embedded clause (typically `ClauseSpine.cP`). -/
   internal : ClauseSpine
   /-- External wrapping shells from C outward (`bareCP / dCP / dnCP / pdCP`). -/
-  external : CPShellInventory
+  external : Slot.ShellInventory
   /-- Whether the embedded CP contains an internal Ā-dependency. -/
   hasInternalAbar : Bool
   deriving Repr
@@ -288,7 +289,7 @@ theorem nezPerce_re_factive_no_nominalization :
 
 /-- The bare-CP shell contains neither D nor N. -/
 theorem bareCP_no_d_no_n :
-    CPShell.d ∉ bareCP ∧ CPShell.n ∉ bareCP := by
+    Slot.Shell.d ∉ bareCP ∧ Slot.Shell.n ∉ bareCP := by
   refine ⟨?_, ?_⟩ <;> decide
 
 -- ============================================================================
@@ -444,7 +445,7 @@ The Studies file integrates four independent substrate layers:
 - Fragment: per-verb consensus typology (CTPClass, factive)
 - Tonhauser projective content: ProjectiveClass (Semantics/Presupposition/)
 - Deal-internal: EmbeddingStrategy + NotionalComplementShape
-- Shell/Ā axes: `CPShellInventory` + `hasNominalShell` (Syntax/Clause/)
+- Shell/Ā axes: `Slot.ShellInventory` + `hasNominalShell` (Syntax/Clause/Frame.lean)
 
 The bridge theorems below derive load-bearing predictions across these
 layers rather than stipulating them. -/

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -2,116 +2,32 @@ import Linglib.Semantics.Verb.Defs
 import Linglib.Syntax.Complementizer.Basic
 
 /-!
-# Clause complementation: surface typology and selection
+# Clause complementation: selection
 
 [deal-2026] [noonan-2007]
 
-[deal-2026]'s notional-complement surface structures and CP external-shell
-inventory, plus the [noonan-2007]-anchored selection relation between verb
-frames and clause-typers.
+The [noonan-2007]-anchored selection relation between verb frames and
+clause-typers.
 
 ## Main definitions
 
-- `CPShell`, `CPShellInventory`, `isAttestedShell`, `hasNominalShell` —
-  CP external shells ([deal-2026] Table 79)
-- `ComplementType.toNoonan`, `Verb.frames`, `Verb.realizes` — the
+- `ComplementType.toNoonan`, `Verb.compTypes`, `Verb.realizes` — the
   selection relation
 
 ## Implementation notes
 
-[noonan-2007]'s enums (`NoonanCompType`, `CTPClass`, `RealityStatus`) live
-in `Features/Complementation.lean`; the generated CTP sample rows in
+The typed complement-frame object (`Slot`, `Frame`) and [deal-2026]'s CP
+external-shell inventory (`Slot.Shell`, `Slot.ShellInventory`, the named
+witnesses) live in `Syntax/Clause/Frame.lean`; [noonan-2007]'s enums
+(`NoonanCompType`, `CTPClass`, `RealityStatus`) in
+`Features/Complementation.lean`; the generated CTP sample rows in
 `Data/Complementation/`. Placement of individual languages in Table 79
 cells consumes Fragment data and lives in `Studies/Deal2026.lean`;
 consistency checks on the selection relation live in Studies
-(e.g. `Bondarenko2022.hanaxa_frames_realized`). Shell implicational
-generalisations ("P-shelling co-occurs with D-shelling") are proven on the
-named witnesses; the universal claims stay in Table 79 commentary.
+(e.g. `Bondarenko2022.hanaxa_frames_realized`).
 -/
 
 namespace Clause.Complementation
-
-/-! ### CP-external wrapping shells
-
-`ComplementSize` and `ClauseSpine` (Syntax/Minimalist/) record *internal*
-clause height; `CPShell` records what wraps the CP *externally*.
-[deal-2026] Table 79 cross-classifies the two axes. -/
-
-/-- A wrapping head above a CP: [deal-2026] Table 79 attests D, N, and P;
-`c` is the base case, so `bareCP = [.c]`. -/
-inductive CPShell where
-  /-- The CP itself (always present). -/
-  | c
-  /-- D shell. -/
-  | d
-  /-- N shell (between D and CP). -/
-  | n
-  /-- P shell. -/
-  | p
-  deriving DecidableEq, Repr
-
-/-- An ordered shell list, innermost first: `[.c, .d]` = D wraps CP,
-`[.c, .n, .d]` = D wraps N wraps CP. -/
-abbrev CPShellInventory := List CPShell
-
-/-- The shell inventory is a [deal-2026] Table 79 cell. -/
-def isAttestedShell : CPShellInventory → Bool
-  | [.c] => true
-  | [.c, .d] => true
-  | [.c, .n, .d] => true
-  | [.c, .d, .p] => true
-  | _ => false
-
-/-- The bare-CP cell (Nez Perce; English *think*). -/
-def bareCP : CPShellInventory := [.c]
-
-/-- The V D CP cell (Washo, [bochnak-hanink-2021]). -/
-def dCP : CPShellInventory := [.c, .d]
-
-/-- The V D N CP cell (Adyghe, [caponigro-polinsky-2011]). -/
-def dnCP : CPShellInventory := [.c, .n, .d]
-
-/-- The V P D CP cell (Bulgarian, [krapova-2010]; Ndebele,
-[pietraszko-2019]). -/
-def pdCP : CPShellInventory := [.c, .d, .p]
-
-/-- The four named witnesses are all attested. -/
-theorem named_shells_attested :
-    isAttestedShell bareCP = true ∧
-    isAttestedShell dCP = true ∧
-    isAttestedShell dnCP = true ∧
-    isAttestedShell pdCP = true :=
-  ⟨rfl, rfl, rfl, rfl⟩
-
-/-- P-shelling co-occurs with D-shelling. -/
-theorem pdCP_contains_p_and_d : CPShell.p ∈ pdCP ∧ CPShell.d ∈ pdCP := by
-  decide
-
-/-- N appears only inside a D shell. -/
-theorem dnCP_contains_n_and_d : CPShell.n ∈ dnCP ∧ CPShell.d ∈ dnCP := by
-  decide
-
-/-- Every named shell contains C. -/
-theorem named_shells_contain_c :
-    CPShell.c ∈ bareCP ∧ CPShell.c ∈ dCP ∧
-    CPShell.c ∈ dnCP ∧ CPShell.c ∈ pdCP := by
-  decide
-
-/-- `V P CP` (P with no D shell) is not a Table 79 cell. -/
-theorem pCP_not_attested : isAttestedShell [.c, .p] = false := rfl
-
-/-- `V N CP` (N with no D shell) is not a Table 79 cell. -/
-theorem nCP_not_attested : isAttestedShell [.c, .n] = false := rfl
-
-/-- The clause complex is wrapped in a nominal projection: its shell
-    contains D (Washo `dCP`, Adyghe `dnCP`, Bulgarian/Ndebele `pdCP`;
-    `bareCP` is not). On [deal-2026]'s attested cells this coincides
-    with `≠ bareCP` (`pCP`/`nCP` are unattested); D-membership is the
-    definitional content, not the complement of a special case. -/
-def hasNominalShell (inv : CPShellInventory) : Prop := CPShell.d ∈ inv
-
-instance : DecidablePred hasNominalShell :=
-  λ inv => inferInstanceAs (Decidable (CPShell.d ∈ inv))
 
 /-! ### Selection
 
@@ -131,12 +47,15 @@ def _root_.ComplementType.toNoonan : ComplementType → Option NoonanCompType
   | .np_pp => none
   | .question => some .indicative
 
-/-- A verb's complement frames: main plus alternate, when present. -/
-def _root_.Verb.frames (v : Verb) : List ComplementType :=
-  v.complementType :: v.altComplementType.toList
+/-- The legacy `ComplementType` cells of a verb's frame inventory
+    (frames richer than any cell are dropped). -/
+def _root_.Verb.compTypes (v : Verb) : List ComplementType :=
+  v.frames.filterMap Frame.toComplementType
 
-/-- `v`'s frame `f` is realized by clause-typer `c` ([noonan-2007]). -/
+/-- Some frame of `v` is realized by clause-typer `c`: a slot's
+    [noonan-2007] coding matches the typer's. The `∃ t` guard keeps
+    coding-less slots from matching type-less typers (`none`/`none`). -/
 def _root_.Verb.realizes (v : Verb) (c : Complementizer) : Prop :=
-  ∃ f ∈ v.frames, f.toNoonan = c.noonanType
+  ∃ fr ∈ v.frames, ∃ s ∈ fr, ∃ t, s.coding = some t ∧ c.noonanType = some t
 
 end Clause.Complementation

--- a/Linglib/Syntax/Clause/Frame.lean
+++ b/Linglib/Syntax/Clause/Frame.lean
@@ -1,0 +1,252 @@
+import Linglib.Features.Complementation
+import Linglib.Features.ClauseForm
+import Linglib.Features.Case.Basic
+
+/-! # Complement frames — typed slots
+
+A verb's complement frame as a list of typed `Slot`s, factoring the flat
+`ComplementType` enum cells into their axes: syntactic category, case
+marking, CP-external shell ([deal-2026]), clause form, [noonan-2007]
+coding, and embedded-subject requirement (genitive subjects of
+nominalized clauses, [bondarenko-2022]). The legacy enum survives as a
+round-trip view (`ComplementType.toFrame` / `Frame.toComplementType`).
+
+## Main declarations
+
+* `Slot.Shell`, `Slot.ShellInventory` (+ `isAttested`, `hasNominalShell`,
+  the named cells) — CP-external wrapping shells ([deal-2026] Table 79)
+* `Slot`, `Slot.WellFormed` — one complement position: category plus
+  optional clausal axes
+* `Frame` + `Frame.np`, `Frame.finiteClause`, … — a frame is a list of
+  slots; the legacy enum cells as smart constructors
+
+## Implementation notes
+
+Frame-conditioned readings (attitude, opacity, control) are not slot
+data — they live on `Verb.Reading` (`Semantics/Verb/Defs.lean`), keyed
+to the verb's frames. The [noonan-2007] selection relation between verb
+frames and clause-typers (`Verb.realizes`) lives in
+`Syntax/Clause/Complementation.lean`. This file never imports
+`Semantics/`.
+-/
+
+namespace Slot
+
+/-! ### CP-external wrapping shells
+
+`ComplementSize` and `ClauseSpine` (Syntax/Minimalist/) record *internal*
+clause height; `Slot.Shell` records what wraps the CP *externally*.
+[deal-2026] Table 79 cross-classifies the two axes. -/
+
+/-- A wrapping head above a CP: [deal-2026] Table 79 attests D, N, and P;
+`c` is the base case, so the bare-CP inventory is `[.c]`. -/
+inductive Shell where
+  /-- The CP itself (always present). -/
+  | c
+  /-- D shell. -/
+  | d
+  /-- N shell (between D and CP). -/
+  | n
+  /-- P shell. -/
+  | p
+  deriving DecidableEq, Repr
+
+/-- An ordered shell list, innermost first: `[.c, .d]` = D wraps CP,
+`[.c, .n, .d]` = D wraps N wraps CP. -/
+abbrev ShellInventory := List Shell
+
+namespace ShellInventory
+
+/-- The shell inventory is a [deal-2026] Table 79 cell. -/
+def isAttested : ShellInventory → Bool
+  | [.c] => true
+  | [.c, .d] => true
+  | [.c, .n, .d] => true
+  | [.c, .d, .p] => true
+  | _ => false
+
+/-- The bare-CP cell (Nez Perce; English *think*). -/
+def bareCP : ShellInventory := [.c]
+
+/-- The V D CP cell (Washo, [bochnak-hanink-2021]). -/
+def dCP : ShellInventory := [.c, .d]
+
+/-- The V D N CP cell (Adyghe, [caponigro-polinsky-2011]). -/
+def dnCP : ShellInventory := [.c, .n, .d]
+
+/-- The V P D CP cell (Bulgarian, [krapova-2010]; Ndebele,
+[pietraszko-2019]). -/
+def pdCP : ShellInventory := [.c, .d, .p]
+
+/-- The four named witnesses are all attested. -/
+theorem named_shells_attested :
+    isAttested bareCP = true ∧
+    isAttested dCP = true ∧
+    isAttested dnCP = true ∧
+    isAttested pdCP = true :=
+  ⟨rfl, rfl, rfl, rfl⟩
+
+/-- P-shelling co-occurs with D-shelling. -/
+theorem pdCP_contains_p_and_d : Shell.p ∈ pdCP ∧ Shell.d ∈ pdCP := by
+  decide
+
+/-- N appears only inside a D shell. -/
+theorem dnCP_contains_n_and_d : Shell.n ∈ dnCP ∧ Shell.d ∈ dnCP := by
+  decide
+
+/-- Every named shell contains C. -/
+theorem named_shells_contain_c :
+    Shell.c ∈ bareCP ∧ Shell.c ∈ dCP ∧
+    Shell.c ∈ dnCP ∧ Shell.c ∈ pdCP := by
+  decide
+
+/-- `V P CP` (P with no D shell) is not a Table 79 cell. -/
+theorem pCP_not_attested : isAttested [.c, .p] = false := rfl
+
+/-- `V N CP` (N with no D shell) is not a Table 79 cell. -/
+theorem nCP_not_attested : isAttested [.c, .n] = false := rfl
+
+/-- The clause complex is wrapped in a nominal projection: its shell
+    contains D (Washo `dCP`, Adyghe `dnCP`, Bulgarian/Ndebele `pdCP`;
+    `bareCP` is not). On [deal-2026]'s attested cells this coincides
+    with `≠ bareCP` (`pCP`/`nCP` are unattested); D-membership is the
+    definitional content, not the complement of a special case. -/
+def hasNominalShell (inv : ShellInventory) : Prop := Shell.d ∈ inv
+
+instance : DecidablePred hasNominalShell :=
+  λ inv => inferInstanceAs (Decidable (Shell.d ∈ inv))
+
+end ShellInventory
+
+/-! ### Complement-frame axes -/
+
+/-- Syntactic category of a complement slot. -/
+inductive Cat where
+  | nominal
+  | adpositional
+  | clausal
+  deriving DecidableEq, Repr
+
+/-- Embedded-subject requirement of a clausal slot: obligatorily null
+    (control/raising infinitives) or overt, optionally with a fixed
+    case (genitive subjects of nominalized clauses, [bondarenko-2022]). -/
+inductive EmbeddedSubject where
+  | obligatorilyNull
+  | overt (subjCase : Option Case)
+  deriving DecidableEq, Repr
+
+end Slot
+
+/-! ### The frame object -/
+
+/-- One complement position of a verb's frame: its category plus, for
+    clausal slots, the recorded clausal axes. On non-clausal slots the
+    clausal axes are `none` (`Slot.WellFormed`); on clausal slots `none`
+    means unrecorded. Frame-conditioned readings and control are not
+    slot data — they live on `Verb.Reading`. -/
+structure Slot where
+  cat : Slot.Cat
+  /-- Case marking on the slot (case-marked nominalized clauses, NPs). -/
+  marking : Option Case := none
+  /-- CP-external wrapping shell ([deal-2026] Table 79). -/
+  shell : Option Slot.ShellInventory := none
+  /-- Clause form (declarative vs embedded question). -/
+  clauseForm : Option Features.ClauseForm := none
+  /-- [noonan-2007] coding of the complement clause. -/
+  coding : Option NoonanCompType := none
+  /-- Embedded-subject requirement. -/
+  embeddedSubject : Option Slot.EmbeddedSubject := none
+  deriving DecidableEq, Repr
+
+/-- Clausal axes are reserved for clausal slots. -/
+def Slot.WellFormed (s : Slot) : Prop :=
+  s.cat = .clausal ∨
+    (s.shell = none ∧ s.clauseForm = none ∧ s.coding = none ∧
+      s.embeddedSubject = none)
+
+instance : DecidablePred Slot.WellFormed := fun s => by
+  unfold Slot.WellFormed; infer_instance
+
+/-- The slot is clausal. -/
+def Slot.isClausal (s : Slot) : Prop := s.cat = .clausal
+
+/-- A complement frame: the verb's selected complement positions in
+    order. Intransitive = `[]`; double object = two slots. -/
+abbrev Frame := List Slot
+
+namespace Frame
+
+/-- The [noonan-2007] codings recorded across the frame's slots. -/
+def codings (fr : Frame) : List NoonanCompType := fr.filterMap (·.coding)
+
+/-- Some slot of the frame records clause form `cf`. -/
+def hasClauseForm (fr : Frame) (cf : Features.ClauseForm) : Prop :=
+  ∃ s ∈ fr, s.clauseForm = some cf
+
+instance (fr : Frame) (cf : Features.ClauseForm) :
+    Decidable (fr.hasClauseForm cf) := by
+  unfold hasClauseForm; infer_instance
+
+/-- Some slot of the frame records [noonan-2007] coding `t`. -/
+def hasCoding (fr : Frame) (t : NoonanCompType) : Prop :=
+  ∃ s ∈ fr, s.coding = some t
+
+instance (fr : Frame) (t : NoonanCompType) : Decidable (fr.hasCoding t) := by
+  unfold hasCoding; infer_instance
+
+/-! ### Smart constructors — the legacy `ComplementType` cells -/
+
+/-- Transitive: one nominal slot. -/
+def np : Frame := [{ cat := .nominal }]
+
+/-- Double object: two nominal slots. -/
+def np_np : Frame := [{ cat := .nominal }, { cat := .nominal }]
+
+/-- NP + PP: a nominal plus an adpositional slot. -/
+def np_pp : Frame := [{ cat := .nominal }, { cat := .adpositional }]
+
+/-- Finite declarative clause. -/
+def finiteClause : Frame :=
+  [{ cat := .clausal, coding := some .indicative,
+     clauseForm := some .declarative }]
+
+/-- Infinitival clause: obligatorily null embedded subject. -/
+def infinitival : Frame :=
+  [{ cat := .clausal, coding := some .infinitive,
+     embeddedSubject := some .obligatorilyNull }]
+
+/-- Gerund / nominalized clause. -/
+def gerund : Frame := [{ cat := .clausal, coding := some .nominalized }]
+
+/-- Small clause (paratactic coding). -/
+def smallClause : Frame := [{ cat := .clausal, coding := some .paratactic }]
+
+/-- Embedded question. -/
+def question : Frame :=
+  [{ cat := .clausal, clauseForm := some .embeddedQuestion }]
+
+end Frame
+
+/-! ### The legacy enum view -/
+
+/-- The `Frame` cell of a legacy `ComplementType` (`.none` ↦ `[]`). -/
+def ComplementType.toFrame : ComplementType → Frame
+  | .none => []
+  | .np => Frame.np
+  | .np_np => Frame.np_np
+  | .np_pp => Frame.np_pp
+  | .finiteClause => Frame.finiteClause
+  | .infinitival => Frame.infinitival
+  | .gerund => Frame.gerund
+  | .smallClause => Frame.smallClause
+  | .question => Frame.question
+
+/-- Partial inverse of `ComplementType.toFrame`: the legacy enum cell a
+    frame instantiates, `none` on frames richer than any cell. -/
+def Frame.toComplementType (fr : Frame) : Option ComplementType :=
+  [ComplementType.none, .np, .np_np, .np_pp, .finiteClause, .infinitival,
+    .gerund, .smallClause, .question].find? (·.toFrame == fr)
+
+/-- The enum view round-trips over the smart-constructor cells. -/
+theorem toComplementType_toFrame (ct : ComplementType) :
+    ct.toFrame.toComplementType = some ct := by cases ct <;> rfl


### PR DESCRIPTION
Roadmap D of the complementizer arc, on the settled seventh-consult design plus the session's home/naming decisions.

- New `Syntax/Clause/Frame.lean`: canonical theory-neutral `Slot` (cat discriminator + Option axes: marking, shell, clauseForm, Noonan coding, embedded subject; decidable `WellFormed`) and `Frame := List Slot` (valence structural: intransitive = `[]`, np_np = two slots); 8 smart-constructor cells mirroring the legacy enum; query API; `ComplementType` demoted to a view with a round-trip lemma. Shell block relocated here with owner-relative renames (`CPShell` → `Slot.Shell`, inventory + vocabulary under `Slot.ShellInventory`).
- `Verb.ArgStructure.frames : List Frame` replaces the four flat fields (derived accessors keep all readers compiling — 3 of ~74 sites needed reproofs); `Verb.Reading` rows carry frame-conditioned attitude/opacity/control; 469 fragment entries migrated by checked-in scripts (`scratch/migrate_verb_frames*.py`).
- `realizes` rebased to the coding axis (∃-guard against none=none false matches); `NoonanCompType` gains `rank` + `LinearOrder` (the ICH coding order).
- Acceptance: `hanaxa_frame_conditioned_attitude` — the think~remember attitude flip as a decidable fact, previously unstateable; Buryat's nominalized frame records its genitive embedded subject.

Full `lake build Linglib` green pre-rebase (6611 jobs); post-rebase cone re-verified.