### PR TITLE
refactor(Semantics/ArgumentStructure): root ns + Grimm Stage 1 inversion

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -25,7 +25,7 @@ open Semantics.Lexical
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Core.Order (Boundedness)
 open Semantics.Aspect.Incremental (VerbIncClass)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § English Morphophonological Rules

--- a/Linglib/Fragments/French/Predicates.lean
+++ b/Linglib/Fragments/French/Predicates.lean
@@ -18,8 +18,9 @@ namespace French.Predicates
 
 open Semantics.Lexical
 open Features (Causative)
-open Semantics.ArgumentStructure.EntailmentProfile
-  (EntailmentProfile kickSubjectProfile seeSubjectProfile runSubjectProfile)
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
+  (kickSubjectProfile seeSubjectProfile runSubjectProfile)
 
 /-- French verb entry: extends Verb with French inflectional paradigm. -/
 structure FrenchVerbEntry extends Verb where

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -30,7 +30,7 @@ namespace Spanish.Predicates
 
 open Minimalist
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 
 -- ============================================================================
 -- § 1: Anticausative Marking

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -65,7 +65,8 @@ you nothing about whether it entails change, and vice versa.
 -/
 
 open Semantics.Lexical.EventStructure
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Features.ChangeOfState
 open Features
 

--- a/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness/Profile.lean
@@ -71,7 +71,8 @@ composed meaning — not the root-level or surface-diagnostic level.
 
 namespace Semantics.ArgumentStructure.Affectedness.Profile
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § 1. Re-exports from Events/AffectednessHierarchy

--- a/Linglib/Semantics/ArgumentStructure/AgentivityLattice.lean
+++ b/Linglib/Semantics/ArgumentStructure/AgentivityLattice.lean
@@ -49,7 +49,8 @@ All ordering infrastructure uses Mathlib typeclasses:
 
 namespace Semantics.ArgumentStructure.AgentivityLattice
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 open Core
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -51,7 +51,8 @@ open Verb
 open Semantics.Lexical
 open Semantics.Lexical.EventStructure (Template)
 open Features.LevinClassProfiles
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 open Root.Kinds
 
 -- ════════════════════════════════════════════════════
@@ -300,7 +301,7 @@ def deriveEnriched (re : Root.Kinds) (mc : MeaningComponents) : Option ArgTempla
     | .activity =>
       if mc.contact then
         -- Transitive activity: subject gets C from causal interaction
-        some { subjectProfile := Semantics.ArgumentStructure.EntailmentProfile.accomplishmentSubjectProfile,
+        some { subjectProfile := ArgumentStructure.EntailmentProfile.accomplishmentSubjectProfile,
                objectProfile := some ⟨false, false, false, false, false, false, false, true, true, false⟩ }
       else
         some base

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -37,7 +37,7 @@ Causation priority ([davis-koenig-2000]) needs no extra clause: it falls out
 of feature-set inclusion.
 -/
 
-namespace Semantics.ArgumentStructure.EntailmentProfile
+namespace ArgumentStructure
 
 /-- The ten entailments defining the proto-roles ([dowty-1991] pp.572–573):
 the first five are Proto-Agent, the last five Proto-Patient. Fields default
@@ -65,18 +65,20 @@ structure EntailmentProfile where
   dependentExistence : Bool := false
   deriving DecidableEq, Repr
 
+namespace EntailmentProfile
+
 variable (p q subj obj : EntailmentProfile)
 
 /-! ### Feature counting -/
 
 /-- Number of Proto-Agent entailments. Informational: the Argument Selection
 Principle uses lattice comparison ([grimm-2011]), not counting. -/
-def EntailmentProfile.pAgentScore : Nat :=
+def pAgentScore : Nat :=
   p.volition.toNat + p.sentience.toNat + p.causation.toNat +
   p.movement.toNat + p.independentExistence.toNat
 
 /-- Number of Proto-Patient entailments. -/
-def EntailmentProfile.pPatientScore : Nat :=
+def pPatientScore : Nat :=
   p.changeOfState.toNat + p.incrementalTheme.toNat +
   p.causallyAffected.toNat + p.stationary.toNat +
   p.dependentExistence.toNat
@@ -174,11 +176,11 @@ instance : DecidablePred PredictsUnergative := λ p => by
 
 /-- Volition presupposes sentience: only sentient entities can act
 volitionally ([dowty-1991] p.607, [levin-2019] §2.1). -/
-def EntailmentProfile.WellFormedInternal : Prop :=
+def WellFormedInternal : Prop :=
   p.volition = true → p.sentience = true
 
-instance : DecidablePred EntailmentProfile.WellFormedInternal := λ p => by
-  unfold EntailmentProfile.WellFormedInternal; infer_instance
+instance : DecidablePred WellFormedInternal := λ p => by
+  unfold WellFormedInternal; infer_instance
 
 /-- Three Proto-Agent entailments pair asymmetrically across a
 subject–object pair ([davis-koenig-2000], [primus-1999]): causation →
@@ -222,7 +224,7 @@ instance : DecidablePred IsForceRecipient := λ p => by
 /-- An effector carries at least two Proto-Agent entailments. -/
 theorem two_le_pAgentScore_of_isEffector (h : IsEffector p) :
     2 ≤ p.pAgentScore := by
-  simp [EntailmentProfile.pAgentScore, h.1, h.2]
+  simp [pAgentScore, h.1, h.2]
 
 /-! ### Canonical verb profiles
 
@@ -327,4 +329,6 @@ measure the event. -/
 def accomplishmentObjectProfile : EntailmentProfile :=
   { changeOfState := true, causallyAffected := true }
 
-end Semantics.ArgumentStructure.EntailmentProfile
+end EntailmentProfile
+
+end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -62,7 +62,8 @@ Accounts expressible via this interface (non-exhaustive):
 
 -/
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 1. Theta Role Labels (derived convenience names)
@@ -92,7 +93,7 @@ inductive ThetaRole where
 -- § 2. EntailmentProfile → ThetaRole (canonical direction)
 -- ════════════════════════════════════════════════════════════════════════
 
-namespace Semantics.ArgumentStructure.EntailmentProfile
+namespace ArgumentStructure.EntailmentProfile
 
 /-- Derive a convenience theta-role label from an entailment profile.
 
@@ -112,7 +113,7 @@ namespace Semantics.ArgumentStructure.EntailmentProfile
     ({causation, IE}), as do goal and source ({IE}). The function
     defaults to stimulus and goal respectively. Disambiguation requires
     external context (e.g., `Verb.causalSource`). -/
-def EntailmentProfile.toRole (p : EntailmentProfile) : Option ThetaRole :=
+def toRole (p : EntailmentProfile) : Option ThetaRole :=
   if p.volition then some .agent
   else if p.sentience && !p.causation then some .experiencer
   else if p.causation && !p.sentience then some .stimulus
@@ -128,7 +129,7 @@ def EntailmentProfile.toRole (p : EntailmentProfile) : Option ThetaRole :=
     else none
   else none
 
-end Semantics.ArgumentStructure.EntailmentProfile
+end ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 3. ThetaRole → Canonical Profile (inverse direction)

--- a/Linglib/Semantics/Lexical/EventStructure.lean
+++ b/Linglib/Semantics/Lexical/EventStructure.lean
@@ -28,7 +28,8 @@ enriched two-predicate event structure for the wiping-verbs class
 namespace Semantics.Lexical.EventStructure
 
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 open Features
 
 /-! ### Event structure templates -/

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -31,7 +31,8 @@ Individual verbs can override class-level profiles via explicit
 namespace Features.LevinClassProfiles
 
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § 1. Argument Structure Templates
@@ -121,7 +122,8 @@ end Features.LevinClassProfiles
 
 namespace Semantics.Lexical
 open Features.LevinClassProfiles
-open Semantics.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure (EntailmentProfile)
+open _root_.ArgumentStructure.EntailmentProfile
 
 /-- Map a Levin class to its argument structure template.
     Returns `none` for classes whose profiles haven't been determined yet. -/
@@ -176,7 +178,7 @@ end Semantics.Lexical
 
 namespace Features.LevinClassProfiles
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Verb
 open Verb.Root.Kinds
 

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -15,7 +15,7 @@ open Semantics.Lexical
 open Features.ChangeOfState
 open NaturalLogic (EntailmentSig)
 open Causation.Psych (CausalSource)
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)
 open Features.LevinClassProfiles

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -48,7 +48,7 @@ open Semantics.Lexical
 open Features.ChangeOfState
 open NaturalLogic (EntailmentSig)
 open Causation.Psych (CausalSource)
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Semantics.Aspect.Incremental (VerbIncClass)
 open Features.LevinClassProfiles

--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -44,7 +44,7 @@ participant roles.
 -/
 
 open Semantics.ArgumentStructure
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 
 /-! ### The theta-grid (derived from the proto-role profiles) -/
 

--- a/Linglib/Semantics/Verb/Root/Basic.lean
+++ b/Linglib/Semantics/Verb/Root/Basic.lean
@@ -36,7 +36,7 @@ namespace Verb
     Participant/proto-role entailments (volition, sentience, movement,
     affectedness, …) are deliberately *not* modeled here: they are an
     orthogonal, linking-relevant layer carried by
-    `Semantics.ArgumentStructure.EntailmentProfile`. -/
+    `ArgumentStructure.EntailmentProfile`. -/
 inductive LexEntailment where
   /-- Attributes a static property (state-kind atom). -/
   | hasState     (label : String)

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -61,7 +61,7 @@ two-feature simplification).
 namespace AndersonJM2006
 
 open Semantics.ArgumentStructure.Linking (LinkingTheory ArgPosition)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ============================================================================
@@ -224,7 +224,7 @@ theorem Case.acc_abs_same_relation :
 namespace AndersonJM2006
 
 open Semantics.ArgumentStructure.Linking (LinkingTheory ArgPosition)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ============================================================================

--- a/Linglib/Studies/Beavers2010.lean
+++ b/Linglib/Studies/Beavers2010.lean
@@ -35,7 +35,7 @@ through the MAP.
 
 namespace Beavers2010
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Semantics.ArgumentStructure.AgentivityLattice
 open Semantics.ArgumentStructure.Affectedness.Profile (AffectednessDegree profileToDegree)
 open Semantics.Lexical (DiathesisAlternation)

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -54,7 +54,7 @@ namespace Bhadra2024
 open Semantics.Lexical
 open Semantics.Lexical.EventStructure
 open Semantics.ArgumentStructure (EventRel)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Semantics.ArgumentStructure.Affectedness.Profile
 
 /-! ### The compositional verb root (eqs. 53–60)

--- a/Linglib/Studies/Dowty1991.lean
+++ b/Linglib/Studies/Dowty1991.lean
@@ -29,7 +29,8 @@ succeed and where they diverge from the modern approach.
 namespace Dowty1991
 
 open Semantics.Lexical
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -37,7 +37,8 @@ object marking profiles in `Studies/Aissen2003.lean`.
 namespace Grimm2011
 
 open Semantics.ArgumentStructure.AgentivityLattice
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Features.Prominence
 open Aissen2003
 

--- a/Linglib/Studies/Kim2024_UPH.lean
+++ b/Linglib/Studies/Kim2024_UPH.lean
@@ -57,7 +57,7 @@ open English.Predicates.Verbal
 open Pesetsky1995.PsychVerbs
 open SolstadBott2022
   (stimExpSubjectProfile stimExpObjectProfile expStimSubjectProfile)
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 
 -- ════════════════════════════════════════════════════
 -- § 1. Consistency Predicates

--- a/Linglib/Studies/KoontzGarboden2009.lean
+++ b/Linglib/Studies/KoontzGarboden2009.lean
@@ -233,7 +233,8 @@ def reflexivizationYieldsAnticausative : CauserSpec → Bool
     would carry more structure than K-G's underspecification account
     predicts. -/
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 
 /-- Derive `CauserSpec` from a proto-role entailment profile.
     Volition is the discriminating feature:

--- a/Linglib/Studies/MartinSchaeferKastner2025.lean
+++ b/Linglib/Studies/MartinSchaeferKastner2025.lean
@@ -64,7 +64,8 @@ syncretism creates voice ambiguity that speakers must manage.
 namespace MartinSchaeferKastner2025
 
 open Minimalist (VoiceFlavor)
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile PredictsUnaccusative)
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile (PredictsUnaccusative)
 open Pragmatics.GriceanMaxims (MannerSubmaxim)
 open French.Predicates
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -1101,7 +1101,7 @@ when both arguments bind the same variable — a thematic-uniqueness
 contradiction.
 
 **Status of this formalization**: The composition predicate below uses
-`Semantics.ArgumentStructure.EntailmentProfile.pPatientScore` to check whether a verb
+`ArgumentStructure.EntailmentProfile.pPatientScore` to check whether a verb
 has theme-like Proto-Patient entailments. An unergative has either no
 object profile (`objectEntailments = none`) or an empty one
 (`pPatientScore = 0`). This `EntailmentProfile`-based predicate is the
@@ -1110,7 +1110,7 @@ clash is now wired in via `Semantics/ArgumentStructure/ArgumentIntroduction.lean
 and consumed in §15c below (`low_appl_blocks_unergative_denotational`,
 `low_external_arg_clash`). -/
 
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 
 /-- A verb has an unsaturated theme argument iff its object entailment
     profile (if any) carries Proto-Patient entailments. Unergatives have
@@ -1175,7 +1175,7 @@ def themeBearingProfile : EntailmentProfile :=
 
 theorem themeBearingProfile_has_unsaturated_theme :
     hasUnsaturatedTheme (some themeBearingProfile) := by
-  unfold hasUnsaturatedTheme themeBearingProfile EntailmentProfile.pPatientScore
+  unfold hasUnsaturatedTheme themeBearingProfile ArgumentStructure.EntailmentProfile.pPatientScore
   decide
 
 /-- Low recipient applicatives can combine with verbs providing a

--- a/Linglib/Studies/RappaportHovavLevin2024.lean
+++ b/Linglib/Studies/RappaportHovavLevin2024.lean
@@ -90,7 +90,7 @@ verbs ([levin-krejci-2019]), and *drown*.
 namespace RappaportHovavLevin2024
 
 open Semantics.Lexical.EventStructure
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure.EntailmentProfile
 open Semantics.Lexical
 
 /-! ### Force-dynamic primitives -/

--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -39,7 +39,7 @@ embedding.
 namespace Siloni2012
 
 open Reciprocal
-open Semantics.ArgumentStructure.EntailmentProfile (EntailmentProfile)
+open ArgumentStructure (EntailmentProfile)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Three-Way Reciprocal Classification (§2.4)

--- a/Linglib/Studies/SolstadBott2022.lean
+++ b/Linglib/Studies/SolstadBott2022.lean
@@ -58,7 +58,8 @@ of grammatical position.
 
 namespace SolstadBott2022
 
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Discourse.Coherence
 open English.Predicates.Verbal
 

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -58,7 +58,8 @@ open Intensional (WorldTimeIndex)
 
 open Semantics.Presupposition
 open French.Predicates
-open Semantics.ArgumentStructure.EntailmentProfile
+open ArgumentStructure (EntailmentProfile)
+open ArgumentStructure.EntailmentProfile
 open Semantics.ArgumentStructure.Affectedness.Profile
 open Features
 open Semantics.Lexical
@@ -441,7 +442,7 @@ theorem active_implies_pAgent_ge_1 (p : EntailmentProfile)
     p.pAgentScore ≥ 1 := by
   obtain ⟨v, s, c, m, ie, cos, it, ca, st, de⟩ := p
   simp only [hasActiveAgentEntailment] at h
-  simp only [EntailmentProfile.pAgentScore]
+  simp only [pAgentScore]
   cases v <;> cases c <;> cases m <;> simp_all (config := { decide := false }) <;> omega
 
 /-- Converse fails: experiencer profiles have pAgentScore ≥ 1 but no


### PR DESCRIPTION
The ArgumentStructure re-foundation, staged on #1072:

- **Namespace**: `EntailmentProfile` doubling fixed and the whole directory flattened to root `ArgumentStructure` — the shared cross-domain home (Dowty entailments, linking, HPSG ARG-ST, CxG all address it); collision-checked; consumers retargeted repo-wide.
- **Grimm Stage 1 (import inversion, no storage change)**: `AgentivityLattice.lean` dissolved into `Agentivity/Defs.lean` (pure order objects, Mathlib-only imports) + `Agentivity/CaseRegions.lean`; `EntailmentProfile` now imports the lattice rather than vice versa. New theorems make the structure primary: `featureCount_monotone` + `pAgentScore` decomposition (the Dowty count = monotone lattice rank + IE bit), the dominance↔order-image iff, and `kiss_subject_dominates` in Studies/Dowty1991 with the original flat-count comparison derived as a corollary — counting demoted to monotonicity.
- Docstrings corrected per the design consult: the 16/80-element carriers are implementation supersets of Grimm's 12-node (Fig. 1) / 38-node (Fig. 3) lattices, carved by the Valid predicates.

Cone-verified locally (Agentivity both, EntailmentProfile, Dowty1991/Grimm2011/Beavers2010, Verb.Basic, English Verbal fragment — 2563 jobs green); CI gates the full build. Stage 2 (storage flip onto the lattice, with the audited canonical-profile bit-flips) is separately gated.