### PR TITLE
style(Phonology/Tone): utp lemma family into the utp namespace

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -212,6 +212,130 @@ theorem isBimachineComputable {L R : Type*} [Fintype L] [Fintype R] {α β : Typ
   ⟨Fin (Fintype.card L), Fin (Fintype.card R), inferInstance, inferInstance,
     B.transferEquiv (Fintype.equivFin L) (Fintype.equivFin R), B.transferEquiv_run _ _⟩
 
+section TwoSidedWitness
+
+variable {α : Type*}
+
+/-! ### The flank-witness template
+
+The recurring witness family for two-sided unboundedness: a target buried in a filler
+run, with independently editable flanks. `RequiresBothSides.of_flanks` packages the
+whole assembly — a map is excluded by exhibiting only the images of the base and the
+two single-flank perturbations at the target. This is the three-map method of
+[yolyan-2025] §5.3, as an object. -/
+
+/-- A flank-controlled word: `x`, then `n` copies of `fill`, then `y`. -/
+def flankWord (x fill y : α) (n : ℕ) : List α := x :: (List.replicate n fill ++ [y])
+
+@[simp] theorem flankWord_length {x fill y : α} {n : ℕ} :
+    (flankWord x fill y n).length = n + 2 := by
+  simp [flankWord]
+
+theorem flankWord_getElem? {x fill y : α} {n k : ℕ} :
+    (flankWord x fill y n)[k]? = if k = 0 then some x else if k = n + 1 then some y
+      else if k < n + 2 then some fill else none := by
+  simp only [flankWord, List.getElem?_cons, List.getElem?_append, List.getElem?_replicate,
+    List.length_replicate, List.getElem?_nil]
+  split_ifs <;> first | rfl | omega
+
+@[simp] theorem flankWord_getElem?_zero {x fill y : α} {n : ℕ} :
+    (flankWord x fill y n)[0]? = some x := rfl
+
+@[simp] theorem flankWord_getElem?_last {x fill y : α} {n : ℕ} :
+    (flankWord x fill y n)[n + 1]? = some y := by
+  rw [flankWord_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+theorem flankWord_getElem?_mid {x fill y : α} {n k : ℕ} (h₁ : 0 < k) (h₂ : k ≤ n) :
+    (flankWord x fill y n)[k]? = some fill := by
+  rw [flankWord_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+/-- A window reaching at most the filler run hits `a` iff the left flank is `a`. -/
+theorem exists_le_flankWord_eq_some_iff {x fill y a : α} {n k : ℕ} (hfill : fill ≠ a)
+    (hk : k ≤ n) : (∃ j ≤ k, (flankWord x fill y n)[j]? = some a) ↔ x = a := by
+  constructor
+  · rintro ⟨j, hj, hja⟩
+    rw [flankWord_getElem?] at hja
+    split_ifs at hja
+    · exact Option.some.inj hja
+    · exact absurd hj (by omega)
+    · exact absurd (Option.some.inj hja) hfill
+  · exact fun h => ⟨0, by omega, h ▸ flankWord_getElem?_zero⟩
+
+/-- A window past the left flank hits `a` iff the right flank is `a`. -/
+theorem exists_ge_flankWord_eq_some_iff {x fill y a : α} {n k : ℕ} (hfill : fill ≠ a)
+    (h0 : 0 < k) (hk : k ≤ n + 1) :
+    (∃ j ≥ k, (flankWord x fill y n)[j]? = some a) ↔ y = a := by
+  constructor
+  · rintro ⟨j, hj, hja⟩
+    rw [flankWord_getElem?] at hja
+    split_ifs at hja
+    · exact absurd hj (by omega)
+    · exact Option.some.inj hja
+    · exact absurd (Option.some.inj hja) hfill
+  · exact fun h => ⟨n + 1, by omega, h ▸ flankWord_getElem?_last⟩
+
+/-- Flank words differing only on the left agree off position `0`. -/
+theorem flankWord_congr_left {x x' fill y : α} {n k : ℕ} (h : k ≠ 0) :
+    (flankWord x fill y n)[k]? = (flankWord x' fill y n)[k]? := by
+  rw [flankWord_getElem?, flankWord_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+/-- Flank words differing only on the right agree off the last position. -/
+theorem flankWord_congr_right {x fill y y' : α} {n k : ℕ} (h : k ≠ n + 1) :
+    (flankWord x fill y n)[k]? = (flankWord x fill y' n)[k]? := by
+  rw [flankWord_getElem?, flankWord_getElem?]
+  split_ifs <;> rfl
+
+/-- `f` requires both sides: some target changes under `f`, yet perturbing either far
+side reverts it to the identity. Unlike `IsUnboundedCircumambient`, a two-sided union
+never satisfies this — removing one trigger leaves the other, so the output stays
+changed. -/
+def RequiresBothSides (f : List α → List α) : Prop :=
+  ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧ (f base)[i]? ≠ base[i]? ∧
+    (∃ uL : List α, uL.length = base.length ∧ AgreeFrom base uL (i - d) ∧
+      uL[i]? = base[i]? ∧ (f uL)[i]? = uL[i]?) ∧
+    (∃ uR : List α, uR.length = base.length ∧ AgreeUpto base uR (i + d) ∧
+      uR[i]? = base[i]? ∧ (f uR)[i]? = uR[i]?)
+
+/-- **The three-map template**: a `d`-indexed family of flank words whose target sits
+`d`-far from both flanks, changed to `on` in the base and reverted by flipping either
+flank alone, requires both sides. -/
+theorem RequiresBothSides.of_flanks {f : List α → List α}
+    {fill on xOn yOn xOff yOff : α} {n t : ℕ → ℕ} (hne : on ≠ fill)
+    (hmargin : ∀ d, d < t d ∧ t d + d < n d + 1)
+    (hchange : ∀ d, (f (flankWord xOn fill yOn (n d)))[t d]? = some on)
+    (hrevL : ∀ d, (f (flankWord xOff fill yOn (n d)))[t d]? = some fill)
+    (hrevR : ∀ d, (f (flankWord xOn fill yOff (n d)))[t d]? = some fill) :
+    RequiresBothSides f := by
+  intro d
+  obtain ⟨hm₁, hm₂⟩ := hmargin d
+  have hmid : ∀ x y : α, (flankWord x fill y (n d))[t d]? = some fill := fun x y =>
+    flankWord_getElem?_mid (by omega) (by omega)
+  refine ⟨flankWord xOn fill yOn (n d), t d, by rw [flankWord_length]; omega,
+    by rw [hchange, hmid]; simpa using hne, ?_, ?_⟩
+  · exact ⟨flankWord xOff fill yOn (n d), by simp,
+      fun k hk => flankWord_congr_left (by omega), by rw [hmid, hmid],
+      by rw [hrevL, hmid]⟩
+  · exact ⟨flankWord xOn fill yOff (n d), by simp,
+      fun k hk => flankWord_congr_right (by omega), by rw [hmid, hmid],
+      by rw [hrevR, hmid]⟩
+
+/-- Requiring both sides strengthens unbounded circumambience: a reverted target is in
+particular a flipped one. The converse fails (a two-sided union is circumambient but
+reverts under neither side alone). -/
+theorem RequiresBothSides.isUnboundedCircumambient {f : List α → List α}
+    (hf : RequiresBothSides f) : IsUnboundedCircumambient f := by
+  intro d
+  obtain ⟨base, i, hi, hchange, ⟨uL, hLlen, hLag, hLsym, hLrev⟩,
+    ⟨uR, hRlen, hRag, hRsym, hRrev⟩⟩ := hf d
+  exact ⟨base, i, hi,
+    ⟨uL, hLlen, hLag, fun h => hchange (h.trans (hLrev.trans hLsym))⟩,
+    ⟨uR, hRlen, hRag, fun h => hchange (h.trans (hRrev.trans hRsym))⟩⟩
+
+end TwoSidedWitness
+
 section NonInteraction
 
 variable {L R α : Type*} [DecidableEq α]
@@ -252,138 +376,6 @@ theorem isBimachineWeaklyDeterministic {L R : Type*} [Fintype L] [Fintype R]
   intro l a r
   show B.out _ a _ = _
   rw [hω]
-
-/-! ### The flank-witness template
-
-The recurring witness family for two-sided unboundedness: a target buried in a filler
-run, with independently editable flanks. `RequiresBothSides.of_flanks` packages the
-whole assembly — a map is excluded by exhibiting only the images of the base and the
-two single-flank perturbations at the target. This is the three-map method of
-[yolyan-2025] §5.3, as an object. -/
-
-/-- A flank-controlled word: `x`, then `n` copies of `fill`, then `y`. -/
-def flankWord (x fill y : α) (n : ℕ) : List α := x :: (List.replicate n fill ++ [y])
-
-omit [DecidableEq α] in
-@[simp] theorem flankWord_length {x fill y : α} {n : ℕ} :
-    (flankWord x fill y n).length = n + 2 := by
-  simp [flankWord]
-
-omit [DecidableEq α] in
-theorem flankWord_getElem? {x fill y : α} {n k : ℕ} :
-    (flankWord x fill y n)[k]? = if k = 0 then some x else if k = n + 1 then some y
-      else if k < n + 2 then some fill else none := by
-  rcases k with _ | k
-  · rfl
-  · simp only [flankWord, List.getElem?_cons_succ, List.getElem?_append,
-      List.getElem?_replicate, List.length_replicate, List.getElem?_cons,
-      List.getElem?_nil]
-    split_ifs <;> first | rfl | exact ‹False›.elim | omega
-
-omit [DecidableEq α] in
-@[simp] theorem flankWord_getElem?_zero {x fill y : α} {n : ℕ} :
-    (flankWord x fill y n)[0]? = some x := rfl
-
-omit [DecidableEq α] in
-@[simp] theorem flankWord_getElem?_last {x fill y : α} {n : ℕ} :
-    (flankWord x fill y n)[n + 1]? = some y := by
-  rw [flankWord_getElem?]
-  split_ifs <;> first | rfl | exact ‹False›.elim | omega
-
-omit [DecidableEq α] in
-theorem flankWord_getElem?_mid {x fill y : α} {n k : ℕ} (h₁ : 0 < k) (h₂ : k ≤ n) :
-    (flankWord x fill y n)[k]? = some fill := by
-  rw [flankWord_getElem?]
-  split_ifs <;> first | rfl | exact ‹False›.elim | omega
-
-omit [DecidableEq α] in
-/-- A window reaching at most the filler run hits `a` iff the left flank is `a`. -/
-theorem exists_le_flankWord_eq_some_iff {x fill y a : α} {n k : ℕ} (hfill : fill ≠ a)
-    (hk : k ≤ n) : (∃ j ≤ k, (flankWord x fill y n)[j]? = some a) ↔ x = a := by
-  constructor
-  · rintro ⟨j, hj, hja⟩
-    rw [flankWord_getElem?] at hja
-    split_ifs at hja
-    · exact Option.some.inj hja
-    · exact absurd hj (by omega)
-    · exact absurd (Option.some.inj hja) hfill
-  · exact fun h => ⟨0, by omega, h ▸ flankWord_getElem?_zero⟩
-
-omit [DecidableEq α] in
-/-- A window past the left flank hits `a` iff the right flank is `a`. -/
-theorem exists_ge_flankWord_eq_some_iff {x fill y a : α} {n k : ℕ} (hfill : fill ≠ a)
-    (h0 : 0 < k) (hk : k ≤ n + 1) :
-    (∃ j ≥ k, (flankWord x fill y n)[j]? = some a) ↔ y = a := by
-  constructor
-  · rintro ⟨j, hj, hja⟩
-    rw [flankWord_getElem?] at hja
-    split_ifs at hja
-    · exact absurd hj (by omega)
-    · exact Option.some.inj hja
-    · exact absurd (Option.some.inj hja) hfill
-  · exact fun h => ⟨n + 1, by omega, h ▸ flankWord_getElem?_last⟩
-
-omit [DecidableEq α] in
-/-- Flank words differing only on the left agree off position `0`. -/
-theorem flankWord_congr_left {x x' fill y : α} {n k : ℕ} (h : k ≠ 0) :
-    (flankWord x fill y n)[k]? = (flankWord x' fill y n)[k]? := by
-  rw [flankWord_getElem?, flankWord_getElem?]
-  split_ifs <;> first | rfl | exact ‹False›.elim | omega
-
-omit [DecidableEq α] in
-/-- Flank words differing only on the right agree off the last position. -/
-theorem flankWord_congr_right {x fill y y' : α} {n k : ℕ} (h : k ≠ n + 1) :
-    (flankWord x fill y n)[k]? = (flankWord x fill y' n)[k]? := by
-  rw [flankWord_getElem?, flankWord_getElem?]
-  split_ifs <;> rfl
-
-/-- `f` requires both sides: some target changes under `f`, yet perturbing either far
-side reverts it to the identity. Unlike `IsUnboundedCircumambient`, a two-sided union
-never satisfies this — removing one trigger leaves the other, so the output stays
-changed. -/
-def RequiresBothSides (f : List α → List α) : Prop :=
-  ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧ (f base)[i]? ≠ base[i]? ∧
-    (∃ uL : List α, uL.length = base.length ∧ AgreeFrom base uL (i - d) ∧
-      uL[i]? = base[i]? ∧ (f uL)[i]? = uL[i]?) ∧
-    (∃ uR : List α, uR.length = base.length ∧ AgreeUpto base uR (i + d) ∧
-      uR[i]? = base[i]? ∧ (f uR)[i]? = uR[i]?)
-
-omit [DecidableEq α] in
-/-- **The three-map template**: a `d`-indexed family of flank words whose target sits
-`d`-far from both flanks, changed to `on` in the base and reverted by flipping either
-flank alone, requires both sides. -/
-theorem RequiresBothSides.of_flanks {f : List α → List α}
-    {fill on xOn yOn xOff yOff : α} {n t : ℕ → ℕ} (hne : on ≠ fill)
-    (hmargin : ∀ d, d < t d ∧ t d + d < n d + 1)
-    (hchange : ∀ d, (f (flankWord xOn fill yOn (n d)))[t d]? = some on)
-    (hrevL : ∀ d, (f (flankWord xOff fill yOn (n d)))[t d]? = some fill)
-    (hrevR : ∀ d, (f (flankWord xOn fill yOff (n d)))[t d]? = some fill) :
-    RequiresBothSides f := by
-  intro d
-  obtain ⟨hm₁, hm₂⟩ := hmargin d
-  have hmid : ∀ x y : α, (flankWord x fill y (n d))[t d]? = some fill := fun x y =>
-    flankWord_getElem?_mid (by omega) (by omega)
-  refine ⟨flankWord xOn fill yOn (n d), t d, by rw [flankWord_length]; omega,
-    by rw [hchange, hmid]; simpa using hne, ?_, ?_⟩
-  · exact ⟨flankWord xOff fill yOn (n d), by simp,
-      fun k hk => flankWord_congr_left (by omega), by rw [hmid, hmid],
-      by rw [hrevL, hmid]⟩
-  · exact ⟨flankWord xOn fill yOff (n d), by simp,
-      fun k hk => flankWord_congr_right (by omega), by rw [hmid, hmid],
-      by rw [hrevR, hmid]⟩
-
-omit [DecidableEq α] in
-/-- Requiring both sides strengthens unbounded circumambience: a reverted target is in
-particular a flipped one. The converse fails (a two-sided union is circumambient but
-reverts under neither side alone). -/
-theorem RequiresBothSides.isUnboundedCircumambient {f : List α → List α}
-    (hf : RequiresBothSides f) : IsUnboundedCircumambient f := by
-  intro d
-  obtain ⟨base, i, hi, hchange, ⟨uL, hLlen, hLag, hLsym, hLrev⟩,
-    ⟨uR, hRlen, hRag, hRsym, hRrev⟩⟩ := hf d
-  exact ⟨base, i, hi,
-    ⟨uL, hLlen, hLag, fun h => hchange (h.trans (hLrev.trans hLsym))⟩,
-    ⟨uR, hRlen, hRag, fun h => hchange (h.trans (hRrev.trans hRsym))⟩⟩
 
 /-- **Unbounded interaction ⟹ not weakly deterministic.** At the witness, the base changes
 but each far perturbation reverts: the right perturbation keeps the left state, forcing `ωL`

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -297,6 +297,33 @@ theorem flankWord_getElem?_mid {x fill y : α} {n k : ℕ} (h₁ : 0 < k) (h₂ 
   split_ifs <;> first | rfl | exact ‹False›.elim | omega
 
 omit [DecidableEq α] in
+/-- A window reaching at most the filler run hits `a` iff the left flank is `a`. -/
+theorem exists_le_flankWord_eq_some_iff {x fill y a : α} {n k : ℕ} (hfill : fill ≠ a)
+    (hk : k ≤ n) : (∃ j ≤ k, (flankWord x fill y n)[j]? = some a) ↔ x = a := by
+  constructor
+  · rintro ⟨j, hj, hja⟩
+    rw [flankWord_getElem?] at hja
+    split_ifs at hja
+    · exact Option.some.inj hja
+    · exact absurd hj (by omega)
+    · exact absurd (Option.some.inj hja) hfill
+  · exact fun h => ⟨0, by omega, h ▸ flankWord_getElem?_zero⟩
+
+omit [DecidableEq α] in
+/-- A window past the left flank hits `a` iff the right flank is `a`. -/
+theorem exists_ge_flankWord_eq_some_iff {x fill y a : α} {n k : ℕ} (hfill : fill ≠ a)
+    (h0 : 0 < k) (hk : k ≤ n + 1) :
+    (∃ j ≥ k, (flankWord x fill y n)[j]? = some a) ↔ y = a := by
+  constructor
+  · rintro ⟨j, hj, hja⟩
+    rw [flankWord_getElem?] at hja
+    split_ifs at hja
+    · exact absurd hj (by omega)
+    · exact Option.some.inj hja
+    · exact absurd (Option.some.inj hja) hfill
+  · exact fun h => ⟨n + 1, by omega, h ▸ flankWord_getElem?_last⟩
+
+omit [DecidableEq α] in
 /-- Flank words differing only on the left agree off position `0`. -/
 theorem flankWord_congr_left {x x' fill y : α} {n k : ℕ} (h : k ≠ 0) :
     (flankWord x fill y n)[k]? = (flankWord x' fill y n)[k]? := by

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -253,6 +253,63 @@ theorem isBimachineWeaklyDeterministic {L R : Type*} [Fintype L] [Fintype R]
   show B.out _ a _ = _
   rw [hω]
 
+/-! ### The flank-witness template
+
+The recurring witness family for two-sided unboundedness: a target buried in a filler
+run, with independently editable flanks. `RequiresBothSides.of_flanks` packages the
+whole assembly — a map is excluded by exhibiting only the images of the base and the
+two single-flank perturbations at the target. This is the three-map method of
+[yolyan-2025] §5.3, as an object. -/
+
+/-- A flank-controlled word: `x`, then `n` copies of `fill`, then `y`. -/
+def flankWord (x fill y : α) (n : ℕ) : List α := x :: (List.replicate n fill ++ [y])
+
+omit [DecidableEq α] in
+@[simp] theorem flankWord_length {x fill y : α} {n : ℕ} :
+    (flankWord x fill y n).length = n + 2 := by
+  simp [flankWord]
+
+omit [DecidableEq α] in
+theorem flankWord_getElem? {x fill y : α} {n k : ℕ} :
+    (flankWord x fill y n)[k]? = if k = 0 then some x else if k = n + 1 then some y
+      else if k < n + 2 then some fill else none := by
+  rcases k with _ | k
+  · rfl
+  · simp only [flankWord, List.getElem?_cons_succ, List.getElem?_append,
+      List.getElem?_replicate, List.length_replicate, List.getElem?_cons,
+      List.getElem?_nil]
+    split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+omit [DecidableEq α] in
+@[simp] theorem flankWord_getElem?_zero {x fill y : α} {n : ℕ} :
+    (flankWord x fill y n)[0]? = some x := rfl
+
+omit [DecidableEq α] in
+@[simp] theorem flankWord_getElem?_last {x fill y : α} {n : ℕ} :
+    (flankWord x fill y n)[n + 1]? = some y := by
+  rw [flankWord_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+omit [DecidableEq α] in
+theorem flankWord_getElem?_mid {x fill y : α} {n k : ℕ} (h₁ : 0 < k) (h₂ : k ≤ n) :
+    (flankWord x fill y n)[k]? = some fill := by
+  rw [flankWord_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+omit [DecidableEq α] in
+/-- Flank words differing only on the left agree off position `0`. -/
+theorem flankWord_congr_left {x x' fill y : α} {n k : ℕ} (h : k ≠ 0) :
+    (flankWord x fill y n)[k]? = (flankWord x' fill y n)[k]? := by
+  rw [flankWord_getElem?, flankWord_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+omit [DecidableEq α] in
+/-- Flank words differing only on the right agree off the last position. -/
+theorem flankWord_congr_right {x fill y y' : α} {n k : ℕ} (h : k ≠ n + 1) :
+    (flankWord x fill y n)[k]? = (flankWord x fill y' n)[k]? := by
+  rw [flankWord_getElem?, flankWord_getElem?]
+  split_ifs <;> rfl
+
 /-- `f` requires both sides: some target changes under `f`, yet perturbing either far
 side reverts it to the identity. Unlike `IsUnboundedCircumambient`, a two-sided union
 never satisfies this — removing one trigger leaves the other, so the output stays
@@ -263,6 +320,30 @@ def RequiresBothSides (f : List α → List α) : Prop :=
       uL[i]? = base[i]? ∧ (f uL)[i]? = uL[i]?) ∧
     (∃ uR : List α, uR.length = base.length ∧ AgreeUpto base uR (i + d) ∧
       uR[i]? = base[i]? ∧ (f uR)[i]? = uR[i]?)
+
+omit [DecidableEq α] in
+/-- **The three-map template**: a `d`-indexed family of flank words whose target sits
+`d`-far from both flanks, changed to `on` in the base and reverted by flipping either
+flank alone, requires both sides. -/
+theorem RequiresBothSides.of_flanks {f : List α → List α}
+    {fill on xOn yOn xOff yOff : α} {n t : ℕ → ℕ} (hne : on ≠ fill)
+    (hmargin : ∀ d, d < t d ∧ t d + d < n d + 1)
+    (hchange : ∀ d, (f (flankWord xOn fill yOn (n d)))[t d]? = some on)
+    (hrevL : ∀ d, (f (flankWord xOff fill yOn (n d)))[t d]? = some fill)
+    (hrevR : ∀ d, (f (flankWord xOn fill yOff (n d)))[t d]? = some fill) :
+    RequiresBothSides f := by
+  intro d
+  obtain ⟨hm₁, hm₂⟩ := hmargin d
+  have hmid : ∀ x y : α, (flankWord x fill y (n d))[t d]? = some fill := fun x y =>
+    flankWord_getElem?_mid (by omega) (by omega)
+  refine ⟨flankWord xOn fill yOn (n d), t d, by rw [flankWord_length]; omega,
+    by rw [hchange, hmid]; simpa using hne, ?_, ?_⟩
+  · exact ⟨flankWord xOff fill yOn (n d), by simp,
+      fun k hk => flankWord_congr_left (by omega), by rw [hmid, hmid],
+      by rw [hrevL, hmid]⟩
+  · exact ⟨flankWord xOn fill yOff (n d), by simp,
+      fun k hk => flankWord_congr_right (by omega), by rw [hmid, hmid],
+      by rw [hrevR, hmid]⟩
 
 omit [DecidableEq α] in
 /-- Requiring both sides strengthens unbounded circumambience: a reverted target is in

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -364,17 +364,10 @@ example : utp.map [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
 Whether the target surfaces is controlled by unboundedly distant flanks: instantiate
 the flank-witness template with `2d+2` toneless TBUs between the flanks. -/
 
-/-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
-plateau target, at every distance. -/
-theorem utp.requiresBothSides : RequiresBothSides utp.map := by
-  have hsurf : ∀ (d : ℕ) (x y : TBU),
-      utp.Surfaces (flankWord x .O y (2 * d + 2)) (d + 1) ↔ x = .H ∧ y = .H := fun d x y => by
-    rw [utp.surfaces_iff, exists_le_flankWord_eq_some_iff (by decide) (by omega),
-      exists_ge_flankWord_eq_some_iff (by decide) (by omega) (by omega)]
-  exact utp.requiresBothSides_of_flanks (fun d => ⟨by omega, by omega⟩)
-    (fun d => (hsurf d .H .H).mpr ⟨rfl, rfl⟩)
-    (fun d hs => by simpa using (hsurf d .O .H).mp hs)
-    (fun d hs => by simpa using (hsurf d .H .O).mp hs)
+/-- UTP requires both sides ([heinz-lai-2013]): its trigger is the two-sided window
+conjunction, so deleting either flanking H reverts the plateau target. -/
+theorem utp.requiresBothSides : RequiresBothSides utp.map :=
+  utp.requiresBothSides_of_surfaces_iff fun _ _ => utp.surfaces_iff
 
 /-- UTP is an unbounded circumambient process: whether a position changes depends on
 unboundedly distant material on both sides. -/

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -361,75 +361,32 @@ example : utp.map [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
 
 /-! ### Unbounded circumambience
 
-The witness family at distance `d`: `flanked d x y` puts `x` and `y` around `2d+2`
-toneless TBUs. The base `flanked d .H .H` is the plateau word with target `d+1`;
-flipping either flank to `.O` is the far perturbation that reverts it. -/
-
-/-- The distance-`d` witness word: flanks `x`, `y` around `2d+2` toneless TBUs. -/
-private def flanked (d : ℕ) (x y : TBU) : List TBU :=
-  x :: (List.replicate (2 * d + 2) .O ++ [y])
-
-private theorem flanked_length (d : ℕ) (x y : TBU) : (flanked d x y).length = 2 * d + 4 := by
-  simp [flanked]
-
-private theorem flanked_getElem? (d : ℕ) (x y : TBU) (j : ℕ) :
-    (flanked d x y)[j]? = if j = 0 then some x else if j = 2 * d + 3 then some y
-      else if j < 2 * d + 4 then some .O else none := by
-  simp only [flanked, List.getElem?_cons, List.getElem?_append, List.getElem?_replicate,
-    List.length_replicate, List.getElem?_nil]
-  split_ifs <;> first | rfl | omega
-
-/-- The target surfaces iff both flanks are H: the toneless fill offers no other
-trigger on either side. -/
-private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
-    utp.Surfaces (flanked d x y) (d + 1) ↔ x = .H ∧ y = .H := by
-  rw [utp.surfaces_iff]
-  constructor
-  · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
-    rw [flanked_getElem?] at h₁ h₂
-    split_ifs at h₁ h₂ <;> simp_all
-    omega
-  · rintro ⟨rfl, rfl⟩
-    exact ⟨⟨0, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩,
-      2 * d + 3, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩
-
-/-- The target cell of every flanked word is toneless. -/
-private theorem flanked_mid (d : ℕ) (x y : TBU) : (flanked d x y)[d + 1]? = some .O := by
-  rw [flanked_getElem?]
-  split_ifs <;> first | rfl | exact ‹False›.elim | omega
-
-/-- The image at the target is controlled by the flanks alone. -/
-private theorem map_flanked_mid (d : ℕ) (x y : TBU) :
-    (utp.map (flanked d x y))[d + 1]? = if x = .H ∧ y = .H then some .H else some .O := by
-  split_ifs with h
-  · exact utp.map_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
-  · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
-      fun hs => h ((surfacesH_flanked_mid d).mp hs)⟩
-
-/-- Flanked words differing only in the left flank agree off position `0`. -/
-private theorem flanked_congr_left (d : ℕ) (x x' y : TBU) {k : ℕ} (h0 : k ≠ 0) :
-    (flanked d x y)[k]? = (flanked d x' y)[k]? := by
-  rw [flanked_getElem?, flanked_getElem?]
-  split_ifs <;> first | rfl | omega
-
-/-- Flanked words differing only in the right flank agree off the last position. -/
-private theorem flanked_congr_right (d : ℕ) (x y y' : TBU) {k : ℕ} (h3 : k ≠ 2 * d + 3) :
-    (flanked d x y)[k]? = (flanked d x y')[k]? := by
-  rw [flanked_getElem?, flanked_getElem?]
-  split_ifs <;> rfl
+Whether the target surfaces is controlled by unboundedly distant flanks: instantiate
+the flank-witness template with `2d+2` toneless TBUs between the flanks. -/
 
 /-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
 plateau target, at every distance. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map := by
-  intro d
-  refine ⟨flanked d .H .H, d + 1, by rw [flanked_length]; omega,
-    by simp [map_flanked_mid, flanked_mid], ?_, ?_⟩
-  · exact ⟨flanked d .O .H, by rw [flanked_length, flanked_length],
-      fun k hk => flanked_congr_left d _ _ _ (by omega),
-      by rw [flanked_mid, flanked_mid], by simp [map_flanked_mid, flanked_mid]⟩
-  · exact ⟨flanked d .H .O, by rw [flanked_length, flanked_length],
-      fun k hk => flanked_congr_right d _ _ _ (by omega),
-      by rw [flanked_mid, flanked_mid], by simp [map_flanked_mid, flanked_mid]⟩
+  have hsurf : ∀ (d : ℕ) (x y : TBU),
+      utp.Surfaces (flankWord x .O y (2 * d + 2)) (d + 1) ↔ x = .H ∧ y = .H := by
+    intro d x y
+    rw [utp.surfaces_iff]
+    constructor
+    · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
+      rw [flankWord_getElem?] at h₁ h₂
+      split_ifs at h₁ h₂ <;> simp_all
+      omega
+    · rintro ⟨rfl, rfl⟩
+      exact ⟨⟨0, by omega, flankWord_getElem?_zero⟩, 2 * d + 3, by omega,
+        by rw [flankWord_getElem?]; split_ifs <;> first | rfl | exact ‹False›.elim | omega⟩
+  refine RequiresBothSides.of_flanks (fill := TBU.O) (on := TBU.H) (xOn := .H)
+    (yOn := .H) (xOff := .O) (yOff := .O) (n := fun d => 2 * d + 2) (t := fun d => d + 1)
+    (by decide) (fun d => ⟨by omega, by omega⟩) (fun d => ?_) (fun d => ?_) (fun d => ?_)
+  · exact utp.map_getElem?_H_iff.mpr ((hsurf d .H .H).mpr ⟨rfl, rfl⟩)
+  · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flankWord_length]; omega,
+      fun hs => by simpa using (hsurf d .O .H).mp hs⟩
+  · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flankWord_length]; omega,
+      fun hs => by simpa using (hsurf d .H .O).mp hs⟩
 
 /-- UTP is an unbounded circumambient process: whether a position changes depends on
 unboundedly distant material on both sides. -/

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -393,33 +393,43 @@ private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
     exact ⟨⟨0, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩,
       2 * d + 3, by omega, by rw [flanked_getElem?]; split_ifs <;> first | rfl | omega⟩
 
+/-- The target cell of every flanked word is toneless. -/
+private theorem flanked_mid (d : ℕ) (x y : TBU) : (flanked d x y)[d + 1]? = some .O := by
+  rw [flanked_getElem?]
+  split_ifs <;> first | rfl | exact ‹False›.elim | omega
+
+/-- The image at the target is controlled by the flanks alone. -/
+private theorem map_flanked_mid (d : ℕ) (x y : TBU) :
+    (utp.map (flanked d x y))[d + 1]? = if x = .H ∧ y = .H then some .H else some .O := by
+  split_ifs with h
+  · exact utp.map_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
+  · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
+      fun hs => h ((surfacesH_flanked_mid d).mp hs)⟩
+
+/-- Flanked words differing only in the left flank agree off position `0`. -/
+private theorem flanked_congr_left (d : ℕ) (x x' y : TBU) {k : ℕ} (h0 : k ≠ 0) :
+    (flanked d x y)[k]? = (flanked d x' y)[k]? := by
+  rw [flanked_getElem?, flanked_getElem?]
+  split_ifs <;> first | rfl | omega
+
+/-- Flanked words differing only in the right flank agree off the last position. -/
+private theorem flanked_congr_right (d : ℕ) (x y y' : TBU) {k : ℕ} (h3 : k ≠ 2 * d + 3) :
+    (flanked d x y)[k]? = (flanked d x y')[k]? := by
+  rw [flanked_getElem?, flanked_getElem?]
+  split_ifs <;> rfl
+
 /-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
 plateau target, at every distance. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map := by
   intro d
-  have hmid : ∀ x y : TBU, (flanked d x y)[d + 1]? = some .O := fun x y => by
-    rw [flanked_getElem?, if_neg (by omega : ¬(d + 1 = 0)),
-      if_neg (by omega : ¬(d + 1 = 2 * d + 3)), if_pos (by omega : d + 1 < 2 * d + 4)]
-  have himg : ∀ x y : TBU, (utp.map (flanked d x y))[d + 1]?
-      = if x = .H ∧ y = .H then some .H else some .O := fun x y => by
-    split_ifs with h
-    · exact utp.map_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
-    · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
-        fun hs => h ((surfacesH_flanked_mid d).mp hs)⟩
-  have hagreeL : ∀ (x x' y : TBU) (k : ℕ), k ≠ 0 →
-      (flanked d x y)[k]? = (flanked d x' y)[k]? := fun x x' y k h0 => by
-    rw [flanked_getElem?, flanked_getElem?]; split_ifs <;> first | rfl | omega
-  have hagreeR : ∀ (x y y' : TBU) (k : ℕ), k ≠ 2 * d + 3 →
-      (flanked d x y)[k]? = (flanked d x y')[k]? := fun x y y' k h3 => by
-    rw [flanked_getElem?, flanked_getElem?]; split_ifs <;> rfl
-  refine ⟨flanked d .H .H, d + 1, by rw [flanked_length]; omega, ?_, ?_, ?_⟩
-  · rw [himg, hmid]; simp
+  refine ⟨flanked d .H .H, d + 1, by rw [flanked_length]; omega,
+    by simp [map_flanked_mid, flanked_mid], ?_, ?_⟩
   · exact ⟨flanked d .O .H, by rw [flanked_length, flanked_length],
-      fun k hk => hagreeL _ _ _ k (by omega), by rw [hmid, hmid],
-      by rw [himg, hmid]; simp⟩
+      fun k hk => flanked_congr_left d _ _ _ (by omega),
+      by rw [flanked_mid, flanked_mid], by simp [map_flanked_mid, flanked_mid]⟩
   · exact ⟨flanked d .H .O, by rw [flanked_length, flanked_length],
-      fun k hk => hagreeR _ _ _ k (by omega), by rw [hmid, hmid],
-      by rw [himg, hmid]; simp⟩
+      fun k hk => flanked_congr_right d _ _ _ (by omega),
+      by rw [flanked_mid, flanked_mid], by simp [map_flanked_mid, flanked_mid]⟩
 
 /-- UTP is an unbounded circumambient process: whether a position changes depends on
 unboundedly distant material on both sides. -/

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -368,25 +368,13 @@ the flank-witness template with `2d+2` toneless TBUs between the flanks. -/
 plateau target, at every distance. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map := by
   have hsurf : ∀ (d : ℕ) (x y : TBU),
-      utp.Surfaces (flankWord x .O y (2 * d + 2)) (d + 1) ↔ x = .H ∧ y = .H := by
-    intro d x y
-    rw [utp.surfaces_iff]
-    constructor
-    · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
-      rw [flankWord_getElem?] at h₁ h₂
-      split_ifs at h₁ h₂ <;> simp_all
-      omega
-    · rintro ⟨rfl, rfl⟩
-      exact ⟨⟨0, by omega, flankWord_getElem?_zero⟩, 2 * d + 3, by omega,
-        by rw [flankWord_getElem?]; split_ifs <;> first | rfl | exact ‹False›.elim | omega⟩
-  refine RequiresBothSides.of_flanks (fill := TBU.O) (on := TBU.H) (xOn := .H)
-    (yOn := .H) (xOff := .O) (yOff := .O) (n := fun d => 2 * d + 2) (t := fun d => d + 1)
-    (by decide) (fun d => ⟨by omega, by omega⟩) (fun d => ?_) (fun d => ?_) (fun d => ?_)
-  · exact utp.map_getElem?_H_iff.mpr ((hsurf d .H .H).mpr ⟨rfl, rfl⟩)
-  · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flankWord_length]; omega,
-      fun hs => by simpa using (hsurf d .O .H).mp hs⟩
-  · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flankWord_length]; omega,
-      fun hs => by simpa using (hsurf d .H .O).mp hs⟩
+      utp.Surfaces (flankWord x .O y (2 * d + 2)) (d + 1) ↔ x = .H ∧ y = .H := fun d x y => by
+    rw [utp.surfaces_iff, exists_le_flankWord_eq_some_iff (by decide) (by omega),
+      exists_ge_flankWord_eq_some_iff (by decide) (by omega) (by omega)]
+  exact utp.requiresBothSides_of_flanks (fun d => ⟨by omega, by omega⟩)
+    (fun d => (hsurf d .H .H).mpr ⟨rfl, rfl⟩)
+    (fun d hs => by simpa using (hsurf d .O .H).mp hs)
+    (fun d hs => by simpa using (hsurf d .H .O).mp hs)
 
 /-- UTP is an unbounded circumambient process: whether a position changes depends on
 unboundedly distant material on both sides. -/

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -24,12 +24,12 @@ unassociated), and `utp` — a `Tone.Surfacing` process — rewrites it pointwis
 surfacing predicate. What surfaces is the *representation*: `utp.Surfaces w i` is by
 definition H-linkedness of timing node `i` in the output representation `plateauAR w`
 (the OCP-merged input, hull-closed — fusion then spreading); the string reading is the
-derived `utp_surfaces_def`. The map is `utp.map`, the surfacing set `plateau`.
+derived `utp.surfaces_def`. The map is `utp.map`, the surfacing set `plateau`.
 
 The map is the flagship *unbounded circumambient* process: whether a position changes
 depends on unboundedly distant material on **both** sides
-(`utp_isUnboundedCircumambient`), and in the strong witness form
-`utp_requiresBothSides` — perturbing either far side alone reverts the change — which
+(`utp.isUnboundedCircumambient`), and in the strong witness form
+`utp.requiresBothSides` — perturbing either far side alone reverts the change — which
 feeds the weak-determinism exclusion theorems of `Studies/Jardine2016Tone` (bimachine
 rendering) and `Studies/Yolyan2025` (BMRS rendering).
 
@@ -45,14 +45,14 @@ rendering) and `Studies/Yolyan2025` (BMRS rendering).
 
 ## Main results
 
-* `utp_getElem?_H_iff` / `utp_getElem?_O_iff` — pointwise characterization of the map.
+* `utp.map_getElem?_H_iff` / `utp.map_getElem?_O_iff` — pointwise characterization of the map.
 * `utp_eq_plateau_indicator`, `plateau_eq_Icc` — the output is the indicator word of an
   interval, from the first trigger to the last.
-* `utp_toneless`, `utp_single`, `utp_plateau` — the rule schemata: toneless words and
+* `utp.map_toneless`, `utp.map_single`, `utp.map_plateau` — the rule schemata: toneless words and
   lone Hs are unchanged; everything between the outermost Hs surfaces H.
-* `utp_getElem?_H_of_getElem?_H`, `utp_mono`, `utp_utp` — plateauing is a closure
+* `utp.map_getElem?_H_of_getElem?_H`, `utp.map_mono`, `utp.map_map` — plateauing is a closure
   operator in the pointwise H-order: extensive, monotone, idempotent.
-* `utp_requiresBothSides` — deleting either flanking H reverts the plateau target, at
+* `utp.requiresBothSides` — deleting either flanking H reverts the plateau target, at
   every distance.
 -/
 
@@ -74,7 +74,7 @@ representations is OCP-fusion followed by hull-closure of the association lines
 ([hyman-katamba-2010]'s rule as an operation on structures). What surfaces is the
 representation: `utp.Surfaces` is *by definition* H-linkedness in the output
 representation `plateauAR w`; the string-level `take`/`drop` reading is the derived
-characterization `utp_surfaces_def`. -/
+characterization `utp.surfaces_def`. -/
 
 open Autosegmental
 
@@ -160,68 +160,68 @@ def utp : Surfacing TBU where
     ⟨List.mem_take_iff.mpr ⟨_, Nat.lt_succ_self _, h⟩, List.mem_drop_iff.mpr ⟨_, le_rfl, h⟩⟩
   decSurfaces w i := decidable_of_iff _ surfacesWith_plateauAR.symm
 
-@[simp] theorem utp_hi : utp.hi = .H := rfl
+@[simp] theorem utp.hi_def : utp.hi = .H := rfl
 
-@[simp] theorem utp_lo : utp.lo = .O := rfl
+@[simp] theorem utp.lo_def : utp.lo = .O := rfl
 
 /-- The string-level reading of surfacing: the windowed form, now derived. -/
-theorem utp_surfaces_def {w : List TBU} {i : ℕ} :
+theorem utp.surfaces_def {w : List TBU} {i : ℕ} :
     utp.Surfaces w i ↔ .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i :=
   surfacesWith_plateauAR
 
 variable {w : List TBU} {i j k : ℕ}
 
 /-- Positionwise reading of surfacing: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
-theorem utp_surfaces_iff :
+theorem utp.surfaces_iff :
     utp.Surfaces w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j ≥ i, w[j]? = some .H := by
-  rw [utp_surfaces_def, List.mem_take_iff, List.mem_drop_iff]
+  rw [utp.surfaces_def, List.mem_take_iff, List.mem_drop_iff]
   simp [Nat.lt_succ_iff]
 
 /-- The surfacing set is convex: the windows only widen. -/
-theorem utp_surfaces_of_le_of_le (hi : utp.Surfaces w i) (hk : utp.Surfaces w k)
-    (hij : i ≤ j) (hjk : j ≤ k) : utp.Surfaces w j :=
-  utp_surfaces_def.mpr
-    ⟨w.take_subset_take_left (by omega) (utp_surfaces_def.mp hi).1,
-      w.drop_subset_drop_left (by omega) (utp_surfaces_def.mp hk).2⟩
+theorem _root_.Tone.Surfacing.Surfaces.of_le_of_le (hi : utp.Surfaces w i)
+    (hk : utp.Surfaces w k) (hij : i ≤ j) (hjk : j ≤ k) : utp.Surfaces w j :=
+  utp.surfaces_def.mpr
+    ⟨w.take_subset_take_left (by omega) (utp.surfaces_def.mp hi).1,
+      w.drop_subset_drop_left (by omega) (utp.surfaces_def.mp hk).2⟩
 
-theorem utp_surfaces_H_mem (h : utp.Surfaces w i) : .H ∈ w :=
-  List.take_subset _ _ (utp_surfaces_def.mp h).1
+theorem _root_.Tone.Surfacing.Surfaces.H_mem (h : utp.Surfaces w i) : .H ∈ w :=
+  List.take_subset _ _ (utp.surfaces_def.mp h).1
 
 /-- Reversal symmetry: under `reverse` the two windows swap. -/
-theorem utp_surfaces_reverse (hi : i < w.length) :
+theorem utp.surfaces_reverse (hi : i < w.length) :
     utp.Surfaces w.reverse i ↔ utp.Surfaces w (w.length - 1 - i) := by
-  rw [utp_surfaces_def, utp_surfaces_def, List.take_reverse, List.drop_reverse,
+  rw [utp.surfaces_def, utp.surfaces_def, List.take_reverse, List.drop_reverse,
     List.mem_reverse, List.mem_reverse,
     show w.length - (i + 1) = w.length - 1 - i from by omega,
     show w.length - i = (w.length - 1 - i) + 1 from by omega, and_comm]
 
 /-- TBU `i` surfaces iff it is itself a H or is strictly flanked. -/
-theorem utp_surfaces_split {a : TBU} (h : w[i]? = some a) :
+theorem utp.surfaces_split {a : TBU} (h : w[i]? = some a) :
     utp.Surfaces w i ↔ a = .H ∨ (.H ∈ w.take i ∧ .H ∈ w.drop (i + 1)) := by
   rcases eq_or_ne a .H with rfl | ha
   · simp [utp.surfaces_of_hi h]
   · obtain ⟨hi, hia⟩ := List.getElem?_eq_some_iff.mp h
-    rw [utp_surfaces_def, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
+    rw [utp.surfaces_def, List.take_add_one, h, List.drop_eq_getElem_cons hi, hia]
     simp [ha, Ne.symm ha]
 
-theorem utp_getElem? :
+theorem utp.map_getElem? :
     (utp.map w)[i]? = w[i]?.map fun _ => if utp.Surfaces w i then TBU.H else TBU.O :=
-  utp.map_getElem?
+  Surfacing.map_getElem? utp
 
-theorem utp_getElem?_H_iff : (utp.map w)[j]? = some .H ↔ utp.Surfaces w j :=
+theorem utp.map_getElem?_H_iff : (utp.map w)[j]? = some .H ↔ utp.Surfaces w j :=
   utp.map_getElem?_hi_iff
 
-theorem utp_getElem?_O_iff :
+theorem utp.map_getElem?_O_iff :
     (utp.map w)[j]? = some .O ↔ j < w.length ∧ ¬ utp.Surfaces w j :=
   utp.map_getElem?_lo_iff
 
 /-- Plateauing is symmetric under string reversal. -/
-theorem utp_reverse : utp.map w.reverse = (utp.map w).reverse := by
+theorem utp.map_reverse : utp.map w.reverse = (utp.map w).reverse := by
   refine List.ext_getElem? fun i => ?_
   by_cases hi : i < w.length
-  · rw [utp_getElem?, List.getElem?_reverse (by simpa using hi),
-      List.getElem?_reverse (by simpa using hi), Surfacing.map_length, utp_getElem?]
-    simp only [utp_surfaces_reverse hi]
+  · rw [utp.map_getElem?, List.getElem?_reverse (by simpa using hi),
+      List.getElem?_reverse (by simpa using hi), Surfacing.map_length, utp.map_getElem?]
+    simp only [utp.surfaces_reverse hi]
   · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by simp; omega)]
 
 /-! ### The plateau set -/
@@ -232,7 +232,7 @@ def plateau (w : List TBU) : Finset ℕ := utp.support w
 @[simp] theorem mem_plateau : j ∈ plateau w ↔ utp.Surfaces w j := utp.mem_support
 
 @[simp] theorem plateau_nonempty : (plateau w).Nonempty ↔ .H ∈ w :=
-  ⟨fun ⟨_, hj⟩ => utp_surfaces_H_mem (mem_plateau.mp hj), fun hw =>
+  ⟨fun ⟨_, hj⟩ => (mem_plateau.mp hj).H_mem, fun hw =>
     have ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     ⟨i, mem_plateau.mpr (utp.surfaces_of_hi hi)⟩⟩
 
@@ -247,7 +247,7 @@ theorem utp_eq_plateau_indicator :
 theorem plateau_eq_Icc_of {lo hi : ℕ} (hlo : w[lo]? = some .H) (hhi : w[hi]? = some .H)
     (hb : ∀ j, w[j]? = some .H → lo ≤ j ∧ j ≤ hi) : plateau w = Finset.Icc lo hi := by
   ext j
-  rw [mem_plateau, Finset.mem_Icc, utp_surfaces_iff]
+  rw [mem_plateau, Finset.mem_Icc, utp.surfaces_iff]
   constructor
   · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
     have hb₁ := hb j₁ h₁; have hb₂ := hb j₂ h₂; omega
@@ -259,55 +259,53 @@ theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
   ext j
   rw [Finset.mem_Icc]
   refine ⟨fun hj => ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩, fun ⟨h₁, h₂⟩ =>
-    mem_plateau.mpr (utp_surfaces_of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
+    mem_plateau.mpr ((mem_plateau.mp ((plateau w).min'_mem hne)).of_le_of_le
       (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)⟩
 
 /-! ### Closure laws
 
 Plateauing is a closure operator in the pointwise H-order: extensive
-(`utp_getElem?_H_of_getElem?_H`), monotone (`utp_mono`), idempotent (`utp_utp`). The
+(`utp.map_getElem?_H_of_getElem?_H`), monotone (`utp.map_mono`), idempotent (`utp.map_map`). The
 engine is convexity: the output's Hs are the plateau, an interval, so plateauing the
-output surfaces nothing new (`utp_surfaces_map`). -/
-
-@[simp] theorem utp_nil : utp.map [] = [] := rfl
+output surfaces nothing new (`utp.surfaces_map`). -/
 
 /-- Extensivity: every H survives plateauing. -/
-theorem utp_getElem?_H_of_getElem?_H (h : w[i]? = some .H) :
+theorem utp.map_getElem?_H_of_getElem?_H (h : w[i]? = some .H) :
     (utp.map w)[i]? = some .H :=
   utp.map_getElem?_hi_of_getElem?_hi h
 
 /-- Surfacing is monotone in the word's H-set. -/
-theorem utp_surfaces_mono {w' : List TBU}
+theorem _root_.Tone.Surfacing.Surfaces.mono {w' : List TBU}
     (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (h : utp.Surfaces w i) :
     utp.Surfaces w' i := by
-  obtain ⟨⟨l, hl, hlH⟩, r, hr, hrH⟩ := utp_surfaces_iff.mp h
-  exact utp_surfaces_iff.mpr ⟨⟨l, hl, hw l hlH⟩, r, hr, hw r hrH⟩
+  obtain ⟨⟨l, hl, hlH⟩, r, hr, hrH⟩ := utp.surfaces_iff.mp h
+  exact utp.surfaces_iff.mpr ⟨⟨l, hl, hw l hlH⟩, r, hr, hw r hrH⟩
 
 /-- Monotonicity: pointwise more Hs in, pointwise more Hs out. -/
-theorem utp_mono {w' : List TBU}
+theorem utp.map_mono {w' : List TBU}
     (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (j : ℕ)
     (h : (utp.map w)[j]? = some TBU.H) : (utp.map w')[j]? = some TBU.H :=
-  utp_getElem?_H_iff.mpr (utp_surfaces_mono hw (utp_getElem?_H_iff.mp h))
+  utp.map_getElem?_H_iff.mpr ((utp.map_getElem?_H_iff.mp h).mono hw)
 
 /-- Surfacing is invariant under plateauing: the output's Hs are the plateau, whose
 convexity flanks no new positions. -/
-theorem utp_surfaces_map : utp.Surfaces (utp.map w) i ↔ utp.Surfaces w i := by
+theorem utp.surfaces_map : utp.Surfaces (utp.map w) i ↔ utp.Surfaces w i := by
   constructor
   · intro h
-    obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := utp_surfaces_iff.mp h
-    rw [utp_getElem?_H_iff] at h₁ h₂
-    obtain ⟨⟨l, hl, hlH⟩, -⟩ := utp_surfaces_iff.mp h₁
-    obtain ⟨-, r, hr, hrH⟩ := utp_surfaces_iff.mp h₂
-    exact utp_surfaces_iff.mpr ⟨⟨l, by omega, hlH⟩, r, by omega, hrH⟩
-  · exact fun h => utp_surfaces_iff.mpr ⟨⟨i, le_rfl, utp_getElem?_H_iff.mpr h⟩,
-      i, le_rfl, utp_getElem?_H_iff.mpr h⟩
+    obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := utp.surfaces_iff.mp h
+    rw [utp.map_getElem?_H_iff] at h₁ h₂
+    obtain ⟨⟨l, hl, hlH⟩, -⟩ := utp.surfaces_iff.mp h₁
+    obtain ⟨-, r, hr, hrH⟩ := utp.surfaces_iff.mp h₂
+    exact utp.surfaces_iff.mpr ⟨⟨l, by omega, hlH⟩, r, by omega, hrH⟩
+  · exact fun h => utp.surfaces_iff.mpr ⟨⟨i, le_rfl, utp.map_getElem?_H_iff.mpr h⟩,
+      i, le_rfl, utp.map_getElem?_H_iff.mpr h⟩
 
 @[simp] theorem plateau_utp : plateau (utp.map w) = plateau w := by
   ext j
-  rw [mem_plateau, mem_plateau, utp_surfaces_map]
+  rw [mem_plateau, mem_plateau, utp.surfaces_map]
 
 /-- Idempotence: a plateau is already closed. -/
-@[simp] theorem utp_utp : utp.map (utp.map w) = utp.map w := by
+@[simp] theorem utp.map_map : utp.map (utp.map w) = utp.map w := by
   rw [utp_eq_plateau_indicator (w := utp.map w), plateau_utp, Surfacing.map_length,
     ← utp_eq_plateau_indicator]
 
@@ -316,13 +314,13 @@ theorem utp_surfaces_map : utp.Surfaces (utp.map w) i ↔ utp.Surfaces w i := by
 The rule schemata as theorems about `utp` rather than clauses of its definition. -/
 
 /-- A toneless word is unchanged. -/
-theorem utp_toneless (n : ℕ) : utp.map (List.replicate n .O) = List.replicate n .O := by
+theorem utp.map_toneless (n : ℕ) : utp.map (List.replicate n .O) = List.replicate n .O := by
   have h : plateau (List.replicate n TBU.O) = ∅ :=
     Finset.not_nonempty_iff_eq_empty.mp (by simp)
   simp [utp_eq_plateau_indicator, h, List.map_const']
 
 /-- A word with a single H is unchanged — one H cannot trigger a plateau. -/
-theorem utp_single (m n : ℕ) :
+theorem utp.map_single (m n : ℕ) :
     utp.map (List.replicate m .O ++ .H :: List.replicate n .O)
       = List.replicate m .O ++ .H :: List.replicate n .O := by
   have hH : ∀ j, (List.replicate m TBU.O ++ TBU.H :: List.replicate n TBU.O)[j]? = some TBU.H
@@ -339,7 +337,7 @@ theorem utp_single (m n : ℕ) :
 
 /-- Everything between the outermost Hs surfaces H; the medial material `w` is
 arbitrary. -/
-theorem utp_plateau (m p : ℕ) (w : List TBU) :
+theorem utp.map_plateau (m p : ℕ) (w : List TBU) :
     utp.map (List.replicate m .O ++ .H :: (w ++ .H :: List.replicate p .O))
       = List.replicate m .O ++ (List.replicate (w.length + 2) .H ++ List.replicate p .O) := by
   have hb : ∀ j, (List.replicate m TBU.O ++ TBU.H :: (w ++ TBU.H :: List.replicate p TBU.O))[j]?
@@ -385,7 +383,7 @@ private theorem flanked_getElem? (d : ℕ) (x y : TBU) (j : ℕ) :
 trigger on either side. -/
 private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
     utp.Surfaces (flanked d x y) (d + 1) ↔ x = .H ∧ y = .H := by
-  rw [utp_surfaces_iff]
+  rw [utp.surfaces_iff]
   constructor
   · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
     rw [flanked_getElem?] at h₁ h₂
@@ -397,7 +395,7 @@ private theorem surfacesH_flanked_mid (d : ℕ) {x y : TBU} :
 
 /-- UTP requires both sides ([heinz-lai-2013]): deleting either flanking H reverts the
 plateau target, at every distance. -/
-theorem utp_requiresBothSides : RequiresBothSides utp.map := by
+theorem utp.requiresBothSides : RequiresBothSides utp.map := by
   intro d
   have hmid : ∀ x y : TBU, (flanked d x y)[d + 1]? = some .O := fun x y => by
     rw [flanked_getElem?, if_neg (by omega : ¬(d + 1 = 0)),
@@ -405,8 +403,8 @@ theorem utp_requiresBothSides : RequiresBothSides utp.map := by
   have himg : ∀ x y : TBU, (utp.map (flanked d x y))[d + 1]?
       = if x = .H ∧ y = .H then some .H else some .O := fun x y => by
     split_ifs with h
-    · exact utp_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
-    · exact utp_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
+    · exact utp.map_getElem?_H_iff.mpr ((surfacesH_flanked_mid d).mpr h)
+    · exact utp.map_getElem?_O_iff.mpr ⟨by rw [flanked_length]; omega,
         fun hs => h ((surfacesH_flanked_mid d).mp hs)⟩
   have hagreeL : ∀ (x x' y : TBU) (k : ℕ), k ≠ 0 →
       (flanked d x y)[k]? = (flanked d x' y)[k]? := fun x x' y k h0 => by
@@ -425,7 +423,7 @@ theorem utp_requiresBothSides : RequiresBothSides utp.map := by
 
 /-- UTP is an unbounded circumambient process: whether a position changes depends on
 unboundedly distant material on both sides. -/
-theorem utp_isUnboundedCircumambient : IsUnboundedCircumambient utp.map :=
-  utp_requiresBothSides.isUnboundedCircumambient
+theorem utp.isUnboundedCircumambient : IsUnboundedCircumambient utp.map :=
+  utp.requiresBothSides.isUnboundedCircumambient
 
 end Tone.Plateauing

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -112,6 +112,24 @@ theorem requiresBothSides_of_flanks {xOn yOn xOff yOff : α} {n t : ℕ → ℕ}
     (fun d => P.map_getElem?_lo_iff.mpr ⟨by simpa using hlen d, hoffL d⟩)
     (fun d => P.map_getElem?_lo_iff.mpr ⟨hlen d, hoffR d⟩)
 
+open Subregular in
+/-- **Conjunctive two-sided triggers require both sides**: a process that surfaces the
+marked tone exactly where one occurrence lies at-or-before and one at-or-after needs
+unboundedly distant information on both sides — the flank witness family is generic. -/
+theorem requiresBothSides_of_surfaces_iff
+    (hiff : ∀ w i, P.Surfaces w i
+      ↔ (∃ j ≤ i, w[j]? = some P.hi) ∧ ∃ j ≥ i, w[j]? = some P.hi) :
+    RequiresBothSides P.map :=
+  P.requiresBothSides_of_flanks (xOn := P.hi) (yOn := P.hi) (xOff := P.lo) (yOff := P.lo)
+    (n := fun d => 2 * d + 2) (t := fun d => d + 1) (fun d => ⟨by omega, by omega⟩)
+    (fun d => (hiff _ _).mpr
+      ⟨(exists_le_flankWord_eq_some_iff P.hi_ne_lo.symm (by omega)).mpr rfl,
+        (exists_ge_flankWord_eq_some_iff P.hi_ne_lo.symm (by omega) (by omega)).mpr rfl⟩)
+    (fun d hs => absurd ((exists_le_flankWord_eq_some_iff P.hi_ne_lo.symm (by omega)).mp
+      ((hiff _ _).mp hs).1) P.hi_ne_lo.symm)
+    (fun d hs => absurd ((exists_ge_flankWord_eq_some_iff P.hi_ne_lo.symm (by omega)
+      (by omega)).mp ((hiff _ _).mp hs).2) P.hi_ne_lo.symm)
+
 /-! ### The surfacing set -/
 
 /-- The surfacing positions of `w`, as a finite set. -/

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.List.TakeDrop
+import Linglib.Core.Computability.Subregular.Function.Bimachine
 
 /-!
 # Tonal surfacing processes
@@ -91,6 +92,25 @@ theorem map_getElem?_hi_of_getElem?_hi (h : w[i]? = some P.hi) :
 theorem Surfaces.lt_length {P : Surfacing α} {w : List α} {i : ℕ}
     (h : P.Surfaces w i) : i < w.length :=
   P.lt_length h
+
+open Subregular in
+/-- **The flank-witness template, at the surfacing level**: a process whose surfacing at
+a `d`-margined target in a flank word is switched on by the base flanks and off by
+either single flip requires both sides — supply only the three surfacing facts. -/
+theorem requiresBothSides_of_flanks {xOn yOn xOff yOff : α} {n t : ℕ → ℕ}
+    (hmargin : ∀ d, d < t d ∧ t d + d < n d + 1)
+    (hon : ∀ d, P.Surfaces (flankWord xOn P.lo yOn (n d)) (t d))
+    (hoffL : ∀ d, ¬ P.Surfaces (flankWord xOff P.lo yOn (n d)) (t d))
+    (hoffR : ∀ d, ¬ P.Surfaces (flankWord xOn P.lo yOff (n d)) (t d)) :
+    RequiresBothSides P.map :=
+  have hlen : ∀ d, t d < (flankWord xOn P.lo yOff (n d)).length := fun d => by
+    rw [flankWord_length]
+    have := hmargin d
+    omega
+  RequiresBothSides.of_flanks P.hi_ne_lo hmargin
+    (fun d => P.map_getElem?_hi_iff.mpr (hon d))
+    (fun d => P.map_getElem?_lo_iff.mpr ⟨by simpa using hlen d, hoffL d⟩)
+    (fun d => P.map_getElem?_lo_iff.mpr ⟨hlen d, hoffR d⟩)
 
 /-! ### The surfacing set -/
 

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -26,8 +26,8 @@ TBUs surfaces H. This file formalizes the paper's formal skeleton over its strin
 representation (§4.1: `H` a H-toned TBU, `O` the paper's Ø).
 
 The map itself and its plateau/circumambience API live in `Phonology/Tone/Plateauing`
-(the rule set (36) as `utp_toneless`/`utp_single`/`utp_plateau`; definition (2) as
-`utp_isUnboundedCircumambient`); this file keeps the paper's theorems about it.
+(the rule set (36) as `utp.map_toneless`/`utp.map_single`/`utp.map_plateau`; definition (2) as
+`utp.isUnboundedCircumambient`); this file keeps the paper's theorems about it.
 
 ## Main definitions
 
@@ -39,7 +39,7 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
 
 * `utp_not_isSubsequential` — the central theorem (§4.2, online appendix): no
   deterministic FST computes UTP in either direction, via
-  `IsLeftSubsequential.bounded_delay` and the reversal symmetry `utp_reverse`.
+  `IsLeftSubsequential.bounded_delay` and the reversal symmetry `utp.map_reverse`.
 * `utp_not_isBimachineWeaklyDeterministic` — §5.2, via `RequiresBothSides`: no union of
   one-sided rules expresses UTP's conjunctive trigger.
 * `utp_markup_decomposition` — (43): with the mark `?`, UTP is right-subsequential after
@@ -76,7 +76,7 @@ def utpBM : Bimachine Bool Bool TBU TBU :=
 theorem utpBM_run : utpBM.run = utp.map := by
   funext w
   refine List.ext_getElem? fun i => ?_
-  rw [utpBM, Bimachine.ofFlags_run_getElem?, utp_getElem?]
+  rw [utpBM, Bimachine.ofFlags_run_getElem?, utp.map_getElem?]
   cases h : w[i]? with
   | none => rfl
   | some a =>
@@ -84,7 +84,7 @@ theorem utpBM_run : utpBM.run = utp.map := by
     congr 1
     have hb : (a == TBU.H || ((w.take i).any (· == .H) && (w.drop (i + 1)).any (· == .H)))
         = true ↔ utp.Surfaces w i := by
-      rw [utp_surfaces_split h]; simp [List.any_eq_true]
+      rw [utp.surfaces_split h]; simp [List.any_eq_true]
     by_cases hs : utp.Surfaces w i
     · rw [if_pos (hb.mpr hs), if_pos hs]
     · rw [if_neg (fun hbt => hs (hb.mp hbt)), if_neg hs]
@@ -106,9 +106,9 @@ theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp.map := by
   · simp only [Tone.Surfacing.map_length, List.length_cons, List.length_replicate]; omega
   · -- the images disagree at position 1: toneless there without the second H, plateau with it
     have h1 : (utp.map (TBU.H :: List.replicate (N + 1) TBU.O))[1]? = some TBU.O :=
-      utp_getElem?_O_iff.mpr ⟨by simp, fun hs => by simpa using (utp_surfaces_def.mp hs).2⟩
+      utp.map_getElem?_O_iff.mpr ⟨by simp, fun hs => by simpa using (utp.surfaces_def.mp hs).2⟩
     have h2 : (utp.map ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H :=
-      utp_getElem?_H_iff.mpr (utp_surfaces_def.mpr ⟨by simp, by simp⟩)
+      utp.map_getElem?_H_iff.mpr (utp.surfaces_def.mpr ⟨by simp, by simp⟩)
     rw [h1, h2]; simp
 
 /-- UTP is not right-subsequential: by the reversal symmetry, a right machine faces the
@@ -117,7 +117,7 @@ theorem utp_not_isRightSubsequential : ¬ IsRightSubsequential utp.map := by
   intro hf
   rw [isRightSubsequential_iff_left_reverse] at hf
   have heq : (fun xs : List TBU => (utp.map xs.reverse).reverse) = utp.map := by
-    funext xs; rw [utp_reverse, List.reverse_reverse]
+    funext xs; rw [utp.map_reverse, List.reverse_reverse]
   exact utp_not_isLeftSubsequential (heq ▸ hf)
 
 /-- UTP is subsequential in neither direction. -/
@@ -133,7 +133,7 @@ expresses. -/
 
 /-- UTP is not weakly deterministic (§5.2). -/
 theorem utp_not_isBimachineWeaklyDeterministic : ¬ IsBimachineWeaklyDeterministic utp.map :=
-  not_isBimachineWeaklyDeterministic_of_requiresBothSides utp_requiresBothSides
+  not_isBimachineWeaklyDeterministic_of_requiresBothSides utp.requiresBothSides
 
 /-! ### The (43) mark-up decomposition
 
@@ -170,7 +170,7 @@ theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w
   have hmark : ∀ i : ℕ, Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) :=
     fun i => by simp only [List.mem_drop_iff, markLeft_run_H_iff]
   refine List.ext_getElem? fun i => ?_
-  rw [utp_getElem?, resolve, resolveRight, Mealy.ofFlag_run_reverse_getElem?]
+  rw [utp.map_getElem?, resolve, resolveRight, Mealy.ofFlag_run_reverse_getElem?]
   simp only [List.any_beq', List.contains_eq_mem, decide_eq_decide.mpr (hmark i)]
   rw [markLeft, Mealy.ofFlag_run_getElem?, Option.map_map]
   simp only [List.any_beq', List.contains_eq_mem]
@@ -183,7 +183,7 @@ theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w
     | H => simp [utp.surfaces_of_hi ha]
     | O =>
       by_cases hL : TBU.H ∈ w.take i <;> by_cases hR : TBU.H ∈ w.drop (i + 1) <;>
-        simp [utp_surfaces_split ha, hL, hR]
+        simp [utp.surfaces_split ha, hL, hR]
 
 /-- The (43) mark-up decomposition (§5.2): over the `?`-enlarged alphabet, UTP is a
 right-subsequential map after a left-subsequential map. -/
@@ -228,7 +228,7 @@ autosegment multiply linked to exactly the `plateau`, over an unchanged timing t
 theorem mem_links_realizeMerged_utp (p : ℕ × ℕ) :
     p ∈ (realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ utp.Surfaces w p.2 := by
   have hL : ∀ j, (realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ utp.Surfaces w j :=
-    fun j => by rw [isLinkedLower_realize_toAR, utp_getElem?_H_iff]
+    fun j => by rw [isLinkedLower_realize_toAR, utp.map_getElem?_H_iff]
   rw [realizeMerged_def,
     mem_links_collapseAR_of_upper_replicate (upper_realize_toAR (utp.map w)), hL]
 
@@ -254,7 +254,7 @@ theorem upper_realizeMerged_utp (hw : .H ∈ w) :
   obtain ⟨m, hm⟩ : ∃ m, ((utp.map w).count .H) = m + 1 := by
     obtain ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     have := List.count_pos_iff.mpr <| List.mem_iff_getElem?.mpr
-      ⟨i, utp_getElem?_H_iff.mpr (utp.surfaces_of_hi hi)⟩
+      ⟨i, utp.map_getElem?_H_iff.mpr (utp.surfaces_of_hi hi)⟩
     exact ⟨(utp.map w).count .H - 1, by omega⟩
   rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR, hm, OCP.collapse_replicate]
 

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -228,7 +228,7 @@ flagship pattern (the class of the paper's Prop. 5.4 Bemba case), through
 theorem utp_not_bmrsWeaklyDeterministic :
     ¬ IsBmrsWeaklyDeterministic Tone.Plateauing.utp.map :=
   not_isBmrsWeaklyDeterministic_of_requiresBothSides
-    Tone.Plateauing.utp_requiresBothSides
+    Tone.Plateauing.utp.requiresBothSides
 
 /-! ### Bemba high-tone spreading is not weakly deterministic (Prop. 5.4)
 


### PR DESCRIPTION
Follow-up to #1071: the `utp_*` lemma family moves into the def-named `utp` namespace (`utp.surfaces_def`, `utp.surfaces_iff`, `utp.map_reverse`, `utp.map_toneless`/`_single`/`_plateau`, `utp.requiresBothSides`, …) and the hypothesis-consumers become projection-namespace dot-lemmas (`h.of_le_of_le`, `h.H_mem`, `h.mono` for `h : utp.Surfaces w i`). One shadow fix: the `utp.map_getElem?` wrapper delegates to `Surfacing.map_getElem? utp` explicitly, since the wrapper constant shadows field-notation resolution of the generic.