### PR TITLE
feat(Phonology/Tone): the commuting square realizeMerged ∘ map = plateauAR

### DIFF
--- a/Linglib/Core/CategoryTheory/Monoidal/LabeledTuple.lean
+++ b/Linglib/Core/CategoryTheory/Monoidal/LabeledTuple.lean
@@ -217,6 +217,9 @@ theorem ext {a b : LabeledTuple α} (hlen : a.len = b.len)
   simp only [ofList_label, toList, List.get_ofFn]
   congr 1
 
+theorem toList_injective : Function.Injective (toList (α := α)) := fun a b h => by
+  rw [← ofList_toList a, ← ofList_toList b, h]
+
 theorem concat_assoc (a b c : LabeledTuple α) :
     (a.concat b).concat c = a.concat (b.concat c) :=
   ext (Nat.add_assoc ..) (by simp only [concat_label]; exact Fin.append_assoc ..)

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -95,4 +95,11 @@ def AR.hull (A : AR α β) : AR α β where
 
 @[simp] theorem AR.hull_lower (A : AR α β) : A.hull.lower = A.lower := rfl
 
+/-- Hull membership on a well-formed representation: no side condition — the
+representation carries its own bounds. -/
+theorem AR.mem_links_hull {A : AR α β} {k j : ℕ} :
+    (k, j) ∈ A.hull.links
+      ↔ ∃ j₁ j₂, (k, j₁) ∈ A.links ∧ (k, j₂) ∈ A.links ∧ j₁ ≤ j ∧ j ≤ j₂ :=
+  Graph.mem_hull_links A.inBounds
+
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -20,7 +20,8 @@ representation, where the melody is a single node and the hull is planar.
 
 ## Main results
 
-* `mem_hull_links` — hull membership as flanking, for in-bounds graphs.
+* `mem_links_hull` — hull membership as flanking (`Graph` form with explicit bounds;
+  side-condition-free `AR.mem_links_hull` for well-formed representations).
 * `links_subset_hull` — the hull extends the link set.
 * `hull_convex` — per-node convexity: the defining property of the hull.
 * `AR.hull` — the operation on well-formed representations.
@@ -44,7 +45,7 @@ def hull (r : Graph α β) : Graph α β where
 @[simp] theorem hull_lower (r : Graph α β) : r.hull.lower = r.lower := rfl
 
 /-- Hull membership, on an in-bounds graph: `j` lies between two of `k`'s links. -/
-theorem mem_hull_links {r : Graph α β} (hr : r.InBounds) {k j : ℕ} :
+theorem mem_links_hull {r : Graph α β} (hr : r.InBounds) {k j : ℕ} :
     (k, j) ∈ r.hull.links
       ↔ ∃ j₁ j₂, (k, j₁) ∈ r.links ∧ (k, j₂) ∈ r.links ∧ j₁ ≤ j ∧ j ≤ j₂ := by
   simp only [hull, Finset.mem_filter, Finset.mem_product, Finset.mem_range]
@@ -62,27 +63,15 @@ theorem InBounds.hull {r : Graph α β} (hr : r.InBounds) : r.hull.InBounds := f
 
 /-- Links flank themselves: the hull extends the link set. -/
 theorem links_subset_hull {r : Graph α β} (hr : r.InBounds) : r.links ⊆ r.hull.links :=
-  fun ⟨k, j⟩ hp => (mem_hull_links hr).mpr ⟨j, j, hp, hp, le_rfl, le_rfl⟩
+  fun ⟨k, j⟩ hp => (mem_links_hull hr).mpr ⟨j, j, hp, hp, le_rfl, le_rfl⟩
 
 /-- Per-node convexity: the defining property of the hull. -/
 theorem hull_convex {r : Graph α β} (hr : r.InBounds) {k j₁ j j₂ : ℕ}
     (h₁ : (k, j₁) ∈ r.hull.links) (h₂ : (k, j₂) ∈ r.hull.links) (hle₁ : j₁ ≤ j)
     (hle₂ : j ≤ j₂) : (k, j) ∈ r.hull.links := by
-  obtain ⟨a₁, -, ha₁, -, hle₃, -⟩ := (mem_hull_links hr).mp h₁
-  obtain ⟨-, a₂, -, ha₂, -, hle₄⟩ := (mem_hull_links hr).mp h₂
-  exact (mem_hull_links hr).mpr ⟨a₁, a₂, ha₁, ha₂, by omega, by omega⟩
-
-/-- Surfacing through the hull: a same-node flanking pair with the right label. -/
-theorem surfacesWith_hull {r : Graph α β} (hr : r.InBounds) {a : α} {j : ℕ} :
-    r.hull.SurfacesWith a j
-      ↔ ∃ i j₁ j₂, (i, j₁) ∈ r.links ∧ (i, j₂) ∈ r.links ∧ j₁ ≤ j ∧ j ≤ j₂
-          ∧ r.upper.get? i = some a := by
-  constructor
-  · rintro ⟨i, hlink, hlabel⟩
-    obtain ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩ := (mem_hull_links hr).mp hlink
-    exact ⟨i, j₁, j₂, h₁, h₂, hle₁, hle₂, hlabel⟩
-  · rintro ⟨i, j₁, j₂, h₁, h₂, hle₁, hle₂, hlabel⟩
-    exact ⟨i, (mem_hull_links hr).mpr ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩, hlabel⟩
+  obtain ⟨a₁, -, ha₁, -, hle₃, -⟩ := (mem_links_hull hr).mp h₁
+  obtain ⟨-, a₂, -, ha₂, -, hle₄⟩ := (mem_links_hull hr).mp h₂
+  exact (mem_links_hull hr).mpr ⟨a₁, a₂, ha₁, ha₂, by omega, by omega⟩
 
 end Graph
 
@@ -100,6 +89,6 @@ representation carries its own bounds. -/
 theorem AR.mem_links_hull {A : AR α β} {k j : ℕ} :
     (k, j) ∈ A.hull.links
       ↔ ∃ j₁ j₂, (k, j₁) ∈ A.links ∧ (k, j₂) ∈ A.links ∧ j₁ ≤ j ∧ j ≤ j₂ :=
-  Graph.mem_hull_links A.inBounds
+  Graph.mem_links_hull A.inBounds
 
 end Autosegmental

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -54,6 +54,8 @@ rendering) and `Studies/Yolyan2025` (BMRS rendering).
   operator in the pointwise H-order: extensive, monotone, idempotent.
 * `utp.requiresBothSides` — deleting either flanking H reverts the plateau target, at
   every distance.
+* `realizeMerged_toAR_map` — the commuting square: the merged representation of the
+  output string is the output representation `plateauAR`.
 -/
 
 namespace Tone.Plateauing
@@ -100,6 +102,15 @@ theorem upper_realize_toAR (v : List TBU) :
     rw [realize_cons, AR.concat_upper, LabeledTuple.toList_concat, ih]
     cases a <;> simp [toAR, List.replicate_succ]
 
+/-- The lower tier of the realization is the bare timing tier. -/
+theorem lower_realize_toAR (v : List TBU) :
+    (realize toAR v).lower.toList = List.replicate v.length () := by
+  induction v with
+  | nil => rfl
+  | cons a v ih =>
+    rw [realize_cons, AR.concat_lower, LabeledTuple.toList_concat, ih]
+    cases a <;> simp [toAR, List.replicate_succ]
+
 /-- A timing node of the input representation is linked iff its TBU is H-toned. -/
 theorem isLinkedLower_realize_toAR {w : List TBU} {j : ℕ} :
     (realize toAR w).toGraph.IsLinkedLower j ↔ w[j]? = some .H := by
@@ -114,13 +125,22 @@ theorem mem_links_realizeMerged_toAR {w : List TBU} {p : ℕ × ℕ} :
   rw [realizeMerged_def, mem_links_collapseAR_of_upper_replicate (upper_realize_toAR w),
     isLinkedLower_realize_toAR]
 
+/-- The melodic tier of the merged representation: one fused H if any, else empty. -/
+theorem upper_realizeMerged_toAR (v : List TBU) :
+    (realizeMerged toAR v).upper.toList
+      = if .H ∈ v then [_root_.Tone.TRN.H] else [] := by
+  rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR]
+  by_cases hv : .H ∈ v
+  · obtain ⟨n, hn⟩ : ∃ n, v.count .H = n + 1 :=
+      ⟨v.count .H - 1, by have := List.count_pos_iff.mpr hv; omega⟩
+    rw [hn, OCP.collapse_replicate, if_pos hv]
+  · rw [List.count_eq_zero.mpr hv, if_neg hv]
+    rfl
+
 /-- With any H present, the fused melody node is the H at index `0`. -/
 theorem upper_get?_realizeMerged_toAR {w : List TBU} (hw : .H ∈ w) :
     (realizeMerged toAR w).upper.get? 0 = some _root_.Tone.TRN.H := by
-  obtain ⟨n, hn⟩ : ∃ n, w.count .H = n + 1 :=
-    ⟨w.count .H - 1, by have := List.count_pos_iff.mpr hw; omega⟩
-  rw [LabeledTuple.get?_eq_getElem?, realizeMerged_def, upper_collapseAR,
-    upper_realize_toAR, hn, OCP.collapse_replicate]
+  rw [LabeledTuple.get?_eq_getElem?, upper_realizeMerged_toAR, if_pos hw]
   rfl
 
 /-- The output representation: fuse, then spread — the merged input, hull-closed. -/
@@ -287,6 +307,13 @@ theorem utp.map_mono {w' : List TBU}
     (h : (utp.map w)[j]? = some TBU.H) : (utp.map w')[j]? = some TBU.H :=
   utp.map_getElem?_H_iff.mpr ((utp.map_getElem?_H_iff.mp h).mono hw)
 
+/-- Plateauing preserves the presence of a trigger in both directions. -/
+theorem utp.H_mem_map : .H ∈ utp.map w ↔ .H ∈ w :=
+  ⟨fun h => have ⟨_, hi⟩ := List.mem_iff_getElem?.mp h
+    (utp.map_getElem?_H_iff.mp hi).H_mem,
+   fun h => have ⟨i, hi⟩ := List.mem_iff_getElem?.mp h
+    List.mem_iff_getElem?.mpr ⟨i, utp.map_getElem?_H_of_getElem?_H hi⟩⟩
+
 /-- Surfacing is invariant under plateauing: the output's Hs are the plateau, whose
 convexity flanks no new positions. -/
 theorem utp.surfaces_map : utp.Surfaces (utp.map w) i ↔ utp.Surfaces w i := by
@@ -358,6 +385,43 @@ theorem utp.map_plateau (m p : ℕ) (w : List TBU) :
 example : utp.map [.O, .O, .O, .H] = [.O, .O, .O, .H] := by decide
 example : utp.map [.H, .O, .O, .O] = [.H, .O, .O, .O] := by decide
 example : utp.map [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
+
+/-! ### The commuting square
+
+The string map linearizes the representational operation: realizing the output string
+gives back exactly the output representation. `utp.Surfaces` reads `plateauAR` by
+definition; the square closes the loop at the level of whole representations. -/
+
+/-- **The commuting square**: the merged representation of the output string *is* the
+output representation — fusion-plus-spreading followed by linearization equals `utp.map`
+followed by realization. -/
+theorem realizeMerged_toAR_map (w : List TBU) :
+    realizeMerged toAR (utp.map w) = plateauAR w := by
+  refine AR.ext_toGraph (Graph.ext ?_ ?_ ?_)
+  · exact LabeledTuple.toList_injective (by
+      show (realizeMerged toAR (utp.map w)).upper.toList
+        = (realizeMerged toAR w).upper.toList
+      rw [upper_realizeMerged_toAR, upper_realizeMerged_toAR]
+      simp only [utp.H_mem_map])
+  · exact LabeledTuple.toList_injective (by
+      show (realizeMerged toAR (utp.map w)).lower.toList
+        = (realizeMerged toAR w).lower.toList
+      rw [realizeMerged_def, realizeMerged_def, collapseAR_lower, collapseAR_lower,
+        lower_realize_toAR, lower_realize_toAR, Surfacing.map_length])
+  · ext ⟨k, j⟩
+    show _ ↔ (k, j) ∈ (realizeMerged toAR w).toGraph.hull.links
+    rw [mem_links_realizeMerged_toAR,
+      Graph.mem_hull_links (realizeMerged toAR w).inBounds]
+    constructor
+    · rintro ⟨rfl, hj⟩
+      obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ :=
+        utp.surfaces_iff.mp (utp.map_getElem?_H_iff.mp hj)
+      exact ⟨j₁, j₂, mem_links_realizeMerged_toAR.mpr ⟨rfl, h₁⟩,
+        mem_links_realizeMerged_toAR.mpr ⟨rfl, h₂⟩, hj₁, hj₂⟩
+    · rintro ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩
+      obtain ⟨hk, hj₁⟩ := mem_links_realizeMerged_toAR.mp h₁
+      exact ⟨hk, utp.map_getElem?_H_iff.mpr (utp.surfaces_iff.mpr
+        ⟨⟨j₁, hle₁, hj₁⟩, j₂, hle₂, (mem_links_realizeMerged_toAR.mp h₂).2⟩)⟩
 
 /-! ### Unbounded circumambience
 

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -137,6 +137,11 @@ theorem upper_realizeMerged_toAR (v : List TBU) :
   · rw [List.count_eq_zero.mpr hv, if_neg hv]
     rfl
 
+/-- The timing tier survives merging: the bare tier of the input's length. -/
+theorem lower_realizeMerged_toAR (v : List TBU) :
+    (realizeMerged toAR v).lower.toList = List.replicate v.length () := by
+  rw [realizeMerged_def, collapseAR_lower, lower_realize_toAR]
+
 /-- With any H present, the fused melody node is the H at index `0`. -/
 theorem upper_get?_realizeMerged_toAR {w : List TBU} (hw : .H ∈ w) :
     (realizeMerged toAR w).upper.get? 0 = some _root_.Tone.TRN.H := by
@@ -146,6 +151,25 @@ theorem upper_get?_realizeMerged_toAR {w : List TBU} (hw : .H ∈ w) :
 /-- The output representation: fuse, then spread — the merged input, hull-closed. -/
 def plateauAR (w : List TBU) : AR _root_.Tone.TRN Unit := (realizeMerged toAR w).hull
 
+@[simp] theorem plateauAR_upper {w : List TBU} :
+    (plateauAR w).upper = (realizeMerged toAR w).upper := rfl
+
+@[simp] theorem plateauAR_lower {w : List TBU} :
+    (plateauAR w).lower = (realizeMerged toAR w).lower := rfl
+
+/-- A link of the output representation: the fused node, over a flanked position. -/
+theorem mem_links_plateauAR {w : List TBU} {k j : ℕ} :
+    (k, j) ∈ (plateauAR w).links
+      ↔ k = 0 ∧ (∃ i ≤ j, w[i]? = some .H) ∧ ∃ i ≥ j, w[i]? = some .H := by
+  rw [plateauAR, AR.mem_links_hull]
+  constructor
+  · rintro ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩
+    obtain ⟨rfl, hj₁⟩ := mem_links_realizeMerged_toAR.mp h₁
+    exact ⟨rfl, ⟨j₁, hle₁, hj₁⟩, j₂, hle₂, (mem_links_realizeMerged_toAR.mp h₂).2⟩
+  · rintro ⟨rfl, ⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
+    exact ⟨j₁, j₂, mem_links_realizeMerged_toAR.mpr ⟨rfl, h₁⟩,
+      mem_links_realizeMerged_toAR.mpr ⟨rfl, h₂⟩, hj₁, hj₂⟩
+
 /-- **What surfaces is the representation**: `i` is H-linked in `plateauAR w` iff some
 H-toned TBU lies at or before `i` and some at or after it — the string-level reading. -/
 theorem surfacesWith_plateauAR {w : List TBU} {i : ℕ} :
@@ -153,15 +177,11 @@ theorem surfacesWith_plateauAR {w : List TBU} {i : ℕ} :
   rw [List.mem_take_iff, List.mem_drop_iff]
   constructor
   · rintro ⟨k, hlink, -⟩
-    obtain ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩ :=
-      (Graph.mem_hull_links (realizeMerged toAR w).inBounds).mp hlink
-    exact ⟨⟨j₁, by omega, (mem_links_realizeMerged_toAR.mp h₁).2⟩,
-      j₂, hle₂, (mem_links_realizeMerged_toAR.mp h₂).2⟩
+    obtain ⟨-, ⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ := mem_links_plateauAR.mp hlink
+    exact ⟨⟨j₁, by omega, h₁⟩, j₂, hj₂, h₂⟩
   · rintro ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩
-    refine ⟨0, (Graph.mem_hull_links (realizeMerged toAR w).inBounds).mpr
-      ⟨j₁, j₂, mem_links_realizeMerged_toAR.mpr ⟨rfl, h₁⟩,
-        mem_links_realizeMerged_toAR.mpr ⟨rfl, h₂⟩, by omega, hj₂⟩, ?_⟩
-    exact upper_get?_realizeMerged_toAR (List.mem_iff_getElem?.mpr ⟨j₁, h₁⟩)
+    exact ⟨0, mem_links_plateauAR.mpr ⟨rfl, ⟨j₁, by omega, h₁⟩, j₂, hj₂, h₂⟩,
+      upper_get?_realizeMerged_toAR (List.mem_iff_getElem?.mpr ⟨j₁, h₁⟩)⟩
 
 /-! ### The plateauing process -/
 
@@ -397,31 +417,13 @@ output representation — fusion-plus-spreading followed by linearization equals
 followed by realization. -/
 theorem realizeMerged_toAR_map (w : List TBU) :
     realizeMerged toAR (utp.map w) = plateauAR w := by
-  refine AR.ext_toGraph (Graph.ext ?_ ?_ ?_)
-  · exact LabeledTuple.toList_injective (by
-      show (realizeMerged toAR (utp.map w)).upper.toList
-        = (realizeMerged toAR w).upper.toList
-      rw [upper_realizeMerged_toAR, upper_realizeMerged_toAR]
-      simp only [utp.H_mem_map])
-  · exact LabeledTuple.toList_injective (by
-      show (realizeMerged toAR (utp.map w)).lower.toList
-        = (realizeMerged toAR w).lower.toList
-      rw [realizeMerged_def, realizeMerged_def, collapseAR_lower, collapseAR_lower,
-        lower_realize_toAR, lower_realize_toAR, Surfacing.map_length])
+  refine AR.ext_toGraph (Graph.ext (LabeledTuple.toList_injective ?_)
+    (LabeledTuple.toList_injective ?_) ?_)
+  · simp only [plateauAR_upper, upper_realizeMerged_toAR, utp.H_mem_map]
+  · simp only [plateauAR_lower, lower_realizeMerged_toAR, Surfacing.map_length]
   · ext ⟨k, j⟩
-    show _ ↔ (k, j) ∈ (realizeMerged toAR w).toGraph.hull.links
-    rw [mem_links_realizeMerged_toAR,
-      Graph.mem_hull_links (realizeMerged toAR w).inBounds]
-    constructor
-    · rintro ⟨rfl, hj⟩
-      obtain ⟨⟨j₁, hj₁, h₁⟩, j₂, hj₂, h₂⟩ :=
-        utp.surfaces_iff.mp (utp.map_getElem?_H_iff.mp hj)
-      exact ⟨j₁, j₂, mem_links_realizeMerged_toAR.mpr ⟨rfl, h₁⟩,
-        mem_links_realizeMerged_toAR.mpr ⟨rfl, h₂⟩, hj₁, hj₂⟩
-    · rintro ⟨j₁, j₂, h₁, h₂, hle₁, hle₂⟩
-      obtain ⟨hk, hj₁⟩ := mem_links_realizeMerged_toAR.mp h₁
-      exact ⟨hk, utp.map_getElem?_H_iff.mpr (utp.surfaces_iff.mpr
-        ⟨⟨j₁, hle₁, hj₁⟩, j₂, hle₂, (mem_links_realizeMerged_toAR.mp h₂).2⟩)⟩
+    rw [mem_links_realizeMerged_toAR, utp.map_getElem?_H_iff, utp.surfaces_iff,
+      mem_links_plateauAR]
 
 /-! ### Unbounded circumambience
 


### PR DESCRIPTION
The crown of the AR-founded surfacing arc (#1071): realizing the output string of `utp.map` yields exactly the output representation `plateauAR w` — the string map is the linearization of fusion-plus-spreading. Assembled via `Graph.ext` from tier equalities (`LabeledTuple.toList_injective`, new) and the link-set equivalence through `utp.surfaces_iff`; `upper_realizeMerged_toAR` states the merged melodic tier as an indicator and re-derives the old `get?` lemma as a corollary.