### PR TITLE
style(Phonology): mathlib-review hygiene sweep

### DIFF
--- a/Linglib/Core/CategoryTheory/Monoidal/LabeledTuple.lean
+++ b/Linglib/Core/CategoryTheory/Monoidal/LabeledTuple.lean
@@ -152,7 +152,7 @@ def get? (a : LabeledTuple α) (i : ℕ) : Option α :=
   · rw [List.getElem?_eq_getElem h, List.get_eq_getElem]
   · rw [List.getElem?_eq_none (by omega)]
 
-theorem get?_eq_getElem? (a : LabeledTuple α) (i : ℕ) : a.get? i = a.toList[i]? := by
+@[simp] theorem get?_eq_getElem? (a : LabeledTuple α) (i : ℕ) : a.get? i = a.toList[i]? := by
   unfold get?
   split <;> rename_i h
   · rw [List.getElem?_eq_getElem (by simpa using h)]; simp [toList, List.getElem_ofFn]

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -410,8 +410,14 @@ def empty : AR α β where
 
 /-- Two ARs are equal iff their underlying graphs are (`inBounds` by proof
     irrelevance). -/
-theorem ext_toGraph {A B : AR α β} (h : A.toGraph = B.toGraph) : A = B := by
+@[ext] theorem ext_toGraph {A B : AR α β} (h : A.toGraph = B.toGraph) : A = B := by
   cases A; cases B; cases h; rfl
+
+theorem toGraph_injective : Function.Injective (toGraph : AR α β → Graph α β) :=
+  fun _ _ => ext_toGraph
+
+instance [DecidableEq α] [DecidableEq β] : DecidableEq (AR α β) := fun A B =>
+  decidable_of_iff _ ⟨ext_toGraph, congrArg toGraph⟩
 
 /-- Objects form a `Monoid` under concatenation, with `empty` as unit
     ([jardine-heinz-2015] Theorems 1, 3): the laws lift the `Graph` monoid laws

--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -196,7 +196,7 @@ theorem mem_toERCSet {p : PartialOrderConstraints n} {α : ERC n} :
 the `a ≫ b` ERCs are the strict dominance requirements, and reflexive pairs impose
 nothing. -/
 theorem satisfiedBy_toERCSet {p : PartialOrderConstraints n} {σ : Ranking n} :
-    ERCSet.satisfiedBy σ p.toERCSet ↔ p.IsConsistent σ := by
+    ERCSet.SatisfiedBy σ p.toERCSet ↔ p.IsConsistent σ := by
   constructor
   · intro h a b hrel
     rcases eq_or_ne a b with rfl | hab
@@ -327,14 +327,14 @@ consumer ([dilworth-1940]; [merchant-riggle-2016]). -/
 
 /-- `p.toERCSet` consists of simple ERCs (each is a `simpleERC` of a strict pair). -/
 theorem toERCSet_isSimpleSet (p : PartialOrderConstraints n) :
-    ERCSet.isSimpleSet p.toERCSet := by
+    ERCSet.IsSimpleSet p.toERCSet := by
   intro α hα
   obtain ⟨a, b, hab, _, rfl⟩ := mem_toERCSet.mp hα
   exact simpleERC_isSimple hab
 
 /-- `p.toERCSet` is consistent: any linear extension of `p` satisfies it. -/
 theorem toERCSet_consistent (p : PartialOrderConstraints n) :
-    ERCSet.consistent p.toERCSet := by
+    ERCSet.Consistent p.toERCSet := by
   obtain ⟨σ, hσ⟩ := p.consistentTotalOrders_nonempty
   exact ⟨σ, satisfiedBy_toERCSet.mpr (mem_consistentTotalOrders.mp hσ)⟩
 

--- a/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
+++ b/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
@@ -92,7 +92,7 @@ theorem maximalChain_last {n : Nat} (r : Ranking n) :
 
     [merchant-riggle-2016] Definition 1. -/
 def MChain {n : Nat} (E : List (ERC n)) : Set (Fin n) → Prop :=
-  fun S => ∃ r : Ranking n, ERCSet.satisfiedBy r E ∧
+  fun S => ∃ r : Ranking n, ERCSet.SatisfiedBy r E ∧
     ∃ k : Fin (n + 1), maximalChain r k = S
 
 /-! ### Local feasibility — a decidable sound over-approximation -/
@@ -146,11 +146,11 @@ isomorphism): a prefix of a ranking that satisfies `E` is locally feasible.
 Winners dominate their losers, so a loser inside the prefix drags its winner in
 (`maximalChain_dominance` in `Finset` form). -/
 theorem feasible_of_satisfiedBy {n : Nat} {E : List (ERC n)} {r : Ranking n}
-    (hr : ERCSet.satisfiedBy r E) (k : Fin (n + 1)) : Feasible E (prefixFinset r k) := by
+    (hr : ERCSet.SatisfiedBy r E) (k : Fin (n + 1)) : Feasible E (prefixFinset r k) := by
   intro α hα ⟨l, hlL, hlmem⟩
   rw [mem_prefixFinset] at hlmem
   obtain ⟨w, hwW, hdom⟩ := (ERC.satisfiedBy_iff_dominance r α).mp (hr α hα) l hlL
-  exact ⟨w, hwW, by rw [mem_prefixFinset]; unfold Ranking.dominates at hdom; omega⟩
+  exact ⟨w, hwW, by rw [mem_prefixFinset]; unfold Ranking.Dominates at hdom; omega⟩
 
 /-! ### `FeasiblePrefix` — the faithful, decidable antimatroid feasibility -/
 
@@ -159,7 +159,7 @@ satisfying `E` — the `Finset`-valued form of `MChain`. Decidable by finite sea
 over `Ranking n` (a `Fintype`) and `Fin (n+1)`, so `decide` reduces — *and*
 unlike `Feasible` it is the genuine antimatroid family, not an over-approximation. -/
 def FeasiblePrefix {n : Nat} (E : List (ERC n)) (S : Finset (Fin n)) : Prop :=
-  ∃ r : Ranking n, ERCSet.satisfiedBy r E ∧ ∃ k : Fin (n + 1), prefixFinset r k = S
+  ∃ r : Ranking n, ERCSet.SatisfiedBy r E ∧ ∃ k : Fin (n + 1), prefixFinset r k = S
 
 instance {n : Nat} (E : List (ERC n)) : DecidablePred (FeasiblePrefix E) :=
   fun _ => Fintype.decidableExistsFintype
@@ -192,7 +192,7 @@ antimatroid for general ERC sets. Hence `Antimat.IsFeasible` stays `MChain`
 on the simple-ERC fragment. -/
 theorem feasible_not_accessible :
     ∃ (E : List (ERC 4)) (S : Finset (Fin 4)),
-      ERCSet.consistent E ∧ Feasible E S ∧ ¬ FeasiblePrefix E S ∧
+      ERCSet.Consistent E ∧ Feasible E S ∧ ¬ FeasiblePrefix E S ∧
         S.Nonempty ∧ ¬ ∃ x ∈ S, Feasible E (S \ {x}) :=
   ⟨[fun i => if i = 0 then .W else if i = 1 then .L else if i = 2 then .W else .e,
     fun i => if i = 0 then .L else if i = 1 then .W else if i = 2 then .e else .W],
@@ -210,10 +210,10 @@ theorem feasible_not_accessible :
     union closure: any W-witness for an L-constraint in a prefix set
     must itself be in that prefix set. -/
 theorem maximalChain_dominance {n : Nat} (r : Ranking n) (k : Fin (n + 1))
-    (w l : Fin n) (hw : r.dominates w l) (hl : l ∈ maximalChain r k) :
+    (w l : Fin n) (hw : r.Dominates w l) (hl : l ∈ maximalChain r k) :
     w ∈ maximalChain r k := by
   simp only [maximalChain, Set.mem_setOf_eq] at hl ⊢
-  unfold Ranking.dominates at hw; omega
+  unfold Ranking.Dominates at hw; omega
 
 -- Helpers for the union closure construction
 
@@ -298,7 +298,7 @@ set_option maxHeartbeats 1600000 in
 
     [merchant-riggle-2016] Lemma 3. -/
 theorem MChain.union_closed {n : Nat} (E : List (ERC n))
-    (_hcons : ERCSet.consistent E) (S T : Set (Fin n))
+    (_hcons : ERCSet.Consistent E) (S T : Set (Fin n))
     (_hS : MChain E S) (_hT : MChain E T) : MChain E (S ∪ T) := by
   obtain ⟨r₁, hr₁, k₁, hk₁⟩ := _hS
   obtain ⟨r₂, hr₂, k₂, hk₂⟩ := _hT
@@ -377,8 +377,8 @@ theorem MChain.union_closed {n : Nat} (E : List (ERC n))
   have hr₃ : ∀ i, r₃.symm i = ff i := by
     intro i; show e.symm.symm i = ff i; simp [Equiv.symm_symm, e]
   -- r₃.dominates w l ↔ f w < f l
-  have hdom : ∀ w l, r₃.dominates w l ↔ f w < f l := by
-    intro w l; unfold Ranking.dominates; constructor
+  have hdom : ∀ w l, r₃.Dominates w l ↔ f w < f l := by
+    intro w l; unfold Ranking.Dominates; constructor
     · intro h; rw [hr₃, hr₃] at h; exact h
     · intro h; rw [hr₃, hr₃]; exact h
   -- Prefix set = S ∪ T
@@ -392,7 +392,7 @@ theorem MChain.union_closed {n : Nat} (E : List (ERC n))
     · exact ⟨fun h => by have := countBelow_lt_card r₁ sR i ((in_sR i).mpr ⟨h1, h2⟩); omega,
         fun h => by rcases h with h | h <;> contradiction⟩
   -- ERC satisfaction
-  have hsat : ERCSet.satisfiedBy r₃ E := by
+  have hsat : ERCSet.SatisfiedBy r₃ E := by
     intro α hα
     rw [ERC.satisfiedBy_iff_dominance]
     intro l hl_L
@@ -442,7 +442,7 @@ theorem MChain.union_closed {n : Nat} (E : List (ERC n))
     maximal chains consistent with `E`.
 
     [merchant-riggle-2016] Definition 6, Lemma 4. -/
-def Antimat {n : Nat} (E : List (ERC n)) (hcons : ERCSet.consistent E) :
+def Antimat {n : Nat} (E : List (ERC n)) (hcons : ERCSet.Consistent E) :
     Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := MChain E
@@ -522,7 +522,7 @@ ranking `r₀` into the block `S` (in `r₀`'s order) followed by `Sᶜ` (in `r�
 order); winner-uniqueness makes every Hasse edge respected, so the result
 satisfies `E` and has `S` as its length-`|S|` prefix. -/
 theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : List (ERC n)}
-    (hcons : ERCSet.consistent E) (hsimple : ERCSet.isSimpleSet E) (S : Finset (Fin n)) :
+    (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (S : Finset (Fin n)) :
     Feasible E S ↔ FeasiblePrefix E S := by
   refine ⟨fun hfeas => ?_, feasible_of_feasiblePrefix⟩
   obtain ⟨r₀, hr₀⟩ := hcons
@@ -592,7 +592,7 @@ theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : List (ERC n)}
 of a locally-feasible `Finset` iff it is `MChain`-feasible. (Bridges the decidable
 `Finset` side to `Antimat`'s `Set`-valued `MChain` family.) -/
 theorem feasible_coe_iff_mChain {n : Nat} {E : List (ERC n)}
-    (hcons : ERCSet.consistent E) (hsimple : ERCSet.isSimpleSet E) (T : Set (Fin n)) :
+    (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (T : Set (Fin n)) :
     (∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S') ↔ MChain E T := by
   constructor
   · rintro ⟨S', rfl, hfeas⟩
@@ -608,8 +608,8 @@ yields an antimatroid on `Fin n` whose feasible sets are the *locally feasible*
 union closure transfer from `Antimat`; concrete membership is checked by `decide`
 via `ofSimple_isFeasible_coe`. This is the order-ideal antimatroid of the
 constraint partial order ([merchant-riggle-2016]). -/
-def Antimat.ofSimple {n : Nat} (E : List (ERC n)) (hcons : ERCSet.consistent E)
-    (hsimple : ERCSet.isSimpleSet E) : Antimatroid (Fin n) where
+def Antimat.ofSimple {n : Nat} (E : List (ERC n)) (hcons : ERCSet.Consistent E)
+    (hsimple : ERCSet.IsSimpleSet E) : Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := fun T => ∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S'
   empty_feasible := (feasible_coe_iff_mChain hcons hsimple ∅).mpr (Antimat E hcons).empty_feasible
@@ -633,7 +633,7 @@ def Antimat.ofSimple {n : Nat} (E : List (ERC n)) (hcons : ERCSet.consistent E)
 /-- Concrete feasibility of `Antimat.ofSimple` is the decidable `Feasible` — the
 hook that lets `decide` settle membership queries. -/
 @[simp] theorem ofSimple_isFeasible_coe {n : Nat} {E : List (ERC n)}
-    (hcons : ERCSet.consistent E) (hsimple : ERCSet.isSimpleSet E) (S : Finset (Fin n)) :
+    (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (S : Finset (Fin n)) :
     (Antimat.ofSimple E hcons hsimple).IsFeasible (↑S : Set (Fin n)) ↔ Feasible E S := by
   constructor
   · rintro ⟨S', hS'eq, hfeas⟩; rwa [Finset.coe_inj.mp hS'eq] at hfeas
@@ -664,8 +664,8 @@ noncomputable def RCErc_single {n : Nat} (A : Antimatroid (Fin n))
     ([merchant-riggle-2016] Theorems 1–2).
 
     Represented as a `Set (ERC n)`; a ranking `r` *satisfies* `RCErc A` when
-    `∀ α ∈ RCErc A, ERC.satisfiedBy r α` — the `Set` analogue of
-    `ERCSet.satisfiedBy`, used to state the isomorphism theorems below. -/
+    `∀ α ∈ RCErc A, ERC.SatisfiedBy r α` — the `Set` analogue of
+    `ERCSet.SatisfiedBy`, used to state the isomorphism theorems below. -/
 noncomputable def RCErc {n : Nat} (A : Antimatroid (Fin n)) : Set (ERC n) :=
   Set.range (RCErc_single A)
 
@@ -699,7 +699,7 @@ theorem RCErc_single_eq_simpleERC {n : Nat} (A : Antimatroid (Fin n))
     Lemmas 7, 9), which is why this direction carries an honest `sorry`. -/
 theorem Antimat_RCErc_inv {n : Nat} (A : Antimatroid (Fin n)) (S : Set (Fin n)) :
     A.IsFeasible S ↔
-      ∃ r : Ranking n, (∀ α ∈ RCErc A, ERC.satisfiedBy r α) ∧
+      ∃ r : Ranking n, (∀ α ∈ RCErc A, ERC.SatisfiedBy r α) ∧
         ∃ k, maximalChain r k = S := by
   -- TODO: [merchant-riggle-2016] Theorem 1 (antimatroid → ERC direction of
   -- the isomorphism). Show A's feasible sets are exactly the maximal chains
@@ -721,9 +721,9 @@ theorem Antimat_RCErc_inv {n : Nat} (A : Antimatroid (Fin n)) (S : Set (Fin n)) 
     [dietrich-1987]'s rooted-circuit characterization (via Lemmas 7, 9), so it
     carries an honest `sorry`. -/
 theorem RCErc_Antimat_inv {n : Nat} (E : List (ERC n))
-    (hcons : ERCSet.consistent E) :
+    (hcons : ERCSet.Consistent E) :
     ∀ r : Ranking n,
-      (∀ α ∈ RCErc (Antimat E hcons), ERC.satisfiedBy r α) ↔ ERCSet.satisfiedBy r E := by
+      (∀ α ∈ RCErc (Antimat E hcons), ERC.SatisfiedBy r α) ↔ ERCSet.SatisfiedBy r E := by
   -- TODO: [merchant-riggle-2016] Theorem 2 (logical-equivalence form). Needs the
   -- rooted-circuit characterization of `Antimat E`'s feasible sets ([dietrich-1987];
   -- [merchant-riggle-2016] Lemmas 7, 9).
@@ -736,8 +736,8 @@ theorem RCErc_Antimat_inv {n : Nat} (E : List (ERC n))
     satisfies `F`), then `Antimat(E) ⊆ Antimat(F)` (every feasible
     set of `Antimat(E)` is also feasible in `Antimat(F)`). -/
 theorem Antimat_entailment {n : Nat} (E F : List (ERC n))
-    (hE : ERCSet.consistent E) (hF : ERCSet.consistent F)
-    (h : ERCSet.entails E F) :
+    (hE : ERCSet.Consistent E) (hF : ERCSet.Consistent F)
+    (h : ERCSet.Entails E F) :
     ∀ S, (Antimat E hE).IsFeasible S → (Antimat F hF).IsFeasible S := by
   intro S ⟨r, hr, k, hk⟩
   exact ⟨r, h r hr, k, hk⟩
@@ -749,8 +749,8 @@ theorem Antimat_entailment {n : Nat} (E F : List (ERC n))
     `B`), then `RCErc(A)` entails `RCErc(B)`. -/
 theorem RCErc_entailment {n : Nat} (A B : Antimatroid (Fin n))
     (h : ∀ S, A.IsFeasible S → B.IsFeasible S) :
-    ∀ r : Ranking n, (∀ α ∈ RCErc A, ERC.satisfiedBy r α) →
-      (∀ α ∈ RCErc B, ERC.satisfiedBy r α) := by
+    ∀ r : Ranking n, (∀ α ∈ RCErc A, ERC.SatisfiedBy r α) →
+      (∀ α ∈ RCErc B, ERC.SatisfiedBy r α) := by
   -- TODO: [merchant-riggle-2016] Theorem 4 (mirror of `Antimat_entailment`).
   -- Feasible-set containment A ⊆ B becomes ERC entailment RCErc A ⊨ RCErc B;
   -- needs the rooted-circuit ↔ feasible-set correspondence of Theorem 1

--- a/Linglib/Phonology/OptimalityTheory/Basic.lean
+++ b/Linglib/Phonology/OptimalityTheory/Basic.lean
@@ -76,7 +76,7 @@ def Tableau.ofRanking (candidates : List C)
     ranking `r : Ranking n`: priority position `p` reads constraint `r p`, so
     coordinate `0` of the lexicographic profile is the most dominant constraint.
     The `Equiv.Perm`-indexed evaluation that the `ElementaryRankingCondition`
-    apparatus (`tableauERC`, `ERC.satisfiedBy`) ranges over. -/
+    apparatus (`tableauERC`, `ERC.SatisfiedBy`) ranges over. -/
 def Tableau.ofPerm (con : CON C n) (r : Ranking n)
     (candidates : List C)
     (h : candidates ≠ [] := by decide) : Tableau C n :=

--- a/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
+++ b/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
@@ -30,7 +30,7 @@ some `W`-constraint ([prince-2002] §0 (3)/(4)).
 * `ERC n` — an ERC over `n` constraints, a sign vector `Fin n → ERCVal`.
 * `Ranking n` — a constraint ranking, a permutation of `Fin n`.
 * `ercOfProfiles` — the sign of a winner/loser violation-profile difference.
-* `ERC.satisfiedBy`, `ERCSet.consistent`, `ERCSet.entails` — the
+* `ERC.SatisfiedBy`, `ERCSet.Consistent`, `ERCSet.Entails` — the
   satisfaction/consistency/entailment algebra.
 * `ERCSet.linearExtensions` — the (decidable) `Finset` of satisfying rankings.
 * `satisfiedBy_ercOfProfiles_iff_le` — the bridge to the Core lex order.
@@ -77,27 +77,27 @@ abbrev ERC (n : ℕ) := Fin n → ERCVal
 
 /-- An ERC is *trivial* if it has no `L`-constraint, so every ranking
 satisfies it. (Prince's "trivial" also includes the all-`L`/no-`W`
-case, captured here by `isContradictory`.) -/
-def ERC.isTrivial (α : ERC n) : Prop := ∀ k, α k ≠ .L
+case, captured here by `IsContradictory`.) -/
+def ERC.IsTrivial (α : ERC n) : Prop := ∀ k, α k ≠ .L
 
-instance (α : ERC n) : Decidable α.isTrivial := Fintype.decidableForallFintype
+instance (α : ERC n) : Decidable α.IsTrivial := Fintype.decidableForallFintype
 
 /-- An ERC is *contradictory* if it has an `L`-constraint but no
 `W`-constraint, so no ranking satisfies it — Prince's class `𝓛⁺`. -/
-def ERC.isContradictory (α : ERC n) : Prop :=
+def ERC.IsContradictory (α : ERC n) : Prop :=
   (∀ k, α k ≠ .W) ∧ (∃ k, α k = .L)
 
-instance (α : ERC n) : Decidable α.isContradictory :=
+instance (α : ERC n) : Decidable α.IsContradictory :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Rankings as permutations -/
 
 /-- Constraint `i` *dominates* constraint `j` under `r`: it sits at a lower
 (more dominant) rank position. -/
-def Ranking.dominates (r : Ranking n) (i j : Fin n) : Prop :=
+def Ranking.Dominates (r : Ranking n) (i j : Fin n) : Prop :=
   r.symm i < r.symm j
 
-instance (r : Ranking n) (i j : Fin n) : Decidable (r.dominates i j) :=
+instance (r : Ranking n) (i j : Fin n) : Decidable (r.Dominates i j) :=
   inferInstanceAs (Decidable (r.symm i < r.symm j))
 
 /-- The identity ranking: rank position equals constraint index. -/
@@ -156,35 +156,35 @@ private theorem ERCVal.zero_lt_iff (x : ERCVal) : 0 < x ↔ x = .W := by revert 
 order, is lexicographically nonnegative — the leading nonzero entry is `W`.
 Equivalently (`satisfiedBy_iff_dominance`, [prince-2002] §0 (3)), every
 `L`-constraint is outranked by some `W`-constraint. -/
-def ERC.satisfiedBy (r : Ranking n) (α : ERC n) : Prop :=
+def ERC.SatisfiedBy (r : Ranking n) (α : ERC n) : Prop :=
   toLex (fun _ : Fin n => (0 : ERCVal)) ≤ toLex (fun p => α (r p))
 
 /-- [prince-2002] §0 (3): satisfaction unfolds to the `∀∃` dominance form — every
 loser-preferring constraint is dominated by some winner-preferring one. -/
 theorem ERC.satisfiedBy_iff_dominance (r : Ranking n) (α : ERC n) :
-    α.satisfiedBy r ↔ ∀ c, α c = .L → ∃ w, α w = .W ∧ r.dominates w c := by
-  unfold ERC.satisfiedBy
+    α.SatisfiedBy r ↔ ∀ c, α c = .L → ∃ w, α w = .W ∧ r.Dominates w c := by
+  unfold ERC.SatisfiedBy
   rw [lex_le_iff_forall]
   constructor
   · intro h c hc
     have hp : α (r (r.symm c)) < 0 := by rw [Equiv.apply_symm_apply, hc]; decide
     obtain ⟨p', hp'lt, hp'pos⟩ := h (r.symm c) hp
     exact ⟨r p', (ERCVal.zero_lt_iff _).mp hp'pos,
-      by unfold Ranking.dominates; rwa [Equiv.symm_apply_apply]⟩
+      by unfold Ranking.Dominates; rwa [Equiv.symm_apply_apply]⟩
   · intro h p hp
     obtain ⟨w, hwW, hwdom⟩ := h (r p) ((ERCVal.lt_zero_iff _).mp hp)
     refine ⟨r.symm w,
-      by unfold Ranking.dominates at hwdom; rwa [Equiv.symm_apply_apply] at hwdom, ?_⟩
+      by unfold Ranking.Dominates at hwdom; rwa [Equiv.symm_apply_apply] at hwdom, ?_⟩
     rw [Equiv.apply_symm_apply, hwW]; decide
 
-instance (r : Ranking n) (α : ERC n) : Decidable (α.satisfiedBy r) :=
+instance (r : Ranking n) (α : ERC n) : Decidable (α.SatisfiedBy r) :=
   decidable_of_iff _ (ERC.satisfiedBy_iff_dominance r α).symm
 
 /-- [prince-2002] §0 (4): the `∀∃` form is equivalent to the `∃∀` form — *some*
 `W`-constraint dominates *every* `L`-constraint — because the ranking is total
 (Prince's footnote 3). Requires a nonempty constraint set. -/
 theorem ERC.satisfiedBy_iff_exists_dominant [NeZero n] (r : Ranking n) (α : ERC n) :
-    α.satisfiedBy r ↔ ∃ d, ∀ c, α c = .L → (α d = .W ∧ r.dominates d c) := by
+    α.SatisfiedBy r ↔ ∃ d, ∀ c, α c = .L → (α d = .W ∧ r.Dominates d c) := by
   rw [ERC.satisfiedBy_iff_dominance]
   constructor
   · intro h
@@ -199,7 +199,7 @@ theorem ERC.satisfiedBy_iff_exists_dominant [NeZero n] (r : Ranking n) (α : ERC
       refine ⟨w, fun c hc => ⟨hwW, ?_⟩⟩
       have hmin : (r.symm cstar : ℕ) ≤ (r.symm c : ℕ) :=
         hcstar_min c (by simp only [Finset.mem_filter, Finset.mem_univ, true_and]; exact hc)
-      unfold Ranking.dominates at hwdom ⊢
+      unfold Ranking.Dominates at hwdom ⊢
       omega
     · simp only [not_exists] at hL
       exact ⟨(0 : Fin n), fun c hc => absurd hc (hL c)⟩
@@ -207,8 +207,8 @@ theorem ERC.satisfiedBy_iff_exists_dominant [NeZero n] (r : Ranking n) (α : ERC
     exact ⟨d, hd c hc⟩
 
 /-- A trivial ERC is satisfied by every ranking. -/
-theorem ERC.trivial_satisfiedBy {α : ERC n} (htriv : α.isTrivial) (r : Ranking n) :
-    α.satisfiedBy r :=
+theorem ERC.trivial_satisfiedBy {α : ERC n} (htriv : α.IsTrivial) (r : Ranking n) :
+    α.SatisfiedBy r :=
   (ERC.satisfiedBy_iff_dominance r α).mpr (fun l hl => absurd hl (htriv l))
 
 /-! ### Sets of ERCs -/
@@ -219,30 +219,30 @@ many rankings; entailment is invariant under reordering and duplication. -/
 abbrev ERCSet (n : ℕ) := List (ERC n)
 
 /-- A ranking satisfies an ERC set iff it satisfies every member. -/
-def ERCSet.satisfiedBy (r : Ranking n) (E : ERCSet n) : Prop :=
-  ∀ α ∈ E, ERC.satisfiedBy r α
+def ERCSet.SatisfiedBy (r : Ranking n) (E : ERCSet n) : Prop :=
+  ∀ α ∈ E, ERC.SatisfiedBy r α
 
-instance (r : Ranking n) (E : ERCSet n) : Decidable (ERCSet.satisfiedBy r E) :=
+instance (r : Ranking n) (E : ERCSet n) : Decidable (ERCSet.SatisfiedBy r E) :=
   List.decidableBAll _ E
 
 /-- An ERC set is *consistent* iff some ranking satisfies all its members. The
 definition searches over all `n!` rankings; for large `n` use ERC fusion. -/
-def ERCSet.consistent (E : ERCSet n) : Prop :=
-  ∃ r : Ranking n, ERCSet.satisfiedBy r E
+def ERCSet.Consistent (E : ERCSet n) : Prop :=
+  ∃ r : Ranking n, ERCSet.SatisfiedBy r E
 
-instance (E : ERCSet n) : Decidable (ERCSet.consistent E) :=
+instance (E : ERCSet n) : Decidable (ERCSet.Consistent E) :=
   Fintype.decidableExistsFintype
 
 /-- The rankings consistent with an ERC set, as a `Finset` — its *linear
 extensions* in the terminology of [merchant-riggle-2016]. Decidable (hence a
-`Finset`) because `satisfiedBy` is. This is the canonical "satisfying rankings"
+`Finset`) because `SatisfiedBy` is. This is the canonical "satisfying rankings"
 object that partial-order grammars reduce to via
 `PartialOrderConstraints.consistentTotalOrders_eq_linearExtensions`. -/
 def ERCSet.linearExtensions (E : ERCSet n) : Finset (Ranking n) :=
-  Finset.univ.filter (fun r => ERCSet.satisfiedBy r E)
+  Finset.univ.filter (fun r => ERCSet.SatisfiedBy r E)
 
 @[simp] theorem ERCSet.mem_linearExtensions {E : ERCSet n} {r : Ranking n} :
-    r ∈ E.linearExtensions ↔ ERCSet.satisfiedBy r E := by
+    r ∈ E.linearExtensions ↔ ERCSet.SatisfiedBy r E := by
   simp [ERCSet.linearExtensions]
 
 /-! ### Entailment -/
@@ -252,25 +252,25 @@ equivalently, the linear extensions of `E` are contained in those of `E'`.
 This is the natural preorder on ERC sets; mutual entailment means the two sets
 describe the same OT grammar. (At the single-coordinate level, entailment is just
 `SignType`'s order `L ≤ e ≤ W`.) -/
-def ERCSet.entails (E E' : ERCSet n) : Prop :=
-  ∀ r : Ranking n, ERCSet.satisfiedBy r E → ERCSet.satisfiedBy r E'
+def ERCSet.Entails (E E' : ERCSet n) : Prop :=
+  ∀ r : Ranking n, ERCSet.SatisfiedBy r E → ERCSet.SatisfiedBy r E'
 
-theorem ERCSet.entails_refl (E : ERCSet n) : ERCSet.entails E E := fun _ h => h
+theorem ERCSet.entails_refl (E : ERCSet n) : ERCSet.Entails E E := fun _ h => h
 
 theorem ERCSet.entails_trans {E₁ E₂ E₃ : ERCSet n}
-    (h₁₂ : ERCSet.entails E₁ E₂) (h₂₃ : ERCSet.entails E₂ E₃) :
-    ERCSet.entails E₁ E₃ := fun r hr => h₂₃ r (h₁₂ r hr)
+    (h₁₂ : ERCSet.Entails E₁ E₂) (h₂₃ : ERCSet.Entails E₂ E₃) :
+    ERCSet.Entails E₁ E₃ := fun r hr => h₂₃ r (h₁₂ r hr)
 
 /-- Adding an ERC strengthens the set: `α :: E` entails `E` (more requirements,
 fewer satisfying rankings). -/
 theorem ERCSet.entails_of_cons (α : ERC n) (E : ERCSet n) :
-    ERCSet.entails (α :: E) E :=
+    ERCSet.Entails (α :: E) E :=
   fun _ hr β hβ => hr β (List.mem_cons_of_mem α hβ)
 
 /-- Pointwise characterization: `E` entails `E'` if it entails each member
 singleton. -/
 theorem ERCSet.entails_of_forall_mem {E E' : ERCSet n}
-    (h : ∀ α ∈ E', ERCSet.entails E [α]) : ERCSet.entails E E' :=
+    (h : ∀ α ∈ E', ERCSet.Entails E [α]) : ERCSet.Entails E E' :=
   fun r hr α hα => h α hα r hr α (List.mem_cons.mpr (Or.inl rfl))
 
 /-! ### Bridge: tableaux and the Core lex order -/
@@ -280,21 +280,21 @@ winner/loser pair iff the winner's profile, read in `r`'s priority order, is
 lex-≤ the loser's ([prince-2002]: an ERC holds of a ranking iff `a ≥ b` holds of
 the candidates). This grounds ERC inference in the Core lex evaluation order. -/
 theorem satisfiedBy_ercOfProfiles_iff_le (r : Ranking n) (w l : ViolationProfile n) :
-    (ercOfProfiles w l).satisfiedBy r ↔
+    (ercOfProfiles w l).SatisfiedBy r ↔
       toLex (fun p => w (r p)) ≤ toLex (fun p => l (r p)) := by
   rw [ERC.satisfiedBy_iff_dominance, lex_le_iff_forall]
   constructor
   · intro h p hp
     obtain ⟨c', hW, hdom⟩ := h (r p) ((ercOfProfiles_eq_L_iff w l (r p)).mpr hp)
     refine ⟨r.symm c',
-      by unfold Ranking.dominates at hdom; rwa [Equiv.symm_apply_apply] at hdom, ?_⟩
+      by unfold Ranking.Dominates at hdom; rwa [Equiv.symm_apply_apply] at hdom, ?_⟩
     have := (ercOfProfiles_eq_W_iff w l c').mp hW
     rwa [Equiv.apply_symm_apply]
   · intro h c hc
     obtain ⟨p', hp'lt, hwin⟩ :=
       h (r.symm c) (by rw [Equiv.apply_symm_apply]; exact (ercOfProfiles_eq_L_iff w l c).mp hc)
     exact ⟨r p', (ercOfProfiles_eq_W_iff w l (r p')).mpr hwin,
-      by unfold Ranking.dominates; rwa [Equiv.symm_apply_apply]⟩
+      by unfold Ranking.Dominates; rwa [Equiv.symm_apply_apply]⟩
 
 /-- The ERC of a winner-loser pair `(w, l)` in tableau `t`: the ranking
 requirements for `w` to beat `l`. Every tableau that selects a winner implicitly
@@ -306,7 +306,7 @@ def tableauERC {C : Type*} [DecidableEq C] (t : Tableau C n) (w l : C) : ERC n :
 ranks the winner at-or-above the loser under the tableau's lex evaluation. -/
 theorem tableauERC_satisfiedBy_iff {C : Type*} [DecidableEq C]
     (t : Tableau C n) (r : Ranking n) (w l : C) :
-    (tableauERC t w l).satisfiedBy r ↔
+    (tableauERC t w l).SatisfiedBy r ↔
       toLex (fun p => t.profile w (r p)) ≤ toLex (fun p => t.profile l (r p)) :=
   satisfiedBy_ercOfProfiles_iff_le r (t.profile w) (t.profile l)
 
@@ -314,7 +314,7 @@ theorem tableauERC_satisfiedBy_iff {C : Type*} [DecidableEq C]
 comparison — connecting ERC inference to `LexMinProblem`. -/
 theorem tableauERC_satisfiedBy_id_iff {C : Type*} [DecidableEq C]
     (t : Tableau C n) (w l : C) :
-    (tableauERC t w l).satisfiedBy (Ranking.id n) ↔ t.profile w ≤ t.profile l := by
+    (tableauERC t w l).SatisfiedBy (Ranking.id n) ↔ t.profile w ≤ t.profile l := by
   rw [tableauERC_satisfiedBy_iff]; exact Iff.rfl
 
 /-- A candidate is the tableau's optimum iff, under the identity ranking, its ERC
@@ -323,7 +323,7 @@ theorem isOptimal_iff_forall_satisfiedBy {C : Type*} [DecidableEq C]
     (t : Tableau C n) (w : C) :
     t.IsOptimal w ↔
       w ∈ t.candidates ∧
-        ∀ l ∈ t.candidates, (tableauERC t w l).satisfiedBy (Ranking.id n) := by
+        ∀ l ∈ t.candidates, (tableauERC t w l).SatisfiedBy (Ranking.id n) := by
   constructor
   · rintro ⟨hmem, hmin⟩
     exact ⟨hmem, fun l hl => (tableauERC_satisfiedBy_id_iff t w l).mpr (hmin l hl)⟩
@@ -342,7 +342,7 @@ theorem Tableau.ofPerm_isOptimal_iff_satisfiedBy {C : Type*} [DecidableEq C] {n 
     (Tableau.ofPerm con r candidates h).IsOptimal w ↔
       w ∈ candidates.toFinset ∧
         ∀ l ∈ candidates.toFinset,
-          (tableauERC (Tableau.ofPerm con (Equiv.refl _) candidates h) w l).satisfiedBy r := by
+          (tableauERC (Tableau.ofPerm con (Equiv.refl _) candidates h) w l).SatisfiedBy r := by
   constructor
   · rintro ⟨hmem, hmin⟩
     exact ⟨hmem, fun l hl => (tableauERC_satisfiedBy_iff _ r w l).mpr (hmin l hl)⟩
@@ -355,13 +355,13 @@ theorem Tableau.ofPerm_isOptimal_iff_satisfiedBy {C : Type*} [DecidableEq C] {n 
 requirement `i ≫ j`. Simple ERCs are the Hasse edges of the ranking partial
 order; sets of them describe exactly the rankings representable as partial
 orders ([merchant-riggle-2016]). -/
-def ERC.isSimple (α : ERC n) : Prop :=
+def ERC.IsSimple (α : ERC n) : Prop :=
   (∃! w, α w = .W) ∧ (∃! l, α l = .L)
 
 /-- An ERC set is *simple* if every member is a simple ERC: a set of Hasse edges,
 which therefore describes a partial order on the constraints rather than a general
 antimatroid ([merchant-riggle-2016]). -/
-def ERCSet.isSimpleSet (E : ERCSet n) : Prop := ∀ α ∈ E, α.isSimple
+def ERCSet.IsSimpleSet (E : ERCSet n) : Prop := ∀ α ∈ E, α.IsSimple
 
 /-- The simple ERC asserting constraint `i` must dominate constraint `j`; all
 other constraints are `e`. -/
@@ -387,7 +387,7 @@ theorem simpleERC_apply_L {i j : Fin n} (hij : i ≠ j) : simpleERC i j j = .L :
 /-- A simple ERC `i ≫ j` (with `i ≠ j`) is satisfied by `r` iff `i` dominates
 `j` under `r`. -/
 theorem simpleERC_satisfiedBy_iff {i j : Fin n} (hij : i ≠ j) (r : Ranking n) :
-    (simpleERC i j).satisfiedBy r ↔ r.dominates i j := by
+    (simpleERC i j).SatisfiedBy r ↔ r.Dominates i j := by
   rw [ERC.satisfiedBy_iff_dominance]
   constructor
   · intro h
@@ -400,7 +400,7 @@ theorem simpleERC_satisfiedBy_iff {i j : Fin n} (hij : i ≠ j) (r : Ranking n) 
 /-- A simple ERC `i ≫ j` (with `i ≠ j`) is consistent: the identity ranking
 witnesses it when `i < j`, and the transposition `(i, j)` otherwise. -/
 theorem simpleERC_consistent {i j : Fin n} (hij : i ≠ j) :
-    ERCSet.consistent [simpleERC i j] := by
+    ERCSet.Consistent [simpleERC i j] := by
   by_cases hlt : i.val < j.val
   · refine ⟨Ranking.id n, fun α hα => ?_⟩
     rw [List.mem_singleton.mp hα]
@@ -418,7 +418,7 @@ theorem simpleERC_consistent {i j : Fin n} (hij : i ≠ j) :
 
 /-- `simpleERC i j` (with `i ≠ j`) is a simple ERC: its unique `W` is `i` and its
 unique `L` is `j`. -/
-theorem simpleERC_isSimple {i j : Fin n} (hij : i ≠ j) : (simpleERC i j).isSimple :=
+theorem simpleERC_isSimple {i j : Fin n} (hij : i ≠ j) : (simpleERC i j).IsSimple :=
   ⟨⟨i, simpleERC_apply_W, fun y hy => (simpleERC_eq_W_iff y).mp hy⟩,
    ⟨j, simpleERC_apply_L hij, fun y hy => (simpleERC_eq_L_iff hij y).mp hy⟩⟩
 

--- a/Linglib/Phonology/OptimalityTheory/Grammar.lean
+++ b/Linglib/Phonology/OptimalityTheory/Grammar.lean
@@ -79,16 +79,16 @@ Grammars are exactly the closed sets `models (conditions R)`, the *extents* of
 this context. -/
 
 /-- The rankings satisfying every condition in `A` (the extent polarity). -/
-def models (A : Set (ERC n)) : Set (Ranking n) := {r | ∀ α ∈ A, ERC.satisfiedBy r α}
+def models (A : Set (ERC n)) : Set (Ranking n) := {r | ∀ α ∈ A, ERC.SatisfiedBy r α}
 
 /-- The conditions satisfied by every ranking in `R` (the intent polarity). -/
-def conditions (R : Set (Ranking n)) : Set (ERC n) := {α | ∀ r ∈ R, ERC.satisfiedBy r α}
+def conditions (R : Set (Ranking n)) : Set (ERC n) := {α | ∀ r ∈ R, ERC.SatisfiedBy r α}
 
 @[simp] theorem mem_models {A : Set (ERC n)} {r : Ranking n} :
-    r ∈ models A ↔ ∀ α ∈ A, ERC.satisfiedBy r α := Iff.rfl
+    r ∈ models A ↔ ∀ α ∈ A, ERC.SatisfiedBy r α := Iff.rfl
 
 @[simp] theorem mem_conditions {R : Set (Ranking n)} {α : ERC n} :
-    α ∈ conditions R ↔ ∀ r ∈ R, ERC.satisfiedBy r α := Iff.rfl
+    α ∈ conditions R ↔ ∀ r ∈ R, ERC.SatisfiedBy r α := Iff.rfl
 
 /-- **The grammar–condition Galois connection.** `R ⊆ models A ↔ A ⊆ conditions R`:
 both sides say every ranking in `R` satisfies every condition in `A`. -/
@@ -174,7 +174,7 @@ theorem coe_linearExtensions_eq_models (E : ERCSet n) :
 of `Ord(S.Con)`. This is the trivial grammar (no ranking conditions). -/
 @[simp] theorem ERCSet.linearExtensions_nil :
     ERCSet.linearExtensions ([] : ERCSet n) = Finset.univ := by
-  ext r; simp [ERCSet.mem_linearExtensions, ERCSet.satisfiedBy]
+  ext r; simp [ERCSet.mem_linearExtensions, ERCSet.SatisfiedBy]
 
 /-- An OT **grammar**: a set of rankings realizable as the linear extensions of
 some consistent ERC set ([merchant-riggle-2016]). The leg set is the grammar's
@@ -183,7 +183,7 @@ structure Grammar (n : ℕ) where
   /-- The grammar's legs: the rankings that select its language's optima. -/
   legs : Finset (Ranking n)
   /-- Every grammar is the linear-extension set of some consistent ERC set. -/
-  realizable : ∃ E : ERCSet n, ERCSet.consistent E ∧ legs = E.linearExtensions
+  realizable : ∃ E : ERCSet n, ERCSet.Consistent E ∧ legs = E.linearExtensions
 
 namespace Grammar
 
@@ -193,11 +193,11 @@ so leg-set equality is grammar equality. -/
   cases G; cases G'; cases h; rfl
 
 /-- The grammar of a consistent ERC set — the ERC face, as a constructor. -/
-def ofERCSet (E : ERCSet n) (hcons : ERCSet.consistent E) : Grammar n where
+def ofERCSet (E : ERCSet n) (hcons : ERCSet.Consistent E) : Grammar n where
   legs := E.linearExtensions
   realizable := ⟨E, hcons, rfl⟩
 
-@[simp] theorem legs_ofERCSet (E : ERCSet n) (hcons : ERCSet.consistent E) :
+@[simp] theorem legs_ofERCSet (E : ERCSet n) (hcons : ERCSet.Consistent E) :
     (ofERCSet E hcons).legs = E.linearExtensions := rfl
 
 /-- Membership: `r ∈ G` means `r` is one of `G`'s legs. -/
@@ -206,8 +206,8 @@ instance : Membership (Ranking n) (Grammar n) where
 
 @[simp] theorem mem_iff {G : Grammar n} {r : Ranking n} : r ∈ G ↔ r ∈ G.legs := Iff.rfl
 
-@[simp] theorem mem_ofERCSet {E : ERCSet n} {hcons : ERCSet.consistent E} {r : Ranking n} :
-    r ∈ ofERCSet E hcons ↔ ERCSet.satisfiedBy r E := by
+@[simp] theorem mem_ofERCSet {E : ERCSet n} {hcons : ERCSet.Consistent E} {r : Ranking n} :
+    r ∈ ofERCSet E hcons ↔ ERCSet.SatisfiedBy r E := by
   simp [mem_iff, ofERCSet]
 
 /-- A grammar has at least one leg: a harmonically-bounded row gives no grammar
@@ -225,8 +225,8 @@ same legs. This is why the leg set, not the ERC set, is the grammar's identity:
 the "logically equivalent, not literally equal" hedge of the ERC presentation
 ([merchant-riggle-2016] Theorem 2) becomes literal `Grammar` equality. -/
 theorem ofERCSet_eq_iff_entails {E E' : ERCSet n}
-    (h : ERCSet.consistent E) (h' : ERCSet.consistent E') :
-    ofERCSet E h = ofERCSet E' h' ↔ ERCSet.entails E E' ∧ ERCSet.entails E' E := by
+    (h : ERCSet.Consistent E) (h' : ERCSet.Consistent E') :
+    ofERCSet E h = ofERCSet E' h' ↔ ERCSet.Entails E E' ∧ ERCSet.Entails E' E := by
   constructor
   · intro he
     have hl : E.linearExtensions = E'.linearExtensions := congrArg Grammar.legs he
@@ -248,7 +248,7 @@ def feasible (G : Grammar n) (S : Set (Fin n)) : Prop :=
 
 /-- The feasible family of `ofERCSet E` is exactly `MChain E`: the antimatroid face
 agrees with [merchant-riggle-2016]'s `Antimat E` construction. -/
-theorem feasible_ofERCSet (E : ERCSet n) (hcons : ERCSet.consistent E) (S : Set (Fin n)) :
+theorem feasible_ofERCSet (E : ERCSet n) (hcons : ERCSet.Consistent E) (S : Set (Fin n)) :
     (ofERCSet E hcons).feasible S ↔ MChain E S := by
   simp only [feasible, legs_ofERCSet, ERCSet.mem_linearExtensions, MChain]
 
@@ -288,7 +288,7 @@ def toAntimatroid (G : Grammar n) : Antimatroid (Fin n) where
     G.toAntimatroid.IsFeasible S ↔ G.feasible S := Iff.rfl
 
 /-- The antimatroid face of `ofERCSet E` has the same feasible sets as `Antimat E`. -/
-theorem toAntimatroid_ofERCSet_isFeasible (E : ERCSet n) (hcons : ERCSet.consistent E)
+theorem toAntimatroid_ofERCSet_isFeasible (E : ERCSet n) (hcons : ERCSet.Consistent E)
     (S : Set (Fin n)) :
     (ofERCSet E hcons).toAntimatroid.IsFeasible S ↔ (Antimat E hcons).IsFeasible S := by
   rw [toAntimatroid_isFeasible, feasible_ofERCSet]
@@ -315,7 +315,7 @@ theorem exists_grammar_of_isGrammarClosed {R : Set (Ranking n)}
     ext α; simp [Set.Finite.mem_toFinset, Finset.mem_toList]
   have hReq : (↑E.linearExtensions : Set (Ranking n)) = R := by
     rw [coe_linearExtensions_eq_models, hAeq]; exact hcl
-  have hcons : ERCSet.consistent E := by
+  have hcons : ERCSet.Consistent E := by
     obtain ⟨r, hr⟩ := hne
     have hmem : r ∈ (↑E.linearExtensions : Set (Ranking n)) := hReq ▸ hr
     rw [Finset.mem_coe, ERCSet.mem_linearExtensions] at hmem
@@ -345,8 +345,8 @@ theorem le_iff_legs {G G' : Grammar n} : G ≤ G' ↔ G.legs ⊆ G'.legs := Iff.
 /-- The specificity order on grammars **is** the entailment order on their ERC sets
 — the order side of the grammar–condition Galois adjunction. -/
 theorem ofERCSet_le_iff_entails {E E' : ERCSet n}
-    (h : ERCSet.consistent E) (h' : ERCSet.consistent E') :
-    ofERCSet E h ≤ ofERCSet E' h' ↔ ERCSet.entails E E' := by
+    (h : ERCSet.Consistent E) (h' : ERCSet.Consistent E') :
+    ofERCSet E h ≤ ofERCSet E' h' ↔ ERCSet.Entails E E' := by
   rw [le_iff_legs]
   constructor
   · intro hle r hr
@@ -356,7 +356,7 @@ theorem ofERCSet_le_iff_entails {E E' : ERCSet n}
 
 /-- The **trivial grammar** — the terminal object of the specificity order: all
 rankings, no ranking conditions (`ofERCSet []`). -/
-def trivial : Grammar n := ofERCSet [] ⟨Ranking.id n, by simp [ERCSet.satisfiedBy]⟩
+def trivial : Grammar n := ofERCSet [] ⟨Ranking.id n, by simp [ERCSet.SatisfiedBy]⟩
 
 @[simp] theorem legs_trivial : (Grammar.trivial : Grammar n).legs = Finset.univ := by
   simp only [Grammar.trivial, legs_ofERCSet, ERCSet.linearExtensions_nil]

--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -67,7 +67,9 @@ example : IsFoot (.node .ft [.node (.syl 2) []]) := by decide
     (the stressed daughter, the head). The `Fin` index forces non-emptiness by construction.
     The inventory and headedness are derived below, not stored. -/
 structure Foot (S : Type*) where
+  /-- The dominated syllable positions, left to right. -/
   syllables : List S
+  /-- The distinguished (stressed) daughter; the `Fin` index forces non-emptiness. -/
   head      : Fin syllables.length
   deriving DecidableEq, Repr
 

--- a/Linglib/Phonology/Prosody/Grid.lean
+++ b/Linglib/Phonology/Prosody/Grid.lean
@@ -33,12 +33,12 @@ a homomorphism from the tree into the head-marked grid, built from a small algeb
 * `Marks` / `Marks.IsContinuous` / `Grid.rows` — the rendered grid and the Continuous Column
   Constraint, which holds for any rendered grid by construction.
 * `MarkedGrid` / `Grid.project` — the head-marked grid and the RPPR projection from a tree.
-* `Grid.columns` / `Grid.headTerminals` / `Grid.headHeights` / `Grid.IsHeaded` — the grid readers.
+* `Tree.columns` / `Tree.headTerminals` / `Tree.headHeights` / `Tree.IsHeaded` — the grid readers.
 
 ## Main results
 * `Grid.ofTree_isContinuous` — the Continuous Column Constraint, by construction (free).
 * `Grid.peak_toProsTree` — head-preservation for a foot (its grid peaks at the head σ).
-* `Grid.headHeights_eq_peak` — on a non-recursive headed word the head terminal's height is the
+* `Tree.headHeights_eq_peak` — on a non-recursive headed word the head terminal's height is the
   grid peak: metrical primary stress is the tallest column.
 * `Grid.ofTree_not_injective` / `Grid.not_culminative_under_recursion` — what the projection
   forgets: constituency, and order-invariant culminativity under recursion.
@@ -211,7 +211,11 @@ theorem rows_isContinuous (g : Grid) : Marks.IsContinuous (rows g) := by
 
 /-! ### The RPPR projection -/
 
-open MarkedGrid
+end Grid
+
+namespace Tree
+
+open MarkedGrid Grid
 
 /-- One RPPR step: pair the node's label with its grid, so a parent can read the
     head flag off each child. -/
@@ -260,11 +264,12 @@ def IsHeaded : Prop := (headHeights t).length = 1
 instance : Decidable (IsHeaded t) := by unfold IsHeaded; infer_instance
 
 /-- The metrical grid of a tree, as stacked rows. -/
-def ofTree : Marks := (columns t).rows
+def _root_.Prosody.Grid.ofTree : Marks := (columns t).rows
 
-/-- `ofTree` always satisfies the Continuous Column Constraint ([prince-1983]; [hayes-1995]) — free
-    from `Grid.rows_isContinuous`, since a projected grid is a histogram. -/
-theorem ofTree_isContinuous : Marks.IsContinuous (ofTree t) := rows_isContinuous _
+/-- `Grid.ofTree` always satisfies the Continuous Column Constraint ([prince-1983];
+    [hayes-1995]) — free from `Grid.rows_isContinuous`: a projected grid is a histogram. -/
+theorem _root_.Prosody.Grid.ofTree_isContinuous : Marks.IsContinuous (Grid.ofTree t) :=
+  rows_isContinuous _
 
 /-! ### The reader recursions
 
@@ -342,7 +347,7 @@ recursion, order-invariant culminativity (`not_culminative_under_recursion`). -/
 
 /-- The grid render is not injective — it **forgets constituency**: a σ parsed under a foot and the
     same σ left bare render to the same grid ([hayes-1995] §3.8). -/
-theorem ofTree_not_injective : ¬ Function.Injective ofTree :=
+theorem _root_.Prosody.Grid.ofTree_not_injective : ¬ Function.Injective Grid.ofTree :=
   Function.not_injective_iff.mpr
     ⟨.om [.ft false [.σ 1]], .om [.σ 1], by decide⟩
 
@@ -480,6 +485,6 @@ theorem head_below_peak_unlayered :
     ∃ t, IsHeaded t ∧ noRec t = 0 ∧ ¬ IsWord t ∧ headHeights t ≠ [peak (columns t)] :=
   ⟨.om [.ph [.ft true [.σ 1 true]], .σ 1 true], by decide⟩
 
-end Grid
+end Tree
 
 end Prosody

--- a/Linglib/Phonology/Prosody/Mora.lean
+++ b/Linglib/Phonology/Prosody/Mora.lean
@@ -31,6 +31,7 @@ open Phonology (Segment)
     the μ node survives). A long vowel is two morae dominating the same melody;
     a non-moraic coda rides on the preceding mora's `dominates`. -/
 structure Mora where
+  /-- The melody this μ node dominates; `[]` is a stranded/floating mora. -/
   dominates : List Segment
   deriving DecidableEq
 

--- a/Linglib/Phonology/Prosody/Syllable.lean
+++ b/Linglib/Phonology/Prosody/Syllable.lean
@@ -40,8 +40,11 @@ open Phonology (Segment)
     mora (the sonority peak; mandatory, so σ has ≥1 mora and the head is initial by
     construction), and a `tail` of further morae (long-vowel morae + a moraic coda). -/
 structure Syllable where
+  /-- The non-moraic onset melody. -/
   onset : List Segment
+  /-- The nucleus mora — the sonority peak; mandatory, so σ has ≥ 1 mora. -/
   head  : Mora
+  /-- Further morae: long-vowel morae and a moraic coda. -/
   tail  : List Mora
   deriving DecidableEq
 
@@ -203,7 +206,9 @@ end Syllable
 /-- The onset-rime structure ([selkirk-1982]): a rival theory of σ structure, an onset
     over a rime. Here a re-representation of the canonical moraic `Syllable`. -/
 structure OnsetRime where
+  /-- The non-moraic onset melody. -/
   onset : List Segment
+  /-- The rime: the moraic spine. -/
   rime  : List Mora
   deriving DecidableEq
 

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -61,7 +61,7 @@ inductive Feature where
   | front            -- tongue body fronted
   | back             -- tongue body backed
   | tense            -- tense vowel quality
-  deriving DecidableEq, Repr, Fintype
+  deriving DecidableEq, Repr
 
 namespace Feature
 
@@ -95,7 +95,7 @@ abbrev IsPlace : Prop := f.category = .labial ∨ f.category = .coronal ∨ f.ca
 
 /-! ### Enumeration -/
 
-/-- All 26 features in declaration order. -/
+/-- All features, in declaration order. -/
 def allFeatures : List Feature :=
   [.syllabic, .consonantal, .sonorant, .approximant,
    .continuant, .delayedRelease, .nasal, .lateral, .strident, .tap, .trill,
@@ -104,10 +104,11 @@ def allFeatures : List Feature :=
    .coronal, .anterior, .distributed,
    .dorsal, .high, .low, .front, .back, .tense]
 
-theorem allFeatures_length : allFeatures.length = 26 := rfl
-
-/-- Every feature appears in `allFeatures`. -/
-theorem allFeatures_complete : f ∈ allFeatures := by cases f <;> simp [allFeatures]
+/-- `allFeatures` is the canonical enumeration: completeness is the `Fintype` law,
+not a theorem re-proved beside it. -/
+instance : Fintype Feature where
+  elems := ⟨allFeatures, by decide⟩
+  complete f := by cases f <;> decide
 
 end Feature
 

--- a/Linglib/Phonology/Subregular/Harmony.lean
+++ b/Linglib/Phonology/Subregular/Harmony.lean
@@ -265,14 +265,6 @@ theorem spreadSuffix_length (sys : System) (val : Bool)
     · rfl
     · simp [ih]
 
-/-- Helper: `takeWhile p l = l` when `p` holds for all elements. -/
-private theorem takeWhile_all {l : List Segment} {p : Segment → Bool}
-    (h : ∀ s ∈ l, p s = true) : l.takeWhile p = l := by
-  induction l with
-  | nil => rfl
-  | cons a t ih =>
-    simp [h a (.head _), ih (fun s hs => h s (.tail _ hs))]
-
 /-- The harmony domain is the full stem when there are no blockers. -/
 theorem harmonyDomain_no_blockers (sys : System) (stem : List Segment)
     (h : ∀ s ∈ stem, ¬ sys.isBlocker s) :
@@ -283,8 +275,8 @@ theorem harmonyDomain_no_blockers (sys : System) (stem : List Segment)
   have hrev : ∀ s ∈ stem.reverse, (!decide (sys.isBlocker s)) = true :=
     fun s hs => hpred s (List.mem_reverse.mp hs)
   split
-  · rw [takeWhile_all hrev, List.reverse_reverse]
-  · exact takeWhile_all hpred
+  · rw [List.takeWhile_eq_self_iff.mpr hrev, List.reverse_reverse]
+  · exact List.takeWhile_eq_self_iff.mpr hpred
 
 /-- Blockers in the suffix halt spreading: segments at and after the first
     blocker are returned unchanged. -/

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -87,30 +87,29 @@ def Relation.flip : Relation → Relation
     Lean. -/
 abbrev Side := Subregular.Direction
 
-/-- A tier-based alternation rule over alphabet `α`.
-
-    - `tier`         : the erasing projection ([goldsmith-1976]) onto
-      which the context-class check is performed.
-    - `side`         : whether the triggering context precedes (`.left`)
-      or follows (`.right`) the unspecified target slot.
-    - `targetIsContext` : the natural class `C` — the rule fires only when
-      the tier-adjacent segment satisfies this predicate. Following
-      mathlib's `Finset.filter` convention this is `Prop`-valued with
-      `[DecidablePred]` carried as the instance field `decTarget`.
-    - `relation`     : `.agree` (assimilation) or `.disagree` (dissimilation).
-    - `featureValue` : the value of `F` extracted from a context segment.
-      `none` means the segment is itself underspecified for `F`, in which
-      case the rule defers to `default`.
-    - `default`      : the Elsewhere value ([belth-2026]'s default
-      fallback). `none` means *no* default — when no context is found,
-      `applyAt` returns `none`. `some v` is the concrete fallback. -/
+/-- A tier-based alternation rule over alphabet `α`: project the word onto a tier,
+    find the adjacent context segment on `side`, and fill the target's feature by
+    `relation` to it, falling back to `default`. -/
 structure TierRule (α : Type) where
+  /-- The erasing projection ([goldsmith-1976]) onto which the context-class check is
+      performed. -/
   tier : TierProjection α α
+  /-- Whether the triggering context precedes (`.left`) or follows (`.right`) the
+      unspecified target slot. -/
   side : Side := .left
+  /-- The natural class `C`: the rule fires only when the tier-adjacent segment
+      satisfies this predicate. -/
   targetIsContext : α → Prop
+  /-- Decidability of the context class, carried as an instance field (mathlib's
+      `Finset.filter` convention). -/
   [decTarget : DecidablePred targetIsContext]
+  /-- `.agree` (assimilation) or `.disagree` (dissimilation). -/
   relation : Relation
+  /-- The value of the alternating feature extracted from a context segment; `none`
+      means the segment is itself underspecified, deferring to `default`. -/
   featureValue : α → Option Bool
+  /-- The Elsewhere value ([belth-2026]'s default fallback): `some v` is the concrete
+      fallback when no context is found, `none` makes `applyAt` return `none`. -/
   default : Option Bool := none
 
 namespace TierRule

--- a/Linglib/Studies/BeckerEtAl2025.lean
+++ b/Linglib/Studies/BeckerEtAl2025.lean
@@ -10,7 +10,7 @@ reversal**: when an iamb would leave a phrase-final long vowel, the last two syl
 trochee instead ([becker-etal-2025] §3.1; [hayes-1995] §5.3b). The **last foot is the head foot**
 of the word, and the **primary stress is the head of the head foot** ([becker-etal-2025] p. 2365)
 — i.e. the syllable reached from the word ω by an all-head descent: the **head terminal**
-(Liberman & Prince's *head terminal*, `Prosody.Grid.headTerminals`).
+(Liberman & Prince's *head terminal*, `Prosody.Tree.headTerminals`).
 
 The paper's title result — *incoherent* stress ([gordon-2016]) — is that the default High tone does
 **not** dock on this head terminal but surfaces displaced, on the last syllable of a tone domain
@@ -20,7 +20,7 @@ The metrically most prominent syllable is thereby dissociated from the high-tone
 This file formalizes the **default-length metrical spine** the tonal analysis is anchored to: the
 left-to-right iambic footing (with final trochaic reversal) of words in isolation, and the
 certification that the primary stress is exactly the grid's head terminal. That a word has a
-*unique* head terminal (`Prosody.Grid.IsHeaded`) is metrical culminativity — head-terminal
+*unique* head terminal (`Prosody.Tree.IsHeaded`) is metrical culminativity — head-terminal
 uniqueness ([hyman-2006]). The paper's `Culminativity-H` (§4.2) is a *distinct, tonal* constraint
 ("one violation per High tone domain with more than one foot head"), part of the deferred tone
 layer. Also deferred alongside tone: lexical long vowels (Max-μ, monosyllabic feet, §3.1), word
@@ -63,38 +63,38 @@ def annatto : Tree :=
 
 /-! ### The grid: secondary stress on every foot head, primary on the head foot's
 
-Reading `Grid.columns ∘` the footing recovers the stress profile: `1` unstressed, `2` a secondary
+Reading `Tree.columns ∘` the footing recovers the stress profile: `1` unstressed, `2` a secondary
 (a non-head foot's head), `3` the primary (the head foot's head). -/
 
-theorem gridColumns_fell    : Grid.columns fell    = [1, 2, 1, 3, 1] := by decide
-theorem gridColumns_weFell  : Grid.columns weFell  = [1, 2, 1, 2, 3, 1] := by decide
-theorem gridColumns_annatto : Grid.columns annatto = [1, 3, 1] := by decide
+theorem gridColumns_fell    : Tree.columns fell    = [1, 2, 1, 3, 1] := by decide
+theorem gridColumns_weFell  : Tree.columns weFell  = [1, 2, 1, 2, 3, 1] := by decide
+theorem gridColumns_annatto : Tree.columns annatto = [1, 3, 1] := by decide
 
 /-! ### Primary stress is the head terminal ([becker-etal-2025] p. 2365)
 
-Each word has a **unique head terminal** (`Grid.IsHeaded` — metrical culminativity, Liberman & Prince's
+Each word has a **unique head terminal** (`Tree.IsHeaded` — metrical culminativity, Liberman & Prince's
 head-terminal uniqueness; cf. [hyman-2006]), and it is exactly the head syllable of the head foot — the long
 `kí:`/`mí:`, or the reversed-trochee's initial `kí`. The primary stress is read off the grid's live
 column as an *element*. -/
 
-theorem isHeaded_fell    : Grid.IsHeaded fell    := by decide
-theorem isHeaded_weFell  : Grid.IsHeaded weFell  := by decide
-theorem isHeaded_annatto : Grid.IsHeaded annatto := by decide
+theorem isHeaded_fell    : Tree.IsHeaded fell    := by decide
+theorem isHeaded_weFell  : Tree.IsHeaded weFell  := by decide
+theorem isHeaded_annatto : Tree.IsHeaded annatto := by decide
 
 /-- 's/he fell': the head terminal is the long `kí:` (head of the rightmost iamb). -/
-theorem headTerminals_fell : Grid.headTerminals fell = [.σ 2 true] := by decide
+theorem headTerminals_fell : Tree.headTerminals fell = [.σ 2 true] := by decide
 
 /-- 'we fell': the head terminal is the reversed trochee's initial short `kí`. -/
-theorem headTerminals_weFell : Grid.headTerminals weFell = [.σ 1 true] := by decide
+theorem headTerminals_weFell : Tree.headTerminals weFell = [.σ 1 true] := by decide
 
 /-- 'annatto': the head terminal is the long `mí:`. -/
-theorem headTerminals_annatto : Grid.headTerminals annatto = [.σ 2 true] := by decide
+theorem headTerminals_annatto : Tree.headTerminals annatto = [.σ 2 true] := by decide
 
 /-- The same fact **declaratively** ([liberman-prince-1977]): `kí:` is the head terminal of `fell`
-    — reached from ω by an all-head descent (ω → head foot → head σ), `Grid.IsHeadTerminal` — lifted
-    from the computed list by `Grid.headTerminal_sound`, not just by computing the list. -/
-theorem isHeadTerminal_fell : Grid.IsHeadTerminal fell (.σ 2 true) :=
-  Grid.headTerminal_sound (by decide)
+    — reached from ω by an all-head descent (ω → head foot → head σ), `Tree.IsHeadTerminal` — lifted
+    from the computed list by `Tree.headTerminal_sound`, not just by computing the list. -/
+theorem isHeadTerminal_fell : Tree.IsHeadTerminal fell (.σ 2 true) :=
+  Tree.headTerminal_sound (by decide)
 
 /-! ### The trochaic reversal is OT-optimal ([becker-etal-2025] §3.1, Table 2)
 
@@ -134,7 +134,7 @@ def cIamb : Constraint FootingCand := fun c => match c.toTree with
 /-- **`*V:]φ`** ([becker-etal-2025] (3)): one mark for a long vowel in the **phrase**-final σ (for a
     one-word phrase, the word-final σ). -/
 def cStarV : Constraint FootingCand := fun c =>
-  match (Grid.terminals c.toTree).getLast? with
+  match (Tree.terminals c.toTree).getLast? with
   | some leaf => if decide (leaf.value.weight? = some 2) then 1 else 0
   | none      => 0
 

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -486,11 +486,11 @@ theorem popularisERC_is_simple :
 theorem pluvalisERC_is_simple :
     pluvalisERC = simpleERC (n := 2) 0 1 := by decide
 
-theorem navalisERC_isTrivial : navalisERC.isTrivial := by decide
-theorem floralisERC_isTrivial : floralisERC.isTrivial := by decide
-theorem legalisERC_isTrivial : legalisERC.isTrivial := by decide
+theorem navalisERC_isTrivial : navalisERC.IsTrivial := by decide
+theorem floralisERC_isTrivial : floralisERC.IsTrivial := by decide
+theorem legalisERC_isTrivial : legalisERC.IsTrivial := by decide
 
-theorem lunarisERC_isContradictory : lunarisERC.isContradictory := by decide
+theorem lunarisERC_isContradictory : lunarisERC.IsContradictory := by decide
 
 /-- The five non-lunaris contrasts form a **consistent** ERC set: the
     identity ranking (OCP at position 0, \*r at position 1) satisfies
@@ -498,19 +498,19 @@ theorem lunarisERC_isContradictory : lunarisERC.isContradictory := by decide
     pluvalis) both reduce to `simpleERC 0 1`; the other three are
     trivial. -/
 theorem latinERCSet_consistent_without_lunaris :
-    ERCSet.consistent
+    ERCSet.Consistent
       [popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC] :=
   ⟨Ranking.id 2, by decide⟩
 
 /-- Bridge to the dominance characterisation: under any ranking
     satisfying the empirical ERC set (sans lunaris), OCP dominates \*r. -/
 theorem latin_OCP_dominates_starR (r : Ranking 2)
-    (hr : ERCSet.satisfiedBy r
+    (hr : ERCSet.SatisfiedBy r
       [popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC]) :
-    r.dominates 0 1 := by
-  have hpop : popularisERC.satisfiedBy r :=
+    r.Dominates 0 1 := by
+  have hpop : popularisERC.SatisfiedBy r :=
     hr popularisERC (List.mem_cons.mpr (Or.inl rfl))
-  have : (simpleERC (n := 2) 0 1).satisfiedBy r := by
+  have : (simpleERC (n := 2) 0 1).SatisfiedBy r := by
     rw [← popularisERC_is_simple]; exact hpop
   exact (simpleERC_satisfiedBy_iff (by decide) r).mp this
 

--- a/Linglib/Studies/Hayes1995.lean
+++ b/Linglib/Studies/Hayes1995.lean
@@ -13,7 +13,7 @@ foot — independently supported by the absence of CV(C) content words in the la
 (unfooted).
 
 `parse` is that algorithm on the weight string; reading the stress off the result with the
-metrical grid (`Prosody.Grid.columns`) recovers the attested prominences — primary `3`,
+metrical grid (`Prosody.Tree.columns`) recovers the attested prominences — primary `3`,
 secondary `2`, unstressed `1`. Quantity moves the peak: all-light `kataba` is stressed on the
 **antepenult**, but a heavy penult (`mudarris`) draws stress to the **penult**. (The forms
 `kataba` and `ʔinkasara` are Cairene *Classical*; [hayes-1995] shows these take the same
@@ -76,7 +76,7 @@ def parse (y : Yield) : Tree := .om (markHeadFoot (parseCells y))
 /-! ### Quantity-sensitive stress
 
 The forms are [hayes-1995]'s, given as their post-extrametricality weight profiles
-(`1` = light CV, `2` = heavy CVC/CVV). Reading `Grid.columns ∘ parse` recovers the attested
+(`1` = light CV, `2` = heavy CVC/CVV). Reading `Tree.columns ∘ parse` recovers the attested
 stress: the column of `3` is the primary, `2` a secondary, `1` unstressed. -/
 
 /-- *kataba* `ka.ta.ba` 'he wrote' — all light (Cairene Classical). -/
@@ -88,23 +88,23 @@ def Pinkasara : Yield := [2, 1, 1, 1]
 
 /-- **Antepenultimate stress** ([hayes-1995] (15d), (16d)): all-light `kataba` parses as
     `(ká.ta)ba`, the rightmost foot heading the antepenult; the final light is stray. -/
-theorem gridColumns_kataba : Grid.columns (parse kataba) = [3, 1, 1] := by decide
+theorem gridColumns_kataba : Tree.columns (parse kataba) = [3, 1, 1] := by decide
 
 /-- **Penultimate stress** ([hayes-1995] (12b), (15b)): with a heavy penult, `mudarris` parses
     as `mu(dár)ri` — the heavy is its own foot, rightmost, so quantity pulls the peak one
     syllable rightward off the antepenult. -/
-theorem gridColumns_mudarris : Grid.columns (parse mudarris) = [1, 3, 1] := by decide
+theorem gridColumns_mudarris : Tree.columns (parse mudarris) = [1, 3, 1] := by decide
 
 /-- **Restarting the count after a heavy, with secondary stress** ([hayes-1995] (15d), (16d)):
     `ʔinkasara` parses as `(ʔìn)(ká.sa)ra` — the heavy initial is its own foot (secondary `2`),
     the count restarts, the next two lights foot, and the antepenult `ka` takes primary `3`. -/
-theorem gridColumns_Pinkasara : Grid.columns (parse Pinkasara) = [2, 3, 1, 1] := by decide
+theorem gridColumns_Pinkasara : Tree.columns (parse Pinkasara) = [2, 3, 1, 1] := by decide
 
 /-- **The head terminal is the antepenult head σ** ([liberman-prince-1977]): `kataba`'s head
     terminal — its primary stress, Liberman & Prince's head terminal — is the head
     syllable of the rightmost (head) foot, read off the grid's live column as an *element*, not
     just a height (cf. `gridColumns_kataba`'s `[3, 1, 1]`). -/
-theorem headTerminals_kataba : Grid.headTerminals (parse kataba) = [.σ 1 true] := by decide
+theorem headTerminals_kataba : Tree.headTerminals (parse kataba) = [.σ 1 true] := by decide
 
 /-! ### The Continuous Column Constraint blocks final promotion
 
@@ -139,7 +139,7 @@ theorem promotedKataba_not_continuous : ¬ Marks.IsContinuous promotedKataba := 
     `kataba` is strictly weaker than the primary — unlike a uniform right-strong word
     ([prince-1983]), whose grid peaks at the edge. The blocked promotion above is why. -/
 theorem kataba_final_below_peak :
-    (Grid.columns (parse kataba)).getLast?.getD 0 < Grid.peak (Grid.columns (parse kataba)) := by
+    (Tree.columns (parse kataba)).getLast?.getD 0 < Grid.peak (Tree.columns (parse kataba)) := by
   decide
 
 end Hayes1995

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -194,7 +194,7 @@ example : ercB maxHIdx = .L ∧ ercB depLinkHIdx = .W ∧
     instance for `Equiv.Perm (Fin n)` is built via `Quot.lift` and does
     not reduce well under kernel `decide`, so the existential search over
     24 rankings stalls. -/
-theorem parallel_OT_inadequate : ¬ ERCSet.consistent pokoSupport := by
+theorem parallel_OT_inadequate : ¬ ERCSet.Consistent pokoSupport := by
   rintro ⟨r, hr⟩
   -- Both ERCs are satisfied by `r`.
   have hA := (ERC.satisfiedBy_iff_dominance r ercA).mp (hr ercA (by simp [pokoSupport]))

--- a/Linglib/Studies/MerchantPrince2022.lean
+++ b/Linglib/Studies/MerchantPrince2022.lean
@@ -59,12 +59,12 @@ engine to the abstract `Grammar` hub ([merchant-prince-2022]; [merchant-riggle-2
 `h` is the consistency of the row's conditions, i.e. that `w` is a genuine,
 non-harmonically-bounded optimum. -/
 noncomputable def rowGrammar (t : Tableau C n) (w : C)
-    (h : ERCSet.consistent (rowERCSet t w)) : Grammar n :=
+    (h : ERCSet.Consistent (rowERCSet t w)) : Grammar n :=
   Grammar.ofERCSet (rowERCSet t w) h
 
 @[simp] theorem mem_rowGrammar_legs {t : Tableau C n} {w : C}
-    {h : ERCSet.consistent (rowERCSet t w)} {r : Ranking n} :
-    r ∈ (rowGrammar t w h).legs ↔ ERCSet.satisfiedBy r (rowERCSet t w) := by
+    {h : ERCSet.Consistent (rowERCSet t w)} {r : Ranking n} :
+    r ∈ (rowGrammar t w h).legs ↔ ERCSet.SatisfiedBy r (rowERCSet t w) := by
   simp only [rowGrammar, Grammar.legs_ofERCSet, ERCSet.mem_linearExtensions]
 
 /-- **The semantic anchor.** A row's grammar collects exactly the rankings under
@@ -73,12 +73,12 @@ dominates every competitor's — i.e. the rankings that select `w` as optimum
 ([prince-smolensky-1993]). This connects the abstract `Grammar` hub back to the
 tableau's lexicographic evaluation. -/
 theorem mem_rowGrammar_legs_iff_lex {t : Tableau C n} {w : C}
-    {h : ERCSet.consistent (rowERCSet t w)} {r : Ranking n} :
+    {h : ERCSet.Consistent (rowERCSet t w)} {r : Ranking n} :
     r ∈ (rowGrammar t w h).legs ↔
       ∀ l ∈ t.candidates.erase w,
         toLex (fun p => t.profile w (r p)) ≤ toLex (fun p => t.profile l (r p)) := by
   rw [mem_rowGrammar_legs]
-  unfold ERCSet.satisfiedBy rowERCSet
+  unfold ERCSet.SatisfiedBy rowERCSet
   constructor
   · intro hsat l hl
     exact (tableauERC_satisfiedBy_iff t r w l).mp

--- a/Linglib/Studies/Prince1983.lean
+++ b/Linglib/Studies/Prince1983.lean
@@ -5,14 +5,14 @@ import Linglib.Phonology.Prosody.Grid
 
 [prince-1983]'s *Relating to the Grid* reads a metrical **grid** off a prosodic tree by the
 Relative Prominence Projection Rule ([liberman-prince-1977]) — formalised as
-`Prosody.Grid.columns` — and observes that a **uniform** metrical tree (every constituent
+`Prosody.Tree.columns` — and observes that a **uniform** metrical tree (every constituent
 strong on the same side) projects to a grid whose single strongest column sits at one **end**:
 the *End Rule*.
 
 This file stress-tests the grid projection against that prediction. A uniformly right-strong
 (iambic) word and a uniformly left-strong (trochaic) word project, by `decide`, to staircase
 column profiles whose strict maximum is the rightmost (resp. leftmost) syllable — the End Rule,
-recovered through `Prosody.Grid.columns`. It also leans on the projection's information loss:
+recovered through `Prosody.Tree.columns`. It also leans on the projection's information loss:
 the grid records *where* the prominence peak is, not the bracketing that produced it
 (`Prosody.Grid.ofTree_not_injective`).
 -/
@@ -50,22 +50,22 @@ def leftStrong : Tree := om [ftH [σh, σw], ftW [σh, σw]]
 /-- **End Rule, right** ([prince-1983]): the rightmost grid column strictly dominates every
     other — the prominence peak is at the right edge. -/
 def EndRuleRight (t : Tree) : Prop :=
-  ∀ h ∈ (Grid.columns t).dropLast, h < (Grid.columns t).getLast?.getD 0
+  ∀ h ∈ (Tree.columns t).dropLast, h < (Tree.columns t).getLast?.getD 0
 instance (t : Tree) : Decidable (EndRuleRight t) := by unfold EndRuleRight; infer_instance
 
 /-- **End Rule, left** ([prince-1983]): the leftmost grid column strictly dominates every
     other — the prominence peak is at the left edge. -/
 def EndRuleLeft (t : Tree) : Prop :=
-  ∀ h ∈ (Grid.columns t).tail, h < (Grid.columns t).headD 0
+  ∀ h ∈ (Tree.columns t).tail, h < (Tree.columns t).headD 0
 instance (t : Tree) : Decidable (EndRuleLeft t) := by unfold EndRuleLeft; infer_instance
 
 /-! ### The RPPR projects uniform trees to End-Rule grids -/
 
 /-- The right-strong word projects to a staircase peaking at the right edge. -/
-theorem gridColumns_rightStrong : Grid.columns rightStrong = [1, 2, 1, 3] := by decide
+theorem gridColumns_rightStrong : Tree.columns rightStrong = [1, 2, 1, 3] := by decide
 
 /-- The left-strong word projects to a staircase peaking at the left edge. -/
-theorem gridColumns_leftStrong : Grid.columns leftStrong = [3, 1, 2, 1] := by decide
+theorem gridColumns_leftStrong : Tree.columns leftStrong = [3, 1, 2, 1] := by decide
 
 /-- **End Rule (right):** a uniformly right-strong word is strongest at its right edge. -/
 theorem endRuleRight_rightStrong : EndRuleRight rightStrong := by decide
@@ -76,11 +76,11 @@ theorem endRuleLeft_leftStrong : EndRuleLeft leftStrong := by decide
 /-- **The End-Rule peak IS the head terminal** ([prince-1983]; [liberman-prince-1977]): the
     rightmost column End Rule Right promotes is the head foot's head σ — the head terminal
     (Liberman & Prince's head terminal) as a *node*, not just the tallest height. -/
-theorem headTerminals_rightStrong : Grid.headTerminals rightStrong = [σh] := by decide
+theorem headTerminals_rightStrong : Tree.headTerminals rightStrong = [σh] := by decide
 
 /-- And its prominence is the grid peak: on a uniform (non-recursive headed) word the head
-    terminal's height is the peak — the concrete instance of `Prosody.Grid.headHeights_eq_peak`. -/
+    terminal's height is the peak — the concrete instance of `Prosody.Tree.headHeights_eq_peak`. -/
 theorem endRulePeak_is_head :
-    Grid.headHeights rightStrong = [Grid.peak (Grid.columns rightStrong)] := by decide
+    Tree.headHeights rightStrong = [Grid.peak (Tree.columns rightStrong)] := by decide
 
 end Prince1983


### PR DESCRIPTION
Mechanical batch from the 3-reviewer Phonology architecture audit:
- `LabeledTuple`: declare the `toList`/`getElem?` simp normal form (`get?_eq_getElem?` now simp); `AR` gains `@[ext]`, `toGraph_injective`, `DecidableEq`.
- ERC cluster: Prop-valued predicates to UpperCamelCase (`IsTrivial`, `IsContradictory`, `IsSimple`, `IsSimpleSet`, `Consistent`, `SatisfiedBy`, `Entails`, `Ranking.Dominates`).
- `Feature.allFeatures` is now the `Fintype`'s enumeration (single source of truth; hand-synced length/completeness re-proofs deleted).
- `takeWhile_all` → mathlib's `List.takeWhile_eq_self_iff`.
- Grid tree-readers (`columns`, `headTerminals`, `headHeights`, `IsHeaded`, `terminals`, `project`, `IsHeadTerminal`) re-namespaced to their receiver `Tree`; `Grid.ofTree` and its theorems stay (constructor-from convention).
- Per-field docstrings on `TierRule`, `Foot`, `Syllable`, `Mora`, `OnsetRime`.