### PR TITLE
refactor(Phonology/OptimalityTheory): constraint identity by label type, not String

### DIFF
--- a/Linglib/Phonology/OptimalityTheory/CophonologyByPhrase.lean
+++ b/Linglib/Phonology/OptimalityTheory/CophonologyByPhrase.lean
@@ -88,18 +88,16 @@ open Minimalist (Phase SyntacticObject)
       matches v heads, `subranking` lists ATRHARM ≫ IDENT-IO(ATR).
     - DP phase carries definite-marker phonology — `phaseSelector`
       matches D heads of definite category. -/
-structure PhrasalCophonology (C : Type*) where
+structure PhrasalCophonology (L C : Type*) where
   /-- Predicate selecting which phase heads activate this cophonology. -/
   phaseSelector : SyntacticObject → Bool
   /-- Constraint subranking promoted within the matched phase. -/
-  subranking    : List (String × Constraint C)
-  /-- Optional human-readable name for diagnostics. -/
-  name          : String := ""
+  subranking    : List (L × Constraint C)
 
 /-- A phrasal cophonology activates on a phase iff its `phaseSelector`
     matches the phase head (the head leaf `ph.head`, as a leaf SO). -/
-def PhrasalCophonology.appliesTo {C : Type*}
-    (pc : PhrasalCophonology C) (ph : Phase) : Bool :=
+def PhrasalCophonology.appliesTo {L C : Type*}
+    (pc : PhrasalCophonology L C) (ph : Phase) : Bool :=
   pc.phaseSelector (Minimalist.SO.lexLeaf ph.head)
 
 -- ============================================================================
@@ -112,18 +110,18 @@ def PhrasalCophonology.appliesTo {C : Type*}
     Delegates to `cophonologicalEval` from `CophonologyTheory.lean`;
     the difference relative to per-VI cophonology is the *trigger*
     (phase head match), not the constraint-merge mechanics. -/
-def phrasalCophonologicalEval {C : Type*} [DecidableEq C]
-    (defaultRanking : List (String × Constraint C))
-    (pc : PhrasalCophonology C)
+def phrasalCophonologicalEval {L C : Type*} [DecidableEq L] [DecidableEq C]
+    (defaultRanking : List (L × Constraint C))
+    (pc : PhrasalCophonology L C)
     (candidates : List C)
     (h : candidates ≠ []) : Finset C :=
   cophonologicalEval defaultRanking pc.subranking candidates h
 
 /-- A phrasal cophonology with empty subranking reduces to default OT.
     Lifts `cophonologicalEval_empty_sub`. -/
-theorem phrasalCophonologicalEval_empty_sub {C : Type*} [DecidableEq C]
-    (defaultRanking : List (String × Constraint C))
-    (pc : PhrasalCophonology C)
+theorem phrasalCophonologicalEval_empty_sub {L C : Type*} [DecidableEq L] [DecidableEq C]
+    (defaultRanking : List (L × Constraint C))
+    (pc : PhrasalCophonology L C)
     (candidates : List C) (h : candidates ≠ [])
     (hsub : pc.subranking = []) :
     phrasalCophonologicalEval defaultRanking pc candidates h
@@ -144,15 +142,15 @@ theorem phrasalCophonologicalEval_empty_sub {C : Type*} [DecidableEq C]
 
     Returns `none` if no registered cophonology matches; in that case
     callers should fall back to the default ranking. -/
-def selectCophonology {C : Type*}
-    (registry : List (PhrasalCophonology C)) (ph : Phase)
-    : Option (PhrasalCophonology C) :=
+def selectCophonology {L C : Type*}
+    (registry : List (PhrasalCophonology L C)) (ph : Phase)
+    : Option (PhrasalCophonology L C) :=
   registry.find? (·.appliesTo ph)
 
 /-- The selected cophonology, when present, applies to the phase. -/
-theorem selectCophonology_applies {C : Type*}
-    {registry : List (PhrasalCophonology C)} {ph : Phase}
-    {pc : PhrasalCophonology C}
+theorem selectCophonology_applies {L C : Type*}
+    {registry : List (PhrasalCophonology L C)} {ph : Phase}
+    {pc : PhrasalCophonology L C}
     (h : selectCophonology registry ph = some pc) :
     pc.appliesTo ph = true := by
   unfold selectCophonology at h
@@ -164,7 +162,7 @@ theorem selectCophonology_applies {C : Type*}
 -- ============================================================================
 
 /-- An empty registry selects no cophonology. -/
-theorem selectCophonology_empty {C : Type*} (ph : Phase) :
-    selectCophonology ([] : List (PhrasalCophonology C)) ph = none := rfl
+theorem selectCophonology_empty {L C : Type*} (ph : Phase) :
+    selectCophonology ([] : List (PhrasalCophonology L C)) ph = none := rfl
 
 end OptimalityTheory.CophonologyByPhrase

--- a/Linglib/Phonology/OptimalityTheory/CophonologyTheory.lean
+++ b/Linglib/Phonology/OptimalityTheory/CophonologyTheory.lean
@@ -66,15 +66,15 @@ open Constraints OptimalityTheory
     - `subranking`: constraints promoted above the default ranking
 
     When this VI wins insertion, its `subranking` overrides the default
-    constraint ranking: constraints named in `subranking` are promoted
+    constraint ranking: constraints labeled in `subranking` are promoted
     to the top of the ranking (in the order listed), and the remaining
     default constraints follow. -/
-structure CophVocabItem (Ctx Root C : Type*) extends VocabItem Ctx Root where
+structure CophVocabItem (Ctx Root L C : Type*) extends VocabItem Ctx Root where
   /-- Morpheme-specific constraint subranking (R component).
       Constraints listed here are promoted to the top of the effective
       ranking, overriding their default position. An empty subranking
       means this VI imposes no morpheme-specific phonology. -/
-  subranking : List (String × Constraint C) := []
+  subranking : List (L × Constraint C) := []
 
 -- ============================================================================
 -- § 2: Ranking Merge
@@ -83,20 +83,20 @@ structure CophVocabItem (Ctx Root C : Type*) extends VocabItem Ctx Root where
 /-- Merge a morpheme-specific subranking with the default ranking.
 
     The effective ranking places the subranking constraints first (in
-    the order given), then appends default constraints whose names do
+    the order given), then appends default constraints whose labels do
     not appear in the subranking. This implements the intuition that
     the morpheme "promotes" certain constraints above the default
     ranking without disturbing the relative order of other constraints.
 
     When `sub` is empty, the result is exactly `default`. -/
-def mergeRanking {C : Type*}
-    (default sub : List (String × Constraint C)) : List (String × Constraint C) :=
-  let subNames := sub.map (·.1)
-  sub ++ default.filter (λ c => !subNames.contains c.1)
+def mergeRanking {L C : Type*} [DecidableEq L]
+    (default sub : List (L × Constraint C)) : List (L × Constraint C) :=
+  let subLabels := sub.map (·.1)
+  sub ++ default.filter (λ c => !subLabels.contains c.1)
 
 /-- An empty subranking produces the default ranking unchanged. -/
-theorem mergeRanking_empty_sub {C : Type*}
-    (default : List (String × Constraint C)) :
+theorem mergeRanking_empty_sub {L C : Type*} [DecidableEq L]
+    (default : List (L × Constraint C)) :
     mergeRanking default [] = default := by
   simp [mergeRanking]
 
@@ -113,9 +113,9 @@ theorem mergeRanking_empty_sub {C : Type*}
     constraint (basemap correspondence) above default markedness
     constraints, forcing the output to match the basemap rather than
     preserving the target's underlying tones ([rolle-2018] Ch 5). -/
-def cophonologicalEval {C : Type*} [DecidableEq C]
-    (defaultRanking : List (String × Constraint C))
-    (subranking : List (String × Constraint C))
+def cophonologicalEval {L C : Type*} [DecidableEq L] [DecidableEq C]
+    (defaultRanking : List (L × Constraint C))
+    (subranking : List (L × Constraint C))
     (candidates : List C)
     (h : candidates ≠ [] := by decide) : Finset C :=
   let effective := mergeRanking defaultRanking subranking
@@ -123,8 +123,8 @@ def cophonologicalEval {C : Type*} [DecidableEq C]
 
 /-- When the subranking is empty, cophonological evaluation reduces to
     standard OT evaluation. CPT is a proper generalization of OT. -/
-theorem cophonologicalEval_empty_sub {C : Type*} [DecidableEq C]
-    (defaultRanking : List (String × Constraint C))
+theorem cophonologicalEval_empty_sub {L C : Type*} [DecidableEq L] [DecidableEq C]
+    (defaultRanking : List (L × Constraint C))
     (candidates : List C) (h : candidates ≠ []) :
     cophonologicalEval defaultRanking [] candidates h =
     (Tableau.ofRanking candidates (defaultRanking.map (·.2)) h).optimal := by

--- a/Linglib/Phonology/OptimalityTheory/Stratal.lean
+++ b/Linglib/Phonology/OptimalityTheory/Stratal.lean
@@ -49,42 +49,35 @@ structure StratalDerivation (S W P : Type*) where
 
 /-! ### Constraint reranking -/
 
-/-- Find the rank (position) of a constraint by name within a ranking.
-    Position 0 = highest-ranked. Returns `none` if the constraint is not
-    active at this stratum. -/
-def findRank {C : Type*} (name : String)
-    (ranking : List (String × Constraint C)) : Option Nat :=
-  go ranking 0
-where
-  go : List (String × Constraint C) → Nat → Option Nat
-    | [], _ => none
-    | c :: cs, i => if c.1 == name then some i else go cs (i + 1)
+variable {L : Type*} [DecidableEq L] {C C₁ C₂ : Type*}
 
-/-- Cross-stratum promotion: `name` is ranked higher (closer to 0) in
-    `r₁ : List (String × Constraint C₁)` than in `r₂ : List (String × Constraint C₂)`.
-    Different candidate types between strata are permitted — the constraint
-    inventory is shared by *name*, not by candidate type (e.g. ONSET is
-    promoted from Word to Phrase level in Telugu, [aitha-2026] §5.3). -/
-def isPromotedAcross {C₁ C₂ : Type*} (name : String)
-    (r₁ : List (String × Constraint C₁)) (r₂ : List (String × Constraint C₂)) : Prop :=
-  match findRank name r₁, findRank name r₂ with
+/-- The rank (position) of the constraint labeled `l` in a ranking: `0` is the highest
+    rank; `none` if the constraint is not active at this stratum. -/
+def findRank (l : L) (ranking : List (L × Constraint C)) : Option ℕ :=
+  ranking.findIdx? (·.1 == l)
+
+/-- Cross-stratum promotion: `l` is ranked higher (closer to `0`) in `r₁` than in `r₂`.
+    Different candidate types between strata are permitted — the constraint inventory is
+    shared by *label*, not by candidate type (e.g. ONSET is promoted from Word to Phrase
+    level in Telugu, [aitha-2026] §5.3). -/
+def IsPromotedAcross (l : L) (r₁ : List (L × Constraint C₁))
+    (r₂ : List (L × Constraint C₂)) : Prop :=
+  match findRank l r₁, findRank l r₂ with
   | some p₁, some p₂ => p₁ < p₂
   | _, _ => False
 
-instance {C₁ C₂ : Type*} (name : String)
-    (r₁ : List (String × Constraint C₁)) (r₂ : List (String × Constraint C₂)) :
-    Decidable (isPromotedAcross name r₁ r₂) := by
-  unfold isPromotedAcross; split <;> infer_instance
+instance (l : L) (r₁ : List (L × Constraint C₁)) (r₂ : List (L × Constraint C₂)) :
+    Decidable (IsPromotedAcross l r₁ r₂) := by
+  unfold IsPromotedAcross; split <;> infer_instance
 
-/-- Cross-stratum demotion. Dual of `isPromotedAcross` (e.g. `*DIST-0` is
-    demoted from Word to Phrase level in Telugu, [aitha-2026] §5.3). -/
-def isDemotedAcross {C₁ C₂ : Type*} (name : String)
-    (r₁ : List (String × Constraint C₁)) (r₂ : List (String × Constraint C₂)) : Prop :=
-  isPromotedAcross name r₂ r₁
+/-- Cross-stratum demotion. Dual of `IsPromotedAcross` (e.g. `*DIST-0` is demoted from
+    Word to Phrase level in Telugu, [aitha-2026] §5.3). -/
+def IsDemotedAcross (l : L) (r₁ : List (L × Constraint C₁))
+    (r₂ : List (L × Constraint C₂)) : Prop :=
+  IsPromotedAcross l r₂ r₁
 
-instance {C₁ C₂ : Type*} (name : String)
-    (r₁ : List (String × Constraint C₁)) (r₂ : List (String × Constraint C₂)) :
-    Decidable (isDemotedAcross name r₁ r₂) := by
-  unfold isDemotedAcross; infer_instance
+instance (l : L) (r₁ : List (L × Constraint C₁)) (r₂ : List (L × Constraint C₂)) :
+    Decidable (IsDemotedAcross l r₁ r₂) := by
+  unfold IsDemotedAcross; infer_instance
 
 end OptimalityTheory.Stratal

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -607,6 +607,14 @@ inductive WordCandDat where
   | compLengthen
   deriving DecidableEq, Repr
 
+/-- The constraint inventory of [aitha-2026], as a label type: cross-stratum identity
+is by label, not by candidate type (the strata have different candidate types). The
+paper's tables abbreviate stress faithfulness as both ID-STR and IDENT-STRESS; both
+spellings are preserved as distinct labels. -/
+inductive Con
+  | distZero | alignR | idStress | ftBin | maxMora | max | identStress
+  deriving DecidableEq, Repr
+
 /-- Word-level ranking for DAT. Same constraint set as NOM, with
     \*DIST-0 additionally relevant (eliminates faithful candidate).
 
@@ -616,13 +624,13 @@ inductive WordCandDat where
     | resyllabify     |          |  1\* |        |        |        |     |
     | deleteNi        |          |      |        |   1\*  |   1    |  2  |
     | ☞ compLengthen  |          |      |        |        |   1    |  1  | -/
-def wordDatRanking : List (String × Constraint WordCandDat) :=
-  [ ("*DIST-0", λ | .faithful => 1 | _ => 0)
-  , ("AL-R",    λ | .resyllabify => 1 | _ => 0)
-  , ("ID-STR",  λ _ => 0)
-  , ("FT-BIN",  λ | .deleteNi => 1 | _ => 0)
-  , ("MAX(μ)",  λ | .deleteNi => 1 | .compLengthen => 1 | _ => 0)
-  , ("MAX",     λ | .deleteNi => 2 | .compLengthen => 1 | _ => 0) ]
+def wordDatRanking : List (Con × Constraint WordCandDat) :=
+  [ (.distZero, λ | .faithful => 1 | _ => 0)
+  , (.alignR,   λ | .resyllabify => 1 | _ => 0)
+  , (.idStress, λ _ => 0)
+  , (.ftBin,    λ | .deleteNi => 1 | _ => 0)
+  , (.maxMora,  λ | .deleteNi => 1 | .compLengthen => 1 | _ => 0)
+  , (.max,      λ | .deleteNi => 2 | .compLengthen => 1 | _ => 0) ]
 
 def wordDatCands : List WordCandDat :=
   [.faithful, .resyllabify, .deleteNi, .compLengthen]
@@ -722,11 +730,11 @@ inductive PhraseCandPostp where
     | deleteM       |              | 1   |         | 1    |
     | deleteN       |              | 1   |         |      |
     | ☞ faithful    |              |     | 1       |      | -/
-def phrasePostpRanking : List (String × Constraint PhraseCandPostp) :=
-  [ ("IDENT-STRESS", λ _ => 0)
-  , ("MAX",          λ | .compLengthen => 1 | .deleteM => 1 | .deleteN => 1 | _ => 0)
-  , ("*DIST-0",      λ | .faithful => 1 | _ => 0)
-  , ("AL-R",         λ | .compLengthen => 1 | .deleteM => 1 | _ => 0) ]
+def phrasePostpRanking : List (Con × Constraint PhraseCandPostp) :=
+  [ (.identStress, λ _ => 0)
+  , (.max,         λ | .compLengthen => 1 | .deleteM => 1 | .deleteN => 1 | _ => 0)
+  , (.distZero,    λ | .faithful => 1 | _ => 0)
+  , (.alignR,      λ | .compLengthen => 1 | .deleteM => 1 | _ => 0) ]
 
 def phrasePostpCands : List PhraseCandPostp :=
   [.compLengthen, .deleteM, .deleteN, .faithful]
@@ -803,8 +811,8 @@ end StratalRecords
 
 /-! Paper §5.3 (p. 31) makes the headline Stratal-OT claim that `*DIST-0`
 is **demoted** going from the Word stratum to the Phrase stratum. The
-substrate's `isPromotedAcross` / `isDemotedAcross` operate on constraint
-*names* — necessary here because `wordDatRanking` and `phrasePostpRanking`
+substrate's `IsPromotedAcross` / `IsDemotedAcross` operate on constraint
+*labels* — necessary here because `wordDatRanking` and `phrasePostpRanking`
 have different candidate types (`WordCandDat` vs `PhraseCandPostp`),
 so the same-`C` `isPromoted`/`isDemoted` would not typecheck. -/
 
@@ -820,13 +828,13 @@ open OptimalityTheory.Stratal
     m-retention at phrase boundaries vs m-deletion + CL inside
     the prosodic word. -/
 theorem dist0_demoted_phrase_relative_to_word :
-    OptimalityTheory.Stratal.isDemotedAcross "*DIST-0" phrasePostpRanking wordDatRanking := by
+    OptimalityTheory.Stratal.IsDemotedAcross .distZero phrasePostpRanking wordDatRanking := by
   decide
 
 /-- Conversely, `MAX` is **promoted** going Word → Phrase. Dual aspect
     of the same reranking. -/
 theorem max_promoted_phrase_relative_to_word :
-    OptimalityTheory.Stratal.isPromotedAcross "MAX" phrasePostpRanking wordDatRanking := by
+    OptimalityTheory.Stratal.IsPromotedAcross .max phrasePostpRanking wordDatRanking := by
   decide
 
 end CrossStratumReranking

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -738,15 +738,15 @@ open OptimalityTheory.CophonologyTheory (mergeRanking cophonologicalEval)
     the basemap output, which is independent of the target's underlying
     tones (`basemapOutput_tone_independent_whole`). -/
 theorem dominant_coph_selects_basemap_faithful
-    {C : Type} [DecidableEq C]
+    {L C : Type} [DecidableEq L] [DecidableEq C]
     (basemapTier : List TRN)
     (extractTier : C → List TRN)
-    (defaultRanking : List (String × Constraints.Constraint C))
+    (l : L) (defaultRanking : List (L × Constraints.Constraint C))
     (candidates : List C) (h : candidates ≠ [])
     (hLen : ∀ c ∈ candidates, (extractTier c).length = basemapTier.length)
     (hFaithful : ∃ c ∈ candidates, extractTier c = basemapTier)
     : let mxbmc := mkBasemapConstraint basemapTier extractTier
-      ∀ c ∈ cophonologicalEval defaultRanking [("MxBM-C", mxbmc)] candidates h,
+      ∀ c ∈ cophonologicalEval defaultRanking [(l, mxbmc)] candidates h,
         extractTier c = basemapTier := by
   intro mxbmc c hc
   simp only [cophonologicalEval, mergeRanking] at hc
@@ -767,10 +767,10 @@ theorem dominant_coph_selects_basemap_faithful
     `dominant_coph_selects_basemap_faithful` ensures the OT evaluation
     selects exactly the basemap-faithful candidates. -/
 theorem dominant_coph_agrees_with_tonalOverwrite
-    {S C : Type} [DecidableEq S] [BEq S] [Repr S] [DecidableEq C]
+    {S L C : Type} [DecidableEq S] [BEq S] [Repr S] [DecidableEq L] [DecidableEq C]
     (host : List (TBU S)) (t defaultTone : TRN)
     (extractTier : C → List TRN)
-    (defaultRanking : List (String × Constraints.Constraint C))
+    (l : L) (defaultRanking : List (L × Constraints.Constraint C))
     (candidates : List C) (h : candidates ≠ [])
     (hLen : ∀ c ∈ candidates,
       (extractTier c).length =
@@ -780,11 +780,11 @@ theorem dominant_coph_agrees_with_tonalOverwrite
     : let spec : Spec := ⟨"", [t], .whole⟩
       let baseTier := tonalTier (basemapOutput host spec defaultTone)
       let mxbmc := mkBasemapConstraint baseTier extractTier
-      ∀ c ∈ cophonologicalEval defaultRanking [("MxBM-C", mxbmc)] candidates h,
+      ∀ c ∈ cophonologicalEval defaultRanking [(l, mxbmc)] candidates h,
         extractTier c = tonalTier (tonalOverwrite host spec) := by
   intro spec baseTier mxbmc c hc
   have hFaith := dominant_coph_selects_basemap_faithful
-    baseTier extractTier defaultRanking candidates h hLen hFaithful c hc
+    baseTier extractTier l defaultRanking candidates h hLen hFaithful c hc
   rw [hFaith]
   exact (tonalOverwrite_basemap_faithful host t defaultTone).symm
 

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -389,10 +389,9 @@ def guebieVPPhaseSelector : SyntacticObject → Bool := fun s =>
     through this study file — out of
     scope. The substrate use is exhibited by the bundle's existence
     and the matched-phase predicate `appliesTo`. -/
-def guebieVPCophonology : PhrasalCophonology Unit :=
+def guebieVPCophonology : PhrasalCophonology Unit Unit :=
   { phaseSelector := guebieVPPhaseSelector
-    subranking    := []
-    name          := "Guébie vP ATR cophonology" }
+    subranking    := [] }
 
 /-- The Guébie vP-cophonology applies to a v head. (Witness: a leaf
     SO whose token's category is `.v`.) -/


### PR DESCRIPTION
From the Phonology architecture audit: cross-stratum/cophonological constraint identity was `String`-keyed (`List (String × Constraint C)`), putting `String` in decide-checked proof paths and reincarnating the dissolved `NamedConstraint`. Now generic over a `[DecidableEq L]` label type:
- `Stratal.findRank` (now via `List.findIdx?`), `IsPromotedAcross`/`IsDemotedAcross` (also UpperCamelCase per Prop convention).
- `CophonologyTheory`/`CophonologyByPhrase`: `mergeRanking`, `cophonologicalEval`, `CophVocabItem`/`PhrasalCophonology` gain a label parameter; dead `name : String` diagnostics field dropped.
- Aitha2026 gets its constraint inventory as a label enum (preserving the paper's ID-STR vs IDENT-STRESS spelling split, now visible); AkinboFwangwar2026's agreement theorems generalize over an arbitrary label, strictly stronger than the old "MxBM-C" form.