### PR TITLE
chore(Phonology/Prosody): delete vestigial Word subtype

### DIFF
--- a/Linglib/Phonology/Prosody/Foot.lean
+++ b/Linglib/Phonology/Prosody/Foot.lean
@@ -203,7 +203,8 @@ def footMorae (ws : List Syllable.Weight) : Nat :=
 
 A **footing**: a flat parse into feet and stray (unfooted) syllables, no designated head
 ([lamont-2022c]); the σ-type `S` carries quantity (`Unit` insensitive, `Syllable.Weight` not).
-A prosodic word ω (`Prosody.Word`) is the headed refinement of a footing. -/
+A prosodic word ω (an `IsWord` tree, `Prosody/Word.lean`) is the headed refinement of a
+footing. -/
 
 /-- A footing: a flat sequence of feet and stray (unfooted) syllables, no designated head
     ([lamont-2022c]). -/

--- a/Linglib/Phonology/Prosody/Syllable.lean
+++ b/Linglib/Phonology/Prosody/Syllable.lean
@@ -219,7 +219,7 @@ theorem Syllable.toOnsetRime_weight (σ : Syllable) :
 
 /-- A **yield**: the terminal σ-weight string of a prosodic structure — the
     unparsed input, or the leaves of a prosodic `Tree`. Distinct from the prosodic
-    word ω (`Prosody.Word`), which is a *headed constituent*: a yield is just the
+    word ω (an `IsWord` tree), which is a *headed constituent*: a yield is just the
     weight profile, with no head and no constituency. -/
 abbrev Yield := List Syllable.Weight
 
@@ -244,8 +244,8 @@ end Yield
 The recursive prosodic constituent ([ito-mester-2003]): the Core ordered rose tree
 `RoseTree` labeled by prosodic-level `Constituent`s — the **violable OT candidate
 carrier** for ω/φ/… structures, including the ill-formed ones (a footless ω, a stray under
-φ) the headed `Prosody.Word` cannot represent. Its OT constraints are
-`Constraints.Constraint Tree` values, defined alongside `Prosody.Word`. Homed here because
+φ) that `IsWord` rules out. Its OT constraints are
+`Constraints.Constraint Tree` values, defined alongside `IsWord`. Homed here because
 `Constituent.weight`/`.syl` need `Syllable.Weight`; it inherits `DecidableEq`/`map` from
 `RoseTree`. -/
 

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -27,8 +27,8 @@ here abstract the foot level. Prominence-head marking is likewise a refinement, 
 
 * `isWordTree` — the structural `Bool` Layeredness checker (decide-reducible; the foot arm
   reuses `Foot.isFootTree`).
-* `IsWord` / `Word` — the Layeredness predicate and the carrier subtype it cuts out.
-* `Word.recursionCount` — the `No-Recursion` violation count, read off the carrier (`noRec`).
+* `IsWord` — the Layeredness predicate; theorems take it as a hypothesis on the carrier
+  (mathlib's `Squarefree`-style), there is no bundled subtype.
 * `noRec` / `parseInto` — the violable OT constraints over the carrier (`Constraint Tree`).
 * `maximalProjections` / `minimalProjections` / `IsMinimalProj` — the topmost / bottommost
   ℓ-nodes of the carrier, and the intrinsic minimal-projection predicate.
@@ -48,7 +48,7 @@ namespace Prosody
 The violable constraints scoring prosodic candidates are `Constraints.Constraint Tree`
 values ([prince-smolensky-1993]); a grammar ranks them and scores with the OT engine
 (`OptimalityTheory.Tableau.ofRanking`). They are defined on the **carrier** `Tree` (which
-holds the ill-formed candidates a well-formed `Word` can't represent). List-recursion auxes
+holds the ill-formed candidates `IsWord` rules out). List-recursion auxes
 are local `where`s. -/
 
 open Constraints
@@ -374,26 +374,6 @@ theorem isWord_children {a : Constituent} {cs : List Tree}
   · exact Or.inl h
   · exact Or.inr h
 
-/-- A well-formed prosodic word: the prosodic-tree carrier restricted to the legal
-    recursive ω-trees (`IsWord`). -/
-abbrev Word := {t : Tree // IsWord t}
-
-namespace Word
-
-/-- The `No-Recursion` violation count of a word ([ito-mester-2009]): its ω-over-ω depth,
-    the carrier fold `noRec` read off the underlying tree. -/
-def recursionCount (w : Word) : ℕ := noRec w.val
-
-/-- The maximal ω-projections of a word: its topmost ω-nodes. A flat word is its own sole
-    maximal projection; a recursive ω-over-ω ([ito-mester-2009]) has the outer ω. -/
-def maximalProjections (w : Word) : List Tree := Prosody.maximalProjections (·.isOm) w.val
-
-/-- The minimal ω-projections of a word: its innermost ω-nodes — the bottommost cores of
-    an ω-over-ω recursion ([ito-mester-2009]). -/
-def minimalProjections (w : Word) : List Tree := Prosody.minimalProjections (·.isOm) w.val
-
-end Word
-
 /-! ### Word-size predicates -/
 
 variable {measure : List Syllable.Weight → ℕ} {t : Tree}
@@ -455,17 +435,17 @@ example : IsWord perfectW := by decide
 example : IsWord recursiveW := by decide
 example : ¬ IsWord (.om [.node .ph []] : Tree) := by decide
 
--- `recursionCount` reads the No-Recursion cost off the carrier: the recursive word scores
+-- `noRec` reads the No-Recursion cost off the carrier: the recursive word scores
 -- one ω-over-ω, the flat one zero.
-example : Word.recursionCount ⟨recursiveW, by decide⟩ = 1 := by decide
-example : Word.recursionCount ⟨perfectW, by decide⟩ = 0 := by decide
+example : noRec recursiveW = 1 := by decide
+example : noRec perfectW = 0 := by decide
 
 -- The ω-over-ω word has the outer ω as its sole maximal projection and the inner ω as its
 -- sole minimal projection; the perfect (flat) word is both at once.
-example : Word.maximalProjections ⟨recursiveW, by decide⟩ = [recursiveW] := by decide
-example : Word.minimalProjections ⟨recursiveW, by decide⟩ = [.node Constituent.om [exFoot]] := by
+example : maximalProjections (·.isOm) recursiveW = [recursiveW] := by decide
+example : minimalProjections (·.isOm) recursiveW = [.node Constituent.om [exFoot]] := by
   decide
-example : Word.maximalProjections ⟨perfectW, by decide⟩ = [perfectW] := by decide
-example : Word.minimalProjections ⟨perfectW, by decide⟩ = [perfectW] := by decide
+example : maximalProjections (·.isOm) perfectW = [perfectW] := by decide
+example : minimalProjections (·.isOm) perfectW = [perfectW] := by decide
 
 end Prosody

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -12,8 +12,8 @@ a *declarative* property of that carrier rather than a separate inductive. `IsWo
 out the well-formed ω-trees as the **Strict-Layer** core ([selkirk-1996]): an ω-node whose
 daughters are only feet, recursive sub-words (ω-over-ω), or stray (unfooted) syllables — the
 inviolable **Layeredness** constraint (no φ/ι/AP inside an ω). The library's OT studies
-score raw `Tree` candidates, so `Word := {t : Tree // IsWord t}` is exactly the carrier
-restricted to the legal recursive words.
+score raw `Tree` candidates, so theorems take `IsWord` as a hypothesis on the carrier
+rather than bundling a subtype.
 
 `Exhaustivity` and `No-Recursion` are *violable* OT constraints, not part of `IsWord`: a
 stray σ (a free clitic) and an ω-over-ω (the extended prosodic word of [ito-mester-2009])


### PR DESCRIPTION
From the Phonology architecture audit: `Prosody.Word := {t : Tree // IsWord t}` and its three folds (`recursionCount`, `maximalProjections`, `minimalProjections`) had zero consumers — every theorem takes `IsWord t` as a raw hypothesis on the carrier (mathlib's `Squarefree` style), and the folds re-read carrier functions that exist directly (`noRec`, `maximalProjections (·.isOm)`). The subtype is deleted, the examples exercise the carrier functions, and prose pointers in Foot/Syllable now cite `IsWord` trees.