### PR TITLE
refactor(Studies/Mizuno2024): de-fab citations, prune X/O substrate

### DIFF
--- a/Linglib/Data/Examples/Mizuno2024.json
+++ b/Linglib/Data/Examples/Mizuno2024.json
@@ -1,13 +1,12 @@
 [
   {
     "id": "mizuno2024_en1a",
-    "source": {"bibkey": "anderson-1951", "paperLabel": "(orig.)"},
-    "reportedIn": {"bibkey": "mizuno-2024", "paperLabel": "(1a)"},
+    "source": {"bibkey": "mizuno-2024", "paperLabel": "(1a)"},
     "language": "stan1293",
-    "primaryText": "If Jones had taken arsenic last night, he would show those symptoms which he is now showing.",
+    "primaryText": "You're right. If Jones had taken arsenic last night, he would show those symptoms which he is now showing.",
     "discourseSegments": [],
     "glossedTokens": [],
-    "translation": "If Jones had taken arsenic last night, he would show those symptoms which he is now showing.",
+    "translation": "You're right. If Jones had taken arsenic last night, he would show those symptoms which he is now showing.",
     "context": "Jones is in the ER with poisoning symptoms; the team is figuring out which chemical. The boss says he must have taken arsenic. A member responds with (1a), and the follow-up (1b) 'So, it looks like he did take arsenic' is felicitous — an Anderson conditional arguing FOR the truth of its antecedent.",
     "judgment": "acceptable",
     "alternatives": [],
@@ -16,7 +15,7 @@
       ["construction", "anderson"],
       ["strategy", "x-marking"]
     ],
-    "comment": "Anderson conditional (Anderson 1951). English X-marks: past-perfect antecedent, 'would' consequent describing the observed fact.",
+    "comment": "Mizuno's adaptation of Anderson's (1951) original ('If Jones had taken arsenic, he would have shown just exactly those symptoms which he does in fact show.'). English X-marks: past-perfect antecedent, 'would' consequent describing the observed fact.",
     "metaLanguage": "stan1293",
     "lgrConformance": ""
   },
@@ -38,7 +37,7 @@
     ],
     "comment": "Infelicitous: the non-expanded domain D makes the consequent (an observed fact) hold everywhere, so the conditional is trivially true (Stalnaker 1975, von Fintel 1999).",
     "metaLanguage": "stan1293",
-    "lgrConformance": "WORD_ALIGNED"
+    "lgrConformance": ""
   },
   {
     "id": "mizuno2024_ja4a",

--- a/Linglib/Data/Examples/Mizuno2024.lean
+++ b/Linglib/Data/Examples/Mizuno2024.lean
@@ -15,19 +15,19 @@ open Data.Examples
 
 def en1a : LinguisticExample :=
   { id := "mizuno2024_en1a"
-    source := ⟨"anderson-1951", "(orig.)"⟩
-    reportedIn := some ⟨"mizuno-2024", "(1a)"⟩
+    source := ⟨"mizuno-2024", "(1a)"⟩
+    reportedIn := none
     language := "stan1293"
-    primaryText := "If Jones had taken arsenic last night, he would show those symptoms which he is now showing."
+    primaryText := "You're right. If Jones had taken arsenic last night, he would show those symptoms which he is now showing."
     discourseSegments := []
     glossedTokens := []
-    translation := "If Jones had taken arsenic last night, he would show those symptoms which he is now showing."
+    translation := "You're right. If Jones had taken arsenic last night, he would show those symptoms which he is now showing."
     context := "Jones is in the ER with poisoning symptoms; the team is figuring out which chemical. The boss says he must have taken arsenic. A member responds with (1a), and the follow-up (1b) 'So, it looks like he did take arsenic' is felicitous — an Anderson conditional arguing FOR the truth of its antecedent."
     judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("construction", "anderson"), ("strategy", "x-marking")]
-    comment := "Anderson conditional (Anderson 1951). English X-marks: past-perfect antecedent, 'would' consequent describing the observed fact."
+    comment := "Mizuno's adaptation of Anderson's (1951) original ('If Jones had taken arsenic, he would have shown just exactly those symptoms which he does in fact show.'). English X-marks: past-perfect antecedent, 'would' consequent describing the observed fact."
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
@@ -47,7 +47,7 @@ def en2 : LinguisticExample :=
     paperFeatures := [("construction", "anderson"), ("strategy", "o-marking")]
     comment := "Infelicitous: the non-expanded domain D makes the consequent (an observed fact) hold everywhere, so the conditional is trivially true (Stalnaker 1975, von Fintel 1999)."
     metaLanguage := "stan1293"
-    lgrConformance := "WORD_ALIGNED" }
+    lgrConformance := "" }
 
 def ja4a : LinguisticExample :=
   { id := "mizuno2024_ja4a"

--- a/Linglib/Data/Examples/Schema.lean
+++ b/Linglib/Data/Examples/Schema.lean
@@ -177,6 +177,10 @@ def surfaceTokens (e : LinguisticExample) : List String :=
 def glossLine (e : LinguisticExample) : List String :=
   e.glossedTokens.map Prod.snd
 
+/-- Value of a `paperFeatures` key, if present. -/
+def feature? (e : LinguisticExample) (key : String) : Option String :=
+  e.paperFeatures.lookup key
+
 end LinguisticExample
 
 end Data.Examples

--- a/Linglib/Fragments/Japanese/Conditionals.lean
+++ b/Linglib/Fragments/Japanese/Conditionals.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Conditionals.Marker
 
 /-!
 # Japanese Conditional Markers
-[iatridou-1991] [mizuno-2024]
+[cao-white-lassiter-2025] [mizuno-2024]
 
 Conditional morphemes in Japanese and their HC/PC restrictions.
 
@@ -12,8 +12,8 @@ Conditional morphemes in Japanese and their HC/PC restrictions.
 - **-ra / -tara**: HC-only. Cannot mark premise conditionals.
 - **nara**: Can mark both HC and PC. PC reading available when antecedent
   echoes prior discourse ([cao-white-lassiter-2025], ex. 15).
-- **-(r)eba**: Can mark both HC and PC. Used in Anderson conditionals with
-  Non-Past consequent ([mizuno-2024], ex. 4a).
+- **-(e)ba**: Can mark both HC and PC — premise use in Anderson conditionals
+  ([mizuno-2024], ex. 4a), hypothetical use in FLVs ([mizuno-2024], ex. 9a).
 -/
 
 namespace Japanese.Conditionals
@@ -42,16 +42,17 @@ def nara : ConditionalMarker where
   markerType := .both
   notes := "Can mark premise conditionals (unlike -ra)"
 
-/-- Japanese -(r)eba: HC and PC conditional marker.
+/-- Japanese -(e)ba: HC and PC conditional marker ([mizuno-2024], fn 8 notation).
 
-    Used in Anderson conditionals. With Non-Past
-    consequent, yields Anderson reading; with Past consequent,
-    yields counterfactual reading. -/
+    Attaches directly to sentence radicals. Both uses are attested in
+    [mizuno-2024]: premise (Anderson, ex. 4a) and hypothetical (FLV, ex. 9a);
+    the Anderson vs counterfactual contrast is carried by the consequent's
+    Non-Past vs Past, not by the marker. -/
 def eba : ConditionalMarker where
   language := "Japanese"
-  marker := "-(r)eba"
+  marker := "-(e)ba"
   gloss := "if (conditional)"
   markerType := .both
-  notes := "Anderson conditionals use this form (Mizuno 2024)"
+  notes := "Anderson conditionals use this form (Mizuno 2024, ex. 4a)"
 
 end Japanese.Conditionals

--- a/Linglib/Semantics/Conditionals/Restrictor.lean
+++ b/Linglib/Semantics/Conditionals/Restrictor.lean
@@ -166,12 +166,13 @@ theorem conditional_K (f : ModalBase W) (g : OrderingSource W)
 
 open Tense.ConditionalShift (domainRestrictedConditional)
 
-/-- `conditionalNecessity` (with empty ordering source) corresponds to
-    `domainRestrictedConditional` at the Prop level. -/
+/-- `conditionalNecessity` (with empty ordering source) is
+    `domainRestrictedConditional` over the accessible worlds: the two
+    files' Kratzer conditionals are the same operation at the Prop level. -/
 theorem conditionalNecessity_iff_domainRestricted
     (f : ModalBase W) (α : W → Prop) (β : W → Prop) (w : W) :
     conditionalNecessity f emptyBackground α β w ↔
-    (∀ w' ∈ accessibleWorlds f w, α w' → β w') :=
+    domainRestrictedConditional (accessibleWorlds f w) α β :=
   restrictor_eq_strict f α β w
 
 end Semantics.Conditionals.Restrictor

--- a/Linglib/Semantics/Modality/Exclusion.lean
+++ b/Linglib/Semantics/Modality/Exclusion.lean
@@ -1,143 +1,55 @@
 import Linglib.Semantics.Context.Tower
 import Linglib.Semantics.Context.Shifts
-import Linglib.Semantics.Context.Rich
-import Linglib.Semantics.Modality.HistoricalAlternatives
-import Linglib.Semantics.Tense.Basic
 import Linglib.Semantics.Mood.Basic
-import Linglib.Semantics.Reference.Kaplan
-import Linglib.Semantics.Tense.ConditionalShift
 
 /-!
 # Exclusion features and X/O-marking strategies
 
-[iatridou-2000] [condoravdi-2002] [deal-2020]
-[anderson-1951] [schlenker-2004] [von-fintel-iatridou-2023]
+[iatridou-2000] [von-fintel-iatridou-2023] [anderson-1951]
+[schlenker-2004] [mizuno-2024]
 
 Framework primitives for the **Exclusion Feature** analysis of past
-morphology ([iatridou-2000]) and the **X-marking / O-marking**
-typology of counterfactuality ([von-fintel-iatridou-2023]).
-
-This file provides the *framework primitives* — types, predicates, and
-bridge theorems usable by any study of counterfactuals or
-crosslinguistic conditional morphology. Paper-specific typologies and
-empirical claims live in the corresponding `Studies/` files:
+morphology ([iatridou-2000]) and the **X-marking / O-marking** typology
+of counterfactuality ([von-fintel-iatridou-2023]). Paper-specific
+typologies and empirical claims live in the corresponding `Studies/`
+files:
 
 - `Studies/Iatridou2000.lean` —
   `IatridouPredType` / `CounterfactualType` / `classifyCounterfactual`
-  (FLV/PresCF/PastCF taxonomy)
+  (FLV/PresCF/PastCF taxonomy) and the tower-bridge theorems
+  consuming `ExclF`
 - `Studies/Mizuno2024.lean` —
   Anderson-conditional empirical observations (English X-marking,
-  Japanese O-marking, FLV correlation)
+  Japanese/Mandarin O-marking, FLV correlation)
 
 ## Core claims
 
-Past morphology encodes **exclusion**:
+Past morphology encodes **exclusion** ([iatridou-2000]):
 - **Temporal**: T(topic) ≠ T(speaker)
 - **Modal**: w(topic) ≠ w(speaker)
 
-This maps onto the `ContextTower`'s `origin` / `innermost` distinction:
-`ExclF dim tower` holds iff the relevant coordinate of `tower.innermost`
-differs from that of `tower.origin`.
+This maps onto the `ContextTower`'s `origin` / `innermost` distinction —
+[schlenker-2004]'s Context of Thought θ (= `tower.origin`) vs Context of
+Utterance υ (= `tower.innermost`): `ExclF dim tower` holds iff the
+relevant coordinate of `tower.innermost` differs from that of
+`tower.origin`. At a root tower the two coincide, so no `ExclF` holds;
+a subjunctive shift produces the modal feature and a temporal shift the
+temporal one (`subjShift_produces_modal_exclF`,
+`temporalShift_produces_temporal_exclF`).
 
-The **X-marking / O-marking** distinction (per
-[von-fintel-iatridou-2023]) is the typological label for whether
-a language uses counterfactual morphology (X-marking, produces ExclF)
-or some other strategy (O-marking, e.g., Japanese Historical Present)
-to grammatically distinguish live from non-live possibilities.
-
-## Bicontextual semantics
-
-[schlenker-2004] distinguishes the **Context of Thought** θ
-(speech-act context, anchors temporal indexicals) from the **Context of
-Utterance** v (can be shifted by HP). The `ContextTower` implements
-this distinction: `tower.origin` = θ, `tower.innermost` = v. The
-`origin_stable` theorem captures Schlenker's claim that θ-anchored
-indexicals are unaffected by HP/CF shifts.
+The **X-marking / O-marking** distinction ([von-fintel-iatridou-2023])
+is the typological label for whether a language uses counterfactual
+morphology (X-marking) or some other strategy (O-marking, e.g., the
+Japanese Historical Present of [mizuno-2024]) to grammatically
+distinguish live from non-live possibilities.
 -/
 
 namespace Semantics.Modality.Exclusion
 
-open Semantics.Context (KContext ContextTower ContextShift RichContext
-  hpShift xMarkingShift DomainExpanding temporalShift)
-open HistoricalAlternatives (historicalBase)
+open Semantics.Context (KContext ContextTower temporalShift)
 open Semantics.Mood (subjShift)
-open Semantics.Reference.Kaplan (opActually_access opActually_shift_invariant)
-open Tense (upperLimitConstraint)
-open Tense.ConditionalShift (domainRestrictedConditional
-  trivialConsequent nonTrivialConsequent
-  trivial_domainRestricted expansion_resolves_triviality
-  nontrivial_conditional_excludes)
 
-
--- ════════════════════════════════════════════════════════════════
--- § Counterfactual past — the two-uses-of-past machinery
--- ════════════════════════════════════════════════════════════════
-
-/-! [iatridou-2000]: past morphology is **ambiguous between
-    temporal and counterfactual uses**, with only the temporal use
-    subject to the Upper Limit Constraint. The substrate primitives
-    here are consumed by the `ExclF` machinery below and by the
-    paper-anchored Iatridou2000 / Mizuno2024 Studies files. -/
-
-/-- Two uses of past morphology, following [iatridou-2000].
-
-    Past morphology is ambiguous between:
-    1. Temporal precedence (genuine past tense)
-    2. Modal remoteness (counterfactual distance from actuality)
-
-    [iatridou-2000]'s "exclusion feature": past morphology marks
-    exclusion from the set of relevant times/worlds. Temporal past
-    excludes present times; counterfactual past excludes actual
-    worlds. -/
-inductive PastMorphologyUse where
-  /-- Temporal: precedence on the time line -/
-  | temporal
-  /-- Counterfactual: distance from actuality -/
-  | counterfactual
-  deriving DecidableEq, Repr
-
-/-- Counterfactual distance: past morphology marks modal remoteness,
-    not temporal precedence. The "reference world" is remote from
-    the actual world. -/
-structure CounterfactualDistance (World : Type*) where
-  /-- The actual world -/
-  actual : World
-  /-- The counterfactual world -/
-  counterfactual : World
-  /-- The worlds are distinct (modal distance > 0) -/
-  distinct : actual ≠ counterfactual
-
-/-- The refined ULC: the upper limit constraint applies only to
-    temporal tense, not to counterfactual tense.
-
-    If the past morphology is temporal, ULC holds (R ≤ E_matrix).
-    If the past morphology is counterfactual, ULC does not apply. -/
-def refinedULC {Time : Type*} [LE Time]
-    (use : PastMorphologyUse) (embeddedR matrixE : Time) : Prop :=
-  match use with
-  | .temporal => upperLimitConstraint embeddedR matrixE
-  | .counterfactual => True
-
-/-- Temporal tense is subject to ULC. -/
-theorem temporal_has_ulc {Time : Type*} [LE Time]
-    (embeddedR matrixE : Time) (h : embeddedR ≤ matrixE) :
-    refinedULC .temporal embeddedR matrixE :=
-  h
-
-/-- Counterfactual tense is exempt from ULC. -/
-theorem counterfactual_exempt_from_ulc {Time : Type*} [LE Time]
-    (embeddedR matrixE : Time) :
-    refinedULC .counterfactual embeddedR matrixE :=
-  trivial
-
-/-- The two uses of past morphology are genuinely distinct. -/
-theorem temporal_ne_counterfactual :
-    PastMorphologyUse.temporal ≠ PastMorphologyUse.counterfactual :=
-  nofun
-
--- ════════════════════════════════════════════════════════════════
--- § ExclF: The Exclusion Feature ([iatridou-2000])
--- ════════════════════════════════════════════════════════════════
+/-! ### ExclF: the exclusion feature -/
 
 /-- The two dimensions along which past morphology can exclude.
 
@@ -159,44 +71,14 @@ coordinate differs from the speaker coordinate on the given dimension.
 
 This is a predicate over context towers: `ExclF dim tower` holds iff
 the relevant coordinate of the innermost context (topic) differs from
-the origin context (speaker). -/
+the origin context (speaker). At a root tower innermost and origin
+coincide, so neither dimension's feature holds. -/
 def ExclF (dim : ExclDimension) (tower : ContextTower (KContext W E P T)) : Prop :=
   match dim with
   | .temporal => tower.innermost.time ≠ tower.origin.time
   | .modal    => tower.innermost.world ≠ tower.origin.world
 
-/-- ExclF temporal unfolds to time inequality. -/
-theorem exclF_temporal_iff (tower : ContextTower (KContext W E P T)) :
-    ExclF .temporal tower ↔ tower.innermost.time ≠ tower.origin.time :=
-  Iff.rfl
-
-/-- ExclF modal unfolds to world inequality. -/
-theorem exclF_modal_iff (tower : ContextTower (KContext W E P T)) :
-    ExclF .modal tower ↔ tower.innermost.world ≠ tower.origin.world :=
-  Iff.rfl
-
--- ════════════════════════════════════════════════════════════════
--- § ExclF–Deal Bridge
--- ════════════════════════════════════════════════════════════════
-
-/-- Map ExclDimension to [deal-2020]'s `PastMorphologyUse`.
-
-This connects [iatridou-2000]'s exclusion analysis to
-[deal-2020]'s tense typology: temporal exclusion corresponds to
-temporal tense, modal exclusion corresponds to counterfactual tense. -/
-def ExclDimension.toDealUse : ExclDimension → PastMorphologyUse
-  | .temporal => .temporal
-  | .modal    => .counterfactual
-
-theorem exclF_temporal_is_deal_temporal :
-    ExclDimension.toDealUse .temporal = .temporal := rfl
-
-theorem exclF_modal_is_deal_cf :
-    ExclDimension.toDealUse .modal = .counterfactual := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § ExclF–Tower Bridge: Shifts produce ExclF
--- ════════════════════════════════════════════════════════════════
+/-! ### Shifts produce ExclF -/
 
 /-- `subjShift` changes world → produces modal ExclF.
 
@@ -218,53 +100,16 @@ theorem temporalShift_produces_temporal_exclF (c : KContext W E P T) (t' : T)
     ExclF .temporal ((ContextTower.root c).push (temporalShift t')) :=
   h
 
-/-- Two shifts → both ExclFs (the PastCF configuration). -/
+/-- Two shifts → both ExclFs: a subjunctive (world) shift followed by a
+temporal one yields modal and temporal exclusion together — the PastCF
+configuration of [iatridou-2000] (two past layers). -/
 theorem two_shifts_two_exclFs (c : KContext W E P T) (w' : W) (t' t'' : T)
     (hw : w' ≠ c.world) (ht : t'' ≠ c.time) :
-    let tower := ((ContextTower.root c).push (subjShift w' t')).push (temporalShift t'')
-    ExclF .modal tower ∧ ExclF .temporal tower :=
+    ExclF .modal (((ContextTower.root c).push (subjShift w' t')).push (temporalShift t'')) ∧
+      ExclF .temporal (((ContextTower.root c).push (subjShift w' t')).push (temporalShift t'')) :=
   ⟨hw, ht⟩
 
--- ════════════════════════════════════════════════════════════════
--- § Root tower has no ExclF
--- ════════════════════════════════════════════════════════════════
-
-theorem root_no_temporal_exclF (c : KContext W E P T) :
-    ¬ ExclF .temporal (ContextTower.root c) :=
-  fun h => h rfl
-
-theorem root_no_modal_exclF (c : KContext W E P T) :
-    ¬ ExclF .modal (ContextTower.root c) :=
-  fun h => h rfl
-
--- ════════════════════════════════════════════════════════════════
--- § X-marking on RichContext (Kratzer ∗-revision bridge)
--- ════════════════════════════════════════════════════════════════
-
-/-- X-marking shift produces modal ExclF on `RichContext` towers.
-
-`xMarkingShift` (from `Semantics.Context.Rich`) changes both world and
-time. When the counterfactual world differs from the origin, the
-resulting tower has modal ExclF.
-
-**Kratzer-level counterpart**: in [kratzer-2012]'s modal
-semantics, the same X-marking operation corresponds to ∗-revision of
-the modal base (`Semantics.Modality.Kratzer.XMarking.IsStarRevision`):
-the `expandedDomain` parameter here maps to the widened accessible
-world set ∩f'(w) ⊇ ∩f(w). See [ferreira-2023] for the full 2×2
-square of necessities generated by X-marking on both modal base (Xf)
-and ordering source (Xg). -/
-theorem xMarking_produces_modal_exclF
-    (rc : RichContext W E P T)
-    (pastTime : T) (cfWorld : W) (expandedDomain : Set W)
-    (h : cfWorld ≠ rc.base.world) :
-    ((xMarkingShift (E := E) (P := P) pastTime cfWorld expandedDomain).apply rc
-      ).base.world ≠ rc.base.world :=
-  h
-
--- ════════════════════════════════════════════════════════════════
--- § X-marking / O-marking typology ([von-fintel-iatridou-2023])
--- ════════════════════════════════════════════════════════════════
+/-! ### X-marking / O-marking typology ([von-fintel-iatridou-2023]) -/
 
 /-- The two crosslinguistic strategies for grammatically distinguishing
 live from non-live possibilities ([von-fintel-iatridou-2023]'s
@@ -275,179 +120,36 @@ express Anderson conditionals: English uses X-marking (counterfactual
 morphology), Japanese uses O-marking (Non-Past + Historical Present). -/
 inductive MarkingStrategy where
   /-- X-marking: counterfactual morphology expands the domain from D
-      to D⁺. "Actually" in the consequent recovers the actual world via
-      Kaplanian origin access.
-      English: "If Jones *had taken* arsenic, he *would have shown*
-      exactly the symptoms he is *actually* showing." -/
+      to D⁺. English ([mizuno-2024], ex. 1a): "If Jones *had taken*
+      arsenic last night, he *would* show those symptoms which he is
+      now showing." -/
   | xMarking
-  /-- O-marking: Non-Past morphology triggers a perspectival shift
-      analogous to the Historical Present ([schlenker-2004]). The
+  /-- O-marking: the absence of X-marking. In Japanese Anderson
+      conditionals, Non-Past morphology triggers a perspectival shift
+      analogous to the Historical Present ([schlenker-2004]); the
       backward time shift expands the domain under branching time,
-      avoiding triviality without counterfactual morphology. The actual
-      world is directly accessible (no world shift, so no need for
-      "actually").
-      Japanese: "Jones-si-ga... nom-*eba*,... mise-*ru* (hazuda)." -/
+      avoiding triviality without counterfactual morphology.
+      Japanese ([mizuno-2024], ex. 4a): "Jones-si-ga ... nom-*eba*,
+      ... mise-*ru* hazuda." -/
   | oMarking
   deriving DecidableEq, Repr
 
 /-- X-marking strategy uses counterfactual morphology; O-marking does
-    not. The single primitive property of marking strategies; all
-    others (`producesExclF`, `requiresActuallyOperator`) derive from
-    it. -/
+    not. -/
 def MarkingStrategy.hasXMarking : MarkingStrategy → Bool
   | .xMarking => true
   | .oMarking => false
 
-/-- X-marking produces ExclF; O-marking does not.
+/-- The complementary marking strategy. O-marking "is generally defined
+    as the absence of X-marking" ([mizuno-2024], §2), so the two
+    strategies complement each other: in a minimal pair, the alternative
+    realizes the `other` of the attested strategy. -/
+def MarkingStrategy.other : MarkingStrategy → MarkingStrategy
+  | .xMarking => .oMarking
+  | .oMarking => .xMarking
 
-X-marking is counterfactual morphology: `subjShift` changes the
-evaluation world, creating modal ExclF. O-marking leaves the tower at
-the root, so no ExclF arises. Definitionally equal to `hasXMarking`. -/
-abbrev MarkingStrategy.producesExclF (s : MarkingStrategy) : Bool :=
-  s.hasXMarking
-
-/-- X-marking requires "actually" to recover the actual world; O-marking
-does not. When X-marking produces ExclF, the actual world is excluded
-from the shifted evaluation; "actually" (Kaplanian origin access)
-reaches back through the shift. With O-marking, the evaluation world
-IS the actual world. Definitionally equal to `hasXMarking`. -/
-abbrev MarkingStrategy.requiresActuallyOperator (s : MarkingStrategy) : Bool :=
-  s.hasXMarking
-
-/-- Map marking strategies to the `ExclDimension` they produce. -/
-def MarkingStrategy.exclDimension : MarkingStrategy → Option ExclDimension
-  | .xMarking => some .modal
-  | .oMarking => none
-
-/-- Map marking strategies to [deal-2020]'s `PastMorphologyUse`. -/
-def MarkingStrategy.toDealUse : MarkingStrategy → PastMorphologyUse
-  | .xMarking => .counterfactual
-  | .oMarking => .temporal
-
-theorem xMarking_exclDimension :
-    MarkingStrategy.xMarking.exclDimension = some .modal := rfl
-
-theorem oMarking_no_exclDimension :
-    MarkingStrategy.oMarking.exclDimension = none := rfl
-
-theorem xMarking_is_deal_counterfactual :
-    MarkingStrategy.xMarking.toDealUse = .counterfactual := rfl
-
-theorem oMarking_is_deal_temporal :
-    MarkingStrategy.oMarking.toDealUse = .temporal := rfl
-
-theorem xMarking_excl_deal_consistent :
-    (MarkingStrategy.xMarking.exclDimension.map ExclDimension.toDealUse) =
-    some MarkingStrategy.xMarking.toDealUse := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § Tower-level X/O-marking theorems
--- ════════════════════════════════════════════════════════════════
-
-/-- X-marking produces modal ExclF: subjunctive shift changes the
-world, creating world exclusion. Wraps `subjShift_produces_modal_exclF`. -/
-theorem xMarking_produces_exclF (c : KContext W E P T) (w' : W) (t' : T)
-    (h : w' ≠ c.world) :
-    ExclF .modal ((ContextTower.root c).push (subjShift w' t')) :=
-  subjShift_produces_modal_exclF c w' t' h
-
-/-- "Actually" recovers the origin world even after a tower shift.
-
-In an X-marked Anderson conditional, the CF morphology pushes the
-tower (shifting the evaluation world). But "actually" — being a
-Kaplanian indexical with `depth = .origin` — resolves to the
-speech-act world regardless. Wraps `opActually_shift_invariant`. -/
-theorem actually_recovers_origin_after_shift
-    (t : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T)) :
-    opActually_access.resolve (t.push σ) = opActually_access.resolve t :=
-  opActually_shift_invariant t σ
-
-/-- O-marking has no modal ExclF: without CF morphology, the tower
-stays at the root. Wraps `root_no_modal_exclF`. -/
-theorem oMarking_no_exclF (c : KContext W E P T) :
-    ¬ ExclF .modal (ContextTower.root c) :=
-  root_no_modal_exclF c
-
--- ════════════════════════════════════════════════════════════════
--- § Domain expansion (the Anderson-conditional triviality fix)
--- ════════════════════════════════════════════════════════════════
-
-/-- Both X-marking and O-marking avoid the triviality problem by
-expanding the domain. General pattern: if a domain expansion produces
-a world where the consequent fails, the conditional is non-trivial.
-
-- X-marking achieves this via `xMarkingShift` (CF morphology → D⁺)
-- O-marking achieves this via `hpShift` (HP → backward time → D⁺)
-
-Wraps `ConditionalShift.expansion_resolves_triviality`. -/
-theorem domain_expansion_avoids_triviality
-    (smallDomain expandedDomain : Set W)
-    (consequent : W → Prop)
-    (h_subset : smallDomain ⊆ expandedDomain)
-    (h_trivial : trivialConsequent smallDomain consequent)
-    (w : W) (hw : w ∈ expandedDomain) (hw_fails : ¬ consequent w) :
-    nonTrivialConsequent expandedDomain consequent :=
-  expansion_resolves_triviality smallDomain expandedDomain consequent
-    h_subset h_trivial w hw hw_fails
-
-/-- End-to-end O-marking domain expansion: backwards-closed history +
-backward time shift → the HP-shifted domain contains the original.
-
-Connects three layers:
-1. `BranchingTime.HistoricalAlternatives.backwardsClosed` (semantic property)
-2. `ConditionalShift.history_monotone_set` (set-level monotonicity)
-3. `hpShift` installs the expanded domain -/
-theorem oMarking_hpShift_expanding
-    {W : Type*} {T : Type*} [Preorder T]
-    (history : HistoricalAlternatives W T) (h_bc : history.backwardsClosed)
-    (w₀ : W) (t₀ t' : T) (h_earlier : t' ≤ t₀)
-    (D : Set W) (h_domain : D ⊆ history ⟨w₀, t₀⟩) :
-    D ⊆ history ⟨w₀, t'⟩ :=
-  Set.Subset.trans h_domain
-    (Tense.ConditionalShift.history_monotone_set
-      history h_bc ⟨w₀, t₀⟩ t' h_earlier)
-
-/-- The O-marking triviality problem: without domain expansion, the
-Anderson conditional is vacuously true. The `domainRestrictedConditional`
-over the non-expanded domain `D` is trivially satisfied because the
-consequent (an observed fact) holds at every world in `D`. -/
-theorem oMarking_trivial
-    (domain : Set W) (antecedent consequent : W → Prop)
-    (h_trivial : trivialConsequent domain consequent) :
-    domainRestrictedConditional domain antecedent consequent :=
-  trivial_domainRestricted domain antecedent consequent h_trivial
-
-/-- The X/O-marking payoff: when domain expansion makes the consequent
-non-trivial, the antecedent of a true conditional must exclude at
-least one world in `D⁺`. The Anderson conditional is informative —
-the antecedent restriction partitions `D⁺` into consequent-satisfying
-worlds (selected by the conditional) and consequent-failing worlds
-(excluded by the antecedent). -/
-theorem expanded_conditional_informative
-    (expandedDomain : Set W) (antecedent consequent : W → Prop)
-    (h_nontrivial : nonTrivialConsequent expandedDomain consequent)
-    (h_cond : domainRestrictedConditional expandedDomain antecedent consequent) :
-    ∃ w ∈ expandedDomain, ¬ antecedent w :=
-  nontrivial_conditional_excludes expandedDomain antecedent consequent
-    h_nontrivial h_cond
-
--- ════════════════════════════════════════════════════════════════
--- § Bicontextual semantics ([schlenker-2004])
--- ════════════════════════════════════════════════════════════════
-
-/-- In O-marking (HP) strategy, temporal indexicals still evaluate
-against the speech-act context (θ = origin), not the shifted context
-(v = innermost).
-
-This explains why Japanese *sakuya* 'last night' in the antecedent of
-an HP-shifted O-marked conditional evaluates against the utterance
-time, paralleling the behavior of *seventy-eight years ago* in
-[schlenker-2004]'s HP example. -/
-theorem oMarking_indexicals_at_origin
-    (ap : Semantics.Context.AccessPattern (KContext W E P T) W)
-    (hd : ap.depth = .origin)
-    (t : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T)) :
-    ap.resolve (t.push σ) = ap.resolve t :=
-  Semantics.Context.AccessPattern.origin_stable ap hd t σ
+@[simp]
+theorem MarkingStrategy.other_other : ∀ s : MarkingStrategy, s.other.other = s
+  | .xMarking | .oMarking => rfl
 
 end Semantics.Modality.Exclusion

--- a/Linglib/Semantics/Tense/ConditionalShift.lean
+++ b/Linglib/Semantics/Tense/ConditionalShift.lean
@@ -1,6 +1,4 @@
-import Linglib.Semantics.Context.Rich
 import Linglib.Semantics.Modality.HistoricalAlternatives
-import Linglib.Semantics.Mood.Basic
 
 /-!
 # Anderson Conditionals and Domain Expansion
@@ -9,74 +7,28 @@ import Linglib.Semantics.Mood.Basic
 Formalizes the connection between backward temporal shifts and domain expansion
 in conditionals. [mizuno-2024] argues that Japanese Anderson conditionals
 use the Historical Present ([schlenker-2004]) to achieve domain expansion
-without X-marking: Non-Past morphology shifts the evaluation time backward,
-and under branching time ([condoravdi-2002]), earlier times have more
-historical alternatives, so the domain expands.
+without X-marking: Non-Past morphology shifts the evaluation time backward, and
+live possibilities monotonically shrink as time develops, so the earlier-time
+domain is larger. The shrinking assumption is [mizuno-2024]'s own; the
+substrate encodes it as a backwards-closed `HistoricalAlternatives`, whose
+independent anchor is [condoravdi-2002]'s historical modal base.
 
-## Key Results
+## Key results
 
-- `andersonConditional` — HP-shifted antecedent evaluated against expanded domain
-- `hp_achieves_expansion` — backward time + domain monotonicity yields expansion
-- `trivialConsequent` / `nonTrivialConsequent` — formalize the triviality puzzle
-- `expansion_resolves_triviality` — domain expansion makes conditionals non-trivial
-- Bridge to `BranchingTime.historicalBase` and `Mood.SUBJ`
-
-## Connection to ContextTower
-
-The HP shift in an Anderson conditional is modeled as a tower push of an
-`hpShift`: a context shift that moves time backward and expands the domain.
-In [schlenker-2004]'s terms, the push shifts the Context of Utterance v
-while preserving the Context of Thought θ (= `tower.origin`).
-
+- `hp_achieves_expansion` / `history_antitone` — backward time over a
+  backwards-closed history yields domain expansion
+- `trivialConsequent` / `nonTrivialConsequent` — the triviality puzzle
+- `expansion_resolves_triviality` — a consequent-falsifying world makes the
+  expansion strict (`D ⊂ D⁺`) and the expanded consequent non-trivial
+- `nontrivial_conditional_excludes` — a non-trivial conditional's antecedent
+  excludes a world: the conditional is informative
 -/
 
 namespace Tense.ConditionalShift
 
 open Intensional (WorldTimeIndex)
 
-open Tense
-open Semantics.Context (RichContext KContext ContextTower ContextShift
-  hpShift DomainExpanding)
-open HistoricalAlternatives
-open Semantics.Mood
-
-/-! ### Anderson Conditional -/
-
-section AndersonConditional
-
-variable {W : Type*} {E : Type*} {P : Type*} {T : Type*} [Preorder T]
-
-/-- An Anderson conditional (context-level model): the antecedent is
-    evaluated at an HP-shifted context (backward time, expanded domain),
-    and the consequent is evaluated at the original context.
-
-    This models the HP shift's effect on a single evaluation point.
-    The full Kratzer-style analysis — restricted universal quantification
-    over the expanded domain D⁺ — is `domainRestrictedConditional`:
-
-      `domainRestrictedConditional D⁺ antecedent consequent`
-      = ∀ w ∈ D⁺, antecedent(w) → consequent(w)
-
-    The domain expansion machinery here (`hpShift`, `hp_achieves_expansion`)
-    provides the D⁺, and `trivial_domainRestricted` /
-    `nontrivial_conditional_excludes` show why expansion matters. -/
-def andersonConditional
-    (antecedent : RichContext W E P T → Prop)
-    (consequent : RichContext W E P T → Prop)
-    (hpTime : T) (expandedDomain : Set W)
-    (rc : RichContext W E P T) : Prop :=
-  let shifted := (hpShift (E := E) (P := P) hpTime expandedDomain).apply rc
-  antecedent shifted → consequent rc
-
-end AndersonConditional
-
-/-- The HP-shifted context in an Anderson conditional has the shifted time. -/
-theorem anderson_shifted_time {W E P T : Type*}
-    (hpTime : T) (expandedDomain : Set W)
-    (rc : RichContext W E P T) :
-    ((hpShift (E := E) (P := P) hpTime expandedDomain).apply rc).time = hpTime := rfl
-
-/-! ### HP Achieves Expansion (Mizuno's Argument) -/
+/-! ### HP achieves expansion (Mizuno's argument) -/
 
 section Expansion
 
@@ -98,37 +50,21 @@ theorem hp_achieves_expansion
     w ∈ history ⟨s₀.world, t'⟩ :=
   h_bc s₀.world w s₀.time t' h_earlier hw
 
-/-- Set-level monotonicity: under backwards-closed history, the set of
-    historical alternatives at an earlier time is a superset of those at a
-    later time. This lifts `hp_achieves_expansion` (element-level) to
-    `Set.Subset` (set-level), connecting it to `DomainExpanding`.
-
-    This is the formal core of [mizuno-2024]'s argument: HP shifts the
-    evaluation time backward, and backward time yields more historical
-    alternatives, i.e., domain expansion. -/
-theorem history_monotone_set
-    (history : HistoricalAlternatives W T)
-    (h_bc : history.backwardsClosed)
-    (s₀ : WorldTimeIndex W T) (t' : T) (h_earlier : t' ≤ s₀.time) :
-    (history s₀ : Set W) ⊆ (history ⟨s₀.world, t'⟩ : Set W) :=
-  λ _ hw => hp_achieves_expansion history h_bc s₀ t' h_earlier _ hw
-
-/-- The historical base (set of situations) at an earlier time includes
-    situations with the same worlds as the later base, plus potentially more.
-    This is the situation-level version of domain expansion. -/
-theorem historicalBase_monotone
-    (history : HistoricalAlternatives W T)
-    (h_bc : history.backwardsClosed)
-    (s₀ : WorldTimeIndex W T) (t' : T) (h_earlier : t' ≤ s₀.time)
-    (s₁ : WorldTimeIndex W T) (h_s₁ : s₁ ∈ historicalBase history s₀)
-    (h_time : s₁.time ≥ t') :
-    s₁ ∈ historicalBase history ⟨s₀.world, t'⟩ := by
-  simp only [historicalBase, Set.mem_setOf_eq] at h_s₁ ⊢
-  exact ⟨h_bc s₀.world s₁.world s₀.time t' h_earlier h_s₁.1, h_time⟩
+/-- Under a backwards-closed history, the live possibilities at a world
+    shrink monotonically as time develops: the set of historical
+    alternatives is antitone in the time coordinate. This is the formal
+    core of [mizuno-2024]'s argument — HP shifts the evaluation time
+    backward, and backward time yields more historical alternatives,
+    i.e., domain expansion. -/
+theorem history_antitone
+    (history : HistoricalAlternatives W T) (h_bc : history.backwardsClosed)
+    (w : W) :
+    Antitone (λ t => (history ⟨w, t⟩ : Set W)) :=
+  λ _ _ h_le _ hw => hp_achieves_expansion history h_bc ⟨w, _⟩ _ h_le _ hw
 
 end Expansion
 
-/-! ### Conditional Triviality and Domain Expansion -/
+/-! ### Conditional triviality and domain expansion -/
 
 section Triviality
 
@@ -142,7 +78,8 @@ variable {W : Type*}
     [kratzer-1986]: if-clauses restrict the modal domain rather than
     functioning as binary connectives. This is the Prop-level counterpart
     of `Semantics.Conditionals.Restrictor.conditionalNecessity` (which
-    operates over finite `(World → Bool)` for computation).
+    operates over finite `(World → Bool)` for computation); the bridge is
+    `Restrictor.conditionalNecessity_iff_domainRestricted`.
 
     Both X-marking and O-marking strategies for Anderson conditionals work
     by expanding D to D⁺ ⊃ D, making this quantification non-trivial. -/
@@ -153,11 +90,9 @@ def domainRestrictedConditional
 /-- A conditional is trivial when every world in the domain satisfies
     the consequent. The antecedent restriction does no work — the
     conditional is vacuously true regardless of what the antecedent says.
-
-    [condoravdi-2002]: indicative conditionals with small domains can be
-    trivial because every accessible world already satisfies the consequent.
-    Domain expansion (via HP/X-marking) resolves this by adding worlds
-    where the consequent may fail. -/
+    In an Anderson conditional the consequent is an observed fact, so it
+    holds throughout the non-expanded domain of live possibilities
+    ([mizuno-2024], §2, citing Stalnaker 1975 and von Fintel 1999). -/
 def trivialConsequent (domain : Set W) (consequent : W → Prop) : Prop :=
   ∀ w ∈ domain, consequent w
 
@@ -180,25 +115,26 @@ theorem trivial_domainRestricted
   λ w hw _ => h_trivial w hw
 
 /-- Domain expansion resolves triviality: if the original domain makes the
-    consequent trivial, but the expanded domain contains a world where the
-    consequent fails, then the expanded conditional is non-trivial.
+    consequent trivial and the expanded domain contains a world where the
+    consequent fails, then the expansion is *strict* (the witness cannot be
+    live — [mizuno-2024]'s D ⊂ D⁺) and the expanded consequent is
+    non-trivial.
 
     This completes the HP/X-marking argument:
     1. `hp_achieves_expansion` — backward time shift expands the domain
-    2. `expansion_resolves_triviality` — expanded domain makes the
-       conditional non-trivial
-
-    The counterfactual "If I had left earlier, I would have caught the train"
-    is non-trivial precisely because the expanded domain (from X-marking's
-    backward time shift) includes worlds where I didn't catch the train. -/
+    2. `expansion_resolves_triviality` — the expanded conditional is
+       non-trivial -/
 theorem expansion_resolves_triviality
     (smallDomain expandedDomain : Set W)
     (consequent : W → Prop)
-    (_h_subset : smallDomain ⊆ expandedDomain)
-    (_h_trivial : trivialConsequent smallDomain consequent)
+    (h_subset : smallDomain ⊆ expandedDomain)
+    (h_trivial : trivialConsequent smallDomain consequent)
     (w : W) (hw : w ∈ expandedDomain) (hw_fails : ¬ consequent w) :
-    nonTrivialConsequent expandedDomain consequent :=
-  ⟨w, hw, hw_fails⟩
+    smallDomain ⊂ expandedDomain ∧
+      nonTrivialConsequent expandedDomain consequent :=
+  ⟨(Set.ssubset_iff_of_subset h_subset).mpr
+      ⟨w, hw, λ h_live => hw_fails (h_trivial w h_live)⟩,
+    w, hw, hw_fails⟩
 
 /-- When the domain-restricted conditional holds over an expanded domain
     where the consequent is non-trivial, the antecedent must exclude at
@@ -218,41 +154,6 @@ theorem nontrivial_conditional_excludes
   obtain ⟨w, hw, hw_fails⟩ := h_nontrivial
   exact ⟨w, hw, λ ha => hw_fails (h_cond w hw ha)⟩
 
-/-- Triviality is monotone: if a superset domain is trivial, then
-    so is any subset domain. Expanding the domain can only resolve
-    triviality, never introduce it. -/
-theorem trivial_monotone
-    (smallDomain expandedDomain : Set W)
-    (consequent : W → Prop)
-    (h_subset : smallDomain ⊆ expandedDomain)
-    (h_expanded_trivial : trivialConsequent expandedDomain consequent) :
-    trivialConsequent smallDomain consequent :=
-  λ w hw => h_expanded_trivial w (h_subset hw)
-
 end Triviality
-
-/-! ### Bridge: SUBJ as Domain-Expanding Shift -/
-
-section SubjBridge
-
-variable {W : Type*} {T : Type*} [Preorder T]
-
-/-- SUBJ's situation introduction can be decomposed into two steps:
-    1. Expand the domain (via backward time shift)
-    2. Existentially quantify over the expanded domain
-
-    When the history is backwards-closed, SUBJ at an earlier time introduces
-    a situation whose world is in the expanded historical alternatives. -/
-theorem subj_subsumes_hp_expansion
-    (history : HistoricalAlternatives W T)
-    (P : WorldTimeIndex W T → WorldTimeIndex W T → Prop)
-    (s : WorldTimeIndex W T)
-    (h : SUBJ history P s) :
-    ∃ s₁, s₁.world ∈ history s ∧ P s₁ s := by
-  obtain ⟨s₁, h_hist, hP⟩ := h
-  simp only [historicalBase, Set.mem_setOf_eq] at h_hist
-  exact ⟨s₁, h_hist.1, hP⟩
-
-end SubjBridge
 
 end Tense.ConditionalShift

--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -273,8 +273,8 @@ def presCFTower : ContextTower CFCtx :=
 theorem presCF_depth : presCFTower.depth = 1 := rfl
 
 /-- Modal ExclF holds: the counterfactual world ≠ the actual world. -/
-theorem presCF_modal_exclF : ExclF .modal presCFTower := by
-  unfold ExclF presCFTower actualTower actualCtx subjShift; decide
+theorem presCF_modal_exclF : ExclF .modal presCFTower :=
+  subjShift_produces_modal_exclF actualCtx false 0 Bool.false_ne_true
 
 /-- Temporal ExclF does *not* hold: the time is unchanged (0 = 0). -/
 theorem presCF_no_temporal_exclF : ¬ ExclF .temporal presCFTower := by
@@ -292,13 +292,15 @@ def pastCFTower : ContextTower CFCtx :=
 /-- The tower has depth 2 — matching two past morpheme layers. -/
 theorem pastCF_depth : pastCFTower.depth = 2 := rfl
 
-/-- Modal ExclF holds: the counterfactual world ≠ the actual world. -/
-theorem pastCF_modal_exclF : ExclF .modal pastCFTower := by
-  unfold ExclF pastCFTower presCFTower actualTower actualCtx subjShift; decide
+/-- Modal ExclF holds: the counterfactual world ≠ the actual world. The
+    modal+temporal pair is the substrate's PastCF configuration
+    (`two_shifts_two_exclFs`). -/
+theorem pastCF_modal_exclF : ExclF .modal pastCFTower :=
+  (two_shifts_two_exclFs actualCtx false 0 (-5) Bool.false_ne_true (by decide)).1
 
 /-- Temporal ExclF holds: the shifted time (-5) ≠ the speech time (0). -/
-theorem pastCF_temporal_exclF : ExclF .temporal pastCFTower := by
-  unfold ExclF pastCFTower presCFTower actualTower actualCtx subjShift temporalShift; decide
+theorem pastCF_temporal_exclF : ExclF .temporal pastCFTower :=
+  (two_shifts_two_exclFs actualCtx false 0 (-5) Bool.false_ne_true (by decide)).2
 
 /-- Tower depth (2) matches the PastCF ExclF-layer count (2). -/
 theorem pastCF_depth_matches_data :

--- a/Linglib/Studies/Mizuno2024.lean
+++ b/Linglib/Studies/Mizuno2024.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Modality.Exclusion
+import Linglib.Semantics.Tense.ConditionalShift
 import Linglib.Fragments.Japanese.Conditionals
 import Linglib.Fragments.Mandarin.Conditionals
 import Linglib.Studies.Iatridou2000
@@ -14,37 +15,39 @@ the Typology of O-Marking and X-Marking", *Semantics and Pragmatics* 17(8): 1–
 Anderson conditionals ([anderson-1951]) argue *for* the truth of their antecedent
 ("If Jones had taken arsenic, he would show exactly the symptoms he is showing — so he
 took arsenic"). Mizuno shows that English must X-mark them (O-marking is trivial),
-whereas Japanese and Mandarin must O-mark them (X-marking — Past -ta, perfective le —
-forces a counterfactual reading). Both strategies avoid triviality by **expanding** the
-modal domain `D ⊆ D⁺`; Mizuno adopts the *expansion* analysis of X-marking (fn 6, citing
-[mackay-2015] against the [iatridou-2000] / [schulz-2014] exclusion analysis), and
+whereas Japanese and Mandarin must O-mark them: their X-marking — the Fake Past -ta
+([ogihara-2014], [mizuno-kaufmann-2019]) and perfective le — forces a counterfactual
+reading. Both strategies avoid triviality by **expanding** the modal domain `D ⊆ D⁺`;
+Mizuno adopts the *expansion* analysis of X-marking (fn 6, citing [mackay-2015],
+[mackay-2019] against the [iatridou-2000] / [schulz-2014] exclusion analysis), and
 analyzes Japanese O-marking as a Historical-Present perspectival shift ([schlenker-2004],
-[ogihara-2014], [mizuno-kaufmann-2019]) that expands `D` by shifting the evaluation time
-backward under branching time.
+[anand-toosarvandani-2018a], [anand-toosarvandani-2018b]) that expands `D` by shifting
+the evaluation time backward under branching time.
 
 ## Main results
 
 * `english_japanese_discrepancy` — English X-marks, Japanese O-marks: the typological twist.
-* `complementary_strategy` — in each language exactly one of the two markings is felicitous.
 * `attested_felicity_matches_strategy` — the attested judgments fit the per-language strategy.
 * `flv_anderson_correlation` — Anderson X-marking ⇔ Future-Less-Vivid X-marking (§4.2).
 * `oMarking_anderson_trivial` / `expansion_resolves_anderson` / `expanded_anderson_informative`
   — the triviality puzzle and its resolution by domain expansion, on the Jones-arsenic scenario.
-* `hp_expands_jones_domain` — Japanese HP: the backward time shift enlarges the live-possibility domain.
+* `hp_expands_jones_domain` / `hp_resolves_anderson` — Japanese HP: the backward time
+  shift enlarges the live-possibility domain, achieving the same semantic effect as
+  X-marking — Mizuno's take (§4.1) on [von-fintel-iatridou-2023]'s uniformity hypothesis.
 
 The glossed stimuli live in `Data/Examples/Mizuno2024.json` (generated module
 `Mizuno2024.Examples`); the substrate (`Semantics.Modality.Exclusion`,
 `Semantics.Tense.ConditionalShift`, both of which cite [mizuno-2024]) supplies the
-domain-expansion machinery instantiated here.
+marking typology and domain-expansion machinery instantiated here.
 -/
 
 namespace Mizuno2024
 
-open Semantics.Modality.Exclusion
-  (MarkingStrategy oMarking_trivial domain_expansion_avoids_triviality
-   expanded_conditional_informative)
+open Semantics.Modality.Exclusion (MarkingStrategy)
 open Tense.ConditionalShift
-  (trivialConsequent nonTrivialConsequent domainRestrictedConditional history_monotone_set)
+  (trivialConsequent nonTrivialConsequent domainRestrictedConditional
+   trivial_domainRestricted expansion_resolves_triviality
+   nontrivial_conditional_excludes history_antitone)
 open Data.Examples (LinguisticExample)
 
 /-! ### Languages and Anderson-conditional strategies
@@ -58,9 +61,9 @@ inductive Language where
   | english | japanese | mandarin
   deriving DecidableEq, Repr
 
-/-- The marking strategy each language uses for *felicitous* Anderson conditionals
-    ([mizuno-2024], §2–3): English X-marks (ex. 1a); Japanese and Mandarin O-mark
-    (ex. 4a -ru, ex. 13a without final le). -/
+/-- The marking strategy each language uses for *felicitous* Anderson conditionals:
+    English X-marks (§2, ex. 1a); Japanese O-marks (§3, ex. 4a -ru); Mandarin O-marks
+    (§4.2, ex. 13a without final le). -/
 def andersonStrategy : Language → MarkingStrategy
   | .english => .xMarking
   | .japanese => .oMarking
@@ -75,26 +78,17 @@ def flvXMarkingAvailable : Language → Bool
   | .mandarin => false
 
 /-- A marking is felicitous for an Anderson conditional in a language iff it is that
-    language's Anderson strategy. Derived from `andersonStrategy`, not stipulated:
-    English requires X-marking (O-marking is trivial, ex. 2); Japanese/Mandarin require
-    O-marking (X-marking is counterfactual, ex. 4a #ta / ex. 13a #le). -/
-def felicitousForAnderson (lang : Language) (m : MarkingStrategy) : Prop :=
+    language's Anderson strategy — so exactly one of the two markings is felicitous per
+    language. Derived from `andersonStrategy`, not stipulated: English requires X-marking
+    (O-marking is trivial, ex. 2); Japanese/Mandarin require O-marking (X-marking is
+    counterfactual, ex. 4a #ta / ex. 13a #le). -/
+abbrev felicitousForAnderson (lang : Language) (m : MarkingStrategy) : Prop :=
   m = andersonStrategy lang
-
-theorem english_xMarks : andersonStrategy .english = .xMarking := rfl
-theorem japanese_oMarks : andersonStrategy .japanese = .oMarking := rfl
-theorem mandarin_oMarks : andersonStrategy .mandarin = .oMarking := rfl
 
 /-- The core typological twist ([mizuno-2024], §3): English and Japanese pick *opposite*
     strategies for Anderson conditionals. -/
 theorem english_japanese_discrepancy :
     andersonStrategy .english ≠ andersonStrategy .japanese := by decide
-
-/-- The two strategies are in complementary distribution: in every language exactly one
-    of X-marking / O-marking is felicitous for an Anderson conditional ([mizuno-2024], §3). -/
-theorem complementary_strategy (lang : Language) :
-    felicitousForAnderson lang .xMarking ↔ ¬ felicitousForAnderson lang .oMarking := by
-  unfold felicitousForAnderson; cases lang <;> decide
 
 /-! ### Attested minimal pairs (the empirical anchor)
 
@@ -118,33 +112,23 @@ def ofGlottocode : String → Option Language
   | "mand1415" => some .mandarin
   | _ => none
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (e : LinguisticExample) (k : String) : Option String :=
-  (e.paperFeatures.find? (·.1 == k)).map (·.2)
-
 /-- Parse the `strategy` tag into a `MarkingStrategy`. -/
 def ofStrategyTag : String → Option MarkingStrategy
   | "x-marking" => some .xMarking
   | "o-marking" => some .oMarking
   | _ => none
 
-/-- The complementary marking strategy ([mizuno-2024], §2: "O-marking [is] generally
-    defined as the absence of X-marking"). The infelicitous alternative in a minimal pair
-    realizes the complement of the felicitous `primaryText`'s strategy. -/
-def otherMarking : MarkingStrategy → MarkingStrategy
-  | .xMarking => .oMarking
-  | .oMarking => .xMarking
-
 /-- Project the Anderson rows from an example: the `primaryText`'s (strategy, felicity),
-    plus — for a minimal-pair example — the complementary strategy paired with the
-    alternative's judgment. Non-Anderson examples and unrecognized language/strategy tags
-    yield no rows. -/
+    plus — for a minimal-pair example — the complementary strategy (`MarkingStrategy.other`,
+    per §2's "O-marking [is] generally defined as the absence of X-marking") paired with
+    the alternative's judgment. Non-Anderson examples and unrecognized language/strategy
+    tags yield no rows. -/
 def andersonRows (e : LinguisticExample) : List (Language × MarkingStrategy × Bool) :=
-  match ofGlottocode e.language, featureOf e "construction",
-        (featureOf e "strategy").bind ofStrategyTag with
+  match ofGlottocode e.language, e.feature? "construction",
+        (e.feature? "strategy").bind ofStrategyTag with
   | some lang, some "anderson", some m =>
       (lang, m, isFelicitous e.judgment) ::
-        e.alternatives.map (fun a => (lang, otherMarking m, isFelicitous a.2))
+        e.alternatives.map (λ a => (lang, m.other, isFelicitous a.2))
   | _, _, _ => []
 
 /-- All attested Anderson rows, projected from the generated example data. -/
@@ -152,11 +136,10 @@ def attestedAndersonRows : List (Language × MarkingStrategy × Bool) :=
   Examples.all.flatMap andersonRows
 
 /-- The attested judgments fit the per-language strategy: every projected row is
-    felicitous iff its marking is the language's `andersonStrategy` (i.e.
-    `felicitousForAnderson`). Derived from the JSON data, not stipulated — flipping any
-    judgment in `Data/Examples/Mizuno2024.json` breaks this. -/
+    felicitous iff its marking is `felicitousForAnderson` in its language. -/
 theorem attested_felicity_matches_strategy :
-    ∀ r ∈ attestedAndersonRows, (r.2.2 = true ↔ r.2.1 = andersonStrategy r.1) := by decide
+    ∀ r ∈ attestedAndersonRows, (r.2.2 = true ↔ felicitousForAnderson r.1 r.2.1) := by
+  decide
 
 /-- The projection is non-vacuous and covers all six cells: both markings are attested in
     every language (English via ex. 1a / 2, Japanese and Mandarin via the 4a / 13a minimal
@@ -175,8 +158,8 @@ theorem attestedAndersonRows_complete :
     conditionals stand or fall together. Across English / Japanese / Mandarin, a language
     X-marks Anderson conditionals iff X-marking is available for its FLV conditionals.
     An empirical generalization (Mizuno speculates a [chierchia-1998] Blocking Principle:
-    covert HP is blocked where overt X-marking is available), not a definitional identity —
-    the two functions are recorded independently. -/
+    covert HP is blocked where overt X-marking is available, fn 14), not a definitional
+    identity — the two functions are recorded independently. -/
 theorem flv_anderson_correlation (lang : Language) :
     (andersonStrategy lang).hasXMarking = flvXMarkingAvailable lang := by
   cases lang <;> rfl
@@ -191,7 +174,7 @@ theorem english_flv_matches_iatridou :
 
 /-- FLV X-marking availability read from the example data (`flv_xmarking` tag). -/
 def flvAvailableTag (e : LinguisticExample) : Option Bool :=
-  match featureOf e "flv_xmarking" with
+  match e.feature? "flv_xmarking" with
   | some "available"   => some true
   | some "unavailable" => some false
   | _                  => none
@@ -211,13 +194,12 @@ conditional is trivially true and uninformative. Both strategies fix this by exp
 to `D⁺ ⊋ D` containing a world where the consequent fails. Mizuno adopts the *expansion*
 analysis of X-marking (fn 6, citing [mackay-2015] against [iatridou-2000] exclusion).
 
-We instantiate the substrate's expansion machinery (`Semantics.Modality.Exclusion`,
-`Semantics.Tense.ConditionalShift`) on the Jones-arsenic scenario: `World = Bool`, where
-`true` is a world in which Jones shows the arsenic symptoms (the observed fact) and `false`
-one in which he does not. -/
+We instantiate the substrate's expansion machinery (`Semantics.Tense.ConditionalShift`)
+on the Jones-arsenic scenario: `World = Bool`, where `true` is a world in which Jones
+shows the arsenic symptoms (the observed fact) and `false` one in which he does not. -/
 
 /-- The Anderson consequent: Jones shows the (arsenic) symptoms. -/
-def showsSymptoms : Bool → Prop := fun w => w = true
+def showsSymptoms : Bool → Prop := λ w => w = true
 
 /-- The non-expanded domain `D` of live possibilities: Jones is assumed to show the
     symptoms, so the only live world is the symptom-showing one. -/
@@ -228,26 +210,22 @@ def expandedDomain : Set Bool := Set.univ
 
 /-- Over `D`, the consequent is trivial — it is an observed fact holding at every live
     world ([mizuno-2024], §2). -/
-theorem consequent_trivial_over_live : trivialConsequent liveDomain showsSymptoms := by
-  intro w hw
-  simp only [liveDomain, Set.mem_singleton_iff] at hw
-  simpa [showsSymptoms] using hw
+theorem consequent_trivial_over_live : trivialConsequent liveDomain showsSymptoms :=
+  λ _ hw => hw
 
 /-- O-marking without expansion: the Anderson conditional is vacuously true over `D` for
     *any* antecedent — Mizuno's triviality puzzle, the infelicity of ex. (2). -/
 theorem oMarking_anderson_trivial (antecedent : Bool → Prop) :
     domainRestrictedConditional liveDomain antecedent showsSymptoms :=
-  oMarking_trivial liveDomain antecedent showsSymptoms consequent_trivial_over_live
+  trivial_domainRestricted liveDomain antecedent showsSymptoms consequent_trivial_over_live
 
-/-- Expansion resolves triviality: `D⁺` contains the symptom-absent `false`-world, so the
-    consequent is non-trivial over `D⁺` ([mizuno-2024], §2). -/
+/-- X-marking's expansion resolves triviality, and is strict — the paper's `D ⊂ D⁺`:
+    `D⁺` properly extends the live domain and contains the symptom-absent `false`-world,
+    so the consequent is non-trivial over `D⁺` ([mizuno-2024], §2). -/
 theorem expansion_resolves_anderson :
-    nonTrivialConsequent expandedDomain showsSymptoms :=
-  domain_expansion_avoids_triviality liveDomain expandedDomain showsSymptoms
-    (by simp only [expandedDomain]; exact Set.subset_univ _)
-    consequent_trivial_over_live
-    false (by simp only [expandedDomain]; exact Set.mem_univ _)
-    (by simp only [showsSymptoms]; decide)
+    liveDomain ⊂ expandedDomain ∧ nonTrivialConsequent expandedDomain showsSymptoms :=
+  expansion_resolves_triviality liveDomain expandedDomain showsSymptoms
+    (Set.subset_univ _) consequent_trivial_over_live false (Set.mem_univ _) Bool.false_ne_true
 
 /-- The payoff ([mizuno-2024], §2: "one can make a meaningful, contingent claim"): an
     Anderson conditional that holds over the expanded `D⁺` is informative — its antecedent
@@ -255,46 +233,56 @@ theorem expansion_resolves_anderson :
 theorem expanded_anderson_informative (antecedent : Bool → Prop)
     (h : domainRestrictedConditional expandedDomain antecedent showsSymptoms) :
     ∃ w ∈ expandedDomain, ¬ antecedent w :=
-  expanded_conditional_informative expandedDomain antecedent showsSymptoms
-    expansion_resolves_anderson h
+  nontrivial_conditional_excludes expandedDomain antecedent showsSymptoms
+    expansion_resolves_anderson.2 h
 
 /-! ### Japanese O-marking: HP expansion under branching time
 
 [mizuno-2024]'s analysis of why Japanese O-marking (Non-Past) escapes triviality without
-X-marking (§3.3–3.4): the Historical-Present shift moves the evaluation time backward, and
-since live possibilities monotonically shrink as time develops ([condoravdi-2002]'s
-backward-closed history), the earlier-time domain is *larger* — domain expansion without
-counterfactual morphology. -/
+X-marking (§3.3): the Historical-Present shift moves the evaluation time backward, and
+since live possibilities monotonically shrink as time develops (Mizuno's assumption,
+which the substrate encodes as a backward-closed history à la [condoravdi-2002]), the
+earlier-time domain is *larger* — domain expansion without counterfactual morphology. -/
 
 /-- A backward-closed history witnessing HP expansion: a world is a live alternative to
     `s` iff it is `s`'s own world, or `s`'s time is at or before `0`. Earlier times have
     strictly more alternatives. -/
 def historyJones : HistoricalAlternatives Bool ℤ :=
-  fun s => { w | w = s.world ∨ s.time ≤ 0 }
+  λ s => { w | w = s.world ∨ s.time ≤ 0 }
 
-theorem historyJones_backwardsClosed : historyJones.backwardsClosed := by
-  intro w w' t t' hle hmem
-  simp only [historyJones, Set.mem_setOf_eq] at hmem ⊢
-  rcases hmem with h | h
-  · exact Or.inl h
-  · exact Or.inr (le_trans hle h)
+theorem historyJones_backwardsClosed : historyJones.backwardsClosed :=
+  λ _ _ _ _ hle hmem => Or.imp id (le_trans hle) hmem
 
 /-- The HP backward shift enlarges the domain of live possibilities: the symptom-absent
     world `false` is *not* a live alternative at the utterance time (`t = 1`) but *is* one
     at the HP-shifted earlier time (`t = 0`), so the expanded domain contains a
-    consequent-failing world — exactly [mizuno-2024]'s argument for Japanese (§3.3–3.4).
-    The subset direction is the substrate's `history_monotone_set`. -/
+    consequent-failing world — exactly [mizuno-2024]'s argument for Japanese (§3.3).
+    The subset direction is the substrate's `history_antitone`. -/
 theorem hp_expands_jones_domain :
     historyJones ⟨true, 1⟩ ⊆ historyJones ⟨true, 0⟩ ∧
       false ∈ historyJones ⟨true, 0⟩ ∧ false ∉ historyJones ⟨true, 1⟩ := by
-  refine ⟨history_monotone_set historyJones historyJones_backwardsClosed ⟨true, 1⟩ 0 (by decide),
-    ?_, ?_⟩
-  · simp only [historyJones, Set.mem_setOf_eq]; decide
-  · simp only [historyJones, Set.mem_setOf_eq]; decide
+  refine ⟨history_antitone historyJones historyJones_backwardsClosed true (by decide),
+    Or.inr le_rfl, ?_⟩
+  simp [historyJones]
+
+/-- Japanese O-marking end-to-end ([mizuno-2024], §3.3): the HP-shifted domain strictly
+    extends the live one and makes the consequent non-trivial — the same semantic effect
+    X-marking achieves by direct expansion (`expansion_resolves_anderson`). Together with
+    `english_japanese_discrepancy`, this renders §4.1's take on
+    [von-fintel-iatridou-2023]'s uniformity hypothesis: the semantic contribution of the
+    two strategies coincides (strict domain expansion resolving triviality); what varies
+    across languages is which strategy may be *deployed* for Anderson conditionals. -/
+theorem hp_resolves_anderson :
+    liveDomain ⊂ historyJones ⟨true, 0⟩ ∧
+      nonTrivialConsequent (historyJones ⟨true, 0⟩) showsSymptoms :=
+  expansion_resolves_triviality liveDomain (historyJones ⟨true, 0⟩) showsSymptoms
+    (Set.Subset.trans (λ _ hw => Or.inl hw) hp_expands_jones_domain.1)
+    consequent_trivial_over_live
+    false hp_expands_jones_domain.2.1 Bool.false_ne_true
 
 /-! ### Fragment marker connection -/
 
--- Japanese Anderson conditionals use -(r)eba, which marks both HC and PC (unlike HC-only
+-- Japanese Anderson conditionals use -(e)ba, which marks both HC and PC (unlike HC-only
 -- -ra): with Non-Past consequent → Anderson, with Past consequent → counterfactual.
 #guard Japanese.Conditionals.eba.markerType ==
   Semantics.Conditionals.ConditionalMarkerType.both

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9604,7 +9604,35 @@
   subfield  = {semantics/conditionals},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Conditionals/Anderson.lean;Studies/Mizuno2024.lean;Semantics/Tense/ConditionalShift.lean}
+  sources   = {Semantics/Modality/Exclusion.lean;Semantics/Tense/ConditionalShift.lean;Studies/Mizuno2024.lean}
+}
+@inproceedings{anand-toosarvandani-2018a,
+  author    = {Anand, Pranav and Toosarvandani, Maziar},
+  year      = {2018},
+  title     = {No Explanation for the Historical Present: Temporal Sequencing and Discourse},
+  booktitle = {Sinn und Bedeutung (SuB)},
+  volume    = {22},
+  number    = {1},
+  pages     = {73--90},
+  doi       = {10.21248/zaspil.60.2018.455},
+  subfield  = {semantics/tense},
+  validated = {true},
+  role      = {cited},
+  sources   = {Studies/Mizuno2024.lean}
+}
+@inproceedings{anand-toosarvandani-2018b,
+  author    = {Anand, Pranav and Toosarvandani, Maziar},
+  year      = {2018},
+  title     = {Unifying the Canonical, Historical, and Play-by-Play Present},
+  booktitle = {Sinn und Bedeutung (SuB)},
+  volume    = {21},
+  number    = {1},
+  pages     = {19--34},
+  doi       = {10.18148/sub/2018.v21i1.122},
+  subfield  = {semantics/tense},
+  validated = {true},
+  role      = {cited},
+  sources   = {Studies/Mizuno2024.lean}
 }
 @article{mackay-2015,
   author    = {Mackay, John},


### PR DESCRIPTION
Random-file deep audit of `Studies/Mizuno2024.lean` (3-reviewer panel + PDF verification against S&P 17(8)).

- de-fabricate: `§3.3–3.4`→`§3.3` (paper's §3 ends at 3.3); HP analysis re-attributed to Schlenker 2004 + Anand & Toosarvandani 2018a,b (new verified bib entries; Ogihara/Mizuno-Kaufmann back to Fake Past); Condoravdi reframed as substrate anchor (uncited by Mizuno); `en1a` provenance was Mizuno's adaptation, not Anderson "(orig.)"; deleted `requiresActuallyOperator` (contradicted by O-marked ex. 7a/13a containing 'actually') and the Deal-2020-misattributed `PastMorphologyUse` bridge (Deal 2020 is indexical shift, not tense).
- prune verified-dead substrate (−623 lines): ConditionalShift's Anderson-context layer, Exclusion's ULC/tower wrappers and same-signature re-exports; study now calls ConditionalShift directly; Iatridou2000's tower theorems rewired onto the surviving ExclF API; `expansion_resolves_triviality` strengthened to strict `D ⊂ D⁺` (all hypotheses now load-bearing, matches the paper); `history_antitone` restated via `Antitone`; Restrictor's bridge theorem now actually states `domainRestrictedConditional`.
- study golf per mathlib calibration: vacuous `complementary_strategy` + three `:= rfl` restatements deleted; new `hp_resolves_anderson` renders §4.1's uniformity point (same semantic effect, language-varying deployment); `LinguisticExample.feature?` added to Schema (24-file dedup sweep to follow separately).