### PR TITLE
refactor(Studies): dedup featureOf onto LinguisticExample.feature?

### DIFF
--- a/Linglib/Studies/AhnZhu2025.lean
+++ b/Linglib/Studies/AhnZhu2025.lean
@@ -181,24 +181,20 @@ section Data
 
 open Data.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-private def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- *na*-CL is acceptable in every condition (both bridging types, both noun
 types) — *na* itself is the relationalizer, so it always supplies the relatum
 slot (`bridge_licensed_iff`, `naApp = true`). -/
 theorem naCL_rows_acceptable :
-    ∀ row ∈ Examples.all, featureOf row "definite_form" = some "naCL" →
+    ∀ row ∈ Examples.all, row.feature? "definite_form" = some "naCL" →
       row.judgment = .acceptable := by decide
 
 /-- Bare + **relational** noun bridges (Study 4): the lexically 2-place noun
 supplies its own relatum (`relational_bare_felicitous`). -/
 theorem bare_relational_noun_bridges :
     ∀ row ∈ Examples.all,
-      featureOf row "definite_form" = some "bare" →
-      featureOf row "bridging_type" = some "relational" →
-      featureOf row "noun_arity" = some "relational" →
+      row.feature? "definite_form" = some "bare" →
+      row.feature? "bridging_type" = some "relational" →
+      row.feature? "noun_arity" = some "relational" →
       row.judgment = .acceptable := by decide
 
 /-- **The decisive Study-4 cell.** Bare + **non-relational** noun in relational
@@ -207,9 +203,9 @@ is lexically relational (`bare_nonrelational_cannot_bridge`). Marginal, not out:
 the cell is rated below its rivals but not at floor. -/
 theorem bare_nonrelational_noun_degraded :
     ∀ row ∈ Examples.all,
-      featureOf row "definite_form" = some "bare" →
-      featureOf row "bridging_type" = some "relational" →
-      featureOf row "noun_arity" = some "sortal" →
+      row.feature? "definite_form" = some "bare" →
+      row.feature? "bridging_type" = some "relational" →
+      row.feature? "noun_arity" = some "sortal" →
       row.judgment = .marginal := by decide
 
 /-- English demonstrative *that* is **degraded but not ungrammatical** in bridging
@@ -217,12 +213,12 @@ theorem bare_nonrelational_noun_degraded :
 Modelled as `.marginal` (the paper's gradient ~4.3–5.0/7 finding), in contrast to
 English *the*, which is acceptable. -/
 theorem english_that_degraded :
-    ∀ row ∈ Examples.all, featureOf row "definite_form" = some "that" →
+    ∀ row ∈ Examples.all, row.feature? "definite_form" = some "that" →
       row.judgment = .marginal := by decide
 
 /-- English definite *the* bridges freely (Study 2 baseline). -/
 theorem english_the_acceptable :
-    ∀ row ∈ Examples.all, featureOf row "definite_form" = some "the" →
+    ∀ row ∈ Examples.all, row.feature? "definite_form" = some "the" →
       row.judgment = .acceptable := by decide
 
 end Data

--- a/Linglib/Studies/AlstottAravind2026TemporalConnectives.lean
+++ b/Linglib/Studies/AlstottAravind2026TemporalConnectives.lean
@@ -20,7 +20,7 @@ Connects three layers:
 
 ## Main declarations
 
-- `vendlerOf`, `featureOf`: adapters reading a row's `paperFeatures`
+- `vendlerOf`: adapter reading a row's `paperFeatures`
 - `coercion_tracks_embedded_telicity`: a *before*/*after* row records a
   coercion operator exactly when the connective × embedded-telicity pair
   demands one (COMPLET for *before* + telic, INCHOAT for *after* + atelic)
@@ -83,13 +83,9 @@ theorem telicity_sensitivity_iff_ordering :
 -- § 2: Row Adapters
 -- ============================================================================
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Vendler-class adapter: the row's `vendler_class` feature. -/
 def vendlerOf (row : LinguisticExample) : Option VendlerClass :=
-  match featureOf row "vendler_class" with
+  match row.feature? "vendler_class" with
   | some "state"          => some .state
   | some "activity"       => some .activity
   | some "achievement"    => some .achievement
@@ -117,8 +113,8 @@ def expectedCoercion (conn : String) (c : VendlerClass) : Option String :=
     [alstott-aravind-2026]'s Exps 2 (COMPLET) and 4 (INCHOAT). -/
 theorem coercion_tracks_embedded_telicity :
     ∀ row ∈ AlstottAravind2026.Examples.all,
-      featureOf row "coercion" =
-        (featureOf row "connective").bind fun conn =>
+      row.feature? "coercion" =
+        (row.feature? "connective").bind fun conn =>
           (vendlerOf row).bind fun c => expectedCoercion conn c := by
   decide
 
@@ -129,8 +125,8 @@ theorem default_reading_matches_fragment :
     before_.defaultReading = .beforeStart ∧
     after_.defaultReading = .afterFinish ∧
     ∀ row ∈ AlstottAravind2026.Examples.all,
-      featureOf row "default_reading" =
-        (featureOf row "connective").bind fun conn =>
+      row.feature? "default_reading" =
+        (row.feature? "connective").bind fun conn =>
           if conn = "before" then some "before-start"
           else if conn = "after" then some "after-finish"
           else none :=
@@ -143,8 +139,8 @@ theorem coerced_reading_matches_fragment :
     before_.coercedReading = some .beforeFinish ∧
     after_.coercedReading = some .afterStart ∧
     ∀ row ∈ AlstottAravind2026.Examples.all,
-      featureOf row "coerced_reading" =
-        (featureOf row "coercion").bind fun op =>
+      row.feature? "coerced_reading" =
+        (row.feature? "coercion").bind fun op =>
           if op = "COMPLET" then some "before-finish"
           else if op = "INCHOAT" then some "after-start"
           else none :=
@@ -234,7 +230,7 @@ def whenCoercionLabel : WhenTarget → Option String
     accomplishments to their telos. -/
 theorem when_coercion_matches_ms :
     ∀ row ∈ MoensSteedman1988.Examples.all,
-      featureOf row "coercion" =
+      row.feature? "coercion" =
         (vendlerOf row).bind fun c => whenCoercionLabel (msOf c).whenTarget := by
   decide
 
@@ -242,8 +238,8 @@ theorem when_coercion_matches_ms :
     records achievement as its result class. -/
 theorem when_coercion_targets_achievement :
     ∀ row ∈ MoensSteedman1988.Examples.all,
-      (featureOf row "coercion").isSome →
-        featureOf row "result_class" = some "achievement" := by
+      (row.feature? "coercion").isSome →
+        row.feature? "result_class" = some "achievement" := by
   decide
 
 -- ============================================================================

--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -461,15 +461,10 @@ states one. The NegStrategy → InflPattern mapping lives in
 the most common verbal-negator → aux-headed mapping, and the Kwerba
 rows witness below that it is a tendency, not a law. -/
 
-/-- Value of a row's `paperFeatures` key, if present. -/
-private def featureOf (row : Data.Examples.LinguisticExample)
-    (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Udihe (49) *bi ei-mi sa:* is classified aux-headed by Anderson,
     and the strategy-level projection expects exactly that. -/
 theorem udihe_negVerb_expects_auxHeaded :
-    featureOf Examples.udihe_neg "infl_pattern" = some "auxHeaded" ∧
+    Examples.udihe_neg.feature? "infl_pattern" = some "auxHeaded" ∧
     NegStrategy.negVerb.expectedInflPattern = some .auxHeaded :=
   ⟨rfl, rfl⟩
 
@@ -478,7 +473,7 @@ theorem udihe_negVerb_expects_auxHeaded :
     expectation of `NegStrategy.expectedInflPattern` is defeasible —
     Anderson's own four-pattern list is the counterexample source. -/
 theorem kwerba_negVerb_lexHeaded_counterexample :
-    featureOf Examples.kwerba_neg_fut "infl_pattern" = some "lexHeaded" ∧
+    Examples.kwerba_neg_fut.feature? "infl_pattern" = some "lexHeaded" ∧
     NegStrategy.negVerb.expectedInflPattern ≠ some .lexHeaded :=
   ⟨rfl, by decide⟩
 

--- a/Linglib/Studies/ArregiPietraszko2021.lean
+++ b/Linglib/Studies/ArregiPietraszko2021.lean
@@ -455,18 +455,14 @@ def declarativeChain : GenHMChain where
 -- § 2  Bridge Table: Empirical Data Meets GenHM Predictions
 -- ============================================================================
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Does the sentence use do-support? (`do_support` feature). -/
 def usesDoSupport (row : LinguisticExample) : Option Bool :=
-  (featureOf row "do_support").map (· == "true")
+  (row.feature? "do_support").map (· == "true")
 
 /-- Does the probe carry lexical content? (auxiliary = true, lexical
     V = false; `verb_type` feature). -/
 def probeHasContent (row : LinguisticExample) : Option Bool :=
-  (featureOf row "verb_type").map (· == "auxiliary")
+  (row.feature? "verb_type").map (· == "auxiliary")
 
 /-- A&P's do-support paradigm as a bridge table: each generated row
     paired with the GenHM chain configuration assigned in §1.

--- a/Linglib/Studies/BergenGoodman2015.lean
+++ b/Linglib/Studies/BergenGoodman2015.lean
@@ -495,13 +495,9 @@ the listener infers that the speaker had reason to protect the stressed word,
 implying exhaustive knowledge.
 -/
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : Data.Examples.LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Utterance adapter: a row's `stress` feature as a `ProsodyModel.Utterance`. -/
 def uttOf (row : Data.Examples.LinguisticExample) : Option ProsodyModel.Utterance :=
-  match featureOf row "stress" with
+  match row.feature? "stress" with
   | some "subject" => some .BOB_went
   | some "none"    => some .bobWent
   | _              => none

--- a/Linglib/Studies/Collins2005.lean
+++ b/Linglib/Studies/Collins2005.lean
@@ -211,36 +211,32 @@ and both *have* and passive *be* select PartP. -/
 
 open Data.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- **C-command rows (10a–d)**: a binding/NPI dependency succeeds iff the
     licensee sits in the by-phrase — the derived subject c-commands the
     by-phrase and not conversely, exactly the asymmetry the smuggled-object
     configuration predicts. -/
 theorem c_command_rows_acceptable_iff_licensee_in_by_phrase :
-    ∀ row ∈ Examples.all, featureOf row "test" = some "c_command" →
+    ∀ row ∈ Examples.all, row.feature? "test" = some "c_command" →
       (row.judgment = .acceptable ↔
-        featureOf row "licensee_position" = some "by_phrase") := by
+        row.feature? "licensee_position" = some "by_phrase") := by
   decide
 
 /-- **Particle rows (15–16)**: a passive particle clause is grammatical iff
     no DP object remains — PartP moved as a constituent, taking the
     particle and leaving no Case position for a second DP. -/
 theorem particle_rows_acceptable_iff_no_dp_object :
-    ∀ row ∈ Examples.all, featureOf row "test" = some "particle" →
+    ∀ row ∈ Examples.all, row.feature? "test" = some "particle" →
       (row.judgment = .acceptable ↔
-        featureOf row "has_dp_object" = some "false") := by
+        row.feature? "has_dp_object" = some "false") := by
   decide
 
 /-- **Auxiliary rows (23a–d)**: both *have* and passive *be* are grammatical
     iff their complement is a past participle — the shared PartP selection
     of conditions (24–25). -/
 theorem aux_rows_acceptable_iff_participial_complement :
-    ∀ row ∈ Examples.all, featureOf row "test" = some "aux_selection" →
+    ∀ row ∈ Examples.all, row.feature? "test" = some "aux_selection" →
       (row.judgment = .acceptable ↔
-        featureOf row "complement_form" = some "past_participle") := by
+        row.feature? "complement_form" = some "past_participle") := by
   decide
 
 end Collins2005

--- a/Linglib/Studies/DeoThomas2025.lean
+++ b/Linglib/Studies/DeoThomas2025.lean
@@ -94,13 +94,9 @@ def associatedSource : JustFlavor → AlternativeSource
 -- B. Row Adapters (Data/Examples/DeoThomas2025.json)
 -- ============================================================================
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- A row's `flavor` feature as a `JustFlavor`. -/
 def flavorOf (row : LinguisticExample) : Option JustFlavor :=
-  match featureOf row "flavor" with
+  match row.feature? "flavor" with
   | some "complementExclusion"   => some .complementExclusion
   | some "rankOrder"             => some .rankOrder
   | some "emphatic"              => some .emphatic
@@ -114,7 +110,7 @@ def flavorOf (row : LinguisticExample) : Option JustFlavor :=
 
 /-- A row's `context_type` feature as a `ContextType`. -/
 def contextTypeOf (row : LinguisticExample) : Option ContextType :=
-  match featureOf row "context_type" with
+  match row.feature? "context_type" with
   | some "answerable"    => some .answerable
   | some "qualityFail"   => some .qualityFail
   | some "relevanceFail" => some .relevanceFail
@@ -122,7 +118,7 @@ def contextTypeOf (row : LinguisticExample) : Option ContextType :=
 
 /-- Whether the row's `#only` substitution test succeeds. -/
 def onlyOkOf (row : LinguisticExample) : Bool :=
-  featureOf row "only_ok" == some "true"
+  row.feature? "only_ok" == some "true"
 
 -- ============================================================================
 -- C. Discourse Context

--- a/Linglib/Studies/Gasparri2025.lean
+++ b/Linglib/Studies/Gasparri2025.lean
@@ -28,10 +28,6 @@ namespace Gasparri2025
 
 open Data.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Judgment of the row's generic reading, if recorded. -/
 def genericOf (row : LinguisticExample) : Option Features.Judgment :=
   (row.readings.find? (·.1 == "generic")).map (·.2)
@@ -41,17 +37,17 @@ def genericOf (row : LinguisticExample) : Option Features.Judgment :=
     This is the asymmetry predicativism leaves unexplained: if *Ruth* is
     just ⟦the⟧ + a predicate, it should pattern with *the tiger*. -/
 theorem generic_recalcitrance :
-    ∀ row ∈ Examples.all, featureOf row "licensor" = some "none" →
+    ∀ row ∈ Examples.all, row.feature? "licensor" = some "none" →
       (genericOf row = some .acceptable ↔
-        featureOf row "subject_type" = some "definite_common") := by
+        row.feature? "subject_type" = some "definite_common") := by
   decide
 
 /-- Naming-convention contexts license generic readings of BSNs:
     recalcitrance is not a categorical ban. -/
 theorem licensing_enables_generic :
     ∀ row ∈ Examples.all,
-      featureOf row "subject_type" = some "bare_name" →
-      featureOf row "licensor" = some "generic_context" →
+      row.feature? "subject_type" = some "bare_name" →
+      row.feature? "licensor" = some "generic_context" →
         genericOf row = some .acceptable := by
   decide
 

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -471,13 +471,9 @@ inductive ActualizationStatus where
   | absent
   deriving DecidableEq, Repr
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- The row's `semantic_type` feature as an `UntilType`. -/
 def untilTypeOf (row : LinguisticExample) : Option UntilType :=
-  match featureOf row "semantic_type" with
+  match row.feature? "semantic_type" with
   | some "before"   => some .before
   | some "endpoint" => some .endpoint
   | some "eventive" => some .eventive
@@ -485,7 +481,7 @@ def untilTypeOf (row : LinguisticExample) : Option UntilType :=
 
 /-- The row's `actualization` feature as an `ActualizationStatus`. -/
 def actualizationOf (row : LinguisticExample) : Option ActualizationStatus :=
-  match featureOf row "actualization" with
+  match row.feature? "actualization" with
   | some "entailment"  => some .entailment
   | some "implicature" => some .implicature
   | some "none"        => some .absent
@@ -513,7 +509,7 @@ theorem actualization_determined_by_type :
     connectives are nonveridical. -/
 theorem veridical_iff_endpoint :
     ∀ row ∈ Examples.all,
-      (featureOf row "complement_veridical" = some "true" ↔
+      (row.feature? "complement_veridical" = some "true" ↔
         untilTypeOf row = some .endpoint) := by
   decide
 
@@ -523,7 +519,7 @@ theorem veridical_iff_endpoint :
     provide; narrow scope (`narrowScopeNotUntil`) does not. -/
 theorem durative_main_iff_endpoint :
     ∀ row ∈ Examples.all,
-      (featureOf row "requires_durative_main" = some "true" ↔
+      (row.feature? "requires_durative_main" = some "true" ↔
         untilTypeOf row = some .endpoint) := by
   decide
 
@@ -532,7 +528,7 @@ theorem durative_main_iff_endpoint :
     NPI-*until*. -/
 theorem requires_de_iff_eventive :
     ∀ row ∈ Examples.all,
-      (featureOf row "requires_de" = some "true" ↔
+      (row.feature? "requires_de" = some "true" ↔
         untilTypeOf row = some .eventive) := by
   decide
 
@@ -541,9 +537,9 @@ theorem requires_de_iff_eventive :
 theorem npi_licensing_by_type :
     ∀ row ∈ Examples.all,
       (untilTypeOf row = some .before →
-        featureOf row "licenses_npis" = some "true") ∧
+        row.feature? "licenses_npis" = some "true") ∧
       (untilTypeOf row = some .endpoint →
-        featureOf row "licenses_npis" = some "false") := by
+        row.feature? "licenses_npis" = some "false") := by
   decide
 
 /-- Greek lexicalizes all three semantic types as distinct connectives:
@@ -564,7 +560,7 @@ def UntilType.greekMood : UntilType → Option String
     The mood split is the morphological reflex of (non)veridicality. -/
 theorem greek_mood_tracks_type :
     ∀ row ∈ Examples.all, row.language = "mode1248" →
-      featureOf row "mood" = (untilTypeOf row).bind UntilType.greekMood := by
+      row.feature? "mood" = (untilTypeOf row).bind UntilType.greekMood := by
   decide
 
 -- ============================================================================

--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -230,22 +230,18 @@ The generalizations are grounded in the verified glossed sentences of
 `Data/Examples/Iatridou2000.json` (generated `Iatridou2000.Examples`): all three CF types
 are attested, and the per-language imperfective fact matches the examples' `impf` tags. -/
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (e : LinguisticExample) (k : String) : Option String :=
-  (e.paperFeatures.find? (·.1 == k)).map (·.2)
-
 /-- The `impf` tag read as a Bool. -/
 def impfTag (e : LinguisticExample) : Option Bool :=
-  match featureOf e "impf" with
+  match e.feature? "impf" with
   | some "yes" => some true
   | some "no"  => some false
   | _          => none
 
 /-- All three CF types are attested in the English stimuli. -/
 theorem cf_types_attested :
-    featureOf Examples.en_flv "cf_type" = some "flv" ∧
-    featureOf Examples.en_presCF "cf_type" = some "presCF" ∧
-    featureOf Examples.en_pastCF "cf_type" = some "pastCF" := by decide
+    Examples.en_flv.feature? "cf_type" = some "flv" ∧
+    Examples.en_presCF.feature? "cf_type" = some "presCF" ∧
+    Examples.en_pastCF.feature? "cf_type" = some "pastCF" := by decide
 
 /-- `usesImperfectiveInCF` matches the example `impf` tags — English (no), Greek (yes),
     French (yes). Flipping a JSON tag or the generalization breaks this. -/
@@ -313,8 +309,8 @@ theorem pastCF_origin_preserved : pastCFTower.origin = actualCtx := rfl
     a PresCF (one modal ExclF, tower depth 1), (2b) a PastCF (two ExclFs, depth 2). Ties
     the glossed (2)-stimuli to the ContextTower model. -/
 theorem cf_diagnostics_examples :
-    featureOf Examples.ex2a "cf_type" = some "presCF" ∧
-    featureOf Examples.ex2b "cf_type" = some "pastCF" ∧
+    Examples.ex2a.feature? "cf_type" = some "presCF" ∧
+    Examples.ex2b.feature? "cf_type" = some "pastCF" ∧
     presCFTower.depth = 1 ∧ pastCFTower.depth = 2 :=
   ⟨by decide, by decide, rfl, rfl⟩
 

--- a/Linglib/Studies/Krifka2007.lean
+++ b/Linglib/Studies/Krifka2007.lean
@@ -181,13 +181,9 @@ equivalent to the bare positive (`equivalent_to_positive`). The theorems
 below are the transfer equations between those classifications and the
 strengthened model (§ 4-5). -/
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Quadruplet-form adapter: the row's `form` feature as an `AntonymForm`. -/
 def formOf (row : LinguisticExample) : Option AntonymForm :=
-  match featureOf row "form" with
+  match row.feature? "form" with
   | some "positive" => some .positive
   | some "notPositive" => some .notPositive
   | some "negative" => some .negative
@@ -197,7 +193,7 @@ def formOf (row : LinguisticExample) : Option AntonymForm :=
 /-- Interpretation adapter: the row's preferred `interpretation` feature as a
     `NegationType`. -/
 def interpretationOf (row : LinguisticExample) : Option NegationType :=
-  match featureOf row "interpretation" with
+  match row.feature? "interpretation" with
   | some "contrary" => some .contrary
   | some "contradictory" => some .contradictory
   | _ => none
@@ -209,7 +205,7 @@ def interpretationOf (row : LinguisticExample) : Option NegationType :=
     analysis where the contrary behavior is pragmatically derived. -/
 theorem interpretation_follows_inner_neg :
     ∀ row ∈ TesslerFranke2019.Examples.all,
-      (featureOf row "inner_neg" = some "morphological" ↔
+      (row.feature? "inner_neg" = some "morphological" ↔
         interpretationOf row = some .contrary) := by
   decide
 
@@ -223,7 +219,7 @@ private instance {max : Nat} (tp : ThresholdPair max) (q : AntonymForm)
     (§ 5, Prediction 3-4) puts it on the non-equivalent side. -/
 theorem equivalent_to_positive_iff_strengthened :
     ∀ row ∈ TesslerFranke2019.Examples.all, ∀ f ∈ formOf row,
-      (featureOf row "equivalent_to_positive" = some "true" ↔
+      (row.feature? "equivalent_to_positive" = some "true" ↔
         ∀ d : HappyDeg, (AntonymForm.strengthenedDenot happyTP f d ↔
           AntonymForm.strengthenedDenot happyTP .positive d)) := by
   decide
@@ -248,7 +244,7 @@ theorem unhappy_marked_by_morphology :
     reading, the costlier one ("not happy") the marked contradictory one. -/
 theorem cost_eq_complexity :
     ∀ row ∈ TesslerFranke2019.Examples.all, ∀ f ∈ formOf row,
-      featureOf row "cost" = some (toString f.complexity) := by
+      row.feature? "cost" = some (toString f.complexity) := by
   decide
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Kubota2026.lean
+++ b/Linglib/Studies/Kubota2026.lean
@@ -177,17 +177,13 @@ The judgment data live in `Data/Examples/Kubota2026.json`. The adapters read a r
 `paperFeatures` back into the theory's vocabulary; the theorems restate the paper's
 generalizations as facts about the rows. -/
 
-/-- Value of a `paperFeatures` key, if present. -/
-private def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- The row's marker, as classified in `Marker.all` (by romaji form). -/
 def markerOf (row : LinguisticExample) : Option Marker :=
-  (featureOf row "marker").bind fun r => Marker.all.find? (·.form.romaji == r)
+  (row.feature? "marker").bind fun r => Marker.all.find? (·.form.romaji == r)
 
 /-- The row's modal flavor, from the `modalFlavor` feature. -/
 def flavorOf (row : LinguisticExample) : Option ModalFlavor :=
-  match featureOf row "modalFlavor" with
+  match row.feature? "modalFlavor" with
   | some "epistemic"      => some .epistemic
   | some "deontic"        => some .deontic
   | some "bouletic"       => some .bouletic
@@ -198,8 +194,8 @@ def flavorOf (row : LinguisticExample) : Option ModalFlavor :=
 is felicitous iff the discourse context makes a counterstance salient — (37)/(39)-Q1
 follow an evaluative assertion or question, (38)/(39)-Q2 a neutral question. -/
 theorem felicitous_iff_counterstance_salient :
-    ∀ row ∈ Examples.all, featureOf row "phenomenon" = some "counterstance" →
-      (row.judgment = .acceptable ↔ featureOf row "counterstanceSalient" = some "true") := by
+    ∀ row ∈ Examples.all, row.feature? "phenomenon" = some "counterstance" →
+      (row.judgment = .acceptable ↔ row.feature? "counterstanceSalient" = some "true") := by
   decide
 
 /-- The theory's prediction for a marker–modal row: the row's flavor lies in the
@@ -211,7 +207,7 @@ def predictedCompat (row : LinguisticExample) : Option Bool := do
 acceptable iff the marker's `modalCompat` contains the row's flavor — the selectional
 restrictions in `Marker` are exactly the attested judgment pattern. -/
 theorem modal_row_acceptable_iff_compat :
-    ∀ row ∈ Examples.all, featureOf row "phenomenon" = some "modalInteraction" →
+    ∀ row ∈ Examples.all, row.feature? "phenomenon" = some "modalInteraction" →
       (row.judgment = .acceptable ↔ predictedCompat row = some true) := by
   decide
 

--- a/Linglib/Studies/Lassiter2025.lean
+++ b/Linglib/Studies/Lassiter2025.lean
@@ -25,13 +25,9 @@ open Data.Examples
 open CaoWhiteLassiter2025
 open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Marker adapter: the Fragment entry for the row's conditional marker. -/
 def markerOf (row : LinguisticExample) : Option ConditionalMarker :=
-  match featureOf row "marker" with
+  match row.feature? "marker" with
   | some "nara"  => some Japanese.Conditionals.nara
   | some "ra"    => some Japanese.Conditionals.ra
   | some "wenn"  => some German.Conditionals.wenn
@@ -42,7 +38,7 @@ def markerOf (row : LinguisticExample) : Option ConditionalMarker :=
     content. Bare content forces the premise-conditional reading, so an
     HC-only marker cannot rescue the LNC. -/
 def bareContent (row : LinguisticExample) : Bool :=
-  featureOf row "content" == some "bare"
+  row.feature? "content" == some "bare"
 
 /-- The marker typology's prediction for a row: the LNC is licensed iff the
     marker can mark premise conditionals (`.both`) or non-bare content makes

--- a/Linglib/Studies/LeBruynDeSwart2022.lean
+++ b/Linglib/Studies/LeBruynDeSwart2022.lean
@@ -41,10 +41,6 @@ open Semantics.Kinds.NMP
   (chierchiaDerivScrambled chierchiaDerivUnscrambled chierchia_position_invariant)
 open Krifka2004 (krifkaDerivScrambled krifkaDerivUnscrambled scope_follows_position)
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Judgment of a named reading, if recorded. -/
 def readingOf (row : LinguisticExample) (name : String) : Option Features.Judgment :=
   (row.readings.find? (·.1 == name)).map (·.2)
@@ -129,7 +125,7 @@ theorem krifka_matches_scrambling_data :
 /-- A scrambled bare plural can still be kind-referring (the *haten* 'hate' cases,
 `Examples.boeken_gehaat`): scrambling affects scope, not kindhood. -/
 theorem scrambled_keeps_kind_reference :
-    featureOf Examples.boeken_gehaat "position" = some "scrambled" ∧
+    Examples.boeken_gehaat.feature? "position" = some "scrambled" ∧
     readingOf Examples.boeken_gehaat "kind_reference" = some .acceptable := ⟨rfl, rfl⟩
 
 end LeBruynDeSwart2022

--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -355,16 +355,12 @@ section StimulusRows
 
 open Data.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-private def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- The stimulus rows' judgment coding matches the rating data: a row is
 `.marginal` iff it instantiates an island condition (the lower-rated
 member of its experimental contrast). -/
 theorem stimulus_judgments_track_island_conditions :
     ∀ row ∈ Examples.all,
-      (featureOf row "island_condition" = some "true" ↔
+      (row.feature? "island_condition" = some "true" ↔
         row.judgment = .marginal) := by decide
 
 end StimulusRows

--- a/Linglib/Studies/Magri2009.lean
+++ b/Linglib/Studies/Magri2009.lean
@@ -1056,14 +1056,10 @@ section BarePluralBridge
 
 open Data.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- The row's predicate level ([carlson-1977]), read from the
     `predicate_level` feature. -/
 def predicateLevelOf (row : LinguisticExample) : Option PredicateLevel :=
-  match featureOf row "predicate_level" with
+  match row.feature? "predicate_level" with
   | some "individual" => some .individualLevel
   | some "stage"      => some .stageLevel
   | _                 => none
@@ -1085,7 +1081,7 @@ reading — matching [magri-2009]'s prediction that the ∃-BPS of an SLP
 is fine (no homogeneity → no mismatch). -/
 theorem slp_argument_data_matches_magri_prediction :
     ∀ row ∈ CohenErteschikShir2002.Examples.all,
-      featureOf row "locative_status" = some "argument" →
+      row.feature? "locative_status" = some "argument" →
         predicateLevelOf row = some .stageLevel ∧ existentialOK row = true := by
   decide
 
@@ -1103,7 +1099,7 @@ independently confirm the existential reading is available. -/
 theorem magri_predicts_slp_existential :
     bpsSLPScenario.blindOdd .existential_ = false ∧
     ∀ row ∈ CohenErteschikShir2002.Examples.all,
-      featureOf row "locative_status" = some "argument" → existentialOK row = true :=
+      row.feature? "locative_status" = some "argument" → existentialOK row = true :=
   ⟨by decide, fun row h hf => (slp_argument_data_matches_magri_prediction row h hf).2⟩
 
 end BarePluralBridge

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -35,12 +35,8 @@ namespace OgiharaSteinertThrelkeld2024
 open Data.Examples (LinguisticExample)
 open OgiharaSteinertThrelkeld2024.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (e : LinguisticExample) (k : String) : Option String :=
-  (e.paperFeatures.find? (·.1 == k)).map (·.2)
-
 /-- A `paperFeatures` flag read as a Bool (`true` iff the value is `"true"`). -/
-def flagOf (e : LinguisticExample) (k : String) : Bool := featureOf e k == some "true"
+def flagOf (e : LinguisticExample) (k : String) : Bool := e.feature? k == some "true"
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1: Veridicality Judgments
@@ -65,7 +61,7 @@ structure VeridicalityDatum where
     `primaryText`; the connective and complement-entailment are `paperFeatures` tags. -/
 def ofVeridicality (e : LinguisticExample) : VeridicalityDatum where
   sentence := e.primaryText
-  connective := (featureOf e "connective").getD ""
+  connective := (e.feature? "connective").getD ""
   complementEntailed := flagOf e "complement_entailed"
   gloss := e.comment
 

--- a/Linglib/Studies/Pollock1989.lean
+++ b/Linglib/Studies/Pollock1989.lean
@@ -29,14 +29,10 @@ open Minimalist
 -- § 1  Transfer Equation over Pollock's Rows
 -- ============================================================================
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Movement-parameter adapter: French lexical verbs raise, English
     lexical verbs stay in situ, English auxiliaries raise. -/
 def paramOf (row : LinguisticExample) : Option VMovementParam :=
-  match row.language, featureOf row "verb_type" with
+  match row.language, row.feature? "verb_type" with
   | "stan1290", some "lexical"   => some french
   | "stan1293", some "lexical"   => some englishLexical
   | "stan1293", some "auxiliary" => some englishAux
@@ -44,7 +40,7 @@ def paramOf (row : LinguisticExample) : Option VMovementParam :=
 
 /-- Diagnostic adapter: the row's `diagnostic` feature as a `VDiagnostic`. -/
 def diagOf (row : LinguisticExample) : Option VDiagnostic :=
-  match featureOf row "diagnostic" with
+  match row.feature? "diagnostic" with
   | some "inversion" => some .inversion
   | some "adverb"    => some .adverb
   | some "negation"  => some .negation
@@ -59,7 +55,7 @@ def predictedOrder (row : LinguisticExample) : Option Bool := do
 /-- The attested surface order recorded in the row's
     `v_precedes_diagnostic` feature. -/
 def surfaceOrder (row : LinguisticExample) : Option Bool :=
-  (featureOf row "v_precedes_diagnostic").map (· == "true")
+  (row.feature? "v_precedes_diagnostic").map (· == "true")
 
 /-- **Transfer equation**: a Pollock row is acceptable iff the verb
     movement parameter predicts exactly the attested surface order.

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -48,7 +48,7 @@ Fragments/English/Nouns ──▷ Montague Lexicon ──▷ Tree
 - `Focus`, `Background` — focus/background partition (§4)
 - `Theme`, `Rheme`, `InfoStructure` — information structure analysis (§5)
 - `FocusedSentence.infoStructure` — IS extractor (§5b; previously a `HasInfoStructure` instance)
-- `featureOf`, `fipPrediction` — row adapters over `Data/Examples/Rooth1992.json` (§8)
+- `fipPrediction` — row adapter over `Data/Examples/Rooth1992.json` (§8)
 - `Tree`, `interp` — compositional derivation (§10–§11)
 - `Derivation` — derivation bundles (§13)
 - `English.Nouns`, `.Predicates.Verbal` — fragment entries (§14)
@@ -352,16 +352,11 @@ theorem only_focus_determines_meaning :
 
 open _root_.Rooth1992
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : Data.Examples.LinguisticExample) (key : String) :
-    Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- The FIP prediction for a row, read off its `focus` feature: subject
     focus ("Fred") evokes the subject-alternative focus value, object
     focus ("beans") the object-alternative one (§6). -/
 def fipPrediction (row : Data.Examples.LinguisticExample) : Prop :=
-  match featureOf row "focus" with
+  match row.feature? "focus" with
   | some "Fred"  => fip q_whoAteBeans fv_subjectFocus
   | some "beans" => fip q_whoAteBeans fv_objectFocus
   | _ => False
@@ -371,7 +366,7 @@ def fipPrediction (row : Data.Examples.LinguisticExample) : Prop :=
     focus passes (§6a); object focus fails (§6b). -/
 theorem qa_acceptable_iff_fip :
     ∀ row ∈ Examples.all,
-      featureOf row "fip_application" = some "qaCongruence" →
+      row.feature? "fip_application" = some "qaCongruence" →
       (row.judgment = .acceptable ↔ fipPrediction row) := by
   intro row hrow happ
   simp only [Examples.all, List.mem_cons, List.not_mem_nil, or_false] at hrow
@@ -386,17 +381,17 @@ theorem qa_acceptable_iff_fip :
     rows form an association-with-focus minimal pair. -/
 theorem focusingAdverb_rows_differ_in_focus :
     ∀ r₁ ∈ Examples.all, ∀ r₂ ∈ Examples.all,
-      featureOf r₁ "fip_application" = some "focusingAdverb" →
-      featureOf r₂ "fip_application" = some "focusingAdverb" →
-      r₁.id ≠ r₂.id → featureOf r₁ "focus" ≠ featureOf r₂ "focus" := by
+      r₁.feature? "fip_application" = some "focusingAdverb" →
+      r₂.feature? "fip_application" = some "focusingAdverb" →
+      r₁.id ≠ r₂.id → r₁.feature? "focus" ≠ r₂.feature? "focus" := by
   decide
 
 /-- Bridge: the focusing-adverb rows differ only in focus position, and
     the theory maps distinct focus positions to distinct "only"
     meanings (§7). -/
 theorem bridge_only_association :
-    featureOf Examples.only_bill "focus" ≠
-      featureOf Examples.only_sue "focus" ∧
+    Examples.only_bill.feature? "focus" ≠
+      Examples.only_sue.feature? "focus" ∧
     onlyBill ≠ onlyJohn :=
   ⟨by decide, only_focus_determines_meaning⟩
 

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -439,27 +439,23 @@ prediction for each row. -/
 
 open Data.Examples
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Kind adapter: the row's `noun` feature as a `Kind`. -/
 def kindOf (row : LinguisticExample) : Option Kind :=
-  match featureOf row "noun" with
+  match row.feature? "noun" with
   | some "basketball player" => some .basketballPlayer
   | some "jockey"            => some .jockey
   | _ => none
 
 /-- Utterance adapter: the row's `adjective` feature as an `Utterance`. -/
 def uttOf (row : LinguisticExample) : Option Utterance :=
-  match featureOf row "adjective" with
+  match row.feature? "adjective" with
   | some "tall"  => some .tall
   | some "short" => some .short
   | _ => none
 
 /-- Comparison-class adapter: the row's attested `inferred_class` feature. -/
 def ccOf (row : LinguisticExample) : Option ComparisonClass :=
-  match featureOf row "inferred_class" with
+  match row.feature? "inferred_class" with
   | some "subordinate"   => some .subordinate
   | some "superordinate" => some .superordinate
   | _ => none

--- a/Linglib/Studies/Thomas2026.lean
+++ b/Linglib/Studies/Thomas2026.lean
@@ -138,17 +138,13 @@ for (72)/(19c), `prejacent_violation_i` for (11), `prejacent_violation_ii` for
 (30)). The *either* row carries no diagnosis — fn. 9 leaves *either* to future
 work — so the transfer equation is stated for *too* rows only. -/
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : Data.Examples.LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- **Transfer equation**: a *too* row is acceptable iff the paper exhibits an
     (ANT, RQ) pair satisfying all of Def 64. Uniform across the standard and
     argument-building rows — [thomas-2026]'s unification thesis. -/
 theorem too_acceptable_iff_def64_satisfied :
-    ∀ row ∈ Examples.all, featureOf row "particle" = some "too" →
+    ∀ row ∈ Examples.all, row.feature? "particle" = some "too" →
       (row.judgment = .acceptable ↔
-        featureOf row "def64_status" = some "satisfied") := by
+        row.feature? "def64_status" = some "satisfied") := by
   decide
 
 end Thomas2026

--- a/Linglib/Studies/VanDerSandtMaier2003.lean
+++ b/Linglib/Studies/VanDerSandtMaier2003.lean
@@ -388,13 +388,9 @@ of its rows (`Data/Examples/VanDerSandtMaier2003.json`): for every row whose
 discourse scenario is formalized as a `LayeredProp` above, the computed
 offensive layers include the layer targeted by the row's denial type. -/
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Denial-type adapter: the row's `denial_type` feature as a `DenialType`. -/
 def denialTypeOf (row : LinguisticExample) : Option DenialType :=
-  match featureOf row "denial_type" with
+  match row.feature? "denial_type" with
   | some "propositional" => some .propositional
   | some "presuppositional" => some .presuppositional
   | some "implicature" => some .implicature
@@ -403,7 +399,7 @@ def denialTypeOf (row : LinguisticExample) : Option DenialType :=
 /-- The Off computation of the `LayeredProp` scenario named by the row's
 `scenario` feature. -/
 private def scenarioOff (row : LinguisticExample) : Option (List ContentLayer) :=
-  match featureOf row "scenario" with
+  match row.feature? "scenario" with
   | some "kingOfFrance" =>
       some (offensiveLayers kfLayered (fun w => w == .noKing) kfWorlds)
   | some "modal" =>
@@ -432,7 +428,7 @@ syntactically positive (ex. 6, where the denial IS the correction) targets fr,
 like negative propositional denials. The mechanism is the same regardless of
 surface polarity. -/
 theorem positive_denial_propositional :
-    ∀ row ∈ Examples.all, featureOf row "surface_polarity" = some "positive" →
+    ∀ row ∈ Examples.all, row.feature? "surface_polarity" = some "positive" →
       denialTypeOf row = some .propositional := by
   decide
 

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -71,14 +71,10 @@ theorem all_evidence_types_nonfuture (e : EvidenceType) :
 -- § 2  Adapters over the Example Rows
 -- ============================================================================
 
-/-- Value of a `paperFeatures` key, if present. -/
-def featureOf (row : LinguisticExample) (key : String) : Option String :=
-  (row.paperFeatures.find? (·.1 == key)).map (·.2)
-
 /-- Evidence-type adapter: the row's `evidence` feature as an
     `EvidenceType`. -/
 def evidenceOf (row : LinguisticExample) : Option EvidenceType :=
-  match featureOf row "evidence" with
+  match row.feature? "evidence" with
   | some "direct" => some .direct
   | some "indirect" => some .indirect
   | some "elimination" => some .elimination
@@ -87,7 +83,7 @@ def evidenceOf (row : LinguisticExample) : Option EvidenceType :=
 /-- Rows whose primary text is the modalized member of a bare/modal
     minimal pair. -/
 def mustPairs : List LinguisticExample :=
-  Examples.all.filter (featureOf · "kind" == some "must_pair")
+  Examples.all.filter (·.feature? "kind" == some "must_pair")
 
 -- ============================================================================
 -- § 3  The Evidential Restriction
@@ -107,7 +103,7 @@ theorem must_felicitous_iff_indirect :
     uniformly on the negative-modal rows (exx. 21, 23, 24) — *can't*
     groups with *must*, not with weak modals. -/
 theorem cant_patterns_with_must :
-    ∀ row ∈ mustPairs.filter (featureOf · "modal" == some "cant"),
+    ∀ row ∈ mustPairs.filter (·.feature? "modal" == some "cant"),
       row.judgment = .acceptable ↔
         (evidenceOf row).map EvidenceType.toCoarseSource ≠ some .direct :=
   fun row hrow => must_felicitous_iff_indirect row (List.mem_filter.mp hrow).1
@@ -123,7 +119,7 @@ theorem cant_patterns_with_must :
     valid, *must φ ∧ perhaps ¬φ* is contradictory, retraction fails) are
     in the same JSON under `kind = inference`. -/
 theorem must_entails_prejacent :
-    ∀ row ∈ mustPairs, featureOf row "must_entails_prejacent" = some "true" := by
+    ∀ row ∈ mustPairs, row.feature? "must_entails_prejacent" = some "true" := by
   decide
 
 /-- The bare prejacent is felicitous in every context: the felicity

--- a/Linglib/Studies/VonFintelGillies2021.lean
+++ b/Linglib/Studies/VonFintelGillies2021.lean
@@ -19,12 +19,12 @@ is anti-knowledge, not anti-perception — direct-enough *knowledge* blocks
 namespace VonFintelGillies2021
 
 open Data.Examples
-open VonFintelGillies2010 (featureOf evidenceOf EvidenceType)
+open VonFintelGillies2010 (evidenceOf EvidenceType)
 
 /-- Rows whose primary text is the modalized member of a bare/modal
     minimal pair. -/
 def mustPairs : List LinguisticExample :=
-  Examples.all.filter (featureOf · "kind" == some "must_pair")
+  Examples.all.filter (·.feature? "kind" == some "must_pair")
 
 /-- **Anti-knowledge**: the evidential restriction extends to rows where
     "direct" is direct-enough knowledge rather than perception. Phil, who


### PR DESCRIPTION
Retires the 24 byte-identical local `featureOf` adapters (plus one cross-study `open` re-export in VonFintelGillies2021) in favour of the `LinguisticExample.feature?` accessor added to the Schema in #1092. Mechanical; all 24 touched modules build green.