### PR TITLE
style(Studies/Mizuno2024): terser docstrings

### DIFF
--- a/Linglib/Fragments/English/Conditionals.lean
+++ b/Linglib/Fragments/English/Conditionals.lean
@@ -30,9 +30,8 @@ def if_ : ConditionalMarker where
   markerType := .both
   notes := "Ambiguous between HC and PC; context determines reading"
 
-/-- English X-marking: Fake Past ([iatridou-2000]). Antecedent X-marking is past
-    alone — a minority pattern ([von-fintel-iatridou-2023], §2); the consequent
-    adds the modal woll (would). -/
+/-- English X-marking: Fake Past ([iatridou-2000]); the consequent adds woll
+    ([von-fintel-iatridou-2023] §2). -/
 def xMarking : Option XMarkingExponent := some ⟨"Past", [.past, .future]⟩
 
 end English.Conditionals

--- a/Linglib/Fragments/Japanese/Conditionals.lean
+++ b/Linglib/Fragments/Japanese/Conditionals.lean
@@ -44,12 +44,9 @@ def nara : ConditionalMarker where
   markerType := .both
   notes := "Can mark premise conditionals (unlike -ra)"
 
-/-- Japanese -(e)ba: HC and PC conditional marker ([mizuno-2024], fn 8 notation).
-
-    Attaches directly to sentence radicals. Both uses are attested in
-    [mizuno-2024]: premise (Anderson, ex. 4a) and hypothetical (FLV, ex. 9a);
-    the Anderson vs counterfactual contrast is carried by the consequent's
-    Non-Past vs Past, not by the marker. -/
+/-- Japanese -(e)ba ([mizuno-2024], fn 8): attaches to sentence radicals; premise
+    use in Andersons (ex. 4a), hypothetical in FLVs (ex. 9a). The Anderson vs
+    counterfactual contrast is carried by the consequent's tense, not the marker. -/
 def eba : ConditionalMarker where
   language := "Japanese"
   marker := "-(e)ba"
@@ -57,9 +54,8 @@ def eba : ConditionalMarker where
   markerType := .both
   notes := "Anderson conditionals use this form (Mizuno 2024, ex. 4a)"
 
-/-- Japanese X-marking: Fake Past -ta ([ogihara-2014], [mizuno-kaufmann-2019]) —
-    Past morphology with counterfactual rather than temporal import, e.g. in the
-    consequent of -(e)ba conditionals ([mizuno-2024], ex. 3). -/
+/-- Japanese X-marking: Fake Past -ta ([ogihara-2014], [mizuno-kaufmann-2019];
+    [mizuno-2024] ex. 3). -/
 def xMarking : Option XMarkingExponent := some ⟨"-ta", [.past]⟩
 
 end Japanese.Conditionals

--- a/Linglib/Semantics/Modality/Exclusion.lean
+++ b/Linglib/Semantics/Modality/Exclusion.lean
@@ -154,11 +154,9 @@ theorem MarkingStrategy.other_other : ∀ s : MarkingStrategy, s.other.other = s
 
 /-! ### X-marking exponents ([von-fintel-iatridou-2023] §2, "The form") -/
 
-/-- The morphological material realizing X-marking. [von-fintel-iatridou-2023]
-(§2) divide languages into those with *dedicated* X-morphology and those whose
-exponents have other functions — "past tense, imperfective, future and/or
-subjunctive"; [mizuno-2024] (§4.2) extends the inventory with the Mandarin
-perfective. -/
+/-- The morphology realizing X-marking ([von-fintel-iatridou-2023] §2): dedicated,
+or borrowed from past / imperfective / future / subjunctive; [mizuno-2024] (§4.2)
+adds the Mandarin perfective. -/
 inductive XMarkingHost where
   /-- Dedicated X-morphology with no other use (Hungarian -nA). -/
   | dedicated
@@ -174,12 +172,10 @@ inductive XMarkingHost where
   | perfective
   deriving DecidableEq, Repr
 
-/-- A language's X-marking exponent: its citation form and its (possibly
-complex — [von-fintel-iatridou-2023] §2: Greek combines fake past with fake
-imperfective) morphological components. Per-language entries live in
-`Fragments/{Language}/Conditionals.lean` as `Option`-valued `xMarking`
-projections; [von-fintel-iatridou-2023]'s total-uniformity hypothesis
-(p. 1471) includes the bet that every language has one. -/
+/-- A language's X-marking exponent: citation form and (possibly complex — Greek:
+past + imperfective) components. `Option`-valued `xMarking` entries live in
+`Fragments/{Language}/Conditionals.lean`; total uniformity
+([von-fintel-iatridou-2023] p. 1471) bets every language has one. -/
 structure XMarkingExponent where
   form : String
   components : List XMarkingHost

--- a/Linglib/Studies/Mizuno2024.lean
+++ b/Linglib/Studies/Mizuno2024.lean
@@ -13,40 +13,33 @@ Teruyuki Mizuno (2024), "Strategies for Anderson Conditionals: Their Implication
 the Typology of O-Marking and X-Marking", *Semantics and Pragmatics* 17(8): 1–14.
 [anderson-1951] [schlenker-2004] [von-fintel-iatridou-2023] [iatridou-2000]
 
-Anderson conditionals ([anderson-1951]) argue *for* the truth of their antecedent
-("If Jones had taken arsenic, he would show exactly the symptoms he is showing — so he
-took arsenic"). Mizuno shows that English must X-mark them (O-marking is trivial),
-whereas Japanese and Mandarin must O-mark them: their X-marking — the Fake Past -ta
-([ogihara-2014], [mizuno-kaufmann-2019]) and perfective le — forces a counterfactual
-reading. Both strategies avoid triviality by **expanding** the modal domain `D ⊂ D⁺`;
-Mizuno adopts the *expansion* analysis of X-marking (fn 6, citing [mackay-2015],
-[mackay-2019] against the [iatridou-2000] / [schulz-2014] exclusion analysis), and
-analyzes Japanese O-marking as a Historical-Present perspectival shift ([schlenker-2004],
-[anand-toosarvandani-2018a], [anand-toosarvandani-2018b]) that expands `D` by shifting
-the evaluation time backward under branching time.
+Anderson conditionals ([anderson-1951]) argue *for* the truth of their antecedent.
+English must X-mark them (O-marking is trivial); Japanese and Mandarin must O-mark
+them — their X-marking (Fake Past -ta: [ogihara-2014], [mizuno-kaufmann-2019];
+perfective le) forces a counterfactual reading. Both strategies expand the modal
+domain `D ⊂ D⁺`; Mizuno adopts the *expansion* analysis (fn 6, [mackay-2015],
+[mackay-2019] contra [iatridou-2000] / [schulz-2014] exclusion) and analyzes Japanese
+O-marking as a Historical-Present shift ([schlenker-2004], [anand-toosarvandani-2018a],
+[anand-toosarvandani-2018b]) expanding `D` backward under branching time.
 
-The glossed stimuli live in `Data/Examples/Mizuno2024.json` (generated module
-`Mizuno2024.Examples`); per-pair `#guard`s check the observed directions on the named
-examples, and the row theorems quantify over `Examples.all`. The semantics is
-`Semantics.Conditionals.strictImp` over a `HistoricalAlternatives` modal base;
-`Semantics.Modality.Exclusion` (which cites [mizuno-2024]) supplies the X/O typology.
+Stimuli: `Data/Examples/Mizuno2024.json` (module `Mizuno2024.Examples`); `#guard`s
+check observed directions on the named examples, row theorems quantify over
+`Examples.all`. Semantics: `Semantics.Conditionals.strictImp` over a
+`HistoricalAlternatives` base; `Semantics.Modality.Exclusion` supplies the X/O
+typology and exponent inventory.
 
 ## Main results
 
-* `english_japanese_discrepancy` — English X-marks, Japanese O-marks: the typological twist.
-* `inventory_prediction_fails_japanese` — the §3.1 puzzle: Japanese *has* X-marking
-  (Fake Past -ta, ex. 3, the Fragment inventory entry), yet the inventory-driven
-  prediction of its Anderson deployment fails; English validates it.
-* `anderson_judgments_match_strategy` — every recorded Anderson judgment (primary text and
-  minimal-pair alternative) matches the per-language strategy record.
-* `flv_anderson_correlation` — Anderson X-marking ⇔ Future-Less-Vivid X-marking, per
-  sample row (§4.2).
+* `english_japanese_discrepancy` — English X-marks, Japanese O-marks.
+* `inventory_prediction_fails_japanese` — the §3.1 puzzle: Japanese has X-marking
+  (ex. 3) yet must not deploy it; English validates the inventory prediction.
+* `anderson_judgments_match_strategy` — every recorded judgment matches the strategy
+  record.
+* `flv_anderson_correlation` — Anderson X-marking ⇔ FLV X-marking, per row (§4.2).
 * `oMarking_anderson_trivial` / `xMarking_expands` / `consequent_open_over_xMarkedBase` /
-  `expanded_anderson_informative` — the triviality puzzle and its resolution by domain
-  expansion, on the Jones-arsenic scenario.
-* `hp_expands_jones_domain` / `consequent_open_after_hp` — the Japanese HP route to the
-  same two conclusions: Mizuno's take (§4.1) on [von-fintel-iatridou-2023]'s uniformity
-  hypothesis.
+  `expanded_anderson_informative` — the triviality puzzle and its resolution.
+* `hp_expands_jones_domain` / `consequent_open_after_hp` — the HP route to the same
+  conclusions: §4.1 on [von-fintel-iatridou-2023]'s uniformity hypothesis.
 -/
 
 namespace Mizuno2024
@@ -57,119 +50,97 @@ open HistoricalAlternatives (histEquiv_mono)
 open Intensional (WorldTimeIndex)
 open Data.Examples (LinguisticExample Glottocode)
 
-/-! ### The per-language strategy record (§2–§4.2)
+/-! ### The per-language strategy record (§2–§4.2) -/
 
-The X-marking / O-marking labels are [von-fintel-iatridou-2023]'s typological vocabulary
-(the theory-neutral `MarkingStrategy` substrate enum). Mizuno's finding is *which* of the
-two each language uses for a felicitous Anderson conditional; the record is keyed by the
-data rows' own Glottocodes and checked against every row below. -/
-
-/-- The felicitous Anderson-conditional marking per language: English X-marks (§2,
-    ex. 1a); Japanese O-marks (§3, ex. 4a -ru); Mandarin O-marks (§4.2, ex. 13a without
-    final le). `none` for languages outside the paper's sample. -/
+/-- The felicitous Anderson marking per language: English X (§2, ex. 1a), Japanese O
+    (§3, ex. 4a -ru), Mandarin O (§4.2, ex. 13a without le); `none` outside the sample. -/
 def andersonStrategy : Glottocode → Option MarkingStrategy
   | "stan1293" => some .xMarking
   | "nucl1643" => some .oMarking
   | "mand1415" => some .oMarking
   | _ => none
 
-/-- Whether X-marking is available for Future-Less-Vivid conditionals ([mizuno-2024],
-    §4.2). English allows it (ex. 8); Japanese Past -ta (ex. 10) and Mandarin perfective
-    le (ex. 12) instead induce strong counterfactuality, blocking the FLV reading. -/
+/-- FLV X-marking availability (§4.2): English yes (ex. 8); Japanese -ta (ex. 10) and
+    Mandarin le (ex. 12) induce strong counterfactuality instead. -/
 def flvXMarkingAvailable : Glottocode → Option Bool
   | "stan1293" => some true
   | "nucl1643" => some false
   | "mand1415" => some false
   | _ => none
 
-/-- The core typological twist ([mizuno-2024], §3): English and Japanese pick *opposite*
-    strategies for Anderson conditionals. -/
+/-- English and Japanese pick opposite Anderson strategies (§3). -/
 theorem english_japanese_discrepancy :
     andersonStrategy "stan1293" ≠ andersonStrategy "nucl1643" := by decide
 
 /-! ### The §3.1 puzzle: available X-marking that must not be deployed
 
-Japanese *has* X-marking — the Fake Past -ta, demonstrated by ex. 3 and recorded in the
-Fragment inventory (`Japanese.Conditionals.xMarking`) — and §2's semantics says Anderson
-conditionals want X-marking, so one would predict -ta in ex. 4a. "Strikingly, this is not
-borne out": the attested strategy is O-marking. [von-fintel-iatridou-2023]'s uniformity
-hypothesis survives via the meaning/use split (§4.1): the exponent's semantics is
-uniform; its Anderson *deployment* is blocked by a third factor. -/
+Japanese has X-marking (Fake Past -ta, ex. 3; `Japanese.Conditionals.xMarking`), and §2
+predicts it in Anderson conditionals — "strikingly, this is not borne out". Uniformity
+(§4.1) survives as a meaning/use split: uniform semantics, blocked deployment. -/
 
-/-- The sample languages' X-marking exponents, routed from the Fragment inventory
-    (English Fake Past + woll; Japanese Fake Past -ta). The Mandarin entry is
-    study-local: consequent-final perfective le rests on a single consultant
-    ([mizuno-2024], fn 15), below the textbook-consensus bar for a Fragment entry. -/
+/-- X-marking exponents, routed from the Fragment inventory. Mandarin le is
+    study-local: fn 15's single consultant is below the Fragment consensus bar. -/
 def xExponentOf : Glottocode → Option XMarkingExponent
   | "stan1293" => English.Conditionals.xMarking
   | "nucl1643" => Japanese.Conditionals.xMarking
   | "mand1415" => some ⟨"le", [.perfective]⟩
   | _ => none
 
-/-- The naive inventory-driven prediction: X-mark Anderson conditionals wherever the
-    inventory provides X-marking — per §2's triviality argument, and a fortiori under
-    fn 14's Blocking Principle, which bans covert HP where overt X-marking exists. -/
+/-- The inventory-driven prediction: X-mark wherever the inventory provides X-marking
+    (§2; a fortiori under fn 14's [chierchia-1998]-style blocking). -/
 def inventoryPrediction (lang : Glottocode) : Option MarkingStrategy :=
   (xExponentOf lang).map (λ _ => .xMarking)
 
-/-- English validates the inventory-driven prediction. -/
+/-- English validates the inventory prediction. -/
 theorem inventory_prediction_holds_english :
     inventoryPrediction "stan1293" = andersonStrategy "stan1293" := by decide
 
-/-- The §3.1 puzzle: Japanese has the X resource yet must not deploy it for Anderson
-    conditionals — the inventory prediction fails. -/
+/-- The §3.1 puzzle: Japanese has the X resource yet must not deploy it. -/
 theorem inventory_prediction_fails_japanese :
     inventoryPrediction "nucl1643" ≠ andersonStrategy "nucl1643" := by decide
 
-/-- Mandarin patterns with Japanese ([mizuno-2024], §4.2). -/
+/-- Mandarin patterns with Japanese (§4.2). -/
 theorem inventory_prediction_fails_mandarin :
     inventoryPrediction "mand1415" ≠ andersonStrategy "mand1415" := by decide
 
--- Ex. (3) grounds the Japanese inventory entry: the row's tagged exponent is the
--- Fragment entry's Fake Past -ta, and the Fake-Past sentence is acceptable.
+-- Ex. (3) grounds the inventory entry: tagged exponent = the Fragment's -ta; acceptable.
 #guard Examples.ja3.feature? "x_exponent" == Japanese.Conditionals.xMarking.map (·.form)
 #guard Examples.ja3.judgment == Features.Judgment.acceptable
 
-/-! ### The attested minimal pairs (the empirical anchor)
+/-! ### The attested minimal pairs
 
-The X/O minimal pairs within one numbered example (4a's -ru / -ta, 13a's ∅ / le) are
-recorded as the felicitous `primaryText` plus the infelicitous `alternatives` entry; the
-realized strategy is tagged in `paperFeatures`. The `#guard`s check the observed
-directions on the named examples; `anderson_judgments_match_strategy` states the
-generalization over all rows. -/
+Pairs live inside one numbered example: the felicitous `primaryText` (strategy `m`)
+plus the infelicitous `alternatives` entry (realizing `m.other`). -/
 
-/-- Felicity as a Bool: an Anderson conditional counts as felicitous iff fully acceptable. -/
+/-- Felicitous iff fully acceptable. -/
 def isFelicitous : Features.Judgment → Bool
   | .acceptable => true
   | _ => false
 
-/-- Parse the `strategy` tag into a `MarkingStrategy`. -/
+/-- Parse the `strategy` tag. -/
 def ofStrategyTag? : String → Option MarkingStrategy
   | "x-marking" => some .xMarking
   | "o-marking" => some .oMarking
   | _ => none
 
--- Ex. (1a) / (2): the English pair — X-marked felicitous, O-marked counterpart not.
+-- Ex. (1a) / (2): English X-marked felicitous, O-marked counterpart not.
 #guard isFelicitous Examples.en1a.judgment && !isFelicitous Examples.en2.judgment
--- Ex. (4a): Japanese O-marked -ru felicitous; the X-marked -ta alternative is not.
+-- Ex. (4a): Japanese -ru felicitous; the -ta alternative not.
 #guard isFelicitous Examples.ja4a.judgment &&
   Examples.ja4a.alternatives.all (λ a => !isFelicitous a.2)
--- Ex. (7a), the radical-HP case: Non-Past required even with an overtly past consequent.
+-- Ex. (7a), radical HP: Non-Past required even with an overtly past consequent.
 #guard isFelicitous Examples.ja7a.judgment &&
   Examples.ja7a.alternatives.all (λ a => !isFelicitous a.2)
--- Ex. (13a): Mandarin without consequent-final le felicitous; with le not.
+-- Ex. (13a): Mandarin without le felicitous; with le not.
 #guard isFelicitous Examples.ma13a.judgment &&
   Examples.ma13a.alternatives.all (λ a => !isFelicitous a.2)
--- The sample has five Anderson rows (ex. 1a, 2, 4a, 7a, 13a), covering all six
--- language × marking cells, and every row's language is in the strategy record.
+-- Five Anderson rows (ex. 1a, 2, 4a, 7a, 13a); every row's language is in the record.
 #guard (Examples.all.filter (·.feature? "construction" == some "anderson")).length == 5
 #guard Examples.all.all (λ e => (andersonStrategy e.language).isSome)
 
-/-- Check one Anderson row against the strategy record: the primary text (realizing the
-    tagged strategy `m`) is judged felicitous iff `m` is the language's strategy, and
-    each minimal-pair alternative (realizing `m.other`, per §2's "O-marking [is]
-    generally defined as the absence of X-marking") is judged felicitous iff `m.other`
-    is. Non-Anderson rows pass vacuously. -/
+/-- One Anderson row against the record: primary judgment matches strategy `m`, each
+    alternative matches `m.other` (§2: O-marking = absence of X-marking). Non-Anderson
+    rows pass vacuously. -/
 def andersonRowOK (e : LinguisticExample) : Bool :=
   match e.feature? "construction", (e.feature? "strategy").bind ofStrategyTag? with
   | some "anderson", some m =>
@@ -178,32 +149,27 @@ def andersonRowOK (e : LinguisticExample) : Bool :=
           isFelicitous a.2 == (andersonStrategy e.language == some m.other))
   | _, _ => true
 
-/-- Every recorded Anderson judgment matches the per-language strategy record. -/
+/-- Every recorded Anderson judgment matches the strategy record. -/
 theorem anderson_judgments_match_strategy :
     ∀ e ∈ Examples.all, andersonRowOK e = true := by decide
 
 /-! ### The Future-Less-Vivid correlation (§4.2) -/
 
-/-- FLV X-marking availability read from the example data (`flv_xmarking` tag). -/
+/-- The `flv_xmarking` tag. -/
 def flvAvailableTag (e : LinguisticExample) : Option Bool :=
   match e.feature? "flv_xmarking" with
   | some "available"   => some true
   | some "unavailable" => some false
   | _                  => none
 
--- The FLV availability record is grounded in ex. 8 (English), 9–10 (Japanese),
--- 11–12 (Mandarin).
+-- The FLV record is grounded in ex. 8 (English), 9–10 (Japanese), 11–12 (Mandarin).
 #guard flvAvailableTag Examples.en8 == some true
 #guard flvAvailableTag Examples.ja9 == some false
 #guard flvAvailableTag Examples.ma11 == some false
 
-/-- [mizuno-2024], §4.2: X-marking for Anderson conditionals and X-marking for FLV
-    conditionals stand or fall together — for every sampled language, the Anderson
-    strategy X-marks iff FLV X-marking is available. An empirical generalization
-    (Mizuno speculates a [chierchia-1998] Blocking Principle: covert HP is blocked
-    where overt X-marking is available, fn 14), not a definitional identity — the two
-    records are kept independently. [iatridou-2000] independently classifies the FLV
-    as carrying a single ExclF layer (`Iatridou2000.CounterfactualType.flv`). -/
+/-- §4.2: Anderson X-marking and FLV X-marking stand or fall together, for every
+    sampled language. An empirical correlation of two independent records, not a
+    definition; cf. `Iatridou2000.CounterfactualType.flv` (one ExclF layer). -/
 theorem flv_anderson_correlation :
     ∀ e ∈ Examples.all,
       (andersonStrategy e.language).map MarkingStrategy.hasXMarking =
@@ -211,28 +177,18 @@ theorem flv_anderson_correlation :
 
 /-! ### The triviality puzzle and its resolution by domain expansion
 
-[mizuno-2024]'s core semantic argument (§2): an Anderson consequent is an observed *fact*,
-true at every world in the non-expanded domain `D` of live possibilities, so over `D` the
-conditional is trivially true and uninformative. Both strategies fix this by expanding `D`
-to a `D⁺` containing a world where the consequent fails. Mizuno adopts the *expansion*
-analysis of X-marking (fn 6, citing [mackay-2015] against [iatridou-2000] exclusion).
+§2: an Anderson consequent is an observed fact, true throughout the live domain `D`,
+so over `D` the conditional is trivial; both strategies expand `D` to a `D⁺` containing
+a consequent-failing world. The Jones scenario as `strictImp` over a historical base:
+worlds are `Bool` (`true` = symptoms shown), the domain at an index is its live
+alternatives. `D` = the domain at `utteranceIdx`; `D⁺` via X-marking (larger base, same
+index: `xMarkedBase`) or via HP (same base, earlier index: `hpIdx`) — same operator,
+same two conclusions on each route: §4.1's uniformity of meaning under varying use. -/
 
-The Jones-arsenic scenario as a strict conditional (`Semantics.Conditionals.strictImp`)
-over a historical modal base: worlds are `Bool` (`true` = Jones shows the symptoms),
-evaluation points are ⟨world, time⟩ indices, and the domain at an index is its set of
-live alternatives. The paper's `D` is the domain at the utterance index; `D⁺` is its
-expansion — reached by X-marking (a larger base, same index: `xMarkedBase`) or by the
-Japanese HP shift (same base, earlier index: `hpIdx`). Same operator, same two
-conclusions on each route (strict expansion, consequent left open) — [mizuno-2024]'s
-take (§4.1) on [von-fintel-iatridou-2023]'s uniformity hypothesis: what varies across
-languages is which route may be deployed, not what the expansion does. -/
-
-/-- The Anderson consequent: Jones shows the (arsenic) symptoms. -/
+/-- The Anderson consequent: Jones shows the symptoms. -/
 def showsSymptoms : Set Bool := {w | w = true}
 
-/-- A backward-closed history: a world is a live alternative to `s` iff it is `s`'s own
-    world, or `s`'s time is at or before `0`. Earlier times have strictly more
-    alternatives. -/
+/-- A backward-closed history: live iff the index's own world, or its time is ≤ 0. -/
 def historyJones : HistoricalAlternatives Bool ℤ :=
   λ s => { w | w = s.world ∨ s.time ≤ 0 }
 
@@ -243,21 +199,17 @@ theorem mem_historyJones {w : Bool} {s : WorldTimeIndex Bool ℤ} :
 theorem historyJones_backwardsClosed : historyJones.backwardsClosed :=
   λ _ _ _ _ hle hmem => Or.imp id (le_trans hle) hmem
 
-/-- The utterance index: the symptom world, at a time (`1`) after the facts are settled.
-    Its domain is the paper's `D`. -/
+/-- The utterance index; its domain is the paper's `D`. -/
 def utteranceIdx : WorldTimeIndex Bool ℤ := ⟨true, 1⟩
 
-/-- The HP-shifted index ([mizuno-2024], §3.3): same world, evaluation time moved
-    backward to `0`. Its domain is the paper's `D⁺` on the O-marking route. -/
+/-- The HP-shifted index (§3.3); its domain is `D⁺` on the O-marking route. -/
 def hpIdx : WorldTimeIndex Bool ℤ := ⟨true, 0⟩
 
-/-- The X-marked base: counterfactual morphology makes every world live at every index
-    ([mizuno-2024], §2's expansion analysis, fn 6) — the paper's `D⁺` on the X-marking
-    route. -/
+/-- The X-marked base: every world live at every index (§2, fn 6) — `D⁺` on the
+    X-marking route. -/
 def xMarkedBase : HistoricalAlternatives Bool ℤ := λ _ => Set.univ
 
-/-- Over `D`, the consequent is trivial: at the utterance index only the symptom world
-    is live, and it is an observed fact there ([mizuno-2024], §2). -/
+/-- Over `D` the consequent is trivial: only the symptom world is live (§2). -/
 theorem consequent_trivial_at_utterance :
     historyJones utteranceIdx ⊆ showsSymptoms :=
   λ _ hw => Or.resolve_right hw (by decide)
@@ -266,9 +218,8 @@ theorem consequent_trivial_at_utterance :
 theorem false_not_live : false ∉ historyJones utteranceIdx :=
   λ h => absurd (Or.resolve_left h Bool.false_ne_true) (by decide)
 
-/-- O-marking without expansion: at the utterance index the Anderson conditional is
-    trivially true for *any* antecedent — Mizuno's triviality puzzle, the infelicity of
-    ex. (2). -/
+/-- O-marking without expansion: trivially true for any antecedent — the infelicity
+    of ex. (2). -/
 theorem oMarking_anderson_trivial (antecedent : Set Bool) :
     utteranceIdx ∈ strictImp historyJones antecedent showsSymptoms :=
   mem_strictImp_of_subset consequent_trivial_at_utterance
@@ -279,40 +230,34 @@ theorem xMarking_expands :
   (Set.ssubset_iff_of_subset (Set.subset_univ _)).mpr
     ⟨false, Set.mem_univ _, false_not_live⟩
 
-/-- Over the X-marked `D⁺` the consequent is left open — no longer trivial (§2:
-    "the new domain signaled by X-marking leaves open ... the truth of the
-    consequent"). -/
+/-- Over the X-marked `D⁺` the consequent is left open (§2). -/
 theorem consequent_open_over_xMarkedBase :
     ¬ xMarkedBase utteranceIdx ⊆ showsSymptoms :=
   λ h => Bool.false_ne_true (h (Set.mem_univ false))
 
 /-! ### Japanese O-marking: HP expansion under branching time
 
-Why Japanese O-marking (Non-Past) escapes triviality without X-marking ([mizuno-2024],
-§3.3): the Historical-Present shift moves the evaluation index backward, and since live
-possibilities monotonically shrink as time develops (Mizuno's assumption; the substrate's
-`backwardsClosed`, anchored on [condoravdi-2002]), the earlier index has a larger
-domain — domain expansion without counterfactual morphology. -/
+§3.3: the HP shift moves the evaluation index backward; live possibilities shrink
+monotonically over time (the substrate's `backwardsClosed`, anchored on
+[condoravdi-2002]), so the earlier index has a larger domain. -/
 
-/-- The HP backward shift strictly enlarges the live domain: every world live at the
-    utterance index stays live at the earlier index (the substrate's `histEquiv_mono`),
-    and the symptom-absent world becomes newly live ([mizuno-2024], §3.3). -/
+/-- The HP shift strictly enlarges the live domain (§3.3): subset by `histEquiv_mono`,
+    strictness by the newly live symptom-absent world. -/
 theorem hp_expands_jones_domain :
     historyJones utteranceIdx ⊂ historyJones hpIdx :=
   (Set.ssubset_iff_of_subset
       (λ _ hw => histEquiv_mono historyJones_backwardsClosed true _ zero_le_one hw)).mpr
     ⟨false, Or.inr le_rfl, false_not_live⟩
 
-/-- Over the HP-shifted domain the consequent is left open — the same conclusion
-    `consequent_open_over_xMarkedBase` reaches by enlarging the base ([mizuno-2024],
-    §3.3; §4.1 on the uniformity of the two routes). -/
+/-- Over the HP-shifted domain the consequent is left open — the conclusion
+    `consequent_open_over_xMarkedBase` reaches by enlarging the base (§3.3, §4.1). -/
 theorem consequent_open_after_hp :
     ¬ historyJones hpIdx ⊆ showsSymptoms :=
   λ h => Bool.false_ne_true (h (Or.inr le_rfl))
 
-/-- The payoff ([mizuno-2024], §2: "one can make a meaningful, contingent claim"): a
-    true Anderson conditional at the HP-shifted index is informative — its antecedent
-    excludes a live world (`Set.not_subset` gives the ∃-witness form). -/
+/-- The payoff (§2: "one can make a meaningful, contingent claim"): a true Anderson
+    conditional at the HP index excludes a live world (`Set.not_subset` for the
+    witness form). -/
 theorem expanded_anderson_informative (antecedent : Set Bool)
     (h : hpIdx ∈ strictImp historyJones antecedent showsSymptoms) :
     ¬ historyJones hpIdx ⊆ antecedent :=
@@ -320,13 +265,11 @@ theorem expanded_anderson_informative (antecedent : Set Bool)
 
 /-! ### Fragment marker connection -/
 
--- Japanese Anderson conditionals use -(e)ba, which marks both HC and PC (unlike HC-only
--- -ra): with Non-Past consequent → Anderson, with Past consequent → counterfactual.
+-- Japanese Anderson conditionals use -(e)ba (both HC and PC, unlike HC-only -ra).
 #guard Japanese.Conditionals.eba.markerType ==
   Semantics.Conditionals.ConditionalMarkerType.both
 
--- Mandarin Anderson conditionals use the general-purpose marker ruguo; the X/O-marking
--- distinction is carried by consequent-final le, not by the conditional marker.
+-- Mandarin uses general-purpose ruguo; X/O is carried by consequent-final le.
 #guard Mandarin.Conditionals.ruguo.markerType ==
   Semantics.Conditionals.ConditionalMarkerType.both
 


### PR DESCRIPTION
Tersening pass over the Mizuno2024 study, the `XMarkingHost`/`XMarkingExponent` additions in Exclusion.lean, and the English/Japanese fragment entries — mathlib register: anchor paper cited once in the module doc, bare §/ex refs elsewhere, no process narration. (Reland: the commit landed on #1097's branch as it merged.) Content unchanged; cone builds green.