### PR TITLE
feat(Discourse): meet monoid + MulActionHom + Truth-Support Bridge

### DIFF
--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -102,7 +102,10 @@ mirroring mathlib's `Pointwise` locale: `open CommonGround` activates it.
 The same meet-monoid structure recurs one level up in inquisitive
 semantics, where contexts are downward-closed sets of information states,
 also updated by intersection ([ciardelli-groenendijk-roelofsen-2018]);
-the classical picture formalized here is its declarative fragment. -/
+the classical picture formalized here is its declarative fragment, along
+the Truth-Support Bridge `Question.declarativeHom` — an order-faithful
+`InfTopHom` that does not preserve `⊔`
+(`Semantics/Questions/Basic.lean`). -/
 
 /-- Meet-monoid on context sets: `* = ∩`, `1 = univ`. Scoped, Pointwise-style. -/
 scoped instance : CommMonoid (ContextSet W) where

--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -1,5 +1,7 @@
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Set.Lattice
+import Mathlib.GroupTheory.GroupAction.Hom
+import Mathlib.Algebra.BigOperators.Group.List.Basic
 
 /-!
 # Common Ground
@@ -91,6 +93,30 @@ theorem trivial_update (p : Set W) : update trivial p = p :=
   Set.univ_inter p
 
 end ContextSet
+
+/-! ### The meet monoid
+
+`(ContextSet W, ∩, univ)` is a commutative idempotent monoid, and
+`ContextSet.update` is its (right) regular action. The instance is scoped,
+mirroring mathlib's `Pointwise` locale: `open CommonGround` activates it.
+The same meet-monoid structure recurs one level up in inquisitive
+semantics, where contexts are downward-closed sets of information states,
+also updated by intersection ([ciardelli-groenendijk-roelofsen-2018]);
+the classical picture formalized here is its declarative fragment. -/
+
+/-- Meet-monoid on context sets: `* = ∩`, `1 = univ`. Scoped, Pointwise-style. -/
+scoped instance : CommMonoid (ContextSet W) where
+  mul c p := c ∩ p
+  one := ContextSet.trivial
+  mul_assoc := Set.inter_assoc
+  mul_comm := Set.inter_comm
+  one_mul := Set.univ_inter
+  mul_one := Set.inter_univ
+
+theorem ContextSet.update_eq_mul (c : ContextSet W) (p : Set W) :
+    ContextSet.update c p = c * p := rfl
+
+theorem ContextSet.trivial_eq_one : (ContextSet.trivial : ContextSet W) = 1 := rfl
 
 /-- The context set determined by a common ground: intersection of its propositions. -/
 def contextSet (cg : CommonGround W) : ContextSet W :=
@@ -295,5 +321,58 @@ instance : HasAssertion (CommonGround W) W where
   assert cg φ := cg.add φ
   toContextSet_initial := rfl
   toContextSet_assert _ φ := Set.inter_comm φ _
+
+/-! ### The assertion action and its equivariant projection
+
+`HasAssertion` in mathlib vocabulary: propositions act on states by
+assertion (a raw `SMul`), the meet monoid acts on itself regularly
+(`Mul.toSMul`), and `toContextSet` is an equivariant map between the two
+actions (a mathlib `MulActionHom`) sending `initial` to `1`. No action
+laws are demanded of the state side — states may record commitment order,
+sources, or credences — yet the projected dynamics inherits every monoid
+equation, and on a played history the projection is the monoid product. -/
+
+namespace HasAssertion
+
+open HasContextSet (toContextSet)
+
+variable {S : Type*} [HasAssertion S W]
+
+/-- Propositions act on any `HasAssertion` state by assertion. Scoped. -/
+scoped instance : SMul (Set W) S := ⟨fun φ s => assert s φ⟩
+
+theorem smul_eq_assert (φ : Set W) (s : S) : φ • s = assert s φ := rfl
+
+/-- `toContextSet` bundled as an equivariant map (`MulActionHom`) from the
+    assertion action to the regular action of the meet monoid. -/
+def toContextSetHom (S : Type*) [HasAssertion S W] :
+    S →[Set W] ContextSet W where
+  toFun := toContextSet
+  map_smul' φ s := by
+    show toContextSet (assert s φ) = φ * toContextSet s
+    rw [toContextSet_assert]
+    exact Set.inter_comm _ φ
+
+/-- Play a history of assertions from a state. -/
+def play (s : S) (h : List (Set W)) : S :=
+  h.foldl assert s
+
+/-- **Forced projection**: the context set of a played history is the
+    monoid product — the intersection — of the history. [stalnaker-1973]
+    p. 450's propositions-to-worlds duality as a hom equation. -/
+theorem toContextSet_play (h : List (Set W)) :
+    toContextSet (play (initial : S) h) = h.prod := by
+  suffices key : ∀ (s : S), toContextSet (play s h) =
+      toContextSet s * h.prod by
+    rw [key, toContextSet_initial, ContextSet.trivial_eq_one, one_mul]
+  induction h with
+  | nil => intro s; simp [play]
+  | cons φ t ih =>
+    intro s
+    rw [List.prod_cons, show play s (φ :: t) = play (assert s φ) t from rfl,
+      ih, toContextSet_assert, ContextSet.update_eq_mul]
+    exact mul_assoc _ _ _
+
+end HasAssertion
 
 end CommonGround

--- a/Linglib/Semantics/Questions/Basic.lean
+++ b/Linglib/Semantics/Questions/Basic.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.SetLike.Basic
 import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.CompleteBooleanAlgebra
 import Mathlib.Order.CompleteLattice.Basic
+import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Order.Lattice
 import Mathlib.Order.Preorder.Finite
 import Mathlib.Order.UpperLower.Basic
@@ -11,7 +12,7 @@ import Linglib.Semantics.Questions.Support
 
 /-!
 # Question — core type, lattice, Heyting derivatives
-[ciardelli-groenendijk-roelofsen-2018] [puncochar-2016]
+[ciardelli-groenendijk-roelofsen-2018] [ciardelli-2022] [puncochar-2016]
 [puncochar-2019] [theiler-etal-2018]
 
 A bundled `Question W` — a non-empty downward-closed family of information
@@ -987,6 +988,74 @@ theorem not_lem_inquisitive_content :
     simp at this
   · have : true ∈ ({true} : Set Bool)ᶜ := h1 (Set.mem_univ true)
     simp at this
+
+/-! ### The Truth-Support Bridge: the declarative embedding
+
+The classical algebra of propositions embeds into the inquisitive
+algebra via `declarative` — [ciardelli-2022]'s Truth-Support Bridge, by
+which a statement names the singleton-generated information type
+`↓{|α|}` (§2.4.2, p. 21). The embedding is order-faithful
+(`declarativeEmbedding`) and preserves meets and `⊤`
+(`declarativeHom : InfTopHom`), but **not** joins: the join of two
+declaratives can be genuinely inquisitive
+(`exists_isInquisitive_declarative_sup`) — inquisitive content enters
+the algebra exactly at `⊔`. The classical context-set picture of
+`Discourse/CommonGround.lean` (its scoped meet monoid and
+`CommonGround.HasAssertion`) is the declarative fragment of the
+inquisitive one along this embedding. -/
+
+@[simp] theorem declarative_top : declarative (Set.univ : Set W) = ⊤ := by
+  ext q; simp
+
+theorem declarative_le_declarative_iff {A B : Set W} :
+    declarative A ≤ declarative B ↔ A ⊆ B :=
+  mem_iff_declarative_le.symm.trans mem_declarative
+
+theorem declarative_injective :
+    Function.Injective (declarative : Set W → Question W) := fun A B h => by
+  rw [← info_declarative A, ← info_declarative B, h]
+
+/-- `declarative` as an order embedding: the classical algebra of
+    propositions sits order-faithfully inside the inquisitive algebra. -/
+def declarativeEmbedding : Set W ↪o Question W where
+  toFun := declarative
+  inj' := declarative_injective
+  map_rel_iff' := declarative_le_declarative_iff
+
+/-- The Truth-Support Bridge, bundled: `declarative` preserves meets and
+    `⊤`. Deliberately not a lattice hom — see
+    `exists_declarative_sup_ne`. -/
+def declarativeHom : InfTopHom (Set W) (Question W) where
+  toFun := declarative
+  map_inf' A B := (declarative_inf A B).symm
+  map_top' := declarative_top
+
+/-- Joins are where inquisitiveness enters: over `Bool`, the join of the
+    declaratives `↓{{true}}` and `↓{{false}}` is the polar question
+    "which truth value?" — its own informative content (`univ`) does not
+    resolve it. -/
+theorem exists_isInquisitive_declarative_sup :
+    ∃ A B : Set Bool, (declarative A ⊔ declarative B).isInquisitive := by
+  refine ⟨{true}, {false}, ?_⟩
+  have hinfo : (declarative ({true} : Set Bool) ⊔ declarative {false}).info =
+      Set.univ := by
+    rw [info_sup, info_declarative, info_declarative]
+    ext b; cases b <;> simp
+  show _ ∉ _
+  rw [hinfo]
+  intro h
+  rcases mem_sup.mp h with h' | h'
+  · have := mem_declarative.mp h' (Set.mem_univ false)
+    simp at this
+  · have := mem_declarative.mp h' (Set.mem_univ true)
+    simp at this
+
+/-- The Truth-Support Bridge does not commute with `⊔`: `declarative` is
+    an `InfTopHom` but not a lattice hom. -/
+theorem exists_declarative_sup_ne :
+    ∃ A B : Set Bool, declarative A ⊔ declarative B ≠ declarative (A ∪ B) := by
+  obtain ⟨A, B, hinq⟩ := exists_isInquisitive_declarative_sup
+  exact ⟨A, B, fun h => not_isInquisitive_declarative (A ∪ B) (h ▸ hinq)⟩
 
 /-! ### `Question.Support` instance
 


### PR DESCRIPTION
Reland of the two commits stranded on #1099's branch after its squash-merge.

- Scoped meet monoid on `ContextSet`, assertion `SMul`, `toContextSetHom : S →[Set W] ContextSet W` (`MulActionHom`), and `toContextSet_play = List.prod`.
- Truth-Support Bridge in `Semantics/Questions/Basic.lean`: `declarativeEmbedding : Set W ↪o Question W`, `declarativeHom : InfTopHom`, and join non-preservation (`exists_isInquisitive_declarative_sup`) — inquisitive content enters exactly at `⊔`.