### PR TITLE
style(Discourse/CommonGround): mathlib-register docstrings

### DIFF
--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -6,30 +6,27 @@ import Mathlib.Algebra.BigOperators.Group.List.Basic
 /-!
 # Common Ground
 
-Framework-agnostic context management following [stalnaker-1973],
-[stalnaker-1974] and [stalnaker-2002]: context sets, common ground as
-proposition lists, and the interfaces unifying both with the various
-discourse-state representations across the discourse layer.
+Stalnakerian context management ([stalnaker-1973], [stalnaker-1974],
+[stalnaker-1978], [stalnaker-2002]): context sets and their update, common
+ground as proposition lists, and the interfaces connecting discourse-state
+representations to both.
 
 ## Main definitions
 
-* `ContextSet W` — worlds compatible with the context (a synonym for `Set W`).
+* `ContextSet W` — worlds compatible with the context (a synonym for
+  `Set W`), with `ContextSet.update` and a scoped meet-monoid instance.
 * `CommonGround W` — common ground as a list of propositions.
-* `CommonGround.HasContextSet` — interface extracting a context set from an
-  arbitrary discourse state.
-* `CommonGround.HasAssertion` — the Stalnakerian update law as an interface:
-  discourse states whose assertion operation projects onto
-  `ContextSet.update` ([stalnaker-1973] p. 455, [stalnaker-1978]).
+* `CommonGround.HasContextSet` — extraction of a context set from a
+  discourse state.
+* `CommonGround.HasAssertion` — discourse states whose assertion operation
+  projects onto `ContextSet.update` ([stalnaker-1973] p. 455);
+  `toContextSetHom` bundles the projection as a `MulActionHom`, and
+  `toContextSet_play` computes it on histories as `List.prod`.
 
-## Implementation notes
-
-`CommonGround` is the root-level type; its API (and `ContextSet` /
-`HasContextSet`) lives in `namespace CommonGround`, mirroring mathlib's
-`Finset`. Consumers `open CommonGround` for the API; the type itself is
-visible unqualified.
-
-Multi-agent epistemic operators (knowledge, belief, common knowledge) are in
-`Semantics/Modality/EpistemicLogic.lean`.
+Proposal-based ([farkas-bruce-2010]) and graded non-monotonic
+([anderson-2021]) assertion models are deliberate non-instances; see
+`FarkasBruce2010.assert_not_narrowing` and
+`Anderson2021.graded_update_keeps_false_world`.
 -/
 
 /-- Common ground as a list of mutually believed propositions. -/
@@ -94,18 +91,7 @@ theorem trivial_update (p : Set W) : update trivial p = p :=
 
 end ContextSet
 
-/-! ### The meet monoid
-
-`(ContextSet W, ∩, univ)` is a commutative idempotent monoid, and
-`ContextSet.update` is its (right) regular action. The instance is scoped,
-mirroring mathlib's `Pointwise` locale: `open CommonGround` activates it.
-The same meet-monoid structure recurs one level up in inquisitive
-semantics, where contexts are downward-closed sets of information states,
-also updated by intersection ([ciardelli-groenendijk-roelofsen-2018]);
-the classical picture formalized here is its declarative fragment, along
-the Truth-Support Bridge `Question.declarativeHom` — an order-faithful
-`InfTopHom` that does not preserve `⊔`
-(`Semantics/Questions/Basic.lean`). -/
+/-! ### The meet monoid -/
 
 /-- Meet-monoid on context sets: `* = ∩`, `1 = univ`. Scoped, Pointwise-style. -/
 scoped instance : CommMonoid (ContextSet W) where
@@ -181,61 +167,15 @@ theorem hasContextSet_add_restricts (cg : CommonGround W) (p : Set W) :
     HasContextSet.toContextSet (cg.add p) ⊆ HasContextSet.toContextSet cg :=
   add_restricts cg p
 
-/-! ### Stalnakerian assertion: `HasAssertion`
+/-! ### Stalnakerian assertion -/
 
-A unifying interface over discourse-state types that admit a one-step
-"speaker asserts φ" operation whose effect on the projected context set is
-exactly Stalnaker's: the context set is updated to its intersection with φ
-(`ContextSet.update`). The law is [stalnaker-1973]'s update principle —
-"after some proposition has been asserted, then the speaker may reasonably
-presuppose it in subsequent conversation" (p. 455) — projected through the
-worlds-side characterization of the presupposition set (p. 450), and
-[stalnaker-1978]'s essential effect of assertion.
-
-Mathematically: `(Set W, ∩, univ)` is a commutative idempotent monoid `M`,
-and `ContextSet.update` is its right regular action. A `HasAssertion`
-structure is a raw pointed `M`-flow `(S, assert, initial)` together
-with an equivariant pointed map into the regular act:
-`toContextSet initial = univ` and
-`toContextSet (assert s φ) = toContextSet s ∩ φ`. No act laws are
-demanded of `S` itself — states may record commitment order, sources, or
-credences — but every equation of `M` transports along the projection,
-which is where the lemma kit (`assert_comm`, `_idem`, `_initial`,
-...) comes from. Frameworks differ in the kernel of the projection (state
-structure the context set cannot see); on states reachable from `initial`,
-the projection is forced: the intersection of everything asserted.
-
-The 1973 principle's own hedge — the asserted proposition stands "until it
-is denied, challenged, retracted or forgotten" — marks the idealization
-this interface bakes in: assertion takes effect immediately and
-unchallenged. Frameworks that model the challenge stage explicitly, or
-that update non-monotonically, do **not** instantiate it — informationally
-important non-instances, not gaps:
-
-* Proposal-based models — [farkas-bruce-2010], where assertion proposes
-  via `dcS` and `table` without touching `cg` until uptake (witnessed by
-  `FarkasBruce2010.assert_not_narrowing`).
-* Graded models — [anderson-2021], whose distributional common ground is
-  non-monotonic by design (excluded worlds can regain probability), so no
-  sharp narrowing law holds
-  (`Anderson2021.graded_update_keeps_false_world`).
-
-Framework instances live with the framework types:
-`Discourse/Stalnaker.lean` (via the `CommonGround` instance below),
-`Discourse/CommitmentSpace.lean` ([krifka-2015] commitment spaces),
-`Discourse/Gunlogson.lean` ([gunlogson-2004] source-marked commitments),
-`Discourse/CredenceThreshold.lean` (credence-gated assertion).
--/
-
-/-- A dialogue-state type that admits a Stalnakerian one-step assertion:
-    `assert s φ` takes immediate effect on the projected context
-    set, updating it by exactly `φ` — [stalnaker-1978]'s essential
-    effect, under the idealization that assertion is not challenged. -/
+/-- A discourse state with a Stalnakerian `assert`: the projected context
+    set updates by exactly the asserted proposition ([stalnaker-1978]). -/
 class HasAssertion (S : Type*) (W : outParam Type*)
     extends HasContextSet S W where
   /-- The initial dialogue state. -/
   initial : S
-  /-- Speaker commits to φ. -/
+  /-- Assert φ. -/
   assert : S → Set W → S
   /-- Nothing is presupposed initially: every world is live. -/
   toContextSet_initial : toContextSet initial = ContextSet.trivial (W := W)
@@ -283,10 +223,8 @@ theorem assert_idem :
   simp only [toContextSet_assert]
   exact ContextSet.update_idem _ φ
 
-/-- Asserting what the state already entails does not change the
-    projected context set — the formal shadow of [stalnaker-1973]'s
-    constraint that asserted content normally not already be
-    presupposed (p. 454): such an assertion is a no-op. -/
+/-- Asserting what the state already entails is a no-op on the projected
+    context set ([stalnaker-1973] p. 454). -/
 theorem assert_of_entails (h : toContextSet s ⊆ φ) :
     toContextSet (assert s φ) = toContextSet s := by
   rw [toContextSet_assert]
@@ -325,15 +263,7 @@ instance : HasAssertion (CommonGround W) W where
   toContextSet_initial := rfl
   toContextSet_assert _ φ := Set.inter_comm φ _
 
-/-! ### The assertion action and its equivariant projection
-
-`HasAssertion` in mathlib vocabulary: propositions act on states by
-assertion (a raw `SMul`), the meet monoid acts on itself regularly
-(`Mul.toSMul`), and `toContextSet` is an equivariant map between the two
-actions (a mathlib `MulActionHom`) sending `initial` to `1`. No action
-laws are demanded of the state side — states may record commitment order,
-sources, or credences — yet the projected dynamics inherits every monoid
-equation, and on a played history the projection is the monoid product. -/
+/-! ### The assertion action -/
 
 namespace HasAssertion
 
@@ -360,9 +290,8 @@ def toContextSetHom (S : Type*) [HasAssertion S W] :
 def play (s : S) (h : List (Set W)) : S :=
   h.foldl assert s
 
-/-- **Forced projection**: the context set of a played history is the
-    monoid product — the intersection — of the history. [stalnaker-1973]
-    p. 450's propositions-to-worlds duality as a hom equation. -/
+/-- The context set of a played history is the monoid product — the
+    intersection — of the history ([stalnaker-1973] p. 450). -/
 theorem toContextSet_play (h : List (Set W)) :
     toContextSet (play (initial : S) h) = h.prod := by
   suffices key : ∀ (s : S), toContextSet (play s h) =


### PR DESCRIPTION
Reland of the polish commit stranded on #1100's branch after its squash-merge: module doc rebuilt to mathlib register (calibrated against `Order/UpperLower` and `Pointwise/Set`), section-header essays removed, terse class/field docstrings.