### PR TITLE
refactor(Core/Order): MeetMonoid wrapper; de-scope context-set monoid

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -227,6 +227,7 @@ import Linglib.Core.Order.IterateFixedPoint
 import Linglib.Core.Order.IntervalContent
 import Linglib.Core.Order.LeftLinear
 import Linglib.Core.Order.Markedness
+import Linglib.Core.Order.MeetMonoid
 import Linglib.Core.Order.Monotone.Monovary
 import Linglib.Core.Order.Normality
 import Linglib.Core.Order.OfCriteria

--- a/Linglib/Core/Order/MeetMonoid.lean
+++ b/Linglib/Core/Order/MeetMonoid.lean
@@ -1,0 +1,66 @@
+import Mathlib.Order.Lattice
+import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Order.BoundedOrder.Lattice
+import Mathlib.Algebra.Group.Defs
+
+/-!
+# The meet monoid of a semilattice
+
+`MeetMonoid α` is a type synonym equipping a meet-semilattice with top
+with its monoid structure: `* = ⊓`, `1 = ⊤` (the `Multiplicative` /
+`OrderDual` pattern). The synonym is non-reducible, so the instance is
+global and never leaks onto `α` itself — in particular it cannot collide
+with the scoped `Pointwise` algebra on `Set`.
+
+[UPSTREAM] mathlib has no lattice-as-monoid wrapper.
+-/
+
+/-- Type synonym: `α` with `⊓` as multiplication and `⊤` as unit. -/
+def MeetMonoid (α : Type*) := α
+
+namespace MeetMonoid
+
+variable {α : Type*}
+
+/-- Wrap an element of `α` as an element of its meet monoid. -/
+def of (a : α) : MeetMonoid α := a
+
+/-- Unwrap an element of the meet monoid. -/
+def val (a : MeetMonoid α) : α := a
+
+@[simp] theorem of_val (a : MeetMonoid α) : of (val a) = a := rfl
+
+@[simp] theorem val_of (a : α) : val (of a) = a := rfl
+
+theorem of_injective : Function.Injective (of : α → MeetMonoid α) :=
+  fun _ _ h => h
+
+instance [SemilatticeInf α] [OrderTop α] : CommMonoid (MeetMonoid α) where
+  mul a b := of (val a ⊓ val b)
+  one := of ⊤
+  mul_assoc a b c :=
+    show val a ⊓ val b ⊓ val c = val a ⊓ (val b ⊓ val c) from inf_assoc ..
+  mul_comm a b := show val a ⊓ val b = val b ⊓ val a from inf_comm ..
+  one_mul a := show (⊤ : α) ⊓ val a = val a from top_inf_eq _
+  mul_one a := show val a ⊓ (⊤ : α) = val a from inf_top_eq _
+
+section Lattice
+
+variable [SemilatticeInf α] [OrderTop α]
+
+@[simp] theorem val_mul (a b : MeetMonoid α) : val (a * b) = val a ⊓ val b :=
+  rfl
+
+@[simp] theorem val_one : val (1 : MeetMonoid α) = (⊤ : α) := rfl
+
+theorem of_inf (a b : α) : of (a ⊓ b) = of a * of b := rfl
+
+theorem of_top : of (⊤ : α) = 1 := rfl
+
+/-- Meet is idempotent, so every element of the meet monoid is. -/
+@[simp] theorem mul_idem (a : MeetMonoid α) : a * a = a :=
+  show val a ⊓ val a = val a from inf_idem _
+
+end Lattice
+
+end MeetMonoid

--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Set.Basic
-import Mathlib.Data.Set.Lattice
 import Mathlib.GroupTheory.GroupAction.Hom
-import Mathlib.Algebra.BigOperators.Group.List.Basic
+import Mathlib.Algebra.BigOperators.Group.List.Defs
+import Linglib.Core.Order.MeetMonoid
 
 /-!
 # Common Ground
@@ -14,7 +14,8 @@ representations to both.
 ## Main definitions
 
 * `ContextSet W` — worlds compatible with the context (a synonym for
-  `Set W`), with `ContextSet.update` and a scoped meet-monoid instance.
+  `Set W`), with `ContextSet.update` as multiplication in its
+  `MeetMonoid`.
 * `CommonGround W` — common ground as a list of propositions.
 * `CommonGround.HasContextSet` — extraction of a context set from a
   discourse state.
@@ -49,32 +50,15 @@ abbrev trivial : ContextSet W := Set.univ
 /-- Entailment: every world in the context satisfies the proposition. -/
 abbrev entails (c : ContextSet W) (p : Set W) : Prop := c ⊆ p
 
-/-- The context set has at least one world. Alias for `Set.Nonempty`. -/
-abbrev nonEmpty (c : ContextSet W) : Prop := c.Nonempty
-
 /-- Compatibility: some world in the context satisfies the proposition. -/
 abbrev compatible (c : ContextSet W) (p : Set W) : Prop := (c ∩ p).Nonempty
 
 /-- Update: keep only worlds where the proposition holds. Alias for `(· ∩ ·)`. -/
 abbrev update (c : ContextSet W) (p : Set W) : ContextSet W := c ∩ p
 
-/-- Updated context entails the update proposition. -/
-theorem update_entails (c : ContextSet W) (p : Set W) : update c p ⊆ p :=
-  Set.inter_subset_right
-
 /-- Updated context is contained in the original. -/
 theorem update_restricts (c : ContextSet W) (p : Set W) : update c p ⊆ c :=
   Set.inter_subset_left
-
-/-- Updating with what's already entailed doesn't change the context. -/
-theorem update_eq_self_of_entails (c : ContextSet W) (p : Set W) (h : c ⊆ p) :
-    update c p = c :=
-  Set.inter_eq_left.mpr h
-
-/-- Sequential updates are associative. -/
-theorem update_assoc (c p q : Set W) :
-    update (update c p) q = update c (update p q) :=
-  Set.inter_assoc c p q
 
 /-- Successive updates commute: assertion order is irrelevant. -/
 theorem update_comm (c p q : Set W) :
@@ -85,27 +69,18 @@ theorem update_comm (c p q : Set W) :
 theorem update_idem (c p : Set W) : update (update c p) p = update c p := by
   simp [update, Set.inter_assoc]
 
-/-- Updating the trivial context with `p` gives `p`. -/
-theorem trivial_update (p : Set W) : update trivial p = p :=
-  Set.univ_inter p
-
 end ContextSet
 
 /-! ### The meet monoid -/
 
-/-- Meet-monoid on context sets: `* = ∩`, `1 = univ`. Scoped, Pointwise-style. -/
-scoped instance : CommMonoid (ContextSet W) where
-  mul c p := c ∩ p
-  one := ContextSet.trivial
-  mul_assoc := Set.inter_assoc
-  mul_comm := Set.inter_comm
-  one_mul := Set.univ_inter
-  mul_one := Set.inter_univ
+/-- `update` is multiplication in the meet monoid of context sets. -/
+theorem ContextSet.of_update (c : ContextSet W) (p : Set W) :
+    MeetMonoid.of (ContextSet.update c p) =
+      MeetMonoid.of c * MeetMonoid.of p := rfl
 
-theorem ContextSet.update_eq_mul (c : ContextSet W) (p : Set W) :
-    ContextSet.update c p = c * p := rfl
-
-theorem ContextSet.trivial_eq_one : (ContextSet.trivial : ContextSet W) = 1 := rfl
+/-- The trivial context is the meet monoid's unit. -/
+theorem ContextSet.of_trivial :
+    MeetMonoid.of (ContextSet.trivial : ContextSet W) = 1 := rfl
 
 /-- The context set determined by a common ground: intersection of its propositions. -/
 def contextSet (cg : CommonGround W) : ContextSet W :=
@@ -178,7 +153,7 @@ class HasAssertion (S : Type*) (W : outParam Type*)
   /-- Assert φ. -/
   assert : S → Set W → S
   /-- Nothing is presupposed initially: every world is live. -/
-  toContextSet_initial : toContextSet initial = ContextSet.trivial (W := W)
+  toContextSet_initial : toContextSet initial = ContextSet.trivial
   /-- Assertion narrows the projected context set by exactly `φ`. -/
   toContextSet_assert : ∀ (s : S) (φ : Set W),
     toContextSet (assert s φ) = ContextSet.update (toContextSet s) φ
@@ -197,7 +172,7 @@ theorem assert_subset_prior :
 /-- Narrowing: every surviving world satisfies the asserted proposition. -/
 theorem assert_narrows :
     toContextSet (assert s φ) ⊆ φ :=
-  toContextSet_assert s φ ▸ ContextSet.update_entails _ φ
+  toContextSet_assert s φ ▸ Set.inter_subset_right
 
 /-- Membership in the post-assertion context set, characterized. -/
 theorem mem_assert {s : S} {φ : Set W} {w : W} :
@@ -207,7 +182,8 @@ theorem mem_assert {s : S} {φ : Set W} {w : W} :
 /-- Asserting φ in the initial context yields exactly φ. -/
 @[simp] theorem assert_initial :
     toContextSet (assert (initial : S) φ) = φ := by
-  rw [toContextSet_assert, toContextSet_initial, ContextSet.trivial_update]
+  rw [toContextSet_assert, toContextSet_initial]
+  exact Set.univ_inter φ
 
 /-- Assertion order is irrelevant on the projected context set. -/
 theorem assert_comm :
@@ -228,7 +204,7 @@ theorem assert_idem :
 theorem assert_of_entails (h : toContextSet s ⊆ φ) :
     toContextSet (assert s φ) = toContextSet s := by
   rw [toContextSet_assert]
-  exact ContextSet.update_eq_self_of_entails _ φ h
+  exact Set.inter_eq_left.mpr h
 
 /-- Two consecutive assertions narrow the context set by the conjunction. -/
 theorem assert_twice :
@@ -271,39 +247,48 @@ open HasContextSet (toContextSet)
 
 variable {S : Type*} [HasAssertion S W]
 
-/-- Propositions act on any `HasAssertion` state by assertion. Scoped. -/
-scoped instance : SMul (Set W) S := ⟨fun φ s => assert s φ⟩
+/-- Propositions, as meet-monoid elements, act on states by assertion. -/
+instance : SMul (MeetMonoid (Set W)) S :=
+  ⟨fun φ s => assert s (MeetMonoid.val φ)⟩
 
-theorem smul_eq_assert (φ : Set W) (s : S) : φ • s = assert s φ := rfl
+theorem smul_eq_assert (φ : Set W) (s : S) :
+    MeetMonoid.of φ • s = assert s φ := rfl
 
 /-- `toContextSet` bundled as an equivariant map (`MulActionHom`) from the
     assertion action to the regular action of the meet monoid. -/
 def toContextSetHom (S : Type*) [HasAssertion S W] :
-    S →[Set W] ContextSet W where
-  toFun := toContextSet
+    S →[MeetMonoid (Set W)] MeetMonoid (ContextSet W) where
+  toFun s := MeetMonoid.of (toContextSet s)
   map_smul' φ s := by
-    show toContextSet (assert s φ) = φ * toContextSet s
+    show MeetMonoid.of (toContextSet (assert s (MeetMonoid.val φ))) =
+      φ * MeetMonoid.of (toContextSet s)
     rw [toContextSet_assert]
-    exact Set.inter_comm _ φ
+    exact congrArg MeetMonoid.of (Set.inter_comm _ _)
 
 /-- Play a history of assertions from a state. -/
 def play (s : S) (h : List (Set W)) : S :=
   h.foldl assert s
 
+@[simp] theorem play_nil (s : S) : play s [] = s := rfl
+
+@[simp] theorem play_cons (s : S) (φ : Set W) (t : List (Set W)) :
+    play s (φ :: t) = play (assert s φ) t := rfl
+
 /-- The context set of a played history is the monoid product — the
     intersection — of the history ([stalnaker-1973] p. 450). -/
 theorem toContextSet_play (h : List (Set W)) :
-    toContextSet (play (initial : S) h) = h.prod := by
-  suffices key : ∀ (s : S), toContextSet (play s h) =
-      toContextSet s * h.prod by
-    rw [key, toContextSet_initial, ContextSet.trivial_eq_one, one_mul]
+    MeetMonoid.of (toContextSet (play (initial : S) h)) =
+      (h.map MeetMonoid.of).prod := by
+  suffices key : ∀ s : S, MeetMonoid.of (toContextSet (play s h)) =
+      MeetMonoid.of (toContextSet s) * (h.map MeetMonoid.of).prod by
+    rw [key, toContextSet_initial, ContextSet.of_trivial, one_mul]
   induction h with
-  | nil => intro s; simp [play]
+  | nil => intro s; simp
   | cons φ t ih =>
     intro s
-    rw [List.prod_cons, show play s (φ :: t) = play (assert s φ) t from rfl,
-      ih, toContextSet_assert, ContextSet.update_eq_mul]
-    exact mul_assoc _ _ _
+    rw [List.map_cons, List.prod_cons, play_cons, ih, toContextSet_assert,
+      ContextSet.of_update]
+    exact mul_assoc ..
 
 end HasAssertion
 

--- a/Linglib/Semantics/Presupposition/Accommodation.lean
+++ b/Linglib/Semantics/Presupposition/Accommodation.lean
@@ -127,7 +127,7 @@ inductive AccommodationStrategy where
  under the threat of inconsistency." -/
 noncomputable def heimSelect (c : ContextSet W) (presup : Set W) :
  AccommodationLevel :=
- if ContextSet.nonEmpty (globalAccommodate c presup)
+ if Set.Nonempty (globalAccommodate c presup)
  then .global
  else .local
 
@@ -146,14 +146,14 @@ noncomputable def heimSelect (c : ContextSet W) (presup : Set W) :
  terse paper, Heim offers a simple synthesis between the two antitheses
  of 1970s presupposition theory." -/
 theorem heim_cancellation_equivalence (c : ContextSet W) (presup : Set W)
- (h_inconsistent : ¬ContextSet.nonEmpty (globalAccommodate c presup)) :
+ (h_inconsistent : ¬Set.Nonempty (globalAccommodate c presup)) :
  heimSelect c presup = .local := by
  simp only [heimSelect, h_inconsistent, ↓reduceIte]
 
 /-- When global accommodation IS consistent, Heim's strategy projects
  the presupposition globally — matching Karttunen's projection. -/
 theorem heim_projection_when_consistent (c : ContextSet W) (presup : Set W)
- (h_consistent : ContextSet.nonEmpty (globalAccommodate c presup)) :
+ (h_consistent : Set.Nonempty (globalAccommodate c presup)) :
  heimSelect c presup = .global := by
  simp only [heimSelect, h_consistent, ↓reduceIte]
 
@@ -170,7 +170,7 @@ theorem heim_projection_when_consistent (c : ContextSet W) (presup : Set W)
 theorem heim_never_intermediate (c : ContextSet W) (presup : Set W) :
  ∀ d, heimSelect c presup ≠ .intermediate d := by
  intro d
- by_cases h : ContextSet.nonEmpty (globalAccommodate c presup)
+ by_cases h : Set.Nonempty (globalAccommodate c presup)
  · rw [heim_projection_when_consistent c presup h]; exact AccommodationLevel.noConfusion
  · rw [heim_cancellation_equivalence c presup h]; exact AccommodationLevel.noConfusion
 

--- a/Linglib/Semantics/Questions/Basic.lean
+++ b/Linglib/Semantics/Questions/Basic.lean
@@ -8,6 +8,8 @@ import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Order.Lattice
 import Mathlib.Order.Preorder.Finite
 import Mathlib.Order.UpperLower.Basic
+import Mathlib.Algebra.Group.Hom.Defs
+import Linglib.Core.Order.MeetMonoid
 import Linglib.Semantics.Questions.Support
 
 /-!
@@ -1056,6 +1058,14 @@ theorem exists_declarative_sup_ne :
     ∃ A B : Set Bool, declarative A ⊔ declarative B ≠ declarative (A ∪ B) := by
   obtain ⟨A, B, hinq⟩ := exists_isInquisitive_declarative_sup
   exact ⟨A, B, fun h => not_isInquisitive_declarative (A ∪ B) (h ▸ hinq)⟩
+
+/-- The Truth-Support Bridge as a monoid hom: the classical meet monoid
+    of propositions embeds in the inquisitive one. -/
+def declarativeMonoidHom :
+    MeetMonoid (Set W) →* MeetMonoid (Question W) where
+  toFun A := MeetMonoid.of (declarative (MeetMonoid.val A))
+  map_one' := congrArg MeetMonoid.of declarative_top
+  map_mul' A B := congrArg MeetMonoid.of (declarative_inf _ _).symm
 
 /-! ### `Question.Support` instance
 

--- a/Linglib/Studies/Beaver2001/Basic.lean
+++ b/Linglib/Studies/Beaver2001/Basic.lean
@@ -279,7 +279,7 @@ open Semantics.Presupposition.Accommodation
     Accommodation input is `p.presup` — structurally connected to PartialProp. -/
 theorem heim_synthesis_projection (c : ContextSet W)
     (p : PartialProp W)
-    (h : ContextSet.nonEmpty
+    (h : Set.Nonempty
            (globalAccommodate c p.presup)) :
     heimSelect c p.presup = .global :=
   heim_projection_when_consistent c p.presup h
@@ -288,7 +288,7 @@ theorem heim_synthesis_projection (c : ContextSet W)
     This matches Gazdar's cancellation prediction. -/
 theorem heim_synthesis_cancellation (c : ContextSet W)
     (p : PartialProp W)
-    (h : ¬ContextSet.nonEmpty
+    (h : ¬Set.Nonempty
            (globalAccommodate c p.presup)) :
     heimSelect c p.presup = .local :=
   heim_cancellation_equivalence c p.presup h

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -818,7 +818,7 @@ theorem negation_grounding :
     because global accommodation would be inconsistent. -/
 theorem accommodation_grounded_in_heim {W : Type*}
     (c : ContextSet W) (pex_output : PartialProp W)
-    (h_consistent : ContextSet.nonEmpty
+    (h_consistent : Set.Nonempty
       (globalAccommodate c pex_output.presup)) :
     heimSelect c pex_output.presup = .global :=
   heim_projection_when_consistent c pex_output.presup h_consistent
@@ -829,7 +829,7 @@ theorem accommodation_grounded_in_heim {W : Type*}
     from projecting in hostile environments. -/
 theorem enemy_territory_blocks_projection {W : Type*}
     (c : ContextSet W) (pex_output : PartialProp W)
-    (h_inconsistent : ¬ContextSet.nonEmpty
+    (h_inconsistent : ¬Set.Nonempty
       (globalAccommodate c pex_output.presup)) :
     heimSelect c pex_output.presup = .local :=
   heim_cancellation_equivalence c pex_output.presup h_inconsistent

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -665,7 +665,7 @@ categorical judgments in examples (5)–(6).
 theorem constant_presup_satisfied_iff_satisfiable
     {W : Type*} (witnessCard : W → Nat) (conceivable : W → Prop)
     (c : CommonGround.ContextSet W)
-    (hne : c.nonEmpty) :
+    (hne : c.Nonempty) :
     Semantics.Presupposition.Context.presupSatisfied c
       (sgIndefPresup witnessCard conceivable) ↔
     Semantics.Presupposition.Context.presupSatisfiable c

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -98,7 +98,7 @@ structure SCF_Allows (W : Type*) where
   content : Set W
   /-- Accommodation is possible: there exist contexts where content is
       informative (not entailed) yet use is felicitous -/
-  accommodable : ∃ (c : ContextSet W), ContextSet.nonEmpty c ∧
+  accommodable : ∃ (c : ContextSet W), Set.Nonempty c ∧
     ¬ContextSet.entails c content
 
 /--


### PR DESCRIPTION
Fixes the mathlib-review block-merge finding on #1100: the scoped `CommMonoid (ContextSet W)` was keyed on the reducible abbrev — i.e. de-facto `CommMonoid (Set W)` — and mathlib's scoped Pointwise instance silently wins over it when both scopes are open.

- New `Core/Order/MeetMonoid.lean` ([UPSTREAM]): non-reducible synonym with a global `CommMonoid (MeetMonoid α)` for any `[SemilatticeInf α] [OrderTop α]` (`Multiplicative`/`OrderDual` pattern); `ContextSet` consumers stay untouched, the algebraic layer routes through the wrapper (`toContextSetHom`, `toContextSet_play`, and the Bridge now also as `Question.declarativeMonoidHom`).
- Review cleanup batch: dead `update_assoc`; `nonEmpty` → `Set.Nonempty` (5 consumers migrated); single-use `update_entails`/`update_eq_self_of_entails`/`trivial_update` inlined; unused `Set.Lattice` import dropped; `List` import narrowed to `Defs`; `(W := W)` annotation dropped; `play_nil`/`play_cons` simp lemmas.