### PR TITLE
docs(Core/Order): MeetMonoid is deliberately not upstream material

### DIFF
--- a/Linglib/Core/Order/MeetMonoid.lean
+++ b/Linglib/Core/Order/MeetMonoid.lean
@@ -12,7 +12,12 @@ with its monoid structure: `* = ⊓`, `1 = ⊤` (the `Multiplicative` /
 global and never leaks onto `α` itself — in particular it cannot collide
 with the scoped `Pointwise` algebra on `Set`.
 
-[UPSTREAM] mathlib has no lattice-as-monoid wrapper.
+Deliberately not upstream material: mathlib serves this role unbundled —
+`Std.Commutative` / `Std.Associative` / `Std.IdempotentOp` instances for
+`⊓` in `Order/Lattice.lean` plus native aggregation (`Finset.inf`,
+`sInf`, `List.foldr`). The wrapper exists here to give discourse-update
+dynamics bundled `MonoidHom` / `MulActionHom` vocabulary, which the
+unbundled route does not provide.
 -/
 
 /-- Type synonym: `α` with `⊓` as multiplication and `⊤` as unit. -/

--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -290,6 +290,18 @@ theorem toContextSet_play (h : List (Set W)) :
       ContextSet.of_update]
     exact mul_assoc ..
 
+/-- The context set of a played history is the common ground of that
+    history: `play` from `initial` lands on the free model. -/
+theorem toContextSet_play_eq_contextSet (h : List (Set W)) :
+    toContextSet (play (initial : S) h) = contextSet ⟨h⟩ := by
+  apply MeetMonoid.of_injective
+  rw [toContextSet_play]
+  induction h with
+  | nil => rfl
+  | cons φ t ih =>
+    rw [List.map_cons, List.prod_cons, ih]
+    exact (ContextSet.of_update φ (contextSet ⟨t⟩)).symm
+
 end HasAssertion
 
 end CommonGround


### PR DESCRIPTION
Corrects the [UPSTREAM] overclaim on `MeetMonoid`: mathlib serves this role unbundled (`Std.Commutative`/`Std.Associative`/`Std.IdempotentOp` for `⊓` in `Order/Lattice.lean` + native `Finset.inf`/`sInf` aggregation) and would not take a consumer-less wrapper; the synonym exists here for bundled `MonoidHom`/`MulActionHom` vocabulary. Adds the mathlib-native corollary `toContextSet_play_eq_contextSet`: a played history's context set is the common ground of that history (the free model).