### PR TITLE
refactor(Semantics/Numerals): prune Precision API; ground Kao rounding

### DIFF
--- a/Linglib/Semantics/Numerals/Precision.lean
+++ b/Linglib/Semantics/Numerals/Precision.lean
@@ -1,130 +1,76 @@
 import Linglib.Semantics.Numerals.Roundness
-import Mathlib.Data.Rat.Defs
+import Mathlib.Data.Rat.Floor
 
 /-!
-# Pragmatic Halo and Precision Modes
-[krifka-2007] [lasersohn-1999] [woodin-etal-2023] [kao-etal-2014-hyperbole]
+# Pragmatic halo and precision modes
 
-Rounding semantics for numeral imprecision.
-Round numbers (100, 1000) are interpreted imprecisely; sharp numbers (103, 1001)
-are interpreted precisely. This is the "pragmatic halo" effect.
+Rounding semantics for numeral imprecision: round numbers (100, 1000) admit
+imprecise construals; sharp numbers (103, 1001) do not — [lasersohn-1999]'s
+pragmatic halo, [krifka-2007]'s approximate interpretation.
 
+## Main definitions
+
+- `PrecisionMode`, `projectPrecision`, `roundToNearest`: the two meaning
+  projections `f_e(s) = s` and `f_a(s) = Round(s)` of
+  [kao-etal-2014-hyperbole], with `Round` = round-to-nearest-multiple.
+  `Studies/KaoEtAl2014PMFHyperbole.lean` grounds its goal projections in these.
+- `haloWidth`, `inferPrecisionMode`: halo width and precision mode as
+  functions of the k-ness score (`Roundness.roundnessScore`). Only the
+  monotone relationship — rounder numerals carry wider halos and favour
+  approximate construal — is motivated by the cited papers
+  ([woodin-etal-2023]'s corpus finding); the magnitude constants and the
+  score threshold are stipulations of this formalisation.
 -/
 
 namespace Semantics.Numerals.Precision
 
-/-- Precision mode for numeral interpretation. -/
+/-- Precision mode for numeral interpretation: which of
+[kao-etal-2014-hyperbole]'s two meaning projections applies. -/
 inductive PrecisionMode where
-  | exact       -- f_e(s) = s
-  | approximate -- f_a(s) = Round(s)
+  /-- Exact interpretation, `f_e(s) = s`. -/
+  | exact
+  /-- Approximate interpretation, `f_a(s) = Round(s)`. -/
+  | approximate
   deriving Repr, DecidableEq
 
-/-- Round a rational number to the nearest multiple of `base`. -/
+/-- Round a rational to the nearest multiple of `base` —
+[kao-etal-2014-hyperbole]'s `Round` at the default `base = 10`. -/
 def roundToNearest (n : ℚ) (base : ℚ := 10) : ℚ :=
-  if base == 0 then n
-  else
-    let scaled := n / base
-    let rounded := (scaled + 1/2).floor
-    rounded * base
+  round (n / base) * base
 
-/-- Check if a number is "round" (divisible by base). -/
-def isRoundNumber (n : ℚ) (base : ℚ := 10) : Bool :=
-  roundToNearest n base == n
-
-/-- Rounding equivalence: two values are equivalent if they round to the same number. -/
-def roundingEquiv (n₁ n₂ : ℚ) (base : ℚ := 10) : Bool :=
-  roundToNearest n₁ base == roundToNearest n₂ base
-
-/-- Project a value according to precision mode. -/
+/-- Project a value according to precision mode: `f_e` is the identity,
+`f_a` rounds to the nearest multiple of `base`. -/
 def projectPrecision (mode : PrecisionMode) (n : ℚ) (base : ℚ := 10) : ℚ :=
   match mode with
   | .exact => n
   | .approximate => roundToNearest n base
 
-/-- Check if stated and actual values match under a given precision mode. -/
-def matchesPrecision (mode : PrecisionMode) (stated actual : ℚ) (base : ℚ := 10) : Bool :=
-  projectPrecision mode stated base == projectPrecision mode actual base
+/-! ### Halo width and precision-mode inference
 
--- ════════════════════════════════════════════════════
--- Adaptive Pragmatic Halo ([woodin-etal-2023], [krifka-2007], [lasersohn-1999])
--- ════════════════════════════════════════════════════
+Stipulated operationalisations over the k-ness score. Making the mode a
+function of the numeral alone idealises away the contextual choice of
+granularity ([krifka-2007]) and joint probabilistic inference
+([kao-etal-2014-hyperbole]); see the caveat on `inferPrecisionMode`. -/
 
-open Semantics.Numerals.Roundness in
-
-/-- Adaptive rounding base: rounder numbers get a coarser base.
-    Uses `RoundnessGrade` to avoid duplicating score-binning logic. -/
-def adaptiveBase (n : Nat) : ℚ :=
-  match Semantics.Numerals.Roundness.roundnessGrade n with
-  | .high =>
-    if n % 1000 == 0 then 100
-    else 10
-  | .moderate => 10
-  | .low => 5
-  | .none => 1
-
-open Semantics.Numerals.Roundness in
-
-/-- Adaptive tolerance: scales a base tolerance by the roundness score. -/
-def adaptiveTolerance (n : Nat) (baseTol : ℚ) : ℚ :=
-  let score := Semantics.Numerals.Roundness.roundnessScore n
-  baseTol * (1 + score / 6)
-
-open Semantics.Numerals.Roundness in
-
-/-- Pragmatic halo width as a function of roundness score. -/
+/-- Pragmatic halo width, increasing in the roundness score. The magnitude
+factors are stipulated, not paper-derived. -/
 def haloWidth (n : Nat) : ℚ :=
-  let score := Semantics.Numerals.Roundness.roundnessScore n
-  let magnitudeFactor : ℚ := if n ≥ 1000 then 50
-                              else if n ≥ 100 then 10
-                              else if n ≥ 10 then 5
-                              else 1
+  let score := Roundness.roundnessScore n
+  let magnitudeFactor : ℚ :=
+    if n ≥ 1000 then 50 else if n ≥ 100 then 10 else if n ≥ 10 then 5 else 1
   magnitudeFactor * score / 6
 
-open Semantics.Numerals.Roundness in
-
-/-- Infer precision mode from k-ness score.
-    roundnessScore ≥ 2 → `.approximate`; roundnessScore < 2 → `.exact`. -/
+/-- Infer precision mode from the k-ness score: `roundnessScore ≥ 2` yields
+`.approximate`. Known idealisation: score-1 numerals (5, 15, 45, …) come out
+`.exact` even though imprecise uses of them are attested. -/
 def inferPrecisionMode (n : Nat) : PrecisionMode :=
-  if Semantics.Numerals.Roundness.roundnessScore n ≥ 2 then .approximate
-  else .exact
+  if Roundness.roundnessScore n ≥ 2 then .approximate else .exact
 
--- Verification
-
-#guard inferPrecisionMode 100 == .approximate  -- score 6 ≥ 2
-#guard inferPrecisionMode 50 == .approximate   -- score 4 ≥ 2
-#guard inferPrecisionMode 110 == .approximate  -- score 2 ≥ 2
-#guard inferPrecisionMode 7 == .exact          -- score 0 < 2
-#guard inferPrecisionMode 99 == .exact         -- score 0 < 2
-#guard inferPrecisionMode 15 == .exact         -- score 1 < 2
-
-/-- Multiples of 10 have adaptive base ≥ 5. -/
-theorem adaptive_base_ge_five_of_div10 (n : Nat) (h10 : n % 10 = 0) :
-    adaptiveBase n ≥ 5 := by
-  unfold adaptiveBase
-  have hs := Semantics.Numerals.Roundness.score_ge_two_of_div10 n h10
-  split
-  · split <;> decide
-  · decide
-  · decide
-  · exact absurd ‹_› (Semantics.Numerals.Roundness.grade_ne_none_of_score_ge_one n (by omega))
-
--- ════════════════════════════════════════════════════
--- Speaker-conditioned precision ([beltrama-schwarz-2024])
--- ════════════════════════════════════════════════════
-
-/-- Speaker-conditioned pragmatic halo width: scales the base `haloWidth`
-    by a tolerance multiplier. [beltrama-schwarz-2024] show that
-    numeral precision is jointly determined by roundness AND speaker
-    identity — the pragmatic halo is not a property of the number alone
-    but of the number-speaker pair. -/
-def speakerModulatedHalo (multiplier : ℚ) (n : Nat) : ℚ :=
-  multiplier * haloWidth n
-
-/-- Whether an actual value falls within the speaker-conditioned
-    pragmatic halo of a stated value. -/
-def inSpeakerHalo (multiplier : ℚ) (stated actual : Nat) : Bool :=
-  let hw := speakerModulatedHalo multiplier stated
-  decide ((actual : ℚ) ≥ (stated : ℚ) - hw ∧
-          (actual : ℚ) ≤ (stated : ℚ) + hw)
+#guard inferPrecisionMode 100 = .approximate  -- score 6 ≥ 2
+#guard inferPrecisionMode 50 = .approximate   -- score 4 ≥ 2
+#guard inferPrecisionMode 110 = .approximate  -- score 2 ≥ 2
+#guard inferPrecisionMode 7 = .exact          -- score 0 < 2
+#guard inferPrecisionMode 99 = .exact         -- score 0 < 2
+#guard inferPrecisionMode 15 = .exact         -- score 1 < 2 (see caveat above)
 
 end Semantics.Numerals.Precision

--- a/Linglib/Semantics/Numerals/Roundness.lean
+++ b/Linglib/Semantics/Numerals/Roundness.lean
@@ -8,25 +8,16 @@ following [sigurd-1988], [jansen-pollmann-2001], and [woodin-etal-2023].
 A number n has **k-ness** (for k ∈ {2, 2.5, 5, 10}) if n = m × k × 10^b
 for some b ≥ 1 and 1 ≤ m ≤ 9.
 
-The 6 properties (ordered by frequency effect, [woodin-etal-2023]):
-1. 10-ness (β = 4.46) — strongest predictor of frequency
-2. 2.5-ness (β = 3.84)
-3. 5-ness (β = 2.61)
-4. 2-ness (β = 1.56)
-5. Multiple of 10 (β = 0.52)
-6. Multiple of 5 (β = 0.06) — weakest predictor
-
-This module lives in substrate because both empirical consumers
-(`Studies/`) and theory files (Semantics.Montague, NeoGricean, RSA)
-depend on the roundness score.
-
+The 6 properties, ordered by strength as frequency predictors in
+[woodin-etal-2023]'s negative binomial regression (strongest first):
+10-ness (β = 4.46), 2.5-ness (β = 3.84), 5-ness (β = 3.39),
+2-ness (β = 2.74), multiple of 10 (β = 2.45), multiple of 5 (β = 0.06);
+the 2-ness and multiple-of-10 credible intervals overlap.
 -/
 
 namespace Semantics.Numerals.Roundness
 
--- ============================================================================
--- k-ness primitives
--- ============================================================================
+/-! ### k-ness primitives -/
 
 /-- Check if n has integer k-ness: n = m × k × 10^b for b ≥ 1, 1 ≤ m ≤ 9. -/
 def hasIntKness (n : Nat) (k : Nat) : Bool :=
@@ -47,9 +38,7 @@ def has2_5ness (n : Nat) : Bool :=
       let divisor := 5 * 10 ^ b
       (2 * n) % divisor == 0 && (2 * n) / divisor ≥ 1 && (2 * n) / divisor ≤ 9
 
--- ============================================================================
--- Roundness properties and score
--- ============================================================================
+/-! ### Roundness properties and score -/
 
 /--
 The 6 graded roundness properties from Sigurd/Jansen & Pollmann.
@@ -90,9 +79,7 @@ def roundnessScore (n : Nat) : Nat :=
 /-- Maximum possible roundness score. -/
 def maxRoundnessScore : Nat := 6
 
--- ============================================================================
--- Roundness grade (binned score)
--- ============================================================================
+/-! ### Roundness grade (binned score) -/
 
 /--
 Binned roundness grade for use in width/tolerance functions.
@@ -114,9 +101,7 @@ def roundnessGrade (n : Nat) : RoundnessGrade :=
   else if roundnessScore n ≥ 1 then .low
   else .none
 
--- ============================================================================
--- Context-sensitive roundness
--- ============================================================================
+/-! ### Context-sensitive roundness -/
 
 /--
 Count k-ness-like properties relative to a non-standard base.
@@ -145,15 +130,11 @@ default k-ness score is 0. On base-60 (minutes), 120 = 2 × 60 is round.
 The contextual score derives from actual divisibility properties relative
 to the base (not a flat bonus), paralleling how standard k-ness derives
 from divisibility by 2/2.5/5/10 × powers of 10.
-
-Composes with `GranularityDatum` in `Studies/ThomasDeo2020.lean`.
 -/
 def roundnessInContext (n : Nat) (base : Nat) : Nat :=
   max (roundnessScore n) (contextualRoundnessScore n base)
 
--- ============================================================================
--- Per-datum verification
--- ============================================================================
+/-! ### Per-datum verification -/
 
 -- Score verification
 #guard roundnessScore 100 == 6
@@ -185,15 +166,5 @@ theorem score_ge_two_of_div10 (n : Nat) (h10 : n % 10 = 0) :
   have h5 : n % 5 = 0 := by omega
   simp only [h10, h5, beq_self_eq_true, ite_true]
   omega
-
-/-- Grade is never `.none` when score ≥ 1. -/
-theorem grade_ne_none_of_score_ge_one (n : Nat) (h : roundnessScore n ≥ 1) :
-    roundnessGrade n ≠ .none := by
-  unfold roundnessGrade
-  split
-  · decide
-  · split
-    · decide
-    · decide
 
 end Semantics.Numerals.Roundness

--- a/Linglib/Studies/BeltramaSchwarz2024.lean
+++ b/Linglib/Studies/BeltramaSchwarz2024.lean
@@ -68,8 +68,9 @@ The illustrated stimulus (the "$200" ticket dialogue against a $207 screen) and
 the text-reported observed directions live in `Data.Examples.BeltramaSchwarz2024`;
 the structural predictions are checked against them by `#guard`. Persona ↔
 precision indexing reuses `Pragmatics.SocialMeaning` (the [eckert-2008] field and
-[burnett-2019]'s Eckert–Montague lift); speaker-conditioned halo width is the
-`Semantics.Numerals.Precision.speakerModulatedHalo` this paper motivates.
+[burnett-2019]'s Eckert–Montague lift); `speakerModulatedHalo` scales the
+substrate `haloWidth` by a speaker multiplier — the paper's claim that the
+halo is a property of the number–speaker pair, not the number alone.
 -/
 
 namespace BeltramaSchwarz2024
@@ -289,9 +290,14 @@ theorem bsb_stim_also_round :
 
 /-! ### Speaker-modulated halo
 
-The substrate map `speakerModulatedHalo` (motivated by this paper) widens or
-narrows a numeral's pragmatic halo by a speaker-specific multiplier; Chill
-speakers get a wider halo than Nerdy ones. -/
+`speakerModulatedHalo` widens or narrows a numeral's pragmatic halo by a
+speaker-specific multiplier; Chill speakers get a wider halo than Nerdy
+ones. -/
+
+/-- Speaker-conditioned pragmatic halo width: scales the substrate
+    `haloWidth` by a speaker's tolerance multiplier. -/
+def speakerModulatedHalo (multiplier : ℚ) (n : Nat) : ℚ :=
+  multiplier * haloWidth n
 
 /-- A larger multiplier yields a wider halo — the monotonicity that ties the
     Competence/Warmth ordering to tolerance width. -/

--- a/Linglib/Studies/Cummins2015.lean
+++ b/Linglib/Studies/Cummins2015.lean
@@ -53,8 +53,9 @@ connecting monotone map. The legacy criterion-based view via
    serves as the RSA `cost : U → ℚ` parameter. Round numerals are cheap;
    non-round are expensive.
 2. **k-ness as `PrecisionMode` threshold** — `roundnessScore ≥ 2` triggers
-   `.approximate` mode, grounding the binary switch used by
-   [kao-etal-2014-hyperbole]. The pragmatic halo width
+   `.approximate` mode, grounding the binary meaning-projection switch
+   (`f_e` vs `f_a`) of [kao-etal-2014-hyperbole] — the projection component
+   only, not that paper's joint goal inference. The pragmatic halo width
    ([lasersohn-1999], [krifka-2007]) is also wider for round
    numerals.
 

--- a/Linglib/Studies/KaoEtAl2014PMFHyperbole.lean
+++ b/Linglib/Studies/KaoEtAl2014PMFHyperbole.lean
@@ -2,6 +2,7 @@ import Linglib.Core.Probability.Softmax
 import Linglib.Core.Probability.Posterior
 import Linglib.Core.Probability.JointPosterior
 import Linglib.Pragmatics.RSA.QUD
+import Linglib.Semantics.Numerals.Precision
 import Mathlib.Probability.ProbabilityMassFunction.Constructions
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLogExp
 
@@ -102,6 +103,14 @@ def PriceState.round : PriceState → PriceState
   | .s1000  | .s1001  => .s1000
   | .s5000  | .s5001  => .s5000
   | .s10000 | .s10001 => .s10000
+
+/-- `PriceState.round` is the substrate rounding map: composing with `value`
+gives `Precision.roundToNearest` at the paper's base 10. -/
+theorem round_value_eq_roundToNearest (p : PriceState) :
+    (p.round.value : ℚ) = Semantics.Numerals.Precision.roundToNearest p.value := by
+  cases p <;>
+    norm_num [PriceState.round, PriceState.value,
+      Semantics.Numerals.Precision.roundToNearest]
 
 /-- Binary affect: speaker has notable opinion, or none. -/
 inductive Affect where
@@ -244,6 +253,20 @@ def project (g : Goal) (w : World) : ℕ :=
   | .priceValence       => w.1.value * 2 + (match w.2 with | .none => 0 | .notable => 1)
   | .approxPrice        => w.1.round.value
   | .approxPriceValence => w.1.round.value * 2 + (match w.2 with | .none => 0 | .notable => 1)
+
+/-- The `price` goal projects by the paper's exact meaning projection `f_e`:
+the substrate `Precision.projectPrecision .exact`. -/
+theorem project_price_eq (w : World) :
+    (project .price w : ℚ) =
+      Semantics.Numerals.Precision.projectPrecision .exact w.1.value := rfl
+
+/-- The `approxPrice` goal projects by the paper's approximate meaning
+projection `f_a`: the substrate `Precision.projectPrecision .approximate`
+at base 10. -/
+theorem project_approxPrice_eq (w : World) :
+    (project .approxPrice w : ℚ) =
+      Semantics.Numerals.Precision.projectPrecision .approximate w.1.value :=
+  round_value_eq_roundToNearest w.1
 
 /-- QUD-projected L0: sum of L0Weight over the QUD-equivalence class of `w`
 under goal `g`. The denominator of the speaker softmax (Eq. 6 of paper).


### PR DESCRIPTION
Deep-audit cleanup of `Semantics/Numerals/Precision.lean`.

- Delete 8 never-consumed defs (the rounding stack duplicated `Questions/PrecisionProjection`; the adaptive-base/tolerance constants were uncited stipulations) and move `speakerModulatedHalo` into its sole consumer `Studies/BeltramaSchwarz2024`.
- Ground `KaoEtAl2014PMFHyperbole`'s `PriceState.round` and goal projections in `Precision.roundToNearest`/`projectPrecision` (bridge theorems; `roundToNearest` now defined via mathlib `round`).
- Fix `Roundness.lean` docstrings: β coefficients corrected against the Woodin et al. PDF; false consumer claims dropped; stipulated constants in `haloWidth`/`inferPrecisionMode` now labelled as such.