### PR TITLE
refactor(Semantics/Numerals): Prop-valued roundness; drop native_decide

### DIFF
--- a/Linglib/Semantics/Quantification/Numerals/Roundness.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Roundness.lean
@@ -1,3 +1,5 @@
+import Mathlib.Data.Nat.Basic
+
 /-!
 # Graded Numeral Roundness (k-ness Model)
 [krifka-2007] [sigurd-1988] [woodin-etal-2023] [jansen-pollmann-2001] [cummins-2015]
@@ -13,71 +15,52 @@ The 6 properties, ordered by strength as frequency predictors in
 10-ness (β = 4.46), 2.5-ness (β = 3.84), 5-ness (β = 3.39),
 2-ness (β = 2.74), multiple of 10 (β = 2.45), multiple of 5 (β = 0.06);
 the 2-ness and multiple-of-10 credible intervals overlap.
+
+## Main definitions
+
+- `HasKness`, `Has2_5ness`: the k-ness properties as decidable predicates
+- `roundnessScore`: count of the six properties that hold (0–6)
+- `RoundnessGrade`, `roundnessGrade`: the score binned into 4 levels
+- `contextualRoundnessScore`, `roundnessInContext`: k-ness relative to a
+  non-standard base (dozens, minutes)
 -/
 
 namespace Semantics.Numerals.Roundness
 
 /-! ### k-ness primitives -/
 
-/-- Check if n has integer k-ness: n = m × k × 10^b for b ≥ 1, 1 ≤ m ≤ 9. -/
-def hasIntKness (n : Nat) (k : Nat) : Bool :=
-  if n == 0 || k == 0 then false
-  else
-    List.range 10 |>.any λ i =>
-      let b := i + 1
-      let divisor := k * 10 ^ b
-      n % divisor == 0 && n / divisor ≥ 1 && n / divisor ≤ 9
+/-- `n` has integer k-ness: `n = m × k × 10^b` for some `b ≥ 1` and
+`1 ≤ m ≤ 9` ([jansen-pollmann-2001]). The witness search is bounded at
+`b ≤ 10`, valid for `n < 10¹¹`. -/
+def HasKness (n k : ℕ) : Prop :=
+  ∃ b < 11, 1 ≤ b ∧ ∃ m < 10, 1 ≤ m ∧ n = m * k * 10 ^ b
 
-/-- Check if n has 2.5-ness: n = m × 2.5 × 10^b for b ≥ 1, 1 ≤ m ≤ 9.
-    Equivalent to: 2n = m × 5 × 10^b. -/
-def has2_5ness (n : Nat) : Bool :=
-  if n == 0 then false
-  else
-    List.range 10 |>.any λ i =>
-      let b := i + 1
-      let divisor := 5 * 10 ^ b
-      (2 * n) % divisor == 0 && (2 * n) / divisor ≥ 1 && (2 * n) / divisor ≤ 9
+instance (n k : ℕ) : Decidable (HasKness n k) :=
+  inferInstanceAs (Decidable (∃ b < 11, 1 ≤ b ∧ ∃ m < 10, 1 ≤ m ∧ n = m * k * 10 ^ b))
 
-/-! ### Roundness properties and score -/
+/-- `n` has 2.5-ness: `n = m × 2.5 × 10^b` for `b ≥ 1`, `1 ≤ m ≤ 9` —
+equivalently `2n = m × 5 × 10^b`. Search bounded as in `HasKness`. -/
+def Has2_5ness (n : ℕ) : Prop :=
+  ∃ b < 11, 1 ≤ b ∧ ∃ m < 10, 1 ≤ m ∧ 2 * n = m * 5 * 10 ^ b
 
-/--
-The 6 graded roundness properties from Sigurd/Jansen & Pollmann.
+instance (n : ℕ) : Decidable (Has2_5ness n) :=
+  inferInstanceAs (Decidable (∃ b < 11, 1 ≤ b ∧ ∃ m < 10, 1 ≤ m ∧ 2 * n = m * 5 * 10 ^ b))
 
-Each field is an independent Boolean property. The number of true
-properties predicts numeral frequency and
-pragmatic behavior.
--/
-structure RoundnessProperties where
-  multipleOf5 : Bool
-  multipleOf10 : Bool
-  twoness : Bool
-  twoPointFiveness : Bool
-  fiveness : Bool
-  tenness : Bool
-  deriving Repr, DecidableEq
+/-! ### Roundness score
 
-/-- Compute all 6 roundness properties for a natural number. -/
-def roundnessProperties (n : Nat) : RoundnessProperties :=
-  { multipleOf5 := n % 5 == 0
-  , multipleOf10 := n % 10 == 0
-  , twoness := hasIntKness n 2
-  , twoPointFiveness := has2_5ness n
-  , fiveness := hasIntKness n 5
-  , tenness := hasIntKness n 10
-  }
+The six graded roundness properties of [sigurd-1988] and
+[jansen-pollmann-2001] — multiple of 5, multiple of 10, 2-ness, 2.5-ness,
+5-ness, 10-ness — counted equally. The count predicts numeral frequency
+and pragmatic behavior ([woodin-etal-2023]). -/
 
 /-- Count of true roundness properties (0–6). Higher = rounder. -/
-def roundnessScore (n : Nat) : Nat :=
-  let rp := roundnessProperties n
-  (if rp.multipleOf5 then 1 else 0) +
-  (if rp.multipleOf10 then 1 else 0) +
-  (if rp.twoness then 1 else 0) +
-  (if rp.twoPointFiveness then 1 else 0) +
-  (if rp.fiveness then 1 else 0) +
-  (if rp.tenness then 1 else 0)
+def roundnessScore (n : ℕ) : ℕ :=
+  (if 5 ∣ n then 1 else 0) + (if 10 ∣ n then 1 else 0) +
+  (if HasKness n 2 then 1 else 0) + (if Has2_5ness n then 1 else 0) +
+  (if HasKness n 5 then 1 else 0) + (if HasKness n 10 then 1 else 0)
 
 /-- Maximum possible roundness score. -/
-def maxRoundnessScore : Nat := 6
+def maxRoundnessScore : ℕ := 6
 
 /-! ### Roundness grade (binned score) -/
 
@@ -88,14 +71,18 @@ Collapses the 0–6 score into 4 levels to avoid duplicating
 step-function logic across Theory files.
 -/
 inductive RoundnessGrade where
-  | high      -- score ≥ 5 (e.g., 100, 1000, 200)
-  | moderate  -- score 3-4 (e.g., 50, 20)
-  | low       -- score 1-2 (e.g., 110, 15)
-  | none      -- score 0 (e.g., 7, 99)
+  /-- score ≥ 5 (e.g., 100, 1000, 200) -/
+  | high
+  /-- score 3–4 (e.g., 50, 20) -/
+  | moderate
+  /-- score 1–2 (e.g., 110, 15) -/
+  | low
+  /-- score 0 (e.g., 7, 99) -/
+  | none
   deriving Repr, DecidableEq
 
 /-- Classify a number into a roundness grade. -/
-def roundnessGrade (n : Nat) : RoundnessGrade :=
+def roundnessGrade (n : ℕ) : RoundnessGrade :=
   if roundnessScore n ≥ 5 then .high
   else if roundnessScore n ≥ 3 then .moderate
   else if roundnessScore n ≥ 1 then .low
@@ -113,13 +100,11 @@ Examples:
 - contextualRoundnessScore 48 12 = 2 (48 ÷ 12 = 4, 48 ÷ 24 = 2)
 - contextualRoundnessScore 120 12 = 4 (divides by 12, 24, 60, 120)
 -/
-def contextualRoundnessScore (n : Nat) (base : Nat) : Nat :=
-  if base ≤ 1 || n == 0 then 0
+def contextualRoundnessScore (n : ℕ) (base : ℕ) : ℕ :=
+  if base ≤ 1 ∨ n = 0 then 0
   else
-    (if n % base == 0 then 1 else 0) +
-    (if n % (base * 2) == 0 then 1 else 0) +
-    (if n % (base * 5) == 0 then 1 else 0) +
-    (if n % (base * 10) == 0 then 1 else 0)
+    (if base ∣ n then 1 else 0) + (if base * 2 ∣ n then 1 else 0) +
+    (if base * 5 ∣ n then 1 else 0) + (if base * 10 ∣ n then 1 else 0)
 
 /--
 Context-sensitive roundness: compose default k-ness with a non-standard base.
@@ -131,40 +116,39 @@ The contextual score derives from actual divisibility properties relative
 to the base (not a flat bonus), paralleling how standard k-ness derives
 from divisibility by 2/2.5/5/10 × powers of 10.
 -/
-def roundnessInContext (n : Nat) (base : Nat) : Nat :=
+def roundnessInContext (n : ℕ) (base : ℕ) : ℕ :=
   max (roundnessScore n) (contextualRoundnessScore n base)
 
 /-! ### Per-datum verification -/
 
 -- Score verification
-#guard roundnessScore 100 == 6
-#guard roundnessScore 50 == 4
-#guard roundnessScore 7 == 0
-#guard roundnessScore 1000 == 6
-#guard roundnessScore 200 == 6
-#guard roundnessScore 110 == 2
-#guard roundnessScore 20 == 3
+#guard roundnessScore 100 = 6
+#guard roundnessScore 50 = 4
+#guard roundnessScore 7 = 0
+#guard roundnessScore 1000 = 6
+#guard roundnessScore 200 = 6
+#guard roundnessScore 110 = 2
+#guard roundnessScore 20 = 3
 
 -- Grade verification
-#guard roundnessGrade 100 == .high
-#guard roundnessGrade 50 == .moderate
-#guard roundnessGrade 110 == .low
-#guard roundnessGrade 7 == .none
+#guard roundnessGrade 100 = .high
+#guard roundnessGrade 50 = .moderate
+#guard roundnessGrade 110 = .low
+#guard roundnessGrade 7 = .none
 
 -- Context-sensitive verification
-#guard contextualRoundnessScore 48 12 == 2
-#guard contextualRoundnessScore 120 12 == 4
-#guard roundnessInContext 48 12 == 2     -- contextual score beats default (0)
-#guard roundnessInContext 48 10 == 0     -- not round on base-10
-#guard roundnessInContext 100 10 == 6    -- default score beats contextual
+#guard contextualRoundnessScore 48 12 = 2
+#guard contextualRoundnessScore 120 12 = 4
+#guard roundnessInContext 48 12 = 2     -- contextual score beats default (0)
+#guard roundnessInContext 48 10 = 0     -- not round on base-10
+#guard roundnessInContext 100 10 = 6    -- default score beats contextual
 
-/-- Multiples of 10 have roundness score ≥ 2 (multipleOf5 + multipleOf10 both true).
-    This is the key lemma for all downstream sorry-free proofs. -/
-theorem score_ge_two_of_div10 (n : Nat) (h10 : n % 10 = 0) :
-    roundnessScore n ≥ 2 := by
-  unfold roundnessScore roundnessProperties
-  have h5 : n % 5 = 0 := by omega
-  simp only [h10, h5, beq_self_eq_true, ite_true]
+/-- Multiples of 10 have roundness score ≥ 2 (multiple-of-5 and
+multiple-of-10 both hold). The keystone for downstream sorry-free proofs. -/
+theorem score_ge_two_of_div10 (n : ℕ) (h10 : 10 ∣ n) :
+    2 ≤ roundnessScore n := by
+  have h5 : 5 ∣ n := Nat.dvd_trans ⟨2, rfl⟩ h10
+  rw [roundnessScore, if_pos h5, if_pos h10]
   omega
 
 end Semantics.Numerals.Roundness

--- a/Linglib/Studies/BeltramaSchwarz2024.lean
+++ b/Linglib/Studies/BeltramaSchwarz2024.lean
@@ -271,7 +271,7 @@ instance (n : Nat) : Decidable (impreciseReadingAvailable n) :=
 
 /-- Any multiple of 10 carries an imprecise reading (general; derived from the
     roundness keystone). -/
-theorem div10_enables_imprecision (n : Nat) (h10 : n % 10 = 0) :
+theorem div10_enables_imprecision (n : ℕ) (h10 : 10 ∣ n) :
     impreciseReadingAvailable n := by
   unfold impreciseReadingAvailable inferPrecisionMode
   exact if_pos (Semantics.Numerals.Roundness.score_ge_two_of_div10 n h10)

--- a/Linglib/Studies/BeltramaSoltBurnett2022.lean
+++ b/Linglib/Studies/BeltramaSoltBurnett2022.lean
@@ -4,6 +4,7 @@ import Linglib.Semantics.Quantification.Numerals.Precision
 import Linglib.Pragmatics.SocialMeaning.SCM
 import Linglib.Pragmatics.SocialMeaning.EckertMontague
 import Linglib.Fragments.English.NumeralModifiers
+import Mathlib.Tactic.NormNum
 
 /-!
 # [beltrama-solt-burnett-2023]
@@ -78,21 +79,21 @@ def stimRound : Nat := 50
 
 /-- 49 has zero roundness — no imprecise reading is possible. -/
 theorem stim_precise_not_round :
-    Semantics.Numerals.Roundness.roundnessScore stimPrecise = 0 := by native_decide
+    Semantics.Numerals.Roundness.roundnessScore stimPrecise = 0 := by decide
 
 /-- 50 has moderate roundness (score 4) — imprecise readings available. -/
 theorem stim_round_is_round :
-    Semantics.Numerals.Roundness.roundnessScore stimRound = 4 := by native_decide
+    Semantics.Numerals.Roundness.roundnessScore stimRound = 4 := by decide
 
 open Semantics.Numerals.Precision in
 /-- 49 → exact precision mode (roundnessScore 0 < 2). -/
 theorem precise_stim_is_exact :
-    inferPrecisionMode stimPrecise = .exact := by native_decide
+    inferPrecisionMode stimPrecise = .exact := by decide
 
 open Semantics.Numerals.Precision in
 /-- 50 → approximate precision mode (roundnessScore 4 ≥ 2). -/
 theorem round_stim_is_approximate :
-    inferPrecisionMode stimRound = .approximate := by native_decide
+    inferPrecisionMode stimRound = .approximate := by decide
 
 open English.NumeralModifiers in
 /-- The Fragment entry "about" is a tolerance modifier that forces an
@@ -120,15 +121,15 @@ def classifyVariant (n : Nat) (hasToleranceModifier : Bool) : Variant :=
 
 /-- "forty-nine minutes" → precise variant. -/
 theorem classify_49 :
-    classifyVariant stimPrecise false = .precise := by native_decide
+    classifyVariant stimPrecise false = .precise := by decide
 
 /-- "fifty minutes" (bare) → underspecified variant. -/
 theorem classify_50_bare :
-    classifyVariant stimRound false = .underspecified := by native_decide
+    classifyVariant stimRound false = .underspecified := by decide
 
 /-- "about fifty minutes" → approximate variant. -/
 theorem classify_50_about :
-    classifyVariant stimRound true = .approximate := by native_decide
+    classifyVariant stimRound true = .approximate := by decide
 
 -- ============================================================================
 -- §4. Experimental data: cell means (7-point Likert scale)
@@ -173,7 +174,7 @@ def exp2Mean : Variant → SocialDimension → ℚ
 theorem competence_precise_gt_approx :
     exp1Mean .precise .competence > exp1Mean .approximate .competence ∧
     exp2Mean .precise .competence > exp2Mean .approximate .competence := by
-  constructor <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 /-- **Warmth: approximate > precise** (both experiments).
 
@@ -183,7 +184,7 @@ theorem competence_precise_gt_approx :
 theorem warmth_approx_gt_precise :
     exp1Mean .approximate .warmth > exp1Mean .precise .warmth ∧
     exp2Mean .approximate .warmth > exp2Mean .precise .warmth := by
-  constructor <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 /-- **Anti-Solidarity: precise > approximate** (both experiments).
 
@@ -192,7 +193,7 @@ theorem warmth_approx_gt_precise :
 theorem antiSol_precise_gt_approx :
     exp1Mean .precise .antiSolidarity > exp1Mean .approximate .antiSolidarity ∧
     exp2Mean .precise .antiSolidarity > exp2Mean .approximate .antiSolidarity := by
-  constructor <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 /-- **Sign alignment**: competence and anti-solidarity share sign direction
     (both favor precise), while warmth reverses (favors approximate).
@@ -207,7 +208,7 @@ theorem sign_alignment :
     (exp2Mean .precise .competence > exp2Mean .approximate .competence ∧
      exp2Mean .precise .antiSolidarity > exp2Mean .approximate .antiSolidarity ∧
      exp2Mean .approximate .warmth > exp2Mean .precise .warmth) := by
-  constructor <;> refine ⟨?_, ?_, ?_⟩ <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 -- ============================================================================
 -- §6. Three-way indexical field
@@ -265,7 +266,7 @@ theorem underspec_near_precise_on_competence :
      exp1Mean .underspecified .competence - exp1Mean .approximate .competence) ∧
     (exp2Mean .precise .competence - exp2Mean .underspecified .competence <
      exp2Mean .underspecified .competence - exp2Mean .approximate .competence) := by
-  constructor <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 /-- On anti-solidarity, underspecified is closer to approximate than to precise.
     The contrast is precision-driven: it is sharp numbers that make you seem
@@ -277,7 +278,7 @@ theorem underspec_near_approx_on_antiSol :
      exp1Mean .precise .antiSolidarity - exp1Mean .underspecified .antiSolidarity) ∧
     (exp2Mean .underspecified .antiSolidarity - exp2Mean .approximate .antiSolidarity <
      exp2Mean .precise .antiSolidarity - exp2Mean .underspecified .antiSolidarity) := by
-  constructor <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 /-- On warmth, underspecified is genuinely intermediate: it falls strictly
     between precise and approximate in both experiments. Both precision and
@@ -288,7 +289,7 @@ theorem underspec_intermediate_on_warmth :
      exp1Mean .underspecified .warmth < exp1Mean .approximate .warmth) ∧
     (exp2Mean .precise .warmth < exp2Mean .underspecified .warmth ∧
      exp2Mean .underspecified .warmth < exp2Mean .approximate .warmth) := by
-  constructor <;> constructor <;> native_decide
+  norm_num [exp1Mean, exp2Mean]
 
 /-- **Diagnostic asymmetry**: the dimension on which underspecified is closest
     to each endpoint differs. On competence, the cluster gap (precise to
@@ -304,7 +305,7 @@ theorem diagnostic_crossover :
     -- On anti-solidarity: approx-to-underspec < underspec-to-precise (reversed!)
     (exp1Mean .underspecified .antiSolidarity - exp1Mean .approximate .antiSolidarity <
      exp1Mean .precise .antiSolidarity - exp1Mean .underspecified .antiSolidarity) := by
-  constructor <;> native_decide
+  norm_num [exp1Mean]
 
 -- ============================================================================
 -- §8. Context modulation
@@ -350,13 +351,13 @@ theorem competence_enhanced_in_high_demand :
     exp1CompetenceByScenario .forTheRecord .approximate >
     exp1CompetenceByScenario .bonding .precise -
     exp1CompetenceByScenario .bonding .approximate := by
-  native_decide
+  norm_num [exp1CompetenceByScenario]
 
 /-- In Bonding, the competence contrast is neutralized: approximate ≥ precise. -/
 theorem competence_neutralized_in_bonding :
     exp1CompetenceByScenario .bonding .approximate ≥
     exp1CompetenceByScenario .bonding .precise := by
-  native_decide
+  norm_num [exp1CompetenceByScenario]
 
 /-- Exp 2 scenario-specific means on warmth (Solidarity).
     Stranger vs For-the-record, precise vs underspecified (the significant
@@ -379,7 +380,7 @@ theorem warmth_enhanced_in_low_demand :
     exp2WarmthByScenario .stranger .precise >
     exp2WarmthByScenario .forTheRecord .underspecified -
     exp2WarmthByScenario .forTheRecord .precise := by
-  native_decide
+  norm_num [exp2WarmthByScenario]
 
 /-- **Bidirectional context modulation**: high-demand contexts amplify
     competence contrasts while suppressing warmth contrasts, and vice versa.
@@ -399,7 +400,7 @@ theorem context_crossover :
      exp2WarmthByScenario .stranger .precise >
      exp2WarmthByScenario .forTheRecord .underspecified -
      exp2WarmthByScenario .forTheRecord .precise) := by
-  constructor <;> native_decide
+  norm_num [exp1CompetenceByScenario, exp2WarmthByScenario]
 
 -- ============================================================================
 -- §9. Roundness gating
@@ -442,13 +443,13 @@ def bsbGroundedField : GroundedField Variant scmSpace :=
 theorem precise_scmProperties :
     bsbGroundedField.indexedProperties .precise =
       {.competent, .cold, .antiSolidary} := by
-  native_decide
+  decide
 
 /-- Approximate indexes {incompetent, warm, solidary}: the complement. -/
 theorem approximate_scmProperties :
     bsbGroundedField.indexedProperties .approximate =
       {.incompetent, .warm, .solidary} := by
-  native_decide
+  decide
 
 /-- Underspecified indexes nothing: zero association on all dimensions
     → no indexed social properties. Under the EM lift, this makes
@@ -456,6 +457,6 @@ theorem approximate_scmProperties :
     diagnostic role as a neutral baseline (§7). -/
 theorem underspecified_indexes_nothing :
     bsbGroundedField.indexedProperties .underspecified = ∅ := by
-  native_decide
+  decide
 
 end BeltramaSoltBurnett2022

--- a/Linglib/Studies/Cummins2015.lean
+++ b/Linglib/Studies/Cummins2015.lean
@@ -91,11 +91,11 @@ structure NumeralCandidate where
   deriving Repr
 
 /-- Infer granularity from a numeral's trailing zeros: 100 → 2, 110 → 1, 111 → 0. -/
-def inferGranularity (n : Nat) : Nat :=
-  if n == 0 then 0
-  else if n % 1000 == 0 then 3
-  else if n % 100 == 0 then 2
-  else if n % 10 == 0 then 1
+def inferGranularity (n : ℕ) : ℕ :=
+  if n = 0 then 0
+  else if 1000 ∣ n then 3
+  else if 100 ∣ n then 2
+  else if 10 ∣ n then 1
   else 0
 
 -- ============================================================================
@@ -141,11 +141,11 @@ theorem round_beats_nonround_nsal (n₁ n₂ : Nat)
   unfold nsalViolations
   omega
 
-#guard nsalViolations 100 == 0    -- maximally round → 0 violations
-#guard nsalViolations 1000 == 0   -- maximally round → 0 violations
-#guard nsalViolations 7 == 6      -- non-round → 6 violations
-#guard nsalViolations 50 == 2     -- moderately round → 2 violations
-#guard nsalViolations 110 == 4    -- slightly round → 4 violations
+#guard nsalViolations 100 = 0    -- maximally round → 0 violations
+#guard nsalViolations 1000 = 0   -- maximally round → 0 violations
+#guard nsalViolations 7 = 6      -- non-round → 6 violations
+#guard nsalViolations 50 = 2     -- moderately round → 2 violations
+#guard nsalViolations 110 = 4    -- slightly round → 4 violations
 
 -- ============================================================================
 -- § 3: ViolationProfile as Profile Nat 4
@@ -292,7 +292,7 @@ theorem precision_7_exact :
     `.approximate` mode. Follows from `score_ge_two_of_div10`: the score is
     at least 2, so the `roundnessScore n ≥ 2` branch of `inferPrecisionMode`
     fires. -/
-theorem multipleOf10_implies_approximate (n : Nat) (hr : n % 10 = 0) :
+theorem multipleOf10_implies_approximate (n : ℕ) (hr : 10 ∣ n) :
     inferPrecisionMode n = .approximate := by
   unfold inferPrecisionMode
   have hs := Semantics.Numerals.Roundness.score_ge_two_of_div10 n hr

--- a/Linglib/Studies/WoodinEtAl2024.lean
+++ b/Linglib/Studies/WoodinEtAl2024.lean
@@ -25,9 +25,7 @@ namespace WoodinEtAl2024
 
 open Semantics.Numerals.Roundness
 
--- ============================================================================
--- β coefficients from regression model (Table 3, [woodin-etal-2023])
--- ============================================================================
+/-! ### β coefficients from the negative binomial regression (§4.2, [woodin-etal-2023]) -/
 
 /--
 Regression coefficient for each k-ness property on log frequency.
@@ -40,7 +38,7 @@ structure RoundnessCoefficient where
   β : ℚ
   deriving Repr
 
-/-- β coefficients ordered by magnitude (Table 3). -/
+/-- β coefficients ordered by magnitude (§4.2). -/
 def β_tenness : RoundnessCoefficient :=
   { property := "10-ness", β := 446 / 100 }  -- 4.46
 
@@ -48,13 +46,13 @@ def β_2_5ness : RoundnessCoefficient :=
   { property := "2.5-ness", β := 384 / 100 }  -- 3.84
 
 def β_5ness : RoundnessCoefficient :=
-  { property := "5-ness", β := 261 / 100 }  -- 2.61
+  { property := "5-ness", β := 339 / 100 }  -- 3.39
 
 def β_2ness : RoundnessCoefficient :=
-  { property := "2-ness", β := 156 / 100 }  -- 1.56
+  { property := "2-ness", β := 274 / 100 }  -- 2.74
 
 def β_mult10 : RoundnessCoefficient :=
-  { property := "multipleOf10", β := 52 / 100 }  -- 0.52
+  { property := "multipleOf10", β := 245 / 100 }  -- 2.45
 
 def β_mult5 : RoundnessCoefficient :=
   { property := "multipleOf5", β := 6 / 100 }  -- 0.06
@@ -76,12 +74,9 @@ theorem hierarchy_ordering :
     β_5ness.β > β_2ness.β ∧
     β_2ness.β > β_mult10.β ∧
     β_mult10.β > β_mult5.β := by
-  unfold β_tenness β_2_5ness β_5ness β_2ness β_mult10 β_mult5
-  native_decide
+  norm_num [β_tenness, β_2_5ness, β_5ness, β_2ness, β_mult10, β_mult5]
 
--- ============================================================================
--- Frequency-weighted roundness score
--- ============================================================================
+/-! ### Frequency-weighted roundness score -/
 
 /--
 Frequency-weighted roundness score using Woodin et al.'s β coefficients.
@@ -89,40 +84,35 @@ Frequency-weighted roundness score using Woodin et al.'s β coefficients.
 Unlike the unweighted `roundnessScore` (which counts properties equally),
 this weights each property by its empirical frequency effect.
 -/
-def weightedRoundnessScore (n : Nat) : ℚ :=
-  let rp := roundnessProperties n
-  (if rp.multipleOf5 then β_mult5.β else 0) +
-  (if rp.multipleOf10 then β_mult10.β else 0) +
-  (if rp.twoness then β_2ness.β else 0) +
-  (if rp.twoPointFiveness then β_2_5ness.β else 0) +
-  (if rp.fiveness then β_5ness.β else 0) +
-  (if rp.tenness then β_tenness.β else 0)
+def weightedRoundnessScore (n : ℕ) : ℚ :=
+  (if 5 ∣ n then β_mult5.β else 0) +
+  (if 10 ∣ n then β_mult10.β else 0) +
+  (if HasKness n 2 then β_2ness.β else 0) +
+  (if Has2_5ness n then β_2_5ness.β else 0) +
+  (if HasKness n 5 then β_5ness.β else 0) +
+  (if HasKness n 10 then β_tenness.β else 0)
 
 -- Weighted score verification
-#guard weightedRoundnessScore 7 == 0
+#guard weightedRoundnessScore 7 = 0
 #guard weightedRoundnessScore 100 > weightedRoundnessScore 50
 #guard weightedRoundnessScore 50 > weightedRoundnessScore 110
 
 theorem weighted_100_gt_50 :
-    weightedRoundnessScore 100 > weightedRoundnessScore 50 := by native_decide
+    weightedRoundnessScore 100 > weightedRoundnessScore 50 := by
+  simp +decide [weightedRoundnessScore, β_tenness, β_2_5ness, β_5ness, β_2ness, β_mult10, β_mult5]; norm_num
 
 theorem weighted_50_gt_110 :
-    weightedRoundnessScore 50 > weightedRoundnessScore 110 := by native_decide
+    weightedRoundnessScore 50 > weightedRoundnessScore 110 := by
+  simp +decide [weightedRoundnessScore, β_2_5ness, β_5ness, β_mult10, β_mult5]; norm_num
 
 theorem weighted_7_eq_zero :
-    weightedRoundnessScore 7 = 0 := by native_decide
+    weightedRoundnessScore 7 = 0 := by simp +decide [weightedRoundnessScore]
 
 /-- `weightedRoundnessScore 50 > 0`: 50 has multipleOf5, multipleOf10,
     2.5-ness, and 5-ness, so its weighted score is the strictly positive
     sum of those β coefficients. -/
 theorem weighted_50_pos : weightedRoundnessScore 50 > 0 := by
-  unfold weightedRoundnessScore
-  have hp : roundnessProperties 50 =
-      ⟨true, true, false, true, true, false⟩ := by decide
-  rw [hp]
-  simp only [↓reduceIte]
-  unfold β_mult5 β_mult10 β_2_5ness β_5ness
-  norm_num
+  simp +decide [weightedRoundnessScore, β_2_5ness, β_5ness, β_mult10, β_mult5]; norm_num
 
 theorem weighted_50_gt_7 :
     weightedRoundnessScore 50 > weightedRoundnessScore 7 := by
@@ -138,9 +128,7 @@ theorem roundness_prior_monotone :
     weightedRoundnessScore 50 > weightedRoundnessScore 7 :=
   ⟨weighted_100_gt_50, weighted_50_gt_7⟩
 
--- ============================================================================
--- Register effect data
--- ============================================================================
+/-! ### Register effect data -/
 
 /--
 Register type from corpus analysis.


### PR DESCRIPTION
Bool→Prop migration for the k-ness substrate, per the numeral-API roadmap.

- `hasIntKness`/`has2_5ness`/`RoundnessProperties` → decidable predicates `HasKness`/`Has2_5ness` (paper-shape `n = m × k × 10^b` existentials); the single-consumer Bool struct is dissolved; keystone restated with `10 ∣ n`.
- All 26 `native_decide`s in BeltramaSoltBurnett2022/WoodinEtAl2024 replaced: kernel `decide` for ℕ/enum facts, `norm_num` for ℚ-literal comparisons (kernel decide sticks on `Rat.div`'s gcd).
- WoodinEtAl2024's encoded β coefficients corrected against the paper's §4.2 results (3.39/2.74/2.45 for 5-ness/2-ness/multiple-of-10; ordering theorems unaffected).