### PR TITLE
feat(Semantics/Exhaustification): chain keystone + Mihoc Chs. 4-5

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1654,6 +1654,7 @@ import Linglib.Semantics.Events.Basic
 import Linglib.Semantics.Events.CEM
 import Linglib.Semantics.Evidential.Basic
 import Linglib.Semantics.Evidential.Defs
+import Linglib.Semantics.Exhaustification.Chain
 import Linglib.Semantics.Exhaustification.Combinators
 import Linglib.Semantics.Exhaustification.Excluder
 import Linglib.Semantics.Exhaustification.FreeChoice
@@ -1662,6 +1663,7 @@ import Linglib.Semantics.Exhaustification.Operators.Antiexhaustive
 import Linglib.Semantics.Exhaustification.Operators.Basic
 import Linglib.Semantics.Exhaustification.Operators.Decidable
 import Linglib.Semantics.Exhaustification.Operators.InnocentInclusion
+import Linglib.Semantics.Exhaustification.PreExhaustified
 import Linglib.Semantics.Exhaustification.Presuppositional
 import Linglib.Semantics.Exhaustification.Relevance
 import Linglib.Semantics.Exhaustification.ScalePredictions

--- a/Linglib/Semantics/Exhaustification/Chain.lean
+++ b/Linglib/Semantics/Exhaustification/Chain.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.Basic
+import Mathlib.Data.Fintype.Basic
+
+/-!
+# Exhaustification over entailment chains
+[horn-1972] [fox-2007] [fox-hackl-2006] [chierchia-2013]
+
+Scalar alternatives typically form an *entailment chain*: a family
+`φ : ι → W → Prop` over an ordered index, antitone in the index (higher
+index = stronger alternative). Exhaustifying a prejacent `φ i` against all
+stronger alternatives (`exhChain`) then collapses to negating the single
+*next-stronger* alternative, when one exists (`exhChain_iff_succ`); on a
+dense scale with no next alternative, exhaustification cannot be satisfied
+at all (`exhChain_not_of_dense` — [fox-hackl-2006]'s Universal Density of
+Measurement crash).
+
+The two lemmas are the two halves of one case split — does a next-stronger
+alternative exist? — instantiated across the numeral literature:
+`Semantics.Numerals.exhNumeral` (Horn's 'exactly', the step-1 instance on
+ℕ), granularity-`g` scalar alternatives in both bound directions
+(`Studies/Mihoc2019`), the dense crash (`Studies/FoxHackl2006Numerals`),
+and grain-size-indexed precisification families ([thomas-deo-2020]'s
+approximative *just*).
+
+## Main definitions
+
+- `exhChain`: assert the prejacent, negate every strictly stronger
+  alternative of the chain
+
+## Main results
+
+- `exhChain_iff_succ`: on a chain, exhaustification = negating the
+  next-stronger alternative
+- `exhChain_not_of_dense`: with no next-stronger alternative,
+  exhaustification is unsatisfiable
+-/
+
+namespace Exhaustification
+
+variable {ι W : Type*} [Preorder ι] {φ : ι → W → Prop} {i s : ι} {w : W}
+
+/-- Exhaustification of the prejacent `φ i` against all strictly stronger
+alternatives of the family: assert `φ i`, negate `φ j` for every `j > i`. -/
+def exhChain (φ : ι → W → Prop) (i : ι) (w : W) : Prop :=
+  φ i w ∧ ∀ j, i < j → ¬ φ j w
+
+instance [DecidableEq ι] [Fintype ι] [DecidableLT ι]
+    [∀ j, Decidable (φ j w)] : Decidable (exhChain φ i w) :=
+  inferInstanceAs (Decidable (_ ∧ ∀ _, _ → _))
+
+/-- On an entailment chain — the family is antitone, so higher alternatives
+entail lower ones — exhaustification collapses to negating the
+*next-stronger* alternative: if `s` lies above `i` and below every other
+index above `i`, then negating `φ s` negates the whole upper set. -/
+theorem exhChain_iff_succ (hanti : ∀ ⦃j k : ι⦄, j ≤ k → ∀ w, φ k w → φ j w)
+    (his : i < s) (hleast : ∀ j, i < j → s ≤ j) :
+    exhChain φ i w ↔ φ i w ∧ ¬ φ s w :=
+  ⟨fun ⟨hp, hstr⟩ => ⟨hp, hstr s his⟩,
+   fun ⟨hp, hs⟩ => ⟨hp, fun j hj hφj => hs (hanti (hleast j hj) w hφj)⟩⟩
+
+/-- If every world verifying the prejacent verifies some strictly stronger
+alternative — as on a dense scale — chain-exhaustification is
+unsatisfiable: the [fox-hackl-2006] density crash. -/
+theorem exhChain_not_of_dense (hdense : ∀ w, φ i w → ∃ j, i < j ∧ φ j w) :
+    ¬ exhChain φ i w := fun ⟨hp, hstr⟩ =>
+  let ⟨j, hij, hφj⟩ := hdense w hp
+  hstr j hij hφj
+
+end Exhaustification

--- a/Linglib/Semantics/Exhaustification/PreExhaustified.lean
+++ b/Linglib/Semantics/Exhaustification/PreExhaustified.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Logic.Basic
+import Mathlib.Logic.ExistsUnique
+import Mathlib.Data.Fintype.Basic
+
+/-!
+# Pre-exhaustified alternatives and proper strengthening
+[chierchia-2013] [fox-2007]
+
+The grammatical theory of implicature negates *pre-exhaustified* domain
+alternatives: each alternative strengthened against its rivals before being
+negated. For a family `A : ι → Prop`, the pre-exhaustification of `A i` is
+"`A i` and no rival holds" — i.e. `A i` holds *uniquely*. Negating every
+pre-exhaustified alternative is therefore exactly the claim that no
+alternative holds uniquely (`forall_not_preExh_iff`): the combinatorial core
+of free-choice effects — plain, modal ([chierchia-2013]), and epistemic
+(ignorance inferences, [mihoc-2019]) — where the assertion supplies "at
+least one region is live" and unique-truth failure spreads possibility
+across all of them.
+
+`ProperlyStrengthens` names the requirement some items impose on their
+exhaustification: the result must be *strictly* stronger than the prejacent.
+When every alternative is individually inconsistent with the prejacent,
+exhaustification is vacuous and the requirement fails
+(`not_properlyStrengthens_of_iff`) — the engine of anti-negativity
+(positive-polarity) verdicts.
+
+## Main definitions
+
+- `preExh`: an alternative strengthened against its rivals
+- `ProperlyStrengthens`: strict strengthening of a prejacent
+
+## Main results
+
+- `exists_preExh_iff_existsUnique`, `forall_not_preExh_iff`: negating all
+  pre-exhaustified alternatives = no alternative holds uniquely
+- `not_properlyStrengthens_of_iff`: vacuous exhaustification fails proper
+  strengthening
+-/
+
+namespace Exhaustification
+
+variable {ι α : Type*} {A : ι → Prop}
+
+/-- Pre-exhaustification of alternative `i` against its rivals: `A i` holds
+and no distinct alternative does. -/
+def preExh (A : ι → Prop) (i : ι) : Prop :=
+  A i ∧ ∀ j, j ≠ i → ¬ A j
+
+instance [DecidableEq ι] [Fintype ι] [∀ i, Decidable (A i)] (i : ι) :
+    Decidable (preExh A i) :=
+  inferInstanceAs (Decidable (_ ∧ ∀ _, _ → _))
+
+/-- Some alternative is pre-exhaustifiedly true iff some alternative is
+*uniquely* true. -/
+theorem exists_preExh_iff_existsUnique : (∃ i, preExh A i) ↔ ∃! i, A i := by
+  constructor
+  · rintro ⟨i, hi, hunique⟩
+    exact ⟨i, hi, fun j hj => by_contra fun hne => hunique j hne hj⟩
+  · rintro ⟨i, hi, hunique⟩
+    exact ⟨i, hi, fun j hne hj => hne (hunique j hj)⟩
+
+/-- Negating every pre-exhaustified alternative is exactly the denial that
+any alternative holds uniquely. -/
+theorem forall_not_preExh_iff : (∀ i, ¬ preExh A i) ↔ ¬ ∃! i, A i := by
+  rw [← exists_preExh_iff_existsUnique, not_exists]
+
+/-- `strong` properly strengthens `weak`: it entails it, and excludes some
+possibility `weak` leaves open. -/
+def ProperlyStrengthens (strong weak : α → Prop) : Prop :=
+  (∀ x, strong x → weak x) ∧ ∃ x, weak x ∧ ¬ strong x
+
+/-- Vacuous exhaustification — the strengthened meaning coincides with the
+prejacent — fails the proper-strengthening requirement. -/
+theorem not_properlyStrengthens_of_iff {strong weak : α → Prop}
+    (h : ∀ x, strong x ↔ weak x) : ¬ ProperlyStrengthens strong weak :=
+  fun ⟨_, x, hw, hns⟩ => hns ((h x).mpr hw)
+
+end Exhaustification

--- a/Linglib/Semantics/Quantification/Numerals/Basic.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Basic.lean
@@ -1,4 +1,10 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Comparison
+import Linglib.Semantics.Exhaustification.Chain
 import Linglib.Semantics.Degree.Predicate
 import Linglib.Semantics.Degree.Defs
 import Linglib.Semantics.Quantification.Quantifier
@@ -325,6 +331,19 @@ theorem exhNumeral_iff_bare (m n : Nat) :
   unfold exhNumeral
   show n ≥ m ∧ ¬ n ≥ m + 1 ↔ n = m
   omega
+
+/-- `exhNumeral` is chain-exhaustification against the full Horn scale of
+stronger numerals (`Exhaustification.exhChain`): the scale is an entailment
+chain, so negating the next-stronger alternative negates them all
+(`Exhaustification.exhChain_iff_succ`). -/
+theorem exhNumeral_eq_exhChain (m n : Nat) :
+    exhNumeral m n ↔
+      Exhaustification.exhChain (fun k => atLeastMeaning (m + k)) 0 n := by
+  rw [Exhaustification.exhChain_iff_succ
+      (fun j k hjk d hd => by
+        simp only [atLeastMeaning_def, ge_iff_le] at hd ⊢; omega)
+      Nat.zero_lt_one fun j hj => hj]
+  simp [exhNumeral]
 
 -- ============================================================================
 -- Section 8: GQT Bridge ([bylinina-nouwen-2020])

--- a/Linglib/Studies/FoxHackl2006Numerals.lean
+++ b/Linglib/Studies/FoxHackl2006Numerals.lean
@@ -1,7 +1,14 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Degree.DirectedMeasure
 import Linglib.Semantics.Degree.Predicate
 import Linglib.Semantics.Entailment.Extremum
 import Linglib.Semantics.Quantification.Numerals.Basic
+import Linglib.Semantics.Exhaustification.Chain
+import Mathlib.Tactic.Linarith
 
 /-!
 # Numeral MIP Bridge
@@ -65,6 +72,17 @@ theorem atLeast_has_maxInf_general (n : ℕ) :
 theorem moreThan_has_maxInf_nat :
     HasMaxInf (Comparison.gt.over (α := ℕ) id) 3 :=
   moreThan_nat_hasMaxInf id 3 (show (3 : ℕ) ∈ Comparison.gt.over id 0 from by decide)
+
+/-- The dense half of the asymmetry as chain-exhaustification: on ℚ the
+stronger *more than* alternatives have no next member, so exhaustifying
+*more than c* against its own scale is unsatisfiable —
+`Exhaustification.exhChain_not_of_dense` at the UDM scale. On ℕ the next
+member exists and exhaustification returns 'exactly' instead
+(`Semantics.Numerals.exhNumeral_eq_exhChain`). -/
+theorem moreThan_exhChain_crash (c maxD : ℚ) :
+    ¬ Exhaustification.exhChain (fun x d => x < d) c maxD :=
+  Exhaustification.exhChain_not_of_dense fun d hd =>
+    ⟨(c + d) / 2, by linarith, by linarith⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. MIP Derives Exact Meaning

--- a/Linglib/Studies/Mihoc2019.lean
+++ b/Linglib/Studies/Mihoc2019.lean
@@ -1,5 +1,14 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Comparison
 import Linglib.Semantics.Quantification.Numerals.Basic
+import Linglib.Semantics.Exhaustification.Chain
+import Linglib.Semantics.Exhaustification.PreExhaustified
+import Linglib.Discourse.CommonGround
+import Mathlib.Data.Fintype.Powerset
 
 /-!
 # [mihoc-2019]: Decomposing Modified Numerals
@@ -62,6 +71,16 @@ obliterates the next-stronger alternative.
   neo-Gricean account derives none (`Kennedy2015.classA_moreThan3_no_primary`)
 - `exhSigma_moreThan_coarse_not_exactly`, `spector_grade_context`: coarser
   granularity avoids the 'exactly' overgeneration (her §3.6–3.7)
+- `exhSigma_moreThan_eq_exhChain` / `exhSigma_atMost_eq_exhChain`: the
+  one-scalemate operator equals whole-scale chain-exhaustification
+  (`Exhaustification.exhChain_iff_succ`)
+- `Ignorance.parse_sg_total`: unpruned parses force total ignorance —
+  the structural core of her Tables 4.1/4.3, via
+  `Exhaustification.forall_not_preExh_iff`; `winner0_blocked`,
+  `sg_accommodates_loser`, `db_blocks_loser`: the residual table cells
+- `AntiNegativity.negation_fails_PS`: `O_ExhDA` is vacuous under negation
+  (her Ch. 5 (9)), so the SMN's Proper Strengthening requirement fails;
+  `NumeralClass`: her [±prune DA, ±PS] parameter pair
 -/
 
 namespace Mihoc2019
@@ -392,5 +411,230 @@ theorem spector_grade_context (maxD : ℕ) :
 #guard (Form.lessThan 3).exhSigma 1 2 ∧ ¬ (Form.lessThan 3).exhSigma 1 1
 #guard (Form.atLeast 3).exhSigma 1 3 ∧ ¬ (Form.atLeast 3).exhSigma 1 4
 #guard (Form.atMost 3).exhSigma 1 3 ∧ ¬ (Form.atMost 3).exhSigma 1 2
+
+
+/-! ### σA scales as entailment chains
+
+`exhSigma` negates one next-stronger scalemate; the substrate keystone
+`Exhaustification.exhChain_iff_succ` shows this equals exhaustification
+against the *whole* granularity-`g` scale, since the scale is an entailment
+chain. (Dually, `Exhaustification.exhChain_not_of_dense` is the
+[fox-hackl-2006] crash that this file's contextual-granularity scales
+avoid: cf. `FoxHackl2006Numerals.moreThan_exhChain_crash`.) -/
+
+theorem exhSigma_moreThan_eq_exhChain (n g maxD : ℕ) :
+    (Form.moreThan n).exhSigma g maxD ↔
+      Exhaustification.exhChain (fun k => (Form.moreThan (n + k * g)).tc) 0 maxD := by
+  rw [Exhaustification.exhChain_iff_succ
+      (fun j k hjk d hd => by
+        simp only [tc_moreThan] at hd ⊢
+        have := Nat.mul_le_mul_right g hjk
+        omega)
+      Nat.zero_lt_one fun j hj => hj]
+  simp only [Form.exhSigma, Form.strongerAlt, tc_moreThan, Nat.zero_mul,
+    Nat.add_zero, Nat.one_mul]
+
+theorem exhSigma_atMost_eq_exhChain (n g maxD : ℕ) :
+    (Form.atMost n).exhSigma g maxD ↔
+      Exhaustification.exhChain (fun k => (Form.atMost (n - k * g)).tc) 0 maxD := by
+  rw [Exhaustification.exhChain_iff_succ
+      (fun j k hjk d hd => by
+        simp only [tc_atMost] at hd ⊢
+        have := Nat.mul_le_mul_right g hjk
+        omega)
+      Nat.zero_lt_one fun j hj => hj]
+  simp only [Form.exhSigma, Form.strongerAlt, tc_atMost, Nat.zero_mul,
+    Nat.sub_zero, Nat.one_mul]
+
+/-! ### Ignorance (her Ch. 4)
+
+Assertions carry a null epistemic necessity modal `□_S`; `O` applies above
+it, negating pre-exhaustified domain alternatives
+(`Exhaustification.preExh`) and the stronger σA. Her running model: the CMN
+*less than three* / SMN *at most two*, worlds = candidate maxima 0–3,
+`□_S` = `ContextSet.entails` over a nonempty epistemic state
+(`boxS_iff_entails`). The DA are the value-regions inside the prejacent set
+{0, 1, 2}: singletons and doubletons.
+
+The load-bearing structure: negating the pre-exhaustified singleton DA says
+no region is settled *uniquely* (`Exhaustification.forall_not_preExh_iff`),
+and a nonempty state settles at most one of the disjoint regions
+(`sgDA_subsingleton`) — so none is settled: **total ignorance**, her Tables
+4.1/4.3, derived structurally. The residual table cells (loser/winner
+accommodation and blocking) are checked exhaustively over all epistemic
+states. -/
+
+namespace Ignorance
+
+/-- Worlds: the candidate maximum, values 0–3. -/
+abbrev EWorld := Fin 4
+
+/-- `□_S` over a finite epistemic state — `ContextSet.entails` in
+computable clothing (`boxS_iff_entails`). -/
+def boxS (E : Finset EWorld) (p : EWorld → Prop) : Prop := ∀ w ∈ E, p w
+
+instance (E : Finset EWorld) (p : EWorld → Prop) [DecidablePred p] :
+    Decidable (boxS E p) :=
+  inferInstanceAs (Decidable (∀ w ∈ E, p w))
+
+theorem boxS_iff_entails (E : Finset EWorld) (p : EWorld → Prop) :
+    boxS E p ↔ CommonGround.ContextSet.entails (↑E : Set EWorld) {w | p w} := by
+  simp [boxS, CommonGround.ContextSet.entails, Set.subset_def]
+
+/-- The asserted prejacent: `□_S`(*less than three*). -/
+def prejacent (E : Finset EWorld) : Prop :=
+  boxS E fun w => (Form.lessThan 3).tc w.val
+
+instance (E : Finset EWorld) : Decidable (prejacent E) :=
+  inferInstanceAs (Decidable (boxS E fun w => (Form.lessThan 3).tc w.val))
+
+/-- Singleton domain alternatives: `□_S(max = i)` for `i < 3`. -/
+def sgDA (E : Finset EWorld) (i : Fin 3) : Prop :=
+  boxS E fun w => w.val = i.val
+
+/-- Doubleton domain alternatives: `□_S` of the prejacent region minus
+value `i`. -/
+def dbDA (E : Finset EWorld) (i : Fin 3) : Prop :=
+  boxS E fun w => w.val < 3 ∧ w.val ≠ i.val
+
+instance (E : Finset EWorld) (i : Fin 3) : Decidable (sgDA E i) :=
+  inferInstanceAs (Decidable (boxS E fun w => w.val = i.val))
+
+instance (E : Finset EWorld) (i : Fin 3) : Decidable (dbDA E i) :=
+  inferInstanceAs (Decidable (boxS E fun w => w.val < 3 ∧ w.val ≠ i.val))
+
+/-- A nonempty state settles at most one singleton region. -/
+theorem sgDA_subsingleton {E : Finset EWorld} (hE : E.Nonempty) {i j : Fin 3}
+    (hi : sgDA E i) (hj : sgDA E j) : i = j := by
+  obtain ⟨w, hw⟩ := hE
+  have h1 := hi w hw
+  have h2 := hj w hw
+  exact Fin.ext (by omega)
+
+/-- **Total ignorance from unique-truth failure**: negating every
+pre-exhaustified singleton DA leaves no settled region at all — the
+'total' verdicts of her Tables 4.1/4.3, structurally. -/
+theorem total_ignorance_of_not_preExh {E : Finset EWorld} (hE : E.Nonempty)
+    (h : ∀ i, ¬ Exhaustification.preExh (sgDA E) i) (i : Fin 3) :
+    ¬ sgDA E i := by
+  intro hi
+  rw [Exhaustification.forall_not_preExh_iff] at h
+  exact h ⟨i, hi, fun j hj => sgDA_subsingleton hE hj hi⟩
+
+/-- The `O_ExhDA+σA` parse of `□_S`(*less than three*) (her (12)/(14)/(16)),
+with her DA-pruning parameter: `sg`/`db` select which DA sizes survive
+pruning. -/
+def parse (sg db : Bool) (E : Finset EWorld) : Prop :=
+  prejacent E ∧
+  (sg = true → ∀ i, ¬ Exhaustification.preExh (sgDA E) i) ∧
+  (db = true → ∀ i, ¬ Exhaustification.preExh (dbDA E) i) ∧
+  ¬ boxS E (fun w => w.val < 2) ∧ ¬ boxS E (fun w => w.val < 1)
+
+instance (sg db : Bool) (E : Finset EWorld) : Decidable (parse sg db E) :=
+  inferInstanceAs (Decidable (prejacent E ∧ _ ∧ _ ∧ _ ∧ _))
+
+/-- Total ignorance (her total row): no value-region is settled. -/
+def TotalIgnorance (E : Finset EWorld) : Prop := ∀ i, ¬ sgDA E i
+
+/-- Her canonical 'winner' scenario: `□_S 0`. -/
+def winner0 (E : Finset EWorld) : Prop := sgDA E 0
+
+/-- Her canonical 'loser' scenario: `□_S ¬0 ∧ ¬□_S 1 ∧ ¬□_S 2` — one region
+excluded, the rest unsettled. -/
+def loser0 (E : Finset EWorld) : Prop :=
+  (boxS E fun w => w.val ≠ 0) ∧ ¬ sgDA E 1 ∧ ¬ sgDA E 2
+
+instance (E : Finset EWorld) : Decidable (loser0 E) :=
+  inferInstanceAs (Decidable ((boxS E fun w => w.val ≠ 0) ∧ _ ∧ _))
+
+/-- Any parse that keeps the singleton DA forces total ignorance — her
+Table 4.1 and 4.3 sum-ups, including the SMN (no-pruning) verdict. -/
+theorem parse_sg_total {db : Bool} {E : Finset EWorld} (hE : E.Nonempty)
+    (h : parse true db E) : TotalIgnorance E :=
+  fun i => total_ignorance_of_not_preExh hE (h.2.1 rfl) i
+
+/-- The 'winner' scenario clashes with the σA-implicature — the ✗ cells of
+her Tables 4.1/4.2: `□_S 0` entails `□_S`(*less than one*). -/
+theorem winner0_blocked {sg db : Bool} {E : Finset EWorld}
+    (h : parse sg db E) : ¬ winner0 E := by
+  intro hw
+  exact h.2.2.2.2 fun w hwE => by have := hw w hwE; omega
+
+/-- The singleton-DA regime accommodates the 'loser' scenario — Table 4.1's
+✓ cell (CMNs, which may prune, admit partial ignorance). -/
+theorem sg_accommodates_loser :
+    ∃ E : Finset EWorld, E.Nonempty ∧ parse true false E ∧ loser0 E := by
+  exact ⟨{1, 2}, by decide, by decide, by decide⟩
+
+/-- The doubleton-DA regime blocks the 'loser' scenario — Table 4.2's ✗
+cell — checked over every epistemic state. -/
+theorem db_blocks_loser :
+    ∀ E : Finset EWorld, E.Nonempty → parse false true E → ¬ loser0 E := by
+  decide
+
+end Ignorance
+
+/-! ### Anti-negativity (her Ch. 5)
+
+Under clausemate negation each pre-exhaustified DA is individually
+inconsistent with the prejacent, so `O_ExhDA` is vacuous (her (9)) — and
+the Proper Strengthening requirement
+(`Exhaustification.ProperlyStrengthens`) fails. Her parameter pair: SMNs
+keep all DA (hence episodic total ignorance, `Ignorance.parse_sg_total`)
+and require PS (hence deviance under negation, `negation_fails_PS`); CMNs
+may prune and impose no PS requirement, escaping both. -/
+
+namespace AntiNegativity
+
+/-- Worlds for the negated case: candidate maxima 0–2. -/
+abbrev NWorld := Fin 3
+
+/-- *John didn't call less than two people*: the negated prejacent. -/
+def negPrejacent (w : NWorld) : Prop := ¬ (Form.lessThan 2).tc w.val
+
+/-- The embedded numeral's DA as propositions at `w`: `max = i`, `i < 2`. -/
+def negDA (w : NWorld) (i : Fin 2) : Prop := w.val = i.val
+
+/-- The `O_ExhDA` parse of the negated sentence (her (8)–(9)). -/
+def oParse (w : NWorld) : Prop :=
+  negPrejacent w ∧ ∀ i, ¬ Exhaustification.preExh (negDA w) i
+
+/-- Her (9): every pre-exhaustified DA contradicts the negated prejacent,
+so negating them adds nothing — `O_ExhDA` is vacuous. -/
+theorem oParse_iff_negPrejacent (w : NWorld) : oParse w ↔ negPrejacent w := by
+  constructor
+  · exact And.left
+  · intro h
+    refine ⟨h, fun i hpe => h ((tc_lessThan 2 w.val).mpr ?_)⟩
+    have hi := hpe.1
+    simp only [negDA] at hi
+    omega
+
+/-- Vacuous exhaustification fails Proper Strengthening — the SMN
+anti-negativity verdict (her §5.1); CMNs, lacking the requirement, are
+fine under negation. -/
+theorem negation_fails_PS :
+    ¬ Exhaustification.ProperlyStrengthens oParse negPrejacent :=
+  Exhaustification.not_properlyStrengthens_of_iff oParse_iff_negPrejacent
+
+/-- Her Ch. 4–5 lexical parameter pair for modified numerals. -/
+inductive NumeralClass where
+  /-- Comparative-modified: may prune DA; no PS requirement. -/
+  | cmn
+  /-- Superlative-modified: full DA; PS required. -/
+  | smn
+  deriving DecidableEq, Repr
+
+/-- Whether the class licenses DA pruning (her Ch. 4). -/
+def NumeralClass.canPruneDA : NumeralClass → Prop
+  | .cmn => True
+  | .smn => False
+
+/-- Whether the class requires Proper Strengthening (her Ch. 5). -/
+def NumeralClass.requiresPS : NumeralClass → Prop
+  | .cmn => False
+  | .smn => True
+
+end AntiNegativity
 
 end Mihoc2019


### PR DESCRIPTION
Substrate-first stage 2 of the Mihoc arc: two new exhaustification primitives, existing operators re-derived as instances, and the ignorance/anti-negativity results as thin consumption.

- `Exhaustification/Chain.lean`: `exhChain` over antitone alternative families; `exhChain_iff_succ` (chain exhaustification = negate the next-stronger alternative, when one exists) and `exhChain_not_of_dense` (no successor → unsatisfiable) are the two halves of one case split. Instances: `exhNumeral_eq_exhChain` (Numerals/Basic), granularity-g scales in both directions (Mihoc2019), and `moreThan_exhChain_crash` on ℚ (FoxHackl2006Numerals) — the Horn/Mihoc/Fox–Hackl accounts as one lemma's branches.
- `Exhaustification/PreExhaustified.lean`: `preExh` + `forall_not_preExh_iff` (negating pre-exhaustified alternatives = no alternative holds uniquely) and `ProperlyStrengthens` + vacuity.
- Mihoc2019 Chs. 4–5: □_S as `ContextSet.entails`; total ignorance derived structurally (unique-truth failure + disjoint regions), residual Table 4.1/4.2 cells checked over all epistemic states (`decide` caught an under-specified loser scenario — her ¬□ conjuncts are load-bearing); Ch. 5 vacuity-under-negation and the failed Proper Strengthening; the [±prune DA, ±PS] `NumeralClass` parameter pair.
- License headers added to all touched files per convention.