### PR TITLE
feat(Studies): Jansen-Pollmann 2001; fix 10-ness to the k = 1 family

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2339,6 +2339,7 @@ import Linglib.Studies.Israel2001
 import Linglib.Studies.ItoMester2009
 import Linglib.Studies.Izvorski1997
 import Linglib.Studies.Jaeger2007
+import Linglib.Studies.JansenPollmann2001
 import Linglib.Studies.Jardine2016
 import Linglib.Studies.Jardine2016Tone
 import Linglib.Studies.Jardine2017

--- a/Linglib/Semantics/Quantification/Numerals/Precision.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Precision.lean
@@ -92,7 +92,7 @@ def PrecisionMode.projection (g : ℕ) : PrecisionMode → PrecisionProjection �
   | .approximate => .roundTo g
 
 #guard inferPrecisionMode 100 = .approximate  -- score 6 ≥ 2
-#guard inferPrecisionMode 50 = .approximate   -- score 4 ≥ 2
+#guard inferPrecisionMode 50 = .approximate   -- score 5 ≥ 2
 #guard inferPrecisionMode 110 = .approximate  -- score 2 ≥ 2
 #guard inferPrecisionMode 7 = .exact          -- score 0 < 2
 #guard inferPrecisionMode 99 = .exact         -- score 0 < 2

--- a/Linglib/Semantics/Quantification/Numerals/Roundness.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Roundness.lean
@@ -7,8 +7,13 @@ import Mathlib.Data.Nat.Basic
 Framework-agnostic infrastructure for graded numeral roundness,
 following [sigurd-1988], [jansen-pollmann-2001], and [woodin-etal-2023].
 
-A number n has **k-ness** (for k ∈ {2, 2.5, 5, 10}) if n = m × k × 10^b
-for some b ≥ 1 and 1 ≤ m ≤ 9.
+A number n has **k-ness** if it lies in [jansen-pollmann-2001]'s set
+[k × (1–9 × 10ⁿ)] (their p. 198): n = m × k × 10^b with 1 ≤ m ≤ 9 —
+so 10-ness is the k = 1 family (divisors 10, 100, …), per their own
+example "70 has only 10-ness". Their original allows b ≥ 0; following
+[woodin-etal-2023] (fn. 3) the search starts at b ≥ 1, which drops the
+single digits from 10-ness and 15, 45, … from 5-ness (cf.
+`Studies/JansenPollmann2001.lean` for the original and the divergence).
 
 The 6 properties, ordered by strength as frequency predictors in
 [woodin-etal-2023]'s negative binomial regression (strongest first):
@@ -57,7 +62,7 @@ and pragmatic behavior ([woodin-etal-2023]). -/
 def roundnessScore (n : ℕ) : ℕ :=
   (if 5 ∣ n then 1 else 0) + (if 10 ∣ n then 1 else 0) +
   (if HasKness n 2 then 1 else 0) + (if Has2_5ness n then 1 else 0) +
-  (if HasKness n 5 then 1 else 0) + (if HasKness n 10 then 1 else 0)
+  (if HasKness n 5 then 1 else 0) + (if HasKness n 1 then 1 else 0)
 
 /-- Maximum possible roundness score. -/
 def maxRoundnessScore : ℕ := 6
@@ -71,9 +76,9 @@ Collapses the 0–6 score into 4 levels to avoid duplicating
 step-function logic across Theory files.
 -/
 inductive RoundnessGrade where
-  /-- score ≥ 5 (e.g., 100, 1000, 200) -/
+  /-- score ≥ 5 (e.g., 100, 50, 200) -/
   | high
-  /-- score 3–4 (e.g., 50, 20) -/
+  /-- score 3–4 (e.g., 20, 40) -/
   | moderate
   /-- score 1–2 (e.g., 110, 15) -/
   | low
@@ -123,16 +128,16 @@ def roundnessInContext (n : ℕ) (base : ℕ) : ℕ :=
 
 -- Score verification
 #guard roundnessScore 100 = 6
-#guard roundnessScore 50 = 4
+#guard roundnessScore 50 = 5
 #guard roundnessScore 7 = 0
 #guard roundnessScore 1000 = 6
 #guard roundnessScore 200 = 6
 #guard roundnessScore 110 = 2
-#guard roundnessScore 20 = 3
+#guard roundnessScore 20 = 4
 
 -- Grade verification
 #guard roundnessGrade 100 = .high
-#guard roundnessGrade 50 = .moderate
+#guard roundnessGrade 50 = .high
 #guard roundnessGrade 110 = .low
 #guard roundnessGrade 7 = .none
 

--- a/Linglib/Studies/BeltramaSoltBurnett2022.lean
+++ b/Linglib/Studies/BeltramaSoltBurnett2022.lean
@@ -81,9 +81,9 @@ def stimRound : Nat := 50
 theorem stim_precise_not_round :
     Semantics.Numerals.Roundness.roundnessScore stimPrecise = 0 := by decide
 
-/-- 50 has moderate roundness (score 4) — imprecise readings available. -/
+/-- 50 is highly round (score 5) — imprecise readings available. -/
 theorem stim_round_is_round :
-    Semantics.Numerals.Roundness.roundnessScore stimRound = 4 := by decide
+    Semantics.Numerals.Roundness.roundnessScore stimRound = 5 := by decide
 
 open Semantics.Numerals.Precision in
 /-- 49 → exact precision mode (roundnessScore 0 < 2). -/

--- a/Linglib/Studies/Cummins2015.lean
+++ b/Linglib/Studies/Cummins2015.lean
@@ -144,7 +144,7 @@ theorem round_beats_nonround_nsal (n₁ n₂ : Nat)
 #guard nsalViolations 100 = 0    -- maximally round → 0 violations
 #guard nsalViolations 1000 = 0   -- maximally round → 0 violations
 #guard nsalViolations 7 = 6      -- non-round → 6 violations
-#guard nsalViolations 50 = 2     -- moderately round → 2 violations
+#guard nsalViolations 50 = 1     -- highly round → 1 violation
 #guard nsalViolations 110 = 4    -- slightly round → 4 violations
 
 -- ============================================================================

--- a/Linglib/Studies/JansenPollmann2001.lean
+++ b/Linglib/Studies/JansenPollmann2001.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Semantics.Quantification.Numerals.Roundness
+import Mathlib.Data.Rat.Defs
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.NormNum.GCD
+
+/-!
+# [jansen-pollmann-2001]: On Round Numbers
+[jansen-pollmann-2001] [sigurd-1988] [krifka-2007] [woodin-etal-2023]
+
+[jansen-pollmann-2001] operationalize roundness as *relative* suitability
+for approximation contexts (frequency after Dutch *ongeveer* 'about') and
+find it carried by four numerical properties — 10-ness, 2-ness, 5-ness,
+and (following [sigurd-1988]) 2½-ness: membership in `[k × (1–9 × 10ⁿ)]`
+(their p. 198). Their explanation (pp. 200–201) is the **principle of
+favourite quantities**: doubling and halving (sometimes followed by
+halving again) are the basic means of manipulating quantities, so the
+round-number unit inventory is the orbit of the decimal base powers under
+these operations — exactly the four k-families (`favUnit_iff`), and
+provably not the 3-family (`not_favUnit_three_mul_pow`; their p. 199:
+3-, 4-, 6-, 7-ness contribute nothing).
+
+Two-number approximative expressions (*about 5 or 6 books*) obey the
+**revised sequence rule** (their p. 197): the pair consists of consecutive
+members of an arithmetic sequence whose ratio and first member are
+`1×10ⁿ`, `2×10ⁿ`, or `½×10ⁿ`. Quarters, which do round single numbers
+(2½-ness), are absent from pairs (`quarter_unit_not_seqRatio`).
+
+Their p. 198 definition allows the zeroth power (`hasKnessOrig`);
+`Roundness.HasKness` follows [woodin-etal-2023]'s b ≥ 1 restriction
+(their fn. 3). The divergence matters downstream: under the original,
+15 has 5-ness (`fifteen_has_orig_fiveness`) — roundness that the
+restricted variant, and hence `Precision.inferPrecisionMode`, misses at
+15, 45, …. Reading this paper also corrected `Roundness`'s 10-ness: it is
+the k = 1 family (divisors 10, 100, …) — their own example "70 has only
+10-ness" — not the k = 10 family.
+
+Their regression (frequency from magnitude n⁻¹, n⁻² plus the four
+properties, R² = 0.968, p. 200) stays prose per the no-regression-theorems
+rule, as does the FA operationalization itself.
+
+## Main definitions
+
+- `QuantityOp`, `IsFavUnit`: doubling/halving over decimal base powers
+- `SeqRatio`, `SeqPair`: the revised sequence rule
+- `hasKnessOrig`: their original (b ≥ 0) k-ness
+
+## Main results
+
+- `favUnit_iff`: the favourite units are exactly the four k-families
+- `not_favUnit_three_mul_pow`: the 3-family is not derivable — why the
+  inventory stops at four properties
+- `quarter_unit_not_seqRatio`: quarters round single numbers, not pairs
+- their p. 198 examples and p. 196 pair judgments, checked by `decide`
+- `fifteen_has_orig_fiveness`: the b ≥ 0 vs b ≥ 1 divergence at 15
+-/
+
+namespace JansenPollmann2001
+
+open Semantics.Numerals.Roundness
+
+/-! ### The principle of favourite quantities (their pp. 200–201) -/
+
+/-- The basic quantity-manipulation operations: "doubling and halving
+(sometimes followed by halving again)". -/
+inductive QuantityOp where
+  /-- Leave the base quantity as is. -/
+  | id
+  /-- Double it. -/
+  | double
+  /-- Halve it. -/
+  | half
+  /-- Halve it twice. -/
+  | halfAgain
+  deriving DecidableEq, Repr
+
+/-- Apply a quantity operation. -/
+def QuantityOp.apply : QuantityOp → ℚ → ℚ
+  | .id, q => q
+  | .double, q => 2 * q
+  | .half, q => q / 2
+  | .halfAgain, q => q / 4
+
+/-- A favourite unit: a decimal base power manipulated by one quantity
+operation. -/
+def IsFavUnit (q : ℚ) : Prop :=
+  ∃ (op : QuantityOp) (n : ℕ), q = op.apply (10 ^ n)
+
+/-- The favourite units are exactly the four k-ness families: powers of
+ten, their doubles, their halves, and their quarters. -/
+theorem favUnit_iff (q : ℚ) :
+    IsFavUnit q ↔
+      ∃ n : ℕ, q = 10 ^ n ∨ q = 2 * 10 ^ n ∨ q = 10 ^ n / 2 ∨ q = 10 ^ n / 4 := by
+  constructor
+  · rintro ⟨op, n, rfl⟩
+    exact ⟨n, by cases op <;> simp [QuantityOp.apply]⟩
+  · rintro ⟨n, h | h | h | h⟩
+    exacts [⟨.id, n, h⟩, ⟨.double, n, h⟩, ⟨.half, n, h⟩, ⟨.halfAgain, n, h⟩]
+
+/-- Halving a base power lands on the 5-family. -/
+theorem half_pow (n : ℕ) : (10 : ℚ) ^ (n + 1) / 2 = 5 * 10 ^ n := by
+  rw [pow_succ]; ring
+
+/-- Halving twice lands on the 2½-family. -/
+theorem halfAgain_pow (n : ℕ) : (10 : ℚ) ^ (n + 1) / 4 = 5 / 2 * 10 ^ n := by
+  rw [pow_succ]; ring
+
+/-- No quantity operation reaches the 3-family: the structural reason the
+roundness inventory has exactly four properties (their p. 199: 3-, 4-, 6-,
+7-ness contribute nothing to frequency). -/
+theorem not_favUnit_three_mul_pow (m : ℕ) : ¬ IsFavUnit (3 * 10 ^ m) := by
+  have h3 : ∀ j : ℕ, ¬ (3 ∣ 10 ^ j) := fun j hd => by
+    have h1 := (Nat.Coprime.pow_right j (show Nat.Coprime 3 10 by norm_num)).eq_one_of_dvd hd
+    omega
+  rintro ⟨op, n, h⟩
+  cases op <;> simp only [QuantityOp.apply] at h
+  · exact h3 n ⟨10 ^ m, by exact_mod_cast h.symm⟩
+  · have hn : 3 * 10 ^ m = 2 * 10 ^ n := by exact_mod_cast h
+    exact h3 n ((Nat.Coprime.dvd_of_dvd_mul_left (by norm_num)) ⟨10 ^ m, hn.symm⟩)
+  · have h2 : (6 : ℚ) * 10 ^ m = 10 ^ n := by field_simp at h; linarith
+    have hn : 6 * 10 ^ m = 10 ^ n := by exact_mod_cast h2
+    exact h3 n ⟨2 * 10 ^ m, by omega⟩
+  · have h2 : (12 : ℚ) * 10 ^ m = 10 ^ n := by field_simp at h; linarith
+    have hn : 12 * 10 ^ m = 10 ^ n := by exact_mod_cast h2
+    exact h3 n ⟨4 * 10 ^ m, by omega⟩
+
+/-! ### The revised sequence rule (their pp. 196–197)
+
+Two-number approximative expressions ([about 5 or 6 books]) consist of
+consecutive members of an arithmetic sequence whose ratio equals its first
+member and is `1×10ⁿ`, `2×10ⁿ`, or `½×10ⁿ` (in ℕ, the half-family is
+`5×10ⁿ`). The original rule also allowed `¼×10ⁿ`; the revision drops it
+(quarter-ratio pairs are under 0.5% in all four corpora). -/
+
+/-- A ratio licensed by the revised sequence rule. -/
+def SeqRatio (r : ℕ) : Prop :=
+  ∃ n < 11, r = 10 ^ n ∨ r = 2 * 10 ^ n ∨ r = 5 * 10 ^ n
+
+instance (r : ℕ) : Decidable (SeqRatio r) :=
+  inferInstanceAs (Decidable (∃ n < 11, _ ∨ _ ∨ _))
+
+/-- The revised sequence rule: `[a, b]` are consecutive members of the
+sequence `r, 2r, 3r, …` for a licensed ratio `r`. -/
+def SeqPair (a b : ℕ) : Prop :=
+  ∃ r ≤ a, 0 < r ∧ SeqRatio r ∧ r ∣ a ∧ b = a + r
+
+instance (a b : ℕ) : Decidable (SeqPair a b) :=
+  inferInstanceAs (Decidable (∃ r ≤ a, _ ∧ _ ∧ _ ∧ _))
+
+-- Their p. 196 pairs: attested combinations conform to the rule …
+#guard SeqPair 3 4        -- [about 3 or 4]: sequence 1, 2, 3, 4
+#guard SeqPair 40 50      -- sequence 10, 20, 30, 40, 50
+#guard SeqPair 18 20      -- sequence 2, 4, …, 18, 20
+#guard SeqPair 100 150    -- sequence 50, 100, 150 (ratio ½ × 10²)
+-- … and their starred non-combinations do not:
+#guard ¬ SeqPair 1 3      -- [*about 1 or 3]
+#guard ¬ SeqPair 5 7      -- [*about 5 or 7]
+#guard ¬ SeqPair 6 9      -- [*about 6 or 9]
+#guard ¬ SeqPair 40 80    -- [*about 40 or 80]
+-- The revision: quarter-ratio pairs are excluded (their p. 197)
+#guard ¬ SeqPair 100 125  -- sequence 25, 50, … (ratio ¼ × 10²)
+
+/-- Quarters split single-number roundness from pair formation: `25` is a
+favourite unit (twice-halved `10²`, whence 2½-ness) but not a licensed
+sequence ratio — their pp. 197, 199–200 asymmetry. -/
+theorem quarter_unit_not_seqRatio : IsFavUnit 25 ∧ ¬ SeqRatio 25 :=
+  ⟨⟨.halfAgain, 2, by norm_num [QuantityOp.apply]⟩, by decide⟩
+
+/-! ### The original k-ness and the b ≥ 1 restriction (their p. 198) -/
+
+/-- Their original k-ness: `n ∈ [k × (1–9 × 10ᵇ)]` with `b ≥ 0` — 10-ness
+is `k = 1`. `Roundness.HasKness` is this with [woodin-etal-2023]'s
+`b ≥ 1` restriction. Search bounded as there. -/
+def hasKnessOrig (n k : ℕ) : Prop :=
+  ∃ b < 11, ∃ m < 10, 1 ≤ m ∧ n = m * k * 10 ^ b
+
+instance (n k : ℕ) : Decidable (hasKnessOrig n k) :=
+  inferInstanceAs (Decidable (∃ b < 11, ∃ m < 10, _ ∧ _))
+
+/-- The restricted variant entails the original. -/
+theorem hasKnessOrig_of_hasKness {n k : ℕ} (h : HasKness n k) :
+    hasKnessOrig n k :=
+  let ⟨b, hb, _, hm⟩ := h
+  ⟨b, hb, hm⟩
+
+-- Their p. 198 examples, under the original definition: "40 has 10-ness,
+-- 2-ness, and 5-ness; 8 has 10-ness and 2-ness but no 5-ness; 300 has
+-- 10-ness and 5-ness but no 2-ness; 70 has only 10-ness; 61 has none."
+#guard hasKnessOrig 40 1 ∧ hasKnessOrig 40 2 ∧ hasKnessOrig 40 5
+#guard hasKnessOrig 8 1 ∧ hasKnessOrig 8 2 ∧ ¬ hasKnessOrig 8 5
+#guard hasKnessOrig 300 1 ∧ hasKnessOrig 300 5 ∧ ¬ hasKnessOrig 300 2
+#guard hasKnessOrig 70 1 ∧ ¬ hasKnessOrig 70 2 ∧ ¬ hasKnessOrig 70 5
+#guard ¬ hasKnessOrig 61 1 ∧ ¬ hasKnessOrig 61 2 ∧ ¬ hasKnessOrig 61 5
+
+/-- The divergence that matters downstream: under the original definition
+15 has 5-ness (15 = 3 × 5 × 10⁰), which the b ≥ 1 variant drops — the
+source of the 15/45-idealization noted at
+`Precision.inferPrecisionMode`. -/
+theorem fifteen_has_orig_fiveness : hasKnessOrig 15 5 ∧ ¬ HasKness 15 5 := by
+  decide
+
+end JansenPollmann2001

--- a/Linglib/Studies/WoodinEtAl2024.lean
+++ b/Linglib/Studies/WoodinEtAl2024.lean
@@ -109,8 +109,8 @@ theorem weighted_7_eq_zero :
     weightedRoundnessScore 7 = 0 := by simp +decide [weightedRoundnessScore]
 
 /-- `weightedRoundnessScore 50 > 0`: 50 has multipleOf5, multipleOf10,
-    2.5-ness, and 5-ness, so its weighted score is the strictly positive
-    sum of those β coefficients. -/
+    2.5-ness, 5-ness, and 10-ness (50 = 5 × 10¹), so its weighted score is
+    the strictly positive sum of those β coefficients. -/
 theorem weighted_50_pos : weightedRoundnessScore 50 > 0 := by
   simp +decide [weightedRoundnessScore, β_2_5ness, β_5ness, β_mult10, β_mult5]; norm_num
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5149,7 +5149,7 @@
   pages     = {187--201},
   doi       = {10.1076/jqul.8.3.187.4095},
   subfield  = {semantics/compositional},
-  role      = {cited},
+  role      = {formalized},
   validated = {true},
   sources   = {Core/Scales/Roundness.lean;Phenomena/Numerals/Studies/WoodinEtAl2024.lean;Pragmatics/NeoGricean/Constraints/NumericalExpressions.lean}
 }% REF: Palmer, F. R. (2001). Mood and Modality. 2nd ed. CUP.


### PR DESCRIPTION
Roadmap step 7, formalized from the JP 2001 PDF — which also exposed a bug.

- **Fix**: `Roundness`'s 10-ness used divisors `10 × 10^b` (100, 1000, …) where JP's p. 198 set — confirmed by their own example "70 has only 10-ness" — and Woodin et al.'s fn. 3 restriction give divisors `10^b, b ≥ 1`. Two-digit multiples of ten were undercounted (50 scores 5, not 4; grade high). Consumer guards updated (Cummins NSAL, BSB2022 stimulus, Woodin weighted score).
- `Studies/JansenPollmann2001.lean`: the **principle of favourite quantities** — the k-ness unit inventory derived as the orbit of decimal base powers under doubling/halving (`favUnit_iff`), with `not_favUnit_three_mul_pow` proving the 3-family unreachable (why the inventory stops at four properties); the **revised sequence rule** with their p. 196 pair judgments checked by `decide` and `quarter_unit_not_seqRatio` (quarters round single numbers but not pairs); their original b ≥ 0 k-ness with all five p. 198 worked examples verified, and `fifteen_has_orig_fiveness` locating the source of the 15/45 idealization documented at `inferPrecisionMode`.
- Bib role → formalized.