### PR TITLE
feat(Syntax/Numeral): Hurford grammar; Ionin-Matushansky 2006 study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2333,6 +2333,7 @@ import Linglib.Studies.IatridouZeijlstra2021
 import Linglib.Studies.Imanishi2014
 import Linglib.Studies.Imanishi2020
 import Linglib.Studies.ImelGuoST2026
+import Linglib.Studies.IoninMatushansky2006
 import Linglib.Studies.IppolitoKissWilliams2022
 import Linglib.Studies.IppolitoKissWilliams2025
 import Linglib.Studies.Israel2001
@@ -2895,6 +2896,7 @@ import Linglib.Syntax.Minimalist.Workspace.Basic
 import Linglib.Syntax.Negation
 import Linglib.Syntax.NullSubject
 import Linglib.Syntax.Numeral.Basic
+import Linglib.Syntax.Numeral.Composition
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
 import Linglib.Syntax.Pronoun.Demonstrative

--- a/Linglib/Semantics/Quantification/Numerals/Roundness.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Roundness.lean
@@ -126,27 +126,25 @@ def roundnessInContext (n : ℕ) (base : ℕ) : ℕ :=
 
 /-! ### Per-datum verification -/
 
--- Score verification
-#guard roundnessScore 100 = 6
-#guard roundnessScore 50 = 5
-#guard roundnessScore 7 = 0
-#guard roundnessScore 1000 = 6
-#guard roundnessScore 200 = 6
-#guard roundnessScore 110 = 2
-#guard roundnessScore 20 = 4
+example : roundnessScore 100 = 6 := by decide
+example : roundnessScore 50 = 5 := by decide
+example : roundnessScore 7 = 0 := by decide
+example : roundnessScore 1000 = 6 := by decide
+example : roundnessScore 200 = 6 := by decide
+example : roundnessScore 110 = 2 := by decide
+example : roundnessScore 20 = 4 := by decide
 
--- Grade verification
-#guard roundnessGrade 100 = .high
-#guard roundnessGrade 50 = .high
-#guard roundnessGrade 110 = .low
-#guard roundnessGrade 7 = .none
+example : roundnessGrade 100 = .high := by decide
+example : roundnessGrade 50 = .high := by decide
+example : roundnessGrade 110 = .low := by decide
+example : roundnessGrade 7 = .none := by decide
 
--- Context-sensitive verification
-#guard contextualRoundnessScore 48 12 = 2
-#guard contextualRoundnessScore 120 12 = 4
-#guard roundnessInContext 48 12 = 2     -- contextual score beats default (0)
-#guard roundnessInContext 48 10 = 0     -- not round on base-10
-#guard roundnessInContext 100 10 = 6    -- default score beats contextual
+example : contextualRoundnessScore 48 12 = 2 := by decide
+example : contextualRoundnessScore 120 12 = 4 := by decide
+-- contextual score beats default; nothing on base-10; default beats contextual
+example : roundnessInContext 48 12 = 2 := by decide
+example : roundnessInContext 48 10 = 0 := by decide
+example : roundnessInContext 100 10 = 6 := by decide
 
 /-- Multiples of 10 have roundness score ≥ 2 (multiple-of-5 and
 multiple-of-10 both hold). The keystone for downstream sorry-free proofs. -/

--- a/Linglib/Studies/IoninMatushansky2006.lean
+++ b/Linglib/Studies/IoninMatushansky2006.lean
@@ -1,0 +1,279 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Linglib.Syntax.Numeral.Composition
+
+/-!
+# [ionin-matushansky-2006]: The Composition of Complex Cardinals
+[ionin-matushansky-2006] [hurford-1975]
+
+[ionin-matushansky-2006] argue that complex cardinals are composed
+entirely in the syntax and interpreted by ordinary composition: simplex
+cardinals are modifiers of type ⟨⟨e,t⟩,⟨e,t⟩⟩ — their (5),
+`⟦n⟧ = λP λx. ∃S [Π(S)(x) ∧ |S| = n ∧ ∀s∈S P(s)]` (here `cardMod`) —
+so *two hundred books* is iterative complementation `[two [hundred
+[books]]]`, and multiplication needs no dedicated rule:
+`cardMod_cardMod_atoms` shows iterated modification computes the product,
+matching [hurford-1975]'s PHRASE projection rule
+(`iterated_matches_phrase`). Determiner and predicate types for cardinals
+are ruled out by complex cardinals (their §2.2): under predicate
+conjunction *two hundred books* is either contradictory (their (12),
+`predicate_conjunction_contradictory`) or satisfied by a plurality of
+just 100 — here scaled to *two four* satisfied by 4
+(`predicate_theory_undershoots`, their (13)).
+
+Addition is xNP coordination (their §4, (44)/(52)): *twenty-two books* =
+*[twenty books] and [two books]* with the split reading
+`⟦A and B⟧ = λx. ∃y z [x = y⊕z ∧ A(y) ∧ B(z)]`; under the full split
+(no overlap — pragmatic, their §4.2.1 Gricean manner) coordination
+computes the sum (`coord_card`). The joint reading is semantically
+impossible for distinct cardinals (`no_joint_reading`, their (56a)).
+
+Their (23) countability presupposition — a cardinal's complement must
+denote equicardinal pluralities — is `Equicardinal`; the keystone
+`card_of_cardMod` is exactly the definedness cascade it feeds: `n` cells
+of uniform size `k` make `n·k`.
+
+Their §3.3 adopts [hurford-1975]'s thesis that most cardinals are
+singular nouns; the syntax here is his grammar
+(`Syntax/Numeral/Composition.lean`).
+
+## Main definitions
+
+- `IsPart`: their (6) partition (Finset counterpart of
+  `Semantics.Plurality.Cover.IsPartition`, chosen for cardinality
+  counting)
+- `cardMod`: their (5) cardinal-as-modifier
+- `Equicardinal`: their (23) countability presupposition
+- `coordSem`: their (52) coordination
+
+## Main results
+
+- `cardMod_atoms_iff`: *n books* = an `n`-atom plurality of books
+- `cardMod_cardMod_atoms`: iterated modification multiplies — and
+  `iterated_matches_phrase` aligns it with the PHRASE projection rule
+- `predicate_conjunction_contradictory` / `predicate_theory_undershoots`:
+  their §2.2 refutation of non-modifier types
+- `coord_card` / `no_joint_reading`: coordination adds; joint readings
+  clash
+-/
+
+namespace IoninMatushansky2006
+
+variable {α : Type*} [DecidableEq α]
+
+/-! ### Partitions and the cardinal modifier (their (5)–(7)) -/
+
+/-- Their (6): `S` is a partition of `x` — nonempty, pairwise-disjoint
+cells whose union is `x`. Finset counterpart of
+`Semantics.Plurality.Cover.IsPartition`. -/
+def IsPart (S : Finset (Finset α)) (x : Finset α) : Prop :=
+  (∀ s ∈ S, s ≠ ∅) ∧ (S : Set (Finset α)).PairwiseDisjoint id ∧
+    S.sup id = x
+
+/-- Their (5): `⟦n⟧ = λP λx. ∃S [Π(S)(x) ∧ |S| = n ∧ ∀s∈S P(s)]` — the
+cardinal as an ⟨⟨e,t⟩,⟨e,t⟩⟩ modifier. -/
+def cardMod (n : ℕ) (P : Finset α → Prop) (x : Finset α) : Prop :=
+  ∃ S : Finset (Finset α), IsPart S x ∧ S.card = n ∧ ∀ s ∈ S, P s
+
+/-- The atomic complement: singleton pluralities of `P`-individuals —
+what their §3.1 atomicity requirement makes the lexical xNP denote. -/
+def IsAtomOf (P : α → Prop) (s : Finset α) : Prop :=
+  ∃ a, P a ∧ s = {a}
+
+/-- Their (23) countability presupposition: all pluralities in the
+complement's denotation have the same cardinality. -/
+def Equicardinal (P : Finset α → Prop) (k : ℕ) : Prop :=
+  ∀ s, P s → s.card = k
+
+theorem equicardinal_atoms (P : α → Prop) : Equicardinal (IsAtomOf P) 1 :=
+  fun _ ⟨_, _, hs⟩ => hs ▸ Finset.card_singleton _
+
+/-- **Keystone**: `n` cells of uniform size `k` make a plurality of
+`n·k` — the definedness cascade their (23) presupposition feeds. -/
+theorem card_of_cardMod {P : Finset α → Prop} {k n : ℕ} {x : Finset α}
+    (hP : Equicardinal P k) (h : cardMod n P x) : x.card = n * k := by
+  obtain ⟨S, ⟨-, hdisj, hsup⟩, hcard, hall⟩ := h
+  rw [← hsup, Finset.sup_eq_biUnion, Finset.card_biUnion (by
+    exact fun s hs t ht hst => hdisj hs ht hst)]
+  simp only [id_eq]
+  rw [Finset.sum_const_nat fun s hs => hP s (hall s hs), hcard]
+
+/-! ### Simple and iterated modification (their (8)–(9)) -/
+
+/-- Partition into singletons: the canonical witness for atomic
+complements. -/
+private theorem cardMod_atoms_of {P : α → Prop} {x : Finset α}
+    (hx : ∀ a ∈ x, P a) : cardMod x.card (IsAtomOf P) x := by
+  refine ⟨x.image ({·}), ⟨?_, ?_, ?_⟩, ?_, ?_⟩
+  · simp +contextual [Finset.eq_empty_iff_forall_notMem]
+  · intro s hs t ht hst
+    simp only [Finset.coe_image, Set.mem_image] at hs ht
+    obtain ⟨a, -, rfl⟩ := hs; obtain ⟨b, -, rfl⟩ := ht
+    exact Finset.disjoint_singleton.mpr fun hab => hst (by rw [hab])
+  · ext a
+    simp
+  · rw [Finset.card_image_of_injective _ fun a b => by simp]
+  · simp only [Finset.mem_image]
+    rintro s ⟨a, ha, rfl⟩
+    exact ⟨a, hx a ha, rfl⟩
+
+/-- Their (8): *hundred books* denotes the 100-atom pluralities of
+books — `cardMod` over an atomic complement counts atoms. -/
+theorem cardMod_atoms_iff (n : ℕ) (P : α → Prop) (x : Finset α) :
+    cardMod n (IsAtomOf P) x ↔ x.card = n ∧ ∀ a ∈ x, P a := by
+  constructor
+  · intro h
+    have hcard := card_of_cardMod (equicardinal_atoms P) h
+    obtain ⟨S, ⟨-, -, hsup⟩, -, hall⟩ := h
+    refine ⟨by omega, fun a ha => ?_⟩
+    rw [← hsup, Finset.mem_sup] at ha
+    obtain ⟨s, hs, has⟩ := ha
+    obtain ⟨b, hb, rfl⟩ := hall s hs
+    obtain rfl := Finset.mem_singleton.mp has
+    exact hb
+  · rintro ⟨rfl, hx⟩
+    exact cardMod_atoms_of hx
+
+/-- Partitions into `n` uniform cells of size `k ≥ 1` exist whenever the
+cardinality is right — the constructive half of iterated modification. -/
+private theorem cardMod_of_card {P : Finset α → Prop} {k : ℕ} (hk : 1 ≤ k) :
+    ∀ (n : ℕ) (x : Finset α), (∀ y ⊆ x, y.card = k → P y) →
+      x.card = n * k → cardMod n P x := by
+  intro n
+  induction n with
+  | zero =>
+    intro x _ hx
+    rw [Nat.zero_mul, Finset.card_eq_zero] at hx
+    exact ⟨∅, ⟨by simp, by simp, by simp [hx]⟩, rfl, by simp⟩
+  | succ n ih =>
+    intro x hsub hx
+    obtain ⟨t, htx, ht⟩ : ∃ t ⊆ x, t.card = k :=
+      Finset.exists_subset_card_eq
+        (by rw [hx]; exact Nat.le_mul_of_pos_left k n.succ_pos)
+    obtain ⟨S, ⟨hne, hdisj, hsup⟩, hcard, hall⟩ :=
+      ih (x \ t) (fun y hy => hsub y (hy.trans Finset.sdiff_subset))
+        (by rw [Finset.card_sdiff, Finset.inter_eq_left.mpr htx, hx, ht,
+          Nat.succ_mul]; omega)
+    have htS : t ∉ S := fun h => by
+      have hsub' := Finset.sup_le_iff.mp hsup.le t h
+      have hte : t = ∅ := Finset.eq_empty_of_forall_notMem fun a ha =>
+        (Finset.mem_sdiff.mp (hsub' ha)).2 ha
+      rw [hte, Finset.card_empty] at ht
+      omega
+    refine ⟨insert t S, ⟨?_, ?_, ?_⟩, ?_, ?_⟩
+    · intro s hs
+      rcases Finset.mem_insert.mp hs with rfl | hs
+      · exact fun h => by simp [h] at ht; omega
+      · exact hne s hs
+    · intro s hs u hu hsu
+      simp only [Finset.coe_insert, Set.mem_insert_iff] at hs hu
+      have hcell : ∀ v ∈ S, Disjoint t v := fun v hv => by
+        have hvsub := Finset.sup_le_iff.mp hsup.le v hv
+        exact Finset.disjoint_left.mpr fun a hat hav =>
+          (Finset.mem_sdiff.mp (hvsub hav)).2 hat
+      rcases hs with rfl | hs <;> rcases hu with rfl | hu
+      · exact absurd rfl hsu
+      · exact hcell u hu
+      · exact (hcell s hs).symm
+      · exact hdisj hs hu hsu
+    · rw [Finset.sup_insert, hsup]
+      simpa [Finset.union_comm] using Finset.sdiff_union_of_subset htx
+    · rw [Finset.card_insert_of_notMem htS, hcard]
+    · intro s hs
+      rcases Finset.mem_insert.mp hs with rfl | hs
+      · exact hsub s htx ht
+      · exact hall s hs
+
+/-- **Their (9): iterated modification multiplies.** *two hundred books*
+= `⟦two⟧(⟦hundred⟧(⟦books⟧))` denotes the `2 × 100`-atom pluralities —
+complex cardinals need no semantic rule beyond ordinary composition. -/
+theorem cardMod_cardMod_atoms {m : ℕ} (hm : 1 ≤ m) (n : ℕ) (P : α → Prop)
+    (x : Finset α) :
+    cardMod n (cardMod m (IsAtomOf P)) x ↔ x.card = n * m ∧ ∀ a ∈ x, P a := by
+  constructor
+  · intro h
+    have hEq : Equicardinal (cardMod m (IsAtomOf P) : Finset α → Prop) m :=
+      fun s hs => ((cardMod_atoms_iff m P s).mp hs).1
+    refine ⟨card_of_cardMod hEq h, fun a ha => ?_⟩
+    obtain ⟨S, ⟨-, -, hsup⟩, -, hall⟩ := h
+    rw [← hsup, Finset.mem_sup] at ha
+    obtain ⟨s, hs, has⟩ := ha
+    exact ((cardMod_atoms_iff m P s).mp (hall s hs)).2 a has
+  · rintro ⟨hcard, hx⟩
+    refine cardMod_of_card hm n x (fun y hyx hyc => ?_) hcard
+    exact (cardMod_atoms_iff m P y).mpr ⟨hyc, fun a ha => hx a (hyx ha)⟩
+
+/-- Iterated modification computes [hurford-1975]'s PHRASE projection
+rule: `⟦[n m] books⟧` counts `(Phrase.mk n m).value` atoms. -/
+theorem iterated_matches_phrase (n : Syntax.Numeral.Number)
+    (m : Syntax.Numeral.M) (P : α → Prop) (x : Finset α) :
+    cardMod n.value (cardMod m.value (IsAtomOf P)) x ↔
+      x.card = (Syntax.Numeral.Phrase.mk n m).value ∧ ∀ a ∈ x, P a :=
+  cardMod_cardMod_atoms m.value_pos n.value P x
+
+/-! ### Ruling out the predicate theory (their §2.2, (12)–(13)) -/
+
+private theorem isPart_of {S : Finset (Finset α)} {x : Finset α}
+    (h1 : ∀ s ∈ S, s ≠ ∅) (h2 : ∀ s ∈ S, ∀ t ∈ S, s ≠ t → Disjoint s t)
+    (h3 : S.sup id = x) : IsPart S x :=
+  ⟨h1, fun s hs t ht hst =>
+    h2 s (Finset.mem_coe.mp hs) t (Finset.mem_coe.mp ht) hst, h3⟩
+
+/-- Their (12): under bare predicate conjunction *two hundred books* is
+self-contradictory — nothing has cardinality 2 and 100 at once. -/
+theorem predicate_conjunction_contradictory (x : Finset α) :
+    ¬ (x.card = 2 ∧ x.card = 100) := by omega
+
+/-- Their (13), scaled to *two four*: with partition-based predicate
+meanings *conjoined* instead of composed, a plurality of just 4 satisfies
+both conjuncts — where the modifier reading demands 2 × 4 = 8. -/
+theorem predicate_theory_undershoots :
+    ∃ x : Finset (Fin 4),
+      cardMod 2 (fun _ => True) x ∧ cardMod 4 (fun _ => True) x ∧
+        x.card = 4 :=
+  ⟨Finset.univ,
+    ⟨{{0, 1}, {2, 3}}, isPart_of (by decide) (by decide) (by decide),
+      by decide, fun _ _ => trivial⟩,
+    ⟨{{0}, {1}, {2}, {3}}, isPart_of (by decide) (by decide) (by decide),
+      by decide, fun _ _ => trivial⟩,
+    by decide⟩
+
+/-! ### Addition as coordination (their §4, (52)) -/
+
+/-- Their (52): coordinated xNPs split the plurality —
+`⟦A and B⟧ = λx. ∃y z [x = y⊕z ∧ A(y) ∧ B(z)]`. -/
+def coordSem (A B : Finset α → Prop) (x : Finset α) : Prop :=
+  ∃ y z, x = y ∪ z ∧ A y ∧ B z
+
+/-- Under the full split (their (56b); overlap excluded pragmatically by
+Gricean manner, their §4.2.1), coordination computes addition:
+*twenty-two books* counts 20 + 2 atoms. -/
+theorem coord_card {P : α → Prop} {n m : ℕ} {x : Finset α}
+    (h : ∃ y z, Disjoint y z ∧ x = y ∪ z ∧
+      cardMod n (IsAtomOf P) y ∧ cardMod m (IsAtomOf P) z) :
+    x.card = n + m ∧ ∀ a ∈ x, P a := by
+  obtain ⟨y, z, hd, rfl, hy, hz⟩ := h
+  obtain ⟨hyc, hyP⟩ := (cardMod_atoms_iff n P y).mp hy
+  obtain ⟨hzc, hzP⟩ := (cardMod_atoms_iff m P z).mp hz
+  refine ⟨by rw [Finset.card_union_of_disjoint hd, hyc, hzc], fun a ha => ?_⟩
+  rcases Finset.mem_union.mp ha with h | h
+  exacts [hyP a h, hzP a h]
+
+/-- Their (56a): the joint reading is semantically impossible for
+distinct cardinals — no plurality is 20 atoms and 2 atoms at once. -/
+theorem no_joint_reading {P : α → Prop} {n m : ℕ} (hnm : n ≠ m)
+    (x : Finset α) :
+    ¬ (cardMod n (IsAtomOf P) x ∧ cardMod m (IsAtomOf P) x) := by
+  rintro ⟨hn, hm⟩
+  have h1 := ((cardMod_atoms_iff n P x).mp hn).1
+  have h2 := ((cardMod_atoms_iff m P x).mp hm).1
+  omega
+
+end IoninMatushansky2006

--- a/Linglib/Studies/JansenPollmann2001.lean
+++ b/Linglib/Studies/JansenPollmann2001.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Semantics.Quantification.Numerals.Roundness
+import Linglib.Syntax.Numeral.Composition
 import Mathlib.Data.Rat.Defs
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.FieldSimp
@@ -154,18 +155,20 @@ def SeqPair (a b : ℕ) : Prop :=
 instance (a b : ℕ) : Decidable (SeqPair a b) :=
   inferInstanceAs (Decidable (∃ r ≤ a, _ ∧ _ ∧ _ ∧ _))
 
--- Their p. 196 pairs: attested combinations conform to the rule …
-#guard SeqPair 3 4        -- [about 3 or 4]: sequence 1, 2, 3, 4
-#guard SeqPair 40 50      -- sequence 10, 20, 30, 40, 50
-#guard SeqPair 18 20      -- sequence 2, 4, …, 18, 20
-#guard SeqPair 100 150    -- sequence 50, 100, 150 (ratio ½ × 10²)
--- … and their starred non-combinations do not:
-#guard ¬ SeqPair 1 3      -- [*about 1 or 3]
-#guard ¬ SeqPair 5 7      -- [*about 5 or 7]
-#guard ¬ SeqPair 6 9      -- [*about 6 or 9]
-#guard ¬ SeqPair 40 80    -- [*about 40 or 80]
--- The revision: quarter-ratio pairs are excluded (their p. 197)
-#guard ¬ SeqPair 100 125  -- sequence 25, 50, … (ratio ¼ × 10²)
+-- Their p. 196 pairs: attested combinations conform to the rule,
+-- their starred non-combinations do not, and the revision excludes
+-- quarter-ratio pairs (their p. 197).
+example : SeqPair 3 4 := by decide      -- sequence 1, 2, 3, 4
+example : SeqPair 40 50 := by decide    -- sequence 10, 20, …, 50
+example : SeqPair 18 20 := by decide    -- sequence 2, 4, …, 20
+set_option maxRecDepth 2048 in
+example : SeqPair 100 150 := by decide  -- sequence 50, 100, 150
+example : ¬ SeqPair 1 3 := by decide    -- [*about 1 or 3]
+example : ¬ SeqPair 5 7 := by decide    -- [*about 5 or 7]
+example : ¬ SeqPair 6 9 := by decide    -- [*about 6 or 9]
+example : ¬ SeqPair 40 80 := by decide  -- [*about 40 or 80]
+set_option maxRecDepth 2048 in
+example : ¬ SeqPair 100 125 := by decide -- ratio ¼ × 10²: excluded
 
 /-- Quarters split single-number roundness from pair formation: `25` is a
 favourite unit (twice-halved `10²`, whence 2½-ness) but not a licensed
@@ -193,11 +196,16 @@ theorem hasKnessOrig_of_hasKness {n k : ℕ} (h : HasKness n k) :
 -- Their p. 198 examples, under the original definition: "40 has 10-ness,
 -- 2-ness, and 5-ness; 8 has 10-ness and 2-ness but no 5-ness; 300 has
 -- 10-ness and 5-ness but no 2-ness; 70 has only 10-ness; 61 has none."
-#guard hasKnessOrig 40 1 ∧ hasKnessOrig 40 2 ∧ hasKnessOrig 40 5
-#guard hasKnessOrig 8 1 ∧ hasKnessOrig 8 2 ∧ ¬ hasKnessOrig 8 5
-#guard hasKnessOrig 300 1 ∧ hasKnessOrig 300 5 ∧ ¬ hasKnessOrig 300 2
-#guard hasKnessOrig 70 1 ∧ ¬ hasKnessOrig 70 2 ∧ ¬ hasKnessOrig 70 5
-#guard ¬ hasKnessOrig 61 1 ∧ ¬ hasKnessOrig 61 2 ∧ ¬ hasKnessOrig 61 5
+example : hasKnessOrig 40 1 ∧ hasKnessOrig 40 2 ∧ hasKnessOrig 40 5 := by
+  decide
+example : hasKnessOrig 8 1 ∧ hasKnessOrig 8 2 ∧ ¬ hasKnessOrig 8 5 := by
+  decide
+example : hasKnessOrig 300 1 ∧ hasKnessOrig 300 5 ∧ ¬ hasKnessOrig 300 2 := by
+  decide
+example : hasKnessOrig 70 1 ∧ ¬ hasKnessOrig 70 2 ∧ ¬ hasKnessOrig 70 5 := by
+  decide
+example : ¬ hasKnessOrig 61 1 ∧ ¬ hasKnessOrig 61 2 ∧ ¬ hasKnessOrig 61 5 := by
+  decide
 
 /-- The divergence that matters downstream: under the original definition
 15 has 5-ness (15 = 3 × 5 × 10⁰), which the b ≥ 1 variant drops — the
@@ -205,5 +213,23 @@ source of the 15/45-idealization noted at
 `Precision.inferPrecisionMode`. -/
 theorem fifteen_has_orig_fiveness : hasKnessOrig 15 5 ∧ ¬ HasKness 15 5 := by
   decide
+
+/-! ### 10-ness as expression shape ([hurford-1975]) -/
+
+/-- 10-ness is two-word expressibility: `n` has 10-ness iff it is the
+value of a digit×base PHRASE — [hurford-1975]'s `[NUMBER M]` with a digit
+NUMBER and a pure ten-power M (*forty*, *four hundred*, …). The
+favourite-quantity properties are facts about numeral expression shape. -/
+theorem hasKness_one_iff_phrase (n : ℕ) :
+    HasKness n 1 ↔ ∃ m ≤ 8, ∃ k ≤ 9,
+      n = (Syntax.Numeral.Phrase.mk (.tally m) (.tenPow k)).value := by
+  simp only [Syntax.Numeral.Phrase.value_tally_tenPow]
+  constructor
+  · rintro ⟨b, hb, hb1, m, hm, hm1, rfl⟩
+    exact ⟨m - 1, by omega, b - 1, by omega, by
+      rw [Nat.sub_add_cancel hm1, Nat.sub_add_cancel hb1, mul_one]⟩
+  · rintro ⟨m, hm, k, hk, rfl⟩
+    exact ⟨k + 1, by omega, by omega, m + 1, by omega, by omega, by
+      rw [mul_one]⟩
 
 end JansenPollmann2001

--- a/Linglib/Syntax/Numeral/Composition.lean
+++ b/Linglib/Syntax/Numeral/Composition.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.Order.Group.Nat
+import Mathlib.Tactic.Ring
+
+/-!
+# Hurford's universal numeral grammar
+[hurford-1975] [ionin-matushansky-2006]
+
+[hurford-1975]'s phrase-structure grammar for number-names (his (2),
+p. 19), proposed as the universal base of numeral systems:
+
+- `NUMBER → {one | PHRASE} (NUMBER)`
+- `PHRASE → NUMBER M`
+- `M → {ten | NUMBER M}`
+
+with the three projection rules of his (23) (pp. 29–30): the value of a
+NUMBER is the **sum** of its immediate constituents, of a PHRASE the
+**product**, and of an M the second constituent raised to the **power**
+of the first. So *twenty-three* is `[[two ten] three]` = 2·10 + 3,
+*thousand* is `[three ten]` = 10³.
+
+His deeper claim ((26)–(29)): the three rules are one operation,
+`CALCULATE`, indexed by constituent *depth* — NUMBERs (depth 1) add,
+PHRASEs (depth 2) multiply, Ms (depth 3) exponentiate, each operation the
+iteration of the one before. `value_eq_calculate` states the unification;
+`calculate_succ_iterate` states the iteration ladder its complexity
+ordering rests on.
+
+Consumers: `Studies/IoninMatushansky2006.lean` (their §3.3 adopts
+Hurford's cardinals-as-nouns; their §4.3 order conventions constrain
+which of these structures surface) and `Studies/JansenPollmann2001.lean`
+(10-ness as digit×M expressibility).
+
+## Main declarations
+
+- `Number`, `Phrase`, `M`: the three syntactic categories, with `value`
+- `Number.tally`, `M.tenPow`: canonical digit and base-power structures
+- `calculate`: the depth-indexed arithmetic (his (26))
+
+## Main results
+
+- `value_eq_calculate`: the three projection rules are `calculate` at
+  depths 1–3
+- `calculate_succ_iterate`: each operation iterates the previous one
+- `Number.exists_value_eq`: every positive number is expressible
+  (the tally structure his rule schema (6) generates)
+-/
+
+namespace Syntax.Numeral
+
+/-! ### The phrase-structure categories (his (2)) -/
+
+mutual
+/-- `NUMBER → {one | PHRASE} (NUMBER)`. -/
+inductive Number where
+  /-- `NUMBER → one`. -/
+  | one : Number
+  /-- `NUMBER → one NUMBER`. -/
+  | oneAnd (rest : Number) : Number
+  /-- `NUMBER → PHRASE`. -/
+  | phrase (p : Phrase) : Number
+  /-- `NUMBER → PHRASE NUMBER` — e.g. *twenty-three*. -/
+  | phraseAnd (p : Phrase) (rest : Number) : Number
+  deriving Repr
+
+/-- `PHRASE → NUMBER M` — e.g. *two hundred*. -/
+inductive Phrase where
+  | mk (n : Number) (m : M) : Phrase
+  deriving Repr
+
+/-- `M → {ten | NUMBER M}` — the base-word hierarchy: *ten*, *hundred*
+(`[two ten]` = 10²), *thousand* (`[three ten]` = 10³), …. -/
+inductive M where
+  | ten : M
+  | mk (n : Number) (m : M) : M
+  deriving Repr
+end
+
+/-! ### The projection rules (his (23)) -/
+
+mutual
+/-- The value of a NUMBER: the sum of its immediate constituents. -/
+def Number.value : Number → ℕ
+  | .one => 1
+  | .oneAnd rest => 1 + rest.value
+  | .phrase p => p.value
+  | .phraseAnd p rest => p.value + rest.value
+
+/-- The value of a PHRASE: the product of its immediate constituents. -/
+def Phrase.value : Phrase → ℕ
+  | .mk n m => n.value * m.value
+
+/-- The value of an M: the second constituent raised to the power of the
+first. -/
+def M.value : M → ℕ
+  | .ten => 10
+  | .mk n m => m.value ^ n.value
+end
+
+/-! ### Canonical structures -/
+
+/-- The bare tally NUMBER: `n + 1` iterations of *one* — the structures
+his rule schema (6) generates before lexicalization compresses them. -/
+def Number.tally : ℕ → Number
+  | 0 => .one
+  | n + 1 => .oneAnd (tally n)
+
+@[simp] theorem Number.value_tally (n : ℕ) : (tally n).value = n + 1 := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [tally, value, ih]; omega
+
+/-- Every positive number is expressible — numeral systems name the whole
+of ℕ⁺ (his ch. 1 universal). -/
+theorem Number.exists_value_eq (n : ℕ) (hn : 1 ≤ n) :
+    ∃ e : Number, e.value = n :=
+  ⟨tally (n - 1), by simp; omega⟩
+
+/-- The base-power M: `tenPow k` is the M of value `10^(k+1)` — *ten*,
+*hundred* (`[two ten]`), *thousand* (`[three ten]`), …. -/
+def M.tenPow : ℕ → M
+  | 0 => .ten
+  | k + 1 => .mk (.tally (k + 1)) .ten
+
+@[simp] theorem M.value_tenPow (k : ℕ) : (tenPow k).value = 10 ^ (k + 1) := by
+  cases k with
+  | zero => rfl
+  | succ k => simp [tenPow, value, Number.value_tally]
+
+theorem M.value_pos : ∀ m : M, 0 < m.value
+  | .ten => by norm_num [value]
+  | .mk n m => by simpa [value] using pow_pos (value_pos m) n.value
+
+/-- A digit×base PHRASE — *four hundred* as `[[four] [two ten]]` — has
+value `m × 10^(k+1)`. -/
+theorem Phrase.value_tally_tenPow (m k : ℕ) :
+    (Phrase.mk (.tally m) (.tenPow k)).value = (m + 1) * 10 ^ (k + 1) := by
+  simp [value]
+
+/-! ### CALCULATE: one depth-indexed operation (his (26)–(29))
+
+The three projection rules order themselves by complexity — addition,
+multiplication, exponentiation — and each is the iteration of the one
+before, bottoming out in incrementing (adding a tally mark). His (29):
+a constituent of depth `d` with immediate constituents `x`, `y` is valued
+`CALCULATE d x y`, so the semantic component is a single rule. -/
+
+/-- The depth-indexed arithmetic: depth 1 adds (NUMBER), depth 2
+multiplies (PHRASE), depth 3 and beyond exponentiates (M). -/
+def calculate : ℕ → ℕ → ℕ → ℕ
+  | 1, x, y => x + y
+  | 2, x, y => x * y
+  | _, x, y => y ^ x
+
+/-- His (29): the three projection rules are `calculate` at the
+constituent's depth — NUMBERs at depth 1, PHRASEs at depth 2, Ms at
+depth 3. -/
+theorem value_eq_calculate (p : Phrase) (rest : Number) (n : Number) (m : M) :
+    (Number.phraseAnd p rest).value = calculate 1 p.value rest.value ∧
+    (Phrase.mk n m).value = calculate 2 n.value m.value ∧
+    (M.mk n m).value = calculate 3 n.value m.value :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- The complexity ladder behind the depth-indexing: each operation is
+the iteration of the one below — multiplication iterates addition,
+exponentiation iterates multiplication. -/
+theorem calculate_succ_iterate (x y : ℕ) :
+    calculate 2 x y = (calculate 1 y)^[x] 0 ∧
+    calculate 3 x y = (calculate 2 y)^[x] 1 := by
+  constructor
+  · induction x with
+    | zero => simp [calculate]
+    | succ x ih =>
+      simp only [Function.iterate_succ_apply', ← ih, calculate]; ring
+  · induction x with
+    | zero => simp [calculate]
+    | succ x ih =>
+      simp only [Function.iterate_succ_apply', ← ih, calculate]; ring
+
+end Syntax.Numeral

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5139,6 +5139,34 @@
   validated = {true},
   sources   = {Phenomena/Polarity/NPIs.lean;Phenomena/Polarity/Studies/Israel2001.lean;Core/Lexical/PolarityItem.lean;Fragments/English/PolarityItems.lean}
 }% REF: Jansen & Pollmann (2001). On round numbers: An analysis of numerical turn-taking points.
+@book{hurford-1975,
+  author    = {Hurford, James R.},
+  year      = {1975},
+  title     = {The Linguistic Theory of Numerals},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  isbn      = {0521207355},
+  subfield  = {syntax},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Syntax/Numeral/Composition.lean}
+}
+
+@article{ionin-matushansky-2006,
+  author    = {Ionin, Tania and Matushansky, Ora},
+  year      = {2006},
+  title     = {The Composition of Complex Cardinals},
+  journal   = {Journal of Semantics},
+  volume    = {23},
+  number    = {4},
+  pages     = {315--360},
+  doi       = {10.1093/jos/ffl006},
+  subfield  = {semantics/compositional},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/IoninMatushansky2006.lean}
+}
+
 @article{jansen-pollmann-2001,
   author    = {Jansen, Carel J. M. and Pollmann, Mathijs M. W.},
   year      = {2001},


### PR DESCRIPTION
Roadmap step 7b: the compositional numeral grammar, formalized from the two PDFs.

- `Syntax/Numeral/Composition.lean` ([hurford-1975]): his (2) phrase-structure grammar (NUMBER/PHRASE/M as mutual inductives) with the (23) projection rules — NUMBER sums, PHRASE multiplies, M exponentiates — and his (26)–(29) unification: `value_eq_calculate` shows the three rules are one depth-indexed operation, `calculate_succ_iterate` the iteration ladder (multiplication iterates addition, exponentiation iterates multiplication).
- `Studies/IoninMatushansky2006.lean`: cardinals as ⟨⟨e,t⟩,⟨e,t⟩⟩ modifiers over partitions (their (5)–(6)); `cardMod_cardMod_atoms` proves iterated modification multiplies (their (9)) and `iterated_matches_phrase` aligns it with the PHRASE rule; the §2.2 predicate-theory refutation ((12) contradiction, (13) undershoot witness); coordination-as-addition with the (56a) joint-reading clash; the (23) equicardinality presupposition as the counting keystone.
- `JansenPollmann2001.lean` gains `hasKness_one_iff_phrase`: 10-ness is exactly two-word digit×ten-power expressibility — roundness as expression shape.
- `#guard`s in the numeral files converted to `example … := by decide` per convention.
- Verified bib entries for hurford-1975 and ionin-matushansky-2006.