### PR TITLE
refactor(Studies): retire rsa_predict in Nouwen2024 and BumfordRett2021

### DIFF
--- a/Linglib/Core/Probability/Posterior.lean
+++ b/Linglib/Core/Probability/Posterior.lean
@@ -468,6 +468,21 @@ theorem mem_support_posterior_iff (κ : α → PMF β) (μ : PMF α) (b : β)
     a ∈ (posterior κ μ b h).support ↔ μ a ≠ 0 ∧ κ a b ≠ 0 :=
   mem_support_reweight_iff _ _ _ _ _
 
+/-- **A constant kernel is uninformative**: when the observation's likelihood
+does not depend on the hypothesis, the posterior is the prior. -/
+theorem posterior_eq_of_kernel_const (κ : α → PMF β) (μ : PMF α) (b : β)
+    (h : marginal κ μ b ≠ 0) {c : ℝ≥0∞} (hc : ∀ a, κ a b = c) :
+    posterior κ μ b h = μ := by
+  have hm : marginal κ μ b = c := by
+    show (μ.bind κ) b = c
+    rw [PMF.bind_apply]
+    simp only [hc]
+    rw [ENNReal.tsum_mul_right, PMF.tsum_coe, one_mul]
+  have hc0 : c ≠ 0 := hm ▸ h
+  have hct : c ≠ ∞ := hm ▸ marginal_ne_top κ μ b
+  ext a
+  rw [posterior_apply, hc a, hm, mul_assoc, ENNReal.mul_inv_cancel hc0 hct, mul_one]
+
 /-- Bayes' rule: the joint factors as marginal × posterior. -/
 theorem marginal_mul_posterior_apply (κ : α → PMF β) (μ : PMF α) (b : β)
     (h : marginal κ μ b ≠ 0) (a : α) :

--- a/Linglib/Studies/BumfordRett2021.lean
+++ b/Linglib/Studies/BumfordRett2021.lean
@@ -1,9 +1,9 @@
-import Linglib.Tactics.RSAPredict
-import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.Canonical
 import Linglib.Semantics.Degree.Gradability.Construction
 import Linglib.Studies.Rett2015Implicature
 import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Fintype.Prod
+import Mathlib.Analysis.Complex.ExponentialBounds
 
 /-!
 # [bumford-rett-2021] — Rationalizing Evaluativity
@@ -152,44 +152,276 @@ def sigmaVal (s : Sigma) : Int := (s.val : Int) - 2
 -- § 5. Shared RSA Infrastructure
 -- ============================================================================
 
-open Real (exp log exp_pos)
+open scoped ENNReal
 
-/-- World prior as ℝ (for RSAConfig). -/
+/-- World prior as ℝ. -/
 noncomputable def worldPriorR (w : EvalWorld) : ℝ := worldPrior w
 
 private theorem worldPrior_nonneg_Q :
-    ∀ w : EvalWorld, (0 : ℚ) ≤ worldPrior w := by native_decide
+    ∀ w : EvalWorld, (0 : ℚ) ≤ worldPrior w := by
+  intro w; unfold worldPrior; split <;> norm_num
 
 theorem worldPriorR_nonneg : ∀ w : EvalWorld, 0 ≤ worldPriorR w := by
   intro w; simp only [worldPriorR]; exact_mod_cast worldPrior_nonneg_Q w
 
-/-- Utterance cost as ℝ (cast from ℚ for use in S1 score). -/
-noncomputable def costR (u : Utterance) : ℝ := cost u
+/-- Utterance cost as a natural exponent: `exp(−α·C(u)) = e^(costN u)` at the
+paper's α = 4, where `e := exp(−4)`. -/
+def costN : Utterance → ℕ
+  | .unmarked => 1
+  | .marked   => 2
+  | .null     => 0
 
 -- ============================================================================
--- § 6. Parametric RSAConfig
+-- § 6. mathlib-PMF pipeline (replaces the RSAConfig; eq 10)
 -- ============================================================================
 
-/-- Parametric RSAConfig for all four constructions.
+/-! Companion architecture on `PMF`, parameterized by the cost-factor base
+`e` (= `exp(−4)` at the paper's α = 4; only the speaker depends on `e`):
 
-    All simulations share the same architecture (eq 10); they differ only
-    in the meaning function (eqs 12, 14, 16, 18). -/
-@[reducible]
-noncomputable def mkEvalCfg (sem : Utterance → Sigma → EvalWorld → Bool) :
-    RSA.RSAConfig Utterance EvalWorld where
-  Latent := Sigma
-  meaning _ σ u w := if sem u σ w then worldPriorR w else 0
-  meaning_nonneg _ σ u w := by split <;> [exact worldPriorR_nonneg w; exact le_refl 0]
-  -- eq 10: Sₙ(u | w, L) ∝ exp(α · (log Lₙ₋₁(w | u, L) − C(u)))
-  s1Score := fun l0 α _ w u =>
-    if l0 u w = 0 then 0 else exp (α * (log (l0 u w) - costR u))
-  s1Score_nonneg := fun _ _ _ _ _ _ _ => by
-    split <;> [exact le_refl 0; exact le_of_lt (exp_pos _)]
-  α := 4
-  α_pos := by norm_num
-  worldPrior := worldPriorR
-  worldPrior_nonneg := worldPriorR_nonneg
-  latentPrior_nonneg _ _ := by positivity
+    L₀(w | u, σ) ∝ ⟦u⟧(σ,w) · P(w)               (`meaningE`, `L0v`)
+    S₁(u | w, σ) ∝ L₀(w | u, σ)⁴ · e^C(u)         (`Sk`)
+    L₁(w, σ | u) ∝ S₁(u | w, σ) · P(w) · P(σ)     (`listener`, `PMF.posterior`)
+
+The prior is baked into the graded L₀ kernel (eq 10, `L₀ ∝ P(w)·⟦u⟧(w)`);
+`null` is licensed everywhere, so the speaker normaliser vanishes only at
+invalid (zero-prior) worlds, which carry joint weight 0 and are handled by a
+`dite` wrapper. Statements are `e`-generic over `0 < e < 1`; `exp(−4)` is
+instantiated only in bridging corollaries. -/
+
+/-- Prior-weighted meaning `⟦u⟧(σ,w) · P(w)`, lifted to `ℝ≥0∞`. -/
+def meaningE (sem : Utterance → Sigma → EvalWorld → Bool) (σ : Sigma)
+    (u : Utterance) (w : EvalWorld) : ℝ≥0∞ :=
+  if sem u σ w then ENNReal.ofReal (worldPrior w) else 0
+
+private theorem meaningE_ne_top (sem) (σ) (u) (w) : meaningE sem σ u w ≠ ⊤ := by
+  simp only [meaningE]; split
+  · exact ENNReal.ofReal_ne_top
+  · exact ENNReal.zero_ne_top
+
+private theorem meaningE_tsum_ne_top (sem) (σ) (u) : (∑' w, meaningE sem σ u w) ≠ ⊤ := by
+  rw [tsum_fintype]; exact ENNReal.sum_ne_top.mpr fun w _ => meaningE_ne_top sem σ u w
+
+/-- Literal-listener value `L₀(w | u, σ) = ⟦u⟧(σ,w)·P(w) / D` (well-defined
+and `0` on empty extensions, since `0 · ⊤ = 0` in `ℝ≥0∞`). -/
+noncomputable def L0v (sem : Utterance → Sigma → EvalWorld → Bool) (σ : Sigma)
+    (u : Utterance) (w : EvalWorld) : ℝ≥0∞ :=
+  meaningE sem σ u w * (∑' w', meaningE sem σ u w')⁻¹
+
+private theorem L0v_ne_top (sem) (σ) (u) (w) : L0v sem σ u w ≠ ⊤ := by
+  rw [L0v]
+  rcases eq_or_ne (∑' w', meaningE sem σ u w') 0 with h | h
+  · have hm : meaningE sem σ u w = 0 := by
+      by_contra hm; exact (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨w, hm⟩) h
+    rw [hm, zero_mul]; exact ENNReal.zero_ne_top
+  · exact ENNReal.mul_ne_top (meaningE_ne_top sem σ u w) (ENNReal.inv_ne_top.mpr h)
+
+/-- Speaker weight `L₀(w|u,σ)⁴ · e^C(u)`. -/
+noncomputable def spkW (sem : Utterance → Sigma → EvalWorld → Bool) (e : ℝ)
+    (s : EvalWorld × Sigma) (u : Utterance) : ℝ≥0∞ :=
+  (L0v sem s.2 u s.1) ^ 4 * ENNReal.ofReal (e ^ costN u)
+
+private theorem spkW_ne_top (sem) (e) (s) (u) : spkW sem e s u ≠ ⊤ :=
+  ENNReal.mul_ne_top (ENNReal.pow_ne_top (L0v_ne_top sem s.2 u s.1)) ENNReal.ofReal_ne_top
+
+private theorem spkW_tsum_ne_top (sem) (e) (s) : (∑' u, spkW sem e s u) ≠ ⊤ := by
+  rw [tsum_fintype]; exact ENNReal.sum_ne_top.mpr fun u _ => spkW_ne_top sem e s u
+
+/-- **Speaker** `S₁(· | w, σ) : PMF Utterance`, `dite`-guarded so it is total
+even at invalid worlds (where every weight vanishes; those carry joint prior 0). -/
+noncomputable def Sk (sem : Utterance → Sigma → EvalWorld → Bool) (e : ℝ)
+    (s : EvalWorld × Sigma) : PMF Utterance :=
+  if h : (∑' u, spkW sem e s u) ≠ 0 then
+    PMF.normalize (spkW sem e s) h (spkW_tsum_ne_top sem e s)
+  else PMF.pure .null
+
+/-- Unnormalised joint prior `P(w) · P(σ)` (uniform latent absorbed). -/
+def jointW (s : EvalWorld × Sigma) : ℝ≥0∞ := ENNReal.ofReal (worldPrior s.1)
+
+/-- Concise world constructor: `mkW h m = (Fin h, Fin m)`. -/
+def mkW (h : Fin 9) (m : Fin 5) : EvalWorld := (h, m)
+
+private theorem worldPrior_pos_of_ne {w : EvalWorld} (h : worldPrior w ≠ 0) :
+    (0 : ℝ) < (worldPrior w : ℝ) := by
+  have := worldPrior_nonneg_Q w; exact_mod_cast lt_of_le_of_ne this (Ne.symm h)
+
+private theorem jointW_ne_zero {s : EvalWorld × Sigma} (h : worldPrior s.1 ≠ 0) :
+    jointW s ≠ 0 := by
+  simp only [jointW]; exact (ENNReal.ofReal_pos.mpr (worldPrior_pos_of_ne h)).ne'
+
+private theorem jointW_tsum_ne_zero : (∑' s, jointW s) ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨(mkW 4 2, 0), jointW_ne_zero (by decide)⟩
+
+private theorem jointW_tsum_ne_top : (∑' s, jointW s) ≠ ⊤ := by
+  rw [tsum_fintype]; exact ENNReal.sum_ne_top.mpr fun _ _ => ENNReal.ofReal_ne_top
+
+/-- Listener's joint prior over `world × σ`. -/
+noncomputable def jointK : PMF (EvalWorld × Sigma) :=
+  PMF.normalize jointW jointW_tsum_ne_zero jointW_tsum_ne_top
+
+private theorem jointK_ne_zero {s : EvalWorld × Sigma} (h : worldPrior s.1 ≠ 0) :
+    jointK s ≠ 0 := by
+  rw [jointK, ← PMF.mem_support_iff, PMF.mem_support_normalize_iff]; exact jointW_ne_zero h
+
+private theorem L0v_ne_zero {sem σ u w} (h : meaningE sem σ u w ≠ 0) :
+    L0v sem σ u w ≠ 0 :=
+  mul_ne_zero h (ENNReal.inv_ne_zero.mpr (meaningE_tsum_ne_top sem σ u))
+
+private theorem meaningE_ne_zero {sem σ u w} (hlic : sem u σ w = true)
+    (hval : worldPrior w ≠ 0) : meaningE sem σ u w ≠ 0 := by
+  simp only [meaningE, hlic, if_true]
+  exact (ENNReal.ofReal_pos.mpr (worldPrior_pos_of_ne hval)).ne'
+
+private theorem spkW_ne_zero {sem} {e : ℝ} (he0 : 0 < e) {s : EvalWorld × Sigma}
+    {u : Utterance} (hlic : sem u s.2 s.1 = true) (hval : worldPrior s.1 ≠ 0) :
+    spkW sem e s u ≠ 0 := by
+  refine mul_ne_zero (pow_ne_zero 4 (L0v_ne_zero (meaningE_ne_zero hlic hval))) ?_
+  exact (ENNReal.ofReal_pos.mpr (pow_pos he0 _)).ne'
+
+private theorem Sk_apply_ne_zero {sem} {e : ℝ} (he0 : 0 < e) {s : EvalWorld × Sigma}
+    {u : Utterance} (hnull : sem .null s.2 s.1 = true) (hval : worldPrior s.1 ≠ 0)
+    (hlic : sem u s.2 s.1 = true) : Sk sem e s u ≠ 0 := by
+  have hsum : (∑' u', spkW sem e s u') ≠ 0 :=
+    ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.null, spkW_ne_zero he0 hnull hval⟩
+  rw [Sk, dif_pos hsum, ← PMF.mem_support_iff, PMF.mem_support_normalize_iff]
+  exact spkW_ne_zero he0 hlic hval
+
+/-- Single-witness discharge of the listener's marginal positivity: a valid
+world `w0` licensed for `u` at some `σ0` (with `null` also licensed there). -/
+theorem marg_ne_zero {sem} {e : ℝ} (he0 : 0 < e) {u : Utterance}
+    {w0 : EvalWorld} {σ0 : Sigma} (hval : worldPrior w0 ≠ 0)
+    (hnull : sem .null σ0 w0 = true) (hlic : sem u σ0 w0 = true) :
+    PMF.marginal (Sk sem e) jointK u ≠ 0 :=
+  PMF.marginal_ne_zero (Sk sem e) jointK u (a := (w0, σ0)) (jointK_ne_zero hval)
+    (Sk_apply_ne_zero he0 hnull hval hlic)
+
+/-! ### Structural speaker/listener monotonicity
+
+Evaluativity is proved *structurally*, with no normaliser computation: the
+per-latent speaker order follows from **licensing-set inclusion** between two
+equal-prior worlds. Two equal-prior worlds with the same licensing bit for `u`
+have identical speaker numerators; a wider licensing set only enlarges the
+denominator. Hence a world that is licensed for *fewer* alternatives (its
+licensing set is contained in the other's) puts *more* mass on the observed
+`u`. Only `0 < e` is used (for strict positivity); nothing needs `e < 1`. -/
+
+private theorem spkW_tsum_ne_zero {sem} {e : ℝ} (he0 : 0 < e) {s : EvalWorld × Sigma}
+    (hnull : sem .null s.2 s.1 = true) (hv : worldPrior s.1 ≠ 0) :
+    (∑' u', spkW sem e s u') ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.null, spkW_ne_zero he0 hnull hv⟩
+
+private theorem Sk_apply_eq {sem} {e : ℝ} {s : EvalWorld × Sigma}
+    (hsum : (∑' u', spkW sem e s u') ≠ 0) (u : Utterance) :
+    Sk sem e s u = spkW sem e s u * (∑' u', spkW sem e s u')⁻¹ := by
+  rw [Sk, dif_pos hsum, PMF.normalize_apply]
+
+private theorem spkW_eq_zero_of_not_lic {sem} {e : ℝ} {s : EvalWorld × Sigma}
+    {u : Utterance} (h : sem u s.2 s.1 = false) : spkW sem e s u = 0 := by
+  rw [spkW]
+  suffices L0v sem s.2 u s.1 = 0 by rw [this, zero_pow (by norm_num), zero_mul]
+  rw [L0v, meaningE, if_neg (by simp [h]), zero_mul]
+
+private theorem Sk_eq_zero_of_not_lic {sem} {e : ℝ} {s : EvalWorld × Sigma}
+    (hsum : (∑' u', spkW sem e s u') ≠ 0) {u : Utterance} (h : sem u s.2 s.1 = false) :
+    Sk sem e s u = 0 := by
+  rw [Sk_apply_eq hsum, spkW_eq_zero_of_not_lic h, zero_mul]
+
+private theorem Sk_pos {sem} {e : ℝ} (he0 : 0 < e) {s : EvalWorld × Sigma}
+    (hnull : sem .null s.2 s.1 = true) (hv : worldPrior s.1 ≠ 0)
+    {u : Utterance} (hlic : sem u s.2 s.1 = true) : 0 < Sk sem e s u := by
+  rw [Sk_apply_eq (spkW_tsum_ne_zero he0 hnull hv)]
+  exact ENNReal.mul_pos (spkW_ne_zero he0 hlic hv)
+    (ENNReal.inv_ne_zero.mpr (spkW_tsum_ne_top sem e s))
+
+/-- **Monotone speaker weight**: with equal world prior, a licensing bit that
+is dominated (`wa` licensed for `u` ⟹ `wb` licensed) forces `spkW wa ≤ spkW wb`. -/
+private theorem spkW_le_of_prior_lic {sem} {e : ℝ} {u σ} {wa wb : EvalWorld}
+    (hp : worldPrior wa = worldPrior wb) (hlic : sem u σ wa = true → sem u σ wb = true) :
+    spkW sem e (wa, σ) u ≤ spkW sem e (wb, σ) u := by
+  unfold spkW L0v
+  gcongr
+  simp only [meaningE]
+  by_cases ha : sem u σ wa = true
+  · rw [if_pos ha, if_pos (hlic ha), hp]
+  · rw [if_neg ha]; exact zero_le
+
+private theorem jointK_apply_eq (s : EvalWorld × Sigma) :
+    jointK s = jointW s * (∑' s', jointW s')⁻¹ := by
+  rw [jointK, PMF.normalize_apply]
+
+private theorem jointK_eq_of_prior {σ : Sigma} {w1 w2 : EvalWorld}
+    (h : worldPrior w1 = worldPrior w2) : jointK (w1, σ) = jointK (w2, σ) := by
+  rw [jointK_apply_eq, jointK_apply_eq, jointW, jointW, h]
+
+private theorem jointK_ne_top (s : EvalWorld × Sigma) : jointK s ≠ ⊤ :=
+  PMF.apply_ne_top jointK s
+
+/-- **Per-latent evaluativity**: at a fixed `σ`, the speaker prefers the
+observed `u` for `w2` at least as much as for `w1`, when `w1, w2` share the
+world prior, `w1`'s `u`-licensing is contained in `w2`'s (`hu`), and — on the
+region where `w1` is `u`-licensed — `w2`'s whole licensing set is contained in
+`w1`'s (`halt`). Pure order argument; no normaliser is evaluated. -/
+private theorem sk_le_of_incl {sem} {e : ℝ} (he0 : 0 < e) {u σ} {w1 w2 : EvalWorld}
+    (hp : worldPrior w1 = worldPrior w2) (hv1 : worldPrior w1 ≠ 0) (hv2 : worldPrior w2 ≠ 0)
+    (hnull1 : sem .null σ w1 = true) (hnull2 : sem .null σ w2 = true)
+    (hu : sem u σ w1 = true → sem u σ w2 = true)
+    (halt : sem u σ w1 = true → ∀ u', sem u' σ w2 = true → sem u' σ w1 = true) :
+    Sk sem e (w1, σ) u ≤ Sk sem e (w2, σ) u := by
+  by_cases h1 : sem u σ w1 = true
+  · rw [Sk_apply_eq (spkW_tsum_ne_zero he0 hnull1 hv1) u,
+        Sk_apply_eq (spkW_tsum_ne_zero he0 hnull2 hv2) u]
+    refine mul_le_mul' (spkW_le_of_prior_lic hp hu) (ENNReal.inv_le_inv.mpr ?_)
+    exact ENNReal.tsum_le_tsum fun u' => spkW_le_of_prior_lic hp.symm (halt h1 u')
+  · rw [Sk_eq_zero_of_not_lic (spkW_tsum_ne_zero he0 hnull1 hv1) (Bool.not_eq_true _ ▸ h1)]
+    exact zero_le
+
+/-- **Strict per-latent gap**: where `w1` is *not* `u`-licensed but `w2` is,
+`w1` contributes `0` and `w2` contributes a positive speaker mass. -/
+private theorem sk_lt_of_gap {sem} {e : ℝ} (he0 : 0 < e) {u σ} {w1 w2 : EvalWorld}
+    (hv1 : worldPrior w1 ≠ 0) (hv2 : worldPrior w2 ≠ 0)
+    (hnull1 : sem .null σ w1 = true) (hnull2 : sem .null σ w2 = true)
+    (h1 : sem u σ w1 = false) (h2 : sem u σ w2 = true) :
+    Sk sem e (w1, σ) u < Sk sem e (w2, σ) u := by
+  rw [Sk_eq_zero_of_not_lic (spkW_tsum_ne_zero he0 hnull1 hv1) h1]
+  exact Sk_pos he0 hnull2 hv2 h2
+
+/-- Strict monotonicity of a finite `ℝ≥0∞` sum from a single strictly-larger
+term (the others being finite): `Finset.sum_lt_sum` is unavailable because
+`ℝ≥0∞` is not cancellative. -/
+private theorem ennreal_sum_lt_sum {ι} [DecidableEq ι] {s : Finset ι} {f g : ι → ℝ≥0∞}
+    (hfg : ∀ i ∈ s, f i ≤ g i) {i₀ : ι} (hi₀ : i₀ ∈ s) (hlt : f i₀ < g i₀)
+    (htop : ∀ i ∈ s, g i ≠ ⊤) : ∑ i ∈ s, f i < ∑ i ∈ s, g i := by
+  rw [← Finset.add_sum_erase s f hi₀, ← Finset.add_sum_erase s g hi₀]
+  have htop' : ∑ x ∈ s.erase i₀, g x ≠ ⊤ :=
+    ENNReal.sum_ne_top.mpr fun i hi => htop i (Finset.mem_of_mem_erase hi)
+  calc f i₀ + ∑ x ∈ s.erase i₀, f x
+      ≤ f i₀ + ∑ x ∈ s.erase i₀, g x := by
+        gcongr with i hi; exact hfg i (Finset.mem_of_mem_erase hi)
+    _ < g i₀ + ∑ x ∈ s.erase i₀, g x := ENNReal.add_lt_add_right htop' hlt
+
+/-- **Evaluativity from licensing inclusion** (Tier A). For two equal-prior
+worlds with `w1`'s `u`-licensing contained in `w2`'s (`hu`) and, on that
+support, `w2`'s whole licensing contained in `w1`'s (`halt`), plus a `σ₀` where
+only `w2` is `u`-licensed, the listener strictly prefers `w2`: `L₁(w1|u) <
+L₁(w2|u)`. Pure order argument — no normaliser is evaluated, and only `0 < e`
+is used. -/
+private theorem evaluative_of_incl {sem} {e : ℝ} (he0 : 0 < e) {u : Utterance}
+    {w1 w2 : EvalWorld} (marg : PMF.marginal (Sk sem e) jointK u ≠ 0)
+    (hp : worldPrior w1 = worldPrior w2) (hv1 : worldPrior w1 ≠ 0) (hv2 : worldPrior w2 ≠ 0)
+    (hnull1 : ∀ σ, sem .null σ w1 = true) (hnull2 : ∀ σ, sem .null σ w2 = true)
+    (hu : ∀ σ, sem u σ w1 = true → sem u σ w2 = true)
+    (halt : ∀ σ, sem u σ w1 = true → ∀ u', sem u' σ w2 = true → sem u' σ w1 = true)
+    (σ₀ : Sigma) (hgap1 : sem u σ₀ w1 = false) (hgap2 : sem u σ₀ w2 = true) :
+    (RSA.Canonical.L1 (Sk sem e) jointK u marg).fst w1
+      < (RSA.Canonical.L1 (Sk sem e) jointK u marg).fst w2 := by
+  rw [RSA.Canonical.L1_world_prefers_iff]
+  refine ennreal_sum_lt_sum (fun σ _ => ?_) (Finset.mem_univ σ₀) ?_
+    (fun σ _ => ENNReal.mul_ne_top (jointK_ne_top _) (PMF.apply_ne_top _ _))
+  · rw [jointK_eq_of_prior hp]
+    gcongr
+    exact sk_le_of_incl he0 hp hv1 hv2 (hnull1 σ) (hnull2 σ) (hu σ) (halt σ)
+  · rw [jointK_eq_of_prior hp]
+    exact ENNReal.mul_lt_mul_right (jointK_ne_zero hv2) (jointK_ne_top _)
+      (sk_lt_of_gap he0 hv1 hv2 (hnull1 σ₀) (hnull2 σ₀) hgap1 hgap2)
 
 -- ============================================================================
 -- § 7. Simulation 1: Positive Construction (§2.2.1, Table 1)
@@ -205,10 +437,13 @@ def posMeaning (u : Utterance) (σ : Sigma) (w : EvalWorld) : Bool :=
   | .marked   => decide (htVal w ≤ muVal w + sigmaVal σ)
   | .null     => true
 
-@[reducible] noncomputable def posCfg := mkEvalCfg posMeaning
-
-/-- Concise world constructor: mkW h m = (Fin h, Fin m). -/
-def mkW (h : Fin 9) (m : Fin 5) : EvalWorld := (h, m)
+/-- Positive-construction pragmatic listener `L₁(· | u)` at cost base `e`. -/
+noncomputable def posL1 (u : Utterance) {e : ℝ} (he0 : 0 < e) : PMF (EvalWorld × Sigma) :=
+  RSA.Canonical.L1 (Sk posMeaning e) jointK u <|
+    match u with
+    | .unmarked => marg_ne_zero he0 (w0 := mkW 4 2) (σ0 := 0) (by decide) (by decide) (by decide)
+    | .marked   => marg_ne_zero he0 (w0 := mkW 4 4) (σ0 := 4) (by decide) (by decide) (by decide)
+    | .null     => marg_ne_zero he0 (w0 := mkW 4 2) (σ0 := 0) (by decide) (by decide) (by decide)
 
 /-! ### Prediction 1: "Tall" shifts height above CC mean
 
@@ -219,9 +454,11 @@ than height 4 (index 3, dev = −1). Both worlds have equal prior (6),
 so the asymmetry is entirely due to pragmatic reasoning.
 The paper reports E[ht − μ] = 2.08 at L₁. -/
 
-theorem pos_tall_evaluative :
-    posCfg.L1 .unmarked (mkW 5 2) > posCfg.L1 .unmarked (mkW 3 2) := by
-  rsa_predict
+theorem pos_tall_evaluative (e : ℝ) (he0 : 0 < e) :
+    (posL1 .unmarked he0).fst (mkW 5 2) > (posL1 .unmarked he0).fst (mkW 3 2) := by
+  simp only [posL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨2, by omega⟩ (by decide) (by decide)
 
 /-! ### Prediction 2: "Short" shifts height below CC mean
 
@@ -231,9 +468,11 @@ The marked form is even more evaluative than the unmarked form,
 because the extra cost signals that the speaker's reason for speaking
 must be particularly strong. -/
 
-theorem pos_short_evaluative :
-    posCfg.L1 .marked (mkW 3 2) > posCfg.L1 .marked (mkW 5 2) := by
-  rsa_predict
+theorem pos_short_evaluative (e : ℝ) (he0 : 0 < e) :
+    (posL1 .marked he0).fst (mkW 3 2) > (posL1 .marked he0).fst (mkW 5 2) := by
+  simp only [posL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨2, by omega⟩ (by decide) (by decide)
 
 -- ============================================================================
 -- § 8. Simulation 2: Exact Equative (§2.2.2, Table 1)
@@ -257,7 +496,13 @@ def eqMeaning (u : Utterance) (σ : Sigma) (w : EvalWorld) : Bool :=
   | .marked   => decide (htVal w = kHeight) && decide (kHeight ≤ muVal w + sigmaVal σ)
   | .null     => true
 
-@[reducible] noncomputable def eqCfg := mkEvalCfg eqMeaning
+/-- Exact-equative pragmatic listener `L₁(· | u)` at cost base `e`. -/
+noncomputable def eqL1 (u : Utterance) {e : ℝ} (he0 : 0 < e) : PMF (EvalWorld × Sigma) :=
+  RSA.Canonical.L1 (Sk eqMeaning e) jointK u <|
+    match u with
+    | .unmarked => marg_ne_zero he0 (w0 := mkW 4 0) (σ0 := 0) (by decide) (by decide) (by decide)
+    | .marked   => marg_ne_zero he0 (w0 := mkW 4 4) (σ0 := 0) (by decide) (by decide) (by decide)
+    | .null     => marg_ne_zero he0 (w0 := mkW 4 0) (σ0 := 0) (by decide) (by decide) (by decide)
 
 -- k = 5 (height index 4). Relevant worlds: (4, j) for j ∈ {0,1,2,3,4}.
 -- μ = 3 (j=0): k well above mean → non-evaluative direction
@@ -276,9 +521,11 @@ By [bergen-levy-goodman-2016]'s logic, L₁ infers the speaker must have
 had a strong reason — the marked form is distinctively informative in worlds
 where k is atypically low. -/
 
-theorem eq_marked_evaluative :
-    eqCfg.L1 .marked (mkW 4 4) > eqCfg.L1 .marked (mkW 4 0) := by
-  rsa_predict
+theorem eq_marked_evaluative (e : ℝ) (he0 : 0 < e) :
+    (eqL1 .marked he0).fst (mkW 4 4) > (eqL1 .marked he0).fst (mkW 4 0) := by
+  simp only [eqL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨0, by omega⟩ (by decide) (by decide)
 
 /-! ### Prediction 4: Unmarked equative is weakly evaluative
 
@@ -291,9 +538,11 @@ This asymmetry — marked evaluative, unmarked weakly/not evaluative — is
 the antonym-sensitive pattern that [rett-2015] identifies categorically
 and this model derives gradiently. -/
 
-theorem eq_unmarked_weakly_evaluative :
-    eqCfg.L1 .unmarked (mkW 4 0) > eqCfg.L1 .unmarked (mkW 4 4) := by
-  rsa_predict
+theorem eq_unmarked_weakly_evaluative (e : ℝ) (he0 : 0 < e) :
+    (eqL1 .unmarked he0).fst (mkW 4 0) > (eqL1 .unmarked he0).fst (mkW 4 4) := by
+  simp only [eqL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨4, by omega⟩ (by decide) (by decide)
 
 -- ============================================================================
 -- § 9. Simulation 3: ≥ Equative (§2.2.3, Table 1)
@@ -318,7 +567,13 @@ def geqMeaning (u : Utterance) (σ : Sigma) (w : EvalWorld) : Bool :=
   | .marked   => decide (htVal w ≤ kHeight) && decide (kHeight ≤ muVal w + sigmaVal σ)
   | .null     => true
 
-@[reducible] noncomputable def geqCfg := mkEvalCfg geqMeaning
+/-- ≥-equative pragmatic listener `L₁(· | u)` at cost base `e`. -/
+noncomputable def geqL1 (u : Utterance) {e : ℝ} (he0 : 0 < e) : PMF (EvalWorld × Sigma) :=
+  RSA.Canonical.L1 (Sk geqMeaning e) jointK u <|
+    match u with
+    | .unmarked => marg_ne_zero he0 (w0 := mkW 4 0) (σ0 := 0) (by decide) (by decide) (by decide)
+    | .marked   => marg_ne_zero he0 (w0 := mkW 4 4) (σ0 := 0) (by decide) (by decide) (by decide)
+    | .null     => marg_ne_zero he0 (w0 := mkW 4 0) (σ0 := 0) (by decide) (by decide) (by decide)
 
 /-! ### Prediction 5: Marked ≥ equative is evaluative
 
@@ -326,9 +581,11 @@ Hearing "Jane is at least as short as Keisha" (marked) shifts L₁'s
 posterior toward worlds where k is below the CC center.
 The paper reports E[k − μ] = −1.52 at L₁. -/
 
-theorem geq_marked_evaluative :
-    geqCfg.L1 .marked (mkW 4 4) > geqCfg.L1 .marked (mkW 4 0) := by
-  rsa_predict
+theorem geq_marked_evaluative (e : ℝ) (he0 : 0 < e) :
+    (geqL1 .marked he0).fst (mkW 4 4) > (geqL1 .marked he0).fst (mkW 4 0) := by
+  simp only [geqL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨0, by omega⟩ (by decide) (by decide)
 
 /-! ### Prediction 6: Unmarked ≥ equative is barely evaluative
 
@@ -336,9 +593,11 @@ Hearing "Jane is at least as tall as Keisha" (unmarked) barely shifts
 the posterior. The paper reports E[k − μ] = 0.11 at L₁ — the weakest
 evaluative effect of any construction. -/
 
-theorem geq_unmarked_barely_evaluative :
-    geqCfg.L1 .unmarked (mkW 4 0) > geqCfg.L1 .unmarked (mkW 4 4) := by
-  rsa_predict
+theorem geq_unmarked_barely_evaluative (e : ℝ) (he0 : 0 < e) :
+    (geqL1 .unmarked he0).fst (mkW 4 0) > (geqL1 .unmarked he0).fst (mkW 4 4) := by
+  simp only [geqL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨4, by omega⟩ (by decide) (by decide)
 
 -- ============================================================================
 -- § 10. Simulation 4: Comparative (§2.2.4, Table 1)
@@ -368,7 +627,13 @@ def compMeaning (u : Utterance) (σ : Sigma) (w : EvalWorld) : Bool :=
   | .marked   => decide (htVal w < kHeight) && decide (kHeight ≤ muVal w + sigmaVal σ)
   | .null     => true
 
-@[reducible] noncomputable def compCfg := mkEvalCfg compMeaning
+/-- Comparative pragmatic listener `L₁(· | u)` at cost base `e`. -/
+noncomputable def compL1 (u : Utterance) {e : ℝ} (he0 : 0 < e) : PMF (EvalWorld × Sigma) :=
+  RSA.Canonical.L1 (Sk compMeaning e) jointK u <|
+    match u with
+    | .unmarked => marg_ne_zero he0 (w0 := mkW 5 2) (σ0 := 0) (by decide) (by decide) (by decide)
+    | .marked   => marg_ne_zero he0 (w0 := mkW 3 2) (σ0 := 2) (by decide) (by decide) (by decide)
+    | .null     => marg_ne_zero he0 (w0 := mkW 5 2) (σ0 := 0) (by decide) (by decide) (by decide)
 
 /-! ### Prediction 7: Comparative marked does not strongly shift k
 
@@ -378,9 +643,11 @@ toward worlds where k is far from the CC center. At equal prior
 world with k well above the mean. The paper reports E[k − μ] = −0.44
 at L₁ — a very weak effect, unlike the equative's −1.06. -/
 
-theorem comp_marked_weak :
-    compCfg.L1 .marked (mkW 3 2) > compCfg.L1 .marked (mkW 3 0) := by
-  rsa_predict
+theorem comp_marked_weak (e : ℝ) (he0 : 0 < e) :
+    (compL1 .marked he0).fst (mkW 3 2) > (compL1 .marked he0).fst (mkW 3 0) := by
+  simp only [compL1, gt_iff_lt]
+  exact evaluative_of_incl he0 _ (by decide) (by decide) (by decide) (fun _ => rfl)
+    (fun _ => rfl) (by decide) (by decide) ⟨2, by omega⟩ (by decide) (by decide)
 
 /-! ### Prediction 8: Comparative unmarked is counter-evaluative
 
@@ -390,9 +657,152 @@ E[k − μ] = −0.74, slightly negative: Keisha is inferred to be
 slightly below the CC mean. This is because knowing Jane exceeds
 Keisha's height leaves more room for Keisha to be below average. -/
 
-theorem comp_unmarked_counter_evaluative :
-    compCfg.L1 .unmarked (mkW 5 3) > compCfg.L1 .unmarked (mkW 5 1) := by
-  rsa_predict
+private theorem meaningE_eq_ofReal (sem) (σ) (u) (w) :
+    meaningE sem σ u w = ENNReal.ofReal (if sem u σ w then worldPrior w else 0) := by
+  unfold meaningE; split <;> simp
+
+/-- Kernel-clean evaluation of a graded-`L₀` normaliser: the `ℝ≥0∞` fan-out
+sum equals `ofReal` of the concrete ℚ mass sum. -/
+private theorem dval {sem σ u} {D : ℚ}
+    (h : (∑ w : Fin 9 × Fin 5, if sem u σ w then worldPrior w else 0) = D) :
+    (∑' w, meaningE sem σ u w) = ENNReal.ofReal D := by
+  rw [tsum_fintype, Finset.sum_congr rfl fun w _ => meaningE_eq_ofReal sem σ u w,
+    ← ENNReal.ofReal_sum_of_nonneg fun w _ => by
+      split
+      · exact_mod_cast worldPrior_nonneg_Q w
+      · exact le_refl 0]
+  congr 1
+  rw [← h, Rat.cast_sum]
+  exact Finset.sum_congr rfl fun w _ => by split <;> simp
+
+private theorem dval_unm :
+    (∑' w, meaningE compMeaning (1 : Sigma) .unmarked w) = ENNReal.ofReal 25 :=
+  dval (by decide +kernel)
+
+private theorem dval_null :
+    (∑' w, meaningE compMeaning (1 : Sigma) .null w) = ENNReal.ofReal 120 :=
+  dval (by decide +kernel)
+
+private theorem wp53 : worldPrior (mkW 5 3) = 10 := by decide +kernel
+
+private theorem L0v_unm :
+    L0v compMeaning (1 : Sigma) .unmarked (mkW 5 3) = ENNReal.ofReal (2 / 5) := by
+  unfold L0v
+  rw [dval_unm, meaningE_eq_ofReal, if_pos (by decide),
+    show ((worldPrior (mkW 5 3) : ℝ)) = 10 by rw [wp53]; norm_num,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num : (0:ℝ) < 25),
+    ← ENNReal.ofReal_mul (by norm_num : (0:ℝ) ≤ 10)]
+  norm_num
+
+private theorem L0v_null :
+    L0v compMeaning (1 : Sigma) .null (mkW 5 3) = ENNReal.ofReal (1 / 12) := by
+  unfold L0v
+  rw [dval_null, meaningE_eq_ofReal, if_pos (by decide),
+    show ((worldPrior (mkW 5 3) : ℝ)) = 10 by rw [wp53]; norm_num,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num : (0:ℝ) < 120),
+    ← ENNReal.ofReal_mul (by norm_num : (0:ℝ) ≤ 10)]
+  norm_num
+
+private theorem spkW_unm (e : ℝ) :
+    spkW compMeaning e (mkW 5 3, (1 : Sigma)) .unmarked = ENNReal.ofReal ((2 / 5) ^ 4 * e) := by
+  unfold spkW
+  rw [L0v_unm, ← ENNReal.ofReal_pow (by norm_num : (0:ℝ) ≤ 2 / 5),
+    show costN .unmarked = 1 from rfl, pow_one, ← ENNReal.ofReal_mul (by positivity)]
+
+private theorem spkW_null (e : ℝ) :
+    spkW compMeaning e (mkW 5 3, (1 : Sigma)) .null = ENNReal.ofReal ((1 / 12) ^ 4) := by
+  unfold spkW
+  rw [L0v_null, ← ENNReal.ofReal_pow (by norm_num : (0:ℝ) ≤ 1 / 12),
+    show costN .null = 0 from rfl, pow_zero, ENNReal.ofReal_one, mul_one]
+
+private theorem spkW_marked (e : ℝ) :
+    spkW compMeaning e (mkW 5 3, (1 : Sigma)) .marked = 0 :=
+  spkW_eq_zero_of_not_lic (by decide)
+
+private theorem spkW_tsum (e : ℝ) :
+    (∑' u, spkW compMeaning e (mkW 5 3, (1 : Sigma)) u)
+      = ENNReal.ofReal ((2 / 5) ^ 4 * e) + ENNReal.ofReal ((1 / 12) ^ 4) := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset Utterance) = {.unmarked, .marked, .null} from by decide,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
+    spkW_unm, spkW_marked, spkW_null, zero_add]
+
+private theorem Sk_bound {e : ℝ} (he0 : 0 < e) (he_lo : (1 : ℝ) / 100 ≤ e) :
+    (5 : ℝ≥0∞) < 10 * Sk compMeaning e (mkW 5 3, (1 : Sigma)) .unmarked := by
+  have hA : (0 : ℝ) < (2 / 5) ^ 4 * e := by positivity
+  have hsum : (∑' u', spkW compMeaning e (mkW 5 3, (1 : Sigma)) u') ≠ 0 := by
+    rw [spkW_tsum]
+    exact ((ENNReal.ofReal_pos.mpr hA).trans_le le_self_add).ne'
+  rw [Sk_apply_eq hsum, spkW_unm, spkW_tsum, ← ENNReal.ofReal_add hA.le (by positivity),
+    ← ENNReal.ofReal_inv_of_pos (by positivity), ← ENNReal.ofReal_mul hA.le,
+    show (10 : ℝ≥0∞) = ENNReal.ofReal 10 by norm_num, ← ENNReal.ofReal_mul (by norm_num),
+    show (5 : ℝ≥0∞) = ENNReal.ofReal 5 by norm_num, ENNReal.ofReal_lt_ofReal_iff (by positivity),
+    ← mul_assoc, ← div_eq_mul_inv, lt_div_iff₀ (by positivity)]
+  nlinarith [he_lo]
+
+private theorem jointK_w1 (σ : Sigma) : jointK (mkW 5 1, σ) = jointK (mkW 5 1, 1) := by
+  simp only [jointK_apply_eq, jointW]
+
+private theorem jointK_w3_ratio :
+    jointK (mkW 5 3, (1 : Sigma)) = 10 * jointK (mkW 5 1, (1 : Sigma)) := by
+  rw [jointK_apply_eq, jointK_apply_eq, jointW, jointW, wp53,
+    show worldPrior (mkW 5 1) = 1 from by decide +kernel, ← mul_assoc]
+  congr 1
+  rw [Rat.cast_one, ENNReal.ofReal_one, mul_one, Rat.cast_ofNat, ENNReal.ofReal_ofNat]
+
+/-- Counter-evaluative comparative — a **prior-magnitude** effect, not a
+licensing one. Unlike the seven Tier-A predictions (which hold for every cost
+base `e ∈ (0,1)` via `evaluative_of_incl`'s bare `0 < e`), here the speaker
+distribution depends on a world only through its *licensing set* (the prior
+cancels inside `Sk`), so the 10:1 world prior of `mkW 5 3` (k at the CC mean)
+over `mkW 5 1` (k above it) is the sole asymmetry and it dominates.
+
+The prior dominates only when markedness costs are not extreme. The sharp
+threshold is `e ≥ (D_unm(1)/D_null)⁴ = (25/120)⁴ ≈ 0.0019`: for `e` below it,
+the cost factor `e^C` so heavily discounts the informative "taller than"
+utterance in the high-threshold worlds that the informativity cost dominates
+the prior mass and the inequality flips. We therefore assume `1/100 ≤ e`
+(comfortably above the threshold, and met by the paper's `e = exp(−4) ≈ 0.018`;
+see `comp_unmarked_counter_evaluative_exp`). -/
+theorem comp_unmarked_counter_evaluative (e : ℝ) (he0 : 0 < e) (he_lo : (1 : ℝ)/100 ≤ e) :
+    (compL1 .unmarked he0).fst (mkW 5 3) > (compL1 .unmarked he0).fst (mkW 5 1) := by
+  -- `L1_world_prefers_iff` reduces to a comparison of joint-weighted speaker
+  -- sums. `jointK(w,·)` is constant in σ, with a 10:1 prior for `mkW 5 3` over
+  -- `mkW 5 1`; `Sk ≤ 1` bounds `mkW 5 1`'s five terms by `5·jointK(w1,·)`, while
+  -- `mkW 5 3`'s σ = 1 term alone gives `10·jointK(w1,·)·Sk(w2,1)` with
+  -- `Sk(w2,1) > 1/2` (`Sk_bound`) — so the prior mass wins.
+  simp only [compL1, gt_iff_lt, RSA.Canonical.L1_world_prefers_iff]
+  calc ∑ σ, jointK (mkW 5 1, σ) * Sk compMeaning e (mkW 5 1, σ) .unmarked
+      ≤ ∑ σ : Sigma, jointK (mkW 5 1, 1) := by
+        refine Finset.sum_le_sum fun σ _ => ?_
+        rw [jointK_w1 σ]
+        calc jointK (mkW 5 1, 1) * Sk compMeaning e (mkW 5 1, σ) .unmarked
+            ≤ jointK (mkW 5 1, 1) * 1 := by gcongr; exact PMF.coe_le_one _ _
+          _ = jointK (mkW 5 1, 1) := mul_one _
+    _ = 5 * jointK (mkW 5 1, 1) := by
+        rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]; norm_num
+    _ < jointK (mkW 5 3, 1) * Sk compMeaning e (mkW 5 3, 1) .unmarked := by
+        rw [jointK_w3_ratio, mul_right_comm]
+        exact ENNReal.mul_lt_mul_left (jointK_ne_zero (by decide +kernel)) (jointK_ne_top _)
+          (Sk_bound he0 he_lo)
+    _ ≤ ∑ σ, jointK (mkW 5 3, σ) * Sk compMeaning e (mkW 5 3, σ) .unmarked :=
+        Finset.single_le_sum
+          (f := fun σ => jointK (mkW 5 3, σ) * Sk compMeaning e (mkW 5 3, σ) .unmarked)
+          (fun σ _ => zero_le) (Finset.mem_univ (1 : Sigma))
+
+/-- The counter-evaluative comparative at the paper's cost base `e = exp(−4)`.
+The hypothesis `1/100 ≤ exp(−4)` reduces to `exp 4 ≤ 100`, and
+`exp 4 = (exp 1)⁴ < 2.7182818286⁴ ≈ 54.6 < 100`. -/
+theorem comp_unmarked_counter_evaluative_exp :
+    (compL1 .unmarked (Real.exp_pos (-4))).fst (mkW 5 3)
+      > (compL1 .unmarked (Real.exp_pos (-4))).fst (mkW 5 1) := by
+  refine comp_unmarked_counter_evaluative (Real.exp (-4)) (Real.exp_pos _) ?_
+  have he4 : Real.exp 4 ≤ 100 :=
+    calc Real.exp 4 = Real.exp 1 ^ 4 := by rw [← Real.exp_nat_mul]; norm_num
+      _ ≤ 2.7182818286 ^ 4 := by gcongr; exact Real.exp_one_lt_d9.le
+      _ ≤ 100 := by norm_num
+  rw [Real.exp_neg, one_div]
+  gcongr
 
 -- ============================================================================
 -- § 11. Cross-Construction Contrast
@@ -440,8 +850,8 @@ constructions categorically using `AdjectivalConstruction` and `Polarity`:
 - **Equative** (`.equative`): evaluative for `.negative` only (Manner/R-implicature)
 - **Comparative** (`.comparative`): NOT evaluative (no applicable implicature)
 
-This RSA model derives the same pattern *gradiently*: each `rsa_predict`
-theorem above confirms a qualitative directional prediction that matches
+This RSA model derives the same pattern *gradiently*: each `L₁` prediction
+above confirms a qualitative directional prediction that matches
 the categorical classification. The RSA model adds:
 1. **Graded predictions** — evaluativity has a continuous strength, not just ±
 2. **Unified mechanism** — rational communication replaces separate Q/R principles
@@ -475,24 +885,24 @@ open Rett2015Implicature (deriveEvaluativity)
     This theorem connects two independent formalizations — the categorical
     `deriveEvaluativity` function and the RSA `L1` predictions — proving they
     make compatible predictions despite using entirely different mechanisms. -/
-theorem rsa_neo_gricean_agreement :
+theorem rsa_neo_gricean_agreement (e : ℝ) (he0 : 0 < e) :
     -- Positive: both accounts say evaluative for both polarities
     (deriveEvaluativity posConstruction .positive).isEvaluative = true ∧
     (deriveEvaluativity posConstruction .negative).isEvaluative = true ∧
-    posCfg.L1 .unmarked (mkW 5 2) > posCfg.L1 .unmarked (mkW 3 2) ∧
-    posCfg.L1 .marked (mkW 3 2) > posCfg.L1 .marked (mkW 5 2) ∧
+    (posL1 .unmarked he0).fst (mkW 5 2) > (posL1 .unmarked he0).fst (mkW 3 2) ∧
+    (posL1 .marked he0).fst (mkW 3 2) > (posL1 .marked he0).fst (mkW 5 2) ∧
     -- Equative: Neo-Gricean says marked-only; RSA shows marked shift
     (deriveEvaluativity eqConstruction .positive).isEvaluative = false ∧
     (deriveEvaluativity eqConstruction .negative).isEvaluative = true ∧
-    eqCfg.L1 .marked (mkW 4 4) > eqCfg.L1 .marked (mkW 4 0) ∧
+    (eqL1 .marked he0).fst (mkW 4 4) > (eqL1 .marked he0).fst (mkW 4 0) ∧
     -- Comparative: both say not evaluative
     (deriveEvaluativity compConstruction .positive).isEvaluative = false ∧
     (deriveEvaluativity compConstruction .negative).isEvaluative = false :=
-  ⟨by native_decide, by native_decide,
-   pos_tall_evaluative, pos_short_evaluative,
-   by native_decide, by native_decide,
-   eq_marked_evaluative,
-   by native_decide, by native_decide⟩
+  ⟨by decide, by decide,
+   pos_tall_evaluative e he0, pos_short_evaluative e he0,
+   by decide, by decide,
+   eq_marked_evaluative e he0,
+   by decide, by decide⟩
 
 -- ============================================================================
 -- § 13. Cross-References
@@ -509,12 +919,19 @@ hearing "tall"/"short" shifts the height posterior.
 
 ### Architecture
 
-This model uses `RSAConfig` with:
-- `Latent := Sigma` (threshold offset, = lexical uncertainty over σ)
-- `meaning` bakes in the world prior (L₀ ∝ P(w) · L(u, w))
-- `s1Score` = exp(α · (log L₀ − C(u))) (action-based, cost-sensitive)
-- `worldPrior` = Gaussian-weighted 2D prior
-- `latentPrior` = uniform over σ (lexica equally likely a priori)
+The model runs on the mathlib-`PMF` RSA pipeline (`RSA.Canonical.L1`), with the
+latent threshold offset `σ` as the joint-listener's second coordinate:
+- `meaningE` bakes the Gaussian 2D world prior into the graded L₀ kernel
+  (L₀ ∝ P(w) · ⟦u⟧(σ,w)); `L0v` is its normalised value.
+- `Sk` is the cost-sensitive speaker `S₁(u | w,σ) ∝ L₀(w|u,σ)⁴ · e^C(u)`, with
+  cost base `e` (= `exp(−4)` at α = 4). It is `dite`-guarded so it stays total
+  at invalid worlds, which carry joint prior 0.
+- `jointK` is the uniform-over-σ joint prior `P(w)·P(σ)`; the listener is the
+  joint Bayesian posterior over `world × σ`, world marginal via `.fst`.
+
+Evaluativity (Tier A) is proved structurally from licensing-set inclusion and
+needs only `0 < e`; the counter-evaluative comparative is the sole
+prior-magnitude case and needs `1/100 ≤ e`.
 -/
 
 end BumfordRett2021

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -1,8 +1,8 @@
 import Linglib.Semantics.Degree.Gradability.Intensification
 import Linglib.Fragments.English.Predicates.Adjectival
-import Linglib.Pragmatics.RSA.Composition
-import Linglib.Tactics.RSAPredict
+import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.Rat.Defs
+import Mathlib.Tactic.FinCases
 
 /-!
 # [nouwen-2024] Deadjectival Intensifiers
@@ -33,38 +33,18 @@ functions). Our formalization uses |d − norm| and norm − |d − norm| respec
 (linear/triangular). Both preserve the qualitative shape: negative measures peak
 at extremes, positive measures peak at the norm.
 
-### Two-Threshold Simultaneous Model
+### Probabilistic model
 
-  P_L1(h, θ, θ_e | u) ∝ P_S1(u | h, θ, θ_e) × P(h) × P(θ) × P(θ_e)
-
-The listener jointly infers height h, adjective threshold θ, and
-evaluative threshold θ_e. The meaning function is an intersection:
-- bare_warm: h > θ
-- horribly_warm: (h > θ) ∧ (μ_horrible(h) > θ_e)
-- pleasantly_warm: (h > θ) ∧ (μ_pleasant(h) > θ_e)
-- silent: ⊤
-
-### Sequential Model ([nouwen-2024]'s key innovation)
-
-The evaluative adverb updates the prior before the adjective threshold
-applies: Step 1 infers P₁(h | "horribly"), Step 2 infers P₂(h | "warm")
-using P₁ as prior.
-
-### RSAConfig Mapping
-
-- **U** = `Utterance` (bare_warm, horribly_warm, pleasantly_warm, silent)
-- **W** = `Height` (Degree 6, 7 values: h0–h6)
-- **Latent** = `Threshold × Threshold` (36 values: θ_adj × θ_eval)
-- **s1Score** = beliefAction: `exp(α · (log L0 − C(u)))`
-- **α** = 4 (matching [lassiter-goodman-2017])
-- **C(bare)** = 1, **C(horribly/pleasantly)** = 2, **C(∅)** = 0
-
-### Performance Note
-
-Uses scale n=6 (7 heights, 6 thresholds) rather than the paper's continuous
-distribution or [lassiter-goodman-2017]'s n=10, giving 4.4× fewer L0 cells
-in the simultaneous model (1008 vs 4400) and 2.6× fewer in the sequential model.
-All qualitative Goldilocks predictions are preserved.
+The RSA model — the rejected simultaneous dual-threshold configuration
+(Nouwen's (49)) and the paper's final sequential/backgrounded chain
+(eqs. 50–51) — lives on the mathlib-PMF face in `Nouwen2024PMF`
+(`Linglib.Studies.Nouwen2024PMF`), where the predictions are proven
+structurally: ratio cancellation collapses each marginalised speaker to a
+mass-monotone sum over the licensed thresholds, and informativity
+monotonicity beats the prior ratio. This file houses the semantic layer:
+the intensifier lexicon, the meaning functions and their theory-layer
+grounding, the exact Goldilocks boundary, the Wheeler leak, and the
+licensing-support order.
 -/
 
 -- ============================================================================
@@ -598,10 +578,7 @@ end Nouwen2024.Intensifiers
 
 namespace RSA.Nouwen2024
 
--- Local scale: n=6 (Degree 6 = Fin 7, Threshold 6 = Fin 6)
--- Coarser than [lassiter-goodman-2017]'s n=10 for faster rsa_predict
--- (1008 vs 4400 L0 cells in the simultaneous model) while preserving
--- all qualitative Goldilocks predictions. Norm = 3.
+-- Local scale: n=6 (Degree 6 = Fin 7, Threshold 6 = Fin 6). Norm = 3.
 
 instance : NeZero (6 : Nat) := ⟨by omega⟩
 
@@ -629,14 +606,6 @@ def heightPrior (h : Height) : ℚ :=
   | 5 => 5
   | _ => 1
 
-noncomputable def heightPriorR (h : Height) : ℝ := heightPrior h
-
-theorem heightPriorR_nonneg : ∀ h : Height, 0 ≤ heightPriorR h := by
-  intro h; simp only [heightPriorR]
-  exact_mod_cast (by
-    unfold heightPrior
-    split <;> norm_num : (0 : ℚ) ≤ heightPrior h)
-
 -- Utterances
 
 /--
@@ -654,7 +623,7 @@ inductive Utterance where
 def allUtterances : List Utterance :=
   [.bare_warm, .horribly_warm, .pleasantly_warm, .silent]
 
--- Evaluative Measures (ℕ-valued for rsa_predict reification)
+-- Evaluative Measures (ℕ-valued)
 
 /--
 Evaluative measure for "horrible" applied to the Height domain.
@@ -871,144 +840,16 @@ def utteranceCost : Utterance → ℚ
   | .silent          => 0
 
 -- ============================================================================
--- RSAConfig (simultaneous dual-threshold model)
--- ============================================================================
-
-open Real (exp log exp_pos)
-
-noncomputable def utteranceCostR (u : Utterance) : ℝ := ↑(utteranceCost u)
-
-/-- S1 scoring rule: exp(α · (log L0(h|u,θ,θ_e) − C(u))), gated at L0=0.
-    Identical to [lassiter-goodman-2017]'s beliefAction but with
-    Latent = Threshold × Threshold for the dual-threshold model. -/
-noncomputable def intensifierS1Score :
-    (Utterance → Height → ℝ) → ℝ → (Threshold × Threshold) → Height → Utterance → ℝ :=
-  fun l0 α _ w u =>
-    if l0 u w = 0 then 0
-    else exp (α * (log (l0 u w) - utteranceCostR u))
-
-theorem intensifierS1Score_nonneg :
-    ∀ (l0 : Utterance → Height → ℝ) (α : ℝ) (l : Threshold × Threshold)
-      (w : Height) (u : Utterance),
-    (∀ u' w', 0 ≤ l0 u' w') → 0 < α → 0 ≤ intensifierS1Score l0 α l w u := by
-  intro _ _ _ _ _ _ _; simp only [intensifierS1Score]; split
-  · exact le_refl 0
-  · exact le_of_lt (exp_pos _)
-
-/-- RSAConfig for the simultaneous dual-threshold model.
-
-    Extends [lassiter-goodman-2017] threshold RSA with a second threshold
-    for the evaluative adverb. L1 jointly infers height, adjective threshold,
-    and evaluative threshold:
-
-      P_L1(h, θ, θ_e | u) ∝ P_S1(u | h, θ, θ_e) · P(h) · P(θ) · P(θ_e)
-
-    The meaning function uses local ℕ-valued evaluative measures, proved
-    equivalent to `Intensification.intensifiedMeaning` by
-    `meaning_grounded_horribly` and `meaning_grounded_pleasantly`. -/
-@[reducible]
-noncomputable def nouwenCfg : RSA.RSAConfig Utterance Height where
-  Latent := Threshold × Threshold
-  meaning _ l u h := if meaning u h l.1 l.2 then heightPriorR h else 0
-  meaning_nonneg _ l u h := by
-    show 0 ≤ if meaning u h l.1 l.2 then heightPriorR h else 0
-    split
-    · exact heightPriorR_nonneg h
-    · exact le_refl 0
-  s1Score := intensifierS1Score
-  s1Score_nonneg := intensifierS1Score_nonneg
-  α := 4
-  α_pos := by norm_num
-  worldPrior := heightPriorR
-  worldPrior_nonneg := heightPriorR_nonneg
-  latentPrior_nonneg _ _ := by positivity
-
--- ============================================================================
--- Goldilocks Effect Predictions (simultaneous model)
--- ============================================================================
-
-/-! ### H-adverb: "horribly warm" shifts height toward extremes
-
-The Goldilocks effect for negative-evaluative bases: μ_horrible(h) = |h − norm|
-peaks at extremes, so L1 hearing "horribly warm" concentrates probability
-on extreme heights. Heights near the norm (h=3) have μ_horrible = 0
-and cannot satisfy the evaluative positive form at any θ_e. -/
-
-theorem horribly_shifts_upward :
-    nouwenCfg.L1 .horribly_warm (deg 5) > nouwenCfg.L1 .horribly_warm (deg 2) := by
-  rsa_predict
-
-theorem horribly_implies_warm :
-    nouwenCfg.L1 .horribly_warm (deg 5) > nouwenCfg.L1 .horribly_warm (deg 1) := by
-  rsa_predict
-
-/-! ### M-adverb: "pleasantly warm" concentrates at moderate heights
-
-The Goldilocks effect for positive-evaluative bases: μ_pleasant(h) = norm − |h − norm|
-peaks at the norm (h=3), so L1 hearing "pleasantly warm" concentrates
-probability on moderate heights. Extreme heights (h=5,6) have
-low μ_pleasant and cannot satisfy the evaluative positive form. -/
-
-theorem pleasantly_prefers_moderate :
-    nouwenCfg.L1 .pleasantly_warm (deg 4) > nouwenCfg.L1 .pleasantly_warm (deg 6) := by
-  rsa_predict
-
-theorem pleasantly_implies_warm :
-    nouwenCfg.L1 .pleasantly_warm (deg 4) > nouwenCfg.L1 .pleasantly_warm (deg 1) := by
-  rsa_predict
-
-/-! ### Cross-utterance Goldilocks predictions
-
-The core Goldilocks effect is a cross-utterance phenomenon: intensifiers
-redistribute probability mass relative to the bare adjective. "Horribly warm"
-assigns MORE probability to extreme heights than "warm" does; "pleasantly warm"
-assigns MORE to moderate heights than "warm" does. -/
-
-/-- At extreme heights, "horribly warm" assigns more probability than "warm". -/
-theorem horribly_above_bare_at_extreme :
-    nouwenCfg.L1 .horribly_warm (deg 5) > nouwenCfg.L1 .bare_warm (deg 5) := by
-  rsa_predict
-
-/-- At moderate heights, "pleasantly warm" assigns more probability than "warm". -/
-theorem pleasantly_above_bare_at_moderate :
-    nouwenCfg.L1 .pleasantly_warm (deg 4) > nouwenCfg.L1 .bare_warm (deg 4) := by
-  rsa_predict
-
-/-- At extreme heights, "horribly warm" dominates "pleasantly warm". -/
-theorem horribly_dominates_pleasantly_at_extreme :
-    nouwenCfg.L1 .horribly_warm (deg 6) > nouwenCfg.L1 .pleasantly_warm (deg 6) := by
-  rsa_predict
-
-/-- At moderate heights, "pleasantly warm" dominates "horribly warm". -/
-theorem pleasantly_dominates_horribly_at_moderate :
-    nouwenCfg.L1 .pleasantly_warm (deg 4) > nouwenCfg.L1 .horribly_warm (deg 4) := by
-  rsa_predict
-
--- ============================================================================
 -- Sequential Model (key innovation)
 -- ============================================================================
 
-/-! ## Sequential Dual-Threshold Model
+/-! ## Sequential Dual-Threshold Model — types
 
-key theoretical contribution: the evaluative adverb and
-base adjective apply sequentially rather than simultaneously. The listener
-first updates beliefs via the evaluative measure, then applies the adjective
-threshold to the resulting posterior:
-
-  Step 1: P₁(h | "horribly") ∝ P_S1(eval_pos | h, θ_e) · P(h) · P(θ_e)
-  Step 2: P₂(h | "warm") ∝ P_S1(warm | h, θ) · P₁(h) · P(θ)
-
-This sequential model makes the same Goldilocks predictions as the
-simultaneous model for simple cases, but differs for complex constructions
-(e.g., "horribly pleasantly warm").
-
-### Implementation
-
-Two RSAConfigs composed: the evaluative step's L1 posterior feeds as the
-adjective step's worldPrior. This uses RSAConfig composition rather than
-the Ctx/transition machinery, which is designed for sequential *production*
-(word-by-word S1 choices), not sequential *comprehension* (listener updating
-beliefs step by step). -/
+[nouwen-2024]'s key innovation: the evaluative adverb and base adjective
+apply sequentially — the listener first updates on the evaluative measure,
+then applies the adjective threshold to the resulting posterior (eqs. 50–51).
+The chain itself and its predictions live in `Nouwen2024PMF`; this section
+provides the stage utterance types, meanings, and costs it consumes. -/
 
 -- Step 1: Evaluative update
 
@@ -1032,42 +873,6 @@ def evalCost : EvalUtterance → ℚ
   | .eval_pos => 1
   | .silent   => 0
 
-noncomputable def evalCostR (u : EvalUtterance) : ℝ := ↑(evalCost u)
-
-noncomputable def evalS1Score :
-    (EvalUtterance → Height → ℝ) → ℝ → Threshold → Height → EvalUtterance → ℝ :=
-  fun l0 α _ w u =>
-    if l0 u w = 0 then 0
-    else exp (α * (log (l0 u w) - evalCostR u))
-
-theorem evalS1Score_nonneg :
-    ∀ (l0 : EvalUtterance → Height → ℝ) (α : ℝ) (l : Threshold)
-      (w : Height) (u : EvalUtterance),
-    (∀ u' w', 0 ≤ l0 u' w') → 0 < α → 0 ≤ evalS1Score l0 α l w u := by
-  intro _ _ _ _ _ _ _; simp only [evalS1Score]; split
-  · exact le_refl 0
-  · exact le_of_lt (exp_pos _)
-
-/-- RSAConfig for the evaluative step with a given measure function.
-
-    L1 hears the evaluative form and infers a posterior over heights,
-    marginalizing over the evaluative threshold θ_e. -/
-@[reducible]
-noncomputable def evalCfg (evalMu : Height → ℕ) : RSA.RSAConfig EvalUtterance Height where
-  Latent := Threshold
-  meaning _ l u h := if evalMeaning evalMu u h l then heightPriorR h else 0
-  meaning_nonneg _ l u h := by
-    show 0 ≤ if evalMeaning evalMu u h l then heightPriorR h else 0
-    split
-    · exact heightPriorR_nonneg h
-    · exact le_refl 0
-  s1Score := evalS1Score
-  s1Score_nonneg := evalS1Score_nonneg
-  α := 4
-  α_pos := by norm_num
-  worldPrior := heightPriorR
-  worldPrior_nonneg := heightPriorR_nonneg
-  latentPrior_nonneg _ _ := by positivity
 
 -- Step 2: Adjective update with updated prior
 
@@ -1086,205 +891,5 @@ def adjMeaning (u : AdjUtterance) (h : Height) (θ : Threshold) : Bool :=
 def adjCost : AdjUtterance → ℚ
   | .warm   => 1
   | .silent => 0
-
-noncomputable def adjCostR (u : AdjUtterance) : ℝ := ↑(adjCost u)
-
-noncomputable def adjS1Score :
-    (AdjUtterance → Height → ℝ) → ℝ → Threshold → Height → AdjUtterance → ℝ :=
-  fun l0 α _ w u =>
-    if l0 u w = 0 then 0
-    else exp (α * (log (l0 u w) - adjCostR u))
-
-theorem adjS1Score_nonneg :
-    ∀ (l0 : AdjUtterance → Height → ℝ) (α : ℝ) (l : Threshold)
-      (w : Height) (u : AdjUtterance),
-    (∀ u' w', 0 ≤ l0 u' w') → 0 < α → 0 ≤ adjS1Score l0 α l w u := by
-  intro _ _ _ _ _ _ _; simp only [adjS1Score]; split
-  · exact le_refl 0
-  · exact le_of_lt (exp_pos _)
-
-/-- Adjective-stage config before prior threading: the evaluative posterior
-    enters the literal listener's normalization via `meaning` (the L&G
-    placement); the world prior is left at its default, to be overridden
-    by `RSA.RSAConfig.composeWithPrior` in `seqAdjCfg`. -/
-@[reducible]
-noncomputable def adjStageCfg (evalMu : Height → ℕ) : RSA.RSAConfig AdjUtterance Height where
-  Latent := Threshold
-  meaning _ l u h := if adjMeaning u h l then (evalCfg evalMu).L1 .eval_pos h else 0
-  meaning_nonneg _ l u h := by
-    show 0 ≤ if adjMeaning u h l then (evalCfg evalMu).L1 .eval_pos h else 0
-    split
-    · exact (evalCfg evalMu).L1agent.policy_nonneg .eval_pos h
-    · exact le_refl 0
-  s1Score := adjS1Score
-  s1Score_nonneg := adjS1Score_nonneg
-  α := 4
-  α_pos := by norm_num
-  worldPrior_nonneg _ := zero_le_one
-  latentPrior_nonneg _ _ := by positivity
-
-/-- RSAConfig for the adjective step with the evaluative posterior as
-    L0 prior AND L1 worldPrior.
-
-    Implements [nouwen-2024] eq (73): the second update applies
-    L&G's pragmatic listener (eq 71) with prior `Π = (evalCfg evalMu).L1
-    .eval_pos`. Per L&G, that prior enters in TWO places —
-    inside the literal listener's normalization (via `adjStageCfg`'s
-    `meaning`) AND in the pragmatic listener's Bayesian inversion (via
-    `composeWithPrior`'s worldPrior override). Both copies are intentional
-    and faithful to the paper, NOT double-counting. The expanded formula is:
-
-      P₂(h | "warm") ∝ Π(h) · Σ_θ P(θ) · S1("warm" | h, θ, Π)
-
-    where S1 has Π baked in via the literal listener π in its
-    log-utility `ln π(h | "warm", θ, Π) - cost`. The "P_S1 · L1_eval · P(θ)"
-    shorthand from the prose section above is true at the L1 layer but
-    elides the L1_eval that also lives inside `P_S1`'s own
-    L&G-style L0 normalization. -/
-@[reducible]
-noncomputable def seqAdjCfg (evalMu : Height → ℕ) : RSA.RSAConfig AdjUtterance Height :=
-  (evalCfg evalMu).composeWithPrior .eval_pos (adjStageCfg evalMu)
-
-/-- Sequential L1 posterior for "horribly warm": evaluative step uses μ_horrible,
-    then adjective step applies the base "warm" meaning. -/
-noncomputable def seqL1_horribly (h : Height) : ℝ :=
-  (seqAdjCfg muHorrible).L1 .warm h
-
-/-- Sequential L1 posterior for "pleasantly warm": evaluative step uses μ_pleasant,
-    then adjective step applies the base "warm" meaning. -/
-noncomputable def seqL1_pleasantly (h : Height) : ℝ :=
-  (seqAdjCfg muPleasant).L1 .warm h
-
--- Sequential Goldilocks Predictions
-
-/-! ### Sequential Goldilocks: same qualitative predictions as simultaneous
-
-The sequential model produces the same Goldilocks pattern: "horribly warm"
-shifts probability toward extremes, "pleasantly warm" concentrates at moderate
-heights. The sequential decomposition affects the quantitative distribution
-but preserves the qualitative ordering. -/
-
-/-- Sequential "horribly warm" shifts upward (Goldilocks). -/
-theorem seq_horribly_shifts_upward :
-    (seqAdjCfg muHorrible).L1 .warm (deg 5) > (seqAdjCfg muHorrible).L1 .warm (deg 2) := by
-  rsa_predict
-
-/-- Sequential "pleasantly warm" prefers moderate heights (Goldilocks). -/
-theorem seq_pleasantly_prefers_moderate :
-    (seqAdjCfg muPleasant).L1 .warm (deg 4) > (seqAdjCfg muPleasant).L1 .warm (deg 6) := by
-  rsa_predict
-
--- ============================================================================
--- Zwicky's Generalization: RSA-Derived Predictions
--- ============================================================================
-
-/-! ## Zwicky Vacuity: Derived from RSA
-
-§5: Positive modal adverbs (*usually, *expectedly) cannot
-serve as intensifiers because their evaluative measure is constant across
-heights, providing no discriminating information about degree. In the
-sequential model, the evaluative step with a constant measure preserves
-the prior's bell-curve shape — "usually warm" offers no intensifying
-information beyond bare "warm".
-
-In contrast, negative modal measures (unusual ≈ horrible) peak at extremes,
-shifting the evaluative posterior away from the norm and producing genuine
-intensification. This is why negative modals pattern with negative evaluatives
-in the Goldilocks effect.
-
-The theorems below derive Zwicky's generalization from the sequential RSA
-model, connecting the data-layer check (`zwickyHolds`) to L1 posterior
-predictions. -/
-
-/-- ℕ-valued constant measure for the sequential model.
-    Models "usual": μ_usual(h) = 3 for all h (no height discrimination). -/
-def muUsualN : Height → ℕ := λ _ => 3
-
-/-- μ_unusual has the same shape as μ_horrible: peaks at extremes.
-    Deviation-denoting adjectives (unusual, impossible) pattern with
-    negative evaluatives (horrible, terrible) because both assign high
-    values to heights far from the norm (§5). -/
-def muUnusualN : Height → ℕ := muHorrible
-
-/-- Deviation measures and negative evaluative measures are structurally
-    identical. This is the semantic foundation of why both types make good
-    intensifiers — "the corresponding measure function has a shape similar
-    to that of negative evaluatives" (§5). -/
-theorem muUnusualN_eq_muHorrible : muUnusualN = muHorrible := rfl
-
-/-- Bare adjective RSAConfig: "warm" vs silence with the original height prior.
-    This is the baseline — what "warm" means without any evaluative step. -/
-@[reducible]
-noncomputable def bareAdjCfg : RSA.RSAConfig AdjUtterance Height where
-  Latent := Threshold
-  meaning _ l u h := if adjMeaning u h l then heightPriorR h else 0
-  meaning_nonneg _ l u h := by
-    show 0 ≤ if adjMeaning u h l then heightPriorR h else 0
-    split
-    · exact heightPriorR_nonneg h
-    · exact le_refl 0
-  s1Score := adjS1Score
-  s1Score_nonneg := adjS1Score_nonneg
-  α := 4
-  α_pos := by norm_num
-  worldPrior := heightPriorR
-  worldPrior_nonneg := heightPriorR_nonneg
-  latentPrior_nonneg _ _ := by positivity
-
-/-! ### Evaluative Step: Constant vs Extreme Measures -/
-
-/-- Constant-measure evaluative step preserves the prior's peak at the norm. -/
-theorem eval_constant_preserves_peak :
-    (evalCfg muUsualN).L1 .eval_pos (deg 3) >
-    (evalCfg muUsualN).L1 .eval_pos (deg 6) := by
-  rsa_predict
-
-/-- Extreme measure (unusual/horrible) boosts extreme heights in L1
-    beyond what the constant measure assigns. -/
-theorem eval_unusual_boosts_extreme :
-    (evalCfg muUnusualN).L1 .eval_pos (deg 6) >
-    (evalCfg muUsualN).L1 .eval_pos (deg 6) := by
-  rsa_predict
-
-/-! ### Sequential Model: Zwicky Predictions -/
-
-/-- "Usually warm" preserves moderate-height preference (like bare "warm"). -/
-theorem usually_warm_prefers_moderate :
-    (seqAdjCfg muUsualN).L1 .warm (deg 4) >
-    (seqAdjCfg muUsualN).L1 .warm (deg 6) := by
-  rsa_predict
-
-/-- "Unusually warm" shifts toward extremes (like "horribly warm").
-    Note: `muUnusualN = muHorrible` by `muUnusualN_eq_muHorrible`,
-    so this is structurally the same prediction as `seq_horribly_shifts_upward`. -/
-theorem unusually_warm_shifts_extreme :
-    (seqAdjCfg muUnusualN).L1 .warm (deg 5) >
-    (seqAdjCfg muUnusualN).L1 .warm (deg 2) := by
-  rsa_predict
-
-set_option maxHeartbeats 800000 in
-/-- **Zwicky's generalization, derived**: at extreme heights, "unusually warm"
-    assigns more probability than "usually warm". Negative modal intensifiers
-    are more informative than positive modal ones because μ_unusual discriminates
-    heights while μ_usual does not. -/
-theorem zwicky_extreme_discrimination :
-    (seqAdjCfg muUnusualN).L1 .warm (deg 6) >
-    (seqAdjCfg muUsualN).L1 .warm (deg 6) := by
-  rsa_predict
-
-set_option maxHeartbeats 800000 in
-/-- Converse: at moderate heights, "usually warm" dominates "unusually warm".
-    The constant measure concentrates mass near the prior peak, while the
-    extreme measure depletes mass at moderate heights. -/
-theorem zwicky_moderate_discrimination :
-    (seqAdjCfg muUsualN).L1 .warm (deg 4) >
-    (seqAdjCfg muUnusualN).L1 .warm (deg 4) := by
-  rsa_predict
-
-/-- Bare "warm" baseline: prefers moderate heights (deg 4 > deg 6).
-    Demonstrates that the bare model and "usually warm" agree qualitatively. -/
-theorem bare_warm_prefers_moderate :
-    bareAdjCfg.L1 .warm (deg 4) > bareAdjCfg.L1 .warm (deg 6) := by
-  rsa_predict
 
 end RSA.Nouwen2024

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -740,6 +740,98 @@ theorem meaning_grounded_pleasantly (h : Height) (θ θ_e : Threshold) :
              Semantics.Gradability.Intensification.intensifiedMeaning,
              muPleasant_eq, Nat.cast_lt]
 
+-- Structural Semantics: Goldilocks, Wheeler, and Licensing Support
+
+/-! ### The Goldilocks effect as a set-theoretic fact
+
+[nouwen-2024] p. 21: "horribly warm will end up being compatible only with the
+higher degrees in this range. Note that extremely low temperatures are also
+horrible, but they are not in the interval [d, d′], because we arrived at that
+interval using the positive form of the adjective." The paper calls Goldilocks
+"merely a tendency" (p. 9; fn. 14 notes the expressive-taboo exception). On
+this scale the tendency has an exact boundary — `θ + θ_e ≥ 2`
+(`horriblyWarm_upperClosed_iff`): below it the intensified meaning leaks into
+the cold tail, which is precisely the Wheeler problem of the paper's Fig. 5
+(`wheeler_cold_leak`). -/
+
+/-- `S` is upward closed within `B`: any `B`-world at least as high as some
+`S`-world is itself in `S`. -/
+def UpwardClosedWithin (S B : Height → Bool) : Prop :=
+  ∀ h h', S h = true → B h' = true → h.toNat ≤ h'.toNat → S h' = true
+
+instance (S B : Height → Bool) : Decidable (UpwardClosedWithin S B) := by
+  unfold UpwardClosedWithin; infer_instance
+
+/-- **Goldilocks, exactly**: *horribly warm* is an upper set within *warm* iff
+the adjectival and evaluative thresholds jointly reach the `norm − 1`
+boundary (`θ + θ_e ≥ 2` on the Degree-6 scale, norm = 3). The U-shaped
+`μ_horrible` targets both scale extremes, but the positive form of *warm* has
+already cut off the cold end whenever the thresholds are high enough. -/
+theorem horriblyWarm_upperClosed_iff (θ θ_e : Threshold) :
+    UpwardClosedWithin (fun h => meaning .horribly_warm h θ θ_e)
+      (fun h => meaning .bare_warm h θ θ_e) ↔ 2 ≤ θ.toNat + θ_e.toNat := by
+  revert θ θ_e; decide
+
+/-- Positive evaluations are "reserved for the middle of a scale"
+([nouwen-2024] p. 21): whenever *pleasantly warm* is satisfiable at all, it is
+never an upper set within *warm* — the mid-peaked `μ_pleasant` cannot produce
+upper-tail intensification. (The nonemptiness guard excludes the vacuous
+`θ_e ≥ 3` cases, where no height is pleasant enough.) -/
+theorem pleasantlyWarm_never_upperClosed (θ θ_e : Threshold)
+    (hne : ∃ h, meaning .pleasantly_warm h θ θ_e = true) :
+    ¬ UpwardClosedWithin (fun h => meaning .pleasantly_warm h θ θ_e)
+      (fun h => meaning .bare_warm h θ θ_e) := by
+  revert θ θ_e; decide
+
+/-- **The Wheeler leak** ([nouwen-2024] Fig. 5, p. 27: "horribly warm is not
+(entirely) incompatible with things being horribly cold"): below the
+Goldilocks boundary, *horribly warm* is true at cold heights. This is the
+semantic root of the problem the paper's backgrounded (sequential) update is
+designed to mitigate. -/
+theorem wheeler_cold_leak :
+    ∃ (θ θ_e : Threshold) (h : Height),
+      h.toNat < 3 ∧ meaning .horribly_warm h θ θ_e = true := by
+  decide
+
+/-! ### Licensing support: the proof engine for the pragmatic shifts
+
+The latent pairs licensing an utterance at a world form the rectangle
+`[0, h) × [0, μ(h))`, so support inclusion is componentwise dominance in the
+two measures: higher-and-more-extreme worlds license strictly more latents —
+the structural mechanism behind upward intensification (the pragmatic
+listener sums over licensed latents). -/
+
+/-- The latent threshold pairs at which `u` is true at `h`. -/
+def licensingSet (u : Utterance) (h : Height) : Finset (Threshold × Threshold) :=
+  Finset.univ.filter fun l => meaning u h l.1 l.2
+
+/-- Componentwise measure dominance yields licensing-support inclusion:
+if `w₁` is at least as high and at least as extreme as `w₂`, every latent
+licensing *horribly warm* at `w₂` licenses it at `w₁`. -/
+theorem licensingSet_horribly_mono {w₂ w₁ : Height}
+    (hw : w₂.toNat ≤ w₁.toNat) (hμ : muHorrible w₂ ≤ muHorrible w₁) :
+    licensingSet .horribly_warm w₂ ⊆ licensingSet .horribly_warm w₁ := by
+  intro l hl
+  simp only [licensingSet, Finset.mem_filter, Finset.mem_univ, true_and, meaning,
+    tallMeaning, Bool.and_eq_true, decide_eq_true_eq] at hl ⊢
+  obtain ⟨h1, h2⟩ := hl
+  exact ⟨lt_of_lt_of_le h1 (by exact_mod_cast hw), by omega⟩
+
+/-- The file's key comparison pair has *strict* support inclusion: the extreme
+height `deg 5` licenses strictly more latents than the moderate `deg 2`. -/
+theorem licensingSet_deg2_ssubset_deg5 :
+    licensingSet .horribly_warm (deg 2) ⊂ licensingSet .horribly_warm (deg 5) := by
+  decide
+
+/-- Licensing support is **not** totally ordered: below the norm, lower
+heights are warmer-false but more extreme, so their supports are
+incomparable — the inclusion order is exactly componentwise dominance, not a
+chain. -/
+theorem licensingSet_not_totalOrder :
+    ¬ (licensingSet .horribly_warm (deg 1) ⊆ licensingSet .horribly_warm (deg 2)) ∧
+    ¬ (licensingSet .horribly_warm (deg 2) ⊆ licensingSet .horribly_warm (deg 1)) := by
+  decide
+
 -- Zwicky Vacuity
 
 /--

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -1016,6 +1016,256 @@ theorem sim_sharedSupport_dominance_fails :
       _ = 2 * heightPriorPMF (deg 5) * v := by ring
   exact absurd (hforall _ hmem) (not_le.mpr hkey)
 
+/-! ## §5d. Measure-generic evaluative stage; the pleasantly chain
+
+The horrible chain (§3–§5) instantiates the architecture with
+measure-specific definitions; the dite-total generic forms below serve the
+remaining measures (μ_pleasant here, μ_usual for the Zwicky section)
+without threading extension-positivity hypotheses. -/
+
+/-- Measure-generic stage-1 literal listener (dite-total). -/
+noncomputable def evalL0At (evalMu : Height → ℕ) (vt : ValidThreshold)
+    (u : EvalUtterance) : PMF Height :=
+  if h_pos : (∑' h, heightPriorPMF h *
+      (if evalLex evalMu (validToThreshold vt) u h then (1 : ℝ≥0∞) else 0)) ≠ 0 then
+    RSA.L0LassiterGoodman heightPriorPMF (evalLex evalMu (validToThreshold vt)) u h_pos
+  else PMF.uniformOfFintype Height
+
+/-- Measure-generic stage-1 speaker (dite-total). -/
+noncomputable def evalSpeakerAt (evalMu : Height → ℕ) (vt : ValidThreshold)
+    (w : Height) : PMF EvalUtterance :=
+  if h_pos : (∑' u, ((evalL0At evalMu vt) u w : ℝ≥0∞) ^ (4 : ℝ) *
+      evalCostFactor u) ≠ 0 then
+    RSA.S1Belief (evalL0At evalMu vt) evalCostFactor 4 w h_pos
+      (ENNReal.tsum_ne_top_of_fintype fun u =>
+        ENNReal.mul_ne_top
+          (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+          (evalCostFactor_finite u))
+  else PMF.pure .silent
+
+/-- Measure-generic marginalized stage-1 speaker. -/
+noncomputable def evalMarginalAt (evalMu : Height → ℕ) : Height → PMF EvalUtterance :=
+  RSA.marginalizeKernel thresholdPriorPMF (fun vt w => evalSpeakerAt evalMu vt w)
+
+theorem evalL0At_silent (evalMu : Height → ℕ) (vt : ValidThreshold) (w : Height) :
+    evalL0At evalMu vt .silent w = heightPriorPMF w := by
+  have hm : (∑' h, heightPriorPMF h *
+      (if evalLex evalMu (validToThreshold vt) .silent h then (1 : ℝ≥0∞) else 0)) = 1 := by
+    simp only [show ∀ h, evalLex evalMu (validToThreshold vt) .silent h = true from
+      fun _ => rfl, if_true, mul_one]
+    exact PMF.tsum_coe _
+  unfold evalL0At
+  rw [dif_pos (by rw [hm]; exact one_ne_zero)]
+  exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl) _ _
+
+private theorem evalSpeakerAt_h_pos (evalMu : Height → ℕ) (vt : ValidThreshold)
+    (w : Height) :
+    (∑' u, ((evalL0At evalMu vt) u w : ℝ≥0∞) ^ (4 : ℝ) * evalCostFactor u) ≠ 0 := by
+  rw [sumEvalUtt]
+  intro hz
+  rcases mul_eq_zero.mp (add_eq_zero.mp hz).2 with h5 | h5
+  · rw [evalL0At_silent] at h5
+    rcases ENNReal.rpow_eq_zero_iff.mp h5 with ⟨hz0, -⟩ | ⟨-, hneg⟩
+    · exact heightPriorPMF_pos w hz0
+    · norm_num at hneg
+  · exact evalCostFactor_pos .silent h5
+
+/-- Generic off-support zero (given a nonempty `.eval_pos` extension). -/
+theorem evalSpeakerAt_apply_of_false (evalMu : Height → ℕ) (vt : ValidThreshold)
+    (w : Height)
+    (hne : (∑' h, heightPriorPMF h *
+      (if evalLex evalMu (validToThreshold vt) .eval_pos h then (1 : ℝ≥0∞) else 0)) ≠ 0)
+    (hw : evalLex evalMu (validToThreshold vt) .eval_pos w = false) :
+    evalSpeakerAt evalMu vt w .eval_pos = 0 := by
+  have hL0 : evalL0At evalMu vt .eval_pos w = 0 := by
+    unfold evalL0At
+    rw [dif_pos hne, RSA.L0LassiterGoodman_apply, hw]
+    simp
+  unfold evalSpeakerAt
+  rw [dif_pos (evalSpeakerAt_h_pos evalMu vt w), RSA.S1Belief_apply, hL0,
+    ENNReal.zero_rpow_of_pos (by norm_num), zero_mul, zero_mul]
+
+/-- Generic on-support positivity (given a nonempty `.eval_pos` extension). -/
+theorem evalSpeakerAt_apply_ne_zero_of_true (evalMu : Height → ℕ) (vt : ValidThreshold)
+    (w : Height)
+    (hne : (∑' h, heightPriorPMF h *
+      (if evalLex evalMu (validToThreshold vt) .eval_pos h then (1 : ℝ≥0∞) else 0)) ≠ 0)
+    (hw : evalLex evalMu (validToThreshold vt) .eval_pos w = true) :
+    evalSpeakerAt evalMu vt w .eval_pos ≠ 0 := by
+  have hL0 : evalL0At evalMu vt .eval_pos w ≠ 0 := by
+    unfold evalL0At
+    rw [dif_pos hne, ← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
+    exact ⟨heightPriorPMF_pos w, hw⟩
+  unfold evalSpeakerAt
+  rw [dif_pos (evalSpeakerAt_h_pos evalMu vt w)]
+  exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 (evalCostFactor_pos _)
+
+/-- Nonempty `.eval_pos` extension for μ_pleasant at every valid threshold
+(witness `deg 3`, where `μ_pleasant = 3`). -/
+theorem evalMass_pleasant_ne_zero (vt : ValidThreshold) :
+    (∑' h, heightPriorPMF h *
+      (if evalLex muPleasant (validToThreshold vt) .eval_pos h then (1 : ℝ≥0∞) else 0)) ≠ 0 := by
+  apply ENNReal.summable.tsum_ne_zero_iff.mpr
+  refine ⟨deg 3, ?_⟩
+  have ht : evalLex muPleasant (validToThreshold vt) .eval_pos (deg 3) = true := by
+    revert vt; decide
+  rw [ht]
+  simp only [if_true, mul_one]
+  exact heightPriorPMF_pos _
+
+/-- Backgrounded prior for "pleasantly": stage-1 posterior under μ_pleasant. -/
+noncomputable def priorAfterEvalPosPleasant : PMF Height :=
+  PMF.posterior (evalMarginalAt muPleasant) heightPriorPMF .eval_pos
+    (PMF.marginal_ne_zero _ _ _ (heightPriorPMF_pos (deg 3)) (by
+      unfold evalMarginalAt
+      rw [RSA.marginalizeKernel_apply]
+      apply ENNReal.summable.tsum_ne_zero_iff.mpr
+      refine ⟨0, mul_ne_zero ?_ ?_⟩
+      · rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]; simp
+      · exact evalSpeakerAt_apply_ne_zero_of_true muPleasant 0 (deg 3)
+          (evalMass_pleasant_ne_zero 0) (by decide)))
+
+/-- Π_pleasant is positive at heights with positive `μ_pleasant`. -/
+theorem priorAfterEvalPosPleasant_pos_at {h : Height} (hpos : 0 < muPleasant h) :
+    priorAfterEvalPosPleasant h ≠ 0 := by
+  unfold priorAfterEvalPosPleasant
+  rw [← PMF.mem_support_iff, PMF.mem_support_posterior_iff]
+  refine ⟨heightPriorPMF_pos h, ?_⟩
+  unfold evalMarginalAt
+  rw [RSA.marginalizeKernel_apply]
+  apply ENNReal.summable.tsum_ne_zero_iff.mpr
+  refine ⟨0, mul_ne_zero ?_ ?_⟩
+  · rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]; simp
+  · refine evalSpeakerAt_apply_ne_zero_of_true muPleasant 0 h
+      (evalMass_pleasant_ne_zero 0) ?_
+    have h0 : (validToThreshold 0).toNat = 0 := rfl
+    simp only [evalLex, evalMeaning, h0]
+    exact decide_eq_true (by omega)
+
+/-- Stage-2 literal listener for the pleasantly chain (dite-total, prior Π_pleasant). -/
+noncomputable def adjL0PleasantAt (vt : ValidThreshold)
+    (u : RSA.Nouwen2024.AdjUtterance) : PMF Height :=
+  if h_pos : (∑' h, priorAfterEvalPosPleasant h *
+      (if adjLex (validToThreshold vt) u h then (1 : ℝ≥0∞) else 0)) ≠ 0 then
+    RSA.L0LassiterGoodman priorAfterEvalPosPleasant (adjLex (validToThreshold vt)) u h_pos
+  else PMF.uniformOfFintype Height
+
+/-- Stage-2 speaker for the pleasantly chain (dite-total). -/
+noncomputable def adjSpeakerPleasantAt (vt : ValidThreshold) (w : Height) :
+    PMF (RSA.Nouwen2024.AdjUtterance) :=
+  if h_pos : (∑' u, ((adjL0PleasantAt vt) u w : ℝ≥0∞) ^ (4 : ℝ) * adjCostFactor u) ≠ 0 then
+    RSA.S1Belief (adjL0PleasantAt vt) adjCostFactor 4 w h_pos
+      (ENNReal.tsum_ne_top_of_fintype fun u =>
+        ENNReal.mul_ne_top
+          (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+          (by unfold adjCostFactor; exact ENNReal.ofReal_ne_top))
+  else PMF.pure .silent
+
+/-- Marginalized stage-2 speaker for the pleasantly chain. -/
+noncomputable def adjMarginalPleasant : Height → PMF AdjUtterance :=
+  RSA.marginalizeKernel thresholdPriorPMF (fun vt w => adjSpeakerPleasantAt vt w)
+
+/-- Nonempty `.warm` extension over Π_pleasant at threshold 0 (witness `deg 4`). -/
+private theorem adjMass_pleasant_zero_ne_zero :
+    (∑' h, priorAfterEvalPosPleasant h *
+      (if adjLex (validToThreshold 0) .warm h then (1 : ℝ≥0∞) else 0)) ≠ 0 := by
+  apply ENNReal.summable.tsum_ne_zero_iff.mpr
+  refine ⟨deg 4, ?_⟩
+  rw [show adjLex (validToThreshold 0) .warm (deg 4) = true from by decide]
+  simp only [if_true, mul_one]
+  exact priorAfterEvalPosPleasant_pos_at (by decide)
+
+/-- The stage-2 pleasantly speaker is positive on `.warm` at `deg 4`, `vt = 0`. -/
+private theorem adjSpeakerPleasant_warm_deg4_ne_zero :
+    adjSpeakerPleasantAt 0 (deg 4) .warm ≠ 0 := by
+  have hL0 : adjL0PleasantAt 0 .warm (deg 4) ≠ 0 := by
+    unfold adjL0PleasantAt
+    rw [dif_pos adjMass_pleasant_zero_ne_zero, ← PMF.mem_support_iff,
+      RSA.mem_support_L0LassiterGoodman_iff]
+    exact ⟨priorAfterEvalPosPleasant_pos_at (by decide), by decide⟩
+  have h_pos : (∑' u, ((adjL0PleasantAt 0) u (deg 4) : ℝ≥0∞) ^ (4 : ℝ) *
+      adjCostFactor u) ≠ 0 := by
+    apply ENNReal.summable.tsum_ne_zero_iff.mpr
+    refine ⟨.warm, mul_ne_zero ?_ ?_⟩
+    · exact (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hL0) (PMF.apply_ne_top _ _)).ne'
+    · unfold adjCostFactor
+      rw [ENNReal.ofReal_ne_zero_iff]
+      exact Real.exp_pos _
+  unfold adjSpeakerPleasantAt
+  rw [dif_pos h_pos]
+  exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 (by
+    unfold adjCostFactor
+    rw [ENNReal.ofReal_ne_zero_iff]
+    exact Real.exp_pos _)
+
+/-- **Sequential L1 for "pleasantly warm"** (mirrors `seqAdjL1HorriblyWarm`). -/
+noncomputable def seqAdjL1PleasantlyWarm (u : RSA.Nouwen2024.AdjUtterance) : PMF Height :=
+  PMF.posterior adjMarginalPleasant priorAfterEvalPosPleasant u
+    (PMF.marginal_ne_zero _ _ _ (priorAfterEvalPosPleasant_pos_at (by decide : 0 < muPleasant (deg 4))) (by
+      unfold adjMarginalPleasant
+      rw [RSA.marginalizeKernel_apply]
+      apply ENNReal.summable.tsum_ne_zero_iff.mpr
+      refine ⟨0, mul_ne_zero ?_ ?_⟩
+      · rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]; simp
+      · cases u
+        · exact adjSpeakerPleasant_warm_deg4_ne_zero
+        · have hL0 : adjL0PleasantAt 0 .silent (deg 4) ≠ 0 := by
+            have hm : (∑' h, priorAfterEvalPosPleasant h *
+                (if adjLex (validToThreshold 0) .silent h then (1 : ℝ≥0∞) else 0)) = 1 := by
+              simp only [show ∀ h, adjLex (validToThreshold 0) .silent h = true from
+                fun _ => rfl, if_true, mul_one]
+              exact PMF.tsum_coe _
+            unfold adjL0PleasantAt
+            rw [dif_pos (by rw [hm]; exact one_ne_zero),
+              RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl)]
+            exact priorAfterEvalPosPleasant_pos_at (by decide)
+          have h_pos : (∑' u', ((adjL0PleasantAt 0) u' (deg 4) : ℝ≥0∞) ^ (4 : ℝ) *
+              adjCostFactor u') ≠ 0 := by
+            apply ENNReal.summable.tsum_ne_zero_iff.mpr
+            refine ⟨.silent, mul_ne_zero ?_ ?_⟩
+            · exact (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hL0)
+                (PMF.apply_ne_top _ _)).ne'
+            · rw [adjCostFactor_silent]; exact one_ne_zero
+          unfold adjSpeakerPleasantAt
+          rw [dif_pos h_pos]
+          exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 (by
+            rw [adjCostFactor_silent]; exact one_ne_zero)))
+
+/-- **"Pleasantly warm" prefers the moderate `deg 4` over the extreme `deg 6`**
+([nouwen-2024] Fig. 8: positive evaluations concentrate mass mid-scale). The
+proof is a support fact: `μ_pleasant (deg 6) = 0` licenses *no* evaluative
+threshold, so the extreme world's evaluative marginal — hence its whole
+chained score — is zero, while the moderate world's is positive. -/
+theorem seq_pleasantly_prefers_moderate_pmf :
+    seqAdjL1PleasantlyWarm .warm (deg 4) > seqAdjL1PleasantlyWarm .warm (deg 6) := by
+  unfold seqAdjL1PleasantlyWarm priorAfterEvalPosPleasant
+  rw [gt_iff_lt, PMF.posterior_chained_lt_iff_score_lt]
+  have hE6 : evalMarginalAt muPleasant (deg 6) .eval_pos = 0 := by
+    unfold evalMarginalAt
+    rw [RSA.marginalizeKernel_apply, sumVT,
+      evalSpeakerAt_apply_of_false muPleasant 0 _ (evalMass_pleasant_ne_zero 0) (by decide),
+      evalSpeakerAt_apply_of_false muPleasant 1 _ (evalMass_pleasant_ne_zero 1) (by decide),
+      evalSpeakerAt_apply_of_false muPleasant 2 _ (evalMass_pleasant_ne_zero 2) (by decide),
+      mul_zero, mul_zero, mul_zero, add_zero, add_zero]
+  have hE4 : evalMarginalAt muPleasant (deg 4) .eval_pos ≠ 0 := by
+    unfold evalMarginalAt
+    rw [RSA.marginalizeKernel_apply]
+    apply ENNReal.summable.tsum_ne_zero_iff.mpr
+    refine ⟨0, mul_ne_zero ?_ ?_⟩
+    · rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]; simp
+    · exact evalSpeakerAt_apply_ne_zero_of_true muPleasant 0 _
+        (evalMass_pleasant_ne_zero 0) (by decide)
+  have hA4 : adjMarginalPleasant (deg 4) .warm ≠ 0 := by
+    unfold adjMarginalPleasant
+    rw [RSA.marginalizeKernel_apply]
+    apply ENNReal.summable.tsum_ne_zero_iff.mpr
+    refine ⟨0, mul_ne_zero ?_ ?_⟩
+    · rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]; simp
+    · exact adjSpeakerPleasant_warm_deg4_ne_zero
+  rw [hE6, mul_zero, zero_mul]
+  exact pos_iff_ne_zero.mpr
+    (mul_ne_zero (mul_ne_zero (heightPriorPMF_pos _) hE4) hA4)
+
 /-! ## §6. Predictions
 
 The headline below states that "horribly warm" shifts probability toward

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -1266,6 +1266,113 @@ theorem seq_pleasantly_prefers_moderate_pmf :
   exact pos_iff_ne_zero.mpr
     (mul_ne_zero (mul_ne_zero (heightPriorPMF_pos _) hE4) hA4)
 
+/-! ## §5e. Zwicky vacuity as an identity; the usually chain
+
+[nouwen-2024] p. 22: the simple account "wrongly predict[s] that usually
+tall means the same as tall but not unusually tall". Model-side content: a
+constant evaluative measure licenses every threshold at every height, so the
+evaluative update is the IDENTITY (`priorAfterEvalPosUsual_eq_prior`) —
+"usually warm" reduces to bare "warm" exactly — while `μ_unusual =
+μ_horrible` holds definitionally, so "unusually warm" IS the horribly chain
+and inherits its upward shift. The old cross-model inequality pair is
+subsumed by these identities plus the single-model shift theorems. -/
+
+/-- ℕ-valued constant measure ("usual"): no height discrimination. -/
+def muUsualN : Height → ℕ := fun _ => 3
+
+/-- μ_unusual has μ_horrible's shape: deviation measures pattern with
+negative evaluatives ([nouwen-2024] §5). -/
+def muUnusualN : Height → ℕ := muHorrible
+
+theorem muUnusualN_eq_muHorrible : muUnusualN = muHorrible := rfl
+
+/-- Under the constant measure every threshold is licensed at every height. -/
+private theorem evalLex_usual_true (vt : ValidThreshold) (u : EvalUtterance) (h : Height) :
+    evalLex muUsualN (validToThreshold vt) u h = true := by
+  cases u
+  · revert vt h; decide
+  · rfl
+
+/-- The constant-measure literal listener is the prior at every utterance. -/
+theorem evalL0At_usual (vt : ValidThreshold) (u : EvalUtterance) (w : Height) :
+    evalL0At muUsualN vt u w = heightPriorPMF w := by
+  have hm : (∑' h, heightPriorPMF h *
+      (if evalLex muUsualN (validToThreshold vt) u h then (1 : ℝ≥0∞) else 0)) = 1 := by
+    simp only [evalLex_usual_true, if_true, mul_one]
+    exact PMF.tsum_coe _
+  unfold evalL0At
+  rw [dif_pos (by rw [hm]; exact one_ne_zero)]
+  exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _
+    (fun w' => evalLex_usual_true vt u w') _ _
+
+/-- Constant-measure speaker value: closed form, height-independent. -/
+theorem evalSpeakerAt_usual_apply (vt : ValidThreshold) (w : Height) :
+    evalSpeakerAt muUsualN vt w .eval_pos
+      = evalCostFactor .eval_pos / (evalCostFactor .eval_pos + 1) := by
+  have hP0 : heightPriorPMF w ≠ 0 := heightPriorPMF_pos w
+  have hPt : heightPriorPMF w ≠ ⊤ := PMF.apply_ne_top _ _
+  unfold evalSpeakerAt
+  rw [dif_pos (evalSpeakerAt_h_pos muUsualN vt w), RSA.S1Belief_apply, sumEvalUtt,
+    evalL0At_usual, evalL0At_usual, evalCostFactor_silent, mul_one]
+  have hP4 : (heightPriorPMF w) ^ (4 : ℝ) ≠ 0 :=
+    (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hP0) hPt).ne'
+  have hP4t : (heightPriorPMF w) ^ (4 : ℝ) ≠ ⊤ :=
+    ENNReal.rpow_ne_top_of_nonneg (by norm_num) hPt
+  rw [← div_eq_mul_inv,
+    show (heightPriorPMF w) ^ (4 : ℝ) * evalCostFactor .eval_pos +
+          (heightPriorPMF w) ^ (4 : ℝ)
+        = (heightPriorPMF w) ^ (4 : ℝ) * (evalCostFactor .eval_pos + 1) from by ring,
+    ENNReal.mul_div_mul_left _ _ hP4 hP4t]
+
+/-- The marginalised constant-measure kernel is constant across heights. -/
+theorem evalMarginalAt_usual_const (w : Height) :
+    evalMarginalAt muUsualN w .eval_pos
+      = evalCostFactor .eval_pos / (evalCostFactor .eval_pos + 1) := by
+  unfold evalMarginalAt
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+    evalSpeakerAt_usual_apply, evalSpeakerAt_usual_apply, evalSpeakerAt_usual_apply,
+    show ∀ x : ℝ≥0∞, 3⁻¹ * x + 3⁻¹ * x + 3⁻¹ * x = 3 * 3⁻¹ * x from fun x => by ring,
+    ENNReal.mul_inv_cancel (by norm_num) (by norm_num), one_mul]
+
+private theorem usualKernelValue_ne_zero :
+    evalCostFactor .eval_pos / (evalCostFactor .eval_pos + 1) ≠ 0 := by
+  rw [ne_eq, ENNReal.div_eq_zero_iff, not_or]
+  exact ⟨evalCostFactor_pos _,
+    ENNReal.add_ne_top.mpr ⟨evalCostFactor_finite _, ENNReal.one_ne_top⟩⟩
+
+/-- Backgrounded prior for "usually". -/
+noncomputable def priorAfterEvalPosUsual : PMF Height :=
+  PMF.posterior (evalMarginalAt muUsualN) heightPriorPMF .eval_pos
+    (PMF.marginal_ne_zero _ _ _ (heightPriorPMF_pos (deg 0))
+      (by rw [evalMarginalAt_usual_const]; exact usualKernelValue_ne_zero))
+
+/-- **Zwicky's vacuity as an identity**: the constant measure's evaluative
+update is the identity — Π_usual IS the prior. This is the deep form of the
+old `eval_constant_preserves_peak` (whose inequality is now a corollary of
+the prior's own shape) and the first half of "usually warm ≈ warm". -/
+theorem priorAfterEvalPosUsual_eq_prior : priorAfterEvalPosUsual = heightPriorPMF :=
+  PMF.posterior_eq_of_kernel_const _ _ _ _ (fun w => evalMarginalAt_usual_const w)
+
+/-- The old `eval_constant_preserves_peak`, now a prior fact: the constant
+measure's stage-1 posterior at the norm exceeds it at the extreme because
+the prior does (`20 : 1` weights) — the evaluative step contributed nothing. -/
+theorem eval_constant_preserves_peak_pmf :
+    priorAfterEvalPosUsual (deg 3) > priorAfterEvalPosUsual (deg 6) := by
+  rw [priorAfterEvalPosUsual_eq_prior]
+  unfold heightPriorPMF
+  rw [gt_iff_lt, PMF.normalize_apply, PMF.normalize_apply,
+    mul_comm, mul_comm (heightPriorENN (deg 3))]
+  refine ENNReal.mul_lt_mul_right
+    (ENNReal.inv_ne_zero.mpr (ENNReal.tsum_ne_top_of_fintype heightPriorENN_finite))
+    (ENNReal.inv_ne_top.mpr
+      (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨deg 0, heightPriorENN_pos _⟩)) ?_
+  unfold heightPriorENN
+  rw [show (heightPrior (deg 6) : ℝ) = 1 from by
+      norm_num [show heightPrior (deg 6) = 1 from rfl],
+    show (heightPrior (deg 3) : ℝ) = 20 from by
+      norm_num [show heightPrior (deg 3) = 20 from rfl]]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
+
 /-! ## §6. Predictions
 
 The headline below states that "horribly warm" shifts probability toward

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -1602,6 +1602,109 @@ theorem bare_warm_prefers_moderate_pmf :
   rw [mul_comm (heightPriorPMF (deg 6)), mul_comm (heightPriorPMF (deg 4))]
   exact ENNReal.mul_lt_mul_right hC0 hCt hP
 
+/-! ## §5g. The posterior-boost fact
+
+`μ_unusual = μ_horrible` holds by definition (`muUnusualN_eq_muHorrible`),
+so every "unusually" prediction is the corresponding horribly theorem
+verbatim; no duplicates are stated. The remaining content of the old
+cross-measure comparison is the posterior-vs-prior boost below. -/
+
+theorem gval_ne_zero (vt : ValidThreshold) : gval vt ≠ 0 := by
+  unfold gval
+  rw [ne_eq, ENNReal.div_eq_zero_iff, not_or]
+  constructor
+  · exact mul_ne_zero
+      (ENNReal.rpow_pos (ENNReal.inv_pos.mpr (evalMass_ne_top vt))
+        (ENNReal.inv_ne_top.mpr (evalMass_ne_zero vt))).ne'
+      (evalCostFactor_pos _)
+  · exact ENNReal.add_ne_top.mpr
+      ⟨ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+          (ENNReal.inv_ne_top.mpr (evalMass_ne_zero vt)))
+        (evalCostFactor_finite _),
+       ENNReal.one_ne_top⟩
+
+theorem evalMarginal_deg6 :
+    evalSpeakerMarginalHorrible (deg 6) .eval_pos
+      = 3⁻¹ * gval 0 + 3⁻¹ * gval 1 + 3⁻¹ * gval 2 := by
+  unfold evalSpeakerMarginalHorrible
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+    evalSpeaker_apply_of_true 0 _ (by decide),
+    evalSpeaker_apply_of_true 1 _ (by decide),
+    evalSpeaker_apply_of_true 2 _ (by decide)]
+
+theorem evalMarginal_deg3 :
+    evalSpeakerMarginalHorrible (deg 3) .eval_pos = 0 := by
+  unfold evalSpeakerMarginalHorrible
+  rw [RSA.marginalizeKernel_apply, sumVT,
+    evalSpeaker_apply_of_false 0 _ (by decide),
+    evalSpeaker_apply_of_false 1 _ (by decide),
+    evalSpeaker_apply_of_false 2 _ (by decide), mul_zero, mul_zero, mul_zero,
+    add_zero, add_zero]
+
+/-- No height's evaluative marginal exceeds the extreme's: `deg 6` licenses
+every valid threshold, so it collects every mass-form value in full. -/
+private theorem evalMarginal_le_deg6 (h : Height) :
+    evalSpeakerMarginalHorrible h .eval_pos
+      ≤ evalSpeakerMarginalHorrible (deg 6) .eval_pos := by
+  have hle : ∀ vt : ValidThreshold,
+      evalSpeaker_horribleAt vt h .eval_pos ≤ gval vt := by
+    intro vt
+    by_cases hw : evalLex muHorrible (validToThreshold vt) .eval_pos h = true
+    · rw [evalSpeaker_apply_of_true vt h hw]
+    · rw [evalSpeaker_apply_of_false vt h (by simpa using hw)]
+      exact zero_le
+  rw [evalMarginal_deg6]
+  unfold evalSpeakerMarginalHorrible
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior]
+  exact add_le_add (add_le_add (mul_le_mul_right (hle 0) _)
+    (mul_le_mul_right (hle 1) _)) (mul_le_mul_right (hle 2) _)
+
+private theorem evalMarginal_deg6_ne_zero :
+    evalSpeakerMarginalHorrible (deg 6) .eval_pos ≠ 0 := by
+  rw [evalMarginal_deg6]
+  intro hz
+  rcases mul_eq_zero.mp (add_eq_zero.mp (add_eq_zero.mp hz).1).1 with h | h
+  · exact ENNReal.inv_ne_zero.mpr (by norm_num) h
+  · exact gval_ne_zero 0 h
+
+/-- **The evaluative update boosts the extreme above its prior** — the deep
+form of the old `eval_unusual_boosts_extreme`: the constant-measure update is
+the identity (`priorAfterEvalPosUsual_eq_prior`), so the old cross-measure
+comparison at `deg 6` is posterior-vs-prior. Average argument: no height
+beats the extreme's marginal (`evalMarginal_le_deg6`) and the norm
+contributes zero (`evalMarginal_deg3`), so the normaliser sits strictly
+below the extreme's kernel value. -/
+theorem eval_unusual_boosts_extreme_pmf :
+    priorAfterEvalPos (deg 6) > heightPriorPMF (deg 6) := by
+  unfold priorAfterEvalPos evalL1Horrible
+  rw [gt_iff_lt, PMF.posterior_apply]
+  have hE6t : evalSpeakerMarginalHorrible (deg 6) .eval_pos ≠ ⊤ := PMF.apply_ne_top _ _
+  have hZlt : PMF.marginal evalSpeakerMarginalHorrible heightPriorPMF .eval_pos
+      < evalSpeakerMarginalHorrible (deg 6) .eval_pos := by
+    show (heightPriorPMF.bind evalSpeakerMarginalHorrible) .eval_pos < _
+    rw [PMF.bind_apply]
+    calc (∑' h, heightPriorPMF h * evalSpeakerMarginalHorrible h .eval_pos)
+        < ∑' h, heightPriorPMF h * evalSpeakerMarginalHorrible (deg 6) .eval_pos := by
+          refine ENNReal.tsum_lt_tsum (i := deg 3)
+            (ENNReal.tsum_ne_top_of_fintype fun h =>
+              ENNReal.mul_ne_top (PMF.apply_ne_top _ _) (PMF.apply_ne_top _ _))
+            (fun h => mul_le_mul_right (evalMarginal_le_deg6 h) _) ?_
+          rw [evalMarginal_deg3, mul_zero]
+          exact pos_iff_ne_zero.mpr
+            (mul_ne_zero (heightPriorPMF_pos _) evalMarginal_deg6_ne_zero)
+      _ = evalSpeakerMarginalHorrible (deg 6) .eval_pos := by
+          rw [ENNReal.tsum_mul_right, PMF.tsum_coe, one_mul]
+  calc heightPriorPMF (deg 6)
+      = heightPriorPMF (deg 6) * evalSpeakerMarginalHorrible (deg 6) .eval_pos *
+          (evalSpeakerMarginalHorrible (deg 6) .eval_pos)⁻¹ := by
+        rw [mul_assoc, ENNReal.mul_inv_cancel evalMarginal_deg6_ne_zero hE6t, mul_one]
+    _ < heightPriorPMF (deg 6) * evalSpeakerMarginalHorrible (deg 6) .eval_pos *
+          (PMF.marginal evalSpeakerMarginalHorrible heightPriorPMF .eval_pos)⁻¹ :=
+        ENNReal.mul_lt_mul_right
+          (mul_ne_zero (heightPriorPMF_pos _) evalMarginal_deg6_ne_zero)
+          (ENNReal.mul_ne_top (PMF.apply_ne_top _ _) hE6t)
+          (ENNReal.inv_lt_inv.mpr hZlt)
+
 /-! ## §6. Predictions
 
 The headline below states that "horribly warm" shifts probability toward

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -1373,6 +1373,235 @@ theorem eval_constant_preserves_peak_pmf :
       norm_num [show heightPrior (deg 3) = 20 from rfl]]
   exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
+/-! ## §5f. Prior-generic adjective stage; the bare and usually chains -/
+
+/-- Prior-generic stage-2 literal listener (dite-total). -/
+noncomputable def adjL0WithPrior (Pi : PMF Height) (vt : ValidThreshold)
+    (u : RSA.Nouwen2024.AdjUtterance) : PMF Height :=
+  if h_pos : (∑' h, Pi h *
+      (if adjLex (validToThreshold vt) u h then (1 : ℝ≥0∞) else 0)) ≠ 0 then
+    RSA.L0LassiterGoodman Pi (adjLex (validToThreshold vt)) u h_pos
+  else PMF.uniformOfFintype Height
+
+/-- Prior-generic stage-2 speaker (dite-total). -/
+noncomputable def adjSpeakerWithPrior (Pi : PMF Height) (vt : ValidThreshold)
+    (w : Height) : PMF (RSA.Nouwen2024.AdjUtterance) :=
+  if h_pos : (∑' u, ((adjL0WithPrior Pi vt) u w : ℝ≥0∞) ^ (4 : ℝ) *
+      adjCostFactor u) ≠ 0 then
+    RSA.S1Belief (adjL0WithPrior Pi vt) adjCostFactor 4 w h_pos
+      (ENNReal.tsum_ne_top_of_fintype fun u =>
+        ENNReal.mul_ne_top
+          (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+          (by unfold adjCostFactor; exact ENNReal.ofReal_ne_top))
+  else PMF.pure .silent
+
+/-- Prior-generic marginalized stage-2 speaker. -/
+noncomputable def adjMarginalWithPrior (Pi : PMF Height) : Height → PMF AdjUtterance :=
+  RSA.marginalizeKernel thresholdPriorPMF (fun vt w => adjSpeakerWithPrior Pi vt w)
+
+theorem adjL0WithPrior_silent (Pi : PMF Height) (vt : ValidThreshold) (w : Height) :
+    adjL0WithPrior Pi vt .silent w = Pi w := by
+  have hm : (∑' h, Pi h *
+      (if adjLex (validToThreshold vt) .silent h then (1 : ℝ≥0∞) else 0)) = 1 := by
+    simp only [show ∀ h, adjLex (validToThreshold vt) .silent h = true from
+      fun _ => rfl, if_true, mul_one]
+    exact PMF.tsum_coe _
+  unfold adjL0WithPrior
+  rw [dif_pos (by rw [hm]; exact one_ne_zero)]
+  exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl) _ _
+
+private theorem adjSpeakerWithPrior_h_pos (Pi : PMF Height) (vt : ValidThreshold)
+    {w : Height} (hPw : Pi w ≠ 0) :
+    (∑' u, ((adjL0WithPrior Pi vt) u w : ℝ≥0∞) ^ (4 : ℝ) * adjCostFactor u) ≠ 0 := by
+  rw [sumAdjUtt]
+  intro hz
+  rcases mul_eq_zero.mp (add_eq_zero.mp hz).2 with h5 | h5
+  · rw [adjL0WithPrior_silent] at h5
+    rcases ENNReal.rpow_eq_zero_iff.mp h5 with ⟨hz0, -⟩ | ⟨-, hneg⟩
+    · exact hPw hz0
+    · norm_num at hneg
+  · rw [adjCostFactor_silent] at h5
+    exact one_ne_zero h5
+
+/-- Π-mass of the `.warm` extension at threshold `vt`. -/
+noncomputable def adjMassP (Pi : PMF Height) (vt : ValidThreshold) : ℝ≥0∞ :=
+  ∑' h, Pi h * (if adjLex (validToThreshold vt) .warm h then (1 : ℝ≥0∞) else 0)
+
+/-- Prior-generic stage-2 speaker value on support: mass form. -/
+noncomputable def fvalP (Pi : PMF Height) (vt : ValidThreshold) : ℝ≥0∞ :=
+  (adjMassP Pi vt)⁻¹ ^ (4 : ℝ) * adjCostFactor .warm /
+    ((adjMassP Pi vt)⁻¹ ^ (4 : ℝ) * adjCostFactor .warm + 1)
+
+/-- **Ratio cancellation, prior-generic stage 2**: on support, at a
+non-degenerate world, the speaker's value is `fvalP Pi vt` — independent of
+the world. -/
+theorem adjSpeakerWithPrior_apply_of_true (Pi : PMF Height) (vt : ValidThreshold)
+    (w : Height) (hw : adjLex (validToThreshold vt) .warm w = true)
+    (hPw : Pi w ≠ 0) :
+    adjSpeakerWithPrior Pi vt w .warm = fvalP Pi vt := by
+  have hPt : Pi w ≠ ⊤ := PMF.apply_ne_top _ _
+  have hmne : adjMassP Pi vt ≠ 0 :=
+    ENNReal.summable.tsum_ne_zero_iff.mpr
+      ⟨w, by rw [hw]; simp only [if_true, mul_one]; exact hPw⟩
+  have hL0warm : adjL0WithPrior Pi vt .warm w = Pi w * (adjMassP Pi vt)⁻¹ := by
+    have hm' : (∑' h, Pi h *
+        (if adjLex (validToThreshold vt) .warm h then (1 : ℝ≥0∞) else 0)) ≠ 0 := hmne
+    unfold adjL0WithPrior
+    rw [dif_pos hm', RSA.L0LassiterGoodman_apply, hw]
+    simp only [if_true, mul_one]
+    rfl
+  unfold adjSpeakerWithPrior
+  rw [dif_pos (adjSpeakerWithPrior_h_pos Pi vt hPw), RSA.S1Belief_apply, sumAdjUtt,
+    hL0warm, adjL0WithPrior_silent, adjCostFactor_silent, mul_one,
+    ENNReal.mul_rpow_of_nonneg _ _ (by norm_num : (0 : ℝ) ≤ 4)]
+  have hP4 : (Pi w) ^ (4 : ℝ) ≠ 0 := (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hPw) hPt).ne'
+  have hP4t : (Pi w) ^ (4 : ℝ) ≠ ⊤ := ENNReal.rpow_ne_top_of_nonneg (by norm_num) hPt
+  rw [mul_assoc ((Pi w) ^ (4 : ℝ)), ← div_eq_mul_inv,
+    show (Pi w) ^ (4 : ℝ) * ((adjMassP Pi vt)⁻¹ ^ (4 : ℝ) * adjCostFactor .warm) +
+          (Pi w) ^ (4 : ℝ)
+        = (Pi w) ^ (4 : ℝ) * ((adjMassP Pi vt)⁻¹ ^ (4 : ℝ) * adjCostFactor .warm + 1)
+      from by ring,
+    ENNReal.mul_div_mul_left _ _ hP4 hP4t]
+  rfl
+
+/-- Marginal positivity for the prior-generic stage-2 chain at any world where
+the prior is positive and `.warm` holds at threshold 0. -/
+private theorem bareAdj_marginal_ne_zero (u : RSA.Nouwen2024.AdjUtterance) :
+    PMF.marginal (adjMarginalWithPrior heightPriorPMF) heightPriorPMF u ≠ 0 := by
+  refine PMF.marginal_ne_zero _ _ _ (heightPriorPMF_pos (deg 4)) ?_
+  unfold adjMarginalWithPrior
+  rw [RSA.marginalizeKernel_apply]
+  apply ENNReal.summable.tsum_ne_zero_iff.mpr
+  refine ⟨0, mul_ne_zero ?_ ?_⟩
+  · rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]; simp
+  · have hcf : adjCostFactor u ≠ 0 := by
+      unfold adjCostFactor
+      rw [ENNReal.ofReal_ne_zero_iff]
+      exact Real.exp_pos _
+    have hL0 : adjL0WithPrior heightPriorPMF 0 u (deg 4) ≠ 0 := by
+      cases u
+      · have hmne : (∑' h, heightPriorPMF h *
+            (if adjLex (validToThreshold 0) .warm h then (1 : ℝ≥0∞) else 0)) ≠ 0 :=
+          ENNReal.summable.tsum_ne_zero_iff.mpr
+            ⟨deg 4, by rw [show adjLex (validToThreshold 0) .warm (deg 4) = true from
+              by decide]; simp only [if_true, mul_one]; exact heightPriorPMF_pos _⟩
+        unfold adjL0WithPrior
+        rw [dif_pos hmne, ← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
+        exact ⟨heightPriorPMF_pos _, by decide⟩
+      · rw [adjL0WithPrior_silent]
+        exact heightPriorPMF_pos _
+    unfold adjSpeakerWithPrior
+    rw [dif_pos (adjSpeakerWithPrior_h_pos heightPriorPMF 0 (heightPriorPMF_pos (deg 4)))]
+    exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 hcf
+
+/-- Baseline chain: bare "warm" over the raw height prior. -/
+noncomputable def bareAdjL1 (u : RSA.Nouwen2024.AdjUtterance) : PMF Height :=
+  PMF.posterior (adjMarginalWithPrior heightPriorPMF) heightPriorPMF u
+    (bareAdj_marginal_ne_zero u)
+
+/-- The "usually warm" chain: stage 2 over the (identity) usual posterior. -/
+noncomputable def seqAdjL1Usually (u : RSA.Nouwen2024.AdjUtterance) : PMF Height :=
+  PMF.posterior (adjMarginalWithPrior priorAfterEvalPosUsual) priorAfterEvalPosUsual u
+    (by rw [priorAfterEvalPosUsual_eq_prior]; exact bareAdj_marginal_ne_zero u)
+
+/-- **"Usually warm" IS bare "warm"**: the second half of Zwicky's vacuity —
+with the identity evaluative update (`priorAfterEvalPosUsual_eq_prior`), the
+whole sequential chain collapses to the baseline. Together with
+`seq_unusually_shifts_extreme` this subsumes the old cross-model
+discrimination pair without any cross-model numeric comparison. -/
+theorem seqUsually_eq_bare (u : RSA.Nouwen2024.AdjUtterance) :
+    seqAdjL1Usually u = bareAdjL1 u := by
+  ext h
+  unfold seqAdjL1Usually bareAdjL1
+  rw [PMF.posterior_apply, PMF.posterior_apply, priorAfterEvalPosUsual_eq_prior]
+
+private theorem adjMassP_ne_top (Pi : PMF Height) (vt : ValidThreshold) :
+    adjMassP Pi vt ≠ ⊤ := by
+  refine ne_top_of_le_ne_top ENNReal.one_ne_top ?_
+  calc adjMassP Pi vt
+      ≤ ∑' h', Pi h' := ENNReal.tsum_le_tsum fun h' => by split <;> simp
+    _ = 1 := PMF.tsum_coe _
+
+private theorem fvalP_ne_zero (Pi : PMF Height) (vt : ValidThreshold)
+    (hm : adjMassP Pi vt ≠ 0) : fvalP Pi vt ≠ 0 := by
+  unfold fvalP
+  rw [ne_eq, ENNReal.div_eq_zero_iff, not_or]
+  have hcf : adjCostFactor .warm ≠ 0 := by
+    unfold adjCostFactor
+    rw [ENNReal.ofReal_ne_zero_iff]
+    exact Real.exp_pos _
+  constructor
+  · exact mul_ne_zero
+      (ENNReal.rpow_pos (ENNReal.inv_pos.mpr (adjMassP_ne_top Pi vt))
+        (ENNReal.inv_ne_top.mpr hm)).ne' hcf
+  · exact ENNReal.add_ne_top.mpr
+      ⟨ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+          (ENNReal.inv_ne_top.mpr hm))
+        (by unfold adjCostFactor; exact ENNReal.ofReal_ne_top),
+       ENNReal.one_ne_top⟩
+
+private theorem fvalP_ne_top (Pi : PMF Height) (vt : ValidThreshold)
+    (hm : adjMassP Pi vt ≠ 0) : fvalP Pi vt ≠ ⊤ :=
+  ENNReal.div_ne_top
+    (ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+        (ENNReal.inv_ne_top.mpr hm))
+      (by unfold adjCostFactor; exact ENNReal.ofReal_ne_top))
+    (by simp)
+
+private theorem bareMass_ne_zero (vt : ValidThreshold) :
+    adjMassP heightPriorPMF vt ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨deg 4, by
+    rw [show adjLex (validToThreshold vt) .warm (deg 4) = true from by revert vt; decide]
+    simp only [if_true, mul_one]
+    exact heightPriorPMF_pos _⟩
+
+/-- Bare "warm" prefers the moderate `deg 4` over the extreme `deg 6`: both
+worlds license every valid threshold, so the marginalised speaker values
+coincide (ratio cancellation) and the raw prior (`10 : 1`) decides. -/
+theorem bare_warm_prefers_moderate_pmf :
+    bareAdjL1 .warm (deg 4) > bareAdjL1 .warm (deg 6) := by
+  unfold bareAdjL1
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt]
+  have hA : ∀ w : Height, (∀ vt : ValidThreshold,
+      adjLex (validToThreshold vt) .warm w = true) →
+      adjMarginalWithPrior heightPriorPMF w .warm
+        = 3⁻¹ * fvalP heightPriorPMF 0 + 3⁻¹ * fvalP heightPriorPMF 1 +
+          3⁻¹ * fvalP heightPriorPMF 2 := by
+    intro w hall
+    unfold adjMarginalWithPrior
+    rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+      adjSpeakerWithPrior_apply_of_true _ _ _ (hall 0) (heightPriorPMF_pos w),
+      adjSpeakerWithPrior_apply_of_true _ _ _ (hall 1) (heightPriorPMF_pos w),
+      adjSpeakerWithPrior_apply_of_true _ _ _ (hall 2) (heightPriorPMF_pos w)]
+  rw [hA _ (by decide), hA _ (by decide)]
+  set C := (3 : ℝ≥0∞)⁻¹ * fvalP heightPriorPMF 0 + 3⁻¹ * fvalP heightPriorPMF 1 +
+    3⁻¹ * fvalP heightPriorPMF 2 with hCdef
+  have hC0 : C ≠ 0 := by
+    intro hz
+    rcases mul_eq_zero.mp (add_eq_zero.mp (add_eq_zero.mp hz).1).1 with h | h
+    · exact ENNReal.inv_ne_zero.mpr (by norm_num) h
+    · exact fvalP_ne_zero _ _ (bareMass_ne_zero 0) h
+  have h3t : (3 : ℝ≥0∞)⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr (by norm_num)
+  have hCt : C ≠ ⊤ := by
+    refine ENNReal.add_ne_top.mpr ⟨ENNReal.add_ne_top.mpr ⟨?_, ?_⟩, ?_⟩ <;>
+      exact ENNReal.mul_ne_top h3t (fvalP_ne_top _ _ (bareMass_ne_zero _))
+  have hP : heightPriorPMF (deg 6) < heightPriorPMF (deg 4) := by
+    unfold heightPriorPMF
+    rw [PMF.normalize_apply, PMF.normalize_apply,
+      mul_comm, mul_comm (heightPriorENN (deg 4))]
+    refine ENNReal.mul_lt_mul_right
+      (ENNReal.inv_ne_zero.mpr (ENNReal.tsum_ne_top_of_fintype heightPriorENN_finite))
+      (ENNReal.inv_ne_top.mpr
+        (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨deg 0, heightPriorENN_pos _⟩)) ?_
+    unfold heightPriorENN
+    rw [show (heightPrior (deg 6) : ℝ) = 1 from by
+        norm_num [show heightPrior (deg 6) = 1 from rfl],
+      show (heightPrior (deg 4) : ℝ) = 10 from by
+        norm_num [show heightPrior (deg 4) = 10 from rfl]]
+    exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
+  rw [mul_comm (heightPriorPMF (deg 6)), mul_comm (heightPriorPMF (deg 4))]
+  exact ENNReal.mul_lt_mul_right hC0 hCt hP
+
 /-! ## §6. Predictions
 
 The headline below states that "horribly warm" shifts probability toward

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -48,29 +48,23 @@ of Nouwen's actual contribution:
    extend to Nouwen's Figures 4-7 construction (which depends on the
    QUD partition + measure-function-on-cells distinction). Stub theorem
    `eq_49_qud_partition_NOT_FORMALISED` below documents the gap.
-3. **`muHorrible` is monotone-decreasing, NOT Nouwen's `f(x) = x²`
-   quadratic.** Nouwen's Figure 4(b) (p. 2:27) handcrafts
-   `f(x) = x²` so BOTH extremes (low + high temperature) are evaluated as
-   horrible — this is what produces the Goldilocks shape in Figures 5-7.
-   The file's `muHorrible (deg 0) = 3, deg 5 = 0` is monotone in
-   `h.toNat`, NOT quadratic-in-distance-from-mean. The file's
-   `seq_horribly_shifts_upward_pmf` is therefore the WRONG headline
-   shape for Goldilocks: it captures monotone shift, not extremes-vs-
-   middle. UNVERIFIED-NOTE: the bundled `Nouwen2024.lean`'s `muHorrible`
-   was originally built for the bundled-API Goldilocks demo and may
-   itself need correction.
+3. **`muHorrible` is linear `|h − norm|`, NOT Nouwen's `f(x) = x²`
+   quadratic.** Nouwen's Figure 4(b) handcrafts `f(x) = x²`; the file's
+   `muHorrible = |h − 3|` (deg 0 ↦ 3, deg 3 ↦ 0, deg 6 ↦ 3) is the
+   linear-V simplification. Both are U-shaped — both extremes count as
+   horrible, which is what the Wheeler leak (`wheeler_cold_leak` in the
+   bundled file) and the Goldilocks boundary depend on — but slopes and
+   hence fitted magnitudes differ. Paper (p. 31): the model is "a proof
+   of concept"; the theorems here are shape-generic where possible.
 
-**Also not captured (substrate gaps):**
-- **Zwicky's generalisation** (paper §5, the third of Nouwen's three
-  desiderata p. 2:15) — the vacuity argument for positive modal adverbs
-  (*usually*, *normally*, *possibly*) is entirely absent. No modal lex,
-  no `usually` utterance, no theorem stating that `usually warm ≈ warm`
-  because the adverb's update is vacuous against a normality-shaped prior.
-- **Positive-valence Goldilocks half** (Figure 8, *pleasantly warm* →
-  narrow moderate peak) — only the negative-valence case is built in
-  the PMF face. The bundled `Nouwen2024.lean` has the positive-valence
-  symmetric pair; lifting it to PMF requires rebuilding stage-2 with
-  `muPleasant` + corrected `f`.
+**Also captured (§5d–§5g):**
+- **Zwicky's generalisation** (paper §5): the constant measure's update
+  is the identity (`priorAfterEvalPosUsual_eq_prior`), so "usually warm"
+  collapses to bare "warm" (`seqUsually_eq_bare`), while `μ_unusual =
+  μ_horrible` definitionally and the extreme-measure update strictly
+  boosts the extreme above its prior (`eval_unusual_boosts_extreme_pmf`).
+- **Positive-valence half** (Figure 8): `seq_pleasantly_prefers_moderate_pmf`
+  — a support fact (`μ_pleasant (deg 6) = 0` licenses no threshold).
 
 ## Connection to `LassiterGoodman2017PMF.lean`
 

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -104,11 +104,13 @@ auditor flagged this as a broader linglib gap; the fix is an
 `IntensifierSemantics` typeclass at the Theory level (deferred — out of
 scope for this file).
 
-## Proof obligations (sorry'd, honestly motivated)
+## Proof obligations
 
-- `seq_horribly_shifts_upward_pmf` (numeric arithmetic core) — same wall
-  as `LassiterGoodman2017PMF`'s headline; structural decomposition reaches
-  product-of-scores via `posterior_chained_lt_iff_score_lt`, then halts.
+- `seq_horribly_shifts_upward_pmf` — PROVEN structurally (§5b ratio
+  cancellation): the height factor cancels in each per-threshold speaker,
+  collapsing the marginals to mass-monotone sums over the licensed
+  thresholds; informativity (`gval 1 > gval 0`) beats the 2:1 prior ratio.
+  No numeric reflection.
 - `eq_44b_factive_embedding_NOT_FORMALISED` — Nouwen's novel contribution.
 - `eq_49_qud_partition_NOT_FORMALISED` — explicit substrate gap.
 
@@ -493,7 +495,325 @@ noncomputable def seqAdjL1HorriblyWarm (u : RSA.Nouwen2024.AdjUtterance) : PMF H
             rw [ENNReal.ofReal_ne_zero_iff]
             exact Real.exp_pos _)))
 
-/-! ## §6. Predictions (sorry'd, with honest scope notes)
+/-! ## §5b. Ratio cancellation: the structural core
+
+Because the L&G literal listener carries the prior multiplicatively
+(`L0(u) h = P h · 1[u true at h] / mass(u)`), the height factor `P h` cancels
+in the speaker's normalisation: on its support, each per-threshold speaker
+value depends only on the prior MASS of the utterance's extension at that
+threshold. Each marginalised speaker is therefore a sum of a mass-monotone
+value over the licensed thresholds, and the headline product comparison
+follows from mass monotonicity alone — no numeric reflection. -/
+
+/-- Prior mass of the `.eval_pos` extension at threshold `vt` (exactly the
+`L0LassiterGoodman` normaliser for stage 1). -/
+noncomputable def evalMass (vt : ValidThreshold) : ℝ≥0∞ :=
+  ∑' h, heightPriorPMF h *
+    (if evalLex muHorrible (validToThreshold vt) .eval_pos h then (1 : ℝ≥0∞) else 0)
+
+theorem evalMass_ne_zero (vt : ValidThreshold) : evalMass vt ≠ 0 :=
+  evalLex_horrible_extension_pos vt .eval_pos
+
+theorem evalMass_ne_top (vt : ValidThreshold) : evalMass vt ≠ ⊤ := by
+  refine ne_top_of_le_ne_top ENNReal.one_ne_top ?_
+  calc evalMass vt
+      ≤ ∑' h, heightPriorPMF h := ENNReal.tsum_le_tsum fun h => by split <;> simp
+    _ = 1 := PMF.tsum_coe _
+
+/-- Π-mass of the `.warm` extension at threshold `vt` (the stage-2
+`L0LassiterGoodman` normaliser, against the backgrounded prior). -/
+noncomputable def adjMass (vt : ValidThreshold) : ℝ≥0∞ :=
+  ∑' h, priorAfterEvalPos h *
+    (if adjLex (validToThreshold vt) .warm h then (1 : ℝ≥0∞) else 0)
+
+theorem adjMass_ne_zero (vt : ValidThreshold) : adjMass vt ≠ 0 :=
+  adjLex_warm_extension_pos vt .warm
+
+theorem adjMass_ne_top (vt : ValidThreshold) : adjMass vt ≠ ⊤ := by
+  refine ne_top_of_le_ne_top ENNReal.one_ne_top ?_
+  calc adjMass vt
+      ≤ ∑' h, priorAfterEvalPos h := ENNReal.tsum_le_tsum fun h => by split <;> simp
+    _ = 1 := PMF.tsum_coe _
+
+/-- Stage-1 speaker value at `.eval_pos` on its support: a function of the
+extension mass only (the height factor has cancelled). -/
+noncomputable def gval (vt : ValidThreshold) : ℝ≥0∞ :=
+  (evalMass vt)⁻¹ ^ (4 : ℝ) * evalCostFactor .eval_pos /
+    ((evalMass vt)⁻¹ ^ (4 : ℝ) * evalCostFactor .eval_pos + 1)
+
+/-- Stage-2 speaker value at `.warm` on its support. -/
+noncomputable def fval (vt : ValidThreshold) : ℝ≥0∞ :=
+  (adjMass vt)⁻¹ ^ (4 : ℝ) * adjCostFactor .warm /
+    ((adjMass vt)⁻¹ ^ (4 : ℝ) * adjCostFactor .warm + 1)
+
+theorem evalCostFactor_silent : evalCostFactor .silent = 1 := by
+  unfold evalCostFactor evalCost
+  norm_num
+
+theorem adjCostFactor_silent : adjCostFactor .silent = 1 := by
+  unfold adjCostFactor
+  show ENNReal.ofReal (Real.exp (-4 * ((RSA.Nouwen2024.adjCost .silent : ℚ) : ℝ))) = 1
+  norm_num [RSA.Nouwen2024.adjCost]
+
+private theorem sumEvalUtt (f : EvalUtterance → ℝ≥0∞) :
+    ∑' u, f u = f .eval_pos + f .silent := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset EvalUtterance) = {.eval_pos, .silent} from by decide,
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+
+private theorem sumAdjUtt (f : RSA.Nouwen2024.AdjUtterance → ℝ≥0∞) :
+    ∑' u, f u = f .warm + f .silent := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset RSA.Nouwen2024.AdjUtterance) = {.warm, .silent} from by decide,
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+
+/-- **Ratio cancellation, stage 1**: on its support the eval speaker's value
+is `gval vt` — independent of the height. -/
+theorem evalSpeaker_apply_of_true (vt : ValidThreshold) (w : Height)
+    (hw : evalLex muHorrible (validToThreshold vt) .eval_pos w = true) :
+    evalSpeaker_horribleAt vt w .eval_pos = gval vt := by
+  have hP0 : heightPriorPMF w ≠ 0 := heightPriorPMF_pos w
+  have hPt : heightPriorPMF w ≠ ⊤ := PMF.apply_ne_top _ _
+  have hL0pos : evalL0_horribleAt vt .eval_pos w = heightPriorPMF w * (evalMass vt)⁻¹ := by
+    unfold evalL0_horribleAt
+    rw [RSA.L0LassiterGoodman_apply, hw]
+    simp only [if_true, mul_one]
+    rfl
+  have hL0sil : evalL0_horribleAt vt .silent w = heightPriorPMF w := by
+    unfold evalL0_horribleAt
+    exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl) _ _
+  unfold evalSpeaker_horribleAt
+  rw [RSA.S1Belief_apply, sumEvalUtt, hL0pos, hL0sil, evalCostFactor_silent, mul_one,
+    ENNReal.mul_rpow_of_nonneg _ _ (by norm_num)]
+  -- value = (P^4 * M^4 * c) * (P^4 * M^4 * c + P^4)⁻¹ ; factor P^4
+  have hP4 : (heightPriorPMF w) ^ (4 : ℝ) ≠ 0 := (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hP0) hPt).ne'
+  have hP4t : (heightPriorPMF w) ^ (4 : ℝ) ≠ ⊤ := ENNReal.rpow_ne_top_of_nonneg (by norm_num) hPt
+  rw [mul_assoc ((heightPriorPMF w) ^ (4 : ℝ)),
+    show (heightPriorPMF w) ^ (4 : ℝ) * ((evalMass vt)⁻¹ ^ (4 : ℝ) *
+          evalCostFactor .eval_pos) + (heightPriorPMF w) ^ (4 : ℝ)
+        = (heightPriorPMF w) ^ (4 : ℝ) * ((evalMass vt)⁻¹ ^ (4 : ℝ) *
+          evalCostFactor .eval_pos + 1) from by rw [mul_add, mul_one],
+    ← div_eq_mul_inv, ENNReal.mul_div_mul_left _ _ hP4 hP4t]
+  rfl
+
+/-- **Ratio cancellation, stage 1, off support**: value 0. -/
+theorem evalSpeaker_apply_of_false (vt : ValidThreshold) (w : Height)
+    (hw : evalLex muHorrible (validToThreshold vt) .eval_pos w = false) :
+    evalSpeaker_horribleAt vt w .eval_pos = 0 := by
+  have hL0pos : evalL0_horribleAt vt .eval_pos w = 0 := by
+    unfold evalL0_horribleAt
+    rw [RSA.L0LassiterGoodman_apply, hw]
+    simp
+  unfold evalSpeaker_horribleAt
+  rw [RSA.S1Belief_apply, hL0pos, ENNReal.zero_rpow_of_pos (by norm_num), zero_mul, zero_mul]
+
+/-- **Ratio cancellation, stage 2**: on its support (and at a non-degenerate
+world, `Π(w) ≠ 0`) the adjective speaker's value is `fval vt`. -/
+theorem adjSpeaker_apply_of_true (vt : ValidThreshold) (w : Height)
+    (hw : adjLex (validToThreshold vt) .warm w = true)
+    (hPi : priorAfterEvalPos w ≠ 0) :
+    adjSpeaker_warmAt vt w .warm = fval vt := by
+  have hPt : priorAfterEvalPos w ≠ ⊤ := PMF.apply_ne_top _ _
+  have hL0warm : adjL0_warmAt vt .warm w = priorAfterEvalPos w * (adjMass vt)⁻¹ := by
+    unfold adjL0_warmAt
+    rw [RSA.L0LassiterGoodman_apply, hw]
+    simp only [if_true, mul_one]
+    rfl
+  have hL0sil : adjL0_warmAt vt .silent w = priorAfterEvalPos w := by
+    unfold adjL0_warmAt
+    exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl) _ _
+  have h_dite : (∑' u, ((adjL0_warmAt vt) u w : ℝ≥0∞) ^ (4 : ℝ) * adjCostFactor u) ≠ 0 := by
+    rw [sumAdjUtt]
+    intro hz
+    obtain ⟨-, h2⟩ := add_eq_zero.mp hz
+    rcases mul_eq_zero.mp h2 with h3 | h3
+    · rw [hL0sil] at h3
+      exact hPi (by
+        by_contra hne
+        exact (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hne) hPt).ne' h3)
+    · rw [adjCostFactor_silent] at h3
+      exact one_ne_zero h3
+  unfold adjSpeaker_warmAt
+  rw [dif_pos h_dite, RSA.S1Belief_apply, sumAdjUtt, hL0warm, hL0sil, adjCostFactor_silent,
+    mul_one, ENNReal.mul_rpow_of_nonneg _ _ (by norm_num)]
+  have hP4 : (priorAfterEvalPos w) ^ (4 : ℝ) ≠ 0 :=
+    (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hPi) hPt).ne'
+  have hP4t : (priorAfterEvalPos w) ^ (4 : ℝ) ≠ ⊤ :=
+    ENNReal.rpow_ne_top_of_nonneg (by norm_num) hPt
+  rw [mul_assoc ((priorAfterEvalPos w) ^ (4 : ℝ)),
+    show (priorAfterEvalPos w) ^ (4 : ℝ) * ((adjMass vt)⁻¹ ^ (4 : ℝ) *
+          adjCostFactor .warm) + (priorAfterEvalPos w) ^ (4 : ℝ)
+        = (priorAfterEvalPos w) ^ (4 : ℝ) * ((adjMass vt)⁻¹ ^ (4 : ℝ) *
+          adjCostFactor .warm + 1) from by rw [mul_add, mul_one],
+    ← div_eq_mul_inv, ENNReal.mul_div_mul_left _ _ hP4 hP4t]
+  rfl
+
+/-- Stage-2 speaker value off support (at a non-degenerate world): `0`. -/
+theorem adjSpeaker_apply_of_false (vt : ValidThreshold) (w : Height)
+    (hw : adjLex (validToThreshold vt) .warm w = false)
+    (hPi : priorAfterEvalPos w ≠ 0) :
+    adjSpeaker_warmAt vt w .warm = 0 := by
+  have hPt : priorAfterEvalPos w ≠ ⊤ := PMF.apply_ne_top _ _
+  have hL0warm : adjL0_warmAt vt .warm w = 0 := by
+    unfold adjL0_warmAt
+    rw [RSA.L0LassiterGoodman_apply, hw]
+    simp
+  have hL0sil : adjL0_warmAt vt .silent w = priorAfterEvalPos w := by
+    unfold adjL0_warmAt
+    exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl) _ _
+  have h_dite : (∑' u, ((adjL0_warmAt vt) u w : ℝ≥0∞) ^ (4 : ℝ) * adjCostFactor u) ≠ 0 := by
+    rw [sumAdjUtt]
+    intro hz
+    obtain ⟨-, h2⟩ := add_eq_zero.mp hz
+    rcases mul_eq_zero.mp h2 with h3 | h3
+    · rw [hL0sil] at h3
+      exact hPi (by
+        by_contra hne
+        exact (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hne) hPt).ne' h3)
+    · rw [adjCostFactor_silent] at h3
+      exact one_ne_zero h3
+  unfold adjSpeaker_warmAt
+  rw [dif_pos h_dite, RSA.S1Belief_apply, hL0warm,
+    ENNReal.zero_rpow_of_pos (by norm_num), zero_mul, zero_mul]
+
+/-! ### Mass monotonicity — structural, no value computation
+
+The `.eval_pos` extension shrinks strictly from threshold 0 to threshold 1
+(`deg 2` has `μ_horrible = 1`, licensed at 0 but not at 1), so the eval mass
+drops strictly; the speaker value `gval` rises strictly (informativity). -/
+
+theorem evalMass_one_lt_zero : evalMass 1 < evalMass 0 := by
+  refine ENNReal.tsum_lt_tsum (i := deg 2) (evalMass_ne_top 1) (fun h => ?_) ?_
+  · fin_cases h <;>
+      simp [evalLex, evalMeaning, muHorrible, validToThreshold, Degree.Degree.toNat,
+        Degree.Threshold.toNat]
+  · simp only [evalLex, evalMeaning, muHorrible, validToThreshold, Degree.Degree.toNat,
+      Degree.Threshold.toNat, deg]
+    norm_num
+    exact pos_iff_ne_zero.mpr (heightPriorPMF_pos _)
+
+/-- `x ↦ x/(x+1)` is strictly monotone on finite `ℝ≥0∞` — the informativity
+step: a bigger unnormalised weight yields a bigger speaker value. -/
+private theorem div_succ_lt_div_succ {a b : ℝ≥0∞} (hb : b ≠ ⊤) (h : a < b) :
+    a / (a + 1) < b / (b + 1) := by
+  have ha : a ≠ ⊤ := ne_top_of_lt h
+  have hda : a / (a + 1) ≠ ⊤ := ENNReal.div_ne_top ha (by simp)
+  have hdb : b / (b + 1) ≠ ⊤ := ENNReal.div_ne_top hb (by simp)
+  rw [← ENNReal.toReal_lt_toReal hda hdb, ENNReal.toReal_div, ENNReal.toReal_div,
+    ENNReal.toReal_add ha ENNReal.one_ne_top, ENNReal.toReal_add hb ENNReal.one_ne_top,
+    ENNReal.toReal_one]
+  have h' : a.toReal < b.toReal := (ENNReal.toReal_lt_toReal ha hb).mpr h
+  have ha0 : (0 : ℝ) ≤ a.toReal := ENNReal.toReal_nonneg
+  rw [div_lt_div_iff₀ (by positivity) (by positivity)]
+  nlinarith
+
+/-- Informativity is threshold-monotone at the eval stage: the strictly
+smaller mass at threshold 1 yields a strictly larger speaker value. -/
+theorem gval_zero_lt_one : gval 0 < gval 1 := by
+  have hc0 : evalCostFactor .eval_pos ≠ 0 := evalCostFactor_pos _
+  have hct : evalCostFactor .eval_pos ≠ ⊤ := evalCostFactor_finite _
+  have hX : (evalMass 0)⁻¹ ^ (4 : ℝ) * evalCostFactor .eval_pos
+      < (evalMass 1)⁻¹ ^ (4 : ℝ) * evalCostFactor .eval_pos := by
+    rw [mul_comm _ (evalCostFactor .eval_pos), mul_comm _ (evalCostFactor .eval_pos)]
+    exact ENNReal.mul_lt_mul_right hc0 hct
+      (ENNReal.rpow_lt_rpow (ENNReal.inv_lt_inv.mpr evalMass_one_lt_zero) (by norm_num))
+  have hbt : (evalMass 1)⁻¹ ^ (4 : ℝ) * evalCostFactor .eval_pos ≠ ⊤ :=
+    ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+      (ENNReal.inv_ne_top.mpr (evalMass_ne_zero 1))) hct
+  exact div_succ_lt_div_succ hbt hX
+
+/-! ### Marginal expansions over the licensed thresholds -/
+
+theorem gval_ne_top (vt : ValidThreshold) : gval vt ≠ ⊤ :=
+  ENNReal.div_ne_top
+    (ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+      (ENNReal.inv_ne_top.mpr (evalMass_ne_zero vt))) (evalCostFactor_finite _))
+    (by simp)
+
+theorem fval_ne_top (vt : ValidThreshold) : fval vt ≠ ⊤ :=
+  ENNReal.div_ne_top
+    (ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+      (ENNReal.inv_ne_top.mpr (adjMass_ne_zero vt)))
+      (by unfold adjCostFactor; exact ENNReal.ofReal_ne_top))
+    (by simp)
+
+theorem fval_ne_zero (vt : ValidThreshold) : fval vt ≠ 0 := by
+  unfold fval
+  rw [ne_eq, ENNReal.div_eq_zero_iff, not_or]
+  constructor
+  · apply mul_ne_zero
+    · exact (ENNReal.rpow_pos (ENNReal.inv_pos.mpr (adjMass_ne_top vt))
+        (ENNReal.inv_ne_top.mpr (adjMass_ne_zero vt))).ne'
+    · unfold adjCostFactor
+      rw [ENNReal.ofReal_ne_zero_iff]
+      exact Real.exp_pos _
+  · exact ENNReal.add_ne_top.mpr
+      ⟨ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+        (ENNReal.inv_ne_top.mpr (adjMass_ne_zero vt)))
+        (by unfold adjCostFactor; exact ENNReal.ofReal_ne_top),
+       ENNReal.one_ne_top⟩
+
+/-- The raw prior ratio `P(deg 2) = 2 · P(deg 5)` (weights 10 vs 5) — no
+normaliser computation needed. -/
+theorem heightPriorPMF_deg2_eq :
+    heightPriorPMF (deg 2) = 2 * heightPriorPMF (deg 5) := by
+  unfold heightPriorPMF
+  rw [PMF.normalize_apply, PMF.normalize_apply, ← mul_assoc]
+  congr 1
+  unfold heightPriorENN
+  rw [show (heightPrior (deg 2) : ℝ) = 10 from by norm_num [show heightPrior (deg 2) = 10 from rfl],
+    show (heightPrior (deg 5) : ℝ) = 5 from by norm_num [show heightPrior (deg 5) = 5 from rfl],
+    show (2 : ℝ≥0∞) = ENNReal.ofReal (2 : ℝ) from (ENNReal.ofReal_ofNat 2).symm,
+    ← ENNReal.ofReal_mul (by norm_num)]
+  norm_num
+
+private theorem sumVT (f : ValidThreshold → ℝ≥0∞) :
+    ∑' vt, f vt = f 0 + f 1 + f 2 := by
+  rw [tsum_fintype, Fin.sum_univ_three]
+
+private theorem uPrior (vt : ValidThreshold) : thresholdPriorPMF vt = 3⁻¹ := by
+  rw [thresholdPriorPMF, PMF.uniformOfFintype_apply]
+  norm_num
+
+theorem evalMarginal_deg2 :
+    evalSpeakerMarginalHorrible (deg 2) .eval_pos = 3⁻¹ * gval 0 := by
+  unfold evalSpeakerMarginalHorrible
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+    evalSpeaker_apply_of_true 0 _ (by decide),
+    evalSpeaker_apply_of_false 1 _ (by decide),
+    evalSpeaker_apply_of_false 2 _ (by decide), mul_zero, add_zero, add_zero]
+
+theorem evalMarginal_deg5 :
+    evalSpeakerMarginalHorrible (deg 5) .eval_pos = 3⁻¹ * gval 0 + 3⁻¹ * gval 1 := by
+  unfold evalSpeakerMarginalHorrible
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+    evalSpeaker_apply_of_true 0 _ (by decide),
+    evalSpeaker_apply_of_true 1 _ (by decide),
+    evalSpeaker_apply_of_false 2 _ (by decide), mul_zero, add_zero]
+
+theorem adjMarginal_deg2 :
+    adjSpeakerMarginal (deg 2) .warm = 3⁻¹ * fval 0 + 3⁻¹ * fval 1 := by
+  unfold adjSpeakerMarginal
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+    adjSpeaker_apply_of_true 0 _ (by decide)
+      (priorAfterEvalPos_pos_at_horrible_pos (by decide)),
+    adjSpeaker_apply_of_true 1 _ (by decide)
+      (priorAfterEvalPos_pos_at_horrible_pos (by decide)),
+    adjSpeaker_apply_of_false 2 _ (by decide)
+      (priorAfterEvalPos_pos_at_horrible_pos (by decide)), mul_zero, add_zero]
+
+theorem adjMarginal_deg5 :
+    adjSpeakerMarginal (deg 5) .warm = 3⁻¹ * fval 0 + 3⁻¹ * fval 1 + 3⁻¹ * fval 2 := by
+  unfold adjSpeakerMarginal
+  rw [RSA.marginalizeKernel_apply, sumVT, uPrior, uPrior, uPrior,
+    adjSpeaker_apply_of_true 0 _ (by decide)
+      (priorAfterEvalPos_pos_at_horrible_pos (by decide)),
+    adjSpeaker_apply_of_true 1 _ (by decide)
+      (priorAfterEvalPos_pos_at_horrible_pos (by decide)),
+    adjSpeaker_apply_of_true 2 _ (by decide)
+      (priorAfterEvalPos_pos_at_horrible_pos (by decide))]
+
+/-! ## §6. Predictions
 
 The headline below states that "horribly warm" shifts probability toward
 *high* heights (deg 5 > deg 2). **HONEST SCOPE**: this is the
@@ -506,35 +826,50 @@ THIS model but the WRONG statement for Nouwen's actual Goldilocks claim.
 See module docstring §3 of "Scope (honest reckoning)". -/
 
 /-- The headline shift prediction in PMF form: "horribly warm" pushes
-probability toward higher heights (under the file's monotone `muHorrible`).
+probability toward the high extreme (`deg 5` over the moderate `deg 2`).
 
-**Discharge structure** (as far as structural decomposition reaches):
-
-The chained `posterior κ₂ (posterior κ₁ μ b₁) b₂` shape decomposes via
-`PMF.posterior_chained_lt_iff_score_lt` (the PMF analogue of mathlib's
-`posterior_comp` for chained Bayesian updates) — this is a single
-`rw` step that cancels both the inner and outer marginal denominators in
-one move, reducing the headline to a comparison of products of
-unnormalised scores `μ a · κ₁ a b₁ · κ₂ a b₂`.
-
-The remaining residue is the genuine "numeric arithmetic core": each side
-is a `Real.exp`-weighted sum over `ValidThreshold` whose value depends on
-the marginalised speaker computation. Same wall as
-`LassiterGoodman2017PMF`'s headline; same wall as the bundled-RSAConfig
-counterpart (`Nouwen2024.seq_horribly_shifts_upward`) — bundled passes via
-`rsa_predict` reflection on rational arithmetic; PMF face inherits the
-barrier and sorrys out. -/
+**Fully structural discharge** — no numeric reflection. The chained
+`posterior κ₂ (posterior κ₁ μ b₁) b₂` shape decomposes via
+`PMF.posterior_chained_lt_iff_score_lt` to a product comparison
+`μ(2)·E(2)·A(2) < μ(5)·E(5)·A(5)`; the ratio-cancellation lemmas (§5b)
+collapse each marginal to a sum of the mass-monotone speaker value over the
+licensed thresholds (`E(h) = Σ_{θ_e < μ_H(h)} gval θ_e`, `A(h) = Σ_{θ < h}
+fval θ`), and the raw prior ratio `μ(2) = 2·μ(5)` is beaten by informativity
+alone: `gval 1 > gval 0` (strictly smaller extension mass at the higher
+threshold), so `(g₀+g₁)(f₀+f₁+f₂) > 2·g₀·(f₀+f₁)`. -/
 theorem seq_horribly_shifts_upward_pmf :
     seqAdjL1HorriblyWarm .warm (deg 5) >
     seqAdjL1HorriblyWarm .warm (deg 2) := by
   unfold seqAdjL1HorriblyWarm priorAfterEvalPos evalL1Horrible
-  rw [gt_iff_lt, PMF.posterior_chained_lt_iff_score_lt]
-  -- Goal: heightPriorPMF (deg 2) * evalSpeakerMarginalHorrible (deg 2) .eval_pos
-  --       * adjSpeakerMarginal (deg 2) .warm
-  --     < heightPriorPMF (deg 5) * evalSpeakerMarginalHorrible (deg 5) .eval_pos
-  --       * adjSpeakerMarginal (deg 5) .warm
-  -- Numeric arithmetic core (same as bundled `rsa_predict` reflection territory).
-  sorry
+  rw [gt_iff_lt, PMF.posterior_chained_lt_iff_score_lt,
+    evalMarginal_deg2, evalMarginal_deg5, adjMarginal_deg2, adjMarginal_deg5,
+    heightPriorPMF_deg2_eq]
+  have hF0 : fval 0 + fval 1 ≠ 0 := fun h => fval_ne_zero 0 (add_eq_zero.mp h).1
+  have hFt : fval 0 + fval 1 ≠ ⊤ :=
+    ENNReal.add_ne_top.mpr ⟨fval_ne_top 0, fval_ne_top 1⟩
+  have key : 2 * gval 0 * (fval 0 + fval 1)
+      < (gval 0 + gval 1) * (fval 0 + fval 1 + fval 2) := by
+    have h1 : 2 * gval 0 * (fval 0 + fval 1)
+        < (gval 0 + gval 1) * (fval 0 + fval 1) := by
+      rw [two_mul, mul_comm (gval 0 + gval 0), mul_comm (gval 0 + gval 1)]
+      exact ENNReal.mul_lt_mul_right hF0 hFt
+        (ENNReal.add_lt_add_left (gval_ne_top 0) gval_zero_lt_one)
+    exact h1.trans_le (mul_le_mul_right le_self_add _)
+  have h3 : (3 : ℝ≥0∞)⁻¹ ≠ 0 := ENNReal.inv_ne_zero.mpr (by norm_num)
+  have h3t : (3 : ℝ≥0∞)⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr (by norm_num)
+  have hP5 : heightPriorPMF (deg 5) ≠ 0 := heightPriorPMF_pos _
+  have hP5t : heightPriorPMF (deg 5) ≠ ⊤ := PMF.apply_ne_top _ _
+  calc 2 * heightPriorPMF (deg 5) * (3⁻¹ * gval 0) * (3⁻¹ * fval 0 + 3⁻¹ * fval 1)
+      = heightPriorPMF (deg 5) * 3⁻¹ * 3⁻¹ * (2 * gval 0 * (fval 0 + fval 1)) := by
+        ring
+    _ < heightPriorPMF (deg 5) * 3⁻¹ * 3⁻¹ *
+        ((gval 0 + gval 1) * (fval 0 + fval 1 + fval 2)) :=
+        ENNReal.mul_lt_mul_right
+          (mul_ne_zero (mul_ne_zero hP5 h3) h3)
+          (ENNReal.mul_ne_top (ENNReal.mul_ne_top hP5t h3t) h3t) key
+    _ = heightPriorPMF (deg 5) * (3⁻¹ * gval 0 + 3⁻¹ * gval 1) *
+        (3⁻¹ * fval 0 + 3⁻¹ * fval 1 + 3⁻¹ * fval 2) := by
+        ring
 
 /-! ## §6'. Substrate gaps documented as sorry'd theorems (Nouwen 2024 not-formalised)
 
@@ -588,7 +923,7 @@ theorem eq_49_qud_partition_NOT_FORMALISED :
 The following theorems exercise the inequality-decomposition lemmas added in
 0.230.387. Each one proves a structural claim about the model that the new
 lemmas dispatch in 1-2 lines — no numeric arithmetic required. The contrast
-with `seq_horribly_shifts_upward_pmf` (which sorrys out the numeric core) is
+with `seq_horribly_shifts_upward_pmf` (closed structurally via §5b) is
 the point: structural shell handles structural claims; the numeric core is
 reflection territory, regardless of bundling. -/
 

--- a/Linglib/Studies/Nouwen2024PMF.lean
+++ b/Linglib/Studies/Nouwen2024PMF.lean
@@ -813,6 +813,209 @@ theorem adjMarginal_deg5 :
     adjSpeaker_apply_of_true 2 _ (by decide)
       (priorAfterEvalPos_pos_at_horrible_pos (by decide))]
 
+/-! ## §5c. The backgrounding contrast: why the paper rejects (49)
+
+[nouwen-2024] p. 28: "the source of this problem lies in the simple
+conjunctive analysis I assume in (49)… the two thresholds are resolved in
+tandem… all we need to do is update the two positive forms successively
+rather than simultaneously." Made structural: in the REJECTED simultaneous
+model, per-latent dominance FAILS on the shared licensing support — at a
+shared latent where every utterance is true at both worlds, ratio
+cancellation makes the speaker values exactly equal, so the raw height
+prior's 2:1 preference for the moderate world wins the term comparison
+(`sim_sharedSupport_dominance_fails`). In the final sequential model the
+same per-latent comparison HOLDS (`seq_horribly_shifts_upward_pmf`'s §5b
+engine): the backgrounded evaluative posterior has already re-loaded the
+prior toward the extremes. Backgrounding is exactly what makes
+intensification term-by-term derivable. -/
+
+/-- Cost factor for the simultaneous model's four utterances. -/
+noncomputable def simCostFactor (u : Utterance) : ℝ≥0∞ :=
+  ENNReal.ofReal (Real.exp (-4 * (utteranceCost u : ℝ)))
+
+theorem simCostFactor_pos (u : Utterance) : simCostFactor u ≠ 0 := by
+  unfold simCostFactor
+  rw [ENNReal.ofReal_ne_zero_iff]
+  exact Real.exp_pos _
+
+theorem simCostFactor_finite (u : Utterance) : simCostFactor u ≠ ∞ :=
+  ENNReal.ofReal_ne_top
+
+/-- Simultaneous-model literal listener at latent `(θ, θ_e)`, gated on the
+utterance's extension being nonempty (the four-utterance L&G L0). -/
+noncomputable def simL0At (l : Threshold × Threshold) (u : Utterance) : PMF Height :=
+  if h_pos : (∑' h, heightPriorPMF h *
+      (if meaning u h l.1 l.2 then (1 : ℝ≥0∞) else 0)) ≠ 0 then
+    RSA.L0LassiterGoodman heightPriorPMF (fun u' h => meaning u' h l.1 l.2) u h_pos
+  else PMF.uniformOfFintype Height
+
+/-- Simultaneous-model speaker at latent `(θ, θ_e)` and world `h` (total, with
+the vacuous fallback at degenerate cells, as in `adjSpeaker_warmAt`). -/
+noncomputable def simSpeakerAt (l : Threshold × Threshold) (h : Height) : PMF Utterance :=
+  if h_pos : (∑' u, ((simL0At l) u h : ℝ≥0∞) ^ (4 : ℝ) * simCostFactor u) ≠ 0 then
+    RSA.S1Belief (simL0At l) simCostFactor 4 h h_pos
+      (ENNReal.tsum_ne_top_of_fintype fun u =>
+        ENNReal.mul_ne_top
+          (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+          (simCostFactor_finite u))
+  else PMF.pure .silent
+
+/-- Per-latent joint term of the simultaneous model for "horribly warm":
+prior × speaker — one latent cell's contribution to the (49)-listener's
+world score. -/
+noncomputable def simTerm (l : Threshold × Threshold) (h : Height) : ℝ≥0∞ :=
+  heightPriorPMF h * simSpeakerAt l h .horribly_warm
+
+/-- Extension mass of utterance `u` at latent `l` (the `simL0At` normaliser). -/
+noncomputable def simMass (l : Threshold × Threshold) (u : Utterance) : ℝ≥0∞ :=
+  ∑' h, heightPriorPMF h * (if meaning u h l.1 l.2 then (1 : ℝ≥0∞) else 0)
+
+private theorem simMass_ne_zero_of_true {l : Threshold × Threshold} {u : Utterance}
+    {h : Height} (hu : meaning u h l.1 l.2 = true) : simMass l u ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr
+    ⟨h, by rw [hu]; simp only [if_true, mul_one]; exact heightPriorPMF_pos h⟩
+
+private theorem sumUtt4 (f : Utterance → ℝ≥0∞) :
+    ∑' u, f u = f .bare_warm + f .horribly_warm + f .pleasantly_warm + f .silent := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset Utterance)
+      = {.bare_warm, .horribly_warm, .pleasantly_warm, .silent} from by decide,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
+
+/-- At an all-true world, the simultaneous speaker's value is a function of
+the four extension masses alone — the height factor has cancelled. -/
+private theorem simValue_of_allTrue (l : Threshold × Threshold) (h : Height)
+    (hall : ∀ u : Utterance, meaning u h l.1 l.2 = true) :
+    simSpeakerAt l h .horribly_warm
+      = (simMass l .horribly_warm)⁻¹ ^ (4 : ℝ) * simCostFactor .horribly_warm /
+        ((simMass l .bare_warm)⁻¹ ^ (4 : ℝ) * simCostFactor .bare_warm +
+         (simMass l .horribly_warm)⁻¹ ^ (4 : ℝ) * simCostFactor .horribly_warm +
+         (simMass l .pleasantly_warm)⁻¹ ^ (4 : ℝ) * simCostFactor .pleasantly_warm +
+         (simMass l .silent)⁻¹ ^ (4 : ℝ) * simCostFactor .silent) := by
+  have hP0 : heightPriorPMF h ≠ 0 := heightPriorPMF_pos h
+  have hPt : heightPriorPMF h ≠ ⊤ := PMF.apply_ne_top _ _
+  have hL0 : ∀ u : Utterance, simL0At l u h = heightPriorPMF h * (simMass l u)⁻¹ := by
+    intro u
+    have hm : (∑' h', heightPriorPMF h' *
+        (if meaning u h' l.1 l.2 then (1 : ℝ≥0∞) else 0)) ≠ 0 :=
+      simMass_ne_zero_of_true (hall u)
+    unfold simL0At
+    rw [dif_pos hm, RSA.L0LassiterGoodman_apply, hall u]
+    simp only [if_true, mul_one]
+    rfl
+  have h_pos : (∑' u, ((simL0At l) u h : ℝ≥0∞) ^ (4 : ℝ) * simCostFactor u) ≠ 0 := by
+    rw [sumUtt4]
+    intro hz
+    rcases mul_eq_zero.mp (add_eq_zero.mp hz).2 with h5 | h5
+    · rw [hL0 .silent] at h5
+      have hne : heightPriorPMF h * (simMass l .silent)⁻¹ ≠ 0 :=
+        mul_ne_zero hP0 (ENNReal.inv_ne_zero.mpr (by
+          refine ne_top_of_le_ne_top ENNReal.one_ne_top ?_
+          calc simMass l .silent
+              ≤ ∑' h', heightPriorPMF h' := ENNReal.tsum_le_tsum fun h' => by
+                split <;> simp
+            _ = 1 := PMF.tsum_coe _))
+      rcases ENNReal.rpow_eq_zero_iff.mp h5 with ⟨hz0, -⟩ | ⟨-, hneg⟩
+      · exact hne hz0
+      · norm_num at hneg
+    · exact simCostFactor_pos .silent h5
+  unfold simSpeakerAt
+  rw [dif_pos h_pos, RSA.S1Belief_apply, sumUtt4, hL0 .bare_warm, hL0 .horribly_warm,
+    hL0 .pleasantly_warm, hL0 .silent]
+  simp only [ENNReal.mul_rpow_of_nonneg _ _ (by norm_num : (0:ℝ) ≤ 4)]
+  have hP4 : (heightPriorPMF h) ^ (4 : ℝ) ≠ 0 :=
+    (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hP0) hPt).ne'
+  have hP4t : (heightPriorPMF h) ^ (4 : ℝ) ≠ ⊤ :=
+    ENNReal.rpow_ne_top_of_nonneg (by norm_num) hPt
+  rw [← div_eq_mul_inv,
+    show heightPriorPMF h ^ (4 : ℝ) * (simMass l .horribly_warm)⁻¹ ^ (4 : ℝ) *
+          simCostFactor .horribly_warm
+        = heightPriorPMF h ^ (4 : ℝ) * ((simMass l .horribly_warm)⁻¹ ^ (4 : ℝ) *
+          simCostFactor .horribly_warm) from by ring,
+    show heightPriorPMF h ^ (4 : ℝ) * (simMass l .bare_warm)⁻¹ ^ (4 : ℝ) *
+          simCostFactor .bare_warm +
+        heightPriorPMF h ^ (4 : ℝ) * ((simMass l .horribly_warm)⁻¹ ^ (4 : ℝ) *
+          simCostFactor .horribly_warm) +
+        heightPriorPMF h ^ (4 : ℝ) * (simMass l .pleasantly_warm)⁻¹ ^ (4 : ℝ) *
+          simCostFactor .pleasantly_warm +
+        heightPriorPMF h ^ (4 : ℝ) * (simMass l .silent)⁻¹ ^ (4 : ℝ) *
+          simCostFactor .silent
+        = heightPriorPMF h ^ (4 : ℝ) * ((simMass l .bare_warm)⁻¹ ^ (4 : ℝ) *
+            simCostFactor .bare_warm +
+          (simMass l .horribly_warm)⁻¹ ^ (4 : ℝ) * simCostFactor .horribly_warm +
+          (simMass l .pleasantly_warm)⁻¹ ^ (4 : ℝ) * simCostFactor .pleasantly_warm +
+          (simMass l .silent)⁻¹ ^ (4 : ℝ) * simCostFactor .silent) from by ring,
+    ENNReal.mul_div_mul_left _ _ hP4 hP4t]
+
+private theorem simMass_ne_top (l : Threshold × Threshold) (u : Utterance) :
+    simMass l u ≠ ⊤ := by
+  refine ne_top_of_le_ne_top ENNReal.one_ne_top ?_
+  calc simMass l u
+      ≤ ∑' h', heightPriorPMF h' := ENNReal.tsum_le_tsum fun h' => by split <;> simp
+    _ = 1 := PMF.tsum_coe _
+
+/-- At a latent where every utterance is true at both worlds, ratio
+cancellation makes the two speaker values exactly equal. -/
+private theorem simSpeaker_value_congr (l : Threshold × Threshold) (h₁ h₂ : Height)
+    (hall₁ : ∀ u : Utterance, meaning u h₁ l.1 l.2 = true)
+    (hall₂ : ∀ u : Utterance, meaning u h₂ l.1 l.2 = true) :
+    simSpeakerAt l h₁ .horribly_warm = simSpeakerAt l h₂ .horribly_warm := by
+  rw [simValue_of_allTrue l h₁ hall₁, simValue_of_allTrue l h₂ hall₂]
+
+/-- **The failure half of the backgrounding contrast** ([nouwen-2024] p. 28:
+in (49) "the two thresholds are resolved in tandem"): in the rejected
+simultaneous model, per-latent dominance fails on the shared licensing
+support. At the shared latent `(θ, θ_e) = (1, 0)` every utterance is true at
+both `deg 2` and `deg 5`, so ratio cancellation makes the speaker values
+exactly equal — and the raw height prior's 2:1 preference for the moderate
+world decides the term comparison. Contrast the sequential model
+(`seq_horribly_shifts_upward_pmf`): after backgrounding, the same per-latent
+comparisons run against the evaluative posterior, which has already
+re-loaded the prior toward the extremes. Backgrounding, not parameter
+tuning, is what makes intensification term-by-term derivable. -/
+theorem sim_sharedSupport_dominance_fails :
+    ¬ ∀ l ∈ licensingSet .horribly_warm (deg 2),
+        simTerm l (deg 2) ≤ simTerm l (deg 5) := by
+  intro hforall
+  have hmem : ((thr 1, thr 0) : Threshold × Threshold)
+      ∈ licensingSet .horribly_warm (deg 2) := by decide
+  have hall2 : ∀ u : Utterance, meaning u (deg 2) (thr 1) (thr 0) = true := by
+    decide
+  have hcongr := simSpeaker_value_congr ((thr 1, thr 0) : Threshold × Threshold)
+    (deg 5) (deg 2) (by decide) hall2
+  set v := simSpeakerAt ((thr 1, thr 0) : Threshold × Threshold) (deg 2) .horribly_warm
+    with hv
+  have hv0 : v ≠ 0 := by
+    rw [hv, simValue_of_allTrue _ _ hall2, ne_eq, ENNReal.div_eq_zero_iff, not_or]
+    have hterm : ∀ u : Utterance,
+        (simMass ((thr 1, thr 0) : Threshold × Threshold) u)⁻¹ ^ (4 : ℝ) *
+          simCostFactor u ≠ ⊤ := fun u =>
+      ENNReal.mul_ne_top
+        (ENNReal.rpow_ne_top_of_nonneg (by norm_num)
+          (ENNReal.inv_ne_top.mpr (simMass_ne_zero_of_true (hall2 u))))
+        (simCostFactor_finite u)
+    refine ⟨mul_ne_zero ?_ (simCostFactor_pos _), ?_⟩
+    · exact (ENNReal.rpow_pos (ENNReal.inv_pos.mpr (simMass_ne_top _ _))
+        (ENNReal.inv_ne_top.mpr (simMass_ne_zero_of_true (hall2 .horribly_warm)))).ne'
+    · exact ENNReal.add_ne_top.mpr
+        ⟨ENNReal.add_ne_top.mpr ⟨ENNReal.add_ne_top.mpr ⟨hterm _, hterm _⟩, hterm _⟩,
+         hterm _⟩
+  have hvt : v ≠ ⊤ := PMF.apply_ne_top _ _
+  have hP5 : heightPriorPMF (deg 5) ≠ 0 := heightPriorPMF_pos _
+  have hP5t : heightPriorPMF (deg 5) ≠ ⊤ := PMF.apply_ne_top _ _
+  have hkey : simTerm (thr 1, thr 0) (deg 5) < simTerm (thr 1, thr 0) (deg 2) := by
+    unfold simTerm
+    rw [hcongr, ← hv, heightPriorPMF_deg2_eq]
+    calc heightPriorPMF (deg 5) * v
+        = heightPriorPMF (deg 5) * v * 1 := (mul_one _).symm
+      _ < heightPriorPMF (deg 5) * v * 2 :=
+          ENNReal.mul_lt_mul_right (mul_ne_zero hP5 hv0)
+            (ENNReal.mul_ne_top hP5t hvt) (by norm_num)
+      _ = 2 * heightPriorPMF (deg 5) * v := by ring
+  exact absurd (hforall _ hmem) (not_le.mpr hkey)
+
 /-! ## §6. Predictions
 
 The headline below states that "horribly warm" shifts probability toward


### PR DESCRIPTION
Wave 3 of the rsa_predict retirement: both files re-founded on the mathlib-PMF face with structural proofs — no numeric reflection, no interval arithmetic.

- Nouwen2024: semantic layer (exact Goldilocks boundary, Wheeler leak, licensing-support order) + PMF twin proves the sequential chain via ratio cancellation and mass monotonicity; backgrounding contrast pair (sim per-latent dominance failure vs seq success); Zwicky vacuity as an identity (constant-kernel posterior = prior, new Core lemma); all 17 rsa_predict theorems and the RSAConfig apparatus deleted.
- BumfordRett2021: evaluativity = σ-licensing-set inclusion between equal-prior worlds (7 theorems, only 0 < e); the non-evaluative comparative as prior dominance with an honest e-threshold (sharp boundary (25/120)⁴) and an exp(−4) bridging corollary.