### PR TITLE
refactor(Studies): retire rsa_predict in the four MEDIUM files

### DIFF
--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -674,9 +674,278 @@ private theorem cgUniform_pos (w : MFWorld) : cgUniform w ≠ 0 := by
   rw [cgUniform, PMF.uniformOfFintype_apply]
   simp
 
+private theorem quarter_eq_half_div : (4 : ℝ≥0∞)⁻¹ = 2⁻¹ / 2 := by
+  rw [div_eq_mul_inv, ← ENNReal.mul_inv (by norm_num) (by norm_num)]
+  norm_num
+
+private theorem quarter_add_quarter : (4 : ℝ≥0∞)⁻¹ + 4⁻¹ = 2⁻¹ := by
+  rw [quarter_eq_half_div, ENNReal.add_halves]
+
+private theorem four_quarters : (4 : ℝ≥0∞)⁻¹ + 4⁻¹ + 4⁻¹ + 4⁻¹ = 1 := by
+  rw [show (4 : ℝ≥0∞)⁻¹ + 4⁻¹ + 4⁻¹ + 4⁻¹ = (4⁻¹ + 4⁻¹) + (4⁻¹ + 4⁻¹) from by ring,
+    quarter_add_quarter, ENNReal.inv_two_add_inv_two]
+
+private theorem quarter_mul_two : (4 : ℝ≥0∞)⁻¹ * 2 = 2⁻¹ := by
+  rw [show (4 : ℝ≥0∞) = 2 * 2 from by norm_num,
+    ENNReal.mul_inv (by norm_num) (by norm_num), mul_assoc,
+    ENNReal.inv_mul_cancel (by norm_num) (by norm_num), mul_one]
+
+private theorem cgUniform_apply (w : MFWorld) : cgUniform w = 4⁻¹ := by
+  rw [cgUniform, PMF.uniformOfFintype_apply, card_mfworld]
+  norm_num
+
+private theorem sumWorlds (f : MFWorld → ℝ≥0∞) :
+    ∑' w, f w = f .ina + f .katie + f .nancy + f .sally := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset MFWorld) = {.ina, .katie, .nancy, .sally} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
+
+/-- Uniform extension masses: `1` for `null`, `1/2` for each specific
+utterance (true at exactly two of the four worlds). -/
+private theorem uniformMass (u : MFUtterance) :
+    (∑' w, cgUniform w * (if mfMeaning u w then (1 : ℝ≥0∞) else 0))
+      = if u = .null then 1 else 2⁻¹ := by
+  rw [sumWorlds]
+  simp only [cgUniform_apply]
+  cases u
+  case null =>
+    simp only [show ∀ w, mfMeaning .null w = true from fun _ => rfl, if_true,
+      mul_one, reduceIte]
+    exact four_quarters
+  case studyHumanity =>
+    rw [show mfMeaning .studyHumanity .ina = false from rfl,
+      show mfMeaning .studyHumanity .katie = false from rfl,
+      show mfMeaning .studyHumanity .nancy = true from rfl,
+      show mfMeaning .studyHumanity .sally = true from rfl]
+    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, zero_add, add_zero]
+    exact quarter_add_quarter
+  case studyScience =>
+    rw [show mfMeaning .studyScience .ina = true from rfl,
+      show mfMeaning .studyScience .katie = true from rfl,
+      show mfMeaning .studyScience .nancy = false from rfl,
+      show mfMeaning .studyScience .sally = false from rfl]
+    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, zero_add, add_zero]
+    exact quarter_add_quarter
+  case likeIndoors =>
+    rw [show mfMeaning .likeIndoors .ina = true from rfl,
+      show mfMeaning .likeIndoors .katie = false from rfl,
+      show mfMeaning .likeIndoors .nancy = false from rfl,
+      show mfMeaning .likeIndoors .sally = true from rfl]
+    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, zero_add, add_zero]
+    rw [show ((4 : ℝ≥0∞)⁻¹ + 4⁻¹) = 4⁻¹ + 4⁻¹ from rfl]
+    exact quarter_add_quarter
+  case likeOutdoors =>
+    rw [show mfMeaning .likeOutdoors .ina = false from rfl,
+      show mfMeaning .likeOutdoors .katie = true from rfl,
+      show mfMeaning .likeOutdoors .nancy = true from rfl,
+      show mfMeaning .likeOutdoors .sally = false from rfl]
+    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, zero_add, add_zero]
+    exact quarter_add_quarter
+
+/-- Literal-listener values under the uniform CG: `1/2` on a specific true
+utterance (mass `1/2` doubles the `1/4` prior), `1/4` on `null`, `0` off
+support. -/
+private theorem cgL0_uniform_apply (u : MFUtterance) (w : MFWorld) :
+    cgL0 cgUniform cgUniform_pos u w
+      = if mfMeaning u w then (if u = .null then 4⁻¹ else 2⁻¹) else 0 := by
+  unfold cgL0
+  rw [RSA.L0LassiterGoodman_apply,
+    show (∑' w', cgUniform w' * (if mfMeaning u w' then (1 : ℝ≥0∞) else 0))
+      = if u = .null then 1 else 2⁻¹ from uniformMass u, cgUniform_apply]
+  by_cases hw : mfMeaning u w = true
+  · rw [hw]
+    by_cases hn : u = .null <;>
+      simp only [hn, if_true, if_false, reduceIte, mul_one, inv_one, inv_inv]
+    exact quarter_mul_two
+  · rw [Bool.not_eq_true] at hw
+    rw [hw]
+    simp
+
+private theorem sumUtts (f : MFUtterance → ℝ≥0∞) :
+    ∑' u, f u = f .studyHumanity + f .studyScience + f .likeIndoors +
+      f .likeOutdoors + f .null := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset MFUtterance)
+      = {.studyHumanity, .studyScience, .likeIndoors, .likeOutdoors, .null} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_singleton]
+  ring
+
+private theorem half_conv : (2 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/2) := by
+  rw [show (2 : ℝ≥0∞) = ENNReal.ofReal 2 from (ENNReal.ofReal_ofNat 2).symm,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+  norm_num
+
+private theorem quarter_conv : (4 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/4) := by
+  rw [show (4 : ℝ≥0∞) = ENNReal.ofReal 4 from (ENNReal.ofReal_ofNat 4).symm,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+  norm_num
+
+/-- The turn-1 speaker normaliser at every world: `1/2 + 1/2 + 1/4 = 5/4`
+(two true specific utterances plus `null`). -/
+private theorem Z_uniform (w : MFWorld) :
+    (∑' u, ((cgL0 cgUniform cgUniform_pos u w : ℝ≥0∞)) ^ (1 : ℝ) * 1)
+      = ENNReal.ofReal (5/4) := by
+  simp only [ENNReal.rpow_one, mul_one]
+  rw [sumUtts]
+  simp only [cgL0_uniform_apply]
+  cases w <;>
+    · simp +decide [mfMeaning, worldMajor, worldLocation]
+      rw [half_conv, quarter_conv, ← ENNReal.ofReal_add (by norm_num) (by norm_num),
+        ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+      norm_num
+
 /-- Turn-1 chain. -/
 noncomputable def s1Turn1 : MFWorld → PMF MFUtterance := cgS1 cgUniform cgUniform_pos
+
+private theorem Z_uniform' (w : MFWorld) :
+    (∑' u, cgL0 cgUniform cgUniform_pos u w) = ENNReal.ofReal (5/4) := by
+  have h := Z_uniform w
+  simpa [ENNReal.rpow_one] using h
+
+private theorem s1_val_arith :
+    (2 : ℝ≥0∞)⁻¹ * (ENNReal.ofReal (5/4))⁻¹ = ENNReal.ofReal (2/5) := by
+  rw [half_conv, ← ENNReal.ofReal_inv_of_pos (by norm_num),
+    ← ENNReal.ofReal_mul (by norm_num)]
+  norm_num
+
+private theorem s1_null_arith :
+    (4 : ℝ≥0∞)⁻¹ * (ENNReal.ofReal (5/4))⁻¹ = ENNReal.ofReal (1/5) := by
+  rw [quarter_conv, ← ENNReal.ofReal_inv_of_pos (by norm_num),
+    ← ENNReal.ofReal_mul (by norm_num)]
+  norm_num
+
+/-- Turn-1 speaker value on a true specific utterance: `2/5` — identical at
+every world (each satisfies exactly two specific utterances plus `null`).
+Derived from the Figure-4 equations; [anderson-2021]'s Figure 5 reports the
+qualitative multi-move profile. -/
+private theorem cgS1_uniform_true {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = true) (hn : u ≠ .null) :
+    cgS1 cgUniform cgUniform_pos w u = ENNReal.ofReal (2/5) := by
+  unfold cgS1
+  rw [RSA.S1Belief_apply]
+  simp only [ENNReal.rpow_one, mul_one]
+  rw [Z_uniform' w, cgL0_uniform_apply, hw]
+  simp only [if_true, reduceIte]
+  rw [if_neg hn]
+  exact s1_val_arith
+
+/-- Turn-1 speaker value on `null`: `1/5` at every world. -/
+private theorem cgS1_uniform_null (w : MFWorld) :
+    cgS1 cgUniform cgUniform_pos w .null = ENNReal.ofReal (1/5) := by
+  unfold cgS1
+  rw [RSA.S1Belief_apply]
+  simp only [ENNReal.rpow_one, mul_one]
+  rw [Z_uniform' w, cgL0_uniform_apply]
+  simp only [show mfMeaning .null w = true from rfl, if_true, reduceIte]
+  exact s1_null_arith
+
+/-- Turn-1 speaker value off support: `0`. -/
+private theorem cgS1_uniform_false {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = false) : cgS1 cgUniform cgUniform_pos w u = 0 := by
+  unfold cgS1
+  rw [RSA.S1Belief_apply]
+  simp only [ENNReal.rpow_one, mul_one]
+  rw [cgL0_uniform_apply, hw]
+  simp
+
+/-- Turn-1 speaker values ([anderson-2021] Figure-4 equations at the uniform
+CG; derived exact rationals — Figure 5 reports the qualitative profile):
+`2/5` on each true specific utterance, `1/5` on `null`, `0` off support. -/
+theorem s1Turn1_true {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = true) (hn : u ≠ .null) :
+    s1Turn1 w u = ENNReal.ofReal (2/5) := cgS1_uniform_true hw hn
+
+theorem s1Turn1_null (w : MFWorld) : s1Turn1 w .null = ENNReal.ofReal (1/5) :=
+  cgS1_uniform_null w
+
+theorem s1Turn1_false {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = false) : s1Turn1 w u = 0 := cgS1_uniform_false hw
+
+/-- The utterance marginal at turn 1 is `1/5` for every utterance: specific
+utterances collect `2 · (1/4)·(2/5)`, `null` collects `4 · (1/4)·(1/5)`. -/
+private theorem marginal_uniform (u : MFUtterance) :
+    PMF.marginal (cgS1 cgUniform cgUniform_pos) cgUniform u = ENNReal.ofReal (1/5) := by
+  show (cgUniform.bind (cgS1 cgUniform cgUniform_pos)) u = _
+  rw [PMF.bind_apply, sumWorlds]
+  simp only [cgUniform_apply]
+  cases u
+  case null =>
+    rw [cgS1_uniform_null, cgS1_uniform_null, cgS1_uniform_null, cgS1_uniform_null,
+      quarter_conv, ← ENNReal.ofReal_mul (by norm_num),
+      ← ENNReal.ofReal_add (by norm_num) (by norm_num),
+      ← ENNReal.ofReal_add (by norm_num) (by norm_num),
+      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+    norm_num
+  all_goals
+    first
+    | (rw [cgS1_uniform_false (by decide), cgS1_uniform_false (by decide),
+          cgS1_uniform_true (by decide) (by decide),
+          cgS1_uniform_true (by decide) (by decide),
+          quarter_conv, ← ENNReal.ofReal_mul (by norm_num)]
+       simp only [mul_zero, zero_add, add_zero]
+       rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+       norm_num)
+    | (rw [cgS1_uniform_true (by decide) (by decide),
+          cgS1_uniform_true (by decide) (by decide),
+          cgS1_uniform_false (by decide), cgS1_uniform_false (by decide),
+          quarter_conv, ← ENNReal.ofReal_mul (by norm_num)]
+       simp only [mul_zero, zero_add, add_zero]
+       rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+       norm_num)
+    | (rw [cgS1_uniform_true (by decide) (by decide),
+          cgS1_uniform_false (by decide), cgS1_uniform_false (by decide),
+          cgS1_uniform_true (by decide) (by decide),
+          quarter_conv, ← ENNReal.ofReal_mul (by norm_num)]
+       simp only [mul_zero, zero_add, add_zero]
+       rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+       norm_num)
+    | (rw [cgS1_uniform_false (by decide),
+          cgS1_uniform_true (by decide) (by decide),
+          cgS1_uniform_true (by decide) (by decide),
+          cgS1_uniform_false (by decide),
+          quarter_conv, ← ENNReal.ofReal_mul (by norm_num)]
+       simp only [mul_zero, zero_add, add_zero]
+       rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+       norm_num)
 noncomputable def l1Turn1 : MFUtterance → PMF MFWorld := cgL1 cgUniform cgUniform_pos
+
+private theorem l1_arith_true :
+    (4 : ℝ≥0∞)⁻¹ * ENNReal.ofReal (2/5) * (ENNReal.ofReal (1/5))⁻¹
+      = ENNReal.ofReal (1/2) := by
+  rw [quarter_conv, ← ENNReal.ofReal_mul (by norm_num),
+    ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
+  norm_num
+
+private theorem l1_arith_null :
+    (4 : ℝ≥0∞)⁻¹ * ENNReal.ofReal (1/5) * (ENNReal.ofReal (1/5))⁻¹
+      = ENNReal.ofReal (1/4) := by
+  rw [quarter_conv, ← ENNReal.ofReal_mul (by norm_num),
+    ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
+  norm_num
+
+/-- Turn-1 listener values (derived; `L1 ∝ PragSpeak·CG`, Figure 4): `1/2`
+on each world satisfying a specific utterance, `1/4` on every world after
+`null`, `0` off support. -/
+theorem l1Turn1_true {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = true) (hn : u ≠ .null) :
+    l1Turn1 u w = ENNReal.ofReal (1/2) := by
+  unfold l1Turn1 cgL1
+  rw [PMF.posterior_apply, marginal_uniform, cgUniform_apply, cgS1_uniform_true hw hn]
+  exact l1_arith_true
+
+theorem l1Turn1_null (w : MFWorld) : l1Turn1 .null w = ENNReal.ofReal (1/4) := by
+  unfold l1Turn1 cgL1
+  rw [PMF.posterior_apply, marginal_uniform, cgUniform_apply, cgS1_uniform_null]
+  exact l1_arith_null
+
+theorem l1Turn1_false {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = false) : l1Turn1 u w = 0 := by
+  unfold l1Turn1 cgL1
+  rw [PMF.posterior_apply, cgS1_uniform_false hw, mul_zero, zero_mul]
 noncomputable def s2Turn1 : MFWorld → PMF MFUtterance := cgS2 cgUniform cgUniform_pos
 
 end PMFChain
@@ -1312,3 +1581,4 @@ theorem a_initial_diff_nancy_highest :
   · rw [ho .sally (by decide)]; norm_num
 
 end Anderson2021
+

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -216,7 +216,7 @@ noncomputable def ofWeights [Fintype W] (f : W → ℝ) (hn : ∀ w, 0 ≤ f w)
     (hpos : 0 < ∑ w, f w) : DistributionalCG W :=
   have hex : ∃ w, 0 < f w := by
     by_contra h
-    push_neg at h
+    push Not at h
     exact absurd hpos (not_lt.mpr (Finset.sum_nonpos fun w _ => h w))
   ⟨PMF.ofRealWeightFn f hn hex.choose hex.choose_spec⟩
 
@@ -701,7 +701,7 @@ private theorem uniformMass (u : MFUtterance) :
   cases u
   case null =>
     simp only [show ∀ w, mfMeaning .null w = true from fun _ => rfl, if_true,
-      mul_one, reduceIte]
+      mul_one]
     exact four_quarters
   case studyHumanity =>
     rw [show mfMeaning .studyHumanity .ina = false from rfl,
@@ -715,14 +715,14 @@ private theorem uniformMass (u : MFUtterance) :
       show mfMeaning .studyScience .katie = true from rfl,
       show mfMeaning .studyScience .nancy = false from rfl,
       show mfMeaning .studyScience .sally = false from rfl]
-    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, zero_add, add_zero]
+    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, add_zero]
     exact quarter_add_quarter
   case likeIndoors =>
     rw [show mfMeaning .likeIndoors .ina = true from rfl,
       show mfMeaning .likeIndoors .katie = false from rfl,
       show mfMeaning .likeIndoors .nancy = false from rfl,
       show mfMeaning .likeIndoors .sally = true from rfl]
-    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, zero_add, add_zero]
+    simp only [reduceIte, reduceCtorEq, mul_one, mul_zero, add_zero]
     rw [show ((4 : ℝ≥0∞)⁻¹ + 4⁻¹) = 4⁻¹ + 4⁻¹ from rfl]
     exact quarter_add_quarter
   case likeOutdoors =>
@@ -746,7 +746,7 @@ private theorem cgL0_uniform_apply (u : MFUtterance) (w : MFWorld) :
   by_cases hw : mfMeaning u w = true
   · rw [hw]
     by_cases hn : u = .null <;>
-      simp only [hn, if_true, if_false, reduceIte, mul_one, inv_one, inv_inv]
+      simp only [hn, if_true, if_false, mul_one, inv_one, inv_inv]
     exact quarter_mul_two
   · rw [Bool.not_eq_true] at hw
     rw [hw]
@@ -782,7 +782,7 @@ private theorem Z_uniform (w : MFWorld) :
   rw [sumUtts]
   simp only [cgL0_uniform_apply]
   cases w <;>
-    · simp +decide [mfMeaning, worldMajor, worldLocation]
+    · simp +decide
       rw [half_conv, quarter_conv, ← ENNReal.ofReal_add (by norm_num) (by norm_num),
         ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
       norm_num
@@ -818,7 +818,7 @@ private theorem cgS1_uniform_true {u : MFUtterance} {w : MFWorld}
   rw [RSA.S1Belief_apply]
   simp only [ENNReal.rpow_one, mul_one]
   rw [Z_uniform' w, cgL0_uniform_apply, hw]
-  simp only [if_true, reduceIte]
+  simp only [if_true]
   rw [if_neg hn]
   exact s1_val_arith
 
@@ -829,7 +829,7 @@ private theorem cgS1_uniform_null (w : MFWorld) :
   rw [RSA.S1Belief_apply]
   simp only [ENNReal.rpow_one, mul_one]
   rw [Z_uniform' w, cgL0_uniform_apply]
-  simp only [show mfMeaning .null w = true from rfl, if_true, reduceIte]
+  simp only [show mfMeaning .null w = true from rfl, if_true]
   exact s1_null_arith
 
 /-- Turn-1 speaker value off support: `0`. -/
@@ -882,14 +882,14 @@ private theorem marginal_uniform (u : MFUtterance) :
           cgS1_uniform_true (by decide) (by decide),
           cgS1_uniform_false (by decide), cgS1_uniform_false (by decide),
           quarter_conv, ← ENNReal.ofReal_mul (by norm_num)]
-       simp only [mul_zero, zero_add, add_zero]
+       simp only [mul_zero, add_zero]
        rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
        norm_num)
     | (rw [cgS1_uniform_true (by decide) (by decide),
           cgS1_uniform_false (by decide), cgS1_uniform_false (by decide),
           cgS1_uniform_true (by decide) (by decide),
           quarter_conv, ← ENNReal.ofReal_mul (by norm_num)]
-       simp only [mul_zero, zero_add, add_zero]
+       simp only [mul_zero, add_zero]
        rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
        norm_num)
     | (rw [cgS1_uniform_false (by decide),
@@ -1083,10 +1083,6 @@ noncomputable def l1Turn2 : MFUtterance → PMF MFWorld := cgL1 cgTurn2PMF cgTur
 private theorem t2_sum : (∑' w, ENNReal.ofReal (cgTurn2 w)) = ENNReal.ofReal 10 := by
   rw [sumWorlds]
   norm_num [cgTurn2]
-  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  try norm_num
 
 private theorem cgTurn2PMF_apply (w : MFWorld) :
     cgTurn2PMF w = ENNReal.ofReal (cgTurn2 w / 10) := by
@@ -1110,14 +1106,13 @@ private theorem t2Mass (u : MFUtterance) :
   rw [sumWorlds]
   simp only [cgTurn2PMF_apply]
   cases u <;>
-    · simp +decide [mfMeaning, worldMajor, worldLocation, cgTurn2, t2MassQ]
+    · simp +decide [cgTurn2, t2MassQ]
       try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
       try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
       try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
       first
         | (rw [half_conv]; congr 1; norm_num)
         | norm_num
-        | rfl
 
 private theorem cgL0_t2_true {u : MFUtterance} {w : MFWorld}
     (hw : mfMeaning u w = true) :
@@ -1125,10 +1120,10 @@ private theorem cgL0_t2_true {u : MFUtterance} {w : MFWorld}
       = ENNReal.ofReal (cgTurn2 w / 10 / t2MassQ u) := by
   unfold cgL0
   rw [RSA.L0LassiterGoodman_apply, hw, t2Mass, cgTurn2PMF_apply]
-  simp only [if_true, mul_one, reduceIte]
+  simp only [if_true, mul_one]
   rw [← ENNReal.ofReal_inv_of_pos (by cases u <;> norm_num [t2MassQ]),
     ← ENNReal.ofReal_mul (by cases w <;> norm_num [cgTurn2])]
-  congr 1 <;> ring
+  congr 1
 
 private theorem cgL0_t2_false {u : MFUtterance} {w : MFWorld}
     (hw : mfMeaning u w = false) :
@@ -1178,7 +1173,7 @@ private theorem cgS1_t2_true {u : MFUtterance} {w : MFWorld}
     cgL0_t2_true hw,
     ← ENNReal.ofReal_inv_of_pos (by cases w <;> norm_num [Zt2Q]),
     ← ENNReal.ofReal_mul (by cases u <;> cases w <;> norm_num [cgTurn2, t2MassQ])]
-  congr 1 <;> ring
+  congr 1
 
 private theorem cgS1_t2_false {u : MFUtterance} {w : MFWorld}
     (hw : mfMeaning u w = false) :

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -1,5 +1,7 @@
 import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.LatentOperators
+import Linglib.Pragmatics.RSA.Operators
 import Linglib.Core.Probability.Choice.Learning
 import Linglib.Discourse.CommonGround
 import Linglib.Core.Probability.Constructions
@@ -591,6 +593,95 @@ noncomputable def mfRSA : RSAConfig MFUtterance MFWorld where
   latentPrior_nonneg _ _ := by norm_num
 
 -- ════════════════════════════════════════════════════
+-- § 8b. PMF chain (CG-parameterized; local pending the RSA API pass)
+-- ════════════════════════════════════════════════════
+
+section PMFChain
+
+open scoped ENNReal
+
+/-- Every utterance is satisfiable (each has two true worlds; `null` four). -/
+private theorem mfMeaning_sat : ∀ u : MFUtterance, ∃ w, mfMeaning u w = true := by
+  decide
+
+private theorem cgL0_pos (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0) (u : MFUtterance) :
+    (∑' w, cg w * (if mfMeaning u w then (1 : ℝ≥0∞) else 0)) ≠ 0 := by
+  obtain ⟨w, hw⟩ := mfMeaning_sat u
+  exact ENNReal.summable.tsum_ne_zero_iff.mpr
+    ⟨w, by rw [hw]; simpa using hcg w⟩
+
+/-- CG-weighted literal listener ([anderson-2021] Figure 4: `L0 ∝ ⟦u⟧·CG`). -/
+private noncomputable def cgL0 (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (u : MFUtterance) : PMF MFWorld :=
+  RSA.L0LassiterGoodman cg mfMeaning u (cgL0_pos cg hcg u)
+
+private theorem cgL0_null (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0) (w : MFWorld) :
+    cgL0 cg hcg .null w = cg w := by
+  unfold cgL0
+  exact RSA.L0LassiterGoodman_apply_of_meaning_true _ _ _ (fun _ => rfl) _ _
+
+/-- Pragmatic speaker ([anderson-2021] Figure 4: `S1 ∝ LitList`; fn. 3: the
+softmax terms are omitted and probabilities renormalized, i.e. `α = 1` and
+no cost — the speaker weight IS the literal-listener value). -/
+private noncomputable def cgS1 (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (w : MFWorld) : PMF MFUtterance :=
+  RSA.S1Belief (cgL0 cg hcg) (fun _ => 1) 1 w
+    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.null, by
+      rw [cgL0_null cg hcg w]
+      exact mul_ne_zero
+        ((ENNReal.rpow_pos (pos_iff_ne_zero.mpr (hcg w)) (PMF.apply_ne_top _ _)).ne')
+        one_ne_zero⟩)
+    (ENNReal.tsum_ne_top_of_fintype fun u =>
+      ENNReal.mul_ne_top
+        (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+        ENNReal.one_ne_top)
+
+private theorem cgS1_marginal_pos (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (u : MFUtterance) : PMF.marginal (cgS1 cg hcg) cg u ≠ 0 := by
+  obtain ⟨w, hw⟩ := mfMeaning_sat u
+  refine PMF.marginal_ne_zero _ _ _ (hcg w) ?_
+  have hL0 : cgL0 cg hcg u w ≠ 0 := by
+    unfold cgL0
+    rw [← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
+    exact ⟨hcg w, hw⟩
+  unfold cgS1
+  exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 one_ne_zero
+
+/-- Pragmatic listener ([anderson-2021] Figure 4: `L1 ∝ PragSpeak·CG`). -/
+private noncomputable def cgL1 (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (u : MFUtterance) : PMF MFWorld :=
+  PMF.posterior (cgS1 cg hcg) cg u (cgS1_marginal_pos cg hcg u)
+
+/-- Endorsement speaker: `S2(u|w) ∝ L1(w|u)` (uniform utterance prior),
+matching `RSAConfig.S2agent`'s Bayes inversion of L1 over utterances. -/
+private noncomputable def cgS2 (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (w : MFWorld) : PMF MFUtterance :=
+  PMF.normalize (fun u => cgL1 cg hcg u w)
+    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.null, by
+      unfold cgL1
+      rw [← PMF.mem_support_iff, PMF.mem_support_posterior_iff]
+      refine ⟨hcg w, ?_⟩
+      unfold cgS1
+      exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _
+        (by rw [cgL0_null cg hcg w]; exact hcg w) one_ne_zero⟩)
+    (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _)
+
+/-- Turn-1 Common Ground: uniform ([anderson-2021] Figure 2:
+`CG = Uniform(worlds)`). -/
+private noncomputable def cgUniform : PMF MFWorld := PMF.uniformOfFintype MFWorld
+
+private theorem cgUniform_pos (w : MFWorld) : cgUniform w ≠ 0 := by
+  rw [cgUniform, PMF.uniformOfFintype_apply]
+  simp
+
+/-- Turn-1 chain. -/
+noncomputable def s1Turn1 : MFWorld → PMF MFUtterance := cgS1 cgUniform cgUniform_pos
+noncomputable def l1Turn1 : MFUtterance → PMF MFWorld := cgL1 cgUniform cgUniform_pos
+noncomputable def s2Turn1 : MFWorld → PMF MFUtterance := cgS2 cgUniform cgUniform_pos
+
+end PMFChain
+
+-- ════════════════════════════════════════════════════
 -- § 9. Turn 1: S1 Predictions
 -- ════════════════════════════════════════════════════
 
@@ -700,6 +791,32 @@ def cgTurn2 : MFWorld → ℝ
 
 theorem cgTurn2_nonneg : ∀ w, 0 ≤ cgTurn2 w := by
   intro w; cases w <;> norm_num [cgTurn2]
+
+section PMFChain
+
+open scoped ENNReal
+
+/-- Turn-2 Common Ground as a PMF: the normalised `[2,2,3,3]` weights
+(= `0.8·uniform + 0.2·L1(studyHumanity)`, [anderson-2021] fn. 9's lr = 0.2). -/
+private noncomputable def cgTurn2PMF : PMF MFWorld :=
+  PMF.normalize (fun w => ENNReal.ofReal (cgTurn2 w))
+    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.ina, by
+      rw [ENNReal.ofReal_ne_zero_iff]
+      norm_num [cgTurn2]⟩)
+    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+
+private theorem cgTurn2PMF_pos (w : MFWorld) : cgTurn2PMF w ≠ 0 := by
+  rw [cgTurn2PMF, PMF.normalize_apply]
+  refine mul_ne_zero ?_ (ENNReal.inv_ne_zero.mpr
+    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top))
+  rw [ENNReal.ofReal_ne_zero_iff]
+  cases w <;> norm_num [cgTurn2]
+
+/-- Turn-2 chain. -/
+noncomputable def s1Turn2 : MFWorld → PMF MFUtterance := cgS1 cgTurn2PMF cgTurn2PMF_pos
+noncomputable def l1Turn2 : MFUtterance → PMF MFWorld := cgL1 cgTurn2PMF cgTurn2PMF_pos
+
+end PMFChain
 
 /-- RSA model after hearing "studyHumanity" at turn 1.
 

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -1093,6 +1093,115 @@ private theorem cgTurn2PMF_pos (w : MFWorld) : cgTurn2PMF w ≠ 0 := by
 noncomputable def s1Turn2 : MFWorld → PMF MFUtterance := cgS1 cgTurn2PMF cgTurn2PMF_pos
 noncomputable def l1Turn2 : MFUtterance → PMF MFWorld := cgL1 cgTurn2PMF cgTurn2PMF_pos
 
+private theorem t2_sum : (∑' w, ENNReal.ofReal (cgTurn2 w)) = ENNReal.ofReal 10 := by
+  rw [sumWorlds]
+  norm_num [cgTurn2]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try norm_num
+
+private theorem cgTurn2PMF_apply (w : MFWorld) :
+    cgTurn2PMF w = ENNReal.ofReal (cgTurn2 w / 10) := by
+  rw [cgTurn2PMF, PMF.normalize_apply, t2_sum,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num),
+    ← ENNReal.ofReal_mul (by cases w <;> norm_num [cgTurn2])]
+  rw [div_eq_mul_inv]
+
+/-- Turn-2 masses: `3/5` for humanity, `2/5` for science, `1/2` for each
+location, `1` for `null` (weights `[2,2,3,3]/10`). -/
+private noncomputable def t2MassQ : MFUtterance → ℝ
+  | .studyHumanity => 3/5
+  | .studyScience  => 2/5
+  | .likeIndoors   => 1/2
+  | .likeOutdoors  => 1/2
+  | .null          => 1
+
+private theorem t2Mass (u : MFUtterance) :
+    (∑' w, cgTurn2PMF w * (if mfMeaning u w then (1 : ℝ≥0∞) else 0))
+      = ENNReal.ofReal (t2MassQ u) := by
+  rw [sumWorlds]
+  simp only [cgTurn2PMF_apply]
+  cases u <;>
+    · simp +decide [mfMeaning, worldMajor, worldLocation, cgTurn2, t2MassQ]
+      try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+      try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+      try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+      first
+        | (rw [half_conv]; congr 1; norm_num)
+        | norm_num
+        | rfl
+
+private theorem cgL0_t2_true {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = true) :
+    cgL0 cgTurn2PMF cgTurn2PMF_pos u w
+      = ENNReal.ofReal (cgTurn2 w / 10 / t2MassQ u) := by
+  unfold cgL0
+  rw [RSA.L0LassiterGoodman_apply, hw, t2Mass, cgTurn2PMF_apply]
+  simp only [if_true, mul_one, reduceIte]
+  rw [← ENNReal.ofReal_inv_of_pos (by cases u <;> norm_num [t2MassQ]),
+    ← ENNReal.ofReal_mul (by cases w <;> norm_num [cgTurn2])]
+  congr 1 <;> ring
+
+private theorem cgL0_t2_false {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = false) :
+    cgL0 cgTurn2PMF cgTurn2PMF_pos u w = 0 := by
+  unfold cgL0
+  rw [RSA.L0LassiterGoodman_apply, hw]
+  simp
+
+/-- Turn-2 speaker normalisers: `7/5` at the high-CG worlds (nancy, sally),
+`11/10` at the low-CG worlds (ina, katie). -/
+private noncomputable def Zt2Q : MFWorld → ℝ
+  | .ina | .katie => 11/10
+  | .nancy | .sally => 7/5
+
+private theorem Z_t2 (w : MFWorld) :
+    (∑' u, cgL0 cgTurn2PMF cgTurn2PMF_pos u w) = ENNReal.ofReal (Zt2Q w) := by
+  rw [sumUtts]
+  cases w <;>
+    · first
+      | rw [cgL0_t2_false (by decide), cgL0_t2_true (by decide),
+          cgL0_t2_true (by decide), cgL0_t2_false (by decide),
+          cgL0_t2_true (by decide)]
+      | rw [cgL0_t2_false (by decide), cgL0_t2_true (by decide),
+          cgL0_t2_false (by decide), cgL0_t2_true (by decide),
+          cgL0_t2_true (by decide)]
+      | rw [cgL0_t2_true (by decide), cgL0_t2_false (by decide),
+          cgL0_t2_false (by decide), cgL0_t2_true (by decide),
+          cgL0_t2_true (by decide)]
+      | rw [cgL0_t2_true (by decide), cgL0_t2_false (by decide),
+          cgL0_t2_true (by decide), cgL0_t2_false (by decide),
+          cgL0_t2_true (by decide)]
+      simp only [cgTurn2, t2MassQ, Zt2Q, zero_add, add_zero]
+      rw [← ENNReal.ofReal_add (by norm_num) (by norm_num),
+        ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+      norm_num
+
+/-- Generic turn-2 speaker value on support. -/
+private theorem cgS1_t2_true {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = true) :
+    cgS1 cgTurn2PMF cgTurn2PMF_pos w u
+      = ENNReal.ofReal (cgTurn2 w / 10 / t2MassQ u / Zt2Q w) := by
+  unfold cgS1
+  rw [RSA.S1Belief_apply]
+  simp only [ENNReal.rpow_one, mul_one]
+  rw [show (∑' u', cgL0 cgTurn2PMF cgTurn2PMF_pos u' w) = ENNReal.ofReal (Zt2Q w)
+      from Z_t2 w,
+    cgL0_t2_true hw,
+    ← ENNReal.ofReal_inv_of_pos (by cases w <;> norm_num [Zt2Q]),
+    ← ENNReal.ofReal_mul (by cases u <;> cases w <;> norm_num [cgTurn2, t2MassQ])]
+  congr 1 <;> ring
+
+private theorem cgS1_t2_false {u : MFUtterance} {w : MFWorld}
+    (hw : mfMeaning u w = false) :
+    cgS1 cgTurn2PMF cgTurn2PMF_pos w u = 0 := by
+  unfold cgS1
+  rw [RSA.S1Belief_apply]
+  simp only [ENNReal.rpow_one, mul_one]
+  rw [cgL0_t2_false hw]
+  simp
+
 end PMFChain
 
 /-- RSA model after hearing "studyHumanity" at turn 1.
@@ -1132,34 +1241,61 @@ Nancy over Katie. In turn 1, they were symmetric (both like outdoors).
 The updated prior (3 vs 1) breaks the tie — Nancy's higher CommonGround weight
 makes her more probable. This is the key multi-turn prediction. -/
 theorem l1_turn2_outdoors_favors_nancy :
-    mfRSA_turn2.L1 .likeOutdoors .nancy > mfRSA_turn2.L1 .likeOutdoors .katie := by
-  rsa_predict
+    l1Turn2 .likeOutdoors .nancy > l1Turn2 .likeOutdoors .katie := by
+  unfold l1Turn2 cgL1
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, cgTurn2PMF_apply, cgTurn2PMF_apply,
+    cgS1_t2_true (by decide), cgS1_t2_true (by decide),
+    ← ENNReal.ofReal_mul (by norm_num [cgTurn2]),
+    ← ENNReal.ofReal_mul (by norm_num [cgTurn2])]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num [cgTurn2, t2MassQ, Zt2Q])).mpr
+    (by norm_num [cgTurn2, t2MassQ, Zt2Q])
 
 /-- After CommonGround update, "likeIndoors" favors Sally over Ina. Both like
 indoors, but Sally has higher prior (3 vs 1) from the CommonGround shift. -/
 theorem l1_turn2_indoors_favors_sally :
-    mfRSA_turn2.L1 .likeIndoors .sally > mfRSA_turn2.L1 .likeIndoors .ina := by
-  rsa_predict
+    l1Turn2 .likeIndoors .sally > l1Turn2 .likeIndoors .ina := by
+  unfold l1Turn2 cgL1
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, cgTurn2PMF_apply, cgTurn2PMF_apply,
+    cgS1_t2_true (by decide), cgS1_t2_true (by decide),
+    ← ENNReal.ofReal_mul (by norm_num [cgTurn2]),
+    ← ENNReal.ofReal_mul (by norm_num [cgTurn2])]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num [cgTurn2, t2MassQ, Zt2Q])).mpr
+    (by norm_num [cgTurn2, t2MassQ, Zt2Q])
 
 /-- After CommonGround update, "studyScience" still treats Ina and Katie equally:
 both study a science and both have equal prior weight (1). -/
 theorem l1_turn2_science_ina_eq_katie :
-    mfRSA_turn2.L1 .studyScience .ina = mfRSA_turn2.L1 .studyScience .katie := by
-  rsa_predict
+    l1Turn2 .studyScience .ina = l1Turn2 .studyScience .katie := by
+  unfold l1Turn2 cgL1
+  have h : cgTurn2PMF .ina * cgS1 cgTurn2PMF cgTurn2PMF_pos .ina .studyScience
+      = cgTurn2PMF .katie * cgS1 cgTurn2PMF cgTurn2PMF_pos .katie .studyScience := by
+    rw [cgTurn2PMF_apply, cgTurn2PMF_apply, cgS1_t2_true (by decide),
+      cgS1_t2_true (by decide)]
+    norm_num [cgTurn2, Zt2Q]
+  exact le_antisymm ((PMF.posterior_le_iff_score_le _ _ _ _ _ _).mpr h.le)
+    ((PMF.posterior_le_iff_score_le _ _ _ _ _ _).mpr h.ge)
 
 /-- After CommonGround update, "studyHumanity" still treats Nancy and Sally equally:
 both study a humanity and both have equal updated prior (3). -/
 theorem l1_turn2_humanity_nancy_eq_sally :
-    mfRSA_turn2.L1 .studyHumanity .nancy = mfRSA_turn2.L1 .studyHumanity .sally := by
-  rsa_predict
+    l1Turn2 .studyHumanity .nancy = l1Turn2 .studyHumanity .sally := by
+  unfold l1Turn2 cgL1
+  have h : cgTurn2PMF .nancy * cgS1 cgTurn2PMF cgTurn2PMF_pos .nancy .studyHumanity
+      = cgTurn2PMF .sally * cgS1 cgTurn2PMF cgTurn2PMF_pos .sally .studyHumanity := by
+    rw [cgTurn2PMF_apply, cgTurn2PMF_apply, cgS1_t2_true (by decide),
+      cgS1_t2_true (by decide)]
+    norm_num [cgTurn2, Zt2Q]
+  exact le_antisymm ((PMF.posterior_le_iff_score_le _ _ _ _ _ _).mpr h.le)
+    ((PMF.posterior_le_iff_score_le _ _ _ _ _ _).mpr h.ge)
 
 /-- CommonGround update breaks turn-1 symmetry: in turn 1, L1("likeOutdoors")
 assigned equal weight to Nancy and Katie. After the CommonGround shift, Nancy
 is favored. Multi-turn conversation enriches inference. -/
 theorem turn2_breaks_symmetry :
-    mfRSA.L1 .likeOutdoors .nancy = mfRSA.L1 .likeOutdoors .katie ∧
-    mfRSA_turn2.L1 .likeOutdoors .nancy > mfRSA_turn2.L1 .likeOutdoors .katie := by
-  exact ⟨by rsa_predict, l1_turn2_outdoors_favors_nancy⟩
+    l1Turn1 .likeOutdoors .nancy = l1Turn1 .likeOutdoors .katie ∧
+    l1Turn2 .likeOutdoors .nancy > l1Turn2 .likeOutdoors .katie :=
+  ⟨by rw [l1Turn1_true (by decide) (by decide), l1Turn1_true (by decide) (by decide)],
+   l1_turn2_outdoors_favors_nancy⟩
 
 -- ════════════════════════════════════════════════════
 -- § 12b. Turn 2: S1 CommonGround-Adapted Speaker
@@ -1182,8 +1318,11 @@ the high-weight subspace (L0(nancy|likeOutdoors) = 3/5) while
 This is Anderson's key insight: the CommonGround-weighted L0 makes speakers prefer
 *new* information over *redundant* information. -/
 theorem s1_turn2_nancy_prefers_outdoors :
-    mfRSA_turn2.S1 () .nancy .likeOutdoors > mfRSA_turn2.S1 () .nancy .studyHumanity := by
-  rsa_predict
+    s1Turn2 .nancy .likeOutdoors > s1Turn2 .nancy .studyHumanity := by
+  show cgS1 _ _ _ _ > cgS1 _ _ _ _
+  rw [cgS1_t2_true (by decide), cgS1_t2_true (by decide)]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num [cgTurn2, t2MassQ, Zt2Q])).mpr
+    (by norm_num [cgTurn2, t2MassQ, Zt2Q])
 
 /-- At turn 1, the same two utterances were equal (pre-CommonGround-adaptation). -/
 theorem s1_turn1_nancy_humanity_eq_outdoors :
@@ -1197,8 +1336,11 @@ L0(ina|likeIndoors) = 2/5 < L0(ina|studyScience) = 1/2. The CommonGround shift
 makes the major dimension MORE informative for low-CommonGround worlds, the opposite
 of the high-CommonGround case (nancy, §12b above). -/
 theorem s1_turn2_ina_prefers_science :
-    mfRSA_turn2.S1 () .ina .studyScience > mfRSA_turn2.S1 () .ina .likeIndoors := by
-  rsa_predict
+    s1Turn2 .ina .studyScience > s1Turn2 .ina .likeIndoors := by
+  show cgS1 _ _ _ _ > cgS1 _ _ _ _
+  rw [cgS1_t2_true (by decide), cgS1_t2_true (by decide)]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num [cgTurn2, t2MassQ, Zt2Q])).mpr
+    (by norm_num [cgTurn2, t2MassQ, Zt2Q])
 
 -- ════════════════════════════════════════════════════
 -- § 13. S2: Endorsement Predictions
@@ -1208,14 +1350,21 @@ theorem s1_turn2_ina_prefers_science :
 "studyHumanity" over "studyScience". S2(u|w) ∝ L1(w|u), and
 L1(nancy|studyHumanity) > 0 = L1(nancy|studyScience). -/
 theorem s2_nancy_endorses_humanity :
-    mfRSA.S2 .nancy .studyHumanity > mfRSA.S2 .nancy .studyScience := by
-  rsa_predict
+    s2Turn1 .nancy .studyHumanity > s2Turn1 .nancy .studyScience := by
+  unfold s2Turn1 cgS2
+  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
+  show l1Turn1 .studyScience .nancy < l1Turn1 .studyHumanity .nancy
+  rw [l1Turn1_false (by decide), l1Turn1_true (by decide) (by decide)]
+  exact ENNReal.ofReal_pos.mpr (by norm_num)
 
 /-- S2 endorsement: given world Nancy, "studyHumanity" and "likeOutdoors"
 are equally endorsed (symmetric L1 posteriors). -/
 theorem s2_nancy_humanity_eq_outdoors :
-    mfRSA.S2 .nancy .studyHumanity = mfRSA.S2 .nancy .likeOutdoors := by
-  rsa_predict
+    s2Turn1 .nancy .studyHumanity = s2Turn1 .nancy .likeOutdoors := by
+  unfold s2Turn1 cgS2
+  rw [PMF.normalize_eq_iff_eq]
+  show l1Turn1 .studyHumanity .nancy = l1Turn1 .likeOutdoors .nancy
+  rw [l1Turn1_true (by decide) (by decide), l1Turn1_true (by decide) (by decide)]
 
 -- ════════════════════════════════════════════════════
 -- § 14. Parametric RSA and Conversation Step

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -1,4 +1,3 @@
-import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Operators
@@ -129,7 +128,7 @@ theorem ext {cg₁ cg₂ : DistributionalCG W} (h : cg₁.dist = cg₂.dist) :
 
 /-- The ℝ-valued masses of the common ground (via `PMF.toRealFn`). This is
     the interface every RSA consumer reads: it plugs directly into
-    `RSAConfig.worldPrior`/`meaning`, which expect `W → ℝ`. -/
+    ℝ-valued consumers (`updateCG`, the samplers), which expect `W → ℝ`. -/
 noncomputable def weight (cg : DistributionalCG W) : W → ℝ := cg.dist.toRealFn
 
 @[simp] theorem weight_def (cg : DistributionalCG W) (w : W) :
@@ -428,10 +427,10 @@ beliefs, and the learning rate for updates. In the **shared CommonGround** model
 **approximate CommonGround** model (§5.2, Figure 6), each maintains a separate
 approximation (not yet formalized).
 
-The distributional CommonGround serves as both `RSAConfig.meaning` (L0 prior) and
-`RSAConfig.worldPrior` (L1 prior) — the CommonGround enters the RSA model at two
-levels (Figure 4). Between turns, the CommonGround evolves via `updateCG`, and the
-RSA model is reconstructed via `mfRSAAt`. -/
+The distributional CommonGround enters the RSA model at two points
+(Figure 4): inside the literal listener and as the pragmatic listener's
+prior. At each turn the chain is rebuilt at the current CommonGround
+(`cgS1Total`/`conversationStep`). -/
 structure ConversationState (W : Type*) where
   cg : DistributionalCG W
   belA : DistributionalCG W
@@ -565,32 +564,22 @@ theorem a_diff_nancy_positive :
   norm_num
 
 -- ════════════════════════════════════════════════════
--- § 8. RSAConfig: Turn 1 (Uniform Prior)
+-- § 8. The Figure-4 model on mathlib PMF
 -- ════════════════════════════════════════════════════
 
 open RSA
 
-/-- RSA model for the MutualFriends domain at turn 1.
+/-! Anderson's Shared CommonGround model ([anderson-2021] Figure 4) uses the
+distributional CommonGround at BOTH ends of the chain:
 
-Anderson's Shared CommonGround model (Figure 4) uses the distributional CommonGround at BOTH
-L0 and L1:
+    L0(w|u) ∝ ⟦u⟧(w) · CG(w)    -- CG enters the literal listener
+    S1(u|w) ∝ L0(w|u)           -- speaker = renormalised L0 row (fn. 3:
+                                --   softmax omitted, α = 1, no cost)
+    L1(w|u) ∝ S1(u|w) · CG(w)   -- CG enters the pragmatic listener
 
-    L0(w|u) ∝ ⟦u⟧(w) · CommonGround(w)     -- CommonGround enters L0 via `meaning`
-    S1(u|w) ∝ L0(w|u)              -- speaker optimizes CommonGround-weighted informativity
-    L1(w|u) ∝ S1(u|w) · CommonGround(w)     -- CommonGround enters L1 via `worldPrior`
-
-At turn 1, CommonGround is uniform (weight 1 everywhere), so the CommonGround factor drops out
-of L0 and the meaning reduces to Boolean semantics: `⟦u⟧(w) · 1 = ⟦u⟧(w)`.
-The general CommonGround-weighted pattern is visible in `mfRSA_turn2`. -/
-noncomputable def mfRSA : RSAConfig MFUtterance MFWorld where
-  meaning _ _ u w := if mfMeaning u w then 1 else 0
-  meaning_nonneg _ _ _ _ := by split <;> norm_num
-  s1Score l0 _ _ w u := l0 u w
-  s1Score_nonneg _ _ _ _ _ hl _ := hl _ _
-  α := 1
-  α_pos := one_pos
-  worldPrior_nonneg _ := by norm_num
-  latentPrior_nonneg _ _ := by norm_num
+At turn 1 the CommonGround is uniform, so the CG factor drops out of L0 and
+the meaning reduces to Boolean semantics. The chain below implements this on
+mathlib `PMF`, parameterized by the CommonGround. -/
 
 -- ════════════════════════════════════════════════════
 -- § 8b. PMF chain (CG-parameterized; local pending the RSA API pass)
@@ -653,7 +642,7 @@ private noncomputable def cgL1 (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
   PMF.posterior (cgS1 cg hcg) cg u (cgS1_marginal_pos cg hcg u)
 
 /-- Endorsement speaker: `S2(u|w) ∝ L1(w|u)` (uniform utterance prior),
-matching `RSAConfig.S2agent`'s Bayes inversion of L1 over utterances. -/
+the standard endorsement inversion of L1 over utterances. -/
 private noncomputable def cgS2 (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
     (w : MFWorld) : PMF MFUtterance :=
   PMF.normalize (fun u => cgL1 cg hcg u w)
@@ -978,7 +967,7 @@ theorem s1_ina_prefers_science :
 
 /-- A speaker who knows it's Ina is indifferent between "studyScience" and
 "likeIndoors": both are true of exactly 2 worlds, giving equal L0 posteriors.
-This tests `rsa_predict` on equality goals. -/
+-/
 theorem s1_ina_science_eq_indoors :
     s1Turn1 .ina .studyScience = s1Turn1 .ina .likeIndoors := by
   rw [s1Turn1_true (by decide) (by decide), s1Turn1_true (by decide) (by decide)]
@@ -1001,7 +990,7 @@ theorem s1_nancy_humanity_eq_outdoors :
 
 /-- False utterances get zero S1 probability.
 "studyScience" is false of Nancy (she studies German), so S1 = 0.
-Tests `rsa_predict` on negation of strict inequality. -/
+-/
 theorem s1_nancy_science_not_gt_null :
     ¬(s1Turn1 .nancy .studyScience > s1Turn1 .nancy .null) := by
   rw [gt_iff_lt,
@@ -1046,7 +1035,7 @@ theorem l1_null_uniform (w₁ w₂ : MFWorld) :
   rw [l1Turn1_null, l1Turn1_null]
 
 -- ════════════════════════════════════════════════════
--- § 11. RSAConfig: Turn 2 (Post-Update Prior)
+-- § 11. Turn 2 (Post-Update Prior)
 -- ════════════════════════════════════════════════════
 
 /-- CommonGround weights after hearing "studyHumanity" at turn 1.
@@ -1066,8 +1055,6 @@ def cgTurn2 : MFWorld → ℝ
   | .ina | .katie => 2
   | .nancy | .sally => 3
 
-theorem cgTurn2_nonneg : ∀ w, 0 ≤ cgTurn2 w := by
-  intro w; cases w <;> norm_num [cgTurn2]
 
 section PMFChain
 
@@ -1204,33 +1191,6 @@ private theorem cgS1_t2_false {u : MFUtterance} {w : MFWorld}
 
 end PMFChain
 
-/-- RSA model after hearing "studyHumanity" at turn 1.
-
-The updated CommonGround enters BOTH L0 and L1 (Figure 4), matching Anderson's
-Shared CommonGround model:
-
-    L0(w|u) ∝ ⟦u⟧(w) · CommonGround'(w)     -- CommonGround in L0 via `meaning`
-    L1(w|u) ∝ S1(u|w) · CommonGround'(w)     -- CommonGround in L1 via `worldPrior`
-
-This means S1 *adapts* to the CommonGround: the speaker reasons about informativity
-relative to the current common ground. After "studyHumanity" shifts the CommonGround
-toward nancy/sally (weights [2,2,3,3] ∝ [1/5, 1/5, 3/10, 3/10]),
-utterances that disambiguate *within* that subspace (e.g., "likeOutdoors")
-become more informative than utterances that merely re-assert the major
-dimension (e.g., "studyHumanity"). -/
-noncomputable def mfRSA_turn2 : RSAConfig MFUtterance MFWorld where
-  meaning _ _ u w := if mfMeaning u w then cgTurn2 w else 0
-  meaning_nonneg _ _ _ w := by
-    split
-    · exact cgTurn2_nonneg w
-    · exact le_refl 0
-  s1Score l0 _ _ w u := l0 u w
-  s1Score_nonneg _ _ _ _ _ hl _ := hl _ _
-  α := 1
-  α_pos := one_pos
-  worldPrior := cgTurn2
-  worldPrior_nonneg := cgTurn2_nonneg
-  latentPrior_nonneg _ _ := by norm_num
 
 -- ════════════════════════════════════════════════════
 -- § 12. Turn 2 Predictions
@@ -1370,55 +1330,56 @@ theorem s2_nancy_humanity_eq_outdoors :
 -- § 14. Parametric RSA and Conversation Step
 -- ════════════════════════════════════════════════════
 
-/-- RSA model for MutualFriends at an arbitrary CommonGround (Figure 4).
+section PMFChain
 
-This is the general form of Anderson's Shared CommonGround model: the CommonGround enters
-as the L0 meaning weight (via `meaning`) AND as the L1 prior (via
-`worldPrior`). One-shot RSA is the special case with uniform CommonGround.
+open scoped ENNReal
 
-Used by `conversationStep` to construct the RSA model at each turn. -/
-noncomputable def mfRSAAt (cg : MFWorld → ℝ) (hcg : ∀ w, 0 ≤ cg w) :
-    RSAConfig MFUtterance MFWorld where
-  meaning _ _ u w := if mfMeaning u w then cg w else 0
-  meaning_nonneg _ _ _ w := by split; exact hcg w; exact le_refl 0
-  s1Score l0 _ _ w u := l0 u w
-  s1Score_nonneg _ _ _ _ _ hl _ := hl _ _
-  α := 1
-  α_pos := one_pos
-  worldPrior := cg
-  worldPrior_nonneg := hcg
-  latentPrior_nonneg _ _ := by norm_num
+/-- Total literal listener at an arbitrary CommonGround (dite fallback for
+utterances whose extension has zero CG mass). -/
+noncomputable def cgL0Total (cg : PMF MFWorld) (u : MFUtterance) : PMF MFWorld :=
+  if h : (∑' w, cg w * (if mfMeaning u w then (1 : ℝ≥0∞) else 0)) ≠ 0 then
+    RSA.L0LassiterGoodman cg mfMeaning u h
+  else PMF.uniformOfFintype MFWorld
+
+/-- Total speaker at an arbitrary CommonGround — the general Figure-4
+production model used by the conversation loop (fallback to `null` at
+zero-support worlds). -/
+noncomputable def cgS1Total (cg : PMF MFWorld) (w : MFWorld) : PMF MFUtterance :=
+  if h : (∑' u, ((cgL0Total cg u) w : ℝ≥0∞) ^ (1 : ℝ) * 1) ≠ 0 then
+    RSA.S1Belief (cgL0Total cg) (fun _ => 1) 1 w h
+      (ENNReal.tsum_ne_top_of_fintype fun _ =>
+        ENNReal.mul_ne_top
+          (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+          ENNReal.one_ne_top)
+  else PMF.pure .null
+
+end PMFChain
 
 /-- One step of the Shared CommonGround conversation loop (Figure 2).
 
 Given the current CommonGround and an utterance:
-1. Build the RSA model at the current CommonGround (`mfRSAAt`)
+1. Build the speaker chain at the current CommonGround (`cgS1Total`)
 2. Compute L1 posteriors: the pragmatic listener's world beliefs
 3. Update the CommonGround via convex combination with the posteriors
 
 This closes the loop: RSA inference → CommonGround update → new RSA model.
 The returned CommonGround serves as the world prior for the next turn's model.
 
-**Renormalisation**: the L1 posterior is repackaged as a `DistributionalCG`
-via `ofWeights` (Anderson 2021, footnote 3: *"the probabilities are
-renormalized"*), so `updateCG` is a genuine convex combination of two
-distributions and the result is again a distribution. The guard handles the
-degenerate case of an utterance contradicting the entire common ground
-(`∑ L1 = 0`, e.g. `studyHumanity` against a CG concentrated on Ina): then
-the posterior carries no information and the CommonGround is left unchanged —
-matching Anderson's null-utterance "skip the update" behaviour (§7.1). -/
+**Renormalisation** is now intrinsic: `PMF.posterior` IS the renormalised
+listener ([anderson-2021] fn. 3: *"the probabilities are renormalized"*), so
+`updateCG` is a genuine convex combination of distributions by construction.
+The guard handles the degenerate case of an utterance contradicting the
+entire common ground (marginal 0, e.g. `studyHumanity` against a CG
+concentrated on Ina): the posterior carries no information and the
+CommonGround is left unchanged — matching Anderson's null-utterance "skip
+the update" behaviour (§7.1). -/
 noncomputable def conversationStep
     (cg : DistributionalCG MFWorld) (u : MFUtterance)
     (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) :
     DistributionalCG MFWorld :=
-  let rsaModel := mfRSAAt cg.weight cg.weight_nonneg
-  let posterior := rsaModel.L1 u
-  let postCG : DistributionalCG MFWorld :=
-    if h : 0 < ∑ w, posterior w then
-      DistributionalCG.ofWeights posterior
-        (fun w => rsaModel.L1agent.policy_nonneg u w) h
-    else cg
-  updateCG cg postCG lr hlr hlr1
+  if h : PMF.marginal (cgS1Total cg.dist) cg.dist u ≠ 0 then
+    updateCG cg ⟨PMF.posterior (cgS1Total cg.dist) cg.dist u h⟩ lr hlr hlr1
+  else cg
 
 /-- The conversation step preserves CommonGround non-negativity (now free:
 the result is a genuine distribution). -/
@@ -1430,8 +1391,10 @@ theorem conversationStep_nonneg (cg : DistributionalCG MFWorld)
 /-- With lr = 0, the conversation step leaves the CommonGround unchanged. -/
 theorem conversationStep_lr_zero (cg : DistributionalCG MFWorld) (u : MFUtterance) (w : MFWorld) :
     (conversationStep cg u 0 (le_refl 0) zero_le_one).weight w = cg.weight w := by
-  simp only [conversationStep]
-  exact updateCG_lr_zero cg _ w
+  unfold conversationStep
+  split
+  · exact updateCG_lr_zero cg _ w
+  · rfl
 
 -- ════════════════════════════════════════════════════
 -- § 15. Qualitative information-sharing properties
@@ -1595,26 +1558,31 @@ noncomputable def ApproxCGState.initial {W : Type*} [Fintype W] [Nonempty W]
   lr := lr
   speakerIsA := true
 
-/-- Approximate comprehension RSA (Figure 6): L0 uses CG_L, but L1
-uses B_L (listener's private beliefs) as the world prior. -/
-noncomputable def approxComprehensionRSA
-    (cgL : MFWorld → ℝ) (hcgL : ∀ w, 0 ≤ cgL w)
-    (belL : MFWorld → ℝ) (hbelL : ∀ w, 0 ≤ belL w) :
-    RSAConfig MFUtterance MFWorld where
-  meaning _ _ u w := if mfMeaning u w then cgL w else 0
-  meaning_nonneg _ _ _ w := by split; exact hcgL w; exact le_refl 0
-  s1Score l0 _ _ w u := l0 u w
-  s1Score_nonneg _ _ _ _ _ hl _ := hl _ _
-  α := 1
-  α_pos := one_pos
-  worldPrior := belL
-  worldPrior_nonneg := hbelL
-  latentPrior_nonneg _ _ := by norm_num
+private theorem cgS1_marginal_pos' (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (bel : PMF MFWorld) (hbel : ∀ w, bel w ≠ 0) (u : MFUtterance) :
+    PMF.marginal (cgS1 cg hcg) bel u ≠ 0 := by
+  obtain ⟨w, hw⟩ := mfMeaning_sat u
+  refine PMF.marginal_ne_zero _ _ _ (hbel w) ?_
+  have hL0 : cgL0 cg hcg u w ≠ 0 := by
+    unfold cgL0
+    rw [← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
+    exact ⟨hcg w, hw⟩
+  unfold cgS1
+  exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 one_ne_zero
+
+/-- Approximate comprehension listener ([anderson-2021] Figure 6): L0/S1 run
+over the listener's CommonGround approximation `CG_L`, but the Bayesian
+inversion uses the listener's private beliefs `B_L` as the prior. Stated for
+everywhere-positive `CG_L`/`B_L` (the degenerate-support cases go through
+the total conversation-loop constructions above). -/
+noncomputable def approxL1 (cgL : PMF MFWorld) (hcgL : ∀ w, cgL w ≠ 0)
+    (belL : PMF MFWorld) (hbelL : ∀ w, belL w ≠ 0) (u : MFUtterance) : PMF MFWorld :=
+  PMF.posterior (cgS1 cgL hcgL) belL u (cgS1_marginal_pos' cgL hcgL belL hbelL u)
 
 /-- When beliefs equal the CommonGround, the approximate model reduces to the
 shared CommonGround model — the split is only meaningful when they diverge. -/
-theorem approx_reduces_to_shared (cg : MFWorld → ℝ) (hcg : ∀ w, 0 ≤ cg w) :
-    approxComprehensionRSA cg hcg cg hcg = mfRSAAt cg hcg := rfl
+theorem approx_reduces_to_shared (cg : PMF MFWorld) (hcg : ∀ w, cg w ≠ 0)
+    (u : MFUtterance) : approxL1 cg hcg cg hcg u = cgL1 cg hcg u := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 19. Belief Update Model (§6, Figure 8)

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -958,49 +958,55 @@ end PMFChain
 "studyScience". Nancy studies German (a humanity), so "studyScience" has
 L0(nancy|studyScience) = 0, while "studyHumanity" has L0(nancy|studyHumanity) = 1/2. -/
 theorem s1_nancy_prefers_humanity :
-    mfRSA.S1 () .nancy .studyHumanity > mfRSA.S1 () .nancy .studyScience := by
-  rsa_predict
+    s1Turn1 .nancy .studyHumanity > s1Turn1 .nancy .studyScience := by
+  rw [s1Turn1_true (by decide) (by decide), s1Turn1_false (by decide)]
+  exact ENNReal.ofReal_pos.mpr (by norm_num)
 
 /-- A speaker who knows it's Nancy prefers "likeOutdoors" over "likeIndoors".
 Nancy likes being outdoors. -/
 theorem s1_nancy_prefers_outdoors :
-    mfRSA.S1 () .nancy .likeOutdoors > mfRSA.S1 () .nancy .likeIndoors := by
-  rsa_predict
+    s1Turn1 .nancy .likeOutdoors > s1Turn1 .nancy .likeIndoors := by
+  rw [s1Turn1_true (by decide) (by decide), s1Turn1_false (by decide)]
+  exact ENNReal.ofReal_pos.mpr (by norm_num)
 
 /-- A speaker who knows it's Ina prefers "studyScience" over "studyHumanity".
 Ina studies Astronomy (a science). -/
 theorem s1_ina_prefers_science :
-    mfRSA.S1 () .ina .studyScience > mfRSA.S1 () .ina .studyHumanity := by
-  rsa_predict
+    s1Turn1 .ina .studyScience > s1Turn1 .ina .studyHumanity := by
+  rw [s1Turn1_true (by decide) (by decide), s1Turn1_false (by decide)]
+  exact ENNReal.ofReal_pos.mpr (by norm_num)
 
 /-- A speaker who knows it's Ina is indifferent between "studyScience" and
 "likeIndoors": both are true of exactly 2 worlds, giving equal L0 posteriors.
 This tests `rsa_predict` on equality goals. -/
 theorem s1_ina_science_eq_indoors :
-    mfRSA.S1 () .ina .studyScience = mfRSA.S1 () .ina .likeIndoors := by
-  rsa_predict
+    s1Turn1 .ina .studyScience = s1Turn1 .ina .likeIndoors := by
+  rw [s1Turn1_true (by decide) (by decide), s1Turn1_true (by decide) (by decide)]
 
 /-- The null utterance is always suboptimal: a speaker who knows it's Nancy
 strictly prefers any true specific utterance over saying nothing.
 Null is true of all 4 worlds (L0 = 1/4), while "studyHumanity" is true of
 only 2 (L0 = 1/2). -/
 theorem s1_null_suboptimal :
-    mfRSA.S1 () .nancy .studyHumanity > mfRSA.S1 () .nancy .null := by
-  rsa_predict
+    s1Turn1 .nancy .studyHumanity > s1Turn1 .nancy .null := by
+  rw [s1Turn1_true (by decide) (by decide), s1Turn1_null]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
 /-- Symmetry: S1(studyHumanity|nancy) = S1(likeOutdoors|nancy).
 Both utterances partition the 4 worlds into 2 true + 2 false, so
 L0(nancy|studyHumanity) = L0(nancy|likeOutdoors) = 1/2, hence equal S1. -/
 theorem s1_nancy_humanity_eq_outdoors :
-    mfRSA.S1 () .nancy .studyHumanity = mfRSA.S1 () .nancy .likeOutdoors := by
-  rsa_predict
+    s1Turn1 .nancy .studyHumanity = s1Turn1 .nancy .likeOutdoors := by
+  rw [s1Turn1_true (by decide) (by decide), s1Turn1_true (by decide) (by decide)]
 
 /-- False utterances get zero S1 probability.
 "studyScience" is false of Nancy (she studies German), so S1 = 0.
 Tests `rsa_predict` on negation of strict inequality. -/
 theorem s1_nancy_science_not_gt_null :
-    ¬(mfRSA.S1 () .nancy .studyScience > mfRSA.S1 () .nancy .null) := by
-  rsa_predict
+    ¬(s1Turn1 .nancy .studyScience > s1Turn1 .nancy .null) := by
+  rw [gt_iff_lt,
+    s1Turn1_false (show mfMeaning .studyScience .nancy = false from by decide)]
+  simp
 
 -- ════════════════════════════════════════════════════
 -- § 10. Turn 1: L1 Predictions
@@ -1009,33 +1015,35 @@ theorem s1_nancy_science_not_gt_null :
 /-- After hearing "studyHumanity", L1 assigns higher probability to Nancy
 than to Ina. Nancy studies a humanity; Ina studies a science. -/
 theorem l1_humanity_favors_nancy :
-    mfRSA.L1 .studyHumanity .nancy > mfRSA.L1 .studyHumanity .ina := by
-  rsa_predict
+    l1Turn1 .studyHumanity .nancy > l1Turn1 .studyHumanity .ina := by
+  rw [l1Turn1_true (by decide) (by decide), l1Turn1_false (by decide)]
+  exact ENNReal.ofReal_pos.mpr (by norm_num)
 
 /-- After hearing "likeOutdoors", L1 favors Nancy over Sally.
 Nancy likes outdoors; Sally likes indoors. -/
 theorem l1_outdoors_favors_nancy :
-    mfRSA.L1 .likeOutdoors .nancy > mfRSA.L1 .likeOutdoors .sally := by
-  rsa_predict
+    l1Turn1 .likeOutdoors .nancy > l1Turn1 .likeOutdoors .sally := by
+  rw [l1Turn1_true (by decide) (by decide), l1Turn1_false (by decide)]
+  exact ENNReal.ofReal_pos.mpr (by norm_num)
 
 /-- After hearing "studyHumanity", L1 assigns equal probability to Nancy
 and Sally — both study a humanity, and S1 scores are symmetric. -/
 theorem l1_humanity_nancy_eq_sally :
-    mfRSA.L1 .studyHumanity .nancy = mfRSA.L1 .studyHumanity .sally := by
-  rsa_predict
+    l1Turn1 .studyHumanity .nancy = l1Turn1 .studyHumanity .sally := by
+  rw [l1Turn1_true (by decide) (by decide), l1Turn1_true (by decide) (by decide)]
 
 /-- After hearing "studyScience", L1 assigns equal probability to Ina
 and Katie — both study a science. -/
 theorem l1_science_ina_eq_katie :
-    mfRSA.L1 .studyScience .ina = mfRSA.L1 .studyScience .katie := by
-  rsa_predict
+    l1Turn1 .studyScience .ina = l1Turn1 .studyScience .katie := by
+  rw [l1Turn1_true (by decide) (by decide), l1Turn1_true (by decide) (by decide)]
 
 /-- The null utterance conveys no information: L1 assigns equal probability
 to all worlds. Every world has S1(null|w) = 1/5 by the domain's symmetry
 (each world makes exactly 2 non-null utterances true). -/
 theorem l1_null_uniform (w₁ w₂ : MFWorld) :
-    mfRSA.L1 .null w₁ = mfRSA.L1 .null w₂ := by
-  cases w₁ <;> cases w₂ <;> first | rfl | rsa_predict
+    l1Turn1 .null w₁ = l1Turn1 .null w₂ := by
+  rw [l1Turn1_null, l1Turn1_null]
 
 -- ════════════════════════════════════════════════════
 -- § 11. RSAConfig: Turn 2 (Post-Update Prior)
@@ -1179,7 +1187,7 @@ theorem s1_turn2_nancy_prefers_outdoors :
 
 /-- At turn 1, the same two utterances were equal (pre-CommonGround-adaptation). -/
 theorem s1_turn1_nancy_humanity_eq_outdoors :
-    mfRSA.S1 () .nancy .studyHumanity = mfRSA.S1 () .nancy .likeOutdoors :=
+    s1Turn1 .nancy .studyHumanity = s1Turn1 .nancy .likeOutdoors :=
   s1_nancy_humanity_eq_outdoors
 
 /-- CommonGround adaptation works differently for low-CommonGround worlds: at turn 2,
@@ -1297,13 +1305,14 @@ L1(nancy|studyHumanity) > L1(nancy|null). The null utterance gives
 uniform L1 (= 1/4), while "studyHumanity" concentrates on the 2
 German-studying worlds (= 1/2). -/
 theorem l1_concentrates_after_utterance :
-    mfRSA.L1 .studyHumanity .nancy > mfRSA.L1 .null .nancy := by
-  rsa_predict
+    l1Turn1 .studyHumanity .nancy > l1Turn1 .null .nancy := by
+  rw [l1Turn1_true (by decide) (by decide), l1Turn1_null]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
 /-- Informed speakers are informative: S1 assigns higher probability
 to a true specific utterance than to null. -/
 theorem s1_informed_speaker_is_informative :
-    mfRSA.S1 () .nancy .studyHumanity > mfRSA.S1 () .nancy .null :=
+    s1Turn1 .nancy .studyHumanity > s1Turn1 .nancy .null :=
   s1_null_suboptimal
 
 -- ════════════════════════════════════════════════════
@@ -1343,51 +1352,64 @@ theorem graded_update_keeps_false_world (cg post : DistributionalCG MFWorld)
   linarith
 
 -- ════════════════════════════════════════════════════
--- § 17. Exact Numerical Predictions (Figure 5)
+-- § 17. Exact Numerical Predictions (turn 1)
 -- ════════════════════════════════════════════════════
 
-/-! Exact rational values for the turn-1 RSA computations underlying
-Figure 5, panel 1A. At turn 1 with uniform CommonGround, the domain's 2×2
-feature symmetry gives clean fractions: each non-null utterance is true
-of exactly 2 worlds (L0 = 1/2), null is true of all 4 (L0 = 1/4), and
-each world makes exactly 2 non-null utterances true, giving
+/-! Exact rational values for the turn-1 RSA computations, derived from
+the Figure-4 equations at the uniform CommonGround. (The paper's Figure 5
+is a qualitative bar chart of a four-move conversation; these exact
+fractions are the formalization's own kernel-checked arithmetic, not
+printed paper values.) The domain's 2×2 feature symmetry gives clean
+fractions: each non-null utterance is true of exactly 2 worlds
+(L0 = 1/2), null is true of all 4 (L0 = 1/4), and each world makes
+exactly 2 non-null utterances true, giving
 S1(true u|w) = (1/2)/(5/4) = 2/5 and S1(null|w) = (1/4)/(5/4) = 1/5. -/
 
 -- S1(·|nancy): production probabilities given obs = Nancy
 
 theorem s1_nancy_studyHumanity_val :
-    mfRSA.S1 () .nancy .studyHumanity = 2/5 := by rsa_predict
+    s1Turn1 .nancy .studyHumanity = ENNReal.ofReal (2/5) :=
+  s1Turn1_true (by decide) (by decide)
 
 theorem s1_nancy_studyScience_val :
-    mfRSA.S1 () .nancy .studyScience = 0 := by rsa_predict
+    s1Turn1 .nancy .studyScience = 0 :=
+  s1Turn1_false (by decide)
 
 theorem s1_nancy_likeIndoors_val :
-    mfRSA.S1 () .nancy .likeIndoors = 0 := by rsa_predict
+    s1Turn1 .nancy .likeIndoors = 0 :=
+  s1Turn1_false (by decide)
 
 theorem s1_nancy_likeOutdoors_val :
-    mfRSA.S1 () .nancy .likeOutdoors = 2/5 := by rsa_predict
+    s1Turn1 .nancy .likeOutdoors = ENNReal.ofReal (2/5) :=
+  s1Turn1_true (by decide) (by decide)
 
 theorem s1_nancy_null_val :
-    mfRSA.S1 () .nancy .null = 1/5 := by rsa_predict
+    s1Turn1 .nancy .null = ENNReal.ofReal (1/5) :=
+  s1Turn1_null .nancy
 
 -- L1(·|studyHumanity): posteriors used in CommonGround update → Figure 5 panel 1A
 
 theorem l1_studyHumanity_nancy_val :
-    mfRSA.L1 .studyHumanity .nancy = 1/2 := by rsa_predict
+    l1Turn1 .studyHumanity .nancy = ENNReal.ofReal (1/2) :=
+  l1Turn1_true (by decide) (by decide)
 
 theorem l1_studyHumanity_sally_val :
-    mfRSA.L1 .studyHumanity .sally = 1/2 := by rsa_predict
+    l1Turn1 .studyHumanity .sally = ENNReal.ofReal (1/2) :=
+  l1Turn1_true (by decide) (by decide)
 
 theorem l1_studyHumanity_ina_val :
-    mfRSA.L1 .studyHumanity .ina = 0 := by rsa_predict
+    l1Turn1 .studyHumanity .ina = 0 :=
+  l1Turn1_false (by decide)
 
 theorem l1_studyHumanity_katie_val :
-    mfRSA.L1 .studyHumanity .katie = 0 := by rsa_predict
+    l1Turn1 .studyHumanity .katie = 0 :=
+  l1Turn1_false (by decide)
 
 /-- Null gives uniform L1: every world has the same S1(null|w) by the
 domain's symmetry, so L1(w|null) = CommonGround(w)/Σ CommonGround = 1/4. -/
 theorem l1_null_val (w : MFWorld) :
-    mfRSA.L1 .null w = 1/4 := by cases w <;> rsa_predict
+    l1Turn1 .null w = ENNReal.ofReal (1/4) :=
+  l1Turn1_null w
 
 -- ════════════════════════════════════════════════════
 -- § 18. Approximate CommonGround Model (§5.2, Figure 6)

--- a/Linglib/Studies/BarnettEtAl2022.lean
+++ b/Linglib/Studies/BarnettEtAl2022.lean
@@ -1,5 +1,6 @@
-import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.LatentOperators
+import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.RSA.ArgumentativeStrength
 import Linglib.Pragmatics.RSA.Speaker.CombinedUtility
 import Mathlib.Data.Rat.Defs
@@ -29,15 +30,15 @@ The paper's experiment uses 5 sticks from {1,...,9} (C(9,5)=126 worlds, midpoint
 We formalize a simplified Stick Contest (3 sticks from {1,...,5}, 10 worlds, midpoint 3)
 that preserves the key structural properties: the prior favors ¬longer (P(longer)=0.4),
 and sticks have monotonically increasing L0(longer|·) values. The simplification enables
-verified interval arithmetic via `rsa_predict`.
+kernel-verified exact rational arithmetic on the PMF face.
 
-## RSAConfig Design
+## Model design
 
 The paper's Eq. 8 gives:
 
   S(u|w, w*=longer, β) ∝ L0(longer|u)^β · 𝟙[u ∈ w]
 
-Since the paper fixes α=1 and treats αβ as a single parameter, RSAConfig's `α`
+Since the paper fixes α=1 and treats αβ as a single parameter, the speaker's exponent
 plays the role of β. The s1Score uses precomputed L0(longer|u) values squared
 (β=2), gated by stick availability.
 
@@ -111,7 +112,7 @@ instance : DecidablePred IsLonger := fun w => by
   cases w <;> unfold IsLonger <;> infer_instance
 
 -- ============================================================
--- §2. RSAConfig (persuasive speaker)
+-- §2. Persuasive-speaker scores
 -- ============================================================
 
 /-- L0(longer|u) as ℚ for each stick. Each stick appears in C(4,2)=6 worlds;
@@ -145,51 +146,326 @@ def s1ScoreQ (w : StickWorld) (u : Stick) : ℚ :=
     | .s5 => 4/9    -- (2/3)²
   else 0
 
-/-- [barnett-griffiths-hawkins-2022] RSA with persuasive speaker.
-
-The s1Score implements Eq. 8: S(u|w, longer, β) ∝ L0(longer|u)^β · 𝟙[u ∈ w].
-The score is precomputed as `s1ScoreQ` (ℚ) and cast to ℝ, so that rsa_predict's
-reifier can extract the rational value directly. -/
-noncomputable def cfg : RSA.RSAConfig Stick StickWorld where
-  meaning _ _ u w := if worldContains w u then 1 else 0
-  meaning_nonneg _ _ _ _ := by split <;> positivity
-  s1Score _l0 _α _ w u := (s1ScoreQ w u : ℝ)
-  s1Score_nonneg _ _ _ _ _ _ _ := by
-    apply Rat.cast_nonneg.mpr
-    simp only [s1ScoreQ]
-    split <;> (try split) <;> positivity
-  α := 2       -- paper's β=2 (fitted β̂ ≈ 2.26; simplified to 2)
-  α_pos := by positivity
-  latentPrior_nonneg := fun _ _ => le_of_lt one_pos
-  worldPrior _ := 1  -- uniform over 10 worlds
-  worldPrior_nonneg _ := le_of_lt one_pos
-
 -- ============================================================
--- §3. Predictions — L0 (via rsa_predict)
+-- §2b. PMF chain (local pending the RSA API pass)
 -- ============================================================
 
-set_option maxHeartbeats 400000 in
+section PMFChain
+
+open scoped ENNReal
+
+set_option linter.unusedTactic false
+set_option linter.unreachableTactic false
+
+private theorem stickSat : ∀ u : Stick, ∃ w, worldContains w u = true := by decide
+
+private noncomputable def bwPrior : PMF StickWorld := PMF.uniformOfFintype StickWorld
+
+private theorem bwPrior_pos (w : StickWorld) : bwPrior w ≠ 0 := by
+  rw [bwPrior, PMF.uniformOfFintype_apply]
+  simp
+
+private theorem bwPrior_apply (w : StickWorld) : bwPrior w = 10⁻¹ := by
+  rw [bwPrior, PMF.uniformOfFintype_apply,
+    show Fintype.card StickWorld = 10 from by decide]
+  norm_num
+
+private theorem sumWorlds (f : StickWorld → ℝ≥0∞) :
+    ∑' w, f w = f .w123 + f .w124 + f .w125 + f .w134 + f .w135 +
+      f .w145 + f .w234 + f .w235 + f .w245 + f .w345 := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset StickWorld)
+      = {.w123, .w124, .w125, .w134, .w135, .w145, .w234, .w235, .w245, .w345}
+      from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
+
+private theorem sumSticks (f : Stick → ℝ≥0∞) :
+    ∑' u, f u = f .s1 + f .s2 + f .s3 + f .s4 + f .s5 := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset Stick) = {.s1, .s2, .s3, .s4, .s5} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_singleton]
+  ring
+
+/-- Literal listener over worlds given a revealed stick (uniform prior;
+every stick appears in exactly six of the ten worlds). -/
+private noncomputable def bwL0 (u : Stick) : PMF StickWorld :=
+  RSA.L0LassiterGoodman bwPrior (fun u w => worldContains w u) u (by
+    obtain ⟨w, hw⟩ := stickSat u
+    exact ENNReal.summable.tsum_ne_zero_iff.mpr
+      ⟨w, by rw [hw]; simpa using bwPrior_pos w⟩)
+
+/-- Every stick's extension mass is `6/10`: L0 is `1/6` per containing world. -/
+private theorem bwL0_apply (u : Stick) (w : StickWorld) :
+    bwL0 u w = if worldContains w u then ENNReal.ofReal (1/6) else 0 := by
+  unfold bwL0
+  rw [RSA.L0LassiterGoodman_apply]
+  have hmass : (∑' w', bwPrior w' * (if worldContains w' u then (1 : ℝ≥0∞) else 0))
+      = ENNReal.ofReal (6/10) := by
+    rw [sumWorlds]
+    simp only [bwPrior_apply]
+    have h10 : (10 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/10) := by
+      rw [show (10 : ℝ≥0∞) = ENNReal.ofReal 10 from (ENNReal.ofReal_ofNat 10).symm,
+        ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+      norm_num
+    cases u <;>
+      · simp +decide
+        simp only [h10]
+        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+        norm_num
+  rw [hmass, bwPrior_apply]
+  by_cases hw : worldContains w u = true
+  · rw [hw]
+    simp only [if_true, mul_one]
+    rw [show (10 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/10) from by
+        rw [show (10 : ℝ≥0∞) = ENNReal.ofReal 10 from (ENNReal.ofReal_ofNat 10).symm,
+          ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+        norm_num,
+      ← ENNReal.ofReal_inv_of_pos (by norm_num),
+      ← ENNReal.ofReal_mul (by norm_num)]
+    norm_num
+  · rw [Bool.not_eq_true] at hw
+    rw [hw]
+    simp
+
+/-- Event marginal of the literal listener (`P(E|u)` over the world posterior). -/
+noncomputable def l0Event (u : Stick) (P : StickWorld → Prop) [DecidablePred P] :
+    ℝ≥0∞ :=
+  ∑' w, if P w then bwL0 u w else 0
+
+/-! ### Persuasive speaker and skeptical listener -/
+
+private theorem worldSat : ∀ w : StickWorld, ∃ u : Stick, (0 : ℚ) < s1ScoreQ w u := by
+  intro w
+  cases w <;>
+    first
+      | (refine ⟨.s1, ?_⟩; norm_num [s1ScoreQ, worldContains]; done)
+      | (refine ⟨.s2, ?_⟩; norm_num [s1ScoreQ, worldContains]; done)
+      | (refine ⟨.s3, ?_⟩; norm_num [s1ScoreQ, worldContains]; done)
+
+private theorem s1ScoreQ_nonneg : ∀ (w : StickWorld) (u : Stick), (0 : ℚ) ≤ s1ScoreQ w u := by
+  intro w u
+  cases w <;> cases u <;> norm_num [s1ScoreQ, worldContains]
+
+/-- Persuasive speaker ([barnett-griffiths-hawkins-2022] eqs. 4–6; p. 175:
+"Because the speaker only has access to true utterances, all utterances have
+equal epistemic utility", so the softmax reduces to
+`L0(longer|u)^β · 𝟙[u ∈ w]` at αβ = 2 — the file's exact `s1ScoreQ` table).
+Local op pending the RSA API pass. -/
+private noncomputable def s1Persuade (w : StickWorld) : PMF Stick :=
+  PMF.normalize (fun u => ENNReal.ofReal ((s1ScoreQ w u : ℝ)))
+    (by
+      obtain ⟨u, hu⟩ := worldSat w
+      exact ENNReal.summable.tsum_ne_zero_iff.mpr ⟨u, by
+        rw [ENNReal.ofReal_ne_zero_iff]
+        exact_mod_cast hu⟩)
+    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+
+/-- Per-world speaker normaliser, exactly. -/
+private def ZQ (w : StickWorld) : ℚ :=
+  s1ScoreQ w .s1 + s1ScoreQ w .s2 + s1ScoreQ w .s3 + s1ScoreQ w .s4 + s1ScoreQ w .s5
+
+private theorem ZQ_pos : ∀ w : StickWorld, (0 : ℚ) < ZQ w := by
+  intro w
+  cases w <;> norm_num [ZQ, s1ScoreQ, worldContains]
+
+/-- Exact speaker values: `score/Z` as a single `ofReal` rational. -/
+private theorem s1Persuade_apply (w : StickWorld) (u : Stick) :
+    s1Persuade w u = ENNReal.ofReal ((s1ScoreQ w u : ℝ) / (ZQ w : ℝ)) := by
+  unfold s1Persuade
+  rw [PMF.normalize_apply]
+  have hn : ∀ u', (0 : ℝ) ≤ (s1ScoreQ w u' : ℝ) := fun u' => by
+    exact_mod_cast s1ScoreQ_nonneg w u'
+  have hmass : (∑' u', ENNReal.ofReal ((s1ScoreQ w u' : ℝ)))
+      = ENNReal.ofReal ((ZQ w : ℝ)) := by
+    rw [sumSticks, ← ENNReal.ofReal_add (hn _) (hn _),
+      ← ENNReal.ofReal_add (add_nonneg (hn _) (hn _)) (hn _),
+      ← ENNReal.ofReal_add (add_nonneg (add_nonneg (hn _) (hn _)) (hn _)) (hn _),
+      ← ENNReal.ofReal_add
+        (add_nonneg (add_nonneg (add_nonneg (hn _) (hn _)) (hn _)) (hn _)) (hn _)]
+    congr 1
+    simp only [ZQ]
+    push_cast
+    ring
+  rw [hmass, ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast ZQ_pos w),
+    ← ENNReal.ofReal_mul (hn u), div_eq_mul_inv]
+
+private theorem stickScoreSat : ∀ u : Stick, ∃ w : StickWorld, (0 : ℚ) < s1ScoreQ w u := by
+  intro u
+  cases u <;>
+    first
+      | (refine ⟨.w123, ?_⟩; norm_num [s1ScoreQ, worldContains]; done)
+      | (refine ⟨.w145, ?_⟩; norm_num [s1ScoreQ, worldContains]; done)
+
+private theorem s1Persuade_marginal_pos (u : Stick) :
+    PMF.marginal (fun w => s1Persuade w) bwPrior u ≠ 0 := by
+  obtain ⟨w, hw⟩ := stickScoreSat u
+  refine PMF.marginal_ne_zero _ _ _ (bwPrior_pos w) ?_
+  rw [s1Persuade_apply, ENNReal.ofReal_ne_zero_iff]
+  exact div_pos (by exact_mod_cast hw) (by exact_mod_cast ZQ_pos w)
+
+/-- Skeptical pragmatic listener ([barnett-griffiths-hawkins-2022] eq. 7:
+the listener "is able to be 'skeptical' of the speaker's agenda and discount
+their evidence accordingly"). -/
+noncomputable def l1w (u : Stick) : PMF StickWorld :=
+  PMF.posterior (fun w => s1Persuade w) bwPrior u (s1Persuade_marginal_pos u)
+
+/-- Event marginal of the pragmatic listener. -/
+noncomputable def l1Event (u : Stick) (P : StickWorld → Prop) [DecidablePred P] :
+    ℝ≥0∞ :=
+  ∑' w, if P w then l1w u w else 0
+
+/-- The uniform prior and the utterance marginal factor out of the event sum. -/
+private theorem l1Event_eq (u : Stick) (P : StickWorld → Prop) [DecidablePred P] :
+    l1Event u P = 10⁻¹ * (∑' w, if P w then s1Persuade w u else 0) *
+      (PMF.marginal (fun w => s1Persuade w) bwPrior u)⁻¹ := by
+  unfold l1Event l1w
+  rw [show (∑' w, if P w then
+        PMF.posterior (fun w' => s1Persuade w') bwPrior u
+          (s1Persuade_marginal_pos u) w else 0)
+      = ∑' w, 10⁻¹ * ((if P w then s1Persuade w u else 0) *
+          (PMF.marginal (fun w' => s1Persuade w') bwPrior u)⁻¹) from
+    tsum_congr fun w => by
+      by_cases h : P w
+      · simp only [h, if_true, PMF.posterior_apply, bwPrior_apply]
+        ring
+      · simp [h],
+    ENNReal.tsum_mul_left, ENNReal.tsum_mul_right, ← mul_assoc]
+
+private theorem S_sum_s4_longer :
+    (∑' w, if IsLonger w then s1Persuade w .s4 else 0) = ENNReal.ofReal (729/754) := by
+  rw [sumWorlds]
+  simp +decide [s1Persuade_apply, s1ScoreQ, ZQ]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+private theorem S_sum_s4_notLonger :
+    (∑' w, if ¬ IsLonger w then s1Persuade w .s4 else 0) = ENNReal.ofReal (216/119) := by
+  rw [sumWorlds]
+  simp +decide [s1Persuade_apply, s1ScoreQ, ZQ]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+private theorem S_sum_s5_longer :
+    (∑' w, if IsLonger w then s1Persuade w .s5 else 0) = ENNReal.ofReal (2698/1131) := by
+  rw [sumWorlds]
+  simp +decide [s1Persuade_apply, s1ScoreQ, ZQ]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+private theorem S_sum_s5_notLonger :
+    (∑' w, if ¬ IsLonger w then s1Persuade w .s5 else 0) = ENNReal.ofReal (32/21) := by
+  rw [sumWorlds]
+  simp +decide [s1Persuade_apply, s1ScoreQ, ZQ]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+set_option linter.unusedTactic false
+set_option linter.unreachableTactic false
+
+private theorem sixth_conv : (6 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/6) := by
+  rw [show (6 : ℝ≥0∞) = ENNReal.ofReal 6 from (ENNReal.ofReal_ofNat 6).symm,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+  norm_num
+
+private theorem l0e_s5_longer : l0Event .s5 IsLonger = ENNReal.ofReal (4/6) := by
+  unfold l0Event
+  rw [sumWorlds]
+  simp +decide [bwL0_apply]
+  simp only [sixth_conv]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+private theorem l0e_s5_notLonger :
+    l0Event .s5 (fun w => ¬ IsLonger w) = ENNReal.ofReal (2/6) := by
+  unfold l0Event
+  rw [sumWorlds]
+  simp +decide [bwL0_apply]
+  simp only [sixth_conv]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+private theorem l0e_s4_longer : l0Event .s4 IsLonger = ENNReal.ofReal (3/6) := by
+  unfold l0Event
+  rw [sumWorlds]
+  simp +decide [bwL0_apply]
+  simp only [sixth_conv]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+private theorem l0e_s1_longer : l0Event .s1 IsLonger = ENNReal.ofReal (1/6) := by
+  unfold l0Event
+  rw [sumWorlds]
+  simp +decide [bwL0_apply]
+
+private theorem l0e_s1_notLonger :
+    l0Event .s1 (fun w => ¬ IsLonger w) = ENNReal.ofReal (5/6) := by
+  unfold l0Event
+  rw [sumWorlds]
+  simp +decide [bwL0_apply]
+  simp only [sixth_conv]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+  congr 1
+  norm_num
+
+end PMFChain
+
+open scoped ENNReal
+
+-- ============================================================
+-- §3. Predictions — L0
+-- ============================================================
+
 /-- L0(longer|s5) > L0(¬longer|s5): stick 5 is positive evidence for "longer".
 4 of 6 worlds containing s5 are longer, vs 2 not-longer. -/
 theorem l0_s5_positive :
-    cfg.L0_marginal () .s5 IsLonger >
-    cfg.L0_marginal () .s5 (fun w => ¬ IsLonger w) := by
-  rsa_predict
+    l0Event .s5 IsLonger > l0Event .s5 (fun w => ¬ IsLonger w) := by
+  rw [gt_iff_lt, l0e_s5_longer, l0e_s5_notLonger]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
-set_option maxHeartbeats 400000 in
 /-- L0(longer|s5) > L0(longer|s4): stick 5 provides stronger evidence than s4. -/
 theorem l0_s5_strongest :
-    cfg.L0_marginal () .s5 IsLonger >
-    cfg.L0_marginal () .s4 IsLonger := by
-  rsa_predict
+    l0Event .s5 IsLonger > l0Event .s4 IsLonger := by
+  rw [gt_iff_lt, l0e_s5_longer, l0e_s4_longer]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
-set_option maxHeartbeats 400000 in
 /-- L0(¬longer|s1) > L0(longer|s1): stick 1 is evidence against "longer".
 Only 1 of 6 worlds containing s1 is longer. -/
 theorem l0_s1_negative :
-    cfg.L0_marginal () .s1 (fun w => ¬ IsLonger w) >
-    cfg.L0_marginal () .s1 IsLonger := by
-  rsa_predict
+    l0Event .s1 (fun w => ¬ IsLonger w) > l0Event .s1 IsLonger := by
+  rw [gt_iff_lt, l0e_s1_longer, l0e_s1_notLonger]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
 
 /-- L0(longer|·) is monotonically increasing in stick length. This structural
 property ensures the simplified domain faithfully mirrors the paper's full domain
@@ -198,35 +474,60 @@ theorem l0_monotone :
     l0LongerQ .s1 ≤ l0LongerQ .s2 ∧
     l0LongerQ .s2 ≤ l0LongerQ .s3 ∧
     l0LongerQ .s3 ≤ l0LongerQ .s4 ∧
-    l0LongerQ .s4 ≤ l0LongerQ .s5 := by native_decide
+    l0LongerQ .s4 ≤ l0LongerQ .s5 := by norm_num [l0LongerQ]
 
 -- ============================================================
--- §4. Predictions — L1 (weak evidence effect, via rsa_predict)
+-- §4. Predictions — L1 (weak evidence effect)
 -- ============================================================
 
-set_option maxHeartbeats 800000 in
 /-- **Weak evidence effect**: at β=2, showing stick 4 (positive literal evidence)
-*decreases* the pragmatic listener's belief in "longer" below the prior.
+*decreases* the pragmatic listener's belief in "longer" below the prior
+([barnett-griffiths-hawkins-2022] p. 172: "the absence of strong evidence
+from a speaker who would be highly motivated to show it statistically
+implies that no such evidence exists").
 
-The listener reasons: "If the true average were high, the speaker would have
-had stronger sticks (like 5) available and would have shown them instead.
-The fact that they showed a 4 implies they lacked stronger evidence."
-
-L1 assigns more posterior mass to ¬longer than longer worlds after seeing s4. -/
+Structurally, this is the Z-gap across the event partition: any longer world
+containing s4 also contains s5 or comparably strong sticks, inflating the
+speaker's normaliser (`Z ≥ 13/18`), while every ¬longer world containing s4
+has `Z ≤ 17/36` — so the s4-scores concentrate on the ¬longer side
+(`216/119 > 729/754`). -/
 theorem weak_evidence_effect :
-    cfg.L1_marginal .s4 (fun w => ¬ IsLonger w) >
-    cfg.L1_marginal .s4 IsLonger := by
-  rsa_predict
+    l1Event .s4 (fun w => ¬ IsLonger w) > l1Event .s4 IsLonger := by
+  rw [gt_iff_lt, l1Event_eq, l1Event_eq, S_sum_s4_longer, S_sum_s4_notLonger]
+  set M := PMF.marginal (fun w => s1Persuade w) bwPrior .s4 with hM
+  have hM0 : M ≠ 0 := s1Persuade_marginal_pos .s4
+  have hMt : M ≠ ⊤ := PMF.marginal_ne_top _ _ _
+  have hc0 : (10 : ℝ≥0∞)⁻¹ * M⁻¹ ≠ 0 :=
+    mul_ne_zero (ENNReal.inv_ne_zero.mpr (by norm_num)) (ENNReal.inv_ne_zero.mpr hMt)
+  have hct : (10 : ℝ≥0∞)⁻¹ * M⁻¹ ≠ ⊤ :=
+    ENNReal.mul_ne_top (ENNReal.inv_ne_top.mpr (by norm_num)) (ENNReal.inv_ne_top.mpr hM0)
+  calc 10⁻¹ * ENNReal.ofReal (729/754) * M⁻¹
+      = 10⁻¹ * M⁻¹ * ENNReal.ofReal (729/754) := by ring
+    _ < 10⁻¹ * M⁻¹ * ENNReal.ofReal (216/119) :=
+        ENNReal.mul_lt_mul_right hc0 hct
+          ((ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num))
+    _ = 10⁻¹ * ENNReal.ofReal (216/119) * M⁻¹ := by ring
 
-set_option maxHeartbeats 800000 in
 /-- Strong evidence does NOT backfire: stick 5 increases belief at β=2.
 
 The strongest available evidence is always effective because it cannot
 be "explained away" by the absence of something better. -/
 theorem strong_evidence_works :
-    cfg.L1_marginal .s5 IsLonger >
-    cfg.L1_marginal .s5 (fun w => ¬ IsLonger w) := by
-  rsa_predict
+    l1Event .s5 IsLonger > l1Event .s5 (fun w => ¬ IsLonger w) := by
+  rw [gt_iff_lt, l1Event_eq, l1Event_eq, S_sum_s5_longer, S_sum_s5_notLonger]
+  set M := PMF.marginal (fun w => s1Persuade w) bwPrior .s5 with hM
+  have hM0 : M ≠ 0 := s1Persuade_marginal_pos .s5
+  have hMt : M ≠ ⊤ := PMF.marginal_ne_top _ _ _
+  have hc0 : (10 : ℝ≥0∞)⁻¹ * M⁻¹ ≠ 0 :=
+    mul_ne_zero (ENNReal.inv_ne_zero.mpr (by norm_num)) (ENNReal.inv_ne_zero.mpr hMt)
+  have hct : (10 : ℝ≥0∞)⁻¹ * M⁻¹ ≠ ⊤ :=
+    ENNReal.mul_ne_top (ENNReal.inv_ne_top.mpr (by norm_num)) (ENNReal.inv_ne_top.mpr hM0)
+  calc 10⁻¹ * ENNReal.ofReal (32/21) * M⁻¹
+      = 10⁻¹ * M⁻¹ * ENNReal.ofReal (32/21) := by ring
+    _ < 10⁻¹ * M⁻¹ * ENNReal.ofReal (2698/1131) :=
+        ENNReal.mul_lt_mul_right hc0 hct
+          ((ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num))
+    _ = 10⁻¹ * ENNReal.ofReal (2698/1131) * M⁻¹ := by ring
 
 -- ============================================================
 -- §5. Bridge Theorems
@@ -246,12 +547,12 @@ theorem goalOriented_via_combined (uEpi uPers β : ℚ) (hβ : 0 ≤ β) :
 /-- Connection to ArgumentativeStrength: stick 4 has positive argumentative
 strength for the goal "longer" (L0(longer|s4) = 1/2 > 2/5 = P(longer)). -/
 theorem s4_positive_argStr :
-    hasPositiveArgStr (l0LongerQ .s4) priorLonger := by native_decide
+    hasPositiveArgStr (l0LongerQ .s4) priorLonger := by norm_num [hasPositiveArgStr, l0LongerQ, priorLonger]
 
 /-- Stick 3 does NOT have positive argumentative strength
 (L0(longer|s3) = 1/3 < 2/5 = P(longer)). -/
 theorem s3_not_positive_argStr :
-    ¬ hasPositiveArgStr (l0LongerQ .s3) priorLonger := by native_decide
+    ¬ hasPositiveArgStr (l0LongerQ .s3) priorLonger := by norm_num [hasPositiveArgStr, l0LongerQ, priorLonger]
 
 /-- The weak evidence effect shows that argumentatively positive evidence
 can still backfire under a pragmatic listener model. This is the core
@@ -262,7 +563,7 @@ Stick 4 has positive argStr at L0 (1/2 > 2/5), yet L1 assigns more mass
 to ¬longer than longer after seeing s4. -/
 theorem argStr_positive_but_backfires :
     hasPositiveArgStr (l0LongerQ .s4) priorLonger ∧
-    cfg.L1_marginal .s4 (fun w => ¬ IsLonger w) > cfg.L1_marginal .s4 IsLonger :=
+    l1Event .s4 (fun w => ¬ IsLonger w) > l1Event .s4 IsLonger :=
   ⟨s4_positive_argStr, weak_evidence_effect⟩
 
 -- ============================================================
@@ -312,7 +613,7 @@ def pragmaticProportion : ℚ := 485 / 723
 /-- Proportion expecting weaker evidence (literal listeners) -/
 def literalProportion : ℚ := 238 / 723
 
-theorem pragmatic_is_majority : pragmaticProportion > 1 / 2 := by native_decide
+theorem pragmatic_is_majority : pragmaticProportion > 1 / 2 := by norm_num [pragmaticProportion]
 
 /-- Key interaction: speaker expectations × evidence strength.
 t(718) = 5.2, p < 0.001 (p. 175) -/
@@ -355,14 +656,14 @@ def literalResult : GroupResult :=
     ci95Upper := none }
 
 /-- Pragmatic group shows backfire: mean significantly below 50 (midpoint) -/
-theorem pragmatic_backfire : pragmaticResult.meanSlider < 50 := by native_decide
+theorem pragmatic_backfire : pragmaticResult.meanSlider < 50 := by norm_num [pragmaticResult]
 
 /-- Literal group shows no backfire: mean at midpoint -/
-theorem literal_no_backfire : literalResult.meanSlider > 49 := by native_decide
+theorem literal_no_backfire : literalResult.meanSlider > 49 := by norm_num [literalResult]
 
 /-- The two groups differ in the predicted direction -/
 theorem groups_differ :
-    pragmaticResult.meanSlider < literalResult.meanSlider := by native_decide
+    pragmaticResult.meanSlider < literalResult.meanSlider := by norm_num [pragmaticResult, literalResult]
 
 -- ============================================================
 -- §7. Model Comparison (Table 1)
@@ -405,11 +706,11 @@ def modelComparison : List ModelComparisonDatum :=
 
 /-- The RSA speaker-dependent model has the best (highest) log-likelihood -/
 theorem rsa_speaker_dep_best_likelihood :
-    (12 : ℚ) > 82 / 10 := by native_decide
+    (12 : ℚ) > 82 / 10 := by norm_num
 
 /-- The RSA speaker-dependent model has the best (lowest) WAIC -/
 theorem rsa_speaker_dep_best_waic :
-    (-164 : ℚ) / 10 < -133 / 10 := by native_decide
+    (-164 : ℚ) / 10 < -133 / 10 := by norm_num
 
 -- ============================================================
 -- §8. Fitted Parameters
@@ -434,15 +735,15 @@ def bestModelParams : FittedParams :=
     literalMixWeight := 1/10 }     -- p̂_z = 0.1 (J0 dominates; p. 178)
 
 /-- β > 0 provides strong support for non-zero persuasive bias -/
-theorem beta_positive : bestModelParams.betaMAP > 0 := by native_decide
+theorem beta_positive : bestModelParams.betaMAP > 0 := by norm_num [bestModelParams]
 
 /-- Pragmatic group is best explained by J1 (pragmatic listener model) -/
 theorem pragmatic_group_uses_j1 :
-    bestModelParams.pragmaticMixWeight > 9 / 10 := by native_decide
+    bestModelParams.pragmaticMixWeight > 9 / 10 := by norm_num [bestModelParams]
 
 /-- Literal group is best explained by J0 (literal listener model) -/
 theorem literal_group_uses_j0 :
-    bestModelParams.literalMixWeight < 2 / 10 := by native_decide
+    bestModelParams.literalMixWeight < 2 / 10 := by norm_num [bestModelParams]
 
 -- ============================================================
 -- §9. Model–Data Connection
@@ -458,7 +759,7 @@ theorem model_predicts_interaction :
     -- Model: L0 (literal) — s4 is positive evidence
     hasPositiveArgStr (l0LongerQ .s4) priorLonger ∧
     -- Model: L1 (pragmatic) — s4 backfires
-    cfg.L1_marginal .s4 (fun w => ¬ IsLonger w) > cfg.L1_marginal .s4 IsLonger ∧
+    l1Event .s4 (fun w => ¬ IsLonger w) > l1Event .s4 IsLonger ∧
     -- Data: pragmatic group shows backfire
     pragmaticResult.meanSlider < 50 ∧
     -- Data: literal group shows no backfire

--- a/Linglib/Studies/BarnettEtAl2022.lean
+++ b/Linglib/Studies/BarnettEtAl2022.lean
@@ -58,8 +58,6 @@ plays the role of β. The s1Score uses precomputed L0(longer|u) values squared
 | 10 | RSA speaker-dependent model fits best | `rsa_speaker_dep_best_waic` |
 -/
 
-set_option autoImplicit false
-
 namespace BarnettEtAl2022
 
 open RSA.ArgumentativeStrength

--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -92,8 +92,6 @@ direction (green_circle: 115/180 = 64%), NOT salience.
 
 -/
 
-set_option autoImplicit false
-
 namespace QingFranke2015
 
 open RSA BigOperators Core

--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -1,5 +1,9 @@
 import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.LatentOperators
+import Linglib.Pragmatics.RSA.Operators
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.Complex.ExponentialBounds
 import Linglib.Pragmatics.GriceanMaxims
 import Linglib.Studies.DaleReiter1995
 
@@ -345,6 +349,280 @@ noncomputable def salienceCfg : RSAConfig Utterance Object :=
 
 -- §9. Action-oriented listener ρ_a is now `RSAConfig.L1_action` in Config.lean.
 -- Use `cfg.L1_action αL u w` via dot notation (open RSA provides namespace).
+
+-- ============================================================================
+-- §9b. PMF chain (local pending the RSA API pass)
+-- ============================================================================
+
+section PMFChain
+
+open scoped ENNReal
+
+/-- Every utterance applies to some object, and every object satisfies some
+utterance. -/
+private theorem appliesTo_sat : ∀ u : Utterance, ∃ w, u.appliesTo w = true := by
+  decide
+
+private noncomputable def qfPriorU : PMF Object := PMF.uniformOfFintype Object
+
+private theorem qfPriorU_pos (w : Object) : qfPriorU w ≠ 0 := by
+  rw [qfPriorU, PMF.uniformOfFintype_apply]
+  simp
+
+private theorem qfPriorU_apply (w : Object) : qfPriorU w = 3⁻¹ := by
+  rw [qfPriorU, PMF.uniformOfFintype_apply,
+    show Fintype.card Object = 3 from by decide]
+  norm_num
+
+private theorem sumObjs (f : Object → ℝ≥0∞) :
+    ∑' w, f w = f .green_square + f .blue_circle + f .green_circle := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset Object)
+      = {.green_square, .blue_circle, .green_circle} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_singleton]
+  ring
+
+private theorem sumUtts (f : Utterance → ℝ≥0∞) :
+    ∑' u, f u = f .square + f .circle + f .green + f .blue := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset Utterance) = {.square, .circle, .green, .blue} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
+
+/-- Salience prior as a PMF (Table 2 counts, total 240). -/
+private noncomputable def qfPriorS : PMF Object :=
+  PMF.normalize (fun w => ENNReal.ofReal (saliencePrior w))
+    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.green_square, by
+      rw [ENNReal.ofReal_ne_zero_iff]
+      norm_num [saliencePrior]⟩)
+    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+
+private theorem salience_sum :
+    (∑' w, ENNReal.ofReal (saliencePrior w)) = ENNReal.ofReal 240 := by
+  rw [sumObjs]
+  norm_num [saliencePrior]
+
+private theorem qfPriorS_apply (w : Object) :
+    qfPriorS w = ENNReal.ofReal (saliencePrior w / 240) := by
+  rw [qfPriorS, PMF.normalize_apply, salience_sum,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num),
+    ← ENNReal.ofReal_mul (by cases w <;> norm_num [saliencePrior])]
+  rw [div_eq_mul_inv]
+
+private theorem qfPriorS_pos (w : Object) : qfPriorS w ≠ 0 := by
+  rw [qfPriorS_apply, ENNReal.ofReal_ne_zero_iff]
+  cases w <;> norm_num [saliencePrior]
+
+/-- Literal listener at a speaker-belief prior (Figure-4-style prior-in-L0;
+[qing-franke-2015] eqs. 5–8). -/
+private noncomputable def qfL0 (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0)
+    (u : Utterance) : PMF Object :=
+  RSA.L0LassiterGoodman bel (fun u w => u.appliesTo w) u (by
+    obtain ⟨w, hw⟩ := appliesTo_sat u
+    exact ENNReal.summable.tsum_ne_zero_iff.mpr
+      ⟨w, by rw [hw]; simpa using hbel w⟩)
+
+/-- Uniform-belief L0 values: `1` on the unique-feature objects, `1/2` on
+shared features (extensions of size 1 and 2 over 3 objects). -/
+private theorem qfL0_uniform_apply (u : Utterance) (w : Object) :
+    qfL0 qfPriorU qfPriorU_pos u w
+      = if u.appliesTo w then
+          (if u = .square ∨ u = .blue then 1 else 2⁻¹) else 0 := by
+  unfold qfL0
+  rw [RSA.L0LassiterGoodman_apply]
+  have hmass : (∑' w', qfPriorU w' * (if u.appliesTo w' then (1 : ℝ≥0∞) else 0))
+      = if u = .square ∨ u = .blue then 3⁻¹ else 3⁻¹ + 3⁻¹ := by
+    rw [sumObjs]
+    simp only [qfPriorU_apply]
+    cases u <;> simp +decide [Utterance.appliesTo]
+  rw [hmass, qfPriorU_apply]
+  by_cases hw : u.appliesTo w = true
+  · rw [hw]
+    by_cases h1 : u = .square ∨ u = .blue
+    · simp only [h1, if_true, mul_one, reduceIte]
+      rw [ENNReal.mul_inv_cancel (by norm_num) (by norm_num)]
+    · simp only [h1, if_false, reduceIte, mul_one]
+      rw [show (3 : ℝ≥0∞)⁻¹ + 3⁻¹ = 3⁻¹ * 2 from by ring,
+        ENNReal.mul_inv (by norm_num) (by norm_num), ← mul_assoc,
+        ENNReal.mul_inv_cancel (by norm_num) (by norm_num), one_mul]
+  · rw [Bool.not_eq_true] at hw
+    rw [hw]
+    simp
+
+/-- Extension salience sums (denominators of the salience L0). -/
+private noncomputable def extSum : Utterance → ℝ
+  | .square => 71
+  | .circle => 169
+  | .green  => 101
+  | .blue   => 139
+
+/-- Salience-belief L0 values on support: object salience over extension
+salience ([qing-franke-2015] L0 ∝ S(t)·⟦m⟧). -/
+private theorem qfL0_salience_true {u : Utterance} {w : Object}
+    (hw : u.appliesTo w = true) :
+    qfL0 qfPriorS qfPriorS_pos u w
+      = ENNReal.ofReal (saliencePrior w / extSum u) := by
+  unfold qfL0
+  rw [RSA.L0LassiterGoodman_apply, hw]
+  have hmass : (∑' w', qfPriorS w' * (if u.appliesTo w' then (1 : ℝ≥0∞) else 0))
+      = ENNReal.ofReal (extSum u / 240) := by
+    rw [sumObjs]
+    simp only [qfPriorS_apply]
+    cases u <;>
+      · simp +decide [Utterance.appliesTo, saliencePrior, extSum]
+        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+        try norm_num
+  rw [hmass, qfPriorS_apply]
+  simp only [reduceIte, mul_one]
+  rw [← ENNReal.ofReal_inv_of_pos (by cases u <;> norm_num [extSum]),
+    ← ENNReal.ofReal_mul (by cases w <;> norm_num [saliencePrior])]
+  congr 1
+  cases u <;> cases w <;> norm_num [saliencePrior, extSum]
+
+private theorem qfL0_salience_false {u : Utterance} {w : Object}
+    (hw : u.appliesTo w = false) :
+    qfL0 qfPriorS qfPriorS_pos u w = 0 := by
+  unfold qfL0
+  rw [RSA.L0LassiterGoodman_apply, hw]
+  simp
+
+/-! ### Speakers and exp-bound helpers -/
+
+private noncomputable def qfCf (c : ℝ) (u : Utterance) : ℝ≥0∞ :=
+  ENNReal.ofReal (Real.exp (-(adjCost c u)))
+
+private theorem qfCf_pos (c : ℝ) (u : Utterance) : qfCf c u ≠ 0 := by
+  rw [qfCf, ENNReal.ofReal_ne_zero_iff]
+  exact Real.exp_pos _
+
+private theorem qfCf_square (c : ℝ) : qfCf c .square = 1 := by
+  simp [qfCf, adjCost]
+
+private theorem qfCf_circle (c : ℝ) : qfCf c .circle = 1 := by
+  simp [qfCf, adjCost]
+
+private theorem qfCf_green (c : ℝ) : qfCf c .green = ENNReal.ofReal (Real.exp (-c)) :=
+  rfl
+
+private theorem qfCf_blue (c : ℝ) : qfCf c .blue = ENNReal.ofReal (Real.exp (-c)) :=
+  rfl
+
+private theorem objSat : ∀ w : Object, ∃ u : Utterance, u.appliesTo w = true := by
+  decide
+
+/-- Belief-oriented speaker ([qing-franke-2015] eq. 10 at λ = 1): weights
+`L0 · exp(−Cost)`. -/
+private noncomputable def s1B (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0) (c : ℝ)
+    (w : Object) : PMF Utterance :=
+  RSA.S1Belief (qfL0 bel hbel) (qfCf c) 1 w
+    (by
+      obtain ⟨u, hu⟩ := objSat w
+      refine ENNReal.summable.tsum_ne_zero_iff.mpr ⟨u, mul_ne_zero ?_ (qfCf_pos c u)⟩
+      have hL0 : qfL0 bel hbel u w ≠ 0 := by
+        unfold qfL0
+        rw [← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
+        exact ⟨hbel w, hu⟩
+      exact (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hL0) (PMF.apply_ne_top _ _)).ne')
+    (ENNReal.tsum_ne_top_of_fintype fun u =>
+      ENNReal.mul_ne_top
+        (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
+        (by rw [qfCf]; exact ENNReal.ofReal_ne_top))
+
+/-- Action-oriented speaker ([qing-franke-2015] eq. 9 at λ = 1): weights
+`exp(L0 − Cost)` — positive on ALL utterances, including false ones (the
+action-oriented speaker softmaxes raw success probability). Local private
+op pending the RSA API pass. -/
+private noncomputable def s1A (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0) (c : ℝ)
+    (w : Object) : PMF Utterance :=
+  PMF.normalize
+    (fun u => ENNReal.ofReal (Real.exp ((qfL0 bel hbel u w).toReal - adjCost c u)))
+    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.square, by
+      rw [ENNReal.ofReal_ne_zero_iff]
+      exact Real.exp_pos _⟩)
+    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+
+/-- The five speaker chains of §7–§8, on the PMF face. -/
+noncomputable def s1ZeroCost : Object → PMF Utterance := s1B qfPriorU qfPriorU_pos 0
+noncomputable def s1Cost : Object → PMF Utterance := s1B qfPriorU qfPriorU_pos (1/2)
+noncomputable def s1AU : Object → PMF Utterance := s1A qfPriorU qfPriorU_pos (1/2)
+noncomputable def s1BS : Object → PMF Utterance := s1B qfPriorS qfPriorS_pos (1/2)
+noncomputable def s1AS : Object → PMF Utterance := s1A qfPriorS qfPriorS_pos (1/2)
+
+private theorem s1B_marginal_pos (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0) (c : ℝ)
+    (lp : PMF Object) (hlp : ∀ w, lp w ≠ 0) (u : Utterance) :
+    PMF.marginal (s1B bel hbel c) lp u ≠ 0 := by
+  obtain ⟨w, hw⟩ := appliesTo_sat u
+  refine PMF.marginal_ne_zero _ _ _ (hlp w) ?_
+  have hL0 : qfL0 bel hbel u w ≠ 0 := by
+    unfold qfL0
+    rw [← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
+    exact ⟨hbel w, hw⟩
+  unfold s1B
+  exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 (qfCf_pos c u)
+
+/-- Pragmatic listeners ([qing-franke-2015] eqs. 12–13, 15): same σ_bU cost
+speaker, uniform vs salience world prior. -/
+noncomputable def l1Cost (u : Utterance) : PMF Object :=
+  PMF.posterior (s1Cost) qfPriorU u
+    (s1B_marginal_pos qfPriorU qfPriorU_pos (1/2) qfPriorU qfPriorU_pos u)
+
+noncomputable def l1Sal (u : Utterance) : PMF Object :=
+  PMF.posterior (s1Cost) qfPriorS u
+    (s1B_marginal_pos qfPriorU qfPriorU_pos (1/2) qfPriorS qfPriorS_pos u)
+
+/-! ### The `exp(−1/2)` atom and its three numeric bounds -/
+
+private noncomputable def xc : ℝ := Real.exp (-(1/2))
+
+private theorem xc_pos : 0 < xc := Real.exp_pos _
+
+private theorem xc_lt_one : xc < 1 := by
+  rw [xc, show (1 : ℝ) = Real.exp 0 from Real.exp_zero.symm]
+  exact Real.exp_lt_exp.mpr (by norm_num)
+
+private theorem xc_sq : xc * xc = (Real.exp 1)⁻¹ := by
+  rw [xc, ← Real.exp_add, ← Real.exp_neg]
+  norm_num
+
+private theorem xc_sq_mul : xc * xc * Real.exp 1 = 1 := by
+  rw [xc_sq, inv_mul_cancel₀ (Real.exp_pos 1).ne']
+
+/-- `exp(−1/2) > 1/2` ⟺ `e < 4` — [qing-franke-2015]'s Finding 2 needs the
+adjective's cost penalty to stay above the halved literal probability. -/
+private theorem xc_gt_half : 1/2 < xc := by
+  by_contra h
+  push Not at h
+  have h2 : xc * xc ≤ 1/4 := by nlinarith [xc_pos]
+  have h3 : Real.exp 1 * (xc * xc) ≤ Real.exp 1 * (1/4) :=
+    mul_le_mul_of_nonneg_left h2 (Real.exp_pos 1).le
+  rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
+  nlinarith [Real.exp_one_lt_d9]
+
+/-- `exp(−1/2) < 139/169` ⟺ `e > (169/139)²` — the salience-belief speaker's
+circle-over-blue reversal at the blue circle. -/
+private theorem xc_lt_139_169 : xc < 139/169 := by
+  by_contra h
+  push Not at h
+  have h2 : (139/169 : ℝ) * (139/169) ≤ xc * xc := by nlinarith [xc_pos]
+  have h3 : Real.exp 1 * ((139/169 : ℝ) * (139/169)) ≤ Real.exp 1 * (xc * xc) :=
+    mul_le_mul_of_nonneg_left h2 (Real.exp_pos 1).le
+  rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
+  nlinarith [Real.exp_one_gt_d9]
+
+/-- `exp(−1/2) > 101/169` ⟺ `e < (169/101)²` ≈ 2.7998 — the tight bound
+(margin ≈ 0.08 over `exp_one_lt_d9`). -/
+private theorem xc_gt_101_169 : 101/169 < xc := by
+  by_contra h
+  push Not at h
+  have h2 : xc * xc ≤ (101/169 : ℝ) * (101/169) := by nlinarith [xc_pos]
+  have h3 : Real.exp 1 * (xc * xc) ≤ Real.exp 1 * ((101/169 : ℝ) * (101/169)) :=
+    mul_le_mul_of_nonneg_left h2 (Real.exp_pos 1).le
+  rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
+  nlinarith [Real.exp_one_lt_d9]
+
+end PMFChain
 
 -- ============================================================================
 -- §10. Structural Properties

--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -1,4 +1,3 @@
-import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Operators
@@ -33,8 +32,8 @@ yielding a family of models that includes [frank-goodman-2012] as one instance:
 - **Salience (S)**: L0 weights by perceptual salience:
   S(t|m) = S(t) · ⟦m⟧(t) / Σ_t' S(t') · ⟦m⟧(t')
 
-This enters the RSAConfig via `meaning`: uniform uses constant 1 for true worlds;
-salience uses S(w) for true worlds.
+This enters the literal listener as its prior: uniform (`qfPriorU`) or
+salience-weighted (`qfPriorS`), via the prior-in-L0 construction.
 
 ### Speaker Goal (x ∈ {a, b}): What does the speaker optimize?
 
@@ -52,8 +51,8 @@ This enters via `s1Score`: belief-oriented uses log L0; action-oriented uses raw
 - **Action-oriented (a)**: softmax over Bayesian posterior
   ρ_a(t|m) ∝ exp(α_L · ρ_b(t|m)) (Eq. 14)
 
-The belief-oriented listener IS `RSAConfig.L1`. The action-oriented listener is
-a composable extension defined as `softmax ∘ L1`.
+The belief-oriented listener IS the Bayesian `PMF.posterior`. The
+action-oriented listener is a composable softmax extension.
 
 ## Speaker Models (4 variants)
 
@@ -239,7 +238,7 @@ theorem actionGoalScore_nonneg (cost : Utterance → ℝ) :
   fun _ _ _ _ _ _ _ => le_of_lt (exp_pos _)
 
 -- ============================================================================
--- §6. RSAConfig Constructor
+-- §6. Priors
 -- ============================================================================
 
 /-- Uniform prior: all objects equally weighted. -/
@@ -248,107 +247,13 @@ def uniformPrior : Object → ℝ := fun _ => 1
 theorem uniformPrior_nonneg : ∀ w, 0 ≤ uniformPrior w :=
   fun _ => le_of_lt one_pos
 
-/-- Parametric Q&F RSAConfig constructor.
-
-    Decouples the three orthogonal dimensions:
-    - `speakerPrior`: belief dimension — baked into `meaning` as L0's prior weight
-      (uniform = 1 for all; salience = S(w))
-    - `s1` + `s1_nn`: goal dimension — beliefGoalScore or actionGoalScore
-    - `listenerPrior`: listener's world prior at L1 (independent of speaker's belief)
-
-    The speaker's belief about L0 and the listener's prior vary independently —
-    the speaker may assume uniform L0 while the listener uses salience, or vice versa.
-    This decoupling is a key feature of the RSAConfig API. -/
-@[reducible]
-noncomputable def mkConfig
-    (speakerPrior : Object → ℝ) (sp_nn : ∀ w, 0 ≤ speakerPrior w)
-    (s1 : (Utterance → Object → ℝ) → ℝ → Unit → Object → Utterance → ℝ)
-    (s1_nn : ∀ (l0 : Utterance → Object → ℝ) (α : ℝ) (l : Unit) (w : Object) (u : Utterance),
-      (∀ u' w', 0 ≤ l0 u' w') → 0 < α → 0 ≤ s1 l0 α l w u)
-    (listenerPrior : Object → ℝ) (lp_nn : ∀ w, 0 ≤ listenerPrior w) :
-    RSAConfig Utterance Object where
-  meaning _ _ u w := if u.appliesTo w then speakerPrior w else 0
-  meaning_nonneg _ _ _ w := by
-    split
-    · exact sp_nn w
-    · exact le_refl 0
-  s1Score := s1
-  s1Score_nonneg := s1_nn
-  worldPrior := listenerPrior
-  worldPrior_nonneg := lp_nn
-  α := 1
-  α_pos := one_pos
-  latentPrior_nonneg _ _ := by positivity
-
 -- ============================================================================
 -- §7. The 4 Speaker Models
 -- ============================================================================
 
-/-- σ_bU: Belief-oriented speaker, uniform L0.
-    This IS standard RSA with utterance costs.
-    S1 score = exp(λ · (log U(t|m) - Cost(m))). -/
-@[reducible]
-noncomputable def σ_bU (cost : Utterance → ℝ) (lp : Object → ℝ) (lp_nn : ∀ w, 0 ≤ lp w) :
-    RSAConfig Utterance Object :=
-  mkConfig uniformPrior uniformPrior_nonneg
-    (beliefGoalScore cost) (beliefGoalScore_nonneg cost)
-    lp lp_nn
-
-/-- σ_aU: Action-oriented speaker, uniform L0.
-    S1 score = exp(λ · (U(t|m) - Cost(m))). -/
-@[reducible]
-noncomputable def σ_aU (cost : Utterance → ℝ) (lp : Object → ℝ) (lp_nn : ∀ w, 0 ≤ lp w) :
-    RSAConfig Utterance Object :=
-  mkConfig uniformPrior uniformPrior_nonneg
-    (actionGoalScore cost) (actionGoalScore_nonneg cost)
-    lp lp_nn
-
-/-- σ_bS: Belief-oriented speaker, salience-weighted L0.
-    The speaker assumes L0 weights worlds by perceptual salience:
-    L0(t|m) ∝ S(t) · ⟦m⟧(t). S1 score = exp(λ · (log S(t|m) - Cost(m))). -/
-@[reducible]
-noncomputable def σ_bS (cost : Utterance → ℝ) (lp : Object → ℝ) (lp_nn : ∀ w, 0 ≤ lp w) :
-    RSAConfig Utterance Object :=
-  mkConfig saliencePrior saliencePrior_nonneg
-    (beliefGoalScore cost) (beliefGoalScore_nonneg cost)
-    lp lp_nn
-
-/-- σ_aS: Action-oriented speaker, salience-weighted L0.
-    Same salience-weighted L0 as σ_bS, but S1 score = exp(λ · (S(t|m) - Cost(m))). -/
-@[reducible]
-noncomputable def σ_aS (cost : Utterance → ℝ) (lp : Object → ℝ) (lp_nn : ∀ w, 0 ≤ lp w) :
-    RSAConfig Utterance Object :=
-  mkConfig saliencePrior saliencePrior_nonneg
-    (actionGoalScore cost) (actionGoalScore_nonneg cost)
-    lp lp_nn
-
 -- ============================================================================
 -- §8. Concrete Configs for Findings
 -- ============================================================================
-
-/-- σ_bU with zero cost, uniform listener prior.
-    Used for finding 4 (no cost → no symmetry breaking). -/
-@[reducible]
-noncomputable def zeroCostCfg : RSAConfig Utterance Object :=
-  σ_bU (fun _ => 0) uniformPrior uniformPrior_nonneg
-
-/-- σ_bU with adjective cost = 1/2, uniform listener prior.
-    Standard RSA with cost asymmetry. Used for speaker predictions (findings 1–3)
-    and the uniform half of salience reversal (findings 5–6). -/
-@[reducible]
-noncomputable def costCfg : RSAConfig Utterance Object :=
-  σ_bU (adjCost (1/2)) uniformPrior uniformPrior_nonneg
-
-/-- σ_bU with adjective cost = 1/2, salience-weighted listener prior.
-    Shares the same S1 policy as costCfg (same speaker model σ_bU) but produces
-    different L1 posteriors because L1's Bayesian inversion uses a salience-weighted
-    world prior [Eq. 15 with v = S]. Used for findings 5–6 (salience half). -/
-@[reducible]
-noncomputable def salienceCfg : RSAConfig Utterance Object :=
-  σ_bU (adjCost (1/2)) saliencePrior saliencePrior_nonneg
-
--- §9. Action-oriented listener ρ_a is now `RSAConfig.L1_action` in Config.lean.
--- Use `cfg.L1_action αL u w` via dot notation (open RSA provides namespace).
 
 -- ============================================================================
 -- §9b. PMF chain (local pending the RSA API pass)
@@ -436,12 +341,12 @@ private theorem qfL0_uniform_apply (u : Utterance) (w : Object) :
       = if u = .square ∨ u = .blue then 3⁻¹ else 3⁻¹ + 3⁻¹ := by
     rw [sumObjs]
     simp only [qfPriorU_apply]
-    cases u <;> simp +decide [Utterance.appliesTo]
+    cases u <;> simp +decide
   rw [hmass, qfPriorU_apply]
   by_cases hw : u.appliesTo w = true
   · rw [hw]
     by_cases h1 : u = .square ∨ u = .blue
-    · simp only [h1, if_true, mul_one, reduceIte]
+    · simp only [h1, if_true, mul_one]
       rw [ENNReal.mul_inv_cancel (by norm_num) (by norm_num)]
     · simp only [h1, if_false, reduceIte, mul_one]
       rw [show (3 : ℝ≥0∞)⁻¹ + 3⁻¹ = 3⁻¹ * 2 from by ring,
@@ -471,7 +376,7 @@ private theorem qfL0_salience_true {u : Utterance} {w : Object}
     rw [sumObjs]
     simp only [qfPriorS_apply]
     cases u <;>
-      · simp +decide [Utterance.appliesTo, saliencePrior, extSum]
+      · simp +decide [saliencePrior, extSum]
         try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
         try norm_num
   rw [hmass, qfPriorS_apply]
@@ -622,7 +527,118 @@ private theorem xc_gt_101_169 : 101/169 < xc := by
   rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
   nlinarith [Real.exp_one_lt_d9]
 
+/-! ### Cost-speaker values (for the listener comparisons) -/
+
+private theorem half_conv : (2 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/2) := by
+  rw [show (2 : ℝ≥0∞) = ENNReal.ofReal 2 from (ENNReal.ofReal_ofNat 2).symm,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+  norm_num
+
+private theorem s1Cost_val {u : Utterance} {w : Object} (hw : u.appliesTo w = true)
+    {q Z : ℝ} (hq0 : 0 ≤ q)
+    (hq : (if u = .square ∨ u = .blue then (1 : ℝ≥0∞) else 2⁻¹) * qfCf (1/2) u
+      = ENNReal.ofReal q)
+    (hZ : (∑' u', (qfL0 qfPriorU qfPriorU_pos u' w : ℝ≥0∞) ^ (1 : ℝ) * qfCf (1/2) u')
+      = ENNReal.ofReal Z) (hZpos : 0 < Z) :
+    s1Cost w u = ENNReal.ofReal (q * Z⁻¹) := by
+  unfold s1Cost s1B
+  rw [RSA.S1Belief_apply, hZ, ENNReal.rpow_one, qfL0_uniform_apply, hw]
+  simp only [if_true]
+  rw [hq, ← ENNReal.ofReal_inv_of_pos hZpos, ← ENNReal.ofReal_mul hq0]
+
+private theorem Z_gs :
+    (∑' u', (qfL0 qfPriorU qfPriorU_pos u' .green_square : ℝ≥0∞) ^ (1 : ℝ) *
+      qfCf (1/2) u') = ENNReal.ofReal (1 + xc/2) := by
+  rw [sumUtts]
+  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_circle,
+    qfCf_green, qfCf_blue]
+  simp +decide
+  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
+    show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from ENNReal.ofReal_one.symm,
+    ← ENNReal.ofReal_add (by norm_num) (by positivity)]
+  congr 1
+  unfold xc
+  norm_num
+  ring
+
+private theorem Z_bc :
+    (∑' u', (qfL0 qfPriorU qfPriorU_pos u' .blue_circle : ℝ≥0∞) ^ (1 : ℝ) *
+      qfCf (1/2) u') = ENNReal.ofReal (1/2 + xc) := by
+  rw [sumUtts]
+  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_circle,
+    qfCf_green, qfCf_blue]
+  simp +decide
+  rw [half_conv, ← ENNReal.ofReal_add (by norm_num) (by positivity)]
+  congr 1
+  unfold xc
+  norm_num
+
+private theorem Z_gc :
+    (∑' u', (qfL0 qfPriorU qfPriorU_pos u' .green_circle : ℝ≥0∞) ^ (1 : ℝ) *
+      qfCf (1/2) u') = ENNReal.ofReal (1/2 + xc/2) := by
+  rw [sumUtts]
+  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_circle,
+    qfCf_green, qfCf_blue]
+  simp +decide
+  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
+    ← ENNReal.ofReal_add (by norm_num) (by positivity)]
+  congr 1
+  unfold xc
+  norm_num
+  ring
+
+private theorem third_conv : (3 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/3) := by
+  rw [show (3 : ℝ≥0∞) = ENNReal.ofReal 3 from (ENNReal.ofReal_ofNat 3).symm,
+    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
+  norm_num
+
+private theorem circle_weight :
+    (if Utterance.circle = Utterance.square ∨ Utterance.circle = Utterance.blue
+      then (1 : ℝ≥0∞) else 2⁻¹) * qfCf (1/2) .circle = ENNReal.ofReal (1/2) := by
+  rw [show (if Utterance.circle = Utterance.square ∨ Utterance.circle = Utterance.blue
+      then (1 : ℝ≥0∞) else 2⁻¹) = 2⁻¹ from by simp +decide, qfCf_circle, mul_one]
+  exact half_conv
+
+private theorem green_weight :
+    (if Utterance.green = Utterance.square ∨ Utterance.green = Utterance.blue
+      then (1 : ℝ≥0∞) else 2⁻¹) * qfCf (1/2) .green = ENNReal.ofReal (xc/2) := by
+  rw [show (if Utterance.green = Utterance.square ∨ Utterance.green = Utterance.blue
+      then (1 : ℝ≥0∞) else 2⁻¹) = 2⁻¹ from by simp +decide, qfCf_green, half_conv,
+    ← ENNReal.ofReal_mul (by norm_num)]
+  congr 1
+  unfold xc
+  ring
+
+private theorem sc_circle_gc :
+    s1Cost .green_circle .circle = ENNReal.ofReal ((1/2) * (1/2 + xc/2)⁻¹) :=
+  s1Cost_val (by decide) (by norm_num) circle_weight Z_gc
+    (by have := xc_pos; linarith)
+
+private theorem sc_circle_bc :
+    s1Cost .blue_circle .circle = ENNReal.ofReal ((1/2) * (1/2 + xc)⁻¹) :=
+  s1Cost_val (by decide) (by norm_num) circle_weight Z_bc
+    (by have := xc_pos; linarith)
+
+private theorem sc_green_gc :
+    s1Cost .green_circle .green = ENNReal.ofReal ((xc/2) * (1/2 + xc/2)⁻¹) :=
+  s1Cost_val (by decide) (by have := xc_pos; linarith) green_weight Z_gc
+    (by have := xc_pos; linarith)
+
+private theorem sc_green_gs :
+    s1Cost .green_square .green = ENNReal.ofReal ((xc/2) * (1 + xc/2)⁻¹) :=
+  s1Cost_val (by decide) (by have := xc_pos; linarith) green_weight Z_gs
+    (by have := xc_pos; linarith)
+
+private theorem xc_eq : Real.exp (-2⁻¹) = xc := by
+  unfold xc
+  norm_num
+
+private theorem qfCf_zero (u : Utterance) : qfCf 0 u = 1 := by
+  cases u <;> simp [qfCf, adjCost]
+
 end PMFChain
+
+open scoped ENNReal
 
 -- ============================================================================
 -- §10. Structural Properties
@@ -664,15 +680,30 @@ theorem green_ambiguous :
     (ambiguous, cost=1/2). Both informativity and cost favor "square".
     Evidence: 135/144 speakers chose "square" (Table 1). -/
 theorem speaker_prefers_unique_shape :
-    costCfg.S1 () .green_square .square > costCfg.S1 () .green_square .green := by
-  rsa_predict
+    s1Cost .green_square .square > s1Cost .green_square .green := by
+  unfold s1Cost s1B
+  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt]
+  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_green]
+  simp +decide
+  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
+    show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from ENNReal.ofReal_one.symm]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr ?_
+  rw [xc_eq]
+  nlinarith [xc_pos, xc_lt_one]
 
 /-- Finding 2: For blue_circle, S1 prefers "blue" (unique, cost=1/2) over "circle"
     (ambiguous, cost=0). Informativity dominates cost.
     Evidence: 119/144 speakers chose "blue" (Table 1). -/
 theorem speaker_prefers_unique_color :
-    costCfg.S1 () .blue_circle .blue > costCfg.S1 () .blue_circle .circle := by
-  rsa_predict
+    s1Cost .blue_circle .blue > s1Cost .blue_circle .circle := by
+  unfold s1Cost s1B
+  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt]
+  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_circle, qfCf_blue]
+  simp +decide
+  rw [half_conv]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by positivity)).mpr ?_
+  rw [xc_eq]
+  exact xc_gt_half
 
 /-- Finding 3: For green_circle, cost breaks the tie between the two ambiguous
     words: S1 prefers "circle" (cost=0) over "green" (cost=1/2). Both are equally
@@ -680,15 +711,29 @@ theorem speaker_prefers_unique_color :
     Evidence: 81/144 chose "circle", 63/144 chose "green" (Table 1;
     not statistically significant: χ²=2.25, p=0.13). -/
 theorem cost_breaks_symmetry :
-    costCfg.S1 () .green_circle .circle > costCfg.S1 () .green_circle .green := by
-  rsa_predict
+    s1Cost .green_circle .circle > s1Cost .green_circle .green := by
+  unfold s1Cost s1B
+  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt]
+  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_circle, qfCf_green]
+  simp +decide
+  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num)]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr ?_
+  rw [xc_eq]
+  nlinarith [xc_lt_one, xc_pos]
 
 /-- Finding 4: Without cost, the symmetry is unbroken — neither ambiguous word
     dominates for green_circle. Both "circle" and "green" apply to exactly 2 objects,
     so L0 assigns equal probability, and S1 assigns equal weight. -/
 theorem no_cost_symmetry :
-    ¬(zeroCostCfg.S1 () .green_circle .circle > zeroCostCfg.S1 () .green_circle .green) := by
-  rsa_predict
+    ¬(s1ZeroCost .green_circle .circle > s1ZeroCost .green_circle .green) := by
+  have h : s1ZeroCost .green_circle .circle = s1ZeroCost .green_circle .green := by
+    refine le_antisymm ?_ ?_ <;>
+      · unfold s1ZeroCost s1B
+        rw [RSA.S1Belief_apply_le_iff_score_le]
+        simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_zero]
+        simp +decide
+  rw [gt_iff_lt, h]
+  exact lt_irrefl _
 
 -- ============================================================================
 -- §12. Listener Predictions (Findings 5–6): Salience Reversal
@@ -714,21 +759,49 @@ prior — exactly the comparison the paper runs (Table 4 rows for ρ_bU vs ρ_bS
     Pragmatic reasoning: a speaker wanting blue_circle would say "blue" (unique),
     so saying "circle" signals green_circle. -/
 theorem uniform_circle_green_circ :
-    costCfg.L1 .circle .green_circle > costCfg.L1 .circle .blue_circle := by
-  rsa_predict
+    l1Cost .circle .green_circle > l1Cost .circle .blue_circle := by
+  unfold l1Cost
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorU_apply, qfPriorU_apply,
+    sc_circle_bc, sc_circle_gc, third_conv,
+    ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; positivity)).mpr ?_
+  have hx := xc_pos
+  have h1 : (0:ℝ) < 1/2 + xc := by linarith
+  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
+  rw [show (1:ℝ)/3 * (1/2 * (1/2 + xc)⁻¹) = (1/6) / (1/2 + xc) from by
+      rw [div_eq_mul_inv]; ring,
+    show (1:ℝ)/3 * (1/2 * (1/2 + xc/2)⁻¹) = (1/6) / (1/2 + xc/2) from by
+      rw [div_eq_mul_inv]; ring,
+    div_lt_div_iff₀ h1 h2]
+  nlinarith [hx]
 
 /-- Salience L1 for "circle": blue_circle > green_circle.
     Salience (139 vs 30) overrides pragmatic narrowing. Matches human data
     (Table 2: 117/180 = 65% chose blue_circle). -/
 theorem salience_circle_blue_circ :
-    salienceCfg.L1 .circle .blue_circle > salienceCfg.L1 .circle .green_circle := by
-  rsa_predict
+    l1Sal .circle .blue_circle > l1Sal .circle .green_circle := by
+  unfold l1Sal
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorS_apply, qfPriorS_apply,
+    sc_circle_bc, sc_circle_gc,
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior]),
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior])]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
+  have hx := xc_pos
+  have h1 : (0:ℝ) < 1/2 + xc := by linarith
+  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
+  rw [saliencePrior, saliencePrior]
+  rw [show ((30:ℝ)/240) * ((1/2) * (1/2 + xc/2)⁻¹) = (30/480) / (1/2 + xc/2) from by
+      rw [div_eq_mul_inv]; ring,
+    show ((139:ℝ)/240) * ((1/2) * (1/2 + xc)⁻¹) = (139/480) / (1/2 + xc) from by
+      rw [div_eq_mul_inv]; ring,
+    div_lt_div_iff₀ h2 h1]
+  nlinarith [hx]
 
 /-- Finding 5: Salience reversal for "circle". Uniform and salience priors make
     opposite L1 predictions, and human data matches the salience direction. -/
 theorem salience_reversal_circle :
-    (costCfg.L1 .circle .green_circle > costCfg.L1 .circle .blue_circle) ∧
-    (salienceCfg.L1 .circle .blue_circle > salienceCfg.L1 .circle .green_circle) :=
+    (l1Cost .circle .green_circle > l1Cost .circle .blue_circle) ∧
+    (l1Sal .circle .blue_circle > l1Sal .circle .green_circle) :=
   ⟨uniform_circle_green_circ, salience_circle_blue_circ⟩
 
 -- Finding 6: Salience reversal for "green"
@@ -739,23 +812,51 @@ theorem salience_reversal_circle :
     Pragmatic reasoning: a speaker wanting green_square would say "square" (unique),
     so saying "green" signals green_circle. -/
 theorem uniform_green_green_circ :
-    costCfg.L1 .green .green_circle > costCfg.L1 .green .green_square := by
-  rsa_predict
+    l1Cost .green .green_circle > l1Cost .green .green_square := by
+  unfold l1Cost
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorU_apply, qfPriorU_apply,
+    sc_green_gs, sc_green_gc, third_conv,
+    ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; positivity)).mpr ?_
+  have hx := xc_pos
+  have h1 : (0:ℝ) < 1 + xc/2 := by linarith
+  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
+  rw [show (1:ℝ)/3 * (xc/2 * (1 + xc/2)⁻¹) = (xc/6) / (1 + xc/2) from by
+      rw [div_eq_mul_inv]; ring,
+    show (1:ℝ)/3 * (xc/2 * (1/2 + xc/2)⁻¹) = (xc/6) / (1/2 + xc/2) from by
+      rw [div_eq_mul_inv]; ring,
+    div_lt_div_iff₀ h1 h2]
+  nlinarith [hx]
 
 /-- Salience L1 for "green": green_square > green_circle.
     Salience (71 vs 30) overrides pragmatic narrowing in the model. However,
     human data goes in the opposite (pragmatic) direction: Table 2 shows
     115/180 = 64% chose green_circle. -/
 theorem salience_green_green_sq :
-    salienceCfg.L1 .green .green_square > salienceCfg.L1 .green .green_circle := by
-  rsa_predict
+    l1Sal .green .green_square > l1Sal .green .green_circle := by
+  unfold l1Sal
+  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorS_apply, qfPriorS_apply,
+    sc_green_gs, sc_green_gc,
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior]),
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior])]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
+  have hx := xc_pos
+  have h1 : (0:ℝ) < 1 + xc/2 := by linarith
+  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
+  rw [saliencePrior, saliencePrior]
+  rw [show ((30:ℝ)/240) * ((xc/2) * (1/2 + xc/2)⁻¹) = (30 * xc/480) / (1/2 + xc/2) from by
+      rw [div_eq_mul_inv]; ring,
+    show ((71:ℝ)/240) * ((xc/2) * (1 + xc/2)⁻¹) = (71 * xc/480) / (1 + xc/2) from by
+      rw [div_eq_mul_inv]; ring,
+    div_lt_div_iff₀ h2 h1]
+  nlinarith [hx]
 
 /-- Finding 6: Salience reversal for "green". Uniform and salience priors make
     opposite L1 predictions. Human data matches the *pragmatic* (uniform)
     direction: 115/180 chose green_circle (Table 2). -/
 theorem salience_reversal_green :
-    (costCfg.L1 .green .green_circle > costCfg.L1 .green .green_square) ∧
-    (salienceCfg.L1 .green .green_square > salienceCfg.L1 .green .green_circle) :=
+    (l1Cost .green .green_circle > l1Cost .green .green_square) ∧
+    (l1Sal .green .green_square > l1Sal .green .green_circle) :=
   ⟨uniform_green_green_circ, salience_green_green_sq⟩
 
 -- ============================================================================
@@ -783,23 +884,6 @@ score for "circle" enough to match or exceed "blue". -/
 -- Concrete configs: all use adjCost 1/2 and uniform listener prior.
 -- (Listener prior doesn't affect S1, so any prior works for speaker comparison.)
 
-/-- σ_aU with adjective cost = 1/2. Action-oriented speaker, uniform L0.
-    S1 score = exp(λ · (U(t|m) - Cost(m))). No exp/log cancellation. -/
-@[reducible]
-noncomputable def σ_aU_cfg : RSAConfig Utterance Object :=
-  σ_aU (adjCost (1/2)) uniformPrior uniformPrior_nonneg
-
-/-- σ_bS with adjective cost = 1/2. Belief-oriented speaker, salience-weighted L0.
-    L0 weights worlds by perceptual salience; S1 score = exp(λ · (log S(t|m) - Cost(m))). -/
-@[reducible]
-noncomputable def σ_bS_cfg : RSAConfig Utterance Object :=
-  σ_bS (adjCost (1/2)) uniformPrior uniformPrior_nonneg
-
-/-- σ_aS with adjective cost = 1/2. Action-oriented speaker, salience-weighted L0. -/
-@[reducible]
-noncomputable def σ_aS_cfg : RSAConfig Utterance Object :=
-  σ_aS (adjCost (1/2)) uniformPrior uniformPrior_nonneg
-
 -- §13a. σ_aU: Action-oriented, uniform belief
 -- Agrees on green_sq and green_circ; ties on blue_circ.
 -- The tie arises because exp/log don't cancel in actionGoalScore:
@@ -808,13 +892,19 @@ noncomputable def σ_aS_cfg : RSAConfig Utterance Object :=
 
 /-- σ_aU agrees: "square" > "green" for green_square. -/
 theorem σ_aU_green_sq :
-    σ_aU_cfg.S1 () .green_square .square > σ_aU_cfg.S1 () .green_square .green := by
-  rsa_predict
+    s1AU .green_square .square > s1AU .green_square .green := by
+  unfold s1AU s1A
+  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
+  simp only [qfL0_uniform_apply]
+  simp +decide [ENNReal.toReal_inv, adjCost]
 
 /-- σ_aU agrees: "circle" > "green" for green_circle (cost breaks symmetry). -/
 theorem σ_aU_green_circ :
-    σ_aU_cfg.S1 () .green_circle .circle > σ_aU_cfg.S1 () .green_circle .green := by
-  rsa_predict
+    s1AU .green_circle .circle > s1AU .green_circle .green := by
+  unfold s1AU s1A
+  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
+  simp only [qfL0_uniform_apply]
+  simp +decide [ENNReal.toReal_inv, adjCost]
 
 /-- σ_aU fails: "blue" and "circle" are tied for blue_circle.
     This is the key prediction that distinguishes σ_aU from σ_bU.
@@ -823,9 +913,16 @@ theorem σ_aU_green_circ :
     under action-oriented scoring (σ_aU), the raw difference is exactly
     offset by cost. -/
 theorem σ_aU_blue_circ_tie :
-    ¬(σ_aU_cfg.S1 () .blue_circle .blue > σ_aU_cfg.S1 () .blue_circle .circle) ∧
-    ¬(σ_aU_cfg.S1 () .blue_circle .circle > σ_aU_cfg.S1 () .blue_circle .blue) :=
-  ⟨by rsa_predict, by rsa_predict⟩
+    ¬(s1AU .blue_circle .blue > s1AU .blue_circle .circle) ∧
+    ¬(s1AU .blue_circle .circle > s1AU .blue_circle .blue) := by
+  have h : s1AU .blue_circle .blue = s1AU .blue_circle .circle := by
+    unfold s1AU s1A
+    rw [PMF.normalize_eq_iff_eq]
+    simp only [qfL0_uniform_apply]
+    simp +decide [ENNReal.toReal_inv, adjCost]
+    norm_num
+  exact ⟨by rw [gt_iff_lt, h]; exact lt_irrefl _,
+         by rw [gt_iff_lt, h]; exact lt_irrefl _⟩
 
 -- §13b. σ_bS: Belief-oriented, salience belief
 -- Agrees on green_sq; reverses on both blue_circ and green_circ.
@@ -835,8 +932,17 @@ theorem σ_aU_blue_circ_tie :
     The unique shape word wins regardless of speaker belief, since "square"
     applies to only one object while "green" is ambiguous. -/
 theorem σ_bS_green_sq :
-    σ_bS_cfg.S1 () .green_square .square > σ_bS_cfg.S1 () .green_square .green := by
-  rsa_predict
+    s1BS .green_square .square > s1BS .green_square .green := by
+  unfold s1BS s1B
+  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt, ENNReal.rpow_one, ENNReal.rpow_one,
+    qfL0_salience_true (show Utterance.green.appliesTo .green_square = true from by decide),
+    qfL0_salience_true (show Utterance.square.appliesTo .green_square = true from by decide),
+    qfCf_square, qfCf_green, mul_one,
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior, extSum])]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num [saliencePrior, extSum])).mpr ?_
+  rw [show Real.exp (-(1/2 : ℝ)) = xc from rfl]
+  norm_num [saliencePrior, extSum]
+  nlinarith [xc_lt_one, xc_pos]
 
 /-- σ_bS reverses blue_circle: predicts "circle" > "blue".
     With salience-weighted L0, blue_circle has the highest salience (139),
@@ -844,8 +950,17 @@ theorem σ_bS_green_sq :
     informative. Combined with zero cost for "circle" vs cost 1/2 for "blue",
     the pragmatic advantage of "blue" is overcome. -/
 theorem σ_bS_blue_circ_reversal :
-    σ_bS_cfg.S1 () .blue_circle .circle > σ_bS_cfg.S1 () .blue_circle .blue := by
-  rsa_predict
+    s1BS .blue_circle .circle > s1BS .blue_circle .blue := by
+  unfold s1BS s1B
+  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt, ENNReal.rpow_one, ENNReal.rpow_one,
+    qfL0_salience_true (show Utterance.blue.appliesTo .blue_circle = true from by decide),
+    qfL0_salience_true (show Utterance.circle.appliesTo .blue_circle = true from by decide),
+    qfCf_circle, qfCf_blue, mul_one,
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior, extSum])]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num [saliencePrior, extSum])).mpr ?_
+  rw [show Real.exp (-(1/2 : ℝ)) = xc from rfl]
+  norm_num [saliencePrior, extSum]
+  nlinarith [xc_lt_139_169]
 
 /-- σ_bS reverses green_circle: predicts "green" > "circle".
     With salience weights, L0(green_circ|"green") = 30/101 ≈ 0.30 and
@@ -853,31 +968,55 @@ theorem σ_bS_blue_circ_reversal :
     for green_circ, and the log transform in belief-oriented scoring
     amplifies this advantage enough to overcome its cost disadvantage. -/
 theorem σ_bS_green_circ_reversal :
-    σ_bS_cfg.S1 () .green_circle .green > σ_bS_cfg.S1 () .green_circle .circle := by
-  rsa_predict
+    s1BS .green_circle .green > s1BS .green_circle .circle := by
+  unfold s1BS s1B
+  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt, ENNReal.rpow_one, ENNReal.rpow_one,
+    qfL0_salience_true (show Utterance.circle.appliesTo .green_circle = true from by decide),
+    qfL0_salience_true (show Utterance.green.appliesTo .green_circle = true from by decide),
+    qfCf_circle, qfCf_green, mul_one,
+    ← ENNReal.ofReal_mul (by norm_num [saliencePrior, extSum])]
+  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num [saliencePrior, extSum]; positivity)).mpr ?_
+  rw [show Real.exp (-(1/2 : ℝ)) = xc from rfl]
+  norm_num [saliencePrior, extSum]
+  nlinarith [xc_gt_101_169]
 
 -- §13c. σ_aS: Action-oriented, salience belief
 -- Agrees on green_sq and green_circ; reverses on blue_circ.
 
 /-- σ_aS agrees: "square" > "green" for green_square. -/
 theorem σ_aS_green_sq :
-    σ_aS_cfg.S1 () .green_square .square > σ_aS_cfg.S1 () .green_square .green := by
-  rsa_predict
+    s1AS .green_square .square > s1AS .green_square .green := by
+  unfold s1AS s1A
+  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
+  simp +decide [qfL0_salience_true, saliencePrior, extSum, adjCost]
+  rw [ENNReal.toReal_ofReal (by norm_num)]
+  exact (ENNReal.ofReal_lt_ofReal_iff (Real.exp_pos _)).mpr
+    (Real.exp_lt_exp.mpr (by norm_num))
 
 /-- σ_aS reverses blue_circle: predicts "circle" > "blue".
     Same mechanism as σ_bS: salience inflates L0(blue_circ|"circle") = 139/169.
     Under action-oriented scoring, this raw probability advantage
     (plus zero cost) overcomes "blue"'s informativity. -/
 theorem σ_aS_blue_circ_reversal :
-    σ_aS_cfg.S1 () .blue_circle .circle > σ_aS_cfg.S1 () .blue_circle .blue := by
-  rsa_predict
+    s1AS .blue_circle .circle > s1AS .blue_circle .blue := by
+  unfold s1AS s1A
+  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
+  simp +decide [qfL0_salience_true, saliencePrior, extSum, adjCost]
+  rw [ENNReal.toReal_ofReal (by norm_num)]
+  exact (ENNReal.ofReal_lt_ofReal_iff (Real.exp_pos _)).mpr
+    (Real.exp_lt_exp.mpr (by norm_num))
 
 /-- σ_aS agrees: "circle" > "green" for green_circle.
     Unlike σ_bS, the action-oriented scoring doesn't amplify the L0
     advantage of "green" via log, so cost wins for green_circle. -/
 theorem σ_aS_green_circ :
-    σ_aS_cfg.S1 () .green_circle .circle > σ_aS_cfg.S1 () .green_circle .green := by
-  rsa_predict
+    s1AS .green_circle .circle > s1AS .green_circle .green := by
+  unfold s1AS s1A
+  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
+  simp +decide [qfL0_salience_true, saliencePrior, extSum, adjCost]
+  rw [ENNReal.toReal_ofReal (by norm_num), ENNReal.toReal_ofReal (by norm_num)]
+  exact (ENNReal.ofReal_lt_ofReal_iff (Real.exp_pos _)).mpr
+    (Real.exp_lt_exp.mpr (by norm_num))
 
 -- §13d. Capstone: σ_bU is the best speaker model
 
@@ -894,14 +1033,14 @@ theorem σ_aS_green_circ :
     uniform L0) best explains production data. -/
 theorem σ_bU_best_speaker_model :
     -- σ_bU correctly predicts blue > circle
-    (costCfg.S1 () .blue_circle .blue > costCfg.S1 () .blue_circle .circle) ∧
+    (s1Cost .blue_circle .blue > s1Cost .blue_circle .circle) ∧
     -- σ_aU ties: neither blue > circle nor circle > blue
-    (¬(σ_aU_cfg.S1 () .blue_circle .blue > σ_aU_cfg.S1 () .blue_circle .circle) ∧
-     ¬(σ_aU_cfg.S1 () .blue_circle .circle > σ_aU_cfg.S1 () .blue_circle .blue)) ∧
+    (¬(s1AU .blue_circle .blue > s1AU .blue_circle .circle) ∧
+     ¬(s1AU .blue_circle .circle > s1AU .blue_circle .blue)) ∧
     -- σ_bS reverses: circle > blue
-    (σ_bS_cfg.S1 () .blue_circle .circle > σ_bS_cfg.S1 () .blue_circle .blue) ∧
+    (s1BS .blue_circle .circle > s1BS .blue_circle .blue) ∧
     -- σ_aS reverses: circle > blue
-    (σ_aS_cfg.S1 () .blue_circle .circle > σ_aS_cfg.S1 () .blue_circle .blue) :=
+    (s1AS .blue_circle .circle > s1AS .blue_circle .blue) :=
   ⟨speaker_prefers_unique_color, σ_aU_blue_circ_tie,
    σ_bS_blue_circ_reversal, σ_aS_blue_circ_reversal⟩
 
@@ -912,19 +1051,19 @@ theorem σ_bU_best_speaker_model :
 /-- Map each empirical finding to the RSA model prediction that accounts for it. -/
 def formalize : Finding → Prop
   | .speaker_prefers_unique_shape =>
-      costCfg.S1 () .green_square .square > costCfg.S1 () .green_square .green
+      s1Cost .green_square .square > s1Cost .green_square .green
   | .speaker_prefers_unique_color =>
-      costCfg.S1 () .blue_circle .blue > costCfg.S1 () .blue_circle .circle
+      s1Cost .blue_circle .blue > s1Cost .blue_circle .circle
   | .cost_breaks_symmetry =>
-      costCfg.S1 () .green_circle .circle > costCfg.S1 () .green_circle .green
+      s1Cost .green_circle .circle > s1Cost .green_circle .green
   | .no_cost_symmetry =>
-      ¬(zeroCostCfg.S1 () .green_circle .circle > zeroCostCfg.S1 () .green_circle .green)
+      ¬(s1ZeroCost .green_circle .circle > s1ZeroCost .green_circle .green)
   | .salience_reversal_circle =>
-      (costCfg.L1 .circle .green_circle > costCfg.L1 .circle .blue_circle) ∧
-      (salienceCfg.L1 .circle .blue_circle > salienceCfg.L1 .circle .green_circle)
+      (l1Cost .circle .green_circle > l1Cost .circle .blue_circle) ∧
+      (l1Sal .circle .blue_circle > l1Sal .circle .green_circle)
   | .salience_reversal_green =>
-      (costCfg.L1 .green .green_circle > costCfg.L1 .green .green_square) ∧
-      (salienceCfg.L1 .green .green_square > salienceCfg.L1 .green .green_circle)
+      (l1Cost .green .green_circle > l1Cost .green .green_square) ∧
+      (l1Sal .green .green_square > l1Sal .green .green_circle)
 
 /-- The RSA model accounts for all 6 qualitative findings from [qing-franke-2015]. -/
 theorem all_findings_verified : ∀ f : Finding, formalize f := by
@@ -948,9 +1087,9 @@ is strictly monotone and multiplication by λ > 0 preserves strict order:
 
 **Consequence**: The qualitative predictions (findings 1–4) hold for ALL λ > 0.
 The paper's strong rejection of λ = 1 (§5) affects only the *magnitude* of
-preferences (softmax temperature), not their *direction*. The existing
-`rsa_predict` proofs at α = 1 establish log(L0) − cost orderings that hold
-at every positive α.
+preferences (softmax temperature), not their *direction*. The PMF-face
+proofs at λ = 1 establish log(L0) − cost orderings that hold at every
+positive λ.
 
 Cost thresholds (the exact c ranges where each finding holds):
 - **Finding 1** (sq > gr for green_sq): all c ≥ 0 (log 1 − 0 > log ½ − c)
@@ -1118,9 +1257,9 @@ which equals `beliefGoalScore (fun _ => 0)` since `x − 0 = x` (`sub_zero`).
 
 FG2012 uses multiple reference game contexts across 7 conditions; Q&F's
 experiment (§4) focuses on one configuration: {green_square, green_circle,
-blue_circle}. The scoring rule, compositional pattern, and RSAConfig structure
-are identical — Q&F's contribution is decomposing along the cost, goal, and
-salience dimensions. -/
+blue_circle}. The scoring rule and compositional pattern are identical —
+Q&F's contribution is decomposing along the cost, goal, and salience
+dimensions. -/
 
 /-- Zero-cost belief-oriented scoring equals FG2012's scoring rule.
 
@@ -1134,36 +1273,29 @@ theorem zeroCost_beliefGoal_eq
   simp [beliefGoalScore, sub_zero]
 
 /-!
-## Summary: What this file tests about the RSAConfig API
+## Summary: the model on the PMF face
 
-1. **Pluggable s1Score**: `beliefGoalScore` and `actionGoalScore` are different
-   scoring functions, plugged into the same RSAConfig structure via `s1Score`.
-   The API is agnostic to what the speaker optimizes.
+1. **Two speaker goals, one chain shape**: the belief-oriented speakers are
+   `RSA.S1Belief` (weights `L0 · exp(−Cost)`, eq. 10 at λ = 1); the
+   action-oriented speakers are a local softmax over `exp(L0 − Cost)`
+   (eq. 9) — positive on false utterances, which is exactly what produces
+   the σ_aU tie at the blue circle.
 
-2. **Meaning encodes speaker belief**: The speaker's assumption about L0
-   (uniform vs salience-weighted) is captured by the `meaning` function.
-   No separate "speaker belief" field is needed.
+2. **Speaker belief enters as the L0 prior**: uniform vs salience-weighted
+   literal listeners are the same `L0LassiterGoodman` construction at
+   different priors (`qfPriorU`/`qfPriorS`).
 
-3. **Cost inside s1Score**: Utterance cost is part of the speaker's
-   score function, not a separate RSAConfig field. This is clean because
-   cost IS part of what the speaker optimizes.
+3. **Independent listener prior**: `l1Cost` and `l1Sal` share the σ_bU
+   speaker and differ only in the posterior's world prior (eqs. 12–13) —
+   the salience-reversal findings are pure prior effects.
 
-4. **Independent listener prior**: `worldPrior` (the listener's prior at L1)
-   is independent of `meaning` (which determines L0). This allows the
-   speaker's belief about L0 and the listener's prior to vary independently,
-   exactly as Q&F require.
+4. **Sharp cost regime**: the three genuinely numeric findings need only
+   `exp(−1/2) > 1/2` (e < 4), `exp(−1/2) < 139/169`, and
+   `exp(−1/2) > 101/169` (e < (169/101)² ≈ 2.7998) — all discharged from
+   `Real.exp_one_lt_d9`/`gt_d9`; everything else is generic in the cost
+   factor.
 
-5. **Composable extensions**: The action-oriented listener is defined as
-   `softmax ∘ L1`, extending the API without modifying RSAConfig. The
-   softmax properties (positivity, sum-to-one, monotonicity) transfer
-   directly from Core.RationalAction.
-
-6. **Model comparison**: All 4 speaker models instantiate the same RSAConfig
-   API with different `s1Score` and `meaning` choices. `rsa_predict` handles
-   all comparisons including score-equality ties (σ_aU, zeroCost). The
-   capstone theorem shows σ_bU uniquely predicts the blue_circle observation.
-
-7. **λ-independence** (§15): `beliefGoal_gt_iff` and `actionGoal_gt_iff` prove
+5. **λ-independence** (§15): `beliefGoal_gt_iff` and `actionGoal_gt_iff` prove
    that speaker rankings depend only on `log L0 − cost` (or `L0 − cost`),
    not on the rationality parameter λ. The paper's rejection of λ = 1 affects
    only quantitative fit, not qualitative predictions.
@@ -1214,9 +1346,9 @@ open Pragmatics.GriceanMaxims
     No-Brevity interpretation (strength = 0), the weakest Q2. -/
 theorem cost_is_q2 :
     -- No cost = no symmetry breaking (No Brevity regime)
-    ¬(zeroCostCfg.S1 () .green_circle .circle > zeroCostCfg.S1 () .green_circle .green) ∧
+    ¬(s1ZeroCost .green_circle .circle > s1ZeroCost .green_circle .green) ∧
     -- With cost = symmetry breaks (Q2 pressure active)
-    costCfg.S1 () .green_circle .circle > costCfg.S1 () .green_circle .green ∧
+    s1Cost .green_circle .circle > s1Cost .green_circle .green ∧
     -- No Brevity is the weakest Q2 interpretation
     DaleReiter1995.BrevityInterpretation.noBrevity.strength = 0 ∧
     -- Q1 and Q2 are independent sub-maxims

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -45,8 +45,6 @@ P(w) · P(C)` over different domains. Blocked on `ScontrasTonhauser2025.lean`
 reaching the PMF face.
 -/
 
-set_option autoImplicit false
-
 namespace QingGoodmanLassiter2016
 
 open BigOperators

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -35,10 +35,14 @@ The paper uses 15 context sets with 5% noise; we model the 9 derivable from
 past/now observations — the omitted 6 carry only the noise prior (≥ 18×
 lower) and do not affect the qualitative predictions.
 
-[scontras-tonhauser-2025] and [warstadt-2022] instantiate the same structure
-(latent = "private assumptions" resp. context set) over factives and
-genus-species; see `ScontrasTonhauser2025.lean`. Per S&T fn. 10 the
-difference is interpretive, not computational.
+## TODO
+
+Prove the structural equivalence with [scontras-tonhauser-2025] (factives;
+latent = "private assumptions", their fn. 10: the difference from QGL's
+"common ground" is interpretive, not computational) and [warstadt-2022]
+(genus-species) — all three compute `L1(w, C | u, Q) ∝ S1(u | w, C, Q) ·
+P(w) · P(C)` over different domains. Blocked on `ScontrasTonhauser2025.lean`
+reaching the PMF face.
 -/
 
 set_option autoImplicit false
@@ -676,34 +680,5 @@ def entailsPast : ContextSet → Bool
 theorem three_entail_past :
     (Finset.univ.filter (fun cs : ContextSet => entailsPast cs)).card = 3 := by
   decide
-
-/-! ### §10. Connection to S&T and Warstadt -/
-
-/-!
-## Mathematical Equivalence with [scontras-tonhauser-2025] and [warstadt-2022]
-
-All three papers implement the same RSA computation:
-
-```
-L1(w, C | u, Q) ∝ S1(u | w, C, Q) · P(w) · P(C)
-```
-
-| Paper | Latent | Interpretation | Domain |
-|-------|--------|---------------|--------|
-| [qing-goodman-lassiter-2016] | Context set C | Common ground | CoS verbs |
-| [scontras-tonhauser-2025] | Assumptions A | Speaker beliefs | Factives |
-| [warstadt-2022] | Context set C | Common ground | Genus-species |
-
-The encoding is structurally identical: the latent is the context/belief
-state, the literal listener filters by compatibility, and the speaker
-scores the QUD-projected literal posterior. See `ScontrasTonhauser2025.lean`
-for the factive domain implementation.
-
-[scontras-tonhauser-2025] fn. 10: "[qing-goodman-lassiter-2016] call these subsets
-the 'common ground,' but we think 'private assumptions' better captures
-this component of the model."
-
-The terminological difference is interpretive, not computational.
--/
 
 end QingGoodmanLassiter2016

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -3,57 +3,42 @@ import Linglib.Pragmatics.RSA.Operators
 import Linglib.Semantics.Aspect.ChangeOfState
 
 /-!
-# [qing-goodman-lassiter-2016]
+# [qing-goodman-lassiter-2016]: an RSA model of projective content
 
-A rational speech-act model of projective content. CogSci 2016, pp. 1110–1115.
+The listener jointly infers the world state and the context set the speaker
+assumed (CogSci 2016, pp. 1110–1115). Under the right QUD this derives
+presupposition projection with no special semantic mechanism: L0 answers the
+QUD within the context set (eq. 5), S1 scores QUD-projected informativity
+(eq. 6, α = 6), and L1 inverts jointly over worlds and context sets (eq. 7).
+Domain: 13 utterances × 4 worlds × 9 context sets.
 
-The listener jointly infers the world state and the common ground (context set)
-the speaker assumed. Under the right QUD, this derives presupposition projection
-without any special semantic mechanism.
+## Main results
 
-## The Model
+* `qud_now_wTT_eq_wFT`: under QUD_now the world marginal cannot show
+  projection — the now-cell aggregation is definitionally symmetric.
+* `context_projection`: the paper's headline — after "didn't stop smoking",
+  L1 infers a +past context set over −past (and over `universe`,
+  `context_projection_over_universe`, despite its higher prior).
+* `projection_under_qud_max` / `qud_max_incomplete_projection`: under the
+  identity QUD projection is visible at the world level but incomplete
+  (wTT = wFF, Figure 1c).
+* `qud_answer_now_true` / `stopped_qud_answer`: L1 recovers the QUD answer.
 
-- **L0** (eq. 5): L0(Q(w) | u, C, Q) ∝ Σ_{w'∈C∩⟦u⟧} δ_{Q(w)=Q(w')} · P(w')
-- **S1** (eq. 6): S(u|w,C,Q) ∝ P(u) · L0(Q(w) | u, C, Q)^α
-- **L1** (eq. 7): L(w,C | u, Q) ∝ P(w) · P(C) · S(u | w, C, Q)
+## Implementation notes
 
-Domain: 13 utterances × 4 worlds × 9 context sets. α = 6.
+α = 6 is a natural power, so every layer is rational: scores are computed in
+exact ℚ (`l0Q` … `ctxScoreQ`), listeners are `PMF.normalize` of those scores
+(bridged by `ENNReal.ofReal_sum_of_nonneg`), and predictions are
+kernel-verified rational comparisons (`decide +kernel`).
 
-## Formalization
+The paper uses 15 context sets with 5% noise; we model the 9 derivable from
+past/now observations — the omitted 6 carry only the noise prior (≥ 18×
+lower) and do not affect the qualitative predictions.
 
-Since α = 6 is a natural power, every layer of the model is a rational
-function of the priors: the scores are computed in exact ℚ (`l0Q` through
-`worldScoreQ`/`ctxScoreQ`), the listeners are `PMF.normalize` of those
-scores, and the two meet through `ENNReal.ofReal_sum_of_nonneg` bridges.
-Every prediction is a kernel-verified rational comparison; the lone
-exception is the QUD_now symmetry, which holds definitionally.
-
-## Key Insight: QUD Projection and Context Set Inference
-
-Under QUD_now ("Does John smoke now?"), S1 scores depend on `now(w)` only —
-worlds with the same `now` value are indistinguishable (§8.1). This means
-presupposition projection CANNOT be observed at the world marginal level.
-Instead, projection surfaces in the **context set posterior** (`l1Ctx`):
-L1 infers the speaker assumed a context set entailing `past=T` (§8.5).
-
-Under QUD_max (identity QUD), the past-now degeneracy breaks and projection
-is visible directly at the world level (§8.4).
-
-## Context Set Simplification
-
-The paper uses 15 non-empty context sets (all 2^4 - 1 subsets of 4 worlds) with
-5% noise added to eq. (8) to ensure nonzero priors. We model only the 9 context
-sets derivable from observations about past/now, since the remaining 6 (e.g.,
-`change = {(T,F),(F,T)}`) receive only the noise prior (≥18× lower) and do not
-affect qualitative predictions.
-
-## Connection to [scontras-tonhauser-2025] and [warstadt-2022]
-
-All three papers implement the same mathematical structure with different
-domains (change-of-state verbs, factives, genus-species). The latent variable
-is called "context set" here and "private assumptions" in S&T, but the
-computation is identical. See `ScontrasTonhauser2025.lean` for the factive
-domain.
+[scontras-tonhauser-2025] and [warstadt-2022] instantiate the same structure
+(latent = "private assumptions" resp. context set) over factives and
+genus-species; see `ScontrasTonhauser2025.lean`. Per S&T fn. 10 the
+difference is interpretive, not computational.
 -/
 
 set_option autoImplicit false
@@ -61,9 +46,7 @@ set_option autoImplicit false
 namespace QingGoodmanLassiter2016
 
 open BigOperators
--- ============================================================================
--- §1. World State
--- ============================================================================
+/-! ### §1. World State -/
 
 /-- World state: (past, now) where past = John smoked, now = John smokes.
     Flat inductive for tactic enumerability. -/
@@ -82,9 +65,7 @@ def WorldState.now : WorldState → Bool
   | .wTT | .wFT => true
   | .wTF | .wFF => false
 
--- ============================================================================
--- §2. Utterances (Table 1 + negations + silence)
--- ============================================================================
+/-! ### §2. Utterances (Table 1 + negations + silence) -/
 
 /-- Utterances about John's smoking habits.
     6 positive utterances from Table 1, their 6 negations, and silence. -/
@@ -104,9 +85,7 @@ inductive Utterance where
   | silence             -- null utterance          {(T,T),(T,F),(F,T),(F,F)}
   deriving DecidableEq, Repr, Inhabited, Fintype
 
--- ============================================================================
--- §3. Literal Semantics
--- ============================================================================
+/-! ### §3. Literal Semantics -/
 
 /-- Literal truth conditions from Table 1. Negation of u is U - ⟦u⟧.
 
@@ -159,9 +138,7 @@ theorem always_matches_continuation (w : WorldState) :
   cases w <;> simp [literalMeaning, priorStatePresup, resultStateAssertion,
     WorldState.past, WorldState.now]
 
--- ============================================================================
--- §4. Context Sets (Common Ground)
--- ============================================================================
+/-! ### §4. Context Sets (Common Ground) -/
 
 /-- Context sets: subsets of worlds representing common ground.
     These are the 9 context sets derivable from observations about past and now
@@ -191,9 +168,7 @@ def compatibleBool : ContextSet → WorldState → Bool
   | .pastFalseNowFalse, w => !w.past && !w.now
   | .universe,          _ => true
 
--- ============================================================================
--- §5. QUD
--- ============================================================================
+/-! ### §5. QUD -/
 
 /-- Questions under discussion. -/
 inductive QUD where
@@ -202,9 +177,7 @@ inductive QUD where
   | past  -- "Did John smoke?" (partitions by past)
   deriving DecidableEq, Repr, Inhabited, Fintype
 
--- ============================================================================
--- §6. Priors
--- ============================================================================
+/-! ### §6. Priors -/
 
 /-- Utterance prior (eq. 1): Pr(u) ∝ 2^{-#content-words(u)}.
     Negation and auxiliaries excluded from count.
@@ -222,7 +195,8 @@ def utterancePrior : Utterance → ℚ
 theorem utterancePrior_nonneg (u : Utterance) : 0 ≤ utterancePrior u := by
   cases u <;> simp [utterancePrior]
 
-/-- Context set prior (eq. 8): Pr(C) ∝ Σ_{CommonGround⊆Obs} P(CommonGround) · δ_{C=∩CommonGround}.
+/-- Context set prior (eq. 8):
+`Pr(C) ∝ Σ_{CG ⊆ Obs} P(CG) · δ_{C = ∩CG}`.
     Each observation enters CommonGround independently with probability 0.4.
     P(CommonGround) = 0.4^|CommonGround| × 0.6^(4-|CommonGround|).
     - 0 observations (universe): 0.6^4 ∝ 9
@@ -237,15 +211,7 @@ def contextPrior : ContextSet → ℚ
 theorem contextPrior_pos (cs : ContextSet) : 0 < contextPrior cs := by
   cases cs <;> simp [contextPrior]
 
--- ============================================================================
--- §7b. Exact-ℚ model and PMF face (local pending the RSA API pass)
--- ============================================================================
-
-/-! The model computed in exact rational arithmetic (the project's RSA
-convention): α = 6 is a natural power, so every layer — literal listener,
-QUD aggregation (eq. 5), speaker (eq. 6), listener scores (eq. 7) — is a
-rational function of the priors. The PMF face below normalizes these scores;
-its values bridge to the ℚ layer by `ENNReal.ofReal_sum_of_nonneg`. -/
+/-! ### §7b. Exact-ℚ model and PMF face (local pending the RSA API pass) -/
 
 section QModel
 
@@ -511,23 +477,13 @@ private theorem l1Ctx_apply (qud : QUD) {u : Utterance} (hu : u ≠ .silence)
 
 end PMFFace
 
--- ============================================================================
--- §8. L1 Predictions
--- ============================================================================
+/-! ### §8. L1 Predictions -/
 
-/-! ### §8.1 QUD_now symmetry
+/-! ### §8.1 QUD_now symmetry -/
 
-Under QUD_now, the QUD aggregation maps wTT and wFT to the same value (both
-have now=T), so S1(cs, wTT, u) = S1(cs, wFT, u) for all cs. With uniform
-worldPrior and w-independent latentPrior, L1(wTT) = L1(wFT). This means
-presupposition projection **cannot** be measured by world marginal under
-QUD_now — the past dimension is invisible to L1. -/
-
-/-- **QUD_now symmetry**: wTT and wFT are indistinguishable.
-
-    This is the structural reason why projection under QUD_now must be
-    measured via context set inference (the `l1Ctx` side), not the world
-    marginal — `qAggQ .now` is definitionally symmetric in the now-cell. -/
+/-- Under QUD_now, wTT and wFT are indistinguishable: `qAggQ .now` is
+definitionally symmetric in the now-cell, so projection must be measured on
+the context-set side (`l1Ctx`), not the world marginal. -/
 theorem qud_now_wTT_eq_wFT :
     l1World .now .notStoppedSmoking .wTT =
     l1World .now .notStoppedSmoking .wFT := by
@@ -535,12 +491,9 @@ theorem qud_now_wTT_eq_wFT :
     l1World_apply .now (by decide) wZ_pos_now_ns]
   congr 2
 
-/-! ### §8.2 QUD answer
+/-! ### §8.2 QUD answer -/
 
-After hearing "didn't stop smoking" with QUD = "Does John smoke now?",
-L1 correctly infers the QUD answer: John smokes (now=T). -/
-
-/-- **QUD answer inference**: L1 infers now=T from "didn't stop smoking". -/
+/-- L1 infers the QUD answer now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
     l1WorldEvent .now .notStoppedSmoking (fun w => w.now = true) >
     l1WorldEvent .now .notStoppedSmoking (fun w => w.now = false) := by
@@ -562,15 +515,14 @@ theorem qud_answer_now_true :
 
 /-! ### §8.3 World elimination
 
-Within worlds sharing the same past value, now=T dominates now=F.
-"Didn't stop smoking" is literally false at wTF (past=T, now=F is exactly
-"stopped smoking"), concentrating L1 mass on wTT. -/
+"Didn't stop smoking" is literally false at wTF, concentrating L1 on wTT. -/
 
-/-- **Now=T dominates now=F** among past=T worlds. -/
+/-- now=T dominates now=F among past=T worlds. -/
 theorem wTT_gt_wTF :
     l1World .now .notStoppedSmoking .wTT >
     l1World .now .notStoppedSmoking .wTF := by
-  rw [gt_iff_lt, l1World_apply .now (by decide) wZ_pos_now_ns, l1World_apply .now (by decide) wZ_pos_now_ns]
+  rw [gt_iff_lt, l1World_apply .now (by decide) wZ_pos_now_ns,
+    l1World_apply .now (by decide) wZ_pos_now_ns]
   exact ofReal_mul_inv_lt wZ_pos_now_ns (wZ_fin _ _)
     (by exact_mod_cast (by decide +kernel : (0:ℚ) < worldScoreQ .now .notStoppedSmoking .wTT))
     (by exact_mod_cast (by decide +kernel :
@@ -578,33 +530,25 @@ theorem wTT_gt_wTF :
 
 /-! ### §8.4 Projection under QUD_max (Figure 1c)
 
-Under the identity QUD, the past-now degeneracy of §8.1 breaks: S1 scores
-depend on all world dimensions, so L1 can distinguish wTT from wFT. The
-key asymmetry: under +past context, "didn't stop" narrows to exactly wTT
-(maximally informative for the speaker), while under -past context it
-spreads over both wFT and wFF (less informative). This makes wTT more
-likely than wFT.
+The identity QUD breaks §8.1's degeneracy — under +past, "didn't stop"
+narrows to exactly wTT — but projection stays incomplete: wTT = wFF, so
+the past marginals still coincide. -/
 
-The paper observes that (T,T) = (F,F) under QUD_max (Figure 1c), so projection
-is incomplete — the past=T marginal still equals the past=F marginal. Full
-projection requires QUD_now + context set inference (§8.5). -/
-
-/-- **Projection under QUD_max**: wTT > wFT. -/
+/-- Projection under QUD_max: wTT > wFT. -/
 theorem projection_under_qud_max :
     l1World .max .notStoppedSmoking .wTT >
     l1World .max .notStoppedSmoking .wFT := by
-  rw [gt_iff_lt, l1World_apply .max (by decide) wZ_pos_max_ns, l1World_apply .max (by decide) wZ_pos_max_ns]
+  rw [gt_iff_lt, l1World_apply .max (by decide) wZ_pos_max_ns,
+    l1World_apply .max (by decide) wZ_pos_max_ns]
   exact ofReal_mul_inv_lt wZ_pos_max_ns (wZ_fin _ _)
     (by exact_mod_cast (by decide +kernel : (0:ℚ) < worldScoreQ .max .notStoppedSmoking .wTT))
     (by exact_mod_cast (by decide +kernel :
       worldScoreQ .max .notStoppedSmoking .wFT < worldScoreQ .max .notStoppedSmoking .wTT))
 
-/-- **Incomplete projection under QUD_max**: wTT = wFF (Figure 1c).
-
-    Under the identity QUD, (T,T) and (F,F) receive equal L1 probability —
-    the involution swapping (past, now) ↦ (¬now, ¬past) fixes the meaning of
-    "didn't stop" and permutes the context sets prior-preservingly. Projection
-    is NOT captured at the world level under QUD_max. -/
+/-- Incomplete projection under QUD_max: wTT = wFF (Figure 1c). The
+involution (past, now) ↦ (¬now, ¬past) fixes ⟦didn't stop⟧ and permutes the
+context sets prior-preservingly, so world marginals cannot fully register
+the presupposition. -/
 theorem qud_max_incomplete_projection :
     l1World .max .notStoppedSmoking .wTT =
     l1World .max .notStoppedSmoking .wFF := by
@@ -617,63 +561,48 @@ theorem qud_max_incomplete_projection :
 
 /-! ### §8.5 Context set projection (the paper's main result, Figure 3)
 
-The paper's headline result: after hearing "didn't stop smoking" under QUD_now,
-L1 infers the speaker assumed a **+past context set** (common ground where John
-smoked). This is presupposition projection: the presupposed content (past=T)
-enters the listener's beliefs about the common ground, even though the utterance
-literally says nothing about the past.
+Under +past, "didn't stop" narrows L0 to wTT (aggregate 1, `1⁶ = 1`); under
+−past it spreads (`(1/2)⁶ = 1/64`). S1 rewards informativity, so L1 infers
+the speaker assumed a +past common ground — projection as context-set
+inference, with (wTT, +past) the joint mode (Figure 3). -/
 
-The mechanism: under +past context, "didn't stop" narrows L0 to exactly wTT,
-giving aggregate 1 and `1⁶ = 1` (maximally informative). Under
--past context, L0 spreads over wFT and wFF, giving aggregate `1/2` and
-`(1/2)⁶ = 1/64` (weakly informative). Since S1 rewards informativity,
-the speaker is much more likely to use "didn't stop" when the +past context
-holds, and L1 infers this.
-
-Figure 3 shows that (T,T) with context set +past is the unique maximum of the
-joint distribution under CommonGround prior + QUD_now. -/
-
-/-- **Context set projection**: L1 infers +past context over -past context. -/
+/-- The headline: L1 infers a +past context set over −past. -/
 theorem context_projection :
     l1Ctx .now .notStoppedSmoking .pastTrue >
     l1Ctx .now .notStoppedSmoking .pastFalse := by
-  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns, l1Ctx_apply .now (by decide) cZ_pos_now_ns]
+  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns,
+    l1Ctx_apply .now (by decide) cZ_pos_now_ns]
   exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
     (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
     (by exact_mod_cast (by decide +kernel :
       ctxScoreQ .now .notStoppedSmoking .pastFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
-/-- **+past beats uninformative universe** despite lower prior (9 vs 6).
-
-    Under +past, "didn't stop" narrows to exactly wTT (`1⁶ = 1`).
-    Under universe, it spreads over 3 worlds (`(1/4)⁶ ≈ 0`). The
-    informativity gain overwhelms the prior advantage. -/
+/-- +past beats `universe` despite the prior (6 vs 9): "didn't stop" narrows
+to wTT under +past (`1⁶ = 1`) but spreads over three worlds under `universe`
+(`(1/4)⁶`). -/
 theorem context_projection_over_universe :
     l1Ctx .now .notStoppedSmoking .pastTrue >
     l1Ctx .now .notStoppedSmoking .universe := by
-  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns, l1Ctx_apply .now (by decide) cZ_pos_now_ns]
+  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns,
+    l1Ctx_apply .now (by decide) cZ_pos_now_ns]
   exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
     (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
     (by exact_mod_cast (by decide +kernel :
       ctxScoreQ .now .notStoppedSmoking .universe < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
-/-- **-now context is dispreferred** (p. 1114): -now already entails the QUD
-    answer (John doesn't smoke now), so the speaker would be maximally
-    informative even saying nothing — "didn't stop smoking" adds no value.
-    L1 therefore infers the speaker did NOT assume a -now context. -/
+/-- −now contexts are dispreferred (p. 1114): −now already entails the QUD
+answer, so "didn't stop smoking" adds nothing there. -/
 theorem now_context_dispreferred :
     l1Ctx .now .notStoppedSmoking .pastTrue >
     l1Ctx .now .notStoppedSmoking .nowFalse := by
-  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns, l1Ctx_apply .now (by decide) cZ_pos_now_ns]
+  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns,
+    l1Ctx_apply .now (by decide) cZ_pos_now_ns]
   exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
     (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
     (by exact_mod_cast (by decide +kernel :
       ctxScoreQ .now .notStoppedSmoking .nowFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
-/-! ### §8.6 "Stopped smoking" projects past=T via QUD answer
-
-"Stopped smoking" is true only at wTF (past=T, now=F). Under QUD_now,
-L1 infers the QUD answer is now=F. -/
+/-! ### §8.6 "Stopped smoking" -/
 
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
@@ -695,9 +624,7 @@ theorem stopped_qud_answer :
       worldScoreQ .now .stoppedSmoking .wTT + worldScoreQ .now .stoppedSmoking .wFT <
       worldScoreQ .now .stoppedSmoking .wTF + worldScoreQ .now .stoppedSmoking .wFF))
 
--- ============================================================================
--- §9. Structural Properties
--- ============================================================================
+/-! ### §9. Structural Properties -/
 
 /-- "didn't stop smoking" is compatible with 3 of 4 worlds. -/
 theorem notStopped_compatible_worlds :
@@ -750,9 +677,7 @@ theorem three_entail_past :
     (Finset.univ.filter (fun cs : ContextSet => entailsPast cs)).card = 3 := by
   decide
 
--- ============================================================================
--- §10. Connection to S&T and Warstadt
--- ============================================================================
+/-! ### §10. Connection to S&T and Warstadt -/
 
 /-!
 ## Mathematical Equivalence with [scontras-tonhauser-2025] and [warstadt-2022]

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -1,7 +1,6 @@
-import Linglib.Tactics.RSAPredict
-import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.LatentOperators
+import Linglib.Pragmatics.RSA.Operators
 import Linglib.Semantics.Aspect.ChangeOfState
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!
 # [qing-goodman-lassiter-2016]
@@ -20,12 +19,21 @@ without any special semantic mechanism.
 
 Domain: 13 utterances × 4 worlds × 9 context sets. α = 6.
 
+## Formalization
+
+Since α = 6 is a natural power, every layer of the model is a rational
+function of the priors: the scores are computed in exact ℚ (`l0Q` through
+`worldScoreQ`/`ctxScoreQ`), the listeners are `PMF.normalize` of those
+scores, and the two meet through `ENNReal.ofReal_sum_of_nonneg` bridges.
+Every prediction is a kernel-verified rational comparison; the lone
+exception is the QUD_now symmetry, which holds definitionally.
+
 ## Key Insight: QUD Projection and Context Set Inference
 
 Under QUD_now ("Does John smoke now?"), S1 scores depend on `now(w)` only —
 worlds with the same `now` value are indistinguishable (§8.1). This means
 presupposition projection CANNOT be observed at the world marginal level.
-Instead, projection surfaces in the **context set posterior** (L1_latent):
+Instead, projection surfaces in the **context set posterior** (`l1Ctx`):
 L1 infers the speaker assumed a context set entailing `past=T` (§8.5).
 
 Under QUD_max (identity QUD), the past-now degeneracy breaks and projection
@@ -53,7 +61,6 @@ set_option autoImplicit false
 namespace QingGoodmanLassiter2016
 
 open BigOperators
-open Real (rpow rpow_nonneg)
 -- ============================================================================
 -- §1. World State
 -- ============================================================================
@@ -195,27 +202,6 @@ inductive QUD where
   | past  -- "Did John smoke?" (partitions by past)
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- QUD aggregation: sums L0 probabilities over the QUD equivalence class.
-    - now: sums over worlds with same now value
-    - max: identity (no aggregation)
-    - past: sums over worlds with same past value -/
-def qudAggregate (qud : QUD) (f : WorldState → ℝ) (w : WorldState) : ℝ :=
-  match qud, w with
-  | .now,  .wTT => f .wTT + f .wFT
-  | .now,  .wTF => f .wTF + f .wFF
-  | .now,  .wFT => f .wTT + f .wFT
-  | .now,  .wFF => f .wTF + f .wFF
-  | .max,  w    => f w
-  | .past, .wTT => f .wTT + f .wTF
-  | .past, .wTF => f .wTT + f .wTF
-  | .past, .wFT => f .wFT + f .wFF
-  | .past, .wFF => f .wFT + f .wFF
-
-theorem qudAggregate_nonneg {qud : QUD} {f : WorldState → ℝ} {w : WorldState}
-    (hf : ∀ w, 0 ≤ f w) : 0 ≤ qudAggregate qud f w := by
-  cases qud <;> cases w <;> simp only [qudAggregate]
-  all_goals first | exact hf _ | exact add_nonneg (hf _) (hf _)
-
 -- ============================================================================
 -- §6. Priors
 -- ============================================================================
@@ -252,40 +238,278 @@ theorem contextPrior_pos (cs : ContextSet) : 0 < contextPrior cs := by
   cases cs <;> simp [contextPrior]
 
 -- ============================================================================
--- §7. RSAConfig
+-- §7b. Exact-ℚ model and PMF face (local pending the RSA API pass)
 -- ============================================================================
 
-/-- RSA model parameterized by QUD. The paper's final model uses QUD_now with
-    CommonGround prior.
+/-! The model computed in exact rational arithmetic (the project's RSA
+convention): α = 6 is a natural power, so every layer — literal listener,
+QUD aggregation (eq. 5), speaker (eq. 6), listener scores (eq. 7) — is a
+rational function of the priors. The PMF face below normalizes these scores;
+its values bridge to the ℚ layer by `ENNReal.ofReal_sum_of_nonneg`. -/
 
-    - L0: meaning = compatibility ∧ literal truth (eq. 5)
-    - S1: utterancePrior × rpow(qudAggregate(L0), α) (eq. 6)
-    - L1: worldPrior × contextPrior × S1 (eq. 7) -/
-noncomputable def cfg (qud : QUD) : RSA.RSAConfig Utterance WorldState where
-  Latent := ContextSet
-  meaning _ cs u w :=
-    if compatibleBool cs w && literalMeaning u w then (1 : ℝ) else 0
-  meaning_nonneg _ _ _ _ := by split <;> norm_num
-  s1Score l0 α cs w u :=
-    (utterancePrior u : ℝ) * rpow (qudAggregate qud (l0 u) w) α
-  s1Score_nonneg _ _ _ _ u hl _ :=
-    mul_nonneg (Rat.cast_nonneg.mpr (utterancePrior_nonneg u))
-      (rpow_nonneg (qudAggregate_nonneg (fun w' => hl u w')) _)
-  α := 6
-  α_pos := by positivity
-  worldPrior _ := 1
-  worldPrior_nonneg _ := by norm_num
-  latentPrior _ cs := (contextPrior cs : ℝ)
-  latentPrior_nonneg _ cs := Rat.cast_nonneg.mpr (le_of_lt (contextPrior_pos cs))
+section QModel
 
-/-- Final model: CommonGround prior + QUD_now (paper's main prediction). -/
-noncomputable abbrev cfgNow := cfg .now
+/-- Literal-listener mass: worlds compatible with the context set where `u`
+is literally true (eq. 5's normaliser; uniform world prior cancels). -/
+def l0MassQ (cs : ContextSet) (u : Utterance) : ℚ :=
+  ∑ w, (if compatibleBool cs w && literalMeaning u w then (1 : ℚ) else 0)
 
-/-- Comparison model: CommonGround prior + QUD_max. -/
-noncomputable abbrev cfgMax := cfg .max
+/-- Literal listener value (division by zero yields 0 at empty extensions). -/
+def l0Q (cs : ContextSet) (u : Utterance) (w : WorldState) : ℚ :=
+  (if compatibleBool cs w && literalMeaning u w then (1 : ℚ) else 0) / l0MassQ cs u
 
-/-- Comparison model: CommonGround prior + QUD_past. -/
-noncomputable abbrev cfgPast := cfg .past
+/-- QUD aggregation of the literal listener (eq. 5): sum over the QUD cell. -/
+def qAggQ (qud : QUD) (cs : ContextSet) (u : Utterance) : WorldState → ℚ
+  | .wTT => match qud with
+    | .now => l0Q cs u .wTT + l0Q cs u .wFT
+    | .max => l0Q cs u .wTT
+    | .past => l0Q cs u .wTT + l0Q cs u .wTF
+  | .wTF => match qud with
+    | .now => l0Q cs u .wTF + l0Q cs u .wFF
+    | .max => l0Q cs u .wTF
+    | .past => l0Q cs u .wTT + l0Q cs u .wTF
+  | .wFT => match qud with
+    | .now => l0Q cs u .wTT + l0Q cs u .wFT
+    | .max => l0Q cs u .wFT
+    | .past => l0Q cs u .wFT + l0Q cs u .wFF
+  | .wFF => match qud with
+    | .now => l0Q cs u .wTF + l0Q cs u .wFF
+    | .max => l0Q cs u .wFF
+    | .past => l0Q cs u .wFT + l0Q cs u .wFF
+
+/-- Speaker weight (eq. 6 at α = 6): `Pr(u) · qAgg⁶`. -/
+def s1WeightQ (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) : ℚ :=
+  utterancePrior u * (qAggQ qud cs u w) ^ 6
+
+/-- Speaker normaliser. -/
+def s1ZQ (qud : QUD) (cs : ContextSet) (w : WorldState) : ℚ :=
+  ∑ u, s1WeightQ qud cs w u
+
+/-- Normalized speaker value. -/
+def s1ValQ (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) : ℚ :=
+  s1WeightQ qud cs w u / s1ZQ qud cs w
+
+/-- Listener world score (eq. 7, world side): context-prior-weighted speaker
+mass, before normalization. -/
+def worldScoreQ (qud : QUD) (u : Utterance) (w : WorldState) : ℚ :=
+  ∑ cs, contextPrior cs * s1ValQ qud cs w u
+
+/-- Listener context score (eq. 7, context side). -/
+def ctxScoreQ (qud : QUD) (u : Utterance) (cs : ContextSet) : ℚ :=
+  contextPrior cs * ∑ w, s1ValQ qud cs w u
+
+theorem l0MassQ_nonneg (cs : ContextSet) (u : Utterance) : 0 ≤ l0MassQ cs u :=
+  Finset.sum_nonneg fun _ _ => by split <;> norm_num
+
+theorem l0Q_nonneg (cs : ContextSet) (u : Utterance) (w : WorldState) :
+    0 ≤ l0Q cs u w :=
+  div_nonneg (by split <;> norm_num) (l0MassQ_nonneg cs u)
+
+theorem qAggQ_nonneg (qud : QUD) (cs : ContextSet) (u : Utterance) (w : WorldState) :
+    0 ≤ qAggQ qud cs u w := by
+  cases w <;> cases qud <;>
+    simp only [qAggQ] <;>
+    first
+      | exact l0Q_nonneg cs u _
+      | exact add_nonneg (l0Q_nonneg cs u _) (l0Q_nonneg cs u _)
+
+theorem s1WeightQ_nonneg (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) :
+    0 ≤ s1WeightQ qud cs w u :=
+  mul_nonneg (utterancePrior_nonneg u) (pow_nonneg (qAggQ_nonneg qud cs u w) 6)
+
+theorem s1ZQ_nonneg (qud : QUD) (cs : ContextSet) (w : WorldState) :
+    0 ≤ s1ZQ qud cs w :=
+  Finset.sum_nonneg fun u _ => s1WeightQ_nonneg qud cs w u
+
+theorem s1ValQ_nonneg (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) :
+    0 ≤ s1ValQ qud cs w u :=
+  div_nonneg (s1WeightQ_nonneg qud cs w u) (s1ZQ_nonneg qud cs w)
+
+theorem worldScoreQ_nonneg (qud : QUD) (u : Utterance) (w : WorldState) :
+    0 ≤ worldScoreQ qud u w :=
+  Finset.sum_nonneg fun cs _ =>
+    mul_nonneg (le_of_lt (contextPrior_pos cs)) (s1ValQ_nonneg qud cs w u)
+
+theorem ctxScoreQ_nonneg (qud : QUD) (u : Utterance) (cs : ContextSet) :
+    0 ≤ ctxScoreQ qud u cs :=
+  mul_nonneg (le_of_lt (contextPrior_pos cs))
+    (Finset.sum_nonneg fun w _ => s1ValQ_nonneg qud cs w u)
+
+end QModel
+
+section PMFFace
+
+open scoped ENNReal
+
+/-- PMF speaker (eq. 6), total via dite (pure-silence fallback at cells with
+no compatible utterance). -/
+noncomputable def s1PMF (qud : QUD) (cs : ContextSet) (w : WorldState) : PMF Utterance :=
+  if h : (∑' u, ENNReal.ofReal ((s1WeightQ qud cs w u : ℝ))) ≠ 0 then
+    PMF.normalize (fun u => ENNReal.ofReal ((s1WeightQ qud cs w u : ℝ))) h
+      (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+  else PMF.pure .silence
+
+private theorem sumW_eq (qud : QUD) (cs : ContextSet) (w : WorldState) :
+    (∑' u, ENNReal.ofReal ((s1WeightQ qud cs w u : ℝ)))
+      = ENNReal.ofReal ((s1ZQ qud cs w : ℝ)) := by
+  rw [tsum_fintype, ← ENNReal.ofReal_sum_of_nonneg
+    (fun u _ => by exact_mod_cast s1WeightQ_nonneg qud cs w u)]
+  congr 1
+  push_cast [s1ZQ]
+  rfl
+
+/-- The PMF speaker's values bridge exactly to the ℚ model (off `silence`,
+which absorbs the degenerate fallback). -/
+theorem s1PMF_apply (qud : QUD) (cs : ContextSet) (w : WorldState)
+    {u : Utterance} (hu : u ≠ .silence) :
+    s1PMF qud cs w u = ENNReal.ofReal ((s1ValQ qud cs w u : ℝ)) := by
+  unfold s1PMF
+  by_cases hZ : (0 : ℚ) < s1ZQ qud cs w
+  · rw [dif_pos (by rw [sumW_eq, ENNReal.ofReal_ne_zero_iff]; exact_mod_cast hZ),
+      PMF.normalize_apply, sumW_eq,
+      ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hZ),
+      ← ENNReal.ofReal_mul (by exact_mod_cast s1WeightQ_nonneg qud cs w u)]
+    congr 1
+    push_cast [s1ValQ]
+    rw [div_eq_mul_inv]
+  · have hZ0 : s1ZQ qud cs w = 0 := le_antisymm (not_lt.mp hZ) (s1ZQ_nonneg _ _ _)
+    rw [dif_neg (by rw [sumW_eq, hZ0]; simp),
+      show s1ValQ qud cs w u = 0 from by rw [s1ValQ, hZ0, div_zero]]
+    simp [PMF.pure_apply, hu]
+
+/-- World score of the pragmatic listener in PMF terms. -/
+noncomputable def wScore (qud : QUD) (u : Utterance) (w : WorldState) : ℝ≥0∞ :=
+  ∑' cs, ENNReal.ofReal ((contextPrior cs : ℝ)) * s1PMF qud cs w u
+
+theorem wScore_eq (qud : QUD) {u : Utterance} (hu : u ≠ .silence) (w : WorldState) :
+    wScore qud u w = ENNReal.ofReal ((worldScoreQ qud u w : ℝ)) := by
+  unfold wScore
+  rw [tsum_fintype,
+    Finset.sum_congr rfl (fun cs _ => by
+      rw [s1PMF_apply qud cs w hu,
+        ← ENNReal.ofReal_mul (by exact_mod_cast le_of_lt (contextPrior_pos cs))]),
+    ← ENNReal.ofReal_sum_of_nonneg (fun cs _ => by
+      exact_mod_cast mul_nonneg (le_of_lt (contextPrior_pos cs))
+        (s1ValQ_nonneg qud cs w u))]
+  congr 1
+  push_cast [worldScoreQ]
+  rfl
+
+/-- Context score of the pragmatic listener in PMF terms. -/
+noncomputable def cScore (qud : QUD) (u : Utterance) (cs : ContextSet) : ℝ≥0∞ :=
+  ENNReal.ofReal ((contextPrior cs : ℝ)) * ∑' w, s1PMF qud cs w u
+
+theorem cScore_eq (qud : QUD) {u : Utterance} (hu : u ≠ .silence) (cs : ContextSet) :
+    cScore qud u cs = ENNReal.ofReal ((ctxScoreQ qud u cs : ℝ)) := by
+  unfold cScore
+  rw [tsum_fintype,
+    Finset.sum_congr rfl (fun w _ => s1PMF_apply qud cs w hu),
+    ← ENNReal.ofReal_sum_of_nonneg (fun w _ => by
+      exact_mod_cast s1ValQ_nonneg qud cs w u),
+    ← ENNReal.ofReal_mul (by exact_mod_cast le_of_lt (contextPrior_pos cs))]
+  congr 1
+  push_cast [ctxScoreQ]
+  rfl
+
+/-- World-side pragmatic listener (eq. 7), dite-total. -/
+noncomputable def l1World (qud : QUD) (u : Utterance) : PMF WorldState :=
+  if h : (∑' w, wScore qud u w) ≠ 0 then
+    PMF.normalize (wScore qud u) h
+      (ENNReal.tsum_ne_top_of_fintype fun _ =>
+        ENNReal.tsum_ne_top_of_fintype fun _ =>
+          ENNReal.mul_ne_top ENNReal.ofReal_ne_top (PMF.apply_ne_top _ _))
+  else PMF.uniformOfFintype WorldState
+
+/-- Context-side pragmatic listener (eq. 7), dite-total. -/
+noncomputable def l1Ctx (qud : QUD) (u : Utterance) : PMF ContextSet :=
+  if h : (∑' cs, cScore qud u cs) ≠ 0 then
+    PMF.normalize (cScore qud u) h
+      (ENNReal.tsum_ne_top_of_fintype fun _ =>
+        ENNReal.mul_ne_top ENNReal.ofReal_ne_top
+          (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _))
+  else PMF.uniformOfFintype ContextSet
+
+end PMFFace
+
+section PMFFace
+
+open scoped ENNReal
+
+private theorem sumWorlds4 (f : WorldState → ℝ≥0∞) :
+    ∑' w, f w = f .wTT + f .wTF + f .wFT + f .wFF := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset WorldState) = {.wTT, .wTF, .wFT, .wFF} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
+
+private theorem wZ_fin (qud : QUD) (u : Utterance) :
+    (∑' w, wScore qud u w) ≠ ⊤ :=
+  ENNReal.tsum_ne_top_of_fintype fun _ =>
+    ENNReal.tsum_ne_top_of_fintype fun _ =>
+      ENNReal.mul_ne_top ENNReal.ofReal_ne_top (PMF.apply_ne_top _ _)
+
+private theorem wZ_pos_now_ns : (∑' w, wScore .now .notStoppedSmoking w) ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.wTT, by
+    rw [wScore_eq .now (by decide) _, ENNReal.ofReal_ne_zero_iff]
+    exact_mod_cast
+      (by decide +kernel : (0:ℚ) < worldScoreQ .now .notStoppedSmoking .wTT)⟩
+
+private theorem wZ_pos_max_ns : (∑' w, wScore .max .notStoppedSmoking w) ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.wTT, by
+    rw [wScore_eq .max (by decide) _, ENNReal.ofReal_ne_zero_iff]
+    exact_mod_cast
+      (by decide +kernel : (0:ℚ) < worldScoreQ .max .notStoppedSmoking .wTT)⟩
+
+private theorem wZ_pos_now_st : (∑' w, wScore .now .stoppedSmoking w) ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.wTF, by
+    rw [wScore_eq .now (by decide) _, ENNReal.ofReal_ne_zero_iff]
+    exact_mod_cast
+      (by decide +kernel : (0:ℚ) < worldScoreQ .now .stoppedSmoking .wTF)⟩
+
+private theorem cZ_pos_now_ns : (∑' cs, cScore .now .notStoppedSmoking cs) ≠ 0 :=
+  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.pastTrue, by
+    rw [cScore_eq .now (by decide) _, ENNReal.ofReal_ne_zero_iff]
+    exact_mod_cast
+      (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue)⟩
+
+/-- Score comparison under a shared normaliser: the workhorse for every
+strict listener prediction below. -/
+private theorem ofReal_mul_inv_lt {Z : ℝ≥0∞} (hZ0 : Z ≠ 0) (hZt : Z ≠ ⊤)
+    {a b : ℝ} (hb : 0 < b) (hab : a < b) :
+    ENNReal.ofReal a * Z⁻¹ < ENNReal.ofReal b * Z⁻¹ := by
+  rw [mul_comm, mul_comm (ENNReal.ofReal b)]
+  exact ENNReal.mul_lt_mul_right (ENNReal.inv_ne_zero.mpr hZt)
+    (ENNReal.inv_ne_top.mpr hZ0) ((ENNReal.ofReal_lt_ofReal_iff hb).mpr hab)
+
+/-- Listener world values in ℚ-bridged form. -/
+private theorem l1World_apply (qud : QUD) {u : Utterance} (hu : u ≠ .silence)
+    (hpos : (∑' w, wScore qud u w) ≠ 0) (w : WorldState) :
+    l1World qud u w
+      = ENNReal.ofReal ((worldScoreQ qud u w : ℝ)) * (∑' w', wScore qud u w')⁻¹ := by
+  unfold l1World
+  rw [dif_pos hpos, PMF.normalize_apply, wScore_eq qud hu w]
+
+/-- Event marginal of the world-side listener. -/
+noncomputable def l1WorldEvent (qud : QUD) (u : Utterance)
+    (P : WorldState → Prop) [DecidablePred P] : ℝ≥0∞ :=
+  ∑' w, if P w then l1World qud u w else 0
+
+private theorem cZ_fin (qud : QUD) (u : Utterance) :
+    (∑' cs, cScore qud u cs) ≠ ⊤ :=
+  ENNReal.tsum_ne_top_of_fintype fun _ =>
+    ENNReal.mul_ne_top ENNReal.ofReal_ne_top
+      (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _)
+
+/-- Listener context values in ℚ-bridged form. -/
+private theorem l1Ctx_apply (qud : QUD) {u : Utterance} (hu : u ≠ .silence)
+    (hpos : (∑' cs, cScore qud u cs) ≠ 0) (cs : ContextSet) :
+    l1Ctx qud u cs
+      = ENNReal.ofReal ((ctxScoreQ qud u cs : ℝ)) * (∑' cs', cScore qud u cs')⁻¹ := by
+  unfold l1Ctx
+  rw [dif_pos hpos, PMF.normalize_apply, cScore_eq qud hu cs]
+
+end PMFFace
 
 -- ============================================================================
 -- §8. L1 Predictions
@@ -293,33 +517,48 @@ noncomputable abbrev cfgPast := cfg .past
 
 /-! ### §8.1 QUD_now symmetry
 
-Under QUD_now, `qudAggregate` maps wTT and wFT to the same value (both
+Under QUD_now, the QUD aggregation maps wTT and wFT to the same value (both
 have now=T), so S1(cs, wTT, u) = S1(cs, wFT, u) for all cs. With uniform
 worldPrior and w-independent latentPrior, L1(wTT) = L1(wFT). This means
 presupposition projection **cannot** be measured by world marginal under
 QUD_now — the past dimension is invisible to L1. -/
 
-set_option maxHeartbeats 3200000 in
 /-- **QUD_now symmetry**: wTT and wFT are indistinguishable.
 
     This is the structural reason why projection under QUD_now must be
-    measured via context set inference (L1_latent), not world marginal. -/
+    measured via context set inference (the `l1Ctx` side), not the world
+    marginal — `qAggQ .now` is definitionally symmetric in the now-cell. -/
 theorem qud_now_wTT_eq_wFT :
-    cfgNow.L1 .notStoppedSmoking .wTT =
-    cfgNow.L1 .notStoppedSmoking .wFT := by
-  rsa_predict
+    l1World .now .notStoppedSmoking .wTT =
+    l1World .now .notStoppedSmoking .wFT := by
+  rw [l1World_apply .now (by decide) wZ_pos_now_ns,
+    l1World_apply .now (by decide) wZ_pos_now_ns]
+  congr 2
 
 /-! ### §8.2 QUD answer
 
 After hearing "didn't stop smoking" with QUD = "Does John smoke now?",
 L1 correctly infers the QUD answer: John smokes (now=T). -/
 
-set_option maxHeartbeats 3200000 in
 /-- **QUD answer inference**: L1 infers now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
-    cfgNow.L1_marginal .notStoppedSmoking (fun w => w.now = true) >
-    cfgNow.L1_marginal .notStoppedSmoking (fun w => w.now = false) := by
-  rsa_predict
+    l1WorldEvent .now .notStoppedSmoking (fun w => w.now = true) >
+    l1WorldEvent .now .notStoppedSmoking (fun w => w.now = false) := by
+  unfold l1WorldEvent
+  rw [gt_iff_lt, sumWorlds4, sumWorlds4]
+  simp +decide only [if_true, if_false, add_zero, zero_add]
+  simp only [l1World_apply .now (by decide) wZ_pos_now_ns]
+  rw [← add_mul, ← add_mul,
+    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _)
+      (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _),
+    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _)
+      (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _)]
+  exact ofReal_mul_inv_lt wZ_pos_now_ns (wZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) <
+      worldScoreQ .now .notStoppedSmoking .wTT + worldScoreQ .now .notStoppedSmoking .wFT))
+    (by exact_mod_cast (by decide +kernel :
+      worldScoreQ .now .notStoppedSmoking .wTF + worldScoreQ .now .notStoppedSmoking .wFF <
+      worldScoreQ .now .notStoppedSmoking .wTT + worldScoreQ .now .notStoppedSmoking .wFT))
 
 /-! ### §8.3 World elimination
 
@@ -327,12 +566,15 @@ Within worlds sharing the same past value, now=T dominates now=F.
 "Didn't stop smoking" is literally false at wTF (past=T, now=F is exactly
 "stopped smoking"), concentrating L1 mass on wTT. -/
 
-set_option maxHeartbeats 3200000 in
 /-- **Now=T dominates now=F** among past=T worlds. -/
 theorem wTT_gt_wTF :
-    cfgNow.L1 .notStoppedSmoking .wTT >
-    cfgNow.L1 .notStoppedSmoking .wTF := by
-  rsa_predict
+    l1World .now .notStoppedSmoking .wTT >
+    l1World .now .notStoppedSmoking .wTF := by
+  rw [gt_iff_lt, l1World_apply .now (by decide) wZ_pos_now_ns, l1World_apply .now (by decide) wZ_pos_now_ns]
+  exact ofReal_mul_inv_lt wZ_pos_now_ns (wZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) < worldScoreQ .now .notStoppedSmoking .wTT))
+    (by exact_mod_cast (by decide +kernel :
+      worldScoreQ .now .notStoppedSmoking .wTF < worldScoreQ .now .notStoppedSmoking .wTT))
 
 /-! ### §8.4 Projection under QUD_max (Figure 1c)
 
@@ -347,23 +589,31 @@ The paper observes that (T,T) = (F,F) under QUD_max (Figure 1c), so projection
 is incomplete — the past=T marginal still equals the past=F marginal. Full
 projection requires QUD_now + context set inference (§8.5). -/
 
-set_option maxHeartbeats 3200000 in
 /-- **Projection under QUD_max**: wTT > wFT. -/
 theorem projection_under_qud_max :
-    cfgMax.L1 .notStoppedSmoking .wTT >
-    cfgMax.L1 .notStoppedSmoking .wFT := by
-  rsa_predict
+    l1World .max .notStoppedSmoking .wTT >
+    l1World .max .notStoppedSmoking .wFT := by
+  rw [gt_iff_lt, l1World_apply .max (by decide) wZ_pos_max_ns, l1World_apply .max (by decide) wZ_pos_max_ns]
+  exact ofReal_mul_inv_lt wZ_pos_max_ns (wZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) < worldScoreQ .max .notStoppedSmoking .wTT))
+    (by exact_mod_cast (by decide +kernel :
+      worldScoreQ .max .notStoppedSmoking .wFT < worldScoreQ .max .notStoppedSmoking .wTT))
 
-set_option maxHeartbeats 3200000 in
 /-- **Incomplete projection under QUD_max**: wTT = wFF (Figure 1c).
 
-    Under the identity QUD, (T,T) and (F,F) receive equal L1 probability.
-    This means the past=T marginal equals the past=F marginal — projection
+    Under the identity QUD, (T,T) and (F,F) receive equal L1 probability —
+    the involution swapping (past, now) ↦ (¬now, ¬past) fixes the meaning of
+    "didn't stop" and permutes the context sets prior-preservingly. Projection
     is NOT captured at the world level under QUD_max. -/
 theorem qud_max_incomplete_projection :
-    cfgMax.L1 .notStoppedSmoking .wTT =
-    cfgMax.L1 .notStoppedSmoking .wFF := by
-  rsa_predict
+    l1World .max .notStoppedSmoking .wTT =
+    l1World .max .notStoppedSmoking .wFF := by
+  rw [l1World_apply .max (by decide) wZ_pos_max_ns,
+    l1World_apply .max (by decide) wZ_pos_max_ns]
+  congr 2
+  exact_mod_cast (by decide +kernel :
+    worldScoreQ .max .notStoppedSmoking .wTT
+      = worldScoreQ .max .notStoppedSmoking .wFF)
 
 /-! ### §8.5 Context set projection (the paper's main result, Figure 3)
 
@@ -374,54 +624,76 @@ enters the listener's beliefs about the common ground, even though the utterance
 literally says nothing about the past.
 
 The mechanism: under +past context, "didn't stop" narrows L0 to exactly wTT,
-giving qudAggregate = 1 and rpow(1, 6) = 1 (maximally informative). Under
--past context, L0 spreads over wFT and wFF, giving qudAggregate = 1/2 and
-rpow(1/2, 6) = 1/64 (weakly informative). Since S1 rewards informativity,
+giving aggregate 1 and `1⁶ = 1` (maximally informative). Under
+-past context, L0 spreads over wFT and wFF, giving aggregate `1/2` and
+`(1/2)⁶ = 1/64` (weakly informative). Since S1 rewards informativity,
 the speaker is much more likely to use "didn't stop" when the +past context
 holds, and L1 infers this.
 
 Figure 3 shows that (T,T) with context set +past is the unique maximum of the
 joint distribution under CommonGround prior + QUD_now. -/
 
-set_option maxHeartbeats 3200000 in
 /-- **Context set projection**: L1 infers +past context over -past context. -/
 theorem context_projection :
-    cfgNow.L1_latent .notStoppedSmoking .pastTrue >
-    cfgNow.L1_latent .notStoppedSmoking .pastFalse := by
-  rsa_predict
+    l1Ctx .now .notStoppedSmoking .pastTrue >
+    l1Ctx .now .notStoppedSmoking .pastFalse := by
+  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns, l1Ctx_apply .now (by decide) cZ_pos_now_ns]
+  exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
+    (by exact_mod_cast (by decide +kernel :
+      ctxScoreQ .now .notStoppedSmoking .pastFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
-set_option maxHeartbeats 3200000 in
 /-- **+past beats uninformative universe** despite lower prior (9 vs 6).
 
-    Under +past, "didn't stop" narrows to exactly wTT (rpow(1,6) = 1).
-    Under universe, it spreads over 3 worlds (rpow(1/4,6) ≈ 0). The
+    Under +past, "didn't stop" narrows to exactly wTT (`1⁶ = 1`).
+    Under universe, it spreads over 3 worlds (`(1/4)⁶ ≈ 0`). The
     informativity gain overwhelms the prior advantage. -/
 theorem context_projection_over_universe :
-    cfgNow.L1_latent .notStoppedSmoking .pastTrue >
-    cfgNow.L1_latent .notStoppedSmoking .universe := by
-  rsa_predict
+    l1Ctx .now .notStoppedSmoking .pastTrue >
+    l1Ctx .now .notStoppedSmoking .universe := by
+  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns, l1Ctx_apply .now (by decide) cZ_pos_now_ns]
+  exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
+    (by exact_mod_cast (by decide +kernel :
+      ctxScoreQ .now .notStoppedSmoking .universe < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
-set_option maxHeartbeats 3200000 in
 /-- **-now context is dispreferred** (p. 1114): -now already entails the QUD
     answer (John doesn't smoke now), so the speaker would be maximally
     informative even saying nothing — "didn't stop smoking" adds no value.
     L1 therefore infers the speaker did NOT assume a -now context. -/
 theorem now_context_dispreferred :
-    cfgNow.L1_latent .notStoppedSmoking .pastTrue >
-    cfgNow.L1_latent .notStoppedSmoking .nowFalse := by
-  rsa_predict
+    l1Ctx .now .notStoppedSmoking .pastTrue >
+    l1Ctx .now .notStoppedSmoking .nowFalse := by
+  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns, l1Ctx_apply .now (by decide) cZ_pos_now_ns]
+  exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
+    (by exact_mod_cast (by decide +kernel :
+      ctxScoreQ .now .notStoppedSmoking .nowFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
 /-! ### §8.6 "Stopped smoking" projects past=T via QUD answer
 
 "Stopped smoking" is true only at wTF (past=T, now=F). Under QUD_now,
 L1 infers the QUD answer is now=F. -/
 
-set_option maxHeartbeats 3200000 in
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
-    cfgNow.L1_marginal .stoppedSmoking (fun w => w.now = false) >
-    cfgNow.L1_marginal .stoppedSmoking (fun w => w.now = true) := by
-  rsa_predict
+    l1WorldEvent .now .stoppedSmoking (fun w => w.now = false) >
+    l1WorldEvent .now .stoppedSmoking (fun w => w.now = true) := by
+  unfold l1WorldEvent
+  rw [gt_iff_lt, sumWorlds4, sumWorlds4]
+  simp +decide only [if_true, if_false, add_zero, zero_add]
+  simp only [l1World_apply .now (by decide) wZ_pos_now_st]
+  rw [← add_mul, ← add_mul,
+    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _)
+      (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _),
+    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _)
+      (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _)]
+  exact ofReal_mul_inv_lt wZ_pos_now_st (wZ_fin _ _)
+    (by exact_mod_cast (by decide +kernel : (0:ℚ) <
+      worldScoreQ .now .stoppedSmoking .wTF + worldScoreQ .now .stoppedSmoking .wFF))
+    (by exact_mod_cast (by decide +kernel :
+      worldScoreQ .now .stoppedSmoking .wTT + worldScoreQ .now .stoppedSmoking .wFT <
+      worldScoreQ .now .stoppedSmoking .wTF + worldScoreQ .now .stoppedSmoking .wFF))
 
 -- ============================================================================
 -- §9. Structural Properties
@@ -476,7 +748,7 @@ def entailsPast : ContextSet → Bool
 /-- 3 of 9 context sets entail past=T. -/
 theorem three_entail_past :
     (Finset.univ.filter (fun cs : ContextSet => entailsPast cs)).card = 3 := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- §10. Connection to S&T and Warstadt
@@ -497,9 +769,10 @@ L1(w, C | u, Q) ∝ S1(u | w, C, Q) · P(w) · P(C)
 | [scontras-tonhauser-2025] | Assumptions A | Speaker beliefs | Factives |
 | [warstadt-2022] | Context set C | Common ground | Genus-species |
 
-The RSAConfig encoding is structurally identical: `Latent` = context/belief
-state, `meaning` filters by compatibility, `s1Score` uses QUD-projected rpow.
-See `ScontrasTonhauser2025.lean` for the factive domain implementation.
+The encoding is structurally identical: the latent is the context/belief
+state, the literal listener filters by compatibility, and the speaker
+scores the QUD-projected literal posterior. See `ScontrasTonhauser2025.lean`
+for the factive domain implementation.
 
 [scontras-tonhauser-2025] fn. 10: "[qing-goodman-lassiter-2016] call these subsets
 the 'common ground,' but we think 'private assumptions' better captures

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -48,7 +48,7 @@ reaching the PMF face.
 namespace QingGoodmanLassiter2016
 
 open BigOperators
-/-! ### §1. World State -/
+/-! ### World states -/
 
 /-- World state: (past, now) where past = John smoked, now = John smokes.
     Flat inductive for tactic enumerability. -/
@@ -67,7 +67,7 @@ def WorldState.now : WorldState → Bool
   | .wTT | .wFT => true
   | .wTF | .wFF => false
 
-/-! ### §2. Utterances (Table 1 + negations + silence) -/
+/-! ### Utterances (Table 1, negations, silence) -/
 
 /-- Utterances about John's smoking habits.
     6 positive utterances from Table 1, their 6 negations, and silence. -/
@@ -87,7 +87,7 @@ inductive Utterance where
   | silence             -- null utterance          {(T,T),(T,F),(F,T),(F,F)}
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-! ### §3. Literal Semantics -/
+/-! ### Literal semantics -/
 
 /-- Literal truth conditions from Table 1. Negation of u is U - ⟦u⟧.
 
@@ -140,7 +140,7 @@ theorem always_matches_continuation (w : WorldState) :
   cases w <;> simp [literalMeaning, priorStatePresup, resultStateAssertion,
     WorldState.past, WorldState.now]
 
-/-! ### §4. Context Sets (Common Ground) -/
+/-! ### Context sets -/
 
 /-- Context sets: subsets of worlds representing common ground.
     These are the 9 context sets derivable from observations about past and now
@@ -170,7 +170,7 @@ def compatibleBool : ContextSet → WorldState → Bool
   | .pastFalseNowFalse, w => !w.past && !w.now
   | .universe,          _ => true
 
-/-! ### §5. QUD -/
+/-! ### QUD -/
 
 /-- Questions under discussion. -/
 inductive QUD where
@@ -179,7 +179,7 @@ inductive QUD where
   | past  -- "Did John smoke?" (partitions by past)
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-! ### §6. Priors -/
+/-! ### Priors -/
 
 /-- Utterance prior (eq. 1): Pr(u) ∝ 2^{-#content-words(u)}.
     Negation and auxiliaries excluded from count.
@@ -213,7 +213,7 @@ def contextPrior : ContextSet → ℚ
 theorem contextPrior_pos (cs : ContextSet) : 0 < contextPrior cs := by
   cases cs <;> simp [contextPrior]
 
-/-! ### §7b. Exact-ℚ model and PMF face (local pending the RSA API pass) -/
+/-! ### The exact-ℚ model and its PMF face (local pending the RSA API pass) -/
 
 section QModel
 
@@ -479,9 +479,9 @@ private theorem l1Ctx_apply (qud : QUD) {u : Utterance} (hu : u ≠ .silence)
 
 end PMFFace
 
-/-! ### §8. L1 Predictions -/
+/-! ### Listener predictions -/
 
-/-! ### §8.1 QUD_now symmetry -/
+/-! ### QUD_now symmetry -/
 
 /-- Under QUD_now, wTT and wFT are indistinguishable: `qAggQ .now` is
 definitionally symmetric in the now-cell, so projection must be measured on
@@ -493,7 +493,7 @@ theorem qud_now_wTT_eq_wFT :
     l1World_apply .now (by decide) wZ_pos_now_ns]
   congr 2
 
-/-! ### §8.2 QUD answer -/
+/-! ### QUD answer -/
 
 /-- L1 infers the QUD answer now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
@@ -515,7 +515,7 @@ theorem qud_answer_now_true :
       worldScoreQ .now .notStoppedSmoking .wTF + worldScoreQ .now .notStoppedSmoking .wFF <
       worldScoreQ .now .notStoppedSmoking .wTT + worldScoreQ .now .notStoppedSmoking .wFT))
 
-/-! ### §8.3 World elimination
+/-! ### World elimination
 
 "Didn't stop smoking" is literally false at wTF, concentrating L1 on wTT. -/
 
@@ -530,9 +530,9 @@ theorem wTT_gt_wTF :
     (by exact_mod_cast (by decide +kernel :
       worldScoreQ .now .notStoppedSmoking .wTF < worldScoreQ .now .notStoppedSmoking .wTT))
 
-/-! ### §8.4 Projection under QUD_max (Figure 1c)
+/-! ### Projection under QUD_max (Figure 1c)
 
-The identity QUD breaks §8.1's degeneracy — under +past, "didn't stop"
+The identity QUD breaks the QUD_now degeneracy — under +past, "didn't stop"
 narrows to exactly wTT — but projection stays incomplete: wTT = wFF, so
 the past marginals still coincide. -/
 
@@ -561,7 +561,7 @@ theorem qud_max_incomplete_projection :
     worldScoreQ .max .notStoppedSmoking .wTT
       = worldScoreQ .max .notStoppedSmoking .wFF)
 
-/-! ### §8.5 Context set projection (the paper's main result, Figure 3)
+/-! ### Context set projection (the paper's main result, Figure 3)
 
 Under +past, "didn't stop" narrows L0 to wTT (aggregate 1, `1⁶ = 1`); under
 −past it spreads (`(1/2)⁶ = 1/64`). S1 rewards informativity, so L1 infers
@@ -604,7 +604,7 @@ theorem now_context_dispreferred :
     (by exact_mod_cast (by decide +kernel :
       ctxScoreQ .now .notStoppedSmoking .nowFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
 
-/-! ### §8.6 "Stopped smoking" -/
+/-! ### "Stopped smoking" -/
 
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
@@ -626,7 +626,7 @@ theorem stopped_qud_answer :
       worldScoreQ .now .stoppedSmoking .wTT + worldScoreQ .now .stoppedSmoking .wFT <
       worldScoreQ .now .stoppedSmoking .wTF + worldScoreQ .now .stoppedSmoking .wFF))
 
-/-! ### §9. Structural Properties -/
+/-! ### Structural properties -/
 
 /-- "didn't stop smoking" is compatible with 3 of 4 worlds. -/
 theorem notStopped_compatible_worlds :


### PR DESCRIPTION
Four files re-founded on the mathlib-PMF face (16/22 done):

- Anderson2021: CG-parameterized chain; ~31 goals as exact-rational value lemmas and posterior score-iffs; conversationStep rebuilt as guarded posterior + updateCG.
- QingFranke2015: belief/action speaker split; salience reversals generic in the cost factor; three exp bounds from exp_one_lt_d9/gt_d9.
- BarnettEtAl2022: persuasive speaker over the paper's L0² scores; the weak evidence effect as an exact event-marginal comparison with the Z-gap mechanism documented.
- QingGoodmanLassiter2016: the full QUD-projection model in exact ℚ (α = 6 is a natural power), PMF listeners bridged by ofReal_sum_of_nonneg, all 11 predictions kernel-verified (decide +kernel); the QUD_now symmetry holds definitionally. Dead imports trimmed (−407 modules from the cone).

Deletes all four RSAConfig apparatuses and RSAPredict imports; all native_decides converted.