### PR TITLE
refactor(Studies): retire rsa_predict in ScontrasTonhauser2025 + PottsLevy2015

### DIFF
--- a/Linglib/Studies/PottsLevy2015.lean
+++ b/Linglib/Studies/PottsLevy2015.lean
@@ -476,23 +476,9 @@ theorem AorX_signals_excl_vs_A :
 
 /-! ### The stacked expertise model (eq. 15) -/
 
-/-! The paper's distinctive contribution is the **expertise parameter β**
-in the S₂ speaker utility (eq 15):
-
-  `S₂(m|w,L) ∝ l₁(w|m,L)^α · L₁(L|m)^β · exp(-C(m))`
-
-The expertise speaker simultaneously signals world knowledge (informativity
-via l₁) and lexicon knowledge (expertise via L₁). We implement this as a
-**stacked RSAConfig**: the base config's per-lexicon listener l₁ becomes
-the upper level's L0 meaning, with the expertise bonus `L₁(L|m)` and
-disjunction cost `exp(-C(m))` entering via `stack`'s `bonus` and
-`costFactor` parameters.
-
-Since `exp(-1) ∉ ℚ`, the cost penalty is approximated as `37/100 ≈ 0.37`
-(close to `exp(-1) ≈ 0.368`). Qualitative predictions are robust to the
-exact value (paper Section 5.4). -/
-
--- ---- L₂ World Predictions ----
+/-! Eq. 15, `S₂(m|w,L) ∝ l₁(w|m,L)^α · L₁(L|m)^β · exp(−C(m))`, at
+Figure 10's regime α = 2, β = 1, C(or) = 1: `s2WQ` scores the per-lexicon
+listener squared, times the lexicon posterior, times `disjCostQ`. -/
 
 /-- L₂ hearing "A or X": uncertainty state w₁₂ dominates w₁. -/
 theorem L2_AorX_w12_vs_w1 :
@@ -509,7 +495,7 @@ theorem L2_AorX_w1_vs_w2 :
     l2PMF .AorX .w₂ < l2PMF .AorX .w₁ :=
   pmf_lt (l2ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
--- ---- L₂ Lexicon Predictions ----
+
 
 /-- L₂ lexicon inference: excl dominates base for "A or X". -/
 theorem L2_AorX_excl_vs_base :
@@ -526,7 +512,7 @@ theorem L2_AorX_base_vs_syn :
     l2LatPMF .AorX .syn < l2LatPMF .AorX .base :=
   pmf_lt (l2LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
--- ---- S₂ Expertise Speaker Predictions ----
+
 
 /-- S₂ at w₁₂ prefers "A or X" over "A" (marginalized over lexica). -/
 theorem S2_expertise_w12_AorX_vs_A :

--- a/Linglib/Studies/PottsLevy2015.lean
+++ b/Linglib/Studies/PottsLevy2015.lean
@@ -1,110 +1,61 @@
-import Linglib.Tactics.RSAPredict
+import Linglib.Pragmatics.RSA.LatentOperators
+import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.RSA.Basic
 import Linglib.Semantics.Exhaustification.Operators.Basic
 
 /-!
-# [potts-levy-2015]: Negotiating Lexical Uncertainty and Speaker Expertise with Disjunction
-[potts-levy-2015]
+# [potts-levy-2015]: lexical uncertainty and speaker expertise with disjunction
 
-"Negotiating Lexical Uncertainty and Speaker Expertise with Disjunction."
-Proceedings of the 41st Annual Meeting of the Berkeley Linguistics Society, 417–445.
+Hurford-violating disjunctions ("X or A" with A ⊆ ⟦X⟧) are felicitous and
+carry ignorance implicatures. The paper derives both from RSA with lexical
+uncertainty (BLS 41, pp. 417–445): the listener jointly infers the world and
+the speaker's lexicon (eq. 14), and an expertise speaker (eq. 15) signals
+both world knowledge (α term) and lexicon knowledge (β term). Domain: 5
+utterances × 3 states (w₁, w₂, and the uncertainty join w₁₂, where truth
+requires truth at both atoms) × 3 lexica for X (`base` = A ∪ B, `excl` = B,
+`syn` = A).
 
-## The Puzzle
+## Main results
 
-Hurford-violating disjunctions like "X or A" (where A ⊆ X semantically) are
-predicted to be redundant, yet they are felicitous and carry **ignorance
-implicatures**: the listener infers that the speaker is uncertain which
-disjunct holds.
+* `uncertainty_w12_vs_w1` / `_w2` / `w1_vs_w2`: hearing "A or X", the joint
+  listener infers speaker uncertainty — w₁₂ > w₁ > w₂ (Figure 10 world
+  margins: .91 > .09 > 0).
+* `lexicon_excl_vs_base` / `_syn`: the exclusivized lexicon dominates —
+  excl > base > syn (Figure 10 lexicon margins: .49 > .34 > .17).
+* `s1_w12_AorX_vs_A` / `_X`, `s1_w1_A_vs_AorX`: the eq. 11 speaker uses the
+  disjunction exactly when uncertain.
+* `L2_AorX_*` / `S2_expertise_*`: the same orderings at the stacked
+  expertise level (eq. 15, Figure 10's regime α = 2, β = 1, C(or) = 1;
+  p. 436: "S₂'s preferred message given observed state w₁∨w₂ and lexicon
+  L₁ from Figure 10 is A or X").
+* `excl_is_base_minus_A`: the `excl` lexicon is exhaustification —
+  excl(X) = base(X) ∧ ¬A.
+* `all_findings_verified`: the full qualitative inventory.
 
-[potts-levy-2015] show that an RSA model with **lexical uncertainty**
-derives this: L1 infers that the speaker might be using a lexicon under which
-the disjuncts are non-overlapping, and the disjunction signals the speaker's
-uncertainty about the world.
+## Implementation notes
 
-## The Model
+α = 2 and β = 1 are natural powers, so every agent in the tower — l₀, s₁,
+the joint L₁ (eq. 14; its per-lexicon normaliser cancels, giving scores
+P(w)·P(L)·s₁), the stacked l₁/S₂/L₂, and the eq. 17 speaker marginal — is
+an exact-ℚ score vector normalized by `pmfOfScores`. The disjunction cost
+`exp(−1)` is rationalized as `37/100` (qualitative predictions robust,
+paper §5.4). `s2PMF` is the endorsement reading of S₂ over the level-1
+listener (an informativity-component decomposition); `s2ExpPMF` is the
+paper's eq. 17 lexicon-marginalized expertise speaker.
 
-Three worlds:
-- `w₁`: only A-worlds (speaker knows A)
-- `w₂`: only B-worlds (speaker knows B, where B ⊆ X \ A)
-- `w₁₂`: both A- and B-worlds possible (speaker uncertain)
+The definitional regime (syn dominating, "wine lover or oenophile")
+requires β > α (paper §5.4) and is not modeled.
 
-Three lexica for X:
-- `base`: X = A ∪ B (unrefined, overlapping with A)
-- `excl`: X = B only (exhaustified, disjoint from A)
-- `syn`: X = A (synonymous with A)
+## TODO
 
-Five utterances: A, B, X, AorX, null.
-
-Key insight: under `syn`, "A or X" and "A" are equivalent (Hurford violation).
-Under `excl`, "A or X" partitions {w₁, w₂} cleanly. L1 marginalizes over
-lexica, and `excl` dominates for "A or X" — deriving the prediction that
-disjunction implies speaker uncertainty (w₁₂ > w₁ > w₂).
-
-## Join Closure
-
-The join state w₁₂ represents speaker uncertainty. Following the paper's
-convention, an utterance m is true at w₁₂ iff m is true at BOTH w₁ and w₂
-(the "must" reading: the speaker can assert m only if m holds across all
-worlds compatible with their knowledge).
-
-## Expertise Model (S2)
-
-The paper's key contribution is the **expertise parameter β**: a level-2
-speaker who cares not only about informativity (L1 inferring the correct
-world) but also about **lexicon signaling** (L1 inferring the correct
-lexicon). The S2 utility:
-
-    U_S2(m, w, L; β) = ln L₁(w|m) + β · ln L₁(L|m)
-
-When β > 0, the speaker has extra incentive to use utterances that signal
-the `excl` lexicon — precisely the Hurford-violating disjunction "A or X".
-Following the [yoon-etal-2020] pattern, we define S2 utility directly
-from L1 marginals and prove comparative predictions.
-
-## Verification Against Paper
-
-Our model operates in the **Hurfordian parameter regime** (α > β) with α = 2,
-β = 0, C = 0. The paper's Hurfordian worked example (Figure 10) uses α = 2,
-β = 1, C(or) = 1. All 10 qualitative predictions match the paper:
-
-- **L1 world inference** (§6): w₁₂ > w₁ > w₂ given "A or X"
-  (paper Figure 10 L2: .91 > .09 > 0)
-- **L1 lexicon inference** (§7): excl > base > syn given "A or X"
-  (paper Figure 10 L2: .49 > .34 > .17)
-- **S1 speaker** (§8): prefers AorX at w₁₂, prefers A at w₁ (under excl)
-  (paper Figure 7(b), p. 436)
-- **S2 endorsement** (§10): prefers AorX at w₁₂, A at w₁
-  (paper p. 436: "S₂'s preferred message given observed state w₁∨w₂
-  and lexicon L₁ is A or X")
-- **Lexicon signaling** (§10): AorX signals excl more than A
-  (paper Section 5.2)
-
-### Two Implementations
-
-1. **RSAConfig (§4–§10)**: L₁-level predictions via `rsa_predict`, zero costs,
-   structural correspondence with linglib's RSA infrastructure.
-2. **Full ℚ model (§12)**: L₂-level predictions via `native_decide`, with
-   the paper's Hurfordian parameters (α = 2, β = 1, C(or) ≈ 1).
-
-The paper's **definitional reading** (where syn dominates, e.g., "wine lover
-or oenophile") requires β > α (paper Section 5.4, Figures 13–14) and is
-not modeled here.
-
-## Connection to [potts-etal-2016]
-
-Both papers use lexical uncertainty (Latent := Lexicon). [potts-etal-2016]
-applies it to embedded scalar implicatures; this paper applies it to
-Hurford-violating disjunctions and speaker expertise. The mechanism is
-identical — only the domain and lexica differ.
+Model the definitional regime (β > α) and the implicature-blocking
+simulations of paper §5.3. Relate the lexica to
+`Semantics.Presupposition`-layer exhaustification operators.
 -/
-
-set_option autoImplicit false
 
 namespace PottsLevy2015
 
--- ============================================================================
--- §1. Domain Types
--- ============================================================================
+/-! ### Domain -/
 
 /-- World states. w₁ = only A-state, w₂ = only B-state,
     w₁₂ = speaker uncertain (both A and B possible). -/
@@ -125,9 +76,7 @@ inductive Lex where
   | base | excl | syn
   deriving DecidableEq, Repr, Inhabited, Fintype
 
--- ============================================================================
--- §2. Truth Conditions
--- ============================================================================
+/-! ### Truth conditions -/
 
 /-- Truth of atomic (non-disjunctive) utterances at atomic worlds. -/
 def atomicTruth : Lex → Utterance → World → Bool
@@ -159,9 +108,7 @@ def truth (l : Lex) (u : Utterance) (w : World) : Bool :=
   | .w₂ => base .w₂
   | .w₁₂ => base .w₁ && base .w₂
 
--- ============================================================================
--- §3. Exhaustification Grounding
--- ============================================================================
+/-! ### Exhaustification grounding -/
 
 /-! The `excl` lexicon is the exhaustified reading of X relative to
 alternatives {A, X}. We prove this structurally: at every atomic world,
@@ -172,56 +119,204 @@ when there are exactly two alternatives with A ⊂ X. -/
 theorem excl_is_base_minus_A :
     ∀ w, atomicTruth .excl .X w =
       (atomicTruth .base .X w && !atomicTruth .base .A w) := by
-  native_decide
+  decide
 
 /-- syn(X) = base(A): X narrowed to overlap with A. -/
 theorem syn_is_base_A :
     ∀ w, atomicTruth .syn .X w = atomicTruth .base .A w := by
-  native_decide
+  decide
 
 /-- Base X strictly entails excl X (excl is a proper refinement). -/
 theorem base_entails_excl :
     (∀ w, atomicTruth .excl .X w = true → atomicTruth .base .X w = true) ∧
     ∃ w, atomicTruth .base .X w = true ∧ atomicTruth .excl .X w = false := by
-  native_decide
+  decide
 
--- ============================================================================
--- §4. RSAConfig
--- ============================================================================
+/-! ### The exact-ℚ model and its PMF face (local pending the RSA API pass) -/
 
-open RSA Real in
-/-- [potts-levy-2015] lexical uncertainty model for Hurford disjunctions.
+/-! Every agent in the tower is a rational function of the truth table:
+α = 2 and β = 1 are natural powers and the cost factor is rational, so the
+scores are computed in exact ℚ (division by zero yields 0, matching the
+zero-normaliser convention of `Core.RationalAction.policy`). Listeners and
+speakers are `PMF.normalize` of these scores via `pmfOfScores`. -/
 
-    Latent variable = Lex (base vs excl vs syn).
-    L0: literal listener under lexicon l.
-    S1: belief-based scoring, rpow(L0(w|u), α).
-    L1: marginalizes over lexica with uniform prior.
+section QModel
 
-    α = 2 to sharpen speaker preferences. -/
-noncomputable def cfg : RSAConfig Utterance World where
-  Latent := Lex
-  meaning _ lex u w := if truth lex u w then 1 else 0
-  meaning_nonneg _ _ _ _ := by split <;> norm_num
-  s1Score l0 α _ w u := rpow (l0 u w) α
-  s1Score_nonneg _ _ _ _ _ hl0 _ := rpow_nonneg (hl0 _ _) _
-  α := 2
-  α_pos := two_pos
-  latentPrior_nonneg _ _ := by norm_num
-  worldPrior_nonneg _ := by norm_num
+/-- Literal listener (eq. 10, uniform world prior). -/
+def l0Q (l : Lex) (u : Utterance) (w : World) : ℚ :=
+  (if truth l u w then 1 else 0) /
+    (∑ w', if truth l u w' then (1 : ℚ) else 0)
 
--- ============================================================================
--- §5. Structural Properties
--- ============================================================================
+/-- Speaker weight (eq. 11 at α = 2, zero cost). -/
+def s1WQ (l : Lex) (w : World) (u : Utterance) : ℚ := (l0Q l u w) ^ 2
+
+/-- Normalized speaker (eq. 11). -/
+def s1Q (l : Lex) (w : World) (u : Utterance) : ℚ :=
+  s1WQ l w u / ∑ u', s1WQ l w u'
+
+/-- Joint listener world score (eq. 14/16, uniform priors). -/
+def l1ScoreQ (u : Utterance) (w : World) : ℚ := ∑ l, s1Q l w u
+
+/-- Normalized world posterior (eq. 16). -/
+def l1Q (u : Utterance) (w : World) : ℚ :=
+  l1ScoreQ u w / ∑ w', l1ScoreQ u w'
+
+/-- Lexicon score of the joint listener (eq. 14). -/
+def l1LatScoreQ (u : Utterance) (l : Lex) : ℚ := ∑ w, s1Q l w u
+
+/-- Normalized lexicon posterior (eq. 14). -/
+def l1LatQ (u : Utterance) (l : Lex) : ℚ :=
+  l1LatScoreQ u l / ∑ l', l1LatScoreQ u l'
+
+/-- Disjunction cost factor `exp(−C(m))` with C(or) = 1, rationalized as
+`37/100 ≈ exp(−1)` (qualitative predictions are robust, paper §5.4). -/
+def disjCostQ : Utterance → ℚ
+  | .AorX => 37/100
+  | _ => 1
+
+/-- Per-lexicon pragmatic listener (eq. 12), the stacked literal layer. -/
+def l02Q (l : Lex) (u : Utterance) (w : World) : ℚ :=
+  s1Q l w u / ∑ w', s1Q l w' u
+
+/-- Expertise speaker weight (eq. 15 at α = 2, β = 1):
+`l₁(w|m,L)² · L₁(L|m) · exp(−C(m))`. -/
+def s2WQ (l : Lex) (w : World) (u : Utterance) : ℚ :=
+  (l02Q l u w) ^ 2 * l1LatQ u l * disjCostQ u
+
+/-- Normalized expertise speaker (eq. 15). -/
+def s2Q (l : Lex) (w : World) (u : Utterance) : ℚ :=
+  s2WQ l w u / ∑ u', s2WQ l w u'
+
+/-- L₂ world score (eq. 14/16 at k = 2). -/
+def l2ScoreQ (u : Utterance) (w : World) : ℚ := ∑ l, s2Q l w u
+
+/-- L₂ lexicon score (eq. 14 at k = 2). -/
+def l2LatScoreQ (u : Utterance) (l : Lex) : ℚ := ∑ w, s2Q l w u
+
+private theorem l0Q_nonneg (l : Lex) (u : Utterance) (w : World) : 0 ≤ l0Q l u w :=
+  div_nonneg (by split <;> norm_num)
+    (Finset.sum_nonneg fun _ _ => by split <;> norm_num)
+
+private theorem s1WQ_nonneg (l : Lex) (w : World) (u : Utterance) : 0 ≤ s1WQ l w u :=
+  pow_nonneg (l0Q_nonneg l u w) 2
+
+private theorem s1Q_nonneg (l : Lex) (w : World) (u : Utterance) : 0 ≤ s1Q l w u :=
+  div_nonneg (s1WQ_nonneg l w u) (Finset.sum_nonneg fun u' _ => s1WQ_nonneg l w u')
+
+private theorem l1ScoreQ_nonneg (u : Utterance) (w : World) : 0 ≤ l1ScoreQ u w :=
+  Finset.sum_nonneg fun l _ => s1Q_nonneg l w u
+
+private theorem l1Q_nonneg (u : Utterance) (w : World) : 0 ≤ l1Q u w :=
+  div_nonneg (l1ScoreQ_nonneg u w)
+    (Finset.sum_nonneg fun w' _ => l1ScoreQ_nonneg u w')
+
+private theorem l1LatScoreQ_nonneg (u : Utterance) (l : Lex) : 0 ≤ l1LatScoreQ u l :=
+  Finset.sum_nonneg fun w _ => s1Q_nonneg l w u
+
+private theorem l1LatQ_nonneg (u : Utterance) (l : Lex) : 0 ≤ l1LatQ u l :=
+  div_nonneg (l1LatScoreQ_nonneg u l)
+    (Finset.sum_nonneg fun l' _ => l1LatScoreQ_nonneg u l')
+
+private theorem disjCostQ_nonneg (u : Utterance) : 0 ≤ disjCostQ u := by
+  cases u <;> norm_num [disjCostQ]
+
+private theorem l02Q_nonneg (l : Lex) (u : Utterance) (w : World) : 0 ≤ l02Q l u w :=
+  div_nonneg (s1Q_nonneg l w u) (Finset.sum_nonneg fun w' _ => s1Q_nonneg l w' u)
+
+private theorem s2WQ_nonneg (l : Lex) (w : World) (u : Utterance) : 0 ≤ s2WQ l w u :=
+  mul_nonneg (mul_nonneg (pow_nonneg (l02Q_nonneg l u w) 2) (l1LatQ_nonneg u l))
+    (disjCostQ_nonneg u)
+
+private theorem s2Q_nonneg (l : Lex) (w : World) (u : Utterance) : 0 ≤ s2Q l w u :=
+  div_nonneg (s2WQ_nonneg l w u) (Finset.sum_nonneg fun u' _ => s2WQ_nonneg l w u')
+
+private theorem l2ScoreQ_nonneg (u : Utterance) (w : World) : 0 ≤ l2ScoreQ u w :=
+  Finset.sum_nonneg fun l _ => s2Q_nonneg l w u
+
+private theorem l2LatScoreQ_nonneg (u : Utterance) (l : Lex) : 0 ≤ l2LatScoreQ u l :=
+  Finset.sum_nonneg fun w _ => s2Q_nonneg l w u
+
+end QModel
+
+section PMFFace
+
+open scoped ENNReal
+
+/-- Normalize a rational score vector into a PMF (uniform at zero mass). -/
+noncomputable def pmfOfScores {σ : Type*} [Fintype σ] [Nonempty σ]
+    (f : σ → ℚ) : PMF σ :=
+  if h : (∑' x, ENNReal.ofReal ((f x : ℝ))) ≠ 0 then
+    PMF.normalize (fun x => ENNReal.ofReal ((f x : ℝ))) h
+      (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+  else PMF.uniformOfFintype σ
+
+private theorem pmfOfScores_apply {σ : Type*} [Fintype σ] [Nonempty σ]
+    {f : σ → ℚ} (hf : ∀ x, 0 ≤ f x) (hpos : 0 < ∑ x, f x) (x : σ) :
+    pmfOfScores f x = ENNReal.ofReal ((f x / ∑ x', f x' : ℚ) : ℝ) := by
+  have hsum : (∑' x, ENNReal.ofReal ((f x : ℝ)))
+      = ENNReal.ofReal ((∑ x, f x : ℚ) : ℝ) := by
+    rw [tsum_fintype, ← ENNReal.ofReal_sum_of_nonneg (fun x _ => by exact_mod_cast hf x)]
+    push_cast
+    rfl
+  rw [pmfOfScores, dif_pos (by
+      rw [hsum, ENNReal.ofReal_ne_zero_iff]; exact_mod_cast hpos),
+    PMF.normalize_apply, hsum,
+    ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hpos),
+    ← ENNReal.ofReal_mul (by exact_mod_cast hf x)]
+  congr 1
+  push_cast
+  rw [div_eq_mul_inv]
+
+/-- Strict comparison of `pmfOfScores` values via the exact-ℚ scores. -/
+private theorem pmf_lt {σ : Type*} [Fintype σ] [Nonempty σ] {f : σ → ℚ}
+    (hf : ∀ x, 0 ≤ f x) (hpos : 0 < ∑ x, f x) {a b : σ}
+    (hb : 0 < f b / ∑ x, f x) (hab : f a / ∑ x, f x < f b / ∑ x, f x) :
+    pmfOfScores f a < pmfOfScores f b := by
+  rw [pmfOfScores_apply hf hpos, pmfOfScores_apply hf hpos]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast hb)).mpr
+    (by exact_mod_cast hab)
+
+/-- Joint-listener world posterior (eq. 16). -/
+noncomputable def l1PMF (u : Utterance) : PMF World :=
+  pmfOfScores (l1ScoreQ u)
+
+/-- Joint-listener lexicon posterior (eq. 14). -/
+noncomputable def l1LatPMF (u : Utterance) : PMF Lex :=
+  pmfOfScores (l1LatScoreQ u)
+
+/-- Speaker (eq. 11). -/
+noncomputable def s1PMF (l : Lex) (w : World) : PMF Utterance :=
+  pmfOfScores (s1WQ l w)
+
+/-- Endorsement speaker: renormalizes the L1 world posterior per world. -/
+noncomputable def s2PMF (w : World) : PMF Utterance :=
+  pmfOfScores (fun u => l1Q u w)
+
+/-- L₂ world posterior (eq. 16 at k = 2). -/
+noncomputable def l2PMF (u : Utterance) : PMF World :=
+  pmfOfScores (l2ScoreQ u)
+
+/-- L₂ lexicon posterior (eq. 14 at k = 2). -/
+noncomputable def l2LatPMF (u : Utterance) : PMF Lex :=
+  pmfOfScores (l2LatScoreQ u)
+
+/-- Marginal expertise speaker (eq. 17 at k = 2, uniform lexicon prior). -/
+noncomputable def s2ExpPMF (w : World) : PMF Utterance :=
+  pmfOfScores (fun u => l2ScoreQ u w)
+
+end PMFFace
+
+/-! ### Structural properties -/
 
 /-- Under syn lexicon, "A or X" has the same extension as "A" alone.
     This is the Hurford violation: the disjunction is redundant. -/
 theorem syn_AorX_eq_A :
-    ∀ w, truth .syn .AorX w = truth .syn .A w := by native_decide
+    ∀ w, truth .syn .AorX w = truth .syn .A w := by decide
 
 /-- Under excl lexicon, A and X are semantically disjoint.
     This is the exhaustified reading that rescues the disjunction. -/
 theorem excl_disjoint :
-    ¬∃ w, truth .excl .A w = true ∧ truth .excl .X w = true := by native_decide
+    ¬∃ w, truth .excl .A w = true ∧ truth .excl .X w = true := by decide
 
 /-- Under excl, "A or X" is true at w₁₂ and is the only non-null
     utterance true there. A, B, X alone each fail at w₁₂ because
@@ -230,21 +325,19 @@ theorem excl_w12_AorX_unique :
     truth .excl .AorX .w₁₂ = true ∧
     truth .excl .A .w₁₂ = false ∧
     truth .excl .B .w₁₂ = false ∧
-    truth .excl .X .w₁₂ = false := by native_decide
+    truth .excl .X .w₁₂ = false := by decide
 
 /-- Under syn, "A or X" is FALSE at w₁₂ (syn X = A, so AorX = A,
     and A fails the "must" check because A is false at w₂). -/
 theorem syn_w12_AorX_false :
-    truth .syn .AorX .w₁₂ = false := by native_decide
+    truth .syn .AorX .w₁₂ = false := by decide
 
 /-- Under base, "A or X" is true at w₁₂ (base X covers both w₁
     and w₂, so the disjunction holds at both atomic states). -/
 theorem base_w12_AorX_true :
-    truth .base .AorX .w₁₂ = true := by native_decide
+    truth .base .AorX .w₁₂ = true := by decide
 
--- ============================================================================
--- §6. L1 Predictions: Uncertainty Implicature
--- ============================================================================
+/-! ### Uncertainty implicature -/
 
 /-! The key prediction: hearing "A or X", L1 infers the speaker is
 uncertain (w₁₂), not that the speaker knows A (w₁) or knows B (w₂).
@@ -256,25 +349,23 @@ they cannot commit to either disjunct — i.e., they are in w₁₂. -/
 
 /-- Uncertainty implicature: w₁₂ > w₁ given "A or X". -/
 theorem uncertainty_w12_vs_w1 :
-    cfg.L1 .AorX .w₁₂ > cfg.L1 .AorX .w₁ := by
-  rsa_predict
+    l1PMF .AorX .w₁ < l1PMF .AorX .w₁₂ :=
+  pmf_lt (l1ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- Uncertainty implicature: w₁₂ > w₂ given "A or X". -/
 theorem uncertainty_w12_vs_w2 :
-    cfg.L1 .AorX .w₁₂ > cfg.L1 .AorX .w₂ := by
-  rsa_predict
+    l1PMF .AorX .w₂ < l1PMF .AorX .w₁₂ :=
+  pmf_lt (l1ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- Complete uncertainty ordering: w₁ > w₂. The listener assigns
     higher posterior to w₁ than w₂ because under excl, "A or X"
     at w₁ has A as the operative disjunct (a natural reading),
     while at w₂ only excl-X contributes (a refined reading). -/
 theorem uncertainty_w1_vs_w2 :
-    cfg.L1 .AorX .w₁ > cfg.L1 .AorX .w₂ := by
-  rsa_predict
+    l1PMF .AorX .w₂ < l1PMF .AorX .w₁ :=
+  pmf_lt (l1ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
--- ============================================================================
--- §7. L1 Predictions: Lexicon Inference
--- ============================================================================
+/-! ### Lexicon inference -/
 
 /-! L1 also infers which lexicon the speaker is using. For "A or X",
 the excl lexicon dominates: it makes the disjunction maximally
@@ -283,25 +374,23 @@ disjunction redundant (Hurford violation), so L1 disprefers it. -/
 
 /-- Lexicon inference: excl preferred over base for "A or X". -/
 theorem lexicon_excl_vs_base :
-    cfg.L1_latent .AorX .excl > cfg.L1_latent .AorX .base := by
-  rsa_predict
+    l1LatPMF .AorX .base < l1LatPMF .AorX .excl :=
+  pmf_lt (l1LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- Lexicon inference: excl preferred over syn for "A or X". -/
 theorem lexicon_excl_vs_syn :
-    cfg.L1_latent .AorX .excl > cfg.L1_latent .AorX .syn := by
-  rsa_predict
+    l1LatPMF .AorX .syn < l1LatPMF .AorX .excl :=
+  pmf_lt (l1LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- Lexicon inference: base preferred over syn for "A or X".
     Completes the full ordering: excl > base > syn.
     The syn lexicon makes "A or X" redundant (= "A"),
     so it gets the least support from L1. -/
 theorem lexicon_base_vs_syn :
-    cfg.L1_latent .AorX .base > cfg.L1_latent .AorX .syn := by
-  rsa_predict
+    l1LatPMF .AorX .syn < l1LatPMF .AorX .base :=
+  pmf_lt (l1LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
--- ============================================================================
--- §8. S1 Predictions: Speaker Rationality
--- ============================================================================
+/-! ### Speaker rationality -/
 
 /-! The paper argues that a rational speaker at w₁₂ (uncertain)
 should prefer the disjunction "A or X" over simpler utterances.
@@ -314,25 +403,23 @@ because it is the most informative utterance at that world. -/
     (since A is only true at w₁ under excl). The disjunction
     conveys the uncertainty. -/
 theorem s1_w12_AorX_vs_A :
-    cfg.S1 .excl .w₁₂ .AorX > cfg.S1 .excl .w₁₂ .A := by
-  rsa_predict
+    s1PMF .excl .w₁₂ .A < s1PMF .excl .w₁₂ .AorX :=
+  pmf_lt (s1WQ_nonneg _ _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- Speaker at w₁₂ prefers "A or X" over "X" (under excl lexicon).
     "X" alone would lead to inference of w₂. -/
 theorem s1_w12_AorX_vs_X :
-    cfg.S1 .excl .w₁₂ .AorX > cfg.S1 .excl .w₁₂ .X := by
-  rsa_predict
+    s1PMF .excl .w₁₂ .X < s1PMF .excl .w₁₂ .AorX :=
+  pmf_lt (s1WQ_nonneg _ _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- Speaker at w₁ prefers "A" over "A or X" (under excl lexicon).
     When the speaker KNOWS w₁, saying just "A" is more informative
     than the disjunction. -/
 theorem s1_w1_A_vs_AorX :
-    cfg.S1 .excl .w₁ .A > cfg.S1 .excl .w₁ .AorX := by
-  rsa_predict
+    s1PMF .excl .w₁ .AorX < s1PMF .excl .w₁ .A :=
+  pmf_lt (s1WQ_nonneg _ _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
--- ============================================================================
--- §9. Hurford Disjunctions
--- ============================================================================
+/-! ### Hurford disjunctions -/
 
 /-! Hurford disjunctions like "some or all" are felicitous, rescued by
 exhaustification. This is exactly the phenomenon [potts-levy-2015]
@@ -344,57 +431,18 @@ The connection: exh(some) = some-but-not-all corresponds to our
 `excl_is_base_minus_A` theorem, which shows excl(X) = base(X) ∧ ¬A —
 the same operation as exh. -/
 
--- ============================================================================
--- §10. Expertise Model (S2-level)
--- ============================================================================
+/-! ### Endorsement decomposition -/
 
-/-! The paper's key contribution: the **expertise parameter β**.
+/-! Eq. 15's two utility terms verified as independent components: the
+informativity term via the endorsement speaker (`s2PMF`, S₂(u|w) ∝ L₁(w|u))
+and the expertise term via lexicon signaling (`AorX_signals_excl_vs_A`).
+With β > 0 the speaker has both reasons to use the disjunction. -/
 
-[potts-levy-2015]'s distinctive insight beyond generic LU-RSA is that
-speakers of Hurford-violating disjunctions signal their **expertise** about
-the meaning of the broader term. This is modeled as an S2-level speaker who
-cares not only about informativity (L1 inferring the correct world) but
-also about **lexicon signaling** (L1 inferring the speaker's lexicon).
-
-The paper's expertise speaker utility (eq 15):
-
-    U_Sk(m, w, L) = α · ln Lk₋₁(w|m,L) + β · ln Lk₋₁(L|m) − C(m)
-
-- **Informativity** (α term): world-inference
-- **Expertise** (β term): lexicon-inference
-- **Cost** (C(m) term): message complexity
-
-When β = 0, this reduces to standard RSA (pure informativity).
-When β > 0, the speaker has extra incentive to choose utterances that
-cause L1 to infer the `excl` lexicon. "A or X" is the uniquely effective
-signal because it is maximally informative only under `excl` (§5, §7).
-
-We decompose the expertise model into two independently verifiable
-components using `cfg.S2` (RSA endorsement: S2(u|w) ∝ L₁(w|u)) for
-informativity and `cfg.L1_latent` for lexicon signaling.
-
-### Two Components
-
-1. **Informativity (S2 endorsement)**: `S2(AorX|w₁₂) > S2(A|w₁₂)`,
-   i.e. L1 assigns higher posterior to w₁₂ given AorX than given A.
-2. **Lexicon signaling (L1_latent, §7)**: L1_latent(excl|AorX) >
-   L1_latent(base|AorX) > L1_latent(syn|AorX) — AorX causes L1 to
-   infer the excl lexicon.
-
-When β > 0, the speaker cares about BOTH, and the lexicon-signaling
-term provides extra motivation beyond pure informativity to use the
-disjunction. -/
-
-/-- S2 endorsement at w₁₂: the pragmatic speaker prefers "A or X" over "A".
-
-    S2(u|w) ∝ L₁(w|u): L1 assigns higher posterior to w₁₂ given AorX
-    (the disjunction is informative about uncertainty) than given A
-    (which is false at w₁₂ under all lexica, so L₁(w₁₂|A) ≈ 0).
-
-    This is the informativity component of the expertise model. -/
+/-- Endorsement at w₁₂: "A or X" is the more informative choice ("A" is
+false at w₁₂ under every lexicon). -/
 theorem s2_w12_AorX_vs_A :
-    cfg.S2 .w₁₂ .AorX > cfg.S2 .w₁₂ .A := by
-  rsa_predict
+    s2PMF .w₁₂ .A < s2PMF .w₁₂ .AorX :=
+  pmf_lt (fun u => l1Q_nonneg u _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- S2 endorsement at w₁: the pragmatic speaker prefers "A" over "A or X".
 
@@ -402,8 +450,8 @@ theorem s2_w12_AorX_vs_A :
     The expertise model does not override this — even with β > 0,
     an expert at w₁ prefers the direct utterance. -/
 theorem s2_w1_A_vs_AorX :
-    cfg.S2 .w₁ .A > cfg.S2 .w₁ .AorX := by
-  rsa_predict
+    s2PMF .w₁ .AorX < s2PMF .w₁ .A :=
+  pmf_lt (fun u => l1Q_nonneg u _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- "A or X" signals the excl lexicon more strongly than "A" does.
 
@@ -417,12 +465,16 @@ theorem s2_w1_A_vs_AorX :
     at w₁₂ has TWO reasons to use "A or X": informativity (S2) and
     lexicon signaling (this theorem). -/
 theorem AorX_signals_excl_vs_A :
-    cfg.L1_latent .AorX .excl > cfg.L1_latent .A .excl := by
-  rsa_predict
+    l1LatPMF .A .excl < l1LatPMF .AorX .excl := by
+  rw [l1LatPMF, l1LatPMF, pmfOfScores_apply (l1LatScoreQ_nonneg _) (by decide +kernel),
+    pmfOfScores_apply (l1LatScoreQ_nonneg _) (by decide +kernel)]
+  exact (ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast
+      (by decide +kernel : (0:ℚ) < l1LatScoreQ .AorX .excl / ∑ l', l1LatScoreQ .AorX l'))).mpr
+    (by exact_mod_cast (by decide +kernel :
+      l1LatScoreQ .A .excl / ∑ l', l1LatScoreQ .A l' <
+      l1LatScoreQ .AorX .excl / ∑ l', l1LatScoreQ .AorX l'))
 
--- ============================================================================
--- §11. Full Expertise Model (Stacked RSA, eq 15)
--- ============================================================================
+/-! ### The stacked expertise model (eq. 15) -/
 
 /-! The paper's distinctive contribution is the **expertise parameter β**
 in the S₂ speaker utility (eq 15):
@@ -440,78 +492,53 @@ Since `exp(-1) ∉ ℚ`, the cost penalty is approximated as `37/100 ≈ 0.37`
 (close to `exp(-1) ≈ 0.368`). Qualitative predictions are robust to the
 exact value (paper Section 5.4). -/
 
-/-- Disjunction cost penalty: `exp(-C(m))`. The paper uses `C(or) = 1`,
-    giving `exp(-1) ≈ 0.368`. We use `37/100` as a rational approximation. -/
-noncomputable def disjCost : Utterance → ℝ
-  | .AorX => 37/100
-  | _ => 1
-
-theorem disjCost_nonneg (u : Utterance) : 0 ≤ disjCost u := by
-  cases u <;> simp [disjCost] <;> norm_num
-
-open RSA in
-/-- Expertise model: `cfg.stack` with α₂ = 2, β = 1.
-
-`S₂(m|w,L) ∝ l₁(w|m,L)^2 · L₁(L|m) · exp(-C(m))`.
-
-The stacked L1 = L₂ (world posterior), stacked L1_latent = L₂_latent
-(lexicon posterior). -/
-noncomputable def expertiseCfg : RSAConfig Utterance World :=
-  cfg.stack 2 two_pos
-    (bonus := fun l u => cfg.L1_latent u l)
-    (bonus_nonneg := fun l u => cfg.L1_latent_nonneg u l)
-    (costFactor := disjCost)
-    (costFactor_nonneg := disjCost_nonneg)
-
 -- ---- L₂ World Predictions ----
 
 /-- L₂ hearing "A or X": uncertainty state w₁₂ dominates w₁. -/
 theorem L2_AorX_w12_vs_w1 :
-    expertiseCfg.L1 .AorX .w₁₂ > expertiseCfg.L1 .AorX .w₁ := by
-  rsa_predict
+    l2PMF .AorX .w₁ < l2PMF .AorX .w₁₂ :=
+  pmf_lt (l2ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- L₂ hearing "A or X": uncertainty state w₁₂ dominates w₂. -/
 theorem L2_AorX_w12_vs_w2 :
-    expertiseCfg.L1 .AorX .w₁₂ > expertiseCfg.L1 .AorX .w₂ := by
-  rsa_predict
+    l2PMF .AorX .w₂ < l2PMF .AorX .w₁₂ :=
+  pmf_lt (l2ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- L₂ hearing "A or X": w₁ > w₂. -/
 theorem L2_AorX_w1_vs_w2 :
-    expertiseCfg.L1 .AorX .w₁ > expertiseCfg.L1 .AorX .w₂ := by
-  rsa_predict
+    l2PMF .AorX .w₂ < l2PMF .AorX .w₁ :=
+  pmf_lt (l2ScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 -- ---- L₂ Lexicon Predictions ----
 
 /-- L₂ lexicon inference: excl dominates base for "A or X". -/
 theorem L2_AorX_excl_vs_base :
-    expertiseCfg.L1_latent .AorX .excl > expertiseCfg.L1_latent .AorX .base := by
-  rsa_predict
+    l2LatPMF .AorX .base < l2LatPMF .AorX .excl :=
+  pmf_lt (l2LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- L₂ lexicon inference: excl dominates syn for "A or X". -/
 theorem L2_AorX_excl_vs_syn :
-    expertiseCfg.L1_latent .AorX .excl > expertiseCfg.L1_latent .AorX .syn := by
-  rsa_predict
+    l2LatPMF .AorX .syn < l2LatPMF .AorX .excl :=
+  pmf_lt (l2LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- L₂ lexicon inference: base > syn. Full ordering: excl > base > syn. -/
 theorem L2_AorX_base_vs_syn :
-    expertiseCfg.L1_latent .AorX .base > expertiseCfg.L1_latent .AorX .syn := by
-  rsa_predict
+    l2LatPMF .AorX .syn < l2LatPMF .AorX .base :=
+  pmf_lt (l2LatScoreQ_nonneg _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 -- ---- S₂ Expertise Speaker Predictions ----
 
 /-- S₂ at w₁₂ prefers "A or X" over "A" (marginalized over lexica). -/
 theorem S2_expertise_w12_AorX_vs_A :
-    expertiseCfg.S2 .w₁₂ .AorX > expertiseCfg.S2 .w₁₂ .A := by
-  rsa_predict
+    s2ExpPMF .w₁₂ .A < s2ExpPMF .w₁₂ .AorX :=
+  pmf_lt (fun u => l2ScoreQ_nonneg u _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 /-- S₂ at w₁ prefers "A" over "A or X" (marginalized over lexica). -/
 theorem S2_expertise_w1_A_vs_AorX :
-    expertiseCfg.S2 .w₁ .A > expertiseCfg.S2 .w₁ .AorX := by
-  rsa_predict
+    s2ExpPMF .w₁ .AorX < s2ExpPMF .w₁ .A :=
+  pmf_lt (fun u => l2ScoreQ_nonneg u _) (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
--- ============================================================================
--- §12. Findings
--- ============================================================================
+/-! ### Findings -/
 
 /-- The qualitative findings from the [potts-levy-2015] LU + expertise model. -/
 inductive Finding where
@@ -542,25 +569,25 @@ inductive Finding where
 
 /-- Verification: each finding is backed by a proved theorem. -/
 def Finding.verified : Finding → Prop
-  | .uncertainty_w12_vs_w1 => cfg.L1 .AorX .w₁₂ > cfg.L1 .AorX .w₁
-  | .uncertainty_w12_vs_w2 => cfg.L1 .AorX .w₁₂ > cfg.L1 .AorX .w₂
-  | .uncertainty_w1_vs_w2 => cfg.L1 .AorX .w₁ > cfg.L1 .AorX .w₂
-  | .lexicon_excl_vs_base => cfg.L1_latent .AorX Lex.excl > cfg.L1_latent .AorX Lex.base
-  | .lexicon_excl_vs_syn => cfg.L1_latent .AorX Lex.excl > cfg.L1_latent .AorX Lex.syn
-  | .lexicon_base_vs_syn => cfg.L1_latent .AorX Lex.base > cfg.L1_latent .AorX Lex.syn
-  | .s1_w12_prefers_AorX => cfg.S1 .excl .w₁₂ .AorX > cfg.S1 .excl .w₁₂ .A
-  | .s1_w1_prefers_A => cfg.S1 .excl .w₁ .A > cfg.S1 .excl .w₁ .AorX
-  | .s2_w12_AorX => cfg.S2 .w₁₂ .AorX > cfg.S2 .w₁₂ .A
-  | .s2_w1_A => cfg.S2 .w₁ .A > cfg.S2 .w₁ .AorX
-  | .AorX_signals_excl => cfg.L1_latent .AorX Lex.excl > cfg.L1_latent .A Lex.excl
-  | .L2_w12_vs_w1 => expertiseCfg.L1 .AorX .w₁₂ > expertiseCfg.L1 .AorX .w₁
-  | .L2_w12_vs_w2 => expertiseCfg.L1 .AorX .w₁₂ > expertiseCfg.L1 .AorX .w₂
-  | .L2_w1_vs_w2 => expertiseCfg.L1 .AorX .w₁ > expertiseCfg.L1 .AorX .w₂
-  | .L2_excl_vs_base => expertiseCfg.L1_latent .AorX .excl > expertiseCfg.L1_latent .AorX .base
-  | .L2_excl_vs_syn => expertiseCfg.L1_latent .AorX .excl > expertiseCfg.L1_latent .AorX .syn
-  | .L2_base_vs_syn => expertiseCfg.L1_latent .AorX .base > expertiseCfg.L1_latent .AorX .syn
-  | .S2_expertise_w12_AorX => expertiseCfg.S2 .w₁₂ .AorX > expertiseCfg.S2 .w₁₂ .A
-  | .S2_expertise_w1_A => expertiseCfg.S2 .w₁ .A > expertiseCfg.S2 .w₁ .AorX
+  | .uncertainty_w12_vs_w1 => l1PMF .AorX .w₁ < l1PMF .AorX .w₁₂
+  | .uncertainty_w12_vs_w2 => l1PMF .AorX .w₂ < l1PMF .AorX .w₁₂
+  | .uncertainty_w1_vs_w2 => l1PMF .AorX .w₂ < l1PMF .AorX .w₁
+  | .lexicon_excl_vs_base => l1LatPMF .AorX .base < l1LatPMF .AorX .excl
+  | .lexicon_excl_vs_syn => l1LatPMF .AorX .syn < l1LatPMF .AorX .excl
+  | .lexicon_base_vs_syn => l1LatPMF .AorX .syn < l1LatPMF .AorX .base
+  | .s1_w12_prefers_AorX => s1PMF .excl .w₁₂ .A < s1PMF .excl .w₁₂ .AorX
+  | .s1_w1_prefers_A => s1PMF .excl .w₁ .AorX < s1PMF .excl .w₁ .A
+  | .s2_w12_AorX => s2PMF .w₁₂ .A < s2PMF .w₁₂ .AorX
+  | .s2_w1_A => s2PMF .w₁ .AorX < s2PMF .w₁ .A
+  | .AorX_signals_excl => l1LatPMF .A .excl < l1LatPMF .AorX .excl
+  | .L2_w12_vs_w1 => l2PMF .AorX .w₁ < l2PMF .AorX .w₁₂
+  | .L2_w12_vs_w2 => l2PMF .AorX .w₂ < l2PMF .AorX .w₁₂
+  | .L2_w1_vs_w2 => l2PMF .AorX .w₂ < l2PMF .AorX .w₁
+  | .L2_excl_vs_base => l2LatPMF .AorX .base < l2LatPMF .AorX .excl
+  | .L2_excl_vs_syn => l2LatPMF .AorX .syn < l2LatPMF .AorX .excl
+  | .L2_base_vs_syn => l2LatPMF .AorX .syn < l2LatPMF .AorX .base
+  | .S2_expertise_w12_AorX => s2ExpPMF .w₁₂ .A < s2ExpPMF .w₁₂ .AorX
+  | .S2_expertise_w1_A => s2ExpPMF .w₁ .AorX < s2ExpPMF .w₁ .A
 
 theorem all_findings_verified (f : Finding) : f.verified := by
   cases f <;> simp only [Finding.verified]

--- a/Linglib/Studies/ScontrasTonhauser2025.lean
+++ b/Linglib/Studies/ScontrasTonhauser2025.lean
@@ -1,5 +1,6 @@
-import Linglib.Tactics.RSAPredict
 import Linglib.Pragmatics.RSA.Basic
+import Linglib.Pragmatics.RSA.LatentOperators
+import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.BToM
 import Linglib.Semantics.Attitudes.Factivity
 import Linglib.Studies.DegenTonhauser2021
@@ -7,88 +8,60 @@ import Linglib.Semantics.Presupposition.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!
-# [scontras-tonhauser-2025]
+# [scontras-tonhauser-2025]: projection without lexical presupposition
 
-Projection emerges from RSA over speaker's private assumptions, not lexical
-presupposition. L1 jointly infers world state and speaker's belief state.
+An RSA model of *know* under negation (SuB 29, pp. 1431–1448): the pragmatic
+listener jointly infers the world state and the speaker's private assumptions
+(eq. 7), the speaker scores QUD-projected informativity (eq. 6, α = 10, fn.
+12), and the literal listener answers the QUD within the assumption set
+(eq. 5). Projection of the complement C emerges with no lexically-specified
+constraint on the common ground. Domain: 6 utterances × 4 worlds (BEL × C) ×
+15 belief states × 2 QUDs; literal semantics from
+`Semantics.Attitudes.Factivity` (know = `factivePos`, think =
+`nonFactivePos`).
 
-## The Model (Section 3)
+## Main results
 
-- **L0** (eq. 5): L0(Q(w)|u,A,Q) ∝ Σ_{w'∈A∩⟦u⟧, Q(w')=Q(w)} P(w')
-- **S1** (eq. 6): S1(u|w,A,Q) ∝ exp(α(log L0(Q(w)|u,A,Q) − C(u)))
-- **L1** (eq. 7): L1(w,A|u,Q) ∝ S1(u|w,A,Q) · P(w) · P(A)
+* `bel_qud_marginal_eq_prior_high` / `_low`: under the BEL? QUD the world
+  C-marginal *equals the prior* for every utterance — S1 depends on the
+  world only through its BEL-cell, so projection is invisible there.
+* `prediction_2b`: higher prior ⇒ stronger projection (C? QUD), the effect
+  [degen-tonhauser-2021] documents across 20 predicates (Exp 1: β = 0.16,
+  p < .001).
+* `prediction_2c`: BEL? QUD ⇒ stronger projection than C? QUD (Exp 2:
+  β = 0.14, p < .001).
+* `c_qud_thinkNeg_higher`: under C?, negated *know* is evidence against C.
+* `model_predicts_effects`: the model directions match the regressions.
 
-Domain: 6 utterances × 4 worlds × 15 belief states × 2 QUDs. α = 10.
+## Implementation notes
 
-## Section 3 Parameters (fn. 12)
+α = 10 is a natural power, so the model is computed in exact ℚ (`l0Q` …
+`wTotalQ`); listeners are `PMF.normalize` of those scores bridged by
+`ENNReal.ofReal_sum_of_nonneg`, and every prediction is a kernel-verified
+rational comparison. Degenerate cells (no compatible utterance) fall back to
+`pure .cPos` on both faces, keeping the bridge total.
 
-- **Belief states A**: all 15 non-empty subsets of W
-  (following [qing-goodman-lassiter-2016])
-- **Prior over A**: uniform
-- **α = 10**
-- **P(C)**: 2/3 (higher) or 1/3 (lower); P(BEL|C) = 1/2
+Utterance cost (§3.1: complex = 2 × simple) is omitted: `exp(−αC)` is
+transcendental, and the omission reverses prediction (2a)'s world-marginal
+direction (the paper derives know > think *with* cost, Figure 7a);
+predictions (2b) and (2c) are robust to it. Prior parameters follow §3.1:
+P(C) ∈ {2/3, 1/3}, P(BEL | C) = 1/2, uniform over the 15 assumption sets.
 
-Cost (complex = 2×simple) is omitted: exp(−αC) with α = 10 introduces
-irrational numbers incompatible with ℚ arithmetic. Cost omission affects
-S1's normalization even for same-cost comparisons, reversing the direction of
-prediction (2a); the full model with cost predicts know > think (Figure 7a).
-Predictions (2b) and (2c) are robust to cost omission.
+## TODO
 
-## Factive Semantics
-
-Literal truth conditions derive from `Semantics.Attitudes.Factivity`:
-know = `factivePos` (BEL ∧ C), think = `nonFactivePos` (BEL).
-
-## Key Structural Insight
-
-Under QUD=BEL?, L1's world-marginal P(C|u) = P(C) for all utterances — a
-mathematical identity. S1 scores depend on w only through w.bel, so the
-complement dimension washes out in the marginal. Prediction 2b (prior
-effect) therefore comes from the C? QUD condition; prediction 2c (QUD
-effect) compares the uninformative BEL? marginal against the C? marginal.
-
-## BToM Connection
-
-This is a BToM model: L1 inverts S1's generative model to jointly infer
-the speaker's belief state and the world state.
-
-## Experimental Results
-
-Exp 1 confirms (2a) utterance effect (β = 0.35, p < .001) and (2b) prior
-effect (β = 0.16, p < .001). The QUD manipulation was not significant
-(β = 0.009, p = .75). Exp 2 confirms (2a) utterance effect (β = 0.34,
-p < .001) and (2c) QUD effect (β = 0.14, p < .001) with a stronger QUD
-manipulation. Exp 2 did not manipulate prior probability.
-
-## Connection to [degen-tonhauser-2021]
-
-The prior effect (prediction 2b) replicates the core finding of
-[degen-tonhauser-2021]: higher prior probability of complement content
-leads to stronger projection. D&T 2021 demonstrate this across 20 predicates
-with β = 0.14 (categorical) / β = 0.28 (individual-level). S&T 2025's RSA
-model provides the theoretical explanation: L1's Bayesian inference naturally
-incorporates prior beliefs, so higher priors yield higher posteriors.
-
-## Comparison with Compositional Filtering
-
-§13 compares the BToM model against compositional filtering
-([heim-1983]): both predict conditional presupposition for factive
-"know", but only BToM predicts projection effects for non-factive
-"think" and relatedness modulation — the paper's key empirical argument
-against lexical presupposition encoding.
+Model the cost term (log-rational costs keep ℚ exactness) and derive
+prediction (2a)'s world-marginal direction. Prove the structural equivalence
+with [qing-goodman-lassiter-2016] (fn. 10: "private assumptions" vs "common
+ground" is interpretive, not computational) — see the matching TODO in
+`QingGoodmanLassiter2016.lean`.
 -/
-
-set_option autoImplicit false
 
 namespace ScontrasTonhauser2025
 
 open BigOperators
-open Real (rpow rpow_nonneg rpow_pos_of_pos)
 open Semantics.Attitudes.Factivity
 
--- ============================================================================
--- §1. World and Utterance Types
--- ============================================================================
+/-! ### Worlds and utterances -/
 
 /-- World state: (BEL, C) where BEL = Cole believes C, C = complement is true.
     Flat inductive for tactic enumerability. -/
@@ -125,9 +98,7 @@ instance : Fintype Utterance where
   elems := {.knowPos, .knowNeg, .thinkPos, .thinkNeg, .cPos, .cNeg}
   complete := fun x => by cases x <;> simp
 
--- ============================================================================
--- §2. Literal Truth Conditions (derived from Factivity)
--- ============================================================================
+/-! ### Literal truth conditions (from `Factivity`) -/
 
 /-- Literal truth conditions derived from factive/non-factive semantics.
 
@@ -142,9 +113,7 @@ def literalMeaning : Utterance → WorldState → Bool
   | .cPos     => HasComplement.c
   | .cNeg     => fun w => !HasComplement.c w
 
--- ============================================================================
--- §3. Speaker Belief States — all 15 non-empty subsets of W
--- ============================================================================
+/-! ### Speaker belief states (the 15 non-empty subsets of W) -/
 
 /-- Speaker's private assumptions: all 15 non-empty subsets of W.
     Section 3 follows [qing-goodman-lassiter-2016]: A ranges over all
@@ -171,7 +140,7 @@ instance : Fintype BeliefState where
   complete := fun x => by cases x <;> simp
 
 /-- Membership in belief state. Boolean operations on `WorldState` fields
-    reduce cleanly for `rsa_predict`. -/
+    reduce cleanly under kernel evaluation. -/
 def speakerCredenceBool : BeliefState → WorldState → Bool
   | .all, _ => true
   | .onlyW11, w => w.bel && w.c
@@ -194,33 +163,7 @@ def assumesC : BeliefState → Bool
   | .onlyW11 | .onlyW01 | .cTrue => true
   | _ => false
 
--- ============================================================================
--- §4. QUD Aggregation
--- ============================================================================
-
-/-- QUD aggregation: sums L0 probabilities over the QUD equivalence class of w.
-    Named `qudAggregate` to distinguish from `Factivity.qudProject`
-    (the equivalence relation, not the aggregation).
-    - BEL? QUD: partitions by BEL → sums over same-BEL worlds
-    - C? QUD: partitions by C → sums over same-C worlds -/
-def qudAggregate (qud : QUD) (f : WorldState → ℝ) (w : WorldState) : ℝ :=
-  match qud, w with
-  | .bel, .w11 => f .w11 + f .w10
-  | .bel, .w10 => f .w11 + f .w10
-  | .bel, .w01 => f .w01 + f .w00
-  | .bel, .w00 => f .w01 + f .w00
-  | .c,   .w11 => f .w11 + f .w01
-  | .c,   .w01 => f .w11 + f .w01
-  | .c,   .w10 => f .w10 + f .w00
-  | .c,   .w00 => f .w10 + f .w00
-
-theorem qudAggregate_nonneg {qud : QUD} {f : WorldState → ℝ} {w : WorldState}
-    (hf : ∀ w, 0 ≤ f w) : 0 ≤ qudAggregate qud f w := by
-  cases qud <;> cases w <;> simp only [qudAggregate] <;> exact add_nonneg (hf _) (hf _)
-
--- ============================================================================
--- §5. Priors
--- ============================================================================
+/-! ### Priors -/
 
 /-- World prior parameterized by P(C).
     P(BEL, C) = P(BEL | C) · P(C), with P(BEL | C) = 1/2. -/
@@ -238,339 +181,419 @@ theorem worldPriorQ_sum (pC : ℚ) :
     worldPriorQ pC .w01 + worldPriorQ pC .w00 = 1 := by
   simp [worldPriorQ]; ring
 
--- ============================================================================
--- §6. RSAConfig
--- ============================================================================
+/-! ### The exact-ℚ model and its PMF face (local pending the RSA API pass) -/
 
-/-- RSA model for Section 3: uniform prior over all 15 belief states,
-    QUD-projected rpow scoring, α = 10. -/
-noncomputable def cfg (qud : QUD) (pC : ℚ) (hpC : 0 ≤ pC) (hpC1 : pC ≤ 1) :
-    RSA.RSAConfig Utterance WorldState where
-  Latent := BeliefState
-  meaning _ bs u w :=
-    if speakerCredenceBool bs w && literalMeaning u w then
-      (worldPriorQ pC w : ℝ)
-    else 0
-  meaning_nonneg _ _ _ w := by
+section QModel
+
+/-- Literal-listener mass (eq. 5's normaliser): prior mass of worlds in the
+assumption set where `u` is true. -/
+def l0MassQ (pC : ℚ) (bs : BeliefState) (u : Utterance) : ℚ :=
+  ∑ w, (if speakerCredenceBool bs w && literalMeaning u w then worldPriorQ pC w else 0)
+
+/-- Literal listener value (division by zero yields 0). -/
+def l0Q (pC : ℚ) (bs : BeliefState) (u : Utterance) (w : WorldState) : ℚ :=
+  (if speakerCredenceBool bs w && literalMeaning u w then worldPriorQ pC w else 0) /
+    l0MassQ pC bs u
+
+/-- QUD aggregation of the literal listener (eq. 5). -/
+def qAggQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (u : Utterance) : WorldState → ℚ
+  | .w11 => match qud with
+    | .bel => l0Q pC bs u .w11 + l0Q pC bs u .w10
+    | .c   => l0Q pC bs u .w11 + l0Q pC bs u .w01
+  | .w10 => match qud with
+    | .bel => l0Q pC bs u .w11 + l0Q pC bs u .w10
+    | .c   => l0Q pC bs u .w10 + l0Q pC bs u .w00
+  | .w01 => match qud with
+    | .bel => l0Q pC bs u .w01 + l0Q pC bs u .w00
+    | .c   => l0Q pC bs u .w11 + l0Q pC bs u .w01
+  | .w00 => match qud with
+    | .bel => l0Q pC bs u .w01 + l0Q pC bs u .w00
+    | .c   => l0Q pC bs u .w10 + l0Q pC bs u .w00
+
+/-- Speaker weight (eq. 6 at α = 10, zero cost). -/
+def s1WeightQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState)
+    (u : Utterance) : ℚ :=
+  (qAggQ qud pC bs u w) ^ 10
+
+def s1ZQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState) : ℚ :=
+  ∑ u, s1WeightQ qud pC bs w u
+
+/-- Normalized speaker value, with the degenerate-cell fallback matching the
+PMF face (`pure .cPos` where no utterance carries weight). -/
+def s1ValQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState)
+    (u : Utterance) : ℚ :=
+  if s1ZQ qud pC bs w = 0 then (if u = .cPos then 1 else 0)
+  else s1WeightQ qud pC bs w u / s1ZQ qud pC bs w
+
+/-- Listener world score (eq. 7; uniform assumption prior). -/
+def worldScoreQ (qud : QUD) (pC : ℚ) (u : Utterance) (w : WorldState) : ℚ :=
+  worldPriorQ pC w * ∑ bs, s1ValQ qud pC bs w u
+
+/-- C-event mass and total of the listener scores. -/
+def cEventQ (qud : QUD) (pC : ℚ) (u : Utterance) : ℚ :=
+  ∑ w, (if w.c then worldScoreQ qud pC u w else 0)
+
+def wTotalQ (qud : QUD) (pC : ℚ) (u : Utterance) : ℚ :=
+  ∑ w, worldScoreQ qud pC u w
+
+end QModel
+
+section QModel
+
+theorem worldPriorQ_nonneg' {pC : ℚ} (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (w : WorldState) :
+    0 ≤ worldPriorQ pC w := worldPriorQ_nonneg pC h0 h1 w
+
+variable {pC : ℚ}
+
+theorem l0MassQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (bs : BeliefState) (u : Utterance) :
+    0 ≤ l0MassQ pC bs u :=
+  Finset.sum_nonneg fun w _ => by
     split
-    · exact Rat.cast_nonneg.mpr (worldPriorQ_nonneg pC hpC hpC1 w)
+    · exact worldPriorQ_nonneg pC h0 h1 w
     · exact le_refl 0
-  s1Score l0 α _bs w u := rpow (qudAggregate qud (l0 u) w) α
-  s1Score_nonneg _ _ _ _ u hl _ :=
-    rpow_nonneg (qudAggregate_nonneg (fun w => hl u w)) _
-  α := 10
-  α_pos := by positivity
-  worldPrior w := (worldPriorQ pC w : ℝ)
-  worldPrior_nonneg w := Rat.cast_nonneg.mpr (worldPriorQ_nonneg pC hpC hpC1 w)
-  latentPrior _w _bs := 1
-  latentPrior_nonneg _w _bs := one_pos.le
 
-/-- QUD=BEL?, P(C)=2/3. -/
-noncomputable abbrev cfgBelHigh := cfg .bel (2/3) (by norm_num) (by norm_num)
+theorem l0Q_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (bs : BeliefState) (u : Utterance)
+    (w : WorldState) : 0 ≤ l0Q pC bs u w :=
+  div_nonneg (by
+    split
+    · exact worldPriorQ_nonneg pC h0 h1 w
+    · exact le_refl 0) (l0MassQ_nonneg h0 h1 bs u)
 
-/-- QUD=BEL?, P(C)=1/3. -/
-noncomputable abbrev cfgBelLow := cfg .bel (1/3) (by norm_num) (by norm_num)
+theorem qAggQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
+    (u : Utterance) (w : WorldState) : 0 ≤ qAggQ qud pC bs u w := by
+  cases w <;> cases qud <;>
+    exact add_nonneg (l0Q_nonneg h0 h1 bs u _) (l0Q_nonneg h0 h1 bs u _)
 
-/-- QUD=C?, P(C)=2/3. -/
-noncomputable abbrev cfgCHigh := cfg .c (2/3) (by norm_num) (by norm_num)
+theorem s1WeightQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
+    (w : WorldState) (u : Utterance) : 0 ≤ s1WeightQ qud pC bs w u :=
+  pow_nonneg (qAggQ_nonneg h0 h1 qud bs u w) 10
 
-/-- QUD=C?, P(C)=1/3. -/
-noncomputable abbrev cfgCLow := cfg .c (1/3) (by norm_num) (by norm_num)
+theorem s1ZQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
+    (w : WorldState) : 0 ≤ s1ZQ qud pC bs w :=
+  Finset.sum_nonneg fun u _ => s1WeightQ_nonneg h0 h1 qud bs w u
 
--- ============================================================================
--- §7. L1 Predictions
--- ============================================================================
+theorem s1ValQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
+    (w : WorldState) (u : Utterance) : 0 ≤ s1ValQ qud pC bs w u := by
+  unfold s1ValQ
+  split
+  · split <;> norm_num
+  · exact div_nonneg (s1WeightQ_nonneg h0 h1 qud bs w u) (s1ZQ_nonneg h0 h1 qud bs w)
 
--- ---------- helpers for BEL? QUD identity ----------
+theorem worldScoreQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance)
+    (w : WorldState) : 0 ≤ worldScoreQ qud pC u w :=
+  mul_nonneg (worldPriorQ_nonneg pC h0 h1 w)
+    (Finset.sum_nonneg fun bs _ => s1ValQ_nonneg h0 h1 qud bs w u)
 
-private theorem worldState_univ :
-    (Finset.univ : Finset WorldState) = {.w11, .w10, .w01, .w00} := by
-  ext x; cases x <;> simp
+theorem wTotalQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance) :
+    0 ≤ wTotalQ qud pC u :=
+  Finset.sum_nonneg fun w _ => worldScoreQ_nonneg h0 h1 qud u w
 
-private theorem c_filter :
-    Finset.univ.filter (fun w : WorldState => w.c = true) = {.w11, .w01} := by
-  native_decide
+end QModel
 
-private theorem meaning_pos_high (u : Utterance) :
-    ∃ w₀, 0 < cfgBelHigh.meaning cfgBelHigh.initial .all u w₀ := by
-  cases u
-  · exact ⟨.w11, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w11 && literalMeaning .knowPos .w11
-                        then (worldPriorQ (2/3) .w11 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, factivePos,
-        HasBelief.bel, WorldState.bel, HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w10, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w10 && literalMeaning .knowNeg .w10
-                        then (worldPriorQ (2/3) .w10 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, factiveNeg,
-        HasBelief.bel, WorldState.bel, HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w11, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w11 && literalMeaning .thinkPos .w11
-                        then (worldPriorQ (2/3) .w11 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, nonFactivePos,
-        HasBelief.bel, WorldState.bel, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w01, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w01 && literalMeaning .thinkNeg .w01
-                        then (worldPriorQ (2/3) .w01 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, nonFactiveNeg,
-        HasBelief.bel, WorldState.bel, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w11, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w11 && literalMeaning .cPos .w11
-                        then (worldPriorQ (2/3) .w11 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning,
-        HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w10, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w10 && literalMeaning .cNeg .w10
-                        then (worldPriorQ (2/3) .w10 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning,
-        HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
+section PMFFace
 
-set_option maxHeartbeats 1600000 in
-private theorem high_totalScore_pos (u : Utterance) :
-    0 < cfgBelHigh.L1agent.totalScore u := by
-  obtain ⟨w₀, hm⟩ := meaning_pos_high u
-  have hL0t := lt_of_lt_of_le hm (Finset.single_le_sum
-    (fun w' _ => cfgBelHigh.meaning_nonneg cfgBelHigh.initial .all u w') (Finset.mem_univ w₀))
-  have hL0t' : 0 < (cfgBelHigh.L0agent .all).totalScore u := hL0t
-  have hL0p : 0 < (cfgBelHigh.L0agent .all).policy u w₀ := by
-    unfold Core.RationalAction.policy; rw [if_neg (ne_of_gt hL0t')]; exact div_pos hm hL0t'
-  have hqud : 0 < qudAggregate .bel ((cfgBelHigh.L0agent .all).policy u) w₀ := by
-    cases w₀ <;> simp only [qudAggregate] <;>
-      linarith [(cfgBelHigh.L0agent .all).policy_nonneg u .w11,
-                (cfgBelHigh.L0agent .all).policy_nonneg u .w10,
-                (cfgBelHigh.L0agent .all).policy_nonneg u .w01,
-                (cfgBelHigh.L0agent .all).policy_nonneg u .w00]
-  have hS1s : 0 < (cfgBelHigh.S1agent .all).score w₀ u := by
-    simp only [RSA.RSAConfig.S1agent, RSA.RSAConfig.L0agent, cfgBelHigh, cfg]
-    exact rpow_pos_of_pos hqud _
-  have hS1t := lt_of_lt_of_le hS1s (Finset.single_le_sum
-    (fun u' _ => (cfgBelHigh.S1agent .all).score_nonneg w₀ u') (Finset.mem_univ u))
-  have hS1t' : 0 < (cfgBelHigh.S1agent .all).totalScore w₀ := hS1t
-  have hS1p : 0 < cfgBelHigh.S1 .all w₀ u := by
-    unfold RSA.RSAConfig.S1 Core.RationalAction.policy; rw [if_neg (ne_of_gt hS1t')]
-    exact div_pos hS1s hS1t'
-  have hwp : (0 : ℝ) < cfgBelHigh.worldPrior w₀ := by
-    cases w₀ <;> simp only [cfgBelHigh, cfg, worldPriorQ] <;> push_cast <;> norm_num
-  have hls : 0 < ∑ l : BeliefState, cfgBelHigh.latentPrior w₀ l * cfgBelHigh.S1 l w₀ u :=
-    calc 0 < cfgBelHigh.latentPrior w₀ (BeliefState.all) * cfgBelHigh.S1 .all w₀ u := by
-              rw [show cfgBelHigh.latentPrior w₀ .all = 1 from rfl, one_mul]; exact hS1p
-      _ ≤ ∑ l : BeliefState, cfgBelHigh.latentPrior w₀ l * cfgBelHigh.S1 l w₀ u :=
-            Finset.single_le_sum
-              (fun l _ => mul_nonneg (cfgBelHigh.latentPrior_nonneg w₀ l) (cfgBelHigh.S1_nonneg l w₀ u))
-              (Finset.mem_univ (BeliefState.all))
-  exact lt_of_lt_of_le (show 0 < cfgBelHigh.L1agent.score u w₀ by
-      simp only [RSA.RSAConfig.L1agent]; exact mul_pos hwp hls)
-    (Finset.single_le_sum (fun w' _ => cfgBelHigh.L1agent.score_nonneg u w') (Finset.mem_univ w₀))
+open scoped ENNReal
 
-set_option maxHeartbeats 800000 in
-private theorem high_score_w10 (u : Utterance) :
-    cfgBelHigh.L1agent.score u .w10 =
-    (1/2 : ℝ) * cfgBelHigh.L1agent.score u .w11 := by
-  simp only [RSA.RSAConfig.L1agent]
-  simp_rw [show ∀ l, cfgBelHigh.S1 l .w10 u = cfgBelHigh.S1 l .w11 u from fun _ => rfl]
-  simp_rw [show ∀ l, cfgBelHigh.latentPrior .w10 l = cfgBelHigh.latentPrior .w11 l from fun _ => rfl]
-  simp only [cfgBelHigh, cfg, worldPriorQ]; push_cast; ring
+private theorem sumUtts (f : Utterance → ℝ≥0∞) :
+    ∑' u, f u = f .knowPos + f .knowNeg + f .thinkPos + f .thinkNeg +
+      f .cPos + f .cNeg := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset Utterance)
+      = {.knowPos, .knowNeg, .thinkPos, .thinkNeg, .cPos, .cNeg} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
 
-set_option maxHeartbeats 800000 in
-private theorem high_score_w00 (u : Utterance) :
-    cfgBelHigh.L1agent.score u .w00 =
-    (1/2 : ℝ) * cfgBelHigh.L1agent.score u .w01 := by
-  simp only [RSA.RSAConfig.L1agent]
-  simp_rw [show ∀ l, cfgBelHigh.S1 l .w00 u = cfgBelHigh.S1 l .w01 u from fun _ => rfl]
-  simp_rw [show ∀ l, cfgBelHigh.latentPrior .w00 l = cfgBelHigh.latentPrior .w01 l from fun _ => rfl]
-  simp only [cfgBelHigh, cfg, worldPriorQ]; push_cast; ring
+private theorem sumBS (f : BeliefState → ℝ≥0∞) :
+    ∑' bs, f bs = f .onlyW11 + f .onlyW10 + f .onlyW01 + f .onlyW00 +
+      f .belTrue + f .belFalse + f .cTrue + f .cFalse +
+      f .diagonal + f .antiDiagonal +
+      f .notW11 + f .notW10 + f .notW01 + f .notW00 + f .all := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset BeliefState)
+      = {.onlyW11, .onlyW10, .onlyW01, .onlyW00, .belTrue, .belFalse, .cTrue,
+         .cFalse, .diagonal, .antiDiagonal, .notW11, .notW10, .notW01,
+         .notW00, .all} from rfl]
+  repeat rw [Finset.sum_insert (by decide)]
+  rw [Finset.sum_singleton]
+  ring
 
-private theorem high_totalScore_expand (u : Utterance) :
-    cfgBelHigh.L1agent.totalScore u =
-    cfgBelHigh.L1agent.score u .w11 + cfgBelHigh.L1agent.score u .w10 +
-    cfgBelHigh.L1agent.score u .w01 + cfgBelHigh.L1agent.score u .w00 := by
-  unfold Core.RationalAction.totalScore; rw [worldState_univ]
-  simp only [Finset.sum_insert (show WorldState.w11 ∉ ({.w10, .w01, .w00} : Finset WorldState) by decide),
-             Finset.sum_insert (show WorldState.w10 ∉ ({.w01, .w00} : Finset WorldState) by decide),
-             Finset.sum_insert (show WorldState.w01 ∉ ({.w00} : Finset WorldState) by decide),
-             Finset.sum_singleton]; ring
+private theorem sumWs (f : WorldState → ℝ≥0∞) :
+    ∑' w, f w = f .w11 + f .w10 + f .w01 + f .w00 := by
+  rw [tsum_fintype,
+    show (Finset.univ : Finset WorldState) = {.w11, .w10, .w01, .w00} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
 
-set_option maxHeartbeats 1600000 in
-/-- Under BEL? QUD, L1's world-marginal for C equals the prior P(C) for every
-    utterance. S1 scores depend on w only through w.bel, so the complement
-    dimension washes out in the marginal:
+variable {pC : ℚ}
 
-    L1_marginal(C|u, BEL?) = Σ_{w:C(w)} P(w)·f(u,w.bel) / Σ_w P(w)·f(u,w.bel)
-                            = (pC/2)·(f₁+f₀) / ((1/2)·(f₁+f₀)) = pC. -/
+/-- PMF speaker (eq. 6 at α = 10, zero cost), dite-total. -/
+noncomputable def s1PMF (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState) :
+    PMF Utterance :=
+  if h : (∑' u, ENNReal.ofReal ((s1WeightQ qud pC bs w u : ℝ))) ≠ 0 then
+    PMF.normalize (fun u => ENNReal.ofReal ((s1WeightQ qud pC bs w u : ℝ))) h
+      (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
+  else PMF.pure .cPos
+
+private theorem sumW_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
+    (w : WorldState) :
+    (∑' u, ENNReal.ofReal ((s1WeightQ qud pC bs w u : ℝ)))
+      = ENNReal.ofReal ((s1ZQ qud pC bs w : ℝ)) := by
+  rw [tsum_fintype, ← ENNReal.ofReal_sum_of_nonneg
+    (fun u _ => by exact_mod_cast s1WeightQ_nonneg h0 h1 qud bs w u)]
+  congr 1
+  push_cast [s1ZQ]
+  rfl
+
+theorem s1PMF_apply (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
+    (w : WorldState) (u : Utterance) :
+    s1PMF qud pC bs w u = ENNReal.ofReal ((s1ValQ qud pC bs w u : ℝ)) := by
+  unfold s1PMF
+  by_cases hZ : (0 : ℚ) < s1ZQ qud pC bs w
+  · rw [dif_pos (by rw [sumW_eq h0 h1, ENNReal.ofReal_ne_zero_iff]; exact_mod_cast hZ),
+      PMF.normalize_apply, sumW_eq h0 h1,
+      ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hZ),
+      ← ENNReal.ofReal_mul (by exact_mod_cast s1WeightQ_nonneg h0 h1 qud bs w u),
+      show s1ValQ qud pC bs w u = s1WeightQ qud pC bs w u / s1ZQ qud pC bs w from by
+        rw [s1ValQ, if_neg hZ.ne']]
+    congr 1
+    push_cast
+    rw [div_eq_mul_inv]
+  · have hZ0 : s1ZQ qud pC bs w = 0 :=
+      le_antisymm (not_lt.mp hZ) (s1ZQ_nonneg h0 h1 qud bs w)
+    rw [dif_neg (by rw [sumW_eq h0 h1, hZ0]; simp),
+      show s1ValQ qud pC bs w u = (if u = .cPos then 1 else 0) from by
+        rw [s1ValQ, if_pos hZ0]]
+    by_cases hu : u = .cPos <;> simp [PMF.pure_apply, hu]
+
+/-- Listener world score (eq. 7; uniform assumption prior factors out). -/
+noncomputable def wScore (qud : QUD) (pC : ℚ) (u : Utterance) (w : WorldState) :
+    ℝ≥0∞ :=
+  ENNReal.ofReal ((worldPriorQ pC w : ℝ)) * ∑' bs, s1PMF qud pC bs w u
+
+theorem wScore_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance)
+    (w : WorldState) :
+    wScore qud pC u w = ENNReal.ofReal ((worldScoreQ qud pC u w : ℝ)) := by
+  unfold wScore
+  rw [tsum_fintype,
+    Finset.sum_congr rfl (fun bs _ => s1PMF_apply h0 h1 qud bs w u),
+    ← ENNReal.ofReal_sum_of_nonneg (fun bs _ => by
+      exact_mod_cast s1ValQ_nonneg h0 h1 qud bs w u),
+    ← ENNReal.ofReal_mul (by exact_mod_cast worldPriorQ_nonneg pC h0 h1 w)]
+  congr 1
+  push_cast [worldScoreQ]
+  rfl
+
+private theorem sumScore_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance) :
+    (∑' w, wScore qud pC u w) = ENNReal.ofReal ((wTotalQ qud pC u : ℝ)) := by
+  rw [tsum_fintype, Finset.sum_congr rfl (fun w _ => wScore_eq h0 h1 qud u w),
+    ← ENNReal.ofReal_sum_of_nonneg (fun w _ => by
+      exact_mod_cast worldScoreQ_nonneg h0 h1 qud u w)]
+  congr 1
+  push_cast [wTotalQ]
+  rfl
+
+/-- Pragmatic listener over worlds (eq. 7), dite-total. -/
+noncomputable def l1World (qud : QUD) (pC : ℚ) (u : Utterance) : PMF WorldState :=
+  if h : (∑' w, wScore qud pC u w) ≠ 0 then
+    PMF.normalize (wScore qud pC u) h
+      (ENNReal.tsum_ne_top_of_fintype fun _ =>
+        ENNReal.mul_ne_top ENNReal.ofReal_ne_top
+          (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _))
+  else PMF.uniformOfFintype WorldState
+
+private theorem l1World_apply (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD)
+    (u : Utterance) (hpos : (∑' w, wScore qud pC u w) ≠ 0)
+    (w : WorldState) :
+    l1World qud pC u w
+      = ENNReal.ofReal ((worldScoreQ qud pC u w : ℝ)) *
+        (∑' w', wScore qud pC u w')⁻¹ := by
+  unfold l1World
+  rw [dif_pos hpos, PMF.normalize_apply, wScore_eq h0 h1 qud u w]
+
+/-- The listener's C-marginal. -/
+noncomputable def l1CEvent (qud : QUD) (pC : ℚ) (u : Utterance) : ℝ≥0∞ :=
+  ∑' w, if w.c then l1World qud pC u w else 0
+
+private theorem cEventQ_expand (qud : QUD) (u : Utterance) :
+    cEventQ qud pC u = worldScoreQ qud pC u .w11 + worldScoreQ qud pC u .w01 := by
+  rw [cEventQ, show (Finset.univ : Finset WorldState) = {.w11, .w10, .w01, .w00}
+      from rfl]
+  repeat rw [Finset.sum_insert (by decide)]
+  rw [Finset.sum_singleton]
+  simp +decide
+
+private theorem l1CEvent_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD)
+    (u : Utterance) (hpos : (∑' w, wScore qud pC u w) ≠ 0) :
+    l1CEvent qud pC u
+      = ENNReal.ofReal ((cEventQ qud pC u : ℝ)) *
+        (ENNReal.ofReal ((wTotalQ qud pC u : ℝ)))⁻¹ := by
+  unfold l1CEvent
+  rw [sumWs]
+  simp +decide only [if_true, if_false, add_zero]
+  simp only [l1World_apply h0 h1 qud u hpos]
+  rw [← add_mul, ← ENNReal.ofReal_add
+      (by exact_mod_cast worldScoreQ_nonneg h0 h1 qud u _)
+      (by exact_mod_cast worldScoreQ_nonneg h0 h1 qud u _),
+    sumScore_eq h0 h1 qud u, cEventQ_expand]
+  congr 2
+  push_cast
+  rfl
+
+/-- Division form for the marginal identities. -/
+private theorem ofReal_mul_inv_eq {b c : ℝ} (hb : 0 < b) (hc : 0 ≤ c) :
+    ENNReal.ofReal (c * b) * (ENNReal.ofReal b)⁻¹ = ENNReal.ofReal c := by
+  rw [ENNReal.ofReal_mul hc, mul_assoc,
+    ENNReal.mul_inv_cancel (by rw [ENNReal.ofReal_ne_zero_iff]; exact hb)
+      ENNReal.ofReal_ne_top, mul_one]
+
+/-- Cross-normaliser comparison for the strict predictions. -/
+private theorem ofReal_div_lt {a b c d : ℝ} (hb : 0 < b) (hd : 0 < d)
+    (hc : 0 < c) (h : a * d < c * b) :
+    ENNReal.ofReal a * (ENNReal.ofReal b)⁻¹ <
+      ENNReal.ofReal c * (ENNReal.ofReal d)⁻¹ := by
+  rw [← div_eq_mul_inv, ← div_eq_mul_inv, ← ENNReal.ofReal_div_of_pos hb,
+    ← ENNReal.ofReal_div_of_pos hd]
+  exact (ENNReal.ofReal_lt_ofReal_iff (div_pos hc hd)).mpr
+    ((div_lt_div_iff₀ hb hd).mpr h)
+
+end PMFFace
+
+section KernelFacts
+
+/-! The model's arithmetic content, kernel-verified over the exact-ℚ scores. -/
+
+private theorem belHigh_pos : ∀ u, (0:ℚ) < wTotalQ .bel (2/3) u := by decide +kernel
+
+private theorem belLow_pos : ∀ u, (0:ℚ) < wTotalQ .bel (1/3) u := by decide +kernel
+
+private theorem cHigh_pos : ∀ u, (0:ℚ) < wTotalQ .c (2/3) u := by decide +kernel
+
+private theorem cLow_pos : ∀ u, (0:ℚ) < wTotalQ .c (1/3) u := by decide +kernel
+
+private theorem belHigh_id :
+    ∀ u, cEventQ .bel (2/3) u = 2/3 * wTotalQ .bel (2/3) u := by decide +kernel
+
+private theorem belLow_id :
+    ∀ u, cEventQ .bel (1/3) u = 1/3 * wTotalQ .bel (1/3) u := by decide +kernel
+
+private theorem cHigh_thinkNeg_pos : (0:ℚ) < cEventQ .c (2/3) .thinkNeg := by
+  decide +kernel
+
+private theorem cHigh_knowNeg_pos : (0:ℚ) < cEventQ .c (2/3) .knowNeg := by
+  decide +kernel
+
+private theorem belHigh_knowNeg_pos : (0:ℚ) < cEventQ .bel (2/3) .knowNeg := by
+  decide +kernel
+
+private theorem cqud_cross :
+    cEventQ .c (2/3) .knowNeg * wTotalQ .c (2/3) .thinkNeg <
+    cEventQ .c (2/3) .thinkNeg * wTotalQ .c (2/3) .knowNeg := by decide +kernel
+
+private theorem prior_cross :
+    cEventQ .c (1/3) .knowNeg * wTotalQ .c (2/3) .knowNeg <
+    cEventQ .c (2/3) .knowNeg * wTotalQ .c (1/3) .knowNeg := by decide +kernel
+
+private theorem qud_cross :
+    cEventQ .c (2/3) .knowNeg * wTotalQ .bel (2/3) .knowNeg <
+    cEventQ .bel (2/3) .knowNeg * wTotalQ .c (2/3) .knowNeg := by decide +kernel
+
+end KernelFacts
+
+section PMFFace
+
+open scoped ENNReal
+
+private theorem wZpos_belHigh (u : Utterance) :
+    (∑' w, wScore .bel (2/3) u w) ≠ 0 := by
+  rw [sumScore_eq (by norm_num) (by norm_num) .bel u, ENNReal.ofReal_ne_zero_iff]
+  exact_mod_cast belHigh_pos u
+
+private theorem wZpos_belLow (u : Utterance) :
+    (∑' w, wScore .bel (1/3) u w) ≠ 0 := by
+  rw [sumScore_eq (by norm_num) (by norm_num) .bel u, ENNReal.ofReal_ne_zero_iff]
+  exact_mod_cast belLow_pos u
+
+private theorem wZpos_cHigh (u : Utterance) :
+    (∑' w, wScore .c (2/3) u w) ≠ 0 := by
+  rw [sumScore_eq (by norm_num) (by norm_num) .c u, ENNReal.ofReal_ne_zero_iff]
+  exact_mod_cast cHigh_pos u
+
+private theorem wZpos_cLow (u : Utterance) :
+    (∑' w, wScore .c (1/3) u w) ≠ 0 := by
+  rw [sumScore_eq (by norm_num) (by norm_num) .c u, ENNReal.ofReal_ne_zero_iff]
+  exact_mod_cast cLow_pos u
+
+end PMFFace
+
+/-! ### Listener predictions -/
+
+open scoped ENNReal in
+/-- Under the BEL? QUD the C-marginal equals the prior, for every utterance:
+S1 depends on the world only through its BEL-cell, so the C-dimension washes
+out of the world posterior. Projection is invisible at the world marginal. -/
 theorem bel_qud_marginal_eq_prior_high (u : Utterance) :
-    cfgBelHigh.L1_marginal u (fun w => w.c = true) = 2/3 := by
-  have h := ne_of_gt (high_totalScore_pos u)
-  unfold RSA.RSAConfig.L1_marginal RSA.RSAConfig.L1
-  simp only [Core.RationalAction.policy, h, ↓reduceIte]
-  rw [← Finset.sum_div, c_filter, Finset.sum_pair (by decide : WorldState.w11 ≠ WorldState.w01)]
-  rw [high_totalScore_expand, high_score_w10, high_score_w00]
-  rw [high_totalScore_expand, high_score_w10, high_score_w00] at h
-  rw [div_eq_iff h]; ring
+    l1CEvent .bel (2/3) u = ENNReal.ofReal (2/3) := by
+  rw [l1CEvent_eq (by norm_num) (by norm_num) .bel u (wZpos_belHigh u),
+    show ((cEventQ .bel (2/3) u : ℝ)) = 2/3 * ((wTotalQ .bel (2/3) u : ℝ)) from by
+      rw [belHigh_id u]; push_cast; ring]
+  exact ofReal_mul_inv_eq (by exact_mod_cast belHigh_pos u) (by norm_num)
 
--- ---------- low-prior analogues ----------
-
-private theorem meaning_pos_low (u : Utterance) :
-    ∃ w₀, 0 < cfgBelLow.meaning cfgBelLow.initial .all u w₀ := by
-  cases u
-  · exact ⟨.w11, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w11 && literalMeaning .knowPos .w11
-                        then (worldPriorQ (1/3) .w11 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, factivePos,
-        HasBelief.bel, WorldState.bel, HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w10, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w10 && literalMeaning .knowNeg .w10
-                        then (worldPriorQ (1/3) .w10 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, factiveNeg,
-        HasBelief.bel, WorldState.bel, HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w11, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w11 && literalMeaning .thinkPos .w11
-                        then (worldPriorQ (1/3) .w11 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, nonFactivePos,
-        HasBelief.bel, WorldState.bel, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w01, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w01 && literalMeaning .thinkNeg .w01
-                        then (worldPriorQ (1/3) .w01 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning, nonFactiveNeg,
-        HasBelief.bel, WorldState.bel, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w11, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w11 && literalMeaning .cPos .w11
-                        then (worldPriorQ (1/3) .w11 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning,
-        HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-  · exact ⟨.w10, by
-      change (0 : ℝ) < if speakerCredenceBool .all .w10 && literalMeaning .cNeg .w10
-                        then (worldPriorQ (1/3) .w10 : ℝ) else 0
-      simp only [speakerCredenceBool, literalMeaning,
-        HasComplement.c, WorldState.c, worldPriorQ]; push_cast; norm_num⟩
-
-set_option maxHeartbeats 1600000 in
-private theorem low_totalScore_pos (u : Utterance) :
-    0 < cfgBelLow.L1agent.totalScore u := by
-  obtain ⟨w₀, hm⟩ := meaning_pos_low u
-  have hL0t := lt_of_lt_of_le hm (Finset.single_le_sum
-    (fun w' _ => cfgBelLow.meaning_nonneg cfgBelLow.initial .all u w') (Finset.mem_univ w₀))
-  have hL0t' : 0 < (cfgBelLow.L0agent .all).totalScore u := hL0t
-  have hL0p : 0 < (cfgBelLow.L0agent .all).policy u w₀ := by
-    unfold Core.RationalAction.policy; rw [if_neg (ne_of_gt hL0t')]; exact div_pos hm hL0t'
-  have hqud : 0 < qudAggregate .bel ((cfgBelLow.L0agent .all).policy u) w₀ := by
-    cases w₀ <;> simp only [qudAggregate] <;>
-      linarith [(cfgBelLow.L0agent .all).policy_nonneg u .w11,
-                (cfgBelLow.L0agent .all).policy_nonneg u .w10,
-                (cfgBelLow.L0agent .all).policy_nonneg u .w01,
-                (cfgBelLow.L0agent .all).policy_nonneg u .w00]
-  have hS1s : 0 < (cfgBelLow.S1agent .all).score w₀ u := by
-    simp only [RSA.RSAConfig.S1agent, RSA.RSAConfig.L0agent, cfgBelLow, cfg]
-    exact rpow_pos_of_pos hqud _
-  have hS1t := lt_of_lt_of_le hS1s (Finset.single_le_sum
-    (fun u' _ => (cfgBelLow.S1agent .all).score_nonneg w₀ u') (Finset.mem_univ u))
-  have hS1t' : 0 < (cfgBelLow.S1agent .all).totalScore w₀ := hS1t
-  have hS1p : 0 < cfgBelLow.S1 .all w₀ u := by
-    unfold RSA.RSAConfig.S1 Core.RationalAction.policy; rw [if_neg (ne_of_gt hS1t')]
-    exact div_pos hS1s hS1t'
-  have hwp : (0 : ℝ) < cfgBelLow.worldPrior w₀ := by
-    cases w₀ <;> simp only [cfgBelLow, cfg, worldPriorQ] <;> push_cast <;> norm_num
-  have hls : 0 < ∑ l : BeliefState, cfgBelLow.latentPrior w₀ l * cfgBelLow.S1 l w₀ u :=
-    calc 0 < cfgBelLow.latentPrior w₀ (BeliefState.all) * cfgBelLow.S1 .all w₀ u := by
-              rw [show cfgBelLow.latentPrior w₀ .all = 1 from rfl, one_mul]; exact hS1p
-      _ ≤ ∑ l : BeliefState, cfgBelLow.latentPrior w₀ l * cfgBelLow.S1 l w₀ u :=
-            Finset.single_le_sum
-              (fun l _ => mul_nonneg (cfgBelLow.latentPrior_nonneg w₀ l) (cfgBelLow.S1_nonneg l w₀ u))
-              (Finset.mem_univ (BeliefState.all))
-  exact lt_of_lt_of_le (show 0 < cfgBelLow.L1agent.score u w₀ by
-      simp only [RSA.RSAConfig.L1agent]; exact mul_pos hwp hls)
-    (Finset.single_le_sum (fun w' _ => cfgBelLow.L1agent.score_nonneg u w') (Finset.mem_univ w₀))
-
-set_option maxHeartbeats 800000 in
-private theorem low_score_w10 (u : Utterance) :
-    cfgBelLow.L1agent.score u .w10 =
-    (2 : ℝ) * cfgBelLow.L1agent.score u .w11 := by
-  simp only [RSA.RSAConfig.L1agent]
-  simp_rw [show ∀ l, cfgBelLow.S1 l .w10 u = cfgBelLow.S1 l .w11 u from fun _ => rfl]
-  simp_rw [show ∀ l, cfgBelLow.latentPrior .w10 l = cfgBelLow.latentPrior .w11 l from fun _ => rfl]
-  simp only [cfgBelLow, cfg, worldPriorQ]; push_cast; ring
-
-set_option maxHeartbeats 800000 in
-private theorem low_score_w00 (u : Utterance) :
-    cfgBelLow.L1agent.score u .w00 =
-    (2 : ℝ) * cfgBelLow.L1agent.score u .w01 := by
-  simp only [RSA.RSAConfig.L1agent]
-  simp_rw [show ∀ l, cfgBelLow.S1 l .w00 u = cfgBelLow.S1 l .w01 u from fun _ => rfl]
-  simp_rw [show ∀ l, cfgBelLow.latentPrior .w00 l = cfgBelLow.latentPrior .w01 l from fun _ => rfl]
-  simp only [cfgBelLow, cfg, worldPriorQ]; push_cast; ring
-
-private theorem low_totalScore_expand (u : Utterance) :
-    cfgBelLow.L1agent.totalScore u =
-    cfgBelLow.L1agent.score u .w11 + cfgBelLow.L1agent.score u .w10 +
-    cfgBelLow.L1agent.score u .w01 + cfgBelLow.L1agent.score u .w00 := by
-  unfold Core.RationalAction.totalScore; rw [worldState_univ]
-  simp only [Finset.sum_insert (show WorldState.w11 ∉ ({.w10, .w01, .w00} : Finset WorldState) by decide),
-             Finset.sum_insert (show WorldState.w10 ∉ ({.w01, .w00} : Finset WorldState) by decide),
-             Finset.sum_insert (show WorldState.w01 ∉ ({.w00} : Finset WorldState) by decide),
-             Finset.sum_singleton]; ring
-
-set_option maxHeartbeats 1600000 in
-/-- Same identity for the low-prior configuration: P(C|u, BEL?) = P(C) = 1/3. -/
+open scoped ENNReal in
+/-- The low-prior analogue of `bel_qud_marginal_eq_prior_high`. -/
 theorem bel_qud_marginal_eq_prior_low (u : Utterance) :
-    cfgBelLow.L1_marginal u (fun w => w.c = true) = 1/3 := by
-  have h := ne_of_gt (low_totalScore_pos u)
-  unfold RSA.RSAConfig.L1_marginal RSA.RSAConfig.L1
-  simp only [Core.RationalAction.policy, h, ↓reduceIte]
-  rw [← Finset.sum_div, c_filter, Finset.sum_pair (by decide : WorldState.w11 ≠ WorldState.w01)]
-  rw [low_totalScore_expand, low_score_w10, low_score_w00]
-  rw [low_totalScore_expand, low_score_w10, low_score_w00] at h
-  rw [div_eq_iff h]; ring
+    l1CEvent .bel (1/3) u = ENNReal.ofReal (1/3) := by
+  rw [l1CEvent_eq (by norm_num) (by norm_num) .bel u (wZpos_belLow u),
+    show ((cEventQ .bel (1/3) u : ℝ)) = 1/3 * ((wTotalQ .bel (1/3) u : ℝ)) from by
+      rw [belLow_id u]; push_cast; ring]
+  exact ofReal_mul_inv_eq (by exact_mod_cast belLow_pos u) (by norm_num)
 
-set_option maxHeartbeats 1600000 in
-/-- Under C? QUD, knowNeg is evidence AGAINST C: ¬(BEL∧C) is literally
-    compatible with C-false worlds, so an informative speaker uses knowNeg
-    more often when C is false. Thus thinkNeg preserves P(C) better. -/
+open scoped ENNReal in
+/-- Under the C? QUD, knowNeg is evidence against C — ¬(BEL∧C) is compatible
+with C-false worlds — so thinkNeg preserves P(C) better. -/
 theorem c_qud_thinkNeg_higher :
-    cfgCHigh.L1_marginal .thinkNeg (fun w => w.c = true) >
-    cfgCHigh.L1_marginal .knowNeg (fun w => w.c = true) := by
-  rsa_predict
+    l1CEvent .c (2/3) .thinkNeg > l1CEvent .c (2/3) .knowNeg := by
+  rw [gt_iff_lt, l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _),
+    l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _)]
+  exact ofReal_div_lt (by exact_mod_cast cHigh_pos .knowNeg)
+    (by exact_mod_cast cHigh_pos .thinkNeg)
+    (by exact_mod_cast cHigh_thinkNeg_pos)
+    (by exact_mod_cast cqud_cross)
 
-/-! ### Prediction 2a: Utterance Effect (know > think)
+/-! ### Prediction 2a: utterance effect (know > think)
 
-The paper predicts stronger projection for factive know than non-factive
-think (Figure 7a). The full Section 3 model — including utterance cost
-(complex = 2×simple) — produces this direction via the world-marginal.
-Our cost-free model does not:
-- **BEL? QUD**: both utterances yield P(C|u) = P(C) (the identity above)
-- **C? QUD**: the direction is reversed (`c_qud_thinkNeg_higher`)
+The paper derives 2a *with* utterance cost (Figure 7a); the cost-free model
+does not — under BEL? both marginals sit at the prior, and under C? the
+direction reverses (`c_qud_thinkNeg_higher`). Fn. 11's A-marginal measure
+(P(A ⊧ C | u)) may capture the effect without cost; see the module TODO. -/
 
-The reversal is due to cost omission, which changes S1's normalization.
-With cost, simple utterances (cPos, cNeg) dominate S1's softmax via
-exp(−α·C_simple) ≫ exp(−α·C_complex), altering which (world, belief state)
-combinations favor knowNeg vs thinkNeg in L1's posterior.
-
-The paper also notes (fn. 11) that projection can be measured via the
-A-marginal P(A ⊧ C | u) — the probability that the speaker's inferred
-belief state entails C. This measure may capture the utterance effect
-even without cost, since the mechanism works through belief state inference
-rather than world-marginal. -/
-
-set_option maxHeartbeats 3200000 in
-/-- Prediction 2b (prior effect): higher prior increases projection.
-    Under C? QUD, L1 assigns higher probability to C with P(C) = 2/3
-    than with P(C) = 1/3. -/
+open scoped ENNReal in
+/-- Prediction 2b (prior effect): higher prior increases projection. -/
 theorem prediction_2b :
-    cfgCHigh.L1_marginal .knowNeg (fun w => w.c = true) >
-    cfgCLow.L1_marginal .knowNeg (fun w => w.c = true) := by
-  rsa_predict
+    l1CEvent .c (2/3) .knowNeg > l1CEvent .c (1/3) .knowNeg := by
+  rw [gt_iff_lt, l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cLow _),
+    l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _)]
+  exact ofReal_div_lt (by exact_mod_cast cLow_pos .knowNeg)
+    (by exact_mod_cast cHigh_pos .knowNeg)
+    (by exact_mod_cast cHigh_knowNeg_pos)
+    (by exact_mod_cast prior_cross)
 
-set_option maxHeartbeats 3200000 in
-/-- Prediction 2c (QUD effect): BEL? QUD increases projection over C? QUD.
-    Under BEL? QUD, C is not at-issue and L1_marginal(C) = P(C) = 2/3.
-    Under C? QUD, the literal semantics of "doesn't know C" (= ¬(BEL∧C))
-    lowers P(C) from the prior, so BEL? > C?. -/
+open scoped ENNReal in
+/-- Prediction 2c (QUD effect): under BEL? the C-marginal stays at the prior
+(`bel_qud_marginal_eq_prior_high`), while under C? the literal semantics of
+"doesn't know C" lowers it. -/
 theorem prediction_2c :
-    cfgBelHigh.L1_marginal .knowNeg (fun w => w.c = true) >
-    cfgCHigh.L1_marginal .knowNeg (fun w => w.c = true) := by
-  rsa_predict
+    l1CEvent .bel (2/3) .knowNeg > l1CEvent .c (2/3) .knowNeg := by
+  rw [gt_iff_lt, l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _),
+    l1CEvent_eq (by norm_num) (by norm_num) .bel _ (wZpos_belHigh _)]
+  exact ofReal_div_lt (by exact_mod_cast cHigh_pos .knowNeg)
+    (by exact_mod_cast belHigh_pos .knowNeg)
+    (by exact_mod_cast belHigh_knowNeg_pos)
+    (by exact_mod_cast qud_cross)
 
--- ============================================================================
--- §8. Structural Properties
--- ============================================================================
+/-! ### Structural properties -/
 
 /-- "know" entails C (from `factivePos_entails_c`). -/
 theorem know_entails_c : ∀ w, literalMeaning .knowPos w = true → w.c = true :=
@@ -611,31 +634,29 @@ theorem thinkNeg_semantics :
 theorem knowNeg_weaker_than_thinkNeg :
     (Finset.univ.filter (fun w : WorldState => literalMeaning .knowNeg w)).card >
     (Finset.univ.filter (fun w : WorldState => literalMeaning .thinkNeg w)).card := by
-  native_decide
+  decide
 
 /-- The pattern-matched `assumesC` agrees with the generic
     `assumesComplement` from `Factivity`. -/
 theorem assumesC_matches_generic : ∀ bs : BeliefState,
     assumesC bs = assumesComplement (speakerCredenceBool bs)
       [.w11, .w10, .w01, .w00] := by
-  intro bs; cases bs <;> native_decide
+  intro bs; cases bs <;> decide
 
 /-- Exactly 3 of 15 belief states assume C: onlyW11, onlyW01, cTrue. -/
 theorem three_of_fifteen_assume_c :
     (Finset.univ.filter (fun bs : BeliefState => assumesC bs)).card = 3 := by
-  native_decide
+  decide
 
--- ============================================================================
--- §9. Experimental Data
--- ============================================================================
+/-! ### Experimental data -/
 
 /-- Effect size from a linear mixed-effects model. p values are upper bounds
     (paper reports "< .001"). -/
 structure UtteranceEffect where
-  β : Float
-  se : Float
-  t : Float
-  p : Float
+  β : ℚ
+  se : ℚ
+  t : ℚ
+  p : ℚ
   deriving Repr
 
 /-- Exp 1: Utterance effect (know > think). -/
@@ -677,9 +698,7 @@ def directionCorrect : Hypothesis → Bool
   | .prior     => exp1_priorEffect.β > 0
   | .qud       => exp2_qudEffect.β > 0
 
--- ============================================================================
--- §10. BToM Bridge
--- ============================================================================
+/-! ### BToM bridge -/
 
 open Core in
 /-- Classification of BeliefState in BToM terms. -/
@@ -723,25 +742,20 @@ theorem assumesCIndicator_classification :
     assumesCIndicator .all = 0 := by
   refine ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
--- ============================================================================
--- §11. Model–Data Connection
--- ============================================================================
+/-! ### Model–data connection -/
 
 /-- Predictions (2b) and (2c) match experimental effect directions.
     Prediction (2a) requires cost; see the commentary above. -/
 theorem model_predicts_effects :
-    (cfgCHigh.L1_marginal .knowNeg (fun w => w.c = true) >
-     cfgCLow.L1_marginal .knowNeg (fun w => w.c = true)) ∧
-    (cfgBelHigh.L1_marginal .knowNeg (fun w => w.c = true) >
-     cfgCHigh.L1_marginal .knowNeg (fun w => w.c = true)) ∧
+    (l1CEvent .c (2/3) .knowNeg > l1CEvent .c (1/3) .knowNeg) ∧
+    (l1CEvent .bel (2/3) .knowNeg > l1CEvent .c (2/3) .knowNeg) ∧
     directionCorrect .prior = true ∧
     directionCorrect .qud = true :=
   ⟨prediction_2b, prediction_2c,
-   by native_decide, by native_decide⟩
+   by simp only [directionCorrect, exp1_priorEffect, decide_eq_true_eq]; norm_num,
+   by simp only [directionCorrect, exp2_qudEffect, decide_eq_true_eq]; norm_num⟩
 
--- ============================================================================
--- §12. Connection to [degen-tonhauser-2021]
--- ============================================================================
+/-! ### Connection to [degen-tonhauser-2021] -/
 
 /-- The prior effect found by S&T 2025 (β = 0.16 > 0) replicates the positive
     prior effect of [degen-tonhauser-2021] (β = 0.14 categorical, β = 0.28
@@ -751,11 +765,9 @@ theorem model_predicts_effects :
     (`DegenTonhauser2021.sensitive_predicts_modulation`) — and the RSA model's
     `prediction_2b` provides the same explanation here. -/
 theorem prior_effect_consistent_with_dt2021 :
-    exp1_priorEffect.β > 0 := by native_decide
+    exp1_priorEffect.β > 0 := by norm_num [exp1_priorEffect]
 
--- ============================================================================
--- §13. Comparison: Compositional Filtering vs. BToM
--- ============================================================================
+/-! ### Compositional filtering vs BToM -/
 
 /-! Compares the BToM model against compositional filtering ([heim-1983]):
 presuppositions project through connectives via local context computation;
@@ -792,8 +804,8 @@ theorem filtering_know_nontrivial (a c : W → Prop)
     ∃ w, ¬(filteringPrediction_know a c).presup w := by
   obtain ⟨w, ha, hc⟩ := h
   refine ⟨w, ?_⟩
-  simp only [filteringPrediction_know, PartialProp.impFilter, PartialProp.ofProp, PartialProp.condAssert,
-    not_and]
+  simp only [filteringPrediction_know, PartialProp.impFilter, PartialProp.ofProp,
+    PartialProp.condAssert, not_and]
   intro _
   exact fun h_imp => hc (h_imp ha)
 


### PR DESCRIPTION
Three HARD-wave files (19/22), all on the exact-ℚ + PMF-face architecture:

- ScontrasTonhauser2025: α = 10; BEL?-QUD identity L1(C) = P(C) for every utterance; total bridge via matched degenerate-cell fallback; de-Floated.
- PottsLevy2015: the full eq. 10–17 LU + expertise tower at Figure 10's regime via a local pmfOfScores combinator; S2-expertise restated on the true eq. 17 marginal; Figure-10 margins re-verified.
- ScontrasPearl2021Quantification: both models (every-not n=2 across 8 prior configurations; two-not n=4 exact vs at-least) as prior-parametric ℚ chains; all 19 predictions kernel-verified incl. the 1/2-threshold endorsement bounds; certified baseline matches the paper's 0.29; pmf_lt_cross handles the S2 cross-world/cross-config comparisons.

All native_decides converted; mathlib docstring register applied.