### PR TITLE
feat(Semantics/Focus): Antecedent layer — the source of the contrast set

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1684,6 +1684,7 @@ import Linglib.Semantics.Exhaustification.ScalePredictions
 import Linglib.Semantics.Exhaustification.Structural
 import Linglib.Semantics.Exhaustification.Tolerant
 import Linglib.Semantics.Exhaustification.Trivalent
+import Linglib.Semantics.Focus.Control
 import Linglib.Semantics.Focus.ExtractionClash
 import Linglib.Semantics.Focus.Interpretation
 import Linglib.Semantics.Focus.Particles

--- a/Linglib/Semantics/Focus/Control.lean
+++ b/Linglib/Semantics/Focus/Control.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Semantics.Focus.Interpretation
+import Linglib.Semantics.Questions.Hamblin
+
+/-!
+# Focus antecedents
+
+The anaphoric source of the squiggle's contrast set ([rooth-1992]):
+what the preceding discourse supplies — a question, a prior assertion
+to correct, explicitly offered alternatives, or a parallel focus
+([uhmann-1991]'s focus-control taxonomy, adopted by
+[hartmann-zimmermann-2007] §1.2). `Use` classifies the shapes;
+felicity (`Antecedent.Admits`) is `fip` on the antecedent's contrast
+set, uniformly across uses — and `use_not_factorsThrough_contrastSet`
+shows the four-way split is invisible to the semantics.
+
+## Implementation notes
+
+Payloads are flat Hamblin sets (`PropFocusValue`), keeping antecedents
+over finite models `decide`-friendly; the inquisitive layer plugs in
+via `Antecedent.ofQuestion` and `Question.alt`, with
+`alt_which_singleton` identifying the two Hamblin constructions. The
+`assertion` payload is a raw prior proposition; the
+`Discourse.CommonGround.HasAssertion` hookup (a correction/denial
+move) is deferred.
+-/
+
+namespace Semantics.Focus
+
+open Semantics.Focus.Interpretation (fip PropFocusValue qaCongruentWeak)
+
+variable {W : Type*}
+
+/-- The four pragmatic uses of one semantic focus ([uhmann-1991]):
+the image of `Antecedent.use`. -/
+inductive Use where
+  | newInfo      -- controlled by a question
+  | corrective   -- correction of a prior assertion
+  | selective    -- selection from explicitly offered alternatives
+  | contrastive  -- parallel contrast across utterances
+  deriving DecidableEq, Repr, Inhabited
+
+/-- A focus antecedent: the discourse object that supplies the
+squiggle's contrast set. -/
+inductive Antecedent (W : Type*) where
+  /-- A question with (flat Hamblin) denotation `q`. -/
+  | question (q : PropFocusValue W)
+  /-- A prior assertion `p`, corrected among alternatives `alts`. -/
+  | assertion (p : Set W) (alts : PropFocusValue W)
+  /-- Explicitly offered alternatives ('coffee or tea?'). -/
+  | offer (alts : PropFocusValue W)
+  /-- A parallel focus with focus value `alts`. -/
+  | parallel (alts : PropFocusValue W)
+
+/-- The contrast set Γ an antecedent supplies to the squiggle. -/
+def Antecedent.contrastSet : Antecedent W → PropFocusValue W
+  | .question q        => q
+  | .assertion _ alts  => alts
+  | .offer alts        => alts
+  | .parallel alts     => alts
+
+/-- The pragmatic use an antecedent shape licenses. -/
+def Antecedent.use : Antecedent W → Use
+  | .question _     => .newInfo
+  | .assertion _ _  => .corrective
+  | .offer _        => .selective
+  | .parallel _     => .contrastive
+
+/-- Roothian felicity of a focus value against an antecedent: `fip` on
+the antecedent's contrast set. -/
+def Antecedent.Admits (c : Antecedent W) (fv : PropFocusValue W) : Prop :=
+  fip c.contrastSet fv
+
+/-- The question case is the substrate's Q-A congruence. -/
+theorem question_admits_iff (q fv : PropFocusValue W) :
+    (Antecedent.question q).Admits fv ↔ qaCongruentWeak fv q := Iff.rfl
+
+/-- Felicity factors through the contrast set: the semantics sees Γ,
+never the use label. -/
+theorem admits_factorsThrough_contrastSet (fv : PropFocusValue W) :
+    Function.FactorsThrough (Antecedent.Admits · fv)
+      (Antecedent.contrastSet (W := W)) :=
+  fun _ _ h => congrArg (fip · fv) h
+
+/-- Distinct uses can supply one and the same Γ (a question and an
+explicit offer, say), so the four-way split is invisible to the
+Roothian semantics — pragmatic, not semantic. -/
+theorem use_not_factorsThrough_contrastSet :
+    ¬ Function.FactorsThrough (Antecedent.use (W := W))
+        Antecedent.contrastSet :=
+  fun h => absurd (h (a := .question ∅) (b := .offer ∅) rfl)
+    (by simp [Antecedent.use])
+
+/-! ### Hamblin antecedents -/
+
+/-- The flat Hamblin set of complete answers over a domain. -/
+def hamblin (D : Type*) : PropFocusValue D := Set.range fun d => ({d} : Set D)
+
+/-- The wh-question antecedent over a whole domain. -/
+def whAntecedent (D : Type*) : Antecedent D := .question (hamblin D)
+
+theorem whAntecedent_admits (D : Type*) :
+    (whAntecedent D).Admits (hamblin D) := subset_rfl
+
+/-- A `Question` supplies its maximal alternatives as a question
+antecedent — the bridge from the inquisitive layer. -/
+def Antecedent.ofQuestion (q : Question W) : Antecedent W :=
+  .question (Question.alt q)
+
+/-- The maximal alternatives of the inquisitive wh-question over the
+singleton predicates are exactly the flat Hamblin set. -/
+theorem alt_which_singleton (D : Type*) [Nonempty D] :
+    Question.alt (Question.which (Set.univ : Set D) fun d => ({d} : Set D)) =
+      hamblin D := by
+  ext q
+  constructor
+  · intro hq
+    rcases Question.alt_which_iff_left hq with hempty | ⟨d, _, rfl, _⟩
+    · subst hempty
+      obtain ⟨-, hmax⟩ := hq
+      obtain ⟨d₀⟩ := ‹Nonempty D›
+      have hmem : ({d₀} : Set D) ∈
+          Question.which (Set.univ : Set D) fun d => ({d} : Set D) :=
+        Question.mem_which.mpr (Or.inr ⟨d₀, trivial, subset_rfl⟩)
+      exact absurd (hmax _ hmem (Set.empty_subset _)).symm
+        (Set.singleton_ne_empty d₀)
+    · exact ⟨d, rfl⟩
+  · rintro ⟨d, rfl⟩
+    exact Question.mem_alt_which_of_maximal d trivial (Set.singleton_nonempty d)
+      fun d' _ hsub => by
+        rw [Set.singleton_subset_singleton.mp hsub]
+
+/-- The inquisitive wh-question and the flat Hamblin antecedent
+coincide. -/
+theorem ofQuestion_which_eq_whAntecedent (D : Type*) [Nonempty D] :
+    Antecedent.ofQuestion
+        (Question.which (Set.univ : Set D) fun d => ({d} : Set D)) =
+      whAntecedent D :=
+  congrArg Antecedent.question (alt_which_singleton D)
+
+end Semantics.Focus

--- a/Linglib/Studies/HartmannZimmermann2007.lean
+++ b/Linglib/Studies/HartmannZimmermann2007.lean
@@ -1,7 +1,7 @@
 import Linglib.Fragments.Hausa.Focus
 import Linglib.Fragments.Hausa.TAM
 import Linglib.Core.Logic.FactorsThroughOn
-import Linglib.Semantics.Focus.Interpretation
+import Linglib.Semantics.Focus.Control
 import Linglib.Data.Examples.HartmannZimmermann2007
 
 /-!
@@ -19,7 +19,9 @@ Mapping Hypothesis" (§3.1), the label following
 [vallduvi-vilkuna-1998]'s phrase "the meaning-structure mapping"; the
 shared schema is `Function.FactorsThroughOn`
 (`Core.Logic.FactorsThroughOn`), making the Hungarian/Hausa contrast
-a difference of verdict on a single set-theoretic predicate.
+a difference of verdict on a single set-theoretic predicate. The §1.2
+control taxonomy (`Antecedent`, `Use`) and its factor-through theorems
+live in `Semantics/Focus/Control.lean`.
 
 Subject foci in TAMs lacking a Relative form (future, habitual,
 subjunctive) are "syntactically and morphologically unmarked" (p. 4);
@@ -36,7 +38,7 @@ situ" — only the categorical no-determination claim is a theorem.
 ## TODO
 
 * §3.2.5 exhaustivity contrast against Kiss 1998 requires an
-  alternatives-semantics exhaustivity operator beyond `PragType` tags.
+  alternatives-semantics exhaustivity operator beyond `Use` tags.
 * §2.3 multiple foci: co-occurrence of one ex-situ focus with in-situ
   foci (18a-c).
 * §4 focus pied-piping / partial focus movement and the (47) "Ex-Situ
@@ -54,89 +56,7 @@ situ" — only the categorical no-determination claim is a theorem.
 namespace HartmannZimmermann2007
 
 open Hausa
-open Semantics.Focus.Interpretation (fip PropFocusValue qaCongruentWeak)
-
-/-! ## Pragmatic focus types (§1.2) -/
-
-/-- The four pragmatic uses of one Roothian semantic focus (§1.2, 1a–d;
-after [uhmann-1991]): the image of `FocusControl.pragType`. The §3.2.5
-*exhaustive* case is deferred to a real exhaustivity operator. -/
-inductive PragType where
-  | newInfo      -- (1a) Q/A new-information focus
-  | corrective   -- (1b) correction of prior assertion
-  | selective    -- (1c) selection from explicit alternatives
-  | contrastive  -- (1d) parallel contrast across utterances
-  deriving DecidableEq, Repr, Inhabited
-
-/-! ## Focus control (§1.2)
-
-The four uses are distinguished by what the preceding context supplies
-("the context controls the focus", after [uhmann-1991]); the
-contrast-set machinery is `Semantics.Focus.Interpretation`. -/
-
-variable {W : Type*}
-
-/-- A focus-controlling context (§1.2): the discourse object that
-supplies the contrast set. -/
-inductive FocusControl (W : Type*) where
-  /-- (1a) A *wh*-question with denotation `q`. -/
-  | question (q : PropFocusValue W)
-  /-- (1b) A prior assertion `p` corrected among alternatives `alts`. -/
-  | assertion (p : Set W) (alts : PropFocusValue W)
-  /-- (1c) Explicitly offered alternatives. -/
-  | alternatives (alts : PropFocusValue W)
-  /-- (1d) A parallel focus with focus value `alts`. -/
-  | parallel (alts : PropFocusValue W)
-
-/-- The contrast set Γ a control supplies to the squiggle. -/
-def FocusControl.contrastSet : FocusControl W → PropFocusValue W
-  | .question q       => q
-  | .assertion _ alts => alts
-  | .alternatives alts => alts
-  | .parallel alts    => alts
-
-/-- The pragmatic use a control shape licenses. -/
-def FocusControl.pragType : FocusControl W → PragType
-  | .question _     => .newInfo
-  | .assertion _ _  => .corrective
-  | .alternatives _ => .selective
-  | .parallel _     => .contrastive
-
-/-- Roothian felicity of a focus value against a control: `fip` on the
-control's contrast set. -/
-def FocusControl.Admits (c : FocusControl W) (fv : PropFocusValue W) : Prop :=
-  fip c.contrastSet fv
-
-/-- The (1a) case is the substrate's Q-A congruence. -/
-theorem question_admits_iff (q fv : PropFocusValue W) :
-    (FocusControl.question q).Admits fv ↔ qaCongruentWeak fv q := Iff.rfl
-
-/-- The Hamblin set of complete answers over a domain `D`. -/
-def hamblin (D : Type*) : PropFocusValue D := Set.range fun d => ({d} : Set D)
-
-/-- A *wh*-question control: the context supplies the full Hamblin set. -/
-def whControl (D : Type*) : FocusControl D := .question (hamblin D)
-
-theorem whControl_admits (D : Type*) : (whControl D).Admits (hamblin D) :=
-  subset_rfl
-
-/-- Felicity factors through the contrast set: the semantics sees Γ,
-never the pragmatic label. -/
-theorem admits_factorsThrough_contrastSet (fv : PropFocusValue W) :
-    Function.FactorsThrough (FocusControl.Admits · fv)
-      (FocusControl.contrastSet (W := W)) :=
-  fun _ _ h => congrArg (fip · fv) h
-
-/-- Distinct pragmatic uses can supply one and the same Γ, so the
-four-way split is invisible to the Roothian semantics — pragmatic, not
-semantic (§1.2). Concretely: a *wh*-question and an explicit offer
-('Coffee or tea?', `control30`) can supply the same contrast set while
-licensing newInfo vs selective uses. -/
-theorem pragType_not_factorsThrough_contrastSet :
-    ¬ Function.FactorsThrough (FocusControl.pragType (W := W))
-        FocusControl.contrastSet :=
-  fun h => absurd (h (a := .question ∅) (b := .alternatives ∅) rfl)
-    (by simp [FocusControl.pragType])
+open Semantics.Focus (Antecedent Use hamblin whAntecedent)
 
 /-! ## What is focused (§2.2.2) -/
 
@@ -153,7 +73,7 @@ inductive Focused where
 constituent. -/
 structure FocusUtterance where
   cfg      : FocusConfig
-  pragType : PragType
+  pragType : Use
   focused  : Focused
   deriving Repr
 
@@ -184,27 +104,27 @@ inductive Caller | daudaa | other
 inductive Traveler | audu | other
 
 /-- 'What is Kande cooking?' ((22)). -/
-def control22 : FocusControl Dish := whControl Dish
+def control22 : Antecedent Dish := whAntecedent Dish
 /-- 'From which city do you come?' ((23)). -/
-def control23 : FocusControl City := whControl City
+def control23 : Antecedent City := whAntecedent City
 /-- 'Was it his mother who died?' — asserted alternative to correct ((24)). -/
-def control24 : FocusControl Deceased :=
+def control24 : Antecedent Deceased :=
   .assertion {Deceased.mother} (hamblin Deceased)
 /-- 'It is twenty Naira that you will pay' — assertion to correct ((25)). -/
-def control25 : FocusControl Price :=
+def control25 : Antecedent Price :=
   .assertion {Price.twenty} (hamblin Price)
 /-- '…you shouldn't pass in front of him' — parallel focus ((26)). -/
-def control26 : FocusControl Route := .parallel (hamblin Route)
+def control26 : Antecedent Route := .parallel (hamblin Route)
 /-- 'no one is chatting…' — parallel focus ((27)). -/
-def control27 : FocusControl Activity := .parallel (hamblin Activity)
+def control27 : Antecedent Activity := .parallel (hamblin Activity)
 /-- 'A whole or a half?' — explicitly offered alternatives ((29)). -/
-def control29 : FocusControl Amount := .alternatives (hamblin Amount)
+def control29 : Antecedent Amount := .offer (hamblin Amount)
 /-- 'Coffee or tea?' — explicitly offered alternatives ((30)). -/
-def control30 : FocusControl Drink := .alternatives (hamblin Drink)
+def control30 : Antecedent Drink := .offer (hamblin Drink)
 /-- 'Who is calling her?' ((17)). -/
-def control17 : FocusControl Caller := whControl Caller
+def control17 : Antecedent Caller := whAntecedent Caller
 /-- 'Who will go to Germany?' ((8)). -/
-def control8 : FocusControl Traveler := whControl Traveler
+def control8 : Antecedent Traveler := whAntecedent Traveler
 
 /-- Roothian felicity holds uniformly: every §3.2 control admits its
 answer's focus value. One semantics, four pragmatic uses. -/
@@ -234,19 +154,19 @@ theorem ex26_parallel_contrast :
 /-! ## The 8-cell empirical matrix (§3.2)
 
 Each cell's pragmatic type is *computed* from its controlling context:
-the constructors take a `FocusControl`, not a tag. -/
+the constructors take a `Semantics.Focus.Antecedent`, not a tag. -/
 
 private def mkExSituUtt (pac : PAC) (g : Gender) (sg hasStab : Bool)
     (h : pac.tam.HasRelativeForm → pac.mode = .relative)
-    {W : Type*} (ctl : FocusControl W) (foc : Focused := .nonSubject) :
+    {W : Type*} (ctl : Antecedent W) (foc : Focused := .nonSubject) :
     FocusUtterance :=
-  ⟨mkExSitu pac g sg h hasStab, ctl.pragType, foc⟩
+  ⟨mkExSitu pac g sg h hasStab, ctl.use, foc⟩
 
 private def mkInSituUtt (pac : PAC) (g : Gender) (sg : Bool)
-    {W : Type*} (ctl : FocusControl W) (foc : Focused := .nonSubject)
+    {W : Type*} (ctl : Antecedent W) (foc : Focused := .nonSubject)
     (hasStab : Bool := false) :
     FocusUtterance :=
-  ⟨mkInSitu pac g sg hasStab, ctl.pragType, foc⟩
+  ⟨mkInSitu pac g sg hasStab, ctl.use, foc⟩
 
 /-- Ex-situ new-information focus ((22), `Examples.ex22`). -/
 def exSitu_newInfo : FocusUtterance :=
@@ -394,7 +314,7 @@ private def strategyLabel : Strategy → String
   | .inSitu => "inSitu"
   | .exSitu => "exSitu"
 
-private def pragLabel : PragType → String
+private def pragLabel : Use → String
   | .newInfo => "newInfo"
   | .corrective => "corrective"
   | .selective => "selective"

--- a/Linglib/Studies/Kiss1998.lean
+++ b/Linglib/Studies/Kiss1998.lean
@@ -97,8 +97,10 @@ def positionFor : FocusType → Position
   | .information      => .postverbal
 
 /-- Class–type compatibility (§3): `universal` is barred from
-identificational focus, `onlyPhrase` from information focus,
-`someIndef` from both. -/
+identificational focus (17b–d); `onlyPhrase` is "obligatorily realized
+as identificational" (§3); `someIndef` is barred from both — starred
+identificationally (17e) and "cannot function as information foci,
+either" (§3). -/
 def ConstituentClass.compatibleWith : ConstituentClass → FocusType → Prop
   | .regular,    _                  => True
   | .universal,  .identificational  => False

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.InformationStructure
 import Linglib.Semantics.Alternatives.AltMeaning
 import Linglib.Semantics.Focus.Interpretation
+import Linglib.Semantics.Focus.Control
 import Linglib.Semantics.Composition.Tree
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Predicates.Verbal
@@ -267,6 +268,27 @@ theorem maryAteBeans_not_in_objectFocus :
 theorem fip_fails_object_focus :
     ¬ fip q_whoAteBeans fv_objectFocus :=
   fun h => maryAteBeans_not_in_objectFocus (h maryAteBeans_in_question)
+
+-- ───────────────────────────────────────────────────────────────────
+-- §6c  The Question as a Focus Antecedent
+-- ───────────────────────────────────────────────────────────────────
+
+/-- 'Who ate the beans?' as a focus antecedent
+    (`Semantics.Focus.Antecedent`): the anaphoric source of the
+    squiggle's contrast set. -/
+def qaAntecedent : Semantics.Focus.Antecedent QAWorld := .question q_whoAteBeans
+
+/-- Question antecedents license the new-information use. -/
+theorem qaAntecedent_use : qaAntecedent.use = .newInfo := rfl
+
+/-- The antecedent admits subject focus — FIP routed through the
+    antecedent layer. -/
+theorem qaAntecedent_admits_subjectFocus :
+    qaAntecedent.Admits fv_subjectFocus := fip_congruent
+
+/-- The antecedent rejects object focus. -/
+theorem qaAntecedent_rejects_objectFocus :
+    ¬ qaAntecedent.Admits fv_objectFocus := fip_fails_object_focus
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- §7  "Only" Association ([rooth-1992] §2.1)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26321,6 +26321,7 @@
 @article{kiss-1998,
   author    = {{\'E}. Kiss, Katalin},
   year      = {1998},
+  doi       = {10.1353/lan.1998.0211},
   title     = {Identificational focus versus information focus},
   journal   = {Language},
   volume    = {74},


### PR DESCRIPTION
B5 of the Focus API consolidation: the Γ-resolution layer graduates to the theory layer with two genuine consumers.

- new `Semantics/Focus/Control.lean`: `Antecedent W` (question / assertion / offer / parallel — Uhmann's focus-control taxonomy as the anaphoric source of the squiggle's contrast set), `Use` as its shape quotient, `Admits` = `fip` on the contrast set, the factor-through theorems (felicity sees Γ, never the use label), and the `Question.alt` bridge (`alt_which_singleton`: the inquisitive wh-question's maximal alternatives are exactly the flat Hamblin set)
- `Studies/HartmannZimmermann2007.lean` re-consumes: local `FocusControl`/`PragType`/`hamblin` machinery deleted (−82 lines), cells built from `Antecedent`
- `Studies/Rooth1992.lean` rewired as second consumer: 'Who ate the beans?' as a `.question` antecedent, FIP facts routed through `Admits`
- includes the Kiss 1998 source-verification commit stranded when #1138 merged (verbatim quotes grounded; kiss-1998 DOI)