### PR TITLE
feat(Semantics/Focus): factorization, antichain law, aSet bridge

### DIFF
--- a/Linglib/Core/Logic/FactorsThroughOn.lean
+++ b/Linglib/Core/Logic/FactorsThroughOn.lean
@@ -46,6 +46,23 @@ theorem not_factorsThroughOn_iff_exists_witness {g : α → γ} {f : α → β} 
     ∃ a b, a ∈ s ∧ b ∈ s ∧ f a = f b ∧ g a ≠ g b := by
   simp only [FactorsThroughOn, not_forall, exists_prop]
 
+/-- Factoring through on `s`, existentially: `g` agrees on `s` with some
+function of `f`. The mirror of `Function.factorsThrough_iff` for the
+set-restricted variant. -/
+theorem factorsThroughOn_iff_exists_eqOn [Nonempty γ] {g : α → γ} {f : α → β}
+    {s : Set α} :
+    FactorsThroughOn g f s ↔ ∃ h : β → γ, Set.EqOn g (h ∘ f) s := by
+  constructor
+  · intro hf
+    classical
+    refine ⟨fun b => if hb : ∃ a ∈ s, f a = b then g hb.choose
+      else Classical.arbitrary γ, fun a ha => ?_⟩
+    have hb : ∃ a' ∈ s, f a' = f a := ⟨a, ha, rfl⟩
+    simp only [Function.comp_apply, dif_pos hb]
+    exact (hf hb.choose_spec.1 ha hb.choose_spec.2).symm
+  · rintro ⟨h, hh⟩ a b ha hb hab
+    rw [hh ha, hh hb, Function.comp_apply, Function.comp_apply, hab]
+
 /-- For an **idempotent** `f`, `g` factors through `f` iff `g` is `f`-invariant
 (pointwise `g = g ∘ f`). -/
 theorem factorsThrough_iff_of_idempotent {g : α → γ} {f : α → α} (hf : ∀ a, f (f a) = f a) :

--- a/Linglib/Semantics/Alternatives/AltMeaning.lean
+++ b/Linglib/Semantics/Alternatives/AltMeaning.lean
@@ -1,4 +1,4 @@
-import Mathlib.Tactic.TypeStar
+import Mathlib.Data.Set.Insert
 
 /-!
 # Two-Dimensional Alternative Meanings
@@ -38,5 +38,18 @@ def AltMeaning.unfeatured {α : Type*} (x : α) : AltMeaning α :=
 
 @[simp] theorem AltMeaning.unfeatured_aValue {α : Type*} (x : α) :
     (AltMeaning.unfeatured x).aValue = [x] := rfl
+
+/-- The alternative set as a `Set` — the theory-side carrier; `aValue`
+is its list presentation. -/
+def AltMeaning.aSet {α : Type*} (m : AltMeaning α) : Set α :=
+  {a | a ∈ m.aValue}
+
+@[simp] theorem AltMeaning.mem_aSet {α : Type*} {m : AltMeaning α} {a : α} :
+    a ∈ m.aSet ↔ a ∈ m.aValue := Iff.rfl
+
+@[simp] theorem AltMeaning.unfeatured_aSet {α : Type*} (x : α) :
+    (AltMeaning.unfeatured x).aSet = {x} := by
+  ext a
+  exact List.mem_singleton.trans Set.mem_singleton_iff.symm
 
 end Alternatives

--- a/Linglib/Semantics/Focus/Control.lean
+++ b/Linglib/Semantics/Focus/Control.lean
@@ -70,6 +70,39 @@ def Antecedent.use : Antecedent W → Use
   | .offer _        => .selective
   | .parallel _     => .contrastive
 
+@[simp] theorem contrastSet_question (q : PropFocusValue W) :
+    (Antecedent.question q).contrastSet = q := rfl
+@[simp] theorem contrastSet_assertion (p : Set W) (alts : PropFocusValue W) :
+    (Antecedent.assertion p alts).contrastSet = alts := rfl
+@[simp] theorem contrastSet_offer (alts : PropFocusValue W) :
+    (Antecedent.offer alts).contrastSet = alts := rfl
+@[simp] theorem contrastSet_parallel (alts : PropFocusValue W) :
+    (Antecedent.parallel alts).contrastSet = alts := rfl
+
+@[simp] theorem use_question (q : PropFocusValue W) :
+    (Antecedent.question q).use = .newInfo := rfl
+@[simp] theorem use_assertion (p : Set W) (alts : PropFocusValue W) :
+    (Antecedent.assertion p alts).use = .corrective := rfl
+@[simp] theorem use_offer (alts : PropFocusValue W) :
+    (Antecedent.offer alts).use = .selective := rfl
+@[simp] theorem use_parallel (alts : PropFocusValue W) :
+    (Antecedent.parallel alts).use = .contrastive := rfl
+
+/-- The canonical antecedent of each shape (empty payloads): a section
+of `Antecedent.use`. -/
+def Use.toAntecedent : Use → Antecedent W
+  | .newInfo     => .question ∅
+  | .corrective  => .assertion ∅ ∅
+  | .selective   => .offer ∅
+  | .contrastive => .parallel ∅
+
+@[simp] theorem use_toAntecedent (u : Use) :
+    (Use.toAntecedent (W := W) u).use = u := by cases u <;> rfl
+
+/-- Every pragmatic use is realised by some antecedent shape. -/
+theorem use_surjective : Function.Surjective (Antecedent.use (W := W)) :=
+  fun u => ⟨u.toAntecedent, use_toAntecedent u⟩
+
 /-- Roothian felicity of a focus value against an antecedent: `fip` on
 the antecedent's contrast set. -/
 def Antecedent.Admits (c : Antecedent W) (fv : PropFocusValue W) : Prop :=
@@ -78,6 +111,15 @@ def Antecedent.Admits (c : Antecedent W) (fv : PropFocusValue W) : Prop :=
 /-- The question case is the substrate's Q-A congruence. -/
 theorem question_admits_iff (q fv : PropFocusValue W) :
     (Antecedent.question q).Admits fv ↔ qaCongruentWeak fv q := Iff.rfl
+
+/-- `Admits` is monotone in the focus value. -/
+theorem Antecedent.Admits.mono {c : Antecedent W} {fv fv' : PropFocusValue W}
+    (hc : c.Admits fv) (h : fv ⊆ fv') : c.Admits fv' := hc.trans h
+
+/-- An intersection of focus values is admitted iff both are. -/
+theorem admits_inter_iff {c : Antecedent W} {fv fv' : PropFocusValue W} :
+    c.Admits (fv ∩ fv') ↔ c.Admits fv ∧ c.Admits fv' :=
+  Set.subset_inter_iff
 
 /-- Felicity factors through the contrast set: the semantics sees Γ,
 never the use label. -/
@@ -92,8 +134,7 @@ Roothian semantics — pragmatic, not semantic. -/
 theorem use_not_factorsThrough_contrastSet :
     ¬ Function.FactorsThrough (Antecedent.use (W := W))
         Antecedent.contrastSet :=
-  fun h => absurd (h (a := .question ∅) (b := .offer ∅) rfl)
-    (by simp [Antecedent.use])
+  fun h => absurd (h (a := .question ∅) (b := .offer ∅) rfl) (by simp)
 
 /-! ### Hamblin antecedents -/
 
@@ -116,23 +157,12 @@ singleton predicates are exactly the flat Hamblin set. -/
 theorem alt_which_singleton (D : Type*) [Nonempty D] :
     Question.alt (Question.which (Set.univ : Set D) fun d => ({d} : Set D)) =
       hamblin D := by
-  ext q
-  constructor
-  · intro hq
-    rcases Question.alt_which_iff_left hq with hempty | ⟨d, _, rfl, _⟩
-    · subst hempty
-      obtain ⟨-, hmax⟩ := hq
-      obtain ⟨d₀⟩ := ‹Nonempty D›
-      have hmem : ({d₀} : Set D) ∈
-          Question.which (Set.univ : Set D) fun d => ({d} : Set D) :=
-        Question.mem_which.mpr (Or.inr ⟨d₀, trivial, subset_rfl⟩)
-      exact absurd (hmax _ hmem (Set.empty_subset _)).symm
-        (Set.singleton_ne_empty d₀)
-    · exact ⟨d, rfl⟩
-  · rintro ⟨d, rfl⟩
-    exact Question.mem_alt_which_of_maximal d trivial (Set.singleton_nonempty d)
-      fun d' _ hsub => by
-        rw [Set.singleton_subset_singleton.mp hsub]
+  have hA : IsAntichain (· ⊆ ·) ((fun d => ({d} : Set D)) '' Set.univ) := by
+    rintro p ⟨a, -, rfl⟩ q ⟨b, -, rfl⟩ hne hsub
+    exact hne (by rw [Set.singleton_subset_singleton.mp hsub])
+  rw [Question.alt_which_of_antichain Set.univ_nonempty
+      (fun d _ => Set.singleton_nonempty d) hA, Set.image_univ]
+  rfl
 
 /-- The inquisitive wh-question and the flat Hamblin antecedent
 coincide. -/

--- a/Linglib/Semantics/Questions/Hamblin.lean
+++ b/Linglib/Semantics/Questions/Hamblin.lean
@@ -1,3 +1,4 @@
+import Mathlib.Order.Antichain
 import Linglib.Semantics.Questions.Basic
 
 /-!
@@ -255,6 +256,33 @@ theorem mem_alt_which_of_maximal {E : Type v} {D : Set E} {P : E → Set W}
     have : P e' = P e := hmax e' he'D hPePe'
     -- Now r ⊆ P e' = P e ⊆ r, so r = P e.
     exact Set.Subset.antisymm hPer (this ▸ hre')
+
+/-- For an antichain of nonempty per-element predicates, the
+alternatives of `which D P` are exactly the predicate family: the
+maximal elements of a lower closure of an antichain recover the
+antichain. -/
+theorem alt_which_of_antichain {E : Type v} {D : Set E} {P : E → Set W}
+    (hD : D.Nonempty) (hne : ∀ e ∈ D, (P e).Nonempty)
+    (hA : IsAntichain (· ⊆ ·) (P '' D)) :
+    alt (which D P) = P '' D := by
+  ext q
+  constructor
+  · intro hq
+    rcases alt_which_iff_left hq with hempty | ⟨e, heD, rfl, _⟩
+    · subst hempty
+      obtain ⟨e₀, he₀⟩ := hD
+      obtain ⟨-, hmax⟩ := hq
+      have hmem : P e₀ ∈ which D P :=
+        mem_which.mpr (Or.inr ⟨e₀, he₀, subset_rfl⟩)
+      exact absurd (hmax _ hmem (Set.empty_subset _)).symm
+        (hne e₀ he₀).ne_empty
+    · exact ⟨e, heD, rfl⟩
+  · rintro ⟨e, heD, rfl⟩
+    refine mem_alt_which_of_maximal e heD (hne e heD) fun e' he'D hsub => ?_
+    by_cases heq : P e' = P e
+    · exact heq
+    · exact absurd hsub
+        (hA ⟨e, heD, rfl⟩ ⟨e', he'D, rfl⟩ fun h => heq h.symm)
 
 /-! ### Hamblin construction from a finite alternative list
 

--- a/Linglib/Studies/Kiss1998.lean
+++ b/Linglib/Studies/Kiss1998.lean
@@ -227,18 +227,27 @@ The same schema is instantiated for Hausa in
 `HartmannZimmermann2007.lean` (with `cfg.strategy` and `pragType`) and
 *refuted* there — a difference of verdict on one shared predicate. -/
 
+/-- The factor witnessing §2: focus type as a function of position. -/
+def typeOfPosition : Position → FocusType
+  | .preverbal  => .identificational
+  | .postverbal => .information
+
+/-- On licensed configurations the focus type is literally
+`typeOfPosition` of the position — the §2 claim in factored form. -/
+theorem focusType_eqOn_typeOfPosition :
+    Set.EqOn FocusConfig.focusType
+      (typeOfPosition ∘ FocusConfig.position) {c | c.Licensed} := by
+  rintro c ⟨hpos, -⟩
+  rw [Function.comp_apply, hpos]
+  cases c.focusType <;> rfl
+
 /-- Position determines focus type on licensed configurations: Kiss's
-§2 structural claim. -/
+§2 structural claim, derived from the explicit factor. -/
 theorem position_determines_focusType :
     Function.FactorsThroughOn
-      FocusConfig.focusType FocusConfig.position {c | c.Licensed} := by
-  intro c₁ c₂ h₁ h₂ hpos
-  obtain ⟨hpos₁, _⟩ := h₁
-  obtain ⟨hpos₂, _⟩ := h₂
-  have heq : positionFor c₁.focusType = positionFor c₂.focusType := by
-    rw [← hpos₁, ← hpos₂]; exact hpos
-  cases ft₁ : c₁.focusType <;> cases ft₂ : c₂.focusType <;>
-    rw [ft₁, ft₂] at heq <;> simp [positionFor] at heq
+      FocusConfig.focusType FocusConfig.position {c | c.Licensed} :=
+  Function.factorsThroughOn_iff_exists_eqOn.mpr
+    ⟨typeOfPosition, focusType_eqOn_typeOfPosition⟩
 
 /-- Position equivalence with exhaustivity: composition of the
 position-type and type-exhaustivity equivalences. The semantic payoff

--- a/Linglib/Studies/TurkHirsch2026.lean
+++ b/Linglib/Studies/TurkHirsch2026.lean
@@ -255,18 +255,26 @@ theorem theory_overgen_without_catmatch : mustP ∈ typeTheoQ :=
 def applyFoC_typeTheo : AltMeaning (Set PolarWorld) :=
   { oValue := p, aValue := typeTheoAlternatives }
 
+/-- The two carriers agree definitionally: the type-theoretic [FoC]
+A-value *as a set* is the type-theoretic question. -/
+theorem applyFoC_typeTheo_aSet : applyFoC_typeTheo.aSet = typeTheoQ := rfl
+
 /-- The type-theoretic A-value produces the wrong question denotation. -/
-theorem applyFoC_is_typeTheo : mustP ∈ ({q | q ∈ applyFoC_typeTheo.aValue} : Set _) := by
+theorem applyFoC_is_typeTheo : mustP ∈ applyFoC_typeTheo.aSet := by
   simp [applyFoC_typeTheo, typeTheoAlternatives, opLexicon]
 
 /-- Restricting the A-value by category match corrects the prediction. -/
 def applyFoC_catMatch : AltMeaning (Set PolarWorld) :=
   { oValue := p, aValue := catMatchAlternatives }
 
+/-- The two carriers agree definitionally on the category-matched side
+as well. -/
+theorem applyFoC_catMatch_aSet : applyFoC_catMatch.aSet = catMatchQ := rfl
+
 /-- The category-matched A-value produces the correct question denotation. -/
 theorem categoryMatch_fixes_applyFoC :
-    mustP ∉ ({q | q ∈ applyFoC_catMatch.aValue} : Set _) := by
-  simp only [applyFoC_catMatch, Set.mem_setOf_eq]
+    mustP ∉ applyFoC_catMatch.aSet := by
+  simp only [applyFoC_catMatch, AltMeaning.mem_aSet]
   show mustP ∉ catMatchAlternatives
   -- catMatchAlternatives = [p, notP]; mustP is neither.
   have hcm : catMatchAlternatives = [p, notP] := by


### PR DESCRIPTION
The composable-operations pass over the focus stack (items i–iv of the mathematical-deepening review).

- `Function.factorsThroughOn_iff_exists_eqOn`: the existential form of set-restricted factoring; Kiss 1998's position→type claim upgrades to a constructive factor (`typeOfPosition` + `Set.EqOn`), with `position_determines_focusType` derived as a corollary
- `Question.alt_which_of_antichain`: maximal alternatives of `which D P` over an antichain of nonempty predicates recover the predicate family; `Control.lean`'s `alt_which_singleton` becomes its atom instance
- `Control.lean` API batch: simp equations for `contrastSet`/`use`, `Admits.mono`, `admits_inter_iff`, and `Use.toAntecedent` section giving `use_surjective` (the shape-quotient claim as a theorem)
- `AltMeaning.aSet`: the Set-side presentation of the List carrier (mathlib Finset/Set coe pattern); TurkHirsch2026's dual encodings reconcile definitionally (`applyFoC_typeTheo.aSet = typeTheoQ := rfl`)