### PR TITLE
feat(Semantics/Focus): squiggle, composition engine, strong-theory only

### DIFF
--- a/Linglib/Semantics/Alternatives/AltMeaning.lean
+++ b/Linglib/Semantics/Alternatives/AltMeaning.lean
@@ -52,4 +52,73 @@ def AltMeaning.aSet {α : Type*} (m : AltMeaning α) : Set α :=
   ext a
   exact List.mem_singleton.trans Set.mem_singleton_iff.symm
 
+/-! ### The composition engine
+
+Alternative semantics composes pointwise ([rooth-1985]): the O-value
+applies ordinarily while the A-value collects applications of
+alternative functions to alternative arguments (Hamblin functional
+application). `AltMeaning` is the product of the identity and list
+monads, so the engine is a lawful `Monad`: `pure` is `unfeatured`,
+`<$>`/`<*>` are the recursive clauses of the two-dimensional semantics,
+and `oValue` is a monad morphism onto the ordinary dimension. -/
+
+namespace AltMeaning
+
+universe u
+variable {α β : Type u}
+
+instance : Monad AltMeaning where
+  pure := unfeatured
+  bind m f := ⟨(f m.oValue).oValue, m.aValue.flatMap fun a => (f a).aValue⟩
+
+instance : LawfulMonad AltMeaning := LawfulMonad.mk'
+  (id_map := fun m => by
+    cases m; simp [Functor.map, unfeatured])
+  (pure_bind := fun x f => by
+    simp [bind, pure, unfeatured])
+  (bind_assoc := fun m f g => by
+    cases m; simp [bind, List.flatMap_assoc])
+
+/-- The O-projection is a monad morphism: composition preserves the
+ordinary dimension. -/
+@[simp] theorem oValue_pure (x : α) : (pure x : AltMeaning α).oValue = x := rfl
+
+@[simp] theorem oValue_bind (m : AltMeaning α) (f : α → AltMeaning β) :
+    (m >>= f).oValue = (f m.oValue).oValue := rfl
+
+@[simp] theorem oValue_map (f : α → β) (m : AltMeaning α) :
+    (f <$> m).oValue = f m.oValue := rfl
+
+@[simp] theorem oValue_seq (mf : AltMeaning (α → β)) (ma : AltMeaning α) :
+    (mf <*> ma).oValue = mf.oValue ma.oValue := rfl
+
+/-- Membership in a mapped A-set: the image law of the engine. -/
+@[simp] theorem mem_aSet_map {f : α → β} {m : AltMeaning α} {b : β} :
+    b ∈ (f <$> m).aSet ↔ ∃ a ∈ m.aSet, f a = b := by
+  simp [Functor.map, aSet, unfeatured, eq_comm]
+
+/-- Membership in an applied A-set: Hamblin functional application. -/
+@[simp] theorem mem_aSet_seq {mf : AltMeaning (α → β)} {ma : AltMeaning α}
+    {b : β} :
+    b ∈ (mf <*> ma).aSet ↔ ∃ g ∈ mf.aSet, ∃ a ∈ ma.aSet, g a = b := by
+  simp [Seq.seq, aSet, unfeatured, eq_comm]
+
+/-- Rooth's containment constraint: the A-value contains the O-value. -/
+def WellFormed (m : AltMeaning α) : Prop := m.oValue ∈ m.aValue
+
+theorem WellFormed.unfeatured (x : α) :
+    (AltMeaning.unfeatured x).WellFormed := List.mem_singleton.mpr rfl
+
+/-- Composition preserves well-formedness. -/
+theorem WellFormed.bind {m : AltMeaning α} {f : α → AltMeaning β}
+    (hm : m.WellFormed) (hf : ∀ a, (f a).WellFormed) :
+    (m >>= f).WellFormed :=
+  List.mem_flatMap.mpr ⟨m.oValue, hm, hf _⟩
+
+theorem WellFormed.map {f : α → β} {m : AltMeaning α} (hm : m.WellFormed) :
+    (f <$> m).WellFormed :=
+  hm.bind fun a => WellFormed.unfeatured (f a)
+
+end AltMeaning
+
 end Alternatives

--- a/Linglib/Semantics/Focus/Control.lean
+++ b/Linglib/Semantics/Focus/Control.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Semantics.Alternatives.AltMeaning
 import Linglib.Semantics.Focus.Interpretation
 import Linglib.Semantics.Questions.Hamblin
 
@@ -17,6 +18,14 @@ to correct, explicitly offered alternatives, or a parallel focus
 felicity (`Antecedent.Admits`) is `fip` on the antecedent's contrast
 set, uniformly across uses — and `use_not_factorsThrough_contrastSet`
 shows the four-way split is invisible to the semantics.
+
+`SquiggleSet`/`SquiggleInd` state the full presuppositions of
+[rooth-1992]'s ~ operator (his (40), set and individual cases):
+`Admits` is only the first set-case clause, and the contrast clauses
+are what make ~ anaphorically demanding — `not_squiggleSet_unfeatured`
+derives "the argument must contain a focus" from the unit focus value
+of focus-free phrases. `Antecedent.Resolves` routes each antecedent
+shape through the appropriate case.
 
 ## Implementation notes
 
@@ -45,7 +54,8 @@ inductive Use where
   deriving DecidableEq, Repr, Inhabited
 
 /-- A focus antecedent: the discourse object that supplies the
-squiggle's contrast set. -/
+squiggle's antecedent — a contrast set for [rooth-1992]'s set case, or
+a single contrasting ordinary value for the individual case. -/
 inductive Antecedent (W : Type*) where
   /-- A question with (flat Hamblin) denotation `q`. -/
   | question (q : PropFocusValue W)
@@ -55,6 +65,9 @@ inductive Antecedent (W : Type*) where
   | offer (alts : PropFocusValue W)
   /-- A parallel focus with focus value `alts`. -/
   | parallel (alts : PropFocusValue W)
+  /-- A contrasting phrase's ordinary value ([rooth-1992]'s individual
+  case; the "contrasting phrases" rule). -/
+  | phrase (γ : Set W)
 
 /-- The contrast set Γ an antecedent supplies to the squiggle. -/
 def Antecedent.contrastSet : Antecedent W → PropFocusValue W
@@ -62,6 +75,7 @@ def Antecedent.contrastSet : Antecedent W → PropFocusValue W
   | .assertion _ alts  => alts
   | .offer alts        => alts
   | .parallel alts     => alts
+  | .phrase γ          => {γ}
 
 /-- The pragmatic use an antecedent shape licenses. -/
 def Antecedent.use : Antecedent W → Use
@@ -69,6 +83,7 @@ def Antecedent.use : Antecedent W → Use
   | .assertion _ _  => .corrective
   | .offer _        => .selective
   | .parallel _     => .contrastive
+  | .phrase _       => .contrastive
 
 @[simp] theorem contrastSet_question (q : PropFocusValue W) :
     (Antecedent.question q).contrastSet = q := rfl
@@ -87,6 +102,10 @@ def Antecedent.use : Antecedent W → Use
     (Antecedent.offer alts).use = .selective := rfl
 @[simp] theorem use_parallel (alts : PropFocusValue W) :
     (Antecedent.parallel alts).use = .contrastive := rfl
+@[simp] theorem contrastSet_phrase (γ : Set W) :
+    (Antecedent.phrase γ).contrastSet = {γ} := rfl
+@[simp] theorem use_phrase (γ : Set W) :
+    (Antecedent.phrase γ).use = .contrastive := rfl
 
 /-- The canonical antecedent of each shape (empty payloads): a section
 of `Antecedent.use`. -/
@@ -121,6 +140,81 @@ theorem admits_inter_iff {c : Antecedent W} {fv fv' : PropFocusValue W} :
     c.Admits (fv ∩ fv') ↔ c.Admits fv ∧ c.Admits fv' :=
   Set.subset_inter_iff
 
+/-! ### The squiggle presupposition
+
+[rooth-1992]'s ~ operator introduces the presuppositions of its (40),
+over an ordinary value `o` and focus value `fv` of any type: in the set
+case the resolved antecedent `Γ` is a subset of `fv` containing `o` and
+a distinct alternative; in the individual case the antecedent is a
+member of `fv` distinct from `o`. `Admits` is the first set-case clause;
+the contrast clauses are what make ~ anaphorically demanding. -/
+
+section Squiggle
+
+variable {α : Type*}
+
+/-- The ~ presupposition, set case: `Γ ⊆ fv`, `o ∈ Γ`, and `Γ` contains
+an alternative distinct from `o` ([rooth-1992] (40)). -/
+def SquiggleSet (o : α) (fv Γ : Set α) : Prop :=
+  Γ ⊆ fv ∧ o ∈ Γ ∧ ∃ x ∈ Γ, x ≠ o
+
+/-- The ~ presupposition, individual case: the antecedent is a member
+of `fv` distinct from `o` ([rooth-1992] (40)); the contrasting-phrases
+rule is this with `γ := ⟦β⟧ᵒ`. -/
+def SquiggleInd (o : α) (fv : Set α) (γ : α) : Prop :=
+  γ ∈ fv ∧ γ ≠ o
+
+/-- The first set-case clause alone: the antecedent is a subset of the
+focus value (at the propositional level, exactly `fip`). -/
+theorem SquiggleSet.subset {o : α} {fv Γ : Set α} (h : SquiggleSet o fv Γ) :
+    Γ ⊆ fv := h.1
+
+/-- A resolved antecedent is nontrivial: it contains the ordinary value
+and a distinct alternative. -/
+theorem SquiggleSet.nontrivial {o : α} {fv Γ : Set α}
+    (h : SquiggleSet o fv Γ) : Γ.Nontrivial :=
+  let ⟨_, ho, x, hx, hne⟩ := h; ⟨x, hx, o, ho, hne⟩
+
+/-- A unit focus value defeats the contrast clause: nothing resolves
+against `{o}`. -/
+theorem not_squiggleSet_singleton (o : α) (Γ : Set α) :
+    ¬ SquiggleSet o {o} Γ :=
+  fun ⟨hsub, _, _, hx, hne⟩ => hne (hsub hx)
+
+theorem not_squiggleInd_singleton (o γ : α) : ¬ SquiggleInd o {o} γ :=
+  fun ⟨hγ, hne⟩ => hne hγ
+
+open Alternatives in
+/-- "The argument must contain a focus": a focus-free phrase has a unit
+focus value, so no antecedent resolves against it ([rooth-1992] §10). -/
+theorem not_squiggleSet_unfeatured (x : α) (Γ : Set α) :
+    ¬ SquiggleSet (AltMeaning.unfeatured x).oValue
+      (AltMeaning.unfeatured x).aSet Γ := by
+  rw [AltMeaning.unfeatured_aSet, AltMeaning.unfeatured_oValue]
+  exact not_squiggleSet_singleton x Γ
+
+end Squiggle
+
+/-- Full Roothian resolution of an antecedent against a two-dimensional
+meaning `(o, fv)`: the set case for question / assertion / offer /
+parallel antecedents, the individual case for contrasting phrases. -/
+def Antecedent.Resolves : Antecedent W → Set W → PropFocusValue W → Prop
+  | .phrase γ, o, fv => SquiggleInd o fv γ
+  | c, o, fv         => SquiggleSet o fv c.contrastSet
+
+/-- Full resolution entails felicity: `Admits` is the set case's first
+clause, and a resolved contrasting phrase is a member of the focus
+value. -/
+theorem Antecedent.Resolves.admits {c : Antecedent W} {o : Set W}
+    {fv : PropFocusValue W} (h : c.Resolves o fv) : c.Admits fv := by
+  cases c with
+  | phrase γ => exact Set.singleton_subset_iff.mpr h.1
+  | question q => exact h.1
+  | assertion p alts => exact h.1
+  | offer alts => exact h.1
+  | parallel alts => exact h.1
+
+
 /-- Felicity factors through the contrast set: the semantics sees Γ,
 never the use label. -/
 theorem admits_factorsThrough_contrastSet (fv : PropFocusValue W) :
@@ -146,6 +240,13 @@ def whAntecedent (D : Type*) : Antecedent D := .question (hamblin D)
 
 theorem whAntecedent_admits (D : Type*) :
     (whAntecedent D).Admits (hamblin D) := subset_rfl
+
+/-- A wh-antecedent over a domain with two distinct elements fully
+resolves against the Hamblin focus value of any complete answer. -/
+theorem whAntecedent_resolves {D : Type*} (d d' : D) (hne : d' ≠ d) :
+    (whAntecedent D).Resolves {d} (hamblin D) :=
+  ⟨subset_rfl, ⟨d, rfl⟩, ⟨{d'}, ⟨d', rfl⟩,
+    fun h => hne (Set.singleton_eq_singleton_iff.mp h)⟩⟩
 
 /-- A `Question` supplies its maximal alternatives as a question
 antecedent — the bridge from the inquisitive layer. -/

--- a/Linglib/Semantics/Focus/Control.lean
+++ b/Linglib/Semantics/Focus/Control.lean
@@ -107,20 +107,22 @@ def Antecedent.use : Antecedent W → Use
 @[simp] theorem use_phrase (γ : Set W) :
     (Antecedent.phrase γ).use = .contrastive := rfl
 
-/-- The canonical antecedent of each shape (empty payloads): a section
-of `Antecedent.use`. -/
-def Use.toAntecedent : Use → Antecedent W
-  | .newInfo     => .question ∅
-  | .corrective  => .assertion ∅ ∅
-  | .selective   => .offer ∅
-  | .contrastive => .parallel ∅
+/-- The canonical antecedent of each use over a designated
+ordinary-value/alternative pair `(o, a)`: a question, an assertion of
+the alternative to be corrected, an offer, or a parallel focus — the
+minimal contentful model of the four controlling contexts. -/
+def Use.model (o a : Set W) : Use → Antecedent W
+  | .newInfo     => .question {o, a}
+  | .corrective  => .assertion a {o, a}
+  | .selective   => .offer {o, a}
+  | .contrastive => .parallel {o, a}
 
-@[simp] theorem use_toAntecedent (u : Use) :
-    (Use.toAntecedent (W := W) u).use = u := by cases u <;> rfl
+@[simp] theorem use_model (o a : Set W) (u : Use) :
+    (Use.model o a u).use = u := by cases u <;> rfl
 
 /-- Every pragmatic use is realised by some antecedent shape. -/
 theorem use_surjective : Function.Surjective (Antecedent.use (W := W)) :=
-  fun u => ⟨u.toAntecedent, use_toAntecedent u⟩
+  fun u => ⟨Use.model ∅ ∅ u, use_model ∅ ∅ u⟩
 
 /-- Roothian felicity of a focus value against an antecedent: `fip` on
 the antecedent's contrast set. -/
@@ -196,11 +198,14 @@ theorem not_squiggleSet_unfeatured (x : α) (Γ : Set α) :
 end Squiggle
 
 /-- Full Roothian resolution of an antecedent against a two-dimensional
-meaning `(o, fv)`: the set case for question / assertion / offer /
-parallel antecedents, the individual case for contrasting phrases. -/
+meaning `(o, fv)`: the set case for question / offer / parallel
+antecedents, the individual case for contrasting phrases — and for
+assertion antecedents additionally the correction clause: the resolved
+ordinary value replaces (differs from) the prior assertion. -/
 def Antecedent.Resolves : Antecedent W → Set W → PropFocusValue W → Prop
-  | .phrase γ, o, fv => SquiggleInd o fv γ
-  | c, o, fv         => SquiggleSet o fv c.contrastSet
+  | .phrase γ, o, fv         => SquiggleInd o fv γ
+  | .assertion p alts, o, fv => SquiggleSet o fv alts ∧ o ≠ p
+  | c, o, fv                 => SquiggleSet o fv c.contrastSet
 
 /-- Full resolution entails felicity: `Admits` is the set case's first
 clause, and a resolved contrasting phrase is a member of the focus
@@ -210,7 +215,7 @@ theorem Antecedent.Resolves.admits {c : Antecedent W} {o : Set W}
   cases c with
   | phrase γ => exact Set.singleton_subset_iff.mpr h.1
   | question q => exact h.1
-  | assertion p alts => exact h.1
+  | assertion p alts => exact h.1.1
   | offer alts => exact h.1
   | parallel alts => exact h.1
 
@@ -247,6 +252,56 @@ theorem whAntecedent_resolves {D : Type*} (d d' : D) (hne : d' ≠ d) :
     (whAntecedent D).Resolves {d} (hamblin D) :=
   ⟨subset_rfl, ⟨d, rfl⟩, ⟨{d'}, ⟨d', rfl⟩,
     fun h => hne (Set.singleton_eq_singleton_iff.mp h)⟩⟩
+
+/-! ### Composed answers over a pair
+
+The minimal contentful scenario: a two-point answer domain
+`{d, d'}` with `d` the true answer. The answer is built by the
+composition engine — the singleton complete-answer predicate mapped
+over the F-marked argument — and every canonical antecedent shape
+fully resolves against it. -/
+
+open Alternatives in
+/-- The composed focused answer `d` over the pair `{d, d'}`. -/
+def pairAnswer {W : Type*} (d d' : W) : AltMeaning (Set W) :=
+  (fun x => ({x} : Set W)) <$> (⟨d, [d, d']⟩ : AltMeaning W)
+
+open Alternatives in
+@[simp] theorem pairAnswer_oValue {W : Type*} (d d' : W) :
+    (pairAnswer d d').oValue = {d} := rfl
+
+open Alternatives in
+@[simp] theorem pairAnswer_aSet {W : Type*} (d d' : W) :
+    (pairAnswer d d').aSet = {{d}, {d'}} := by
+  ext q
+  simp only [pairAnswer, AltMeaning.mem_aSet_map]
+  constructor
+  · rintro ⟨a, ha, rfl⟩
+    rcases (by simpa using ha : a = d ∨ a = d') with rfl | rfl
+    · exact Or.inl rfl
+    · exact Or.inr rfl
+  · rintro (rfl | rfl)
+    · exact ⟨d, by simp, rfl⟩
+    · exact ⟨d', by simp, rfl⟩
+
+/-- **Uniform resolution across the four uses**: every canonical
+antecedent shape fully resolves — all squiggle clauses, including the
+correction clause — against the composed answer over its pair. One
+semantics, four pragmatic uses. -/
+theorem use_model_resolves {W : Type*} {d d' : W} (hne : d' ≠ d) (u : Use) :
+    (Use.model {d} {d'} u).Resolves
+      (pairAnswer d d').oValue (pairAnswer d d').aSet := by
+  have hne' : ({d'} : Set W) ≠ {d} :=
+    fun h => hne (Set.singleton_eq_singleton_iff.mp h)
+  have hSq : SquiggleSet (pairAnswer d d').oValue (pairAnswer d d').aSet
+      {{d}, {d'}} := by
+    rw [pairAnswer_oValue, pairAnswer_aSet]
+    exact ⟨subset_rfl, Or.inl rfl, ⟨{d'}, Or.inr rfl, hne'⟩⟩
+  cases u with
+  | newInfo     => exact hSq
+  | corrective  => exact ⟨hSq, by rw [pairAnswer_oValue]; exact hne'.symm⟩
+  | selective   => exact hSq
+  | contrastive => exact hSq
 
 /-- A `Question` supplies its maximal alternatives as a question
 antecedent — the bridge from the inquisitive layer. -/

--- a/Linglib/Semantics/Focus/Control.lean
+++ b/Linglib/Semantics/Focus/Control.lean
@@ -303,6 +303,41 @@ theorem use_model_resolves {W : Type*} {d d' : W} (hne : d' ≠ d) (u : Use) :
   | selective   => exact hSq
   | contrastive => exact hSq
 
+/-! ### Strong-theory *only*
+
+[rooth-1992]'s official semantics: *only* quantifies over the resolved
+contrast variable `C`; the focus constraint `C ⊆ ⟦·⟧f` is supplied
+separately by the squiggle, "leaving room for a pragmatic process of
+constructing a domain of quantification". The operator has no lexical
+access to focus values — direct-association implementations carry an
+alternative list lexically instead, and the two provably diverge under
+domain restriction (`Studies/Rooth1992.lean`). -/
+
+/-- The strong-theory *only* assertion, transposed to the propositional
+level: every true member of the resolved contrast set is the prejacent.
+The prejacent presupposition is carried separately. -/
+def onlyVia (C : PropFocusValue W) (prejacent : Set W) : Set W :=
+  {w | ∀ q ∈ C, w ∈ q → q = prejacent}
+
+@[simp] theorem mem_onlyVia {C : PropFocusValue W} {p : Set W} {w : W} :
+    w ∈ onlyVia C p ↔ ∀ q ∈ C, w ∈ q → q = p := Iff.rfl
+
+/-- Narrowing the domain weakens *only* — the pragmatic domain
+restriction that repairs the over-generation of a fixed full-focus
+domain. -/
+theorem onlyVia_antitone {C C' : PropFocusValue W} (h : C ⊆ C')
+    (p : Set W) : onlyVia C' p ⊆ onlyVia C p :=
+  fun _ hw q hq => hw q (h hq)
+
+/-- Against a squiggle-resolved contrast set, *only* genuinely
+excludes: the contrast clause supplies a distinct alternative that the
+assertion rules out wherever it holds. -/
+theorem onlyVia_excludes_of_squiggleSet {o : Set W} {fv C : PropFocusValue W}
+    (h : SquiggleSet o fv C) :
+    ∃ q ∈ C, q ≠ o ∧ ∀ w ∈ onlyVia C o, w ∉ q :=
+  let ⟨_, _, q, hq, hne⟩ := h
+  ⟨q, hq, hne, fun _ hw hwq => hne (hw q hq hwq)⟩
+
 /-- A `Question` supplies its maximal alternatives as a question
 antecedent — the bridge from the inquisitive layer. -/
 def Antecedent.ofQuestion (q : Question W) : Antecedent W :=

--- a/Linglib/Studies/HartmannZimmermann2007.lean
+++ b/Linglib/Studies/HartmannZimmermann2007.lean
@@ -37,8 +37,9 @@ situ" — only the categorical no-determination claim is a theorem.
 
 ## TODO
 
-* §3.2.5 exhaustivity contrast against Kiss 1998 requires an
-  alternatives-semantics exhaustivity operator beyond `Use` tags.
+* The Kiss-side semantic interpretation of `FocusType.IsExhaustive`
+  (obligatory covert `onlyVia`) for the like-for-like §3.2.5 contrast —
+  needs a semantic layer in `Kiss1998.lean`.
 * §2.3 multiple foci: co-occurrence of one ex-situ focus with in-situ
   foci (18a-c).
 * §4 focus pied-piping / partial focus movement and the (47) "Ex-Situ
@@ -115,6 +116,41 @@ cells. One semantics, four pragmatic uses. -/
 theorem ctx_resolves (u : Use) :
     (ctx u).Resolves answer.oValue answer.aSet :=
   use_model_resolves (d := Alt.ans) (d' := Alt.alt) nofun u
+
+/-! ## Exhaustive focus (§3.2.5)
+
+Exhaustivity is not structurally encoded: it is induced by focus
+particles (*kawài* 'only'; *nee/cee* per the paper's fn. 3) over the
+resolved contrast set, in either strategy — (32a/b) attest in-situ and
+ex-situ *only BOOKS* alike. -/
+
+/-- The exhaustified answer: strong-theory *only* over the scenario's
+resolved contrast set. -/
+private def exhAnswer (u : Use) : Set Alt :=
+  onlyVia (ctx u).contrastSet answer.oValue
+
+/-- The exhaustified answer computes to the bare true answer, uniformly
+across the four uses: exhaustification consumes the resolved contrast
+set and prejacent, never the strategy — the §3.2.5 point that
+exhaustive readings are available in both positions. -/
+theorem exhAnswer_eq (u : Use) : exhAnswer u = {Alt.ans} := by
+  have key : onlyVia ({{Alt.ans}, {Alt.alt}} : Semantics.Focus.Interpretation.PropFocusValue Alt)
+      {Alt.ans} = {Alt.ans} := by
+    ext w
+    constructor
+    · intro hw
+      have halt := hw {Alt.alt} (Or.inr rfl)
+      cases w with
+      | ans => rfl
+      | alt =>
+        exact absurd (halt rfl)
+          (by simp [Set.singleton_eq_singleton_iff])
+    · rintro rfl
+      intro q hq hwq
+      rcases hq with rfl | rfl
+      · rfl
+      · exact absurd hwq (by simp)
+  cases u <;> exact key
 
 /-! ## The 8-cell empirical matrix (§3.2)
 

--- a/Linglib/Studies/HartmannZimmermann2007.lean
+++ b/Linglib/Studies/HartmannZimmermann2007.lean
@@ -56,7 +56,7 @@ situ" — only the categorical no-determination claim is a theorem.
 namespace HartmannZimmermann2007
 
 open Hausa
-open Semantics.Focus (Antecedent Use hamblin whAntecedent)
+open Semantics.Focus
 
 /-! ## What is focused (§2.2.2) -/
 
@@ -88,74 +88,33 @@ instance (u : FocusUtterance) : Decidable u.IsHausaLicensed :=
 
 /-! ## Controlling contexts of the §3.2 matrix
 
-One small answer domain per Q/A pair (`other` stands in for the
-unmentioned rest of open *wh*-domains); each control carries the
-context's actual Hamblin denotation. -/
+Every cell's mini-scenario has one shape: a two-point answer domain —
+the mentioned answer `ans` vs the contextual alternative `alt` — whose
+content (fish vs other dishes, fifteen vs twenty Naira, behind vs in
+front, …) lives in the cell's data row. The antecedent is the canonical
+`Use.model` of the row's context shape; the answer is composed by the
+engine (`pairAnswer`); `ctx_resolves` is the uniform full-resolution
+fact. Ex-situ variants are interpreted at the base structure (fronting
+is A'-movement for the paper, and alternatives do not distribute
+through abstraction: `PredAbs AltMeaning = ⟨none⟩`). -/
 
-inductive Dish | kiifii | other
-inductive City | birninKwanni | other
-inductive Deceased | wife | mother
-inductive Price | fifteen | twenty
-inductive Route | front | behind
-inductive Activity | eating | chatting
-inductive Amount | whole | half
-inductive Drink | tea | coffee
-inductive Caller | daudaa | other
-inductive Traveler | audu | other
+/-- The two-point answer domain of a cell's mini-scenario. -/
+inductive Alt | ans | alt
 
-/-- 'What is Kande cooking?' ((22)). -/
-def control22 : Antecedent Dish := whAntecedent Dish
-/-- 'From which city do you come?' ((23)). -/
-def control23 : Antecedent City := whAntecedent City
-/-- 'Was it his mother who died?' — asserted alternative to correct ((24)). -/
-def control24 : Antecedent Deceased :=
-  .assertion {Deceased.mother} (hamblin Deceased)
-/-- 'It is twenty Naira that you will pay' — assertion to correct ((25)). -/
-def control25 : Antecedent Price :=
-  .assertion {Price.twenty} (hamblin Price)
-/-- '…you shouldn't pass in front of him' — parallel focus ((26)). -/
-def control26 : Antecedent Route := .parallel (hamblin Route)
-/-- 'no one is chatting…' — parallel focus ((27)). -/
-def control27 : Antecedent Activity := .parallel (hamblin Activity)
-/-- 'A whole or a half?' — explicitly offered alternatives ((29)). -/
-def control29 : Antecedent Amount := .offer (hamblin Amount)
-/-- 'Coffee or tea?' — explicitly offered alternatives ((30)). -/
-def control30 : Antecedent Drink := .offer (hamblin Drink)
-/-- 'Who is calling her?' ((17)). -/
-def control17 : Antecedent Caller := whAntecedent Caller
-/-- 'Who will go to Germany?' ((8)). -/
-def control8 : Antecedent Traveler := whAntecedent Traveler
+/-- The canonical antecedent of a use over the two-point scenario. -/
+private def ctx (u : Use) : Antecedent Alt :=
+  Use.model {Alt.ans} {Alt.alt} u
 
-/-- The wh-cells resolve fully, not just felicitously: all three
-squiggle clauses hold for (22)'s control against the fish answer. -/
-theorem control22_resolves :
-    control22.Resolves {Dish.kiifii} (hamblin Dish) :=
-  Semantics.Focus.whAntecedent_resolves Dish.kiifii Dish.other nofun
+/-- The composed answer of the two-point scenario. -/
+private def answer : Alternatives.AltMeaning (Set Alt) :=
+  pairAnswer Alt.ans Alt.alt
 
-/-- Roothian felicity holds uniformly: every §3.2 control admits its
-answer's focus value. One semantics, four pragmatic uses. -/
-theorem controls_admit :
-    control22.Admits (hamblin Dish) ∧ control23.Admits (hamblin City) ∧
-    control24.Admits (hamblin Deceased) ∧ control25.Admits (hamblin Price) ∧
-    control26.Admits (hamblin Route) ∧ control27.Admits (hamblin Activity) ∧
-    control29.Admits (hamblin Amount) ∧ control30.Admits (hamblin Drink) :=
-  ⟨subset_rfl, subset_rfl, subset_rfl, subset_rfl,
-   subset_rfl, subset_rfl, subset_rfl, subset_rfl⟩
-
-/-- (25) is a real correction: the answer's ordinary value lies in the
-contrast set and differs from the asserted alternative. -/
-theorem ex25_corrects :
-    ({Price.fifteen} : Set Price) ∈ control25.contrastSet ∧
-    ({Price.fifteen} : Set Price) ≠ {Price.twenty} :=
-  ⟨⟨Price.fifteen, rfl⟩, by simp⟩
-
-/-- (26) is a real parallel contrast: 'in front' and 'behind' are
-distinct members of one contrast set. -/
-theorem ex26_parallel_contrast :
-    ({Route.front} : Set Route) ∈ control26.contrastSet ∧
-    ({Route.behind} : Set Route) ∈ control26.contrastSet ∧
-    ({Route.front} : Set Route) ≠ {Route.behind} :=
-  ⟨⟨Route.front, rfl⟩, ⟨Route.behind, rfl⟩, by simp⟩
+/-- Every cell's context fully resolves against the composed answer —
+all squiggle clauses, plus the correction clause for the corrective
+cells. One semantics, four pragmatic uses. -/
+theorem ctx_resolves (u : Use) :
+    (ctx u).Resolves answer.oValue answer.aSet :=
+  use_model_resolves (d := Alt.ans) (d' := Alt.alt) nofun u
 
 /-! ## The 8-cell empirical matrix (§3.2)
 
@@ -176,36 +135,36 @@ private def mkInSituUtt (pac : PAC) (g : Gender) (sg : Bool)
 
 /-- Ex-situ new-information focus ((22), `Examples.ex22`). -/
 def exSitu_newInfo : FocusUtterance :=
-  mkExSituUtt cont_3sf_R .masculine true true (fun _ => rfl) control22
+  mkExSituUtt cont_3sf_R .masculine true true (fun _ => rfl) (ctx .newInfo)
 
 /-- Ex-situ corrective focus on a feminine subject ((24),
 `Examples.ex24`). -/
 def exSitu_corrective : FocusUtterance :=
-  mkExSituUtt cmp_3sf_R .feminine true true (fun _ => rfl) control24 .subject
+  mkExSituUtt cmp_3sf_R .feminine true true (fun _ => rfl) (ctx .corrective) .subject
 
 /-- Ex-situ selective focus, no stabilizer ((29), `Examples.ex29`). -/
 def exSitu_selective : FocusUtterance :=
-  mkExSituUtt cont_1sg_R .masculine true false (fun _ => rfl) control29
+  mkExSituUtt cont_1sg_R .masculine true false (fun _ => rfl) (ctx .selective)
 
 /-- Ex-situ contrastive focus, no stabilizer ((27), `Examples.ex27`);
 the paper's 4sg impersonal *akèe* is approximated with the 3sg.M
 Relative continuous. -/
 def exSitu_contrastive : FocusUtterance :=
-  mkExSituUtt cont_3sm_R .masculine true false (fun _ => rfl) control27
+  mkExSituUtt cont_3sm_R .masculine true false (fun _ => rfl) (ctx .contrastive)
 
 /-- In-situ new-information focus ((23), `Examples.ex23`). -/
-def inSitu_newInfo : FocusUtterance := mkInSituUtt cmp_1sg_G .masculine true control23
+def inSitu_newInfo : FocusUtterance := mkInSituUtt cmp_1sg_G .masculine true (ctx .newInfo)
 
 /-- In-situ corrective focus with sentence-final *nèe* ((25),
 `Examples.ex25`). -/
 def inSitu_corrective : FocusUtterance :=
-  mkInSituUtt fut_1sg .masculine true control25 (hasStab := true)
+  mkInSituUtt fut_1sg .masculine true (ctx .corrective) (hasStab := true)
 
 /-- In-situ selective focus ((30), `Examples.ex30`). -/
-def inSitu_selective : FocusUtterance := mkInSituUtt fut_1sg .masculine true control30
+def inSitu_selective : FocusUtterance := mkInSituUtt fut_1sg .masculine true (ctx .selective)
 
 /-- In-situ contrastive focus ((26), `Examples.ex26`). -/
-def inSitu_contrastive : FocusUtterance := mkInSituUtt fut_1sg .masculine true control26
+def inSitu_contrastive : FocusUtterance := mkInSituUtt fut_1sg .masculine true (ctx .contrastive)
 
 /-- The 8-cell matrix of §3.2: both strategies × all four pragmatic
 types. -/
@@ -252,14 +211,14 @@ theorem subject_focus_only_exSitu (u : FocusUtterance)
 
 /-- The starred in-situ subject focus ((17 A2), `Examples.ex17a2`). -/
 def starred_inSitu_subject : FocusUtterance :=
-  mkInSituUtt cont_3sm_G .masculine true control17 .subject
+  mkInSituUtt cont_3sm_G .masculine true (ctx .newInfo) .subject
 
 theorem starred_inSitu_subject_not_IsHausaLicensed :
     ¬ starred_inSitu_subject.IsHausaLicensed := by decide
 
 /-- The grammatical ex-situ subject focus ((17 A1), `Examples.ex17a1`). -/
 def licensed_exSitu_subject : FocusUtterance :=
-  mkExSituUtt cont_3sm_R .masculine true true (fun _ => rfl) control17 .subject
+  mkExSituUtt cont_3sm_R .masculine true true (fun _ => rfl) (ctx .newInfo) .subject
 
 theorem licensed_exSitu_subject_IsHausaLicensed :
     licensed_exSitu_subject.IsHausaLicensed := by decide
@@ -268,7 +227,7 @@ theorem licensed_exSitu_subject_IsHausaLicensed :
 `Examples.ex8`): string-vacuous fronting with no overt reflex — see
 `exSitu_subject_subjunctive_no_reflex`. -/
 def exSitu_subject_subjunctive : FocusUtterance :=
-  mkExSituUtt subj_3sm .masculine true false (by decide) control8 .subject
+  mkExSituUtt subj_3sm .masculine true false (by decide) (ctx .newInfo) .subject
 
 theorem exSitu_subject_subjunctive_IsHausaLicensed :
     exSitu_subject_subjunctive.IsHausaLicensed := by decide

--- a/Linglib/Studies/HartmannZimmermann2007.lean
+++ b/Linglib/Studies/HartmannZimmermann2007.lean
@@ -126,6 +126,12 @@ def control17 : Antecedent Caller := whAntecedent Caller
 /-- 'Who will go to Germany?' ((8)). -/
 def control8 : Antecedent Traveler := whAntecedent Traveler
 
+/-- The wh-cells resolve fully, not just felicitously: all three
+squiggle clauses hold for (22)'s control against the fish answer. -/
+theorem control22_resolves :
+    control22.Resolves {Dish.kiifii} (hamblin Dish) :=
+  Semantics.Focus.whAntecedent_resolves Dish.kiifii Dish.other nofun
+
 /-- Roothian felicity holds uniformly: every §3.2 control admits its
 answer's focus value. One semantics, four pragmatic uses. -/
 theorem controls_admit :

--- a/Linglib/Studies/Kiss1998.lean
+++ b/Linglib/Studies/Kiss1998.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Logic.FactorsThroughOn
+import Linglib.Semantics.Focus.Control
 
 /-!
 # Hungarian preverbal/postverbal focus contrast
@@ -295,5 +296,101 @@ theorem postverbal_information_licensed :
 positions, different focus types — both licensed. -/
 theorem minimal_pair_distinct_types :
     preverbal_hat.focusType ≠ postverbal_hat.focusType := by decide
+
+/-! ### Exhaustive identification semantics (§2)
+
+The hat/coat model of the paper's own test sentences ((8), (12)–(15)).
+Identificational focus is the prejacent exhaustified over the resolved
+alternatives — covert obligatory `Semantics.Focus.onlyVia` — while
+information focus is the bare prejacent. Szabolcsi's coordination test
+and Farkas's dialogue test come out as theorems, and position
+*determines* whether exhaustification applies: the like-for-like
+counterpart of `HartmannZimmermann2007.exhAnswer_eq`, where
+exhaustification is strategy-blind. -/
+
+open Semantics.Focus (onlyVia)
+
+/-- Worlds tracking what Mary picked for herself. -/
+inductive HatWorld where
+  | hatOnly | coatOnly | both | neither
+  deriving DecidableEq, Repr
+
+/-- 'Mary picked a hat' (at least). -/
+def pickedHat : Set HatWorld := {.hatOnly, .both}
+/-- 'Mary picked a coat' (at least). -/
+def pickedCoat : Set HatWorld := {.coatOnly, .both}
+
+/-- The resolved atomic alternatives for the picking scenario. -/
+def hatAlts : Semantics.Focus.Interpretation.PropFocusValue HatWorld :=
+  {pickedHat, pickedCoat}
+
+/-- Identificational focus: the prejacent exhaustified over the
+resolved alternatives (§2's "exhaustive subset of the relevant set"). -/
+def identificational (p : Set HatWorld) : Set HatWorld :=
+  p ∩ onlyVia hatAlts p
+
+/-- The identificational meaning of (8a)/(12b) computes to
+picked-exactly-a-hat. -/
+theorem identificational_hat_eq :
+    identificational pickedHat = {HatWorld.hatOnly} := by
+  ext w
+  constructor
+  · rintro ⟨hp, hw⟩
+    have hcoat := hw pickedCoat (Or.inr rfl)
+    cases w with
+    | hatOnly => rfl
+    | coatOnly => exact absurd hp (fun h => h.elim nofun nofun)
+    | both =>
+      have heq : pickedCoat = pickedHat := hcoat (Or.inr rfl)
+      have hmem : HatWorld.coatOnly ∈ pickedHat :=
+        heq ▸ (show HatWorld.coatOnly ∈ pickedCoat from Or.inl rfl)
+      exact absurd hmem (fun h => h.elim nofun nofun)
+    | neither => exact absurd hp (fun h => h.elim nofun nofun)
+  · rintro rfl
+    refine ⟨Or.inl rfl, fun q hq hwq => ?_⟩
+    rcases hq with rfl | rfl
+    · rfl
+    · exact absurd hwq (fun h => h.elim nofun nofun)
+
+/-- **Szabolcsi's coordination test** ((12) vs (13)): the
+identificational *a hat* contradicts the *hat-and-coat* content, while
+the information-focus *a hat* is entailed by it. -/
+theorem szabolcsi_test :
+    identificational pickedHat ∩ (pickedHat ∩ pickedCoat) = ∅ ∧
+    pickedHat ∩ pickedCoat ⊆ pickedHat := by
+  refine ⟨?_, Set.inter_subset_left⟩
+  rw [identificational_hat_eq]
+  ext w
+  constructor
+  · rintro ⟨rfl, -, hcoat⟩
+    exact absurd hcoat (fun h => h.elim nofun nofun)
+  · exact fun h => h.elim
+
+/-- **Farkas's dialogue test** ((15)): in the situation where Mary
+picked a coat too, the identificational claim is false (so B's "No,
+she picked a coat, too" is a coherent denial of exhaustivity), while
+the information-focus claim is true (so the denial is infelicitous). -/
+theorem farkas_test :
+    HatWorld.both ∉ identificational pickedHat ∧
+    HatWorld.both ∈ pickedHat := by
+  refine ⟨?_, Or.inr rfl⟩
+  rw [identificational_hat_eq]
+  exact nofun
+
+/-- The two focus types' denotations for the hat prejacent. -/
+def semanticsOf : FocusType → Set HatWorld
+  | .identificational => identificational pickedHat
+  | .information      => pickedHat
+
+/-- **Position determines the semantics**: the preverbal slot's meaning
+is exhaustified, the postverbal one's is plain — Kiss's §2 claim cashed
+out through the factor `typeOfPosition`. The Hausa counterpart
+(`HartmannZimmermann2007.exhAnswer_eq`) shows exhaustification
+*strategy-blind*: the two-verdict contrast at the level of one
+semantic operator. -/
+theorem position_determines_exhaustification :
+    semanticsOf (typeOfPosition .preverbal) = {HatWorld.hatOnly} ∧
+    semanticsOf (typeOfPosition .postverbal) = pickedHat :=
+  ⟨identificational_hat_eq, rfl⟩
 
 end Kiss1998

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -290,6 +290,35 @@ theorem qaAntecedent_admits_subjectFocus :
 theorem qaAntecedent_rejects_objectFocus :
     ¬ qaAntecedent.Admits fv_objectFocus := fip_fails_object_focus
 
+/-- The question antecedent *fully* resolves against the subject-focus
+    meaning: all three clauses of the squiggle presupposition, not just
+    FIP — the contrast set contains the ordinary value `fredAteBeans`
+    and the distinct alternative `maryAteBeans`. -/
+theorem qaAntecedent_resolves :
+    qaAntecedent.Resolves fredAteBeans fv_subjectFocus :=
+  ⟨fip_congruent, Or.inl rfl,
+    maryAteBeans, Or.inr rfl,
+    fun h => by
+      have : maryBeans ∈ fredAteBeans := h ▸ (rfl : maryBeans ∈ maryAteBeans)
+      exact absurd this (by simp [fredAteBeans, maryAteBeans])⟩
+
+/-- A focus-free answer cannot resolve any antecedent: its focus value
+    is the unit set `{fredAteBeans}`, defeating the contrast clause —
+    "the argument must contain a focus". -/
+theorem focusFree_answer_cannot_resolve (Γ : PropFocusValue QAWorld) :
+    ¬ Semantics.Focus.SquiggleSet fredAteBeans {fredAteBeans} Γ :=
+  Semantics.Focus.not_squiggleSet_singleton fredAteBeans Γ
+
+/-- Contrasting phrases (Rooth's symmetric-contrast joke opening, his
+    rule construing α as contrasting with β via ⟦β⟧ᵒ ∈ ⟦α⟧f): *Canadian
+    farmer*'s ordinary value is a member of *[American]F farmer*'s focus
+    value distinct from its ordinary value. -/
+theorem farmer_contrast :
+    Semantics.Focus.SquiggleInd "American farmer"
+      ({"American farmer", "Canadian farmer"} : Set String)
+      "Canadian farmer" :=
+  ⟨Or.inr rfl, by decide⟩
+
 -- ═══════════════════════════════════════════════════════════════════════
 -- §7  "Only" Association ([rooth-1992] §2.1)
 -- ═══════════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -2,6 +2,7 @@ import Linglib.Features.InformationStructure
 import Linglib.Semantics.Alternatives.AltMeaning
 import Linglib.Semantics.Focus.Interpretation
 import Linglib.Semantics.Focus.Control
+import Linglib.Semantics.Focus.Particles
 import Linglib.Semantics.Composition.Tree
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Predicates.Verbal
@@ -318,6 +319,72 @@ theorem farmer_contrast :
       ({"American farmer", "Canadian farmer"} : Set String)
       "Canadian farmer" :=
   ⟨Or.inr rfl, by decide⟩
+
+-- ───────────────────────────────────────────────────────────────────
+-- §6d  Strong vs Direct Association ("The Recognitions")
+-- ───────────────────────────────────────────────────────────────────
+
+/-! With a focused transitive verb, the full focus value contains
+    "even trivial relations", so fixing *only*'s domain to it yields
+    unsatisfiable truth conditions — while intuitively *Mary only READ
+    The Recognitions* can be true. The strong theory's separately
+    resolved `C` "might be quite a small set"; a lexically carried
+    alternative list cannot be pragmatically narrowed. -/
+
+/-- Worlds tracking Mary's relation to *The Recognitions*. -/
+inductive RWorld where
+  | readOnly      -- read it, nothing more
+  | readAndGrasp  -- read and understood it
+  | neither
+  deriving DecidableEq, Repr
+
+/-- 'reading The Recognitions'. -/
+def reading : Set RWorld := {.readOnly, .readAndGrasp}
+/-- 'understanding The Recognitions'. -/
+def grasping : Set RWorld := {.readAndGrasp}
+/-- A trivial property of the same semantic type — a member of the
+    full focus value. -/
+def trivialR : Set RWorld := Set.univ
+
+/-- With the pragmatically restricted domain, *only READ* is
+    satisfiable: true where Mary read without understanding. -/
+theorem restricted_only_satisfiable :
+    RWorld.readOnly ∈
+      Semantics.Focus.onlyVia {reading, grasping} reading := by
+  intro q hq hw
+  rcases hq with rfl | rfl
+  · rfl
+  · exact absurd hw (by simp [grasping])
+
+/-- With the domain fixed to the full focus value (trivial property
+    included), *only READ* is unsatisfiable — direct association
+    over-generates exclusions. -/
+theorem direct_only_unsatisfiable :
+    Semantics.Focus.onlyVia {reading, grasping, trivialR} reading = ∅ := by
+  have hne : trivialR ≠ reading := fun h =>
+    (by simp [reading] : RWorld.neither ∉ reading)
+      (h ▸ Set.mem_univ RWorld.neither)
+  ext w
+  simp only [Semantics.Focus.mem_onlyVia, Set.mem_empty_iff_false, iff_false]
+  exact fun hw => hne (hw trivialR (by simp) (Set.mem_univ w))
+
+private def readingB : RWorld → Bool
+  | .readOnly | .readAndGrasp => true
+  | .neither => false
+private def graspingB : RWorld → Bool
+  | .readAndGrasp => true
+  | _ => false
+private def trivialB : RWorld → Bool := fun _ => true
+
+/-- The direct-association operator with its lexically carried full
+    alternative list is the same over-generation, exhibited on
+    `TraditionalOnly` itself: its assertion is everywhere false in this
+    model. No pragmatic narrowing is possible — the list is fixed in
+    the lexical entry, which is the strong theory's objection. -/
+theorem traditional_only_unsatisfiable (w : RWorld) :
+    (Semantics.Focus.Particles.TraditionalOnly.mk
+      readingB [graspingB, trivialB]).assertion w = false := by
+  cases w <;> rfl
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- §7  "Only" Association ([rooth-1992] §2.1)

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -562,6 +562,64 @@ theorem comp_grounds_fredAteRice :
   funext w; cases w <;> rfl
 
 -- ═══════════════════════════════════════════════════════════════════════
+-- §12b  The Focus Dimension Through the Same Engine
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-! F-marking is a non-`pure` lexicon entry: the same `interp` that
+    computes ordinary values at `M = Id` computes focus values at
+    `M = AltMeaning` (`pure = AltMeaning.unfeatured` lifts the
+    focus-free entries), with `applyForward`'s `<*>` doing Hamblin
+    functional application. -/
+
+/-- Alternatives do not distribute through predicate abstraction —
+    the honest `none`. -/
+instance (E W : Type) : PredAbs AltMeaning E W := ⟨none⟩
+
+/-- The focus lexicon at `M = AltMeaning`: every entry `pure`-lifts
+    except focused *[Fred]F*, whose entry carries the subject
+    alternatives. -/
+def focusLexF (w : QAWorld) : Lexicon E Unit AltMeaning := fun word =>
+  match word with
+  | "Fred" => some ⟨.e, (⟨E.fred, [E.fred, E.mary]⟩ : AltMeaning _)⟩
+  | w' => Lexicon.lift AltMeaning (focusLex w) w'
+
+/-- Focus-dimension tree interpretation. -/
+def treeResultF (lex : Lexicon E Unit AltMeaning) (t : Tree Unit String) :
+    Option (AltMeaning Prop) :=
+  match interp E Unit lex g₀ t with
+  | some ⟨.t, p⟩ => some p
+  | _ => none
+
+/-- The engine at `M = AltMeaning` computes the two-dimensional meaning
+    of *[FRED]F ate the beans*: the O-value is the ordinary
+    interpretation and the A-value is the subject-alternative family —
+    the focus value is computed, not stipulated. -/
+theorem treeResultF_fredAteBeans (w : QAWorld) :
+    treeResultF (focusLexF w) tree_fredAteBeans =
+      some ⟨ateInWorld w E.beans E.fred,
+            [ateInWorld w E.beans E.fred, ateInWorld w E.beans E.mary]⟩ := by
+  cases w <;> rfl
+
+/-- O-projection through the engine: mapping `oValue` over the
+    `AltMeaning` run recovers the `Id` run. -/
+theorem treeResultF_oValue (w : QAWorld) :
+    (treeResultF (focusLexF w) tree_fredAteBeans).map (·.oValue) =
+      treeResult (focusLex w) tree_fredAteBeans := by
+  cases w <;> rfl
+
+/-- The stipulated `fv_subjectFocus` of §6 is exactly the engine's
+    computed alternative family, read as proposition sets. -/
+theorem fv_subjectFocus_computed :
+    fv_subjectFocus =
+      {{w | ateInWorld w E.beans E.fred}, {w | ateInWorld w E.beans E.mary}} := by
+  have h1 : ({w | ateInWorld w E.beans E.fred} : Set QAWorld) = fredAteBeans := by
+    ext w; cases w <;> simp [ateInWorld, fredAteBeans]
+  have h2 : ({w | ateInWorld w E.beans E.mary} : Set QAWorld) = maryAteBeans := by
+    ext w; cases w <;> simp [ateInWorld, maryAteBeans]
+  rw [h1, h2]
+  rfl
+
+-- ═══════════════════════════════════════════════════════════════════════
 -- §13  Fragment Connection
 -- ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
The deep-Rooth arc: the three missing pillars identified by the source-verified audit, all run through the existing effect-polymorphic interpreter.

- **Full squiggle** (his (40), both cases): `SquiggleSet`/`SquiggleInd`, the `phrase` constructor, `Antecedent.Resolves` (with the correction clause: assertion antecedents require o ≠ p), `not_squiggleSet_unfeatured` = "the argument must contain a focus"
- **Composition engine**: `AltMeaning` as a lawful `Monad` (Id ⋉ List); O-projection a monad morphism; Hamblin-application membership laws; `WellFormed` preservation; Rooth1992 §12b runs the same tree through `Tree.interp` at `M := AltMeaning` (F-marking = non-pure lexicon entry; `PredAbs AltMeaning = ⟨none⟩`), deriving the stipulated `fv_subjectFocus`
- **One scenario shape**: `Use.model` + `pairAnswer` + `use_model_resolves` replace HZ2007's ten per-cell enums/controls/answers with a single two-point scenario and one ∀-use resolution theorem; content lives in the JSON rows
- **Strong-theory *only*** (his (9)): `onlyVia` quantifies over the resolved contrast variable — no lexical access to focus values — with `onlyVia_antitone` (pragmatic domain restriction) and the divergence exhibited in Rooth1992's Recognitions model: restricted domain satisfiable, full-focus-value domain unsatisfiable, and `TraditionalOnly`'s lexically fixed list reproduces the over-generation with no narrowing possible. HZ2007's §3.2.5 TODO discharged: `exhAnswer_eq` — exhaustification is strategy-blind, uniformly across the four uses.