### PR TITLE
feat(Fragments/Tangale): ground HZ2004 in Kidda's grammar

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2382,6 +2382,7 @@ import Linglib.Studies.KatzirSingh2015
 import Linglib.Studies.Kawahara2015
 import Linglib.Studies.KayFillmore1999
 import Linglib.Studies.KayMichaelis2019
+import Linglib.Studies.Kenstowicz1987
 import Linglib.Studies.KeenanComrie1977
 import Linglib.Studies.KeenanStavi1986
 import Linglib.Studies.KehlerRohde2013

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1203,6 +1203,7 @@ import Linglib.Fragments.Tagalog.TemporalConnectives
 import Linglib.Fragments.Tagalog.TenseAspect
 import Linglib.Fragments.Tamil.Case
 import Linglib.Fragments.Tamil.Pronouns
+import Linglib.Fragments.Tangale.Phonology
 import Linglib.Fragments.Tangale.TAM
 import Linglib.Fragments.Taos.Agreement
 import Linglib.Fragments.Tariana.Evidentiality

--- a/Linglib/Fragments/Tangale/Phonology.lean
+++ b/Linglib/Fragments/Tangale/Phonology.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.AR
+
+/-!
+# Tangale tone processes and the elision cascade
+
+[kidda-1985]'s tonal and segmental rules that carry the perfective
+focus-marking reflex of [hartmann-zimmermann-2004]. Tonemes are two
+(H, L; §1.16); High Tone Spread (her (31)) links a boundary-adjacent
+H one TBU rightward, creating a falling contour on the docked TBU,
+and Left Line Delinking (her (35a), her coinage) then erases the
+original line, shifting the H. Segmentally, final-vowel elision plus
+u-epenthesis into the resulting final cluster produce the perfective
+alternation *pon-go ~ pon-ug* (her (4a)): the suffix surfaces
+faithful at a prosodic boundary and elided–repaired phrase-medially.
+`boundary_audible` is the witness that blocking the cascade — the
+prosodic reflex of [hartmann-zimmermann-2004]'s perfective focus —
+is perceptible.
+-/
+
+namespace Tangale
+
+open Autosegmental
+
+/-- Tangale tonemes ([kidda-1985] §1.16): two levels; extralow is a
+phonetic realization, and falling contours arise only from spread. -/
+inductive Tone where
+  | H | L
+  deriving DecidableEq, Repr
+
+variable {β : Type*}
+
+/-- High Tone Spread ([kidda-1985] (31)): the toneme at `i` — an H
+linked to TBU `j` at a morpheme or word boundary — spreads onto the
+following TBU. The structural description is carried by the
+application theorems. -/
+def hts (g : Graph Tone β) (i j : ℕ) : Graph Tone β := g.link i (j + 1)
+
+/-- Left Line Delinking ([kidda-1985] (35a)): erase the original
+(left) line after the toneme has spread rightward. -/
+def lld (g : Graph Tone β) (i j : ℕ) : Graph Tone β := g.delink i j
+
+/-- Spread creates the falling contour (§4.6): the docked TBU
+surfaces with H on top of whatever it already bore. -/
+theorem hts_surfacesWith_H {g : Graph Tone β} {i j : ℕ}
+    (hH : g.upper.get? i = some Tone.H) :
+    (hts g i j).SurfacesWith Tone.H (j + 1) :=
+  ⟨i, Finset.mem_insert_self _ _, hH⟩
+
+/-- Spread followed by Left Line Delinking shifts the H one TBU
+rightward ((34)): the docked TBU keeps the new line and the source
+loses the original. -/
+theorem lld_hts_shift {g : Graph Tone β} {i j : ℕ}
+    (hH : g.upper.get? i = some Tone.H) :
+    (lld (hts g i j) i j).SurfacesWith Tone.H (j + 1) ∧
+    (i, j) ∉ (lld (hts g i j) i j).links := by
+  refine ⟨⟨i, ?_, hH⟩, by simp [lld, hts]⟩
+  simp [lld, hts]
+
+/-- Blocking is representationally visible: where the spread line is
+absent, applying HTS changes the graph. -/
+theorem hts_ne_self {g : Graph Tone β} {i j : ℕ}
+    (h : (i, j + 1) ∉ g.links) : hts g i j ≠ g :=
+  fun he => h (he ▸ Finset.mem_insert_self _ _)
+
+/-- 'Horse is good' ([kidda-1985] (29a) *tuužé koŋ*): H on the noun's
+final TBU, L on the predicate. -/
+def horseIsGood : Graph Tone Unit :=
+  ⟨.ofList [Tone.H, Tone.L], .ofList [(), (), ()], {(0, 1), (1, 2)}⟩
+
+/-- After HTS the predicate TBU bears both H and L — the falling
+contour of *tụụzẹ́ kôŋ*, realized as such pause-finally ((29a)). -/
+example :
+    (hts horseIsGood 0 1).SurfacesWith Tone.H 2 ∧
+    (hts horseIsGood 0 1).SurfacesWith Tone.L 2 := by decide
+
+/-! ### The elision cascade (Ch. 2)
+
+Final-vowel elision builds consonant clusters; the cluster
+constraints then force u-epenthesis. On the perfective suffix this
+yields [kidda-1985]'s (4a) alternation `pón-é + gó → pon-go`
+(clause-final, faithful) vs `pon-ug` (phrase-medial, elided and
+repaired) — the alternation whose blocking under focus is
+[hartmann-zimmermann-2004]'s prosodic reflex. -/
+
+/-- CV slots for the cluster phonotactics. -/
+inductive Slot where
+  | C | V
+  deriving DecidableEq, Repr
+
+/-- The cluster constraints ([kidda-1985] p. 64): initial clusters
+are impermissible, medial three-consonant clusters are disallowed,
+and word-final clusters are not permitted. -/
+def Phonotactic (w : List Slot) : Prop :=
+  ¬ [Slot.C, Slot.C] <+: w ∧
+  ¬ [Slot.C, Slot.C, Slot.C] <:+: w ∧
+  ¬ [Slot.C, Slot.C] <:+ w
+
+instance (w : List Slot) : Decidable (Phonotactic w) :=
+  inferInstanceAs (Decidable (¬ _ ∧ ¬ _ ∧ ¬ _))
+
+/-- Final-vowel elision (§2.2): delete a word-final vowel. Triggered
+by suffixation, compounding, and phrase-medial position; blocked at
+a prosodic boundary. -/
+def ve (w : List Slot) : List Slot :=
+  if w.getLast? = some Slot.V then w.dropLast else w
+
+/-- u-epenthesis ((4)): repair a word-final cluster by inserting the
+vowel between the penultimate and ultimate consonants. -/
+def epenthesize (w : List Slot) : List Slot :=
+  if [Slot.C, Slot.C] <:+ w then w.dropLast ++ [Slot.V, Slot.C] else w
+
+/-- *pón-é* 'knew' ((4a)). -/
+def ponE : List Slot := [.C, .V, .C, .V]
+/-- The perfective suffix *gó*. -/
+def go : List Slot := [.C, .V]
+
+/-- The boundary form: word-internal elision only; the suffix
+surfaces faithful (*pon-go*; before a focused constituent,
+*wai-gó lánda* of [hartmann-zimmermann-2004] (25)). -/
+def blockedForm : List Slot := ve ponE ++ go
+
+/-- The phrase-medial form: phrasal elision hits the suffix vowel and
+epenthesis repairs the final cluster (*pon-ug ŋâi* 'knew Ngai'). -/
+def elidedForm : List Slot := epenthesize (ve (ve ponE ++ go))
+
+/-- The cascade is audible: both outputs are phonotactically licit
+and they differ — blocking phrasal elision (the prosodic boundary
+of the perfective focus reflex) is perceptible. -/
+theorem boundary_audible :
+    blockedForm ≠ elidedForm ∧
+    Phonotactic blockedForm ∧ Phonotactic elidedForm := by decide
+
+end Tangale

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -125,6 +125,23 @@ def empty : Graph α β := ⟨LabeledTuple.empty, LabeledTuple.empty, ∅⟩
 /-- **Planar** (no-crossing): the link set satisfies [goldsmith-1976]'s NCC. -/
 def IsPlanar : Prop := IsNonCrossing r.links
 
+/-! ### Link rewrites -/
+
+/-- Add an association line — the elementary *spread* step. -/
+def link (i j : ℕ) : Graph α β := { r with links := insert (i, j) r.links }
+
+/-- Erase an association line — the elementary *delink* step. -/
+def delink (i j : ℕ) : Graph α β := { r with links := r.links.erase (i, j) }
+
+@[simp] theorem mem_link_links {i j : ℕ} {p : ℕ × ℕ} :
+    p ∈ (r.link i j).links ↔ p = (i, j) ∨ p ∈ r.links := Finset.mem_insert
+
+@[simp] theorem mem_delink_links {i j : ℕ} {p : ℕ × ℕ} :
+    p ∈ (r.delink i j).links ↔ p ≠ (i, j) ∧ p ∈ r.links := Finset.mem_erase
+
+@[simp] theorem link_upper (i j : ℕ) : (r.link i j).upper = r.upper := rfl
+@[simp] theorem delink_upper (i j : ℕ) : (r.delink i j).upper = r.upper := rfl
+
 /-! ### Index predicates -/
 
 /-- Upper index `i` is **linked** to some lower position (no in-bounds check). -/

--- a/Linglib/Studies/HartmannZimmermann2004.lean
+++ b/Linglib/Studies/HartmannZimmermann2004.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Semantics.Focus.Control
 import Linglib.Semantics.Focus.Realization
+import Linglib.Fragments.Tangale.TAM
 import Linglib.Data.Examples.HartmannZimmermann2004
 
 /-!
@@ -24,14 +25,16 @@ structural.
 
 ## Implementation notes
 
-The marking function and its `Strategy` codomain are study-local; with
-Hausa (`HartmannZimmermann2007.lean`) they are the two data points for
-a future `Semantics/Focus/Realization.lean` (the marking-typology
-layer). The *núm* readings use the strong-theory
+Realisation uses the shared `Semantics.Focus.Realization` vocabulary
+(reflex lists; `Strategy` is the paper's label set, derived from the
+reflex shape). The aspect frames are grounded in the Tangale fragment
+via `Aspect.entry`: the perfective rows carry [kidda-1985]'s singular
+perfective suffix and the paper's progressive is the fragment's
+continuous (preposed *né*). The *núm* readings use the strong-theory
 `Semantics.Focus.onlyVia`: one string, three contrast-set resolutions.
 
 The paper's fn. 6 notes the suffix *-i* does not occur with all
-intransitive verbs; `marking` idealises it as the intransitive
+intransitive verbs; `realize` idealises it as the intransitive
 perfective strategy. The autosegmental detail of the boundary
 diagnosis (vowel elision, left-line delinking, H-spread) is kept as
 prose; formalising it against the tone substrate is a TODO.
@@ -39,10 +42,7 @@ prose; formalising it against the tone substrate is a TODO.
 ## TODO
 
 * The VE/LLD phonology as autosegmental operations (connect to the
-  tone substrate).
-* Graduate the marking vocabulary to `Semantics/Focus/Realization.lean`
-  once this file and `HartmannZimmermann2007.lean` consume a shared
-  version (the B7 plan).
+  tone substrate; [kidda-1985] Ch. 2 and Ch. 4 are the sources).
 * The paper's two solutions (§6): the prosodic-boundary account vs the
   subjects-vs-non-subjects account as rival `Predict`-style theories.
 -/
@@ -58,6 +58,22 @@ open Semantics.Focus.Interpretation (PropFocusValue)
 inductive Aspect where
   | perfective | progressive
   deriving DecidableEq, Repr
+
+/-- The fragment entry realising each aspect frame
+(`Fragments/Tangale/TAM.lean`): the perfective rows carry
+[kidda-1985]'s singular perfective (the *-gó* of *wai-gó*, *wur-gó*),
+and the paper's progressive is the continuous (preposed *né*, the
+paper's PROG *n*). -/
+def Aspect.entry : Aspect → Tangale.TAMEntry
+  | .perfective  => Tangale.perfectiveSg
+  | .progressive => Tangale.continuous
+
+/-- The paper's glosses are grounded in the fragment: PERF is the
+voiced alternant of the perfective suffix, and PROG is the preposed
+continuous marker. -/
+theorem aspect_entry_grounds_glosses :
+    "gó" ∈ Aspect.perfective.entry.suffixAlternants ∧
+    Aspect.progressive.entry.marker = .preposed "né" := by decide
 
 /-- The focused constituent in the paper's paradigm. -/
 inductive Focused where

--- a/Linglib/Studies/HartmannZimmermann2004.lean
+++ b/Linglib/Studies/HartmannZimmermann2004.lean
@@ -7,6 +7,7 @@ import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Semantics.Focus.Control
 import Linglib.Semantics.Focus.Realization
 import Linglib.Fragments.Tangale.TAM
+import Linglib.Fragments.Tangale.Phonology
 import Linglib.Data.Examples.HartmannZimmermann2004
 
 /-!
@@ -35,14 +36,15 @@ continuous (preposed *né*). The *núm* readings use the strong-theory
 
 The paper's fn. 6 notes the suffix *-i* does not occur with all
 intransitive verbs; `realize` idealises it as the intransitive
-perfective strategy. The autosegmental detail of the boundary
-diagnosis (vowel elision, left-line delinking, H-spread) is kept as
-prose; formalising it against the tone substrate is a TODO.
+perfective strategy. The boundary diagnosis is grounded in
+`Fragments/Tangale/Phonology.lean`: `prosodic_reflex_audible` cites
+[kidda-1985]'s elision cascade as what makes the boundary reflex
+perceptible.
 
 ## TODO
 
-* The VE/LLD phonology as autosegmental operations (connect to the
-  tone substrate; [kidda-1985] Ch. 2 and Ch. 4 are the sources).
+* The interleaved elision-feeding-tone-shift derivations of
+  [kidda-1985] (34) on lexical forms.
 * The paper's two solutions (§6): the prosodic-boundary account vs the
   subjects-vs-non-subjects account as rival `Predict`-style theories.
 -/
@@ -149,6 +151,14 @@ chapter states against the Basic Focus Rule. -/
 theorem tangale_refutes_perceptibility :
     ¬ Semantics.Focus.EveryFocusPerceptible realize :=
   fun h => h ⟨.object, .progressive, true⟩ rfl
+
+/-- The prosodic reflex is audible: the boundary-blocked perfective
+form differs from the phrase-medial elided form — [kidda-1985]'s
+elision cascade is what makes `Reflex.prosodic` perceptible in the
+(25) cells. -/
+theorem prosodic_reflex_audible :
+    Tangale.blockedForm ≠ Tangale.elidedForm :=
+  Tangale.boundary_audible.1
 
 /-- The perfective boundary underdetermines the focus extent: on
 transitive perfective non-subject configurations, `focused` does not

--- a/Linglib/Studies/Kenstowicz1987.lean
+++ b/Linglib/Studies/Kenstowicz1987.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Logic.FactorsThroughOn
+import Linglib.Fragments.Tangale.Phonology
+
+/-!
+# Tangale sandhi as a probe for syntactic structure
+
+Formalises [kenstowicz-1987]: the blockage of phrasal phonological
+rules can reveal surface syntax "that we did not already know".
+Tangale elision and tonal delinking apply obligatorily between a verb
+and its object (15b, e) but block before a wh-object (15c, f). A
+[wh]-sensitive sandhi rule is rejected both on interface-theoretic
+grounds and by the minimal pair (16): wh-*possessors* inside NP
+trigger elision (*ayab noŋ* 'whose banana'). The solution: wh-subjects
+obligatorily postpose to a position with "the force of the English
+cleft" (18) — the Focus position — and apparently in-situ wh-objects
+occupy it string-vacuously, so a constituent boundary blocks sandhi.
+Elision tracks government exactly once the Focus position is admitted;
+the [wh] feature does not factor it.
+-/
+
+namespace Kenstowicz1987
+
+/-- The junctures at which the sandhi rules are tested
+((4)–(5), (15)–(16)). -/
+inductive Juncture where
+  | headComplementNP
+  | verbObject
+  | verbAdjunct
+  | subjectVP
+  | verbWhObject
+  | headWhPossessor
+  deriving DecidableEq, Repr
+
+/-- Observed: elision (and delinking) applies at the juncture
+((4a, b), (5a–c), (15c, f), (16a, b)). -/
+def elides : Juncture → Bool
+  | .headComplementNP => true
+  | .verbObject       => true
+  | .verbAdjunct      => false
+  | .subjectVP        => false
+  | .verbWhObject     => false
+  | .headWhPossessor  => true
+
+/-- Whether the juncture's second element is a wh-word. -/
+def secondIsWh : Juncture → Bool
+  | .verbWhObject | .headWhPossessor => true
+  | _ => false
+
+/-- The juncture is a government configuration under the Focus-position
+analysis: head–complement and verb–object are; adjuncts and subjects
+are not; a wh-object sits in the postverbal Focus position across a
+constituent boundary (string-vacuous postposing, as with the
+obligatorily postposed wh-subjects of (18)); a wh-possessor has no
+NP-internal Focus position and stays in situ. -/
+def governed : Juncture → Bool
+  | .headComplementNP => true
+  | .verbObject       => true
+  | .verbAdjunct      => false
+  | .subjectVP        => false
+  | .verbWhObject     => false
+  | .headWhPossessor  => true
+
+/-- The rejected account: elision does not factor through the [wh]
+feature of the second word — wh-objects block it while wh-possessors
+trigger it ((15c, f) vs (16a, b)). -/
+theorem elision_not_factor_through_wh :
+    ¬ Function.FactorsThroughOn elides secondIsWh Set.univ := by
+  rw [Function.not_factorsThroughOn_iff_exists_witness]
+  exact ⟨.verbWhObject, .headWhPossessor, trivial, trivial, rfl, by decide⟩
+
+/-- His solution: elision tracks government exactly, once apparently
+in-situ wh-objects are placed in the postverbal Focus position. The
+blockage is a syntactic discovery made by phonology. -/
+theorem elision_tracks_government : ∀ j, elides j = governed j := by
+  intro j; cases j <;> rfl
+
+/-- (15d–f): before a wh-object the verb surfaces in the blocked
+(faithful) form (*dobgo noŋ*), before a plain object in the
+elided–repaired form (*dobug Malay*) — audibly distinct by
+[kidda-1985]'s cascade. -/
+theorem wh_object_cell_audible :
+    Tangale.blockedForm ≠ Tangale.elidedForm :=
+  Tangale.boundary_audible.1
+
+end Kenstowicz1987

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -35350,3 +35350,17 @@
   role      = {reference},
   sources   = {Fragments/Tangale/TAM.lean}
 }
+
+% REF: Kenstowicz, M. (1987). The phonology and syntax of wh-expressions in Tangale. Phonology Yearbook 4: 229-241.
+@article{kenstowicz-1987,
+  author    = {Kenstowicz, Michael},
+  year      = {1987},
+  title     = {The Phonology and Syntax of Wh-Expressions in {Tangale}},
+  journal   = {Phonology Yearbook},
+  volume    = {4},
+  pages     = {229--241},
+  doi       = {10.1017/S0952675700000841},
+  subfield  = {phonology},
+  role      = {formalized},
+  sources   = {Studies/Kenstowicz1987.lean}
+}


### PR DESCRIPTION
Wires the Tangale study to consensus grammar and lands the origin paper of the boundary diagnosis. Sources read and verified: Kidda 1985 §2.2 + §4.6–4.7 (scan), Kenstowicz 1987 (Phonology Yearbook 4, DOI verified).

- `Aspect.entry`: the study's aspect frames map to the fragment's paradigm entries, with `aspect_entry_grounds_glosses` pinning the PERF/PROG glosses to *-gó* and preposed *né*
- **`Graph.link`/`Graph.delink`** (Autosegmental substrate): the elementary spread/delink rewrites
- **`Fragments/Tangale/Phonology.lean`**: HTS (Kidda (31)) and LLD (her (35a), her coinage) as graph rewrites with the falling-contour and H-shift theorems and the (29a) derivation; the elision cascade — her p. 64 cluster phonotactics, final-vowel elision, u-epenthesis — deriving the (4a) *pon-go ~ pon-ug* alternation; `boundary_audible`
- **`prosodic_reflex_audible`** in the study: what makes `Reflex.prosodic` perceptible in the (25) cells, derived from the cascade; the VE/LLD TODO discharged
- **`Studies/Kenstowicz1987.lean`** (third consumer): sandhi blockage as a syntactic probe — `elision_not_factor_through_wh` (the (15)/(16) minimal pair: wh-objects block elision, wh-possessors trigger it — the [wh]-sensitive account refuted as a factor-through failure) and `elision_tracks_government` (admitting the postverbal Focus position, where his (18) postposed wh-subjects have 'the force of the English cleft' — the origin of the Tangale/Chadic focus-position analysis H&Z later inherit)