### PR TITLE
feat(Pragmatics/RSA): ScoreChain combinators and certified atoms

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1416,6 +1416,7 @@ import Linglib.Pragmatics.Implicature.SomeAll
 import Linglib.Pragmatics.InformationTheory.Channel
 import Linglib.Pragmatics.InformationTheory.ChannelCapacity
 import Linglib.Pragmatics.RSA.ArgumentativeStrength
+import Linglib.Pragmatics.RSA.Atoms
 import Linglib.Pragmatics.RSA.BToM
 import Linglib.Pragmatics.RSA.Cancellation
 import Linglib.Pragmatics.RSA.Canonical
@@ -1432,6 +1433,7 @@ import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.RSA.QUD
 import Linglib.Pragmatics.RSA.Ranking
 import Linglib.Pragmatics.RSA.ReferenceGame
+import Linglib.Pragmatics.RSA.ScoreChain
 import Linglib.Pragmatics.RSA.Sequential
 import Linglib.Pragmatics.RSA.Silence
 import Linglib.Pragmatics.RSA.SimpAttr
@@ -2385,7 +2387,6 @@ import Linglib.Studies.KatzirSingh2015
 import Linglib.Studies.Kawahara2015
 import Linglib.Studies.KayFillmore1999
 import Linglib.Studies.KayMichaelis2019
-import Linglib.Studies.Kenstowicz1987
 import Linglib.Studies.KeenanComrie1977
 import Linglib.Studies.KeenanStavi1986
 import Linglib.Studies.KehlerRohde2013
@@ -2396,6 +2397,7 @@ import Linglib.Studies.Kennedy2007
 import Linglib.Studies.Kennedy2015
 import Linglib.Studies.Kennedy2015PMF
 import Linglib.Studies.KennedyLevin2008
+import Linglib.Studies.Kenstowicz1987
 import Linglib.Studies.KeshetAbney2024
 import Linglib.Studies.KeshetAbney2024.Basic
 import Linglib.Studies.KeshetAbney2024.Bridges

--- a/Linglib/Pragmatics/RSA/Atoms.lean
+++ b/Linglib/Pragmatics/RSA/Atoms.lean
@@ -1,0 +1,85 @@
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.Complex.ExponentialBounds
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+/-!
+# Certified atoms for transcendental RSA models
+
+RSA models with real-exponent utilities or exponential costs reduce, after
+exact-rational bookkeeping, to a handful of named transcendental *atoms*:
+n-th roots of explicit rationals (softmax utilities with denominator-`n`
+weights) and `exp` of negated rational costs. This file provides the atoms
+and their two-sided rational-bound certificates, so study-level predictions
+close by `nlinarith` over kernel-checked power inequalities.
+
+* `rootAtom X n` is `X ^ (n⁻¹ : ℝ)`: bound it by exhibiting `r ^ n ≤ X` and
+  `X ≤ s ^ n`, both kernel-checkable when `r`, `s`, `X` are rational.
+* `expAtom q` is `exp (−q)`: for rational `q = m / n` the identity
+  `expAtom q ^ n * exp m = 1` turns digit bounds on `e` into two-sided
+  bounds on the atom.
+
+## Main results
+
+* `le_rootAtom_of_pow_le`, `rootAtom_le_of_le_pow`, `rootAtom_mem_Icc` —
+  n-th-root certificates.
+* `rootAtom_eq_exp` — the bridge to the paper-facing `exp`/`log` form.
+* `expAtom_pow_mul_exp_eq_one` — the inversion identity for cost atoms.
+-/
+
+open Real
+
+namespace RSA
+
+/-! ### Root atoms -/
+
+/-- The `n`-th root of `X` as a real power. For rational `X` this is the
+shape of softmax utilities with denominator-`n` weights. -/
+noncomputable def rootAtom (X : ℝ) (n : ℕ) : ℝ := X ^ ((n : ℝ)⁻¹)
+
+theorem rootAtom_pos {X : ℝ} (hX : 0 < X) (n : ℕ) : 0 < rootAtom X n :=
+  Real.rpow_pos_of_pos hX _
+
+/-- Lower certificate: `r ^ n ≤ X` gives `r ≤ ⁿ√X`. -/
+theorem le_rootAtom_of_pow_le {r X : ℝ} {n : ℕ} (hn : n ≠ 0) (hr : 0 ≤ r)
+    (h : r ^ n ≤ X) : r ≤ rootAtom X n := by
+  rw [rootAtom, ← Real.pow_rpow_inv_natCast hr hn]
+  exact Real.rpow_le_rpow (by positivity) h (by positivity)
+
+/-- Upper certificate: `X ≤ s ^ n` gives `ⁿ√X ≤ s`. -/
+theorem rootAtom_le_of_le_pow {X s : ℝ} {n : ℕ} (hn : n ≠ 0) (hX : 0 ≤ X)
+    (hs : 0 ≤ s) (h : X ≤ s ^ n) : rootAtom X n ≤ s := by
+  rw [rootAtom, ← Real.pow_rpow_inv_natCast hs hn]
+  exact Real.rpow_le_rpow hX h (by positivity)
+
+/-- Two-sided certificate from kernel-checkable power bounds. -/
+theorem rootAtom_mem_Icc {r X s : ℝ} {n : ℕ} (hn : n ≠ 0) (hr : 0 ≤ r)
+    (hX : 0 ≤ X) (hs : 0 ≤ s) (hlo : r ^ n ≤ X) (hhi : X ≤ s ^ n) :
+    rootAtom X n ∈ Set.Icc r s :=
+  ⟨le_rootAtom_of_pow_le hn hr hlo, rootAtom_le_of_le_pow hn hX hs hhi⟩
+
+/-- Bridge to the paper-facing exponential form:
+`ⁿ√X = exp (log X / n)` for positive `X`. (The `log X * n⁻¹` orientation
+is what `rpow_def_of_pos` produces; commute afterwards as needed.) -/
+theorem rootAtom_eq_exp {X : ℝ} (hX : 0 < X) (n : ℕ) :
+    rootAtom X n = Real.exp (Real.log X / n) := by
+  rw [rootAtom, Real.rpow_def_of_pos hX, div_eq_mul_inv]
+
+/-! ### Exponential cost atoms -/
+
+/-- The multiplicative cost factor `exp (−q)` for a cost `q`. -/
+noncomputable def expAtom (q : ℝ) : ℝ := Real.exp (-q)
+
+theorem expAtom_pos (q : ℝ) : 0 < expAtom q := Real.exp_pos _
+
+/-- The inversion identity: for `q = m / n`, `expAtom q ^ n · exp m = 1`.
+Combined with digit bounds on `exp m` (from `Real.exp_one_gt_d9` /
+`exp_one_lt_d9` raised by `pow_lt_pow_left₀`), this yields two-sided
+rational bounds on the atom via kernel-checked power comparisons. -/
+theorem expAtom_pow_mul_exp_eq_one {m : ℝ} {n : ℕ} (hn : n ≠ 0) :
+    expAtom (m / n) ^ n * Real.exp m = 1 := by
+  rw [expAtom, ← Real.exp_nat_mul,
+    show (n : ℝ) * -(m / n) = -m by
+      field_simp,
+    ← Real.exp_add, neg_add_cancel, Real.exp_zero]
+
+end RSA

--- a/Linglib/Pragmatics/RSA/ScoreChain.lean
+++ b/Linglib/Pragmatics/RSA/ScoreChain.lean
@@ -1,0 +1,109 @@
+import Linglib.Core.Probability.Scores
+
+/-!
+# RSA score chains in ℚ≥0
+
+Combinators for the exact-rational face of RSA models: literal listener,
+exponentiated speaker with cost, joint pragmatic listener, marginals, and
+stacked higher-order speakers. A study composes these into its chain and
+wraps normalization sites with `PMF.ofScores`; predictions then reduce to
+`ℚ≥0` comparisons closed by `decide +kernel` via the `PMF.ofScores_lt`
+family.
+
+`s1` applies `PMF.scoresWith` mid-tower, so a zero-mass utterance row takes
+its declared fallback *inside* the ℚ≥0 values — downstream marginals are
+total and the PMF bridges need no side conditions.
+
+Scope: this face covers natural-`α`, rational-parameter models. Models with
+transcendental ingredients state their chains on the `ℝ≥0∞`
+`RSA.Canonical`/operator face with kernel-certified rational bounds on
+named atoms.
+
+## Main definitions
+
+* `RSA.Score.l0` — literal listener from a Boolean meaning and a prior.
+* `RSA.Score.s1` — speaker scores `l0^α · cost`, fallback-completed.
+* `RSA.Score.l1Joint` — joint pragmatic-listener scores over `W × Lat`.
+* `RSA.Score.worldMarginal` / `latentMarginal` — marginals of joint scores.
+* `RSA.Score.s2` — stacked speaker over listener coordinates.
+
+## Kernel hygiene
+
+* Declare the full instance set on ℚ≥0-face sections:
+  `[Fintype _] [DecidableEq _] [Nonempty _]`.
+* Guard on strict inequalities (`Rat.blt` kernel-reduces), never on
+  equality with a `ℚ≥0` sum (its `Decidable` instance may not).
+* Prefer strict-bound sandwiches over equalities with literals.
+* Certify every numeric claim externally (exact fractions, mirroring the
+  Lean definitions including fallback semantics) before proving.
+-/
+
+open scoped NNRat
+
+namespace RSA.Score
+
+variable {U W Lat : Type*} [Fintype U] [Fintype W] [Fintype Lat]
+
+/-- Literal listener: prior conditioned on the meaning's truth, row-wise
+(`÷0 = 0` on utterances true nowhere; speakers complete such rows via
+their fallback). -/
+def l0 (meaning : U → W → Bool) (prior : W → ℚ≥0) (u : U) (w : W) : ℚ≥0 :=
+  (if meaning u w then prior w else 0) /
+    ∑ w', if meaning u w' then prior w' else 0
+
+/-- Speaker scores: `(l0 u w)^α · cost u`, normalized over utterances and
+completed by `fb` on zero-mass rows. `α : ℕ` keeps the chain in ℚ≥0; `cost`
+is the multiplicative cost factor (e.g. a rationalized `exp (−C)`). -/
+def s1 (l0 : U → W → ℚ≥0) (α : ℕ) (cost : U → ℚ≥0) (fb : PMF.Fallback U)
+    (w : W) : U → ℚ≥0 :=
+  PMF.scoresWith fb (fun u => l0 u w ^ α * cost u)
+
+/-- Joint pragmatic-listener scores over world × latent coordinates:
+`prior p · s1 p u`. Wrap with `PMF.ofScores` for the joint listener PMF, or
+marginalize first. -/
+def l1Joint (prior : W × Lat → ℚ≥0) (s1 : W × Lat → U → ℚ≥0) (u : U)
+    (p : W × Lat) : ℚ≥0 :=
+  prior p * s1 p u
+
+/-- World marginal of joint scores. -/
+def worldMarginal (f : W × Lat → ℚ≥0) (w : W) : ℚ≥0 := ∑ l, f (w, l)
+
+/-- Latent marginal of joint scores. -/
+def latentMarginal (f : W × Lat → ℚ≥0) (l : Lat) : ℚ≥0 := ∑ w, f (w, l)
+
+/-- Stacked speaker: scores over utterances from pragmatic-listener
+coordinates `l1World^α · l1Lat^β · cost`, fallback-completed. Higher
+levels iterate the same shape. -/
+def s2 (l1World : U → W → ℚ≥0) (l1Lat : U → Lat → ℚ≥0) (α β : ℕ)
+    (cost : U → ℚ≥0) (fb : PMF.Fallback U) (l : Lat) (w : W) : U → ℚ≥0 :=
+  PMF.scoresWith fb (fun u => l1World u w ^ α * l1Lat u l ^ β * cost u)
+
+/-! ### Basic lemmas -/
+
+omit [Fintype U] in
+theorem l0_le_one (meaning : U → W → Bool) (prior : W → ℚ≥0) (u : U) (w : W) :
+    l0 meaning prior u w ≤ 1 := by
+  unfold l0
+  rcases eq_or_ne (∑ w', if meaning u w' then prior w' else 0) 0 with h | h
+  · simp [h]
+  · rw [div_le_one (pos_iff_ne_zero.mpr h)]
+    exact Finset.single_le_sum (f := fun w' => if meaning u w' then prior w' else 0)
+      (fun _ _ => zero_le) (Finset.mem_univ w)
+
+omit [Fintype U] in
+theorem l0_eq_zero_of_not_meaning {meaning : U → W → Bool} {u : U} {w : W}
+    (h : ¬ meaning u w) (prior : W → ℚ≥0) : l0 meaning prior u w = 0 := by
+  simp [l0, h]
+
+omit [Fintype W] in
+theorem s1_sum_eq_one (l0 : U → W → ℚ≥0) (α : ℕ) (cost : U → ℚ≥0)
+    (fb : PMF.Fallback U) (w : W) : ∑ u, s1 l0 α cost fb w u = 1 :=
+  PMF.scoresWith_sum_eq_one fb _
+
+omit [Fintype U] in
+theorem worldMarginal_l1Joint_total (prior : W × Lat → ℚ≥0)
+    (s1 : W × Lat → U → ℚ≥0) (u : U) :
+    ∑ w, worldMarginal (l1Joint prior s1 u) w = ∑ p, prior p * s1 p u := by
+  simp [worldMarginal, l1Joint, Fintype.sum_prod_type]
+
+end RSA.Score


### PR DESCRIPTION
PR 2 of the RSA API pass (design: scratch/rsa-api-design.md).

- ScoreChain.lean: `RSA.Score.{l0,s1,l1Joint,worldMarginal,latentMarginal,s2}` — the ℚ≥0 combinator kit over `PMF.scoresWith`/`ofScores` (#1157); `s1` fallback-completes mid-tower so downstream marginals are total. Kernel-hygiene checklist in the module docstring.
- Atoms.lean: `rootAtom`/`expAtom` with two-sided rational-bound certificates (`le_rootAtom_of_pow_le` etc. via `Real.pow_rpow_inv_natCast`; `expAtom_pow_mul_exp_eq_one` for digit-bound inversion) — the substrate for transcendental models.