### PR TITLE
refactor(Semantics/Focus): aSet as applicative morphism; audit cleanup

### DIFF
--- a/Linglib/Semantics/Alternatives/AltMeaning.lean
+++ b/Linglib/Semantics/Alternatives/AltMeaning.lean
@@ -103,6 +103,24 @@ ordinary dimension. -/
     b ∈ (mf <*> ma).aSet ↔ ∃ g ∈ mf.aSet, ∃ a ∈ ma.aSet, g a = b := by
   simp [Seq.seq, aSet, unfeatured, eq_comm]
 
+/-! ### `aSet` as a morphism into the `Set` applicative
+
+Together with the `oValue` monad-morphism laws above, these exhibit
+the alternatives monad as a span `Id ⟵ AltMeaning ⟶ Set`: ordinary
+meaning and focal-target set are its two structure-preserving
+projections. Hamblin application is the image of `<*>` under `aSet`. -/
+
+theorem aSet_pure (a : α) : (pure a : AltMeaning α).aSet = {a} := by
+  ext b; simp [pure, aSet, unfeatured]
+
+theorem aSet_seq (mf : AltMeaning (α → β)) (ma : AltMeaning α) :
+    (mf <*> ma).aSet = mf.aSet.seq ma.aSet := by
+  ext b; simp only [mem_aSet_seq, Set.mem_seq_iff]
+
+theorem aSet_bind (m : AltMeaning α) (f : α → AltMeaning β) :
+    (m >>= f).aSet = {b | ∃ a ∈ m.aSet, b ∈ (f a).aSet} := by
+  ext b; simp [Bind.bind, aSet]
+
 /-- Rooth's containment constraint: the A-value contains the O-value. -/
 def WellFormed (m : AltMeaning α) : Prop := m.oValue ∈ m.aValue
 

--- a/Linglib/Semantics/Attitudes/Preferential.lean
+++ b/Linglib/Semantics/Attitudes/Preferential.lean
@@ -103,17 +103,12 @@ Focus triggers significance presup [[kennedy-2007]]
 For positive valence: significance = ∃p ∈ C. μ(x,p) > θ = TSP
 ```
 
-### Rooth Integration (see `Focus/Sensitivity.lean`)
+### Rooth Integration
 
-The compositional chain from focus marking to TSP is now explicit:
-
-- `Focus/Interpretation.lean`: `FocusResolution` bundles ~'s two constraints
-  (C ⊆ ⟦α⟧f, ⟦α⟧o ∈ C)
-- `Focus/Sensitivity.lean`: `focusSignificance` derives the significance
-  presupposition from a degree predicate + FocusResolution;
-  `tsp_from_focus` proves significance = TSP for positive valence;
-  `assertion_entails_tsp` shows TSP is entailed by the assertion
-  (because ⟦α⟧o ∈ C guarantees a witness)
+The squiggle's two constraints (Γ ⊆ ⟦α⟧f, ⟦α⟧o ∈ Γ) live in
+`Semantics/Focus/Control.lean` (`SquiggleSet`, `Antecedent.Resolves`);
+deriving the significance presupposition from a degree predicate plus
+a resolved contrast set is an open TODO.
 -/
 
 /--

--- a/Linglib/Semantics/Focus/Interpretation.lean
+++ b/Linglib/Semantics/Focus/Interpretation.lean
@@ -1,48 +1,27 @@
 import Linglib.Features.InformationStructure
 import Mathlib.Data.Set.Basic
-import Mathlib.Tactic.Tauto
 
 /-!
 # Focus interpretation
 
-Set-based encoding of Rooth's focus interpretation principle (FIP) and
-the squiggle (~) operator. Focus values are represented as `Set (Set W)`,
-matching Hamblin-style question denotations.
-
-## Main definitions
-
-* `PropFocusValue W`: propositional focus value `Set (Set W)`.
-* `Squiggle W`: a squiggle anaphor carrying its contrast set Γ.
-* `fip`: Rooth's focus interpretation principle (Γ ⊆ ⟦α⟧f).
-* `qaCongruent` / `qaCongruentWeak`: Q-A congruence as set-equality
-  and as the weaker subset relation.
-* `FocusResolution W`: bundles FIP with the ordinary-value-in-class
-  constraint.
-* `ClauseEmbedPred W E`: clause-embedding predicate with explicit
-  access to focus alternatives.
-* `IsFocusSensitive`, `IsNotFocusSensitive`: focus sensitivity of a
-  clause-embedding predicate, with a `liftNonFS` lift for the negative
-  case.
+Set-based encoding of Rooth's focus interpretation principle (FIP).
+Focus values are represented as `Set (Set W)`, matching Hamblin-style
+question denotations; the anaphoric squiggle machinery lives in
+`Semantics/Focus/Control.lean`.
 
 ## References
 
-* [rooth-1992], [ozyildiz-etal-2025].
+* [rooth-1992].
 -/
 
 open Features.InformationStructure
 
 namespace Semantics.Focus.Interpretation
 
-variable {W E : Type*}
+variable {W : Type*}
 
 /-- Propositional focus value: a set of propositions over `W`. -/
 abbrev PropFocusValue (W : Type*) := Set (Set W)
-
-/-- The ~ operator introduces a focus constraint via the anaphoric
-contrast set `Γ`. -/
-structure Squiggle (W : Type*) where
-  /-- The contrast set `Γ`, resolved from context. -/
-  contrastSet : Set (Set W)
 
 /-- Focus interpretation principle: the contextual contrast set `Γ` is a
 subset of the focus semantic value. -/
@@ -58,54 +37,5 @@ def qaCongruent (answerFocus question : PropFocusValue W) : Prop :=
 focus value. -/
 def qaCongruentWeak (answerFocus question : PropFocusValue W) : Prop :=
   question ⊆ answerFocus
-
-/-- The full ~ operator: resolves focus alternatives to a comparison
-class `C` constrained by FIP (`C ⊆ ⟦α⟧f`) and ordinary-inclusion
-(`⟦α⟧o ∈ C`). -/
-structure FocusResolution (W : Type*) where
-  /-- The ordinary semantic value `⟦α⟧o`. -/
-  ordinary : Set W
-  /-- The focus semantic value `⟦α⟧f`. -/
-  focusValue : PropFocusValue W
-  /-- The comparison class `C`, resolved from context. -/
-  comparisonClass : Set (Set W)
-  /-- FIP: `C ⊆ ⟦α⟧f`. -/
-  fip_subset : comparisonClass ⊆ focusValue
-  /-- The ordinary value lies in the comparison class. -/
-  ordinary_in_C : ordinary ∈ comparisonClass
-
-/-- Clause-embedding predicate with explicit access to focus
-alternatives: agent → ordinary proposition → focus alternatives → world
-predicate. [ozyildiz-etal-2025]. -/
-abbrev ClauseEmbedPred (W E : Type*) := E → Set W → PropFocusValue W → Set W
-
-/-- A clause-embedding predicate is focus-sensitive when its truth
-depends on the focus alternatives, not just the ordinary proposition. -/
-def IsFocusSensitive (V : ClauseEmbedPred W E) : Prop :=
-  ∃ (x : E) (p : Set W) (f₁ f₂ : PropFocusValue W) (w : W),
-    (w ∈ V x p f₁) ≠ (w ∈ V x p f₂)
-
-/-- A clause-embedding predicate ignores focus alternatives entirely. -/
-def IsNotFocusSensitive (V : ClauseEmbedPred W E) : Prop :=
-  ∀ (x : E) (p : Set W) (f₁ f₂ : PropFocusValue W),
-    V x p f₁ = V x p f₂
-
-theorem not_fs_iff_ignores_focus (V : ClauseEmbedPred W E) :
-    IsNotFocusSensitive V ↔ ¬ IsFocusSensitive V := by
-  constructor
-  · intro h ⟨x, p, f₁, f₂, w, hne⟩; exact hne (by rw [h x p f₁ f₂])
-  · intro h x p f₁ f₂
-    ext w
-    by_contra hne
-    exact h ⟨x, p, f₁, f₂, w, by tauto⟩
-
-/-- Lift a focus-agnostic predicate to a `ClauseEmbedPred` by ignoring
-the focus alternatives. -/
-def liftNonFS (V : E → Set W → Set W) : ClauseEmbedPred W E :=
-  λ x p _f => V x p
-
-theorem liftNonFS_not_fs (V : E → Set W → Set W) :
-    IsNotFocusSensitive (liftNonFS V) := by
-  intro _ _ _ _; rfl
 
 end Semantics.Focus.Interpretation

--- a/Linglib/Semantics/Focus/Realization.lean
+++ b/Linglib/Semantics/Focus/Realization.lean
@@ -24,12 +24,11 @@ universalist claim that every focus receives an overt reflex.
 
 String-vacuous operations (Hausa subject fronting) contribute no
 reflex: the reflex list carries only perceptible material, which is
-what makes `IsOvert` honest. The host-vs-focus tightness relations
-(`ExactOn`, `Within`, `Contains`) are stated over any `PartialOrder`;
-the overlap-weakening of [hartmann-zimmermann-2007]'s Ex-Situ
-Generalisation is deferred until pied-piping data land — it must be
-stated via `¬ Disjoint` or bot-free carriers, since `Mereology.Overlap`
-is vacuous over orders with a bottom.
+what makes `IsOvert` honest. Host-vs-focus tightness relations
+(and the overlap-weakening of [hartmann-zimmermann-2007]'s Ex-Situ
+Generalisation) are deferred until pied-piping data land; note
+`Mereology.Overlap` is vacuous over orders with a bottom, so that
+member must use `¬ Disjoint` or bot-free carriers.
 -/
 
 namespace Semantics.Focus
@@ -47,12 +46,6 @@ inductive Reflex (C : Type*) where
   /-- A prosodic event — boundary or prominence — at a host. -/
   | prosodic (host : C)
   deriving DecidableEq, Repr
-
-/-- The constituent bearing the reflex. -/
-def Reflex.host : Reflex C → C
-  | .displacement e => e
-  | .morpheme h     => h
-  | .prosodic h     => h
 
 /-- A focus realization: the focus constituent and the grammatical
 reflexes marking it. -/
@@ -75,28 +68,5 @@ instance. -/
 def EveryFocusPerceptible {I : Type*} (realize : I → Realization C) : Prop :=
   ∀ i, (realize i).IsOvert
 
-/-! ### Host-vs-focus tightness -/
-
-section Tightness
-
-variable [PartialOrder C]
-
-/-- The reflex sits on the focus itself. -/
-def Reflex.ExactOn (ρ : Reflex C) (f : C) : Prop := ρ.host = f
-
-/-- The reflex's host lies within the focus — the Selkirk-style
-projection configuration. -/
-def Reflex.Within (ρ : Reflex C) (f : C) : Prop := ρ.host ≤ f
-
-/-- The host contains the focus — the pied-piping configuration. -/
-def Reflex.Contains (ρ : Reflex C) (f : C) : Prop := f ≤ ρ.host
-
-theorem Reflex.ExactOn.within {ρ : Reflex C} {f : C}
-    (h : ρ.ExactOn f) : ρ.Within f := h.le
-
-theorem Reflex.ExactOn.contains {ρ : Reflex C} {f : C}
-    (h : ρ.ExactOn f) : ρ.Contains f := h.ge
-
-end Tightness
 
 end Semantics.Focus

--- a/Linglib/Semantics/Focus/Unalternatives.lean
+++ b/Linglib/Semantics/Focus/Unalternatives.lean
@@ -3,32 +3,38 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Order.Basic
-import Linglib.Semantics.Alternatives.AltMeaning
+import Mathlib.Data.Set.Lattice.Image
+import Mathlib.Order.Minimal
+import Linglib.Semantics.Focus.Control
 
 /-!
 # Unalternative Semantics
 
 Focus marking without [F]-features ([buring-2015],
 [assmann-etal-2023]): constructions directly constrain the focal
-targets they can realize. Two constructor families:
+targets they can realize.
 
 * **Morphosyntactic** ([assmann-etal-2023] §2): a construction focally
-  marks exactly one constituent (`Marking`); No Projection makes it
-  realize any focus within that constituent (`Realizes`), and
-  `Blocked`/`Usable` implement preemption by strictly more specific
-  markings. Syncretism is containment minus blocking.
+  marks exactly one constituent; No Projection lets it realize any
+  focus within that constituent, and Blocking preempts it wherever a
+  strictly more specific marking would do. `Usable` packages both;
+  `usable_iff_minimal` identifies it with minimality among inventory
+  covers.
 * **Prosodic** ([buring-2015]): a branching node's metrical pattern
-  restricts targets pointwise. Under default weak–strong prosody the
-  banned targets vary the weak daughter over its alternative domain
-  while the strong daughter stays at its ordinary value
-  (`weakBanned`, his Weak Restriction); under prosodic reversal only
-  targets varying the accented daughter non-trivially are allowed
-  (`strongAllowed`, his Strong Restriction).
+  restricts targets pointwise. `weakBanned` (his Weak Restriction)
+  bans targets that vary the weak daughter over its alternative domain
+  while the strong daughter stays at its ordinary value;
+  `strongAllowed` (his Strong Restriction) allows only targets varying
+  the accented daughter non-trivially. Both are `Set.seq` images of
+  `AltMeaning.aSet` — Hamblin application with one side held at its
+  ordinary value — so the prosodic calculus runs through the same
+  applicative as the Roothian engine (`AltMeaning.aSet_seq`).
 
-`strongAllowed_subset_weakBanned` connects the two rules: reversal
-allows only targets that the default bans — prosodic shift is the
-complement operation on focal targets, minus the trivial one.
+`licensedFocusValue` is the pipeline connector: the composable targets
+minus the banned ones. At propositional type its values are
+`PropFocusValue`s, the focus values [rooth-1992]'s squiggle consumes —
+the metrical structure derives the focus value that F-marking
+stipulates (`Antecedent.Admits.of_licensed`).
 -/
 
 namespace Semantics.Focus
@@ -37,49 +43,27 @@ namespace Semantics.Focus
 
 section Marking
 
-variable {C : Type*} [PartialOrder C]
+variable {C : Type*} [PartialOrder C] {inv : List C} {m f : C}
 
-/-- A focal marking: a construction focally marking exactly one
-constituent ([assmann-etal-2023] §2.2). -/
-structure Marking (C : Type*) where
-  marked : C
-  deriving DecidableEq, Repr
+/-- A focally marked constituent is usable for focus `f`
+([assmann-etal-2023] §2.2–2.3): it is in the language's inventory,
+`f` lies within it (No Projection), and no strictly more specific
+inventory constituent also covers `f` (Blocking). -/
+def Usable (inv : List C) (m f : C) : Prop :=
+  m ∈ inv ∧ f ≤ m ∧ ∀ m' ∈ inv, f ≤ m' → m' ≤ m → m' = m
 
-/-- No Projection ([assmann-etal-2023] §2.2): a marking realizes focus
-`f` iff `f` lies within its focally marked constituent — broad foci
-are marked directly, narrower foci realized syncretically. -/
-def Marking.Realizes (m : Marking C) (f : C) : Prop := f ≤ m.marked
-
-instance [DecidableLE C] (m : Marking C) (f : C) :
-    Decidable (m.Realizes f) :=
-  inferInstanceAs (Decidable (_ ≤ _))
-
-/-- Blocking ([assmann-etal-2023] §2.3): `m` is blocked for `f` when
-the inventory has a strictly more specific marking that also realizes
-`f`. -/
-def Marking.Blocked (inv : List (Marking C)) (m : Marking C) (f : C) :
-    Prop :=
-  ∃ m' ∈ inv, m'.Realizes f ∧ m'.marked ≤ m.marked ∧ m'.marked ≠ m.marked
-
-/-- A marking is usable for a focus: in the inventory, realizes it,
-and not blocked. -/
-def Marking.Usable (inv : List (Marking C)) (m : Marking C) (f : C) :
-    Prop :=
-  m ∈ inv ∧ m.Realizes f ∧ ¬ Marking.Blocked inv m f
-
-instance [DecidableLE C] [DecidableEq C] (inv : List (Marking C))
-    (m : Marking C) (f : C) : Decidable (Marking.Blocked inv m f) :=
-  List.decidableBEx _ inv
-
-instance [DecidableLE C] [DecidableEq C] (inv : List (Marking C))
-    (m : Marking C) (f : C) : Decidable (Marking.Usable inv m f) :=
+instance [DecidableEq C] [DecidableLE C] : Decidable (Usable inv m f) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
-/-- No Projection makes realizability downward-closed: whatever
-realizes a focus realizes anything within it. -/
-theorem Marking.Realizes.mono {m : Marking C} {f f' : C}
-    (h : m.Realizes f) (hle : f' ≤ f) : m.Realizes f' :=
-  hle.trans h
+/-- Usability is minimality among inventory covers of the focus. -/
+theorem usable_iff_minimal :
+    Usable inv m f ↔ Minimal (fun c => c ∈ inv ∧ f ≤ c) m := by
+  constructor
+  · rintro ⟨hm, hf, hmin⟩
+    exact ⟨⟨hm, hf⟩, fun b ⟨hb, hfb⟩ hbm => (hmin b hb hfb hbm) ▸ le_rfl⟩
+  · rintro ⟨⟨hm, hf⟩, hmin⟩
+    exact ⟨hm, hf, fun m' hm' hfm' hm'm =>
+      le_antisymm hm'm (hmin ⟨hm', hfm'⟩ hm'm)⟩
 
 end Marking
 
@@ -89,32 +73,54 @@ section Prosodic
 
 open Alternatives
 
-variable {α β : Type*}
+variable {W α β : Type*}
 
-/-- Pointwise combination of alternative sets ([buring-2015]'s ⊗). -/
-def otimes (F : Set (α → β)) (A : Set α) : Set β :=
-  {b | ∃ f ∈ F, ∃ a ∈ A, f a = b}
-
-/-- Weak Restriction ([buring-2015] (1)): under the default
-weak–strong pattern, the banned focal targets vary the weak
-(function) daughter over its alternative domain while the strong
-daughter stays at its ordinary value. -/
+/-- Weak Restriction ([buring-2015]): under the default weak–strong
+pattern, the banned focal targets vary the weak (function) daughter
+over its alternative domain while the strong daughter stays at its
+ordinary value. -/
 def weakBanned (dw : AltMeaning (α → β)) (ds : AltMeaning α) : Set β :=
-  otimes dw.aSet {ds.oValue}
+  dw.aSet.seq {ds.oValue}
 
-/-- Strong Restriction ([buring-2015] (9)): under prosodic reversal,
-the allowed focal targets vary the accented (function) daughter
+/-- Strong Restriction ([buring-2015]): under prosodic reversal, the
+allowed focal targets vary the accented (function) daughter
 non-trivially while the deaccented daughter stays at its ordinary
 value. -/
 def strongAllowed (dm : AltMeaning (α → β)) (ds : AltMeaning α) :
     Set β :=
-  otimes (dm.aSet \ {dm.oValue}) {ds.oValue}
+  (dm.aSet \ {dm.oValue}).seq {ds.oValue}
 
-/-- Reversal allows only targets that the default bans: prosodic
-shift complements the default's focal-target restriction. -/
+/-- Reversal allows only targets that the default bans. -/
 theorem strongAllowed_subset_weakBanned (dm : AltMeaning (α → β))
     (ds : AltMeaning α) : strongAllowed dm ds ⊆ weakBanned dm ds :=
-  fun _ ⟨f, hf, a, ha, h⟩ => ⟨f, hf.1, a, ha, h⟩
+  Set.seq_mono Set.sdiff_subset subset_rfl
+
+/-- The focal targets a metrical configuration licenses: everything
+the daughters compose to, minus the banned targets. At `β := Set W`
+this is a `PropFocusValue W` — the focus value the prosody derives. -/
+def licensedFocusValue (dw : AltMeaning (α → β)) (ds : AltMeaning α) :
+    Set β :=
+  dw.aSet.seq ds.aSet \ weakBanned dw ds
+
+theorem licensedFocusValue_subset_seq (dw : AltMeaning (α → β))
+    (ds : AltMeaning α) :
+    licensedFocusValue dw ds ⊆ dw.aSet.seq ds.aSet :=
+  Set.sdiff_subset
+
+theorem disjoint_licensedFocusValue_weakBanned
+    (dw : AltMeaning (α → β)) (ds : AltMeaning α) :
+    Disjoint (licensedFocusValue dw ds) (weakBanned dw ds) :=
+  Set.disjoint_sdiff_left
+
+/-- Prosodic restriction only strengthens admission: an antecedent the
+licensed focus value admits is admitted by the unrestricted Hamblin
+composition — [rooth-1992]'s fip against the prosodically derived
+focus value. -/
+theorem Antecedent.Admits.of_licensed {a : Antecedent W}
+    {dw : AltMeaning (α → Set W)} {ds : AltMeaning α}
+    (h : a.Admits (licensedFocusValue dw ds)) :
+    a.Admits (dw.aSet.seq ds.aSet) :=
+  h.mono Set.sdiff_subset
 
 end Prosodic
 

--- a/Linglib/Studies/AssmannEtAl2023.lean
+++ b/Linglib/Studies/AssmannEtAl2023.lean
@@ -15,7 +15,7 @@ Each construction focally marks exactly one constituent; **No
 Projection** (§2.2) lets it realize any focus within that constituent
 (the marked constituent and the pragmatic focus need not coincide);
 **Blocking** (§2.3) preempts a marking wherever a strictly more
-specific one would do. Syncretism is containment minus blocking:
+specific one would do — `Usable` is minimality among inventory covers. Syncretism is containment minus blocking:
 disjoint-constituent syncretisms (V with Obj, §4.2.1) — which
 "directly contradict Uniform Marking" — fall out by focally marking
 the common mother (§4.2.3).
@@ -38,7 +38,7 @@ fn. 18.
 
 namespace AssmannEtAl2023
 
-open Semantics.Focus (Marking)
+open Semantics.Focus (Usable)
 
 
 /-! ## The constituent skeleton of the case studies -/
@@ -69,19 +69,19 @@ instance : DecidableLE Node := fun _ _ =>
 
 /-- The Gùrùntùm inventory: *a* before the subject, *a* before the
 object marking VP, clausal *á* ((4a–c)). -/
-def guruntumInv : List (Marking Node) := [⟨.sbj⟩, ⟨.vp⟩, ⟨.s⟩]
+def guruntumInv : List Node := [.sbj, .vp, .s]
 
 /-- (4b): focally marking VP is syncretic for V, VP and Obj focus —
 No Projection in action. -/
 theorem guruntum_vp_syncretism :
-    Marking.Usable guruntumInv ⟨.vp⟩ .v ∧ Marking.Usable guruntumInv ⟨.vp⟩ .vp ∧
-    Marking.Usable guruntumInv ⟨.vp⟩ .obj := by decide
+    Usable guruntumInv .vp .v ∧ Usable guruntumInv .vp .vp ∧
+    Usable guruntumInv .vp .obj := by decide
 
 /-- (4c)/(5): the clausal marking realizes only clausal focus — every
 smaller focus is blocked by a specialized marking. -/
 theorem guruntum_clausal_blocked :
-    Marking.Usable guruntumInv ⟨.s⟩ .s ∧ ¬ Marking.Usable guruntumInv ⟨.s⟩ .sbj ∧
-    ¬ Marking.Usable guruntumInv ⟨.s⟩ .vp ∧ ¬ Marking.Usable guruntumInv ⟨.s⟩ .obj := by
+    Usable guruntumInv .s .s ∧ ¬ Usable guruntumInv .s .sbj ∧
+    ¬ Usable guruntumInv .s .vp ∧ ¬ Usable guruntumInv .s .obj := by
   decide
 
 /-! ## Case study: Hausa (§3.2) -/
@@ -89,19 +89,19 @@ theorem guruntum_clausal_blocked :
 /-- The Hausa canonical-order inventory: the relative form of the PAC
 focally marks the subject ((10)); the absolute form is the default,
 "the absence of a specific marking", focally marking the clause. -/
-def hausaInv : List (Marking Node) := [⟨.sbj⟩, ⟨.s⟩]
+def hausaInv : List Node := [.sbj, .s]
 
 /-- (11): the absolute form answers any non-subject constituent
 question and all-new contexts — one default, syncretic for V, VP,
 Obj and clausal focus. -/
 theorem hausa_default_syncretism :
-    Marking.Usable hausaInv ⟨.s⟩ .v ∧ Marking.Usable hausaInv ⟨.s⟩ .vp ∧
-    Marking.Usable hausaInv ⟨.s⟩ .obj ∧ Marking.Usable hausaInv ⟨.s⟩ .s := by decide
+    Usable hausaInv .s .v ∧ Usable hausaInv .s .vp ∧
+    Usable hausaInv .s .obj ∧ Usable hausaInv .s .s := by decide
 
 /-- Only subject focus has to be marked (their fn. 13): the default
 is blocked for subject focus by the relative form. -/
 theorem hausa_subject_needs_relative :
-    ¬ Marking.Usable hausaInv ⟨.s⟩ .sbj ∧ Marking.Usable hausaInv ⟨.sbj⟩ .sbj := by
+    ¬ Usable hausaInv .s .sbj ∧ Usable hausaInv .sbj .sbj := by
   decide
 
 /-! ## The Tangale rivalry (their fn. 13, 17, 18)
@@ -119,10 +119,10 @@ open HartmannZimmermann2004 in
 specific subject marking (postposing); perfective non-subject foci
 the VP-marking (the prosodic boundary, fn. 18); progressive
 non-subject foci the default clause marking (fn. 13). -/
-def uaTangale : Config → Marking Node
-  | ⟨.subject, _, _⟩        => ⟨.sbj⟩
-  | ⟨_, .perfective, _⟩     => ⟨.vp⟩
-  | ⟨_, .progressive, _⟩    => ⟨.s⟩
+def uaTangale : Config → Node
+  | ⟨.subject, _, _⟩        => .sbj
+  | ⟨_, .perfective, _⟩     => .vp
+  | ⟨_, .progressive, _⟩    => .s
 
 open HartmannZimmermann2004 in
 /-- Cell-by-cell agreement with the reflex analysis: a configuration
@@ -131,7 +131,7 @@ has an overt reflex iff its UA marking is not the default. What
 for UA, the default marking whose focally marked constituent
 properly contains the focus. -/
 theorem ua_agrees_with_hz_on_overtness (c : Config) :
-    (realize c).IsOvert ↔ uaTangale c ≠ ⟨Node.s⟩ := by
+    (realize c).IsOvert ↔ uaTangale c ≠ Node.s := by
   obtain ⟨f, a, t⟩ := c
   cases f <;> cases a <;> cases t <;> decide
 

--- a/Linglib/Studies/Buring2015.lean
+++ b/Linglib/Studies/Buring2015.lean
@@ -27,7 +27,7 @@ morphosyntactic extension of [assmann-etal-2023].
 namespace Buring2015
 
 open Alternatives
-open Semantics.Focus (weakBanned strongAllowed)
+open Semantics.Focus (weakBanned strongAllowed licensedFocusValue)
 
 /-- Transitive-verb meanings. -/
 inductive Rel where
@@ -98,5 +98,41 @@ theorem reversal_excludes_object_focus :
   rcases List.mem_cons.mp hf' with rfl | hf''
   · exact absurd (congrArg Prod.snd heq) (by decide)
   · exact nomatch hf''
+
+/-- The licensed focal targets of default *ordered BREAKfast*
+compute to exactly the *breakfast*-free compositions: object focus
+with a new object survives; everything about *breakfast* is banned.
+The licensed set is the focus value the prosody derives — the
+pipeline the squiggle consumes at propositional type. -/
+theorem licensed_eq :
+    licensedFocusValue orderedM breakfastM =
+      {p : Rel × Obj | p.2 = Obj.lunch} := by
+  ext ⟨r, o⟩
+  constructor
+  · rintro ⟨⟨f, hf, a, ha, heq⟩, hban⟩
+    rcases List.mem_cons.mp ha with rfl | ha'
+    · exact absurd ⟨f, hf, .breakfast, rfl, heq⟩ hban
+    rcases List.mem_cons.mp ha' with rfl | ha''
+    · rcases List.mem_cons.mp hf with rfl | hf'
+      · exact (congrArg Prod.snd heq).symm
+      rcases List.mem_cons.mp hf' with rfl | hf''
+      · exact (congrArg Prod.snd heq).symm
+      · exact nomatch hf''
+    · exact nomatch ha''
+  · intro ho
+    have ho' : o = Obj.lunch := ho
+    subst ho'
+    refine ⟨⟨vt r, ?_, .lunch,
+      List.mem_cons_of_mem _ (List.mem_cons_self ..), rfl⟩, ?_⟩
+    · cases r
+      · exact List.mem_cons_self ..
+      · exact List.mem_cons_of_mem _ (List.mem_cons_self ..)
+    · rintro ⟨g, hg, a, ha, heq⟩
+      rcases Set.eq_of_mem_singleton ha with rfl
+      rcases List.mem_cons.mp hg with rfl | hg'
+      · exact absurd (congrArg Prod.snd heq) nofun
+      rcases List.mem_cons.mp hg' with rfl | hg''
+      · exact absurd (congrArg Prod.snd heq) nofun
+      · exact nomatch hg''
 
 end Buring2015

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -436,13 +436,13 @@ def onlyJohn : OnlyWorld → Bool
 theorem only_bill_semantics :
     (onlyWorlds.all fun w =>
       onlyBill w == (introBill w && !introJohn w)) = true := by
-  native_decide
+  decide
 
 /-- "Only" with focus on JOHN: symmetric case. -/
 theorem only_john_semantics :
     (onlyWorlds.all fun w =>
       onlyJohn w == (introJohn w && !introBill w)) = true := by
-  native_decide
+  decide
 
 /-- Different focus → different "only" meaning.
     Focus on BILL excludes John; focus on JOHN excludes Bill

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9146,7 +9146,7 @@
   author    = {Beaver, David and Clark, Brady Zack and Flemming, Edward and Jaeger, T. Florian and Wolters, Maria},
   year      = {2007},
   title     = {When semantics meets phonetics},
-  journal   = {Language 83: 245-276},
+  journal   = {Language},
   volume    = {83},
   number    = {2},
   pages     = {245--276},
@@ -35411,4 +35411,17 @@
   subfield  = {semantics},
   role      = {formalized},
   sources   = {Studies/Buring2015.lean}
+}
+
+% REF: Büring, D. (2016). Intonation and Meaning. Oxford University Press.
+@book{buring-2016,
+  author    = {B{\"u}ring, Daniel},
+  year      = {2016},
+  title     = {Intonation and Meaning},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  isbn      = {9780199226276},
+  subfield  = {semantics},
+  role      = {reference},
+  sources   = {Semantics/Focus/Unalternatives.lean}
 }


### PR DESCRIPTION
The three-lens hom audit applied (design: scratch/prosody-semantics-hom-design.md). This is the stranded final commit of #1153, replayed onto main.

- **The hom**: `aSet` as an applicative/monad morphism `AltMeaning → Set` (`aSet_pure`/`aSet_seq`/`aSet_bind`) — with the `oValue` laws, the alternatives monad is a span `Id ⟵ AltMeaning ⟶ Set`
- `otimes` retired (it was `Set.seq`, the 4th Hamblin-application encoding); Weak/Strong Restriction as `Set.seq` images; `Marking` struct dissolved (`Usable` over bare constituents, `usable_iff_minimal` via `Order.Minimal`)
- **`licensedFocusValue`** + `Antecedent.Admits.of_licensed`: the prosodic calculus now feeds Rooth's fip — metrical structure derives the focus value F-marking stipulates; `Buring2015.licensed_eq` computes the worked example's licensed set
- cleanup: dead `Reflex` tightness triple and `Interpretation.lean`'s zero-consumer family deleted; stale `Focus/Sensitivity.lean` docstring fixed; `native_decide` ×2 → `decide` in Rooth1992; K&S (45)–(47) verified verbatim against the PDF; bib `buring-2016` added, `beaver-2007` repaired