### PR TITLE
feat(Semantics/Focus): boundary/prominence reflexes; AltMeaning.Given

### DIFF
--- a/Linglib/Semantics/Alternatives/AltMeaning.lean
+++ b/Linglib/Semantics/Alternatives/AltMeaning.lean
@@ -137,6 +137,31 @@ theorem WellFormed.map {f : α → β} {m : AltMeaning α} (hm : m.WellFormed) :
     (f <$> m).WellFormed :=
   hm.bind fun a => WellFormed.unfeatured (f a)
 
+/-! ### Givenness -/
+
+/-- Given with respect to `a`: the alternatives have collapsed to the
+singleton `{a}` ([kratzer-selkirk-2020] (46)). -/
+def Given (m : AltMeaning α) (a : α) : Prop := m.aSet = {a}
+
+/-- Unfeatured meanings are Given with respect to their value. -/
+theorem Given.unfeatured (x : α) : (unfeatured x).Given x :=
+  unfeatured_aSet x
+
+/-- A Given function collapses Hamblin composition to application on
+the argument's alternatives — deaccented material contributes exactly
+its ordinary value. -/
+theorem Given.aSet_seq {mf : AltMeaning (α → β)} {f : α → β}
+    (h : mf.Given f) (ma : AltMeaning α) :
+    (mf <*> ma).aSet = f '' ma.aSet := by
+  ext b
+  simp only [mem_aSet_seq, Set.mem_image]
+  constructor
+  · rintro ⟨g, hg, a, ha, rfl⟩
+    obtain rfl := Set.mem_singleton_iff.mp (h ▸ hg)
+    exact ⟨a, ha, rfl⟩
+  · rintro ⟨a, ha, rfl⟩
+    exact ⟨f, h ▸ rfl, a, ha, rfl⟩
+
 end AltMeaning
 
 end Alternatives

--- a/Linglib/Semantics/Focus/Realization.lean
+++ b/Linglib/Semantics/Focus/Realization.lean
@@ -11,7 +11,9 @@ import Mathlib.Tactic.DeriveFintype
 
 What a grammar overtly does to mark a focus: a `Realization` pairs the
 focus constituent with the list of grammatical `Reflex`es marking it —
-a displaced exponent, a dedicated morpheme, or a prosodic event.
+a displaced exponent, a dedicated morpheme, a phrase-edge, or a
+metrical prominence — the demarcative vs culminative cut kept visible
+in the type.
 Overtness is derived (`IsOvert`: the reflex list is nonempty), not
 flagged; strategy labels are shape classifications over reflexes; and
 multi-channel marking (Hausa ex-situ focus: displacement + Relative
@@ -43,8 +45,12 @@ inductive Reflex (C : Type*) where
   /-- A dedicated morpheme — affix, particle, or form alternation — at
   a host constituent. -/
   | morpheme (host : C)
-  /-- A prosodic event — boundary or prominence — at a host. -/
-  | prosodic (host : C)
+  /-- A demarcative prosodic event: a phrase-edge at a host constituent
+  (the Tangale/Chadic pattern). -/
+  | boundary (edge : C)
+  /-- A culminative prosodic event: metrical prominence on a host (the
+  English pattern). -/
+  | prominence (host : C)
   deriving DecidableEq, Repr
 
 /-- A focus realization: the focus constituent and the grammatical

--- a/Linglib/Studies/HartmannZimmermann2004.lean
+++ b/Linglib/Studies/HartmannZimmermann2004.lean
@@ -110,7 +110,7 @@ foci receive nothing ((31)/(32a–c)). -/
 def realize : Config → Realization Focused
   | ⟨.subject, _, _⟩        => ⟨.subject, [.displacement .subject]⟩
   | ⟨f, .perfective, false⟩ => ⟨f, [.morpheme f]⟩
-  | ⟨f, .perfective, true⟩  => ⟨f, [.prosodic .verb]⟩
+  | ⟨f, .perfective, true⟩  => ⟨f, [.boundary .verb]⟩
   | ⟨f, .progressive, _⟩    => ⟨f, []⟩
 
 /-- The paper's strategy labels, classified from the realization
@@ -119,7 +119,7 @@ def marking (c : Config) : Strategy :=
   match (realize c).reflexes with
   | [.displacement _] => .postposing
   | [.morpheme _]     => .suffixI
-  | [.prosodic _]     => .boundary
+  | [.boundary _]     => .boundary
   | _                 => .unmarked
 
 /-- Focused subjects are overtly marked in every aspect — the paper's
@@ -154,7 +154,7 @@ theorem tangale_refutes_perceptibility :
 
 /-- The prosodic reflex is audible: the boundary-blocked perfective
 form differs from the phrase-medial elided form — [kidda-1985]'s
-elision cascade is what makes `Reflex.prosodic` perceptible in the
+elision cascade is what makes `Reflex.boundary` perceptible in the
 (25) cells. -/
 theorem prosodic_reflex_audible :
     Tangale.blockedForm ≠ Tangale.elidedForm :=

--- a/Linglib/Studies/KratzerSelkirk2020.lean
+++ b/Linglib/Studies/KratzerSelkirk2020.lean
@@ -311,6 +311,14 @@ theorem consumed_alts_enable_g {α : Type*} [DecidableEq α]
   unfold isGiven
   rfl
 
+/-- The ~-consumed result is Given with respect to the ordinary value —
+the `AltMeaning.Given` form of `consumed_alts_enable_g` (their (46)). -/
+theorem consumed_alts_given {α : Type*} (op : ContrastOperator α) :
+    op.result.Given op.meaning.oValue := by
+  show op.result.aSet = {op.meaning.oValue}
+  ext x
+  simp [AltMeaning.mem_aSet, squiggle_singleton_aValue]
+
 /-! ## Prosodic spellout
 
 In Standard American and British English, [FoC] and [G] are spelled out


### PR DESCRIPTION
B4.4 + B4.5 of the correspondence-layer spec (scratch/b4-correspondence-spec.md) — the two independent batches, now complete after the #1160 rebase.

- **`Reflex.prosodic` split** into `boundary` (demarcative: phrase-edge — the Tangale/Chadic pattern) and `prominence` (culminative: metrical head — the English pattern): the field's central typological cut, visible in the type. HZ2004's perfective cell is now `.boundary .verb`
- **`AltMeaning.Given`** := `aSet = {a}` — verbatim K&S (46), verified against the Glossa PDF — with `Given.unfeatured` and `Given.aSet_seq` (a Given function collapses Hamblin composition to application); `consumed_alts_given` in the K&S study
- **`licensedFocusValue_eq_empty_of_given`**: with a Given strong daughter the default pattern licenses nothing — the deaccenting imperative (prominence must shift off given material, Schwarzschild 1999) derived from Büring's Weak Restriction plus K&S Givenness