### PR TITLE
feat(Phonology/Prosody): phrase layer — heads on ω/φ, ι, Phrase.lean

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1363,6 +1363,7 @@ import Linglib.Phonology.OptimalityTheory.TableauSystem
 import Linglib.Phonology.Prosody.Foot
 import Linglib.Phonology.Prosody.Grid
 import Linglib.Phonology.Prosody.Mora
+import Linglib.Phonology.Prosody.Phrase
 import Linglib.Phonology.Prosody.Syllable
 import Linglib.Phonology.Prosody.Word
 import Linglib.Phonology.Segmental.Basic

--- a/Linglib/Phonology/Prosody/Phrase.lean
+++ b/Linglib/Phonology/Prosody/Phrase.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Prosody.Word
+
+/-!
+# Phrase-level prosodic structure
+
+The φ and ι layers above the prosodic word: Strict-Layer
+well-formedness one level up ([selkirk-1996]; overview
+[ishihara-kalivoda-2022]). A phrase is a φ-node over well-formed
+ω-trees; an utterance is an ι-node over phrases. `HeadUnique` is the
+culminativity of prominence — at most one head child per node — the
+structural hook the metrical weak–strong calculus of [buring-2015]
+reads ([buring-2016]). `phrases` reads the φ-constituents off an
+utterance; φ-edges are what demarcative focus reflexes
+(`Semantics.Focus.Reflex.boundary`) realize.
+-/
+
+namespace Prosody
+
+open RoseTree
+
+/-- A φ-node over well-formed prosodic words: the Strict Layer at the
+phrase level. -/
+def isPhraseTree (t : Tree) : Bool :=
+  t.value.isPh && t.children.all isWordTree
+
+/-- Well-formed phonological phrase. -/
+def IsPhrase (t : Tree) : Prop := isPhraseTree t
+
+instance (t : Tree) : Decidable (IsPhrase t) :=
+  inferInstanceAs (Decidable (_ = true))
+
+/-- An ι-node over well-formed phrases: the utterance level. -/
+def isUtteranceTree (t : Tree) : Bool :=
+  t.value.isIota && t.children.all isPhraseTree
+
+/-- Well-formed intonational phrase (utterance). -/
+def IsUtterance (t : Tree) : Prop := isUtteranceTree t
+
+instance (t : Tree) : Decidable (IsUtterance t) :=
+  inferInstanceAs (Decidable (_ = true))
+
+/-- Culminativity of prominence: at most one child heads its parent. -/
+def HeadUnique (t : Tree) : Prop :=
+  (t.children.filter (fun c => c.value.isHead)).length ≤ 1
+
+instance (t : Tree) : Decidable (HeadUnique t) :=
+  inferInstanceAs (Decidable (_ ≤ _))
+
+/-- The φ-constituents of a tree, outermost-first. -/
+def phrases (t : Tree) : List Tree :=
+  maximalProjections Constituent.isPh t
+
+/-- Every child of a well-formed phrase is a well-formed word. -/
+theorem IsPhrase.children_isWord {t : Tree} (h : IsPhrase t) :
+    ∀ c ∈ t.children, IsWord c := by
+  have := (Bool.and_eq_true _ _).mp h
+  exact fun c hc => (List.all_eq_true.mp this.2) c hc
+
+/-- Every child of a well-formed utterance is a well-formed phrase. -/
+theorem IsUtterance.children_isPhrase {t : Tree} (h : IsUtterance t) :
+    ∀ c ∈ t.children, IsPhrase c := by
+  have := (Bool.and_eq_true _ _).mp h
+  exact fun c hc => (List.all_eq_true.mp this.2) c hc
+
+end Prosody

--- a/Linglib/Phonology/Prosody/Syllable.lean
+++ b/Linglib/Phonology/Prosody/Syllable.lean
@@ -255,25 +255,30 @@ carrier** for ω/φ/… structures, including the ill-formed ones (a footless ω
 `RoseTree`. -/
 
 /-- A prosodic node — the **level is the constructor**: a σ carries its mora `weight` and `isHead`,
-    a foot only `isHead`, ω/φ neither. Constructor defaults match the former smart constructors, so
-    node literals are unchanged; illegal nodes (a weight on a foot, a head on ω) are
-    unrepresentable. -/
+    every non-root level carries `isHead` (whether it heads its parent). Constructor defaults match
+    the former smart constructors, so node literals are unchanged; illegal nodes (a weight on a
+    foot, a head on the ι root) are unrepresentable. -/
 inductive Constituent
   /-- A syllable of the given `weight`, optionally the head of its foot. -/
   | syl (weight : Syllable.Weight := 0) (isHead : Bool := false)
   /-- A foot, optionally the head foot of its word. -/
   | ft (isHead : Bool := false)
-  /-- A prosodic word ω. -/
-  | om
-  /-- A phonological phrase φ — interim, until `Prosody.Phrase` lands. -/
-  | ph
+  /-- A prosodic word ω, optionally the head word of its phrase. -/
+  | om (isHead : Bool := false)
+  /-- A phonological phrase φ, optionally the head phrase of its
+  intonational phrase. -/
+  | ph (isHead : Bool := false)
+  /-- An intonational phrase ι — the root of the utterance-level
+  hierarchy, headless. -/
+  | iota
   deriving DecidableEq, Repr
 
 namespace Constituent
 
-/-- Whether a node heads its parent (a σ heads its foot, a foot heads its word); `false` for ω/φ. -/
+/-- Whether a node heads its parent (a σ heads its foot, a foot heads its word, an ω its phrase,
+    a φ its intonational phrase); `false` for the ι root. -/
 def isHead : Constituent → Bool
-  | .syl _ h => h | .ft h => h | .om | .ph => false
+  | .syl _ h => h | .ft h => h | .om h => h | .ph h => h | .iota => false
 
 /-- The mora weight of a σ node; `none` for non-σ nodes. -/
 def weight? : Constituent → Option Syllable.Weight
@@ -284,12 +289,17 @@ def isSyl : Constituent → Bool | .syl .. => true | _ => false
 /-- A foot (f) node. -/
 def isFt : Constituent → Bool | .ft _ => true | _ => false
 /-- A prosodic-word (ω) node. -/
-def isOm : Constituent → Bool | .om => true | _ => false
+def isOm : Constituent → Bool | .om _ => true | _ => false
+/-- A phonological-phrase (φ) node. -/
+def isPh : Constituent → Bool | .ph _ => true | _ => false
+/-- An intonational-phrase (ι) node. -/
+def isIota : Constituent → Bool | .iota => true | _ => false
 
 /-- Two nodes at the same prosodic level (the same constructor, ignoring weight/head) — the
     same-category test the No-Recursion family reads off the carrier. -/
 def sameLevel : Constituent → Constituent → Bool
-  | .syl .., .syl .. | .ft _, .ft _ | .om, .om | .ph, .ph => true
+  | .syl .., .syl .. | .ft _, .ft _ | .om _, .om _ | .ph _, .ph _
+  | .iota, .iota => true
   | _, _ => false
 
 /-- The level family is exclusive: a foot is not a syllable. -/

--- a/Linglib/Phonology/Prosody/Word.lean
+++ b/Linglib/Phonology/Prosody/Word.lean
@@ -345,16 +345,18 @@ theorem isWord_children {a : Constituent} {cs : List Tree}
   simp only [IsWord, isWordTree, isWordTree.go, Bool.and_eq_true,
     isWordTree.goList_all, List.all_eq_true] at hw
   obtain ⟨ha, hall⟩ := hw
-  obtain rfl : a = .om := by cases a <;> simp_all [Constituent.isOm]
-  have hr' : (cs.filter (fun c => Constituent.sameLevel c.value .om)).length = 0 := by
-    have e : noRec (.node (.om : Constituent) cs)
-        = (cs.filter (fun c => Constituent.sameLevel c.value .om)).length + noRec.goList cs := rfl
+  obtain ⟨hd, rfl⟩ : ∃ b, a = .om b := by
+    cases a <;> first | exact ⟨_, rfl⟩ | simp_all [Constituent.isOm]
+  have hr' : (cs.filter (fun c => Constituent.sameLevel c.value (.om hd))).length = 0 := by
+    have e : noRec (.node (Constituent.om hd) cs)
+        = (cs.filter (fun c => Constituent.sameLevel c.value (.om hd))).length
+          + noRec.goList cs := rfl
     rw [hr] at e; omega
-  have hnoω : ∀ c ∈ cs, Constituent.sameLevel c.value .om = false := by
+  have hnoω : ∀ c ∈ cs, Constituent.sameLevel c.value (.om hd) = false := by
     intro c hc
     by_contra h
     rw [Bool.not_eq_false] at h
-    have hmem : c ∈ cs.filter (fun c => Constituent.sameLevel c.value .om) := by
+    have hmem : c ∈ cs.filter (fun c => Constituent.sameLevel c.value (.om hd)) := by
       rw [List.mem_filter]; exact ⟨hc, h⟩
     rw [List.length_eq_zero_iff] at hr'
     rw [hr'] at hmem; exact List.not_mem_nil hmem


### PR DESCRIPTION
B4.1 of the correspondence-layer spec (scratch/b4-correspondence-spec.md) — completing the extension `Constituent`'s own docstring planned ('interim, until `Prosody.Phrase` lands').

- `om`/`ph` gain `isHead` payloads (defaults keep every existing literal compiling; the head convention stays 'node records whether it heads its parent', now through ω→φ and φ→ι); new headless `iota` root; `isPh`/`isIota` testers; `isHead`/`sameLevel`/`isWord_children` extended (one proof generalized from `a = .om` to `∃ b, a = .om b`)
- **`Phrase.lean`**: `IsPhrase` (φ over well-formed ω-trees) and `IsUtterance` (ι over phrases) as the Strict Layer one level up, `HeadUnique` (culminativity of prominence — the hook the metrical weak–strong calculus reads), `phrases` reader; decidable throughout
- All nine downstream consumers (Grid + six metrical studies) build unchanged