### PR TITLE
docs(references): add mccarthy-mullin-smith-2012; cite in Floating GEN

### DIFF
--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -224,8 +224,9 @@ abbrev Crosses (k : TierIdx) (i : SegIdx) : Prop :=
 
 /-- One-step GEN: the faithful candidate, deleting each alive tone, and (for
     each FLOATING tone) inserting a link to each TBU that doesn't cross an
-    existing link. A subset of [mcpherson-lamont-2026]'s GEN — omits
-    insert-and-associate and shift. The no-crossing filter ([goldsmith-1976])
+    existing link. One operation per step, after [mccarthy-mullin-smith-2012];
+    a subset of [mcpherson-lamont-2026]'s operation set (omits
+    insert-and-associate and shift). The no-crossing filter ([goldsmith-1976])
     enforces well-formedness: without it a floating tone could dock across an
     intervening linked tone. -/
 def gen : Finset (FloatingForm S T) :=

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23976,6 +23976,21 @@
   sources   = {Studies/Lionnet2022Laal.lean}
 }
 
+@incollection{mccarthy-mullin-smith-2012,
+  author    = {McCarthy, John J. and Mullin, Kevin and Smith, Brian W.},
+  year      = {2012},
+  title     = {Implications of Harmonic Serialism for lexical tone association},
+  booktitle = {Phonological Explorations: Empirical, Theoretical and Diachronic Issues},
+  editor    = {Botma, Bert and Noske, Roland},
+  publisher = {De Gruyter},
+  address   = {Berlin/Boston},
+  pages     = {265--297},
+  subfield  = {phonology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Phonology/Autosegmental/Floating.lean}
+}
+
 @incollection{pulleyblank-1986,
   author    = {Pulleyblank, Douglas},
   year      = {1986},


### PR DESCRIPTION
Verified entry for McCarthy, Mullin & Smith 2012 (Botma & Noske eds., De Gruyter, 265–297; cross-checked against the offprint and Zotero), cited from `FloatingForm.gen` — the substrate's one-operation-per-step GEN is theirs. Groundwork for the melody/association-status builder.