### PR TITLE
refactor(Studies): QGL2016 + ST2025 onto RSA.Score fallback chains

### DIFF
--- a/Linglib/Core/Probability/Scores.lean
+++ b/Linglib/Core/Probability/Scores.lean
@@ -274,5 +274,21 @@ theorem ofScores_event_lt (fb : Fallback σ) (f : σ → ℚ≥0) {P Q : σ → 
   rw [ofScores_event_eq, ofScores_event_eq]
   exact_mod_cast h
 
+theorem ofScores_event_lt_cross {τ : Type*} [Fintype τ]
+    (fb₁ : Fallback σ) (fb₂ : Fallback τ) (f : σ → ℚ≥0) (g : τ → ℚ≥0)
+    {P : σ → Bool} {Q : τ → Bool}
+    (h : eventMass (scoresWith fb₁ f) P < eventMass (scoresWith fb₂ g) Q) :
+    (∑' x, if P x then ofScores fb₁ f x else 0)
+      < ∑' y, if Q y then ofScores fb₂ g y else 0 := by
+  rw [ofScores_event_eq, ofScores_event_eq]
+  exact_mod_cast h
+
+/-- Exact-value form: an event mass that is a rational literal on the ℚ≥0
+face is that literal on the PMF face. -/
+theorem ofScores_event_eq_ratCast (fb : Fallback σ) (f : σ → ℚ≥0)
+    (P : σ → Bool) {q : ℚ≥0} (h : eventMass (scoresWith fb f) P = q) :
+    (∑' x, if P x then ofScores fb f x else 0) = ((q : ℝ≥0) : ℝ≥0∞) := by
+  rw [ofScores_event_eq, h]
+
 end PMF
 

--- a/Linglib/Semantics/Aspect/ChangeOfState.lean
+++ b/Linglib/Semantics/Aspect/ChangeOfState.lean
@@ -159,6 +159,21 @@ def cosSemantics (t : CoSType) (P : W → Prop) : PartialProp W :=
   { presup := priorStatePresup t P
   , assertion := resultStateAssertion t P }
 
+/-- Boolean evaluation of a CoS predicate at a prior/result state pair —
+the kernel-computable face of `cosSemantics` for finite world models. -/
+def CoSType.eval : CoSType → Bool → Bool → Bool
+  | .cessation,    p, n => p && !n
+  | .inception,    p, n => !p && n
+  | .continuation, p, n => p && n
+
+/-- `CoSType.eval` computes presupposition-and-assertion truth: the Bool
+face agrees with `priorStatePresup`/`resultStateAssertion` at the
+projections. -/
+theorem CoSType.eval_iff (t : CoSType) (p n : Bool) :
+    t.eval p n = true ↔
+      priorStatePresup t (· = true) p ∧ resultStateAssertion t (· = true) n := by
+  cases t <;> constructor <;> simp_all [eval, priorStatePresup, resultStateAssertion]
+
 /--
 Semantics for a lexical entry applied to an activity predicate.
 -/

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -94,55 +94,26 @@ inductive Utterance where
 
 /-- Literal truth conditions from Table 1. Negation of u is U - ⟦u⟧.
 
-    The change-of-state utterances (stopped, started, always smoked) encode
-    presupposition + assertion as a conjunction over two temporal projections
-    of the world state. See bridge theorems below connecting these to the
-    CoS theory in `Semantics.Aspect.ChangeOfState`. -/
+    The change-of-state utterances evaluate the corresponding
+    `Features.ChangeOfState.CoSType` at the world's temporal projections —
+    presupposition and assertion by construction
+    (`Features.ChangeOfState.CoSType.eval_iff`), not by bridge theorem. -/
 def literalMeaning : Utterance → WorldState → Bool
   | .smokes,            w => w.now
   | .doesntSmoke,       w => !w.now
   | .smoked,            w => w.past
   | .didntSmoke,        w => !w.past
-  | .alwaysSmoked,      w => w.past && w.now
-  | .notAlwaysSmoked,   w => !(w.past && w.now)
-  | .stoppedSmoking,    w => w.past && !w.now
-  | .notStoppedSmoking, w => !(w.past && !w.now)
-  | .startedSmoking,    w => !w.past && w.now
-  | .notStartedSmoking, w => !(!w.past && w.now)
+  | .alwaysSmoked,      w => Features.ChangeOfState.CoSType.continuation.eval w.past w.now
+  | .notAlwaysSmoked,   w => !Features.ChangeOfState.CoSType.continuation.eval w.past w.now
+  | .stoppedSmoking,    w => Features.ChangeOfState.CoSType.cessation.eval w.past w.now
+  | .notStoppedSmoking, w => !Features.ChangeOfState.CoSType.cessation.eval w.past w.now
+  | .startedSmoking,    w => Features.ChangeOfState.CoSType.inception.eval w.past w.now
+  | .notStartedSmoking, w => !Features.ChangeOfState.CoSType.inception.eval w.past w.now
   | .neverSmoked,       w => !w.past && !w.now
   | .notNeverSmoked,    w => !(!w.past && !w.now)
   | .silence,           _ => true
 
-open Features.ChangeOfState (priorStatePresup resultStateAssertion)
-
-/-- "Stopped smoking" = cessation presupposition (past=T) ∧ cessation assertion (now=F).
-
-    The CoS theory operates on a single predicate P, but the QGL world model
-    separates prior state (`past`) from current state (`now`). We use `·.past`
-    for the presupposition and `·.now` for the assertion. -/
-theorem stopped_matches_cessation (w : WorldState) :
-    literalMeaning .stoppedSmoking w = true ↔
-    (priorStatePresup .cessation (fun w => w.past = true) w ∧
-     resultStateAssertion .cessation (fun w => w.now = true) w) := by
-  cases w <;> simp [literalMeaning, priorStatePresup, resultStateAssertion,
-    WorldState.past, WorldState.now]
-
-/-- "Started smoking" = inception presupposition (past=F) ∧ inception assertion (now=T). -/
-theorem started_matches_inception (w : WorldState) :
-    literalMeaning .startedSmoking w = true ↔
-    (priorStatePresup .inception (fun w => w.past = true) w ∧
-     resultStateAssertion .inception (fun w => w.now = true) w) := by
-  cases w <;> simp [literalMeaning, priorStatePresup, resultStateAssertion,
-    WorldState.past, WorldState.now]
-
-/-- "Always smoked" = continuation presupposition (past=T) ∧ continuation assertion (now=T). -/
-theorem always_matches_continuation (w : WorldState) :
-    literalMeaning .alwaysSmoked w = true ↔
-    (priorStatePresup .continuation (fun w => w.past = true) w ∧
-     resultStateAssertion .continuation (fun w => w.now = true) w) := by
-  cases w <;> simp [literalMeaning, priorStatePresup, resultStateAssertion,
-    WorldState.past, WorldState.now]
-
+open Features.ChangeOfState (CoSType)
 /-! ### Context sets -/
 
 /-- Context sets: subsets of worlds representing common ground.
@@ -354,46 +325,27 @@ theorem stopped_qud_answer :
 
 /-! ### Structural properties -/
 
-/-- "didn't stop smoking" is compatible with 3 of 4 worlds. -/
-theorem notStopped_compatible_worlds :
-    literalMeaning .notStoppedSmoking .wTT = true ∧
-    literalMeaning .notStoppedSmoking .wTF = false ∧
-    literalMeaning .notStoppedSmoking .wFT = true ∧
-    literalMeaning .notStoppedSmoking .wFF = true :=
-  ⟨rfl, rfl, rfl, rfl⟩
+/-- "didn't stop smoking" excludes exactly the stopping world. -/
+theorem notStopped_compatible_worlds (w : WorldState) :
+    literalMeaning .notStoppedSmoking w = true ↔ w ≠ .wTF := by cases w <;> decide
 
-/-- Under context set +past, "didn't stop" is maximally informative for QUD_now:
-    it narrows to exactly (T,T). -/
-theorem notStopped_informative_in_pastTrue :
-    (compatibleBool .pastTrue .wTT && literalMeaning .notStoppedSmoking .wTT) = true ∧
-    (compatibleBool .pastTrue .wTF && literalMeaning .notStoppedSmoking .wTF) = false ∧
-    (compatibleBool .pastTrue .wFT && literalMeaning .notStoppedSmoking .wFT) = false ∧
-    (compatibleBool .pastTrue .wFF && literalMeaning .notStoppedSmoking .wFF) = false :=
-  ⟨rfl, rfl, rfl, rfl⟩
+/-- Under a +past context set, "didn't stop" is maximally informative for
+QUD_now: it narrows to exactly wTT. -/
+theorem notStopped_informative_in_pastTrue (w : WorldState) :
+    (compatibleBool .pastTrue w && literalMeaning .notStoppedSmoking w) = true ↔
+      w = .wTT := by cases w <;> decide
 
-/-- "stopped smoking" narrows to exactly (T,F): past=T and now=F. -/
-theorem stopped_world :
-    literalMeaning .stoppedSmoking .wTT = false ∧
-    literalMeaning .stoppedSmoking .wTF = true ∧
-    literalMeaning .stoppedSmoking .wFT = false ∧
-    literalMeaning .stoppedSmoking .wFF = false :=
-  ⟨rfl, rfl, rfl, rfl⟩
+/-- "stopped smoking" denotes exactly the stopping world (T,F). -/
+theorem stopped_world (w : WorldState) :
+    literalMeaning .stoppedSmoking w = true ↔ w = .wTF := by cases w <;> decide
 
-/-- "always smoked" = {(T,T)}, maximally informative for (T,T). -/
-theorem alwaysSmoked_world :
-    literalMeaning .alwaysSmoked .wTT = true ∧
-    literalMeaning .alwaysSmoked .wTF = false ∧
-    literalMeaning .alwaysSmoked .wFT = false ∧
-    literalMeaning .alwaysSmoked .wFF = false :=
-  ⟨rfl, rfl, rfl, rfl⟩
+/-- "always smoked" denotes exactly (T,T). -/
+theorem alwaysSmoked_world (w : WorldState) :
+    literalMeaning .alwaysSmoked w = true ↔ w = .wTT := by cases w <;> decide
 
-/-- "never smoked" = {(F,F)}, maximally informative for (F,F). -/
-theorem neverSmoked_world :
-    literalMeaning .neverSmoked .wTT = false ∧
-    literalMeaning .neverSmoked .wTF = false ∧
-    literalMeaning .neverSmoked .wFT = false ∧
-    literalMeaning .neverSmoked .wFF = true :=
-  ⟨rfl, rfl, rfl, rfl⟩
+/-- "never smoked" denotes exactly (F,F). -/
+theorem neverSmoked_world (w : WorldState) :
+    literalMeaning .neverSmoked w = true ↔ w = .wFF := by cases w <;> decide
 
 /-- Context sets that entail past=T (used for measuring projection). -/
 def entailsPast : ContextSet → Bool

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -79,14 +79,14 @@ inductive Utterance where
   | doesntSmoke         -- "John doesn't smoke"    {(T,F),(F,F)}
   | smoked              -- "John smoked"           {(T,T),(T,F)}
   | didntSmoke          -- "John didn't smoke"     {(F,T),(F,F)}
-  | alwaysSmoked        -- "John has always smoked"  {(T,T)}
-  | notAlwaysSmoked     -- "John hasn't always smoked" {(T,F),(F,T),(F,F)}
-  | stoppedSmoking      -- "John stopped smoking"  {(T,F)}
-  | notStoppedSmoking   -- "John didn't stop smoking" {(T,T),(F,T),(F,F)}
-  | startedSmoking      -- "John started smoking"  {(F,T)}
-  | notStartedSmoking   -- "John didn't start smoking" {(T,T),(T,F),(F,F)}
-  | neverSmoked         -- "John has never smoked" {(F,F)}
-  | notNeverSmoked      -- "John hasn't never smoked" {(T,T),(T,F),(F,T)}
+  | always        -- "John has always smoked"  {(T,T)}
+  | notAlways     -- "John hasn't always smoked" {(T,F),(F,T),(F,F)}
+  | stopped      -- "John stopped smoking"  {(T,F)}
+  | notStopped   -- "John didn't stop smoking" {(T,T),(F,T),(F,F)}
+  | started      -- "John started smoking"  {(F,T)}
+  | notStarted   -- "John didn't start smoking" {(T,T),(T,F),(F,F)}
+  | never         -- "John has never smoked" {(F,F)}
+  | notNever      -- "John hasn't never smoked" {(T,T),(T,F),(F,T)}
   | silence             -- null utterance          {(T,T),(T,F),(F,T),(F,F)}
   deriving DecidableEq, Repr, Inhabited, Fintype
 
@@ -103,14 +103,14 @@ def literalMeaning : Utterance → WorldState → Bool
   | .doesntSmoke,       w => !w.now
   | .smoked,            w => w.past
   | .didntSmoke,        w => !w.past
-  | .alwaysSmoked,      w => Features.ChangeOfState.CoSType.continuation.eval w.past w.now
-  | .notAlwaysSmoked,   w => !Features.ChangeOfState.CoSType.continuation.eval w.past w.now
-  | .stoppedSmoking,    w => Features.ChangeOfState.CoSType.cessation.eval w.past w.now
-  | .notStoppedSmoking, w => !Features.ChangeOfState.CoSType.cessation.eval w.past w.now
-  | .startedSmoking,    w => Features.ChangeOfState.CoSType.inception.eval w.past w.now
-  | .notStartedSmoking, w => !Features.ChangeOfState.CoSType.inception.eval w.past w.now
-  | .neverSmoked,       w => !w.past && !w.now
-  | .notNeverSmoked,    w => !(!w.past && !w.now)
+  | .always,      w => Features.ChangeOfState.CoSType.continuation.eval w.past w.now
+  | .notAlways,   w => !Features.ChangeOfState.CoSType.continuation.eval w.past w.now
+  | .stopped,    w => Features.ChangeOfState.CoSType.cessation.eval w.past w.now
+  | .notStopped, w => !Features.ChangeOfState.CoSType.cessation.eval w.past w.now
+  | .started,    w => Features.ChangeOfState.CoSType.inception.eval w.past w.now
+  | .notStarted, w => !Features.ChangeOfState.CoSType.inception.eval w.past w.now
+  | .never,       w => !w.past && !w.now
+  | .notNever,    w => !(!w.past && !w.now)
   | .silence,           _ => true
 
 open Features.ChangeOfState (CoSType)
@@ -162,10 +162,10 @@ inductive QUD where
     - 0 content words: silence → 1 -/
 def utterancePrior : Utterance → ℚ≥0
   | .smokes | .doesntSmoke | .smoked | .didntSmoke => 1/2
-  | .alwaysSmoked | .notAlwaysSmoked
-  | .stoppedSmoking | .notStoppedSmoking
-  | .startedSmoking | .notStartedSmoking
-  | .neverSmoked | .notNeverSmoked => 1/4
+  | .always | .notAlways
+  | .stopped | .notStopped
+  | .started | .notStarted
+  | .never | .notNever => 1/4
   | .silence => 1
 
 /-- Context set prior (eq. 8):
@@ -243,17 +243,14 @@ noncomputable def l1WorldEvent (qud : QUD) (u : Utterance)
 /-- Under QUD_now, wTT and wFT are indistinguishable: `qAggQ .now` is
 definitionally symmetric in the now-cell, so projection must be measured on
 the context-set side (`l1Ctx`), not the world marginal. -/
-theorem qud_now_wTT_eq_wFT :
-    l1World .now .notStoppedSmoking .wTT =
-    l1World .now .notStoppedSmoking .wFT :=
+theorem qud_now_wTT_eq_wFT : l1World .now .notStopped .wTT = l1World .now .notStopped .wFT :=
   PMF.ofScores_eq_cross _ _ (by decide +kernel)
 
 /-! ### QUD answer -/
 
 /-- L1 infers the QUD answer now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
-    l1WorldEvent .now .notStoppedSmoking (fun w => !w.now) <
-    l1WorldEvent .now .notStoppedSmoking (·.now) :=
+    l1WorldEvent .now .notStopped (fun w => !w.now) < l1WorldEvent .now .notStopped (·.now) :=
   PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### World elimination
@@ -261,9 +258,7 @@ theorem qud_answer_now_true :
 "Didn't stop smoking" is literally false at wTF, concentrating L1 on wTT. -/
 
 /-- now=T dominates now=F among past=T worlds. -/
-theorem wTT_gt_wTF :
-    l1World .now .notStoppedSmoking .wTF <
-    l1World .now .notStoppedSmoking .wTT :=
+theorem wTT_gt_wTF : l1World .now .notStopped .wTF < l1World .now .notStopped .wTT :=
   PMF.ofScores_lt _ (by decide +kernel)
 
 /-! ### Projection under QUD_max (Figure 1c)
@@ -273,9 +268,7 @@ narrows to exactly wTT — but projection stays incomplete: wTT = wFF, so
 the past marginals still coincide. -/
 
 /-- Projection under QUD_max: wTT > wFT. -/
-theorem projection_under_qud_max :
-    l1World .max .notStoppedSmoking .wFT <
-    l1World .max .notStoppedSmoking .wTT :=
+theorem projection_under_qud_max : l1World .max .notStopped .wFT < l1World .max .notStopped .wTT :=
   PMF.ofScores_lt _ (by decide +kernel)
 
 /-- Incomplete projection under QUD_max: wTT = wFF (Figure 1c). The
@@ -283,8 +276,7 @@ involution (past, now) ↦ (¬now, ¬past) fixes ⟦didn't stop⟧ and permutes 
 context sets prior-preservingly, so world marginals cannot fully register
 the presupposition. -/
 theorem qud_max_incomplete_projection :
-    l1World .max .notStoppedSmoking .wTT =
-    l1World .max .notStoppedSmoking .wFF :=
+    l1World .max .notStopped .wTT = l1World .max .notStopped .wFF :=
   PMF.ofScores_eq_cross _ _ (by decide +kernel)
 
 /-! ### Context set projection (the paper's main result, Figure 3)
@@ -295,57 +287,52 @@ the speaker assumed a +past common ground — projection as context-set
 inference, with (wTT, +past) the joint mode (Figure 3). -/
 
 /-- The headline: L1 infers a +past context set over −past. -/
-theorem context_projection :
-    l1Ctx .now .notStoppedSmoking .pastFalse <
-    l1Ctx .now .notStoppedSmoking .pastTrue :=
+theorem context_projection : l1Ctx .now .notStopped .pastFalse < l1Ctx .now .notStopped .pastTrue :=
   PMF.ofScores_lt _ (by decide +kernel)
 
 /-- +past beats `universe` despite the prior (6 vs 9): "didn't stop" narrows
 to wTT under +past (`1⁶ = 1`) but spreads over three worlds under `universe`
 (`(1/4)⁶`). -/
 theorem context_projection_over_universe :
-    l1Ctx .now .notStoppedSmoking .universe <
-    l1Ctx .now .notStoppedSmoking .pastTrue :=
+    l1Ctx .now .notStopped .universe < l1Ctx .now .notStopped .pastTrue :=
   PMF.ofScores_lt _ (by decide +kernel)
 
 /-- −now contexts are dispreferred (p. 1114): −now already entails the QUD
 answer, so "didn't stop smoking" adds nothing there. -/
 theorem now_context_dispreferred :
-    l1Ctx .now .notStoppedSmoking .nowFalse <
-    l1Ctx .now .notStoppedSmoking .pastTrue :=
+    l1Ctx .now .notStopped .nowFalse < l1Ctx .now .notStopped .pastTrue :=
   PMF.ofScores_lt _ (by decide +kernel)
 
 /-! ### "Stopped smoking" -/
 
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
-    l1WorldEvent .now .stoppedSmoking (·.now) <
-    l1WorldEvent .now .stoppedSmoking (fun w => !w.now) :=
+    l1WorldEvent .now .stopped (·.now) < l1WorldEvent .now .stopped (fun w => !w.now) :=
   PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### Structural properties -/
 
 /-- "didn't stop smoking" excludes exactly the stopping world. -/
 theorem notStopped_compatible_worlds (w : WorldState) :
-    literalMeaning .notStoppedSmoking w = true ↔ w ≠ .wTF := by cases w <;> decide
+    literalMeaning .notStopped w = true ↔ w ≠ .wTF := by cases w <;> decide
 
 /-- Under a +past context set, "didn't stop" is maximally informative for
 QUD_now: it narrows to exactly wTT. -/
 theorem notStopped_informative_in_pastTrue (w : WorldState) :
-    (compatibleBool .pastTrue w && literalMeaning .notStoppedSmoking w) = true ↔
+    (compatibleBool .pastTrue w && literalMeaning .notStopped w) = true ↔
       w = .wTT := by cases w <;> decide
 
 /-- "stopped smoking" denotes exactly the stopping world (T,F). -/
 theorem stopped_world (w : WorldState) :
-    literalMeaning .stoppedSmoking w = true ↔ w = .wTF := by cases w <;> decide
+    literalMeaning .stopped w = true ↔ w = .wTF := by cases w <;> decide
 
 /-- "always smoked" denotes exactly (T,T). -/
 theorem alwaysSmoked_world (w : WorldState) :
-    literalMeaning .alwaysSmoked w = true ↔ w = .wTT := by cases w <;> decide
+    literalMeaning .always w = true ↔ w = .wTT := by cases w <;> decide
 
 /-- "never smoked" denotes exactly (F,F). -/
 theorem neverSmoked_world (w : WorldState) :
-    literalMeaning .neverSmoked w = true ↔ w = .wFF := by cases w <;> decide
+    literalMeaning .never w = true ↔ w = .wFF := by cases w <;> decide
 
 /-- Context sets that entail past=T (used for measuring projection). -/
 def entailsPast : ContextSet → Bool

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -1,3 +1,4 @@
+import Linglib.Pragmatics.RSA.ScoreChain
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Operators
 import Linglib.Semantics.Aspect.ChangeOfState
@@ -26,10 +27,11 @@ Domain: 13 utterances × 4 worlds × 9 context sets.
 
 ## Implementation notes
 
-α = 6 is a natural power, so every layer is rational: scores are computed in
-exact ℚ (`l0Q` … `ctxScoreQ`), listeners are `PMF.normalize` of those scores
-(bridged by `ENNReal.ofReal_sum_of_nonneg`), and predictions are
-kernel-verified rational comparisons (`decide +kernel`).
+α = 6 is a natural power, so the chain is exact ℚ≥0: the speaker is
+`RSA.Score.s1` over the QUD-aggregated literal listener (dead cells fall
+back to silence — one fallback declaration covers both faces), listeners
+are `PMF.ofScores` of the prior-weighted speaker mass, and each prediction
+closes by the `ofScores` comparison family with one kernel certificate.
 
 The paper uses 15 context sets with 5% noise; we model the 9 derivable from
 past/now observations — the omitted 6 carry only the noise prior (≥ 18×
@@ -48,6 +50,7 @@ reaching the PMF face.
 namespace QingGoodmanLassiter2016
 
 open BigOperators
+open scoped ENNReal NNRat
 /-! ### World states -/
 
 /-- World state: (past, now) where past = John smoked, now = John smokes.
@@ -186,16 +189,13 @@ inductive QUD where
     - 2 content words: stopped/started/always/never smoking → 1/4
     - 1 content word: smokes/smoked → 1/2
     - 0 content words: silence → 1 -/
-def utterancePrior : Utterance → ℚ
+def utterancePrior : Utterance → ℚ≥0
   | .smokes | .doesntSmoke | .smoked | .didntSmoke => 1/2
   | .alwaysSmoked | .notAlwaysSmoked
   | .stoppedSmoking | .notStoppedSmoking
   | .startedSmoking | .notStartedSmoking
   | .neverSmoked | .notNeverSmoked => 1/4
   | .silence => 1
-
-theorem utterancePrior_nonneg (u : Utterance) : 0 ≤ utterancePrior u := by
-  cases u <;> simp [utterancePrior]
 
 /-- Context set prior (eq. 8):
 `Pr(C) ∝ Σ_{CG ⊆ Obs} P(CG) · δ_{C = ∩CG}`.
@@ -204,280 +204,66 @@ theorem utterancePrior_nonneg (u : Utterance) : 0 ≤ utterancePrior u := by
     - 0 observations (universe): 0.6^4 ∝ 9
     - 1 observation (single): 0.4 × 0.6^3 ∝ 6
     - 2 observations (pair): 0.4^2 × 0.6^2 ∝ 4 -/
-def contextPrior : ContextSet → ℚ
+def contextPrior : ContextSet → ℚ≥0
   | .universe => 9
   | .pastTrue | .pastFalse | .nowTrue | .nowFalse => 6
   | .pastTrueNowTrue | .pastTrueNowFalse
   | .pastFalseNowTrue | .pastFalseNowFalse => 4
 
-theorem contextPrior_pos (cs : ContextSet) : 0 < contextPrior cs := by
-  cases cs <;> simp [contextPrior]
+/-! ### The score chain -/
 
-/-! ### The exact-ℚ model and its PMF face (local pending the RSA API pass) -/
-
-section QModel
-
-/-- Literal-listener mass: worlds compatible with the context set where `u`
-is literally true (eq. 5's normaliser; uniform world prior cancels). -/
-def l0MassQ (cs : ContextSet) (u : Utterance) : ℚ :=
-  ∑ w, (if compatibleBool cs w && literalMeaning u w then (1 : ℚ) else 0)
-
-/-- Literal listener value (division by zero yields 0 at empty extensions). -/
-def l0Q (cs : ContextSet) (u : Utterance) (w : WorldState) : ℚ :=
-  (if compatibleBool cs w && literalMeaning u w then (1 : ℚ) else 0) / l0MassQ cs u
+/-- Literal listener within the context set (eq. 5; the uniform world
+prior cancels, and empty extensions normalize to the zero row). -/
+def l0Score (cs : ContextSet) (u : Utterance) : WorldState → ℚ≥0 :=
+  PMF.normalizeScores fun w =>
+    if compatibleBool cs w && literalMeaning u w then 1 else 0
 
 /-- QUD aggregation of the literal listener (eq. 5): sum over the QUD cell. -/
-def qAggQ (qud : QUD) (cs : ContextSet) (u : Utterance) : WorldState → ℚ
+def qAgg (qud : QUD) (cs : ContextSet) (u : Utterance) : WorldState → ℚ≥0
   | .wTT => match qud with
-    | .now => l0Q cs u .wTT + l0Q cs u .wFT
-    | .max => l0Q cs u .wTT
-    | .past => l0Q cs u .wTT + l0Q cs u .wTF
+    | .now => l0Score cs u .wTT + l0Score cs u .wFT
+    | .max => l0Score cs u .wTT
+    | .past => l0Score cs u .wTT + l0Score cs u .wTF
   | .wTF => match qud with
-    | .now => l0Q cs u .wTF + l0Q cs u .wFF
-    | .max => l0Q cs u .wTF
-    | .past => l0Q cs u .wTT + l0Q cs u .wTF
+    | .now => l0Score cs u .wTF + l0Score cs u .wFF
+    | .max => l0Score cs u .wTF
+    | .past => l0Score cs u .wTT + l0Score cs u .wTF
   | .wFT => match qud with
-    | .now => l0Q cs u .wTT + l0Q cs u .wFT
-    | .max => l0Q cs u .wFT
-    | .past => l0Q cs u .wFT + l0Q cs u .wFF
+    | .now => l0Score cs u .wTT + l0Score cs u .wFT
+    | .max => l0Score cs u .wFT
+    | .past => l0Score cs u .wFT + l0Score cs u .wFF
   | .wFF => match qud with
-    | .now => l0Q cs u .wTF + l0Q cs u .wFF
-    | .max => l0Q cs u .wFF
-    | .past => l0Q cs u .wFT + l0Q cs u .wFF
+    | .now => l0Score cs u .wTF + l0Score cs u .wFF
+    | .max => l0Score cs u .wFF
+    | .past => l0Score cs u .wFT + l0Score cs u .wFF
 
-/-- Speaker weight (eq. 6 at α = 6): `Pr(u) · qAgg⁶`. -/
-def s1WeightQ (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) : ℚ :=
-  utterancePrior u * (qAggQ qud cs u w) ^ 6
+/-- Speaker (eq. 6 at α = 6): `RSA.Score.s1` over the QUD-aggregated
+literal listener with the utterance prior as multiplicative cost; dead
+cells fall back to silence. -/
+def s1Post (qud : QUD) (cs : ContextSet) : WorldState → Utterance → ℚ≥0 :=
+  RSA.Score.s1 (fun u w => qAgg qud cs u w) 6 utterancePrior (.pure .silence)
 
-/-- Speaker normaliser. -/
-def s1ZQ (qud : QUD) (cs : ContextSet) (w : WorldState) : ℚ :=
-  ∑ u, s1WeightQ qud cs w u
-
-/-- Normalized speaker value. -/
-def s1ValQ (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) : ℚ :=
-  s1WeightQ qud cs w u / s1ZQ qud cs w
-
-/-- Listener world score (eq. 7, world side): context-prior-weighted speaker
-mass, before normalization. -/
-def worldScoreQ (qud : QUD) (u : Utterance) (w : WorldState) : ℚ :=
-  ∑ cs, contextPrior cs * s1ValQ qud cs w u
+/-- Listener world score (eq. 7, world side): context-prior-weighted
+speaker mass. -/
+def worldScore (qud : QUD) (u : Utterance) (w : WorldState) : ℚ≥0 :=
+  ∑ cs, contextPrior cs * s1Post qud cs w u
 
 /-- Listener context score (eq. 7, context side). -/
-def ctxScoreQ (qud : QUD) (u : Utterance) (cs : ContextSet) : ℚ :=
-  contextPrior cs * ∑ w, s1ValQ qud cs w u
+def ctxScore (qud : QUD) (u : Utterance) (cs : ContextSet) : ℚ≥0 :=
+  contextPrior cs * ∑ w, s1Post qud cs w u
 
-theorem l0MassQ_nonneg (cs : ContextSet) (u : Utterance) : 0 ≤ l0MassQ cs u :=
-  Finset.sum_nonneg fun _ _ => by split <;> norm_num
-
-theorem l0Q_nonneg (cs : ContextSet) (u : Utterance) (w : WorldState) :
-    0 ≤ l0Q cs u w :=
-  div_nonneg (by split <;> norm_num) (l0MassQ_nonneg cs u)
-
-theorem qAggQ_nonneg (qud : QUD) (cs : ContextSet) (u : Utterance) (w : WorldState) :
-    0 ≤ qAggQ qud cs u w := by
-  cases w <;> cases qud <;>
-    simp only [qAggQ] <;>
-    first
-      | exact l0Q_nonneg cs u _
-      | exact add_nonneg (l0Q_nonneg cs u _) (l0Q_nonneg cs u _)
-
-theorem s1WeightQ_nonneg (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) :
-    0 ≤ s1WeightQ qud cs w u :=
-  mul_nonneg (utterancePrior_nonneg u) (pow_nonneg (qAggQ_nonneg qud cs u w) 6)
-
-theorem s1ZQ_nonneg (qud : QUD) (cs : ContextSet) (w : WorldState) :
-    0 ≤ s1ZQ qud cs w :=
-  Finset.sum_nonneg fun u _ => s1WeightQ_nonneg qud cs w u
-
-theorem s1ValQ_nonneg (qud : QUD) (cs : ContextSet) (w : WorldState) (u : Utterance) :
-    0 ≤ s1ValQ qud cs w u :=
-  div_nonneg (s1WeightQ_nonneg qud cs w u) (s1ZQ_nonneg qud cs w)
-
-theorem worldScoreQ_nonneg (qud : QUD) (u : Utterance) (w : WorldState) :
-    0 ≤ worldScoreQ qud u w :=
-  Finset.sum_nonneg fun cs _ =>
-    mul_nonneg (le_of_lt (contextPrior_pos cs)) (s1ValQ_nonneg qud cs w u)
-
-theorem ctxScoreQ_nonneg (qud : QUD) (u : Utterance) (cs : ContextSet) :
-    0 ≤ ctxScoreQ qud u cs :=
-  mul_nonneg (le_of_lt (contextPrior_pos cs))
-    (Finset.sum_nonneg fun w _ => s1ValQ_nonneg qud cs w u)
-
-end QModel
-
-section PMFFace
-
-open scoped ENNReal
-
-/-- PMF speaker (eq. 6), total via dite (pure-silence fallback at cells with
-no compatible utterance). -/
-noncomputable def s1PMF (qud : QUD) (cs : ContextSet) (w : WorldState) : PMF Utterance :=
-  if h : (∑' u, ENNReal.ofReal ((s1WeightQ qud cs w u : ℝ))) ≠ 0 then
-    PMF.normalize (fun u => ENNReal.ofReal ((s1WeightQ qud cs w u : ℝ))) h
-      (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
-  else PMF.pure .silence
-
-private theorem sumW_eq (qud : QUD) (cs : ContextSet) (w : WorldState) :
-    (∑' u, ENNReal.ofReal ((s1WeightQ qud cs w u : ℝ)))
-      = ENNReal.ofReal ((s1ZQ qud cs w : ℝ)) := by
-  rw [tsum_fintype, ← ENNReal.ofReal_sum_of_nonneg
-    (fun u _ => by exact_mod_cast s1WeightQ_nonneg qud cs w u)]
-  congr 1
-  push_cast [s1ZQ]
-  rfl
-
-/-- The PMF speaker's values bridge exactly to the ℚ model (off `silence`,
-which absorbs the degenerate fallback). -/
-theorem s1PMF_apply (qud : QUD) (cs : ContextSet) (w : WorldState)
-    {u : Utterance} (hu : u ≠ .silence) :
-    s1PMF qud cs w u = ENNReal.ofReal ((s1ValQ qud cs w u : ℝ)) := by
-  unfold s1PMF
-  by_cases hZ : (0 : ℚ) < s1ZQ qud cs w
-  · rw [dif_pos (by rw [sumW_eq, ENNReal.ofReal_ne_zero_iff]; exact_mod_cast hZ),
-      PMF.normalize_apply, sumW_eq,
-      ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hZ),
-      ← ENNReal.ofReal_mul (by exact_mod_cast s1WeightQ_nonneg qud cs w u)]
-    congr 1
-    push_cast [s1ValQ]
-    rw [div_eq_mul_inv]
-  · have hZ0 : s1ZQ qud cs w = 0 := le_antisymm (not_lt.mp hZ) (s1ZQ_nonneg _ _ _)
-    rw [dif_neg (by rw [sumW_eq, hZ0]; simp),
-      show s1ValQ qud cs w u = 0 from by rw [s1ValQ, hZ0, div_zero]]
-    simp [PMF.pure_apply, hu]
-
-/-- World score of the pragmatic listener in PMF terms. -/
-noncomputable def wScore (qud : QUD) (u : Utterance) (w : WorldState) : ℝ≥0∞ :=
-  ∑' cs, ENNReal.ofReal ((contextPrior cs : ℝ)) * s1PMF qud cs w u
-
-theorem wScore_eq (qud : QUD) {u : Utterance} (hu : u ≠ .silence) (w : WorldState) :
-    wScore qud u w = ENNReal.ofReal ((worldScoreQ qud u w : ℝ)) := by
-  unfold wScore
-  rw [tsum_fintype,
-    Finset.sum_congr rfl (fun cs _ => by
-      rw [s1PMF_apply qud cs w hu,
-        ← ENNReal.ofReal_mul (by exact_mod_cast le_of_lt (contextPrior_pos cs))]),
-    ← ENNReal.ofReal_sum_of_nonneg (fun cs _ => by
-      exact_mod_cast mul_nonneg (le_of_lt (contextPrior_pos cs))
-        (s1ValQ_nonneg qud cs w u))]
-  congr 1
-  push_cast [worldScoreQ]
-  rfl
-
-/-- Context score of the pragmatic listener in PMF terms. -/
-noncomputable def cScore (qud : QUD) (u : Utterance) (cs : ContextSet) : ℝ≥0∞ :=
-  ENNReal.ofReal ((contextPrior cs : ℝ)) * ∑' w, s1PMF qud cs w u
-
-theorem cScore_eq (qud : QUD) {u : Utterance} (hu : u ≠ .silence) (cs : ContextSet) :
-    cScore qud u cs = ENNReal.ofReal ((ctxScoreQ qud u cs : ℝ)) := by
-  unfold cScore
-  rw [tsum_fintype,
-    Finset.sum_congr rfl (fun w _ => s1PMF_apply qud cs w hu),
-    ← ENNReal.ofReal_sum_of_nonneg (fun w _ => by
-      exact_mod_cast s1ValQ_nonneg qud cs w u),
-    ← ENNReal.ofReal_mul (by exact_mod_cast le_of_lt (contextPrior_pos cs))]
-  congr 1
-  push_cast [ctxScoreQ]
-  rfl
-
-/-- World-side pragmatic listener (eq. 7), dite-total. -/
+/-- World-side pragmatic listener (eq. 7). -/
 noncomputable def l1World (qud : QUD) (u : Utterance) : PMF WorldState :=
-  if h : (∑' w, wScore qud u w) ≠ 0 then
-    PMF.normalize (wScore qud u) h
-      (ENNReal.tsum_ne_top_of_fintype fun _ =>
-        ENNReal.tsum_ne_top_of_fintype fun _ =>
-          ENNReal.mul_ne_top ENNReal.ofReal_ne_top (PMF.apply_ne_top _ _))
-  else PMF.uniformOfFintype WorldState
+  .ofScores .uniform (worldScore qud u)
 
-/-- Context-side pragmatic listener (eq. 7), dite-total. -/
+/-- Context-side pragmatic listener (eq. 7). -/
 noncomputable def l1Ctx (qud : QUD) (u : Utterance) : PMF ContextSet :=
-  if h : (∑' cs, cScore qud u cs) ≠ 0 then
-    PMF.normalize (cScore qud u) h
-      (ENNReal.tsum_ne_top_of_fintype fun _ =>
-        ENNReal.mul_ne_top ENNReal.ofReal_ne_top
-          (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _))
-  else PMF.uniformOfFintype ContextSet
-
-end PMFFace
-
-section PMFFace
-
-open scoped ENNReal
-
-private theorem sumWorlds4 (f : WorldState → ℝ≥0∞) :
-    ∑' w, f w = f .wTT + f .wTF + f .wFT + f .wFF := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset WorldState) = {.wTT, .wTF, .wFT, .wFF} from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-  ring
-
-private theorem wZ_fin (qud : QUD) (u : Utterance) :
-    (∑' w, wScore qud u w) ≠ ⊤ :=
-  ENNReal.tsum_ne_top_of_fintype fun _ =>
-    ENNReal.tsum_ne_top_of_fintype fun _ =>
-      ENNReal.mul_ne_top ENNReal.ofReal_ne_top (PMF.apply_ne_top _ _)
-
-private theorem wZ_pos_now_ns : (∑' w, wScore .now .notStoppedSmoking w) ≠ 0 :=
-  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.wTT, by
-    rw [wScore_eq .now (by decide) _, ENNReal.ofReal_ne_zero_iff]
-    exact_mod_cast
-      (by decide +kernel : (0:ℚ) < worldScoreQ .now .notStoppedSmoking .wTT)⟩
-
-private theorem wZ_pos_max_ns : (∑' w, wScore .max .notStoppedSmoking w) ≠ 0 :=
-  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.wTT, by
-    rw [wScore_eq .max (by decide) _, ENNReal.ofReal_ne_zero_iff]
-    exact_mod_cast
-      (by decide +kernel : (0:ℚ) < worldScoreQ .max .notStoppedSmoking .wTT)⟩
-
-private theorem wZ_pos_now_st : (∑' w, wScore .now .stoppedSmoking w) ≠ 0 :=
-  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.wTF, by
-    rw [wScore_eq .now (by decide) _, ENNReal.ofReal_ne_zero_iff]
-    exact_mod_cast
-      (by decide +kernel : (0:ℚ) < worldScoreQ .now .stoppedSmoking .wTF)⟩
-
-private theorem cZ_pos_now_ns : (∑' cs, cScore .now .notStoppedSmoking cs) ≠ 0 :=
-  ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.pastTrue, by
-    rw [cScore_eq .now (by decide) _, ENNReal.ofReal_ne_zero_iff]
-    exact_mod_cast
-      (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue)⟩
-
-/-- Score comparison under a shared normaliser: the workhorse for every
-strict listener prediction below. -/
-private theorem ofReal_mul_inv_lt {Z : ℝ≥0∞} (hZ0 : Z ≠ 0) (hZt : Z ≠ ⊤)
-    {a b : ℝ} (hb : 0 < b) (hab : a < b) :
-    ENNReal.ofReal a * Z⁻¹ < ENNReal.ofReal b * Z⁻¹ := by
-  rw [mul_comm, mul_comm (ENNReal.ofReal b)]
-  exact ENNReal.mul_lt_mul_right (ENNReal.inv_ne_zero.mpr hZt)
-    (ENNReal.inv_ne_top.mpr hZ0) ((ENNReal.ofReal_lt_ofReal_iff hb).mpr hab)
-
-/-- Listener world values in ℚ-bridged form. -/
-private theorem l1World_apply (qud : QUD) {u : Utterance} (hu : u ≠ .silence)
-    (hpos : (∑' w, wScore qud u w) ≠ 0) (w : WorldState) :
-    l1World qud u w
-      = ENNReal.ofReal ((worldScoreQ qud u w : ℝ)) * (∑' w', wScore qud u w')⁻¹ := by
-  unfold l1World
-  rw [dif_pos hpos, PMF.normalize_apply, wScore_eq qud hu w]
+  .ofScores .uniform (ctxScore qud u)
 
 /-- Event marginal of the world-side listener. -/
 noncomputable def l1WorldEvent (qud : QUD) (u : Utterance)
-    (P : WorldState → Prop) [DecidablePred P] : ℝ≥0∞ :=
+    (P : WorldState → Bool) : ℝ≥0∞ :=
   ∑' w, if P w then l1World qud u w else 0
-
-private theorem cZ_fin (qud : QUD) (u : Utterance) :
-    (∑' cs, cScore qud u cs) ≠ ⊤ :=
-  ENNReal.tsum_ne_top_of_fintype fun _ =>
-    ENNReal.mul_ne_top ENNReal.ofReal_ne_top
-      (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _)
-
-/-- Listener context values in ℚ-bridged form. -/
-private theorem l1Ctx_apply (qud : QUD) {u : Utterance} (hu : u ≠ .silence)
-    (hpos : (∑' cs, cScore qud u cs) ≠ 0) (cs : ContextSet) :
-    l1Ctx qud u cs
-      = ENNReal.ofReal ((ctxScoreQ qud u cs : ℝ)) * (∑' cs', cScore qud u cs')⁻¹ := by
-  unfold l1Ctx
-  rw [dif_pos hpos, PMF.normalize_apply, cScore_eq qud hu cs]
-
-end PMFFace
 
 /-! ### Listener predictions -/
 
@@ -488,32 +274,16 @@ definitionally symmetric in the now-cell, so projection must be measured on
 the context-set side (`l1Ctx`), not the world marginal. -/
 theorem qud_now_wTT_eq_wFT :
     l1World .now .notStoppedSmoking .wTT =
-    l1World .now .notStoppedSmoking .wFT := by
-  rw [l1World_apply .now (by decide) wZ_pos_now_ns,
-    l1World_apply .now (by decide) wZ_pos_now_ns]
-  congr 2
+    l1World .now .notStoppedSmoking .wFT :=
+  PMF.ofScores_eq_cross _ _ (by decide +kernel)
 
 /-! ### QUD answer -/
 
 /-- L1 infers the QUD answer now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
-    l1WorldEvent .now .notStoppedSmoking (fun w => w.now = true) >
-    l1WorldEvent .now .notStoppedSmoking (fun w => w.now = false) := by
-  unfold l1WorldEvent
-  rw [gt_iff_lt, sumWorlds4, sumWorlds4]
-  simp +decide only [if_true, if_false, add_zero, zero_add]
-  simp only [l1World_apply .now (by decide) wZ_pos_now_ns]
-  rw [← add_mul, ← add_mul,
-    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _)
-      (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _),
-    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _)
-      (by exact_mod_cast worldScoreQ_nonneg .now .notStoppedSmoking _)]
-  exact ofReal_mul_inv_lt wZ_pos_now_ns (wZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) <
-      worldScoreQ .now .notStoppedSmoking .wTT + worldScoreQ .now .notStoppedSmoking .wFT))
-    (by exact_mod_cast (by decide +kernel :
-      worldScoreQ .now .notStoppedSmoking .wTF + worldScoreQ .now .notStoppedSmoking .wFF <
-      worldScoreQ .now .notStoppedSmoking .wTT + worldScoreQ .now .notStoppedSmoking .wFT))
+    l1WorldEvent .now .notStoppedSmoking (fun w => !w.now) <
+    l1WorldEvent .now .notStoppedSmoking (·.now) :=
+  PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### World elimination
 
@@ -521,14 +291,9 @@ theorem qud_answer_now_true :
 
 /-- now=T dominates now=F among past=T worlds. -/
 theorem wTT_gt_wTF :
-    l1World .now .notStoppedSmoking .wTT >
-    l1World .now .notStoppedSmoking .wTF := by
-  rw [gt_iff_lt, l1World_apply .now (by decide) wZ_pos_now_ns,
-    l1World_apply .now (by decide) wZ_pos_now_ns]
-  exact ofReal_mul_inv_lt wZ_pos_now_ns (wZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) < worldScoreQ .now .notStoppedSmoking .wTT))
-    (by exact_mod_cast (by decide +kernel :
-      worldScoreQ .now .notStoppedSmoking .wTF < worldScoreQ .now .notStoppedSmoking .wTT))
+    l1World .now .notStoppedSmoking .wTF <
+    l1World .now .notStoppedSmoking .wTT :=
+  PMF.ofScores_lt _ (by decide +kernel)
 
 /-! ### Projection under QUD_max (Figure 1c)
 
@@ -538,14 +303,9 @@ the past marginals still coincide. -/
 
 /-- Projection under QUD_max: wTT > wFT. -/
 theorem projection_under_qud_max :
-    l1World .max .notStoppedSmoking .wTT >
-    l1World .max .notStoppedSmoking .wFT := by
-  rw [gt_iff_lt, l1World_apply .max (by decide) wZ_pos_max_ns,
-    l1World_apply .max (by decide) wZ_pos_max_ns]
-  exact ofReal_mul_inv_lt wZ_pos_max_ns (wZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) < worldScoreQ .max .notStoppedSmoking .wTT))
-    (by exact_mod_cast (by decide +kernel :
-      worldScoreQ .max .notStoppedSmoking .wFT < worldScoreQ .max .notStoppedSmoking .wTT))
+    l1World .max .notStoppedSmoking .wFT <
+    l1World .max .notStoppedSmoking .wTT :=
+  PMF.ofScores_lt _ (by decide +kernel)
 
 /-- Incomplete projection under QUD_max: wTT = wFF (Figure 1c). The
 involution (past, now) ↦ (¬now, ¬past) fixes ⟦didn't stop⟧ and permutes the
@@ -553,13 +313,8 @@ context sets prior-preservingly, so world marginals cannot fully register
 the presupposition. -/
 theorem qud_max_incomplete_projection :
     l1World .max .notStoppedSmoking .wTT =
-    l1World .max .notStoppedSmoking .wFF := by
-  rw [l1World_apply .max (by decide) wZ_pos_max_ns,
-    l1World_apply .max (by decide) wZ_pos_max_ns]
-  congr 2
-  exact_mod_cast (by decide +kernel :
-    worldScoreQ .max .notStoppedSmoking .wTT
-      = worldScoreQ .max .notStoppedSmoking .wFF)
+    l1World .max .notStoppedSmoking .wFF :=
+  PMF.ofScores_eq_cross _ _ (by decide +kernel)
 
 /-! ### Context set projection (the paper's main result, Figure 3)
 
@@ -570,61 +325,32 @@ inference, with (wTT, +past) the joint mode (Figure 3). -/
 
 /-- The headline: L1 infers a +past context set over −past. -/
 theorem context_projection :
-    l1Ctx .now .notStoppedSmoking .pastTrue >
-    l1Ctx .now .notStoppedSmoking .pastFalse := by
-  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns,
-    l1Ctx_apply .now (by decide) cZ_pos_now_ns]
-  exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
-    (by exact_mod_cast (by decide +kernel :
-      ctxScoreQ .now .notStoppedSmoking .pastFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
+    l1Ctx .now .notStoppedSmoking .pastFalse <
+    l1Ctx .now .notStoppedSmoking .pastTrue :=
+  PMF.ofScores_lt _ (by decide +kernel)
 
 /-- +past beats `universe` despite the prior (6 vs 9): "didn't stop" narrows
 to wTT under +past (`1⁶ = 1`) but spreads over three worlds under `universe`
 (`(1/4)⁶`). -/
 theorem context_projection_over_universe :
-    l1Ctx .now .notStoppedSmoking .pastTrue >
-    l1Ctx .now .notStoppedSmoking .universe := by
-  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns,
-    l1Ctx_apply .now (by decide) cZ_pos_now_ns]
-  exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
-    (by exact_mod_cast (by decide +kernel :
-      ctxScoreQ .now .notStoppedSmoking .universe < ctxScoreQ .now .notStoppedSmoking .pastTrue))
+    l1Ctx .now .notStoppedSmoking .universe <
+    l1Ctx .now .notStoppedSmoking .pastTrue :=
+  PMF.ofScores_lt _ (by decide +kernel)
 
 /-- −now contexts are dispreferred (p. 1114): −now already entails the QUD
 answer, so "didn't stop smoking" adds nothing there. -/
 theorem now_context_dispreferred :
-    l1Ctx .now .notStoppedSmoking .pastTrue >
-    l1Ctx .now .notStoppedSmoking .nowFalse := by
-  rw [gt_iff_lt, l1Ctx_apply .now (by decide) cZ_pos_now_ns,
-    l1Ctx_apply .now (by decide) cZ_pos_now_ns]
-  exact ofReal_mul_inv_lt cZ_pos_now_ns (cZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) < ctxScoreQ .now .notStoppedSmoking .pastTrue))
-    (by exact_mod_cast (by decide +kernel :
-      ctxScoreQ .now .notStoppedSmoking .nowFalse < ctxScoreQ .now .notStoppedSmoking .pastTrue))
+    l1Ctx .now .notStoppedSmoking .nowFalse <
+    l1Ctx .now .notStoppedSmoking .pastTrue :=
+  PMF.ofScores_lt _ (by decide +kernel)
 
 /-! ### "Stopped smoking" -/
 
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
-    l1WorldEvent .now .stoppedSmoking (fun w => w.now = false) >
-    l1WorldEvent .now .stoppedSmoking (fun w => w.now = true) := by
-  unfold l1WorldEvent
-  rw [gt_iff_lt, sumWorlds4, sumWorlds4]
-  simp +decide only [if_true, if_false, add_zero, zero_add]
-  simp only [l1World_apply .now (by decide) wZ_pos_now_st]
-  rw [← add_mul, ← add_mul,
-    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _)
-      (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _),
-    ← ENNReal.ofReal_add (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _)
-      (by exact_mod_cast worldScoreQ_nonneg .now .stoppedSmoking _)]
-  exact ofReal_mul_inv_lt wZ_pos_now_st (wZ_fin _ _)
-    (by exact_mod_cast (by decide +kernel : (0:ℚ) <
-      worldScoreQ .now .stoppedSmoking .wTF + worldScoreQ .now .stoppedSmoking .wFF))
-    (by exact_mod_cast (by decide +kernel :
-      worldScoreQ .now .stoppedSmoking .wTT + worldScoreQ .now .stoppedSmoking .wFT <
-      worldScoreQ .now .stoppedSmoking .wTF + worldScoreQ .now .stoppedSmoking .wFF))
+    l1WorldEvent .now .stoppedSmoking (·.now) <
+    l1WorldEvent .now .stoppedSmoking (fun w => !w.now) :=
+  PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### Structural properties -/
 

--- a/Linglib/Studies/ScontrasTonhauser2025.lean
+++ b/Linglib/Studies/ScontrasTonhauser2025.lean
@@ -1,10 +1,10 @@
+import Linglib.Pragmatics.RSA.ScoreChain
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.BToM
 import Linglib.Semantics.Attitudes.Factivity
 import Linglib.Studies.DegenTonhauser2021
 import Linglib.Semantics.Presupposition.Basic
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!
 # [scontras-tonhauser-2025]: projection without lexical presupposition
@@ -34,11 +34,11 @@ constraint on the common ground. Domain: 6 utterances × 4 worlds (BEL × C) ×
 
 ## Implementation notes
 
-α = 10 is a natural power, so the model is computed in exact ℚ (`l0Q` …
-`wTotalQ`); listeners are `PMF.normalize` of those scores bridged by
-`ENNReal.ofReal_sum_of_nonneg`, and every prediction is a kernel-verified
-rational comparison. Degenerate cells (no compatible utterance) fall back to
-`pure .cPos` on both faces, keeping the bridge total.
+α = 10 is a natural power, so the chain is exact ℚ≥0: the speaker is
+`RSA.Score.s1` over the QUD-aggregated literal listener with degenerate
+cells falling back to `cPos` (one declaration covering both faces), the
+listener is `PMF.ofScores`, and every prediction is one kernel-verified
+event-mass comparison.
 
 Utterance cost (§3.1: complex = 2 × simple) is omitted: `exp(−αC)` is
 transcendental, and the omission reverses prediction (2a)'s world-marginal
@@ -54,6 +54,8 @@ with [qing-goodman-lassiter-2016] (fn. 10: "private assumptions" vs "common
 ground" is interpretive, not computational) — see the matching TODO in
 `QingGoodmanLassiter2016.lean`.
 -/
+
+open scoped ENNReal NNReal NNRat
 
 namespace ScontrasTonhauser2025
 
@@ -166,400 +168,97 @@ def assumesC : BeliefState → Bool
 
 /-- World prior parameterized by P(C).
     P(BEL, C) = P(BEL | C) · P(C), with P(BEL | C) = 1/2. -/
-def worldPriorQ (pC : ℚ) : WorldState → ℚ
+def worldPrior (pC : ℚ≥0) : WorldState → ℚ≥0
   | .w11 | .w01 => pC / 2
   | .w10 | .w00 => (1 - pC) / 2
 
-theorem worldPriorQ_nonneg (pC : ℚ) (h0 : 0 ≤ pC) (h1 : pC ≤ 1)
-    (w : WorldState) : 0 ≤ worldPriorQ pC w := by
-  cases w <;> simp [worldPriorQ] <;> linarith
+/-- World prior sums to 1 whenever P(C) is a probability. -/
+theorem worldPrior_sum {pC : ℚ≥0} (h1 : pC ≤ 1) :
+    worldPrior pC .w11 + worldPrior pC .w10 +
+    worldPrior pC .w01 + worldPrior pC .w00 = 1 := by
+  rw [← NNRat.coe_inj]
+  push_cast [worldPrior, NNRat.coe_sub h1]
+  ring
 
-/-- World prior sums to 1 for any P(C). -/
-theorem worldPriorQ_sum (pC : ℚ) :
-    worldPriorQ pC .w11 + worldPriorQ pC .w10 +
-    worldPriorQ pC .w01 + worldPriorQ pC .w00 = 1 := by
-  simp [worldPriorQ]; ring
+/-! ### The score chain -/
 
-/-! ### The exact-ℚ model and its PMF face (local pending the RSA API pass) -/
-
-section QModel
-
-/-- Literal-listener mass (eq. 5's normaliser): prior mass of worlds in the
-assumption set where `u` is true. -/
-def l0MassQ (pC : ℚ) (bs : BeliefState) (u : Utterance) : ℚ :=
-  ∑ w, (if speakerCredenceBool bs w && literalMeaning u w then worldPriorQ pC w else 0)
-
-/-- Literal listener value (division by zero yields 0). -/
-def l0Q (pC : ℚ) (bs : BeliefState) (u : Utterance) (w : WorldState) : ℚ :=
-  (if speakerCredenceBool bs w && literalMeaning u w then worldPriorQ pC w else 0) /
-    l0MassQ pC bs u
+/-- Literal listener within the assumption set (eq. 5): prior conditioned
+on worlds where `u` is true, empty extensions normalizing to zero rows. -/
+def l0Score (pC : ℚ≥0) (bs : BeliefState) (u : Utterance) : WorldState → ℚ≥0 :=
+  PMF.normalizeScores fun w =>
+    if speakerCredenceBool bs w && literalMeaning u w then worldPrior pC w else 0
 
 /-- QUD aggregation of the literal listener (eq. 5). -/
-def qAggQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (u : Utterance) : WorldState → ℚ
+def qAgg (qud : QUD) (pC : ℚ≥0) (bs : BeliefState) (u : Utterance) :
+    WorldState → ℚ≥0
   | .w11 => match qud with
-    | .bel => l0Q pC bs u .w11 + l0Q pC bs u .w10
-    | .c   => l0Q pC bs u .w11 + l0Q pC bs u .w01
+    | .bel => l0Score pC bs u .w11 + l0Score pC bs u .w10
+    | .c   => l0Score pC bs u .w11 + l0Score pC bs u .w01
   | .w10 => match qud with
-    | .bel => l0Q pC bs u .w11 + l0Q pC bs u .w10
-    | .c   => l0Q pC bs u .w10 + l0Q pC bs u .w00
+    | .bel => l0Score pC bs u .w11 + l0Score pC bs u .w10
+    | .c   => l0Score pC bs u .w10 + l0Score pC bs u .w00
   | .w01 => match qud with
-    | .bel => l0Q pC bs u .w01 + l0Q pC bs u .w00
-    | .c   => l0Q pC bs u .w11 + l0Q pC bs u .w01
+    | .bel => l0Score pC bs u .w01 + l0Score pC bs u .w00
+    | .c   => l0Score pC bs u .w11 + l0Score pC bs u .w01
   | .w00 => match qud with
-    | .bel => l0Q pC bs u .w01 + l0Q pC bs u .w00
-    | .c   => l0Q pC bs u .w10 + l0Q pC bs u .w00
+    | .bel => l0Score pC bs u .w01 + l0Score pC bs u .w00
+    | .c   => l0Score pC bs u .w10 + l0Score pC bs u .w00
 
-/-- Speaker weight (eq. 6 at α = 10, zero cost). -/
-def s1WeightQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState)
-    (u : Utterance) : ℚ :=
-  (qAggQ qud pC bs u w) ^ 10
-
-def s1ZQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState) : ℚ :=
-  ∑ u, s1WeightQ qud pC bs w u
-
-/-- Normalized speaker value, with the degenerate-cell fallback matching the
-PMF face (`pure .cPos` where no utterance carries weight). -/
-def s1ValQ (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState)
-    (u : Utterance) : ℚ :=
-  if s1ZQ qud pC bs w = 0 then (if u = .cPos then 1 else 0)
-  else s1WeightQ qud pC bs w u / s1ZQ qud pC bs w
+/-- Speaker (eq. 6 at α = 10, zero cost): `RSA.Score.s1` over the
+QUD-aggregated literal listener; degenerate cells fall back to `cPos` —
+one declaration covering both faces. -/
+def s1Post (qud : QUD) (pC : ℚ≥0) (bs : BeliefState) :
+    WorldState → Utterance → ℚ≥0 :=
+  RSA.Score.s1 (fun u w => qAgg qud pC bs u w) 10 (fun _ => 1) (.pure .cPos)
 
 /-- Listener world score (eq. 7; uniform assumption prior). -/
-def worldScoreQ (qud : QUD) (pC : ℚ) (u : Utterance) (w : WorldState) : ℚ :=
-  worldPriorQ pC w * ∑ bs, s1ValQ qud pC bs w u
+def worldScore (qud : QUD) (pC : ℚ≥0) (u : Utterance) (w : WorldState) : ℚ≥0 :=
+  worldPrior pC w * ∑ bs, s1Post qud pC bs w u
 
-/-- C-event mass and total of the listener scores. -/
-def cEventQ (qud : QUD) (pC : ℚ) (u : Utterance) : ℚ :=
-  ∑ w, (if w.c then worldScoreQ qud pC u w else 0)
-
-def wTotalQ (qud : QUD) (pC : ℚ) (u : Utterance) : ℚ :=
-  ∑ w, worldScoreQ qud pC u w
-
-end QModel
-
-section QModel
-
-theorem worldPriorQ_nonneg' {pC : ℚ} (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (w : WorldState) :
-    0 ≤ worldPriorQ pC w := worldPriorQ_nonneg pC h0 h1 w
-
-variable {pC : ℚ}
-
-theorem l0MassQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (bs : BeliefState) (u : Utterance) :
-    0 ≤ l0MassQ pC bs u :=
-  Finset.sum_nonneg fun w _ => by
-    split
-    · exact worldPriorQ_nonneg pC h0 h1 w
-    · exact le_refl 0
-
-theorem l0Q_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (bs : BeliefState) (u : Utterance)
-    (w : WorldState) : 0 ≤ l0Q pC bs u w :=
-  div_nonneg (by
-    split
-    · exact worldPriorQ_nonneg pC h0 h1 w
-    · exact le_refl 0) (l0MassQ_nonneg h0 h1 bs u)
-
-theorem qAggQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
-    (u : Utterance) (w : WorldState) : 0 ≤ qAggQ qud pC bs u w := by
-  cases w <;> cases qud <;>
-    exact add_nonneg (l0Q_nonneg h0 h1 bs u _) (l0Q_nonneg h0 h1 bs u _)
-
-theorem s1WeightQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
-    (w : WorldState) (u : Utterance) : 0 ≤ s1WeightQ qud pC bs w u :=
-  pow_nonneg (qAggQ_nonneg h0 h1 qud bs u w) 10
-
-theorem s1ZQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
-    (w : WorldState) : 0 ≤ s1ZQ qud pC bs w :=
-  Finset.sum_nonneg fun u _ => s1WeightQ_nonneg h0 h1 qud bs w u
-
-theorem s1ValQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
-    (w : WorldState) (u : Utterance) : 0 ≤ s1ValQ qud pC bs w u := by
-  unfold s1ValQ
-  split
-  · split <;> norm_num
-  · exact div_nonneg (s1WeightQ_nonneg h0 h1 qud bs w u) (s1ZQ_nonneg h0 h1 qud bs w)
-
-theorem worldScoreQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance)
-    (w : WorldState) : 0 ≤ worldScoreQ qud pC u w :=
-  mul_nonneg (worldPriorQ_nonneg pC h0 h1 w)
-    (Finset.sum_nonneg fun bs _ => s1ValQ_nonneg h0 h1 qud bs w u)
-
-theorem wTotalQ_nonneg (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance) :
-    0 ≤ wTotalQ qud pC u :=
-  Finset.sum_nonneg fun w _ => worldScoreQ_nonneg h0 h1 qud u w
-
-end QModel
-
-section PMFFace
-
-open scoped ENNReal
-
-private theorem sumUtts (f : Utterance → ℝ≥0∞) :
-    ∑' u, f u = f .knowPos + f .knowNeg + f .thinkPos + f .thinkNeg +
-      f .cPos + f .cNeg := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset Utterance)
-      = {.knowPos, .knowNeg, .thinkPos, .thinkNeg, .cPos, .cNeg} from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-  ring
-
-private theorem sumBS (f : BeliefState → ℝ≥0∞) :
-    ∑' bs, f bs = f .onlyW11 + f .onlyW10 + f .onlyW01 + f .onlyW00 +
-      f .belTrue + f .belFalse + f .cTrue + f .cFalse +
-      f .diagonal + f .antiDiagonal +
-      f .notW11 + f .notW10 + f .notW01 + f .notW00 + f .all := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset BeliefState)
-      = {.onlyW11, .onlyW10, .onlyW01, .onlyW00, .belTrue, .belFalse, .cTrue,
-         .cFalse, .diagonal, .antiDiagonal, .notW11, .notW10, .notW01,
-         .notW00, .all} from rfl]
-  repeat rw [Finset.sum_insert (by decide)]
-  rw [Finset.sum_singleton]
-  ring
-
-private theorem sumWs (f : WorldState → ℝ≥0∞) :
-    ∑' w, f w = f .w11 + f .w10 + f .w01 + f .w00 := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset WorldState) = {.w11, .w10, .w01, .w00} from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-  ring
-
-variable {pC : ℚ}
-
-/-- PMF speaker (eq. 6 at α = 10, zero cost), dite-total. -/
-noncomputable def s1PMF (qud : QUD) (pC : ℚ) (bs : BeliefState) (w : WorldState) :
-    PMF Utterance :=
-  if h : (∑' u, ENNReal.ofReal ((s1WeightQ qud pC bs w u : ℝ))) ≠ 0 then
-    PMF.normalize (fun u => ENNReal.ofReal ((s1WeightQ qud pC bs w u : ℝ))) h
-      (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
-  else PMF.pure .cPos
-
-private theorem sumW_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
-    (w : WorldState) :
-    (∑' u, ENNReal.ofReal ((s1WeightQ qud pC bs w u : ℝ)))
-      = ENNReal.ofReal ((s1ZQ qud pC bs w : ℝ)) := by
-  rw [tsum_fintype, ← ENNReal.ofReal_sum_of_nonneg
-    (fun u _ => by exact_mod_cast s1WeightQ_nonneg h0 h1 qud bs w u)]
-  congr 1
-  push_cast [s1ZQ]
-  rfl
-
-theorem s1PMF_apply (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (bs : BeliefState)
-    (w : WorldState) (u : Utterance) :
-    s1PMF qud pC bs w u = ENNReal.ofReal ((s1ValQ qud pC bs w u : ℝ)) := by
-  unfold s1PMF
-  by_cases hZ : (0 : ℚ) < s1ZQ qud pC bs w
-  · rw [dif_pos (by rw [sumW_eq h0 h1, ENNReal.ofReal_ne_zero_iff]; exact_mod_cast hZ),
-      PMF.normalize_apply, sumW_eq h0 h1,
-      ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hZ),
-      ← ENNReal.ofReal_mul (by exact_mod_cast s1WeightQ_nonneg h0 h1 qud bs w u),
-      show s1ValQ qud pC bs w u = s1WeightQ qud pC bs w u / s1ZQ qud pC bs w from by
-        rw [s1ValQ, if_neg hZ.ne']]
-    congr 1
-    push_cast
-    rw [div_eq_mul_inv]
-  · have hZ0 : s1ZQ qud pC bs w = 0 :=
-      le_antisymm (not_lt.mp hZ) (s1ZQ_nonneg h0 h1 qud bs w)
-    rw [dif_neg (by rw [sumW_eq h0 h1, hZ0]; simp),
-      show s1ValQ qud pC bs w u = (if u = .cPos then 1 else 0) from by
-        rw [s1ValQ, if_pos hZ0]]
-    by_cases hu : u = .cPos <;> simp [PMF.pure_apply, hu]
-
-/-- Listener world score (eq. 7; uniform assumption prior factors out). -/
-noncomputable def wScore (qud : QUD) (pC : ℚ) (u : Utterance) (w : WorldState) :
-    ℝ≥0∞ :=
-  ENNReal.ofReal ((worldPriorQ pC w : ℝ)) * ∑' bs, s1PMF qud pC bs w u
-
-theorem wScore_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance)
-    (w : WorldState) :
-    wScore qud pC u w = ENNReal.ofReal ((worldScoreQ qud pC u w : ℝ)) := by
-  unfold wScore
-  rw [tsum_fintype,
-    Finset.sum_congr rfl (fun bs _ => s1PMF_apply h0 h1 qud bs w u),
-    ← ENNReal.ofReal_sum_of_nonneg (fun bs _ => by
-      exact_mod_cast s1ValQ_nonneg h0 h1 qud bs w u),
-    ← ENNReal.ofReal_mul (by exact_mod_cast worldPriorQ_nonneg pC h0 h1 w)]
-  congr 1
-  push_cast [worldScoreQ]
-  rfl
-
-private theorem sumScore_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD) (u : Utterance) :
-    (∑' w, wScore qud pC u w) = ENNReal.ofReal ((wTotalQ qud pC u : ℝ)) := by
-  rw [tsum_fintype, Finset.sum_congr rfl (fun w _ => wScore_eq h0 h1 qud u w),
-    ← ENNReal.ofReal_sum_of_nonneg (fun w _ => by
-      exact_mod_cast worldScoreQ_nonneg h0 h1 qud u w)]
-  congr 1
-  push_cast [wTotalQ]
-  rfl
-
-/-- Pragmatic listener over worlds (eq. 7), dite-total. -/
-noncomputable def l1World (qud : QUD) (pC : ℚ) (u : Utterance) : PMF WorldState :=
-  if h : (∑' w, wScore qud pC u w) ≠ 0 then
-    PMF.normalize (wScore qud pC u) h
-      (ENNReal.tsum_ne_top_of_fintype fun _ =>
-        ENNReal.mul_ne_top ENNReal.ofReal_ne_top
-          (ENNReal.tsum_ne_top_of_fintype fun _ => PMF.apply_ne_top _ _))
-  else PMF.uniformOfFintype WorldState
-
-private theorem l1World_apply (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD)
-    (u : Utterance) (hpos : (∑' w, wScore qud pC u w) ≠ 0)
-    (w : WorldState) :
-    l1World qud pC u w
-      = ENNReal.ofReal ((worldScoreQ qud pC u w : ℝ)) *
-        (∑' w', wScore qud pC u w')⁻¹ := by
-  unfold l1World
-  rw [dif_pos hpos, PMF.normalize_apply, wScore_eq h0 h1 qud u w]
+/-- Pragmatic listener over worlds (eq. 7). -/
+noncomputable def l1World (qud : QUD) (pC : ℚ≥0) (u : Utterance) :
+    PMF WorldState :=
+  .ofScores .uniform (worldScore qud pC u)
 
 /-- The listener's C-marginal. -/
-noncomputable def l1CEvent (qud : QUD) (pC : ℚ) (u : Utterance) : ℝ≥0∞ :=
+noncomputable def l1CEvent (qud : QUD) (pC : ℚ≥0) (u : Utterance) : ℝ≥0∞ :=
   ∑' w, if w.c then l1World qud pC u w else 0
-
-private theorem cEventQ_expand (qud : QUD) (u : Utterance) :
-    cEventQ qud pC u = worldScoreQ qud pC u .w11 + worldScoreQ qud pC u .w01 := by
-  rw [cEventQ, show (Finset.univ : Finset WorldState) = {.w11, .w10, .w01, .w00}
-      from rfl]
-  repeat rw [Finset.sum_insert (by decide)]
-  rw [Finset.sum_singleton]
-  simp +decide
-
-private theorem l1CEvent_eq (h0 : 0 ≤ pC) (h1 : pC ≤ 1) (qud : QUD)
-    (u : Utterance) (hpos : (∑' w, wScore qud pC u w) ≠ 0) :
-    l1CEvent qud pC u
-      = ENNReal.ofReal ((cEventQ qud pC u : ℝ)) *
-        (ENNReal.ofReal ((wTotalQ qud pC u : ℝ)))⁻¹ := by
-  unfold l1CEvent
-  rw [sumWs]
-  simp +decide only [if_true, if_false, add_zero]
-  simp only [l1World_apply h0 h1 qud u hpos]
-  rw [← add_mul, ← ENNReal.ofReal_add
-      (by exact_mod_cast worldScoreQ_nonneg h0 h1 qud u _)
-      (by exact_mod_cast worldScoreQ_nonneg h0 h1 qud u _),
-    sumScore_eq h0 h1 qud u, cEventQ_expand]
-  congr 2
-  push_cast
-  rfl
-
-/-- Division form for the marginal identities. -/
-private theorem ofReal_mul_inv_eq {b c : ℝ} (hb : 0 < b) (hc : 0 ≤ c) :
-    ENNReal.ofReal (c * b) * (ENNReal.ofReal b)⁻¹ = ENNReal.ofReal c := by
-  rw [ENNReal.ofReal_mul hc, mul_assoc,
-    ENNReal.mul_inv_cancel (by rw [ENNReal.ofReal_ne_zero_iff]; exact hb)
-      ENNReal.ofReal_ne_top, mul_one]
-
-/-- Cross-normaliser comparison for the strict predictions. -/
-private theorem ofReal_div_lt {a b c d : ℝ} (hb : 0 < b) (hd : 0 < d)
-    (hc : 0 < c) (h : a * d < c * b) :
-    ENNReal.ofReal a * (ENNReal.ofReal b)⁻¹ <
-      ENNReal.ofReal c * (ENNReal.ofReal d)⁻¹ := by
-  rw [← div_eq_mul_inv, ← div_eq_mul_inv, ← ENNReal.ofReal_div_of_pos hb,
-    ← ENNReal.ofReal_div_of_pos hd]
-  exact (ENNReal.ofReal_lt_ofReal_iff (div_pos hc hd)).mpr
-    ((div_lt_div_iff₀ hb hd).mpr h)
-
-end PMFFace
-
-section KernelFacts
-
-/-! The model's arithmetic content, kernel-verified over the exact-ℚ scores. -/
-
-private theorem belHigh_pos : ∀ u, (0:ℚ) < wTotalQ .bel (2/3) u := by decide +kernel
-
-private theorem belLow_pos : ∀ u, (0:ℚ) < wTotalQ .bel (1/3) u := by decide +kernel
-
-private theorem cHigh_pos : ∀ u, (0:ℚ) < wTotalQ .c (2/3) u := by decide +kernel
-
-private theorem cLow_pos : ∀ u, (0:ℚ) < wTotalQ .c (1/3) u := by decide +kernel
-
-private theorem belHigh_id :
-    ∀ u, cEventQ .bel (2/3) u = 2/3 * wTotalQ .bel (2/3) u := by decide +kernel
-
-private theorem belLow_id :
-    ∀ u, cEventQ .bel (1/3) u = 1/3 * wTotalQ .bel (1/3) u := by decide +kernel
-
-private theorem cHigh_thinkNeg_pos : (0:ℚ) < cEventQ .c (2/3) .thinkNeg := by
-  decide +kernel
-
-private theorem cHigh_knowNeg_pos : (0:ℚ) < cEventQ .c (2/3) .knowNeg := by
-  decide +kernel
-
-private theorem belHigh_knowNeg_pos : (0:ℚ) < cEventQ .bel (2/3) .knowNeg := by
-  decide +kernel
-
-private theorem cqud_cross :
-    cEventQ .c (2/3) .knowNeg * wTotalQ .c (2/3) .thinkNeg <
-    cEventQ .c (2/3) .thinkNeg * wTotalQ .c (2/3) .knowNeg := by decide +kernel
-
-private theorem prior_cross :
-    cEventQ .c (1/3) .knowNeg * wTotalQ .c (2/3) .knowNeg <
-    cEventQ .c (2/3) .knowNeg * wTotalQ .c (1/3) .knowNeg := by decide +kernel
-
-private theorem qud_cross :
-    cEventQ .c (2/3) .knowNeg * wTotalQ .bel (2/3) .knowNeg <
-    cEventQ .bel (2/3) .knowNeg * wTotalQ .c (2/3) .knowNeg := by decide +kernel
-
-end KernelFacts
-
-section PMFFace
-
-open scoped ENNReal
-
-private theorem wZpos_belHigh (u : Utterance) :
-    (∑' w, wScore .bel (2/3) u w) ≠ 0 := by
-  rw [sumScore_eq (by norm_num) (by norm_num) .bel u, ENNReal.ofReal_ne_zero_iff]
-  exact_mod_cast belHigh_pos u
-
-private theorem wZpos_belLow (u : Utterance) :
-    (∑' w, wScore .bel (1/3) u w) ≠ 0 := by
-  rw [sumScore_eq (by norm_num) (by norm_num) .bel u, ENNReal.ofReal_ne_zero_iff]
-  exact_mod_cast belLow_pos u
-
-private theorem wZpos_cHigh (u : Utterance) :
-    (∑' w, wScore .c (2/3) u w) ≠ 0 := by
-  rw [sumScore_eq (by norm_num) (by norm_num) .c u, ENNReal.ofReal_ne_zero_iff]
-  exact_mod_cast cHigh_pos u
-
-private theorem wZpos_cLow (u : Utterance) :
-    (∑' w, wScore .c (1/3) u w) ≠ 0 := by
-  rw [sumScore_eq (by norm_num) (by norm_num) .c u, ENNReal.ofReal_ne_zero_iff]
-  exact_mod_cast cLow_pos u
-
-end PMFFace
 
 /-! ### Listener predictions -/
 
-open scoped ENNReal in
+/-- The C-marginals on the ℚ≥0 face. -/
+private def cMass (qud : QUD) (pC : ℚ≥0) (u : Utterance) : ℚ≥0 :=
+  PMF.eventMass (PMF.scoresWith .uniform (worldScore qud pC u)) (·.c)
+
+private theorem l1CEvent_eq (qud : QUD) (pC : ℚ≥0) (u : Utterance)
+    {q : ℚ≥0} (h : cMass qud pC u = q) :
+    l1CEvent qud pC u = ((q : ℝ≥0) : ℝ≥0∞) :=
+  PMF.ofScores_event_eq_ratCast _ _ _ h
+
+private theorem l1CEvent_lt (q₁ q₂ : QUD) (p₁ p₂ : ℚ≥0) (u₁ u₂ : Utterance)
+    (h : cMass q₁ p₁ u₁ < cMass q₂ p₂ u₂) :
+    l1CEvent q₁ p₁ u₁ < l1CEvent q₂ p₂ u₂ :=
+  PMF.ofScores_event_lt_cross _ _ _ _ h
+
 /-- Under the BEL? QUD the C-marginal equals the prior, for every utterance:
 S1 depends on the world only through its BEL-cell, so the C-dimension washes
 out of the world posterior. Projection is invisible at the world marginal. -/
 theorem bel_qud_marginal_eq_prior_high (u : Utterance) :
-    l1CEvent .bel (2/3) u = ENNReal.ofReal (2/3) := by
-  rw [l1CEvent_eq (by norm_num) (by norm_num) .bel u (wZpos_belHigh u),
-    show ((cEventQ .bel (2/3) u : ℝ)) = 2/3 * ((wTotalQ .bel (2/3) u : ℝ)) from by
-      rw [belHigh_id u]; push_cast; ring]
-  exact ofReal_mul_inv_eq (by exact_mod_cast belHigh_pos u) (by norm_num)
+    l1CEvent .bel (2/3) u = (((2/3 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
+  l1CEvent_eq _ _ _ ((by revert u; decide +kernel :
+    ∀ u, cMass .bel (2/3) u = 2/3) u)
 
-open scoped ENNReal in
 /-- The low-prior analogue of `bel_qud_marginal_eq_prior_high`. -/
 theorem bel_qud_marginal_eq_prior_low (u : Utterance) :
-    l1CEvent .bel (1/3) u = ENNReal.ofReal (1/3) := by
-  rw [l1CEvent_eq (by norm_num) (by norm_num) .bel u (wZpos_belLow u),
-    show ((cEventQ .bel (1/3) u : ℝ)) = 1/3 * ((wTotalQ .bel (1/3) u : ℝ)) from by
-      rw [belLow_id u]; push_cast; ring]
-  exact ofReal_mul_inv_eq (by exact_mod_cast belLow_pos u) (by norm_num)
+    l1CEvent .bel (1/3) u = (((1/3 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
+  l1CEvent_eq _ _ _ ((by revert u; decide +kernel :
+    ∀ u, cMass .bel (1/3) u = 1/3) u)
 
-open scoped ENNReal in
 /-- Under the C? QUD, knowNeg is evidence against C — ¬(BEL∧C) is compatible
 with C-false worlds — so thinkNeg preserves P(C) better. -/
 theorem c_qud_thinkNeg_higher :
-    l1CEvent .c (2/3) .thinkNeg > l1CEvent .c (2/3) .knowNeg := by
-  rw [gt_iff_lt, l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _),
-    l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _)]
-  exact ofReal_div_lt (by exact_mod_cast cHigh_pos .knowNeg)
-    (by exact_mod_cast cHigh_pos .thinkNeg)
-    (by exact_mod_cast cHigh_thinkNeg_pos)
-    (by exact_mod_cast cqud_cross)
+    l1CEvent .c (2/3) .knowNeg < l1CEvent .c (2/3) .thinkNeg :=
+  l1CEvent_lt _ _ _ _ _ _ (by decide +kernel)
 
 /-! ### Prediction 2a: utterance effect (know > think)
 
@@ -568,29 +267,15 @@ does not — under BEL? both marginals sit at the prior, and under C? the
 direction reverses (`c_qud_thinkNeg_higher`). Fn. 11's A-marginal measure
 (P(A ⊧ C | u)) may capture the effect without cost; see the module TODO. -/
 
-open scoped ENNReal in
 /-- Prediction 2b (prior effect): higher prior increases projection. -/
-theorem prediction_2b :
-    l1CEvent .c (2/3) .knowNeg > l1CEvent .c (1/3) .knowNeg := by
-  rw [gt_iff_lt, l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cLow _),
-    l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _)]
-  exact ofReal_div_lt (by exact_mod_cast cLow_pos .knowNeg)
-    (by exact_mod_cast cHigh_pos .knowNeg)
-    (by exact_mod_cast cHigh_knowNeg_pos)
-    (by exact_mod_cast prior_cross)
+theorem prediction_2b : l1CEvent .c (1/3) .knowNeg < l1CEvent .c (2/3) .knowNeg :=
+  l1CEvent_lt _ _ _ _ _ _ (by decide +kernel)
 
-open scoped ENNReal in
 /-- Prediction 2c (QUD effect): under BEL? the C-marginal stays at the prior
 (`bel_qud_marginal_eq_prior_high`), while under C? the literal semantics of
 "doesn't know C" lowers it. -/
-theorem prediction_2c :
-    l1CEvent .bel (2/3) .knowNeg > l1CEvent .c (2/3) .knowNeg := by
-  rw [gt_iff_lt, l1CEvent_eq (by norm_num) (by norm_num) .c _ (wZpos_cHigh _),
-    l1CEvent_eq (by norm_num) (by norm_num) .bel _ (wZpos_belHigh _)]
-  exact ofReal_div_lt (by exact_mod_cast cHigh_pos .knowNeg)
-    (by exact_mod_cast belHigh_pos .knowNeg)
-    (by exact_mod_cast belHigh_knowNeg_pos)
-    (by exact_mod_cast qud_cross)
+theorem prediction_2c : l1CEvent .c (2/3) .knowNeg < l1CEvent .bel (2/3) .knowNeg :=
+  l1CEvent_lt _ _ _ _ _ _ (by decide +kernel)
 
 /-! ### Structural properties -/
 


### PR DESCRIPTION
Polish-pattern pass on the two joint-latent projection models (the structural twins per QGL fn. 10): both chains retype to ℚ≥0 with RSA.Score.s1 and a Fallback.pure declaration shared by both faces, deleting the dite PMFs, the prior-bound hypothesis threading, the u ≠ silence side conditions, and both PMFFace bridge sections; predictions close by the ofScores comparison family (Scores.lean gains the event cross/ratCast variants). QGL literalMeaning rows now derive from a new ChangeOfState.CoSType.eval Bool face instead of bridge theorems, and conjunct-wall structural theorems became extension characterizations. QGL 682 → 347, ST 896 → 581.