### PR TITLE
docs(references): zimmermann-2017 entry; rolle-2018 DOI

### DIFF
--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -21,8 +21,9 @@ associate to one backbone position (forming contours); a tier element
 with no associations is **floating**. Generic over both backbone type
 `S` (the lower tier) and tier-value type `T` (the upper tier); tonal use
 instantiates `T := TRN`, while non-tonal autosegmental work
-([laoide-kemp-2026]'s floating consonants, [lieber-1983]'s
-floating features) chooses other `T` values.
+([laoide-kemp-2026]'s floating consonants, [lieber-1983]'s floating
+features, [zimmermann-2017]'s floating moras and prosodic nodes)
+chooses other `T` values.
 
 ## Main definitions
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23976,6 +23976,21 @@
   sources   = {Studies/Lionnet2022Laal.lean}
 }
 
+@book{zimmermann-2017,
+  author    = {Zimmermann, Eva},
+  year      = {2017},
+  title     = {Morphological Length and Prosodically Defective Morphemes},
+  series    = {Oxford Studies in Phonology and Phonetics},
+  volume    = {1},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  isbn      = {978-0-19-874732-1},
+  subfield  = {phonology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Phonology/Autosegmental/Floating.lean}
+}
+
 @incollection{mccarthy-mullin-smith-2012,
   author    = {McCarthy, John J. and Mullin, Kevin and Smith, Brian W.},
   year      = {2012},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -24242,6 +24242,8 @@
   year      = {2018},
   title     = {Grammatical tone: Typology and theory},
   school    = {University of California, Berkeley},
+  doi       = {10.5070/BF211040767},
+  url       = {https://escholarship.org/uc/item/9v01c4vr},
   subfield  = {phonology},
   role      = {formalized},
   sources   = {Phonology/Autosegmental/GrammaticalTone.lean;Phonology/Autosegmental/BasemapCorrespondence.lean;Phonology/Autosegmental/CoPScope.lean;Phonology/CophonologyTheory.lean}


### PR DESCRIPTION
Two verified reference improvements orphaned by the #1170 merge race: the rolle-2018 DOI/eScholarship URL (from the dissertation cover), and a new zimmermann-2017 entry (OUP, Oxford Studies in Phonology and Phonetics 1, ISBN from copyright page) cited from `Floating.lean`'s generality note.