### PR TITLE
feat(Phonology/Autosegmental): melody API; derive Poko inputs

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1329,6 +1329,7 @@ import Linglib.Phonology.Autosegmental.Floating
 import Linglib.Phonology.Autosegmental.Hull
 import Linglib.Phonology.Autosegmental.Inclusion
 import Linglib.Phonology.Autosegmental.Junction
+import Linglib.Phonology.Autosegmental.Melody
 import Linglib.Phonology.Autosegmental.MultiAR
 import Linglib.Phonology.Autosegmental.MultiGraph
 import Linglib.Phonology.Autosegmental.NonCrossing

--- a/Linglib/Fragments/Poko/Tone.lean
+++ b/Linglib/Fragments/Poko/Tone.lean
@@ -1,5 +1,6 @@
 import Linglib.Phonology.Tone.Basic
-import Linglib.Phonology.Autosegmental.Floating
+import Linglib.Phonology.Tone.Grammatical
+import Linglib.Phonology.Autosegmental.Melody
 
 /-!
 # Poko Tonal Fragment
@@ -21,10 +22,9 @@ a fuller fragment when a second Poko paper arrives.
 ## Main definitions
 
 * `Poko.Syll` — the stems, one morpheme each (`Syll.morpheme`).
-* `Poko.Syll.melody` — lexical melody as ordered tier elements.
-* `Poko.seg`, `Poko.mTone`, `Poko.hTone`, `Poko.lTone` — `SegSpec` /
-  `TierSpec` builders carrying the morpheme membership that feeds
-  `*TAUTDOCK` and `*CROWD`.
+* `Poko.Syll.melody` — each stem's lexical melody: tones, TBU, and
+  pre-linking ([rolle-2018] §2.1; the floating H of `/M^H/` stems is
+  the unlinked element).
 * `Poko.Form` — autosegmental forms (`FloatingForm Syll TRN`).
 -/
 
@@ -58,7 +58,7 @@ inductive Syll
   | ne
   deriving DecidableEq, Repr
 
-/-! ### Morphemes -/
+/-! ### Morphemes and melodies -/
 
 /-- Stable morpheme per stem, keyed by the syllable's surface form. -/
 def Syll.morpheme : Syll → Morpheme
@@ -71,38 +71,24 @@ def Syll.morpheme : Syll → Morpheme
   | .ili => { form := "ili" }
   | .ne  => { form := "ne" }
 
-/-! ### Builders -/
+/-- Each stem's lexical melody ([mcpherson-lamont-2026] ex. 3): tones
+    over the stem's single TBU, with the lexical pre-linking — the H of
+    an `/M^H/` stem is the sole unlinked (floating) element. -/
+def Syll.melody (s : Syll) : Graph (TierSpec TRN) (SegSpec Syll) :=
+  match s with
+  | .kak => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
+  | .ri  => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
+  | .do  => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
+  | .nan => .melody s.morpheme [.M] [s] {(0, 0)}              -- /M/
+  | .na  => .melody s.morpheme [.M] [s] {(0, 0)}              -- /M/
+  | .ka  => .melody s.morpheme [.M, .H] [s] {(0, 0), (1, 0)}  -- /MH/, both linked
+  | .ili => .melody s.morpheme [.L, .H] [s] {(0, 0), (1, 0)}  -- /LH/, both linked
+  | .ne  => .melody s.morpheme [] [s] ∅                       -- toneless
 
-/-- Wrap a syllable as a `SegSpec` carrying its morpheme. -/
-def seg (s : Syll) : SegSpec Syll :=
-  { seg := s, morpheme := s.morpheme }
-
-/-- An M tone belonging to the morpheme of syllable `s`. -/
-def mTone (s : Syll) : TierSpec TRN :=
-  { value := TRN.M, morpheme := s.morpheme }
-
-/-- An H tone belonging to the morpheme of syllable `s`. -/
-def hTone (s : Syll) : TierSpec TRN :=
-  { value := TRN.H, morpheme := s.morpheme }
-
-/-- An L tone belonging to the morpheme of syllable `s`. -/
-def lTone (s : Syll) : TierSpec TRN :=
-  { value := TRN.L, morpheme := s.morpheme }
-
-/-! ### Melodies and forms -/
-
-/-- Lexical melody of each stem, in tier order (linked tones before a
-    floating H). Which tones are underlyingly linked is per-input data
-    — the `links` argument of `FloatingForm.mkInput`. -/
-def Syll.melody : Syll → List (TierSpec TRN)
-  | .kak => [mTone .kak, hTone .kak]  -- /M^H/
-  | .ri  => [mTone .ri, hTone .ri]    -- /M^H/
-  | .do  => [mTone .do, hTone .do]    -- /M^H/
-  | .nan => [mTone .nan]              -- /M/
-  | .na  => [mTone .na]               -- /M/
-  | .ka  => [mTone .ka, hTone .ka]    -- /MH/, both linked
-  | .ili => [lTone .ili, hTone .ili]  -- /LH/, both linked
-  | .ne  => []                        -- toneless
+/-- The underlying form of a stem sequence: melodies concatenated
+    left-to-right. -/
+def word (ss : List Syll) : Graph (TierSpec TRN) (SegSpec Syll) :=
+  .concatList (ss.map Syll.melody)
 
 /-- Poko autosegmental forms: syllable backbone, `TRN` tone tier. -/
 abbrev Form := FloatingForm Syll TRN

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -23,7 +23,10 @@ substrate already provides.
 
 A word's underlying form is the left-to-right `Graph.concat` fold of its
 melodies ([jardine-heinz-2015] §5), and `FloatingForm.ofGraph` packages
-it as a derivation input.
+it as a derivation input. This melody-concatenation view of
+non-concatenative exponence is [bye-svenonius-2012]'s Generalized
+Nonlinear Affixation (survey: [zimmermann-2024]); GEN's compliance with
+Consistency of Exponence is `FloatingForm.gen_preserves_morphemes`.
 
 ## Main definitions
 
@@ -97,5 +100,16 @@ def FloatingForm.ofGraph (g : Graph (TierSpec T) (SegSpec S)) : FloatingForm S T
 theorem FloatingForm.mkInput_eq_ofGraph (lower : List (SegSpec S))
     (upper : List (TierSpec T)) (links : Finset Link) :
     mkInput lower upper links = ofGraph ⟨.ofList upper, .ofList lower, links⟩ := rfl
+
+/-- **Consistency of Exponence** ([zimmermann-2024] §4): GEN never alters
+    morphemic affiliation — every one-step candidate carries its input's
+    sponsors on both tiers. -/
+theorem FloatingForm.gen_preserves_morphemes [DecidableEq S] [DecidableEq T]
+    (f : FloatingForm S T) : ∀ g ∈ f.gen,
+    g.upperMorpheme? = f.upperMorpheme? ∧ g.lowerMorpheme? = f.lowerMorpheme? := by
+  intro g hg
+  simp only [FloatingForm.gen, Finset.mem_insert, Finset.mem_union, Finset.mem_image,
+    Finset.mem_filter, Finset.mem_product] at hg
+  rcases hg with rfl | ⟨k, _, rfl⟩ | ⟨⟨k, i⟩, _, rfl⟩ <;> exact ⟨rfl, rfl⟩
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -24,9 +24,12 @@ substrate already provides.
 A word's underlying form is the left-to-right `Graph.concat` fold of its
 melodies ([jardine-heinz-2015] §5), and `FloatingForm.ofGraph` packages
 it as a derivation input. This melody-concatenation view of
-non-concatenative exponence is [bye-svenonius-2012]'s Generalized
-Nonlinear Affixation (survey: [zimmermann-2024]); GEN's compliance with
-Consistency of Exponence is `FloatingForm.gen_preserves_morphemes`.
+non-concatenative exponence is the Generalized Nonlinear Affixation
+program — [bermudez-otero-2012]'s term; [bye-svenonius-2012] give the
+programmatic statement (non-concatenative morphology as epiphenomenon
+of deficient lexical entries); [zimmermann-2024] surveys. GEN's
+compliance with Consistency of Exponence is
+`FloatingForm.gen_preserves_morphemes`.
 
 ## Main definitions
 

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Autosegmental.Floating
+
+/-!
+# Lexical melodies: per-morpheme autosegmental contributions
+
+A **melody** is one morpheme's underlying autosegmental contribution
+([rolle-2018] §2.1 Def 1): tier elements and backbone slots, every one
+sponsored by the same morpheme ([rolle-2018] §2.1.4; [wolf-2007]), plus
+the lexical pre-linking ([pulleyblank-1986]) in melody-local coordinates.
+Which elements are pre-linked is per-analysis data — a melody with no
+links is [mccarthy-mullin-smith-2012]'s universally-unlinked underlying
+form, while a partially linked one is [mcpherson-lamont-2026]'s stratal
+`/M^H/`. In [rolle-2018] Table 1's vocabulary, a backbone slot `j` is
+*valued* iff `Graph.IsLinkedLower j`, *unvalued* iff
+`Graph.IsFloatingLower j`, and a tier element is *floating* iff
+`Graph.IsFloatingUpper i` — the per-index predicates the `Graph`
+substrate already provides.
+
+A word's underlying form is the left-to-right `Graph.concat` fold of its
+melodies ([jardine-heinz-2015] §5), and `FloatingForm.ofGraph` packages
+it as a derivation input.
+
+## Main definitions
+
+* `Graph.melody` — one morpheme's tones, slots, and pre-links.
+* `Graph.concatList` — the word: melodies folded by `Graph.concat`.
+* `FloatingForm.ofGraph` — an underlying graph as a derivation input
+  (surface mirrors underlying).
+-/
+
+namespace Autosegmental
+
+variable {S T : Type*}
+
+namespace Graph
+
+/-- One morpheme's underlying autosegmental contribution ([rolle-2018]
+    §2.1 Def 1): `tones` over `tbus`, every element sponsored by `m`,
+    pre-linked by `links` in melody-local coordinates. -/
+def melody (m : Morpheme) (tones : List T) (tbus : List S)
+    (links : Finset Link) : Graph (TierSpec T) (SegSpec S) where
+  upper := .ofList (tones.map fun t => { value := t, morpheme := m })
+  lower := .ofList (tbus.map fun s => { seg := s, morpheme := m })
+  links := links
+
+@[simp] theorem melody_upper (m : Morpheme) (tones : List T) (tbus : List S)
+    (links : Finset Link) :
+    (melody m tones tbus links).upper
+      = .ofList (tones.map fun t => { value := t, morpheme := m }) := rfl
+
+@[simp] theorem melody_lower (m : Morpheme) (tones : List T) (tbus : List S)
+    (links : Finset Link) :
+    (melody m tones tbus links).lower
+      = .ofList (tbus.map fun s => { seg := s, morpheme := m }) := rfl
+
+@[simp] theorem melody_links (m : Morpheme) (tones : List T) (tbus : List S)
+    (links : Finset Link) : (melody m tones tbus links).links = links := rfl
+
+/-- Every tier element of a melody is sponsored by its morpheme. -/
+theorem melody_upper_morpheme (m : Morpheme) (tones : List T) (tbus : List S)
+    (links : Finset Link) {k : ℕ} (hk : k < tones.length) :
+    ((melody m tones tbus links).upper.get? k).map TierSpec.morpheme = some m := by
+  rw [melody_upper, LabeledTuple.ofList_get?]
+  simp [hk]
+
+/-- Every backbone slot of a melody is sponsored by its morpheme. -/
+theorem melody_lower_morpheme (m : Morpheme) (tones : List T) (tbus : List S)
+    (links : Finset Link) {j : ℕ} (hj : j < tbus.length) :
+    ((melody m tones tbus links).lower.get? j).map SegSpec.morpheme = some m := by
+  rw [melody_lower, LabeledTuple.ofList_get?]
+  simp [hj]
+
+/-- Left-to-right concatenation of a word's melodies ([jardine-heinz-2015]
+    §5): tier juxtaposition with index-shifted links. -/
+def concatList {α β : Type*} (gs : List (Graph α β)) : Graph α β :=
+  gs.foldr concat empty
+
+@[simp] theorem concatList_nil {α β : Type*} :
+    concatList ([] : List (Graph α β)) = empty := rfl
+
+@[simp] theorem concatList_cons {α β : Type*} (g : Graph α β) (gs : List (Graph α β)) :
+    concatList (g :: gs) = g.concat (concatList gs) := rfl
+
+end Graph
+
+/-- Package an underlying graph as a derivation input: nothing deleted,
+    surface links mirror the underlying links. -/
+def FloatingForm.ofGraph (g : Graph (TierSpec T) (SegSpec S)) : FloatingForm S T :=
+  { g with deletedTier := ∅, surfaceLinks := g.links }
+
+/-- `mkInput` is `ofGraph` of the corresponding raw graph. -/
+theorem FloatingForm.mkInput_eq_ofGraph (lower : List (SegSpec S))
+    (upper : List (TierSpec T)) (links : Finset Link) :
+    mkInput lower upper links = ofGraph ⟨.ofList upper, .ofList lower, links⟩ := rfl
+
+end Autosegmental

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -192,10 +192,7 @@ def lrDerivation (input : Form) : HSDerivation Form where
 namespace Fig3
 
 /-- Fig. 3 input `/kāk^H + rī^H + dō^H/`: each M linked, each H floating. -/
-def fig3Input : Form :=
-  let stems : List Syll := [.kak, .ri, .do]
-  FloatingForm.mkInput (stems.map seg) (stems.flatMap Syll.melody)
-    (links := {(0, 0), (2, 1), (4, 2)})
+def fig3Input : Form := .ofGraph (word [.kak, .ri, .do])
 
 /-- Directional-LR derivation (`*FLOAT^→`). -/
 def derivationLR : HSDerivation Form := lrDerivation fig3Input
@@ -300,10 +297,7 @@ end Fig3
 namespace Eq24
 
 /-- Eq. (24) input `/nãn + rī^H + nã/`; H-rī is the only floating tone. -/
-def eq24Input : Form :=
-  let stems : List Syll := [.nan, .ri, .na]
-  FloatingForm.mkInput (stems.map seg) (stems.flatMap Syll.melody)
-    (links := {(0, 0), (1, 1), (3, 2)})
+def eq24Input : Form := .ofGraph (word [.nan, .ri, .na])
 
 /-- Directional-LR derivation over `stdRanking`. -/
 def derivationLR : HSDerivation Form := lrDerivation eq24Input
@@ -333,10 +327,7 @@ end Eq24
 namespace Eq21
 
 /-- Eq. (21) input `/nãn + rī^H/` (phrase-final): no rightward landing site. -/
-def eq21Input : Form :=
-  let stems : List Syll := [.nan, .ri]
-  FloatingForm.mkInput (stems.map seg) (stems.flatMap Syll.melody)
-    (links := {(0, 0), (1, 1)})
+def eq21Input : Form := .ofGraph (word [.nan, .ri])
 
 /-- Directional-LR derivation; eq. (20)'s `*FLOAT, *TAUTDOCK ≫ MAX(H)` is a sub-ranking. -/
 def derivationLR : HSDerivation Form := lrDerivation eq21Input
@@ -358,10 +349,7 @@ end Eq21
 namespace Eq27
 
 /-- Eq. (27) input `/kāk^H + kǎ/`; kǎ carries a linked MH contour. -/
-def eq27Input : Form :=
-  let stems : List Syll := [.kak, .ka]
-  FloatingForm.mkInput (stems.map seg) (stems.flatMap Syll.melody)
-    (links := {(0, 0), (2, 1), (3, 1)})
+def eq27Input : Form := .ofGraph (word [.kak, .ka])
 
 /-- Directional-LR derivation over `stdRanking`. -/
 def derivationLR : HSDerivation Form := lrDerivation eq27Input
@@ -383,10 +371,7 @@ end Eq27
 namespace Eq30
 
 /-- Eq. (30) input `/kāk^H + ìlí/`; ìlí carries a linked LH contour (L% omitted). -/
-def eq30Input : Form :=
-  let stems : List Syll := [.kak, .ili]
-  FloatingForm.mkInput (stems.map seg) (stems.flatMap Syll.melody)
-    (links := {(0, 0), (2, 1), (3, 1)})
+def eq30Input : Form := .ofGraph (word [.kak, .ili])
 
 /-- Eq. (30) ranking: `stdRanking` plus `*M◁L` above *TAUTDOCK — the inversion that
     licenses tautomorphemic docking (30c). -/
@@ -417,10 +402,7 @@ end Eq30
 namespace Eq22
 
 /-- Eq. (22a) input `/nãn + rī^H + ne/`; ne is toneless. -/
-def eq22Input : Form :=
-  let stems : List Syll := [.nan, .ri, .ne]
-  FloatingForm.mkInput (stems.map seg) (stems.flatMap Syll.melody)
-    (links := {(0, 0), (1, 1)})
+def eq22Input : Form := .ofGraph (word [.nan, .ri, .ne])
 
 /-- Directional-LR derivation over `stdRanking`. -/
 def derivationLR : HSDerivation Form := lrDerivation eq22Input

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23976,6 +23976,31 @@
   sources   = {Studies/Lionnet2022Laal.lean}
 }
 
+@incollection{bye-svenonius-2012,
+  author    = {Bye, Patrik and Svenonius, Peter},
+  year      = {2012},
+  title     = {Non-concatenative morphology as epiphenomenon},
+  booktitle = {The Morphology and Phonology of Exponence},
+  editor    = {Trommer, Jochen},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {phonology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Phonology/Autosegmental/Melody.lean}
+}
+
+@unpublished{zimmermann-2024,
+  author    = {Zimmermann, Eva},
+  year      = {2024},
+  title     = {Morphemes in Phonology},
+  note      = {Draft, October 2024. To appear in Paul de Lacy and Adam Jardine (eds.), The Cambridge Handbook of Phonology, 2nd edn. Cambridge: Cambridge University Press},
+  subfield  = {phonology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Phonology/Autosegmental/Melody.lean}
+}
+
 @incollection{mccarthy-mullin-smith-2012,
   author    = {McCarthy, John J. and Mullin, Kevin and Smith, Brian W.},
   year      = {2012},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23984,6 +23984,7 @@
   editor    = {Trommer, Jochen},
   publisher = {Oxford University Press},
   address   = {Oxford},
+  pages     = {427--495},
   subfield  = {phonology},
   role      = {cited},
   validated = {true},


### PR DESCRIPTION
Adds `Autosegmental/Melody.lean`: `Graph.melody` (one morpheme's tones, TBUs, and lexical pre-linking — [rolle-2018] §2.1 Def 1, [pulleyblank-1986]), `Graph.concatList` (word = left-to-right fold of the existing [jardine-heinz-2015] `Graph.concat` monoid), and `FloatingForm.ofGraph` (underlying graph → derivation input), with sponsor-uniformity lemmas.

First consumer: the Poko fragment now states each stem's melody *including its pre-linking* once (`Syll.melody` + `word`), and all six McPhersonLamont2026 tableau inputs become one-liners (`.ofGraph (word [.kak, .ri, .do])`) — no hand-computed link offsets anywhere. The `seg`/`mTone`/`hTone`/`lTone` builders are subsumed and deleted. All decide witnesses reduce through the concat fold unchanged.