### PR TITLE
refactor(Studies): WD2021 expAtom adoption; QF2015 parametric rebuild

### DIFF
--- a/Linglib/Pragmatics/RSA/Atoms.lean
+++ b/Linglib/Pragmatics/RSA/Atoms.lean
@@ -129,4 +129,29 @@ theorem expAtom_pow_mul_exp_eq_one {m : ℝ} {n : ℕ} (hn : n ≠ 0) :
       field_simp,
     ← Real.exp_add, neg_add_cancel, Real.exp_zero]
 
+/-- Power form of the inversion identity, stated at the atom's own
+exponent (no division shape): `expAtom q ^ n · exp (n·q) = 1`. -/
+theorem expAtom_pow_mul_exp_nat_mul {q : ℝ} (n : ℕ) :
+    expAtom q ^ n * Real.exp (n * q) = 1 := by
+  rw [expAtom, ← Real.exp_nat_mul, ← Real.exp_add, mul_neg, neg_add_cancel,
+    Real.exp_zero]
+
+/-- Lower certificate: `r ^ n · exp (n·q) < 1` gives `r < expAtom q`. -/
+theorem lt_expAtom {q r : ℝ} {n : ℕ} (hn : n ≠ 0) (hr : 0 ≤ r)
+    (h : r ^ n * Real.exp (n * q) < 1) : r < expAtom q := by
+  have hpos := expAtom_pos q
+  have hid := expAtom_pow_mul_exp_nat_mul (q := q) n
+  have he := Real.exp_pos ((n : ℝ) * q)
+  refine lt_of_pow_lt_pow_left₀ n hpos.le ?_
+  nlinarith [pow_nonneg hr n]
+
+/-- Upper certificate: `1 < s ^ n · exp (n·q)` gives `expAtom q < s`. -/
+theorem expAtom_lt {q s : ℝ} {n : ℕ} (hn : n ≠ 0) (hs : 0 ≤ s)
+    (h : 1 < s ^ n * Real.exp (n * q)) : expAtom q < s := by
+  have hpos := expAtom_pos q
+  have hid := expAtom_pow_mul_exp_nat_mul (q := q) n
+  have he := Real.exp_pos ((n : ℝ) * q)
+  refine lt_of_pow_lt_pow_left₀ n hs ?_
+  nlinarith [pow_pos hpos n]
+
 end RSA

--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -1,115 +1,71 @@
-import Linglib.Pragmatics.RSA.Atoms
-import Linglib.Pragmatics.RSA.LatentOperators
-import Linglib.Pragmatics.RSA.Operators
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Analysis.Complex.ExponentialBounds
+import Linglib.Core.Probability.Scores
 import Linglib.Pragmatics.GriceanMaxims
 import Linglib.Studies.DaleReiter1995
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 /-!
 # [qing-franke-2015]
 [frank-goodman-2012] [grice-1975] [dale-reiter-1995]
 
-"Variations on a Bayesian Theme: Comparing Bayesian Models of Referential Reasoning"
+Variations on a Bayesian theme: comparing Bayesian models of referential
+reasoning. In *Bayesian Natural Language Semantics and Pragmatics*, 91–117.
 
-## Paradigm
+One referential game (green square, green circle, blue circle; Fig. 1) and
+a family of models decomposed along three design dimensions: the speaker's
+goal (belief-oriented log-informativity, eq. 10, vs action-oriented raw
+informativity, eq. 9), the speaker's belief about the literal listener
+(uniform vs salience prior), and the listener's own prior (eqs. 12–13).
+Utterance cost is a constant `c` on adjectives (eq. 11), marginalized over
+`(−0.4, 0.4)` in the paper's model comparison.
 
-Three objects varying on two dimensions (color × shape) in a reference game:
-{green_square, green_circle, blue_circle}. Speaker produces a single feature word;
-listener identifies the target object.
+## Main results
 
-Utterances: {square, circle, green, blue}
+The belief-oriented chain is stated parametrically in the **cost factor**
+`k = exp(−c)` (`k < 1` ↔ a noun preference `c > 0`), so each prediction
+carries its exact validity region:
 
-## The Decomposition
+* `speaker_prefers_unique_shape` (k < 2) / `speaker_prefers_unique_color`
+  (k > 1/2, i.e. c < ln 2) / `cost_breaks_symmetry` (k < 1) /
+  `no_cost_symmetry` (k = 1): σ_bU matches all three Table-1 directions on
+  the whole noun-preference regime 1/2 < k < 1
+  (`σ_bU_matches_speaker_data`).
+* `salience_reversal_circle` / `salience_reversal_green`: at **every**
+  k > 0, the uniform-prior listener follows pragmatic narrowing while the
+  salience-prior listener follows salience — the reversals are pure prior
+  effects, needing no cost regime at all.
+* `σ_bS_blue_circ_iff` (k vs 139/169) / `σ_bS_green_circ_iff` (k vs
+  101/169): the salience-belief speaker's predictions flip *inside* the
+  paper's cost support — thresholds, not directions, are that model's
+  content.
+* `σ_aU_blue_circ_threshold` (c < 1/2) vs `σ_bU_blue_circ_threshold`
+  (c < ln 2): the goal dimension shifts the blue-circle boundary; the σ_aU
+  tie at c = 1/2 is the boundary case.
+* `beliefGoal_gt_iff` / `actionGoal_gt_iff`: speaker rankings are
+  λ-independent — the paper's rejection of λ = 1 affects fit, not
+  direction.
+* `speakerData_matches_model` / `listenerData_circle_matches_salience` /
+  `listenerData_green_matches_pragmatic`: Tables 1–2, with "green"
+  following the pragmatic direction against salience (p. 212).
+* `zeroCost_beliefGoal_eq`: at zero cost the belief-oriented score is
+  [frank-goodman-2012]'s scoring rule.
+* `cost_is_q2`: the cost dimension is [grice-1975]'s Q2 sub-maxim, in
+  [dale-reiter-1995]'s No-Brevity reading at strength 0.
 
-The paper decomposes Bayesian reference games along 3 orthogonal dimensions,
-yielding a family of models that includes [frank-goodman-2012] as one instance:
+## Implementation notes
 
-### Speaker Belief (y ∈ {U, S}): What does L0 assume?
-
-- **Uniform (U)**: L0 treats all referents equally:
-  U(t|m) = ⟦m⟧(t) / |⟦m⟧| (Eq. 1)
-- **Salience (S)**: L0 weights by perceptual salience:
-  S(t|m) = S(t) · ⟦m⟧(t) / Σ_t' S(t') · ⟦m⟧(t')
-
-This enters the literal listener as its prior: uniform (`qfPriorU`) or
-salience-weighted (`qfPriorS`), via the prior-in-L0 construction.
-
-### Speaker Goal (x ∈ {a, b}): What does the speaker optimize?
-
-- **Belief-oriented (b)**: maximize log-probability of correct belief
-  σ_b(m|t) ∝ exp(λ_S · (log y(t|m) - Cost(m))) (Eq. 10)
-- **Action-oriented (a)**: maximize probability of correct action
-  σ_a(m|t) ∝ exp(λ_S · (y(t|m) - Cost(m))) (Eq. 9)
-
-This enters via `s1Score`: belief-oriented uses log L0; action-oriented uses raw L0.
-
-### Listener Action: How does the listener choose?
-
-- **Belief-oriented (b)**: standard Bayesian update
-  ρ_b(t|m) ∝ v(t) · σ(m|t) (Eq. 15)
-- **Action-oriented (a)**: softmax over Bayesian posterior
-  ρ_a(t|m) ∝ exp(α_L · ρ_b(t|m)) (Eq. 14)
-
-The belief-oriented listener IS the Bayesian `PMF.posterior`. The
-action-oriented listener is a composable softmax extension.
-
-## Speaker Models (4 variants)
-
-| Model | Goal | Belief | S1 Score |
-|-------|------|--------|----------|
-| σ_bU  | belief | uniform | exp(λ · (log U(t\|m) - C(m))) |
-| σ_aU  | action | uniform | exp(λ · (U(t\|m) - C(m))) |
-| σ_bS  | belief | salience | exp(λ · (log S(t\|m) - C(m))) |
-| σ_aS  | action | salience | exp(λ · (S(t\|m) - C(m))) |
-
-σ_bU is standard RSA with utterance costs.
-
-## Key Findings
-
-**Speaker data** (Table 1, N=144 per target): σ_bU and σ_aU best explain production
-data (Table 3). Salience in the speaker does NOT help. Cost preference exists (c > 0).
-
-**Listener data** (Table 2, N=180 per utterance): Salience-prior models dominate in
-model comparison (Table 4). Best overall: ρ_aS(σ_aU) with informed-correlated
-hyperprior.
-
-**Salience reversal**: Uniform and salience priors make **opposite** L1 predictions
-for ambiguous utterances. For "circle", human data matches the salience direction
-(blue_circle: 117/180 = 65%). For "green", human data matches the pragmatic
-direction (green_circle: 115/180 = 64%), NOT salience.
-
-## Qualitative Findings
-
-| # | Finding | Type | Config |
-|---|---------|------|--------|
-| 1 | `speaker_prefers_unique_shape` | S1: "square" > "green" for green_sq | σ_bU |
-| 2 | `speaker_prefers_unique_color` | S1: "blue" > "circle" for blue_circ | σ_bU |
-| 3 | `cost_breaks_symmetry` | S1: "circle" > "green" for green_circ | σ_bU |
-| 4 | `no_cost_symmetry` | ¬(S1 "circle" > "green" for green_circ) | σ_bU, no cost |
-| 5 | `salience_reversal_circle` | uniform vs salience L1 flip for "circle" | σ_bU |
-| 6 | `salience_reversal_green` | uniform vs salience L1 flip for "green" | σ_bU |
-
+At λ = 1 the belief-oriented weight is `L0 · k`, so the chain is rational
+in `k` and every prediction is symbolic algebra over
+`PMF.normalizeOrUniform` — no transcendental atoms; `c` re-enters only
+through the threshold identities (`k = 1/2` ↔ `c = ln 2`).
 -/
+
+open scoped ENNReal
+open Real (exp log exp_lt_exp)
 
 namespace QingFranke2015
 
-open RSA BigOperators
-open Real (exp log exp_pos exp_lt_exp)
-
--- ============================================================================
--- §1. Empirical Data
--- ============================================================================
-
--- ============================================================================
--- §2. Domain Types
--- ============================================================================
-
-/-- The three objects in the reference game context (Table 1).
-
-    green_square: unique shape, shared color
-    blue_circle: unique color, shared shape
-    green_circle: both features shared -/
+/-- The three objects in the reference game context (Fig. 1): unique shape,
+unique color, and both features shared. -/
 inductive Object where
   | green_square | blue_circle | green_circle
   deriving DecidableEq, Repr, Inhabited, Fintype
@@ -123,12 +79,7 @@ inductive Utterance where
 
 instance : Nonempty Utterance := ⟨.square⟩
 
-/-- Boolean semantics: ⟦utterance⟧(object).
-
-    - "square" applies to green_square only (unique shape)
-    - "circle" applies to blue_circle and green_circle (shared shape)
-    - "green" applies to green_square and green_circle (shared color)
-    - "blue" applies to blue_circle only (unique color) -/
+/-- Boolean semantics ⟦utterance⟧(object) (Fig. 1b). -/
 def Utterance.appliesTo : Utterance → Object → Bool
   | .square, .green_square => true
   | .circle, .blue_circle  => true
@@ -138,980 +89,18 @@ def Utterance.appliesTo : Utterance → Object → Bool
   | .blue,   .blue_circle  => true
   | _, _ => false
 
--- ============================================================================
--- §3. Cost Structure
--- ============================================================================
-
-/-- Adjective cost: shape words (nouns) cost 0, color words (adjectives) cost c.
-    From [qing-franke-2015] Eq. 11: Cost(m) = c if m is an adjective, 0 otherwise. -/
-noncomputable def adjCost (c : ℝ) : Utterance → ℝ
-  | .square | .circle => 0
-  | .green  | .blue   => c
-
--- ============================================================================
--- §4. Salience Data
--- ============================================================================
-
-/-- Salience data from Table 2, salience condition (N = 240).
-
-    Blue circle (139) is most salient; green circle (30) least. -/
-def saliencePrior : Object → ℝ
-  | .green_square => 71
-  | .blue_circle  => 139
-  | .green_circle => 30
-
-theorem saliencePrior_nonneg : ∀ w, 0 ≤ saliencePrior w := by
-  intro w; cases w <;> simp [saliencePrior]
-
--- ============================================================================
--- §5. Speaker Goal Types (Goal Dimension)
--- ============================================================================
-
-/-- Belief-oriented S1 score [Eq. 10]:
-    σ_b(m|t) ∝ exp(λ · (log y(t|m) - Cost(m)))
-
-    The speaker maximizes log-probability of correct belief at L0. Gated by
-    if-then-else because `log 0 = 0` in Lean (unlike WebPPL where `log 0 = -∞`
-    naturally zeros out false utterances). -/
-noncomputable def beliefGoalScore (cost : Utterance → ℝ) :
-    (Utterance → Object → ℝ) → ℝ → Unit → Object → Utterance → ℝ :=
-  fun l0 α _ w u =>
-    if l0 u w = 0 then 0
-    else exp (α * (log (l0 u w) - cost u))
-
-theorem beliefGoalScore_nonneg (cost : Utterance → ℝ) :
-    ∀ (l0 : Utterance → Object → ℝ) (α : ℝ) (l : Unit) (w : Object) (u : Utterance),
-    (∀ u' w', 0 ≤ l0 u' w') → 0 < α → 0 ≤ beliefGoalScore cost l0 α l w u := by
-  intro _ _ _ _ _ _ _; simp only [beliefGoalScore]; split
-  · exact le_refl 0
-  · exact le_of_lt (exp_pos _)
-
-/-- Action-oriented S1 score [Eq. 9]:
-    σ_a(m|t) ∝ exp(λ · (y(t|m) - Cost(m)))
-
-    The speaker maximizes the raw probability that the listener picks the correct
-    referent, rather than log-probability. Unlike beliefGoalScore, this gives
-    nonzero score even for false utterances (exp(-λ·C) > 0 when y=0).
-    The paper notes (Footnote 13) that model comparison restricts to truthful
-    predictions; here the model comparison theorems (§13) only compare
-    utterances that are true of the target object, so no gating is needed. -/
-noncomputable def actionGoalScore (cost : Utterance → ℝ) :
-    (Utterance → Object → ℝ) → ℝ → Unit → Object → Utterance → ℝ :=
-  fun l0 α _ w u => exp (α * (l0 u w - cost u))
-
-theorem actionGoalScore_nonneg (cost : Utterance → ℝ) :
-    ∀ (l0 : Utterance → Object → ℝ) (α : ℝ) (l : Unit) (w : Object) (u : Utterance),
-    (∀ u' w', 0 ≤ l0 u' w') → 0 < α → 0 ≤ actionGoalScore cost l0 α l w u :=
-  fun _ _ _ _ _ _ _ => le_of_lt (exp_pos _)
-
--- ============================================================================
--- §6. Priors
--- ============================================================================
-
-/-- Uniform prior: all objects equally weighted. -/
-def uniformPrior : Object → ℝ := fun _ => 1
-
-theorem uniformPrior_nonneg : ∀ w, 0 ≤ uniformPrior w :=
-  fun _ => le_of_lt one_pos
-
--- ============================================================================
--- §7. The 4 Speaker Models
--- ============================================================================
-
--- ============================================================================
--- §8. Concrete Configs for Findings
--- ============================================================================
-
--- ============================================================================
--- §9b. PMF chain (local pending the RSA API pass)
--- ============================================================================
-
-section PMFChain
-
-open scoped ENNReal
-
-/-- Every utterance applies to some object, and every object satisfies some
-utterance. -/
-private theorem appliesTo_sat : ∀ u : Utterance, ∃ w, u.appliesTo w = true := by
-  decide
-
-private noncomputable def qfPriorU : PMF Object := PMF.uniformOfFintype Object
-
-private theorem qfPriorU_pos (w : Object) : qfPriorU w ≠ 0 := by
-  rw [qfPriorU, PMF.uniformOfFintype_apply]
-  simp
-
-private theorem qfPriorU_apply (w : Object) : qfPriorU w = 3⁻¹ := by
-  rw [qfPriorU, PMF.uniformOfFintype_apply,
-    show Fintype.card Object = 3 from by decide]
-  norm_num
-
-private theorem sumObjs (f : Object → ℝ≥0∞) :
-    ∑' w, f w = f .green_square + f .blue_circle + f .green_circle := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset Object)
-      = {.green_square, .blue_circle, .green_circle} from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_singleton]
-  ring
-
-private theorem sumUtts (f : Utterance → ℝ≥0∞) :
-    ∑' u, f u = f .square + f .circle + f .green + f .blue := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset Utterance) = {.square, .circle, .green, .blue} from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-  ring
-
-/-- Salience prior as a PMF (Table 2 counts, total 240). -/
-private noncomputable def qfPriorS : PMF Object :=
-  PMF.normalize (fun w => ENNReal.ofReal (saliencePrior w))
-    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.green_square, by
-      rw [ENNReal.ofReal_ne_zero_iff]
-      norm_num [saliencePrior]⟩)
-    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
-
-private theorem salience_sum :
-    (∑' w, ENNReal.ofReal (saliencePrior w)) = ENNReal.ofReal 240 := by
-  rw [sumObjs]
-  norm_num [saliencePrior]
-
-private theorem qfPriorS_apply (w : Object) :
-    qfPriorS w = ENNReal.ofReal (saliencePrior w / 240) := by
-  rw [qfPriorS, PMF.normalize_apply, salience_sum,
-    ← ENNReal.ofReal_inv_of_pos (by norm_num),
-    ← ENNReal.ofReal_mul (by cases w <;> norm_num [saliencePrior])]
-  rw [div_eq_mul_inv]
-
-private theorem qfPriorS_pos (w : Object) : qfPriorS w ≠ 0 := by
-  rw [qfPriorS_apply, ENNReal.ofReal_ne_zero_iff]
-  cases w <;> norm_num [saliencePrior]
-
-/-- Literal listener at a speaker-belief prior (Figure-4-style prior-in-L0;
-[qing-franke-2015] eqs. 5–8). -/
-private noncomputable def qfL0 (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0)
-    (u : Utterance) : PMF Object :=
-  RSA.L0LassiterGoodman bel (fun u w => u.appliesTo w) u (by
-    obtain ⟨w, hw⟩ := appliesTo_sat u
-    exact ENNReal.summable.tsum_ne_zero_iff.mpr
-      ⟨w, by rw [hw]; simpa using hbel w⟩)
-
-/-- Uniform-belief L0 values: `1` on the unique-feature objects, `1/2` on
-shared features (extensions of size 1 and 2 over 3 objects). -/
-private theorem qfL0_uniform_apply (u : Utterance) (w : Object) :
-    qfL0 qfPriorU qfPriorU_pos u w
-      = if u.appliesTo w then
-          (if u = .square ∨ u = .blue then 1 else 2⁻¹) else 0 := by
-  unfold qfL0
-  rw [RSA.L0LassiterGoodman_apply]
-  have hmass : (∑' w', qfPriorU w' * (if u.appliesTo w' then (1 : ℝ≥0∞) else 0))
-      = if u = .square ∨ u = .blue then 3⁻¹ else 3⁻¹ + 3⁻¹ := by
-    rw [sumObjs]
-    simp only [qfPriorU_apply]
-    cases u <;> simp +decide
-  rw [hmass, qfPriorU_apply]
-  by_cases hw : u.appliesTo w = true
-  · rw [hw]
-    by_cases h1 : u = .square ∨ u = .blue
-    · simp only [h1, if_true, mul_one]
-      rw [ENNReal.mul_inv_cancel (by norm_num) (by norm_num)]
-    · simp only [h1, if_false, reduceIte, mul_one]
-      rw [show (3 : ℝ≥0∞)⁻¹ + 3⁻¹ = 3⁻¹ * 2 from by ring,
-        ENNReal.mul_inv (by norm_num) (by norm_num), ← mul_assoc,
-        ENNReal.mul_inv_cancel (by norm_num) (by norm_num), one_mul]
-  · rw [Bool.not_eq_true] at hw
-    rw [hw]
-    simp
-
-/-- Extension salience sums (denominators of the salience L0). -/
-private noncomputable def extSum : Utterance → ℝ
-  | .square => 71
-  | .circle => 169
-  | .green  => 101
-  | .blue   => 139
-
-/-- Salience-belief L0 values on support: object salience over extension
-salience ([qing-franke-2015] L0 ∝ S(t)·⟦m⟧). -/
-private theorem qfL0_salience_true {u : Utterance} {w : Object}
-    (hw : u.appliesTo w = true) :
-    qfL0 qfPriorS qfPriorS_pos u w
-      = ENNReal.ofReal (saliencePrior w / extSum u) := by
-  unfold qfL0
-  rw [RSA.L0LassiterGoodman_apply, hw]
-  have hmass : (∑' w', qfPriorS w' * (if u.appliesTo w' then (1 : ℝ≥0∞) else 0))
-      = ENNReal.ofReal (extSum u / 240) := by
-    rw [sumObjs]
-    simp only [qfPriorS_apply]
-    cases u <;>
-      · simp +decide [saliencePrior, extSum]
-        try rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-        try norm_num
-  rw [hmass, qfPriorS_apply]
-  simp only [reduceIte, mul_one]
-  rw [← ENNReal.ofReal_inv_of_pos (by cases u <;> norm_num [extSum]),
-    ← ENNReal.ofReal_mul (by cases w <;> norm_num [saliencePrior])]
-  congr 1
-  cases u <;> cases w <;> norm_num [saliencePrior, extSum]
-
-private theorem qfL0_salience_false {u : Utterance} {w : Object}
-    (hw : u.appliesTo w = false) :
-    qfL0 qfPriorS qfPriorS_pos u w = 0 := by
-  unfold qfL0
-  rw [RSA.L0LassiterGoodman_apply, hw]
-  simp
-
-/-! ### Speakers and exp-bound helpers -/
-
-private noncomputable def qfCf (c : ℝ) (u : Utterance) : ℝ≥0∞ :=
-  ENNReal.ofReal (Real.exp (-(adjCost c u)))
-
-private theorem qfCf_pos (c : ℝ) (u : Utterance) : qfCf c u ≠ 0 := by
-  rw [qfCf, ENNReal.ofReal_ne_zero_iff]
-  exact Real.exp_pos _
-
-private theorem qfCf_square (c : ℝ) : qfCf c .square = 1 := by
-  simp [qfCf, adjCost]
-
-private theorem qfCf_circle (c : ℝ) : qfCf c .circle = 1 := by
-  simp [qfCf, adjCost]
-
-private theorem qfCf_green (c : ℝ) : qfCf c .green = ENNReal.ofReal (Real.exp (-c)) :=
-  rfl
-
-private theorem qfCf_blue (c : ℝ) : qfCf c .blue = ENNReal.ofReal (Real.exp (-c)) :=
-  rfl
-
-private theorem objSat : ∀ w : Object, ∃ u : Utterance, u.appliesTo w = true := by
-  decide
-
-/-- Belief-oriented speaker ([qing-franke-2015] eq. 10 at λ = 1): weights
-`L0 · exp(−Cost)`. -/
-private noncomputable def s1B (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0) (c : ℝ)
-    (w : Object) : PMF Utterance :=
-  RSA.S1Belief (qfL0 bel hbel) (qfCf c) 1 w
-    (by
-      obtain ⟨u, hu⟩ := objSat w
-      refine ENNReal.summable.tsum_ne_zero_iff.mpr ⟨u, mul_ne_zero ?_ (qfCf_pos c u)⟩
-      have hL0 : qfL0 bel hbel u w ≠ 0 := by
-        unfold qfL0
-        rw [← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
-        exact ⟨hbel w, hu⟩
-      exact (ENNReal.rpow_pos (pos_iff_ne_zero.mpr hL0) (PMF.apply_ne_top _ _)).ne')
-    (ENNReal.tsum_ne_top_of_fintype fun u =>
-      ENNReal.mul_ne_top
-        (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (PMF.apply_ne_top _ _))
-        (by rw [qfCf]; exact ENNReal.ofReal_ne_top))
-
-/-- Action-oriented speaker ([qing-franke-2015] eq. 9 at λ = 1): weights
-`exp(L0 − Cost)` — positive on ALL utterances, including false ones (the
-action-oriented speaker softmaxes raw success probability). Local private
-op pending the RSA API pass. -/
-private noncomputable def s1A (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0) (c : ℝ)
-    (w : Object) : PMF Utterance :=
-  PMF.normalize
-    (fun u => ENNReal.ofReal (Real.exp ((qfL0 bel hbel u w).toReal - adjCost c u)))
-    (ENNReal.summable.tsum_ne_zero_iff.mpr ⟨.square, by
-      rw [ENNReal.ofReal_ne_zero_iff]
-      exact Real.exp_pos _⟩)
-    (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
-
-/-- The five speaker chains of §7–§8, on the PMF face. -/
-noncomputable def s1ZeroCost : Object → PMF Utterance := s1B qfPriorU qfPriorU_pos 0
-noncomputable def s1Cost : Object → PMF Utterance := s1B qfPriorU qfPriorU_pos (1/2)
-noncomputable def s1AU : Object → PMF Utterance := s1A qfPriorU qfPriorU_pos (1/2)
-noncomputable def s1BS : Object → PMF Utterance := s1B qfPriorS qfPriorS_pos (1/2)
-noncomputable def s1AS : Object → PMF Utterance := s1A qfPriorS qfPriorS_pos (1/2)
-
-private theorem s1B_marginal_pos (bel : PMF Object) (hbel : ∀ w, bel w ≠ 0) (c : ℝ)
-    (lp : PMF Object) (hlp : ∀ w, lp w ≠ 0) (u : Utterance) :
-    PMF.marginal (s1B bel hbel c) lp u ≠ 0 := by
-  obtain ⟨w, hw⟩ := appliesTo_sat u
-  refine PMF.marginal_ne_zero _ _ _ (hlp w) ?_
-  have hL0 : qfL0 bel hbel u w ≠ 0 := by
-    unfold qfL0
-    rw [← PMF.mem_support_iff, RSA.mem_support_L0LassiterGoodman_iff]
-    exact ⟨hbel w, hw⟩
-  unfold s1B
-  exact RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ hL0 (qfCf_pos c u)
-
-/-- Pragmatic listeners ([qing-franke-2015] eqs. 12–13, 15): same σ_bU cost
-speaker, uniform vs salience world prior. -/
-noncomputable def l1Cost (u : Utterance) : PMF Object :=
-  PMF.posterior (s1Cost) qfPriorU u
-    (s1B_marginal_pos qfPriorU qfPriorU_pos (1/2) qfPriorU qfPriorU_pos u)
-
-noncomputable def l1Sal (u : Utterance) : PMF Object :=
-  PMF.posterior (s1Cost) qfPriorS u
-    (s1B_marginal_pos qfPriorU qfPriorU_pos (1/2) qfPriorS qfPriorS_pos u)
-
-/-! ### The `exp(−1/2)` atom and its three numeric bounds -/
-
-private noncomputable def xc : ℝ := RSA.expAtom (1/2)
-
-private theorem xc_pos : 0 < xc := RSA.expAtom_pos _
-
-private theorem e_half : ((2:ℕ) : ℝ) * (1/2) = 1 := by norm_num
-
-private theorem xc_lt_one : xc < 1 :=
-  RSA.expAtom_lt (n := 2) two_ne_zero (by norm_num)
-    (by rw [e_half, one_pow, one_mul]; nlinarith [Real.exp_one_gt_d9])
-
-/-- `exp(−1/2) > 1/2` ⟺ `e < 4` — [qing-franke-2015]'s Finding 2 needs the
-adjective's cost penalty to stay above the halved literal probability. -/
-private theorem xc_gt_half : 1/2 < xc :=
-  RSA.lt_expAtom (n := 2) two_ne_zero (by norm_num)
-    (by rw [e_half]; nlinarith [Real.exp_one_lt_d9])
-
-/-- `exp(−1/2) < 139/169` ⟺ `e > (169/139)²` — the salience-belief speaker's
-circle-over-blue reversal at the blue circle. -/
-private theorem xc_lt_139_169 : xc < 139/169 :=
-  RSA.expAtom_lt (n := 2) two_ne_zero (by norm_num)
-    (by rw [e_half]; nlinarith [Real.exp_one_gt_d9])
-
-/-- `exp(−1/2) > 101/169` ⟺ `e < (169/101)²` ≈ 2.7998 — the tight bound
-(margin ≈ 0.08 over `exp_one_lt_d9`). -/
-private theorem xc_gt_101_169 : 101/169 < xc :=
-  RSA.lt_expAtom (n := 2) two_ne_zero (by norm_num)
-    (by rw [e_half]; nlinarith [Real.exp_one_lt_d9])
-
-/-! ### Cost-speaker values (for the listener comparisons) -/
-
-private theorem half_conv : (2 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/2) := by
-  rw [show (2 : ℝ≥0∞) = ENNReal.ofReal 2 from (ENNReal.ofReal_ofNat 2).symm,
-    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
-  norm_num
-
-private theorem s1Cost_val {u : Utterance} {w : Object} (hw : u.appliesTo w = true)
-    {q Z : ℝ} (hq0 : 0 ≤ q)
-    (hq : (if u = .square ∨ u = .blue then (1 : ℝ≥0∞) else 2⁻¹) * qfCf (1/2) u
-      = ENNReal.ofReal q)
-    (hZ : (∑' u', (qfL0 qfPriorU qfPriorU_pos u' w : ℝ≥0∞) ^ (1 : ℝ) * qfCf (1/2) u')
-      = ENNReal.ofReal Z) (hZpos : 0 < Z) :
-    s1Cost w u = ENNReal.ofReal (q * Z⁻¹) := by
-  unfold s1Cost s1B
-  rw [RSA.S1Belief_apply, hZ, ENNReal.rpow_one, qfL0_uniform_apply, hw]
-  simp only [if_true]
-  rw [hq, ← ENNReal.ofReal_inv_of_pos hZpos, ← ENNReal.ofReal_mul hq0]
-
-private theorem Z_gs :
-    (∑' u', (qfL0 qfPriorU qfPriorU_pos u' .green_square : ℝ≥0∞) ^ (1 : ℝ) *
-      qfCf (1/2) u') = ENNReal.ofReal (1 + xc/2) := by
-  rw [sumUtts]
-  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_circle,
-    qfCf_green, qfCf_blue]
-  simp +decide
-  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
-    show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from ENNReal.ofReal_one.symm,
-    ← ENNReal.ofReal_add (by norm_num) (by positivity)]
-  congr 1
-  unfold xc RSA.expAtom
-  norm_num
-  ring
-
-private theorem Z_bc :
-    (∑' u', (qfL0 qfPriorU qfPriorU_pos u' .blue_circle : ℝ≥0∞) ^ (1 : ℝ) *
-      qfCf (1/2) u') = ENNReal.ofReal (1/2 + xc) := by
-  rw [sumUtts]
-  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_circle,
-    qfCf_green, qfCf_blue]
-  simp +decide
-  rw [half_conv, ← ENNReal.ofReal_add (by norm_num) (by positivity)]
-  congr 1
-  unfold xc RSA.expAtom
-  norm_num
-
-private theorem Z_gc :
-    (∑' u', (qfL0 qfPriorU qfPriorU_pos u' .green_circle : ℝ≥0∞) ^ (1 : ℝ) *
-      qfCf (1/2) u') = ENNReal.ofReal (1/2 + xc/2) := by
-  rw [sumUtts]
-  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_circle,
-    qfCf_green, qfCf_blue]
-  simp +decide
-  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
-    ← ENNReal.ofReal_add (by norm_num) (by positivity)]
-  congr 1
-  unfold xc RSA.expAtom
-  norm_num
-  ring
-
-private theorem third_conv : (3 : ℝ≥0∞)⁻¹ = ENNReal.ofReal (1/3) := by
-  rw [show (3 : ℝ≥0∞) = ENNReal.ofReal 3 from (ENNReal.ofReal_ofNat 3).symm,
-    ← ENNReal.ofReal_inv_of_pos (by norm_num)]
-  norm_num
-
-private theorem circle_weight :
-    (if Utterance.circle = Utterance.square ∨ Utterance.circle = Utterance.blue
-      then (1 : ℝ≥0∞) else 2⁻¹) * qfCf (1/2) .circle = ENNReal.ofReal (1/2) := by
-  rw [show (if Utterance.circle = Utterance.square ∨ Utterance.circle = Utterance.blue
-      then (1 : ℝ≥0∞) else 2⁻¹) = 2⁻¹ from by simp +decide, qfCf_circle, mul_one]
-  exact half_conv
-
-private theorem green_weight :
-    (if Utterance.green = Utterance.square ∨ Utterance.green = Utterance.blue
-      then (1 : ℝ≥0∞) else 2⁻¹) * qfCf (1/2) .green = ENNReal.ofReal (xc/2) := by
-  rw [show (if Utterance.green = Utterance.square ∨ Utterance.green = Utterance.blue
-      then (1 : ℝ≥0∞) else 2⁻¹) = 2⁻¹ from by simp +decide, qfCf_green, half_conv,
-    ← ENNReal.ofReal_mul (by norm_num)]
-  congr 1
-  unfold xc RSA.expAtom
-  ring
-
-private theorem sc_circle_gc :
-    s1Cost .green_circle .circle = ENNReal.ofReal ((1/2) * (1/2 + xc/2)⁻¹) :=
-  s1Cost_val (by decide) (by norm_num) circle_weight Z_gc
-    (by have := xc_pos; linarith)
-
-private theorem sc_circle_bc :
-    s1Cost .blue_circle .circle = ENNReal.ofReal ((1/2) * (1/2 + xc)⁻¹) :=
-  s1Cost_val (by decide) (by norm_num) circle_weight Z_bc
-    (by have := xc_pos; linarith)
-
-private theorem sc_green_gc :
-    s1Cost .green_circle .green = ENNReal.ofReal ((xc/2) * (1/2 + xc/2)⁻¹) :=
-  s1Cost_val (by decide) (by have := xc_pos; linarith) green_weight Z_gc
-    (by have := xc_pos; linarith)
-
-private theorem sc_green_gs :
-    s1Cost .green_square .green = ENNReal.ofReal ((xc/2) * (1 + xc/2)⁻¹) :=
-  s1Cost_val (by decide) (by have := xc_pos; linarith) green_weight Z_gs
-    (by have := xc_pos; linarith)
-
-private theorem xc_eq : Real.exp (-2⁻¹) = xc := by
-  unfold xc RSA.expAtom
-  norm_num
-
-private theorem qfCf_zero (u : Utterance) : qfCf 0 u = 1 := by
-  cases u <;> simp [qfCf, adjCost]
-
-end PMFChain
-
-open scoped ENNReal
-
--- ============================================================================
--- §10. Structural Properties
--- ============================================================================
-
-/-- "square" uniquely identifies green_square. -/
-theorem square_unique :
-    Utterance.appliesTo .square .green_square = true ∧
-    Utterance.appliesTo .square .blue_circle = false ∧
-    Utterance.appliesTo .square .green_circle = false :=
-  ⟨rfl, rfl, rfl⟩
-
-/-- "blue" uniquely identifies blue_circle. -/
-theorem blue_unique :
-    Utterance.appliesTo .blue .blue_circle = true ∧
-    Utterance.appliesTo .blue .green_square = false ∧
-    Utterance.appliesTo .blue .green_circle = false :=
-  ⟨rfl, rfl, rfl⟩
-
-/-- "circle" is ambiguous between blue_circle and green_circle. -/
-theorem circle_ambiguous :
-    Utterance.appliesTo .circle .blue_circle = true ∧
-    Utterance.appliesTo .circle .green_circle = true ∧
-    Utterance.appliesTo .circle .green_square = false :=
-  ⟨rfl, rfl, rfl⟩
-
-/-- "green" is ambiguous between green_square and green_circle. -/
-theorem green_ambiguous :
-    Utterance.appliesTo .green .green_square = true ∧
-    Utterance.appliesTo .green .green_circle = true ∧
-    Utterance.appliesTo .green .blue_circle = false :=
-  ⟨rfl, rfl, rfl⟩
-
--- ============================================================================
--- §11. Speaker Predictions (Findings 1–4)
--- ============================================================================
-
-/-- Finding 1: For green_square, S1 prefers "square" (unique, cost=0) over "green"
-    (ambiguous, cost=1/2). Both informativity and cost favor "square".
-    Evidence: 135/144 speakers chose "square" (Table 1). -/
-theorem speaker_prefers_unique_shape :
-    s1Cost .green_square .square > s1Cost .green_square .green := by
-  unfold s1Cost s1B
-  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt]
-  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_square, qfCf_green]
-  simp +decide
-  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
-    show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from ENNReal.ofReal_one.symm]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr ?_
-  rw [xc_eq]
-  nlinarith [xc_pos, xc_lt_one]
-
-/-- Finding 2: For blue_circle, S1 prefers "blue" (unique, cost=1/2) over "circle"
-    (ambiguous, cost=0). Informativity dominates cost.
-    Evidence: 119/144 speakers chose "blue" (Table 1). -/
-theorem speaker_prefers_unique_color :
-    s1Cost .blue_circle .blue > s1Cost .blue_circle .circle := by
-  unfold s1Cost s1B
-  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt]
-  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_circle, qfCf_blue]
-  simp +decide
-  rw [half_conv]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by positivity)).mpr ?_
-  rw [xc_eq]
-  exact xc_gt_half
-
-/-- Finding 3: For green_circle, cost breaks the tie between the two ambiguous
-    words: S1 prefers "circle" (cost=0) over "green" (cost=1/2). Both are equally
-    informative (each applies to 2 objects), so cost is the tiebreaker.
-    Evidence: 81/144 chose "circle", 63/144 chose "green" (Table 1;
-    not statistically significant: χ²=2.25, p=0.13). -/
-theorem cost_breaks_symmetry :
-    s1Cost .green_circle .circle > s1Cost .green_circle .green := by
-  unfold s1Cost s1B
-  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt]
-  simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_circle, qfCf_green]
-  simp +decide
-  rw [half_conv, ← ENNReal.ofReal_mul (by norm_num)]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr ?_
-  rw [xc_eq]
-  nlinarith [xc_lt_one, xc_pos]
-
-/-- Finding 4: Without cost, the symmetry is unbroken — neither ambiguous word
-    dominates for green_circle. Both "circle" and "green" apply to exactly 2 objects,
-    so L0 assigns equal probability, and S1 assigns equal weight. -/
-theorem no_cost_symmetry :
-    ¬(s1ZeroCost .green_circle .circle > s1ZeroCost .green_circle .green) := by
-  have h : s1ZeroCost .green_circle .circle = s1ZeroCost .green_circle .green := by
-    refine le_antisymm ?_ ?_ <;>
-      · unfold s1ZeroCost s1B
-        rw [RSA.S1Belief_apply_le_iff_score_le]
-        simp only [ENNReal.rpow_one, qfL0_uniform_apply, qfCf_zero]
-        simp +decide
-  rw [gt_iff_lt, h]
-  exact lt_irrefl _
-
--- ============================================================================
--- §12. Listener Predictions (Findings 5–6): Salience Reversal
--- ============================================================================
-
-/-! The paper's central contribution: perceptual salience **reverses** L1 predictions.
-
-Under uniform prior (costCfg), pragmatic reasoning dominates: the listener infers
-that ambiguous words signal the object without a unique alternative. Under salience
-prior (salienceCfg), salience overrides pragmatics: salient objects dominate even
-though pragmatics would favor the other.
-
-The listener prior v ∈ {U, S} enters at L1 via `worldPrior`, independent of the
-speaker's belief y ∈ {U, S} which enters at L0 via `meaning`. Both costCfg and
-salienceCfg use σ_bU (speaker belief = uniform), but differ in the listener's
-prior — exactly the comparison the paper runs (Table 4 rows for ρ_bU vs ρ_bS). -/
-
--- Finding 5: Salience reversal for "circle"
--- Uniform: green_circle > blue_circle (pragmatic narrowing)
--- Salience: blue_circle > green_circle (salience override; matches human 66%)
-
-/-- Uniform L1 for "circle": green_circle > blue_circle.
-    Pragmatic reasoning: a speaker wanting blue_circle would say "blue" (unique),
-    so saying "circle" signals green_circle. -/
-theorem uniform_circle_green_circ :
-    l1Cost .circle .green_circle > l1Cost .circle .blue_circle := by
-  unfold l1Cost
-  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorU_apply, qfPriorU_apply,
-    sc_circle_bc, sc_circle_gc, third_conv,
-    ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; positivity)).mpr ?_
-  have hx := xc_pos
-  have h1 : (0:ℝ) < 1/2 + xc := by linarith
-  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
-  rw [show (1:ℝ)/3 * (1/2 * (1/2 + xc)⁻¹) = (1/6) / (1/2 + xc) from by
-      rw [div_eq_mul_inv]; ring,
-    show (1:ℝ)/3 * (1/2 * (1/2 + xc/2)⁻¹) = (1/6) / (1/2 + xc/2) from by
-      rw [div_eq_mul_inv]; ring,
-    div_lt_div_iff₀ h1 h2]
-  nlinarith [hx]
-
-/-- Salience L1 for "circle": blue_circle > green_circle.
-    Salience (139 vs 30) overrides pragmatic narrowing. Matches human data
-    (Table 2: 117/180 = 65% chose blue_circle). -/
-theorem salience_circle_blue_circ :
-    l1Sal .circle .blue_circle > l1Sal .circle .green_circle := by
-  unfold l1Sal
-  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorS_apply, qfPriorS_apply,
-    sc_circle_bc, sc_circle_gc,
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior]),
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior])]
-  refine (ENNReal.ofReal_lt_ofReal_iff
-    (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
-  have hx := xc_pos
-  have h1 : (0:ℝ) < 1/2 + xc := by linarith
-  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
-  rw [saliencePrior, saliencePrior]
-  rw [show ((30:ℝ)/240) * ((1/2) * (1/2 + xc/2)⁻¹) = (30/480) / (1/2 + xc/2) from by
-      rw [div_eq_mul_inv]; ring,
-    show ((139:ℝ)/240) * ((1/2) * (1/2 + xc)⁻¹) = (139/480) / (1/2 + xc) from by
-      rw [div_eq_mul_inv]; ring,
-    div_lt_div_iff₀ h2 h1]
-  nlinarith [hx]
-
-/-- Finding 5: Salience reversal for "circle". Uniform and salience priors make
-    opposite L1 predictions, and human data matches the salience direction. -/
-theorem salience_reversal_circle :
-    (l1Cost .circle .green_circle > l1Cost .circle .blue_circle) ∧
-    (l1Sal .circle .blue_circle > l1Sal .circle .green_circle) :=
-  ⟨uniform_circle_green_circ, salience_circle_blue_circ⟩
-
--- Finding 6: Salience reversal for "green"
--- Uniform: green_circle > green_square (pragmatic narrowing)
--- Salience: green_square > green_circle (salience override; matches human 56%)
-
-/-- Uniform L1 for "green": green_circle > green_square.
-    Pragmatic reasoning: a speaker wanting green_square would say "square" (unique),
-    so saying "green" signals green_circle. -/
-theorem uniform_green_green_circ :
-    l1Cost .green .green_circle > l1Cost .green .green_square := by
-  unfold l1Cost
-  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorU_apply, qfPriorU_apply,
-    sc_green_gs, sc_green_gc, third_conv,
-    ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; positivity)).mpr ?_
-  have hx := xc_pos
-  have h1 : (0:ℝ) < 1 + xc/2 := by linarith
-  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
-  rw [show (1:ℝ)/3 * (xc/2 * (1 + xc/2)⁻¹) = (xc/6) / (1 + xc/2) from by
-      rw [div_eq_mul_inv]; ring,
-    show (1:ℝ)/3 * (xc/2 * (1/2 + xc/2)⁻¹) = (xc/6) / (1/2 + xc/2) from by
-      rw [div_eq_mul_inv]; ring,
-    div_lt_div_iff₀ h1 h2]
-  nlinarith [hx]
-
-/-- Salience L1 for "green": green_square > green_circle.
-    Salience (71 vs 30) overrides pragmatic narrowing in the model. However,
-    human data goes in the opposite (pragmatic) direction: Table 2 shows
-    115/180 = 64% chose green_circle. -/
-theorem salience_green_green_sq :
-    l1Sal .green .green_square > l1Sal .green .green_circle := by
-  unfold l1Sal
-  rw [gt_iff_lt, PMF.posterior_lt_iff_score_lt, qfPriorS_apply, qfPriorS_apply,
-    sc_green_gs, sc_green_gc,
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior]),
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior])]
-  refine (ENNReal.ofReal_lt_ofReal_iff
-    (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
-  have hx := xc_pos
-  have h1 : (0:ℝ) < 1 + xc/2 := by linarith
-  have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
-  rw [saliencePrior, saliencePrior]
-  rw [show ((30:ℝ)/240) * ((xc/2) * (1/2 + xc/2)⁻¹) = (30 * xc/480) / (1/2 + xc/2) from by
-      rw [div_eq_mul_inv]; ring,
-    show ((71:ℝ)/240) * ((xc/2) * (1 + xc/2)⁻¹) = (71 * xc/480) / (1 + xc/2) from by
-      rw [div_eq_mul_inv]; ring,
-    div_lt_div_iff₀ h2 h1]
-  nlinarith [hx]
-
-/-- Finding 6: Salience reversal for "green". Uniform and salience priors make
-    opposite L1 predictions. Human data matches the *pragmatic* (uniform)
-    direction: 115/180 chose green_circle (Table 2). -/
-theorem salience_reversal_green :
-    (l1Cost .green .green_circle > l1Cost .green .green_square) ∧
-    (l1Sal .green .green_square > l1Sal .green .green_circle) :=
-  ⟨uniform_green_green_circ, salience_green_green_sq⟩
-
--- ============================================================================
--- §13. Model Comparison: Alternative Speaker Models
--- ============================================================================
-
-/-! The paper compares 4 speaker models along the speaker-goal × speaker-belief
-dimensions (Table 3). Only σ_bU correctly predicts all three speaker preferences.
-Each alternative fails on at least one observation:
-
-| Model | green_sq (sq > gr) | blue_circ (bl > ci) | green_circ (ci > gr) | Score |
-|-------|-------------------|--------------------|--------------------|-------|
-| σ_bU  | ✓                 | ✓                  | ✓                  | 3/3   |
-| σ_aU  | ✓                 | = (tie)            | ✓                  | 2/3   |
-| σ_bS  | ✓                 | ✗ (ci > bl)        | ✗ (gr > ci)        | 1/3   |
-| σ_aS  | ✓                 | ✗ (ci > bl)        | ✓                  | 2/3   |
-
-The discriminating observation is **blue_circle**: only σ_bU predicts "blue" > "circle".
-σ_aU ties (equal S1 scores), while σ_bS and σ_aS reverse the preference.
-
-Salience in the speaker is harmful: it inflates L0's posterior for blue_circle given
-"circle" (since blue_circle has the highest salience, 139 vs 30), which raises S1's
-score for "circle" enough to match or exceed "blue". -/
-
--- Concrete configs: all use adjCost 1/2 and uniform listener prior.
--- (Listener prior doesn't affect S1, so any prior works for speaker comparison.)
-
--- §13a. σ_aU: Action-oriented, uniform belief
--- Agrees on green_sq and green_circ; ties on blue_circ.
--- The tie arises because exp/log don't cancel in actionGoalScore:
--- score(blue) = exp(1 * (1 - 1/2)) = exp(1/2)
--- score(circle) = exp(1 * (1/2 - 0)) = exp(1/2)
-
-/-- σ_aU agrees: "square" > "green" for green_square. -/
-theorem σ_aU_green_sq :
-    s1AU .green_square .square > s1AU .green_square .green := by
-  unfold s1AU s1A
-  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
-  simp only [qfL0_uniform_apply]
-  simp +decide [ENNReal.toReal_inv, adjCost]
-
-/-- σ_aU agrees: "circle" > "green" for green_circle (cost breaks symmetry). -/
-theorem σ_aU_green_circ :
-    s1AU .green_circle .circle > s1AU .green_circle .green := by
-  unfold s1AU s1A
-  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
-  simp only [qfL0_uniform_apply]
-  simp +decide [ENNReal.toReal_inv, adjCost]
-
-/-- σ_aU fails: "blue" and "circle" are tied for blue_circle.
-    This is the key prediction that distinguishes σ_aU from σ_bU.
-    Under belief-oriented scoring (σ_bU), the log transform amplifies the
-    informativity advantage of "blue" (L0 = 1) over "circle" (L0 = 1/2);
-    under action-oriented scoring (σ_aU), the raw difference is exactly
-    offset by cost. -/
-theorem σ_aU_blue_circ_tie :
-    ¬(s1AU .blue_circle .blue > s1AU .blue_circle .circle) ∧
-    ¬(s1AU .blue_circle .circle > s1AU .blue_circle .blue) := by
-  have h : s1AU .blue_circle .blue = s1AU .blue_circle .circle := by
-    unfold s1AU s1A
-    rw [PMF.normalize_eq_iff_eq]
-    simp only [qfL0_uniform_apply]
-    simp +decide [ENNReal.toReal_inv, adjCost]
-    norm_num
-  exact ⟨by rw [gt_iff_lt, h]; exact lt_irrefl _,
-         by rw [gt_iff_lt, h]; exact lt_irrefl _⟩
-
--- §13b. σ_bS: Belief-oriented, salience belief
--- Agrees on green_sq; reverses on both blue_circ and green_circ.
--- Worst speaker model (1/3).
-
-/-- σ_bS agrees: "square" > "green" for green_square.
-    The unique shape word wins regardless of speaker belief, since "square"
-    applies to only one object while "green" is ambiguous. -/
-theorem σ_bS_green_sq :
-    s1BS .green_square .square > s1BS .green_square .green := by
-  unfold s1BS s1B
-  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt, ENNReal.rpow_one, ENNReal.rpow_one,
-    qfL0_salience_true (show Utterance.green.appliesTo .green_square = true from by decide),
-    qfL0_salience_true (show Utterance.square.appliesTo .green_square = true from by decide),
-    qfCf_square, qfCf_green, mul_one,
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior, extSum])]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num [saliencePrior, extSum])).mpr ?_
-  rw [show Real.exp (-(1/2 : ℝ)) = xc from rfl]
-  norm_num [saliencePrior, extSum]
-  nlinarith [xc_lt_one, xc_pos]
-
-/-- σ_bS reverses blue_circle: predicts "circle" > "blue".
-    With salience-weighted L0, blue_circle has the highest salience (139),
-    so L0(blue_circ|"circle") = 139/169 ≈ 0.82, making "circle" quite
-    informative. Combined with zero cost for "circle" vs cost 1/2 for "blue",
-    the pragmatic advantage of "blue" is overcome. -/
-theorem σ_bS_blue_circ_reversal :
-    s1BS .blue_circle .circle > s1BS .blue_circle .blue := by
-  unfold s1BS s1B
-  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt, ENNReal.rpow_one, ENNReal.rpow_one,
-    qfL0_salience_true (show Utterance.blue.appliesTo .blue_circle = true from by decide),
-    qfL0_salience_true (show Utterance.circle.appliesTo .blue_circle = true from by decide),
-    qfCf_circle, qfCf_blue, mul_one,
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior, extSum])]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num [saliencePrior, extSum])).mpr ?_
-  rw [show Real.exp (-(1/2 : ℝ)) = xc from rfl]
-  norm_num [saliencePrior, extSum]
-  nlinarith [xc_lt_139_169]
-
-/-- σ_bS reverses green_circle: predicts "green" > "circle".
-    With salience weights, L0(green_circ|"green") = 30/101 ≈ 0.30 and
-    L0(green_circ|"circle") = 30/169 ≈ 0.18. "green" has higher L0 posterior
-    for green_circ, and the log transform in belief-oriented scoring
-    amplifies this advantage enough to overcome its cost disadvantage. -/
-theorem σ_bS_green_circ_reversal :
-    s1BS .green_circle .green > s1BS .green_circle .circle := by
-  unfold s1BS s1B
-  rw [gt_iff_lt, RSA.S1Belief_apply_lt_iff_score_lt, ENNReal.rpow_one, ENNReal.rpow_one,
-    qfL0_salience_true (show Utterance.circle.appliesTo .green_circle = true from by decide),
-    qfL0_salience_true (show Utterance.green.appliesTo .green_circle = true from by decide),
-    qfCf_circle, qfCf_green, mul_one,
-    ← ENNReal.ofReal_mul (by norm_num [saliencePrior, extSum])]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by norm_num [saliencePrior, extSum]; positivity)).mpr ?_
-  rw [show Real.exp (-(1/2 : ℝ)) = xc from rfl]
-  norm_num [saliencePrior, extSum]
-  nlinarith [xc_gt_101_169]
-
--- §13c. σ_aS: Action-oriented, salience belief
--- Agrees on green_sq and green_circ; reverses on blue_circ.
-
-/-- σ_aS agrees: "square" > "green" for green_square. -/
-theorem σ_aS_green_sq :
-    s1AS .green_square .square > s1AS .green_square .green := by
-  unfold s1AS s1A
-  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
-  simp +decide [qfL0_salience_true, saliencePrior, extSum, adjCost]
-  rw [ENNReal.toReal_ofReal (by norm_num)]
-  exact (ENNReal.ofReal_lt_ofReal_iff (Real.exp_pos _)).mpr
-    (Real.exp_lt_exp.mpr (by norm_num))
-
-/-- σ_aS reverses blue_circle: predicts "circle" > "blue".
-    Same mechanism as σ_bS: salience inflates L0(blue_circ|"circle") = 139/169.
-    Under action-oriented scoring, this raw probability advantage
-    (plus zero cost) overcomes "blue"'s informativity. -/
-theorem σ_aS_blue_circ_reversal :
-    s1AS .blue_circle .circle > s1AS .blue_circle .blue := by
-  unfold s1AS s1A
-  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
-  simp +decide [qfL0_salience_true, saliencePrior, extSum, adjCost]
-  rw [ENNReal.toReal_ofReal (by norm_num)]
-  exact (ENNReal.ofReal_lt_ofReal_iff (Real.exp_pos _)).mpr
-    (Real.exp_lt_exp.mpr (by norm_num))
-
-/-- σ_aS agrees: "circle" > "green" for green_circle.
-    Unlike σ_bS, the action-oriented scoring doesn't amplify the L0
-    advantage of "green" via log, so cost wins for green_circle. -/
-theorem σ_aS_green_circ :
-    s1AS .green_circle .circle > s1AS .green_circle .green := by
-  unfold s1AS s1A
-  rw [gt_iff_lt, PMF.normalize_lt_iff_lt]
-  simp +decide [qfL0_salience_true, saliencePrior, extSum, adjCost]
-  rw [ENNReal.toReal_ofReal (by norm_num), ENNReal.toReal_ofReal (by norm_num)]
-  exact (ENNReal.ofReal_lt_ofReal_iff (Real.exp_pos _)).mpr
-    (Real.exp_lt_exp.mpr (by norm_num))
-
--- §13d. Capstone: σ_bU is the best speaker model
-
-/-- σ_bU uniquely predicts "blue" > "circle" for blue_circle.
-
-    The blue_circle observation is the decisive test: 119/144 speakers chose "blue"
-    over "circle" (Table 1). σ_bU is the only model that predicts this:
-    - σ_bU: blue > circle (correct) — log transform amplifies informativity
-    - σ_aU: blue = circle (tie) — raw probability and cost exactly cancel
-    - σ_bS: circle > blue (reversal) — salience makes "circle" informative
-    - σ_aS: circle > blue (reversal) — same salience effect
-
-    This is Q&F's main speaker-side finding: standard RSA (belief-oriented,
-    uniform L0) best explains production data. -/
-theorem σ_bU_best_speaker_model :
-    -- σ_bU correctly predicts blue > circle
-    (s1Cost .blue_circle .blue > s1Cost .blue_circle .circle) ∧
-    -- σ_aU ties: neither blue > circle nor circle > blue
-    (¬(s1AU .blue_circle .blue > s1AU .blue_circle .circle) ∧
-     ¬(s1AU .blue_circle .circle > s1AU .blue_circle .blue)) ∧
-    -- σ_bS reverses: circle > blue
-    (s1BS .blue_circle .circle > s1BS .blue_circle .blue) ∧
-    -- σ_aS reverses: circle > blue
-    (s1AS .blue_circle .circle > s1AS .blue_circle .blue) :=
-  ⟨speaker_prefers_unique_color, σ_aU_blue_circ_tie,
-   σ_bS_blue_circ_reversal, σ_aS_blue_circ_reversal⟩
-
--- ============================================================================
--- §14. Verification
--- ============================================================================
-
--- ============================================================================
--- §15. λ-Independence of Speaker Rankings
--- ============================================================================
-
-/-! The speaker ranking under both belief-oriented and action-oriented scoring
-is **completely independent of λ** (the rationality parameter). Since `exp`
-is strictly monotone and multiplication by λ > 0 preserves strict order:
-
-    exp(λ · a) > exp(λ · b) ⟺ a > b (for λ > 0)
-
-**Consequence**: The qualitative predictions (findings 1–4) hold for ALL λ > 0.
-The paper's strong rejection of λ = 1 (§5) affects only the *magnitude* of
-preferences (softmax temperature), not their *direction*. The PMF-face
-proofs at λ = 1 establish log(L0) − cost orderings that hold at every
-positive λ.
-
-Cost thresholds (the exact c ranges where each finding holds):
-- **Finding 1** (sq > gr for green_sq): all c ≥ 0 (log 1 − 0 > log ½ − c)
-- **Finding 2** (bl > ci for blue_circ): c < ln 2 ≈ 0.693 (see §16)
-- **Finding 3** (ci > gr for green_circ): all c > 0 (log ½ − 0 > log ½ − c)
-- **Finding 4** (ci = gr, no cost): equality, independent of everything -/
-
-/-- Belief-oriented score ranking reduces to log L0 minus cost, independent of λ.
-
-    For two truthful utterances (l0 ≠ 0 for both), the beliefGoalScore comparison
-    is equivalent to comparing `log L0 − cost`, which has no λ dependence.
-    Combined with `RationalAction.policy_gt_of_score_gt`, this means all
-    qualitative belief-oriented S1 predictions are λ-independent. -/
-theorem beliefGoal_gt_iff
-    (cost : Utterance → ℝ) (l0 : Utterance → Object → ℝ)
-    (u₁ u₂ : Utterance) (w : Object)
-    {α : ℝ} (hα : 0 < α)
-    (h1 : l0 u₁ w ≠ 0) (h2 : l0 u₂ w ≠ 0) :
-    beliefGoalScore cost l0 α () w u₁ > beliefGoalScore cost l0 α () w u₂ ↔
-    log (l0 u₁ w) - cost u₁ > log (l0 u₂ w) - cost u₂ := by
-  simp only [beliefGoalScore, if_neg h1, if_neg h2]
-  exact ⟨fun h => lt_of_mul_lt_mul_left (exp_lt_exp.mp h) (le_of_lt hα),
-         fun h => exp_lt_exp.mpr (mul_lt_mul_of_pos_left h hα)⟩
-
-/-- Action-oriented score ranking reduces to L0 minus cost, independent of λ.
-
-    Same λ-independence as belief-oriented, but comparing raw L0 rather than
-    log L0. The difference between σ_a and σ_b is not λ-sensitivity (both are
-    λ-independent) but how they *transform* L0: log compresses the informativity
-    scale, amplifying small differences in L0 posterior. -/
-theorem actionGoal_gt_iff
-    (cost : Utterance → ℝ) (l0 : Utterance → Object → ℝ)
-    (u₁ u₂ : Utterance) (w : Object)
-    {α : ℝ} (hα : 0 < α) :
-    actionGoalScore cost l0 α () w u₁ > actionGoalScore cost l0 α () w u₂ ↔
-    l0 u₁ w - cost u₁ > l0 u₂ w - cost u₂ := by
-  simp only [actionGoalScore]
-  exact ⟨fun h => lt_of_mul_lt_mul_left (exp_lt_exp.mp h) (le_of_lt hα),
-         fun h => exp_lt_exp.mpr (mul_lt_mul_of_pos_left h hα)⟩
-
--- ============================================================================
--- §16. Cost Thresholds
--- ============================================================================
-
-/-! The σ_aU tie at c = 1/2 (§13a) is the **exact boundary**: σ_aU predicts
-"blue" > "circle" for blue_circle iff c < 1/2. Action-oriented scoring uses
-raw L0: 1 − c > 1/2 − 0 ⟺ c < 1/2.
-
-Belief-oriented scoring (σ_bU) uses log L0, giving a wider threshold of
-c < ln 2 ≈ 0.693: log 1 − c > log(1/2) − 0 ⟺ c < ln 2.
-
-Figure 4 shows that the posterior over c for σ_bU peaks around c ≈ 0.15,
-well below the ln 2 ≈ 0.693 threshold. So the MAP cost estimate is
-consistent with σ_bU correctly predicting blue > circle. -/
-
-/-- σ_aU cost threshold for blue_circle: "blue" > "circle" ⟺ c < 1/2.
-
-    Given L0(blue_circ|"blue") = 1 and L0(blue_circ|"circle") = 1/2,
-    the action-oriented comparison reduces to 1 − c > 1/2. The existing tie
-    `σ_aU_blue_circ_tie` is the corollary at c = 1/2. -/
-theorem σ_aU_blue_circ_threshold
-    {l0 : Utterance → Object → ℝ} {c : ℝ} {α : ℝ} (hα : 0 < α)
-    (hbl : l0 .blue .blue_circle = 1) (hci : l0 .circle .blue_circle = 1/2) :
-    actionGoalScore (adjCost c) l0 α () .blue_circle .blue >
-    actionGoalScore (adjCost c) l0 α () .blue_circle .circle ↔ c < 1/2 := by
-  rw [actionGoal_gt_iff _ _ _ _ _ hα]
-  simp only [hbl, hci, adjCost]
-  constructor <;> intro h <;> linarith
-
-/-- σ_bU cost threshold for blue_circle: "blue" > "circle" ⟺ c < ln 2.
-
-    Belief-oriented scoring uses log, so the threshold is wider than σ_aU's
-    (ln 2 ≈ 0.693 > 0.5). This explains why σ_bU accommodates cost better
-    than σ_aU: the log transform amplifies informativity differences,
-    leaving more room for cost before the ranking flips. -/
-theorem σ_bU_blue_circ_threshold
-    {l0 : Utterance → Object → ℝ} {c : ℝ} {α : ℝ} (hα : 0 < α)
-    (hbl : l0 .blue .blue_circle = 1) (hci : l0 .circle .blue_circle = 1/2)
-    (hbl_ne : l0 .blue .blue_circle ≠ 0) (hci_ne : l0 .circle .blue_circle ≠ 0) :
-    beliefGoalScore (adjCost c) l0 α () .blue_circle .blue >
-    beliefGoalScore (adjCost c) l0 α () .blue_circle .circle ↔ c < log 2 := by
-  rw [beliefGoal_gt_iff _ _ _ _ _ hα hbl_ne hci_ne]
-  simp only [hbl, hci, adjCost, Real.log_one]
-  have hlog : log ((1:ℝ) / 2) = -log 2 := by rw [one_div, Real.log_inv]
-  rw [hlog]
-  constructor <;> intro h <;> linarith
-
--- ============================================================================
--- §17. Raw Experimental Data (Tables 1–2)
--- ============================================================================
-
-/-! Production and comprehension counts from the experiment (N = 1032 total:
-432 speakers, 600 listeners). These connect model predictions to empirical
-observations. -/
-
-/-- Speaker production data from Table 1 (N = 144 per target object).
-
-    - green_square: 135 "square", 9 "green" (93.8% unique shape)
-    - blue_circle: 119 "blue", 25 "circle" (82.6% unique color)
-    - green_circle: 81 "circle", 63 "green" (56.3% preferred noun; n.s.) -/
+/-- "square" and "blue" each denote a single object; "circle" and "green"
+are two-ways ambiguous. -/
+theorem extension_characterization (w : Object) :
+    (Utterance.appliesTo .square w = true ↔ w = .green_square) ∧
+    (Utterance.appliesTo .blue w = true ↔ w = .blue_circle) ∧
+    (Utterance.appliesTo .circle w = true ↔ w ≠ .green_square) ∧
+    (Utterance.appliesTo .green w = true ↔ w ≠ .blue_circle) := by
+  cases w <;> decide
+
+/-! ### Empirical data (Tables 1–2) -/
+
+/-- Speaker production data (Table 1, N = 144 per target). -/
 def speakerData : Object → Utterance → Nat
   | .green_square, .square => 135
   | .green_square, .green  => 9
@@ -1121,10 +110,7 @@ def speakerData : Object → Utterance → Nat
   | .green_circle, .green  => 63
   | _, _                    => 0
 
-/-- Listener comprehension data from Table 2 (N = 180 per ambiguous utterance).
-
-    - "circle": 117 blue_circle, 62 green_circle, 1 green_square (65% salience)
-    - "green": 65 green_square, 115 green_circle (64% pragmatic direction) -/
+/-- Listener comprehension data (Table 2, N = 180 per ambiguous utterance). -/
 def listenerData : Utterance → Object → Nat
   | .circle, .blue_circle  => 117
   | .circle, .green_circle => 62
@@ -1132,6 +118,17 @@ def listenerData : Utterance → Object → Nat
   | .green,  .green_square => 65
   | .green,  .green_circle => 115
   | _, _                    => 0
+
+/-- Salience prior: the salience condition of Table 2 (N = 240), the
+paper's empirical estimate of `S(t)`. -/
+def saliencePrior : Object → ℝ
+  | .green_square => 71
+  | .blue_circle  => 139
+  | .green_circle => 30
+
+/-- Uniform prior. -/
+def uniformPrior : Object → ℝ
+  | _ => 1
 
 /-- Speaker data sums to N = 144 per target. -/
 theorem speakerData_consistent :
@@ -1147,135 +144,441 @@ theorem listenerData_consistent :
     listenerData .green .green_square + listenerData .green .green_circle = 180 :=
   ⟨rfl, rfl⟩
 
-/-- Speaker majority choice agrees with σ_bU S1 ranking (findings 1–3). -/
+/-! ### Speaker goal types
+
+The goal dimension (eqs. 9–10), generic in the literal listener and λ. -/
+
+/-- Adjective cost (eq. 11): shape words cost 0, color words cost `c`. -/
+noncomputable def adjCost (c : ℝ) : Utterance → ℝ
+  | .square | .circle => 0
+  | .green  | .blue   => c
+
+/-- Belief-oriented S1 score (eq. 10): `exp (λ (log L0 − Cost))`, gated at
+false utterances (Lean's `log 0 = 0` would otherwise leak mass). -/
+noncomputable def beliefGoalScore (cost : Utterance → ℝ)
+    (l0 : Utterance → Object → ℝ) (α : ℝ) (w : Object) (u : Utterance) : ℝ :=
+  if l0 u w = 0 then 0 else exp (α * (log (l0 u w) - cost u))
+
+/-- Action-oriented S1 score (eq. 9): `exp (λ (L0 − Cost))` — positive even
+on false utterances (the paper's fn. 7 restricts comparisons to truthful
+ones). -/
+noncomputable def actionGoalScore (cost : Utterance → ℝ)
+    (l0 : Utterance → Object → ℝ) (α : ℝ) (w : Object) (u : Utterance) : ℝ :=
+  exp (α * (l0 u w - cost u))
+
+/-- Belief-oriented ranking is λ-independent: it compares `log L0 − cost`. -/
+theorem beliefGoal_gt_iff (cost : Utterance → ℝ) (l0 : Utterance → Object → ℝ)
+    (u₁ u₂ : Utterance) (w : Object) {α : ℝ} (hα : 0 < α)
+    (h1 : l0 u₁ w ≠ 0) (h2 : l0 u₂ w ≠ 0) :
+    beliefGoalScore cost l0 α w u₁ > beliefGoalScore cost l0 α w u₂ ↔
+    log (l0 u₁ w) - cost u₁ > log (l0 u₂ w) - cost u₂ := by
+  simp only [beliefGoalScore, if_neg h1, if_neg h2]
+  exact ⟨fun h => lt_of_mul_lt_mul_left (exp_lt_exp.mp h) hα.le,
+         fun h => exp_lt_exp.mpr (mul_lt_mul_of_pos_left h hα)⟩
+
+/-- Action-oriented ranking is λ-independent: it compares `L0 − cost`. -/
+theorem actionGoal_gt_iff (cost : Utterance → ℝ) (l0 : Utterance → Object → ℝ)
+    (u₁ u₂ : Utterance) (w : Object) {α : ℝ} (hα : 0 < α) :
+    actionGoalScore cost l0 α w u₁ > actionGoalScore cost l0 α w u₂ ↔
+    l0 u₁ w - cost u₁ > l0 u₂ w - cost u₂ := by
+  simp only [actionGoalScore]
+  exact ⟨fun h => lt_of_mul_lt_mul_left (exp_lt_exp.mp h) hα.le,
+         fun h => exp_lt_exp.mpr (mul_lt_mul_of_pos_left h hα)⟩
+
+/-! ### The belief-oriented chain, parametric in the cost factor
+
+At λ = 1, `exp (log L0 − c) = L0 · exp (−c)`, so the whole σ_b chain is
+rational in the cost factor `k = exp (−c)`: `k = 1` is zero cost, `k < 1`
+a noun preference, and thresholds in `k` translate back to cost bounds
+(`k > 1/2` ↔ `c < ln 2`). -/
+
+/-- Multiplicative cost factor: `1` on shape words, `k` on color words. -/
+def cf (k : ℝ) : Utterance → ℝ
+  | .square | .circle => 1
+  | .green  | .blue   => k
+
+/-- Literal listener at prior `p` (eq. 1): prior conditioned on the
+extension. -/
+noncomputable def l0 (p : Object → ℝ) (u : Utterance) (w : Object) : ℝ :=
+  (if u.appliesTo w then p w else 0) /
+    ∑ w', if u.appliesTo w' then p w' else 0
+
+/-- Belief-oriented speaker weight at λ = 1: `L0 · k^cost`. -/
+noncomputable def sbScore (p : Object → ℝ) (k : ℝ) (w : Object)
+    (u : Utterance) : ℝ :=
+  l0 p u w * cf k u
+
+/-- Belief-oriented speaker (eq. 10). -/
+noncomputable def s1 (p : Object → ℝ) (k : ℝ) (w : Object) : PMF Utterance :=
+  PMF.normalizeOrUniform fun u => ENNReal.ofReal (sbScore p k w u)
+
+/-- Pragmatic-listener score (eqs. 12–13): the listener's own prior times
+the σ_bU speaker (the paper's best-supported speaker model). -/
+noncomputable def l1Score (prior : Object → ℝ) (k : ℝ) (u : Utterance)
+    (w : Object) : ℝ :=
+  prior w * (sbScore uniformPrior k w u / ∑ u', sbScore uniformPrior k w u')
+
+/-- Pragmatic listener (eq. 6). -/
+noncomputable def l1 (prior : Object → ℝ) (k : ℝ) (u : Utterance) :
+    PMF Object :=
+  PMF.normalizeOrUniform fun w => ENNReal.ofReal (l1Score prior k u w)
+
+private theorem sumU (f : Utterance → ℝ) :
+    ∑ u, f u = f .square + f .circle + f .green + f .blue := by
+  rw [show (Finset.univ : Finset Utterance) = {.square, .circle, .green, .blue}
+      from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  ring
+
+private theorem sumO (f : Object → ℝ) :
+    ∑ w, f w = f .green_square + f .blue_circle + f .green_circle := by
+  rw [show (Finset.univ : Finset Object)
+      = {.green_square, .blue_circle, .green_circle} from rfl,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_singleton]
+  ring
+
+section Parametric
+
+variable {k : ℝ}
+
+/-- The σ_bU weights, symbolically in k. -/
+private theorem sbScore_values :
+    sbScore uniformPrior k .green_square .square = 1 ∧
+    sbScore uniformPrior k .green_square .green = k/2 ∧
+    sbScore uniformPrior k .green_square .circle = 0 ∧
+    sbScore uniformPrior k .green_square .blue = 0 ∧
+    sbScore uniformPrior k .green_circle .circle = 1/2 ∧
+    sbScore uniformPrior k .green_circle .green = k/2 ∧
+    sbScore uniformPrior k .green_circle .square = 0 ∧
+    sbScore uniformPrior k .green_circle .blue = 0 ∧
+    sbScore uniformPrior k .blue_circle .blue = k ∧
+    sbScore uniformPrior k .blue_circle .circle = 1/2 ∧
+    sbScore uniformPrior k .blue_circle .square = 0 ∧
+    sbScore uniformPrior k .blue_circle .green = 0 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    · simp only [sbScore, l0, cf, uniformPrior, sumO, Utterance.appliesTo]
+      norm_num
+      try ring
+
+private theorem sbScore_nonneg (hk : 0 ≤ k) (p : Object → ℝ)
+    (hp : ∀ w, 0 ≤ p w) (w : Object) (u : Utterance) :
+    0 ≤ sbScore p k w u := by
+  refine mul_nonneg (div_nonneg ?_ (Finset.sum_nonneg fun w' _ => ?_)) ?_
+  · split
+    exacts [hp _, le_rfl]
+  · split
+    exacts [hp _, le_rfl]
+  · cases u <;> simp only [cf] <;> first | exact zero_le_one | exact hk
+
+/-- Same-target speaker comparison: reduces to the raw weights. -/
+private theorem s1_lt (p : Object → ℝ) (hk : 0 ≤ k) (hp : ∀ w, 0 ≤ p w)
+    {w : Object} {u₁ u₂ : Utterance}
+    (hpos : 0 < ∑ u, sbScore p k w u)
+    (h : sbScore p k w u₁ < sbScore p k w u₂) :
+    s1 p k w u₁ < s1 p k w u₂ := by
+  unfold s1
+  exact PMF.normalizeOrUniform_ofReal_lt_cross (sbScore_nonneg hk p hp w)
+    (sbScore_nonneg hk p hp w) hpos hpos (div_lt_div_of_pos_right h hpos)
+
+private theorem l1Score_nonneg (hk : 0 ≤ k) (prior : Object → ℝ)
+    (hp : ∀ w, 0 ≤ prior w) (u : Utterance) (w : Object) :
+    0 ≤ l1Score prior k u w :=
+  mul_nonneg (hp w) (div_nonneg
+    (sbScore_nonneg hk uniformPrior (fun _ => zero_le_one) w u)
+    (Finset.sum_nonneg fun u' _ =>
+      sbScore_nonneg hk uniformPrior (fun _ => zero_le_one) w u'))
+
+/-- Same-utterance listener comparison: reduces to the scores. -/
+private theorem l1_lt (prior : Object → ℝ) (hk : 0 ≤ k)
+    (hp : ∀ w, 0 ≤ prior w) {u : Utterance} {w₁ w₂ : Object}
+    (hpos : 0 < ∑ w, l1Score prior k u w)
+    (h : l1Score prior k u w₁ < l1Score prior k u w₂) :
+    l1 prior k u w₁ < l1 prior k u w₂ := by
+  unfold l1
+  exact PMF.normalizeOrUniform_ofReal_lt_cross (l1Score_nonneg hk prior hp u)
+    (l1Score_nonneg hk prior hp u) hpos hpos (div_lt_div_of_pos_right h hpos)
+
+/-! ### Speaker predictions (Table 1 directions) -/
+
+/-- For the green square, σ_bU prefers the unique "square" over the
+ambiguous "green" at every cost factor k < 2 (135/144 speakers, Table 1). -/
+theorem speaker_prefers_unique_shape (hk : 0 ≤ k) (hk2 : k < 2) :
+    s1 uniformPrior k .green_square .green <
+      s1 uniformPrior k .green_square .square := by
+  obtain ⟨h1, h2, h3, h4, -⟩ := sbScore_values (k := k)
+  exact s1_lt uniformPrior hk (fun _ => zero_le_one)
+    (by rw [sumU, h1, h2, h3, h4]; linarith) (by rw [h1, h2]; linarith)
+
+/-- For the blue circle, σ_bU prefers the unique "blue" over "circle" once
+the cost factor exceeds 1/2 (c < ln 2); 119/144 speakers chose "blue". -/
+theorem speaker_prefers_unique_color (hk : 1/2 < k) :
+    s1 uniformPrior k .blue_circle .circle <
+      s1 uniformPrior k .blue_circle .blue := by
+  obtain ⟨-, -, -, -, -, -, -, -, h9, h10, h11, h12⟩ := sbScore_values (k := k)
+  exact s1_lt uniformPrior (by linarith) (fun _ => zero_le_one)
+    (by rw [sumU, h9, h10, h11, h12]; linarith) (by rw [h9, h10]; linarith)
+
+/-- For the green circle, cost is the tiebreaker: any noun preference
+(k < 1) favors "circle" over "green" (81 vs 63, Table 1, n.s.). -/
+theorem cost_breaks_symmetry (hk : 0 < k) (hk1 : k < 1) :
+    s1 uniformPrior k .green_circle .green <
+      s1 uniformPrior k .green_circle .circle := by
+  obtain ⟨-, -, -, -, h5, h6, h7, h8, -⟩ := sbScore_values (k := k)
+  exact s1_lt uniformPrior hk.le (fun _ => zero_le_one)
+    (by rw [sumU, h5, h6, h7, h8]; linarith) (by rw [h5, h6]; linarith)
+
+/-- Without cost (k = 1) the green-circle tie is unbroken: Q1 alone cannot
+distinguish two equally informative words. -/
+theorem no_cost_symmetry :
+    sbScore uniformPrior 1 .green_circle .circle =
+      sbScore uniformPrior 1 .green_circle .green := by
+  simp only [sbScore, l0, cf, uniformPrior, sumO, Utterance.appliesTo]
+  norm_num
+
+/-- σ_bU with any noun preference in (1/2, 1) — covering the paper's whole
+positive-cost support c ∈ (0, 0.4] — matches all three Table-1 majority
+directions. -/
+theorem σ_bU_matches_speaker_data (hk : 1/2 < k) (hk1 : k < 1) :
+    (s1 uniformPrior k .green_square .green <
+      s1 uniformPrior k .green_square .square) ∧
+    (s1 uniformPrior k .blue_circle .circle <
+      s1 uniformPrior k .blue_circle .blue) ∧
+    (s1 uniformPrior k .green_circle .green <
+      s1 uniformPrior k .green_circle .circle) :=
+  ⟨speaker_prefers_unique_shape (by linarith) (by linarith),
+   speaker_prefers_unique_color hk, cost_breaks_symmetry (by linarith) hk1⟩
+
+/-! ### Listener predictions: the salience reversal (Tables 2 and 4)
+
+Both listeners embed the same σ_bU speaker and differ only in their prior
+(eqs. 12–13). The reversals hold at **every** k > 0: they are pure prior
+effects, independent of the cost regime. -/
+
+/-- The listener scores at the contested cells, symbolically in k. -/
+private theorem l1Score_values (hk : 0 < k) :
+    l1Score uniformPrior k .circle .green_circle = 1/(1 + k) ∧
+    l1Score uniformPrior k .circle .blue_circle = 1/(1 + 2*k) ∧
+    l1Score saliencePrior k .circle .green_circle = 30/(1 + k) ∧
+    l1Score saliencePrior k .circle .blue_circle = 139/(1 + 2*k) ∧
+    l1Score uniformPrior k .green .green_square = k/(2 + k) ∧
+    l1Score uniformPrior k .green .green_circle = k/(1 + k) ∧
+    l1Score saliencePrior k .green .green_square = 71*k/(2 + k) ∧
+    l1Score saliencePrior k .green .green_circle = 30*k/(1 + k) := by
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12⟩ :=
+    sbScore_values (k := k)
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    · unfold l1Score
+      rw [sumU]
+      first
+        | rw [h5, h6, h7, h8] | rw [h9, h10, h11, h12] | rw [h1, h2, h3, h4]
+      simp only [uniformPrior, saliencePrior]
+      rw [mul_div_assoc', div_eq_div_iff (by linarith) (by linarith)]
+      ring
+
+/-- Uniform-prior listener, "circle": pragmatic narrowing favors the green
+circle (a blue-circle speaker had "blue"), at every k > 0. -/
+theorem uniform_circle_green_circ (hk : 0 < k) :
+    l1 uniformPrior k .circle .blue_circle <
+      l1 uniformPrior k .circle .green_circle := by
+  obtain ⟨h1, h2, -⟩ := l1Score_values hk
+  have hgs : (0:ℝ) ≤ l1Score uniformPrior k .circle .green_square :=
+    l1Score_nonneg hk.le _ (fun _ => zero_le_one) _ _
+  refine l1_lt uniformPrior hk.le (fun _ => zero_le_one) ?_ ?_
+  · rw [sumO, h1, h2]
+    have : (0:ℝ) < 1/(1 + k) := by positivity
+    have : (0:ℝ) < 1/(1 + 2*k) := by positivity
+    linarith
+  · rw [h1, h2, div_lt_div_iff₀ (by linarith) (by linarith)]
+    linarith
+
+/-- Salience-prior listener, "circle": salience (139 vs 30) overrides the
+pragmatic direction, at every k > 0. Matches Table 2 (117/180 blue). -/
+theorem salience_circle_blue_circ (hk : 0 < k) :
+    l1 saliencePrior k .circle .green_circle <
+      l1 saliencePrior k .circle .blue_circle := by
+  obtain ⟨-, -, h3, h4, -⟩ := l1Score_values hk
+  have hp : ∀ w, 0 ≤ saliencePrior w := by
+    intro w; cases w <;> simp [saliencePrior]
+  have hgs : (0:ℝ) ≤ l1Score saliencePrior k .circle .green_square :=
+    l1Score_nonneg hk.le _ hp _ _
+  refine l1_lt saliencePrior hk.le hp ?_ ?_
+  · rw [sumO, h3, h4]
+    have : (0:ℝ) < 30/(1 + k) := by positivity
+    have : (0:ℝ) < 139/(1 + 2*k) := by positivity
+    linarith
+  · rw [h3, h4, div_lt_div_iff₀ (by linarith) (by linarith)]
+    nlinarith
+
+/-- Finding 5: the salience reversal for "circle", at every k > 0. The
+human data follow the salience direction. -/
+theorem salience_reversal_circle (hk : 0 < k) :
+    (l1 uniformPrior k .circle .blue_circle <
+      l1 uniformPrior k .circle .green_circle) ∧
+    (l1 saliencePrior k .circle .green_circle <
+      l1 saliencePrior k .circle .blue_circle) :=
+  ⟨uniform_circle_green_circ hk, salience_circle_blue_circ hk⟩
+
+/-- Uniform-prior listener, "green": pragmatic narrowing favors the green
+circle (a green-square speaker had "square"), at every k > 0. -/
+theorem uniform_green_green_circ (hk : 0 < k) :
+    l1 uniformPrior k .green .green_square <
+      l1 uniformPrior k .green .green_circle := by
+  obtain ⟨-, -, -, -, h5, h6, -⟩ := l1Score_values hk
+  have hbc : (0:ℝ) ≤ l1Score uniformPrior k .green .blue_circle :=
+    l1Score_nonneg hk.le _ (fun _ => zero_le_one) _ _
+  refine l1_lt uniformPrior hk.le (fun _ => zero_le_one) ?_ ?_
+  · rw [sumO, h5, h6]
+    have : (0:ℝ) < k/(2 + k) := by positivity
+    have : (0:ℝ) < k/(1 + k) := by positivity
+    linarith
+  · rw [h5, h6, div_lt_div_iff₀ (by linarith) (by linarith)]
+    nlinarith
+
+/-- Salience-prior listener, "green": salience (71 vs 30) overrides the
+pragmatic direction, at every k > 0. Here the humans go the *other* way
+(115/180 green circle, Table 2; p. 212). -/
+theorem salience_green_green_sq (hk : 0 < k) :
+    l1 saliencePrior k .green .green_circle <
+      l1 saliencePrior k .green .green_square := by
+  obtain ⟨-, -, -, -, -, -, h7, h8⟩ := l1Score_values hk
+  have hp : ∀ w, 0 ≤ saliencePrior w := by
+    intro w; cases w <;> simp [saliencePrior]
+  have hbc : (0:ℝ) ≤ l1Score saliencePrior k .green .blue_circle :=
+    l1Score_nonneg hk.le _ hp _ _
+  refine l1_lt saliencePrior hk.le hp ?_ ?_
+  · rw [sumO, h7, h8]
+    have : (0:ℝ) < 71*k/(2 + k) := by positivity
+    have : (0:ℝ) < 30*k/(1 + k) := by positivity
+    linarith
+  · rw [h7, h8, div_lt_div_iff₀ (by linarith) (by linarith)]
+    nlinarith
+
+/-- Finding 6: the salience reversal for "green", at every k > 0. The human
+data follow the *pragmatic* direction — no single listener prior gets both
+"circle" and "green" right. -/
+theorem salience_reversal_green (hk : 0 < k) :
+    (l1 uniformPrior k .green .green_square <
+      l1 uniformPrior k .green .green_circle) ∧
+    (l1 saliencePrior k .green .green_circle <
+      l1 saliencePrior k .green .green_square) :=
+  ⟨uniform_green_green_circ hk, salience_green_green_sq hk⟩
+
+/-! ### The salience-belief speaker: thresholds inside the cost support
+
+σ_bS replaces the speaker's literal-listener prior with the salience data
+(eq. 7). Its blue-circle and green-circle predictions flip at k = 139/169
+and k = 101/169 — both *inside* the paper's cost support (c ∈ (0, 0.4) is
+k ∈ (0.67, 1)) — so that model's content is a pair of thresholds, not
+directions. -/
+
+/-- σ_bS weights at the contested cells: `L0` conditions the salience
+prior on the extension. -/
+private theorem sbS_values :
+    sbScore saliencePrior k .blue_circle .blue = k ∧
+    sbScore saliencePrior k .blue_circle .circle = 139/169 ∧
+    sbScore saliencePrior k .green_circle .green = 30/101 * k ∧
+    sbScore saliencePrior k .green_circle .circle = 30/169 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;>
+    · simp only [sbScore, l0, cf, saliencePrior, sumO, Utterance.appliesTo]
+      norm_num
+
+/-- σ_bS prefers "blue" at the blue circle iff k > 139/169. -/
+theorem σ_bS_blue_circ_iff :
+    sbScore saliencePrior k .blue_circle .circle <
+      sbScore saliencePrior k .blue_circle .blue ↔ 139/169 < k := by
+  obtain ⟨h1, h2, -⟩ := sbS_values (k := k)
+  rw [h1, h2]
+
+/-- σ_bS prefers "green" at the green circle iff k > 101/169. -/
+theorem σ_bS_green_circ_iff :
+    sbScore saliencePrior k .green_circle .circle <
+      sbScore saliencePrior k .green_circle .green ↔ 101/169 < k := by
+  obtain ⟨-, -, h3, h4⟩ := sbS_values (k := k)
+  rw [h3, h4]
+  constructor <;> intro h <;> nlinarith
+
+end Parametric
+
+/-! ### Cost thresholds across the goal dimension
+
+The blue-circle boundary separates the goal types: action-oriented scoring
+flips at c = 1/2, belief-oriented at c = ln 2 ≈ 0.693 — the log transform
+amplifies informativity differences, widening the viable cost range.
+Figure 3's posterior over c peaks well below both. -/
+
+/-- σ_aU threshold: "blue" > "circle" at the blue circle iff c < 1/2; the
+σ_aU tie at c = 1/2 is the boundary case. -/
+theorem σ_aU_blue_circ_threshold
+    {l0 : Utterance → Object → ℝ} {c : ℝ} {α : ℝ} (hα : 0 < α)
+    (hbl : l0 .blue .blue_circle = 1) (hci : l0 .circle .blue_circle = 1/2) :
+    actionGoalScore (adjCost c) l0 α .blue_circle .blue >
+    actionGoalScore (adjCost c) l0 α .blue_circle .circle ↔ c < 1/2 := by
+  rw [actionGoal_gt_iff _ _ _ _ _ hα]
+  simp only [hbl, hci, adjCost]
+  constructor <;> intro h <;> linarith
+
+/-- σ_bU threshold: "blue" > "circle" at the blue circle iff c < ln 2 —
+the exponentiated form of `speaker_prefers_unique_color`'s k > 1/2. -/
+theorem σ_bU_blue_circ_threshold
+    {l0 : Utterance → Object → ℝ} {c : ℝ} {α : ℝ} (hα : 0 < α)
+    (hbl : l0 .blue .blue_circle = 1) (hci : l0 .circle .blue_circle = 1/2)
+    (hbl_ne : l0 .blue .blue_circle ≠ 0) (hci_ne : l0 .circle .blue_circle ≠ 0) :
+    beliefGoalScore (adjCost c) l0 α .blue_circle .blue >
+    beliefGoalScore (adjCost c) l0 α .blue_circle .circle ↔ c < log 2 := by
+  rw [beliefGoal_gt_iff _ _ _ _ _ hα hbl_ne hci_ne]
+  simp only [hbl, hci, adjCost, Real.log_one]
+  have hlog : log ((1:ℝ) / 2) = -log 2 := by rw [one_div, Real.log_inv]
+  rw [hlog]
+  constructor <;> intro h <;> linarith
+
+/-! ### Data–model match -/
+
+/-- Speaker majority choices match the σ_bU rankings (Table 1). -/
 theorem speakerData_matches_model :
     speakerData .green_square .square > speakerData .green_square .green ∧
     speakerData .blue_circle .blue > speakerData .blue_circle .circle ∧
     speakerData .green_circle .circle > speakerData .green_circle .green :=
   ⟨by decide, by decide, by decide⟩
 
-/-- For "circle", listener majority matches the salience L1 direction (finding 5):
-    blue_circle (117) > green_circle (62). -/
+/-- For "circle", the listener majority follows the salience direction
+(117 vs 62). -/
 theorem listenerData_circle_matches_salience :
-    listenerData .circle .blue_circle > listenerData .circle .green_circle :=
-  by decide
+    listenerData .circle .blue_circle > listenerData .circle .green_circle := by
+  decide
 
-/-- For "green", listener majority matches the pragmatic/uniform L1 direction,
-    NOT the salience direction: green_circle (115) > green_square (65).
-    The paper notes this explicitly (p. 212). -/
+/-- For "green", the listener majority follows the pragmatic direction, not
+salience (115 vs 65; p. 212). -/
 theorem listenerData_green_matches_pragmatic :
-    listenerData .green .green_circle > listenerData .green .green_square :=
-  by decide
+    listenerData .green .green_circle > listenerData .green .green_square := by
+  decide
 
--- ============================================================================
--- §18. FG2012 Bridge
--- ============================================================================
+/-! ### Bridges -/
 
-/-! σ_bU with zero cost IS [frank-goodman-2012]'s model. FG2012 defines:
-
-    s1Score l0 α _ w u := if l0 u w = 0 then 0 else exp(α * log(l0 u w))
-
-which equals `beliefGoalScore (fun _ => 0)` since `x − 0 = x` (`sub_zero`).
-
-FG2012 uses multiple reference game contexts across 7 conditions; Q&F's
-experiment (§4) focuses on one configuration: {green_square, green_circle,
-blue_circle}. The scoring rule and compositional pattern are identical —
-Q&F's contribution is decomposing along the cost, goal, and salience
-dimensions. -/
-
-/-- Zero-cost belief-oriented scoring equals FG2012's scoring rule.
-
-    `beliefGoalScore (fun _ => 0)` reduces to `if l0 = 0 then 0 else exp(α * log l0)`
-    by `sub_zero`. This is the formal statement that σ_bU generalizes FG2012
-    by adding utterance cost — setting cost to zero recovers the original model. -/
+/-- At zero cost the belief-oriented score is [frank-goodman-2012]'s
+scoring rule — σ_bU generalizes FG2012 by the cost dimension. -/
 theorem zeroCost_beliefGoal_eq
     (l0 : Utterance → Object → ℝ) (α : ℝ) (w : Object) (u : Utterance) :
-    beliefGoalScore (fun _ => (0 : ℝ)) l0 α () w u =
+    beliefGoalScore (fun _ => (0 : ℝ)) l0 α w u =
     if l0 u w = 0 then 0 else exp (α * log (l0 u w)) := by
   simp [beliefGoalScore, sub_zero]
 
-/-!
-## Summary: the model on the PMF face
-
-1. **Two speaker goals, one chain shape**: the belief-oriented speakers are
-   `RSA.S1Belief` (weights `L0 · exp(−Cost)`, eq. 10 at λ = 1); the
-   action-oriented speakers are a local softmax over `exp(L0 − Cost)`
-   (eq. 9) — positive on false utterances, which is exactly what produces
-   the σ_aU tie at the blue circle.
-
-2. **Speaker belief enters as the L0 prior**: uniform vs salience-weighted
-   literal listeners are the same `L0LassiterGoodman` construction at
-   different priors (`qfPriorU`/`qfPriorS`).
-
-3. **Independent listener prior**: `l1Cost` and `l1Sal` share the σ_bU
-   speaker and differ only in the posterior's world prior (eqs. 12–13) —
-   the salience-reversal findings are pure prior effects.
-
-4. **Sharp cost regime**: the three genuinely numeric findings need only
-   `exp(−1/2) > 1/2` (e < 4), `exp(−1/2) < 139/169`, and
-   `exp(−1/2) > 101/169` (e < (169/101)² ≈ 2.7998) — all discharged from
-   `Real.exp_one_lt_d9`/`gt_d9`; everything else is generic in the cost
-   factor.
-
-5. **λ-independence** (§15): `beliefGoal_gt_iff` and `actionGoal_gt_iff` prove
-   that speaker rankings depend only on `log L0 − cost` (or `L0 − cost`),
-   not on the rationality parameter λ. The paper's rejection of λ = 1 affects
-   only quantitative fit, not qualitative predictions.
-
-8. **Cost thresholds** (§16): `σ_aU_blue_circ_threshold` (c < 1/2) and
-   `σ_bU_blue_circ_threshold` (c < ln 2) give the exact cost boundaries
-   for each model's blue_circle prediction. The log transform in σ_bU
-   widens the viable cost range.
-
-9. **Raw data** (§17): `speakerData` and `listenerData` formalize Tables 1–2.
-   `speakerData_matches_model` verifies that speaker majority choices match
-   σ_bU predictions. `listenerData_circle_matches_salience` confirms "circle"
-   follows salience; `listenerData_green_matches_pragmatic` confirms "green"
-   follows pragmatics — a richer pattern than uniform salience dominance.
-
-10. **FG2012 bridge** (§18): `zeroCost_beliefGoal_eq` proves that belief-oriented
-    scoring at zero cost recovers [frank-goodman-2012]'s scoring rule.
--/
-
--- ============================================================================
--- §19. Bridge: Cost = Q2 (Gricean/D&R Connection)
--- ============================================================================
-
-/-! The cost dimension in [qing-franke-2015]'s S1 score decomposition
-IS [grice-1975]'s Q2 sub-maxim (brevity):
-
-    σ_b(m|t) ∝ exp(λ · (log L0(t|m) − Cost(m)))
-                        ╰── Q1 ──╯   ╰── Q2 ──╯
-
-This connects three frameworks:
-
-- [grice-1975]: Q1 (be informative) and Q2 (be brief) are independent
-- [dale-reiter-1995]: No-Brevity = Q2 not enforced (strength = 0)
-- [qing-franke-2015]: Cost = 0 ↔ no Q2 pressure ↔ No Brevity
-
-The zero-cost ↔ cost comparison (`no_cost_symmetry` vs `cost_breaks_symmetry`)
-directly demonstrates Q2's role: it is the *tiebreaker* when Q1 (informativity)
-is equal across alternatives. For green_circle, both "circle" and "green"
-have the same L0 informativity (each applies to 2 objects), so Q1 cannot
-distinguish them. Only Q2 (cost) breaks the tie. -/
-
-open Pragmatics.GriceanMaxims
-
-/-- Q&F's cost dimension IS Grice's Q2 sub-maxim. Without cost
-    (No Brevity regime), ambiguous words with equal informativity are
-    symmetric — Q1 alone cannot break the tie. With cost (Q2 active),
-    the cheaper word wins. This maps onto [dale-reiter-1995]'s
-    No-Brevity interpretation (strength = 0), the weakest Q2. -/
+open Pragmatics.GriceanMaxims in
+/-- The cost dimension is [grice-1975]'s Q2 sub-maxim (brevity): without
+cost the equally-informative words tie (Q1 alone cannot break it), any
+noun preference breaks it, and zero cost is [dale-reiter-1995]'s
+No-Brevity interpretation at strength 0, independent of Q1. -/
 theorem cost_is_q2 :
-    -- No cost = no symmetry breaking (No Brevity regime)
-    ¬(s1ZeroCost .green_circle .circle > s1ZeroCost .green_circle .green) ∧
-    -- With cost = symmetry breaks (Q2 pressure active)
-    s1Cost .green_circle .circle > s1Cost .green_circle .green ∧
-    -- No Brevity is the weakest Q2 interpretation
+    (sbScore uniformPrior 1 .green_circle .circle =
+      sbScore uniformPrior 1 .green_circle .green) ∧
+    (∀ k : ℝ, 0 < k → k < 1 →
+      s1 uniformPrior k .green_circle .green <
+        s1 uniformPrior k .green_circle .circle) ∧
     DaleReiter1995.BrevityInterpretation.noBrevity.strength = 0 ∧
-    -- Q1 and Q2 are independent sub-maxims
     QuantityViolation.underInformative.submaxim ≠
     QuantityViolation.overInformative.submaxim :=
-  ⟨no_cost_symmetry, cost_breaks_symmetry, rfl, violations_independent⟩
+  ⟨no_cost_symmetry, fun _ hk hk1 => cost_breaks_symmetry hk hk1, rfl,
+   violations_independent⟩
 
 end QingFranke2015

--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -1,3 +1,4 @@
+import Linglib.Pragmatics.RSA.Atoms
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Operators
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
@@ -445,53 +446,33 @@ noncomputable def l1Sal (u : Utterance) : PMF Object :=
 
 /-! ### The `exp(−1/2)` atom and its three numeric bounds -/
 
-private noncomputable def xc : ℝ := Real.exp (-(1/2))
+private noncomputable def xc : ℝ := RSA.expAtom (1/2)
 
-private theorem xc_pos : 0 < xc := Real.exp_pos _
+private theorem xc_pos : 0 < xc := RSA.expAtom_pos _
 
-private theorem xc_lt_one : xc < 1 := by
-  rw [xc, show (1 : ℝ) = Real.exp 0 from Real.exp_zero.symm]
-  exact Real.exp_lt_exp.mpr (by norm_num)
+private theorem e_half : ((2:ℕ) : ℝ) * (1/2) = 1 := by norm_num
 
-private theorem xc_sq : xc * xc = (Real.exp 1)⁻¹ := by
-  rw [xc, ← Real.exp_add, ← Real.exp_neg]
-  norm_num
-
-private theorem xc_sq_mul : xc * xc * Real.exp 1 = 1 := by
-  rw [xc_sq, inv_mul_cancel₀ (Real.exp_pos 1).ne']
+private theorem xc_lt_one : xc < 1 :=
+  RSA.expAtom_lt (n := 2) two_ne_zero (by norm_num)
+    (by rw [e_half, one_pow, one_mul]; nlinarith [Real.exp_one_gt_d9])
 
 /-- `exp(−1/2) > 1/2` ⟺ `e < 4` — [qing-franke-2015]'s Finding 2 needs the
 adjective's cost penalty to stay above the halved literal probability. -/
-private theorem xc_gt_half : 1/2 < xc := by
-  by_contra h
-  push Not at h
-  have h2 : xc * xc ≤ 1/4 := by nlinarith [xc_pos]
-  have h3 : Real.exp 1 * (xc * xc) ≤ Real.exp 1 * (1/4) :=
-    mul_le_mul_of_nonneg_left h2 (Real.exp_pos 1).le
-  rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
-  nlinarith [Real.exp_one_lt_d9]
+private theorem xc_gt_half : 1/2 < xc :=
+  RSA.lt_expAtom (n := 2) two_ne_zero (by norm_num)
+    (by rw [e_half]; nlinarith [Real.exp_one_lt_d9])
 
 /-- `exp(−1/2) < 139/169` ⟺ `e > (169/139)²` — the salience-belief speaker's
 circle-over-blue reversal at the blue circle. -/
-private theorem xc_lt_139_169 : xc < 139/169 := by
-  by_contra h
-  push Not at h
-  have h2 : (139/169 : ℝ) * (139/169) ≤ xc * xc := by nlinarith [xc_pos]
-  have h3 : Real.exp 1 * ((139/169 : ℝ) * (139/169)) ≤ Real.exp 1 * (xc * xc) :=
-    mul_le_mul_of_nonneg_left h2 (Real.exp_pos 1).le
-  rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
-  nlinarith [Real.exp_one_gt_d9]
+private theorem xc_lt_139_169 : xc < 139/169 :=
+  RSA.expAtom_lt (n := 2) two_ne_zero (by norm_num)
+    (by rw [e_half]; nlinarith [Real.exp_one_gt_d9])
 
 /-- `exp(−1/2) > 101/169` ⟺ `e < (169/101)²` ≈ 2.7998 — the tight bound
 (margin ≈ 0.08 over `exp_one_lt_d9`). -/
-private theorem xc_gt_101_169 : 101/169 < xc := by
-  by_contra h
-  push Not at h
-  have h2 : xc * xc ≤ (101/169 : ℝ) * (101/169) := by nlinarith [xc_pos]
-  have h3 : Real.exp 1 * (xc * xc) ≤ Real.exp 1 * ((101/169 : ℝ) * (101/169)) :=
-    mul_le_mul_of_nonneg_left h2 (Real.exp_pos 1).le
-  rw [show Real.exp 1 * (xc * xc) = xc * xc * Real.exp 1 from by ring, xc_sq_mul] at h3
-  nlinarith [Real.exp_one_lt_d9]
+private theorem xc_gt_101_169 : 101/169 < xc :=
+  RSA.lt_expAtom (n := 2) two_ne_zero (by norm_num)
+    (by rw [e_half]; nlinarith [Real.exp_one_lt_d9])
 
 /-! ### Cost-speaker values (for the listener comparisons) -/
 
@@ -523,7 +504,7 @@ private theorem Z_gs :
     show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from ENNReal.ofReal_one.symm,
     ← ENNReal.ofReal_add (by norm_num) (by positivity)]
   congr 1
-  unfold xc
+  unfold xc RSA.expAtom
   norm_num
   ring
 
@@ -536,7 +517,7 @@ private theorem Z_bc :
   simp +decide
   rw [half_conv, ← ENNReal.ofReal_add (by norm_num) (by positivity)]
   congr 1
-  unfold xc
+  unfold xc RSA.expAtom
   norm_num
 
 private theorem Z_gc :
@@ -549,7 +530,7 @@ private theorem Z_gc :
   rw [half_conv, ← ENNReal.ofReal_mul (by norm_num),
     ← ENNReal.ofReal_add (by norm_num) (by positivity)]
   congr 1
-  unfold xc
+  unfold xc RSA.expAtom
   norm_num
   ring
 
@@ -572,7 +553,7 @@ private theorem green_weight :
       then (1 : ℝ≥0∞) else 2⁻¹) = 2⁻¹ from by simp +decide, qfCf_green, half_conv,
     ← ENNReal.ofReal_mul (by norm_num)]
   congr 1
-  unfold xc
+  unfold xc RSA.expAtom
   ring
 
 private theorem sc_circle_gc :
@@ -596,7 +577,7 @@ private theorem sc_green_gs :
     (by have := xc_pos; linarith)
 
 private theorem xc_eq : Real.exp (-2⁻¹) = xc := by
-  unfold xc
+  unfold xc RSA.expAtom
   norm_num
 
 private theorem qfCf_zero (u : Utterance) : qfCf 0 u = 1 := by

--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -732,7 +732,8 @@ theorem salience_circle_blue_circ :
     sc_circle_bc, sc_circle_gc,
     ← ENNReal.ofReal_mul (by norm_num [saliencePrior]),
     ← ENNReal.ofReal_mul (by norm_num [saliencePrior])]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
+  refine (ENNReal.ofReal_lt_ofReal_iff
+    (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
   have hx := xc_pos
   have h1 : (0:ℝ) < 1/2 + xc := by linarith
   have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith
@@ -786,7 +787,8 @@ theorem salience_green_green_sq :
     sc_green_gs, sc_green_gc,
     ← ENNReal.ofReal_mul (by norm_num [saliencePrior]),
     ← ENNReal.ofReal_mul (by norm_num [saliencePrior])]
-  refine (ENNReal.ofReal_lt_ofReal_iff (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
+  refine (ENNReal.ofReal_lt_ofReal_iff
+    (by have := xc_pos; norm_num [saliencePrior]; positivity)).mpr ?_
   have hx := xc_pos
   have h1 : (0:ℝ) < 1 + xc/2 := by linarith
   have h2 : (0:ℝ) < 1/2 + xc/2 := by linarith

--- a/Linglib/Studies/WaldonDegen2021.lean
+++ b/Linglib/Studies/WaldonDegen2021.lean
@@ -2,6 +2,8 @@ import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.Operators
 import Mathlib.Analysis.Complex.ExponentialBounds
 import Linglib.Pragmatics.RSA.Channel
+import Linglib.Core.Probability.Scores
+import Linglib.Pragmatics.RSA.Atoms
 import Linglib.Pragmatics.RSA.Noisy
 import Linglib.Pragmatics.RSA.Sequential
 
@@ -208,12 +210,12 @@ def csScene : Referent → Bool
   | .smallRed | .bigRed | .smallBlue => true
   | _ => false
 
-/-! ### Exact-ℚ face and the cost atom (local pending the RSA API pass) -/
+/-! ### Exact-ℚ face and the cost atom -/
 
 /-! With α = 7 the informativity factor `L0^α` is exact ℚ; the only
 transcendental ingredient is the per-adjective cost factor
-`cAtom = exp(−α·C) = exp(−7/10)`, bounded two-sidedly below via
-`cAtom¹⁰ · e⁷ = 1` and kernel arithmetic on `e`-bounds. Every prediction
+`cAtom = RSA.expAtom (7/10)`, bounded two-sidedly via the substrate
+certificates and kernel arithmetic on `e`-bounds. Every prediction
 trajectory reduces to `K · cAtom / (A + B · cAtom)` with kernel-certified
 rational constants, so the comparisons are linear (the sum comparison
 quadratic) in the atom. -/
@@ -258,13 +260,9 @@ end QFace
 section CostAtom
 
 /-- The per-adjective cost factor `exp(−α·C) = exp(−7/10)`. -/
-noncomputable def cAtom : ℝ := Real.exp (-(7/10 : ℝ))
+noncomputable def cAtom : ℝ := RSA.expAtom (7/10)
 
-theorem cAtom_pos : 0 < cAtom := Real.exp_pos _
-
-private theorem cAtom_pow10 : cAtom ^ (10:ℕ) * Real.exp 7 = 1 := by
-  rw [cAtom, ← Real.exp_nat_mul, ← Real.exp_add]
-  norm_num
+theorem cAtom_pos : 0 < cAtom := RSA.expAtom_pos _
 
 private theorem e7_bounds :
     (1096.633 : ℝ) < Real.exp 7 ∧ Real.exp 7 < 1096.634 := by
@@ -280,16 +278,14 @@ private theorem e7_bounds :
         pow_lt_pow_left₀ Real.exp_one_lt_d9 (Real.exp_pos 1).le (by norm_num)
       _ < 1096.634 := by norm_num
 
-/-- Kernel-certified atom bounds: `(4965/10000)¹⁰·e⁷ < 1 < (4967/10000)¹⁰·e⁷`. -/
+/-- Kernel-certified atom bounds via `RSA.lt_expAtom`/`expAtom_lt` at
+n = 10: `(4965/10000)¹⁰·e⁷ < 1 < (4967/10000)¹⁰·e⁷`. -/
 theorem cAtom_bounds : (4965/10000 : ℝ) < cAtom ∧ cAtom < 4967/10000 := by
-  obtain ⟨he1, he2⟩ := e7_bounds
-  have h10 := cAtom_pow10
-  have hc := cAtom_pos
-  constructor
-  · have : (4965/10000 : ℝ) ^ (10:ℕ) < cAtom ^ (10:ℕ) := by nlinarith
-    exact lt_of_pow_lt_pow_left₀ 10 hc.le this
-  · have : cAtom ^ (10:ℕ) < (4967/10000 : ℝ) ^ (10:ℕ) := by nlinarith
-    exact lt_of_pow_lt_pow_left₀ 10 (by norm_num) this
+  have h7 : ((10:ℕ) : ℝ) * (7/10) = 7 := by norm_num
+  exact ⟨RSA.lt_expAtom (n := 10) (by norm_num) (by norm_num)
+      (by rw [h7]; nlinarith [e7_bounds.2]),
+    RSA.expAtom_lt (n := 10) (by norm_num) (by norm_num)
+      (by rw [h7]; nlinarith [e7_bounds.1])⟩
 
 end CostAtom
 
@@ -301,11 +297,8 @@ open scoped ENNReal
 dite-total. -/
 noncomputable def s1PMF (utts : List (List Word)) (scene : Referent → Bool)
     (tgt : Referent) (ctx : List Word) : PMF Word :=
-  if h : (∑' u, ENNReal.ofReal ((s1BaseQ utts scene tgt ctx u : ℝ) *
-      cAtom ^ costExp u)) ≠ 0 then
-    PMF.normalize _ h
-      (ENNReal.tsum_ne_top_of_fintype fun _ => ENNReal.ofReal_ne_top)
-  else PMF.uniformOfFintype Word
+  PMF.normalizeOrUniform fun u =>
+    ENNReal.ofReal ((s1BaseQ utts scene tgt ctx u : ℝ) * cAtom ^ costExp u)
 
 private theorem sumWordsE (f : Word → ℝ≥0∞) :
     ∑ u, f u = f .blue + f .red + f .big + f .small + f .pin + f .stop := by
@@ -363,9 +356,9 @@ private theorem s1PMF_step (utts : List (List Word)) (scene : Referent → Bool)
       exact_mod_cast congrArg (fun q : ℚ => (q : ℝ)) hA
     simp only [costExp, pow_one, pow_zero, mul_one]
     linear_combination cAtom * hb + ha
-  rw [s1PMF, dif_pos (by
-      rw [hZ, ENNReal.ofReal_ne_zero_iff]; exact hden),
-    PMF.normalize_apply, hZ, hN,
+  rw [s1PMF, PMF.normalizeOrUniform_apply
+      (by rw [hZ, ENNReal.ofReal_ne_zero_iff]; exact hden)
+      (by rw [hZ]; exact ENNReal.ofReal_ne_top), hZ, hN,
     ← ENNReal.ofReal_inv_of_pos hden,
     ← ENNReal.ofReal_mul (mul_nonneg (by exact_mod_cast
       (hN ▸ s1BaseQ_nonneg utts scene tgt ctx step)) (pow_nonneg hc.le _))]


### PR DESCRIPTION
WD2021's cost atom moves onto RSA.expAtom (new power-form inversion identity + lt_expAtom/expAtom_lt certificate pair in Atoms.lean; speaker onto PMF.normalizeOrUniform). QF2015 is rebuilt from scratch, parametric in the cost factor k = exp(−c): every listener reversal now holds at all k > 0 (pure prior effects), the speaker predictions carry their exact validity regions (k < 2, k > 1/2, k < 1), and the σ_bS content is a pair of threshold iffs at k = 139/169 and 101/169 — the old file's exp(−1/2) atom and its three e-digit bound proofs were artifacts of fixing c = 1/2 (outside the paper's own (−0.4, 0.4) cost support) and are deleted along with the ~360-line PMF-chain bridge apparatus. 1298 → 584 lines.