### PR TITLE
style(Phonology/Autosegmental): tighten Melody docstring; lift variables

### DIFF
--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -244,6 +244,16 @@ theorem concat_assoc : (A.concat B).concat C = A.concat (B.concat C) :=
     (by grind [links_concat, upper_concat, lower_concat, LabeledTuple.concat_len,
           Finset.image_union, Finset.image_image, shiftLink_comp])
 
+/-- Left-to-right concatenation of a list of graphs ([jardine-heinz-2015]
+    §5): tier juxtaposition with index-shifted links. -/
+def concatList (gs : List (Graph α β)) : Graph α β :=
+  gs.foldr concat empty
+
+@[simp] theorem concatList_nil : concatList ([] : List (Graph α β)) = empty := rfl
+
+@[simp] theorem concatList_cons (g : Graph α β) (gs : List (Graph α β)) :
+    concatList (g :: gs) = g.concat (concatList gs) := rfl
+
 /-! #### Planarity preservation ([jardine-heinz-2015] Theorem 4) -/
 
 /-- Concatenation preserves planarity, given `A.InBounds`: `A.links` and the

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -9,34 +9,26 @@ import Linglib.Phonology.Autosegmental.Floating
 # Lexical melodies: per-morpheme autosegmental contributions
 
 A **melody** is one morpheme's underlying autosegmental contribution
-([rolle-2018] §2.1 Def 1): tier elements and backbone slots, every one
-sponsored by the same morpheme ([rolle-2018] §2.1.4; [wolf-2007]), plus
-the lexical pre-linking ([pulleyblank-1986]) in melody-local coordinates.
-Which elements are pre-linked is per-analysis data — a melody with no
-links is [mccarthy-mullin-smith-2012]'s universally-unlinked underlying
-form, while a partially linked one is [mcpherson-lamont-2026]'s stratal
-`/M^H/`. In [rolle-2018] Table 1's vocabulary, a backbone slot `j` is
-*valued* iff `Graph.IsLinkedLower j`, *unvalued* iff
-`Graph.IsFloatingLower j`, and a tier element is *floating* iff
-`Graph.IsFloatingUpper i` — the per-index predicates the `Graph`
-substrate already provides.
-
-A word's underlying form is the left-to-right `Graph.concat` fold of its
-melodies ([jardine-heinz-2015] §5), and `FloatingForm.ofGraph` packages
-it as a derivation input. This melody-concatenation view of
-non-concatenative exponence is the Generalized Nonlinear Affixation
-program — [bermudez-otero-2012]'s term; [bye-svenonius-2012] give the
-programmatic statement (non-concatenative morphology as epiphenomenon
-of deficient lexical entries); [zimmermann-2024] surveys. GEN's
-compliance with Consistency of Exponence is
-`FloatingForm.gen_preserves_morphemes`.
+([rolle-2018] §2.1): tier elements and backbone slots sponsored by the
+same morpheme ([wolf-2007]), plus lexical pre-linking
+([pulleyblank-1986]) in melody-local coordinates. Pre-linking is
+per-analysis data — no links is [mccarthy-mullin-smith-2012]'s
+universally-unlinked underlying form, partial linking is
+[mcpherson-lamont-2026]'s stratal `/M^H/` — and [rolle-2018] Table 1's
+*valued*, *unvalued*, and *floating* are the substrate's
+`Graph.IsLinkedLower`, `IsFloatingLower`, and `IsFloatingUpper`. A word
+is the `Graph.concat` fold of its melodies ([jardine-heinz-2015] §5) —
+the Generalized Nonlinear Affixation program ([bermudez-otero-2012]'s
+term, [bye-svenonius-2012]'s programmatic statement; survey:
+[zimmermann-2024]).
 
 ## Main definitions
 
 * `Graph.melody` — one morpheme's tones, slots, and pre-links.
 * `Graph.concatList` — the word: melodies folded by `Graph.concat`.
-* `FloatingForm.ofGraph` — an underlying graph as a derivation input
-  (surface mirrors underlying).
+* `FloatingForm.ofGraph` — an underlying graph as a derivation input.
+* `FloatingForm.gen_preserves_morphemes` — GEN respects Consistency of
+  Exponence: every candidate keeps its input's sponsors.
 -/
 
 namespace Autosegmental
@@ -45,51 +37,46 @@ variable {S T : Type*}
 
 namespace Graph
 
+variable {α β : Type*} (m : Morpheme) (tones : List T) (tbus : List S) (links : Finset Link)
+
 /-- One morpheme's underlying autosegmental contribution ([rolle-2018]
     §2.1 Def 1): `tones` over `tbus`, every element sponsored by `m`,
     pre-linked by `links` in melody-local coordinates. -/
-def melody (m : Morpheme) (tones : List T) (tbus : List S)
-    (links : Finset Link) : Graph (TierSpec T) (SegSpec S) where
+def melody : Graph (TierSpec T) (SegSpec S) where
   upper := .ofList (tones.map fun t => { value := t, morpheme := m })
   lower := .ofList (tbus.map fun s => { seg := s, morpheme := m })
   links := links
 
-@[simp] theorem melody_upper (m : Morpheme) (tones : List T) (tbus : List S)
-    (links : Finset Link) :
+@[simp] theorem melody_upper :
     (melody m tones tbus links).upper
       = .ofList (tones.map fun t => { value := t, morpheme := m }) := rfl
 
-@[simp] theorem melody_lower (m : Morpheme) (tones : List T) (tbus : List S)
-    (links : Finset Link) :
+@[simp] theorem melody_lower :
     (melody m tones tbus links).lower
       = .ofList (tbus.map fun s => { seg := s, morpheme := m }) := rfl
 
-@[simp] theorem melody_links (m : Morpheme) (tones : List T) (tbus : List S)
-    (links : Finset Link) : (melody m tones tbus links).links = links := rfl
+@[simp] theorem melody_links : (melody m tones tbus links).links = links := rfl
 
 /-- Every tier element of a melody is sponsored by its morpheme. -/
-theorem melody_upper_morpheme (m : Morpheme) (tones : List T) (tbus : List S)
-    (links : Finset Link) {k : ℕ} (hk : k < tones.length) :
+theorem melody_upper_morpheme {k : ℕ} (hk : k < tones.length) :
     ((melody m tones tbus links).upper.get? k).map TierSpec.morpheme = some m := by
   rw [melody_upper, LabeledTuple.ofList_get?]
   simp [hk]
 
 /-- Every backbone slot of a melody is sponsored by its morpheme. -/
-theorem melody_lower_morpheme (m : Morpheme) (tones : List T) (tbus : List S)
-    (links : Finset Link) {j : ℕ} (hj : j < tbus.length) :
+theorem melody_lower_morpheme {j : ℕ} (hj : j < tbus.length) :
     ((melody m tones tbus links).lower.get? j).map SegSpec.morpheme = some m := by
   rw [melody_lower, LabeledTuple.ofList_get?]
   simp [hj]
 
 /-- Left-to-right concatenation of a word's melodies ([jardine-heinz-2015]
     §5): tier juxtaposition with index-shifted links. -/
-def concatList {α β : Type*} (gs : List (Graph α β)) : Graph α β :=
+def concatList (gs : List (Graph α β)) : Graph α β :=
   gs.foldr concat empty
 
-@[simp] theorem concatList_nil {α β : Type*} :
-    concatList ([] : List (Graph α β)) = empty := rfl
+@[simp] theorem concatList_nil : concatList ([] : List (Graph α β)) = empty := rfl
 
-@[simp] theorem concatList_cons {α β : Type*} (g : Graph α β) (gs : List (Graph α β)) :
+@[simp] theorem concatList_cons (g : Graph α β) (gs : List (Graph α β)) :
     concatList (g :: gs) = g.concat (concatList gs) := rfl
 
 end Graph

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -25,7 +25,6 @@ term, [bye-svenonius-2012]'s programmatic statement; survey:
 ## Main definitions
 
 * `Graph.melody` — one morpheme's tones, slots, and pre-links.
-* `Graph.concatList` — the word: melodies folded by `Graph.concat`.
 * `FloatingForm.ofGraph` — an underlying graph as a derivation input.
 * `FloatingForm.gen_preserves_morphemes` — GEN respects Consistency of
   Exponence: every candidate keeps its input's sponsors.
@@ -37,7 +36,7 @@ variable {S T : Type*}
 
 namespace Graph
 
-variable {α β : Type*} (m : Morpheme) (tones : List T) (tbus : List S) (links : Finset Link)
+variable (m : Morpheme) (tones : List T) (tbus : List S) (links : Finset Link)
 
 /-- One morpheme's underlying autosegmental contribution ([rolle-2018]
     §2.1 Def 1): `tones` over `tbus`, every element sponsored by `m`,
@@ -68,16 +67,6 @@ theorem melody_lower_morpheme {j : ℕ} (hj : j < tbus.length) :
     ((melody m tones tbus links).lower.get? j).map SegSpec.morpheme = some m := by
   rw [melody_lower, LabeledTuple.ofList_get?]
   simp [hj]
-
-/-- Left-to-right concatenation of a word's melodies ([jardine-heinz-2015]
-    §5): tier juxtaposition with index-shifted links. -/
-def concatList (gs : List (Graph α β)) : Graph α β :=
-  gs.foldr concat empty
-
-@[simp] theorem concatList_nil : concatList ([] : List (Graph α β)) = empty := rfl
-
-@[simp] theorem concatList_cons (g : Graph α β) (gs : List (Graph α β)) :
-    concatList (g :: gs) = g.concat (concatList gs) := rfl
 
 end Graph
 


### PR DESCRIPTION
Module docstring to one paragraph + Main definitions (CoE theorem folded into the list; every [key] kept exactly once); `m tones tbus links` and `{α β}` lifted to the Graph-namespace variable block, decluttering six signatures.