### PR TITLE
feat(Syntax/Particle): core API + question-particle cohort migration

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -636,6 +636,7 @@ import Linglib.Features.Case.Capabilities
 import Linglib.Features.Case.Grammaticalization
 import Linglib.Features.Case.Source
 import Linglib.Features.Causation
+import Linglib.Features.ClauseCtx
 import Linglib.Features.ClauseForm
 import Linglib.Features.Clusivity
 import Linglib.Features.Complementation
@@ -2921,6 +2922,7 @@ import Linglib.Syntax.Negation
 import Linglib.Syntax.NullSubject
 import Linglib.Syntax.Numeral.Basic
 import Linglib.Syntax.Numeral.Composition
+import Linglib.Syntax.Particle.Basic
 import Linglib.Syntax.Pronoun.Basic
 import Linglib.Syntax.Pronoun.Capabilities
 import Linglib.Syntax.Pronoun.Demonstrative

--- a/Linglib/Features/ClauseCtx.lean
+++ b/Linglib/Features/ClauseCtx.lean
@@ -1,0 +1,51 @@
+/-!
+# Clause-Context Feature
+[sadock-zwicky-1985]
+
+The clause-type inventory particles are distributed over, following
+[sadock-zwicky-1985]'s cross-linguistic typology of sentence types:
+the major forces (declarative, interrogative, imperative, exclamative)
+with the interrogative refined into polar, alternative, and constituent
+subtypes. The polar/alternative/constituent split is load-bearing for
+particle distribution (German *denn* is licensed in polar and constituent
+questions; Hindi-Urdu *ya: nahii:* forms specifically alternative
+questions).
+
+Lives in `Features/` (sibling of `QParticleLayer`) because it is a
+feature taxonomy with no semantic commitments. Neighboring inventories
+cut differently and complement it: `Semantics.Mood.IllocutionaryMood`
+collapses the three interrogative cells; `Semantics.Mood.ClauseType`
+crosses force with verbal mood; `Features.ClauseForm` distinguishes
+matrix from embedded questions (the word-order/embedding axis,
+orthogonal to the sentence-type axis here).
+-/
+
+namespace Features
+
+/-- A clause context a particle may be distributed over:
+[sadock-zwicky-1985]'s sentence types, with the interrogative split
+into its polar / alternative / constituent subtypes. -/
+inductive ClauseCtx where
+  | declarative
+  | polarInterrogative
+  /-- Alternative question ("Is it A or B?"; Hindi-Urdu *ya: nahii:*). -/
+  | alternativeInterrogative
+  /-- Constituent (wh-) question. -/
+  | constituentInterrogative
+  | imperative
+  | exclamative
+  deriving DecidableEq, Repr
+
+namespace ClauseCtx
+
+/-- The interrogative cells. -/
+def IsInterrogative : ClauseCtx → Prop
+  | polarInterrogative | alternativeInterrogative | constituentInterrogative => True
+  | _ => False
+
+instance : DecidablePred IsInterrogative := fun c => by
+  cases c <;> simp only [IsInterrogative] <;> infer_instance
+
+end ClauseCtx
+
+end Features

--- a/Linglib/Fragments/German/QuestionParticles.lean
+++ b/Linglib/Fragments/German/QuestionParticles.lean
@@ -1,75 +1,44 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
 
 /-!
 # German Question Particles
 
 Lexical entries for the German interrogative/flavoring particles *denn* and
-*doch wohl*, committing only to theory-neutral lexical primitives. *denn* is a
-highlighting-sensitive flavoring particle ([theiler-2021]); *doch wohl* is a
-non-compositional marker of rejecting questions ([seeliger-repp-2018]). The
-layer assignments and full analyses live in the paper-anchored studies
-`Theiler2021` and `SeeligerRepp2018`.
+*doch wohl*, as `Particle` values. *denn* is a highlighting-sensitive
+flavoring particle ([theiler-2021]); *doch wohl* is a non-compositional
+marker of rejecting questions ([seeliger-repp-2018]). Layer assignments,
+bias profiles, and full analyses live in the paper-anchored studies
+`Theiler2021` and `SeeligerRepp2018` — a particle's bias requirement is an
+analytical classification, not consensus lexical data.
 -/
 
 namespace German.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A German interrogative/flavoring particle entry. -/
-structure QParticleEntry where
-  /-- Orthographic form of the particle. -/
-  form : String
-  /-- Felicitous in polar interrogatives. -/
-  polarOk : Bool
-  /-- Felicitous in declarative clauses. -/
-  declOk : Bool
-  /-- Felicitous in wh-interrogatives. -/
-  whOk : Bool
-  /-- Contextual-evidence bias the particle requires, or `none` if it imposes
-      no such constraint. -/
-  requiresContextualEvidence : Option ContextualEvidence
-  /-- Original speaker bias the particle requires, or `none` if it imposes
-      no such constraint. -/
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
 /-- *denn* — highlighting-sensitive flavoring particle ([theiler-2021]),
-licensed in both polar and wh-questions (unlike *nandao*). It imposes no
-bias requirement: its felicity condition is the highlighting/precondition
-relation analysed in `Theiler2021`, not contextual or speaker bias. -/
-def denn : QParticleEntry where
+licensed in both polar and constituent questions (unlike *nandao*),
+excluded from declaratives. Its felicity condition
+(highlighting/precondition) and bias profile live in `Theiler2021`. -/
+def denn : Particle where
   form := "denn"
-  polarOk := true
-  declOk := false
-  whOk := true
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+  position := .clauseMedial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .optional }
 
 /-- *doch wohl* — non-compositional marker of rejecting questions
-([seeliger-repp-2018]). The fields record the prototypical negated (NRQ)
-reading — contextual evidence for p, prior speaker bias against p
-([seeliger-repp-2018] Table 1) — i.e. the speaker assumed ¬p but the evidence
-points to p. The positive (PRQ) reading flips both dimensions; the direction
-tracks clause polarity, which a single fixed-direction entry cannot capture
-(the full PRQ/NRQ analysis is in `SeeligerRepp2018`). -/
-def dochWohl : QParticleEntry where
+([seeliger-repp-2018]): declarative-syntax polar questions (recorded under
+`polarInterrogative` following the source schema's question-function
+reading), not assertions and not wh-questions. The PRQ/NRQ bias profile
+lives in `SeeligerRepp2018`. -/
+def dochWohl : Particle where
   form := "doch wohl"
-  polarOk := true
-  declOk := false  -- marks a question, not an assertion
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := some .againstP
+  position := .clauseMedial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-/-- All German question-particle entries. -/
-def allQuestionParticles : List QParticleEntry := [denn, dochWohl]
-
-/-- *doch wohl* requires both contextual-evidence and original-speaker bias,
-whereas *denn* imposes neither — reflecting the insisting nature of rejecting
-questions versus the merely highlighting nature of *denn*-questions. -/
-theorem dochWohl_stricter_than_denn :
-    dochWohl.requiresContextualEvidence = some .forP ∧
-    dochWohl.requiresOriginalBias = some .againstP ∧
-    denn.requiresContextualEvidence = none ∧
-    denn.requiresOriginalBias = none := ⟨rfl, rfl, rfl, rfl⟩
+def allQuestionParticles : List Particle := [denn, dochWohl]
 
 end German.QuestionParticles

--- a/Linglib/Fragments/Mandarin/QuestionParticles.lean
+++ b/Linglib/Fragments/Mandarin/QuestionParticles.lean
@@ -1,168 +1,69 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
 
 /-!
 # Mandarin Question Particles
 [zheng-2025]
 
-Lexical entries for Mandarin interrogative particles with distributional
-properties and bias profiles. The fragment commits only to theory-neutral
-lexical primitives; the left-peripheral layer assignment lives in
-`Zheng2025`.
+Lexical entries for Mandarin interrogative particles as `Particle` values.
+Bias profiles (ba's speaker-bias requirement, nandao's evidential
+requirement) are analytical classifications and live with the analysis
+that assigns them, in `Zheng2025` — alongside the left-peripheral layer
+assignments.
 
 ## Particles
 
-| Particle | Gloss | Evidential | Epistemic | Restriction |
-|----------|-------|-----------|-----------|-------------|
-| 吗 ma | PQ marker | ± | ± | polar + wh |
-| 吧 ba | TAG/confirm | ± | +forP | polar only |
-| 难道 nándào | NANDAO | +forP | ± | polar only |
+| Particle | Gloss | Restriction |
+|----------|-------|-------------|
+| 吗 ma | PQ marker | polar + wh |
+| 吧 ba | TAG/confirm | polar only |
+| 难道 nándào | NANDAO | polar only |
 
 ## Cross-Module Connections
 
-- `Bias.OriginalBias`: ba requires `.forP`; nandao/ma compatible with `.neutral`
-- `Bias.ContextualEvidence`: nandao requires `.forP`; ma/ba do not
-- `Kernel.nandaoFelicitous`: formal felicity conditions for nandao
-
+- `Zheng2025`: bias profiles, layer assignments, `Kernel.nandaoFelicitous`
 -/
 
 namespace Mandarin.QuestionParticles
 
-open Semantics.Questions.Bias (OriginalBias ContextualEvidence)
+/-- 吗 ma — unmarked polar question particle. Sentence-final; turns a
+declarative into a yes/no question. Bias-neutral (see `Zheng2025`). -/
+def ma : Particle where
+  form := "ma"
+  script := some "吗"
+  position := .clauseFinal
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .optional }
 
-/-- A Mandarin interrogative particle entry. -/
-structure QuestionParticleEntry where
-  hanzi : String
-  pinyin : String
-  gloss : String
-  /-- Compatible with polar questions? -/
-  polarOk : Bool
-  /-- Compatible with declaratives? -/
-  declOk : Bool
-  /-- Compatible with wh-questions? -/
-  whOk : Bool
-  /-- Contextual-evidence bias the particle requires, or `none`. -/
-  requiresContextualEvidence : Option ContextualEvidence
-  /-- Original speaker bias the particle requires, or `none`. -/
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
+/-- 吧 ba — confirmation-seeking particle. Speaker expects a positive
+answer and seeks confirmation, comparable to English tag questions
+("It's raining, isn't it?"). Its speaker-bias requirement lives in
+`Zheng2025`. -/
+def ba : Particle where
+  form := "ba"
+  script := some "吧"
+  position := .clauseFinal
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
--- ============================================================================
--- 吗 ma — basic polar question particle
--- ============================================================================
+/-- 难道 nándào — evidential question particle: marks that the speaker has
+encountered unexpected contextual evidence supporting the prejacent;
+compatible with a neutral epistemic state (pure inquiry use, [zheng-2025]
+ex. 3). Canonically clause-initial (post-subject placement possible).
+Polar-only — the contrast with wh-compatible *denn* lives in `Theiler2021`.
+Its evidential requirement lives in `Zheng2025`. -/
+def nandao : Particle where
+  form := "nándào"
+  script := some "难道"
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-/-- 吗 ma — unmarked polar question particle.
-Sentence-final particle that turns a declarative into a yes/no question.
-No bias requirements; compatible with all contexts. -/
-def ma : QuestionParticleEntry where
-  hanzi := "吗"
-  pinyin := "ma"
-  gloss := "PQ (basic polar question marker)"
-  polarOk := true
-  declOk := false
-  whOk := true
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
-
--- ============================================================================
--- 吧 ba — confirmation-seeking / tag particle
--- ============================================================================
-
-/-- 吧 ba — confirmation-seeking particle.
-Speaker expects a positive answer and seeks confirmation. Comparable to
-English tag questions ("It's raining, isn't it?"). Requires original
-speaker bias for p but no evidential bias. -/
-def ba : QuestionParticleEntry where
-  hanzi := "吧"
-  pinyin := "ba"
-  gloss := "TAG (confirmation-seeking)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := none
-  requiresOriginalBias := some .forP
-
--- ============================================================================
--- 难道 nándào — evidential question particle
--- ============================================================================
-
-/-- 难道 nándào — evidential question particle.
-Marks that the speaker has encountered unexpected contextual evidence
-supporting the prejacent. Compatible with neutral epistemic state
-(pure inquiry use, [zheng-2025] ex. 3). -/
-def nandao : QuestionParticleEntry where
-  hanzi := "难道"
-  pinyin := "nándào"
-  gloss := "NANDAO (evidential Q-particle)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := none
-
-def allQuestionParticles : List QuestionParticleEntry := [ma, ba, nandao]
-
--- ============================================================================
--- Per-Datum Verification Theorems
--- ============================================================================
-
--- ma
-
-/-- ma is the unmarked baseline: no bias requirements. -/
-theorem ma_no_bias :
-    ma.requiresContextualEvidence = none ∧ ma.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-/-- ma is compatible with wh-questions (unlike ba and nandao). -/
-theorem ma_wh_ok : ma.whOk = true := rfl
-
--- ba
-
-/-- ba requires epistemic bias (speaker expects p). -/
-theorem ba_requires_epistemic :
-    ba.requiresOriginalBias = some .forP ∧ ba.requiresContextualEvidence = none :=
-  ⟨rfl, rfl⟩
-
-/-- ba is restricted to polar questions. -/
-theorem ba_polar_only :
-    ba.polarOk = true ∧ ba.declOk = false ∧ ba.whOk = false :=
-  ⟨rfl, rfl, rfl⟩
-
--- nandao
-
-/-- nandao is restricted to polar questions ([zheng-2025] ex. 12). -/
-theorem nandao_polar_only :
-    nandao.polarOk = true ∧ nandao.declOk = false ∧ nandao.whOk = false :=
-  ⟨rfl, rfl, rfl⟩
-
-/-- nandao requires evidential but not epistemic bias ([zheng-2025] §2). -/
-theorem nandao_bias_profile :
-    nandao.requiresContextualEvidence = some .forP ∧ nandao.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-/-- nandao is compatible with neutral original speaker bias (pure inquiry). -/
-theorem nandao_neutral_bias_ok :
-    nandao.requiresOriginalBias = none := rfl
-
--- ============================================================================
--- Cross-Particle Contrast Theorems
--- ============================================================================
-
-/-- The three particles form a bias contrast triple: ma is neutral,
-ba requires epistemic, nandao requires evidential. -/
-theorem bias_contrast_triple :
-    ma.requiresContextualEvidence = none ∧ ma.requiresOriginalBias = none ∧
-    ba.requiresContextualEvidence = none ∧ ba.requiresOriginalBias = some .forP ∧
-    nandao.requiresContextualEvidence = some .forP ∧ nandao.requiresOriginalBias = none :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- Only ma is compatible with wh-questions. -/
-theorem only_ma_allows_wh :
-    allQuestionParticles.filter (·.whOk) = [ma] := by decide
-
-/-- No particle requires BOTH contextual-evidence and original-speaker bias. -/
-theorem no_double_bias :
-    allQuestionParticles.all
-      (λ p => !(p.requiresContextualEvidence.isSome && p.requiresOriginalBias.isSome)) = true := by
-  decide
+def allQuestionParticles : List Particle := [ma, ba, nandao]
 
 end Mandarin.QuestionParticles

--- a/Linglib/Fragments/Slavic/Bulgarian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/QuestionParticles.lean
@@ -1,79 +1,48 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Bulgarian Question Particles
 [simik-2024]
 
-Lexical entries for Bulgarian interrogative particles. The fragment
-commits only to theory-neutral lexical primitives; the left-peripheral
-layer assignment lives in `Simik2024`.
-
-## Particles
-
-| Particle | Romanization | Gloss | Bias |
-|----------|-------------|-------|------|
-| ли | li | neutral PQ | none |
-| нима | nima | RAZVE (mirative) | +evidential |
+Lexical entries for Bulgarian interrogative particles as `Particle`
+values. Bias classifications (nima's evidential requirement) and the
+left-peripheral layer assignments live in `Simik2024`.
 
 ## Cross-Module Connections
 
-- `Simik2024.bulgarian` (`Studies/Simik2024`): PQ strategy profile (verb-attached li)
+- `Simik2024.bulgarian` (`Studies/Simik2024`): PQ strategy profile
+  (verb-attached li) and the neutral/evidential contrast
 - Cross-Slavic RAZVE family: nima is the Bulgarian member
 - Dukova-Zheleva: nima expresses incredulity/surprise
-
 -/
 
 namespace Bulgarian.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A Bulgarian interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  romanization : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
 /-- ли li — verb-attached neutral PQ particle ([simik-2024] ex. 33).
-Encliticizes onto the focused constituent. -/
-def li : QParticleEntry where
-  form := "ли"
-  romanization := "li"
-  gloss := "PQ (verb-attached neutral)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+Second-position (Wackernagel): encliticizes onto the focused
+constituent. -/
+def li : Particle where
+  form := "li"
+  script := some "ли"
+  position := .secondPosition
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-/-- нима nima — mirative/dubitative particle (RAZVE family, [simik-2024] §4.2.4).
-Expresses incredulity: speaker encounters evidence conflicting with prior
-expectations (Dukova-Zheleva). -/
-def nima : QParticleEntry where
-  form := "нима"
-  romanization := "nima"
-  gloss := "RAZVE (mirative/incredulity)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := none
+/-- нима nima — mirative/dubitative particle (RAZVE family, [simik-2024]
+§4.2.4). Expresses incredulity: speaker encounters evidence conflicting
+with prior expectations (Dukova-Zheleva). Evidential classification in
+`Simik2024`. -/
+def nima : Particle where
+  form := "nima"
+  script := some "нима"
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [li, nima]
-
-theorem li_neutral :
-    li.requiresContextualEvidence = none ∧ li.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-theorem nima_evidential : nima.requiresContextualEvidence = some .forP := rfl
-
-/-- li and nima form a neutral/evidential contrast. -/
-theorem bias_contrast :
-    li.requiresContextualEvidence = none ∧ nima.requiresContextualEvidence = some .forP :=
-  ⟨rfl, rfl⟩
+def allQuestionParticles : List Particle := [li, nima]
 
 end Bulgarian.QuestionParticles

--- a/Linglib/Fragments/Slavic/Macedonian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Macedonian/QuestionParticles.lean
@@ -1,67 +1,34 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Macedonian Question Particles
 [simik-2024]
 
-Lexical entries for Macedonian interrogative particles. The fragment
-commits only to theory-neutral lexical primitives; the left-peripheral
-layer assignment lives in `Simik2024`.
-
-## Particles
-
-| Particle | Romanization | Gloss | Bias |
-|----------|-------------|-------|------|
-| дали | dali | neutral PQ | none |
-
-Macedonian *dali* can introduce negative PQs without triggering epistemic
-bias, unlike Bulgarian *li* ([simik-2024] ex. 32). Mitkovska, Bužarovska &
-Saračević (2024) contrast *dali* with biased particles *zar* and *neli*.
+Lexical entry for Macedonian *dali* as a `Particle` value. Macedonian
+*dali* can introduce negative PQs without triggering epistemic bias,
+unlike Bulgarian *li* ([simik-2024] ex. 32) — that contrast is an
+analytical classification and lives in `Simik2024`. Mitkovska,
+Bužarovska & Saračević (2024) contrast *dali* with biased particles
+*zar* and *neli*.
 
 ## Cross-Module Connections
 
-- `Simik2024.macedonian` (`Studies/Simik2024`): PQ strategy profile (negationTriggersBias = false)
-
+- `Simik2024.macedonian` (`Studies/Simik2024`): PQ strategy profile
+  (negation does not trigger bias)
 -/
 
 namespace Macedonian.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
+/-- дали dali — clause-initial PQ particle ([simik-2024] ex. 32). -/
+def dali : Particle where
+  form := "dali"
+  script := some "дали"
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-/-- A Macedonian interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  romanization : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  /-- Does adding negation to the PQ trigger epistemic bias? -/
-  negationTriggersBias : Bool
-  deriving Repr, DecidableEq
-
-/-- дали dali — clause-initial PQ particle ([simik-2024] ex. 32).
-Unlike Bulgarian li, dali + negation is unbiased. -/
-def dali : QParticleEntry where
-  form := "дали"
-  romanization := "dali"
-  gloss := "PQ (clause-initial neutral)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
-  negationTriggersBias := false
-
-def allQuestionParticles : List QParticleEntry := [dali]
-
-theorem dali_neutral :
-    dali.requiresContextualEvidence = none ∧ dali.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-/-- dali + negation does NOT trigger bias (unlike Bulgarian li).
-This is the key Macedonian-Bulgarian contrast ([simik-2024] ex. 32). -/
-theorem dali_neg_unbiased : dali.negationTriggersBias = false := rfl
+def allQuestionParticles : List Particle := [dali]
 
 end Macedonian.QuestionParticles

--- a/Linglib/Fragments/Slavic/Polish/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Polish/QuestionParticles.lean
@@ -1,74 +1,43 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Polish Question Particles
 [simik-2024]
 
-Lexical entries for Polish interrogative particles. The fragment
-commits only to theory-neutral lexical primitives; the left-peripheral
-layer assignment lives in `Simik2024`.
-
-## Particles
-
-| Particle | Gloss | Bias |
-|----------|-------|------|
-| czy | neutral PQ | none |
-| czyżby | RAZVE (mirative) | +evidential |
+Lexical entries for Polish interrogative particles as `Particle` values.
+Bias classifications (czyżby's evidential requirement) and layer
+assignments live in `Simik2024`.
 
 ## Cross-Module Connections
 
-- `Simik2024.polish` (`Studies/Simik2024`): PQ strategy profile (clause-initial czy obligatory)
+- `Simik2024.polish` (`Studies/Simik2024`): PQ strategy profile
+  (clause-initial czy obligatory) and the neutral/evidential contrast
 - Cross-Slavic RAZVE family: czyżby is the Polish member
-
 -/
 
 namespace Polish.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A Polish interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
 /-- czy — obligatory clause-initial PQ particle ([simik-2024] ex. 30).
 Verb-initial PQs possible but unacceptable in quiz scenarios. -/
-def czy : QParticleEntry where
+def czy : Particle where
   form := "czy"
-  gloss := "PQ (clause-initial neutral)"
-  polarOk := true
-  declOk := false
-  whOk := true
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .obligatory
+      constituentInterrogative := some .optional }
 
-/-- czyżby — mirative/dubitative particle (RAZVE family, [simik-2024] §4.2.4).
-Polish member of the cross-Slavic razve family. -/
-def czyzby : QParticleEntry where
+/-- czyżby — mirative/dubitative particle (RAZVE family, [simik-2024]
+§4.2.4). Polish member of the cross-Slavic razve family. Evidential
+classification in `Simik2024`. -/
+def czyzby : Particle where
   form := "czyżby"
-  gloss := "RAZVE (mirative/dubitative)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := none
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [czy, czyzby]
-
-theorem czy_neutral :
-    czy.requiresContextualEvidence = none ∧ czy.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-theorem czyzby_evidential : czyzby.requiresContextualEvidence = some .forP := rfl
-
-/-- czy and czyżby form a neutral/evidential contrast. -/
-theorem bias_contrast :
-    czy.requiresContextualEvidence = none ∧ czyzby.requiresContextualEvidence = some .forP :=
-  ⟨rfl, rfl⟩
+def allQuestionParticles : List Particle := [czy, czyzby]
 
 end Polish.QuestionParticles

--- a/Linglib/Fragments/Slavic/Russian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Russian/QuestionParticles.lean
@@ -1,84 +1,47 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Russian Question Particles
 [esipova-romero-2023] [simik-2024]
 
-Lexical entries for Russian interrogative particles with distributional
-properties and bias profiles. The fragment commits only to theory-neutral
-lexical primitives (form, gloss, distribution, bias profile); the
-left-peripheral layer assignment lives in
-`Simik2024`.
-
-## Particles
-
-| Particle | Romanization | Gloss | Bias |
-|----------|-------------|-------|------|
-| ли | li | neutral PQ | none |
-| разве | razve | RAZVE (mirative) | +evidential |
+Lexical entries for Russian interrogative particles as `Particle`
+values. Bias classifications (razve's evidential requirement) and layer
+assignments live in `Simik2024`.
 
 ## Cross-Module Connections
 
-- `Simik2024.russian` (`Studies/Simik2024`): PQ strategy profile (intonation default, li formal)
-- Layer assignments and Fragment-derived bias theorems in `Studies/Simik2024`
-
+- `Simik2024.russian` (`Studies/Simik2024`): PQ strategy profile
+  (intonation default, li formal) and the neutral/evidential contrast
 -/
 
 namespace Russian.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A Russian interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  romanization : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
 /-- ли li — neutral polar question particle (formal register).
-Verb-attached enclitic, cliticizes onto the focused constituent.
-Rare in spoken Russian (only 6/500 PQs in Onoeva & Staňková corpus). -/
-def li : QParticleEntry where
-  form := "ли"
-  romanization := "li"
-  gloss := "PQ (neutral polar question particle)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+Second-position (Wackernagel) enclitic, cliticizes onto the focused
+constituent. Rare in spoken Russian (only 6/500 PQs in Onoeva &
+Staňková corpus). -/
+def li : Particle where
+  form := "li"
+  script := some "ли"
+  position := .secondPosition
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-/-- разве razve — mirative/dubitative question particle ([simik-2024] §4.2.4).
-Indicates conflict between speaker's prior epistemic state and current
-contextual evidence. Compatible with both outer and inner negation. -/
-def razve_ : QParticleEntry where
-  form := "разве"
-  romanization := "razve"
-  gloss := "RAZVE (mirative/dubitative Q-particle)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := none
+/-- разве razve — mirative/dubitative question particle ([simik-2024]
+§4.2.4). Indicates conflict between speaker's prior epistemic state and
+current contextual evidence. Compatible with both outer and inner
+negation. Evidential classification in `Simik2024`. -/
+def razve_ : Particle where
+  form := "razve"
+  script := some "разве"
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [li, razve_]
-
--- Per-datum verification
-
-theorem li_neutral :
-    li.requiresContextualEvidence = none ∧ li.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-theorem razve_evidential : razve_.requiresContextualEvidence = some .forP := rfl
-theorem razve_no_epistemic : razve_.requiresOriginalBias = none := rfl
-
-/-- li and razve form a neutral/evidential contrast (like Mandarin ma/nandao). -/
-theorem bias_contrast :
-    li.requiresContextualEvidence = none ∧ razve_.requiresContextualEvidence = some .forP :=
-  ⟨rfl, rfl⟩
+def allQuestionParticles : List Particle := [li, razve_]
 
 end Russian.QuestionParticles

--- a/Linglib/Fragments/Slavic/Serbian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Serbian/QuestionParticles.lean
@@ -1,74 +1,42 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Serbian Question Particles
 [simik-2024]
 
-Lexical entries for Serbian interrogative particles. The fragment
-commits only to theory-neutral lexical primitives; the left-peripheral
-layer assignment lives in `Simik2024`.
-
-## Particles
-
-| Particle | Gloss | Bias |
-|----------|-------|------|
-| da li | neutral PQ | none |
-| zar | RAZVE (mirative) | +evidential |
+Lexical entries for Serbian interrogative particles as `Particle` values.
+Bias classifications (zar's evidential requirement) and layer assignments
+live in `Simik2024`.
 
 ## Cross-Module Connections
 
-- `Simik2024.serbian` (`Studies/Simik2024`): PQ strategy profile (da li + verb movement)
-- Layer assignments and Fragment-derived bias theorems in `Studies/Simik2024`
-
+- `Simik2024.serbian` (`Studies/Simik2024`): PQ strategy profile
+  (da li + verb movement) and the neutral/evidential contrast
 -/
 
 namespace Serbian.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A Serbian interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
-/-- da li — default PQ particle combination ([simik-2024] ex. 31).
-Particle + verb movement. Neutral baseline. -/
-def daLi : QParticleEntry where
+/-- da li — default PQ particle combination ([simik-2024] ex. 31):
+clause-initial particle + verb movement. Neutral baseline. -/
+def daLi : Particle where
   form := "da li"
-  gloss := "PQ (particle + movement)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-/-- zar — mirative/dubitative particle (RAZVE family, [simik-2024] §4.2.4).
-Compatible with both outer and inner negation (like Russian razve). -/
-def zar_ : QParticleEntry where
+/-- zar — mirative/dubitative particle (RAZVE family, [simik-2024]
+§4.2.4). Compatible with both outer and inner negation (like Russian
+razve). Evidential classification in `Simik2024`. -/
+def zar_ : Particle where
   form := "zar"
-  gloss := "RAZVE (mirative/dubitative)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := none
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [daLi, zar_]
-
-theorem daLi_neutral :
-    daLi.requiresContextualEvidence = none ∧ daLi.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-theorem zar_evidential : zar_.requiresContextualEvidence = some .forP := rfl
-
-/-- da li and zar form a neutral/evidential contrast. -/
-theorem bias_contrast :
-    daLi.requiresContextualEvidence = none ∧ zar_.requiresContextualEvidence = some .forP :=
-  ⟨rfl, rfl⟩
+def allQuestionParticles : List Particle := [daLi, zar_]
 
 end Serbian.QuestionParticles

--- a/Linglib/Fragments/Slavic/Slovenian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Slovenian/QuestionParticles.lean
@@ -1,57 +1,29 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Slovenian Question Particles
 [simik-2024]
 
-Lexical entries for Slovenian interrogative particles. The fragment
-commits only to theory-neutral lexical primitives; the left-peripheral
-layer assignment lives in `Simik2024`.
-
-## Particles
-
-| Particle | Gloss | Bias |
-|----------|-------|------|
-| ali | neutral PQ | none |
-
-*ali* is a clause-initial particle, optional in default PQs.
-Incompatible with DeclPQs ([simik-2024] ex. 28).
+Lexical entry for Slovenian *ali* as a `Particle` value. Layer
+assignment lives in `Simik2024`.
 
 ## Cross-Module Connections
 
 - `Simik2024.slovenian` (`Studies/Simik2024`): PQ strategy profile
-
 -/
 
 namespace Slovenian.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A Slovenian interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
-/-- ali — clause-initial PQ particle ([simik-2024] ex. 28).
-Optional; incompatible with DeclPQs. No bias requirements. -/
-def ali : QParticleEntry where
+/-- ali — clause-initial PQ particle ([simik-2024] ex. 28). Optional in
+default PQs; incompatible with DeclPQs. -/
+def ali : Particle where
   form := "ali"
-  gloss := "PQ (clause-initial neutral)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [ali]
-
-theorem ali_neutral :
-    ali.requiresContextualEvidence = none ∧ ali.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
+def allQuestionParticles : List Particle := [ali]
 
 end Slovenian.QuestionParticles

--- a/Linglib/Fragments/Slavic/Ukrainian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Ukrainian/QuestionParticles.lean
@@ -1,78 +1,47 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Ukrainian Question Particles
 [simik-2024]
 
-Lexical entries for Ukrainian interrogative particles. The fragment
-commits only to theory-neutral lexical primitives; the left-peripheral
-layer assignment lives in `Simik2024`.
-
-## Particles
-
-| Particle | Romanization | Gloss | Bias |
-|----------|-------------|-------|------|
-| чи | čy | neutral PQ | none |
-| хіба | xiba | RAZVE (mirative) | +evidential |
+Lexical entries for Ukrainian interrogative particles as `Particle`
+values. Bias classifications (xiba's evidential requirement) and layer
+assignments live in `Simik2024`.
 
 ## Cross-Module Connections
 
-- `Simik2024.ukrainian` (`Studies/Simik2024`): PQ strategy profile (clause-initial čy obligatory)
-- Cross-Slavic RAZVE family: xiba is the Ukrainian cognate of Russian razve
-
+- `Simik2024.ukrainian` (`Studies/Simik2024`): PQ strategy profile
+  (clause-initial čy obligatory) and the neutral/evidential contrast
+- Cross-Slavic RAZVE family: xiba is the Ukrainian cognate of Russian
+  razve
 -/
 
 namespace Ukrainian.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence OriginalBias)
-
-/-- A Ukrainian interrogative particle entry. -/
-structure QParticleEntry where
-  form : String
-  romanization : String
-  gloss : String
-  polarOk : Bool
-  declOk : Bool
-  whOk : Bool
-  requiresContextualEvidence : Option ContextualEvidence
-  requiresOriginalBias : Option OriginalBias
-  deriving Repr, DecidableEq
-
 /-- чи čy — obligatory clause-initial PQ particle ([simik-2024] ex. 29).
-Neutral baseline, no bias requirements. -/
-def cy : QParticleEntry where
-  form := "чи"
-  romanization := "čy"
-  gloss := "PQ (clause-initial neutral)"
-  polarOk := true
-  declOk := false
-  whOk := true
-  requiresContextualEvidence := none
-  requiresOriginalBias := none
+Neutral baseline. -/
+def cy : Particle where
+  form := "čy"
+  script := some "чи"
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .obligatory
+      constituentInterrogative := some .optional }
 
-/-- хіба xiba — mirative/dubitative particle (RAZVE family, [simik-2024] §4.2.4).
-Ukrainian cognate of Russian razve. Indicates conflict between speaker's
-prior state and contextual evidence. -/
-def xiba : QParticleEntry where
-  form := "хіба"
-  romanization := "xiba"
-  gloss := "RAZVE (mirative/dubitative)"
-  polarOk := true
-  declOk := false
-  whOk := false
-  requiresContextualEvidence := some .forP
-  requiresOriginalBias := none
+/-- хіба xiba — mirative/dubitative particle (RAZVE family, [simik-2024]
+§4.2.4). Ukrainian cognate of Russian razve: indicates conflict between
+speaker's prior state and contextual evidence. Evidential classification
+in `Simik2024`. -/
+def xiba : Particle where
+  form := "xiba"
+  script := some "хіба"
+  position := .clauseInitial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [cy, xiba]
-
-theorem cy_neutral :
-    cy.requiresContextualEvidence = none ∧ cy.requiresOriginalBias = none :=
-  ⟨rfl, rfl⟩
-
-theorem xiba_evidential : xiba.requiresContextualEvidence = some .forP := rfl
-
-/-- čy and xiba form a neutral/evidential contrast. -/
-theorem bias_contrast :
-    cy.requiresContextualEvidence = none ∧ xiba.requiresContextualEvidence = some .forP :=
-  ⟨rfl, rfl⟩
+def allQuestionParticles : List Particle := [cy, xiba]
 
 end Ukrainian.QuestionParticles

--- a/Linglib/Fragments/Swedish/QuestionParticles.lean
+++ b/Linglib/Fragments/Swedish/QuestionParticles.lean
@@ -1,96 +1,43 @@
-import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Syntax.Particle.Basic
+
 /-!
 # Swedish Question Particles
 [seeliger-repp-2018]
 
-Lexical entries for Swedish modal particles that occur in declarative
-questions. The fragment commits only to theory-neutral lexical primitives;
-the left-peripheral layer assignment lives in
-`SeeligerRepp2018`.
-
-## Particles
-
-| Particle | Function | Position | DQ type |
-|----------|----------|----------|---------|
-| väl | question-inducing modal particle | clause-medial (after finite V) | PDQ / NRQ |
-
-Swedish *väl* signals that the speaker is not certain about the
-proposition but suspects it to be true, and expects confirmation from
-the addressee. It is functionally similar to German *wohl* but unlike
-*wohl*, *väl* can also occur in rejecting questions (NRQs) when
-combined with fronted negation.
+Lexical entry for Swedish *väl* as a `Particle` value. *väl* is a
+clause-medial modal particle that turns declaratives into questions:
+it signals speaker uncertainty and invites addressee confirmation.
+Functionally similar to German *wohl*, but unlike *wohl* it can occur in
+rejecting questions (NRQs) when combined with fronted negation. Its bias
+profile and the PDQ/NRQ analysis live in `SeeligerRepp2018`.
 
 Crucially, *väl* is distinct from *jo* (in `AnswerParticles.lean`):
-- *jo* is a polarity-reversing answer particle — it answers negative
-  questions with positive polarity
-- *väl* is a modal particle that turns declaratives into questions —
-  it marks speaker uncertainty and invites addressee confirmation
+*jo* is a polarity-reversing answer particle; *väl* marks declarative
+questions.
 
 ## Other Swedish particles
 
 Swedish also has clause-initial *visst* and *nog* which can mark PRQs,
 but these are not formalized here. [seeliger-repp-2018] note that
-*visst*/*nog* have no overlap in meaning with *väl* in clause-medial
+*visst* and *nog* have no overlap in meaning with *väl* in clause-medial
 position, and their clause-initial uses require further investigation.
-
-## Cross-Module Connections
-
-- `Swedish.AnswerParticles`: *jo* (polarity reversal, not DQ marking)
-- `German.QuestionParticles`: *doch wohl* (German RQ marker)
-- `Semantics.Questions.DeclarativeQuestions`: bias profile typology
 -/
 
 namespace Swedish.QuestionParticles
 
-open Semantics.Questions.Bias (ContextualEvidence)
-
-/-- A Swedish question/modal particle entry. -/
-structure QParticleEntry where
-  form : String
-  gloss : String
-  /-- Compatible with polar questions (declarative syntax)? -/
-  polarOk : Bool
-  /-- Compatible with declarative assertions? -/
-  declOk : Bool
-  /-- Compatible with wh-questions? -/
-  whOk : Bool
-  /-- Contextual-evidence bias the particle requires, or `none`. -/
-  requiresContextualEvidence : Option ContextualEvidence
-  /-- Does this particle signal epistemic uncertainty? -/
-  signalsEpistemicUncertainty : Bool
-  /-- Is this particle question-inducing? -/
-  questionInducing : Bool
-  deriving Repr, DecidableEq
-
-/-- *väl* — question-inducing modal particle.
-
-    [seeliger-repp-2018] SS 5.2: *väl* signals that the speaker is not
-    certain about the proposition but suspects it to be true. The speaker
-    expects a confirmation from the addressee. Declaratives with *väl*
-    cannot be assertions — they are declarative questions.
-
-    Positive *väl*-declaratives have the bias profile of PDQs:
-    evidential [+positive], epistemic [-positive].
-
-    When combined with fronted negation (*inte*), *väl* can mark NRQs:
-    "Inte kommer Peter?" / "Peter kommer väl inte?" -/
-def val : QParticleEntry where
+/-- *väl* — question-inducing modal particle, clause-medial (after the
+finite verb): declarative-syntax polar questions (recorded under
+`polarInterrogative` following the source schema's question-function
+reading), not plain assertions, not wh-questions. Epistemic-uncertainty
+signal and evidential bias live in `SeeligerRepp2018`. -/
+def val : Particle where
   form := "väl"
-  gloss := "MP (question-inducing uncertainty particle)"
-  polarOk := true
-  declOk := false  -- väl-declaratives are questions, not assertions
-  whOk := false
-  requiresContextualEvidence := some .forP
-  signalsEpistemicUncertainty := true
-  questionInducing := true
+  position := .clauseMedial
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional
+      constituentInterrogative := some .excluded }
 
-def allQuestionParticles : List QParticleEntry := [val]
-
--- Verification theorems
-theorem val_form : val.form = "väl" := rfl
-theorem val_question_inducing : val.questionInducing = true := rfl
-theorem val_signals_uncertainty : val.signalsEpistemicUncertainty = true := rfl
-theorem val_requires_evidential : val.requiresContextualEvidence = some .forP := rfl
-theorem val_not_assertion : val.declOk = false := rfl
+def allQuestionParticles : List Particle := [val]
 
 end Swedish.QuestionParticles

--- a/Linglib/Studies/SeeligerRepp2018.lean
+++ b/Linglib/Studies/SeeligerRepp2018.lean
@@ -485,76 +485,69 @@ open German.PolarityMarking (dochPreUtterance)
 open Semantics.Polarity.Marking (Env)
 
 /-- Swedish *väl* is question-inducing — declaratives with *väl* are
-    questions, not assertions ([seeliger-repp-2018] §5.2). -/
+    questions, not assertions ([seeliger-repp-2018] §5.2). Derived from
+    the fragment's distribution facet. -/
 theorem val_creates_questions :
-    Swedish.QuestionParticles.val.questionInducing = true ∧
-    Swedish.QuestionParticles.val.declOk = false := ⟨rfl, rfl⟩
+    ¬ Swedish.QuestionParticles.val.LicensedIn .declarative := by decide
 
-/-- Swedish *väl* requires evidential bias — it is felicitous only in
-    contexts with contextual evidence for the proposition, matching the
-    evidential bias of PDQs and NRQs. -/
-theorem val_requires_evidence :
-    Swedish.QuestionParticles.val.requiresContextualEvidence = some .forP := rfl
+/-- S&R's bias classification of *väl* (formerly fragment fields; a
+    particle's bias requirement is the analysis, so it lives here):
+    felicitous only in contexts with contextual evidence for the
+    proposition, matching the evidential bias of PDQs and NRQs. -/
+def valContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
+  some .forP
 
-/-- Swedish *väl* signals epistemic uncertainty — the speaker suspects
-    p is true but is not certain. This corresponds to the [-positive]
-    epistemic bias of PDQs (speaker did not already assume p). -/
-theorem val_signals_uncertainty :
-    Swedish.QuestionParticles.val.signalsEpistemicUncertainty = true := rfl
+/-- S&R's classification, epistemic dimension: *väl* signals epistemic
+    *uncertainty* — the speaker suspects p but is not certain,
+    corresponding to the [-positive] epistemic bias of PDQs — so it
+    imposes no original-bias requirement (contrast `dochWohlOriginalBias`). -/
+def valOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10. German *doch wohl* marks RQs via REJECTQ
 -- ════════════════════════════════════════════════════════════════
 
-/-- German *doch wohl* requires both bias dimensions to be active,
-    consistent with the fact that RQs have both evidential and epistemic
-    presuppositions in the REJECTQ definition (eq. 40). Both presuppositions
-    must be satisfied for REJECTQ to be felicitous. -/
-theorem dochWohl_matches_rejectQ :
-    German.QuestionParticles.dochWohl.requiresContextualEvidence = some .forP ∧
-    German.QuestionParticles.dochWohl.requiresOriginalBias = some .againstP := ⟨rfl, rfl⟩
+/-- S&R's bias classification of *doch wohl*: both dimensions active —
+    contextual evidence for p (prototypical NRQ reading) and prior
+    speaker bias against p — consistent with RQs having both evidential
+    and epistemic presuppositions in the REJECTQ definition (eq. 40).
+    Shares its evidential value with `valContextualEvidence`; the
+    epistemic dimension is where German is stricter than Swedish. -/
+def dochWohlContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
+  some .forP
 
-/-- *doch wohl* is not usable in assertions — it marks questions. -/
+/-- See `dochWohlContextualEvidence`: prior speaker bias against p. -/
+def dochWohlOriginalBias : Option Semantics.Questions.Bias.OriginalBias :=
+  some .againstP
+
+/-- *doch wohl* is not usable in assertions — it marks questions.
+    Derived from the fragment's distribution facet. -/
 theorem dochWohl_not_assertion :
-    German.QuestionParticles.dochWohl.declOk = false := rfl
+    ¬ German.QuestionParticles.dochWohl.LicensedIn .declarative := by decide
 
-/-- *doch wohl* requires both bias dimensions to be "plus" (active bias),
-    matching the derived RQ property that RQ epistemic bias is always active.
-    This connects the Fragment entry to the theory-level theorem
-    `rq_epistemic_is_plus`. -/
-theorem dochWohl_both_biases_active :
-    dochWohl.requiresContextualEvidence = some .forP ∧
-    dochWohl.requiresOriginalBias = some .againstP ∧
+/-- The derived RQ property behind `dochWohlOriginalBias`: both DQ types
+    *doch wohl* can mark have active ("plus") epistemic bias — the
+    theory-level theorem `rq_epistemic_is_plus` in fragment-free form. -/
+theorem rq_bias_dimensions_active :
     DeclQuestionType.PRQ.biasProfile.epistemic.IsPlus ∧
-    DeclQuestionType.NRQ.biasProfile.epistemic.IsPlus := ⟨rfl, rfl, by decide, by decide⟩
+    DeclQuestionType.NRQ.biasProfile.epistemic.IsPlus := ⟨by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 11. Cross-linguistic comparison
 -- ════════════════════════════════════════════════════════════════
 
-/-- Both Swedish *väl* and German *doch wohl* require evidential bias.
-    This reflects the shared property that both languages require
-    contextual evidence for DQs/RQs. -/
+/-- Both Swedish *väl* and German *doch wohl* require evidential bias
+    (`valContextualEvidence` = `dochWohlContextualEvidence` = `some .forP`),
+    reflecting the shared property that both languages require contextual
+    evidence for DQs/RQs. Where they differ is the epistemic dimension:
+    *doch wohl* marks RQs (prior commitment against p,
+    `dochWohlOriginalBias`), *väl* marks DQs (uncertainty, no
+    original-bias requirement, `valOriginalBias`) — German is stricter.
+    German *denn* differs from both: it imposes no bias requirement at
+    all; its felicity condition is the highlighting/precondition relation
+    (see `Theiler2021`). -/
 theorem both_require_evidential :
-    Swedish.QuestionParticles.val.requiresContextualEvidence =
-    German.QuestionParticles.dochWohl.requiresContextualEvidence := rfl
-
-/-- German *doch wohl* additionally requires epistemic bias, while
-    Swedish *väl* signals epistemic *uncertainty* — a weaker condition.
-    This corresponds to the difference between RQs (epistemic commitment)
-    and DQs (epistemic non-commitment): *doch wohl* marks RQs (plus
-    epistemic), *väl* marks DQs (minus epistemic). -/
-theorem german_stricter_epistemic :
-    German.QuestionParticles.dochWohl.requiresOriginalBias = some .againstP ∧
-    Swedish.QuestionParticles.val.signalsEpistemicUncertainty = true := ⟨rfl, rfl⟩
-
-/-- German *denn* (flavoring particle) differs from *doch wohl* (RQ marker):
-    *denn* imposes no bias requirement — its felicity condition is the
-    highlighting/precondition relation (see `Theiler2021`), not bias —
-    whereas *doch wohl* requires both bias dimensions. -/
-theorem denn_vs_dochWohl :
-    German.QuestionParticles.denn.requiresOriginalBias = none ∧
-    German.QuestionParticles.dochWohl.requiresOriginalBias = some .againstP := ⟨rfl, rfl⟩
+    valContextualEvidence = dochWohlContextualEvidence := rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § 12. Non-compositional *doch wohl* and the dual role of *doch*
@@ -573,7 +566,7 @@ theorem dochWohl_is_complex :
     In RQs, *doch* has a "conflict" meaning — it signals surprise or
     realization — rather than the "reminding" function of assertive *doch*. -/
 theorem dochWohl_is_question_marker :
-    German.QuestionParticles.dochWohl.declOk = false := rfl
+    ¬ German.QuestionParticles.dochWohl.LicensedIn .declarative := by decide
 
 /-- German *doch* is formally ambiguous between two distinct roles:
     1. **Polarity-reversal *doch***: pre-utterance correction particle
@@ -594,7 +587,7 @@ theorem doch_dual_role :
     Env.correction ∈ dochPreUtterance.environments ∧
     Env.sentenceInternal ∉ dochPreUtterance.environments ∧
     -- The RQ *doch wohl* is a question marker (not usable in assertions)
-    dochWohl.declOk = false := ⟨rfl, by decide, by decide, rfl⟩
+    ¬ dochWohl.LicensedIn .declarative := ⟨rfl, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13. Romero-bridge applied to the Swedish/German data
@@ -619,8 +612,8 @@ open Features (QParticleLayer)
     [dayal-2025] cartography `[SAP [PerspP [CP ...]]]`. The `_`
     argument is unused: the layer is a theoretical overlay on the
     fragment particle, not a computed property of its lexical fields. -/
-def val_layer      (_ : Swedish.QuestionParticles.QParticleEntry) : QParticleLayer := .perspP
-def dochWohl_layer (_ : German.QuestionParticles.QParticleEntry)  : QParticleLayer := .perspP
+def val_layer      (_ : Particle) : QParticleLayer := .perspP
+def dochWohl_layer (_ : Particle) : QParticleLayer := .perspP
 
 /-- Both modal-particle complexes that mark RQs/DQs in this study sit
     at PerspP — the layer for biased, matrix-only question particles. -/

--- a/Linglib/Studies/Simik2024.lean
+++ b/Linglib/Studies/Simik2024.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.QParticleLayer
+import Linglib.Semantics.Questions.Bias.Defs
 import Linglib.Fragments.Slavic.Russian.QuestionParticles
 import Linglib.Fragments.Slavic.Bulgarian.QuestionParticles
 import Linglib.Fragments.Slavic.Ukrainian.QuestionParticles
@@ -16,9 +17,10 @@ particle by its left-peripheral layer in the [bhatt-dayal-2020] /
 [dayal-2025] cartography `[SAP [PerspP [CP ...]]]`.
 
 The fragments in `Fragments/{Russian,Bulgarian,Ukrainian,Polish,
-Slovenian,Serbian,Macedonian}/QuestionParticles.lean` carry only theory-
-neutral lexical primitives (form, gloss, bias profile). This study file
-overlays [simik-2024]'s layer assignments and proves the Slavic
+Slovenian,Serbian,Macedonian}/QuestionParticles.lean` carry only
+theory-neutral lexical primitives (form, position, distribution). This
+study file overlays [simik-2024]'s layer assignments and bias
+classification (`evidentialRequirement`) and proves the Slavic
 generalization that the *neutral* PQ-particle of each surveyed language
 sits at CP, while the *biased mirative* particles (the cross-Slavic
 RAZVE family) sit at PerspP.
@@ -58,18 +60,18 @@ Each `def` records Šimík's classification of a Fragment particle. The
 `_` argument is unused because the layer assignment is a theoretical
 overlay on the particle, not a computed property of its lexical fields. -/
 
-def russianLi_layer        (_ : Russian.QuestionParticles.QParticleEntry)    : QParticleLayer := .cp
-def russianRazve_layer     (_ : Russian.QuestionParticles.QParticleEntry)    : QParticleLayer := .perspP
-def bulgarianLi_layer      (_ : Bulgarian.QuestionParticles.QParticleEntry)  : QParticleLayer := .cp
-def bulgarianNima_layer    (_ : Bulgarian.QuestionParticles.QParticleEntry)  : QParticleLayer := .perspP
-def ukrainianCy_layer      (_ : Ukrainian.QuestionParticles.QParticleEntry)  : QParticleLayer := .cp
-def ukrainianXiba_layer    (_ : Ukrainian.QuestionParticles.QParticleEntry)  : QParticleLayer := .perspP
-def polishCzy_layer        (_ : Polish.QuestionParticles.QParticleEntry)     : QParticleLayer := .cp
-def polishCzyzby_layer     (_ : Polish.QuestionParticles.QParticleEntry)     : QParticleLayer := .perspP
-def slovenianAli_layer     (_ : Slovenian.QuestionParticles.QParticleEntry)  : QParticleLayer := .cp
-def serbianDaLi_layer      (_ : Serbian.QuestionParticles.QParticleEntry)    : QParticleLayer := .cp
-def serbianZar_layer       (_ : Serbian.QuestionParticles.QParticleEntry)    : QParticleLayer := .perspP
-def macedonianDali_layer   (_ : Macedonian.QuestionParticles.QParticleEntry) : QParticleLayer := .cp
+def russianLi_layer        (_ : Particle) : QParticleLayer := .cp
+def russianRazve_layer     (_ : Particle) : QParticleLayer := .perspP
+def bulgarianLi_layer      (_ : Particle) : QParticleLayer := .cp
+def bulgarianNima_layer    (_ : Particle) : QParticleLayer := .perspP
+def ukrainianCy_layer      (_ : Particle) : QParticleLayer := .cp
+def ukrainianXiba_layer    (_ : Particle) : QParticleLayer := .perspP
+def polishCzy_layer        (_ : Particle) : QParticleLayer := .cp
+def polishCzyzby_layer     (_ : Particle) : QParticleLayer := .perspP
+def slovenianAli_layer     (_ : Particle) : QParticleLayer := .cp
+def serbianDaLi_layer      (_ : Particle) : QParticleLayer := .cp
+def serbianZar_layer       (_ : Particle) : QParticleLayer := .perspP
+def macedonianDali_layer   (_ : Particle) : QParticleLayer := .cp
 
 /-! ## Cross-Slavic generalizations -/
 
@@ -81,9 +83,8 @@ open Slovenian.QuestionParticles  in
 open Serbian.QuestionParticles    in
 open Macedonian.QuestionParticles in
 /-- The neutral polar-question particle of every surveyed Slavic language
-    sits at CP. The fragment-level evidence that this is the *neutral*
-    particle is the conjunction of `requiresContextualEvidence = none` and
-    `requiresOriginalBias = none`. -/
+    sits at CP. Which particle counts as *neutral* is Šimík's
+    classification, recorded below as `evidentialRequirement`. -/
 theorem neutral_PQ_particles_are_CP :
     russianLi_layer Russian.QuestionParticles.li = .cp ∧
     bulgarianLi_layer Bulgarian.QuestionParticles.li = .cp ∧
@@ -110,23 +111,23 @@ theorem razve_family_is_PerspP :
     serbianZar_layer Serbian.QuestionParticles.zar_ = .perspP :=
   ⟨rfl, rfl, rfl, rfl, rfl⟩
 
-/-- Bridge between the layer assignment and the bias profile recorded
-    in the fragments: every PerspP-layer Slavic particle in this study
-    requires evidential bias, while every CP-layer particle does not. -/
-theorem layer_correlates_with_bias :
-    Russian.QuestionParticles.li.requiresContextualEvidence = none ∧
-    Russian.QuestionParticles.razve_.requiresContextualEvidence = some .forP ∧
-    Bulgarian.QuestionParticles.li.requiresContextualEvidence = none ∧
-    Bulgarian.QuestionParticles.nima.requiresContextualEvidence = some .forP ∧
-    Ukrainian.QuestionParticles.cy.requiresContextualEvidence = none ∧
-    Ukrainian.QuestionParticles.xiba.requiresContextualEvidence = some .forP ∧
-    Polish.QuestionParticles.czy.requiresContextualEvidence = none ∧
-    Polish.QuestionParticles.czyzby.requiresContextualEvidence = some .forP ∧
-    Serbian.QuestionParticles.daLi.requiresContextualEvidence = none ∧
-    Serbian.QuestionParticles.zar_.requiresContextualEvidence = some .forP ∧
-    Slovenian.QuestionParticles.ali.requiresContextualEvidence = none ∧
-    Macedonian.QuestionParticles.dali.requiresContextualEvidence = none :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+/-- The cross-Slavic *RAZVE* family as a list. Šimík's bias
+    classification (§4.2): these require contextual evidence for p
+    (`evidentialRequirement`), while the neutral PQ particles impose no
+    bias requirement. The layer assignments above correlate — RAZVE =
+    PerspP, neutral = CP — which is Šimík's analysis, not a lexical
+    fact, so both classifications live here rather than on the fragment
+    entries. -/
+def razveFamily : List Particle :=
+  [Russian.QuestionParticles.razve_, Bulgarian.QuestionParticles.nima,
+   Ukrainian.QuestionParticles.xiba, Polish.QuestionParticles.czyzby,
+   Serbian.QuestionParticles.zar_]
+
+/-- Evidential requirement per Šimík: `.forP` for the RAZVE family,
+    none for the neutral particles. -/
+def evidentialRequirement (p : Particle) :
+    Option Semantics.Questions.Bias.ContextualEvidence :=
+  if p ∈ razveFamily then some .forP else none
 
 /-! ### Default PQ strategies
 
@@ -211,7 +212,7 @@ def slovenian : PQProfile :=
 def ukrainian : PQProfile :=
   { language := "Ukrainian", code := "uk"
   , defaultStrategy := .clauseInitialParticle
-  , particle := some Ukrainian.QuestionParticles.cy.romanization
+  , particle := some Ukrainian.QuestionParticles.cy.form
   , declPQ := .available }
 
 /-- Polish: clause-initial *czy* (obligatory in default PQ).
@@ -239,7 +240,7 @@ Bulgarian *li*. -/
 def macedonian : PQProfile :=
   { language := "Macedonian", code := "mk"
   , defaultStrategy := .clauseInitialParticle
-  , particle := some Macedonian.QuestionParticles.dali.romanization
+  , particle := some Macedonian.QuestionParticles.dali.form
   , declPQ := .unavailable
   , negationTriggersBias := false }
 
@@ -249,7 +250,7 @@ constituent. DeclPQs are colloquial only. -/
 def bulgarian : PQProfile :=
   { language := "Bulgarian", code := "bg"
   , defaultStrategy := .verbAttachedParticle
-  , particle := some Bulgarian.QuestionParticles.li.romanization
+  , particle := some Bulgarian.QuestionParticles.li.form
   , declPQ := .marginal }
 
 /-- Russian: verb-attached *li* (formal) or IntonPQ (default).
@@ -259,7 +260,7 @@ arguably unbiased (see [simik-2024]). -/
 def russian : PQProfile :=
   { language := "Russian", code := "ru"
   , defaultStrategy := .intonationOnly
-  , particle := some Russian.QuestionParticles.li.romanization
+  , particle := some Russian.QuestionParticles.li.form
   , declPQ := .unavailable }
 
 /-- All ten surveyed Slavic PQ profiles. -/

--- a/Linglib/Studies/Theiler2021.lean
+++ b/Linglib/Studies/Theiler2021.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.QParticleLayer
 import Linglib.Fragments.German.QuestionParticles
 import Linglib.Fragments.Mandarin.QuestionParticles
+import Linglib.Semantics.Questions.Bias.Defs
 
 /-!
 # Theiler (2021): *Denn* as a Highlighting-Sensitive Particle
@@ -31,25 +32,28 @@ open Features (QParticleLayer)
 /-- Theiler's layer assignment for *denn*. The `_` argument is unused
     because the layer is a theoretical overlay, not a computed property
     of the fragment entry. -/
-def denn_layer (_ : German.QuestionParticles.QParticleEntry) : QParticleLayer := .perspP
+def denn_layer (_ : Particle) : QParticleLayer := .perspP
 
 /-- *denn* sits at PerspP, the same layer as Mandarin *nandao*. -/
 theorem denn_is_PerspP :
     denn_layer German.QuestionParticles.denn = .perspP := rfl
 
-/-- *denn* imposes no bias requirement. Theiler's felicity condition is a
-    highlighting/precondition relation, not a contextual- or speaker-bias
-    requirement; this is the point on which *denn* differs from its
-    evidence-requiring Mandarin parallel *nandao*. -/
-theorem denn_imposes_no_bias :
-    German.QuestionParticles.denn.requiresContextualEvidence = none ∧
-    German.QuestionParticles.denn.requiresOriginalBias = none := ⟨rfl, rfl⟩
+/-- Theiler's bias classification of *denn*: no contextual-evidence and no
+    speaker-bias requirement — the felicity condition is a
+    highlighting/precondition relation instead. This is the point on which
+    *denn* differs from its evidence-requiring Mandarin parallel *nandao*
+    (whose classification lives in `Zheng2025`), and the point on which
+    Bayer/Obenauer-style evidence-sensitive analyses of *denn* would
+    disagree. -/
+def dennBias : Option Semantics.Questions.Bias.ContextualEvidence := none
 
-/-- Unlike Mandarin *nandao*, *denn* is compatible with *wh*-questions.
-    Both are PerspP-layer particles, but *denn* lacks *nandao*'s polar-only
-    restriction (and its contextual-evidence requirement). -/
+/-- Unlike Mandarin *nandao*, *denn* is licensed in constituent
+    questions. Both are PerspP-layer particles, but *denn* lacks
+    *nandao*'s polar-only restriction. Derived from the fragments'
+    distribution facets. -/
 theorem denn_wh_unlike_nandao :
-    German.QuestionParticles.denn.whOk = true ∧
-    Mandarin.QuestionParticles.nandao.whOk = false := ⟨rfl, rfl⟩
+    German.QuestionParticles.denn.LicensedIn .constituentInterrogative ∧
+    ¬ Mandarin.QuestionParticles.nandao.LicensedIn .constituentInterrogative := by
+  decide
 
 end Theiler2021

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -2,6 +2,7 @@ import Linglib.Data.UD.Basic
 import Linglib.Fragments.Mandarin.QuestionParticles
 import Linglib.Semantics.Modality.Kernel
 import Linglib.Features.QParticleLayer
+import Linglib.Semantics.Questions.Bias.Defs
 import Linglib.Semantics.Questions.Singleton
 import Linglib.Studies.BhattDayal2020
 
@@ -25,10 +26,9 @@ nor sufficient**.
 
 ## Predictions verified
 
-- `fragment_data_evidential`: Fragment entry's evidential bias requirement
-  matches the empirical generalization
-- `fragment_data_epistemic`: Fragment entry correctly does not require
-  epistemic bias
+- `nandaoContextualEvidence` / `nandaoOriginalBias`: Zheng's bias
+  classification of *nandao*, grounded in `evidential_bias_necessary`
+  and `epistemic_bias_not_necessary`
 - `kernel_requires_evidence`: Kernel `nandaoFelicitous` entails
   `evidenceSupports`
 - `nandaoFullFelicity`: integrated two-layer felicity (singleton sister
@@ -215,23 +215,21 @@ theorem dataset_size : allData.length = 9 := by native_decide
 open Mandarin.QuestionParticles (nandao)
 open Semantics.Modality (Kernel Background nandaoFelicitous World)
 
-/-- The nandao Fragment entry's evidential bias requirement matches the
-empirical generalization: all felicitous nandao-Qs have evidential bias. -/
-theorem fragment_data_evidential :
-    nandao.requiresContextualEvidence = some .forP ∧
-    (allData.filter (·.felicitous)).all (·.evidentialBias) = true :=
-  ⟨rfl, by native_decide⟩
+/-- Zheng's evidential classification of *nandao*: requires contextual
+evidence for p — the lexical face of `evidential_bias_necessary`.
+(Formerly a fragment field; a particle's bias requirement is the
+analysis, so it lives here.) -/
+def nandaoContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
+  some .forP
 
-/-- The nandao Fragment entry correctly does NOT require epistemic bias,
-matching the empirical finding that some felicitous nandao-Qs lack it. -/
-theorem fragment_data_epistemic :
-    nandao.requiresOriginalBias = none ∧
-    (allData.filter (λ d => d.felicitous && !d.epistemicBias)).length > 0 :=
-  ⟨rfl, by native_decide⟩
+/-- Zheng's classification: *nandao* does NOT require epistemic bias —
+compatible with a neutral epistemic state (pure inquiry use, ex. 3);
+the lexical face of `epistemic_bias_not_necessary`. -/
+def nandaoOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
 
 /-- Kernel `nandaoFelicitous` entails `evidenceSupports`, connecting the
-Theory predicate to the Fragment's `requiresContextualEvidence = some .forP` and
-the empirical generalization `evidential_bias_necessary`. -/
+Theory predicate to `nandaoContextualEvidence` and the empirical
+generalization `evidential_bias_necessary`. -/
 theorem kernel_requires_evidence (k : Kernel World) (u : Background World) (φ : (World → Prop))
     [DecidablePred φ] (h : nandaoFelicitous k u φ) :
     k.evidenceSupports φ :=
@@ -242,15 +240,15 @@ theorem kernel_requires_evidence (k : Kernel World) (u : Background World) (φ :
 -- ════════════════════════════════════════════════════════════════════════════
 
 open Features (QParticleLayer)
-open Mandarin.QuestionParticles (QuestionParticleEntry ma ba)
+open Mandarin.QuestionParticles (ma ba)
 
 /-- Zheng's layer assignments for the three Mandarin Q-particles in the
     [dayal-2025] cartography `[SAP [PerspP [CP ...]]]`. The `_`
     argument is unused: the layer is a theoretical overlay on the
     fragment particle, not a computed property of its lexical fields. -/
-def ma_layer     (_ : QuestionParticleEntry) : QParticleLayer := .cp
-def ba_layer     (_ : QuestionParticleEntry) : QParticleLayer := .perspP
-def nandao_layer (_ : QuestionParticleEntry) : QParticleLayer := .perspP
+def ma_layer     (_ : Particle) : QParticleLayer := .cp
+def ba_layer     (_ : Particle) : QParticleLayer := .perspP
+def nandao_layer (_ : Particle) : QParticleLayer := .perspP
 
 /-- *ma* is the unmarked CP-layer particle: widest distribution
     (matrix, subordinated, quasi-subordinated). -/
@@ -261,14 +259,12 @@ theorem ma_is_CP : ma_layer ma = .cp := rfl
 theorem ba_nandao_PerspP :
     ba_layer ba = .perspP ∧ nandao_layer nandao = .perspP := ⟨rfl, rfl⟩
 
-/-- The layer split mirrors the bias-profile split: the unbiased
-    particle is CP, the biased ones are PerspP. -/
-theorem layer_correlates_with_bias :
-    ma_layer ma = .cp ∧
-    ma.requiresContextualEvidence = none ∧ ma.requiresOriginalBias = none ∧
-    ba_layer ba = .perspP ∧ ba.requiresOriginalBias = some .forP ∧
-    nandao_layer nandao = .perspP ∧ nandao.requiresContextualEvidence = some .forP :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+/-- Zheng's classification of *ba*: speaker-bias (expects a positive
+    answer, seeks confirmation), no evidential requirement; the unbiased
+    *ma* imposes neither. The layer split mirrors this bias split — the
+    unbiased particle is CP (`ma_is_CP`), the biased ones PerspP
+    (`ba_nandao_PerspP`). -/
+def baOriginalBias : Option Semantics.Questions.Bias.OriginalBias := some .forP
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- §4 — Singleton-Alternative Presupposition (parallel to kya:)

--- a/Linglib/Syntax/Particle/Basic.lean
+++ b/Linglib/Syntax/Particle/Basic.lean
@@ -1,0 +1,139 @@
+import Linglib.Features.ClauseCtx
+import Linglib.Morphology.Word
+
+/-!
+# Particle
+[zwicky-1985-clitics]
+
+Lexical core for the particle as a grammatical object: an uninflectable
+function word associated with a host constituent. Per [zwicky-1985-clitics],
+"particle" is a residual class — membership is non-inflectability plus
+function-word status, not a rich natural kind — so the core carries only
+what every particle has (form, position), and everything else lives in
+domain-layer facets and study files.
+
+The clause-type distribution facet records *distributional felicity*
+across [sadock-zwicky-1985] clause contexts, three-valued per cell
+(obligatory / optional / excluded, cf. WALS ch. 116 on polar-question
+marking: Polish *czy* is obligatory in polar interrogatives, Japanese
+*ka* optional in matrix but obligatory in subordinated clauses). It does
+NOT record the licensing *mechanism* (use-conditional conflict,
+clause-typing, selection) — that is analytical and stays in study files.
+A cell is `none` when the anchoring source records nothing for it —
+absence of a record is not a claim of exclusion.
+
+## Main declarations
+
+* `Particle` — the core: surface `form`, optional native `script`,
+  `position`, and an optional clause-type `distribution` facet
+  (particles with no clause-type restriction — focus, case — carry
+  `none`).
+* `Particle.Position` — host/position class (the [zwicky-1985-clitics]
+  positional diagnostic; second-position = Wackernagel).
+* `ParticleStatus` / `ClauseDistribution` — three-valued per-cell
+  distribution over `Features.ClauseCtx`.
+* `Particle.status?` / `Particle.LicensedIn` — derived distribution
+  views; `status?` is the class-ready signature a future
+  `Distributed α Ctx` capability abstracts.
+* `Particle.toWord` — projection to `Word` (UD `PART`).
+-/
+
+set_option autoImplicit false
+
+open Features (ClauseCtx)
+
+/-- Where a particle sits relative to its host domain
+([zwicky-1985-clitics]'s positional diagnostic; the cline from free
+word to clitic surfaces here — Polish *czy* clause-initial free word,
+Slavic *li* second-position Wackernagel clitic, Japanese *ka*
+clause-final clitic/suffix). -/
+inductive Particle.Position where
+  | clauseInitial
+  /-- Second position (Wackernagel; Slavic *li*). -/
+  | secondPosition
+  /-- Clause-medial / middle field (German *denn*, Swedish *väl*). -/
+  | clauseMedial
+  | clauseFinal
+  /-- Immediately before a host constituent (adnominal focus particles). -/
+  | preHost
+  /-- Immediately after a host constituent. -/
+  | postHost
+  deriving DecidableEq, Repr
+
+/-- Three-valued distribution status of a particle in a clause context
+(cf. WALS ch. 116): obligatorily present, optionally present, or
+excluded. -/
+inductive ParticleStatus where
+  | obligatory
+  | optional
+  | excluded
+  deriving DecidableEq, Repr
+
+/-- Per-clause-context distribution record. Each cell is `Option`-valued:
+`none` means the anchoring source records nothing for that context —
+distinct from `some .excluded`, which is a positive claim. -/
+structure ClauseDistribution where
+  declarative : Option ParticleStatus := none
+  polarInterrogative : Option ParticleStatus := none
+  alternativeInterrogative : Option ParticleStatus := none
+  constituentInterrogative : Option ParticleStatus := none
+  imperative : Option ParticleStatus := none
+  exclamative : Option ParticleStatus := none
+  deriving DecidableEq, Repr
+
+/-- Recorded status in context `c`, if any. -/
+def ClauseDistribution.status? (d : ClauseDistribution) : ClauseCtx → Option ParticleStatus
+  | .declarative => d.declarative
+  | .polarInterrogative => d.polarInterrogative
+  | .alternativeInterrogative => d.alternativeInterrogative
+  | .constituentInterrogative => d.constituentInterrogative
+  | .imperative => d.imperative
+  | .exclamative => d.exclamative
+
+/-- A particle: an uninflectable function word associated with a host
+constituent. -/
+structure Particle where
+  /-- Surface form (romanization or orthographic). -/
+  form : String
+  /-- Native-script form, when `form` is a romanization (Mandarin 吗). -/
+  script : Option String := none
+  /-- Host/position class. -/
+  position : Particle.Position
+  /-- Clause-type distribution facet; `none` for particles with no
+      clause-type restriction (focus particles, case particles). -/
+  distribution : Option ClauseDistribution := none
+  deriving DecidableEq, Repr
+
+namespace Particle
+
+/-- Recorded distribution status in context `c`, if any. Class-ready
+signature: a future `Distributed α Ctx` capability exposes exactly this. -/
+def status? (p : Particle) (c : ClauseCtx) : Option ParticleStatus :=
+  p.distribution.bind (·.status? c)
+
+/-- The particle is positively recorded as available (obligatorily or
+optionally) in context `c`. -/
+def LicensedIn (p : Particle) (c : ClauseCtx) : Prop :=
+  match p.status? c with
+  | some .obligatory | some .optional => True
+  | _ => False
+
+instance (p : Particle) (c : ClauseCtx) : Decidable (p.LicensedIn c) := by
+  unfold LicensedIn; exact match p.status? c with
+    | some .obligatory => .isTrue trivial
+    | some .optional => .isTrue trivial
+    | some .excluded => .isFalse nofun
+    | none => .isFalse nofun
+
+/-- Carries a clause-type distribution (the sentential/illocutionary
+particle family: question, modal, sentence-final particles). -/
+def IsSentential (p : Particle) : Prop := p.distribution.isSome
+
+instance (p : Particle) : Decidable p.IsSentential :=
+  inferInstanceAs (Decidable (_ = true))
+
+/-- Projection to `Word` (UD `PART`). -/
+def toWord (p : Particle) : Word :=
+  { form := p.form, cat := .PART, features := {} }
+
+end Particle

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -35498,3 +35498,29 @@
   role      = {formalized},
   sources   = {Studies/HartmannZimmermann2004.lean}
 }
+
+@article{zwicky-1985-clitics,
+  author    = {Zwicky, Arnold M.},
+  year      = {1985},
+  title     = {Clitics and Particles},
+  journal   = {Language},
+  volume    = {61},
+  number    = {2},
+  pages     = {283--305},
+  subfield  = {syntax/particles},
+  role      = {foundational},
+  sources   = {Syntax/Particle/Basic.lean}
+}
+
+@incollection{sadock-zwicky-1985,
+  author    = {Sadock, Jerrold M. and Zwicky, Arnold M.},
+  year      = {1985},
+  title     = {Speech Act Distinctions in Syntax},
+  booktitle = {Language Typology and Syntactic Description, Volume 1: Clause Structure},
+  editor    = {Shopen, Timothy},
+  publisher = {Cambridge University Press},
+  pages     = {155--196},
+  subfield  = {semantics/mood},
+  role      = {foundational},
+  sources   = {Features/ClauseCtx.lean}
+}


### PR DESCRIPTION
New `Syntax/Particle/Basic.lean` (form/script/position + three-valued clause-type distribution facet over the new Sadock-Zwicky-anchored `Features/ClauseCtx.lean`) replacing ten identical per-language `QParticleEntry` structs; the four consumer studies now own their bias classifications as defs instead of rfl-reading fragment fields.

- Distribution cells are `Option ParticleStatus` (obligatory/optional/excluded; `none` = source silent), with `LicensedIn` as the derived decidable Prop — class-ready for a future `Distributed α Ctx` capability.
- Bib: adds verified `zwicky-1985-clitics` and `sadock-zwicky-1985` entries.