### PR TITLE
refactor(Semantics/Focus): evenPresupWith Bool to Prop with DecidableRel

### DIFF
--- a/Linglib/Semantics/Focus/Particles.lean
+++ b/Linglib/Semantics/Focus/Particles.lean
@@ -150,18 +150,28 @@ inductive EvenThreshold where
 
 /-- Count of alternatives that the prejacent exceeds under a decidable ordering. -/
 def countExceeded {α : Type*} (prejacent : α) (alternatives : List α)
-    (moreSurprising : α → α → Bool) : Nat :=
-  (alternatives.filter (moreSurprising prejacent)).length
+    (moreSurprising : α → α → Prop) [DecidableRel moreSurprising] : Nat :=
+  (alternatives.filter (fun a => decide (moreSurprising prejacent a))).length
 
 /-- Generalized EVEN presupposition parameterized by threshold.
-    `moreSurprising a b` returns `true` when `a` is more surprising
-    (less likely) than `b`. -/
+    `moreSurprising a b` holds when `a` is more surprising (less
+    likely) than `b`. -/
 def evenPresupWith {α : Type*} (prejacent : α) (alternatives : List α)
-    (moreSurprising : α → α → Bool) (threshold : EvenThreshold) : Bool :=
+    (moreSurprising : α → α → Prop) [DecidableRel moreSurprising]
+    (threshold : EvenThreshold) : Prop :=
   let n := countExceeded prejacent alternatives moreSurprising
   match threshold with
-  | .existential => decide (n > 0)
-  | .universal => decide (n = alternatives.length)
-  | .most => decide (n * 2 > alternatives.length)
+  | .existential => n > 0
+  | .universal => n = alternatives.length
+  | .most => n * 2 > alternatives.length
+
+instance {α : Type*} (prejacent : α) (alternatives : List α)
+    (moreSurprising : α → α → Prop) [DecidableRel moreSurprising]
+    (threshold : EvenThreshold) :
+    Decidable (evenPresupWith prejacent alternatives moreSurprising threshold) := by
+  unfold evenPresupWith; exact match threshold with
+    | .existential => inferInstanceAs (Decidable (_ > _))
+    | .universal => inferInstanceAs (Decidable (_ = _))
+    | .most => inferInstanceAs (Decidable (_ > _))
 
 end Semantics.Focus.Particles

--- a/Linglib/Studies/Francescotti1995.lean
+++ b/Linglib/Studies/Francescotti1995.lean
@@ -58,7 +58,7 @@ structure EvenScenario where
 
 /-- Predict felicity for a scenario under a given threshold. -/
 def predict (s : EvenScenario) (t : EvenThreshold) : Bool :=
-  evenPresupWith s.prejacent s.neighbors (fun a b => decide (a > b)) t
+  decide (evenPresupWith s.prejacent s.neighbors (· > ·) t)
 
 /-!
 ### Scenario 1: Bennett's threshold is too weak (p. 155)


### PR DESCRIPTION
Bool→Prop hygiene from the Stage-3 design review: `evenPresupWith`/`countExceeded` take a `Prop`-valued `moreSurprising` with `[DecidableRel]`, with a `Decidable` instance so Francescotti1995's kernel-checked scenario proofs stay one-line `decide`s. Groundwork for a future pragmatic-strength scalar kernel (Beaver-Clark/Gast-van der Auwera direction, recorded in the design spec).