### PR TITLE
feat(Features/AnsweringSystem): graduate AnswerParticle; derive reversal

### DIFF
--- a/Linglib/Features/AnsweringSystem.lean
+++ b/Linglib/Features/AnsweringSystem.lean
@@ -116,6 +116,34 @@ This is the book's deepest explanatory contribution: the binary answering-system
 parameter is not stipulated but derived from independently motivated syntactic
 variation in negation height. -/
 
+/-! ## Answer particles
+
+An answer particle assigns a value to the question's [±Pol] variable
+and is lexically restricted to antecedent contexts of certain
+polarities. Reversal-hood is derived, not stored. Answer particles are
+pro-sentential — deliberately outside the host-associated
+`Syntax/Particle` core. -/
+
+/-- An answer particle: assigns a polarity, responds to antecedent
+contexts of the recorded polarities. -/
+structure AnswerParticle where
+  /-- Citation form. -/
+  form : String
+  /-- The polarity value assigned to [±Pol]. -/
+  assigns : Polarity
+  /-- Polarities of antecedent context the particle can respond to. -/
+  respondsTo : List Polarity
+  deriving DecidableEq, Repr
+
+/-- A polarity-reversing particle assigns [+Pol] while responding only
+to negative contexts (Swedish *jo*, German *doch*, French *si*;
+[holmberg-2016]). -/
+def AnswerParticle.IsReversal (p : AnswerParticle) : Prop :=
+  p.assigns = .positive ∧ p.respondsTo = [.negative]
+
+instance : DecidablePred AnswerParticle.IsReversal :=
+  fun _ => inferInstanceAs (Decidable (_ ∧ _))
+
 /-- Structural height of sentential negation relative to PolP.
 
     Note: this classifies *constructions*, not languages. A single language

--- a/Linglib/Fragments/German/PolarityMarking.lean
+++ b/Linglib/Fragments/German/PolarityMarking.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Polarity.Marking
+import Linglib.Features.AnsweringSystem
 
 /-!
 # German Polarity-Marking Strategies
@@ -65,5 +66,31 @@ theorem doch_not_sentenceInternal : Env.sentenceInternal ∉ dochPreUtterance.en
 theorem doch_not_contrastOk : Env.contrast ∉ dochPreUtterance.environments := by decide
 theorem doch_correctionOk : Env.correction ∈ dochPreUtterance.environments := by decide
 theorem doch_strategy : dochPreUtterance.strategy = .polarityReversal := rfl
+
+/-! ### German answer particles ([holmberg-2016])
+
+The response system in `Features.AnswerParticle` vocabulary. *doch*
+here is the answer-particle face of `dochPreUtterance` (the same item
+in the [turco-braun-dimroth-2014] marking vocabulary above); its
+clause-internal modal-particle homonym lives in `German/Particles.lean`. -/
+
+/-- *ja* — standard affirmative answer particle; positive contexts only
+    (like Swedish *ja*). Distinct from the modal particle *ja*
+    (`German/Particles.lean`). -/
+def jaAnswer : Features.AnswerParticle :=
+  { form := "ja", assigns := .positive, respondsTo := [.positive] }
+
+/-- *nein* — standard negative answer particle. -/
+def nein : Features.AnswerParticle :=
+  { form := "nein", assigns := .negative, respondsTo := [.positive, .negative] }
+
+/-- *doch* — polarity-reversing answer particle: "Kommt er nicht?" →
+    "Doch" = "he is coming". -/
+def dochAnswer : Features.AnswerParticle :=
+  { form := "doch", assigns := .positive, respondsTo := [.negative] }
+
+/-- *doch* is a polarity-reversing particle — derived from its
+    assign/respond profile. -/
+theorem dochAnswer_is_reversal : dochAnswer.IsReversal := by decide
 
 end German.PolarityMarking

--- a/Linglib/Fragments/Swedish/AnswerParticles.lean
+++ b/Linglib/Fragments/Swedish/AnswerParticles.lean
@@ -30,73 +30,39 @@ open Features.Polarity
 open Semantics.Polarity.Marking (Entry Strategy Env)
 open Features (AnsweringSystem AnswerStrategy PolarAnswerProfile)
 
-/-- A Swedish answer particle entry. -/
-structure AnswerParticle where
-  /-- Citation form -/
-  form : String
-  /-- The polarity this particle assigns -/
-  polarity : Features.Polarity
-  /-- Does this particle require a negative context? -/
-  requiresNegativeContext : Bool
-  /-- Is this a polarity-reversing particle? -/
-  isPolarityReversal : Bool := requiresNegativeContext
-  /-- Is this particle blocked (ungrammatical) in negative contexts?
-      [holmberg-2016] p165: Swedish *ja* is ungrammatical (not just
-      infelicitous) as a response to negative questions. -/
-  blockedInNegativeContext : Bool := false
-  deriving Repr
+/-- *ja* — standard affirmative. Assigns [+Pol]. Responds only to
+    positive contexts: "Dricker han inte?" → *"Ja" is ungrammatical
+    ([holmberg-2016], p165). Swedish uses *jo* instead. -/
+def ja : Features.AnswerParticle :=
+  { form := "ja", assigns := .positive, respondsTo := [.positive] }
 
-/-- *ja* — standard affirmative. Assigns [+Pol].
-    Blocked in negative contexts: "Dricker han inte?" → *"Ja" is
-    ungrammatical ([holmberg-2016], p165). Swedish uses *jo* instead. -/
-def ja : AnswerParticle :=
-  { form := "ja"
-  , polarity := .positive
-  , requiresNegativeContext := false
-  , blockedInNegativeContext := true
-  }
+/-- *nej* — standard negative. Assigns [-Pol]; responds to positive and
+    negative contexts alike. -/
+def nej : Features.AnswerParticle :=
+  { form := "nej", assigns := .negative, respondsTo := [.positive, .negative] }
 
-/-- *nej* — standard negative. Assigns [-Pol]. -/
-def nej : AnswerParticle :=
-  { form := "nej"
-  , polarity := .negative
-  , requiresNegativeContext := false
-  }
+/-- *jo* — polarity-reversing affirmative: "Dricker han inte?" → "Jo" =
+    "He does drink". Infelicitous responding to positive questions or
+    out of the blue (no negative context to reverse). -/
+def jo : Features.AnswerParticle :=
+  { form := "jo", assigns := .positive, respondsTo := [.negative] }
 
-/-- *jo* — polarity-reversing affirmative. Assigns [+Pol] while
-    contradicting a negative context.
-
-    "Dricker han inte?" (Doesn't he drink?)
-    → "Jo" = "He does drink" (reverses the expected negative polarity)
-
-    Cannot be used in response to positive questions or out of the blue:
-    "Dricker han?" (Does he drink?)
-    → *"Jo" is infelicitous (no negative context to reverse) -/
-def jo : AnswerParticle :=
-  { form := "jo"
-  , polarity := .positive
-  , requiresNegativeContext := true
-  }
-
-/-- *jo* is a polarity-reversing particle. -/
-theorem jo_is_reversal : jo.isPolarityReversal = true := rfl
+/-- *jo* is a polarity-reversing particle — derived from its
+    assign/respond profile. -/
+theorem jo_is_reversal : jo.IsReversal := by decide
 
 /-- *ja* is not polarity-reversing. -/
-theorem ja_not_reversal : ja.isPolarityReversal = false := rfl
+theorem ja_not_reversal : ¬ ja.IsReversal := by decide
 
-/-- *jo* and *ja* both assign positive polarity. The difference is
-    context: *jo* requires a negative context, *ja* does not. -/
-theorem jo_ja_same_polarity : jo.polarity = ja.polarity := rfl
+/-- *jo* and *ja* both assign positive polarity; only the antecedent
+    contexts differ. -/
+theorem jo_ja_same_polarity : jo.assigns = ja.assigns := rfl
 
-/-- *ja* is blocked in negative contexts — this is why *jo* exists. -/
-theorem ja_blocked_in_negative : ja.blockedInNegativeContext = true := rfl
-
-/-- *ja* and *jo* are in complementary distribution: *ja* is blocked where
-    *jo* is required (negative contexts), and *jo* is blocked where *ja*
-    is available (positive contexts). -/
+/-- *ja* and *jo* partition the context polarities: *ja* is blocked
+    where *jo* is required (negative contexts) and vice versa. -/
 theorem ja_jo_complementary :
-    ja.blockedInNegativeContext = true ∧ jo.requiresNegativeContext = true ∧
-    ja.requiresNegativeContext = false ∧ jo.blockedInNegativeContext = false := ⟨rfl, rfl, rfl, rfl⟩
+    Features.Polarity.negative ∉ ja.respondsTo ∧
+    Features.Polarity.positive ∉ jo.respondsTo := by decide
 
 /-- *jo* — Swedish polarity-reversing affirmative particle.
     Assigns [+Pol] while contradicting a negative context.

--- a/Linglib/Studies/Holmberg2016.lean
+++ b/Linglib/Studies/Holmberg2016.lean
@@ -5,6 +5,7 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 import Linglib.Semantics.Mood.ClauseType
 import Linglib.Features.Polarity
 import Linglib.Fragments.Swedish.AnswerParticles
+import Linglib.Fragments.German.PolarityMarking
 import Linglib.Data.Examples.Holmberg2016
 
 /-!
@@ -329,6 +330,15 @@ def japaneseProfile : PolarAnswerProfile :=
     Derived from `Swedish.AnswerParticles.profile`. -/
 def swedishProfile : PolarAnswerProfile :=
   Swedish.AnswerParticles.profile
+
+/-- The cross-linguistic polarity-reversal class: Swedish *jo* and
+    German *doch* have the same assign/respond profile — [+Pol]
+    assignment restricted to negative antecedent contexts. Holmberg's
+    class membership derived from the fragments' profiles rather than
+    stipulated. -/
+theorem reversal_class :
+    Swedish.AnswerParticles.jo.IsReversal ∧
+    German.PolarityMarking.dochAnswer.IsReversal := by decide
 
 /-- Finnish polar answer profile (mixed: verb echo + *kyllä*, polarity-based). -/
 def finnishProfile : PolarAnswerProfile :=


### PR DESCRIPTION
The answer-particle arc: `AnswerParticle` graduates from Swedish-local to the Holmberg-anchored `Features/AnsweringSystem.lean`, redesigned derived-not-stored — two primitives (`assigns`, `respondsTo`) with reversal-hood as a derived decidable predicate instead of three stored Bools.

- Swedish *ja/nej/jo* retyped; the readback theorems become genuine derivations (`jo_is_reversal : jo.IsReversal := by decide`).
- German gains its answer system (*ja/nein/doch*) as the second carrier, cross-referenced with `dochPreUtterance` (TBD2014 marking vocabulary) and the modal-particle homonyms.
- Holmberg2016 gains `reversal_class`: Swedish *jo* and German *doch* proven same-class from the fragments' profiles rather than asserted in prose.