### PR TITLE
refactor(Studies/BhattDayal2020): restore 2020 claims; move cartography

### DIFF
--- a/Linglib/Semantics/Questions/Singleton.lean
+++ b/Linglib/Semantics/Questions/Singleton.lean
@@ -42,7 +42,7 @@ variable {W : Type u}
 /-- An inquisitive content is **singleton** iff its alternative set
     contains exactly one element. The shape encoded by the singleton
     presupposition of [bhatt-dayal-2020]'s eq. 23 (kya:) and the
-    parallel nandao analysis cited in [bhatt-dayal-2020] fn. 11. -/
+    parallel nandao analysis of [xu-2012] the paper draws on. -/
 def IsSingleton (P : Question W) : Prop :=
   ∃ p, alt P = {p}
 

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -26,7 +26,7 @@ where honorification surfaces (`HonDomain`).
 
 - **Agree.lean**: AA validity reduces to `validAgree`
 - **Phase.lean**: `isPhaseHeadOf .SA` — SAP as the highest phase
-- **Questions/Studies/BhattDayal2020.lean**: `sap_particles_not_in_quasi_sub`
+- **Studies/Dayal2025.lean**: `particle_layer_predicts_embedding`
   — SAP unembeddability parallels allocutive root-only restriction
 - **RSA/YoonEtAl2020**: Social utility (φ weighting) is the pragmatic analogue
   of syntactic [iHON] — both encode social relations between discourse
@@ -285,9 +285,9 @@ theorem hon_agree_values (level : HonLevel) :
       = some (.ofGramFeatures [.valued (.hon level)]) := by
   cases level <;> native_decide
 
-/-- Bridge to Studies/BhattDayal2020: SAP unembeddability
-    parallels `sap_particles_not_in_quasi_sub`. Both follow from SAP being
-    the speech-act layer that does not embed.
+/-- Bridge to Studies/Dayal2025: SAP unembeddability parallels the SAP
+    clause of `Dayal2025.particle_layer_predicts_embedding`. Both follow
+    from SAP being the speech-act layer that does not embed.
 
     Connection: SA-based allocutive markers (particles) pattern with
     SAP-layer question particles — neither appears in quasi-subordination.

--- a/Linglib/Studies/BhattDayal2020.lean
+++ b/Linglib/Studies/BhattDayal2020.lean
@@ -31,26 +31,23 @@ variable {W : Type*}
 
 `⟦kya:⟧ = λQ⟨st⟩t : ∃p ∈ Q[∀q[q ∈ Q → q = p]].Q` — defined only when the
 sister question `Q` has a singleton alternative set, and then the identity
-on `Q`. The presupposition is `Question.IsSingleton`; the well-typed
-"felicitous sister" is the subtype `SingletonQuestion W`. -/
+on `Q`. The presupposition is `Question.IsSingleton`; the felicitous sister
+is the subtype `SingletonQuestion W`. In the paper a polar question denotes
+a singleton (eq. 22b: ⟦did John leave⟧ = {John left}) — the substrate's
+one-cell `declarative p`, not its two-cell Hamblin `polar`. -/
 
-/-- Felicitous case: the paper's polar question denotes a singleton set
-(eq. 22b: ⟦did John leave⟧ = {John left}) — in substrate terms the one-cell
-`declarative p`, not the two-cell Hamblin polar. -/
+/-- Felicitous case: a polar question in the paper's sense is a singleton. -/
 theorem kya_felicitous_singleton_polar (p : Set W) :
     IsSingleton (declarative (W := W) p) :=
   isSingleton_declarative p
 
-/-- Defined case: on a felicitous sister, kya: returns the question
-unchanged. -/
+/-- Defined case: on a felicitous sister, kya: is the identity. -/
 theorem kya_interp (p : Set W) :
     (SingletonQuestion.ofDeclarative (W := W) p).issue = declarative p :=
   SingletonQuestion.ofDeclarative_issue p
 
-/-- The headline restriction (ex. 4): kya: occurs in polar questions but not
-in wh-questions. A wh-question whose answer cells form an antichain with two
-distinct nonempty members has a non-singleton alternative set, so the
-presupposition fails. -/
+/-- The headline restriction (ex. 4): a wh-question with two distinct answer
+cells is non-singleton, so kya: rejects it. -/
 theorem kya_infelicitous_wh {E : Type*} {D : Set E} {P : E → Set W}
     (hD : D.Nonempty) (hne : ∀ e ∈ D, (P e).Nonempty)
     (hA : IsAntichain (· ⊆ ·) (P '' D))
@@ -60,9 +57,7 @@ theorem kya_infelicitous_wh {E : Type*} {D : Set E} {P : E → Set W}
     rw [alt_which_of_antichain hD hne hA]
   exacts [⟨e₁, h₁, rfl⟩, ⟨e₂, h₂, rfl⟩]
 
-/-- A two-cell Hamblin polar also fails the presupposition: the
-kya:-compatible polar denotation is the singleton of eq. 22b, not
-`{p, pᶜ}`. -/
+/-- A two-cell Hamblin polar likewise fails the presupposition. -/
 theorem kya_infelicitous_two_cell_polar {p : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     ¬ IsSingleton (polar (W := W) p) :=

--- a/Linglib/Studies/BhattDayal2020.lean
+++ b/Linglib/Studies/BhattDayal2020.lean
@@ -1,134 +1,83 @@
-import Linglib.Features.QParticleLayer
 import Linglib.Semantics.Questions.Singleton
+import Linglib.Semantics.Questions.Hamblin
 import Linglib.Fragments.HindiUrdu.Particles
-import Linglib.Fragments.Japanese.Particles
-import Linglib.Fragments.English.QuestionParticles
 
 /-!
-# Bhatt & Dayal (2020): PQP analysis of Hindi-Urdu *kya:* [bhatt-dayal-2020]
+# Bhatt & Dayal (2020): the polar question particle *kya:*
+[bhatt-dayal-2020]
 
-Polar Question Particle analysis: Hindi-Urdu *kya:* sits at PerspP, not CP.
-Combined with [dayal-2025]'s three-layer cartography
-`[SAP [PerspP [CP ...]]]` and [sauerland-yatsushiro-2017]'s analysis
-of Japanese *kke* as a meta question particle (MQP).
-
-This study file is the canonical home for the layer assignments of
-the four typologically representative particles that motivate the
-three-way `cp / perspP / sap` split:
-
-| Layer  | Language    | Particle        | Distribution         |
-|--------|-------------|-----------------|----------------------|
-| CP     | Japanese    | *ka*            | matrix + subord + QS |
-| PerspP | Hindi-Urdu  | *kya:*          | matrix + QS, no sub  |
-| SAP    | Japanese    | *kke*           | matrix + quotation   |
-| SAP    | English     | *quick(ly)*     | matrix only          |
-
-The layer of each particle is DERIVED from its fragment's
-embedding-distribution facet by `layerOf` — the cartography's defining
-correlation (layer ↔ embedding distribution), stated once as a
-classifier rather than stipulated per particle.
+Hindi-Urdu polar *kya:* is a **polar question particle** (PQP) — a class
+distinct from clause-typing Q-morphemes like Japanese *ka*: it occurs only in
+polar questions (not in wh-questions), sits in a projection above CP the
+paper labels ForceP, and embeds only in the quasi-subordinated configuration
+of [dayal-grimshaw-2009] (complements of rogatives), not in ordinary
+subordination. Semantically kya: presupposes that its sister question has a
+**singleton** alternative set (eq. 23) and is otherwise the identity; a polar
+question denotes the singleton `{p}` (eq. 22b). The same singleton
+restriction models the (bias-introducing) Mandarin particle *nandao* in
+[xu-2012] (cross-linguistic picture in [xu-2017]), which the paper draws on.
 -/
 
 namespace BhattDayal2020
 
-open Features (QParticleLayer)
-open Question (IsSingleton SingletonQuestion declarative polar
-  isSingleton_declarative not_isSingleton_polar_of_nontrivial)
+open Question (IsSingleton SingletonQuestion declarative polar which
+  isSingleton_declarative not_isSingleton_polar_of_nontrivial
+  not_isSingleton_of_two_alternatives alt_which_of_antichain)
 open HindiUrdu.Particles (kya)
-open Japanese.Particles (ka kke)
-open English.QuestionParticles (quick)
 
--- ============================================================================
--- §1 — The layer classifier (derived, not stipulated)
--- ============================================================================
+variable {W : Type*}
 
-/-- The [dayal-2025] cartography's defining correlation, as a
-    classifier: a question particle's left-peripheral layer is read off
-    its embedding distribution — subordinated-licensed → CP
-    (clause-typing); subordinated-excluded but quasi-subordinated-
-    licensed → PerspP; quasi-subordinated-excluded but matrix-licensed →
-    SAP. Defined for question particles only — Japanese *koto* (a
-    declarative complementizer, kept in the fragment for the *ka*
-    contrast at [dayal-2025] (15)) is outside its intended domain. -/
-def layerOf (p : Particle) : Option QParticleLayer :=
-  if p.LicensedInEmbed .subordinated then some .cp
-  else if p.LicensedInEmbed .quasiSubordinated then some .perspP
-  else if p.LicensedInEmbed .matrix then some .sap
-  else none
+/-! ### The singleton-alternative presupposition (eq. 23)
 
-/-- `layerOf`'s intended domain: the question particles this study
-    classifies. Membership is a claim about what the particle *does*
-    (question-forming), not about its distribution — Japanese *koto*
-    (declarative complementizer) has an embedding facet but is
-    deliberately outside. -/
-def qParticles : List Particle := [ka, kya, kke, quick]
+`⟦kya:⟧ = λQ⟨st⟩t : ∃p ∈ Q[∀q[q ∈ Q → q = p]].Q` — defined only when the
+sister question `Q` has a singleton alternative set, and then the identity
+on `Q`. The presupposition is `Question.IsSingleton`; the well-typed
+"felicitous sister" is the subtype `SingletonQuestion W`. -/
 
-/-- The four representative layer assignments, DERIVED from the
-    fragments' embedding facets: *ka* CP ([dayal-2025]), *kya:* PerspP
-    ([bhatt-dayal-2020]), *kke* SAP ([sauerland-yatsushiro-2017]),
-    *quick* SAP ([dayal-2025] ex. (19)). Formerly four stipulated
-    constants; now one classifier plus kernel-checked facts. -/
-theorem layers_derived :
-    layerOf ka = some .cp ∧
-    layerOf kya = some .perspP ∧
-    layerOf kke = some .sap ∧
-    layerOf quick = some .sap := by decide
-
-/-- Every particle in the classifier's domain receives a layer. -/
-theorem qParticles_layered : ∀ p ∈ qParticles, (layerOf p).isSome := by decide
-
--- ============================================================================
--- §2 — Singleton-Alternative Presupposition (eq. 23)
--- ============================================================================
-
-/-! [bhatt-dayal-2020] eq. 23:
-`⟦kya:⟧ = λp[∃q ∈ Q[∀q′[q′ ∈ Q → q′ = q]].Q`
-i.e. *kya:* is interpreted only when its sister question `Q` has a
-singleton alternative set, in which case the particle is the identity
-on `Q`. The presupposition is exactly `Question.IsSingleton`; the
-well-typed analogue of "felicitous sister content" is the subtype
-`SingletonQuestion W` (a question paired with a proof that its
-alternative set is a singleton). The "highlighted" terminology of
-[roelofsen-farkas-2015] corresponds to `declarative p` in this
-setting (one-cell denotation, in contrast to the two-cell `polar p`).
-
-[bhatt-dayal-2020] fn. 11 cites the parallel Mandarin *nandao*
-analysis as the model for kya:; the shared `IsSingleton` predicate
-captures that convergence by construction. See
-`Zheng2025` for the nandao binding. -/
-
-universe u
-variable {W : Type u}
-
-/-- **Empirical prediction (felicitous case)**: kya: composes
-    felicitously with a one-cell "highlighted" polar — i.e. with the
-    declarative content `declarative p`, the singleton-alternative
-    analogue of the standard two-cell polar. The canonical good input. -/
-theorem kya_felicitous_declarative (p : Set W) :
+/-- Felicitous case: the paper's polar question denotes a singleton set
+(eq. 22b: ⟦did John leave⟧ = {John left}) — in substrate terms the one-cell
+`declarative p`, not the two-cell Hamblin polar. -/
+theorem kya_felicitous_singleton_polar (p : Set W) :
     IsSingleton (declarative (W := W) p) :=
   isSingleton_declarative p
 
-/-- **Empirical prediction (defined case)**: kya: on a felicitous
-    sister returns the question unchanged — packaged as a
-    `SingletonQuestion` whose underlying issue is the input declarative.
-    Mathlib pattern: subtype + `.val` rather than `Option`. -/
-theorem kya_interp_declarative (p : Set W) :
-    (SingletonQuestion.ofDeclarative (W := W) p).issue = declarative p := rfl
+/-- Defined case: on a felicitous sister, kya: returns the question
+unchanged. -/
+theorem kya_interp (p : Set W) :
+    (SingletonQuestion.ofDeclarative (W := W) p).issue = declarative p :=
+  SingletonQuestion.ofDeclarative_issue p
 
-/-- **Empirical prediction (infelicitous case)**: kya: cannot license
-    a two-cell Hamblin polar with a non-trivial proposition — the
-    presupposition fails because such a polar has two alternatives. -/
+/-- The headline restriction (ex. 4): kya: occurs in polar questions but not
+in wh-questions. A wh-question whose answer cells form an antichain with two
+distinct nonempty members has a non-singleton alternative set, so the
+presupposition fails. -/
+theorem kya_infelicitous_wh {E : Type*} {D : Set E} {P : E → Set W}
+    (hD : D.Nonempty) (hne : ∀ e ∈ D, (P e).Nonempty)
+    (hA : IsAntichain (· ⊆ ·) (P '' D))
+    {e₁ e₂ : E} (h₁ : e₁ ∈ D) (h₂ : e₂ ∈ D) (hPne : P e₁ ≠ P e₂) :
+    ¬ IsSingleton (which D P) := by
+  refine not_isSingleton_of_two_alternatives _ ?_ ?_ hPne <;>
+    rw [alt_which_of_antichain hD hne hA]
+  exacts [⟨e₁, h₁, rfl⟩, ⟨e₂, h₂, rfl⟩]
+
+/-- A two-cell Hamblin polar also fails the presupposition: the
+kya:-compatible polar denotation is the singleton of eq. 22b, not
+`{p, pᶜ}`. -/
 theorem kya_infelicitous_two_cell_polar {p : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     ¬ IsSingleton (polar (W := W) p) :=
   not_isSingleton_polar_of_nontrivial hne hnu
 
-/-- **Bridge to fragment**: the PerspP layer derived from kya:'s
-    embedding facet (`layers_derived`) is the surface signal of the
-    singleton-presupposition analysis — the PerspP-layer particle is
-    the one whose interpretation is given by the `IsSingleton`
-    presupposition + identity on `SingletonQuestion`. -/
-theorem kya_perspP_signals_singletonPresup :
-    layerOf kya = some .perspP := layers_derived.2.1
+/-! ### Embedding: quasi-subordination only
+
+kya: appears in matrix polar questions and in the quasi-subordinated
+configuration of [dayal-grimshaw-2009] (complements of rogatives, ex. 9)
+but not in ordinary subordination (complements of responsives, ex. 8) —
+read off the fragment's embedding facet. -/
+
+theorem kya_embedding_profile :
+    kya.LicensedInEmbed .matrix ∧ kya.LicensedInEmbed .quasiSubordinated ∧
+      ¬ kya.LicensedInEmbed .subordinated := by
+  decide
 
 end BhattDayal2020

--- a/Linglib/Studies/Dayal2025.lean
+++ b/Linglib/Studies/Dayal2025.lean
@@ -1,5 +1,8 @@
 import Linglib.Syntax.Minimalist.LeftPeriphery
-import Linglib.Studies.BhattDayal2020
+import Linglib.Features.QParticleLayer
+import Linglib.Fragments.HindiUrdu.Particles
+import Linglib.Fragments.Japanese.Particles
+import Linglib.Fragments.English.QuestionParticles
 
 /-!
 # Dayal (2025): Three-layer cartography for clause-typing
@@ -43,7 +46,10 @@ This study file is the canonical home for:
 namespace Dayal2025
 
 open Minimalist.LeftPeriphery
-open BhattDayal2020
+open Features (QParticleLayer)
+open HindiUrdu.Particles (kya)
+open Japanese.Particles (ka kke)
+open English.QuestionParticles (quick)
 
 -- ============================================================================
 -- §1. Clause-typing typology (Dayal 2025 §4.4)
@@ -407,6 +413,50 @@ theorem cross_linguistic_shiftiness_predicted :
           classifyCrossLingVerb,
           hindi_urdu_want_to_know, hindi_urdu_know_bare,
           hindi_urdu_know_negated, hindi_urdu_know_questioned]
+
+/-! ### The three-layer classifier for question particles
+
+The cartography's defining correlation as a classifier: a question
+particle's left-peripheral layer is read off its embedding distribution —
+subordinated-licensed → CP (clause-typing); subordinated-excluded but
+quasi-subordinated-licensed → PerspP; quasi-subordinated-excluded but
+matrix-licensed → SAP. [bhatt-dayal-2020]'s ForceP location for Hindi-Urdu
+*kya:* is recast here as PerspP.
+
+| Layer  | Language    | Particle    | Distribution         |
+|--------|-------------|-------------|----------------------|
+| CP     | Japanese    | *ka*        | matrix + subord + QS |
+| PerspP | Hindi-Urdu  | *kya:*      | matrix + QS, no sub  |
+| SAP    | Japanese    | *kke*       | matrix + quotation   |
+| SAP    | English     | *quick(ly)* | matrix only          |
+-/
+
+/-- A question particle's layer, read off its embedding distribution.
+    Defined for question particles only — Japanese *koto* (a declarative
+    complementizer) is outside the intended domain. -/
+def layerOf (p : Particle) : Option QParticleLayer :=
+  if p.LicensedInEmbed .subordinated then some .cp
+  else if p.LicensedInEmbed .quasiSubordinated then some .perspP
+  else if p.LicensedInEmbed .matrix then some .sap
+  else none
+
+/-- The classifier's intended domain: the question particles this study
+    classifies. Membership is a claim about what the particle *does*
+    (question-forming), not about its distribution. -/
+def qParticles : List Particle := [ka, kya, kke, quick]
+
+/-- The four representative layer assignments, derived from the fragments'
+    embedding facets: *ka* CP, *kya:* PerspP (recasting
+    [bhatt-dayal-2020]'s ForceP), *kke* SAP ([sauerland-yatsushiro-2017]),
+    *quick* SAP. -/
+theorem layers_derived :
+    layerOf ka = some .cp ∧
+    layerOf kya = some .perspP ∧
+    layerOf kke = some .sap ∧
+    layerOf quick = some .sap := by decide
+
+/-- Every particle in the classifier's domain receives a layer. -/
+theorem qParticles_layered : ∀ p ∈ qParticles, (layerOf p).isSome := by decide
 
 /-- Q-particle embedding follows from which left-peripheral layer they occupy:
     CP-layer particles are licensed in subordination, PerspP- and SAP-layer

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -4,7 +4,6 @@ import Linglib.Semantics.Modality.Kernel
 import Linglib.Features.QParticleLayer
 import Linglib.Semantics.Questions.Bias.Defs
 import Linglib.Semantics.Questions.Singleton
-import Linglib.Studies.BhattDayal2020
 
 /-!
 # Zheng (2025): Nandao-Q Felicity [zheng-2025]
@@ -285,21 +284,14 @@ open Question (IsSingleton SingletonQuestion declarative
 universe u
 variable {W : Type u}
 
-/-- nandao is felicitous on a one-cell ("highlighted") polar — same
-    canonical good-input case as kya:. The proof reduces to
-    `isSingleton_declarative`, identical to the kya: side. -/
+/-- nandao is felicitous on a one-cell ("highlighted") polar — the same
+    canonical good-input case as kya:, and by construction the same
+    substrate fact: both this and `BhattDayal2020.kya_felicitous_singleton_polar`
+    are `isSingleton_declarative`, capturing the kya:–nandao convergence
+    [bhatt-dayal-2020] draw from [xu-2012]. -/
 theorem nandao_felicitous_declarative (p : Set W) :
     IsSingleton (declarative (W := W) p) :=
   isSingleton_declarative p
-
-/-- **Cross-particle agreement**: the felicity conditions for kya: and
-    nandao on a one-cell polar are *the same theorem* — both reduce to
-    `isSingleton_declarative`. The convergence noted in
-    [bhatt-dayal-2020] fn. 11 holds by construction. -/
-theorem nandao_kya_share_felicity (p : Set W) :
-    nandao_felicitous_declarative (W := W) p =
-      BhattDayal2020.kya_felicitous_declarative
-        (W := W) p := rfl
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- §5 — Integrated Felicity: §2 (Kernel-bias) ∧ §4 (Question-singleton)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -12336,6 +12336,36 @@
   role      = {formalized},
   sources   = {Fragments/HindiUrdu/Particles.lean;Studies/BhattDayal2020.lean}
 }
+@inproceedings{xu-2012,
+  author    = {Xu, Beibei},
+  year      = {2012},
+  title     = {Nandao-Questions as a Special Kind of Rhetorical Questions},
+  booktitle = {Proceedings of Semantics and Linguistic Theory (SALT) 22},
+  editor    = {Chereches, Anca},
+  pages     = {508--526},
+  doi       = {10.3765/salt.v22i0.2643},
+  subfield  = {semantics/questions},
+  role      = {cited},
+  sources   = {Studies/BhattDayal2020.lean}
+}
+@phdthesis{xu-2017,
+  author    = {Xu, Beibei},
+  year      = {2017},
+  title     = {Question Bias and Biased Question Words in {M}andarin, {G}erman and {B}angla},
+  school    = {Rutgers University},
+  subfield  = {semantics/questions},
+  role      = {cited},
+  sources   = {Studies/BhattDayal2020.lean}
+}
+@unpublished{dayal-grimshaw-2009,
+  author    = {Dayal, Veneeta and Grimshaw, Jane},
+  year      = {2009},
+  title     = {Subordination at the Interface: A Quasi-Subordination Hypothesis},
+  note      = {Ms., Rutgers University},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/BhattDayal2020.lean}
+}
 @incollection{simik-2024,
   author    = {\v{S}im\'{i}k, Radek},
   year      = {2024},


### PR DESCRIPTION
Deep cleanse of BhattDayal2020.lean against the NLLT PDF (two-reviewer audit):

- eq. 23 transcription corrected (outer binder is λQ, not λp), fn.-11 misattribution fixed (the Mandarin *nandao* parallel is Xu 2012/2017 in main text; fn. 11 is an acknowledgment) — verified bib entries added for [xu-2012], [xu-2017], [dayal-grimshaw-2009].
- The 2020 paper's structural claim restored: kya: in **ForceP** (PerspP appears nowhere in it); the three-layer cartography (`layerOf`, `qParticles`, `layers_derived`, the four-particle table) moved to Dayal2025.lean per the chronological-dependency rule.
- Inverted felicity naming fixed (the paper's felicitous host is the polar-as-singleton, eq. 22b); new real wh-exclusion theorem via `alt_which_of_antichain` replaces reliance on the two-cell straw case; new `kya_embedding_profile` (quasi-subordination only — [dayal-grimshaw-2009] vocabulary, genuinely 2020).
- Seam fixes: AlokBhalla2026's references to the deleted `sap_particles_not_in_quasi_sub`; Zheng2025's vacuous proof-equality bridge (proof irrelevance) replaced by an honest docstring; Singleton.lean's propagated fn.-11 claim.