### PR TITLE
refactor(Studies/Dayal2025): split clause-typing parameters; PDF-verify

### DIFF
--- a/Linglib/Studies/Dayal2025.lean
+++ b/Linglib/Studies/Dayal2025.lean
@@ -9,35 +9,36 @@ import Linglib.Fragments.English.QuestionParticles
 [dayal-2025] [mccloskey-2006] [zu-2018]
 [bhatt-dayal-2020]
 
-Veneeta Dayal (2025), *Linguistic Inquiry* 56(4):663-712. Develops the
-three-layer cartographic split `[SAP [PerspP [CP ...]]]` and uses it to
-account for cross-linguistic clause-typing variation, the responsive/
-rogative split, and McCloskey-style quasi-subordination.
+Veneeta Dayal (2025), *Linguistic Inquiry* 56(4):663–712, develops the
+three-layer split `[SAP [PerspP [CP ...]]]` of the interrogative left
+periphery and derives cross-linguistic clause-typing variation, the
+responsive/rogative split, and McCloskey-style quasi-subordination from it.
 
-This study file is the canonical home for:
+## Main declarations
 
-1. **Clause-typing typology** (§§4.3–4.4): the two orthogonal parameters —
-   polar wh-complementizer and delayed typing — behind English/Italian/
-   Hindi-Urdu variation.
-2. **Hindi-Urdu shiftiness** (§3.2): the McCloskey parallel for Hindi-Urdu
-   *jaanna:*.
-3. **Left-Periphery verification**: the LeftPeriphery `SelectionClass`
-   apparatus checked against the English embedding data (§1.2) and the
-   cross-linguistic shiftiness data.
-4. **Three-layer particle classifier** (§1.3): CP / PerspP / SAP read off
-   embedding distribution.
+* `ClauseTyping`: the two orthogonal clause-typing parameters (§§4.3–4.4),
+  polar wh-complementizer and delayed typing.
+* `simplex_subordination_matches_complementizer`,
+  `neutral_decl_matches_delay`: the per-parameter typological projections
+  over the English/Italian/Hindi-Urdu sample.
+* `cross_linguistic_shiftiness_predicted`: Hindi-Urdu *kya:* shiftiness
+  (§3.2) derived by the same `allowsQuasiSub` account as McCloskey's
+  English data.
+* `theory_predicts_embedding`: the `SelectionClass` apparatus checked
+  against the §1.2 English embedding judgments.
+* `layerOf`, `layers_derived`, `particle_layer_predicts_embedding`: the
+  CP / PerspP / SAP particle classifier (§1.3), read off embedding
+  distribution.
 
-## Cross-framework relations
+## Implementation notes
 
-- **Rizzi 1997 / `Syntax/Minimalist/Questions.lean`** places clause-typing
-  at `Force⁰[+Q]`; Dayal places it at `C` with a downstream `PerspP` shift.
-- **Holmberg 2016 / `Studies/Holmberg2016.lean`** places the polar-Q-typing
-  locus at `PolP` and competes for the same matrix-polar facts.
-- **Speas-Tenny / `Studies/SpeasTenny2003.lean`** derives the seat of
-  knowledge from a feature matrix; Dayal places it in PerspP with PRO. Both
-  predict the Newari conjunct/disjunct flip (paper §5.2, via [zu-2018]),
-  which the paper reads as matrix perspective shift only, leaving open
-  whether PerspP is Zu's SentienceP.
+Rival analyses of the same facts: Rizzi-style `Force⁰[+Q]` typing lives in
+`Syntax/Minimalist/Questions.lean`, Holmberg's `PolP` locus in
+`Studies/Holmberg2016.lean`, and the Speas–Tenny seat-of-knowledge matrix
+in `Studies/SpeasTenny2003.lean`. Both Dayal and Speas–Tenny predict the
+Newari conjunct/disjunct flip (§5.2, via [zu-2018]), which the paper reads
+as matrix perspective shift only, leaving open whether PerspP is Zu's
+SentienceP.
 -/
 
 namespace Dayal2025

--- a/Linglib/Studies/Dayal2025.lean
+++ b/Linglib/Studies/Dayal2025.lean
@@ -51,22 +51,19 @@ open English.QuestionParticles (quick)
 
 /-! ### Clause-typing typology
 
-Two orthogonal parameters govern polar-question syntax. Whether the
-language has a dedicated wh-complementizer for polar questions (English
-*whether*, Italian *se*; Hindi-Urdu has none) governs simplex-polar
-subordination (§4.4, ex. 70–71). Whether clause-typing may be delayed past
-C to PerspP (Italian and Hindi-Urdu, ex. 66) or is forced at the earliest
-opportunity (English) governs whether a rising declarative can be a
-neutral question (§4.3, ex. 63b). English and Italian share the first
-parameter but differ on the second, so the two must not be collapsed. -/
+Two orthogonal parameters govern polar-question syntax (§§4.3–4.4): a
+polar wh-complementizer licenses simplex-polar subordination, and delayed
+clause-typing admits neutral rising declaratives. English and Italian
+share the first but differ on the second, so the two must not be
+collapsed. -/
 
 /-- A language's clause-typing profile for polar questions. -/
 structure ClauseTyping where
   /-- Has a dedicated polar wh-complementizer (English *whether*,
-  Italian *se*). -/
+  Italian *se*; Hindi-Urdu has none). -/
   hasPolarComplementizer : Bool
-  /-- Clause-typing may be delayed past C to PerspP; forced-early languages
-  type at C immediately. -/
+  /-- Clause-typing may be delayed past C to PerspP (ex. 66); forced-early
+  languages type at C immediately. -/
   delayedTyping : Bool
   deriving DecidableEq, Repr
 
@@ -110,14 +107,13 @@ def hindi_urdu_polar : PolarSyntaxDatum :=
 def allPolarSyntaxData : List PolarSyntaxDatum :=
   [english_polar, italian_polar, hindi_urdu_polar]
 
-/-- Simplex-polar subordination tracks the complementizer parameter. -/
+/-- Simplex-polar subordination tracks the complementizer parameter (§4.4). -/
 theorem simplex_subordination_matches_complementizer :
     ∀ d ∈ allPolarSyntaxData,
       d.subordinationOk = d.typing.hasPolarComplementizer := by decide
 
-/-- Neutral rising declaratives track the delayed-typing parameter: forced
-early typing leaves only the biased reading (English); delayable typing
-admits the neutral question (Italian, Hindi-Urdu). -/
+/-- Neutral rising declaratives track the delayed-typing parameter
+(§4.3, ex. 63b). -/
 theorem neutral_decl_matches_delay :
     ∀ d ∈ allPolarSyntaxData,
       d.neutralDeclOk = d.typing.delayedTyping := by decide
@@ -302,13 +298,8 @@ theorem cross_linguistic_shiftiness_predicted :
 
 /-! ### The three-layer classifier for question particles
 
-The cartography's defining correlation as a classifier: a question
-particle's left-peripheral layer is read off its embedding distribution —
-subordinated-licensed → CP (clause-typing); subordinated-excluded but
-quasi-subordinated-licensed → PerspP; quasi-subordinated-excluded but
-matrix-licensed → SAP (§1.3). [bhatt-dayal-2020]'s ForceP location for
-Hindi-Urdu *kya:* is recast here as PerspP (a terminological change by the
-paper's own fn. 3).
+A question particle's left-peripheral layer is read off its embedding
+distribution (§1.3); the four representative assignments:
 
 | Layer  | Language    | Particle    | Distribution         |
 |--------|-------------|-------------|----------------------|
@@ -316,7 +307,9 @@ paper's own fn. 3).
 | PerspP | Hindi-Urdu  | *kya:*      | matrix + QS, no sub  |
 | SAP    | Japanese    | *kke*       | matrix + quotation   |
 | SAP    | English     | *quick(ly)* | matrix + quotation   |
--/
+
+[bhatt-dayal-2020]'s ForceP location for *kya:* is recast here as PerspP
+(a terminological change by the paper's own fn. 3). -/
 
 /-- A question particle's layer, read off its embedding distribution.
     Defined for question particles only — Japanese *koto* (a declarative

--- a/Linglib/Studies/Dayal2025.lean
+++ b/Linglib/Studies/Dayal2025.lean
@@ -16,31 +16,28 @@ rogative split, and McCloskey-style quasi-subordination.
 
 This study file is the canonical home for:
 
-1. **Clause-typing typology** (§4.4): forced-CP vs delayed-PerspP variation
-   across English/Italian/Hindi-Urdu.
+1. **Clause-typing typology** (§§4.3–4.4): the two orthogonal parameters —
+   polar wh-complementizer and delayed typing — behind English/Italian/
+   Hindi-Urdu variation.
 2. **Hindi-Urdu shiftiness** (§3.2): the McCloskey parallel for Hindi-Urdu
    *jaanna:*.
-3. **Newari conjunct/disjunct** (§5.2): the perspective-shift evidence
-   from Newari person marking.
-4. **Left-Periphery bridge**: the verification of the LeftPeriphery
-   `SelectionClass` apparatus against the English embedding data (§5)
-   and the cross-linguistic shiftiness data.
+3. **Left-Periphery verification**: the LeftPeriphery `SelectionClass`
+   apparatus checked against the English embedding data (§1.2) and the
+   cross-linguistic shiftiness data.
+4. **Three-layer particle classifier** (§1.3): CP / PerspP / SAP read off
+   embedding distribution.
 
 ## Cross-framework relations
 
-- **Rizzi 1997 / `Syntax/Minimalist/Questions.lean`** places
-  clause-typing at `Force⁰[+Q]`; Dayal places it at `C` with a downstream
-  `PerspP` shift. The disagreement is real and not currently formalized as
-  a bridge theorem. See `Syntax/Minimalist/Questions.lean`.
-- **Holmberg 2016 / `Studies/Holmberg2016.lean`**
-  places the polar-Q-typing locus at `PolP` (via the
-  `Features/AnsweringSystem.lean` typological parameter). Holmberg's
-  analysis competes with Dayal's for the same matrix-polar facts.
-- **Speas-Tenny / `Studies/SpeasTenny2003.lean`** derives
-  `SpeasTenny2003.seatOfKnowledge` from a 2×2 feature matrix; Dayal places SoK
-  in PerspP with PRO. Both predict the Newari conjunct/disjunct flip; the bridge
-  theorem `SpeasTenny2003.seatOfKnowledge ↔ PerspP-PRO over Newari` is
-  unformalized.
+- **Rizzi 1997 / `Syntax/Minimalist/Questions.lean`** places clause-typing
+  at `Force⁰[+Q]`; Dayal places it at `C` with a downstream `PerspP` shift.
+- **Holmberg 2016 / `Studies/Holmberg2016.lean`** places the polar-Q-typing
+  locus at `PolP` and competes for the same matrix-polar facts.
+- **Speas-Tenny / `Studies/SpeasTenny2003.lean`** derives the seat of
+  knowledge from a feature matrix; Dayal places it in PerspP with PRO. Both
+  predict the Newari conjunct/disjunct flip (paper §5.2, via [zu-2018]),
+  which the paper reads as matrix perspective shift only, leaving open
+  whether PerspP is Zu's SentienceP.
 -/
 
 namespace Dayal2025
@@ -51,131 +48,86 @@ open HindiUrdu.Particles (kya)
 open Japanese.Particles (ka kke)
 open English.QuestionParticles (quick)
 
--- ============================================================================
--- §1. Clause-typing typology (Dayal 2025 §4.4)
--- ============================================================================
+/-! ### Clause-typing typology
 
-/-- How a language handles clause-typing for polar questions. The contrast
-    is the cartographic locus of `[+Q]`-typing, not a difference in feature
-    inventory. CP-typed languages license simplex polars in subordination
-    via a wh-complementizer (English `whether`, Italian `se`); PerspP-typed
-    languages route polar questions through a higher PerspP layer that does
-    not embed under canonical responsive predicates. -/
-inductive ClauseTypingStrategy where
-  /-- Clause-typing locus is `C` (English `whether`, Italian `se`). -/
-  | cpTyped
-  /-- Clause-typing locus is `PerspP` (Hindi-Urdu rising intonation). -/
-  | perspPTyped
+Two orthogonal parameters govern polar-question syntax. Whether the
+language has a dedicated wh-complementizer for polar questions (English
+*whether*, Italian *se*; Hindi-Urdu has none) governs simplex-polar
+subordination (§4.4, ex. 70–71). Whether clause-typing may be delayed past
+C to PerspP (Italian and Hindi-Urdu, ex. 66) or is forced at the earliest
+opportunity (English) governs whether a rising declarative can be a
+neutral question (§4.3, ex. 63b). English and Italian share the first
+parameter but differ on the second, so the two must not be collapsed. -/
+
+/-- A language's clause-typing profile for polar questions. -/
+structure ClauseTyping where
+  /-- Has a dedicated polar wh-complementizer (English *whether*,
+  Italian *se*). -/
+  hasPolarComplementizer : Bool
+  /-- Clause-typing may be delayed past C to PerspP; forced-early languages
+  type at C immediately. -/
+  delayedTyping : Bool
   deriving DecidableEq, Repr
 
-/-- Structural projection: which clause-typing strategies license simplex
-    polar questions in subordination. CP-typed languages do (the wh-
-    complementizer is the embedding selector); PerspP-typed languages do
-    not (PerspP is too high to be selected by canonical responsive verbs).
-    `delayed_blocks_simplex_subordination` below derives from this
-    projection together with the Fragment data, rather than holding
-    vacuously over a 1-element sample. -/
-def ClauseTypingStrategy.licensesSimplexSubordination :
-    ClauseTypingStrategy → Bool
-  | .cpTyped     => true
-  | .perspPTyped => false
-
-/-- Data on simplex polar question embedding across languages.
-    A simplex polar question is just the nucleus *p* (no "or not"). -/
-structure SimplexPolarDatum where
+/-- Per-language polar-question syntax: simplex-polar distribution and
+neutral rising declaratives. A simplex polar is the nucleus alone
+(*p?* rather than *p or not (p)?*). -/
+structure PolarSyntaxDatum where
   language : String
-  clauseTyping : ClauseTypingStrategy
-  /-- Simplex polar in matrix? -/
+  typing : ClauseTyping
+  /-- Simplex polar in matrix position? -/
   matrixOk : Bool
   /-- Simplex polar in quasi-subordination? -/
   quasiSubOk : Bool
   /-- Simplex polar in subordination? -/
   subordinationOk : Bool
-  deriving Repr
-
-def english_simplex : SimplexPolarDatum :=
-  { language := "English", clauseTyping := .cpTyped
-  , matrixOk := true, quasiSubOk := true, subordinationOk := true }
-
-def italian_simplex : SimplexPolarDatum :=
-  { language := "Italian", clauseTyping := .cpTyped
-  , matrixOk := true, quasiSubOk := true, subordinationOk := true }
-
-/-- Hindi-Urdu: simplex polar questions require PerspP (rising intonation
-    activates [+WH] at PerspP level). No wh-complementizer → cannot
-    clause-type at C. (Dayal 2025: ex (70)–(71); UNVERIFIED page numbers.) -/
-def hindi_urdu_simplex : SimplexPolarDatum :=
-  { language := "Hindi-Urdu", clauseTyping := .perspPTyped
-  , matrixOk := true, quasiSubOk := true, subordinationOk := false }
-
-def allSimplexPolarData : List SimplexPolarDatum :=
-  [english_simplex, italian_simplex, hindi_urdu_simplex]
-
-/-- The Fragment data is consistent with the structural projection: every
-    PerspP-typed language in the sample lacks simplex-polar subordination.
-    Unlike a 1-direction stipulation, this connects per-language data to a
-    typed projection on `ClauseTypingStrategy`. -/
-theorem simplex_subordination_matches_projection :
-    ∀ d ∈ allSimplexPolarData,
-      d.subordinationOk = d.clauseTyping.licensesSimplexSubordination := by
-  intro d hd
-  simp only [allSimplexPolarData, List.mem_cons, List.mem_nil_iff, or_false] at hd
-  rcases hd with rfl | rfl | rfl <;> rfl
-
-/-- Corollary: PerspP-typed languages cannot subordinate simplex polars.
-    Now derived from the structural projection, not from the data alone. -/
-theorem perspPTyped_blocks_simplex_subordination :
-    ∀ d ∈ allSimplexPolarData,
-      d.clauseTyping = .perspPTyped → d.subordinationOk = false := by
-  intro d hd hp
-  rw [simplex_subordination_matches_projection d hd, hp]
-  rfl
-
--- ============================================================================
--- §2. Declarative questions and bias (Dayal 2025 §4.3)
--- ============================================================================
-
-/-- Whether declarative questions in a language are obligatorily biased.
-    English: "You drink wine?" is obligatorily biased (speaker expects yes).
-    Hindi-Urdu/Italian: rising declaratives can be neutral.
-    This follows from whether clause-typing is forced at C (CP-typed) or
-    routed through PerspP. (Italian `neutralOk := true` is contested in
-    the rising-declarative literature, e.g. Gunlogson 2003 vs Bartels 1999;
-    Dayal 2025 makes the specific claim — UNVERIFIED page numbers.) -/
-structure DeclarativeQuestionDatum where
-  language : String
   /-- Can a rising declarative be a neutral (unbiased) question? -/
-  neutralOk : Bool
-  /-- Is a rising declarative always biased? -/
-  obligatorilyBiased : Bool
-  clauseTyping : ClauseTypingStrategy
-  deriving Repr
+  neutralDeclOk : Bool
+  deriving DecidableEq, Repr
 
-def english_decl_q : DeclarativeQuestionDatum :=
+def english_polar : PolarSyntaxDatum :=
   { language := "English"
-  , neutralOk := false, obligatorilyBiased := true
-  , clauseTyping := .cpTyped }
+  , typing := { hasPolarComplementizer := true, delayedTyping := false }
+  , matrixOk := true, quasiSubOk := true, subordinationOk := true
+  , neutralDeclOk := false }
 
-def hindi_urdu_decl_q : DeclarativeQuestionDatum :=
-  { language := "Hindi-Urdu"
-  , neutralOk := true, obligatorilyBiased := false
-  , clauseTyping := .perspPTyped }
-
-def italian_decl_q : DeclarativeQuestionDatum :=
+def italian_polar : PolarSyntaxDatum :=
   { language := "Italian"
-  , neutralOk := true, obligatorilyBiased := false
-  , clauseTyping := .cpTyped }
+  , typing := { hasPolarComplementizer := true, delayedTyping := true }
+  , matrixOk := true, quasiSubOk := true, subordinationOk := true
+  , neutralDeclOk := true }
 
-def allDeclQData : List DeclarativeQuestionDatum :=
-  [english_decl_q, hindi_urdu_decl_q, italian_decl_q]
+/-- Hindi-Urdu: no wh-complementizer, so simplex polars cannot be
+subordinated (ex. 70–71); typing is delayed, so rising declaratives can be
+neutral. -/
+def hindi_urdu_polar : PolarSyntaxDatum :=
+  { language := "Hindi-Urdu"
+  , typing := { hasPolarComplementizer := false, delayedTyping := true }
+  , matrixOk := true, quasiSubOk := true, subordinationOk := false
+  , neutralDeclOk := true }
 
--- ============================================================================
--- §3. Hindi-Urdu shiftiness (Dayal 2025 §3.2, ex (39)–(41))
--- ============================================================================
+def allPolarSyntaxData : List PolarSyntaxDatum :=
+  [english_polar, italian_polar, hindi_urdu_polar]
 
-/-- Cross-linguistic shiftiness data. Parallels McCloskey's English data.
-    Hindi-Urdu *kya:* shows the same pattern as English embedded inversion:
-    blocked under bare responsive, licensed under negation/questioning. -/
+/-- Simplex-polar subordination tracks the complementizer parameter. -/
+theorem simplex_subordination_matches_complementizer :
+    ∀ d ∈ allPolarSyntaxData,
+      d.subordinationOk = d.typing.hasPolarComplementizer := by decide
+
+/-- Neutral rising declaratives track the delayed-typing parameter: forced
+early typing leaves only the biased reading (English); delayable typing
+admits the neutral question (Italian, Hindi-Urdu). -/
+theorem neutral_decl_matches_delay :
+    ∀ d ∈ allPolarSyntaxData,
+      d.neutralDeclOk = d.typing.delayedTyping := by decide
+
+/-! ### Hindi-Urdu shiftiness (§3.2, ex. 39–41)
+
+Hindi-Urdu *kya:* under attitude predicates patterns with McCloskey's
+English embedded inversion: blocked under a bare responsive, licensed
+under negation or questioning. -/
+
+/-- Cross-linguistic shiftiness data. -/
 structure CrossLingShiftinessDatum where
   language : String
   verb : String
@@ -183,29 +135,27 @@ structure CrossLingShiftinessDatum where
   negated : Bool
   questioned : Bool
   quasiSubOk : Bool
-  deriving Repr
+  deriving DecidableEq, Repr
 
-/-- Hindi-Urdu: "want to know" (rogative) freely takes *kya:*
-    (Dayal 2025: ex (39a)). -/
+/-- Hindi-Urdu: "want to know" (rogative) freely takes *kya:* (ex. 39a). -/
 def hindi_urdu_want_to_know : CrossLingShiftinessDatum :=
   { language := "Hindi-Urdu", verb := "ja:n-na: ca:h-na: (want to know)"
   , sentence := "anu ja:nna: ca:hti: hai [ki (kya:) tum cai piyoge↑]"
   , negated := false, questioned := false, quasiSubOk := true }
 
-/-- Hindi-Urdu: "know" (responsive) rejects *kya:* (Dayal 2025: ex (39b)). -/
+/-- Hindi-Urdu: bare "know" (responsive) rejects *kya:* (ex. 39b). -/
 def hindi_urdu_know_bare : CrossLingShiftinessDatum :=
   { language := "Hindi-Urdu", verb := "ja:n-na: (know)"
   , sentence := "*anu ja:nti: hai [ki (kya:) tum cai piyoge↑]"
   , negated := false, questioned := false, quasiSubOk := false }
 
-/-- Hindi-Urdu: "nobody knows" + *kya:* → OK (negation, Dayal 2025: ex (41a)). -/
+/-- Hindi-Urdu: "nobody knows" + *kya:* → OK (negation, ex. 41a). -/
 def hindi_urdu_know_negated : CrossLingShiftinessDatum :=
   { language := "Hindi-Urdu", verb := "ja:n-na: (know)"
   , sentence := "koii nahii jaanta [ki kya: TiTo sTa:lin-se mile the↑]"
   , negated := true, questioned := false, quasiSubOk := true }
 
-/-- Hindi-Urdu: "does anyone know" + *kya:* → OK (questioning,
-    Dayal 2025: ex (41b)). -/
+/-- Hindi-Urdu: "does anyone know" + *kya:* → OK (questioning, ex. 41b). -/
 def hindi_urdu_know_questioned : CrossLingShiftinessDatum :=
   { language := "Hindi-Urdu", verb := "ja:n-na: (know)"
   , sentence := "kisii-ko bhi maalum hai [ki (kya:) TiTo sTa:lin-se mile the↑]"
@@ -216,68 +166,34 @@ def allCrossLingShiftinessData : List CrossLingShiftinessDatum :=
    hindi_urdu_know_negated, hindi_urdu_know_questioned]
 
 /-- English: bare responsive *remember* rejects embedded inversion
-    ([mccloskey-2006]). -/
+([mccloskey-2006]). -/
 def remember_bare : CrossLingShiftinessDatum :=
   { language := "English", verb := "remember"
   , sentence := "*I remember [was Henry a communist↑]"
   , negated := false, questioned := false, quasiSubOk := false }
 
-/-- English: negated *remember* licenses embedded inversion
-    ([mccloskey-2006]). -/
+/-- English: negated *remember* licenses embedded inversion — McCloskey's
+judgment is marginal ("?"), encoded here as licensed. -/
 def remember_negated : CrossLingShiftinessDatum :=
   { language := "English", verb := "remember"
-  , sentence := "I don't remember [was Henry a communist↑]"
+  , sentence := "?I don't remember [was Henry a communist↑]"
   , negated := true, questioned := false, quasiSubOk := true }
 
 /-- English: questioned *remember* licenses embedded inversion
-    ([mccloskey-2006]). -/
+([mccloskey-2006]). -/
 def remember_questioned : CrossLingShiftinessDatum :=
   { language := "English", verb := "remember"
   , sentence := "Does Sue remember [was Henry a communist↑]"
   , negated := false, questioned := true, quasiSubOk := true }
 
-/-- Hindi-Urdu shiftiness parallels English: bare responsive blocks quasi-sub,
-    negation and questioning license it. -/
-theorem hindi_urdu_shiftiness_parallels_english :
-    hindi_urdu_know_bare.quasiSubOk = false ∧
-    hindi_urdu_know_negated.quasiSubOk = true ∧
-    hindi_urdu_know_questioned.quasiSubOk = true := by
-  simp [hindi_urdu_know_bare, hindi_urdu_know_negated, hindi_urdu_know_questioned]
+/-! ### Verification against empirical embedding data
 
--- ============================================================================
--- §4. Newari conjunct/disjunct marking (Dayal 2025 §5.2, [zu-2018])
--- ============================================================================
+The `SelectionClass` apparatus checked against the paper's §1.2
+classification of English attitude predicates: rogatives split three ways
+by the largest structure they take (CP / PerspP / SAP); responsives and
+uninterrogatives take none of the larger structures. -/
 
-/-- Newari uses conjunct vs disjunct verb forms sensitive to whether the
-    subject is coindexed with the perspectival center (Seat of Knowledge).
-    - Declaratives: conjunct = 1st person subject (SoK = speaker)
-    - Interrogatives: conjunct = 2nd person subject (SoK = addressee)
-    This provides independent evidence for perspective shift in questions
-    (canonical Newari conjunct/disjunct pattern; Zu 2018 reanalyses as
-    perspective shift). -/
-structure ConjunctDisjunctDatum where
-  language : String
-  clauseType : String  -- "declarative" or "interrogative"
-  conjunctPerson : String  -- which person gets conjunct marking
-  deriving Repr
-
-def newari_declarative : ConjunctDisjunctDatum :=
-  { language := "Newari", clauseType := "declarative"
-  , conjunctPerson := "1st" }
-
-def newari_interrogative : ConjunctDisjunctDatum :=
-  { language := "Newari", clauseType := "interrogative"
-  , conjunctPerson := "2nd" }
-
-def allConjunctDisjunctData : List ConjunctDisjunctDatum :=
-  [newari_declarative, newari_interrogative]
-
--- ============================================================================
--- §5. Verification against empirical embedding data
--- ============================================================================
-
-/-- Embedding judgment for an English attitude predicate
-    ([dayal-2025]: §§1–3). -/
+/-- Embedding judgment for an English attitude predicate (§1.2). -/
 structure EmbeddingDatum where
   verb : String
   /-- "V whether/who..." -/
@@ -286,7 +202,7 @@ structure EmbeddingDatum where
   quasiSubordination : Bool
   /-- 'V, "Did S leave?"' -/
   quotation : Bool
-  deriving Repr
+  deriving DecidableEq, Repr
 
 -- Rogative predicates (embed only interrogatives)
 
@@ -333,86 +249,55 @@ def believe_d : EmbeddingDatum :=
 def allEmbeddingData : List EmbeddingDatum :=
   [investigate_d, depend_on_d, wonder_d, ask_d, know_d, care_d, matter_d, believe_d]
 
-/-- Quasi-subordination implies subordination ([dayal-2025]). -/
--- UNVERIFIED: ex (20)
+/-- Quasi-subordination implies subordination: the §1.2 classification is
+cumulative — each larger-structure class also takes the smaller ones. -/
 theorem quasi_sub_implies_sub :
     ∀ d ∈ allEmbeddingData,
-      d.quasiSubordination = true → d.subordination = true := by
-  intro d hd hq
-  simp [allEmbeddingData] at hd
-  rcases hd with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
-    simp_all [investigate_d, depend_on_d, wonder_d, ask_d, know_d, care_d, matter_d, believe_d]
+      d.quasiSubordination = true → d.subordination = true := by decide
 
-/-- Quotation implies quasi-subordination ([dayal-2025]). -/
--- UNVERIFIED: ex (20)
+/-- Quotation implies quasi-subordination among the interrogative-selecting
+predicates sampled here (per §1.2; *say* takes interrogative quotations
+without quasi-subordinating, but is not interrogative-selecting). -/
 theorem quotation_implies_quasi_sub :
     ∀ d ∈ allEmbeddingData,
-      d.quotation = true → d.quasiSubordination = true := by
-  intro d hd hq
-  simp [allEmbeddingData] at hd
-  rcases hd with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
-    simp_all [investigate_d, depend_on_d, wonder_d, ask_d, know_d, care_d, matter_d, believe_d]
+      d.quotation = true → d.quasiSubordination = true := by decide
 
-/-- Classify each empirical embedding datum. -/
-def classifyVerb : String → SelectionClass
-  | "investigate" => .rogativeCP
-  | "depend on"   => .rogativeCP
-  | "wonder"      => .rogativePerspP
-  | "ask"         => .rogativeSAP
-  | "know"        => .responsive
-  | "care"        => .responsive
-  | "matter"      => .responsive
-  | "believe"     => .uninterrogative
-  | _             => .uninterrogative
+/-- The substrate classifier extended with [elliott-etal-2017]'s predicates
+of relevance (*care*, *matter*), which classify as responsive. -/
+def classify : String → SelectionClass
+  | "care"   => .responsive
+  | "matter" => .responsive
+  | v        => classifyVerb v
 
 /-- The theory correctly predicts all embedding judgments from the data. -/
 theorem theory_predicts_embedding :
     ∀ d ∈ allEmbeddingData,
-      allowsEmbedding (classifyVerb d.verb) .subordination false false
+      allowsEmbedding (classify d.verb) .subordination false false
         = d.subordination ∧
-      allowsEmbedding (classifyVerb d.verb) .quasiSubordination false false
+      allowsEmbedding (classify d.verb) .quasiSubordination false false
         = d.quasiSubordination ∧
-      allowsEmbedding (classifyVerb d.verb) .quotation false false
-        = d.quotation := by
-  intro d hd
-  simp only [allEmbeddingData, List.mem_cons, List.mem_nil_iff, or_false] at hd
-  rcases hd with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> decide
+      allowsEmbedding (classify d.verb) .quotation false false
+        = d.quotation := by decide
 
-/-- Shiftiness predictions match McCloskey's data for *remember* (responsive). -/
+/-- Shiftiness predictions match McCloskey's data for *remember*
+(responsive). -/
 theorem shiftiness_predicted :
     allowsQuasiSub .responsive remember_bare.negated remember_bare.questioned
       = remember_bare.quasiSubOk ∧
     allowsQuasiSub .responsive remember_negated.negated remember_negated.questioned
       = remember_negated.quasiSubOk ∧
     allowsQuasiSub .responsive remember_questioned.negated remember_questioned.questioned
-      = remember_questioned.quasiSubOk := by
-  simp [allowsQuasiSub, perspPConsistent, effectiveKnowledge, entailsKnowledge,
-        remember_bare, remember_negated, remember_questioned]
+      = remember_questioned.quasiSubOk := by decide
 
--- ============================================================================
--- §6. Cross-linguistic predictions
--- ============================================================================
-
-/-- Classify Hindi-Urdu verbs from the cross-linguistic shiftiness data. -/
-def classifyCrossLingVerb : String → SelectionClass
-  | "ja:n-na: ca:h-na: (want to know)" => .rogativePerspP
-  | "ja:n-na: (know)"                  => .responsive
-  | _                                  => .responsive
+/-! ### Cross-linguistic predictions -/
 
 /-- Hindi-Urdu shiftiness follows the same derivation as English:
-    responsive predicates reject quasi-sub in bare form, allow under
-    negation/questioning. The theory predicts ALL cross-linguistic data. -/
+responsive predicates reject quasi-sub in bare form, allow it under
+negation/questioning. -/
 theorem cross_linguistic_shiftiness_predicted :
     ∀ d ∈ allCrossLingShiftinessData,
       allowsQuasiSub (classifyCrossLingVerb d.verb) d.negated d.questioned
-        = d.quasiSubOk := by
-  intro d hd
-  simp [allCrossLingShiftinessData] at hd
-  rcases hd with rfl | rfl | rfl | rfl <;>
-    simp [allowsQuasiSub, perspPConsistent, effectiveKnowledge, entailsKnowledge,
-          classifyCrossLingVerb,
-          hindi_urdu_want_to_know, hindi_urdu_know_bare,
-          hindi_urdu_know_negated, hindi_urdu_know_questioned]
+        = d.quasiSubOk := by decide
 
 /-! ### The three-layer classifier for question particles
 
@@ -420,20 +305,22 @@ The cartography's defining correlation as a classifier: a question
 particle's left-peripheral layer is read off its embedding distribution —
 subordinated-licensed → CP (clause-typing); subordinated-excluded but
 quasi-subordinated-licensed → PerspP; quasi-subordinated-excluded but
-matrix-licensed → SAP. [bhatt-dayal-2020]'s ForceP location for Hindi-Urdu
-*kya:* is recast here as PerspP.
+matrix-licensed → SAP (§1.3). [bhatt-dayal-2020]'s ForceP location for
+Hindi-Urdu *kya:* is recast here as PerspP (a terminological change by the
+paper's own fn. 3).
 
 | Layer  | Language    | Particle    | Distribution         |
 |--------|-------------|-------------|----------------------|
 | CP     | Japanese    | *ka*        | matrix + subord + QS |
 | PerspP | Hindi-Urdu  | *kya:*      | matrix + QS, no sub  |
 | SAP    | Japanese    | *kke*       | matrix + quotation   |
-| SAP    | English     | *quick(ly)* | matrix only          |
+| SAP    | English     | *quick(ly)* | matrix + quotation   |
 -/
 
 /-- A question particle's layer, read off its embedding distribution.
     Defined for question particles only — Japanese *koto* (a declarative
-    complementizer) is outside the intended domain. -/
+    complementizer, the *ka* contrast of ex. 15) is outside the intended
+    domain. -/
 def layerOf (p : Particle) : Option QParticleLayer :=
   if p.LicensedInEmbed .subordinated then some .cp
   else if p.LicensedInEmbed .quasiSubordinated then some .perspP
@@ -448,7 +335,7 @@ def qParticles : List Particle := [ka, kya, kke, quick]
 /-- The four representative layer assignments, derived from the fragments'
     embedding facets: *ka* CP, *kya:* PerspP (recasting
     [bhatt-dayal-2020]'s ForceP), *kke* SAP ([sauerland-yatsushiro-2017]),
-    *quick* SAP. -/
+    *quick* SAP (ex. 18–19). -/
 theorem layers_derived :
     layerOf ka = some .cp ∧
     layerOf kya = some .perspP ∧
@@ -469,43 +356,6 @@ theorem particle_layer_predicts_embedding :
       (layerOf p = some .cp → p.LicensedInEmbed .subordinated) ∧
       (layerOf p = some .perspP → ¬ p.LicensedInEmbed .subordinated) ∧
       (layerOf p = some .sap → ¬ p.LicensedInEmbed .quasiSubordinated) := by
-  decide
-
--- ============================================================================
--- §7. Cross-layer agreement
--- ============================================================================
-
-open English.Predicates.Verbal
-
-/-- The structurally derived classification matches the manually-assigned
-    string-based classification for all verbs in the embedding data. -/
-theorem derived_class_matches_manual :
-    deriveSelectionClass English.Predicates.Verbal.know
-      = classifyVerb "know" ∧
-    deriveSelectionClass English.Predicates.Verbal.wonder
-      = classifyVerb "wonder" ∧
-    deriveSelectionClass English.Predicates.Verbal.ask
-      = classifyVerb "ask" ∧
-    deriveSelectionClass English.Predicates.Verbal.investigate
-      = classifyVerb "investigate" ∧
-    deriveSelectionClass English.Predicates.Verbal.believe
-      = classifyVerb "believe" := by
-  decide
-
-/-- String-based classification matches field-based derivation. -/
-theorem classifyVerb_agrees_with_selectionClass :
-    classifyVerb "know"
-      = fieldSelectionClass English.Predicates.Verbal.know ∧
-    classifyVerb "wonder"
-      = fieldSelectionClass English.Predicates.Verbal.wonder ∧
-    classifyVerb "ask"
-      = fieldSelectionClass English.Predicates.Verbal.ask ∧
-    classifyVerb "investigate"
-      = fieldSelectionClass English.Predicates.Verbal.investigate ∧
-    classifyVerb "depend on"
-      = fieldSelectionClass English.Predicates.Verbal.depend_on ∧
-    classifyVerb "believe"
-      = fieldSelectionClass English.Predicates.Verbal.believe := by
   decide
 
 end Dayal2025

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19360,7 +19360,7 @@
   volume    = {48},
   number    = {4},
   pages     = {651--678},
-  subfield  = {morphology},
+  subfield  = {semantics/questions},
   role      = {cited},
   doi       = {10.1162/ling_a_00257},
   validated = {true},


### PR DESCRIPTION
Deep cleanse of Dayal2025.lean against the LI 56(4) PDF (two-reviewer audit); companion to #1192.

- The single `ClauseTypingStrategy` collapsed two orthogonal parameters the paper keeps apart: polar wh-complementizer (governs simplex-polar subordination, §4.4) vs delayed clause-typing (governs neutral rising declaratives, §4.3). Split into `ClauseTyping` with both fields; the previously dead and self-contradicting declarative-bias table becomes a real projection theorem (`neutral_decl_matches_delay` — Italian now correctly groups with Hindi-Urdu).
- All UNVERIFIED location markers resolved against the PDF (ex. 70–71, 63b, §1.2 containment); Newari table deleted per the paper's own agnosticism (PerspP ≟ SentienceP), retained as a cross-framework docstring note; McCloskey's marginal "?" judgment restored on negated *remember*.
- Substrate dedup: study-local `classifyCrossLingVerb` (verbatim copy) and two duplicate agreement theorems deleted; `classifyVerb` reduced to the [elliott-etal-2017] care/matter delta (`classify`).
- Style: seven ASCII banners → `/-! ### -/`; five simp/rcases walls → `decide`; scope note on `quotation_implies_quasi_sub` (*say* caveat); *quick* distribution corrected to matrix + quotation.