### PR TITLE
style(Studies/Stankova2026): deep cleanse; examples to JSON pipeline

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2937,6 +2937,7 @@ import Linglib.Syntax.WordGrammar.Inheritance.Order
 import Linglib.Syntax.WordGrammar.LexicalRules
 import Linglib.Syntax.WordGrammar.Network
 import Linglib.Data.Examples.VonFintel1999
+import Linglib.Data.Examples.Stankova2026
 /-
 # Linglib
 

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1126,6 +1126,7 @@ import Linglib.Fragments.Slavic.Cassubian.Case
 import Linglib.Fragments.Slavic.Czech.Case
 import Linglib.Fragments.Slavic.Czech.Determiners
 import Linglib.Fragments.Slavic.Czech.Negation
+import Linglib.Fragments.Slavic.Czech.Particles
 import Linglib.Fragments.Slavic.Czech.PolarityItems
 import Linglib.Fragments.Slavic.Czech.Reciprocals
 import Linglib.Fragments.Slavic.Macedonian.QuestionParticles

--- a/Linglib/Data/Examples/Stankova2026.json
+++ b/Linglib/Data/Examples/Stankova2026.json
@@ -1,0 +1,174 @@
+[
+  {
+    "id": "stankova2026_ex6a",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 6a"},
+    "language": "czec1258",
+    "primaryText": "Petr si nekoupil žádný časopis?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Petr", "Petr"],
+      ["si", "REFL"],
+      ["nekoupil", "NEG.bought"],
+      ["žádný", "DET.NCI"],
+      ["časopis", "magazine"]
+    ],
+    "translation": "Petr didn't buy any magazine?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "inner"],
+      ["diagnostic", "nciLicensed"]
+    ],
+    "comment": "Inner negation licenses the NCI žádný (nonV1 word order)."
+  },
+  {
+    "id": "stankova2026_ex6b",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 6b"},
+    "language": "czec1258",
+    "primaryText": "Nekoupil si Petr žádný časopis?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Nekoupil", "NEG.bought"],
+      ["si", "REFL"],
+      ["Petr", "Petr"],
+      ["žádný", "DET.NCI"],
+      ["časopis", "magazine"]
+    ],
+    "translation": "Didn't Petr buy a magazine?",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "outer"],
+      ["diagnostic", "nciLicensed"]
+    ],
+    "comment": "High (V1) negation anti-licenses NCIs: only the outer reading is available and it cannot license žádný."
+  },
+  {
+    "id": "stankova2026_ex7a",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 7a"},
+    "language": "czec1258",
+    "primaryText": "Eva si neobjednala nějaký burger?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Eva", "Eva"],
+      ["si", "REFL"],
+      ["neobjednala", "NEG.ordered"],
+      ["nějaký", "DET.PPI"],
+      ["burger", "burger"]
+    ],
+    "translation": "Eva didn't order some burger?",
+    "context": "Eva and her colleagues from the office ordered take-out food for lunch. The delivery guy brings only pizzas. One of the colleagues asks.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "medial"],
+      ["diagnostic", "ppiOutscoping"]
+    ],
+    "comment": "Medial negation: syntactically low (nonV1) but wide LF scope, letting the PPI nějaký be interpreted under it."
+  },
+  {
+    "id": "stankova2026_ex7b",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 7b"},
+    "language": "czec1258",
+    "primaryText": "Neobjednala si Eva nějaký burger?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Neobjednala", "NEG.ordered"],
+      ["si", "REFL"],
+      ["Eva", "Eva"],
+      ["nějaký", "DET.PPI"],
+      ["burger", "burger"]
+    ],
+    "translation": "Didn't Eva order some burger?",
+    "context": "Eva and her colleagues from the office ordered take-out food for lunch. The delivery guy brings only pizzas. One of the colleagues asks.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "outer"],
+      ["diagnostic", "ppiOutscoping"]
+    ],
+    "comment": "Outer (V1) negation allows the PPI nějaký."
+  },
+  {
+    "id": "stankova2026_ex11",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 11"},
+    "language": "czec1258",
+    "primaryText": "Nepůjčila si tam Eva náhodou nějakou encyklopedii?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Nepůjčila", "NEG.borrowed"],
+      ["si", "REFL"],
+      ["tam", "there"],
+      ["Eva", "Eva"],
+      ["náhodou", "NÁHODOU"],
+      ["nějakou", "DET.PPI"],
+      ["encyklopedii", "encyclopedia"]
+    ],
+    "translation": "Didn't Eva borrow some encyclopedia, by any chance?",
+    "context": "Eva is doing research for a school presentation. Yesterday she went to the school library. The speaker knows all this from before and asks.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "outer"],
+      ["diagnostic", "nahodou"]
+    ],
+    "comment": "The paper marks the NCI variant žádnou # in the same frame: náhodou depends on outer negation."
+  },
+  {
+    "id": "stankova2026_ex15a",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 15a"},
+    "language": "czec1258",
+    "primaryText": "Eva fakt neviděla žádný Tarantinův film?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Eva", "Eva"],
+      ["fakt", "FAKT"],
+      ["neviděla", "NEG.saw"],
+      ["žádný", "DET.NCI"],
+      ["Tarantinův", "Tarantino's"],
+      ["film", "film"]
+    ],
+    "translation": "Eva really hasn't seen any film by Tarantino?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "inner"],
+      ["diagnostic", "fakt"]
+    ],
+    "comment": "fakt > ¬ > ∃_NCI: fakt over inner negation."
+  },
+  {
+    "id": "stankova2026_ex15d",
+    "source": {"bibkey": "stankova-2026", "paperLabel": "ex. 15d"},
+    "language": "czec1258",
+    "primaryText": "Neviděla Eva fakt nějaký Tarantinův film?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Neviděla", "NEG.saw"],
+      ["Eva", "Eva"],
+      ["fakt", "FAKT"],
+      ["nějaký", "DET.PPI"],
+      ["Tarantinův", "Tarantino's"],
+      ["film", "film"]
+    ],
+    "translation": "Is it really not the case that Eva has seen a film by Tarantino?",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["negation", "outer"],
+      ["diagnostic", "fakt"]
+    ],
+    "comment": "fakt is repelled by outer negation on its canonical reading; grammatical only on the 'after all' reading (fn. 8)."
+  }
+]

--- a/Linglib/Data/Examples/Stankova2026.lean
+++ b/Linglib/Data/Examples/Stankova2026.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Stankova2026` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Stankova2026.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Stankova2026.Examples`.
+-/
+
+namespace Stankova2026.Examples
+
+open Data.Examples
+
+def ex6a : LinguisticExample :=
+  { id := "stankova2026_ex6a"
+    source := ⟨"stankova-2026", "ex. 6a"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Petr si nekoupil žádný časopis?"
+    discourseSegments := []
+    glossedTokens := [("Petr", "Petr"), ("si", "REFL"), ("nekoupil", "NEG.bought"), ("žádný", "DET.NCI"), ("časopis", "magazine")]
+    translation := "Petr didn't buy any magazine?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "inner"), ("diagnostic", "nciLicensed")]
+    comment := "Inner negation licenses the NCI žádný (nonV1 word order)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6b : LinguisticExample :=
+  { id := "stankova2026_ex6b"
+    source := ⟨"stankova-2026", "ex. 6b"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nekoupil si Petr žádný časopis?"
+    discourseSegments := []
+    glossedTokens := [("Nekoupil", "NEG.bought"), ("si", "REFL"), ("Petr", "Petr"), ("žádný", "DET.NCI"), ("časopis", "magazine")]
+    translation := "Didn't Petr buy a magazine?"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "outer"), ("diagnostic", "nciLicensed")]
+    comment := "High (V1) negation anti-licenses NCIs: only the outer reading is available and it cannot license žádný."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex7a : LinguisticExample :=
+  { id := "stankova2026_ex7a"
+    source := ⟨"stankova-2026", "ex. 7a"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Eva si neobjednala nějaký burger?"
+    discourseSegments := []
+    glossedTokens := [("Eva", "Eva"), ("si", "REFL"), ("neobjednala", "NEG.ordered"), ("nějaký", "DET.PPI"), ("burger", "burger")]
+    translation := "Eva didn't order some burger?"
+    context := "Eva and her colleagues from the office ordered take-out food for lunch. The delivery guy brings only pizzas. One of the colleagues asks."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "medial"), ("diagnostic", "ppiOutscoping")]
+    comment := "Medial negation: syntactically low (nonV1) but wide LF scope, letting the PPI nějaký be interpreted under it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex7b : LinguisticExample :=
+  { id := "stankova2026_ex7b"
+    source := ⟨"stankova-2026", "ex. 7b"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Neobjednala si Eva nějaký burger?"
+    discourseSegments := []
+    glossedTokens := [("Neobjednala", "NEG.ordered"), ("si", "REFL"), ("Eva", "Eva"), ("nějaký", "DET.PPI"), ("burger", "burger")]
+    translation := "Didn't Eva order some burger?"
+    context := "Eva and her colleagues from the office ordered take-out food for lunch. The delivery guy brings only pizzas. One of the colleagues asks."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "outer"), ("diagnostic", "ppiOutscoping")]
+    comment := "Outer (V1) negation allows the PPI nějaký."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex11 : LinguisticExample :=
+  { id := "stankova2026_ex11"
+    source := ⟨"stankova-2026", "ex. 11"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nepůjčila si tam Eva náhodou nějakou encyklopedii?"
+    discourseSegments := []
+    glossedTokens := [("Nepůjčila", "NEG.borrowed"), ("si", "REFL"), ("tam", "there"), ("Eva", "Eva"), ("náhodou", "NÁHODOU"), ("nějakou", "DET.PPI"), ("encyklopedii", "encyclopedia")]
+    translation := "Didn't Eva borrow some encyclopedia, by any chance?"
+    context := "Eva is doing research for a school presentation. Yesterday she went to the school library. The speaker knows all this from before and asks."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "outer"), ("diagnostic", "nahodou")]
+    comment := "The paper marks the NCI variant žádnou # in the same frame: náhodou depends on outer negation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex15a : LinguisticExample :=
+  { id := "stankova2026_ex15a"
+    source := ⟨"stankova-2026", "ex. 15a"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Eva fakt neviděla žádný Tarantinův film?"
+    discourseSegments := []
+    glossedTokens := [("Eva", "Eva"), ("fakt", "FAKT"), ("neviděla", "NEG.saw"), ("žádný", "DET.NCI"), ("Tarantinův", "Tarantino's"), ("film", "film")]
+    translation := "Eva really hasn't seen any film by Tarantino?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "inner"), ("diagnostic", "fakt")]
+    comment := "fakt > ¬ > ∃_NCI: fakt over inner negation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex15d : LinguisticExample :=
+  { id := "stankova2026_ex15d"
+    source := ⟨"stankova-2026", "ex. 15d"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Neviděla Eva fakt nějaký Tarantinův film?"
+    discourseSegments := []
+    glossedTokens := [("Neviděla", "NEG.saw"), ("Eva", "Eva"), ("fakt", "FAKT"), ("nějaký", "DET.PPI"), ("Tarantinův", "Tarantino's"), ("film", "film")]
+    translation := "Is it really not the case that Eva has seen a film by Tarantino?"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("negation", "outer"), ("diagnostic", "fakt")]
+    comment := "fakt is repelled by outer negation on its canonical reading; grammatical only on the 'after all' reading (fn. 8)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex6a, ex6b, ex7a, ex7b, ex11, ex15a, ex15d]
+
+end Stankova2026.Examples

--- a/Linglib/Fragments/Slavic/Czech/Particles.lean
+++ b/Linglib/Fragments/Slavic/Czech/Particles.lean
@@ -1,0 +1,68 @@
+import Linglib.Syntax.Particle.Basic
+
+/-!
+# Czech Particles
+[stankova-2025] [stankova-2026] [simik-2024] [nekula-1996]
+
+Czech discourse particles of polar questions as `Particle` values.
+The negation-position diagnostics and Table 1 licensing live in
+`Stankova2026`; the bias experiments in `StankovaSimik2025`.
+-/
+
+namespace Czech.Particles
+
+/-- *náhodou* 'by (any) chance' — in its particle use restricted to
+negative polar questions ([stankova-2026] §2.2.1; the adverbial reading
+'accidentally' is a separate item, her fn. 3). Diagnoses outer negation
+(`Stankova2026`); FALSUM experiments in `StankovaSimik2025`. -/
+def nahodou : Particle where
+  form := "náhodou"
+  distribution := some
+    { declarative := some .excluded
+      polarInterrogative := some .optional }
+
+/-- *ještě* 'yet, still' — aspectual particle of declaratives and polar
+questions ([stankova-2026] (13)-(14)); inner-negation diagnostic in
+`Stankova2026`. -/
+def jeste : Particle where
+  form := "ještě"
+  distribution := some
+    { declarative := some .optional
+      polarInterrogative := some .optional }
+
+/-- *fakt* 'really' — emphatic particle of declaratives and polar
+questions ([stankova-2026] (15)); inner/medial-negation diagnostic in
+`Stankova2026`. -/
+def fakt : Particle where
+  form := "fakt"
+  distribution := some
+    { declarative := some .optional
+      polarInterrogative := some .optional }
+
+/-- *vůbec* 'at all' — NPI particle of assertions and polar questions
+([stankova-2026] (9)); parallels English *at all*. -/
+def vubec : Particle where
+  form := "vůbec"
+  distribution := some
+    { declarative := some .optional
+      polarInterrogative := some .optional }
+
+/-- *snad* 'perhaps, surely not' — adversative/mirative PQ particle of
+the cross-Slavic RAZVE family ([simik-2024] §4.2.4, [nekula-1996],
+[stankova-2023]). -/
+def snad : Particle where
+  form := "snad"
+  distribution := some { polarInterrogative := some .optional }
+
+/-- *copak* 'what then' — RAZVE-family particle of positive and
+negative polar questions ([stankova-2025] exs. 19a-b, [nekula-1996]);
+evidential-bias experiments in `StankovaSimik2025`. -/
+def copak : Particle where
+  form := "copak"
+  distribution := some { polarInterrogative := some .optional }
+
+/-- All Czech PQ particles indexed in this file. -/
+def allParticles : List Particle :=
+  [nahodou, jeste, fakt, vubec, snad, copak]
+
+end Czech.Particles

--- a/Linglib/Studies/Stankova2026.lean
+++ b/Linglib/Studies/Stankova2026.lean
@@ -1,3 +1,5 @@
+import Linglib.Syntax.Particle.Capabilities
+import Linglib.Fragments.Slavic.Czech.Particles
 import Linglib.Semantics.Negation.CzechNegation
 import Linglib.Studies.StankovaSimik2025
 import Linglib.Semantics.Questions.Bias.Defs
@@ -71,42 +73,21 @@ theorem only_inner_licenses_nci :
 
 /-! ### The diagnostic particles ([stankova-2026] §2.2, Table 1)
 
-*náhodou* and *copak* live with the experiments in
-`StankovaSimik2025`; this paper contributes *ještě*, *fakt*, *vůbec*,
-the Table 1 assignments, and the fingerprint results. -/
+Entries live in `Czech.Particles`; this paper contributes the §2.2
+licensing profiles — *ještě* felicitous in PQs only under inner
+negation (§2.2.2, (14); with telic predicates it requires negation,
+(13)), *fakt* licensed by inner and medial but repelled by outer on its
+canonical reading (§2.2.3, (15), fn. 8), *vůbec* an NPI licensed by
+inner only ((9)-(10)) — plus the Table 1 assignments and the
+fingerprint results. -/
 
-open StankovaSimik2025 (nahodou copak snad ParticleSemantics)
-
-/-- *ještě* 'yet, still' — inner-negation diagnostic ([stankova-2026]
-§2.2.2, (14)): with telic predicates it requires negation and in PQs is
-felicitous only under inner negation (NCI or wide-scoping PPI), not
-medial or outer; atelic *ještě* occurs without negation ((13a)). -/
-def jeste : Particle where
-  form := "ještě"
-  distribution := some { polarInterrogative := some .optional }
-
-/-- *fakt* 'really' — licensed by inner and medial negation, repelled by
-outer on its canonical reading ([stankova-2026] §2.2.3, (15); the
-'after all' reading is exempt, fn. 8). The paper defers its semantic
-contribution, noting the parallels to English *really* (Romero & Han's
-VERUM) and Russian *razve*. -/
-def fakt : Particle where
-  form := "fakt"
-  distribution := some { polarInterrogative := some .optional }
-
-/-- *vůbec* 'at all' — NPI, licensed by inner negation only among the
-three readings ([stankova-2026] (9)-(10)); outside Table 1. Parallels
-English *at all*. -/
-def vubec : Particle where
-  form := "vůbec"
-  distribution := some { polarInterrogative := some .optional }
-
-/-- The full six-particle inventory across the two papers. -/
-def allParticles : List Particle :=
-  [nahodou, jeste, fakt, vubec, snad, copak]
+open Czech.Particles (nahodou jeste fakt vubec snad copak)
+open StankovaSimik2025 (ParticleSemantics)
 
 /-- This paper's classification of its three particles (the others are
-classified in `StankovaSimik2025.classification`). -/
+classified in `StankovaSimik2025.classification`). The paper defers
+*fakt*'s semantics, noting the parallels to English *really* (Romero &
+Han's VERUM) and Russian *razve*. -/
 def classification : List (Particle × ParticleSemantics) :=
   [(jeste, .temporalEndpoint), (fakt, .veridicalEmphasis), (vubec, .npi)]
 

--- a/Linglib/Studies/Stankova2026.lean
+++ b/Linglib/Studies/Stankova2026.lean
@@ -1,70 +1,52 @@
 import Linglib.Semantics.Negation.CzechNegation
 import Linglib.Studies.StankovaSimik2025
 import Linglib.Semantics.Questions.Bias.Defs
+import Linglib.Data.Examples.Stankova2026
 
 /-!
-# Czech Three-Way Negation in Polar Questions
-[stankova-2026] [stankova-2025] [zeijlstra-2004] [romero-2024]
+# Czech three-way negation in polar questions (Staňková 2026)
 
-Core empirical data for [stankova-2026], which proposes that negation in
-Czech occupies three distinct LF positions in polar questions (her (16)):
+[stankova-2026] proposes that negation in Czech polar questions occupies
+three LF positions (her (16)) — outer (PolP), medial (ModP), inner (TP)
+— fingerprinted by polarity items and the diagnostic particles
+*náhodou* / *ještě* / *fakt* (her Table 1, encoded as the substrate's
+`licenses`):
 
-| Position | LF site | Scope   | ne- > PPI | NCI | náhodou | ještě | fakt |
-|----------|---------|---------|-----------|-----|---------|-------|------|
-| inner    | TP      | narrow  | ✗         | ✓   | ✗       | ✓     | ✓    |
-| medial   | ModP    | wide    | ✓         | ✗   | ✗       | ✗     | ✓    |
-| outer    | PolP    | widest  | ✓         | ✗   | ✓       | ✗     | ✗    |
+| Position | ne- > PPI | NCI | náhodou | ještě | fakt |
+|----------|-----------|-----|---------|-------|------|
+| outer    | ✓         | ✗   | ✓       | ✗     | ✗    |
+| medial   | ✓         | ✗   | ✗       | ✗     | ✓    |
+| inner    | ✗         | ✓   | ✗       | ✓     | ✓    |
 
-The three readings differ in (i) licensing conditions on polarity/concord items,
-(ii) compatibility with particles *náhodou* 'by chance', *ještě* 'yet', *fakt*
-'really', (iii) scope relative to the evidential bias modal □_ev, and (iv)
-syntactic/prosodic encoding (word order and focus).
+## Main results
 
-The core types (`NegPosition`, `Diagnostic`, `licenses`) are in
-`Semantics.Negation.CzechNegation`; this file contains the per-cell
-verification theorems, scope generalizations, the §2.2 diagnostic
-particles, and the cross-linguistic typology bridges ([romero-2024],
-[simik-2024], [gartner-gyuris-2017], verb position, bias profiles,
-corpus data).
+* `signatures_distinct`, `particle_signatures_distinct` — the Table 1
+  columns jointly fingerprint the three positions.
+* `nahodou_identifies_outer`, `jeste_identifies_inner`,
+  `fakt_plus_no_jeste_identifies_medial` — per-particle pinning.
+* `instance Distributed Particle NegPosition` — Table 1 as a licensing
+  axis alongside clause type and embedding.
+* `czech_refines_loNQ` — Czech splits [romero-2024]'s LoNQ into inner
+  and medial.
+* `czechBiasProfile` — [simik-2024]'s Table 2 grid of PQ forms by
+  evidential × original bias.
+* `examples_match_table1` — the paper's examples
+  (`Data.Examples.Stankova2026`) check against Table 1.
+
+## References
+
+* [stankova-2026], [stankova-2025], [stankova-2023], [zeijlstra-2004],
+  [romero-2024], [simik-2024], [gartner-gyuris-2017].
 -/
 
 namespace Stankova2026
 
 open Semantics.Negation.CzechNegation
 
--- ============================================================================
--- §4: Per-Cell Verification Theorems
--- ============================================================================
+/-! ### Table 1 fingerprints -/
 
-/-! Each cell of Table 1 gets its own theorem. Changing any single entry in
-`licenses` breaks exactly one theorem — maximum interconnection density. -/
-
--- Outer negation
-theorem outer_licenses_ppi     : licenses .outer .ppiOutscoping = true  := rfl
-theorem outer_blocks_nci       : licenses .outer .nciLicensed   = false := rfl
-theorem outer_licenses_nahodou : licenses .outer .nahodou       = true  := rfl
-theorem outer_blocks_jeste     : licenses .outer .jeste         = false := rfl
-theorem outer_blocks_fakt      : licenses .outer .fakt          = false := rfl
-
--- Medial negation
-theorem medial_licenses_ppi     : licenses .medial .ppiOutscoping = true  := rfl
-theorem medial_blocks_nci       : licenses .medial .nciLicensed   = false := rfl
-theorem medial_blocks_nahodou   : licenses .medial .nahodou       = false := rfl
-theorem medial_blocks_jeste     : licenses .medial .jeste         = false := rfl
-theorem medial_licenses_fakt    : licenses .medial .fakt          = true  := rfl
-
--- Inner negation
-theorem inner_blocks_ppi       : licenses .inner .ppiOutscoping = false := rfl
-theorem inner_licenses_nci     : licenses .inner .nciLicensed   = true  := rfl
-theorem inner_blocks_nahodou   : licenses .inner .nahodou       = false := rfl
-theorem inner_licenses_jeste   : licenses .inner .jeste         = true  := rfl
-theorem inner_licenses_fakt    : licenses .inner .fakt          = true  := rfl
-
--- ============================================================================
--- §5: Uniqueness of Fingerprints
--- ============================================================================
-
-/-- The Boolean signature of a negation position across all five diagnostics. -/
+/-- The Boolean signature of a negation position across the five
+Table 1 diagnostics. -/
 def signature (pos : NegPosition) : List Bool :=
   [ licenses pos .ppiOutscoping
   , licenses pos .nciLicensed
@@ -72,53 +54,26 @@ def signature (pos : NegPosition) : List Bool :=
   , licenses pos .jeste
   , licenses pos .fakt ]
 
-/-- Each negation position has a unique diagnostic signature.
-This is the empirical basis for the three-way distinction. -/
+/-- Each negation position has a unique diagnostic signature — the
+empirical basis for the three-way distinction. -/
 theorem signatures_distinct :
     signature .outer ≠ signature .medial ∧
     signature .outer ≠ signature .inner ∧
     signature .medial ≠ signature .inner := by
   refine ⟨?_, ?_, ?_⟩ <;> (unfold signature licenses; decide)
 
-/-- The three positions exhaust all negation readings in Czech PQs. -/
-theorem positions_exhaustive : ∀ p : NegPosition,
-    p = .inner ∨ p = .medial ∨ p = .outer := by
-  intro p; cases p <;> simp
-
--- ============================================================================
--- §6: Scope Generalizations
--- ============================================================================
-
-/-- Only inner negation licenses NCIs — because only inner negation is in the
-scope domain of the Agree relation. NCIs must be c-commanded
-by ¬ at LF. Medial and outer negation are too high. -/
+/-- Only inner negation licenses NCIs: the Agree relation with `¬`
+requires LF c-command, and medial and outer negation are too high
+([stankova-2026] (6), (10)). -/
 theorem only_inner_licenses_nci :
-    (∀ p : NegPosition, licenses p .nciLicensed = true → p = .inner) := by
+    ∀ p : NegPosition, licenses p .nciLicensed = true → p = .inner := by
   intro p h; cases p <;> simp_all [licenses]
-
-/-- Only outer negation licenses *náhodou* — because *náhodou* modifies the
-ordering source of the epistemic possibility contributed by FALSUM,
-including less stereotypical worlds (Staňková §2.2.1). -/
-theorem only_outer_licenses_nahodou :
-    (∀ p : NegPosition, licenses p .nahodou = true → p = .outer) := by
-  intro p h; cases p <;> simp_all [licenses]
-
-/-- Inner negation does not outscope PPIs — PPIs like *nějaký* must outscope
-¬, but inner negation has narrow scope (within TP). So PPIs in the scope of
-inner negation yield infelicity. -/
-theorem inner_neg_cannot_outscope_ppi :
-    licenses .inner .ppiOutscoping = false := rfl
-
-/-- Both medial and outer license PPIs outscoping negation. -/
-theorem noninner_licenses_ppi :
-    licenses .medial .ppiOutscoping = true ∧
-    licenses .outer .ppiOutscoping = true := ⟨rfl, rfl⟩
 
 /-! ### The diagnostic particles ([stankova-2026] §2.2, Table 1)
 
 *náhodou* and *copak* live with the experiments in
 `StankovaSimik2025`; this paper contributes *ještě*, *fakt*, *vůbec*,
-and *snad*, the Table 1 assignments, and the fingerprint results. -/
+the Table 1 assignments, and the fingerprint results. -/
 
 open StankovaSimik2025 (nahodou copak snad ParticleSemantics)
 
@@ -150,11 +105,10 @@ def vubec : Particle where
 def allParticles : List Particle :=
   [nahodou, jeste, fakt, vubec, snad, copak]
 
-/-- This paper's classification of its four particles (the other two
-are classified in `StankovaSimik2025.classification`). -/
+/-- This paper's classification of its three particles (the others are
+classified in `StankovaSimik2025.classification`). -/
 def classification : List (Particle × ParticleSemantics) :=
-  [(jeste, .temporalEndpoint), (fakt, .veridicalEmphasis),
-   (vubec, .npi), (snad, .orderingSourceModifier)]
+  [(jeste, .temporalEndpoint), (fakt, .veridicalEmphasis), (vubec, .npi)]
 
 /-- [stankova-2026]'s Table 1: which diagnostic each particle
 realizes. -/
@@ -196,8 +150,8 @@ theorem fakt_plus_no_jeste_identifies_medial :
       pos = .medial := by
   intro pos; cases pos <;> decide
 
-/-- The three Table 1 diagnostics jointly fingerprint the three
-negation positions: no two positions share a signature. -/
+/-- The three Table 1 particles jointly fingerprint the three negation
+positions. -/
 theorem particle_signatures_distinct :
     ∀ pos pos' : NegPosition,
       (∀ p ∈ [nahodou, jeste, fakt], compatibleWith? p pos = compatibleWith? p pos') →
@@ -213,55 +167,74 @@ theorem particle_signatures_distinct :
 alike ([stankova-2025] exs. 19a-b). -/
 theorem copak_no_diagnostic : diagnostic? copak = none := by decide
 
+/-! ### Word order and PQ-form typology
+
+Czech PQs come in V1 (interrogative) and nonV1 (declarative) word
+orders; since *ne-* is inseparable from the finite verb, verb position
+determines the syntactic position of negation ([stankova-2025] §2,
+[stankova-2026] §1). Crossing word order with polarity gives
+[simik-2024]'s 2×2 grid of PQ forms, which maps onto [romero-2024]'s
+PosQ/LoNQ/HiNQ typology. -/
+
+/-- Verb position in Czech PQs: V1 (interrogative word order, verb+ne-
+high) vs nonV1 (declarative word order, verb+ne- in TP). -/
+inductive VerbPosition where
+  | v1
+  | nonV1
+  deriving DecidableEq, Repr
+
+/-- [simik-2024]'s 2×2 grid of Czech PQ forms ([simik-2024] §3.2,
+exx. 11-17): word order (interrogative vs declarative) × polarity. -/
+inductive CzechPQForm where
+  /-- Interrogative (V1), positive: the default unbiased PQ. -/
+  | interPPQ
+  /-- Interrogative (V1), negative: outer negation, positive epistemic
+      bias; broader distribution than English HiNQ ([simik-2024] §5). -/
+  | interNPQ
+  /-- Declarative (nonV1), positive: positive evidential bias. -/
+  | declPPQ
+  /-- Declarative (nonV1), negative: negative evidential bias. -/
+  | declNPQ
+  deriving DecidableEq, Repr
+
 end Stankova2026
-
-/-! ## Cross-linguistic typology
-
-Bridges from the three-way distinction to [romero-2024]'s PQ typology,
-[simik-2024]'s Czech PQ forms, and [gartner-gyuris-2017]'s bias
-profiles, plus example and corpus data ([stankova-2025] for verb
-position and context sensitivity). -/
-
--- ============================================================================
--- §7: NegPosition dot-notation extensions (must be in NegPosition's namespace)
--- ============================================================================
-
-open Semantics.Questions.Bias
 
 namespace Semantics.Negation.CzechNegation
 
-/-- Map Czech negation positions to Romero's PQ form typology.
+open Semantics.Questions.Bias
+open Stankova2026 (VerbPosition CzechPQForm)
 
-Czech VSO (interrogative) word order = high negation = HiNQ.
-Czech SVO (declarative) word order = low negation = LoNQ.
-Inner and medial are both syntactically low (SVO) but differ in LF scope.
-
-Staňková (2026 §2): "When a PQ has the SVO word order, I call it declarative;
-when a PQ has the VSO word order, I call it interrogative." -/
+/-- [romero-2024] PQ form of a negation position: outer is high
+negation (HiNQ), inner and medial are both low (LoNQ). -/
 def NegPosition.toPQForm : NegPosition → PQForm
-  | .inner  => .LoNQ  -- SVO, low negation
-  | .medial => .LoNQ  -- SVO, low negation (ambiguous with inner)
-  | .outer  => .HiNQ  -- VSO, high negation
+  | .inner | .medial => .LoNQ
+  | .outer => .HiNQ
 
-/-- Map Czech negation positions to Romero's evidential bias strength.
-
-Inner negation: strong contextual evidence bias (□_ev > ¬, must be ¬p).
-Medial negation: weak contextual evidence bias (¬ > □_ev, needn't be p).
-Outer negation: no contextual evidence bias (FALSUM, not □_ev-based). -/
+/-- Evidential bias strength of a negation position ([stankova-2026]
+§3.1): inner strong, medial weak, outer none (FALSUM is
+epistemic-bias-based). -/
 def NegPosition.biasStrength : NegPosition → EvidentialBiasStrength
   | .inner  => .strong
   | .medial => .weak
   | .outer  => .none_
 
-/-- Whether the negation position requires obligatory focus.
-
-Only outer negation (FALSUM) is obligatorily focused — it targets discourse
-polarity and generates alternatives on whether p is or isn't in the CommonGround
-(Staňková §3.2, §4). -/
+/-- Only outer negation (FALSUM) is obligatorily focused
+([stankova-2026] §3.2). -/
 def NegPosition.requiresFocus : NegPosition → Bool
-  | .outer  => true
-  | .medial => false
-  | .inner  => false
+  | .outer => true
+  | .medial | .inner => false
+
+/-- Verb position realizing a negation position: outer is V1, inner and
+medial are nonV1. -/
+def NegPosition.toVerbPosition : NegPosition → VerbPosition
+  | .inner | .medial => .nonV1
+  | .outer => .v1
+
+/-- [simik-2024] PQ form of a negation position: outer is InterNPQ,
+inner and medial are DeclNPQ. -/
+def NegPosition.toCzechPQForm : NegPosition → CzechPQForm
+  | .inner | .medial => .declNPQ
+  | .outer => .interNPQ
 
 end Semantics.Negation.CzechNegation
 
@@ -270,633 +243,153 @@ namespace Stankova2026
 open Semantics.Negation.CzechNegation
 open Semantics.Questions.Bias
 
-/-- Outer negation maps to HiNQ (high negation = interrogative word order). -/
-theorem outer_is_hiNQ : NegPosition.outer.toPQForm = .HiNQ := rfl
+/-- [romero-2024] PQ form of each [simik-2024] grid cell: InterNPQ is
+HiNQ, DeclNPQ is LoNQ, positive forms are PosQ. -/
+def CzechPQForm.toPQForm : CzechPQForm → PQForm
+  | .interPPQ | .declPPQ => .PosQ
+  | .interNPQ => .HiNQ
+  | .declNPQ  => .LoNQ
 
-/-- Inner and medial both map to LoNQ (low negation = declarative word order).
-Czech low negation PQs are ambiguous between inner and medial readings,
-distinguished by polarity items and particles (Table 1). -/
-theorem inner_medial_are_loNQ :
-    NegPosition.inner.toPQForm = .LoNQ ∧
-    NegPosition.medial.toPQForm = .LoNQ := ⟨rfl, rfl⟩
+/-- The two form typologies agree: [simik-2024]'s grid refines
+[romero-2024]'s. -/
+theorem czechPQForm_consistent_with_pqForm :
+    ∀ pos : NegPosition, pos.toCzechPQForm.toPQForm = pos.toPQForm := by
+  intro pos; cases pos <;> rfl
 
-theorem inner_strong_bias : NegPosition.inner.biasStrength = .strong := rfl
-theorem medial_weak_bias : NegPosition.medial.biasStrength = .weak := rfl
-theorem outer_no_bias : NegPosition.outer.biasStrength = .none_ := rfl
+/-- Czech refines [romero-2024]'s LoNQ: inner and medial share the LoNQ
+form but differ in evidential bias strength and in their Table 1
+signatures. -/
+theorem czech_refines_loNQ :
+    NegPosition.inner.toPQForm = NegPosition.medial.toPQForm ∧
+    NegPosition.inner.biasStrength ≠ NegPosition.medial.biasStrength ∧
+    signature .inner ≠ signature .medial :=
+  ⟨rfl, by decide, by (unfold signature licenses; decide)⟩
 
-/-- Czech outer negation (HiNQ) requires original speaker bias for p,
-matching Romero's Table 1: HiNQs mandatorily convey bias for p. -/
+/-- Obligatory focus singles out outer negation ([stankova-2026]
+§3.2). -/
+theorem only_outer_requires_focus :
+    ∀ p : NegPosition, p.requiresFocus = true → p = .outer := by
+  intro p h; cases p <;> simp_all [NegPosition.requiresFocus]
+
+/-- Czech outer negation is a HiNQ with mandatory original bias for p,
+matching [romero-2024]'s Table 1. -/
 theorem czech_outer_matches_romero_hiNQ_bias :
     NegPosition.outer.toPQForm = .HiNQ ∧
     originalBiasOK .HiNQ .forP = true ∧
     originalBiasOK .HiNQ .neutral = false := ⟨rfl, rfl, rfl⟩
 
-/-- Czech inner/medial negation (LoNQ) is compatible with neutral original bias,
-matching Romero's Table 1: LoNQs can be used without prior expectation. -/
+/-- Czech low negation is a LoNQ compatible with neutral original bias,
+matching [romero-2024]'s Table 1. -/
 theorem czech_low_neg_matches_romero_loNQ_bias :
     NegPosition.inner.toPQForm = .LoNQ ∧
     originalBiasOK .LoNQ .neutral = true := ⟨rfl, rfl⟩
 
-/-- Czech inner negation requires contextual evidence against p (Staňková §3.1,
-ex. 17a/18a). This matches Romero's Table 2: LoNQs require evidence against p. -/
+/-- Czech inner negation requires contextual evidence against p,
+matching [romero-2024]'s Table 2 for LoNQs. -/
 theorem czech_inner_matches_romero_evidence_bias :
     NegPosition.inner.toPQForm = .LoNQ ∧
     evidenceBiasOK .LoNQ .againstP = true := ⟨rfl, rfl⟩
 
 /-- Czech outer negation (HiNQ) is compatible with evidence against p
-(contradiction scenarios, Staňková ex. 24 / Romero ex. 15). -/
+(contradiction scenarios). -/
 theorem czech_outer_matches_romero_evidence :
     NegPosition.outer.toPQForm = .HiNQ ∧
     evidenceBiasOK .HiNQ .againstP = true := ⟨rfl, rfl⟩
 
--- ============================================================================
--- §8: Bridge to Focus / Information Structure
--- ============================================================================
-
-theorem only_outer_requires_focus :
-    (∀ p : NegPosition, p.requiresFocus = true → p = .outer) := by
-  intro p h; cases p <;> simp_all [NegPosition.requiresFocus]
-
--- ============================================================================
--- §9: Example Data
--- ============================================================================
-
-/-- Verb position in Czech polar questions ([stankova-2025] §2).
-
-Czech PQs use two word orders, determined by whether the finite verb
-moves to clause-initial position:
-- **V1** (verb-initial): interrogative word order, verb+ne- in PolP
-- **nonV1** (non-verb-initial): declarative word order, verb+ne- in TP
-
-Since Czech negation prefix *ne-* is inseparable from the verb,
-verb position directly determines the syntactic position of negation.
-This creates the surface syntax–negation interpretation mapping
-([zeijlstra-2004] Agree analysis, S&Š eqs. 11–12). -/
-inductive VerbPosition where
-  /-- Verb-initial (interrogative) word order.
-      The verb+ne- moves to PolP, within the scope of FALSUM[iNeg].
-      Only outer negation (FALSUM) is available (S&Š eq. 11). -/
-  | v1
-  /-- Non-verb-initial (declarative) word order.
-      The verb+ne- stays low in TP. Can be licensed by either
-      FALSUM[iNeg] or Op¬[iNeg], but not both simultaneously (S&Š eq. 12). -/
-  | nonV1
-  deriving DecidableEq, Repr
-
-end Stankova2026
-
-namespace Semantics.Negation.CzechNegation
-open Stankova2026 (VerbPosition)
-
-/-- Map negation positions to verb position.
-
-Inner/medial → nonV1 (declarative SVO).
-Outer → v1 (interrogative VSO). -/
-def NegPosition.toVerbPosition : NegPosition → VerbPosition
-  | .inner  => .nonV1
-  | .medial => .nonV1
-  | .outer  => .v1
-
-end Semantics.Negation.CzechNegation
-
-namespace Stankova2026
-open Semantics.Negation.CzechNegation
-open Semantics.Questions.Bias
-open Stankova2026 (signature)
-
-/-- A Czech PQ negation example with its reading and Romero classification. -/
-structure CzechNegDatum where
-  /-- The Czech sentence -/
-  sentence : String
-  /-- Glossed translation -/
-  gloss : String
-  /-- English translation -/
-  english : String
-  /-- The negation reading (Staňková 2026) -/
-  position : NegPosition
-  /-- Whether the example is grammatical -/
-  grammatical : Bool
-  /-- Reference example number from Staňková 2026 -/
-  exampleNum : String
-  /-- Verb position derived from negation position -/
-  verbPosition : VerbPosition := position.toVerbPosition
-  /-- Romero PQ form derived from negation position -/
-  pqForm : PQForm := position.toPQForm
-  deriving Repr
-
-/-- Ex. (6a): Inner negation with NCI — grammatical. -/
-def ex6a : CzechNegDatum :=
-  { sentence := "Petr si nekoupil žádný časopis?"
-  , gloss := "Petr REFL NEG.bought DET.NCI magazine"
-  , english := "Petr didn't buy any magazine?"
-  , position := .inner
-  , grammatical := true
-  , exampleNum := "6a" }
-
-/-- Ex. (6b): Outer negation with NCI — ungrammatical. -/
-def ex6b : CzechNegDatum :=
-  { sentence := "*Nekoupil si Petr žádný časopis?"
-  , gloss := "NEG.bought REFL Petr DET.NCI magazine"
-  , english := "Didn't Petr buy a magazine?"
-  , position := .outer
-  , grammatical := false
-  , exampleNum := "6b" }
-
-/-- Ex. (7a): Medial negation with PPI — grammatical. -/
-def ex7a : CzechNegDatum :=
-  { sentence := "Eva si neobjednala nějaký burger?"
-  , gloss := "Eva REFL NEG.ordered DET.PPI burger"
-  , english := "Eva didn't order some burger?"
-  , position := .medial
-  , grammatical := true
-  , exampleNum := "7a" }
-
-/-- Ex. (7b): Outer negation with PPI — grammatical. -/
-def ex7b : CzechNegDatum :=
-  { sentence := "Neobjednala si Eva nějaký burger?"
-  , gloss := "NEG.ordered REFL Eva DET.PPI burger"
-  , english := "Didn't Eva order some burger?"
-  , position := .outer
-  , grammatical := true
-  , exampleNum := "7b" }
-
-/-- Ex. (11): Outer negation with *náhodou* — grammatical. -/
-def ex11 : CzechNegDatum :=
-  { sentence := "Nepůjčila si tam Eva náhodou nějakou encyklopedii?"
-  , gloss := "NEG.borrowed REFL there Eva NÁHODOU DET.PPI encyclopedia"
-  , english := "Didn't Eva borrow some encyclopedia, by any chance?"
-  , position := .outer
-  , grammatical := true
-  , exampleNum := "11" }
-
-/-- Ex. (15a): Inner negation with *fakt* — grammatical. -/
-def ex15a : CzechNegDatum :=
-  { sentence := "Eva fakt neviděla žádný Tarantinův film?"
-  , gloss := "Eva FAKT NEG.saw DET.NCI Tarantino's film"
-  , english := "Eva really hasn't seen any film by Tarantino?"
-  , position := .inner
-  , grammatical := true
-  , exampleNum := "15a" }
-
-/-- Ex. (15d): Outer negation with *fakt* — ungrammatical. -/
-def ex15d : CzechNegDatum :=
-  { sentence := "*Neviděla Eva fakt nějaký Tarantinův film?"
-  , gloss := "NEG.saw Eva FAKT DET.PPI Tarantino's film"
-  , english := "Is it really not the case that Eva has seen a film by Tarantino?"
-  , position := .outer
-  , grammatical := false
-  , exampleNum := "15d" }
-
-def allExamples : List CzechNegDatum :=
-  [ex6a, ex6b, ex7a, ex7b, ex11, ex15a, ex15d]
-
--- ============================================================================
--- §10: Per-Example Verification
--- ============================================================================
-
-/-- Examples predicted grammatical by Table 1 are marked grammatical. -/
-theorem ex6a_grammatical_iff_inner_licenses_nci :
-    ex6a.grammatical = licenses ex6a.position .nciLicensed := rfl
-
-theorem ex6b_ungrammatical_iff_outer_blocks_nci :
-    ex6b.grammatical = licenses ex6b.position .nciLicensed := rfl
-
-theorem ex7a_grammatical_iff_medial_licenses_ppi :
-    ex7a.grammatical = licenses ex7a.position .ppiOutscoping := rfl
-
-theorem ex7b_grammatical_iff_outer_licenses_ppi :
-    ex7b.grammatical = licenses ex7b.position .ppiOutscoping := rfl
-
-theorem ex11_grammatical_iff_outer_licenses_nahodou :
-    ex11.grammatical = licenses ex11.position .nahodou := rfl
-
-theorem ex15a_grammatical_iff_inner_licenses_fakt :
-    ex15a.grammatical = licenses ex15a.position .fakt := rfl
-
-theorem ex15d_ungrammatical_iff_outer_blocks_fakt :
-    ex15d.grammatical = licenses ex15d.position .fakt := rfl
-
--- ============================================================================
--- §11: Per-Example Romero Classification
--- ============================================================================
-
-/-! Each Czech example carries its Romero PQ form automatically via
-`NegPosition.toPQForm`. These bridge theorems verify that the classification
-is consistent with the word order and bias conditions. -/
-
-/-- Ex. 6a (inner, nonV1) is a LoNQ. -/
-theorem ex6a_is_loNQ : ex6a.pqForm = .LoNQ := rfl
-
-/-- Ex. 6b (outer, V1) is a HiNQ. -/
-theorem ex6b_is_hiNQ : ex6b.pqForm = .HiNQ := rfl
-
-/-- Ex. 7a (medial, nonV1) is a LoNQ. -/
-theorem ex7a_is_loNQ : ex7a.pqForm = .LoNQ := rfl
-
-/-- Ex. 7b (outer, V1) is a HiNQ. -/
-theorem ex7b_is_hiNQ : ex7b.pqForm = .HiNQ := rfl
-
-/-- Ex. 11 (outer, V1) is a HiNQ with *náhodou*. -/
-theorem ex11_is_hiNQ : ex11.pqForm = .HiNQ := rfl
-
-/-- Ex. 15a (inner, nonV1) is a LoNQ with *fakt*. -/
-theorem ex15a_is_loNQ : ex15a.pqForm = .LoNQ := rfl
-
-/-- Ex. 15d (outer, V1) is a HiNQ — *fakt* is incompatible. -/
-theorem ex15d_is_hiNQ : ex15d.pqForm = .HiNQ := rfl
-
--- ============================================================================
--- §12: Romero Bias Predictions for Czech Examples
--- ============================================================================
-
-/-! Romero's Tables 1–2 make predictions about which Czech examples should be
-felicitous. These bridge theorems verify that Staňková's Czech data is
-consistent with Romero's cross-linguistic generalizations. -/
-
-/-- Ex. 6b is a HiNQ. Romero Table 1 says HiNQ mandatorily conveys original
-bias for p. The example IS a HiNQ but is ungrammatical because the NCI *žádný*
-is incompatible with outer negation — a Czech-specific constraint layered on
-top of the Romero framework. -/
-theorem ex6b_hiNQ_blocked_by_nci :
-    ex6b.pqForm = .HiNQ ∧
-    originalBiasOK ex6b.pqForm .forP = true ∧
-    licenses ex6b.position .nciLicensed = false := ⟨rfl, rfl, rfl⟩
-
-/-- Ex. 7b is a HiNQ (outer, V1) with a PPI. Romero Table 1: HiNQ requires
-original bias for p. The PPI is licensed because outer negation allows PPI
-outscoping. This is a felicitous Czech HiNQ consistent with Romero. -/
-theorem ex7b_hiNQ_consistent_with_romero :
-    ex7b.pqForm = .HiNQ ∧
-    ex7b.grammatical = true ∧
-    originalBiasOK ex7b.pqForm .forP = true ∧
-    licenses ex7b.position .ppiOutscoping = true := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- Ex. 11 is a HiNQ with *náhodou* 'by chance'. This is the prototypical
-outer-HiNQ: original speaker bias for p (Romero Table 1), compatible with
-neutral or against-p evidence (Romero Table 2). *Náhodou* modifies the
-epistemic possibility component of FALSUM. -/
-theorem ex11_hiNQ_with_nahodou :
-    ex11.pqForm = .HiNQ ∧
-    ex11.grammatical = true ∧
-    originalBiasOK ex11.pqForm .forP = true ∧
-    evidenceBiasOK ex11.pqForm .neutral = true ∧
-    licenses ex11.position .nahodou = true := ⟨rfl, rfl, rfl, rfl, rfl⟩
-
-/-- Ex. 7a (medial, nonV1, LoNQ) is felicitous in contexts with some evidence
-against p. Romero Table 2: LoNQ requires evidence against p. Staňková's
-medial negation carries weak evidential bias — weaker than inner, but still
-requires contextual evidence. -/
-theorem ex7a_loNQ_with_evidence :
-    ex7a.pqForm = .LoNQ ∧
-    ex7a.grammatical = true ∧
-    evidenceBiasOK ex7a.pqForm .againstP = true ∧
-    ex7a.position.biasStrength = .weak := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- Ex. 6a (inner, nonV1, LoNQ) is felicitous only with strong contextual
-evidence against p. Romero Table 2: LoNQ requires evidence against p.
-Staňková adds the refinement that inner neg requires *strong* evidence
-(the inner/medial split within LoNQ). -/
-theorem ex6a_loNQ_strong_evidence :
-    ex6a.pqForm = .LoNQ ∧
-    ex6a.grammatical = true ∧
-    evidenceBiasOK ex6a.pqForm .againstP = true ∧
-    ex6a.position.biasStrength = .strong := ⟨rfl, rfl, rfl, rfl⟩
-
--- ============================================================================
--- §13: Czech Refines Romero's LoNQ
--- ============================================================================
-
-/-- Czech reveals a finer-grained distinction within Romero's LoNQ category.
-
-Romero treats LoNQ as a single PQ form. Staňková shows that Czech SVO
-(= LoNQ) polar questions are actually ambiguous between inner and medial
-readings, distinguished by their diagnostic signatures (Table 1) and by
-the strength of their evidential bias.
-
-This is a cross-linguistic prediction: languages with overt NCI/PPI contrasts
-and diagnostic particles may reveal the inner/medial split within LoNQ. -/
-theorem czech_refines_loNQ :
-    NegPosition.inner.toPQForm = NegPosition.medial.toPQForm ∧   -- both LoNQ
-    NegPosition.inner.biasStrength ≠ NegPosition.medial.biasStrength ∧  -- different bias
-    signature .inner ≠ signature .medial :=                      -- different diagnostics
-  ⟨rfl, by decide, by (unfold signature licenses; decide)⟩
-
--- ============================================================================
--- §14: Czech PQ Form Typology ([simik-2024] §3.2)
--- ============================================================================
-
-/-- Czech polar question forms: the 2×2 grid of [Interrogative vs Declarative]
-× [Positive vs Negative] ([simik-2024] §3.2, exx. 11–17).
-
-Czech uses two independent formal strategies to express bias:
-1. **Negation**: positive vs negative (ne- prefix)
-2. **Word order**: interrogative (VSO, verb-initial) vs declarative (SVO)
-
-This is finer-grained than Romero's PosQ/LoNQ/HiNQ, because Czech
-declarative PQs (DeclPQ) are a separate grammatical category not present
-in English ([simik-2024]: "declarative PQs represent yet another type of utterance
-with a canonical SVO word order"). -/
-inductive CzechPQForm where
-  /-- InterPPQ: Interrogative (VSO), Positive. Default unbiased PQ. -/
-  | interPPQ
-  /-- InterNPQ: Interrogative (VSO), Negative. Conveys positive epistemic bias.
-      Broader distribution than English HiNQ ([simik-2024] §5). -/
-  | interNPQ
-  /-- DeclPPQ: Declarative (SVO), Positive. Conveys positive evidential bias. -/
-  | declPPQ
-  /-- DeclNPQ: Declarative (SVO), Negative. Requires negative evidential bias. -/
-  | declNPQ
-  deriving DecidableEq, Repr
-
-/-- Map Czech PQ forms to Romero's cross-linguistic PQ typology.
-
-[simik-2024]'s InterNPQ is Romero's HiNQ (outer negation with VSO).
-[simik-2024]'s DeclNPQ is Romero's LoNQ (inner/medial negation with SVO).
-[simik-2024]'s InterPPQ and DeclPPQ are both Romero's PosQ. -/
-def CzechPQForm.toPQForm : CzechPQForm → PQForm
-  | .interPPQ => .PosQ
-  | .interNPQ => .HiNQ  -- outer negation, verb-initial
-  | .declPPQ  => .PosQ
-  | .declNPQ  => .LoNQ  -- inner/medial negation, declarative
-
-theorem interNPQ_is_hiNQ : CzechPQForm.interNPQ.toPQForm = .HiNQ := rfl
-theorem declNPQ_is_loNQ : CzechPQForm.declNPQ.toPQForm = .LoNQ := rfl
-
-end Stankova2026
-
-namespace Semantics.Negation.CzechNegation
-open Stankova2026 (CzechPQForm)
-
-/-- Map negation positions to Czech PQ forms.
-
-Inner/medial → DeclNPQ (SVO, negative).
-Outer → InterNPQ (VSO, negative). -/
-def NegPosition.toCzechPQForm : NegPosition → CzechPQForm
-  | .inner  => .declNPQ
-  | .medial => .declNPQ
-  | .outer  => .interNPQ
-
-end Semantics.Negation.CzechNegation
-
-namespace Stankova2026
-open Semantics.Negation.CzechNegation
-open Semantics.Questions.Bias
-
-/-- The CzechPQForm → PQForm mapping is consistent with NegPosition → PQForm. -/
-theorem czechPQForm_consistent_with_pqForm :
-    ∀ pos : NegPosition,
-      pos.toCzechPQForm.toPQForm = pos.toPQForm := by
-  intro pos; cases pos <;> rfl
-
--- ============================================================================
--- §15: Czech Bias Profiles ([simik-2024], Table 2 / [stankova-2023])
--- ============================================================================
-
-/-- Czech bias profile ([simik-2024] Table 2, based on [stankova-2023]).
-
-Each cell records which Czech PQ forms are felicitous under a given
-combination of contextual evidence × original speaker bias. Empty list = no
-form is natural.
-
-Uses `ContextualEvidence` and `OriginalBias` from Bias
-rather than Czech-specific copies — these are the same bias dimensions.
-
-Table 2 (glossing over details):
-| Evid \ Epist | forP               | neutral            | againstP   |
-|--------------|--------------------|--------------------|------------|
-| forP         |                    | DeclPPQ, InterNPQ  | DeclPPQ    |
-| neutral      | InterPPQ, InterNPQ | InterPPQ           |            |
-| againstP     | DeclNPQ, InterNPQ  | DeclNPQ            |            |
-
-*DeclPPQ with neutral/neutral is conditioned by information structure.
-InterNPQ with neutral epistemic requires explanation-seeking context. -/
+/-! ### Verb position and context sensitivity -/
+
+/-- Negation readings available per verb position ([stankova-2025]
+eqs. 11-12 with [stankova-2026]'s medial added): V1 only outer; nonV1
+all three (outer in nonV1 needs contrastive topic + focused verb,
+[stankova-2025] ex. 18). -/
+def VerbPosition.availableReadings : VerbPosition → List NegPosition
+  | .v1    => [.outer]
+  | .nonV1 => [.inner, .medial, .outer]
+
+/-- The default (unmarked) negation reading per verb position. -/
+def VerbPosition.defaultReading : VerbPosition → NegPosition
+  | .v1    => .outer
+  | .nonV1 => .inner
+
+/-- Whether a verb position's default reading requires contextual
+evidence ([stankova-2025] §5): V1 (FALSUM) is context-insensitive —
+compatible with positive, negative, and neutral evidential bias, unlike
+English HiNQs — while nonV1 (inner) requires negative evidential
+bias. -/
+def VerbPosition.requiresContextualEvidence : VerbPosition → Bool
+  | .v1    => false
+  | .nonV1 => true
+
+/-- Context sensitivity tracks evidential bias strength: V1/outer none,
+nonV1/inner strong. -/
+theorem context_tracks_bias_strength :
+    VerbPosition.v1.defaultReading.biasStrength = .none_ ∧
+    VerbPosition.nonV1.defaultReading.biasStrength = .strong := ⟨rfl, rfl⟩
+
+/-! ### The Czech bias profile ([simik-2024] Table 2) -/
+
+/-- Which Czech PQ forms are felicitous per contextual evidence ×
+original speaker bias cell ([simik-2024] Table 2, based on
+[stankova-2023]); empty list = no form natural. -/
 def czechBiasProfile : ContextualEvidence → OriginalBias → List CzechPQForm
-  | .forP,     .forP     => []  -- no form natural in this cell
+  | .forP,     .forP      => []
   | .forP,     .neutral   => [.declPPQ, .interNPQ]
   | .forP,     .againstP  => [.declPPQ]
   | .neutral,  .forP      => [.interPPQ, .interNPQ]
-  | .neutral,  .neutral   => [.interPPQ]  -- default: InterPPQ
+  | .neutral,  .neutral   => [.interPPQ]
   | .neutral,  .againstP  => []
   | .againstP, .forP      => [.declNPQ, .interNPQ]
   | .againstP, .neutral   => [.declNPQ]
   | .againstP, .againstP  => []
 
-/-- InterPPQ is the default (unbiased) Czech PQ — the only form felicitous
-in quiz scenarios where no bias is intended ([simik-2024] §4.1, ex. 25). -/
+/-- InterPPQ is the sole form felicitous with no bias at all — the
+default PQ ([simik-2024] §4.1, ex. 25). -/
 theorem interPPQ_is_default :
     (czechBiasProfile .neutral .neutral).contains .interPPQ = true := rfl
 
-/-- DeclPQs require matching evidential bias ([stankova-2023], [simik-2024] §3.2):
-DeclPPQ needs positive evidence, DeclNPQ needs negative evidence. -/
+/-- DeclPPQ needs positive contextual evidence ([stankova-2023],
+[simik-2024] §3.2). -/
 theorem declPPQ_requires_positive_evidence :
     (czechBiasProfile .forP .neutral).contains .declPPQ = true ∧
     (czechBiasProfile .againstP .neutral).contains .declPPQ = false := ⟨rfl, rfl⟩
 
+/-- DeclNPQ needs negative contextual evidence ([stankova-2023],
+[simik-2024] §3.2). -/
 theorem declNPQ_requires_negative_evidence :
     (czechBiasProfile .againstP .neutral).contains .declNPQ = true ∧
     (czechBiasProfile .forP .neutral).contains .declNPQ = false := ⟨rfl, rfl⟩
 
-/-- InterNPQ has the broadest distribution among negative forms —
-it appears in three bias cells, reflecting Czech outer negation's
-broader distribution than English HiNQ ([simik-2024] §5). -/
+/-- InterNPQ appears in three bias cells — the broadest distribution
+among negative forms, reflecting Czech outer negation's broader range
+than English HiNQ ([simik-2024] §5). -/
 theorem interNPQ_broad_distribution :
     (czechBiasProfile .forP .neutral).contains .interNPQ = true ∧
     (czechBiasProfile .neutral .forP).contains .interNPQ = true ∧
     (czechBiasProfile .againstP .forP).contains .interNPQ = true := ⟨rfl, rfl, rfl⟩
 
--- ============================================================================
--- §16: DeclPQ Evidential Bias Generalization ([simik-2024] §3.2)
--- ============================================================================
+/-! ### The paper's examples
 
-/-- [simik-2024]'s key generalization: Declarative PQs are specialized for conveying
-evidential bias. The polarity of the DeclPQ matches the polarity of the
-evidential bias — DeclPPQ conveys positive evidential bias, DeclNPQ conveys
-negative evidential bias.
+Typed stimuli live in `Data.Examples.Stankova2026`; each is paired here
+with the negation reading and Table 1 diagnostic the paper assigns. -/
 
-Interrogative PQs, by contrast, convey epistemic bias (speaker's prior belief),
-and InterNPQ can additionally convey evidential bias.
+open Data.Examples (LinguisticExample)
 
-This is captured by: for any evidential bias, the DeclPQ that appears has
-matching polarity. -/
-theorem decl_polarity_matches_evidence :
-    (czechBiasProfile .forP .neutral).contains .declPPQ = true ∧
-    (czechBiasProfile .forP .againstP).contains .declPPQ = true ∧
-    (czechBiasProfile .againstP .forP).contains .declNPQ = true ∧
-    (czechBiasProfile .againstP .neutral).contains .declNPQ = true := ⟨rfl, rfl, rfl, rfl⟩
+/-- The paper's polarity/particle examples with their negation reading
+and tested diagnostic. -/
+def analyzedExamples : List (LinguisticExample × NegPosition × Diagnostic) :=
+  [ (Examples.ex6a,  .inner,  .nciLicensed)
+  , (Examples.ex6b,  .outer,  .nciLicensed)
+  , (Examples.ex7a,  .medial, .ppiOutscoping)
+  , (Examples.ex7b,  .outer,  .ppiOutscoping)
+  , (Examples.ex11,  .outer,  .nahodou)
+  , (Examples.ex15a, .inner,  .fakt)
+  , (Examples.ex15d, .outer,  .fakt) ]
 
--- ============================================================================
--- §17: Verb Position Readings ([stankova-2025])
--- ============================================================================
-
-/-- Which negation readings are available for each verb position.
-
-V1 → only outer (FALSUM) — S&Š eq. (11):
-  [ForceP Q [StrengthP FALSUM[iNeg] [PolP NEG-V[uNeg] [CP … [TP SUBJECT tV …]]]]]
-
-nonV1 → inner, medial, or outer — S&Š eq. (12), plus Staňková 2026's medial:
-  [ForceP Q [StrengthP {FALSUM[iNeg]} [CP SUBJECT [TP {Op¬[iNeg]} NEG-V[uNeg] …]]]]
-
-Note: outer negation in nonV1 requires contrastive topic on the subject
-and contrastive focus on the verb (S&Š ex. 18). -/
-def VerbPosition.availableReadings : VerbPosition → List NegPosition
-  | .v1    => [.outer]
-  | .nonV1 => [.inner, .medial, .outer]
-
-/-- The default (unmarked) negation reading for each verb position. -/
-def VerbPosition.defaultReading : VerbPosition → NegPosition
-  | .v1    => .outer
-  | .nonV1 => .inner
-
-/-- V1 only allows outer negation. -/
-theorem v1_only_outer :
-    VerbPosition.v1.availableReadings = [NegPosition.outer] := rfl
-
-/-- V1 default reading is outer. -/
-theorem v1_default_outer :
-    VerbPosition.v1.defaultReading = .outer := rfl
-
-/-- nonV1 default reading is inner. -/
-theorem nonV1_default_inner :
-    VerbPosition.nonV1.defaultReading = .inner := rfl
-
-/-- V1 default maps to HiNQ (Romero). -/
-theorem v1_default_is_hiNQ :
-    VerbPosition.v1.defaultReading.toPQForm = .HiNQ := rfl
-
-/-- nonV1 default maps to LoNQ (Romero). -/
-theorem nonV1_default_is_loNQ :
-    VerbPosition.nonV1.defaultReading.toPQForm = .LoNQ := rfl
-
-/-- V1 maps to InterNPQ ([simik-2024]'s finer typology). -/
-theorem v1_default_is_interNPQ :
-    VerbPosition.v1.defaultReading.toCzechPQForm = .interNPQ := rfl
-
-/-- nonV1 default maps to DeclNPQ ([simik-2024]'s finer typology). -/
-theorem nonV1_default_is_declNPQ :
-    VerbPosition.nonV1.defaultReading.toCzechPQForm = .declNPQ := rfl
-
--- ============================================================================
--- §18: Context Sensitivity per Verb Position (S&Š §5.2–5.3)
--- ============================================================================
-
-/-- Whether a verb position's default negation reading requires
-contextual evidence (evidential bias) to be felicitous.
-
-V1 (FALSUM): no — insensitive to context (S&Š §5.2, §5.3)
-nonV1 (inner): yes — requires negative evidential bias (S&Š §5.2)
-
-This is the key experimental finding of S&Š: the syntactic position
-of negation determines sensitivity to contextual evidence. -/
-def VerbPosition.requiresContextualEvidence : VerbPosition → Bool
-  | .v1    => false  -- FALSUM = epistemic bias only
-  | .nonV1 => true   -- inner neg = evidential bias
-
-theorem v1_context_insensitive :
-    VerbPosition.v1.requiresContextualEvidence = false := rfl
-
-theorem nonV1_context_sensitive :
-    VerbPosition.nonV1.requiresContextualEvidence = true := rfl
-
-/-- Context sensitivity correlates with evidential bias strength:
-V1/outer has no evidential bias requirement (FALSUM is epistemic).
-nonV1/inner has strong evidential bias (requires contextual evidence for ¬p). -/
-theorem context_tracks_bias_strength :
-    VerbPosition.v1.defaultReading.biasStrength = .none_ ∧
-    VerbPosition.nonV1.defaultReading.biasStrength = .strong := ⟨rfl, rfl⟩
-
--- ============================================================================
--- §19: Czech FALSUM Broader Than English (S&Š §5.3, ex. 14)
--- ============================================================================
-
-/-- Czech outer negation (FALSUM) is compatible with all types of
-evidential bias — positive, negative, and neutral — unlike English HiNQs
-which require negative or neutral evidence.
-
-This is confirmed by the positive-evidence subexperiment (S&Š ex. 14):
-V1 PQs with positive evidential bias were rated very natural (median 6/7).
-
-The broader distribution follows from Czech FALSUM being tied to
-epistemic bias (speaker's possibility assessment) rather than to
-evidential bias. FALSUM^CZ ([simik-2024] eq. 44) only requires that the
-speaker considers p epistemically possible, regardless of evidence. -/
-theorem czech_falsum_broader_than_english :
-    VerbPosition.v1.requiresContextualEvidence = false ∧
-    VerbPosition.v1.defaultReading.biasStrength = .none_ := ⟨rfl, rfl⟩
-
--- ============================================================================
--- §20: Corpus Data ([simik-2024], fn. 56)
--- ============================================================================
-
-/-- Corpus data for *náhodou* in PQs ([simik-2024] fn. 56).
-
-From 100 random occurrences of *náhodou* in PQs (SYN v11, Czech National Corpus):
-- All 100 involved negation
-- 6 had indefinite pronoun/determiners, all were PPIs (no NCIs)
-- All diagnosed outer negation
-
-This confirms the fragment-level claim that náhodou requires outer negation
-and is incompatible with NCIs. -/
-structure NahodouCorpusData where
-  /-- Total random sample size -/
-  sampleSize : Nat
-  /-- Number involving negation -/
-  withNegation : Nat
-  /-- Number with indefinite determiners -/
-  withIndefinites : Nat
-  /-- Number of those indefinites that were PPIs -/
-  ppiIndefinites : Nat
-
-def nahodouCorpus : NahodouCorpusData :=
-  { sampleSize := 100
-  , withNegation := 100
-  , withIndefinites := 6
-  , ppiIndefinites := 6 }
-
-/-- All náhodou PQ occurrences involved negation. -/
-theorem nahodou_always_negated :
-    nahodouCorpus.withNegation = nahodouCorpus.sampleSize := rfl
-
-/-- All indefinites with náhodou were PPIs (no NCIs). -/
-theorem nahodou_only_ppis :
-    nahodouCorpus.ppiIndefinites = nahodouCorpus.withIndefinites := rfl
-
--- ============================================================================
--- §21: InterNPQ Use Categories ([simik-2024] §5.2)
--- ============================================================================
-
-/-- Categories of InterNPQ use with *náhodou* ([simik-2024] §5.2, fn. 59).
-
-From 100 random occurrences, the four main categories are:
-1. Prior speaker belief (conflict-resolving PQ) — 14%
-2. Explanation-seeking (no prior bias, situational evidence) — 40%
-3. Relevance PQ (suggesting p is worth discussing) — 20%
-4. Hope (speaker hopes p is true) — 20%
--/
-inductive InterNPQUseCategory where
-  /-- Conflict between prior epistemic bias for p and evidential bias for ¬p.
-      The prototypical biased HiNQ use. -/
-  | belief
-  /-- No prior epistemic bias; evidential bias from observed situation.
-      Not available in English HiNQ. -/
-  | explanationSeeking
-  /-- Speaker suggests p is relevant for further discussion. -/
-  | relevance
-  /-- Speaker hopes that p, and considers it epistemically possible. -/
-  | hope
-  deriving DecidableEq, Repr
-
-/-- Distribution of InterNPQ+náhodou use categories ([simik-2024] fn. 59). -/
-def interNPQDistribution : InterNPQUseCategory → Nat
-  | .belief             => 14
-  | .explanationSeeking => 40
-  | .relevance          => 20
-  | .hope               => 20
-
-/-- Explanation-seeking is the most common InterNPQ+náhodou use.
-This motivates [simik-2024]'s weaker FALSUM^CZ: the attitude holder merely
-considers p epistemically possible, not that they believe p. -/
-theorem explanationSeeking_most_common :
-    interNPQDistribution .explanationSeeking >
-    interNPQDistribution .belief := by decide
+/-- Table 1 predicts each example's judgment: the diagnostic is
+licensed at the example's negation position iff the example is
+acceptable. -/
+theorem examples_match_table1 :
+    analyzedExamples.all (fun (e, pos, d) =>
+      (e.judgment == .acceptable) == licenses pos d) = true := by decide
 
 end Stankova2026

--- a/Linglib/Studies/StankovaSimik2025.lean
+++ b/Linglib/Studies/StankovaSimik2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Particle.Capabilities
+import Linglib.Fragments.Slavic.Czech.Particles
 import Linglib.Semantics.Negation.CzechNegation
 
 /-!
@@ -7,9 +7,9 @@ import Linglib.Semantics.Negation.CzechNegation
 This file formalizes [stankova-2025]'s particle results: *náhodou* as
 an overt indicator of the covert FALSUM operator (§6.1 subexperiment)
 and *copak* as sensitive to contextual evidence (§6.2 subexperiment,
-exs. 19-20). The paper distinguishes two negation readings (inner and
-outer); the three-way system and its Table 1 diagnostics are
-[stankova-2026]'s and live in `Stankova2026`.
+exs. 19-20). The lexical entries live in `Czech.Particles`; the
+three-way system and its Table 1 diagnostics are [stankova-2026]'s and
+live in `Stankova2026`.
 
 ## Main results
 
@@ -24,39 +24,7 @@ outer); the three-way system and its Table 1 diagnostics are
 
 namespace StankovaSimik2025
 
-/-! ### The particles
-
-All occur in Czech polar questions, the paper's domain; other
-clause-type cells and placements are unrecorded. -/
-
-/-- *náhodou* 'by (any) chance' — licensed by FALSUM: the §6.1
-subexperiment shows NCIs (inner negation) degrade *náhodou* PQs
-(main effect of INDEFINITE, z = −12.845, p < .001), so *náhodou* "could
-be used as an overt indicator of the covert FALSUM operator being
-present in the structure" ([stankova-2025] §6.1). Insensitive to
-contextual evidence, unlike *copak*. -/
-def nahodou : Particle where
-  form := "náhodou"
-  distribution := some { polarInterrogative := some .optional }
-
-/-- *snad* 'perhaps, surely not' — adversative/mirative particle of the
-cross-Slavic RAZVE family ([simik-2024] §4.2.4, [nekula-1996],
-[stankova-2023]); not experimentally tested in [stankova-2025]. -/
-def snad : Particle where
-  form := "snad"
-  distribution := some { polarInterrogative := some .optional }
-
-/-- *copak* 'what then' — "strongly indicates a conflict between
-speaker's prior belief and the currently available evidence"
-([stankova-2025] §6.2, citing [nekula-1996]): licensed in positive and
-negative PQs alike (exs. 19a-b), requiring a context whose evidence
-matches the PQ's polarity; the §6.2 subexperiment confirms the biased >
-neutral preference (main effect of CONTEXT, z = 9.372, p < .001). The
-Czech member of the cross-Slavic family with Polish *czyby* and Russian
-*razve* (p. 12). -/
-def copak : Particle where
-  form := "copak"
-  distribution := some { polarInterrogative := some .optional }
+open Czech.Particles (nahodou snad copak)
 
 /-! ### Classification -/
 
@@ -94,9 +62,19 @@ def requiresEvidentialBias (p : Particle) : Option Bool :=
   else if p = nahodou then some false
   else none
 
+/-- The §6.1 subexperiment: NCIs (inner negation) degrade *náhodou* PQs
+(main effect of INDEFINITE, z = −12.845, p < .001), so *náhodou* "could
+be used as an overt indicator of the covert FALSUM operator being
+present in the structure" — and FALSUM is context-insensitive. -/
 theorem nahodou_context_insensitive :
     requiresEvidentialBias nahodou = some false := by decide
 
+/-- The §6.2 subexperiment: *copak* "strongly indicates a conflict
+between speaker's prior belief and the currently available evidence"
+(citing [nekula-1996]) — biased > neutral contexts, main effect of
+CONTEXT, z = 9.372, p < .001; licensed in positive and negative PQs
+alike (exs. 19a-b). Cross-Slavic kin: Polish *czyby*, Russian *razve*
+(p. 12). -/
 theorem copak_context_sensitive :
     requiresEvidentialBias copak = some true := by decide
 


### PR DESCRIPTION
Deep cleanse of the merged Stankova2026 study (903→395 lines): mathlib header with Main results; per-cell/per-example rfl readbacks, derived-field theorems, and the corpus-count blocks cut ([simik-2024] fn. 56/59 percentages were also mis-anchored here); one CzechNegation extension block; the paper's seven examples move to the Data/Examples JSON pipeline with a single `examples_match_table1` prediction check.