### PR TITLE
refactor(Syntax/Minimalist): polish Externalization; PermEquiv.lift_eq

### DIFF
--- a/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
@@ -102,6 +102,13 @@ theorem of_step {t s : RoseTree α} (h : PermStep t s) : PermEquiv t s :=
 theorem isEquivalence : Equivalence (PermEquiv : RoseTree α → RoseTree α → Prop) :=
   Relation.EqvGen.is_equivalence _
 
+/-- Extend an `Eq`-valued invariant from single steps to the equivalence closure:
+    a function unchanged by every `PermStep` is unchanged by `PermEquiv`. -/
+theorem lift_eq {β : Sort*} {f : RoseTree α → β}
+    (hf : ∀ t s : RoseTree α, PermStep t s → f t = f s)
+    {t s : RoseTree α} (h : PermEquiv t s) : f t = f s :=
+  congrArg (Quot.lift f hf) (Quot.eqvGen_sound h)
+
 end PermEquiv
 
 /-! ### Lifting structural invariants from `RoseTree` to `Nonplanar`
@@ -111,10 +118,10 @@ through the equivalence closure to functions `Nonplanar α → β`. Below
 we lift `numNodes` (vertex count) and the other counts as worked examples.
 
 The pattern: prove invariance under the elementary `PermStep`, then
-extend to `PermEquiv = EqvGen PermStep` by an `EqvGen` induction. On
-`RoseTree` the counts sum/`foldr`-max directly over `cs.map …`, so
-permutation invariance is just `List.Perm.sum_eq` / `List.Perm.foldr_eq`
-on the child list. -/
+extend to `PermEquiv` with `PermEquiv.lift_eq`. On `RoseTree` the
+counts sum/`foldr`-max directly over `cs.map …`, so permutation
+invariance is just `List.Perm.sum_eq` / `List.Perm.foldr_eq` on the
+child list. -/
 
 /-! #### Node count invariance -/
 
@@ -132,14 +139,10 @@ private theorem numNodes_permStep {t s : RoseTree α} (h : PermStep t s) :
     simp only [numNodes_node, List.map_append, List.map_cons, List.sum_append,
       List.sum_cons, ih]
 
-/-- `numNodes` is invariant under `PermEquiv`. By induction on `EqvGen`. -/
+/-- `numNodes` is invariant under `PermEquiv`. -/
 theorem numNodes_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
-    t.numNodes = s.numNodes := by
-  induction h with
-  | rel _ _ hstep => exact numNodes_permStep hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    t.numNodes = s.numNodes :=
+  PermEquiv.lift_eq (fun _ _ h' => numNodes_permStep h') h
 
 /-! #### Leaf-count invariance -/
 
@@ -157,12 +160,8 @@ private theorem numLeaves_permStep {t s : RoseTree α} (h : PermStep t s) :
 
 /-- `numLeaves` is invariant under `PermEquiv`. -/
 theorem numLeaves_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
-    t.numLeaves = s.numLeaves := by
-  induction h with
-  | rel _ _ hstep => exact numLeaves_permStep hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    t.numLeaves = s.numLeaves :=
+  PermEquiv.lift_eq (fun _ _ h' => numLeaves_permStep h') h
 
 /-! #### Value invariance -/
 
@@ -175,12 +174,8 @@ private theorem permStep_value_eq {t s : RoseTree α} (h : PermStep t s) :
 
 /-- The root value is preserved by `PermEquiv`. -/
 theorem value_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
-    t.value = s.value := by
-  induction h with
-  | rel _ _ hstep => exact permStep_value_eq hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    t.value = s.value :=
+  PermEquiv.lift_eq (fun _ _ h' => permStep_value_eq h') h
 
 /-! #### Lifting child-list operations to `PermEquiv`
 
@@ -293,7 +288,7 @@ theorem permEquiv_node_componentwise {a : α} {cs ds : List (RoseTree α)}
 Three more invariants of tree structure that are preserved by
 `PermEquiv`. The pattern follows `numNodes`: prove `*_permStep`
 by case on the step constructor, then lift to `*_permEquiv` via
-`EqvGen` induction. -/
+`PermEquiv.lift_eq`. -/
 
 /-- Arity (root child count) is invariant under `PermStep`: both
     `swapAtRoot` and `recurse` keep the children list's length fixed. -/
@@ -303,12 +298,8 @@ private theorem arity_permStep {t s : RoseTree α} (h : PermStep t s) :
 
 /-- Arity is invariant under `PermEquiv`. -/
 theorem arity_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
-    t.arity = s.arity := by
-  induction h with
-  | rel _ _ hstep => exact arity_permStep hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    t.arity = s.arity :=
+  PermEquiv.lift_eq (fun _ _ h' => arity_permStep h') h
 
 /-- Depth is invariant under `PermStep`. The `swapAtRoot` case uses
     `List.Perm.foldr_eq` (`max` is left-commutative); the `recurse` case
@@ -325,12 +316,8 @@ private theorem depth_permStep {t s : RoseTree α} (h : PermStep t s) :
 
 /-- Depth is invariant under `PermEquiv`. -/
 theorem depth_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
-    t.depth = s.depth := by
-  induction h with
-  | rel _ _ hstep => exact depth_permStep hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    t.depth = s.depth :=
+  PermEquiv.lift_eq (fun _ _ h' => depth_permStep h') h
 
 /-- Leaf-ness is invariant under `PermStep`. Both `swapAtRoot` and
     `recurse` keep a non-empty children list on both sides, so both are
@@ -343,12 +330,8 @@ private theorem isLeaf_permStep {t s : RoseTree α} (h : PermStep t s) :
 
 /-- Leaf-ness is invariant under `PermEquiv`. -/
 theorem isLeaf_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
-    t.isLeaf = s.isLeaf := by
-  induction h with
-  | rel _ _ hstep => exact isLeaf_permStep hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    t.isLeaf = s.isLeaf :=
+  PermEquiv.lift_eq (fun _ _ h' => isLeaf_permStep h') h
 
 /-! ### Setoid instance -/
 
@@ -471,12 +454,8 @@ private theorem childrenMk_permStep {t s : RoseTree α} (h : RoseTree.PermStep t
     simp [RoseTree.children, mk_step h]
 
 private theorem childrenMk_permEquiv {t s : RoseTree α} (h : RoseTree.PermEquiv t s) :
-    (↑(t.children.map mk) : Multiset (Nonplanar α)) = ↑(s.children.map mk) := by
-  induction h with
-  | rel _ _ h => exact childrenMk_permStep h
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    (↑(t.children.map mk) : Multiset (Nonplanar α)) = ↑(s.children.map mk) :=
+  RoseTree.PermEquiv.lift_eq (fun _ _ h' => childrenMk_permStep h') h
 
 /-- The children of a nonplanar tree, as a multiset of nonplanar trees. -/
 def children : Nonplanar α → Multiset (Nonplanar α) :=

--- a/Linglib/Syntax/Minimalist/Defs.lean
+++ b/Linglib/Syntax/Minimalist/Defs.lean
@@ -171,6 +171,11 @@ def uposToCat : UD.UPOS → Cat
 def LIToken.phonForm (tok : LIToken) : String :=
   tok.item.features.head?.map (·.phonForm) |>.getD ""
 
+/-- The phonological form of a pronounced token; `none` when the form is empty. -/
+def LIToken.phonForm? (tok : LIToken) : Option String :=
+  let p := tok.phonForm
+  if p.isEmpty then none else some p
+
 /-- LIToken-level c-selection: `selector` selects `selected` iff
     `selector`'s outermost selectional feature equals `selected`'s outer
     category. A pure `LIToken` relation; no SO structure involved. -/

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -238,7 +238,7 @@ def surfaceCats (d : SO.Derivation) : List Cat := d.surfaceTokens.map (·.item.o
 
 /-- Surface phonological string: pronounced forms left-to-right (empty forms dropped). -/
 def surfacePhon (d : SO.Derivation) : List String :=
-  d.surfaceTokens.filterMap fun t => let p := t.phonForm; if p.isEmpty then none else some p
+  d.surfaceTokens.filterMap LIToken.phonForm?
 
 end SO.Derivation
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Externalization.lean
@@ -7,33 +7,45 @@ import Mathlib.Data.Option.NAry
 import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 
 /-!
-# Externalization on the `SO` carrier (selection-induced order)
+# Externalization on the `SO` carrier
 
-[marcolli-chomsky-berwick-2025] §1.12.1 and §1.13: externalization sends the unordered
-syntactic object through a planar embedding to a surface token string. Lemma 1.13.5
-identifies the head functions on a binary tree with its planar embeddings — read off
-harmonically head-initial or head-final (`ConventionDir`) — and Lemma 1.13.7 identifies
-abstract head functions with bare-phrase-structure projection ([chomsky-1995-bare]).
-This file composes the two with [adger-2003]'s identification of the projecting item
-as the selecting item (a synthesis step of the formalization, not a claim of the book):
-c-selection (`selSide`, `Selection.lean`) picks the projecting daughter, so the induced
-planar order — hence the linearization — is computable and `PermEquiv`-invariant.
+This file defines the selection-induced linearization of syntactic objects
+([marcolli-chomsky-berwick-2025] §1.12.1, §1.13): the surface token order obtained by
+placing the projecting daughter's yield on a language's harmonic head side. Lemma
+1.13.5 identifies head functions on a binary tree with its planar embeddings, and
+Lemma 1.13.7 identifies head functions with bare-phrase-structure projection
+([chomsky-1995-bare]); composed with [adger-2003]'s identification of the projecting
+item as the selecting item (a synthesis step of this formalization, not a claim of
+the book), c-selection (`selSide`) computes the planar order.
 
-Head functions are **partial** ([marcolli-chomsky-berwick-2025] §1.13.2–§1.13.3): at
-exocentric nodes, off `Dom(h)`, no daughter projects and no order is determined — the
-book rejects inducing one from a total order on labels as "not a realistic linguistic
-assumption". `linearizeP` is therefore `Option`-valued, `none` off `Dom(h)`, matching
-the book's elimination of nonparsable objects at externalization. Only the two
-*harmonic* sections are realized: uniform head-side placement is right for
-head–complement structure but does not model specifier placement; mixed placement
-needs the `headSide : Cat → ConventionDir` refinement noted at `ConventionDir`.
+## Main declarations
+
+* `Minimalist.linearizePlanar`: the yield of a planar `SO`-tree; `Option`-valued,
+  `none` off `Dom(h)`.
+* `Minimalist.SO.linearize`: the yield of a syntactic object, via the quotient lift
+  `linearizeN`.
+* `Minimalist.SO.phonYield`: the pronounced surface forms.
+
+## Main results
+
+* `Minimalist.linearizePlanar_permEquiv`: the yield is invariant under sibling
+  permutation, hence descends to the nonplanar quotient.
+
+## Implementation notes
+
+Head functions are partial ([marcolli-chomsky-berwick-2025] §1.13.2): at exocentric
+nodes no daughter projects and no order is determined — the book rejects inducing one
+from a total order on labels as "not a realistic linguistic assumption" — so
+linearization returns `none` there, matching the book's elimination of nonparsable
+objects at externalization. Only the two harmonic sections are realized: uniform
+head-side placement is right for head–complement structure but does not model
+specifier placement (that needs the `headSide : Cat → ConventionDir` refinement noted
+at `ConventionDir`).
 -/
 
 namespace Minimalist
 
 open RootedTree
-
-/-! ### Yield combinator -/
 
 /-- Place the head daughter's yield on the convention side: `.initial` (head-initial)
     → head-yield first, `.final` (head-final) → head-yield last. -/
@@ -43,104 +55,77 @@ def placeYield : ConventionDir → List LIToken → List LIToken → List LIToke
 
 /-! ### Linearization on the planar carrier -/
 
-/-- Selection-induced externalization yield on a planar `SO`-tree: a lexical leaf is
-    pronounced (`some [tok]`), a bare trace leaf is unpronounced (`some []`, the
-    cancelled copy of [marcolli-chomsky-berwick-2025]'s `T/d` form), and a bare binary
-    node places the projecting (selector) daughter's yield on the `side`-convention
-    side. Partial: `none` at exocentric nodes (off `Dom(h)` no order is determined,
-    §1.13.2) and at bare nodes of non-`SO` arity. -/
-def linearizeP (side : ConventionDir) : RoseTree SOLabel → Option (List LIToken)
+/-- Selection-induced yield of a planar `SO`-tree: a lexical leaf is pronounced, a
+    bare trace leaf is silent (the cancelled `T/d` copy of
+    [marcolli-chomsky-berwick-2025] §1.12), and a bare binary node places the
+    projecting daughter's yield on the `side`-convention side. `none` at exocentric
+    nodes (off `Dom(h)`, §1.13.2) and at bare nodes of non-`SO` arity. -/
+def linearizePlanar (side : ConventionDir) : RoseTree SOLabel → Option (List LIToken)
   | .node (.inl tok) _     => some [tok]
   | .node (.inr ()) []     => some []
   | .node (.inr ()) [l, r] =>
       match selSide (selCheckPlanar l) (selCheckPlanar r) with
-      | some true  => Option.map₂ (placeYield side) (linearizeP side l) (linearizeP side r)
-      | some false => Option.map₂ (placeYield side) (linearizeP side r) (linearizeP side l)
+      | some true  =>
+          Option.map₂ (placeYield side) (linearizePlanar side l) (linearizePlanar side r)
+      | some false =>
+          Option.map₂ (placeYield side) (linearizePlanar side r) (linearizePlanar side l)
       | none       => none
   | .node (.inr ()) _      => none
 
-/-- A bare node of arity 1 or ≥ 3 is not an `SO` shape and has no yield. The yield
-    analogue of `selCheckPlanar_node_none`. -/
-private theorem linearizeP_node_default (side : ConventionDir) {cs : List (RoseTree SOLabel)}
-    (h0 : cs.length ≠ 0) (h2 : cs.length ≠ 2) :
-    linearizeP side (RoseTree.node (Sum.inr ()) cs) = none := by
+/-- A bare node with more than two children is not an `SO` shape and has no yield. -/
+private theorem linearizePlanar_node_big (side : ConventionDir)
+    {cs : List (RoseTree SOLabel)} (h : 2 < cs.length) :
+    linearizePlanar side (RoseTree.node (Sum.inr ()) cs) = none := by
   match cs with
-  | [] => exact absurd rfl h0
-  | [_] => rfl
-  | [_, _] => exact absurd rfl h2
   | _ :: _ :: _ :: _ => rfl
+  | [] | [_] | [_, _] => simp at h
 
-private theorem linearizeP_permStep (side : ConventionDir) {t s : RoseTree SOLabel}
-    (hstep : RoseTree.PermStep t s) : linearizeP side t = linearizeP side s := by
+private theorem linearizePlanar_permStep (side : ConventionDir) {t s : RoseTree SOLabel}
+    (hstep : RoseTree.PermStep t s) :
+    linearizePlanar side t = linearizePlanar side s := by
   induction hstep with
   | @swapAtRoot a l r pre post =>
     cases a with
-    | inl _ => simp only [linearizeP]
+    | inl _ => simp only [linearizePlanar]
     | inr u =>
       cases u
-      cases pre with
-      | nil => cases post with
-        | nil =>
-          simp only [List.nil_append, linearizeP,
-            selSide_comm (selCheckPlanar r) (selCheckPlanar l)]
-          cases selSide (selCheckPlanar l) (selCheckPlanar r) with
-          | none => rfl
-          | some b => cases b <;> rfl
-        | cons c cs =>
-          have h2 : ([] ++ l :: r :: c :: cs).length ≠ 2 := by
-            simp only [List.nil_append, List.length_cons]; omega
-          have h2' : ([] ++ r :: l :: c :: cs).length ≠ 2 := by
-            simp only [List.nil_append, List.length_cons]; omega
-          rw [linearizeP_node_default side (by simp) h2,
-              linearizeP_node_default side (by simp) h2']
-      | cons q qs =>
-        have h2 : ((q :: qs) ++ l :: r :: post).length ≠ 2 := by
-          simp only [List.length_append, List.length_cons]; omega
-        have h2' : ((q :: qs) ++ r :: l :: post).length ≠ 2 := by
-          simp only [List.length_append, List.length_cons]; omega
-        rw [linearizeP_node_default side (by simp) h2,
-            linearizeP_node_default side (by simp) h2']
+      match pre, post with
+      | [], [] =>
+        simp only [List.nil_append, linearizePlanar,
+          selSide_comm (selCheckPlanar r) (selCheckPlanar l)]
+        cases selSide (selCheckPlanar l) (selCheckPlanar r) with
+        | none => rfl
+        | some b => cases b <;> rfl
+      | [], _ :: _ | _ :: _, _ =>
+        rw [linearizePlanar_node_big side (by simp +arith),
+            linearizePlanar_node_big side (by simp +arith)]
   | @recurse a pre old new post _hstep ih =>
     cases a with
-    | inl _ => simp only [linearizeP]
+    | inl _ => simp only [linearizePlanar]
     | inr u =>
       cases u
       have hsc : selCheckPlanar old = selCheckPlanar new :=
         selCheckPlanar_permEquiv (RoseTree.PermEquiv.of_step _hstep)
-      cases pre with
-      | nil => cases post with
-        | nil => simp only [List.nil_append, linearizeP]
-        | cons c cs => cases cs with
-          | nil => simp only [List.nil_append, linearizeP, hsc, ih]
-          | cons d ds => simp only [List.nil_append, linearizeP]
-      | cons q qs => cases qs with
-        | nil => cases post with
-          | nil => simp only [List.cons_append, List.nil_append, linearizeP, hsc, ih]
-          | cons d ds => simp only [List.cons_append, List.nil_append, linearizeP]
-        | cons q2 qs2 =>
-          have h2 : ((q :: q2 :: qs2) ++ old :: post).length ≠ 2 := by
-            simp only [List.length_append, List.length_cons]; omega
-          have h2' : ((q :: q2 :: qs2) ++ new :: post).length ≠ 2 := by
-            simp only [List.length_append, List.length_cons]; omega
-          rw [linearizeP_node_default side (by simp) h2,
-              linearizeP_node_default side (by simp) h2']
+      match pre, post with
+      | [], [] => simp only [List.nil_append, linearizePlanar]
+      | [], [_] => simp only [List.nil_append, linearizePlanar, hsc, ih]
+      | [_], [] => simp only [List.cons_append, List.nil_append, linearizePlanar, hsc, ih]
+      | [], _ :: _ :: _ | [_], _ :: _ | _ :: _ :: _, _ =>
+        rw [linearizePlanar_node_big side (by simp +arith),
+            linearizePlanar_node_big side (by simp +arith)]
 
-/-- `linearizeP side` is `PermEquiv`-invariant, so it descends to the quotient: the
-    surface order is projection-determined, not representative-position-determined. -/
-theorem linearizeP_permEquiv (side : ConventionDir) {t s : RoseTree SOLabel}
-    (h : RoseTree.PermEquiv t s) : linearizeP side t = linearizeP side s := by
-  induction h with
-  | rel _ _ hstep => exact linearizeP_permStep side hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+/-- `linearizePlanar side` is `PermEquiv`-invariant, so it descends to the quotient:
+    the surface order is projection-determined, not representative-determined. -/
+theorem linearizePlanar_permEquiv (side : ConventionDir) {t s : RoseTree SOLabel}
+    (h : RoseTree.PermEquiv t s) : linearizePlanar side t = linearizePlanar side s :=
+  RoseTree.PermEquiv.lift_eq (fun _ _ h' => linearizePlanar_permStep side h') h
 
 /-- Linearization lifted to the nonplanar carrier. -/
 def linearizeN (side : ConventionDir) : Nonplanar SOLabel → Option (List LIToken) :=
-  Nonplanar.lift (linearizeP side) (fun _ _ h => linearizeP_permEquiv side h)
+  Nonplanar.lift (linearizePlanar side) (fun _ _ h => linearizePlanar_permEquiv side h)
 
 @[simp] theorem linearizeN_mk (side : ConventionDir) (p : RoseTree SOLabel) :
-    linearizeN side (Nonplanar.mk p) = linearizeP side p := rfl
+    linearizeN side (Nonplanar.mk p) = linearizePlanar side p := rfl
 
 theorem linearizeN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
     linearizeN side (Nonplanar.node (Sum.inr ()) {a, b}) =
@@ -162,23 +147,21 @@ theorem linearizeN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
              Option.map₂ (placeYield side)
                (linearizeN side (Nonplanar.mk pb)) (linearizeN side (Nonplanar.mk pa))
          | none       => none)
-  rw [key]; simp only [linearizeN_mk, linearizeP, selCheckN_mk]
+  rw [key]; simp only [linearizeN_mk, linearizePlanar, selCheckN_mk]
 
 /-! ### Externalization on `SO` -/
 
-/-- **Externalization** ([marcolli-chomsky-berwick-2025] §1.12.1): the surface token
-    order of a syntactic object under the head-side convention `side` — the
-    selection-induced harmonic candidate for the externalization section σ_L, defined
-    on `Dom(h)` only; the book's σ_L must extend it *noncanonically* off `Dom(h)`,
-    so exocentric structure yields `none` here. -/
+/-- The surface token order of a syntactic object under the head-side convention
+    `side` ([marcolli-chomsky-berwick-2025] §1.12.1): the selection-induced harmonic
+    candidate for the externalization section σ_L, defined on `Dom(h)` only — the
+    book's σ_L must extend it *noncanonically* off `Dom(h)`. -/
 def SO.linearize (side : ConventionDir) (s : SO) : Option (List LIToken) :=
   linearizeN side s.val
 
-/-- **Phonological yield**: the surface order, keeping only pronounced (non-empty
-    `phonForm`) tokens. Traces, being the bare `Sum.inr ()` leaf, contribute nothing. -/
+/-- The pronounced surface forms: the yield with unpronounced (empty-`phonForm`)
+    tokens dropped. Traces, being the bare `Sum.inr ()` leaf, contribute nothing. -/
 def SO.phonYield (side : ConventionDir) (s : SO) : Option (List String) :=
-  (SO.linearize side s).map
-    (·.filterMap fun tok => let p := tok.phonForm; if p.isEmpty then none else some p)
+  (SO.linearize side s).map (·.filterMap LIToken.phonForm?)
 
 @[simp] theorem SO.linearize_lexLeaf (side : ConventionDir) (tok : LIToken) :
     (SO.lexLeaf tok).linearize side = some [tok] := rfl
@@ -198,11 +181,11 @@ theorem SO.linearize_node (side : ConventionDir) (l r : SO) :
 
 /-! ### `decide` demonstration
 
-The selection-induced order reduces on concrete `mk`-built trees, the head-side
-parameter genuinely flips the surface order, and exocentric Merge is correctly
-order-undefined. A determiner `the` (category `D`, selecting `N`) over a noun `dog`:
-`D` projects, so head-initial yields `the dog` and head-final yields `dog the`. -/
+The order reduces on concrete `mk`-built trees, the head-side parameter flips it, and
+exocentric Merge is order-undefined. -/
 
+/-- A determiner (category `D`, selecting `N`) over a noun: `D` projects, so
+    head-initial yields `the dog` and head-final yields `dog the`. -/
 private def demoTheDog : SO :=
   ⟨Nonplanar.mk (.node (Sum.inr ())
     [.node (Sum.inl ⟨.simple .D [.N] (phonForm := "the"), 0⟩) [],


### PR DESCRIPTION
Mathlib polish of `Externalization.lean`: module docstring restructured to the convention (Main declarations / Main results / Implementation notes); `linearizeP` → `linearizePlanar` per the directory's planar-recursion naming; permutation-step proof consolidated (`node_big` + flat two-scrutinee matches). Adds `RoseTree.PermEquiv.lift_eq` (step-invariance → closure-invariance, via `congrArg` + `Quot.eqvGen_sound`) and collapses the seven in-file EqvGen inductions to one-liners; dedups the phonForm filter into `LIToken.phonForm?` (shared by `SO.phonYield` and `surfacePhon`).