### PR TITLE
refactor(Syntax/Minimalist): linearize via permutation-invariant fold

### DIFF
--- a/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Nonplanar.lean
@@ -117,51 +117,43 @@ Functions `RoseTree α → β` that are invariant under `PermStep` lift
 through the equivalence closure to functions `Nonplanar α → β`. Below
 we lift `numNodes` (vertex count) and the other counts as worked examples.
 
-The pattern: prove invariance under the elementary `PermStep`, then
-extend to `PermEquiv` with `PermEquiv.lift_eq`. On `RoseTree` the
-counts sum/`foldr`-max directly over `cs.map …`, so permutation
-invariance is just `List.Perm.sum_eq` / `List.Perm.foldr_eq` on the
-child list. -/
+Two keystones: `PermEquiv.lift_eq` extends any `Eq`-valued step-invariant
+to the closure, and `fold_permEquiv` discharges the step case generically
+for any `fold` whose algebra is permutation-invariant. The counts
+(`numNodes`, `numLeaves`, `depth`) are such folds — their invariance is
+just `List.Perm.sum_eq` / `List.Perm.foldr_eq` on the algebra. -/
 
-/-! #### Node count invariance -/
-
-/-- `numNodes` is invariant under `PermStep`: a root swap permutes the
-    children list (`List.Perm.sum_eq`); a recursive step rewrites one
-    child by an equal-count subtree. -/
-private theorem numNodes_permStep {t s : RoseTree α} (h : PermStep t s) :
-    t.numNodes = s.numNodes := by
+/-- A `fold` whose algebra is invariant under permutations of the folded-children
+    list is invariant under `PermStep`. -/
+private theorem fold_permStep {β : Type*} {g : α → List β → β}
+    (hg : ∀ (a : α) (l₁ l₂ : List β), l₁.Perm l₂ → g a l₁ = g a l₂)
+    {t s : RoseTree α} (h : PermStep t s) : fold g t = fold g s := by
   induction h with
   | @swapAtRoot a l r pre post =>
-    simp only [numNodes_node]
-    congr 1
-    exact (((List.Perm.swap r l post).append_left pre).map numNodes).sum_eq
+    simp only [fold_node]
+    exact hg a _ _ (((List.Perm.swap r l post).append_left pre).map (fold g))
   | @recurse a pre old new post _ ih =>
-    simp only [numNodes_node, List.map_append, List.map_cons, List.sum_append,
-      List.sum_cons, ih]
+    simp only [fold_node, List.map_append, List.map_cons, ih]
 
-/-- `numNodes` is invariant under `PermEquiv`. -/
+/-- A `fold` with a permutation-invariant algebra descends to the nonplanar
+    quotient: the generic dissolver of per-function `PermStep` inductions. -/
+theorem fold_permEquiv {β : Type*} {g : α → List β → β}
+    (hg : ∀ (a : α) (l₁ l₂ : List β), l₁.Perm l₂ → g a l₁ = g a l₂)
+    {t s : RoseTree α} (h : PermEquiv t s) : fold g t = fold g s :=
+  PermEquiv.lift_eq (fun _ _ h' => fold_permStep hg h') h
+
+/-! #### Count invariance -/
+
+/-- `numNodes` is invariant under `PermEquiv`: the fold of a permutation-invariant
+    algebra (`List.Perm.sum_eq`). -/
 theorem numNodes_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
     t.numNodes = s.numNodes :=
-  PermEquiv.lift_eq (fun _ _ h' => numNodes_permStep h') h
-
-/-! #### Leaf-count invariance -/
-
-/-- `numLeaves` is invariant under `PermStep`. -/
-private theorem numLeaves_permStep {t s : RoseTree α} (h : PermStep t s) :
-    t.numLeaves = s.numLeaves := by
-  induction h with
-  | @swapAtRoot a l r pre post =>
-    simp only [numLeaves_node]
-    congr 1
-    exact (((List.Perm.swap r l post).append_left pre).map numLeaves).sum_eq
-  | @recurse a pre old new post _ ih =>
-    simp only [numLeaves_node, List.map_append, List.map_cons, List.sum_append,
-      List.sum_cons, ih]
+  fold_permEquiv (fun _ _ _ h' => congrArg (1 + ·) h'.sum_eq) h
 
 /-- `numLeaves` is invariant under `PermEquiv`. -/
 theorem numLeaves_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
     t.numLeaves = s.numLeaves :=
-  PermEquiv.lift_eq (fun _ _ h' => numLeaves_permStep h') h
+  fold_permEquiv (fun _ _ _ h' => congrArg (max 1) h'.sum_eq) h
 
 /-! #### Value invariance -/
 
@@ -285,10 +277,9 @@ theorem permEquiv_node_componentwise {a : α} {cs ds : List (RoseTree α)}
 
 /-! #### Arity / depth / isLeaf invariance
 
-Three more invariants of tree structure that are preserved by
-`PermEquiv`. The pattern follows `numNodes`: prove `*_permStep`
-by case on the step constructor, then lift to `*_permEquiv` via
-`PermEquiv.lift_eq`. -/
+Arity and leaf-ness are root-shape invariants: prove `*_permStep` by
+case on the step constructor, then lift via `PermEquiv.lift_eq`. Depth
+is another permutation-invariant fold. -/
 
 /-- Arity (root child count) is invariant under `PermStep`: both
     `swapAtRoot` and `recurse` keep the children list's length fixed. -/
@@ -301,23 +292,11 @@ theorem arity_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
     t.arity = s.arity :=
   PermEquiv.lift_eq (fun _ _ h' => arity_permStep h') h
 
-/-- Depth is invariant under `PermStep`. The `swapAtRoot` case uses
-    `List.Perm.foldr_eq` (`max` is left-commutative); the `recurse` case
-    rewrites one child by an equal-depth subtree. -/
-private theorem depth_permStep {t s : RoseTree α} (h : PermStep t s) :
-    t.depth = s.depth := by
-  induction h with
-  | @swapAtRoot a l r pre post =>
-    simp only [depth_node]
-    congr 1
-    exact (((List.Perm.swap r l post).append_left pre).map depth).foldr_eq 0
-  | @recurse a pre old new post _ ih =>
-    simp only [depth_node, List.map_append, List.map_cons, ih]
-
-/-- Depth is invariant under `PermEquiv`. -/
+/-- Depth is invariant under `PermEquiv`: the fold of a permutation-invariant
+    algebra (`List.Perm.foldr_eq`, `max` being commutative). -/
 theorem depth_permEquiv {t s : RoseTree α} (h : PermEquiv t s) :
     t.depth = s.depth :=
-  PermEquiv.lift_eq (fun _ _ h' => depth_permStep h') h
+  fold_permEquiv (fun _ _ _ h' => congrArg (1 + ·) (h'.foldr_eq 0)) h
 
 /-- Leaf-ness is invariant under `PermStep`. Both `swapAtRoot` and
     `recurse` keep a non-empty children list on both sides, so both are

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Externalization.lean
@@ -16,10 +16,12 @@ placing the projecting daughter's yield on a language's harmonic head side. Lemm
 Lemma 1.13.7 identifies head functions with bare-phrase-structure projection
 ([chomsky-1995-bare]); composed with [adger-2003]'s identification of the projecting
 item as the selecting item (a synthesis step of this formalization, not a claim of
-the book), c-selection (`selSide`) computes the planar order.
+the book), c-selection computes the planar order.
 
 ## Main declarations
 
+* `Minimalist.linCombine`: the externalization algebra — selection state and yield
+  computed together, the book's two descriptions of a head function.
 * `Minimalist.linearizePlanar`: the yield of a planar `SO`-tree; `Option`-valued,
   `none` off `Dom(h)`.
 * `Minimalist.SO.linearize`: the yield of a syntactic object, via the quotient lift
@@ -28,8 +30,11 @@ the book), c-selection (`selSide`) computes the planar order.
 
 ## Main results
 
-* `Minimalist.linearizePlanar_permEquiv`: the yield is invariant under sibling
-  permutation, hence descends to the nonplanar quotient.
+* `Minimalist.selLinPlanar_fst`: the paired fold's selection component is
+  `selCheckPlanar`.
+* `Minimalist.linearizePlanar_permEquiv`: the yield descends to the nonplanar
+  quotient — by `RoseTree.fold_permEquiv`, since the algebra is
+  permutation-invariant (`linCombine_perm`).
 
 ## Implementation notes
 
@@ -41,6 +46,12 @@ objects at externalization. Only the two harmonic sections are realized: uniform
 head-side placement is right for head–complement structure but does not model
 specifier placement (that needs the `headSide : Cat → ConventionDir` refinement noted
 at `ConventionDir`).
+
+Linearization is the second component of one catamorphism `RoseTree.fold`, mirroring
+the book's switching "between these two descriptions without changing the notation":
+the head function as a head leaf (selection state) and as the ordered leaf sequence
+(yield). All `PermEquiv`-invariance is inherited from the algebra's
+permutation-invariance; there is no bespoke step induction.
 -/
 
 namespace Minimalist
@@ -53,72 +64,130 @@ def placeYield : ConventionDir → List LIToken → List LIToken → List LIToke
   | .initial, headY, otherY => headY ++ otherY
   | .final,   headY, otherY => otherY ++ headY
 
-/-! ### Linearization on the planar carrier -/
+/-! ### The externalization algebra -/
 
-/-- Selection-induced yield of a planar `SO`-tree: a lexical leaf is pronounced, a
-    bare trace leaf is silent (the cancelled `T/d` copy of
-    [marcolli-chomsky-berwick-2025] §1.12), and a bare binary node places the
-    projecting daughter's yield on the `side`-convention side. `none` at exocentric
-    nodes (off `Dom(h)`, §1.13.2) and at bare nodes of non-`SO` arity. -/
-def linearizePlanar (side : ConventionDir) : RoseTree SOLabel → Option (List LIToken)
-  | .node (.inl tok) _     => some [tok]
-  | .node (.inr ()) []     => some []
-  | .node (.inr ()) [l, r] =>
-      match selSide (selCheckPlanar l) (selCheckPlanar r) with
-      | some true  =>
-          Option.map₂ (placeYield side) (linearizePlanar side l) (linearizePlanar side r)
-      | some false =>
-          Option.map₂ (placeYield side) (linearizePlanar side r) (linearizePlanar side l)
-      | none       => none
-  | .node (.inr ()) _      => none
+/-- The externalization algebra: a node's selection state (`selCombine` over the
+    daughters' states) paired with its yield. A lexical leaf is pronounced, a bare
+    trace leaf is silent (the cancelled `T/d` copy of [marcolli-chomsky-berwick-2025]
+    §1.12), and a bare binary node places the projecting daughter's yield on the
+    `side`-convention side; the yield is `none` at exocentric nodes (off `Dom(h)`,
+    §1.13.2) and at bare nodes of non-`SO` arity. -/
+def linCombine (side : ConventionDir) (a : SOLabel)
+    (ps : List (Option (LIToken × List Cat) × Option (List LIToken))) :
+    Option (LIToken × List Cat) × Option (List LIToken) :=
+  (selCombine a (ps.map Prod.fst),
+   match a, ps with
+   | .inl tok, _ => some [tok]
+   | .inr (), [] => some []
+   | .inr (), [(cl, yl), (cr, yr)] =>
+       match selSide cl cr with
+       | some true  => Option.map₂ (placeYield side) yl yr
+       | some false => Option.map₂ (placeYield side) yr yl
+       | none       => none
+   | .inr (), _ => none)
 
-/-- A bare node with more than two children is not an `SO` shape and has no yield. -/
-private theorem linearizePlanar_node_big (side : ConventionDir)
-    {cs : List (RoseTree SOLabel)} (h : 2 < cs.length) :
-    linearizePlanar side (RoseTree.node (Sum.inr ()) cs) = none := by
-  match cs with
+/-- A daughter list of three or more has no yield. -/
+private theorem linCombine_snd_big (side : ConventionDir)
+    {ps : List (Option (LIToken × List Cat) × Option (List LIToken))}
+    (h : 2 < ps.length) : (linCombine side (Sum.inr ()) ps).2 = none := by
+  match ps with
   | _ :: _ :: _ :: _ => rfl
   | [] | [_] | [_, _] => simp at h
 
-private theorem linearizePlanar_permStep (side : ConventionDir) {t s : RoseTree SOLabel}
-    (hstep : RoseTree.PermStep t s) :
-    linearizePlanar side t = linearizePlanar side s := by
-  induction hstep with
-  | @swapAtRoot a l r pre post =>
-    cases a with
-    | inl _ => simp only [linearizePlanar]
-    | inr u =>
-      cases u
-      match pre, post with
-      | [], [] =>
-        simp only [List.nil_append, linearizePlanar,
-          selSide_comm (selCheckPlanar r) (selCheckPlanar l)]
-        cases selSide (selCheckPlanar l) (selCheckPlanar r) with
+/-- `linCombine` is invariant under permutation of the daughter values: the selection
+    component by `selCombine_perm`, the yield because only the binary shape is
+    order-sensitive, where `selSide_comm` swaps the placement decision with the
+    arguments. -/
+theorem linCombine_perm (side : ConventionDir) (a : SOLabel)
+    {l₁ l₂ : List (Option (LIToken × List Cat) × Option (List LIToken))}
+    (h : l₁.Perm l₂) : linCombine side a l₁ = linCombine side a l₂ := by
+  refine Prod.ext (selCombine_perm a (h.map Prod.fst)) ?_
+  cases a with
+  | inl tok => rfl
+  | inr u =>
+    cases u
+    induction h with
+    | nil => rfl
+    | @cons x l₁ l₂ h _ih =>
+      match l₁, l₂, h with
+      | [], l₂, h => rw [show l₂ = [] from h.symm.eq_nil]
+      | [y], l₂, h => rw [show l₂ = [y] from List.perm_singleton.mp h.symm]
+      | _ :: _ :: _, l₂, h =>
+        rw [linCombine_snd_big side (by simp +arith),
+            linCombine_snd_big side (by
+              have hl := h.length_eq
+              simp only [List.length_cons] at hl ⊢
+              omega)]
+    | swap x y l =>
+      cases l with
+      | nil =>
+        obtain ⟨cx, yx⟩ := x
+        obtain ⟨cy, yy⟩ := y
+        show (match selSide cy cx with
+              | some true  => Option.map₂ (placeYield side) yy yx
+              | some false => Option.map₂ (placeYield side) yx yy
+              | none       => none)
+           = (match selSide cx cy with
+              | some true  => Option.map₂ (placeYield side) yx yy
+              | some false => Option.map₂ (placeYield side) yy yx
+              | none       => none)
+        rw [selSide_comm cy cx]
+        cases selSide cx cy with
         | none => rfl
         | some b => cases b <;> rfl
-      | [], _ :: _ | _ :: _, _ =>
-        rw [linearizePlanar_node_big side (by simp +arith),
-            linearizePlanar_node_big side (by simp +arith)]
-  | @recurse a pre old new post _hstep ih =>
-    cases a with
-    | inl _ => simp only [linearizePlanar]
-    | inr u =>
-      cases u
-      have hsc : selCheckPlanar old = selCheckPlanar new :=
-        selCheckPlanar_permEquiv (RoseTree.PermEquiv.of_step _hstep)
-      match pre, post with
-      | [], [] => simp only [List.nil_append, linearizePlanar]
-      | [], [_] => simp only [List.nil_append, linearizePlanar, hsc, ih]
-      | [_], [] => simp only [List.cons_append, List.nil_append, linearizePlanar, hsc, ih]
-      | [], _ :: _ :: _ | [_], _ :: _ | _ :: _ :: _, _ =>
-        rw [linearizePlanar_node_big side (by simp +arith),
-            linearizePlanar_node_big side (by simp +arith)]
+      | cons z l => rfl
+    | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
 
-/-- `linearizePlanar side` is `PermEquiv`-invariant, so it descends to the quotient:
-    the surface order is projection-determined, not representative-determined. -/
+/-! ### Linearization on the planar carrier -/
+
+/-- Selection state and yield of a planar `SO`-tree, computed together:
+    [marcolli-chomsky-berwick-2025]'s dual description of a head function as a head
+    leaf and as an ordered leaf sequence. -/
+def selLinPlanar (side : ConventionDir) :
+    RoseTree SOLabel → Option (LIToken × List Cat) × Option (List LIToken) :=
+  RoseTree.fold (linCombine side)
+
+/-- Selection-induced yield of a planar `SO`-tree: the yield component of
+    `selLinPlanar`. -/
+def linearizePlanar (side : ConventionDir) (t : RoseTree SOLabel) :
+    Option (List LIToken) :=
+  (selLinPlanar side t).2
+
+/-- Fusion: the selection component of the paired fold is `selCheckPlanar`. -/
+theorem selLinPlanar_fst (side : ConventionDir) (t : RoseTree SOLabel) :
+    (selLinPlanar side t).1 = selCheckPlanar t := by
+  induction t with
+  | node a cs ih =>
+    show (RoseTree.fold (linCombine side) (.node a cs)).1 = selCheckPlanar (.node a cs)
+    rw [RoseTree.fold_node, selCheckPlanar_node]
+    show selCombine a ((cs.map (RoseTree.fold (linCombine side))).map Prod.fst)
+       = selCombine a (cs.map selCheckPlanar)
+    rw [List.map_map]
+    exact congrArg (selCombine a) (List.map_congr_left fun c hc => ih c hc)
+
+/-- Reduction of the yield at a bare binary node, through the fusion theorem. -/
+theorem linearizePlanar_node_pair (side : ConventionDir) (l r : RoseTree SOLabel) :
+    linearizePlanar side (.node (.inr ()) [l, r]) =
+      (match selSide (selCheckPlanar l) (selCheckPlanar r) with
+       | some true  =>
+           Option.map₂ (placeYield side) (linearizePlanar side l) (linearizePlanar side r)
+       | some false =>
+           Option.map₂ (placeYield side) (linearizePlanar side r) (linearizePlanar side l)
+       | none       => none) := by
+  show (match selSide (selLinPlanar side l).1 (selLinPlanar side r).1 with
+        | some true  =>
+            Option.map₂ (placeYield side) (selLinPlanar side l).2 (selLinPlanar side r).2
+        | some false =>
+            Option.map₂ (placeYield side) (selLinPlanar side r).2 (selLinPlanar side l).2
+        | none       => none) = _
+  rw [selLinPlanar_fst side l, selLinPlanar_fst side r]; exact rfl
+
+/-- `linearizePlanar side` descends to the quotient: the surface order is
+    projection-determined, not representative-determined. -/
 theorem linearizePlanar_permEquiv (side : ConventionDir) {t s : RoseTree SOLabel}
     (h : RoseTree.PermEquiv t s) : linearizePlanar side t = linearizePlanar side s :=
-  RoseTree.PermEquiv.lift_eq (fun _ _ h' => linearizePlanar_permStep side h') h
+  congrArg Prod.snd
+    (RoseTree.fold_permEquiv (fun a _ _ h' => linCombine_perm side a h') h)
 
 /-- Linearization lifted to the nonplanar carrier. -/
 def linearizeN (side : ConventionDir) : Nonplanar SOLabel → Option (List LIToken) :=
@@ -147,7 +216,8 @@ theorem linearizeN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
              Option.map₂ (placeYield side)
                (linearizeN side (Nonplanar.mk pb)) (linearizeN side (Nonplanar.mk pa))
          | none       => none)
-  rw [key]; simp only [linearizeN_mk, linearizePlanar, selCheckN_mk]
+  rw [key]
+  simp only [linearizeN_mk, selCheckN_mk, linearizePlanar_node_pair]
 
 /-! ### Externalization on `SO` -/
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -19,10 +19,12 @@ the foundation the Phase API consumes (`isPhaseHeadOf`).
 
 The carrier-free selection combinators `selStep`/`selSide` (commutative —
 `selStep_comm`/`selSide_comm`) operate purely on selection states
-(`Option (LIToken × List Cat)`); the tree recursion lives on `RoseTree SOLabel` and
-lifts to `SO`, exactly as `subtreesN`. **Index-free traces**: a bare trace leaf gets
-the canonical saturated value `(mkTraceToken 0, [])` — `selCheck` reads only the
-token's category (`.N`) and `outerSel` (`[]`), both index-independent.
+(`Option (LIToken × List Cat)`). The tree recursion is the catamorphism
+`RoseTree.fold selCombine`; since the algebra is permutation-invariant
+(`selCombine_perm`), invariance and the `SO` lift come from `fold_permEquiv` — no
+bespoke step induction. **Index-free traces**: a bare trace leaf gets the canonical
+saturated value `(mkTraceToken 0, [])` — `selCheck` reads only the token's category
+(`.N`) and `outerSel` (`[]`), both index-independent.
 -/
 
 namespace Minimalist
@@ -123,74 +125,65 @@ theorem selStep_eq_some {x y : Option (LIToken × List Cat)} {hd : LIToken}
 
 /-! ### Selection check on the planar carrier -/
 
-/-- Selection check on a planar `SO`-tree: the projecting head + residual pending
-    features, or `none` outside the endocentric domain. Lexical leaf ↦ its token +
-    `outerSel`; bare trace leaf ↦ canonical `(mkTraceToken 0, [])` (index-free);
-    bare binary node ↦ `selStep` of the daughters. -/
-def selCheckPlanar : RoseTree SOLabel → Option (LIToken × List Cat)
-  | .node (.inl tok) _     => some (tok, tok.item.outerSel)
-  | .node (.inr ()) []     => some (mkTraceToken 0, [])
-  | .node (.inr ()) [l, r] => selStep (selCheckPlanar l) (selCheckPlanar r)
-  | .node (.inr ()) _      => none
+/-- The selection algebra: combine a node label with its daughters' selection
+    states. Lexical leaf ↦ its token + `outerSel`; bare trace leaf ↦ canonical
+    `(mkTraceToken 0, [])` (index-free); bare binary node ↦ `selStep` of the
+    daughters; other arities ↦ `none`. -/
+def selCombine : SOLabel → List (Option (LIToken × List Cat)) →
+    Option (LIToken × List Cat)
+  | .inl tok, _     => some (tok, tok.item.outerSel)
+  | .inr (), []     => some (mkTraceToken 0, [])
+  | .inr (), [x, y] => selStep x y
+  | .inr (), _      => none
 
-/-- A non-binary, non-leaf bare node has no selection value. -/
-private theorem selCheckPlanar_node_none {cs : List (RoseTree SOLabel)}
-    (h0 : cs.length ≠ 0) (h2 : cs.length ≠ 2) :
-    selCheckPlanar (RoseTree.node (Sum.inr ()) cs) = none := by
-  match cs with
-  | [] => exact absurd rfl h0
-  | [_] => rfl
-  | [_, _] => exact absurd rfl h2
+/-- A daughter list of three or more has no selection value. -/
+private theorem selCombine_big {l : List (Option (LIToken × List Cat))}
+    (h : 2 < l.length) : selCombine (Sum.inr ()) l = none := by
+  match l with
   | _ :: _ :: _ :: _ => rfl
+  | [] | [_] | [_, _] => simp at h
 
-private theorem selCheckPlanar_permStep {t s : RoseTree SOLabel}
-    (hstep : RoseTree.PermStep t s) : selCheckPlanar t = selCheckPlanar s := by
-  induction hstep with
-  | @swapAtRoot a l r pre post =>
-    cases a with
-    | inl _ => simp only [selCheckPlanar]
-    | inr u =>
-      cases u
-      cases pre with
-      | nil => cases post with
-        | nil => exact selStep_comm _ _
-        | cons c cs => simp only [List.nil_append, selCheckPlanar]
-      | cons q qs =>
-        have h2 : ((q :: qs) ++ l :: r :: post).length ≠ 2 := by
-          simp only [List.length_append, List.length_cons]; omega
-        have h2' : ((q :: qs) ++ r :: l :: post).length ≠ 2 := by
-          simp only [List.length_append, List.length_cons]; omega
-        rw [selCheckPlanar_node_none (by simp) h2, selCheckPlanar_node_none (by simp) h2']
-  | @recurse a pre old new post _hstep ih =>
-    cases a with
-    | inl _ => simp only [selCheckPlanar]
-    | inr u =>
-      cases u
-      cases pre with
-      | nil => cases post with
-        | nil => simp only [List.nil_append, selCheckPlanar]
-        | cons c cs => cases cs with
-          | nil => simp only [List.nil_append, selCheckPlanar, ih]
-          | cons d ds => simp only [List.nil_append, selCheckPlanar]
-      | cons q qs => cases qs with
-        | nil => cases post with
-          | nil => simp only [List.cons_append, List.nil_append, selCheckPlanar, ih]
-          | cons d ds => simp only [List.cons_append, List.nil_append, selCheckPlanar]
-        | cons q2 qs2 =>
-          have h2 : ((q :: q2 :: qs2) ++ old :: post).length ≠ 2 := by
-            simp only [List.length_append, List.length_cons]; omega
-          have h2' : ((q :: q2 :: qs2) ++ new :: post).length ≠ 2 := by
-            simp only [List.length_append, List.length_cons]; omega
-          rw [selCheckPlanar_node_none (by simp) h2, selCheckPlanar_node_none (by simp) h2']
+/-- `selCombine` is invariant under permutation of the daughter states: only the
+    binary shape is order-sensitive, and there `selStep_comm` applies. -/
+theorem selCombine_perm (a : SOLabel) {l₁ l₂ : List (Option (LIToken × List Cat))}
+    (h : l₁.Perm l₂) : selCombine a l₁ = selCombine a l₂ := by
+  cases a with
+  | inl tok => rfl
+  | inr u =>
+    cases u
+    induction h with
+    | nil => rfl
+    | @cons x l₁ l₂ h _ih =>
+      match l₁, l₂, h with
+      | [], l₂, h => rw [show l₂ = [] from h.symm.eq_nil]
+      | [y], l₂, h => rw [show l₂ = [y] from List.perm_singleton.mp h.symm]
+      | _ :: _ :: _, l₂, h =>
+        rw [selCombine_big (by simp +arith),
+            selCombine_big (by
+              have hl := h.length_eq
+              simp only [List.length_cons] at hl ⊢
+              omega)]
+    | swap x y l =>
+      cases l with
+      | nil => exact selStep_comm y x
+      | cons z l => rfl
+    | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
+
+/-- Selection check on a planar `SO`-tree: the projecting head + residual pending
+    features, or `none` outside the endocentric domain — the catamorphism of
+    `selCombine`. -/
+def selCheckPlanar : RoseTree SOLabel → Option (LIToken × List Cat) :=
+  RoseTree.fold selCombine
+
+/-- Reduction of `selCheckPlanar` at a node: fold the algebra over the daughters. -/
+theorem selCheckPlanar_node (a : SOLabel) (cs : List (RoseTree SOLabel)) :
+    selCheckPlanar (RoseTree.node a cs) = selCombine a (cs.map selCheckPlanar) :=
+  RoseTree.fold_node ..
 
 /-- `selCheckPlanar` is `PermEquiv`-invariant, so it descends to the quotient. -/
 theorem selCheckPlanar_permEquiv {t s : RoseTree SOLabel}
-    (h : RoseTree.PermEquiv t s) : selCheckPlanar t = selCheckPlanar s := by
-  induction h with
-  | rel _ _ hstep => exact selCheckPlanar_permStep hstep
-  | refl _ => rfl
-  | symm _ _ _ ih => exact ih.symm
-  | trans _ _ _ _ _ ih1 ih2 => exact ih1.trans ih2
+    (h : RoseTree.PermEquiv t s) : selCheckPlanar t = selCheckPlanar s :=
+  RoseTree.fold_permEquiv (fun a _ _ h' => selCombine_perm a h') h
 
 /-- Selection check lifted to the nonplanar carrier. -/
 def selCheckN : Nonplanar SOLabel → Option (LIToken × List Cat) :=
@@ -208,7 +201,7 @@ theorem selCheckN_node (a b : Nonplanar SOLabel) :
           = Multiset.ofList ([pa, pb].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
   show selCheckN (Nonplanar.node (Sum.inr ()) {Nonplanar.mk pa, Nonplanar.mk pb})
       = selStep (selCheckN (Nonplanar.mk pa)) (selCheckN (Nonplanar.mk pb))
-  rw [key]; simp only [selCheckN_mk, selCheckPlanar]
+  rw [key]; exact rfl
 
 /-! ### The selection-driven head on `SO` -/
 


### PR DESCRIPTION
Adds `RoseTree.fold_permEquiv`: a catamorphism with a permutation-invariant algebra descends to the nonplanar quotient generically. `selCheckPlanar` and `linearizePlanar` become folds (`selCombine`; `linCombine` pairing selection state with yield, MCB's dual description of a head function, with fst-fusion `selLinPlanar_fst`), dissolving both bespoke `PermStep` inductions; the three count invariances collapse likewise. Obligations reduce to the algebras' `List.Perm` invariance (`selStep_comm`/`selSide_comm`). `decide` demos unchanged.