### PR TITLE
style(Syntax/Minimalist): selCombine coherence as Bool.cond; cut mul_eq_some

### DIFF
--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -95,24 +95,18 @@ instance : CommMagma SelState where
 
 variable {x y}
 
-/-- The selection decision determines side and head coherently: the projected head
-    is the head of the sister on the side it reports. The single raw analysis;
-    `SelState.mul_fst` and `SelState.mul_eq_some` are corollaries. -/
+/-- The selection decision is coherent: the projected head is the head of the
+    sister on the side it reports — the coherence of the two projections. The single
+    raw analysis; `SelState.mul_fst` is a corollary. -/
 theorem selCombine_eq_some {b : Bool} {hd : LIToken} {res : List Cat}
     (h : selCombine x y = some (b, hd, res)) :
-    (b = true ∧ x.map (·.1) = some hd) ∨ (b = false ∧ y.map (·.1) = some hd) := by
+    (bif b then x else y).map (·.1) = some hd := by
   match x, y with
-  | some (ha, c :: rest'), some (hb, []) =>
-    simp only [selCombine] at h
-    split_ifs at h with hcat
-    simp only [Option.some.injEq, Prod.mk.injEq] at h
-    exact Or.inl ⟨h.1.symm, by simp [h.2.1]⟩
+  | some (ha, c :: rest'), some (hb, [])
   | some (ha, []), some (hb, c :: rest') =>
     simp only [selCombine] at h
-    split_ifs at h with hcat
-    simp only [Option.some.injEq, Prod.mk.injEq] at h
-    exact Or.inr ⟨h.1.symm, by simp [h.2.1]⟩
-  | some (_, []), some (_, []) | some (_, _ :: _), some (_, _ :: _) => simp [selCombine] at h
+    split_ifs at h; cases h; rfl
+  | some (_, []), some (_, []) | some (_, _ :: _), some (_, _ :: _)
   | none, _ | some _, none => simp [selCombine] at h
 
 /-- The head of `x * y` (when defined) is one of `x`/`y`'s heads. -/
@@ -120,23 +114,9 @@ theorem SelState.mul_fst {r : LIToken}
     (h : (x * y).map (·.1) = some r) :
     x.map (·.1) = some r ∨ y.map (·.1) = some r := by
   simp only [SelState.mul_def, Option.map_map, Option.map_eq_some_iff] at h
-  obtain ⟨⟨b, hd, res⟩, hproj, rfl⟩ := h
-  rcases selCombine_eq_some hproj with ⟨_, hx⟩ | ⟨_, hy⟩
-  · exact Or.inl hx
-  · exact Or.inr hy
-
-/-- When the product is defined, its head is the projecting daughter's head, and
-    `selSide` agrees on which daughter projects. -/
-theorem SelState.mul_eq_some {hd : LIToken} {res : List Cat}
-    (h : x * y = some (hd, res)) :
-    (selSide x y = some true ∧ x.map (·.1) = some hd) ∨
-    (selSide x y = some false ∧ y.map (·.1) = some hd) := by
-  simp only [SelState.mul_def, Option.map_eq_some_iff] at h
-  obtain ⟨⟨b, hd', res'⟩, hproj, heq⟩ := h
-  obtain ⟨rfl, rfl⟩ : hd' = hd ∧ res' = res := by simpa using heq
-  rcases selCombine_eq_some hproj with ⟨rfl, hx⟩ | ⟨rfl, hy⟩
-  · exact Or.inl ⟨by simp [selSide, hproj], hx⟩
-  · exact Or.inr ⟨by simp [selSide, hproj], hy⟩
+  obtain ⟨⟨b, _, _⟩, hproj, rfl⟩ := h
+  cases b
+  exacts [Or.inr (selCombine_eq_some hproj), Or.inl (selCombine_eq_some hproj)]
 
 /-! ### Selection check on the planar carrier -/
 


### PR DESCRIPTION
Supersedes #1206 (contains its diff). `selCombine_eq_some` restated as one `Bool.cond` equation (the head is the head of the sister on the reported side); its two symmetric proof arms merge under pattern alternation (16 → 8 lines). `SelState.mul_fst` golfed to `cases b; exacts [...]`. `SelState.mul_eq_some` DELETED: zero consumers, and post-restatement its content is `selCombine_eq_some` plus two lines of unfolding — recoverable on demand.