### PR TITLE
style(Syntax/Minimalist): rename fused value to LinearizationState

### DIFF
--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -19,22 +19,23 @@ the book), c-selection computes the planar order.
 
 ## Main declarations
 
-* `Minimalist.Head`: the head of a constituent in the book's two descriptions —
-  the selection state enriched with the yield, `none` off `Dom(h)`; a `CommMagma`
-  under the `side`-indexed Merge-local product.
-* `Minimalist.Head.sel`: the projection morphism `Head side →ₙ* SelState`
+* `Minimalist.LinearizationState`: the value of the book's head function in its two
+  descriptions — the selection state enriched with the yield, `none` off `Dom(h)`;
+  a `CommMagma` under the `side`-indexed Merge-local product.
+* `Minimalist.LinearizationState.sel`: the projection morphism to `SelState`,
   forgetting the order description.
-* `Minimalist.headHom`: taking the head as a morphism of magmas
-  `SO →ₙ* Head side`, refining `selCheckHom` with the yield.
+* `Minimalist.headHom`: the head function as a morphism of magmas
+  `SO →ₙ* LinearizationState side`, refining `selCheckHom` with the yield.
 * `Minimalist.SO.linearize`, `Minimalist.SO.phonYield`: the yield readout and the
   pronounced surface forms.
 
 ## Main results
 
-* `Minimalist.sel_comp_headHom`: fusion — projecting the head to its selection
-  component is the selection check, as a commuting triangle of magma morphisms.
+* `Minimalist.sel_comp_headHom`: fusion — the selection component of the head
+  function's value is the selection check, as a commuting triangle of magma
+  morphisms.
 * `Minimalist.headNode_perm`: the head algebra is permutation-invariant
-  (`List.Perm.congr_arity₂` on `mul_comm`), so the head descends to the nonplanar
+  (`List.Perm.congr_arity₂` on `mul_comm`), so the state descends to the nonplanar
   quotient by `RoseTree.fold_perm`.
 
 ## Implementation notes
@@ -42,12 +43,17 @@ the book), c-selection computes the planar order.
 Head functions are partial ([marcolli-chomsky-berwick-2025] §1.13.2): at exocentric
 nodes no daughter projects and no order is determined — the book rejects inducing one
 from a total order on labels as "not a realistic linguistic assumption" — so the
-head is `none` there, matching the book's elimination of nonparsable objects at
+state is `none` there, matching the book's elimination of nonparsable objects at
 externalization. The selection state and the yield are the book's two descriptions
-of *one* head function, so their domains coincide; `Head` fuses them into a single
-`Option`, making `Dom(yield) = Dom(h)` true by construction. The `side` index is
-phantom in the carrier and read by the multiplication (the `WithLp` pattern); the
-head-leaf description is side-invariant, only the yield description is
+of *one* head function: eq. (1.13.3) reads `h(T)` as "a single leaf (the head)" or
+as the ordered leaf sequence, "switch[ing] between these two descriptions without
+changing the notation". `LinearizationState` fuses them into a single `Option`,
+making `Dom(yield) = Dom(h)` true by construction. **Naming**: the head-function
+*maps* (`headNode`, `headPlanar`, `headN`, `headHom`) carry the book's name for `h`;
+the *value* type does not — the book restricts "the term head to terminal elements"
+(quoting [chomsky-1995-bare] §4), and the strict head is recovered via `sel`. The
+`side` index is phantom in the carrier and read by the multiplication (the `WithLp`
+pattern); the head-leaf description is side-invariant, only the yield description is
 convention-relative. Conceptually the yield component is
 `WithZero (FreeMonoid LIToken)`: a silent trace is the unit, exocentricity the
 absorbing zero, and head-final placement is multiplication in the opposite monoid.
@@ -67,24 +73,26 @@ def placeYield : ConventionDir → List LIToken → List LIToken → List LIToke
   | .initial, headY, otherY => headY ++ otherY
   | .final,   headY, otherY => otherY ++ headY
 
-/-! ### The head in both descriptions -/
+/-! ### The linearization state -/
 
 set_option linter.unusedVariables false in
-/-- The head of a constituent under head-side convention `side`: the projecting head
-    with its residual selectional stack (the `SelState` data) enriched with the
-    yield, `none` off `Dom(h)` — [marcolli-chomsky-berwick-2025] §1.13's two
-    descriptions of a head function (head leaf, ordered leaf sequence) as one
-    partial value. The `side` parameter is phantom in the carrier — the
-    multiplication reads it (the `WithLp` pattern). -/
-def Head (side : ConventionDir) : Type := Option ((LIToken × List Cat) × List LIToken)
+/-- The linearization state of a constituent under head-side convention `side`: the
+    projecting head with its residual selectional stack (the `SelState` data)
+    enriched with the yield, `none` off `Dom(h)` — the value of
+    [marcolli-chomsky-berwick-2025]'s head function in its two descriptions, "a
+    single leaf (the head)" or the ordered leaf sequence (eq. (1.13.3)), which the
+    book reads interchangeably "without changing the notation". The `side` parameter
+    is phantom in the carrier — the multiplication reads it (the `WithLp` pattern). -/
+def LinearizationState (side : ConventionDir) : Type :=
+  Option ((LIToken × List Cat) × List LIToken)
 
-namespace Head
+namespace LinearizationState
 
 variable {side : ConventionDir}
 
 /-- Merge-local externalization: the `selCombine` decision projects the head and
     places the projecting daughter's yield on the convention side. -/
-instance : Mul (Head side) :=
+instance : Mul (LinearizationState side) :=
   ⟨fun x y =>
     match x, y with
     | some (s₁, y₁), some (s₂, y₂) =>
@@ -92,7 +100,7 @@ instance : Mul (Head side) :=
           (p.2, placeYield side (bif p.1 then y₁ else y₂) (bif p.1 then y₂ else y₁))
     | _, _ => none⟩
 
-instance : CommMagma (Head side) where
+instance : CommMagma (LinearizationState side) where
   mul_comm x y := by
     match x, y with
     | none, none | none, some _ | some _, none => rfl
@@ -105,7 +113,7 @@ instance : CommMagma (Head side) where
 
 /-- The projection to the selection state, as a morphism of magmas: forgetting the
     order description of the head. -/
-def sel : Head side →ₙ* SelState where
+def sel : LinearizationState side →ₙ* SelState where
   toFun := Option.map (·.1)
   map_mul' x y := by
     match x, y with
@@ -115,70 +123,71 @@ def sel : Head side →ₙ* SelState where
       show Option.map _ ((selCombine (some s₁) (some s₂)).map _) = _
       rw [Option.map_map]; rfl
 
-end Head
+end LinearizationState
 
 /-! ### The head algebra -/
 
 /-- The head algebra: a lexical leaf is pronounced carrying its `outerSel` stack, a
     bare trace leaf is silent and saturated (the cancelled copy of
-    [marcolli-chomsky-berwick-2025] §1.12), a bare binary node is the `Head`
+    [marcolli-chomsky-berwick-2025] §1.12), a bare binary node is the `LinearizationState`
     product, and other arities are off `Dom(h)`. -/
-def headNode (side : ConventionDir) : SOLabel → List (Head side) → Head side
+def headNode (side : ConventionDir) :
+    SOLabel → List (LinearizationState side) → LinearizationState side
   | .inl tok, _     => some ((tok, tok.item.outerSel), [tok])
   | .inr (), []     => some ((mkTraceToken 0, []), [])
   | .inr (), [x, y] => x * y
   | .inr (), _      => none
 
 /-- A daughter list of three or more is off `Dom(h)`. -/
-private theorem headNode_big {side : ConventionDir} {l : List (Head side)}
+private theorem headNode_big {side : ConventionDir} {l : List (LinearizationState side)}
     (h : 2 < l.length) : headNode side (Sum.inr ()) l = none := by
   match l with
   | _ :: _ :: _ :: _ => rfl
   | [] | [_] | [_, _] => simp at h
 
-/-- `headNode` is invariant under permutation of the daughter heads: only the
+/-- `headNode` is invariant under permutation of the daughter states: only the
     binary shape is order-sensitive, and there `mul_comm` applies. -/
-theorem headNode_perm (side : ConventionDir) (a : SOLabel) {l₁ l₂ : List (Head side)}
+theorem headNode_perm (side : ConventionDir) (a : SOLabel) {l₁ l₂ : List (LinearizationState side)}
     (h : l₁.Perm l₂) : headNode side a l₁ = headNode side a l₂ := by
   cases a with
   | inl tok => rfl
   | inr u => cases u; exact h.congr_arity₂ (fun x y => mul_comm x y) fun _ h => headNode_big h
 
-/-- `Head.sel` intertwines the head and selection algebras. -/
-theorem sel_headNode (side : ConventionDir) (a : SOLabel) (ps : List (Head side)) :
-    Head.sel (headNode side a ps) = selNode a (ps.map Head.sel) := by
+/-- `LinearizationState.sel` intertwines the head and selection algebras. -/
+theorem sel_headNode (side : ConventionDir) (a : SOLabel) (ps : List (LinearizationState side)) :
+    LinearizationState.sel (headNode side a ps) = selNode a (ps.map LinearizationState.sel) := by
   match a, ps with
   | .inl tok, _ => rfl
   | .inr (), [] => rfl
-  | .inr (), [x, y] => exact map_mul Head.sel x y
+  | .inr (), [x, y] => exact map_mul LinearizationState.sel x y
   | .inr (), [_] | .inr (), _ :: _ :: _ :: _ => rfl
 
-/-! ### The head on the planar and nonplanar carriers -/
+/-! ### The head function on the planar and nonplanar carriers -/
 
-/-- The head of a planar `SO`-tree: the catamorphism of the head algebra. -/
-def headPlanar (side : ConventionDir) : RoseTree SOLabel → Head side :=
+/-- The head function on planar `SO`-trees: the catamorphism of the head algebra. -/
+def headPlanar (side : ConventionDir) : RoseTree SOLabel → LinearizationState side :=
   RoseTree.fold (headNode side)
 
-/-- **Fusion** on the planar carrier: the selection component of the head is the
-    selection check. -/
+/-- **Fusion** on the planar carrier: the selection component of the head
+    function's value is the selection check. -/
 theorem sel_headPlanar (side : ConventionDir) (t : RoseTree SOLabel) :
-    Head.sel (headPlanar side t) = selCheckPlanar t :=
+    LinearizationState.sel (headPlanar side t) = selCheckPlanar t :=
   RoseTree.fold_hom _ (sel_headNode side) t
 
-/-- The head is projection-determined, not representative-determined: it descends
+/-- The state is projection-determined, not representative-determined: it descends
     to the nonplanar quotient. -/
 theorem headPlanar_perm (side : ConventionDir) {t s : RoseTree SOLabel}
     (h : RoseTree.Perm t s) : headPlanar side t = headPlanar side s :=
   RoseTree.fold_perm (fun a _ _ h' => headNode_perm side a h') h
 
-/-- The head on the nonplanar carrier. -/
-def headN (side : ConventionDir) : Nonplanar SOLabel → Head side :=
+/-- The head function on the nonplanar carrier. -/
+def headN (side : ConventionDir) : Nonplanar SOLabel → LinearizationState side :=
   Nonplanar.lift (headPlanar side) fun _ _ h => headPlanar_perm side h
 
 @[simp] theorem headN_mk (side : ConventionDir) (p : RoseTree SOLabel) :
     headN side (Nonplanar.mk p) = headPlanar side p := rfl
 
-/-- The nonplanar magma law: Merge multiplies heads. -/
+/-- The nonplanar magma law: Merge multiplies linearization states. -/
 theorem headN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
     headN side (Nonplanar.node (Sum.inr ()) {a, b}) = headN side a * headN side b := by
   refine Quotient.inductionOn₂ a b fun pa pb => ?_
@@ -188,37 +197,41 @@ theorem headN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
 
 /-! ### Externalization on `SO` -/
 
-/-- The head of a syntactic object, in both descriptions. -/
-def SO.head (side : ConventionDir) (s : SO) : Head side := headN side s.val
+/-- The linearization state of a syntactic object: the value of the head function
+    in both descriptions. -/
+def SO.linearizationState (side : ConventionDir) (s : SO) : LinearizationState side :=
+  headN side s.val
 
-@[simp] theorem SO.head_node (side : ConventionDir) (l r : SO) :
-    (SO.node l r).head side = l.head side * r.head side := by
+@[simp] theorem SO.linearizationState_node (side : ConventionDir) (l r : SO) :
+    (SO.node l r).linearizationState side
+      = l.linearizationState side * r.linearizationState side := by
   show headN side (SO.node l r).val = headN side l.val * headN side r.val
   rw [SO.node_val, headN_node]
 
-/-- **Taking the head is a morphism of magmas** `SO →ₙ* Head side`
+/-- **The head function is a morphism of magmas** `SO →ₙ* LinearizationState side`
     ([marcolli-chomsky-berwick-2025] §1.13's algebraic frame): Merge multiplies
-    constituents, externalization multiplies heads. -/
-noncomputable def headHom (side : ConventionDir) : SO →ₙ* Head side where
-  toFun := SO.head side
-  map_mul' := SO.head_node side
+    constituents, the head function multiplies linearization states. -/
+noncomputable def headHom (side : ConventionDir) : SO →ₙ* LinearizationState side where
+  toFun := SO.linearizationState side
+  map_mul' := SO.linearizationState_node side
 
-/-- **Fusion as a commuting triangle**: projecting the head to its selection
-    component is the selection check — `Head.sel ∘ headHom = selCheckHom`. -/
+/-- **Fusion as a commuting triangle**: projecting the head function's value to its
+    selection component is the selection check —
+    `LinearizationState.sel ∘ headHom = selCheckHom`. -/
 theorem sel_comp_headHom (side : ConventionDir) :
-    Head.sel.comp (headHom side) = selCheckHom :=
+    LinearizationState.sel.comp (headHom side) = selCheckHom :=
   MulHom.ext fun s => by
-    show Head.sel (headN side s.val) = selCheckN s.val
+    show LinearizationState.sel (headN side s.val) = selCheckN s.val
     exact Quotient.inductionOn s.val (sel_headPlanar side)
 
 /-- The surface token order of a syntactic object under the head-side convention
     `side` ([marcolli-chomsky-berwick-2025] §1.12.1): the yield readout of the
-    head — the selection-induced harmonic candidate for the externalization
+    linearization state — the selection-induced harmonic candidate for the externalization
     section σ_L, defined on `Dom(h)` only (the book's σ_L must extend it
     *noncanonically* off `Dom(h)`). The readout alone is not a morphism: placing a
-    yield needs the head leaf, which is why `Head` carries both descriptions. -/
+    yield needs the head leaf, which is why `LinearizationState` carries both descriptions. -/
 def SO.linearize (side : ConventionDir) (s : SO) : Option (List LIToken) :=
-  Option.map (·.2) (s.head side)
+  Option.map (·.2) (s.linearizationState side)
 
 /-- The pronounced surface forms: the yield with unpronounced (empty-`phonForm`)
     tokens dropped. Traces, being the bare `Sum.inr ()` leaf, contribute nothing. -/


### PR DESCRIPTION
Naming triple-check against the book text and literature: MCB restrict "the term head to terminal elements" (quoting Chomsky 1995 §4) and every bare-noun "head" in the book denotes the leaf, while the literature uniformly reserves "head" for the projecting item. #1211 auto-merged with the pre-verdict `Head` type name; this renames the fused value type to `LinearizationState` and keeps head-names on the maps only (`headNode`/`headPlanar`/`headN`/`headHom` — the book's `h`, which eq. (1.13.3) itself reads sequence-valued).