### PR TITLE
refactor(Syntax/Minimalist): rename SO to SyntacticObject

### DIFF
--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -91,8 +91,8 @@ alongside Tz'utujil, Chickasaw, Sinitic double-unaccusative).
 - `GramFunction`, `absPosition` from `Fragments/Mayan/Tseltalan.lean`
 - `ABSPosition` from `Fragments/Mayan/Params.lean`
 - `Probe.Profile`, `closestGoalB`, `behindHorizonB` from
-  `Syntax/Minimalist/Agree.lean`; `SO` construction DSL (`SO.ofPlanar`,
-  `SO.leafP`, `SO.nodeP`, `SO.lexLeaf`) from
+  `Syntax/Minimalist/Agree.lean`; `SyntacticObject` construction DSL (`SyntacticObject.ofPlanar`,
+  `SyntacticObject.leafP`, `SyntacticObject.nodeP`, `SyntacticObject.lexLeaf`) from
   `Syntax/Minimalist/SyntacticObject/Build.lean`
 -/
 
@@ -879,8 +879,8 @@ geometry and which nodes carry D features:
     Matching criterion for T°'s [EPP:D] probe: D-bearing elements
     (possessor DPs, D° heads, agent DPs) are potential goals.
 
-    Reads the root token via `SO.getLIToken`. Only leaf SOs carry a
-    token; internal (`SO.node`) nodes and traces return `none` and are
+    Reads the root token via `SyntacticObject.getLIToken`. Only leaf SOs carry a
+    token; internal (`SyntacticObject.node`) nodes and traces return `none` and are
     not D-bearing (no structural-position-dependent feature lookup is
     needed). -/
 private def hasDFeatures (s : SyntacticObject) : Bool :=
@@ -890,10 +890,12 @@ private def hasDFeatures (s : SyntacticObject) : Bool :=
 
 /-! ### Leaf Tokens and Nodes
 
-Concrete trees are built **planar-first** (`SO.ofPlanar`/`SO.nodeP`/`SO.leafP`)
-because Merge (`SO.node`) is noncomputable; `closestGoalB`/`behindHorizonB` then
-reduce under `decide`. Each leaf `SO` is `SO.lexLeaf` of its token, and the trees
-reference the same tokens via `SO.leafP` so the two match definitionally. -/
+Concrete trees are built **planar-first**
+(`SyntacticObject.ofPlanar`/`SyntacticObject.nodeP`/`SyntacticObject.leafP`)
+because Merge (`SyntacticObject.node`) is noncomputable; `closestGoalB`/`behindHorizonB` then
+reduce under `decide`. Each leaf `SyntacticObject` is `SyntacticObject.lexLeaf` of its token, and
+the trees
+reference the same tokens via `SyntacticObject.leafP` so the two match definitionally. -/
 
 private def tT₀  : LIToken := ⟨.simple .T [], 1⟩   -- T° head ([EPP:D] probe)
 private def tV₀  : LIToken := ⟨.simple .V [], 2⟩   -- V° (lexical verb)
@@ -903,13 +905,13 @@ private def tPsm : LIToken := ⟨.simple .N [], 5⟩   -- Possessum (not D-beari
 private def tD₀  : LIToken := ⟨.simple .D [], 6⟩   -- D° head of specific nominal
 private def tAgt : LIToken := ⟨.simple .D [], 7⟩   -- Agent DP (D-bearing)
 
-private def T₀  : SyntacticObject := SO.lexLeaf tT₀
-private def V₀  : SyntacticObject := SO.lexLeaf tV₀
-private def v₀  : SyntacticObject := SO.lexLeaf tv₀
-private def Psr : SyntacticObject := SO.lexLeaf tPsr
-private def Psm : SyntacticObject := SO.lexLeaf tPsm
-private def D₀  : SyntacticObject := SO.lexLeaf tD₀
-private def Agt : SyntacticObject := SO.lexLeaf tAgt
+private def T₀  : SyntacticObject := SyntacticObject.lexLeaf tT₀
+private def V₀  : SyntacticObject := SyntacticObject.lexLeaf tV₀
+private def v₀  : SyntacticObject := SyntacticObject.lexLeaf tv₀
+private def Psr : SyntacticObject := SyntacticObject.lexLeaf tPsr
+private def Psm : SyntacticObject := SyntacticObject.lexLeaf tPsm
+private def D₀  : SyntacticObject := SyntacticObject.lexLeaf tD₀
+private def Agt : SyntacticObject := SyntacticObject.lexLeaf tAgt
 
 /-! ### Clause Trees ([aissen-polian-2025] (9a-c))
 
@@ -922,34 +924,37 @@ private def Agt : SyntacticObject := SO.lexLeaf tAgt
 Object is PossP (non-specific) or DP (specific). -/
 
 -- Non-specific possessive object: [PossP Psr Psm]
-private def possPp : RoseTree SOLabel := SO.nodeP (SO.leafP tPsr) (SO.leafP tPsm)
+private def possPp : RoseTree SOLabel :=
+  SyntacticObject.nodeP (SyntacticObject.leafP tPsr) (SyntacticObject.leafP tPsm)
 
 -- Specific possessive object: [DP D° [PossP Psr Psm]]
-private def dpObjp : RoseTree SOLabel := SO.nodeP (SO.leafP tD₀) possPp
+private def dpObjp : RoseTree SOLabel := SyntacticObject.nodeP (SyntacticObject.leafP tD₀) possPp
 
 -- (9a) Unaccusative + non-specific: [TP T° [VP V° [PossP Psr Psm]]]
 private def treeUnaccPossP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tT₀) (SO.nodeP (SO.leafP tV₀) possPp))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) possPp))
 
 -- (9a') Unaccusative + specific: [TP T° [VP V° [DP D° [PossP Psr Psm]]]]
 private def treeUnaccDP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tT₀) (SO.nodeP (SO.leafP tV₀) dpObjp))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) dpObjp))
 
 -- (9b) Transitive + non-specific:
 -- [TP T° [vP Agt [v' v° [VP V° [PossP Psr Psm]]]]]
 private def treeTransPossP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tT₀)
-    (SO.nodeP (SO.leafP tAgt)
-      (SO.nodeP (SO.leafP tv₀)
-        (SO.nodeP (SO.leafP tV₀) possPp))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tAgt)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tv₀)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) possPp))))
 
 -- (9b') Transitive + specific:
 -- [TP T° [vP Agt [v' v° [VP V° [DP D° [PossP Psr Psm]]]]]]
 private def treeTransDP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tT₀)
-    (SO.nodeP (SO.leafP tAgt)
-      (SO.nodeP (SO.leafP tv₀)
-        (SO.nodeP (SO.leafP tV₀) dpObjp))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tAgt)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tv₀)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) dpObjp))))
 
 /-! ### Core Predictions
 
@@ -1040,23 +1045,25 @@ are now derived from tree geometry:
 -/
 
 private def tC₀ : LIToken := ⟨.simple .C [], 8⟩
-private def C₀ : SyntacticObject := SO.lexLeaf tC₀
+private def C₀ : SyntacticObject := SyntacticObject.lexLeaf tC₀
 
 -- Planar bodies of the unaccusative trees, reused under the CP node.
 private def treeUnaccDPp : RoseTree SOLabel :=
-  SO.nodeP (SO.leafP tT₀) (SO.nodeP (SO.leafP tV₀) dpObjp)
+  SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) dpObjp)
 private def treeUnaccPossPp : RoseTree SOLabel :=
-  SO.nodeP (SO.leafP tT₀) (SO.nodeP (SO.leafP tV₀) possPp)
+  SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) possPp)
 
 -- CP wrapping unaccusative + DP:
 -- [CP C° [TP T° [VP V° [DP D° [PossP Psr Psm]]]]]
 private def treeCPUnaccDP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tC₀) treeUnaccDPp)
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tC₀) treeUnaccDPp)
 
 -- CP wrapping unaccusative + PossP:
 -- [CP C° [TP T° [VP V° [PossP Psr Psm]]]]
 private def treeCPUnaccPossP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tC₀) treeUnaccPossPp)
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tC₀) treeUnaccPossPp)
 
 /-! ### Core Predictions -/
 

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -226,7 +226,7 @@ structure HonRelation (E : Type*) where
   level : HonLevel
 
 /-- HonP: a functional projection in the nominal spine that hosts [iHON].
-    Wraps a DP's SO with an honorific feature. -/
+    Wraps a DP's SyntacticObject with an honorific feature. -/
 structure HonP where
   /-- The underlying DP -/
   dp : SyntacticObject

--- a/Linglib/Studies/Amato2025.lean
+++ b/Linglib/Studies/Amato2025.lean
@@ -120,10 +120,10 @@ theorem bulgarianMultiWh_is_nested :
     IsNestedAgreeConfig bulgarianMultiWh := by decide
 
 theorem bulgarianMultiWh_runStack_0 :
-    runStack bulgarianMultiWh 0 = some (SO.lexLeaf aWhObj) := by decide
+    runStack bulgarianMultiWh 0 = some (SyntacticObject.lexLeaf aWhObj) := by decide
 
 theorem bulgarianMultiWh_runStack_1 :
-    runStack bulgarianMultiWh 1 = some (SO.lexLeaf aWhObj) := by decide
+    runStack bulgarianMultiWh 1 = some (SyntacticObject.lexLeaf aWhObj) := by decide
 
 /-- **Apparent wh-subject intervention is not actual.** The
     wh-subject is in C's c-command (probe 0's full domain) but is
@@ -137,9 +137,9 @@ theorem bulgarianMultiWh_runStack_1 :
     structurally closer wh-phrase. wh-obj raises first; wh-sbj is
     raised in the (out-of-scope) restart phase. -/
 theorem bulgarianMultiWh_excludes_wh_subject :
-    SO.lexLeaf aWhSbj ∈ bulgarianMultiWh.searchDomain 0 ∧
-    SO.lexLeaf aWhSbj ∉ bulgarianMultiWh.searchDomain 1 :=
-  apparent_intervener_excluded bulgarianMultiWh 0 (SO.lexLeaf aWhSbj)
+    SyntacticObject.lexLeaf aWhSbj ∈ bulgarianMultiWh.searchDomain 0 ∧
+    SyntacticObject.lexLeaf aWhSbj ∉ bulgarianMultiWh.searchDomain 1 :=
+  apparent_intervener_excluded bulgarianMultiWh 0 (SyntacticObject.lexLeaf aWhSbj)
     (by decide) (by decide)
 
 end Bulgarian

--- a/Linglib/Studies/Amato2025/NestedAgree.lean
+++ b/Linglib/Studies/Amato2025/NestedAgree.lean
@@ -119,7 +119,7 @@ def length (c : NestedAgreeConfig) : Nat := c.stack.length
     `List` flavor. -/
 def initialDomain (c : NestedAgreeConfig) : Multiset SyntacticObject :=
   c.root.subtrees.filter (fun y =>
-    decide (SO.cCommandsIn c.root c.probingHead y) && c.validGoal y)
+    decide (SyntacticObject.cCommandsIn c.root c.probingHead y) && c.validGoal y)
 
 /-- The shared goal's daughters: the goal itself plus everything it
     c-commands, filtered by phi-activity. The reflexive inclusion of
@@ -127,7 +127,7 @@ def initialDomain (c : NestedAgreeConfig) : Multiset SyntacticObject :=
     probe must be able to find the goal again. -/
 def daughters (c : NestedAgreeConfig) : Multiset SyntacticObject :=
   c.root.subtrees.filter (fun y =>
-    (y == c.goalHead || decide (SO.cCommandsIn c.root c.goalHead y)) &&
+    (y == c.goalHead || decide (SyntacticObject.cCommandsIn c.root c.goalHead y)) &&
       c.validGoal y)
 
 /-- Search domain at probe `i`: derived from the structural
@@ -313,9 +313,9 @@ tree, the 2-probe stack — is captured by `standardConfig`. -/
     Shared template across the landed Amato 2025 case studies. -/
 def standardLinearTree (probeHd intervener midNode terminal : LIToken) :
     SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP probeHd)
-    (SO.nodeP (SO.leafP intervener)
-      (SO.nodeP (SO.leafP midNode) (SO.leafP terminal))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP probeHd)
+    (SyntacticObject.nodeP (SyntacticObject.leafP intervener)
+      (SyntacticObject.nodeP (SyntacticObject.leafP midNode) (SyntacticObject.leafP terminal))))
 
 /-- A `NestedAgreeConfig` over the standard linear tree, with a
     2-probe stack on `probeHd`. The `goalHd` selects which leaf
@@ -326,8 +326,8 @@ def standardConfig (probeProfile : Probe.Profile)
     NestedAgreeConfig where
   stack := [probeProfile, probeProfile]
   root := standardLinearTree probeHd intervener midNode terminal
-  probingHead := SO.lexLeaf probeHd
-  goalHead := SO.lexLeaf goalHd
+  probingHead := SyntacticObject.lexLeaf probeHd
+  goalHead := SyntacticObject.lexLeaf goalHd
   validGoal := vg
 
 -- ============================================================================
@@ -344,7 +344,7 @@ from probe 1 — encoding [amato-2025]'s resolution of the
 apparent minimality violation.
 
 `validGoal` is `true` everywhere here (transitive case); the
-unaccusative case (`validGoal (SO.lexLeaf aV) = false`) is the one tested
+unaccusative case (`validGoal (SyntacticObject.lexLeaf aV) = false`) is the one tested
 in `Studies/Amato2025.lean`. -/
 
 private def aT : LIToken := ⟨LexicalItem.simple .T [], 0⟩
@@ -362,19 +362,19 @@ theorem italianAuxExample_is_nested :
     IsNestedAgreeConfig italianAuxExample := by decide
 
 theorem italianAuxExample_runStack_0 :
-    runStack italianAuxExample 0 = some (SO.lexLeaf aV) := by decide
+    runStack italianAuxExample 0 = some (SyntacticObject.lexLeaf aV) := by decide
 
 theorem italianAuxExample_runStack_1 :
-    runStack italianAuxExample 1 = some (SO.lexLeaf aV) := by decide
+    runStack italianAuxExample 1 = some (SyntacticObject.lexLeaf aV) := by decide
 
 /-- DPsubj is in probe 0's c-command (Perf c-commands DPsubj) but
     not in probe 1's truncated domain (v doesn't c-command DPsubj).
     Real strict-truncation content from the Minimalist c-command
     primitive. -/
 theorem italianAuxExample_excludes_apparent_intervener :
-    SO.lexLeaf aDPsubj ∈ italianAuxExample.searchDomain 0 ∧
-    SO.lexLeaf aDPsubj ∉ italianAuxExample.searchDomain 1 :=
-  apparent_intervener_excluded italianAuxExample 0 (SO.lexLeaf aDPsubj)
+    SyntacticObject.lexLeaf aDPsubj ∈ italianAuxExample.searchDomain 0 ∧
+    SyntacticObject.lexLeaf aDPsubj ∉ italianAuxExample.searchDomain 1 :=
+  apparent_intervener_excluded italianAuxExample 0 (SyntacticObject.lexLeaf aDPsubj)
     (by decide) (by decide)
 
 end Amato2025.NestedAgree

--- a/Linglib/Studies/Amato2025Agreement.lean
+++ b/Linglib/Studies/Amato2025Agreement.lean
@@ -109,10 +109,10 @@ def icelandicOrderingA : NestedAgreeConfig :=
 theorem orderingA_is_nested : IsNestedAgreeConfig icelandicOrderingA := by decide
 
 theorem orderingA_runStack_0 :
-    runStack icelandicOrderingA 0 = some (SO.lexLeaf aDPnom) := by decide
+    runStack icelandicOrderingA 0 = some (SyntacticObject.lexLeaf aDPnom) := by decide
 
 theorem orderingA_runStack_1 :
-    runStack icelandicOrderingA 1 = some (SO.lexLeaf aDPnom) := by decide
+    runStack icelandicOrderingA 1 = some (SyntacticObject.lexLeaf aDPnom) := by decide
 
 /-- **Apparent dative intervention is not actual.** The dative subject
     is in T's c-command (probe 0's domain) but is *not* in DPnom's
@@ -120,9 +120,9 @@ theorem orderingA_runStack_1 :
     above DPnom). DPdat is excluded from probe 1's truncated domain
     by Nested Agree. -/
 theorem orderingA_excludes_dative :
-    SO.lexLeaf aDPdat ∈ icelandicOrderingA.searchDomain 0 ∧
-    SO.lexLeaf aDPdat ∉ icelandicOrderingA.searchDomain 1 :=
-  apparent_intervener_excluded icelandicOrderingA 0 (SO.lexLeaf aDPdat)
+    SyntacticObject.lexLeaf aDPdat ∈ icelandicOrderingA.searchDomain 0 ∧
+    SyntacticObject.lexLeaf aDPdat ∉ icelandicOrderingA.searchDomain 1 :=
+  apparent_intervener_excluded icelandicOrderingA 0 (SyntacticObject.lexLeaf aDPdat)
     (by decide) (by decide)
 
 /-! ### Configuration B — default agreement -/
@@ -132,7 +132,7 @@ theorem orderingA_excludes_dative :
     quirky/defective for finite T's valuation purposes. -/
 def icelandicOrderingB : NestedAgreeConfig :=
   standardConfig tProbe aT aDPdat aV aDPnom aDPdat
-    (fun y => decide (y ≠ SO.lexLeaf aDPdat))
+    (fun y => decide (y ≠ SyntacticObject.lexLeaf aDPdat))
 
 /-- Ordering B is *not* well-formed: the chosen goal is φ-defective.
     The formal expression of "default agreement surfaces because
@@ -251,10 +251,10 @@ def lakPerfective : NestedAgreeConfig :=
 theorem lakPerfective_is_nested : IsNestedAgreeConfig lakPerfective := by decide
 
 theorem lakPerfective_runStack_0 :
-    runStack lakPerfective 0 = some (SO.lexLeaf aV) := by decide
+    runStack lakPerfective 0 = some (SyntacticObject.lexLeaf aV) := by decide
 
 theorem lakPerfective_runStack_1 :
-    runStack lakPerfective 1 = some (SO.lexLeaf aV) := by decide
+    runStack lakPerfective 1 = some (SyntacticObject.lexLeaf aV) := by decide
 
 /-- **Apparent ergative intervention is not actual.** The ergative
     subject is in Asp's c-command (probe 0's domain) but is *not* in
@@ -268,9 +268,9 @@ theorem lakPerfective_runStack_1 :
     presence. Surface result: agreement with Abs (transitively
     through v's prior cyclic Agree). -/
 theorem lakPerfective_excludes_ergative :
-    SO.lexLeaf aErg ∈ lakPerfective.searchDomain 0 ∧
-    SO.lexLeaf aErg ∉ lakPerfective.searchDomain 1 :=
-  apparent_intervener_excluded lakPerfective 0 (SO.lexLeaf aErg)
+    SyntacticObject.lexLeaf aErg ∈ lakPerfective.searchDomain 0 ∧
+    SyntacticObject.lexLeaf aErg ∉ lakPerfective.searchDomain 1 :=
+  apparent_intervener_excluded lakPerfective 0 (SyntacticObject.lexLeaf aErg)
     (by decide) (by decide)
 
 end Lak

--- a/Linglib/Studies/Amato2025Auxiliary.lean
+++ b/Linglib/Studies/Amato2025Auxiliary.lean
@@ -329,7 +329,7 @@ private def perfProbe : Probe.Profile := ⟨.T, some .C⟩
     φ-active iff `VIsPhiActive c`; all other heads are phi-active. -/
 def toNestedConfig (c : RestructuringClauseAmato) : NestedAgreeConfig :=
   standardConfig perfProbe aT aDPsubj aV aDPobj aV
-    (fun y => if y = SO.lexLeaf aV then decide (VIsPhiActive c) else true)
+    (fun y => if y = SyntacticObject.lexLeaf aV then decide (VIsPhiActive c) else true)
 
 /-- Every Amato clause whose v is φ-active yields a well-formed Nested
     Agree configuration. The precondition is structurally meaningful
@@ -346,15 +346,15 @@ theorem amato_clause_is_nested (c : RestructuringClauseAmato)
   rw [Multiset.mem_filter]
   refine ⟨?_, ?_⟩
   · -- .leaf aV ∈ standardLinearTree _.subtrees: purely structural after unfold.
-    show SO.lexLeaf aV ∈
+    show SyntacticObject.lexLeaf aV ∈
       (standardLinearTree aT aDPsubj aV aDPobj).subtrees
     decide
   · -- (decide (cCommandsIn _ perf v) && validGoal v) = true
     rw [Bool.and_eq_true]
     refine ⟨?_, ?_⟩
     · -- Perf c-commands v in the standardLinearTree: purely structural.
-      show decide (SO.cCommandsIn (standardLinearTree aT aDPsubj aV aDPobj)
-        (SO.lexLeaf aT) (SO.lexLeaf aV)) = true
+      show decide (SyntacticObject.cCommandsIn (standardLinearTree aT aDPsubj aV aDPobj)
+        (SyntacticObject.lexLeaf aT) (SyntacticObject.lexLeaf aV)) = true
       decide
     · -- validGoal (.leaf aV) = decide (VIsPhiActive c) = true (from h).
       show (decide (VIsPhiActive c)) = true
@@ -379,7 +379,7 @@ theorem personAgree_iff_runStack_hits (c : RestructuringClauseAmato) :
       decide
     · -- goalHead ∈ searchDomain 1 = daughters; reflexively in its
       -- own daughters when phi-active.
-      show SO.lexLeaf aV ∈ (toNestedConfig c).searchDomain 1
+      show SyntacticObject.lexLeaf aV ∈ (toNestedConfig c).searchDomain 1
       rw [searchDomain_succ]
       exact goalHead_mem_daughters _ (amato_clause_is_nested c h)
   · rintro ⟨_, hMem⟩

--- a/Linglib/Studies/ArregiPietraszko2021.lean
+++ b/Linglib/Studies/ArregiPietraszko2021.lean
@@ -133,7 +133,7 @@ structure GenHMRelation where
   /-- The containing tree -/
   root : SyntacticObject
   /-- Structural condition: probe c-commands goal -/
-  probe_commands_goal : SO.cCommandsIn root probe goal
+  probe_commands_goal : SyntacticObject.cCommandsIn root probe goal
   /-- The goal bears valued M-features -/
   goal_has_mvalue : hasValuedFeature mValue feature = true
   /-- The probe bears unvalued M-features -/

--- a/Linglib/Studies/Bruening2001.lean
+++ b/Linglib/Studies/Bruening2001.lean
@@ -139,7 +139,7 @@ def qrIsBlocked (q : PositionedQuantifier) : Option QRBarrier :=
     tree derivation. -/
 def superiorityFromTree (tree : SyntacticObject)
     (q1 q2 : SyntacticObject) : Bool :=
-  decide (SO.asymCCommandsIn tree q1 q2)
+  decide (SyntacticObject.asymCCommandsIn tree q1 q2)
 
 -- Scope Economy ([fox-2000])
 
@@ -172,14 +172,14 @@ def economyBlocksQR (e : ScopeEconomy) : Bool :=
 
     This derives the previously-stipulated `QRBarrier.dpPhase` from deeper
     principles: PIC makes DP-internal material inaccessible to operations outside
-    DP. On the MCB-faithful `SO` phase API the **interior Φ°_ℓ *is* the head's
+    DP. On the MCB-faithful `SyntacticObject` phase API the **interior Φ°_ℓ *is* the head's
     c-command domain** (Def 1.14.3, "Z is the interior of the phase"), so a goal
-    in that domain is impenetrable by construction (`SO.mem_phaseInterior`). -/
+    in that domain is impenetrable by construction (`SyntacticObject.mem_phaseInterior`). -/
 theorem dp_phase_barrier_from_pic (φ : Phase) {goal : SyntacticObject}
     (hacc : goal ∈ φ.tree.Acc)
-    (hcc : φ.tree.cCommandsIn (SO.lexLeaf φ.head) goal) :
+    (hcc : φ.tree.cCommandsIn (SyntacticObject.lexLeaf φ.head) goal) :
     φ.Impenetrable goal :=
-  SO.mem_phaseInterior.mpr ⟨hacc, hcc⟩
+  SyntacticObject.mem_phaseInterior.mpr ⟨hacc, hcc⟩
 
 end Scope
 
@@ -521,7 +521,7 @@ structure MinimalistScopeConfig where
 
 /-- Check if superiority blocks QR in this configuration.
 
-    When a tree and SO positions are provided, superiority is DERIVED
+    When a tree and SyntacticObject positions are provided, superiority is DERIVED
     from asymmetric c-command. Otherwise falls back to the freezing
     context annotation. -/
 def superiorityBlocked (config : MinimalistScopeConfig) : Bool :=
@@ -594,10 +594,10 @@ c-commands the theme in complement of Appl. QR of the theme over the goal
 is blocked by superiority, derived from c-command rather than stipulated.
 
 The Voice + low-Appl tree is rebuilt locally (planar-first, since the smart
-Merge `SO.node` is noncomputable) so this study stays self-contained and the
+Merge `SyntacticObject.node` is noncomputable) so this study stays self-contained and the
 `decide` proof reduces. It mirrors `Pylkkanen2008.ditransitiveTree`'s
 structure (`[John [Voice [sent [Mary [Appl letter]]]]]`); a future dedup can
-re-point at that tree once the `SO`-carrier flip reaches `Studies/Pylkkanen2008`. -/
+re-point at that tree once the `SyntacticObject`-carrier flip reaches `Studies/Pylkkanen2008`. -/
 
 /-- Voice[AG] head (introduces the external argument, [kratzer-1996]). -/
 def voice_ag_t  : Minimalist.LIToken := ⟨.simple .Voice [.V] "Voice[AG]", 400⟩
@@ -617,12 +617,13 @@ def DP_letter_t : Minimalist.LIToken := ⟨.simple .D [] "a letter", 408⟩
     Spec-ApplP asymmetrically c-commands the theme (a letter) in the
     complement of Appl — the [barss-lasnik-1986] asymmetry, structural. -/
 def ditransitiveTree : Minimalist.SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP DP_john_t)
-      (SO.nodeP (SO.leafP voice_ag_t)
-        (SO.nodeP (SO.leafP V_sent_t)
-          (SO.nodeP (SO.leafP DP_mary_t)
-            (SO.nodeP (SO.leafP appl_low_t) (SO.leafP DP_letter_t))))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP DP_john_t)
+      (SyntacticObject.nodeP (SyntacticObject.leafP voice_ag_t)
+        (SyntacticObject.nodeP (SyntacticObject.leafP V_sent_t)
+          (SyntacticObject.nodeP (SyntacticObject.leafP DP_mary_t)
+            (SyntacticObject.nodeP (SyntacticObject.leafP appl_low_t)
+              (SyntacticObject.leafP DP_letter_t))))))
 
 /-- DOC scope freezing config with the local low-Appl tree:
     superiority is derived from goal asymmetrically c-commanding theme
@@ -630,10 +631,10 @@ def ditransitiveTree : Minimalist.SyntacticObject :=
 def docScopeConfig : MinimalistScopeConfig :=
   { q1 := { quantifier := "every worker"
            , position := .specVP
-           , so := some (SO.lexLeaf DP_mary_t) }
+           , so := some (SyntacticObject.lexLeaf DP_mary_t) }
   , q2 := { quantifier := "a paycheck"
            , position := .specVP
-           , so := some (SO.lexLeaf DP_letter_t) }
+           , so := some (SyntacticObject.lexLeaf DP_letter_t) }
   , freezingContext := .doubleObject
   , tree := some ditransitiveTree }
 

--- a/Linglib/Studies/Chomsky1981.lean
+++ b/Linglib/Studies/Chomsky1981.lean
@@ -75,7 +75,7 @@ combine it with English's binding-class classifier.
 /-! #### C-command from tree geometry -/
 
 /-- Convert a word to a Minimalist lexical-item token (UPOS mapped to `Cat`,
-    phonological form attached). The smart Merge `SO.node` is noncomputable, so
+    phonological form attached). The smart Merge `SyntacticObject.node` is noncomputable, so
     concrete trees are built planar-first from these tokens and `decide`d over. -/
 private def wordTok (w : Word) (id : Nat) : LIToken :=
   ⟨.simple (uposToCat w.cat) [] w.form, id⟩
@@ -85,24 +85,26 @@ private def wordTok (w : Word) (id : Nat) : LIToken :=
     `{subj, verb}`. C-command follows from the geometry. Built planar-first so
     the containment / c-command decision procedures reduce. -/
 def toSyntacticObject (clause : SimpleClause) : SyntacticObject :=
-  let subjP := SO.leafP (wordTok clause.subject 0)
-  let verbP := SO.leafP (wordTok clause.verb 1)
+  let subjP := SyntacticObject.leafP (wordTok clause.subject 0)
+  let verbP := SyntacticObject.leafP (wordTok clause.verb 1)
   match clause.object with
-  | none => SO.ofPlanar (SO.nodeP subjP verbP)
-  | some obj => SO.ofPlanar (SO.nodeP subjP (SO.nodeP verbP (SO.leafP (wordTok obj 2))))
+  | none => SyntacticObject.ofPlanar (SyntacticObject.nodeP subjP verbP)
+  | some obj =>
+    SyntacticObject.ofPlanar (SyntacticObject.nodeP subjP
+      (SyntacticObject.nodeP verbP (SyntacticObject.leafP (wordTok obj 2))))
 
 private def subjectSO (clause : SimpleClause) : SyntacticObject :=
-  SO.lexLeaf (wordTok clause.subject 0)
+  SyntacticObject.lexLeaf (wordTok clause.subject 0)
 
 private def objectSO? (clause : SimpleClause) : Option SyntacticObject :=
-  clause.object.map fun obj => SO.lexLeaf (wordTok obj 2)
+  clause.object.map fun obj => SyntacticObject.lexLeaf (wordTok obj 2)
 
 /-- Subject c-commands object: in `{subj, {verb, obj}}`, the subject's sister
     `{verb, obj}` contains the object. -/
 def subjectCCommandsObject (clause : SimpleClause) : Prop :=
   match objectSO? clause with
   | none => False
-  | some objSO => SO.cCommandsIn (toSyntacticObject clause) (subjectSO clause) objSO
+  | some objSO => SyntacticObject.cCommandsIn (toSyntacticObject clause) (subjectSO clause) objSO
 
 instance (clause : SimpleClause) : Decidable (subjectCCommandsObject clause) := by
   unfold subjectCCommandsObject; cases objectSO? clause <;> infer_instance
@@ -112,7 +114,7 @@ instance (clause : SimpleClause) : Decidable (subjectCCommandsObject clause) := 
 def objectCCommandsSubject (clause : SimpleClause) : Prop :=
   match objectSO? clause with
   | none => False
-  | some objSO => SO.cCommandsIn (toSyntacticObject clause) objSO (subjectSO clause)
+  | some objSO => SyntacticObject.cCommandsIn (toSyntacticObject clause) objSO (subjectSO clause)
 
 instance (clause : SimpleClause) : Decidable (objectCCommandsSubject clause) := by
   unfold objectCCommandsSubject; cases objectSO? clause <;> infer_instance
@@ -122,8 +124,8 @@ def sameLocalDomain (clause : SimpleClause) : Prop :=
   match objectSO? clause with
   | none => True
   | some objSO =>
-    SO.contains (toSyntacticObject clause) (subjectSO clause) ∧
-    SO.contains (toSyntacticObject clause) objSO
+    SyntacticObject.contains (toSyntacticObject clause) (subjectSO clause) ∧
+    SyntacticObject.contains (toSyntacticObject clause) objSO
 
 instance (clause : SimpleClause) : Decidable (sameLocalDomain clause) := by
   unfold sameLocalDomain; cases objectSO? clause <;> infer_instance
@@ -244,7 +246,8 @@ def complementaryDistributionData : PhenomenonData := {
 /-- Reciprocals require a plural/coordinated antecedent and local binding. -/
 def reciprocalCoreferenceData : PhenomenonData := {
   name := "Reciprocal Coreference"
-  generalization := "Reciprocals require a c-commanding semantically plural antecedent in the local domain"
+  generalization :=
+    "Reciprocals require a c-commanding semantically plural antecedent in the local domain"
   pairs := [
     -- Coordinated antecedent required
     { lhs := [sam, and_, pat, saw, eachOther]

--- a/Linglib/Studies/Chomsky1995.lean
+++ b/Linglib/Studies/Chomsky1995.lean
@@ -31,15 +31,16 @@ def verbToSelStack (v : VerbEntry) : SelStack :=
 
 /-- A `VerbEntry` as a `SyntacticObject` leaf (`Cat = .V`, selStack from `complementType`). -/
 def verbToSO (v : VerbEntry) (id : Nat) : SyntacticObject :=
-  SO.mkLeafPhon .V (verbToSelStack v) v.form3sg id
+  SyntacticObject.mkLeafPhon .V (verbToSelStack v) v.form3sg id
 
 /-- A `NounEntry` as a leaf: proper names project as `.D`, common nouns as bare `.N`. -/
 def nounToSO (n : NounEntry) (id : Nat) : SyntacticObject :=
-  if n.proper then SO.mkLeafPhon .D [] n.formSg id else SO.mkLeafPhon .N [] n.formSg id
+  if n.proper then SyntacticObject.mkLeafPhon .D [] n.formSg id
+  else SyntacticObject.mkLeafPhon .N [] n.formSg id
 
 /-- "John sees Mary" as a Minimalist Merge derivation: *see*'s complement
     is *Mary* (`emR`), then *John* is added as specifier (`emL`). -/
-def john_sees_mary : SO.Derivation :=
+def john_sees_mary : SyntacticObject.Derivation :=
   { initial := verbToSO English.Predicates.Verbal.see 31
     steps   := [.emR (nounToSO English.Nouns.mary 11),
                 .emL (nounToSO English.Nouns.john 10)] }
@@ -47,7 +48,7 @@ def john_sees_mary : SO.Derivation :=
 /-- The phonological yield of `john_sees_mary` is the SVO string
     "John sees Mary": the Minimalist derivation (built by `emR` then
     `emL` over `verbToSO`/`nounToSO`) linearizes subject-verb-object via the
-    derivation-grounded computable externalization (`SO.Derivation.surfacePhon`). -/
+    derivation-grounded computable externalization (`SyntacticObject.Derivation.surfacePhon`). -/
 theorem models_svo_word_order :
     String.intercalate " " john_sees_mary.surfacePhon = "John sees Mary" := by decide
 

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -20,15 +20,18 @@ require a *wrong Merge order* of the modifiers).
 
 ## What this file establishes
 
-This study runs Cinque's derivations on the **single MCB `SO` carrier**
+This study runs Cinque's derivations on the **single MCB `SyntacticObject` carrier**
 (`Syntax/Minimalist/SyntacticObject/Derivation.lean`): each order is an
-`SO.Derivation` (fixed-order External Merge to build the base, then `SO.Step.im`
+`SyntacticObject.Derivation` (fixed-order External Merge to build the base, then
+`SyntacticObject.Step.im`
 leftward movements), and the surface order is read off by the computable
-`SO.Derivation.surfaceCats` (derivation-grounded externalization — MCB σ_L, not
+`SyntacticObject.Derivation.surfaceCats` (derivation-grounded externalization — MCB σ_L, not
 `Quot.out`). The orders are verified by `decide`. Internal Merge is **index-free**
-(`SO.Step.im mover`, no trace id); the trace it leaves is the bare `SO.traceLeaf`,
+(`SyntacticObject.Step.im mover`, no trace id); the trace it leaves is the bare
+`SyntacticObject.traceLeaf`,
 and pied-piping movers (which contain an earlier trace) are built planar-first via
-the computable DSL (`SO.ofPlanar`/`SO.nodeP`/`SO.leafP`/`SO.traceP`).
+the computable DSL (`SyntacticObject.ofPlanar`/`SyntacticObject.nodeP`/`SyntacticObject.leafP`/
+`SyntacticObject.traceP`).
 
 **Eight of the fourteen attested orders are derived explicitly here** (the
 bare-NP-raising series a–d and the pied-piping cases n, o, t, x), demonstrating
@@ -54,13 +57,13 @@ open RootedTree
 /-! ### The four elements (head-initial leaves) -/
 
 /-- Noun (the raising NP). -/
-def noun : SyntacticObject := SO.mkLeaf .N [] 1
+def noun : SyntacticObject := SyntacticObject.mkLeaf .N [] 1
 /-- Adjective. -/
-def adj : SyntacticObject := SO.mkLeaf .A [] 2
+def adj : SyntacticObject := SyntacticObject.mkLeaf .A [] 2
 /-- Numeral. -/
-def numl : SyntacticObject := SO.mkLeaf .Num [] 3
+def numl : SyntacticObject := SyntacticObject.mkLeaf .Num [] 3
 /-- Demonstrative (encoded as `.D`; see module note). -/
-def dem : SyntacticObject := SO.mkLeaf .D [] 4
+def dem : SyntacticObject := SyntacticObject.mkLeaf .D [] 4
 
 /-! ### Frequency buckets and the 24-order attestation table ([cinque-2005] (6))
 
@@ -121,57 +124,65 @@ theorem table_freq_consistent :
 /-! ### Derivations on the MCB substrate
 
 Built bottom-up: `initial := noun`, then head-initial External Merge of A, Num,
-Dem (`emL`), interleaved with `SO.Step.im` leftward raising. `surfaceCats` reads
+Dem (`emL`), interleaved with `SyntacticObject.Step.im` leftward raising. `surfaceCats` reads
 off the order via the computable derivation-grounded externalization.
 
 Movers: a bare NP raise passes `noun`; a pied-piping raise passes the
-NP-containing constituent (which contains the earlier `SO.traceLeaf`), built with
+NP-containing constituent (which contains the earlier `SyntacticObject.traceLeaf`), built with
 the planar DSL so the surface orders `decide`. -/
 
 /-- The four leaf tokens, used to build pied-piping movers planar-first. -/
-private def pN : RoseTree SOLabel := SO.leafP ⟨.simple .N [], 1⟩
-private def pA : RoseTree SOLabel := SO.leafP ⟨.simple .A [], 2⟩
-private def pNum : RoseTree SOLabel := SO.leafP ⟨.simple .Num [], 3⟩
+private def pN : RoseTree SOLabel := SyntacticObject.leafP ⟨.simple .N [], 1⟩
+private def pA : RoseTree SOLabel := SyntacticObject.leafP ⟨.simple .A [], 2⟩
+private def pNum : RoseTree SOLabel := SyntacticObject.leafP ⟨.simple .Num [], 3⟩
 
 /-- The pied-piped `[N [A t]]` mover (N raised around A, then the whole `[A t]`
     with N on top). -/
-def movNAt : SyntacticObject := SO.ofPlanar (SO.nodeP pN (SO.nodeP pA SO.traceP))
+def movNAt : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP pN (SyntacticObject.nodeP pA SyntacticObject.traceP))
 /-- The pied-piped `[A N]` mover. -/
-def movAN : SyntacticObject := SO.ofPlanar (SO.nodeP pA pN)
+def movAN : SyntacticObject := SyntacticObject.ofPlanar (SyntacticObject.nodeP pA pN)
 /-- The pied-piped `[N [A t]]` constituent raised again past Num, with the Num
     sub-trace: `[N [Num [t [A t]]]]` — the (t) roll-up's third mover. -/
 def movNNumAt : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP pN (SO.nodeP pNum (SO.nodeP SO.traceP (SO.nodeP pA SO.traceP))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP pN
+    (SyntacticObject.nodeP pNum
+      (SyntacticObject.nodeP SyntacticObject.traceP
+        (SyntacticObject.nodeP pA SyntacticObject.traceP))))
 /-- The successive pied-pipe past Num for (x): `[[N [A t]] [Num t]]`. -/
 def movNAtNum : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.nodeP pN (SO.nodeP pA SO.traceP)) (SO.nodeP pNum SO.traceP))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP
+    (SyntacticObject.nodeP pN (SyntacticObject.nodeP pA SyntacticObject.traceP))
+    (SyntacticObject.nodeP pNum SyntacticObject.traceP))
 
 /-- (a) Dem Num A N — no movement. -/
-def derA : SO.Derivation := ⟨noun, [.emL adj, .emL numl, .emL dem]⟩
+def derA : SyntacticObject.Derivation := ⟨noun, [.emL adj, .emL numl, .emL dem]⟩
 
 /-- (b) Dem Num N A — NP raises around A (bare). -/
-def derB : SO.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .emL dem]⟩
+def derB : SyntacticObject.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .emL dem]⟩
 
 /-- (c) Dem N Num A — NP raises around A then Num (partial, bare). -/
-def derC : SO.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem]⟩
+def derC : SyntacticObject.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem]⟩
 
 /-- (d) N Dem Num A — NP raises around A, Num, Dem (total, bare). -/
-def derD : SO.Derivation :=
+def derD : SyntacticObject.Derivation :=
   ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem, .im noun]⟩
 
 /-- (n) Dem A N Num — pied-pipe `[A N]` around Num (no sub-raise). -/
-def derN : SO.Derivation := ⟨noun, [.emL adj, .emL numl, .im movAN, .emL dem]⟩
+def derN : SyntacticObject.Derivation := ⟨noun, [.emL adj, .emL numl, .im movAN, .emL dem]⟩
 
 /-- (o) Dem N A Num — raise N around A, then pied-pipe `[N A]` around Num. -/
-def derO : SO.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .im movNAt, .emL dem]⟩
+def derO : SyntacticObject.Derivation :=
+  ⟨noun, [.emL adj, .im noun, .emL numl, .im movNAt, .emL dem]⟩
 
 /-- (t) N Num A Dem — bare raise around A and Num, then pied-pipe `[N Num A]`
     around Dem. -/
-def derT : SO.Derivation :=
+def derT : SyntacticObject.Derivation :=
   ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem, .im movNNumAt]⟩
 
 /-- (x) N A Num Dem — successive pied-piping all the way up (the roll-up). -/
-def derX : SO.Derivation :=
+def derX : SyntacticObject.Derivation :=
   ⟨noun, [.emL adj, .im noun, .emL numl, .im movNAt, .emL dem, .im movNAtNum]⟩
 
 /-! ### The eight derivations produce their attested orders (kernel-checked) -/
@@ -213,7 +224,7 @@ private def tokA : LIToken := ⟨.simple .A [], 2⟩
 private def tokNum : LIToken := ⟨.simple .Num [], 3⟩
 private def tokD : LIToken := ⟨.simple .D [], 4⟩
 
-/-- Does the planar structure contain the noun leaf? (Canonical SO trees are
+/-- Does the planar structure contain the noun leaf? (Canonical SyntacticObject trees are
     binary: a leaf is `.node _ []`, an internal node `.node _ [l, r]`.) -/
 private def pHasN : RoseTree SOLabel → Bool
   | .node (.inl t) _ => t == tokN
@@ -233,10 +244,10 @@ private def pMovers (cur : RoseTree SOLabel) : List (RoseTree SOLabel) :=
   (pSubtrees cur).filter (fun s => pHasN s && s != cur)
 
 /-- Raise the first subtree equal to `s` to the LEFT edge, leaving the bare trace
-    `SO.traceP` (planar leftward movement) — `none` if `s` is absent. -/
+    `SyntacticObject.traceP` (planar leftward movement) — `none` if `s` is absent. -/
 private def pMoveLeft (s : RoseTree SOLabel) (cur : RoseTree SOLabel) : Option (RoseTree SOLabel) :=
   if (pSubtrees cur).contains s then
-    some (SO.nodeP s (planarReplaceWhereP (· == s) SO.traceP cur))
+    some (SyntacticObject.nodeP s (planarReplaceWhereP (· == s) SyntacticObject.traceP cur))
   else none
 
 /-- At a spec: keep, or raise one eligible mover (leftward). -/
@@ -246,9 +257,10 @@ private def pOpt (cur : RoseTree SOLabel) : List (RoseTree SOLabel) :=
 /-- The whole legal derivation space (planar externalizations): merge A, Num, Dem
     head-initially with an optional raise at each spec. -/
 private def space : List (RoseTree SOLabel) :=
-  ([SO.leafP tokN].map (fun c => SO.nodeP (SO.leafP tokA) c)).flatMap pOpt
-    |>.map (fun c => SO.nodeP (SO.leafP tokNum) c) |>.flatMap pOpt
-    |>.map (fun c => SO.nodeP (SO.leafP tokD) c)   |>.flatMap pOpt
+  ([SyntacticObject.leafP tokN].map
+      (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokA) c)).flatMap pOpt
+    |>.map (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokNum) c) |>.flatMap pOpt
+    |>.map (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokD) c)   |>.flatMap pOpt
 
 /-- The distinct surface orders reachable by Cinque's movement. -/
 def reachableOrders : List (List Cat) :=
@@ -369,9 +381,9 @@ private def stepCost (build : RoseTree SOLabel → RoseTree SOLabel) (p : RoseTr
 /-- The legal derivation space (as in `space`) carrying accumulated local
     marked-move cost. -/
 private def spaceCost : List (RoseTree SOLabel × Nat) :=
-  [(SO.nodeP (SO.leafP tokA) (SO.leafP tokN), 0)]
-    |>.flatMap (stepCost (fun c => SO.nodeP (SO.leafP tokNum) c))
-    |>.flatMap (stepCost (fun c => SO.nodeP (SO.leafP tokD) c))
+  [(SyntacticObject.nodeP (SyntacticObject.leafP tokA) (SyntacticObject.leafP tokN), 0)]
+    |>.flatMap (stepCost (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokNum) c))
+    |>.flatMap (stepCost (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokD) c))
     |>.flatMap (stepCost id)
 
 /-- **Derived** local proxy: the minimum number of locally-marked moves over the

--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -165,7 +165,7 @@ structure SharedNode where
 
     **Substrate note (post-MCB Phase 1.0).** The `conjunct1` / `conjunct2`
     field names are **stipulated planar labels** at the coord-structure
-    *meta*-level, NOT inherited from the SO substrate (which is nonplanar
+    *meta*-level, NOT inherited from the SyntacticObject substrate (which is nonplanar
     via FreeCommMagma — see `Minimalist.merge_comm`). The first-vs-second
     conjunct distinction tracked by these fields is a *coordination-
     specific stipulation* about which conjunct hosts the shared / deleted
@@ -776,13 +776,13 @@ theorem cs_twoEFeature_wholeDeriv_pf_differs :
 /-- The adopted CWH structure: non-bulk-sharing MD, no ellipsis (paper's (10b)).
     Shared nodes: C and T are individually multiply dominated. -/
 def cwhStructure : PFReducedCoordination where
-  conjunct1 := SO.mkLeaf .C [] 0
-  conjunct2 := SO.mkLeaf .C [] 1
+  conjunct1 := SyntacticObject.mkLeaf .C [] 0
+  conjunct2 := SyntacticObject.mkLeaf .C [] 1
   mechanisms := [.multidominance]
   sharing := some .nonBulk
   sharedNodes :=
-    [ { node := SO.mkLeaf .C [] 10, category := some .C, pronounced := true }
-    , { node := SO.mkLeaf .T [] 11, category := some .T, pronounced := false } ]
+    [ { node := SyntacticObject.mkLeaf .C [] 10, category := some .C, pronounced := true }
+    , { node := SyntacticObject.mkLeaf .T [] 11, category := some .T, pronounced := false } ]
   pfOutput := ["what", "and", "when", "should", "you", "teach"]
 
 /-- The adopted CS structure: bulk-sharing MD + ellipsis (paper's (20b)).
@@ -790,14 +790,14 @@ def cwhStructure : PFReducedCoordination where
     triggers TP deletion, repairing the MWF violation at the vP edge.
     Shared nodes: entire C' is shared (includes C, TP, vP, VP). -/
 def csStructure : PFReducedCoordination where
-  conjunct1 := SO.mkLeaf .C [] 0
-  conjunct2 := SO.mkLeaf .C [] 1
+  conjunct1 := SyntacticObject.mkLeaf .C [] 0
+  conjunct2 := SyntacticObject.mkLeaf .C [] 1
   mechanisms := [.multidominance, .ellipsis]
   sharing := some .bulk
   sharedNodes :=
-    [ { node := SO.mkLeaf .C [] 10, category := some .C, pronounced := true }
-    , { node := SO.mkLeaf .T [] 11, category := some .T, pronounced := false }
-    , { node := SO.mkLeaf .v [] 12, category := some .v, pronounced := false } ]
+    [ { node := SyntacticObject.mkLeaf .C [] 10, category := some .C, pronounced := true }
+    , { node := SyntacticObject.mkLeaf .T [] 11, category := some .T, pronounced := false }
+    , { node := SyntacticObject.mkLeaf .v [] 12, category := some .v, pronounced := false } ]
   pfOutput := ["what", "and", "when"]
 
 /-- Structural drift sentry over the four key properties of cwhStructure
@@ -920,13 +920,15 @@ def rnr_pureMD : RNRDatum :=
 /-- Ellipsis + MD: verb morphology mismatch forces ellipsis for VP,
     but PP pivot is still shared via MD (ex 52/53). -/
 def rnr_ellipsisPlusMD : RNRDatum :=
-  { sentence := "Alice must work on different topics, and Iris ought to be working on different topics."
+  { sentence :=
+    "Alice must work on different topics, and Iris ought to be working on different topics."
   , pivot := "on different topics"
   , morphologicalIdentity := false
   , mdProperties := true
   , involvesEllipsis := true
   , pivotType := .minimal
-  , notes := "Morphological mismatch (work vs working); PP shared via MD, VP ellipsis in first conjunct" }
+  , notes :=
+    "Morphological mismatch (work vs working); PP shared via MD, VP ellipsis in first conjunct" }
 
 /-- Vehicle-change diagnostic from [barros-vicente-2011] ex (47):
     morphological mismatch signals ellipsis (not MD).

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -34,13 +34,14 @@ base-generation. Three lines of evidence converge:
 
 ## Carrier note (P4 single-carrier flip)
 
-On the MCB-faithful `SO` carrier, Merge (`SO.node`/`*`) is noncomputable,
-so `SO.Derivation.final`/`.stageAt` do not `decide`. The computable layers —
+On the MCB-faithful `SyntacticObject` carrier, Merge (`SyntacticObject.node`/`*`) is noncomputable,
+so `SyntacticObject.Derivation.final`/`.stageAt` do not `decide`. The computable layers —
 `movedItems` and the externalized surface order (`surfacePhon`) — are proved
-over the `SO.Derivation` directly. The c-command predictions are stated over
-the **derived/base trees built planar-first** (`SO.ofPlanar (SO.nodeP …)`),
+over the `SyntacticObject.Derivation` directly. The c-command predictions are stated over
+the **derived/base trees built planar-first** (`SyntacticObject.ofPlanar (SyntacticObject.nodeP
+…)`),
 i.e. the very trees each derivation produces, written out explicitly per the
-prose diagrams; c-command (`SO.cCommandsIn`) reduces on those.
+prose diagrams; c-command (`SyntacticObject.cCommandsIn`) reduces on those.
 
 ## Simplification
 
@@ -100,19 +101,19 @@ open RootedTree
 -- ============================================================================
 
 /-- "mangatuk" — ACT-hit (active voice transitive verb). -/
-def v_mangatuk := SO.mkLeafPhon .V [] "mangatuk" 1
+def v_mangatuk := SyntacticObject.mkLeafPhon .V [] "mangatuk" 1
 
 /-- "biangi" — dog-DEF (definite object DP). -/
-def n_biangi := SO.mkLeafPhon .N [] "biangi" 2
+def n_biangi := SyntacticObject.mkLeafPhon .N [] "biangi" 2
 
 /-- "dakdanakan" — child-that (subject DP). -/
-def n_dakdanakan := SO.mkLeafPhon .N [] "dakdanakan" 3
+def n_dakdanakan := SyntacticObject.mkLeafPhon .N [] "dakdanakan" 3
 
 /-- Little v (silent, selects VP). -/
-def v_head := SO.mkLeaf .v [.V] 4
+def v_head := SyntacticObject.mkLeaf .v [.V] 4
 
 /-- T (silent, selects vP). -/
-def t_head := SO.mkLeaf .T [.v] 5
+def t_head := SyntacticObject.mkLeaf .T [.v] 5
 
 /-! Planar leaf tokens for building the result/base trees. -/
 
@@ -125,10 +126,12 @@ private def tok_t          : LIToken := ⟨.simple .T [.v], 5⟩
 /-- The VP constituent `[VP V Obj]` — the phrase that raises. Built
     planar-first so containment over it `decide`s. -/
 def vp : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tok_mangatuk) (SO.leafP tok_biangi))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_mangatuk) (SyntacticObject.leafP tok_biangi))
 
 /-- The VP as a planar subtree (for embedding in larger result trees). -/
-private def vpP : RoseTree SOLabel := SO.nodeP (SO.leafP tok_mangatuk) (SO.leafP tok_biangi)
+private def vpP : RoseTree SOLabel :=
+  SyntacticObject.nodeP (SyntacticObject.leafP tok_mangatuk) (SyntacticObject.leafP tok_biangi)
 
 -- ============================================================================
 -- § 2: Toba Batak VOS Derivation
@@ -142,7 +145,7 @@ private def vpP : RoseTree SOLabel := SO.nodeP (SO.leafP tok_mangatuk) (SO.leafP
     3. EM-L Subj → `[vP Subj [v' v VP]]`
     4. EM-L T  → `[TP T [vP Subj [v' v VP]]]`
     5. IM VP   → `[TP VP [T' T [vP Subj [v' v tVP]]]]` -/
-def tobaBatakVOS : SO.Derivation :=
+def tobaBatakVOS : SyntacticObject.Derivation :=
   { initial := v_mangatuk
     steps := [
       .emR n_biangi,
@@ -155,30 +158,30 @@ def tobaBatakVOS : SO.Derivation :=
 /-- The VOS **base** tree at stage 4 (pre-movement):
     `[TP T [vP Subj [v' v [VP V Obj]]]]`. Built planar-first. -/
 def tobaBatakBaseTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_t)
-      (SO.nodeP (SO.leafP tok_dakdanakan)
-        (SO.nodeP (SO.leafP tok_v) vpP)))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_t)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_dakdanakan)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_v) vpP)))
 
 /-- The VOS **derived** tree after VP-raising:
     `[TP [VP V Obj] [T' T [vP Subj [v' v tVP]]]]`. The raised VP sits at
     the left edge; the original VP position is the bare trace. -/
 def tobaBatakDerivedTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP vpP
-      (SO.nodeP (SO.leafP tok_t)
-        (SO.nodeP (SO.leafP tok_dakdanakan)
-          (SO.nodeP (SO.leafP tok_v) SO.traceP))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP vpP
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_t)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_dakdanakan)
+          (SyntacticObject.nodeP (SyntacticObject.leafP tok_v) SyntacticObject.traceP))))
 
 -- ============================================================================
 -- § 3: English SVO Derivation (Comparison)
 -- ============================================================================
 
-def v_saw   := SO.mkLeafPhon .V [] "saw" 11
-def n_mary  := SO.mkLeafPhon .N [] "Mary" 12
-def n_john  := SO.mkLeafPhon .N [] "John" 13
-def v_head2 := SO.mkLeaf .v [.V] 14
-def t_head2 := SO.mkLeaf .T [.v] 15
+def v_saw   := SyntacticObject.mkLeafPhon .V [] "saw" 11
+def n_mary  := SyntacticObject.mkLeafPhon .N [] "Mary" 12
+def n_john  := SyntacticObject.mkLeafPhon .N [] "John" 13
+def v_head2 := SyntacticObject.mkLeaf .v [.V] 14
+def t_head2 := SyntacticObject.mkLeaf .T [.v] 15
 
 private def tok_saw   : LIToken := ⟨.simple .V [] (phonForm := "saw"), 11⟩
 private def tok_mary_en : LIToken := ⟨.simple .N [] (phonForm := "Mary"), 12⟩
@@ -189,7 +192,7 @@ private def tok_t2    : LIToken := ⟨.simple .T [.v], 15⟩
 /-- English SVO via subject-raising to Spec,TP.
 
     Same base as Toba Batak, but the subject (not VP) moves to Spec,TP. -/
-def englishSVO : SO.Derivation :=
+def englishSVO : SyntacticObject.Derivation :=
   { initial := v_saw
     steps := [
       .emR n_mary,
@@ -203,11 +206,12 @@ def englishSVO : SO.Derivation :=
     `[TP T [vP John [v' v [VP saw Mary]]]]`. Built planar-first; same shape
     as `tobaBatakBaseTree`, modulo lexical content. -/
 def englishBaseTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_t2)
-      (SO.nodeP (SO.leafP tok_john_en)
-        (SO.nodeP (SO.leafP tok_v2)
-          (SO.nodeP (SO.leafP tok_saw) (SO.leafP tok_mary_en)))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_t2)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_john_en)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_v2)
+          (SyntacticObject.nodeP (SyntacticObject.leafP tok_saw)
+            (SyntacticObject.leafP tok_mary_en)))))
 
 -- ============================================================================
 -- § 4: Word Order Predictions
@@ -223,8 +227,8 @@ theorem english_is_svo :
 
 /-- Both base trees (stage 4, pre-movement) have the same shape — same node
     and leaf counts. The only parametric difference is *what* moves in step 5.
-    Stated over the explicit base trees (the `SO.Derivation.stageAt` fold is
-    noncomputable on the `SO` carrier; the planar-built base trees are the
+    Stated over the explicit base trees (the `SyntacticObject.Derivation.stageAt` fold is
+    noncomputable on the `SyntacticObject` carrier; the planar-built base trees are the
     trees those stages produce). -/
 theorem same_base_counts :
     tobaBatakBaseTree.nodeCount = englishBaseTree.nodeCount ∧
@@ -262,7 +266,7 @@ theorem english_moves_subject :
     does not entail that the DO (properly contained within VP) individually
     c-commands the subject. -/
 theorem vp_ccommands_subject :
-    SO.cCommandsIn tobaBatakDerivedTree vp n_dakdanakan := by decide
+    SyntacticObject.cCommandsIn tobaBatakDerivedTree vp n_dakdanakan := by decide
 
 -- ============================================================================
 -- § 6: EPP Parameter
@@ -302,7 +306,7 @@ These predictions match the Toba Batak extraction data formalized in
 
     This is verified computationally: `n_biangi` is contained in `vp`. -/
 theorem object_inside_fronted_vp :
-    SO.contains vp n_biangi := by decide
+    SyntacticObject.contains vp n_biangi := by decide
 
 /-- The subject is NOT contained within the fronted VP. It is stranded
     outside the moved constituent and remains accessible for extraction.
@@ -311,7 +315,7 @@ theorem object_inside_fronted_vp :
     only the subject (= pivot) survives VP-raising in a position where
     Ā-extraction is possible. -/
 theorem subject_outside_fronted_vp :
-    ¬ SO.contains vp n_dakdanakan := by decide
+    ¬ SyntacticObject.contains vp n_dakdanakan := by decide
 
 /-- Extraction prediction: the VP-raising analysis predicts exactly the
     extraction pattern found in Toba Batak.
@@ -324,10 +328,10 @@ theorem subject_outside_fronted_vp :
     and `TobaBatak.avPatientExtraction` (ungrammatical). -/
 theorem extraction_matches_vp_containment :
     -- Agent is outside VP → extractable (matches AV agent = grammatical)
-    ¬ SO.contains vp n_dakdanakan ∧
+    ¬ SyntacticObject.contains vp n_dakdanakan ∧
     TobaBatak.avAgentExtraction.judgment = .grammatical ∧
     -- Object is inside VP → frozen (matches AV patient = ungrammatical)
-    SO.contains vp n_biangi ∧
+    SyntacticObject.contains vp n_biangi ∧
     TobaBatak.avPatientExtraction.judgment = .ungrammatical := by
   refine ⟨?_, rfl, ?_, rfl⟩ <;> decide
 
@@ -445,7 +449,7 @@ theorem binding_acceptability_pattern :
     c-commands into VP (can bind a reflexive DO), but the DO (inside VP)
     cannot c-command out past VP (cannot bind a reflexive subject). -/
 theorem object_does_not_ccommand_subject :
-    ¬ SO.cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan := by
+    ¬ SyntacticObject.cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan := by
   decide
 
 -- ============================================================================
@@ -509,7 +513,7 @@ the Linear Correspondence Axiom (LCA).
 -/
 
 /-- F head (higher functional projection above TP). -/
-def f_head := SO.mkLeaf .C [.T] 6
+def f_head := SyntacticObject.mkLeaf .C [.T] 6
 
 /-- Toba Batak SVO via the VOS Hypothesis.
 
@@ -519,7 +523,7 @@ def f_head := SO.mkLeaf .C [.T] 6
     7. IM Subj → `[FP Subj [F' F [TP VP [T' T [vP tSubj [v' v tVP]]]]]]`
 
     The subject raises past the fronted VP, yielding S-V-O surface order. -/
-def tobaBatakSVO : SO.Derivation :=
+def tobaBatakSVO : SyntacticObject.Derivation :=
   { initial := v_mangatuk
     steps := [
       .emR n_biangi,
@@ -538,15 +542,15 @@ theorem toba_batak_svo_order :
 /-- SVO goes through VOS: at stage 5 (before subject-raising), the
     intermediate tree has VOS order — the same as `tobaBatakVOS.final`. -/
 theorem svo_passes_through_vos :
-    (⟨tobaBatakSVO.initial, tobaBatakSVO.steps.take 5⟩ : SO.Derivation).surfacePhon
+    (⟨tobaBatakSVO.initial, tobaBatakSVO.steps.take 5⟩ : SyntacticObject.Derivation).surfacePhon
       = tobaBatakVOS.surfacePhon := by decide
 
 /-- The VOS Hypothesis predicts identical extraction restrictions for SVO:
     the DO is still inside the fronted VP, regardless of whether the
     subject subsequently raises past it. -/
 theorem svo_same_extraction_as_vos :
-    SO.contains vp n_biangi ∧
-    ¬ SO.contains vp n_dakdanakan := by
+    SyntacticObject.contains vp n_biangi ∧
+    ¬ SyntacticObject.contains vp n_dakdanakan := by
   refine ⟨?_, ?_⟩ <;> decide
 
 /-- SVO requires two movement steps (VP-raising + subject-raising). -/
@@ -581,11 +585,11 @@ We model the English passive with the agent as a low complement of V
 (following [larson-1988]), with no external argument in Spec,vP.
 -/
 
-def v_injured     := SO.mkLeafPhon .V [] "was-injured" 21
-def n_boy         := SO.mkLeafPhon .N [] "the-boy" 22
-def n_by_himself  := SO.mkLeafPhon .N [] "by-himself" 23
-def v_head_pass   := SO.mkLeaf .v [.V] 24
-def t_head_pass   := SO.mkLeaf .T [.v] 25
+def v_injured     := SyntacticObject.mkLeafPhon .V [] "was-injured" 21
+def n_boy         := SyntacticObject.mkLeafPhon .N [] "the-boy" 22
+def n_by_himself  := SyntacticObject.mkLeafPhon .N [] "by-himself" 23
+def v_head_pass   := SyntacticObject.mkLeaf .v [.V] 24
+def t_head_pass   := SyntacticObject.mkLeaf .T [.v] 25
 
 private def tok_injured    : LIToken := ⟨.simple .V [] (phonForm := "was-injured"), 21⟩
 private def tok_boy        : LIToken := ⟨.simple .N [] (phonForm := "the-boy"), 22⟩
@@ -595,8 +599,10 @@ private def tok_t_pass     : LIToken := ⟨.simple .T [.v], 25⟩
 
 /-- The passive VP: `[VP patient [V' V agent-PP]]`. Built planar-first. -/
 def vp_passive : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_boy) (SO.nodeP (SO.leafP tok_injured) (SO.leafP tok_by_himself)))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_boy)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_injured)
+        (SyntacticObject.leafP tok_by_himself)))
 
 /-- English passive derivation (trees 97–100 of the paper).
 
@@ -606,7 +612,7 @@ def vp_passive : SyntacticObject :=
     3. EM-L v        → `[v' v VP]` (no external argument — passive)
     4. EM-L T        → `[TP T [vP v VP]]`
     5. IM patient    → `[TP patient [T' T [vP v [VP t [V' V agent]]]]]` -/
-def englishPassive : SO.Derivation :=
+def englishPassive : SyntacticObject.Derivation :=
   { initial := v_injured
     steps := [
       .emR n_by_himself,
@@ -621,12 +627,13 @@ def englishPassive : SO.Derivation :=
     sits at the top edge above its base trace; the agent is a low
     complement of V. -/
 def englishPassiveDerivedTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_boy)
-      (SO.nodeP (SO.leafP tok_t_pass)
-        (SO.nodeP (SO.leafP tok_v_pass)
-          (SO.nodeP SO.traceP
-            (SO.nodeP (SO.leafP tok_injured) (SO.leafP tok_by_himself))))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_boy)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_t_pass)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_v_pass)
+          (SyntacticObject.nodeP SyntacticObject.traceP
+            (SyntacticObject.nodeP (SyntacticObject.leafP tok_injured)
+              (SyntacticObject.leafP tok_by_himself))))))
 
 /-- English passive yields patient-verb-agent surface order. -/
 theorem english_passive_order :
@@ -653,14 +660,14 @@ Both predictions follow from c-command in the derived tree:
 - Both: patient (raised to Spec,TP/FP) c-commands agent
 
 The formalization verifies the c-command predictions computationally
-using `SO.cCommandsIn` over the derived trees.
+using `SyntacticObject.cCommandsIn` over the derived trees.
 -/
 
 /-- In the English passive, the patient (raised to Spec,TP) c-commands
     the by-phrase agent. This is why "The boy was injured by himself" is
     grammatical: the patient can bind a reflexive in the agent position. -/
 theorem english_passive_patient_ccommands_agent :
-    SO.cCommandsIn englishPassiveDerivedTree n_boy n_by_himself := by
+    SyntacticObject.cCommandsIn englishPassiveDerivedTree n_boy n_by_himself := by
   decide
 
 /-- In the English passive, the by-phrase agent does NOT c-command the
@@ -668,7 +675,7 @@ theorem english_passive_patient_ccommands_agent :
     ungrammatical: the agent (low adjunct inside VP) cannot bind a
     reflexive in subject position. -/
 theorem english_passive_agent_not_ccommands_patient :
-    ¬ SO.cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
+    ¬ SyntacticObject.cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
   decide
 
 /-- In the TB active **base structure** (pre-movement, stage 4), the
@@ -680,7 +687,7 @@ theorem english_passive_agent_not_ccommands_patient :
     contains the object. After VP-raising, the object moves to a
     different branch; reconstruction restores the base c-command. -/
 theorem tb_active_subject_ccommands_object_at_base :
-    SO.cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi := by
+    SyntacticObject.cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi := by
   decide
 
 /-- Cross-linguistic contrast verified: same c-command theory, different
@@ -693,11 +700,11 @@ theorem tb_active_subject_ccommands_object_at_base :
     4. English passive (derived): agent does not c-command patient (ex. 96) -/
 theorem cross_linguistic_binding_contrast :
     -- TB active (base stage for binding, derived stage for anti-binding)
-    SO.cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi ∧
-    ¬ SO.cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan ∧
+    SyntacticObject.cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi ∧
+    ¬ SyntacticObject.cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan ∧
     -- English passive (derived tree)
-    SO.cCommandsIn englishPassiveDerivedTree n_boy n_by_himself ∧
-    ¬ SO.cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
+    SyntacticObject.cCommandsIn englishPassiveDerivedTree n_boy n_by_himself ∧
+    ¬ SyntacticObject.cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 end ColeHermon2008

--- a/Linglib/Studies/Dendikken1995ParticleVerbs.lean
+++ b/Linglib/Studies/Dendikken1995ParticleVerbs.lean
@@ -80,8 +80,8 @@ with SpecSC empty. The current `SmallClause` shape forces a subject
 field, so we record the post-movement form. -/
 
 def pvToSmallClause (pv : ParticleVerb) (dpId prtId : Nat) : SmallClause :=
-  { subject := SO.mkLeafPhon .D [] "DP" dpId
-    predicate := SO.mkLeafPhon .P [] pv.particle prtId
+  { subject := SyntacticObject.mkLeafPhon .D [] "DP" dpId
+    predicate := SyntacticObject.mkLeafPhon .P [] pv.particle prtId
     predCat := .P }
 
 /-- All PVC small clauses have predicate category P. -/
@@ -97,14 +97,14 @@ binary tree (subject + predicate). This is the shape consumed by any
 file that wants to compose PVC SCs into larger structures (e.g.
 `embedUnderV` for the full `[VP V [SC DP Prt]]` analysis, as used by
 `HaddicanEtAl2026.pvc_sc`). Stated as a leaf count over the noncomputable
-Merge node (`SO.leafCount_merge`) so downstream files can rewrite without
+Merge node (`SyntacticObject.leafCount_merge`) so downstream files can rewrite without
 unfolding `pvToSmallClause`. -/
 
 /-- Any PVC small clause is a 2-leaf binary tree (subject + predicate). -/
 theorem pvToSmallClause_toSO_shape (pv : ParticleVerb) (dpId prtId : Nat) :
     (pvToSmallClause pv dpId prtId).toSO.leafCount = 2 := by
-  simp only [pvToSmallClause, SmallClause.toSO, SO.leafCount_merge,
-    SO.mkLeafPhon, SO.leafCount_lexLeaf]
+  simp only [pvToSmallClause, SmallClause.toSO, SyntacticObject.leafCount_merge,
+    SyntacticObject.mkLeafPhon, SyntacticObject.leafCount_lexLeaf]
 
 /-- The `predCat` field of `pvToSmallClause` agrees with the
     `predicate.headCat` reading — the well-formedness invariant

--- a/Linglib/Studies/Dendikken1995Resultatives.lean
+++ b/Linglib/Studies/Dendikken1995Resultatives.lean
@@ -102,8 +102,8 @@ theorem resultative_cats_are_A_or_P (rt : ResultativeType) :
 
 /-- Build a small clause from a resultative datum. -/
 def datumToSC (d : ResultativeDatum) (dpId predId : Nat) : SmallClause :=
-  { subject := SO.mkLeafPhon .D [] "DP_patient" dpId
-    predicate := SO.mkLeafPhon (SCPredCategory.toCat (resToSCPred d.resType))
+  { subject := SyntacticObject.mkLeafPhon .D [] "DP_patient" dpId
+    predicate := SyntacticObject.mkLeafPhon (SCPredCategory.toCat (resToSCPred d.resType))
                                [] "XP_result" predId
     predCat := resToSCPred d.resType }
 

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -453,18 +453,19 @@ private def voiceTok   : LIToken := ⟨.simple .Voice [.V] "", 4⟩
 private def tTok       : LIToken := ⟨.simple .T [.Voice] "", 5⟩
 private def cTok       : LIToken := ⟨.simple .C [.T] "", 6⟩
 
-/-- The full CP derivation, built planar-first (Merge `SO.node` is noncomputable,
+/-- The full CP derivation, built planar-first (Merge `SyntacticObject.node` is noncomputable,
     so concrete `decide`-able trees use the planar DSL): the oblique DP undergoes
     successive-cyclic Ā-movement, surfacing at Spec,CP with a trace lower down.
     Structure: `[CP oblique [C' C [TP T [VoiceP oblique [Voice' Voice [VP V obj]]]]]]`. -/
-private def cp : SO :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP obliqueTok)
-      (SO.nodeP (SO.leafP cTok)
-        (SO.nodeP (SO.leafP tTok)
-          (SO.nodeP (SO.leafP obliqueTok)
-            (SO.nodeP (SO.leafP voiceTok)
-              (SO.nodeP (SO.leafP verbTok) (SO.leafP objectTok)))))))
+private def cp : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP obliqueTok)
+      (SyntacticObject.nodeP (SyntacticObject.leafP cTok)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tTok)
+          (SyntacticObject.nodeP (SyntacticObject.leafP obliqueTok)
+            (SyntacticObject.nodeP (SyntacticObject.leafP voiceTok)
+              (SyntacticObject.nodeP (SyntacticObject.leafP verbTok)
+                (SyntacticObject.leafP objectTok)))))))
 
 theorem derivation_tree_size : cp.nodeCount = 6 := by decide
 

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -275,9 +275,10 @@ Traces left by movement are interpreted as variables bound by
 
 #### Trace convention
 
-On the index-free `SO` carrier ([marcolli-chomsky-berwick-2025] Def 1.2.1,
+On the index-free `SyntacticObject` carrier ([marcolli-chomsky-berwick-2025] Def 1.2.1,
 chain identity is workspace-level) a trace is the **single** bare trace leaf
-`SO.traceLeaf`, recognized by `SO.isTrace`. The semantic trace *index* `n` is
+`SyntacticObject.traceLeaf`, recognized by `SyntacticObject.isTrace`. The semantic trace *index* `n`
+is
 not carried by the leaf: it is supplied by the binder (λ-abstraction) at the
 landing site, exactly as in the H&K rule ⟦t_n⟧^g = g(n). The interpretation
 functions below therefore take the index as an explicit argument.
@@ -331,30 +332,31 @@ The semantic type corresponding to a syntactic object.
 - Other SOs need lexical lookup
 -/
 def soSemanticType (so : Minimalist.SyntacticObject) : Option Ty :=
-  if Minimalist.SO.isTrace so then some .e else none
+  if Minimalist.SyntacticObject.isTrace so then some .e else none
 
 /--
 Interpret a trace leaf in a syntactic object at a given index.
 
-On the index-free `SO` carrier the trace leaf carries no index; the binder at
+On the index-free `SyntacticObject` carrier the trace leaf carries no index; the binder at
 the landing site supplies `n` (H&K's ⟦t_n⟧^g = g(n)). Returns `none` when `so`
 is not the trace leaf.
 -/
 def interpSOTrace {E : Type} (n : ℕ) (so : Minimalist.SyntacticObject) :
     Option (DenotG E Unit .e) :=
-  if Minimalist.SO.isTrace so then some (interpTrace n) else none
+  if Minimalist.SyntacticObject.isTrace so then some (interpTrace n) else none
 
 /-- The trace leaf is recognized as type `e`. -/
 @[simp] theorem soSemanticType_traceLeaf :
-    soSemanticType Minimalist.SO.traceLeaf = some .e := rfl
+    soSemanticType Minimalist.SyntacticObject.traceLeaf = some .e := rfl
 
 /-- A lexical leaf is not a trace, so it gets no carrier-level type. -/
 @[simp] theorem soSemanticType_lexLeaf (tok : Minimalist.LIToken) :
-    soSemanticType (Minimalist.SO.lexLeaf tok) = none := by
-  have hne : ¬ Minimalist.SO.isTrace (Minimalist.SO.lexLeaf tok) := by
+    soSemanticType (Minimalist.SyntacticObject.lexLeaf tok) = none := by
+  have hne : ¬ Minimalist.SyntacticObject.isTrace (Minimalist.SyntacticObject.lexLeaf tok) := by
     intro h
-    have hg := congrArg Minimalist.SO.getLIToken h
-    rw [Minimalist.SO.getLIToken_lexLeaf, Minimalist.SO.getLIToken_traceLeaf] at hg
+    have hg := congrArg Minimalist.SyntacticObject.getLIToken h
+    rw [Minimalist.SyntacticObject.getLIToken_lexLeaf,
+      Minimalist.SyntacticObject.getLIToken_traceLeaf] at hg
     exact Option.some_ne_none tok hg
   simp only [soSemanticType, if_neg hne]
 

--- a/Linglib/Studies/Kratzer1996.lean
+++ b/Linglib/Studies/Kratzer1996.lean
@@ -56,7 +56,7 @@ section TreeDerivations
 
 open Minimalist
 
--- Leaf tokens (the smart Merge `SO.node` is noncomputable, so concrete trees
+-- Leaf tokens (the smart Merge `SyntacticObject.node` is noncomputable, so concrete trees
 -- are built planar-first from `LIToken`s and `decide`d over).
 
 def voice_ag_t  : LIToken := ⟨.simple .Voice [.v]  "Voice[AG]",  200⟩
@@ -76,73 +76,78 @@ def DP_door_t   : LIToken := ⟨.simple .D     []    "the door",   217⟩
 /-- Transitive: "John broke the vase"
     `[VoiceP John [Voice' Voice_AG [vP v [VP broke [DP the vase]]]]]` -/
 def transitiveTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP DP_john_t)
-      (SO.nodeP (SO.leafP voice_ag_t)
-        (SO.nodeP (SO.leafP v_head_t)
-          (SO.nodeP (SO.leafP V_broke_t) (SO.leafP DP_vase_t)))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP DP_john_t)
+      (SyntacticObject.nodeP (SyntacticObject.leafP voice_ag_t)
+        (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
+          (SyntacticObject.nodeP (SyntacticObject.leafP V_broke_t)
+            (SyntacticObject.leafP DP_vase_t)))))
 
 /-- Anticausative: "The vase broke"
     `[VoiceP Voice_∅ [vP v [VP broke [DP the vase]]]]` -/
 def anticausativeTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP voice_nth_t)
-      (SO.nodeP (SO.leafP v_head_t)
-        (SO.nodeP (SO.leafP V_broke_t) (SO.leafP DP_vase_t))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP voice_nth_t)
+      (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
+        (SyntacticObject.nodeP (SyntacticObject.leafP V_broke_t)
+          (SyntacticObject.leafP DP_vase_t))))
 
 /-- Unaccusative: "The ship sank"
     `[VoiceP Voice_∅ [vP v [VP sank [DP the ship]]]]` -/
 def unaccusativeTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP voice_nth_t)
-      (SO.nodeP (SO.leafP v_head_t)
-        (SO.nodeP (SO.leafP V_sank_t) (SO.leafP DP_ship_t))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP voice_nth_t)
+      (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
+        (SyntacticObject.nodeP (SyntacticObject.leafP V_sank_t) (SyntacticObject.leafP DP_ship_t))))
 
 /-- Middle: "The door opened"
     `[VoiceP Voice_MID [vP v [VP opened [DP the door]]]]` -/
 def middleTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP voice_mid_t)
-      (SO.nodeP (SO.leafP v_head_t)
-        (SO.nodeP (SO.leafP V_opened_t) (SO.leafP DP_door_t))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP voice_mid_t)
+      (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
+        (SyntacticObject.nodeP (SyntacticObject.leafP V_opened_t)
+          (SyntacticObject.leafP DP_door_t))))
 
 -- C-command predictions
 
 /-- Agent c-commands theme in the transitive. -/
 theorem transitive_agent_ccommands_theme :
-    SO.cCommandsIn transitiveTree (SO.lexLeaf DP_john_t) (SO.lexLeaf DP_vase_t) := by decide
+    SyntacticObject.cCommandsIn transitiveTree (SyntacticObject.lexLeaf DP_john_t)
+      (SyntacticObject.lexLeaf DP_vase_t) := by decide
 
 /-- Theme does NOT c-command agent. -/
 theorem transitive_theme_not_ccommands_agent :
-    ¬ SO.cCommandsIn transitiveTree (SO.lexLeaf DP_vase_t) (SO.lexLeaf DP_john_t) := by decide
+    ¬ SyntacticObject.cCommandsIn transitiveTree (SyntacticObject.lexLeaf DP_vase_t)
+      (SyntacticObject.lexLeaf DP_john_t) := by decide
 
 /-- Anticausative contains theme but no agent DP. -/
 theorem anticausative_contains_theme :
-    SO.contains anticausativeTree (SO.lexLeaf DP_vase_t) := by decide
+    SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf DP_vase_t) := by decide
 
 /-- Unaccusative contains theme. -/
 theorem unaccusative_contains_theme :
-    SO.contains unaccusativeTree (SO.lexLeaf DP_ship_t) := by decide
+    SyntacticObject.contains unaccusativeTree (SyntacticObject.lexLeaf DP_ship_t) := by decide
 
 /-- Middle contains theme. -/
 theorem middle_contains_theme :
-    SO.contains middleTree (SO.lexLeaf DP_door_t) := by decide
+    SyntacticObject.contains middleTree (SyntacticObject.lexLeaf DP_door_t) := by decide
 
 -- Causative alternation
 
 /-- The transitive and anticausative share the VP core:
     both contain V("broke") and DP("the vase"). -/
 theorem causative_pair_shared_vp :
-    SO.contains transitiveTree (SO.lexLeaf V_broke_t) ∧
-    SO.contains transitiveTree (SO.lexLeaf DP_vase_t) ∧
-    SO.contains anticausativeTree (SO.lexLeaf V_broke_t) ∧
-    SO.contains anticausativeTree (SO.lexLeaf DP_vase_t) := by
+    SyntacticObject.contains transitiveTree (SyntacticObject.lexLeaf V_broke_t) ∧
+    SyntacticObject.contains transitiveTree (SyntacticObject.lexLeaf DP_vase_t) ∧
+    SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf V_broke_t) ∧
+    SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf DP_vase_t) := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 /-- The transitive has an agent DP; the anticausative does not. -/
 theorem causative_pair_agent_contrast :
-    SO.contains transitiveTree (SO.lexLeaf DP_john_t) ∧
-    ¬ SO.contains anticausativeTree (SO.lexLeaf DP_john_t) := by
+    SyntacticObject.contains transitiveTree (SyntacticObject.lexLeaf DP_john_t) ∧
+    ¬ SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf DP_john_t) := by
   constructor <;> decide
 
 /-- Voice determines the alternation: agentive assigns θ,

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -23,7 +23,7 @@ import Linglib.Semantics.ArgumentStructure.Linking
 2. **Dative Shift = PASSIVE**: The double object construction (DOC) is
    derived from the oblique dative by Internal Merge — the same operation
    as Passive — applied within the VP domain rather than the IP domain.
-   Both operations are `SO.Step.im` in the `SO.Derivation` infrastructure.
+   Both operations are `SyntacticObject.Step.im` in the `SyntacticObject.Derivation` infrastructure.
 
 3. **[barss-lasnik-1986] asymmetries**: In the derived DOC, the
    indirect object (NP1) asymmetrically c-commands the direct object
@@ -41,23 +41,24 @@ import Linglib.Semantics.ArgumentStructure.Linking
 
 ## Carrier note (P4 single-carrier flip)
 
-The MCB-faithful `SO` carrier makes Merge (`SO.node`/`*`) noncomputable, so
-`SO.Derivation.final` (the folded result tree) does not `decide`. The
+The MCB-faithful `SyntacticObject` carrier makes Merge (`SyntacticObject.node`/`*`) noncomputable,
+so
+`SyntacticObject.Derivation.final` (the folded result tree) does not `decide`. The
 *movement bookkeeping* (`movedItems`) and the *externalized surface order*
 (`surfacePhon`/`surfaceCats`) **are** computable and `decide`-able, so they
-are proved over the `SO.Derivation` directly.
+are proved over the `SyntacticObject.Derivation` directly.
 
 The c-command asymmetries are stated over the **derived tree built
-planar-first** (`SO.ofPlanar (SO.nodeP …)`), i.e. the very tree each
+planar-first** (`SyntacticObject.ofPlanar (SyntacticObject.nodeP …)`), i.e. the very tree each
 derivation produces, written out explicitly per the file's prose diagrams.
 This is faithful: the derivation records the operations; the planar tree
-is its result, and c-command (`SO.cCommandsIn`) reduces on it.
+is its result, and c-command (`SyntacticObject.cCommandsIn`) reduces on it.
 
 ## Simplification
 
 The paper's VP shell has V raising from the inner V position to an
 initially empty outer V position (head-to-head movement, §2.1, trees
-13–14). This formalization uses `SO.Step.im` (phrasal Internal Merge)
+13–14). This formalization uses `SyntacticObject.Step.im` (phrasal Internal Merge)
 for Dative Shift and Passive, which correctly captures the NP Movement
 component. Head movement (V Raising) is not modeled. This omission does
 not affect the c-command predictions, which depend on the positions of
@@ -65,11 +66,11 @@ DP arguments, not the position of V.
 
 ## Cross-references
 
-- `Minimalist.SO.Derivation`: `SO.Step.im` = Internal Merge
+- `Minimalist.SyntacticObject.Derivation`: `SyntacticObject.Step.im` = Internal Merge
 - `Studies/Pylkkanen2008.lean`: Modern Voice/Appl decomposition with
   tree-based c-command verification; bridge theorem proving convergence
 - `ColeHermon2008`: English passive derivation
-  using the same `SO.Derivation` infrastructure
+  using the same `SyntacticObject.Derivation` infrastructure
 -/
 
 namespace Larson1988
@@ -81,14 +82,14 @@ open RootedTree
 -- § 1: Lexical Items
 -- ============================================================================
 
-def V_send    := SO.mkLeafPhon .V [.D]  "send"     300
-def P_to      := SO.mkLeafPhon .P [.D]  "to"       301
-def DP_john   := SO.mkLeafPhon .D []    "John"     302
-def DP_mary   := SO.mkLeafPhon .D []    "Mary"     303
-def DP_letter := SO.mkLeafPhon .D []    "a letter" 304
+def V_send    := SyntacticObject.mkLeafPhon .V [.D]  "send"     300
+def P_to      := SyntacticObject.mkLeafPhon .P [.D]  "to"       301
+def DP_john   := SyntacticObject.mkLeafPhon .D []    "John"     302
+def DP_mary   := SyntacticObject.mkLeafPhon .D []    "Mary"     303
+def DP_letter := SyntacticObject.mkLeafPhon .D []    "a letter" 304
 
-def V_kick    := SO.mkLeafPhon .V [.D]  "kicked"   310
-def DP_ball   := SO.mkLeafPhon .D []    "the ball" 311
+def V_kick    := SyntacticObject.mkLeafPhon .V [.D]  "kicked"   310
+def DP_ball   := SyntacticObject.mkLeafPhon .D []    "the ball" 311
 
 /-! Planar leaf tokens, used for building the result trees the derivations
     produce (the c-command theorems reason over these). -/
@@ -102,7 +103,8 @@ private def tok_kick   : LIToken := ⟨.simple .V [.D] (phonForm := "kicked"), 3
 private def tok_ball   : LIToken := ⟨.simple .D [] (phonForm := "the ball"), 311⟩
 
 /-- The `[PP to Mary]` constituent as a planar subtree. -/
-private def ppToMaryP : RoseTree SOLabel := SO.nodeP (SO.leafP tok_to) (SO.leafP tok_mary)
+private def ppToMaryP : RoseTree SOLabel :=
+  SyntacticObject.nodeP (SyntacticObject.leafP tok_to) (SyntacticObject.leafP tok_mary)
 
 -- ============================================================================
 -- § 2: Oblique Dative Derivation
@@ -117,44 +119,44 @@ private def ppToMaryP : RoseTree SOLabel := SO.nodeP (SO.leafP tok_to) (SO.leafP
     The direct object (a letter) c-commands the goal (Mary), but not
     vice versa — Mary is buried inside PP. -/
 
-def obliqueDative : SO.Derivation :=
+def obliqueDative : SyntacticObject.Derivation :=
   { initial := V_send
     steps := [
-      .emR (SO.ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (SyntacticObject.ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .emL DP_john                    -- [VP John [VP a_letter [V' send [PP to Mary]]]]
     ] }
 
 /-- The oblique dative result tree: `[John [letter [send [to Mary]]]]`.
     Built planar-first; this is exactly what `obliqueDative` produces. -/
-def obliqueDativeTree : SO :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_john)
-      (SO.nodeP (SO.leafP tok_letter)
-        (SO.nodeP (SO.leafP tok_send) ppToMaryP)))
+def obliqueDativeTree : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_john)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_letter)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_send) ppToMaryP)))
 
 -- Oblique dative c-command predictions
 
 theorem oblique_do_ccommands_goal :
-    SO.cCommandsIn obliqueDativeTree DP_letter DP_mary := by decide
+    SyntacticObject.cCommandsIn obliqueDativeTree DP_letter DP_mary := by decide
 
 theorem oblique_goal_not_ccommands_do :
-    ¬ SO.cCommandsIn obliqueDativeTree DP_mary DP_letter := by decide
+    ¬ SyntacticObject.cCommandsIn obliqueDativeTree DP_mary DP_letter := by decide
 
 theorem oblique_agent_ccommands_both :
-    SO.cCommandsIn obliqueDativeTree DP_john DP_letter ∧
-    SO.cCommandsIn obliqueDativeTree DP_john DP_mary := by
+    SyntacticObject.cCommandsIn obliqueDativeTree DP_john DP_letter ∧
+    SyntacticObject.cCommandsIn obliqueDativeTree DP_john DP_mary := by
   constructor <;> decide
 
 -- ============================================================================
--- § 3: DOC Derivation — Dative Shift as SO.Step.im
+-- § 3: DOC Derivation — Dative Shift as SyntacticObject.Step.im
 -- ============================================================================
 
 /-! The DOC "John sent Mary a letter" extends the oblique dative with
-one additional step: **Internal Merge of the indirect object** (`SO.Step.im`).
+one additional step: **Internal Merge of the indirect object** (`SyntacticObject.Step.im`).
 
 This is Larson's central insight: Dative Shift = PASSIVE within VP.
-The `SO.Step.im` constructor is the same one used for standard Passive
+The `SyntacticObject.Step.im` constructor is the same one used for standard Passive
 (cf. `ColeHermon2008.lean`'s `englishPassive` derivation). The only
 difference is *which* argument moves and *when* in the derivation.
 
@@ -166,10 +168,10 @@ Derivation steps:
    This promotes Mary above the direct object.
 4. EM-L the agent `John` -/
 
-def docDativeShift : SO.Derivation :=
+def docDativeShift : SyntacticObject.Derivation :=
   { initial := V_send
     steps := [
-      .emR (SO.ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (SyntacticObject.ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .im DP_mary,                    -- DATIVE SHIFT: Mary moves to Spec
       .emL DP_john                    -- [VP John [VP Mary_i [VP a_letter ...]]]
@@ -178,13 +180,13 @@ def docDativeShift : SO.Derivation :=
 /-- The DOC result tree: Mary, internally merged, sits at the left edge of
     the shell, asymmetrically c-commanding the theme; the original Mary
     position is the bare trace. `[John [Mary [letter [send [to t]]]]]`. -/
-def docDativeShiftTree : SO :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_john)
-      (SO.nodeP (SO.leafP tok_mary)
-        (SO.nodeP (SO.leafP tok_letter)
-          (SO.nodeP (SO.leafP tok_send)
-            (SO.nodeP (SO.leafP tok_to) SO.traceP)))))
+def docDativeShiftTree : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_john)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_mary)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_letter)
+          (SyntacticObject.nodeP (SyntacticObject.leafP tok_send)
+            (SyntacticObject.nodeP (SyntacticObject.leafP tok_to) SyntacticObject.traceP)))))
 
 -- DOC c-command predictions: the asymmetries are REVERSED
 
@@ -195,27 +197,27 @@ def docDativeShiftTree : SO :=
     - Quantifier binding: "I gave every worker his paycheck"
     - Weak crossover, superiority, *each...the other*, NPI licensing -/
 theorem doc_io_ccommands_do :
-    SO.cCommandsIn docDativeShiftTree DP_mary DP_letter := by decide
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter := by decide
 
 /-- The direct object does NOT c-command the indirect object in the DOC. -/
 theorem doc_do_not_ccommands_io :
-    ¬ SO.cCommandsIn docDativeShiftTree DP_letter DP_mary := by decide
+    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary := by decide
 
 theorem doc_agent_ccommands_both :
-    SO.cCommandsIn docDativeShiftTree DP_john DP_mary ∧
-    SO.cCommandsIn docDativeShiftTree DP_john DP_letter := by
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_john DP_mary ∧
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_john DP_letter := by
   constructor <;> decide
 
 -- ============================================================================
--- § 4: PASSIVE — Same SO.Step.im, Different Domain
+-- § 4: PASSIVE — Same SyntacticObject.Step.im, Different Domain
 -- ============================================================================
 
-/-! Standard Passive ("The ball was kicked by John") is also `SO.Step.im`:
-the object moves to subject position. By using the same `SO.Step.im`
+/-! Standard Passive ("The ball was kicked by John") is also `SyntacticObject.Step.im`:
+the object moves to subject position. By using the same `SyntacticObject.Step.im`
 constructor, the type system enforces Larson's thesis that Passive
 and Dative Shift share the same structural operation. -/
 
-def standardPassive : SO.Derivation :=
+def standardPassive : SyntacticObject.Derivation :=
   { initial := V_kick
     steps := [
       .emR DP_ball,   -- [V' kicked [DP the ball]]
@@ -225,25 +227,25 @@ def standardPassive : SO.Derivation :=
 
 /-- The passive result tree: the ball (promoted) sits above John (demoted),
     leaving a trace in object position. `[ball [John [kicked t]]]`. -/
-def standardPassiveTree : SO :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_ball)
-      (SO.nodeP (SO.leafP tok_john)
-        (SO.nodeP (SO.leafP tok_kick) SO.traceP)))
+def standardPassiveTree : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_ball)
+      (SyntacticObject.nodeP (SyntacticObject.leafP tok_john)
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_kick) SyntacticObject.traceP)))
 
 -- Passive c-command: promoted object c-commands demoted subject
 
 theorem passive_object_ccommands_subject :
-    SO.cCommandsIn standardPassiveTree DP_ball DP_john := by decide
+    SyntacticObject.cCommandsIn standardPassiveTree DP_ball DP_john := by decide
 
 theorem passive_subject_not_ccommands_object :
-    ¬ SO.cCommandsIn standardPassiveTree DP_john DP_ball := by decide
+    ¬ SyntacticObject.cCommandsIn standardPassiveTree DP_john DP_ball := by decide
 
 -- ============================================================================
 -- § 5: Structural Parallel — Passive and Dative Shift
 -- ============================================================================
 
-/-! Both Passive and Dative Shift use `SO.Step.im`. We extract the
+/-! Both Passive and Dative Shift use `SyntacticObject.Step.im`. We extract the
 movement steps (computable `movedItems`) and verify they share the same
 structure, and we verify the c-command reversal on the result trees. -/
 
@@ -259,14 +261,14 @@ theorem passive_has_one_im :
     the c-command relation between the two internal arguments.
 
     Oblique dative:  DO > IO  (letter c-commands Mary)
-    DOC:             IO > DO  (Mary c-commands letter)  [reversed by SO.Step.im]
+    DOC:             IO > DO  (Mary c-commands letter)  [reversed by SyntacticObject.Step.im]
     Active:          Subj > Obj (John c-commands ball)
-    Passive:         Obj > Subj (ball c-commands John)  [reversed by SO.Step.im] -/
+    Passive:         Obj > Subj (ball c-commands John)  [reversed by SyntacticObject.Step.im] -/
 theorem passive_dativeShift_parallel :
-    -- Both reverse c-command via the same SO.Step.im mechanism
-    SO.cCommandsIn obliqueDativeTree DP_letter DP_mary ∧
-    SO.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
-    SO.cCommandsIn standardPassiveTree DP_ball DP_john := by
+    -- Both reverse c-command via the same SyntacticObject.Step.im mechanism
+    SyntacticObject.cCommandsIn obliqueDativeTree DP_letter DP_mary ∧
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    SyntacticObject.cCommandsIn standardPassiveTree DP_ball DP_john := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 -- ============================================================================
@@ -324,8 +326,8 @@ theorem bl_six_asymmetries : blAsymmetries.length = 6 := rfl
 /-- All six asymmetries are derived from a single structural fact:
     in the DOC, NP1 (IO) asymmetrically c-commands NP2 (DO). -/
 theorem bl_asymmetries_from_ccommand :
-    SO.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
-    ¬ SO.cCommandsIn docDativeShiftTree DP_letter DP_mary := by
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary := by
   constructor <;> decide
 
 -- ============================================================================
@@ -423,9 +425,9 @@ available. The data are recorded in `Bruening2001`
     which records "Someone gave every student a book" as `surfaceOnly`. -/
 theorem doc_scope_freezing_structural_basis :
     -- IO > DO (IO c-commands DO): surface scope available
-    SO.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
     -- DO ≯ IO (DO does not c-command IO): inverse scope blocked
-    ¬ SO.cCommandsIn docDativeShiftTree DP_letter DP_mary := by
+    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary := by
   constructor <;> decide
 
 -- ============================================================================
@@ -439,14 +441,14 @@ by Passive (DOC → indirect passive). Larson proposes an alternative
 "3→1 advancement" where PASSIVE applies directly to the oblique
 dative, promoting the IO without an intermediate DOC stage.
 
-Both routes use the same operations (NP Movement = `SO.Step.im`). We
+Both routes use the same operations (NP Movement = `SyntacticObject.Step.im`). We
 formalize the two-step route, which produces the same surface
 c-command relations. -/
 
-def V_sent     := SO.mkLeafPhon .V [.D]  "was-sent" 320
-def DP_mary2   := SO.mkLeafPhon .D []    "Mary"     321
-def DP_letter2 := SO.mkLeafPhon .D []    "a letter" 322
-def P_to2      := SO.mkLeafPhon .P [.D]  "to"       323
+def V_sent     := SyntacticObject.mkLeafPhon .V [.D]  "was-sent" 320
+def DP_mary2   := SyntacticObject.mkLeafPhon .D []    "Mary"     321
+def DP_letter2 := SyntacticObject.mkLeafPhon .D []    "a letter" 322
+def P_to2      := SyntacticObject.mkLeafPhon .P [.D]  "to"       323
 
 private def tok_sent    : LIToken := ⟨.simple .V [.D] (phonForm := "was-sent"), 320⟩
 private def tok_mary2   : LIToken := ⟨.simple .D [] (phonForm := "Mary"), 321⟩
@@ -459,10 +461,11 @@ private def tok_to2     : LIToken := ⟨.simple .P [.D] (phonForm := "to"), 323�
     1. Build oblique dative base: [VP a_letter [V' send [PP to Mary]]]
     2. Dative Shift (IM Mary): Mary promotes to inner Spec
     3. Passive (IM Mary again): Mary promotes to outer Spec (subject) -/
-def indirectPassive : SO.Derivation :=
+def indirectPassive : SyntacticObject.Derivation :=
   { initial := V_sent
     steps := [
-      .emR (SO.ofPlanar (SO.nodeP (SO.leafP tok_to2) (SO.leafP tok_mary2))),
+      .emR (SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tok_to2)
+        (SyntacticObject.leafP tok_mary2))),
                        -- [V' sent [PP to Mary]]
       .emL DP_letter2, -- [VP a_letter [V' sent [PP to Mary]]]
       .im DP_mary2,    -- DATIVE SHIFT: Mary to inner Spec
@@ -471,7 +474,7 @@ def indirectPassive : SO.Derivation :=
 
 /-- The indirect-passive result tree, exactly as `indirectPassive` produces it.
     Mary moves successive-cyclically (Dative Shift then Passive), so each
-    `SO.Step.im` leaves a trace at its extraction site: one at the inner Spec
+    `SyntacticObject.Step.im` leaves a trace at its extraction site: one at the inner Spec
     (the intermediate Dative-Shift landing site) and one in the *to*-complement.
     `[Mary [t [letter [sent [to t]]]]]` — Mary at the top edge above the
     intermediate trace and the stranded direct object.
@@ -479,21 +482,21 @@ def indirectPassive : SO.Derivation :=
     (The single-trace abbreviation `[Mary [letter [sent [to t]]]]` collapses the
     intermediate landing site; it gives the same Mary-c-commands-letter
     asymmetry but is *not* what the two-step derivation emits.) -/
-def indirectPassiveTree : SO :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP tok_mary2)
-      (SO.nodeP SO.traceP
-        (SO.nodeP (SO.leafP tok_letter2)
-          (SO.nodeP (SO.leafP tok_sent)
-            (SO.nodeP (SO.leafP tok_to2) SO.traceP)))))
+def indirectPassiveTree : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP tok_mary2)
+      (SyntacticObject.nodeP SyntacticObject.traceP
+        (SyntacticObject.nodeP (SyntacticObject.leafP tok_letter2)
+          (SyntacticObject.nodeP (SyntacticObject.leafP tok_sent)
+            (SyntacticObject.nodeP (SyntacticObject.leafP tok_to2) SyntacticObject.traceP)))))
 
 /-- In the indirect passive, the promoted IO (Mary) c-commands the
     stranded DO (a letter). -/
 theorem indirect_passive_io_ccommands_do :
-    SO.cCommandsIn indirectPassiveTree DP_mary2 DP_letter2 := by decide
+    SyntacticObject.cCommandsIn indirectPassiveTree DP_mary2 DP_letter2 := by decide
 
 /-- The indirect passive uses two Internal Merge steps:
-    Dative Shift + Passive — both are `SO.Step.im`. -/
+    Dative Shift + Passive — both are `SyntacticObject.Step.im`. -/
 theorem indirect_passive_two_im :
     indirectPassive.movedItems.length = 2 := by decide
 

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -371,18 +371,19 @@ private def isKLeaf (s : SyntacticObject) : Bool :=
     immediate-child level: a node is "KP" iff *some* immediate daughter
     is a K-headed leaf.
 
-    Under the MCB nonplanar `SO` carrier, Merge is unordered (`SO.mul_comm`),
+    Under the MCB nonplanar `SyntacticObject` carrier, Merge is unordered
+    (`SyntacticObject.mul_comm`),
     so the head's identity is not structurally distinguished — we settle for
     "some daughter is K", the natural unordered analogue. The predicate
-    quantifies over the immediate daughters (`SO.immediatelyContains`), so
+    quantifies over the immediate daughters (`SyntacticObject.immediatelyContains`), so
     left/right symmetry is automatic. TODO Phase 2: refine via
-    head-function-aware projection (`SO.selHead`). -/
+    head-function-aware projection (`SyntacticObject.selHead`). -/
 private def isKP (s : SyntacticObject) : Prop :=
-  ∃ d, SO.immediatelyContains s d ∧ isKLeaf d
+  ∃ d, SyntacticObject.immediatelyContains s d ∧ isKLeaf d
 
 /-! #### `isKP` detection — positive and negative witnesses
 
-`isKP`'s existential ranges over *all* `SO` (no `DecidablePred` instance), so it
+`isKP`'s existential ranges over *all* `SyntacticObject` (no `DecidablePred` instance), so it
 is exercised by explicit witnesses rather than `decide`. A KP node `[K DP]` is
 detected; a non-K node `[V DP]` and a bare K leaf (no daughters) are rejected.
 The tokens are local probes (ids 900–902) for these checks only. -/
@@ -393,25 +394,29 @@ private def kProbeV  : LIToken := ⟨.simple .V [.D] (phonForm := "see"), 902⟩
 
 /-- A K-headed leaf is detected by `isKLeaf`; a D-headed leaf is not. -/
 private theorem isKLeaf_detects :
-    isKLeaf (SO.lexLeaf kProbeK) = true ∧ isKLeaf (SO.lexLeaf kProbeD) = false := by
+    isKLeaf (SyntacticObject.lexLeaf kProbeK) = true ∧
+      isKLeaf (SyntacticObject.lexLeaf kProbeD) = false := by
   decide
 
 /-- Positive: `[K DP]` (a K daughter present) is a KP. -/
 private theorem isKP_detects_kp :
-    isKP (SO.node (SO.lexLeaf kProbeK) (SO.lexLeaf kProbeD)) :=
-  ⟨SO.lexLeaf kProbeK, (SO.immediatelyContains_node _ _ _).mpr (Or.inl rfl), by decide⟩
+    isKP (SyntacticObject.node (SyntacticObject.lexLeaf kProbeK)
+      (SyntacticObject.lexLeaf kProbeD)) :=
+  ⟨SyntacticObject.lexLeaf kProbeK,
+    (SyntacticObject.immediatelyContains_node _ _ _).mpr (Or.inl rfl), by decide⟩
 
 /-- Negative: `[V DP]` (no K daughter) is not a KP. -/
 private theorem isKP_rejects_non_kp :
-    ¬ isKP (SO.node (SO.lexLeaf kProbeV) (SO.lexLeaf kProbeD)) := by
+    ¬ isKP (SyntacticObject.node (SyntacticObject.lexLeaf kProbeV)
+      (SyntacticObject.lexLeaf kProbeD)) := by
   rintro ⟨d, hd, hk⟩
-  rw [SO.immediatelyContains_node] at hd
+  rw [SyntacticObject.immediatelyContains_node] at hd
   rcases hd with rfl | rfl <;> exact absurd hk (by decide)
 
 /-- Negative: a bare K *leaf* is a K head, not a KP — it has no daughters. -/
-private theorem isKP_rejects_bare_K_leaf : ¬ isKP (SO.lexLeaf kProbeK) := by
+private theorem isKP_rejects_bare_K_leaf : ¬ isKP (SyntacticObject.lexLeaf kProbeK) := by
   rintro ⟨d, hd, _⟩
-  exact (SO.immediatelyContains_lexLeaf kProbeK d) hd
+  exact (SyntacticObject.immediatelyContains_lexLeaf kProbeK d) hd
 
 -- ============================================================================
 -- § 9: Anti-Redundancy in Agreement
@@ -742,8 +747,9 @@ theorem impersonal_passive_converges : passiveV.features.hasD = false := rfl
 -- structure (VP is specifier of v), neither internal argument
 -- c-commands the other → symmetric binding (either can passivize).
 
--- Concrete trees are built **planar-first** (`SO.ofPlanar`/`SO.nodeP`/`SO.leafP`)
--- because Merge (`SO.node`) is noncomputable; the c-command decision procedure
+-- Concrete trees are built **planar-first**
+-- (`SyntacticObject.ofPlanar`/`SyntacticObject.nodeP`/`SyntacticObject.leafP`)
+-- because Merge (`SyntacticObject.node`) is noncomputable; the c-command decision procedure
 -- then reduces under `decide`. Each leaf is a lexical leaf over a token, and the
 -- tree references the same tokens via the planar DSL so the two match
 -- definitionally.
@@ -763,10 +769,10 @@ private def DO₁ : LIToken := tok .D "DO" 13
 private def XP₁ : LIToken := tok .P "to-Mary" 14
 
 def lowXPTree : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP agent₁)
-    (SO.nodeP (SO.leafP v₁)
-      (SO.nodeP (SO.leafP DO₁)
-        (SO.nodeP (SO.leafP V₁) (SO.leafP XP₁)))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP agent₁)
+    (SyntacticObject.nodeP (SyntacticObject.leafP v₁)
+      (SyntacticObject.nodeP (SyntacticObject.leafP DO₁)
+        (SyntacticObject.nodeP (SyntacticObject.leafP V₁) (SyntacticObject.leafP XP₁)))))
 
 -- DOC ditransitive: V: [·D·], v: [·D·][·X·][·V·]
 -- Structure: [vP VP [vP agent [v' v IO]]]
@@ -780,9 +786,10 @@ private def DO₂ : LIToken := tok .D "DO" 23
 private def IO₂ : LIToken := tok .D "IO" 24
 
 def docTree : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.nodeP (SO.leafP V₂) (SO.leafP DO₂))
-    (SO.nodeP (SO.leafP agent₂)
-      (SO.nodeP (SO.leafP v₂) (SO.leafP IO₂))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP
+    (SyntacticObject.nodeP (SyntacticObject.leafP V₂) (SyntacticObject.leafP DO₂))
+    (SyntacticObject.nodeP (SyntacticObject.leafP agent₂)
+      (SyntacticObject.nodeP (SyntacticObject.leafP v₂) (SyntacticObject.leafP IO₂))))
 
 -- § 10a: Internal argument binding asymmetry
 
@@ -790,30 +797,38 @@ def docTree : SyntacticObject :=
     DO (specifier of V, by Non-DP First) c-commands into the
     complement position. -/
 theorem low_xp_DO_ccommands_XP :
-    SO.cCommandsIn lowXPTree (SO.lexLeaf DO₁) (SO.lexLeaf XP₁) := by decide
+    SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf DO₁)
+      (SyntacticObject.lexLeaf XP₁) := by decide
 
 theorem low_xp_XP_not_ccommands_DO :
-    ¬ SO.cCommandsIn lowXPTree (SO.lexLeaf XP₁) (SO.lexLeaf DO₁) := by decide
+    ¬ SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf XP₁)
+      (SyntacticObject.lexLeaf DO₁) := by decide
 
 /-- DOC: neither internal argument c-commands the other — symmetric.
     DO is inside VP (outer specifier), IO is complement of v.
     They are in separate branches. -/
 theorem doc_DO_not_ccommands_IO :
-    ¬ SO.cCommandsIn docTree (SO.lexLeaf DO₂) (SO.lexLeaf IO₂) := by decide
+    ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf DO₂)
+      (SyntacticObject.lexLeaf IO₂) := by decide
 
 theorem doc_IO_not_ccommands_DO :
-    ¬ SO.cCommandsIn docTree (SO.lexLeaf IO₂) (SO.lexLeaf DO₂) := by decide
+    ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf IO₂)
+      (SyntacticObject.lexLeaf DO₂) := by decide
 
 /-- The structural asymmetry derived from VP-as-specifier:
     VP-as-complement gives binding asymmetry between internal
     arguments; VP-as-specifier gives symmetric binding. -/
 theorem binding_asymmetry_iff_vp_complement :
     -- Low-XP (VP complement): DO c-commands XP, not vice versa
-    (SO.cCommandsIn lowXPTree (SO.lexLeaf DO₁) (SO.lexLeaf XP₁) ∧
-     ¬ SO.cCommandsIn lowXPTree (SO.lexLeaf XP₁) (SO.lexLeaf DO₁)) ∧
+    (SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf DO₁)
+        (SyntacticObject.lexLeaf XP₁) ∧
+     ¬ SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf XP₁)
+        (SyntacticObject.lexLeaf DO₁)) ∧
     -- DOC (VP specifier): neither c-commands the other
-    (¬ SO.cCommandsIn docTree (SO.lexLeaf DO₂) (SO.lexLeaf IO₂) ∧
-     ¬ SO.cCommandsIn docTree (SO.lexLeaf IO₂) (SO.lexLeaf DO₂)) := by
+    (¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf DO₂)
+        (SyntacticObject.lexLeaf IO₂) ∧
+     ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf IO₂)
+        (SyntacticObject.lexLeaf DO₂)) := by
   refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> decide
 
 -- § 10b: Agent c-command differences
@@ -821,19 +836,23 @@ theorem binding_asymmetry_iff_vp_complement :
 /-- In the low-XP structure, the agent c-commands both internal
     arguments (VP is complement, fully inside agent's sister). -/
 theorem low_xp_agent_ccommands_DO :
-    SO.cCommandsIn lowXPTree (SO.lexLeaf agent₁) (SO.lexLeaf DO₁) := by decide
+    SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf agent₁)
+      (SyntacticObject.lexLeaf DO₁) := by decide
 
 theorem low_xp_agent_ccommands_XP :
-    SO.cCommandsIn lowXPTree (SO.lexLeaf agent₁) (SO.lexLeaf XP₁) := by decide
+    SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf agent₁)
+      (SyntacticObject.lexLeaf XP₁) := by decide
 
 /-- In the DOC structure with Tucking In, the agent (inner specifier)
     c-commands IO (complement of v) but NOT DO (inside VP, the outer
     specifier). The agent and VP are in separate branches — a direct
     consequence of VP being a specifier rather than a complement. -/
 theorem doc_agent_ccommands_IO :
-    SO.cCommandsIn docTree (SO.lexLeaf agent₂) (SO.lexLeaf IO₂) := by decide
+    SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf agent₂)
+      (SyntacticObject.lexLeaf IO₂) := by decide
 
 theorem doc_agent_not_ccommands_DO :
-    ¬ SO.cCommandsIn docTree (SO.lexLeaf agent₂) (SO.lexLeaf DO₂) := by decide
+    ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf agent₂)
+      (SyntacticObject.lexLeaf DO₂) := by decide
 
 end Newman2024

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -149,17 +149,18 @@ def subjectTraceToken : LIToken :=
   { item := LexicalItem.simple .D [], id := idSubjectTrace }
 
 /-- The subject DP at its base position (Spec,vP). Class 1 (uZondi). -/
-def subjectAtBase : SyntacticObject := SO.lexLeaf subjectToken
+def subjectAtBase : SyntacticObject := SyntacticObject.lexLeaf subjectToken
 
 /-- The subject DP after movement to Spec,VoiceP (a fresh copy, since
     each `LIToken` in copy theory is a distinct token). -/
-def subjectAtSpecVoiceP : SyntacticObject := SO.lexLeaf subjectToken
+def subjectAtSpecVoiceP : SyntacticObject := SyntacticObject.lexLeaf subjectToken
 
 /-- A trace at the base position after movement (distinct LIToken). -/
-def subjectTrace : SyntacticObject := SO.lexLeaf subjectTraceToken
+def subjectTrace : SyntacticObject := SyntacticObject.lexLeaf subjectTraceToken
 
-/-! The trees below are built **planar-first** via the DSL (`SO.ofPlanar`
-    / `SO.nodeP` / `SO.leafP`) because the smart Merge `SO.node` is
+/-! The trees below are built **planar-first** via the DSL (`SyntacticObject.ofPlanar`
+    / `SyntacticObject.nodeP` / `SyntacticObject.leafP`) because the smart Merge
+    `SyntacticObject.node` is
     noncomputable; planar construction keeps the `decide` PIC proofs
     reducing. -/
 
@@ -167,17 +168,18 @@ def subjectTrace : SyntacticObject := SO.lexLeaf subjectTraceToken
     Structure: `voice (subject v)`. Voice is the phase; its complement
     is the entire vP, which contains the subject. -/
 def voiceP_noSpec : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP voiceToken)
-    (SO.nodeP (SO.leafP subjectToken) (SO.leafP vToken)))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
+    (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken) (SyntacticObject.leafP vToken)))
 
 /-- The Voice projection with subject at Spec,VoiceP (phase edge).
     Structure: `subject (voice (trace v))`. The OUTER node is not the
     phase; the inner `voice (trace v)` is the phase, and the subject
     (sister to it) is at the edge. -/
 def voiceP_withSpec : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP subjectToken)
-    (SO.nodeP (SO.leafP voiceToken)
-      (SO.nodeP (SO.leafP subjectTraceToken) (SO.leafP vToken))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken)
+    (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
+      (SyntacticObject.nodeP (SyntacticObject.leafP subjectTraceToken)
+        (SyntacticObject.leafP vToken))))
 
 /-- The Voice phase for `voiceP_noSpec`: phase head `voiceToken`, tree
     `voiceP_noSpec`. Its interior (= the head's c-command domain, the
@@ -194,21 +196,23 @@ def voicePhase_withSpec : Phase :=
 
 /-- The full Aux-V tree (T > Asp > Voice > vP) with subject in situ. -/
 def auxVTree_inSitu : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tToken)
-    (SO.nodeP (SO.leafP aspToken)
-      (SO.nodeP (SO.leafP voiceToken)
-        (SO.nodeP (SO.leafP subjectToken) (SO.leafP vToken)))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tToken)
+    (SyntacticObject.nodeP (SyntacticObject.leafP aspToken)
+      (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
+        (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken)
+          (SyntacticObject.leafP vToken)))))
 
 /-- The full Aux-V tree with subject moved to Spec,VoiceP. T's probe will
     additionally attract the subject to Spec,TP — that movement is the
     derivational step we don't model here; the salient question is just
     whether T's probe *finds* the subject under PIC. -/
 def auxVTree_subjectMoved : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP tToken)
-    (SO.nodeP (SO.leafP aspToken)
-      (SO.nodeP (SO.leafP subjectToken)
-        (SO.nodeP (SO.leafP voiceToken)
-          (SO.nodeP (SO.leafP subjectTraceToken) (SO.leafP vToken))))))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tToken)
+    (SyntacticObject.nodeP (SyntacticObject.leafP aspToken)
+      (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken)
+        (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
+          (SyntacticObject.nodeP (SyntacticObject.leafP subjectTraceToken)
+            (SyntacticObject.leafP vToken))))))
 
 end Sample
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -350,20 +350,20 @@ theorem inapplicable_with_fails_classifies_low :
 -- § 1: Lexical Items
 -- ============================================================================
 
-def voice_ag_t  := SO.mkLeafPhon .Voice [.V]    "Voice[AG]"  400
-def appl_low_t  := SO.mkLeafPhon .Appl  [.D]    "Appl[LOW]"  402
-def appl_high_t := SO.mkLeafPhon .Appl  [.V]    "Appl[HI]"   403
-def V_sent_t    := SO.mkLeafPhon .V     [.Appl] "sent"        404
-def V_eat_t     := SO.mkLeafPhon .V     [.D]    "eat"         405
-def DP_john_t   := SO.mkLeafPhon .D     []      "John"        406
-def DP_mary_t   := SO.mkLeafPhon .D     []      "Mary"        407
-def DP_letter_t := SO.mkLeafPhon .D     []      "a letter"    408
-def DP_wife_t   := SO.mkLeafPhon .D     []      "wife"        409
-def DP_food_t   := SO.mkLeafPhon .D     []      "food"        410
+def voice_ag_t  := SyntacticObject.mkLeafPhon .Voice [.V]    "Voice[AG]"  400
+def appl_low_t  := SyntacticObject.mkLeafPhon .Appl  [.D]    "Appl[LOW]"  402
+def appl_high_t := SyntacticObject.mkLeafPhon .Appl  [.V]    "Appl[HI]"   403
+def V_sent_t    := SyntacticObject.mkLeafPhon .V     [.Appl] "sent"        404
+def V_eat_t     := SyntacticObject.mkLeafPhon .V     [.D]    "eat"         405
+def DP_john_t   := SyntacticObject.mkLeafPhon .D     []      "John"        406
+def DP_mary_t   := SyntacticObject.mkLeafPhon .D     []      "Mary"        407
+def DP_letter_t := SyntacticObject.mkLeafPhon .D     []      "a letter"    408
+def DP_wife_t   := SyntacticObject.mkLeafPhon .D     []      "wife"        409
+def DP_food_t   := SyntacticObject.mkLeafPhon .D     []      "food"        410
 
 /-! Planar leaf tokens, used to build the concrete trees the c-command
-    theorems reason over (Merge `SO.node` is noncomputable; trees are
-    built planar-first via `SO.ofPlanar`). -/
+    theorems reason over (Merge `SyntacticObject.node` is noncomputable; trees are
+    built planar-first via `SyntacticObject.ofPlanar`). -/
 
 private def t_voice_ag  : LIToken := ⟨.simple .Voice [.V] (phonForm := "Voice[AG]"), 400⟩
 private def t_appl_low  : LIToken := ⟨.simple .Appl [.D] (phonForm := "Appl[LOW]"), 402⟩
@@ -390,12 +390,13 @@ private def t_DP_food   : LIToken := ⟨.simple .D [] (phonForm := "food"), 410�
     asymmetry that IO asymmetrically c-commands DO. Built planar-first
     so the c-command theorems `decide`. -/
 def ditransitiveTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP t_DP_john)
-      (SO.nodeP (SO.leafP t_voice_ag)
-        (SO.nodeP (SO.leafP t_V_sent)
-          (SO.nodeP (SO.leafP t_DP_mary)
-            (SO.nodeP (SO.leafP t_appl_low) (SO.leafP t_DP_letter))))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_john)
+      (SyntacticObject.nodeP (SyntacticObject.leafP t_voice_ag)
+        (SyntacticObject.nodeP (SyntacticObject.leafP t_V_sent)
+          (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_mary)
+            (SyntacticObject.nodeP (SyntacticObject.leafP t_appl_low)
+              (SyntacticObject.leafP t_DP_letter))))))
 
 /-- High applicative benefactive (Chaga pattern): "he ate food for wife"
 
@@ -406,12 +407,13 @@ def ditransitiveTree : SyntacticObject :=
     theme). High Appl is attested in Bantu languages (Chaga, Luganda,
     Venda) and Albanian, but NOT in English. -/
 def benefactiveTree : SyntacticObject :=
-  SO.ofPlanar
-    (SO.nodeP (SO.leafP t_DP_john)
-      (SO.nodeP (SO.leafP t_voice_ag)
-        (SO.nodeP (SO.leafP t_DP_wife)
-          (SO.nodeP (SO.leafP t_appl_high)
-            (SO.nodeP (SO.leafP t_V_eat) (SO.leafP t_DP_food))))))
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_john)
+      (SyntacticObject.nodeP (SyntacticObject.leafP t_voice_ag)
+        (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_wife)
+          (SyntacticObject.nodeP (SyntacticObject.leafP t_appl_high)
+            (SyntacticObject.nodeP (SyntacticObject.leafP t_V_eat)
+              (SyntacticObject.leafP t_DP_food))))))
 
 -- ============================================================================
 -- § 3: C-command Predictions
@@ -421,40 +423,40 @@ def benefactiveTree : SyntacticObject :=
 
 /-- Agent c-commands goal. -/
 theorem ditransitive_agent_ccommands_goal :
-    SO.cCommandsIn ditransitiveTree DP_john_t DP_mary_t := by decide
+    SyntacticObject.cCommandsIn ditransitiveTree DP_john_t DP_mary_t := by decide
 
 /-- Agent c-commands theme. -/
 theorem ditransitive_agent_ccommands_theme :
-    SO.cCommandsIn ditransitiveTree DP_john_t DP_letter_t := by decide
+    SyntacticObject.cCommandsIn ditransitiveTree DP_john_t DP_letter_t := by decide
 
 /-- Goal c-commands theme — the [barss-lasnik-1986] asymmetry
     derived structurally from V selecting ApplP. -/
 theorem ditransitive_goal_ccommands_theme :
-    SO.cCommandsIn ditransitiveTree DP_mary_t DP_letter_t := by decide
+    SyntacticObject.cCommandsIn ditransitiveTree DP_mary_t DP_letter_t := by decide
 
 /-- Theme does NOT c-command goal: the asymmetry is structural. -/
 theorem ditransitive_theme_not_ccommands_goal :
-    ¬ SO.cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by decide
+    ¬ SyntacticObject.cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by decide
 
 -- Benefactive (high Appl): benefactive > theme
 
 /-- Benefactive c-commands theme. -/
 theorem benefactive_benef_ccommands_theme :
-    SO.cCommandsIn benefactiveTree DP_wife_t DP_food_t := by decide
+    SyntacticObject.cCommandsIn benefactiveTree DP_wife_t DP_food_t := by decide
 
 /-- Theme does NOT c-command benefactive. -/
 theorem benefactive_theme_not_ccommands_benef :
-    ¬ SO.cCommandsIn benefactiveTree DP_food_t DP_wife_t := by decide
+    ¬ SyntacticObject.cCommandsIn benefactiveTree DP_food_t DP_wife_t := by decide
 
 -- Appl head containment
 
 /-- Low applicative marks the ditransitive. -/
 theorem send_is_low_appl :
-    SO.contains ditransitiveTree appl_low_t := by decide
+    SyntacticObject.contains ditransitiveTree appl_low_t := by decide
 
 /-- High applicative marks the benefactive. -/
 theorem eat_is_high_appl :
-    SO.contains benefactiveTree appl_high_t := by decide
+    SyntacticObject.contains benefactiveTree appl_high_t := by decide
 
 -- ============================================================================
 -- § 4: ApplType Association
@@ -654,14 +656,14 @@ open Larson1988 in
     prediction for [barss-lasnik-1986] asymmetries. (Larson's side is
     stated over `docDativeShiftTree`, the planar-built result tree of his
     Dative-Shift derivation; `docDativeShift.final` is noncomputable on
-    the `SO` carrier.) -/
+    the `SyntacticObject` carrier.) -/
 theorem larson_modern_same_hierarchy :
     -- Larson's DOC: IO > DO
-    SO.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
-    ¬ SO.cCommandsIn docDativeShiftTree DP_letter DP_mary ∧
+    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary ∧
     -- Modern Voice/Appl: goal > theme (same asymmetry)
-    SO.cCommandsIn ditransitiveTree DP_mary_t DP_letter_t ∧
-    ¬ SO.cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by
+    SyntacticObject.cCommandsIn ditransitiveTree DP_mary_t DP_letter_t ∧
+    ¬ SyntacticObject.cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 /-! ## §7. Voice as the head that introduces the external argument
@@ -671,7 +673,8 @@ theorem larson_modern_same_hierarchy :
 "Eliminating Linking"): the external argument is *not* projected by
 the verb itself but by a separate Voice head, following
 [kratzer-1996]. Voice combines with VP via Event Identification
-(Event Identification, Ch. 1; -- UNVERIFIED: eq. number), introducing the external argument and relating it to
+(Event Identification, Ch. 1; -- UNVERIFIED: eq. number), introducing the external argument and
+relating it to
 the event described by the verb.
 
 This is one of the two competing views of Voice surveyed in
@@ -836,7 +839,8 @@ theorem analyses_oppose_on_qbind :
 
 Japanese adversity passives split into *gapped* (low source applicative)
 and *gapless* (high applicative). The gapped/gapless distinction itself
-is Kubo's 1992 work (cited by [pylkkanen-2008]; not yet in linglib bib)'s; [pylkkanen-2008]'s contribution is the
+is Kubo's 1992 work (cited by [pylkkanen-2008]; not yet in linglib bib)'s; [pylkkanen-2008]'s
+contribution is the
 reanalysis as a low-source vs. high applicative typology. Both share
 the *-rare-* passive morphology; the distinguishing criterion is the
 possessive/transfer relation to the direct object — the gapped (low

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -329,22 +329,23 @@ theorem guebie_PIC_admits_remnant_movement (φ : Minimalist.Phase)
     What it does establish is that the substrate is *usable*: the
     `properRemnant` predicate is decidable on the witness. -/
 
-open Minimalist (SyntacticObject LIToken LexicalItem SO)
+open Minimalist (SyntacticObject LIToken LexicalItem SyntacticObject)
 open Minimalist.Movement (RemnantFronting PredicateDoubling properRemnant)
 
 /-- A schematic verb leaf for the `PredicateDoubling` witness. -/
 private def guebieVerbTok : LIToken := ⟨.simple .V [], 1⟩
-private def guebieVerbLeaf : SyntacticObject := SO.lexLeaf guebieVerbTok
+private def guebieVerbLeaf : SyntacticObject := SyntacticObject.lexLeaf guebieVerbTok
 
 /-- A schematic remnant-VP node containing the verb leaf as a trace
     pronounced for recoverability. Built planar-first (the smart
-    `SO.node` is noncomputable) so the `decide` proofs below reduce. -/
+    `SyntacticObject.node` is noncomputable) so the `decide` proofs below reduce. -/
 private def guebieFrontedVP : SyntacticObject :=
-  SO.ofPlanar (SO.nodeP (SO.leafP guebieVerbTok) (SO.leafP guebieVerbTok))
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP guebieVerbTok)
+    (SyntacticObject.leafP guebieVerbTok))
 
 /-- A schematic landing-site leaf (Spec,CP). -/
 private def guebieLandingTok : LIToken := ⟨.simple .C [], 2⟩
-private def guebieLandingSite : SyntacticObject := SO.lexLeaf guebieLandingTok
+private def guebieLandingSite : SyntacticObject := SyntacticObject.lexLeaf guebieLandingTok
 
 /-- The Guébie predicate-fronting witness: V evacuates the VP, and
     the remnant VP fronts to Spec,CP. The trace is pronounced — verb
@@ -373,9 +374,9 @@ candidate type the OT machinery uses, which we don't instantiate
 inline). -/
 
 /-- The phase-selector for Guébie's vP cophonology: matches v heads
-    (and only v heads). On the `SO` carrier the selector reads the root
+    (and only v heads). On the `SyntacticObject` carrier the selector reads the root
     leaf's token (`PhrasalCophonology.appliesTo` only ever applies it to a
-    `SO.lexLeaf` of the phase head), so a v head is detected by its
+    `SyntacticObject.lexLeaf` of the phase head), so a v head is detected by its
     outer category. -/
 def guebieVPPhaseSelector : SyntacticObject → Bool := fun s =>
   match s.getLIToken with
@@ -394,10 +395,10 @@ def guebieVPCophonology : PhrasalCophonology Unit Unit :=
     payload  := [] }
 
 /-- The Guébie vP-cophonology applies to a v head. (Witness: a leaf
-    SO whose token's category is `.v`.) -/
+    SyntacticObject whose token's category is `.v`.) -/
 theorem guebieVPCophonology_applies_to_v :
     let vTok : LIToken := ⟨.simple .v [], 99⟩
-    let vHead : SyntacticObject := SO.lexLeaf vTok
+    let vHead : SyntacticObject := SyntacticObject.lexLeaf vTok
     let vPhase : Minimalist.Phase := { tree := vHead, head := vTok }
     guebieVPCophonology.appliesTo vPhase = true := by decide
 
@@ -423,7 +424,7 @@ open Minimalist (VerbDoublingIsSyntacticIn)
 /-- A schematic Guébie Derivation: the verb undergoes Internal Merge
     in the predicate-fronting derivation (per SCD 2026 §3 island
     diagnostics establishing this is narrow-syntactic, not PF). -/
-def guebieFrontingDerivation : Minimalist.SO.Derivation :=
+def guebieFrontingDerivation : Minimalist.SyntacticObject.Derivation :=
   { initial := guebieFrontedVP
     steps   := [.im guebieVerbLeaf] }
 

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -267,11 +267,11 @@ theorem seatOfKnowledge_imperative_resolves {W E P T : Type*}
 theorem sa_is_phase_head (so : SyntacticObject)
     (h : so.outerCatC = some .SA) :
     isPhaseHeadOf .SA so = true := by
-  simp only [isPhaseHeadOf, SO.isPhaseHeadOf, h, beq_self_eq_true]
+  simp only [isPhaseHeadOf, SyntacticObject.isPhaseHeadOf, h, beq_self_eq_true]
 
 /-- SAP is derivation-final (the highest phase). -/
 theorem sa_phase_derivation_final :
-    isPhaseHeadOf .SA (SO.mkLeaf .SA [] 0) = true := by
+    isPhaseHeadOf .SA (SyntacticObject.mkLeaf .SA [] 0) = true := by
   decide
 
 /-- SAP outranks CP on the extended-projection F-hierarchy

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -84,7 +84,7 @@ structure AgreeRelation where
 
 /-- The probe c-commands the goal within a given tree -/
 def AgreeRelation.probeCommands (a : AgreeRelation) (root : SyntacticObject) : Prop :=
-  SO.cCommandsIn root a.probe a.goal
+  SyntacticObject.cCommandsIn root a.probe a.goal
 
 /-- The goal has the relevant valued feature -/
 def AgreeRelation.goalHasFeature (a : AgreeRelation) : Bool :=
@@ -117,11 +117,11 @@ def validAgree (a : AgreeRelation) (root : SyntacticObject) : Prop :=
     `pred`-matching node c-commanded by `probe` c-commanding `goal`. -/
 def closestGoalB (root probe goal : SyntacticObject)
     (pred : SyntacticObject → Bool) : Bool :=
-  decide (SO.cCommandsIn root probe goal) &&
+  decide (SyntacticObject.cCommandsIn root probe goal) &&
   pred goal &&
   (! @decide (∃ x ∈ root.subtrees,
     x ≠ goal ∧ pred x = true ∧
-    SO.cCommandsIn root probe x ∧ SO.cCommandsIn root x goal)
+    SyntacticObject.cCommandsIn root probe x ∧ SyntacticObject.cCommandsIn root x goal)
     Multiset.decidableExistsMultiset)
 
 -- ============================================================================
@@ -130,14 +130,14 @@ def closestGoalB (root probe goal : SyntacticObject)
 
 /-- Per-vertex horizon predicate: leaf with category = horizonCat. -/
 private def isHorizonLeafFor (horizonCat : Cat) (n : SyntacticObject) : Prop :=
-  match SO.getLIToken n with
+  match SyntacticObject.getLIToken n with
   | some tok => tok.item.outerCat = horizonCat
   | none => False
 
 instance (horizonCat : Cat) (n : SyntacticObject) :
     Decidable (isHorizonLeafFor horizonCat n) := by
   unfold isHorizonLeafFor
-  cases SO.getLIToken n <;> infer_instance
+  cases SyntacticObject.getLIToken n <;> infer_instance
 
 /-- Is `target` behind a horizon of category `horizonCat` relative to
     `probe` in tree `root`?
@@ -162,8 +162,8 @@ def behindHorizonB (root probe target : SyntacticObject)
     (horizonCat : Cat) : Bool :=
   @decide (∃ n ∈ root.subtrees,
     isHorizonLeafFor horizonCat n ∧
-    SO.cCommandsIn root n target ∧
-    SO.cCommandsIn root probe n)
+    SyntacticObject.cCommandsIn root n target ∧
+    SyntacticObject.cCommandsIn root probe n)
     Multiset.decidableExistsMultiset
 
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/Agree/Consistency.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Consistency.lean
@@ -12,7 +12,8 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 
 [marcolli-chomsky-berwick-2025]'s account of the syntax–semantics interface replaces a per-feature
 checking *lifecycle* (the retired activate → check → erase state machine with a Boolean
-`convergesAtLF`-style verdict) by a **single recursive map** `φ₊` — the renormalized character of a Birkhoff
+`convergesAtLF`-style verdict) by a **single recursive map** `φ₊` — the renormalized character of a
+Birkhoff
 factorization over the Connes–Kreimer Hopf algebra of the syntactic object, which "recursively
 modifies an initially chosen assignment of semantic values so as to incorporate the consistency
 checking over all substructures" (§3.1.5).
@@ -31,7 +32,7 @@ structural proof.
 ## Main definitions
 
 - `Consistency`: the Boolean consistency semiring (MCB §3.5 Boolean parsing).
-- `SyntacticObject.toCK`: the SO → Connes–Kreimer Hopf algebra bridge `ofTree S.val`.
+- `SyntacticObject.toCK`: the SyntacticObject → Connes–Kreimer Hopf algebra bridge `ofTree S.val`.
 
 ## References
 
@@ -98,7 +99,7 @@ def rbId : RotaBaxterSemiring Consistency where
 
 end Consistency
 
-/-! ### The SO → Hopf algebra bridge -/
+/-! ### The SyntacticObject → Hopf algebra bridge -/
 
 /-- The syntactic object as an element of the Connes–Kreimer Hopf algebra over `ℕ`: the singleton
     forest of its underlying nonplanar tree `S.val : Nonplanar SOLabel`. The base ring is `ℕ`
@@ -114,7 +115,7 @@ noncomputable def SyntacticObject.toCK (S : SyntacticObject) :
 open scoped TensorProduct
 
 /-- The **feature-consistency map** `φ₊` on a syntactic object: the renormalized value of a feature
-    character `φ` (with weight-`+1` Rota–Baxter operator `R`) at the SO. This is
+    character `φ` (with weight-`+1` Rota–Baxter operator `R`) at the SyntacticObject. This is
     [marcolli-chomsky-berwick-2025]'s "single recursive map [that] recursively modifies an
     initially chosen assignment of semantic values so as to incorporate the consistency checking
     over all substructures" — superseding the retired per-feature checking lifecycle. -/
@@ -124,7 +125,8 @@ noncomputable def featureConsistency
   SemiringRenorm.birkhoffPlusTree φ RB S.val
 
 /-- The feature-consistency map factors as the semiring Birkhoff convolution `φ₊ = φ₋ ⋆ φ`
-    ([marcolli-chomsky-berwick-2025] Def. 3.1.6, Prop. 3.1.9): on the SO's Hopf-algebra image
+    ([marcolli-chomsky-berwick-2025] Def. 3.1.6, Prop. 3.1.9): on the SyntacticObject's Hopf-algebra
+    image
     `S.toCK`, the convolution of the Bogolyubov counterterm `φ₋` with the character `φ` recovers the
     consistency verdict. Needs `φ` unital. -/
 theorem featureConsistency_eq_convMul

--- a/Linglib/Syntax/Minimalist/Defs.lean
+++ b/Linglib/Syntax/Minimalist/Defs.lean
@@ -9,7 +9,7 @@ import Linglib.Data.UD.Basic
 The **lexical alphabet** of the Minimalist Program: categorial features,
 lexical items, and the `LIToken` leaves over which syntactic objects are
 built. The `SyntacticObject` carrier itself — the MCB-faithful nonplanar
-`SO` type — lives in `SyntacticObject.lean` (which imports this file for the
+`SyntacticObject` type — lives in `SyntacticObject.lean` (which imports this file for the
 alphabet), so this `Defs` module is carrier-agnostic.
 
 Per [marcolli-chomsky-berwick-2025] Def 1.1.1 (book p. 22), `SO₀` consists of
@@ -178,7 +178,7 @@ def LIToken.phonForm? (tok : LIToken) : Option String :=
 
 /-- LIToken-level c-selection: `selector` selects `selected` iff
     `selector`'s outermost selectional feature equals `selected`'s outer
-    category. A pure `LIToken` relation; no SO structure involved. -/
+    category. A pure `LIToken` relation; no SyntacticObject structure involved. -/
 def LIToken.selects (selector selected : LIToken) : Prop :=
   selector.item.outerSel.head? = some selected.item.outerCat
 
@@ -189,7 +189,7 @@ instance (lt1 lt2 : LIToken) : Decidable (LIToken.selects lt1 lt2) := by
     when a selection check needs an `LIToken` at that position. The `index`
     is recorded in the `id` field (sentinel ≥ 10000) but is **not** part of
     chain identity — MCB chain identity is workspace-level (Def 1.2.1), and the
-    `SO` carrier's trace leaf is bare/index-free. Selection reads only the
+    `SyntacticObject` carrier's trace leaf is bare/index-free. Selection reads only the
     token's category (`.N`) and `outerSel` (`[]`), both index-independent. -/
 def mkTraceToken (index : Nat) : LIToken :=
   ⟨.simple .N [] (phonForm := ""), index + 10000⟩

--- a/Linglib/Syntax/Minimalist/Economy.lean
+++ b/Linglib/Syntax/Minimalist/Economy.lean
@@ -114,7 +114,7 @@ end DerivationCost
     numeration draw.)
     `mergeOps`: total step count.
     `agreeOps`/`ellipsisOps`: not tracked by the step-based model. -/
-def SO.Derivation.cost (d : SO.Derivation) : DerivationCost where
+def SyntacticObject.Derivation.cost (d : SyntacticObject.Derivation) : DerivationCost where
   lexicalItems :=
     d.steps.filter
       (match · with | .emL _ | .emR _ => true | _ => false)

--- a/Linglib/Syntax/Minimalist/LateMerger.lean
+++ b/Linglib/Syntax/Minimalist/LateMerger.lean
@@ -37,10 +37,10 @@ docstring), each chain position is marked by a `.trace n` leaf
 sharing the index `n` with its mover. Either encoding licenses the
 same Late Merger reasoning: the sub-constituent is introduced at any
 admissible chain position, regardless of how that position is
-materialized in the SO. This file's `chain : List ChainPosition`
+materialized in the SyntacticObject. This file's `chain : List ChainPosition`
 abstraction is encoding-agnostic at the API level; the substrate
 choice (trace-as-leaf) shows up only at the level of the concrete
-SO produced after IM.
+SyntacticObject produced after IM.
 
 If the late-merged constituent contains an R-expression that would be
 c-commanded by a coreferential pronoun at the base position, full
@@ -228,7 +228,7 @@ theorem no_case_forces_reconstruction
     `SyntacticObject` trees, complementing the abstract chain-position
     analysis in `wlmForcesReconstruction`. -/
 def conditionCViolation (root binder rExpr : SyntacticObject) : Bool :=
-  decide (SO.cCommandsIn root binder rExpr)
+  decide (SyntacticObject.cCommandsIn root binder rExpr)
 
 /-- Condition C is satisfied in a tree: the binder does NOT c-command
     the R-expression. Takes the tree after any WLM has applied.

--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 
 /-!
-# Externalization on the `SO` carrier
+# Externalization on the `SyntacticObject` carrier
 
 This file defines the selection-induced linearization of syntactic objects
 ([marcolli-chomsky-berwick-2025] §1.12.1, §1.13): the surface token order obtained by
@@ -25,8 +25,9 @@ the book), c-selection computes the planar order.
 * `Minimalist.LinearizationState.sel`: the projection morphism to `SelState`,
   forgetting the order description.
 * `Minimalist.headHom`: the head function as a morphism of magmas
-  `SO →ₙ* LinearizationState side`, refining `selCheckHom` with the yield.
-* `Minimalist.SO.linearize`, `Minimalist.SO.phonYield`: the yield readout and the
+  `SyntacticObject →ₙ* LinearizationState side`, refining `selCheckHom` with the yield.
+* `Minimalist.SyntacticObject.linearize`, `Minimalist.SyntacticObject.phonYield`: the yield readout
+and the
   pronounced surface forms.
 
 ## Main results
@@ -164,7 +165,7 @@ theorem sel_headNode (side : ConventionDir) (a : SOLabel) (ps : List (Linearizat
 
 /-! ### The head function on the planar and nonplanar carriers -/
 
-/-- The head function on planar `SO`-trees: the catamorphism of the head algebra. -/
+/-- The head function on planar `SyntacticObject`-trees: the catamorphism of the head algebra. -/
 def headPlanar (side : ConventionDir) : RoseTree SOLabel → LinearizationState side :=
   RoseTree.fold (headNode side)
 
@@ -195,25 +196,27 @@ theorem headN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
       = headN side (Nonplanar.mk pa) * headN side (Nonplanar.mk pb)
   rw [Nonplanar.node_pair_mk]; exact rfl
 
-/-! ### Externalization on `SO` -/
+/-! ### Externalization on `SyntacticObject` -/
 
 /-- The linearization state of a syntactic object: the value of the head function
     in both descriptions. -/
-def SO.linearizationState (side : ConventionDir) (s : SO) : LinearizationState side :=
+def SyntacticObject.linearizationState (side : ConventionDir) (s : SyntacticObject) :
+    LinearizationState side :=
   headN side s.val
 
-@[simp] theorem SO.linearizationState_node (side : ConventionDir) (l r : SO) :
-    (SO.node l r).linearizationState side
+@[simp] theorem SyntacticObject.linearizationState_node (side : ConventionDir)
+    (l r : SyntacticObject) :
+    (SyntacticObject.node l r).linearizationState side
       = l.linearizationState side * r.linearizationState side := by
-  show headN side (SO.node l r).val = headN side l.val * headN side r.val
-  rw [SO.node_val, headN_node]
+  show headN side (SyntacticObject.node l r).val = headN side l.val * headN side r.val
+  rw [SyntacticObject.node_val, headN_node]
 
-/-- **The head function is a morphism of magmas** `SO →ₙ* LinearizationState side`
+/-- **The head function is a morphism of magmas** `SyntacticObject →ₙ* LinearizationState side`
     ([marcolli-chomsky-berwick-2025] §1.13's algebraic frame): Merge multiplies
     constituents, the head function multiplies linearization states. -/
-noncomputable def headHom (side : ConventionDir) : SO →ₙ* LinearizationState side where
-  toFun := SO.linearizationState side
-  map_mul' := SO.linearizationState_node side
+noncomputable def headHom (side : ConventionDir) : SyntacticObject →ₙ* LinearizationState side where
+  toFun := SyntacticObject.linearizationState side
+  map_mul' := SyntacticObject.linearizationState_node side
 
 /-- **Fusion as a commuting triangle**: projecting the head function's value to its
     selection component is the selection check —
@@ -230,19 +233,20 @@ theorem sel_comp_headHom (side : ConventionDir) :
     section σ_L, defined on `Dom(h)` only (the book's σ_L must extend it
     *noncanonically* off `Dom(h)`). The readout alone is not a morphism: placing a
     yield needs the head leaf, which is why `LinearizationState` carries both descriptions. -/
-def SO.linearize (side : ConventionDir) (s : SO) : Option (List LIToken) :=
+def SyntacticObject.linearize (side : ConventionDir) (s : SyntacticObject) :
+    Option (List LIToken) :=
   Option.map (·.2) (s.linearizationState side)
 
 /-- The pronounced surface forms: the yield with unpronounced (empty-`phonForm`)
     tokens dropped. Traces, being the bare `Sum.inr ()` leaf, contribute nothing. -/
-def SO.phonYield (side : ConventionDir) (s : SO) : Option (List String) :=
-  (SO.linearize side s).map (·.filterMap LIToken.phonForm?)
+def SyntacticObject.phonYield (side : ConventionDir) (s : SyntacticObject) : Option (List String) :=
+  (SyntacticObject.linearize side s).map (·.filterMap LIToken.phonForm?)
 
-@[simp] theorem SO.linearize_lexLeaf (side : ConventionDir) (tok : LIToken) :
-    (SO.lexLeaf tok).linearize side = some [tok] := rfl
+@[simp] theorem SyntacticObject.linearize_lexLeaf (side : ConventionDir) (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).linearize side = some [tok] := rfl
 
-@[simp] theorem SO.linearize_traceLeaf (side : ConventionDir) :
-    SO.traceLeaf.linearize side = some [] := rfl
+@[simp] theorem SyntacticObject.linearize_traceLeaf (side : ConventionDir) :
+    SyntacticObject.traceLeaf.linearize side = some [] := rfl
 
 /-! ### `decide` demonstration
 
@@ -251,7 +255,7 @@ exocentric Merge is order-undefined. -/
 
 /-- A determiner (category `D`, selecting `N`) over a noun: `D` projects, so
     head-initial yields `the dog` and head-final yields `dog the`. -/
-private def demoTheDog : SO :=
+private def demoTheDog : SyntacticObject :=
   ⟨Nonplanar.mk (.node (Sum.inr ())
     [.node (Sum.inl ⟨.simple .D [.N] (phonForm := "the"), 0⟩) [],
      .node (Sum.inl ⟨.simple .N [] (phonForm := "dog"), 1⟩) []]), by decide⟩
@@ -263,7 +267,7 @@ example : demoTheDog.phonYield .final = some ["dog", "the"] := by decide
 
 /-- Exocentric Merge — two saturated `N`s, neither selecting the other — determines
     no head and hence no order: linearization is undefined off `Dom(h)`. -/
-private def demoExo : SO :=
+private def demoExo : SyntacticObject :=
   ⟨Nonplanar.mk (.node (Sum.inr ())
     [.node (Sum.inl ⟨.simple .N [] (phonForm := "cats"), 0⟩) [],
      .node (Sum.inl ⟨.simple .N [] (phonForm := "dogs"), 1⟩) []]), by decide⟩

--- a/Linglib/Syntax/Minimalist/Linearization/Replay.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Replay.lean
@@ -8,17 +8,18 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
 /-!
 # Derivation-grounded externalization (computable PF order)
 
-[marcolli-chomsky-berwick-2025] §1.12. `SO.Derivation.final` is an unordered
+[marcolli-chomsky-berwick-2025] §1.12. `SyntacticObject.Derivation.final` is an unordered
 `Nonplanar` quotient, so the surface left-to-right order is not recoverable from it.
 But a `Derivation` *records* the planarization choices: `emL`/`im` place material on
 the LEFT edge, `emR` on the right — exactly MCB's externalization section σ_L, here
 fixed by the derivation ("the language `L`") rather than a noncanonical `Quot.out`.
 `externalizeP?` replays the steps on an ordered `RoseTree SOLabel` accumulator,
 giving a fully **computable** PF: it never calls the noncomputable
-`SO.node`/`SO.replace` (planar tree surgery + a `Nonplanar.mk` equality test), so
+`SyntacticObject.node`/`SyntacticObject.replace` (planar tree surgery + a `Nonplanar.mk` equality
+test), so
 surface orders `decide`. Traces are unpronounced, dropped by `planarYield`.
 
-The Π-bridge faithfulness theorem `SO.Derivation.externalizeP?_faithful` proves
+The Π-bridge faithfulness theorem `SyntacticObject.Derivation.externalizeP?_faithful` proves
 `Nonplanar.mk externalizeP? = final` whenever the replay succeeds: the surface
 readouts (`surfaceTokens`/`surfaceCats`/`surfacePhon`) are the word order of the
 *actual* derived object. Sibling accounts of linearization: the selection-induced
@@ -38,21 +39,23 @@ the planarization choices: `emL`/`im` place material on the LEFT edge, `emR` on 
 right — exactly MCB's externalization section `σ_L`, here fixed by the derivation ("the
 language `L`") rather than a noncanonical `Quot.out`. The fold below replays the steps on
 an **ordered `RoseTree SOLabel` accumulator**, giving a fully **computable** PF: it never
-calls the noncomputable `SO.node`/`SO.replace` (it uses planar tree surgery + a
+calls the noncomputable `SyntacticObject.node`/`SyntacticObject.replace` (it uses planar tree
+surgery + a
 `Nonplanar.mk` equality test), so surface orders `decide`. Index-free traces are sound
 here: traces are unpronounced, dropped by `planarYield`.
 
-The formal Π-bridge faithfulness theorem (`SO.Derivation.externalizeP?_faithful`, below)
+The formal Π-bridge faithfulness theorem (`SyntacticObject.Derivation.externalizeP?_faithful`,
+below)
 proves `Nonplanar.mk externalizeP? = final` whenever the replay succeeds: the surface
 readouts are the word order of the *actual* derived object, not just a replay that happens
 to reproduce attested orders. The `decide` demos below exercise concrete derivations. -/
 
-/-- Planar form of a leaf/trace `SO` (the only items merged in canonical derivations);
-    `none` for a complex `SO` (no recorded internal order). -/
-def SO.toPlanarLeaf? (s : SO) : Option (RoseTree SOLabel) :=
+/-- Planar form of a leaf/trace `SyntacticObject` (the only items merged in canonical derivations);
+    `none` for a complex `SyntacticObject` (no recorded internal order). -/
+def SyntacticObject.toPlanarLeaf? (s : SyntacticObject) : Option (RoseTree SOLabel) :=
   match s.getLIToken with
-  | some tok => some (SO.leafP tok)
-  | none     => if s = SO.traceLeaf then some SO.traceP else none
+  | some tok => some (SyntacticObject.leafP tok)
+  | none     => if s = SyntacticObject.traceLeaf then some SyntacticObject.traceP else none
 
 /-- Plain left-to-right token yield of an *already-ordered* planar tree; traces
     (`Sum.inr ()`) are unpronounced and contribute nothing. -/
@@ -62,10 +65,11 @@ def planarYield : RoseTree SOLabel → List LIToken
   | .node (.inr ()) [l, r] => planarYield l ++ planarYield r
   | .node (.inr ()) _    => []
 
-/-- "Projects to `target`": a planar subtree whose nonplanar projection is the `SO`
+/-- "Projects to `target`": a planar subtree whose nonplanar projection is the `SyntacticObject`
     `target` — the predicate the `im` replay uses to locate a mover. Computable
     (`DecidableEq (Nonplanar …)`), so it `decide`s. -/
-def projEqP (target : SO) (s : RoseTree SOLabel) : Bool := decide (Nonplanar.mk s = target.val)
+def projEqP (target : SyntacticObject) (s : RoseTree SOLabel) : Bool :=
+  decide (Nonplanar.mk s = target.val)
 
 /-- Leftmost (root-first) subtree satisfying `p`. -/
 def planarFindP? (p : RoseTree SOLabel → Bool) : RoseTree SOLabel → Option (RoseTree SOLabel)
@@ -83,89 +87,98 @@ def planarReplaceWhereP (p : RoseTree SOLabel → Bool) (rep : RoseTree SOLabel)
   | t@(.node _ _)      => if p t then rep else t
 
 /-- Internal Merge on the ordered accumulator: raise the leftmost subtree projecting to
-    `mover` to the LEFT edge, leaving the bare trace `SO.traceP`. `none` if absent. -/
-def moveLeftPlanarP (acc : RoseTree SOLabel) (mover : SO) : Option (RoseTree SOLabel) :=
+    `mover` to the LEFT edge, leaving the bare trace `SyntacticObject.traceP`. `none` if absent. -/
+def moveLeftPlanarP (acc : RoseTree SOLabel) (mover : SyntacticObject) :
+    Option (RoseTree SOLabel) :=
   (planarFindP? (projEqP mover) acc).map fun s =>
-    SO.nodeP s (planarReplaceWhereP (projEqP mover) SO.traceP acc)
+    SyntacticObject.nodeP s (planarReplaceWhereP (projEqP mover) SyntacticObject.traceP acc)
 
-/-- One externalization step on the ordered accumulator (mirrors `SO.Step.apply`). -/
-def externStepP (acc? : Option (RoseTree SOLabel)) (step : SO.Step) : Option (RoseTree SOLabel) :=
+/-- One externalization step on the ordered accumulator (mirrors `SyntacticObject.Step.apply`). -/
+def externStepP (acc? : Option (RoseTree SOLabel)) (step : SyntacticObject.Step) :
+    Option (RoseTree SOLabel) :=
   acc?.bind fun acc => match step with
-    | .emL item  => item.toPlanarLeaf?.map (fun p => SO.nodeP p acc)
-    | .emR item  => item.toPlanarLeaf?.map (fun p => SO.nodeP acc p)
+    | .emL item  => item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP p acc)
+    | .emR item  => item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP acc p)
     | .im mover  => moveLeftPlanarP acc mover
 
-namespace SO.Derivation
+namespace SyntacticObject.Derivation
 
 /-- The derivation's ordered planar representative (MCB `σ_L` for this derivation),
     or `none` if a merged item is complex / a mover is missing. -/
-def externalizeP? (d : SO.Derivation) : Option (RoseTree SOLabel) :=
+def externalizeP? (d : SyntacticObject.Derivation) : Option (RoseTree SOLabel) :=
   d.initial.toPlanarLeaf?.bind fun init => d.steps.foldl externStepP (some init)
 
 /-- Surface (pronounced) tokens, left-to-right; traces dropped. Empty if
     externalization fails. -/
-def surfaceTokens (d : SO.Derivation) : List LIToken :=
+def surfaceTokens (d : SyntacticObject.Derivation) : List LIToken :=
   (d.externalizeP?.map planarYield).getD []
 
 /-- Surface category sequence — the readout used by word-order studies. -/
-def surfaceCats (d : SO.Derivation) : List Cat := d.surfaceTokens.map (·.item.outerCat)
+def surfaceCats (d : SyntacticObject.Derivation) : List Cat := d.surfaceTokens.map (·.item.outerCat)
 
 /-- Surface phonological string: pronounced forms left-to-right (empty forms dropped). -/
-def surfacePhon (d : SO.Derivation) : List String :=
+def surfacePhon (d : SyntacticObject.Derivation) : List String :=
   d.surfaceTokens.filterMap LIToken.phonForm?
 
-end SO.Derivation
+end SyntacticObject.Derivation
 
 /-! ### Π-bridge faithfulness: `Nonplanar.mk externalizeP? = final`
 
 [marcolli-chomsky-berwick-2025] §1.12. The externalization replay (`externStepP` on an
 ordered `RoseTree SOLabel` accumulator) is *faithful* to the abstract derived object: each
-planar op's `Nonplanar.mk` equals the corresponding noncomputable `SO` op, so whenever
+planar op's `Nonplanar.mk` equals the corresponding noncomputable `SyntacticObject` op, so whenever
 the replay succeeds its nonplanar projection is exactly `final`. This upgrades
 `surfaceCats`/`surfacePhon` from "validated by `decide` demos" to "provably the word
-order of the actual derived SO" — the guarantee the word-order studies (Cinque2005,
+order of the actual derived SyntacticObject" — the guarantee the word-order studies (Cinque2005,
 ColeHermon2008, Chomsky1995, …) rely on. -/
 
 /-- `isSOPlanar` of a bare binary node is the conjunction of the children's. -/
 private theorem isSOPlanar_nodeP {a b : RoseTree SOLabel}
-    (ha : isSOPlanar a = true) (hb : isSOPlanar b = true) : isSOPlanar (SO.nodeP a b) = true := by
+    (ha : isSOPlanar a = true) (hb : isSOPlanar b = true) :
+    isSOPlanar (SyntacticObject.nodeP a b) = true := by
   simp only [isSOPlanar, isSOPlanarList, ha, hb, List.length_cons, List.length_nil,
     Nat.reduceAdd, Nat.reduceBEq, Bool.or_true, Bool.and_self]
 
 /-- `Nonplanar.mk` of the planar binary builder is the bare binary nonplanar node. -/
 private theorem mk_nodeP (a b : RoseTree SOLabel) :
-    Nonplanar.mk (SO.nodeP a b) = Nonplanar.node (Sum.inr ()) {Nonplanar.mk a, Nonplanar.mk b} := by
+    Nonplanar.mk (SyntacticObject.nodeP a b)
+      = Nonplanar.node (Sum.inr ()) {Nonplanar.mk a, Nonplanar.mk b} := by
   rw [show ({Nonplanar.mk a, Nonplanar.mk b} : Multiset (Nonplanar SOLabel))
         = Multiset.ofList ([a, b].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
 
 /-- A bare binary node (two children) is never the trace leaf (no children). -/
-private theorem SO.node_ne_traceLeaf (l r : SO) : SO.node l r ≠ SO.traceLeaf := by
+private theorem SyntacticObject.node_ne_traceLeaf (l r : SyntacticObject) :
+    SyntacticObject.node l r ≠ SyntacticObject.traceLeaf := by
   intro heq
-  have ha : (SO.node l r).val.rootChildren = SO.traceLeaf.val.rootChildren := by rw [heq]
-  rw [SO.node_val, Nonplanar.rootChildren_node] at ha
-  simp only [SO.traceLeaf, Nonplanar.leaf_def, Nonplanar.rootChildren_mk, RoseTree.children,
-    Multiset.insert_eq_cons] at ha
+  have ha : (SyntacticObject.node l r).val.rootChildren
+      = SyntacticObject.traceLeaf.val.rootChildren := by rw [heq]
+  rw [SyntacticObject.node_val, Nonplanar.rootChildren_node] at ha
+  simp only [SyntacticObject.traceLeaf, Nonplanar.leaf_def, Nonplanar.rootChildren_mk,
+    RoseTree.children, Multiset.insert_eq_cons] at ha
   exact Multiset.cons_ne_zero ha
 
 /-- **Lemma 1.** A successful `toPlanarLeaf?` projects (under `Nonplanar.mk`) back to the
-    `SO` it came from, and is a well-formed planar leaf. -/
-private theorem toPlanarLeaf?_mk {s : SO} {ip : RoseTree SOLabel} (h : s.toPlanarLeaf? = some ip) :
+    `SyntacticObject` it came from, and is a well-formed planar leaf. -/
+private theorem toPlanarLeaf?_mk {s : SyntacticObject} {ip : RoseTree SOLabel}
+    (h : s.toPlanarLeaf? = some ip) :
     Nonplanar.mk ip = s.val ∧ isSOPlanar ip = true := by
-  induction s using SO.ind with
+  induction s using SyntacticObject.ind with
   | lex tok =>
-    rw [SO.toPlanarLeaf?, SO.getLIToken_lexLeaf] at h
-    obtain rfl : ip = SO.leafP tok := by simpa using h.symm
+    rw [SyntacticObject.toPlanarLeaf?, SyntacticObject.getLIToken_lexLeaf] at h
+    obtain rfl : ip = SyntacticObject.leafP tok := by simpa using h.symm
     exact ⟨rfl, rfl⟩
   | trace =>
-    rw [SO.toPlanarLeaf?, SO.getLIToken_traceLeaf, if_pos rfl] at h
-    obtain rfl : ip = SO.traceP := by simpa using h.symm
+    rw [SyntacticObject.toPlanarLeaf?, SyntacticObject.getLIToken_traceLeaf, if_pos rfl] at h
+    obtain rfl : ip = SyntacticObject.traceP := by simpa using h.symm
     exact ⟨rfl, rfl⟩
   | node l r _ _ =>
-    rw [SO.toPlanarLeaf?, SO.getLIToken_node, if_neg (SO.node_ne_traceLeaf l r)] at h
+    rw [SyntacticObject.toPlanarLeaf?, SyntacticObject.getLIToken_node,
+        if_neg (SyntacticObject.node_ne_traceLeaf l r)] at h
     exact absurd h (by simp)
 
 /-- **Lemma 2.** `projEqP target s` certifies that `s` projects to `target`. -/
-private theorem projEqP_eq {target : SO} {s : RoseTree SOLabel} (h : projEqP target s = true) :
+private theorem projEqP_eq {target : SyntacticObject} {s : RoseTree SOLabel}
+    (h : projEqP target s = true) :
     Nonplanar.mk s = target.val := of_decide_eq_true h
 
 /-- **Lemma 3a.** A subtree raised by `planarFindP?` satisfies the predicate. -/
@@ -184,8 +197,9 @@ private theorem planarFindP?_pred {p : RoseTree SOLabel → Bool} {t s : RoseTre
 
 /-- A bare binary node's children are both well-formed when the node is. -/
 private theorem isSOPlanar_pair_children {l r : RoseTree SOLabel}
-    (ht : isSOPlanar (SO.nodeP l r) = true) : isSOPlanar l = true ∧ isSOPlanar r = true := by
-  rw [SO.nodeP, isSOPlanar, isSOPlanarList, isSOPlanarList, isSOPlanarList,
+    (ht : isSOPlanar (SyntacticObject.nodeP l r) = true) :
+    isSOPlanar l = true ∧ isSOPlanar r = true := by
+  rw [SyntacticObject.nodeP, isSOPlanar, isSOPlanarList, isSOPlanarList, isSOPlanarList,
     Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at ht
   exact ⟨ht.2.1, ht.2.2.1⟩
 
@@ -224,21 +238,24 @@ private theorem isSOPlanar_length {a : SOLabel} {cs : List (RoseTree SOLabel)}
     exact ht.1
 
 /-- `projEqP` reflects (in)equality of the nonplanar projection to the target. -/
-private theorem not_projEqP {target : SO} {s : RoseTree SOLabel}
+private theorem not_projEqP {target : SyntacticObject} {s : RoseTree SOLabel}
     (h : ¬ projEqP target s = true) : Nonplanar.mk s ≠ target.val := by
   rw [projEqP, decide_eq_true_eq] at h; exact h
 
 /-- **Lemma 4 (CRUX): the replace bridge.** On a well-formed planar tree, the computable
-    planar replacement (`planarReplaceWhereP (projEqP target) SO.traceP`) projects under
-    `Nonplanar.mk` to the abstract structural substitution `replaceN target SO.traceLeaf`,
+    planar replacement (`planarReplaceWhereP (projEqP target) SyntacticObject.traceP`) projects
+    under
+    `Nonplanar.mk` to the abstract structural substitution `replaceN target
+    SyntacticObject.traceLeaf`,
     and stays well-formed. The two `if`-conditions agree (`projEqP target s = true ↔
     Nonplanar.mk s = target.val`), and the recursive bare-binary case lines up with
     `replaceN_node`'s else branch (`{·,·}` multiset built from the two daughters). -/
-private theorem replaceWhereP_mk (target : SO) {t : RoseTree SOLabel} (ht : isSOPlanar t = true) :
-    Nonplanar.mk (planarReplaceWhereP (projEqP target) SO.traceP t)
-        = replaceN target.val SO.traceLeaf.val (Nonplanar.mk t)
-      ∧ isSOPlanar (planarReplaceWhereP (projEqP target) SO.traceP t) = true := by
-  fun_induction planarReplaceWhereP (projEqP target) SO.traceP t with
+private theorem replaceWhereP_mk (target : SyntacticObject) {t : RoseTree SOLabel}
+    (ht : isSOPlanar t = true) :
+    Nonplanar.mk (planarReplaceWhereP (projEqP target) SyntacticObject.traceP t)
+        = replaceN target.val SyntacticObject.traceLeaf.val (Nonplanar.mk t)
+      ∧ isSOPlanar (planarReplaceWhereP (projEqP target) SyntacticObject.traceP t) = true := by
+  fun_induction planarReplaceWhereP (projEqP target) SyntacticObject.traceP t with
   | case1 _ hp =>
     refine ⟨?_, rfl⟩
     rw [projEqP_eq hp, replaceN_self]; rfl
@@ -263,10 +280,11 @@ private theorem replaceWhereP_mk (target : SO) {t : RoseTree SOLabel} (ht : isSO
     refine ⟨?_, isSOPlanar_nodeP ihls ihrs⟩
     have hne : Nonplanar.node (Sum.inr ()) {Nonplanar.mk l, Nonplanar.mk r} ≠ target.val := by
       rw [← mk_nodeP]; exact not_projEqP hp
-    rw [show RoseTree.node (Sum.inr ()) [planarReplaceWhereP (projEqP target) SO.traceP l,
-          planarReplaceWhereP (projEqP target) SO.traceP r]
-        = SO.nodeP (planarReplaceWhereP (projEqP target) SO.traceP l)
-          (planarReplaceWhereP (projEqP target) SO.traceP r) from rfl,
+    rw [show RoseTree.node (Sum.inr ())
+          [planarReplaceWhereP (projEqP target) SyntacticObject.traceP l,
+          planarReplaceWhereP (projEqP target) SyntacticObject.traceP r]
+        = SyntacticObject.nodeP (planarReplaceWhereP (projEqP target) SyntacticObject.traceP l)
+          (planarReplaceWhereP (projEqP target) SyntacticObject.traceP r) from rfl,
       mk_nodeP, ihle, ihre, mk_nodeP, replaceN_node, if_neg hne]
   | case5 _ cs hnil hpair _ =>
     rcases isSOPlanar_length ht with hlen | hlen
@@ -278,30 +296,31 @@ private theorem replaceWhereP_mk (target : SO) {t : RoseTree SOLabel} (ht : isSO
     · obtain ⟨x, y, rfl⟩ := List.length_eq_two.mp hlen; exact absurd rfl (hpair x y)
 
 /-- **Lemma 6: per-step faithfulness.** A successful replay step on a well-formed
-    accumulator stays well-formed and projects to the abstract `SO.Step.apply`. -/
-private theorem externStepP_step {acc : SO} {accp p' : RoseTree SOLabel} {step : SO.Step}
+    accumulator stays well-formed and projects to the abstract `SyntacticObject.Step.apply`. -/
+private theorem externStepP_step {acc : SyntacticObject} {accp p' : RoseTree SOLabel}
+    {step : SyntacticObject.Step}
     (h : externStepP (some accp) step = some p') (hwf : isSOPlanar accp = true)
     (hmk : Nonplanar.mk accp = acc.val) :
     isSOPlanar p' = true ∧ Nonplanar.mk p' = (step.apply acc).val := by
   cases step with
   | emL item =>
-    change item.toPlanarLeaf?.map (fun p => SO.nodeP p accp) = some p' at h
+    change item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP p accp) = some p' at h
     rcases hip : item.toPlanarLeaf? with _ | ip
     · rw [hip, Option.map_none] at h; exact absurd h (by simp)
     · rw [hip, Option.map_some] at h
       obtain rfl := Option.some.inj h
       obtain ⟨hmkip, hwfip⟩ := toPlanarLeaf?_mk hip
       refine ⟨isSOPlanar_nodeP hwfip hwf, ?_⟩
-      rw [SO.Step.apply, SO.merge_val, mk_nodeP, hmkip, hmk]
+      rw [SyntacticObject.Step.apply, SyntacticObject.merge_val, mk_nodeP, hmkip, hmk]
   | emR item =>
-    change item.toPlanarLeaf?.map (fun p => SO.nodeP accp p) = some p' at h
+    change item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP accp p) = some p' at h
     rcases hip : item.toPlanarLeaf? with _ | ip
     · rw [hip, Option.map_none] at h; exact absurd h (by simp)
     · rw [hip, Option.map_some] at h
       obtain rfl := Option.some.inj h
       obtain ⟨hmkip, hwfip⟩ := toPlanarLeaf?_mk hip
       refine ⟨isSOPlanar_nodeP hwf hwfip, ?_⟩
-      rw [SO.Step.apply, SO.merge_val, mk_nodeP, hmkip, hmk]
+      rw [SyntacticObject.Step.apply, SyntacticObject.merge_val, mk_nodeP, hmkip, hmk]
   | im mover =>
     change moveLeftPlanarP accp mover = some p' at h
     rw [moveLeftPlanarP] at h
@@ -313,19 +332,22 @@ private theorem externStepP_step {acc : SO} {accp p' : RoseTree SOLabel} {step :
       have hwfs : isSOPlanar s = true := planarFindP?_isSOPlanar hfind hwf
       obtain ⟨hrwe, hrws⟩ := replaceWhereP_mk mover hwf
       refine ⟨isSOPlanar_nodeP hwfs hrws, ?_⟩
-      rw [SO.Step.apply, SO.intMerge_val, SO.deleteAccessible_val, mk_nodeP, hmks, hrwe, hmk]
+      rw [SyntacticObject.Step.apply, SyntacticObject.intMerge_val,
+          SyntacticObject.deleteAccessible_val, mk_nodeP, hmks, hrwe, hmk]
       exact congrArg (Nonplanar.node (Sum.inr ())) (Multiset.cons_swap _ _ _)
 
 /-- `none` is absorbing for the replay fold: once externalization fails, it stays failed. -/
-private theorem foldl_externStepP_none (steps : List SO.Step) :
+private theorem foldl_externStepP_none (steps : List SyntacticObject.Step) :
     steps.foldl externStepP none = none := by
   induction steps with
   | nil => rfl
   | cons st rest ih => rw [List.foldl_cons, show externStepP none st = none from rfl]; exact ih
 
 /-- **Lemma 7: foldl faithfulness.** A successful replay fold from a well-formed,
-    faithful accumulator projects to the abstract `final`-style fold of `SO.Step.apply`. -/
-private theorem foldl_externStepP_mk : ∀ (steps : List SO.Step) {acc : SO} {accp p : RoseTree SOLabel},
+    faithful accumulator projects to the abstract `final`-style fold of
+    `SyntacticObject.Step.apply`. -/
+private theorem foldl_externStepP_mk :
+    ∀ (steps : List SyntacticObject.Step) {acc : SyntacticObject} {accp p : RoseTree SOLabel},
     steps.foldl externStepP (some accp) = some p → isSOPlanar accp = true →
     Nonplanar.mk accp = acc.val →
     Nonplanar.mk p = (steps.foldl (fun so st => st.apply so) acc).val
@@ -346,9 +368,10 @@ private theorem foldl_externStepP_mk : ∀ (steps : List SO.Step) {acc : SO} {ac
     derived syntactic object — the guarantee the word-order studies depend on. The replay
     is partial by design (EM of a complex item / a missing mover ⇒ `none`, making the claim
     vacuous there); on the canonical leaf/trace derivations the studies build, it succeeds. -/
-theorem SO.Derivation.externalizeP?_faithful (d : SO.Derivation) {p : RoseTree SOLabel}
+theorem SyntacticObject.Derivation.externalizeP?_faithful (d : SyntacticObject.Derivation)
+    {p : RoseTree SOLabel}
     (h : d.externalizeP? = some p) : Nonplanar.mk p = d.final.val := by
-  rw [SO.Derivation.externalizeP?] at h
+  rw [SyntacticObject.Derivation.externalizeP?] at h
   rcases hinit : d.initial.toPlanarLeaf? with _ | init
   · rw [hinit] at h; exact absurd h (by simp [Option.bind])
   · rw [hinit] at h
@@ -363,26 +386,27 @@ Dem-N-A-Num (raise N around A, then pied-pipe `[N A]` around Num) is distinct fr
 Dem-A-N-Num (pied-pipe `[A N]` around Num). Movers are built with the computable DSL so
 the surface orders `decide`. (`.D` stands in for the demonstrative.) -/
 
-private def xN : SO := SO.mkLeaf .N [] 1
-private def xA : SO := SO.mkLeaf .A [] 2
-private def xNum : SO := SO.mkLeaf .Num [] 3
-private def xD : SO := SO.mkLeaf .D [] 4
+private def xN : SyntacticObject := SyntacticObject.mkLeaf .N [] 1
+private def xA : SyntacticObject := SyntacticObject.mkLeaf .A [] 2
+private def xNum : SyntacticObject := SyntacticObject.mkLeaf .Num [] 3
+private def xD : SyntacticObject := SyntacticObject.mkLeaf .D [] 4
 /-- The pied-piped `[N [A t]]` mover (built planar-first, so it is computable). -/
-private def xNAt : SO :=
-  SO.ofPlanar (SO.nodeP (SO.leafP ⟨.simple .N [], 1⟩)
-    (SO.nodeP (SO.leafP ⟨.simple .A [], 2⟩) SO.traceP))
+private def xNAt : SyntacticObject :=
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .N [], 1⟩)
+    (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .A [], 2⟩) SyntacticObject.traceP))
 /-- The pied-piped `[A N]` mover. -/
-private def xAN : SO :=
-  SO.ofPlanar (SO.nodeP (SO.leafP ⟨.simple .A [], 2⟩) (SO.leafP ⟨.simple .N [], 1⟩))
+private def xAN : SyntacticObject :=
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .A [], 2⟩)
+    (SyntacticObject.leafP ⟨.simple .N [], 1⟩))
 
 /-- No movement: `Dem Num A N`. -/
-private def xDerivBase : SO.Derivation :=
+private def xDerivBase : SyntacticObject.Derivation :=
   ⟨xN, [.emL xA, .emL xNum, .emL xD]⟩
 /-- Raise N around A, pied-pipe `[N A]` around Num: `Dem N A Num`. -/
-private def xDerivO : SO.Derivation :=
+private def xDerivO : SyntacticObject.Derivation :=
   ⟨xN, [.emL xA, .im xN, .emL xNum, .im xNAt, .emL xD]⟩
 /-- Pied-pipe `[A N]` around Num, no sub-raise: `Dem A N Num`. -/
-private def xDerivN : SO.Derivation :=
+private def xDerivN : SyntacticObject.Derivation :=
   ⟨xN, [.emL xA, .emL xNum, .im xAN, .emL xD]⟩
 
 example : xDerivBase.surfaceCats = [.D, .Num, .A, .N] := by decide

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -312,7 +312,7 @@ theorem mergeOp_pair_residual {R : Type*} [CommSemiring R] {α : Type*}
 /-! The linguistic External-Merge bridges `mergeOp_emR/emL_matches_Step` (which
 related `mergeOp (Sum.inl L)` on the head-decorated `toNonplanar` projection to the
 legacy `Step.emR/emL`) have been retired by the single-carrier migration. On the
-bare `SO` carrier the bridge is `Workspace.lean`'s `SO.merge_toForest`
+bare `SyntacticObject` carrier the bridge is `Workspace.lean`'s `SyntacticObject.merge_toForest`
 (`mergeOp_pair` with the bare `Sum.inr ()` label). -/
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/Internal.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Internal.lean
@@ -159,8 +159,8 @@ theorem mergeOp_im_composition
 /-! The linguistic Internal-Merge bridge `mergeOp_im_matches_Step` (which related the
 `mergeOp ∘ mergeOpUnit` composition on the head-decorated `toNonplanar` projection to
 the legacy `Step.im` + `⊕ Nat` trace index) has been retired by the single-carrier
-migration. On the bare `SO` carrier the bridge is `Workspace.lean`'s
-`SO.intMerge_toForest` (`mergeOp_im_composition` with the bare `Sum.inr ()` label and
-the index-free `SO.traceLeaf`). -/
+migration. On the bare `SyntacticObject` carrier the bridge is `Workspace.lean`'s
+`SyntacticObject.intMerge_toForest` (`mergeOp_im_composition` with the bare `Sum.inr ()` label and
+the index-free `SyntacticObject.traceLeaf`). -/
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Movement/Remnant.lean
+++ b/Linglib/Syntax/Minimalist/Movement/Remnant.lean
@@ -119,7 +119,7 @@ structure RemnantFronting where
     heads' traces are spelled out (verb doubling vs. silent copy) — that
     is a per-construction choice. -/
 def properRemnant (rf : RemnantFronting) : Prop :=
-  ∀ h ∈ rf.evacuatedHeads, SO.contains rf.frontedXP h
+  ∀ h ∈ rf.evacuatedHeads, SyntacticObject.contains rf.frontedXP h
 
 instance (rf : RemnantFronting) : Decidable (properRemnant rf) := by
   unfold properRemnant; infer_instance
@@ -151,7 +151,7 @@ structure PredicateDoubling extends RemnantFronting where
     sat originally inside the fronted XP. -/
 theorem predicateDoubling_verb_in_frontedXP
     (pd : PredicateDoubling) (h : properRemnant pd.toRemnantFronting) :
-    SO.contains pd.frontedXP pd.verb :=
+    SyntacticObject.contains pd.frontedXP pd.verb :=
   h pd.verb pd.verb_evacuated
 
 end Minimalist.Movement

--- a/Linglib/Syntax/Minimalist/Phase/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Basic.lean
@@ -10,10 +10,11 @@ import Linglib.Syntax.Minimalist.Features
 # Phase Theory (linguistic-facing API)
 
 Formalization of derivational phases following [chomsky-2000], [abels-2012], and
-[citko-2014], built **directly on the `SO`-carrier phase domain**
+[citko-2014], built **directly on the `SyntacticObject`-carrier phase domain**
 (`Phase/Domain.lean`, MCB §1.14). This file packages the carrier-native
-primitives (`SO.isPhaseHeadOf`, `SO.phase`/`phaseInterior`/`phaseEdge`,
-`SO.Impenetrable`, `SO.isPhaseHead`) into the study-facing `Phase` record + the
+primitives (`SyntacticObject.isPhaseHeadOf`, `SyntacticObject.phase`/`phaseInterior`/`phaseEdge`,
+`SyntacticObject.Impenetrable`, `SyntacticObject.isPhaseHead`) into the study-facing `Phase` record
++ the
 PIC-strength / Transfer / feature-inheritance / DP-deactivation layer that the
 paper-anchored study files consume.
 
@@ -27,10 +28,10 @@ paper-anchored study files consume.
 
 ## Design
 
-A `Phase` is a `tree`-relative `(tree, head)` pair: the head function on `SO` is the
-**selection-driven head** (`SO.selHead`, Lemma 1.13.7), so the phase domain is read
+A `Phase` is a `tree`-relative `(tree, head)` pair: the head function on `SyntacticObject` is the
+**selection-driven head** (`SyntacticObject.selHead`, Lemma 1.13.7), so the phase domain is read
 off the carrier with no separate head-function field. Every phase notion delegates to
-the `SO.*` phase API, so concrete PIC checks `decide`. `isPhaseHeadOf c so` is the
+the `SyntacticObject.*` phase API, so concrete PIC checks `decide`. `isPhaseHeadOf c so` is the
 projecting head's outer category — convention-independent (the carrier is unordered).
 -/
 
@@ -44,7 +45,7 @@ namespace Minimalist
     exactly `c`? ([marcolli-chomsky-berwick-2025] Lemma 1.13.7 — the selector
     projects.) Computable and convention-independent; `none` (≠ `some c`) at
     exocentric nodes. -/
-def isPhaseHeadOf (c : Cat) (so : SyntacticObject) : Bool := SO.isPhaseHeadOf c so
+def isPhaseHeadOf (c : Cat) (so : SyntacticObject) : Bool := SyntacticObject.isPhaseHeadOf c so
 
 /-! ### Phase-head selectors
 
@@ -88,15 +89,15 @@ inductive PICStrength where
   deriving Repr, DecidableEq
 
 -- ============================================================================
--- Part 3: Phase (MCB §1.14 — grounded in the selection head on `SO`)
+-- Part 3: Phase (MCB §1.14 — grounded in the selection head on `SyntacticObject`)
 -- ============================================================================
 
 /-- A **phase** ([marcolli-chomsky-berwick-2025] §1.14): a phase-head leaf `head`
     together with the containing tree `tree`. Phases are tree-relative; the head
-    function is the carrier-native selection head (`SO.selHead`), so no separate
+    function is the carrier-native selection head (`SyntacticObject.selHead`), so no separate
     head-function field is needed. Every phase notion — content `Φ_ℓ` (eq 1.14.2),
     interior `Φ°_ℓ` (eq 1.14.3), edge `∂Φ_ℓ` (eq 1.14.4) — is a derived accessor over
-    the `SO.*` phase API.
+    the `SyntacticObject.*` phase API.
 
     Per-analysis discipline (Keine 2020 C-only; Chomsky 2000/2001 C+v; Pietraszko 2026
     / Erlewine & Sommerlot 2025 also Voice; Citko 2014 also D) is expressed by *which
@@ -131,10 +132,10 @@ instance (φ : Phase) (goal : SyntacticObject) : Decidable (φ.Impenetrable goal
 
 /-- A genuine phase: its head projects nontrivially (`head ∈ L_Φ(T)`, MCB Def 1.14.3
     eq 1.14.1) — `γ_ℓ` reaches an internal vertex. -/
-def IsWellFormed (φ : Phase) : Prop := SO.isPhaseHead φ.tree φ.head
+def IsWellFormed (φ : Phase) : Prop := SyntacticObject.isPhaseHead φ.tree φ.head
 
 instance (φ : Phase) : Decidable φ.IsWellFormed :=
-  inferInstanceAs (Decidable (SO.isPhaseHead _ _))
+  inferInstanceAs (Decidable (SyntacticObject.isPhaseHead _ _))
 
 /-! ### Spell-out triggers
 
@@ -155,9 +156,9 @@ structure Trigger (P : Type*) where
 variable {P : Type*}
 
 /-- A trigger applies to a phase iff its `selector` matches the phase head (the head
-leaf `ph.head`, as a leaf SO). -/
+leaf `ph.head`, as a leaf SyntacticObject). -/
 def Trigger.appliesTo (tr : Trigger P) (ph : Phase) : Bool :=
-  tr.selector (SO.lexLeaf ph.head)
+  tr.selector (SyntacticObject.lexLeaf ph.head)
 
 /-- The *first* registered trigger whose `selector` matches the phase head —
 first-match encodes lexicographic precedence (the elsewhere ordering of
@@ -265,7 +266,7 @@ structure FeatureInheritance where
   /-- The head receiving features (T, V, vMOD). -/
   target : SyntacticObject
   /-- Source must immediately contain target. -/
-  locality : SO.immediatelyContains source target
+  locality : SyntacticObject.immediatelyContains source target
   /-- Which transfer operation applies (default: classical [chomsky-2008] donate). -/
   style : TransferStyle := .donate
   /-- The features transferred (default: none specified at this layer). -/

--- a/Linglib/Syntax/Minimalist/Phase/Domain.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Domain.lean
@@ -8,12 +8,12 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
 import Linglib.Syntax.Minimalist.SyntacticObject.Build
 
 /-!
-# Phase theory on the `SO` carrier
+# Phase theory on the `SyntacticObject` carrier
 
 [marcolli-chomsky-berwick-2025] §1.14 (Def 1.14.1–1.14.4); [chomsky-2000].
 
 **P3b — phase-head identification**: derived from the **selection-driven head**
-(`SO.outerCatC`, #800) — the projecting head's outer category. Because the head is
+(`SyntacticObject.outerCatC`, #800) — the projecting head's outer category. Because the head is
 the *selector* (Lemma 1.13.7), the test is **convention-independent** (the carrier
 is unordered anyway).
 
@@ -37,7 +37,7 @@ namespace Minimalist
 
 open RootedTree
 
-/-- **Phase-head test on `SO`** ([marcolli-chomsky-berwick-2025] Lemma 1.13.7):
+/-- **Phase-head test on `SyntacticObject`** ([marcolli-chomsky-berwick-2025] Lemma 1.13.7):
     is the projecting (selection-driven) head's outer category exactly `c`?
     `none` (≠ `some c`) at exocentric nodes. The carrier-native counterpart of
     `Minimalist.isPhaseHeadOf`.
@@ -45,15 +45,15 @@ open RootedTree
     Phase-head selectors (call directly): C — `isPhaseHeadOf .C` (linglib default
     per [keine-2020]; the Chomsky v-phase extension is `… .C s || … .v s`); D —
     `isPhaseHeadOf .D` ([citko-2014]); SA — `isPhaseHeadOf .SA`. -/
-def SO.isPhaseHeadOf (c : Cat) (s : SO) : Bool := s.outerCatC == some c
+def SyntacticObject.isPhaseHeadOf (c : Cat) (s : SyntacticObject) : Bool := s.outerCatC == some c
 
-@[simp] theorem SO.isPhaseHeadOf_lexLeaf (c : Cat) (tok : LIToken) :
-    SO.isPhaseHeadOf c (SO.lexLeaf tok) = (tok.item.outerCat == c) := by
-  rw [SO.isPhaseHeadOf, SO.outerCatC_lexLeaf]; rfl
+@[simp] theorem SyntacticObject.isPhaseHeadOf_lexLeaf (c : Cat) (tok : LIToken) :
+    SyntacticObject.isPhaseHeadOf c (SyntacticObject.lexLeaf tok) = (tok.item.outerCat == c) := by
+  rw [SyntacticObject.isPhaseHeadOf, SyntacticObject.outerCatC_lexLeaf]; rfl
 
 /-! ### The phase domain (MCB Def 1.14.2–1.14.3)
 
-The head function on `SO` is `selHead` (#800); a phase is relative to a tree `T` and
+The head function on `SyntacticObject` is `selHead` (#800); a phase is relative to a tree `T` and
 a phase-head leaf `ℓ` (the study supplies *which* leaf, per the per-analysis
 discipline — C / C+v / +D / +Voice). Every notion is a filter over the invariant
 subterm API (`subtrees`/`Acc`/`containsOrEq`/`areSistersIn`/`cCommandsIn`), so it
@@ -63,10 +63,11 @@ subterm API (`subtrees`/`Acc`/`containsOrEq`/`areSistersIn`/`cCommandsIn`), so i
     **phase head** in `T` when its projection path γ_ℓ is nontrivial — the leaf
     `lexLeaf ℓ` has a mother whose head is still `ℓ` (so γ_ℓ reaches an internal
     vertex). Read off `selHead` at the mother; section-free. -/
-def SO.isPhaseHead (T : SO) (ℓ : LIToken) : Prop :=
-  ∃ n ∈ T.subtrees, SO.immediatelyContains n (SO.lexLeaf ℓ) ∧ n.selHead = some ℓ
+def SyntacticObject.isPhaseHead (T : SyntacticObject) (ℓ : LIToken) : Prop :=
+  ∃ n ∈ T.subtrees,
+    SyntacticObject.immediatelyContains n (SyntacticObject.lexLeaf ℓ) ∧ n.selHead = some ℓ
 
-instance (T : SO) (ℓ : LIToken) : Decidable (SO.isPhaseHead T ℓ) :=
+instance (T : SyntacticObject) (ℓ : LIToken) : Decidable (SyntacticObject.isPhaseHead T ℓ) :=
   Multiset.decidableExistsMultiset
 
 /-- **Within the maximal projection** `T_v ⊆ T_{v_ℓ}`
@@ -74,17 +75,19 @@ instance (T : SO) (ℓ : LIToken) : Decidable (SO.isPhaseHead T ℓ) :=
     `T_v` is contained in *some* `ℓ`-headed subtree. The maximal projection `v_ℓ`
     is the largest `ℓ`-headed subtree, so `T_v ⊆ T_{v_ℓ}` iff `T_v` sits inside one
     of them (all `ℓ`-headed vertices lie on γ_ℓ below `v_ℓ`). -/
-def SO.withinProjection (T : SO) (ℓ : LIToken) (Tv : SO) : Prop :=
-  ∃ p ∈ T.subtrees, p.selHead = some ℓ ∧ SO.containsOrEq p Tv
+def SyntacticObject.withinProjection (T : SyntacticObject) (ℓ : LIToken)
+    (Tv : SyntacticObject) : Prop :=
+  ∃ p ∈ T.subtrees, p.selHead = some ℓ ∧ SyntacticObject.containsOrEq p Tv
 
-instance (T : SO) (ℓ : LIToken) (Tv : SO) : Decidable (SO.withinProjection T ℓ Tv) :=
+instance (T : SyntacticObject) (ℓ : LIToken) (Tv : SyntacticObject) :
+    Decidable (SyntacticObject.withinProjection T ℓ Tv) :=
   Multiset.decidableExistsMultiset
 
 /-- **The phase Φ_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.2):
     `{T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ}}` — all accessible terms within the maximal
     projection (`Acc'(T) = T.subtrees`, including the root). -/
-def SO.phase (T : SO) (ℓ : LIToken) : Multiset SO :=
-  T.subtrees.filter (fun Tv => SO.withinProjection T ℓ Tv)
+def SyntacticObject.phase (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
+  T.subtrees.filter (fun Tv => SyntacticObject.withinProjection T ℓ Tv)
 
 /-- **The interior Φ°_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.3):
     `{T_v ∈ Acc(T) | T_v ⊆ T_{s_ℓ}}` — the head's sister `T_{s_ℓ}` and all of its
@@ -94,45 +97,52 @@ def SO.phase (T : SO) (ℓ : LIToken) : Multiset SO :=
     sister of `ℓ` contains-or-equals `T_v`, i.e. `cCommandsIn T (lexLeaf ℓ) T_v`
     (#798). The textbook "complement domain = head's c-command domain", by
     construction — and `Acc(T) = T.Acc` (non-root). -/
-def SO.phaseInterior (T : SO) (ℓ : LIToken) : Multiset SO :=
-  T.Acc.filter (fun Tv => SO.cCommandsIn T (SO.lexLeaf ℓ) Tv)
+def SyntacticObject.phaseInterior (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
+  T.Acc.filter (fun Tv => SyntacticObject.cCommandsIn T (SyntacticObject.lexLeaf ℓ) Tv)
 
 /-- **The edge ∂Φ_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.4):
     `{T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ} ∧ T_v ⊄ T_{s_ℓ}}` — the phase content not in
     the interior (head, specifiers, modifiers); `= Φ_ℓ` when the complement is
     empty. Computed as `phase ∖ interior`. -/
-def SO.phaseEdge (T : SO) (ℓ : LIToken) : Multiset SO :=
+def SyntacticObject.phaseEdge (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
   (T.phase ℓ).filter (fun Tv => Tv ∉ T.phaseInterior ℓ)
 
 /-- **Phase Impenetrability Condition**: `goal` is frozen in the phase headed by `ℓ`
     iff it lies in the interior (= the complement domain). True by construction — the
     PIC *is* interior membership ([marcolli-chomsky-berwick-2025] §1.14). -/
-def SO.Impenetrable (T : SO) (ℓ : LIToken) (goal : SO) : Prop :=
+def SyntacticObject.Impenetrable (T : SyntacticObject) (ℓ : LIToken)
+    (goal : SyntacticObject) : Prop :=
   goal ∈ T.phaseInterior ℓ
 
-instance (T : SO) (ℓ : LIToken) (goal : SO) : Decidable (SO.Impenetrable T ℓ goal) :=
+instance (T : SyntacticObject) (ℓ : LIToken) (goal : SyntacticObject) :
+    Decidable (SyntacticObject.Impenetrable T ℓ goal) :=
   inferInstanceAs (Decidable (_ ∈ _))
 
 /-! ### Membership characterizations -/
 
-@[simp] theorem SO.mem_phase {T : SO} {ℓ : LIToken} {Tv : SO} :
-    Tv ∈ T.phase ℓ ↔ Tv ∈ T.subtrees ∧ SO.withinProjection T ℓ Tv :=
+@[simp] theorem SyntacticObject.mem_phase {T : SyntacticObject} {ℓ : LIToken}
+    {Tv : SyntacticObject} :
+    Tv ∈ T.phase ℓ ↔ Tv ∈ T.subtrees ∧ SyntacticObject.withinProjection T ℓ Tv :=
   Multiset.mem_filter
 
 /-- **The interior is the phase head's (non-root) c-command domain** — the keystone
     identity (MCB Def 1.14.3, "Z is the interior of the phase"). -/
-@[simp] theorem SO.mem_phaseInterior {T : SO} {ℓ : LIToken} {Tv : SO} :
-    Tv ∈ T.phaseInterior ℓ ↔ Tv ∈ T.Acc ∧ T.cCommandsIn (SO.lexLeaf ℓ) Tv :=
+@[simp] theorem SyntacticObject.mem_phaseInterior {T : SyntacticObject} {ℓ : LIToken}
+    {Tv : SyntacticObject} :
+    Tv ∈ T.phaseInterior ℓ ↔ Tv ∈ T.Acc ∧ T.cCommandsIn (SyntacticObject.lexLeaf ℓ) Tv :=
   Multiset.mem_filter
 
-@[simp] theorem SO.mem_phaseEdge {T : SO} {ℓ : LIToken} {Tv : SO} :
+@[simp] theorem SyntacticObject.mem_phaseEdge {T : SyntacticObject} {ℓ : LIToken}
+    {Tv : SyntacticObject} :
     Tv ∈ T.phaseEdge ℓ ↔ Tv ∈ T.phase ℓ ∧ Tv ∉ T.phaseInterior ℓ :=
   Multiset.mem_filter
 
 /-- The PIC freezes exactly the head's (non-root) c-command domain. -/
-theorem SO.Impenetrable_iff {T : SO} {ℓ : LIToken} {goal : SO} :
-    SO.Impenetrable T ℓ goal ↔ goal ∈ T.Acc ∧ T.cCommandsIn (SO.lexLeaf ℓ) goal :=
-  SO.mem_phaseInterior
+theorem SyntacticObject.Impenetrable_iff {T : SyntacticObject} {ℓ : LIToken}
+    {goal : SyntacticObject} :
+    SyntacticObject.Impenetrable T ℓ goal ↔
+      goal ∈ T.Acc ∧ T.cCommandsIn (SyntacticObject.lexLeaf ℓ) goal :=
+  SyntacticObject.mem_phaseInterior
 
 /-! ### `decide` demonstrations
 
@@ -141,18 +151,21 @@ left head c-selects the right: the selector projects, regardless of which side i
 sits on (the carrier is unordered) — so the phase head is the selector. -/
 
 /-- A two-leaf bare node over the given tokens (built planar-first via the DSL;
-    `SO.node` is noncomputable). -/
-private def clause (head comp : LIToken) : SO :=
-  SO.ofPlanar (SO.nodeP (SO.leafP head) (SO.leafP comp))
+    `SyntacticObject.node` is noncomputable). -/
+private def clause (head comp : LIToken) : SyntacticObject :=
+  SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP head) (SyntacticObject.leafP comp))
 
 /-- A C selecting a T projects C: the node is a **C-phase**, not a v-phase. -/
 example :
-    SO.isPhaseHeadOf .C (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = true
-    ∧ SO.isPhaseHeadOf .v (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = false := by
+    SyntacticObject.isPhaseHeadOf .C (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = true
+    ∧ SyntacticObject.isPhaseHeadOf .v (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = false :=
+      by
   decide
 
 /-- A D selecting an N projects D: the node is a **D-phase** ([citko-2014]). -/
-example : SO.isPhaseHeadOf .D (clause ⟨.simple .D [.N], 0⟩ ⟨.simple .N [], 1⟩) = true := by
+example :
+    SyntacticObject.isPhaseHeadOf .D (clause ⟨.simple .D [.N], 0⟩ ⟨.simple .N [], 1⟩) = true := by
   decide
 
 /-- **Convention-independence**: swapping the two daughters (the carrier is
@@ -172,19 +185,20 @@ private def cTok : LIToken := ⟨.simple .C [.T], 0⟩
 private def tTok : LIToken := ⟨.simple .T [.V], 1⟩
 private def vTok : LIToken := ⟨.simple .V [], 2⟩
 
-private def cP : SO :=
-  SO.ofPlanar (SO.nodeP (SO.leafP cTok) (SO.nodeP (SO.leafP tTok) (SO.leafP vTok)))
+private def cP : SyntacticObject :=
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP cTok)
+    (SyntacticObject.nodeP (SyntacticObject.leafP tTok) (SyntacticObject.leafP vTok)))
 
 /-- C heads a nontrivial phase (it projects over the TP). -/
-example : SO.isPhaseHead cP cTok := by decide
+example : SyntacticObject.isPhaseHead cP cTok := by decide
 
 /-- The embedded `V` is in C's complement domain — **frozen** by the PIC. -/
-example : SO.Impenetrable cP cTok (SO.lexLeaf vTok) := by decide
+example : SyntacticObject.Impenetrable cP cTok (SyntacticObject.lexLeaf vTok) := by decide
 
 /-- The phase head `C` is at the **edge** — *not* frozen (it can still probe out). -/
-example : ¬ SO.Impenetrable cP cTok (SO.lexLeaf cTok) := by decide
+example : ¬ SyntacticObject.Impenetrable cP cTok (SyntacticObject.lexLeaf cTok) := by decide
 
 /-- …and `C` sits in the edge, not the interior. -/
-example : SO.lexLeaf cTok ∈ cP.phaseEdge cTok := by decide
+example : SyntacticObject.lexLeaf cTok ∈ cP.phaseEdge cTok := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Position.lean
+++ b/Linglib/Syntax/Minimalist/Position.lean
@@ -68,14 +68,14 @@ inductive MergeType where
     what was merged, into which projection, and what positional slot
     the merged element occupies.
 
-    The `result` field stores the SO after this merge — useful for
+    The `result` field stores the SyntacticObject after this merge — useful for
     inspecting the representational state at any derivational point. -/
 structure MergeEvent where
   /-- The projection being extended (the "target" of Merge) -/
   target   : SyntacticObject
   /-- The constituent merged into that projection -/
   daughter : SyntacticObject
-  /-- The resulting SO after this Merge -/
+  /-- The resulting SyntacticObject after this Merge -/
   result   : SyntacticObject
   /-- What positional slot the daughter occupies -/
   mtype    : MergeType
@@ -126,7 +126,7 @@ def compToSpecAntiLocality
 def specToSpecAntiLocality
     (events : List MergeEvent) (mover xP yP : SyntacticObject) : Prop :=
   isSpecIn events mover xP →
-  SO.immediatelyContains yP xP →
+  SyntacticObject.immediatelyContains yP xP →
   ¬movedToSpecOf events mover yP
 
 -- ============================================================================
@@ -152,20 +152,20 @@ structure PredicateFronting where
     NOT inside the fronted predicate. Stranded elements remain accessible
     for further operations (e.g., extraction by a higher probe). -/
 def isStranded (pf : PredicateFronting) (x : SyntacticObject) : Prop :=
-  ¬SO.contains pf.predicate x
+  ¬SyntacticObject.contains pf.predicate x
 
 /-- After predicate fronting, a constituent X is "trapped" if it IS
     inside the fronted predicate. Trapped elements are inaccessible:
     the fronted phrase is a moved constituent and acts as a freezing
     domain. -/
 def isTrapped (pf : PredicateFronting) (x : SyntacticObject) : Prop :=
-  SO.contains pf.predicate x
+  SyntacticObject.contains pf.predicate x
 
 /-- Stranded and trapped are complementary: every constituent of the
     clause is either stranded or trapped (tertium non datur). -/
 theorem stranded_or_trapped (pf : PredicateFronting) (x : SyntacticObject) :
     isStranded pf x ∨ isTrapped pf x :=
-  em (SO.contains pf.predicate x) |>.elim (Or.inr) (Or.inl)
+  em (SyntacticObject.contains pf.predicate x) |>.elim (Or.inr) (Or.inl)
 
 -- ============================================================================
 -- § 6: Extraction Restriction ([erlewine-2018])
@@ -194,14 +194,14 @@ structure Pivot where
     (outside the fronted predicate), hence extractable. -/
 theorem pivot_is_stranded
     (pf : PredicateFronting) (pivot : Pivot)
-    (h_outside : ¬SO.contains pf.predicate pivot.element) :
+    (h_outside : ¬SyntacticObject.contains pf.predicate pivot.element) :
     extractionRestriction pf pivot.element := h_outside
 
 /-- Non-pivot arguments are trapped (inside the fronted predicate),
     hence not extractable. -/
 theorem nonpivot_trapped
     (pf : PredicateFronting) (x : SyntacticObject)
-    (h_inside : SO.contains pf.predicate x) :
+    (h_inside : SyntacticObject.contains pf.predicate x) :
     ¬extractionRestriction pf x := by
   intro h_stranded
   exact h_stranded h_inside
@@ -215,7 +215,7 @@ theorem nonpivot_trapped
 theorem pivot_blocked_by_anti_locality
     (events : List MergeEvent) (pivot tP cP : SyntacticObject)
     (h_spec : isSpecIn events pivot tP)
-    (h_imm : SO.immediatelyContains cP tP)
+    (h_imm : SyntacticObject.immediatelyContains cP tP)
     (h_anti : specToSpecAntiLocality events pivot tP cP) :
     ¬movedToSpecOf events pivot cP :=
   h_anti h_spec h_imm

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Amalgamation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Amalgamation.lean
@@ -57,8 +57,8 @@ namespace Minimalist
     This is the "closest" c-command relation, used to define amalgamation
     locality (HMC compliance). -/
 def immediatelyCCommands (x y root : SyntacticObject) : Prop :=
-  SO.cCommandsIn root x y ∧
-  ¬∃ z, z ≠ x ∧ z ≠ y ∧ SO.cCommandsIn root x z ∧ SO.cCommandsIn root z y
+  SyntacticObject.cCommandsIn root x y ∧
+  ¬∃ z, z ≠ x ∧ z ≠ y ∧ SyntacticObject.cCommandsIn root x z ∧ SyntacticObject.cCommandsIn root z y
 
 -- ============================================================================
 -- § 2: Amalgamation
@@ -95,7 +95,7 @@ structure Amalgamation where
     the definition: `is_local` requires no intervener. -/
 theorem amalgamation_no_intervener (a : Amalgamation) (root : SyntacticObject) :
     ¬∃ z, z ≠ a.host ∧ z ≠ a.target ∧
-      SO.cCommandsIn root a.host z ∧ SO.cCommandsIn root z a.target := by
+      SyntacticObject.cCommandsIn root a.host z ∧ SyntacticObject.cCommandsIn root z a.target := by
   have h := a.is_local root
   unfold immediatelyCCommands at h
   exact h.2
@@ -107,8 +107,8 @@ theorem intervener_rules_out_amalgamation
     (host target intervener root : SyntacticObject)
     (h_neq_host : intervener ≠ host)
     (h_neq_target : intervener ≠ target)
-    (h_host_cmd : SO.cCommandsIn root host intervener)
-    (h_int_cmd : SO.cCommandsIn root intervener target) :
+    (h_host_cmd : SyntacticObject.cCommandsIn root host intervener)
+    (h_int_cmd : SyntacticObject.cCommandsIn root intervener target) :
     ¬∃ (a : Amalgamation), a.host = host ∧ a.target = target := by
   intro ⟨a, hHost, hTarget⟩
   have hLocal := a.is_local root
@@ -120,7 +120,7 @@ theorem intervener_rules_out_amalgamation
 
 /-- Amalgamation respects locality: the host c-commands the target. -/
 theorem amalgamation_host_ccommands_target (a : Amalgamation) (root : SyntacticObject) :
-    SO.cCommandsIn root a.host a.target := by
+    SyntacticObject.cCommandsIn root a.host a.target := by
   have h := a.is_local root
   unfold immediatelyCCommands at h
   exact h.1
@@ -157,10 +157,10 @@ theorem amalgamation_host_ccommands_target (a : Amalgamation) (root : SyntacticO
     rewrite will rebuild HG2019's amalgamation-as-covering analysis
     on top of the MCB-native `Minimalist.Labeling.isMaximalAt h /
     isHeadIn h` predicates. -/
-def VerbDoublingIsSyntacticIn (d : SO.Derivation) (x : SyntacticObject) : Prop :=
+def VerbDoublingIsSyntacticIn (d : SyntacticObject.Derivation) (x : SyntacticObject) : Prop :=
   x ∈ d.movedItems
 
-instance (d : SO.Derivation) (x : SyntacticObject) :
+instance (d : SyntacticObject.Derivation) (x : SyntacticObject) :
     Decidable (VerbDoublingIsSyntacticIn d x) := by
   unfold VerbDoublingIsSyntacticIn; infer_instance
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
@@ -18,7 +18,7 @@ P0's carrier skeleton: the well-formed subset of `Nonplanar (LIToken ⊕ Unit)`.
 
 ## Faithful labelling (§1.1.3.1: "no labels at any non-leaf vertices")
 
-MCB's SO is a **binary, nonplanar** rooted tree with **leaves labelled by SO₀**
+MCB's SyntacticObject is a **binary, nonplanar** rooted tree with **leaves labelled by SO₀**
 (lexical items + features) and **internal vertices bare** — the head is *not* on
 the tree; it comes from a separate labelling algorithm (§1.15, the head function).
 So on `Nonplanar (LIToken ⊕ Unit)` (the algebra's `α ⊕ β`, `β = Unit`), **role by arity**:
@@ -35,11 +35,11 @@ legacy `toNonplanar` image, which decorated internal nodes with the head
 
 ## Scope
 
-The carrier + `IsSO` + decidability + the `SO` subtype, with the faithful three-role
+The carrier + `IsSO` + decidability + the `SyntacticObject` subtype, with the faithful three-role
 alphabet (lexical/trace leaves + bare internals). **Out of scope (later phases):**
 workspaces + Merge on the carrier (EM + IM-via-coproduct, MCB Prop 1.4.2 — uses the
 existing `comul{D,C}N`; P1 continued), the structural ops (`contains`/`subtrees` =
-`Acc'`) + flip `SyntacticObject := SO` (P2), the head function + Phase API re-home
+`Acc'`) + the `SyntacticObject` naming flip (P2, landed), the head function + Phase API re-home
 (P3), retiring `FreeCommMagma`/`toNonplanar` (P4). See `scratch/p1-spec-and-audit.md`.
 -/
 
@@ -47,7 +47,7 @@ namespace Minimalist
 
 open RootedTree
 
-/-- The SO label alphabet, in the algebra's `α ⊕ β` form (`α = LIToken` lexical,
+/-- The SyntacticObject label alphabet, in the algebra's `α ⊕ β` form (`α = LIToken` lexical,
     `β = Unit` bare). Each **role is fixed by arity**, not by a third label:
 
     - `Sum.inl tok` on a **leaf** — a lexical item (`LIToken` ≈ SO₀);
@@ -111,9 +111,9 @@ theorem isSOPlanarList_permList : ∀ {cs ds : List (RoseTree SOLabel)},
   | _, _, .trans h₁ h₂ => (isSOPlanarList_permList h₁).trans (isSOPlanarList_permList h₂)
 end
 
-/-! ### The carrier: `IsSO` on `Nonplanar` + the `SO` subtype -/
+/-! ### The carrier: `IsSO` on `Nonplanar` + the `SyntacticObject` subtype -/
 
-/-- Well-formed-SO check on the nonplanar carrier, lifted from `isSOPlanar`. -/
+/-- Well-formed-SyntacticObject check on the nonplanar carrier, lifted from `isSOPlanar`. -/
 def isSO : Nonplanar SOLabel → Bool :=
   Nonplanar.lift isSOPlanar (fun _ _ h => isSOPlanar_perm h)
 
@@ -128,26 +128,27 @@ def IsSO (t : Nonplanar SOLabel) : Prop := isSO t = true
 instance : DecidablePred IsSO := fun t => inferInstanceAs (Decidable (isSO t = true))
 
 /-- The MCB-faithful **syntactic object** carrier: well-formed nonplanar trees over
-    `SOLabel`. This is the target type that will become `SyntacticObject` once the
-    operations (P2) and the head function / Phase API (P3) are ported onto it. -/
-def SO : Type := { t : Nonplanar SOLabel // IsSO t }
+    `SOLabel`. Formerly `SO`; renamed once the operations (P2) and the head
+    function / Phase API (P3) were ported onto it. -/
+def SyntacticObject : Type := { t : Nonplanar SOLabel // IsSO t }
 
-instance : DecidableEq SO := Subtype.instDecidableEq
+instance : DecidableEq SyntacticObject := Subtype.instDecidableEq
 
 /-! ### Smart constructors: leaves and the bare binary node
 
 The three faithful shapes (§1.1.3.1): a **lexical leaf** (`Sum.inl tok`), a
 **trace leaf** (bare `Sum.inr ()`, index-free — chain identity is workspace-level,
-MCB Def 1.2.1), and a **bare binary node** (`Sum.inr ()`, internal). `SO.node` is the
-structural binary constructor; `Workspace.lean`'s `SO.merge`/`SO.intMerge` are its
+MCB Def 1.2.1), and a **bare binary node** (`Sum.inr ()`, internal). `SyntacticObject.node` is the
+structural binary constructor; `Workspace.lean`'s `SyntacticObject.merge`/`SyntacticObject.intMerge`
+are its
 Merge semantics. -/
 
 /-- A **lexical leaf**: a childless `Sum.inl tok` (an SO₀ item). -/
-def SO.lexLeaf (tok : LIToken) : SO := ⟨Nonplanar.leaf (Sum.inl tok), rfl⟩
+def SyntacticObject.lexLeaf (tok : LIToken) : SyntacticObject := ⟨Nonplanar.leaf (Sum.inl tok), rfl⟩
 
 /-- The **trace leaf**: a childless, **bare** `Sum.inr ()` vertex
     ([marcolli-chomsky-berwick-2025] Def 1.2.7's ρ-vertex), index-free. -/
-def SO.traceLeaf : SO := ⟨Nonplanar.leaf (Sum.inr ()), by decide⟩
+def SyntacticObject.traceLeaf : SyntacticObject := ⟨Nonplanar.leaf (Sum.inr ()), by decide⟩
 
 /-- `isSO` of a bare binary node is the conjunction of `isSO` on the two children:
     `Sum.inr ()` at arity 2 is well-formed exactly when both daughters are.
@@ -169,24 +170,24 @@ theorem isSO_node_pair (a b : Nonplanar SOLabel) :
     well-formed internal vertex over two syntactic objects, with no head label.
     Noncomputable (it uses the smart `Nonplanar.node`); build concrete results via
     `node_mk` + `decide`. -/
-noncomputable def SO.node (l r : SO) : SO :=
+noncomputable def SyntacticObject.node (l r : SyntacticObject) : SyntacticObject :=
   ⟨Nonplanar.node (Sum.inr ()) {l.val, r.val}, by
     show isSO (Nonplanar.node (Sum.inr ()) {l.val, r.val}) = true
     have hl : isSO l.val = true := l.2
     have hr : isSO r.val = true := r.2
     rw [isSO_node_pair, hl, hr, Bool.and_self]⟩
 
-@[simp] theorem SO.node_val (l r : SO) :
-    (SO.node l r).val = Nonplanar.node (Sum.inr ()) {l.val, r.val} := rfl
+@[simp] theorem SyntacticObject.node_val (l r : SyntacticObject) :
+    (SyntacticObject.node l r).val = Nonplanar.node (Sum.inr ()) {l.val, r.val} := rfl
 
 /-- **Construction bridge**: a `node` of two `mk`-built objects is the single `RoseTree`
     binary node `mk (.node (inr ()) [pl, pr])` — built *without* the smart `node`'s
     `Quotient.out`, so concrete results are `decide`-able. -/
-theorem SO.node_mk (pl pr : RoseTree SOLabel)
+theorem SyntacticObject.node_mk (pl pr : RoseTree SOLabel)
     (hl : IsSO (Nonplanar.mk pl)) (hr : IsSO (Nonplanar.mk pr)) :
-    (SO.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩).val
+    (SyntacticObject.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩).val
       = Nonplanar.mk (.node (Sum.inr ()) [pl, pr]) := by
-  rw [SO.node_val,
+  rw [SyntacticObject.node_val,
       show ({Nonplanar.mk pl, Nonplanar.mk pr} : Multiset (Nonplanar SOLabel))
         = Multiset.ofList ([pl, pr].map Nonplanar.mk) from rfl,
       Nonplanar.node_mk_tree_list]
@@ -207,17 +208,17 @@ theorem isSOPlanar_of_mem {cs : List (RoseTree SOLabel)} (h : isSOPlanarList cs 
     · exact ih h.2 c hmem
 
 /-- **Induction on syntactic objects** ([marcolli-chomsky-berwick-2025] §1.1.3.1).
-    Every `SO` is a lexical leaf, the (bare) trace leaf, or a bare binary node of two
+    Every `SyntacticObject` is a lexical leaf, the (bare) trace leaf, or a bare binary node of two
     syntactic objects — the faithful analogue of the legacy `SyntacticObject.ind`
-    (leaf/trace/mul), with the `mul` case the bare `SO.node`. Proved by strong
+    (leaf/trace/mul), with the `mul` case the bare `SyntacticObject.node`. Proved by strong
     induction on the node count (`numNodes`; the two daughters of a binary node are
     strictly smaller). -/
 @[elab_as_elim]
-theorem SO.ind {motive : SO → Prop}
-    (lex : ∀ tok, motive (SO.lexLeaf tok))
-    (trace : motive SO.traceLeaf)
-    (node : ∀ l r : SO, motive l → motive r → motive (SO.node l r))
-    (s : SO) : motive s := by
+theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
+    (lex : ∀ tok, motive (SyntacticObject.lexLeaf tok))
+    (trace : motive SyntacticObject.traceLeaf)
+    (node : ∀ l r : SyntacticObject, motive l → motive r → motive (SyntacticObject.node l r))
+    (s : SyntacticObject) : motive s := by
   suffices H : ∀ n (p : RoseTree SOLabel) (hp : IsSO (Nonplanar.mk p)),
       p.numNodes = n → motive ⟨Nonplanar.mk p, hp⟩ by
     obtain ⟨t, ht⟩ := s
@@ -243,9 +244,9 @@ theorem SO.ind {motive : SO → Prop}
       · simp at hlen
       · have hl : isSOPlanar pl = true := isSOPlanar_of_mem hlist pl (by simp)
         have hr : isSOPlanar pr = true := isSOPlanar_of_mem hlist pr (by simp)
-        have hnode : (⟨Nonplanar.mk (RoseTree.node (Sum.inr ()) [pl, pr]), hp⟩ : SO)
-            = SO.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩ :=
-          Subtype.ext (SO.node_mk pl pr hl hr).symm
+        have hnode : (⟨Nonplanar.mk (RoseTree.node (Sum.inr ()) [pl, pr]), hp⟩ : SyntacticObject)
+            = SyntacticObject.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩ :=
+          Subtype.ext (SyntacticObject.node_mk pl pr hl hr).symm
         rw [hnode]
         simp only [RoseTree.numNodes_node, List.map_cons, List.map_nil, List.sum_cons,
           List.sum_nil] at hw
@@ -254,21 +255,12 @@ theorem SO.ind {motive : SO → Prop}
 
 /-- **Case analysis** ([marcolli-chomsky-berwick-2025] §1.1.3.1): every syntactic
     object is a lexical leaf, the bare trace leaf, or a bare binary node. -/
-theorem SO.exists_form (s : SO) :
-    (∃ tok, s = SO.lexLeaf tok) ∨ s = SO.traceLeaf ∨ (∃ l r, s = SO.node l r) := by
-  induction s using SO.ind with
+theorem SyntacticObject.exists_form (s : SyntacticObject) :
+    (∃ tok, s = SyntacticObject.lexLeaf tok) ∨ s = SyntacticObject.traceLeaf ∨
+      (∃ l r, s = SyntacticObject.node l r) := by
+  induction s using SyntacticObject.ind with
   | lex tok => exact Or.inl ⟨tok, rfl⟩
   | trace => exact Or.inr (Or.inl rfl)
   | node l r _ _ => exact Or.inr (Or.inr ⟨l, r, rfl⟩)
-
-/-! ### The `SyntacticObject` carrier
-
-`SyntacticObject` is the linguistic-facing name for the MCB-faithful `SO` carrier
-([marcolli-chomsky-berwick-2025] §1.1.3.1: binary, nonplanar, rooted trees with
-bare internal vertices). It is a reducible abbreviation, so dot-notation on a value
-`s : SyntacticObject` dispatches to the `SO.*` API for free. The former
-`FreeCommMagma (LIToken ⊕ Nat)` carrier (with head-decorated nodes and `⊕ Nat`
-trace indices) has been retired in favour of this one. -/
-abbrev SyntacticObject : Type := SO
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -9,22 +9,23 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Basic
 # Construction DSL and accessors for syntactic objects
 
 [marcolli-chomsky-berwick-2025] §1.1. The computable construction layer and the
-read-back accessors for the `SO` carrier, completing P2's API parity with the legacy
+read-back accessors for the `SyntacticObject` carrier, completing P2's API parity with the legacy
 `FreeCommMagma (LIToken ⊕ Nat)` surface. Imports only the carrier skeleton.
 
 ## Construction discipline
 
-The Merge operator (`SO.node`/`SO.merge`) is `noncomputable` (the smart
+The Merge operator (`SyntacticObject.node`/`SyntacticObject.merge`) is `noncomputable` (the smart
 `Nonplanar.node` round-trips through `Quotient.out`). So concrete syntactic objects
 — the ones studies `decide` over — are built **planar-first** and quotiented once:
-`SO.ofPlanar (SO.nodeP (SO.leafP tok₁) (SO.leafP tok₂))`. `SO.node_mk` (skeleton)
-relates such a build to `SO.node`, so theorems stated over `node`/`*` still apply.
+`SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tok₁) (SyntacticObject.leafP
+tok₂))`. `SyntacticObject.node_mk` (skeleton)
+relates such a build to `SyntacticObject.node`, so theorems stated over `node`/`*` still apply.
 
 ## Index-free traces
 
 A trace is a bare `Sum.inr ()` leaf with **no index** (MCB Def 1.2.1: chain identity
-is workspace-level), so there is exactly **one** trace leaf — `SO.isTrace` is just
-`· = SO.traceLeaf`.
+is workspace-level), so there is exactly **one** trace leaf — `SyntacticObject.isTrace` is just
+`· = SyntacticObject.traceLeaf`.
 -/
 
 namespace Minimalist
@@ -34,142 +35,163 @@ open RootedTree
 /-! ### Computable planar construction DSL -/
 
 /-- Planar builder: a lexical leaf. -/
-abbrev SO.leafP (tok : LIToken) : RoseTree SOLabel := .node (Sum.inl tok) []
+abbrev SyntacticObject.leafP (tok : LIToken) : RoseTree SOLabel := .node (Sum.inl tok) []
 /-- Planar builder: the bare trace leaf. -/
-abbrev SO.traceP : RoseTree SOLabel := .node (Sum.inr ()) []
+abbrev SyntacticObject.traceP : RoseTree SOLabel := .node (Sum.inr ()) []
 /-- Planar builder: a bare binary node. -/
-abbrev SO.nodeP (l r : RoseTree SOLabel) : RoseTree SOLabel := .node (Sum.inr ()) [l, r]
+abbrev SyntacticObject.nodeP (l r : RoseTree SOLabel) : RoseTree SOLabel :=
+  .node (Sum.inr ()) [l, r]
 
 /-- Build a syntactic object from a planar tree, discharging well-formedness by
     `decide` (concrete trees) — the computable entry point for `decide`-based studies. -/
-def SO.ofPlanar (p : RoseTree SOLabel) (h : isSOPlanar p = true := by first | rfl | decide) : SO :=
+def SyntacticObject.ofPlanar (p : RoseTree SOLabel) (h : isSOPlanar p = true :=
+  by first | rfl | decide) : SyntacticObject :=
   ⟨Nonplanar.mk p, h⟩
 
-@[simp] theorem SO.ofPlanar_leafP (tok : LIToken) :
-    SO.ofPlanar (SO.leafP tok) = SO.lexLeaf tok := rfl
+@[simp] theorem SyntacticObject.ofPlanar_leafP (tok : LIToken) :
+    SyntacticObject.ofPlanar (SyntacticObject.leafP tok) = SyntacticObject.lexLeaf tok := rfl
 
-@[simp] theorem SO.ofPlanar_traceP : SO.ofPlanar SO.traceP = SO.traceLeaf := rfl
+@[simp] theorem SyntacticObject.ofPlanar_traceP :
+    SyntacticObject.ofPlanar SyntacticObject.traceP = SyntacticObject.traceLeaf := rfl
 
-/-- Default syntactic object: the bare trace leaf. Lets structures with an `SO`
+/-- Default syntactic object: the bare trace leaf. Lets structures with an `SyntacticObject`
     field be `Inhabited`/`deriving Repr`-free of bespoke witnesses. -/
-instance : Inhabited SO := ⟨SO.traceLeaf⟩
+instance : Inhabited SyntacticObject := ⟨SyntacticObject.traceLeaf⟩
 
 /-! ### Merge as multiplication -/
 
 /-- `*` is (External) Merge: the bare binary node. Noncomputable — build concrete
     trees with the planar DSL above, not `*`. -/
-noncomputable instance : Mul SO := ⟨SO.node⟩
+noncomputable instance : Mul SyntacticObject := ⟨SyntacticObject.node⟩
 
-@[simp] theorem SO.mul_def (l r : SO) : l * r = SO.node l r := rfl
+@[simp] theorem SyntacticObject.mul_def (l r : SyntacticObject) :
+    l * r = SyntacticObject.node l r := rfl
 
-theorem SO.mul_comm (l r : SO) : l * r = r * l := by
+theorem SyntacticObject.mul_comm (l r : SyntacticObject) : l * r = r * l := by
   apply Subtype.ext
-  rw [SO.mul_def, SO.mul_def, SO.node_val, SO.node_val, Multiset.pair_comm]
+  rw [SyntacticObject.mul_def, SyntacticObject.mul_def, SyntacticObject.node_val,
+      SyntacticObject.node_val, Multiset.pair_comm]
 
 /-! ### The canonical Merge operators (carrier primitives)
 
-`SO.merge` / `SO.intMerge` are the carrier-level Merge operators
+`SyntacticObject.merge` / `SyntacticObject.intMerge` are the carrier-level Merge operators
 ([marcolli-chomsky-berwick-2025] Lemma 1.4.1 / Prop 1.4.2): they need only the bare
 binary node, so they live here. Their **coproduct identity** on the workspace Hopf
-algebra (`SO.merge_toForest` / `SO.intMerge_toForest`) lives in `Workspace.lean`, which
+algebra (`SyntacticObject.merge_toForest` / `SyntacticObject.intMerge_toForest`) lives in
+`Workspace.lean`, which
 imports the Merge algebra; this file stays algebra-free so `decide`-based consumers
 (e.g. the externalization replay in `SyntacticObject/Derivation.lean`) keep the
 computable `DecidableEq (Nonplanar …)` (#792) in scope. -/
 
 /-- **External Merge on the carrier** ([marcolli-chomsky-berwick-2025] Lemma 1.4.1): the
-    bare binary node `SO.node` *is* External Merge (for distinct workspace items) and the
+    bare binary node `SyntacticObject.node` *is* External Merge (for distinct workspace items) and
+    the
     re-merge stage of Internal Merge. Noncomputable; build concrete results with the
     planar DSL + `decide`. -/
-noncomputable def SO.merge (S S' : SO) : SO := SO.node S S'
+noncomputable def SyntacticObject.merge (S S' : SyntacticObject) : SyntacticObject :=
+  SyntacticObject.node S S'
 
-@[simp] theorem SO.merge_val (S S' : SO) :
-    (SO.merge S S').val = Nonplanar.node (Sum.inr ()) {S.val, S'.val} := rfl
+@[simp] theorem SyntacticObject.merge_val (S S' : SyntacticObject) :
+    (SyntacticObject.merge S S').val = Nonplanar.node (Sum.inr ()) {S.val, S'.val} := rfl
 
 /-- **Internal Merge on the carrier** ([marcolli-chomsky-berwick-2025] Prop 1.4.2):
     re-Merge the `mover` with the **deletion remainder** `remainder = T/mover` (the
     `M_{T/β, β}` order: remainder left, mover right). IM is *not* a new structural
-    primitive — it is `SO.merge` of the remainder and the mover. The mover ↔ trace
+    primitive — it is `SyntacticObject.merge` of the remainder and the mover. The mover ↔ trace
     correspondence (the chain) is read at the workspace level (`Workspace.chainMultiplicity`),
     not from an index. -/
-noncomputable def SO.intMerge (mover remainder : SO) : SO := SO.merge remainder mover
+noncomputable def SyntacticObject.intMerge (mover remainder : SyntacticObject) : SyntacticObject :=
+  SyntacticObject.merge remainder mover
 
-@[simp] theorem SO.intMerge_val (mover remainder : SO) :
-    (SO.intMerge mover remainder).val
+@[simp] theorem SyntacticObject.intMerge_val (mover remainder : SyntacticObject) :
+    (SyntacticObject.intMerge mover remainder).val
       = Nonplanar.node (Sum.inr ()) {remainder.val, mover.val} := rfl
 
 /-! ### Lexical-leaf construction (the legacy `mkLeaf` API) -/
 
 /-- A lexical leaf from a category and selectional stack. -/
-def SO.mkLeaf (cat : Cat) (sel : SelStack) (id : Nat) : SO :=
-  SO.lexLeaf ⟨.simple cat sel, id⟩
+def SyntacticObject.mkLeaf (cat : Cat) (sel : SelStack) (id : Nat) : SyntacticObject :=
+  SyntacticObject.lexLeaf ⟨.simple cat sel, id⟩
 
 /-- A lexical leaf with a phonological form. -/
-def SO.mkLeafPhon (cat : Cat) (sel : SelStack) (phon : String) (id : Nat) : SO :=
-  SO.lexLeaf ⟨.simple cat sel (phonForm := phon), id⟩
+def SyntacticObject.mkLeafPhon (cat : Cat) (sel : SelStack) (phon : String) (id : Nat) :
+    SyntacticObject :=
+  SyntacticObject.lexLeaf ⟨.simple cat sel (phonForm := phon), id⟩
 
 /-! ### Accessors -/
 
 /-- The lexical token at the root, if the root is a lexical leaf. -/
-def SO.getLIToken (s : SO) : Option LIToken :=
+def SyntacticObject.getLIToken (s : SyntacticObject) : Option LIToken :=
   match Nonplanar.rootValue s.val with
   | .inl tok => some tok
   | .inr () => none
 
-@[simp] theorem SO.getLIToken_lexLeaf (tok : LIToken) :
-    (SO.lexLeaf tok).getLIToken = some tok := rfl
+@[simp] theorem SyntacticObject.getLIToken_lexLeaf (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).getLIToken = some tok := rfl
 
-@[simp] theorem SO.getLIToken_traceLeaf : SO.traceLeaf.getLIToken = none := rfl
+@[simp] theorem SyntacticObject.getLIToken_traceLeaf :
+    SyntacticObject.traceLeaf.getLIToken = none := rfl
 
-@[simp] theorem SO.getLIToken_node (l r : SO) : (SO.node l r).getLIToken = none := by
-  rw [SO.getLIToken, SO.node_val, Nonplanar.rootValue_node]
+@[simp] theorem SyntacticObject.getLIToken_node (l r : SyntacticObject) :
+    (SyntacticObject.node l r).getLIToken = none := by
+  rw [SyntacticObject.getLIToken, SyntacticObject.node_val, Nonplanar.rootValue_node]
 
 /-- A trace is the unique bare trace leaf (chain identity is workspace-level). -/
-def SO.isTrace (s : SO) : Prop := s = SO.traceLeaf
+def SyntacticObject.isTrace (s : SyntacticObject) : Prop := s = SyntacticObject.traceLeaf
 
-instance (s : SO) : Decidable (SO.isTrace s) := inferInstanceAs (Decidable (_ = _))
+instance (s : SyntacticObject) : Decidable (SyntacticObject.isTrace s) :=
+  inferInstanceAs (Decidable (_ = _))
 
-@[simp] theorem SO.isTrace_traceLeaf : SO.isTrace SO.traceLeaf := rfl
+@[simp] theorem SyntacticObject.isTrace_traceLeaf :
+    SyntacticObject.isTrace SyntacticObject.traceLeaf := rfl
 
 /-- Leaf count (number of leaves + traces). -/
-def SO.leafCount (s : SO) : Nat := Nonplanar.numLeaves s.val
+def SyntacticObject.leafCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val
 
 /-- Is `s` a leaf (lexical or trace)? A leaf has a single vertex; a bare binary node
     has ≥ 2 leaves. -/
-def SO.isLeaf (s : SO) : Bool := s.leafCount == 1
+def SyntacticObject.isLeaf (s : SyntacticObject) : Bool := s.leafCount == 1
 
-/-- Is `s` a (bare binary) internal node? The complement of `SO.isLeaf`. -/
-def SO.isNode (s : SO) : Bool := !s.isLeaf
+/-- Is `s` a (bare binary) internal node? The complement of `SyntacticObject.isLeaf`. -/
+def SyntacticObject.isNode (s : SyntacticObject) : Bool := !s.isLeaf
 
-@[simp] theorem SO.isLeaf_lexLeaf (tok : LIToken) : (SO.lexLeaf tok).isLeaf = true := rfl
-@[simp] theorem SO.isLeaf_traceLeaf : SO.traceLeaf.isLeaf = true := rfl
-@[simp] theorem SO.isNode_lexLeaf (tok : LIToken) : (SO.lexLeaf tok).isNode = false := rfl
+@[simp] theorem SyntacticObject.isLeaf_lexLeaf (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).isLeaf = true := rfl
+@[simp] theorem SyntacticObject.isLeaf_traceLeaf : SyntacticObject.traceLeaf.isLeaf = true := rfl
+@[simp] theorem SyntacticObject.isNode_lexLeaf (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).isNode = false := rfl
 
-/-- A lightweight `Repr` so structures with an `SO` field can `deriving Repr`. The full
+/-- A lightweight `Repr` so structures with an `SyntacticObject` field can `deriving Repr`. The full
     tree is a `Nonplanar` quotient (no faithful structural readout without `Quot.out`);
-    for debugging surface order use `SO.linearize`. -/
-instance : Repr SO where
+    for debugging surface order use `SyntacticObject.linearize`. -/
+instance : Repr SyntacticObject where
   reprPrec s _ := match s.getLIToken with
-    | some tok => f!"SO.lexLeaf {repr tok}"
-    | none => if s.isLeaf then f!"SO.traceLeaf" else f!"⟨SO node, {s.leafCount} leaves⟩"
+    | some tok => f!"SyntacticObject.lexLeaf {repr tok}"
+    | none =>
+      if s.isLeaf then f!"SyntacticObject.traceLeaf"
+      else f!"⟨SyntacticObject node, {s.leafCount} leaves⟩"
 
 /-- Internal-node count = leaf count − 1 (full binary tree). -/
-def SO.nodeCount (s : SO) : Nat := Nonplanar.numLeaves s.val - 1
+def SyntacticObject.nodeCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val - 1
 
-@[simp] theorem SO.leafCount_lexLeaf (tok : LIToken) : (SO.lexLeaf tok).leafCount = 1 := rfl
-@[simp] theorem SO.leafCount_traceLeaf : SO.traceLeaf.leafCount = 1 := rfl
+@[simp] theorem SyntacticObject.leafCount_lexLeaf (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).leafCount = 1 := rfl
+@[simp] theorem SyntacticObject.leafCount_traceLeaf : SyntacticObject.traceLeaf.leafCount = 1 := rfl
 
 /-! ### `decide` demonstrations -/
 
-private def demoVP : SO :=
-  SO.ofPlanar (SO.nodeP (SO.leafP (mkTraceToken 0)) (SO.leafP (mkTraceToken 1)))
+private def demoVP : SyntacticObject :=
+  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP (mkTraceToken 0))
+    (SyntacticObject.leafP (mkTraceToken 1)))
 
 /-- The DSL-built tree is a genuine syntactic object. -/
 example : IsSO demoVP.val := by decide
 /-- Its head token reads back via `getLIToken` of the left leaf. -/
-example : (SO.lexLeaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by decide
+example : (SyntacticObject.lexLeaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by decide
 /-- It has two leaves and one internal node. -/
 example : demoVP.leafCount = 2 ∧ demoVP.nodeCount = 1 := by decide
 /-- The trace leaf is recognized; a lexical leaf is not a trace. -/
-example : SO.isTrace SO.traceLeaf ∧ ¬ SO.isTrace (SO.lexLeaf (mkTraceToken 0)) := by decide
+example : SyntacticObject.isTrace SyntacticObject.traceLeaf ∧
+    ¬ SyntacticObject.isTrace (SyntacticObject.lexLeaf (mkTraceToken 0)) := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -6,27 +6,29 @@ Authors: Robert Hawkins
 import Linglib.Syntax.Minimalist.SyntacticObject.Replace
 
 /-!
-# Derivation steps on the `SO` carrier
+# Derivation steps on the `SyntacticObject` carrier
 
-P4-pre-b of the single-carrier program: the ordered **derivation** layer on the `SO`
+P4-pre-b of the single-carrier program: the ordered **derivation** layer on the `SyntacticObject`
 carrier — the sequence of Merge/Move operations producing a syntactic object — replacing
 the legacy `FreeCommMagma`-based `Step`/`Derivation`.
 
 **The derivation's Merge *is* the workspace Merge by construction.** Each step applies a
-canonical MCB Merge operator (`Workspace.lean`): External Merge is `SO.merge` (Lemma
-1.4.1), Internal Merge is `SO.intMerge` (Prop 1.4.2's `M_{T/β,β}`) on the deletion
-remainder `SO.deleteAccessible mover current` (= `T/mover`). So `Step.apply` *unfolds*
-to the coproduct operators (`SO.Step.apply_emL`/`apply_im`); the Δ^ρ-coproduct identity
-is `SO.merge_toForest`/`SO.intMerge_toForest` — nothing is independently stipulated then
+canonical MCB Merge operator (`Workspace.lean`): External Merge is `SyntacticObject.merge` (Lemma
+1.4.1), Internal Merge is `SyntacticObject.intMerge` (Prop 1.4.2's `M_{T/β,β}`) on the deletion
+remainder `SyntacticObject.deleteAccessible mover current` (= `T/mover`). So `Step.apply` *unfolds*
+to the coproduct operators (`SyntacticObject.Step.apply_emL`/`apply_im`); the Δ^ρ-coproduct identity
+is `SyntacticObject.merge_toForest`/`SyntacticObject.intMerge_toForest` — nothing is independently
+stipulated then
 bridged.
 
-**Index-free traces (D2):** Internal Merge leaves the bare `SO.traceLeaf`; chain identity
+**Index-free traces (D2):** Internal Merge leaves the bare `SyntacticObject.traceLeaf`; chain
+identity
 is **workspace-level** (`Workspace`, `chainMultiplicity`, #795, MCB Def 1.2.1), not a
-per-step `Nat`. The deletion remainder is realized by `SO.replace` (#804): for a
-uniquely-accessible mover this is exactly the Δ^ρ cut remainder `SO.intMerge_toForest`
+per-step `Nat`. The deletion remainder is realized by `SyntacticObject.replace` (#804): for a
+uniquely-accessible mover this is exactly the Δ^ρ cut remainder `SyntacticObject.intMerge_toForest`
 extracts, and `replace`-all is its total extension to the multi-occurrence (chain) case.
 
-Because `SO.node` is noncomputable, so are `Step.apply`/`Derivation.final` — concrete
+Because `SyntacticObject.node` is noncomputable, so are `Step.apply`/`Derivation.final` — concrete
 trees are reasoned about structurally, not by `decide`. The **computable, `decide`-able
 surface order** (externalization replay + the Π bridge, the Cinque-style word-order
 readout) lives in `Linearization/Replay.lean`; it replays the linear choices on an
@@ -39,104 +41,111 @@ open RootedTree
 
 /-! ### Steps -/
 
-/-- A single derivation step on the `SO` carrier. **Index-free** (D2): `im` records
-    only the mover; the trace it leaves is the bare `SO.traceLeaf`, and the mover ↔ trace
+/-- A single derivation step on the `SyntacticObject` carrier. **Index-free** (D2): `im` records
+    only the mover; the trace it leaves is the bare `SyntacticObject.traceLeaf`, and the mover ↔
+    trace
     chain lives at the workspace level (#795), not in a per-step index. -/
-inductive SO.Step where
+inductive SyntacticObject.Step where
   /-- External Merge, new item as the left daughter. -/
-  | emL (item : SO)
+  | emL (item : SyntacticObject)
   /-- External Merge, new item as the right daughter. -/
-  | emR (item : SO)
+  | emR (item : SyntacticObject)
   /-- Internal Merge: raise `mover`, leaving the bare trace in its place. -/
-  | im (mover : SO)
+  | im (mover : SyntacticObject)
 
 /-- **Internal-Merge deletion remainder** `T/mover` ([marcolli-chomsky-berwick-2025]
     Def 1.2.7, the ρ-form): the syntactic object left when the moved constituent's
-    accessible occurrence is cut, with the bare `SO.traceLeaf` in its place. For a
+    accessible occurrence is cut, with the bare `SyntacticObject.traceLeaf` in its place. For a
     uniquely-accessible `mover` this is the Δ^ρ deletion remainder `p0.2` that
-    `SO.intMerge_toForest` extracts from `cutSummandsN`; `SO.replace` (replace-all) is
+    `SyntacticObject.intMerge_toForest` extracts from `cutSummandsN`; `SyntacticObject.replace`
+    (replace-all) is
     its total extension to the multi-occurrence case (the chain is then read at the
     workspace level, Def 1.2.1). -/
-noncomputable def SO.deleteAccessible (mover current : SO) : SO :=
-  current.replace mover SO.traceLeaf
+noncomputable def SyntacticObject.deleteAccessible (mover current : SyntacticObject) :
+    SyntacticObject :=
+  current.replace mover SyntacticObject.traceLeaf
 
-@[simp] theorem SO.deleteAccessible_val (mover current : SO) :
-    (SO.deleteAccessible mover current).val
-      = replaceN mover.val SO.traceLeaf.val current.val := rfl
+@[simp] theorem SyntacticObject.deleteAccessible_val (mover current : SyntacticObject) :
+    (SyntacticObject.deleteAccessible mover current).val
+      = replaceN mover.val SyntacticObject.traceLeaf.val current.val := rfl
 
 /-- Apply a derivation step to the current tree. **The derivation Merge *is* the
-    workspace Merge by construction:** External Merge is `SO.merge` (Lemma 1.4.1),
-    Internal Merge is `SO.intMerge` (Prop 1.4.2's `M_{T/β,β}`) applied to the deletion
-    remainder `SO.deleteAccessible mover current` (= `T/mover`). The coproduct identity
-    of each is `SO.merge_toForest`/`SO.intMerge_toForest`. Since `SO.merge` is commutative
-    (`SO.mul_comm`), `emL`/`emR` and the mover-left/remainder-left orders give the *same*
-    `SO` (`apply_emL_eq_emR`); the left/right distinction matters only for the surface
+    workspace Merge by construction:** External Merge is `SyntacticObject.merge` (Lemma 1.4.1),
+    Internal Merge is `SyntacticObject.intMerge` (Prop 1.4.2's `M_{T/β,β}`) applied to the deletion
+    remainder `SyntacticObject.deleteAccessible mover current` (= `T/mover`). The coproduct identity
+    of each is `SyntacticObject.merge_toForest`/`SyntacticObject.intMerge_toForest`. Since
+    `SyntacticObject.merge` is commutative
+    (`SyntacticObject.mul_comm`), `emL`/`emR` and the mover-left/remainder-left orders give the
+    *same*
+    `SyntacticObject` (`apply_emL_eq_emR`); the left/right distinction matters only for the surface
     (PF) order, recovered downstream by the externalization replay. -/
-noncomputable def SO.Step.apply (step : SO.Step) (current : SO) : SO :=
+noncomputable def SyntacticObject.Step.apply (step : SyntacticObject.Step)
+    (current : SyntacticObject) : SyntacticObject :=
   match step with
-  | .emL item  => SO.merge item current
-  | .emR item  => SO.merge current item
-  | .im mover  => SO.intMerge mover (SO.deleteAccessible mover current)
+  | .emL item  => SyntacticObject.merge item current
+  | .emR item  => SyntacticObject.merge current item
+  | .im mover  => SyntacticObject.intMerge mover (SyntacticObject.deleteAccessible mover current)
 
-/-- External Merge unfolds to the canonical workspace EM `SO.merge` (Lemma 1.4.1). -/
-theorem SO.Step.apply_emL (item current : SO) :
-    (SO.Step.emL item).apply current = SO.merge item current := rfl
+/-- External Merge unfolds to the canonical workspace EM `SyntacticObject.merge` (Lemma 1.4.1). -/
+theorem SyntacticObject.Step.apply_emL (item current : SyntacticObject) :
+    (SyntacticObject.Step.emL item).apply current = SyntacticObject.merge item current := rfl
 
-/-- External Merge unfolds to the canonical workspace EM `SO.merge` (Lemma 1.4.1). -/
-theorem SO.Step.apply_emR (item current : SO) :
-    (SO.Step.emR item).apply current = SO.merge current item := rfl
+/-- External Merge unfolds to the canonical workspace EM `SyntacticObject.merge` (Lemma 1.4.1). -/
+theorem SyntacticObject.Step.apply_emR (item current : SyntacticObject) :
+    (SyntacticObject.Step.emR item).apply current = SyntacticObject.merge current item := rfl
 
 /-- **Internal Merge unfolds to the coproduct operator by construction.** The `im` step
-    *is* the canonical workspace IM `SO.intMerge` (MCB Prop 1.4.2) on the deletion
-    remainder — definitionally, not via a bridge. Composing with `SO.intMerge_toForest`
+    *is* the canonical workspace IM `SyntacticObject.intMerge` (MCB Prop 1.4.2) on the deletion
+    remainder — definitionally, not via a bridge. Composing with `SyntacticObject.intMerge_toForest`
     gives the Δ^ρ-coproduct identity on the workspace. -/
-theorem SO.Step.apply_im (mover current : SO) :
-    (SO.Step.im mover).apply current = SO.intMerge mover (SO.deleteAccessible mover current) :=
+theorem SyntacticObject.Step.apply_im (mover current : SyntacticObject) :
+    (SyntacticObject.Step.im mover).apply current
+      = SyntacticObject.intMerge mover (SyntacticObject.deleteAccessible mover current) :=
   rfl
 
 /-- External Merge is side-indifferent on the unordered carrier: `emL` and `emR` build
     the same syntactic object (they diverge only at externalization). -/
-theorem SO.Step.apply_emL_eq_emR (item current : SO) :
-    (SO.Step.emL item).apply current = (SO.Step.emR item).apply current :=
+theorem SyntacticObject.Step.apply_emL_eq_emR (item current : SyntacticObject) :
+    (SyntacticObject.Step.emL item).apply current = (SyntacticObject.Step.emR item).apply current :=
   mul_comm item current
 
 /-! ### Derivations -/
 
-/-- An ordered derivation: an initial `SO` together with a sequence of steps. -/
-structure SO.Derivation where
+/-- An ordered derivation: an initial `SyntacticObject` together with a sequence of steps. -/
+structure SyntacticObject.Derivation where
   /-- The initial syntactic object (a lexical item, in canonical derivations). -/
-  initial : SO
+  initial : SyntacticObject
   /-- The ordered sequence of Merge/Move steps. -/
-  steps : List SO.Step
+  steps : List SyntacticObject.Step
 
-namespace SO.Derivation
+namespace SyntacticObject.Derivation
 
 /-- The final tree produced by applying every step in order. -/
-noncomputable def final (d : SO.Derivation) : SO :=
+noncomputable def final (d : SyntacticObject.Derivation) : SyntacticObject :=
   d.steps.foldl (fun so step => step.apply so) d.initial
 
 /-- The intermediate tree after the first `n` steps. -/
-noncomputable def stageAt (d : SO.Derivation) (n : Nat) : SO :=
+noncomputable def stageAt (d : SyntacticObject.Derivation) (n : Nat) : SyntacticObject :=
   (d.steps.take n).foldl (fun so step => step.apply so) d.initial
 
 /-- The number of derivation steps. -/
-def length (d : SO.Derivation) : Nat := d.steps.length
+def length (d : SyntacticObject.Derivation) : Nat := d.steps.length
 
 /-- The movers — the subtrees that underwent Internal Merge. -/
-def movedItems (d : SO.Derivation) : List SO :=
+def movedItems (d : SyntacticObject.Derivation) : List SyntacticObject :=
   d.steps.filterMap fun
     | .im mover => some mover
     | _ => none
 
 /-- Stage `0` is the initial tree (no steps applied). -/
-@[simp] theorem stageAt_zero (d : SO.Derivation) : d.stageAt 0 = d.initial := by
+@[simp] theorem stageAt_zero (d : SyntacticObject.Derivation) : d.stageAt 0 = d.initial := by
   simp [stageAt]
 
 /-- The stage at full length is the final tree. -/
-theorem stageAt_length (d : SO.Derivation) : d.stageAt d.steps.length = d.final := by
+theorem stageAt_length (d : SyntacticObject.Derivation) : d.stageAt d.steps.length = d.final := by
   simp [stageAt, final, List.take_length]
 
-end SO.Derivation
+end SyntacticObject.Derivation
 
 /-! ### Worked example
 
@@ -144,16 +153,17 @@ The movers of a small derivation are read directly off the steps (a `filterMap`,
 this is `decide`-able even though `final` is not): a derivation that internally merges
 two objects records exactly those two as moved. -/
 
-private def demoTok (i : Nat) : SO := SO.lexLeaf ⟨.simple .N [], i⟩
+private def demoTok (i : Nat) : SyntacticObject := SyntacticObject.lexLeaf ⟨.simple .N [], i⟩
 
 example :
-    (SO.Derivation.mk (demoTok 0)
-      [SO.Step.emL (demoTok 1), SO.Step.im (demoTok 1), SO.Step.emR (demoTok 2),
-       SO.Step.im (demoTok 2)]).movedItems
+    (SyntacticObject.Derivation.mk (demoTok 0)
+      [SyntacticObject.Step.emL (demoTok 1), SyntacticObject.Step.im (demoTok 1),
+       SyntacticObject.Step.emR (demoTok 2), SyntacticObject.Step.im (demoTok 2)]).movedItems
       = [demoTok 1, demoTok 2] := by
-  simp [SO.Derivation.movedItems, demoTok]
+  simp [SyntacticObject.Derivation.movedItems, demoTok]
 
 example :
-    (SO.Derivation.mk (demoTok 0) [SO.Step.emL (demoTok 1)]).length = 1 := rfl
+    (SyntacticObject.Derivation.mk (demoTok 0) [SyntacticObject.Step.emL (demoTok 1)]).length = 1 :=
+      rfl
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
@@ -6,24 +6,24 @@ Authors: Robert Hawkins
 import Linglib.Syntax.Minimalist.SyntacticObject.Build
 
 /-!
-# Structural substitution on the `SO` carrier
+# Structural substitution on the `SyntacticObject` carrier
 
-P4-pre-a of the single-carrier program. `SO.replace s target replacement` substitutes
+P4-pre-a of the single-carrier program. `SyntacticObject.replace s target replacement` substitutes
 every subterm of `s` equal (in the nonplanar quotient) to `target` by `replacement` —
-the structural-substitution primitive on the `SO` carrier, replacing the legacy
+the structural-substitution primitive on the `SyntacticObject` carrier, replacing the legacy
 `FreeCommMagma.lift`-based `SyntacticObject.replace`.
 
-The intended copy-theory use is `s.replace mover SO.traceLeaf` (leave an index-free
+The intended copy-theory use is `s.replace mover SyntacticObject.traceLeaf` (leave an index-free
 trace where a mover was). **Framing:** this is a *structural* operation; the
 **canonical** MCB Internal Merge is the workspace coproduct composition (Prop 1.4.2,
-`SO.intMerge`/`Workspace`, #795), with traces as coproduct remainders and chains held
+`SyntacticObject.intMerge`/`Workspace`, #795), with traces as coproduct remainders and chains held
 at the workspace level (Def 1.2.1). `replace` supports the derived, transformational
 view that the paper-anchored study files are written in; it is not a claim that
 movement *is* substitution.
 
 Built the established way (`subtreesN`): a planar recursion with quotient-level `target`
 matching, proved `Perm`-invariant and lifted, then closed under `IsSO` via
-`SO.ind`. It is **noncomputable** (it rebuilds via `Nonplanar.node`); concrete results
+`SyntacticObject.ind`. It is **noncomputable** (it rebuilds via `Nonplanar.node`); concrete results
 are related by the reduction lemmas (`replace_lexLeaf`/`_traceLeaf`/`_node`), not by
 `decide`.
 -/
@@ -35,7 +35,7 @@ open RootedTree
 /-! ### Substitution on the planar carrier -/
 
 mutual
-/-- Structural substitution on a planar `SO`-tree: replace every subtree equal (in the
+/-- Structural substitution on a planar `SyntacticObject`-tree: replace every subtree equal (in the
     nonplanar quotient) to `target` by `replacement`, rebuilding the surrounding tree. -/
 noncomputable def replacePlanar (target replacement : Nonplanar SOLabel) :
     RoseTree SOLabel → Nonplanar SOLabel
@@ -124,72 +124,82 @@ theorem replaceN_self (t r : Nonplanar SOLabel) : replaceN t r t = r := by
   show replacePlanar (Nonplanar.mk (RoseTree.node a cs)) r (RoseTree.node a cs) = r
   simp only [replacePlanar, if_pos]
 
-/-! ### `IsSO` closure and `SO.replace` -/
+/-! ### `IsSO` closure and `SyntacticObject.replace` -/
 
-/-- Substitution preserves well-formedness: replacing subterms of an `SO` by another
-    `SO` yields an `SO` (the arity of every node is preserved). -/
-theorem replaceN_isSO (target replacement s : SO) :
+/-- Substitution preserves well-formedness: replacing subterms of an `SyntacticObject` by another
+    `SyntacticObject` yields an `SyntacticObject` (the arity of every node is preserved). -/
+theorem replaceN_isSO (target replacement s : SyntacticObject) :
     IsSO (replaceN target.val replacement.val s.val) := by
-  induction s using SO.ind with
+  induction s using SyntacticObject.ind with
   | lex tok =>
-    rw [show (SO.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl, replaceN_leaf]
+    rw [show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+        replaceN_leaf]
     split
     · exact replacement.2
-    · exact (SO.lexLeaf tok).2
+    · exact (SyntacticObject.lexLeaf tok).2
   | trace =>
-    rw [show SO.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, replaceN_leaf]
+    rw [show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, replaceN_leaf]
     split
     · exact replacement.2
-    · exact SO.traceLeaf.2
+    · exact SyntacticObject.traceLeaf.2
   | node l r ihl ihr =>
-    rw [SO.node_val, replaceN_node]
+    rw [SyntacticObject.node_val, replaceN_node]
     split
     · exact replacement.2
     · show isSO (Nonplanar.node (Sum.inr ())
         {replaceN target.val replacement.val l.val, replaceN target.val replacement.val r.val}) = true
       rw [isSO_node_pair, ihl, ihr]; rfl
 
-/-- **Structural substitution** on the `SO` carrier ([marcolli-chomsky-berwick-2025]
+/-- **Structural substitution** on the `SyntacticObject` carrier ([marcolli-chomsky-berwick-2025]
     §1.2): replace every subterm of `s` equal to `target` by `replacement`. The
-    copy-theory use is `s.replace mover SO.traceLeaf`. Noncomputable (rebuilds via
-    `SO.node`); reduce concrete cases via `replace_self`/`replace_node_of_ne`/
+    copy-theory use is `s.replace mover SyntacticObject.traceLeaf`. Noncomputable (rebuilds via
+    `SyntacticObject.node`); reduce concrete cases via `replace_self`/`replace_node_of_ne`/
     `replace_lexLeaf_of_ne`. -/
-noncomputable def SO.replace (s target replacement : SO) : SO :=
+noncomputable def SyntacticObject.replace (s target replacement : SyntacticObject) :
+    SyntacticObject :=
   ⟨replaceN target.val replacement.val s.val, replaceN_isSO target replacement s⟩
 
-@[simp] theorem SO.replace_val (s target replacement : SO) :
-    (SO.replace s target replacement).val = replaceN target.val replacement.val s.val := rfl
+@[simp] theorem SyntacticObject.replace_val (s target replacement : SyntacticObject) :
+    (SyntacticObject.replace s target replacement).val
+      = replaceN target.val replacement.val s.val := rfl
 
 /-- Replacing the whole object by `replacement`. -/
-@[simp] theorem SO.replace_self (target replacement : SO) :
-    SO.replace target target replacement = replacement :=
-  Subtype.ext (by rw [SO.replace_val, replaceN_self])
+@[simp] theorem SyntacticObject.replace_self (target replacement : SyntacticObject) :
+    SyntacticObject.replace target target replacement = replacement :=
+  Subtype.ext (by rw [SyntacticObject.replace_val, replaceN_self])
 
 /-- At a node that is not itself the `target`, substitution recurses into both
     daughters (the Head Feature Principle of substitution: structure is preserved). -/
-theorem SO.replace_node_of_ne {l r target replacement : SO} (h : SO.node l r ≠ target) :
-    SO.replace (SO.node l r) target replacement
-      = SO.node (SO.replace l target replacement) (SO.replace r target replacement) := by
+theorem SyntacticObject.replace_node_of_ne {l r target replacement : SyntacticObject}
+    (h : SyntacticObject.node l r ≠ target) :
+    SyntacticObject.replace (SyntacticObject.node l r) target replacement
+      = SyntacticObject.node (SyntacticObject.replace l target replacement)
+          (SyntacticObject.replace r target replacement) := by
   apply Subtype.ext
-  rw [SO.replace_val, SO.node_val, replaceN_node, if_neg, SO.node_val, SO.replace_val,
-      SO.replace_val]
-  rw [← SO.node_val]
+  rw [SyntacticObject.replace_val, SyntacticObject.node_val, replaceN_node, if_neg,
+      SyntacticObject.node_val, SyntacticObject.replace_val, SyntacticObject.replace_val]
+  rw [← SyntacticObject.node_val]
   exact fun heq => h (Subtype.ext heq)
 
 /-- A lexical leaf that is not the `target` is left unchanged. -/
-theorem SO.replace_lexLeaf_of_ne {tok : LIToken} {target replacement : SO}
-    (h : SO.lexLeaf tok ≠ target) :
-    SO.replace (SO.lexLeaf tok) target replacement = SO.lexLeaf tok := by
+theorem SyntacticObject.replace_lexLeaf_of_ne {tok : LIToken} {target replacement : SyntacticObject}
+    (h : SyntacticObject.lexLeaf tok ≠ target) :
+    SyntacticObject.replace (SyntacticObject.lexLeaf tok) target replacement
+      = SyntacticObject.lexLeaf tok := by
   apply Subtype.ext
-  rw [SO.replace_val, show (SO.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+  rw [SyntacticObject.replace_val,
+      show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
       replaceN_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
 
 /-- The bare trace leaf, not being the `target`, is left unchanged. -/
-theorem SO.replace_traceLeaf_of_ne {target replacement : SO} (h : SO.traceLeaf ≠ target) :
-    SO.replace SO.traceLeaf target replacement = SO.traceLeaf := by
+theorem SyntacticObject.replace_traceLeaf_of_ne {target replacement : SyntacticObject}
+    (h : SyntacticObject.traceLeaf ≠ target) :
+    SyntacticObject.replace SyntacticObject.traceLeaf target replacement
+      = SyntacticObject.traceLeaf := by
   apply Subtype.ext
-  rw [SO.replace_val, show SO.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+  rw [SyntacticObject.replace_val,
+      show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
       replaceN_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
 
@@ -202,9 +212,10 @@ from weight via `Subterm`'s `immediatelyContains_lt_weight`), taken as a hypothe
 here to keep this module's dependencies minimal. Substitution is noncomputable, so this
 is a structural proof, not a `decide`. -/
 
-example (l r : SO) (h : SO.node l r ≠ r) :
-    SO.replace (SO.node l r) r SO.traceLeaf
-      = SO.node (SO.replace l r SO.traceLeaf) SO.traceLeaf := by
-  rw [SO.replace_node_of_ne h, SO.replace_self]
+example (l r : SyntacticObject) (h : SyntacticObject.node l r ≠ r) :
+    SyntacticObject.replace (SyntacticObject.node l r) r SyntacticObject.traceLeaf
+      = SyntacticObject.node (SyntacticObject.replace l r SyntacticObject.traceLeaf)
+          SyntacticObject.traceLeaf := by
+  rw [SyntacticObject.replace_node_of_ne h, SyntacticObject.replace_self]
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Group.Hom.Defs
 import Linglib.Syntax.Minimalist.SyntacticObject.Build
 
 /-!
-# Selection-driven heads on the `SO` carrier
+# Selection-driven heads on the `SyntacticObject` carrier
 
 This file defines the c-selection head of a syntactic object: whichever sister's
 head selects the saturated other projects — [adger-2003]'s identification of the
@@ -22,18 +22,19 @@ head functions it is partial: `none` at exocentric nodes.
   together with its residual selectional stack.
 * `Mul SelState` and `Minimalist.selSide`: the carrier-free combinators — the
   selection product, and which daughter projects.
-* `Minimalist.selNode`, `Minimalist.selCheckPlanar`, `Minimalist.SO.selCheck`:
-  the selection algebra, its catamorphism, and the `SO` lift.
-* `Minimalist.SO.selHead`, `Minimalist.SO.outerCatC`: the head token and its outer
+* `Minimalist.selNode`, `Minimalist.selCheckPlanar`, `Minimalist.SyntacticObject.selCheck`:
+  the selection algebra, its catamorphism, and the `SyntacticObject` lift.
+* `Minimalist.SyntacticObject.selHead`, `Minimalist.SyntacticObject.outerCatC`: the head token and
+its outer
   category — the foundation the Phase API consumes (`isPhaseHeadOf`).
-* `Minimalist.selCheckHom`: `selCheck` as a morphism of magmas `SO →ₙ* SelState` —
+* `Minimalist.selCheckHom`: `selCheck` as a morphism of magmas `SyntacticObject →ₙ* SelState` —
   the book's algebraic frame, with `SelState` a `CommMagma`.
 
 ## Main results
 
 * `mul_comm` (via `CommMagma SelState`) and `Minimalist.selSide_comm`:
   order-independence — the formal content of Merge's unordered output.
-* `Minimalist.SO.selHead_node`: endocentricity — a node's head is one of its
+* `Minimalist.SyntacticObject.selHead_node`: endocentricity — a node's head is one of its
   daughters' heads.
 
 ## Implementation notes
@@ -175,7 +176,7 @@ theorem selNode_perm (a : SOLabel) {l₁ l₂ : List SelState} (h : l₁.Perm l�
   | inl tok => rfl
   | inr u => cases u; exact h.congr_arity₂ (fun x y => mul_comm x y) (fun _ h => selNode_big h)
 
-/-- Selection check on a planar `SO`-tree: the projecting head + residual pending
+/-- Selection check on a planar `SyntacticObject`-tree: the projecting head + residual pending
     features, or `none` outside the endocentric domain — the catamorphism of
     `selNode`. -/
 def selCheckPlanar : RoseTree SOLabel → SelState :=
@@ -205,56 +206,58 @@ theorem selCheckN_node (a b : Nonplanar SOLabel) :
       = selCheckN (Nonplanar.mk pa) * selCheckN (Nonplanar.mk pb)
   rw [Nonplanar.node_pair_mk]; exact rfl
 
-/-! ### The selection-driven head on `SO` -/
+/-! ### The selection-driven head on `SyntacticObject` -/
 
-variable (s : SO) (tok : LIToken)
+variable (s : SyntacticObject) (tok : LIToken)
 
-/-- **Selection-driven head check** on `SO`: the projecting head + residual
+/-- **Selection-driven head check** on `SyntacticObject`: the projecting head + residual
     features, or `none` off the endocentric domain. Section-free and computable;
     the selection instance of [marcolli-chomsky-berwick-2025]'s head functions. -/
-def SO.selCheck : SelState := selCheckN s.val
+def SyntacticObject.selCheck : SelState := selCheckN s.val
 
 /-- The projecting head's lexical item, by c-selection. -/
-def SO.selHead : Option LIToken := s.selCheck.map (·.1)
+def SyntacticObject.selHead : Option LIToken := s.selCheck.map (·.1)
 
 /-- Residual pending selectional features (`some []` = saturated). -/
-def SO.checkedSel : Option (List Cat) := s.selCheck.map (·.2)
+def SyntacticObject.checkedSel : Option (List Cat) := s.selCheck.map (·.2)
 
 /-- The projecting head's **outer category** (the phase-head selector); `none` at
     exocentric nodes. -/
-def SO.outerCatC : Option Cat := s.selHead.map (·.item.outerCat)
+def SyntacticObject.outerCatC : Option Cat := s.selHead.map (·.item.outerCat)
 
-@[simp] theorem SO.selCheck_lexLeaf :
-    (SO.lexLeaf tok).selCheck = some (tok, tok.item.outerSel) := rfl
+@[simp] theorem SyntacticObject.selCheck_lexLeaf :
+    (SyntacticObject.lexLeaf tok).selCheck = some (tok, tok.item.outerSel) := rfl
 
-@[simp] theorem SO.selCheck_traceLeaf :
-    SO.traceLeaf.selCheck = some (mkTraceToken 0, []) := rfl
+@[simp] theorem SyntacticObject.selCheck_traceLeaf :
+    SyntacticObject.traceLeaf.selCheck = some (mkTraceToken 0, []) := rfl
 
-@[simp] theorem SO.selCheck_node (l r : SO) :
-    (SO.node l r).selCheck = l.selCheck * r.selCheck := by
-  show selCheckN (SO.node l r).val = selCheckN l.val * selCheckN r.val
-  rw [SO.node_val, selCheckN_node]
+@[simp] theorem SyntacticObject.selCheck_node (l r : SyntacticObject) :
+    (SyntacticObject.node l r).selCheck = l.selCheck * r.selCheck := by
+  show selCheckN (SyntacticObject.node l r).val = selCheckN l.val * selCheckN r.val
+  rw [SyntacticObject.node_val, selCheckN_node]
 
 /-- `selCheck` as a **morphism of magmas** — [marcolli-chomsky-berwick-2025] §1.13's
     algebraic frame for head functions: Merge multiplies constituents, `selCheck`
     multiplies their selection states. Contrast the externalization *readout*, which
     is not a morphism — placing a yield needs the head
     (`Linearization/Externalization.lean`). -/
-noncomputable def selCheckHom : SO →ₙ* SelState where
-  toFun := SO.selCheck
-  map_mul' := SO.selCheck_node
+noncomputable def selCheckHom : SyntacticObject →ₙ* SelState where
+  toFun := SyntacticObject.selCheck
+  map_mul' := SyntacticObject.selCheck_node
 
-@[simp] theorem SO.selHead_lexLeaf : (SO.lexLeaf tok).selHead = some tok := rfl
+@[simp] theorem SyntacticObject.selHead_lexLeaf :
+    (SyntacticObject.lexLeaf tok).selHead = some tok := rfl
 
 /-- **Endocentricity**: a node's projecting head is one of its daughters' heads —
     bare-phrase-structure projection ([chomsky-1995-bare] §4, abstracted as
     [marcolli-chomsky-berwick-2025] Definition 1.13.6 / Lemma 1.13.7). -/
-theorem SO.selHead_node {l r : SO} {h : LIToken}
-    (hlr : (SO.node l r).selHead = some h) : l.selHead = some h ∨ r.selHead = some h := by
-  simp only [SO.selHead, SO.selCheck_node] at hlr ⊢
+theorem SyntacticObject.selHead_node {l r : SyntacticObject} {h : LIToken}
+    (hlr : (SyntacticObject.node l r).selHead = some h) : l.selHead = some h ∨ r.selHead = some h :=
+      by
+  simp only [SyntacticObject.selHead, SyntacticObject.selCheck_node] at hlr ⊢
   exact SelState.mul_fst hlr
 
-@[simp] theorem SO.outerCatC_lexLeaf :
-    (SO.lexLeaf tok).outerCatC = some tok.item.outerCat := rfl
+@[simp] theorem SyntacticObject.outerCatC_lexLeaf :
+    (SyntacticObject.lexLeaf tok).outerCatC = some tok.item.outerCat := rfl
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
@@ -9,14 +9,17 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Basic
 # Subterm enumeration and containment for syntactic objects
 
 [marcolli-chomsky-berwick-2025] §1.1–1.2. The containment / subterm theory of the
-`SO` carrier, mirroring the legacy `Basic.lean` theory on
+`SyntacticObject` carrier, mirroring the legacy `Basic.lean` theory on
 `FreeCommMagma (LIToken ⊕ Nat)`. Imports only the carrier skeleton (no Merge algebra).
 
 ## Contents
-- `SO.immediatelyContains` — membership in the root children (via `Nonplanar.rootChildren`).
-- `SO.subtrees`/`SO.Acc` — subterm enumeration (incl. root) and MCB's accessible terms
+- `SyntacticObject.immediatelyContains` — membership in the root children (via
+`Nonplanar.rootChildren`).
+- `SyntacticObject.subtrees`/`SyntacticObject.Acc` — subterm enumeration (incl. root) and MCB's
+accessible terms
   `Acc(T)` (Def 1.2.2, root excluded).
-- `SO.contains`/`isTermOf`/`containsOrEq` — dominance and its reflexive/term-of variants.
+- `SyntacticObject.contains`/`isTermOf`/`containsOrEq` — dominance and its reflexive/term-of
+variants.
 - subtree ↔ containment bridges, and tree-relative c-command (`cCommandsIn`).
 -/
 
@@ -28,26 +31,27 @@ open RootedTree
 
 /-- `x` **immediately contains** `y`: `y` is one of `x`'s root daughters
     ([marcolli-chomsky-berwick-2025] §1.1; Definition 13 of the legacy theory). -/
-def SO.immediatelyContains (x y : SO) : Prop := y.val ∈ Nonplanar.rootChildren x.val
+def SyntacticObject.immediatelyContains (x y : SyntacticObject) : Prop :=
+  y.val ∈ Nonplanar.rootChildren x.val
 
-instance (x y : SO) : Decidable (SO.immediatelyContains x y) :=
+instance (x y : SyntacticObject) : Decidable (SyntacticObject.immediatelyContains x y) :=
   inferInstanceAs (Decidable (_ ∈ _))
 
-@[simp] theorem SO.immediatelyContains_lexLeaf (tok : LIToken) (y : SO) :
-    ¬ SO.immediatelyContains (SO.lexLeaf tok) y := by
-  simp only [SO.immediatelyContains, SO.lexLeaf, Nonplanar.leaf, Nonplanar.rootChildren_mk,
-    RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil, Multiset.notMem_zero,
-    not_false_iff]
+@[simp] theorem SyntacticObject.immediatelyContains_lexLeaf (tok : LIToken) (y : SyntacticObject) :
+    ¬ SyntacticObject.immediatelyContains (SyntacticObject.lexLeaf tok) y := by
+  simp only [SyntacticObject.immediatelyContains, SyntacticObject.lexLeaf, Nonplanar.leaf,
+    Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
+    Multiset.notMem_zero, not_false_iff]
 
-@[simp] theorem SO.immediatelyContains_traceLeaf (y : SO) :
-    ¬ SO.immediatelyContains SO.traceLeaf y := by
-  simp only [SO.immediatelyContains, SO.traceLeaf, Nonplanar.leaf, Nonplanar.rootChildren_mk,
-    RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil, Multiset.notMem_zero,
-    not_false_iff]
+@[simp] theorem SyntacticObject.immediatelyContains_traceLeaf (y : SyntacticObject) :
+    ¬ SyntacticObject.immediatelyContains SyntacticObject.traceLeaf y := by
+  simp only [SyntacticObject.immediatelyContains, SyntacticObject.traceLeaf, Nonplanar.leaf,
+    Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
+    Multiset.notMem_zero, not_false_iff]
 
-@[simp] theorem SO.immediatelyContains_node (l r y : SO) :
-    SO.immediatelyContains (SO.node l r) y ↔ y = l ∨ y = r := by
-  rw [SO.immediatelyContains, SO.node_val, Nonplanar.rootChildren_node,
+@[simp] theorem SyntacticObject.immediatelyContains_node (l r y : SyntacticObject) :
+    SyntacticObject.immediatelyContains (SyntacticObject.node l r) y ↔ y = l ∨ y = r := by
+  rw [SyntacticObject.immediatelyContains, SyntacticObject.node_val, Nonplanar.rootChildren_node,
       Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton]
   exact ⟨fun h => h.imp Subtype.ext Subtype.ext,
          fun h => h.imp (congrArg Subtype.val) (congrArg Subtype.val)⟩
@@ -137,69 +141,75 @@ theorem self_mem_subtreesN (u : Nonplanar SOLabel) : u ∈ subtreesN u := by
   show Nonplanar.mk (RoseTree.node lbl cs) ∈ subtreesNPlanar (RoseTree.node lbl cs)
   rw [subtreesNPlanar]; exact Multiset.mem_cons_self _ _
 
-/-! ### `SO.subtrees` / `SO.Acc` -/
+/-! ### `SyntacticObject.subtrees` / `SyntacticObject.Acc` -/
 
 /-- Subtrees of a syntactic object are themselves syntactic objects. -/
-theorem subtreesN_closure (s : SO) : ∀ m ∈ subtreesN s.val, IsSO m := by
-  induction s using SO.ind with
+theorem subtreesN_closure (s : SyntacticObject) : ∀ m ∈ subtreesN s.val, IsSO m := by
+  induction s using SyntacticObject.ind with
   | lex tok =>
     intro m hm
-    rw [show (SO.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         mem_subtreesN_leaf] at hm
-    subst hm; exact (SO.lexLeaf tok).2
+    subst hm; exact (SyntacticObject.lexLeaf tok).2
   | trace =>
     intro m hm
-    rw [show SO.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, mem_subtreesN_leaf] at hm
-    subst hm; exact SO.traceLeaf.2
+    rw [show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+        mem_subtreesN_leaf] at hm
+    subst hm; exact SyntacticObject.traceLeaf.2
   | node l r ihl ihr =>
     intro m hm
-    rw [SO.node_val, mem_subtreesN_node] at hm
+    rw [SyntacticObject.node_val, mem_subtreesN_node] at hm
     rcases hm with rfl | hl | hr
-    · exact (SO.node l r).2
+    · exact (SyntacticObject.node l r).2
     · exact ihl m hl
     · exact ihr m hr
 
 /-- All subtrees of a syntactic object (incl. the root), as syntactic objects
     ([marcolli-chomsky-berwick-2025] §1.2; the legacy `SyntacticObject.subtrees`). -/
-def SO.subtrees (s : SO) : Multiset SO :=
+def SyntacticObject.subtrees (s : SyntacticObject) : Multiset SyntacticObject :=
   (subtreesN s.val).pmap (fun m h => ⟨m, h⟩) (subtreesN_closure s)
 
-@[simp] theorem SO.mem_subtrees {x s : SO} : x ∈ s.subtrees ↔ x.val ∈ subtreesN s.val := by
-  rw [SO.subtrees, Multiset.mem_pmap]
+@[simp] theorem SyntacticObject.mem_subtrees {x s : SyntacticObject} :
+    x ∈ s.subtrees ↔ x.val ∈ subtreesN s.val := by
+  rw [SyntacticObject.subtrees, Multiset.mem_pmap]
   constructor
   · rintro ⟨m, hm, he⟩; rw [← he]; exact hm
   · intro h; exact ⟨x.val, h, Subtype.ext rfl⟩
 
 /-- The root is among its own subtrees. -/
-theorem SO.self_mem_subtrees (s : SO) : s ∈ s.subtrees := by
-  rw [SO.mem_subtrees]; exact self_mem_subtreesN s.val
+theorem SyntacticObject.self_mem_subtrees (s : SyntacticObject) : s ∈ s.subtrees := by
+  rw [SyntacticObject.mem_subtrees]; exact self_mem_subtreesN s.val
 
 /-- Subtree membership at a bare binary node: the node itself, or a subtree of a
     daughter. -/
-@[simp] theorem SO.mem_subtrees_node {x l r : SO} :
-    x ∈ (SO.node l r).subtrees ↔ x = SO.node l r ∨ x ∈ l.subtrees ∨ x ∈ r.subtrees := by
-  rw [SO.mem_subtrees, SO.node_val, mem_subtreesN_node, ← SO.mem_subtrees, ← SO.mem_subtrees]
-  exact Iff.or ⟨fun h => Subtype.ext h, fun h => by rw [h, SO.node_val]⟩ Iff.rfl
+@[simp] theorem SyntacticObject.mem_subtrees_node {x l r : SyntacticObject} :
+    x ∈ (SyntacticObject.node l r).subtrees ↔
+      x = SyntacticObject.node l r ∨ x ∈ l.subtrees ∨ x ∈ r.subtrees := by
+  rw [SyntacticObject.mem_subtrees, SyntacticObject.node_val, mem_subtreesN_node,
+      ← SyntacticObject.mem_subtrees, ← SyntacticObject.mem_subtrees]
+  exact Iff.or ⟨fun h => Subtype.ext h, fun h => by rw [h, SyntacticObject.node_val]⟩ Iff.rfl
 
 /-- `subtrees` is downward-closed along the subtree relation: every subtree of a
     subtree of `s` is a subtree of `s`. -/
-theorem SO.subtrees_subset_of_mem {w s : SO} (h : w ∈ s.subtrees) :
+theorem SyntacticObject.subtrees_subset_of_mem {w s : SyntacticObject} (h : w ∈ s.subtrees) :
     w.subtrees ⊆ s.subtrees := by
-  induction s using SO.ind with
+  induction s using SyntacticObject.ind with
   | lex tok =>
-    rw [SO.mem_subtrees, show (SO.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [SyntacticObject.mem_subtrees,
+        show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         mem_subtreesN_leaf] at h
-    rw [(Subtype.ext h : w = SO.lexLeaf tok)]; exact Multiset.Subset.refl _
+    rw [(Subtype.ext h : w = SyntacticObject.lexLeaf tok)]; exact Multiset.Subset.refl _
   | trace =>
-    rw [SO.mem_subtrees, show SO.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [SyntacticObject.mem_subtrees,
+        show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
         mem_subtreesN_leaf] at h
-    rw [(Subtype.ext h : w = SO.traceLeaf)]; exact Multiset.Subset.refl _
+    rw [(Subtype.ext h : w = SyntacticObject.traceLeaf)]; exact Multiset.Subset.refl _
   | node l r ihl ihr =>
-    rw [SO.mem_subtrees_node] at h
+    rw [SyntacticObject.mem_subtrees_node] at h
     rcases h with rfl | hl | hr
     · exact Multiset.Subset.refl _
-    · intro z hz; rw [SO.mem_subtrees_node]; exact Or.inr (Or.inl (ihl hl hz))
-    · intro z hz; rw [SO.mem_subtrees_node]; exact Or.inr (Or.inr (ihr hr hz))
+    · intro z hz; rw [SyntacticObject.mem_subtrees_node]; exact Or.inr (Or.inl (ihl hl hz))
+    · intro z hz; rw [SyntacticObject.mem_subtrees_node]; exact Or.inr (Or.inr (ihr hr hz))
 
 /-! ### Cardinality (MCB's vertex/accessible-term counts, Def 1.2.2 eq. 1.2.5) -/
 
@@ -224,8 +234,9 @@ theorem subtreesN_card (u : Nonplanar SOLabel) :
 
 /-- **`subtrees` enumerates the vertices** ([marcolli-chomsky-berwick-2025] Def 1.2.2:
     `subtrees = Acc'(T)`, so its size is `#V(T)`, the MCB workspace-size primitive). -/
-theorem SO.subtrees_card (s : SO) : (s.subtrees).card = Nonplanar.numNodes s.val := by
-  rw [SO.subtrees, Multiset.card_pmap, subtreesN_card]
+theorem SyntacticObject.subtrees_card (s : SyntacticObject) :
+    (s.subtrees).card = Nonplanar.numNodes s.val := by
+  rw [SyntacticObject.subtrees, Multiset.card_pmap, subtreesN_card]
 
 /-! ### Accessible terms `Acc(T)` (Def 1.2.2) -/
 
@@ -233,20 +244,25 @@ theorem SO.subtrees_card (s : SO) : (s.subtrees).card = Nonplanar.numNodes s.val
     Def 1.2.2, eq. 1.2.2): the subtrees at **all non-root vertices** (leaves
     included — the counting identity eq. 1.2.5 `#V = b₀ + #Acc` forces this).
     Defined as `subtrees − {self}` (`Acc'(T) = {T} ∪ Acc(T)`, eq. 1.2.3). -/
-def SO.Acc (s : SO) : Multiset SO := s.subtrees - {s}
+def SyntacticObject.Acc (s : SyntacticObject) : Multiset SyntacticObject := s.subtrees - {s}
 
 /-- **MCB counting identity** (eq. 1.2.5, one-component case): `#Acc(T) = #V(T) − 1`. -/
-theorem SO.Acc_card (s : SO) : (s.Acc).card = Nonplanar.numNodes s.val - 1 := by
-  rw [SO.Acc, Multiset.card_sub (Multiset.singleton_le.mpr (SO.self_mem_subtrees s)),
-      SO.subtrees_card, Multiset.card_singleton]
+theorem SyntacticObject.Acc_card (s : SyntacticObject) :
+    (s.Acc).card = Nonplanar.numNodes s.val - 1 := by
+  rw [SyntacticObject.Acc,
+      Multiset.card_sub (Multiset.singleton_le.mpr (SyntacticObject.self_mem_subtrees s)),
+      SyntacticObject.subtrees_card, Multiset.card_singleton]
 
-@[simp] theorem SO.Acc_lexLeaf (tok : LIToken) : (SO.lexLeaf tok).Acc = 0 := by
-  rw [← Multiset.card_eq_zero, SO.Acc_card,
-      show (SO.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl, Nonplanar.numNodes_leaf]
+@[simp] theorem SyntacticObject.Acc_lexLeaf (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).Acc = 0 := by
+  rw [← Multiset.card_eq_zero, SyntacticObject.Acc_card,
+      show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+      Nonplanar.numNodes_leaf]
 
-@[simp] theorem SO.Acc_traceLeaf : SO.traceLeaf.Acc = 0 := by
-  rw [← Multiset.card_eq_zero, SO.Acc_card,
-      show SO.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, Nonplanar.numNodes_leaf]
+@[simp] theorem SyntacticObject.Acc_traceLeaf : SyntacticObject.traceLeaf.Acc = 0 := by
+  rw [← Multiset.card_eq_zero, SyntacticObject.Acc_card,
+      show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+      Nonplanar.numNodes_leaf]
 
 /-! ### Containment / dominance -/
 
@@ -267,163 +283,183 @@ theorem weight_node_pair (a b : Nonplanar SOLabel) :
 
 /-- **Containment (dominance)** is the transitive closure of immediate containment
     ([marcolli-chomsky-berwick-2025] §1.1; the legacy `contains`). -/
-inductive SO.contains : SO → SO → Prop
-  | imm : ∀ x y, SO.immediatelyContains x y → SO.contains x y
-  | trans : ∀ x y z, SO.immediatelyContains x z → SO.contains z y → SO.contains x y
+inductive SyntacticObject.contains : SyntacticObject → SyntacticObject → Prop
+  | imm : ∀ x y, SyntacticObject.immediatelyContains x y → SyntacticObject.contains x y
+  | trans : ∀ x y z, SyntacticObject.immediatelyContains x z → SyntacticObject.contains z y →
+      SyntacticObject.contains x y
 
-theorem SO.imm_implies_contains {x y : SO} (h : SO.immediatelyContains x y) :
-    SO.contains x y := .imm x y h
+theorem SyntacticObject.imm_implies_contains {x y : SyntacticObject}
+    (h : SyntacticObject.immediatelyContains x y) : SyntacticObject.contains x y := .imm x y h
 
-theorem SO.contains_trans {x y z : SO} (hxy : SO.contains x y) (hyz : SO.contains y z) :
-    SO.contains x z := by
+theorem SyntacticObject.contains_trans {x y z : SyntacticObject}
+    (hxy : SyntacticObject.contains x y) (hyz : SyntacticObject.contains y z) :
+    SyntacticObject.contains x z := by
   induction hxy with
   | imm x y himm => exact .trans x z y himm hyz
   | trans x y w himm _ ih => exact .trans x z w himm (ih hyz)
 
 /-- Immediate containment strictly decreases weight. -/
-theorem SO.immediatelyContains_lt_weight {x y : SO} (h : SO.immediatelyContains x y) :
+theorem SyntacticObject.immediatelyContains_lt_weight {x y : SyntacticObject}
+    (h : SyntacticObject.immediatelyContains x y) :
     Nonplanar.numNodes y.val < Nonplanar.numNodes x.val := by
-  rcases SO.exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
-  · exact absurd h (SO.immediatelyContains_lexLeaf tok y)
-  · exact absurd h (SO.immediatelyContains_traceLeaf y)
-  · rw [SO.immediatelyContains_node] at h
-    rw [SO.node_val, weight_node_pair]
+  rcases SyntacticObject.exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
+  · exact absurd h (SyntacticObject.immediatelyContains_lexLeaf tok y)
+  · exact absurd h (SyntacticObject.immediatelyContains_traceLeaf y)
+  · rw [SyntacticObject.immediatelyContains_node] at h
+    rw [SyntacticObject.node_val, weight_node_pair]
     rcases h with rfl | rfl <;> omega
 
 /-- Containment strictly decreases weight; hence it is irreflexive. -/
-theorem SO.contains_lt_weight {x y : SO} (h : SO.contains x y) :
+theorem SyntacticObject.contains_lt_weight {x y : SyntacticObject}
+    (h : SyntacticObject.contains x y) :
     Nonplanar.numNodes y.val < Nonplanar.numNodes x.val := by
   induction h with
-  | imm _ _ himm => exact SO.immediatelyContains_lt_weight himm
-  | trans _ _ _ himm _ ih => exact lt_trans ih (SO.immediatelyContains_lt_weight himm)
+  | imm _ _ himm => exact SyntacticObject.immediatelyContains_lt_weight himm
+  | trans _ _ _ himm _ ih => exact lt_trans ih (SyntacticObject.immediatelyContains_lt_weight himm)
 
-theorem SO.contains_irrefl (x : SO) : ¬ SO.contains x x :=
-  fun h => absurd (SO.contains_lt_weight h) (lt_irrefl _)
+theorem SyntacticObject.contains_irrefl (x : SyntacticObject) : ¬ SyntacticObject.contains x x :=
+  fun h => absurd (SyntacticObject.contains_lt_weight h) (lt_irrefl _)
 
 /-! ### Subtree ↔ containment bridge -/
 
-theorem SO.mem_subtrees_of_immediatelyContains {x y : SO} (h : SO.immediatelyContains x y) :
+theorem SyntacticObject.mem_subtrees_of_immediatelyContains {x y : SyntacticObject}
+    (h : SyntacticObject.immediatelyContains x y) :
     y ∈ x.subtrees := by
-  rcases SO.exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
-  · exact absurd h (SO.immediatelyContains_lexLeaf tok y)
-  · exact absurd h (SO.immediatelyContains_traceLeaf y)
-  · rw [SO.immediatelyContains_node] at h
+  rcases SyntacticObject.exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
+  · exact absurd h (SyntacticObject.immediatelyContains_lexLeaf tok y)
+  · exact absurd h (SyntacticObject.immediatelyContains_traceLeaf y)
+  · rw [SyntacticObject.immediatelyContains_node] at h
     rcases h with heq | heq
-    · rw [heq, SO.mem_subtrees_node]; exact Or.inr (Or.inl (SO.self_mem_subtrees l))
-    · rw [heq, SO.mem_subtrees_node]; exact Or.inr (Or.inr (SO.self_mem_subtrees r))
+    · rw [heq, SyntacticObject.mem_subtrees_node]
+      exact Or.inr (Or.inl (SyntacticObject.self_mem_subtrees l))
+    · rw [heq, SyntacticObject.mem_subtrees_node]
+      exact Or.inr (Or.inr (SyntacticObject.self_mem_subtrees r))
 
-theorem SO.mem_subtrees_of_contains {x y : SO} (h : SO.contains x y) : y ∈ x.subtrees := by
+theorem SyntacticObject.mem_subtrees_of_contains {x y : SyntacticObject}
+    (h : SyntacticObject.contains x y) : y ∈ x.subtrees := by
   induction h with
-  | imm x y himm => exact SO.mem_subtrees_of_immediatelyContains himm
+  | imm x y himm => exact SyntacticObject.mem_subtrees_of_immediatelyContains himm
   | trans x y w himm _ ih =>
-    exact SO.subtrees_subset_of_mem (SO.mem_subtrees_of_immediatelyContains himm) ih
+    exact SyntacticObject.subtrees_subset_of_mem
+      (SyntacticObject.mem_subtrees_of_immediatelyContains himm) ih
 
 /-- A subtree of `x` is either `x` itself or properly contained in `x`. -/
-theorem SO.mem_subtrees_iff_eq_or_contains {x y : SO} :
-    y ∈ x.subtrees ↔ y = x ∨ SO.contains x y := by
-  refine ⟨fun h => ?_, fun h => h.elim (fun he => he ▸ SO.self_mem_subtrees x)
-    SO.mem_subtrees_of_contains⟩
-  induction x using SO.ind with
+theorem SyntacticObject.mem_subtrees_iff_eq_or_contains {x y : SyntacticObject} :
+    y ∈ x.subtrees ↔ y = x ∨ SyntacticObject.contains x y := by
+  refine ⟨fun h => ?_, fun h => h.elim (fun he => he ▸ SyntacticObject.self_mem_subtrees x)
+    SyntacticObject.mem_subtrees_of_contains⟩
+  induction x using SyntacticObject.ind with
   | lex tok =>
-    rw [SO.mem_subtrees, show (SO.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [SyntacticObject.mem_subtrees,
+        show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         mem_subtreesN_leaf] at h
     exact Or.inl (Subtype.ext h)
   | trace =>
-    rw [SO.mem_subtrees, show SO.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [SyntacticObject.mem_subtrees,
+        show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
         mem_subtreesN_leaf] at h
     exact Or.inl (Subtype.ext h)
   | node l r ihl ihr =>
-    rw [SO.mem_subtrees_node] at h
+    rw [SyntacticObject.mem_subtrees_node] at h
     rcases h with rfl | hl | hr
     · exact Or.inl rfl
     · refine Or.inr ?_
       rcases ihl hl with heq | hc
-      · rw [heq]; exact .imm _ _ ((SO.immediatelyContains_node l r l).mpr (Or.inl rfl))
-      · exact .trans _ _ l ((SO.immediatelyContains_node l r l).mpr (Or.inl rfl)) hc
+      · rw [heq]; exact .imm _ _ ((SyntacticObject.immediatelyContains_node l r l).mpr (Or.inl rfl))
+      · exact .trans _ _ l ((SyntacticObject.immediatelyContains_node l r l).mpr (Or.inl rfl)) hc
     · refine Or.inr ?_
       rcases ihr hr with heq | hc
-      · rw [heq]; exact .imm _ _ ((SO.immediatelyContains_node l r r).mpr (Or.inr rfl))
-      · exact .trans _ _ r ((SO.immediatelyContains_node l r r).mpr (Or.inr rfl)) hc
+      · rw [heq]; exact .imm _ _ ((SyntacticObject.immediatelyContains_node l r r).mpr (Or.inr rfl))
+      · exact .trans _ _ r ((SyntacticObject.immediatelyContains_node l r r).mpr (Or.inr rfl)) hc
 
 /-- **Containment ↔ proper subtree membership.** Gives a decision procedure for
     `contains` without well-founded recursion: `y` is properly contained in `x` iff
     it is a subtree distinct from `x`. -/
-theorem SO.contains_iff_mem_subtrees_and_ne {x y : SO} :
-    SO.contains x y ↔ y ∈ x.subtrees ∧ y ≠ x := by
+theorem SyntacticObject.contains_iff_mem_subtrees_and_ne {x y : SyntacticObject} :
+    SyntacticObject.contains x y ↔ y ∈ x.subtrees ∧ y ≠ x := by
   constructor
   · intro h
-    exact ⟨SO.mem_subtrees_of_contains h, fun he => SO.contains_irrefl x (he ▸ h)⟩
+    exact ⟨SyntacticObject.mem_subtrees_of_contains h,
+      fun he => SyntacticObject.contains_irrefl x (he ▸ h)⟩
   · rintro ⟨hmem, hne⟩
-    rcases SO.mem_subtrees_iff_eq_or_contains.mp hmem with rfl | hc
+    rcases SyntacticObject.mem_subtrees_iff_eq_or_contains.mp hmem with rfl | hc
     · exact absurd rfl hne
     · exact hc
 
-instance (x y : SO) : Decidable (SO.contains x y) :=
-  decidable_of_iff _ SO.contains_iff_mem_subtrees_and_ne.symm
+instance (x y : SyntacticObject) : Decidable (SyntacticObject.contains x y) :=
+  decidable_of_iff _ SyntacticObject.contains_iff_mem_subtrees_and_ne.symm
 
 /-! ### Term-of and reflexive containment -/
 
 /-- `x` is a **term of** `y`: `x = y` or `y` contains `x`. -/
-def SO.isTermOf (x y : SO) : Prop := x = y ∨ SO.contains y x
+def SyntacticObject.isTermOf (x y : SyntacticObject) : Prop := x = y ∨ SyntacticObject.contains y x
 
-instance (x y : SO) : Decidable (SO.isTermOf x y) := inferInstanceAs (Decidable (_ ∨ _))
+instance (x y : SyntacticObject) : Decidable (SyntacticObject.isTermOf x y) :=
+  inferInstanceAs (Decidable (_ ∨ _))
 
-theorem SO.isTermOf_iff_mem_subtrees (x y : SO) : SO.isTermOf x y ↔ x ∈ y.subtrees :=
-  SO.mem_subtrees_iff_eq_or_contains.symm
+theorem SyntacticObject.isTermOf_iff_mem_subtrees (x y : SyntacticObject) :
+    SyntacticObject.isTermOf x y ↔ x ∈ y.subtrees :=
+  SyntacticObject.mem_subtrees_iff_eq_or_contains.symm
 
 /-- Reflexive containment. -/
-def SO.containsOrEq (x y : SO) : Prop := x = y ∨ SO.contains x y
+def SyntacticObject.containsOrEq (x y : SyntacticObject) : Prop :=
+  x = y ∨ SyntacticObject.contains x y
 
-instance (x y : SO) : Decidable (SO.containsOrEq x y) := inferInstanceAs (Decidable (_ ∨ _))
+instance (x y : SyntacticObject) : Decidable (SyntacticObject.containsOrEq x y) :=
+  inferInstanceAs (Decidable (_ ∨ _))
 
-theorem SO.containsOrEq_trans {x y z : SO}
-    (hxy : SO.containsOrEq x y) (hyz : SO.containsOrEq y z) : SO.containsOrEq x z := by
+theorem SyntacticObject.containsOrEq_trans {x y z : SyntacticObject}
+    (hxy : SyntacticObject.containsOrEq x y) (hyz : SyntacticObject.containsOrEq y z) :
+    SyntacticObject.containsOrEq x z := by
   rcases hxy with rfl | hxy
   · exact hyz
   · rcases hyz with rfl | hyz
     · exact Or.inr hxy
-    · exact Or.inr (SO.contains_trans hxy hyz)
+    · exact Or.inr (SyntacticObject.contains_trans hxy hyz)
 
 /-! ### RoseTree-relative c-command ([reinhart-1976]) -/
 
 /-- `x` and `y` are **sisters in** `root`: distinct co-daughters of some subtree. -/
-def SO.areSistersIn (root x y : SO) : Prop :=
-  ∃ z ∈ root.subtrees, SO.immediatelyContains z x ∧ SO.immediatelyContains z y ∧ x ≠ y
+def SyntacticObject.areSistersIn (root x y : SyntacticObject) : Prop :=
+  ∃ z ∈ root.subtrees,
+    SyntacticObject.immediatelyContains z x ∧ SyntacticObject.immediatelyContains z y ∧ x ≠ y
 
-instance (root x y : SO) : Decidable (SO.areSistersIn root x y) :=
+instance (root x y : SyntacticObject) : Decidable (SyntacticObject.areSistersIn root x y) :=
   Multiset.decidableExistsMultiset
 
 /-- `x` **c-commands** `y` in `root`: `x` has a sister (in `root`) that
     contains-or-equals `y`. -/
-def SO.cCommandsIn (root x y : SO) : Prop :=
-  ∃ z ∈ root.subtrees, SO.areSistersIn root x z ∧ SO.containsOrEq z y
+def SyntacticObject.cCommandsIn (root x y : SyntacticObject) : Prop :=
+  ∃ z ∈ root.subtrees, SyntacticObject.areSistersIn root x z ∧ SyntacticObject.containsOrEq z y
 
-instance (root x y : SO) : Decidable (SO.cCommandsIn root x y) :=
+instance (root x y : SyntacticObject) : Decidable (SyntacticObject.cCommandsIn root x y) :=
   Multiset.decidableExistsMultiset
 
 /-- `x` **asymmetrically** c-commands `y` in `root`. -/
-def SO.asymCCommandsIn (root x y : SO) : Prop :=
-  SO.cCommandsIn root x y ∧ ¬ SO.cCommandsIn root y x
+def SyntacticObject.asymCCommandsIn (root x y : SyntacticObject) : Prop :=
+  SyntacticObject.cCommandsIn root x y ∧ ¬ SyntacticObject.cCommandsIn root y x
 
-instance (root x y : SO) : Decidable (SO.asymCCommandsIn root x y) :=
+instance (root x y : SyntacticObject) : Decidable (SyntacticObject.asymCCommandsIn root x y) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### `decide` demonstrations
 
 The containment / c-command decision procedures reduce on concrete trees built
-via `Nonplanar.mk ∘ RoseTree.node` (not the noncomputable `SO.node`), confirming the
+via `Nonplanar.mk ∘ RoseTree.node` (not the noncomputable `SyntacticObject.node`), confirming the
 "state result trees directly" discipline carries through to the relational layer. -/
 
-private def demoL : SO := ⟨Nonplanar.mk (.node (Sum.inl (mkTraceToken 0)) []), by decide⟩
-private def demoR : SO := ⟨Nonplanar.mk (.node (Sum.inl (mkTraceToken 1)) []), by decide⟩
-private def demoT : SO :=
+private def demoL : SyntacticObject :=
+  ⟨Nonplanar.mk (.node (Sum.inl (mkTraceToken 0)) []), by decide⟩
+private def demoR : SyntacticObject :=
+  ⟨Nonplanar.mk (.node (Sum.inl (mkTraceToken 1)) []), by decide⟩
+private def demoT : SyntacticObject :=
   ⟨Nonplanar.mk (.node (Sum.inr ())
     [.node (Sum.inl (mkTraceToken 0)) [], .node (Sum.inl (mkTraceToken 1)) []]), by decide⟩
 
 /-- The root properly contains its left daughter; the daughter does not contain the root. -/
-example : SO.contains demoT demoL ∧ ¬ SO.contains demoL demoT := by decide
+example : SyntacticObject.contains demoT demoL ∧ ¬ SyntacticObject.contains demoL demoT := by decide
 /-- The two daughters c-command each other in the root. -/
-example : SO.cCommandsIn demoT demoL demoR := by decide
+example : SyntacticObject.cCommandsIn demoT demoL demoR := by decide
 /-- A node has one more vertex than the sum of its daughters' (eq. 1.2.5 witness). -/
 example : (demoT.subtrees).card = 3 := by decide
 

--- a/Linglib/Syntax/Minimalist/Verbal/Applicative.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Applicative.lean
@@ -20,7 +20,7 @@ to it; a **low** applicative Merges with the theme (recipient = transfer *to*, s
 semantically null Voice (middles, anticausatives); low applicatives are Voice-independent.
 
 The high/low distinction is read off the Merge complement's category via the head function
-`SO.outerCatC`, so the typology follows from attachment height by construction.
+`SyntacticObject.outerCatC`, so the typology follows from attachment height by construction.
 
 ## Main definitions
 
@@ -55,10 +55,11 @@ def ApplType.complement : ApplType → Cat
   | .lowSource    => .D
 
 /-- The complement constituent an applicative Merges with — a leaf headed by `a.complement`. -/
-def ApplType.complementSO (a : ApplType) : SO :=
-  SO.mkLeaf a.complement [] 0
+def ApplType.complementSO (a : ApplType) : SyntacticObject :=
+  SyntacticObject.mkLeaf a.complement [] 0
 
-/-- The Merge complement's categorial features, read via the §1.13 head function `SO.outerCatC`. -/
+/-- The Merge complement's categorial features, read via the §1.13 head function
+`SyntacticObject.outerCatC`. -/
 def ApplType.complementFeatures (a : ApplType) : CatFeatures :=
   a.complementSO.outerCatC.elim ⟨false, false⟩ catFeatures
 

--- a/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
@@ -77,12 +77,12 @@ structure SmallClause where
 
 /-- Build the syntactic object for a small clause: `[SC Subj Pred]`. -/
 noncomputable def SmallClause.toSO (sc : SmallClause) : SyntacticObject :=
-  SO.merge sc.subject sc.predicate
+  SyntacticObject.merge sc.subject sc.predicate
 
 /-- Embed a small clause under a verb: `V [SC Subj Pred]`. -/
 noncomputable def SmallClause.embedUnderV (v : SyntacticObject) (sc : SmallClause) :
     SyntacticObject :=
-  SO.merge v sc.toSO
+  SyntacticObject.merge v sc.toSO
 
 /-- The construction type name for each SC predicate category. -/
 def SCPredCategory.constructionName : SCPredCategory → String
@@ -100,7 +100,7 @@ def SCPredCategory.constructionName : SCPredCategory → String
 The bundled `structure SmallClause` is the `Submonoid`-style API
 object: it carries data + the predicate-category discriminator. The
 companion predicate `IsSmallClause : SyntacticObject → Prop` lets us
-ask "is this raw SO an SC?" without constructing a `SmallClause`.
+ask "is this raw SyntacticObject an SC?" without constructing a `SmallClause`.
 Mathlib analogue: `Submonoid` (structure) + `IsSubmonoid` (predicate).
 
 Use this companion to characterize SC encodings written as raw
@@ -118,12 +118,12 @@ without forcing them through the `SmallClause` constructor. -/
     Supersedes the former `Quot.out`-based `leftSpine.outerCat` (arbitrary
     leftmost leaf): the value now tracks the genuine selector, not the
     representative choice. -/
-abbrev SO.headCat (so : SyntacticObject) : Option Cat :=
-  SO.outerCatC so
+abbrev SyntacticObject.headCat (so : SyntacticObject) : Option Cat :=
+  SyntacticObject.outerCatC so
 
 /-! ## Binary-node leaf/node counts
 
-`SO.merge` / `SO.node` are noncomputable (the `Nonplanar` carrier
+`SyntacticObject.merge` / `SyntacticObject.node` are noncomputable (the `Nonplanar` carrier
 round-trips through `Quotient.out`), so `decide`/`rfl` can't read back the
 shape of a `merge`-built tree. These two lemmas give the structural facts
 study files need — a binary node has the summed leaf count of its children
@@ -145,14 +145,15 @@ private theorem Nonplanar.numLeaves_node_pair {α : Type*} (a : α)
   omega
 
 /-- Leaf count of a binary Merge node is the sum of its children's. -/
-theorem SO.leafCount_node (l r : SyntacticObject) :
-    (SO.node l r).leafCount = l.leafCount + r.leafCount := by
-  rw [SO.leafCount, SO.node_val, Nonplanar.numLeaves_node_pair]; rfl
+theorem SyntacticObject.leafCount_node (l r : SyntacticObject) :
+    (SyntacticObject.node l r).leafCount = l.leafCount + r.leafCount := by
+  rw [SyntacticObject.leafCount, SyntacticObject.node_val, Nonplanar.numLeaves_node_pair]; rfl
 
-/-- Leaf count of a Merge is the sum of its children's (`SO.merge = SO.node`). -/
-@[simp] theorem SO.leafCount_merge (l r : SyntacticObject) :
-    (SO.merge l r).leafCount = l.leafCount + r.leafCount :=
-  SO.leafCount_node l r
+/-- Leaf count of a Merge is the sum of its children's (`SyntacticObject.merge =
+SyntacticObject.node`). -/
+@[simp] theorem SyntacticObject.leafCount_merge (l r : SyntacticObject) :
+    (SyntacticObject.merge l r).leafCount = l.leafCount + r.leafCount :=
+  SyntacticObject.leafCount_node l r
 
 /-- A syntactic object qualifies as a small-clause predicate iff its
     head category is one of [dendikken-1995]'s four SC-licensed
@@ -178,32 +179,36 @@ instance : DecidablePred IsSmallClausePredicate :=
     of which Quot.out representative was chosen. Computable via
     `immediatelyContains` (which is decidable and Multiset-based). -/
 def IsSmallClause (so : SyntacticObject) : Prop :=
-  ∃ pred, SO.immediatelyContains so pred ∧ IsSmallClausePredicate pred
+  ∃ pred, SyntacticObject.immediatelyContains so pred ∧ IsSmallClausePredicate pred
 
 noncomputable instance : DecidablePred IsSmallClause := fun so => by
   unfold IsSmallClause; classical infer_instance
 
-/-- `SO.merge`-form rewrite for `IsSmallClause`. Symmetric — by the swap-
+/-- `SyntacticObject.merge`-form rewrite for `IsSmallClause`. Symmetric — by the swap-
     invariant existential, the predicate can be either the left or the
     right child. -/
 theorem isSmallClause_merge (l r : SyntacticObject) :
-    IsSmallClause (SO.merge l r) ↔
+    IsSmallClause (SyntacticObject.merge l r) ↔
       (IsSmallClausePredicate l ∨ IsSmallClausePredicate r) := by
   unfold IsSmallClause
   constructor
   · rintro ⟨pred, himm, hpred⟩
-    -- SO.merge l r = SO.node l r; immediatelyContains_node: pred = l ∨ pred = r
-    rw [show SO.merge l r = SO.node l r from rfl, SO.immediatelyContains_node] at himm
+    -- SyntacticObject.merge l r = SyntacticObject.node l r;
+    -- immediatelyContains_node: pred = l ∨ pred = r
+    rw [show SyntacticObject.merge l r = SyntacticObject.node l r from rfl,
+        SyntacticObject.immediatelyContains_node] at himm
     rcases himm with rfl | rfl
     · exact Or.inl hpred
     · exact Or.inr hpred
   · intro h
     rcases h with hl | hr
     · refine ⟨l, ?_, hl⟩
-      rw [show SO.merge l r = SO.node l r from rfl, SO.immediatelyContains_node]
+      rw [show SyntacticObject.merge l r = SyntacticObject.node l r from rfl,
+          SyntacticObject.immediatelyContains_node]
       exact Or.inl rfl
     · refine ⟨r, ?_, hr⟩
-      rw [show SO.merge l r = SO.node l r from rfl, SO.immediatelyContains_node]
+      rw [show SyntacticObject.merge l r = SyntacticObject.node l r from rfl,
+          SyntacticObject.immediatelyContains_node]
       exact Or.inr rfl
 
 /-- Round-trip: any `SmallClause` whose stored `predCat` agrees with

--- a/Linglib/Syntax/Minimalist/Workspace/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Basic.lean
@@ -10,9 +10,9 @@ import Linglib.Syntax.Minimalist.Merge.Internal
 # Workspaces and Merge over syntactic objects
 
 [marcolli-chomsky-berwick-2025] §1.2–1.4. The single-carrier program's P1b: the
-**Merge and workspace layer over the `SO` syntactic objects** (`SyntacticObject.lean`).
+**Merge and workspace layer over the `SyntacticObject` syntactic objects** (`SyntacticObject.lean`).
 This is additive — it does *not* touch the legacy `SyntacticObject`/`Step`/`Derivation`
-(`FreeCommMagma (LIToken ⊕ Nat)`); flipping `SyntacticObject := SO` and retiring
+(`FreeCommMagma (LIToken ⊕ Nat)`); completing the `SyntacticObject` flip and retiring
 the `⊕ Nat` index is P2.
 
 ## What this file connects
@@ -37,7 +37,8 @@ function *applied*, and P3/P4 retire them.
 ## Computability discipline
 
 `Nonplanar.node`, `mergeOp`, and the coproduct are `noncomputable` (the Hopf
-machinery round-trips through `Quotient.out`). So `SO.merge`/`SO.intMerge` are
+machinery round-trips through `Quotient.out`). So `SyntacticObject.merge`/`SyntacticObject.intMerge`
+are
 `noncomputable`, and studies must **state result trees directly** (built computably
 via `Nonplanar.mk ∘ RoseTree.node`, then `decide` on `IsSO`) and relate them to Merge
 by theorem — never compute Merge under `decide`. `merge_mk` is the construction
@@ -51,7 +52,8 @@ open RootedTree RootedTree.ConnesKreimer
 
 /-! ### Workspaces (MCB Def 1.2.1)
 
-The carrier Merge operators `SO.merge` (Lemma 1.4.1) and `SO.intMerge` (Prop 1.4.2) are
+The carrier Merge operators `SyntacticObject.merge` (Lemma 1.4.1) and `SyntacticObject.intMerge`
+(Prop 1.4.2) are
 defined in `SyntacticObject/Build.lean` (they need only the bare binary node); this file
 adds their **coproduct identity** on the workspace Hopf algebra. -/
 
@@ -60,27 +62,27 @@ adds their **coproduct identity** on the workspace Hopf algebra. -/
     union** (`+` on `Multiset`), with unit the empty forest (`0`); a *well-formed*
     workspace is nonempty. `Forest` is the algebra's forest type, so a workspace is
     exactly what `of'` lifts into `ConnesKreimer ℤ (Nonplanar SOLabel)`. -/
-abbrev Workspace : Type := Forest SO
+abbrev Workspace : Type := Forest SyntacticObject
 
 /-- A moved element occupies **repeated isomorphic components** of the workspace; the
     number of copies is their multiplicity ([marcolli-chomsky-berwick-2025]
     Def 1.2.1: "those isomorphism classes are the chain"). Decidable now that the
-    carrier has `DecidableEq SO` (#792) — this is the workspace-level chain identity
+    carrier has `DecidableEq SyntacticObject` (#792) — this is the workspace-level chain identity
     that **replaces the legacy `⊕ Nat` trace index**. -/
-def Workspace.chainMultiplicity (S : SO) (W : Workspace) : Nat := W.count S
+def Workspace.chainMultiplicity (S : SyntacticObject) (W : Workspace) : Nat := W.count S
 
 /-! ### External Merge: bridge to the algebra (Lemma 1.4.1) -/
 
 /-- **External Merge ↔ algebra** ([marcolli-chomsky-berwick-2025] Lemma 1.4.1,
     F̂ = ∅). The algebraic Merge `mergeOp (Sum.inr ())` on the 2-object workspace
-    `{S, S'}` yields the singleton workspace of the carrier Merge `SO.merge S S'`.
+    `{S, S'}` yields the singleton workspace of the carrier Merge `SyntacticObject.merge S S'`.
     The root label is the **bare** `Sum.inr ()` — the faithful departure from the
     head-decorated legacy bridge. -/
-theorem SO.merge_toForest (S S' : SO) :
+theorem SyntacticObject.merge_toForest (S S' : SyntacticObject) :
     Merge.mergeOp (R := ℤ) (Sum.inr ()) S.val S'.val
         (of' ({S.val, S'.val} : Forest (Nonplanar SOLabel)))
-      = of' (R := ℤ) ({(SO.merge S S').val} : Forest (Nonplanar SOLabel)) := by
-  rw [Merge.mergeOp_pair, SO.merge_val]
+      = of' (R := ℤ) ({(SyntacticObject.merge S S').val} : Forest (Nonplanar SOLabel)) := by
+  rw [Merge.mergeOp_pair, SyntacticObject.merge_val]
 
 /-! ### Internal Merge as composition (MCB Prop 1.4.2) -/
 
@@ -88,9 +90,9 @@ theorem SO.merge_toForest (S S' : SO) :
     the Δ^ρ cut data on `T` extracting `mover` with remainder `remainder` (the unique
     crown-`{mover}` summand `p0`, `p0.2 = remainder.val`, `T ≠ mover`), the two-stage
     composition `mergeOp (inr ()) ∘ mergeOpUnit mover` over `{T}` yields the singleton
-    workspace of `SO.intMerge mover remainder`. This is `mergeOp_im_composition`
+    workspace of `SyntacticObject.intMerge mover remainder`. This is `mergeOp_im_composition`
     transported to the carrier with the `IsSO`-carrying result. -/
-theorem SO.intMerge_toForest (mover remainder T : SO)
+theorem SyntacticObject.intMerge_toForest (mover remainder T : SyntacticObject)
     (p0 : Forest (Nonplanar SOLabel) × Nonplanar SOLabel)
     (h_filter : (cutSummandsN T.val).filter
         (fun p => p.1 = ({mover.val} : Forest (Nonplanar SOLabel))) = {p0})
@@ -99,9 +101,10 @@ theorem SO.intMerge_toForest (mover remainder T : SO)
     Merge.mergeOp (R := ℤ) (Sum.inr ()) remainder.val mover.val
         (Merge.mergeOpUnit (R := ℤ) mover.val
           (of' ({T.val} : Forest (Nonplanar SOLabel))))
-      = of' (R := ℤ) ({(SO.intMerge mover remainder).val} : Forest (Nonplanar SOLabel)) := by
+      = of' (R := ℤ)
+          ({(SyntacticObject.intMerge mover remainder).val} : Forest (Nonplanar SOLabel)) := by
   rw [Merge.mergeOp_im_composition (Sum.inr ()) mover.val T.val remainder.val
-        p0 h_filter h_remainder hT, SO.intMerge_val]
+        p0 h_filter h_remainder hT, SyntacticObject.intMerge_val]
 
 /-! ### `decide` demonstrations (the P1 computability spike, as carrier tests)
 
@@ -113,10 +116,10 @@ noncomputable; ill-formed shapes are rejected. -/
 private def demoTok : LIToken := mkTraceToken 0
 
 /-- A lexical leaf is well-formed. -/
-example : IsSO (SO.lexLeaf demoTok).val := by decide
+example : IsSO (SyntacticObject.lexLeaf demoTok).val := by decide
 
 /-- The bare trace leaf is well-formed. -/
-example : IsSO SO.traceLeaf.val := by decide
+example : IsSO SyntacticObject.traceLeaf.val := by decide
 
 /-- An IM-result-shaped tree — bare binary node over a lexical leaf and a bare
     trace — is well-formed (built directly, no Merge operator). -/
@@ -135,7 +138,8 @@ example :
       [.leaf (Sum.inr ()), .leaf (Sum.inr ()), .leaf (Sum.inr ())])) := by decide
 
 /-- Workspace chain identity is decidable: two isomorphic components ⇒ chain of 2. -/
-example : Workspace.chainMultiplicity SO.traceLeaf {SO.traceLeaf, SO.traceLeaf} = 2 := by
+example : Workspace.chainMultiplicity SyntacticObject.traceLeaf
+    {SyntacticObject.traceLeaf, SyntacticObject.traceLeaf} = 2 := by
   decide
 
 end Minimalist


### PR DESCRIPTION
Completes the single-carrier program's own P2 flip (Basic.lean scope note: "the target type that will become `SyntacticObject`"): the subtype is now `def SyntacticObject`, the `abbrev SyntacticObject := SO` alias is gone, and all 47 consumer files use the full name — so a file can `open SyntacticObject` for the namespace.

- `SOLabel` deliberately kept: `SyntacticObject.Label` would collide with §1.15 labeling-algorithm vocabulary
- protected: `SO₀` (book alphabet), WALS subject-object values, word-order "SO" prose
- line reflows for the 13-char-longer name (203 lines; pure whitespace)