### PR TITLE
feat(Syntax/Minimalist): SyntacticObject.lift/hom_ext; MulZeroClass states

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -111,6 +111,7 @@ import Linglib.Core.Computability.Variety.Langs
 import Linglib.Core.Data.Fin.Tuple.Basic
 import Linglib.Core.Data.List.Bookend
 import Linglib.Core.Data.List.Chain
+import Linglib.Core.Data.List.Perm
 import Linglib.Core.Data.List.Destutter
 import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Data.List.Factors
@@ -2900,6 +2901,7 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Amalgamation
 import Linglib.Syntax.Minimalist.SyntacticObject.Basic
 import Linglib.Syntax.Minimalist.SyntacticObject.Build
 import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
+import Linglib.Syntax.Minimalist.SyntacticObject.Lift
 import Linglib.Syntax.Minimalist.Linearization.Externalization
 import Linglib.Syntax.Minimalist.Phase.Domain
 import Linglib.Syntax.Minimalist.SyntacticObject.Replace

--- a/Linglib/Core/Data/List/Perm.lean
+++ b/Linglib/Core/Data/List/Perm.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.Perm.Basic
+
+/-!
+# Permutation invariance from binary symmetry
+
+`List.Perm.congr_arity₂`: a list function symmetric on pairs and constant above
+length two is `Perm`-invariant. Keystone for node algebras whose only
+order-sensitive shape is binary (Merge-style algebras over unordered daughters).
+-/
+
+/-- A list function symmetric on pairs and constant above length two is
+    `Perm`-invariant: lengths ≤ 1 are rigid under permutation, pairs by the
+    symmetry, longer lists by the constancy. -/
+theorem List.Perm.congr_arity₂ {β γ : Type*} {g : List β → γ} {c : γ}
+    (hswap : ∀ x y, g [x, y] = g [y, x])
+    (hbig : ∀ l : List β, 2 < l.length → g l = c)
+    {l₁ l₂ : List β} (h : l₁.Perm l₂) : g l₁ = g l₂ := by
+  induction h with
+  | nil => rfl
+  | @cons x l₁ l₂ h _ih =>
+    match l₁, l₂, h with
+    | [], l₂, h => rw [show l₂ = [] from h.symm.eq_nil]
+    | [y], l₂, h => rw [show l₂ = [y] from List.perm_singleton.mp h.symm]
+    | _ :: _ :: _, l₂, h =>
+      have hl := h.length_eq
+      rw [hbig _ (by simp +arith), hbig _ (by simp only [List.length_cons] at hl ⊢; omega)]
+  | swap x y l =>
+    match l with
+    | [] => exact hswap y x
+    | _ :: _ => rw [hbig _ (by simp +arith), hbig _ (by simp +arith)]
+  | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂

--- a/Linglib/Core/Data/RoseTree/Nonplanar.lean
+++ b/Linglib/Core/Data/RoseTree/Nonplanar.lean
@@ -82,6 +82,17 @@ def lift {β : Sort*} (f : RoseTree α → β)
     (h : ∀ t s, RoseTree.Perm t s → f t = f s) (t : RoseTree α) :
     lift f h (mk t) = f t := rfl
 
+/-- Induction in `mk`-form (cf. `Multiset.induction_on`): goals display
+    `Nonplanar.mk` rather than `Quotient.mk`, so `mk`-stated lemmas rewrite. -/
+@[elab_as_elim] theorem inductionOn {motive : Nonplanar α → Prop} (t : Nonplanar α)
+    (mk : ∀ p, motive (mk p)) : motive t :=
+  Quotient.inductionOn t mk
+
+/-- Binary induction in `mk`-form. -/
+@[elab_as_elim] theorem inductionOn₂ {motive : Nonplanar α → Nonplanar α → Prop}
+    (t s : Nonplanar α) (mk : ∀ p q, motive (mk p) (mk q)) : motive t s :=
+  Quotient.inductionOn₂ t s mk
+
 /-! ### Smart leaf constructor + lifted counts
 
 A leaf in `Nonplanar α` is `mk (RoseTree.leaf a)`. `numNodes` is the

--- a/Linglib/Syntax/Minimalist/Agree/Consistency.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Consistency.lean
@@ -153,7 +153,7 @@ head-following toy model — deliberately the simplest illustration; §3.2.2 ref
     probe `Υ` applied to `T`'s §1.13 selection head (`selCheckN`); `inconsistent` (`−∞`) when `T`
     has no well-defined head (off the endocentric domain). -/
 def headProbeTree (Υ : LIToken → Consistency) (T : Nonplanar SOLabel) : Consistency :=
-  (selCheckN T).elim Consistency.inconsistent fun p => Υ p.1
+  (selCheckN T).head.elim Consistency.inconsistent Υ
 
 /-- `Υ_{s,h}` extended multiplicatively to forests (the semiring character of Lemma 3.2.5): a
     workspace is consistent iff each of its trees is. Mirrors `birkhoffMinusMonoidHom`. -/

--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -20,42 +20,36 @@ the book), c-selection computes the planar order.
 ## Main declarations
 
 * `Minimalist.LinearizationState`: the value of the book's head function in its two
-  descriptions — the selection state enriched with the yield, `none` off `Dom(h)`;
-  a `CommMagma` under the `side`-indexed Merge-local product.
-* `Minimalist.LinearizationState.sel`: the projection morphism to `SelState`,
-  forgetting the order description.
+  descriptions — the selection state enriched with the yield, `0` off `Dom(h)`; a
+  `CommMagma` and `MulZeroClass` under the `side`-indexed Merge-local product.
+* `Minimalist.LinearizationState.sel`: the projection morphism to `SelectionState`.
 * `Minimalist.headHom`: the head function as a morphism of magmas
-  `SyntacticObject →ₙ* LinearizationState side`, refining `selCheckHom` with the yield.
-* `Minimalist.SyntacticObject.linearize`, `Minimalist.SyntacticObject.phonYield`: the yield readout
-and the
-  pronounced surface forms.
+  `SyntacticObject →ₙ* LinearizationState side`, refining `selCheckHom`.
+* `Minimalist.SyntacticObject.linearize`, `Minimalist.SyntacticObject.phonYield`:
+  the yield readout and the pronounced surface forms.
 
 ## Main results
 
 * `Minimalist.sel_comp_headHom`: fusion — the selection component of the head
-  function's value is the selection check, as a commuting triangle of magma
-  morphisms.
-* `Minimalist.headNode_perm`: the head algebra is permutation-invariant
-  (`List.Perm.congr_arity₂` on `mul_comm`), so the state descends to the nonplanar
-  quotient by `RoseTree.fold_perm`.
+  function's value is the selection check, by `SyntacticObject.hom_ext`.
 
 ## Implementation notes
 
 Head functions are partial ([marcolli-chomsky-berwick-2025] §1.13.2): at exocentric
 nodes no daughter projects and no order is determined — the book rejects inducing one
 from a total order on labels as "not a realistic linguistic assumption" — so the
-state is `none` there, matching the book's elimination of nonparsable objects at
-externalization. The selection state and the yield are the book's two descriptions
-of *one* head function: eq. (1.13.3) reads `h(T)` as "a single leaf (the head)" or
-as the ordered leaf sequence, "switch[ing] between these two descriptions without
-changing the notation". `LinearizationState` fuses them into a single `Option`,
-making `Dom(yield) = Dom(h)` true by construction. **Naming**: the head-function
-*maps* (`headNode`, `headPlanar`, `headN`, `headHom`) carry the book's name for `h`;
-the *value* type does not — the book restricts "the term head to terminal elements"
-(quoting [chomsky-1995-bare] §4), and the strict head is recovered via `sel`. The
-`side` index is phantom in the carrier and read by the multiplication (the `WithLp`
-pattern); the head-leaf description is side-invariant, only the yield description is
-convention-relative. Conceptually the yield component is
+state is `0` there, the absorbing element of the book's renormalization reading of
+partial head functions. The selection state and the yield are the book's two
+descriptions of *one* head function: eq. (1.13.3) reads `h(T)` as "a single leaf
+(the head)" or as the ordered leaf sequence, "switch[ing] between these two
+descriptions without changing the notation". `LinearizationState` fuses them into
+one partial value, making `Dom(yield) = Dom(h)` true by construction. **Naming**:
+the head-function *maps* (`headHom` and the leaf data it lifts) carry the book's
+name for `h`; the *value* type does not — the book restricts "the term head to
+terminal elements" (quoting [chomsky-1995-bare] §4), and the strict head is
+recovered via `sel`. `SyntacticObject.linearize` is the harmonic candidate for the
+externalization section σ_L, defined on `Dom(h)` only — the book's σ_L must extend
+it *noncanonically* off `Dom(h)`. Conceptually the yield component is
 `WithZero (FreeMonoid LIToken)`: a silent trace is the unit, exocentricity the
 absorbing zero, and head-final placement is multiplication in the opposite monoid.
 
@@ -68,184 +62,141 @@ namespace Minimalist
 
 open RootedTree
 
-/-- Place the head daughter's yield on the convention side: `.initial` (head-initial)
-    → head-yield first, `.final` (head-final) → head-yield last. -/
+/-- Place the head daughter's yield on the convention side: `.initial` → head-yield
+    first, `.final` → head-yield last. -/
 def placeYield : ConventionDir → List LIToken → List LIToken → List LIToken
   | .initial, headY, otherY => headY ++ otherY
   | .final,   headY, otherY => otherY ++ headY
 
 /-! ### The linearization state -/
 
-set_option linter.unusedVariables false in
-/-- The linearization state of a constituent under head-side convention `side`: the
-    projecting head with its residual selectional stack (the `SelState` data)
-    enriched with the yield, `none` off `Dom(h)` — the value of
-    [marcolli-chomsky-berwick-2025]'s head function in its two descriptions, "a
-    single leaf (the head)" or the ordered leaf sequence (eq. (1.13.3)), which the
-    book reads interchangeably "without changing the notation". The `side` parameter
-    is phantom in the carrier — the multiplication reads it (the `WithLp` pattern). -/
-def LinearizationState (side : ConventionDir) : Type :=
-  Option ((LIToken × List Cat) × List LIToken)
+/-- The value of the head function in its two descriptions: the projecting head
+    with its residual stack, enriched with the yield; `0` off `Dom(h)`. The `side`
+    parameter is phantom in the carrier — the multiplication reads it. -/
+structure LinearizationState (side : ConventionDir) : Type where
+  toOption : Option ((LIToken × List Cat) × List LIToken)
+deriving DecidableEq
 
 namespace LinearizationState
 
 variable {side : ConventionDir}
 
-/-- Merge-local externalization: the `selCombine` decision projects the head and
-    places the projecting daughter's yield on the convention side. -/
-instance : Mul (LinearizationState side) :=
-  ⟨fun x y =>
+/-- A defined state: projecting head `tok`, residual stack `stack`, yield `yld`. -/
+def of (tok : LIToken) (stack : List Cat) (yld : List LIToken) : LinearizationState side :=
+  ⟨some ((tok, stack), yld)⟩
+
+/-- Merge-local externalization: the `selCombine` decision places the projecting
+    daughter's yield on the convention side; `0` is absorbing. -/
+instance : MulZeroClass (LinearizationState side) where
+  mul x y :=
     match x, y with
-    | some (s₁, y₁), some (s₂, y₂) =>
-        (selCombine (some s₁) (some s₂)).map fun p =>
-          (p.2, placeYield side (bif p.1 then y₁ else y₂) (bif p.1 then y₂ else y₁))
-    | _, _ => none⟩
+    | ⟨some (s₁, y₁)⟩, ⟨some (s₂, y₂)⟩ =>
+        ⟨(selCombine ⟨some s₁⟩ ⟨some s₂⟩).map fun p =>
+          (p.2, placeYield side (bif p.1 then y₁ else y₂) (bif p.1 then y₂ else y₁))⟩
+    | _, _ => ⟨none⟩
+  zero := ⟨none⟩
+  zero_mul _ := rfl
+  mul_zero x := by rcases x with ⟨_ | _⟩ <;> rfl
+
+/-- `*` on defined states: the canonical accessor. -/
+theorem some_mul_some (s₁ s₂ : LIToken × List Cat) (y₁ y₂ : List LIToken) :
+    (⟨some (s₁, y₁)⟩ * ⟨some (s₂, y₂)⟩ : LinearizationState side) =
+      ⟨(selCombine ⟨some s₁⟩ ⟨some s₂⟩).map fun p =>
+          (p.2, placeYield side (bif p.1 then y₁ else y₂) (bif p.1 then y₂ else y₁))⟩ := rfl
 
 instance : CommMagma (LinearizationState side) where
   mul_comm x y := by
     match x, y with
-    | none, none | none, some _ | some _, none => rfl
-    | some (s₁, y₁), some (s₂, y₂) =>
-      show (selCombine (some s₁) (some s₂)).map _ = (selCombine (some s₂) (some s₁)).map _
-      rw [selCombine_comm]
-      cases selCombine (some s₂) (some s₁) with
-      | none => rfl
-      | some p => obtain ⟨b, hd, res⟩ := p; cases b <;> rfl
+    | ⟨none⟩, ⟨none⟩ | ⟨none⟩, ⟨some _⟩ | ⟨some _⟩, ⟨none⟩ => rfl
+    | ⟨some (s₁, y₁)⟩, ⟨some (s₂, y₂)⟩ =>
+      rw [some_mul_some, some_mul_some, selCombine_comm]
+      rcases selCombine ⟨some s₂⟩ ⟨some s₁⟩ with _ | ⟨_ | _, _, _⟩ <;> rfl
 
-/-- The projection to the selection state, as a morphism of magmas: forgetting the
-    order description of the head. -/
-def sel : LinearizationState side →ₙ* SelState where
-  toFun := Option.map (·.1)
+/-- The projection to the selection state: forgetting the order description. -/
+def sel : LinearizationState side →ₙ* SelectionState where
+  toFun x := ⟨x.toOption.map (·.1)⟩
   map_mul' x y := by
     match x, y with
-    | none, _ => rfl
-    | some _, none => exact (SelState.mul_none _).symm
-    | some (s₁, y₁), some (s₂, y₂) =>
-      show Option.map _ ((selCombine (some s₁) (some s₂)).map _) = _
-      rw [Option.map_map]; rfl
+    | ⟨none⟩, _ => rfl
+    | ⟨some _⟩, ⟨none⟩ => exact (mul_zero _).symm
+    | ⟨some (s₁, y₁)⟩, ⟨some (s₂, y₂)⟩ =>
+      rw [some_mul_some]
+      simp only [Option.map_map]
+      rfl
+
+@[simp] theorem sel_of (tok : LIToken) (stack : List Cat) (yld : List LIToken) :
+    sel (of tok stack yld : LinearizationState side) = .of tok stack := rfl
+
+@[simp] theorem sel_zero : sel (0 : LinearizationState side) = 0 := rfl
+
+/-- The yield component: the ordered leaf sequence, `none` off `Dom(h)`. -/
+def yield (x : LinearizationState side) : Option (List LIToken) :=
+  x.toOption.map (·.2)
+
+@[simp] theorem yield_of (tok : LIToken) (stack : List Cat) (yld : List LIToken) :
+    (of tok stack yld : LinearizationState side).yield = some yld := rfl
+
+@[simp] theorem yield_zero : (0 : LinearizationState side).yield = none := rfl
 
 end LinearizationState
 
-/-! ### The head algebra -/
-
-/-- The head algebra: a lexical leaf is pronounced carrying its `outerSel` stack, a
-    bare trace leaf is silent and saturated (the cancelled copy of
-    [marcolli-chomsky-berwick-2025] §1.12), a bare binary node is the `LinearizationState`
-    product, and other arities are off `Dom(h)`. -/
-def headNode (side : ConventionDir) :
-    SOLabel → List (LinearizationState side) → LinearizationState side
-  | .inl tok, _     => some ((tok, tok.item.outerSel), [tok])
-  | .inr (), []     => some ((mkTraceToken 0, []), [])
-  | .inr (), [x, y] => x * y
-  | .inr (), _      => none
-
-/-- A daughter list of three or more is off `Dom(h)`. -/
-private theorem headNode_big {side : ConventionDir} {l : List (LinearizationState side)}
-    (h : 2 < l.length) : headNode side (Sum.inr ()) l = none := by
-  match l with
-  | _ :: _ :: _ :: _ => rfl
-  | [] | [_] | [_, _] => simp at h
-
-/-- `headNode` is invariant under permutation of the daughter states: only the
-    binary shape is order-sensitive, and there `mul_comm` applies. -/
-theorem headNode_perm (side : ConventionDir) (a : SOLabel) {l₁ l₂ : List (LinearizationState side)}
-    (h : l₁.Perm l₂) : headNode side a l₁ = headNode side a l₂ := by
-  cases a with
-  | inl tok => rfl
-  | inr u => cases u; exact h.congr_arity₂ (fun x y => mul_comm x y) fun _ h => headNode_big h
-
-/-- `LinearizationState.sel` intertwines the head and selection algebras. -/
-theorem sel_headNode (side : ConventionDir) (a : SOLabel) (ps : List (LinearizationState side)) :
-    LinearizationState.sel (headNode side a ps) = selNode a (ps.map LinearizationState.sel) := by
-  match a, ps with
-  | .inl tok, _ => rfl
-  | .inr (), [] => rfl
-  | .inr (), [x, y] => exact map_mul LinearizationState.sel x y
-  | .inr (), [_] | .inr (), _ :: _ :: _ :: _ => rfl
-
-/-! ### The head function on the planar and nonplanar carriers -/
-
-/-- The head function on planar `SyntacticObject`-trees: the catamorphism of the head algebra. -/
-def headPlanar (side : ConventionDir) : RoseTree SOLabel → LinearizationState side :=
-  RoseTree.fold (headNode side)
-
-/-- **Fusion** on the planar carrier: the selection component of the head
-    function's value is the selection check. -/
-theorem sel_headPlanar (side : ConventionDir) (t : RoseTree SOLabel) :
-    LinearizationState.sel (headPlanar side t) = selCheckPlanar t :=
-  RoseTree.fold_hom _ (sel_headNode side) t
-
-/-- The state is projection-determined, not representative-determined: it descends
-    to the nonplanar quotient. -/
-theorem headPlanar_perm (side : ConventionDir) {t s : RoseTree SOLabel}
-    (h : RoseTree.Perm t s) : headPlanar side t = headPlanar side s :=
-  RoseTree.fold_perm (fun a _ _ h' => headNode_perm side a h') h
-
-/-- The head function on the nonplanar carrier. -/
-def headN (side : ConventionDir) : Nonplanar SOLabel → LinearizationState side :=
-  Nonplanar.lift (headPlanar side) fun _ _ h => headPlanar_perm side h
-
-@[simp] theorem headN_mk (side : ConventionDir) (p : RoseTree SOLabel) :
-    headN side (Nonplanar.mk p) = headPlanar side p := rfl
-
-/-- The nonplanar magma law: Merge multiplies linearization states. -/
-theorem headN_node (side : ConventionDir) (a b : Nonplanar SOLabel) :
-    headN side (Nonplanar.node (Sum.inr ()) {a, b}) = headN side a * headN side b := by
-  refine Quotient.inductionOn₂ a b fun pa pb => ?_
-  show headN side (Nonplanar.node (Sum.inr ()) {Nonplanar.mk pa, Nonplanar.mk pb})
-      = headN side (Nonplanar.mk pa) * headN side (Nonplanar.mk pb)
-  rw [Nonplanar.node_pair_mk]; exact rfl
-
 /-! ### Externalization on `SyntacticObject` -/
 
-/-- The linearization state of a syntactic object: the value of the head function
-    in both descriptions. -/
-def SyntacticObject.linearizationState (side : ConventionDir) (s : SyntacticObject) :
+variable (side : ConventionDir)
+
+/-- The head function's value on a syntactic object: the `SyntacticObject.liftFun`
+    of pronounced lexical leaves and the silent, saturated trace. -/
+def SyntacticObject.linearizationState (s : SyntacticObject) :
     LinearizationState side :=
-  headN side s.val
+  SyntacticObject.liftFun (fun tok => .of tok tok.item.outerSel [tok])
+    (.of (mkTraceToken 0) [] []) s
 
-@[simp] theorem SyntacticObject.linearizationState_node (side : ConventionDir)
+@[simp] theorem SyntacticObject.linearizationState_lexLeaf
+    (tok : LIToken) :
+    (SyntacticObject.lexLeaf tok).linearizationState side =
+      .of tok tok.item.outerSel [tok] := rfl
+
+@[simp] theorem SyntacticObject.linearizationState_traceLeaf :
+    SyntacticObject.traceLeaf.linearizationState side = .of (mkTraceToken 0) [] [] := rfl
+
+@[simp] theorem SyntacticObject.linearizationState_node
     (l r : SyntacticObject) :
-    (SyntacticObject.node l r).linearizationState side
-      = l.linearizationState side * r.linearizationState side := by
-  show headN side (SyntacticObject.node l r).val = headN side l.val * headN side r.val
-  rw [SyntacticObject.node_val, headN_node]
+    (SyntacticObject.node l r).linearizationState side =
+      l.linearizationState side * r.linearizationState side :=
+  SyntacticObject.liftFun_node _ _ l r
 
-/-- **The head function is a morphism of magmas** `SyntacticObject →ₙ* LinearizationState side`
-    ([marcolli-chomsky-berwick-2025] §1.13's algebraic frame): Merge multiplies
-    constituents, the head function multiplies linearization states. -/
-noncomputable def headHom (side : ConventionDir) : SyntacticObject →ₙ* LinearizationState side where
-  toFun := SyntacticObject.linearizationState side
-  map_mul' := SyntacticObject.linearizationState_node side
+/-- The head function as a morphism of magmas ([marcolli-chomsky-berwick-2025]
+    §1.13's algebraic frame): Merge multiplies constituents, `h` multiplies states. -/
+noncomputable def headHom :
+    SyntacticObject →ₙ* LinearizationState side :=
+  SyntacticObject.lift (fun tok => .of tok tok.item.outerSel [tok])
+    (.of (mkTraceToken 0) [] [])
 
-/-- **Fusion as a commuting triangle**: projecting the head function's value to its
-    selection component is the selection check —
-    `LinearizationState.sel ∘ headHom = selCheckHom`. -/
-theorem sel_comp_headHom (side : ConventionDir) :
+@[simp] theorem headHom_apply (s : SyntacticObject) :
+    headHom side s = s.linearizationState side := rfl
+
+/-- Fusion: the selection component of the head function's value is the selection
+    check — two morphisms agreeing on the leaves (`SyntacticObject.hom_ext`). -/
+theorem sel_comp_headHom :
     LinearizationState.sel.comp (headHom side) = selCheckHom :=
-  MulHom.ext fun s => by
-    show LinearizationState.sel (headN side s.val) = selCheckN s.val
-    exact Quotient.inductionOn s.val (sel_headPlanar side)
+  SyntacticObject.hom_ext (fun _ => rfl) rfl
 
-/-- The surface token order of a syntactic object under the head-side convention
-    `side` ([marcolli-chomsky-berwick-2025] §1.12.1): the yield readout of the
-    linearization state — the selection-induced harmonic candidate for the externalization
-    section σ_L, defined on `Dom(h)` only (the book's σ_L must extend it
-    *noncanonically* off `Dom(h)`). The readout alone is not a morphism: placing a
-    yield needs the head leaf, which is why `LinearizationState` carries both descriptions. -/
-def SyntacticObject.linearize (side : ConventionDir) (s : SyntacticObject) :
+/-- The surface token order under head-side convention `side`
+    ([marcolli-chomsky-berwick-2025] §1.12.1): the yield readout of the
+    linearization state. Not a morphism — placing a yield needs the head. -/
+def SyntacticObject.linearize (s : SyntacticObject) :
     Option (List LIToken) :=
-  Option.map (·.2) (s.linearizationState side)
+  (s.linearizationState side).yield
 
-/-- The pronounced surface forms: the yield with unpronounced (empty-`phonForm`)
-    tokens dropped. Traces, being the bare `Sum.inr ()` leaf, contribute nothing. -/
-def SyntacticObject.phonYield (side : ConventionDir) (s : SyntacticObject) : Option (List String) :=
-  (SyntacticObject.linearize side s).map (·.filterMap LIToken.phonForm?)
+/-- The pronounced surface forms: the yield with unpronounced tokens dropped. -/
+def SyntacticObject.phonYield (s : SyntacticObject) :
+    Option (List String) :=
+  (s.linearize side).map (·.filterMap LIToken.phonForm?)
 
-@[simp] theorem SyntacticObject.linearize_lexLeaf (side : ConventionDir) (tok : LIToken) :
+@[simp] theorem SyntacticObject.linearize_lexLeaf (tok : LIToken) :
     (SyntacticObject.lexLeaf tok).linearize side = some [tok] := rfl
 
-@[simp] theorem SyntacticObject.linearize_traceLeaf (side : ConventionDir) :
+@[simp] theorem SyntacticObject.linearize_traceLeaf :
     SyntacticObject.traceLeaf.linearize side = some [] := rfl
 
 /-! ### `decide` demonstration
@@ -253,8 +204,7 @@ def SyntacticObject.phonYield (side : ConventionDir) (s : SyntacticObject) : Opt
 The order reduces on concrete `mk`-built trees, the head-side parameter flips it, and
 exocentric Merge is order-undefined. -/
 
-/-- A determiner (category `D`, selecting `N`) over a noun: `D` projects, so
-    head-initial yields `the dog` and head-final yields `dog the`. -/
+/-- A determiner over a noun: `D` selects `N`, so `D` projects. -/
 private def demoTheDog : SyntacticObject :=
   ⟨Nonplanar.mk (.node (Sum.inr ())
     [.node (Sum.inl ⟨.simple .D [.N] (phonForm := "the"), 0⟩) [],
@@ -265,8 +215,8 @@ example : (demoTheDog.linearize .final).map (·.map (·.id)) = some [1, 0] := by
 example : demoTheDog.phonYield .initial = some ["the", "dog"] := by decide
 example : demoTheDog.phonYield .final = some ["dog", "the"] := by decide
 
-/-- Exocentric Merge — two saturated `N`s, neither selecting the other — determines
-    no head and hence no order: linearization is undefined off `Dom(h)`. -/
+/-- Exocentric Merge: two saturated `N`s, neither selecting the other — no head, no
+    order. -/
 private def demoExo : SyntacticObject :=
   ⟨Nonplanar.mk (.node (Sum.inr ())
     [.node (Sum.inl ⟨.simple .N [] (phonForm := "cats"), 0⟩) [],

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.Group.Hom.Defs
+import Linglib.Core.Data.List.Perm
+import Linglib.Syntax.Minimalist.SyntacticObject.Build
+
+/-!
+# The universal property of the syntactic-object carrier
+
+Leaf data valued in a commutative magma with zero extends to a morphism of magmas
+out of `SyntacticObject` (`lift`, the `FreeMagma.lift` analogue), and two such
+morphisms agreeing on the leaves are equal (`hom_ext`). The zero absorbs the
+off-carrier arities, so one total algebra (`mergeAlgebra`) drives the fold, the
+quotient descent, and the subtype restriction once and for all: consumers supply a
+lexical-leaf value and a trace value, and inherit `Perm`-invariance from
+`mul_comm` via `List.Perm.congr_arity₂` — no bespoke step induction.
+
+## Main declarations
+
+* `Minimalist.SyntacticObject.mergeAlgebra`: the node algebra induced by a
+  magma-with-zero — lexical leaf ↦ `ℓ`, trace leaf ↦ `τ`, bare binary node ↦ `*`,
+  other arities ↦ `0`.
+* `Minimalist.SyntacticObject.liftN`: its evaluation on the nonplanar carrier.
+* `Minimalist.SyntacticObject.liftFun`, `Minimalist.SyntacticObject.lift`: the
+  induced map on syntactic objects, unbundled (computable) and as `→ₙ*`.
+
+## Main results
+
+* `Minimalist.SyntacticObject.hom_ext`: morphisms of magmas out of
+  `SyntacticObject` agreeing on lexical and trace leaves are equal.
+* `Minimalist.SyntacticObject.liftN_node`: the nonplanar magma law.
+-/
+
+namespace Minimalist.SyntacticObject
+
+open RootedTree
+
+variable {β : Type*}
+
+/-- The node algebra of a magma-with-zero: lexical leaf ↦ `ℓ`, trace leaf ↦ `τ`,
+    bare binary node ↦ `*`, off-carrier arities ↦ `0`. -/
+def mergeAlgebra [Mul β] [Zero β] (ℓ : LIToken → β) (τ : β) : SOLabel → List β → β
+  | .inl tok, _     => ℓ tok
+  | .inr (), []     => τ
+  | .inr (), [x, y] => x * y
+  | .inr (), _      => 0
+
+/-- A daughter list of three or more is off the carrier. -/
+private theorem mergeAlgebra_big [Mul β] [Zero β] {ℓ : LIToken → β} {τ : β} {l : List β}
+    (h : 2 < l.length) : mergeAlgebra ℓ τ (Sum.inr ()) l = 0 := by
+  match l with
+  | _ :: _ :: _ :: _ => rfl
+  | [] | [_] | [_, _] => simp at h
+
+/-- `mergeAlgebra` is invariant under permutation of the daughter values: only the
+    binary shape is order-sensitive, and there `mul_comm` applies. -/
+theorem mergeAlgebra_perm [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) (a : SOLabel)
+    {l₁ l₂ : List β} (h : l₁.Perm l₂) : mergeAlgebra ℓ τ a l₁ = mergeAlgebra ℓ τ a l₂ := by
+  cases a with
+  | inl tok => rfl
+  | inr u =>
+    cases u
+    exact h.congr_arity₂ (fun x y => _root_.mul_comm x y) fun _ h => mergeAlgebra_big h
+
+/-- The induced algebra on the nonplanar carrier: the catamorphism descends by
+    `mergeAlgebra_perm`. -/
+def liftN [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) : Nonplanar SOLabel → β :=
+  Nonplanar.lift (RoseTree.fold (mergeAlgebra ℓ τ))
+    fun _ _ h => RoseTree.fold_perm (fun a _ _ h' => mergeAlgebra_perm ℓ τ a h') h
+
+@[simp] theorem liftN_mk [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (p : RoseTree SOLabel) :
+    liftN ℓ τ (Nonplanar.mk p) = RoseTree.fold (mergeAlgebra ℓ τ) p := rfl
+
+/-- The nonplanar magma law: Merge multiplies values. -/
+theorem liftN_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (a b : Nonplanar SOLabel) :
+    liftN ℓ τ (Nonplanar.node (Sum.inr ()) {a, b}) = liftN ℓ τ a * liftN ℓ τ b := by
+  refine Nonplanar.inductionOn₂ a b fun pa pb => ?_
+  rw [Nonplanar.node_pair_mk]
+  exact rfl
+
+/-- The induced map on syntactic objects, unbundled — computable, `decide`-friendly. -/
+def liftFun [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) (s : SyntacticObject) : β :=
+  liftN ℓ τ s.val
+
+@[simp] theorem liftFun_lexLeaf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (tok : LIToken) : liftFun ℓ τ (lexLeaf tok) = ℓ tok := rfl
+
+@[simp] theorem liftFun_traceLeaf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) :
+    liftFun ℓ τ traceLeaf = τ := rfl
+
+@[simp] theorem liftFun_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (l r : SyntacticObject) :
+    liftFun ℓ τ (node l r) = liftFun ℓ τ l * liftFun ℓ τ r := by
+  show liftN ℓ τ (node l r).val = liftN ℓ τ l.val * liftN ℓ τ r.val
+  rw [node_val, liftN_node]
+
+/-- The universal property, existence half (cf. `FreeMagma.lift`): leaf data
+    extends to a morphism of magmas out of the carrier. -/
+noncomputable def lift [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) :
+    SyntacticObject →ₙ* β where
+  toFun := liftFun ℓ τ
+  map_mul' := liftFun_node ℓ τ
+
+@[simp] theorem lift_apply [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (s : SyntacticObject) : lift ℓ τ s = liftFun ℓ τ s := rfl
+
+/-- The universal property, uniqueness half: morphisms agreeing on the leaves are
+    equal. -/
+theorem hom_ext [Mul β] {f g : SyntacticObject →ₙ* β}
+    (hlex : ∀ tok, f (lexLeaf tok) = g (lexLeaf tok))
+    (htrace : f traceLeaf = g traceLeaf) : f = g :=
+  MulHom.ext fun s => by
+    induction s using SyntacticObject.ind with
+    | lex tok => exact hlex tok
+    | trace => exact htrace
+    | node l r ihl ihr =>
+      rw [show node l r = l * r from rfl, map_mul, map_mul, ihl, ihr]
+
+end Minimalist.SyntacticObject

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Algebra.Group.Hom.Defs
-import Linglib.Syntax.Minimalist.SyntacticObject.Build
+import Mathlib.Algebra.GroupWithZero.Defs
+import Linglib.Syntax.Minimalist.SyntacticObject.Lift
 
 /-!
 # Selection-driven heads on the `SyntacticObject` carrier
@@ -14,172 +14,158 @@ head selects the saturated other projects — [adger-2003]'s identification of t
 projecting item with the selecting item, instantiating the bare-phrase-structure
 projection ([chomsky-1995-bare] §4) that [marcolli-chomsky-berwick-2025] §1.13.3
 abstracts as head functions (Definition 1.13.6 / Lemma 1.13.7). Like the book's
-head functions it is partial: `none` at exocentric nodes.
+head functions it is partial: `0` at exocentric nodes.
 
 ## Main declarations
 
-* `Minimalist.SelState`: a constituent's selection state — the projecting head
-  together with its residual selectional stack.
-* `Mul SelState` and `Minimalist.selSide`: the carrier-free combinators — the
-  selection product, and which daughter projects.
-* `Minimalist.selNode`, `Minimalist.selCheckPlanar`, `Minimalist.SyntacticObject.selCheck`:
-  the selection algebra, its catamorphism, and the `SyntacticObject` lift.
-* `Minimalist.SyntacticObject.selHead`, `Minimalist.SyntacticObject.outerCatC`: the head token and
-its outer
-  category — the foundation the Phase API consumes (`isPhaseHeadOf`).
-* `Minimalist.selCheckHom`: `selCheck` as a morphism of magmas `SyntacticObject →ₙ* SelState` —
-  the book's algebraic frame, with `SelState` a `CommMagma`.
+* `Minimalist.SelectionState`: a constituent's selection state — the projecting
+  head with its residual selectional stack; a `CommMagma` and `MulZeroClass`, with
+  `0` the off-`Dom(h)` failure.
+* `Mul SelectionState` and `Minimalist.selSide`: the carrier-free combinators —
+  the selection product, and which daughter projects.
+* `Minimalist.selNode`, `Minimalist.selCheckPlanar`,
+  `Minimalist.SyntacticObject.selCheck`: the selection algebra
+  (`SyntacticObject.mergeAlgebra`), its catamorphism, and the carrier lift.
+* `Minimalist.SyntacticObject.selHead`, `Minimalist.SyntacticObject.outerCatC`:
+  the head token and its outer category — the foundation the Phase API consumes
+  (`isPhaseHeadOf`).
+* `Minimalist.selCheckHom`: `selCheck` as a morphism of magmas
+  `SyntacticObject →ₙ* SelectionState`, via `SyntacticObject.lift`.
 
 ## Main results
 
-* `mul_comm` (via `CommMagma SelState`) and `Minimalist.selSide_comm`:
+* `mul_comm` (via `CommMagma SelectionState`) and `Minimalist.selSide_comm`:
   order-independence — the formal content of Merge's unordered output.
-* `Minimalist.SyntacticObject.selHead_node`: endocentricity — a node's head is one of its
-  daughters' heads.
+* `Minimalist.SyntacticObject.selHead_node`: endocentricity — a node's head is one
+  of its daughters' heads.
 
 ## Implementation notes
 
-The tree recursion is the catamorphism `RoseTree.fold selNode`; the algebra is
-permutation-invariant (`selNode_perm`), so invariance and the quotient lift come
-from `fold_perm` — no bespoke step induction. **Index-free traces**: a bare trace
-leaf gets the canonical saturated value `(mkTraceToken 0, [])`; `selCheck` reads
-only the token's category and `outerSel`, both index-independent.
+`SelectionState` is a one-field structure over `Option (LIToken × List Cat)`: the
+`Option` is implementation, `0` is the public spelling of the exocentric failure —
+the absorbing element of [marcolli-chomsky-berwick-2025]'s renormalization reading
+of partial head functions (off-domain values as the "meaningless infinities" of
+computation, their §1.13.2 remark). No `One` (two saturated states multiply to
+`0` — exocentricity is a zero divisor) and no associativity claim, so the
+structure is `CommMagma` + `MulZeroClass` only. **Index-free traces**: a bare
+trace leaf gets the canonical saturated value `.of (mkTraceToken 0) []`;
+`selCheck` reads only the token's category and `outerSel`, both index-independent.
 -/
 
 namespace Minimalist
 
 open RootedTree
 
+/-! ### The selection state -/
+
+/-- A constituent's selection state: the projecting head with its residual stack
+    (`.of tok []` = saturated), `0` off the endocentric domain. -/
+structure SelectionState : Type where
+  toOption : Option (LIToken × List Cat)
+deriving DecidableEq
+
+/-- A defined selection state: projecting head `tok` with residual stack `stack`. -/
+def SelectionState.of (tok : LIToken) (stack : List Cat) : SelectionState :=
+  ⟨some (tok, stack)⟩
+
+instance : Zero SelectionState := ⟨⟨none⟩⟩
+
+/-- The projecting head token; `none` off the endocentric domain. -/
+def SelectionState.head (x : SelectionState) : Option LIToken := x.toOption.map (·.1)
+
+/-- The residual selectional stack (`some []` = saturated). -/
+def SelectionState.residual (x : SelectionState) : Option (List Cat) := x.toOption.map (·.2)
+
+@[simp] theorem SelectionState.head_of (tok : LIToken) (stack : List Cat) :
+    (SelectionState.of tok stack).head = some tok := rfl
+
+@[simp] theorem SelectionState.head_zero : (0 : SelectionState).head = none := rfl
+
 /-! ### Carrier-free selection combinators -/
 
-/-- The selection state of a constituent: the projecting head token together with
-    its residual selectional stack (`some []` = saturated), or `none` off the
-    endocentric domain. -/
-abbrev SelState := Option (LIToken × List Cat)
-
-variable (x y : SelState)
+variable (x y : SelectionState)
 
 /-- The selection decision at a binary node — (which sister projects, head,
     residual), `none` at exocentric nodes; `*` and `selSide` are its projections. -/
-def selCombine : SelState → SelState → Option (Bool × LIToken × List Cat)
-  | some (ha, c :: rest), some (hb, []) =>
+def selCombine : SelectionState → SelectionState → Option (Bool × LIToken × List Cat)
+  | ⟨some (ha, c :: rest)⟩, ⟨some (hb, [])⟩ =>
       if hb.item.outerCat = c then some (true, ha, rest) else none
-  | some (ha, []), some (hb, c :: rest) =>
+  | ⟨some (ha, [])⟩, ⟨some (hb, c :: rest)⟩ =>
       if ha.item.outerCat = c then some (false, hb, rest) else none
   | _, _ => none
 
 /-- Which daughter projects: `some true` = left, `some false` = right. -/
-def selSide (x y : SelState) : Option Bool := (selCombine x y).map (·.1)
+def selSide (x y : SelectionState) : Option Bool := (selCombine x y).map (·.1)
 
 /-- Swapping the sisters flips the side and keeps the head and residual. -/
 theorem selCombine_comm : selCombine x y = (selCombine y x).map fun p => (!p.1, p.2) := by
-  rcases x with _ | ⟨hx, _ | ⟨cx, sx⟩⟩ <;> rcases y with _ | ⟨hy, _ | ⟨cy, sy⟩⟩ <;>
+  rcases x with ⟨_ | ⟨hx, _ | ⟨cx, sx⟩⟩⟩ <;> rcases y with ⟨_ | ⟨hy, _ | ⟨cy, sy⟩⟩⟩ <;>
     first
     | rfl
     | (simp only [selCombine, Option.map]; split <;> rfl)
 
-/-- S₂-equivariance: swap acts on the sisters, `Bool.not` on the side — the
-    coordinate form of MCB's per-vertex edge-marking (Lemma 1.13.4); the invariant
-    part of the decision is the product (hence `mul_comm`). -/
+/-- S₂-equivariance: swap acts on the sisters, `Bool.not` on the side — MCB's
+    per-vertex edge-marking (Lemma 1.13.4). -/
 theorem selSide_comm : selSide x y = (selSide y x).map Bool.not := by
   simp only [selSide, selCombine_comm x y, Option.map_map]; rfl
 
-/-- Multiplication of selection states — the head-and-residual of the `selCombine`
-    decision, [marcolli-chomsky-berwick-2025] §1.13's Merge-local head choice. -/
-instance : Mul SelState := ⟨fun x y => (selCombine x y).map (·.2)⟩
+/-- The selection product: the head-and-residual of the `selCombine` decision
+    ([marcolli-chomsky-berwick-2025] §1.13); `0` is absorbing. -/
+instance : MulZeroClass SelectionState where
+  mul x y := ⟨(selCombine x y).map (·.2)⟩
+  zero := ⟨none⟩
+  zero_mul _ := rfl
+  mul_zero x := by rcases x with ⟨_ | ⟨h, _ | ⟨c, s⟩⟩⟩ <;> rfl
 
 /-- `*` unfolded: the canonical accessor for the selection product. -/
-theorem SelState.mul_def : x * y = (selCombine x y).map (·.2) := rfl
+theorem SelectionState.mul_def : x * y = ⟨(selCombine x y).map (·.2)⟩ := rfl
 
-/-- `none` (the exocentric failure) is absorbing on the left. -/
-@[simp] theorem SelState.none_mul : (none : SelState) * x = none := rfl
-
-/-- `none` (the exocentric failure) is absorbing on the right. -/
-@[simp] theorem SelState.mul_none : x * none = none := by
-  rcases x with _ | ⟨h, _ | ⟨c, s⟩⟩ <;> rfl
-
-instance : CommMagma SelState where
+instance : CommMagma SelectionState where
   mul_comm x y := by
-    simp only [SelState.mul_def, selCombine_comm x y, Option.map_map]; rfl
+    simp only [SelectionState.mul_def, selCombine_comm x y, Option.map_map]; rfl
+
+/-- Exocentricity is a zero divisor: two saturated nonzero states multiply to `0`. -/
+example : ∃ x y : SelectionState, x ≠ 0 ∧ y ≠ 0 ∧ x * y = 0 :=
+  ⟨.of (mkTraceToken 0) [], .of (mkTraceToken 0) [], by decide⟩
 
 variable {x y}
 
-/-- The selection decision is coherent: the projected head is the head of the
-    sister on the side it reports — the coherence of the two projections. The single
-    raw analysis; `SelState.mul_fst` is a corollary. -/
+/-- Coherence: the projected head is the head of the sister on the reported side. -/
 theorem selCombine_eq_some {b : Bool} {hd : LIToken} {res : List Cat}
     (h : selCombine x y = some (b, hd, res)) :
-    (bif b then x else y).map (·.1) = some hd := by
+    (bif b then x else y).head = some hd := by
   match x, y with
-  | some (ha, c :: rest'), some (hb, [])
-  | some (ha, []), some (hb, c :: rest') =>
+  | ⟨some (ha, c :: rest')⟩, ⟨some (hb, [])⟩
+  | ⟨some (ha, [])⟩, ⟨some (hb, c :: rest')⟩ =>
     simp only [selCombine] at h
     split_ifs at h; cases h; rfl
-  | some (_, []), some (_, []) | some (_, _ :: _), some (_, _ :: _)
-  | none, _ | some _, none => simp [selCombine] at h
+  | ⟨some (_, [])⟩, ⟨some (_, [])⟩ | ⟨some (_, _ :: _)⟩, ⟨some (_, _ :: _)⟩
+  | ⟨none⟩, _ | ⟨some _⟩, ⟨none⟩ => simp [selCombine] at h
 
 /-- The head of `x * y` (when defined) is one of `x`/`y`'s heads. -/
-theorem SelState.mul_fst {r : LIToken}
-    (h : (x * y).map (·.1) = some r) :
-    x.map (·.1) = some r ∨ y.map (·.1) = some r := by
-  simp only [SelState.mul_def, Option.map_map, Option.map_eq_some_iff] at h
+theorem SelectionState.head_mul {r : LIToken}
+    (h : (x * y).head = some r) : x.head = some r ∨ y.head = some r := by
+  simp only [SelectionState.mul_def, SelectionState.head, Option.map_map,
+    Option.map_eq_some_iff] at h
   obtain ⟨⟨b, _, _⟩, hproj, rfl⟩ := h
   cases b
   exacts [Or.inr (selCombine_eq_some hproj), Or.inl (selCombine_eq_some hproj)]
 
-/-! ### Selection check on the planar carrier -/
+/-! ### Selection check on the carriers -/
 
-/-- The selection algebra: combine a node label with its daughters' selection
-    states. Lexical leaf ↦ its token + `outerSel`; bare trace leaf ↦ canonical
-    `(mkTraceToken 0, [])` (index-free); bare binary node ↦ the product of the
-    daughters (the `SelState` magma multiplication); other arities ↦ `none`. -/
-def selNode : SOLabel → List SelState → SelState
-  | .inl tok, _     => some (tok, tok.item.outerSel)
-  | .inr (), []     => some (mkTraceToken 0, [])
-  | .inr (), [x, y] => x * y
-  | .inr (), _      => none
+/-- The selection algebra: the `SyntacticObject.mergeAlgebra` of token + `outerSel`
+    leaves and the saturated, index-free trace. -/
+def selNode : SOLabel → List SelectionState → SelectionState :=
+  SyntacticObject.mergeAlgebra (fun tok => .of tok tok.item.outerSel)
+    (.of (mkTraceToken 0) [])
 
-/-- A daughter list of three or more has no selection value. -/
-private theorem selNode_big {l : List SelState} (h : 2 < l.length) :
-    selNode (Sum.inr ()) l = none := by
-  match l with
-  | _ :: _ :: _ :: _ => rfl
-  | [] | [_] | [_, _] => simp at h
+/-- `selNode` is invariant under permutation of the daughter states. -/
+theorem selNode_perm (a : SOLabel) {l₁ l₂ : List SelectionState} (h : l₁.Perm l₂) :
+    selNode a l₁ = selNode a l₂ :=
+  SyntacticObject.mergeAlgebra_perm _ _ a h
 
-/-- A list function symmetric on pairs and constant above length two is
-    `Perm`-invariant: lengths ≤ 1 are rigid under permutation, pairs by the
-    symmetry, longer lists by the constancy. -/
-theorem _root_.List.Perm.congr_arity₂ {β γ : Type*} {g : List β → γ} {c : γ}
-    (hswap : ∀ x y, g [x, y] = g [y, x])
-    (hbig : ∀ l : List β, 2 < l.length → g l = c)
-    {l₁ l₂ : List β} (h : l₁.Perm l₂) : g l₁ = g l₂ := by
-  induction h with
-  | nil => rfl
-  | @cons x l₁ l₂ h _ih =>
-    match l₁, l₂, h with
-    | [], l₂, h => rw [show l₂ = [] from h.symm.eq_nil]
-    | [y], l₂, h => rw [show l₂ = [y] from List.perm_singleton.mp h.symm]
-    | _ :: _ :: _, l₂, h =>
-      have hl := h.length_eq
-      rw [hbig _ (by simp +arith), hbig _ (by simp only [List.length_cons] at hl ⊢; omega)]
-  | swap x y l =>
-    match l with
-    | [] => exact hswap y x
-    | _ :: _ => rw [hbig _ (by simp +arith), hbig _ (by simp +arith)]
-  | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
-
-/-- `selNode` is invariant under permutation of the daughter states: only the
-    binary shape is order-sensitive, and there `mul_comm` applies. -/
-theorem selNode_perm (a : SOLabel) {l₁ l₂ : List SelState} (h : l₁.Perm l₂) :
-    selNode a l₁ = selNode a l₂ := by
-  cases a with
-  | inl tok => rfl
-  | inr u => cases u; exact h.congr_arity₂ (fun x y => mul_comm x y) (fun _ h => selNode_big h)
-
-/-- Selection check on a planar `SyntacticObject`-tree: the projecting head + residual pending
-    features, or `none` outside the endocentric domain — the catamorphism of
-    `selNode`. -/
-def selCheckPlanar : RoseTree SOLabel → SelState :=
+/-- Selection check on a planar tree: the catamorphism of `selNode`. -/
+def selCheckPlanar : RoseTree SOLabel → SelectionState :=
   RoseTree.fold selNode
 
 /-- Reduction of `selCheckPlanar` at a node: fold the algebra over the daughters. -/
@@ -192,58 +178,51 @@ theorem selCheckPlanar_perm {t s : RoseTree SOLabel} (h : RoseTree.Perm t s) :
     selCheckPlanar t = selCheckPlanar s :=
   RoseTree.fold_perm (fun a _ _ h' => selNode_perm a h') h
 
-/-- Selection check lifted to the nonplanar carrier. -/
-def selCheckN : Nonplanar SOLabel → SelState :=
-  Nonplanar.lift selCheckPlanar (fun _ _ h => selCheckPlanar_perm h)
+/-- Selection check on the nonplanar carrier. -/
+def selCheckN : Nonplanar SOLabel → SelectionState :=
+  SyntacticObject.liftN (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
 
 @[simp] theorem selCheckN_mk (p : RoseTree SOLabel) :
     selCheckN (Nonplanar.mk p) = selCheckPlanar p := rfl
 
 theorem selCheckN_node (a b : Nonplanar SOLabel) :
-    selCheckN (Nonplanar.node (Sum.inr ()) {a, b}) = selCheckN a * selCheckN b := by
-  refine Quotient.inductionOn₂ a b fun pa pb => ?_
-  show selCheckN (Nonplanar.node (Sum.inr ()) {Nonplanar.mk pa, Nonplanar.mk pb})
-      = selCheckN (Nonplanar.mk pa) * selCheckN (Nonplanar.mk pb)
-  rw [Nonplanar.node_pair_mk]; exact rfl
+    selCheckN (Nonplanar.node (Sum.inr ()) {a, b}) = selCheckN a * selCheckN b :=
+  SyntacticObject.liftN_node _ _ a b
 
 /-! ### The selection-driven head on `SyntacticObject` -/
 
 variable (s : SyntacticObject) (tok : LIToken)
 
-/-- **Selection-driven head check** on `SyntacticObject`: the projecting head + residual
-    features, or `none` off the endocentric domain. Section-free and computable;
-    the selection instance of [marcolli-chomsky-berwick-2025]'s head functions. -/
-def SyntacticObject.selCheck : SelState := selCheckN s.val
+/-- **Selection-driven head check**: the selection instance of
+    [marcolli-chomsky-berwick-2025]'s head functions; computable. -/
+def SyntacticObject.selCheck : SelectionState := selCheckN s.val
 
 /-- The projecting head's lexical item, by c-selection. -/
-def SyntacticObject.selHead : Option LIToken := s.selCheck.map (·.1)
+def SyntacticObject.selHead : Option LIToken := s.selCheck.head
 
 /-- Residual pending selectional features (`some []` = saturated). -/
-def SyntacticObject.checkedSel : Option (List Cat) := s.selCheck.map (·.2)
+def SyntacticObject.checkedSel : Option (List Cat) := s.selCheck.residual
 
 /-- The projecting head's **outer category** (the phase-head selector); `none` at
     exocentric nodes. -/
 def SyntacticObject.outerCatC : Option Cat := s.selHead.map (·.item.outerCat)
 
 @[simp] theorem SyntacticObject.selCheck_lexLeaf :
-    (SyntacticObject.lexLeaf tok).selCheck = some (tok, tok.item.outerSel) := rfl
+    (SyntacticObject.lexLeaf tok).selCheck = .of tok tok.item.outerSel := rfl
 
 @[simp] theorem SyntacticObject.selCheck_traceLeaf :
-    SyntacticObject.traceLeaf.selCheck = some (mkTraceToken 0, []) := rfl
+    SyntacticObject.traceLeaf.selCheck = .of (mkTraceToken 0) [] := rfl
 
 @[simp] theorem SyntacticObject.selCheck_node (l r : SyntacticObject) :
-    (SyntacticObject.node l r).selCheck = l.selCheck * r.selCheck := by
-  show selCheckN (SyntacticObject.node l r).val = selCheckN l.val * selCheckN r.val
-  rw [SyntacticObject.node_val, selCheckN_node]
+    (SyntacticObject.node l r).selCheck = l.selCheck * r.selCheck :=
+  SyntacticObject.liftFun_node _ _ l r
 
-/-- `selCheck` as a **morphism of magmas** — [marcolli-chomsky-berwick-2025] §1.13's
-    algebraic frame for head functions: Merge multiplies constituents, `selCheck`
-    multiplies their selection states. Contrast the externalization *readout*, which
-    is not a morphism — placing a yield needs the head
-    (`Linearization/Externalization.lean`). -/
-noncomputable def selCheckHom : SyntacticObject →ₙ* SelState where
-  toFun := SyntacticObject.selCheck
-  map_mul' := SyntacticObject.selCheck_node
+/-- `selCheck` as a morphism of magmas ([marcolli-chomsky-berwick-2025] §1.13's
+    algebraic frame): the `SyntacticObject.lift` of the leaf data. -/
+noncomputable def selCheckHom : SyntacticObject →ₙ* SelectionState :=
+  SyntacticObject.lift (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
+
+@[simp] theorem selCheckHom_apply : selCheckHom s = s.selCheck := rfl
 
 @[simp] theorem SyntacticObject.selHead_lexLeaf :
     (SyntacticObject.lexLeaf tok).selHead = some tok := rfl
@@ -252,10 +231,10 @@ noncomputable def selCheckHom : SyntacticObject →ₙ* SelState where
     bare-phrase-structure projection ([chomsky-1995-bare] §4, abstracted as
     [marcolli-chomsky-berwick-2025] Definition 1.13.6 / Lemma 1.13.7). -/
 theorem SyntacticObject.selHead_node {l r : SyntacticObject} {h : LIToken}
-    (hlr : (SyntacticObject.node l r).selHead = some h) : l.selHead = some h ∨ r.selHead = some h :=
-      by
+    (hlr : (SyntacticObject.node l r).selHead = some h) :
+    l.selHead = some h ∨ r.selHead = some h := by
   simp only [SyntacticObject.selHead, SyntacticObject.selCheck_node] at hlr ⊢
-  exact SelState.mul_fst hlr
+  exact SelectionState.head_mul hlr
 
 @[simp] theorem SyntacticObject.outerCatC_lexLeaf :
     (SyntacticObject.lexLeaf tok).outerCatC = some tok.item.outerCat := rfl


### PR DESCRIPTION
The universal property of the carrier, and the state carriers as algebra objects.

- `SyntacticObject/Lift.lean`: `mergeAlgebra` (one total node algebra over any `CommMagma`+`Zero`), `liftN`/`liftFun`/`lift : SyntacticObject →ₙ* β` (existence, cf. `FreeMagma.lift`), `hom_ext` (uniqueness, via `SyntacticObject.ind`) — the per-file fold/Perm plumbing in Selection and Externalization collapses into instantiations, and fusion `sel_comp_headHom` is `hom_ext (fun _ => rfl) rfl`
- `SelectionState` (renamed from `SelState`) and `LinearizationState` become one-field structures with `CommMagma` + `MulZeroClass`: instances are statable (the def-synonym made `*` unstatable and leaked metavariables), `0` is the exocentric failure (MCB's renormalization reading; exocentricity-as-zero-divisor witnessed), `head`/`residual`/`yield` accessors replace raw `Option` maps
- substrate: `Nonplanar.inductionOn`/`inductionOn₂` mk-form eliminators (kills the `show`+`node_pair_mk` dance); `List.Perm.congr_arity₂` hoisted to `Core/Data/List/Perm.lean`
- decl docstrings tightened to mathlib one-liners