### PR TITLE
style(Syntax/Minimalist): SyntacticObject namespace de-qualification

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2492,6 +2492,7 @@ import Linglib.Studies.Mandelkern2019
 import Linglib.Studies.Mandelkern2022
 import Linglib.Studies.Marantz1991
 import Linglib.Studies.MarcoRasin2026
+import Linglib.Studies.MarcolliChomskyBerwick2025
 import Linglib.Studies.MartinRoseNichols2025
 import Linglib.Studies.MartinSchaeferKastner2025
 import Linglib.Studies.MartinezVera2026

--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -851,7 +851,7 @@ theorem tseltalan_case_locus :
 
 section AttractClosest
 
-open Minimalist
+open Minimalist SyntacticObject
 open RootedTree
 
 /-! ### Attract Closest on Concrete Trees
@@ -905,13 +905,13 @@ private def tPsm : LIToken := ⟨.simple .N [], 5⟩   -- Possessum (not D-beari
 private def tD₀  : LIToken := ⟨.simple .D [], 6⟩   -- D° head of specific nominal
 private def tAgt : LIToken := ⟨.simple .D [], 7⟩   -- Agent DP (D-bearing)
 
-private def T₀  : SyntacticObject := SyntacticObject.lexLeaf tT₀
-private def V₀  : SyntacticObject := SyntacticObject.lexLeaf tV₀
-private def v₀  : SyntacticObject := SyntacticObject.lexLeaf tv₀
-private def Psr : SyntacticObject := SyntacticObject.lexLeaf tPsr
-private def Psm : SyntacticObject := SyntacticObject.lexLeaf tPsm
-private def D₀  : SyntacticObject := SyntacticObject.lexLeaf tD₀
-private def Agt : SyntacticObject := SyntacticObject.lexLeaf tAgt
+private def T₀  : SyntacticObject := lexLeaf tT₀
+private def V₀  : SyntacticObject := lexLeaf tV₀
+private def v₀  : SyntacticObject := lexLeaf tv₀
+private def Psr : SyntacticObject := lexLeaf tPsr
+private def Psm : SyntacticObject := lexLeaf tPsm
+private def D₀  : SyntacticObject := lexLeaf tD₀
+private def Agt : SyntacticObject := lexLeaf tAgt
 
 /-! ### Clause Trees ([aissen-polian-2025] (9a-c))
 
@@ -924,37 +924,34 @@ private def Agt : SyntacticObject := SyntacticObject.lexLeaf tAgt
 Object is PossP (non-specific) or DP (specific). -/
 
 -- Non-specific possessive object: [PossP Psr Psm]
-private def possPp : RoseTree SOLabel :=
-  SyntacticObject.nodeP (SyntacticObject.leafP tPsr) (SyntacticObject.leafP tPsm)
+private def possPp : RoseTree SOLabel := nodeP (leafP tPsr) (leafP tPsm)
 
 -- Specific possessive object: [DP D° [PossP Psr Psm]]
-private def dpObjp : RoseTree SOLabel := SyntacticObject.nodeP (SyntacticObject.leafP tD₀) possPp
+private def dpObjp : RoseTree SOLabel := nodeP (leafP tD₀) possPp
 
 -- (9a) Unaccusative + non-specific: [TP T° [VP V° [PossP Psr Psm]]]
 private def treeUnaccPossP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) possPp))
+  ofPlanar (nodeP (leafP tT₀) (nodeP (leafP tV₀) possPp))
 
 -- (9a') Unaccusative + specific: [TP T° [VP V° [DP D° [PossP Psr Psm]]]]
 private def treeUnaccDP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) dpObjp))
+  ofPlanar (nodeP (leafP tT₀) (nodeP (leafP tV₀) dpObjp))
 
 -- (9b) Transitive + non-specific:
 -- [TP T° [vP Agt [v' v° [VP V° [PossP Psr Psm]]]]]
 private def treeTransPossP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tAgt)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tv₀)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) possPp))))
+  ofPlanar (nodeP (leafP tT₀)
+    (nodeP (leafP tAgt)
+      (nodeP (leafP tv₀)
+        (nodeP (leafP tV₀) possPp))))
 
 -- (9b') Transitive + specific:
 -- [TP T° [vP Agt [v' v° [VP V° [DP D° [PossP Psr Psm]]]]]]
 private def treeTransDP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tAgt)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tv₀)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) dpObjp))))
+  ofPlanar (nodeP (leafP tT₀)
+    (nodeP (leafP tAgt)
+      (nodeP (leafP tv₀)
+        (nodeP (leafP tV₀) dpObjp))))
 
 /-! ### Core Predictions
 
@@ -1045,25 +1042,23 @@ are now derived from tree geometry:
 -/
 
 private def tC₀ : LIToken := ⟨.simple .C [], 8⟩
-private def C₀ : SyntacticObject := SyntacticObject.lexLeaf tC₀
+private def C₀ : SyntacticObject := lexLeaf tC₀
 
 -- Planar bodies of the unaccusative trees, reused under the CP node.
 private def treeUnaccDPp : RoseTree SOLabel :=
-  SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) dpObjp)
+  nodeP (leafP tT₀) (nodeP (leafP tV₀) dpObjp)
 private def treeUnaccPossPp : RoseTree SOLabel :=
-  SyntacticObject.nodeP (SyntacticObject.leafP tT₀)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tV₀) possPp)
+  nodeP (leafP tT₀) (nodeP (leafP tV₀) possPp)
 
 -- CP wrapping unaccusative + DP:
 -- [CP C° [TP T° [VP V° [DP D° [PossP Psr Psm]]]]]
 private def treeCPUnaccDP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tC₀) treeUnaccDPp)
+  ofPlanar (nodeP (leafP tC₀) treeUnaccDPp)
 
 -- CP wrapping unaccusative + PossP:
 -- [CP C° [TP T° [VP V° [PossP Psr Psm]]]]
 private def treeCPUnaccPossP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tC₀) treeUnaccPossPp)
+  ofPlanar (nodeP (leafP tC₀) treeUnaccPossPp)
 
 /-! ### Core Predictions -/
 

--- a/Linglib/Studies/Amato2025.lean
+++ b/Linglib/Studies/Amato2025.lean
@@ -53,7 +53,7 @@ is future work.
 
 namespace Amato2025
 
-open Minimalist
+open Minimalist SyntacticObject
 open Amato2025.NestedAgree
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -120,10 +120,10 @@ theorem bulgarianMultiWh_is_nested :
     IsNestedAgreeConfig bulgarianMultiWh := by decide
 
 theorem bulgarianMultiWh_runStack_0 :
-    runStack bulgarianMultiWh 0 = some (SyntacticObject.lexLeaf aWhObj) := by decide
+    runStack bulgarianMultiWh 0 = some (lexLeaf aWhObj) := by decide
 
 theorem bulgarianMultiWh_runStack_1 :
-    runStack bulgarianMultiWh 1 = some (SyntacticObject.lexLeaf aWhObj) := by decide
+    runStack bulgarianMultiWh 1 = some (lexLeaf aWhObj) := by decide
 
 /-- **Apparent wh-subject intervention is not actual.** The
     wh-subject is in C's c-command (probe 0's full domain) but is
@@ -137,9 +137,9 @@ theorem bulgarianMultiWh_runStack_1 :
     structurally closer wh-phrase. wh-obj raises first; wh-sbj is
     raised in the (out-of-scope) restart phase. -/
 theorem bulgarianMultiWh_excludes_wh_subject :
-    SyntacticObject.lexLeaf aWhSbj ∈ bulgarianMultiWh.searchDomain 0 ∧
-    SyntacticObject.lexLeaf aWhSbj ∉ bulgarianMultiWh.searchDomain 1 :=
-  apparent_intervener_excluded bulgarianMultiWh 0 (SyntacticObject.lexLeaf aWhSbj)
+    lexLeaf aWhSbj ∈ bulgarianMultiWh.searchDomain 0 ∧
+    lexLeaf aWhSbj ∉ bulgarianMultiWh.searchDomain 1 :=
+  apparent_intervener_excluded bulgarianMultiWh 0 (lexLeaf aWhSbj)
     (by decide) (by decide)
 
 end Bulgarian

--- a/Linglib/Studies/Amato2025/NestedAgree.lean
+++ b/Linglib/Studies/Amato2025/NestedAgree.lean
@@ -75,7 +75,7 @@ that consumers select by phenomenon.
 
 namespace Amato2025.NestedAgree
 
-open Minimalist
+open Minimalist SyntacticObject
 
 -- ============================================================================
 -- § 1: Probe stack
@@ -119,7 +119,7 @@ def length (c : NestedAgreeConfig) : Nat := c.stack.length
     `List` flavor. -/
 def initialDomain (c : NestedAgreeConfig) : Multiset SyntacticObject :=
   c.root.subtrees.filter (fun y =>
-    decide (SyntacticObject.cCommandsIn c.root c.probingHead y) && c.validGoal y)
+    decide (cCommandsIn c.root c.probingHead y) && c.validGoal y)
 
 /-- The shared goal's daughters: the goal itself plus everything it
     c-commands, filtered by phi-activity. The reflexive inclusion of
@@ -127,7 +127,7 @@ def initialDomain (c : NestedAgreeConfig) : Multiset SyntacticObject :=
     probe must be able to find the goal again. -/
 def daughters (c : NestedAgreeConfig) : Multiset SyntacticObject :=
   c.root.subtrees.filter (fun y =>
-    (y == c.goalHead || decide (SyntacticObject.cCommandsIn c.root c.goalHead y)) &&
+    (y == c.goalHead || decide (cCommandsIn c.root c.goalHead y)) &&
       c.validGoal y)
 
 /-- Search domain at probe `i`: derived from the structural
@@ -313,9 +313,9 @@ tree, the 2-probe stack — is captured by `standardConfig`. -/
     Shared template across the landed Amato 2025 case studies. -/
 def standardLinearTree (probeHd intervener midNode terminal : LIToken) :
     SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP probeHd)
-    (SyntacticObject.nodeP (SyntacticObject.leafP intervener)
-      (SyntacticObject.nodeP (SyntacticObject.leafP midNode) (SyntacticObject.leafP terminal))))
+  ofPlanar (nodeP (leafP probeHd)
+    (nodeP (leafP intervener)
+      (nodeP (leafP midNode) (leafP terminal))))
 
 /-- A `NestedAgreeConfig` over the standard linear tree, with a
     2-probe stack on `probeHd`. The `goalHd` selects which leaf
@@ -326,8 +326,8 @@ def standardConfig (probeProfile : Probe.Profile)
     NestedAgreeConfig where
   stack := [probeProfile, probeProfile]
   root := standardLinearTree probeHd intervener midNode terminal
-  probingHead := SyntacticObject.lexLeaf probeHd
-  goalHead := SyntacticObject.lexLeaf goalHd
+  probingHead := lexLeaf probeHd
+  goalHead := lexLeaf goalHd
   validGoal := vg
 
 -- ============================================================================
@@ -362,19 +362,19 @@ theorem italianAuxExample_is_nested :
     IsNestedAgreeConfig italianAuxExample := by decide
 
 theorem italianAuxExample_runStack_0 :
-    runStack italianAuxExample 0 = some (SyntacticObject.lexLeaf aV) := by decide
+    runStack italianAuxExample 0 = some (lexLeaf aV) := by decide
 
 theorem italianAuxExample_runStack_1 :
-    runStack italianAuxExample 1 = some (SyntacticObject.lexLeaf aV) := by decide
+    runStack italianAuxExample 1 = some (lexLeaf aV) := by decide
 
 /-- DPsubj is in probe 0's c-command (Perf c-commands DPsubj) but
     not in probe 1's truncated domain (v doesn't c-command DPsubj).
     Real strict-truncation content from the Minimalist c-command
     primitive. -/
 theorem italianAuxExample_excludes_apparent_intervener :
-    SyntacticObject.lexLeaf aDPsubj ∈ italianAuxExample.searchDomain 0 ∧
-    SyntacticObject.lexLeaf aDPsubj ∉ italianAuxExample.searchDomain 1 :=
-  apparent_intervener_excluded italianAuxExample 0 (SyntacticObject.lexLeaf aDPsubj)
+    lexLeaf aDPsubj ∈ italianAuxExample.searchDomain 0 ∧
+    lexLeaf aDPsubj ∉ italianAuxExample.searchDomain 1 :=
+  apparent_intervener_excluded italianAuxExample 0 (lexLeaf aDPsubj)
     (by decide) (by decide)
 
 end Amato2025.NestedAgree

--- a/Linglib/Studies/Amato2025Agreement.lean
+++ b/Linglib/Studies/Amato2025Agreement.lean
@@ -46,7 +46,7 @@ analysis to Amato's feature-ordering analysis are future work.
 
 namespace Amato2025Agreement
 
-open Minimalist
+open Minimalist SyntacticObject
 open Amato2025.NestedAgree
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -109,10 +109,10 @@ def icelandicOrderingA : NestedAgreeConfig :=
 theorem orderingA_is_nested : IsNestedAgreeConfig icelandicOrderingA := by decide
 
 theorem orderingA_runStack_0 :
-    runStack icelandicOrderingA 0 = some (SyntacticObject.lexLeaf aDPnom) := by decide
+    runStack icelandicOrderingA 0 = some (lexLeaf aDPnom) := by decide
 
 theorem orderingA_runStack_1 :
-    runStack icelandicOrderingA 1 = some (SyntacticObject.lexLeaf aDPnom) := by decide
+    runStack icelandicOrderingA 1 = some (lexLeaf aDPnom) := by decide
 
 /-- **Apparent dative intervention is not actual.** The dative subject
     is in T's c-command (probe 0's domain) but is *not* in DPnom's
@@ -120,9 +120,9 @@ theorem orderingA_runStack_1 :
     above DPnom). DPdat is excluded from probe 1's truncated domain
     by Nested Agree. -/
 theorem orderingA_excludes_dative :
-    SyntacticObject.lexLeaf aDPdat ∈ icelandicOrderingA.searchDomain 0 ∧
-    SyntacticObject.lexLeaf aDPdat ∉ icelandicOrderingA.searchDomain 1 :=
-  apparent_intervener_excluded icelandicOrderingA 0 (SyntacticObject.lexLeaf aDPdat)
+    lexLeaf aDPdat ∈ icelandicOrderingA.searchDomain 0 ∧
+    lexLeaf aDPdat ∉ icelandicOrderingA.searchDomain 1 :=
+  apparent_intervener_excluded icelandicOrderingA 0 (lexLeaf aDPdat)
     (by decide) (by decide)
 
 /-! ### Configuration B — default agreement -/
@@ -132,7 +132,7 @@ theorem orderingA_excludes_dative :
     quirky/defective for finite T's valuation purposes. -/
 def icelandicOrderingB : NestedAgreeConfig :=
   standardConfig tProbe aT aDPdat aV aDPnom aDPdat
-    (fun y => decide (y ≠ SyntacticObject.lexLeaf aDPdat))
+    (fun y => decide (y ≠ lexLeaf aDPdat))
 
 /-- Ordering B is *not* well-formed: the chosen goal is φ-defective.
     The formal expression of "default agreement surfaces because
@@ -251,10 +251,10 @@ def lakPerfective : NestedAgreeConfig :=
 theorem lakPerfective_is_nested : IsNestedAgreeConfig lakPerfective := by decide
 
 theorem lakPerfective_runStack_0 :
-    runStack lakPerfective 0 = some (SyntacticObject.lexLeaf aV) := by decide
+    runStack lakPerfective 0 = some (lexLeaf aV) := by decide
 
 theorem lakPerfective_runStack_1 :
-    runStack lakPerfective 1 = some (SyntacticObject.lexLeaf aV) := by decide
+    runStack lakPerfective 1 = some (lexLeaf aV) := by decide
 
 /-- **Apparent ergative intervention is not actual.** The ergative
     subject is in Asp's c-command (probe 0's domain) but is *not* in
@@ -268,9 +268,9 @@ theorem lakPerfective_runStack_1 :
     presence. Surface result: agreement with Abs (transitively
     through v's prior cyclic Agree). -/
 theorem lakPerfective_excludes_ergative :
-    SyntacticObject.lexLeaf aErg ∈ lakPerfective.searchDomain 0 ∧
-    SyntacticObject.lexLeaf aErg ∉ lakPerfective.searchDomain 1 :=
-  apparent_intervener_excluded lakPerfective 0 (SyntacticObject.lexLeaf aErg)
+    lexLeaf aErg ∈ lakPerfective.searchDomain 0 ∧
+    lexLeaf aErg ∉ lakPerfective.searchDomain 1 :=
+  apparent_intervener_excluded lakPerfective 0 (lexLeaf aErg)
     (by decide) (by decide)
 
 end Lak

--- a/Linglib/Studies/Amato2025Auxiliary.lean
+++ b/Linglib/Studies/Amato2025Auxiliary.lean
@@ -65,7 +65,7 @@ namespace Amato2025Auxiliary
 
 open ArgumentStructure.AuxiliarySelection
 open Olivier2026Auxiliary
-open Minimalist
+open Minimalist SyntacticObject
 open Amato2025.NestedAgree
 
 /-! ## Probe stack (Nested Agree on Perf) -/
@@ -329,7 +329,7 @@ private def perfProbe : Probe.Profile := ⟨.T, some .C⟩
     φ-active iff `VIsPhiActive c`; all other heads are phi-active. -/
 def toNestedConfig (c : RestructuringClauseAmato) : NestedAgreeConfig :=
   standardConfig perfProbe aT aDPsubj aV aDPobj aV
-    (fun y => if y = SyntacticObject.lexLeaf aV then decide (VIsPhiActive c) else true)
+    (fun y => if y = lexLeaf aV then decide (VIsPhiActive c) else true)
 
 /-- Every Amato clause whose v is φ-active yields a well-formed Nested
     Agree configuration. The precondition is structurally meaningful
@@ -346,15 +346,15 @@ theorem amato_clause_is_nested (c : RestructuringClauseAmato)
   rw [Multiset.mem_filter]
   refine ⟨?_, ?_⟩
   · -- .leaf aV ∈ standardLinearTree _.subtrees: purely structural after unfold.
-    show SyntacticObject.lexLeaf aV ∈
+    show lexLeaf aV ∈
       (standardLinearTree aT aDPsubj aV aDPobj).subtrees
     decide
   · -- (decide (cCommandsIn _ perf v) && validGoal v) = true
     rw [Bool.and_eq_true]
     refine ⟨?_, ?_⟩
     · -- Perf c-commands v in the standardLinearTree: purely structural.
-      show decide (SyntacticObject.cCommandsIn (standardLinearTree aT aDPsubj aV aDPobj)
-        (SyntacticObject.lexLeaf aT) (SyntacticObject.lexLeaf aV)) = true
+      show decide (cCommandsIn (standardLinearTree aT aDPsubj aV aDPobj)
+        (lexLeaf aT) (lexLeaf aV)) = true
       decide
     · -- validGoal (.leaf aV) = decide (VIsPhiActive c) = true (from h).
       show (decide (VIsPhiActive c)) = true
@@ -379,7 +379,7 @@ theorem personAgree_iff_runStack_hits (c : RestructuringClauseAmato) :
       decide
     · -- goalHead ∈ searchDomain 1 = daughters; reflexively in its
       -- own daughters when phi-active.
-      show SyntacticObject.lexLeaf aV ∈ (toNestedConfig c).searchDomain 1
+      show lexLeaf aV ∈ (toNestedConfig c).searchDomain 1
       rw [searchDomain_succ]
       exact goalHead_mem_daughters _ (amato_clause_is_nested c h)
   · rintro ⟨_, hMem⟩

--- a/Linglib/Studies/Bruening2001.lean
+++ b/Linglib/Studies/Bruening2001.lean
@@ -68,7 +68,7 @@ This study uses it to connect DOC scope freezing to
 section Scope
 
 open ScopeTheory
-open Minimalist
+open Minimalist SyntacticObject
 
 -- Structural Positions
 
@@ -139,7 +139,7 @@ def qrIsBlocked (q : PositionedQuantifier) : Option QRBarrier :=
     tree derivation. -/
 def superiorityFromTree (tree : SyntacticObject)
     (q1 q2 : SyntacticObject) : Bool :=
-  decide (SyntacticObject.asymCCommandsIn tree q1 q2)
+  decide (asymCCommandsIn tree q1 q2)
 
 -- Scope Economy ([fox-2000])
 
@@ -177,9 +177,9 @@ def economyBlocksQR (e : ScopeEconomy) : Bool :=
     in that domain is impenetrable by construction (`SyntacticObject.mem_phaseInterior`). -/
 theorem dp_phase_barrier_from_pic (φ : Phase) {goal : SyntacticObject}
     (hacc : goal ∈ φ.tree.Acc)
-    (hcc : φ.tree.cCommandsIn (SyntacticObject.lexLeaf φ.head) goal) :
+    (hcc : φ.tree.cCommandsIn (lexLeaf φ.head) goal) :
     φ.Impenetrable goal :=
-  SyntacticObject.mem_phaseInterior.mpr ⟨hacc, hcc⟩
+  mem_phaseInterior.mpr ⟨hacc, hcc⟩
 
 end Scope
 
@@ -480,7 +480,7 @@ end ScopeFreezing
 section MinimalistAnalysis
 
 open ScopeTheory
-open Minimalist
+open Minimalist SyntacticObject
 
 /-! Connects Minimalist QR / Scope Economy theory to the empirical
 scope-freezing data above. The central claim is Bruening's "QR obeys
@@ -617,13 +617,12 @@ def DP_letter_t : Minimalist.LIToken := ⟨.simple .D [] "a letter", 408⟩
     Spec-ApplP asymmetrically c-commands the theme (a letter) in the
     complement of Appl — the [barss-lasnik-1986] asymmetry, structural. -/
 def ditransitiveTree : Minimalist.SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP DP_john_t)
-      (SyntacticObject.nodeP (SyntacticObject.leafP voice_ag_t)
-        (SyntacticObject.nodeP (SyntacticObject.leafP V_sent_t)
-          (SyntacticObject.nodeP (SyntacticObject.leafP DP_mary_t)
-            (SyntacticObject.nodeP (SyntacticObject.leafP appl_low_t)
-              (SyntacticObject.leafP DP_letter_t))))))
+  ofPlanar
+    (nodeP (leafP DP_john_t)
+      (nodeP (leafP voice_ag_t)
+        (nodeP (leafP V_sent_t)
+          (nodeP (leafP DP_mary_t)
+            (nodeP (leafP appl_low_t) (leafP DP_letter_t))))))
 
 /-- DOC scope freezing config with the local low-Appl tree:
     superiority is derived from goal asymmetrically c-commanding theme
@@ -631,10 +630,10 @@ def ditransitiveTree : Minimalist.SyntacticObject :=
 def docScopeConfig : MinimalistScopeConfig :=
   { q1 := { quantifier := "every worker"
            , position := .specVP
-           , so := some (SyntacticObject.lexLeaf DP_mary_t) }
+           , so := some (lexLeaf DP_mary_t) }
   , q2 := { quantifier := "a paycheck"
            , position := .specVP
-           , so := some (SyntacticObject.lexLeaf DP_letter_t) }
+           , so := some (lexLeaf DP_letter_t) }
   , freezingContext := .doubleObject
   , tree := some ditransitiveTree }
 

--- a/Linglib/Studies/Chomsky1981.lean
+++ b/Linglib/Studies/Chomsky1981.lean
@@ -40,7 +40,7 @@ tables.
 namespace Chomsky1981
 
 open Features.MinimalPairs
-open Minimalist
+open Minimalist SyntacticObject
 open Binding (SimpleClause Pos CommandRelation)
 
 private abbrev john := English.Nouns.john.toWordSg
@@ -85,26 +85,24 @@ private def wordTok (w : Word) (id : Nat) : LIToken :=
     `{subj, verb}`. C-command follows from the geometry. Built planar-first so
     the containment / c-command decision procedures reduce. -/
 def toSyntacticObject (clause : SimpleClause) : SyntacticObject :=
-  let subjP := SyntacticObject.leafP (wordTok clause.subject 0)
-  let verbP := SyntacticObject.leafP (wordTok clause.verb 1)
+  let subjP := leafP (wordTok clause.subject 0)
+  let verbP := leafP (wordTok clause.verb 1)
   match clause.object with
-  | none => SyntacticObject.ofPlanar (SyntacticObject.nodeP subjP verbP)
-  | some obj =>
-    SyntacticObject.ofPlanar (SyntacticObject.nodeP subjP
-      (SyntacticObject.nodeP verbP (SyntacticObject.leafP (wordTok obj 2))))
+  | none => ofPlanar (nodeP subjP verbP)
+  | some obj => ofPlanar (nodeP subjP (nodeP verbP (leafP (wordTok obj 2))))
 
 private def subjectSO (clause : SimpleClause) : SyntacticObject :=
-  SyntacticObject.lexLeaf (wordTok clause.subject 0)
+  lexLeaf (wordTok clause.subject 0)
 
 private def objectSO? (clause : SimpleClause) : Option SyntacticObject :=
-  clause.object.map fun obj => SyntacticObject.lexLeaf (wordTok obj 2)
+  clause.object.map fun obj => lexLeaf (wordTok obj 2)
 
 /-- Subject c-commands object: in `{subj, {verb, obj}}`, the subject's sister
     `{verb, obj}` contains the object. -/
 def subjectCCommandsObject (clause : SimpleClause) : Prop :=
   match objectSO? clause with
   | none => False
-  | some objSO => SyntacticObject.cCommandsIn (toSyntacticObject clause) (subjectSO clause) objSO
+  | some objSO => cCommandsIn (toSyntacticObject clause) (subjectSO clause) objSO
 
 instance (clause : SimpleClause) : Decidable (subjectCCommandsObject clause) := by
   unfold subjectCCommandsObject; cases objectSO? clause <;> infer_instance
@@ -114,7 +112,7 @@ instance (clause : SimpleClause) : Decidable (subjectCCommandsObject clause) := 
 def objectCCommandsSubject (clause : SimpleClause) : Prop :=
   match objectSO? clause with
   | none => False
-  | some objSO => SyntacticObject.cCommandsIn (toSyntacticObject clause) objSO (subjectSO clause)
+  | some objSO => cCommandsIn (toSyntacticObject clause) objSO (subjectSO clause)
 
 instance (clause : SimpleClause) : Decidable (objectCCommandsSubject clause) := by
   unfold objectCCommandsSubject; cases objectSO? clause <;> infer_instance
@@ -124,8 +122,8 @@ def sameLocalDomain (clause : SimpleClause) : Prop :=
   match objectSO? clause with
   | none => True
   | some objSO =>
-    SyntacticObject.contains (toSyntacticObject clause) (subjectSO clause) ∧
-    SyntacticObject.contains (toSyntacticObject clause) objSO
+    contains (toSyntacticObject clause) (subjectSO clause) ∧
+    contains (toSyntacticObject clause) objSO
 
 instance (clause : SimpleClause) : Decidable (sameLocalDomain clause) := by
   unfold sameLocalDomain; cases objectSO? clause <;> infer_instance

--- a/Linglib/Studies/Chomsky1995.lean
+++ b/Linglib/Studies/Chomsky1995.lean
@@ -16,7 +16,7 @@ English-derivation lexicon now lives).
 
 namespace Chomsky1995
 
-open Minimalist
+open Minimalist SyntacticObject
 open English.Predicates.Verbal (VerbEntry)
 open English.Nouns (NounEntry)
 
@@ -31,16 +31,15 @@ def verbToSelStack (v : VerbEntry) : SelStack :=
 
 /-- A `VerbEntry` as a `SyntacticObject` leaf (`Cat = .V`, selStack from `complementType`). -/
 def verbToSO (v : VerbEntry) (id : Nat) : SyntacticObject :=
-  SyntacticObject.mkLeafPhon .V (verbToSelStack v) v.form3sg id
+  mkLeafPhon .V (verbToSelStack v) v.form3sg id
 
 /-- A `NounEntry` as a leaf: proper names project as `.D`, common nouns as bare `.N`. -/
 def nounToSO (n : NounEntry) (id : Nat) : SyntacticObject :=
-  if n.proper then SyntacticObject.mkLeafPhon .D [] n.formSg id
-  else SyntacticObject.mkLeafPhon .N [] n.formSg id
+  if n.proper then mkLeafPhon .D [] n.formSg id else mkLeafPhon .N [] n.formSg id
 
 /-- "John sees Mary" as a Minimalist Merge derivation: *see*'s complement
     is *Mary* (`emR`), then *John* is added as specifier (`emL`). -/
-def john_sees_mary : SyntacticObject.Derivation :=
+def john_sees_mary : Derivation :=
   { initial := verbToSO English.Predicates.Verbal.see 31
     steps   := [.emR (nounToSO English.Nouns.mary 11),
                 .emL (nounToSO English.Nouns.john 10)] }

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -51,19 +51,19 @@ needs four distinct categories.
 
 namespace Cinque2005
 
-open Minimalist
+open Minimalist SyntacticObject
 open RootedTree
 
 /-! ### The four elements (head-initial leaves) -/
 
 /-- Noun (the raising NP). -/
-def noun : SyntacticObject := SyntacticObject.mkLeaf .N [] 1
+def noun : SyntacticObject := mkLeaf .N [] 1
 /-- Adjective. -/
-def adj : SyntacticObject := SyntacticObject.mkLeaf .A [] 2
+def adj : SyntacticObject := mkLeaf .A [] 2
 /-- Numeral. -/
-def numl : SyntacticObject := SyntacticObject.mkLeaf .Num [] 3
+def numl : SyntacticObject := mkLeaf .Num [] 3
 /-- Demonstrative (encoded as `.D`; see module note). -/
-def dem : SyntacticObject := SyntacticObject.mkLeaf .D [] 4
+def dem : SyntacticObject := mkLeaf .D [] 4
 
 /-! ### Frequency buckets and the 24-order attestation table ([cinque-2005] (6))
 
@@ -132,57 +132,49 @@ NP-containing constituent (which contains the earlier `SyntacticObject.traceLeaf
 the planar DSL so the surface orders `decide`. -/
 
 /-- The four leaf tokens, used to build pied-piping movers planar-first. -/
-private def pN : RoseTree SOLabel := SyntacticObject.leafP ⟨.simple .N [], 1⟩
-private def pA : RoseTree SOLabel := SyntacticObject.leafP ⟨.simple .A [], 2⟩
-private def pNum : RoseTree SOLabel := SyntacticObject.leafP ⟨.simple .Num [], 3⟩
+private def pN : RoseTree SOLabel := leafP ⟨.simple .N [], 1⟩
+private def pA : RoseTree SOLabel := leafP ⟨.simple .A [], 2⟩
+private def pNum : RoseTree SOLabel := leafP ⟨.simple .Num [], 3⟩
 
 /-- The pied-piped `[N [A t]]` mover (N raised around A, then the whole `[A t]`
     with N on top). -/
-def movNAt : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP pN (SyntacticObject.nodeP pA SyntacticObject.traceP))
+def movNAt : SyntacticObject := ofPlanar (nodeP pN (nodeP pA traceP))
 /-- The pied-piped `[A N]` mover. -/
-def movAN : SyntacticObject := SyntacticObject.ofPlanar (SyntacticObject.nodeP pA pN)
+def movAN : SyntacticObject := ofPlanar (nodeP pA pN)
 /-- The pied-piped `[N [A t]]` constituent raised again past Num, with the Num
     sub-trace: `[N [Num [t [A t]]]]` — the (t) roll-up's third mover. -/
 def movNNumAt : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP pN
-    (SyntacticObject.nodeP pNum
-      (SyntacticObject.nodeP SyntacticObject.traceP
-        (SyntacticObject.nodeP pA SyntacticObject.traceP))))
+  ofPlanar (nodeP pN (nodeP pNum (nodeP traceP (nodeP pA traceP))))
 /-- The successive pied-pipe past Num for (x): `[[N [A t]] [Num t]]`. -/
 def movNAtNum : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP
-    (SyntacticObject.nodeP pN (SyntacticObject.nodeP pA SyntacticObject.traceP))
-    (SyntacticObject.nodeP pNum SyntacticObject.traceP))
+  ofPlanar (nodeP (nodeP pN (nodeP pA traceP)) (nodeP pNum traceP))
 
 /-- (a) Dem Num A N — no movement. -/
-def derA : SyntacticObject.Derivation := ⟨noun, [.emL adj, .emL numl, .emL dem]⟩
+def derA : Derivation := ⟨noun, [.emL adj, .emL numl, .emL dem]⟩
 
 /-- (b) Dem Num N A — NP raises around A (bare). -/
-def derB : SyntacticObject.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .emL dem]⟩
+def derB : Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .emL dem]⟩
 
 /-- (c) Dem N Num A — NP raises around A then Num (partial, bare). -/
-def derC : SyntacticObject.Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem]⟩
+def derC : Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem]⟩
 
 /-- (d) N Dem Num A — NP raises around A, Num, Dem (total, bare). -/
-def derD : SyntacticObject.Derivation :=
+def derD : Derivation :=
   ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem, .im noun]⟩
 
 /-- (n) Dem A N Num — pied-pipe `[A N]` around Num (no sub-raise). -/
-def derN : SyntacticObject.Derivation := ⟨noun, [.emL adj, .emL numl, .im movAN, .emL dem]⟩
+def derN : Derivation := ⟨noun, [.emL adj, .emL numl, .im movAN, .emL dem]⟩
 
 /-- (o) Dem N A Num — raise N around A, then pied-pipe `[N A]` around Num. -/
-def derO : SyntacticObject.Derivation :=
-  ⟨noun, [.emL adj, .im noun, .emL numl, .im movNAt, .emL dem]⟩
+def derO : Derivation := ⟨noun, [.emL adj, .im noun, .emL numl, .im movNAt, .emL dem]⟩
 
 /-- (t) N Num A Dem — bare raise around A and Num, then pied-pipe `[N Num A]`
     around Dem. -/
-def derT : SyntacticObject.Derivation :=
+def derT : Derivation :=
   ⟨noun, [.emL adj, .im noun, .emL numl, .im noun, .emL dem, .im movNNumAt]⟩
 
 /-- (x) N A Num Dem — successive pied-piping all the way up (the roll-up). -/
-def derX : SyntacticObject.Derivation :=
+def derX : Derivation :=
   ⟨noun, [.emL adj, .im noun, .emL numl, .im movNAt, .emL dem, .im movNAtNum]⟩
 
 /-! ### The eight derivations produce their attested orders (kernel-checked) -/
@@ -247,7 +239,7 @@ private def pMovers (cur : RoseTree SOLabel) : List (RoseTree SOLabel) :=
     `SyntacticObject.traceP` (planar leftward movement) — `none` if `s` is absent. -/
 private def pMoveLeft (s : RoseTree SOLabel) (cur : RoseTree SOLabel) : Option (RoseTree SOLabel) :=
   if (pSubtrees cur).contains s then
-    some (SyntacticObject.nodeP s (planarReplaceWhereP (· == s) SyntacticObject.traceP cur))
+    some (nodeP s (planarReplaceWhereP (· == s) traceP cur))
   else none
 
 /-- At a spec: keep, or raise one eligible mover (leftward). -/
@@ -257,10 +249,9 @@ private def pOpt (cur : RoseTree SOLabel) : List (RoseTree SOLabel) :=
 /-- The whole legal derivation space (planar externalizations): merge A, Num, Dem
     head-initially with an optional raise at each spec. -/
 private def space : List (RoseTree SOLabel) :=
-  ([SyntacticObject.leafP tokN].map
-      (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokA) c)).flatMap pOpt
-    |>.map (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokNum) c) |>.flatMap pOpt
-    |>.map (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokD) c)   |>.flatMap pOpt
+  ([leafP tokN].map (fun c => nodeP (leafP tokA) c)).flatMap pOpt
+    |>.map (fun c => nodeP (leafP tokNum) c) |>.flatMap pOpt
+    |>.map (fun c => nodeP (leafP tokD) c)   |>.flatMap pOpt
 
 /-- The distinct surface orders reachable by Cinque's movement. -/
 def reachableOrders : List (List Cat) :=
@@ -381,9 +372,9 @@ private def stepCost (build : RoseTree SOLabel → RoseTree SOLabel) (p : RoseTr
 /-- The legal derivation space (as in `space`) carrying accumulated local
     marked-move cost. -/
 private def spaceCost : List (RoseTree SOLabel × Nat) :=
-  [(SyntacticObject.nodeP (SyntacticObject.leafP tokA) (SyntacticObject.leafP tokN), 0)]
-    |>.flatMap (stepCost (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokNum) c))
-    |>.flatMap (stepCost (fun c => SyntacticObject.nodeP (SyntacticObject.leafP tokD) c))
+  [(nodeP (leafP tokA) (leafP tokN), 0)]
+    |>.flatMap (stepCost (fun c => nodeP (leafP tokNum) c))
+    |>.flatMap (stepCost (fun c => nodeP (leafP tokD) c))
     |>.flatMap (stepCost id)
 
 /-- **Derived** local proxy: the minimum number of locally-marked moves over the

--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -70,7 +70,7 @@ multidominance as the PF reduction mechanism.
 
 namespace CitkoGracaninYuksek2025
 
-open Minimalist
+open Minimalist SyntacticObject
 open Syntax.Question
 
 /-! ### Multidominance (relocated from Minimalist/Multidominance.lean)
@@ -776,13 +776,13 @@ theorem cs_twoEFeature_wholeDeriv_pf_differs :
 /-- The adopted CWH structure: non-bulk-sharing MD, no ellipsis (paper's (10b)).
     Shared nodes: C and T are individually multiply dominated. -/
 def cwhStructure : PFReducedCoordination where
-  conjunct1 := SyntacticObject.mkLeaf .C [] 0
-  conjunct2 := SyntacticObject.mkLeaf .C [] 1
+  conjunct1 := mkLeaf .C [] 0
+  conjunct2 := mkLeaf .C [] 1
   mechanisms := [.multidominance]
   sharing := some .nonBulk
   sharedNodes :=
-    [ { node := SyntacticObject.mkLeaf .C [] 10, category := some .C, pronounced := true }
-    , { node := SyntacticObject.mkLeaf .T [] 11, category := some .T, pronounced := false } ]
+    [ { node := mkLeaf .C [] 10, category := some .C, pronounced := true }
+    , { node := mkLeaf .T [] 11, category := some .T, pronounced := false } ]
   pfOutput := ["what", "and", "when", "should", "you", "teach"]
 
 /-- The adopted CS structure: bulk-sharing MD + ellipsis (paper's (20b)).
@@ -790,14 +790,14 @@ def cwhStructure : PFReducedCoordination where
     triggers TP deletion, repairing the MWF violation at the vP edge.
     Shared nodes: entire C' is shared (includes C, TP, vP, VP). -/
 def csStructure : PFReducedCoordination where
-  conjunct1 := SyntacticObject.mkLeaf .C [] 0
-  conjunct2 := SyntacticObject.mkLeaf .C [] 1
+  conjunct1 := mkLeaf .C [] 0
+  conjunct2 := mkLeaf .C [] 1
   mechanisms := [.multidominance, .ellipsis]
   sharing := some .bulk
   sharedNodes :=
-    [ { node := SyntacticObject.mkLeaf .C [] 10, category := some .C, pronounced := true }
-    , { node := SyntacticObject.mkLeaf .T [] 11, category := some .T, pronounced := false }
-    , { node := SyntacticObject.mkLeaf .v [] 12, category := some .v, pronounced := false } ]
+    [ { node := mkLeaf .C [] 10, category := some .C, pronounced := true }
+    , { node := mkLeaf .T [] 11, category := some .T, pronounced := false }
+    , { node := mkLeaf .v [] 12, category := some .v, pronounced := false } ]
   pfOutput := ["what", "and", "when"]
 
 /-- Structural drift sentry over the four key properties of cwhStructure

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -93,7 +93,7 @@ end Minimalist
 
 namespace ColeHermon2008
 
-open Minimalist
+open Minimalist SyntacticObject
 open RootedTree
 
 -- ============================================================================
@@ -101,19 +101,19 @@ open RootedTree
 -- ============================================================================
 
 /-- "mangatuk" — ACT-hit (active voice transitive verb). -/
-def v_mangatuk := SyntacticObject.mkLeafPhon .V [] "mangatuk" 1
+def v_mangatuk := mkLeafPhon .V [] "mangatuk" 1
 
 /-- "biangi" — dog-DEF (definite object DP). -/
-def n_biangi := SyntacticObject.mkLeafPhon .N [] "biangi" 2
+def n_biangi := mkLeafPhon .N [] "biangi" 2
 
 /-- "dakdanakan" — child-that (subject DP). -/
-def n_dakdanakan := SyntacticObject.mkLeafPhon .N [] "dakdanakan" 3
+def n_dakdanakan := mkLeafPhon .N [] "dakdanakan" 3
 
 /-- Little v (silent, selects VP). -/
-def v_head := SyntacticObject.mkLeaf .v [.V] 4
+def v_head := mkLeaf .v [.V] 4
 
 /-- T (silent, selects vP). -/
-def t_head := SyntacticObject.mkLeaf .T [.v] 5
+def t_head := mkLeaf .T [.v] 5
 
 /-! Planar leaf tokens for building the result/base trees. -/
 
@@ -126,12 +126,10 @@ private def tok_t          : LIToken := ⟨.simple .T [.v], 5⟩
 /-- The VP constituent `[VP V Obj]` — the phrase that raises. Built
     planar-first so containment over it `decide`s. -/
 def vp : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_mangatuk) (SyntacticObject.leafP tok_biangi))
+  ofPlanar (nodeP (leafP tok_mangatuk) (leafP tok_biangi))
 
 /-- The VP as a planar subtree (for embedding in larger result trees). -/
-private def vpP : RoseTree SOLabel :=
-  SyntacticObject.nodeP (SyntacticObject.leafP tok_mangatuk) (SyntacticObject.leafP tok_biangi)
+private def vpP : RoseTree SOLabel := nodeP (leafP tok_mangatuk) (leafP tok_biangi)
 
 -- ============================================================================
 -- § 2: Toba Batak VOS Derivation
@@ -145,7 +143,7 @@ private def vpP : RoseTree SOLabel :=
     3. EM-L Subj → `[vP Subj [v' v VP]]`
     4. EM-L T  → `[TP T [vP Subj [v' v VP]]]`
     5. IM VP   → `[TP VP [T' T [vP Subj [v' v tVP]]]]` -/
-def tobaBatakVOS : SyntacticObject.Derivation :=
+def tobaBatakVOS : Derivation :=
   { initial := v_mangatuk
     steps := [
       .emR n_biangi,
@@ -158,30 +156,30 @@ def tobaBatakVOS : SyntacticObject.Derivation :=
 /-- The VOS **base** tree at stage 4 (pre-movement):
     `[TP T [vP Subj [v' v [VP V Obj]]]]`. Built planar-first. -/
 def tobaBatakBaseTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_t)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_dakdanakan)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_v) vpP)))
+  ofPlanar
+    (nodeP (leafP tok_t)
+      (nodeP (leafP tok_dakdanakan)
+        (nodeP (leafP tok_v) vpP)))
 
 /-- The VOS **derived** tree after VP-raising:
     `[TP [VP V Obj] [T' T [vP Subj [v' v tVP]]]]`. The raised VP sits at
     the left edge; the original VP position is the bare trace. -/
 def tobaBatakDerivedTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP vpP
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_t)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_dakdanakan)
-          (SyntacticObject.nodeP (SyntacticObject.leafP tok_v) SyntacticObject.traceP))))
+  ofPlanar
+    (nodeP vpP
+      (nodeP (leafP tok_t)
+        (nodeP (leafP tok_dakdanakan)
+          (nodeP (leafP tok_v) traceP))))
 
 -- ============================================================================
 -- § 3: English SVO Derivation (Comparison)
 -- ============================================================================
 
-def v_saw   := SyntacticObject.mkLeafPhon .V [] "saw" 11
-def n_mary  := SyntacticObject.mkLeafPhon .N [] "Mary" 12
-def n_john  := SyntacticObject.mkLeafPhon .N [] "John" 13
-def v_head2 := SyntacticObject.mkLeaf .v [.V] 14
-def t_head2 := SyntacticObject.mkLeaf .T [.v] 15
+def v_saw   := mkLeafPhon .V [] "saw" 11
+def n_mary  := mkLeafPhon .N [] "Mary" 12
+def n_john  := mkLeafPhon .N [] "John" 13
+def v_head2 := mkLeaf .v [.V] 14
+def t_head2 := mkLeaf .T [.v] 15
 
 private def tok_saw   : LIToken := ⟨.simple .V [] (phonForm := "saw"), 11⟩
 private def tok_mary_en : LIToken := ⟨.simple .N [] (phonForm := "Mary"), 12⟩
@@ -192,7 +190,7 @@ private def tok_t2    : LIToken := ⟨.simple .T [.v], 15⟩
 /-- English SVO via subject-raising to Spec,TP.
 
     Same base as Toba Batak, but the subject (not VP) moves to Spec,TP. -/
-def englishSVO : SyntacticObject.Derivation :=
+def englishSVO : Derivation :=
   { initial := v_saw
     steps := [
       .emR n_mary,
@@ -206,12 +204,11 @@ def englishSVO : SyntacticObject.Derivation :=
     `[TP T [vP John [v' v [VP saw Mary]]]]`. Built planar-first; same shape
     as `tobaBatakBaseTree`, modulo lexical content. -/
 def englishBaseTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_t2)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_john_en)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_v2)
-          (SyntacticObject.nodeP (SyntacticObject.leafP tok_saw)
-            (SyntacticObject.leafP tok_mary_en)))))
+  ofPlanar
+    (nodeP (leafP tok_t2)
+      (nodeP (leafP tok_john_en)
+        (nodeP (leafP tok_v2)
+          (nodeP (leafP tok_saw) (leafP tok_mary_en)))))
 
 -- ============================================================================
 -- § 4: Word Order Predictions
@@ -266,7 +263,7 @@ theorem english_moves_subject :
     does not entail that the DO (properly contained within VP) individually
     c-commands the subject. -/
 theorem vp_ccommands_subject :
-    SyntacticObject.cCommandsIn tobaBatakDerivedTree vp n_dakdanakan := by decide
+    cCommandsIn tobaBatakDerivedTree vp n_dakdanakan := by decide
 
 -- ============================================================================
 -- § 6: EPP Parameter
@@ -306,7 +303,7 @@ These predictions match the Toba Batak extraction data formalized in
 
     This is verified computationally: `n_biangi` is contained in `vp`. -/
 theorem object_inside_fronted_vp :
-    SyntacticObject.contains vp n_biangi := by decide
+    contains vp n_biangi := by decide
 
 /-- The subject is NOT contained within the fronted VP. It is stranded
     outside the moved constituent and remains accessible for extraction.
@@ -315,7 +312,7 @@ theorem object_inside_fronted_vp :
     only the subject (= pivot) survives VP-raising in a position where
     Ā-extraction is possible. -/
 theorem subject_outside_fronted_vp :
-    ¬ SyntacticObject.contains vp n_dakdanakan := by decide
+    ¬ contains vp n_dakdanakan := by decide
 
 /-- Extraction prediction: the VP-raising analysis predicts exactly the
     extraction pattern found in Toba Batak.
@@ -328,10 +325,10 @@ theorem subject_outside_fronted_vp :
     and `TobaBatak.avPatientExtraction` (ungrammatical). -/
 theorem extraction_matches_vp_containment :
     -- Agent is outside VP → extractable (matches AV agent = grammatical)
-    ¬ SyntacticObject.contains vp n_dakdanakan ∧
+    ¬ contains vp n_dakdanakan ∧
     TobaBatak.avAgentExtraction.judgment = .grammatical ∧
     -- Object is inside VP → frozen (matches AV patient = ungrammatical)
-    SyntacticObject.contains vp n_biangi ∧
+    contains vp n_biangi ∧
     TobaBatak.avPatientExtraction.judgment = .ungrammatical := by
   refine ⟨?_, rfl, ?_, rfl⟩ <;> decide
 
@@ -449,7 +446,7 @@ theorem binding_acceptability_pattern :
     c-commands into VP (can bind a reflexive DO), but the DO (inside VP)
     cannot c-command out past VP (cannot bind a reflexive subject). -/
 theorem object_does_not_ccommand_subject :
-    ¬ SyntacticObject.cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan := by
+    ¬ cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan := by
   decide
 
 -- ============================================================================
@@ -513,7 +510,7 @@ the Linear Correspondence Axiom (LCA).
 -/
 
 /-- F head (higher functional projection above TP). -/
-def f_head := SyntacticObject.mkLeaf .C [.T] 6
+def f_head := mkLeaf .C [.T] 6
 
 /-- Toba Batak SVO via the VOS Hypothesis.
 
@@ -523,7 +520,7 @@ def f_head := SyntacticObject.mkLeaf .C [.T] 6
     7. IM Subj → `[FP Subj [F' F [TP VP [T' T [vP tSubj [v' v tVP]]]]]]`
 
     The subject raises past the fronted VP, yielding S-V-O surface order. -/
-def tobaBatakSVO : SyntacticObject.Derivation :=
+def tobaBatakSVO : Derivation :=
   { initial := v_mangatuk
     steps := [
       .emR n_biangi,
@@ -542,15 +539,15 @@ theorem toba_batak_svo_order :
 /-- SVO goes through VOS: at stage 5 (before subject-raising), the
     intermediate tree has VOS order — the same as `tobaBatakVOS.final`. -/
 theorem svo_passes_through_vos :
-    (⟨tobaBatakSVO.initial, tobaBatakSVO.steps.take 5⟩ : SyntacticObject.Derivation).surfacePhon
+    (⟨tobaBatakSVO.initial, tobaBatakSVO.steps.take 5⟩ : Derivation).surfacePhon
       = tobaBatakVOS.surfacePhon := by decide
 
 /-- The VOS Hypothesis predicts identical extraction restrictions for SVO:
     the DO is still inside the fronted VP, regardless of whether the
     subject subsequently raises past it. -/
 theorem svo_same_extraction_as_vos :
-    SyntacticObject.contains vp n_biangi ∧
-    ¬ SyntacticObject.contains vp n_dakdanakan := by
+    contains vp n_biangi ∧
+    ¬ contains vp n_dakdanakan := by
   refine ⟨?_, ?_⟩ <;> decide
 
 /-- SVO requires two movement steps (VP-raising + subject-raising). -/
@@ -585,11 +582,11 @@ We model the English passive with the agent as a low complement of V
 (following [larson-1988]), with no external argument in Spec,vP.
 -/
 
-def v_injured     := SyntacticObject.mkLeafPhon .V [] "was-injured" 21
-def n_boy         := SyntacticObject.mkLeafPhon .N [] "the-boy" 22
-def n_by_himself  := SyntacticObject.mkLeafPhon .N [] "by-himself" 23
-def v_head_pass   := SyntacticObject.mkLeaf .v [.V] 24
-def t_head_pass   := SyntacticObject.mkLeaf .T [.v] 25
+def v_injured     := mkLeafPhon .V [] "was-injured" 21
+def n_boy         := mkLeafPhon .N [] "the-boy" 22
+def n_by_himself  := mkLeafPhon .N [] "by-himself" 23
+def v_head_pass   := mkLeaf .v [.V] 24
+def t_head_pass   := mkLeaf .T [.v] 25
 
 private def tok_injured    : LIToken := ⟨.simple .V [] (phonForm := "was-injured"), 21⟩
 private def tok_boy        : LIToken := ⟨.simple .N [] (phonForm := "the-boy"), 22⟩
@@ -599,10 +596,8 @@ private def tok_t_pass     : LIToken := ⟨.simple .T [.v], 25⟩
 
 /-- The passive VP: `[VP patient [V' V agent-PP]]`. Built planar-first. -/
 def vp_passive : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_boy)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_injured)
-        (SyntacticObject.leafP tok_by_himself)))
+  ofPlanar
+    (nodeP (leafP tok_boy) (nodeP (leafP tok_injured) (leafP tok_by_himself)))
 
 /-- English passive derivation (trees 97–100 of the paper).
 
@@ -612,7 +607,7 @@ def vp_passive : SyntacticObject :=
     3. EM-L v        → `[v' v VP]` (no external argument — passive)
     4. EM-L T        → `[TP T [vP v VP]]`
     5. IM patient    → `[TP patient [T' T [vP v [VP t [V' V agent]]]]]` -/
-def englishPassive : SyntacticObject.Derivation :=
+def englishPassive : Derivation :=
   { initial := v_injured
     steps := [
       .emR n_by_himself,
@@ -627,13 +622,12 @@ def englishPassive : SyntacticObject.Derivation :=
     sits at the top edge above its base trace; the agent is a low
     complement of V. -/
 def englishPassiveDerivedTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_boy)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_t_pass)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_v_pass)
-          (SyntacticObject.nodeP SyntacticObject.traceP
-            (SyntacticObject.nodeP (SyntacticObject.leafP tok_injured)
-              (SyntacticObject.leafP tok_by_himself))))))
+  ofPlanar
+    (nodeP (leafP tok_boy)
+      (nodeP (leafP tok_t_pass)
+        (nodeP (leafP tok_v_pass)
+          (nodeP traceP
+            (nodeP (leafP tok_injured) (leafP tok_by_himself))))))
 
 /-- English passive yields patient-verb-agent surface order. -/
 theorem english_passive_order :
@@ -667,7 +661,7 @@ using `SyntacticObject.cCommandsIn` over the derived trees.
     the by-phrase agent. This is why "The boy was injured by himself" is
     grammatical: the patient can bind a reflexive in the agent position. -/
 theorem english_passive_patient_ccommands_agent :
-    SyntacticObject.cCommandsIn englishPassiveDerivedTree n_boy n_by_himself := by
+    cCommandsIn englishPassiveDerivedTree n_boy n_by_himself := by
   decide
 
 /-- In the English passive, the by-phrase agent does NOT c-command the
@@ -675,7 +669,7 @@ theorem english_passive_patient_ccommands_agent :
     ungrammatical: the agent (low adjunct inside VP) cannot bind a
     reflexive in subject position. -/
 theorem english_passive_agent_not_ccommands_patient :
-    ¬ SyntacticObject.cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
+    ¬ cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
   decide
 
 /-- In the TB active **base structure** (pre-movement, stage 4), the
@@ -687,7 +681,7 @@ theorem english_passive_agent_not_ccommands_patient :
     contains the object. After VP-raising, the object moves to a
     different branch; reconstruction restores the base c-command. -/
 theorem tb_active_subject_ccommands_object_at_base :
-    SyntacticObject.cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi := by
+    cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi := by
   decide
 
 /-- Cross-linguistic contrast verified: same c-command theory, different
@@ -700,11 +694,11 @@ theorem tb_active_subject_ccommands_object_at_base :
     4. English passive (derived): agent does not c-command patient (ex. 96) -/
 theorem cross_linguistic_binding_contrast :
     -- TB active (base stage for binding, derived stage for anti-binding)
-    SyntacticObject.cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi ∧
-    ¬ SyntacticObject.cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan ∧
+    cCommandsIn tobaBatakBaseTree n_dakdanakan n_biangi ∧
+    ¬ cCommandsIn tobaBatakDerivedTree n_biangi n_dakdanakan ∧
     -- English passive (derived tree)
-    SyntacticObject.cCommandsIn englishPassiveDerivedTree n_boy n_by_himself ∧
-    ¬ SyntacticObject.cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
+    cCommandsIn englishPassiveDerivedTree n_boy n_by_himself ∧
+    ¬ cCommandsIn englishPassiveDerivedTree n_by_himself n_boy := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 end ColeHermon2008

--- a/Linglib/Studies/Dendikken1995ParticleVerbs.lean
+++ b/Linglib/Studies/Dendikken1995ParticleVerbs.lean
@@ -50,7 +50,7 @@ to SpecSC. It does **not** capture:
 
 namespace Dendikken1995ParticleVerbs
 
-open Minimalist
+open Minimalist SyntacticObject
 
 /-! ## Particle verb inventory -/
 
@@ -80,8 +80,8 @@ with SpecSC empty. The current `SmallClause` shape forces a subject
 field, so we record the post-movement form. -/
 
 def pvToSmallClause (pv : ParticleVerb) (dpId prtId : Nat) : SmallClause :=
-  { subject := SyntacticObject.mkLeafPhon .D [] "DP" dpId
-    predicate := SyntacticObject.mkLeafPhon .P [] pv.particle prtId
+  { subject := mkLeafPhon .D [] "DP" dpId
+    predicate := mkLeafPhon .P [] pv.particle prtId
     predCat := .P }
 
 /-- All PVC small clauses have predicate category P. -/
@@ -103,8 +103,8 @@ unfolding `pvToSmallClause`. -/
 /-- Any PVC small clause is a 2-leaf binary tree (subject + predicate). -/
 theorem pvToSmallClause_toSO_shape (pv : ParticleVerb) (dpId prtId : Nat) :
     (pvToSmallClause pv dpId prtId).toSO.leafCount = 2 := by
-  simp only [pvToSmallClause, SmallClause.toSO, SyntacticObject.leafCount_merge,
-    SyntacticObject.mkLeafPhon, SyntacticObject.leafCount_lexLeaf]
+  simp only [pvToSmallClause, SmallClause.toSO, leafCount_merge,
+    mkLeafPhon, leafCount_lexLeaf]
 
 /-- The `predCat` field of `pvToSmallClause` agrees with the
     `predicate.headCat` reading — the well-formedness invariant

--- a/Linglib/Studies/Dendikken1995Resultatives.lean
+++ b/Linglib/Studies/Dendikken1995Resultatives.lean
@@ -40,7 +40,7 @@ onto SC predicate categories:
 
 namespace Dendikken1995Resultatives
 
-open Minimalist
+open Minimalist SyntacticObject
 open GoldbergJackendoff2004
 
 /-! ## §1. Resultative types → SC predicate categories
@@ -102,8 +102,8 @@ theorem resultative_cats_are_A_or_P (rt : ResultativeType) :
 
 /-- Build a small clause from a resultative datum. -/
 def datumToSC (d : ResultativeDatum) (dpId predId : Nat) : SmallClause :=
-  { subject := SyntacticObject.mkLeafPhon .D [] "DP_patient" dpId
-    predicate := SyntacticObject.mkLeafPhon (SCPredCategory.toCat (resToSCPred d.resType))
+  { subject := mkLeafPhon .D [] "DP_patient" dpId
+    predicate := mkLeafPhon (SCPredCategory.toCat (resToSCPred d.resType))
                                [] "XP_result" predId
     predCat := resToSCPred d.resType }
 

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -129,7 +129,7 @@ theorem different_mechanisms :
 -- Part II: Minimalist Analysis
 -- ============================================================================
 
-open Minimalist
+open Minimalist SyntacticObject
 
 /-! ### Mam Voice substrate (Minimalist)
 
@@ -458,20 +458,18 @@ private def cTok       : LIToken := ⟨.simple .C [.T] "", 6⟩
     successive-cyclic Ā-movement, surfacing at Spec,CP with a trace lower down.
     Structure: `[CP oblique [C' C [TP T [VoiceP oblique [Voice' Voice [VP V obj]]]]]]`. -/
 private def cp : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP obliqueTok)
-      (SyntacticObject.nodeP (SyntacticObject.leafP cTok)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tTok)
-          (SyntacticObject.nodeP (SyntacticObject.leafP obliqueTok)
-            (SyntacticObject.nodeP (SyntacticObject.leafP voiceTok)
-              (SyntacticObject.nodeP (SyntacticObject.leafP verbTok)
-                (SyntacticObject.leafP objectTok)))))))
+  ofPlanar
+    (nodeP (leafP obliqueTok)
+      (nodeP (leafP cTok)
+        (nodeP (leafP tTok)
+          (nodeP (leafP obliqueTok)
+            (nodeP (leafP voiceTok)
+              (nodeP (leafP verbTok) (leafP objectTok)))))))
 
 theorem derivation_tree_size : cp.nodeCount = 6 := by decide
 
 theorem voice_has_uOblique :
-    hasUnvaluedFeature mamVoice.features (.oblique false) = true := by
-  decide
+    hasUnvaluedFeature mamVoice.features (.oblique false) = true := by decide
 
 private def oblique_goal_features : FeatureBundle := .ofGramFeatures [.valued (.oblique true)]
 

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -61,6 +61,7 @@ open Semantics.Composition.Tree
 open Quantification.Quantifier
 open Quantification
 open Semantics.Montague.ToyLexicon (student_sem person_sem)
+open Minimalist.SyntacticObject
 
 /-! ### Model and lexicon -/
 
@@ -332,7 +333,7 @@ The semantic type corresponding to a syntactic object.
 - Other SOs need lexical lookup
 -/
 def soSemanticType (so : Minimalist.SyntacticObject) : Option Ty :=
-  if Minimalist.SyntacticObject.isTrace so then some .e else none
+  if isTrace so then some .e else none
 
 /--
 Interpret a trace leaf in a syntactic object at a given index.
@@ -343,20 +344,19 @@ is not the trace leaf.
 -/
 def interpSOTrace {E : Type} (n : ℕ) (so : Minimalist.SyntacticObject) :
     Option (DenotG E Unit .e) :=
-  if Minimalist.SyntacticObject.isTrace so then some (interpTrace n) else none
+  if isTrace so then some (interpTrace n) else none
 
 /-- The trace leaf is recognized as type `e`. -/
 @[simp] theorem soSemanticType_traceLeaf :
-    soSemanticType Minimalist.SyntacticObject.traceLeaf = some .e := rfl
+    soSemanticType traceLeaf = some .e := rfl
 
 /-- A lexical leaf is not a trace, so it gets no carrier-level type. -/
 @[simp] theorem soSemanticType_lexLeaf (tok : Minimalist.LIToken) :
-    soSemanticType (Minimalist.SyntacticObject.lexLeaf tok) = none := by
-  have hne : ¬ Minimalist.SyntacticObject.isTrace (Minimalist.SyntacticObject.lexLeaf tok) := by
+    soSemanticType (lexLeaf tok) = none := by
+  have hne : ¬ isTrace (lexLeaf tok) := by
     intro h
-    have hg := congrArg Minimalist.SyntacticObject.getLIToken h
-    rw [Minimalist.SyntacticObject.getLIToken_lexLeaf,
-      Minimalist.SyntacticObject.getLIToken_traceLeaf] at hg
+    have hg := congrArg getLIToken h
+    rw [getLIToken_lexLeaf, getLIToken_traceLeaf] at hg
     exact Option.some_ne_none tok hg
   simp only [soSemanticType, if_neg hne]
 

--- a/Linglib/Studies/Kratzer1996.lean
+++ b/Linglib/Studies/Kratzer1996.lean
@@ -54,7 +54,7 @@ predictions are verified in `Core/Voice.lean` via `buildDecomposition`. -/
 
 section TreeDerivations
 
-open Minimalist
+open Minimalist SyntacticObject
 
 -- Leaf tokens (the smart Merge `SyntacticObject.node` is noncomputable, so concrete trees
 -- are built planar-first from `LIToken`s and `decide`d over).
@@ -76,78 +76,73 @@ def DP_door_t   : LIToken := ⟨.simple .D     []    "the door",   217⟩
 /-- Transitive: "John broke the vase"
     `[VoiceP John [Voice' Voice_AG [vP v [VP broke [DP the vase]]]]]` -/
 def transitiveTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP DP_john_t)
-      (SyntacticObject.nodeP (SyntacticObject.leafP voice_ag_t)
-        (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
-          (SyntacticObject.nodeP (SyntacticObject.leafP V_broke_t)
-            (SyntacticObject.leafP DP_vase_t)))))
+  ofPlanar
+    (nodeP (leafP DP_john_t)
+      (nodeP (leafP voice_ag_t)
+        (nodeP (leafP v_head_t)
+          (nodeP (leafP V_broke_t) (leafP DP_vase_t)))))
 
 /-- Anticausative: "The vase broke"
     `[VoiceP Voice_∅ [vP v [VP broke [DP the vase]]]]` -/
 def anticausativeTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP voice_nth_t)
-      (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
-        (SyntacticObject.nodeP (SyntacticObject.leafP V_broke_t)
-          (SyntacticObject.leafP DP_vase_t))))
+  ofPlanar
+    (nodeP (leafP voice_nth_t)
+      (nodeP (leafP v_head_t)
+        (nodeP (leafP V_broke_t) (leafP DP_vase_t))))
 
 /-- Unaccusative: "The ship sank"
     `[VoiceP Voice_∅ [vP v [VP sank [DP the ship]]]]` -/
 def unaccusativeTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP voice_nth_t)
-      (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
-        (SyntacticObject.nodeP (SyntacticObject.leafP V_sank_t) (SyntacticObject.leafP DP_ship_t))))
+  ofPlanar
+    (nodeP (leafP voice_nth_t)
+      (nodeP (leafP v_head_t)
+        (nodeP (leafP V_sank_t) (leafP DP_ship_t))))
 
 /-- Middle: "The door opened"
     `[VoiceP Voice_MID [vP v [VP opened [DP the door]]]]` -/
 def middleTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP voice_mid_t)
-      (SyntacticObject.nodeP (SyntacticObject.leafP v_head_t)
-        (SyntacticObject.nodeP (SyntacticObject.leafP V_opened_t)
-          (SyntacticObject.leafP DP_door_t))))
+  ofPlanar
+    (nodeP (leafP voice_mid_t)
+      (nodeP (leafP v_head_t)
+        (nodeP (leafP V_opened_t) (leafP DP_door_t))))
 
 -- C-command predictions
 
 /-- Agent c-commands theme in the transitive. -/
 theorem transitive_agent_ccommands_theme :
-    SyntacticObject.cCommandsIn transitiveTree (SyntacticObject.lexLeaf DP_john_t)
-      (SyntacticObject.lexLeaf DP_vase_t) := by decide
+    cCommandsIn transitiveTree (lexLeaf DP_john_t) (lexLeaf DP_vase_t) := by decide
 
 /-- Theme does NOT c-command agent. -/
 theorem transitive_theme_not_ccommands_agent :
-    ¬ SyntacticObject.cCommandsIn transitiveTree (SyntacticObject.lexLeaf DP_vase_t)
-      (SyntacticObject.lexLeaf DP_john_t) := by decide
+    ¬ cCommandsIn transitiveTree (lexLeaf DP_vase_t) (lexLeaf DP_john_t) := by decide
 
 /-- Anticausative contains theme but no agent DP. -/
 theorem anticausative_contains_theme :
-    SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf DP_vase_t) := by decide
+    contains anticausativeTree (lexLeaf DP_vase_t) := by decide
 
 /-- Unaccusative contains theme. -/
 theorem unaccusative_contains_theme :
-    SyntacticObject.contains unaccusativeTree (SyntacticObject.lexLeaf DP_ship_t) := by decide
+    contains unaccusativeTree (lexLeaf DP_ship_t) := by decide
 
 /-- Middle contains theme. -/
 theorem middle_contains_theme :
-    SyntacticObject.contains middleTree (SyntacticObject.lexLeaf DP_door_t) := by decide
+    contains middleTree (lexLeaf DP_door_t) := by decide
 
 -- Causative alternation
 
 /-- The transitive and anticausative share the VP core:
     both contain V("broke") and DP("the vase"). -/
 theorem causative_pair_shared_vp :
-    SyntacticObject.contains transitiveTree (SyntacticObject.lexLeaf V_broke_t) ∧
-    SyntacticObject.contains transitiveTree (SyntacticObject.lexLeaf DP_vase_t) ∧
-    SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf V_broke_t) ∧
-    SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf DP_vase_t) := by
+    contains transitiveTree (lexLeaf V_broke_t) ∧
+    contains transitiveTree (lexLeaf DP_vase_t) ∧
+    contains anticausativeTree (lexLeaf V_broke_t) ∧
+    contains anticausativeTree (lexLeaf DP_vase_t) := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 /-- The transitive has an agent DP; the anticausative does not. -/
 theorem causative_pair_agent_contrast :
-    SyntacticObject.contains transitiveTree (SyntacticObject.lexLeaf DP_john_t) ∧
-    ¬ SyntacticObject.contains anticausativeTree (SyntacticObject.lexLeaf DP_john_t) := by
+    contains transitiveTree (lexLeaf DP_john_t) ∧
+    ¬ contains anticausativeTree (lexLeaf DP_john_t) := by
   constructor <;> decide
 
 /-- Voice determines the alternation: agentive assigns θ,

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -75,21 +75,21 @@ DP arguments, not the position of V.
 
 namespace Larson1988
 
-open Minimalist
+open Minimalist SyntacticObject
 open RootedTree
 
 -- ============================================================================
 -- § 1: Lexical Items
 -- ============================================================================
 
-def V_send    := SyntacticObject.mkLeafPhon .V [.D]  "send"     300
-def P_to      := SyntacticObject.mkLeafPhon .P [.D]  "to"       301
-def DP_john   := SyntacticObject.mkLeafPhon .D []    "John"     302
-def DP_mary   := SyntacticObject.mkLeafPhon .D []    "Mary"     303
-def DP_letter := SyntacticObject.mkLeafPhon .D []    "a letter" 304
+def V_send    := mkLeafPhon .V [.D]  "send"     300
+def P_to      := mkLeafPhon .P [.D]  "to"       301
+def DP_john   := mkLeafPhon .D []    "John"     302
+def DP_mary   := mkLeafPhon .D []    "Mary"     303
+def DP_letter := mkLeafPhon .D []    "a letter" 304
 
-def V_kick    := SyntacticObject.mkLeafPhon .V [.D]  "kicked"   310
-def DP_ball   := SyntacticObject.mkLeafPhon .D []    "the ball" 311
+def V_kick    := mkLeafPhon .V [.D]  "kicked"   310
+def DP_ball   := mkLeafPhon .D []    "the ball" 311
 
 /-! Planar leaf tokens, used for building the result trees the derivations
     produce (the c-command theorems reason over these). -/
@@ -103,8 +103,7 @@ private def tok_kick   : LIToken := ⟨.simple .V [.D] (phonForm := "kicked"), 3
 private def tok_ball   : LIToken := ⟨.simple .D [] (phonForm := "the ball"), 311⟩
 
 /-- The `[PP to Mary]` constituent as a planar subtree. -/
-private def ppToMaryP : RoseTree SOLabel :=
-  SyntacticObject.nodeP (SyntacticObject.leafP tok_to) (SyntacticObject.leafP tok_mary)
+private def ppToMaryP : RoseTree SOLabel := nodeP (leafP tok_to) (leafP tok_mary)
 
 -- ============================================================================
 -- § 2: Oblique Dative Derivation
@@ -119,10 +118,10 @@ private def ppToMaryP : RoseTree SOLabel :=
     The direct object (a letter) c-commands the goal (Mary), but not
     vice versa — Mary is buried inside PP. -/
 
-def obliqueDative : SyntacticObject.Derivation :=
+def obliqueDative : Derivation :=
   { initial := V_send
     steps := [
-      .emR (SyntacticObject.ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .emL DP_john                    -- [VP John [VP a_letter [V' send [PP to Mary]]]]
     ] }
@@ -130,22 +129,22 @@ def obliqueDative : SyntacticObject.Derivation :=
 /-- The oblique dative result tree: `[John [letter [send [to Mary]]]]`.
     Built planar-first; this is exactly what `obliqueDative` produces. -/
 def obliqueDativeTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_john)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_letter)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_send) ppToMaryP)))
+  ofPlanar
+    (nodeP (leafP tok_john)
+      (nodeP (leafP tok_letter)
+        (nodeP (leafP tok_send) ppToMaryP)))
 
 -- Oblique dative c-command predictions
 
 theorem oblique_do_ccommands_goal :
-    SyntacticObject.cCommandsIn obliqueDativeTree DP_letter DP_mary := by decide
+    cCommandsIn obliqueDativeTree DP_letter DP_mary := by decide
 
 theorem oblique_goal_not_ccommands_do :
-    ¬ SyntacticObject.cCommandsIn obliqueDativeTree DP_mary DP_letter := by decide
+    ¬ cCommandsIn obliqueDativeTree DP_mary DP_letter := by decide
 
 theorem oblique_agent_ccommands_both :
-    SyntacticObject.cCommandsIn obliqueDativeTree DP_john DP_letter ∧
-    SyntacticObject.cCommandsIn obliqueDativeTree DP_john DP_mary := by
+    cCommandsIn obliqueDativeTree DP_john DP_letter ∧
+    cCommandsIn obliqueDativeTree DP_john DP_mary := by
   constructor <;> decide
 
 -- ============================================================================
@@ -168,10 +167,10 @@ Derivation steps:
    This promotes Mary above the direct object.
 4. EM-L the agent `John` -/
 
-def docDativeShift : SyntacticObject.Derivation :=
+def docDativeShift : Derivation :=
   { initial := V_send
     steps := [
-      .emR (SyntacticObject.ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .im DP_mary,                    -- DATIVE SHIFT: Mary moves to Spec
       .emL DP_john                    -- [VP John [VP Mary_i [VP a_letter ...]]]
@@ -181,12 +180,12 @@ def docDativeShift : SyntacticObject.Derivation :=
     the shell, asymmetrically c-commanding the theme; the original Mary
     position is the bare trace. `[John [Mary [letter [send [to t]]]]]`. -/
 def docDativeShiftTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_john)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_mary)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_letter)
-          (SyntacticObject.nodeP (SyntacticObject.leafP tok_send)
-            (SyntacticObject.nodeP (SyntacticObject.leafP tok_to) SyntacticObject.traceP)))))
+  ofPlanar
+    (nodeP (leafP tok_john)
+      (nodeP (leafP tok_mary)
+        (nodeP (leafP tok_letter)
+          (nodeP (leafP tok_send)
+            (nodeP (leafP tok_to) traceP)))))
 
 -- DOC c-command predictions: the asymmetries are REVERSED
 
@@ -197,15 +196,15 @@ def docDativeShiftTree : SyntacticObject :=
     - Quantifier binding: "I gave every worker his paycheck"
     - Weak crossover, superiority, *each...the other*, NPI licensing -/
 theorem doc_io_ccommands_do :
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter := by decide
+    cCommandsIn docDativeShiftTree DP_mary DP_letter := by decide
 
 /-- The direct object does NOT c-command the indirect object in the DOC. -/
 theorem doc_do_not_ccommands_io :
-    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary := by decide
+    ¬ cCommandsIn docDativeShiftTree DP_letter DP_mary := by decide
 
 theorem doc_agent_ccommands_both :
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_john DP_mary ∧
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_john DP_letter := by
+    cCommandsIn docDativeShiftTree DP_john DP_mary ∧
+    cCommandsIn docDativeShiftTree DP_john DP_letter := by
   constructor <;> decide
 
 -- ============================================================================
@@ -217,7 +216,7 @@ the object moves to subject position. By using the same `SyntacticObject.Step.im
 constructor, the type system enforces Larson's thesis that Passive
 and Dative Shift share the same structural operation. -/
 
-def standardPassive : SyntacticObject.Derivation :=
+def standardPassive : Derivation :=
   { initial := V_kick
     steps := [
       .emR DP_ball,   -- [V' kicked [DP the ball]]
@@ -228,18 +227,18 @@ def standardPassive : SyntacticObject.Derivation :=
 /-- The passive result tree: the ball (promoted) sits above John (demoted),
     leaving a trace in object position. `[ball [John [kicked t]]]`. -/
 def standardPassiveTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_ball)
-      (SyntacticObject.nodeP (SyntacticObject.leafP tok_john)
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_kick) SyntacticObject.traceP)))
+  ofPlanar
+    (nodeP (leafP tok_ball)
+      (nodeP (leafP tok_john)
+        (nodeP (leafP tok_kick) traceP)))
 
 -- Passive c-command: promoted object c-commands demoted subject
 
 theorem passive_object_ccommands_subject :
-    SyntacticObject.cCommandsIn standardPassiveTree DP_ball DP_john := by decide
+    cCommandsIn standardPassiveTree DP_ball DP_john := by decide
 
 theorem passive_subject_not_ccommands_object :
-    ¬ SyntacticObject.cCommandsIn standardPassiveTree DP_john DP_ball := by decide
+    ¬ cCommandsIn standardPassiveTree DP_john DP_ball := by decide
 
 -- ============================================================================
 -- § 5: Structural Parallel — Passive and Dative Shift
@@ -266,9 +265,9 @@ theorem passive_has_one_im :
     Passive:         Obj > Subj (ball c-commands John)  [reversed by SyntacticObject.Step.im] -/
 theorem passive_dativeShift_parallel :
     -- Both reverse c-command via the same SyntacticObject.Step.im mechanism
-    SyntacticObject.cCommandsIn obliqueDativeTree DP_letter DP_mary ∧
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
-    SyntacticObject.cCommandsIn standardPassiveTree DP_ball DP_john := by
+    cCommandsIn obliqueDativeTree DP_letter DP_mary ∧
+    cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    cCommandsIn standardPassiveTree DP_ball DP_john := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 -- ============================================================================
@@ -326,8 +325,8 @@ theorem bl_six_asymmetries : blAsymmetries.length = 6 := rfl
 /-- All six asymmetries are derived from a single structural fact:
     in the DOC, NP1 (IO) asymmetrically c-commands NP2 (DO). -/
 theorem bl_asymmetries_from_ccommand :
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
-    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary := by
+    cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    ¬ cCommandsIn docDativeShiftTree DP_letter DP_mary := by
   constructor <;> decide
 
 -- ============================================================================
@@ -425,9 +424,9 @@ available. The data are recorded in `Bruening2001`
     which records "Someone gave every student a book" as `surfaceOnly`. -/
 theorem doc_scope_freezing_structural_basis :
     -- IO > DO (IO c-commands DO): surface scope available
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
     -- DO ≯ IO (DO does not c-command IO): inverse scope blocked
-    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary := by
+    ¬ cCommandsIn docDativeShiftTree DP_letter DP_mary := by
   constructor <;> decide
 
 -- ============================================================================
@@ -445,10 +444,10 @@ Both routes use the same operations (NP Movement = `SyntacticObject.Step.im`). W
 formalize the two-step route, which produces the same surface
 c-command relations. -/
 
-def V_sent     := SyntacticObject.mkLeafPhon .V [.D]  "was-sent" 320
-def DP_mary2   := SyntacticObject.mkLeafPhon .D []    "Mary"     321
-def DP_letter2 := SyntacticObject.mkLeafPhon .D []    "a letter" 322
-def P_to2      := SyntacticObject.mkLeafPhon .P [.D]  "to"       323
+def V_sent     := mkLeafPhon .V [.D]  "was-sent" 320
+def DP_mary2   := mkLeafPhon .D []    "Mary"     321
+def DP_letter2 := mkLeafPhon .D []    "a letter" 322
+def P_to2      := mkLeafPhon .P [.D]  "to"       323
 
 private def tok_sent    : LIToken := ⟨.simple .V [.D] (phonForm := "was-sent"), 320⟩
 private def tok_mary2   : LIToken := ⟨.simple .D [] (phonForm := "Mary"), 321⟩
@@ -461,11 +460,10 @@ private def tok_to2     : LIToken := ⟨.simple .P [.D] (phonForm := "to"), 323�
     1. Build oblique dative base: [VP a_letter [V' send [PP to Mary]]]
     2. Dative Shift (IM Mary): Mary promotes to inner Spec
     3. Passive (IM Mary again): Mary promotes to outer Spec (subject) -/
-def indirectPassive : SyntacticObject.Derivation :=
+def indirectPassive : Derivation :=
   { initial := V_sent
     steps := [
-      .emR (SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tok_to2)
-        (SyntacticObject.leafP tok_mary2))),
+      .emR (ofPlanar (nodeP (leafP tok_to2) (leafP tok_mary2))),
                        -- [V' sent [PP to Mary]]
       .emL DP_letter2, -- [VP a_letter [V' sent [PP to Mary]]]
       .im DP_mary2,    -- DATIVE SHIFT: Mary to inner Spec
@@ -483,17 +481,17 @@ def indirectPassive : SyntacticObject.Derivation :=
     intermediate landing site; it gives the same Mary-c-commands-letter
     asymmetry but is *not* what the two-step derivation emits.) -/
 def indirectPassiveTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP tok_mary2)
-      (SyntacticObject.nodeP SyntacticObject.traceP
-        (SyntacticObject.nodeP (SyntacticObject.leafP tok_letter2)
-          (SyntacticObject.nodeP (SyntacticObject.leafP tok_sent)
-            (SyntacticObject.nodeP (SyntacticObject.leafP tok_to2) SyntacticObject.traceP)))))
+  ofPlanar
+    (nodeP (leafP tok_mary2)
+      (nodeP traceP
+        (nodeP (leafP tok_letter2)
+          (nodeP (leafP tok_sent)
+            (nodeP (leafP tok_to2) traceP)))))
 
 /-- In the indirect passive, the promoted IO (Mary) c-commands the
     stranded DO (a letter). -/
 theorem indirect_passive_io_ccommands_do :
-    SyntacticObject.cCommandsIn indirectPassiveTree DP_mary2 DP_letter2 := by decide
+    cCommandsIn indirectPassiveTree DP_mary2 DP_letter2 := by decide
 
 /-- The indirect passive uses two Internal Merge steps:
     Dative Shift + Passive — both are `SyntacticObject.Step.im`. -/

--- a/Linglib/Studies/MarcolliChomskyBerwick2025.lean
+++ b/Linglib/Studies/MarcolliChomskyBerwick2025.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Linearization.Externalization
+
+/-!
+# Externalization examples from Marcolli–Chomsky–Berwick
+
+`decide`-checked worked examples of [marcolli-chomsky-berwick-2025] §1.12.1/§1.13
+externalization on the `SyntacticObject` carrier: the harmonic head-initial and
+head-final orders of a determiner–noun Merge (the head-side convention flips the
+yield), and exocentric elimination — two saturated nouns determine no head and no
+order (§1.13.2).
+
+The book's framework itself is the `Syntax/Minimalist/` theory layer; this file
+holds its concrete examples, kernel-checked against that substrate.
+-/
+
+namespace MarcolliChomskyBerwick2025
+
+open RootedTree Minimalist SyntacticObject
+
+/-- A determiner over a noun: `D` selects `N`, so `D` projects. -/
+private def theDog : SyntacticObject :=
+  ⟨Nonplanar.mk (.node (Sum.inr ())
+    [.node (Sum.inl ⟨.simple .D [.N] (phonForm := "the"), 0⟩) [],
+     .node (Sum.inl ⟨.simple .N [] (phonForm := "dog"), 1⟩) []]), by decide⟩
+
+/-- Harmonic head-initial: the projecting `D`'s yield comes first. -/
+example : (theDog.linearize .initial).map (·.map (·.id)) = some [0, 1] := by decide
+
+/-- Harmonic head-final: the same head function, mirrored. -/
+example : (theDog.linearize .final).map (·.map (·.id)) = some [1, 0] := by decide
+
+example : theDog.phonYield .initial = some ["the", "dog"] := by decide
+example : theDog.phonYield .final = some ["dog", "the"] := by decide
+
+/-- Exocentric Merge: two saturated `N`s, neither selecting the other — no head,
+    no order ([marcolli-chomsky-berwick-2025] §1.13.2). -/
+private def exoNN : SyntacticObject :=
+  ⟨Nonplanar.mk (.node (Sum.inr ())
+    [.node (Sum.inl ⟨.simple .N [] (phonForm := "cats"), 0⟩) [],
+     .node (Sum.inl ⟨.simple .N [] (phonForm := "dogs"), 1⟩) []]), by decide⟩
+
+example : exoNN.linearize .initial = none := by decide
+example : exoNN.linearize .final = none := by decide
+
+end MarcolliChomskyBerwick2025

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -47,6 +47,8 @@ and to support qualified lookup if a future paper picks them up.
 
 namespace Minimalist.CMH
 
+open SyntacticObject
+
 -- ============================================================================
 -- § 1: Merge Features
 -- ============================================================================
@@ -379,7 +381,7 @@ private def isKLeaf (s : SyntacticObject) : Bool :=
     left/right symmetry is automatic. TODO Phase 2: refine via
     head-function-aware projection (`SyntacticObject.selHead`). -/
 private def isKP (s : SyntacticObject) : Prop :=
-  ∃ d, SyntacticObject.immediatelyContains s d ∧ isKLeaf d
+  ∃ d, immediatelyContains s d ∧ isKLeaf d
 
 /-! #### `isKP` detection — positive and negative witnesses
 
@@ -394,29 +396,25 @@ private def kProbeV  : LIToken := ⟨.simple .V [.D] (phonForm := "see"), 902⟩
 
 /-- A K-headed leaf is detected by `isKLeaf`; a D-headed leaf is not. -/
 private theorem isKLeaf_detects :
-    isKLeaf (SyntacticObject.lexLeaf kProbeK) = true ∧
-      isKLeaf (SyntacticObject.lexLeaf kProbeD) = false := by
+    isKLeaf (lexLeaf kProbeK) = true ∧ isKLeaf (lexLeaf kProbeD) = false := by
   decide
 
 /-- Positive: `[K DP]` (a K daughter present) is a KP. -/
 private theorem isKP_detects_kp :
-    isKP (SyntacticObject.node (SyntacticObject.lexLeaf kProbeK)
-      (SyntacticObject.lexLeaf kProbeD)) :=
-  ⟨SyntacticObject.lexLeaf kProbeK,
-    (SyntacticObject.immediatelyContains_node _ _ _).mpr (Or.inl rfl), by decide⟩
+    isKP (node (lexLeaf kProbeK) (lexLeaf kProbeD)) :=
+  ⟨lexLeaf kProbeK, (immediatelyContains_node _ _ _).mpr (Or.inl rfl), by decide⟩
 
 /-- Negative: `[V DP]` (no K daughter) is not a KP. -/
 private theorem isKP_rejects_non_kp :
-    ¬ isKP (SyntacticObject.node (SyntacticObject.lexLeaf kProbeV)
-      (SyntacticObject.lexLeaf kProbeD)) := by
+    ¬ isKP (node (lexLeaf kProbeV) (lexLeaf kProbeD)) := by
   rintro ⟨d, hd, hk⟩
-  rw [SyntacticObject.immediatelyContains_node] at hd
+  rw [immediatelyContains_node] at hd
   rcases hd with rfl | rfl <;> exact absurd hk (by decide)
 
 /-- Negative: a bare K *leaf* is a K head, not a KP — it has no daughters. -/
-private theorem isKP_rejects_bare_K_leaf : ¬ isKP (SyntacticObject.lexLeaf kProbeK) := by
+private theorem isKP_rejects_bare_K_leaf : ¬ isKP (lexLeaf kProbeK) := by
   rintro ⟨d, hd, _⟩
-  exact (SyntacticObject.immediatelyContains_lexLeaf kProbeK d) hd
+  exact (immediatelyContains_lexLeaf kProbeK d) hd
 
 -- ============================================================================
 -- § 9: Anti-Redundancy in Agreement
@@ -461,6 +459,7 @@ end Minimalist.CMH
 namespace Newman2024
 
 open Minimalist Minimalist.CMH
+open SyntacticObject
 
 -- ============================================================================
 -- § 1: The Space of Possible vPs
@@ -769,10 +768,10 @@ private def DO₁ : LIToken := tok .D "DO" 13
 private def XP₁ : LIToken := tok .P "to-Mary" 14
 
 def lowXPTree : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP agent₁)
-    (SyntacticObject.nodeP (SyntacticObject.leafP v₁)
-      (SyntacticObject.nodeP (SyntacticObject.leafP DO₁)
-        (SyntacticObject.nodeP (SyntacticObject.leafP V₁) (SyntacticObject.leafP XP₁)))))
+  ofPlanar (nodeP (leafP agent₁)
+    (nodeP (leafP v₁)
+      (nodeP (leafP DO₁)
+        (nodeP (leafP V₁) (leafP XP₁)))))
 
 -- DOC ditransitive: V: [·D·], v: [·D·][·X·][·V·]
 -- Structure: [vP VP [vP agent [v' v IO]]]
@@ -786,10 +785,9 @@ private def DO₂ : LIToken := tok .D "DO" 23
 private def IO₂ : LIToken := tok .D "IO" 24
 
 def docTree : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP
-    (SyntacticObject.nodeP (SyntacticObject.leafP V₂) (SyntacticObject.leafP DO₂))
-    (SyntacticObject.nodeP (SyntacticObject.leafP agent₂)
-      (SyntacticObject.nodeP (SyntacticObject.leafP v₂) (SyntacticObject.leafP IO₂))))
+  ofPlanar (nodeP (nodeP (leafP V₂) (leafP DO₂))
+    (nodeP (leafP agent₂)
+      (nodeP (leafP v₂) (leafP IO₂))))
 
 -- § 10a: Internal argument binding asymmetry
 
@@ -797,38 +795,30 @@ def docTree : SyntacticObject :=
     DO (specifier of V, by Non-DP First) c-commands into the
     complement position. -/
 theorem low_xp_DO_ccommands_XP :
-    SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf DO₁)
-      (SyntacticObject.lexLeaf XP₁) := by decide
+    cCommandsIn lowXPTree (lexLeaf DO₁) (lexLeaf XP₁) := by decide
 
 theorem low_xp_XP_not_ccommands_DO :
-    ¬ SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf XP₁)
-      (SyntacticObject.lexLeaf DO₁) := by decide
+    ¬ cCommandsIn lowXPTree (lexLeaf XP₁) (lexLeaf DO₁) := by decide
 
 /-- DOC: neither internal argument c-commands the other — symmetric.
     DO is inside VP (outer specifier), IO is complement of v.
     They are in separate branches. -/
 theorem doc_DO_not_ccommands_IO :
-    ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf DO₂)
-      (SyntacticObject.lexLeaf IO₂) := by decide
+    ¬ cCommandsIn docTree (lexLeaf DO₂) (lexLeaf IO₂) := by decide
 
 theorem doc_IO_not_ccommands_DO :
-    ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf IO₂)
-      (SyntacticObject.lexLeaf DO₂) := by decide
+    ¬ cCommandsIn docTree (lexLeaf IO₂) (lexLeaf DO₂) := by decide
 
 /-- The structural asymmetry derived from VP-as-specifier:
     VP-as-complement gives binding asymmetry between internal
     arguments; VP-as-specifier gives symmetric binding. -/
 theorem binding_asymmetry_iff_vp_complement :
     -- Low-XP (VP complement): DO c-commands XP, not vice versa
-    (SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf DO₁)
-        (SyntacticObject.lexLeaf XP₁) ∧
-     ¬ SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf XP₁)
-        (SyntacticObject.lexLeaf DO₁)) ∧
+    (cCommandsIn lowXPTree (lexLeaf DO₁) (lexLeaf XP₁) ∧
+     ¬ cCommandsIn lowXPTree (lexLeaf XP₁) (lexLeaf DO₁)) ∧
     -- DOC (VP specifier): neither c-commands the other
-    (¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf DO₂)
-        (SyntacticObject.lexLeaf IO₂) ∧
-     ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf IO₂)
-        (SyntacticObject.lexLeaf DO₂)) := by
+    (¬ cCommandsIn docTree (lexLeaf DO₂) (lexLeaf IO₂) ∧
+     ¬ cCommandsIn docTree (lexLeaf IO₂) (lexLeaf DO₂)) := by
   refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> decide
 
 -- § 10b: Agent c-command differences
@@ -836,23 +826,19 @@ theorem binding_asymmetry_iff_vp_complement :
 /-- In the low-XP structure, the agent c-commands both internal
     arguments (VP is complement, fully inside agent's sister). -/
 theorem low_xp_agent_ccommands_DO :
-    SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf agent₁)
-      (SyntacticObject.lexLeaf DO₁) := by decide
+    cCommandsIn lowXPTree (lexLeaf agent₁) (lexLeaf DO₁) := by decide
 
 theorem low_xp_agent_ccommands_XP :
-    SyntacticObject.cCommandsIn lowXPTree (SyntacticObject.lexLeaf agent₁)
-      (SyntacticObject.lexLeaf XP₁) := by decide
+    cCommandsIn lowXPTree (lexLeaf agent₁) (lexLeaf XP₁) := by decide
 
 /-- In the DOC structure with Tucking In, the agent (inner specifier)
     c-commands IO (complement of v) but NOT DO (inside VP, the outer
     specifier). The agent and VP are in separate branches — a direct
     consequence of VP being a specifier rather than a complement. -/
 theorem doc_agent_ccommands_IO :
-    SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf agent₂)
-      (SyntacticObject.lexLeaf IO₂) := by decide
+    cCommandsIn docTree (lexLeaf agent₂) (lexLeaf IO₂) := by decide
 
 theorem doc_agent_not_ccommands_DO :
-    ¬ SyntacticObject.cCommandsIn docTree (SyntacticObject.lexLeaf agent₂)
-      (SyntacticObject.lexLeaf DO₂) := by decide
+    ¬ cCommandsIn docTree (lexLeaf agent₂) (lexLeaf DO₂) := by decide
 
 end Newman2024

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -48,7 +48,7 @@ as formalized siblings; bibliography backlog).
 
 namespace Pietraszko2026
 
-open Minimalist
+open Minimalist SyntacticObject
 
 /-! ## Notes
 
@@ -149,14 +149,14 @@ def subjectTraceToken : LIToken :=
   { item := LexicalItem.simple .D [], id := idSubjectTrace }
 
 /-- The subject DP at its base position (Spec,vP). Class 1 (uZondi). -/
-def subjectAtBase : SyntacticObject := SyntacticObject.lexLeaf subjectToken
+def subjectAtBase : SyntacticObject := lexLeaf subjectToken
 
 /-- The subject DP after movement to Spec,VoiceP (a fresh copy, since
     each `LIToken` in copy theory is a distinct token). -/
-def subjectAtSpecVoiceP : SyntacticObject := SyntacticObject.lexLeaf subjectToken
+def subjectAtSpecVoiceP : SyntacticObject := lexLeaf subjectToken
 
 /-- A trace at the base position after movement (distinct LIToken). -/
-def subjectTrace : SyntacticObject := SyntacticObject.lexLeaf subjectTraceToken
+def subjectTrace : SyntacticObject := lexLeaf subjectTraceToken
 
 /-! The trees below are built **planar-first** via the DSL (`SyntacticObject.ofPlanar`
     / `SyntacticObject.nodeP` / `SyntacticObject.leafP`) because the smart Merge
@@ -168,18 +168,17 @@ def subjectTrace : SyntacticObject := SyntacticObject.lexLeaf subjectTraceToken
     Structure: `voice (subject v)`. Voice is the phase; its complement
     is the entire vP, which contains the subject. -/
 def voiceP_noSpec : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
-    (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken) (SyntacticObject.leafP vToken)))
+  ofPlanar (nodeP (leafP voiceToken)
+    (nodeP (leafP subjectToken) (leafP vToken)))
 
 /-- The Voice projection with subject at Spec,VoiceP (phase edge).
     Structure: `subject (voice (trace v))`. The OUTER node is not the
     phase; the inner `voice (trace v)` is the phase, and the subject
     (sister to it) is at the edge. -/
 def voiceP_withSpec : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken)
-    (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
-      (SyntacticObject.nodeP (SyntacticObject.leafP subjectTraceToken)
-        (SyntacticObject.leafP vToken))))
+  ofPlanar (nodeP (leafP subjectToken)
+    (nodeP (leafP voiceToken)
+      (nodeP (leafP subjectTraceToken) (leafP vToken))))
 
 /-- The Voice phase for `voiceP_noSpec`: phase head `voiceToken`, tree
     `voiceP_noSpec`. Its interior (= the head's c-command domain, the
@@ -196,23 +195,21 @@ def voicePhase_withSpec : Phase :=
 
 /-- The full Aux-V tree (T > Asp > Voice > vP) with subject in situ. -/
 def auxVTree_inSitu : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tToken)
-    (SyntacticObject.nodeP (SyntacticObject.leafP aspToken)
-      (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
-        (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken)
-          (SyntacticObject.leafP vToken)))))
+  ofPlanar (nodeP (leafP tToken)
+    (nodeP (leafP aspToken)
+      (nodeP (leafP voiceToken)
+        (nodeP (leafP subjectToken) (leafP vToken)))))
 
 /-- The full Aux-V tree with subject moved to Spec,VoiceP. T's probe will
     additionally attract the subject to Spec,TP — that movement is the
     derivational step we don't model here; the salient question is just
     whether T's probe *finds* the subject under PIC. -/
 def auxVTree_subjectMoved : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP tToken)
-    (SyntacticObject.nodeP (SyntacticObject.leafP aspToken)
-      (SyntacticObject.nodeP (SyntacticObject.leafP subjectToken)
-        (SyntacticObject.nodeP (SyntacticObject.leafP voiceToken)
-          (SyntacticObject.nodeP (SyntacticObject.leafP subjectTraceToken)
-            (SyntacticObject.leafP vToken))))))
+  ofPlanar (nodeP (leafP tToken)
+    (nodeP (leafP aspToken)
+      (nodeP (leafP subjectToken)
+        (nodeP (leafP voiceToken)
+          (nodeP (leafP subjectTraceToken) (leafP vToken))))))
 
 end Sample
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -65,7 +65,7 @@ in the "Applicative diagnostics" section below.
 
 namespace Pylkkanen2008
 
-open Minimalist
+open Minimalist SyntacticObject
 open RootedTree
 
 /-! ### Voice projection (relocated from Minimalist/VoiceProjection.lean)
@@ -350,16 +350,16 @@ theorem inapplicable_with_fails_classifies_low :
 -- § 1: Lexical Items
 -- ============================================================================
 
-def voice_ag_t  := SyntacticObject.mkLeafPhon .Voice [.V]    "Voice[AG]"  400
-def appl_low_t  := SyntacticObject.mkLeafPhon .Appl  [.D]    "Appl[LOW]"  402
-def appl_high_t := SyntacticObject.mkLeafPhon .Appl  [.V]    "Appl[HI]"   403
-def V_sent_t    := SyntacticObject.mkLeafPhon .V     [.Appl] "sent"        404
-def V_eat_t     := SyntacticObject.mkLeafPhon .V     [.D]    "eat"         405
-def DP_john_t   := SyntacticObject.mkLeafPhon .D     []      "John"        406
-def DP_mary_t   := SyntacticObject.mkLeafPhon .D     []      "Mary"        407
-def DP_letter_t := SyntacticObject.mkLeafPhon .D     []      "a letter"    408
-def DP_wife_t   := SyntacticObject.mkLeafPhon .D     []      "wife"        409
-def DP_food_t   := SyntacticObject.mkLeafPhon .D     []      "food"        410
+def voice_ag_t  := mkLeafPhon .Voice [.V]    "Voice[AG]"  400
+def appl_low_t  := mkLeafPhon .Appl  [.D]    "Appl[LOW]"  402
+def appl_high_t := mkLeafPhon .Appl  [.V]    "Appl[HI]"   403
+def V_sent_t    := mkLeafPhon .V     [.Appl] "sent"        404
+def V_eat_t     := mkLeafPhon .V     [.D]    "eat"         405
+def DP_john_t   := mkLeafPhon .D     []      "John"        406
+def DP_mary_t   := mkLeafPhon .D     []      "Mary"        407
+def DP_letter_t := mkLeafPhon .D     []      "a letter"    408
+def DP_wife_t   := mkLeafPhon .D     []      "wife"        409
+def DP_food_t   := mkLeafPhon .D     []      "food"        410
 
 /-! Planar leaf tokens, used to build the concrete trees the c-command
     theorems reason over (Merge `SyntacticObject.node` is noncomputable; trees are
@@ -390,13 +390,12 @@ private def t_DP_food   : LIToken := ⟨.simple .D [] (phonForm := "food"), 410�
     asymmetry that IO asymmetrically c-commands DO. Built planar-first
     so the c-command theorems `decide`. -/
 def ditransitiveTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_john)
-      (SyntacticObject.nodeP (SyntacticObject.leafP t_voice_ag)
-        (SyntacticObject.nodeP (SyntacticObject.leafP t_V_sent)
-          (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_mary)
-            (SyntacticObject.nodeP (SyntacticObject.leafP t_appl_low)
-              (SyntacticObject.leafP t_DP_letter))))))
+  ofPlanar
+    (nodeP (leafP t_DP_john)
+      (nodeP (leafP t_voice_ag)
+        (nodeP (leafP t_V_sent)
+          (nodeP (leafP t_DP_mary)
+            (nodeP (leafP t_appl_low) (leafP t_DP_letter))))))
 
 /-- High applicative benefactive (Chaga pattern): "he ate food for wife"
 
@@ -407,13 +406,12 @@ def ditransitiveTree : SyntacticObject :=
     theme). High Appl is attested in Bantu languages (Chaga, Luganda,
     Venda) and Albanian, but NOT in English. -/
 def benefactiveTree : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_john)
-      (SyntacticObject.nodeP (SyntacticObject.leafP t_voice_ag)
-        (SyntacticObject.nodeP (SyntacticObject.leafP t_DP_wife)
-          (SyntacticObject.nodeP (SyntacticObject.leafP t_appl_high)
-            (SyntacticObject.nodeP (SyntacticObject.leafP t_V_eat)
-              (SyntacticObject.leafP t_DP_food))))))
+  ofPlanar
+    (nodeP (leafP t_DP_john)
+      (nodeP (leafP t_voice_ag)
+        (nodeP (leafP t_DP_wife)
+          (nodeP (leafP t_appl_high)
+            (nodeP (leafP t_V_eat) (leafP t_DP_food))))))
 
 -- ============================================================================
 -- § 3: C-command Predictions
@@ -423,40 +421,40 @@ def benefactiveTree : SyntacticObject :=
 
 /-- Agent c-commands goal. -/
 theorem ditransitive_agent_ccommands_goal :
-    SyntacticObject.cCommandsIn ditransitiveTree DP_john_t DP_mary_t := by decide
+    cCommandsIn ditransitiveTree DP_john_t DP_mary_t := by decide
 
 /-- Agent c-commands theme. -/
 theorem ditransitive_agent_ccommands_theme :
-    SyntacticObject.cCommandsIn ditransitiveTree DP_john_t DP_letter_t := by decide
+    cCommandsIn ditransitiveTree DP_john_t DP_letter_t := by decide
 
 /-- Goal c-commands theme — the [barss-lasnik-1986] asymmetry
     derived structurally from V selecting ApplP. -/
 theorem ditransitive_goal_ccommands_theme :
-    SyntacticObject.cCommandsIn ditransitiveTree DP_mary_t DP_letter_t := by decide
+    cCommandsIn ditransitiveTree DP_mary_t DP_letter_t := by decide
 
 /-- Theme does NOT c-command goal: the asymmetry is structural. -/
 theorem ditransitive_theme_not_ccommands_goal :
-    ¬ SyntacticObject.cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by decide
+    ¬ cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by decide
 
 -- Benefactive (high Appl): benefactive > theme
 
 /-- Benefactive c-commands theme. -/
 theorem benefactive_benef_ccommands_theme :
-    SyntacticObject.cCommandsIn benefactiveTree DP_wife_t DP_food_t := by decide
+    cCommandsIn benefactiveTree DP_wife_t DP_food_t := by decide
 
 /-- Theme does NOT c-command benefactive. -/
 theorem benefactive_theme_not_ccommands_benef :
-    ¬ SyntacticObject.cCommandsIn benefactiveTree DP_food_t DP_wife_t := by decide
+    ¬ cCommandsIn benefactiveTree DP_food_t DP_wife_t := by decide
 
 -- Appl head containment
 
 /-- Low applicative marks the ditransitive. -/
 theorem send_is_low_appl :
-    SyntacticObject.contains ditransitiveTree appl_low_t := by decide
+    contains ditransitiveTree appl_low_t := by decide
 
 /-- High applicative marks the benefactive. -/
 theorem eat_is_high_appl :
-    SyntacticObject.contains benefactiveTree appl_high_t := by decide
+    contains benefactiveTree appl_high_t := by decide
 
 -- ============================================================================
 -- § 4: ApplType Association
@@ -659,11 +657,11 @@ open Larson1988 in
     the `SyntacticObject` carrier.) -/
 theorem larson_modern_same_hierarchy :
     -- Larson's DOC: IO > DO
-    SyntacticObject.cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
-    ¬ SyntacticObject.cCommandsIn docDativeShiftTree DP_letter DP_mary ∧
+    cCommandsIn docDativeShiftTree DP_mary DP_letter ∧
+    ¬ cCommandsIn docDativeShiftTree DP_letter DP_mary ∧
     -- Modern Voice/Appl: goal > theme (same asymmetry)
-    SyntacticObject.cCommandsIn ditransitiveTree DP_mary_t DP_letter_t ∧
-    ¬ SyntacticObject.cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by
+    cCommandsIn ditransitiveTree DP_mary_t DP_letter_t ∧
+    ¬ cCommandsIn ditransitiveTree DP_letter_t DP_mary_t := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 /-! ## §7. Voice as the head that introduces the external argument

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -331,21 +331,21 @@ theorem guebie_PIC_admits_remnant_movement (φ : Minimalist.Phase)
 
 open Minimalist (SyntacticObject LIToken LexicalItem SyntacticObject)
 open Minimalist.Movement (RemnantFronting PredicateDoubling properRemnant)
+open Minimalist.SyntacticObject
 
 /-- A schematic verb leaf for the `PredicateDoubling` witness. -/
 private def guebieVerbTok : LIToken := ⟨.simple .V [], 1⟩
-private def guebieVerbLeaf : SyntacticObject := SyntacticObject.lexLeaf guebieVerbTok
+private def guebieVerbLeaf : SyntacticObject := lexLeaf guebieVerbTok
 
 /-- A schematic remnant-VP node containing the verb leaf as a trace
     pronounced for recoverability. Built planar-first (the smart
     `SyntacticObject.node` is noncomputable) so the `decide` proofs below reduce. -/
 private def guebieFrontedVP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP guebieVerbTok)
-    (SyntacticObject.leafP guebieVerbTok))
+  ofPlanar (nodeP (leafP guebieVerbTok) (leafP guebieVerbTok))
 
 /-- A schematic landing-site leaf (Spec,CP). -/
 private def guebieLandingTok : LIToken := ⟨.simple .C [], 2⟩
-private def guebieLandingSite : SyntacticObject := SyntacticObject.lexLeaf guebieLandingTok
+private def guebieLandingSite : SyntacticObject := lexLeaf guebieLandingTok
 
 /-- The Guébie predicate-fronting witness: V evacuates the VP, and
     the remnant VP fronts to Spec,CP. The trace is pronounced — verb
@@ -398,7 +398,7 @@ def guebieVPCophonology : PhrasalCophonology Unit Unit :=
     SyntacticObject whose token's category is `.v`.) -/
 theorem guebieVPCophonology_applies_to_v :
     let vTok : LIToken := ⟨.simple .v [], 99⟩
-    let vHead : SyntacticObject := SyntacticObject.lexLeaf vTok
+    let vHead : SyntacticObject := lexLeaf vTok
     let vPhase : Minimalist.Phase := { tree := vHead, head := vTok }
     guebieVPCophonology.appliesTo vPhase = true := by decide
 
@@ -424,7 +424,7 @@ open Minimalist (VerbDoublingIsSyntacticIn)
 /-- A schematic Guébie Derivation: the verb undergoes Internal Merge
     in the predicate-fronting derivation (per SCD 2026 §3 island
     diagnostics establishing this is narrow-syntactic, not PF). -/
-def guebieFrontingDerivation : Minimalist.SyntacticObject.Derivation :=
+def guebieFrontingDerivation : Derivation :=
   { initial := guebieFrontedVP
     steps   := [.im guebieVerbLeaf] }
 

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -43,7 +43,7 @@ This captures e.g. Mam's Infl probe, which has satisfaction condition
 
 namespace Minimalist
 
-open Features.Prominence
+open Features.Prominence SyntacticObject
 
 -- ============================================================================
 -- § 1: Extended Lexical Items with Features
@@ -84,7 +84,7 @@ structure AgreeRelation where
 
 /-- The probe c-commands the goal within a given tree -/
 def AgreeRelation.probeCommands (a : AgreeRelation) (root : SyntacticObject) : Prop :=
-  SyntacticObject.cCommandsIn root a.probe a.goal
+  cCommandsIn root a.probe a.goal
 
 /-- The goal has the relevant valued feature -/
 def AgreeRelation.goalHasFeature (a : AgreeRelation) : Bool :=
@@ -117,11 +117,10 @@ def validAgree (a : AgreeRelation) (root : SyntacticObject) : Prop :=
     `pred`-matching node c-commanded by `probe` c-commanding `goal`. -/
 def closestGoalB (root probe goal : SyntacticObject)
     (pred : SyntacticObject → Bool) : Bool :=
-  decide (SyntacticObject.cCommandsIn root probe goal) &&
+  decide (cCommandsIn root probe goal) &&
   pred goal &&
   (! @decide (∃ x ∈ root.subtrees,
-    x ≠ goal ∧ pred x = true ∧
-    SyntacticObject.cCommandsIn root probe x ∧ SyntacticObject.cCommandsIn root x goal)
+    x ≠ goal ∧ pred x = true ∧ cCommandsIn root probe x ∧ cCommandsIn root x goal)
     Multiset.decidableExistsMultiset)
 
 -- ============================================================================
@@ -130,14 +129,14 @@ def closestGoalB (root probe goal : SyntacticObject)
 
 /-- Per-vertex horizon predicate: leaf with category = horizonCat. -/
 private def isHorizonLeafFor (horizonCat : Cat) (n : SyntacticObject) : Prop :=
-  match SyntacticObject.getLIToken n with
+  match getLIToken n with
   | some tok => tok.item.outerCat = horizonCat
   | none => False
 
 instance (horizonCat : Cat) (n : SyntacticObject) :
     Decidable (isHorizonLeafFor horizonCat n) := by
   unfold isHorizonLeafFor
-  cases SyntacticObject.getLIToken n <;> infer_instance
+  cases getLIToken n <;> infer_instance
 
 /-- Is `target` behind a horizon of category `horizonCat` relative to
     `probe` in tree `root`?
@@ -161,9 +160,7 @@ instance (horizonCat : Cat) (n : SyntacticObject) :
 def behindHorizonB (root probe target : SyntacticObject)
     (horizonCat : Cat) : Bool :=
   @decide (∃ n ∈ root.subtrees,
-    isHorizonLeafFor horizonCat n ∧
-    SyntacticObject.cCommandsIn root n target ∧
-    SyntacticObject.cCommandsIn root probe n)
+    isHorizonLeafFor horizonCat n ∧ cCommandsIn root n target ∧ cCommandsIn root probe n)
     Multiset.decidableExistsMultiset
 
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/Economy.lean
+++ b/Linglib/Syntax/Minimalist/Economy.lean
@@ -114,7 +114,7 @@ end DerivationCost
     numeration draw.)
     `mergeOps`: total step count.
     `agreeOps`/`ellipsisOps`: not tracked by the step-based model. -/
-def SyntacticObject.Derivation.cost (d : SyntacticObject.Derivation) : DerivationCost where
+def SyntacticObject.Derivation.cost (d : Derivation) : DerivationCost where
   lexicalItems :=
     d.steps.filter
       (match · with | .emL _ | .emR _ => true | _ => false)

--- a/Linglib/Syntax/Minimalist/LateMerger.lean
+++ b/Linglib/Syntax/Minimalist/LateMerger.lean
@@ -65,6 +65,8 @@ A/A-bar distinction.
 
 namespace Minimalist
 
+open SyntacticObject
+
 -- ============================================================================
 -- S 1: Generic Late-Merger Bleeding
 -- ============================================================================
@@ -228,7 +230,7 @@ theorem no_case_forces_reconstruction
     `SyntacticObject` trees, complementing the abstract chain-position
     analysis in `wlmForcesReconstruction`. -/
 def conditionCViolation (root binder rExpr : SyntacticObject) : Bool :=
-  decide (SyntacticObject.cCommandsIn root binder rExpr)
+  decide (cCommandsIn root binder rExpr)
 
 /-- Condition C is satisfied in a tree: the binder does NOT c-command
     the R-expression. Takes the tree after any WLM has applied.

--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -23,14 +23,14 @@ the book), c-selection computes the planar order.
   descriptions — the selection state enriched with the yield, `0` off `Dom(h)`; a
   `CommMagma` and `MulZeroClass` under the `side`-indexed Merge-local product.
 * `Minimalist.LinearizationState.sel`: the projection morphism to `SelectionState`.
-* `Minimalist.headHom`: the head function as a morphism of magmas
+* `Minimalist.SyntacticObject.headHom`: the head function as a morphism of magmas
   `SyntacticObject →ₙ* LinearizationState side`, refining `selCheckHom`.
 * `Minimalist.SyntacticObject.linearize`, `Minimalist.SyntacticObject.phonYield`:
   the yield readout and the pronounced surface forms.
 
 ## Main results
 
-* `Minimalist.sel_comp_headHom`: fusion — the selection component of the head
+* `Minimalist.SyntacticObject.sel_comp_headHom`: fusion — the selection component of the head
   function's value is the selection check, by `SyntacticObject.hom_ext`.
 
 ## Implementation notes
@@ -142,87 +142,55 @@ end LinearizationState
 
 /-! ### Externalization on `SyntacticObject` -/
 
+namespace SyntacticObject
+
 variable (side : ConventionDir)
 
-/-- The head function's value on a syntactic object: the `SyntacticObject.liftFun`
-    of pronounced lexical leaves and the silent, saturated trace. -/
-def SyntacticObject.linearizationState (s : SyntacticObject) :
-    LinearizationState side :=
-  SyntacticObject.liftFun (fun tok => .of tok tok.item.outerSel [tok])
-    (.of (mkTraceToken 0) [] []) s
+/-- The head function's value on a syntactic object: the `liftFun` of pronounced
+    lexical leaves and the silent, saturated trace. -/
+def linearizationState (s : SyntacticObject) : LinearizationState side :=
+  liftFun (fun tok => .of tok tok.item.outerSel [tok]) (.of (mkTraceToken 0) [] []) s
 
-@[simp] theorem SyntacticObject.linearizationState_lexLeaf
-    (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).linearizationState side =
-      .of tok tok.item.outerSel [tok] := rfl
+@[simp] theorem linearizationState_lexLeaf (tok : LIToken) :
+    (lexLeaf tok).linearizationState side = .of tok tok.item.outerSel [tok] := rfl
 
-@[simp] theorem SyntacticObject.linearizationState_traceLeaf :
-    SyntacticObject.traceLeaf.linearizationState side = .of (mkTraceToken 0) [] [] := rfl
+@[simp] theorem linearizationState_traceLeaf :
+    traceLeaf.linearizationState side = .of (mkTraceToken 0) [] [] := rfl
 
-@[simp] theorem SyntacticObject.linearizationState_node
-    (l r : SyntacticObject) :
-    (SyntacticObject.node l r).linearizationState side =
+@[simp] theorem linearizationState_node (l r : SyntacticObject) :
+    (node l r).linearizationState side =
       l.linearizationState side * r.linearizationState side :=
-  SyntacticObject.liftFun_node _ _ l r
+  liftFun_node _ _ l r
 
 /-- The head function as a morphism of magmas ([marcolli-chomsky-berwick-2025]
     §1.13's algebraic frame): Merge multiplies constituents, `h` multiplies states. -/
-noncomputable def headHom :
-    SyntacticObject →ₙ* LinearizationState side :=
-  SyntacticObject.lift (fun tok => .of tok tok.item.outerSel [tok])
-    (.of (mkTraceToken 0) [] [])
+noncomputable def headHom : SyntacticObject →ₙ* LinearizationState side :=
+  lift (fun tok => .of tok tok.item.outerSel [tok]) (.of (mkTraceToken 0) [] [])
 
 @[simp] theorem headHom_apply (s : SyntacticObject) :
     headHom side s = s.linearizationState side := rfl
 
 /-- Fusion: the selection component of the head function's value is the selection
-    check — two morphisms agreeing on the leaves (`SyntacticObject.hom_ext`). -/
+    check — two morphisms agreeing on the leaves (`hom_ext`). -/
 theorem sel_comp_headHom :
     LinearizationState.sel.comp (headHom side) = selCheckHom :=
-  SyntacticObject.hom_ext (fun _ => rfl) rfl
+  hom_ext (fun _ => rfl) rfl
 
 /-- The surface token order under head-side convention `side`
     ([marcolli-chomsky-berwick-2025] §1.12.1): the yield readout of the
     linearization state. Not a morphism — placing a yield needs the head. -/
-def SyntacticObject.linearize (s : SyntacticObject) :
-    Option (List LIToken) :=
+def linearize (s : SyntacticObject) : Option (List LIToken) :=
   (s.linearizationState side).yield
 
 /-- The pronounced surface forms: the yield with unpronounced tokens dropped. -/
-def SyntacticObject.phonYield (s : SyntacticObject) :
-    Option (List String) :=
+def phonYield (s : SyntacticObject) : Option (List String) :=
   (s.linearize side).map (·.filterMap LIToken.phonForm?)
 
-@[simp] theorem SyntacticObject.linearize_lexLeaf (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).linearize side = some [tok] := rfl
+@[simp] theorem linearize_lexLeaf (tok : LIToken) :
+    (lexLeaf tok).linearize side = some [tok] := rfl
 
-@[simp] theorem SyntacticObject.linearize_traceLeaf :
-    SyntacticObject.traceLeaf.linearize side = some [] := rfl
+@[simp] theorem linearize_traceLeaf : traceLeaf.linearize side = some [] := rfl
 
-/-! ### `decide` demonstration
-
-The order reduces on concrete `mk`-built trees, the head-side parameter flips it, and
-exocentric Merge is order-undefined. -/
-
-/-- A determiner over a noun: `D` selects `N`, so `D` projects. -/
-private def demoTheDog : SyntacticObject :=
-  ⟨Nonplanar.mk (.node (Sum.inr ())
-    [.node (Sum.inl ⟨.simple .D [.N] (phonForm := "the"), 0⟩) [],
-     .node (Sum.inl ⟨.simple .N [] (phonForm := "dog"), 1⟩) []]), by decide⟩
-
-example : (demoTheDog.linearize .initial).map (·.map (·.id)) = some [0, 1] := by decide
-example : (demoTheDog.linearize .final).map (·.map (·.id)) = some [1, 0] := by decide
-example : demoTheDog.phonYield .initial = some ["the", "dog"] := by decide
-example : demoTheDog.phonYield .final = some ["dog", "the"] := by decide
-
-/-- Exocentric Merge: two saturated `N`s, neither selecting the other — no head, no
-    order. -/
-private def demoExo : SyntacticObject :=
-  ⟨Nonplanar.mk (.node (Sum.inr ())
-    [.node (Sum.inl ⟨.simple .N [] (phonForm := "cats"), 0⟩) [],
-     .node (Sum.inl ⟨.simple .N [] (phonForm := "dogs"), 1⟩) []]), by decide⟩
-
-example : demoExo.linearize .initial = none := by decide
-example : demoExo.linearize .final = none := by decide
+end SyntacticObject
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Linearization/Replay.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Replay.lean
@@ -29,7 +29,7 @@ linearization (`Linearization/Cyclic.lean`).
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
 
 /-! ## Derivation-grounded externalization (computable PF order)
 
@@ -54,8 +54,8 @@ to reproduce attested orders. The `decide` demos below exercise concrete derivat
     `none` for a complex `SyntacticObject` (no recorded internal order). -/
 def SyntacticObject.toPlanarLeaf? (s : SyntacticObject) : Option (RoseTree SOLabel) :=
   match s.getLIToken with
-  | some tok => some (SyntacticObject.leafP tok)
-  | none     => if s = SyntacticObject.traceLeaf then some SyntacticObject.traceP else none
+  | some tok => some (leafP tok)
+  | none     => if s = traceLeaf then some traceP else none
 
 /-- Plain left-to-right token yield of an *already-ordered* planar tree; traces
     (`Sum.inr ()`) are unpronounced and contribute nothing. -/
@@ -91,33 +91,33 @@ def planarReplaceWhereP (p : RoseTree SOLabel → Bool) (rep : RoseTree SOLabel)
 def moveLeftPlanarP (acc : RoseTree SOLabel) (mover : SyntacticObject) :
     Option (RoseTree SOLabel) :=
   (planarFindP? (projEqP mover) acc).map fun s =>
-    SyntacticObject.nodeP s (planarReplaceWhereP (projEqP mover) SyntacticObject.traceP acc)
+    nodeP s (planarReplaceWhereP (projEqP mover) traceP acc)
 
 /-- One externalization step on the ordered accumulator (mirrors `SyntacticObject.Step.apply`). -/
-def externStepP (acc? : Option (RoseTree SOLabel)) (step : SyntacticObject.Step) :
+def externStepP (acc? : Option (RoseTree SOLabel)) (step : Step) :
     Option (RoseTree SOLabel) :=
   acc?.bind fun acc => match step with
-    | .emL item  => item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP p acc)
-    | .emR item  => item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP acc p)
+    | .emL item  => item.toPlanarLeaf?.map (fun p => nodeP p acc)
+    | .emR item  => item.toPlanarLeaf?.map (fun p => nodeP acc p)
     | .im mover  => moveLeftPlanarP acc mover
 
 namespace SyntacticObject.Derivation
 
 /-- The derivation's ordered planar representative (MCB `σ_L` for this derivation),
     or `none` if a merged item is complex / a mover is missing. -/
-def externalizeP? (d : SyntacticObject.Derivation) : Option (RoseTree SOLabel) :=
+def externalizeP? (d : Derivation) : Option (RoseTree SOLabel) :=
   d.initial.toPlanarLeaf?.bind fun init => d.steps.foldl externStepP (some init)
 
 /-- Surface (pronounced) tokens, left-to-right; traces dropped. Empty if
     externalization fails. -/
-def surfaceTokens (d : SyntacticObject.Derivation) : List LIToken :=
+def surfaceTokens (d : Derivation) : List LIToken :=
   (d.externalizeP?.map planarYield).getD []
 
 /-- Surface category sequence — the readout used by word-order studies. -/
-def surfaceCats (d : SyntacticObject.Derivation) : List Cat := d.surfaceTokens.map (·.item.outerCat)
+def surfaceCats (d : Derivation) : List Cat := d.surfaceTokens.map (·.item.outerCat)
 
 /-- Surface phonological string: pronounced forms left-to-right (empty forms dropped). -/
-def surfacePhon (d : SyntacticObject.Derivation) : List String :=
+def surfacePhon (d : Derivation) : List String :=
   d.surfaceTokens.filterMap LIToken.phonForm?
 
 end SyntacticObject.Derivation
@@ -135,25 +135,23 @@ ColeHermon2008, Chomsky1995, …) rely on. -/
 /-- `isSOPlanar` of a bare binary node is the conjunction of the children's. -/
 private theorem isSOPlanar_nodeP {a b : RoseTree SOLabel}
     (ha : isSOPlanar a = true) (hb : isSOPlanar b = true) :
-    isSOPlanar (SyntacticObject.nodeP a b) = true := by
+    isSOPlanar (nodeP a b) = true := by
   simp only [isSOPlanar, isSOPlanarList, ha, hb, List.length_cons, List.length_nil,
     Nat.reduceAdd, Nat.reduceBEq, Bool.or_true, Bool.and_self]
 
 /-- `Nonplanar.mk` of the planar binary builder is the bare binary nonplanar node. -/
 private theorem mk_nodeP (a b : RoseTree SOLabel) :
-    Nonplanar.mk (SyntacticObject.nodeP a b)
-      = Nonplanar.node (Sum.inr ()) {Nonplanar.mk a, Nonplanar.mk b} := by
+    Nonplanar.mk (nodeP a b) = Nonplanar.node (Sum.inr ()) {Nonplanar.mk a, Nonplanar.mk b} := by
   rw [show ({Nonplanar.mk a, Nonplanar.mk b} : Multiset (Nonplanar SOLabel))
         = Multiset.ofList ([a, b].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
 
 /-- A bare binary node (two children) is never the trace leaf (no children). -/
 private theorem SyntacticObject.node_ne_traceLeaf (l r : SyntacticObject) :
-    SyntacticObject.node l r ≠ SyntacticObject.traceLeaf := by
+    node l r ≠ traceLeaf := by
   intro heq
-  have ha : (SyntacticObject.node l r).val.rootChildren
-      = SyntacticObject.traceLeaf.val.rootChildren := by rw [heq]
-  rw [SyntacticObject.node_val, Nonplanar.rootChildren_node] at ha
-  simp only [SyntacticObject.traceLeaf, Nonplanar.leaf_def, Nonplanar.rootChildren_mk,
+  have ha : (node l r).val.rootChildren = traceLeaf.val.rootChildren := by rw [heq]
+  rw [node_val, Nonplanar.rootChildren_node] at ha
+  simp only [traceLeaf, Nonplanar.leaf_def, Nonplanar.rootChildren_mk,
     RoseTree.children, Multiset.insert_eq_cons] at ha
   exact Multiset.cons_ne_zero ha
 
@@ -162,18 +160,18 @@ private theorem SyntacticObject.node_ne_traceLeaf (l r : SyntacticObject) :
 private theorem toPlanarLeaf?_mk {s : SyntacticObject} {ip : RoseTree SOLabel}
     (h : s.toPlanarLeaf? = some ip) :
     Nonplanar.mk ip = s.val ∧ isSOPlanar ip = true := by
-  induction s using SyntacticObject.ind with
+  induction s using ind with
   | lex tok =>
-    rw [SyntacticObject.toPlanarLeaf?, SyntacticObject.getLIToken_lexLeaf] at h
-    obtain rfl : ip = SyntacticObject.leafP tok := by simpa using h.symm
+    rw [toPlanarLeaf?, getLIToken_lexLeaf] at h
+    obtain rfl : ip = leafP tok := by simpa using h.symm
     exact ⟨rfl, rfl⟩
   | trace =>
-    rw [SyntacticObject.toPlanarLeaf?, SyntacticObject.getLIToken_traceLeaf, if_pos rfl] at h
-    obtain rfl : ip = SyntacticObject.traceP := by simpa using h.symm
+    rw [toPlanarLeaf?, getLIToken_traceLeaf, if_pos rfl] at h
+    obtain rfl : ip = traceP := by simpa using h.symm
     exact ⟨rfl, rfl⟩
   | node l r _ _ =>
-    rw [SyntacticObject.toPlanarLeaf?, SyntacticObject.getLIToken_node,
-        if_neg (SyntacticObject.node_ne_traceLeaf l r)] at h
+    rw [toPlanarLeaf?, getLIToken_node,
+        if_neg (node_ne_traceLeaf l r)] at h
     exact absurd h (by simp)
 
 /-- **Lemma 2.** `projEqP target s` certifies that `s` projects to `target`. -/
@@ -197,9 +195,9 @@ private theorem planarFindP?_pred {p : RoseTree SOLabel → Bool} {t s : RoseTre
 
 /-- A bare binary node's children are both well-formed when the node is. -/
 private theorem isSOPlanar_pair_children {l r : RoseTree SOLabel}
-    (ht : isSOPlanar (SyntacticObject.nodeP l r) = true) :
+    (ht : isSOPlanar (nodeP l r) = true) :
     isSOPlanar l = true ∧ isSOPlanar r = true := by
-  rw [SyntacticObject.nodeP, isSOPlanar, isSOPlanarList, isSOPlanarList, isSOPlanarList,
+  rw [nodeP, isSOPlanar, isSOPlanarList, isSOPlanarList, isSOPlanarList,
     Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at ht
   exact ⟨ht.2.1, ht.2.2.1⟩
 
@@ -252,10 +250,10 @@ private theorem not_projEqP {target : SyntacticObject} {s : RoseTree SOLabel}
     `replaceN_node`'s else branch (`{·,·}` multiset built from the two daughters). -/
 private theorem replaceWhereP_mk (target : SyntacticObject) {t : RoseTree SOLabel}
     (ht : isSOPlanar t = true) :
-    Nonplanar.mk (planarReplaceWhereP (projEqP target) SyntacticObject.traceP t)
-        = replaceN target.val SyntacticObject.traceLeaf.val (Nonplanar.mk t)
-      ∧ isSOPlanar (planarReplaceWhereP (projEqP target) SyntacticObject.traceP t) = true := by
-  fun_induction planarReplaceWhereP (projEqP target) SyntacticObject.traceP t with
+    Nonplanar.mk (planarReplaceWhereP (projEqP target) traceP t)
+        = replaceN target.val traceLeaf.val (Nonplanar.mk t)
+      ∧ isSOPlanar (planarReplaceWhereP (projEqP target) traceP t) = true := by
+  fun_induction planarReplaceWhereP (projEqP target) traceP t with
   | case1 _ hp =>
     refine ⟨?_, rfl⟩
     rw [projEqP_eq hp, replaceN_self]; rfl
@@ -281,10 +279,10 @@ private theorem replaceWhereP_mk (target : SyntacticObject) {t : RoseTree SOLabe
     have hne : Nonplanar.node (Sum.inr ()) {Nonplanar.mk l, Nonplanar.mk r} ≠ target.val := by
       rw [← mk_nodeP]; exact not_projEqP hp
     rw [show RoseTree.node (Sum.inr ())
-          [planarReplaceWhereP (projEqP target) SyntacticObject.traceP l,
-          planarReplaceWhereP (projEqP target) SyntacticObject.traceP r]
-        = SyntacticObject.nodeP (planarReplaceWhereP (projEqP target) SyntacticObject.traceP l)
-          (planarReplaceWhereP (projEqP target) SyntacticObject.traceP r) from rfl,
+          [planarReplaceWhereP (projEqP target) traceP l,
+          planarReplaceWhereP (projEqP target) traceP r]
+        = nodeP (planarReplaceWhereP (projEqP target) traceP l)
+          (planarReplaceWhereP (projEqP target) traceP r) from rfl,
       mk_nodeP, ihle, ihre, mk_nodeP, replaceN_node, if_neg hne]
   | case5 _ cs hnil hpair _ =>
     rcases isSOPlanar_length ht with hlen | hlen
@@ -298,29 +296,29 @@ private theorem replaceWhereP_mk (target : SyntacticObject) {t : RoseTree SOLabe
 /-- **Lemma 6: per-step faithfulness.** A successful replay step on a well-formed
     accumulator stays well-formed and projects to the abstract `SyntacticObject.Step.apply`. -/
 private theorem externStepP_step {acc : SyntacticObject} {accp p' : RoseTree SOLabel}
-    {step : SyntacticObject.Step}
+    {step : Step}
     (h : externStepP (some accp) step = some p') (hwf : isSOPlanar accp = true)
     (hmk : Nonplanar.mk accp = acc.val) :
     isSOPlanar p' = true ∧ Nonplanar.mk p' = (step.apply acc).val := by
   cases step with
   | emL item =>
-    change item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP p accp) = some p' at h
+    change item.toPlanarLeaf?.map (fun p => nodeP p accp) = some p' at h
     rcases hip : item.toPlanarLeaf? with _ | ip
     · rw [hip, Option.map_none] at h; exact absurd h (by simp)
     · rw [hip, Option.map_some] at h
       obtain rfl := Option.some.inj h
       obtain ⟨hmkip, hwfip⟩ := toPlanarLeaf?_mk hip
       refine ⟨isSOPlanar_nodeP hwfip hwf, ?_⟩
-      rw [SyntacticObject.Step.apply, SyntacticObject.merge_val, mk_nodeP, hmkip, hmk]
+      rw [Step.apply, merge_val, mk_nodeP, hmkip, hmk]
   | emR item =>
-    change item.toPlanarLeaf?.map (fun p => SyntacticObject.nodeP accp p) = some p' at h
+    change item.toPlanarLeaf?.map (fun p => nodeP accp p) = some p' at h
     rcases hip : item.toPlanarLeaf? with _ | ip
     · rw [hip, Option.map_none] at h; exact absurd h (by simp)
     · rw [hip, Option.map_some] at h
       obtain rfl := Option.some.inj h
       obtain ⟨hmkip, hwfip⟩ := toPlanarLeaf?_mk hip
       refine ⟨isSOPlanar_nodeP hwf hwfip, ?_⟩
-      rw [SyntacticObject.Step.apply, SyntacticObject.merge_val, mk_nodeP, hmkip, hmk]
+      rw [Step.apply, merge_val, mk_nodeP, hmkip, hmk]
   | im mover =>
     change moveLeftPlanarP accp mover = some p' at h
     rw [moveLeftPlanarP] at h
@@ -332,12 +330,12 @@ private theorem externStepP_step {acc : SyntacticObject} {accp p' : RoseTree SOL
       have hwfs : isSOPlanar s = true := planarFindP?_isSOPlanar hfind hwf
       obtain ⟨hrwe, hrws⟩ := replaceWhereP_mk mover hwf
       refine ⟨isSOPlanar_nodeP hwfs hrws, ?_⟩
-      rw [SyntacticObject.Step.apply, SyntacticObject.intMerge_val,
-          SyntacticObject.deleteAccessible_val, mk_nodeP, hmks, hrwe, hmk]
+      rw [Step.apply, intMerge_val,
+          deleteAccessible_val, mk_nodeP, hmks, hrwe, hmk]
       exact congrArg (Nonplanar.node (Sum.inr ())) (Multiset.cons_swap _ _ _)
 
 /-- `none` is absorbing for the replay fold: once externalization fails, it stays failed. -/
-private theorem foldl_externStepP_none (steps : List SyntacticObject.Step) :
+private theorem foldl_externStepP_none (steps : List Step) :
     steps.foldl externStepP none = none := by
   induction steps with
   | nil => rfl
@@ -347,7 +345,7 @@ private theorem foldl_externStepP_none (steps : List SyntacticObject.Step) :
     faithful accumulator projects to the abstract `final`-style fold of
     `SyntacticObject.Step.apply`. -/
 private theorem foldl_externStepP_mk :
-    ∀ (steps : List SyntacticObject.Step) {acc : SyntacticObject} {accp p : RoseTree SOLabel},
+    ∀ (steps : List Step) {acc : SyntacticObject} {accp p : RoseTree SOLabel},
     steps.foldl externStepP (some accp) = some p → isSOPlanar accp = true →
     Nonplanar.mk accp = acc.val →
     Nonplanar.mk p = (steps.foldl (fun so st => st.apply so) acc).val
@@ -368,10 +366,9 @@ private theorem foldl_externStepP_mk :
     derived syntactic object — the guarantee the word-order studies depend on. The replay
     is partial by design (EM of a complex item / a missing mover ⇒ `none`, making the claim
     vacuous there); on the canonical leaf/trace derivations the studies build, it succeeds. -/
-theorem SyntacticObject.Derivation.externalizeP?_faithful (d : SyntacticObject.Derivation)
-    {p : RoseTree SOLabel}
-    (h : d.externalizeP? = some p) : Nonplanar.mk p = d.final.val := by
-  rw [SyntacticObject.Derivation.externalizeP?] at h
+theorem SyntacticObject.Derivation.externalizeP?_faithful (d : Derivation)
+    {p : RoseTree SOLabel} (h : d.externalizeP? = some p) : Nonplanar.mk p = d.final.val := by
+  rw [Derivation.externalizeP?] at h
   rcases hinit : d.initial.toPlanarLeaf? with _ | init
   · rw [hinit] at h; exact absurd h (by simp [Option.bind])
   · rw [hinit] at h
@@ -386,28 +383,23 @@ Dem-N-A-Num (raise N around A, then pied-pipe `[N A]` around Num) is distinct fr
 Dem-A-N-Num (pied-pipe `[A N]` around Num). Movers are built with the computable DSL so
 the surface orders `decide`. (`.D` stands in for the demonstrative.) -/
 
-private def xN : SyntacticObject := SyntacticObject.mkLeaf .N [] 1
-private def xA : SyntacticObject := SyntacticObject.mkLeaf .A [] 2
-private def xNum : SyntacticObject := SyntacticObject.mkLeaf .Num [] 3
-private def xD : SyntacticObject := SyntacticObject.mkLeaf .D [] 4
+private def xN : SyntacticObject := mkLeaf .N [] 1
+private def xA : SyntacticObject := mkLeaf .A [] 2
+private def xNum : SyntacticObject := mkLeaf .Num [] 3
+private def xD : SyntacticObject := mkLeaf .D [] 4
 /-- The pied-piped `[N [A t]]` mover (built planar-first, so it is computable). -/
 private def xNAt : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .N [], 1⟩)
-    (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .A [], 2⟩) SyntacticObject.traceP))
+  ofPlanar (nodeP (leafP ⟨.simple .N [], 1⟩) (nodeP (leafP ⟨.simple .A [], 2⟩) traceP))
 /-- The pied-piped `[A N]` mover. -/
 private def xAN : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .A [], 2⟩)
-    (SyntacticObject.leafP ⟨.simple .N [], 1⟩))
+  ofPlanar (nodeP (leafP ⟨.simple .A [], 2⟩) (leafP ⟨.simple .N [], 1⟩))
 
 /-- No movement: `Dem Num A N`. -/
-private def xDerivBase : SyntacticObject.Derivation :=
-  ⟨xN, [.emL xA, .emL xNum, .emL xD]⟩
+private def xDerivBase : Derivation := ⟨xN, [.emL xA, .emL xNum, .emL xD]⟩
 /-- Raise N around A, pied-pipe `[N A]` around Num: `Dem N A Num`. -/
-private def xDerivO : SyntacticObject.Derivation :=
-  ⟨xN, [.emL xA, .im xN, .emL xNum, .im xNAt, .emL xD]⟩
+private def xDerivO : Derivation := ⟨xN, [.emL xA, .im xN, .emL xNum, .im xNAt, .emL xD]⟩
 /-- Pied-pipe `[A N]` around Num, no sub-raise: `Dem A N Num`. -/
-private def xDerivN : SyntacticObject.Derivation :=
-  ⟨xN, [.emL xA, .emL xNum, .im xAN, .emL xD]⟩
+private def xDerivN : Derivation := ⟨xN, [.emL xA, .emL xNum, .im xAN, .emL xD]⟩
 
 example : xDerivBase.surfaceCats = [.D, .Num, .A, .N] := by decide
 example : xDerivO.surfaceCats = [.D, .N, .A, .Num] := by decide

--- a/Linglib/Syntax/Minimalist/Movement/Remnant.lean
+++ b/Linglib/Syntax/Minimalist/Movement/Remnant.lean
@@ -89,6 +89,8 @@ their analysis. SCD 2026's predicate-fronting is remnant; Collins
 
 namespace Minimalist.Movement
 
+open SyntacticObject
+
 -- ============================================================================
 -- § 1: Remnant Fronting Record
 -- ============================================================================
@@ -119,7 +121,7 @@ structure RemnantFronting where
     heads' traces are spelled out (verb doubling vs. silent copy) — that
     is a per-construction choice. -/
 def properRemnant (rf : RemnantFronting) : Prop :=
-  ∀ h ∈ rf.evacuatedHeads, SyntacticObject.contains rf.frontedXP h
+  ∀ h ∈ rf.evacuatedHeads, contains rf.frontedXP h
 
 instance (rf : RemnantFronting) : Decidable (properRemnant rf) := by
   unfold properRemnant; infer_instance
@@ -151,7 +153,7 @@ structure PredicateDoubling extends RemnantFronting where
     sat originally inside the fronted XP. -/
 theorem predicateDoubling_verb_in_frontedXP
     (pd : PredicateDoubling) (h : properRemnant pd.toRemnantFronting) :
-    SyntacticObject.contains pd.frontedXP pd.verb :=
+    contains pd.frontedXP pd.verb :=
   h pd.verb pd.verb_evacuated
 
 end Minimalist.Movement

--- a/Linglib/Syntax/Minimalist/Phase/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Basic.lean
@@ -37,6 +37,8 @@ projecting head's outer category — convention-independent (the carrier is unor
 
 namespace Minimalist
 
+open SyntacticObject
+
 -- ============================================================================
 -- Part 1: Phase Head Identification (the selection-driven head)
 -- ============================================================================
@@ -132,10 +134,10 @@ instance (φ : Phase) (goal : SyntacticObject) : Decidable (φ.Impenetrable goal
 
 /-- A genuine phase: its head projects nontrivially (`head ∈ L_Φ(T)`, MCB Def 1.14.3
     eq 1.14.1) — `γ_ℓ` reaches an internal vertex. -/
-def IsWellFormed (φ : Phase) : Prop := SyntacticObject.isPhaseHead φ.tree φ.head
+def IsWellFormed (φ : Phase) : Prop := isPhaseHead φ.tree φ.head
 
 instance (φ : Phase) : Decidable φ.IsWellFormed :=
-  inferInstanceAs (Decidable (SyntacticObject.isPhaseHead _ _))
+  inferInstanceAs (Decidable (isPhaseHead _ _))
 
 /-! ### Spell-out triggers
 
@@ -158,7 +160,7 @@ variable {P : Type*}
 /-- A trigger applies to a phase iff its `selector` matches the phase head (the head
 leaf `ph.head`, as a leaf SyntacticObject). -/
 def Trigger.appliesTo (tr : Trigger P) (ph : Phase) : Bool :=
-  tr.selector (SyntacticObject.lexLeaf ph.head)
+  tr.selector (lexLeaf ph.head)
 
 /-- The *first* registered trigger whose `selector` matches the phase head —
 first-match encodes lexicographic precedence (the elsewhere ordering of
@@ -266,7 +268,7 @@ structure FeatureInheritance where
   /-- The head receiving features (T, V, vMOD). -/
   target : SyntacticObject
   /-- Source must immediately contain target. -/
-  locality : SyntacticObject.immediatelyContains source target
+  locality : immediatelyContains source target
   /-- Which transfer operation applies (default: classical [chomsky-2008] donate). -/
   style : TransferStyle := .donate
   /-- The features transferred (default: none specified at this layer). -/

--- a/Linglib/Syntax/Minimalist/Phase/Domain.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Domain.lean
@@ -35,7 +35,9 @@ out of the formalization.
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
+
+namespace SyntacticObject
 
 /-- **Phase-head test on `SyntacticObject`** ([marcolli-chomsky-berwick-2025] Lemma 1.13.7):
     is the projecting (selection-driven) head's outer category exactly `c`?
@@ -45,11 +47,11 @@ open RootedTree
     Phase-head selectors (call directly): C — `isPhaseHeadOf .C` (linglib default
     per [keine-2020]; the Chomsky v-phase extension is `… .C s || … .v s`); D —
     `isPhaseHeadOf .D` ([citko-2014]); SA — `isPhaseHeadOf .SA`. -/
-def SyntacticObject.isPhaseHeadOf (c : Cat) (s : SyntacticObject) : Bool := s.outerCatC == some c
+def isPhaseHeadOf (c : Cat) (s : SyntacticObject) : Bool := s.outerCatC == some c
 
-@[simp] theorem SyntacticObject.isPhaseHeadOf_lexLeaf (c : Cat) (tok : LIToken) :
-    SyntacticObject.isPhaseHeadOf c (SyntacticObject.lexLeaf tok) = (tok.item.outerCat == c) := by
-  rw [SyntacticObject.isPhaseHeadOf, SyntacticObject.outerCatC_lexLeaf]; rfl
+@[simp] theorem isPhaseHeadOf_lexLeaf (c : Cat) (tok : LIToken) :
+    isPhaseHeadOf c (lexLeaf tok) = (tok.item.outerCat == c) := by
+  rw [isPhaseHeadOf, outerCatC_lexLeaf]; rfl
 
 /-! ### The phase domain (MCB Def 1.14.2–1.14.3)
 
@@ -63,11 +65,10 @@ subterm API (`subtrees`/`Acc`/`containsOrEq`/`areSistersIn`/`cCommandsIn`), so i
     **phase head** in `T` when its projection path γ_ℓ is nontrivial — the leaf
     `lexLeaf ℓ` has a mother whose head is still `ℓ` (so γ_ℓ reaches an internal
     vertex). Read off `selHead` at the mother; section-free. -/
-def SyntacticObject.isPhaseHead (T : SyntacticObject) (ℓ : LIToken) : Prop :=
-  ∃ n ∈ T.subtrees,
-    SyntacticObject.immediatelyContains n (SyntacticObject.lexLeaf ℓ) ∧ n.selHead = some ℓ
+def isPhaseHead (T : SyntacticObject) (ℓ : LIToken) : Prop :=
+  ∃ n ∈ T.subtrees, immediatelyContains n (lexLeaf ℓ) ∧ n.selHead = some ℓ
 
-instance (T : SyntacticObject) (ℓ : LIToken) : Decidable (SyntacticObject.isPhaseHead T ℓ) :=
+instance (T : SyntacticObject) (ℓ : LIToken) : Decidable (isPhaseHead T ℓ) :=
   Multiset.decidableExistsMultiset
 
 /-- **Within the maximal projection** `T_v ⊆ T_{v_ℓ}`
@@ -75,19 +76,18 @@ instance (T : SyntacticObject) (ℓ : LIToken) : Decidable (SyntacticObject.isPh
     `T_v` is contained in *some* `ℓ`-headed subtree. The maximal projection `v_ℓ`
     is the largest `ℓ`-headed subtree, so `T_v ⊆ T_{v_ℓ}` iff `T_v` sits inside one
     of them (all `ℓ`-headed vertices lie on γ_ℓ below `v_ℓ`). -/
-def SyntacticObject.withinProjection (T : SyntacticObject) (ℓ : LIToken)
-    (Tv : SyntacticObject) : Prop :=
-  ∃ p ∈ T.subtrees, p.selHead = some ℓ ∧ SyntacticObject.containsOrEq p Tv
+def withinProjection (T : SyntacticObject) (ℓ : LIToken) (Tv : SyntacticObject) : Prop :=
+  ∃ p ∈ T.subtrees, p.selHead = some ℓ ∧ containsOrEq p Tv
 
 instance (T : SyntacticObject) (ℓ : LIToken) (Tv : SyntacticObject) :
-    Decidable (SyntacticObject.withinProjection T ℓ Tv) :=
+    Decidable (withinProjection T ℓ Tv) :=
   Multiset.decidableExistsMultiset
 
 /-- **The phase Φ_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.2):
     `{T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ}}` — all accessible terms within the maximal
     projection (`Acc'(T) = T.subtrees`, including the root). -/
-def SyntacticObject.phase (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
-  T.subtrees.filter (fun Tv => SyntacticObject.withinProjection T ℓ Tv)
+def phase (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
+  T.subtrees.filter (fun Tv => withinProjection T ℓ Tv)
 
 /-- **The interior Φ°_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.3):
     `{T_v ∈ Acc(T) | T_v ⊆ T_{s_ℓ}}` — the head's sister `T_{s_ℓ}` and all of its
@@ -97,52 +97,48 @@ def SyntacticObject.phase (T : SyntacticObject) (ℓ : LIToken) : Multiset Synta
     sister of `ℓ` contains-or-equals `T_v`, i.e. `cCommandsIn T (lexLeaf ℓ) T_v`
     (#798). The textbook "complement domain = head's c-command domain", by
     construction — and `Acc(T) = T.Acc` (non-root). -/
-def SyntacticObject.phaseInterior (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
-  T.Acc.filter (fun Tv => SyntacticObject.cCommandsIn T (SyntacticObject.lexLeaf ℓ) Tv)
+def phaseInterior (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
+  T.Acc.filter (fun Tv => cCommandsIn T (lexLeaf ℓ) Tv)
 
 /-- **The edge ∂Φ_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.4):
     `{T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ} ∧ T_v ⊄ T_{s_ℓ}}` — the phase content not in
     the interior (head, specifiers, modifiers); `= Φ_ℓ` when the complement is
     empty. Computed as `phase ∖ interior`. -/
-def SyntacticObject.phaseEdge (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
+def phaseEdge (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
   (T.phase ℓ).filter (fun Tv => Tv ∉ T.phaseInterior ℓ)
 
 /-- **Phase Impenetrability Condition**: `goal` is frozen in the phase headed by `ℓ`
     iff it lies in the interior (= the complement domain). True by construction — the
     PIC *is* interior membership ([marcolli-chomsky-berwick-2025] §1.14). -/
-def SyntacticObject.Impenetrable (T : SyntacticObject) (ℓ : LIToken)
-    (goal : SyntacticObject) : Prop :=
+def Impenetrable (T : SyntacticObject) (ℓ : LIToken) (goal : SyntacticObject) : Prop :=
   goal ∈ T.phaseInterior ℓ
 
 instance (T : SyntacticObject) (ℓ : LIToken) (goal : SyntacticObject) :
-    Decidable (SyntacticObject.Impenetrable T ℓ goal) :=
+    Decidable (Impenetrable T ℓ goal) :=
   inferInstanceAs (Decidable (_ ∈ _))
 
 /-! ### Membership characterizations -/
 
-@[simp] theorem SyntacticObject.mem_phase {T : SyntacticObject} {ℓ : LIToken}
-    {Tv : SyntacticObject} :
-    Tv ∈ T.phase ℓ ↔ Tv ∈ T.subtrees ∧ SyntacticObject.withinProjection T ℓ Tv :=
+@[simp] theorem mem_phase {T : SyntacticObject} {ℓ : LIToken} {Tv : SyntacticObject} :
+    Tv ∈ T.phase ℓ ↔ Tv ∈ T.subtrees ∧ withinProjection T ℓ Tv :=
   Multiset.mem_filter
 
 /-- **The interior is the phase head's (non-root) c-command domain** — the keystone
     identity (MCB Def 1.14.3, "Z is the interior of the phase"). -/
-@[simp] theorem SyntacticObject.mem_phaseInterior {T : SyntacticObject} {ℓ : LIToken}
-    {Tv : SyntacticObject} :
-    Tv ∈ T.phaseInterior ℓ ↔ Tv ∈ T.Acc ∧ T.cCommandsIn (SyntacticObject.lexLeaf ℓ) Tv :=
+@[simp] theorem mem_phaseInterior {T : SyntacticObject} {ℓ : LIToken} {Tv : SyntacticObject} :
+    Tv ∈ T.phaseInterior ℓ ↔ Tv ∈ T.Acc ∧ T.cCommandsIn (lexLeaf ℓ) Tv :=
   Multiset.mem_filter
 
-@[simp] theorem SyntacticObject.mem_phaseEdge {T : SyntacticObject} {ℓ : LIToken}
-    {Tv : SyntacticObject} :
+@[simp] theorem mem_phaseEdge {T : SyntacticObject} {ℓ : LIToken} {Tv : SyntacticObject} :
     Tv ∈ T.phaseEdge ℓ ↔ Tv ∈ T.phase ℓ ∧ Tv ∉ T.phaseInterior ℓ :=
   Multiset.mem_filter
 
 /-- The PIC freezes exactly the head's (non-root) c-command domain. -/
-theorem SyntacticObject.Impenetrable_iff {T : SyntacticObject} {ℓ : LIToken}
-    {goal : SyntacticObject} :
-    SyntacticObject.Impenetrable T ℓ goal ↔
-      goal ∈ T.Acc ∧ T.cCommandsIn (SyntacticObject.lexLeaf ℓ) goal :=
-  SyntacticObject.mem_phaseInterior
+theorem Impenetrable_iff {T : SyntacticObject} {ℓ : LIToken} {goal : SyntacticObject} :
+    Impenetrable T ℓ goal ↔ goal ∈ T.Acc ∧ T.cCommandsIn (lexLeaf ℓ) goal :=
+  mem_phaseInterior
+
+end SyntacticObject
 
 /-! ### `decide` demonstrations
 
@@ -153,19 +149,17 @@ sits on (the carrier is unordered) — so the phase head is the selector. -/
 /-- A two-leaf bare node over the given tokens (built planar-first via the DSL;
     `SyntacticObject.node` is noncomputable). -/
 private def clause (head comp : LIToken) : SyntacticObject :=
-  SyntacticObject.ofPlanar
-    (SyntacticObject.nodeP (SyntacticObject.leafP head) (SyntacticObject.leafP comp))
+  ofPlanar (nodeP (leafP head) (leafP comp))
 
 /-- A C selecting a T projects C: the node is a **C-phase**, not a v-phase. -/
 example :
-    SyntacticObject.isPhaseHeadOf .C (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = true
-    ∧ SyntacticObject.isPhaseHeadOf .v (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = false :=
-      by
+    isPhaseHeadOf .C (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = true
+    ∧ isPhaseHeadOf .v (clause ⟨.simple .C [.T], 0⟩ ⟨.simple .T [], 1⟩) = false := by
   decide
 
 /-- A D selecting an N projects D: the node is a **D-phase** ([citko-2014]). -/
 example :
-    SyntacticObject.isPhaseHeadOf .D (clause ⟨.simple .D [.N], 0⟩ ⟨.simple .N [], 1⟩) = true := by
+    isPhaseHeadOf .D (clause ⟨.simple .D [.N], 0⟩ ⟨.simple .N [], 1⟩) = true := by
   decide
 
 /-- **Convention-independence**: swapping the two daughters (the carrier is
@@ -186,19 +180,18 @@ private def tTok : LIToken := ⟨.simple .T [.V], 1⟩
 private def vTok : LIToken := ⟨.simple .V [], 2⟩
 
 private def cP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP cTok)
-    (SyntacticObject.nodeP (SyntacticObject.leafP tTok) (SyntacticObject.leafP vTok)))
+  ofPlanar (nodeP (leafP cTok) (nodeP (leafP tTok) (leafP vTok)))
 
 /-- C heads a nontrivial phase (it projects over the TP). -/
-example : SyntacticObject.isPhaseHead cP cTok := by decide
+example : isPhaseHead cP cTok := by decide
 
 /-- The embedded `V` is in C's complement domain — **frozen** by the PIC. -/
-example : SyntacticObject.Impenetrable cP cTok (SyntacticObject.lexLeaf vTok) := by decide
+example : Impenetrable cP cTok (lexLeaf vTok) := by decide
 
 /-- The phase head `C` is at the **edge** — *not* frozen (it can still probe out). -/
-example : ¬ SyntacticObject.Impenetrable cP cTok (SyntacticObject.lexLeaf cTok) := by decide
+example : ¬ Impenetrable cP cTok (lexLeaf cTok) := by decide
 
 /-- …and `C` sits in the edge, not the interior. -/
-example : SyntacticObject.lexLeaf cTok ∈ cP.phaseEdge cTok := by decide
+example : lexLeaf cTok ∈ cP.phaseEdge cTok := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Position.lean
+++ b/Linglib/Syntax/Minimalist/Position.lean
@@ -38,6 +38,8 @@ Two variants are formalized:
 
 namespace Minimalist
 
+open SyntacticObject
+
 -- ============================================================================
 -- § 1: Merge Types
 -- ============================================================================
@@ -125,9 +127,7 @@ def compToSpecAntiLocality
     primary extraction restriction derives from nominal licensing. -/
 def specToSpecAntiLocality
     (events : List MergeEvent) (mover xP yP : SyntacticObject) : Prop :=
-  isSpecIn events mover xP →
-  SyntacticObject.immediatelyContains yP xP →
-  ¬movedToSpecOf events mover yP
+  isSpecIn events mover xP → immediatelyContains yP xP → ¬movedToSpecOf events mover yP
 
 -- ============================================================================
 -- § 5: Predicate Fronting
@@ -152,20 +152,20 @@ structure PredicateFronting where
     NOT inside the fronted predicate. Stranded elements remain accessible
     for further operations (e.g., extraction by a higher probe). -/
 def isStranded (pf : PredicateFronting) (x : SyntacticObject) : Prop :=
-  ¬SyntacticObject.contains pf.predicate x
+  ¬contains pf.predicate x
 
 /-- After predicate fronting, a constituent X is "trapped" if it IS
     inside the fronted predicate. Trapped elements are inaccessible:
     the fronted phrase is a moved constituent and acts as a freezing
     domain. -/
 def isTrapped (pf : PredicateFronting) (x : SyntacticObject) : Prop :=
-  SyntacticObject.contains pf.predicate x
+  contains pf.predicate x
 
 /-- Stranded and trapped are complementary: every constituent of the
     clause is either stranded or trapped (tertium non datur). -/
 theorem stranded_or_trapped (pf : PredicateFronting) (x : SyntacticObject) :
     isStranded pf x ∨ isTrapped pf x :=
-  em (SyntacticObject.contains pf.predicate x) |>.elim (Or.inr) (Or.inl)
+  em (contains pf.predicate x) |>.elim (Or.inr) (Or.inl)
 
 -- ============================================================================
 -- § 6: Extraction Restriction ([erlewine-2018])
@@ -194,14 +194,14 @@ structure Pivot where
     (outside the fronted predicate), hence extractable. -/
 theorem pivot_is_stranded
     (pf : PredicateFronting) (pivot : Pivot)
-    (h_outside : ¬SyntacticObject.contains pf.predicate pivot.element) :
+    (h_outside : ¬contains pf.predicate pivot.element) :
     extractionRestriction pf pivot.element := h_outside
 
 /-- Non-pivot arguments are trapped (inside the fronted predicate),
     hence not extractable. -/
 theorem nonpivot_trapped
     (pf : PredicateFronting) (x : SyntacticObject)
-    (h_inside : SyntacticObject.contains pf.predicate x) :
+    (h_inside : contains pf.predicate x) :
     ¬extractionRestriction pf x := by
   intro h_stranded
   exact h_stranded h_inside
@@ -215,7 +215,7 @@ theorem nonpivot_trapped
 theorem pivot_blocked_by_anti_locality
     (events : List MergeEvent) (pivot tP cP : SyntacticObject)
     (h_spec : isSpecIn events pivot tP)
-    (h_imm : SyntacticObject.immediatelyContains cP tP)
+    (h_imm : immediatelyContains cP tP)
     (h_anti : specToSpecAntiLocality events pivot tP cP) :
     ¬movedToSpecOf events pivot cP :=
   h_anti h_spec h_imm

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Amalgamation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Amalgamation.lean
@@ -46,6 +46,8 @@ files (e.g., HG2019Amalgamation.lean's diagnostic predicates).
 
 namespace Minimalist
 
+open SyntacticObject
+
 -- ============================================================================
 -- § 1: Immediate C-Command for Heads
 -- ============================================================================
@@ -57,8 +59,7 @@ namespace Minimalist
     This is the "closest" c-command relation, used to define amalgamation
     locality (HMC compliance). -/
 def immediatelyCCommands (x y root : SyntacticObject) : Prop :=
-  SyntacticObject.cCommandsIn root x y ∧
-  ¬∃ z, z ≠ x ∧ z ≠ y ∧ SyntacticObject.cCommandsIn root x z ∧ SyntacticObject.cCommandsIn root z y
+  cCommandsIn root x y ∧ ¬∃ z, z ≠ x ∧ z ≠ y ∧ cCommandsIn root x z ∧ cCommandsIn root z y
 
 -- ============================================================================
 -- § 2: Amalgamation
@@ -94,8 +95,7 @@ structure Amalgamation where
     displacement obeys the Head Movement Constraint"). Immediate from
     the definition: `is_local` requires no intervener. -/
 theorem amalgamation_no_intervener (a : Amalgamation) (root : SyntacticObject) :
-    ¬∃ z, z ≠ a.host ∧ z ≠ a.target ∧
-      SyntacticObject.cCommandsIn root a.host z ∧ SyntacticObject.cCommandsIn root z a.target := by
+    ¬∃ z, z ≠ a.host ∧ z ≠ a.target ∧ cCommandsIn root a.host z ∧ cCommandsIn root z a.target := by
   have h := a.is_local root
   unfold immediatelyCCommands at h
   exact h.2
@@ -107,8 +107,8 @@ theorem intervener_rules_out_amalgamation
     (host target intervener root : SyntacticObject)
     (h_neq_host : intervener ≠ host)
     (h_neq_target : intervener ≠ target)
-    (h_host_cmd : SyntacticObject.cCommandsIn root host intervener)
-    (h_int_cmd : SyntacticObject.cCommandsIn root intervener target) :
+    (h_host_cmd : cCommandsIn root host intervener)
+    (h_int_cmd : cCommandsIn root intervener target) :
     ¬∃ (a : Amalgamation), a.host = host ∧ a.target = target := by
   intro ⟨a, hHost, hTarget⟩
   have hLocal := a.is_local root
@@ -120,7 +120,7 @@ theorem intervener_rules_out_amalgamation
 
 /-- Amalgamation respects locality: the host c-commands the target. -/
 theorem amalgamation_host_ccommands_target (a : Amalgamation) (root : SyntacticObject) :
-    SyntacticObject.cCommandsIn root a.host a.target := by
+    cCommandsIn root a.host a.target := by
   have h := a.is_local root
   unfold immediatelyCCommands at h
   exact h.1
@@ -157,10 +157,10 @@ theorem amalgamation_host_ccommands_target (a : Amalgamation) (root : SyntacticO
     rewrite will rebuild HG2019's amalgamation-as-covering analysis
     on top of the MCB-native `Minimalist.Labeling.isMaximalAt h /
     isHeadIn h` predicates. -/
-def VerbDoublingIsSyntacticIn (d : SyntacticObject.Derivation) (x : SyntacticObject) : Prop :=
+def VerbDoublingIsSyntacticIn (d : Derivation) (x : SyntacticObject) : Prop :=
   x ∈ d.movedItems
 
-instance (d : SyntacticObject.Derivation) (x : SyntacticObject) :
+instance (d : Derivation) (x : SyntacticObject) :
     Decidable (VerbDoublingIsSyntacticIn d x) := by
   unfold VerbDoublingIsSyntacticIn; infer_instance
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -30,47 +30,44 @@ is workspace-level), so there is exactly **one** trace leaf — `SyntacticObject
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
+
+namespace SyntacticObject
 
 /-! ### Computable planar construction DSL -/
 
 /-- Planar builder: a lexical leaf. -/
-abbrev SyntacticObject.leafP (tok : LIToken) : RoseTree SOLabel := .node (Sum.inl tok) []
+abbrev leafP (tok : LIToken) : RoseTree SOLabel := .node (Sum.inl tok) []
 /-- Planar builder: the bare trace leaf. -/
-abbrev SyntacticObject.traceP : RoseTree SOLabel := .node (Sum.inr ()) []
+abbrev traceP : RoseTree SOLabel := .node (Sum.inr ()) []
 /-- Planar builder: a bare binary node. -/
-abbrev SyntacticObject.nodeP (l r : RoseTree SOLabel) : RoseTree SOLabel :=
-  .node (Sum.inr ()) [l, r]
+abbrev nodeP (l r : RoseTree SOLabel) : RoseTree SOLabel := .node (Sum.inr ()) [l, r]
 
 /-- Build a syntactic object from a planar tree, discharging well-formedness by
     `decide` (concrete trees) — the computable entry point for `decide`-based studies. -/
-def SyntacticObject.ofPlanar (p : RoseTree SOLabel) (h : isSOPlanar p = true :=
+def ofPlanar (p : RoseTree SOLabel) (h : isSOPlanar p = true :=
   by first | rfl | decide) : SyntacticObject :=
   ⟨Nonplanar.mk p, h⟩
 
-@[simp] theorem SyntacticObject.ofPlanar_leafP (tok : LIToken) :
-    SyntacticObject.ofPlanar (SyntacticObject.leafP tok) = SyntacticObject.lexLeaf tok := rfl
+@[simp] theorem ofPlanar_leafP (tok : LIToken) : ofPlanar (leafP tok) = lexLeaf tok := rfl
 
-@[simp] theorem SyntacticObject.ofPlanar_traceP :
-    SyntacticObject.ofPlanar SyntacticObject.traceP = SyntacticObject.traceLeaf := rfl
+@[simp] theorem ofPlanar_traceP : ofPlanar traceP = traceLeaf := rfl
 
 /-- Default syntactic object: the bare trace leaf. Lets structures with an `SyntacticObject`
     field be `Inhabited`/`deriving Repr`-free of bespoke witnesses. -/
-instance : Inhabited SyntacticObject := ⟨SyntacticObject.traceLeaf⟩
+instance : Inhabited SyntacticObject := ⟨traceLeaf⟩
 
 /-! ### Merge as multiplication -/
 
 /-- `*` is (External) Merge: the bare binary node. Noncomputable — build concrete
     trees with the planar DSL above, not `*`. -/
-noncomputable instance : Mul SyntacticObject := ⟨SyntacticObject.node⟩
+noncomputable instance : Mul SyntacticObject := ⟨node⟩
 
-@[simp] theorem SyntacticObject.mul_def (l r : SyntacticObject) :
-    l * r = SyntacticObject.node l r := rfl
+@[simp] theorem mul_def (l r : SyntacticObject) : l * r = node l r := rfl
 
-theorem SyntacticObject.mul_comm (l r : SyntacticObject) : l * r = r * l := by
+theorem mul_comm (l r : SyntacticObject) : l * r = r * l := by
   apply Subtype.ext
-  rw [SyntacticObject.mul_def, SyntacticObject.mul_def, SyntacticObject.node_val,
-      SyntacticObject.node_val, Multiset.pair_comm]
+  rw [mul_def, mul_def, node_val, node_val, Multiset.pair_comm]
 
 /-! ### The canonical Merge operators (carrier primitives)
 
@@ -88,11 +85,10 @@ computable `DecidableEq (Nonplanar …)` (#792) in scope. -/
     the
     re-merge stage of Internal Merge. Noncomputable; build concrete results with the
     planar DSL + `decide`. -/
-noncomputable def SyntacticObject.merge (S S' : SyntacticObject) : SyntacticObject :=
-  SyntacticObject.node S S'
+noncomputable def merge (S S' : SyntacticObject) : SyntacticObject := node S S'
 
-@[simp] theorem SyntacticObject.merge_val (S S' : SyntacticObject) :
-    (SyntacticObject.merge S S').val = Nonplanar.node (Sum.inr ()) {S.val, S'.val} := rfl
+@[simp] theorem merge_val (S S' : SyntacticObject) :
+    (merge S S').val = Nonplanar.node (Sum.inr ()) {S.val, S'.val} := rfl
 
 /-- **Internal Merge on the carrier** ([marcolli-chomsky-berwick-2025] Prop 1.4.2):
     re-Merge the `mover` with the **deletion remainder** `remainder = T/mover` (the
@@ -100,66 +96,58 @@ noncomputable def SyntacticObject.merge (S S' : SyntacticObject) : SyntacticObje
     primitive — it is `SyntacticObject.merge` of the remainder and the mover. The mover ↔ trace
     correspondence (the chain) is read at the workspace level (`Workspace.chainMultiplicity`),
     not from an index. -/
-noncomputable def SyntacticObject.intMerge (mover remainder : SyntacticObject) : SyntacticObject :=
-  SyntacticObject.merge remainder mover
+noncomputable def intMerge (mover remainder : SyntacticObject) : SyntacticObject :=
+  merge remainder mover
 
-@[simp] theorem SyntacticObject.intMerge_val (mover remainder : SyntacticObject) :
-    (SyntacticObject.intMerge mover remainder).val
-      = Nonplanar.node (Sum.inr ()) {remainder.val, mover.val} := rfl
+@[simp] theorem intMerge_val (mover remainder : SyntacticObject) :
+    (intMerge mover remainder).val = Nonplanar.node (Sum.inr ()) {remainder.val, mover.val} := rfl
 
 /-! ### Lexical-leaf construction (the legacy `mkLeaf` API) -/
 
 /-- A lexical leaf from a category and selectional stack. -/
-def SyntacticObject.mkLeaf (cat : Cat) (sel : SelStack) (id : Nat) : SyntacticObject :=
-  SyntacticObject.lexLeaf ⟨.simple cat sel, id⟩
+def mkLeaf (cat : Cat) (sel : SelStack) (id : Nat) : SyntacticObject :=
+  lexLeaf ⟨.simple cat sel, id⟩
 
 /-- A lexical leaf with a phonological form. -/
-def SyntacticObject.mkLeafPhon (cat : Cat) (sel : SelStack) (phon : String) (id : Nat) :
-    SyntacticObject :=
-  SyntacticObject.lexLeaf ⟨.simple cat sel (phonForm := phon), id⟩
+def mkLeafPhon (cat : Cat) (sel : SelStack) (phon : String) (id : Nat) : SyntacticObject :=
+  lexLeaf ⟨.simple cat sel (phonForm := phon), id⟩
 
 /-! ### Accessors -/
 
 /-- The lexical token at the root, if the root is a lexical leaf. -/
-def SyntacticObject.getLIToken (s : SyntacticObject) : Option LIToken :=
+def getLIToken (s : SyntacticObject) : Option LIToken :=
   match Nonplanar.rootValue s.val with
   | .inl tok => some tok
   | .inr () => none
 
-@[simp] theorem SyntacticObject.getLIToken_lexLeaf (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).getLIToken = some tok := rfl
+@[simp] theorem getLIToken_lexLeaf (tok : LIToken) : (lexLeaf tok).getLIToken = some tok := rfl
 
-@[simp] theorem SyntacticObject.getLIToken_traceLeaf :
-    SyntacticObject.traceLeaf.getLIToken = none := rfl
+@[simp] theorem getLIToken_traceLeaf : traceLeaf.getLIToken = none := rfl
 
-@[simp] theorem SyntacticObject.getLIToken_node (l r : SyntacticObject) :
-    (SyntacticObject.node l r).getLIToken = none := by
-  rw [SyntacticObject.getLIToken, SyntacticObject.node_val, Nonplanar.rootValue_node]
+@[simp] theorem getLIToken_node (l r : SyntacticObject) : (node l r).getLIToken = none := by
+  rw [getLIToken, node_val, Nonplanar.rootValue_node]
 
 /-- A trace is the unique bare trace leaf (chain identity is workspace-level). -/
-def SyntacticObject.isTrace (s : SyntacticObject) : Prop := s = SyntacticObject.traceLeaf
+def isTrace (s : SyntacticObject) : Prop := s = traceLeaf
 
-instance (s : SyntacticObject) : Decidable (SyntacticObject.isTrace s) :=
+instance (s : SyntacticObject) : Decidable (isTrace s) :=
   inferInstanceAs (Decidable (_ = _))
 
-@[simp] theorem SyntacticObject.isTrace_traceLeaf :
-    SyntacticObject.isTrace SyntacticObject.traceLeaf := rfl
+@[simp] theorem isTrace_traceLeaf : isTrace traceLeaf := rfl
 
 /-- Leaf count (number of leaves + traces). -/
-def SyntacticObject.leafCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val
+def leafCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val
 
 /-- Is `s` a leaf (lexical or trace)? A leaf has a single vertex; a bare binary node
     has ≥ 2 leaves. -/
-def SyntacticObject.isLeaf (s : SyntacticObject) : Bool := s.leafCount == 1
+def isLeaf (s : SyntacticObject) : Bool := s.leafCount == 1
 
 /-- Is `s` a (bare binary) internal node? The complement of `SyntacticObject.isLeaf`. -/
-def SyntacticObject.isNode (s : SyntacticObject) : Bool := !s.isLeaf
+def isNode (s : SyntacticObject) : Bool := !s.isLeaf
 
-@[simp] theorem SyntacticObject.isLeaf_lexLeaf (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).isLeaf = true := rfl
-@[simp] theorem SyntacticObject.isLeaf_traceLeaf : SyntacticObject.traceLeaf.isLeaf = true := rfl
-@[simp] theorem SyntacticObject.isNode_lexLeaf (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).isNode = false := rfl
+@[simp] theorem isLeaf_lexLeaf (tok : LIToken) : (lexLeaf tok).isLeaf = true := rfl
+@[simp] theorem isLeaf_traceLeaf : traceLeaf.isLeaf = true := rfl
+@[simp] theorem isNode_lexLeaf (tok : LIToken) : (lexLeaf tok).isNode = false := rfl
 
 /-- A lightweight `Repr` so structures with an `SyntacticObject` field can `deriving Repr`. The full
     tree is a `Nonplanar` quotient (no faithful structural readout without `Quot.out`);
@@ -172,26 +160,25 @@ instance : Repr SyntacticObject where
       else f!"⟨SyntacticObject node, {s.leafCount} leaves⟩"
 
 /-- Internal-node count = leaf count − 1 (full binary tree). -/
-def SyntacticObject.nodeCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val - 1
+def nodeCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val - 1
 
-@[simp] theorem SyntacticObject.leafCount_lexLeaf (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).leafCount = 1 := rfl
-@[simp] theorem SyntacticObject.leafCount_traceLeaf : SyntacticObject.traceLeaf.leafCount = 1 := rfl
+@[simp] theorem leafCount_lexLeaf (tok : LIToken) : (lexLeaf tok).leafCount = 1 := rfl
+@[simp] theorem leafCount_traceLeaf : traceLeaf.leafCount = 1 := rfl
+
+end SyntacticObject
 
 /-! ### `decide` demonstrations -/
 
 private def demoVP : SyntacticObject :=
-  SyntacticObject.ofPlanar (SyntacticObject.nodeP (SyntacticObject.leafP (mkTraceToken 0))
-    (SyntacticObject.leafP (mkTraceToken 1)))
+  ofPlanar (nodeP (leafP (mkTraceToken 0)) (leafP (mkTraceToken 1)))
 
 /-- The DSL-built tree is a genuine syntactic object. -/
 example : IsSO demoVP.val := by decide
 /-- Its head token reads back via `getLIToken` of the left leaf. -/
-example : (SyntacticObject.lexLeaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by decide
+example : (lexLeaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by decide
 /-- It has two leaves and one internal node. -/
 example : demoVP.leafCount = 2 ∧ demoVP.nodeCount = 1 := by decide
 /-- The trace leaf is recognized; a lexical leaf is not a trace. -/
-example : SyntacticObject.isTrace SyntacticObject.traceLeaf ∧
-    ¬ SyntacticObject.isTrace (SyntacticObject.lexLeaf (mkTraceToken 0)) := by decide
+example : isTrace traceLeaf ∧ ¬ isTrace (lexLeaf (mkTraceToken 0)) := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -37,7 +37,9 @@ ordered planar accumulator, since `final` (a `Nonplanar` quotient) is unordered.
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
+
+namespace SyntacticObject
 
 /-! ### Steps -/
 
@@ -45,7 +47,7 @@ open RootedTree
     only the mover; the trace it leaves is the bare `SyntacticObject.traceLeaf`, and the mover ↔
     trace
     chain lives at the workspace level (#795), not in a per-step index. -/
-inductive SyntacticObject.Step where
+inductive Step where
   /-- External Merge, new item as the left daughter. -/
   | emL (item : SyntacticObject)
   /-- External Merge, new item as the right daughter. -/
@@ -61,13 +63,11 @@ inductive SyntacticObject.Step where
     (replace-all) is
     its total extension to the multi-occurrence case (the chain is then read at the
     workspace level, Def 1.2.1). -/
-noncomputable def SyntacticObject.deleteAccessible (mover current : SyntacticObject) :
-    SyntacticObject :=
-  current.replace mover SyntacticObject.traceLeaf
+noncomputable def deleteAccessible (mover current : SyntacticObject) : SyntacticObject :=
+  current.replace mover traceLeaf
 
-@[simp] theorem SyntacticObject.deleteAccessible_val (mover current : SyntacticObject) :
-    (SyntacticObject.deleteAccessible mover current).val
-      = replaceN mover.val SyntacticObject.traceLeaf.val current.val := rfl
+@[simp] theorem deleteAccessible_val (mover current : SyntacticObject) :
+    (deleteAccessible mover current).val = replaceN mover.val traceLeaf.val current.val := rfl
 
 /-- Apply a derivation step to the current tree. **The derivation Merge *is* the
     workspace Merge by construction:** External Merge is `SyntacticObject.merge` (Lemma 1.4.1),
@@ -79,73 +79,72 @@ noncomputable def SyntacticObject.deleteAccessible (mover current : SyntacticObj
     *same*
     `SyntacticObject` (`apply_emL_eq_emR`); the left/right distinction matters only for the surface
     (PF) order, recovered downstream by the externalization replay. -/
-noncomputable def SyntacticObject.Step.apply (step : SyntacticObject.Step)
-    (current : SyntacticObject) : SyntacticObject :=
+noncomputable def Step.apply (step : Step) (current : SyntacticObject) : SyntacticObject :=
   match step with
-  | .emL item  => SyntacticObject.merge item current
-  | .emR item  => SyntacticObject.merge current item
-  | .im mover  => SyntacticObject.intMerge mover (SyntacticObject.deleteAccessible mover current)
+  | .emL item  => merge item current
+  | .emR item  => merge current item
+  | .im mover  => intMerge mover (deleteAccessible mover current)
 
 /-- External Merge unfolds to the canonical workspace EM `SyntacticObject.merge` (Lemma 1.4.1). -/
-theorem SyntacticObject.Step.apply_emL (item current : SyntacticObject) :
-    (SyntacticObject.Step.emL item).apply current = SyntacticObject.merge item current := rfl
+theorem Step.apply_emL (item current : SyntacticObject) :
+    (Step.emL item).apply current = merge item current := rfl
 
 /-- External Merge unfolds to the canonical workspace EM `SyntacticObject.merge` (Lemma 1.4.1). -/
-theorem SyntacticObject.Step.apply_emR (item current : SyntacticObject) :
-    (SyntacticObject.Step.emR item).apply current = SyntacticObject.merge current item := rfl
+theorem Step.apply_emR (item current : SyntacticObject) :
+    (Step.emR item).apply current = merge current item := rfl
 
 /-- **Internal Merge unfolds to the coproduct operator by construction.** The `im` step
     *is* the canonical workspace IM `SyntacticObject.intMerge` (MCB Prop 1.4.2) on the deletion
     remainder — definitionally, not via a bridge. Composing with `SyntacticObject.intMerge_toForest`
     gives the Δ^ρ-coproduct identity on the workspace. -/
-theorem SyntacticObject.Step.apply_im (mover current : SyntacticObject) :
-    (SyntacticObject.Step.im mover).apply current
-      = SyntacticObject.intMerge mover (SyntacticObject.deleteAccessible mover current) :=
-  rfl
+theorem Step.apply_im (mover current : SyntacticObject) :
+    (Step.im mover).apply current = intMerge mover (deleteAccessible mover current) := rfl
 
 /-- External Merge is side-indifferent on the unordered carrier: `emL` and `emR` build
     the same syntactic object (they diverge only at externalization). -/
-theorem SyntacticObject.Step.apply_emL_eq_emR (item current : SyntacticObject) :
-    (SyntacticObject.Step.emL item).apply current = (SyntacticObject.Step.emR item).apply current :=
+theorem Step.apply_emL_eq_emR (item current : SyntacticObject) :
+    (Step.emL item).apply current = (Step.emR item).apply current :=
   mul_comm item current
 
 /-! ### Derivations -/
 
 /-- An ordered derivation: an initial `SyntacticObject` together with a sequence of steps. -/
-structure SyntacticObject.Derivation where
+structure Derivation where
   /-- The initial syntactic object (a lexical item, in canonical derivations). -/
   initial : SyntacticObject
   /-- The ordered sequence of Merge/Move steps. -/
-  steps : List SyntacticObject.Step
+  steps : List Step
 
-namespace SyntacticObject.Derivation
+namespace Derivation
 
 /-- The final tree produced by applying every step in order. -/
-noncomputable def final (d : SyntacticObject.Derivation) : SyntacticObject :=
+noncomputable def final (d : Derivation) : SyntacticObject :=
   d.steps.foldl (fun so step => step.apply so) d.initial
 
 /-- The intermediate tree after the first `n` steps. -/
-noncomputable def stageAt (d : SyntacticObject.Derivation) (n : Nat) : SyntacticObject :=
+noncomputable def stageAt (d : Derivation) (n : Nat) : SyntacticObject :=
   (d.steps.take n).foldl (fun so step => step.apply so) d.initial
 
 /-- The number of derivation steps. -/
-def length (d : SyntacticObject.Derivation) : Nat := d.steps.length
+def length (d : Derivation) : Nat := d.steps.length
 
 /-- The movers — the subtrees that underwent Internal Merge. -/
-def movedItems (d : SyntacticObject.Derivation) : List SyntacticObject :=
+def movedItems (d : Derivation) : List SyntacticObject :=
   d.steps.filterMap fun
     | .im mover => some mover
     | _ => none
 
 /-- Stage `0` is the initial tree (no steps applied). -/
-@[simp] theorem stageAt_zero (d : SyntacticObject.Derivation) : d.stageAt 0 = d.initial := by
+@[simp] theorem stageAt_zero (d : Derivation) : d.stageAt 0 = d.initial := by
   simp [stageAt]
 
 /-- The stage at full length is the final tree. -/
-theorem stageAt_length (d : SyntacticObject.Derivation) : d.stageAt d.steps.length = d.final := by
+theorem stageAt_length (d : Derivation) : d.stageAt d.steps.length = d.final := by
   simp [stageAt, final, List.take_length]
 
-end SyntacticObject.Derivation
+end Derivation
+
+end SyntacticObject
 
 /-! ### Worked example
 
@@ -153,17 +152,14 @@ The movers of a small derivation are read directly off the steps (a `filterMap`,
 this is `decide`-able even though `final` is not): a derivation that internally merges
 two objects records exactly those two as moved. -/
 
-private def demoTok (i : Nat) : SyntacticObject := SyntacticObject.lexLeaf ⟨.simple .N [], i⟩
+private def demoTok (i : Nat) : SyntacticObject := lexLeaf ⟨.simple .N [], i⟩
 
 example :
-    (SyntacticObject.Derivation.mk (demoTok 0)
-      [SyntacticObject.Step.emL (demoTok 1), SyntacticObject.Step.im (demoTok 1),
-       SyntacticObject.Step.emR (demoTok 2), SyntacticObject.Step.im (demoTok 2)]).movedItems
-      = [demoTok 1, demoTok 2] := by
-  simp [SyntacticObject.Derivation.movedItems, demoTok]
+    (Derivation.mk (demoTok 0)
+      [Step.emL (demoTok 1), Step.im (demoTok 1),
+       Step.emR (demoTok 2), Step.im (demoTok 2)]).movedItems = [demoTok 1, demoTok 2] := by
+  simp [Derivation.movedItems, demoTok]
 
-example :
-    (SyntacticObject.Derivation.mk (demoTok 0) [SyntacticObject.Step.emL (demoTok 1)]).length = 1 :=
-      rfl
+example : (Derivation.mk (demoTok 0) [Step.emL (demoTok 1)]).length = 1 := rfl
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
@@ -30,7 +30,7 @@ are related by the reduction lemmas (`replace_lexLeaf`/`_traceLeaf`/`_node`), no
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
 
 /-! ### Substitution on the planar carrier -/
 
@@ -130,78 +130,70 @@ theorem replaceN_self (t r : Nonplanar SOLabel) : replaceN t r t = r := by
     `SyntacticObject` yields an `SyntacticObject` (the arity of every node is preserved). -/
 theorem replaceN_isSO (target replacement s : SyntacticObject) :
     IsSO (replaceN target.val replacement.val s.val) := by
-  induction s using SyntacticObject.ind with
+  induction s using ind with
   | lex tok =>
-    rw [show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
-        replaceN_leaf]
+    rw [show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl, replaceN_leaf]
     split
     · exact replacement.2
-    · exact (SyntacticObject.lexLeaf tok).2
+    · exact (lexLeaf tok).2
   | trace =>
-    rw [show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, replaceN_leaf]
+    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, replaceN_leaf]
     split
     · exact replacement.2
-    · exact SyntacticObject.traceLeaf.2
+    · exact traceLeaf.2
   | node l r ihl ihr =>
-    rw [SyntacticObject.node_val, replaceN_node]
+    rw [node_val, replaceN_node]
     split
     · exact replacement.2
     · show isSO (Nonplanar.node (Sum.inr ())
         {replaceN target.val replacement.val l.val, replaceN target.val replacement.val r.val}) = true
       rw [isSO_node_pair, ihl, ihr]; rfl
 
+namespace SyntacticObject
+
 /-- **Structural substitution** on the `SyntacticObject` carrier ([marcolli-chomsky-berwick-2025]
     §1.2): replace every subterm of `s` equal to `target` by `replacement`. The
     copy-theory use is `s.replace mover SyntacticObject.traceLeaf`. Noncomputable (rebuilds via
     `SyntacticObject.node`); reduce concrete cases via `replace_self`/`replace_node_of_ne`/
     `replace_lexLeaf_of_ne`. -/
-noncomputable def SyntacticObject.replace (s target replacement : SyntacticObject) :
-    SyntacticObject :=
+noncomputable def replace (s target replacement : SyntacticObject) : SyntacticObject :=
   ⟨replaceN target.val replacement.val s.val, replaceN_isSO target replacement s⟩
 
-@[simp] theorem SyntacticObject.replace_val (s target replacement : SyntacticObject) :
-    (SyntacticObject.replace s target replacement).val
-      = replaceN target.val replacement.val s.val := rfl
+@[simp] theorem replace_val (s target replacement : SyntacticObject) :
+    (replace s target replacement).val = replaceN target.val replacement.val s.val := rfl
 
 /-- Replacing the whole object by `replacement`. -/
-@[simp] theorem SyntacticObject.replace_self (target replacement : SyntacticObject) :
-    SyntacticObject.replace target target replacement = replacement :=
-  Subtype.ext (by rw [SyntacticObject.replace_val, replaceN_self])
+@[simp] theorem replace_self (target replacement : SyntacticObject) :
+    replace target target replacement = replacement :=
+  Subtype.ext (by rw [replace_val, replaceN_self])
 
 /-- At a node that is not itself the `target`, substitution recurses into both
     daughters (the Head Feature Principle of substitution: structure is preserved). -/
-theorem SyntacticObject.replace_node_of_ne {l r target replacement : SyntacticObject}
-    (h : SyntacticObject.node l r ≠ target) :
-    SyntacticObject.replace (SyntacticObject.node l r) target replacement
-      = SyntacticObject.node (SyntacticObject.replace l target replacement)
-          (SyntacticObject.replace r target replacement) := by
+theorem replace_node_of_ne {l r target replacement : SyntacticObject} (h : node l r ≠ target) :
+    replace (node l r) target replacement
+      = node (replace l target replacement) (replace r target replacement) := by
   apply Subtype.ext
-  rw [SyntacticObject.replace_val, SyntacticObject.node_val, replaceN_node, if_neg,
-      SyntacticObject.node_val, SyntacticObject.replace_val, SyntacticObject.replace_val]
-  rw [← SyntacticObject.node_val]
+  rw [replace_val, node_val, replaceN_node, if_neg, node_val, replace_val, replace_val]
+  rw [← node_val]
   exact fun heq => h (Subtype.ext heq)
 
 /-- A lexical leaf that is not the `target` is left unchanged. -/
-theorem SyntacticObject.replace_lexLeaf_of_ne {tok : LIToken} {target replacement : SyntacticObject}
-    (h : SyntacticObject.lexLeaf tok ≠ target) :
-    SyntacticObject.replace (SyntacticObject.lexLeaf tok) target replacement
-      = SyntacticObject.lexLeaf tok := by
+theorem replace_lexLeaf_of_ne {tok : LIToken} {target replacement : SyntacticObject}
+    (h : lexLeaf tok ≠ target) : replace (lexLeaf tok) target replacement = lexLeaf tok := by
   apply Subtype.ext
-  rw [SyntacticObject.replace_val,
-      show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+  rw [replace_val, show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
       replaceN_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
 
 /-- The bare trace leaf, not being the `target`, is left unchanged. -/
-theorem SyntacticObject.replace_traceLeaf_of_ne {target replacement : SyntacticObject}
-    (h : SyntacticObject.traceLeaf ≠ target) :
-    SyntacticObject.replace SyntacticObject.traceLeaf target replacement
-      = SyntacticObject.traceLeaf := by
+theorem replace_traceLeaf_of_ne {target replacement : SyntacticObject}
+    (h : traceLeaf ≠ target) : replace traceLeaf target replacement = traceLeaf := by
   apply Subtype.ext
-  rw [SyntacticObject.replace_val,
-      show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+  rw [replace_val, show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
       replaceN_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
+
+end SyntacticObject
 
 /-! ### Worked example
 
@@ -212,10 +204,8 @@ from weight via `Subterm`'s `immediatelyContains_lt_weight`), taken as a hypothe
 here to keep this module's dependencies minimal. Substitution is noncomputable, so this
 is a structural proof, not a `decide`. -/
 
-example (l r : SyntacticObject) (h : SyntacticObject.node l r ≠ r) :
-    SyntacticObject.replace (SyntacticObject.node l r) r SyntacticObject.traceLeaf
-      = SyntacticObject.node (SyntacticObject.replace l r SyntacticObject.traceLeaf)
-          SyntacticObject.traceLeaf := by
-  rw [SyntacticObject.replace_node_of_ne h, SyntacticObject.replace_self]
+example (l r : SyntacticObject) (h : node l r ≠ r) :
+    replace (node l r) r traceLeaf = node (replace l r traceLeaf) traceLeaf := by
+  rw [replace_node_of_ne h, replace_self]
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -29,7 +29,7 @@ head functions it is partial: `0` at exocentric nodes.
 * `Minimalist.SyntacticObject.selHead`, `Minimalist.SyntacticObject.outerCatC`:
   the head token and its outer category — the foundation the Phase API consumes
   (`isPhaseHeadOf`).
-* `Minimalist.selCheckHom`: `selCheck` as a morphism of magmas
+* `Minimalist.SyntacticObject.selCheckHom`: `selCheck` as a morphism of magmas
   `SyntacticObject →ₙ* SelectionState`, via `SyntacticObject.lift`.
 
 ## Main results
@@ -54,7 +54,7 @@ trace leaf gets the canonical saturated value `.of (mkTraceToken 0) []`;
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
 
 /-! ### The selection state -/
 
@@ -156,13 +156,12 @@ theorem SelectionState.head_mul {r : LIToken}
 /-- The selection algebra: the `SyntacticObject.mergeAlgebra` of token + `outerSel`
     leaves and the saturated, index-free trace. -/
 def selNode : SOLabel → List SelectionState → SelectionState :=
-  SyntacticObject.mergeAlgebra (fun tok => .of tok tok.item.outerSel)
-    (.of (mkTraceToken 0) [])
+  mergeAlgebra (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
 
 /-- `selNode` is invariant under permutation of the daughter states. -/
 theorem selNode_perm (a : SOLabel) {l₁ l₂ : List SelectionState} (h : l₁.Perm l₂) :
     selNode a l₁ = selNode a l₂ :=
-  SyntacticObject.mergeAlgebra_perm _ _ a h
+  mergeAlgebra_perm _ _ a h
 
 /-- Selection check on a planar tree: the catamorphism of `selNode`. -/
 def selCheckPlanar : RoseTree SOLabel → SelectionState :=
@@ -180,63 +179,61 @@ theorem selCheckPlanar_perm {t s : RoseTree SOLabel} (h : RoseTree.Perm t s) :
 
 /-- Selection check on the nonplanar carrier. -/
 def selCheckN : Nonplanar SOLabel → SelectionState :=
-  SyntacticObject.liftN (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
+  liftN (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
 
 @[simp] theorem selCheckN_mk (p : RoseTree SOLabel) :
     selCheckN (Nonplanar.mk p) = selCheckPlanar p := rfl
 
 theorem selCheckN_node (a b : Nonplanar SOLabel) :
     selCheckN (Nonplanar.node (Sum.inr ()) {a, b}) = selCheckN a * selCheckN b :=
-  SyntacticObject.liftN_node _ _ a b
+  liftN_node _ _ a b
 
 /-! ### The selection-driven head on `SyntacticObject` -/
 
 variable (s : SyntacticObject) (tok : LIToken)
 
+namespace SyntacticObject
+
 /-- **Selection-driven head check**: the selection instance of
     [marcolli-chomsky-berwick-2025]'s head functions; computable. -/
-def SyntacticObject.selCheck : SelectionState := selCheckN s.val
+def selCheck : SelectionState := selCheckN s.val
 
 /-- The projecting head's lexical item, by c-selection. -/
-def SyntacticObject.selHead : Option LIToken := s.selCheck.head
+def selHead : Option LIToken := s.selCheck.head
 
 /-- Residual pending selectional features (`some []` = saturated). -/
-def SyntacticObject.checkedSel : Option (List Cat) := s.selCheck.residual
+def checkedSel : Option (List Cat) := s.selCheck.residual
 
 /-- The projecting head's **outer category** (the phase-head selector); `none` at
     exocentric nodes. -/
-def SyntacticObject.outerCatC : Option Cat := s.selHead.map (·.item.outerCat)
+def outerCatC : Option Cat := s.selHead.map (·.item.outerCat)
 
-@[simp] theorem SyntacticObject.selCheck_lexLeaf :
-    (SyntacticObject.lexLeaf tok).selCheck = .of tok tok.item.outerSel := rfl
+@[simp] theorem selCheck_lexLeaf : (lexLeaf tok).selCheck = .of tok tok.item.outerSel := rfl
 
-@[simp] theorem SyntacticObject.selCheck_traceLeaf :
-    SyntacticObject.traceLeaf.selCheck = .of (mkTraceToken 0) [] := rfl
+@[simp] theorem selCheck_traceLeaf : traceLeaf.selCheck = .of (mkTraceToken 0) [] := rfl
 
-@[simp] theorem SyntacticObject.selCheck_node (l r : SyntacticObject) :
-    (SyntacticObject.node l r).selCheck = l.selCheck * r.selCheck :=
-  SyntacticObject.liftFun_node _ _ l r
+@[simp] theorem selCheck_node (l r : SyntacticObject) :
+    (node l r).selCheck = l.selCheck * r.selCheck := liftFun_node _ _ l r
 
 /-- `selCheck` as a morphism of magmas ([marcolli-chomsky-berwick-2025] §1.13's
-    algebraic frame): the `SyntacticObject.lift` of the leaf data. -/
+    algebraic frame): the `lift` of the leaf data. -/
 noncomputable def selCheckHom : SyntacticObject →ₙ* SelectionState :=
-  SyntacticObject.lift (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
+  lift (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
 
 @[simp] theorem selCheckHom_apply : selCheckHom s = s.selCheck := rfl
 
-@[simp] theorem SyntacticObject.selHead_lexLeaf :
-    (SyntacticObject.lexLeaf tok).selHead = some tok := rfl
+@[simp] theorem selHead_lexLeaf : (lexLeaf tok).selHead = some tok := rfl
 
 /-- **Endocentricity**: a node's projecting head is one of its daughters' heads —
     bare-phrase-structure projection ([chomsky-1995-bare] §4, abstracted as
     [marcolli-chomsky-berwick-2025] Definition 1.13.6 / Lemma 1.13.7). -/
-theorem SyntacticObject.selHead_node {l r : SyntacticObject} {h : LIToken}
-    (hlr : (SyntacticObject.node l r).selHead = some h) :
+theorem selHead_node {l r : SyntacticObject} {h : LIToken} (hlr : (node l r).selHead = some h) :
     l.selHead = some h ∨ r.selHead = some h := by
-  simp only [SyntacticObject.selHead, SyntacticObject.selCheck_node] at hlr ⊢
+  simp only [selHead, selCheck_node] at hlr ⊢
   exact SelectionState.head_mul hlr
 
-@[simp] theorem SyntacticObject.outerCatC_lexLeaf :
-    (SyntacticObject.lexLeaf tok).outerCatC = some tok.item.outerCat := rfl
+@[simp] theorem outerCatC_lexLeaf : (lexLeaf tok).outerCatC = some tok.item.outerCat := rfl
+
+end SyntacticObject
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
@@ -25,36 +25,40 @@ variants.
 
 namespace Minimalist
 
-open RootedTree
+open RootedTree SyntacticObject
 
 /-! ### Immediate containment (via `Nonplanar.rootChildren`) -/
 
+namespace SyntacticObject
+
 /-- `x` **immediately contains** `y`: `y` is one of `x`'s root daughters
     ([marcolli-chomsky-berwick-2025] §1.1; Definition 13 of the legacy theory). -/
-def SyntacticObject.immediatelyContains (x y : SyntacticObject) : Prop :=
+def immediatelyContains (x y : SyntacticObject) : Prop :=
   y.val ∈ Nonplanar.rootChildren x.val
 
-instance (x y : SyntacticObject) : Decidable (SyntacticObject.immediatelyContains x y) :=
+instance (x y : SyntacticObject) : Decidable (immediatelyContains x y) :=
   inferInstanceAs (Decidable (_ ∈ _))
 
-@[simp] theorem SyntacticObject.immediatelyContains_lexLeaf (tok : LIToken) (y : SyntacticObject) :
-    ¬ SyntacticObject.immediatelyContains (SyntacticObject.lexLeaf tok) y := by
-  simp only [SyntacticObject.immediatelyContains, SyntacticObject.lexLeaf, Nonplanar.leaf,
+@[simp] theorem immediatelyContains_lexLeaf (tok : LIToken) (y : SyntacticObject) :
+    ¬ immediatelyContains (lexLeaf tok) y := by
+  simp only [immediatelyContains, lexLeaf, Nonplanar.leaf,
     Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
     Multiset.notMem_zero, not_false_iff]
 
-@[simp] theorem SyntacticObject.immediatelyContains_traceLeaf (y : SyntacticObject) :
-    ¬ SyntacticObject.immediatelyContains SyntacticObject.traceLeaf y := by
-  simp only [SyntacticObject.immediatelyContains, SyntacticObject.traceLeaf, Nonplanar.leaf,
+@[simp] theorem immediatelyContains_traceLeaf (y : SyntacticObject) :
+    ¬ immediatelyContains traceLeaf y := by
+  simp only [immediatelyContains, traceLeaf, Nonplanar.leaf,
     Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
     Multiset.notMem_zero, not_false_iff]
 
-@[simp] theorem SyntacticObject.immediatelyContains_node (l r y : SyntacticObject) :
-    SyntacticObject.immediatelyContains (SyntacticObject.node l r) y ↔ y = l ∨ y = r := by
-  rw [SyntacticObject.immediatelyContains, SyntacticObject.node_val, Nonplanar.rootChildren_node,
+@[simp] theorem immediatelyContains_node (l r y : SyntacticObject) :
+    immediatelyContains (node l r) y ↔ y = l ∨ y = r := by
+  rw [immediatelyContains, node_val, Nonplanar.rootChildren_node,
       Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton]
   exact ⟨fun h => h.imp Subtype.ext Subtype.ext,
          fun h => h.imp (congrArg Subtype.val) (congrArg Subtype.val)⟩
+
+end SyntacticObject
 
 /-! ### Subterm enumeration
 
@@ -145,71 +149,71 @@ theorem self_mem_subtreesN (u : Nonplanar SOLabel) : u ∈ subtreesN u := by
 
 /-- Subtrees of a syntactic object are themselves syntactic objects. -/
 theorem subtreesN_closure (s : SyntacticObject) : ∀ m ∈ subtreesN s.val, IsSO m := by
-  induction s using SyntacticObject.ind with
+  induction s using ind with
   | lex tok =>
     intro m hm
-    rw [show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         mem_subtreesN_leaf] at hm
-    subst hm; exact (SyntacticObject.lexLeaf tok).2
+    subst hm; exact (lexLeaf tok).2
   | trace =>
     intro m hm
-    rw [show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
         mem_subtreesN_leaf] at hm
-    subst hm; exact SyntacticObject.traceLeaf.2
+    subst hm; exact traceLeaf.2
   | node l r ihl ihr =>
     intro m hm
-    rw [SyntacticObject.node_val, mem_subtreesN_node] at hm
+    rw [node_val, mem_subtreesN_node] at hm
     rcases hm with rfl | hl | hr
-    · exact (SyntacticObject.node l r).2
+    · exact (node l r).2
     · exact ihl m hl
     · exact ihr m hr
 
+namespace SyntacticObject
+
 /-- All subtrees of a syntactic object (incl. the root), as syntactic objects
     ([marcolli-chomsky-berwick-2025] §1.2; the legacy `SyntacticObject.subtrees`). -/
-def SyntacticObject.subtrees (s : SyntacticObject) : Multiset SyntacticObject :=
+def subtrees (s : SyntacticObject) : Multiset SyntacticObject :=
   (subtreesN s.val).pmap (fun m h => ⟨m, h⟩) (subtreesN_closure s)
 
-@[simp] theorem SyntacticObject.mem_subtrees {x s : SyntacticObject} :
+@[simp] theorem mem_subtrees {x s : SyntacticObject} :
     x ∈ s.subtrees ↔ x.val ∈ subtreesN s.val := by
-  rw [SyntacticObject.subtrees, Multiset.mem_pmap]
+  rw [subtrees, Multiset.mem_pmap]
   constructor
   · rintro ⟨m, hm, he⟩; rw [← he]; exact hm
   · intro h; exact ⟨x.val, h, Subtype.ext rfl⟩
 
 /-- The root is among its own subtrees. -/
-theorem SyntacticObject.self_mem_subtrees (s : SyntacticObject) : s ∈ s.subtrees := by
-  rw [SyntacticObject.mem_subtrees]; exact self_mem_subtreesN s.val
+theorem self_mem_subtrees (s : SyntacticObject) : s ∈ s.subtrees := by
+  rw [mem_subtrees]; exact self_mem_subtreesN s.val
 
 /-- Subtree membership at a bare binary node: the node itself, or a subtree of a
     daughter. -/
-@[simp] theorem SyntacticObject.mem_subtrees_node {x l r : SyntacticObject} :
-    x ∈ (SyntacticObject.node l r).subtrees ↔
-      x = SyntacticObject.node l r ∨ x ∈ l.subtrees ∨ x ∈ r.subtrees := by
-  rw [SyntacticObject.mem_subtrees, SyntacticObject.node_val, mem_subtreesN_node,
-      ← SyntacticObject.mem_subtrees, ← SyntacticObject.mem_subtrees]
-  exact Iff.or ⟨fun h => Subtype.ext h, fun h => by rw [h, SyntacticObject.node_val]⟩ Iff.rfl
+@[simp] theorem mem_subtrees_node {x l r : SyntacticObject} :
+    x ∈ (node l r).subtrees ↔ x = node l r ∨ x ∈ l.subtrees ∨ x ∈ r.subtrees := by
+  rw [mem_subtrees, node_val, mem_subtreesN_node, ← mem_subtrees, ← mem_subtrees]
+  exact Iff.or ⟨fun h => Subtype.ext h, fun h => by rw [h, node_val]⟩ Iff.rfl
 
 /-- `subtrees` is downward-closed along the subtree relation: every subtree of a
     subtree of `s` is a subtree of `s`. -/
-theorem SyntacticObject.subtrees_subset_of_mem {w s : SyntacticObject} (h : w ∈ s.subtrees) :
+theorem subtrees_subset_of_mem {w s : SyntacticObject} (h : w ∈ s.subtrees) :
     w.subtrees ⊆ s.subtrees := by
-  induction s using SyntacticObject.ind with
+  induction s using ind with
   | lex tok =>
-    rw [SyntacticObject.mem_subtrees,
-        show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [mem_subtrees, show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         mem_subtreesN_leaf] at h
-    rw [(Subtype.ext h : w = SyntacticObject.lexLeaf tok)]; exact Multiset.Subset.refl _
+    rw [(Subtype.ext h : w = lexLeaf tok)]; exact Multiset.Subset.refl _
   | trace =>
-    rw [SyntacticObject.mem_subtrees,
-        show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
         mem_subtreesN_leaf] at h
-    rw [(Subtype.ext h : w = SyntacticObject.traceLeaf)]; exact Multiset.Subset.refl _
+    rw [(Subtype.ext h : w = traceLeaf)]; exact Multiset.Subset.refl _
   | node l r ihl ihr =>
-    rw [SyntacticObject.mem_subtrees_node] at h
+    rw [mem_subtrees_node] at h
     rcases h with rfl | hl | hr
     · exact Multiset.Subset.refl _
-    · intro z hz; rw [SyntacticObject.mem_subtrees_node]; exact Or.inr (Or.inl (ihl hl hz))
-    · intro z hz; rw [SyntacticObject.mem_subtrees_node]; exact Or.inr (Or.inr (ihr hr hz))
+    · intro z hz; rw [mem_subtrees_node]; exact Or.inr (Or.inl (ihl hl hz))
+    · intro z hz; rw [mem_subtrees_node]; exact Or.inr (Or.inr (ihr hr hz))
+
+end SyntacticObject
 
 /-! ### Cardinality (MCB's vertex/accessible-term counts, Def 1.2.2 eq. 1.2.5) -/
 
@@ -232,11 +236,12 @@ theorem subtreesN_card (u : Nonplanar SOLabel) :
     (subtreesN u).card = Nonplanar.numNodes u :=
   Quotient.inductionOn u subtreesNPlanar_card
 
+namespace SyntacticObject
+
 /-- **`subtrees` enumerates the vertices** ([marcolli-chomsky-berwick-2025] Def 1.2.2:
     `subtrees = Acc'(T)`, so its size is `#V(T)`, the MCB workspace-size primitive). -/
-theorem SyntacticObject.subtrees_card (s : SyntacticObject) :
-    (s.subtrees).card = Nonplanar.numNodes s.val := by
-  rw [SyntacticObject.subtrees, Multiset.card_pmap, subtreesN_card]
+theorem subtrees_card (s : SyntacticObject) : (s.subtrees).card = Nonplanar.numNodes s.val := by
+  rw [subtrees, Multiset.card_pmap, subtreesN_card]
 
 /-! ### Accessible terms `Acc(T)` (Def 1.2.2) -/
 
@@ -244,25 +249,24 @@ theorem SyntacticObject.subtrees_card (s : SyntacticObject) :
     Def 1.2.2, eq. 1.2.2): the subtrees at **all non-root vertices** (leaves
     included — the counting identity eq. 1.2.5 `#V = b₀ + #Acc` forces this).
     Defined as `subtrees − {self}` (`Acc'(T) = {T} ∪ Acc(T)`, eq. 1.2.3). -/
-def SyntacticObject.Acc (s : SyntacticObject) : Multiset SyntacticObject := s.subtrees - {s}
+def Acc (s : SyntacticObject) : Multiset SyntacticObject := s.subtrees - {s}
 
 /-- **MCB counting identity** (eq. 1.2.5, one-component case): `#Acc(T) = #V(T) − 1`. -/
-theorem SyntacticObject.Acc_card (s : SyntacticObject) :
-    (s.Acc).card = Nonplanar.numNodes s.val - 1 := by
-  rw [SyntacticObject.Acc,
-      Multiset.card_sub (Multiset.singleton_le.mpr (SyntacticObject.self_mem_subtrees s)),
-      SyntacticObject.subtrees_card, Multiset.card_singleton]
+theorem Acc_card (s : SyntacticObject) : (s.Acc).card = Nonplanar.numNodes s.val - 1 := by
+  rw [Acc, Multiset.card_sub (Multiset.singleton_le.mpr (self_mem_subtrees s)),
+      subtrees_card, Multiset.card_singleton]
 
-@[simp] theorem SyntacticObject.Acc_lexLeaf (tok : LIToken) :
-    (SyntacticObject.lexLeaf tok).Acc = 0 := by
-  rw [← Multiset.card_eq_zero, SyntacticObject.Acc_card,
-      show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+@[simp] theorem Acc_lexLeaf (tok : LIToken) : (lexLeaf tok).Acc = 0 := by
+  rw [← Multiset.card_eq_zero, Acc_card,
+      show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
       Nonplanar.numNodes_leaf]
 
-@[simp] theorem SyntacticObject.Acc_traceLeaf : SyntacticObject.traceLeaf.Acc = 0 := by
-  rw [← Multiset.card_eq_zero, SyntacticObject.Acc_card,
-      show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+@[simp] theorem Acc_traceLeaf : traceLeaf.Acc = 0 := by
+  rw [← Multiset.card_eq_zero, Acc_card,
+      show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
       Nonplanar.numNodes_leaf]
+
+end SyntacticObject
 
 /-! ### Containment / dominance -/
 
@@ -281,166 +285,157 @@ theorem weight_node_pair (a b : Nonplanar SOLabel) :
   show (RoseTree.node (Sum.inr ()) [pa, pb]).numNodes = pa.numNodes + pb.numNodes + 1
   simp only [RoseTree.numNodes_node, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil]; omega
 
+namespace SyntacticObject
+
 /-- **Containment (dominance)** is the transitive closure of immediate containment
     ([marcolli-chomsky-berwick-2025] §1.1; the legacy `contains`). -/
-inductive SyntacticObject.contains : SyntacticObject → SyntacticObject → Prop
-  | imm : ∀ x y, SyntacticObject.immediatelyContains x y → SyntacticObject.contains x y
-  | trans : ∀ x y z, SyntacticObject.immediatelyContains x z → SyntacticObject.contains z y →
-      SyntacticObject.contains x y
+inductive contains : SyntacticObject → SyntacticObject → Prop
+  | imm : ∀ x y, immediatelyContains x y → contains x y
+  | trans : ∀ x y z, immediatelyContains x z → contains z y → contains x y
 
-theorem SyntacticObject.imm_implies_contains {x y : SyntacticObject}
-    (h : SyntacticObject.immediatelyContains x y) : SyntacticObject.contains x y := .imm x y h
+theorem imm_implies_contains {x y : SyntacticObject} (h : immediatelyContains x y) :
+    contains x y := .imm x y h
 
-theorem SyntacticObject.contains_trans {x y z : SyntacticObject}
-    (hxy : SyntacticObject.contains x y) (hyz : SyntacticObject.contains y z) :
-    SyntacticObject.contains x z := by
+theorem contains_trans {x y z : SyntacticObject} (hxy : contains x y) (hyz : contains y z) :
+    contains x z := by
   induction hxy with
   | imm x y himm => exact .trans x z y himm hyz
   | trans x y w himm _ ih => exact .trans x z w himm (ih hyz)
 
 /-- Immediate containment strictly decreases weight. -/
-theorem SyntacticObject.immediatelyContains_lt_weight {x y : SyntacticObject}
-    (h : SyntacticObject.immediatelyContains x y) :
+theorem immediatelyContains_lt_weight {x y : SyntacticObject} (h : immediatelyContains x y) :
     Nonplanar.numNodes y.val < Nonplanar.numNodes x.val := by
-  rcases SyntacticObject.exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
-  · exact absurd h (SyntacticObject.immediatelyContains_lexLeaf tok y)
-  · exact absurd h (SyntacticObject.immediatelyContains_traceLeaf y)
-  · rw [SyntacticObject.immediatelyContains_node] at h
-    rw [SyntacticObject.node_val, weight_node_pair]
+  rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
+  · exact absurd h (immediatelyContains_lexLeaf tok y)
+  · exact absurd h (immediatelyContains_traceLeaf y)
+  · rw [immediatelyContains_node] at h
+    rw [node_val, weight_node_pair]
     rcases h with rfl | rfl <;> omega
 
 /-- Containment strictly decreases weight; hence it is irreflexive. -/
-theorem SyntacticObject.contains_lt_weight {x y : SyntacticObject}
-    (h : SyntacticObject.contains x y) :
+theorem contains_lt_weight {x y : SyntacticObject} (h : contains x y) :
     Nonplanar.numNodes y.val < Nonplanar.numNodes x.val := by
   induction h with
-  | imm _ _ himm => exact SyntacticObject.immediatelyContains_lt_weight himm
-  | trans _ _ _ himm _ ih => exact lt_trans ih (SyntacticObject.immediatelyContains_lt_weight himm)
+  | imm _ _ himm => exact immediatelyContains_lt_weight himm
+  | trans _ _ _ himm _ ih => exact lt_trans ih (immediatelyContains_lt_weight himm)
 
-theorem SyntacticObject.contains_irrefl (x : SyntacticObject) : ¬ SyntacticObject.contains x x :=
-  fun h => absurd (SyntacticObject.contains_lt_weight h) (lt_irrefl _)
+theorem contains_irrefl (x : SyntacticObject) : ¬ contains x x :=
+  fun h => absurd (contains_lt_weight h) (lt_irrefl _)
 
 /-! ### Subtree ↔ containment bridge -/
 
-theorem SyntacticObject.mem_subtrees_of_immediatelyContains {x y : SyntacticObject}
-    (h : SyntacticObject.immediatelyContains x y) :
-    y ∈ x.subtrees := by
-  rcases SyntacticObject.exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
-  · exact absurd h (SyntacticObject.immediatelyContains_lexLeaf tok y)
-  · exact absurd h (SyntacticObject.immediatelyContains_traceLeaf y)
-  · rw [SyntacticObject.immediatelyContains_node] at h
+theorem mem_subtrees_of_immediatelyContains {x y : SyntacticObject}
+    (h : immediatelyContains x y) : y ∈ x.subtrees := by
+  rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
+  · exact absurd h (immediatelyContains_lexLeaf tok y)
+  · exact absurd h (immediatelyContains_traceLeaf y)
+  · rw [immediatelyContains_node] at h
     rcases h with heq | heq
-    · rw [heq, SyntacticObject.mem_subtrees_node]
-      exact Or.inr (Or.inl (SyntacticObject.self_mem_subtrees l))
-    · rw [heq, SyntacticObject.mem_subtrees_node]
-      exact Or.inr (Or.inr (SyntacticObject.self_mem_subtrees r))
+    · rw [heq, mem_subtrees_node]
+      exact Or.inr (Or.inl (self_mem_subtrees l))
+    · rw [heq, mem_subtrees_node]
+      exact Or.inr (Or.inr (self_mem_subtrees r))
 
-theorem SyntacticObject.mem_subtrees_of_contains {x y : SyntacticObject}
-    (h : SyntacticObject.contains x y) : y ∈ x.subtrees := by
+theorem mem_subtrees_of_contains {x y : SyntacticObject} (h : contains x y) :
+    y ∈ x.subtrees := by
   induction h with
-  | imm x y himm => exact SyntacticObject.mem_subtrees_of_immediatelyContains himm
+  | imm x y himm => exact mem_subtrees_of_immediatelyContains himm
   | trans x y w himm _ ih =>
-    exact SyntacticObject.subtrees_subset_of_mem
-      (SyntacticObject.mem_subtrees_of_immediatelyContains himm) ih
+    exact subtrees_subset_of_mem (mem_subtrees_of_immediatelyContains himm) ih
 
 /-- A subtree of `x` is either `x` itself or properly contained in `x`. -/
-theorem SyntacticObject.mem_subtrees_iff_eq_or_contains {x y : SyntacticObject} :
-    y ∈ x.subtrees ↔ y = x ∨ SyntacticObject.contains x y := by
-  refine ⟨fun h => ?_, fun h => h.elim (fun he => he ▸ SyntacticObject.self_mem_subtrees x)
-    SyntacticObject.mem_subtrees_of_contains⟩
-  induction x using SyntacticObject.ind with
+theorem mem_subtrees_iff_eq_or_contains {x y : SyntacticObject} :
+    y ∈ x.subtrees ↔ y = x ∨ contains x y := by
+  refine ⟨fun h => ?_, fun h => h.elim (fun he => he ▸ self_mem_subtrees x)
+    mem_subtrees_of_contains⟩
+  induction x using ind with
   | lex tok =>
-    rw [SyntacticObject.mem_subtrees,
-        show (SyntacticObject.lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [mem_subtrees, show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         mem_subtreesN_leaf] at h
     exact Or.inl (Subtype.ext h)
   | trace =>
-    rw [SyntacticObject.mem_subtrees,
-        show SyntacticObject.traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
         mem_subtreesN_leaf] at h
     exact Or.inl (Subtype.ext h)
   | node l r ihl ihr =>
-    rw [SyntacticObject.mem_subtrees_node] at h
+    rw [mem_subtrees_node] at h
     rcases h with rfl | hl | hr
     · exact Or.inl rfl
     · refine Or.inr ?_
       rcases ihl hl with heq | hc
-      · rw [heq]; exact .imm _ _ ((SyntacticObject.immediatelyContains_node l r l).mpr (Or.inl rfl))
-      · exact .trans _ _ l ((SyntacticObject.immediatelyContains_node l r l).mpr (Or.inl rfl)) hc
+      · rw [heq]; exact .imm _ _ ((immediatelyContains_node l r l).mpr (Or.inl rfl))
+      · exact .trans _ _ l ((immediatelyContains_node l r l).mpr (Or.inl rfl)) hc
     · refine Or.inr ?_
       rcases ihr hr with heq | hc
-      · rw [heq]; exact .imm _ _ ((SyntacticObject.immediatelyContains_node l r r).mpr (Or.inr rfl))
-      · exact .trans _ _ r ((SyntacticObject.immediatelyContains_node l r r).mpr (Or.inr rfl)) hc
+      · rw [heq]; exact .imm _ _ ((immediatelyContains_node l r r).mpr (Or.inr rfl))
+      · exact .trans _ _ r ((immediatelyContains_node l r r).mpr (Or.inr rfl)) hc
 
 /-- **Containment ↔ proper subtree membership.** Gives a decision procedure for
     `contains` without well-founded recursion: `y` is properly contained in `x` iff
     it is a subtree distinct from `x`. -/
-theorem SyntacticObject.contains_iff_mem_subtrees_and_ne {x y : SyntacticObject} :
-    SyntacticObject.contains x y ↔ y ∈ x.subtrees ∧ y ≠ x := by
+theorem contains_iff_mem_subtrees_and_ne {x y : SyntacticObject} :
+    contains x y ↔ y ∈ x.subtrees ∧ y ≠ x := by
   constructor
   · intro h
-    exact ⟨SyntacticObject.mem_subtrees_of_contains h,
-      fun he => SyntacticObject.contains_irrefl x (he ▸ h)⟩
+    exact ⟨mem_subtrees_of_contains h, fun he => contains_irrefl x (he ▸ h)⟩
   · rintro ⟨hmem, hne⟩
-    rcases SyntacticObject.mem_subtrees_iff_eq_or_contains.mp hmem with rfl | hc
+    rcases mem_subtrees_iff_eq_or_contains.mp hmem with rfl | hc
     · exact absurd rfl hne
     · exact hc
 
-instance (x y : SyntacticObject) : Decidable (SyntacticObject.contains x y) :=
-  decidable_of_iff _ SyntacticObject.contains_iff_mem_subtrees_and_ne.symm
+instance (x y : SyntacticObject) : Decidable (contains x y) :=
+  decidable_of_iff _ contains_iff_mem_subtrees_and_ne.symm
 
 /-! ### Term-of and reflexive containment -/
 
 /-- `x` is a **term of** `y`: `x = y` or `y` contains `x`. -/
-def SyntacticObject.isTermOf (x y : SyntacticObject) : Prop := x = y ∨ SyntacticObject.contains y x
+def isTermOf (x y : SyntacticObject) : Prop := x = y ∨ contains y x
 
-instance (x y : SyntacticObject) : Decidable (SyntacticObject.isTermOf x y) :=
+instance (x y : SyntacticObject) : Decidable (isTermOf x y) :=
   inferInstanceAs (Decidable (_ ∨ _))
 
-theorem SyntacticObject.isTermOf_iff_mem_subtrees (x y : SyntacticObject) :
-    SyntacticObject.isTermOf x y ↔ x ∈ y.subtrees :=
-  SyntacticObject.mem_subtrees_iff_eq_or_contains.symm
+theorem isTermOf_iff_mem_subtrees (x y : SyntacticObject) : isTermOf x y ↔ x ∈ y.subtrees :=
+  mem_subtrees_iff_eq_or_contains.symm
 
 /-- Reflexive containment. -/
-def SyntacticObject.containsOrEq (x y : SyntacticObject) : Prop :=
-  x = y ∨ SyntacticObject.contains x y
+def containsOrEq (x y : SyntacticObject) : Prop := x = y ∨ contains x y
 
-instance (x y : SyntacticObject) : Decidable (SyntacticObject.containsOrEq x y) :=
+instance (x y : SyntacticObject) : Decidable (containsOrEq x y) :=
   inferInstanceAs (Decidable (_ ∨ _))
 
-theorem SyntacticObject.containsOrEq_trans {x y z : SyntacticObject}
-    (hxy : SyntacticObject.containsOrEq x y) (hyz : SyntacticObject.containsOrEq y z) :
-    SyntacticObject.containsOrEq x z := by
+theorem containsOrEq_trans {x y z : SyntacticObject}
+    (hxy : containsOrEq x y) (hyz : containsOrEq y z) : containsOrEq x z := by
   rcases hxy with rfl | hxy
   · exact hyz
   · rcases hyz with rfl | hyz
     · exact Or.inr hxy
-    · exact Or.inr (SyntacticObject.contains_trans hxy hyz)
+    · exact Or.inr (contains_trans hxy hyz)
 
 /-! ### RoseTree-relative c-command ([reinhart-1976]) -/
 
 /-- `x` and `y` are **sisters in** `root`: distinct co-daughters of some subtree. -/
-def SyntacticObject.areSistersIn (root x y : SyntacticObject) : Prop :=
-  ∃ z ∈ root.subtrees,
-    SyntacticObject.immediatelyContains z x ∧ SyntacticObject.immediatelyContains z y ∧ x ≠ y
+def areSistersIn (root x y : SyntacticObject) : Prop :=
+  ∃ z ∈ root.subtrees, immediatelyContains z x ∧ immediatelyContains z y ∧ x ≠ y
 
-instance (root x y : SyntacticObject) : Decidable (SyntacticObject.areSistersIn root x y) :=
+instance (root x y : SyntacticObject) : Decidable (areSistersIn root x y) :=
   Multiset.decidableExistsMultiset
 
 /-- `x` **c-commands** `y` in `root`: `x` has a sister (in `root`) that
     contains-or-equals `y`. -/
-def SyntacticObject.cCommandsIn (root x y : SyntacticObject) : Prop :=
-  ∃ z ∈ root.subtrees, SyntacticObject.areSistersIn root x z ∧ SyntacticObject.containsOrEq z y
+def cCommandsIn (root x y : SyntacticObject) : Prop :=
+  ∃ z ∈ root.subtrees, areSistersIn root x z ∧ containsOrEq z y
 
-instance (root x y : SyntacticObject) : Decidable (SyntacticObject.cCommandsIn root x y) :=
+instance (root x y : SyntacticObject) : Decidable (cCommandsIn root x y) :=
   Multiset.decidableExistsMultiset
 
 /-- `x` **asymmetrically** c-commands `y` in `root`. -/
-def SyntacticObject.asymCCommandsIn (root x y : SyntacticObject) : Prop :=
-  SyntacticObject.cCommandsIn root x y ∧ ¬ SyntacticObject.cCommandsIn root y x
+def asymCCommandsIn (root x y : SyntacticObject) : Prop :=
+  cCommandsIn root x y ∧ ¬ cCommandsIn root y x
 
-instance (root x y : SyntacticObject) : Decidable (SyntacticObject.asymCCommandsIn root x y) :=
+instance (root x y : SyntacticObject) : Decidable (asymCCommandsIn root x y) :=
   inferInstanceAs (Decidable (_ ∧ _))
+
+end SyntacticObject
 
 /-! ### `decide` demonstrations
 
@@ -457,9 +452,9 @@ private def demoT : SyntacticObject :=
     [.node (Sum.inl (mkTraceToken 0)) [], .node (Sum.inl (mkTraceToken 1)) []]), by decide⟩
 
 /-- The root properly contains its left daughter; the daughter does not contain the root. -/
-example : SyntacticObject.contains demoT demoL ∧ ¬ SyntacticObject.contains demoL demoT := by decide
+example : contains demoT demoL ∧ ¬ contains demoL demoT := by decide
 /-- The two daughters c-command each other in the root. -/
-example : SyntacticObject.cCommandsIn demoT demoL demoR := by decide
+example : cCommandsIn demoT demoL demoR := by decide
 /-- A node has one more vertex than the sum of its daughters' (eq. 1.2.5 witness). -/
 example : (demoT.subtrees).card = 3 := by decide
 

--- a/Linglib/Syntax/Minimalist/Verbal/Applicative.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Applicative.lean
@@ -36,6 +36,8 @@ The high/low distinction is read off the Merge complement's category via the hea
 
 namespace Minimalist
 
+open SyntacticObject
+
 /-! ### Applicative type and its Merge complement -/
 
 /-- High vs low applicatives ([pylkkanen-2008]): high relates to the event, low to the theme. -/
@@ -55,8 +57,7 @@ def ApplType.complement : ApplType → Cat
   | .lowSource    => .D
 
 /-- The complement constituent an applicative Merges with — a leaf headed by `a.complement`. -/
-def ApplType.complementSO (a : ApplType) : SyntacticObject :=
-  SyntacticObject.mkLeaf a.complement [] 0
+def ApplType.complementSO (a : ApplType) : SyntacticObject := mkLeaf a.complement [] 0
 
 /-- The Merge complement's categorial features, read via the §1.13 head function
 `SyntacticObject.outerCatC`. -/

--- a/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
@@ -35,6 +35,8 @@ a goal and a theme, mediated by a P head.
 
 namespace Minimalist
 
+open SyntacticObject
+
 /-- Category of the predicate head in a small clause.
 
     [dendikken-1995]: X ∈ {A, N, P, V} — the four
@@ -77,12 +79,12 @@ structure SmallClause where
 
 /-- Build the syntactic object for a small clause: `[SC Subj Pred]`. -/
 noncomputable def SmallClause.toSO (sc : SmallClause) : SyntacticObject :=
-  SyntacticObject.merge sc.subject sc.predicate
+  merge sc.subject sc.predicate
 
 /-- Embed a small clause under a verb: `V [SC Subj Pred]`. -/
 noncomputable def SmallClause.embedUnderV (v : SyntacticObject) (sc : SmallClause) :
     SyntacticObject :=
-  SyntacticObject.merge v sc.toSO
+  merge v sc.toSO
 
 /-- The construction type name for each SC predicate category. -/
 def SCPredCategory.constructionName : SCPredCategory → String
@@ -118,8 +120,7 @@ without forcing them through the `SmallClause` constructor. -/
     Supersedes the former `Quot.out`-based `leftSpine.outerCat` (arbitrary
     leftmost leaf): the value now tracks the genuine selector, not the
     representative choice. -/
-abbrev SyntacticObject.headCat (so : SyntacticObject) : Option Cat :=
-  SyntacticObject.outerCatC so
+abbrev SyntacticObject.headCat (so : SyntacticObject) : Option Cat := outerCatC so
 
 /-! ## Binary-node leaf/node counts
 
@@ -146,14 +147,13 @@ private theorem Nonplanar.numLeaves_node_pair {α : Type*} (a : α)
 
 /-- Leaf count of a binary Merge node is the sum of its children's. -/
 theorem SyntacticObject.leafCount_node (l r : SyntacticObject) :
-    (SyntacticObject.node l r).leafCount = l.leafCount + r.leafCount := by
-  rw [SyntacticObject.leafCount, SyntacticObject.node_val, Nonplanar.numLeaves_node_pair]; rfl
+    (node l r).leafCount = l.leafCount + r.leafCount := by
+  rw [leafCount, node_val, Nonplanar.numLeaves_node_pair]; rfl
 
 /-- Leaf count of a Merge is the sum of its children's (`SyntacticObject.merge =
 SyntacticObject.node`). -/
 @[simp] theorem SyntacticObject.leafCount_merge (l r : SyntacticObject) :
-    (SyntacticObject.merge l r).leafCount = l.leafCount + r.leafCount :=
-  SyntacticObject.leafCount_node l r
+    (merge l r).leafCount = l.leafCount + r.leafCount := leafCount_node l r
 
 /-- A syntactic object qualifies as a small-clause predicate iff its
     head category is one of [dendikken-1995]'s four SC-licensed
@@ -179,7 +179,7 @@ instance : DecidablePred IsSmallClausePredicate :=
     of which Quot.out representative was chosen. Computable via
     `immediatelyContains` (which is decidable and Multiset-based). -/
 def IsSmallClause (so : SyntacticObject) : Prop :=
-  ∃ pred, SyntacticObject.immediatelyContains so pred ∧ IsSmallClausePredicate pred
+  ∃ pred, immediatelyContains so pred ∧ IsSmallClausePredicate pred
 
 noncomputable instance : DecidablePred IsSmallClause := fun so => by
   unfold IsSmallClause; classical infer_instance
@@ -188,27 +188,23 @@ noncomputable instance : DecidablePred IsSmallClause := fun so => by
     invariant existential, the predicate can be either the left or the
     right child. -/
 theorem isSmallClause_merge (l r : SyntacticObject) :
-    IsSmallClause (SyntacticObject.merge l r) ↔
-      (IsSmallClausePredicate l ∨ IsSmallClausePredicate r) := by
+    IsSmallClause (merge l r) ↔ (IsSmallClausePredicate l ∨ IsSmallClausePredicate r) := by
   unfold IsSmallClause
   constructor
   · rintro ⟨pred, himm, hpred⟩
     -- SyntacticObject.merge l r = SyntacticObject.node l r;
     -- immediatelyContains_node: pred = l ∨ pred = r
-    rw [show SyntacticObject.merge l r = SyntacticObject.node l r from rfl,
-        SyntacticObject.immediatelyContains_node] at himm
+    rw [show merge l r = node l r from rfl, immediatelyContains_node] at himm
     rcases himm with rfl | rfl
     · exact Or.inl hpred
     · exact Or.inr hpred
   · intro h
     rcases h with hl | hr
     · refine ⟨l, ?_, hl⟩
-      rw [show SyntacticObject.merge l r = SyntacticObject.node l r from rfl,
-          SyntacticObject.immediatelyContains_node]
+      rw [show merge l r = node l r from rfl, immediatelyContains_node]
       exact Or.inl rfl
     · refine ⟨r, ?_, hr⟩
-      rw [show SyntacticObject.merge l r = SyntacticObject.node l r from rfl,
-          SyntacticObject.immediatelyContains_node]
+      rw [show merge l r = node l r from rfl, immediatelyContains_node]
       exact Or.inr rfl
 
 /-- Round-trip: any `SmallClause` whose stored `predCat` agrees with

--- a/Linglib/Syntax/Minimalist/Workspace/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Basic.lean
@@ -48,7 +48,7 @@ on this carrier (the P1 spike, now as carrier tests).
 
 namespace Minimalist
 
-open RootedTree RootedTree.ConnesKreimer
+open RootedTree RootedTree.ConnesKreimer SyntacticObject
 
 /-! ### Workspaces (MCB Def 1.2.1)
 
@@ -71,6 +71,8 @@ abbrev Workspace : Type := Forest SyntacticObject
     that **replaces the legacy `⊕ Nat` trace index**. -/
 def Workspace.chainMultiplicity (S : SyntacticObject) (W : Workspace) : Nat := W.count S
 
+namespace SyntacticObject
+
 /-! ### External Merge: bridge to the algebra (Lemma 1.4.1) -/
 
 /-- **External Merge ↔ algebra** ([marcolli-chomsky-berwick-2025] Lemma 1.4.1,
@@ -78,11 +80,11 @@ def Workspace.chainMultiplicity (S : SyntacticObject) (W : Workspace) : Nat := W
     `{S, S'}` yields the singleton workspace of the carrier Merge `SyntacticObject.merge S S'`.
     The root label is the **bare** `Sum.inr ()` — the faithful departure from the
     head-decorated legacy bridge. -/
-theorem SyntacticObject.merge_toForest (S S' : SyntacticObject) :
+theorem merge_toForest (S S' : SyntacticObject) :
     Merge.mergeOp (R := ℤ) (Sum.inr ()) S.val S'.val
         (of' ({S.val, S'.val} : Forest (Nonplanar SOLabel)))
-      = of' (R := ℤ) ({(SyntacticObject.merge S S').val} : Forest (Nonplanar SOLabel)) := by
-  rw [Merge.mergeOp_pair, SyntacticObject.merge_val]
+      = of' (R := ℤ) ({(merge S S').val} : Forest (Nonplanar SOLabel)) := by
+  rw [Merge.mergeOp_pair, merge_val]
 
 /-! ### Internal Merge as composition (MCB Prop 1.4.2) -/
 
@@ -92,7 +94,7 @@ theorem SyntacticObject.merge_toForest (S S' : SyntacticObject) :
     composition `mergeOp (inr ()) ∘ mergeOpUnit mover` over `{T}` yields the singleton
     workspace of `SyntacticObject.intMerge mover remainder`. This is `mergeOp_im_composition`
     transported to the carrier with the `IsSO`-carrying result. -/
-theorem SyntacticObject.intMerge_toForest (mover remainder T : SyntacticObject)
+theorem intMerge_toForest (mover remainder T : SyntacticObject)
     (p0 : Forest (Nonplanar SOLabel) × Nonplanar SOLabel)
     (h_filter : (cutSummandsN T.val).filter
         (fun p => p.1 = ({mover.val} : Forest (Nonplanar SOLabel))) = {p0})
@@ -102,9 +104,11 @@ theorem SyntacticObject.intMerge_toForest (mover remainder T : SyntacticObject)
         (Merge.mergeOpUnit (R := ℤ) mover.val
           (of' ({T.val} : Forest (Nonplanar SOLabel))))
       = of' (R := ℤ)
-          ({(SyntacticObject.intMerge mover remainder).val} : Forest (Nonplanar SOLabel)) := by
+          ({(intMerge mover remainder).val} : Forest (Nonplanar SOLabel)) := by
   rw [Merge.mergeOp_im_composition (Sum.inr ()) mover.val T.val remainder.val
-        p0 h_filter h_remainder hT, SyntacticObject.intMerge_val]
+        p0 h_filter h_remainder hT, intMerge_val]
+
+end SyntacticObject
 
 /-! ### `decide` demonstrations (the P1 computability spike, as carrier tests)
 
@@ -116,10 +120,10 @@ noncomputable; ill-formed shapes are rejected. -/
 private def demoTok : LIToken := mkTraceToken 0
 
 /-- A lexical leaf is well-formed. -/
-example : IsSO (SyntacticObject.lexLeaf demoTok).val := by decide
+example : IsSO (lexLeaf demoTok).val := by decide
 
 /-- The bare trace leaf is well-formed. -/
-example : IsSO SyntacticObject.traceLeaf.val := by decide
+example : IsSO traceLeaf.val := by decide
 
 /-- An IM-result-shaped tree — bare binary node over a lexical leaf and a bare
     trace — is well-formed (built directly, no Merge operator). -/
@@ -139,7 +143,6 @@ example :
 
 /-- Workspace chain identity is decidable: two isomorphic components ⇒ chain of 2. -/
 example : Workspace.chainMultiplicity SyntacticObject.traceLeaf
-    {SyntacticObject.traceLeaf, SyntacticObject.traceLeaf} = 2 := by
-  decide
+    {SyntacticObject.traceLeaf, SyntacticObject.traceLeaf} = 2 := by decide
 
 end Minimalist


### PR DESCRIPTION
Follow-through on the #1213 rename: the namespace now does the work the `SO.` prefix used to.

- substrate files wrap their declaration runs in `namespace SyntacticObject` blocks (fully-qualified names unchanged); use-only files and 21 Studies get `open SyntacticObject` — ~1130 prefix sites removed, ~90 lines rejoined
- `headHom`/`sel_comp_headHom`/`selCheckHom` move into the namespace (mathlib homing: canonical homs out of a type live in its namespace, cf. `FreeMonoid.lift`)
- the externalization decide-demos move to a new `Studies/MarcolliChomskyBerwick2025.lean` — the book's study anchor, seeded with its §1.12.1/§1.13.2 worked examples
- kept qualified: genuine clashes (`ConnesKreimer.traceLeaf`, `Phase/Basic` delegating def, SpeasTenny's `isPhaseHeadOf` ambiguity — parallel-API cleanup tracked separately)