### PR TITLE
refactor(Syntax/Minimalist): cyclic linearization as spellout order

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -116,6 +116,7 @@ import Linglib.Core.Data.List.Destutter
 import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Data.List.Factors
 import Linglib.Core.Data.List.Fold
+import Linglib.Core.Data.List.Sublist
 import Linglib.Core.Data.List.TakeDrop
 import Linglib.Core.Data.Multiset.Rel
 import Linglib.Core.Data.RoseTree.Basic
@@ -2217,6 +2218,7 @@ import Linglib.Studies.Fox2018
 import Linglib.Studies.FoxHackl2006
 import Linglib.Studies.FoxHackl2006Numerals
 import Linglib.Studies.FoxKatzir2011
+import Linglib.Studies.FoxPesetsky2005
 import Linglib.Studies.FoxSpector2018
 import Linglib.Studies.Francescotti1995
 import Linglib.Studies.FrancikClark1985

--- a/Linglib/Core/Data/List/Sublist.lean
+++ b/Linglib/Core/Data/List/Sublist.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.Nodup
+
+/-!
+# Pair sublists as positional order
+
+`List.pair_sublist_iff_idxOf_lt`: on a `Nodup` list, `[a, b] <+ l` says exactly that
+`a` and `b` are members with `a` at a strictly earlier index — the pair-sublist
+relation is the strict linear order a duplicate-free list carries.
+-/
+
+namespace List
+
+variable {α : Type*} [DecidableEq α] {a b : α} {l : List α}
+
+theorem pair_sublist_of_idxOf_lt (ha : a ∈ l) (hb : b ∈ l)
+    (h : l.idxOf a < l.idxOf b) : [a, b] <+ l := by
+  induction l with
+  | nil => cases ha
+  | cons x xs ih =>
+    by_cases hax : a = x
+    · subst hax
+      rcases mem_cons.mp hb with rfl | hb'
+      · exact absurd h (Nat.lt_irrefl _)
+      · exact (singleton_sublist.mpr hb').cons_cons a
+    · have ha' : a ∈ xs := (mem_cons.mp ha).resolve_left hax
+      have hbx : b ≠ x := by
+        rintro rfl
+        rw [idxOf_cons_self] at h
+        exact Nat.not_lt_zero _ h
+      have hb' : b ∈ xs := (mem_cons.mp hb).resolve_left hbx
+      refine (ih ha' hb' ?_).cons x
+      rw [idxOf_cons_ne _ (Ne.symm hax), idxOf_cons_ne _ (Ne.symm hbx)] at h
+      exact Nat.lt_of_succ_lt_succ h
+
+theorem idxOf_lt_of_pair_sublist (hnd : l.Nodup) (h : [a, b] <+ l) :
+    l.idxOf a < l.idxOf b := by
+  induction l with
+  | nil => simp at h
+  | cons x xs ih =>
+    rw [nodup_cons] at hnd
+    obtain ⟨hx, hnd'⟩ := hnd
+    cases h with
+    | cons _ h' =>
+      have ha : a ∈ xs := h'.subset (by simp)
+      have hb : b ∈ xs := h'.subset (by simp)
+      have hax : x ≠ a := by rintro rfl; exact hx ha
+      have hbx : x ≠ b := by rintro rfl; exact hx hb
+      rw [idxOf_cons_ne _ hax, idxOf_cons_ne _ hbx]
+      exact Nat.succ_lt_succ (ih hnd' h')
+    | cons_cons _ h' =>
+      have hb : b ∈ xs := singleton_sublist.mp h'
+      have hba : a ≠ b := by rintro rfl; exact hx hb
+      rw [idxOf_cons_self, idxOf_cons_ne _ hba]
+      exact Nat.succ_pos _
+
+/-- On a `Nodup` list, the pair-sublist relation is the strict positional order. -/
+theorem pair_sublist_iff_idxOf_lt (hnd : l.Nodup) :
+    [a, b] <+ l ↔ a ∈ l ∧ b ∈ l ∧ l.idxOf a < l.idxOf b :=
+  ⟨fun h => ⟨h.subset (by simp), h.subset (by simp), idxOf_lt_of_pair_sublist hnd h⟩,
+   fun ⟨ha, hb, hlt⟩ => pair_sublist_of_idxOf_lt ha hb hlt⟩
+
+end List

--- a/Linglib/Studies/ErlewineSommerlot2025.lean
+++ b/Linglib/Studies/ErlewineSommerlot2025.lean
@@ -41,7 +41,7 @@ constraint from cyclic linearization alone, without invoking the
 Phase Impenetrability Condition. This positions them at
 `PICStrength.linearizationBound` (per `Syntax/Minimalist/Phase.lean`):
 no opacity constraint per se, only ordering constraints from
-`SpelloutAndCheck`. Same regime adopted by
+`Consistent`. Same regime adopted by
 [sande-clem-dabkowski-2026] for Guébie discontinuous harmony,
 [branan-davis-2019] for agreement-edge unlocking, and others.
 The structural diagnostic that the meN-deletion derivation is
@@ -59,7 +59,7 @@ overt Voice creates a contradiction, while null Voice does not.
 
 namespace ErlewineSommerlot2025
 
-open Minimalist.Linearization
+open List Minimalist.Linearization
 open Malayic.VoiceSystem
 
 -- ============================================================================
@@ -161,38 +161,38 @@ Each grammatical derivation produces consistent ordering across phases.
 /-- Active clause is consistently linearizable.
     [erlewine-sommerlot-2025] (36). -/
 theorem active_consistent :
-    SpelloutAndCheck [voiceP_active, cp_active] := by decide
+    Consistent [voiceP_active, cp_active] := by decide
 
 /-- Active clause with short *N-* prefix (Desa free variation). -/
 theorem active_short_consistent :
-    SpelloutAndCheck [voiceP_active_short, cp_active_short] := by decide
+    Consistent [voiceP_active_short, cp_active_short] := by decide
 
 /-- Subject extraction from active is consistent.
     The subject (agent) was already leftmost in VoiceP and moves further
     left through Spec,TP to Spec,CP — classic edge movement (Scenario 1
     of [fox-pesetsky-2005]). -/
 theorem subject_extraction_consistent :
-    SpelloutAndCheck [voiceP_active, cp_subjExtr] := by decide
+    Consistent [voiceP_active, cp_subjExtr] := by decide
 
 /-- *di-* passive is consistently linearizable.
     [erlewine-sommerlot-2025] (37a). -/
 theorem di_passive_consistent :
-    SpelloutAndCheck [voiceP_diPassive, cp_diPassive] := by decide
+    Consistent [voiceP_diPassive, cp_diPassive] := by decide
 
 /-- Bare passive is consistently linearizable.
     [erlewine-sommerlot-2025] (37b)/(39c). -/
 theorem bare_passive_consistent :
-    SpelloutAndCheck [voiceP_barePassive, cp_barePassive] := by decide
+    Consistent [voiceP_barePassive, cp_barePassive] := by decide
 
 /-- Object extraction with null Voice (Desa) is consistent.
     [erlewine-sommerlot-2025] (44). -/
 theorem obj_extraction_desa_consistent :
-    SpelloutAndCheck [voiceP_objExtr_null, cp_objExtr_desa] := by decide
+    Consistent [voiceP_objExtr_null, cp_objExtr_desa] := by decide
 
 /-- Object extraction with null Voice (SI/SM) is consistent.
     [erlewine-sommerlot-2025] (54)–(56). -/
 theorem obj_extraction_sism_consistent :
-    SpelloutAndCheck [voiceP_objExtr_null_sism, cp_objExtr_sism] := by decide
+    Consistent [voiceP_objExtr_null_sism, cp_objExtr_sism] := by decide
 
 /-! ### The ordering paradox: overt Voice in object extraction
 
@@ -212,20 +212,15 @@ establishing agent < *me-*. The two are contradictory.
 
     These two statements contradict: me- < agent ∧ agent < me-. -/
 theorem men_deletion :
-    ¬ SpelloutAndCheck [voiceP_objExtr_overt, cp_objExtr_overt] := by decide
+    ¬ Consistent [voiceP_objExtr_overt, cp_objExtr_overt] := by decide
 
-/-- The specific contradiction: VoiceP says me- before agent;
-    CP says agent before me-. -/
+/-- The specific contradiction: VoiceP spells out me- before agent;
+    CP spells out agent before me-. -/
 theorem men_deletion_witness :
-    -- me- < agent from VoiceP
-    (allPrecs voiceP_objExtr_overt).any
-      (λ s => s.before == "me-" && s.after == "agent") = true ∧
-    -- agent < me- from CP
-    (allPrecs cp_objExtr_overt).any
-      (λ s => s.before == "agent" && s.after == "me-") = true ∧
-    -- combined is inconsistent
-    HasContradiction
-      (allPrecs voiceP_objExtr_overt ++ allPrecs cp_objExtr_overt) := by decide
+    ["me-", "agent"] <+ voiceP_objExtr_overt ∧
+    ["agent", "me-"] <+ cp_objExtr_overt ∧
+    ¬ Consistent [voiceP_objExtr_overt, cp_objExtr_overt] :=
+  ⟨by decide, by decide, by decide⟩
 
 -- ============================================================================
 -- § 4: Cross-Linguistic Predictions
@@ -305,7 +300,7 @@ Voice is overt.
 -- VoiceP: [PP, agent, me-, NV, theme]  (PP is leftmost, then agent)
 -- CP: [PP, agent, Aux, me-, NV, theme]
 theorem pp_extraction_with_overt_voice :
-    SpelloutAndCheck [["PP", "agent", "me-", "NV", "theme"],
+    Consistent [["PP", "agent", "me-", "NV", "theme"],
                       ["PP", "agent", "Aux", "me-", "NV", "theme"]] := by
   decide
 
@@ -318,19 +313,19 @@ theorem pp_extraction_with_overt_voice :
     Object extraction requires null Voice (derived, not stipulated). -/
 theorem all_grammatical_derivations_consistent :
     -- Active (with me-N-)
-    SpelloutAndCheck [voiceP_active, cp_active] ∧
+    Consistent [voiceP_active, cp_active] ∧
     -- Active (with N- only, Desa)
-    SpelloutAndCheck [voiceP_active_short, cp_active_short] ∧
+    Consistent [voiceP_active_short, cp_active_short] ∧
     -- Di-passive
-    SpelloutAndCheck [voiceP_diPassive, cp_diPassive] ∧
+    Consistent [voiceP_diPassive, cp_diPassive] ∧
     -- Bare passive
-    SpelloutAndCheck [voiceP_barePassive, cp_barePassive] ∧
+    Consistent [voiceP_barePassive, cp_barePassive] ∧
     -- Object extraction, null Voice (Desa)
-    SpelloutAndCheck [voiceP_objExtr_null, cp_objExtr_desa] ∧
+    Consistent [voiceP_objExtr_null, cp_objExtr_desa] ∧
     -- Object extraction, null Voice (SI/SM)
-    SpelloutAndCheck [voiceP_objExtr_null_sism, cp_objExtr_sism] ∧
+    Consistent [voiceP_objExtr_null_sism, cp_objExtr_sism] ∧
     -- Object extraction, overt Voice → CRASH
-    ¬ SpelloutAndCheck [voiceP_objExtr_overt, cp_objExtr_overt] := by
+    ¬ Consistent [voiceP_objExtr_overt, cp_objExtr_overt] := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
 -- ============================================================================

--- a/Linglib/Studies/FoxPesetsky2005.lean
+++ b/Linglib/Studies/FoxPesetsky2005.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Linearization.Cyclic
+
+/-!
+# Fox & Pesetsky 2005: cyclic linearization
+
+[fox-pesetsky-2005]'s worked examples, kernel-checked against the
+`Minimalist.Linearization` spell-out order: the two movement scenarios ((13), (14)),
+successive-cyclic *wh*-movement ((3)–(8)), order-preserving simultaneous movement,
+and Holmberg's Generalization (§3) — plus the paper's central architectural claim,
+that convergence is a property of the derivational history rather than of the
+output string (`history_dependence`).
+-/
+
+namespace FoxPesetsky2005
+
+open Minimalist.Linearization
+
+/-- Scenario 1 ([fox-pesetsky-2005] (13)): leftward movement from a left-edge
+    position. `X` was at the left edge of `D`; moving further left in `D′` is
+    consistent with the order established at `D`. -/
+theorem edge_movement_consistent :
+    Consistent [["X", "Y", "Z"], ["X", "α", "Y", "Z"]] := by decide
+
+/-- Scenario 2 ([fox-pesetsky-2005] (14)): leftward movement from a non-edge
+    position. `Y` was not at the left edge of `D`, so moving it left in `D′`
+    contradicts the order established at `D`. -/
+theorem non_edge_movement_contradiction :
+    ¬ Consistent [["X", "Y", "Z"], ["Y", "α", "X", "Z"]] := by decide
+
+/-- Successive-cyclic *wh*-movement ([fox-pesetsky-2005] (6)–(8)): *to whom* moves
+    through the VP edge before Spec,CP, preserving VP-internal order. -/
+theorem successive_cyclic_ok :
+    Consistent [["to_whom", "gave", "the_book"],
+                ["to_whom", "that", "Mary", "gave", "the_book"]] := by decide
+
+/-- Non-successive-cyclic movement ([fox-pesetsky-2005] (3)–(5)): *to whom* skips
+    the VP edge, contradicting VP-internal order. -/
+theorem non_successive_cyclic_bad :
+    ¬ Consistent [["gave", "the_book", "to_whom"],
+                  ["to_whom", "that", "Mary", "gave", "the_book"]] := by decide
+
+/-- **The paper's central architectural claim**: convergence is a property of the
+    derivational history, not the output — the same final Spell-out converges after
+    successive-cyclic movement through the VP edge and crashes without it. The
+    spell-out order does not factor through the final string. -/
+theorem history_dependence :
+    Consistent [["to_whom", "gave", "the_book"],
+                ["to_whom", "that", "Mary", "gave", "the_book"]] ∧
+    ¬ Consistent [["gave", "the_book", "to_whom"],
+                  ["to_whom", "that", "Mary", "gave", "the_book"]] :=
+  ⟨successive_cyclic_ok, non_successive_cyclic_bad⟩
+
+/-- Simultaneous movement preserving relative order creates no contradiction
+    (the configuration behind Malayic object extraction,
+    `Studies/ErlewineSommerlot2025.lean`). -/
+theorem simultaneous_order_preserving :
+    Consistent [["A", "B", "C"], ["A", "B", "D", "C"]] := by decide
+
+/-- Simultaneous movement reversing relative order contradicts. -/
+theorem simultaneous_order_reversing :
+    ¬ Consistent [["B", "A", "C"], ["A", "B", "D", "C"]] := by decide
+
+/-- A purely transitive ordering cycle also crashes: the crash condition is
+    acyclicity of the full spell-out order, not the absence of a directly
+    contradicting pair. -/
+theorem transitive_cycle_crashes :
+    ¬ Consistent [["a", "b"], ["b", "c"], ["c", "a"]] := by decide
+
+/-! ### Holmberg's Generalization ([fox-pesetsky-2005] §3)
+
+Object Shift in Scandinavian is possible only when the verb also moves out of VP:
+VP Spell-out establishes V < Obj, and a shifted object with an in-situ verb reverses
+it at the higher domain. -/
+
+/-- Baseline: no Object Shift, verb moves to I. -/
+theorem no_object_shift :
+    Consistent [["V", "Obj"], ["Subj", "V", "Neg", "Obj"]] := by decide
+
+/-- Object Shift with verb movement: V < Obj is preserved past Neg. -/
+theorem object_shift_with_verb_movement :
+    Consistent [["V", "Obj"], ["Subj", "V", "Obj", "Neg"]] := by decide
+
+/-- Object Shift without verb movement reverses V < Obj — this crash **is**
+    Holmberg's Generalization, derived from cyclic linearization. -/
+theorem object_shift_without_verb_movement :
+    ¬ Consistent [["V", "Obj"], ["Subj", "Obj", "Neg", "V"]] := by decide
+
+end FoxPesetsky2005

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -52,8 +52,7 @@ vP at the moment of vP-spell-out (when local harmony applied).
 4. **Frozen ATR survives later movement**. Once the particle has
    harmonized to V's ATR value at vP-spell-out, the value persists
    through subsequent A′-fronting of the remnant VP into Spec,CP
-   (Cyclic-Linearization-style preservation —
-   `Minimalist.Linearization.frozenValue`).
+   (Cyclic-Linearization-style preservation — `frozenValue` below).
 
 5. **Strict PIC is rejected**. For step 4 to work, already-spelled-out
    material must remain accessible to later syntactic operations
@@ -67,7 +66,7 @@ vP at the moment of vP-spell-out (when local harmony applied).
 For each of the four word orders, the file:
 
 - proves the derivation is consistently linearizable
-  (`Minimalist.Linearization.SpelloutAndCheck`),
+  (`Minimalist.Linearization.Consistent`),
 - computes the predicted harmony status (true iff V is in vP-content),
 - decides the (44) table by `decide`,
 - registers Guébie predicate fronting as a positive instance of
@@ -120,9 +119,7 @@ lives in Studies, not Fragments".
 namespace SandeClemDabkowski2026
 
 open Minimalist (PICStrength)
-open Minimalist.Linearization
-  (SpelloutAndCheck FrozenFeature FrozenFeatureTable
-   extendFrozenFeatures frozenValue)
+open Minimalist.Linearization (Consistent)
 open OptimalityTheory.Cophonology (PhrasalCophonology)
 
 -- ============================================================================
@@ -219,20 +216,20 @@ def derivation (wo : WordOrder) : List (List String) :=
 -- ============================================================================
 
 /-- `SVOPart`: V in T, Part in clause-final position. Consistent. -/
-theorem SVOPart_consistent : SpelloutAndCheck (derivation .SVOPart) := by decide
+theorem SVOPart_consistent : Consistent (derivation .SVOPart) := by decide
 
 /-- `SAuxOPartV`: V in v, both V and Part inside vP. Consistent. -/
-theorem SAuxOPartV_consistent : SpelloutAndCheck (derivation .SAuxOPartV) := by decide
+theorem SAuxOPartV_consistent : Consistent (derivation .SAuxOPartV) := by decide
 
 /-- `PartSVO`: V in T, Part fronts. Consistent under
     Cyclic-Linearization (no contradiction with vP-internal order). -/
-theorem PartSVO_consistent : SpelloutAndCheck (derivation .PartSVO) := by decide
+theorem PartSVO_consistent : Consistent (derivation .PartSVO) := by decide
 
 /-- `PartSAuxOV`: V in v, remnant VP fronts. Consistent. The crucial
     derivation for discontinuous harmony — Part is local to V at
     vP-spell-out, and the linearization remains coherent after
     fronting. -/
-theorem PartSAuxOV_consistent : SpelloutAndCheck (derivation .PartSAuxOV) := by decide
+theorem PartSAuxOV_consistent : Consistent (derivation .PartSAuxOV) := by decide
 
 -- ============================================================================
 -- § 4: Predicted harmony status (Table 44)
@@ -269,6 +266,50 @@ theorem partSAuxOV_discontinuous_yet_harmonizes :
 -- § 5: Frozen ATR survives later movement (SCD 2026 §6.1)
 -- ============================================================================
 
+/-! ### Per-cycle frozen feature assignments
+
+[fox-pesetsky-2005]'s Order Preservation shape applied to *feature values*
+established by phase-bounded phonological computation: [sande-clem-dabkowski-2026]
+§6.1 argues the particle's ATR value is fixed at vP spell-out and preserved through
+later movement. The append-only accumulator below is the feature analogue of the
+spell-out order's never-deleted statements. -/
+
+/-- A frozen feature assignment: terminal `t` had feature `f` set to `value` at the
+    spell-out cycle that emitted this entry. -/
+structure FrozenFeature where
+  terminal : String
+  feature  : String
+  value    : Bool
+  deriving DecidableEq, Repr
+
+/-- Per-cycle log of feature assignments preserved across spell-out; append-only. -/
+abbrev FrozenFeatureTable := List FrozenFeature
+
+/-- Extend a frozen-feature table with the assignments emitted by one cycle. -/
+def extendFrozenFeatures (existing : FrozenFeatureTable)
+    (phaseFreezings : List FrozenFeature) : FrozenFeatureTable :=
+  existing ++ phaseFreezings
+
+/-- Order-Preservation analogue for features: freezings emitted at earlier phases
+    survive subsequent spell-out. -/
+theorem extendFrozenFeatures_preserves
+    (existing : FrozenFeatureTable) (phaseFreezings : List FrozenFeature)
+    (f : FrozenFeature) (h : f ∈ existing) :
+    f ∈ extendFrozenFeatures existing phaseFreezings := by
+  unfold extendFrozenFeatures; exact List.mem_append_left _ h
+
+/-- The most-recently-frozen value of `feature` on `terminal`, if any. -/
+def frozenValue (table : FrozenFeatureTable) (terminal feature : String) : Option Bool :=
+  (table.reverse.find? (fun f => f.terminal == terminal && f.feature == feature)).map (·.value)
+
+/-- A later phase that re-freezes the same feature overrides the earlier value —
+    the intended override semantics (not exercised by [sande-clem-dabkowski-2026],
+    which posits no CP-phase ATR re-write for the particle). -/
+theorem frozen_value_later_overrides :
+    frozenValue
+      (extendFrozenFeatures [⟨"Part", "ATR", true⟩] [⟨"Part", "ATR", false⟩])
+      "Part" "ATR" = some false := by decide
+
 /-- The ATR value frozen at vP-spell-out for `PartSAuxOV`: when V is
     +ATR (e.g. /joku/), Part inherits +ATR via local vP-internal
     harmony. This is the freezing event. -/
@@ -297,7 +338,7 @@ def guebiePICMode : PICStrength := .linearizationBound
 
 /-- Under the Guébie PIC mode, every phase admits extraction of any
     goal at the phasehood layer; concrete crashes come from
-    `SpelloutAndCheck` instead. The four-derivation theorem above
+    `Consistent` instead. The four-derivation theorem above
     confirms no derivation crashes. -/
 theorem guebie_PIC_admits_remnant_movement (φ : Minimalist.Phase)
     (goal : Minimalist.SyntacticObject) :

--- a/Linglib/Studies/ShenHuang2026.lean
+++ b/Linglib/Studies/ShenHuang2026.lean
@@ -645,27 +645,31 @@ converges. This is why `WhDependencyType.binding` is not constrained
 by the PIC — it cannot create the ordering conflicts that the PIC
 (via Order Preservation) is designed to prevent.
 
-The `extendOrderingTable` function from `Minimalist.Linearization`
-takes an existing `OrderingTable` and a list of terminals that move —
-for binding, this list is empty, so the table is unchanged and
-trivially consistent. -/
+An in-situ binding dependency contributes an empty Spell-out snapshot to
+`Minimalist.Linearization.spelloutOrder`, and an empty snapshot leaves the
+induced order unchanged. -/
 
-/-- Binding adds no precedence statements: when no elements move
-(the terminal list is empty), `extendOrderingTable` returns the
-existing table unchanged. This is the formal content of "binding does
-not change linear order" ([fox-pesetsky-2005], as applied in
-[shen-huang-2026] §4.2). -/
-theorem binding_no_new_precedences (existing : OrderingTable) :
-    extendOrderingTable existing [] = existing := by
-  unfold extendOrderingTable allPrecs; simp
+/-- Binding adds no precedence statements: an empty Spell-out snapshot leaves the
+spell-out order unchanged. The formal content of "binding does not change linear
+order" ([fox-pesetsky-2005], as applied in [shen-huang-2026] §4.2). -/
+theorem binding_no_new_precedences (phases : List (List String)) :
+    spelloutOrder (phases ++ [[]]) = spelloutOrder phases := by
+  funext a b
+  refine propext ⟨Relation.TransGen.mono ?_, Relation.TransGen.mono ?_⟩ <;>
+    rintro x y ⟨p, hp, hs⟩
+  · rcases List.mem_append.mp hp with hp | hp
+    · exact ⟨p, hp, hs⟩
+    · rw [List.mem_singleton] at hp
+      subst hp
+      simp at hs
+  · exact ⟨p, List.mem_append_left _ hp, hs⟩
 
-/-- Consequence: binding never creates an ordering contradiction.
-If the existing ordering table is consistent, it stays consistent
-after a binding operation (because nothing changes). -/
-theorem binding_preserves_consistency (existing : OrderingTable)
-    (h : Consistent existing) :
-    Consistent (extendOrderingTable existing []) := by
-  rw [binding_no_new_precedences]; exact h
+/-- Consequence: binding never creates an ordering contradiction. -/
+theorem binding_preserves_consistency (phases : List (List String))
+    (h : Consistent phases) : Consistent (phases ++ [[]]) := by
+  intro a
+  rw [binding_no_new_precedences]
+  exact h a
 
 -- ============================================================================
 -- §14. Bridge: Phase Theory → Violation Model

--- a/Linglib/Syntax/Minimalist/Linearization/Cyclic.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Cyclic.lean
@@ -1,422 +1,150 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Relation.ReflTransGen
-import Mathlib.Data.List.Dedup
+import Linglib.Core.Data.List.Sublist
 import Mathlib.Logic.Relation
 
 /-!
-# Cyclic Linearization of Syntactic Structure
-[fox-pesetsky-2005]
+# Cyclic linearization of syntactic structure
 
-Formalizes the core of [fox-pesetsky-2005]'s theory of the
-syntax-phonology interface. The key claims:
+[fox-pesetsky-2005]'s theory of the syntax–phonology interface: linearization
+applies at the end of each phase (Spell-out domain), the ordering statements it
+establishes are never deleted (Order Preservation, their (52)), and a derivation
+converges only if the accumulated statements cohere.
 
-1. **Spell-out domains**: linearization applies at the end of each phase
-   (Spell-out domain), establishing the relative order of overt terminals.
+The account is one mathematical object: a derivation exposes a word of phase
+snapshots, each snapshot carries its pair-sublist relation (`[a, b] <+ p` — the
+paper's ordering statements, their (10)), and `spelloutOrder` is the transitive
+closure of their union. Grammaticality (`Consistent`) is the statement that this
+candidate is a genuine strict order (`consistent_iff_isStrictOrder`); transitivity
+is free, so the entire crash condition is irreflexivity. Order Preservation is
+monotonicity (`spelloutOrder_mono`), not an axiom, and the order is blind to the
+sequencing of Spell-outs (`spelloutOrder_perm`) — the account reads only the *set*
+of snapshots.
 
-2. **Order Preservation**: ordering established at Spell-out of a domain
-   is never deleted or contradicted by later Spell-out.
+The paper's worked examples (Scenarios (13)/(14), successive-cyclic movement
+(3)–(8), Holmberg's Generalization §3) live in `Studies/FoxPesetsky2005.lean`;
+Malayic and Guébie applications in `Studies/ErlewineSommerlot2025.lean` and
+`Studies/SandeClemDabkowski2026.lean`.
 
-3. **Successive cyclicity as a consequence**: movement from a phase must
-   proceed through the phase edge (leftmost position) to avoid
-   contradicting ordering established at earlier Spell-out.
+## Main declarations
 
-4. **Ordering contradiction → ungrammaticality**: if the ordering
-   statements accumulated across phases form a cycle, the structure
-   cannot be coherently linearized and the derivation crashes.
+* `Minimalist.Linearization.spelloutOrder`: the induced candidate order.
+* `Minimalist.Linearization.Consistent`: the derivation linearizes — decidable on
+  concrete phase data.
 
-The formalization here provides the minimal infrastructure needed to
-derive the *meN*-deletion effect in Malayic languages
-([erlewine-sommerlot-2025]), Holmberg's Generalization
-(Object Shift requires verb movement), and successive-cyclicity
-requirements. All three are formalized as concrete theorems.
+## Main results
 
-## Key definitions
-
-- `Prec`: a precedence statement (α precedes β)
-- `allPrecs`: generates all pairwise precedences from a terminal sequence
-- `hasContradiction`: checks for direct ordering cycles (a < b ∧ b < a)
-- `hasCycle`: checks for cycles of any length via BFS reachability
-- `extendOrderingTable`: Linearize operation accumulating precedences across phases
-- `SpelloutAndCheck`: extend an empty table over all phases and check consistency
-
-The operation `extendOrderingTable` was previously named `spellout` and
-collided with `Minimalist.spellout` (the VI exponent-realization
-operation in `Morphology/DM/VocabSimple.lean`); the rename
-disambiguates.
+* `Minimalist.Linearization.consistent_iff_isStrictOrder`: the crash condition is
+  exactly "spell-out induces a strict order".
+* `Minimalist.Linearization.spelloutOrder_mono`, `spelloutOrder_perm`: Order
+  Preservation and snapshot-set blindness.
+* `Minimalist.Linearization.consistent_singleton`: a single Spell-out of distinct
+  terminals always linearizes.
 -/
 
 namespace Minimalist.Linearization
 
--- ============================================================================
--- § 1: Precedence Statements
--- ============================================================================
+open List
 
-/-- A precedence statement: `before` must linearly precede `after` in PF.
-    Corresponds to [fox-pesetsky-2005]'s "α < β" notation (their (10)). -/
-structure Prec where
-  before : String
-  after  : String
-  deriving DecidableEq, Repr
+variable {α : Type*}
 
-/-- Generate all pairwise precedences from a left-to-right sequence of
-    overt terminal labels. Given terminals [a, b, c], produces
-    [a < b, a < c, b < c]. -/
-def allPrecs : List String → List Prec
-  | [] => []
-  | x :: xs => (xs.map λ y => ⟨x, y⟩) ++ allPrecs xs
+/-- The spell-out order induced by a derivation's phase snapshots: the transitive
+    closure of "`a` precedes `b` at some Spell-out", per-phase precedence being the
+    pair-sublist relation ([fox-pesetsky-2005] (10), (52)). -/
+def spelloutOrder (phases : List (List α)) : α → α → Prop :=
+  Relation.TransGen fun a b => ∃ p ∈ phases, [a, b] <+ p
 
--- ============================================================================
--- § 2: Ordering Table and Consistency
--- ============================================================================
+/-- The derivation linearizes: spell-out induces a genuine strict order
+    ([fox-pesetsky-2005]'s convergence condition). Transitivity is free, so the
+    content is irreflexivity — no ordering cycle of any length. -/
+def Consistent (phases : List (List α)) : Prop :=
+  ∀ a, ¬ spelloutOrder phases a a
 
-/-- An Ordering Table is the accumulated set of precedence statements
-    across all Spell-out domains in a derivation.
-    Corresponds to [fox-pesetsky-2005]'s Ordering Table ((52)). -/
-abbrev OrderingTable := List Prec
+variable {phases ps qs : List (List α)} {a b : α}
 
-/-- An Ordering Table contains a direct contradiction: some α, β such
-    that both α < β and β < α appear. A contradiction means the
-    derivation cannot be coherently linearized and crashes.
+/-- The crash condition, in order-theoretic vocabulary. -/
+theorem consistent_iff_isStrictOrder :
+    Consistent phases ↔ IsStrictOrder α (spelloutOrder phases) :=
+  ⟨fun h => { irrefl := h, trans := fun _ _ _ => Relation.TransGen.trans },
+   fun h => h.toIrrefl.irrefl⟩
 
-    Note: for the Malayic voice/extraction application, all contradictions
-    are direct (no transitive closure needed). For cycles of length > 2
-    use `HasCycle` (BFS-based, decidable too). -/
-def HasContradiction (table : OrderingTable) : Prop :=
-  ∃ s ∈ table, ∃ t ∈ table, s.before = t.after ∧ s.after = t.before
+/-- Order Preservation ([fox-pesetsky-2005] (52)): ordering statements are never
+    deleted — a larger derivation induces a larger order. -/
+theorem spelloutOrder_mono (h : ∀ p ∈ ps, p ∈ qs) (hab : spelloutOrder ps a b) :
+    spelloutOrder qs a b :=
+  Relation.TransGen.mono (fun _ _ ⟨p, hp, hs⟩ => ⟨p, h p hp, hs⟩) hab
 
-instance (table : OrderingTable) : Decidable (HasContradiction table) := by
-  unfold HasContradiction; infer_instance
+/-- The induced order is blind to the sequencing of Spell-outs: it reads only the
+    set of phase snapshots. -/
+theorem spelloutOrder_perm (h : ps.Perm qs) : spelloutOrder ps = spelloutOrder qs := by
+  funext a b
+  exact propext ⟨spelloutOrder_mono fun p hp => h.mem_iff.mp hp,
+    spelloutOrder_mono fun p hp => h.mem_iff.mpr hp⟩
 
-/-- An Ordering Table is consistent iff it contains no contradictions. -/
-def Consistent (table : OrderingTable) : Prop := ¬ HasContradiction table
+variable [DecidableEq α]
 
-instance (table : OrderingTable) : Decidable (Consistent table) :=
-  inferInstanceAs (Decidable (¬ _))
+/-- On a single duplicate-free snapshot, the induced order is index order. -/
+theorem spelloutOrder_singleton_idxOf {p : List α} (hnd : p.Nodup)
+    (h : spelloutOrder [p] a b) : p.idxOf a < p.idxOf b := by
+  induction h with
+  | single h =>
+    obtain ⟨q, hq, hs⟩ := h
+    rw [List.mem_singleton] at hq
+    exact hq ▸ List.idxOf_lt_of_pair_sublist (hq ▸ hnd) hs
+  | tail _ h ih =>
+    obtain ⟨q, hq, hs⟩ := h
+    rw [List.mem_singleton] at hq
+    exact ih.trans (hq ▸ List.idxOf_lt_of_pair_sublist (hq ▸ hnd) hs)
 
--- ============================================================================
--- § 3: Spell-out (Linearize)
--- ============================================================================
+/-- A single Spell-out of distinct terminals always linearizes. -/
+theorem consistent_singleton {p : List α} (hnd : p.Nodup) : Consistent [p] :=
+  fun _ h => Nat.lt_irrefl _ (spelloutOrder_singleton_idxOf hnd h)
 
-/-- Extend an existing Ordering Table by Linearizing one phase: generate
-    ordering statements from the left-to-right sequence of overt
-    terminals in the phase, and append them to the table.
+/-! ### Decidability
 
-    Implements Order Preservation: existing statements are kept (never
-    deleted), new statements appended. Corresponds to [fox-pesetsky-2005]'s
-    Linearize operation ((52)). Renamed from `spellout` to disambiguate
-    from `Minimalist.spellout` (the VI exponent-realization operation). -/
-def extendOrderingTable (existing : OrderingTable)
-    (phaseTerminals : List String) : OrderingTable :=
-  existing ++ allPrecs phaseTerminals
+`Consistent` decides on concrete phase data: the candidate order's generator only
+relates terminals mentioned at some Spell-out, so irreflexivity reduces to a finite
+check over the support, with reachability decided by
+`Relation.ReflTransGen.decidable_of_finite`. -/
 
-/-- Multi-phase derivation is consistently linearizable. Each element
-    of `phases` is the left-to-right sequence of overt terminals at the
-    corresponding Spell-out domain. Ordering statements accumulate
-    across phases via Order Preservation. -/
-def SpelloutAndCheck (phases : List (List String)) : Prop :=
-  Consistent (phases.foldl extendOrderingTable [])
+section Decidability
 
-instance (phases : List (List String)) : Decidable (SpelloutAndCheck phases) :=
-  inferInstanceAs (Decidable (Consistent _))
+variable (phases : List (List α))
 
-/-- Order Preservation: existing ordering statements are never deleted
-    by extension. All precedences from earlier phases persist.
-    Formal content of [fox-pesetsky-2005]'s Order Preservation. -/
-theorem extendOrderingTable_preserves (existing : OrderingTable) (phase : List String)
-    (p : Prec) (hp : p ∈ existing) : p ∈ extendOrderingTable existing phase := by
-  unfold extendOrderingTable; exact List.mem_append_left _ hp
+/-- Every terminal mentioned at any Spell-out. -/
+def support : List α := phases.flatten.dedup
 
--- ============================================================================
--- § 4: Core Theorems
--- ============================================================================
+private theorem gen_src_mem {a b : α} (h : ∃ p ∈ phases, [a, b] <+ p) :
+    a ∈ support phases := by
+  obtain ⟨p, hp, hs⟩ := h
+  exact List.mem_dedup.mpr (List.mem_flatten.mpr ⟨p, hp, hs.subset (by simp)⟩)
 
-/-- Every element of `allPrecs ts` has its `after` field drawn from `ts`. -/
-theorem allPrecs_after_mem {p : Prec} {ts : List String}
-    (h : p ∈ allPrecs ts) : p.after ∈ ts := by
-  induction ts with
-  | nil => simp only [allPrecs, List.not_mem_nil] at h
-  | cons x xs ih =>
-    simp only [allPrecs, List.mem_append] at h
-    rcases h with h | h
-    · obtain ⟨y, hy, rfl⟩ := List.mem_map.mp h
-      exact List.mem_cons_of_mem x hy
-    · exact List.mem_cons_of_mem x (ih h)
+private theorem gen_dst_mem {a b : α} (h : ∃ p ∈ phases, [a, b] <+ p) :
+    b ∈ support phases := by
+  obtain ⟨p, hp, hs⟩ := h
+  exact List.mem_dedup.mpr (List.mem_flatten.mpr ⟨p, hp, hs.subset (by simp)⟩)
 
-/-- Every element of `allPrecs ts` has its `before` field drawn from `ts`. -/
-theorem allPrecs_before_mem {p : Prec} {ts : List String}
-    (h : p ∈ allPrecs ts) : p.before ∈ ts := by
-  induction ts with
-  | nil => simp only [allPrecs, List.not_mem_nil] at h
-  | cons x xs ih =>
-    simp only [allPrecs, List.mem_append] at h
-    rcases h with h | h
-    · obtain ⟨_, _, rfl⟩ := List.mem_map.mp h
-      exact List.mem_cons_self ..
-    · exact List.mem_cons_of_mem x (ih h)
+instance instDecidableReflTransGen (a b : α) :
+    Decidable (Relation.ReflTransGen (fun a b => ∃ p ∈ phases, [a, b] <+ p) a b) :=
+  Relation.ReflTransGen.decidable_of_finite (support phases)
+    (fun _ _ h => gen_dst_mem phases h) a b
 
-/-- In a `Nodup` list, `allPrecs` never contains both `⟨a,b⟩` and `⟨b,a⟩`:
-    if `a` precedes `b`, then `b` does not precede `a`. -/
-theorem allPrecs_antisym : ∀ (ts : List String), ts.Nodup →
-    ∀ (s : Prec), s ∈ allPrecs ts → ∀ (t : Prec), t ∈ allPrecs ts →
-    s.before = t.after → s.after ≠ t.before := by
-  intro ts
-  induction ts with
-  | nil => intro _ s hs; simp only [allPrecs, List.not_mem_nil] at hs
-  | cons x xs ih =>
-    intro hnd s hs t ht h1
-    rw [List.nodup_cons] at hnd; obtain ⟨hx, hnd'⟩ := hnd
-    simp only [allPrecs, List.mem_append] at hs ht
-    rcases hs with hs | hs <;> rcases ht with ht | ht
-    · obtain ⟨ys, hys, rfl⟩ := List.mem_map.mp hs
-      obtain ⟨yt, hyt, rfl⟩ := List.mem_map.mp ht
-      dsimp at h1
-      rw [← h1] at hyt
-      exact absurd hyt hx
-    · obtain ⟨ys, hys, rfl⟩ := List.mem_map.mp hs
-      dsimp at h1
-      have hta := allPrecs_after_mem ht
-      rw [← h1] at hta
-      exact absurd hta hx
-    · obtain ⟨yt, hyt, rfl⟩ := List.mem_map.mp ht
-      dsimp at h1 ⊢
-      intro heq
-      have hsa := allPrecs_after_mem hs
-      rw [heq] at hsa
-      exact hx hsa
-    · exact ih hnd' s hs t ht h1
+instance instDecidableSpelloutOrder (a b : α) : Decidable (spelloutOrder phases a b) :=
+  decidable_of_iff (∃ c ∈ support phases, (∃ p ∈ phases, [a, c] <+ p) ∧
+      Relation.ReflTransGen (fun a b => ∃ p ∈ phases, [a, b] <+ p) c b) <| by
+    rw [spelloutOrder, Relation.TransGen.head'_iff]
+    exact ⟨fun ⟨c, _, h, h'⟩ => ⟨c, h, h'⟩, fun ⟨c, h, h'⟩ => ⟨c, gen_dst_mem phases h, h, h'⟩⟩
 
-/-- A single phase is always consistent: no ordering contradiction can arise
-    within a single left-to-right linearization of distinct terminals.
-    Requires `Nodup` because duplicate terminals create trivial self-loops
-    (α < α), which `HasContradiction` correctly flags. -/
-theorem single_phase_consistent (ts : List String) (hnd : ts.Nodup) :
-    Consistent (allPrecs ts) := by
-  unfold Consistent HasContradiction
-  rintro ⟨s, hs, t, ht, h1, h2⟩
-  exact allPrecs_antisym _ hnd s hs t ht h1 h2
+instance instDecidableConsistent : Decidable (Consistent phases) :=
+  decidable_of_iff (∀ a ∈ support phases, ¬ spelloutOrder phases a a) <| by
+    refine ⟨fun h a ha => ?_, fun h a _ => h a⟩
+    rcases (Relation.TransGen.head'_iff.mp ha) with ⟨c, hac, _⟩
+    exact h a (gen_src_mem phases hac) ha
 
-/-- Leftward movement from the phase edge preserves ordering.
-    Scenario 1 of [fox-pesetsky-2005] (their (13)):
-    X was at the left edge of D; when D' is spelled out, X moves further
-    left. The new ordering X < α is consistent with X < Y from D. -/
-theorem edge_movement_consistent :
-    SpelloutAndCheck [["X", "Y", "Z"], ["X", "α", "Y", "Z"]] := by decide
-
-/-- Leftward movement from a non-edge position creates contradiction.
-    Scenario 2 of [fox-pesetsky-2005] (their (14)):
-    Y was NOT at the left edge of D (X < Y at D Spell-out). When Y moves
-    left in D', it must precede α, but α < X and X < Y yield a cycle. -/
-theorem non_edge_movement_contradiction :
-    ¬ SpelloutAndCheck [["X", "Y", "Z"], ["Y", "α", "X", "Z"]] := by decide
-
-/-- Successive-cyclic *wh*-movement avoids ordering contradiction.
-    [fox-pesetsky-2005] (their (6)–(8)): *to whom* moves through
-    Spec,VP before moving to Spec,CP, preserving VP-internal order. -/
-theorem successive_cyclic_ok :
-    SpelloutAndCheck [["to_whom", "gave", "the_book"],
-                      ["to_whom", "that", "Mary", "gave", "the_book"]] := by
-  decide
-
-/-- Non-successive-cyclic movement creates ordering contradiction.
-    [fox-pesetsky-2005] (their (3)–(5)): *to whom* skips Spec,VP
-    and moves directly to Spec,CP, contradicting VP-internal order. -/
-theorem non_successive_cyclic_bad :
-    ¬ SpelloutAndCheck [["gave", "the_book", "to_whom"],
-                        ["to_whom", "that", "Mary", "gave", "the_book"]] := by
-  decide
-
-/-- Order-preserving simultaneous movement: two elements moving out of a
-    phase in their original relative order creates no contradiction.
-    This is the key configuration for Malayic object extraction
-    ([erlewine-sommerlot-2025] ex. 55–56). -/
-theorem simultaneous_order_preserving :
-    SpelloutAndCheck [["A", "B", "C"], ["A", "B", "D", "C"]] := by decide
-
-/-- Simultaneous movement that reverses relative order contradicts. -/
-theorem simultaneous_order_reversing :
-    ¬ SpelloutAndCheck [["A", "B", "C"], ["B", "A", "D", "C"]] := by decide
-
--- ============================================================================
--- § 5: Holmberg's Generalization
--- ============================================================================
-
-/-! ### Object Shift and verb movement
-
-[fox-pesetsky-2005] derive Holmberg's Generalization: Object Shift
-in Scandinavian is only possible when the verb has also moved out of VP.
-
-VP Spell-out establishes V < Obj. If the verb stays in VP and the object
-shifts leftward, the higher Spell-out domain orders Obj < V — directly
-contradicting V < Obj. When the verb also moves, V < Obj is preserved.
--/
-
-/-- Baseline: no Object Shift, verb moves to I. Consistent.
-    VP contains only [V, Obj]; Neg is above VP. -/
-theorem no_object_shift :
-    SpelloutAndCheck [["V", "Obj"],
-                      ["Subj", "V", "Neg", "Obj"]] := by decide
-
-/-- Object Shift WITH verb movement: both V and Obj move past Neg.
-    VP-internal ordering V < Obj is preserved at IP. Consistent.
-    [fox-pesetsky-2005] §3. -/
-theorem object_shift_with_verb_movement :
-    SpelloutAndCheck [["V", "Obj"],
-                      ["Subj", "V", "Obj", "Neg"]] := by decide
-
-/-- Object Shift WITHOUT verb movement: Obj moves past Neg but V stays.
-    VP: V < Obj. IP: Obj < ... < V. Direct contradiction → crash.
-    This IS Holmberg's Generalization, derived from cyclic linearization.
-    [fox-pesetsky-2005] §3. -/
-theorem object_shift_without_verb_movement :
-    ¬ SpelloutAndCheck [["V", "Obj"],
-                        ["Subj", "Obj", "Neg", "V"]] := by decide
-
--- ============================================================================
--- § 6: Transitive Cycle Detection
--- ============================================================================
-
-/-! ### Full cycle detection via reachability
-
-`HasContradiction` detects direct ordering cycles (a < b ∧ b < a).
-For completeness, `HasCycle` detects cycles of any length via the
-`Relation.ReflTransGen` reachability over the directed precedence
-graph (with `Decidable` derived from
-`Core.Relation.ReflTransGen.decidable_of_finite`). For all current
-applications (Malayic voice, Holmberg's Generalization), contradictions
-are direct, so both predicates agree.
--/
-
-/-- One-step precedence relation in `table`: there exists an entry
-    `⟨src, dst⟩`. -/
-def precedeStep (table : OrderingTable) (src dst : String) : Prop :=
-  ⟨src, dst⟩ ∈ table
-
-instance (table : OrderingTable) (src dst : String) :
-    Decidable (precedeStep table src dst) :=
-  inferInstanceAs (Decidable (_ ∈ _))
-
-/-- `dst` is reachable from `src` via directed edges in `table`. The
-    relation is `Relation.ReflTransGen` of the one-step `precedeStep`.
-    Decidability is supplied by the `Core.Relation.ReflTransGen` substrate
-    using the table's vertex universe as the finite carrier. -/
-def Reachable (table : OrderingTable) (src dst : String) : Prop :=
-  Relation.ReflTransGen (precedeStep table) src dst
-
-/-- All vertices mentioned by `table`: every successor of `precedeStep`
-    sits here. -/
-private def tableVerts (table : OrderingTable) : List String :=
-  (table.map (·.before) ++ table.map (·.after)).dedup
-
-private theorem precedeStep_dst_mem_tableVerts (table : OrderingTable) :
-    ∀ src dst, precedeStep table src dst → dst ∈ tableVerts table := by
-  intro src dst h
-  simp only [tableVerts, List.mem_dedup, List.mem_append, List.mem_map]
-  exact Or.inr ⟨⟨src, dst⟩, h, rfl⟩
-
-instance (table : OrderingTable) (src dst : String) :
-    Decidable (Reachable table src dst) :=
-  Relation.ReflTransGen.decidable_of_finite (r := precedeStep table)
-    (tableVerts table) (precedeStep_dst_mem_tableVerts table) src dst
-
-/-- An Ordering Table contains a directed cycle of any length: some
-    edge a → b such that b can reach a via other edges. -/
-def HasCycle (table : OrderingTable) : Prop :=
-  ∃ edge ∈ table, Reachable table edge.after edge.before
-
-instance (table : OrderingTable) : Decidable (HasCycle table) := by
-  unfold HasCycle; infer_instance
-
-/-- `HasCycle` detects the transitive cycle a < b, b < c, c < a which
-    `HasContradiction` misses (no direct a < b ∧ b < a pair). -/
-theorem hasCycle_detects_transitive :
-    HasCycle [⟨"a", "b"⟩, ⟨"b", "c"⟩, ⟨"c", "a"⟩] ∧
-    ¬ HasContradiction [⟨"a", "b"⟩, ⟨"b", "c"⟩, ⟨"c", "a"⟩] := by decide
-
-/-- On the Malayic meN-deletion example, both checks agree
-    (the contradiction is direct). -/
-theorem cycle_direct_agree_malayic :
-    let t := allPrecs ["theme", "me-", "agent", "NV"] ++
-             allPrecs ["theme", "agent", "Aux", "me-", "NV"]
-    HasCycle t ↔ HasContradiction t := by decide
-
--- ============================================================================
--- § 7: Feature Preservation Across Phases
--- ============================================================================
-
-/-! ### Per-cycle frozen feature assignments
-
-[fox-pesetsky-2005]'s Order Preservation says precedences emitted
-at one Spell-out are preserved through subsequent Spell-outs. The same
-shape applies to *feature values* established by phase-bounded
-phonological computation: when vP is spelled out and a feature value
-(e.g. `+ATR` on a particle) is set by phase-internal phonology, that
-value is preserved through later syntactic movement of the bearer.
-
-[sande-clem-dabkowski-2026] §6.1 argues this is the right way to
-think about Guébie discontinuous harmony: the particle's ATR value is
-fixed at vP spell-out (when the verb is local to it inside vP), and
-later A′-movement of the remnant VP carries the frozen value to
-Spec,CP. The intervening subject/auxiliary/object are spelled out in
-the higher CP phase with their own (unaffected) ATR values.
-
-This section provides the analogous append-only accumulator for feature
-freezings. It does *not* generalize `OrderingTable` (which stays
-precedence-only); the two registries can be combined externally by a
-study file when needed.
--/
-
-/-- A frozen feature assignment: terminal `t` had feature `f` set to
-    `value` at the spell-out cycle that emitted this entry. -/
-structure FrozenFeature where
-  terminal : String
-  feature  : String
-  value    : Bool
-  deriving DecidableEq, Repr
-
-/-- Per-cycle log of feature assignments preserved across spell-out.
-    The analogue of `OrderingTable` for features rather than precedences.
-    Append-only: never deleted. -/
-abbrev FrozenFeatureTable := List FrozenFeature
-
-/-- Extend a frozen-feature table with the assignments emitted by one
-    spell-out cycle. The analogue of `extendOrderingTable`. -/
-def extendFrozenFeatures (existing : FrozenFeatureTable)
-    (phaseFreezings : List FrozenFeature) : FrozenFeatureTable :=
-  existing ++ phaseFreezings
-
-/-- Order-Preservation analogue for features: feature freezings emitted
-    at earlier phases survive subsequent spell-out. The formal content
-    of [sande-clem-dabkowski-2026]'s "the ATR value persists through
-    syntactic movement" claim. -/
-theorem extendFrozenFeatures_preserves
-    (existing : FrozenFeatureTable) (phaseFreezings : List FrozenFeature)
-    (f : FrozenFeature) (h : f ∈ existing) :
-    f ∈ extendFrozenFeatures existing phaseFreezings := by
-  unfold extendFrozenFeatures; exact List.mem_append_left _ h
-
-/-- Lookup the most-recently-frozen value of `feature` on `terminal`,
-    if any. Returns `none` if not yet frozen.
-
-    Phase-internal phonology that resets a feature value writes a new
-    entry; the most recent assignment wins per `List.find?` traversal
-    order (we reverse so later-appended entries are checked first). -/
-def frozenValue (table : FrozenFeatureTable) (terminal feature : String) : Option Bool :=
-  (table.reverse.find? (fun f => f.terminal == terminal && f.feature == feature)).map (·.value)
-
-/-- Two-phase feature preservation example: ATR value frozen at vP
-    survives the CP-phase spell-out. Mimics SCD 2026's PartSAuxOV
-    derivation: at vP spell-out, the particle (`Part`) is set to
-    `+ATR` by harmony with the verb; the CP phase emits no further
-    ATR assignments on `Part`; the value persists. -/
-theorem frozen_atr_persists_through_cp_phase :
-    frozenValue (extendFrozenFeatures [⟨"Part", "ATR", true⟩] []) "Part" "ATR"
-      = some true := by decide
-
-/-- A later phase that re-freezes the same feature overrides the earlier
-    value. (Not used by SCD 2026, which posits no CP-phase ATR re-write
-    for the particle, but documents the intended override semantics.) -/
-theorem frozen_value_later_overrides :
-    frozenValue
-      (extendFrozenFeatures [⟨"Part", "ATR", true⟩] [⟨"Part", "ATR", false⟩])
-      "Part" "ATR" = some false := by decide
+end Decidability
 
 end Minimalist.Linearization


### PR DESCRIPTION
Rewrites Fox–Pesetsky cyclic linearization at MCB-grade rigor: per-phase precedence is the pair-sublist relation (`[a,b] <+ p`), `spelloutOrder` is the transitive closure over the phase word, and the crash condition is `Consistent phases ↔ IsStrictOrder α (spelloutOrder phases)` — Order Preservation becomes monotonicity, phase-order blindness a theorem, and duplicate self-crash automatic. Fixes the audit's faithfulness gap: the old `SpelloutAndCheck` missed transitive cycles (`transitive_cycle_crashes` now witnesses the closed gap).

- new `Studies/FoxPesetsky2005.lean`: the paper's worked examples ((13)/(14), (3)–(8), Holmberg §3) + `history_dependence` (the derivational thesis: same final string, opposite verdicts)
- `Prec`/`OrderingTable`/`allPrecs`/`HasContradiction`/`HasCycle` deleted; `FrozenFeature` apparatus moved to its sole consumer `SandeClemDabkowski2026`; ES2025/ShenHuang2026 migrated
- substrate: `List.pair_sublist_iff_idxOf_lt` (pair sublists = positional order on `Nodup` lists); `Consistent` decidable via the existing `ReflTransGen.decidable_of_finite`