### PR TITLE
docs(Studies): fix joku attribution in SandeClemDabkowski2026

### DIFF
--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -311,8 +311,9 @@ theorem frozen_value_later_overrides :
       "Part" "ATR" = some false := by decide
 
 /-- The ATR value frozen at vP-spell-out for `PartSAuxOV`: when V is
-    +ATR (e.g. /joku/), Part inherits +ATR via local vP-internal
-    harmony. This is the freezing event. -/
+    +ATR (e.g. /ni/ 'see', whose harmony yields the +ATR particle
+    surface form [joku], their (41)), Part inherits +ATR via local
+    vP-internal harmony. This is the freezing event. -/
 def vPFrozen_PartSAuxOV (vIsPlusATR : ATR) : FrozenFeatureTable :=
   if vIsPlusATR then [⟨"Part", "ATR", true⟩]
   else            [⟨"Part", "ATR", false⟩]


### PR DESCRIPTION
Primary-source verification against the published PDF (Language 2026, 1–32): their (41) glosses *joku* as the PARTICLE (the +ATR surface form under harmony), not a +ATR verb — the trigger is /ni/ 'see'. Docstring corrected. (The fix raced #1216's auto-merge and was stranded on that branch.)