### PR TITLE
style(Studies): rename study-local Clause to ClauseConfig

### DIFF
--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -23,9 +23,9 @@ is their (44): harmony iff V is spelled out inside vP.
 
 ## Main definitions
 
-* `Clause`, `WordOrder`: the §4 parameters and the four attested settings, with
+* `ClauseConfig`, `WordOrder`: the §4 parameters and the four attested settings, with
   derived Spell-outs ((45)/(48)) and surface strings ((31)–(34)).
-* `Clause.harmony`, `surfaceATR`, `harmonyTableau`: trigger-locality (§6.1), the
+* `ClauseConfig.harmony`, `surfaceATR`, `harmonyTableau`: trigger-locality (§6.1), the
   particle's surface value ((12)–(13)), and the (46)/(47) ranking as a tableau.
 * `FrozenATR`, `guebiePICMode`: the per-cycle harmony record (§6.1) and the PIC
   stance (§6.2).
@@ -85,22 +85,22 @@ def particleDefaultATR : ATR := false
 /-- The two parameters of [sande-clem-dabkowski-2026] §4's predicate-fronting
     analysis: an auxiliary in T blocks V-to-T ((32)/(34)), and the remnant VP
     (containing the particle) may front to Spec,CP ((33)/(34)). -/
-structure Clause where
+structure ClauseConfig where
   hasAux  : Bool
   fronted : Bool
   deriving DecidableEq, Repr
 
 /-- V stays in v — hence inside the vP Spell-out — iff Aux occupies T (§4.1). -/
-def Clause.verbInVP (c : Clause) : Bool := c.hasAux
+def ClauseConfig.verbInVP (c : ClauseConfig) : Bool := c.hasAux
 
 /-- Overt terminals spelled out within vP ((45)/(48)): the particle, plus V iff it
     has not raised past v. The object has independently shifted out. -/
-def Clause.vPSpellOut (c : Clause) : List String :=
+def ClauseConfig.vPSpellOut (c : ClauseConfig) : List String :=
   "Part" :: if c.verbInVP then ["V"] else []
 
 /-- The surface clause, derived compositionally ((31)–(34)): fronted particle,
     subject, T-material, object, in-situ particle, clause-final verb. -/
-def Clause.surfaceOrder (c : Clause) : List String :=
+def ClauseConfig.surfaceOrder (c : ClauseConfig) : List String :=
   (if c.fronted then ["Part"] else []) ++ ["S"]
     ++ (if c.hasAux then ["Aux"] else ["V"]) ++ ["O"]
     ++ (if c.fronted then [] else ["Part"])
@@ -109,7 +109,7 @@ def Clause.surfaceOrder (c : Clause) : List String :=
 /-- The two-phase Cyclic-Linearization derivation: vP Spell-out, then the full
     surface clause ([fox-pesetsky-2005]'s final Linearize). Previously-spelled-out
     terminals recur, so Order Preservation is what makes consistency contentful. -/
-def Clause.derivation (c : Clause) : List (List String) :=
+def ClauseConfig.derivation (c : ClauseConfig) : List (List String) :=
   [c.vPSpellOut, c.surfaceOrder]
 
 /-- The four attested word orders as parameter settings
@@ -126,7 +126,7 @@ inductive WordOrder where
   deriving DecidableEq, Repr
 
 /-- The parameter settings behind the four orders ((31)–(34)). -/
-def WordOrder.clause : WordOrder → Clause
+def WordOrder.config : WordOrder → ClauseConfig
   | .SVOPart    => ⟨false, false⟩
   | .SAuxOPartV => ⟨true,  false⟩
   | .PartSVO    => ⟨false, true⟩
@@ -134,17 +134,17 @@ def WordOrder.clause : WordOrder → Clause
 
 /-- The derived surface strings are the attested orders. -/
 theorem surfaceOrder_attested :
-    WordOrder.SVOPart.clause.surfaceOrder    = ["S", "V", "O", "Part"] ∧
-    WordOrder.SAuxOPartV.clause.surfaceOrder = ["S", "Aux", "O", "Part", "V"] ∧
-    WordOrder.PartSVO.clause.surfaceOrder    = ["Part", "S", "V", "O"] ∧
-    WordOrder.PartSAuxOV.clause.surfaceOrder = ["Part", "S", "Aux", "O", "V"] := by
+    WordOrder.SVOPart.config.surfaceOrder    = ["S", "V", "O", "Part"] ∧
+    WordOrder.SAuxOPartV.config.surfaceOrder = ["S", "Aux", "O", "Part", "V"] ∧
+    WordOrder.PartSVO.config.surfaceOrder    = ["Part", "S", "V", "O"] ∧
+    WordOrder.PartSAuxOV.config.surfaceOrder = ["Part", "S", "Aux", "O", "V"] := by
   decide
 
 /-! ### Consistency: every setting linearizes; non-edge fronting would not -/
 
 /-- Every parameter setting linearizes consistently. -/
 theorem all_clauses_consistent :
-    ∀ aux fronted : Bool, Consistent (Clause.derivation ⟨aux, fronted⟩) := by decide
+    ∀ aux fronted : Bool, Consistent (ClauseConfig.derivation ⟨aux, fronted⟩) := by decide
 
 /-- The §6.2 escape-hatch argument: the particle can front because it is "the
     leftmost overt element in the vP phase upon spell-out". A counterfactual vP
@@ -156,28 +156,28 @@ theorem nonedge_particle_fronting_crashes :
 /-! ### The (44) correlation, derived -/
 
 /-- Harmony applies iff the trigger V is spelled out within vP (§6.1). -/
-def Clause.harmony (c : Clause) : Bool :=
+def ClauseConfig.harmony (c : ClauseConfig) : Bool :=
   c.vPSpellOut.contains "V"
 
 /-- The (44) correlation derived from the syntax: harmony iff Aux blocks V-to-T. -/
 theorem harmony_eq_hasAux (aux fronted : Bool) :
-    (Clause.mk aux fronted).harmony = aux := by decide +revert
+    (ClauseConfig.mk aux fronted).harmony = aux := by decide +revert
 
 /-- Fronting is irrelevant to harmony — the discontinuity is purely a surface
     effect of later movement. -/
 theorem harmony_independent_of_fronting (aux f₁ f₂ : Bool) :
-    (Clause.mk aux f₁).harmony = (Clause.mk aux f₂).harmony := by decide +revert
+    (ClauseConfig.mk aux f₁).harmony = (ClauseConfig.mk aux f₂).harmony := by decide +revert
 
 /-- Discontinuity as a theorem: in the fronted SAuxOV clause, particle and verb
     are not surface-adjacent in either order, yet harmony applies ((24)). -/
 theorem discontinuous_harmony :
-    (Clause.mk true true).harmony = true ∧
-    ¬ (["Part", "V"] <:+: (Clause.mk true true).surfaceOrder ∨
-       ["V", "Part"] <:+: (Clause.mk true true).surfaceOrder) := by decide
+    (ClauseConfig.mk true true).harmony = true ∧
+    ¬ (["Part", "V"] <:+: (ClauseConfig.mk true true).surfaceOrder ∨
+       ["V", "Part"] <:+: (ClauseConfig.mk true true).surfaceOrder) := by decide
 
 /-- The particle's surface ATR: the verb root's value under harmony ((12)), its
     lexical default otherwise ((13)). -/
-def surfaceATR (c : Clause) (vRoot : ATR) : ATR :=
+def surfaceATR (c : ClauseConfig) (vRoot : ATR) : ATR :=
   if c.harmony then vRoot else particleDefaultATR
 
 /-! ### §6.1's mechanism: the (46)/(47) ranking derives the surface value
@@ -204,7 +204,7 @@ def atrHarm : Constraint HarmonyCand :=
   Constraints.Constraint.binary fun c => ∃ t ∈ c.trigger, t ≠ c.out
 
 /-- The domain-local trigger: the verb root's value when V is spelled out in vP. -/
-def vPTrigger (c : Clause) (vRoot : ATR) : Option ATR :=
+def vPTrigger (c : ClauseConfig) (vRoot : ATR) : Option ATR :=
   if c.harmony then some vRoot else none
 
 /-- The vP-domain tableau: both output values, ranked `ATRHARM ≫ IDENT-IO(ATR)`. -/
@@ -345,8 +345,8 @@ instance (low surface : List String) (trigger target : String) :
 /-- Guébie's fronted SAuxOV clause instantiates the §7 profile: V and Part are
     co-spelled-out in vP, and the fronted surface linearizes consistently. -/
 theorem guebie_profile :
-    HarmonyProfile (Clause.mk true true).vPSpellOut
-      (Clause.mk true true).surfaceOrder "V" "Part" := by decide
+    HarmonyProfile (ClauseConfig.mk true true).vPSpellOut
+      (ClauseConfig.mk true true).surfaceOrder "V" "Part" := by decide
 
 /-- The Wolof shapes ([sy-2005] (49)–(50)): a bare noun–demonstrative DP, or a
     relative clause with the head noun fronted past the stative verb. -/


### PR DESCRIPTION
`SandeClemDabkowski2026.Clause` invited confusion with `Syntax/Clause/` (complementation typology) while being neither that nor `ExtendedProjection` spine substrate — it is the paper's §4 two-parameter derivation configuration. `ClauseConfig` says so; accessor `WordOrder.clause` → `WordOrder.config`.