### PR TITLE
refactor(Fragments): ATR as a proper enum, not a Bool synonym

### DIFF
--- a/Linglib/Fragments/Guebie/ParticleVerbs.lean
+++ b/Linglib/Fragments/Guebie/ParticleVerbs.lean
@@ -34,10 +34,16 @@ inductive Vowel where
   | I | E | a | O | U
   deriving DecidableEq, Repr
 
-/-- The ±ATR split ([sande-clem-dabkowski-2026] (1)): `+ATR = true`. -/
-def Vowel.atr : Vowel → Bool
-  | .i | .e | .schwa | .o | .u => true
-  | .I | .E | .a | .O | .U => false
+/-- The tongue-root feature value: `[+ATR]` or `[−ATR]`. -/
+inductive ATR where
+  | plus
+  | minus
+  deriving DecidableEq, Repr
+
+/-- The ±ATR split ([sande-clem-dabkowski-2026] (1)). -/
+def Vowel.atr : Vowel → ATR
+  | .i | .e | .schwa | .o | .u => .plus
+  | .I | .E | .a | .O | .U => .minus
 
 /-- A Guébie morpheme: transcription, vowel skeleton, optional gloss. -/
 structure Morpheme where
@@ -46,10 +52,11 @@ structure Morpheme where
   gloss  : Option String := none
   deriving DecidableEq, Repr
 
-/-- The lexical ATR value: the value of the morpheme's (agreeing) vowels;
-    `false` for the rare vowelless morphemes. -/
-def Morpheme.atr (m : Morpheme) : Bool :=
-  (m.vowels.head?.map Vowel.atr).getD false
+/-- The lexical ATR value: the value of the morpheme's (agreeing) vowels. The
+    rare vowelless morphemes are treated as `[−ATR]`; they neither trigger nor
+    block (kɔ-ɲ 'give' surfaces −ATR, (10)). -/
+def Morpheme.atr (m : Morpheme) : ATR :=
+  (m.vowels.head?.map Vowel.atr).getD .minus
 
 /-- Morpheme-internal vowels agree in ATR ([sande-clem-dabkowski-2026] §2.1). -/
 def Morpheme.ATRUniform (m : Morpheme) : Prop :=
@@ -95,7 +102,7 @@ structure ParticleVerb where
 
 /-- The particle's surface ATR in SAuxOV contexts: the verb root's value
     ([sande-clem-dabkowski-2026] (12)). -/
-def ParticleVerb.harmonizedParticleATR (pv : ParticleVerb) : Bool :=
+def ParticleVerb.harmonizedParticleATR (pv : ParticleVerb) : ATR :=
   pv.verb.atr
 
 /-- The (10) inventory, plus the (11)–(12) /jɔkʊ/+/ni/ pair. -/
@@ -114,7 +121,7 @@ theorem particleVerbs_ATRUniform :
 /-- The (11)–(12) alternation: −ATR /jɔkʊ/ surfaces +ATR ([joku]) under harmony
     with the +ATR root /ni/ 'see'. -/
 theorem joku_alternation :
-    jOkU.atr = false ∧
-    (ParticleVerb.mk jOkU ni "see").harmonizedParticleATR = true := by decide
+    jOkU.atr = .minus ∧
+    (ParticleVerb.mk jOkU ni "see").harmonizedParticleATR = .plus := by decide
 
 end Guebie

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -73,8 +73,9 @@ Guébie has a ten-vowel system, +ATR `ə e i o u` vs. −ATR `a ɛ ɪ ɔ ʊ`, ha
 as a binary feature; affixes and particles agree with the verb root when both are
 inside the same Spell-out domain. Only the per-terminal binary value matters here. -/
 
-/-- The ATR feature value of a terminal: `+ATR = true`, `−ATR = false`. -/
-abbrev ATR := Bool
+/-- The ATR feature value, from the fragment lexicon
+    (`Guebie.ATR`: `.plus`/`.minus`). -/
+abbrev ATR := Guebie.ATR
 
 /-- The particle's lexical default, surfacing when no harmony trigger is local
     ((13)). Defaults are lexical per particle ((12)); we model the /jɔkʊ/ type,
@@ -185,7 +186,7 @@ def surfaceATR (c : ClauseConfig) (vRoot : ATR) : ATR :=
     harmonized with /ni/ 'see') in the SAuxOV clause, but with its −ATR default in
     the SVO clause. -/
 example :
-    surfaceATR ⟨true, true⟩ Guebie.ni.atr = true ∧
+    surfaceATR ⟨true, true⟩ Guebie.ni.atr = .plus ∧
     surfaceATR ⟨false, true⟩ Guebie.ni.atr = Guebie.jOkU.atr := by decide
 
 /-! ### §6.1's mechanism: the (46)/(47) ranking derives the surface value
@@ -217,7 +218,7 @@ def vPTrigger (c : ClauseConfig) (vRoot : ATR) : Option ATR :=
 
 /-- The vP-domain tableau: both output values, ranked `ATRHARM ≫ IDENT-IO(ATR)`. -/
 def harmonyTableau (lex : ATR) (trig : Option ATR) : Tableau HarmonyCand 2 :=
-  Tableau.ofRanking [⟨lex, trig, true⟩, ⟨lex, trig, false⟩] [atrHarm, identIO]
+  Tableau.ofRanking [⟨lex, trig, .plus⟩, ⟨lex, trig, .minus⟩] [atrHarm, identIO]
     (List.cons_ne_nil _ _)
 
 /-- §6.1's mechanism, closed: the unique OT winner under `ATRHARM ≫ IDENT-IO(ATR)`
@@ -253,8 +254,8 @@ def frozenATR? (table : FrozenATR) (terminal : String) : Option ATR :=
 /-- A later re-freeze overrides — the intended semantics, though
     [sande-clem-dabkowski-2026] posit no CP-cycle ATR re-write for the particle. -/
 theorem frozenATR?_later_overrides :
-    frozenATR? (extendFrozenATR [("Part", true)] [("Part", false)]) "Part"
-      = some false := by decide
+    frozenATR? (extendFrozenATR [("Part", .plus)] [("Part", .minus)]) "Part"
+      = some .minus := by decide
 
 /-- The vP-cycle freezing for `PartSAuxOV`: Part inherits the verb root's value
     (e.g. /ni/ 'see' +ATR yields the particle surface form [joku], (11)–(12)). -/


### PR DESCRIPTION
`abbrev ATR := Bool` was a transparent synonym in a file that also has two other semantically distinct `Bool`s (`hasAux`, `fronted`) — ATR values and syntax flags interchanged freely. Now `Guebie.ATR` is a two-constructor enum (`.plus`/`.minus`) owned by the fragment and consumed by the study; the flags stay `Bool`. Hayes' `Phonology.Feature` inventory deliberately lacks ATR (it has `tense`), so there is no substrate type to consume — graduation to a Casali-anchored Phonology home waits for a second language's fragment.