### PR TITLE
feat(Phonology/Segmental): Casali tongue-root typology substrate

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1374,6 +1374,7 @@ import Linglib.Phonology.Segmental.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Phonology.Segmental.ElementTheory
 import Linglib.Phonology.Segmental.Geometry
+import Linglib.Phonology.Segmental.TongueRoot
 import Linglib.Phonology.Subregular.Agree
 import Linglib.Phonology.Subregular.ForbidPairs
 import Linglib.Phonology.Subregular.Harmony

--- a/Linglib/Fragments/Guebie/ParticleVerbs.lean
+++ b/Linglib/Fragments/Guebie/ParticleVerbs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Phonology.Segmental.TongueRoot
 
 /-!
 # Guébie: vowels, ATR, and particle verbs
@@ -34,11 +35,7 @@ inductive Vowel where
   | I | E | a | O | U
   deriving DecidableEq, Repr
 
-/-- The tongue-root feature value: `[+ATR]` or `[−ATR]`. -/
-inductive ATR where
-  | plus
-  | minus
-  deriving DecidableEq, Repr
+open Phonology.TongueRoot (ATR)
 
 /-- The ±ATR split ([sande-clem-dabkowski-2026] (1)). -/
 def Vowel.atr : Vowel → ATR
@@ -123,5 +120,11 @@ theorem particleVerbs_ATRUniform :
 theorem joku_alternation :
     jOkU.atr = .minus ∧
     (ParticleVerb.mk jOkU ni "see").harmonizedParticleATR = .plus := by decide
+
+/-- Guébie's tongue-root row: a ten-vowel `/2IU/` system with root-controlled
+    harmony ([sande-clem-dabkowski-2026] §2.1; [casali-2024-inventory] (1)). No
+    dominance pattern is reported. -/
+def tongueRoot : Phonology.TongueRoot.TongueRootProfile :=
+  { inventoryClass := .twoIU, control := .rootControlled, dominant := none }
 
 end Guebie

--- a/Linglib/Phonology/Segmental/TongueRoot.lean
+++ b/Linglib/Phonology/Segmental/TongueRoot.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+
+/-!
+# Tongue-root systems and the [ATR]-inventory correlation
+
+Casali's typology of tongue-root harmony systems ([casali-2024-inventory], the
+inventory-structure chapter of [ritter-vanderhulst-2024]; [casali-2003],
+[casali-2008]): systems with a tongue-root contrast in high vowels (`/2IU/`) are
+characteristically [+ATR]-dominant (69 of 72 surveyed), while systems contrasting
+tongue root only in non-high vowels (`/1IU/`) show [+ATR] inertness and [−ATR]
+dominance indicators. Whether the feature is binary [±ATR] or privative
+[ATR]/[RTR] is explicitly open in the source; the value type here is neutral
+between the two readings.
+
+The correlation is a defeasible typological tendency, never a theorem: Casali's
+own chapter records /1IU/ exceptions (Legbo, Ikoma), a questionable /2IU/
+exception (Kimatuumbi), and a dominance-reversal class (Kinande, Komo, Lango,
+Turkana, …) where [+ATR] dominance is overridden in identifiable contexts.
+Per-language rows live with fragments and studies, not here.
+
+## Main definitions
+
+* `ATR`: the tongue-root feature value.
+* `InventoryClass`: Casali's `/2IU/` vs `/1IU/` classification (applies only to
+  systems with a tongue-root contrast at all — five-vowel systems are excluded).
+* `ControlType`: root-controlled vs dominant-recessive harmony — cross-cutting
+  the inventory classification.
+* `DominanceIndicator`: the five evidence types for a dominant value.
+* `TongueRootProfile`, `conformsToCorrelation`: a language's row schema and the
+  correlation as a decidable predicate over it.
+-/
+
+namespace Phonology.TongueRoot
+
+/-- The tongue-root feature value: `[+ATR]` or `[−ATR]`. Neutral between binary
+    and privative readings ([casali-2024-inventory]). -/
+inductive ATR where
+  | plus
+  | minus
+  deriving DecidableEq, Repr
+
+/-- The opposite value. -/
+def ATR.opp : ATR → ATR
+  | .plus => .minus
+  | .minus => .plus
+
+@[simp] theorem ATR.opp_opp (v : ATR) : v.opp.opp = v := by cases v <;> rfl
+
+/-- Casali's inventory classification: where the tongue-root contrast lives.
+    Only systems with a contrast at all are classified (five-vowel `/i e a o u/`
+    systems fall outside the typology, [casali-2024-inventory] fn. 1). -/
+inductive InventoryClass where
+  /-- Contrast in high vowels (possibly elsewhere too): nine-vowel Akan/Maasai,
+      seven-vowel Kinande, ten-vowel Guébie. -/
+  | twoIU
+  /-- Contrast only in non-high vowels: the common seven-vowel
+      `/i u e ɛ o ɔ a/` type (Yoruba, Wolof). -/
+  | oneIU
+  deriving DecidableEq, Repr
+
+/-- Harmony control type — cross-cutting the inventory classification: affixes
+    harmonizing to the root regardless of value (root control, e.g. Degema,
+    Guébie) vs a designated value winning regardless of morphological position
+    (dominant-recessive, e.g. Maasai). -/
+inductive ControlType where
+  | rootControlled
+  | dominantRecessive (dominant : ATR)
+  deriving DecidableEq, Repr
+
+/-- The five evidence types for a dominant [ATR] value
+    ([casali-2024-inventory] §15.2.1, following [casali-2003]). -/
+inductive DominanceIndicator where
+  /-- Invariant dominant affixes spreading onto roots (Maasai `/íé/`). -/
+  | dominantAffix
+  /-- Spreading across word boundaries or between compound members. -/
+  | crossWordSpreading
+  /-- Systematic preservation of one value in vowel coalescence. -/
+  | coalescencePreservation
+  /-- A phonemically unpaired vowel with a predictable harmonized allophone. -/
+  | allophonicDominance
+  /-- Harmonizing affixes surfacing with one value where harmony is inapplicable. -/
+  | weakAssimilatory
+  deriving DecidableEq, Repr
+
+/-- A language's tongue-root row: inventory class, control type, and the observed
+    dominant value with its evidence (`none` = symmetric/inert patterning). -/
+structure TongueRootProfile where
+  inventoryClass : InventoryClass
+  control        : ControlType
+  dominant       : Option ATR
+  evidence       : List DominanceIndicator := []
+  deriving DecidableEq, Repr
+
+/-- The [ATR]-inventory correlation ([casali-2024-inventory]): a `/2IU/` system
+    with observed dominance has [+ATR] dominant; a `/1IU/` system does not have
+    [+ATR] dominant. Symmetric systems (no observed dominance) conform trivially.
+    A defeasible tendency over rows — Casali's chapter records the exceptions —
+    so this is a predicate for per-language conformance, never a theorem. -/
+def conformsToCorrelation (p : TongueRootProfile) : Prop :=
+  match p.inventoryClass, p.dominant with
+  | _, none => True
+  | .twoIU, some v => v = .plus
+  | .oneIU, some v => v = .minus
+
+instance (p : TongueRootProfile) : Decidable (conformsToCorrelation p) := by
+  unfold conformsToCorrelation
+  rcases p with ⟨_ | _, _, _ | _, _⟩ <;> exact inferInstanceAs (Decidable _)
+
+end Phonology.TongueRoot

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -73,9 +73,8 @@ Guébie has a ten-vowel system, +ATR `ə e i o u` vs. −ATR `a ɛ ɪ ɔ ʊ`, ha
 as a binary feature; affixes and particles agree with the verb root when both are
 inside the same Spell-out domain. Only the per-terminal binary value matters here. -/
 
-/-- The ATR feature value, from the fragment lexicon
-    (`Guebie.ATR`: `.plus`/`.minus`). -/
-abbrev ATR := Guebie.ATR
+/-- The tongue-root feature value (`Phonology.TongueRoot.ATR`). -/
+abbrev ATR := Phonology.TongueRoot.ATR
 
 /-- The particle's lexical default, surfacing when no harmony trigger is local
     ((13)). Defaults are lexical per particle ((12)); we model the /jɔkʊ/ type,

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -29803,6 +29803,54 @@
   role      = {cited}
 }
 
+@book{ritter-vanderhulst-2024,
+  editor    = {Ritter, Nancy A. and van der Hulst, Harry},
+  year      = {2024},
+  title     = {The Oxford Handbook of Vowel Harmony},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {phonology},
+  role      = {background},
+  sources   = {Phonology/Segmental/TongueRoot.lean}
+}
+
+@incollection{casali-2024-inventory,
+  author    = {Casali, Roderic F.},
+  year      = {2024},
+  title     = {Tongue-root harmony and vowel inventory structure},
+  booktitle = {The Oxford Handbook of Vowel Harmony},
+  editor    = {Ritter, Nancy A. and van der Hulst, Harry},
+  pages     = {156--170},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {phonology},
+  role      = {primary},
+  validated = {true},
+  sources   = {Phonology/Segmental/TongueRoot.lean}
+}
+
+@article{casali-2003,
+  author    = {Casali, Roderic F.},
+  year      = {2003},
+  title     = {[{ATR}] value asymmetries and underlying vowel inventory structure in {Niger-Congo} and {Nilo-Saharan}},
+  journal   = {Linguistic Typology},
+  subfield  = {phonology},
+  role      = {background},
+  sources   = {Phonology/Segmental/TongueRoot.lean}
+}
+
+@article{casali-2008,
+  author    = {Casali, Roderic F.},
+  year      = {2008},
+  title     = {{ATR} harmony in {African} languages},
+  journal   = {Language and Linguistics Compass},
+  volume    = {2},
+  doi       = {10.1111/j.1749-818X.2008.00064.x},
+  subfield  = {phonology},
+  role      = {background},
+  sources   = {Phonology/Segmental/TongueRoot.lean}
+}
+
 @incollection{casali-2011,
   author    = {Casali, Roderic F.},
   year      = {2011},


### PR DESCRIPTION
New `Phonology/Segmental/TongueRoot.lean`, written with Casali's inventory-structure chapter open (Oxford Handbook of Vowel Harmony, pp. 156–170): the `ATR` value (neutral between binary and privative readings, per the chapter's own framing), the `/2IU/`–`/1IU/` inventory classification (with fn. 1's five-vowel exclusion), root-control vs dominant-recessive as cross-cutting `ControlType`, the five `DominanceIndicator` evidence types (§15.2.1), and the [ATR]-inventory correlation as a decidable per-language predicate — a defeasible tendency with the chapter's recorded exceptions in the docstring, never a theorem. Types only; language rows live with fragments/studies.

- `Guebie.ATR` graduates: the fragment now opens the substrate type and declares Guébie's row (`/2IU/`, root-controlled); the study's `ATR` abbrev follows
- four verified bib entries (handbook, chapter, Casali 2003/2008 — unverifiable fields left blank)
- Casali-anchored sibling of the Hayes-anchored `Segmental/Defs.lean`, which deliberately lacks ATR