### PR TITLE
feat(Phonology/Harmony): harmonicity is TSL2 by construction

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1354,6 +1354,7 @@ import Linglib.Phonology.HarmonicGrammar.Separability
 import Linglib.Phonology.HarmonicGrammar.ViolationSemiring
 import Linglib.Phonology.Harmony.Basic
 import Linglib.Phonology.Harmony.TongueRoot
+import Linglib.Phonology.Harmony.TSL
 import Linglib.Phonology.OCP
 import Linglib.Phonology.OptimalityTheory.Antimatroid
 import Linglib.Phonology.OptimalityTheory.Cophonology

--- a/Linglib/Phonology/Harmony/Basic.lean
+++ b/Linglib/Phonology/Harmony/Basic.lean
@@ -128,11 +128,18 @@ structure Pattern (α : Type u) (V : Type v) where
 def AgreeOn (p : Pattern α V) (w : List α) : Prop :=
   w.Pairwise fun a b => p.value a = p.value b
 
-/-- The harmonic tier: participating and opaque segments. Transparent and icy
-    segments project out; opaque segments stay because they delimit spans. -/
+/-- Tier membership: participating and opaque segments are on the harmonic
+    tier. Transparent and icy segments project out; opaque segments stay
+    because they delimit spans. -/
+def Pattern.OnTier (p : Pattern α V) (s : α) : Prop :=
+  p.participation s = .participating ∨ p.participation s = .opaque
+
+instance (p : Pattern α V) : DecidablePred p.OnTier := fun s => by
+  unfold Pattern.OnTier; infer_instance
+
+/-- The harmonic tier of a string. -/
 def Pattern.tier (p : Pattern α V) (w : List α) : List α :=
-  w.filter fun s =>
-    decide (p.participation s = .participating ∨ p.participation s = .opaque)
+  w.filter fun s => decide (p.OnTier s)
 
 /-- Adjacent harmonic compatibility: two neighbouring tier segments agree in
     value unless either is an opaque blocker
@@ -140,6 +147,9 @@ def Pattern.tier (p : Pattern α V) (w : List α) : List α :=
 def Pattern.Compatible (p : Pattern α V) (a b : α) : Prop :=
   p.participation a = .opaque ∨ p.participation b = .opaque ∨
     p.value a = p.value b
+
+instance [DecidableEq V] (p : Pattern α V) : DecidableRel p.Compatible :=
+  fun a b => by unfold Pattern.Compatible; infer_instance
 
 /-- Surface harmonicity: the tier is a chain of compatible segments — within
     every opaque-delimited span, participating segments agree in value. -/
@@ -154,7 +164,7 @@ theorem Pattern.harmonic_insert_transparent {p : Pattern α V} {t : α}
     (ho : p.participation t ≠ .opaque) :
     p.Harmonic (w₁ ++ t :: w₂) ↔ p.Harmonic (w₁ ++ w₂) := by
   unfold Pattern.Harmonic Pattern.tier
-  simp [List.filter_append, hp, ho]
+  simp [List.filter_append, Pattern.OnTier, hp, ho]
 
 /-- Without opaque segments, harmonicity is pairwise agreement on the whole
     tier: adjacent compatibility is plain value-agreement, which is transitive,
@@ -166,6 +176,7 @@ theorem Pattern.harmonic_iff_agreeOn {p : Pattern α V} {w : List α}
     p.Harmonic w ↔ AgreeOn p (p.tier w) := by
   have hmem : ∀ s ∈ p.tier w, p.participation s ≠ .opaque :=
     fun s hs => h s (List.mem_of_mem_filter hs)
+
   haveI : Trans (fun a b => p.value a = p.value b)
       (fun a b => p.value a = p.value b) (fun a b => p.value a = p.value b) :=
     ⟨fun h₁ h₂ => h₁.trans h₂⟩

--- a/Linglib/Phonology/Harmony/TSL.lean
+++ b/Linglib/Phonology/Harmony/TSL.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.Subregular.Language.ForbiddenPairs
+import Linglib.Phonology.Harmony.Basic
+
+/-!
+# Harmony patterns are tier-based strictly local
+
+The bridge between the pattern layer and the consensus subregular mechanism
+([aksenova-rawski-graf-heinz-2024]): a harmony pattern's surface predicate is
+a TSL₂ language by construction. The tier is the pattern's
+participating-plus-opaque projection; the banned bigrams are the incompatible
+pairs. Strictly local grammars cannot express harmony (unbounded distance) and
+strictly piecewise grammars cannot express blocking; the tier-based class
+captures both, which is why it is the chapter's consensus characterization.
+
+## Main results
+
+* `Pattern.harmonic_iff_mem_tsl`: harmonicity is membership in the
+  forbidden-pairs TSL₂ grammar over the pattern's tier.
+-/
+
+namespace Phonology.Harmony
+
+open Subregular
+
+variable {α : Type*} {V : Type*}
+
+/-- **Harmony is TSL₂ by construction** ([aksenova-rawski-graf-heinz-2024]):
+    a pattern's surface harmonicity is membership in the tier-based strictly
+    2-local grammar whose tier is `Pattern.OnTier` and whose banned bigrams
+    are the incompatible pairs. -/
+theorem Pattern.harmonic_iff_mem_tsl [DecidableEq V]
+    (p : Pattern α V) (w : List α) :
+    p.Harmonic w ↔
+      w ∈ (TSLGrammar.ofForbiddenPairs
+        (R := fun a b => ¬ p.Compatible a b) p.OnTier).lang := by
+  rw [mem_ofForbiddenPairs_lang_iff_filter_isChain]
+  unfold Pattern.Harmonic Pattern.tier
+  simp only [not_not]
+
+end Phonology.Harmony

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -29829,6 +29829,21 @@
   sources   = {Phonology/Segmental/TongueRoot.lean}
 }
 
+@incollection{aksenova-rawski-graf-heinz-2024,
+  author    = {Aks{\"e}nova, Al{\"e}na and Rawski, Jonathan and Graf, Thomas and Heinz, Jeffrey},
+  year      = {2024},
+  title     = {The computational power of harmonic forms},
+  booktitle = {The Oxford Handbook of Vowel Harmony},
+  editor    = {Ritter, Nancy A. and van der Hulst, Harry},
+  pages     = {437--451},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {phonology},
+  role      = {primary},
+  validated = {true},
+  sources   = {Phonology/Harmony/TSL.lean}
+}
+
 @incollection{casali-2024-inventory,
   author    = {Casali, Roderic F.},
   year      = {2024},


### PR DESCRIPTION
The Phase-B bridge: `Pattern.harmonic_iff_mem_tsl` — a harmony pattern's surface predicate is membership in the tier-based strictly 2-local grammar over its participating-plus-opaque tier, banning incompatible bigrams. This is the Oxford Handbook computational chapter's consensus claim (Aksënova–Rawski–Graf–Heinz, pp. 437–451, read; verified bib entry) as a kernel-checked theorem, and it lands on the pre-existing generic `ofForbiddenPairs` machinery — the proof is one rewrite plus `not_not`.

- `Harmony/Basic.lean`: `Pattern.OnTier` extracted as the named tier predicate; `DecidableRel Pattern.Compatible` instance
- new `Harmony/TSL.lean` importing only the core language-side machinery (no OT dependency)
- placement may adjust per the pending mathlib-architecture review