### PR TITLE
fix(Phonology/Harmony): blocker imposition and icy semantics per audit

### DIFF
--- a/Linglib/Phonology/Harmony/Basic.lean
+++ b/Linglib/Phonology/Harmony/Basic.lean
@@ -8,36 +8,26 @@ import Mathlib.Data.List.Chain
 /-!
 # Vowel harmony: pattern-level vocabulary
 
-The theory-neutral typological vocabulary of vowel harmony, anchored on
-[ritter-vanderhulst-2024-themes], the framing chapter of
-[ritter-vanderhulst-2024]: participation roles, directionality, control type,
-domain, and the harmonic feature types. Mechanisms — subregular transduction
-(`Phonology/Subregular/Harmony.lean`), autosegmental spreading, constraint
-ranking — consume this vocabulary; rival analyses of one pattern differ in
-mechanism, not in these descriptors.
+The theory-neutral vocabulary of vowel harmony, anchored on
+[ritter-vanderhulst-2024-themes]: the typological enums and `Pattern`, the
+descriptive object mechanisms derive. At a finite alphabet a pattern presents
+a TSL₂ grammar (`Pattern.harmonic_iff_mem_tsl`). Segment-level participation
+cannot express parasitic harmony ((8b)) or configuration-dependent blocking
+(Yakut); those need the general forbidden-pairs machinery.
 
 ## Main definitions
 
-* `Participation`: how a segment participates — full participant, transparent,
-  opaque (blocker), or icy target.
-* `Direction`: the direction of the agreement relation.
-* `ControlType`: root-controlled vs dominant-recessive vs affix-controlled,
-  parameterized by the harmonic value type.
-* `Domain`: the morphological or prosodic domain delimiting harmony.
-* `HarmonyType`: the attested harmonic feature types.
-* `Pattern`: a harmony pattern over a segment type — valuation, participation,
-  direction, domain, control. `Pattern.Harmonic` is its surface semantics:
-  within every opaque-delimited span, participating segments agree in value.
-  At a finite alphabet a pattern presents a TSL₂ grammar
-  (`Pattern.harmonic_iff_mem_tsl`) — a small DFA on the tier.
+* `Participation`, `Direction`, `ControlType`, `Domain`, `HarmonyType`: the
+  typological enums.
+* `Pattern`: valuation, participation, descriptors; `Pattern.Harmonic` is the
+  surface semantics — tier-adjacent compatibility with blocker imposition and
+  icy absorption.
 
 ## Main results
 
-* `harmonic_insert_transparent`: transparent segments interrupt harmlessly —
-  inserting one never changes harmonicity.
-* `Pattern.harmonic_iff_agreeOn`: with all segments participating, harmonicity
-  is pairwise agreement — the local (chain) and global (pairwise) formulations
-  coincide.
+* `Pattern.harmonic_insert_transparent`: transparency interrupts harmlessly.
+* `Pattern.harmonic_iff_agreeOn`: with all segments participating, the chain
+  and pairwise formulations coincide.
 -/
 
 namespace Phonology.Harmony
@@ -46,70 +36,64 @@ universe u v
 
 variable {α : Type u} {V : Type v}
 
-/-- How a segment participates in harmony ([ritter-vanderhulst-2024-themes]
-    §1.3): full participants alternate and propagate; transparent (neutral)
-    vowels are skipped harmlessly; opaque vowels (blockers) impose their own
-    value on subsequent targets; icy targets (absorbing vowels, [jurgec-2011])
-    undergo harmony without passing it on. -/
+/-- How a segment participates in harmony ([ritter-vanderhulst-2024-themes] §1.3). -/
 inductive Participation where
+  /-- Alternates and propagates. -/
   | participating
+  /-- Skipped harmlessly (neutral). -/
   | transparent
+  /-- Does not undergo; imposes its value on what follows ((8c)). -/
   | opaque
+  /-- Undergoes without passing on ([jurgec-2011]'s absorbing vowels). -/
   | icyTarget
   deriving DecidableEq, Repr
 
-/-- Direction of the harmonic agreement relation
-    ([ritter-vanderhulst-2024-themes] §1.2.3): prototypical harmony may have no
-    direction, being bidirectional (moving outward from the root); unidirectional
-    cases are either stipulated or derived from target criteria or domain
-    exclusions. -/
+/-- Direction of the agreement relation ([ritter-vanderhulst-2024-themes] §1.2.3). -/
 inductive Direction where
   | rightward
   | leftward
+  /-- The prototype: outward from the root, no stipulated direction. -/
   | bidirectional
   deriving DecidableEq, Repr
 
-/-- Who determines the harmonic value ([ritter-vanderhulst-2024-themes]
-    §1.2.4): the root (morphologically determined trigger; affixes alternate,
-    roots do not), a designated dominant value regardless of morphological
-    position (phonologically determined, typical of ATR systems), or affixes —
-    a class the chapter poses as an open question, instanced by metaphony and
-    umlaut where stress acts as an attractor of the harmonic value.
-    Parameterized by the harmonic value type `V`. -/
+/-- Who determines the harmonic value ([ritter-vanderhulst-2024-themes] §1.2.4). -/
 inductive ControlType (V : Type u) where
+  /-- Roots do not alternate; affixes harmonize to them (morphologically determined). -/
   | rootControlled
+  /-- A designated value wins regardless of position (phonologically determined). -/
   | dominantRecessive (dominant : V)
+  /-- Posed as an open question by the chapter: metaphony and umlaut, where
+      stress attracts the harmonic value. -/
   | affixControlled
   deriving DecidableEq, Repr
 
-/-- The domain delimiting harmony ([ritter-vanderhulst-2024-themes] §1.2.2):
-    morphological (root, stem, word) or prosodic (foot, as in metaphony and
-    umlaut; phrase, in post-lexical harmony); `stemAndFirstAffix` is the bounded
-    bisyllabic agreement the chapter singles out — the stem-final vowel and the
-    first suffix vowel only. -/
+/-- The domain delimiting harmony ([ritter-vanderhulst-2024-themes] §1.2.2). -/
 inductive Domain where
   | root
   | stem
+  /-- Bounded bisyllabic agreement: the stem-final vowel and first suffix vowel only. -/
   | stemAndFirstAffix
   | word
+  /-- As in metaphony and umlaut. -/
   | foot
+  /-- Post-lexical harmony. -/
   | phrase
   deriving DecidableEq, Repr
 
-/-- The harmonic feature types surveyed in [ritter-vanderhulst-2024-themes]
-    §1.5: palatal and labial harmony occur frequently; height, tongue-root
-    ([ATR]/[RTR] — `Phonology/Harmony/TongueRoot.lean`), tense-lax, nasal,
-    emphasis (post-velar), retroflexion, and total (echo) harmony are attested.
-    Tonal harmony is unattested. -/
+/-- The feature types of [ritter-vanderhulst-2024-themes] §1.5; tonal harmony
+    is unattested. -/
 inductive HarmonyType where
   | palatal
   | labial
   | height
+  /-- [ATR]/[RTR]; see `Phonology/Harmony/TongueRoot.lean`. -/
   | tongueRoot
   | tenseLax
   | nasal
+  /-- Post-velar harmony. -/
   | emphasis
   | retroflex
+  /-- Echo/copy harmony: all features. -/
   | total
   deriving DecidableEq, Repr
 
@@ -123,17 +107,14 @@ are skipped; opaque blockers do not undergo but impose their transmitted value
 on what follows ((8c)); icy targets undergo without passing on
 ([jurgec-2011]). -/
 
-/-- A harmony pattern over segment type `α` with harmonic values in `V`: the
-    feature valuation (`none` = no harmonic counterpart), the participation
-    classification, and the typological descriptors. Participation is stored
-    independently of the valuation because the behavior of neutral vowels as
-    transparent or opaque is not predictable ([ritter-vanderhulst-2024-themes]
-    §1.3.2); intended discipline: `value s = none → participation s ≠
-    .participating` (allophonic undergoing of neutral vowels lives in a
-    separate valuation). For an opaque or icy segment, `value` is the value it
-    transmits, which may differ from its phonetic specification. -/
+/-- A harmony pattern over segment type `α` with harmonic values in `V`. -/
 structure Pattern (α : Type u) (V : Type v) where
+  /-- The valuation; `none` = no harmonic counterpart. For opaque and icy
+      segments, the value transmitted (not necessarily the phonetic one). -/
   value         : α → Option V
+  /-- Stored independently of the valuation: neutral vowels' transparent-vs-opaque
+      behavior is not predictable (§1.3.2). Discipline:
+      `value s = none → participation s ≠ .participating`. -/
   participation : α → Participation
   direction     : Direction := .bidirectional
   domain        : Domain := .word
@@ -143,10 +124,7 @@ structure Pattern (α : Type u) (V : Type v) where
 def Pattern.AgreeOn (p : Pattern α V) (w : List α) : Prop :=
   w.Pairwise fun a b => p.value a = p.value b
 
-/-- Tier membership: everything but transparent segments. Opaque blockers stay
-    on the tier because they impose values; icy targets stay because they
-    undergo ([aksenova-rawski-graf-heinz-2024]'s Yakut keeps its harmonizing
-    blockers on the tier). -/
+/-- Tier membership: everything but transparent segments. -/
 def Pattern.OnTier (p : Pattern α V) (s : α) : Prop :=
   p.participation s ≠ .transparent
 
@@ -157,14 +135,9 @@ instance (p : Pattern α V) : DecidablePred p.OnTier := fun s => by
 def Pattern.tier (p : Pattern α V) (w : List α) : List α :=
   w.filter fun s => decide (p.OnTier s)
 
-/-- Adjacent harmonic compatibility, read left to right: the right member is
-    exempt if it is an opaque blocker (blockers do not undergo, but as left
-    member they impose their transmitted `value` on what follows —
-    [ritter-vanderhulst-2024-themes] (8c)); the left member is exempt if it is
-    an icy target (undergoes without passing on, [jurgec-2011]). Otherwise the
-    pair agrees in value. Deliberately asymmetric — blocking is directional
-    (Buryat's `*[+high][−high,+round]`, [aksenova-rawski-graf-heinz-2024]);
-    imposition is encoded left-to-right, mirroring for leftward systems. -/
+/-- Adjacent compatibility, left to right: an opaque right member is exempt
+    (blockers do not undergo), an icy left member is exempt (no passing on);
+    otherwise the values agree. Deliberately asymmetric. -/
 def Pattern.Compatible (p : Pattern α V) (a b : α) : Prop :=
   p.participation a = .icyTarget ∨ p.participation b = .opaque ∨
     p.value a = p.value b
@@ -172,9 +145,7 @@ def Pattern.Compatible (p : Pattern α V) (a b : α) : Prop :=
 instance [DecidableEq V] (p : Pattern α V) : DecidableRel p.Compatible :=
   fun a b => by unfold Pattern.Compatible; infer_instance
 
-/-- Surface harmonicity: the tier is a chain of compatible segments —
-    agreement propagates left to right, blockers impose their transmitted
-    value, icy targets absorb. -/
+/-- Surface harmonicity: the tier is a chain of compatible segments. -/
 def Pattern.Harmonic (p : Pattern α V) (w : List α) : Prop :=
   (p.tier w).IsChain p.Compatible
 
@@ -182,20 +153,15 @@ instance [DecidableEq V] (p : Pattern α V) (w : List α) :
     Decidable (p.Harmonic w) := by
   unfold Pattern.Harmonic; infer_instance
 
-/-- **Transparency is harmless interruption** ([ritter-vanderhulst-2024-themes]
-    §1.3.2): inserting a non-participating, non-opaque segment never changes
-    harmonicity. -/
+/-- Transparency interrupts harmlessly ([ritter-vanderhulst-2024-themes] §1.3.2). -/
 theorem Pattern.harmonic_insert_transparent {p : Pattern α V} {t : α}
     (w₁ w₂ : List α) (ht : p.participation t = .transparent) :
     p.Harmonic (w₁ ++ t :: w₂) ↔ p.Harmonic (w₁ ++ w₂) := by
   unfold Pattern.Harmonic Pattern.tier
   simp [List.filter_append, Pattern.OnTier, ht]
 
-/-- Without opaque segments, harmonicity is pairwise agreement on the whole
-    tier: adjacent compatibility is plain value-agreement, which is transitive,
-    so the local (chain) and global (pairwise) formulations coincide. The chain
-    formulation is the interface of the tier-based agreement machinery
-    (`Phonology/Subregular/Agree.lean`). -/
+/-- With all segments participating, the chain and pairwise formulations
+    coincide (value-agreement is transitive). -/
 theorem Pattern.harmonic_iff_agreeOn {p : Pattern α V} {w : List α}
     (h : ∀ s ∈ w, p.participation s = .participating) :
     p.Harmonic w ↔ p.AgreeOn (p.tier w) := by

--- a/Linglib/Phonology/Harmony/Basic.lean
+++ b/Linglib/Phonology/Harmony/Basic.lean
@@ -178,6 +178,10 @@ instance [DecidableEq V] (p : Pattern α V) : DecidableRel p.Compatible :=
 def Pattern.Harmonic (p : Pattern α V) (w : List α) : Prop :=
   (p.tier w).IsChain p.Compatible
 
+instance [DecidableEq V] (p : Pattern α V) (w : List α) :
+    Decidable (p.Harmonic w) := by
+  unfold Pattern.Harmonic; infer_instance
+
 /-- **Transparency is harmless interruption** ([ritter-vanderhulst-2024-themes]
     §1.3.2): inserting a non-participating, non-opaque segment never changes
     harmonicity. -/

--- a/Linglib/Phonology/Harmony/Basic.lean
+++ b/Linglib/Phonology/Harmony/Basic.lean
@@ -35,9 +35,9 @@ mechanism, not in these descriptors.
 
 * `harmonic_insert_transparent`: transparent segments interrupt harmlessly —
   inserting one never changes harmonicity.
-* `Pattern.harmonic_iff_agreeOn`: without blockers, harmonicity is pairwise
-  agreement on the whole tier — the local (chain) and global (pairwise)
-  formulations coincide.
+* `Pattern.harmonic_iff_agreeOn`: with all segments participating, harmonicity
+  is pairwise agreement — the local (chain) and global (pairwise) formulations
+  coincide.
 -/
 
 namespace Phonology.Harmony
@@ -49,8 +49,8 @@ variable {α : Type u} {V : Type v}
 /-- How a segment participates in harmony ([ritter-vanderhulst-2024-themes]
     §1.3): full participants alternate and propagate; transparent (neutral)
     vowels are skipped harmlessly; opaque vowels (blockers) impose their own
-    value on subsequent targets; icy targets (absorbing vowels) undergo harmony
-    without passing it on. -/
+    value on subsequent targets; icy targets (absorbing vowels, [jurgec-2011])
+    undergo harmony without passing it on. -/
 inductive Participation where
   | participating
   | transparent
@@ -59,9 +59,10 @@ inductive Participation where
   deriving DecidableEq, Repr
 
 /-- Direction of the harmonic agreement relation
-    ([ritter-vanderhulst-2024-themes] §1.2.3): prototypical harmony is
-    bidirectional, moving outward from the root; unidirectional cases are
-    either stipulated or derived from target criteria or domain exclusions. -/
+    ([ritter-vanderhulst-2024-themes] §1.2.3): prototypical harmony may have no
+    direction, being bidirectional (moving outward from the root); unidirectional
+    cases are either stipulated or derived from target criteria or domain
+    exclusions. -/
 inductive Direction where
   | rightward
   | leftward
@@ -71,8 +72,10 @@ inductive Direction where
 /-- Who determines the harmonic value ([ritter-vanderhulst-2024-themes]
     §1.2.4): the root (morphologically determined trigger; affixes alternate,
     roots do not), a designated dominant value regardless of morphological
-    position (phonologically determined, typical of ATR systems), or affixes
-    (metaphony and umlaut). Parameterized by the harmonic value type `V`. -/
+    position (phonologically determined, typical of ATR systems), or affixes —
+    a class the chapter poses as an open question, instanced by metaphony and
+    umlaut where stress acts as an attractor of the harmonic value.
+    Parameterized by the harmonic value type `V`. -/
 inductive ControlType (V : Type u) where
   | rootControlled
   | dominantRecessive (dominant : V)
@@ -81,8 +84,9 @@ inductive ControlType (V : Type u) where
 
 /-- The domain delimiting harmony ([ritter-vanderhulst-2024-themes] §1.2.2):
     morphological (root, stem, word) or prosodic (foot, as in metaphony and
-    umlaut; phrase, in post-lexical harmony); `stemAndFirstAffix` is the
-    bounded bisyllabic agreement the chapter singles out. -/
+    umlaut; phrase, in post-lexical harmony); `stemAndFirstAffix` is the bounded
+    bisyllabic agreement the chapter singles out — the stem-final vowel and the
+    first suffix vowel only. -/
 inductive Domain where
   | root
   | stem
@@ -111,14 +115,23 @@ inductive HarmonyType where
 
 /-! ### Patterns and their surface semantics
 
-The descriptive object every mechanism must derive
-([ritter-vanderhulst-2024-themes] (2)): harmony creates likeness among the
-participating vowels of a domain. Transparent segments are skipped; opaque
-segments delimit the spans within which agreement holds. -/
+The descriptive object every mechanism must derive: harmony creates likeness
+among the participating vowels of a domain ((2) of
+[ritter-vanderhulst-2024-themes]). The undergoer/blocker/transparent
+decomposition follows [aksenova-rawski-graf-heinz-2024]: transparent segments
+are skipped; opaque blockers do not undergo but impose their transmitted value
+on what follows ((8c)); icy targets undergo without passing on
+([jurgec-2011]). -/
 
 /-- A harmony pattern over segment type `α` with harmonic values in `V`: the
     feature valuation (`none` = no harmonic counterpart), the participation
-    classification, and the typological descriptors. -/
+    classification, and the typological descriptors. Participation is stored
+    independently of the valuation because the behavior of neutral vowels as
+    transparent or opaque is not predictable ([ritter-vanderhulst-2024-themes]
+    §1.3.2); intended discipline: `value s = none → participation s ≠
+    .participating` (allophonic undergoing of neutral vowels lives in a
+    separate valuation). For an opaque or icy segment, `value` is the value it
+    transmits, which may differ from its phonetic specification. -/
 structure Pattern (α : Type u) (V : Type v) where
   value         : α → Option V
   participation : α → Participation
@@ -130,11 +143,12 @@ structure Pattern (α : Type u) (V : Type v) where
 def Pattern.AgreeOn (p : Pattern α V) (w : List α) : Prop :=
   w.Pairwise fun a b => p.value a = p.value b
 
-/-- Tier membership: participating and opaque segments are on the harmonic
-    tier. Transparent and icy segments project out; opaque segments stay
-    because they delimit spans. -/
+/-- Tier membership: everything but transparent segments. Opaque blockers stay
+    on the tier because they impose values; icy targets stay because they
+    undergo ([aksenova-rawski-graf-heinz-2024]'s Yakut keeps its harmonizing
+    blockers on the tier). -/
 def Pattern.OnTier (p : Pattern α V) (s : α) : Prop :=
-  p.participation s = .participating ∨ p.participation s = .opaque
+  p.participation s ≠ .transparent
 
 instance (p : Pattern α V) : DecidablePred p.OnTier := fun s => by
   unfold Pattern.OnTier; infer_instance
@@ -143,25 +157,24 @@ instance (p : Pattern α V) : DecidablePred p.OnTier := fun s => by
 def Pattern.tier (p : Pattern α V) (w : List α) : List α :=
   w.filter fun s => decide (p.OnTier s)
 
-/-- Adjacent harmonic compatibility: two neighbouring tier segments agree in
-    value unless either is an opaque blocker
-    ([ritter-vanderhulst-2024-themes] (8c)). -/
+/-- Adjacent harmonic compatibility, read left to right: the right member is
+    exempt if it is an opaque blocker (blockers do not undergo, but as left
+    member they impose their transmitted `value` on what follows —
+    [ritter-vanderhulst-2024-themes] (8c)); the left member is exempt if it is
+    an icy target (undergoes without passing on, [jurgec-2011]). Otherwise the
+    pair agrees in value. Deliberately asymmetric — blocking is directional
+    (Buryat's `*[+high][−high,+round]`, [aksenova-rawski-graf-heinz-2024]);
+    imposition is encoded left-to-right, mirroring for leftward systems. -/
 def Pattern.Compatible (p : Pattern α V) (a b : α) : Prop :=
-  p.participation a = .opaque ∨ p.participation b = .opaque ∨
+  p.participation a = .icyTarget ∨ p.participation b = .opaque ∨
     p.value a = p.value b
 
 instance [DecidableEq V] (p : Pattern α V) : DecidableRel p.Compatible :=
   fun a b => by unfold Pattern.Compatible; infer_instance
 
-/-- Compatibility is symmetric. -/
-theorem Pattern.compatible_comm {p : Pattern α V} {a b : α} :
-    p.Compatible a b ↔ p.Compatible b a := by
-  unfold Pattern.Compatible
-  rw [eq_comm]
-  tauto
-
-/-- Surface harmonicity: the tier is a chain of compatible segments — within
-    every opaque-delimited span, participating segments agree in value. -/
+/-- Surface harmonicity: the tier is a chain of compatible segments —
+    agreement propagates left to right, blockers impose their transmitted
+    value, icy targets absorb. -/
 def Pattern.Harmonic (p : Pattern α V) (w : List α) : Prop :=
   (p.tier w).IsChain p.Compatible
 
@@ -169,11 +182,10 @@ def Pattern.Harmonic (p : Pattern α V) (w : List α) : Prop :=
     §1.3.2): inserting a non-participating, non-opaque segment never changes
     harmonicity. -/
 theorem Pattern.harmonic_insert_transparent {p : Pattern α V} {t : α}
-    (w₁ w₂ : List α) (hp : p.participation t ≠ .participating)
-    (ho : p.participation t ≠ .opaque) :
+    (w₁ w₂ : List α) (ht : p.participation t = .transparent) :
     p.Harmonic (w₁ ++ t :: w₂) ↔ p.Harmonic (w₁ ++ w₂) := by
   unfold Pattern.Harmonic Pattern.tier
-  simp [List.filter_append, Pattern.OnTier, hp, ho]
+  simp [List.filter_append, Pattern.OnTier, ht]
 
 /-- Without opaque segments, harmonicity is pairwise agreement on the whole
     tier: adjacent compatibility is plain value-agreement, which is transitive,
@@ -181,9 +193,9 @@ theorem Pattern.harmonic_insert_transparent {p : Pattern α V} {t : α}
     formulation is the interface of the tier-based agreement machinery
     (`Phonology/Subregular/Agree.lean`). -/
 theorem Pattern.harmonic_iff_agreeOn {p : Pattern α V} {w : List α}
-    (h : ∀ s ∈ w, p.participation s ≠ .opaque) :
+    (h : ∀ s ∈ w, p.participation s = .participating) :
     p.Harmonic w ↔ p.AgreeOn (p.tier w) := by
-  have hmem : ∀ s ∈ p.tier w, p.participation s ≠ .opaque :=
+  have hmem : ∀ s ∈ p.tier w, p.participation s = .participating :=
     fun s hs => h s (List.mem_of_mem_filter hs)
 
   haveI : Trans (fun a b => p.value a = p.value b)
@@ -191,7 +203,7 @@ theorem Pattern.harmonic_iff_agreeOn {p : Pattern α V} {w : List α}
     ⟨fun h₁ h₂ => h₁.trans h₂⟩
   unfold Pattern.Harmonic Pattern.AgreeOn
   rw [← List.isChain_iff_pairwise]
-  suffices key : ∀ l : List α, (∀ s ∈ l, p.participation s ≠ .opaque) →
+  suffices key : ∀ l : List α, (∀ s ∈ l, p.participation s = .participating) →
       (l.IsChain p.Compatible ↔ l.IsChain fun a b => p.value a = p.value b) from
     key _ hmem
   intro l hl
@@ -203,7 +215,8 @@ theorem Pattern.harmonic_iff_agreeOn {p : Pattern α V} {w : List α}
     | cons b l =>
       have ha := hl a (by simp)
       have hb := hl b (by simp)
-      simp only [List.isChain_cons_cons, Pattern.Compatible, ha, hb, false_or,
+      simp only [List.isChain_cons_cons, Pattern.Compatible, ha, hb,
+        reduceCtorEq, false_or,
         ih fun s hs => hl s (List.mem_cons_of_mem a hs)]
 
 end Phonology.Harmony

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -96,7 +96,8 @@ def round : BuryatV → Bool
 
 end BuryatV
 
-/-- Table 34.4, featurally: `H_ATR ∪ H_r1 ∪ H_r2`. -/
+/-- Table 34.4's bans: ATR disagreement anywhere; rounding disagreement
+    between non-high vowels; a rounded non-high vowel after a high vowel. -/
 def buryatBanned (x y : BuryatV) : Prop :=
   x.tense ≠ y.tense ∨
     (¬ x.high ∧ ¬ y.high ∧ x.round ≠ y.round) ∨
@@ -105,7 +106,8 @@ def buryatBanned (x y : BuryatV) : Prop :=
 instance : DecidableRel buryatBanned := fun x y => by
   unfold buryatBanned; infer_instance
 
-/-- `H_r2` is asymmetric: `*ʊɔ` is banned but `ɔʊ` is fine ((9b)). -/
+/-- The high-vowel blocking clause is asymmetric: `*ʊɔ` is banned but `ɔʊ`
+    is fine ((9b)). -/
 theorem buryat_asymmetric : buryatBanned .uh .oh ∧ ¬ buryatBanned .oh .uh := by
   decide
 
@@ -120,14 +122,14 @@ theorem buryat_not_symmetric (R : BuryatV → BuryatV → Prop)
 def buryatATR : Pattern BuryatV Bool :=
   { value := fun v => some v.tense, participation := fun _ => .participating }
 
-/-- Rounding harmony: high vowels are opaque blockers transmitting [−round]
-    (`H_r2`). -/
+/-- Rounding harmony: high vowels are opaque blockers transmitting
+    unroundedness to what follows. -/
 def buryatRound : Pattern BuryatV Bool :=
   { value := fun v => some (if v.high then false else v.round)
     participation := fun v => if v.high then .opaque else .participating }
 
 /-- With imposition, Buryat is expressible: the printed grammar is exactly
-    ATR ∧ rounding-with-opaque-highs. -/
+    the conjunction of the ATR pattern and the rounding pattern. -/
 theorem buryat_expressible (x y : BuryatV) :
     buryatBanned x y ↔
       ¬ (buryatATR.Compatible x y ∧ buryatRound.Compatible x y) := by
@@ -140,8 +142,9 @@ def buryatWellFormed (w : List BuryatV) : Prop :=
 instance (w : List BuryatV) : Decidable (buryatWellFormed w) := by
   unfold buryatWellFormed; infer_instance
 
-/-- The (9) forms: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` in (the latter through the
-    imposition path); `*ɔr-aːd` and `*ɔr-ʊːl-ɔːd` out. -/
+/-- The (9) forms as vowel skeletons: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` are
+    well-formed — the latter because the high causative transmits unroundedness
+    to the perfective — while `*ɔr-aːd` and `*ɔr-ʊːl-ɔːd` are not. -/
 example : buryatWellFormed [.oh, .oh] ∧ ¬ buryatWellFormed [.oh, .a] ∧
     buryatWellFormed [.oh, .uh, .a] ∧ ¬ buryatWellFormed [.oh, .uh, .oh] := by
   decide
@@ -169,7 +172,9 @@ def high : YakutV → Bool
 
 end YakutV
 
-/-- Table 34.5, featurally: `H_front ∪ H_r1 ∪ H_r2 ∪ H_r3`. -/
+/-- Table 34.5's bans: fronting disagreement anywhere; rounding disagreement
+    between high vowels; a rounded non-high vowel after a high vowel; rounding
+    disagreement after a non-high vowel. -/
 def yakutBanned (x y : YakutV) : Prop :=
   x.front ≠ y.front ∨
     (x.high ∧ y.high ∧ x.round ≠ y.round) ∨
@@ -179,8 +184,8 @@ def yakutBanned (x y : YakutV) : Prop :=
 instance : DecidableRel yakutBanned := fun x y => by
   unfold yakutBanned; infer_instance
 
-/-- Yakut's harmonizing blockers ((14g)): rounding spreads `o`→`u` but not
-    `u`→`o`. -/
+/-- Yakut's low vowels are harmonizing blockers ((14g)): rounding spreads
+    from `o` to `u` but not from `u` to `o` — the icy-target configuration. -/
 theorem yakut_asymmetric : yakutBanned .u .o ∧ ¬ yakutBanned .o .u := by decide
 
 /-- Spot-checks against (14): `oɣo-lor`, `murum-u` licensed; `*tünnük-lör` banned. -/

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -172,6 +172,9 @@ theorem buryat_expressible (x y : BuryatV) :
 def buryatWellFormed (w : List BuryatV) : Prop :=
   buryatATR.Harmonic w ∧ buryatRound.Harmonic w
 
+instance (w : List BuryatV) : Decidable (buryatWellFormed w) := by
+  unfold buryatWellFormed; infer_instance
+
 /-- The (9) forms, as vowel skeletons: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` are
     well-formed — the second because the high causative transmits [−round] to
     the perfective (the imposition path) — while `*ɔr-aːd` (rounding agreement

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -9,44 +9,20 @@ import Linglib.Phonology.Harmony.Basic
 /-!
 # Aksënova, Rawski, Graf & Heinz 2024: the computational power of harmonic forms
 
-[aksenova-rawski-graf-heinz-2024] survey the subregular characterization of
-harmony: strictly local grammars cannot express it (unbounded distance),
-strictly piecewise grammars cannot express blocking, and tier-based strictly
-local grammars capture both. Their §34.3.1 works out three double vowel
-harmonies with the full TSL grammars printed (their Tables 34.3–34.5), showing
-a single tier always suffices for double VH.
+[aksenova-rawski-graf-heinz-2024] §34.3.1 works out three double vowel
+harmonies with their TSL grammars printed (Tables 34.3–34.5); a single tier
+always suffices. This study transcribes the grammars featurally and
+stress-tests `Phonology.Harmony.Pattern`: Kirghiz is the conjunction of two
+patterns on one tier (`kirghiz_two_patterns`); Buryat's asymmetric blocking
+defeats every symmetric relation (`buryat_not_symmetric`) — the finding that
+forced blocker imposition into `Pattern.Compatible` — and with imposition is
+expressible (`buryat_expressible`, certified on the (9) forms); Yakut's
+harmonizing blockers show the same asymmetry (`yakut_asymmetric`); whether its
+configuration-dependent grammar is a conjunction of patterns is left open.
 
-This study transcribes the three grammars featurally (the tables' banned-bigram
-sets are their extensions) and stress-tests `Phonology.Harmony.Pattern` against
-them:
-
-* **Kirghiz** ((5), Table 34.3): frontness and rounding spread together over
-  all vowels. Expressible — the grammar is exactly the conjunction of two
-  `Pattern` compatibilities on the same tier (`kirghiz_two_patterns`).
-* **Buryat** ((9), Table 34.4): ATR harmony over all vowels; rounding agreement
-  among non-high vowels, blocked by high vowels. The blocking clause
-  `*[+high][−high,+round]` is asymmetric, so no symmetric adjacency relation
-  renders the grammar (`buryat_not_symmetric`) — the finding that forced
-  blocker-imposition into `Pattern.Compatible`. With imposition, Buryat is
-  expressible: `buryat_expressible` certifies ATR ∧ rounding-with-opaque-highs
-  against the printed table by kernel `decide`.
-* **Yakut** ((14), Table 34.5): fronting over all vowels; rounding spreads
-  high→high and nonhigh→any, but not high→low — low vowels are harmonizing
-  blockers (the icy-target class of `Phonology.Harmony.Participation`), and the
-  ban `*[+high][−high,+round]` is again asymmetric (`yakut_asymmetric`);
-  whether the full grammar is a conjunction of patterns is left open.
-
-The Buryat finding is the stress-test payload that reshaped the substrate:
-blocker-imposition ((8c) of [ritter-vanderhulst-2024-themes]) entered
-`Pattern.Compatible` because `buryat_not_symmetric` proved the symmetric
-formulation could not render Table 34.4. Whether Yakut's
-configuration-dependent blocking is expressible as a conjunction of patterns
-is left open; its asymmetry witness stands either way.
-
-Vowel constructor names ASCII-ize the chapter's IPA: `ih` = ɨ, `oe` = ö,
-`ue` = ü, `oh` = ɔ, `uh` = ʊ. The chapter's §34.3.4 tier-relation typology
-(same/embedded/disjoint attested, partial overlap unattested) is not yet
-formalized here. TODO: `TierRelation` classifier over Table 34.8's rows.
+Constructor names ASCII-ize the IPA: `ih` = ɨ, `oe` = ö, `ue` = ü, `oh` = ɔ,
+`uh` = ʊ. TODO: the §34.3.4 tier-relation typology (same/embedded/disjoint
+attested, partial overlap unattested) over Table 34.8's rows.
 -/
 
 namespace AksenovaEtAl2024
@@ -72,8 +48,7 @@ def round : KirghizV → Bool
 
 end KirghizV
 
-/-- Table 34.3's banned bigrams, featurally: any tier-adjacent pair disagreeing
-    in fronting or rounding. -/
+/-- Table 34.3, featurally: pairs disagreeing in fronting or rounding. -/
 def kirghizBanned (x y : KirghizV) : Prop :=
   x.front ≠ y.front ∨ x.round ≠ y.round
 
@@ -88,15 +63,13 @@ def kirghizFront : Pattern KirghizV Bool :=
 def kirghizRound : Pattern KirghizV Bool :=
   { value := fun v => some v.round, participation := fun _ => .participating }
 
-/-- Kirghiz's printed grammar is the conjunction of the two patterns'
-    compatibilities: double harmony on a single tier, as the chapter says. -/
+/-- Kirghiz's grammar is the conjunction of the two patterns' compatibilities. -/
 theorem kirghiz_two_patterns (x y : KirghizV) :
     kirghizBanned x y ↔
       ¬ (kirghizFront.Compatible x y ∧ kirghizRound.Compatible x y) := by
   revert x y; decide
 
-/-- Spot-checks against Table 34.3's extension: `*ai` and `*oe` are banned,
-    `üö` (agreeing in both features) is not. -/
+/-- Spot-checks against Table 34.3: `*ai`, `*oe` banned; `üö` licensed. -/
 example : kirghizBanned .a .i ∧ kirghizBanned .o .e ∧
     ¬ kirghizBanned .ue .oe := by decide
 
@@ -123,9 +96,7 @@ def round : BuryatV → Bool
 
 end BuryatV
 
-/-- Table 34.4's banned bigrams, featurally: ATR disagreement (`H_ATR`),
-    rounding disagreement between non-high vowels (`H_r1`), and a rounded
-    non-high vowel after a high vowel (`H_r2`). -/
+/-- Table 34.4, featurally: `H_ATR ∪ H_r1 ∪ H_r2`. -/
 def buryatBanned (x y : BuryatV) : Prop :=
   x.tense ≠ y.tense ∨
     (¬ x.high ∧ ¬ y.high ∧ x.round ≠ y.round) ∨
@@ -134,9 +105,7 @@ def buryatBanned (x y : BuryatV) : Prop :=
 instance : DecidableRel buryatBanned := fun x y => by
   unfold buryatBanned; infer_instance
 
-/-- The `H_r2` clause is asymmetric: `*ʊɔ` is banned but `ɔʊ` is fine
-    ((9b): the perfective no longer agrees in rounding across the high
-    causative). -/
+/-- `H_r2` is asymmetric: `*ʊɔ` is banned but `ɔʊ` is fine ((9b)). -/
 theorem buryat_asymmetric : buryatBanned .uh .oh ∧ ¬ buryatBanned .oh .uh := by
   decide
 
@@ -147,38 +116,32 @@ theorem buryat_not_symmetric (R : BuryatV → BuryatV → Prop)
   exact buryat_asymmetric.2 ((h _ _).mp ((hsymm _ _).mp ((h _ _).mpr
     buryat_asymmetric.1)))
 
-/-- ATR harmony as a pattern: all tier vowels participate. -/
+/-- ATR harmony: all tier vowels participate. -/
 def buryatATR : Pattern BuryatV Bool :=
   { value := fun v => some v.tense, participation := fun _ => .participating }
 
-/-- Rounding harmony as a pattern: high vowels are opaque blockers whose
-    transmitted value is [−round] — they license only unrounded non-high
-    vowels after themselves (`H_r2`). -/
+/-- Rounding harmony: high vowels are opaque blockers transmitting [−round]
+    (`H_r2`). -/
 def buryatRound : Pattern BuryatV Bool :=
   { value := fun v => some (if v.high then false else v.round)
     participation := fun v => if v.high then .opaque else .participating }
 
-/-- With blocker-imposition in `Pattern.Compatible`, Buryat is expressible:
-    the printed grammar is exactly the conjunction of the ATR pattern and the
-    rounding pattern with opaque high vowels. The asymmetry that defeats every
-    symmetric relation (`buryat_not_symmetric`) is carried by the imposition
-    clause. -/
+/-- With imposition, Buryat is expressible: the printed grammar is exactly
+    ATR ∧ rounding-with-opaque-highs. -/
 theorem buryat_expressible (x y : BuryatV) :
     buryatBanned x y ↔
       ¬ (buryatATR.Compatible x y ∧ buryatRound.Compatible x y) := by
   revert x y; decide
 
-/-- Buryat surface well-formedness: harmonic for both patterns. -/
+/-- Buryat well-formedness: harmonic for both patterns. -/
 def buryatWellFormed (w : List BuryatV) : Prop :=
   buryatATR.Harmonic w ∧ buryatRound.Harmonic w
 
 instance (w : List BuryatV) : Decidable (buryatWellFormed w) := by
   unfold buryatWellFormed; infer_instance
 
-/-- The (9) forms, as vowel skeletons: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` are
-    well-formed — the second because the high causative transmits [−round] to
-    the perfective (the imposition path) — while `*ɔr-aːd` (rounding agreement
-    skipped) and `*ɔr-ʊːl-ɔːd` (rounded vowel after the blocker) are not. -/
+/-- The (9) forms: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` in (the latter through the
+    imposition path); `*ɔr-aːd` and `*ɔr-ʊːl-ɔːd` out. -/
 example : buryatWellFormed [.oh, .oh] ∧ ¬ buryatWellFormed [.oh, .a] ∧
     buryatWellFormed [.oh, .uh, .a] ∧ ¬ buryatWellFormed [.oh, .uh, .oh] := by
   decide
@@ -206,10 +169,7 @@ def high : YakutV → Bool
 
 end YakutV
 
-/-- Table 34.5's banned bigrams, featurally: fronting disagreement (`H_front`),
-    rounding disagreement between high vowels (`H_r1`), a rounded low vowel
-    after a high vowel (`H_r2`), and rounding disagreement after a non-high
-    vowel (`H_r3`). -/
+/-- Table 34.5, featurally: `H_front ∪ H_r1 ∪ H_r2 ∪ H_r3`. -/
 def yakutBanned (x y : YakutV) : Prop :=
   x.front ≠ y.front ∨
     (x.high ∧ y.high ∧ x.round ≠ y.round) ∨
@@ -219,13 +179,11 @@ def yakutBanned (x y : YakutV) : Prop :=
 instance : DecidableRel yakutBanned := fun x y => by
   unfold yakutBanned; infer_instance
 
-/-- Yakut's low vowels are harmonizing blockers ((14g): `ojum-lar`, not
-    `*ojum-lor`): rounding spreads from `o` to `u` but not from `u` to `o` —
-    the icy-target configuration, and again asymmetric. -/
+/-- Yakut's harmonizing blockers ((14g)): rounding spreads `o`→`u` but not
+    `u`→`o`. -/
 theorem yakut_asymmetric : yakutBanned .u .o ∧ ¬ yakutBanned .o .u := by decide
 
-/-- Spot-checks against (14): `oɣo-lor` (rounding spreads low→low) and
-    `murum-u` (high→high) are well-formed; `*tünnük-lör` ((14h)) is banned. -/
+/-- Spot-checks against (14): `oɣo-lor`, `murum-u` licensed; `*tünnük-lör` banned. -/
 example : ¬ yakutBanned .o .o ∧ ¬ yakutBanned .u .u ∧
     yakutBanned .ue .oe := by decide
 

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -48,28 +48,30 @@ def round : KirghizV → Bool
 
 end KirghizV
 
-/-- Table 34.3, featurally: pairs disagreeing in fronting or rounding. -/
+/-- `kirghizBanned x y`: the tier bigram `xy` disagrees in fronting or in
+    rounding (Table 34.3). -/
 def kirghizBanned (x y : KirghizV) : Prop :=
   x.front ≠ y.front ∨ x.round ≠ y.round
 
 instance : DecidableRel kirghizBanned := fun x y => by
   unfold kirghizBanned; infer_instance
 
-/-- Frontness harmony as a pattern: all vowels participate. -/
+/-- `kirghizFront` is Kirghiz frontness harmony: every vowel participates. -/
 def kirghizFront : Pattern KirghizV Bool :=
   { value := fun v => some v.front, participation := fun _ => .participating }
 
-/-- Rounding harmony as a pattern on the same tier. -/
+/-- `kirghizRound` is Kirghiz rounding harmony, on the same tier. -/
 def kirghizRound : Pattern KirghizV Bool :=
   { value := fun v => some v.round, participation := fun _ => .participating }
 
-/-- Kirghiz's grammar is the conjunction of the two patterns' compatibilities. -/
+/-- Kirghiz double harmony fits a single tier: the printed grammar is the
+    conjunction of the two patterns' compatibilities. -/
 theorem kirghiz_two_patterns (x y : KirghizV) :
     kirghizBanned x y ↔
       ¬ (kirghizFront.Compatible x y ∧ kirghizRound.Compatible x y) := by
   revert x y; decide
 
-/-- Spot-checks against Table 34.3: `*ai`, `*oe` banned; `üö` licensed. -/
+/-- `*ai` and `*oe` are banned; `üö` is licensed (Table 34.3). -/
 example : kirghizBanned .a .i ∧ kirghizBanned .o .e ∧
     ¬ kirghizBanned .ue .oe := by decide
 
@@ -96,8 +98,9 @@ def round : BuryatV → Bool
 
 end BuryatV
 
-/-- Table 34.4's bans: ATR disagreement anywhere; rounding disagreement
-    between non-high vowels; a rounded non-high vowel after a high vowel. -/
+/-- `buryatBanned x y`: the bigram disagrees in ATR; or disagrees in rounding
+    between non-high vowels; or places a rounded non-high vowel after a high
+    vowel (Table 34.4). -/
 def buryatBanned (x y : BuryatV) : Prop :=
   x.tense ≠ y.tense ∨
     (¬ x.high ∧ ¬ y.high ∧ x.round ≠ y.round) ∨
@@ -106,8 +109,8 @@ def buryatBanned (x y : BuryatV) : Prop :=
 instance : DecidableRel buryatBanned := fun x y => by
   unfold buryatBanned; infer_instance
 
-/-- The high-vowel blocking clause is asymmetric: `*ʊɔ` is banned but `ɔʊ`
-    is fine ((9b)). -/
+/-- Buryat blocking is directional: `*ʊɔ` is banned but `ɔʊ` is licensed
+    ((9b)). -/
 theorem buryat_asymmetric : buryatBanned .uh .oh ∧ ¬ buryatBanned .oh .uh := by
   decide
 
@@ -118,12 +121,12 @@ theorem buryat_not_symmetric (R : BuryatV → BuryatV → Prop)
   exact buryat_asymmetric.2 ((h _ _).mp ((hsymm _ _).mp ((h _ _).mpr
     buryat_asymmetric.1)))
 
-/-- ATR harmony: all tier vowels participate. -/
+/-- `buryatATR` is Buryat ATR harmony: every tier vowel participates. -/
 def buryatATR : Pattern BuryatV Bool :=
   { value := fun v => some v.tense, participation := fun _ => .participating }
 
-/-- Rounding harmony: high vowels are opaque blockers transmitting
-    unroundedness to what follows. -/
+/-- `buryatRound` is Buryat rounding harmony: high vowels are opaque blockers
+    transmitting unroundedness to what follows. -/
 def buryatRound : Pattern BuryatV Bool :=
   { value := fun v => some (if v.high then false else v.round)
     participation := fun v => if v.high then .opaque else .participating }
@@ -135,7 +138,8 @@ theorem buryat_expressible (x y : BuryatV) :
       ¬ (buryatATR.Compatible x y ∧ buryatRound.Compatible x y) := by
   revert x y; decide
 
-/-- Buryat well-formedness: harmonic for both patterns. -/
+/-- `buryatWellFormed w` says the skeleton `w` is harmonic for both Buryat
+    patterns. -/
 def buryatWellFormed (w : List BuryatV) : Prop :=
   buryatATR.Harmonic w ∧ buryatRound.Harmonic w
 
@@ -172,9 +176,9 @@ def high : YakutV → Bool
 
 end YakutV
 
-/-- Table 34.5's bans: fronting disagreement anywhere; rounding disagreement
-    between high vowels; a rounded non-high vowel after a high vowel; rounding
-    disagreement after a non-high vowel. -/
+/-- `yakutBanned x y`: the bigram disagrees in fronting; or disagrees in
+    rounding between high vowels; or places a rounded non-high vowel after a
+    high vowel; or disagrees in rounding after a non-high vowel (Table 34.5). -/
 def yakutBanned (x y : YakutV) : Prop :=
   x.front ≠ y.front ∨
     (x.high ∧ y.high ∧ x.round ≠ y.round) ∨
@@ -188,7 +192,7 @@ instance : DecidableRel yakutBanned := fun x y => by
     from `o` to `u` but not from `u` to `o` — the icy-target configuration. -/
 theorem yakut_asymmetric : yakutBanned .u .o ∧ ¬ yakutBanned .o .u := by decide
 
-/-- Spot-checks against (14): `oɣo-lor`, `murum-u` licensed; `*tünnük-lör` banned. -/
+/-- `oɣo-lor` and `murum-u` are licensed; `*tünnük-lör` is banned ((14)). -/
 example : ¬ yakutBanned .o .o ∧ ¬ yakutBanned .u .u ∧
     yakutBanned .ue .oe := by decide
 

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -142,9 +142,9 @@ def buryatWellFormed (w : List BuryatV) : Prop :=
 instance (w : List BuryatV) : Decidable (buryatWellFormed w) := by
   unfold buryatWellFormed; infer_instance
 
-/-- The (9) forms as vowel skeletons: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` are
-    well-formed — the latter because the high causative transmits unroundedness
-    to the perfective — while `*ɔr-aːd` and `*ɔr-ʊːl-ɔːd` are not. -/
+/-- The (9) forms as vowel skeletons: the attested `ɔr-ɔːd` and `ɔr-ʊːl-aːd`
+    are accepted — the latter because the high causative transmits unroundedness
+    to the perfective — and the starred `*ɔr-aːd` and `*ɔr-ʊːl-ɔːd` rejected. -/
 example : buryatWellFormed [.oh, .oh] ∧ ¬ buryatWellFormed [.oh, .a] ∧
     buryatWellFormed [.oh, .uh, .a] ∧ ¬ buryatWellFormed [.oh, .uh, .oh] := by
   decide

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -168,6 +168,18 @@ theorem buryat_expressible (x y : BuryatV) :
       ¬ (buryatATR.Compatible x y ∧ buryatRound.Compatible x y) := by
   revert x y; decide
 
+/-- Buryat surface well-formedness: harmonic for both patterns. -/
+def buryatWellFormed (w : List BuryatV) : Prop :=
+  buryatATR.Harmonic w ∧ buryatRound.Harmonic w
+
+/-- The (9) forms, as vowel skeletons: `ɔr-ɔːd` and `ɔr-ʊːl-aːd` are
+    well-formed — the second because the high causative transmits [−round] to
+    the perfective (the imposition path) — while `*ɔr-aːd` (rounding agreement
+    skipped) and `*ɔr-ʊːl-ɔːd` (rounded vowel after the blocker) are not. -/
+example : buryatWellFormed [.oh, .oh] ∧ ¬ buryatWellFormed [.oh, .a] ∧
+    buryatWellFormed [.oh, .uh, .a] ∧ ¬ buryatWellFormed [.oh, .uh, .oh] := by
+  decide
+
 /-! ### Yakut ((14), Table 34.5): harmonizing blockers -/
 
 /-- The Yakut vowel tier `T = {a, ɨ, e, i, o, ö, u, ü}`. -/

--- a/Linglib/Studies/AksenovaEtAl2024.lean
+++ b/Linglib/Studies/AksenovaEtAl2024.lean
@@ -25,19 +25,23 @@ them:
   `Pattern` compatibilities on the same tier (`kirghiz_two_patterns`).
 * **Buryat** ((9), Table 34.4): ATR harmony over all vowels; rounding agreement
   among non-high vowels, blocked by high vowels. The blocking clause
-  `*[+high][−high,+round]` is **asymmetric**, and `Pattern.Compatible` is
-  symmetric — so no pattern, nor any conjunction of patterns, renders Buryat's
-  grammar (`buryat_not_symmetric`, `buryat_no_pattern`).
+  `*[+high][−high,+round]` is asymmetric, so no symmetric adjacency relation
+  renders the grammar (`buryat_not_symmetric`) — the finding that forced
+  blocker-imposition into `Pattern.Compatible`. With imposition, Buryat is
+  expressible: `buryat_expressible` certifies ATR ∧ rounding-with-opaque-highs
+  against the printed table by kernel `decide`.
 * **Yakut** ((14), Table 34.5): fronting over all vowels; rounding spreads
   high→high and nonhigh→any, but not high→low — low vowels are harmonizing
   blockers (the icy-target class of `Phonology.Harmony.Participation`), and the
-  ban `*[+high][−high,+round]` is again asymmetric (`yakut_asymmetric`).
+  ban `*[+high][−high,+round]` is again asymmetric (`yakut_asymmetric`);
+  whether the full grammar is a conjunction of patterns is left open.
 
-The Buryat/Yakut findings are the stress-test payload: the pattern layer's
-symmetric adjacent-compatibility semantics covers plain and double harmony with
-symmetric blocking, but directional blocker-imposition requires the asymmetric
-relation of the underlying forbidden-pairs machinery
-(`Subregular.TSLGrammar.ofForbiddenPairs` takes an arbitrary `R`).
+The Buryat finding is the stress-test payload that reshaped the substrate:
+blocker-imposition ((8c) of [ritter-vanderhulst-2024-themes]) entered
+`Pattern.Compatible` because `buryat_not_symmetric` proved the symmetric
+formulation could not render Table 34.4. Whether Yakut's
+configuration-dependent blocking is expressible as a conjunction of patterns
+is left open; its asymmetry witness stands either way.
 
 Vowel constructor names ASCII-ize the chapter's IPA: `ih` = ɨ, `oe` = ö,
 `ue` = ü, `oh` = ɔ, `uh` = ʊ. The chapter's §34.3.4 tier-relation typology
@@ -101,7 +105,7 @@ example : kirghizBanned .a .i ∧ kirghizBanned .o .e ∧
 /-- The Buryat vowel tier `T = {a, e, ɔ, o, ʊ, u}` (transparent /i/ excluded). -/
 inductive BuryatV where
   | a | e | oh | o | uh | u
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Fintype, Repr
 
 namespace BuryatV
 
@@ -143,12 +147,26 @@ theorem buryat_not_symmetric (R : BuryatV → BuryatV → Prop)
   exact buryat_asymmetric.2 ((h _ _).mp ((hsymm _ _).mp ((h _ _).mpr
     buryat_asymmetric.1)))
 
-/-- In particular no single `Pattern`'s incompatibility does
-    (`Pattern.Compatible` is symmetric) — nor any conjunction of patterns,
-    since symmetric relations are closed under conjunction. -/
-theorem buryat_no_pattern (p : Pattern BuryatV Bool) :
-    ¬ ∀ x y, ¬ p.Compatible x y ↔ buryatBanned x y :=
-  buryat_not_symmetric _ fun _ _ => not_congr Pattern.compatible_comm
+/-- ATR harmony as a pattern: all tier vowels participate. -/
+def buryatATR : Pattern BuryatV Bool :=
+  { value := fun v => some v.tense, participation := fun _ => .participating }
+
+/-- Rounding harmony as a pattern: high vowels are opaque blockers whose
+    transmitted value is [−round] — they license only unrounded non-high
+    vowels after themselves (`H_r2`). -/
+def buryatRound : Pattern BuryatV Bool :=
+  { value := fun v => some (if v.high then false else v.round)
+    participation := fun v => if v.high then .opaque else .participating }
+
+/-- With blocker-imposition in `Pattern.Compatible`, Buryat is expressible:
+    the printed grammar is exactly the conjunction of the ATR pattern and the
+    rounding pattern with opaque high vowels. The asymmetry that defeats every
+    symmetric relation (`buryat_not_symmetric`) is carried by the imposition
+    clause. -/
+theorem buryat_expressible (x y : BuryatV) :
+    buryatBanned x y ↔
+      ¬ (buryatATR.Compatible x y ∧ buryatRound.Compatible x y) := by
+  revert x y; decide
 
 /-! ### Yakut ((14), Table 34.5): harmonizing blockers -/
 


### PR DESCRIPTION
Implements the phonology audit's two HIGH findings against `Pattern`'s composed semantics, certified by the stress-test study:

- **Blocker imposition (HIGH-1)**: `Compatible` is now asymmetric — a blocker as right member is exempt (does not undergo), as left member it imposes its transmitted `value` on what follows ((8c), which the old symmetric definition cited while omitting). `compatible_comm` deleted (its falsity is the finding). `buryat_expressible` kernel-certifies the fix against Table 34.4's printed grammar: the pattern `buryat_not_symmetric` proved inexpressible under symmetry is now generated exactly, as ATR ∧ rounding-with-opaque-highs.
- **Icy-target semantics (HIGH-2)**: `OnTier := ≠ .transparent` (icy on the tier, per ch. 34's Yakut); the icy clause makes them undergo without passing on ([jurgec-2011] added — the term's coinage; ch. 21 attribution corrected to Krämer). `harmonic_insert_transparent` tightened to a transparent-only hypothesis, retiring its false icy corollary.
- MEDIUMs/LOWs: span semantics re-anchored to the ch. 34 decomposition; `value = none` discipline and transmitted-value reading documented; 'surface semantics' scope narrowed with the parasitic/configuration-dependent coverage limits stated; `affixControlled`/`Direction` hedges restored; `stemAndFirstAffix` glossed precisely.

TSL bridge, `System`, fragments, and studies all survive unchanged (the forbidden-pairs machinery always took an arbitrary `R`); `harmonic_iff_agreeOn` strengthened to an all-participating hypothesis.