### PR TITLE
refactor(Core): extract Multiset.count_powerset keystone from Aut

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -119,6 +119,8 @@ import Linglib.Core.Data.List.Factors
 import Linglib.Core.Data.List.Fold
 import Linglib.Core.Data.List.Sublist
 import Linglib.Core.Data.List.TakeDrop
+import Linglib.Core.Data.Multiset.Antidiagonal
+import Linglib.Core.Data.Multiset.Powerset
 import Linglib.Core.Data.Multiset.Rel
 import Linglib.Core.Data.RoseTree.Basic
 import Linglib.Core.Data.RoseTree.Perm

--- a/Linglib/Core/Algebra/ConnesKreimer/Shuffle.lean
+++ b/Linglib/Core/Algebra/ConnesKreimer/Shuffle.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
+import Linglib.Core.Data.Multiset.Antidiagonal
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.LinearAlgebra.Finsupp.LSum
 import Mathlib.Algebra.BigOperators.Ring.Multiset
@@ -256,26 +257,6 @@ theorem comulShuffle_mul [DecidableEq T] (F G : ConnesKreimer R T) :
 The shuffle Δ is cocommutative: swapping the two tensor factors leaves
 Δ unchanged. This follows from the involution `F₁ ↦ F - F₁` on
 `F.powerset`. -/
-
-/-- **Δ-cocommutativity at the antidiagonal level**: `s.antidiagonal` is
-    invariant under `Prod.swap`. Pairs `(s₁, s₂)` with `s₁ + s₂ = s` map
-    bijectively to `(s₂, s₁)` with the same constraint, since `+` is
-    commutative.
-
-    In Oudom-Guin §2 / Sweedler notation this is the cocommutativity
-    `(swap ∘ Δ) = Δ` for the symmetric algebra coproduct.
-
-    Mathlib has the analogue `Multiset.Nat.antidiagonal_map_swap` for
-    `Nat` antidiagonal but not (as of mathlib 4.30) for the general
-    `Multiset.antidiagonal`. `[UPSTREAM]` candidate for
-    `Mathlib.Data.Multiset.Antidiagonal`. -/
-theorem _root_.Multiset.antidiagonal_swap {α : Type*} (s : Multiset α) :
-    s.antidiagonal.map Prod.swap = s.antidiagonal := by
-  induction s using Multiset.induction_on with
-  | empty => rfl
-  | cons a t ih =>
-    simp only [Multiset.antidiagonal_cons, Multiset.map_add, Multiset.map_map,
-      ← Prod.map_comp_swap, ← Multiset.map_map _ Prod.swap, ih, add_comm]
 
 /-- Reindex a partition-sum over `C.powerset` using the involution
     `C₁ ↦ C - C₁`. Specialisation of `antidiagonal_swap` to a

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -310,14 +310,14 @@ theorem pairing_of'_mul_of' (W C₁ C₂ : Forest (Nonplanar α)) :
     have hS1 := Nonplanar.forestAutCard_add C₁ C₂
     have hcast := congr_arg (Nat.cast (R := R)) hS1
     push_cast at hcast
-    -- hcast : ↑count * (↑forestAutCard C₁ * ↑forestAutCard C₂) = ↑forestAutCard (C₁+C₂)
+    -- hcast : ↑forestAutCard (C₁+C₂) = ↑count * (↑forestAutCard C₁ * ↑forestAutCard C₂)
     -- `forestAutCard` here is the GL re-export of `Nonplanar.forestAutCard`.
     show (Nonplanar.forestAutCard (C₁ + C₂) : R) =
         ((Multiset.count (C₁, C₂) (Multiset.antidiagonal (C₁ + C₂)) : ℕ) : R) *
           ((Nonplanar.forestAutCard C₁ : R) * (Nonplanar.forestAutCard C₂ : R))
     -- Decidable instances on Forest = Multiset (Nonplanar α) are unique up to
     -- propositional equality; `convert` closes the residual.
-    convert hcast.symm using 4
+    convert hcast using 4
   · -- W ≠ C₁ + C₂. LHS = 0. The if now uses the ambient instance.
     simp only [if_neg hW]
     -- Every p ∈ antidiagonal W has p.1 + p.2 = W ≠ C₁ + C₂. So at every p, the term is 0.

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -8,7 +8,6 @@ import Linglib.Core.Data.RoseTree.DecEq
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
 import Mathlib.Data.Multiset.Antidiagonal
-import Mathlib.Data.Multiset.Basic
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Tactic.Ring
@@ -32,8 +31,8 @@ Grossman-Larson pairing (`Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing`
 
 * `RootedTree.Nonplanar.autCard_node`: the recursion `autCard (node a M) = forestAutCard M`.
 * `RootedTree.Nonplanar.forestAutCard_add`: the multinomial split identity
-  `count (F, G) (antidiagonal (F + G)) * (forestAutCard F * forestAutCard G) =
-  forestAutCard (F + G)`, the combinatorial core of the pairing's product-coproduct adjunction.
+  `forestAutCard (F + G) = (antidiagonal (F + G)).count (F, G) * (forestAutCard F *
+  forestAutCard G)`, the combinatorial core of the pairing's product-coproduct adjunction.
 
 ## Implementation notes
 
@@ -62,11 +61,8 @@ through the quotient. -/
 def multinomialFactor (M : Multiset (Nonplanar α)) : ℕ :=
   M.toFinset.prod fun t => (M.count t).factorial
 
-/-- The automorphism count `|Aut(mk t)|` of the nonplanar tree represented
-    by a planar `RoseTree` `t`. Substrate for `Nonplanar.autCard` (which lifts
-    it through the `Perm` quotient). At a node, the product of the
-    children's counts times `multinomialFactor` on the multiset of
-    nonplanar-`mk` children (counting symmetric rearrangements). -/
+/-- The automorphism count `|Aut(mk t)|` of the nonplanar tree represented by a planar
+    `RoseTree` `t`; substrate for `Nonplanar.autCard`. -/
 def treeAutCard : RoseTree α → ℕ
   | .node _ cs =>
       (cs.map treeAutCard).prod * multinomialFactor (Multiset.ofList (cs.map mk))
@@ -79,9 +75,7 @@ theorem treeAutCard_node (a : α) (cs : List (RoseTree α)) :
 /-! #### `treeAutCard` is `Perm`-invariant -/
 
 mutual
-/-- `treeAutCard` is invariant under `Perm`. At a node the algebra reads the
-    children only through the child-`treeAutCard` product and the `mk`-multiset,
-    both fixed by the `PermList` companion. -/
+/-- `treeAutCard` is invariant under `RoseTree.Perm`. -/
 theorem treeAutCard_perm : ∀ {t s : RoseTree α}, RoseTree.Perm t s →
     treeAutCard t = treeAutCard s
   | _, _, .node h => by
@@ -90,10 +84,7 @@ theorem treeAutCard_perm : ∀ {t s : RoseTree α}, RoseTree.Perm t s →
     rw [hprod, hmk]
   | _, _, .trans h₁ h₂ => (treeAutCard_perm h₁).trans (treeAutCard_perm h₂)
 
-/-- The two children statistics `treeAutCard` reads — the child-`treeAutCard`
-    product and the `mk`-multiset — are `PermList`-invariant: `cons` matches heads
-    by the mutual `treeAutCard_perm` and `mk_eq_mk_iff`, `swap` by commutativity
-    of `*` and `Multiset.cons_swap`. -/
+/-- The child-`treeAutCard` product and the `mk`-multiset are `PermList`-invariant. -/
 theorem treeAutCard_permList : ∀ {cs ds : List (RoseTree α)}, RoseTree.PermList cs ds →
     (cs.map treeAutCard).prod = (ds.map treeAutCard).prod ∧
       (Multiset.ofList (cs.map mk) : Multiset (Nonplanar α)) = Multiset.ofList (ds.map mk)
@@ -113,13 +104,12 @@ end
 
 /-! #### Positivity of `treeAutCard` -/
 
-/-- Every factor in `multinomialFactor M` is positive (each is a factorial). -/
+/-- `multinomialFactor` is positive. -/
 private theorem multinomialFactor_pos (M : Multiset (Nonplanar α)) :
     0 < multinomialFactor M :=
   Finset.prod_pos fun _ _ => Nat.factorial_pos _
 
-/-- `treeAutCard` is positive: at a node, `multinomialFactor` is positive
-    (factorials) and the children product is positive by the IH. -/
+/-- `treeAutCard` is positive. -/
 theorem treeAutCard_pos (t : RoseTree α) : 0 < treeAutCard t := by
   induction t with
   | node a cs ih =>
@@ -129,14 +119,9 @@ theorem treeAutCard_pos (t : RoseTree α) : 0 < treeAutCard t := by
 
 /-! ### Nonplanar automorphism count via lift -/
 
-/-- The cardinality `|Aut(t)|` of the automorphism group of a rooted
-    nonplanar tree `t`.
-
-    Recursive structure: for `t = node a M` with children-multiset `M`,
-    `autCard t = ∏ distinct c ∈ M, (M.count c)! * (autCard c)^(M.count c)`
-    (see `autCard_node`). A leaf has `autCard = 1` (`autCard_leaf`).
-
-    Defined by lifting `treeAutCard` through the `Perm` quotient. -/
+/-- The cardinality `|Aut(t)|` of the automorphism group of a rooted nonplanar tree:
+    `∏_{distinct c ∈ M} (M.count c)! · autCard c ^ M.count c` at `node a M`
+    (`autCard_node`), `1` at a leaf (`autCard_leaf`). -/
 def autCard : Nonplanar α → ℕ :=
   Nonplanar.lift treeAutCard (fun _ _ h => treeAutCard_perm h)
 
@@ -148,34 +133,21 @@ def autCard : Nonplanar α → ℕ :=
   rw [RoseTree.leaf_def, treeAutCard_node]
   simp [multinomialFactor]
 
-/-- The automorphism group of any tree is non-trivial (contains identity).
-    Stated as positivity of the cardinality. Descends from
-    `treeAutCard_pos` via the quotient. -/
+/-- `autCard` is positive: the automorphism group contains the identity. -/
 theorem autCard_pos (t : Nonplanar α) : 0 < autCard t :=
   Quotient.inductionOn t treeAutCard_pos
 
-/-- The cardinality `|Aut(F)|` of the automorphism group of a forest
-    `F` (multiset of nonplanar trees), defined as the product over
-    distinct trees `T ∈ F`:
-    ```
-    forestAutCard F = ∏_{distinct T ∈ F} (F.count T)! · (autCard T)^(F.count T)
-    ```
-    Stays in `Nonplanar` namespace (rather than `Forest`) because
-    `Forest = Multiset` is just a stylistic alias used at the
-    `ConnesKreimer` algebra layer; here we work directly with
-    `Multiset (Nonplanar α)` to keep the combinatorics layer free of
-    algebra-layer abbreviations. -/
+/-- The automorphism count `|Aut(F)|` of a forest of nonplanar trees:
+    `∏_{distinct T ∈ F} (F.count T)! · autCard T ^ F.count T`. -/
 def forestAutCard (F : Multiset (Nonplanar α)) : ℕ :=
-  F.toFinset.prod fun t => Nat.factorial (F.count t) * autCard t ^ F.count t
+  F.toFinset.prod fun t => (F.count t).factorial * autCard t ^ F.count t
 
 /-- The empty forest has trivial aut group. -/
 @[simp] theorem forestAutCard_zero :
     forestAutCard (0 : Multiset (Nonplanar α)) = 1 := by
   simp [forestAutCard]
 
-/-- The aut group of any forest is non-trivial (contains identity).
-    Each factor `(F.count t)! * autCard t ^ F.count t` is positive
-    (factorial always positive; `autCard_pos` gives the tree factor). -/
+/-- `forestAutCard` is positive. -/
 theorem forestAutCard_pos (F : Multiset (Nonplanar α)) : 0 < forestAutCard F := by
   unfold forestAutCard
   exact Finset.prod_pos fun t _ =>
@@ -187,8 +159,7 @@ private theorem treeAutCard_out (x : Nonplanar α) :
   conv_rhs => rw [← x.out_eq]
   rfl
 
-/-- The `treeAutCard`-product over `Quotient.out`-representatives of a list
-    of nonplanar trees equals the `autCard`-product over the list. -/
+/-- The `treeAutCard`-product over `Quotient.out` representatives is the `autCard`-product. -/
 private theorem prod_out_treeAutCard (lst : List (Nonplanar α)) :
     ((lst.map Quotient.out).map treeAutCard).prod = (lst.map autCard).prod := by
   congr 1
@@ -196,8 +167,7 @@ private theorem prod_out_treeAutCard (lst : List (Nonplanar α)) :
   exact List.map_congr_left fun x _ => treeAutCard_out x
 
 omit [DecidableEq α] in
-/-- The mk-multiset of `Q.out`-lifted list of nonplanar trees equals the
-    original list. -/
+/-- `mk ∘ Quotient.out` is the identity on lists of nonplanar trees. -/
 private theorem ofList_map_mk_qout (lst : List (Nonplanar α)) :
     (Multiset.ofList (((lst.map Quotient.out).map mk)) :
         Multiset (Nonplanar α)) = Multiset.ofList lst := by
@@ -205,71 +175,48 @@ private theorem ofList_map_mk_qout (lst : List (Nonplanar α)) :
   congr 1
   exact (List.map_congr_left (fun x _ => x.out_eq)).trans (List.map_id lst)
 
-/-- `autCard` on the smart `node` constructor: the recursive definition.
-    Proof: induct on `F` to get a list rep `lst`; `treeAutCard` on the
-    tree node splits into a children-product factor (which lifts to
-    `(lst.map autCard).prod` via `prod_out_treeAutCard`) and a
-    `multinomialFactor` factor (which lifts to `multinomialFactor F` via
-    `ofList_map_mk_qout`). Combine via `Finset.prod_multiset_map_count`
-    (to express `(F.map autCard).prod` as a Finset prod over `F.toFinset`)
-    and `Finset.prod_mul_distrib` (to recombine the two legs into
-    `forestAutCard F`). -/
+/-- `forestAutCard` as the `autCard`-product over all members times the symmetry factor:
+    the forest analogue of `treeAutCard_node`'s shape. -/
+theorem forestAutCard_eq_prod_mul_multinomialFactor (F : Multiset (Nonplanar α)) :
+    forestAutCard F = (F.map autCard).prod * multinomialFactor F := by
+  unfold forestAutCard multinomialFactor
+  rw [Finset.prod_multiset_map_count, ← Finset.prod_mul_distrib]
+  exact Finset.prod_congr rfl fun t _ => mul_comm _ _
+
+/-- `autCard` at a node is `forestAutCard` of the children: the recursive formula. -/
 @[simp] theorem autCard_node (a : α) (F : Multiset (Nonplanar α)) :
     autCard (Nonplanar.node a F) = forestAutCard F := by
   induction F using Quotient.inductionOn with
   | h lst =>
-    -- Convert `Quotient.mk _ lst` to `Multiset.ofList lst` (definitionally equal).
-    show treeAutCard (RoseTree.node a (lst.map Quotient.out)) =
-        forestAutCard (Multiset.ofList lst)
-    rw [treeAutCard_node, prod_out_treeAutCard lst, ofList_map_mk_qout lst]
-    -- LHS: (lst.map autCard).prod * multinomialFactor (Multiset.ofList lst).
-    -- RHS: forestAutCard (Multiset.ofList lst) =
-    --      (Multiset.ofList lst).toFinset.prod fun t => (count t)! * autCard t ^ count t.
-    unfold forestAutCard multinomialFactor
-    -- (lst.map autCard).prod = ((Multiset.ofList lst).map autCard).prod
-    --                       = ∏ t ∈ toFinset, autCard t ^ count t.
-    have hprod_lst : ((Multiset.ofList lst).map autCard).prod
-                  = ((Multiset.ofList lst).toFinset).prod
-                      fun t => autCard t ^ (Multiset.ofList lst).count t :=
-      Finset.prod_multiset_map_count (Multiset.ofList lst) autCard
-    have hcoe : (lst.map autCard).prod = ((Multiset.ofList lst).map autCard).prod := rfl
-    rw [hcoe, hprod_lst]
-    -- Combine the two Finset prods via Finset.prod_mul_distrib.
-    rw [← Finset.prod_mul_distrib]
-    -- Match summands: pow * factorial = factorial * pow.
-    apply Finset.prod_congr rfl
-    intro t _
-    ring
+    show treeAutCard (RoseTree.node a (lst.map Quotient.out)) = _
+    rw [treeAutCard_node, prod_out_treeAutCard lst, ofList_map_mk_qout lst,
+        forestAutCard_eq_prod_mul_multinomialFactor]
+    rfl
 
 /-! ### Multinomial split identity
 
-The antidiagonal multiplicity `count (F, G) (antidiagonal (F + G))` is the binomial
-product `∏ t, C((F+G).count t, G.count t)`
-(`Multiset.count_antidiagonal_eq_count_powerset` + `Multiset.count_powerset_of_le`);
-recombining it with the factorials per distinct tree
-(`Nat.add_choose_mul_factorial_mul_factorial`) yields the split identity below — the
-combinatorial core of the pairing's product-coproduct adjunction
-(`GrossmanLarsonPairing.pairing_of'_mul_of'`). -/
+`Multiset.count_antidiagonal_eq_count_powerset` and `Multiset.count_powerset_of_le`
+compute the split multiplicity; `Nat.add_choose_mul_factorial_mul_factorial` recombines
+it with the factorials per distinct tree. This identity is the combinatorial core of the
+pairing's product-coproduct adjunction (`GrossmanLarsonPairing.pairing_of'_mul_of'`). -/
 
 /-- **Multinomial split identity** for `forestAutCard`:
-    `count (F,G) (antidiagonal (F+G)) · |Aut F| · |Aut G| = |Aut (F+G)|`. -/
+    `|Aut (F+G)| = count (F,G) (antidiagonal (F+G)) · |Aut F| · |Aut G|`. -/
 theorem forestAutCard_add (F G : Multiset (Nonplanar α)) :
-    Multiset.count (F, G) (Multiset.antidiagonal (F + G)) *
-      (forestAutCard F * forestAutCard G) = forestAutCard (F + G) := by
+    forestAutCard (F + G) = (Multiset.antidiagonal (F + G)).count (F, G) *
+      (forestAutCard F * forestAutCard G) := by
   have hext : ∀ M : Multiset (Nonplanar α), M ≤ F + G →
-      M.toFinset.prod (fun t => Nat.factorial (M.count t) * autCard t ^ M.count t)
-        = (F + G).toFinset.prod
-            (fun t => Nat.factorial (M.count t) * autCard t ^ M.count t) := by
+      forestAutCard M
+        = (F + G).toFinset.prod (fun t => (M.count t).factorial * autCard t ^ M.count t) := by
     intro M hM
     refine Finset.prod_subset
       (Multiset.toFinset_subset.mpr (Multiset.subset_of_le hM)) fun x _ hx => ?_
     rw [Multiset.count_eq_zero.mpr fun hm => hx (Multiset.mem_toFinset.mpr hm)]
     simp
   rw [Multiset.count_antidiagonal_eq_count_powerset,
-      Multiset.count_powerset_of_le (Multiset.le_add_left G F)]
-  unfold forestAutCard
-  rw [hext F (Multiset.le_add_right F G), hext G (Multiset.le_add_left G F),
-      ← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
+      Multiset.count_powerset_of_le (Multiset.le_add_left G F),
+      hext F (Multiset.le_add_right F G), hext G (Multiset.le_add_left G F),
+      hext (F + G) le_rfl, ← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
   refine Finset.prod_congr rfl fun t _ => ?_
   rw [Multiset.count_add, pow_add,
       ← Nat.add_choose_mul_factorial_mul_factorial (F.count t) (G.count t)]

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -3,65 +3,47 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Data.Multiset.Antidiagonal
 import Linglib.Core.Data.RoseTree.DecEq
-import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
-import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Multiset.Antidiagonal
 import Mathlib.Data.Multiset.Basic
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Nat.Factorial.Basic
-
-set_option autoImplicit false
+import Mathlib.Tactic.Ring
 
 /-!
 # Automorphism cardinality for rooted nonplanar trees
 
-The cardinality of the automorphism group of a rooted nonplanar tree
-(or a forest of such trees), used as the symmetry-weight in the
-Connes-Kreimer / Grossman-Larson pairing
-(`Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean`).
+For a rooted nonplanar tree whose children form the multiset `M = {c₁ × k₁, …, cₙ × kₙ}`
+(distinct subtrees `cᵢ` with multiplicity `kᵢ`), the automorphism group has cardinality
+`∏ᵢ kᵢ! · |Aut(cᵢ)| ^ kᵢ`; the same formula applied to the top-level multiset counts the
+automorphisms of a forest. These counts are the symmetry weights of the Connes-Kreimer /
+Grossman-Larson pairing (`Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing`).
 
-## RoseTree-level formula
+## Main definitions
 
-For a node with children-multiset `M = {c₁ × k₁, c₂ × k₂, …}` (distinct
-trees `cᵢ` with multiplicities `kᵢ`):
-```
-|Aut(node a M)| = ∏ᵢ kᵢ! · |Aut(cᵢ)|^kᵢ
-```
-A leaf has `|Aut(leaf)| = 1`.
+* `RootedTree.Nonplanar.autCard`: the automorphism count `|Aut(t)|` of a rooted nonplanar tree.
+* `RootedTree.Nonplanar.forestAutCard`: the automorphism count of a forest (multiset of rooted
+  nonplanar trees).
 
-The factorial factor `kᵢ!` accounts for permutations of identical
-children; the power `|Aut(cᵢ)|^kᵢ` accounts for independent choice of
-auts within each copy.
+## Main results
 
-## Forest-level formula
+* `RootedTree.Nonplanar.autCard_node`: the recursion `autCard (node a M) = forestAutCard M`.
+* `RootedTree.Nonplanar.forestAutCard_add`: the multinomial split identity
+  `count (F, G) (antidiagonal (F + G)) * (forestAutCard F * forestAutCard G) =
+  forestAutCard (F + G)`, the combinatorial core of the pairing's product-coproduct adjunction.
 
-For a forest (multiset of trees) `F = {T₁ × m₁, T₂ × m₂, …}`:
-```
-|Aut(F)| = ∏ⱼ mⱼ! · |Aut(Tⱼ)|^mⱼ
-```
-Same formula structure as the tree-level case, applied to the
-top-level multiset of constituent trees.
+## Implementation notes
 
-## Implementation status
+`treeAutCard` computes the count by structural recursion on a planar `RoseTree` representative;
+`Perm`-invariance (`treeAutCard_perm`) descends it to `Nonplanar.autCard` through the quotient.
+`[UPSTREAM]` candidate; eventual mathlib home would be `Mathlib.Combinatorics.RootedTree.Aut`.
 
-`[UPSTREAM]` candidate. Eventual mathlib home would be
-`Mathlib.Combinatorics.RootedTree.Aut`. **Sorry-free.**
+## Tags
 
-`Nonplanar.autCard` descends from `treeAutCard` on the `RoseTree α`
-representative, defined by structural recursion over the children list
-(`(cs.map treeAutCard).prod` aggregates the children product; no aux
-twin — `RoseTree`'s nested-`List` recursion is handled by the equation
-compiler and its `@[induction_eliminator]`). `Perm`-invariance is
-established via a `PermList` companion pair, and the lift to
-`Nonplanar` uses `Nonplanar.lift`. `autCard_node` bridges to the
-`forestAutCard`-as-Finset-product form via `Finset.prod_multiset_map_count`
-(turning the all-children prod into a `∏ distinct, c ^ count`-form) +
-`Finset.prod_mul_distrib`.
-
-`forestAutCard` is defined in terms of `autCard`.
+rooted tree, automorphism, symmetry factor, multinomial
 -/
 
 namespace RootedTree
@@ -79,12 +61,6 @@ through the quotient. -/
 /-- Symmetry-factor at one node: `∏_{distinct c ∈ M} (M.count c)!`. -/
 def multinomialFactor (M : Multiset (Nonplanar α)) : ℕ :=
   M.toFinset.prod fun t => (M.count t).factorial
-
-/-- `multinomialFactor` as a `Finsupp.prod` over `M.toFinsupp` — the
-    multiplicity-indexed form used by the multinomial arguments below. -/
-theorem multinomialFactor_eq_prod (M : Multiset (Nonplanar α)) :
-    multinomialFactor M = M.toFinsupp.prod fun _ k => k.factorial := by
-  simp only [multinomialFactor, Finsupp.prod, Multiset.toFinsupp_support, Multiset.toFinsupp_apply]
 
 /-- The automorphism count `|Aut(mk t)|` of the nonplanar tree represented
     by a planar `RoseTree` `t`. Substrate for `Nonplanar.autCard` (which lifts
@@ -192,12 +168,6 @@ theorem autCard_pos (t : Nonplanar α) : 0 < autCard t :=
 def forestAutCard (F : Multiset (Nonplanar α)) : ℕ :=
   F.toFinset.prod fun t => Nat.factorial (F.count t) * autCard t ^ F.count t
 
-/-- `forestAutCard` as a `Finsupp.prod` over `F.toFinsupp` — the
-    multiplicity-indexed form used by `forestAutCard_add`. -/
-theorem forestAutCard_eq_prod (F : Multiset (Nonplanar α)) :
-    forestAutCard F = F.toFinsupp.prod fun t k => k.factorial * autCard t ^ k := by
-  simp only [forestAutCard, Finsupp.prod, Multiset.toFinsupp_support, Multiset.toFinsupp_apply]
-
 /-- The empty forest has trivial aut group. -/
 @[simp] theorem forestAutCard_zero :
     forestAutCard (0 : Multiset (Nonplanar α)) = 1 := by
@@ -273,194 +243,37 @@ private theorem ofList_map_mk_qout (lst : List (Nonplanar α)) :
 
 /-! ### Multinomial split identity
 
-The automorphism count of a disjoint union `F + G` factors through any
-fixed split: `|Aut(F+G)| = N · |Aut F| · |Aut G|` where `N` counts the
-occurrences of the ordered pair `(F, G)` among the two-sided sub-multiset
-splits of `F + G` (`Multiset.antidiagonal`). Per distinct tree `t`, this
-is `(m₁ + m₂)! = C(m₁ + m₂, m₁) · m₁! · m₂!` with `mᵢ` the
-multiplicities in `F`, `G` — `Nat.add_choose_mul_factorial_mul_factorial`
-aggregated over `(F + G).toFinset`. The adjoint role: this is exactly
-what makes the symmetry-weighted pairing turn CK multiplication into the
-sub-multiset split coproduct (`GrossmanLarsonPairing.pairing_of'_mul`).
-
-Computationally validated (`scratch/validate_duality.lean`, V2 battery,
-exhaustive over forests of weight ≤ 3 plus duplicate-tree traps). -/
-
-/-- Count of an ordered split `(F, G)` in `antidiagonal (F + G)` equals the
-    count of `G` in `powerset (F + G)`: `antidiagonal_eq_map_powerset`
-    expresses the antidiagonal as the powerset mapped through the injective
-    `t ↦ (s - t, t)`, and the second coordinate `G` is in the image at
-    exactly one preimage. -/
-private theorem count_antidiagonal_eq_count_powerset
-    (F G : Multiset (Nonplanar α)) :
-    Multiset.count (F, G) (Multiset.antidiagonal (F + G)) =
-      Multiset.count G (Multiset.powerset (F + G)) := by
-  rw [Multiset.antidiagonal_eq_map_powerset]
-  -- Map is `fun t => (F + G - t, t)`, which is injective in `t` (second coord).
-  have hinj : Function.Injective
-      (fun t : Multiset (Nonplanar α) => (F + G - t, t)) :=
-    fun _ _ h => congrArg Prod.snd h
-  -- `(F, G) = (F + G - G, G)` because `F + G - G = F`.
-  have hpair : ((F + G - G, G) : Multiset (Nonplanar α) × _) = (F, G) := by
-    rw [Multiset.add_sub_cancel_right]
-  rw [← hpair]
-  exact Multiset.count_map_eq_count' _ _ hinj _
-
-/-- Peel the multiplicity at `a` out of a `Multiset.toFinsupp`-product, for `a ∈ M`. -/
-private theorem prod_toFinsupp_of_mem (M : Multiset (Nonplanar α)) (a : Nonplanar α)
-    (g : Nonplanar α → ℕ → ℕ) (ha : a ∈ M) :
-    M.toFinsupp.prod g = g a (M.count a) * (Finsupp.erase a M.toFinsupp).prod g := by
-  have ha' : a ∈ M.toFinsupp.support := by
-    rw [Multiset.toFinsupp_support, Multiset.mem_toFinset]; exact ha
-  rw [← Finsupp.mul_prod_erase M.toFinsupp a g ha', Multiset.toFinsupp_apply]
-
-/-- Erasing `a` from `(a ::ₘ M).toFinsupp` agrees with erasing it from `M.toFinsupp`:
-    the two finsupps coincide away from `a`. -/
-private theorem erase_toFinsupp_cons (a : Nonplanar α) (M : Multiset (Nonplanar α)) :
-    Finsupp.erase a (a ::ₘ M).toFinsupp = Finsupp.erase a M.toFinsupp := by
-  ext t
-  rcases eq_or_ne t a with rfl | ht
-  · rw [Finsupp.erase_same, Finsupp.erase_same]
-  · rw [Finsupp.erase_ne ht, Finsupp.erase_ne ht, Multiset.toFinsupp_apply,
-        Multiset.toFinsupp_apply, Multiset.count_cons_of_ne ht]
-
-/-- The count of `F` in `powerset H` is the product over distinct elements
-    of `H` of `(H.count t).choose (F.count t)`, provided `F ≤ H`. Proved by
-    induction on `H`: at `H = a ::ₘ H'`, peel the multiplicity of `a` out of
-    each `toFinsupp`-product (`prod_toFinsupp_of_mem`) and close with Pascal's
-    rule `Nat.choose_succ_succ'` at the single updated point. -/
-private theorem count_powerset_eq_prod_choose
-    (F H : Multiset (Nonplanar α)) (hFH : F ≤ H) :
-    Multiset.count F (Multiset.powerset H) =
-      H.toFinsupp.prod (fun t k => k.choose (F.count t)) := by
-  induction H using Multiset.induction_on generalizing F with
-  | empty =>
-    obtain rfl := Multiset.le_zero.mp hFH
-    simp
-  | cons a H' ih =>
-    rw [Multiset.powerset_cons, Multiset.count_add,
-        prod_toFinsupp_of_mem (a ::ₘ H') a _ (Multiset.mem_cons_self a H'),
-        Multiset.count_cons_self, erase_toFinsupp_cons]
-    have h_inj : Function.Injective (Multiset.cons a) := fun _ _ h =>
-      (Multiset.cons_inj_right a).mp h
-    by_cases ha_in_F : a ∈ F
-    · -- `a ∈ F`: `F = a ::ₘ F'` with `F' ≤ H'`.
-      obtain ⟨F', rfl⟩ := Multiset.exists_cons_of_mem ha_in_F
-      have hF'_le : F' ≤ H' := (Multiset.cons_le_cons_iff a).mp hFH
-      have hca : Multiset.count a F' ≤ Multiset.count a H' := Multiset.le_iff_count.mp hF'_le a
-      -- Off `a`, the erased product does not see the `cons a`.
-      have hP : (Finsupp.erase a H'.toFinsupp).prod (fun t k => k.choose ((a ::ₘ F').count t)) =
-          (Finsupp.erase a H'.toFinsupp).prod (fun t k => k.choose (F'.count t)) := by
-        refine Finsupp.prod_congr fun x hx => ?_
-        have hxa : x ≠ a := by rw [Finsupp.support_erase, Finset.mem_erase] at hx; exact hx.1
-        rw [Multiset.count_cons_of_ne hxa]
-      have h_second : Multiset.count (a ::ₘ F') ((Multiset.powerset H').map (Multiset.cons a)) =
-          Multiset.count F' (Multiset.powerset H') := Multiset.count_map_eq_count' _ _ h_inj F'
-      rw [h_second, Multiset.count_cons_self, hP, ih F' hF'_le]
-      by_cases ha_in_H' : a ∈ H'
-      · -- Peel `a` from the second summand's IH; the first splits by Pascal.
-        rw [prod_toFinsupp_of_mem H' a _ ha_in_H']
-        by_cases h_strict : Multiset.count a F' + 1 ≤ Multiset.count a H'
-        · have h_le' : a ::ₘ F' ≤ H' := by
-            rw [Multiset.le_iff_count]
-            intro b
-            rcases eq_or_ne b a with rfl | hb
-            · rw [Multiset.count_cons_self]; omega
-            · have hb' := Multiset.le_iff_count.mp hFH b
-              rw [Multiset.count_cons_of_ne hb, Multiset.count_cons_of_ne hb] at hb'
-              rwa [Multiset.count_cons_of_ne hb]
-          rw [ih (a ::ₘ F') h_le', prod_toFinsupp_of_mem H' a _ ha_in_H',
-            Multiset.count_cons_self, hP, ← add_mul, Nat.choose_succ_succ']
-          ring
-        · -- `count a F' = count a H'`: the first summand is `0` and both `choose`s are `1`.
-          have h_eq : Multiset.count a F' = Multiset.count a H' := by omega
-          have h_first_zero : Multiset.count (a ::ₘ F') (Multiset.powerset H') = 0 := by
-            rw [Multiset.count_eq_zero, Multiset.mem_powerset]
-            intro h_le_H'
-            have := Multiset.le_iff_count.mp h_le_H' a
-            rw [Multiset.count_cons_self] at this; omega
-          rw [h_first_zero, Nat.zero_add, h_eq, Nat.choose_self, Nat.choose_self]
-      · -- `a ∉ H'`: erase is a no-op and the first summand vanishes.
-        rw [Finsupp.erase_of_notMem_support
-          (by rw [Multiset.toFinsupp_support, Multiset.mem_toFinset]; exact ha_in_H')]
-        have h_first_zero : Multiset.count (a ::ₘ F') (Multiset.powerset H') = 0 := by
-          rw [Multiset.count_eq_zero, Multiset.mem_powerset]
-          exact fun h_le_H' => ha_in_H' (Multiset.subset_of_le h_le_H' (Multiset.mem_cons_self a F'))
-        have h_count_aF' : Multiset.count a F' = 0 :=
-          Multiset.count_eq_zero.mpr fun h => ha_in_H' (Multiset.subset_of_le hF'_le h)
-        rw [h_first_zero, Nat.zero_add, Multiset.count_eq_zero.mpr ha_in_H', h_count_aF']
-        simp
-    · -- `a ∉ F`: `F ≤ H'` and the second summand vanishes.
-      have hF_le' : F ≤ H' := by
-        rw [Multiset.le_iff_count]
-        intro b
-        rcases eq_or_ne b a with rfl | hb
-        · rw [Multiset.count_eq_zero.mpr ha_in_F]; exact Nat.zero_le _
-        · have := Multiset.le_iff_count.mp hFH b
-          rwa [Multiset.count_cons_of_ne hb] at this
-      have h_second_zero :
-          Multiset.count F ((Multiset.powerset H').map (Multiset.cons a)) = 0 := by
-        rw [Multiset.count_eq_zero, Multiset.mem_map]
-        rintro ⟨S, _, hS⟩
-        exact ha_in_F (hS ▸ Multiset.mem_cons_self a S)
-      have h_count_aF : Multiset.count a F = 0 := Multiset.count_eq_zero.mpr ha_in_F
-      rw [h_second_zero, Nat.add_zero, ih F hF_le', h_count_aF, Nat.choose_zero_right, one_mul]
-      by_cases ha_in_H' : a ∈ H'
-      · rw [prod_toFinsupp_of_mem H' a _ ha_in_H', h_count_aF, Nat.choose_zero_right, one_mul]
-      · rw [Finsupp.erase_of_notMem_support
-          (by rw [Multiset.toFinsupp_support, Multiset.mem_toFinset]; exact ha_in_H')]
-
-/-- Per-element multinomial: at every distinct tree `t`,
-    `((F+G).count t).choose (G.count t) * (F.count t)! * (G.count t)!
-      = ((F+G).count t)!`. This is
-    `Nat.add_choose_mul_factorial_mul_factorial` with
-    `i = F.count t`, `j = G.count t`, after rewriting
-    `(F+G).count t = F.count t + G.count t`. -/
-private theorem pointwise_factorial_split
-    (F G : Multiset (Nonplanar α)) (t : Nonplanar α) :
-    ((F + G).count t).choose (G.count t) *
-        Nat.factorial (F.count t) * Nat.factorial (G.count t) =
-      Nat.factorial ((F + G).count t) := by
-  rw [Multiset.count_add]
-  exact Nat.add_choose_mul_factorial_mul_factorial _ _
+The antidiagonal multiplicity `count (F, G) (antidiagonal (F + G))` is the binomial
+product `∏ t, C((F+G).count t, G.count t)`
+(`Multiset.count_antidiagonal_eq_count_powerset` + `Multiset.count_powerset_of_le`);
+recombining it with the factorials per distinct tree
+(`Nat.add_choose_mul_factorial_mul_factorial`) yields the split identity below — the
+combinatorial core of the pairing's product-coproduct adjunction
+(`GrossmanLarsonPairing.pairing_of'_mul_of'`). -/
 
 /-- **Multinomial split identity** for `forestAutCard`:
     `count (F,G) (antidiagonal (F+G)) · |Aut F| · |Aut G| = |Aut (F+G)|`. -/
 theorem forestAutCard_add (F G : Multiset (Nonplanar α)) :
     Multiset.count (F, G) (Multiset.antidiagonal (F + G)) *
       (forestAutCard F * forestAutCard G) = forestAutCard (F + G) := by
-  rw [count_antidiagonal_eq_count_powerset,
-      count_powerset_eq_prod_choose G (F + G) (Multiset.le_add_left G F),
-      forestAutCard_eq_prod F, forestAutCard_eq_prod G, forestAutCard_eq_prod (F + G)]
-  -- Extend the `F`- and `G`-legs onto `(F+G).toFinset` (each missing factor is
-  -- `0! · autCard ^ 0 = 1`), then match the combined product pointwise.
   have hext : ∀ M : Multiset (Nonplanar α), M ≤ F + G →
-      M.toFinsupp.prod (fun t k => k.factorial * autCard t ^ k) =
-        ∏ x ∈ (F + G).toFinset, (M.count x).factorial * autCard x ^ M.count x := by
+      M.toFinset.prod (fun t => Nat.factorial (M.count t) * autCard t ^ M.count t)
+        = (F + G).toFinset.prod
+            (fun t => Nat.factorial (M.count t) * autCard t ^ M.count t) := by
     intro M hM
-    have hsub : M.toFinsupp.support ⊆ (F + G).toFinset := fun t ht => by
-      rw [Multiset.toFinsupp_support, Multiset.mem_toFinset] at ht
-      exact Multiset.mem_toFinset.mpr (Multiset.subset_of_le hM ht)
-    rw [Finsupp.prod_of_support_subset _ hsub
-          (fun t k => k.factorial * autCard t ^ k) (fun i _ => by simp)]
-    exact Finset.prod_congr rfl fun x _ => by rw [Multiset.toFinsupp_apply]
-  have hchoose : (F + G).toFinsupp.prod (fun t k => k.choose (G.count t)) =
-      ∏ x ∈ (F + G).toFinset, ((F + G).count x).choose (G.count x) := by
-    simp only [Finsupp.prod, Multiset.toFinsupp_support, Multiset.toFinsupp_apply]
+    refine Finset.prod_subset
+      (Multiset.toFinset_subset.mpr (Multiset.subset_of_le hM)) fun x _ hx => ?_
+    rw [Multiset.count_eq_zero.mpr fun hm => hx (Multiset.mem_toFinset.mpr hm)]
+    simp
+  rw [Multiset.count_antidiagonal_eq_count_powerset,
+      Multiset.count_powerset_of_le (Multiset.le_add_left G F)]
+  unfold forestAutCard
   rw [hext F (Multiset.le_add_right F G), hext G (Multiset.le_add_left G F),
-      hext (F + G) le_rfl, hchoose, ← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
+      ← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
   refine Finset.prod_congr rfl fun t _ => ?_
-  rw [Multiset.count_add, pow_add]
-  have h_fact := pointwise_factorial_split F G t
-  rw [Multiset.count_add] at h_fact
-  set m₁ := F.count t
-  set m₂ := G.count t
-  set a := autCard t
-  -- h_fact : (m₁ + m₂).choose m₂ * m₁! * m₂! = (m₁ + m₂)!
-  calc (m₁ + m₂).choose m₂ * (m₁.factorial * a ^ m₁ * (m₂.factorial * a ^ m₂))
-      = ((m₁ + m₂).choose m₂ * m₁.factorial * m₂.factorial) *
-          (a ^ m₁ * a ^ m₂) := by ring
-    _ = (m₁ + m₂).factorial * (a ^ m₁ * a ^ m₂) := by rw [h_fact]
+  rw [Multiset.count_add, pow_add,
+      ← Nat.add_choose_mul_factorial_mul_factorial (F.count t) (G.count t)]
+  ring
 
 end Nonplanar
 

--- a/Linglib/Core/Data/Multiset/Antidiagonal.lean
+++ b/Linglib/Core/Data/Multiset/Antidiagonal.lean
@@ -10,16 +10,15 @@ import Mathlib.Data.Multiset.Antidiagonal
 # Counting pairs in `Multiset.antidiagonal`
 
 `Multiset.antidiagonal w` enumerates the ordered splits `w = p.1 + p.2` *with
-multiplicities*; this file computes them: the multiplicity of `(u, v)` is the product of
-binomial coefficients `∏ x, (w.count x).choose (v.count x)` (and `0` off the diagonal
-`u + v = w`).
+multiplicities*; this file computes those multiplicities: `(u, v)` occurs
+`∏ x, (w.count x).choose (v.count x)` times when `u + v = w`, and `0` times otherwise.
 
 ## Main results
 
 * `Multiset.count_antidiagonal`: the closed form for `(antidiagonal w).count (u, v)`.
-* `Multiset.count_antidiagonal_eq_count_powerset`: the guard-free bridge
-  `(antidiagonal (s + t)).count (s, t) = (s + t).powerset.count t`, reducing antidiagonal
-  counting to `Multiset.count_powerset_of_le`.
+* `Multiset.count_antidiagonal_eq_count_powerset`: the guard-free bridge to
+  `Multiset.count_powerset_of_le`.
+* `Multiset.count_antidiagonal_swap`: the multiplicity is symmetric in the two slots.
 
 `[UPSTREAM]` candidate; eventual mathlib home `Mathlib.Data.Multiset.Antidiagonal`, where
 the closed form also evaluates `Finsupp.antidiagonal'`.
@@ -31,18 +30,26 @@ multiset, antidiagonal, count, binomial coefficient
 
 namespace Multiset
 
-variable {α : Type*} [DecidableEq α]
+variable {α : Type*}
 
-/-- The multiplicity of the ordered split `(s, t)` in `antidiagonal (s + t)` is the number
-    of ways to select the sub-multiset `t` from `s + t`: `antidiagonal_eq_map_powerset`
-    exhibits the antidiagonal as the powerset mapped through `u ↦ (s + t - u, u)`, which is
-    injective in the second coordinate. -/
+/-- `antidiagonal` is invariant under `Prod.swap`: commutativity of `+` permutes the
+    ordered splits. -/
+theorem antidiagonal_swap (s : Multiset α) :
+    s.antidiagonal.map Prod.swap = s.antidiagonal := by
+  induction s using Multiset.induction_on with
+  | empty => rfl
+  | cons a t ih =>
+    simp only [Multiset.antidiagonal_cons, Multiset.map_add, Multiset.map_map,
+      ← Prod.map_comp_swap, ← Multiset.map_map _ Prod.swap, ih, add_comm]
+
+variable [DecidableEq α]
+
+/-- The multiplicity of `(s, t)` in `antidiagonal (s + t)` is the number of ways to
+    select the sub-multiset `t` from `s + t`. -/
 theorem count_antidiagonal_eq_count_powerset (s t : Multiset α) :
     (antidiagonal (s + t)).count (s, t) = (s + t).powerset.count t := by
-  rw [antidiagonal_eq_map_powerset]
-  have hpair : ((s + t - t, t) : Multiset α × Multiset α) = (s, t) := by
-    rw [Multiset.add_sub_cancel_right]
-  rw [← hpair]
+  rw [antidiagonal_eq_map_powerset,
+      show (s, t) = (s + t - t, t) by rw [Multiset.add_sub_cancel_right]]
   exact count_map_eq_count' _ _ (fun _ _ h => congrArg Prod.snd h) t
 
 /-- Closed form for the multiplicities of `Multiset.antidiagonal`: an ordered split
@@ -54,5 +61,11 @@ theorem count_antidiagonal (u v w : Multiset α) :
   · subst h
     rw [count_antidiagonal_eq_count_powerset, count_powerset_of_le (le_add_left v u)]
   · exact count_eq_zero.mpr fun hmem => h (mem_antidiagonal.mp hmem)
+
+/-- The antidiagonal multiplicity is symmetric in the two slots. -/
+theorem count_antidiagonal_swap (u v w : Multiset α) :
+    (antidiagonal w).count (u, v) = (antidiagonal w).count (v, u) := by
+  conv_lhs => rw [← antidiagonal_swap w]
+  exact count_map_eq_count' _ _ Prod.swap_injective (v, u)
 
 end Multiset

--- a/Linglib/Core/Data/Multiset/Antidiagonal.lean
+++ b/Linglib/Core/Data/Multiset/Antidiagonal.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Data.Multiset.Powerset
+import Mathlib.Data.Multiset.Antidiagonal
+
+/-!
+# Counting pairs in `Multiset.antidiagonal`
+
+`Multiset.antidiagonal w` enumerates the ordered splits `w = p.1 + p.2` *with
+multiplicities*; this file computes them: the multiplicity of `(u, v)` is the product of
+binomial coefficients `∏ x, (w.count x).choose (v.count x)` (and `0` off the diagonal
+`u + v = w`).
+
+## Main results
+
+* `Multiset.count_antidiagonal`: the closed form for `(antidiagonal w).count (u, v)`.
+* `Multiset.count_antidiagonal_eq_count_powerset`: the guard-free bridge
+  `(antidiagonal (s + t)).count (s, t) = (s + t).powerset.count t`, reducing antidiagonal
+  counting to `Multiset.count_powerset_of_le`.
+
+`[UPSTREAM]` candidate; eventual mathlib home `Mathlib.Data.Multiset.Antidiagonal`, where
+the closed form also evaluates `Finsupp.antidiagonal'`.
+
+## Tags
+
+multiset, antidiagonal, count, binomial coefficient
+-/
+
+namespace Multiset
+
+variable {α : Type*} [DecidableEq α]
+
+/-- The multiplicity of the ordered split `(s, t)` in `antidiagonal (s + t)` is the number
+    of ways to select the sub-multiset `t` from `s + t`: `antidiagonal_eq_map_powerset`
+    exhibits the antidiagonal as the powerset mapped through `u ↦ (s + t - u, u)`, which is
+    injective in the second coordinate. -/
+theorem count_antidiagonal_eq_count_powerset (s t : Multiset α) :
+    (antidiagonal (s + t)).count (s, t) = (s + t).powerset.count t := by
+  rw [antidiagonal_eq_map_powerset]
+  have hpair : ((s + t - t, t) : Multiset α × Multiset α) = (s, t) := by
+    rw [Multiset.add_sub_cancel_right]
+  rw [← hpair]
+  exact count_map_eq_count' _ _ (fun _ _ h => congrArg Prod.snd h) t
+
+/-- Closed form for the multiplicities of `Multiset.antidiagonal`: an ordered split
+    `(u, v)` of `w` occurs `∏ x, (w.count x).choose (v.count x)` times. -/
+theorem count_antidiagonal (u v w : Multiset α) :
+    (antidiagonal w).count (u, v) =
+      if u + v = w then ∏ x ∈ w.toFinset, (w.count x).choose (v.count x) else 0 := by
+  split_ifs with h
+  · subst h
+    rw [count_antidiagonal_eq_count_powerset, count_powerset_of_le (le_add_left v u)]
+  · exact count_eq_zero.mpr fun hmem => h (mem_antidiagonal.mp hmem)
+
+end Multiset

--- a/Linglib/Core/Data/Multiset/Powerset.lean
+++ b/Linglib/Core/Data/Multiset/Powerset.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Multiset.Powerset
+import Mathlib.Data.Nat.Choose.Basic
+
+/-!
+# Counting sub-multisets in `Multiset.powerset`
+
+The multiplicity of `s` in `t.powerset` is a product of binomial coefficients: a
+sub-multiset picks `s.count x` of the `t.count x` copies of each distinct `x`. (This
+product of binomials is not `Nat.multinomial`, which is the quotient `(∑ᵢ kᵢ)! / ∏ᵢ kᵢ!`.)
+
+## Main results
+
+* `Multiset.count_powerset_of_le`: for `s ≤ t`,
+  `t.powerset.count s = ∏ x ∈ t.toFinset, (t.count x).choose (s.count x)`.
+* `Multiset.count_powerset`: the hypothesis-free form, indexed by `(s + t).toFinset` so
+  that `Nat.choose` vanishing makes both sides `0` when `s ≰ t`.
+
+## Implementation notes
+
+The induction runs over a fixed ambient `Finset` containing both supports
+(`count_powerset_subset`): the index set stays constant through the recursion and the
+unconditional induction hypothesis absorbs the `s ≰ t` boundary cases by
+`Nat.choose` vanishing. `[UPSTREAM]` candidate; eventual mathlib home
+`Mathlib.Data.Multiset.Powerset`.
+
+## Tags
+
+multiset, powerset, count, binomial coefficient
+-/
+
+namespace Multiset
+
+variable {α : Type*} [DecidableEq α]
+
+/-- Workhorse for `count_powerset`: the product may be taken over any fixed `Finset`
+    containing the supports of both multisets. -/
+private theorem count_powerset_subset {S : Finset α} :
+    ∀ t : Multiset α, t.toFinset ⊆ S → ∀ s : Multiset α, s.toFinset ⊆ S →
+      t.powerset.count s = ∏ x ∈ S, (t.count x).choose (s.count x) := by
+  intro t
+  induction t using Multiset.induction_on with
+  | empty =>
+    intro _ s hs
+    rw [powerset_zero, count_singleton]
+    split_ifs with h
+    · subst h
+      simp
+    · obtain ⟨x, hx⟩ := exists_mem_of_ne_zero h
+      symm
+      rw [← Finset.mul_prod_erase S _ (hs (mem_toFinset.mpr hx)), count_zero,
+          Nat.choose_eq_zero_of_lt (count_pos.mpr hx), Nat.zero_mul]
+  | cons a t' ih =>
+    intro ht s hs
+    have haS : a ∈ S := ht (mem_toFinset.mpr (mem_cons_self a t'))
+    have ht' : t'.toFinset ⊆ S := fun x hx => ht (by
+      rw [toFinset_cons]; exact Finset.mem_insert_of_mem hx)
+    have hQ : ∏ x ∈ S.erase a, ((a ::ₘ t').count x).choose (s.count x)
+        = ∏ x ∈ S.erase a, (t'.count x).choose (s.count x) :=
+      Finset.prod_congr rfl fun x hx => by
+        rw [count_cons_of_ne (Finset.ne_of_mem_erase hx)]
+    rw [powerset_cons, count_add, ih ht' s hs,
+        ← Finset.mul_prod_erase S (fun x => ((a ::ₘ t').count x).choose (s.count x)) haS,
+        ← Finset.mul_prod_erase S (fun x => (t'.count x).choose (s.count x)) haS,
+        count_cons_self, hQ]
+    by_cases has : a ∈ s
+    · have hs' : (s.erase a).toFinset ⊆ S := fun x hx =>
+        hs (mem_toFinset.mpr (mem_of_subset (erase_subset a s) (mem_toFinset.mp hx)))
+      have hmap : (t'.powerset.map (Multiset.cons a)).count s
+          = t'.powerset.count (s.erase a) := by
+        conv_lhs => rw [← cons_erase has]
+        exact count_map_eq_count' _ _ (fun _ _ h => (cons_inj_right a).mp h) _
+      have hR : ∏ x ∈ S.erase a, (t'.count x).choose ((s.erase a).count x)
+          = ∏ x ∈ S.erase a, (t'.count x).choose (s.count x) :=
+        Finset.prod_congr rfl fun x hx => by
+          rw [count_erase_of_ne (Finset.ne_of_mem_erase hx)]
+      rw [hmap, ih ht' (s.erase a) hs',
+          ← Finset.mul_prod_erase S (fun x => (t'.count x).choose ((s.erase a).count x)) haS,
+          count_erase_self, hR, Nat.choose_succ_left _ _ (count_pos.mpr has),
+          ← Nat.add_mul, Nat.add_comm ((t'.count a).choose (s.count a))]
+    · have hmap : (t'.powerset.map (Multiset.cons a)).count s = 0 :=
+        count_eq_zero.mpr fun hmem => by
+          obtain ⟨u, -, rfl⟩ := mem_map.mp hmem
+          exact has (mem_cons_self a u)
+      rw [hmap, count_eq_zero.mpr has]
+      simp
+
+/-- Count of a sub-multiset `s ≤ t` among the sub-multisets of `t`: for each distinct
+    `x`, choose `s.count x` of the `t.count x` copies. -/
+theorem count_powerset_of_le {s t : Multiset α} (h : s ≤ t) :
+    t.powerset.count s = ∏ x ∈ t.toFinset, (t.count x).choose (s.count x) :=
+  count_powerset_subset t Finset.Subset.rfl s (toFinset_subset.mpr (subset_of_le h))
+
+/-- Hypothesis-free form of `count_powerset_of_le`: over `(s + t).toFinset`, some factor
+    `(t.count x).choose (s.count x)` vanishes whenever `s ≰ t`, so both sides are `0`. -/
+theorem count_powerset (s t : Multiset α) :
+    t.powerset.count s = ∏ x ∈ (s + t).toFinset, (t.count x).choose (s.count x) :=
+  count_powerset_subset t (by rw [toFinset_add]; exact Finset.subset_union_right)
+    s (by rw [toFinset_add]; exact Finset.subset_union_left)
+
+@[simp] theorem count_zero_powerset (t : Multiset α) : t.powerset.count 0 = 1 := by
+  rw [count_powerset_of_le (zero_le t)]
+  simp
+
+@[simp] theorem count_powerset_self (t : Multiset α) : t.powerset.count t = 1 := by
+  rw [count_powerset_of_le le_rfl]
+  simp
+
+end Multiset

--- a/Linglib/Core/Data/Multiset/Powerset.lean
+++ b/Linglib/Core/Data/Multiset/Powerset.lean
@@ -38,15 +38,12 @@ namespace Multiset
 
 variable {α : Type*} [DecidableEq α]
 
-/-- Workhorse for `count_powerset`: the product may be taken over any fixed `Finset`
-    containing the supports of both multisets. -/
-private theorem count_powerset_subset {S : Finset α} :
-    ∀ t : Multiset α, t.toFinset ⊆ S → ∀ s : Multiset α, s.toFinset ⊆ S →
-      t.powerset.count s = ∏ x ∈ S, (t.count x).choose (s.count x) := by
-  intro t
-  induction t using Multiset.induction_on with
+/-- Workhorse for `count_powerset_of_le` and `count_powerset`: the product may be taken
+    over any fixed `Finset` containing the supports of both multisets. -/
+private theorem count_powerset_subset {S : Finset α} {t s : Multiset α} (ht : t.toFinset ⊆ S)
+    (hs : s.toFinset ⊆ S) : t.powerset.count s = ∏ x ∈ S, (t.count x).choose (s.count x) := by
+  induction t using Multiset.induction_on generalizing s hs with
   | empty =>
-    intro _ s hs
     rw [powerset_zero, count_singleton]
     split_ifs with h
     · subst h
@@ -56,21 +53,18 @@ private theorem count_powerset_subset {S : Finset α} :
       rw [← Finset.mul_prod_erase S _ (hs (mem_toFinset.mpr hx)), count_zero,
           Nat.choose_eq_zero_of_lt (count_pos.mpr hx), Nat.zero_mul]
   | cons a t' ih =>
-    intro ht s hs
     have haS : a ∈ S := ht (mem_toFinset.mpr (mem_cons_self a t'))
-    have ht' : t'.toFinset ⊆ S := fun x hx => ht (by
-      rw [toFinset_cons]; exact Finset.mem_insert_of_mem hx)
+    have ht' : t'.toFinset ⊆ S := (toFinset_subset.mpr (subset_cons t' a)).trans ht
     have hQ : ∏ x ∈ S.erase a, ((a ::ₘ t').count x).choose (s.count x)
         = ∏ x ∈ S.erase a, (t'.count x).choose (s.count x) :=
       Finset.prod_congr rfl fun x hx => by
         rw [count_cons_of_ne (Finset.ne_of_mem_erase hx)]
-    rw [powerset_cons, count_add, ih ht' s hs,
+    rw [powerset_cons, count_add, ih ht' hs,
         ← Finset.mul_prod_erase S (fun x => ((a ::ₘ t').count x).choose (s.count x)) haS,
         ← Finset.mul_prod_erase S (fun x => (t'.count x).choose (s.count x)) haS,
         count_cons_self, hQ]
     by_cases has : a ∈ s
-    · have hs' : (s.erase a).toFinset ⊆ S := fun x hx =>
-        hs (mem_toFinset.mpr (mem_of_subset (erase_subset a s) (mem_toFinset.mp hx)))
+    · have hs' : (s.erase a).toFinset ⊆ S := (toFinset_subset.mpr (erase_subset a s)).trans hs
       have hmap : (t'.powerset.map (Multiset.cons a)).count s
           = t'.powerset.count (s.erase a) := by
         conv_lhs => rw [← cons_erase has]
@@ -79,7 +73,7 @@ private theorem count_powerset_subset {S : Finset α} :
           = ∏ x ∈ S.erase a, (t'.count x).choose (s.count x) :=
         Finset.prod_congr rfl fun x hx => by
           rw [count_erase_of_ne (Finset.ne_of_mem_erase hx)]
-      rw [hmap, ih ht' (s.erase a) hs',
+      rw [hmap, ih ht' hs',
           ← Finset.mul_prod_erase S (fun x => (t'.count x).choose ((s.erase a).count x)) haS,
           count_erase_self, hR, Nat.choose_succ_left _ _ (count_pos.mpr has),
           ← Nat.add_mul, Nat.add_comm ((t'.count a).choose (s.count a))]
@@ -94,14 +88,18 @@ private theorem count_powerset_subset {S : Finset α} :
     `x`, choose `s.count x` of the `t.count x` copies. -/
 theorem count_powerset_of_le {s t : Multiset α} (h : s ≤ t) :
     t.powerset.count s = ∏ x ∈ t.toFinset, (t.count x).choose (s.count x) :=
-  count_powerset_subset t Finset.Subset.rfl s (toFinset_subset.mpr (subset_of_le h))
+  count_powerset_subset Finset.Subset.rfl (toFinset_subset.mpr (subset_of_le h))
 
 /-- Hypothesis-free form of `count_powerset_of_le`: over `(s + t).toFinset`, some factor
     `(t.count x).choose (s.count x)` vanishes whenever `s ≰ t`, so both sides are `0`. -/
 theorem count_powerset (s t : Multiset α) :
     t.powerset.count s = ∏ x ∈ (s + t).toFinset, (t.count x).choose (s.count x) :=
-  count_powerset_subset t (by rw [toFinset_add]; exact Finset.subset_union_right)
-    s (by rw [toFinset_add]; exact Finset.subset_union_left)
+  count_powerset_subset (by rw [toFinset_add]; exact Finset.subset_union_right)
+    (by rw [toFinset_add]; exact Finset.subset_union_left)
+
+/-- A multiset that is not below `t` does not occur in `t.powerset`. -/
+theorem count_powerset_eq_zero {s t : Multiset α} (h : ¬s ≤ t) : t.powerset.count s = 0 :=
+  count_eq_zero.mpr (mt mem_powerset.mp h)
 
 @[simp] theorem count_zero_powerset (t : Multiset α) : t.powerset.count 0 = 1 := by
   rw [count_powerset_of_le (zero_le t)]


### PR DESCRIPTION
Extracts the generic counting combinatorics from `RootedTree/Aut.lean` into `Core/Data/Multiset/{Powerset,Antidiagonal}.lean` (`[UPSTREAM]`): `count_powerset(_of_le)` and `count_antidiagonal` compute the multiplicities mathlib's own docstrings advertise but never evaluate.

- `forestAutCard_add` keeps its exact statement over a short consumer proof; Aut.lean 468→279 lines, Finsupp scaffold and dead scratch reference removed.
- Aut.lean module docstring brought to the mathlib template.