### PR TITLE
refactor(Core): upstream-prep RootedTree/Counting

### DIFF
--- a/Linglib/Core/Combinatorics/RootedTree/Counting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Counting.lean
@@ -2,39 +2,28 @@ import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 import Linglib.Core.Data.RoseTree.Nonplanar
 
 /-!
-# Size counting on nonplanar rooted trees and workspaces
+# Size measures on forests of rooted nonplanar trees
 
-The MCB size measures for syntactic-object combinatorics
-([marcolli-chomsky-berwick-2025]), on the canonical `Nonplanar` carrier.
-A *workspace* (forest) is a `Multiset (Nonplanar α)`; MCB foregrounds the
-measures `b₀`/`α`/`σ` on workspaces (eq. 1.6.1), with a single tree as the
-one-component case. The tree-level `accCount` is the recursive primitive that
-`α` folds over.
-
-These build directly on the lifted `Nonplanar.numNodes` (= MCB's `#V`); the
-legacy planar `Decorated`/`AdmissibleCut` substrate provided the same measures
-over the unfaithful planar-binary `TraceTree`.
+For a forest `F : Multiset (Nonplanar α)`: `b₀` counts component trees, `alpha` counts
+non-root vertices (equivalently, edges), and `sigma = b₀ + alpha` is the total vertex
+count (`sigma_eq_sum_numNodes`) — the forest case of `#V = b₀ + #E`.
 
 ## Main definitions
 
-* `Nonplanar.accCount` — accessible-term count `α(T) = #V(T) - 1` (tree primitive).
-* `Forest.b₀` — number of component trees (Betti number).
-* `Forest.alpha` — total accessible terms `α(F) = Σ α(Tᵢ)`.
-* `Forest.sigma` — workspace size `σ(F) = b₀(F) + α(F)`.
+* `RootedTree.Nonplanar.accCount`: the non-root vertex count `numNodes - 1` of a tree.
+* `RootedTree.Forest.b₀`: the number of component trees.
+* `RootedTree.Forest.alpha`: the total non-root vertex count.
+* `RootedTree.Forest.sigma`: `b₀ + alpha`.
 
 ## Main results
 
-* `Nonplanar.accCount_merge` — external Merge adds two accessible terms (eq. 1.6.5).
-* `Forest.sigma_eq_sum_numNodes` — `σ(F) = #V(F)` (eq. 1.2.6); unconditional on the
-  generic carrier (no trace leaves). The contraction-quotient exception
-  (`σᶜ ≠ #V`, MCB p.66) lives in `TraceCounting`.
+* `RootedTree.Forest.sigma_eq_sum_numNodes`: `sigma F = (F.map numNodes).sum`.
 
-## TODO
+`[UPSTREAM]` candidate alongside the `Nonplanar` carrier.
 
-* Trace-aware `accCountC`/`alphaC`/`sigmaC` and the complexity grading `#L`
-  on lexical leaves (`leafCountSO0`) over `Nonplanar (α ⊕ β)` (`TraceCounting.lean`);
-  builds on the carrier `Nonplanar.numLeaves`.
-* The admissible-cut layer (`Fintype`-enumerable cuts + extraction identities 1.6.7/1.6.8).
+## Tags
+
+rooted tree, forest, counting, vertex count
 -/
 
 namespace RootedTree
@@ -43,8 +32,8 @@ namespace Nonplanar
 
 variable {α : Type*}
 
-/-- The **accessible-term count** `α(T) = #V(T) - 1`: every vertex of a
-syntactic object except its root (MCB eq. 1.2.5). -/
+/-- The number of non-root vertices of a rooted tree, `numNodes - 1` (equivalently, its
+    edge count). -/
 def accCount (t : Nonplanar α) : ℕ := t.numNodes - 1
 
 @[simp] theorem accCount_leaf (a : α) : (leaf a : Nonplanar α).accCount = 0 := by
@@ -52,29 +41,32 @@ def accCount (t : Nonplanar α) : ℕ := t.numNodes - 1
 
 theorem accCount_eq_numNodes_sub_one (t : Nonplanar α) : t.accCount = t.numNodes - 1 := rfl
 
-/-- External Merge of two syntactic objects adds exactly two accessible terms
-(MCB Lemma 1.6.3, eq. 1.6.5). -/
-theorem accCount_merge (a : α) (l r : Nonplanar α) :
+/-- `accCount + 1` recovers the vertex count. -/
+theorem accCount_add_one (t : Nonplanar α) : t.accCount + 1 = t.numNodes :=
+  Nat.succ_pred_eq_of_pos t.numNodes_pos
+
+/-- `accCount` at a node is the total vertex count of the children. -/
+theorem accCount_node (a : α) (F : Multiset (Nonplanar α)) :
+    (node a F).accCount = (F.map numNodes).sum := by
+  simp [accCount]
+
+/-- Adjoining a root above a pair of trees adds two non-root vertices. -/
+theorem accCount_node_pair (a : α) (l r : Nonplanar α) :
     (node a {l, r}).accCount = l.accCount + r.accCount + 2 := by
-  have hl := l.numNodes_pos
-  have hr := r.numNodes_pos
-  simp only [accCount, numNodes_node, Multiset.insert_eq_cons, Multiset.map_cons,
-    Multiset.sum_cons, Multiset.map_singleton, Multiset.sum_singleton]
+  rw [accCount_node]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton, ← accCount_add_one]
   omega
 
 end Nonplanar
 
-/-! ## Workspace (forest) measures
-
-A workspace is a `Multiset (Nonplanar α)`. MCB's primitive workspace measures
-are `b₀` (component count) and `α` (accessible terms); `σ` is derived. -/
+/-! ### Forest measures -/
 
 namespace Forest
 
 variable {α : Type*}
 
-/-- The number of component trees in a workspace — MCB's `b₀`, the Betti
-number `b₀(F) = #I` (eq. 1.6.1). -/
+/-- The number of component trees of a forest (its zeroth Betti number). -/
 def b₀ (F : Multiset (Nonplanar α)) : ℕ := Multiset.card F
 
 @[simp] theorem b₀_zero : b₀ (0 : Multiset (Nonplanar α)) = 0 := Multiset.card_zero
@@ -85,7 +77,7 @@ def b₀ (F : Multiset (Nonplanar α)) : ℕ := Multiset.card F
 @[simp] theorem b₀_add (F G : Multiset (Nonplanar α)) :
     b₀ (F + G) = b₀ F + b₀ G := Multiset.card_add F G
 
-/-- Total accessible terms across the workspace, `α(F) = Σ α(Tᵢ)` (eq. 1.2.4). -/
+/-- The total non-root vertex count of a forest. -/
 def alpha (F : Multiset (Nonplanar α)) : ℕ := (F.map Nonplanar.accCount).sum
 
 @[simp] theorem alpha_zero : alpha (0 : Multiset (Nonplanar α)) = 0 := rfl
@@ -99,25 +91,23 @@ def alpha (F : Multiset (Nonplanar α)) : ℕ := (F.map Nonplanar.accCount).sum
     alpha (F + G) = alpha F + alpha G := by
   simp only [alpha, Multiset.map_add, Multiset.sum_add]
 
-/-- Workspace size `σ(F) = b₀(F) + α(F)` (MCB eq. 1.6.1): components plus
-accessible terms. For trace-free workspaces this is the total vertex count
-(`sigma_eq_sum_numNodes`); it is *not* the vertex count for contraction quotients
-(a trace leaf is a vertex but not an accessible term, MCB p.66). -/
+/-- `b₀ + alpha`: the total vertex count of a forest (`sigma_eq_sum_numNodes`). -/
 def sigma (F : Multiset (Nonplanar α)) : ℕ := b₀ F + alpha F
 
 @[simp] theorem sigma_zero : sigma (0 : Multiset (Nonplanar α)) = 0 := rfl
 @[simp] theorem sigma_cons (T : Nonplanar α) (F : Multiset (Nonplanar α)) :
     sigma (T ::ₘ F) = T.numNodes + sigma F := by
-  have hT := T.numNodes_pos
-  simp only [sigma, b₀_cons, alpha_cons, Nonplanar.accCount_eq_numNodes_sub_one]
+  simp only [sigma, b₀_cons, alpha_cons, ← Nonplanar.accCount_add_one]
+  omega
+@[simp] theorem sigma_singleton (T : Nonplanar α) :
+    sigma ({T} : Multiset (Nonplanar α)) = T.numNodes := by
+  simp only [sigma, b₀_singleton, alpha_singleton, ← Nonplanar.accCount_add_one]
   omega
 @[simp] theorem sigma_add (F G : Multiset (Nonplanar α)) :
     sigma (F + G) = sigma F + sigma G := by
   simp only [sigma, b₀_add, alpha_add]; omega
 
-/-- `σ(F) = #V(F)`, the total vertex count (MCB eq. 1.2.6). Unconditional on the
-generic carrier, where every `accCount` is `numNodes − 1`; the contraction-quotient
-exception lives in `TraceCounting`. -/
+/-- `sigma` is the total vertex count: the forest case of `#V = b₀ + #E`. -/
 theorem sigma_eq_sum_numNodes (F : Multiset (Nonplanar α)) :
     sigma F = (F.map Nonplanar.numNodes).sum := by
   induction F using Multiset.induction with

--- a/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
@@ -259,7 +259,7 @@ def accCountC (t : Nonplanar (α ⊕ β)) : ℕ := t.accCount - t.traceLeafCount
 theorem accCountC_merge (a : α) (l r : Nonplanar (α ⊕ β))
     (hl : l.traceLeafCount < l.numNodes) (hr : r.traceLeafCount < r.numNodes) :
     (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 := by
-  have hw := Nonplanar.accCount_merge (Sum.inl a) l r
+  have hw := Nonplanar.accCount_node_pair (Sum.inl a) l r
   have htl : (Nonplanar.node (Sum.inl a) {l, r}).traceLeafCount
       = l.traceLeafCount + r.traceLeafCount := by
     rw [traceLeafCount_node_inl]
@@ -313,6 +313,9 @@ def sigmaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := b₀ F + alphaC F
     (F : Multiset (Nonplanar (α ⊕ β))) :
     sigmaC (T ::ₘ F) = T.accCountC + 1 + sigmaC F := by
   simp only [sigmaC, b₀_cons, alphaC_cons]; omega
+@[simp] theorem sigmaC_singleton (T : Nonplanar (α ⊕ β)) :
+    sigmaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC + 1 := by
+  simp only [sigmaC, b₀_singleton, alphaC_singleton]; omega
 @[simp] theorem sigmaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
     sigmaC (F + G) = sigmaC F + sigmaC G := by
   simp only [sigmaC, b₀_add, alphaC_add]; omega

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -76,7 +76,7 @@ theorem em_pair_satisfiesMinimalYield (lbl : α) (S S' : Nonplanar (α ⊕ β)) 
     MinimalYield ({S, S'} : Forest (Nonplanar (α ⊕ β)))
                  ({Nonplanar.node (Sum.inl lbl) {S, S'}}) := by
   have hnode : (Nonplanar.node (Sum.inl lbl) {S, S'}).accCount
-      = S.accCount + S'.accCount + 2 := Nonplanar.accCount_merge (Sum.inl lbl) S S'
+      = S.accCount + S'.accCount + 2 := Nonplanar.accCount_node_pair (Sum.inl lbl) S S'
   refine ⟨⟨?_, ?_⟩, ?_⟩
   · simp only [Forest.b₀_singleton, Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_zero]
     omega
@@ -102,7 +102,7 @@ theorem im_pair_size_deltas_deletion (lbl : α) {T mover Q : Nonplanar (α ⊕ �
       ∧ Forest.sigma ({Nonplanar.node (Sum.inl lbl) {mover, Q}} : Forest (Nonplanar (α ⊕ β)))
         = Forest.sigma ({T} : Forest (Nonplanar (α ⊕ β))) := by
   have hnode : (Nonplanar.node (Sum.inl lbl) {mover, Q}).accCount
-      = mover.accCount + Q.accCount + 2 := Nonplanar.accCount_merge (Sum.inl lbl) mover Q
+      = mover.accCount + Q.accCount + 2 := Nonplanar.accCount_node_pair (Sum.inl lbl) mover Q
   refine ⟨rfl, ?_, ?_⟩
   · rw [Forest.alpha_singleton, Forest.alpha_singleton, hnode]
     omega


### PR DESCRIPTION
De-linguistifies the forest size-measure file for the rooted-tree upstream cone: module doc reframed as the forest case of `#V = b₀ + #E`, MCB/Merge vocabulary moved to its consumers, `accCount_merge` renamed to `accCount_node_pair`.

- new `accCount_node` (general node formula) and `accCount_add_one`; positivity `have`+`omega` boilerplate dropped from three proofs
- new `sigma_singleton`/`sigmaC_singleton` simp lemmas (MinimalYield proofs no longer hand-unfold `Forest.sigma`)