### PR TITLE
refactor(Core): upstream-prep TraceCounting; split TraceMeasures

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -63,6 +63,7 @@ import Linglib.Core.Data.RoseTree.DecEq
 import Linglib.Core.Data.RoseTree.Nonplanar
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNonplanar
 import Linglib.Core.Combinatorics.RootedTree.TraceCounting
+import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
 import Linglib.Core.Computability.Lens
 import Linglib.Core.Computability.ContextFreeGrammar.Closure
 import Linglib.Core.Computability.ContextFreeGrammar.InterRegular

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
 import Linglib.Core.Combinatorics.RootedTree.TraceCounting
+import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
 
 set_option autoImplicit false
 
@@ -383,46 +384,6 @@ nodes), and the trunk keeps the tree's root. -/
 
 end RootedTree
 
-namespace RoseTree
-
-variable {α β : Type*}
-
-mutual
-/-- A trace leaf is a vertex, so a tree has at least as many vertices as
-    trace leaves. -/
-theorem traceLeafCount_le_numNodes :
-    ∀ (t : RoseTree (α ⊕ β)), traceLeafCount t ≤ numNodes t
-  | .node (Sum.inl _) cs => by
-    rw [traceLeafCount_node_inl, numNodes_node]
-    have := traceLeafCountSum_le_numNodesSum cs
-    omega
-  | .node (Sum.inr _) [] => by simp
-  | .node (Sum.inr _) (c :: cs) => by
-    rw [traceLeafCount_node_of_ne_nil _ _ (by simp), numNodes_node]
-    have := traceLeafCountSum_le_numNodesSum (c :: cs)
-    omega
-theorem traceLeafCountSum_le_numNodesSum :
-    ∀ (cs : List (RoseTree (α ⊕ β))),
-      (cs.map traceLeafCount).sum ≤ (cs.map numNodes).sum
-  | [] => by simp
-  | c :: cs => by
-    simp only [List.map_cons, List.sum_cons]
-    have h1 := traceLeafCount_le_numNodes c
-    have h2 := traceLeafCountSum_le_numNodesSum cs
-    omega
-end
-
-/-- A lexical-rooted tree has a non-trace vertex (its root), so its trace
-    leaves number strictly fewer than its vertices. -/
-theorem traceLeafCount_lt_numNodes_of_inl (a : α) (cs : List (RoseTree (α ⊕ β))) :
-    traceLeafCount (RoseTree.node (Sum.inl a) cs) <
-      numNodes (RoseTree.node (Sum.inl a) cs) := by
-  rw [traceLeafCount_node_inl, numNodes_node]
-  have := traceLeafCountSum_le_numNodesSum cs
-  omega
-
-end RoseTree
-
 namespace RootedTree
 
 namespace ConnesKreimer
@@ -486,40 +447,6 @@ theorem extractC_ne_none_imp_inl (τ : RoseTree (α ⊕ β) → β) (t : RoseTre
     | inr b => rw [extractC_inr] at h; exact absurd rfl h
 
 end ConnesKreimer
-
-namespace Nonplanar
-
-variable {α β : Type*}
-
-/-- A lexical-rooted (`Sum.inl`) nonplanar tree has a non-trace vertex
-    (its root), so its trace leaves number strictly fewer than its vertices. -/
-theorem traceLeafCount_lt_numNodes_of_rootInl (t : Nonplanar (α ⊕ β)) (a : α)
-    (h : t.rootValue = Sum.inl a) : t.traceLeafCount < t.numNodes := by
-  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
-    ⟨t.out, (Quotient.out_eq t).symm⟩
-  rw [Nonplanar.rootValue_mk] at h
-  cases t₀ with
-  | node x cs =>
-    rw [RoseTree.value_node] at h
-    subst h
-    rw [Nonplanar.traceLeafCount_mk, Nonplanar.numNodes_mk]
-    exact RoseTree.traceLeafCount_lt_numNodes_of_inl a cs
-
-/-- A lexical-rooted nonplanar tree puts every trace marker at depth ≥ 1, so its
-    depth-weighted trace count dominates its plain trace count. -/
-theorem traceLeafCount_le_traceDepthSum_of_rootInl (t : Nonplanar (α ⊕ β)) (a : α)
-    (h : t.rootValue = Sum.inl a) : t.traceLeafCount ≤ t.traceDepthSum := by
-  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
-    ⟨t.out, (Quotient.out_eq t).symm⟩
-  rw [Nonplanar.rootValue_mk] at h
-  cases t₀ with
-  | node x cs =>
-    rw [RoseTree.value_node] at h
-    subst h
-    rw [Nonplanar.traceLeafCount_mk, Nonplanar.traceDepthSum_mk]
-    exact RoseTree.traceLeafCount_le_traceDepthSum_of_inl a cs
-
-end Nonplanar
 
 /-! ### α extraction identity (MCB eq. 1.6.8) -/
 

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -18,8 +18,7 @@ import Mathlib.Tactic.Ring
 For a rooted nonplanar tree whose children form the multiset `M = {c₁ × k₁, …, cₙ × kₙ}`
 (distinct subtrees `cᵢ` with multiplicity `kᵢ`), the automorphism group has cardinality
 `∏ᵢ kᵢ! · |Aut(cᵢ)| ^ kᵢ`; the same formula applied to the top-level multiset counts the
-automorphisms of a forest. These counts are the symmetry weights of the Connes-Kreimer /
-Grossman-Larson pairing (`Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing`).
+automorphisms of a forest.
 
 ## Main definitions
 

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -40,9 +40,6 @@ Grossman-Larson pairing (`Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing`
 `Perm`-invariance (`treeAutCard_perm`) descends it to `Nonplanar.autCard` through the quotient.
 `[UPSTREAM]` candidate; eventual mathlib home would be `Mathlib.Combinatorics.RootedTree.Aut`.
 
-## Tags
-
-rooted tree, automorphism, symmetry factor, multinomial
 -/
 
 namespace RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/ContractUnary.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/ContractUnary.lean
@@ -27,9 +27,6 @@ number of unary vertices.
 
 `[UPSTREAM]` candidate alongside the `RoseTree` carrier.
 
-## Tags
-
-rose tree, unary vertex, contraction, series reduction
 -/
 
 namespace RoseTree

--- a/Linglib/Core/Combinatorics/RootedTree/Counting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Counting.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 import Linglib.Core.Data.RoseTree.Nonplanar
 
@@ -20,10 +25,6 @@ count (`sigma_eq_sum_numNodes`) — the forest case of `#V = b₀ + #E`.
 * `RootedTree.Forest.sigma_eq_sum_numNodes`: `sigma F = (F.map numNodes).sum`.
 
 `[UPSTREAM]` candidate alongside the `Nonplanar` carrier.
-
-## Tags
-
-rooted tree, forest, counting, vertex count
 -/
 
 namespace RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceCounting.lean
@@ -1,53 +1,73 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Combinatorics.RootedTree.Counting
 
 /-!
-# Trace-aware size counting on `Nonplanar (α ⊕ β)`
-[marcolli-chomsky-berwick-2025]
+# Counting marked leaves of a rose tree
 
-The MCB size measures specialized to the **contraction-quotient carrier**
-`Nonplanar (α ⊕ β)`, where `Sum.inl` vertices carry original lexical
-decorations and `Sum.inr` vertices are trace-marker placeholders left by
-the Δ^c coproduct (a trace leaf is `node (Sum.inr b) []`, the encoding of
-`Coproduct.Trace.traceLeaf`). A trace leaf is a vertex but **not** an
-accessible term: it is excluded from `Acc`, so the trace-aware counts
-subtract it off the generic carrier measures.
-
-The key consequence is the failure of the clean trace-free identity
-`σ = #V`: for a contraction quotient `σᶜ ≠ #V` (MCB p. 66 caveat), because
-a trace leaf inflates `#V` without contributing an accessible term.
+For rose trees over `α ⊕ β` whose `Sum.inr`-labeled leaves are *markers*:
+`traceLeafCount` counts the marked leaves and `traceDepthSum` weights each by its
+root-distance. The two statistics are one paired fold (`traceStats`), so a single
+`fold_perm` descends both to the `Nonplanar` quotient.
 
 ## Main definitions
 
-* `Nonplanar.traceLeafCount` — number of `Sum.inr`-labeled leaves.
-* `Nonplanar.accCountC` — trace-excluding accessible-term count `α − #traceLeaves`.
-* `Nonplanar.leafCountSO0` — complexity grading `#L` on lexical leaves only.
-* `Forest.alphaC` / `Forest.sigmaC` — the trace-aware workspace measures.
+* `RoseTree.traceLeafCount`, `RoseTree.traceDepthSum`: the marked-leaf count and its
+  depth-weighted refinement, with descents `RootedTree.Nonplanar.traceLeafCount` and
+  `RootedTree.Nonplanar.traceDepthSum`.
+
+## Main results
+
+* `RoseTree.traceLeafCount_le_numNodes`: a marked leaf is a vertex; strict for
+  `Sum.inl`-rooted trees (`traceLeafCount_lt_numNodes_of_inl`).
+* `RoseTree.traceLeafCount_le_traceDepthSum_of_inl`: under a `Sum.inl` root every
+  marker sits at depth ≥ 1, so the depth-weighted count dominates the plain one.
+
+`[UPSTREAM]` candidate alongside the `RoseTree` carrier. The `α ⊕ β` labeling is a
+2-coloring with decorated colors (Foissy's decorated rooted trees; the bicoloured trees
+of partitioned B-series), and the upstream form is the mathlib counting idiom: a leaf
+projection (`leafMultiset : Nonplanar α → Multiset α`) with counts as `Multiset.countP`
+and the bounds inherited from `countP_le_card` — `trace` is domain vocabulary,
+`Sum.isRight` the color-class predicate.
 -/
 
 namespace RoseTree
 
-variable {α β : Type*}
+variable {α β : Type*} (a : α) (b : β)
 
-/-! ### `traceLeafCount` — counting trace-marker leaves
+/-! ### Marked-leaf statistics as a paired fold -/
 
-A trace marker is a `Sum.inr`-labeled vertex (always a leaf in practice).
-A `fold` over `RoseTree (α ⊕ β)`: at a node, sum the children's counts, adding
-`1` only for a bare `Sum.inr`-leaf. -/
-
-/-- The trace-leaf algebra: `1` at a bare `Sum.inr` leaf, else the children's total. -/
+/-- The marked-leaf algebra: `1` at a bare `Sum.inr` leaf, else the children's total. -/
 private def tlcAlg (v : α ⊕ β) (ns : List ℕ) : ℕ :=
   match v, ns with
   | Sum.inr _, [] => 1
   | _,         ns => ns.sum
 
-/-- The number of `Sum.inr`-labeled leaves (trace markers) in a tree. -/
+/-- The number of `Sum.inr`-labeled (marked) leaves in a tree. -/
 def traceLeafCount : RoseTree (α ⊕ β) → ℕ :=
   fold tlcAlg
 
-@[simp] theorem traceLeafCount_leaf_inr (b : β) :
+/-- The paired statistic `(traceLeafCount t, traceDepthSum t)` as a single fold: the
+    depth leg adds, per child, its own depth plus one per marked leaf it carries. -/
+private def traceStats : RoseTree (α ⊕ β) → ℕ × ℕ :=
+  fold fun v ps => (tlcAlg v (ps.map Prod.fst), (ps.map fun p => p.2 + p.1).sum)
+
+private theorem traceStats_fst (t : RoseTree (α ⊕ β)) :
+    (traceStats t).1 = traceLeafCount t :=
+  fold_hom Prod.fst (fun _ _ => rfl) t
+
+/-- Sum of root-distances of the `Sum.inr`-labeled (marked) leaves. -/
+def traceDepthSum (t : RoseTree (α ⊕ β)) : ℕ := (traceStats t).2
+
+/-! ### Equations -/
+
+@[simp] theorem traceLeafCount_leaf_inr :
     traceLeafCount (.node (Sum.inr b) [] : RoseTree (α ⊕ β)) = 1 := rfl
 
-@[simp] theorem traceLeafCount_leaf_inl (a : α) :
+@[simp] theorem traceLeafCount_leaf_inl :
     traceLeafCount (.node (Sum.inl a) [] : RoseTree (α ⊕ β)) = 0 := rfl
 
 /-- On a non-leaf node, `traceLeafCount` is the sum of the children's counts,
@@ -58,61 +78,28 @@ theorem traceLeafCount_node_of_ne_nil (v : α ⊕ β) (cs : List (RoseTree (α �
   | nil => exact absurd rfl h
   | cons c cs => cases v <;> simp only [traceLeafCount, tlcAlg, fold_node, List.map_cons]
 
-/-- On a `Sum.inl` root the count is just the children's total (the lexical
-    root is never itself a trace leaf), for any child list. -/
-@[simp] theorem traceLeafCount_node_inl (a : α) (cs : List (RoseTree (α ⊕ β))) :
+@[simp] theorem traceLeafCount_node_cons (v : α ⊕ β) (c : RoseTree (α ⊕ β))
+    (cs : List (RoseTree (α ⊕ β))) :
+    traceLeafCount (.node v (c :: cs)) = ((c :: cs).map traceLeafCount).sum :=
+  traceLeafCount_node_of_ne_nil v (c :: cs) (by simp)
+
+/-- On a `Sum.inl` root the count is just the children's total (the root is never
+    itself a marked leaf), for any child list. -/
+@[simp] theorem traceLeafCount_node_inl (cs : List (RoseTree (α ⊕ β))) :
     traceLeafCount (.node (Sum.inl a) cs) = (cs.map traceLeafCount).sum := by
   cases cs with
   | nil => rfl
   | cons c cs => exact traceLeafCount_node_of_ne_nil _ _ (by simp)
 
-/-! #### Trace-leaf-count invariance under `Perm` -/
-
-/-- `traceLeafCount` is a `Perm`-invariant: the fold of a permutation-invariant
-    algebra (the shape split is nil-vs-nonempty, which `List.Perm` preserves). -/
-theorem traceLeafCount_perm {t s : RoseTree (α ⊕ β)}
-    (h : Perm t s) : t.traceLeafCount = s.traceLeafCount := by
-  refine fold_perm (fun v l₁ l₂ h' => ?_) h
-  cases l₁ with
-  | nil => rw [← h'.nil_eq]
-  | cons x xs =>
-    cases l₂ with
-    | nil => exact absurd h'.eq_nil (by simp)
-    | cons y ys => cases v <;> exact h'.sum_eq
-
-/-! ### `traceDepthSum` — depth-weighted trace-marker count (Minimal Search depth)
-
-The **Minimal Search depth** `d_v` of MCB §1.5.2 (book p. 59): the sum over
-trace-marker leaves of their distance from the root. The recurrence couples to
-`traceLeafCount` — descending into a child adds one per trace leaf below it — so both
-statistics are computed by one paired fold (`traceStats`), with `fold_hom` recovering
-`traceLeafCount` as the first component and one `fold_perm` giving both
-`Perm`-invariances.
-
-For a Δ^c cut, the quotient (trunk) places a trace leaf at each cut site at
-exactly the cut depth (`Coproduct.Trace.traceLeaf`), so `traceDepthSum(quotient)`
-reads off the total extraction depth `Σ d_{v_i}` of MCB rule 1 directly. -/
-
-/-- The paired statistic `(traceLeafCount t, traceDepthSum t)` as a single fold: the
-    depth leg adds, per child, its own depth plus one per trace leaf it carries. -/
-private def traceStats : RoseTree (α ⊕ β) → ℕ × ℕ :=
-  fold fun v ps => (tlcAlg v (ps.map Prod.fst), (ps.map fun p => p.2 + p.1).sum)
-
-private theorem traceStats_fst (t : RoseTree (α ⊕ β)) :
-    (traceStats t).1 = traceLeafCount t :=
-  fold_hom Prod.fst (fun _ _ => rfl) t
-
-/-- Sum of root-distances of the `Sum.inr`-labeled (trace-marker) leaves. -/
-def traceDepthSum (t : RoseTree (α ⊕ β)) : ℕ := (traceStats t).2
-
-@[simp] theorem traceDepthSum_leaf_inl (a : α) :
+@[simp] theorem traceDepthSum_leaf_inl :
     traceDepthSum (.node (Sum.inl a) [] : RoseTree (α ⊕ β)) = 0 := rfl
 
-@[simp] theorem traceDepthSum_leaf_inr (b : β) :
+@[simp] theorem traceDepthSum_leaf_inr :
     traceDepthSum (.node (Sum.inr b) [] : RoseTree (α ⊕ β)) = 0 := rfl
 
-/-- Each child contributes its own trace-depth plus one per trace leaf it carries. -/
-theorem traceDepthSum_node (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β))) :
+/-- Each child contributes its own depth-weighted count plus one per marked leaf it
+    carries (the extra edge from the node to the child). -/
+@[simp] theorem traceDepthSum_node (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β))) :
     traceDepthSum (.node v cs)
       = (cs.map fun c => traceDepthSum c + traceLeafCount c).sum := by
   show (traceStats (.node v cs)).2 = _
@@ -121,9 +108,11 @@ theorem traceDepthSum_node (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β))) :
   exact congrArg List.sum (List.map_congr_left fun c _ =>
     congrArg ((traceStats c).2 + ·) (traceStats_fst c))
 
-/-! #### Trace-depth invariance under `Perm` -/
+/-! ### `Perm` invariance
 
-/-- The paired algebra is permutation-invariant, so one `fold_perm` covers the pair. -/
+The paired algebra is permutation-invariant, so one `fold_perm` covers both
+statistics. -/
+
 private theorem traceStats_perm {t s : RoseTree (α ⊕ β)} (h : Perm t s) :
     traceStats t = traceStats s := by
   refine fold_perm (fun v l₁ l₂ h' => ?_) h
@@ -135,23 +124,65 @@ private theorem traceStats_perm {t s : RoseTree (α ⊕ β)} (h : Perm t s) :
     | nil => exact absurd h'.eq_nil (by simp)
     | cons y ys => cases v <;> exact (h'.map Prod.fst).sum_eq
 
+/-- `traceLeafCount` is a `Perm`-invariant. -/
+theorem traceLeafCount_perm {t s : RoseTree (α ⊕ β)} (h : Perm t s) :
+    t.traceLeafCount = s.traceLeafCount := by
+  rw [← traceStats_fst, ← traceStats_fst]
+  exact congrArg Prod.fst (traceStats_perm h)
+
 /-- `traceDepthSum` is a `Perm`-invariant. -/
 theorem traceDepthSum_perm {t s : RoseTree (α ⊕ β)} (h : Perm t s) :
     t.traceDepthSum = s.traceDepthSum :=
   congrArg Prod.snd (traceStats_perm h)
 
-/-- The children's trace leaves are bounded by the node's: a `Sum.inr` root
-    can only *add* a trace leaf (the empty-trace-leaf case), never remove one. -/
+/-! ### Bounds -/
+
+/-- The children's marked leaves are bounded by the node's: a `Sum.inr` root can only
+    *add* a marked leaf (the bare-leaf case), never remove one. -/
 theorem traceLeafCount_le_node (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β))) :
     (cs.map traceLeafCount).sum ≤ traceLeafCount (.node v cs) := by
   rcases eq_or_ne cs [] with h | h
   · subst h; exact Nat.zero_le _
   · exact (traceLeafCount_node_of_ne_nil v cs h).ge
 
-/-- **A lexical root puts every trace marker at depth ≥ 1**: for a
-    `Sum.inl`-rooted tree, the depth-weighted trace count dominates the plain
-    trace count. Underlies the Minimal-Search positivity `Cut.depthC_pos`. -/
-theorem traceLeafCount_le_traceDepthSum_of_inl (a : α) (cs : List (RoseTree (α ⊕ β))) :
+mutual
+/-- A marked leaf is a vertex, so a tree has at least as many vertices as marked
+    leaves. -/
+theorem traceLeafCount_le_numNodes :
+    ∀ (t : RoseTree (α ⊕ β)), traceLeafCount t ≤ numNodes t
+  | .node (Sum.inl _) cs => by
+    rw [traceLeafCount_node_inl, numNodes_node]
+    have := traceLeafCountSum_le_numNodesSum cs
+    omega
+  | .node (Sum.inr _) [] => by simp
+  | .node (Sum.inr _) (c :: cs) => by
+    rw [traceLeafCount_node_cons, numNodes_node]
+    have := traceLeafCountSum_le_numNodesSum (c :: cs)
+    omega
+/-- Auxiliary: the bound summed over a list of children. -/
+theorem traceLeafCountSum_le_numNodesSum :
+    ∀ (cs : List (RoseTree (α ⊕ β))),
+      (cs.map traceLeafCount).sum ≤ (cs.map numNodes).sum
+  | [] => by simp
+  | c :: cs => by
+    simp only [List.map_cons, List.sum_cons]
+    have h1 := traceLeafCount_le_numNodes c
+    have h2 := traceLeafCountSum_le_numNodesSum cs
+    omega
+end
+
+/-- A `Sum.inl`-rooted tree has an unmarked vertex (its root), so its marked leaves
+    number strictly fewer than its vertices. -/
+theorem traceLeafCount_lt_numNodes_of_inl (cs : List (RoseTree (α ⊕ β))) :
+    traceLeafCount (RoseTree.node (Sum.inl a) cs) <
+      numNodes (RoseTree.node (Sum.inl a) cs) := by
+  rw [traceLeafCount_node_inl, numNodes_node]
+  have := traceLeafCountSum_le_numNodesSum cs
+  omega
+
+/-- A `Sum.inl` root puts every marked leaf at depth ≥ 1, so the depth-weighted count
+    dominates the plain count. -/
+theorem traceLeafCount_le_traceDepthSum_of_inl (cs : List (RoseTree (α ⊕ β))) :
     traceLeafCount (.node (Sum.inl a) cs) ≤ traceDepthSum (.node (Sum.inl a) cs) := by
   rw [traceLeafCount_node_inl, traceDepthSum_node]
   induction cs with
@@ -162,47 +193,55 @@ theorem traceLeafCount_le_traceDepthSum_of_inl (a : α) (cs : List (RoseTree (α
 
 end RoseTree
 
-namespace RootedTree
+/-! ### Descent to `Nonplanar` -/
 
-namespace Nonplanar
+namespace RootedTree.Nonplanar
 
-variable {α β : Type*}
+variable {α β : Type*} (a : α) (b : β)
 
-/-- The number of `Sum.inr`-labeled (trace-marker) leaves of a nonplanar
-    tree, lifted from `RoseTree.traceLeafCount`. -/
+/-- The number of `Sum.inr`-labeled (marked) leaves of a nonplanar tree. -/
 def traceLeafCount : Nonplanar (α ⊕ β) → ℕ :=
-  Nonplanar.lift RoseTree.traceLeafCount
-    (fun _ _ h => RoseTree.traceLeafCount_perm h)
+  Nonplanar.lift RoseTree.traceLeafCount fun _ _ => RoseTree.traceLeafCount_perm
 
 @[simp] theorem traceLeafCount_mk (t : RoseTree (α ⊕ β)) :
     (mk t).traceLeafCount = t.traceLeafCount := rfl
 
-@[simp] theorem traceLeafCount_leaf_inl (a : α) :
+@[simp] theorem traceLeafCount_leaf_inl :
     (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceLeafCount = 0 := rfl
 
-@[simp] theorem traceLeafCount_leaf_inr (b : β) :
+@[simp] theorem traceLeafCount_leaf_inr :
     (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceLeafCount = 1 := rfl
 
-/-- The **Minimal Search depth** `d_v` of MCB §1.5: the sum of root-distances
-    of the trace-marker leaves, lifted from `RoseTree.traceDepthSum`. For a Δ^c
-    cut, `traceDepthSum` of the quotient is the total extraction depth. -/
+/-- Marked leaves of a `Sum.inl`-rooted node: the root contributes none, so the count
+    is the children's total. -/
+@[simp] theorem traceLeafCount_node_inl (F : Multiset (Nonplanar (α ⊕ β))) :
+    (Nonplanar.node (Sum.inl a) F).traceLeafCount = (F.map Nonplanar.traceLeafCount).sum := by
+  refine Quotient.inductionOn F fun lst => ?_
+  show (mk (.node (Sum.inl a) (lst.map Quotient.out))).traceLeafCount = _
+  rw [traceLeafCount_mk, RoseTree.traceLeafCount_node_inl, List.map_map]
+  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
+  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
+  show (mk (Quotient.out t)).traceLeafCount = Nonplanar.traceLeafCount t
+  exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
+
+/-- The depth-weighted marked-leaf count of a nonplanar tree. For a Δ^c cut this reads
+    off the total extraction depth of the quotient — see the consumers in
+    `Coproduct/Conservation.lean`. -/
 def traceDepthSum : Nonplanar (α ⊕ β) → ℕ :=
-  Nonplanar.lift RoseTree.traceDepthSum
-    (fun _ _ h => RoseTree.traceDepthSum_perm h)
+  Nonplanar.lift RoseTree.traceDepthSum fun _ _ => RoseTree.traceDepthSum_perm
 
 @[simp] theorem traceDepthSum_mk (t : RoseTree (α ⊕ β)) :
     (mk t).traceDepthSum = t.traceDepthSum := rfl
 
-@[simp] theorem traceDepthSum_leaf_inl (a : α) :
+@[simp] theorem traceDepthSum_leaf_inl :
     (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := rfl
 
-@[simp] theorem traceDepthSum_leaf_inr (b : β) :
+@[simp] theorem traceDepthSum_leaf_inr :
     (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := rfl
 
-/-- Trace-depth of a node decomposes over children: each child `c`
-    contributes its own trace-depth plus one per trace leaf it carries
-    (the `+1` for the extra level between the node and `c`). -/
-@[simp] theorem traceDepthSum_node_inl (a : α) (F : Multiset (Nonplanar (α ⊕ β))) :
+/-- Each child contributes its own depth-weighted count plus one per marked leaf it
+    carries. -/
+@[simp] theorem traceDepthSum_node_inl (F : Multiset (Nonplanar (α ⊕ β))) :
     (Nonplanar.node (Sum.inl a) F).traceDepthSum
       = (F.map (fun c => c.traceDepthSum + c.traceLeafCount)).sum := by
   refine Quotient.inductionOn F fun lst => ?_
@@ -216,139 +255,32 @@ def traceDepthSum : Nonplanar (α ⊕ β) → ℕ :=
   · exact congrArg Nonplanar.traceDepthSum (Quotient.out_eq t)
   · exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
 
-/-- The **trace-excluding accessible-term count** `αᶜ(T) = α(T) − #traceLeaves(T)`:
-    a trace leaf is a vertex but not an accessible term (MCB p. 66). Truncated
-    subtraction handles the all-trace edge case (e.g. `T = traceLeaf b`, where
-    `α = 0` and `#traceLeaves = 1`). -/
-def accCountC (t : Nonplanar (α ⊕ β)) : ℕ := t.accCount - t.traceLeafCount
+/-- A `Sum.inl`-rooted nonplanar tree has an unmarked vertex (its root), so its marked
+    leaves number strictly fewer than its vertices. -/
+theorem traceLeafCount_lt_numNodes_of_rootInl (t : Nonplanar (α ⊕ β)) (x : α)
+    (h : t.rootValue = Sum.inl x) : t.traceLeafCount < t.numNodes := by
+  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
+    ⟨t.out, (Quotient.out_eq t).symm⟩
+  rw [Nonplanar.rootValue_mk] at h
+  cases t₀ with
+  | node x cs =>
+    rw [RoseTree.value_node] at h
+    subst h
+    rw [Nonplanar.traceLeafCount_mk, Nonplanar.numNodes_mk]
+    exact RoseTree.traceLeafCount_lt_numNodes_of_inl x cs
 
-/-- Trace leaves of a lexical-rooted node: the root contributes none, so the
-    count is the children's total. -/
-@[simp] theorem traceLeafCount_node_inl (a : α) (F : Multiset (Nonplanar (α ⊕ β))) :
-    (Nonplanar.node (Sum.inl a) F).traceLeafCount = (F.map Nonplanar.traceLeafCount).sum := by
-  refine Quotient.inductionOn F fun lst => ?_
-  show (mk (.node (Sum.inl a) (lst.map Quotient.out))).traceLeafCount = _
-  rw [traceLeafCount_mk, RoseTree.traceLeafCount_node_inl, List.map_map]
-  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
-  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
-  show (mk (Quotient.out t)).traceLeafCount = Nonplanar.traceLeafCount t
-  exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
+/-- A `Sum.inl`-rooted nonplanar tree puts every marked leaf at depth ≥ 1, so its
+    depth-weighted count dominates its plain count. -/
+theorem traceLeafCount_le_traceDepthSum_of_rootInl (t : Nonplanar (α ⊕ β)) (x : α)
+    (h : t.rootValue = Sum.inl x) : t.traceLeafCount ≤ t.traceDepthSum := by
+  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
+    ⟨t.out, (Quotient.out_eq t).symm⟩
+  rw [Nonplanar.rootValue_mk] at h
+  cases t₀ with
+  | node x cs =>
+    rw [RoseTree.value_node] at h
+    subst h
+    rw [Nonplanar.traceLeafCount_mk, Nonplanar.traceDepthSum_mk]
+    exact RoseTree.traceLeafCount_le_traceDepthSum_of_inl x cs
 
-/-- External Merge adds two accessible terms in the trace-aware count: the two
-    children's roots become accessible (MCB Lemma 1.6.3, eq. 1.6.5). Needs each
-    child to have a lexical vertex (`traceLeafCount < numNodes`), automatic for a
-    real syntactic object. -/
-theorem accCountC_merge (a : α) (l r : Nonplanar (α ⊕ β))
-    (hl : l.traceLeafCount < l.numNodes) (hr : r.traceLeafCount < r.numNodes) :
-    (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 := by
-  have hw := Nonplanar.accCount_node_pair (Sum.inl a) l r
-  have htl : (Nonplanar.node (Sum.inl a) {l, r}).traceLeafCount
-      = l.traceLeafCount + r.traceLeafCount := by
-    rw [traceLeafCount_node_inl]
-    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
-      Multiset.map_singleton, Multiset.sum_singleton]
-  have hbl : l.traceLeafCount ≤ l.accCount := by
-    rw [Nonplanar.accCount_eq_numNodes_sub_one]; omega
-  have hbr : r.traceLeafCount ≤ r.accCount := by
-    rw [Nonplanar.accCount_eq_numNodes_sub_one]; omega
-  simp only [accCountC, htl, hw]
-  omega
-
-/-- The **complexity grading** `#L` restricted to lexical leaves:
-    `#L_{SO₀}(T) = #L(T) − #traceLeaves(T)`. The trace-exclusion follows the
-    UNVERIFIED-default reading of MCB Remark 1.2.2 (leaves labeled by `SO₀`);
-    whether a trace leaf counts in `#L` is not settled in the book. -/
-def leafCountSO0 (t : Nonplanar (α ⊕ β)) : ℕ := t.numLeaves - t.traceLeafCount
-
-end Nonplanar
-
-/-! ## Trace-aware workspace (forest) measures -/
-
-namespace Forest
-
-variable {α β : Type*}
-
-/-- Trace-excluding accessible terms across a workspace, `αᶜ(F) = Σ αᶜ(Tᵢ)`. -/
-def alphaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ :=
-  (F.map Nonplanar.accCountC).sum
-
-@[simp] theorem alphaC_zero : alphaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
-@[simp] theorem alphaC_cons (T : Nonplanar (α ⊕ β))
-    (F : Multiset (Nonplanar (α ⊕ β))) :
-    alphaC (T ::ₘ F) = T.accCountC + alphaC F := by
-  simp only [alphaC, Multiset.map_cons, Multiset.sum_cons]
-@[simp] theorem alphaC_singleton (T : Nonplanar (α ⊕ β)) :
-    alphaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC := by
-  simp only [alphaC, Multiset.map_singleton, Multiset.sum_singleton]
-@[simp] theorem alphaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
-    alphaC (F + G) = alphaC F + alphaC G := by
-  simp only [alphaC, Multiset.map_add, Multiset.sum_add]
-
-/-- Trace-aware workspace size `σᶜ(F) = b₀(F) + αᶜ(F)`. Unlike the generic
-    `σ`, this is **not** the vertex count for contraction quotients
-    (`σᶜ ≠ #V`, MCB p. 66): a trace leaf is a vertex but not an accessible
-    term, so it raises `#V` without raising `σᶜ`. -/
-def sigmaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := b₀ F + alphaC F
-
-@[simp] theorem sigmaC_zero : sigmaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
-@[simp] theorem sigmaC_cons (T : Nonplanar (α ⊕ β))
-    (F : Multiset (Nonplanar (α ⊕ β))) :
-    sigmaC (T ::ₘ F) = T.accCountC + 1 + sigmaC F := by
-  simp only [sigmaC, b₀_cons, alphaC_cons]; omega
-@[simp] theorem sigmaC_singleton (T : Nonplanar (α ⊕ β)) :
-    sigmaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC + 1 := by
-  simp only [sigmaC, b₀_singleton, alphaC_singleton]; omega
-@[simp] theorem sigmaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
-    sigmaC (F + G) = sigmaC F + sigmaC G := by
-  simp only [sigmaC, b₀_add, alphaC_add]; omega
-
-end Forest
-
-/-! ### The `σᶜ ≠ #V` caveat, concretely
-
-A lexical root over a single trace leaf: `#V = 2` (root + trace leaf) but the
-trace leaf contributes no accessible term, so `αᶜ = 0` and `σᶜ = 1`. -/
-
-namespace Nonplanar
-
-variable {α β : Type*}
-
-/-- Minimal contraction-quotient witness for the `σᶜ ≠ #V` caveat. -/
-private def traceWitness (a : α) (b : β) : Nonplanar (α ⊕ β) :=
-  Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inr b) []])
-
-example (a : α) (b : β) : (traceWitness a b).numNodes = 2 := rfl
-example (a : α) (b : β) : (traceWitness a b).traceLeafCount = 1 := rfl
-example (a : α) (b : β) : (traceWitness a b).accCountC = 0 := rfl
-example (a : α) (b : β) : (traceWitness a b).leafCountSO0 = 0 := rfl
-
-/-- The trace leaf of `traceWitness` sits at depth 1, so `traceDepthSum = 1`. -/
-example (a : α) (b : β) : (traceWitness a b).traceDepthSum = 1 := rfl
-
-/-- A trace leaf two levels down contributes depth 2 to `traceDepthSum`. -/
-example (a a' : α) (b : β) :
-    Nonplanar.traceDepthSum
-      (Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inl a') [.node (Sum.inr b) []]])) = 2 := rfl
-
-/-- Two trace leaves at depths 1 and 2 sum to 3 — the multi-extraction
-    additivity `d_v = Σ d_{v_i}` of MCB rule 3. -/
-example (a a' : α) (b b' : β) :
-    Nonplanar.traceDepthSum
-      (Nonplanar.mk (.node (Sum.inl a)
-        [.node (Sum.inr b) [], .node (Sum.inl a') [.node (Sum.inr b') []]])) = 3 := rfl
-
-/-- `σᶜ` undercounts `#V` on the contraction quotient: the trace leaf is a
-    vertex but not an accessible term. -/
-example (a : α) (b : β) :
-    Forest.sigmaC ({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))) ≠
-      (({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))).map
-        Nonplanar.numNodes).sum := by
-  simp only [Forest.sigmaC, Forest.b₀_singleton, Forest.alphaC_singleton,
-    Multiset.map_singleton, Multiset.sum_singleton,
-    show (traceWitness a b).accCountC = 0 from rfl,
-    show (traceWitness a b).numNodes = 2 from rfl]
-  decide
-
-end Nonplanar
-
-end RootedTree
+end RootedTree.Nonplanar

--- a/Linglib/Core/Combinatorics/RootedTree/TraceMeasures.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceMeasures.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Combinatorics.RootedTree.TraceCounting
+
+/-!
+# Trace-aware size measures on the contraction-quotient carrier
+[marcolli-chomsky-berwick-2025]
+
+The MCB size measures on `Nonplanar (α ⊕ β)`, where `Sum.inl` vertices carry lexical
+decorations and `Sum.inr` vertices are trace-marker placeholders left by the Δ^c
+coproduct. A trace leaf is a vertex but **not** an accessible term, so the trace-aware
+counts subtract the marked-leaf count off the generic measures — and the trace-free
+identity `σ = #V` fails on contraction quotients (`σᶜ ≠ #V`, MCB p. 66), witnessed
+concretely at the end of the file.
+
+## Main definitions
+
+* `Nonplanar.accCountC`: trace-excluding accessible-term count `α − #traceLeaves`.
+* `Forest.alphaC` / `Forest.sigmaC`: the trace-aware workspace measures.
+
+## Main results
+
+* `Nonplanar.accCountC_merge`: External Merge adds two accessible terms in the
+  trace-aware count (MCB Lemma 1.6.3, eq. 1.6.5).
+-/
+
+namespace RootedTree
+
+namespace Nonplanar
+
+variable {α β : Type*} (a : α) (b : β)
+
+/-- The **trace-excluding accessible-term count** `αᶜ(T) = α(T) − #traceLeaves(T)`:
+    a trace leaf is a vertex but not an accessible term (MCB p. 66). Truncated
+    subtraction handles the all-trace edge case. -/
+def accCountC (t : Nonplanar (α ⊕ β)) : ℕ := t.accCount - t.traceLeafCount
+
+@[simp] theorem accCountC_leaf_inl :
+    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).accCountC = 0 := rfl
+
+/-- The truncation case: a bare trace leaf has `α = 0` but one marked leaf. -/
+@[simp] theorem accCountC_leaf_inr :
+    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).accCountC = 0 := rfl
+
+/-- The marked leaves of a tree are among its non-root vertices whenever the root is
+    unmarked. -/
+theorem traceLeafCount_le_accCount (t : Nonplanar (α ⊕ β))
+    (h : t.traceLeafCount < t.numNodes) : t.traceLeafCount ≤ t.accCount := by
+  rw [Nonplanar.accCount_eq_numNodes_sub_one]
+  omega
+
+/-- External Merge adds two accessible terms in the trace-aware count: the two
+    children's roots become accessible (MCB Lemma 1.6.3, eq. 1.6.5). Needs each child
+    to have a lexical vertex (`traceLeafCount < numNodes`), automatic for a real
+    syntactic object. -/
+theorem accCountC_merge (l r : Nonplanar (α ⊕ β))
+    (hl : l.traceLeafCount < l.numNodes) (hr : r.traceLeafCount < r.numNodes) :
+    (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 := by
+  have hw := Nonplanar.accCount_node_pair (Sum.inl a) l r
+  have htl : (Nonplanar.node (Sum.inl a) {l, r}).traceLeafCount
+      = l.traceLeafCount + r.traceLeafCount := by
+    rw [traceLeafCount_node_inl]
+    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
+      Multiset.map_singleton, Multiset.sum_singleton]
+  have hbl := l.traceLeafCount_le_accCount hl
+  have hbr := r.traceLeafCount_le_accCount hr
+  simp only [accCountC, htl, hw]
+  omega
+
+end Nonplanar
+
+/-! ### Trace-aware workspace (forest) measures -/
+
+namespace Forest
+
+variable {α β : Type*}
+
+/-- Trace-excluding accessible terms across a workspace, `αᶜ(F) = Σ αᶜ(Tᵢ)`. -/
+def alphaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ :=
+  (F.map Nonplanar.accCountC).sum
+
+@[simp] theorem alphaC_zero : alphaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
+@[simp] theorem alphaC_cons (T : Nonplanar (α ⊕ β))
+    (F : Multiset (Nonplanar (α ⊕ β))) :
+    alphaC (T ::ₘ F) = T.accCountC + alphaC F := by
+  simp only [alphaC, Multiset.map_cons, Multiset.sum_cons]
+@[simp] theorem alphaC_singleton (T : Nonplanar (α ⊕ β)) :
+    alphaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC := by
+  simp only [alphaC, Multiset.map_singleton, Multiset.sum_singleton]
+@[simp] theorem alphaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
+    alphaC (F + G) = alphaC F + alphaC G := by
+  simp only [alphaC, Multiset.map_add, Multiset.sum_add]
+
+/-- Trace-aware workspace size `σᶜ(F) = b₀(F) + αᶜ(F)`. Unlike the generic `σ`, this
+    is **not** the vertex count for contraction quotients (`σᶜ ≠ #V`, MCB p. 66): a
+    trace leaf raises `#V` without raising `σᶜ`. -/
+def sigmaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := b₀ F + alphaC F
+
+@[simp] theorem sigmaC_zero : sigmaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
+@[simp] theorem sigmaC_cons (T : Nonplanar (α ⊕ β))
+    (F : Multiset (Nonplanar (α ⊕ β))) :
+    sigmaC (T ::ₘ F) = T.accCountC + 1 + sigmaC F := by
+  simp only [sigmaC, b₀_cons, alphaC_cons]; omega
+@[simp] theorem sigmaC_singleton (T : Nonplanar (α ⊕ β)) :
+    sigmaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC + 1 := by
+  simp only [sigmaC, b₀_singleton, alphaC_singleton]; omega
+@[simp] theorem sigmaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
+    sigmaC (F + G) = sigmaC F + sigmaC G := by
+  simp only [sigmaC, b₀_add, alphaC_add]; omega
+
+end Forest
+
+/-! ### The `σᶜ ≠ #V` caveat, concretely
+
+A lexical root over a single trace leaf: `#V = 2` (root + trace leaf) but the trace
+leaf contributes no accessible term, so `αᶜ = 0` and `σᶜ = 1`. -/
+
+namespace Nonplanar
+
+variable {α β : Type*}
+
+/-- Minimal contraction-quotient witness for the `σᶜ ≠ #V` caveat. -/
+private def traceWitness (a : α) (b : β) : Nonplanar (α ⊕ β) :=
+  Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inr b) []])
+
+example (a : α) (b : β) : (traceWitness a b).numNodes = 2 := rfl
+example (a : α) (b : β) : (traceWitness a b).traceLeafCount = 1 := rfl
+example (a : α) (b : β) : (traceWitness a b).accCountC = 0 := rfl
+
+/-- The trace leaf of `traceWitness` sits at depth 1, so `traceDepthSum = 1`. -/
+example (a : α) (b : β) : (traceWitness a b).traceDepthSum = 1 := rfl
+
+/-- A trace leaf two levels down contributes depth 2 to `traceDepthSum`. -/
+example (a a' : α) (b : β) :
+    Nonplanar.traceDepthSum
+      (Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inl a') [.node (Sum.inr b) []]])) = 2 := rfl
+
+/-- Two trace leaves at depths 1 and 2 sum to 3 — the multi-extraction additivity
+    `d_v = Σ d_{v_i}` of MCB rule 3. -/
+example (a a' : α) (b b' : β) :
+    Nonplanar.traceDepthSum
+      (Nonplanar.mk (.node (Sum.inl a)
+        [.node (Sum.inr b) [], .node (Sum.inl a') [.node (Sum.inr b') []]])) = 3 := rfl
+
+/-- `σᶜ` undercounts `#V` on the contraction quotient: the trace leaf is a vertex but
+    not an accessible term. -/
+example (a : α) (b : β) :
+    Forest.sigmaC ({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))) ≠
+      (({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))).map
+        Nonplanar.numNodes).sum := by
+  simp only [Forest.sigmaC, Forest.b₀_singleton, Forest.alphaC_singleton,
+    Multiset.map_singleton, Multiset.sum_singleton,
+    show (traceWitness a b).accCountC = 0 from rfl,
+    show (traceWitness a b).numNodes = 2 from rfl]
+  decide
+
+end Nonplanar
+
+end RootedTree

--- a/Linglib/Core/Data/Multiset/Antidiagonal.lean
+++ b/Linglib/Core/Data/Multiset/Antidiagonal.lean
@@ -23,9 +23,6 @@ multiplicities*; this file computes those multiplicities: `(u, v)` occurs
 `[UPSTREAM]` candidate; eventual mathlib home `Mathlib.Data.Multiset.Antidiagonal`, where
 the closed form also evaluates `Finsupp.antidiagonal'`.
 
-## Tags
-
-multiset, antidiagonal, count, binomial coefficient
 -/
 
 namespace Multiset

--- a/Linglib/Core/Data/Multiset/Powerset.lean
+++ b/Linglib/Core/Data/Multiset/Powerset.lean
@@ -29,9 +29,6 @@ unconditional induction hypothesis absorbs the `s ≰ t` boundary cases by
 `Nat.choose` vanishing. `[UPSTREAM]` candidate; eventual mathlib home
 `Mathlib.Data.Multiset.Powerset`.
 
-## Tags
-
-multiset, powerset, count, binomial coefficient
 -/
 
 namespace Multiset

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Combinatorics.RootedTree.Counting
 import Linglib.Core.Combinatorics.RootedTree.TraceCounting
+import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
 import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
 import Linglib.Core.Order.PullbackPreorder


### PR DESCRIPTION
Splits the generic marked-leaf layer from the MCB-interpreted measures, per the sibling-file precedent.

- `TraceCounting.lean` is now the generic half (2-colored leaf counting: `traceLeafCount`/`traceDepthSum`, equations, one shared `fold_perm` invariance, bounds), module doc on the house template; the five generic bounds previously injected into `RoseTree`'s namespace from `Coproduct/Conservation.lean` are repatriated.
- New `TraceMeasures.lean` holds the MCB layer (`accCountC` with new leaf equations and the `traceLeafCount_le_accCount` bridge, `alphaC`/`sigmaC`, the `σᶜ ≠ #V` witnesses); `leafCountSO0` (zero consumers, self-flagged UNVERIFIED semantics) is cut.
- Constructor simp grid completed (`traceLeafCount_node_cons`); false "one `fold_perm`" claim fixed by deriving `traceLeafCount_perm` from the paired fold.
- Housekeeping ridealongs: copyright header + Tags removal in `Counting.lean`; Tags/consumer-pointer removal in `Aut.lean`, `ContractUnary.lean`, and the Multiset keystones.