### PR TITLE
refactor(Core): generic discounted measures; TraceMeasures as shim

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Conservation.lean
@@ -511,7 +511,7 @@ theorem cutSummandsCN_accCountC_single (τ : Nonplanar (α ⊕ β) → β)
       ((cutSummandsCN_trunk_rootValue τ T p hp).trans hT_root)
   rw [hcard] at hw hl
   simp only [Multiset.map_singleton, Multiset.sum_singleton, Multiset.card_singleton] at hw hl
-  simp only [Nonplanar.accCountC, Nonplanar.accCount]
+  simp only [Nonplanar.accCountC_eq, Nonplanar.accCount]
   omega
 
 /-- **Two-cut accessible-term extraction** (MCB eq. 1.6.8 for a 2-edge admissible
@@ -542,7 +542,7 @@ theorem cutSummandsCN_accCountC_pair (τ : Nonplanar (α ⊕ β) → β)
   simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
     Multiset.map_singleton, Multiset.sum_singleton, Multiset.card_cons,
     Multiset.card_singleton] at hw hl
-  simp only [Nonplanar.accCountC, Nonplanar.accCount]
+  simp only [Nonplanar.accCountC_eq, Nonplanar.accCount]
   omega
 
 /-! ### Minimal-Search positivity (MCB Prop 1.5.1, Sideward direction) -/

--- a/Linglib/Core/Combinatorics/RootedTree/Counting.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Counting.lean
@@ -31,11 +31,7 @@ namespace RoseTree
 
 variable {α : Type*}
 
-/-! ### Leaf statistics by predicate
-
-Counts over the leaf projection (`Linglib.Core.Data.RoseTree.Leaves`): the count is
-`Multiset.countP`, the vertex bound is inherited from `Multiset.countP_le_card`, and
-`Perm`-descent is inherited from the projection's. -/
+/-! ### Leaf statistics by predicate -/
 
 /-- The number of leaves whose label satisfies `p`. -/
 def leafCountP (p : α → Prop) [DecidablePred p] (t : RoseTree α) : ℕ := t.leaves.countP p
@@ -215,6 +211,115 @@ theorem accCount_node_pair (a : α) (l r : Nonplanar α) :
     Multiset.sum_cons, Multiset.sum_singleton, ← accCount_add_one]
   omega
 
+
+/-! ### Leaf statistics by predicate, on the quotient -/
+
+/-- The number of leaves whose label satisfies `p`. -/
+def leafCountP (p : α → Prop) [DecidablePred p] : Nonplanar α → ℕ :=
+  Nonplanar.lift (RoseTree.leafCountP p) fun _ _ => RoseTree.leafCountP_perm p
+
+@[simp] theorem leafCountP_mk (p : α → Prop) [DecidablePred p] (t : RoseTree α) :
+    (mk t).leafCountP p = t.leafCountP p := rfl
+
+@[simp] theorem leafCountP_leaf (p : α → Prop) [DecidablePred p] (a : α) :
+    (leaf a : Nonplanar α).leafCountP p = if p a then 1 else 0 := by
+  show (mk (.node a [])).leafCountP p = _
+  rw [leafCountP_mk, RoseTree.leafCountP_leaf]
+
+/-- A root failing `p` contributes nothing: the count is the children's total. -/
+theorem leafCountP_node_of_not (p : α → Prop) [DecidablePred p] (a : α)
+    (F : Multiset (Nonplanar α)) (h : ¬p a) :
+    (Nonplanar.node a F).leafCountP p = (F.map (Nonplanar.leafCountP p)).sum := by
+  refine Quotient.inductionOn F fun lst => ?_
+  show (mk (.node a (lst.map Quotient.out))).leafCountP p = _
+  rw [leafCountP_mk, RoseTree.leafCountP_node_of_not p a _ h, List.map_map]
+  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
+  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
+  show (mk (Quotient.out t)).leafCountP p = Nonplanar.leafCountP p t
+  exact congrArg (Nonplanar.leafCountP p) (Quotient.out_eq t)
+
+/-- The sum of root-distances of the leaves whose label satisfies `p`. -/
+def leafDepthSumP (p : α → Prop) [DecidablePred p] : Nonplanar α → ℕ :=
+  Nonplanar.lift (RoseTree.leafDepthSumP p) fun _ _ => RoseTree.leafDepthSumP_perm p
+
+@[simp] theorem leafDepthSumP_mk (p : α → Prop) [DecidablePred p] (t : RoseTree α) :
+    (mk t).leafDepthSumP p = t.leafDepthSumP p := rfl
+
+@[simp] theorem leafDepthSumP_leaf (p : α → Prop) [DecidablePred p] (a : α) :
+    (leaf a : Nonplanar α).leafDepthSumP p = 0 := by
+  show (mk (.node a [])).leafDepthSumP p = _
+  rw [leafDepthSumP_mk, RoseTree.leafDepthSumP_leaf]
+
+/-- Each child contributes its own depth-weighted count plus one per counted leaf it
+    carries. -/
+@[simp] theorem leafDepthSumP_node (p : α → Prop) [DecidablePred p] (a : α)
+    (F : Multiset (Nonplanar α)) :
+    (Nonplanar.node a F).leafDepthSumP p
+      = (F.map fun c => c.leafDepthSumP p + c.leafCountP p).sum := by
+  refine Quotient.inductionOn F fun lst => ?_
+  show (mk (.node a (lst.map Quotient.out))).leafDepthSumP p = _
+  rw [leafDepthSumP_mk, RoseTree.leafDepthSumP_node, List.map_map]
+  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
+  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
+  show RoseTree.leafDepthSumP p (Quotient.out t) + RoseTree.leafCountP p (Quotient.out t)
+      = Nonplanar.leafDepthSumP p t + Nonplanar.leafCountP p t
+  congr 1
+  · exact congrArg (Nonplanar.leafDepthSumP p) (Quotient.out_eq t)
+  · exact congrArg (Nonplanar.leafCountP p) (Quotient.out_eq t)
+
+/-- A root failing `p` is an uncounted vertex, so the count is strict. -/
+theorem leafCountP_lt_numNodes_of_not_root (p : α → Prop) [DecidablePred p]
+    (t : Nonplanar α) (h : ¬p t.rootValue) : t.leafCountP p < t.numNodes := by
+  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree α, t = Nonplanar.mk t₀ :=
+    ⟨t.out, (Quotient.out_eq t).symm⟩
+  rw [Nonplanar.rootValue_mk] at h
+  cases t₀ with
+  | node x cs =>
+    rw [RoseTree.value_node] at h
+    rw [Nonplanar.leafCountP_mk, Nonplanar.numNodes_mk]
+    exact RoseTree.leafCountP_lt_numNodes_of_not p x cs h
+
+/-- A root failing `p` puts every counted leaf at depth ≥ 1. -/
+theorem leafCountP_le_leafDepthSumP_of_not_root (p : α → Prop) [DecidablePred p]
+    (t : Nonplanar α) (h : ¬p t.rootValue) : t.leafCountP p ≤ t.leafDepthSumP p := by
+  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree α, t = Nonplanar.mk t₀ :=
+    ⟨t.out, (Quotient.out_eq t).symm⟩
+  rw [Nonplanar.rootValue_mk] at h
+  cases t₀ with
+  | node x cs =>
+    rw [RoseTree.value_node] at h
+    rw [Nonplanar.leafCountP_mk, Nonplanar.leafDepthSumP_mk]
+    exact RoseTree.leafCountP_le_leafDepthSumP_of_not p x cs h
+
+/-! ### Discounted accessible-term count -/
+
+/-- Non-root vertices, discounting the `p`-leaves. Truncated subtraction covers the
+    single-`p`-leaf tree, whose root is its one leaf. -/
+def accCountP (p : α → Prop) [DecidablePred p] (t : Nonplanar α) : ℕ :=
+  t.accCount - t.leafCountP p
+
+/-- Counted leaves are among the non-root vertices whenever some vertex is uncounted. -/
+theorem leafCountP_le_accCount (p : α → Prop) [DecidablePred p] (t : Nonplanar α)
+    (h : t.leafCountP p < t.numNodes) : t.leafCountP p ≤ t.accCount := by
+  rw [Nonplanar.accCount_eq_numNodes_sub_one]
+  omega
+
+/-- Adjoining a root (not counted by `p`) above a pair adds two discounted
+    accessible terms. -/
+theorem accCountP_node_pair (p : α → Prop) [DecidablePred p] (a : α)
+    (l r : Nonplanar α) (hpa : ¬p a)
+    (hl : l.leafCountP p < l.numNodes) (hr : r.leafCountP p < r.numNodes) :
+    (Nonplanar.node a {l, r}).accCountP p = l.accCountP p + r.accCountP p + 2 := by
+  have hw := Nonplanar.accCount_node_pair a l r
+  have htl : (Nonplanar.node a {l, r}).leafCountP p = l.leafCountP p + r.leafCountP p := by
+    rw [leafCountP_node_of_not p a _ hpa]
+    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
+      Multiset.map_singleton, Multiset.sum_singleton]
+  have hbl := leafCountP_le_accCount p l hl
+  have hbr := leafCountP_le_accCount p r hr
+  simp only [accCountP, htl, hw]
+  omega
+
 end Nonplanar
 
 /-! ### Forest measures -/
@@ -270,6 +375,40 @@ theorem sigma_eq_sum_numNodes (F : Multiset (Nonplanar α)) :
   induction F using Multiset.induction with
   | empty => rfl
   | cons T F ih => rw [sigma_cons, ih, Multiset.map_cons, Multiset.sum_cons]
+
+
+/-- Discounted accessible terms across a forest. -/
+def alphaP (p : α → Prop) [DecidablePred p] (F : Multiset (Nonplanar α)) : ℕ :=
+  (F.map (Nonplanar.accCountP p)).sum
+
+@[simp] theorem alphaP_zero (p : α → Prop) [DecidablePred p] :
+    alphaP p (0 : Multiset (Nonplanar α)) = 0 := rfl
+@[simp] theorem alphaP_cons (p : α → Prop) [DecidablePred p] (T : Nonplanar α)
+    (F : Multiset (Nonplanar α)) : alphaP p (T ::ₘ F) = T.accCountP p + alphaP p F := by
+  simp only [alphaP, Multiset.map_cons, Multiset.sum_cons]
+@[simp] theorem alphaP_singleton (p : α → Prop) [DecidablePred p] (T : Nonplanar α) :
+    alphaP p ({T} : Multiset (Nonplanar α)) = T.accCountP p := by
+  simp only [alphaP, Multiset.map_singleton, Multiset.sum_singleton]
+@[simp] theorem alphaP_add (p : α → Prop) [DecidablePred p]
+    (F G : Multiset (Nonplanar α)) : alphaP p (F + G) = alphaP p F + alphaP p G := by
+  simp only [alphaP, Multiset.map_add, Multiset.sum_add]
+
+/-- Discounted forest size: components plus discounted accessible terms. Unlike
+    `sigma`, this is not the vertex count when counted leaves exist. -/
+def sigmaP (p : α → Prop) [DecidablePred p] (F : Multiset (Nonplanar α)) : ℕ :=
+  b₀ F + alphaP p F
+
+@[simp] theorem sigmaP_zero (p : α → Prop) [DecidablePred p] :
+    sigmaP p (0 : Multiset (Nonplanar α)) = 0 := rfl
+@[simp] theorem sigmaP_cons (p : α → Prop) [DecidablePred p] (T : Nonplanar α)
+    (F : Multiset (Nonplanar α)) : sigmaP p (T ::ₘ F) = T.accCountP p + 1 + sigmaP p F := by
+  simp only [sigmaP, b₀_cons, alphaP_cons]; omega
+@[simp] theorem sigmaP_singleton (p : α → Prop) [DecidablePred p] (T : Nonplanar α) :
+    sigmaP p ({T} : Multiset (Nonplanar α)) = T.accCountP p + 1 := by
+  simp only [sigmaP, b₀_singleton, alphaP_singleton]; omega
+@[simp] theorem sigmaP_add (p : α → Prop) [DecidablePred p]
+    (F G : Multiset (Nonplanar α)) : sigmaP p (F + G) = sigmaP p F + sigmaP p G := by
+  simp only [sigmaP, b₀_add, alphaP_add]; omega
 
 end Forest
 

--- a/Linglib/Core/Combinatorics/RootedTree/TraceMeasures.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/TraceMeasures.lean
@@ -6,34 +6,21 @@ Authors: Robert Hawkins
 import Linglib.Core.Combinatorics.RootedTree.Counting
 
 /-!
-# Trace-aware size measures on the contraction-quotient carrier
+# Trace vocabulary for the leaf statistics
 [marcolli-chomsky-berwick-2025]
 
-The MCB size measures on `Nonplanar (α ⊕ β)`, where `Sum.inl` vertices carry lexical
-decorations and `Sum.inr` vertices are trace-marker placeholders left by the Δ^c
-coproduct. A trace leaf is a vertex but **not** an accessible term, so the trace-aware
-counts subtract the marked-leaf count off the generic measures — and the trace-free
-identity `σ = #V` fails on contraction quotients (`σᶜ ≠ #V`, MCB p. 66), witnessed
-concretely at the end of the file.
+One-line specializations of the generic leaf statistics and discounted measures
+(`leafCountP`, `leafDepthSumP`, `accCountP`, `alphaP`, `sigmaP`) at the trace-marker
+color class `Sum.isRight`, under MCB's names (`traceLeafCount`, `traceDepthSum`,
+`accCountC`, `alphaC`, `sigmaC`). No independent content.
 
-## Main definitions
-
-* `RoseTree.traceLeafCount` / `RoseTree.traceDepthSum` (with `Nonplanar` descents): the
-  marker statistics, `leafCountP`/`leafDepthSumP` at the `Sum.isRight` color class.
-* `Nonplanar.accCountC`: trace-excluding accessible-term count `α − #traceLeaves`.
-* `Forest.alphaC` / `Forest.sigmaC`: the trace-aware workspace measures.
-
-## Main results
-
-* `Nonplanar.accCountC_merge`: External Merge adds two accessible terms in the
-  trace-aware count (MCB Lemma 1.6.3, eq. 1.6.5).
+This file is domain vocabulary and moves out of `Core/` together with the MCB layer of
+`Coproduct/Conservation.lean`, which consumes it from the algebra layer.
 -/
 
 namespace RoseTree
 
 variable {α β : Type*}
-
-/-! ### Trace statistics: `leafCountP`/`leafDepthSumP` at the marker color class -/
 
 /-- The number of `Sum.inr`-labeled (trace-marker) leaves in a tree. -/
 def traceLeafCount (t : RoseTree (α ⊕ β)) : ℕ := leafCountP (·.isRight = true) t
@@ -49,8 +36,6 @@ def traceDepthSum (t : RoseTree (α ⊕ β)) : ℕ := leafDepthSumP (·.isRight 
     traceLeafCount (.node (Sum.inl a) [] : RoseTree (α ⊕ β)) = 0 := by
   simp [traceLeafCount]
 
-/-- On a non-leaf node, `traceLeafCount` is the sum of the children's counts,
-    regardless of the root label's `Sum`-side. -/
 theorem traceLeafCount_node_of_ne_nil (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β)))
     (h : cs ≠ []) : traceLeafCount (.node v cs) = (cs.map traceLeafCount).sum :=
   leafCountP_node_of_ne_nil _ v cs h
@@ -60,8 +45,6 @@ theorem traceLeafCount_node_of_ne_nil (v : α ⊕ β) (cs : List (RoseTree (α �
     traceLeafCount (.node v (c :: cs)) = ((c :: cs).map traceLeafCount).sum :=
   leafCountP_node_cons _ v c cs
 
-/-- On a `Sum.inl` root the count is just the children's total (the root is never
-    itself a trace leaf), for any child list. -/
 @[simp] theorem traceLeafCount_node_inl (a : α) (cs : List (RoseTree (α ⊕ β))) :
     traceLeafCount (.node (Sum.inl a) cs) = (cs.map traceLeafCount).sum :=
   leafCountP_node_of_not _ _ cs (by simp)
@@ -74,41 +57,32 @@ theorem traceLeafCount_node_of_ne_nil (v : α ⊕ β) (cs : List (RoseTree (α �
     traceDepthSum (.node (Sum.inr b) [] : RoseTree (α ⊕ β)) = 0 :=
   leafDepthSumP_leaf _ _
 
-/-- Each child contributes its own trace-depth plus one per trace leaf it carries. -/
 @[simp] theorem traceDepthSum_node (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β))) :
     traceDepthSum (.node v cs)
       = (cs.map fun c => traceDepthSum c + traceLeafCount c).sum :=
   leafDepthSumP_node _ v cs
 
-/-- `traceLeafCount` is a `Perm`-invariant. -/
 theorem traceLeafCount_perm {t s : RoseTree (α ⊕ β)} (h : Perm t s) :
     t.traceLeafCount = s.traceLeafCount :=
   leafCountP_perm _ h
 
-/-- `traceDepthSum` is a `Perm`-invariant. -/
 theorem traceDepthSum_perm {t s : RoseTree (α ⊕ β)} (h : Perm t s) :
     t.traceDepthSum = s.traceDepthSum :=
   leafDepthSumP_perm _ h
 
-/-- The children's trace leaves are bounded by the node's. -/
 theorem traceLeafCount_le_node (v : α ⊕ β) (cs : List (RoseTree (α ⊕ β))) :
     (cs.map traceLeafCount).sum ≤ traceLeafCount (.node v cs) :=
   sum_map_leafCountP_le_node _ v cs
 
-/-- A trace leaf is a vertex. -/
 theorem traceLeafCount_le_numNodes (t : RoseTree (α ⊕ β)) :
     t.traceLeafCount ≤ t.numNodes :=
   leafCountP_le_numNodes _ t
 
-/-- A `Sum.inl`-rooted tree has a non-trace vertex (its root), so its trace leaves
-    number strictly fewer than its vertices. -/
 theorem traceLeafCount_lt_numNodes_of_inl (a : α) (cs : List (RoseTree (α ⊕ β))) :
     traceLeafCount (RoseTree.node (Sum.inl a) cs) <
       numNodes (RoseTree.node (Sum.inl a) cs) :=
   leafCountP_lt_numNodes_of_not _ _ cs (by simp)
 
-/-- A `Sum.inl` root puts every trace leaf at depth ≥ 1, so the depth-weighted count
-    dominates the plain count. -/
 theorem traceLeafCount_le_traceDepthSum_of_inl (a : α) (cs : List (RoseTree (α ⊕ β))) :
     traceLeafCount (.node (Sum.inl a) cs) ≤ traceDepthSum (.node (Sum.inl a) cs) :=
   leafCountP_le_leafDepthSumP_of_not _ _ cs (by simp)
@@ -119,216 +93,117 @@ namespace RootedTree
 
 namespace Nonplanar
 
-variable {α β : Type*} (a : α) (b : β)
+variable {α β : Type*}
 
-/-- The number of `Sum.inr`-labeled (marked) leaves of a nonplanar tree. -/
-def traceLeafCount : Nonplanar (α ⊕ β) → ℕ :=
-  Nonplanar.lift RoseTree.traceLeafCount fun _ _ => RoseTree.traceLeafCount_perm
+/-- The number of `Sum.inr`-labeled (trace-marker) leaves of a nonplanar tree. -/
+def traceLeafCount : Nonplanar (α ⊕ β) → ℕ := leafCountP (·.isRight = true)
 
 @[simp] theorem traceLeafCount_mk (t : RoseTree (α ⊕ β)) :
     (mk t).traceLeafCount = t.traceLeafCount := rfl
 
-@[simp] theorem traceLeafCount_leaf_inl :
-    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceLeafCount = 0 := rfl
+@[simp] theorem traceLeafCount_leaf_inl (a : α) :
+    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceLeafCount = 0 := by
+  simp [traceLeafCount]
 
-@[simp] theorem traceLeafCount_leaf_inr :
-    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceLeafCount = 1 := rfl
+@[simp] theorem traceLeafCount_leaf_inr (b : β) :
+    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceLeafCount = 1 := by
+  simp [traceLeafCount]
 
-/-- Marked leaves of a `Sum.inl`-rooted node: the root contributes none, so the count
-    is the children's total. -/
-@[simp] theorem traceLeafCount_node_inl (F : Multiset (Nonplanar (α ⊕ β))) :
-    (Nonplanar.node (Sum.inl a) F).traceLeafCount = (F.map Nonplanar.traceLeafCount).sum := by
-  refine Quotient.inductionOn F fun lst => ?_
-  show (mk (.node (Sum.inl a) (lst.map Quotient.out))).traceLeafCount = _
-  rw [traceLeafCount_mk, RoseTree.traceLeafCount_node_inl, List.map_map]
-  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
-  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
-  show (mk (Quotient.out t)).traceLeafCount = Nonplanar.traceLeafCount t
-  exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
+@[simp] theorem traceLeafCount_node_inl (a : α) (F : Multiset (Nonplanar (α ⊕ β))) :
+    (Nonplanar.node (Sum.inl a) F).traceLeafCount
+      = (F.map Nonplanar.traceLeafCount).sum :=
+  leafCountP_node_of_not _ _ F (by simp)
 
-/-- The depth-weighted marked-leaf count of a nonplanar tree. For a Δ^c cut this reads
-    off the total extraction depth of the quotient — see the consumers in
-    `Coproduct/Conservation.lean`. -/
-def traceDepthSum : Nonplanar (α ⊕ β) → ℕ :=
-  Nonplanar.lift RoseTree.traceDepthSum fun _ _ => RoseTree.traceDepthSum_perm
+/-- The depth-weighted trace-marker count of a nonplanar tree. -/
+def traceDepthSum : Nonplanar (α ⊕ β) → ℕ := leafDepthSumP (·.isRight = true)
 
 @[simp] theorem traceDepthSum_mk (t : RoseTree (α ⊕ β)) :
     (mk t).traceDepthSum = t.traceDepthSum := rfl
 
-@[simp] theorem traceDepthSum_leaf_inl :
-    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := rfl
+@[simp] theorem traceDepthSum_leaf_inl (a : α) :
+    (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := by
+  simp [traceDepthSum]
 
-@[simp] theorem traceDepthSum_leaf_inr :
-    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := rfl
+@[simp] theorem traceDepthSum_leaf_inr (b : β) :
+    (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).traceDepthSum = 0 := by
+  simp [traceDepthSum]
 
-/-- Each child contributes its own depth-weighted count plus one per marked leaf it
-    carries. -/
-@[simp] theorem traceDepthSum_node_inl (F : Multiset (Nonplanar (α ⊕ β))) :
+@[simp] theorem traceDepthSum_node_inl (a : α) (F : Multiset (Nonplanar (α ⊕ β))) :
     (Nonplanar.node (Sum.inl a) F).traceDepthSum
-      = (F.map (fun c => c.traceDepthSum + c.traceLeafCount)).sum := by
-  refine Quotient.inductionOn F fun lst => ?_
-  show (mk (.node (Sum.inl a) (lst.map Quotient.out))).traceDepthSum = _
-  rw [traceDepthSum_mk, RoseTree.traceDepthSum_node, List.map_map]
-  simp only [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.sum_coe]
-  refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
-  show RoseTree.traceDepthSum (Quotient.out t) + RoseTree.traceLeafCount (Quotient.out t)
-      = Nonplanar.traceDepthSum t + Nonplanar.traceLeafCount t
-  congr 1
-  · exact congrArg Nonplanar.traceDepthSum (Quotient.out_eq t)
-  · exact congrArg Nonplanar.traceLeafCount (Quotient.out_eq t)
+      = (F.map (fun c => c.traceDepthSum + c.traceLeafCount)).sum :=
+  leafDepthSumP_node _ _ F
 
-/-- A `Sum.inl`-rooted nonplanar tree has an unmarked vertex (its root), so its marked
-    leaves number strictly fewer than its vertices. -/
 theorem traceLeafCount_lt_numNodes_of_rootInl (t : Nonplanar (α ⊕ β)) (x : α)
-    (h : t.rootValue = Sum.inl x) : t.traceLeafCount < t.numNodes := by
-  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
-    ⟨t.out, (Quotient.out_eq t).symm⟩
-  rw [Nonplanar.rootValue_mk] at h
-  cases t₀ with
-  | node x cs =>
-    rw [RoseTree.value_node] at h
-    subst h
-    rw [Nonplanar.traceLeafCount_mk, Nonplanar.numNodes_mk]
-    exact RoseTree.traceLeafCount_lt_numNodes_of_inl x cs
+    (h : t.rootValue = Sum.inl x) : t.traceLeafCount < t.numNodes :=
+  leafCountP_lt_numNodes_of_not_root _ t (by rw [h]; simp)
 
-/-- A `Sum.inl`-rooted nonplanar tree puts every marked leaf at depth ≥ 1, so its
-    depth-weighted count dominates its plain count. -/
 theorem traceLeafCount_le_traceDepthSum_of_rootInl (t : Nonplanar (α ⊕ β)) (x : α)
-    (h : t.rootValue = Sum.inl x) : t.traceLeafCount ≤ t.traceDepthSum := by
-  obtain ⟨t₀, rfl⟩ : ∃ t₀ : RoseTree (α ⊕ β), t = Nonplanar.mk t₀ :=
-    ⟨t.out, (Quotient.out_eq t).symm⟩
-  rw [Nonplanar.rootValue_mk] at h
-  cases t₀ with
-  | node x cs =>
-    rw [RoseTree.value_node] at h
-    subst h
-    rw [Nonplanar.traceLeafCount_mk, Nonplanar.traceDepthSum_mk]
-    exact RoseTree.traceLeafCount_le_traceDepthSum_of_inl x cs
+    (h : t.rootValue = Sum.inl x) : t.traceLeafCount ≤ t.traceDepthSum :=
+  leafCountP_le_leafDepthSumP_of_not_root _ t (by rw [h]; simp)
 
-/-- The **trace-excluding accessible-term count** `αᶜ(T) = α(T) − #traceLeaves(T)`:
-    a trace leaf is a vertex but not an accessible term (MCB p. 66). Truncated
-    subtraction handles the all-trace edge case. -/
-def accCountC (t : Nonplanar (α ⊕ β)) : ℕ := t.accCount - t.traceLeafCount
+/-- The trace-excluding accessible-term count `αᶜ(T) = α(T) − #traceLeaves(T)`. -/
+def accCountC : Nonplanar (α ⊕ β) → ℕ := accCountP (·.isRight = true)
 
-@[simp] theorem accCountC_leaf_inl :
+@[simp] theorem accCountC_leaf_inl (a : α) :
     (leaf (Sum.inl a) : Nonplanar (α ⊕ β)).accCountC = 0 := rfl
 
-/-- The truncation case: a bare trace leaf has `α = 0` but one marked leaf. -/
-@[simp] theorem accCountC_leaf_inr :
+@[simp] theorem accCountC_leaf_inr (b : β) :
     (leaf (Sum.inr b) : Nonplanar (α ⊕ β)).accCountC = 0 := rfl
 
-/-- The marked leaves of a tree are among its non-root vertices whenever the root is
-    unmarked. -/
-theorem traceLeafCount_le_accCount (t : Nonplanar (α ⊕ β))
-    (h : t.traceLeafCount < t.numNodes) : t.traceLeafCount ≤ t.accCount := by
-  rw [Nonplanar.accCount_eq_numNodes_sub_one]
-  omega
+theorem accCountC_eq (t : Nonplanar (α ⊕ β)) :
+    t.accCountC = t.accCount - t.traceLeafCount := rfl
 
-/-- External Merge adds two accessible terms in the trace-aware count: the two
-    children's roots become accessible (MCB Lemma 1.6.3, eq. 1.6.5). Needs each child
-    to have a lexical vertex (`traceLeafCount < numNodes`), automatic for a real
-    syntactic object. -/
-theorem accCountC_merge (l r : Nonplanar (α ⊕ β))
+theorem traceLeafCount_le_accCount (t : Nonplanar (α ⊕ β))
+    (h : t.traceLeafCount < t.numNodes) : t.traceLeafCount ≤ t.accCount :=
+  leafCountP_le_accCount _ t h
+
+/-- External Merge adds two accessible terms in the trace-aware count
+    (MCB Lemma 1.6.3, eq. 1.6.5). -/
+theorem accCountC_merge (a : α) (l r : Nonplanar (α ⊕ β))
     (hl : l.traceLeafCount < l.numNodes) (hr : r.traceLeafCount < r.numNodes) :
-    (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 := by
-  have hw := Nonplanar.accCount_node_pair (Sum.inl a) l r
-  have htl : (Nonplanar.node (Sum.inl a) {l, r}).traceLeafCount
-      = l.traceLeafCount + r.traceLeafCount := by
-    rw [traceLeafCount_node_inl]
-    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.sum_cons,
-      Multiset.map_singleton, Multiset.sum_singleton]
-  have hbl := l.traceLeafCount_le_accCount hl
-  have hbr := r.traceLeafCount_le_accCount hr
-  simp only [accCountC, htl, hw]
-  omega
+    (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 :=
+  accCountP_node_pair _ _ l r (by simp) hl hr
 
 end Nonplanar
-
-/-! ### Trace-aware workspace (forest) measures -/
 
 namespace Forest
 
 variable {α β : Type*}
 
 /-- Trace-excluding accessible terms across a workspace, `αᶜ(F) = Σ αᶜ(Tᵢ)`. -/
-def alphaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ :=
-  (F.map Nonplanar.accCountC).sum
+def alphaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := alphaP (·.isRight = true) F
+
+theorem alphaC_eq (F : Multiset (Nonplanar (α ⊕ β))) :
+    alphaC F = (F.map Nonplanar.accCountC).sum := rfl
 
 @[simp] theorem alphaC_zero : alphaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
-@[simp] theorem alphaC_cons (T : Nonplanar (α ⊕ β))
-    (F : Multiset (Nonplanar (α ⊕ β))) :
-    alphaC (T ::ₘ F) = T.accCountC + alphaC F := by
-  simp only [alphaC, Multiset.map_cons, Multiset.sum_cons]
+@[simp] theorem alphaC_cons (T : Nonplanar (α ⊕ β)) (F : Multiset (Nonplanar (α ⊕ β))) :
+    alphaC (T ::ₘ F) = T.accCountC + alphaC F :=
+  alphaP_cons _ T F
 @[simp] theorem alphaC_singleton (T : Nonplanar (α ⊕ β)) :
-    alphaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC := by
-  simp only [alphaC, Multiset.map_singleton, Multiset.sum_singleton]
+    alphaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC :=
+  alphaP_singleton _ T
 @[simp] theorem alphaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
-    alphaC (F + G) = alphaC F + alphaC G := by
-  simp only [alphaC, Multiset.map_add, Multiset.sum_add]
+    alphaC (F + G) = alphaC F + alphaC G :=
+  alphaP_add _ F G
 
-/-- Trace-aware workspace size `σᶜ(F) = b₀(F) + αᶜ(F)`. Unlike the generic `σ`, this
-    is **not** the vertex count for contraction quotients (`σᶜ ≠ #V`, MCB p. 66): a
-    trace leaf raises `#V` without raising `σᶜ`. -/
-def sigmaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := b₀ F + alphaC F
+/-- Trace-aware workspace size `σᶜ(F) = b₀(F) + αᶜ(F)`; not the vertex count for
+    contraction quotients (`σᶜ ≠ #V`, MCB p. 66). -/
+def sigmaC (F : Multiset (Nonplanar (α ⊕ β))) : ℕ := sigmaP (·.isRight = true) F
+
+theorem sigmaC_eq (F : Multiset (Nonplanar (α ⊕ β))) : sigmaC F = b₀ F + alphaC F := rfl
 
 @[simp] theorem sigmaC_zero : sigmaC (0 : Multiset (Nonplanar (α ⊕ β))) = 0 := rfl
-@[simp] theorem sigmaC_cons (T : Nonplanar (α ⊕ β))
-    (F : Multiset (Nonplanar (α ⊕ β))) :
-    sigmaC (T ::ₘ F) = T.accCountC + 1 + sigmaC F := by
-  simp only [sigmaC, b₀_cons, alphaC_cons]; omega
+@[simp] theorem sigmaC_cons (T : Nonplanar (α ⊕ β)) (F : Multiset (Nonplanar (α ⊕ β))) :
+    sigmaC (T ::ₘ F) = T.accCountC + 1 + sigmaC F :=
+  sigmaP_cons _ T F
 @[simp] theorem sigmaC_singleton (T : Nonplanar (α ⊕ β)) :
-    sigmaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC + 1 := by
-  simp only [sigmaC, b₀_singleton, alphaC_singleton]; omega
+    sigmaC ({T} : Multiset (Nonplanar (α ⊕ β))) = T.accCountC + 1 :=
+  sigmaP_singleton _ T
 @[simp] theorem sigmaC_add (F G : Multiset (Nonplanar (α ⊕ β))) :
-    sigmaC (F + G) = sigmaC F + sigmaC G := by
-  simp only [sigmaC, b₀_add, alphaC_add]; omega
+    sigmaC (F + G) = sigmaC F + sigmaC G :=
+  sigmaP_add _ F G
 
 end Forest
-
-/-! ### The `σᶜ ≠ #V` caveat, concretely
-
-A lexical root over a single trace leaf: `#V = 2` (root + trace leaf) but the trace
-leaf contributes no accessible term, so `αᶜ = 0` and `σᶜ = 1`. -/
-
-namespace Nonplanar
-
-variable {α β : Type*}
-
-/-- Minimal contraction-quotient witness for the `σᶜ ≠ #V` caveat. -/
-private def traceWitness (a : α) (b : β) : Nonplanar (α ⊕ β) :=
-  Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inr b) []])
-
-example (a : α) (b : β) : (traceWitness a b).numNodes = 2 := rfl
-example (a : α) (b : β) : (traceWitness a b).traceLeafCount = 1 := rfl
-example (a : α) (b : β) : (traceWitness a b).accCountC = 0 := rfl
-
-/-- The trace leaf of `traceWitness` sits at depth 1, so `traceDepthSum = 1`. -/
-example (a : α) (b : β) : (traceWitness a b).traceDepthSum = 1 := rfl
-
-/-- A trace leaf two levels down contributes depth 2 to `traceDepthSum`. -/
-example (a a' : α) (b : β) :
-    Nonplanar.traceDepthSum
-      (Nonplanar.mk (.node (Sum.inl a) [.node (Sum.inl a') [.node (Sum.inr b) []]])) = 2 := rfl
-
-/-- Two trace leaves at depths 1 and 2 sum to 3 — the multi-extraction additivity
-    `d_v = Σ d_{v_i}` of MCB rule 3. -/
-example (a a' : α) (b b' : β) :
-    Nonplanar.traceDepthSum
-      (Nonplanar.mk (.node (Sum.inl a)
-        [.node (Sum.inr b) [], .node (Sum.inl a') [.node (Sum.inr b') []]])) = 3 := rfl
-
-/-- `σᶜ` undercounts `#V` on the contraction quotient: the trace leaf is a vertex but
-    not an accessible term. -/
-example (a : α) (b : β) :
-    Forest.sigmaC ({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))) ≠
-      (({traceWitness a b} : Multiset (Nonplanar (α ⊕ β))).map
-        Nonplanar.numNodes).sum := by
-  simp only [Forest.sigmaC, Forest.b₀_singleton, Forest.alphaC_singleton,
-    Multiset.map_singleton, Multiset.sum_singleton,
-    show (traceWitness a b).accCountC = 0 from rfl,
-    show (traceWitness a b).numNodes = 2 from rfl]
-  decide
-
-end Nonplanar
 
 end RootedTree

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -141,7 +141,7 @@ theorem im_pair_size_deltas_contraction (lbl : α) {T β_t Q : Nonplanar (α ⊕
   · rw [Forest.alphaC_singleton, Forest.alphaC_singleton,
         Nonplanar.accCountC_merge lbl β_t Q hβ hQ]
     omega
-  · simp only [Forest.sigmaC, Forest.b₀_singleton, Forest.alphaC_singleton]
+  · simp only [Forest.sigmaC_eq, Forest.b₀_singleton, Forest.alphaC_singleton]
     rw [Nonplanar.accCountC_merge lbl β_t Q hβ hQ]
     omega
 


### PR DESCRIPTION
Completes the Core-purity move for the leaf-measure layer: all substance is now predicate-generic in `Counting.lean` — `Nonplanar` lifts of `leafCountP`/`leafDepthSumP` with node equations and root-condition bounds, plus the discounted measures `accCountP`/`alphaP`/`sigmaP` with their grids — and `TraceMeasures.lean` reduces to a one-line `Sum.isRight` specialization shim with no independent content, flagged to move out of `Core/` together with `Conservation.lean`'s MCB layer (which still consumes the trace vocabulary from the algebra layer). Consumers keep their surface via `_eq` rfl-bridges where they previously unfolded definitions.