### PR TITLE
chore(Syntax/Minimalist): MCB measures and conservation exit Core

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -16,10 +16,8 @@ import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorizationSemiring
 import Linglib.Core.Algebra.RootedTree.BirkhoffLaurent
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
-import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
 import Linglib.Core.Algebra.RootedTree.Coproduct.CutAvoidingNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.Defs
-import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.GenericNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
@@ -61,7 +59,6 @@ import Linglib.Core.Combinatorics.RootedTree.ContractUnary
 import Linglib.Core.Data.RoseTree.DecEq
 import Linglib.Core.Data.RoseTree.Nonplanar
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNonplanar
-import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
 import Linglib.Core.Computability.Lens
 import Linglib.Core.Computability.ContextFreeGrammar.Closure
 import Linglib.Core.Computability.ContextFreeGrammar.InterRegular
@@ -2923,6 +2920,9 @@ import Linglib.Syntax.Minimalist.Verbal.Decomposition
 import Linglib.Syntax.Minimalist.Verbal.SmallClause
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Syntax.Minimalist.Workspace.Basic
+import Linglib.Syntax.Minimalist.Workspace.Conservation
+import Linglib.Syntax.Minimalist.Workspace.DeletionConservation
+import Linglib.Syntax.Minimalist.Workspace.TraceMeasures
 import Linglib.Syntax.Negation
 import Linglib.Syntax.NullSubject
 import Linglib.Syntax.Numeral.Basic

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Minimalist.Merge.Basic
 import Linglib.Syntax.Minimalist.Defs
-import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
+import Linglib.Syntax.Minimalist.Workspace.DeletionConservation
 import Linglib.Core.Algebra.RootedTree.Coproduct.CutAvoidingNonplanar
 import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
 import Linglib.Core.Data.RoseTree.DecEq

--- a/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Minimalist.Merge.Basic
 import Linglib.Core.Algebra.RootedTree.Coproduct.GenericNonplanar
-import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
+import Linglib.Syntax.Minimalist.Workspace.Conservation
 
 set_option autoImplicit false
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -1,7 +1,7 @@
 import Linglib.Core.Data.RoseTree.Count
-import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
-import Linglib.Core.Algebra.RootedTree.Coproduct.Conservation
-import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionConservation
+import Linglib.Syntax.Minimalist.Workspace.TraceMeasures
+import Linglib.Syntax.Minimalist.Workspace.Conservation
+import Linglib.Syntax.Minimalist.Workspace.DeletionConservation
 import Linglib.Core.Order.PullbackPreorder
 import Mathlib.Order.OrderDual
 

--- a/Linglib/Syntax/Minimalist/Workspace/Conservation.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Conservation.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
-import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
+import Linglib.Syntax.Minimalist.Workspace.TraceMeasures
 
 set_option autoImplicit false
 

--- a/Linglib/Syntax/Minimalist/Workspace/DeletionConservation.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/DeletionConservation.lean
@@ -2,7 +2,7 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 import Linglib.Core.Combinatorics.RootedTree.ContractUnary
 import Linglib.Core.Data.RoseTree.Count
-import Linglib.Core.Combinatorics.RootedTree.TraceMeasures
+import Linglib.Syntax.Minimalist.Workspace.TraceMeasures
 
 /-!
 # Vertex conservation for the Δ^ρ / Δᵈ (deletion) cut enumeration

--- a/Linglib/Syntax/Minimalist/Workspace/TraceMeasures.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/TraceMeasures.lean
@@ -15,8 +15,9 @@ MCB's vocabulary over the generic measures of `Counting.lean`: the letter names
 the trace-marker color class `Sum.isRight` (`traceLeafCount`, `traceDepthSum`,
 `accCountC`, `alphaC`, `sigmaC`).
 
-This file is domain vocabulary and moves out of `Core/` together with the MCB layer of
-`Coproduct/Conservation.lean`, which consumes it from the algebra layer.
+Domain vocabulary over the generic substrate of `Core/Data/RoseTree/Count.lean`;
+consumed by the workspace conservation laws (`Workspace/Conservation.lean`) and the
+Merge economy files.
 -/
 
 namespace RoseTree


### PR DESCRIPTION
Completes the Core-purity arc for the measure layer: `TraceMeasures.lean` (the MCB vocabulary shim), `Conservation.lean`, and `DeletionConservation.lean` move from `Core/` to `Syntax/Minimalist/Workspace/`, joining the MCB workspace substrate. The import graph made this a pure move — the two conservation files had no Core-side consumers (MinimalYield/MinimalSearch/External are all Syntax), so no code changes beyond import paths. Core/ retains only the generic substrate (`Data/RoseTree/Count.lean`, the coproducts).