### PR TITLE
feat(Core/Analysis): least-squares keystone; re-found ERM existence

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -49,6 +49,7 @@ import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 import Linglib.Core.Algebra.RootedTree.PreLie.Path
 import Linglib.Core.Algebra.RotaBaxter
 import Linglib.Core.Algebra.RotaBaxterLaurent
+import Linglib.Core.Analysis.LeastSquares
 import Linglib.Core.Analysis.SpecialFunctions.Log.NegMulLog
 import Linglib.Core.Categorical.AgentCat
 import Linglib.Core.Categorical.PartitionCat

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1459,7 +1459,7 @@ import Linglib.Processing.Expectation.InformationValue
 import Linglib.Processing.Expectation.LanguageModel
 import Linglib.Processing.Expectation.PrefixProbability
 import Linglib.Processing.Lexical.Discriminative.Defs
-import Linglib.Processing.Lexical.Discriminative.Existence
+import Linglib.Processing.Lexical.Discriminative.Regression
 import Linglib.Processing.Lexical.Discriminative.Measures
 import Linglib.Processing.Lexical.Discriminative.Normed
 import Linglib.Processing.Lexical.Discriminative.Training

--- a/Linglib/Core/Analysis/LeastSquares.lean
+++ b/Linglib/Core/Analysis/LeastSquares.lean
@@ -1,0 +1,100 @@
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+
+/-!
+# Least-squares solutions
+
+`IsLeastSquares A b x` says `x` minimises `‖A y − b‖` over the domain of a
+linear map `A` into a real inner product space. Mathlib provides the
+subspace side (`Submodule.starProjection` and its minimality); this file
+packages the pulled-back problem: the first-order characterisation,
+existence, uniqueness of fitted values, and the solution coset.
+
+`[UPSTREAM]` candidate — mathlib has the ingredients but not the packaging;
+generalises from `ℝ` to `RCLike 𝕜`.
+
+## Main declarations
+
+* `IsLeastSquares A b x`: `x` minimises `‖A y − b‖`.
+* `isLeastSquares_iff_inner_eq_zero`: the first-order characterisation —
+  the residual is orthogonal to the range of `A` (the *normal equations*).
+* `exists_isLeastSquares`: solutions exist whenever the range of `A` admits
+  an orthogonal projection (in particular in finite dimension).
+* `IsLeastSquares.map_eq`: fitted values are unique.
+* `IsLeastSquares.iff_map_eq`: the solutions are exactly the preimages of
+  the fitted value.
+-/
+
+namespace Core
+
+open RealInnerProductSpace
+
+variable {E F : Type*} [AddCommGroup E] [Module ℝ E]
+  [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+  (A : E →ₗ[ℝ] F) (b : F)
+
+/-- `x` is a **least-squares solution** of `A y ≈ b` if it minimises the
+    residual norm `‖A y − b‖`. -/
+def IsLeastSquares (x : E) : Prop := ∀ y, ‖A x - b‖ ≤ ‖A y - b‖
+
+variable {A b}
+
+/-- The first-order characterisation of least squares: `x` is a solution iff
+    the residual `b − A x` is orthogonal to everything `A` can produce —
+    the **normal equations**, with no rank hypothesis. -/
+theorem isLeastSquares_iff_inner_eq_zero {x : E} :
+    IsLeastSquares A b x ↔ ∀ y, ⟪b - A x, A y⟫ = 0 := by
+  constructor
+  · intro hx
+    have heq : ‖b - A x‖ = ⨅ w : LinearMap.range A, ‖b - ↑w‖ := by
+      refine le_antisymm (le_ciInf fun w => ?_) ?_
+      · obtain ⟨y, hy⟩ := w.2
+        rw [← hy]
+        simpa [norm_sub_rev] using hx y
+      · have hbdd : BddBelow (Set.range fun w : LinearMap.range A => ‖b - ↑w‖) :=
+          ⟨0, by rintro r ⟨w, rfl⟩; exact norm_nonneg _⟩
+        exact ciInf_le hbdd ⟨A x, LinearMap.mem_range_self A x⟩
+    intro y
+    exact ((LinearMap.range A).norm_eq_iInf_iff_real_inner_eq_zero
+      (LinearMap.mem_range_self A x)).mp heq (A y) (LinearMap.mem_range_self A y)
+  · intro h y
+    have hsq : ‖b - A y‖ ^ 2
+        = ‖b - A x‖ ^ 2 + ‖A x - A y‖ ^ 2 := by
+      have hdecomp : b - A y = (b - A x) + (A x - A y) := by abel
+      rw [hdecomp, norm_add_sq_real, ← map_sub, h (x - y), mul_zero, add_zero]
+    have hle : ‖b - A x‖ ^ 2 ≤ ‖b - A y‖ ^ 2 := by
+      nlinarith [sq_nonneg ‖A x - A y‖]
+    have hroot := Real.sqrt_le_sqrt hle
+    rw [Real.sqrt_sq (norm_nonneg _), Real.sqrt_sq (norm_nonneg _)] at hroot
+    simpa [norm_sub_rev] using hroot
+
+/-- Least-squares solutions exist whenever the range of `A` admits an
+    orthogonal projection — in particular whenever it is finite-dimensional. -/
+theorem exists_isLeastSquares [(LinearMap.range A).HasOrthogonalProjection] :
+    ∃ x, IsLeastSquares A b x := by
+  obtain ⟨x, hx⟩ := LinearMap.mem_range.mp
+    ((LinearMap.range A).starProjection_apply_mem b)
+  exact ⟨x, isLeastSquares_iff_inner_eq_zero.mpr fun y => hx ▸
+    Submodule.starProjection_inner_eq_zero b (A y) (LinearMap.mem_range_self A y)⟩
+
+/-- Fitted values are unique: any two least-squares solutions produce the
+    same point of the range. -/
+theorem IsLeastSquares.map_eq {x x' : E}
+    (hx : IsLeastSquares A b x) (hx' : IsLeastSquares A b x') :
+    A x = A x' := by
+  have h := isLeastSquares_iff_inner_eq_zero.mp hx
+  have h' := isLeastSquares_iff_inner_eq_zero.mp hx'
+  have key : ∀ y, ⟪A x - A x', A y⟫ = 0 := fun y => by
+    have hd : A x - A x' = (b - A x') - (b - A x) := by abel
+    rw [hd, inner_sub_left, h y, h' y, sub_zero]
+  have h0 := key (x - x')
+  rw [map_sub] at h0
+  exact sub_eq_zero.mp ((inner_self_eq_zero (𝕜 := ℝ)).mp h0)
+
+/-- The least-squares solutions are exactly the preimages of the fitted
+    value: given one solution, another point solves iff it maps to the same
+    place. -/
+theorem IsLeastSquares.iff_map_eq {x x' : E} (hx : IsLeastSquares A b x) :
+    IsLeastSquares A b x' ↔ A x' = A x :=
+  ⟨fun hx' => hx'.map_eq hx, fun h y => h ▸ hx y⟩
+
+end Core

--- a/Linglib/Processing/Lexical/Discriminative/Existence.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Existence.lean
@@ -1,16 +1,18 @@
+import Linglib.Core.Analysis.LeastSquares
 import Linglib.Processing.Lexical.Discriminative.Training
 import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
 # Existence of ERM solutions
 [gahl-baayen-2024] [heitmeier-2024]
 
-ERM solutions exist for any nonnegative frequency vector: each observed form
-column is orthogonally projected onto the prediction subspace
-(`Submodule.starProjection`), and the columns assemble through
-`isERMSolution_iff_coordResidual`. The normal-equations solvability of
+The weighted loss is a least-squares residual: `√q`-scaling embeds the
+training objective into `EuclideanSpace ℝ (Fin m × Fin n)`
+(`weightedLoss_eq_norm_sq`), identifying the ERM solutions with the
+least-squares solutions of the design map (`isERMSolution_iff_isLeastSquares`).
+Existence then follows from the Hilbert projection theorem via
+`Core.exists_isLeastSquares` — the normal-equations solvability of
 [gahl-baayen-2024]'s appendix, with no invertibility hypothesis.
 -/
 
@@ -20,64 +22,79 @@ noncomputable section
 
 variable {m n d : ℕ}
 
-private theorem coordResidual_uniform_eq_norm_sq (data : TrainingExperience m n d)
-    (pred : Fin m → ℝ) (j : Fin n) :
-    coordResidual data (uniformFrequency m) pred j
-      = ‖WithLp.toLp 2 (fun k => data.forms k j)
-          - WithLp.toLp 2 pred‖ ^ 2 := by
+/-- The `√q`-scaled **design map**: the linear embedding of candidate
+    production maps into Euclidean event-coordinate space whose residual
+    against `scaledTarget` is the weighted loss. -/
+def designMap (data : TrainingExperience m n d) (q : FrequencyVector m) :
+    (MeaningVec d →ₗ[ℝ] FormVec n) →ₗ[ℝ] EuclideanSpace ℝ (Fin m × Fin n) :=
+  (WithLp.linearEquiv 2 ℝ (Fin m × Fin n → ℝ)).symm.toLinearMap ∘ₗ
+    LinearMap.pi fun p => Real.sqrt (q p.1) •
+      (LinearMap.proj p.2 ∘ₗ LinearMap.applyₗ (data.meanings p.1))
+
+@[simp] theorem designMap_apply (data : TrainingExperience m n d)
+    (q : FrequencyVector m) (G : MeaningVec d →ₗ[ℝ] FormVec n)
+    (p : Fin m × Fin n) :
+    designMap data q G p = Real.sqrt (q p.1) * G (data.meanings p.1) p.2 := rfl
+
+/-- The `√q`-scaled observed forms, as a point of Euclidean
+    event-coordinate space. -/
+def scaledTarget (data : TrainingExperience m n d) (q : FrequencyVector m) :
+    EuclideanSpace ℝ (Fin m × Fin n) :=
+  WithLp.toLp 2 fun p => Real.sqrt (q p.1) * data.forms p.1 p.2
+
+/-- The weighted loss is the squared least-squares residual of the design
+    map against the scaled target. -/
+theorem weightedLoss_eq_norm_sq (data : TrainingExperience m n d)
+    {q : FrequencyVector m} (hq : ∀ i, 0 ≤ q i)
+    (G : MeaningVec d →ₗ[ℝ] FormVec n) :
+    weightedLoss data q G
+      = ‖designMap data q G - scaledTarget data q‖ ^ 2 := by
   rw [EuclideanSpace.norm_sq_eq]
-  unfold coordResidual
-  refine Finset.sum_congr rfl fun k _ => ?_
-  show 1 * (pred k - data.forms k j) ^ 2 = _
-  rw [one_mul, ← WithLp.toLp_sub]
-  simp only [Pi.sub_apply, Real.norm_eq_abs, sq_abs]
-  ring
+  unfold weightedLoss squaredDist
+  rw [Fintype.sum_prod_type]
+  simp_rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  have hs : (Real.sqrt (q i) * G (data.meanings i) j
+        - Real.sqrt (q i) * data.forms i j) ^ 2
+      = Real.sqrt (q i) ^ 2 * (G (data.meanings i) j - data.forms i j) ^ 2 := by
+    ring
+  simp only [PiLp.sub_apply, designMap_apply, scaledTarget,
+             Real.norm_eq_abs, sq_abs]
+  rw [hs, Real.sq_sqrt (hq i)]
 
-private theorem exists_forall_coordResidual_le (data : TrainingExperience m n d)
-    (j : Fin n) :
-    ∃ w : MeaningVec d →ₗ[ℝ] ℝ, ∀ w' : MeaningVec d →ₗ[ℝ] ℝ,
-      coordResidual data (uniformFrequency m) (fun k => w (data.meanings k)) j
-        ≤ coordResidual data (uniformFrequency m) (fun k => w' (data.meanings k)) j := by
-  classical
-  -- prediction subspace: range of the evaluation map into Euclidean event space
-  set Ev : (MeaningVec d →ₗ[ℝ] ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin m) :=
-    (WithLp.linearEquiv 2 ℝ (Fin m → ℝ)).symm.toLinearMap.comp
-      (LinearMap.pi fun k => LinearMap.applyₗ (data.meanings k)) with hEv
-  set y : EuclideanSpace ℝ (Fin m) := WithLp.toLp 2 (fun k => data.forms k j) with hy
-  haveI : CompleteSpace ↥(LinearMap.range Ev) := FiniteDimensional.complete ℝ _
-  obtain ⟨w, hw⟩ := LinearMap.mem_range.mp ((LinearMap.range Ev).starProjection_apply_mem y)
-  refine ⟨w, fun w' => ?_⟩
-  have hmin : ∀ v : ↥(LinearMap.range Ev),
-      ‖y - (LinearMap.range Ev).starProjection y‖ ≤ ‖y - ↑v‖ := fun v => by
-    rw [Submodule.starProjection_minimal]
-    exact ciInf_le ⟨0, by rintro r ⟨x, rfl⟩; exact norm_nonneg _⟩ v
-  have hle : ‖y - Ev w‖ ≤ ‖y - Ev w'‖ := by
-    rw [hw]
-    exact hmin ⟨Ev w', LinearMap.mem_range_self _ _⟩
-  have hsq := pow_le_pow_left₀ (norm_nonneg _) hle 2
-  have hEvw : ∀ v : MeaningVec d →ₗ[ℝ] ℝ,
-      Ev v = WithLp.toLp 2 (fun k => v (data.meanings k)) := fun _ => rfl
-  rw [coordResidual_uniform_eq_norm_sq, coordResidual_uniform_eq_norm_sq]
-  rw [hEvw w, hEvw w', hy] at hsq
-  exact hsq
+/-- ERM solutions are exactly the least-squares solutions of the design
+    map — the DLM training problem, seen through `√q`-scaling, is weighted
+    linear regression. -/
+theorem isERMSolution_iff_isLeastSquares (data : TrainingExperience m n d)
+    {q : FrequencyVector m} (hq : ∀ i, 0 ≤ q i)
+    {G : MeaningVec d →ₗ[ℝ] FormVec n} :
+    IsERMSolution data q G
+      ↔ Core.IsLeastSquares (designMap data q) (scaledTarget data q) G := by
+  unfold IsERMSolution Core.IsLeastSquares
+  refine forall_congr' fun G' => ?_
+  rw [weightedLoss_eq_norm_sq data hq, weightedLoss_eq_norm_sq data hq]
+  constructor
+  · intro h
+    have hroot := Real.sqrt_le_sqrt h
+    rwa [Real.sqrt_sq (norm_nonneg _), Real.sqrt_sq (norm_nonneg _)] at hroot
+  · intro h
+    exact pow_le_pow_left₀ (norm_nonneg _) h 2
 
-/-- Endstate solutions exist — the normal-equations
-    solvability of [gahl-baayen-2024]'s appendix, by orthogonal projection
-    of each observed form column onto the prediction subspace. -/
-theorem exists_isELSolution (data : TrainingExperience m n d) :
-    ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, IsELSolution data G := by
-  choose w hw using exists_forall_coordResidual_le data
-  refine ⟨LinearMap.pi w, (isERMSolution_iff_coordResidual _ _ _).mpr fun j w' => ?_⟩
-  simpa only [LinearMap.pi_apply] using hw j w'
-
-/-- ERM solutions exist for any nonnegative frequency
-    vector, via `exists_isELSolution` on the `√q`-premultiplied experience. -/
+/-- ERM solutions exist for any nonnegative frequency vector, by the
+    Hilbert projection theorem (`Core.exists_isLeastSquares`). -/
 theorem exists_isERMSolution (data : TrainingExperience m n d)
     {q : FrequencyVector m} (hq : ∀ i, 0 ≤ q i) :
-    ∃ G, IsERMSolution data q G :=
-  let ⟨G, hG⟩ := exists_isELSolution (data.sqrtScale q)
-  ⟨G, (isELSolution_sqrtScale_iff hq).mp hG⟩
+    ∃ G, IsERMSolution data q G := by
+  haveI : CompleteSpace ↥(LinearMap.range (designMap data q)) :=
+    FiniteDimensional.complete ℝ _
+  obtain ⟨G, hG⟩ := Core.exists_isLeastSquares
+    (A := designMap data q) (b := scaledTarget data q)
+  exact ⟨G, (isERMSolution_iff_isLeastSquares data hq).mpr hG⟩
 
+/-- Endstate solutions exist. -/
+theorem exists_isELSolution (data : TrainingExperience m n d) :
+    ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, IsELSolution data G :=
+  exists_isERMSolution data fun _ => zero_le_one
 
 end
 

--- a/Linglib/Processing/Lexical/Discriminative/Regression.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Regression.lean
@@ -4,7 +4,7 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
-# Existence of ERM solutions
+# DLM training as weighted regression
 [gahl-baayen-2024] [heitmeier-2024]
 
 The weighted loss is a least-squares residual: `√q`-scaling embeds the

--- a/Linglib/Processing/Lexical/Discriminative/Training.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Training.lean
@@ -36,8 +36,9 @@ frequency-informed learning); the optimisation is fixed across theories.
 * `IsERMSolution.apply_eq_of_mem_span` / `exists_apply_ne`: fitted values are
   unique exactly on the span of experienced meanings.
 
-Existence of ERM solutions is in `Existence.lean`, via the least-squares
-keystone `Core.IsLeastSquares`. The endstate theory is rule-agnostic: composing
+The identification of DLM training with weighted regression — and existence
+of ERM solutions — is in `Regression.lean`, via the least-squares keystone
+`Core.IsLeastSquares`. The endstate theory is rule-agnostic: composing
 `isERMSolution_iff_forall_column` with the orthogonality principle
 `Core.sum_whCorrection_eq_zero_iff` identifies the ERM set with the
 equilibria of any error-driven rule in the Widrow-Hoff family.
@@ -221,7 +222,7 @@ regression and FIL by solving the EL problem on `√Q`-premultiplied `S` and
 data via the closed-form normal-equations solution, under invertibility.
 Here the premultiplied experience is `TrainingExperience.sqrtScale` and the
 equivalence (`isELSolution_sqrtScale_iff`) is stated invertibility-free at
-the level of ERM solution sets. (`Existence.lean` applies the same `√q`
+the level of ERM solution sets. (`Regression.lean` applies the same `√q`
 scaling inside its design map.) -/
 
 /-- The `√q`-premultiplied training experience scales event `i` by `√(q i)`

--- a/Linglib/Processing/Lexical/Discriminative/Training.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Training.lean
@@ -36,8 +36,8 @@ frequency-informed learning); the optimisation is fixed across theories.
 * `IsERMSolution.apply_eq_of_mem_span` / `exists_apply_ne`: fitted values are
   unique exactly on the span of experienced meanings.
 
-Existence of ERM solutions (by columnwise orthogonal projection) is in
-`Existence.lean`. The endstate theory is rule-agnostic: composing
+Existence of ERM solutions is in `Existence.lean`, via the least-squares
+keystone `Core.IsLeastSquares`. The endstate theory is rule-agnostic: composing
 `isERMSolution_iff_forall_column` with the orthogonality principle
 `Core.sum_whCorrection_eq_zero_iff` identifies the ERM set with the
 equilibria of any error-driven rule in the Widrow-Hoff family.
@@ -221,7 +221,8 @@ regression and FIL by solving the EL problem on `√Q`-premultiplied `S` and
 data via the closed-form normal-equations solution, under invertibility.
 Here the premultiplied experience is `TrainingExperience.sqrtScale` and the
 equivalence (`isELSolution_sqrtScale_iff`) is stated invertibility-free at
-the level of ERM solution sets; `Existence.lean` derives existence from it. -/
+the level of ERM solution sets. (`Existence.lean` applies the same `√q`
+scaling inside its design map.) -/
 
 /-- The `√q`-premultiplied training experience scales event `i` by `√(q i)`
     in both meaning and form — the `√Q`-premultiplication of `S` and `C` of


### PR DESCRIPTION
The abstract weighted-least-squares keystone (panel roadmap item; triple-checked absent from mathlib under any name — the ingredients exist, the packaging doesn't).

- `Core/Analysis/LeastSquares.lean` (`[UPSTREAM]` candidate): `IsLeastSquares A b x` over any real inner-product target — first-order characterisation (the normal equations, rank-free), existence via `Submodule.starProjection`, fitted-value uniqueness, solution coset. ~100 lines, proven once against mathlib's projection theory.
- `Discriminative/Existence.lean` re-founded: `designMap`/`scaledTarget` embed the training objective into `EuclideanSpace ℝ (Fin m × Fin n)` by `√q`-scaling; `isERMSolution_iff_isLeastSquares` identifies DLM training with weighted linear regression; `exists_isERMSolution` becomes a keystone corollary. The per-column projection machinery is gone; public signatures unchanged.
- Training.lean's algebra-tier proofs deliberately untouched (tier discipline); the closed form `G = (SᵀS)⁻¹SᵀC` now has its natural landing site via `IsLeastSquares.iff_map_eq` + adjoints.