### PR TITLE
feat(Processing/Lexical): trained lexicon unique iff meanings span

### DIFF
--- a/Linglib/Core/Analysis/LeastSquares.lean
+++ b/Linglib/Core/Analysis/LeastSquares.lean
@@ -97,4 +97,9 @@ theorem IsLeastSquares.iff_map_eq {x x' : E} (hx : IsLeastSquares A b x) :
     IsLeastSquares A b x' ↔ A x' = A x :=
   ⟨fun hx' => hx'.map_eq hx, fun h y => h ▸ hx y⟩
 
+/-- Under an injective design map the least-squares solution is unique. -/
+theorem IsLeastSquares.eq_of_injective (hA : Function.Injective A) {x x' : E}
+    (hx : IsLeastSquares A b x) (hx' : IsLeastSquares A b x') : x = x' :=
+  hA (hx.map_eq hx')
+
 end Core

--- a/Linglib/Processing/Lexical/Discriminative/Regression.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Regression.lean
@@ -96,6 +96,33 @@ theorem exists_isELSolution (data : TrainingExperience m n d) :
     ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, IsELSolution data G :=
   exists_isERMSolution data fun _ => zero_le_one
 
+/-- The trained lexicon is **uniquely determined** exactly when the
+    experienced meanings span the whole meaning space — the coordinate-free
+    form of the papers' full-column-rank condition on the closed-form
+    solution ([gahl-baayen-2024] appendix; [heitmeier-2024]). Below that
+    threshold the ERM map is genuinely underdetermined
+    (`IsERMSolution.exists_apply_ne`), though its fitted values never are
+    (`IsERMSolution.apply_meanings_eq`). -/
+theorem existsUnique_isERMSolution_iff [NeZero n]
+    (data : TrainingExperience m n d) {q : FrequencyVector m}
+    (hq : ∀ i, 0 < q i) :
+    (∃! G : MeaningVec d →ₗ[ℝ] FormVec n, IsERMSolution data q G)
+      ↔ Submodule.span ℝ (Set.range data.meanings) = ⊤ := by
+  constructor
+  · rintro ⟨G, hG, huniq⟩
+    by_contra hne
+    obtain ⟨s, hs⟩ : ∃ s, s ∉ Submodule.span ℝ (Set.range data.meanings) := by
+      by_contra hall
+      push Not at hall
+      exact hne (Submodule.eq_top_iff'.mpr hall)
+    obtain ⟨G', hG', hne'⟩ := hG.exists_apply_ne hs
+    exact hne' (by rw [huniq G' hG'])
+  · intro htop
+    obtain ⟨G, hG⟩ := exists_isERMSolution data fun i => (hq i).le
+    exact ⟨G, hG, fun G' hG' => LinearMap.ext fun s =>
+      IsERMSolution.apply_eq_of_mem_span hq hG' hG
+        (Submodule.eq_top_iff'.mp htop s)⟩
+
 end
 
 end Processing.Lexical.Discriminative

--- a/Linglib/Processing/Lexical/Discriminative/Training.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Training.lean
@@ -45,7 +45,8 @@ equilibria of any error-driven rule in the Widrow-Hoff family.
 
 ## TODO
 
-Closed form `G = (SᵀS)⁻¹SᵀC` under full column rank; approximate-decodability
+Matrix closed form `G = (SᵀS)⁻¹SᵀC` (the uniqueness half is
+`existsUnique_isERMSolution_iff` in `Regression.lean`); approximate-decodability
 gap bounds for `semSup`.
 -/
 


### PR DESCRIPTION
Capstone of the ERM statics: `existsUnique_isERMSolution_iff` — the trained lexicon is uniquely determined exactly when the experienced meanings span the meaning space (coordinate-free form of the papers' full-column-rank condition on `G = (SᵀS)⁻¹SᵀC`). Both halves were already in place (`apply_eq_of_mem_span`, `exists_apply_ne`, keystone existence); this is their ∃!-packaging in `Regression.lean`. Also `Core.IsLeastSquares.eq_of_injective` (two-line corollary).