### PR TITLE
feat(Processing/Lexical): DLM coding typeclasses; generic analogy

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1458,6 +1458,7 @@ import Linglib.Processing.Expectation.Defs
 import Linglib.Processing.Expectation.InformationValue
 import Linglib.Processing.Expectation.LanguageModel
 import Linglib.Processing.Expectation.PrefixProbability
+import Linglib.Processing.Lexical.Discriminative.Coding
 import Linglib.Processing.Lexical.Discriminative.Defs
 import Linglib.Processing.Lexical.Discriminative.Regression
 import Linglib.Processing.Lexical.Discriminative.Measures

--- a/Linglib/Processing/Lexical/Discriminative/Coding.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Coding.lean
@@ -12,16 +12,16 @@ symbol string; its cues are the `k`-factors of the boundary-augmented
 string — the same windowing as subregular locality (`Subregular.SLGrammar`)
 — and its form vector is the binary cue indicator (Box 4.2: the `C` matrix
 holds only 1s and 0s, not counts; the count refinement is where strict
-locality's unit margin lives, `Subregular.SLGrammar`). A `SemDecomposable`
-type yields a multiset of semantic primitives — lexeme plus
-inflectional-function tags — and its meaning vector is the sum of primitive
-embeddings (the book's additive decomposition, ch. 5, generalising the
-multi-hot coding it attributes to naive discriminative learning).
+locality's unit margin lives, `Subregular.SLGrammar`). A `SemanticPrimitives`
+type yields a multiset of atomic semantic primitives — a lexeme plus
+inflectional-function tags (the book's term, ch. 5) — and `conceptualize`
+builds its meaning vector as the sum of primitive embeddings: the book's
+additive decomposition (eq. 5.3) and its verb for the operation (§16.3).
 
-`embedSem_analogy` is the general form of proportional analogy: a linear
-map respects every multiset-level relation among primitive decompositions.
-The stem-exponent fourth proportional of `Studies/HeitmeierChuangBaayen2026`
-is the two-primitive case.
+`conceptualize_analogy` is the general form of proportional analogy: a
+linear map respects every multiset-level relation among primitive
+decompositions. The stem-exponent fourth proportional of
+`Studies/HeitmeierChuangBaayen2026` is the two-primitive case.
 -/
 
 namespace Processing.Lexical.Discriminative
@@ -57,23 +57,26 @@ def Discriminable (k : ℕ) (lexicon : Set W) : Prop :=
 
 /-! ### Meaning side -/
 
-/-- A meaning type that decomposes into a multiset of semantic primitives —
-    lexeme and inflectional-function tags. -/
-class SemDecomposable (M : Type*) (Prim : outParam Type*) where
-  prims : M → Multiset Prim
+/-- A meaning type with atomic semantic primitives — a lexeme and
+    inflectional-function tags. -/
+class SemanticPrimitives (M : Type*) (Prim : outParam Type*) where
+  primitives : M → Multiset Prim
 
-variable {M Prim : Type*} [SemDecomposable M Prim] {d n : ℕ}
+export SemanticPrimitives (primitives)
 
-/-- The additive semantic embedding: the meaning vector is the sum of its
+variable {M Prim : Type*} [SemanticPrimitives M Prim] {d n : ℕ}
+
+/-- **Conceptualization**: the meaning vector of an object is the sum of its
     primitives' vectors. -/
-def embedSem (emb : Prim → MeaningVec d) (m : M) : MeaningVec d :=
-  ((SemDecomposable.prims m).map emb).sum
+def conceptualize (emb : Prim → MeaningVec d) (m : M) : MeaningVec d :=
+  ((primitives m).map emb).sum
 
-theorem embedSem_add_of_prims_add (emb : Prim → MeaningVec d) {m₁ m₂ m₃ m₄ : M}
-    (h : SemDecomposable.prims m₁ + SemDecomposable.prims m₂
-       = SemDecomposable.prims m₃ + SemDecomposable.prims m₄) :
-    embedSem emb m₁ + embedSem emb m₂ = embedSem emb m₃ + embedSem emb m₄ := by
-  unfold embedSem
+theorem conceptualize_add_of_primitives_add (emb : Prim → MeaningVec d)
+    {m₁ m₂ m₃ m₄ : M}
+    (h : primitives m₁ + primitives m₂ = primitives m₃ + primitives m₄) :
+    conceptualize emb m₁ + conceptualize emb m₂
+      = conceptualize emb m₃ + conceptualize emb m₄ := by
+  unfold conceptualize
   rw [← Multiset.sum_add, ← Multiset.map_add, h, Multiset.map_add,
       Multiset.sum_add]
 
@@ -81,12 +84,11 @@ theorem embedSem_add_of_prims_add (emb : Prim → MeaningVec d) {m₁ m₂ m₃ 
     multiset-level relation among primitive decompositions. The
     stem-exponent fourth proportional is the case
     `{lex, PL} + {lex', SG} = {lex, SG} + {lex', PL}`. -/
-theorem embedSem_analogy (emb : Prim → MeaningVec d)
+theorem conceptualize_analogy (emb : Prim → MeaningVec d)
     (G : MeaningVec d →ₗ[ℝ] FormVec n) {m₁ m₂ m₃ m₄ : M}
-    (h : SemDecomposable.prims m₁ + SemDecomposable.prims m₂
-       = SemDecomposable.prims m₃ + SemDecomposable.prims m₄) :
-    G (embedSem emb m₁) + G (embedSem emb m₂)
-      = G (embedSem emb m₃) + G (embedSem emb m₄) := by
-  rw [← map_add, embedSem_add_of_prims_add emb h, map_add]
+    (h : primitives m₁ + primitives m₂ = primitives m₃ + primitives m₄) :
+    G (conceptualize emb m₁) + G (conceptualize emb m₂)
+      = G (conceptualize emb m₃) + G (conceptualize emb m₄) := by
+  rw [← map_add, conceptualize_add_of_primitives_add emb h, map_add]
 
 end Processing.Lexical.Discriminative

--- a/Linglib/Processing/Lexical/Discriminative/Coding.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Coding.lean
@@ -1,0 +1,92 @@
+import Linglib.Processing.Lexical.Discriminative.Defs
+import Linglib.Core.Computability.Subregular.Language.Boundary
+import Linglib.Core.Data.List.Factors
+
+/-!
+# Form and meaning coding for the DLM
+[heitmeier-chuang-baayen-2026]
+
+The interfaces by which linguistic objects feed the discriminative lexicon
+([heitmeier-chuang-baayen-2026] ch. 4-5). A `Linearizable` type yields a
+symbol string; its cues are the `k`-factors of the boundary-augmented
+string — the same windowing as subregular locality (`Subregular.SLGrammar`)
+— and its form vector is the binary cue indicator (Box 4.2: the `C` matrix
+holds only 1s and 0s, not counts; the count refinement is where strict
+locality's unit margin lives, `Subregular.SLGrammar`). A `SemDecomposable`
+type yields a multiset of semantic primitives — lexeme plus
+inflectional-function tags — and its meaning vector is the sum of primitive
+embeddings (the book's additive decomposition, ch. 5, generalising the
+multi-hot coding it attributes to naive discriminative learning).
+
+`embedSem_analogy` is the general form of proportional analogy: a linear
+map respects every multiset-level relation among primitive decompositions.
+The stem-exponent fourth proportional of `Studies/HeitmeierChuangBaayen2026`
+is the two-primitive case.
+-/
+
+namespace Processing.Lexical.Discriminative
+
+open Subregular
+
+/-! ### Form side -/
+
+/-- A form type that linearizes to a symbol string — the domain of the
+    DLM's cue coding. -/
+class Linearizable (W : Type*) (Sym : outParam Type*) where
+  symbols : W → List Sym
+
+instance {α : Type*} : Linearizable (List α) α := ⟨id⟩
+
+variable {W Sym : Type*} [Linearizable W Sym]
+
+/-- The `k`-gram cues of a form: `k`-factors of the boundary-augmented
+    symbol string. -/
+def cues (k : ℕ) (w : W) : List (Augmented Sym) :=
+  List.kFactors k (boundary k (Linearizable.symbols w))
+
+/-- The binary cue-indicator vector over a fixed cue inventory. -/
+def cueVector [DecidableEq Sym] (k : ℕ) {N : ℕ} (inv : Fin N → Augmented Sym)
+    (w : W) : FormVec N :=
+  fun j => if inv j ∈ cues k w then 1 else 0
+
+/-- A lexicon is **discriminable** at width `k` when cue coding separates
+    its forms; failures are homographs
+    ([heitmeier-chuang-baayen-2026] ch. 7). -/
+def Discriminable (k : ℕ) (lexicon : Set W) : Prop :=
+  Set.InjOn (cues (Sym := Sym) k) lexicon
+
+/-! ### Meaning side -/
+
+/-- A meaning type that decomposes into a multiset of semantic primitives —
+    lexeme and inflectional-function tags. -/
+class SemDecomposable (M : Type*) (Prim : outParam Type*) where
+  prims : M → Multiset Prim
+
+variable {M Prim : Type*} [SemDecomposable M Prim] {d n : ℕ}
+
+/-- The additive semantic embedding: the meaning vector is the sum of its
+    primitives' vectors. -/
+def embedSem (emb : Prim → MeaningVec d) (m : M) : MeaningVec d :=
+  ((SemDecomposable.prims m).map emb).sum
+
+theorem embedSem_add_of_prims_add (emb : Prim → MeaningVec d) {m₁ m₂ m₃ m₄ : M}
+    (h : SemDecomposable.prims m₁ + SemDecomposable.prims m₂
+       = SemDecomposable.prims m₃ + SemDecomposable.prims m₄) :
+    embedSem emb m₁ + embedSem emb m₂ = embedSem emb m₃ + embedSem emb m₄ := by
+  unfold embedSem
+  rw [← Multiset.sum_add, ← Multiset.map_add, h, Multiset.map_add,
+      Multiset.sum_add]
+
+/-- **Generic proportional analogy**: any linear map respects every
+    multiset-level relation among primitive decompositions. The
+    stem-exponent fourth proportional is the case
+    `{lex, PL} + {lex', SG} = {lex, SG} + {lex', PL}`. -/
+theorem embedSem_analogy (emb : Prim → MeaningVec d)
+    (G : MeaningVec d →ₗ[ℝ] FormVec n) {m₁ m₂ m₃ m₄ : M}
+    (h : SemDecomposable.prims m₁ + SemDecomposable.prims m₂
+       = SemDecomposable.prims m₃ + SemDecomposable.prims m₄) :
+    G (embedSem emb m₁) + G (embedSem emb m₂)
+      = G (embedSem emb m₃) + G (embedSem emb m₄) := by
+  rw [← map_add, embedSem_add_of_prims_add emb h, map_add]
+
+end Processing.Lexical.Discriminative

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -1,3 +1,4 @@
+import Linglib.Processing.Lexical.Discriminative.Coding
 import Linglib.Processing.Lexical.Discriminative.Training
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 
@@ -108,6 +109,25 @@ theorem not_isAnalogicallyRegular_of_xor {f : Bool → Bool → FormVec n}
     simp only [Pi.sub_apply] at hj
     linarith
   exact hne ((hxor.1.trans h0).trans hxor.2.symm)
+
+/-! ### The coding interface
+
+The stem-exponent setting is the two-primitive case of the DLM coding
+interface: a paradigm cell's primitives are its stem and cell tags, and
+`embedSem` over `Sum.elim σ ε` is the imputed additive semantics. The
+fourth proportional above is `embedSem_analogy` at the multiset relation
+`{st, c} + {st', c'} = {st, c'} + {st', c}`. -/
+
+instance : SemDecomposable (Stem × Cell) (Stem ⊕ Cell) :=
+  ⟨fun p => {Sum.inl p.1, Sum.inr p.2}⟩
+
+@[simp] theorem prims_pair (st : Stem) (c : Cell) :
+    SemDecomposable.prims (Prim := Stem ⊕ Cell) (st, c)
+      = {Sum.inl st, Sum.inr c} := rfl
+
+theorem embedSem_sumElim (st : Stem) (c : Cell) :
+    embedSem (Sum.elim σ ε) (st, c) = σ st + ε c := by
+  simp [embedSem]
 
 variable [Fintype Stem] [Fintype Cell]
 

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -113,21 +113,20 @@ theorem not_isAnalogicallyRegular_of_xor {f : Bool → Bool → FormVec n}
 /-! ### The coding interface
 
 The stem-exponent setting is the two-primitive case of the DLM coding
-interface: a paradigm cell's primitives are its stem and cell tags, and
-`embedSem` over `Sum.elim σ ε` is the imputed additive semantics. The
-fourth proportional above is `embedSem_analogy` at the multiset relation
-`{st, c} + {st', c'} = {st, c'} + {st', c}`. -/
+interface: a paradigm cell's semantic primitives are its stem and cell
+tags, and conceptualization over `Sum.elim σ ε` is the imputed additive
+semantics. The fourth proportional above is `conceptualize_analogy` at the
+multiset relation `{st, c} + {st', c'} = {st, c'} + {st', c}`. -/
 
-instance : SemDecomposable (Stem × Cell) (Stem ⊕ Cell) :=
+instance : SemanticPrimitives (Stem × Cell) (Stem ⊕ Cell) :=
   ⟨fun p => {Sum.inl p.1, Sum.inr p.2}⟩
 
-@[simp] theorem prims_pair (st : Stem) (c : Cell) :
-    SemDecomposable.prims (Prim := Stem ⊕ Cell) (st, c)
-      = {Sum.inl st, Sum.inr c} := rfl
+@[simp] theorem primitives_pair (st : Stem) (c : Cell) :
+    primitives (Prim := Stem ⊕ Cell) (st, c) = {Sum.inl st, Sum.inr c} := rfl
 
-theorem embedSem_sumElim (st : Stem) (c : Cell) :
-    embedSem (Sum.elim σ ε) (st, c) = σ st + ε c := by
-  simp [embedSem]
+theorem conceptualize_sumElim (st : Stem) (c : Cell) :
+    conceptualize (Sum.elim σ ε) (st, c) = σ st + ε c := by
+  simp [conceptualize]
 
 variable [Fintype Stem] [Fintype Cell]
 


### PR DESCRIPTION
The plug-in interface for the DLM, per the book's ch. 4-5 (agent-verified against the text): `Linearizable W Sym` (form side — cues are k-factors of the boundary-augmented string, reusing the Subregular windowing; `cueVector` is the binary indicator per Box 4.2, not counts) and `SemDecomposable M Prim` (meaning side — `embedSem` sums primitive vectors, the book's additive decomposition). `embedSem_analogy`: a linear map respects every multiset relation among primitive decompositions — generic proportional analogy, with HeitmeierChuangBaayen2026's stem-exponent fourth proportional instantiated as the two-primitive case.