### PR TITLE
feat(Studies/Wellwood2015): type-driven derivations via composition engine

### DIFF
--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -23,6 +23,7 @@ Composition principles:
    β expects an intension `⟨s,σ⟩` and γ has type σ ([von-fintel-heim-2011] Step 10)
 5. Predicate Modification (PM): combine two `⟨e,t⟩` predicates (Ch. 4)
 6. Predicate Abstraction (PA): `⟦[n β]⟧^g = λx. ⟦β⟧^{g[n↦x]}` (Ch. 5)
+7. Event Identification (EI): role head + eventuality predicate ([kratzer-1996])
 
 Two effect-discipline choices, both visible rather than stipulated:
 
@@ -163,10 +164,27 @@ def tryPM {E W : Type} {M : Type → Type} [Applicative M]
     some ⟨.fn .e .t, Modifier.intersective <$> p1 <*> p2⟩
   | _, _ => none
 
-/-- Binary node: try FA, then IFA, then PM. -/
+/-- EI: Event Identification ([kratzer-1996]): a role head `⟨e,⟨e,t⟩⟩`
+combines with an eventuality predicate `⟨e,t⟩`, conjoining the predicate
+onto the head's event argument — `λx.λe. f(x)(e) ∧ g(e)`. Tried in both
+orders; effects sequence in linear order. -/
+def tryEI {E W : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+  match h1 : d1.ty, h2 : d2.ty with
+  | .fn .e (.fn .e .t), .fn .e .t =>
+    let f : M (Denot E W (.e ⇒ .e ⇒ .t)) := h1 ▸ d1.val
+    let p : M (Denot E W (.e ⇒ .t)) := h2 ▸ d2.val
+    some ⟨.e ⇒ .e ⇒ .t, (λ fv pv => λ x e => fv x e ∧ pv e) <$> f <*> p⟩
+  | .fn .e .t, .fn .e (.fn .e .t) =>
+    let p : M (Denot E W (.e ⇒ .t)) := h1 ▸ d1.val
+    let f : M (Denot E W (.e ⇒ .e ⇒ .t)) := h2 ▸ d2.val
+    some ⟨.e ⇒ .e ⇒ .t, (λ pv fv => λ x e => fv x e ∧ pv e) <$> p <*> f⟩
+  | _, _ => none
+
+/-- Binary node: try FA, then IFA, then PM, then EI. -/
 def interpBinary {E W : Type} {M : Type → Type} [Applicative M]
     (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
-  tryFA d1 d2 <|> tryIFA d1 d2 <|> tryPM d1 d2
+  tryFA d1 d2 <|> tryIFA d1 d2 <|> tryPM d1 d2 <|> tryEI d1 d2
 
 /-! ### Tree interpretation -/
 
@@ -273,7 +291,7 @@ theorem tryPM_preserves_type {E W : Type} [Applicative M] (d1 d2 : TypedDenot E 
 
 theorem interpBinary_eq {E W : Type} [Applicative M] (d1 d2 : TypedDenot E W M) :
     interpBinary d1 d2 =
-    (tryFA d1 d2 <|> tryIFA d1 d2 <|> tryPM d1 d2) := rfl
+    (tryFA d1 d2 <|> tryIFA d1 d2 <|> tryPM d1 d2 <|> tryEI d1 d2) := rfl
 
 end Properties
 

--- a/Linglib/Semantics/Intensional/Conjunction.lean
+++ b/Linglib/Semantics/Intensional/Conjunction.lean
@@ -30,6 +30,7 @@ def genConj (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ → Denot E W
   match τ with
   | .t => λ x y => x ∧ y
   | .e => λ x _ => x
+  | .d => λ x _ => x
   | .fn _ τ' => λ f g => λ x => genConj τ' E W (f x) (g x)
   | .intens a => λ f g => λ i => genConj a E W (f i) (g i)
 
@@ -38,6 +39,7 @@ def genDisj (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ → Denot E W
   match τ with
   | .t => λ x y => x ∨ y
   | .e => λ x _ => x
+  | .d => λ x _ => x
   | .fn _ τ' => λ f g => λ x => genDisj τ' E W (f x) (g x)
   | .intens a => λ f g => λ i => genDisj a E W (f i) (g i)
 
@@ -47,6 +49,7 @@ def genNeg (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ :=
   match τ with
   | .t => λ p => ¬p
   | .e => λ x => x
+  | .d => λ x => x
   | .fn _ τ' => λ f => λ x => genNeg τ' E W (f x)
   | .intens a => λ f => λ i => genNeg a E W (f i)
 

--- a/Linglib/Semantics/Intensional/Defs.lean
+++ b/Linglib/Semantics/Intensional/Defs.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Set.Basic
+import Mathlib.Data.Rat.Defs
 
 /-!
 # Intensional Logic: Types and Denotations
@@ -34,6 +35,10 @@ intensionality is a type-forming operation, not a separate domain. -/
 inductive Ty where
   | e : Ty
   | t : Ty
+  /-- Degrees (type `d`): the scale sort of degree semantics
+      ([heim-2001], [wellwood-2015]). Denoted by ℚ, the repo's exact
+      degree carrier. -/
+  | d : Ty
   | fn : Ty → Ty → Ty
   | intens : Ty → Ty
   deriving Repr, DecidableEq
@@ -55,6 +60,7 @@ abbrev Ty.indConcept : Ty := .intens .e
 def Ty.isConjoinable : Ty → Bool
   | .t => true
   | .e => false
+  | .d => false
   | .fn _ τ => τ.isConjoinable
   | .intens a => a.isConjoinable
 
@@ -76,6 +82,7 @@ def Ty.isConjoinable : Ty → Bool
 def Denot (E W : Type) : Ty → Type
   | .e => E
   | .t => Prop
+  | .d => ℚ
   | .fn a b => Denot E W a → Denot E W b
   | .intens a => W → Denot E W a
 

--- a/Linglib/Studies/Wellwood2015.lean
+++ b/Linglib/Studies/Wellwood2015.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Degree.Measure
+import Linglib.Semantics.Composition.Tree
 import Linglib.Semantics.Degree.Comparative
 import Linglib.Semantics.Mereology
 import Linglib.Semantics.ArgumentStructure.Thematic.Defs
@@ -26,9 +27,12 @@ not lexical category (§3.4).
 
 * `comparativeTruth` / `equativeTruth`: the shared truth conditions for
   `-er` and `as` (eq. 27), instances of `Degree.maxComparative` /
-  `Degree.maxEquative`; `derivation_eq_comparativeTruth` proves the
-  paper's step-by-step composition (`matrixDegP`, `absDegP`, `predMod`,
-  `thanClause`) yields the former.
+  `Degree.maxEquative`.
+* `matrix_derivation_denotes` / `than_derivation_denotes`: the
+  derivations run type-driven through the [heim-kratzer-1998] engine —
+  one lexicon (`-er`, `much`, `ABS`, a role head) and one tree derive
+  every domain's matrix and than-clause by FA/PM/EI/closure, and
+  `derivation_eq_comparativeTruth` assembles them into eqs. 42/48/65.
 * `nominalComparative`, `verbalComparative`, `adjectivalComparative`:
   the three domain instantiations (role × extraction).
 * `coffee_much_matches` … `wooden_much_matches`: the §§2–3 felicity
@@ -150,6 +154,95 @@ theorem derivation_eq_comparativeTruth {Measured : Type*}
     matrixClause, predMod, matrixDegP, absDegP, ge_iff_le, gt_iff_lt, and_assoc]
 
 end Derivation
+
+
+/-! ### The derivations, type-driven
+
+The step-licensed derivations (37.i–viii, 45.i–vi, 61) run through the
+shared [heim-kratzer-1998] engine (`Semantics/Composition/Tree.lean`):
+one lexicon — `-er`, `much` (eqs. 7/28), `ABS` (38.ii), the standard δ,
+a base predicate, and a [kratzer-1996] role head — and one tree shape,
+composed by FA, PM, EI, FA, and existential closure. Degree abstraction
+for the than-clause (39–41) is the meta-language λ over the same tree
+with `ABS` in place of `-er`. The cross-categorial thesis is the
+parametricity: nominal, verbal, and adjectival matrices are the SAME
+tree at different (role, predicate, measure) cells. -/
+
+section TypeDriven
+
+open Semantics.Composition.Tree
+open Semantics.Montague (Lexicon)
+open Intensional (Ty Denot)
+open Syntax (Tree)
+
+variable {Ent α : Type}
+
+/-- The sorted composition domain: individuals ⊕ eventualities. -/
+abbrev Dom (Ent α : Type) : Type := Ent ⊕ α
+
+/-- Wellwood's lexicon over the engine: `much` is the assignment-supplied
+    measure (eqs. 7/28), `-er` the strict and `ABS` (38.ii) the weak
+    degree head, `role` a [kratzer-1996] role head composing by EI. -/
+def lexicon (role : Ent → α → Prop) (P : α → Prop) (μ0 : α → ℚ)
+    (subj : Ent) (δ : ℚ) : Lexicon (Dom Ent α) Unit := fun w =>
+  match w with
+  | "much" => some ⟨.e ⇒ .d, show Dom Ent α → ℚ from fun x => match x with
+      | .inr e => μ0 e
+      | .inl _ => 0⟩
+  | "er" => some ⟨(.e ⇒ .d) ⇒ .d ⇒ .e ⇒ .t,
+      show (Dom Ent α → ℚ) → ℚ → Dom Ent α → Prop from fun m d x => m x > d⟩
+  | "ABS" => some ⟨(.e ⇒ .d) ⇒ .d ⇒ .e ⇒ .t,
+      show (Dom Ent α → ℚ) → ℚ → Dom Ent α → Prop from fun m d x => m x ≥ d⟩
+  | "δ" => some ⟨.d, show ℚ from δ⟩
+  | "pred" => some ⟨.e ⇒ .t, fun x => match x with
+      | .inr e => P e
+      | .inl _ => False⟩
+  | "role" => some ⟨.e ⇒ .e ⇒ .t, fun x ev => match x, ev with
+      | .inl i, .inr e => role i e
+      | _, _ => False⟩
+  | "subj" => some ⟨.e, .inl subj⟩
+  | "EC" => some ⟨(.e ⇒ .t) ⇒ .t, fun p => ∃ e : α, p (.inr e)⟩
+  | _ => none
+
+/-- The shared matrix tree (37.i–viii / 45.i–vi):
+    `[EC [subj [role [pred [[er much] δ]]]]]` — Deg′ = FA(-er, much),
+    DegP = FA(Deg′, δ), VP = PM, vP = EI, S = FA, then closure. -/
+def matrixTree : Tree Unit String :=
+  .node () [.terminal () "EC",
+    .node () [.terminal () "subj",
+      .node () [.terminal () "role",
+        .node () [.terminal () "pred",
+          .node () [.node () [.terminal () "er", .terminal () "much"],
+            .terminal () "δ"]]]]]
+
+/-- The than-clause body (39–41/47): the same tree with `ABS` (38.ii)
+    for `-er`. -/
+def thanTree : Tree Unit String :=
+  .node () [.terminal () "EC",
+    .node () [.terminal () "subj",
+      .node () [.terminal () "role",
+        .node () [.terminal () "pred",
+          .node () [.node () [.terminal () "ABS", .terminal () "much"],
+            .terminal () "δ"]]]]]
+
+/-- The engine derives the matrix clause: type-driven interpretation of
+    `matrixTree` succeeds and denotes `matrixClause` (45.vi / 37.viii). -/
+theorem matrix_derivation_denotes (role : Ent → α → Prop) (P : α → Prop)
+    (μ0 : α → ℚ) (a : Ent) (δ : ℚ) (g : Core.Assignment (Dom Ent α)) :
+    interp (Dom Ent α) Unit (lexicon role P μ0 a δ) g matrixTree =
+      some ⟨.t, pure (matrixClause role P μ0 a δ)⟩ :=
+  rfl
+
+/-- The engine derives the than-clause degree set pointwise: at each
+    degree `d`, `thanTree` denotes membership of `d` in `thanClause`
+    (39–41/47); degree abstraction is the meta-language λ over `d`. -/
+theorem than_derivation_denotes (role : Ent → α → Prop) (P : α → Prop)
+    (μ0 : α → ℚ) (b : Ent) (d : ℚ) (g : Core.Assignment (Dom Ent α)) :
+    interp (Dom Ent α) Unit (lexicon role P μ0 b d) g thanTree =
+      some ⟨.t, pure (d ∈ thanClause role P μ0 b)⟩ :=
+  rfl
+
+end TypeDriven
 
 /-! ### Three domain instantiations -/
 


### PR DESCRIPTION
The paper's derivations as real compositional objects, not pre-flattened combinators.

- `Ty.d` degree base type in the intensional type system (`Denot .d = ℚ`); `tryEI` Event Identification ([kratzer-1996]) as a new engine mode alongside FA/IFA/PM.
- Wellwood's fragment as an engine lexicon (`-er`, `much` (eqs. 7/28), `ABS` (38.ii), role head, EC) over a sorted individuals ⊕ eventualities domain; ONE tree derives every domain's matrix by FA/PM/EI/closure (37.i–viii, 45.i–vi).
- `matrix_derivation_denotes` / `than_derivation_denotes`: type-driven interpretation computes `matrixClause`/`thanClause` **by `rfl`** — the derivation theorem now certifies composition, and the cross-categorial thesis is the lexicon's parametricity.