### PR TITLE
refactor(Core/Order): one threshold semantics on the Comparison spine

### DIFF
--- a/Linglib/Core/Order/Comparison.lean
+++ b/Linglib/Core/Order/Comparison.lean
@@ -152,4 +152,61 @@ the point predication. Makes [hoeksema-1983]'s NP↔S equivalence definitional. 
     (c : Comparison) (μ : E → α) (n : α) : c.overSet μ {n} = c.over μ n := by
   simp only [Comparison.overSet, Comparison.over, Comparison.bounds_singleton]
 
+/-! ### Threshold and measure monotonicity
+
+The shared content of every threshold-semantics face (Kennedy positive
+form, CSW positive region, credence thresholds): raising a non-strict
+lower threshold shrinks the extension, raising the measure preserves
+membership, and on a linear order the positive/negative poles are
+complementary and comparison reduces to a separating threshold (Klein). -/
+
+section ThresholdMonotone
+
+variable {E α : Type*} [Preorder α] (μ : E → α)
+
+/-- Raising an `at least` threshold shrinks the extension. -/
+theorem Comparison.antitone_ge_over : Antitone (Comparison.ge.over μ) :=
+  fun _ _ h _ hx => le_trans h hx
+
+/-- Raising a `more than` threshold shrinks the extension. -/
+theorem Comparison.antitone_gt_over : Antitone (Comparison.gt.over μ) :=
+  fun _ _ h _ hx => lt_of_le_of_lt h hx
+
+/-- Raising an `at most` threshold grows the extension. -/
+theorem Comparison.monotone_le_over : Monotone (Comparison.le.over μ) :=
+  fun _ _ h _ hx => le_trans hx h
+
+/-- Raising a `less than` threshold grows the extension. -/
+theorem Comparison.monotone_lt_over : Monotone (Comparison.lt.over μ) :=
+  fun _ _ h _ hx => lt_of_lt_of_le hx h
+
+/-- Membership in an `at least` extension transports up the measure. -/
+theorem Comparison.mem_ge_over_of_le {θ : α} {x y : E}
+    (hx : x ∈ Comparison.ge.over μ θ) (hxy : μ x ≤ μ y) :
+    y ∈ Comparison.ge.over μ θ :=
+  le_trans hx hxy
+
+end ThresholdMonotone
+
+section ThresholdLinear
+
+variable {E α : Type*} [LinearOrder α] (μ : E → α)
+
+/-- Polarity duality: clearing the threshold is exactly not falling
+    below it. -/
+theorem Comparison.mem_ge_over_iff_not_mem_lt_over {θ : α} {x : E} :
+    x ∈ Comparison.ge.over μ θ ↔ x ∉ Comparison.lt.over μ θ := by
+  simp [Comparison.mem_over, Comparison.rel, not_lt]
+
+/-- The Klein reduction: strict comparison holds iff some threshold
+    separates the two measures. -/
+theorem Comparison.lt_iff_separating_threshold {x y : E} :
+    μ y < μ x ↔ ∃ θ, x ∈ Comparison.ge.over μ θ ∧ y ∉ Comparison.ge.over μ θ := by
+  constructor
+  · exact fun h => ⟨μ x, le_refl _, not_le.mpr h⟩
+  · rintro ⟨θ, hx, hy⟩
+    exact lt_of_lt_of_le (not_le.mp hy) hx
+
+end ThresholdLinear
+
 end Core.Order

--- a/Linglib/Core/Order/Rat01.lean
+++ b/Linglib/Core/Order/Rat01.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Set.Basic
 import Mathlib.Data.Rat.Defs
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Tactic.NormNum
+import Linglib.Core.Order.Comparison
 import Mathlib.Tactic.Linarith
 import Mathlib.Order.Monotone.Basic
 
@@ -55,8 +56,10 @@ def one : Rat01 := ⟨1, by norm_num, by norm_num⟩
 /-- The midpoint ½, the standard default threshold. -/
 def half : Rat01 := ⟨1/2, by norm_num, by norm_num⟩
 
-/-- Does the value strictly exceed a threshold? -/
-def exceeds (d θ : Rat01) : Prop := θ.val < d.val
+/-- Does the value strictly exceed a threshold? The `Rat01` face of
+`Core.Order.Comparison.gt.over`. -/
+def exceeds (d θ : Rat01) : Prop :=
+  d ∈ Core.Order.Comparison.gt.over Subtype.val θ.val
 
 instance (d θ : Rat01) : Decidable (exceeds d θ) :=
   inferInstanceAs (Decidable (θ.val < d.val))

--- a/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
+++ b/Linglib/Semantics/Attitudes/EpistemicThreshold.lean
@@ -196,7 +196,7 @@ variable {E W : Type*}
     `measure(entity) ≥ threshold`. -/
 def meetsThreshold (cr : AgentCredence E W) (θ : ℚ)
     (a : E) (φ : (W → Bool)) : Prop :=
-  cr a φ ≥ θ
+  φ ∈ Core.Order.Comparison.ge.over (cr a) θ
 
 /-- Reversed threshold: agent `a`'s credence in `φ` is strictly BELOW `θ`.
 
@@ -204,7 +204,7 @@ def meetsThreshold (cr : AgentCredence E W) (θ : ℚ)
     Pr(A, φ) < θ_uncertain ∧ Pr(A, ψ) < θ_uncertain (Table 1(a)). -/
 def failsThreshold (cr : AgentCredence E W) (θ : ℚ)
     (a : E) (φ : (W → Bool)) : Prop :=
-  cr a φ < θ
+  φ ∈ Core.Order.Comparison.lt.over (cr a) θ
 
 /-- Full epistemic evaluation: credence meets threshold, plus factivity.
 
@@ -253,16 +253,6 @@ def mostStr (cr : AgentCredence E W) (entry : EpistemicEntry)
 -- §4. Entailment Properties
 -- ============================================================================
 
-/-- Higher thresholds entail lower thresholds.
-
-    If an expression with threshold θ₂ holds, then any expression with
-    a lower threshold θ₁ ≤ θ₂ also holds. This derives the entailment
-    patterns of epistemic vocabulary from the threshold ordering alone. -/
-theorem threshold_monotone (cr : AgentCredence E W)
-    (a : E) (φ : (W → Bool)) {θ₁ θ₂ : ℚ} (h : θ₁ ≤ θ₂) :
-    meetsThreshold cr θ₂ a φ → meetsThreshold cr θ₁ a φ :=
-  fun h₂ => le_trans h h₂
-
 /-- Generic `holdsAt` entailment: a stronger entry (higher threshold,
     weaker factivity) entails a weaker one.
 
@@ -274,7 +264,7 @@ theorem holdsAt_mono_of_le {e₁ e₂ : EpistemicEntry}
     (cr : AgentCredence E W) (a : E) (φ : (W → Bool)) (w : W) :
     holdsAt cr e₂ a φ w → holdsAt cr e₁ a φ w := by
   intro ⟨hcr, hfact⟩
-  refine ⟨threshold_monotone cr a φ hθ hcr, ?_⟩
+  refine ⟨Core.Order.Comparison.antitone_ge_over (cr a) hθ hcr, ?_⟩
   intro h₁
   exact hfact (hf h₁)
 
@@ -337,17 +327,6 @@ theorem moreCredent_transitive (cr : AgentCredence E W)
     (h₁ : moreCredent cr a φ ψ) (h₂ : moreCredent cr a ψ χ) :
     moreCredent cr a φ χ :=
   lt_trans h₂ h₁
-
-/-- Upward monotonicity of belief under the credence ordering.
-
-    If the agent believes φ and is at least as confident of ψ as of φ,
-    then the agent believes ψ. This is the credence-based analogue of
-    `confidence_upward_monotone` in `Confidence.lean` (CSW (53)). -/
-theorem credence_upward_monotone (cr : AgentCredence E W)
-    (θ : ℚ) (a : E) (φ ψ : (W → Bool))
-    (h_bel : meetsThreshold cr θ a φ) (h_more : cr a φ ≤ cr a ψ) :
-    meetsThreshold cr θ a ψ :=
-  le_trans h_bel h_more
 
 -- ============================================================================
 -- §6. Probabilistic Credence and Conjunction
@@ -494,17 +473,6 @@ def epistemicAsDirectedMeasure (cr : AgentCredence E W) (_entry : EpistemicEntry
   μ := fun ⟨a, φ⟩ => cr a φ
   boundedness := epistemicBoundedness
 
-/-- The degree-threshold identity: `meetsThreshold` is the ≥-threshold
-    condition `θ ≤ μ(entity)` with credence as the measure function.
-
-    This is the formal statement that epistemic threshold semantics IS
-    degree semantics (the positive-form `Comparison.ge.over μ θ`
-    condition) with credence as the measure function. -/
-theorem meetsThreshold_eq_threshold (cr : AgentCredence E W) (θ : ℚ)
-    (a : E) (φ : (W → Bool)) :
-    meetsThreshold cr θ a φ ↔ θ ≤ cr a φ := by
-  rfl
-
 /-- The epistemic scale is licensed: closed → admits absolute standards.
 
     Since credence is bounded by [0, 1], [kennedy-2007]'s licensing
@@ -543,36 +511,6 @@ Table 1(b) are points on a finitely additive probability scale that
 satisfies System FA (and hence all of W ⊂ F ⊂ FA).
 -/
 
-/-- Threshold semantics is upward monotone in the credence ordering:
-    if `cr a φ ≥ θ` and `cr a φ ≤ cr a ψ`, then `cr a ψ ≥ θ`.
-
-    This is an instance of `Degree.IsUpwardMonotone` applied to the
-    epistemic scale. The family of propositions `P(θ) = meetsThreshold θ`
-    is upward monotone in credence — higher credence always satisfies
-    lower thresholds.
-
-    Connects to CSW's `confidence_upward_monotone` and to Lassiter's
-    observation that epistemic modals form a Horn scale ordered by
-    threshold strength. -/
-theorem threshold_upwardMonotone (cr : AgentCredence E W)
-    (a : E) (φ : (W → Bool)) :
-    ∀ (θ₁ θ₂ : ℚ), θ₁ ≤ θ₂ →
-    meetsThreshold cr θ₂ a φ → meetsThreshold cr θ₁ a φ :=
-  fun _ _ h h₂ => le_trans h h₂
-
-/-- `failsThreshold` is downward monotone: if credence is below θ₁
-    and θ₁ ≤ θ₂, then credence is below θ₂. This is the polarity
-    reversal for `uncertain`/`unlikely`: higher thresholds are easier
-    to fail.
-
-    Connects to Kennedy's negative adjective pattern (short, cold):
-    negative polarity on the same scale. -/
-theorem failsThreshold_downwardMonotone (cr : AgentCredence E W)
-    (a : E) (φ : (W → Bool)) :
-    ∀ (θ₁ θ₂ : ℚ), θ₁ ≤ θ₂ →
-    failsThreshold cr θ₁ a φ → failsThreshold cr θ₂ a φ :=
-  fun _ _ h h₁ => lt_of_lt_of_le h₁ h
-
 /-- The epistemic threshold scale forms a `ComparativeScale` with
     closed boundedness. This places it in the same categorical
     structure as Kennedy's adjective scales, Krifka's mereological
@@ -608,70 +546,6 @@ comparative implies a separating threshold exists (uses the witness
 the comparative hypothesis). This is a genuine mathematical fact about
 the structure of threshold semantics on a linear order.
 -/
-
-/-- **Klein's reduction**: the comparative reduces to the positive form.
-
-    "φ more likely than ψ" iff there exists a threshold that φ meets
-    and ψ fails. This is THE structural theorem connecting comparative
-    and positive-form degree semantics, originally due to
-    [klein-1980]'s delineation semantics for adjectives and
-    extended to epistemic vocabulary by treating credence as a measure
-    function.
-
-    - Forward: if cr(a,ψ) < cr(a,φ), witness θ = cr(a,φ).
-    - Backward: if θ separates, then cr(a,ψ) < θ ≤ cr(a,φ).
-
-    Note: linglib's `Semantics/Gradability/Theory.lean` follows
-    [kennedy-2007]'s degree typology (open/closed scales,
-    min/max-standard adjectives), which is downstream of Klein's
-    comparative reduction. -/
-theorem comparative_from_positive (cr : AgentCredence E W)
-    (a : E) (φ ψ : (W → Bool)) :
-    moreCredent cr a φ ψ ↔
-    ∃ θ : ℚ, meetsThreshold cr θ a φ ∧ ¬meetsThreshold cr θ a ψ := by
-  constructor
-  · intro h
-    exact ⟨cr a φ, le_refl _, not_le.mpr h⟩
-  · intro ⟨θ, hφ, hψ⟩
-    exact lt_of_lt_of_le (not_le.mp hψ) hφ
-
-/-- Polarity duality: `meetsThreshold` (positive) ↔ ¬`failsThreshold`.
-
-    On a linear order, cr(a,φ) ≥ θ iff ¬(cr(a,φ) < θ). This is not
-    `rfl` — it requires `not_lt` on `ℚ`'s linear order.
-
-    On a probability scale, positive and negative epistemic modals are
-    contradictories, not contraries — the same threshold θ separates
-    "likely" from "unlikely" (cf. [lassiter-goodman-2017] fn. 8
-    for the analogous tall/short case). -/
-theorem meetsThreshold_iff_not_failsThreshold (cr : AgentCredence E W)
-    (θ : ℚ) (a : E) (φ : (W → Bool)) :
-    meetsThreshold cr θ a φ ↔ ¬failsThreshold cr θ a φ := by
-  simp [meetsThreshold, failsThreshold, not_lt]
-
-/-- **Antonymy from polarity**: the comparative holds iff there exists a
-    threshold where the *positive* predicate holds for φ and the
-    *negative* predicate holds for ψ.
-
-    This is the formal content of "antonymy = scale reversal": the
-    comparative "more likely" decomposes into a threshold that is
-    simultaneously *met* by φ (positive: likely_θ) and *failed* by ψ
-    (negative: unlikely_θ). Unlike the `rfl`-level type coincidence,
-    this *derives* the antonymy connection from `comparative_from_positive`
-    + `meetsThreshold_iff_not_failsThreshold`.
-
-    The likely/unlikely pattern parallels [lassiter-goodman-2017]'s
-    tall/short (Eqs. 22–23): same scale, reversed polarity. -/
-theorem antonymy_from_polarity (cr : AgentCredence E W)
-    (a : E) (φ ψ : (W → Bool)) :
-    moreCredent cr a φ ψ ↔
-    ∃ θ : ℚ, meetsThreshold cr θ a φ ∧ failsThreshold cr θ a ψ := by
-  rw [comparative_from_positive]
-  constructor
-  · intro ⟨θ, hφ, hψ⟩
-    exact ⟨θ, hφ, not_le.mp hψ⟩
-  · intro ⟨θ, hφ, hψ⟩
-    exact ⟨θ, hφ, not_le.mpr hψ⟩
 
 -- ============================================================================
 -- §11. Quantified Operators (Table 1(a))
@@ -754,8 +628,10 @@ theorem uncertainAbout_contradicts_certainAbout (cr : AgentCredence E W)
     (h_cert : certainAbout cr a C φ) : False := by
   obtain ⟨x, hC, hcr⟩ := h_cert
   have h_fail := h_unc x hC
-  simp only [failsThreshold, EpistemicEntry.uncertain_] at h_fail
-  simp only [meetsThreshold, EpistemicEntry.certain_] at hcr
+  simp only [failsThreshold, EpistemicEntry.uncertain_,
+    Core.Order.Comparison.mem_over, Core.Order.Comparison.rel] at h_fail
+  simp only [meetsThreshold, EpistemicEntry.certain_,
+    Core.Order.Comparison.mem_over, Core.Order.Comparison.rel] at hcr
   linarith
 
 -- ============================================================================

--- a/Linglib/Semantics/Degree/Discrete.lean
+++ b/Linglib/Semantics/Degree/Discrete.lean
@@ -1,4 +1,5 @@
 import Mathlib.Order.BoundedOrder.Basic
+import Linglib.Core.Order.Comparison
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Fintype.Card
 import Mathlib.Order.Fin.Basic
@@ -107,36 +108,29 @@ section Concrete
 
 variable {max : Nat}
 
-/-- Positive form (*tall*): `t < d`. -/
+/-- Positive form (*tall*): `t < d` — the strict threshold face of
+`Core.Order.Comparison.gt.over` on the discrete carrier. -/
 def positiveMeaning (d : Degree max) (t : Threshold max) : Prop :=
-  (t : Degree max) < d
+  d ∈ Core.Order.Comparison.gt.over id (t : Degree max)
 
 /-- Polar antonym (*short*): `d < t`, evaluated against the antonym's own
 threshold (which may sit below the positive's — see `Gradability.ThresholdPair`). -/
 def negativeMeaning (d : Degree max) (t : Threshold max) : Prop :=
-  d < (t : Degree max)
+  d ∈ Core.Order.Comparison.lt.over id (t : Degree max)
 
 /-- Contradictory negation (*not tall*): `d ≤ t`, the complement of
 `positiveMeaning`. Not the polar antonym — that is `negativeMeaning`. -/
 def notPositiveMeaning (d : Degree max) (t : Threshold max) : Prop :=
-  d ≤ (t : Degree max)
+  d ∈ Core.Order.Comparison.le.over id (t : Degree max)
 
 instance (d : Degree max) (t : Threshold max) : Decidable (positiveMeaning d t) :=
-  inferInstanceAs (Decidable (_ < _))
+  inferInstanceAs (Decidable ((t : Degree max) < d))
 
 instance (d : Degree max) (t : Threshold max) : Decidable (negativeMeaning d t) :=
-  inferInstanceAs (Decidable (_ < _))
+  inferInstanceAs (Decidable (d < (t : Degree max)))
 
 instance (d : Degree max) (t : Threshold max) : Decidable (notPositiveMeaning d t) :=
-  inferInstanceAs (Decidable (_ ≤ _))
-
-/-- Monotonicity of `positiveMeaning` in the threshold: a higher threshold
-is informationally stronger. Grounds the weak-vs-strong-adjective
-distinction (`InformationalStrength`). -/
-theorem positiveMeaning_monotone (d : Degree max) (θ_weak θ_strong : Threshold max)
-    (h_ord : θ_weak ≤ θ_strong) (h_strong : positiveMeaning d θ_strong) :
-    positiveMeaning d θ_weak :=
-  lt_of_le_of_lt h_ord h_strong
+  inferInstanceAs (Decidable (d ≤ (t : Degree max)))
 
 end Concrete
 

--- a/Linglib/Semantics/Degree/Gradability/Antonymy.lean
+++ b/Linglib/Semantics/Degree/Gradability/Antonymy.lean
@@ -38,7 +38,8 @@ namespace Degree.Antonymy
 @[simp] theorem contradictory_is_complement {max : Nat}
     (d : Degree max) (θ : Threshold max) :
     contradictoryNeg d θ ↔ ¬ positiveMeaning d θ := by
-  simp only [contradictoryNeg, notPositiveMeaning, positiveMeaning, not_lt]
+  simp only [contradictoryNeg, notPositiveMeaning, positiveMeaning,
+    Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, id_eq, not_lt]
 
 /-- Double contradictory negation eliminates: "not [not happy]" = "happy".
 
@@ -67,7 +68,8 @@ theorem contradictory_exhaustive {max : Nat}
     (d : Degree max) (tp : ThresholdPair max) :
     inGapRegion d tp ↔ notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
   simp only [inGapRegion, notContraryNegMeaning, positiveMeaning',
-             Degree.positiveMeaning, not_lt]
+             Degree.positiveMeaning, Core.Order.Comparison.mem_over,
+             Core.Order.Comparison.rel, id_eq, not_lt]
 
 /-- When the gap is strict (θ_neg < θ_pos), there exists a degree that is
     "not unhappy" but NOT "happy" — double negation through contrary fails.
@@ -76,7 +78,8 @@ theorem contrary_gap_exists {max : Nat} (tp : ThresholdPair max)
     (h : (tp.neg : Degree max) < (tp.pos : Degree max)) :
     ∃ d : Degree max, notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
   refine ⟨↑tp.neg, le_refl _, ?_⟩
-  simp only [positiveMeaning', Degree.positiveMeaning, not_lt]
+  simp only [positiveMeaning', Degree.positiveMeaning,
+    Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, id_eq, not_lt]
   exact le_of_lt h
 
 /-- The gap region is nonempty when θ_neg < θ_pos. -/

--- a/Linglib/Semantics/Degree/Gradability/StatesBased.lean
+++ b/Linglib/Semantics/Degree/Gradability/StatesBased.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Order.Boundedness
+import Linglib.Core.Order.Comparison
 import Linglib.Core.Order.ComparativeScale
 
 /-!
@@ -68,7 +69,7 @@ variable {S : Type*} [Preorder S]
     instead of `d > θ` (degree exceeds threshold), we have `c ≤ s`
     (state is at or above the contrast point in the preorder). -/
 def StatesBasedEntry.inPositiveRegion (entry : StatesBasedEntry S) (s : S) : Prop :=
-  entry.contrastPoint ≤ s
+  s ∈ Core.Order.Comparison.ge.over id entry.contrastPoint
 
 /-- A state is in the *lower* region iff it is at or below the contrast
     point. The dual of `inPositiveRegion`, used for negative-polarity
@@ -80,7 +81,7 @@ def StatesBasedEntry.inPositiveRegion (entry : StatesBasedEntry S) (s : S) : Pro
     `Mathlib.Order.UpperLower` provides `UpperSet` and `LowerSet` as
     separate types over the same preorder. -/
 def StatesBasedEntry.inLowerRegion (entry : StatesBasedEntry S) (s : S) : Prop :=
-  s ≤ entry.contrastPoint
+  s ∈ Core.Order.Comparison.le.over id entry.contrastPoint
 
 /-- Two entries with strictly-ordered contrast points carve out
     disjoint upper/lower regions. If `e_pos.contrastPoint > e_low.contrastPoint`

--- a/Linglib/Semantics/Degree/Predicate.lean
+++ b/Linglib/Semantics/Degree/Predicate.lean
@@ -11,7 +11,8 @@ import Linglib.Core.Order.Comparison
 
 Predicate transformers over a measure function `μ : W → α`:
 
-- `IsUpwardMonotone` / `IsDownwardMonotone` / `IsConstant` / `AdmitsOptimum`
+- `IsConstant` / `AdmitsOptimum` (informativity; monotonicity is mathlib's
+  `Monotone`/`Antitone` under the pointwise order on `W → Prop`)
 - `typeLower` (Partee 1987 existential lowering)
 - monotonicity / anti-Horn-scale lemmas about the `Core.Order.Comparison.over`
   degree predicates (general)
@@ -32,17 +33,11 @@ open Core.Order
 
 variable {α : Type*} [LinearOrder α]
 
-/-- A family of propositions indexed by scale values is **upward monotone**
-    (entailments go from smaller to larger values).
-    Kennedy: "tall" — if x is tall, x is tall-or-more.
-    Rouillard: E-TIA with telic VP — if event fits in n days, it fits in m ≥ n days. -/
-def IsUpwardMonotone {W : Type*} (P : α → W → Prop) : Prop :=
-  ∀ (x y : α), x ≤ y → ∀ w, P x w → P y w
-
-/-- A family is **downward monotone**: entailments go from larger to smaller.
-    Rouillard: E-TIA with atelic VP — if sick during n-day time, sick during m ≤ n day time. -/
-def IsDownwardMonotone {W : Type*} (P : α → W → Prop) : Prop :=
-  ∀ (x y : α), x ≤ y → ∀ w, P y w → P x w
+-- A family of propositions indexed by scale values is **upward monotone**
+-- (entailments go from smaller to larger; Kennedy: if x is tall, x is
+-- tall-or-more; Rouillard: telic E-TIA) exactly when it is mathlib's
+-- `Monotone` under the pointwise order on `W → Prop` (`p ≤ q ↔ p → q`);
+-- downward monotone (atelic E-TIA) is `Antitone`. No local aliases.
 
 /-- A family is **constant**: every value yields the same proposition.
     This is information collapse — no value is more informative than another.
@@ -52,18 +47,18 @@ def IsConstant {W : Type*} (P : α → W → Prop) : Prop :=
 
 /-- If P is both upward and downward monotone, it is constant. -/
 theorem bimonotone_constant {W : Type*} (P : α → W → Prop)
-    (hUp : IsUpwardMonotone P) (hDown : IsDownwardMonotone P) :
+    (hUp : Monotone P) (hDown : Antitone P) :
     IsConstant P := by
   intro x y w
   constructor
   · intro hx
     rcases le_total x y with h | h
-    · exact hUp x y h w hx
-    · exact hDown y x h w hx
+    · exact hUp h w hx
+    · exact hDown h w hx
   · intro hy
     rcases le_total y x with h | h
-    · exact hUp y x h w hy
-    · exact hDown x y h w hy
+    · exact hUp h w hy
+    · exact hDown h w hy
 
 /-- **Informativity licensing**: a scale admits a well-defined optimum iff
     it is NOT constant. When the family is constant (information collapse),
@@ -81,7 +76,7 @@ def AdmitsOptimum {W : Type*} (P : α → W → Prop) : Prop :=
     maximally informative. This is the abstract core of why open-scale
     degree modification and atelic-VP E-TIAs are both blocked. -/
 theorem bimonotone_no_optimum {W : Type*} (P : α → W → Prop)
-    (hUp : IsUpwardMonotone P) (hDown : IsDownwardMonotone P) :
+    (hUp : Monotone P) (hDown : Antitone P) :
     ¬ AdmitsOptimum P :=
   fun h => h (bimonotone_constant P hUp hDown)
 
@@ -97,14 +92,6 @@ theorem bimonotone_no_optimum {W : Type*} (P : α → W → Prop)
     (`Mathlib.Order.Bounds.Image`). -/
 
 /-! ### Licensing Predictions (Data-Level) -/
-
-/-- Closed scales predict licensing (Kennedy: "completely full" ✓;
-    Rouillard: telic VP E-TIA ✓). -/
-theorem closed_isLicensed : Boundedness.closed.IsLicensed := trivial
-
-/-- Open scales predict blocking (Kennedy: "??completely tall";
-    Rouillard: atelic VP E-TIA ✗). -/
-theorem open_notLicensed : ¬ Boundedness.open_.IsLicensed := id
 
 /-! ### Degree Properties ([fox-hackl-2006]) -/
 
@@ -127,13 +114,9 @@ The key divergence: on ℕ, `>` collapses to `≥` with successor, so both
 have `HasMaxInf`. On dense scales, `>` yields an open set with no max⊨.
 This is the UDM prediction ([fox-hackl-2006]). -/
 
-/-- "At least" is downward monotone: weaker thresholds are easier to satisfy. -/
-theorem geOver_downMono {W : Type*} (μ : W → α) : IsDownwardMonotone (Comparison.ge.over μ) :=
-  fun _ _ hxy _ hy => le_trans hxy hy
-
-/-- "More than" is downward monotone: weaker thresholds are easier to satisfy. -/
-theorem gtOver_downMono {W : Type*} (μ : W → α) : IsDownwardMonotone (Comparison.gt.over μ) :=
-  fun _ _ hxy _ hy => lt_of_le_of_lt hxy hy
+-- "At least"/"more than" are threshold-antitone and "at most" is
+-- threshold-monotone: `Comparison.antitone_ge_over`, `antitone_gt_over`,
+-- `monotone_le_over` (Core/Order/Comparison.lean).
 
 /-- On ℕ, `>` collapses to `≥` with successor: "more than m" ↔ "at least m+1".
     This is the discrete equivalence that density breaks. -/
@@ -270,12 +253,6 @@ theorem distinct_no_universal_witness {α : Type*} (k₁ k₂ : α) (hne : k₁ 
     ¬ ∃ x, ∀ k, k = k₁ ∨ k = k₂ → x = k := by
   rintro ⟨x, h⟩
   exact hne ((h k₁ (Or.inl rfl)).symm.trans (h k₂ (Or.inr rfl)))
-
-/-! ### "At most" Symmetry (Rouillard's direction) -/
-
-/-- "At most" is upward monotone: larger thresholds are easier to satisfy. -/
-theorem leOver_upMono {W : Type*} (μ : W → α) : IsUpwardMonotone (Comparison.le.over μ) :=
-  fun _ _ hxy _ hy => le_trans hy hxy
 
 /-! IsMaxInf-flavored consequences of "at most" (`atMost_hasMaxInf`,
     `isMaxInf_atMost_iff_eq`) live in

--- a/Linglib/Semantics/Dynamic/Effects/Probability.lean
+++ b/Linglib/Semantics/Dynamic/Effects/Probability.lean
@@ -286,12 +286,6 @@ This probability is the graded truth value.
 variable {ε : Type}
 
 /--
-Threshold semantics: entity satisfies predicate if measure exceeds threshold.
--/
-def thresholdSem (measure : ε → ℚ) (threshold : ℚ) (x : ε) : Bool :=
-  measure x > threshold
-
-/--
 Graded truth from threshold uncertainty.
 
 Given a prior over thresholds, the graded truth is the probability

--- a/Linglib/Semantics/Entailment/Extremum.lean
+++ b/Linglib/Semantics/Entailment/Extremum.lean
@@ -97,18 +97,18 @@ def InformationCollapse {W : Type*} (P : α → W → Prop) : Prop :=
     cross-world maximally informative. The converse requires
     threshold-witness assumptions on the world space (one direction only). -/
 theorem isMaxInf_of_isLeast_upward {W : Type*}
-    {P : α → W → Prop} (hUp : IsUpwardMonotone P) (w : W) (x : α)
+    {P : α → W → Prop} (hUp : Monotone P) (w : W) (x : α)
     (h : IsLeast {y | P y w} x) : IsMaxInf P x w := by
   refine ⟨h.1, fun y hy w' hx_w' => ?_⟩
-  exact hUp x y (h.2 hy) w' hx_w'
+  exact hUp (h.2 hy) w' hx_w'
 
 /-- Dually for downward-monotone families: the per-world largest-true value
     is cross-world maximally informative. -/
 theorem isMaxInf_of_isGreatest_downward {W : Type*}
-    {P : α → W → Prop} (hDown : IsDownwardMonotone P) (w : W) (x : α)
+    {P : α → W → Prop} (hDown : Antitone P) (w : W) (x : α)
     (h : IsGreatest {y | P y w} x) : IsMaxInf P x w := by
   refine ⟨h.1, fun y hy w' hx_w' => ?_⟩
-  exact hDown y x (h.2 hy) w' hx_w'
+  exact hDown (h.2 hy) w' hx_w'
 
 -- ════════════════════════════════════════════════════
 -- § 3. MIP licensing

--- a/Linglib/Semantics/Modality/EpistemicProbability.lean
+++ b/Linglib/Semantics/Modality/EpistemicProbability.lean
@@ -145,7 +145,8 @@ theorem nestedThreshold_const_iff {E W : Type*}
     (cr : AgentCredence E W) (θ : ℚ) (a : E) (φ : (W → Bool)) (w : W) :
     (nestedThreshold (liftCredence cr) θ a φ) w = true ↔
     meetsThreshold cr θ a φ := by
-  simp only [nestedThreshold, liftCredence, meetsThreshold, decide_eq_true_eq]
+  simp only [nestedThreshold, liftCredence, meetsThreshold,
+    Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, id_eq, decide_eq_true_eq]
 
 -- ============================================================================
 -- §4. Standard Thresholds for Probability Expressions

--- a/Linglib/Semantics/Quantification/Numerals/Basic.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Basic.lean
@@ -100,7 +100,7 @@ of the corresponding `Core.Order.Comparison.over` degree property. They capture
 where `n` plays the role of `max{d | #P ≥ d}` and `m` is the numeral.
 `bareMeaning` is the exact (Kennedy) reading; the lower-bound (Horn) reading
 of bare numerals is `atLeastMeaning`. Grounding in `Comparison.over` makes the
-density predictions (`geOver_downMono`, `moreThan_noMaxInf`,
+density predictions (`Comparison.antitone_ge_over`, `moreThan_noMaxInf`,
 `atLeast_hasMaxInf`, etc.) hold by construction. -/
 
 /-- Bare numeral meaning (exact reading): `n = m`. -/

--- a/Linglib/Studies/AlexandropoulouGotzner2024.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024.lean
@@ -32,7 +32,8 @@ theorem (lexical commitment ↔ output of pragmatic strengthening) lives there.
 ## Substrate consumed
 
 - `Semantics/Degree/Basic.lean` — `positiveMeaning`, `notPositiveMeaning`,
-  `positiveMeaning_monotone` (all `Prop`-valued, decidable).
+  threshold antitonicity (`Comparison.antitone_gt_over`; all `Prop`-valued,
+  decidable).
 - `Semantics/Gradability/Theory.lean` — `ThresholdPair`,
   `positiveMeaning'`, `contraryNegMeaning`, `notContraryNegMeaning`,
   `inGapRegion` (all `abbrev`s over the Core primitives).
@@ -63,7 +64,8 @@ open Core.Order (Boundedness)
 open Degree (Degree Threshold deg thr)
 open Degree (GradableAdjective ThresholdPair inGapRegion
   positiveMeaning' contraryNegMeaning notContraryNegMeaning)
-open Degree (positiveMeaning notPositiveMeaning positiveMeaning_monotone)
+open Degree (positiveMeaning notPositiveMeaning)
+open Core.Order (Comparison)
 open English.Predicates.Adjectival
   (large small gigantic tiny clean dirty pristine filthy)
 
@@ -181,8 +183,9 @@ theorem contradictory_is_complement {max : Nat}
 -- § 5. Monotonicity → Strength & Precision
 -- ============================================================================
 
-/-! `positiveMeaning_monotone` (Core): higher threshold ⇒ informationally
-    stronger. This single substrate theorem grounds both:
+/-! Threshold antitonicity (`Comparison.antitone_gt_over`): higher
+    threshold ⇒ informationally stronger. This single substrate theorem
+    grounds both:
     1. Strong adjectives entail weak (gigantic ⇒ large).
     2. Precision upshift entails standard (pristine-precision ⇒ standard
        precision; cf. Glossa §4.2 precision-shift mechanism in §7 below). -/
@@ -192,15 +195,17 @@ theorem strong_entails_weak (θ_weak θ_strong : Thr5)
     (h_ord : θ_weak ≤ θ_strong) (d : Deg5)
     (h_strong : positiveMeaning d θ_strong) :
     positiveMeaning d θ_weak :=
-  positiveMeaning_monotone d θ_weak θ_strong h_ord h_strong
+  Comparison.antitone_gt_over id
+    (show (θ_weak : Deg5) ≤ (θ_strong : Deg5) from h_ord) h_strong
 
 /-- Concrete witness: degree 4 is positive at the weak threshold (thr 2)
     BECAUSE it is positive at the strong threshold (thr 3) and monotonicity
     propagates. -/
 theorem gigantic_entails_large :
     positiveMeaning (deg 4 : Deg5) (thr 2 : Thr5) :=
-  positiveMeaning_monotone (deg 4) (thr 2 : Thr5) (thr 3 : Thr5)
-    (by decide) (by decide)
+  Comparison.antitone_gt_over id
+    (show ((thr 2 : Thr5) : Deg5) ≤ ((thr 3 : Thr5) : Deg5) by decide)
+    (by decide)
 
 /-- Precision upshift entails the standard reading: a degree satisfying
     "clean" at pristine precision (θ = 3) satisfies "clean" at standard
@@ -208,7 +213,8 @@ theorem gigantic_entails_large :
 theorem precision_entails_standard (d : Deg5)
     (h : positiveMeaning d (thr 3 : Thr5)) :
     positiveMeaning d (thr 1 : Thr5) :=
-  positiveMeaning_monotone d (thr 1 : Thr5) (thr 3 : Thr5) (by decide) h
+  Comparison.antitone_gt_over id
+    (show ((thr 1 : Thr5) : Deg5) ≤ ((thr 3 : Thr5) : Deg5) by decide) h
 
 -- ============================================================================
 -- § 6. Predictions for Contrary Antonyms

--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -1146,19 +1146,19 @@ def factiveComplementAI : AtIssuenessDegree := ⟨3/4, by norm_num, by norm_num�
 
 private theorem isAtIssue_lexical :
     ¬ isAtIssue (complementAtIssueness .lexical) defaultThreshold := by
-  simp only [isAtIssue, Core.Order.Rat01.exceeds, complementAtIssueness,
+  simp only [isAtIssue, Core.Order.Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, complementAtIssueness,
              defaultThreshold, Core.Order.Rat01.half, not_lt]
   norm_num
 
 private theorem isAtIssue_none :
     isAtIssue (complementAtIssueness .none) defaultThreshold := by
-  simp only [isAtIssue, Core.Order.Rat01.exceeds, complementAtIssueness,
+  simp only [isAtIssue, Core.Order.Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, complementAtIssueness,
              defaultThreshold, Core.Order.Rat01.half]
   norm_num
 
 private theorem isAtIssue_factive :
     isAtIssue factiveComplementAI defaultThreshold := by
-  simp only [isAtIssue, Core.Order.Rat01.exceeds, factiveComplementAI,
+  simp only [isAtIssue, Core.Order.Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, factiveComplementAI,
              defaultThreshold, Core.Order.Rat01.half]
   norm_num
 
@@ -1210,6 +1210,7 @@ theorem predictIsland_monotone (d₁ d₂ : AtIssuenessDegree)
     simp [h₁, h₂]
   -- Contradictory case: d₁ at-issue but d₂ not, yet d₁.val ≤ d₂.val
   unfold isAtIssue Core.Order.Rat01.exceeds at h₁ h₂
+  simp only [Core.Order.Comparison.mem_over, Core.Order.Comparison.rel] at h₁ h₂
   rw [not_lt] at h₂
   exact absurd (lt_of_lt_of_le h₁ (le_trans h h₂)) (lt_irrefl _)
 

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -295,7 +295,7 @@ def gTIAPropertyOpenNeg (P : W → Event Time → Prop) (μ : NonemptyInterval T
     `TimeMeasure.extensibleLeft`. -/
 theorem gTIAPropertyOpen_upwardMonotone {μ : NonemptyInterval Time → α}
     [TimeMeasure Time μ] (P : W → Event Time → Prop) (s : Time) :
-    IsUpwardMonotone (gTIAPropertyOpen P μ s) := by
+    Monotone (gTIAPropertyOpen P μ s) := by
   rintro n m hnm w ⟨ptsGI, hOpen, hRight, hμ, e, hP, hSub⟩
   obtain ⟨j, hij, hjsnd, hjμ⟩ :=
     TimeMeasure.extensibleLeft ptsGI.toInterval m (hμ ▸ hnm)
@@ -318,9 +318,9 @@ theorem gTIAPropertyOpen_upwardMonotone {μ : NonemptyInterval Time → α}
     monotonicity that `gTIANeg_hasIsGreatest` needs. -/
 theorem gTIAPropertyOpenNeg_downwardMonotone {μ : NonemptyInterval Time → α}
     [TimeMeasure Time μ] (P : W → Event Time → Prop) (s : Time) :
-    IsDownwardMonotone (gTIAPropertyOpenNeg P μ s) :=
+    Antitone (gTIAPropertyOpenNeg P μ s) :=
   fun x y hxy w hy hx =>
-    hy (gTIAPropertyOpen_upwardMonotone P s x y hxy w hx)
+    hy (gTIAPropertyOpen_upwardMonotone P s hxy w hx)
 
 /-! ### The MIP licensing predicate
 
@@ -377,7 +377,7 @@ theorem eTIA_atelic_not_licensed {μ : NonemptyInterval Time → α} [TimeMeasur
     measures via `TimeMeasure.extensible`. -/
 theorem eTIA_telic_upwardMonotone {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
     (P : W → Event Time → Prop) (g1 : NonemptyInterval Time) :
-    IsUpwardMonotone (eTIAProperty P μ g1) := by
+    Monotone (eTIAProperty P μ g1) := by
   intro n m hnm w ⟨t, hμ, e, hP, hg1, hsub⟩
   have h_le : μ t ≤ m := by rw [hμ]; exact hnm
   obtain ⟨j, hj_sup, hj_μ⟩ := TimeMeasure.extensible (μ := μ) t m h_le
@@ -391,7 +391,7 @@ theorem eTIA_telic_upwardMonotone {μ : NonemptyInterval Time → α} [TimeMeasu
     `ℕ`: extremum existence needs a well-founded codomain, which dense `α`
     deliberately lacks (that failure IS the G-TIA collapse below). -/
 theorem upwardMonotone_hasIsLeast_of_witness {W : Type*}
-    {P : ℕ → W → Prop} (_hUp : IsUpwardMonotone P) (w : W)
+    {P : ℕ → W → Prop} (_hUp : Monotone P) (w : W)
     [DecidablePred (fun n => P n w)]
     (h_witness : ∃ n, P n w) :
     ∃ x, IsLeast {y | P y w} x := by
@@ -529,7 +529,7 @@ example {W : Type*} (P : W → Event ℚ → Prop) (s : ℚ) :
     bridge is `Extremum.isMaxInf_of_isGreatest_downward`. Pinned to `ℕ` for
     the same well-foundedness reason as its dual. -/
 theorem downwardMonotone_hasIsGreatest_of_bound {W : Type*}
-    {P : ℕ → W → Prop} (hDown : IsDownwardMonotone P) (w : W)
+    {P : ℕ → W → Prop} (hDown : Antitone P) (w : W)
     [DecidablePred (fun n => P n w)]
     (h_witness : ∃ n, P n w) (h_bound : ∃ n, ¬ P n w) :
     ∃ x, IsGreatest {y | P y w} x := by
@@ -537,13 +537,13 @@ theorem downwardMonotone_hasIsGreatest_of_bound {W : Type*}
   obtain ⟨n₀, hn₀⟩ := h_witness
   have h_pos : 0 < Nat.find h_bound :=
     Nat.pos_of_ne_zero fun h =>
-      (h ▸ Nat.find_spec h_bound) (hDown 0 n₀ (Nat.zero_le _) w hn₀)
+      (h ▸ Nat.find_spec h_bound) (hDown (Nat.zero_le _) w hn₀)
   refine ⟨Nat.find h_bound - 1,
     not_not.mp (Nat.find_min h_bound (Nat.sub_lt h_pos one_pos)),
     fun y hy => ?_⟩
   have h_lt : y < Nat.find h_bound := by
     by_contra h_ge
-    exact Nat.find_spec h_bound (hDown _ y (not_lt.mp h_ge) w hy)
+    exact Nat.find_spec h_bound (hDown (not_lt.mp h_ge) w hy)
   omega
 
 /-- **Negated G-TIAs satisfy the MIP at the gap length**. With a true

--- a/Linglib/Studies/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Studies/TonhauserBeaverDegen2018.lean
@@ -70,7 +70,7 @@ at-issue — is the threshold collapse of the gradient GPP. -/
 /-- The GPP projects past `θ` iff at-issueness is below the complementary threshold. -/
 theorem gpp_projects_iff (ai θ : Rat01) :
     isProjective (gppProjection ai) θ ↔ ai.val < (Rat01.compl θ).val := by
-  simp only [isProjective, Rat01.exceeds, gppProjection, Rat01.compl_val]
+  simp only [isProjective, Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, gppProjection, Rat01.compl_val]
   constructor <;> intro h <;> linarith
 
 /-- The binary Projection Principle: never both at-issue and projecting at
@@ -78,7 +78,7 @@ theorem gpp_projects_iff (ai θ : Rat01) :
 theorem gpp_excludes_atIssue (ai θ : Rat01) :
     ¬ (isAtIssue ai (Rat01.compl θ) ∧ isProjective (gppProjection ai) θ) := by
   rintro ⟨ha, hp⟩
-  simp only [isAtIssue, Rat01.exceeds, Rat01.compl_val] at ha
+  simp only [isAtIssue, Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, Rat01.compl_val] at ha
   rw [gpp_projects_iff, Rat01.compl_val] at hp
   linarith
 


### PR DESCRIPTION
Positive-form/threshold prune (survey: 5 duplication clusters across Degree/Attitudes/Modality).

- `Core/Order/Comparison.lean` gains the missing threshold API: `antitone_ge_over`/`antitone_gt_over`/`monotone_le_over`/`monotone_lt_over`, measure transport `mem_ge_over_of_le`, polarity duality, and the Klein separating-threshold reduction — previously re-proved locally at ℚ/`Degree max`/credences.
- The framework faces stay as owner vocabulary but are now DEFINED via the spine: `Degree.positiveMeaning` (+neg/notPos), `StatesBasedEntry.inPositiveRegion` (+lower), `meetsThreshold`/`failsThreshold`, `Rat01.exceeds`.
- Killed: 9 duplicate threshold/measure-monotonicity and ℚ-specific Klein/duality lemmas; dead `thresholdSem`; `IsUpwardMonotone`/`IsDownwardMonotone` (= mathlib `Monotone`/`Antitone` on pointwise Prop order) and the `Comparison.over` monotonicity trio in Predicate.lean (subsumed by the spine); two trivial licensing echoes.
- Standard-selection stays per-framework (Kennedy IE, CSW contrast points, LaBToM entries, Krifka pairs, Fagin–Halpern nesting, Klein delineation) — the comparison is what they share; the θ-fixing is what they disagree about.