### PR TITLE
refactor(Semantics/Degree): mathlib names over Extent alias lemmas

### DIFF
--- a/Linglib/Semantics/Degree/Comparative.lean
+++ b/Linglib/Semantics/Degree/Comparative.lean
@@ -410,10 +410,10 @@ theorem gtOverSet_atomic_eq_comparativeSem (μ : Entity → D) (a b : Entity) :
   rw [Comparison.overSet_singleton, ← comparativeSem_positive_eq_over]
 
 /-- "A is taller than B" iff A's positive extent strictly contains B's
-([kennedy-1999]). Bridges the point comparison to `posExt_ssubset_iff`. -/
+([kennedy-1999]). Bridges the point comparison to `Set.Iic_ssubset_Iic`. -/
 theorem comparative_iff_posExt_ssubset (μ : Entity → D) (a b : Entity) :
     comparativeSem μ a b .positive ↔ posExt μ b ⊂ posExt μ a :=
-  (posExt_ssubset_iff μ b a).symm
+  Set.Iic_ssubset_Iic.symm
 
 /-- "A taller than B" iff "B shorter than A", derived from the complementarity
 of positive and negative extents rather than stipulated as a lexical property
@@ -458,13 +458,13 @@ theorem negatedEquative_iff_not_sem [LinearOrder D] (μ : Entity → D) (a b : E
 iff `posExt μ b ⊆ posExt μ a` — every degree B has, A also has. -/
 theorem equativeSem_iff_posExt_subset [LinearOrder D] (μ : Entity → D) (a b : Entity) :
     equativeSem μ a b .positive ↔ posExt μ b ⊆ posExt μ a :=
-  (posExt_subset_iff μ b a).symm
+  Set.Iic_subset_Iic.symm
 
 /-- Negated equative as strict extent inclusion: B has strictly more degrees
 than A. -/
 theorem negatedEquative_iff_posExt_ssubset [LinearOrder D] (μ : Entity → D) (a b : Entity) :
     negatedEquative μ a b ↔ posExt μ a ⊂ posExt μ b :=
-  (posExt_ssubset_iff μ a b).symm
+  Set.Iic_ssubset_Iic.symm
 
 end Equative
 

--- a/Linglib/Semantics/Degree/Extent.lean
+++ b/Linglib/Semantics/Degree/Extent.lean
@@ -57,25 +57,9 @@ abbrev posExt [Preorder D] (μ : Entity → D) (x : Entity) : Set D :=
 abbrev negExt [Preorder D] (μ : Entity → D) (x : Entity) : Set D :=
   Set.Ioi (μ x)
 
-/-- Higher degree ↔ larger positive extent. -/
-theorem posExt_subset_iff [Preorder D] (μ : Entity → D) (a b : Entity) :
-    posExt μ a ⊆ posExt μ b ↔ μ a ≤ μ b :=
-  Set.Iic_subset_Iic
-
-/-- Strict version of `posExt_subset_iff`. -/
-theorem posExt_ssubset_iff [Preorder D] (μ : Entity → D) (a b : Entity) :
-    posExt μ a ⊂ posExt μ b ↔ μ a < μ b :=
-  Set.Iic_ssubset_Iic
-
-/-- Higher degree ↔ SMALLER negative extent (reverse monotonicity). -/
-theorem negExt_subset_iff [LinearOrder D] (μ : Entity → D) (a b : Entity) :
-    negExt μ a ⊆ negExt μ b ↔ μ b ≤ μ a :=
-  Set.Ioi_subset_Ioi_iff
-
-/-- Strict version of `negExt_subset_iff`. -/
-theorem negExt_ssubset_iff [LinearOrder D] (μ : Entity → D) (a b : Entity) :
-    negExt μ a ⊂ negExt μ b ↔ μ b < μ a :=
-  Set.Ioi_ssubset_Ioi_iff
+-- Extent inclusion/complement algebra is mathlib's, applying through the
+-- abbrevs directly: `Set.Iic_subset_Iic`, `Set.Iic_ssubset_Iic`,
+-- `Set.Ioi_subset_Ioi_iff`, `Set.Ioi_ssubset_Ioi_iff`, `Set.compl_Iic`.
 
 /-- **Antonymy biconditional** ([kennedy-1999] eq (54)).
 
@@ -90,14 +74,7 @@ theorem negExt_ssubset_iff [LinearOrder D] (μ : Entity → D) (a b : Entity) :
     a lexical antonymy property — survives the convention deviation. -/
 theorem antonymy_biconditional [LinearOrder D] (μ : Entity → D) (a b : Entity) :
     posExt μ b ⊂ posExt μ a ↔ negExt μ a ⊂ negExt μ b := by
-  rw [posExt_ssubset_iff, negExt_ssubset_iff]
-
-/-- `posExt` and `negExt` are set-theoretic complements on a linear order
-    (`Set.compl_Iic` under the abbrev). The lattice expression of
-    [kennedy-1999] eqs (52)–(53)'s join-complementarity. -/
-theorem compl_posExt [LinearOrder D] (μ : Entity → D) (x : Entity) :
-    (posExt μ x)ᶜ = negExt μ x :=
-  Set.compl_Iic
+  rw [Set.Iic_ssubset_Iic, Set.Ioi_ssubset_Ioi_iff]
 
 /-- Order-reversing equivalence between `posExt`- and `negExt`-inclusions.
     The Galois-antitone framing is `compl_subset_compl` specialized at
@@ -108,7 +85,7 @@ theorem compl_posExt [LinearOrder D] (μ : Entity → D) (x : Entity) :
     but the algebraic shadow of LITTLE *is* this antitone identity. -/
 theorem extent_galois_antitone [LinearOrder D] (μ : Entity → D) (a b : Entity) :
     posExt μ a ⊆ posExt μ b ↔ negExt μ b ⊆ negExt μ a := by
-  rw [posExt_subset_iff, negExt_subset_iff]
+  rw [Set.Iic_subset_Iic, Set.Ioi_subset_Ioi_iff]
 
 /-- The set-theoretic claim of "cross-polar inclusion": that the positive
     extent of one entity is included in the negative extent of another.

--- a/Linglib/Studies/Kennedy1999.lean
+++ b/Linglib/Studies/Kennedy1999.lean
@@ -64,7 +64,7 @@ namespace Kennedy1999
 open Degree (comparativeSem equativeSem
   comparative_iff_posExt_ssubset comparative_iff_negExt_ssubset
   equativeSem_iff_posExt_subset)
-open Degree (posExt negExt crossExtentInclusion crossExtent_always_false posExt_subset_iff negExt_subset_iff extent_galois_antitone)
+open Degree (posExt negExt crossExtentInclusion crossExtent_always_false extent_galois_antitone)
 -- ════════════════════════════════════════════════════
 -- § 1. Cross-Polar Anomaly Data
 -- ════════════════════════════════════════════════════
@@ -140,7 +140,7 @@ theorem samePolar_equative_welldefined {Entity D : Type*} [LinearOrder D]
 
 /-- "A is taller than B" iff B's positive extent is strictly contained
     in A's. Bridges the consensus comparative to the algebraic
-    `posExt_ssubset_iff` from `Degree`. -/
+    `Set.Iic_ssubset_Iic` through the `posExt` abbrev. -/
 theorem comparative_extent_bridge {Entity D : Type*} [LinearOrder D]
     (μ : Entity → D) (a b : Entity) :
     comparativeSem μ a b .positive ↔ posExt μ b ⊂ posExt μ a :=


### PR DESCRIPTION
Extent.lean under the mathlib-file lens: `posExt`/`negExt` abbrevs, the derived antonymy pair, `crossExtent_always_false`, and `isGreatest_posExt` stay (legitimate Kennedy-extent faces with honest convention-deviation docs); the five pure renames of `Set.Iic_subset_Iic`/`Set.Ioi_ssubset_Ioi_iff`/`Set.compl_Iic` die — the mathlib lemmas apply through the abbrevs directly. Consumers rewired (Comparative, Kennedy1999).