### PR TITLE
feat(Studies): Cresswell 1976 + Bale 2008; degree construction in Hom

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1616,6 +1616,7 @@ import Linglib.Studies.DinisJacinto2026
 import Linglib.Semantics.Degree.StatesBased
 import Linglib.Semantics.Degree.Granularity
 import Linglib.Semantics.Degree.Standard
+import Linglib.Studies.Bale2008
 import Linglib.Studies.Buring2007
 import Linglib.Semantics.Degree.MeasureOfChange
 import Linglib.Semantics.Degree.Measure
@@ -2170,6 +2171,7 @@ import Linglib.Studies.DegenTonhauser2021
 import Linglib.Studies.DegenTonhauser2022
 import Linglib.Studies.Dekier2021
 import Linglib.Studies.Dekker2012
+import Linglib.Studies.Cresswell1976
 import Linglib.Studies.DelPinal2015
 import Linglib.Studies.DelPinalBassiSauerland2024
 import Linglib.Studies.DelPrete2013

--- a/Linglib/Semantics/Degree/Hom.lean
+++ b/Linglib/Semantics/Degree/Hom.lean
@@ -1,3 +1,7 @@
+import Mathlib.Order.Antisymmetrization
+import Mathlib.Data.Fintype.Card
+import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Tactic.GCongr
 import Linglib.Features.Dimension
 import Linglib.Semantics.Degree.Delineation
 import Linglib.Semantics.Degree.Measurement
@@ -428,5 +432,97 @@ theorem very_strictly_stronger_degree :
   intro ⟨y, ⟨z, _, hlt_z⟩, hlt_y⟩
   simp only [id] at hlt_z hlt_y
   omega
+
+
+/-! ### The degree construction ([cresswell-1976] §4, [bale-2008])
+
+Degrees built from comparisons rather than assumed: [cresswell-1976]
+(4.1) quotients an arbitrary comparison relation `φ` by two-sided
+φ-indistinguishability, and (4.2) shows the induced comparison on
+classes is well-defined. On a preorder the construction coincides with
+mathlib's `Antisymmetrization` (`cresswellSetoid_le_iff`). [bale-2008]
+then maps any finite scale into the universal scale Ω ≅ ℚ ∩ (0, 1] by
+relative position (`relativeRank`), the homomorphism that licenses
+indirect cross-scale comparison. -/
+
+/-- Two-sided indistinguishability under a comparison `φ`
+    ([cresswell-1976] (4.1)): same φ-profile on the left and right. -/
+def cresswellSetoid {E : Type*} (φ : E → E → Prop) : Setoid E where
+  r a b := (∀ c, φ a c ↔ φ b c) ∧ (∀ c, φ c a ↔ φ c b)
+  iseqv :=
+    ⟨fun _ => ⟨fun _ => Iff.rfl, fun _ => Iff.rfl⟩,
+     fun h => ⟨fun c => (h.1 c).symm, fun c => (h.2 c).symm⟩,
+     fun h₁ h₂ => ⟨fun c => (h₁.1 c).trans (h₂.1 c),
+                   fun c => (h₁.2 c).trans (h₂.2 c)⟩⟩
+
+/-- Degrees of comparison as φ-equivalence classes ([cresswell-1976] (4.1)). -/
+abbrev CresswellDegree {E : Type*} (φ : E → E → Prop) : Type _ :=
+  Quotient (cresswellSetoid φ)
+
+/-- The induced comparison on degrees; well-definedness is
+    [cresswell-1976]'s own consistency proof for (4.2). -/
+def CresswellDegree.rel {E : Type*} {φ : E → E → Prop} :
+    CresswellDegree φ → CresswellDegree φ → Prop :=
+  Quotient.lift₂ φ fun _ b c _ hac hbd =>
+    propext ((hac.1 b).trans (hbd.2 c))
+
+/-- [cresswell-1976] (4.2): `ā >_φ b̄ iff φ(a, b)`. -/
+@[simp] theorem CresswellDegree.rel_mk {E : Type*} {φ : E → E → Prop} (a b : E) :
+    CresswellDegree.rel (⟦a⟧ : CresswellDegree φ) ⟦b⟧ ↔ φ a b :=
+  Iff.rfl
+
+/-- On a preorder, φ-indistinguishability under `≤` is mathlib's
+    `AntisymmRel`: the Cresswell quotient IS `Antisymmetrization`. -/
+theorem cresswellSetoid_le_iff {E : Type*} [Preorder E] (a b : E) :
+    (cresswellSetoid (· ≤ ·)).r a b ↔ AntisymmRel (· ≤ ·) a b := by
+  constructor
+  · intro ⟨h₁, h₂⟩
+    exact ⟨(h₁ b).mpr le_rfl, (h₁ a).mp le_rfl⟩
+  · intro ⟨hab, hba⟩
+    exact ⟨fun c => ⟨hba.trans, hab.trans⟩,
+           fun c => ⟨(le_trans · hab), (le_trans · hba)⟩⟩
+
+/-- [bale-2008]'s universal-degree homomorphism on a finite scale: the
+    relative position of `d`, in Ω ≅ ℚ ∩ (0, 1]. Defined on whatever
+    carrier plays the primary scale — in Bale's regime the *quotient*,
+    so equivalent individuals share a universal degree by construction
+    and the value counts equivalence classes, not individuals. -/
+def relativeRank {D : Type*} [Fintype D] [LinearOrder D] (d : D) : ℚ :=
+  (Finset.univ.filter (· ≤ d)).card / Fintype.card D
+
+/-- The universal-degree map preserves the primary scale's order
+    ([bale-2008]: ℌ preserves ≥_δ). -/
+theorem relativeRank_strictMono {D : Type*} [Fintype D] [LinearOrder D] :
+    StrictMono (relativeRank (D := D)) := by
+  intro a b hab
+  have hD : 0 < (Fintype.card D : ℚ) := by
+    exact_mod_cast Fintype.card_pos_iff.mpr ⟨a⟩
+  have hcard : ((Finset.univ.filter (· ≤ a)).card : ℚ) <
+      ((Finset.univ.filter (· ≤ b)).card : ℚ) := by
+    have h : (Finset.univ.filter (· ≤ a)).card <
+        (Finset.univ.filter (· ≤ b)).card := by
+      apply Finset.card_lt_card
+      refine ⟨fun c hc => ?_, fun hsub => ?_⟩
+      · simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hc ⊢
+        exact hc.trans hab.le
+      · have hb := hsub (Finset.mem_filter.mpr ⟨Finset.mem_univ b, le_rfl⟩)
+        simp only [Finset.mem_filter] at hb
+        exact absurd hb.2 (not_le.mpr hab)
+    exact_mod_cast h
+  unfold relativeRank
+  rw [div_eq_mul_inv, div_eq_mul_inv]
+  exact mul_lt_mul_of_pos_right hcard (inv_pos.mpr hD)
+
+/-- Universal degrees land in (0, 1]. -/
+theorem relativeRank_mem_Ioc {D : Type*} [Fintype D] [LinearOrder D] (d : D) :
+    relativeRank d ∈ Set.Ioc (0 : ℚ) 1 := by
+  have hD : 0 < (Fintype.card D : ℚ) := by
+    exact_mod_cast Fintype.card_pos_iff.mpr ⟨d⟩
+  unfold relativeRank
+  refine ⟨div_pos ?_ hD, ?_⟩
+  · exact_mod_cast Finset.card_pos.mpr ⟨d, by simp⟩
+  · rw [div_le_one hD]
+    exact_mod_cast Finset.card_filter_le _ _
+
 
 end Degree

--- a/Linglib/Studies/Bale2008.lean
+++ b/Linglib/Studies/Bale2008.lean
@@ -1,0 +1,167 @@
+import Linglib.Semantics.Degree.Hom
+import Linglib.Semantics.Degree.Basic
+
+/-!
+# Bale (2008): A Universal Scale of Comparison
+[bale-2008]
+
+Direct comparisons (*Seymour is taller than he is wide*) and indirect
+comparisons (*Esme is more beautiful than Einstein is intelligent*)
+unified through a Universal Scale Ω ≅ ℚ ∩ (0, 1]: individuals map to a
+primary scale built from an adjectival quasi-order restricted to a
+comparison class ([cresswell-1976]-style equivalence classes), and the
+homomorphism ℌ maps each class to the universal degree encoding its
+relative position (`Degree.relativeRank`). `MORE` compares universal
+degrees (`λμ λd λx. μ(x) ≻ d`), so cross-scale comparison is
+well-typed; direct comparison is the special case where a measurement
+system structures both primary scales identically.
+
+Formalized: the ten-member committee model with the beauty and
+intelligence orders, the (19a)/(19b) truth-value contrast, preservation
+of the primary order under ℌ, robustness of universal degrees under
+adding equally-ranked members (degrees count equivalence classes, not
+individuals), and the for-clause prediction that class-relative ranks
+can invert raw measurements (*taller for a boy than wide for a boy*
+false for a Seymour who is extremely wide but average in height).
+-/
+
+namespace Bale2008
+
+open Degree
+
+/-! ### The committee model (§4.2, Figs. 4–5) -/
+
+/-- The ten committee members `a`–`j`. -/
+inductive Member where
+  | a | b | c | d | e | f | g | h | i | j
+  deriving DecidableEq, Repr
+
+/-- Position in the beauty primary scale, bottom = 0: the order
+    a → b → c → d → e → f → g → h → i → j from most to least beautiful. -/
+def beautyPos : Member → Fin 10
+  | .a => 9 | .b => 8 | .c => 7 | .d => 6 | .e => 5
+  | .f => 4 | .g => 3 | .h => 2 | .i => 1 | .j => 0
+
+/-- Position in the intelligence primary scale: the order
+    i → f → j → g → h → a → d → b → e → c from most to least intelligent. -/
+def intelligencePos : Member → Fin 10
+  | .i => 9 | .f => 8 | .j => 7 | .g => 6 | .h => 5
+  | .a => 4 | .d => 3 | .b => 2 | .e => 1 | .c => 0
+
+/-- Universal beauty degree: ℌ applied to the member's class in the
+    beauty scale. Betty (`b`) receives `d_{9/10}` as in Fig. 4. -/
+def universalBeauty (m : Member) : ℚ := relativeRank (beautyPos m)
+
+/-- Universal intelligence degree; Heather (`h`) receives `d_{6/10}`
+    as in Fig. 5. -/
+def universalIntelligence (m : Member) : ℚ := relativeRank (intelligencePos m)
+
+/-- ℌ on a ten-class scale: position `k` from the bottom receives
+    `d_{(k+1)/10}` (Figs. 4–5's degree labels). -/
+theorem relativeRank_fin10 (k : Fin 10) : relativeRank k = (k.1 + 1 : ℚ) / 10 := by
+  have h : (Finset.univ.filter (· ≤ k)).card = k.1 + 1 := by revert k; decide
+  unfold relativeRank
+  rw [h, Fintype.card_fin]
+  push_cast
+  ring
+
+example : universalBeauty .b = 9/10 := by
+  simp [universalBeauty, beautyPos, relativeRank_fin10]
+  norm_num
+example : universalIntelligence .h = 6/10 := by
+  simp [universalIntelligence, intelligencePos, relativeRank_fin10]
+  norm_num
+
+/-- (19a) *Betty is more beautiful for a committee member than Heather
+    is intelligent* — true: `d_{9/10} ≻ d_{6/10}`. -/
+theorem betty_beautiful_gt_heather_intelligent :
+    universalIntelligence .h < universalBeauty .b := by
+  simp [universalBeauty, universalIntelligence, beautyPos, intelligencePos,
+        relativeRank_fin10]
+  norm_num
+
+/-- (19b) *Betty is more intelligent for a committee member than Evelin
+    is beautiful* — false: `d_{3/10} ⊁ d_{6/10}`. -/
+theorem betty_intelligent_not_gt_evelin_beautiful :
+    ¬ universalBeauty .e < universalIntelligence .b := by
+  simp [universalBeauty, universalIntelligence, beautyPos, intelligencePos,
+        relativeRank_fin10]
+  norm_num
+
+/-- Indirect comparison IS the point-standard comparative over universal
+    degrees: Bale's `MORE = λμ λd λx. μ(x) ≻ d` instantiated at the
+    than-clause degree. -/
+theorem more_eq_comparativeSem (x y : Member) :
+    universalIntelligence y < universalBeauty x ↔
+      (universalBeauty x > universalIntelligence y) :=
+  Iff.rfl
+
+/-- ℌ preserves the primary scale (§3.2): within one scale, indirect
+    comparison agrees with direct rank comparison. -/
+theorem universalBeauty_lt_iff (x y : Member) :
+    universalBeauty x < universalBeauty y ↔ beautyPos x < beautyPos y :=
+  relativeRank_strictMono.lt_iff_lt
+
+/-! ### Robustness (§4.2, Figs. 6–9): degrees count classes -/
+
+/-- The expanded committee: five extra members, each exactly as
+    beautiful as an original member (`b' ≈ b`, `a' ≈ b`, `c' ≈ c`,
+    `d' ≈ d`, `e' ≈ e` per Fig. 6). -/
+inductive Member' where
+  | old (m : Member) | a' | b' | c' | d' | e'
+  deriving DecidableEq, Repr
+
+/-- Beauty class in the expanded model: equivalent members share a
+    class, so the scale still has ten positions. -/
+def beautyPos' : Member' → Fin 10
+  | .old m => beautyPos m
+  | .a' => 8 | .b' => 8 | .c' => 7 | .d' => 6 | .e' => 5
+
+/-- Universal degrees are unchanged by adding equally-ranked members:
+    the assignment "is based on the number of equivalence classes in
+    the domain rather than the number of individuals". -/
+theorem universalBeauty_stable (m : Member) :
+    relativeRank (beautyPos' (.old m)) = universalBeauty m := rfl
+
+/-! ### For-clauses strip measurements (§1, §4.1) -/
+
+/-- Five boys with height and width measurements (in feet): Seymour is
+    5 ft tall — dead average — but 4 ft wide — the widest by far. -/
+inductive Boy where
+  | seymour | huey | dewey | louie | webby
+  deriving DecidableEq, Repr
+
+def heightFt : Boy → ℚ
+  | .seymour => 5 | .huey => 6 | .dewey => 55/10 | .louie => 45/10 | .webby => 4
+
+def widthFt : Boy → ℚ
+  | .seymour => 4 | .huey => 2 | .dewey => 15/10 | .louie => 1 | .webby => 1/2
+
+/-- Class-relative height position among the boys (Seymour: middle). -/
+def heightPos : Boy → Fin 5
+  | .huey => 4 | .dewey => 3 | .seymour => 2 | .louie => 1 | .webby => 0
+
+/-- Class-relative width position among the boys (Seymour: top). -/
+def widthPos : Boy → Fin 5
+  | .seymour => 4 | .huey => 3 | .dewey => 2 | .louie => 1 | .webby => 0
+
+/-- *Seymour is taller for a boy than he is wide for a boy* is FALSE
+    "despite the fact that the measurement of his height is greater
+    than the measurement of his width": for-clauses restrict the
+    primary scales to measurement-free class-relative ones, on which
+    Seymour's width position exceeds his height position. -/
+theorem seymour_for_a_boy :
+    widthFt .seymour < heightFt .seymour ∧
+      ¬ relativeRank (widthPos .seymour) < relativeRank (heightPos .seymour) := by
+  have h5 : ∀ k : Fin 5, relativeRank k = (k.1 + 1 : ℚ) / 5 := by
+    intro k
+    have h : (Finset.univ.filter (· ≤ k)).card = k.1 + 1 := by revert k; decide
+    unfold relativeRank
+    rw [h, Fintype.card_fin]
+    push_cast
+    ring
+  refine ⟨by norm_num [widthFt, heightFt], ?_⟩
+  simp [widthPos, heightPos, h5]
+  norm_num
+
+end Bale2008

--- a/Linglib/Studies/Cresswell1976.lean
+++ b/Linglib/Studies/Cresswell1976.lean
@@ -1,0 +1,117 @@
+import Linglib.Semantics.Degree.Hom
+import Linglib.Semantics.Degree.Quantifier
+
+/-!
+# Cresswell (1976): The Semantics of Degree
+[cresswell-1976]
+
+Degrees of comparison in a λ-categorial possible-worlds semantics: a
+degree is a scale-tagged point `⟨u, >⟩` (2.1), *er than* (2.3) compares
+degrees only on a **shared** scale (so (23) *taller man than … clever
+man* is anomalous — the same-scale restriction [bale-2008]'s universal
+scale later removes), the equative *as as* (2.7) is weak `≥` with
+*exactly* forcing `=`, and §4 grounds the degree ontology by
+constructing degrees from comparison relations: φ-equivalence classes
+(4.1) with the induced comparison well-defined (4.2). The construction
+is `Degree.cresswellSetoid`/`Degree.CresswellDegree` in
+`Semantics/Degree/Hom.lean`; this file checks the paper's claims on its
+own examples.
+
+Formalized here: the (4.1)–(4.2) construction on the Arabella/Clarissa
+beauty example (62), the same-scale comparative (18) *Bill is a taller
+man than Ophidia is a long snake* (heights and lengths share the
+spatial-distance scale), the weak equative, and footnote 10's
+disjunctive than-clause universality (*taller than Arabella or
+Clarissa* = taller than both), derived from `Degree.maxComparative`.
+-/
+
+namespace Cresswell1976
+
+open Degree
+
+/-! ### §4: degrees constructed from comparisons (62) -/
+
+/-- Individuals of the beauty example (62)–(63). -/
+inductive Person where
+  | arabella | clarissa | bill | tom
+  deriving DecidableEq, Repr
+
+/-- A comparison relation φ: *x is more beautiful than y*, with Bill and
+    Tom equally beautiful (both below Clarissa, who is below Arabella). -/
+def moreBeautiful : Person → Person → Prop
+  | .arabella, .clarissa | .arabella, .bill | .arabella, .tom => True
+  | .clarissa, .bill | .clarissa, .tom => True
+  | _, _ => False
+
+instance : DecidableRel moreBeautiful := fun a b => by
+  cases a <;> cases b <;> simp only [moreBeautiful] <;> infer_instance
+
+/-- Bill and Tom are φ-indistinguishable, so they determine the **same
+    degree of beauty** — (4.1)'s equivalence collapses ties. -/
+theorem bill_tom_same_degree :
+    (⟦Person.bill⟧ : CresswellDegree moreBeautiful) = ⟦Person.tom⟧ :=
+  Quotient.sound ⟨fun c => by cases c <;> simp [moreBeautiful],
+                  fun c => by cases c <;> simp [moreBeautiful]⟩
+
+/-- The induced comparison on constructed degrees tracks φ ((4.2) at
+    work): Arabella's degree exceeds the shared Bill/Tom degree. -/
+example : CresswellDegree.rel
+    (⟦Person.arabella⟧ : CresswellDegree moreBeautiful) ⟦Person.tom⟧ :=
+  (CresswellDegree.rel_mk _ _).mpr trivial
+
+/-! ### §2: same-scale comparison (18) and the equative (2.7) -/
+
+/-- Heights and lengths in the shared spatial-distance scale (ℚ):
+    (2.2)'s point that `tall` and `long` "both involve the same scale"
+    is what licenses (18). -/
+def extent : Person → ℚ
+  | .bill => 6 | .tom => 5 | .arabella => 4 | .clarissa => 3
+
+/-- (18) *Bill is a taller man than Ophidia is a long snake*, in the
+    single-scale regime: the comparative reduces to `comparativeSem` on
+    the shared measure ((2.3) with unique degree witnesses). -/
+theorem er_than_single_scale (a b : Person) :
+    (∃ u₁ u₂ : ℚ, u₁ = extent a ∧ u₂ = extent b ∧ u₂ < u₁) ↔
+      comparativeSem extent a b .positive := by
+  constructor
+  · rintro ⟨u₁, u₂, rfl, rfl, h⟩; exact h
+  · exact fun h => ⟨extent a, extent b, rfl, rfl, h⟩
+
+/-- (2.7): *as as* is the weak equative — "either u₁ > u₂ or u₁ = u₂" —
+    i.e. `equativeSem`; *exactly* (`u₁ = u₂`) is `equativeStrengthened`. -/
+theorem as_as_weak (a b : Person) :
+    (extent b < extent a ∨ extent a = extent b) ↔
+      equativeSem extent a b .positive := by
+  constructor
+  · rintro (h | h)
+    · exact le_of_lt h
+    · exact le_of_eq h.symm
+  · intro h
+    rcases lt_or_eq_of_le h with h' | h'
+    · exact Or.inl h'
+    · exact Or.inr h'.symm
+
+/-! ### Footnote 10: disjunctive than-clauses are universal -/
+
+/-- *Bill is taller than Arabella or Clarissa* entails taller than
+    **both** ((iii)–(v)): the than-clause maximum over a disjunctive
+    predicate is the max of the two degrees, so the max-quantified
+    comparative decomposes into the conjunction. -/
+theorem taller_than_disjunction_iff (x y z : Person) :
+    maxComparative (· = x) (fun w => w = y ∨ w = z) extent ↔
+      extent y < extent x ∧ extent z < extent x := by
+  constructor
+  · rintro ⟨δ, ⟨_, hub⟩, w, rfl, hlt⟩
+    have hy : extent y ≤ δ := hub ⟨y, Or.inl rfl, le_rfl⟩
+    have hz : extent z ≤ δ := hub ⟨z, Or.inr rfl, le_rfl⟩
+    exact ⟨lt_of_le_of_lt hy hlt, lt_of_le_of_lt hz hlt⟩
+  · rintro ⟨hy, hz⟩
+    refine ⟨max (extent y) (extent z), ⟨?_, ?_⟩, x, rfl, max_lt hy hz⟩
+    · rcases max_cases (extent y) (extent z) with ⟨heq, _⟩ | ⟨heq, _⟩
+      · exact ⟨y, Or.inl rfl, le_of_eq heq⟩
+      · exact ⟨z, Or.inr rfl, le_of_eq heq⟩
+    · rintro d ⟨w, hw | hw, hle⟩
+      · subst hw; exact le_trans hle (le_max_left _ _)
+      · subst hw; exact le_trans hle (le_max_right _ _)
+
+end Cresswell1976

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19625,6 +19625,34 @@
   validated = {true},
   sources   = {Studies/Theiler2021.lean}
 }% REF: Bale, A. & Schwarz, B. (2022). Measurements from "per" without complex dimensions. *SALT 32*, 543--560.
+@article{bale-2008,
+  author    = {Bale, Alan Clinton},
+  year      = {2008},
+  title     = {A universal scale of comparison},
+  journal   = {Linguistics and Philosophy},
+  volume    = {31},
+  number    = {1},
+  pages     = {1--55},
+  doi       = {10.1007/s10988-008-9028-z},
+  subfield  = {semantics},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Bale2008.lean;Semantics/Degree/Hom.lean}
+}
+@incollection{cresswell-1976,
+  author    = {Cresswell, Maxwell J.},
+  year      = {1976},
+  title     = {The semantics of degree},
+  booktitle = {Montague Grammar},
+  editor    = {Partee, Barbara H.},
+  publisher = {Academic Press},
+  address   = {New York},
+  pages     = {261--292},
+  subfield  = {semantics},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Cresswell1976.lean;Semantics/Degree/Hom.lean}
+}
 @incollection{bale-schwarz-2022,
   author    = {Bale, Alan and Schwarz, Bernhard},
   year      = {2022},


### PR DESCRIPTION
The two degree-construction morphisms from the syllabus-derived roadmap, both from primary-source reads.

- `Degree/Hom.lean`: Cresswell's §4 construction — `cresswellSetoid` (two-sided φ-indistinguishability, eq. 4.1, for an *arbitrary* comparison relation), `CresswellDegree` + induced `rel` (well-definedness = the paper's own 4.2 proof), and `cresswellSetoid_le_iff` grounding it in mathlib (`AntisymmRel` coincidence on preorders); Bale's ℌ as `relativeRank` (finite scale → Ω ≅ ℚ ∩ (0,1], `StrictMono`, degrees count classes by construction).
- `Studies/Cresswell1976.lean`: the (4.1)–(4.2) construction on the beauty example (Bill/Tom tie collapses to one degree), same-scale er-than (18), weak equative (2.7) = `equativeSem`, and footnote 10's disjunctive than-clause universality derived from `maxComparative`.
- `Studies/Bale2008.lean`: the ten-member committee model (Figs. 4–5) with the (19a)/(19b) contrast, ℌ-preservation, robustness under equally-ranked extension (Figs. 6–7), and the for-clause measurement-stripping prediction (Seymour 4ft-wide/5ft-tall).
- Verified bib entries `cresswell-1976`, `bale-2008` (DOI from the article PDF).