### PR TITLE
refactor(Semantics/Mood): fix citations, derive interp, drop dead code

### DIFF
--- a/Linglib/Semantics/Mood/POSW.lean
+++ b/Linglib/Semantics/Mood/POSW.lean
@@ -4,19 +4,23 @@ import Mathlib.Order.Lattice
 
 /-!
 # Partially Ordered Set of Worlds (POSW)
-[portner-2018] [kratzer-1981] [stalnaker-1978] [farkas-2003] [condoravdi-lauer-2012]
+[portner-2018] [veltman-1996] [kratzer-1981] [stalnaker-1978] [condoravdi-lauer-2012]
 
 [portner-2018] (Ch. 4) argues that the apparently disparate "mood"
-phenomena — verbal mood (indicative/subjunctive selection by attitudes),
-sentence mood (declarative/imperative/interrogative force), and modal
-flavor (epistemic/deontic/bouletic) — all share a single mathematical
-substrate: a **partially ordered set of worlds** that the relevant
-linguistic objects update or quantify over. The pair-of-information-and-
-ordering structure with `+`/`⋆` updates predates [portner-2018];
-[farkas-2003] introduces it for assertion-vs-direction, and the
-Stalnakerian context-set/Kratzerian ordering-source decomposition behind
-it goes back to [stalnaker-1978] and [kratzer-1981].
-[condoravdi-lauer-2012] works out the preferential-modal side
+phenomena — verbal mood (indicative/subjunctive selection by
+attitudes, Ch. 2), sentence mood (declarative/imperative/interrogative
+force, Ch. 3), and modal flavor (epistemic/deontic/bouletic) — all
+share a single mathematical substrate: a **partially ordered set of
+worlds** that the relevant linguistic objects update or quantify over.
+The pair-of-information-and-ordering structure predates
+[portner-2018]: it is [veltman-1996]'s expectation state `⟨ε, s⟩` (§3
+there) — a fact set plus a normality preorder on worlds, where factual
+update refines the set and `normally`-update refines the ordering —
+and the Stalnakerian context-set/Kratzerian ordering-source
+decomposition behind it goes back to [stalnaker-1978] and
+[kratzer-1981]. [farkas-2003] contributes the assertive fixed-point
+characterization of the informational side (§ *Assertive fixed-point*
+below). [condoravdi-lauer-2012] works out the preferential-modal side
 (desire predicates over orderings) in detail. **Caveat**: C&L's
 *preference structures* are strict partial orders on **propositions**
 (`Set (Set W)`), one type level above POSW's preorder on **worlds**
@@ -62,20 +66,23 @@ mathematical core of Portner's unification thesis.
 - We work with `W → Prop` (classical propositions) rather than `W → Bool`
   (decidable propositions) because POSW is the foundational substrate;
   decidability concerns belong downstream.
-- [portner-2018] (Ch. 4, footnote 3) flags a strict-typing wart:
-  on his definition `c + p` is technically not a POSW because the
-  ordering is not restricted to the new (smaller) `cs`. We inherit the
-  same wart (our `plus` keeps `c.le` unchanged), and the same
-  workaround: read the `le_refl` / `le_trans` axioms as conditioned on
-  `cs`-membership, so behaviour outside `cs` is irrelevant.
+- [portner-2018] flags a strict-typing wart (-- UNVERIFIED: footnote
+  number): on his definition `c + p` is technically not a POSW because
+  the ordering is not restricted to the new (smaller) `cs`. We keep
+  the same behaviour (our `plus` leaves `c.le` unchanged) —
+  deliberately, not as a workaround: [veltman-1996] (fn. 5) shows the
+  ordering must live on all of `W` rather than on the current fact
+  set, or rule-persistence fails under factual update. The `le_refl` /
+  `le_trans` axioms are conditioned on `cs`-membership, so behaviour
+  outside `cs` is irrelevant.
 - We use a reflexive partial preorder `le` matching the partition /
   `Setoid` lattice convention (finer ≤ coarser).
 
 ## Lattice unification (linglib extension)
 
-[portner-2018] writes eq. (2a) as set intersection and eq. (2b)
-via Condoravdi-Lauer ordering refinement; the `?`-update (our
-extension) is naturally a `Setoid` meet. All three updates turn out
+[portner-2018] defines the `+`-update as set intersection and the
+`⋆`-update via Condoravdi-Lauer ordering refinement; the `?`-update
+(our extension) is naturally a `Setoid` meet. All three updates turn out
 to be **`inf` in three parallel mathlib lattices**, none of which
 appear in [portner-2018]:
 
@@ -91,7 +98,7 @@ lattice. Commutativity (`star_star_comm_le`), idempotency
 (`star_star_self_le`), and the corresponding theorems on the other
 two updates all collapse to one-line invocations of `inf_right_comm`
 / `inf_idem` in the appropriate lattice. The `K`-axiom for `boxCs` /
-`boxLe` (§8) is the universal-quantification-preserves-inf pattern.
+`boxLe` (the *Normal modality structure* section) is the universal-quantification-preserves-inf pattern.
 -/
 
 namespace Semantics.Mood
@@ -102,7 +109,8 @@ universe u
     `cs` of worlds equipped with a reflexive transitive ordering `le`
     on `cs`. [portner-2018] (Ch. 4) writes the ordering `<`
     (at-least-as-good); we use `le` for mathlib alignment. The
-    underlying pair structure appears already in [farkas-2003].
+    underlying pair structure appears already in [veltman-1996]'s
+    expectation states.
 
     Non-emptiness is not enforced at the type level — empty POSWs are
     pathological but algebraically permitted (e.g., the result of
@@ -123,24 +131,25 @@ namespace POSW
 
 variable {W : Type u}
 
-/-! ## §1. Updates: `+` and `⋆` -/
+/-! ### Updates: `+` and `⋆` -/
 
-/-- **`+`-update** ([portner-2018], Ch. 4 §4.1; [farkas-2003]):
-    refine `cs` by intersection with `p`. Leaves `≤` untouched.
+/-- **`+`-update** ([portner-2018]; [stalnaker-1978]): refine `cs` by
+    intersection with `p`. Leaves `≤` untouched.
 
     Used by assertion (Stalnakerian context-set update) and by `□_cs`
     modals' restriction.
 
-    *Footnote 3 wart*: the resulting `le` is not strictly restricted to
-    the new `cs`, but the structure satisfies the (cs-conditioned)
-    POSW axioms. -/
+    The resulting `le` is not restricted to the new `cs` — deliberately
+    (see the module docstring's note on [veltman-1996], fn. 5); the
+    structure satisfies the (cs-conditioned) POSW axioms. -/
 def plus (c : POSW W) (p : W → Prop) : POSW W where
   cs := fun w => c.cs w ∧ p w
   le := c.le
   le_refl  := fun w hw => c.le_refl w hw.1
   le_trans := fun w u v hw hu hv => c.le_trans w u v hw.1 hu.1 hv.1
 
-/-- **`⋆`-update** ([portner-2018], Ch. 4 §4.1; [farkas-2003]):
+/-- **`⋆`-update** ([portner-2018]; ordering refinement as in
+    [veltman-1996]'s `normally`-update):
     refine `≤` by promoting `p`-worlds. The new ordering keeps the old
     ordering and additionally requires that whenever the upper world
     satisfies `p`, the lower world does too.
@@ -154,7 +163,7 @@ def star (c : POSW W) (p : W → Prop) : POSW W where
   le_trans := fun w u v hw hu hv => fun ⟨hwu, hwu'⟩ ⟨huv, huv'⟩ =>
     ⟨c.le_trans w u v hw hu hv hwu huv, fun hp => hwu' (huv' hp)⟩
 
-/-! ## §2. Modals: `□_cs` and `□_≤` -/
+/-! ### Modals: `□_cs` and `□_≤` -/
 
 /-- A world is **best** in `c` if it is in `cs` and at least as good
     as every other `cs`-world. The quantification domain of
@@ -162,23 +171,20 @@ def star (c : POSW W) (p : W → Prop) : POSW W where
 def best (c : POSW W) (w : W) : Prop :=
   c.cs w ∧ ∀ v, c.cs v → c.le v w
 
-/-- **Informational necessity** `□_cs` ([portner-2018], Ch. 4 §4.1):
+/-- **Informational necessity** `□_cs` ([portner-2018], Ch. 2):
     `p` holds at every world in the context set. The semantics of
     `believe` and the Stalnakerian context-set entailment. -/
 def boxCs (c : POSW W) (p : W → Prop) : Prop :=
   ∀ w, c.cs w → p w
 
-/-- **Preferential necessity** `□_≤` ([portner-2018], Ch. 4 §4.1):
+/-- **Preferential necessity** `□_≤` ([portner-2018], Ch. 2):
     `p` holds at every `≤`-best world in the context set. The
     semantics of `want` and Kratzerian deontic/bouletic modals
     ([kratzer-1981], [condoravdi-lauer-2012]). -/
 def boxLe (c : POSW W) (p : W → Prop) : Prop :=
   ∀ w, c.best w → p w
 
-@[deprecated boxLe (since := "2026-04-18")]
-abbrev boxLt (c : POSW W) (p : W → Prop) : Prop := c.boxLe p
-
-/-! ## §3. Algebraic facts -/
+/-! ### Algebraic facts -/
 
 @[simp] theorem plus_cs (c : POSW W) (p : W → Prop) (w : W) :
     (c.plus p).cs w ↔ c.cs w ∧ p w := Iff.rfl
@@ -197,13 +203,14 @@ abbrev boxLt (c : POSW W) (p : W → Prop) : Prop := c.boxLe p
 `+`-update on `cs` *is* meet in the Heyting algebra `W → Prop`: the new
 context set is the pointwise conjunction of the old context set and the
 asserted proposition. The identity is definitional — no proof obligation.
-This puts the [portner-2018] eq. (2a) "`c + ϕ = ⟨cs_c ∩ ⟦ϕ⟧^c, <_c⟩`"
+This puts [portner-2018]'s intersective definition of `+`-update
 on the same algebraic footing as the `Setoid` meet that defines
-`POSWQ.inquire` and the relation meet that defines `star` (§6). The
+`POSWQ.inquire` and the relation meet that defines `star` (`star_le_eq_inf`). The
 mathlib instance chain is `Prop.instDistribLattice` → `Pi.instLattice`. -/
 
-/-- `+`-update on `cs` is meet in `W → Prop`. The Heyting characterization
-    of [portner-2018] eq. (2a) — `c + ϕ` intersects `cs` with `ϕ`. -/
+/-- `+`-update on `cs` is meet in `W → Prop`: the Heyting form of
+    [portner-2018]'s intersective definition — `c + ϕ` intersects
+    `cs` with `ϕ`. -/
 @[simp] theorem plus_cs_eq_inf (c : POSW W) (p : W → Prop) :
     (c.plus p).cs = c.cs ⊓ p := rfl
 
@@ -241,20 +248,14 @@ theorem boxLe_mono (c : POSW W) (p q : W → Prop)
     c.boxLe p → c.boxLe q :=
   fun hp w hw => h w (hp w hw)
 
-@[deprecated boxLe_mono (since := "2026-04-18")]
-theorem boxLt_mono (c : POSW W) (p q : W → Prop)
-    (h : ∀ w, p w → q w) :
-    c.boxLe p → c.boxLe q :=
-  boxLe_mono c p q h
-
 /-- After `+`-updating with `p`, `p` becomes informationally necessary.
     The Stalnakerian assertion principle: asserting `p` makes `p`
-    common ground. [stalnaker-1978], [portner-2018] (Ch. 4). -/
+    common ground. [stalnaker-1978]; [portner-2018]. -/
 theorem boxCs_plus_self (c : POSW W) (p : W → Prop) :
     (c.plus p).boxCs p :=
   fun _ hw => hw.2
 
-/-! ## §4. Refinement preorder
+/-! ### Refinement preorder
 
 A POSW is more *refined* than another when it carries strictly more
 information: a smaller context set, and a smaller (i.e., more
@@ -330,7 +331,7 @@ theorem boxCs_anti (c₁ c₂ : POSW W) (h : c₁ ≤ c₂) (p : W → Prop) :
     c₂.boxCs p → c₁.boxCs p :=
   fun hbox w hcs => hbox w (h.1 w hcs)
 
-/-! ## §5. Subtype Preorder
+/-! ### Subtype preorder
 
 `POSW W` is *not* a `Preorder W` (the `le` axioms are conditioned on
 `cs`-membership). But it *is* a `Preorder (Subtype c.cs)` — the
@@ -348,13 +349,13 @@ instance instPreorderSubtype (c : POSW W) : Preorder {w // c.cs w} where
   le_refl w := c.le_refl w.1 w.2
   le_trans w u v := c.le_trans w.1 u.1 v.1 w.2 u.2 v.2
 
-/-! ## §6. The `promote` preorder and `⋆`-update as relation meet
+/-! ### The `promote` preorder and `⋆`-update as relation meet
 
 `⋆`-update has a clean lattice-theoretic identity: it is meet in the
 relation lattice `W → W → Prop` of the existing preorder with the
 **promotion preorder** of `p`, where `promote p w v` says "if `p`
 holds at the lower world it holds at the higher one too". This is
-the relation-side analogue of `plus_cs_eq_inf` (§3): `+`-update is
+the relation-side analogue of `plus_cs_eq_inf`: `+`-update is
 meet in `W → Prop`, `⋆`-update is meet in `W → W → Prop`. Both reduce
 their respective updates to the same mathematical operation —
 `Pi.instLattice` over `Prop.instDistribLattice` — and inherit
@@ -408,22 +409,25 @@ theorem star_star_self_le (c : POSW W) (p : W → Prop) :
   show c.le ⊓ promote p ⊓ promote p = c.le ⊓ promote p
   rw [inf_assoc, inf_idem]
 
-/-! ## §7. Farkas-style update fixed-point
+/-! ### Assertive fixed-point
 
-[farkas-2003]'s eq. 11 alternative to the [portner-2018]
-Indicative/Subjunctive Principles characterizes mood selection by
-*update type*: declarative `+`-update vs. directive `⋆`-update, rather
-than by the matrix operator. The mathematical core is the
-**update-fixedpoint** characterization: an update *adds nothing*
-exactly when its content is already consequential at the input.
+[farkas-2003] characterizes indicative-licensing (assertive) contexts
+via a Stalnakerian fixed-point: an update is assertive when its
+content can be non-vacuously added, and `p` is already *accepted* when
+adding it changes nothing (`c + p = c`). This is [veltman-1996]'s
+acceptance relation (`σ ⊩ φ` iff `σ[φ] = σ`, §1 there) specialized to
+the `+`-update. Farkas's account covers the indicative/assertive side
+only; the `⋆` (To-Do-List) update belongs to [portner-2004] and plays
+no role in [farkas-2003].
 
 For `+`-update on `cs`: `c` already implies `p` (i.e. `c.boxCs p`)
 iff `c ≤ c.plus p` (i.e. `c.plus p` doesn't shrink `cs`). -/
 
-/-- **Farkas update-fixedpoint** for `+`: the input refines the
-    `+`-update iff the proposition is already informationally necessary.
-    Formal content of [farkas-2003]'s eq. 11 distinction between
-    consequential and merely-redundant assertions. -/
+/-- **Assertive fixed-point**: the input refines the `+`-update iff
+    the proposition is already informationally necessary —
+    [veltman-1996]'s acceptance (`σ[φ] = σ`) for the `+`-update, and
+    the formal core of [farkas-2003]'s assertive characterization of
+    indicative-licensing contexts. -/
 theorem le_plus_iff_boxCs (c : POSW W) (p : W → Prop) :
     c ≤ c.plus p ↔ c.boxCs p := by
   constructor
@@ -432,7 +436,7 @@ theorem le_plus_iff_boxCs (c : POSW W) (p : W → Prop) :
   · intro hp
     refine ⟨fun w hw => ⟨hw, hp w hw⟩, fun _ _ h => h⟩
 
-/-! ## §8. Normal modality structure
+/-! ### Normal modality structure
 
 `boxCs` and `boxLe` are both **normal modalities** in the sense of
 modal logic: each satisfies necessitation (`□⊤`) and the K-axiom

--- a/Linglib/Semantics/Mood/POSWQ.lean
+++ b/Linglib/Semantics/Mood/POSWQ.lean
@@ -5,25 +5,25 @@ import Linglib.Semantics.Mood.POSW
 # POSW with Inquiry Partition (POSWQ)
 [portner-2018] [groenendijk-stokhof-1984] [roberts-2012]
 
-This file is **our extension** of [portner-2018]'s POSW substrate
-to interrogative force, by way of a third component recording the open
-question. It is not the extension Portner himself works out.
-Portner's interrogative variant — **PPOSW** — replaces `cs` with a
-*partition* of `cs`, so the "informational" and "inquisitive"
-components are fused. We instead keep `cs` intact and add `inquiry :
-Setoid W` as a separate third coordinate; this preserves Portner's
-disjoint-target story (`+`, `⋆`, `?` each touch one component) and
-lets the inquiry partition compose orthogonally with `cs`-refinement
-and `≤`-refinement.
+This file is **our extension** of [portner-2018]'s POSW substrate to
+interrogative force, by way of a third component recording the open
+question: `cs` stays intact and `inquiry : Setoid W` is a separate
+third coordinate, so `+`, `⋆`, `?` each touch one component and the
+inquiry partition composes orthogonally with `cs`-refinement and
+`≤`-refinement. [portner-2018]'s verbal-mood unification itself is
+stated over the two POSW components only; the separate question
+coordinate follows the architecture of [portner-2004]'s discourse
+model, which keeps the Question Set apart from the Common Ground and
+the To-Do Lists.
 
 The third-component idea is grounded in the dynamic-question tradition:
 [groenendijk-stokhof-1984]'s partition theory takes the meaning of
 a question to be an equivalence relation on worlds; [roberts-2012]
 maintains a QUD stack alongside the common ground; inquisitive
-semantics (Ciardelli et al. 2013) folds it into a single
-informative/inquisitive content. The Setoid representation makes the
-partition view directly available via mathlib's `CompleteLattice
-(Setoid W)`.
+semantics ([ciardelli-groenendijk-roelofsen-2018]) folds it into a
+single informative/inquisitive content. The Setoid representation
+makes the partition view directly available via mathlib's
+`CompleteLattice (Setoid W)`.
 
 ## The 3×3 Portner-style unification
 
@@ -46,7 +46,7 @@ extensions; they do not appear in [portner-2018].
   refinement (finer ≤ coarser).
 - The Setoid `≤` convention (`r ≤ s ↔ ∀ x y, r x y → s x y`) coincides
   with the POSW refinement preorder convention from
-  `Linglib/Semantics/Mood/POSW.lean` §4: finer ≤ coarser, more
+  `Linglib/Semantics/Mood/POSW.lean`'s refinement-preorder section: finer ≤ coarser, more
   discriminating ≤ less discriminating.
 - `extends POSW W` mirrors `Group extends Monoid`: a POSWQ *is* a POSW
   (via the auto-generated `POSWQ.toPOSW`) plus extra structure.
@@ -61,8 +61,7 @@ and each of `+`, `⋆`, `?` is meet in its component's lattice. The
 `?`-update inherits not just `inf` but `iInf` over arbitrary index
 sets — reading off "asking the conjunction of a family of questions"
 as `iInf` is then a one-line consequence. The `?`-update inherits
-`inf_assoc`, `inf_idem`, and `inf_comm` directly (`inquire_inquire_self`
-in §7 is a one-liner via `inf_assoc + inf_idem`).
+`inf_assoc`, `inf_idem`, and `inf_comm` directly (`inquire_inquire_self` is a one-liner via `inf_assoc + inf_idem`).
 
 ## Architectural note: Setoid vs. InquisitiveContent
 
@@ -104,10 +103,11 @@ universe u
 /-- A **POSW with an inquiry partition** (POSWQ): the [portner-2018]
     POSW substrate enriched with a third component recording the open
     question. The `inquiry : Setoid W` partitions worlds into
-    "answers"; its `⊤` element is "no question". This three-coordinate
-    extension is ours and is distinct from [portner-2018]'s own
-    PPOSW (which replaces `cs` with a partition rather than adding a
-    third field). -/
+    "answers"; its `⊤` element is "no question". The three-coordinate
+    packaging is ours; the separate question coordinate follows
+    [portner-2004]'s Question Set (kept apart from the Common Ground),
+    while [portner-2018]'s verbal-mood unification is stated over the
+    two POSW components only. -/
 structure POSWQ (W : Type u) extends POSW W where
   /-- The inquiry partition: `inquiry.r w v` means worlds `w` and `v`
       are indistinguishable answers to the open question. -/
@@ -117,7 +117,7 @@ namespace POSWQ
 
 variable {W : Type u}
 
-/-! ## §1. Constructors -/
+/-! ### Constructors -/
 
 /-- Lift a POSW to a POSWQ with no question under discussion (trivial
     inquiry partition: every world is in the same cell). -/
@@ -153,7 +153,7 @@ def polarSetoid (q : W → Prop) : Setoid W where
   ext w v
   simp
 
-/-! ## §2. The third update: `?` (inquiry refinement) -/
+/-! ### The third update: `?` (inquiry refinement) -/
 
 /-- **`?`-update** (our extension; not in [portner-2018]): refine
     the inquiry partition by meet with `q`. The partition-side
@@ -185,7 +185,7 @@ theorem inquire_inquiry (c : POSWQ W) (q : Setoid W) :
 @[simp] theorem inquire_inquiry_eq_inf (c : POSWQ W) (q : Setoid W) :
     (c.inquire q).inquiry = c.inquiry ⊓ q := rfl
 
-/-! ## §3. The third modal: `boxAns` (informational answerhood) -/
+/-! ### The third modal: `boxAns` (informational answerhood) -/
 
 /-- **Informational answerhood** (our extension): `p` is *settled by the
     question* at `c` iff `p` has a constant truth value within every
@@ -202,7 +202,7 @@ theorem inquire_inquiry (c : POSWQ W) (q : Setoid W) :
 def boxAns (c : POSWQ W) (p : W → Prop) : Prop :=
   ∀ w v, c.cs w → c.cs v → c.inquiry.r w v → (p w ↔ p v)
 
-/-! ## §4. Disjointness of components
+/-! ### Disjointness of components
 
 The `+`-, `⋆`-, and `?`-updates target *disjoint* components of the
 POSWQ. The first two leave `inquiry` alone (vacuously, since they're
@@ -213,10 +213,10 @@ theorem inquire_targets_disjoint_components (c : POSWQ W) (q : Setoid W) :
     (c.inquire q).cs = c.cs ∧ (c.inquire q).le = c.le :=
   ⟨rfl, rfl⟩
 
-/-! ## §5. Refinement preorder
+/-! ### Refinement preorder
 
 `POSWQ W` inherits a refinement preorder componentwise from `POSW W`'s
-refinement preorder (Mood/POSW.lean §4) and the `Setoid W` lattice:
+refinement preorder (Mood/POSW.lean) and the `Setoid W` lattice:
 `c₁ ≤ c₂` iff `c₁.toPOSW ≤ c₂.toPOSW` and `c₁.inquiry ≤ c₂.inquiry`.
 Both directions agree on "finer ≤ coarser". -/
 
@@ -250,7 +250,7 @@ theorem boxAns_anti (c₁ c₂ : POSWQ W) (h : c₁ ≤ c₂) (p : W → Prop) :
   fun hbox w v hw hv hwv =>
     hbox w v (h.1.1 w hw) (h.1.1 v hv) (h.2 hwv)
 
-/-! ## §6. Closure properties of `boxAns`
+/-! ### Closure properties of `boxAns`
 
 `boxAns p` says "`p` is constant on each inquiry cell within `cs`".
 This class of propositions is closed under the standard logical
@@ -290,7 +290,7 @@ theorem boxAns_imp (c : POSWQ W) (p q : W → Prop) :
     ⟨fun himp hpv => (hq w v hw hv hwv).mp (himp ((hp w v hw hv hwv).mpr hpv)),
      fun himp hpw => (hq w v hw hv hwv).mpr (himp ((hp w v hw hv hwv).mp hpw))⟩
 
-/-! ## §7. Three-component update disjointness
+/-! ### Three-component update disjointness
 
 The three updates `+`, `⋆`, `?` touch disjoint POSWQ components, so
 they pairwise commute when lifted to act on `POSWQ`. The lifts are
@@ -341,7 +341,7 @@ theorem inquire_inquire_self (c : POSWQ W) (s : Setoid W) :
   show (c.inquiry ⊓ s) ⊓ s = c.inquiry ⊓ s
   rw [inf_assoc, inf_idem]
 
-/-! ## §8. Distinctness witness: `boxAns` ≠ `boxCs` ∘ projection
+/-! ### Distinctness witness: `boxAns` ≠ `boxCs` ∘ projection
 
 The third modal genuinely differs from `boxCs`. We exhibit a POSWQ
 where some `p` is settled by the question (`boxAns p`) but is *not*

--- a/Linglib/Semantics/Mood/POSWTarget.lean
+++ b/Linglib/Semantics/Mood/POSWTarget.lean
@@ -1,6 +1,4 @@
-import Linglib.Semantics.Mood.Basic
 import Linglib.Semantics.Mood.IllocutionaryMood
-import Linglib.Semantics.Mood.ClauseType
 import Linglib.Semantics.Mood.POSWQ
 
 /-!
@@ -10,27 +8,27 @@ import Linglib.Semantics.Mood.POSWQ
 Each mood-bearing object (verbal mood, sentence mood, modal flavor)
 targets a specific component of a `POSW` (or, for the `partition`
 case, of our extended `POSWQ`; see `Semantics/Mood/POSWQ.lean`).
-[portner-2018]'s unification thesis says: the surface diversity
-of mood phenomena reduces to *which component gets touched*.
+[portner-2018]'s unification thesis (Ch. 4) says: the surface
+diversity of mood phenomena reduces to *which component gets touched*.
 
-This file packages that thesis as a type-level enum `POSWTarget` and
-a typeclass `HasPOSWTarget`, instantiated for `GramMood` (verbal
-mood) and `IllocutionaryMood` (sentence mood). The companion
-*value-level* implementation lives in `Semantics/Mood/POSWQ.lean`: the
-`POSWQ` structure exposes `cs`, `lt`, and `inquiry` as actual
-fields, and the updates `POSW.plus`/`POSW.star`/`POSWQ.inquire` do
-the work that this file's enum labels.
+This file packages that thesis as a type-level enum `POSWTarget` and a
+typeclass `HasPOSWTarget`, instantiated here for `IllocutionaryMood`
+(sentence mood) and in `Semantics/Mood/VerbalMood.lean` for
+`VerbalMoodOp` (verbal mood). The companion *value-level*
+implementation lives in `Semantics/Mood/POSWQ.lean`: the `POSWQ`
+structure exposes `cs`, `le`, and `inquiry` as actual fields, and the
+updates `POSW.plus`/`POSW.star`/`POSWQ.inquire` do the work that this
+file's enum labels. The link between the two views is the projection
+`POSWTarget.boxOn` below, which sends each label to the necessity
+modal quantifying over the labelled component.
 
-The two views are kept separate because they answer different
-questions. `POSWTarget` is a *typeclass-resolved label* used by
-typology code that wants to ask "what kind of thing is this mood?";
-`POSWQ` and its updates are the *operational substrate* used by
-semantic glosses. The link is the projection
-`POSWTarget.toComponent` below, which sends each label to the
-matching POSWQ-level operation type.
+"Target" is selection-side vocabulary: verbal mood in [portner-2018]
+(Ch. 2) is *selected by* the embedding attitude, so a verbal mood's
+target is the component the selecting predicate's modality quantifies
+over — not an operation the mood morpheme itself performs.
 
-Modal flavors will get their own instance once
-`Semantics/Modality/` is rephrased over POSW.
+Modal flavors would get their own instance if `Semantics/Modality/`
+is ever rephrased over POSW.
 -/
 
 namespace Semantics.Mood
@@ -39,52 +37,46 @@ namespace Semantics.Mood
     mood-bearing object operates on. [portner-2018], Ch. 4.
 
     - `informational`: the context set `cs`. Targeted by indicative
-      verbal mood and declarative force (assertion via `+`-update,
-      belief via `□_cs`).
+      verbal mood (Ch. 2) and declarative force (Ch. 3): assertion via
+      `+`-update, belief via `□_cs`.
     - `preferential`: the ordering `≤`. Targeted by subjunctive verbal
-      mood and imperative force (directive via `⋆`-update,
-      desire via `□_≤`). The `.promissive` and `.exclamative`
-      assignments below are extensions of [portner-2018]'s
-      core declarative/imperative/interrogative trichotomy and
-      should be treated as conjectural.
-    - `partition`: a refinement of `cs` into a partition.
-      Targeted by interrogative force. [portner-2018] formalizes
-      this as PPOSW (a partition replaces `cs`); we instead represent
-      it as a third coordinate of `POSWQ`. Verbal mood does not
-      select for partition in [portner-2018]; see
+      mood (Ch. 2) and imperative force (Ch. 3): directive via
+      `⋆`-update, desire via `□_≤`.
+    - `partition`: the inquiry component. Targeted by interrogative
+      force. Portner's discourse model keeps the question component
+      separate from the common ground ([portner-2004]'s Question Set);
+      our `POSWQ` renders it as a third coordinate. Verbal mood does
+      not select for partition in [portner-2018]; see
       `Semantics/Mood/VerbalMood.lean` for our extension. -/
 inductive POSWTarget where
   | informational
   | preferential
   | partition
-  deriving DecidableEq, Repr, Inhabited
+  deriving DecidableEq, Repr
 
 /-- Typeclass for mood-bearing types. `target m` says which POSW
     component `m` operates on. -/
-class HasPOSWTarget (M : Type) where
+class HasPOSWTarget (M : Type*) where
   target : M → POSWTarget
 
 export HasPOSWTarget (target)
 
-/-! ## Instances -/
+/-! ### Sentence-mood instance -/
 
-/-- Verbal mood ([portner-2018], Ch. 4):
-    - indicative selected by `believe`-class attitudes (`□_cs` on agent's POSW)
-    - subjunctive selected by `want`-class attitudes (`□_≤` on agent's POSW) -/
-instance : HasPOSWTarget GramMood where
-  target
-    | .indicative  => .informational
-    | .subjunctive => .preferential
-
-/-- Sentence mood ([portner-2018], Ch. 4):
+/-- Sentence mood ([portner-2018], Ch. 3):
     - declarative `+`-updates `cs` of the discourse POSW
-    - imperative `⋆`-updates `<` of the addressee's To-Do List
-    - interrogative partitions `cs` (PPOSW)
+    - imperative `⋆`-updates the ordering (the addressee's To-Do List,
+      [portner-2004])
+    - interrogative refines the inquiry component
+
     The `promissive` (preferential) and `exclamative` (informational)
-    assignments are linglib extensions; [portner-2018] treats
-    only the declarative/imperative/interrogative trichotomy in
-    detail. They are included here for typological coverage and
-    should be revisited when each is independently formalized. -/
+    assignments are linglib extensions; [portner-2018] treats only the
+    declarative/imperative/interrogative trichotomy in detail. The
+    exclamative assignment moreover sits in tension with its Searle
+    classification (`Discourse/SpeechAct.lean`: expressive class,
+    *null* direction of fit — no component to target); it is retained
+    as a conjectural placeholder until an exclamative-force account is
+    formalized. -/
 instance : HasPOSWTarget IllocutionaryMood where
   target
     | .declarative   => .informational
@@ -93,117 +85,19 @@ instance : HasPOSWTarget IllocutionaryMood where
     | .interrogative => .partition
     | .exclamative   => .informational
 
-/-! ## Mood alignment
+/-! ### Operational projection: from `POSWTarget` to a POSWQ modal
 
-A canonical declarative-indicative clause exhibits a *target
-agreement* between its illocutionary force and its grammatical mood:
-both target the informational component. This is the type-level
-shadow of [portner-2018]'s **Indicative Principle**, which is
-itself stated as a one-way conditional ("if a clause's matrix
-operator is `□_cs`, the clause is indicative") rather than as
-target-equality.
+The `POSWTarget` enum is a typeclass-resolved label. To turn that
+label into semantic work — the `□_cs`/`□_≤`/`boxAns` modal that
+quantifies over the labelled component — we project into a function
+`POSWQ W → (W → Prop) → Prop`. This makes "target is informational"
+*operational*: it picks out exactly `boxCs` as the modal to use, by
+definition. Downstream glosses write `(target m).boxOn c p` and get
+the right quantification by enum-match instead of manual case
+analysis (`VerbalMoodOp.interp` in `Semantics/Mood/VerbalMood.lean`
+is defined this way). -/
 
-We state both: the target-equality version (`decl_ind_target_match`)
-and the conditional version (`gram_mood_target_iff` and friends below).
-The conditional version captures Portner's principle directly at the
-type level: the GramMood enum is in bijection with the two POSW
-components it can target, so "target = informational" and "mood =
-indicative" are interchangeable (and similarly for subjunctive).
-The full clause-level conditional ("if the matrix operator is `□_cs`,
-the clause is indicative") would additionally require a syntax-side
-mood-features infrastructure mapping operators to mood realizations,
-which does not yet exist in linglib. -/
-
-/-- The canonical declarative-indicative clause has matching
-    POSW-target on its force and mood components. The type-level
-    shadow of [portner-2018]'s Indicative Principle. -/
-theorem decl_ind_target_match :
-    target ClauseType.declInd.force = target ClauseType.declInd.mood := by
-  rfl
-
-@[deprecated decl_ind_target_match (since := "2026-04-18")]
-theorem mood_alignment_decl_ind :
-    target ClauseType.declInd.force = target ClauseType.declInd.mood :=
-  decl_ind_target_match
-
-/-- A polar question targets a partition (force) over a clause whose
-    verbal mood is indicative (informational). The two POSW targets
-    are *intentionally distinct* — interrogative force reshapes the
-    informational component into a partition. -/
-theorem mood_misalignment_polar_question :
-    target ClauseType.polarQuestion.force ≠ target ClauseType.polarQuestion.mood := by
-  decide
-
-/-! ## Indicative / Subjunctive Principles as biconditionals
-
-The conditional form of [portner-2018]'s Indicative Principle
-("if the matrix operator is `□_cs`, the clause is indicative") and its
-subjunctive counterpart, restricted to the verbal-mood layer (`GramMood`).
-Because `GramMood` is in bijection with the two POSW components it
-can target, the conditionals collapse to biconditionals: targeting the
-informational component *exactly* picks out indicative; targeting the
-preferential component *exactly* picks out subjunctive.
-
-These are the strongest type-level statements of Portner's principles
-available without a syntax-side mood-features infrastructure. -/
-
-/-- **Indicative Principle** ([portner-2018], Ch. 4): a verbal
-    mood targets the informational component iff it is indicative.
-    The biconditional form available at the GramMood layer. -/
-theorem gram_mood_target_informational_iff_indicative (m : GramMood) :
-    target m = .informational ↔ m = .indicative := by
-  cases m <;> decide
-
-/-- **Subjunctive Principle** ([portner-2018], Ch. 4): a verbal
-    mood targets the preferential component iff it is subjunctive.
-    The biconditional form available at the GramMood layer. -/
-theorem gram_mood_target_preferential_iff_subjunctive (m : GramMood) :
-    target m = .preferential ↔ m = .subjunctive := by
-  cases m <;> decide
-
-/-- A `GramMood` never targets the partition component — the
-    declarative-complement column is closed under the
-    informational/preferential split. The complement of
-    `IllocutionaryMood` (which can target `.partition` via
-    `.interrogative`). -/
-theorem gram_mood_target_ne_partition (m : GramMood) :
-    target m ≠ .partition := by
-  cases m <;> decide
-
-/-! ## §3. Farkas-style alternative: target by update type
-
-[farkas-2003] (eq. 11) characterizes mood selection by the *update
-type* — `+` for indicative, `⋆` for subjunctive — rather than by the
-matrix modal operator. The target equality `decl_ind_target_match`
-above is the type-level shadow of Farkas's principle as well: the
-POSW component refined by the force-side update (`+` refines `cs`,
-`⋆` refines `≤`) coincides with the POSW component quantified by the
-mood-side modal (`boxCs` over `cs`, `boxLe` over best-of-`≤`).
-
-The Farkas alternative and Portner's Indicative/Subjunctive Principles
-agree on the canonical declarative-indicative and imperative-subjunctive
-cases (which is why `decl_ind_target_match` works for both); they
-differ in their predictions about non-canonical pairings, where this
-substrate does not yet take a position. -/
-
-/-! ## §2. Operational projection: from `POSWTarget` to a POSWQ modal
-
-The `POSWTarget` enum is a *typeclass-resolved label*. To turn that
-label into actual semantic work — the `□_cs`/`□_≤`/`boxAns` modal
-that quantifies over the labelled component — we project into a
-function `POSWQ W → (W → Prop) → Prop`. The projection is
-exhaustive and uniformly typed across the three components: the
-`partition` case uses `POSWQ.boxAns`, the other two factor through
-`POSW`.
-
-This makes "target is informational" *operational*: it picks out
-exactly `boxCs` as the modal to use, by definition. Downstream
-glosses can write `(target m).boxOn c p` and have the right
-quantification chosen by enum-match instead of by manual case
-analysis. -/
-
-universe u
-variable {W : Type u}
+variable {W : Type*}
 
 /-- The modal projection: each `POSWTarget` selects the necessity
     modal that quantifies over the labelled POSWQ component. -/

--- a/Linglib/Semantics/Mood/VerbalMood.lean
+++ b/Linglib/Semantics/Mood/VerbalMood.lean
@@ -17,11 +17,11 @@ component for question-embedding predicates.
 [portner-2018] (Ch. 2) identifies two main intuitions about what
 distinguishes indicative from subjunctive complementation:
 
-- **Truth intuition** (Farkas 1985, Portner 1997 tradition):
+- **Truth intuition** ([farkas-1985], [portner-1997] tradition):
   indicative is selected for clauses true throughout a designated
   modal base. Subjunctive is selected when this universal-truth
   pattern fails.
-- **Comparison intuition** (Giorgi & Pianesi 1997 tradition):
+- **Comparison intuition** ([giorgi-pianesi-1997] tradition):
   subjunctive is selected when the embedding predicate involves
   ordering or comparison among alternatives — preference, doxastic
   ranking, intention.
@@ -44,9 +44,11 @@ the same POSWQ substrate to give all three operators a uniform type.
 
 This file formalizes the selection as the `interp` function on a
 three-element `VerbalMoodOp`, with signature `POSWQ W → (W → Prop)
-→ Prop`. The split is *type-driven*: `boxCs`, `boxLe`, and `boxAns`
-operate on the same POSWQ and the same proposition; only which
-component they consult differs.
+→ Prop`. `interp` is defined as `boxOn ∘ target` — each operator's
+`HasPOSWTarget` label selects the component, and the label's modal
+projection does the quantifying — so the operator/component
+correspondence holds by construction rather than by a bridge
+theorem.
 
 ## Connection to sentence mood
 
@@ -69,10 +71,7 @@ matrix predicate (`MoodSelector` for declarative-embedders;
 
 namespace Semantics.Mood
 
-open Semantics.Mood
-
-universe u
-variable {W : Type u}
+variable {W : Type*}
 
 /-- The three verbal-mood operators on POSWQ. The `.indicative` and
     `.subjunctive` cases are [portner-2018]'s; `.interrogative`
@@ -97,18 +96,45 @@ inductive VerbalMoodOp where
   | interrogative
   deriving DecidableEq, Repr
 
-/-- Compositional interpretation of a verbal-mood operator against
-    an embedding POSWQ and an embedded proposition. The three cases
-    consult disjoint POSWQ components:
+/-- The POSWQ component each verbal-mood operator consults. `target`
+    here is selection-side vocabulary: the component the selecting
+    predicate's modality quantifies over ([portner-2018], Ch. 2), not
+    an operation the mood morpheme performs. Packaged as the same
+    `HasPOSWTarget` typeclass that `IllocutionaryMood` instantiates in
+    `Semantics/Mood/POSWTarget.lean`. -/
+instance : HasPOSWTarget VerbalMoodOp where
+  target
+    | .indicative    => .informational
+    | .subjunctive   => .preferential
+    | .interrogative => .partition
+
+@[simp] theorem target_indicative :
+    Semantics.Mood.target VerbalMoodOp.indicative = .informational := rfl
+
+@[simp] theorem target_subjunctive :
+    Semantics.Mood.target VerbalMoodOp.subjunctive = .preferential := rfl
+
+@[simp] theorem target_interrogative :
+    Semantics.Mood.target VerbalMoodOp.interrogative = .partition := rfl
+
+/-- Compositional interpretation of a verbal-mood operator against an
+    embedding POSWQ and an embedded proposition: run the necessity
+    modal of the operator's POSW target on the embedded proposition.
+    Definitionally `boxOn ∘ target`, so the three cases consult
+    disjoint POSWQ components:
     `.indicative ↦ POSW.boxCs`,
     `.subjunctive ↦ POSW.boxLe`,
     `.interrogative ↦ POSWQ.boxAns`. -/
-def VerbalMoodOp.interp : VerbalMoodOp → POSWQ W → (W → Prop) → Prop
-  | .indicative,    c, p => c.toPOSW.boxCs p
-  | .subjunctive,   c, p => c.toPOSW.boxLe p
-  | .interrogative, c, p => c.boxAns p
+def VerbalMoodOp.interp (m : VerbalMoodOp) : POSWQ W → (W → Prop) → Prop :=
+  (target m).boxOn
 
-/-! ## §1. Definitional equalities -/
+/-- The interpretation is the target component's necessity modal, by
+    definition: `target` is not just a typological label. -/
+@[simp] theorem interp_eq_target_boxOn (m : VerbalMoodOp) (c : POSWQ W)
+    (p : W → Prop) :
+    m.interp c p = (Semantics.Mood.target m).boxOn c p := rfl
+
+/-! ### Definitional equalities -/
 
 @[simp] theorem interp_indicative (c : POSWQ W) (p : W → Prop) :
     VerbalMoodOp.indicative.interp c p = c.toPOSW.boxCs p := rfl
@@ -119,7 +145,7 @@ def VerbalMoodOp.interp : VerbalMoodOp → POSWQ W → (W → Prop) → Prop
 @[simp] theorem interp_interrogative (c : POSWQ W) (p : W → Prop) :
     VerbalMoodOp.interrogative.interp c p = c.boxAns p := rfl
 
-/-! ## §2. Operator-specific monotonicity
+/-! ### Operator-specific monotonicity
 
 `boxCs` and `boxLe` are upward-monotone in the embedded proposition:
 strengthening the modal base preserves universal truth there.
@@ -143,7 +169,7 @@ theorem interp_subjunctive_mono (c : POSWQ W) (p q : W → Prop)
     VerbalMoodOp.subjunctive.interp c p → VerbalMoodOp.subjunctive.interp c q :=
   POSW.boxLe_mono c.toPOSW p q h
 
-/-! ## §3. Distinctness witnesses
+/-! ### Distinctness witnesses
 
 The three mood operators are pairwise non-equivalent — each consults
 a disjoint POSWQ component. We exhibit concrete witnesses showing
@@ -202,48 +228,17 @@ theorem interrogative_ne_indicative :
       ¬ VerbalMoodOp.indicative.interp c p :=
   POSWQ.boxAns_not_reducible_to_boxCs
 
-/-! ## §4. Operational `POSWTarget` projection
-
-Each verbal-mood operator selects exactly one POSWQ component. That
-selection is the `HasPOSWTarget` instance below, packaged as the same
-typeclass that `GramMood` and `IllocutionaryMood` use in
-`Semantics/Mood/POSWTarget.lean`. With this in hand, `interp` factors as
-`boxOn ∘ target` — the verbal mood's interpretation is exactly "run
-the target component's necessity modal on the embedded
-proposition". -/
-
-instance : Semantics.Mood.HasPOSWTarget VerbalMoodOp where
-  target
-    | .indicative    => .informational
-    | .subjunctive   => .preferential
-    | .interrogative => .partition
-
-@[simp] theorem target_indicative :
-    Semantics.Mood.target VerbalMoodOp.indicative = .informational := rfl
-
-@[simp] theorem target_subjunctive :
-    Semantics.Mood.target VerbalMoodOp.subjunctive = .preferential := rfl
-
-@[simp] theorem target_interrogative :
-    Semantics.Mood.target VerbalMoodOp.interrogative = .partition := rfl
-
-/-- **Operational factoring**: the verbal-mood interpretation is
-    exactly the necessity modal selected by the operator's POSW
-    target. Says that `target` is not just a typological label —
-    it determines `interp` definitionally. -/
-@[simp] theorem interp_eq_target_boxOn (m : VerbalMoodOp) (c : POSWQ W)
-    (p : W → Prop) :
-    m.interp c p = (Semantics.Mood.target m).boxOn c p := by
-  cases m <;> rfl
-
-/-! ## Verbal-mood biconditional characterization
+/-! ### Verbal-mood biconditional characterization
 
 `VerbalMoodOp` is in bijection with `POSWTarget`: each operator
 *exactly* picks out one POSW component, and conversely each component
-is targeted by *exactly* one operator. The biconditionals below are
-the type-level shadow of [portner-2018]'s Indicative / Subjunctive
-Principles extended to interrogative — at the verbal-mood layer, mood
-selection and POSWQ-component selection are the same thing. -/
+is targeted by *exactly* one operator. [portner-2018] states the
+corresponding licensing conditions one-way and defeasibly (an
+indicative clause's context is relevantly like a root assertion); the
+biconditional form below reflects only the bijection between this
+three-element operator enum and the three components — at the
+verbal-mood layer, mood selection and POSWQ-component selection are
+the same thing by construction. -/
 
 theorem verbal_mood_target_informational_iff_indicative (m : VerbalMoodOp) :
     Semantics.Mood.target m = .informational ↔ m = .indicative := by
@@ -257,7 +252,7 @@ theorem verbal_mood_target_partition_iff_interrogative (m : VerbalMoodOp) :
     Semantics.Mood.target m = .partition ↔ m = .interrogative := by
   cases m <;> decide
 
-/-! ## §5. Bridge to `MoodSelector`
+/-! ### Bridge to `MoodSelector`
 
 The `MoodSelector` enum (Mood/Basic.lean, taxonomic by predicate
 class — knowledge/belief, preference/desire, etc.) projects onto
@@ -301,7 +296,7 @@ theorem toVerbalMood_ne_interrogative (m : MoodSelector) :
     m.toVerbalMood ≠ some .interrogative := by
   cases m <;> simp [MoodSelector.toVerbalMood]
 
-/-! ## §6. Bridge to `QuestionEmbedder`
+/-! ### Bridge to `QuestionEmbedder`
 
 `MoodSelector` covers declarative-complement-taking predicates only;
 its `toVerbalMood` projection cannot land in `.interrogative`
@@ -311,7 +306,7 @@ question-embedding predicates like `wonder`, `ask`, `know-Q`,
 property: every `QuestionEmbedder` projects to `.interrogative`,
 never to `.indicative` or `.subjunctive`.
 
-The factive/non-factive split (Karttunen 1977 tradition) is the
+The factive/non-factive split ([karttunen-1977] tradition) is the
 standard subdivision of question embedders; we record it for future
 expansion (e.g., a finer projection that distinguishes factive-Q
 embedders' presupposition profile) without committing to particular
@@ -319,7 +314,7 @@ semantic consequences here. -/
 
 /-- Question-embedding predicate class. Disjoint from `MoodSelector`,
     which covers only declarative-complement embedders. The
-    factive/non-factive split follows Karttunen's typology. -/
+    factive/non-factive split follows [karttunen-1977]'s typology. -/
 inductive QuestionEmbedder where
   /-- Factive question-embedders: `know-Q`, `discover-Q`, `realize-Q`. -/
   | factive

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9004,6 +9004,47 @@
   role      = {foundational},
   sources   = {Semantics/Mood/POSW.lean}
 }
+@unpublished{farkas-2003,
+  author    = {Farkas, Donka F.},
+  year      = {2003},
+  title     = {Assertion, belief and mood choice},
+  note      = {Paper presented at the workshop on Conditional and Unconditional Modality, ESSLLI, Vienna},
+  subfield  = {semantics/modality},
+  role      = {cited},
+  sources   = {Semantics/Mood/POSW.lean}
+}
+@article{portner-1997,
+  author    = {Portner, Paul},
+  year      = {1997},
+  title     = {The semantics of mood, complementation, and conversational force},
+  journal   = {Natural Language Semantics},
+  volume    = {5},
+  pages     = {167--212},
+  doi       = {10.1023/A:1008280630142},
+  subfield  = {semantics/modality},
+  role      = {cited},
+  sources   = {Semantics/Mood/VerbalMood.lean}
+}
+@book{farkas-1985,
+  author    = {Farkas, Donka F.},
+  year      = {1985},
+  title     = {Intensional Descriptions and the Romance Subjunctive Mood},
+  publisher = {Garland},
+  address   = {New York},
+  subfield  = {semantics/modality},
+  role      = {cited},
+  sources   = {Semantics/Mood/VerbalMood.lean}
+}
+@book{giorgi-pianesi-1997,
+  author    = {Giorgi, Alessandra and Pianesi, Fabio},
+  year      = {1997},
+  title     = {Tense and Aspect: From Semantics to Morphosyntax},
+  publisher = {Oxford University Press},
+  address   = {New York},
+  subfield  = {semantics/tense},
+  role      = {cited},
+  sources   = {Semantics/Mood/VerbalMood.lean}
+}
 @book{bratman-1987,
   author    = {Bratman, Michael E.},
   year      = {1987},


### PR DESCRIPTION
Deep-audit fixes for the POSW/POSWTarget cone.

- Corrects the [farkas-2003] attribution (assertive fixed-point only; no ⋆-update, no eq. 11) and adds the missing bib entry, plus portner-1997/farkas-1985/giorgi-pianesi-1997; credits the pair-of-information-and-ordering state to [veltman-1996] and fixes Portner 2018 chapter cites (Ch. 2 verbal / Ch. 3 sentence / Ch. 4 unification).
- Defines `VerbalMoodOp.interp := boxOn ∘ target` (bridge lemma now rfl) and deletes the consumer-free GramMood alignment block, deprecated aliases, and the invented "PPOSW" prose.