### PR TITLE
refactor(Semantics/Mood): rebuild POSW on Veltman expectation states

### DIFF
--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
@@ -26,7 +26,7 @@ This module formalizes Veltman's §3: expectation states, the operators
 - "Normally p; presumably p" succeeds (`normally_presumably_succeeds`)
 - Conflicting defaults yield agnosticism (`conflicting_defaults_iff_agree`)
 - Compatible defaults reinforce (`compatible_defaults_optimal`)
-- "Normally" is idempotent and commutative (`normallyUpdate_idempotent`, `normallyUpdate_comm`)
+- Promotion is idempotent and commutative (`promote_respects_idempotent`, `promote_comm`)
 
 ## What's not here (§5)
 
@@ -95,20 +95,23 @@ def ExpState.optimal (σ : ExpState W) : Set W :=
 
 -- ═══ Update Operations ═══
 
-/-- **Assertion update**: eliminate non-p-worlds, preserve pattern.
-
-    This is the standard eliminative update from CCP.lean, lifted to
-    expectation states. Information grows; expectations are unchanged. -/
-def assertUpdate (φ : W → Prop) (σ : ExpState W) : ExpState W :=
+/-- **Assertion update** (Veltman's factual update): eliminate
+    non-φ-worlds, preserve the pattern. Information grows; expectations
+    are unchanged. This is [portner-2018]'s `+`-update on the context
+    set, and the standard eliminative update from CCP.lean lifted to
+    expectation states. -/
+def ExpState.assert (σ : ExpState W) (φ : W → Prop) : ExpState W :=
   ⟨{ w ∈ σ.info | φ w }, σ.order⟩
 
-/-- **"Normally p"**: refine the pattern so p-worlds are preferred.
-    The information state is unchanged — we don't learn that p is true,
-    only that p is *expected*.
+/-- **Promotion update** (Veltman's *normally φ*): refine the pattern
+    so φ-worlds are preferred. The information state is unchanged — we
+    don't learn that φ is true, only that φ is *expected*.
 
     This is the core innovation of [veltman-1996]: defaults operate on
-    the expectation pattern, not on the information state. -/
-def normallyUpdate (φ : W → Prop) (σ : ExpState W) : ExpState W :=
+    the expectation pattern, not on the information state. Read at the
+    discourse level it is [portner-2018]'s `⋆`-update (the To-Do-List
+    update of [portner-2004]). -/
+def ExpState.promote (σ : ExpState W) (φ : W → Prop) : ExpState W :=
   ⟨σ.info, Normality.refine σ.order φ⟩
 
 section Classical
@@ -133,17 +136,79 @@ end Classical
 
 -- ═══ Basic Properties ═══
 
-/-- Assertion preserves the normality ordering. -/
-theorem assertUpdate_preserves_order (φ : W → Prop) (σ : ExpState W) :
-    (assertUpdate φ σ).order = σ.order := rfl
+namespace ExpState
 
-/-- "Normally" preserves the information state. -/
-theorem normallyUpdate_preserves_info (φ : W → Prop) (σ : ExpState W) :
-    (normallyUpdate φ σ).info = σ.info := rfl
+@[simp] theorem assert_info (σ : ExpState W) (φ : W → Prop) :
+    (σ.assert φ).info = { w ∈ σ.info | φ w } := rfl
+
+/-- Assertion preserves the normality ordering. -/
+@[simp] theorem assert_order (σ : ExpState W) (φ : W → Prop) :
+    (σ.assert φ).order = σ.order := rfl
+
+/-- Promotion preserves the information state. -/
+@[simp] theorem promote_info (σ : ExpState W) (φ : W → Prop) :
+    (σ.promote φ).info = σ.info := rfl
+
+@[simp] theorem promote_order (σ : ExpState W) (φ : W → Prop) :
+    (σ.promote φ).order = Normality.refine σ.order φ := rfl
 
 /-- Assertion is eliminative: it can only shrink the info state. -/
-theorem assertUpdate_eliminative (φ : W → Prop) (σ : ExpState W) :
-    (assertUpdate φ σ).info ⊆ σ.info := fun _ hw => hw.1
+theorem assert_info_subset (σ : ExpState W) (φ : W → Prop) :
+    (σ.assert φ).info ⊆ σ.info := fun _ hw => hw.1
+
+/-! Refinement order on expectation states: more constrained ≤ less
+constrained, componentwise — finer ≤ coarser, matching the `Setoid`
+convention. (NB [veltman-1996] orients his `≤` the other way, weaker
+below stronger; the content is the same.) Both updates are
+deflationary, monotone, and idempotent for this order, and
+*acceptance* — [veltman-1996]'s `σ ⊩ φ` iff `σ[φ] = σ` — is the
+fixpoint condition `σ ≤ σ[φ]`. -/
+
+instance : Preorder (ExpState W) where
+  le σ τ := σ.info ⊆ τ.info ∧ σ.order ≤ τ.order
+  le_refl _ := ⟨subset_rfl, le_refl _⟩
+  le_trans _ _ _ h₁ h₂ := ⟨h₁.1.trans h₂.1, h₁.2.trans h₂.2⟩
+
+theorem le_iff {σ τ : ExpState W} :
+    σ ≤ τ ↔ σ.info ⊆ τ.info ∧ σ.order ≤ τ.order := Iff.rfl
+
+/-- Assertion lands below the input. -/
+theorem assert_le_self (σ : ExpState W) (φ : W → Prop) : σ.assert φ ≤ σ :=
+  ⟨σ.assert_info_subset φ, le_refl _⟩
+
+/-- Promotion lands below the input. -/
+theorem promote_le_self (σ : ExpState W) (φ : W → Prop) : σ.promote φ ≤ σ :=
+  ⟨subset_rfl, inf_le_left⟩
+
+theorem assert_mono {σ τ : ExpState W} (h : σ ≤ τ) (φ : W → Prop) :
+    σ.assert φ ≤ τ.assert φ :=
+  ⟨fun _ hw => ⟨h.1 hw.1, hw.2⟩, h.2⟩
+
+theorem promote_mono {σ τ : ExpState W} (h : σ ≤ τ) (φ : W → Prop) :
+    σ.promote φ ≤ τ.promote φ :=
+  ⟨h.1, inf_le_inf_right _ h.2⟩
+
+/-- **Acceptance fixpoint for assertion** ([veltman-1996], §1): the
+    input refines its own assertion iff φ already holds throughout the
+    information state. -/
+theorem le_assert_iff (σ : ExpState W) (φ : W → Prop) :
+    σ ≤ σ.assert φ ↔ ∀ w ∈ σ.info, φ w :=
+  ⟨fun h w hw => (h.1 hw).2, fun h => ⟨fun _ hw => ⟨hw, h _ hw⟩, le_refl _⟩⟩
+
+/-- **Acceptance fixpoint for promotion** ([veltman-1996]: `e` is a
+    *default* in `ε` iff `ε ∘ e = ε`, his Def 4.2): the input refines
+    its own promotion iff the ordering already respects φ. This is the
+    support notion for the preferential component — "φ is already on
+    the To-Do List" — distinct from truth at the best worlds. -/
+theorem le_promote_iff (σ : ExpState W) (φ : W → Prop) :
+    σ ≤ σ.promote φ ↔ Normality.respects σ.order φ := by
+  constructor
+  · intro h w v hle hv
+    exact (h.2 hle).2 hv
+  · intro h
+    exact ⟨subset_rfl, le_inf (le_refl _) (fun w v hle hv => h w v hle hv)⟩
+
+end ExpState
 
 /-- Presumably is a test: it either returns the state or empties info. -/
 theorem presumably_isTest (φ : W → Prop) (σ : ExpState W) :
@@ -192,8 +257,8 @@ theorem presumably_passes (σ : ExpState W) (φ : W → Prop)
 theorem normally_presumably_succeeds (φ : W → Prop) (d : Set W)
     (hex : ∃ w ∈ d, φ w) :
     let σ : ExpState W := ⟨d, Normality.total⟩
-    presumablyTest φ (normallyUpdate φ σ) = normallyUpdate φ σ := by
-  simp only [presumablyTest, normallyUpdate, ExpState.optimal]
+    presumablyTest φ (σ.promote φ) = σ.promote φ := by
+  simp only [presumablyTest, ExpState.promote, ExpState.optimal]
   rw [if_pos]
   intro w hw
   rw [Normality.refine_total_optimal φ d hex] at hw
@@ -209,7 +274,7 @@ theorem normally_presumably_succeeds (φ : W → Prop) (d : Set W)
     [veltman-1996], Proposition 3.6(iv). -/
 theorem persistence_assert (σ : ExpState W) (φ ψ : W → Prop)
     (h : Normality.respects σ.order φ) :
-    Normality.respects (assertUpdate ψ σ).order φ := h
+    Normality.respects (σ.assert ψ).order φ := h
 
 /-- **Persistence under further defaults**: if the ordering respects p,
     then processing "normally q" (for any q) preserves this. Later
@@ -218,13 +283,13 @@ theorem persistence_assert (σ : ExpState W) (φ ψ : W → Prop)
     [veltman-1996], Proposition 3.6(iv). -/
 theorem persistence_normally (σ : ExpState W) (φ ψ : W → Prop)
     (h : Normality.respects σ.order φ) :
-    Normality.respects (normallyUpdate ψ σ).order φ :=
+    Normality.respects (σ.promote ψ).order φ :=
   Normality.refine_preserves_respects σ.order φ ψ h
 
 /-- After "normally p", the ordering respects p. Combined with
     persistence, this means "normally p" creates a permanent expectation. -/
 theorem normally_creates_respect (σ : ExpState W) (φ : W → Prop) :
-    Normality.respects (normallyUpdate φ σ).order φ :=
+    Normality.respects (σ.promote φ).order φ :=
   Normality.refine_respects σ.order φ
 
 
@@ -234,22 +299,22 @@ theorem normally_creates_respect (σ : ExpState W) (φ : W → Prop) :
     ordering respects φ), then processing "normally φ" again is a no-op.
 
     [veltman-1996], Proposition 3.6(ii) at the state level. -/
-theorem normallyUpdate_idempotent (σ : ExpState W) (φ : W → Prop)
+theorem promote_respects_idempotent (σ : ExpState W) (φ : W → Prop)
     (h : Normality.respects σ.order φ) :
-    normallyUpdate φ σ = σ := by
+    σ.promote φ = σ := by
   show ExpState.mk σ.info (Normality.refine σ.order φ) = σ
   congr 1
   exact Normality.refine_of_respects σ.order φ h
 
 /-- Corollary: "normally φ; normally φ" = "normally φ" from any state. -/
-theorem normallyUpdate_normally_idempotent (σ : ExpState W) (φ : W → Prop) :
-    normallyUpdate φ (normallyUpdate φ σ) = normallyUpdate φ σ :=
-  normallyUpdate_idempotent _ φ (normally_creates_respect σ φ)
+theorem promote_promote_self (σ : ExpState W) (φ : W → Prop) :
+    (σ.promote φ).promote φ = σ.promote φ :=
+  promote_respects_idempotent _ φ (normally_creates_respect σ φ)
 
 /-- **Commutativity**: the order of defaults doesn't matter.
     "Normally φ; normally ψ" = "normally ψ; normally φ". -/
-theorem normallyUpdate_comm (σ : ExpState W) (φ ψ : W → Prop) :
-    normallyUpdate ψ (normallyUpdate φ σ) = normallyUpdate φ (normallyUpdate ψ σ) := by
+theorem promote_comm (σ : ExpState W) (φ ψ : W → Prop) :
+    (σ.promote φ).promote ψ = (σ.promote ψ).promote φ := by
   show ExpState.mk σ.info (Normality.refine (Normality.refine σ.order φ) ψ) =
        ExpState.mk σ.info (Normality.refine (Normality.refine σ.order ψ) φ)
   congr 1

--- a/Linglib/Semantics/Genericity/Dynamic.lean
+++ b/Linglib/Semantics/Genericity/Dynamic.lean
@@ -484,7 +484,7 @@ theorem disjoint_pair_consistent
 [kirkpatrick-2024] Appendix A (pp. 544–548) shows that
 [veltman-1996]'s update semantics predicts both generic Sobel
 sequences and their reverses are consistent, because Veltman's
-`normallyUpdate` is commutative (`normallyUpdate_comm` in
+`ExpState.promote` is commutative (`promote_comm` in
 `UpdateSemantics/Default.lean`): the final expectation state σ₁ = σ₂
 regardless of processing order, since the expectation frame π₁ = π₂.
 
@@ -502,7 +502,7 @@ variable {G S : Type}
     on the final state gives the same truth value in both orders.
 
     This is the formal content of Kirkpatrick's argument against Veltman:
-    since `normallyUpdate` commutes, the consistency predicate cannot
+    since `ExpState.promote` commutes, the consistency predicate cannot
     distinguish σ[φ₁][φ₂] from σ[φ₂][φ₁]. In particular, if a Sobel
     sequence is consistent under Veltman's semantics, its reverse must
     be too — contrary to empirical judgment.

--- a/Linglib/Semantics/Mood/POSW.lean
+++ b/Linglib/Semantics/Mood/POSW.lean
@@ -1,485 +1,178 @@
-import Mathlib.Order.Basic
-import Mathlib.Order.PropInstances
-import Mathlib.Order.Lattice
+import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 
 /-!
-# Partially Ordered Set of Worlds (POSW)
+# POSW: Portner's Modal API over Expectation States
 [portner-2018] [veltman-1996] [kratzer-1981] [stalnaker-1978] [condoravdi-lauer-2012]
 
-[portner-2018] (Ch. 4) argues that the apparently disparate "mood"
-phenomena — verbal mood (indicative/subjunctive selection by
-attitudes, Ch. 2), sentence mood (declarative/imperative/interrogative
-force, Ch. 3), and modal flavor (epistemic/deontic/bouletic) — all
-share a single mathematical substrate: a **partially ordered set of
-worlds** that the relevant linguistic objects update or quantify over.
-The pair-of-information-and-ordering structure predates
-[portner-2018]: it is [veltman-1996]'s expectation state `⟨ε, s⟩` (§3
-there) — a fact set plus a normality preorder on worlds, where factual
-update refines the set and `normally`-update refines the ordering —
-and the Stalnakerian context-set/Kratzerian ordering-source
-decomposition behind it goes back to [stalnaker-1978] and
-[kratzer-1981]. [farkas-2003] contributes the assertive fixed-point
-characterization of the informational side (§ *Assertive fixed-point*
-below). [condoravdi-lauer-2012] works out the preferential-modal side
-(desire predicates over orderings) in detail. **Caveat**: C&L's
-*preference structures* are strict partial orders on **propositions**
-(`Set (Set W)`), one type level above POSW's preorder on **worlds**
-(`W → W → Prop`); see `Core.Order.PreferenceStructure`. The two
-connect via the maximal-element-induced world preorder
-(`Core.Order.PreferenceStructure.maxInducedLe`) — POSW *consumes* the
-output of C&L's machinery rather than instantiating it. The
-"preferential-modal side" framing is thematic, not structural.
+[portner-2018]'s **partially ordered set of worlds** (POSW) — the pair
+`⟨cs, ≤⟩` of a context set and an ordering that his mood unification
+(Ch. 4) has verbal mood (Ch. 2), sentence mood (Ch. 3), and modal
+flavor operate on — is [veltman-1996]'s expectation state `ExpState`
+read at the discourse level: `info` is the Stalnakerian context set
+([stalnaker-1978]), `order` the Kratzerian ordering source
+([kratzer-1981]), `ExpState.assert` the `+`-update, and
+`ExpState.promote` the `⋆`-update ([portner-2004]'s To-Do-List
+update). Portner's central architectural insight — belief vs. desire
+is `□_cs` vs. `□_≤` over the same agent's state, assertion vs.
+directive is `+` vs. `⋆` over the discourse state — becomes: the two
+updates touch disjoint components (`ExpState.assert_order`,
+`ExpState.promote_info`), and the two modals quantify over them.
 
-A POSW is a pair `c = ⟨cs_c, ≤_c⟩` where:
-- `cs_c ⊆ W` is a non-empty set of worlds (the "context set" — the
-  informational component, à la [stalnaker-1978]);
-- `≤_c` is a reflexive transitive preorder on `cs_c` (the "ordering
-  source" component, à la [kratzer-1981]). [portner-2018]
-  writes this `<` and reads it "at-least-as-good as", which is the
-  reflexive `≤` reading; we use `le` for mathlib alignment.
+This file adds the *modal* half of that API: the necessity modals
+`□_cs` (`boxCs`) and `□_≤` (`boxLe`), the `best` worlds the latter
+quantifies over, their normality in the modal-logic sense
+(`NormalModality`), and the support/necessity comparison relating
+each modal to its update's acceptance fixpoint.
 
-There are two canonical updates:
-- **`+`-update** refines `cs` by intersection: `c + p` keeps only
-  `cs`-worlds where `p` holds. Targets the *informational* component.
-- **`⋆`-update** refines `≤` by promoting `p`-worlds: in `c ⋆ p`,
-  the ordering on `cs` is the original ordering plus the constraint
-  that any world satisfying `p` is at least as good as one that
-  doesn't. Targets the *preferential* component.
+## Support vs necessity
 
-There are two canonical necessity modals:
-- `□_cs p` — informational necessity: `p` holds at every world in `cs`.
-- `□_≤ p` — preferential necessity: `p` holds at every `≤`-best world
-  in `cs`.
+[veltman-1996]'s acceptance (`σ ⊩ φ` iff `σ[φ] = σ`) gives each
+update a *support* condition (`ExpState.le_assert_iff`,
+`ExpState.le_promote_iff`). Comparing support with necessity:
 
-Portner's central architectural insight is that *what differs across
-mood-and-modality phenomena is which POSW component is targeted*, not
-the substrate itself. Belief vs. desire is `□_cs` vs. `□_≤` over the
-same agent's POSW; assertion vs. directive is `+` vs. `⋆` over the
-discourse POSW; epistemic vs. deontic modal flavor is the same split
-again.
+- **informational**: support of `assert` *is* `boxCs`
+  (`le_assert_iff_boxCs`) — the fixpoint [farkas-2003] uses to
+  characterize indicative-licensing (assertive) contexts.
+- **preferential**: support of `promote` is `Normality.respects`
+  ("φ is already on the To-Do List"), which is *not* equivalent to
+  `boxLe` and implies it only on connected orders with a φ-witness
+  (`boxLe_of_respects` — [veltman-1996]'s *normally φ ⊩ presumably
+  φ*). Connectedness can be destroyed by `promote` itself; Veltman's
+  ambiguous states are exactly the disconnected ones.
 
-The `+` and `⋆` updates target *disjoint* POSW components — that is the
-content of `updates_target_disjoint_components` below, which is the
-mathematical core of Portner's unification thesis.
+That the informational component is the one where support and
+necessity coincide is the type-level face of assertion's special
+status among the updates.
 
-## Notes
-- We work with `W → Prop` (classical propositions) rather than `W → Bool`
-  (decidable propositions) because POSW is the foundational substrate;
-  decidability concerns belong downstream.
-- [portner-2018] flags a strict-typing wart (-- UNVERIFIED: footnote
-  number): on his definition `c + p` is technically not a POSW because
-  the ordering is not restricted to the new (smaller) `cs`. We keep
-  the same behaviour (our `plus` leaves `c.le` unchanged) —
-  deliberately, not as a workaround: [veltman-1996] (fn. 5) shows the
-  ordering must live on all of `W` rather than on the current fact
-  set, or rule-persistence fails under factual update. The `le_refl` /
-  `le_trans` axioms are conditioned on `cs`-membership, so behaviour
-  outside `cs` is irrelevant.
-- We use a reflexive partial preorder `le` matching the partition /
-  `Setoid` lattice convention (finer ≤ coarser).
-
-## Lattice unification (linglib extension)
-
-[portner-2018] defines the `+`-update as set intersection and the
-`⋆`-update via Condoravdi-Lauer ordering refinement; the `?`-update
-(our extension) is naturally a `Setoid` meet. All three updates turn out
-to be **`inf` in three parallel mathlib lattices**, none of which
-appear in [portner-2018]:
-
-| update | acts on | lattice                    | identity                                       |
-|--------|---------|----------------------------|------------------------------------------------|
-| `+`    | `cs`    | `Pi.instLattice` over Prop | `(c + p).cs = c.cs ⊓ p` (`plus_cs_eq_inf`)     |
-| `⋆`    | `le`    | `Pi.instLattice` over Prop | `(c ⋆ p).le = c.le ⊓ promote p` (`star_le_eq_inf`) |
-| `?`    | `inquiry` | `Setoid.completeLattice` | `(c ? q).inquiry = c.inquiry ⊓ q` (POSWQ)       |
-
-The unified picture: each of the three POSW(Q) components carries an
-already-mathlib'd lattice, and each update is meet in its component's
-lattice. Commutativity (`star_star_comm_le`), idempotency
-(`star_star_self_le`), and the corresponding theorems on the other
-two updates all collapse to one-line invocations of `inf_right_comm`
-/ `inf_idem` in the appropriate lattice. The `K`-axiom for `boxCs` /
-`boxLe` (the *Normal modality structure* section) is the universal-quantification-preserves-inf pattern.
+**Caveat** on the preferential side: [condoravdi-lauer-2012]'s
+*preference structures* are strict partial orders on **propositions**,
+one type level above the world ordering here; see
+`Core.Order.PreferenceStructure`. POSW-style states consume the
+maximal-element-induced world preorder
+(`Core.Order.PreferenceStructure.maxInducedLe`) rather than
+instantiating them.
 -/
 
-namespace Semantics.Mood
+namespace Semantics.Dynamic.Default.ExpState
 
-universe u
+open Core.Order
 
-/-- A **partially ordered set of worlds** (POSW): a non-empty subset
-    `cs` of worlds equipped with a reflexive transitive ordering `le`
-    on `cs`. [portner-2018] (Ch. 4) writes the ordering `<`
-    (at-least-as-good); we use `le` for mathlib alignment. The
-    underlying pair structure appears already in [veltman-1996]'s
-    expectation states.
+variable {W : Type*}
 
-    Non-emptiness is not enforced at the type level — empty POSWs are
-    pathological but algebraically permitted (e.g., the result of
-    `+`-updating with an inconsistent proposition). Operations make
-    sense regardless. -/
-structure POSW (W : Type u) where
-  /-- The context set: worlds compatible with the POSW's information. -/
-  cs : W → Prop
-  /-- The ordering: `le w v` means w is at least as good as v.
-      Reflexive on `cs`, transitive on `cs`. -/
-  le : W → W → Prop
-  /-- Reflexivity on the context set. -/
-  le_refl : ∀ w, cs w → le w w
-  /-- Transitivity on the context set. -/
-  le_trans : ∀ w u v, cs w → cs u → cs v → le w u → le u v → le w v
-
-namespace POSW
-
-variable {W : Type u}
-
-/-! ### Updates: `+` and `⋆` -/
-
-/-- **`+`-update** ([portner-2018]; [stalnaker-1978]): refine `cs` by
-    intersection with `p`. Leaves `≤` untouched.
-
-    Used by assertion (Stalnakerian context-set update) and by `□_cs`
-    modals' restriction.
-
-    The resulting `le` is not restricted to the new `cs` — deliberately
-    (see the module docstring's note on [veltman-1996], fn. 5); the
-    structure satisfies the (cs-conditioned) POSW axioms. -/
-def plus (c : POSW W) (p : W → Prop) : POSW W where
-  cs := fun w => c.cs w ∧ p w
-  le := c.le
-  le_refl  := fun w hw => c.le_refl w hw.1
-  le_trans := fun w u v hw hu hv => c.le_trans w u v hw.1 hu.1 hv.1
-
-/-- **`⋆`-update** ([portner-2018]; ordering refinement as in
-    [veltman-1996]'s `normally`-update):
-    refine `≤` by promoting `p`-worlds. The new ordering keeps the old
-    ordering and additionally requires that whenever the upper world
-    satisfies `p`, the lower world does too.
-
-    Used by directives (To-Do List update à la [portner-2004])
-    and by `□_≤` modals' refinement ([condoravdi-lauer-2012]). -/
-def star (c : POSW W) (p : W → Prop) : POSW W where
-  cs := c.cs
-  le := fun w v => c.le w v ∧ (p v → p w)
-  le_refl  := fun w hw => ⟨c.le_refl w hw, fun hp => hp⟩
-  le_trans := fun w u v hw hu hv => fun ⟨hwu, hwu'⟩ ⟨huv, huv'⟩ =>
-    ⟨c.le_trans w u v hw hu hv hwu huv, fun hp => hwu' (huv' hp)⟩
-
-/-! ### Modals: `□_cs` and `□_≤` -/
-
-/-- A world is **best** in `c` if it is in `cs` and at least as good
-    as every other `cs`-world. The quantification domain of
-    [portner-2018]'s preferential necessity modal `□_≤`. -/
-def best (c : POSW W) (w : W) : Prop :=
-  c.cs w ∧ ∀ v, c.cs v → c.le v w
-
-/-- **Informational necessity** `□_cs` ([portner-2018], Ch. 2):
-    `p` holds at every world in the context set. The semantics of
+/-- **Informational necessity** `□_cs` ([portner-2018], Ch. 2): `p`
+    holds at every world in the information state. The semantics of
     `believe` and the Stalnakerian context-set entailment. -/
-def boxCs (c : POSW W) (p : W → Prop) : Prop :=
-  ∀ w, c.cs w → p w
+def boxCs (σ : ExpState W) (p : W → Prop) : Prop :=
+  ∀ w ∈ σ.info, p w
 
-/-- **Preferential necessity** `□_≤` ([portner-2018], Ch. 2):
-    `p` holds at every `≤`-best world in the context set. The
+/-- Portner's **best** worlds: members of the information state at
+    least as good as every other member — `IsLeast σ.info` under the
+    state's ordering, as `ExpState.optimal` is its `Minimal`. These
+    are [veltman-1996]'s *normal* worlds relativized to the fact set;
+    his *optimal* worlds (`ExpState.optimal`) require only
+    non-domination, so `best ⊆ optimal`, with equality on connected
+    orders. -/
+def best (σ : ExpState W) : Set W :=
+  {w ∈ σ.info | ∀ v ∈ σ.info, σ.order.le w v}
+
+/-- **Preferential necessity** `□_≤` ([portner-2018], Ch. 2): `p`
+    holds at every `≤`-best world of the information state. The
     semantics of `want` and Kratzerian deontic/bouletic modals
     ([kratzer-1981], [condoravdi-lauer-2012]). -/
-def boxLe (c : POSW W) (p : W → Prop) : Prop :=
-  ∀ w, c.best w → p w
+def boxLe (σ : ExpState W) (p : W → Prop) : Prop :=
+  ∀ w ∈ σ.best, p w
 
-/-! ### Algebraic facts -/
+theorem best_subset_optimal (σ : ExpState W) : σ.best ⊆ σ.optimal :=
+  fun _ hw => ⟨hw.1, fun v hv _ => hw.2 v hv⟩
 
-@[simp] theorem plus_cs (c : POSW W) (p : W → Prop) (w : W) :
-    (c.plus p).cs w ↔ c.cs w ∧ p w := Iff.rfl
-
-@[simp] theorem plus_le (c : POSW W) (p : W → Prop) :
-    (c.plus p).le = c.le := rfl
-
-@[simp] theorem star_cs (c : POSW W) (p : W → Prop) :
-    (c.star p).cs = c.cs := rfl
-
-@[simp] theorem star_le (c : POSW W) (p : W → Prop) (w v : W) :
-    (c.star p).le w v ↔ c.le w v ∧ (p v → p w) := Iff.rfl
-
-/-! ### Lattice characterization of `+`-update
-
-`+`-update on `cs` *is* meet in the Heyting algebra `W → Prop`: the new
-context set is the pointwise conjunction of the old context set and the
-asserted proposition. The identity is definitional — no proof obligation.
-This puts [portner-2018]'s intersective definition of `+`-update
-on the same algebraic footing as the `Setoid` meet that defines
-`POSWQ.inquire` and the relation meet that defines `star` (`star_le_eq_inf`). The
-mathlib instance chain is `Prop.instDistribLattice` → `Pi.instLattice`. -/
-
-/-- `+`-update on `cs` is meet in `W → Prop`: the Heyting form of
-    [portner-2018]'s intersective definition — `c + ϕ` intersects
-    `cs` with `ϕ`. -/
-@[simp] theorem plus_cs_eq_inf (c : POSW W) (p : W → Prop) :
-    (c.plus p).cs = c.cs ⊓ p := rfl
-
-/-- **Portner's central insight**: the two updates target *disjoint*
-    POSW components. `+` revises `cs` and leaves `le` alone; `⋆`
-    revises `le` and leaves `cs` alone.
-
-    This is the mathematical content of [portner-2018]'s
-    unification thesis (Ch. 4): the surface diversity of mood phenomena
-    reduces to *which component of the same substrate gets touched*. -/
-theorem updates_target_disjoint_components (c : POSW W) (p : W → Prop) :
-    (c.plus p).le = c.le ∧ (c.star p).cs = c.cs :=
-  ⟨rfl, rfl⟩
-
-/-- `+`-update is monotone in the proposition (intersection lemma). -/
-theorem plus_cs_mono (c : POSW W) (p q : W → Prop)
-    (h : ∀ w, p w → q w) (w : W) :
-    (c.plus p).cs w → (c.plus q).cs w :=
-  fun ⟨hcs, hp⟩ => ⟨hcs, h w hp⟩
-
-/-- `+`-update with a tautology is the identity on `cs`. -/
-theorem plus_top_cs (c : POSW W) (w : W) :
-    (c.plus (fun _ => True)).cs w ↔ c.cs w := by
-  simp [plus]
+theorem best_eq_optimal_of_connected (σ : ExpState W)
+    (hconn : Normality.connected σ.order) : σ.best = σ.optimal :=
+  Set.Subset.antisymm σ.best_subset_optimal
+    (fun w hw => ⟨hw.1, fun v hv => (hconn w v).elim id (fun h => hw.2 hv h)⟩)
 
 /-- `□_cs` is upward monotone. -/
-theorem boxCs_mono (c : POSW W) (p q : W → Prop)
-    (h : ∀ w, p w → q w) :
-    c.boxCs p → c.boxCs q :=
+theorem boxCs_mono (σ : ExpState W) (p q : W → Prop)
+    (h : ∀ w, p w → q w) : σ.boxCs p → σ.boxCs q :=
   fun hp w hw => h w (hp w hw)
 
 /-- `□_≤` is upward monotone. -/
-theorem boxLe_mono (c : POSW W) (p q : W → Prop)
-    (h : ∀ w, p w → q w) :
-    c.boxLe p → c.boxLe q :=
+theorem boxLe_mono (σ : ExpState W) (p q : W → Prop)
+    (h : ∀ w, p w → q w) : σ.boxLe p → σ.boxLe q :=
   fun hp w hw => h w (hp w hw)
 
-/-- After `+`-updating with `p`, `p` becomes informationally necessary.
-    The Stalnakerian assertion principle: asserting `p` makes `p`
-    common ground. [stalnaker-1978]; [portner-2018]. -/
-theorem boxCs_plus_self (c : POSW W) (p : W → Prop) :
-    (c.plus p).boxCs p :=
+/-- After asserting `p`, `p` is informationally necessary. The
+    Stalnakerian assertion principle: asserting `p` makes `p` common
+    ground. [stalnaker-1978]; [portner-2018]. -/
+theorem boxCs_assert_self (σ : ExpState W) (p : W → Prop) :
+    (σ.assert p).boxCs p :=
   fun _ hw => hw.2
 
-/-! ### Refinement preorder
+/-- Refining the state *strengthens* informational necessity. `boxLe`
+    admits no parallel result: refinement changes which worlds are
+    best, in either direction. -/
+theorem boxCs_anti {σ τ : ExpState W} (h : σ ≤ τ) (p : W → Prop) :
+    τ.boxCs p → σ.boxCs p :=
+  fun hbox w hw => hbox w (h.1 hw)
 
-A POSW is more *refined* than another when it carries strictly more
-information: a smaller context set, and a smaller (i.e., more
-discriminating) ordering relation. In the [portner-2018] update
-algebra, both `+`-update and `⋆`-update produce a refinement of the
-input POSW — refinement is what *update* means.
-
-The order convention follows the partition / `Setoid` lattice in
-mathlib: **finer ≤ coarser**, **more constrained ≤ less constrained**.
-The trivial POSW (`cs = ⊤`, `le = ⊤`) sits at the top; a fully
-informative POSW (smaller `cs`, smaller `le`) sits below.
-
-The `boxCs_anti` lemma gives the modal counterpart: refining the POSW
-*strengthens* informational necessity. `boxLe` admits no parallel
-result in general — refinement can change which worlds are best.
-
-(The componentwise refinement preorder is not stated in
-[portner-2018]; it is our linglib addition, packaging the
-"update means refine" intuition into a `Preorder` instance so the
-update lemmas factor through `≤` and downstream `Setoid`-style
-machinery composes.) -/
-
-/-- Refinement order on POSWs: `c₁ ≤ c₂` iff `c₁` is at least as
-    constrained as `c₂` — its context set is a subset of `c₂`'s,
-    and its ordering relation is a subset of `c₂`'s (fewer pairs are
-    "at-least-as-good as" each other under `c₁` than under `c₂`).
-    Both POSW updates land in the input's lower set. -/
-instance : Preorder (POSW W) where
-  le c₁ c₂ :=
-    (∀ w, c₁.cs w → c₂.cs w) ∧ (∀ w v, c₁.le w v → c₂.le w v)
-  le_refl _ := ⟨fun _ h => h, fun _ _ h => h⟩
-  le_trans _ _ _ h₁₂ h₂₃ :=
-    ⟨fun w h => h₂₃.1 w (h₁₂.1 w h),
-     fun w v h => h₂₃.2 w v (h₁₂.2 w v h)⟩
-
-theorem le_iff (c₁ c₂ : POSW W) :
-    c₁ ≤ c₂ ↔
-      (∀ w, c₁.cs w → c₂.cs w) ∧ (∀ w v, c₁.le w v → c₂.le w v) :=
-  Iff.rfl
-
-/-- `+`-update lands below the input: refining `cs` by intersection
-    with `p` can only constrain the POSW further. -/
-theorem plus_le_self (c : POSW W) (p : W → Prop) : c.plus p ≤ c :=
-  ⟨fun _ h => h.1, fun _ _ h => h⟩
-
-/-- `⋆`-update lands below the input: refining `le` with the
-    `p`-promotion constraint can only constrain the POSW further. -/
-theorem star_le_self (c : POSW W) (p : W → Prop) : c.star p ≤ c :=
-  ⟨fun _ h => h, fun _ _ h => h.1⟩
-
-/-- `+`-update is monotone in the underlying POSW: refining `c₁`
-    against `c₂` is preserved by adding the same `+`-update on top. -/
-theorem plus_mono {c₁ c₂ : POSW W} (h : c₁ ≤ c₂) (p : W → Prop) :
-    c₁.plus p ≤ c₂.plus p :=
-  ⟨fun w hp => ⟨h.1 w hp.1, hp.2⟩,
-   fun w v hlt => h.2 w v hlt⟩
-
-/-- `⋆`-update is monotone in the underlying POSW. -/
-theorem star_mono {c₁ c₂ : POSW W} (h : c₁ ≤ c₂) (p : W → Prop) :
-    c₁.star p ≤ c₂.star p :=
-  ⟨fun w hcs => h.1 w hcs,
-   fun w v hlt => ⟨h.2 w v hlt.1, hlt.2⟩⟩
-
-/-- Refining the POSW *strengthens* informational necessity: if `c₁`
-    is more refined than `c₂` and `p` is informationally necessary at
-    `c₂`, then `p` is informationally necessary at `c₁` too.
-
-    `boxLe` does *not* admit a parallel anti-monotonicity result:
-    refining the POSW changes which worlds are best, and the change
-    can move `p`-satisfying worlds either into or out of the best
-    set. -/
-theorem boxCs_anti (c₁ c₂ : POSW W) (h : c₁ ≤ c₂) (p : W → Prop) :
-    c₂.boxCs p → c₁.boxCs p :=
-  fun hbox w hcs => hbox w (h.1 w hcs)
-
-/-! ### Subtype preorder
-
-`POSW W` is *not* a `Preorder W` (the `le` axioms are conditioned on
-`cs`-membership). But it *is* a `Preorder (Subtype c.cs)` — the
-`cs`-restricted subtype carries an unconditional reflexive transitive
-preorder, courtesy of `le_refl` and `le_trans`. This makes mathlib's
-`Preorder` API (transitivity tactics, `le_trans`, `le_refl`, …)
-available on the in-context portion. -/
-
-/-- The `cs`-restricted subtype carries a reflexive transitive
-    preorder: the conditioning on `cs`-membership becomes
-    unconditional once we work in the subtype. Gives access to
-    mathlib's `Preorder` API on the in-context worlds. -/
-instance instPreorderSubtype (c : POSW W) : Preorder {w // c.cs w} where
-  le w v := c.le w.1 v.1
-  le_refl w := c.le_refl w.1 w.2
-  le_trans w u v := c.le_trans w.1 u.1 v.1 w.2 u.2 v.2
-
-/-! ### The `promote` preorder and `⋆`-update as relation meet
-
-`⋆`-update has a clean lattice-theoretic identity: it is meet in the
-relation lattice `W → W → Prop` of the existing preorder with the
-**promotion preorder** of `p`, where `promote p w v` says "if `p`
-holds at the lower world it holds at the higher one too". This is
-the relation-side analogue of `plus_cs_eq_inf`: `+`-update is
-meet in `W → Prop`, `⋆`-update is meet in `W → W → Prop`. Both reduce
-their respective updates to the same mathematical operation —
-`Pi.instLattice` over `Prop.instDistribLattice` — and inherit
-`inf_comm`, `inf_assoc`, `inf_idem` for free, which closes the
-commutativity / idempotency theorems below in one line each.
-
-The relation-meet identity also explains why `⋆`-update is *not* a
-literal monoid action of `(W → Prop, ∧, ⊤)` on `POSW W`: `promote
-(p ∧ q)` is in general strictly finer than `promote p ⊓ promote q`
-(a world where `p` holds and `q` doesn't witnesses the gap). What we
-get is weaker than a monoid action, but the relation-lattice meet is
-exactly the right level of abstraction for the algebraic theorems
-below. -/
-
-/-- The **promotion preorder** of a proposition: `w` is at least as
-    `p`-good as `v` iff `p`-truth at `v` carries to `p`-truth at `w`.
-    The structural content of `⋆`-update on the ordering: one
-    `⋆`-application meets `c.le` with `promote p` in `W → W → Prop`. -/
-def promote (p : W → Prop) (w v : W) : Prop := p v → p w
-
-theorem promote_refl (p : W → Prop) (w : W) : promote p w w :=
-  fun hp => hp
-
-theorem promote_trans (p : W → Prop) (w u v : W) :
-    promote p w u → promote p u v → promote p w v :=
-  fun h₁ h₂ hp => h₁ (h₂ hp)
-
-/-- `⋆`-update is meet in `W → W → Prop`: `(c ⋆ p).le = c.le ⊓ promote p`.
-    The relation-side analogue of `plus_cs_eq_inf` — both updates are
-    `inf` in the appropriate `Pi`-over-`Prop` lattice. Definitional. -/
-@[simp] theorem star_le_eq_inf (c : POSW W) (p : W → Prop) :
-    (c.star p).le = c.le ⊓ promote p := rfl
-
-/-- Pointwise restatement of `star_le_eq_inf`. -/
-@[simp] theorem star_le_eq (c : POSW W) (p : W → Prop) (w v : W) :
-    (c.star p).le w v ↔ c.le w v ∧ promote p w v := Iff.rfl
-
-/-- **`⋆`-update commutes with itself** (relation level): applying two
-    `⋆`-updates in either order produces the same ordering relation.
-    One-line corollary of `inf_right_comm` in `W → W → Prop`. -/
-theorem star_star_comm_le (c : POSW W) (p q : W → Prop) :
-    ((c.star p).star q).le = ((c.star q).star p).le := by
-  show c.le ⊓ promote p ⊓ promote q = c.le ⊓ promote q ⊓ promote p
-  rw [inf_right_comm]
-
-/-- **`⋆`-update is idempotent** (relation level): applying the same
-    `⋆`-update twice produces the same ordering as once. One-line
-    corollary of `inf_assoc` + `inf_idem` in `W → W → Prop`. -/
-theorem star_star_self_le (c : POSW W) (p : W → Prop) :
-    ((c.star p).star p).le = (c.star p).le := by
-  show c.le ⊓ promote p ⊓ promote p = c.le ⊓ promote p
-  rw [inf_assoc, inf_idem]
-
-/-! ### Assertive fixed-point
-
-[farkas-2003] characterizes indicative-licensing (assertive) contexts
-via a Stalnakerian fixed-point: an update is assertive when its
-content can be non-vacuously added, and `p` is already *accepted* when
-adding it changes nothing (`c + p = c`). This is [veltman-1996]'s
-acceptance relation (`σ ⊩ φ` iff `σ[φ] = σ`, §1 there) specialized to
-the `+`-update. Farkas's account covers the indicative/assertive side
-only; the `⋆` (To-Do-List) update belongs to [portner-2004] and plays
-no role in [farkas-2003].
-
-For `+`-update on `cs`: `c` already implies `p` (i.e. `c.boxCs p`)
-iff `c ≤ c.plus p` (i.e. `c.plus p` doesn't shrink `cs`). -/
-
-/-- **Assertive fixed-point**: the input refines the `+`-update iff
+/-- **Assertive fixed-point**: the input refines its own assertion iff
     the proposition is already informationally necessary —
-    [veltman-1996]'s acceptance (`σ[φ] = σ`) for the `+`-update, and
-    the formal core of [farkas-2003]'s assertive characterization of
+    [veltman-1996]'s acceptance for the `+`-update, and the formal
+    core of [farkas-2003]'s assertive characterization of
     indicative-licensing contexts. -/
-theorem le_plus_iff_boxCs (c : POSW W) (p : W → Prop) :
-    c ≤ c.plus p ↔ c.boxCs p := by
-  constructor
-  · intro h w hw
-    exact (h.1 w hw).2
-  · intro hp
-    refine ⟨fun w hw => ⟨hw, hp w hw⟩, fun _ _ h => h⟩
+theorem le_assert_iff_boxCs (σ : ExpState W) (p : W → Prop) :
+    σ ≤ σ.assert p ↔ σ.boxCs p :=
+  σ.le_assert_iff p
+
+/-- **Support implies preferential necessity on connected orders**
+    ([veltman-1996]'s *normally φ ⊩ presumably φ*): if the ordering
+    already respects `p` (the `promote`-support condition,
+    `ExpState.le_promote_iff`) and is connected, and the information
+    state has a `p`-world, then `p` holds at every best world. The
+    converse fails, and without connectedness so does this direction —
+    Veltman's ambiguous states. -/
+theorem boxLe_of_respects (σ : ExpState W) (p : W → Prop)
+    (hresp : Normality.respects σ.order p)
+    (hconn : Normality.connected σ.order)
+    (hex : ∃ w ∈ σ.info, p w) : σ.boxLe p :=
+  fun _ hw =>
+    (Normality.optimal_of_respects_connected σ.order p σ.info hresp hconn hex
+      (σ.best_subset_optimal hw)).2
+
+end Semantics.Dynamic.Default.ExpState
+
+namespace Semantics.Mood
+
+open Semantics.Dynamic.Default
+
+universe u
+variable {W : Type u}
 
 /-! ### Normal modality structure
 
-`boxCs` and `boxLe` are both **normal modalities** in the sense of
-modal logic: each satisfies necessitation (`□⊤`) and the K-axiom
-(`□(p→q) → □p → □q`). The K-axiom is one shape of the general
-**inf-preservation** pattern that `∀` over any subset enjoys:
-`(∀ w ∈ S, p w → q w) ∧ (∀ w ∈ S, p w) → (∀ w ∈ S, q w)`. So both
-`boxCs` (= `∀_{c.cs}`) and `boxLe` (= `∀_{c.best}`) inherit
-normality from `Pi.instLattice` on `Prop` — the same lattice that
-underlies `+` and `⋆` updates (cf. file docstring "Lattice
-unification" table).
-
-The third modal `boxAns` is *not* normal — it does not satisfy K.
-A counterexample: with `cs = {a, b, c}`, inquiry partition
-`{{a, b}, {c}}`, take `p` false on `{a, b}` and `q` true at `a`,
-false at `b`. Then `boxAns p` (vacuously, since `p` is false on the
-cell), `boxAns (p → q)` (vacuously, since `p → q` is true on the
-cell when `p` is false), but not `boxAns q`. `boxAns` instead has its
-own closure structure: it is closed under boolean operations on the
-*proposition* (`POSWQ.boxAns_not / and / or / imp`), which makes it
-a different kind of constancy modality.
-
-The `NormalModality` typeclass packages N + K and exposes them by
-TC inference, so any future code that abstracts over a normal box
-can dispatch to `boxCs` and `boxLe` uniformly. -/
+`boxCs` and `boxLe` are both **normal modalities** in the modal-logic
+sense: each satisfies necessitation (`□⊤`) and the K-axiom
+(`□(p→q) → □p → □q`) — one shape of the inf-preservation pattern that
+`∀` over any subset enjoys. The third POSWQ modal `boxAns` is *not*
+normal (see `Semantics/Mood/POSWQ.lean`); it has its own closure
+structure under boolean operations instead. -/
 
 /-- A **normal modality** in the sense of basic modal logic:
     quantifies a unary box over `W → Prop` predicates, satisfying
     necessitation (`box ⊤`) and the K-axiom (`box (p → q) → box p
-    → box q`). The two POSW universal modalities `boxCs` and `boxLe`
-    are normal; `POSWQ.boxAns` is not (see the section docstring). -/
+    → box q`). The two universal modals `ExpState.boxCs` and
+    `ExpState.boxLe` are normal; `POSWQ.boxAns` is not. -/
 class NormalModality (W : Type u) (box : (W → Prop) → Prop) : Prop where
   /-- Necessitation: the box always holds for `⊤`. -/
   necessitation : box (fun _ => True)
   /-- The K-axiom: distribution of the box over implication. -/
   K : ∀ p q : W → Prop, box (fun w => p w → q w) → box p → box q
 
-instance (c : POSW W) : NormalModality W c.boxCs where
+instance (σ : ExpState W) : NormalModality W σ.boxCs where
   necessitation := fun _ _ => trivial
   K _ _ hpq hp w hcs := hpq w hcs (hp w hcs)
 
-instance (c : POSW W) : NormalModality W c.boxLe where
+instance (σ : ExpState W) : NormalModality W σ.boxLe where
   necessitation := fun _ _ => trivial
   K _ _ hpq hp w hbest := hpq w hbest (hp w hbest)
 
-end POSW
 end Semantics.Mood

--- a/Linglib/Semantics/Mood/POSWQ.lean
+++ b/Linglib/Semantics/Mood/POSWQ.lean
@@ -5,12 +5,14 @@ import Linglib.Semantics.Mood.POSW
 # POSW with Inquiry Partition (POSWQ)
 [portner-2018] [groenendijk-stokhof-1984] [roberts-2012]
 
-This file is **our extension** of [portner-2018]'s POSW substrate to
-interrogative force, by way of a third component recording the open
-question: `cs` stays intact and `inquiry : Setoid W` is a separate
-third coordinate, so `+`, `⋆`, `?` each touch one component and the
-inquiry partition composes orthogonally with `cs`-refinement and
-`≤`-refinement. [portner-2018]'s verbal-mood unification itself is
+This file is **our extension** of the POSW substrate
+(`Semantics/Mood/POSW.lean`: [veltman-1996]'s `ExpState` under
+[portner-2018]'s modal reading) to interrogative force, by way of a
+third component recording the open question: `info` and `order` stay
+intact and `inquiry : Setoid W` is a separate third coordinate, so
+`assert`, `promote`, `inquire` each touch one component and the
+inquiry partition composes orthogonally with the other two
+refinements. [portner-2018]'s verbal-mood unification itself is
 stated over the two POSW components only; the separate question
 coordinate follows the architecture of [portner-2004]'s discourse
 model, which keeps the Question Set apart from the Common Ground and
@@ -29,39 +31,29 @@ makes the partition view directly available via mathlib's
 
 | layer            | declarative      | imperative       | interrogative      |
 |------------------|------------------|------------------|--------------------|
-| sentence mood    | assertion (`+`)  | direction (`⋆`)  | inquiry (`?`)      |
+| sentence mood    | `assert` (`+`)   | `promote` (`⋆`)  | `inquire` (`?`)    |
 | modal necessity  | `boxCs`          | `boxLe`          | `boxAns`           |
 | verbal mood      | `.indicative`    | (no analogue)    | `.interrogative`   |
 
-The columns are the three POSW components (`cs`, `le`, `inquiry`); the
+The columns are the three components (`info`, `order`, `inquiry`); the
 rows are the operations on each component (refining update,
 quantification). Refinement of the inquiry partition (`?`-update),
 the modal `boxAns`, and the third column entries are this library's
-extensions; they do not appear in [portner-2018].
+extensions; they do not appear in [portner-2018]. Each update is meet
+in its component's lattice (`Pi` over `Prop` for `info`; the preorder
+lattice via `Normality.refine` for `order`; `Setoid.completeLattice`
+for `inquiry`), so commutativity and idempotency are one-line
+`inf`-facts throughout.
 
-## Mathlib alignment
+## Support vs necessity, inquiry column
 
-- `inquiry : Setoid W` uses mathlib's `CompleteLattice (Setoid W)`
-  instance directly: `⊓` for partition meet (jointly-finer), `≤` for
-  refinement (finer ≤ coarser).
-- The Setoid `≤` convention (`r ≤ s ↔ ∀ x y, r x y → s x y`) coincides
-  with the POSW refinement preorder convention from
-  `Linglib/Semantics/Mood/POSW.lean`'s refinement-preorder section: finer ≤ coarser, more
-  discriminating ≤ less discriminating.
-- `extends POSW W` mirrors `Group extends Monoid`: a POSWQ *is* a POSW
-  (via the auto-generated `POSWQ.toPOSW`) plus extra structure.
-
-## Three-lattice unification (third corner)
-
-The POSWQ `?`-update is the third corner of the linglib lattice
-unification described in `Mood/POSW.lean`'s "Lattice unification"
-docstring: each of `cs`, `le`, `inquiry` carries a mathlib lattice,
-and each of `+`, `⋆`, `?` is meet in its component's lattice. The
-`inquiry` corner uses `Setoid.completeLattice α` (mathlib), so the
-`?`-update inherits not just `inf` but `iInf` over arbitrary index
-sets — reading off "asking the conjunction of a family of questions"
-as `iInf` is then a one-line consequence. The `?`-update inherits
-`inf_assoc`, `inf_idem`, and `inf_comm` directly (`inquire_inquire_self` is a one-liner via `inf_assoc + inf_idem`).
+Acceptance-as-fixpoint extends to the third coordinate: the state
+supports `inquire q` iff its inquiry already refines `q`
+(`le_inquire_iff`). Routing a proposition through `polarSetoid`,
+support implies answerhood (`boxAns_of_inquiry_le_polarSetoid`), and
+the two coincide when `info = Set.univ`
+(`inquiry_le_polarSetoid_iff_boxAns_of_univ`) — `boxAns` is
+`info`-relativized while the inquiry coordinate is not.
 
 ## Architectural note: Setoid vs. InquisitiveContent
 
@@ -98,36 +90,38 @@ and `Filter`/`Ultrafilter` parallel rather than collapsing them.
 
 namespace Semantics.Mood
 
-universe u
+open Semantics.Dynamic.Default
 
-/-- A **POSW with an inquiry partition** (POSWQ): the [portner-2018]
-    POSW substrate enriched with a third component recording the open
+/-- A **POSW with an inquiry partition** (POSWQ): the POSW substrate
+    (an `ExpState`) enriched with a third component recording the open
     question. The `inquiry : Setoid W` partitions worlds into
     "answers"; its `⊤` element is "no question". The three-coordinate
     packaging is ours; the separate question coordinate follows
     [portner-2004]'s Question Set (kept apart from the Common Ground),
     while [portner-2018]'s verbal-mood unification is stated over the
     two POSW components only. -/
-structure POSWQ (W : Type u) extends POSW W where
+structure POSWQ (W : Type*) extends ExpState W where
   /-- The inquiry partition: `inquiry.r w v` means worlds `w` and `v`
       are indistinguishable answers to the open question. -/
   inquiry : Setoid W
 
 namespace POSWQ
 
-variable {W : Type u}
+variable {W : Type*}
 
 /-! ### Constructors -/
 
-/-- Lift a POSW to a POSWQ with no question under discussion (trivial
-    inquiry partition: every world is in the same cell). -/
-def ofPOSW (c : POSW W) : POSWQ W :=
-  { c with inquiry := ⊤ }
+/-- Lift an expectation state to a POSWQ with no question under
+    discussion (trivial inquiry partition: every world is in the same
+    cell). -/
+def ofExpState (σ : ExpState W) : POSWQ W :=
+  { σ with inquiry := ⊤ }
 
-@[simp] theorem ofPOSW_toPOSW (c : POSW W) : (ofPOSW c).toPOSW = c := rfl
+@[simp] theorem ofExpState_toExpState (σ : ExpState W) :
+    (ofExpState σ).toExpState = σ := rfl
 
-@[simp] theorem ofPOSW_inquiry (c : POSW W) :
-    (ofPOSW c).inquiry = (⊤ : Setoid W) := rfl
+@[simp] theorem ofExpState_inquiry (σ : ExpState W) :
+    (ofExpState σ).inquiry = (⊤ : Setoid W) := rfl
 
 /-- The **polar Setoid** of a proposition `q : W → Prop`: two worlds
     are equivalent iff they agree on `q`. The smallest piece of
@@ -157,9 +151,8 @@ def polarSetoid (q : W → Prop) : Setoid W where
 
 /-- **`?`-update** (our extension; not in [portner-2018]): refine
     the inquiry partition by meet with `q`. The partition-side
-    analogue of `+`-update on `cs` and `⋆`-update on `le`: it
-    constrains the third POSW component without touching the other
-    two.
+    analogue of `assert` on `info` and `promote` on `order`: it
+    constrains the third component without touching the other two.
 
     The meet of two equivalence relations on `W` is "agree on both";
     refining the inquiry by `q` shrinks each cell down to its
@@ -167,21 +160,18 @@ def polarSetoid (q : W → Prop) : Setoid W where
 def inquire (c : POSWQ W) (q : Setoid W) : POSWQ W :=
   { c with inquiry := c.inquiry ⊓ q }
 
-@[simp] theorem inquire_toPOSW (c : POSWQ W) (q : Setoid W) :
-    (c.inquire q).toPOSW = c.toPOSW := rfl
+@[simp] theorem inquire_toExpState (c : POSWQ W) (q : Setoid W) :
+    (c.inquire q).toExpState = c.toExpState := rfl
 
-@[simp] theorem inquire_cs (c : POSWQ W) (q : Setoid W) :
-    (c.inquire q).cs = c.cs := rfl
+@[simp] theorem inquire_info (c : POSWQ W) (q : Setoid W) :
+    (c.inquire q).info = c.info := rfl
 
-@[simp] theorem inquire_le (c : POSWQ W) (q : Setoid W) :
-    (c.inquire q).le = c.le := rfl
+@[simp] theorem inquire_order (c : POSWQ W) (q : Setoid W) :
+    (c.inquire q).order = c.order := rfl
 
-theorem inquire_inquiry (c : POSWQ W) (q : Setoid W) :
-    (c.inquire q).inquiry = c.inquiry ⊓ q := rfl
-
-/-- `?`-update is meet in `Setoid.completeLattice W`. The inquiry-side
-    analogue of `POSW.plus_cs_eq_inf` (meet in `W → Prop`) and
-    `POSW.star_le_eq_inf` (meet in `W → W → Prop`). Definitional. -/
+/-- `?`-update is meet in `Setoid.completeLattice W` — the inquiry-side
+    analogue of `assert` (meet in `W → Prop`) and `promote` (meet with
+    the criterion preorder, `Normality.refine`). Definitional. -/
 @[simp] theorem inquire_inquiry_eq_inf (c : POSWQ W) (q : Setoid W) :
     (c.inquire q).inquiry = c.inquiry ⊓ q := rfl
 
@@ -189,50 +179,40 @@ theorem inquire_inquiry (c : POSWQ W) (q : Setoid W) :
 
 /-- **Informational answerhood** (our extension): `p` is *settled by the
     question* at `c` iff `p` has a constant truth value within every
-    cell of `c.inquiry` (restricted to the context set). The
-    answerhood counterpart of [portner-2018]'s `boxCs` (truth
-    throughout `cs`) and `boxLe` (truth at every best world); the
-    formulation is closest in spirit to [groenendijk-stokhof-1984]
-    answerhood.
+    cell of `c.inquiry` (restricted to the information state). The
+    answerhood counterpart of `boxCs` (truth throughout `info`) and
+    `boxLe` (truth at every best world); the formulation is closest in
+    spirit to [groenendijk-stokhof-1984] answerhood.
 
     Unlike `boxCs` and `boxLe`, `boxAns` is *not* upward-monotone in
     `p`: a strengthening of `p` can break the constant-truth property
     on a cell. The natural monotonicity for `boxAns` is *anti*-monotone
     in the inquiry partition (`boxAns_anti` below). -/
 def boxAns (c : POSWQ W) (p : W → Prop) : Prop :=
-  ∀ w v, c.cs w → c.cs v → c.inquiry.r w v → (p w ↔ p v)
-
-/-! ### Disjointness of components
-
-The `+`-, `⋆`-, and `?`-updates target *disjoint* components of the
-POSWQ. The first two leave `inquiry` alone (vacuously, since they're
-defined on the underlying POSW), and `?`-update leaves both `cs` and
-`le` alone. The Portner unification thesis extends to three columns. -/
-
-theorem inquire_targets_disjoint_components (c : POSWQ W) (q : Setoid W) :
-    (c.inquire q).cs = c.cs ∧ (c.inquire q).le = c.le :=
-  ⟨rfl, rfl⟩
+  ∀ w v, w ∈ c.info → v ∈ c.info → c.inquiry.r w v → (p w ↔ p v)
 
 /-! ### Refinement preorder
 
-`POSWQ W` inherits a refinement preorder componentwise from `POSW W`'s
-refinement preorder (Mood/POSW.lean) and the `Setoid W` lattice:
-`c₁ ≤ c₂` iff `c₁.toPOSW ≤ c₂.toPOSW` and `c₁.inquiry ≤ c₂.inquiry`.
-Both directions agree on "finer ≤ coarser". -/
+`POSWQ W` inherits a refinement preorder componentwise from the
+`ExpState` refinement preorder and the `Setoid W` lattice:
+`c₁ ≤ c₂` iff `c₁.toExpState ≤ c₂.toExpState` and
+`c₁.inquiry ≤ c₂.inquiry`. All components agree on "finer ≤
+coarser". -/
 
 instance : Preorder (POSWQ W) where
-  le c₁ c₂ := c₁.toPOSW ≤ c₂.toPOSW ∧ c₁.inquiry ≤ c₂.inquiry
+  le c₁ c₂ := c₁.toExpState ≤ c₂.toExpState ∧ c₁.inquiry ≤ c₂.inquiry
   le_refl c := ⟨le_refl _, le_refl _⟩
   le_trans _ _ _ h₁₂ h₂₃ :=
     ⟨le_trans h₁₂.1 h₂₃.1, le_trans h₁₂.2 h₂₃.2⟩
 
 theorem le_iff (c₁ c₂ : POSWQ W) :
-    c₁ ≤ c₂ ↔ c₁.toPOSW ≤ c₂.toPOSW ∧ c₁.inquiry ≤ c₂.inquiry :=
+    c₁ ≤ c₂ ↔ c₁.toExpState ≤ c₂.toExpState ∧ c₁.inquiry ≤ c₂.inquiry :=
   Iff.rfl
 
 /-- `?`-update lands below the input: refining `inquiry` by meet with
     `q` can only constrain the POSWQ further. The third-component
-    analogue of `POSW.plus_le_self` and `POSW.star_le_self`. -/
+    analogue of `ExpState.assert_le_self` and
+    `ExpState.promote_le_self`. -/
 theorem inquire_le_self (c : POSWQ W) (q : Setoid W) : c.inquire q ≤ c :=
   ⟨le_refl _, inf_le_left⟩
 
@@ -241,18 +221,43 @@ theorem inquire_mono {c₁ c₂ : POSWQ W} (h : c₁ ≤ c₂) (q : Setoid W) :
     c₁.inquire q ≤ c₂.inquire q :=
   ⟨h.1, inf_le_inf_right q h.2⟩
 
+/-- **Acceptance fixpoint for `inquire`**: the input refines its own
+    `?`-update iff its inquiry already refines the question. The
+    third-coordinate instance of [veltman-1996]'s acceptance
+    (`ExpState.le_assert_iff`, `ExpState.le_promote_iff`). -/
+theorem le_inquire_iff (c : POSWQ W) (q : Setoid W) :
+    c ≤ c.inquire q ↔ c.inquiry ≤ q :=
+  ⟨fun h => le_trans h.2 inf_le_right,
+   fun h => ⟨le_refl _, le_inf (le_refl _) h⟩⟩
+
+/-- Support implies answerhood: if the inquiry already refines `p`'s
+    polar partition, `p` is settled by the question. -/
+theorem boxAns_of_inquiry_le_polarSetoid (c : POSWQ W) (p : W → Prop)
+    (h : c.inquiry ≤ polarSetoid p) : c.boxAns p :=
+  fun _ _ _ _ hwv => h hwv
+
+/-- On states with total information (`info = Set.univ`), answerhood
+    *is* inquiry-support for the polar partition: the `info`-guards in
+    `boxAns` are the only gap between the two. -/
+theorem inquiry_le_polarSetoid_iff_boxAns_of_univ (c : POSWQ W)
+    (p : W → Prop) (h : c.info = Set.univ) :
+    c.inquiry ≤ polarSetoid p ↔ c.boxAns p :=
+  ⟨fun hle => c.boxAns_of_inquiry_le_polarSetoid p hle,
+   fun hbox w v hwv =>
+     hbox w v (h ▸ Set.mem_univ w) (h ▸ Set.mem_univ v) hwv⟩
+
 /-- Refining the POSWQ *strengthens* informational answerhood: if
     `c₁` is more refined than `c₂` and `p` is settled by the question
     at `c₂`, then `p` is settled at `c₁` too. The answerhood
-    counterpart of `POSW.boxCs_anti`. -/
+    counterpart of `ExpState.boxCs_anti`. -/
 theorem boxAns_anti (c₁ c₂ : POSWQ W) (h : c₁ ≤ c₂) (p : W → Prop) :
     c₂.boxAns p → c₁.boxAns p :=
   fun hbox w v hw hv hwv =>
-    hbox w v (h.1.1 w hw) (h.1.1 v hv) (h.2 hwv)
+    hbox w v (h.1.1 hw) (h.1.1 hv) (h.2 hwv)
 
 /-! ### Closure properties of `boxAns`
 
-`boxAns p` says "`p` is constant on each inquiry cell within `cs`".
+`boxAns p` says "`p` is constant on each inquiry cell within `info`".
 This class of propositions is closed under the standard logical
 operations — answers to a question can be combined like ordinary
 propositions. -/
@@ -292,46 +297,48 @@ theorem boxAns_imp (c : POSWQ W) (p q : W → Prop) :
 
 /-! ### Three-component update disjointness
 
-The three updates `+`, `⋆`, `?` touch disjoint POSWQ components, so
-they pairwise commute when lifted to act on `POSWQ`. The lifts are
-defined here because `POSW.plus` and `POSW.star` strip the inquiry
-field; `POSWQ.plus` and `POSWQ.star` are the inquiry-preserving
-counterparts. -/
+The three updates `assert`, `promote`, `inquire` touch disjoint POSWQ
+components, so they pairwise commute when lifted to act on `POSWQ`.
+The lifts are defined here because `ExpState.assert` and
+`ExpState.promote` strip the inquiry field; `POSWQ.assert` and
+`POSWQ.promote` are the inquiry-preserving counterparts. -/
 
-/-- POSWQ-side `+`-update: refine `cs` while preserving the inquiry
-    partition. The inquiry-preserving lift of `POSW.plus`. -/
-def plus (c : POSWQ W) (p : W → Prop) : POSWQ W :=
-  { c.toPOSW.plus p with inquiry := c.inquiry }
+/-- POSWQ-side `+`-update: refine `info` while preserving the inquiry
+    partition. The inquiry-preserving lift of `ExpState.assert`. -/
+def assert (c : POSWQ W) (p : W → Prop) : POSWQ W :=
+  { c.toExpState.assert p with inquiry := c.inquiry }
 
-/-- POSWQ-side `⋆`-update: refine `le` while preserving the inquiry
-    partition. The inquiry-preserving lift of `POSW.star`. -/
-def star (c : POSWQ W) (p : W → Prop) : POSWQ W :=
-  { c.toPOSW.star p with inquiry := c.inquiry }
+/-- POSWQ-side `⋆`-update: refine `order` while preserving the inquiry
+    partition. The inquiry-preserving lift of `ExpState.promote`. -/
+def promote (c : POSWQ W) (p : W → Prop) : POSWQ W :=
+  { c.toExpState.promote p with inquiry := c.inquiry }
 
-@[simp] theorem plus_toPOSW (c : POSWQ W) (p : W → Prop) :
-    (c.plus p).toPOSW = c.toPOSW.plus p := rfl
+@[simp] theorem assert_toExpState (c : POSWQ W) (p : W → Prop) :
+    (c.assert p).toExpState = c.toExpState.assert p := rfl
 
-@[simp] theorem plus_inquiry (c : POSWQ W) (p : W → Prop) :
-    (c.plus p).inquiry = c.inquiry := rfl
+@[simp] theorem assert_inquiry (c : POSWQ W) (p : W → Prop) :
+    (c.assert p).inquiry = c.inquiry := rfl
 
-@[simp] theorem star_toPOSW (c : POSWQ W) (p : W → Prop) :
-    (c.star p).toPOSW = c.toPOSW.star p := rfl
+@[simp] theorem promote_toExpState (c : POSWQ W) (p : W → Prop) :
+    (c.promote p).toExpState = c.toExpState.promote p := rfl
 
-@[simp] theorem star_inquiry (c : POSWQ W) (p : W → Prop) :
-    (c.star p).inquiry = c.inquiry := rfl
+@[simp] theorem promote_inquiry (c : POSWQ W) (p : W → Prop) :
+    (c.promote p).inquiry = c.inquiry := rfl
 
-/-- `+` and `⋆` commute on POSWQ: applying `+`-then-`⋆` and `⋆`-then-`+`
-    produces the same POSWQ. The components never interact. -/
-@[simp] theorem plus_star_comm (c : POSWQ W) (p q : W → Prop) :
-    (c.plus p).star q = (c.star q).plus p := rfl
+/-- `assert` and `promote` commute on POSWQ: the components never
+    interact. -/
+@[simp] theorem assert_promote_comm (c : POSWQ W) (p q : W → Prop) :
+    (c.assert p).promote q = (c.promote q).assert p := rfl
 
-/-- `+` and `?` commute on POSWQ: each touches a different component. -/
-@[simp] theorem plus_inquire_comm (c : POSWQ W) (p : W → Prop) (s : Setoid W) :
-    (c.plus p).inquire s = (c.inquire s).plus p := rfl
+/-- `assert` and `inquire` commute on POSWQ: each touches a different
+    component. -/
+@[simp] theorem assert_inquire_comm (c : POSWQ W) (p : W → Prop) (s : Setoid W) :
+    (c.assert p).inquire s = (c.inquire s).assert p := rfl
 
-/-- `⋆` and `?` commute on POSWQ: each touches a different component. -/
-@[simp] theorem star_inquire_comm (c : POSWQ W) (p : W → Prop) (s : Setoid W) :
-    (c.star p).inquire s = (c.inquire s).star p := rfl
+/-- `promote` and `inquire` commute on POSWQ: each touches a different
+    component. -/
+@[simp] theorem promote_inquire_comm (c : POSWQ W) (p : W → Prop) (s : Setoid W) :
+    (c.promote p).inquire s = (c.inquire s).promote p := rfl
 
 /-- `?`-update is idempotent on the same partition: refining inquiry
     by `s` twice equals refining once. The Setoid-meet is idempotent
@@ -348,15 +355,14 @@ where some `p` is settled by the question (`boxAns p`) but is *not*
 informationally necessary (`¬ boxCs p`). The witness is a non-trivial
 inquiry partition with two cells, where `p` is true on one cell and
 false on the other: it has a constant truth value per cell (so
-`boxAns`), but is not uniformly true on `cs` (so not `boxCs`). -/
+`boxAns`), but is not uniformly true on `info` (so not `boxCs`). -/
 
-/-- Two-cell inquiry POSWQ: `cs = ⊤` over `Bool`, `le = ⊤`, with
-    `inquiry` the identity Setoid (each Bool in its own cell). -/
+/-- Two-cell inquiry POSWQ: `info = Set.univ` over `Bool`, `order`
+    total, with `inquiry` the identity Setoid (each Bool in its own
+    cell). -/
 def sepPOSWQ : POSWQ Bool where
-  cs := fun _ => True
-  le := fun _ _ => True
-  le_refl  := fun _ _ => trivial
-  le_trans := fun _ _ _ _ _ _ _ _ => trivial
+  info := Set.univ
+  order := Core.Order.Normality.total
   inquiry := { r := fun w v => w = v, iseqv :=
     ⟨fun _ => rfl, fun {_ _} h => h.symm, fun {_ _ _} h₁ h₂ => h₁.trans h₂⟩ }
 
@@ -371,8 +377,9 @@ theorem boxAns_sepPOSWQ_sepProp : sepPOSWQ.boxAns sepProp := by
   rw [show w = v from hwv]
 
 /-- The separation proposition is *not* informationally necessary at
-    `sepPOSWQ.toPOSW`: `true` is in `cs` but does not satisfy `p`. -/
-theorem not_boxCs_sepPOSWQ_sepProp : ¬ sepPOSWQ.toPOSW.boxCs sepProp := by
+    `sepPOSWQ.toExpState`: `true` is in `info` but does not satisfy
+    `p`. -/
+theorem not_boxCs_sepPOSWQ_sepProp : ¬ sepPOSWQ.toExpState.boxCs sepProp := by
   intro h
   exact Bool.noConfusion (h true trivial)
 
@@ -381,7 +388,7 @@ theorem not_boxCs_sepPOSWQ_sepProp : ¬ sepPOSWQ.toPOSW.boxCs sepProp := by
     and `boxCs` fails. The inquiry component is doing genuine work. -/
 theorem boxAns_not_reducible_to_boxCs :
     ∃ (c : POSWQ Bool) (p : Bool → Prop),
-      c.boxAns p ∧ ¬ c.toPOSW.boxCs p :=
+      c.boxAns p ∧ ¬ c.toExpState.boxCs p :=
   ⟨sepPOSWQ, sepProp, boxAns_sepPOSWQ_sepProp, not_boxCs_sepPOSWQ_sepProp⟩
 
 end POSWQ

--- a/Linglib/Semantics/Mood/POSWTarget.lean
+++ b/Linglib/Semantics/Mood/POSWTarget.lean
@@ -16,9 +16,9 @@ typeclass `HasPOSWTarget`, instantiated here for `IllocutionaryMood`
 (sentence mood) and in `Semantics/Mood/VerbalMood.lean` for
 `VerbalMoodOp` (verbal mood). The companion *value-level*
 implementation lives in `Semantics/Mood/POSWQ.lean`: the `POSWQ`
-structure exposes `cs`, `le`, and `inquiry` as actual fields, and the
-updates `POSW.plus`/`POSW.star`/`POSWQ.inquire` do the work that this
-file's enum labels. The link between the two views is the projection
+structure exposes `info`, `order`, and `inquiry` as actual fields, and
+the updates `assert`/`promote`/`inquire` do the work that this file's
+enum labels. The link between the two views is the projection
 `POSWTarget.boxOn` below, which sends each label to the necessity
 modal quantifying over the labelled component.
 
@@ -102,15 +102,15 @@ variable {W : Type*}
 /-- The modal projection: each `POSWTarget` selects the necessity
     modal that quantifies over the labelled POSWQ component. -/
 def POSWTarget.boxOn : POSWTarget → POSWQ W → (W → Prop) → Prop
-  | .informational, c, p => c.toPOSW.boxCs p
-  | .preferential,  c, p => c.toPOSW.boxLe p
+  | .informational, c, p => c.toExpState.boxCs p
+  | .preferential,  c, p => c.toExpState.boxLe p
   | .partition,     c, p => c.boxAns p
 
 @[simp] theorem boxOn_informational (c : POSWQ W) (p : W → Prop) :
-    POSWTarget.informational.boxOn c p = c.toPOSW.boxCs p := rfl
+    POSWTarget.informational.boxOn c p = c.toExpState.boxCs p := rfl
 
 @[simp] theorem boxOn_preferential (c : POSWQ W) (p : W → Prop) :
-    POSWTarget.preferential.boxOn c p = c.toPOSW.boxLe p := rfl
+    POSWTarget.preferential.boxOn c p = c.toExpState.boxLe p := rfl
 
 @[simp] theorem boxOn_partition (c : POSWQ W) (p : W → Prop) :
     POSWTarget.partition.boxOn c p = c.boxAns p := rfl

--- a/Linglib/Semantics/Mood/VerbalMood.lean
+++ b/Linglib/Semantics/Mood/VerbalMood.lean
@@ -29,9 +29,9 @@ distinguishes indicative from subjunctive complementation:
 [portner-2018]'s unification of these two: *both intuitions are
 correct* because they target two different POSW components. The
 **information component** (`cs`) underwrites Truth-style universal
-quantification (`POSW.boxCs`); the **preference component** (`le`)
+quantification (`ExpState.boxCs`); the **preference component** (`order`)
 underwrites Comparison-style quantification over the best-ranked
-subset (`POSW.boxLe`).
+subset (`ExpState.boxLe`).
 
 We add a third operator `.interrogative` for question-embedding
 predicates (`wonder`, `ask`, `investigate`), which select for clauses
@@ -70,6 +70,8 @@ matrix predicate (`MoodSelector` for declarative-embedders;
 -/
 
 namespace Semantics.Mood
+
+open Semantics.Dynamic.Default
 
 variable {W : Type*}
 
@@ -122,8 +124,8 @@ instance : HasPOSWTarget VerbalMoodOp where
     modal of the operator's POSW target on the embedded proposition.
     Definitionally `boxOn ∘ target`, so the three cases consult
     disjoint POSWQ components:
-    `.indicative ↦ POSW.boxCs`,
-    `.subjunctive ↦ POSW.boxLe`,
+    `.indicative ↦ ExpState.boxCs`,
+    `.subjunctive ↦ ExpState.boxLe`,
     `.interrogative ↦ POSWQ.boxAns`. -/
 def VerbalMoodOp.interp (m : VerbalMoodOp) : POSWQ W → (W → Prop) → Prop :=
   (target m).boxOn
@@ -137,10 +139,10 @@ def VerbalMoodOp.interp (m : VerbalMoodOp) : POSWQ W → (W → Prop) → Prop :
 /-! ### Definitional equalities -/
 
 @[simp] theorem interp_indicative (c : POSWQ W) (p : W → Prop) :
-    VerbalMoodOp.indicative.interp c p = c.toPOSW.boxCs p := rfl
+    VerbalMoodOp.indicative.interp c p = c.toExpState.boxCs p := rfl
 
 @[simp] theorem interp_subjunctive (c : POSWQ W) (p : W → Prop) :
-    VerbalMoodOp.subjunctive.interp c p = c.toPOSW.boxLe p := rfl
+    VerbalMoodOp.subjunctive.interp c p = c.toExpState.boxLe p := rfl
 
 @[simp] theorem interp_interrogative (c : POSWQ W) (p : W → Prop) :
     VerbalMoodOp.interrogative.interp c p = c.boxAns p := rfl
@@ -162,12 +164,12 @@ which carry different lattice structures. -/
 theorem interp_indicative_mono (c : POSWQ W) (p q : W → Prop)
     (h : ∀ w, p w → q w) :
     VerbalMoodOp.indicative.interp c p → VerbalMoodOp.indicative.interp c q :=
-  POSW.boxCs_mono c.toPOSW p q h
+  c.toExpState.boxCs_mono p q h
 
 theorem interp_subjunctive_mono (c : POSWQ W) (p q : W → Prop)
     (h : ∀ w, p w → q w) :
     VerbalMoodOp.subjunctive.interp c p → VerbalMoodOp.subjunctive.interp c q :=
-  POSW.boxLe_mono c.toPOSW p q h
+  c.toExpState.boxLe_mono p q h
 
 /-! ### Distinctness witnesses
 
@@ -176,35 +178,29 @@ a disjoint POSWQ component. We exhibit concrete witnesses showing
 that no operator can be defined in terms of the others on the POSWQ
 substrate alone. -/
 
-/-- Separation POSW: `cs = ⊤` over `Bool`, with `le w v = (w = false →
-    v = false)`. Under this ordering `false` is the unique element
-    `w` such that every `v` satisfies `le v w`, so `false` is the
-    unique world picked out by `POSW.best`. -/
-def sepPOSW : POSW Bool where
-  cs := fun _ => True
-  le := fun w v => w = false → v = false
-  le_refl  := fun _ _ h => h
-  le_trans := fun _ _ _ _ _ _ hwu huv hw => huv (hwu hw)
+/-- Separation state: total information over `Bool`, ordered by the
+    criterion preorder for `POSWQ.sepProp` (the ordering that
+    `ExpState.promote` would install from the total order). Under it
+    `false` — the unique `sepProp`-world — is the unique best world. -/
+def sepState : ExpState Bool :=
+  ⟨Set.univ, Core.Order.Normality.crit POSWQ.sepProp⟩
 
-/-- Lift of `sepPOSW` to a POSWQ with trivial inquiry. Used to
+/-- Lift of `sepState` to a POSWQ with trivial inquiry. Used to
     distinguish indicative from subjunctive without engaging the
     inquiry component. -/
-def sepPOSWQ_triv : POSWQ Bool := POSWQ.ofPOSW sepPOSW
-
-/-- Separation proposition: only `false` satisfies it. -/
-def sepProp : Bool → Prop := fun w => w = false
+def sepPOSWQ_triv : POSWQ Bool := POSWQ.ofExpState sepState
 
 /-- The subjunctive operator accepts `(sepPOSWQ_triv, sepProp)`. -/
 theorem subjunctive_accepts_separation :
-    VerbalMoodOp.subjunctive.interp sepPOSWQ_triv sepProp := by
+    VerbalMoodOp.subjunctive.interp sepPOSWQ_triv POSWQ.sepProp := by
   intro w hbest
-  exact (hbest.2 false trivial) rfl
+  exact hbest.2 false (Set.mem_univ false) rfl
 
 /-- The indicative operator rejects `(sepPOSWQ_triv, sepProp)`. -/
 theorem indicative_rejects_separation :
-    ¬ VerbalMoodOp.indicative.interp sepPOSWQ_triv sepProp := by
+    ¬ VerbalMoodOp.indicative.interp sepPOSWQ_triv POSWQ.sepProp := by
   intro h
-  exact Bool.noConfusion (h true trivial)
+  exact Bool.noConfusion (h true (Set.mem_univ true))
 
 /-- **Indicative ≠ subjunctive**. The two mood operators are
     distinguishable: there exists a POSWQ and a proposition on which
@@ -214,7 +210,7 @@ theorem indicative_ne_subjunctive :
     ∃ (c : POSWQ Bool) (p : Bool → Prop),
       VerbalMoodOp.subjunctive.interp c p ∧
       ¬ VerbalMoodOp.indicative.interp c p :=
-  ⟨sepPOSWQ_triv, sepProp,
+  ⟨sepPOSWQ_triv, POSWQ.sepProp,
     subjunctive_accepts_separation, indicative_rejects_separation⟩
 
 /-- **Interrogative ≠ indicative**. Reuses the witness from

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -505,8 +505,8 @@ robustly subjunctive predicates, the projection lands in
 `some .subjunctive`; for cross-linguistically variable predicates,
 in `none`. The chain `verb → MoodSelector → VerbalMoodOp` makes
 the lexical-class commitment of [grano-2024] operationally
-ready to feed POSWQ-side glosses (`POSW.boxLe` for subjunctive,
-`POSW.boxCs` for indicative). -/
+ready to feed POSWQ-side glosses (`ExpState.boxLe` for subjunctive,
+`ExpState.boxCs` for indicative). -/
 
 /-- 'want' lifts to the subjunctive POSWQ operator. -/
 theorem want_verbalMood :
@@ -520,7 +520,7 @@ theorem hope_verbalMood :
 
 /-- The robust subjunctive predicates (e.g. 'want') project to the
     `preferential` POSW component — they quantify over the best-ranked
-    subset of the POSWQ via `POSW.boxLe`. The composed projection
+    subset of the POSWQ via `ExpState.boxLe`. The composed projection
     (`MoodSelector → VerbalMoodOp → POSWTarget`) makes the operational
     target explicit. -/
 theorem want_target :

--- a/Linglib/Studies/Kirkpatrick2024.lean
+++ b/Linglib/Studies/Kirkpatrick2024.lean
@@ -321,10 +321,10 @@ arises: the subset relation between restrictors (albino raven ⊆ raven)
 creates asymmetric blocking in horizon evolution. The abstract
 impossibility theorem (`commutative_implies_equal_verdicts` in
 `Genericity/Basic.lean`) then rules out ANY commutative framework — including
-[veltman-1996]'s `normallyUpdate` — from modeling this asymmetry.
+[veltman-1996]'s `ExpState.promote` — from modeling this asymmetry.
 
-[veltman-1996]'s `normallyUpdate` is commutative
-(`normallyUpdate_comm` in `UpdateSemantics/Default.lean`), meaning that
+[veltman-1996]'s `ExpState.promote` is commutative
+(`promote_comm` in `UpdateSemantics/Default.lean`), meaning that
 processing "normally (ravens are black)" then "normally (albino ravens
 aren't black)" produces the same expectation state as the reverse order.
 Since the state is identical, any consistency test must give the same

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -55,8 +55,8 @@ standalone formalization of an imperative mood ontology:
   the prejacent's modal flavor.
 - The scoreboard updates are `Discourse.Scoreboard`'s
   assertion/interrogation/direction; the *derivation* that
-  `directionUpdate` factors as `POSW.star` lives in Scoreboard.lean
-  (`toPOSW_direction_eq_star`).
+  `directionUpdate` factors as `ExpState.promote` lives in the
+  Scoreboard section (`toExpState_direction_eq_promote`).
 
 ## Equation citations
 
@@ -324,8 +324,10 @@ def directionUpdate (K : Scoreboard W) (p : W → Prop)
 /-! ### POSW substrate bridge
 
 The scoreboard's CommonGround and G components project jointly into a
-`Semantics.Mood.POSW`: CommonGround via `contextSet`, G via the goal-induced
-preference ordering. Assertion ↔ `plus`, direction ↔ `star`. -/
+the POSW substrate (`Semantics.Dynamic.Default.ExpState` under its
+`Semantics/Mood/POSW.lean` modal reading): CommonGround via
+`contextSet`, G via the goal-induced preference ordering. Assertion ↔
+`assert`, direction ↔ `promote`. -/
 
 /-- Flat list of goal contents across all agents. -/
 def goalContents (K : Scoreboard W) : List (W → Prop) :=
@@ -375,42 +377,47 @@ lemma mem_directionUpdate_goalContents (K : Scoreboard W) (p : W → Prop)
   exact mem_addGoalAt_flatMap K.goals t 0 ⟨p, fun _ => True, pr⟩
     (Nat.zero_le _) (by simpa using hin) q
 
-/-- Project the scoreboard into a POSW: `cs` from CommonGround, `le` from
-    goal-induced preference. -/
-def toPOSW (K : Scoreboard W) : Semantics.Mood.POSW W where
-  cs := K.contextSet
-  le := fun w v => ∀ p ∈ K.goalContents, p v → p w
-  le_refl  := fun _ _ _ _ hp => hp
-  le_trans := fun _ _ _ _ _ _ hwu huv p hp hpv => hwu p hp (huv p hp hpv)
+/-- Project the scoreboard into a POSW-style expectation state: `info`
+    from CommonGround, `order` from goal-induced preference. -/
+def toExpState (K : Scoreboard W) : Semantics.Dynamic.Default.ExpState W where
+  info := K.contextSet
+  order := Preorder.ofLE (fun w v => ∀ p ∈ K.goalContents, p v → p w)
+    (fun _ _ _ hp => hp)
+    (fun _ _ _ hwu huv p hp hpv => hwu p hp (huv p hp hpv))
 
-@[simp] theorem toPOSW_cs (K : Scoreboard W) :
-    K.toPOSW.cs = K.contextSet := rfl
+@[simp] theorem toExpState_info (K : Scoreboard W) :
+    K.toExpState.info = K.contextSet := rfl
 
-@[simp] theorem toPOSW_le (K : Scoreboard W) (w v : W) :
-    K.toPOSW.le w v ↔ ∀ p ∈ K.goalContents, p v → p w := Iff.rfl
+@[simp] theorem toExpState_le (K : Scoreboard W) (w v : W) :
+    K.toExpState.order.le w v ↔ ∀ p ∈ K.goalContents, p v → p w := Iff.rfl
 
 /-- Assertion-as-`+`-update bridge: `assertionUpdate` refines the
-    projected POSW's `cs` exactly as `POSW.plus` does. -/
-theorem toPOSW_assertion_eq_plus (K : Scoreboard W) (p : W → Prop) (a : Nat) (w : W) :
-    (K.assertionUpdate p a).toPOSW.cs w ↔ (K.toPOSW.plus p).cs w := by
-  simp [toPOSW, contextSet, assertionUpdate, Semantics.Mood.POSW.plus]
+    projected state's `info` exactly as `ExpState.assert` does. -/
+theorem toExpState_assertion_eq_assert (K : Scoreboard W) (p : W → Prop) (a : Nat) (w : W) :
+    w ∈ (K.assertionUpdate p a).toExpState.info ↔
+      w ∈ (K.toExpState.assert p).info := by
+  show (∀ q ∈ p :: K.cg, q w) ↔ (∀ q ∈ K.cg, q w) ∧ p w
+  rw [List.forall_mem_cons]
   exact And.comm
 
 /-- After asserting `p`, `p` is informationally necessary on the
-    projected POSW (Stalnakerian assertion principle). -/
+    projected state (Stalnakerian assertion principle). -/
 theorem boxCs_after_assertion (K : Scoreboard W) (p : W → Prop) (a : Nat) :
-    (K.assertionUpdate p a).toPOSW.boxCs p := by
+    (K.assertionUpdate p a).toExpState.boxCs p := by
   intro w hw
-  have hplus : (K.toPOSW.plus p).cs w := (toPOSW_assertion_eq_plus K p a w).mp hw
-  exact Semantics.Mood.POSW.boxCs_plus_self K.toPOSW p w hplus
+  have hassert : w ∈ (K.toExpState.assert p).info :=
+    (toExpState_assertion_eq_assert K p a w).mp hw
+  exact K.toExpState.boxCs_assert_self p w hassert
 
 /-- Direction-as-`⋆`-update bridge: `directionUpdate` refines the
-    projected POSW's `le` exactly as `POSW.star` does
+    projected state's `order` exactly as `ExpState.promote` does
     (modulo target-in-bounds). -/
-theorem toPOSW_direction_eq_star (K : Scoreboard W) (p : W → Prop)
+theorem toExpState_direction_eq_promote (K : Scoreboard W) (p : W → Prop)
     (s t pr : Nat) (hin : t < K.goals.length) (w v : W) :
-    (K.directionUpdate p s t pr).toPOSW.le w v ↔ (K.toPOSW.star p).le w v := by
-  simp only [toPOSW_le, Semantics.Mood.POSW.star_le]
+    (K.directionUpdate p s t pr).toExpState.order.le w v ↔
+      (K.toExpState.promote p).order.le w v := by
+  simp only [toExpState_le, Semantics.Dynamic.Default.ExpState.promote_order,
+    Core.Order.Normality.refine_le, toExpState_le]
   constructor
   · intro h
     refine ⟨fun q hq => h q ?_, h p ?_⟩
@@ -425,11 +432,11 @@ theorem toPOSW_direction_eq_star (K : Scoreboard W) (p : W → Prop)
 theorem direction_demotes_violators (K : Scoreboard W) (p : W → Prop)
     (s t pr : Nat) (hin : t < K.goals.length) (w v : W)
     (hpv : p v) (hpw : ¬ p w) :
-    ¬ (K.directionUpdate p s t pr).toPOSW.le w v := by
+    ¬ (K.directionUpdate p s t pr).toExpState.order.le w v := by
   intro hlt
-  have hstar : (K.toPOSW.star p).le w v :=
-    (toPOSW_direction_eq_star K p s t pr hin w v).mp hlt
-  exact hpw (hstar.2 hpv)
+  have hstar : (K.toExpState.promote p).order.le w v :=
+    (toExpState_direction_eq_promote K p s t pr hin w v).mp hlt
+  exact hpw ((Core.Order.Normality.refine_le.mp hstar).2 hpv)
 
 /-! ### POSWQ inquiry-partition bridge
 
@@ -458,12 +465,12 @@ def qudInquiry (K : Scoreboard W) : Setoid W :=
     (q : W → Prop) (a : Nat) :
     (K.interrogationUpdate q a).goalContents = K.goalContents := rfl
 
-/-- Project the scoreboard into a POSWQ: underlying POSW + QUD inquiry. -/
+/-- Project the scoreboard into a POSWQ: underlying state + QUD inquiry. -/
 def toPOSWQ (K : Scoreboard W) : Semantics.Mood.POSWQ W :=
-  { K.toPOSW with inquiry := K.qudInquiry }
+  { K.toExpState with inquiry := K.qudInquiry }
 
-@[simp] theorem toPOSWQ_toPOSW (K : Scoreboard W) :
-    K.toPOSWQ.toPOSW = K.toPOSW := rfl
+@[simp] theorem toPOSWQ_toExpState (K : Scoreboard W) :
+    K.toPOSWQ.toExpState = K.toExpState := rfl
 
 @[simp] theorem toPOSWQ_inquiry (K : Scoreboard W) :
     K.toPOSWQ.inquiry = K.qudInquiry := rfl
@@ -492,7 +499,8 @@ namespace Roberts2023
 open Intensional (WorldTimeIndex)
 open Discourse (forceLinkingPrinciple defaultSemanticType Scoreboard)
 open Semantics.Mood.IllocutionaryMood (sincerityCondition)
-open Semantics.Mood (POSW POSWQ POSWTarget IllocutionaryMood HasPOSWTarget)
+open Semantics.Mood (POSWQ POSWTarget IllocutionaryMood HasPOSWTarget)
+open Semantics.Dynamic.Default (ExpState)
 open HistoricalAlternatives
 open Semantics.Modality.Kratzer
 
@@ -568,8 +576,8 @@ restipulated) here. -/
     This is the type-level shadow of "deontic force is pragmatic,
     not LF": deontic-style content lives where the preference
     component does, and the imperative refines that component
-    (via `POSW.star` / `Scoreboard.directionUpdate`) rather than
-    the informational one. -/
+    (via `ExpState.promote` / `Scoreboard.directionUpdate`) rather
+    than the informational one. -/
 theorem imperative_targets_preferential :
     HasPOSWTarget.target IllocutionaryMood.imperative = .preferential := rfl
 
@@ -579,7 +587,7 @@ theorem imperative_targets_preferential :
     the **preferential** component of the projected POSW: every
     prejacent-violator `w` (`¬ p w`) is demoted relative to every
     prejacent-satisfier `v` (`p v`) in the preference order
-    (`¬ (· ).toPOSW.le w v`).
+    (`¬ (· ).toExpState.order.le w v`).
 
     The dual negative claim — that the **informational** component
     (CommonGround) is untouched — is `Scoreboard.direction_preserves_cg` (a
@@ -598,7 +606,7 @@ theorem imperative_targets_preferential :
 theorem pragmatic_deontic_routing
     {W : Type*} (K : Scoreboard W) (p : W → Prop) (s t pr : Nat)
     (hin : t < K.goals.length) {w v : W} (hpv : p v) (hpw : ¬ p w) :
-    ¬ (K.directionUpdate p s t pr).toPOSW.le w v :=
+    ¬ (K.directionUpdate p s t pr).toExpState.order.le w v :=
   Scoreboard.direction_demotes_violators K p s t pr hin w v hpv hpw
 
 /-! ## §1 Desideratum (h): Futurate Flavor
@@ -680,7 +688,7 @@ theorem disagrees_with_ruytenbeek_imperative_flavor :
     theorem (deleted after Ruytenbeek's `directiveCompatible` wrapper
     was inlined): under Roberts, an imperative is directive *despite*
     not having deontic flavor in its prejacent — the directive force
-    comes from the `POSW.star` update on the addressee's preference
+    comes from the `ExpState.promote` update on the addressee's preference
     structure (see `pragmatic_deontic_routing`), not from the
     prejacent's flavor matching the imperative's. -/
 theorem disagrees_with_assert :

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -87,7 +87,7 @@ section Examples310
 /-- After "normally p", learning ¬p doesn't crash — the info state
     still has ¬p-worlds. Rules can have exceptions. -/
 theorem ex310_i_exception :
-    (assertUpdate (fun w => ¬atomP w) (normallyUpdate atomP σ₀)).info.Nonempty :=
+    ((σ₀.promote atomP).assert (fun w => ¬atomP w)).info.Nonempty :=
   ⟨w₀, ⟨Set.mem_univ _, atomP_w₀⟩⟩
 
 /-- After "normally p", the globally optimal worlds are exactly the
@@ -95,11 +95,11 @@ theorem ex310_i_exception :
     satisfies ¬p. This is [veltman-1996]'s coherence check
     (Definition 3.9). -/
 theorem ex310_i_conflict :
-    ¬∃ w ∈ Normality.optimal (normallyUpdate atomP σ₀).order Set.univ, ¬atomP w := by
+    ¬∃ w ∈ Normality.optimal (σ₀.promote atomP).order Set.univ, ¬atomP w := by
   intro ⟨w, hw_opt, hnp⟩
   have hex : ∃ v ∈ (Set.univ : Set PQWorld), atomP v :=
     ⟨w₁, Set.mem_univ _, atomP_w₁⟩
-  simp only [normallyUpdate, σ₀, ExpState.init] at hw_opt
+  simp only [ExpState.promote, σ₀, ExpState.init] at hw_opt
   rw [Normality.refine_total_optimal atomP Set.univ hex] at hw_opt
   exact hnp hw_opt.2
 
@@ -111,11 +111,11 @@ theorem ex310_i_conflict :
 
     [veltman-1996], Examples 3.10(ii): normally p, ¬p ⊬ presumably p. -/
 theorem ex310_ii_defeat :
-    ¬∀ w ∈ (assertUpdate (fun w => ¬atomP w) (normallyUpdate atomP σ₀)).optimal,
+    ¬∀ w ∈ ((σ₀.promote atomP).assert (fun w => ¬atomP w)).optimal,
       atomP w := by
   intro h
   apply h w₀
-  simp only [ExpState.optimal, assertUpdate, normallyUpdate, σ₀, ExpState.init,
+  simp only [ExpState.optimal, ExpState.assert, ExpState.promote, σ₀, ExpState.init,
     Normality.optimal]
   refine ⟨⟨Set.mem_univ _, atomP_w₀⟩, fun v ⟨_, hnpv⟩ _ => ?_⟩
   exact ⟨True.intro, fun hpv => absurd hpv hnpv⟩
@@ -124,8 +124,8 @@ theorem ex310_ii_defeat :
 
     [veltman-1996], Examples 3.10(ii): normally p, ¬p ⊩ normally p. -/
 theorem ex310_ii_rule_persists :
-    Normality.respects (assertUpdate (fun w => ¬atomP w) (normallyUpdate atomP σ₀)).order atomP :=
-  persistence_assert (normallyUpdate atomP σ₀) atomP _ (normally_creates_respect σ₀ atomP)
+    Normality.respects ((σ₀.promote atomP).assert (fun w => ¬atomP w)).order atomP :=
+  persistence_assert (σ₀.promote atomP) atomP _ (normally_creates_respect σ₀ atomP)
 
 -- ─── Example 3.10(iii): Irrelevant information ───
 
@@ -134,9 +134,9 @@ theorem ex310_ii_rule_persists :
 
     [veltman-1996], Examples 3.10(iii): normally p, q ⊩ presumably p. -/
 theorem ex310_iii_irrelevant :
-    ∀ w ∈ (assertUpdate atomQ (normallyUpdate atomP σ₀)).optimal, atomP w := by
+    ∀ w ∈ ((σ₀.promote atomP).assert atomQ).optimal, atomP w := by
   intro w ⟨⟨_, hqw⟩, hopt⟩
-  simp only [normallyUpdate, σ₀, ExpState.init] at hopt
+  simp only [ExpState.promote, σ₀, ExpState.init] at hopt
   by_contra hnpw
   have hle : (Normality.refine Normality.total atomP).le w₃ w :=
     ⟨True.intro, fun _ => atomP_w₃⟩
@@ -151,11 +151,10 @@ theorem ex310_iii_irrelevant :
     [veltman-1996], Examples 3.10(iv):
     normally p, normally q, ¬p ⊩ presumably q. -/
 theorem ex310_iv_independence :
-    ∀ w ∈ (assertUpdate (fun w => ¬atomP w)
-            (normallyUpdate atomQ (normallyUpdate atomP σ₀))).optimal,
+    ∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (fun w => ¬atomP w)).optimal,
       atomQ w := by
   intro w ⟨⟨_, hnpw⟩, hopt⟩
-  simp only [normallyUpdate, σ₀, ExpState.init] at hopt
+  simp only [ExpState.promote, σ₀, ExpState.init] at hopt
   by_contra hnqw
   -- w₂ (¬p, q) dominates any ¬p ∧ ¬q world
   have hle : (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₂ w :=
@@ -172,12 +171,11 @@ theorem ex310_iv_independence :
     [veltman-1996], Examples 3.10(v):
     normally p, normally q, ¬(p ∧ q) ⊬ presumably p. -/
 theorem ex310_v_ambiguity_p :
-    ¬∀ w ∈ (assertUpdate (fun w => ¬(atomP w ∧ atomQ w))
-             (normallyUpdate atomQ (normallyUpdate atomP σ₀))).optimal,
+    ¬∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (fun w => ¬(atomP w ∧ atomQ w))).optimal,
       atomP w := by
   intro h
   apply h w₂
-  simp only [ExpState.optimal, assertUpdate, normallyUpdate, σ₀, ExpState.init,
+  simp only [ExpState.optimal, ExpState.assert, ExpState.promote, σ₀, ExpState.init,
     Normality.optimal]
   refine ⟨⟨Set.mem_univ _, fun ⟨hp, _⟩ => atomP_w₂ hp⟩, fun v ⟨_, hnpq⟩ hle => ?_⟩
   -- hle gives atomQ v (via the atomQ-refinement component evaluated at w₂)
@@ -191,12 +189,11 @@ theorem ex310_v_ambiguity_p :
     [veltman-1996], Examples 3.10(v):
     normally p, normally q, ¬(p ∧ q) ⊬ presumably q. -/
 theorem ex310_v_ambiguity_q :
-    ¬∀ w ∈ (assertUpdate (fun w => ¬(atomP w ∧ atomQ w))
-             (normallyUpdate atomQ (normallyUpdate atomP σ₀))).optimal,
+    ¬∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (fun w => ¬(atomP w ∧ atomQ w))).optimal,
       atomQ w := by
   intro h
   apply h w₁
-  simp only [ExpState.optimal, assertUpdate, normallyUpdate, σ₀, ExpState.init,
+  simp only [ExpState.optimal, ExpState.assert, ExpState.promote, σ₀, ExpState.init,
     Normality.optimal]
   refine ⟨⟨Set.mem_univ _, fun ⟨_, hq⟩ => atomQ_w₁ hq⟩, fun v ⟨_, hnpq⟩ hle => ?_⟩
   -- hle gives atomP v (via the atomP-refinement component evaluated at w₁)


### PR DESCRIPTION
Deduplicates the mood-state substrate: Portner's POSW and Veltman's `ExpState` were the same two-coordinate state (identical ordering-refinement formulas) formalized in disconnected corners; the Mood layer now consumes `ExpState` and contributes only its modal reading (`boxCs`/`boxLe`/`best`, `NormalModality`, POSWQ's inquiry coordinate).

- Updates land as `ExpState.assert`/`ExpState.promote` with a refinement preorder and Veltman acceptance fixpoints (`le_assert_iff`, `le_promote_iff`); support/necessity results per coordinate (`le_assert_iff_boxCs`, `boxLe_of_respects` = *normally φ ⊩ presumably φ*, `le_inquire_iff` + polar-Setoid bridge).
- Fixes a latent orientation bug: `POSW.best` quantified over top-dominated worlds, mis-composing with `⋆`-promotion (its own docstring and Veltman's Def 3.3 have the bottom-dominant form); witnesses rebuilt accordingly.
- Roberts2023's scoreboard projects to `ExpState`; Veltman1996/Grano2024/Kirkpatrick2024 migrated.