### PR TITLE
refactor(Semantics/Mood): de-acronym and de-stutter the Mood API

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1760,12 +1760,12 @@ import Linglib.Semantics.Mood.Categories
 import Linglib.Semantics.Mood.ClauseType
 import Linglib.Semantics.Mood.Dynamic
 import Linglib.Semantics.Mood.Gutzmann
-import Linglib.Semantics.Mood.IllocutionaryMood
-import Linglib.Semantics.Mood.POSW
-import Linglib.Semantics.Mood.POSWQ
-import Linglib.Semantics.Mood.POSWTarget
+import Linglib.Semantics.Mood.Component
+import Linglib.Semantics.Mood.Illocutionary
+import Linglib.Semantics.Mood.Modal
 import Linglib.Semantics.Mood.PartitionAsInquiry
-import Linglib.Semantics.Mood.VerbalMood
+import Linglib.Semantics.Mood.State
+import Linglib.Semantics.Mood.Verbal
 import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Negation.CzechNegation
 import Linglib.Semantics.Negation.Defs

--- a/Linglib/Discourse/Commitment/Space.lean
+++ b/Linglib/Discourse/Commitment/Space.lean
@@ -77,7 +77,7 @@ open Discourse.Commitment
    HasSupport CommitmentGrade)
 open Discourse (DiscourseRole)
 open CommonGround (ContextSet)
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Commitment Space: Tree Structure ([krifka-2015], eq. (2), p. 329)
@@ -637,7 +637,7 @@ structure SpeechAct (W : Type*) where
   /-- Propositional content (TP layer) -/
   content : W → Prop
   /-- Speech act type: assertion (.) or question (?) -/
-  actType : IllocutionaryMood := .declarative
+  actType : Illocutionary := .declarative
   /-- Actor/committer assignment -/
   roles : ActorCommitter := assertionRoles
 

--- a/Linglib/Discourse/Commitment/Table.lean
+++ b/Linglib/Discourse/Commitment/Table.lean
@@ -1,6 +1,6 @@
 import Linglib.Discourse.Commitment.Basic
 import Linglib.Discourse.CommonGround
-import Linglib.Semantics.Mood.IllocutionaryMood
+import Linglib.Semantics.Mood.Illocutionary
 
 /-!
 # The Table Model
@@ -27,7 +27,7 @@ namespace Discourse.Commitment.Table
 
 open Discourse.Commitment (TaggedSlate CommitmentSource CommitmentForce)
 open CommonGround (HasContextSet)
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 /-- An at-issue item on the conversational table. -/
 structure Item (A W : Type*) where
@@ -36,7 +36,7 @@ structure Item (A W : Type*) where
   /-- Addressee. -/
   addressee : A
   /-- Illocutionary force. -/
-  mood : IllocutionaryMood
+  mood : Illocutionary
   /-- Alternatives at issue: `[p]` for assertion, `[p, ¬p]` for
       polar question, the answer set for wh-questions. -/
   alternatives : List (W → Prop)

--- a/Linglib/Discourse/Roles.lean
+++ b/Linglib/Discourse/Roles.lean
@@ -8,9 +8,9 @@ the function that resolves them through a `ContextTower` to concrete
 entities.
 
 This file exists separately from `Discourse/SpeechAct.lean`
-to break a would-be cycle between `Semantics/Mood/IllocutionaryMood.lean` (which
-needs `DiscourseRole` for `moodAuthority`) and the act-side material in
-`SpeechAct.lean` (which extends `IllocutionaryMood` with Searle
+to break a would-be cycle between `Semantics/Mood/Illocutionary.lean` (which
+needs `DiscourseRole` for `Illocutionary.authority`) and the act-side material in
+`SpeechAct.lean` (which extends `Illocutionary` with Searle
 classes and direction of fit).
 -/
 

--- a/Linglib/Discourse/SpeechAct.lean
+++ b/Linglib/Discourse/SpeechAct.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Mood.IllocutionaryMood
+import Linglib.Semantics.Mood.Illocutionary
 
 /-!
 # Searlean Speech Acts: F(p) and S(r)
@@ -14,13 +14,13 @@ conditions for directives, in the inventory of [francik-clark-1985].
 * `DirectionOfFit` — how responsibility for matching state and world is distributed.
 * `SearleClass` — [searle-1979]'s five illocutionary classes.
 * `PsychMode` — the psychological modes (the `S` in `S(r)`).
-* `IllocutionaryMood.searleClass`, `IllocutionaryMood.sincerityCondition` — the
+* `Illocutionary.searleClass`, `Illocutionary.sincerityCondition` — the
   per-mood illocutionary class and the `F → S` bridge.
 * `CausalSelfRef`, `PsychMode.causalSelfRef` — whether a mode must figure in the
   causal chain producing its own conditions of satisfaction.
 * `PreparatoryCondition` — felicity preconditions for directives, ordered by the
   `subsumes` specificity relation.
-* `IllocutionaryMood.sincerityCondition_directionOfFit` — the sincerity
+* `Illocutionary.sincerityCondition_directionOfFit` — the sincerity
   condition's direction of fit matches the speech act's.
 * `PsychMode.causalSelfRef_not_determined_by_directionOfFit` — causal
   self-referentiality is not a function of direction of fit.
@@ -32,7 +32,7 @@ sincerity states (gratitude, pleasure, regret, ...) into a single mode; its null
 direction of fit is [searle-1979]'s claim about the expressive class.
 Commitment-based accounts (`CommitmentForce.doxastic` "act-as-if-believe", per
 [condoravdi-lauer-2012] and [lauer-2013]; Brandom's commitment-without-entitlement)
-deliberately weaken `IllocutionaryMood.sincerityCondition .declarative = .belief`
+deliberately weaken `Illocutionary.sincerityCondition .declarative = .belief`
 from sincere belief to public commitment.
 
 ## References
@@ -40,7 +40,7 @@ from sincere belief to public commitment.
 * [searle-1969], [searle-1979], [searle-1983], [francik-clark-1985]
 -/
 
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 /-! ### Direction of fit -/
 
@@ -109,10 +109,10 @@ def PsychMode.directionOfFit : PsychMode → DirectionOfFit
 
 /-! ### Mood bridges — class and sincerity condition -/
 
-namespace Semantics.Mood.IllocutionaryMood
+namespace Semantics.Mood.Illocutionary
 
 /-- The [searle-1979] illocutionary class of each mood. -/
-def searleClass : IllocutionaryMood → SearleClass
+def searleClass : Illocutionary → SearleClass
   | .declarative   => .assertive
   | .interrogative => .directive
   | .imperative    => .directive
@@ -120,12 +120,12 @@ def searleClass : IllocutionaryMood → SearleClass
   | .exclamative   => .expressive
 
 /-- Direction of fit for an illocutionary mood, derived via Searle class. -/
-def directionOfFit (m : IllocutionaryMood) : DirectionOfFit :=
+def directionOfFit (m : Illocutionary) : DirectionOfFit :=
   m.searleClass.directionOfFit
 
 /-- Sincerity condition ([searle-1969]): performing a speech act with mood `F`
 expresses the corresponding Intentional state `S`. -/
-def sincerityCondition : IllocutionaryMood → PsychMode
+def sincerityCondition : Illocutionary → PsychMode
   | .declarative   => .belief      -- asserting `p` expresses `Bel(p)`
   | .interrogative => .desire      -- asking expresses `Des(addressee answers)`
   | .imperative    => .desire      -- ordering expresses `Des(hearer does A)`
@@ -134,11 +134,11 @@ def sincerityCondition : IllocutionaryMood → PsychMode
 
 /-- The sincerity condition's direction of fit matches the speech act's:
 [searle-1983]'s central `F(p)` / `S(r)` parallel. -/
-theorem sincerityCondition_directionOfFit (m : IllocutionaryMood) :
+theorem sincerityCondition_directionOfFit (m : Illocutionary) :
     m.sincerityCondition.directionOfFit = m.directionOfFit := by
   cases m <;> rfl
 
-end Semantics.Mood.IllocutionaryMood
+end Semantics.Mood.Illocutionary
 
 /-! ### Causal self-referentiality -/
 

--- a/Linglib/Fragments/French/Modals.lean
+++ b/Linglib/Fragments/French/Modals.lean
@@ -42,7 +42,7 @@ namespace French.Modals
 
 open Semantics.Modality (ModalForce ModalFlavor ForceFlavor)
 open Semantics.Modality.Assert (primaryFlavor)
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Pragmatics/Bias.lean
+++ b/Linglib/Pragmatics/Bias.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Negation.Expletive
-import Linglib.Semantics.Mood.IllocutionaryMood
+import Linglib.Semantics.Mood.Illocutionary
 
 /-!
 # Bias-Conditioned Negation: A Shared Licensing Predicate
@@ -75,7 +75,7 @@ commitment-update ([farkas-bruce-2010]) reanalyses.
 namespace Pragmatics.Bias
 
 open Semantics.Negation (PolarityLicensing weakENProfile)
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
 -- § 1. The four licensing conditions
@@ -83,7 +83,7 @@ open Semantics.Mood (IllocutionaryMood)
 
 /-- Bias-licensing profile: one bit per [napoli-nespor-1976] §2
     condition (with the assertive-force axis recorded as a full
-    `IllocutionaryMood`). The licensing predicate `licenses` is the
+    `Illocutionary`). The licensing predicate `licenses` is the
     conjunction of the four axes; see §2. -/
 structure BiasLicensingProfile where
   /-- Speaker presupposes the assertion contradicts a prior belief.
@@ -92,7 +92,7 @@ structure BiasLicensingProfile where
   /-- Illocutionary force of the move. The licensing predicate fires
       only on `.declarative`; `isAssertive` is the projection.
       [napoli-nespor-1976] §2.1 ex. 10b, 12b. -/
-  illocutionaryMood : IllocutionaryMood
+  illocutionaryMood : Illocutionary
   /-- The matrix predicate is not negated.
       [napoli-nespor-1976] §2.2 ex. 18. -/
   matrixUnnegated : Bool

--- a/Linglib/Semantics/Attitudes/Representationality.lean
+++ b/Linglib/Semantics/Attitudes/Representationality.lean
@@ -166,7 +166,7 @@ This captures the strong (but imperfect) correlation between mood
 selection and representationality across Romance. The correlation
 is imperfect because subjunctive tracks preferences, not
 representationality directly ([anand-hacquard-2013], §6). -/
-def fromMoodSelector : MoodSelector → Representationality
+def fromSelector : Selector → Representationality
   | .indicativeSelecting         => .representational
   | .subjunctiveSelecting        => .nonRepresentational
   | .crossLinguisticallyVariable => .hybrid
@@ -175,17 +175,17 @@ def fromMoodSelector : MoodSelector → Representationality
 /-- Indicative-selecting attitudes are representational:
     they provide an information state and license epistemics. -/
 theorem indicative_representational :
-    fromMoodSelector .indicativeSelecting = .representational := rfl
+    fromSelector .indicativeSelecting = .representational := rfl
 
 /-- Subjunctive-selecting attitudes are non-representational:
     they use comparative semantics and block epistemics. -/
 theorem subjunctive_nonRepresentational :
-    fromMoodSelector .subjunctiveSelecting = .nonRepresentational := rfl
+    fromSelector .subjunctiveSelecting = .nonRepresentational := rfl
 
 /-- Cross-linguistically variable attitudes are hybrid:
     they have both representational and preference components. -/
 theorem variable_hybrid :
-    fromMoodSelector .crossLinguisticallyVariable = .hybrid := rfl
+    fromSelector .crossLinguisticallyVariable = .hybrid := rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5. Attitude Verb Classification

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -59,7 +59,7 @@ equivalence within an appropriate context (the
 namespace Semantics.Conditionals
 
 open CommonGround (ContextSet)
-open Semantics.Mood (GramMood)
+open Semantics.Mood (Grammatical)
 open _root_.Semantics.Conditionals (SelectionFunction selectionPrefers)
 open Core.Order (SimilarityOrdering)
 
@@ -116,12 +116,12 @@ is captured by which selection functions are admissible (see
 
 Single source of truth: indicative and subjunctive conditionals do not
 have distinct semantic clauses. -/
-def moodedConditional {W : Type*} (_m : GramMood) (s : SelectionFunction W)
+def moodedConditional {W : Type*} (_m : Grammatical) (s : SelectionFunction W)
     (p q : W → Prop) : W → Prop :=
   selectionConditional s p q
 
 /-- `moodedConditional` is decidable when its consequent is. -/
-instance moodedConditional_decidable {W : Type*} (m : GramMood)
+instance moodedConditional_decidable {W : Type*} (m : Grammatical)
     (s : SelectionFunction W) (p q : W → Prop) [DecidablePred q] (w : W) :
     Decidable (moodedConditional m s p q w) :=
   inferInstanceAs (Decidable (selectionConditional s p q w))
@@ -141,7 +141,7 @@ clause:
 This makes "indicative vs subjunctive" a property of the
 *selection-function / context pairing*, not a separate semantic
 operator. -/
-def Mood.admissibleSelection {W : Type*} (m : GramMood) (s : SelectionFunction W)
+def Mood.admissibleSelection {W : Type*} (m : Grammatical) (s : SelectionFunction W)
     (C : ContextSet W) : Prop :=
   match m with
   | .indicative  => pragmaticConstraint s C
@@ -160,7 +160,7 @@ theorem admissibleSelection_subjunctive {W : Type*} (s : SelectionFunction W)
 /-- **Mood is irrelevant to the truth-conditional clause**
 ([stalnaker-1975]). For any grammatical mood, the mooded
 conditional reduces to the bare selection conditional. -/
-theorem moodedConditional_eq_selectionConditional {W : Type*} (m : GramMood)
+theorem moodedConditional_eq_selectionConditional {W : Type*} (m : Grammatical)
     (s : SelectionFunction W) (p q : W → Prop) :
     moodedConditional m s p q = selectionConditional s p q := rfl
 

--- a/Linglib/Semantics/Modality/Assert.lean
+++ b/Linglib/Semantics/Modality/Assert.lean
@@ -38,7 +38,7 @@ namespace Semantics.Modality.Assert
 
 open Semantics.Modality.EventRelativity
 open Semantics.Modality (ModalFlavor)
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 
 -- ════════════════════════════════════════════════════
@@ -50,10 +50,10 @@ open Semantics.Mood (IllocutionaryMood)
 [hacquard-2006]: "The content of the speech event
 is different depending on the type of speech act."
 
-Now unified with `IllocutionaryMood` from `Discourse`. The five
+Now unified with `Illocutionary` from `Discourse`. The five
 constructors — declarative, interrogative, imperative, promissive,
 exclamative — classify the pragmatic act performed. -/
-abbrev SpeechActType := IllocutionaryMood
+abbrev SpeechActType := Illocutionary
 
 /-- All speech acts are contentful events. This is definitional:
 a speech act IS the performance of propositional content.
@@ -343,7 +343,7 @@ speech act (always the speaker in Hacquard's framework). This is distinct
 from the SEAT OF KNOWLEDGE, which is the hearer for
 interrogatives — that notion captures who has epistemic authority over
 the content, not who initiates the speech event. That notion is tracked per-mood by
-`Semantics.Mood.moodAuthority`. -/
+`Semantics.Mood.Illocutionary.authority`. -/
 def speechActProjection : EventProjection SpeechActType Interlocutor SpeechTime where
   holder
     | .declarative => .speaker

--- a/Linglib/Semantics/Mood/Basic.lean
+++ b/Linglib/Semantics/Mood/Basic.lean
@@ -188,7 +188,7 @@ Certain predicates select for specific moods in their complement:
 - "hope" → cross-linguistically variable ([grano-2024], Table 1)
 - "say", "think" → mood-neutral (pragmatically flexible)
 -/
-inductive MoodSelector where
+inductive Selector where
   | indicativeSelecting          -- "know", "see", "believe"
   | subjunctiveSelecting         -- "want", "wish", "demand", "intend"
   | crossLinguisticallyVariable  -- "hope", "expect": SBJV in some languages,
@@ -199,7 +199,7 @@ inductive MoodSelector where
 /--
 Does the selector prefer subjunctive?
 -/
-def prefersSubjunctive : MoodSelector → Bool
+def prefersSubjunctive : Selector → Bool
   | .indicativeSelecting => false
   | .subjunctiveSelecting => true
   | .crossLinguisticallyVariable => false  -- default: variable, not robust SBJV

--- a/Linglib/Semantics/Mood/Categories.lean
+++ b/Linglib/Semantics/Mood/Categories.lean
@@ -4,7 +4,7 @@
 Morphological mood categories: indicative vs subjunctive (and subtypes).
 
 This is the verb-morphological distinction, independent of:
-- `IllocutionaryMood` (declarative/interrogative/imperative — speech act force)
+- `Illocutionary` (declarative/interrogative/imperative — speech act force)
 - `SAPMood` (configurational mood from Speas & Tenny's 2×2 matrix)
 
 The two dimensions are orthogonal: a clause can be
@@ -14,7 +14,7 @@ The two dimensions are orthogonal: a clause can be
 See `Semantics/Mood/Basic.lean` for the semantic operators (SUBJ, IND)
 that interpret these categories.
 
-This file lives in `Semantics/Mood/` alongside `IllocutionaryMood.lean` (force) and
+This file lives in `Semantics/Mood/` alongside `Illocutionary.lean` (force) and
 `ClauseType.lean` (force × mood); together they form the unified mood-category
 namespace `Semantics.Mood`. Discourse-act material (Searle classes, direction of
 fit, preparatory conditions, discourse roles) lives in
@@ -30,7 +30,7 @@ Following the typological literature:
 - **Indicative**: The default, "realis" mood
 - **Subjunctive**: Non-default, "irrealis" mood (covers many subtypes)
 -/
-inductive GramMood where
+inductive Grammatical where
   | indicative
   | subjunctive
   deriving DecidableEq, Repr, Inhabited
@@ -65,7 +65,7 @@ anchoring (SF in Portuguese/Spanish), while eventuality openness enables
 abstraction over the event argument (required by causatives, intention reports,
 aspectual predicates, and memory/perception reports).
 -/
-structure MoodEffect where
+structure Effect where
   /-- SUBJ introduces a new situation dref ([mendes-2025]) -/
   introducesSituation : Bool
   /-- SBJV leaves the eventuality argument open for abstraction ([grano-2024]) -/
@@ -79,18 +79,18 @@ structure MoodEffect where
 
     Subjunctive mood does both: it introduces a new situation dref and
     leaves the eventuality argument open for abstraction. -/
-def GramMood.effect : GramMood → MoodEffect
+def Grammatical.effect : Grammatical → Effect
   | .indicative  => { introducesSituation := false, eventualityOpen := false }
   | .subjunctive => { introducesSituation := true,  eventualityOpen := true }
 
 /-- Indicative mood closes the eventuality argument. -/
-theorem ind_closes_eventuality : GramMood.indicative.effect.eventualityOpen = false := rfl
+theorem ind_closes_eventuality : Grammatical.indicative.effect.eventualityOpen = false := rfl
 
 /-- Subjunctive mood leaves the eventuality argument open. -/
-theorem subj_opens_eventuality : GramMood.subjunctive.effect.eventualityOpen = true := rfl
+theorem subj_opens_eventuality : Grammatical.subjunctive.effect.eventualityOpen = true := rfl
 
 /-- Indicative and subjunctive differ on both dimensions. -/
 theorem mood_effects_differ :
-    GramMood.indicative.effect ≠ GramMood.subjunctive.effect := by decide
+    Grammatical.indicative.effect ≠ Grammatical.subjunctive.effect := by decide
 
 end Semantics.Mood

--- a/Linglib/Semantics/Mood/ClauseType.lean
+++ b/Linglib/Semantics/Mood/ClauseType.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Mood.Basic
-import Linglib.Semantics.Mood.IllocutionaryMood
+import Linglib.Semantics.Mood.Illocutionary
 import Linglib.Discourse.Roles
 import Linglib.Data.UD.Basic
 
@@ -8,8 +8,8 @@ import Linglib.Data.UD.Basic
 [holmberg-2016] [rizzi-1997]
 
 A clause type is a pair of independent dimensions:
-- **Force** (`IllocutionaryMood`): declarative, interrogative, imperative, ...
-- **Mood** (`GramMood`): indicative, subjunctive
+- **Force** (`Illocutionary`): declarative, interrogative, imperative, ...
+- **Mood** (`Grammatical`): indicative, subjunctive
 
 These are orthogonal — [holmberg-2016]'s analysis requires both:
 a polar question is [interrogative, indicative], while a deliberative
@@ -37,9 +37,9 @@ open Discourse (DiscourseRole)
     with grammatical mood. -/
 structure ClauseType where
   /-- Illocutionary force: the speech act performed -/
-  force : IllocutionaryMood
+  force : Illocutionary
   /-- Grammatical mood: verb morphology -/
-  mood : GramMood
+  mood : Grammatical
   deriving DecidableEq, Repr
 
 /-- A standard declarative-indicative clause. -/
@@ -57,7 +57,7 @@ theorem force_mood_independent :
 
 /-- Map from `ClauseType` to epistemic authority (via force, ignoring mood). -/
 def ClauseType.authority (ct : ClauseType) : DiscourseRole :=
-  moodAuthority ct.force
+  Illocutionary.authority ct.force
 
 /-- Polar questions have addressee authority regardless of mood. -/
 theorem polarQuestion_addressee_authority :

--- a/Linglib/Semantics/Mood/Component.lean
+++ b/Linglib/Semantics/Mood/Component.lean
@@ -1,25 +1,25 @@
-import Linglib.Semantics.Mood.IllocutionaryMood
-import Linglib.Semantics.Mood.POSWQ
+import Linglib.Semantics.Mood.Illocutionary
+import Linglib.Semantics.Mood.State
 
 /-!
-# POSWTarget: Which Component a Mood Targets
+# Mood Components: Which Component a Mood Targets
 [portner-2018]
 
 Each mood-bearing object (verbal mood, sentence mood, modal flavor)
-targets a specific component of a `POSW` (or, for the `partition`
-case, of our extended `POSWQ`; see `Semantics/Mood/POSWQ.lean`).
+targets a specific component of a `POSW` (or, for the `inquisitive`
+case, of our extended `State`; see `Semantics/Mood/State.lean`).
 [portner-2018]'s unification thesis (Ch. 4) says: the surface
 diversity of mood phenomena reduces to *which component gets touched*.
 
-This file packages that thesis as a type-level enum `POSWTarget` and a
-typeclass `HasPOSWTarget`, instantiated here for `IllocutionaryMood`
-(sentence mood) and in `Semantics/Mood/VerbalMood.lean` for
-`VerbalMoodOp` (verbal mood). The companion *value-level*
-implementation lives in `Semantics/Mood/POSWQ.lean`: the `POSWQ`
+This file packages that thesis as a type-level enum `Component` and a
+typeclass `HasTarget`, instantiated here for `Illocutionary`
+(sentence mood) and in `Semantics/Mood/Verbal.lean` for
+`VerbalOp` (verbal mood). The companion *value-level*
+implementation lives in `Semantics/Mood/State.lean`: the `State`
 structure exposes `info`, `order`, and `inquiry` as actual fields, and
 the updates `assert`/`promote`/`inquire` do the work that this file's
 enum labels. The link between the two views is the projection
-`POSWTarget.boxOn` below, which sends each label to the necessity
+`Component.boxOn` below, which sends each label to the necessity
 modal quantifying over the labelled component.
 
 "Target" is selection-side vocabulary: verbal mood in [portner-2018]
@@ -33,7 +33,7 @@ is ever rephrased over POSW.
 
 namespace Semantics.Mood
 
-/-- The component of a `POSW` (or of `POSWQ`, for `.partition`) that a
+/-- The component of a `POSW` (or of `State`, for `.inquisitive`) that a
     mood-bearing object operates on. [portner-2018], Ch. 4.
 
     - `informational`: the context set `cs`. Targeted by indicative
@@ -42,25 +42,25 @@ namespace Semantics.Mood
     - `preferential`: the ordering `≤`. Targeted by subjunctive verbal
       mood (Ch. 2) and imperative force (Ch. 3): directive via
       `⋆`-update, desire via `□_≤`.
-    - `partition`: the inquiry component. Targeted by interrogative
+    - `inquisitive`: the inquiry component. Targeted by interrogative
       force. [portner-2018] offers a partition-variant pposw (his
       (10), replacing `cs`) and the alternative of a separate
       question-set coordinate ([roberts-1996]; [portner-2004]);
-      `POSWQ` adopts the latter. Verbal mood does not select for
-      partition in [portner-2018]; see
-      `Semantics/Mood/VerbalMood.lean` for our extension. -/
-inductive POSWTarget where
+      `State` adopts the latter. Verbal mood does not select for the
+      inquiry component in [portner-2018]; see
+      `Semantics/Mood/Verbal.lean` for our extension. -/
+inductive Component where
   | informational
   | preferential
-  | partition
+  | inquisitive
   deriving DecidableEq, Repr
 
 /-- Typeclass for mood-bearing types. `target m` says which POSW
     component `m` operates on. -/
-class HasPOSWTarget (M : Type*) where
-  target : M → POSWTarget
+class HasTarget (M : Type*) where
+  target : M → Component
 
-export HasPOSWTarget (target)
+export HasTarget (target)
 
 /-! ### Sentence-mood instance -/
 
@@ -78,42 +78,42 @@ export HasPOSWTarget (target)
     *null* direction of fit — no component to target); it is retained
     as a conjectural placeholder until an exclamative-force account is
     formalized. -/
-instance : HasPOSWTarget IllocutionaryMood where
+instance : HasTarget Illocutionary where
   target
     | .declarative   => .informational
     | .imperative    => .preferential
     | .promissive    => .preferential
-    | .interrogative => .partition
+    | .interrogative => .inquisitive
     | .exclamative   => .informational
 
-/-! ### Operational projection: from `POSWTarget` to a POSWQ modal
+/-! ### Operational projection: from `Component` to a State modal
 
-The `POSWTarget` enum is a typeclass-resolved label. To turn that
+The `Component` enum is a typeclass-resolved label. To turn that
 label into semantic work — the `□_cs`/`□_≤`/`boxAns` modal that
 quantifies over the labelled component — we project into a function
-`POSWQ W → (W → Prop) → Prop`. This makes "target is informational"
+`State W → (W → Prop) → Prop`. This makes "target is informational"
 *operational*: it picks out exactly `boxCs` as the modal to use, by
 definition. Downstream glosses write `(target m).boxOn c p` and get
 the right quantification by enum-match instead of manual case
-analysis (`VerbalMoodOp.interp` in `Semantics/Mood/VerbalMood.lean`
+analysis (`VerbalOp.interp` in `Semantics/Mood/Verbal.lean`
 is defined this way). -/
 
 variable {W : Type*}
 
-/-- The modal projection: each `POSWTarget` selects the necessity
-    modal that quantifies over the labelled POSWQ component. -/
-def POSWTarget.boxOn : POSWTarget → POSWQ W → (W → Prop) → Prop
+/-- The modal projection: each `Component` selects the necessity
+    modal that quantifies over the labelled State component. -/
+def Component.boxOn : Component → State W → (W → Prop) → Prop
   | .informational, c, p => c.toExpState.boxCs p
   | .preferential,  c, p => c.toExpState.boxLe p
-  | .partition,     c, p => c.boxAns p
+  | .inquisitive,   c, p => c.boxAns p
 
-@[simp] theorem boxOn_informational (c : POSWQ W) (p : W → Prop) :
-    POSWTarget.informational.boxOn c p = c.toExpState.boxCs p := rfl
+@[simp] theorem boxOn_informational (c : State W) (p : W → Prop) :
+    Component.informational.boxOn c p = c.toExpState.boxCs p := rfl
 
-@[simp] theorem boxOn_preferential (c : POSWQ W) (p : W → Prop) :
-    POSWTarget.preferential.boxOn c p = c.toExpState.boxLe p := rfl
+@[simp] theorem boxOn_preferential (c : State W) (p : W → Prop) :
+    Component.preferential.boxOn c p = c.toExpState.boxLe p := rfl
 
-@[simp] theorem boxOn_partition (c : POSWQ W) (p : W → Prop) :
-    POSWTarget.partition.boxOn c p = c.boxAns p := rfl
+@[simp] theorem boxOn_inquisitive (c : State W) (p : W → Prop) :
+    Component.inquisitive.boxOn c p = c.boxAns p := rfl
 
 end Semantics.Mood

--- a/Linglib/Semantics/Mood/Illocutionary.lean
+++ b/Linglib/Semantics/Mood/Illocutionary.lean
@@ -8,13 +8,13 @@ The category of speech-act force a clause is associated with: declarative,
 interrogative, imperative, promissive, exclamative. This is the F in F(p).
 
 Distinct from:
-- `Semantics.Mood.GramMood` (indicative/subjunctive morphology — see `Basic.lean`)
+- `Semantics.Mood.Grammatical` (indicative/subjunctive morphology — see `Basic.lean`)
 - `SpeasTenny2003.SAPMood` (Speas & Tenny's 2×2 configuration)
 
-The pair `(IllocutionaryMood, GramMood)` is `Semantics.Mood.ClauseType`.
+The pair `(Illocutionary, Grammatical)` is `Semantics.Mood.ClauseType`.
 
 This file contains only the *category* — the enum + its sole intrinsic
-property `moodAuthority` (which participant has epistemic authority). The
+property `Illocutionary.authority` (which participant has epistemic authority). The
 *act-side* extensions (Searle classes, direction of fit, preparatory
 conditions) live in `Discourse/SpeechAct.lean`, which imports
 this file. The split keeps `Semantics/Mood/` framework-agnostic and free of
@@ -30,10 +30,10 @@ open Discourse (DiscourseRole)
 
 /-- Illocutionary mood — the speech-act force of an utterance.
 
-    Distinct from `GramMood` (indicative/subjunctive morphology) and the
+    Distinct from `Grammatical` (indicative/subjunctive morphology) and the
     Minimalist `SAPMood` (configurational). This classifies the pragmatic
     act performed — the F in F(p). -/
-inductive IllocutionaryMood where
+inductive Illocutionary where
   | declarative
   | interrogative
   | imperative
@@ -45,7 +45,7 @@ inductive IllocutionaryMood where
 
     [lakoff-1970]: in declaratives, imperatives, and promissives the
     speaker is the seat of knowledge; in interrogatives the addressee is. -/
-def moodAuthority : IllocutionaryMood → DiscourseRole
+def Illocutionary.authority : Illocutionary → DiscourseRole
   | .declarative   => .speaker
   | .interrogative  => .addressee
   | .imperative     => .speaker

--- a/Linglib/Semantics/Mood/Modal.lean
+++ b/Linglib/Semantics/Mood/Modal.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 
 /-!
-# POSW: Portner's Modal API over Expectation States
+# Mood Modals: Portner's POSW API over Expectation States
 [portner-2018] [veltman-1996] [kratzer-1981] [stalnaker-1978] [condoravdi-lauer-2012]
 
 [portner-2018]'s **partially ordered set of worlds** (posw, his (1),
@@ -149,15 +149,15 @@ variable {W : Type u}
 `boxCs` and `boxLe` are both **normal modalities** in the modal-logic
 sense: each satisfies necessitation (`□⊤`) and the K-axiom
 (`□(p→q) → □p → □q`) — one shape of the inf-preservation pattern that
-`∀` over any subset enjoys. The third POSWQ modal `boxAns` is *not*
-normal (see `Semantics/Mood/POSWQ.lean`); it has its own closure
+`∀` over any subset enjoys. The third State modal `boxAns` is *not*
+normal (see `Semantics/Mood/State.lean`); it has its own closure
 structure under boolean operations instead. -/
 
 /-- A **normal modality** in the sense of basic modal logic:
     quantifies a unary box over `W → Prop` predicates, satisfying
     necessitation (`box ⊤`) and the K-axiom (`box (p → q) → box p
     → box q`). The two universal modals `ExpState.boxCs` and
-    `ExpState.boxLe` are normal; `POSWQ.boxAns` is not. -/
+    `ExpState.boxLe` are normal; `State.boxAns` is not. -/
 class NormalModality (W : Type u) (box : (W → Prop) → Prop) : Prop where
   /-- Necessitation: the box always holds for `⊤`. -/
   necessitation : box (fun _ => True)

--- a/Linglib/Semantics/Mood/PartitionAsInquiry.lean
+++ b/Linglib/Semantics/Mood/PartitionAsInquiry.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.Setoid.Partition
 import Linglib.Semantics.Questions.Basic
-import Linglib.Semantics.Mood.POSWQ
+import Linglib.Semantics.Mood.State
 
 /-!
 # Partition as Inquiry — Setoid → Question embedding
@@ -8,7 +8,7 @@ import Linglib.Semantics.Mood.POSWQ
 [puncochar-2019]
 
 The faithful embedding of partition-based inquiry (`Setoid W` — what
-`POSWQ.inquiry` carries) into the more general inquisitive-content
+`State.inquiry` carries) into the more general inquisitive-content
 representation (`Question W` — downward-closed nonempty
 families of information states).
 
@@ -16,8 +16,8 @@ families of information states).
 
 This file implements the embedding direction prescribed in the
 "Architectural note: Setoid vs. Question" section of
-`POSWQ.lean` (added 0.229.922): we keep `inquiry : Setoid W` as the
-field of `POSWQ` (partitions are the right shape for the propositional-
+`State.lean` (added 0.229.922): we keep `inquiry : Setoid W` as the
+field of `State` (partitions are the right shape for the propositional-
 discourse use cases that currently exist), and provide a *one-way*
 embedding `Setoid → Question`. The embedding goes this way
 and not the other because every Setoid-based partition can be expressed
@@ -191,10 +191,10 @@ theorem class_mem_alt_fromSetoid (r : Setoid W) {c : Set W}
 end Question
 
 
-/-! ## POSWQ bridge
+/-! ## State bridge
 
-Lift the partition-based inquiry component of a `POSWQ` to its full
-`Question`. This makes every existing POSWQ-using study
+Lift the partition-based inquiry component of a `State` to its full
+`Question`. This makes every existing State-using study
 automatically a consumer of the inquisitive-content API: `info`,
 `alt`, `isInquisitive`, the lattice operations, and the
 mention-some/IE-question forcing arguments all become available
@@ -202,26 +202,26 @@ without rewriting the underlying state. -/
 
 namespace Semantics.Mood
 
-namespace POSWQ
+namespace State
 
 -- open removed: Question is top-level after Semantics/Questions/ relocation
 
 universe u
 variable {W : Type u}
 
-/-- The inquisitive content embedded in a POSWQ via its inquiry
+/-- The inquisitive content embedded in a State via its inquiry
     partition. Always non-informative (`info = univ`); inquisitive
     iff the partition has more than one cell. -/
-def inquiryContent (c : POSWQ W) : Question W :=
+def inquiryContent (c : State W) : Question W :=
   Question.fromSetoid c.inquiry
 
-@[simp] theorem inquiryContent_eq (c : POSWQ W) :
+@[simp] theorem inquiryContent_eq (c : State W) :
     c.inquiryContent = Question.fromSetoid c.inquiry := rfl
 
-@[simp] theorem info_inquiryContent (c : POSWQ W) :
+@[simp] theorem info_inquiryContent (c : State W) :
     c.inquiryContent.info = Set.univ :=
   Question.info_fromSetoid c.inquiry
 
-end POSWQ
+end State
 
 end Semantics.Mood

--- a/Linglib/Semantics/Mood/State.lean
+++ b/Linglib/Semantics/Mood/State.lean
@@ -1,12 +1,12 @@
 import Mathlib.Data.Setoid.Basic
-import Linglib.Semantics.Mood.POSW
+import Linglib.Semantics.Mood.Modal
 
 /-!
-# POSW with Inquiry Partition (POSWQ)
+# Mood State: POSW with Inquiry Partition
 [portner-2018] [groenendijk-stokhof-1984] [roberts-2012]
 
 This file is **our extension** of the POSW substrate
-(`Semantics/Mood/POSW.lean`: [veltman-1996]'s `ExpState` under
+(`Semantics/Mood/Modal.lean`: [veltman-1996]'s `ExpState` under
 [portner-2018]'s modal reading) to interrogative force, by way of a
 third component recording the open question: `info` and `order` stay
 intact and `inquiry : Setoid W` is a separate third coordinate, so
@@ -17,7 +17,7 @@ interrogatives: his **pposw** (his (10)) *replaces* `cs` with a
 partition of it, fusing the informational and inquisitive components;
 and he names the alternative of "adding a third component, a question
 set, to the basic definition of a posw", crediting [roberts-1996],
-[roberts-2012], and [portner-2004]. `POSWQ` adopts the second option,
+[roberts-2012], and [portner-2004]. `State` adopts the second option,
 which preserves the disjoint-target architecture. (He also notes that
 his update-based mood-selection principles would treat interrogative
 sentence mood via the `+`-update — a further alternative to the
@@ -84,7 +84,7 @@ intermediate-exhaustive readings as theorems and shows that
 [groenendijk-stokhof-1984]'s partition theory provably cannot.
 When that study is formalized in `Studies/`, the
 `InquisitiveContent W` type becomes load-bearing; until then, every
-existing POSWQ use case is partition-based and `Setoid W` is the
+existing State use case is partition-based and `Setoid W` is the
 right structure (mathlib already provides its `CompleteLattice`).
 
 The lift, when it happens, should be a **sibling** structure (parallel
@@ -97,7 +97,7 @@ namespace Semantics.Mood
 
 open Semantics.Dynamic.Default
 
-/-- A **POSW with an inquiry partition** (POSWQ): the POSW substrate
+/-- A **POSW with an inquiry partition** (State): the POSW substrate
     (an `ExpState`) enriched with a third component recording the open
     question. The `inquiry : Setoid W` partitions worlds into
     "answers"; its `⊤` element is "no question". [portner-2018]'s own
@@ -105,21 +105,21 @@ open Semantics.Dynamic.Default
     `cs` with a partition; the third-coordinate design here is the
     alternative he names — a separate question set à la
     [roberts-1996] and [portner-2004]. -/
-structure POSWQ (W : Type*) extends ExpState W where
+structure State (W : Type*) extends ExpState W where
   /-- The inquiry partition: `inquiry.r w v` means worlds `w` and `v`
       are indistinguishable answers to the open question. -/
   inquiry : Setoid W
 
-namespace POSWQ
+namespace State
 
 variable {W : Type*}
 
 /-! ### Constructors -/
 
-/-- Lift an expectation state to a POSWQ with no question under
+/-- Lift an expectation state to a State with no question under
     discussion (trivial inquiry partition: every world is in the same
     cell). -/
-def ofExpState (σ : ExpState W) : POSWQ W :=
+def ofExpState (σ : ExpState W) : State W :=
   { σ with inquiry := ⊤ }
 
 @[simp] theorem ofExpState_toExpState (σ : ExpState W) :
@@ -162,22 +162,22 @@ def polarSetoid (q : W → Prop) : Setoid W where
     The meet of two equivalence relations on `W` is "agree on both";
     refining the inquiry by `q` shrinks each cell down to its
     intersection with `q`'s cells (jointly-finer partition). -/
-def inquire (c : POSWQ W) (q : Setoid W) : POSWQ W :=
+def inquire (c : State W) (q : Setoid W) : State W :=
   { c with inquiry := c.inquiry ⊓ q }
 
-@[simp] theorem inquire_toExpState (c : POSWQ W) (q : Setoid W) :
+@[simp] theorem inquire_toExpState (c : State W) (q : Setoid W) :
     (c.inquire q).toExpState = c.toExpState := rfl
 
-@[simp] theorem inquire_info (c : POSWQ W) (q : Setoid W) :
+@[simp] theorem inquire_info (c : State W) (q : Setoid W) :
     (c.inquire q).info = c.info := rfl
 
-@[simp] theorem inquire_order (c : POSWQ W) (q : Setoid W) :
+@[simp] theorem inquire_order (c : State W) (q : Setoid W) :
     (c.inquire q).order = c.order := rfl
 
 /-- `?`-update is meet in `Setoid.completeLattice W` — the inquiry-side
     analogue of `assert` (meet in `W → Prop`) and `promote` (meet with
     the criterion preorder, `Normality.refine`). Definitional. -/
-@[simp] theorem inquire_inquiry_eq_inf (c : POSWQ W) (q : Setoid W) :
+@[simp] theorem inquire_inquiry_eq_inf (c : State W) (q : Setoid W) :
     (c.inquire q).inquiry = c.inquiry ⊓ q := rfl
 
 /-! ### The third modal: `boxAns` (informational answerhood) -/
@@ -193,36 +193,36 @@ def inquire (c : POSWQ W) (q : Setoid W) : POSWQ W :=
     `p`: a strengthening of `p` can break the constant-truth property
     on a cell. The natural monotonicity for `boxAns` is *anti*-monotone
     in the inquiry partition (`boxAns_anti` below). -/
-def boxAns (c : POSWQ W) (p : W → Prop) : Prop :=
+def boxAns (c : State W) (p : W → Prop) : Prop :=
   ∀ w v, w ∈ c.info → v ∈ c.info → c.inquiry.r w v → (p w ↔ p v)
 
 /-! ### Refinement preorder
 
-`POSWQ W` inherits a refinement preorder componentwise from the
+`State W` inherits a refinement preorder componentwise from the
 `ExpState` refinement preorder and the `Setoid W` lattice:
 `c₁ ≤ c₂` iff `c₁.toExpState ≤ c₂.toExpState` and
 `c₁.inquiry ≤ c₂.inquiry`. All components agree on "finer ≤
 coarser". -/
 
-instance : Preorder (POSWQ W) where
+instance : Preorder (State W) where
   le c₁ c₂ := c₁.toExpState ≤ c₂.toExpState ∧ c₁.inquiry ≤ c₂.inquiry
   le_refl c := ⟨le_refl _, le_refl _⟩
   le_trans _ _ _ h₁₂ h₂₃ :=
     ⟨le_trans h₁₂.1 h₂₃.1, le_trans h₁₂.2 h₂₃.2⟩
 
-theorem le_iff (c₁ c₂ : POSWQ W) :
+theorem le_iff (c₁ c₂ : State W) :
     c₁ ≤ c₂ ↔ c₁.toExpState ≤ c₂.toExpState ∧ c₁.inquiry ≤ c₂.inquiry :=
   Iff.rfl
 
 /-- `?`-update lands below the input: refining `inquiry` by meet with
-    `q` can only constrain the POSWQ further. The third-component
+    `q` can only constrain the State further. The third-component
     analogue of `ExpState.assert_le_self` and
     `ExpState.promote_le_self`. -/
-theorem inquire_le_self (c : POSWQ W) (q : Setoid W) : c.inquire q ≤ c :=
+theorem inquire_le_self (c : State W) (q : Setoid W) : c.inquire q ≤ c :=
   ⟨le_refl _, inf_le_left⟩
 
-/-- `?`-update is monotone in the underlying POSWQ. -/
-theorem inquire_mono {c₁ c₂ : POSWQ W} (h : c₁ ≤ c₂) (q : Setoid W) :
+/-- `?`-update is monotone in the underlying State. -/
+theorem inquire_mono {c₁ c₂ : State W} (h : c₁ ≤ c₂) (q : Setoid W) :
     c₁.inquire q ≤ c₂.inquire q :=
   ⟨h.1, inf_le_inf_right q h.2⟩
 
@@ -230,32 +230,32 @@ theorem inquire_mono {c₁ c₂ : POSWQ W} (h : c₁ ≤ c₂) (q : Setoid W) :
     `?`-update iff its inquiry already refines the question. The
     third-coordinate instance of [veltman-1996]'s acceptance
     (`ExpState.le_assert_iff`, `ExpState.le_promote_iff`). -/
-theorem le_inquire_iff (c : POSWQ W) (q : Setoid W) :
+theorem le_inquire_iff (c : State W) (q : Setoid W) :
     c ≤ c.inquire q ↔ c.inquiry ≤ q :=
   ⟨fun h => le_trans h.2 inf_le_right,
    fun h => ⟨le_refl _, le_inf (le_refl _) h⟩⟩
 
 /-- Support implies answerhood: if the inquiry already refines `p`'s
     polar partition, `p` is settled by the question. -/
-theorem boxAns_of_inquiry_le_polarSetoid (c : POSWQ W) (p : W → Prop)
+theorem boxAns_of_inquiry_le_polarSetoid (c : State W) (p : W → Prop)
     (h : c.inquiry ≤ polarSetoid p) : c.boxAns p :=
   fun _ _ _ _ hwv => h hwv
 
 /-- On states with total information (`info = Set.univ`), answerhood
     *is* inquiry-support for the polar partition: the `info`-guards in
     `boxAns` are the only gap between the two. -/
-theorem inquiry_le_polarSetoid_iff_boxAns_of_univ (c : POSWQ W)
+theorem inquiry_le_polarSetoid_iff_boxAns_of_univ (c : State W)
     (p : W → Prop) (h : c.info = Set.univ) :
     c.inquiry ≤ polarSetoid p ↔ c.boxAns p :=
   ⟨fun hle => c.boxAns_of_inquiry_le_polarSetoid p hle,
    fun hbox w v hwv =>
      hbox w v (h ▸ Set.mem_univ w) (h ▸ Set.mem_univ v) hwv⟩
 
-/-- Refining the POSWQ *strengthens* informational answerhood: if
+/-- Refining the State *strengthens* informational answerhood: if
     `c₁` is more refined than `c₂` and `p` is settled by the question
     at `c₂`, then `p` is settled at `c₁` too. The answerhood
     counterpart of `ExpState.boxCs_anti`. -/
-theorem boxAns_anti (c₁ c₂ : POSWQ W) (h : c₁ ≤ c₂) (p : W → Prop) :
+theorem boxAns_anti (c₁ c₂ : State W) (h : c₁ ≤ c₂) (p : W → Prop) :
     c₂.boxAns p → c₁.boxAns p :=
   fun hbox w v hw hv hwv =>
     hbox w v (h.1.1 hw) (h.1.1 hv) (h.2 hwv)
@@ -268,21 +268,21 @@ operations — answers to a question can be combined like ordinary
 propositions. -/
 
 /-- Negation preserves answerhood. -/
-theorem boxAns_not (c : POSWQ W) (p : W → Prop) :
+theorem boxAns_not (c : State W) (p : W → Prop) :
     c.boxAns p → c.boxAns (fun w => ¬ p w) :=
   fun hp w v hw hv hwv =>
     ⟨fun hnpw hpv => hnpw ((hp w v hw hv hwv).mpr hpv),
      fun hnpv hpw => hnpv ((hp w v hw hv hwv).mp hpw)⟩
 
 /-- Conjunction preserves answerhood. -/
-theorem boxAns_and (c : POSWQ W) (p q : W → Prop) :
+theorem boxAns_and (c : State W) (p q : W → Prop) :
     c.boxAns p → c.boxAns q → c.boxAns (fun w => p w ∧ q w) :=
   fun hp hq w v hw hv hwv =>
     ⟨fun ⟨hpw, hqw⟩ => ⟨(hp w v hw hv hwv).mp hpw, (hq w v hw hv hwv).mp hqw⟩,
      fun ⟨hpv, hqv⟩ => ⟨(hp w v hw hv hwv).mpr hpv, (hq w v hw hv hwv).mpr hqv⟩⟩
 
 /-- Disjunction preserves answerhood. -/
-theorem boxAns_or (c : POSWQ W) (p q : W → Prop) :
+theorem boxAns_or (c : State W) (p q : W → Prop) :
     c.boxAns p → c.boxAns q → c.boxAns (fun w => p w ∨ q w) :=
   fun hp hq w v hw hv hwv =>
     ⟨fun hpqw => hpqw.elim
@@ -294,7 +294,7 @@ theorem boxAns_or (c : POSWQ W) (p q : W → Prop) :
 
 /-- Material implication preserves answerhood. Follows from the
     Boolean-algebra closure of constant-on-cell propositions. -/
-theorem boxAns_imp (c : POSWQ W) (p q : W → Prop) :
+theorem boxAns_imp (c : State W) (p q : W → Prop) :
     c.boxAns p → c.boxAns q → c.boxAns (fun w => p w → q w) :=
   fun hp hq w v hw hv hwv =>
     ⟨fun himp hpv => (hq w v hw hv hwv).mp (himp ((hp w v hw hv hwv).mpr hpv)),
@@ -302,70 +302,70 @@ theorem boxAns_imp (c : POSWQ W) (p q : W → Prop) :
 
 /-! ### Three-component update disjointness
 
-The three updates `assert`, `promote`, `inquire` touch disjoint POSWQ
-components, so they pairwise commute when lifted to act on `POSWQ`.
+The three updates `assert`, `promote`, `inquire` touch disjoint State
+components, so they pairwise commute when lifted to act on `State`.
 The lifts are defined here because `ExpState.assert` and
-`ExpState.promote` strip the inquiry field; `POSWQ.assert` and
-`POSWQ.promote` are the inquiry-preserving counterparts. -/
+`ExpState.promote` strip the inquiry field; `State.assert` and
+`State.promote` are the inquiry-preserving counterparts. -/
 
-/-- POSWQ-side `+`-update: refine `info` while preserving the inquiry
+/-- State-side `+`-update: refine `info` while preserving the inquiry
     partition. The inquiry-preserving lift of `ExpState.assert`. -/
-def assert (c : POSWQ W) (p : W → Prop) : POSWQ W :=
+def assert (c : State W) (p : W → Prop) : State W :=
   { c.toExpState.assert p with inquiry := c.inquiry }
 
-/-- POSWQ-side `⋆`-update: refine `order` while preserving the inquiry
+/-- State-side `⋆`-update: refine `order` while preserving the inquiry
     partition. The inquiry-preserving lift of `ExpState.promote`. -/
-def promote (c : POSWQ W) (p : W → Prop) : POSWQ W :=
+def promote (c : State W) (p : W → Prop) : State W :=
   { c.toExpState.promote p with inquiry := c.inquiry }
 
-@[simp] theorem assert_toExpState (c : POSWQ W) (p : W → Prop) :
+@[simp] theorem assert_toExpState (c : State W) (p : W → Prop) :
     (c.assert p).toExpState = c.toExpState.assert p := rfl
 
-@[simp] theorem assert_inquiry (c : POSWQ W) (p : W → Prop) :
+@[simp] theorem assert_inquiry (c : State W) (p : W → Prop) :
     (c.assert p).inquiry = c.inquiry := rfl
 
-@[simp] theorem promote_toExpState (c : POSWQ W) (p : W → Prop) :
+@[simp] theorem promote_toExpState (c : State W) (p : W → Prop) :
     (c.promote p).toExpState = c.toExpState.promote p := rfl
 
-@[simp] theorem promote_inquiry (c : POSWQ W) (p : W → Prop) :
+@[simp] theorem promote_inquiry (c : State W) (p : W → Prop) :
     (c.promote p).inquiry = c.inquiry := rfl
 
-/-- `assert` and `promote` commute on POSWQ: the components never
+/-- `assert` and `promote` commute on State: the components never
     interact. -/
-@[simp] theorem assert_promote_comm (c : POSWQ W) (p q : W → Prop) :
+@[simp] theorem assert_promote_comm (c : State W) (p q : W → Prop) :
     (c.assert p).promote q = (c.promote q).assert p := rfl
 
-/-- `assert` and `inquire` commute on POSWQ: each touches a different
+/-- `assert` and `inquire` commute on State: each touches a different
     component. -/
-@[simp] theorem assert_inquire_comm (c : POSWQ W) (p : W → Prop) (s : Setoid W) :
+@[simp] theorem assert_inquire_comm (c : State W) (p : W → Prop) (s : Setoid W) :
     (c.assert p).inquire s = (c.inquire s).assert p := rfl
 
-/-- `promote` and `inquire` commute on POSWQ: each touches a different
+/-- `promote` and `inquire` commute on State: each touches a different
     component. -/
-@[simp] theorem promote_inquire_comm (c : POSWQ W) (p : W → Prop) (s : Setoid W) :
+@[simp] theorem promote_inquire_comm (c : State W) (p : W → Prop) (s : Setoid W) :
     (c.promote p).inquire s = (c.inquire s).promote p := rfl
 
 /-- `?`-update is idempotent on the same partition: refining inquiry
     by `s` twice equals refining once. The Setoid-meet is idempotent
     in the `CompleteLattice (Setoid W)`. -/
-theorem inquire_inquire_self (c : POSWQ W) (s : Setoid W) :
+theorem inquire_inquire_self (c : State W) (s : Setoid W) :
     ((c.inquire s).inquire s).inquiry = (c.inquire s).inquiry := by
   show (c.inquiry ⊓ s) ⊓ s = c.inquiry ⊓ s
   rw [inf_assoc, inf_idem]
 
 /-! ### Distinctness witness: `boxAns` ≠ `boxCs` ∘ projection
 
-The third modal genuinely differs from `boxCs`. We exhibit a POSWQ
+The third modal genuinely differs from `boxCs`. We exhibit a State
 where some `p` is settled by the question (`boxAns p`) but is *not*
 informationally necessary (`¬ boxCs p`). The witness is a non-trivial
 inquiry partition with two cells, where `p` is true on one cell and
 false on the other: it has a constant truth value per cell (so
 `boxAns`), but is not uniformly true on `info` (so not `boxCs`). -/
 
-/-- Two-cell inquiry POSWQ: `info = Set.univ` over `Bool`, `order`
+/-- Two-cell inquiry State: `info = Set.univ` over `Bool`, `order`
     total, with `inquiry` the identity Setoid (each Bool in its own
     cell). -/
-def sepPOSWQ : POSWQ Bool where
+def sepInquiry : State Bool where
   info := Set.univ
   order := Core.Order.Normality.total
   inquiry := { r := fun w v => w = v, iseqv :=
@@ -375,26 +375,26 @@ def sepPOSWQ : POSWQ Bool where
 def sepProp : Bool → Prop := fun w => w = false
 
 /-- The separation proposition is settled by the question at
-    `sepPOSWQ`: within each (singleton) cell, its truth value is
+    `sepInquiry`: within each (singleton) cell, its truth value is
     constant. -/
-theorem boxAns_sepPOSWQ_sepProp : sepPOSWQ.boxAns sepProp := by
+theorem boxAns_sepInquiry_sepProp : sepInquiry.boxAns sepProp := by
   intro w v _ _ hwv
   rw [show w = v from hwv]
 
 /-- The separation proposition is *not* informationally necessary at
-    `sepPOSWQ.toExpState`: `true` is in `info` but does not satisfy
+    `sepInquiry.toExpState`: `true` is in `info` but does not satisfy
     `p`. -/
-theorem not_boxCs_sepPOSWQ_sepProp : ¬ sepPOSWQ.toExpState.boxCs sepProp := by
+theorem not_boxCs_sepInquiry_sepProp : ¬ sepInquiry.toExpState.boxCs sepProp := by
   intro h
   exact Bool.noConfusion (h true trivial)
 
 /-- **`boxAns` and `boxCs` are not interderivable** on the POSW substrate
-    alone: there exists a POSWQ and a proposition where `boxAns` holds
+    alone: there exists a State and a proposition where `boxAns` holds
     and `boxCs` fails. The inquiry component is doing genuine work. -/
 theorem boxAns_not_reducible_to_boxCs :
-    ∃ (c : POSWQ Bool) (p : Bool → Prop),
+    ∃ (c : State Bool) (p : Bool → Prop),
       c.boxAns p ∧ ¬ c.toExpState.boxCs p :=
-  ⟨sepPOSWQ, sepProp, boxAns_sepPOSWQ_sepProp, not_boxCs_sepPOSWQ_sepProp⟩
+  ⟨sepInquiry, sepProp, boxAns_sepInquiry_sepProp, not_boxCs_sepInquiry_sepProp⟩
 
-end POSWQ
+end State
 end Semantics.Mood

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -1,10 +1,10 @@
-import Linglib.Semantics.Mood.POSW
-import Linglib.Semantics.Mood.POSWQ
-import Linglib.Semantics.Mood.POSWTarget
+import Linglib.Semantics.Mood.Modal
+import Linglib.Semantics.Mood.State
+import Linglib.Semantics.Mood.Component
 import Linglib.Semantics.Mood.Basic
 
 /-!
-# Verbal Mood as POSWQ Component Selection
+# Verbal Mood as State Component Selection
 [portner-2018] [groenendijk-stokhof-1984]
 
 Verbal mood — the indicative/subjunctive contrast visible in the
@@ -36,16 +36,16 @@ subset (`ExpState.boxLe`).
 We add a third operator `.interrogative` for question-embedding
 predicates (`wonder`, `ask`, `investigate`), which select for clauses
 *settled by the open question* — clauses with constant truth value
-within each cell of the inquiry partition (`POSWQ.boxAns`,
+within each cell of the inquiry partition (`State.boxAns`,
 [groenendijk-stokhof-1984] answerhood). Question embedding is
 not part of [portner-2018]'s verbal-mood unification proper,
 which is restricted to declarative complementation; we plug it into
-the same POSWQ substrate to give all three operators a uniform type.
+the same State substrate to give all three operators a uniform type.
 
 This file formalizes the selection as the `interp` function on a
-three-element `VerbalMoodOp`, with signature `POSWQ W → (W → Prop)
+three-element `VerbalOp`, with signature `State W → (W → Prop)
 → Prop`. `interp` is defined as `boxOn ∘ target` — each operator's
-`HasPOSWTarget` label selects the component, and the label's modal
+`HasTarget` label selects the component, and the label's modal
 projection does the quantifying — so the operator/component
 correspondence holds by construction rather than by a bridge
 theorem.
@@ -62,10 +62,10 @@ lives in `Studies/Roberts2023.lean`:
 | verbal mood      | `interp .indicative`         | `interp .subjunctive`         | `interp .interrogative`    |
 
 The first two columns are [portner-2018]'s; the third column is
-this library's extension (see `Semantics/Mood/POSWQ.lean`). The shared
-substrate is `POSWQ`. Verbal mood is the *modal* row read as a
+this library's extension (see `Semantics/Mood/State.lean`). The shared
+substrate is `State`. Verbal mood is the *modal* row read as a
 complementizer-domain selector triggered by lexical class of the
-matrix predicate (`MoodSelector` for declarative-embedders;
+matrix predicate (`Selector` for declarative-embedders;
 `QuestionEmbedder` for question-embedders).
 -/
 
@@ -75,17 +75,17 @@ open Semantics.Dynamic.Default
 
 variable {W : Type*}
 
-/-- The three verbal-mood operators on POSWQ. The `.indicative` and
+/-- The three verbal-mood operators on State. The `.indicative` and
     `.subjunctive` cases are [portner-2018]'s; `.interrogative`
     is our extension to question-embedding predicates. The
-    `crossLinguistic` and `neutral` cases of `MoodSelector`
+    `crossLinguistic` and `neutral` cases of `Selector`
     (Mood/Basic.lean) project to `none` via
-    `MoodSelector.toVerbalMood` because their selection pattern is
-    not committed to a single POSWQ component by lexical class
+    `Selector.toVerbalOp` because their selection pattern is
+    not committed to a single State component by lexical class
     alone. -/
-inductive VerbalMoodOp where
+inductive VerbalOp where
   /-- Indicative: universal quantification over the *informational*
-      component of the embedding POSWQ. The Truth intuition. -/
+      component of the embedding State. The Truth intuition. -/
   | indicative
   /-- Subjunctive: universal quantification over the *preferential*
       component (best-ranked subset). The Comparison intuition. -/
@@ -98,54 +98,54 @@ inductive VerbalMoodOp where
   | interrogative
   deriving DecidableEq, Repr
 
-/-- The POSWQ component each verbal-mood operator consults. `target`
+/-- The State component each verbal-mood operator consults. `target`
     here is selection-side vocabulary: the component the selecting
     predicate's modality quantifies over ([portner-2018], Ch. 2), not
     an operation the mood morpheme performs. Packaged as the same
-    `HasPOSWTarget` typeclass that `IllocutionaryMood` instantiates in
-    `Semantics/Mood/POSWTarget.lean`. -/
-instance : HasPOSWTarget VerbalMoodOp where
+    `HasTarget` typeclass that `Illocutionary` instantiates in
+    `Semantics/Mood/Component.lean`. -/
+instance : HasTarget VerbalOp where
   target
     | .indicative    => .informational
     | .subjunctive   => .preferential
-    | .interrogative => .partition
+    | .interrogative => .inquisitive
 
 @[simp] theorem target_indicative :
-    Semantics.Mood.target VerbalMoodOp.indicative = .informational := rfl
+    Semantics.Mood.target VerbalOp.indicative = .informational := rfl
 
 @[simp] theorem target_subjunctive :
-    Semantics.Mood.target VerbalMoodOp.subjunctive = .preferential := rfl
+    Semantics.Mood.target VerbalOp.subjunctive = .preferential := rfl
 
 @[simp] theorem target_interrogative :
-    Semantics.Mood.target VerbalMoodOp.interrogative = .partition := rfl
+    Semantics.Mood.target VerbalOp.interrogative = .inquisitive := rfl
 
 /-- Compositional interpretation of a verbal-mood operator against an
-    embedding POSWQ and an embedded proposition: run the necessity
+    embedding State and an embedded proposition: run the necessity
     modal of the operator's POSW target on the embedded proposition.
     Definitionally `boxOn ∘ target`, so the three cases consult
-    disjoint POSWQ components:
+    disjoint State components:
     `.indicative ↦ ExpState.boxCs`,
     `.subjunctive ↦ ExpState.boxLe`,
-    `.interrogative ↦ POSWQ.boxAns`. -/
-def VerbalMoodOp.interp (m : VerbalMoodOp) : POSWQ W → (W → Prop) → Prop :=
+    `.interrogative ↦ State.boxAns`. -/
+def VerbalOp.interp (m : VerbalOp) : State W → (W → Prop) → Prop :=
   (target m).boxOn
 
 /-- The interpretation is the target component's necessity modal, by
     definition: `target` is not just a typological label. -/
-@[simp] theorem interp_eq_target_boxOn (m : VerbalMoodOp) (c : POSWQ W)
+@[simp] theorem interp_eq_target_boxOn (m : VerbalOp) (c : State W)
     (p : W → Prop) :
     m.interp c p = (Semantics.Mood.target m).boxOn c p := rfl
 
 /-! ### Definitional equalities -/
 
-@[simp] theorem interp_indicative (c : POSWQ W) (p : W → Prop) :
-    VerbalMoodOp.indicative.interp c p = c.toExpState.boxCs p := rfl
+@[simp] theorem interp_indicative (c : State W) (p : W → Prop) :
+    VerbalOp.indicative.interp c p = c.toExpState.boxCs p := rfl
 
-@[simp] theorem interp_subjunctive (c : POSWQ W) (p : W → Prop) :
-    VerbalMoodOp.subjunctive.interp c p = c.toExpState.boxLe p := rfl
+@[simp] theorem interp_subjunctive (c : State W) (p : W → Prop) :
+    VerbalOp.subjunctive.interp c p = c.toExpState.boxLe p := rfl
 
-@[simp] theorem interp_interrogative (c : POSWQ W) (p : W → Prop) :
-    VerbalMoodOp.interrogative.interp c p = c.boxAns p := rfl
+@[simp] theorem interp_interrogative (c : State W) (p : W → Prop) :
+    VerbalOp.interrogative.interp c p = c.boxAns p := rfl
 
 /-! ### Operator-specific monotonicity
 
@@ -154,80 +154,80 @@ strengthening the modal base preserves universal truth there.
 `boxAns` is *not* upward-monotone — a strengthening of `p` can break
 the constant-truth-per-cell property. The natural monotonicity for
 `boxAns` is *anti*-monotone in the inquiry partition (covered by
-`POSWQ.boxAns_anti`).
+`State.boxAns_anti`).
 
 This asymmetry is itself a content claim of [portner-2018]'s
 unification: the three operators have *different* natural ordering
-behaviors precisely because they consult different POSWQ components,
+behaviors precisely because they consult different State components,
 which carry different lattice structures. -/
 
-theorem interp_indicative_mono (c : POSWQ W) (p q : W → Prop)
+theorem interp_indicative_mono (c : State W) (p q : W → Prop)
     (h : ∀ w, p w → q w) :
-    VerbalMoodOp.indicative.interp c p → VerbalMoodOp.indicative.interp c q :=
+    VerbalOp.indicative.interp c p → VerbalOp.indicative.interp c q :=
   c.toExpState.boxCs_mono p q h
 
-theorem interp_subjunctive_mono (c : POSWQ W) (p q : W → Prop)
+theorem interp_subjunctive_mono (c : State W) (p q : W → Prop)
     (h : ∀ w, p w → q w) :
-    VerbalMoodOp.subjunctive.interp c p → VerbalMoodOp.subjunctive.interp c q :=
+    VerbalOp.subjunctive.interp c p → VerbalOp.subjunctive.interp c q :=
   c.toExpState.boxLe_mono p q h
 
 /-! ### Distinctness witnesses
 
 The three mood operators are pairwise non-equivalent — each consults
-a disjoint POSWQ component. We exhibit concrete witnesses showing
-that no operator can be defined in terms of the others on the POSWQ
+a disjoint State component. We exhibit concrete witnesses showing
+that no operator can be defined in terms of the others on the State
 substrate alone. -/
 
 /-- Separation state: total information over `Bool`, ordered by the
-    criterion preorder for `POSWQ.sepProp` (the ordering that
+    criterion preorder for `State.sepProp` (the ordering that
     `ExpState.promote` would install from the total order). Under it
     `false` — the unique `sepProp`-world — is the unique optimal
     world. -/
 def sepState : ExpState Bool :=
-  ⟨Set.univ, Core.Order.Normality.crit POSWQ.sepProp⟩
+  ⟨Set.univ, Core.Order.Normality.crit State.sepProp⟩
 
-/-- Lift of `sepState` to a POSWQ with trivial inquiry. Used to
+/-- Lift of `sepState` to a State with trivial inquiry. Used to
     distinguish indicative from subjunctive without engaging the
     inquiry component. -/
-def sepPOSWQ_triv : POSWQ Bool := POSWQ.ofExpState sepState
+def sepStateTriv : State Bool := State.ofExpState sepState
 
-/-- The subjunctive operator accepts `(sepPOSWQ_triv, sepProp)`. -/
+/-- The subjunctive operator accepts `(sepStateTriv, sepProp)`. -/
 theorem subjunctive_accepts_separation :
-    VerbalMoodOp.subjunctive.interp sepPOSWQ_triv POSWQ.sepProp := by
+    VerbalOp.subjunctive.interp sepStateTriv State.sepProp := by
   intro w hw
   exact hw.2 (Set.mem_univ false) (fun _ => rfl) rfl
 
-/-- The indicative operator rejects `(sepPOSWQ_triv, sepProp)`. -/
+/-- The indicative operator rejects `(sepStateTriv, sepProp)`. -/
 theorem indicative_rejects_separation :
-    ¬ VerbalMoodOp.indicative.interp sepPOSWQ_triv POSWQ.sepProp := by
+    ¬ VerbalOp.indicative.interp sepStateTriv State.sepProp := by
   intro h
   exact Bool.noConfusion (h true (Set.mem_univ true))
 
 /-- **Indicative ≠ subjunctive**. The two mood operators are
-    distinguishable: there exists a POSWQ and a proposition on which
+    distinguishable: there exists a State and a proposition on which
     they disagree. The Truth/Comparison split is genuine, not a
     notational variant. -/
 theorem indicative_ne_subjunctive :
-    ∃ (c : POSWQ Bool) (p : Bool → Prop),
-      VerbalMoodOp.subjunctive.interp c p ∧
-      ¬ VerbalMoodOp.indicative.interp c p :=
-  ⟨sepPOSWQ_triv, POSWQ.sepProp,
+    ∃ (c : State Bool) (p : Bool → Prop),
+      VerbalOp.subjunctive.interp c p ∧
+      ¬ VerbalOp.indicative.interp c p :=
+  ⟨sepStateTriv, State.sepProp,
     subjunctive_accepts_separation, indicative_rejects_separation⟩
 
 /-- **Interrogative ≠ indicative**. Reuses the witness from
-    `POSWQ.boxAns_not_reducible_to_boxCs`: a POSWQ where the inquiry
+    `State.boxAns_not_reducible_to_boxCs`: a State where the inquiry
     component partitions worlds finely enough that some `p` has
     constant truth value per cell (so `boxAns p`) yet fails to be
     universally true on `cs` (so not `boxCs p`). -/
 theorem interrogative_ne_indicative :
-    ∃ (c : POSWQ Bool) (p : Bool → Prop),
-      VerbalMoodOp.interrogative.interp c p ∧
-      ¬ VerbalMoodOp.indicative.interp c p :=
-  POSWQ.boxAns_not_reducible_to_boxCs
+    ∃ (c : State Bool) (p : Bool → Prop),
+      VerbalOp.interrogative.interp c p ∧
+      ¬ VerbalOp.indicative.interp c p :=
+  State.boxAns_not_reducible_to_boxCs
 
 /-! ### Verbal-mood biconditional characterization
 
-`VerbalMoodOp` is in bijection with `POSWTarget`: each operator
+`VerbalOp` is in bijection with `Component`: each operator
 *exactly* picks out one POSW component, and conversely each component
 is targeted by *exactly* one operator. [portner-2018] states his
 **Indicative and Subjunctive principles** one-way — "If a clause φ is
@@ -238,25 +238,25 @@ fixpoints) and the note that a theory may endorse one or both, the
 other mood arising by default. The biconditional form below reflects
 only the bijection between this three-element operator enum and the
 three components — at the verbal-mood layer, mood selection and
-POSWQ-component selection are the same thing by construction. -/
+State-component selection are the same thing by construction. -/
 
-theorem verbal_mood_target_informational_iff_indicative (m : VerbalMoodOp) :
+theorem verbal_mood_target_informational_iff_indicative (m : VerbalOp) :
     Semantics.Mood.target m = .informational ↔ m = .indicative := by
   cases m <;> decide
 
-theorem verbal_mood_target_preferential_iff_subjunctive (m : VerbalMoodOp) :
+theorem verbal_mood_target_preferential_iff_subjunctive (m : VerbalOp) :
     Semantics.Mood.target m = .preferential ↔ m = .subjunctive := by
   cases m <;> decide
 
-theorem verbal_mood_target_partition_iff_interrogative (m : VerbalMoodOp) :
-    Semantics.Mood.target m = .partition ↔ m = .interrogative := by
+theorem verbal_mood_target_inquisitive_iff_interrogative (m : VerbalOp) :
+    Semantics.Mood.target m = .inquisitive ↔ m = .interrogative := by
   cases m <;> decide
 
-/-! ### Bridge to `MoodSelector`
+/-! ### Bridge to `Selector`
 
-The `MoodSelector` enum (Mood/Basic.lean, taxonomic by predicate
+The `Selector` enum (Mood/Basic.lean, taxonomic by predicate
 class — knowledge/belief, preference/desire, etc.) projects onto
-`VerbalMoodOp` for the predicate classes that select the *same*
+`VerbalOp` for the predicate classes that select the *same*
 mood across [portner-2018]'s indicative/subjunctive languages.
 Cross-linguistically variable selectors and mood-neutral predicates
 project to `none` — they are not committed to either quantification
@@ -265,42 +265,42 @@ scheme by lexical-class membership alone.
 Question-embedding predicates (`wonder`, `ask`, `investigate`) are a
 *different* lexical dimension — they're question-embedders, not
 mood-selectors-on-declarative-complements — and so are not in
-`MoodSelector`'s scope. The `.interrogative` operator is reachable
+`Selector`'s scope. The `.interrogative` operator is reachable
 by direct construction; a future predicate-class enum specific to
 question-embedders can project into it. -/
 
-/-- Project a `MoodSelector` to its `VerbalMoodOp`, when the lexical
+/-- Project a `Selector` to its `VerbalOp`, when the lexical
     class is committed to a single mood cross-linguistically.
-    `MoodSelector` covers declarative-complement-taking predicates;
+    `Selector` covers declarative-complement-taking predicates;
     question-embedders project to `.interrogative` via a separate
     dimension. -/
-def MoodSelector.toVerbalMood : MoodSelector → Option VerbalMoodOp
+def Selector.toVerbalOp : Selector → Option VerbalOp
   | .indicativeSelecting          => some .indicative
   | .subjunctiveSelecting         => some .subjunctive
   | .crossLinguisticallyVariable  => none
   | .moodNeutral                  => none
 
 /-- The `prefersSubjunctive` boolean (Mood/Basic.lean) and the
-    `toVerbalMood` projection agree on whether the result is the
+    `toVerbalOp` projection agree on whether the result is the
     subjunctive operator. Two surface representations of the same
     lexical-class commitment, equivalent by construction. -/
-theorem prefersSubjunctive_eq_subjunctive (m : MoodSelector) :
-    prefersSubjunctive m = true ↔ m.toVerbalMood = some .subjunctive := by
-  cases m <;> simp [prefersSubjunctive, MoodSelector.toVerbalMood]
+theorem prefersSubjunctive_eq_subjunctive (m : Selector) :
+    prefersSubjunctive m = true ↔ m.toVerbalOp = some .subjunctive := by
+  cases m <;> simp [prefersSubjunctive, Selector.toVerbalOp]
 
-/-- `MoodSelector.toVerbalMood` never projects to `.interrogative`:
+/-- `Selector.toVerbalOp` never projects to `.interrogative`:
     the declarative-complement classification is *closed* under the
     indicative/subjunctive split. Question-embedding lives elsewhere
     — see `QuestionEmbedder` below. -/
-theorem toVerbalMood_ne_interrogative (m : MoodSelector) :
-    m.toVerbalMood ≠ some .interrogative := by
-  cases m <;> simp [MoodSelector.toVerbalMood]
+theorem toVerbalOp_ne_interrogative (m : Selector) :
+    m.toVerbalOp ≠ some .interrogative := by
+  cases m <;> simp [Selector.toVerbalOp]
 
 /-! ### Bridge to `QuestionEmbedder`
 
-`MoodSelector` covers declarative-complement-taking predicates only;
-its `toVerbalMood` projection cannot land in `.interrogative`
-(`toVerbalMood_ne_interrogative` above). The dual lexical class —
+`Selector` covers declarative-complement-taking predicates only;
+its `toVerbalOp` projection cannot land in `.interrogative`
+(`toVerbalOp_ne_interrogative` above). The dual lexical class —
 question-embedding predicates like `wonder`, `ask`, `know-Q`,
 `investigate` — gets its own enum here, with the inverse projection
 property: every `QuestionEmbedder` projects to `.interrogative`,
@@ -312,7 +312,7 @@ expansion (e.g., a finer projection that distinguishes factive-Q
 embedders' presupposition profile) without committing to particular
 semantic consequences here. -/
 
-/-- Question-embedding predicate class. Disjoint from `MoodSelector`,
+/-- Question-embedding predicate class. Disjoint from `Selector`,
     which covers only declarative-complement embedders. The
     factive/non-factive split follows [karttunen-1977]'s typology. -/
 inductive QuestionEmbedder where
@@ -323,21 +323,21 @@ inductive QuestionEmbedder where
   deriving DecidableEq, Repr, Inhabited
 
 /-- Every `QuestionEmbedder` projects to the interrogative verbal-mood
-    operator. The dual of `MoodSelector.toVerbalMood`: where
-    `MoodSelector` ranges over the indicative/subjunctive split,
+    operator. The dual of `Selector.toVerbalOp`: where
+    `Selector` ranges over the indicative/subjunctive split,
     `QuestionEmbedder` ranges over the inquiry-component column. -/
-def QuestionEmbedder.toVerbalMood : QuestionEmbedder → VerbalMoodOp :=
+def QuestionEmbedder.toVerbalOp : QuestionEmbedder → VerbalOp :=
   fun _ => .interrogative
 
-@[simp] theorem QuestionEmbedder.toVerbalMood_eq (q : QuestionEmbedder) :
-    q.toVerbalMood = .interrogative := rfl
+@[simp] theorem QuestionEmbedder.toVerbalOp_eq (q : QuestionEmbedder) :
+    q.toVerbalOp = .interrogative := rfl
 
-/-- `QuestionEmbedder.toVerbalMood` always lands in `.interrogative` —
-    the inverse of `toVerbalMood_ne_interrogative` for `MoodSelector`.
+/-- `QuestionEmbedder.toVerbalOp` always lands in `.interrogative` —
+    the inverse of `toVerbalOp_ne_interrogative` for `Selector`.
     Together these say: the indicative/subjunctive column and the
     interrogative column are reached by *disjoint* lexical-class
     enums, with no overlap and no gap. -/
-theorem QuestionEmbedder.toVerbalMood_target (q : QuestionEmbedder) :
-    Semantics.Mood.target q.toVerbalMood = .partition := rfl
+theorem QuestionEmbedder.toVerbalOp_target (q : QuestionEmbedder) :
+    Semantics.Mood.target q.toVerbalOp = .inquisitive := rfl
 
 end Semantics.Mood

--- a/Linglib/Semantics/Questions/Basic.lean
+++ b/Linglib/Semantics/Questions/Basic.lean
@@ -40,7 +40,7 @@ LEM-fails witness.
 For Hamblin constructions (`polar`, `which`), see
 `Core/Question/Hamblin.lean`. For partial-answerhood and Roberts
 QUD-relevance predicates, see `Core/Question/Relevance.lean`. For
-the `Setoid → Question` embedding (used by `POSWQ`), see
+the `Setoid → Question` embedding (used by `State`), see
 `Semantics/Mood/PartitionAsInquiry.lean`.
 
 ## Mathlib alignment

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -184,7 +184,7 @@ structure TAMEEntry where
   /-- Utterance perspective constraint: T vs S -/
   up : UPCondition
   /-- Grammatical mood (indicative, subjunctive), if specified -/
-  mood : Option Semantics.Mood.GramMood := none
+  mood : Option Semantics.Mood.Grammatical := none
   /-- Mirativity value (expected, unexpected, neutral), if specified -/
   mirative : Option MirativityValue := none
 

--- a/Linglib/Semantics/TypeTheoretic/Discourse.lean
+++ b/Linglib/Semantics/TypeTheoretic/Discourse.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.TypeTheoretic.Basic
 import Linglib.Semantics.Dynamic.Connectives.CCP
-import Linglib.Semantics.Mood.IllocutionaryMood
+import Linglib.Semantics.Mood.Illocutionary
 import Linglib.Features.ClauseForm
 
 /-!
@@ -10,7 +10,7 @@ import Linglib.Features.ClauseForm
 Discourse-level infrastructure for TTR ([cooper-2023], Chapters 2, 4, 5):
 
 **Signs & Illocutionary Force**: TTRSign, ForcedSign (§2.5–2.6) — the
-illocutionary force component reuses `Semantics.Mood.IllocutionaryMood` rather
+illocutionary force component reuses `Semantics.Mood.Illocutionary` rather
 than [cooper-2023]'s parallel four-way `IllocForce` enum (the surface
 distinction `assertion | query | command | acknowledgement` is the
 declarative/interrogative/imperative slice plus a backchannel constructor;
@@ -47,53 +47,53 @@ open Features
 Signs may carry illocutionary force. [cooper-2023]'s ex (91)
 introduces a four-way TTR-internal enum `assertion | query | command |
 acknowledgement`. We collapse `assertion/query/command` into
-`Semantics.Mood.IllocutionaryMood`'s `declarative/interrogative/imperative`
+`Semantics.Mood.Illocutionary`'s `declarative/interrogative/imperative`
 (the same Searlean cuts) and let backchannel acknowledgements be handled
 where dialogue moves live (`Pragmatics/Dialogue/Gameboard/`). The
 result: TTR signs share the rest of the library's mood vocabulary
 rather than re-stipulating it. -/
 
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 /-- A sign with illocutionary force. [cooper-2023] ex (91), with
-    `IllocForce` replaced by `Semantics.Mood.IllocutionaryMood`. -/
+    `IllocForce` replaced by `Semantics.Mood.Illocutionary`. -/
 structure ForcedSign (Phon Cont : Type) extends TTRSign Phon Cont where
-  illoc : IllocutionaryMood
+  illoc : Illocutionary
 
 /-- ForcedSign ⊑ TTRSign (adding illoc = more fields = subtype). -/
 instance (Phon Cont : Type) : Coe (ForcedSign Phon Cont) (TTRSign Phon Cont) where
   coe := ForcedSign.toTTRSign
 
-/-- Bridge: `IllocutionaryMood` → form-level `ClauseForm`. The two
+/-- Bridge: `Illocutionary` → form-level `ClauseForm`. The two
     question form distinctions (matrix vs embedded) are not visible from
     illocutionary force alone, so we project to the matrix variant.
 
     Imperatives, promissives, and exclamatives have no `ClauseForm`
     form-counterpart in `Features.ClauseForm` (which only enumerates the
     declarative/question word-order distinctions); they map to `none`. -/
-def IllocutionaryMood.toClauseForm? : IllocutionaryMood → Option ClauseForm
+def Illocutionary.toClauseForm? : Illocutionary → Option ClauseForm
   | .declarative   => some .declarative
   | .interrogative => some .matrixQuestion
   | .imperative    => none
   | .promissive    => none
   | .exclamative   => none
 
-/-- Bridge: form-level `ClauseForm` → `IllocutionaryMood`. The form
+/-- Bridge: form-level `ClauseForm` → `Illocutionary`. The form
     distinction between matrix and embedded questions collapses on the
     force side. -/
-def IllocutionaryMood.fromClauseForm : ClauseForm → IllocutionaryMood
+def Illocutionary.fromClauseForm : ClauseForm → Illocutionary
   | .declarative      => .declarative
   | .matrixQuestion   => .interrogative
   | .embeddedQuestion => .interrogative
 
 /-- Round-trip: `fromClauseForm` preserves the declarative slot. -/
 theorem illoc_declarative_roundtrip :
-    IllocutionaryMood.toClauseForm? (IllocutionaryMood.fromClauseForm .declarative) =
+    Illocutionary.toClauseForm? (Illocutionary.fromClauseForm .declarative) =
     some .declarative := rfl
 
 /-- Round-trip: `fromClauseForm` preserves the matrix-question slot. -/
 theorem illoc_question_roundtrip :
-    IllocutionaryMood.toClauseForm? (IllocutionaryMood.fromClauseForm .matrixQuestion) =
+    Illocutionary.toClauseForm? (Illocutionary.fromClauseForm .matrixQuestion) =
     some .matrixQuestion := rfl
 
 -- ============================================================================
@@ -213,7 +213,7 @@ example : (fetchThrow ⌢ fetchRunAfter).events = [.throw, .runAfter] := rfl
 /-- The three type acts map to the three Searlean basic illocutionary
     moods (declarative, interrogative, imperative). -/
 theorem typeAct_covers_illoc :
-    ∀ ta : TypeAct, ∃ i : IllocutionaryMood,
+    ∀ ta : TypeAct, ∃ i : Illocutionary,
       (ta = .judge ∧ i = .declarative) ∨
       (ta = .query ∧ i = .interrogative) ∨
       (ta = .create ∧ i = .imperative) := by

--- a/Linglib/Studies/FarkasRoelofsen2017.lean
+++ b/Linglib/Studies/FarkasRoelofsen2017.lean
@@ -142,7 +142,7 @@ inductive Intonation where
     are explicitly out of scope.
 
     This triple refines the coarse declarative/interrogative cut of
-    `Semantics.Mood.IllocutionaryMood` (which `Item.mood` carries). -/
+    `Semantics.Mood.Illocutionary` (which `Item.mood` carries). -/
 structure MarkerTriple where
   clauseType : ClauseType
   intonation : Intonation

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Mood.Basic
-import Linglib.Semantics.Mood.VerbalMood
+import Linglib.Semantics.Mood.Verbal
 import Linglib.Semantics.Attitudes.RationalAttitude
 import Linglib.Studies.Noonan2007
 import Linglib.Fragments.Greek.StandardModern.MoodChoice
@@ -50,7 +50,7 @@ When neither departure is present, only indicative mood is possible.
 namespace Grano2024
 
 open Semantics.Lexical
-open Semantics.Mood (GramMood MoodEffect)
+open Semantics.Mood (Grammatical Effect)
 open Semantics.Mood
 open Semantics.Attitudes.RationalAttitude
 
@@ -173,28 +173,28 @@ theorem causatives_pattern_with_intend :
   native_decide
 
 -- ════════════════════════════════════════════════════════════════
--- § 3. Bridge: Empirical Data → MoodSelector
+-- § 3. Bridge: Empirical Data → Selector
 -- ════════════════════════════════════════════════════════════════
 
-open Noonan2007 (deriveMoodSelector)
+open Noonan2007 (deriveSelector)
 open English.Predicates.Verbal (want hope)
 
-/-- The deriveMoodSelector function correctly classifies 'want' as
+/-- The deriveSelector function correctly classifies 'want' as
     robustly subjunctive-selecting, matching the cross-linguistic data. -/
 theorem want_selector_matches_data :
-    deriveMoodSelector want = .subjunctiveSelecting ∧
+    deriveSelector want = .subjunctiveSelecting ∧
     wantData.all (·.rejectsIndicative) = true := by
   native_decide
 
-/-- The deriveMoodSelector function correctly classifies 'hope' as
+/-- The deriveSelector function correctly classifies 'hope' as
     cross-linguistically variable, matching the data showing variation. -/
 theorem hope_selector_matches_data :
-    deriveMoodSelector hope = .crossLinguisticallyVariable ∧
+    deriveSelector hope = .crossLinguisticallyVariable ∧
     hopeData.all (·.rejectsIndicative) = false := by
   native_decide
 
 -- ════════════════════════════════════════════════════════════════
--- § 4. Bridge: MoodEffect → Indicative Rejection
+-- § 4. Bridge: Effect → Indicative Rejection
 -- ════════════════════════════════════════════════════════════════
 
 /-- Indicative mood closes the eventuality argument. Therefore,
@@ -205,12 +205,12 @@ theorem hope_selector_matches_data :
     Premise 2 (CAUSE* needs open event arg) + Premise 3 (IND closes it)
     → Conclusion (intention reports reject IND). -/
 theorem ind_incompatible_with_eventuality_abstraction :
-    GramMood.indicative.effect.eventualityOpen = false := rfl
+    Grammatical.indicative.effect.eventualityOpen = false := rfl
 
 /-- Subjunctive mood leaves the eventuality argument open, enabling
     CAUSE* to bind it. This is why 'intend' and causatives accept SBJV. -/
 theorem subj_enables_eventuality_abstraction :
-    GramMood.subjunctive.effect.eventualityOpen = true := rfl
+    Grammatical.subjunctive.effect.eventualityOpen = true := rfl
 
 /-- The three-premise argument chain:
     1. `intentionHolds` requires P : E → W → Event Time → Prop (open event arg)
@@ -219,8 +219,8 @@ theorem subj_enables_eventuality_abstraction :
     → intention reports require SBJV, reject IND -/
 theorem grano_argument_chain :
     -- Premise 3: IND closes, SBJV opens
-    GramMood.indicative.effect.eventualityOpen = false ∧
-    GramMood.subjunctive.effect.eventualityOpen = true ∧
+    Grammatical.indicative.effect.eventualityOpen = false ∧
+    Grammatical.subjunctive.effect.eventualityOpen = true ∧
     -- Empirical confirmation: intend rejects IND
     intendData.all (·.rejectsIndicative) = true ∧
     -- Empirical confirmation: causatives also reject IND (independent support)
@@ -269,7 +269,7 @@ inductive DepartureKind where
       IND existentially closes the event argument, making it
       type-incompatible with CAUSE* / aspect / perception. No
       simplification can rescue IND here. -/
-def DepartureKind.moodPrediction : DepartureKind → MoodSelector
+def DepartureKind.moodPrediction : DepartureKind → Selector
   | .comparisonSimplifiable    => .crossLinguisticallyVariable
   | .comparisonNonSimplifiable => .subjunctiveSelecting
   | .eventualityAbstraction    => .subjunctiveSelecting
@@ -470,61 +470,61 @@ theorem cp_to_indicative :
 -- rather than computed from VerbEntry fields because the crucial
 -- distinction — whether a predicate has a causative component (CAUSE*)
 -- — is not yet captured by a VerbEntry field. The classifications are
--- verified to agree with the independently derived `deriveMoodSelector`.
+-- verified to agree with the independently derived `deriveSelector`.
 
 /-- 'want' involves non-simplifiable comparison (robust SBJV). -/
 theorem want_moodPrediction_agrees :
     DepartureKind.comparisonNonSimplifiable.moodPrediction =
-      deriveMoodSelector want := by native_decide
+      deriveSelector want := by native_decide
 
 /-- 'hope' involves simplifiable comparison (variable mood). -/
 theorem hope_moodPrediction_agrees :
     DepartureKind.comparisonSimplifiable.moodPrediction =
-      deriveMoodSelector hope := by native_decide
+      deriveSelector hope := by native_decide
 
 /-- 'intend' involves both comparison and eventuality abstraction
     (robust SBJV). -/
 theorem intend_moodPrediction_agrees :
     DepartureKind.comparisonAndAbstraction.moodPrediction =
-      deriveMoodSelector intend := by native_decide
+      deriveSelector intend := by native_decide
 
 /-- Causatives involve eventuality abstraction (robust SBJV). -/
 theorem causative_moodPrediction_agrees :
     DepartureKind.eventualityAbstraction.moodPrediction =
-      deriveMoodSelector English.Predicates.Verbal.make := by native_decide
+      deriveSelector English.Predicates.Verbal.make := by native_decide
 
 -- ════════════════════════════════════════════════════════════════
--- § 8b. Bridge: deriveMoodSelector → VerbalMoodOp
+-- § 8b. Bridge: deriveSelector → VerbalOp
 -- ════════════════════════════════════════════════════════════════
 
-/-! Per-verb closure of `deriveMoodSelector` under
-`MoodSelector.toVerbalMood`. The cross-linguistic mood-choice
-data (§3) flows through `deriveMoodSelector` (§3) and into the
-POSWQ-typed verbal-mood operator (`VerbalMood.lean`). For
+/-! Per-verb closure of `deriveSelector` under
+`Selector.toVerbalOp`. The cross-linguistic mood-choice
+data (§3) flows through `deriveSelector` (§3) and into the
+State-typed verbal-mood operator (`VerbalMood.lean`). For
 robustly subjunctive predicates, the projection lands in
 `some .subjunctive`; for cross-linguistically variable predicates,
-in `none`. The chain `verb → MoodSelector → VerbalMoodOp` makes
+in `none`. The chain `verb → Selector → VerbalOp` makes
 the lexical-class commitment of [grano-2024] operationally
-ready to feed POSWQ-side glosses (`ExpState.boxLe` for subjunctive,
+ready to feed State-side glosses (`ExpState.boxLe` for subjunctive,
 `ExpState.boxCs` for indicative). -/
 
-/-- 'want' lifts to the subjunctive POSWQ operator. -/
+/-- 'want' lifts to the subjunctive State operator. -/
 theorem want_verbalMood :
-    (deriveMoodSelector want).toVerbalMood = some .subjunctive := by
+    (deriveSelector want).toVerbalOp = some .subjunctive := by
   native_decide
 
 /-- 'hope' is cross-linguistically variable, so it lifts to `none`. -/
 theorem hope_verbalMood :
-    (deriveMoodSelector hope).toVerbalMood = none := by
+    (deriveSelector hope).toVerbalOp = none := by
   native_decide
 
 /-- The robust subjunctive predicates (e.g. 'want') project to the
     `preferential` POSW component — they quantify over the best-ranked
-    subset of the POSWQ via `ExpState.boxLe`. The composed projection
-    (`MoodSelector → VerbalMoodOp → POSWTarget`) makes the operational
+    subset of the State via `ExpState.boxLe`. The composed projection
+    (`Selector → VerbalOp → Component`) makes the operational
     target explicit. -/
 theorem want_target :
-    Option.map (Semantics.Mood.target ·) (deriveMoodSelector want).toVerbalMood
+    Option.map (Semantics.Mood.target ·) (deriveSelector want).toVerbalOp
       = some .preferential := by
   native_decide
 
@@ -538,7 +538,7 @@ The cross-linguistic fragment files encode verb properties that should be
 consistent with the mood choice data. For predicates in the want-class
 (levinClass = .want), the datum should have rejectsIndicative = true.
 For predicates NOT in the want-class (like 'hope'), the mood variability
-is captured by deriveMoodSelector returning .crossLinguisticallyVariable. -/
+is captured by deriveSelector returning .crossLinguisticallyVariable. -/
 
 -- Greek fragments match Greek data
 theorem greek_want_fragment_consistent :

--- a/Linglib/Studies/Holmberg2016.lean
+++ b/Linglib/Studies/Holmberg2016.lean
@@ -57,7 +57,7 @@ namespace Holmberg2016
 open Question
 open Features (AnsweringSystem PolarAnswerProfile)
 open Minimalist
-open Semantics.Mood (ClauseType GramMood IllocutionaryMood)
+open Semantics.Mood (ClauseType Grammatical Illocutionary)
 
 /-! ### Syntactic polarity: PolP and [±Pol] (relocated from Minimalist/Polarity.lean)
 
@@ -207,8 +207,8 @@ unformalized — silent divergences, not committed disagreements.
 
 A clause's `Semantics.Mood.ClauseType` (force × mood) is determined by
 the syntactic projections:
-- Force⁰[+Q] → `IllocutionaryMood.interrogative`
-- Force⁰[-Q] → `IllocutionaryMood.declarative`
+- Force⁰[+Q] → `Illocutionary.interrogative`
+- Force⁰[-Q] → `Illocutionary.declarative`
 - Mood is determined lower (by T/Fin morphology), not by ForceP.
 -/
 
@@ -224,7 +224,7 @@ def QFeature.toFeatureVal : QFeature → FeatureVal
   | .minusQ => .q false
 
 /-- Map the Q-feature to illocutionary force. -/
-def QFeature.toForce : QFeature → IllocutionaryMood
+def QFeature.toForce : QFeature → Illocutionary
   | .plusQ  => .interrogative
   | .minusQ => .declarative
 
@@ -249,7 +249,7 @@ theorem polP_always_projected :
     The Q-feature on Force determines illocutionary force; mood is
     determined by the morphological properties of the verb (indicative
     vs subjunctive), independent of Force. -/
-def clauseType (q : QFeature) (m : GramMood) : ClauseType :=
+def clauseType (q : QFeature) (m : Grammatical) : ClauseType :=
   { force := q.toForce, mood := m }
 
 /-- A polar question with indicative mood. -/

--- a/Linglib/Studies/Krifka2020.lean
+++ b/Linglib/Studies/Krifka2020.lean
@@ -58,7 +58,7 @@ the other — and study files target whichever is appropriate:
 
 namespace Discourse.Krifka
 
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Commitment Strength
@@ -98,7 +98,7 @@ theorem strength_ordering :
 
     Each layer is independent: the epistemic status (JP) can vary without
     affecting the commitment strength (ComP), and vice versa. The actType
-    uses `IllocutionaryMood` from `Discourse/SpeechAct.lean`. -/
+    uses `Illocutionary` from `Discourse/SpeechAct.lean`. -/
 structure LayeredAssertion (W : Type*) where
   /-- TP: the propositional content -/
   content : Set W
@@ -107,7 +107,7 @@ structure LayeredAssertion (W : Type*) where
   /-- ComP: the strength of the speaker's public commitment -/
   commitmentStrength : CommitmentStrength := .standard
   /-- ActP: the type of speech act performed -/
-  actType : IllocutionaryMood := .declarative
+  actType : Illocutionary := .declarative
 
 -- ════════════════════════════════════════════════════
 -- § 3. Informative vs Performative Updates

--- a/Linglib/Studies/NapoliNespor1976.lean
+++ b/Linglib/Studies/NapoliNespor1976.lean
@@ -198,10 +198,10 @@ inductive CliticPresence where
 
 /-- §3.21: grammatical mood of the *than*-clause. Subjunctive surfaces
     iff *non₂* is underlyingly present (modulo lexical mood control by
-    *credere* etc., abstracted away here). Returning `Semantics.Mood.GramMood`
+    *credere* etc., abstracted away here). Returning `Semantics.Mood.Grammatical`
     rather than `Bool` connects this prediction to the mood semantics in
     `Semantics/Mood/`. -/
-def predictsGramMood (p : BiasLicensingProfile) : Semantics.Mood.GramMood :=
+def predictsGrammatical (p : BiasLicensingProfile) : Semantics.Mood.Grammatical :=
   if p.licenses then .subjunctive else .indicative
 
 /-- §3.11 ex. 46–48: under bias-licensed negation the comparative admits
@@ -254,7 +254,7 @@ def predictsLoClitic (p : BiasLicensingProfile) : CliticPresence :=
     the Italian Fragment's `neanche.licensingContexts` and needs `decide`
     on the registry data. -/
 theorem licensed_diagnostics_agree :
-    predictsGramMood licensedProfile = .subjunctive ∧
+    predictsGrammatical licensedProfile = .subjunctive ∧
     predictsWeakNPISurface licensedProfile = some pur.form ∧
     predictsSpecificity licensedProfile = .nonspecificOnly ∧
     predictsNeancheConjunction licensedProfile ∧
@@ -267,7 +267,7 @@ theorem licensed_diagnostics_agree :
     the six diagnostics are genuinely *predictive* (their values vary
     with the bias profile) rather than constant functions. -/
 theorem blocked_diagnostics_agree :
-    predictsGramMood blockedProfile = .indicative ∧
+    predictsGrammatical blockedProfile = .indicative ∧
     predictsWeakNPISurface blockedProfile = none ∧
     predictsSpecificity blockedProfile = .unrestricted ∧
     ¬ predictsNeancheConjunction blockedProfile ∧

--- a/Linglib/Studies/Noonan2007.lean
+++ b/Linglib/Studies/Noonan2007.lean
@@ -34,10 +34,10 @@ subject omission is pro-drop, not Noonan-equi; English *hope* has
 Five bridges connecting CTPClass to existing infrastructure:
 1. CTPClass ↔ VerbEntry (Verbal.lean) — derive CTP class from verb features
 2. CTPClass ↔ SelectionClass (LeftPeriphery.lean) — map CTP to question embedding
-3. CTPClass ↔ MoodSelector (Mood/Basic.lean) — map CTP to mood selection
+3. CTPClass ↔ Selector (Mood/Basic.lean) — map CTP to mood selection
 4. ComplementType ↔ NoonanCompType — via the substrate adapter
    `ComplementType.toNoonan` (`Syntax/Clause/Complementation.lean`)
-5. VerbEntry → MoodSelector — derive mood selection from verb features
+5. VerbEntry → Selector — derive mood selection from verb features
 
 -/
 
@@ -308,7 +308,7 @@ theorem ctp_selection_consistent_ask :
     ctpToDefaultSelectionClass .utterance = deriveSelectionClass ask := by native_decide
 
 -- ============================================================================
--- C. Bridge 3: CTPClass ↔ MoodSelector (Mood/Basic.lean)
+-- C. Bridge 3: CTPClass ↔ Selector (Mood/Basic.lean)
 -- ============================================================================
 
 /-! ## C1. Map CTP classes to mood selection
@@ -319,7 +319,7 @@ The realis/irrealis split predicts mood selection. -/
 /-- Map CTP class to mood selection.
     Realis CTPs select indicative; irrealis select subjunctive.
     Some are language-dependent (moodNeutral). -/
-def ctpToMoodSelector : CTPClass → MoodSelector
+def ctpToSelector : CTPClass → Selector
   | .knowledge => .indicativeSelecting
   | .utterance => .moodNeutral        -- "say" varies: IND in English, SUBJ in some Romance
   | .propAttitude => .indicativeSelecting
@@ -337,17 +337,17 @@ def ctpToMoodSelector : CTPClass → MoodSelector
 theorem realis_not_subjunctive :
     ∀ c : CTPClass,
       ctpRealityStatus c = .realis →
-      ctpToMoodSelector c ≠ .subjunctiveSelecting := by
+      ctpToSelector c ≠ .subjunctiveSelecting := by
   intro c h
-  cases c <;> simp_all [ctpRealityStatus, ctpToMoodSelector]
+  cases c <;> simp_all [ctpRealityStatus, ctpToSelector]
 
 /-- Irrealis CTPs select subjunctive or are mood-neutral (never indicative-selecting). -/
 theorem irrealis_not_indicative :
     ∀ c : CTPClass,
       ctpRealityStatus c = .irrealis →
-      ctpToMoodSelector c ≠ .indicativeSelecting := by
+      ctpToSelector c ≠ .indicativeSelecting := by
   intro c h
-  cases c <;> simp_all [ctpRealityStatus, ctpToMoodSelector]
+  cases c <;> simp_all [ctpRealityStatus, ctpToSelector]
 
 -- ============================================================================
 -- D. Bridge 4: English ComplementType ↔ NoonanCompType
@@ -367,10 +367,10 @@ theorem clausal_complements_have_noonan_type :
     ComplementType.toNoonan .smallClause ≠ none := by decide
 
 -- ============================================================================
--- E. Gap fix: VerbEntry → MoodSelector (derived function)
+-- E. Gap fix: VerbEntry → Selector (derived function)
 -- ============================================================================
 
-/-! ## E1. Derive MoodSelector from VerbEntry fields
+/-! ## E1. Derive Selector from VerbEntry fields
 
 This is placed in Bridge.lean (not Verbal.lean) to avoid circular imports:
 it needs both Verbal and Mood/Basic. Follows the `deriveSelectionClass` pattern. -/
@@ -391,7 +391,7 @@ it needs both Verbal and Mood/Basic. Follows the `deriveSelectionClass` pattern.
     - Causative → subjunctive (make: irrealis)
     - Implicative → moodNeutral (manage: varies)
     - Otherwise → moodNeutral -/
-def deriveMoodSelector (v : VerbEntry) : MoodSelector :=
+def deriveSelector (v : VerbEntry) : Selector :=
   match v.attitude with
   | some (.preferential (.degreeComparison .positive)) =>
     if v.levinClass == some .want then .subjunctiveSelecting
@@ -411,53 +411,53 @@ def deriveMoodSelector (v : VerbEntry) : MoodSelector :=
 
 -- Indicative-selecting verbs
 theorem know_selects_indicative :
-    deriveMoodSelector know = .indicativeSelecting := by native_decide
+    deriveSelector know = .indicativeSelecting := by native_decide
 theorem believe_selects_indicative :
-    deriveMoodSelector believe = .indicativeSelecting := by native_decide
+    deriveSelector believe = .indicativeSelecting := by native_decide
 theorem think_selects_indicative :
-    deriveMoodSelector think = .indicativeSelecting := by native_decide
+    deriveSelector think = .indicativeSelecting := by native_decide
 theorem realize_selects_indicative :
-    deriveMoodSelector realize = .indicativeSelecting := by native_decide
+    deriveSelector realize = .indicativeSelecting := by native_decide
 theorem see_selects_indicative :
-    deriveMoodSelector see = .indicativeSelecting := by native_decide
+    deriveSelector see = .indicativeSelecting := by native_decide
 theorem fear_selects_indicative :
-    deriveMoodSelector fear = .indicativeSelecting := by native_decide
+    deriveSelector fear = .indicativeSelecting := by native_decide
 theorem worry_selects_indicative :
-    deriveMoodSelector worry = .indicativeSelecting := by native_decide
+    deriveSelector worry = .indicativeSelecting := by native_decide
 
 -- Subjunctive-selecting verbs (robustly SBJV cross-linguistically)
 theorem want_selects_subjunctive :
-    deriveMoodSelector want = .subjunctiveSelecting := by native_decide
+    deriveSelector want = .subjunctiveSelecting := by native_decide
 theorem wish_selects_subjunctive :
-    deriveMoodSelector wish = .subjunctiveSelecting := by native_decide
+    deriveSelector wish = .subjunctiveSelecting := by native_decide
 theorem intend_selects_subjunctive :
-    deriveMoodSelector intend = .subjunctiveSelecting := by native_decide
+    deriveSelector intend = .subjunctiveSelecting := by native_decide
 theorem cause_selects_subjunctive :
-    deriveMoodSelector cause = .subjunctiveSelecting := by native_decide
+    deriveSelector cause = .subjunctiveSelecting := by native_decide
 theorem make_selects_subjunctive :
-    deriveMoodSelector make = .subjunctiveSelecting := by native_decide
+    deriveSelector make = .subjunctiveSelecting := by native_decide
 theorem decide_selects_subjunctive :
-    deriveMoodSelector decide_ = .subjunctiveSelecting := by native_decide
+    deriveSelector decide_ = .subjunctiveSelecting := by native_decide
 
 -- Cross-linguistically variable verbs ([grano-2024], Table 1:
 -- 'hope' is SBJV in Spanish, IND/%SBJV in French, IND/SBJV in Portuguese,
 -- %IND in Italian, IND/SBJV in Greek/Romanian, IND/for-to in English)
 theorem hope_mood_variable :
-    deriveMoodSelector hope = .crossLinguisticallyVariable := by native_decide
+    deriveSelector hope = .crossLinguisticallyVariable := by native_decide
 theorem expect_mood_variable :
-    deriveMoodSelector expect = .crossLinguisticallyVariable := by native_decide
+    deriveSelector expect = .crossLinguisticallyVariable := by native_decide
 
 -- Mood-neutral verbs
 theorem say_mood_neutral :
-    deriveMoodSelector say = .moodNeutral := by native_decide
+    deriveSelector say = .moodNeutral := by native_decide
 theorem tell_mood_neutral :
-    deriveMoodSelector tell = .moodNeutral := by native_decide
+    deriveSelector tell = .moodNeutral := by native_decide
 theorem stop_mood_neutral :
-    deriveMoodSelector stop = .moodNeutral := by native_decide
+    deriveSelector stop = .moodNeutral := by native_decide
 theorem start_mood_neutral :
-    deriveMoodSelector start = .moodNeutral := by native_decide
+    deriveSelector start = .moodNeutral := by native_decide
 theorem manage_mood_neutral :
-    deriveMoodSelector manage = .moodNeutral := by native_decide
+    deriveSelector manage = .moodNeutral := by native_decide
 
 -- ============================================================================
 -- F. Cross-bridge consistency
@@ -471,50 +471,50 @@ from VerbEntry should be consistent with the CTP-based derivation. -/
 /-- The CTP-based mood mapping agrees with the direct derivation for
     representative verbs from each CTP class. -/
 theorem ctp_mood_consistent_knowledge :
-    ctpToMoodSelector .knowledge = deriveMoodSelector know := by native_decide
+    ctpToSelector .knowledge = deriveSelector know := by native_decide
 theorem ctp_mood_consistent_propAttitude :
-    ctpToMoodSelector .propAttitude = deriveMoodSelector believe := by native_decide
+    ctpToSelector .propAttitude = deriveSelector believe := by native_decide
 theorem ctp_mood_consistent_desiderative :
-    ctpToMoodSelector .desiderative = deriveMoodSelector want := by native_decide
+    ctpToSelector .desiderative = deriveSelector want := by native_decide
 theorem ctp_mood_consistent_manipulative :
-    ctpToMoodSelector .manipulative = deriveMoodSelector cause := by native_decide
+    ctpToSelector .manipulative = deriveSelector cause := by native_decide
 theorem ctp_mood_consistent_perception :
-    ctpToMoodSelector .perception = deriveMoodSelector see := by native_decide
+    ctpToSelector .perception = deriveSelector see := by native_decide
 
 /-! ## F2. Three-way agreement for key verbs
 
 For important verbs, all three classification systems agree:
 1. deriveCTPClass → CTP class
 2. deriveSelectionClass → question embedding
-3. deriveMoodSelector → mood selection -/
+3. deriveSelector → mood selection -/
 
 /-- "know" is classified consistently across all three bridges:
     knowledge CTP, responsive selection, indicative mood. -/
 theorem know_triple_consistency :
     deriveCTPClass know = some .knowledge ∧
     deriveSelectionClass know = .responsive ∧
-    deriveMoodSelector know = .indicativeSelecting := by native_decide
+    deriveSelector know = .indicativeSelecting := by native_decide
 
 /-- "believe" is classified consistently:
     propAttitude CTP, uninterrogative, indicative mood. -/
 theorem believe_triple_consistency :
     deriveCTPClass believe = some .propAttitude ∧
     deriveSelectionClass believe = .uninterrogative ∧
-    deriveMoodSelector believe = .indicativeSelecting := by native_decide
+    deriveSelector believe = .indicativeSelecting := by native_decide
 
 /-- "want" is classified consistently:
     desiderative CTP, uninterrogative (anti-rogative), subjunctive mood. -/
 theorem want_triple_consistency :
     deriveCTPClass want = some .desiderative ∧
     deriveSelectionClass want = .uninterrogative ∧
-    deriveMoodSelector want = .subjunctiveSelecting := by native_decide
+    deriveSelector want = .subjunctiveSelecting := by native_decide
 
 /-- "ask" is classified consistently:
     utterance CTP, rogativeSAP, mood-neutral. -/
 theorem ask_triple_consistency :
     deriveCTPClass ask = some .utterance ∧
     deriveSelectionClass ask = .rogativeSAP ∧
-    deriveMoodSelector ask = .moodNeutral := by native_decide
+    deriveSelector ask = .moodNeutral := by native_decide
 
 -- ============================================================================
 -- G. Bridge 5: CTPClass → ComplementSize ([egressy-2026])

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -1,8 +1,8 @@
 import Linglib.Semantics.Intensional.WorldTimeIndex
 import Linglib.Semantics.Modality.HistoricalAlternatives
-import Linglib.Semantics.Mood.IllocutionaryMood
-import Linglib.Semantics.Mood.POSW
-import Linglib.Semantics.Mood.POSWTarget
+import Linglib.Semantics.Mood.Illocutionary
+import Linglib.Semantics.Mood.Modal
+import Linglib.Semantics.Mood.Component
 import Linglib.Discourse.SpeechAct
 import Linglib.Semantics.Modality.Kratzer.Flavor
 import Linglib.Semantics.Modality.Directive
@@ -13,7 +13,7 @@ import Mathlib.Data.List.Sort
 import Linglib.Discourse.Commitment.Basic
 import Linglib.Semantics.Questions.Partition.QUD
 import Linglib.Semantics.Questions.PrecisionProjection
-import Linglib.Semantics.Mood.POSWQ
+import Linglib.Semantics.Mood.State
 
 /-!
 # Roberts (2023): Imperatives in Dynamic Pragmatics
@@ -49,7 +49,7 @@ standalone formalization of an imperative mood ontology:
   `TeleologicalFlavor` (no parallel types).
 - The architectural commitment "imperative force targets the
   preferential POSW component, not the informational" is
-  `Semantics.Mood.POSWTarget`'s `HasPOSWTarget IllocutionaryMood`
+  `Semantics.Mood.Component`'s `HasTarget Illocutionary`
   instance — Roberts agrees with [portner-2018] on the
   POSW component, disagrees with [kaufmann-2012] only on
   the prejacent's modal flavor.
@@ -85,12 +85,12 @@ Acc (accepted).
 
 namespace Discourse
 
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 /-- An illocutionary move: a speech act performed by an agent. -/
 structure Move (W : Type*) where
   /-- Which kind of speech act. -/
-  mood : IllocutionaryMood
+  mood : Illocutionary
   /-- Propositional content (for assertions and questions; for directions,
       the propositional closure of the targeted property). -/
   content : W → Prop
@@ -123,7 +123,7 @@ Force Linking Principle ([roberts-2023]).
 
 namespace Discourse
 
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 
 variable {W : Type*}
 
@@ -187,7 +187,7 @@ inductive SemanticType where
 
 /-- Illocutionary Force Linking Principle: the default illocutionary
     force of a root sentence is determined by its semantic type. -/
-def forceLinkingPrinciple : SemanticType → IllocutionaryMood
+def forceLinkingPrinciple : SemanticType → Illocutionary
   | .proposition       => .declarative
   | .setOfPropositions  => .interrogative
   | .indexedProperty    => .imperative
@@ -202,7 +202,7 @@ def forceLinkingPrinciple : SemanticType → IllocutionaryMood
     forceLinkingPrinciple .indexedProperty = .imperative := rfl
 
 /-- The default semantic type for each illocutionary mood (inverse of IFLP). -/
-def defaultSemanticType : IllocutionaryMood → SemanticType
+def defaultSemanticType : Illocutionary → SemanticType
   | .declarative   => .proposition
   | .interrogative  => .setOfPropositions
   | .imperative     => .indexedProperty
@@ -325,7 +325,7 @@ def directionUpdate (K : Scoreboard W) (p : W → Prop)
 
 The scoreboard's CommonGround and G components project jointly into a
 the POSW substrate (`Semantics.Dynamic.Default.ExpState` under its
-`Semantics/Mood/POSW.lean` modal reading): CommonGround via
+`Semantics/Mood/Modal.lean` modal reading): CommonGround via
 `contextSet`, G via the goal-induced preference ordering. Assertion ↔
 `assert`, direction ↔ `promote`. -/
 
@@ -438,16 +438,16 @@ theorem direction_demotes_violators (K : Scoreboard W) (p : W → Prop)
     (toExpState_direction_eq_promote K p s t pr hin w v).mp hlt
   exact hpw ((Core.Order.Normality.refine_le.mp hstar).2 hpv)
 
-/-! ### POSWQ inquiry-partition bridge
+/-! ### State inquiry-partition bridge
 
-QUD projects into POSWQ's inquiry partition: meet of polar Setoids
+QUD projects into State's inquiry partition: meet of polar Setoids
 over the QUD stack. Interrogation ↔ `inquire`. -/
 
 /-- Inquiry partition from the QUD stack: meet of polar Setoids
     (`⊤` as identity). Cons-right convention so that consing reduces
     definitionally to `inquire`. -/
 def qudInquiry (K : Scoreboard W) : Setoid W :=
-  K.qud.foldr (fun q s => s ⊓ Semantics.Mood.POSWQ.polarSetoid q) ⊤
+  K.qud.foldr (fun q s => s ⊓ Semantics.Mood.State.polarSetoid q) ⊤
 
 @[simp] theorem qudInquiry_nil (K : Scoreboard W) (h : K.qud = []) :
     K.qudInquiry = (⊤ : Setoid W) := by
@@ -456,8 +456,8 @@ def qudInquiry (K : Scoreboard W) : Setoid W :=
 @[simp] theorem qudInquiry_cons (K : Scoreboard W) (q : W → Prop)
     (rest : List (W → Prop)) (h : K.qud = q :: rest) :
     K.qudInquiry =
-      (rest.foldr (fun q s => s ⊓ Semantics.Mood.POSWQ.polarSetoid q) ⊤) ⊓
-        Semantics.Mood.POSWQ.polarSetoid q := by
+      (rest.foldr (fun q s => s ⊓ Semantics.Mood.State.polarSetoid q) ⊤) ⊓
+        Semantics.Mood.State.polarSetoid q := by
   simp [qudInquiry, h]
 
 /-- Interrogation update preserves goal contents (doesn't touch G). -/
@@ -465,28 +465,28 @@ def qudInquiry (K : Scoreboard W) : Setoid W :=
     (q : W → Prop) (a : Nat) :
     (K.interrogationUpdate q a).goalContents = K.goalContents := rfl
 
-/-- Project the scoreboard into a POSWQ: underlying state + QUD inquiry. -/
-def toPOSWQ (K : Scoreboard W) : Semantics.Mood.POSWQ W :=
+/-- Project the scoreboard into a State: underlying state + QUD inquiry. -/
+def toMoodState (K : Scoreboard W) : Semantics.Mood.State W :=
   { K.toExpState with inquiry := K.qudInquiry }
 
-@[simp] theorem toPOSWQ_toExpState (K : Scoreboard W) :
-    K.toPOSWQ.toExpState = K.toExpState := rfl
+@[simp] theorem toMoodState_toExpState (K : Scoreboard W) :
+    K.toMoodState.toExpState = K.toExpState := rfl
 
-@[simp] theorem toPOSWQ_inquiry (K : Scoreboard W) :
-    K.toPOSWQ.inquiry = K.qudInquiry := rfl
+@[simp] theorem toMoodState_inquiry (K : Scoreboard W) :
+    K.toMoodState.inquiry = K.qudInquiry := rfl
 
 /-- Interrogation-as-`?`-update bridge: `interrogationUpdate` refines
-    the projected POSWQ's `inquiry` exactly as `POSWQ.inquire` does. -/
-theorem toPOSWQ_interrogation_eq_inquire (K : Scoreboard W)
+    the projected State's `inquiry` exactly as `State.inquire` does. -/
+theorem toMoodState_interrogation_eq_inquire (K : Scoreboard W)
     (q : W → Prop) (a : Nat) :
-    (K.interrogationUpdate q a).toPOSWQ.inquiry =
-      (K.toPOSWQ.inquire (Semantics.Mood.POSWQ.polarSetoid q)).inquiry := rfl
+    (K.interrogationUpdate q a).toMoodState.inquiry =
+      (K.toMoodState.inquire (Semantics.Mood.State.polarSetoid q)).inquiry := rfl
 
 /-- After posing `q`, the polar partition of `q` is settled by
-    the new POSWQ (inquiry analogue of `boxCs_after_assertion`). -/
+    the new State (inquiry analogue of `boxCs_after_assertion`). -/
 theorem boxAns_polar_after_interrogation (K : Scoreboard W)
     (q : W → Prop) (a : Nat) :
-    (K.interrogationUpdate q a).toPOSWQ.boxAns q := by
+    (K.interrogationUpdate q a).toMoodState.boxAns q := by
   intro w v _ _ hwv
   exact hwv.2
 
@@ -498,8 +498,8 @@ namespace Roberts2023
 
 open Intensional (WorldTimeIndex)
 open Discourse (forceLinkingPrinciple defaultSemanticType Scoreboard)
-open Semantics.Mood.IllocutionaryMood (sincerityCondition)
-open Semantics.Mood (POSWQ POSWTarget IllocutionaryMood HasPOSWTarget)
+open Semantics.Mood.Illocutionary (sincerityCondition)
+open Semantics.Mood (State Component Illocutionary HasTarget)
 open Semantics.Dynamic.Default (ExpState)
 open HistoricalAlternatives
 open Semantics.Modality.Kratzer
@@ -563,12 +563,12 @@ def ImperativeCharacter.conservativeOn {W : Type*}
 Roberts's central architectural claim is that the deontic flavor of
 imperatives is **pragmatic** — it lives in the preferential POSW
 component (the addressee's goals/plans), not in the LF as a deontic
-modal. This is precisely the [portner-2018] `POSWTarget`
-assignment for `IllocutionaryMood.imperative`, derived (not
+modal. This is precisely the [portner-2018] `Component`
+assignment for `Illocutionary.imperative`, derived (not
 restipulated) here. -/
 
 /-- **Roberts's architectural commitment**, derived from
-    [portner-2018]'s `HasPOSWTarget IllocutionaryMood`
+    [portner-2018]'s `HasTarget Illocutionary`
     instance: the imperative targets the preferential POSW
     component (= the addressee's preference structure), not the
     informational component (= CommonGround).
@@ -579,7 +579,7 @@ restipulated) here. -/
     (via `ExpState.promote` / `Scoreboard.directionUpdate`) rather
     than the informational one. -/
 theorem imperative_targets_preferential :
-    HasPOSWTarget.target IllocutionaryMood.imperative = .preferential := rfl
+    HasTarget.target Illocutionary.imperative = .preferential := rfl
 
 /-- **Pragmatic-deontic routing** ([roberts-2023] §3, headline claim).
 
@@ -600,7 +600,7 @@ theorem imperative_targets_preferential :
     the addressee must be a real participant for the directive to
     have its preferential effect. Composes
     `Scoreboard.direction_demotes_violators` (the substrate theorem
-    that does the work) with the POSWTarget assignment
+    that does the work) with the Component assignment
     `imperative_targets_preferential` (the architectural commitment
     that this preference-side change *is* the deontic content). -/
 theorem pragmatic_deontic_routing
@@ -626,7 +626,7 @@ theorem futurate {W T : Type*} [LT T]
 
 /-! ## §2.2 Force Linking — integration tests
 
-These are smoke tests that the `IllocutionaryMood` infrastructure
+These are smoke tests that the `Illocutionary` infrastructure
 agrees with Roberts's IFLP and her sincerity-condition triad.
 Each `rfl` is a structural check that the `Scoreboard` enum
 assignment matches the paper. -/

--- a/Linglib/Studies/Rudin2025LI.lean
+++ b/Linglib/Studies/Rudin2025LI.lean
@@ -99,7 +99,7 @@ simultaneously be both values.
 namespace Discourse.QuotationFBOntology
 
 open Discourse.Commitment.Table
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 open Semantics.Quotation.Demonstration
 
 -- ════════════════════════════════════════════════════
@@ -118,7 +118,7 @@ inductive Volume where
     update. -/
 structure FBPerformance (W : Type*) where
   /-- Sentence form (declarative / interrogative). -/
-  form : IllocutionaryMood
+  form : Illocutionary
   /-- Propositional content. -/
   content : Set W
   /-- Whether the performance is linguistic material. False allows

--- a/Linglib/Studies/RuytenbeekEtAl2017.lean
+++ b/Linglib/Studies/RuytenbeekEtAl2017.lean
@@ -77,10 +77,10 @@ regression coefficients.
 
 ## Mood substrate choice
 
-This file uses `Semantics.Mood.IllocutionaryMood` rather than the
+This file uses `Semantics.Mood.Illocutionary` rather than the
 Minimalist-derived `SAPMood`. The two are isomorphic on the
 declarative/interrogative/imperative cases used here, and
-`IllocutionaryMood` is the canonical substrate (`SAPMood` adds
+`Illocutionary` is the canonical substrate (`SAPMood` adds
 syntax-derivation machinery the paper does not invoke). This also
 keeps the file independent of the Minimalist substrate.
 -/
@@ -88,7 +88,7 @@ keeps the file independent of the Minimalist substrate.
 namespace RuytenbeekEtAl2017
 
 open Semantics.Modality (ModalFlavor ModalForce)
-open Semantics.Mood (IllocutionaryMood)
+open Semantics.Mood (Illocutionary)
 open Semantics.Modality.Assert (primaryFlavor)
 
 /-! ### Sentence types and modal projections -/
@@ -132,7 +132,7 @@ inductive SentType where
   deriving DecidableEq, Repr
 
 /-- Morphosyntactic mood of each sentence type. -/
-def SentType.mood : SentType → IllocutionaryMood
+def SentType.mood : SentType → Illocutionary
   | .imperative       => .imperative
   | .canYouInterrog   => .interrogative
   | .possibleInterrog => .interrogative
@@ -362,7 +362,7 @@ the existence of force–type mismatch witnesses below. -/
     interpretation. The five mismatch cases (`mustDeclarative`,
     `canDeclarative`, `possibleDecl`, `canYouInterrog`,
     `possibleInterrog`) all instantiate this. -/
-abbrev SentType.forceTypeMismatch (s : SentType) (m : IllocutionaryMood) : Prop :=
+abbrev SentType.forceTypeMismatch (s : SentType) (m : Illocutionary) : Prop :=
   s.mood = m ∧ s.isDirective
 
 /-- The literalist Searle default for declarative mood is
@@ -370,7 +370,7 @@ abbrev SentType.forceTypeMismatch (s : SentType) (m : IllocutionaryMood) : Prop 
     consequence "declarative-mood utterances cannot carry directive
     force" (witnessed by `anti_literalism_for_declaratives`). -/
 theorem declarative_default_searleClass :
-    IllocutionaryMood.declarative.searleClass = .assertive := rfl
+    Illocutionary.declarative.searleClass = .assertive := rfl
 
 /-- Anti-literalism witness: there is a sentence type whose
     morphosyntactic mood is declarative yet which licenses directive

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -9,7 +9,7 @@ import Linglib.Syntax.Minimalist.Phase.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Semantics.Context.Tower
 import Linglib.Discourse.Roles
-import Linglib.Semantics.Mood.IllocutionaryMood
+import Linglib.Semantics.Mood.Illocutionary
 import Linglib.Semantics.Mood.ClauseType
 import Linglib.Semantics.Epistemicity
 import Linglib.Features.Evidentiality
@@ -44,7 +44,7 @@ the content.
 - **Phase.lean**: `isPhaseHeadOf .SA` — SAP is the highest phase.
 - **ExtendedProjection/Basic.lean**: `fValue .SA = 7 > fValue .C = 6`.
 - **Semantics/Mood/ClauseType.lean**: the configurational seat-of-knowledge
-  *diverges* from Lakoff's deontic `moodAuthority` on imperatives
+  *diverges* from Lakoff's deontic `Illocutionary.authority` on imperatives
   (`seatOfKnowledge_diverges_from_authority_on_imperative`).
 - **Semantics/Epistemicity.lean**: EvalP-spec → `EpistemicProfile.authority`,
   EvidP-spec → `EpistemicProfile.source`; S&T's seat is the speech-act-
@@ -60,7 +60,7 @@ namespace SpeasTenny2003
 
 open Minimalist
 open Semantics.Context (KContext ContextTower ContextShift)
-open Semantics.Mood (IllocutionaryMood ClauseType)
+open Semantics.Mood (Illocutionary ClauseType)
 open Semantics.Epistemicity (EpistemicAuthority EpistemicProfile)
 
 /-! ### Pragmatic roles -/
@@ -141,7 +141,7 @@ theorem features_deriveMood (f h : Bool) :
     - `.imperative`    → ⟨imperative, indicative⟩  (mood often neutralized)
     - `.subjunctive`   → ⟨declarative, subjunctive⟩
 
-    The subjunctive mapping is a *lossy placeholder*: `IllocutionaryMood` has
+    The subjunctive mapping is a *lossy placeholder*: `Illocutionary` has
     no token for S&T's configurational subjunctive (Latin promise/wish/jussive;
     the speaker is "responsible for choosing the preferred world", p.335), so
     the force component falls back to `.declarative`. (The earlier `.promissive`
@@ -155,7 +155,7 @@ def SAPMood.toClauseType : SAPMood → ClauseType
   | .subjunctive    => { force := .declarative,   mood := .subjunctive }
 
 /-- Convenience projection: SAPMood's illocutionary force component. -/
-def SAPMood.toForce (m : SAPMood) : IllocutionaryMood :=
+def SAPMood.toForce (m : SAPMood) : Illocutionary :=
   m.toClauseType.force
 
 /-! ### Seat of knowledge (derived) -/
@@ -193,7 +193,7 @@ def PRole.toEpistemicAuthority : PRole → EpistemicAuthority
   | .seatOfKnowledge => .ego
 
 /-- **Divergence (the empirical content).** S&T's configurational
-    seat-of-knowledge and Lakoff's deontic `moodAuthority`
+    seat-of-knowledge and Lakoff's deontic `Illocutionary.authority`
     ([lakoff-1970], via `ClauseType.authority`) DISAGREE on imperatives:
     S&T locate the seat with the HEARER (who must realize the unrealized
     proposition, p.335), Lakoff with the SPEAKER (who has authority to

--- a/Linglib/Studies/Stalnaker1975.lean
+++ b/Linglib/Studies/Stalnaker1975.lean
@@ -182,7 +182,7 @@ end Discourse.ReasonableInference
 
 namespace Stalnaker1975
 
-open Semantics.Mood (GramMood)
+open Semantics.Mood (Grammatical)
 open CommonGround (ContextSet)
 open _root_.Semantics.Conditionals (SelectionFunction)
 open Semantics.Conditionals

--- a/Linglib/Studies/TheilerRoelofsenAloni2018.lean
+++ b/Linglib/Studies/TheilerRoelofsenAloni2018.lean
@@ -36,7 +36,7 @@ example from Section 3.1, which justifies the existence of
    *no* `Setoid W` produces this content via `fromSetoid`.
 
    This is the forcing theorem for the architectural decision in the
-   "Architectural note" docstring of `Semantics/Mood/POSWQ.lean` (added
+   "Architectural note" docstring of `Semantics/Mood/State.lean` (added
    0.229.922) — it shows that `Setoid → Question` is a
    strictly weaker representation, and so the sibling-structure
    architecture is necessary rather than redundant.

--- a/Linglib/Syntax/Clause/Context.lean
+++ b/Linglib/Syntax/Clause/Context.lean
@@ -4,7 +4,7 @@
 This file defines `Clause.Context`, the [sadock-zwicky-1985] sentence types
 with the interrogative split into polar, alternative, and constituent
 subtypes. `Clause.Embedding` is the orthogonal embedding axis;
-`Semantics.Mood.IllocutionaryMood`, `Semantics.Mood.ClauseType`, and
+`Semantics.Mood.Illocutionary`, `Semantics.Mood.ClauseType`, and
 `Features.ClauseForm` are coarser cuts.
 -/
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -2684,7 +2684,7 @@
   url       = {http://www.cssp.cnrs.fr/eiss9/eiss9_condoravdi-and-lauer.pdf},
   subfield  = {pragmatics/assertion},
   role      = {formalized},
-  sources   = {Core/Order/PreferenceStructure.lean;Core/Order/PreferenceStructure/EffectivePreference.lean;Semantics/Attitudes/CondoravdiLauer.lean;Studies/CondoravdiLauer2012.lean;Semantics/Mood/POSW.lean}
+  sources   = {Core/Order/PreferenceStructure.lean;Core/Order/PreferenceStructure/EffectivePreference.lean;Semantics/Attitudes/CondoravdiLauer.lean;Studies/CondoravdiLauer2012.lean;Semantics/Mood/Modal.lean}
 }
 @article{condoravdi-lauer-2016,
   author    = {Condoravdi, Cleo and Lauer, Sven},
@@ -2909,7 +2909,7 @@
   subfield  = {pragmatics/assertion},
   validated = {true},
   role      = {formalized},
-  sources   = {Discourse/Commitment/SourceMarked.lean;Semantics/Mood/POSW.lean;Discourse/CommonGround.lean}
+  sources   = {Discourse/Commitment/SourceMarked.lean;Semantics/Mood/Modal.lean;Discourse/CommonGround.lean}
 }% REF: Stalnaker, R. (1981). A Defense of Conditional Excluded Middle.
 @incollection{stalnaker-1981,
   author    = {Stalnaker, Robert C.},
@@ -9002,7 +9002,7 @@
   series    = {Oxford Surveys in Semantics and Pragmatics},
   subfield  = {semantics/modality},
   role      = {foundational},
-  sources   = {Semantics/Mood/POSW.lean}
+  sources   = {Semantics/Mood/Modal.lean}
 }
 @unpublished{farkas-2003,
   author    = {Farkas, Donka F.},
@@ -9011,7 +9011,7 @@
   note      = {Paper presented at the workshop on Conditional and Unconditional Modality, ESSLLI, Vienna},
   subfield  = {semantics/modality},
   role      = {cited},
-  sources   = {Semantics/Mood/POSW.lean}
+  sources   = {Semantics/Mood/Modal.lean}
 }
 @article{portner-1997,
   author    = {Portner, Paul},
@@ -9023,7 +9023,7 @@
   doi       = {10.1023/A:1008280630142},
   subfield  = {semantics/modality},
   role      = {cited},
-  sources   = {Semantics/Mood/VerbalMood.lean}
+  sources   = {Semantics/Mood/Verbal.lean}
 }
 @book{farkas-1985,
   author    = {Farkas, Donka F.},
@@ -9033,7 +9033,7 @@
   address   = {New York},
   subfield  = {semantics/modality},
   role      = {cited},
-  sources   = {Semantics/Mood/VerbalMood.lean}
+  sources   = {Semantics/Mood/Verbal.lean}
 }
 @book{giorgi-pianesi-1997,
   author    = {Giorgi, Alessandra and Pianesi, Fabio},
@@ -9043,7 +9043,7 @@
   address   = {New York},
   subfield  = {semantics/tense},
   role      = {cited},
-  sources   = {Semantics/Mood/VerbalMood.lean}
+  sources   = {Semantics/Mood/Verbal.lean}
 }
 @book{bratman-1987,
   author    = {Bratman, Michael E.},


### PR DESCRIPTION
Mechanical rename batch; no semantic changes (438+/438−, whole affected cone builds green).

- De-acronym: `POSWQ` → `Mood.State`, `POSWTarget` → `Mood.Component` (case `partition` → `inquisitive`), `HasPOSWTarget` → `Mood.HasTarget`; files → `Mood/{Modal,State,Component}.lean`. Portner's "POSW"/"pposw" remain as cited vocabulary in docstrings.
- De-stutter: `Mood/Verbal.lean` (`Mood.VerbalOp`), `Mood/Illocutionary.lean` (`Mood.Illocutionary`), `GramMood` → `Mood.Grammatical`, `MoodSelector`/`MoodEffect` → `Mood.Selector`/`Mood.Effect`, `moodAuthority` → `Illocutionary.authority`.