### PR TITLE
refactor(Semantics/Mood): split Basic.lean; derive Effect from operators

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1757,9 +1757,9 @@ import Linglib.Semantics.Modification.Basic
 import Linglib.Semantics.Modification.RelativeClause
 import Linglib.Semantics.Mood.Categories
 import Linglib.Semantics.Mood.ClauseType
+import Linglib.Semantics.Mood.Component
 import Linglib.Semantics.Mood.Dynamic
 import Linglib.Semantics.Mood.Eventuality
-import Linglib.Semantics.Mood.Component
 import Linglib.Semantics.Mood.Illocutionary
 import Linglib.Semantics.Mood.Modal
 import Linglib.Semantics.Mood.PartitionAsInquiry

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1755,14 +1755,15 @@ import Linglib.Semantics.Modality.TemporalConstraint
 import Linglib.Semantics.Modality.Typology
 import Linglib.Semantics.Modification.Basic
 import Linglib.Semantics.Modification.RelativeClause
-import Linglib.Semantics.Mood.Basic
 import Linglib.Semantics.Mood.Categories
 import Linglib.Semantics.Mood.ClauseType
 import Linglib.Semantics.Mood.Dynamic
+import Linglib.Semantics.Mood.Eventuality
 import Linglib.Semantics.Mood.Component
 import Linglib.Semantics.Mood.Illocutionary
 import Linglib.Semantics.Mood.Modal
 import Linglib.Semantics.Mood.PartitionAsInquiry
+import Linglib.Semantics.Mood.Situation
 import Linglib.Semantics.Mood.State
 import Linglib.Semantics.Mood.Verbal
 import Linglib.Semantics.NaturalLogic

--- a/Linglib/Semantics/Attitudes/Representationality.lean
+++ b/Linglib/Semantics/Attitudes/Representationality.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Attitudes.Doxastic
 import Linglib.Semantics.Attitudes.Preferential
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 
 /-!
 # Representationality and Epistemic Licensing

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Conditionals.Basic
 import Linglib.Semantics.Conditionals.SelectionFunction
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 import Linglib.Core.Order.SimilarityOrdering
 import Linglib.Discourse.CommonGround
 

--- a/Linglib/Semantics/Modality/Exclusion.lean
+++ b/Linglib/Semantics/Modality/Exclusion.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Context.Tower
 import Linglib.Semantics.Context.Shifts
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Situation
 
 /-!
 # Exclusion features and X/O-marking strategies

--- a/Linglib/Semantics/Mood/Categories.lean
+++ b/Linglib/Semantics/Mood/Categories.lean
@@ -1,7 +1,8 @@
 /-!
-# Grammatical Mood
+# Grammatical Mood Categories
 
-Morphological mood categories: indicative vs subjunctive (and subtypes).
+Morphological mood categories (indicative vs subjunctive, with
+subtypes) and the lexical classification of mood-selecting predicates.
 
 This is the verb-morphological distinction, independent of:
 - `Illocutionary` (declarative/interrogative/imperative — speech act force)
@@ -11,14 +12,20 @@ The two dimensions are orthogonal: a clause can be
 [interrogative, indicative] ("Does he sleep?") or
 [interrogative, subjunctive] (Spanish "¿Que duerma?").
 
-See `Semantics/Mood/Basic.lean` for the semantic operators (SUBJ, IND)
-that interpret these categories.
+The semantic content of these categories lives downstream:
+situation-level operators in `Semantics/Mood/Situation.lean`
+([mendes-2025]: SUBJ introduces a situation dref, IND retrieves),
+event-level operators in `Semantics/Mood/Eventuality.lean`
+([grano-2024]: `Grammatical.eventDenotation` — indicative closes the
+event argument, subjunctive leaves it open), and the dynamic lifts in
+`Semantics/Mood/Dynamic.lean` (`Grammatical.dynOp` — indicative
+eliminative, subjunctive generative).
 
-This file lives in `Semantics/Mood/` alongside `Illocutionary.lean` (force) and
-`ClauseType.lean` (force × mood); together they form the unified mood-category
-namespace `Semantics.Mood`. Discourse-act material (Searle classes, direction of
-fit, preparatory conditions, discourse roles) lives in
-`Discourse/SpeechAct.lean`.
+This file lives in `Semantics/Mood/` alongside `Illocutionary.lean`
+(force) and `ClauseType.lean` (force × mood); together they form the
+unified mood-category namespace `Semantics.Mood`. Discourse-act
+material (Searle classes, direction of fit, preparatory conditions,
+discourse roles) lives in `Discourse/SpeechAct.lean`.
 -/
 
 namespace Semantics.Mood
@@ -53,44 +60,23 @@ inductive SubjunctiveType where
   deriving DecidableEq, Repr
 
 /--
-The semantic effects of grammatical mood, connecting two independent dimensions:
+Mood selection by embedding predicates.
 
-- **Situation-level** ([mendes-2025]): SUBJ introduces a new situation dref;
-  IND retrieves an existing one
-- **Eventuality-level** ([grano-2024]): SBJV leaves the complement's eventuality
-  argument open for abstraction; IND existentially closes it
+Certain predicates select for specific moods in their complement:
+- "know", "see" → typically indicative
+- "want", "wish" → robustly subjunctive cross-linguistically
+- "hope" → cross-linguistically variable ([grano-2024], Table 1)
+- "say", "think" → mood-neutral (pragmatically flexible)
 
-These dimensions are complementary: situation introduction enables temporal
-anchoring (SF in Portuguese/Spanish), while eventuality openness enables
-abstraction over the event argument (required by causatives, intention reports,
-aspectual predicates, and memory/perception reports).
+The projection onto the semantic operators is
+`Selector.toVerbalOp` (`Semantics/Mood/Verbal.lean`).
 -/
-structure Effect where
-  /-- SUBJ introduces a new situation dref ([mendes-2025]) -/
-  introducesSituation : Bool
-  /-- SBJV leaves the eventuality argument open for abstraction ([grano-2024]) -/
-  eventualityOpen : Bool
+inductive Selector where
+  | indicativeSelecting          -- "know", "see", "believe"
+  | subjunctiveSelecting         -- "want", "wish", "demand", "intend"
+  | crossLinguisticallyVariable  -- "hope", "expect": SBJV in some languages,
+                                 -- IND in others ([grano-2024], Table 1)
+  | moodNeutral                  -- "say", "think" (pragmatically flexible)
   deriving DecidableEq, Repr
-
-/-- Map grammatical mood to its semantic effects.
-
-    Indicative mood does neither: it retrieves an existing situation and
-    existentially closes the eventuality argument.
-
-    Subjunctive mood does both: it introduces a new situation dref and
-    leaves the eventuality argument open for abstraction. -/
-def Grammatical.effect : Grammatical → Effect
-  | .indicative  => { introducesSituation := false, eventualityOpen := false }
-  | .subjunctive => { introducesSituation := true,  eventualityOpen := true }
-
-/-- Indicative mood closes the eventuality argument. -/
-theorem ind_closes_eventuality : Grammatical.indicative.effect.eventualityOpen = false := rfl
-
-/-- Subjunctive mood leaves the eventuality argument open. -/
-theorem subj_opens_eventuality : Grammatical.subjunctive.effect.eventualityOpen = true := rfl
-
-/-- Indicative and subjunctive differ on both dimensions. -/
-theorem mood_effects_differ :
-    Grammatical.indicative.effect ≠ Grammatical.subjunctive.effect := by decide
 
 end Semantics.Mood

--- a/Linglib/Semantics/Mood/ClauseType.lean
+++ b/Linglib/Semantics/Mood/ClauseType.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 import Linglib.Semantics.Mood.Illocutionary
 import Linglib.Discourse.Roles
 import Linglib.Data.UD.Basic

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Dynamic.Core.ContextFilter
 import Linglib.Semantics.Modality.HistoricalAlternatives
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Situation
+import Linglib.Semantics.Mood.Categories
 
 /-!
 # Dynamic Mood as Eliminative + Generative Updates of Static Mood
@@ -8,7 +9,7 @@ import Linglib.Semantics.Mood.Basic
 [de-groote-2006] [charlow-2021] [mendes-2025]
 
 `dynIND` and `dynSUBJ` are the dynamic-context-update counterparts of
-the static `Mood.IND` and `Mood.SUBJ` operators in `Mood/Basic.lean`.
+the static `Mood.IND` and `Mood.SUBJ` operators in `Mood/Situation.lean`.
 Together they instantiate the two basic operations of the powerset
 monad on situation contexts:
 
@@ -42,7 +43,7 @@ of dynamic semantics:
   is `Set.bind` (Kleisli composition).
 
 `Semantics.Mood.IND` and `Semantics.Mood.SUBJ` (defined in
-`Mood/Basic.lean`) call the same two kernels (`sameWorld` and
+`Mood/Situation.lean`) call the same two kernels (`sameWorld` and
 `historicalBase`) directly. The static and dynamic faces share *one
 modal constraint and one alternative-generator*, lifted from a
 state-level predicate to a context-level operation.
@@ -66,7 +67,7 @@ vacuous — the algebraic fact that a `dynRelationOn` filter is
 trivially satisfied after the projections it compares are forced
 equal by the preceding `dynIntroduce`.
 
-Sibling of `Mood/Basic.lean` and `Tense/Dynamic.lean`. Used by
+Sibling of `Mood/Situation.lean` and `Tense/Dynamic.lean`. Used by
 `Studies/Mendes2025.lean` (which hosts the SF
 operator and the modal donkey anaphora chain that consumes
 `dynSUBJ`/`dynIND`).
@@ -256,6 +257,47 @@ theorem dynSUBJ_realizes_SUBJ {W Time : Type*} [LE Time]
     refine ⟨(Function.update g v s₁, s₁), ?_, ?_⟩
     · exact ⟨g, s₀, s₁, rfl, h_hist, rfl, rfl⟩
     · simp only [Function.update_self]; exact h_P
+
+/-!
+### Mood as update polarity, by assignment
+
+`Grammatical.dynOp` assigns each grammatical mood its dynamic
+operator. The eliminative/generative contrast — indicative *tests*
+(a context filter), subjunctive *introduces* (a fresh dref) — is then
+a pair of theorems about the assignment, not a stipulated feature:
+this replaces the former `Effect.introducesSituation` table. -/
+
+/-- The dynamic operator each grammatical mood denotes: indicative the
+    eliminative `dynIND`, subjunctive the generative `dynSUBJ`. The
+    assignment is the theory's sole stipulation; its polarity facts
+    (`dynOp_indicative_isFilter`, `dynOp_subjunctive_introduces`)
+    follow. -/
+def Grammatical.dynOp {W Time : Type*} [LE Time]
+    (history : HistoricalAlternatives W Time) :
+    Grammatical → SVar → SitContext W Time → SitContext W Time
+  | .indicative  => dynIND
+  | .subjunctive => dynSUBJ history
+
+/-- Indicative's dynamic operator is eliminative: a context filter.
+    Half of the polarity contrast formerly stipulated as
+    `introducesSituation := false`. -/
+theorem dynOp_indicative_isFilter {W Time : Type*} [LE Time]
+    (history : HistoricalAlternatives W Time) (v : SVar) :
+    IsContextFilter (α := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+      (Grammatical.indicative.dynOp history v) :=
+  dynIND_isFilter v
+
+/-- Subjunctive's dynamic operator is generative: every output entry
+    carries a freshly introduced situation from the historical base,
+    bound to `v`. Half of the polarity contrast formerly stipulated as
+    `introducesSituation := true`. -/
+theorem dynOp_subjunctive_introduces {W Time : Type*} [LE Time]
+    (history : HistoricalAlternatives W Time) (v : SVar)
+    (c : SitContext W Time)
+    (gs : Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+    (h : gs ∈ Grammatical.subjunctive.dynOp history v c) :
+    gs.1 v = gs.2 ∧ ∃ s₀, (∃ g₀, (g₀, s₀) ∈ c) ∧ gs.2 ∈ historicalBase history s₀ :=
+  ⟨dynSUBJ_binds_current history v c gs h, dynSUBJ_existential history v c gs h⟩
 
 /--
 IND is identity after SUBJ on the same variable.

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -1,0 +1,119 @@
+import Mathlib.Tactic.TypeStar
+import Linglib.Semantics.Mood.Categories
+
+/-!
+# Event-Level Mood Operators
+[grano-2024]
+
+[grano-2024] proposes that mood morphemes operate on the eventuality
+argument of the complement clause: indicative existentially closes it
+(`INDev`, his (87)), yielding a proposition; subjunctive leaves it
+open for abstraction (`SBJVev₁`, his (88a)), as required by
+causatives, intention reports, aspectual predicates, and
+memory/perception reports; the *intend* variant additionally requires
+causal self-reference (`SBJVev₂`, his (134)). This is the event-level
+dimension of grammatical mood, complementary to the situation-level
+dimension of `Semantics/Mood/Situation.lean`.
+
+The closed/open contrast is carried by the *type* of the denotation.
+`Grammatical.eventDenotation` assigns each mood its operator, landing
+in the constructor-distinguished `EventDenotation`; that indicative
+closes and subjunctive abstracts is then read off the constructor
+(`eventDenotation_indicative`, `eventDenotation_subjunctive`) rather
+than stipulated in a feature table.
+-/
+
+namespace Semantics.Mood
+
+/-- IND existentially closes the eventuality argument ([grano-2024], (87)).
+
+    ⟦INDIC⟧ = λP_(⟨vt⟩).∃e.P(e)
+
+    The eventuality variable is bound; the complement denotes a proposition. -/
+def INDev {Event : Type*} (P : Event → Prop) : Prop := ∃ e, P e
+
+/-- SBJV₁ leaves the eventuality argument open ([grano-2024], (88a);
+    §7 Subjunctive₃ (135)).
+
+    ⟦SBJV₁⟧ = λP_(⟨vt⟩).P
+
+    The complement retains type ⟨vt⟩ — an event predicate, not a proposition.
+    In the core proposal (§5, (88a)), this is the general non-closing mood
+    operator. In the §7 unified theory, it becomes specifically Subjunctive₃
+    (135) — the identity variant for perception predicates ('see'), causative
+    predicates ('make'), and aspectual predicates ('begin'). These predicates
+    require or are compatible with eventuality abstraction but do not involve
+    causal self-reference or ordering semantics. Distinct from the 'want'
+    variant (§7, Subjunctive₁ (133)), which uses Portner & Rubinstein's `ln`
+    (local necessity), and the 'intend' variant (Subjunctive₂ (134) =
+    `SBJVev₂`), which incorporates CAUSE*. -/
+def SBJVev₁ {Event : Type*} (P : Event → Prop) : Event → Prop := P
+
+/-- SBJV₂ leaves the eventuality argument open AND requires causal
+    self-reference ([grano-2024], (134); unified theory §7).
+
+    ⟦Subjunctive₂⟧ = λPλe[sn({λw.∃e'.CAUSE*(e,e',w) & P(w)(e')}, content(e), e)]
+
+    This is the variant operative with 'intend' in the §7 unified theory,
+    which integrates CAUSE* from the core proposal (§4, (79)) with Portner
+    & Rubinstein's ([portner-rubinstein-2020]) modal quantification
+    framework. The attitude state e must causally bring about the described
+    event e' "in the right way" ([searle-1983]; [harman-1976]). -/
+def SBJVev₂ {Event W : Type*}
+    (causeStar : Event → Event → W → Prop)  -- CAUSE*(state, event, world)
+    (content : Event → W → Prop)          -- content of the attitude state
+    (P : W → Event → Prop)               -- world-indexed event predicate
+    (e : Event) : Prop :=
+  ∀ w, content e w → ∃ e', causeStar e e' w ∧ P w e'
+
+/-- IND closure yields a proposition (no free eventuality variable). -/
+theorem INDev_is_propositional {Event : Type*} (P : Event → Prop) :
+    (INDev P) = (∃ e, P e) := rfl
+
+/-- SBJV₁ is the identity on event predicates. -/
+theorem SBJVev₁_is_identity {Event : Type*} (P : Event → Prop) :
+    SBJVev₁ P = P := rfl
+
+/-! ### Mood as event closure, by constructor
+
+The result of applying a mood's event operator: either a *closed*
+proposition (the event argument is bound) or an *abstracted* event
+predicate (the argument remains open). The closed/open distinction is
+the constructor, so downstream facts about which moods enable
+eventuality abstraction are read off `Grammatical.eventDenotation`
+rather than stipulated. -/
+
+/-- The result of a mood's event-level denotation: a proposition with
+    the event argument closed, or an event predicate with the argument
+    still open for abstraction. -/
+inductive EventDenotation (Event : Type*) where
+  /-- The event argument has been existentially closed. -/
+  | closed (p : Prop)
+  /-- The event argument remains open for abstraction. -/
+  | abstracted (p : Event → Prop)
+
+/-- The event-level denotation each grammatical mood assigns to a
+    complement's event predicate ([grano-2024]): indicative applies
+    `INDev` (closing), subjunctive applies `SBJVev₁` (abstracting).
+    This assignment is the theory's sole stipulation; openness facts
+    follow from the constructors. -/
+def Grammatical.eventDenotation {Event : Type*} (P : Event → Prop) :
+    Grammatical → EventDenotation Event
+  | .indicative  => .closed (INDev P)
+  | .subjunctive => .abstracted (SBJVev₁ P)
+
+/-- Indicative closes the event argument: its denotation lands in
+    `closed`. The formal correlate of [grano-2024]'s premise that
+    indicative complements cannot feed CAUSE* or aspectual operators
+    that bind the event variable. -/
+@[simp] theorem eventDenotation_indicative {Event : Type*} (P : Event → Prop) :
+    Grammatical.indicative.eventDenotation P = .closed (∃ e, P e) := rfl
+
+/-- Subjunctive leaves the event argument open: its denotation lands in
+    `abstracted`, with the predicate unchanged. The formal correlate of
+    [grano-2024]'s premise that subjunctive complements feed
+    eventuality abstraction. -/
+@[simp] theorem eventDenotation_subjunctive {Event : Type*} (P : Event → Prop) :
+    Grammatical.subjunctive.eventDenotation P = .abstracted P := rfl
+
+end Semantics.Mood

--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -1,44 +1,33 @@
-/-
-# Mood Semantics
-
-Semantic operators for grammatical mood (IND, SUBJ), operating at two
-independent levels:
-
-## Two Dimensions of Mood
-
-**Situation-level** ([mendes-2025]): Mood operators function like
-determiners for situations:
-- **SUBJ**: Introduces a new situation dref (like indefinite "a")
-- **IND**: Retrieves/uses an existing situation (like definite "the")
-
-**Event-level** ([grano-2024]): Mood morphemes existentially close
-or leave open the complement clause's eventuality argument:
-- **IND**: ∃e.P(e) — existentially closes, yielding a proposition
-- **SBJV₁**: P — leaves open, enabling eventuality abstraction
-- **SBJV₂**: P + CAUSE* — leaves open with causal self-reference (intentions)
-
-These dimensions are complementary: situation introduction enables temporal
-anchoring, while eventuality openness enables abstraction (required by
-causatives, intention reports, aspectual predicates, memory/perception reports).
-
-## Subordinate Future
-
-The "Subordinate Future" (SF) in Portuguese/Spanish:
-- Uses present morphology for future reference in subordinate contexts
-- Is actually **subjunctive** - introduces a situation dref
-- This dref is retrieved by the main clause for temporal anchoring
-
-## CDRT Connection
-
-In CDRT, these operators compose dynamically:
-- SUBJ introduces a situation variable and updates the context
-- IND retrieves a situation from the context
-
--/
-
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Context.Shifts
-import Linglib.Semantics.Mood.Categories
+
+/-!
+# Situation-Level Mood Operators
+[mendes-2025]
+
+[mendes-2025]'s mood operators work like determiners for situations:
+`SUBJ` introduces a new situation dref constrained to the historical
+alternatives of the anchor (like indefinite *a*), `IND` retrieves an
+existing situation and tests same-worldhood (like definite *the*).
+This is the situation-level dimension of grammatical mood — see
+`Semantics/Mood/Eventuality.lean` for the complementary event-level
+dimension ([grano-2024]) and `Semantics/Mood/Dynamic.lean` for the
+dynamic lifts (`dynSUBJ` generative, `dynIND` eliminative).
+
+The Subordinate Future (SF) of Portuguese/Spanish — present morphology
+with future reference in subordinate contexts — is [mendes-2025]'s
+main application: SF is subjunctive, introducing a future situation
+dref that the main clause retrieves for temporal anchoring
+(`conditionalSF`).
+
+## Main declarations
+
+* `SitPred`, `sameWorld` — situation predicates and the modal kernel.
+* `SUBJ`, `IND` — the situation-level mood operators.
+* `conditionalSF` — the SF conditional.
+* `nonVeridical`, `subj_nonveridical` — subjunctive non-veridicality.
+* `subjShift`, `subj_as_tower_push` — SUBJ as a tower context shift.
+-/
 
 namespace Semantics.Mood
 
@@ -107,103 +96,6 @@ def IND {W Time : Type*}
     (P : SitPred W Time)
     (s₁ s₂ : WorldTimeIndex W Time) : Prop :=
   sameWorld s₂ s₁ ∧ P s₂ s₁
-
--- ════════════════════════════════════════════════════════════════
--- § Event-Level Mood Operators ([grano-2024])
--- ════════════════════════════════════════════════════════════════
-
-/-!
-### Mood as Event Closure
-
-[grano-2024] proposes that mood morphemes operate on the eventuality
-argument of the complement clause:
-
-- **IND**: existentially closes the eventuality argument (87),
-  yielding a proposition
-- **SBJV₁**: leaves the eventuality argument open (88a),
-  yielding an event predicate (identity function)
-- **SBJV₂**: leaves the eventuality argument open AND requires
-  causal self-reference (134), for intention reports
-
-This is independent of — and complementary to — the situation-level
-SUBJ/IND operators defined above.
--/
-
-/-- IND existentially closes the eventuality argument ([grano-2024], (87)).
-
-    ⟦INDIC⟧ = λP_(⟨vt⟩).∃e.P(e)
-
-    The eventuality variable is bound; the complement denotes a proposition. -/
-def INDev {Event : Type*} (P : Event → Prop) : Prop := ∃ e, P e
-
-/-- SBJV₁ leaves the eventuality argument open ([grano-2024], (88a);
-    §7 Subjunctive₃ (135)).
-
-    ⟦SBJV₁⟧ = λP_(⟨vt⟩).P
-
-    The complement retains type ⟨vt⟩ — an event predicate, not a proposition.
-    In the core proposal (§5, (88a)), this is the general non-closing mood
-    operator. In the §7 unified theory, it becomes specifically Subjunctive₃
-    (135) — the identity variant for perception predicates ('see'), causative
-    predicates ('make'), and aspectual predicates ('begin'). These predicates
-    require or are compatible with eventuality abstraction but do not involve
-    causal self-reference or ordering semantics. Distinct from the 'want'
-    variant (§7, Subjunctive₁ (133)), which uses Portner & Rubinstein's `ln`
-    (local necessity), and the 'intend' variant (Subjunctive₂ (134) =
-    `SBJVev₂`), which incorporates CAUSE*. -/
-def SBJVev₁ {Event : Type*} (P : Event → Prop) : Event → Prop := P
-
-/-- SBJV₂ leaves the eventuality argument open AND requires causal
-    self-reference ([grano-2024], (134); unified theory §7).
-
-    ⟦Subjunctive₂⟧ = λPλe[sn({λw.∃e'.CAUSE*(e,e',w) & P(w)(e')}, content(e), e)]
-
-    This is the variant operative with 'intend' in the §7 unified theory,
-    which integrates CAUSE* from the core proposal (§4, (79)) with Portner
-    & Rubinstein's ([portner-rubinstein-2020]) modal quantification
-    framework. The attitude state e must causally bring about the described
-    event e' "in the right way" ([searle-1983]; [harman-1976]). -/
-def SBJVev₂ {Event W : Type*}
-    (causeStar : Event → Event → W → Prop)  -- CAUSE*(state, event, world)
-    (content : Event → W → Prop)          -- content of the attitude state
-    (P : W → Event → Prop)               -- world-indexed event predicate
-    (e : Event) : Prop :=
-  ∀ w, content e w → ∃ e', causeStar e e' w ∧ P w e'
-
-/-- IND closure yields a proposition (no free eventuality variable). -/
-theorem INDev_is_propositional {Event : Type*} (P : Event → Prop) :
-    (INDev P) = (∃ e, P e) := rfl
-
-/-- SBJV₁ is the identity on event predicates. -/
-theorem SBJVev₁_is_identity {Event : Type*} (P : Event → Prop) :
-    SBJVev₁ P = P := rfl
-
-
-/--
-Mood selection by embedding predicates.
-
-Certain predicates select for specific moods in their complement:
-- "know", "see" → typically indicative
-- "want", "wish" → robustly subjunctive cross-linguistically
-- "hope" → cross-linguistically variable ([grano-2024], Table 1)
-- "say", "think" → mood-neutral (pragmatically flexible)
--/
-inductive Selector where
-  | indicativeSelecting          -- "know", "see", "believe"
-  | subjunctiveSelecting         -- "want", "wish", "demand", "intend"
-  | crossLinguisticallyVariable  -- "hope", "expect": SBJV in some languages,
-                                 -- IND in others ([grano-2024], Table 1)
-  | moodNeutral                  -- "say", "think" (pragmatically flexible)
-  deriving DecidableEq, Repr
-
-/--
-Does the selector prefer subjunctive?
--/
-def prefersSubjunctive : Selector → Bool
-  | .indicativeSelecting => false
-  | .subjunctiveSelecting => true
-  | .crossLinguisticallyVariable => false  -- default: variable, not robust SBJV
-  | .moodNeutral => false  -- default to indicative
 
 /--
 Conditional with SF antecedent ([mendes-2025], main application).
@@ -323,12 +215,7 @@ theorem subj_nonveridical {W Time : Type*} [LE Time]
   -- ¬(s₀ = s₁)
   exact hne
 
--- ════════════════════════════════════════════════════════════════
--- § Bridge: SUBJ and Attitude Temporal Anchoring
--- ════════════════════════════════════════════════════════════════
-
-/-!
-### SUBJ as Temporal Anchor
+/-! ### SUBJ as temporal anchor
 [giannakidou-1998] [mendes-2025] [muskens-1996]
 
 Both SUBJ's situation introduction and attitude embedding create new temporal
@@ -371,12 +258,7 @@ theorem subj_temporal_anchor {W Time : Type*} [LE Time]
 
 end AttitudeTemporalAnchor
 
--- ════════════════════════════════════════════════════════════════
--- § Tower Integration: SUBJ as Context Shift
--- ════════════════════════════════════════════════════════════════
-
-/-!
-### SUBJ as Tower Push
+/-! ### SUBJ as tower push
 
 SUBJ introduces a new situation from the historical base. In the tower
 framework, this corresponds to pushing a mood-labeled context shift that

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Mood.Modal
 import Linglib.Semantics.Mood.State
 import Linglib.Semantics.Mood.Component
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 
 /-!
 # Verbal Mood as State Component Selection
@@ -79,7 +79,7 @@ variable {W : Type*}
     `.subjunctive` cases are [portner-2018]'s; `.interrogative`
     is our extension to question-embedding predicates. The
     `crossLinguistic` and `neutral` cases of `Selector`
-    (Mood/Basic.lean) project to `none` via
+    (Mood/Categories.lean) project to `none` via
     `Selector.toVerbalOp` because their selection pattern is
     not committed to a single State component by lexical class
     alone. -/
@@ -254,7 +254,7 @@ theorem verbal_mood_target_inquisitive_iff_interrogative (m : VerbalOp) :
 
 /-! ### Bridge to `Selector`
 
-The `Selector` enum (Mood/Basic.lean, taxonomic by predicate
+The `Selector` enum (Mood/Categories.lean, taxonomic by predicate
 class — knowledge/belief, preference/desire, etc.) projects onto
 `VerbalOp` for the predicate classes that select the *same*
 mood across [portner-2018]'s indicative/subjunctive languages.
@@ -279,14 +279,6 @@ def Selector.toVerbalOp : Selector → Option VerbalOp
   | .subjunctiveSelecting         => some .subjunctive
   | .crossLinguisticallyVariable  => none
   | .moodNeutral                  => none
-
-/-- The `prefersSubjunctive` boolean (Mood/Basic.lean) and the
-    `toVerbalOp` projection agree on whether the result is the
-    subjunctive operator. Two surface representations of the same
-    lexical-class commitment, equivalent by construction. -/
-theorem prefersSubjunctive_eq_subjunctive (m : Selector) :
-    prefersSubjunctive m = true ↔ m.toVerbalOp = some .subjunctive := by
-  cases m <;> simp [prefersSubjunctive, Selector.toVerbalOp]
 
 /-- `Selector.toVerbalOp` never projects to `.interrogative`:
     the declarative-complement classification is *closed* under the

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -2,7 +2,7 @@ import Linglib.Semantics.Tense.Compositional
 import Linglib.Features.Evidentiality
 import Linglib.Features.Mirativity
 import Linglib.Semantics.Presupposition.Basic
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 import Linglib.Semantics.Context.Shifts
 
 /-!

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Eventuality
 import Linglib.Semantics.Mood.Verbal
 import Linglib.Semantics.Attitudes.RationalAttitude
 import Linglib.Studies.Noonan2007
@@ -50,7 +50,7 @@ When neither departure is present, only indicative mood is possible.
 namespace Grano2024
 
 open Semantics.Lexical
-open Semantics.Mood (Grammatical Effect)
+open Semantics.Mood (Grammatical EventDenotation)
 open Semantics.Mood
 open Semantics.Attitudes.RationalAttitude
 
@@ -194,38 +194,41 @@ theorem hope_selector_matches_data :
   native_decide
 
 -- ════════════════════════════════════════════════════════════════
--- § 4. Bridge: Effect → Indicative Rejection
+-- § 4. Bridge: Event Denotation → Indicative Rejection
 -- ════════════════════════════════════════════════════════════════
 
-/-- Indicative mood closes the eventuality argument. Therefore,
-    predicates requiring eventuality abstraction (CAUSE* binds the
-    event variable) reject indicative complements.
+/-- Indicative mood closes the eventuality argument: its event-level
+    denotation lands in the `closed` constructor, so predicates
+    requiring eventuality abstraction (CAUSE* binds the event
+    variable) reject indicative complements.
 
     This is the formal correlate of [grano-2024]'s argument chain:
     Premise 2 (CAUSE* needs open event arg) + Premise 3 (IND closes it)
     → Conclusion (intention reports reject IND). -/
-theorem ind_incompatible_with_eventuality_abstraction :
-    Grammatical.indicative.effect.eventualityOpen = false := rfl
+theorem ind_incompatible_with_eventuality_abstraction {E : Type*} (P : E → Prop) :
+    Grammatical.indicative.eventDenotation P = .closed (∃ e, P e) := rfl
 
-/-- Subjunctive mood leaves the eventuality argument open, enabling
-    CAUSE* to bind it. This is why 'intend' and causatives accept SBJV. -/
-theorem subj_enables_eventuality_abstraction :
-    Grammatical.subjunctive.effect.eventualityOpen = true := rfl
+/-- Subjunctive mood leaves the eventuality argument open — its
+    denotation lands in `abstracted` with the predicate intact —
+    enabling CAUSE* to bind it. This is why 'intend' and causatives
+    accept SBJV. -/
+theorem subj_enables_eventuality_abstraction {E : Type*} (P : E → Prop) :
+    Grammatical.subjunctive.eventDenotation P = .abstracted P := rfl
 
 /-- The three-premise argument chain:
     1. `intentionHolds` requires P : E → W → Event Time → Prop (open event arg)
-    2. IND closes the event argument (eventualityOpen = false)
-    3. SBJV leaves it open (eventualityOpen = true)
+    2. IND closes the event argument (`eventDenotation` lands in `closed`)
+    3. SBJV leaves it open (`eventDenotation` lands in `abstracted`)
     → intention reports require SBJV, reject IND -/
 theorem grano_argument_chain :
-    -- Premise 3: IND closes, SBJV opens
-    Grammatical.indicative.effect.eventualityOpen = false ∧
-    Grammatical.subjunctive.effect.eventualityOpen = true ∧
+    -- Premise 3: IND closes, SBJV opens (event denotations by constructor)
+    (∀ P : Unit → Prop, Grammatical.indicative.eventDenotation P = .closed (∃ e, P e)) ∧
+    (∀ P : Unit → Prop, Grammatical.subjunctive.eventDenotation P = .abstracted P) ∧
     -- Empirical confirmation: intend rejects IND
     intendData.all (·.rejectsIndicative) = true ∧
     -- Empirical confirmation: causatives also reject IND (independent support)
     causativeData.all (·.rejectsIndicative) = true := by
-  refine ⟨rfl, rfl, ?_, ?_⟩ <;> native_decide
+  refine ⟨fun _ => rfl, fun _ => rfl, ?_, ?_⟩ <;> native_decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5. Bridge: Unified Theory — Two Kinds of Departure

--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Modality.Exclusion
+import Linglib.Semantics.Mood.Categories
 import Linglib.Data.Examples.Iatridou2000
 import Linglib.Fragments.English.Conditionals
 import Mathlib.Data.Finset.Basic

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -799,7 +799,7 @@ theorem subjIndChain_entails_conditionalSF {W Time : Type*} [LE Time]
 ### Bridge to Hofmann (2025) accessibility
 
 The same-world constraint enforced by `dynIND` (via the `sameWorld`
-kernel in `Mood/Basic.lean`) parallels [hofmann-2025]'s
+kernel in `Mood/Situation.lean`) parallels [hofmann-2025]'s
 veridicality-based accessibility for individual drefs:
 
 - **Situation level** (this file, [mendes-2025]): `dynIND`

--- a/Linglib/Studies/NapoliNespor1976.lean
+++ b/Linglib/Studies/NapoliNespor1976.lean
@@ -2,7 +2,7 @@ import Linglib.Pragmatics.Bias
 import Linglib.Studies.Rett2026
 import Linglib.Studies.Tsiakmakis2025
 import Linglib.Fragments.Italian.PolarityItems
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 
 /-!
 # Napoli & Nespor (1976): Negatives in Comparatives [napoli-nespor-1976]

--- a/Linglib/Studies/Noonan2007.lean
+++ b/Linglib/Studies/Noonan2007.lean
@@ -1,7 +1,7 @@
 import Linglib.Data.Complementation.Noonan2007
 import Linglib.Syntax.Clause.Complementation
 import Linglib.Syntax.Minimalist.LeftPeriphery
-import Linglib.Semantics.Mood.Basic
+import Linglib.Semantics.Mood.Categories
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 
 /-! # Noonan (2007): Complementation Typology + Bridge Theorems
@@ -34,7 +34,7 @@ subject omission is pro-drop, not Noonan-equi; English *hope* has
 Five bridges connecting CTPClass to existing infrastructure:
 1. CTPClass ↔ VerbEntry (Verbal.lean) — derive CTP class from verb features
 2. CTPClass ↔ SelectionClass (LeftPeriphery.lean) — map CTP to question embedding
-3. CTPClass ↔ Selector (Mood/Basic.lean) — map CTP to mood selection
+3. CTPClass ↔ Selector (Mood/Categories.lean) — map CTP to mood selection
 4. ComplementType ↔ NoonanCompType — via the substrate adapter
    `ComplementType.toNoonan` (`Syntax/Clause/Complementation.lean`)
 5. VerbEntry → Selector — derive mood selection from verb features
@@ -308,7 +308,7 @@ theorem ctp_selection_consistent_ask :
     ctpToDefaultSelectionClass .utterance = deriveSelectionClass ask := by native_decide
 
 -- ============================================================================
--- C. Bridge 3: CTPClass ↔ Selector (Mood/Basic.lean)
+-- C. Bridge 3: CTPClass ↔ Selector (Mood/Categories.lean)
 -- ============================================================================
 
 /-! ## C1. Map CTP classes to mood selection
@@ -373,7 +373,7 @@ theorem clausal_complements_have_noonan_type :
 /-! ## E1. Derive Selector from VerbEntry fields
 
 This is placed in Bridge.lean (not Verbal.lean) to avoid circular imports:
-it needs both Verbal and Mood/Basic. Follows the `deriveSelectionClass` pattern. -/
+it needs both Verbal and Mood/Categories. Follows the `deriveSelectionClass` pattern. -/
 
 /-- Derive mood selection from a VerbEntry's primitive fields.
 


### PR DESCRIPTION
Completes the Stage-2 tail of the Mood API rework.

- Splits the misnamed `Basic.lean` into anchored files: `Situation.lean` (Mendes 2025 SUBJ/IND, SF conditional, non-veridicality, tower shifts) and `Eventuality.lean` (Grano 2024 INDev/SBJVev); `Selector` moves to `Categories.lean`.
- Deletes the stipulated `Effect` Bool table and `prefersSubjunctive`: the event-level contrast is now `Grammatical.eventDenotation` into a constructor-distinguished sum (openness read off the constructor), and the situation-level contrast is `Grammatical.dynOp` with eliminative/generative theorems (`dynOp_indicative_isFilter`, `dynOp_subjunctive_introduces`). Grano2024's bridge consumes the derived facts.