### PR TITLE
style(Semantics/Mood): mathlib-register docstrings in Defs.lean

### DIFF
--- a/Linglib/Semantics/Mood/Defs.lean
+++ b/Linglib/Semantics/Mood/Defs.lean
@@ -9,37 +9,23 @@ import Mathlib.Tactic.DeriveFintype
 The definitions core of `Semantics/Mood/`: the category enums for
 grammatical mood and illocutionary force, their cross-product
 `ClauseType`, the lexical classification of mood-selecting predicates,
-and the corpus bridge from `UD.Mood`.
-
-The semantic content of these categories lives downstream:
-situation-level operators in `Semantics/Mood/Situation.lean`
-([mendes-2025]: SUBJ introduces a situation dref, IND retrieves),
-event-level operators in `Semantics/Mood/Eventuality.lean`
-([grano-2024]: `Grammatical.eventDenotation` — indicative closes the
-event argument, subjunctive leaves it open), the dynamic lifts in
-`Semantics/Mood/Dynamic.lean` (`Grammatical.dynOp` — indicative
-eliminative, subjunctive generative), and the component/modal layer in
-`Semantics/Mood/{Component,Modal,State,Verbal}.lean`. Discourse-act
-extensions of force (Searle classes, direction of fit, preparatory
-conditions) live in `Discourse/SpeechAct.lean`, which imports this
-file; the split keeps the category layer free of pragmatic-act
-commitments. `DiscourseRole` lives in `Discourse/Roles.lean` because
-it is about discourse participants, not mood.
+and the corpus bridge from `UD.Mood`. This file carries the categories
+only; their semantics lives in the sibling `Semantics/Mood/` files
+(`Situation`, `Eventuality`, `Dynamic`, `Component`, `Modal`, `State`,
+`Verbal`, `SpeechEvent`), and the discourse-act extensions of force
+(Searle classes, direction of fit) in `Discourse/SpeechAct.lean`.
 
 ## Main declarations
 
 * `Grammatical`, `SubjunctiveType` — verb-morphological mood.
 * `Illocutionary`, `Illocutionary.authority` — speech-act force
   (the F in F(p)) and its epistemic-authority assignment.
-* `ClauseType` — force × mood, the two dimensions orthogonal.
+* `ClauseType` — force × mood. The dimensions are independent
+  ([holmberg-2016]): a clause can be [interrogative, indicative]
+  ("Does he sleep?") or [interrogative, subjunctive] (Spanish "¿Que
+  duerma?"). Both are distinct from `SpeasTenny2003.SAPMood`.
 * `Selector` — mood selection by embedding predicate class.
 * `UD.Mood.toClauseType` — corpus bridge.
-
-Grammatical mood and illocutionary force are independent dimensions
-([holmberg-2016]): a clause can be [interrogative, indicative] ("Does
-he sleep?") or [interrogative, subjunctive] (Spanish "¿Que duerma?").
-Both are distinct from `SpeasTenny2003.SAPMood` (Speas & Tenny's 2×2
-configuration).
 -/
 
 namespace Semantics.Mood
@@ -48,42 +34,31 @@ open Discourse (DiscourseRole)
 
 /-! ### Grammatical mood -/
 
-/--
-Grammatical mood categories.
-
-Following the typological literature:
-- **Indicative**: The default, "realis" mood
-- **Subjunctive**: Non-default, "irrealis" mood (covers many subtypes)
--/
+/-- Grammatical (verb-morphological) mood: the indicative/subjunctive contrast. -/
 inductive Grammatical where
+  /-- The default, "realis" mood. -/
   | indicative
+  /-- The non-default, "irrealis" mood. -/
   | subjunctive
   deriving DecidableEq, Repr, Inhabited
 
-/--
-Subjunctive subtypes (for finer-grained analysis).
-
-Different languages grammaticalize different subjunctive functions:
-- Counterfactual: contrary-to-fact conditionals
-- Dubitative: epistemic uncertainty
-- Optative: wishes and desires
-- Potential: epistemic/circumstantial possibility
--/
+/-- The subjunctive functions that individual languages grammaticalize. -/
 inductive SubjunctiveType where
-  | counterfactual  -- contrary to fact
-  | dubitative      -- epistemic uncertainty
-  | optative        -- wishes
-  | potential        -- possibility
-  | subordinateFuture  -- Mendes' SF (present morphology, future reference)
+  /-- Contrary-to-fact conditionals. -/
+  | counterfactual
+  /-- Epistemic uncertainty. -/
+  | dubitative
+  /-- Wishes and desires. -/
+  | optative
+  /-- Epistemic or circumstantial possibility. -/
+  | potential
+  /-- [mendes-2025]'s Subordinate Future: present morphology, future reference. -/
+  | subordinateFuture
   deriving DecidableEq, Repr
 
 /-! ### Illocutionary force -/
 
-/-- Illocutionary mood — the speech-act force of an utterance.
-
-    Distinct from `Grammatical` (indicative/subjunctive morphology) and the
-    Minimalist `SAPMood` (configurational). This classifies the pragmatic
-    act performed — the F in F(p). -/
+/-- Illocutionary mood: the speech-act force of an utterance — the F in F(p). -/
 inductive Illocutionary where
   | declarative
   | interrogative
@@ -92,10 +67,8 @@ inductive Illocutionary where
   | exclamative
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- Which participant holds epistemic authority for a given illocutionary mood.
-
-    [lakoff-1970]: in declaratives, imperatives, and promissives the
-    speaker is the seat of knowledge; in interrogatives the addressee is. -/
+/-- The participant with epistemic authority for each force ([lakoff-1970]):
+the addressee for interrogatives, the speaker otherwise. -/
 def Illocutionary.authority : Illocutionary → DiscourseRole
   | .declarative   => .speaker
   | .interrogative  => .addressee
@@ -114,12 +87,12 @@ def Illocutionary.authority : Illocutionary → DiscourseRole
 | imperative    | —           | "Sleep!" (mood often neutralized)    |
 -/
 
-/-- A clause's type: the independent pairing of illocutionary force
-    with grammatical mood ([holmberg-2016], [rizzi-1997]). -/
+/-- A clause type: the independent pairing of illocutionary force with
+grammatical mood ([holmberg-2016], [rizzi-1997]). -/
 structure ClauseType where
-  /-- Illocutionary force: the speech act performed -/
+  /-- The illocutionary force: the speech act performed. -/
   force : Illocutionary
-  /-- Grammatical mood: verb morphology -/
+  /-- The grammatical mood: verb morphology. -/
   mood : Grammatical
   deriving DecidableEq, Repr
 
@@ -136,7 +109,7 @@ theorem force_mood_independent :
     ClauseType.declInd.mood = ClauseType.polarQuestion.mood ∧
     ClauseType.declInd.force ≠ ClauseType.polarQuestion.force := ⟨rfl, nofun⟩
 
-/-- Map from `ClauseType` to epistemic authority (via force, ignoring mood). -/
+/-- The epistemic authority of a clause type, via its force. -/
 def ClauseType.authority (ct : ClauseType) : DiscourseRole :=
   Illocutionary.authority ct.force
 
@@ -146,55 +119,48 @@ theorem polarQuestion_addressee_authority :
 
 /-! ### Mood selection by predicate class -/
 
-/--
-Mood selection by embedding predicates.
-
-Certain predicates select for specific moods in their complement:
-- "know", "see" → typically indicative
-- "want", "wish" → robustly subjunctive cross-linguistically
-- "hope" → cross-linguistically variable ([grano-2024], Table 1)
-- "say", "think" → mood-neutral (pragmatically flexible)
-
-The projection onto the semantic operators is
-`Selector.toVerbalOp` (`Semantics/Mood/Verbal.lean`).
--/
+/-- The mood-selection class of an embedding predicate; the projection onto
+the semantic operators is `Selector.toVerbalOp` (`Semantics/Mood/Verbal.lean`). -/
 inductive Selector where
-  | indicativeSelecting          -- "know", "see", "believe"
-  | subjunctiveSelecting         -- "want", "wish", "demand", "intend"
-  | crossLinguisticallyVariable  -- "hope", "expect": SBJV in some languages,
-                                 -- IND in others ([grano-2024], Table 1)
-  | moodNeutral                  -- "say", "think" (pragmatically flexible)
+  /-- Indicative-selecting: *know*, *see*, *believe*. -/
+  | indicativeSelecting
+  /-- Robustly subjunctive-selecting: *want*, *wish*, *demand*, *intend*. -/
+  | subjunctiveSelecting
+  /-- Variable across languages: *hope*, *expect* ([grano-2024], Table 1). -/
+  | crossLinguisticallyVariable
+  /-- Pragmatically flexible: *say*, *think*. -/
+  | moodNeutral
   deriving DecidableEq, Repr
 
 end Semantics.Mood
 
-/-! ### Bridge to UD.Mood -/
+/-! ### Bridge to UD.Mood
+
+`UD.Mood` is a flat enum conflating illocutionary force (Imp, Jus, Adm)
+with grammatical mood (Ind, Sub) and finer irrealis subtypes (Cnd, Opt,
+Pot, Nec, Irr). The bridge picks the most defensible default
+cross-product:
+
+| UD.Mood | force         | mood        |
+|---------|---------------|-------------|
+| Ind     | declarative   | indicative  |
+| Sub     | declarative   | subjunctive |
+| Imp     | imperative    | indicative  |
+| Cnd     | declarative   | subjunctive |
+| Opt     | declarative   | subjunctive |
+| Jus     | imperative    | subjunctive |
+| Pot     | declarative   | subjunctive |
+| Qot     | declarative   | indicative  |
+| Adm     | exclamative   | indicative  |
+| Nec     | declarative   | subjunctive |
+| Irr     | declarative   | subjunctive |
+-/
 
 namespace UD.Mood
 
-/-- Project a `UD.Mood` feature value to a `Semantics.Mood.ClauseType`.
-
-    `UD.Mood` is a flat enum that conflates illocutionary force
-    (Imp, Jus, Adm) with grammatical mood (Ind, Sub) with finer
-    irrealis subtypes (Cnd, Opt, Pot, Nec, Irr). The bridge picks the
-    most defensible default cross-product:
-
-    | UD.Mood | force         | mood        |
-    |---------|---------------|-------------|
-    | Ind     | declarative   | indicative  |
-    | Sub     | declarative   | subjunctive |
-    | Imp     | imperative    | indicative  |
-    | Cnd     | declarative   | subjunctive |
-    | Opt     | declarative   | subjunctive |
-    | Jus     | imperative    | subjunctive |
-    | Pot     | declarative   | subjunctive |
-    | Qot     | declarative   | indicative  |
-    | Adm     | exclamative   | indicative  |
-    | Nec     | declarative   | subjunctive |
-    | Irr     | declarative   | subjunctive |
-
-    The mapping is non-injective by design — UD.Mood draws finer
-    distinctions on the irrealis side than (force × mood) records. -/
+/-- The default force × mood cross-product for a `UD.Mood` value —
+non-injective by design, since `UD.Mood` draws finer irrealis
+distinctions than force × mood records. -/
 def toClauseType : UD.Mood → Semantics.Mood.ClauseType
   | .Ind => { force := .declarative, mood := .indicative }
   | .Sub => { force := .declarative, mood := .subjunctive }


### PR DESCRIPTION
One-line declaration docstrings throughout (SignType-style), constructor comments promoted to proper one-line case docstrings, the UD.Mood routing table moved to a section docstring, and the module docstring tightened.