### PR TITLE
refactor(Semantics/Mood): namespace Semantics.Mood → Mood

### DIFF
--- a/Linglib/Discourse/Commitment/Space.lean
+++ b/Linglib/Discourse/Commitment/Space.lean
@@ -77,7 +77,7 @@ open Discourse.Commitment
    HasSupport CommitmentGrade)
 open Discourse (DiscourseRole)
 open CommonGround (ContextSet)
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Commitment Space: Tree Structure ([krifka-2015], eq. (2), p. 329)

--- a/Linglib/Discourse/Commitment/Table.lean
+++ b/Linglib/Discourse/Commitment/Table.lean
@@ -27,7 +27,7 @@ namespace Discourse.Commitment.Table
 
 open Discourse.Commitment (TaggedSlate CommitmentSource CommitmentForce)
 open CommonGround (HasContextSet)
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 /-- An at-issue item on the conversational table. -/
 structure Item (A W : Type*) where

--- a/Linglib/Discourse/SpeechAct.lean
+++ b/Linglib/Discourse/SpeechAct.lean
@@ -40,7 +40,7 @@ from sincere belief to public commitment.
 * [searle-1969], [searle-1979], [searle-1983], [francik-clark-1985]
 -/
 
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 /-! ### Direction of fit -/
 
@@ -109,7 +109,7 @@ def PsychMode.directionOfFit : PsychMode → DirectionOfFit
 
 /-! ### Mood bridges — class and sincerity condition -/
 
-namespace Semantics.Mood.Illocutionary
+namespace Mood.Illocutionary
 
 /-- The [searle-1979] illocutionary class of each mood. -/
 def searleClass : Illocutionary → SearleClass
@@ -138,7 +138,7 @@ theorem sincerityCondition_directionOfFit (m : Illocutionary) :
     m.sincerityCondition.directionOfFit = m.directionOfFit := by
   cases m <;> rfl
 
-end Semantics.Mood.Illocutionary
+end Mood.Illocutionary
 
 /-! ### Causal self-referentiality -/
 

--- a/Linglib/Features/ClauseForm.lean
+++ b/Linglib/Features/ClauseForm.lean
@@ -8,9 +8,9 @@ embedded question vs declarative) — what conditions inversion and other
 word-order alternations. Echo questions are *not* a constructor here;
 they are declarative-form sentences with question force in discourse,
 handled via `Features.InformationStructure`. Distinct from
-`Semantics.Mood.ClauseType`, which pairs illocutionary force with verbal
+`Mood.ClauseType`, which pairs illocutionary force with verbal
 mood. The two complement each other: a polar question has
-`ClauseForm = matrixQuestion` and `Semantics.Mood.ClauseType =
+`ClauseForm = matrixQuestion` and `Mood.ClauseType =
 ⟨interrogative, indicative⟩`.
 -/
 

--- a/Linglib/Fragments/French/Modals.lean
+++ b/Linglib/Fragments/French/Modals.lean
@@ -41,8 +41,8 @@ in position-sensitive flavor selection ([hacquard-2006]).
 namespace French.Modals
 
 open Semantics.Modality (ModalForce ModalFlavor ForceFlavor)
-open Semantics.Mood.Illocutionary (primaryFlavor)
-open Semantics.Mood (Illocutionary)
+open Mood.Illocutionary (primaryFlavor)
+open Mood (Illocutionary)
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Pragmatics/Bias.lean
+++ b/Linglib/Pragmatics/Bias.lean
@@ -75,7 +75,7 @@ commitment-update ([farkas-bruce-2010]) reanalyses.
 namespace Pragmatics.Bias
 
 open Semantics.Negation (PolarityLicensing weakENProfile)
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
 -- § 1. The four licensing conditions

--- a/Linglib/Semantics/Attitudes/Representationality.lean
+++ b/Linglib/Semantics/Attitudes/Representationality.lean
@@ -158,7 +158,7 @@ theorem licensing_requires_information_state (r : Representationality)
 -- § 4. Mood Selection Correlation
 -- ════════════════════════════════════════════════════════════════
 
-open Semantics.Mood
+open Mood
 
 /-- Map mood selector to expected representationality.
 

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -59,7 +59,7 @@ equivalence within an appropriate context (the
 namespace Semantics.Conditionals
 
 open CommonGround (ContextSet)
-open Semantics.Mood (Grammatical)
+open Mood (Grammatical)
 open _root_.Semantics.Conditionals (SelectionFunction selectionPrefers)
 open Core.Order (SimilarityOrdering)
 

--- a/Linglib/Semantics/Dynamic/Core/ContextFilter.lean
+++ b/Linglib/Semantics/Dynamic/Core/ContextFilter.lean
@@ -88,7 +88,7 @@ common specializations are:
 
 - `dynRelation` (both projections look up bound variables `gs.1 v₁`,
   `gs.1 v₂`) — used by `Tense.dynPAST`/`dynPRES`/`dynFUT`.
-- `Semantics.Mood.dynIND` (one projection is the entry's current
+- `Mood.dynIND` (one projection is the entry's current
   situation `gs.2`, the other is a bound variable `gs.1 v`).
 
 Mathlib precedent: `Set.image2` over `Set.image`.
@@ -230,7 +230,7 @@ is exactly the `Set.filter` vs `Set.bind` dichotomy of the powerset monad.
 fresh entries by binding a situation variable to alternatives drawn from
 a Kleisli arrow `gen : WorldTimeIndex → Set WorldTimeIndex`.
 
-This is the canonical primitive behind `Semantics.Mood.dynSUBJ` (with
+This is the canonical primitive behind `Mood.dynSUBJ` (with
 `gen = historicalBase history`) and any other operator that introduces
 a fresh situation dref.
 -/

--- a/Linglib/Semantics/Modality/Exclusion.lean
+++ b/Linglib/Semantics/Modality/Exclusion.lean
@@ -47,7 +47,7 @@ distinguish live from non-live possibilities.
 namespace Semantics.Modality.Exclusion
 
 open Semantics.Context (KContext ContextTower temporalShift)
-open Semantics.Mood (subjShift)
+open Mood (subjShift)
 
 /-! ### ExclF: the exclusion feature -/
 

--- a/Linglib/Semantics/Mood/Component.lean
+++ b/Linglib/Semantics/Mood/Component.lean
@@ -31,7 +31,7 @@ Modal flavors would get their own instance if `Semantics/Modality/`
 is ever rephrased over POSW.
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 /-- The component of a `POSW` (or of `State`, for `.inquisitive`) that a
     mood-bearing object operates on. [portner-2018], Ch. 4.
@@ -116,4 +116,4 @@ def Component.boxOn : Component → State W → (W → Prop) → Prop
 @[simp] theorem boxOn_inquisitive (c : State W) (p : W → Prop) :
     Component.inquisitive.boxOn c p = c.boxAns p := rfl
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/Defs.lean
+++ b/Linglib/Semantics/Mood/Defs.lean
@@ -27,7 +27,7 @@ The Searle-class and direction-of-fit API for `Illocutionary` is in
 `Discourse/SpeechAct.lean`.
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 open Discourse (DiscourseRole)
 
@@ -122,7 +122,7 @@ inductive Selector where
   | moodNeutral
   deriving DecidableEq, Repr
 
-end Semantics.Mood
+end Mood
 
 /-! ### Bridge to UD.Mood -/
 
@@ -131,7 +131,7 @@ namespace UD.Mood
 /-- The default `ClauseType` for a `UD.Mood` value. The UD feature is a
 flat enum conflating force with mood, so the map is a non-injective
 default cross-product. -/
-def toClauseType : UD.Mood → Semantics.Mood.ClauseType
+def toClauseType : UD.Mood → Mood.ClauseType
   | .Ind => { force := .declarative, mood := .indicative }
   | .Sub => { force := .declarative, mood := .subjunctive }
   | .Imp => { force := .imperative,  mood := .indicative }

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -42,7 +42,7 @@ of dynamic semantics:
   on situation contexts. `dynRelationOn` is `Set.filter`; `dynIntroduce`
   is `Set.bind` (Kleisli composition).
 
-`Semantics.Mood.IND` and `Semantics.Mood.SUBJ` (defined in
+`Mood.IND` and `Mood.SUBJ` (defined in
 `Mood/Situation.lean`) call the same two kernels (`sameWorld` and
 `historicalBase`) directly. The static and dynamic faces share *one
 modal constraint and one alternative-generator*, lifted from a
@@ -73,7 +73,7 @@ operator and the modal donkey anaphora chain that consumes
 `dynSUBJ`/`dynIND`).
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 open _root_.Core (Assignment)
 open _root_.Intensional (WorldTimeIndex)
@@ -317,4 +317,4 @@ theorem dynIND_after_dynSUBJ_same_var {W Time : Type*} [LE Time]
   show sameWorld gs.2 (gs.1 v)
   rw [dynSUBJ_binds_current history v c gs h_mem]
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -23,7 +23,7 @@ closes and subjunctive abstracts is then read off the constructor
 than stipulated in a feature table.
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 /-- IND existentially closes the eventuality argument ([grano-2024], (87)).
 
@@ -116,4 +116,4 @@ def Grammatical.eventDenotation {Event : Type*} (P : Event → Prop) :
 @[simp] theorem eventDenotation_subjunctive {Event : Type*} (P : Event → Prop) :
     Grammatical.subjunctive.eventDenotation P = .abstracted P := rfl
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/Modal.lean
+++ b/Linglib/Semantics/Mood/Modal.lean
@@ -137,7 +137,7 @@ theorem boxLe_of_respects (σ : ExpState W) (p : W → Prop)
 
 end Semantics.Dynamic.Default.ExpState
 
-namespace Semantics.Mood
+namespace Mood
 
 open Semantics.Dynamic.Default
 
@@ -172,4 +172,4 @@ instance (σ : ExpState W) : NormalModality W σ.boxLe where
   necessitation := fun _ _ => trivial
   K _ _ hpq hp w hopt := hpq w hopt (hp w hopt)
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/PartitionAsInquiry.lean
+++ b/Linglib/Semantics/Mood/PartitionAsInquiry.lean
@@ -200,7 +200,7 @@ automatically a consumer of the inquisitive-content API: `info`,
 mention-some/IE-question forcing arguments all become available
 without rewriting the underlying state. -/
 
-namespace Semantics.Mood
+namespace Mood
 
 namespace State
 
@@ -224,4 +224,4 @@ def inquiryContent (c : State W) : Question W :=
 
 end State
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -29,7 +29,7 @@ dref that the main clause retrieves for temporal anchoring
 * `subjShift`, `subj_as_tower_push` — SUBJ as a tower context shift.
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 open Intensional (WorldTimeIndex)
 
@@ -50,7 +50,7 @@ The `sameWorld` kernel: two situations share their world coordinate.
 
 This is the modal counterpart of the temporal kernels
 (`Tense.precedes`/`coincides`/`follows`). The static `IND`
-operator and its dynamic lift `Semantics.Mood.dynIND` both call this
+operator and its dynamic lift `Mood.dynIND` both call this
 kernel; they share *the same modal constraint*, lifted from a static
 situation predicate to a context filter via
 `Semantics.Dynamic.Core.dynRelationOn`.
@@ -319,4 +319,4 @@ theorem subj_as_tower_push [LE Time]
 
 end TowerMood
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/SpeechEvent.lean
+++ b/Linglib/Semantics/Mood/SpeechEvent.lean
@@ -49,7 +49,7 @@ territory; this file consumes its `EventProjection` for the
 participant structure of `e*`.
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 open Semantics.Dynamic.Default
 open Semantics.Modality (ModalFlavor)
@@ -317,4 +317,4 @@ theorem declarative_projects_to_speaker :
 theorem imperative_projects_to_addressee :
     speechActProjection.toPair .imperative = ⟨.addressee, .now⟩ := rfl
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/State.lean
+++ b/Linglib/Semantics/Mood/State.lean
@@ -93,7 +93,7 @@ rather than a replacement — mirroring how mathlib keeps `Set`/`Finset`
 and `Filter`/`Ultrafilter` parallel rather than collapsing them.
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 open Semantics.Dynamic.Default
 
@@ -397,4 +397,4 @@ theorem boxAns_not_reducible_to_boxCs :
   ⟨sepInquiry, sepProp, boxAns_sepInquiry_sepProp, not_boxCs_sepInquiry_sepProp⟩
 
 end State
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -69,7 +69,7 @@ matrix predicate (`Selector` for declarative-embedders;
 `QuestionEmbedder` for question-embedders).
 -/
 
-namespace Semantics.Mood
+namespace Mood
 
 open Semantics.Dynamic.Default
 
@@ -111,13 +111,13 @@ instance : HasTarget VerbalOp where
     | .interrogative => .inquisitive
 
 @[simp] theorem target_indicative :
-    Semantics.Mood.target VerbalOp.indicative = .informational := rfl
+    Mood.target VerbalOp.indicative = .informational := rfl
 
 @[simp] theorem target_subjunctive :
-    Semantics.Mood.target VerbalOp.subjunctive = .preferential := rfl
+    Mood.target VerbalOp.subjunctive = .preferential := rfl
 
 @[simp] theorem target_interrogative :
-    Semantics.Mood.target VerbalOp.interrogative = .inquisitive := rfl
+    Mood.target VerbalOp.interrogative = .inquisitive := rfl
 
 /-- Compositional interpretation of a verbal-mood operator against an
     embedding State and an embedded proposition: run the necessity
@@ -134,7 +134,7 @@ def VerbalOp.interp (m : VerbalOp) : State W → (W → Prop) → Prop :=
     definition: `target` is not just a typological label. -/
 @[simp] theorem interp_eq_target_boxOn (m : VerbalOp) (c : State W)
     (p : W → Prop) :
-    m.interp c p = (Semantics.Mood.target m).boxOn c p := rfl
+    m.interp c p = (Mood.target m).boxOn c p := rfl
 
 /-! ### Definitional equalities -/
 
@@ -241,15 +241,15 @@ three components — at the verbal-mood layer, mood selection and
 State-component selection are the same thing by construction. -/
 
 theorem verbal_mood_target_informational_iff_indicative (m : VerbalOp) :
-    Semantics.Mood.target m = .informational ↔ m = .indicative := by
+    Mood.target m = .informational ↔ m = .indicative := by
   cases m <;> decide
 
 theorem verbal_mood_target_preferential_iff_subjunctive (m : VerbalOp) :
-    Semantics.Mood.target m = .preferential ↔ m = .subjunctive := by
+    Mood.target m = .preferential ↔ m = .subjunctive := by
   cases m <;> decide
 
 theorem verbal_mood_target_inquisitive_iff_interrogative (m : VerbalOp) :
-    Semantics.Mood.target m = .inquisitive ↔ m = .interrogative := by
+    Mood.target m = .inquisitive ↔ m = .interrogative := by
   cases m <;> decide
 
 /-! ### Bridge to `Selector`
@@ -330,6 +330,6 @@ def QuestionEmbedder.toVerbalOp : QuestionEmbedder → VerbalOp :=
     interrogative column are reached by *disjoint* lexical-class
     enums, with no overlap and no gap. -/
 theorem QuestionEmbedder.toVerbalOp_target (q : QuestionEmbedder) :
-    Semantics.Mood.target q.toVerbalOp = .inquisitive := rfl
+    Mood.target q.toVerbalOp = .inquisitive := rfl
 
-end Semantics.Mood
+end Mood

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -184,7 +184,7 @@ structure TAMEEntry where
   /-- Utterance perspective constraint: T vs S -/
   up : UPCondition
   /-- Grammatical mood (indicative, subjunctive), if specified -/
-  mood : Option Semantics.Mood.Grammatical := none
+  mood : Option Mood.Grammatical := none
   /-- Mirativity value (expected, unexpected, neutral), if specified -/
   mirative : Option MirativityValue := none
 

--- a/Linglib/Semantics/TypeTheoretic/Discourse.lean
+++ b/Linglib/Semantics/TypeTheoretic/Discourse.lean
@@ -10,7 +10,7 @@ import Linglib.Features.ClauseForm
 Discourse-level infrastructure for TTR ([cooper-2023], Chapters 2, 4, 5):
 
 **Signs & Illocutionary Force**: TTRSign, ForcedSign (§2.5–2.6) — the
-illocutionary force component reuses `Semantics.Mood.Illocutionary` rather
+illocutionary force component reuses `Mood.Illocutionary` rather
 than [cooper-2023]'s parallel four-way `IllocForce` enum (the surface
 distinction `assertion | query | command | acknowledgement` is the
 declarative/interrogative/imperative slice plus a backchannel constructor;
@@ -47,16 +47,16 @@ open Features
 Signs may carry illocutionary force. [cooper-2023]'s ex (91)
 introduces a four-way TTR-internal enum `assertion | query | command |
 acknowledgement`. We collapse `assertion/query/command` into
-`Semantics.Mood.Illocutionary`'s `declarative/interrogative/imperative`
+`Mood.Illocutionary`'s `declarative/interrogative/imperative`
 (the same Searlean cuts) and let backchannel acknowledgements be handled
 where dialogue moves live (`Pragmatics/Dialogue/Gameboard/`). The
 result: TTR signs share the rest of the library's mood vocabulary
 rather than re-stipulating it. -/
 
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 /-- A sign with illocutionary force. [cooper-2023] ex (91), with
-    `IllocForce` replaced by `Semantics.Mood.Illocutionary`. -/
+    `IllocForce` replaced by `Mood.Illocutionary`. -/
 structure ForcedSign (Phon Cont : Type) extends TTRSign Phon Cont where
   illoc : Illocutionary
 

--- a/Linglib/Studies/FarkasRoelofsen2017.lean
+++ b/Linglib/Studies/FarkasRoelofsen2017.lean
@@ -142,7 +142,7 @@ inductive Intonation where
     are explicitly out of scope.
 
     This triple refines the coarse declarative/interrogative cut of
-    `Semantics.Mood.Illocutionary` (which `Item.mood` carries). -/
+    `Mood.Illocutionary` (which `Item.mood` carries). -/
 structure MarkerTriple where
   clauseType : ClauseType
   intonation : Intonation

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -50,8 +50,8 @@ When neither departure is present, only indicative mood is possible.
 namespace Grano2024
 
 open Semantics.Lexical
-open Semantics.Mood (Grammatical EventDenotation)
-open Semantics.Mood
+open Mood (Grammatical EventDenotation)
+open Mood
 open Semantics.Attitudes.RationalAttitude
 
 -- ════════════════════════════════════════════════════════════════
@@ -527,7 +527,7 @@ theorem hope_verbalMood :
     (`Selector → VerbalOp → Component`) makes the operational
     target explicit. -/
 theorem want_target :
-    Option.map (Semantics.Mood.target ·) (deriveSelector want).toVerbalOp
+    Option.map (Mood.target ·) (deriveSelector want).toVerbalOp
       = some .preferential := by
   native_decide
 

--- a/Linglib/Studies/Holmberg2016.lean
+++ b/Linglib/Studies/Holmberg2016.lean
@@ -57,7 +57,7 @@ namespace Holmberg2016
 open Question
 open Features (AnsweringSystem PolarAnswerProfile)
 open Minimalist
-open Semantics.Mood (ClauseType Grammatical Illocutionary)
+open Mood (ClauseType Grammatical Illocutionary)
 
 /-! ### Syntactic polarity: PolP and [±Pol] (relocated from Minimalist/Polarity.lean)
 
@@ -205,7 +205,7 @@ unformalized — silent divergences, not committed disagreements.
 
 ## Connection to ClauseType
 
-A clause's `Semantics.Mood.ClauseType` (force × mood) is determined by
+A clause's `Mood.ClauseType` (force × mood) is determined by
 the syntactic projections:
 - Force⁰[+Q] → `Illocutionary.interrogative`
 - Force⁰[-Q] → `Illocutionary.declarative`

--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -37,7 +37,7 @@ namespace Iatridou2000
 
 open Semantics.Modality.Exclusion
 open Semantics.Context
-open Semantics.Mood (subjShift)
+open Mood (subjShift)
 open Data.Examples (LinguisticExample)
 
 /-! ### Iatridou's counterfactual typology -/
@@ -123,9 +123,9 @@ def iatridouSubjGeneralization (hasPastSubj requiresSubj : Bool) : Prop :=
   requiresSubj = hasPastSubj
 
 /-- All three CF types collapse to the framework-agnostic
-    `Semantics.Mood.SubjunctiveType.counterfactual` tag. -/
+    `Mood.SubjunctiveType.counterfactual` tag. -/
 def CounterfactualType.toSubjunctiveType (_ : CounterfactualType) :
-    Semantics.Mood.SubjunctiveType := .counterfactual
+    Mood.SubjunctiveType := .counterfactual
 
 theorem all_counterfactuals_are_counterfactual (t : CounterfactualType) :
     t.toSubjunctiveType = .counterfactual := by cases t <;> rfl

--- a/Linglib/Studies/Krifka2020.lean
+++ b/Linglib/Studies/Krifka2020.lean
@@ -58,7 +58,7 @@ the other — and study files target whichever is appropriate:
 
 namespace Discourse.Krifka
 
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Commitment Strength

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -42,7 +42,7 @@ open Intensional (WorldTimeIndex)
 open HistoricalAlternatives
 open Semantics.Dynamic.Core
 open Tense
-open Semantics.Mood
+open Mood
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/NapoliNespor1976.lean
+++ b/Linglib/Studies/NapoliNespor1976.lean
@@ -198,10 +198,10 @@ inductive CliticPresence where
 
 /-- §3.21: grammatical mood of the *than*-clause. Subjunctive surfaces
     iff *non₂* is underlyingly present (modulo lexical mood control by
-    *credere* etc., abstracted away here). Returning `Semantics.Mood.Grammatical`
+    *credere* etc., abstracted away here). Returning `Mood.Grammatical`
     rather than `Bool` connects this prediction to the mood semantics in
     `Semantics/Mood/`. -/
-def predictsGrammatical (p : BiasLicensingProfile) : Semantics.Mood.Grammatical :=
+def predictsGrammatical (p : BiasLicensingProfile) : Mood.Grammatical :=
   if p.licenses then .subjunctive else .indicative
 
 /-- §3.11 ex. 46–48: under bias-licensed negation the comparative admits

--- a/Linglib/Studies/Noonan2007.lean
+++ b/Linglib/Studies/Noonan2007.lean
@@ -46,7 +46,7 @@ namespace Noonan2007
 open Data.Complementation Data.Complementation.Noonan2007
 open English.Predicates.Verbal
 open Minimalist.LeftPeriphery
-open Semantics.Mood
+open Mood
 
 -- ============================================================================
 -- Part I: Noonan's generalizations over the generated CTP sample

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -49,7 +49,7 @@ standalone formalization of an imperative mood ontology:
   `TeleologicalFlavor` (no parallel types).
 - The architectural commitment "imperative force targets the
   preferential POSW component, not the informational" is
-  `Semantics.Mood.Component`'s `HasTarget Illocutionary`
+  `Mood.Component`'s `HasTarget Illocutionary`
   instance — Roberts agrees with [portner-2018] on the
   POSW component, disagrees with [kaufmann-2012] only on
   the prejacent's modal flavor.
@@ -85,7 +85,7 @@ Acc (accepted).
 
 namespace Discourse
 
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 /-- An illocutionary move: a speech act performed by an agent. -/
 structure Move (W : Type*) where
@@ -123,7 +123,7 @@ Force Linking Principle ([roberts-2023]).
 
 namespace Discourse
 
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 
 variable {W : Type*}
 
@@ -447,7 +447,7 @@ over the QUD stack. Interrogation ↔ `inquire`. -/
     (`⊤` as identity). Cons-right convention so that consing reduces
     definitionally to `inquire`. -/
 def qudInquiry (K : Scoreboard W) : Setoid W :=
-  K.qud.foldr (fun q s => s ⊓ Semantics.Mood.State.polarSetoid q) ⊤
+  K.qud.foldr (fun q s => s ⊓ Mood.State.polarSetoid q) ⊤
 
 @[simp] theorem qudInquiry_nil (K : Scoreboard W) (h : K.qud = []) :
     K.qudInquiry = (⊤ : Setoid W) := by
@@ -456,8 +456,8 @@ def qudInquiry (K : Scoreboard W) : Setoid W :=
 @[simp] theorem qudInquiry_cons (K : Scoreboard W) (q : W → Prop)
     (rest : List (W → Prop)) (h : K.qud = q :: rest) :
     K.qudInquiry =
-      (rest.foldr (fun q s => s ⊓ Semantics.Mood.State.polarSetoid q) ⊤) ⊓
-        Semantics.Mood.State.polarSetoid q := by
+      (rest.foldr (fun q s => s ⊓ Mood.State.polarSetoid q) ⊤) ⊓
+        Mood.State.polarSetoid q := by
   simp [qudInquiry, h]
 
 /-- Interrogation update preserves goal contents (doesn't touch G). -/
@@ -466,7 +466,7 @@ def qudInquiry (K : Scoreboard W) : Setoid W :=
     (K.interrogationUpdate q a).goalContents = K.goalContents := rfl
 
 /-- Project the scoreboard into a State: underlying state + QUD inquiry. -/
-def toMoodState (K : Scoreboard W) : Semantics.Mood.State W :=
+def toMoodState (K : Scoreboard W) : Mood.State W :=
   { K.toExpState with inquiry := K.qudInquiry }
 
 @[simp] theorem toMoodState_toExpState (K : Scoreboard W) :
@@ -480,7 +480,7 @@ def toMoodState (K : Scoreboard W) : Semantics.Mood.State W :=
 theorem toMoodState_interrogation_eq_inquire (K : Scoreboard W)
     (q : W → Prop) (a : Nat) :
     (K.interrogationUpdate q a).toMoodState.inquiry =
-      (K.toMoodState.inquire (Semantics.Mood.State.polarSetoid q)).inquiry := rfl
+      (K.toMoodState.inquire (Mood.State.polarSetoid q)).inquiry := rfl
 
 /-- After posing `q`, the polar partition of `q` is settled by
     the new State (inquiry analogue of `boxCs_after_assertion`). -/
@@ -498,8 +498,8 @@ namespace Roberts2023
 
 open Intensional (WorldTimeIndex)
 open Discourse (forceLinkingPrinciple defaultSemanticType Scoreboard)
-open Semantics.Mood.Illocutionary (sincerityCondition)
-open Semantics.Mood (State Component Illocutionary HasTarget)
+open Mood.Illocutionary (sincerityCondition)
+open Mood (State Component Illocutionary HasTarget)
 open Semantics.Dynamic.Default (ExpState)
 open HistoricalAlternatives
 open Semantics.Modality.Kratzer
@@ -693,7 +693,7 @@ theorem disagrees_with_ruytenbeek_imperative_flavor :
     prejacent's flavor matching the imperative's. -/
 theorem disagrees_with_assert :
     robertsImperativeFlavor ≠
-    Semantics.Mood.Illocutionary.primaryFlavor .imperative := by decide
+    Mood.Illocutionary.primaryFlavor .imperative := by decide
 
 /-- **Mechanism wedge** (post-2026-05-13: empirical wedge collapsed).
     `possibleDecl` ("Il est possible de VP") was previously the lone

--- a/Linglib/Studies/Rudin2025LI.lean
+++ b/Linglib/Studies/Rudin2025LI.lean
@@ -99,7 +99,7 @@ simultaneously be both values.
 namespace Discourse.QuotationFBOntology
 
 open Discourse.Commitment.Table
-open Semantics.Mood (Illocutionary)
+open Mood (Illocutionary)
 open Semantics.Quotation.Demonstration
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/RuytenbeekEtAl2017.lean
+++ b/Linglib/Studies/RuytenbeekEtAl2017.lean
@@ -77,7 +77,7 @@ regression coefficients.
 
 ## Mood substrate choice
 
-This file uses `Semantics.Mood.Illocutionary` rather than the
+This file uses `Mood.Illocutionary` rather than the
 Minimalist-derived `SAPMood`. The two are isomorphic on the
 declarative/interrogative/imperative cases used here, and
 `Illocutionary` is the canonical substrate (`SAPMood` adds
@@ -88,8 +88,8 @@ keeps the file independent of the Minimalist substrate.
 namespace RuytenbeekEtAl2017
 
 open Semantics.Modality (ModalFlavor ModalForce)
-open Semantics.Mood (Illocutionary)
-open Semantics.Mood.Illocutionary (primaryFlavor)
+open Mood (Illocutionary)
+open Mood.Illocutionary (primaryFlavor)
 
 /-! ### Sentence types and modal projections -/
 
@@ -145,7 +145,7 @@ def SentType.mood : SentType → Illocutionary
 /-- Contextually salient modal flavor for each sentence type.
 
     The imperative branch is **derived** from
-    `Semantics.Mood.Illocutionary.primaryFlavor` rather than restipulated
+    `Mood.Illocutionary.primaryFlavor` rather than restipulated
     (layered grounding — see `imperative_modalFlavor_eq_assert` below).
 
     `canDeclarative = .deontic` follows the paper's §3.4 Discussion

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -59,7 +59,7 @@ namespace SpeasTenny2003
 
 open Minimalist
 open Semantics.Context (KContext ContextTower ContextShift)
-open Semantics.Mood (Illocutionary ClauseType)
+open Mood (Illocutionary ClauseType)
 open Semantics.Epistemicity (EpistemicAuthority EpistemicProfile)
 
 /-! ### Pragmatic roles -/

--- a/Linglib/Studies/Stalnaker1975.lean
+++ b/Linglib/Studies/Stalnaker1975.lean
@@ -182,7 +182,7 @@ end Discourse.ReasonableInference
 
 namespace Stalnaker1975
 
-open Semantics.Mood (Grammatical)
+open Mood (Grammatical)
 open CommonGround (ContextSet)
 open _root_.Semantics.Conditionals (SelectionFunction)
 open Semantics.Conditionals

--- a/Linglib/Syntax/Clause/Context.lean
+++ b/Linglib/Syntax/Clause/Context.lean
@@ -4,7 +4,7 @@
 This file defines `Clause.Context`, the [sadock-zwicky-1985] sentence types
 with the interrogative split into polar, alternative, and constituent
 subtypes. `Clause.Embedding` is the orthogonal embedding axis;
-`Semantics.Mood.Illocutionary`, `Semantics.Mood.ClauseType`, and
+`Mood.Illocutionary`, `Mood.ClauseType`, and
 `Features.ClauseForm` are coarser cuts.
 -/
 


### PR DESCRIPTION
Mechanical namespace rename across 47 files: mathlib names namespaces by owning concept (`Filter`, `Polynomial`), the Semantics/ siblings already use bare concept namespaces (`HistoricalAlternatives`, `BranchingTime`), and a stray root `Mood.admissibleSelection` existed anyway. File paths unchanged (`Linglib/Semantics/Mood/`); `UD.Mood` (a type inside `namespace UD`) is unaffected.