### PR TITLE
style(Semantics/Mood): drop target export; tighten HasTarget docstrings

### DIFF
--- a/Linglib/Semantics/Mood/Defs.lean
+++ b/Linglib/Semantics/Mood/Defs.lean
@@ -112,10 +112,9 @@ def ClauseType.authority (ct : ClauseType) : DiscourseRole :=
 /-! ### Mood components -/
 
 /-- The component of the mood state that a mood-bearing object operates
-on ([portner-2018], Ch. 4): his unification thesis is that the surface
-diversity of mood phenomena reduces to which component gets touched. -/
+on ([portner-2018], Ch. 4). -/
 inductive Component where
-  /-- The information coordinate (`State.info`, Portner's context set). -/
+  /-- The information coordinate (`State.info`). -/
   | informational
   /-- The ordering coordinate (`State.order`). -/
   | preferential
@@ -123,21 +122,15 @@ inductive Component where
   | inquisitive
   deriving DecidableEq, Repr
 
-/-- The class of mood-bearing types: `target m` is the component `m`
-operates on. "Target" is selection-side vocabulary — a verbal mood is
-*selected by* the embedding attitude ([portner-2018], Ch. 2), so its
-target is the component the selecting predicate's modality quantifies
-over, not an operation the morpheme performs. -/
+/-- The class of mood-bearing types: `target m` is the component the
+context selecting `m` quantifies over, not an operation `m` performs. -/
 class HasTarget (M : Type*) where
   target : M → Component
 
-export HasTarget (target)
-
-/-- Sentence-mood targets ([portner-2018], Ch. 3). The promissive and
-exclamative assignments are linglib extensions beyond Portner's
-declarative/imperative/interrogative trichotomy; the exclamative one
-sits in tension with its null direction of fit
-(`Discourse/SpeechAct.lean`) and is a conjectural placeholder. -/
+/-- Sentence-mood targets ([portner-2018], Ch. 3). Promissive and
+exclamative are linglib extensions; the exclamative assignment
+conflicts with its null direction of fit (`Discourse/SpeechAct.lean`)
+and is a conjectural placeholder. -/
 instance : HasTarget Illocutionary where
   target
     | .declarative   => .informational

--- a/Linglib/Semantics/Mood/SpeechEvent.lean
+++ b/Linglib/Semantics/Mood/SpeechEvent.lean
@@ -53,6 +53,7 @@ namespace Mood
 
 open Semantics.Dynamic.Default
 open Semantics.Modality (ModalFlavor)
+open HasTarget (target)
 open Semantics.Modality.EventRelativity (EventProjection)
 
 variable {W : Type*}

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -71,6 +71,7 @@ matrix predicate (`Selector` for declarative-embedders;
 namespace Mood
 
 open Semantics.Dynamic.Default
+open HasTarget (target)
 
 variable {W : Type*}
 
@@ -110,13 +111,13 @@ instance : HasTarget VerbalOp where
     | .interrogative => .inquisitive
 
 @[simp] theorem target_indicative :
-    Mood.target VerbalOp.indicative = .informational := rfl
+    target VerbalOp.indicative = .informational := rfl
 
 @[simp] theorem target_subjunctive :
-    Mood.target VerbalOp.subjunctive = .preferential := rfl
+    target VerbalOp.subjunctive = .preferential := rfl
 
 @[simp] theorem target_interrogative :
-    Mood.target VerbalOp.interrogative = .inquisitive := rfl
+    target VerbalOp.interrogative = .inquisitive := rfl
 
 /-- Compositional interpretation of a verbal-mood operator against an
     embedding State and an embedded proposition: run the necessity
@@ -133,7 +134,7 @@ def VerbalOp.interp (m : VerbalOp) : State W → (W → Prop) → Prop :=
     definition: `target` is not just a typological label. -/
 @[simp] theorem interp_eq_target_boxOn (m : VerbalOp) (c : State W)
     (p : W → Prop) :
-    m.interp c p = (Mood.target m).boxOn c p := rfl
+    m.interp c p = (target m).boxOn c p := rfl
 
 /-! ### Definitional equalities -/
 
@@ -240,15 +241,15 @@ three components — at the verbal-mood layer, mood selection and
 State-component selection are the same thing by construction. -/
 
 theorem verbal_mood_target_informational_iff_indicative (m : VerbalOp) :
-    Mood.target m = .informational ↔ m = .indicative := by
+    target m = .informational ↔ m = .indicative := by
   cases m <;> decide
 
 theorem verbal_mood_target_preferential_iff_subjunctive (m : VerbalOp) :
-    Mood.target m = .preferential ↔ m = .subjunctive := by
+    target m = .preferential ↔ m = .subjunctive := by
   cases m <;> decide
 
 theorem verbal_mood_target_inquisitive_iff_interrogative (m : VerbalOp) :
-    Mood.target m = .inquisitive ↔ m = .interrogative := by
+    target m = .inquisitive ↔ m = .interrogative := by
   cases m <;> decide
 
 /-! ### Bridge to `Selector`
@@ -329,6 +330,6 @@ def QuestionEmbedder.toVerbalOp : QuestionEmbedder → VerbalOp :=
     interrogative column are reached by *disjoint* lexical-class
     enums, with no overlap and no gap. -/
 theorem QuestionEmbedder.toVerbalOp_target (q : QuestionEmbedder) :
-    Mood.target q.toVerbalOp = .inquisitive := rfl
+    target q.toVerbalOp = .inquisitive := rfl
 
 end Mood

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -527,7 +527,7 @@ theorem hope_verbalMood :
     (`Selector → VerbalOp → Component`) makes the operational
     target explicit. -/
 theorem want_target :
-    Option.map (Mood.target ·) (deriveSelector want).toVerbalOp
+    Option.map (Mood.HasTarget.target ·) (deriveSelector want).toVerbalOp
       = some .preferential := by
   native_decide
 


### PR DESCRIPTION
Removes `export HasTarget (target)` — the generic name no longer leaks into the root `Mood` namespace; `Verbal.lean`/`SpeechEvent.lean` opt in with a file-local `open HasTarget (target)` (the mathlib pattern), and study consumers qualify. Also brings the `Component`/`HasTarget`/instance docstrings to the ratified register: the thesis clause that duplicated the module docstring is cut, the selection-side caveat compresses to one guard sentence, case docstrings are bare coordinate pointers.