### PR TITLE
style(Semantics/Mood): copyright headers; cleanse Eventuality.lean

### DIFF
--- a/Linglib/Semantics/Mood/Defs.lean
+++ b/Linglib/Semantics/Mood/Defs.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Discourse.Roles
 import Linglib.Data.UD.Basic
 import Mathlib.Tactic.DeriveFintype

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Dynamic.Core.ContextFilter
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Mood.Situation

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -54,8 +54,7 @@ inductive EventDenotation (Event : Type*) where
   | abstracted (p : Event → Prop)
 
 /-- The event-level denotation of a complement under each grammatical
-mood ([grano-2024]): the assignment is the theory's sole stipulation;
-openness facts follow from the constructors. -/
+mood ([grano-2024]). -/
 def Grammatical.eventDenotation (P : Event → Prop) :
     Grammatical → EventDenotation Event
   | .indicative  => .closed (INDev P)

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -26,16 +26,16 @@ namespace Mood
 
 variable {Event : Type*}
 
-/-- Indicative closure ([grano-2024], (87)): `⟦INDIC⟧ = λP.∃e.P(e)`,
-so the complement denotes a proposition. -/
+/-- The indicative existentially closes the complement's event
+argument, yielding a proposition ([grano-2024], (87)). -/
 def INDev (P : Event → Prop) : Prop := ∃ e, P e
 
-/-- Subjunctive non-closure ([grano-2024], (88a)): `⟦SBJV₁⟧ = λP.P`,
-leaving the complement open for eventuality abstraction. -/
+/-- The subjunctive leaves the complement's event argument open for
+abstraction ([grano-2024], (88a)). -/
 def SBJVev₁ (P : Event → Prop) : Event → Prop := P
 
-/-- The *intend* variant ([grano-2024], (134)): the attitude state must
-causally bring about the described event ([searle-1983]). -/
+/-- The *intend* subjunctive: the attitude state must causally bring
+about the described event ([grano-2024], (134); [searle-1983]). -/
 def SBJVev₂ {W : Type*}
     (causeStar : Event → Event → W → Prop)  -- CAUSE*(state, event, world)
     (content : Event → W → Prop)          -- content of the attitude state

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -26,22 +26,16 @@ namespace Mood
 
 variable {Event : Type*}
 
-/-- Indicative closure of the eventuality argument ([grano-2024], (87)):
-`⟦INDIC⟧ = λP.∃e.P(e)`. The complement denotes a proposition. -/
+/-- Indicative closure ([grano-2024], (87)): `⟦INDIC⟧ = λP.∃e.P(e)`,
+so the complement denotes a proposition. -/
 def INDev (P : Event → Prop) : Prop := ∃ e, P e
 
-/-- Subjunctive non-closure ([grano-2024], (88a); Subjunctive₃ (135) in
-his §7 unified theory): `⟦SBJV₁⟧ = λP.P`. The complement stays an event
-predicate, open for abstraction — the variant for perception,
-causative, and aspectual predicates, without the causal
-self-reference of `SBJVev₂` or the ordering semantics of his
-Subjunctive₁. -/
+/-- Subjunctive non-closure ([grano-2024], (88a)): `⟦SBJV₁⟧ = λP.P`,
+leaving the complement open for eventuality abstraction. -/
 def SBJVev₁ (P : Event → Prop) : Event → Prop := P
 
-/-- The *intend* variant, with causal self-reference ([grano-2024],
-(134), integrating CAUSE* with [portner-rubinstein-2020]'s modal
-framework): the attitude state must causally bring about the
-described event "in the right way" ([searle-1983]; [harman-1976]). -/
+/-- The *intend* variant ([grano-2024], (134)): the attitude state must
+causally bring about the described event ([searle-1983]). -/
 def SBJVev₂ {W : Type*}
     (causeStar : Event → Event → W → Prop)  -- CAUSE*(state, event, world)
     (content : Event → W → Prop)          -- content of the attitude state

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -14,12 +14,7 @@ following [grano-2024]: mood morphemes operate on the eventuality
 argument of the complement clause. Indicative existentially closes
 it, yielding a proposition; subjunctive leaves it open, as required
 by causatives, intention reports, aspectual predicates, and
-memory/perception reports. `Grammatical.eventDenotation` assigns each
-mood its operator, landing in the constructor-distinguished
-`EventDenotation`, so the closed/open contrast is read off the
-constructor rather than stipulated in a feature table. The
-situation-level dimension is `Semantics/Mood/Situation.lean`, the
-dynamic lifts `Semantics/Mood/Dynamic.lean`.
+memory/perception reports.
 -/
 
 namespace Mood

--- a/Linglib/Semantics/Mood/Eventuality.lean
+++ b/Linglib/Semantics/Mood/Eventuality.lean
@@ -1,119 +1,80 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Tactic.TypeStar
 import Linglib.Semantics.Mood.Defs
 
 /-!
-# Event-Level Mood Operators
-[grano-2024]
+# Event-level mood operators
 
-[grano-2024] proposes that mood morphemes operate on the eventuality
-argument of the complement clause: indicative existentially closes it
-(`INDev`, his (87)), yielding a proposition; subjunctive leaves it
-open for abstraction (`SBJVev₁`, his (88a)), as required by
-causatives, intention reports, aspectual predicates, and
-memory/perception reports; the *intend* variant additionally requires
-causal self-reference (`SBJVev₂`, his (134)). This is the event-level
-dimension of grammatical mood, complementary to the situation-level
-dimension of `Semantics/Mood/Situation.lean`.
-
-The closed/open contrast is carried by the *type* of the denotation.
-`Grammatical.eventDenotation` assigns each mood its operator, landing
-in the constructor-distinguished `EventDenotation`; that indicative
-closes and subjunctive abstracts is then read off the constructor
-(`eventDenotation_indicative`, `eventDenotation_subjunctive`) rather
-than stipulated in a feature table.
+This file defines the event-level dimension of grammatical mood,
+following [grano-2024]: mood morphemes operate on the eventuality
+argument of the complement clause. Indicative existentially closes
+it, yielding a proposition; subjunctive leaves it open, as required
+by causatives, intention reports, aspectual predicates, and
+memory/perception reports. `Grammatical.eventDenotation` assigns each
+mood its operator, landing in the constructor-distinguished
+`EventDenotation`, so the closed/open contrast is read off the
+constructor rather than stipulated in a feature table. The
+situation-level dimension is `Semantics/Mood/Situation.lean`, the
+dynamic lifts `Semantics/Mood/Dynamic.lean`.
 -/
 
 namespace Mood
 
-/-- IND existentially closes the eventuality argument ([grano-2024], (87)).
+variable {Event : Type*}
 
-    ⟦INDIC⟧ = λP_(⟨vt⟩).∃e.P(e)
+/-- Indicative closure of the eventuality argument ([grano-2024], (87)):
+`⟦INDIC⟧ = λP.∃e.P(e)`. The complement denotes a proposition. -/
+def INDev (P : Event → Prop) : Prop := ∃ e, P e
 
-    The eventuality variable is bound; the complement denotes a proposition. -/
-def INDev {Event : Type*} (P : Event → Prop) : Prop := ∃ e, P e
+/-- Subjunctive non-closure ([grano-2024], (88a); Subjunctive₃ (135) in
+his §7 unified theory): `⟦SBJV₁⟧ = λP.P`. The complement stays an event
+predicate, open for abstraction — the variant for perception,
+causative, and aspectual predicates, without the causal
+self-reference of `SBJVev₂` or the ordering semantics of his
+Subjunctive₁. -/
+def SBJVev₁ (P : Event → Prop) : Event → Prop := P
 
-/-- SBJV₁ leaves the eventuality argument open ([grano-2024], (88a);
-    §7 Subjunctive₃ (135)).
-
-    ⟦SBJV₁⟧ = λP_(⟨vt⟩).P
-
-    The complement retains type ⟨vt⟩ — an event predicate, not a proposition.
-    In the core proposal (§5, (88a)), this is the general non-closing mood
-    operator. In the §7 unified theory, it becomes specifically Subjunctive₃
-    (135) — the identity variant for perception predicates ('see'), causative
-    predicates ('make'), and aspectual predicates ('begin'). These predicates
-    require or are compatible with eventuality abstraction but do not involve
-    causal self-reference or ordering semantics. Distinct from the 'want'
-    variant (§7, Subjunctive₁ (133)), which uses Portner & Rubinstein's `ln`
-    (local necessity), and the 'intend' variant (Subjunctive₂ (134) =
-    `SBJVev₂`), which incorporates CAUSE*. -/
-def SBJVev₁ {Event : Type*} (P : Event → Prop) : Event → Prop := P
-
-/-- SBJV₂ leaves the eventuality argument open AND requires causal
-    self-reference ([grano-2024], (134); unified theory §7).
-
-    ⟦Subjunctive₂⟧ = λPλe[sn({λw.∃e'.CAUSE*(e,e',w) & P(w)(e')}, content(e), e)]
-
-    This is the variant operative with 'intend' in the §7 unified theory,
-    which integrates CAUSE* from the core proposal (§4, (79)) with Portner
-    & Rubinstein's ([portner-rubinstein-2020]) modal quantification
-    framework. The attitude state e must causally bring about the described
-    event e' "in the right way" ([searle-1983]; [harman-1976]). -/
-def SBJVev₂ {Event W : Type*}
+/-- The *intend* variant, with causal self-reference ([grano-2024],
+(134), integrating CAUSE* with [portner-rubinstein-2020]'s modal
+framework): the attitude state must causally bring about the
+described event "in the right way" ([searle-1983]; [harman-1976]). -/
+def SBJVev₂ {W : Type*}
     (causeStar : Event → Event → W → Prop)  -- CAUSE*(state, event, world)
     (content : Event → W → Prop)          -- content of the attitude state
     (P : W → Event → Prop)               -- world-indexed event predicate
     (e : Event) : Prop :=
   ∀ w, content e w → ∃ e', causeStar e e' w ∧ P w e'
 
-/-- IND closure yields a proposition (no free eventuality variable). -/
-theorem INDev_is_propositional {Event : Type*} (P : Event → Prop) :
-    (INDev P) = (∃ e, P e) := rfl
+/-! ### Mood as event closure, by constructor -/
 
-/-- SBJV₁ is the identity on event predicates. -/
-theorem SBJVev₁_is_identity {Event : Type*} (P : Event → Prop) :
-    SBJVev₁ P = P := rfl
-
-/-! ### Mood as event closure, by constructor
-
-The result of applying a mood's event operator: either a *closed*
-proposition (the event argument is bound) or an *abstracted* event
-predicate (the argument remains open). The closed/open distinction is
-the constructor, so downstream facts about which moods enable
-eventuality abstraction are read off `Grammatical.eventDenotation`
-rather than stipulated. -/
-
-/-- The result of a mood's event-level denotation: a proposition with
-    the event argument closed, or an event predicate with the argument
-    still open for abstraction. -/
+/-- The result of a mood's event-level denotation: the event argument
+closed to a proposition, or still open for abstraction. -/
 inductive EventDenotation (Event : Type*) where
   /-- The event argument has been existentially closed. -/
   | closed (p : Prop)
   /-- The event argument remains open for abstraction. -/
   | abstracted (p : Event → Prop)
 
-/-- The event-level denotation each grammatical mood assigns to a
-    complement's event predicate ([grano-2024]): indicative applies
-    `INDev` (closing), subjunctive applies `SBJVev₁` (abstracting).
-    This assignment is the theory's sole stipulation; openness facts
-    follow from the constructors. -/
-def Grammatical.eventDenotation {Event : Type*} (P : Event → Prop) :
+/-- The event-level denotation of a complement under each grammatical
+mood ([grano-2024]): the assignment is the theory's sole stipulation;
+openness facts follow from the constructors. -/
+def Grammatical.eventDenotation (P : Event → Prop) :
     Grammatical → EventDenotation Event
   | .indicative  => .closed (INDev P)
   | .subjunctive => .abstracted (SBJVev₁ P)
 
-/-- Indicative closes the event argument: its denotation lands in
-    `closed`. The formal correlate of [grano-2024]'s premise that
-    indicative complements cannot feed CAUSE* or aspectual operators
-    that bind the event variable. -/
-@[simp] theorem eventDenotation_indicative {Event : Type*} (P : Event → Prop) :
+/-- Indicative closes the event argument — why indicative complements
+cannot feed CAUSE* or aspectual operators ([grano-2024]). -/
+@[simp] theorem eventDenotation_indicative (P : Event → Prop) :
     Grammatical.indicative.eventDenotation P = .closed (∃ e, P e) := rfl
 
-/-- Subjunctive leaves the event argument open: its denotation lands in
-    `abstracted`, with the predicate unchanged. The formal correlate of
-    [grano-2024]'s premise that subjunctive complements feed
-    eventuality abstraction. -/
-@[simp] theorem eventDenotation_subjunctive {Event : Type*} (P : Event → Prop) :
+/-- Subjunctive leaves the event argument open — why subjunctive
+complements feed eventuality abstraction ([grano-2024]). -/
+@[simp] theorem eventDenotation_subjunctive (P : Event → Prop) :
     Grammatical.subjunctive.eventDenotation P = .abstracted P := rfl
 
 end Mood

--- a/Linglib/Semantics/Mood/Modal.lean
+++ b/Linglib/Semantics/Mood/Modal.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 
 /-!

--- a/Linglib/Semantics/Mood/PartitionAsInquiry.lean
+++ b/Linglib/Semantics/Mood/PartitionAsInquiry.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Data.Setoid.Partition
 import Linglib.Semantics.Questions.Basic
 import Linglib.Semantics.Mood.State

--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Context.Shifts
 

--- a/Linglib/Semantics/Mood/SpeechEvent.lean
+++ b/Linglib/Semantics/Mood/SpeechEvent.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Mood.State
 import Linglib.Semantics.Modality.EventRelativity
 

--- a/Linglib/Semantics/Mood/State.lean
+++ b/Linglib/Semantics/Mood/State.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Data.Setoid.Basic
 import Linglib.Semantics.Mood.Defs
 import Linglib.Semantics.Mood.Modal

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Mood.Modal
 import Linglib.Semantics.Mood.State
 import Linglib.Semantics.Mood.Defs


### PR DESCRIPTION
Adds the standard copyright header to the eight Mood files missing it (Dynamic.lean's rides on #1294), and applies the ratified register to `Eventuality.lean`: mathlib-shaped module docstring, one-to-three-line decl docstrings, recurring `{Event : Type*}` lifted to a variable block, and the two zero-consumer `rfl` definition-restatements (`INDev_is_propositional`, `SBJVev₁_is_identity`) deleted. The `eventDenotation_*` `@[simp]` pair stays as the normal-form rewrite set. Not consolidated into `Defs.lean`: it is semantics rather than categories (Defs' documented contract), and one of the three parallel dimension files.