### PR TITLE
feat(Semantics/Modality): induce ExpState from Kratzer pairs

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1661,6 +1661,7 @@ import Linglib.Semantics.Dynamic.Postsupposition
 import Linglib.Semantics.Dynamic.UpdateSemantics.Basic
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 import Linglib.Semantics.Dynamic.UpdateSemantics.Frames
+import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
 import Linglib.Semantics.Entailment.AntiAdditivity
 import Linglib.Semantics.Entailment.AsymStronger
 import Linglib.Semantics.Entailment.Basic
@@ -1730,7 +1731,6 @@ import Linglib.Semantics.Modality.ActualityEntailments
 import Linglib.Semantics.Mood.Defs
 import Linglib.Semantics.Mood.Dynamic
 import Linglib.Semantics.Mood.Eventuality
-import Linglib.Semantics.Mood.Modal
 import Linglib.Semantics.Mood.PartitionAsInquiry
 import Linglib.Semantics.Mood.Situation
 import Linglib.Semantics.Mood.SpeechEvent

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Necessity.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Necessity.lean
@@ -6,8 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 
 /-!
-# Mood Modals: Portner's POSW API over Expectation States
-[portner-2018] [veltman-1996] [kratzer-1981] [stalnaker-1978] [condoravdi-lauer-2012]
+# Necessity modals over expectation states
 
 [portner-2018]'s **partially ordered set of worlds** (posw, his (1),
 Ch. 4) — the pair `⟨cs, ≤⟩` of a context set and an ordering that his
@@ -142,12 +141,9 @@ theorem boxLe_of_respects (σ : ExpState W) (p : W → Prop)
 
 end Semantics.Dynamic.Default.ExpState
 
-namespace Mood
+namespace Semantics.Dynamic.Default
 
-open Semantics.Dynamic.Default
-
-universe u
-variable {W : Type u}
+variable {W : Type*}
 
 /-! ### Normal modality structure
 
@@ -163,7 +159,7 @@ structure under boolean operations instead. -/
     necessitation (`box ⊤`) and the K-axiom (`box (p → q) → box p
     → box q`). The two universal modals `ExpState.boxCs` and
     `ExpState.boxLe` are normal; `State.boxAns` is not. -/
-class NormalModality (W : Type u) (box : (W → Prop) → Prop) : Prop where
+class NormalModality (W : Type*) (box : (W → Prop) → Prop) : Prop where
   /-- Necessitation: the box always holds for `⊤`. -/
   necessitation : box (fun _ => True)
   /-- The K-axiom: distribution of the box over implication. -/
@@ -177,4 +173,4 @@ instance (σ : ExpState W) : NormalModality W σ.boxLe where
   necessitation := fun _ _ => trivial
   K _ _ hpq hp w hopt := hpq w hopt (hp w hopt)
 
-end Mood
+end Semantics.Dynamic.Default

--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -38,6 +38,7 @@ Sources:
 
 import Linglib.Semantics.Modality.Kratzer.Ordering
 import Linglib.Core.Logic.Modal.Basic
+import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
 
 namespace Semantics.Modality.Kratzer
 
@@ -91,6 +92,48 @@ def necessity (f : ModalBase W) (g : OrderingSource W) (p : W → Prop) (w : W) 
     `⟦can⟧_{f,g}(p)(w) = ∃w' ∈ Best(f,g,w). p(w')`. -/
 def possibility (f : ModalBase W) (g : OrderingSource W) (p : W → Prop) (w : W) : Prop :=
   diamond (kratzerBestR f g) p w
+
+/-! ### The Portner identification
+
+[portner-2018]'s gloss on his (3): reading the mood state's components
+as a modal base and ordering source, `□_cs` expresses simple necessity
+and `□_≤` human necessity ([kratzer-1981]). Stated over `stateAt`. -/
+
+open Semantics.Dynamic.Default in
+/-- Simple necessity is informational necessity over the induced state
+(the ordering source is irrelevant). -/
+theorem simpleNecessity_iff_boxCs (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W) :
+    simpleNecessity f p w ↔ (stateAt f g w).boxCs p :=
+  Iff.rfl
+
+open Semantics.Dynamic.Default in
+/-- Preferential necessity over the induced state implies Kratzer
+necessity: `bestWorlds` is contained in the state's optimal set. -/
+theorem necessity_of_boxLe (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W)
+    (h : (stateAt f g w).boxLe p) : necessity f g p w :=
+  fun w' hw' => h w' (bestWorlds_subset_optimal f g w hw')
+
+open Semantics.Dynamic.Default in
+/-- On connected ordering sources, Kratzer necessity is preferential
+necessity over the induced state — human necessity as `□_≤`. -/
+theorem necessity_iff_boxLe_of_connected (f : ModalBase W)
+    (g : OrderingSource W) (p : W → Prop) (w : W)
+    (hconn : Core.Order.Normality.connected (kratzerNormality (g w))) :
+    necessity f g p w ↔ (stateAt f g w).boxLe p := by
+  rw [show necessity f g p w ↔ ∀ w' ∈ bestWorlds f g w, p w' from Iff.rfl,
+    bestWorlds_eq_optimal_of_connected f g w hconn]
+  exact Iff.rfl
+
+open Semantics.Dynamic.Default ExpState in
+/-- Veltman acceptance at a Kratzer state: the induced state supports
+asserting `p` iff `p` is a simple necessity. -/
+theorem le_assert_iff_simpleNecessity (f : ModalBase W)
+    (g : OrderingSource W) (p : W → Prop) (w : W) :
+    stateAt f g w ≤ (stateAt f g w).assert p ↔ simpleNecessity f p w :=
+  ((stateAt f g w).le_assert_iff p).trans
+    (simpleNecessity_iff_boxCs f g p w).symm
 
 /-! ### Characterization lemmas -/
 

--- a/Linglib/Semantics/Modality/Kratzer/Ordering.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Ordering.lean
@@ -14,6 +14,7 @@ All types are polymorphic over the world type `W`. Propositions are
 
 import Linglib.Semantics.Modality.Kratzer.ConversationalBackground
 import Linglib.Core.Order.Normality
+import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 import Linglib.Core.Order.OfCriteria
 import Mathlib.Order.Basic
 import Mathlib.Data.Set.Basic
@@ -177,6 +178,47 @@ theorem empty_ordering_emptyBackground (f : ModalBase W) (w : W) :
     bestWorlds f emptyBackground w = accessibleWorlds f w := by
   unfold emptyBackground
   exact empty_ordering_simple f w
+
+/-! ### The induced expectation state
+
+[portner-2018] identifies the two components of his mood state with
+Kratzer's parameters: "If we think of ⟨cs_c, <_c⟩ as a modal base and
+ordering source, □_cs φ expresses simple necessity and □_< φ expresses
+human necessity" (his commentary on (3), citing [kratzer-1981]).
+`stateAt` is that identification read in the other direction: a
+Kratzer pair is a world-indexed family of expectation states. -/
+
+open Semantics.Dynamic.Default in
+/-- The expectation state a modal base and ordering source induce at a
+world: accessible worlds as information, the ordering-source ranking
+as pattern. -/
+def stateAt (f : ModalBase W) (g : OrderingSource W) (w : W) :
+    ExpState W :=
+  ⟨accessibleWorlds f w, kratzerNormality (g w)⟩
+
+@[simp] theorem stateAt_info (f : ModalBase W) (g : OrderingSource W) (w : W) :
+    (stateAt f g w).info = accessibleWorlds f w := rfl
+
+@[simp] theorem stateAt_order (f : ModalBase W) (g : OrderingSource W) (w : W) :
+    (stateAt f g w).order = kratzerNormality (g w) := rfl
+
+/-- Dominant best worlds are optimal: `bestWorlds` requires being at
+least as good as every accessible world, `ExpState.optimal` only
+non-domination, so the former is the stronger notion on non-connected
+orderings. -/
+theorem bestWorlds_subset_optimal (f : ModalBase W) (g : OrderingSource W)
+    (w : W) :
+    bestWorlds f g w ⊆ (stateAt f g w).optimal :=
+  fun _ hw => ⟨hw.1, fun v hv _ => hw.2 v hv⟩
+
+/-- On connected orderings the two best-world notions coincide. -/
+theorem bestWorlds_eq_optimal_of_connected (f : ModalBase W)
+    (g : OrderingSource W) (w : W)
+    (hconn : Core.Order.Normality.connected (kratzerNormality (g w))) :
+    bestWorlds f g w = (stateAt f g w).optimal :=
+  Set.Subset.antisymm (bestWorlds_subset_optimal f g w)
+    (fun w' hw' => ⟨hw'.1, fun v hv =>
+      (hconn w' v).elim id (fun h => hw'.2 hv h)⟩)
 
 /-- The best worlds among a given set, ranked by an ordering.
     Unlike `bestWorlds` which computes accessible worlds from a modal base,

--- a/Linglib/Semantics/Mood/State.lean
+++ b/Linglib/Semantics/Mood/State.lean
@@ -5,14 +5,14 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.Setoid.Basic
 import Linglib.Semantics.Mood.Defs
-import Linglib.Semantics.Mood.Modal
+import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
 
 /-!
 # Mood State: POSW with Inquiry Partition
 [portner-2018] [groenendijk-stokhof-1984] [roberts-2012]
 
 This file is **our extension** of the POSW substrate
-(`Semantics/Mood/Modal.lean`: [veltman-1996]'s `ExpState` under
+(`Semantics/Dynamic/UpdateSemantics/Necessity.lean`: [veltman-1996]'s `ExpState` under
 [portner-2018]'s modal reading) to interrogative force, by way of a
 third component recording the open question: `info` and `order` stay
 intact and `inquiry : Setoid W` is a separate third coordinate, so

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Semantics.Mood.Modal
+import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
 import Linglib.Semantics.Mood.State
 import Linglib.Semantics.Mood.Defs
 

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Intensional.WorldTimeIndex
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Mood.Defs
-import Linglib.Semantics.Mood.Modal
+import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
 import Linglib.Discourse.SpeechAct
 import Linglib.Semantics.Modality.Kratzer.Flavor
 import Linglib.Semantics.Modality.Directive
@@ -324,7 +324,7 @@ def directionUpdate (K : Scoreboard W) (p : W → Prop)
 
 The scoreboard's CommonGround and G components project jointly into a
 the POSW substrate (`Semantics.Dynamic.Default.ExpState` under its
-`Semantics/Mood/Modal.lean` modal reading): CommonGround via
+`Semantics/Dynamic/UpdateSemantics/Necessity.lean` modal reading): CommonGround via
 `contextSet`, G via the goal-induced preference ordering. Assertion ↔
 `assert`, direction ↔ `promote`. -/
 


### PR DESCRIPTION
Wires the Modality↔Mood connection at its core, formalizing [portner-2018]'s own gloss on his (3) ("if we think of ⟨cs, <⟩ as a modal base and ordering source, □cs expresses simple necessity and □< human necessity", citing Kratzer 1981).

- `Kratzer.stateAt f g w`: a modal base + ordering source is a world-indexed family of expectation states (finally consuming the previously dead `kratzerNormality` hook).
- Bridges: `simpleNecessity_iff_boxCs` (definitional), `necessity_of_boxLe`, `necessity_iff_boxLe_of_connected`, `le_assert_iff_simpleNecessity` (Veltman acceptance at Kratzer states), and `bestWorlds_subset_optimal` + connected equality — surfacing that `bestWorlds` uses the dominance form where Portner glosses Kratzer's Best as the Minimal form (migration deferred pending Kratzer 1981).
- `Mood/Modal.lean` → `UpdateSemantics/Necessity.lean`: the state necessity modals graduate to the Veltman layer now that both Mood and Modality consume them — Modality never imports Mood/.