### PR TITLE
feat(Semantics/Mood): HasTarget ModalFlavor; realism as fiber-reflexivity

### DIFF
--- a/Linglib/Semantics/Modality/Kratzer/Ordering.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Ordering.lean
@@ -211,6 +211,13 @@ theorem bestWorlds_subset_optimal (f : ModalBase W) (g : OrderingSource W)
     bestWorlds f g w ⊆ (stateAt f g w).optimal :=
   fun _ hw => ⟨hw.1, fun v hv _ => hw.2 v hv⟩
 
+/-- Realism is fiber-reflexivity: a modal base is realistic iff every
+world belongs to its own induced information state. -/
+theorem isRealistic_iff_mem_stateAt_info (f : ModalBase W)
+    (g : OrderingSource W) :
+    isRealistic f ↔ ∀ w, w ∈ (stateAt f g w).info :=
+  ⟨fun h w p hp => h w p hp, fun h w p hp => h w p hp⟩
+
 /-- On connected orderings the two best-world notions coincide. -/
 theorem bestWorlds_eq_optimal_of_connected (f : ModalBase W)
     (g : OrderingSource W) (w : W)

--- a/Linglib/Semantics/Mood/SpeechEvent.lean
+++ b/Linglib/Semantics/Mood/SpeechEvent.lean
@@ -182,6 +182,21 @@ theorem SpeechEvent.modal_declarative_iff
 
 /-! ### Flavor factors through the component classification -/
 
+/-- Modal flavors target the component their Kratzer parameter feeds:
+modal-base flavors the informational component, ordering-source
+flavors the preferential ([kratzer-1981]'s parameter roles under
+[portner-2018]'s component identification — imperatives as deontic
+ordering-source modals, desires as the ordering in his (4)). The
+third `HasTarget` instance, beside sentence mood (`Mood/Defs.lean`)
+and verbal mood (`Mood/Verbal.lean`): Portner's unification of
+verbal mood, sentence mood, and modal flavor as one classification. -/
+instance : HasTarget Semantics.Modality.ModalFlavor where
+  target
+    | .epistemic      => .informational
+    | .deontic        => .preferential
+    | .bouletic       => .preferential
+    | .circumstantial => .informational
+
 /-- The modal flavor a POSW component licenses, on [hacquard-2006]'s
     reading of `CON(e*)`: the informational component carries belief
     content (epistemic), the preferential component carries To-Do
@@ -202,6 +217,13 @@ def Component.flavor : Component → ModalFlavor
     imperative, and quotative acts. -/
 def Illocutionary.primaryFlavor (f : Illocutionary) : ModalFlavor :=
   (target f).flavor
+
+/-- `Component.flavor` is a section of the modal-flavor targeting on
+the two POSW components: the representative flavor of a component
+targets that component back. -/
+theorem target_flavor (c : Component) (h : c ≠ .inquisitive) :
+    target c.flavor = c := by
+  cases c <;> first | rfl | exact absurd rfl h
 
 /-- Hacquard's flavor assignment factors through [portner-2018]'s
     component targeting — definitionally. -/


### PR DESCRIPTION
Completes the paper-faithful core of the Modality↔Mood wiring on top of #1296, under the settled ontology (UpdateSemantics = state substrate; Modality = world-indexed families of states; Mood = fiber theory + grammatical functors; Modality never imports Mood).

- `instance : HasTarget ModalFlavor` (declared in Mood, the downstream layer): modal-base flavors ↦ informational, ordering-source flavors ↦ preferential — the third instance of [portner-2018]'s one classification, book-verified (p. 233: imperatives as deontic ordering-source modals; desires as the ordering in his (4)); plus the section lemma `target_flavor`.
- `isRealistic_iff_mem_stateAt_info`: Kratzer's realism postulate is fiber-reflexivity — every world belongs to its own induced information state.