### PR TITLE
fix(Semantics/Modality): bestWorlds as minimality, per Kratzer 1981

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2422,6 +2422,7 @@ import Linglib.Studies.KonukEtAl2026
 import Linglib.Studies.KoontzGarboden2009
 import Linglib.Studies.Kramer2020
 import Linglib.Studies.Kratzer1977
+import Linglib.Studies.Kratzer1981
 import Linglib.Studies.Kratzer1996
 import Linglib.Studies.Kratzer1998
 import Linglib.Studies.Kratzer2012Conditionals

--- a/Linglib/Semantics/Modality/Directive.lean
+++ b/Linglib/Semantics/Modality/Directive.lean
@@ -15,17 +15,19 @@ Strong and weak necessity share the same modal base (circumstantial) but differ
 in ordering:
 
 - **Strong necessity** (must φ): necessity under ordering g
-- **Weak necessity** (ought φ): necessity under refined ordering g ∪ g'
+- **Weak necessity** (ought φ): necessity over the g'-best of the
+  g-best worlds
 
-The secondary ordering g' adds criteria beyond the primary norms, creating a
-more discriminating ranking. More criteria → smaller "best" set → the universal
-quantification is over a subset, making it a weaker (easier to satisfy) claim.
+The secondary ordering g' selects *within* the primary best set — the
+lexicographic refinement of [kratzer-1981]'s Conclusion, where later
+ordering sources undo the ties left by their predecessors. Selecting
+within a set can only shrink it, so the universal quantification is
+over a subset, making the claim weaker (easier to satisfy).
 
 ## Key Result
 
-`strong_entails_weak`: strong necessity entails weak necessity. If all g-best
-worlds have φ, then all (g∪g')-best worlds have φ, because the refined best
-set is a subset of the original.
+`strong_entails_weak`: strong necessity entails weak necessity, since
+the g'-best of the g-best worlds are g-best (`bestAmong_sub`).
 
 `weak_not_entails_strong`: the converse fails. A concrete counterexample shows
 that refining the ordering can eliminate a world where φ fails, making weak
@@ -70,27 +72,12 @@ def strongNecessity (f : ModalBase W) (g : OrderingSource W)
     (p : W → Prop) (w : W) : Prop :=
   necessity f g p w
 
-/-- **Weak necessity** ("ought φ"): Kratzer necessity under refined ordering g ∪ g'. -/
+/-- **Weak necessity** ("ought φ"): necessity over the g'-best of the
+    g-best worlds — the lexicographic refinement of [kratzer-1981]'s
+    Conclusion. -/
 def weakNecessity (f : ModalBase W) (g g' : OrderingSource W)
     (p : W → Prop) (w : W) : Prop :=
-  necessity f (combineOrdering g g') p w
-
-/-! ## Ordering extension lemma -/
-
-private theorem ordering_extension_mono (A extra : List (W → Prop)) (w z : W)
-    (h : atLeastAsGoodAs (A ++ extra) w z) :
-    atLeastAsGoodAs A w z :=
-  fun p hp hpz => h p (List.mem_append_left _ hp) hpz
-
-/-! ## Best worlds monotonicity -/
-
-/-- Refining the ordering can only shrink the set of best worlds. -/
-theorem best_refines (f : ModalBase W) (g g' : OrderingSource W) (w : W) :
-    ∀ w', w' ∈ bestWorlds f (combineOrdering g g') w →
-          w' ∈ bestWorlds f g w := by
-  intro w' hw'
-  refine ⟨hw'.1, fun w'' hw'' => ?_⟩
-  exact ordering_extension_mono (g w) (g' w) w' w'' (hw'.2 w'' hw'')
+  ∀ w' ∈ bestAmong (bestWorlds f g w) (g' w), p w'
 
 /-! ## Main entailment -/
 
@@ -100,18 +87,17 @@ theorem strong_entails_weak (f : ModalBase W) (g g' : OrderingSource W)
     (h : strongNecessity f g p w) :
     weakNecessity f g g' p w := by
   rw [strongNecessity, necessity_iff_all] at h
-  rw [weakNecessity, necessity_iff_all]
   intro w' hw'
-  exact h w' (best_refines f g g' w w' hw')
+  exact h w' (bestAmong_sub _ _ hw')
 
 /-! ## The converse fails -/
 
 /-- Weak necessity does NOT entail strong necessity.
 
-    Counterexample: W = Bool. g is the trivial ordering (all worlds tied);
-    g' identifies `true`. Under g, both `true` and `false` are best; under
-    g∪g', only `true` is best. With p = (· = true), weakNecessity holds
-    (only `true` ∈ best), but strongNecessity fails (`false` ∈ best, p false). -/
+    Counterexample: W = Bool. g is the trivial ordering (all worlds tied),
+    so both worlds are g-best; g' identifies `true`, so only `true` is
+    g'-best among them. With p = (· = true), weakNecessity holds but
+    strongNecessity fails at the g-best world `false`. -/
 theorem weak_not_entails_strong :
     ¬(∀ (W : Type)
         (f : ModalBase W) (g g' : OrderingSource W) (p : W → Prop) (w : W),
@@ -121,27 +107,36 @@ theorem weak_not_entails_strong :
   let g : OrderingSource Bool := fun _ => [fun _ => True]
   let g' : OrderingSource Bool := fun _ => [fun w => w = true]
   let p : Bool → Prop := fun w => w = true
-  -- All worlds are accessible (empty modal base).
   have hAcc : ∀ w' : Bool, w' ∈ accessibleWorlds f true := by
-    intro w'
-    intro q hq
+    intro w' q hq
     cases hq
-  -- Weak necessity holds: only `true` is best under g∪g'.
+  have hTriv : ∀ a b : Bool, atLeastAsGoodAs (g true) a b := by
+    intro a b q hq _
+    cases hq with
+    | head => trivial
+    | tail _ h => cases h
+  have hBestAll : ∀ w' : Bool, w' ∈ bestWorlds f g true := by
+    intro w'
+    refine ⟨hAcc w', ?_⟩
+    intro v _ _
+    exact hTriv w' v
+  -- Weak necessity holds: only `true` is g'-best among the g-best.
   have hWeak : weakNecessity f g g' p true := by
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
-    have hIdent : (fun w : Bool => w = true) ∈ combineOrdering g g' true := by
-      simp [combineOrdering, g, g']
-    exact hBest true (hAcc true) (fun w => w = true) hIdent rfl
-  -- Strong necessity fails: `false` is best under g (trivial), but p false is false.
-  have hNot : ¬ strongNecessity f g p true := by
-    intro hStrong
-    have hFalseBest : false ∈ bestWorlds f g true := by
-      refine ⟨hAcc false, fun w'' _ q hq _ => ?_⟩
-      simp [g] at hq
-      rw [hq]
-      trivial
-    exact Bool.false_ne_true (hStrong false hFalseBest)
+    rintro w' ⟨_, hmin⟩
+    cases w' with
+    | true => rfl
+    | false =>
+      have hTF : atLeastAsGoodAs (g' true) true false := by
+        intro q hq _
+        cases hq with
+        | head => rfl
+        | tail _ h => cases h
+      have hFT := hmin true (hBestAll true) hTF
+      exact absurd (hFT (fun w => w = true) List.mem_cons_self rfl)
+        Bool.false_ne_true
+  -- Strong necessity fails at the g-best world `false`.
+  have hNot : ¬ strongNecessity f g p true := fun hStrong =>
+    Bool.false_ne_true (hStrong false (hBestAll false))
   exact hNot (h Bool f g g' p true hWeak)
 
 /-! ## Deontic application -/
@@ -174,11 +169,9 @@ theorem weak_eq_strong_no_secondary (f : ModalBase W) (g : OrderingSource W)
     (p : W → Prop) (w : W) :
     weakNecessity f g (emptyBackground (W := W)) p w ↔
     strongNecessity f g p w := by
-  simp only [weakNecessity, strongNecessity, necessity_iff_all]
-  constructor <;> intro h
-  · rwa [show bestWorlds f (combineOrdering g (emptyBackground (W := W))) w =
-      bestWorlds f g w from by unfold combineOrdering emptyBackground; simp] at h
-  · rwa [show bestWorlds f g w = bestWorlds f (combineOrdering g (emptyBackground (W := W))) w
-      from by unfold combineOrdering emptyBackground; simp] at h
+  unfold weakNecessity strongNecessity
+  rw [show bestAmong (bestWorlds f g w) ((emptyBackground (W := W)) w) =
+    bestWorlds f g w from bestAmong_empty _]
+  exact (necessity_iff_all f g p w).symm
 
 end Semantics.Modality.Directive

--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -108,23 +108,12 @@ theorem simpleNecessity_iff_boxCs (f : ModalBase W) (g : OrderingSource W)
   Iff.rfl
 
 open Semantics.Dynamic.Default in
-/-- Preferential necessity over the induced state implies Kratzer
-necessity: `bestWorlds` is contained in the state's optimal set. -/
-theorem necessity_of_boxLe (f : ModalBase W) (g : OrderingSource W)
-    (p : W → Prop) (w : W)
-    (h : (stateAt f g w).boxLe p) : necessity f g p w :=
-  fun w' hw' => h w' (bestWorlds_subset_optimal f g w hw')
-
-open Semantics.Dynamic.Default in
-/-- On connected ordering sources, Kratzer necessity is preferential
-necessity over the induced state — human necessity as `□_≤`. -/
-theorem necessity_iff_boxLe_of_connected (f : ModalBase W)
-    (g : OrderingSource W) (p : W → Prop) (w : W)
-    (hconn : Core.Order.Normality.connected (kratzerNormality (g w))) :
-    necessity f g p w ↔ (stateAt f g w).boxLe p := by
-  rw [show necessity f g p w ↔ ∀ w' ∈ bestWorlds f g w, p w' from Iff.rfl,
-    bestWorlds_eq_optimal_of_connected f g w hconn]
-  exact Iff.rfl
+/-- Kratzer necessity is preferential necessity over the induced state
+— human necessity as `□_≤` ([portner-2018]'s (3b) identification). -/
+theorem necessity_iff_boxLe (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W) :
+    necessity f g p w ↔ (stateAt f g w).boxLe p :=
+  Iff.rfl
 
 open Semantics.Dynamic.Default ExpState in
 /-- Veltman acceptance at a Kratzer state: the induced state supports
@@ -134,6 +123,67 @@ theorem le_assert_iff_simpleNecessity (f : ModalBase W)
     stateAt f g w ≤ (stateAt f g w).assert p ↔ simpleNecessity f p w :=
   ((stateAt f g w).le_assert_iff p).trans
     (simpleNecessity_iff_boxCs f g p w).symm
+
+/-! ### Human necessity
+
+[kratzer-1981]'s official definition needs no Limit Assumption: it
+asks each accessible world to see, at least as good, a witness below
+which only `p`-worlds occur. `necessity` (universal quantification
+over `bestWorlds`) is its Limit-Assumption collapse. -/
+
+/-- Human necessity ([kratzer-1981]): every accessible world has an
+accessible world at least as good, below which `p` holds throughout. -/
+def humanNecessity (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W) : Prop :=
+  ∀ u ∈ accessibleWorlds f w, ∃ v ∈ accessibleWorlds f w,
+    atLeastAsGoodAs (g w) v u ∧
+    ∀ z ∈ accessibleWorlds f w, atLeastAsGoodAs (g w) z v → p z
+
+/-- Human necessity implies best-worlds necessity, unconditionally. -/
+theorem necessity_of_humanNecessity {f : ModalBase W} {g : OrderingSource W}
+    {p : W → Prop} {w : W}
+    (h : humanNecessity f g p w) : necessity f g p w := by
+  rintro w' ⟨hacc, hmin⟩
+  obtain ⟨v, hvacc, hvle, hall⟩ := h w' hacc
+  exact hall w' hacc (hmin hvacc hvle)
+
+/-- The Limit Assumption at `w`: every accessible world sees a best
+world at least as good. -/
+def LimitAssumption (f : ModalBase W) (g : OrderingSource W) (w : W) : Prop :=
+  ∀ u ∈ accessibleWorlds f w, ∃ v ∈ bestWorlds f g w,
+    atLeastAsGoodAs (g w) v u
+
+/-- Under the Limit Assumption, best-worlds necessity implies human
+necessity. -/
+theorem humanNecessity_of_necessity {f : ModalBase W} {g : OrderingSource W}
+    {p : W → Prop} {w : W}
+    (hlim : LimitAssumption f g w) (h : necessity f g p w) :
+    humanNecessity f g p w := by
+  intro u hu
+  obtain ⟨v, hvbest, hvle⟩ := hlim u hu
+  refine ⟨v, hvbest.1, hvle, fun z hz hzv => h z ⟨hz, fun z' hz' hz'z => ?_⟩⟩
+  exact ordering_transitive (g w) z v z' hzv
+    (hvbest.2 hz' (ordering_transitive (g w) z' z v hz'z hzv))
+
+/-- Under the Limit Assumption, [kratzer-1981]'s human necessity is
+exactly universal quantification over the best worlds. -/
+theorem humanNecessity_iff_necessity {f : ModalBase W} {g : OrderingSource W}
+    {p : W → Prop} {w : W} (hlim : LimitAssumption f g w) :
+    humanNecessity f g p w ↔ necessity f g p w :=
+  ⟨necessity_of_humanNecessity, humanNecessity_of_necessity hlim⟩
+
+/-- With the empty ordering source, human necessity is simple necessity
+([kratzer-1981], her equivalence for arbitrary `f` and empty `g`). -/
+theorem humanNecessity_emptyBackground_iff (f : ModalBase W)
+    (p : W → Prop) (w : W) :
+    humanNecessity f emptyBackground p w ↔ simpleNecessity f p w := by
+  constructor
+  · intro h u hu
+    obtain ⟨v, _, _, hall⟩ := h u hu
+    exact hall u hu ((empty_ordering_all_equivalent u v).1)
+  · intro h u hu
+    exact ⟨u, hu, (empty_ordering_all_equivalent u u).1,
+      fun z hz _ => h z hz⟩
 
 /-! ### Characterization lemmas -/
 
@@ -207,7 +257,7 @@ theorem totally_realistic_gives_T (f : ModalBase W) (g : OrderingSource W)
     (p : W → Prop) (w : W)
     (hNec : necessity f g p w) : p w := by
   have hSelf : kratzerBestR f g w w := by
-    refine ⟨?_, fun w'' hw'' => ?_⟩
+    refine ⟨?_, fun w'' hw'' _ => ?_⟩
     · show w ∈ propIntersection (f w)
       rw [hTotal w]; rfl
     · have : w'' ∈ propIntersection (f w) := hw''

--- a/Linglib/Semantics/Modality/Kratzer/Ordering.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Ordering.lean
@@ -150,35 +150,6 @@ These are exactly the worlds in ⋂f(w) — worlds compatible with all facts in 
 def accessibleWorlds (f : ModalBase W) (w : W) : Set W :=
   propIntersection (f w)
 
-/--
-The **best** worlds among accessible worlds, according to ordering source g.
-
-These are the accessible worlds that are maximal under ≤_{g(w)}:
-worlds w' such that for all accessible w'', w' ≤_{g(w)} w''.
-
-When g(w) = ∅, all accessible worlds are best (by Theorem 2).
--/
-def bestWorlds (f : ModalBase W) (g : OrderingSource W) (w : W) : Set W :=
-  {w' | w' ∈ accessibleWorlds f w ∧
-        ∀ w'' ∈ accessibleWorlds f w, atLeastAsGoodAs (g w) w' w''}
-
-/--
-**Theorem 3: Empty ordering source reduces to simple accessibility.**
-
-When g(w) = ∅, bestWorlds = accessibleWorlds.
--/
-theorem empty_ordering_simple (f : ModalBase W) (w : W) :
-    bestWorlds f (fun _ => []) w = accessibleWorlds f w := by
-  ext w'
-  refine ⟨fun h => h.1, fun h => ⟨h, fun w'' _ => ?_⟩⟩
-  exact (empty_ordering_all_equivalent w' w'').1
-
-/-- Variant of `empty_ordering_simple` matching `emptyBackground` by name. -/
-theorem empty_ordering_emptyBackground (f : ModalBase W) (w : W) :
-    bestWorlds f emptyBackground w = accessibleWorlds f w := by
-  unfold emptyBackground
-  exact empty_ordering_simple f w
-
 /-! ### The induced expectation state
 
 [portner-2018] identifies the two components of his mood state with
@@ -202,14 +173,33 @@ def stateAt (f : ModalBase W) (g : OrderingSource W) (w : W) :
 @[simp] theorem stateAt_order (f : ModalBase W) (g : OrderingSource W) (w : W) :
     (stateAt f g w).order = kratzerNormality (g w) := rfl
 
-/-- Dominant best worlds are optimal: `bestWorlds` requires being at
-least as good as every accessible world, `ExpState.optimal` only
-non-domination, so the former is the stronger notion on non-connected
-orderings. -/
-theorem bestWorlds_subset_optimal (f : ModalBase W) (g : OrderingSource W)
-    (w : W) :
-    bestWorlds f g w ⊆ (stateAt f g w).optimal :=
-  fun _ hw => ⟨hw.1, fun v hv _ => hw.2 v hv⟩
+/-- The best accessible worlds: those no accessible world strictly
+betters — `ExpState.optimal` at the induced state. [kratzer-1981]'s
+official human necessity is the limit-free `humanNecessity`; it
+quantifies over exactly this set under the Limit Assumption
+(`humanNecessity_iff_necessity`). Her practical-inference tripartition
+(pp. 66-67) is non-connected by construction, so the stronger
+dominance form (at least as good as *every* accessible world) would
+be empty there; minimality is the faithful reading. -/
+def bestWorlds (f : ModalBase W) (g : OrderingSource W) (w : W) : Set W :=
+  (stateAt f g w).optimal
+
+/--
+**Theorem 3: Empty ordering source reduces to simple accessibility.**
+
+When g(w) = ∅, bestWorlds = accessibleWorlds.
+-/
+theorem empty_ordering_simple (f : ModalBase W) (w : W) :
+    bestWorlds f (fun _ => []) w = accessibleWorlds f w := by
+  ext w'
+  refine ⟨fun h => h.1, fun h => ⟨h, fun v _ _ => ?_⟩⟩
+  exact (empty_ordering_all_equivalent w' v).1
+
+/-- Variant of `empty_ordering_simple` matching `emptyBackground` by name. -/
+theorem empty_ordering_emptyBackground (f : ModalBase W) (w : W) :
+    bestWorlds f emptyBackground w = accessibleWorlds f w := by
+  unfold emptyBackground
+  exact empty_ordering_simple f w
 
 /-- Realism is fiber-reflexivity: a modal base is realistic iff every
 world belongs to its own induced information state. -/
@@ -218,28 +208,22 @@ theorem isRealistic_iff_mem_stateAt_info (f : ModalBase W)
     isRealistic f ↔ ∀ w, w ∈ (stateAt f g w).info :=
   ⟨fun h w p hp => h w p hp, fun h w p hp => h w p hp⟩
 
-/-- On connected orderings the two best-world notions coincide. -/
-theorem bestWorlds_eq_optimal_of_connected (f : ModalBase W)
-    (g : OrderingSource W) (w : W)
-    (hconn : Core.Order.Normality.connected (kratzerNormality (g w))) :
-    bestWorlds f g w = (stateAt f g w).optimal :=
-  Set.Subset.antisymm (bestWorlds_subset_optimal f g w)
-    (fun w' hw' => ⟨hw'.1, fun v hv =>
-      (hconn w' v).elim id (fun h => hw'.2 hv h)⟩)
-
-/-- The best worlds among a given set, ranked by an ordering.
-    Unlike `bestWorlds` which computes accessible worlds from a modal base,
-    `bestAmong` takes a precomputed world set. This is needed when the
-    domain has already been restricted (e.g., by promoted priorities in
-    [rubinstein-2014]'s favored worlds). -/
+/-- The best worlds among a given set: members no other member strictly
+    betters. Unlike `bestWorlds`, which computes the domain from a modal
+    base, `bestAmong` takes a precomputed world set — the form needed
+    when the domain is already restricted, by promoted priorities in
+    [rubinstein-2014]'s favored worlds or by a primary ordering in the
+    lexicographic refinement of [kratzer-1981]'s Conclusion. -/
 def bestAmong (worlds : Set W) (ordering : List (W → Prop)) : Set W :=
-  {w' | w' ∈ worlds ∧ ∀ w'' ∈ worlds, atLeastAsGoodAs ordering w' w''}
+  {w' | w' ∈ worlds ∧
+        ∀ w'' ∈ worlds, atLeastAsGoodAs ordering w'' w' →
+          atLeastAsGoodAs ordering w' w''}
 
 /-- With empty ordering, all worlds are best (Kratzer's theorem 2). -/
 theorem bestAmong_empty (worlds : Set W) :
     bestAmong worlds [] = worlds := by
   ext w
-  refine ⟨fun h => h.1, fun h => ⟨h, fun w' _ => ?_⟩⟩
+  refine ⟨fun h => h.1, fun h => ⟨h, fun w' _ _ => ?_⟩⟩
   exact (empty_ordering_all_equivalent w w').1
 
 /-- bestAmong is a subset of the input worlds. -/
@@ -247,16 +231,15 @@ theorem bestAmong_sub (worlds : Set W) (ordering : List (W → Prop)) :
     bestAmong worlds ordering ⊆ worlds :=
   fun _ hw => hw.1
 
-/-- Best worlds in a superset that belong to a subset are best in the subset.
-
-    If w' beats every world in a larger set, it certainly beats every world
-    in any subset. This is the key lemma for showing that star-revision
-    (domain widening) preserves strong necessity. -/
+/-- Best worlds in a superset that belong to a subset are best in the
+    subset: unbettered among more competitors, unbettered among fewer.
+    The key lemma for showing that star-revision (domain widening)
+    preserves strong necessity. -/
 theorem bestAmong_superset {sub sup : Set W} {ordering : List (W → Prop)} {w' : W}
     (hSub : sub ⊆ sup)
     (hBest : w' ∈ bestAmong sup ordering)
     (hMem : w' ∈ sub) :
     w' ∈ bestAmong sub ordering :=
-  ⟨hMem, fun v hv => hBest.2 v (hSub hv)⟩
+  ⟨hMem, fun v hv hle => hBest.2 v (hSub hv) hle⟩
 
 end Semantics.Modality.Kratzer

--- a/Linglib/Semantics/Modality/ProbabilityOrdering.lean
+++ b/Linglib/Semantics/Modality/ProbabilityOrdering.lean
@@ -100,12 +100,19 @@ private lemma w0_mem_univ_toList :
 theorem prob_ordering_best_w0 (w : World) :
     bestWorlds emptyBackground (probToOrdering skewedProb) w = ({0} : Set World) := by
   ext w'
-  rw [bestWorlds, Set.mem_setOf_eq, Set.mem_singleton_iff]
+  simp only [Set.mem_singleton_iff]
   refine ⟨?_, ?_⟩
-  · rintro ⟨_, hAll⟩
+  · rintro ⟨_, hMin⟩
     have hUniv : (0 : World) ∈ accessibleWorlds emptyBackground w := by
       rw [empty_base_universal_access]; exact Set.mem_univ _
-    have hLeq := hAll _ hUniv
+    have hDom : atLeastAsGoodAs (probToOrdering skewedProb w) 0 w' := by
+      apply higher_prob_dominates
+      match w' with
+      | 0 => simp [skewedProb]
+      | 1 => simp [skewedProb]; norm_num
+      | 2 => simp [skewedProb]; norm_num
+      | 3 => simp [skewedProb]; norm_num
+    have hLeq := hMin hUniv hDom
     have hp_mem : (λ x => skewedProb x ≥ skewedProb (0 : World))
         ∈ probToOrdering skewedProb w := by
       rw [probToOrdering, List.mem_map]
@@ -119,8 +126,9 @@ theorem prob_ordering_best_w0 (w : World) :
     | 3 => simp [skewedProb] at h_w'; norm_num at h_w'
   · rintro rfl
     refine ⟨?_, ?_⟩
-    · rw [empty_base_universal_access]; exact Set.mem_univ _
-    · intro w'' _
+    · show (0 : World) ∈ accessibleWorlds emptyBackground w
+      rw [empty_base_universal_access]; exact Set.mem_univ _
+    · intro w'' _ _
       apply higher_prob_dominates
       match w'' with
       | 0 => simp [skewedProb]

--- a/Linglib/Studies/AghaJeretic2026.lean
+++ b/Linglib/Studies/AghaJeretic2026.lean
@@ -367,16 +367,16 @@ condition — the domain is a subsingleton — and differ only in how each const
 that domain. -/
 
 /-- **Domain-restriction (von Fintel & Iatridou) wired to the shared lemma.** VFI
-    weak necessity neg-raises at `(f, g, g', w)` iff its refined best-world domain
-    `bestWorlds f (g ∪ g') w` is a subsingleton — the same
+    weak necessity neg-raises at `(f, g, g', w)` iff its nested best-world domain
+    `bestAmong (bestWorlds f g w) (g' w)` is a subsingleton — the same
     `Homogeneity.negRaising_iff_subsingleton` characterization as Rubinstein's
     `BEST(favored, negotiable)` and A&J's gap domain. -/
 theorem vfiWeak_negRaises_iff {W : Type*} (f : ModalBase W) (g g' : OrderingSource W)
     (w : W) :
     (∀ p : W → Prop, ¬ weakNecessity f g g' p w →
         weakNecessity f g g' (fun w' => ¬ p w') w) ↔
-      (bestWorlds f (combineOrdering g g') w).Subsingleton := by
-  simp only [weakNecessity, necessity_iff_all]
+      (bestAmong (bestWorlds f g w) (g' w)).Subsingleton := by
+  simp only [weakNecessity]
   exact negRaising_iff_subsingleton _
 
 end AghaJeretic2026

--- a/Linglib/Studies/Ferreira2023.lean
+++ b/Linglib/Studies/Ferreira2023.lean
@@ -103,16 +103,90 @@ abbrev sn (f : ModalBase W) (g : OrderingSource W)
 /-! ### Key equation: WN ≡ SN_Xg -/
 
 theorem wn_equiv_snXg (f : ModalBase W) (g : OrderingSource W)
-    (p : W → Prop) (w : W) :
-    weakNecessity f g (λ _ => [p]) p w ↔ snXg f g p w := Iff.rfl
+    (p : W → Prop) (w : W)
+    (hconn : Core.Order.Normality.connected (kratzerNormality (g w))) :
+    weakNecessity f g (λ _ => [p]) p w ↔ snXg f g p w := by
+  constructor
+  · intro hweak
+    rintro w' ⟨hacc, hmin⟩
+    by_cases hp : p w'
+    · exact hp
+    have hminG : w' ∈ bestWorlds f g w := by
+      refine ⟨hacc, ?_⟩
+      intro v hv hvle
+      have hvle' : atLeastAsGoodAs (xMarkOrdering g p w) v w' := by
+        intro q hq hqw'
+        rcases List.mem_append.mp hq with hq | hq
+        · exact hvle q hq hqw'
+        · rcases List.mem_singleton.mp hq with rfl
+          exact absurd hqw' hp
+      intro q hq hqw'
+      exact hmin hv hvle' q (List.mem_append_left _ hq) hqw'
+    have hnop : ∀ v ∈ bestWorlds f g w, ¬ p v := by
+      intro v hv hpv
+      have hvle : atLeastAsGoodAs (xMarkOrdering g p w) v w' := by
+        intro q hq hqw'
+        rcases List.mem_append.mp hq with hq | hq
+        · rcases hconn v w' with h | h
+          · exact h q hq hqw'
+          · exact hv.2 hminG.1 h q hq hqw'
+        · rcases List.mem_singleton.mp hq with rfl
+          exact absurd hqw' hp
+      exact hp (hmin hv.1 hvle p
+        (List.mem_append_right _ (List.mem_singleton.mpr rfl)) hpv)
+    have hwmem : w' ∈ bestAmong (bestWorlds f g w) ((fun _ => [p]) w) := by
+      refine ⟨hminG, ?_⟩
+      intro v hv _ q hq hqv
+      rcases List.mem_singleton.mp hq with rfl
+      exact absurd hqv (hnop v hv)
+    exact absurd (hweak w' hwmem) hp
+  · intro hsnxg
+    rintro w' ⟨hwB, hmin⟩
+    by_cases hp : p w'
+    · exact hp
+    refine hsnxg w' ⟨hwB.1, ?_⟩
+    intro v hv hvle
+    have hvleG : atLeastAsGoodAs (g w) v w' := fun q hq hqw' =>
+      hvle q (List.mem_append_left _ hq) hqw'
+    have hwlev : atLeastAsGoodAs (g w) w' v := hwB.2 hv hvleG
+    have hvB : v ∈ bestWorlds f g w := by
+      refine ⟨hv, ?_⟩
+      intro u hu hule
+      have huw' : atLeastAsGoodAs (g w) u w' :=
+        ordering_transitive _ u v w' hule hvleG
+      exact ordering_transitive _ v w' u hvleG (hwB.2 hu huw')
+    have hnopv : ¬ p v := by
+      intro hpv
+      have hvlp : atLeastAsGoodAs [p] v w' := by
+        intro q hq hqw'
+        rcases List.mem_singleton.mp hq with rfl
+        exact absurd hqw' hp
+      exact hp (hmin v hvB hvlp p (List.mem_singleton.mpr rfl) hpv)
+    intro q hq hqv
+    rcases List.mem_append.mp hq with hq | hq
+    · exact hwlev q hq hqv
+    · rcases List.mem_singleton.mp hq with rfl
+      exact absurd hqv hnopv
 
 /-! ### Entailment: SN → SN_Xg (must → ought) -/
 
 theorem sn_entails_snXg (f : ModalBase W) (g : OrderingSource W)
     (p : W → Prop) (w : W)
     (h : sn f g p w) :
-    snXg f g p w :=
-  strong_entails_weak f g (λ _ => [p]) p w h
+    snXg f g p w := by
+  rintro w' ⟨hacc, hmin⟩
+  by_cases hp : p w'
+  · exact hp
+  · refine h w' ⟨hacc, ?_⟩
+    intro v hv hvle
+    have hvle' : atLeastAsGoodAs (xMarkOrdering g p w) v w' := by
+      intro q hq hqw'
+      rcases List.mem_append.mp hq with hq | hq
+      · exact hvle q hq hqw'
+      · rcases List.mem_singleton.mp hq with rfl
+        exact absurd hqw' hp
+    intro q hq hqw'
+    exact hmin hv hvle' q (List.mem_append_left _ hq) hqw'
 
 /-- The converse fails: SN_Xg ⊭ SN.
 
@@ -130,16 +204,21 @@ theorem snXg_not_entails_sn :
   have hAcc : ∀ w' : Bool, w' ∈ accessibleWorlds f true := by
     intro w' q hq; cases hq
   have hSnXg : snXg f g p true := by
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
+    rintro w' ⟨_, hmin⟩
     have hIdent : (fun w : Bool => w = true) ∈ xMarkOrdering g p true := by
       simp [xMarkOrdering, combineOrdering, g, p, emptyBackground]
-    exact hBest true (hAcc true) (fun w => w = true) hIdent rfl
+    have hTop : atLeastAsGoodAs (xMarkOrdering g p true) true w' := by
+      intro q hq _
+      have hq' : q = fun w => w = true := by
+        simpa [xMarkOrdering, combineOrdering, g, p, emptyBackground] using hq
+      subst hq'; rfl
+    exact hmin (hAcc true) hTop _ hIdent rfl
   have hNotSn : ¬ sn f g p true := by
     intro hSn
     have hFalseBest : false ∈ bestWorlds f g true := by
-      refine ⟨hAcc false, fun w'' _ q hq _ => ?_⟩
-      simp [g, emptyBackground] at hq
+      show false ∈ bestWorlds f emptyBackground true
+      rw [empty_ordering_emptyBackground]
+      exact hAcc false
     exact Bool.false_ne_true (hSn false hFalseBest)
   exact hNotSn (h Bool f g p true hSnXg)
 
@@ -212,11 +291,15 @@ theorem xMarked_unmarked_independent :
       · exact (this rfl).elim
       · rfl
   have hSnXfg : snXfg f' g p true := by
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
+    rintro w' ⟨_, hmin⟩
     have hIdent : (fun w : Bool => w = true) ∈ xMarkOrdering g p true := by
       simp [xMarkOrdering, combineOrdering, g, p, emptyBackground]
-    exact hBest true (hAccF' true) (fun w => w = true) hIdent rfl
+    have hTop : atLeastAsGoodAs (xMarkOrdering g p true) true w' := by
+      intro q hq _
+      have hq' : q = fun w => w = true := by
+        simpa [xMarkOrdering, combineOrdering, g, p, emptyBackground] using hq
+      subst hq'; rfl
+    exact hmin (hAccF' true) hTop _ hIdent rfl
   have hNotSnXg : ¬ snXg f g p true := by
     intro hSnXg
     have hAccFalse : false ∈ accessibleWorlds f true := by
@@ -224,11 +307,11 @@ theorem xMarked_unmarked_independent :
       rcases List.mem_singleton.mp hq with rfl
       rfl
     have hFalseBest : false ∈ bestWorlds f (xMarkOrdering g p) true := by
-      refine ⟨hAccFalse, fun w'' hw'' q _ hqw'' => ?_⟩
-      have hw : w'' = false :=
-        hw'' (fun w => w = false) (List.mem_singleton.mpr rfl)
-      subst hw
-      exact hqw''
+      refine ⟨hAccFalse, ?_⟩
+      intro v hv _
+      have hv' : v = false := hv (fun w => w = false) (List.mem_singleton.mpr rfl)
+      subst hv'
+      exact ordering_reflexive _ _
     exact Bool.false_ne_true (hSnXg false hFalseBest)
   exact hNotSnXg (h Bool f f' g p true hRev hSnXfg)
 
@@ -243,16 +326,21 @@ theorem snXfg_not_entails_snXf :
   have hAcc : ∀ w' : Bool, w' ∈ accessibleWorlds f' true := by
     intro w' q hq; cases hq
   have hSnXfg : snXfg f' g p true := by
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
+    rintro w' ⟨_, hmin⟩
     have hIdent : (fun w : Bool => w = true) ∈ xMarkOrdering g p true := by
       simp [xMarkOrdering, combineOrdering, g, p, emptyBackground]
-    exact hBest true (hAcc true) (fun w => w = true) hIdent rfl
+    have hTop : atLeastAsGoodAs (xMarkOrdering g p true) true w' := by
+      intro q hq _
+      have hq' : q = fun w => w = true := by
+        simpa [xMarkOrdering, combineOrdering, g, p, emptyBackground] using hq
+      subst hq'; rfl
+    exact hmin (hAcc true) hTop _ hIdent rfl
   have hNotSnXf : ¬ snXf f' g p true := by
     intro hSnXf
     have hFalseBest : false ∈ bestWorlds f' g true := by
-      refine ⟨hAcc false, fun w'' _ q hq _ => ?_⟩
-      simp [g, emptyBackground] at hq
+      show false ∈ bestWorlds f' emptyBackground true
+      rw [empty_ordering_emptyBackground]
+      exact hAcc false
     exact Bool.false_ne_true (hSnXf false hFalseBest)
   exact hNotSnXf (h Bool f' g p true hSnXfg)
 
@@ -339,20 +427,25 @@ theorem dever_not_entails_terQue :
     intro w'; rw [empty_base_universal_access]; exact Set.mem_univ _
   have hSnXg : snXg (emptyBackground (W := World)) (emptyBackground (W := World))
                  (fun w : World => w = (0 : World)) (0 : World) := by
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
+    rintro w' ⟨_, hmin⟩
     have hIdent : (fun w : World => w = (0 : World)) ∈
         xMarkOrdering (emptyBackground (W := World)) (fun w : World => w = (0 : World)) (0 : World) := by
       simp [xMarkOrdering, combineOrdering, emptyBackground]
-    exact hBest (0 : World) (hAcc (0 : World)) (fun w : World => w = (0 : World)) hIdent rfl
+    have hTop : atLeastAsGoodAs
+        (xMarkOrdering (emptyBackground (W := World)) (fun w : World => w = (0 : World)) (0 : World))
+        (0 : World) w' := by
+      intro q hq _
+      have hq' : q = fun w : World => w = (0 : World) := by
+        simpa [xMarkOrdering, combineOrdering, emptyBackground] using hq
+      subst hq'; rfl
+    exact hmin (hAcc (0 : World)) hTop _ hIdent rfl
   -- snXg → sn would force w1 = w0, contradiction
   have hSn := hCE hSnXg
   rw [sn, necessity_iff_all] at hSn
   have hW1Best : ((1 : World) : World) ∈
       bestWorlds (emptyBackground (W := World)) (emptyBackground (W := World)) (0 : World) := by
-    refine ⟨hAcc (1 : World), ?_⟩
-    intro w'' _ q hq _
-    simp [emptyBackground] at hq
+    rw [empty_ordering_emptyBackground]
+    exact hAcc (1 : World)
   have : ((1 : World) : World) = (0 : World) := hSn (1 : World) hW1Best
   exact absurd this (by decide)
 
@@ -387,14 +480,20 @@ theorem dever_consistent_with_not_p :
          (0 : World),
          ?_, ?_⟩
   · -- snXg: every best world satisfies p
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
+    rintro w' ⟨_, hmin⟩
     have hAcc1 : ((1 : World) : World) ∈ accessibleWorlds (emptyBackground (W := World)) (0 : World) := by
       rw [empty_base_universal_access]; exact Set.mem_univ _
     have hIdent : (fun w : World => w = (1 : World)) ∈
         xMarkOrdering (emptyBackground (W := World)) (fun w : World => w = (1 : World)) (0 : World) := by
       simp [xMarkOrdering, combineOrdering, emptyBackground]
-    exact hBest (1 : World) hAcc1 (fun w : World => w = (1 : World)) hIdent rfl
+    have hTop : atLeastAsGoodAs
+        (xMarkOrdering (emptyBackground (W := World)) (fun w : World => w = (1 : World)) (0 : World))
+        (1 : World) w' := by
+      intro q hq _
+      have hq' : q = fun w : World => w = (1 : World) := by
+        simpa [xMarkOrdering, combineOrdering, emptyBackground] using hq
+      subst hq'; rfl
+    exact hmin hAcc1 hTop _ hIdent rfl
   · -- ¬ p (0 : World)
     intro h; exact absurd h (by decide)
 
@@ -451,19 +550,24 @@ theorem devia_not_entails_deve :
       · exact hw0
       · exact absurd hw1 hNotW1
   have hSnXfg : snXfg fWide (emptyBackground (W := World)) p (0 : World) := by
-    intro w' hw'
-    obtain ⟨_, hBest⟩ := hw'
+    rintro w' ⟨_, hmin⟩
     have hAcc0 : ((0 : World) : World) ∈ accessibleWorlds fWide (0 : World) := (hWideAcc (0 : World)).mpr (Or.inl rfl)
     have hPMem : p ∈ xMarkOrdering (emptyBackground (W := World)) p (0 : World) := by
       simp [xMarkOrdering, combineOrdering, emptyBackground]
-    exact hBest (0 : World) hAcc0 p hPMem rfl
+    have hTop : atLeastAsGoodAs
+        (xMarkOrdering (emptyBackground (W := World)) p (0 : World)) (0 : World) w' := by
+      intro q hq _
+      have hq' : q = p := by
+        simpa [xMarkOrdering, combineOrdering, emptyBackground] using hq
+      subst hq'; rfl
+    exact hmin hAcc0 hTop p hPMem rfl
   have hNotSnXg : ¬ snXg fNarrow (emptyBackground (W := World)) p (0 : World) := by
     intro hSn
     have hAcc1 : ((1 : World) : World) ∈ accessibleWorlds fNarrow (0 : World) := (hNarrowAcc (1 : World)).mpr rfl
     have hBest1 : ((1 : World) : World) ∈
         bestWorlds fNarrow (xMarkOrdering (emptyBackground (W := World)) p) (0 : World) := by
       refine ⟨hAcc1, ?_⟩
-      intro w'' hw''
+      intro w'' hw'' _
       have hw''1 : w'' = (1 : World) := (hNarrowAcc w'').mp hw''
       subst hw''1
       exact ordering_reflexive _ ((1 : World) : World)

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -258,8 +258,8 @@ theorem izvorski_koev_diverge :
   rw [necessity_iff_all] at h
   have hAcc : (1 : World) ∈ accessibleWorlds (emptyBackground (W := World)) (0 : World) := by
     rw [empty_base_universal_access]; exact Set.mem_univ _
-  have hBest : (1 : World) ∈ bestWorlds emptyBackground emptyBackground (W := World) (0 : World) :=
-    ⟨hAcc, fun w'' _ q hq _ => by simp [emptyBackground] at hq⟩
+  have hBest : (1 : World) ∈ bestWorlds emptyBackground emptyBackground (W := World) (0 : World) := by
+    rw [empty_ordering_emptyBackground]; exact hAcc
   exact (h (1 : World) hBest : pOnlyW0 (1 : World))
 
 theorem izvorski_collapses_to_koev_when_realistic

--- a/Linglib/Studies/Kratzer1981.lean
+++ b/Linglib/Studies/Kratzer1981.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Fintype.Prod
+import Linglib.Semantics.Modality.Kratzer.Operators
+
+/-!
+# Kratzer 1981: The Notional Category of Modality
+
+[kratzer-1981]'s practical-inference example (her §7): *I want to
+become mayor; I will become mayor only if I go to the pub regularly.*
+The circumstances contribute the modal base, the desires the ordering
+source, and the ordering source's two ideals — becoming mayor, not
+going to the pub — pull in opposite directions, so the induced
+ordering is non-connected by construction: her clause (c), "If v ∈ A
+and z ∈ B, then neither v ≤ z nor z ≤ v."
+
+Her verdicts: conclusions one ("must go to the pub"), two ("must not
+go"), and three ("possible to become mayor without going") are
+faulty; four ("possible to go") and five ("possible not to go") are
+correct. The example also fixes the form of `bestWorlds`: under the
+dominance reading (at least as good as *every* accessible world) the
+best set here is empty and all five conclusions would come out
+trivially, so her verdicts require the minimality reading
+(`dominance_best_empty`, `best_nonempty`).
+-/
+
+namespace Kratzer1981
+
+open Semantics.Modality.Kratzer
+
+/-- A world: does the speaker become mayor, and go to the pub regularly? -/
+abbrev World := Bool × Bool
+
+/-- The evaluation world (arbitrary; the backgrounds are constant). -/
+def w₀ : World := (false, false)
+
+/-- Circumstances: I will become mayor only if I go to the pub regularly. -/
+def circumstances : ModalBase World :=
+  fun _ => [fun w => w.1 = true → w.2 = true]
+
+/-- Desires: to become mayor, and not to go to the pub. -/
+def desires : OrderingSource World :=
+  fun _ => [fun w => w.1 = true, fun w => w.2 = false]
+
+private lemma mem_acc_iff (w : World) :
+    w ∈ accessibleWorlds circumstances w₀ ↔ (w.1 = true → w.2 = true) := by
+  simp [accessibleWorlds, circumstances, Intensional.Premise.propIntersection]
+
+private lemma agag_iff (a b : World) :
+    atLeastAsGoodAs (desires w₀) a b ↔
+      ((b.1 = true → a.1 = true) ∧ (b.2 = false → a.2 = false)) := by
+  constructor
+  · intro h
+    exact ⟨h _ List.mem_cons_self, h _ (List.mem_cons_of_mem _ List.mem_cons_self)⟩
+  · rintro ⟨h1, h2⟩ q hq hqb
+    cases hq with
+    | head => exact h1 hqb
+    | tail _ hq =>
+      cases hq with
+      | head => exact h2 hqb
+      | tail _ hq => cases hq
+
+/-- Her clause (c): the mayor-ideal world and the no-pub-ideal world are
+incomparable — the ordering is non-connected by construction. -/
+theorem mayor_pub_incomparable :
+    ¬ atLeastAsGoodAs (desires w₀) (true, true) (false, false) ∧
+    ¬ atLeastAsGoodAs (desires w₀) (false, false) (true, true) := by
+  constructor <;> rw [agag_iff] <;> decide
+
+private lemma mem_best_iff (w : World) :
+    w ∈ bestWorlds circumstances desires w₀ ↔
+      (w.1 = true → w.2 = true) ∧
+      ∀ v : World, (v.1 = true → v.2 = true) →
+        ((w.1 = true → v.1 = true) ∧ (w.2 = false → v.2 = false)) →
+        ((v.1 = true → w.1 = true) ∧ (v.2 = false → w.2 = false)) := by
+  constructor
+  · rintro ⟨hacc, hmin⟩
+    refine ⟨(mem_acc_iff w).mp hacc, fun v hv hle => ?_⟩
+    exact (agag_iff w v).mp (hmin ((mem_acc_iff v).mpr hv) ((agag_iff v w).mpr hle))
+  · rintro ⟨hacc, hmin⟩
+    refine ⟨(mem_acc_iff w).mpr hacc, fun v hv hle => ?_⟩
+    exact (agag_iff w v).mpr
+      (hmin v ((mem_acc_iff v).mp hv) ((agag_iff v w).mp hle))
+
+/-- The best worlds are exactly the two ideal-realizing ones: become
+mayor and go, or stay home and skip the pub. -/
+theorem best_eq :
+    ∀ w : World, w ∈ bestWorlds circumstances desires w₀ ↔
+      (w = (true, true) ∨ w = (false, false)) := by
+  intro w
+  rw [mem_best_iff]
+  revert w
+  decide
+
+/-- Conclusion one is faulty: it is not necessary to go to the pub. -/
+theorem conclusion_one_faulty :
+    ¬ necessity circumstances desires (fun w => w.2 = true) w₀ := by
+  intro h
+  exact absurd (h (false, false) ((best_eq _).mpr (Or.inr rfl))) (by decide)
+
+/-- Conclusion two is faulty: it is not necessary to skip the pub. -/
+theorem conclusion_two_faulty :
+    ¬ necessity circumstances desires (fun w => w.2 = false) w₀ := by
+  intro h
+  exact absurd (h (true, true) ((best_eq _).mpr (Or.inl rfl))) (by decide)
+
+/-- Conclusion three is faulty: becoming mayor without the pub is not
+even accessible. -/
+theorem conclusion_three_faulty :
+    ¬ possibility circumstances desires (fun w => w.1 = true ∧ w.2 = false) w₀ := by
+  rintro ⟨w, hw, h1, h2⟩
+  have := ((best_eq w).mp hw)
+  rcases this with rfl | rfl <;> simp_all
+
+/-- Conclusion four is correct: going to the pub is possible. -/
+theorem conclusion_four_correct :
+    possibility circumstances desires (fun w => w.2 = true) w₀ :=
+  ⟨(true, true), (best_eq _).mpr (Or.inl rfl), rfl⟩
+
+/-- Conclusion five is correct: skipping the pub is possible. -/
+theorem conclusion_five_correct :
+    possibility circumstances desires (fun w => w.2 = false) w₀ :=
+  ⟨(false, false), (best_eq _).mpr (Or.inr rfl), rfl⟩
+
+/-! ### The example fixes the form of `bestWorlds` -/
+
+/-- Under the dominance reading of "best" — at least as good as every
+accessible world — the best set of her example is empty: the two
+ideal-realizing worlds disqualify each other. -/
+theorem dominance_best_empty :
+    {w : World | w ∈ accessibleWorlds circumstances w₀ ∧
+      ∀ v ∈ accessibleWorlds circumstances w₀,
+        atLeastAsGoodAs (desires w₀) w v} = ∅ := by
+  ext w
+  simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false, not_and]
+  intro hacc h
+  have h1 := (agag_iff w (true, true)).mp
+    (h (true, true) ((mem_acc_iff _).mpr (by decide)))
+  have h2 := (agag_iff w (false, false)).mp
+    (h (false, false) ((mem_acc_iff _).mpr (by decide)))
+  have hw := (mem_acc_iff w).mp hacc
+  obtain ⟨a, b⟩ := w
+  revert h1 h2 hw
+  cases a <;> cases b <;> decide
+
+/-- The minimality reading leaves the best set nonempty, as her verdicts
+require. -/
+theorem best_nonempty :
+    (bestWorlds circumstances desires w₀).Nonempty :=
+  ⟨(true, true), (best_eq _).mpr (Or.inl rfl)⟩
+
+end Kratzer1981

--- a/Linglib/Studies/Kratzer2012Conditionals.lean
+++ b/Linglib/Studies/Kratzer2012Conditionals.lean
@@ -182,18 +182,22 @@ def traditionalMoralBase : ModalBase World := fun _ => [(fun w' => w' = 0)]
 theorem ex59_holds (w : World) :
     necessity emptyBackground morallyGood (fun w' => ¬ injustice w') w := by
   rw [necessity_iff_all]
-  intro w' ⟨_, hBest⟩
+  intro w' ⟨_, hmin⟩
   -- w0 is accessible (vacuously, since emptyBackground gives universal access)
   have hAccW0 : (0 : World) ∈ accessibleWorlds emptyBackground w := by
     intro p hp
     simp [emptyBackground] at hp
-  -- w0 satisfies "¬ injustice"
-  have hP1AtW0 : ¬ injustice (0 : World) := by decide
-  -- The proposition "¬ injustice" is in morallyGood w
   have hP1MemG : (fun w'' => ¬ injustice w'') ∈ morallyGood w := by
     simp [morallyGood]
-  -- Since w' is best, w' is at-least-as-good as w0; transferring p1
-  exact hBest (0 : World) hAccW0 (fun w'' => ¬ injustice w'') hP1MemG hP1AtW0
+  -- w0 satisfies every moral ideal, so it is at-least-as-good as anything
+  have hTop : atLeastAsGoodAs (morallyGood w) (0 : World) w' := by
+    intro q hq _
+    simp [morallyGood] at hq
+    rcases hq with rfl | rfl
+    · decide
+    · exact fun h => absurd h (by decide)
+  -- minimality returns the comparison; transfer the ideal ¬ injustice
+  exact hmin hAccW0 hTop _ hP1MemG (by decide)
 
 /-- **(60) "If injustice, must be amended"** under Kratzer's analysis succeeds.
     With empty modal base restricted by `injustice` + morally-good ordering,
@@ -202,7 +206,7 @@ theorem ex59_holds (w : World) :
 theorem ex60_holds (w : World) :
     necessity (restrictedBase emptyBackground injustice) morallyGood amended w := by
   rw [necessity_iff_all]
-  intro w' ⟨hAcc, hBest⟩
+  intro w' ⟨hAcc, hmin⟩
   -- w' has injustice (it's in the restricted base)
   have hInjW' : injustice w' := hAcc injustice (by simp [restrictedBase])
   -- w1 is accessible (injustice + emptyBackground)
@@ -211,14 +215,16 @@ theorem ex60_holds (w : World) :
     simp [restrictedBase, emptyBackground] at hp
     subst hp
     decide
-  -- w1 satisfies "injustice → amended"
-  have hP2AtW1 : injustice (1 : World) → amended (1 : World) := fun _ => by decide
   have hP2MemG : (fun w'' => injustice w'' → amended w'') ∈ morallyGood w := by
     simp [morallyGood]
-  -- Transfer to w' via best-ness
-  have hP2AtW' : injustice w' → amended w' :=
-    hBest (1 : World) hAccW1 (fun w'' => injustice w'' → amended w'') hP2MemG hP2AtW1
-  exact hP2AtW' hInjW'
+  -- w1 is at-least-as-good as w' (¬ injustice fails at w', the other ideal holds at w1)
+  have hTop : atLeastAsGoodAs (morallyGood w) (1 : World) w' := by
+    intro q hq hqw'
+    simp [morallyGood] at hq
+    rcases hq with rfl | rfl
+    · exact absurd hInjW' hqw'
+    · exact fun _ => by decide
+  exact hmin hAccW1 hTop _ hP2MemG (fun _ => by decide) hInjW'
 
 /-- **(61) "If injustice, must be rewarded"** under Kratzer's analysis fails.
     The best injustice-world is w1, but w1 is NOT rewarded. -/
@@ -246,7 +252,7 @@ theorem ex61_fails (w : World) :
     · -- p = injustice → amended. We need w1 satisfies p, i.e., amended (1 : World).
       subst hp2
       intro _; decide
-  have : rewarded (1 : World) := hNec 1 ⟨hAccW1, hBestW1⟩
+  have : rewarded (1 : World) := hNec 1 ⟨hAccW1, fun {u} hu _ => hBestW1 u hu⟩
   exact absurd this (by decide)
 
 /-! ## §4. Headline: Kratzer differentiates (60) and (61); traditional analysis collapses them. -/

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -761,7 +761,8 @@ private theorem empty_best (w : World) :
     w ∈ bestWorlds (W := World) emptyBackground emptyBackground w := by
   have hAcc : w ∈ accessibleWorlds (emptyBackground (W := World)) w := by
     rw [empty_base_universal_access]; exact Set.mem_univ _
-  exact ⟨hAcc, fun _ _ q hq _ => by simp [emptyBackground] at hq⟩
+  rw [empty_ordering_emptyBackground]
+  exact hAcc
 
 theorem nobody_move_total_prohibition :
     ∀ w, ¬ nobodyMoveExample.realize w := by
@@ -822,16 +823,12 @@ open Semantics.Modality.Directive in
 theorem cookie_is_suggestion :
     haveCookieExample.weakRealize
       (λ _ => [λ w => w = (0 : World)]) (0 : World) := by
-  show necessity _ _ _ _
-  rw [necessity_iff_all]
-  intro w hw
-  by_contra hne
-  rcases hw with ⟨_, hBest⟩
-  have hw0Acc : (0 : World) ∈ accessibleWorlds (emptyBackground (W := World)) (0 : World) := by
-    rw [empty_base_universal_access]; exact Set.mem_univ _
-  have hgoal : (λ w' : World => w' = (0 : World)) (0 : World) := rfl
-  have hweq : w = (0 : World) := hBest (0 : World) hw0Acc (λ w' : World => w' = (0 : World))
-    (by simp [combineOrdering]) hgoal
-  exact hne hweq
+  rintro w ⟨_, hmin⟩
+  have hTop : atLeastAsGoodAs [λ w' : World => w' = (0 : World)] (0 : World) w := by
+    intro q hq _
+    have hq' : q = λ w' : World => w' = (0 : World) := by simpa using hq
+    subst hq'; rfl
+  exact hmin (0 : World) (empty_best (0 : World)) hTop _
+    (List.mem_singleton.mpr rfl) rfl
 
 end Roberts2023

--- a/Linglib/Studies/Rubinstein2014.lean
+++ b/Linglib/Studies/Rubinstein2014.lean
@@ -155,11 +155,16 @@ theorem weak_not_entails_strong_R :
   -- `ce_p` (= "is w₁") holds at every BEST world: w₁ is favored and tops the ordering.
   have hWeak : weakNecessityR ce_pt ce_p w₀ := by
     intro w' hw'
-    obtain ⟨_hMem, hBest⟩ := hw'
+    obtain ⟨_hMem, hmin⟩ := hw'
     have hW1Fav : w₁ ∈ favoredWorlds ce_pt w₀ := by rw [hFav]; exact Set.mem_univ _
     have hProp : (λ w : World => w = w₁) ∈ ce_pt.negotiable w₀ := by
       simp only [ce_pt, List.mem_singleton]
-    exact hBest w₁ hW1Fav (λ w : World => w = w₁) hProp rfl
+    have hTop : atLeastAsGoodAs (ce_pt.negotiable w₀) w₁ w' := by
+      intro q hq _
+      have hq' : q = fun w : World => w = w₁ := by
+        simpa [ce_pt] using hq
+      subst hq'; rfl
+    exact hmin w₁ hW1Fav hTop _ hProp rfl
   -- but it fails at the favored world w₀, so strong necessity does not hold.
   have hNotStrong : ¬ strongNecessityR ce_pt ce_p w₀ := by
     intro hS
@@ -282,8 +287,12 @@ theorem tax_should_holds :
     unfold reportInternational; left; rfl
   have hPropMem : reportInternational ∈ taxScenarioA.negotiable w₀ := by
     simp only [taxScenarioA, List.mem_singleton]
-  -- w' is at-least-as-good as w₀, which satisfies the negotiable ideal, so w' does too.
-  have hInt : reportInternational w' := hBest w₀ hW0Fav reportInternational hPropMem hW0Int
+  -- w₀ tops the negotiable ordering, so minimality transfers its ideal to w'.
+  have hTop : atLeastAsGoodAs (taxScenarioA.negotiable w₀) w₀ w' := by
+    intro q hq _
+    have hq' : q = reportInternational := by simpa [taxScenarioA] using hq
+    subst hq'; exact hW0Int
+  have hInt : reportInternational w' := hBest w₀ hW0Fav hTop reportInternational hPropMem hW0Int
   exact ⟨hDom, hInt⟩
 
 /-- In scenario A, strong necessity FAILS: not all favored worlds
@@ -466,8 +475,12 @@ theorem comparative_split :
     obtain ⟨_, hB⟩ := hb
     have hPmem : (fun w : World => w = w₁) ∈ ce_pt.negotiable w₀ := by
       simp only [ce_pt, List.mem_singleton]
-    have hav : a = w₁ := hA w₁ (Set.mem_univ w₁) (fun w => w = w₁) hPmem rfl
-    have hbv : b = w₁ := hB w₁ (Set.mem_univ w₁) (fun w => w = w₁) hPmem rfl
+    have hTop : ∀ x : World, atLeastAsGoodAs (ce_pt.negotiable w₀) w₁ x := by
+      intro x q hq _
+      have hq' : q = fun w : World => w = w₁ := by simpa [ce_pt] using hq
+      subst hq'; rfl
+    have hav : a = w₁ := hA w₁ (Set.mem_univ w₁) (hTop a) (fun w => w = w₁) hPmem rfl
+    have hbv : b = w₁ := hB w₁ (Set.mem_univ w₁) (hTop b) (fun w => w = w₁) hPmem rfl
     rw [hav, hbv]
 
 /-- Membership in Rubinstein's comparative natural class: an evaluative


### PR DESCRIPTION
Verified against [kratzer-1981] (paper in hand): her practical-inference tripartition (§7) constructs a non-connected ordering on which the dominance form of `bestWorlds` is *empty*, trivializing her verdicts — minimality is the faithful reading.

- `bestWorlds f g w` := `(stateAt f g w).optimal` (deduplicated onto the state substrate); `bestAmong` migrated to match; `necessity_iff_boxLe` now unconditional.
- `humanNecessity`: her official limit-free ∀∃∀ definition, with `necessity_of_humanNecessity` (unconditional), `humanNecessity_iff_necessity` under `LimitAssumption`, and the empty-ordering collapse to `simpleNecessity` (her stated equivalence).
- `Directive.weakNecessity` rebuilt as the nested lexicographic form (`bestAmong` within the g-best) — the premise-concatenation form's best-shrinking lemma is false under minimality; nesting is both vFI's construction and the ordering-source-sequence refinement of Kratzer's Conclusion.
- `Ferreira2023.wn_equiv_snXg` restated with a connectedness hypothesis and proved both ways — the equation was an implementation-rfl under dominance; the combined→nested direction is unconditional, the converse fails on non-connected orderings (counterexample in hand).
- New `Studies/Kratzer1981.lean`: the tripartition example — her clause (c) incomparability, verdicts on all five conclusions, and the regression pair `dominance_best_empty` / `best_nonempty`.
- Graded possibility notions (her pp. 48-49, missing from the scan) deferred; the 2012 book PDF is a 0-byte placeholder pending Dropbox sync.