### PR TITLE
refactor(Semantics/Modality): Kratzer layer stands on Core/Order only

### DIFF
--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -38,7 +38,6 @@ Sources:
 
 import Linglib.Semantics.Modality.Kratzer.Ordering
 import Linglib.Core.Logic.Modal.Basic
-import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
 
 namespace Semantics.Modality.Kratzer
 
@@ -93,37 +92,6 @@ def necessity (f : ModalBase W) (g : OrderingSource W) (p : W → Prop) (w : W) 
 def possibility (f : ModalBase W) (g : OrderingSource W) (p : W → Prop) (w : W) : Prop :=
   diamond (kratzerBestR f g) p w
 
-/-! ### The Portner identification
-
-[portner-2018]'s gloss on his (3): reading the mood state's components
-as a modal base and ordering source, `□_cs` expresses simple necessity
-and `□_≤` human necessity ([kratzer-1981]). Stated over `stateAt`. -/
-
-open Semantics.Dynamic.Default in
-/-- Simple necessity is informational necessity over the induced state
-(the ordering source is irrelevant). -/
-theorem simpleNecessity_iff_boxCs (f : ModalBase W) (g : OrderingSource W)
-    (p : W → Prop) (w : W) :
-    simpleNecessity f p w ↔ (stateAt f g w).boxCs p :=
-  Iff.rfl
-
-open Semantics.Dynamic.Default in
-/-- Kratzer necessity is preferential necessity over the induced state
-— human necessity as `□_≤` ([portner-2018]'s (3b) identification). -/
-theorem necessity_iff_boxLe (f : ModalBase W) (g : OrderingSource W)
-    (p : W → Prop) (w : W) :
-    necessity f g p w ↔ (stateAt f g w).boxLe p :=
-  Iff.rfl
-
-open Semantics.Dynamic.Default ExpState in
-/-- Veltman acceptance at a Kratzer state: the induced state supports
-asserting `p` iff `p` is a simple necessity. -/
-theorem le_assert_iff_simpleNecessity (f : ModalBase W)
-    (g : OrderingSource W) (p : W → Prop) (w : W) :
-    stateAt f g w ≤ (stateAt f g w).assert p ↔ simpleNecessity f p w :=
-  ((stateAt f g w).le_assert_iff p).trans
-    (simpleNecessity_iff_boxCs f g p w).symm
-
 /-! ### Human necessity
 
 [kratzer-1981]'s official definition needs no Limit Assumption: it
@@ -131,8 +99,10 @@ asks each accessible world to see, at least as good, a witness below
 which only `p`-worlds occur. `necessity` (universal quantification
 over `bestWorlds`) is its Limit-Assumption collapse. -/
 
-/-- Human necessity ([kratzer-1981]): every accessible world has an
-accessible world at least as good, below which `p` holds throughout. -/
+/-- Human necessity ([kratzer-1981]; restated verbatim as "Necessity"
+in [kratzer-2012]): every accessible world has an accessible world at
+least as good, below which `p` holds throughout. Neutral with respect
+to the Limit Assumption, after Lewis's counterfactual semantics. -/
 def humanNecessity (f : ModalBase W) (g : OrderingSource W)
     (p : W → Prop) (w : W) : Prop :=
   ∀ u ∈ accessibleWorlds f w, ∃ v ∈ accessibleWorlds f w,
@@ -171,6 +141,12 @@ theorem humanNecessity_iff_necessity {f : ModalBase W} {g : OrderingSource W}
     {p : W → Prop} {w : W} (hlim : LimitAssumption f g w) :
     humanNecessity f g p w ↔ necessity f g p w :=
   ⟨necessity_of_humanNecessity, humanNecessity_of_necessity hlim⟩
+
+/-- Human possibility ([kratzer-2012]: "a possibility ... iff its
+negation ... is not a necessity"): the dual of `humanNecessity`. -/
+def humanPossibility (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W) : Prop :=
+  ¬ humanNecessity f g (fun v => ¬ p v) w
 
 /-- With the empty ordering source, human necessity is simple necessity
 ([kratzer-1981], her equivalence for arbitrary `f` and empty `g`). -/

--- a/Linglib/Semantics/Modality/Kratzer/Ordering.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Ordering.lean
@@ -14,7 +14,6 @@ All types are polymorphic over the world type `W`. Propositions are
 
 import Linglib.Semantics.Modality.Kratzer.ConversationalBackground
 import Linglib.Core.Order.Normality
-import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 import Linglib.Core.Order.OfCriteria
 import Mathlib.Order.Basic
 import Mathlib.Data.Set.Basic
@@ -150,39 +149,17 @@ These are exactly the worlds in ⋂f(w) — worlds compatible with all facts in 
 def accessibleWorlds (f : ModalBase W) (w : W) : Set W :=
   propIntersection (f w)
 
-/-! ### The induced expectation state
-
-[portner-2018] identifies the two components of his mood state with
-Kratzer's parameters: "If we think of ⟨cs_c, <_c⟩ as a modal base and
-ordering source, □_cs φ expresses simple necessity and □_< φ expresses
-human necessity" (his commentary on (3), citing [kratzer-1981]).
-`stateAt` is that identification read in the other direction: a
-Kratzer pair is a world-indexed family of expectation states. -/
-
-open Semantics.Dynamic.Default in
-/-- The expectation state a modal base and ordering source induce at a
-world: accessible worlds as information, the ordering-source ranking
-as pattern. -/
-def stateAt (f : ModalBase W) (g : OrderingSource W) (w : W) :
-    ExpState W :=
-  ⟨accessibleWorlds f w, kratzerNormality (g w)⟩
-
-@[simp] theorem stateAt_info (f : ModalBase W) (g : OrderingSource W) (w : W) :
-    (stateAt f g w).info = accessibleWorlds f w := rfl
-
-@[simp] theorem stateAt_order (f : ModalBase W) (g : OrderingSource W) (w : W) :
-    (stateAt f g w).order = kratzerNormality (g w) := rfl
-
 /-- The best accessible worlds: those no accessible world strictly
-betters — `ExpState.optimal` at the induced state. [kratzer-1981]'s
-official human necessity is the limit-free `humanNecessity`; it
-quantifies over exactly this set under the Limit Assumption
-(`humanNecessity_iff_necessity`). Her practical-inference tripartition
-(pp. 66-67) is non-connected by construction, so the stronger
+betters. [kratzer-1981]'s official necessity is the limit-free
+`humanNecessity`; it quantifies over exactly this set under the Limit
+Assumption (`humanNecessity_iff_necessity`). Her practical-inference
+tripartition (pp. 66-67) is non-connected by construction — the
+ordering "is not necessarily connected. Technically, ≤_A is a partial
+preorder" ([kratzer-2012], her note 12 chapter) — so the stronger
 dominance form (at least as good as *every* accessible world) would
 be empty there; minimality is the faithful reading. -/
 def bestWorlds (f : ModalBase W) (g : OrderingSource W) (w : W) : Set W :=
-  (stateAt f g w).optimal
+  Core.Order.Normality.optimal (kratzerNormality (g w)) (accessibleWorlds f w)
 
 /--
 **Theorem 3: Empty ordering source reduces to simple accessibility.**
@@ -201,11 +178,10 @@ theorem empty_ordering_emptyBackground (f : ModalBase W) (w : W) :
   unfold emptyBackground
   exact empty_ordering_simple f w
 
-/-- Realism is fiber-reflexivity: a modal base is realistic iff every
-world belongs to its own induced information state. -/
-theorem isRealistic_iff_mem_stateAt_info (f : ModalBase W)
-    (g : OrderingSource W) :
-    isRealistic f ↔ ∀ w, w ∈ (stateAt f g w).info :=
+/-- A modal base is realistic iff every world is accessible from
+itself. -/
+theorem isRealistic_iff_mem_accessible (f : ModalBase W) :
+    isRealistic f ↔ ∀ w, w ∈ accessibleWorlds f w :=
   ⟨fun h w p hp => h w p hp, fun h w p hp => h w p hp⟩
 
 /-- The best worlds among a given set: members no other member strictly

--- a/Linglib/Semantics/Mood/State.lean
+++ b/Linglib/Semantics/Mood/State.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Setoid.Basic
 import Linglib.Semantics.Mood.Defs
 import Linglib.Semantics.Dynamic.UpdateSemantics.Necessity
+import Linglib.Semantics.Modality.Kratzer.Operators
 
 /-!
 # Mood State: POSW with Inquiry Partition
@@ -424,5 +425,63 @@ def Component.boxOn : Component → State W → (W → Prop) → Prop
 
 @[simp] theorem boxOn_inquisitive (c : State W) (p : W → Prop) :
     Component.inquisitive.boxOn c p = c.boxAns p := rfl
+
+/-! ### Kratzer backgrounds induce states
+
+[portner-2018]'s gloss on his (3): reading the mood state's components
+as a modal base and ordering source ([kratzer-1981]), `□_cs` expresses
+simple necessity and `□_≤` human necessity. `stateAt` is that
+identification read in the other direction — a Kratzer pair is a
+world-indexed family of expectation states — and the theorems below
+are his (3a)/(3b). -/
+
+open Semantics.Modality.Kratzer
+
+/-- The expectation state a modal base and ordering source induce at a
+world: accessible worlds as information, the ordering-source ranking
+as pattern. -/
+def stateAt (f : ModalBase W) (g : OrderingSource W) (w : W) :
+    ExpState W :=
+  ⟨accessibleWorlds f w, kratzerNormality (g w)⟩
+
+@[simp] theorem stateAt_info (f : ModalBase W) (g : OrderingSource W) (w : W) :
+    (stateAt f g w).info = accessibleWorlds f w := rfl
+
+@[simp] theorem stateAt_order (f : ModalBase W) (g : OrderingSource W) (w : W) :
+    (stateAt f g w).order = kratzerNormality (g w) := rfl
+
+/-- Kratzer's best worlds are the induced state's optimal worlds. -/
+theorem bestWorlds_eq_optimal (f : ModalBase W) (g : OrderingSource W)
+    (w : W) :
+    bestWorlds f g w = (stateAt f g w).optimal := rfl
+
+/-- Simple necessity is informational necessity over the induced state
+(the ordering source is irrelevant) — [portner-2018]'s (3a). -/
+theorem simpleNecessity_iff_boxCs (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W) :
+    simpleNecessity f p w ↔ (stateAt f g w).boxCs p :=
+  Iff.rfl
+
+/-- Kratzer necessity is preferential necessity over the induced state
+— human necessity as `□_≤`, [portner-2018]'s (3b). -/
+theorem necessity_iff_boxLe (f : ModalBase W) (g : OrderingSource W)
+    (p : W → Prop) (w : W) :
+    necessity f g p w ↔ (stateAt f g w).boxLe p :=
+  Iff.rfl
+
+/-- Veltman acceptance at a Kratzer state: the induced state supports
+asserting `p` iff `p` is a simple necessity. -/
+theorem le_assert_iff_simpleNecessity (f : ModalBase W)
+    (g : OrderingSource W) (p : W → Prop) (w : W) :
+    stateAt f g w ≤ (stateAt f g w).assert p ↔ simpleNecessity f p w :=
+  ((stateAt f g w).le_assert_iff p).trans
+    (simpleNecessity_iff_boxCs f g p w).symm
+
+/-- Kratzer realism is fiber-reflexivity: a modal base is realistic iff
+every world belongs to its own induced information state. -/
+theorem isRealistic_iff_mem_stateAt_info (f : ModalBase W)
+    (g : OrderingSource W) :
+    isRealistic f ↔ ∀ w, w ∈ (stateAt f g w).info :=
+  isRealistic_iff_mem_accessible f
 
 end Mood


### PR DESCRIPTION
Kratzer 1981 cites Lewis, not Veltman (bibliography verified — no Veltman entry), so `Modality/Kratzer/` importing the update-semantics substrate misstated the theory's lineage. Now the import graph matches the citation graph:

- `bestWorlds` := `Core.Order.Normality.optimal (kratzerNormality (g w)) (accessibleWorlds f w)` — pure order-theory dependence, defeq-identical to the previous form, so no consumer changes.
- `stateAt` and the Portner (3a)/(3b) bridges (`simpleNecessity_iff_boxCs`, `necessity_iff_boxLe`, `le_assert_iff_simpleNecessity`, fiber-reflexivity) move to `Mood/State.lean` — the identification is Portner's synthesis, so the Mood layer, which cites both traditions, is where they meet. Kratzer keeps the native `isRealistic_iff_mem_accessible`.
- Book verification ([kratzer-2012], now in hand): her 2012 "Necessity" is verbatim our `humanNecessity` ∀∃∀ form; she flags the ordering as "not necessarily connected ... a partial preorder" and the Limit-Assumption neutrality after Lewis. Added `humanPossibility` as her stated dual.