### PR TITLE
fix(Fragments): correct Japanese/Korean wh-indeterminate polarity items

### DIFF
--- a/Linglib/Fragments/Japanese/PolarityItems.lean
+++ b/Linglib/Fragments/Japanese/PolarityItems.lean
@@ -2,13 +2,14 @@ import Linglib.Semantics.Polarity.Item
 
 /-!
 # Japanese Polarity-Sensitive Items
-[haspelmath-1997]
+[haspelmath-1997] [kratzer-shimoyama-2002] [shimoyama-2011] [watanabe-2004]
 
 Japanese indefinite pronoun polarity items, typed by the categories from
 `Semantics.Polarity`.
 
-Japanese builds polarity items compositionally from wh-words + particles:
-- **dare-mo** (neg): wh + mo under negation → NPI (nobody)
+Japanese builds polarity items from wh-indeterminates + particles
+([kratzer-shimoyama-2002]):
+- **dare-mo** (with clausemate negation): wh + mo → 'nobody'
 - **dare-demo**: wh + demo → FCI (anyone/whoever)
 -/
 
@@ -16,38 +17,49 @@ namespace Japanese.PolarityItems
 
 open Semantics.Polarity
 
--- ============================================================================
--- NPI
--- ============================================================================
+/-! ### NPI -/
 
-/-- *dare-mo* (under negation) — N-word.
-    wh + mo under negation: 'dare-mo konakatta' (nobody came). -/
+/-- *dare-mo* (with clausemate negation) — n-word: *dare-mo ko-nakat-ta*
+    'nobody came'. Requires clausemate sentential negation and is
+    ungrammatical in weak-DE contexts like questions and conditionals, which
+    take *dare-ka* or bare indeterminates instead ([shimoyama-2011]);
+    [watanabe-2004] analyzes it as a negative-concord item.
+
+    `baseForce` follows the Hamblin-universal analysis of *-mo*
+    ([shimoyama-2006], [kratzer-shimoyama-2002]; so also
+    `Japanese.Determiners.dare_mo`), on which *dare-mo…nai* is ∀ scoping over
+    negation; the rival negative-indefinite tradition posits ¬∃
+    (truth-conditionally equivalent under plain clausemate negation, teased
+    apart by the scope diagnostics of [shimoyama-2011]). The affirmative
+    *dare-mo* 'everyone' is the same wh + mo formation without negation. -/
 def dareMo : PolarityItemEntry :=
   { form := "dare-mo (誰も, neg)"
-  , polarityType := .npiWeak
-  , baseForce := .existential
-  , licensingContexts := [.negation, .nobody]
+  , polarityType := .npiStrong
+  , baseForce := .universal
+  , licensingContexts := [.negation]
   , scalarDirection := .strengthening
-  , notes := "wh + mo under negation: nobody" }
+  , morphology := .indefPlusEven
+  , alternativeType := .domain
+  , nWordStatus := some .nWord }
 
--- ============================================================================
--- FCI
--- ============================================================================
+/-! ### FCI -/
 
-/-- *dare-demo* — Free choice item.
-    wh + demo: 'dare-demo dekiru' (anyone can do it). -/
+/-- *dare-demo* — free choice item: *dare-demo dekiru* 'anyone can do it'.
+    wh + demo (built on the additive/'even' particle *mo*); free choice and
+    concessive-conditional uses ([kratzer-shimoyama-2002]). -/
 def dareDemo : PolarityItemEntry :=
   { form := "dare-demo (誰でも)"
   , polarityType := .fci
   , baseForce := .existential
   , licensingContexts := [.modalPossibility, .modalNecessity, .imperative, .generic]
-  , notes := "wh + demo: free choice / concessive conditional" }
+  , morphology := .indefPlusEven
+  , alternativeType := .domain }
 
--- ============================================================================
--- Verification
--- ============================================================================
+/-! ### Verification -/
 
-theorem dareMo_dareDemo_distinct :
-    dareMo.polarityType ≠ dareDemo.polarityType := by decide
+/-- Complementary distribution: the n-word and the FCI are licensed in
+    disjoint context sets (clausemate negation vs modal/imperative/generic). -/
+theorem dareMo_dareDemo_licensing_disjoint :
+    ∀ c ∈ dareMo.licensingContexts, c ∉ dareDemo.licensingContexts := by decide
 
 end Japanese.PolarityItems

--- a/Linglib/Fragments/Korean/PolarityItems.lean
+++ b/Linglib/Fragments/Korean/PolarityItems.lean
@@ -9,7 +9,7 @@ Korean indefinite pronoun polarity items, typed by the categories from
 
 Korean, like Japanese, builds polarity items from wh-words + particles:
 - **nwukwu** (bare): Weak NPI in non-interrogative uses
-- **nwukwu-to** (neg): wh + to under negation → NPI (nobody)
+- **nwukwu-to** (with clausemate negation): wh + to → 'nobody'
 - **nwukwu-na**: wh + na → FCI (anyone)
 -/
 
@@ -17,9 +17,7 @@ namespace Korean.PolarityItems
 
 open Semantics.Polarity
 
--- ============================================================================
--- NPIs
--- ============================================================================
+/-! ### NPIs -/
 
 /-- *nwukwu* (누구, bare) — Weak NPI.
     Bare wh-word as indefinite in non-interrogative non-specific contexts
@@ -29,22 +27,22 @@ def nwukwu : PolarityItemEntry :=
   , polarityType := .npiWeak
   , baseForce := .existential
   , licensingContexts := [.question, .conditionalAntecedent]
-  , scalarDirection := .strengthening
-  , notes := "Bare wh-word as non-specific indefinite" }
+  , scalarDirection := .strengthening }
 
-/-- *nwukwu-to* (누구도, under negation) — N-word.
-    wh + to under negation: 'nwukwu-to an wass-ta' (nobody came). -/
+/-- *nwukwu-to* (누구도, with clausemate negation) — n-word: *nwukwu-to an
+    wass-ta* 'nobody came'. wh + the additive/'even' particle *-to*, requiring
+    clausemate negation — the strict-negative-concord parallel of Japanese
+    *dare-mo* (see `Japanese.PolarityItems.dareMo`). -/
 def nwukwuTo : PolarityItemEntry :=
   { form := "nwukwu-to (누구도, neg)"
-  , polarityType := .npiWeak
+  , polarityType := .npiStrong
   , baseForce := .existential
-  , licensingContexts := [.negation, .nobody]
+  , licensingContexts := [.negation]
   , scalarDirection := .strengthening
-  , notes := "wh + to under negation: nobody" }
+  , morphology := .indefPlusEven
+  , nWordStatus := some .nWord }
 
--- ============================================================================
--- FCI
--- ============================================================================
+/-! ### FCI -/
 
 /-- *nwukwu-na* (누구나) — Free choice item.
     wh + na: 'nwukwu-na hal su issda' (anyone can do it). -/
@@ -53,11 +51,9 @@ def nwukwuNa : PolarityItemEntry :=
   , polarityType := .fci
   , baseForce := .existential
   , licensingContexts := [.modalPossibility, .modalNecessity, .imperative, .generic]
-  , notes := "wh + na: free choice / universal" }
+  , morphology := .indefPlusEven }
 
--- ============================================================================
--- Verification
--- ============================================================================
+/-! ### Verification -/
 
 theorem korean_npis_strengthening :
     [nwukwu, nwukwuTo].all

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -8874,7 +8874,7 @@
   subfield  = {semantics/quantification},
   validated = {true},
   role      = {formalized},
-  sources   = {Fragments/German/ModalIndefinites.lean;Studies/AlonsoOvalleMenendezBenito2010.lean;Studies/AlonsoOvalleRoyer2024.lean;Studies/KratzerShimoyama2002.lean;Features/ModalIndefinite.lean}
+  sources   = {Fragments/German/ModalIndefinites.lean;Studies/AlonsoOvalleMenendezBenito2010.lean;Studies/AlonsoOvalleRoyer2024.lean;Studies/KratzerShimoyama2002.lean;Features/ModalIndefinite.lean;Fragments/Japanese/PolarityItems.lean}
 }
 @article{kratzer-selkirk-2020,
   author    = {Kratzer, Angelika and Selkirk, Elisabeth},
@@ -19333,7 +19333,35 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/Japanese/Determiners.lean}
+  sources   = {Fragments/Japanese/Determiners.lean;Fragments/Japanese/PolarityItems.lean}
+}
+@article{shimoyama-2011,
+  author    = {Shimoyama, Junko},
+  year      = {2011},
+  title     = {Japanese Indeterminate Negative Polarity Items and Their Scope},
+  doi       = {10.1093/jos/ffr004},
+  journal   = {Journal of Semantics},
+  volume    = {28},
+  number    = {4},
+  pages     = {413--450},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Japanese/PolarityItems.lean}
+}
+@article{watanabe-2004,
+  author    = {Watanabe, Akira},
+  year      = {2004},
+  title     = {The Genesis of Negative Concord: Syntax and Morphology of Negative Doubling},
+  doi       = {10.1162/0024389042350497},
+  journal   = {Linguistic Inquiry},
+  volume    = {35},
+  number    = {4},
+  pages     = {559--612},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Japanese/PolarityItems.lean}
 }% REF: Nakanishi, K. (2007). Formal properties of measurement constructions.
 @book{nakanishi-2007,
   author    = {Nakanishi, Kimiko},


### PR DESCRIPTION
Random-file deep audit (5-agent panel, primary sources read): *dare-mo* was typed `.npiWeak`/`.existential`/`[.negation, .nobody]` — no published analysis supports any of the three. Now a strict-NC n-word: `.npiStrong` + `nWordStatus := some .nWord` (Watanabe 2004), `baseForce := .universal` matching the in-repo Hamblin analysis (`Determiners.lean`, `KratzerShimoyama2002.lean`; scope debate documented in the docstring), clausemate `[.negation]` only, `morphology := .indefPlusEven`. Korean *nwukwu-to* fixed in lockstep (identical template bugs); vacuous distinctness theorems replaced by a complementary-distribution check; verified bib entries added for watanabe-2004 and shimoyama-2011.