### PR TITLE
feat(Semantics/Polarity): licensing keystone LicensingContext.licenses

### DIFF
--- a/Linglib/Features/LicensingContext.lean
+++ b/Linglib/Features/LicensingContext.lean
@@ -1,3 +1,5 @@
+import Mathlib.Tactic.DeriveFintype
+
 /-!
 # Features.LicensingContext
 [ladusaw-1979] [kadmon-landman-1993]
@@ -84,6 +86,6 @@ inductive LicensingContext where
   | universalRestrictor -- Restrictor of universal: "everyone who saw anyone"
   | doubtVerb         -- DE attitude verbs: "I doubt anyone came"
   | denyVerb          -- Anti-additive attitude verbs: "She denied seeing anyone"
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Fintype, Repr
 
 end Features

--- a/Linglib/Fragments/Japanese/PolarityItems.lean
+++ b/Linglib/Fragments/Japanese/PolarityItems.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Polarity.Item
+import Linglib.Semantics.Polarity.Licensing
 
 /-!
 # Japanese Polarity-Sensitive Items
@@ -56,6 +56,17 @@ def dareDemo : PolarityItemEntry :=
   , alternativeType := .domain }
 
 /-! ### Verification -/
+
+/-- The licensing keystone characterizes *dare-mo* exactly: as an n-word it
+    requires an anti-morphic licensor, and clausal negation is the only such
+    row — predicted distribution and attested list coincide. -/
+theorem dareMo_licensing_characterized :
+    ∀ c, c.licenses dareMo ↔ c ∈ dareMo.licensingContexts := by decide
+
+/-- Every attested *dare-demo* context is predicted licensed: all four rows
+    license free choice items. -/
+theorem dareDemo_licensing_sound :
+    ∀ c ∈ dareDemo.licensingContexts, c.licenses dareDemo := by decide
 
 /-- Complementary distribution: the n-word and the FCI are licensed in
     disjoint context sets (clausemate negation vs modal/imperative/generic). -/

--- a/Linglib/Fragments/Korean/PolarityItems.lean
+++ b/Linglib/Fragments/Korean/PolarityItems.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Polarity.Item
+import Linglib.Semantics.Polarity.Licensing
 
 /-!
 # Korean Polarity-Sensitive Items
@@ -54,6 +54,17 @@ def nwukwuNa : PolarityItemEntry :=
   , morphology := .indefPlusEven }
 
 /-! ### Verification -/
+
+/-- The licensing keystone characterizes *nwukwu-to* exactly: as an n-word it
+    requires an anti-morphic licensor, and clausal negation is the only such
+    row — predicted distribution and attested list coincide. -/
+theorem nwukwuTo_licensing_characterized :
+    ∀ c, c.licenses nwukwuTo ↔ c ∈ nwukwuTo.licensingContexts := by decide
+
+/-- Every attested context of every Korean entry is predicted licensed. -/
+theorem korean_licensing_sound :
+    ∀ e ∈ [nwukwu, nwukwuTo, nwukwuNa], ∀ c ∈ e.licensingContexts,
+      c.licenses e := by decide
 
 theorem korean_npis_strengthening :
     [nwukwu, nwukwuTo].all

--- a/Linglib/Semantics/Polarity/Item.lean
+++ b/Linglib/Semantics/Polarity/Item.lean
@@ -293,14 +293,18 @@ structure PolarityItemEntry where
 -- § 8. Predicates
 -- ════════════════════════════════════════════════════
 
-/-- The [zwarts-1998] strength class an item requires of its licensor,
-    derived from `polarityType`: weak NPIs (and the NPI face of dual
-    NPI/FCIs) need weak DE, strong NPIs need anti-additivity; FCIs and
-    PPIs are not strength-keyed. The superstrong class (*a tad bit*,
-    anti-morphic) has no registry items yet — extend `PolarityType`
-    when one lands. -/
+/-- The [zwarts-1998] strength class an item requires of its licensor.
+    N-words (`nWordStatus = some .nWord`) require an anti-morphic licensor —
+    extensionally, clausal negation: the strict-negative-concord distribution
+    ([giannakidou-2000], [watanabe-2004]) read at the context-enum grain
+    (concord locality lives in `nWordStatus`, not in this projection). Other
+    items derive from `polarityType`: weak NPIs (and the NPI face of dual
+    NPI/FCIs) need weak DE, strong NPIs anti-additivity; FCIs and PPIs are
+    not strength-keyed. A genuine superstrong NPI (*a tad bit*) would still
+    extend `PolarityType` when one lands. -/
 def PolarityItemEntry.strength (e : PolarityItemEntry) :
     Option NaturalLogic.DEStrength :=
+  if e.nWordStatus = some .nWord then some .antiMorphic else
   match e.polarityType with
   | .npiWeak => some .weak
   | .npiFci => some .weak

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -310,6 +310,45 @@ theorem zwartsScale_licenses_iff (e : Semantics.Polarity.PolarityItemEntry)
   cases (contextProperties c).strawsonSignature.toDEStrength <;>
     cases e.strength <;> simp
 
+/-! ### The licensing keystone -/
+
+/-- The item↔context licensing relation (stipulated grade), read
+context-side: `c.licenses e` says environment `c` licenses item `e`.
+Dispatched on the row's `LicensingMechanism`:
+
+- signature rows (`byStrengthening`, `byStrawsonDE`): Zwarts-strength
+  licensing — the row's Strawson signature supplies at least `e.strength`
+  (n-words require anti-morphic strength, so clausal negation is the only
+  qualifying row);
+- `byGenericIndefinite` rows license free choice items;
+- `byEntropy` rows (questions, [van-rooy-2003-npi]) license weak NPIs;
+- `strengtheningFails` rows license nothing.
+
+The grounded grade — deriving the signature side from the context
+witnesses of `Witnesses.lean` via the Kadmon–Landman strengthening
+chain — is planned (N1 of the NPI-API sweep). -/
+def _root_.Features.LicensingContext.licenses (c : LicensingContext)
+    (e : Semantics.Polarity.PolarityItemEntry) : Prop :=
+  match (contextProperties c).mechanism with
+  | .byStrengthening | .byStrawsonDE => LicensedBySignature e c
+  | .byGenericIndefinite => e.isFCI
+  | .byEntropy => e.strength = some .weak
+  | .strengtheningFails => False
+
+instance (c : LicensingContext) (e : Semantics.Polarity.PolarityItemEntry) :
+    Decidable (c.licenses e) := by
+  unfold Features.LicensingContext.licenses; split <;> infer_instance
+
+/-- On signature-mechanism rows the keystone is exactly Zwarts-strength
+licensing (`LicensedBySignature`). -/
+theorem licenses_iff_signature (c : LicensingContext)
+    (e : Semantics.Polarity.PolarityItemEntry)
+    (h : (contextProperties c).mechanism = .byStrengthening ∨
+         (contextProperties c).mechanism = .byStrawsonDE) :
+    c.licenses e ↔ LicensedBySignature e c := by
+  unfold Features.LicensingContext.licenses
+  rcases h with h | h <;> rw [h]
+
 /-- A context is **Strawson-only** when no classical signature row holds
 ([von-fintel-1999]): only-focus, adversatives, temporal *since*,
 superlatives. -/


### PR DESCRIPTION
N0 of the NPI-API sweep (`scratch/npi-api-design.md`): the single item↔context licensing relation, as a dot-notation API read context-side — `c.licenses e` — mechanism-dispatched over `contextProperties`, with a `Decidable` instance and a bridge lemma to `LicensedBySignature` on signature rows.

- N-words ride the Zwarts chain instead of a bespoke arm: `PolarityItemEntry.strength` is `nWordStatus`-aware (n-words require `.antiMorphic`), so strict-NC clausal-negation-only distribution falls out of the existing scale.
- `LicensingContext` derives `Fintype`, making full ∀-over-contexts characterizations decidable.
- First exact fragment characterizations: `∀ c, c.licenses dareMo ↔ c ∈ dareMo.licensingContexts` (Japanese), same for Korean *nwukwu-to*, plus FCI soundness theorems.