### PR TITLE
feat(Features/Indefinite): Haspelmath adapter; fix map per the book

### DIFF
--- a/Linglib/Features/Indefinite.lean
+++ b/Linglib/Features/Indefinite.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
+import Linglib.Features.LicensingContext
 
 /-!
 # Indefinite series — feature taxonomy and the word-class-neutral capability
@@ -51,9 +52,10 @@ inductive HaspelmathFunction where
   | conditional
   /-- Function 6: Standard of comparison. -/
   | comparative
-  /-- Function 7: Indirect (clause-mate) negation. -/
+  /-- Function 7: Indirect negation (superordinate or implicit negation:
+      *without*, *doubt*, *deny*). -/
   | indirectNeg
-  /-- Function 8: Direct negation. -/
+  /-- Function 8: Direct (clause-mate) negation. -/
   | directNeg
   /-- Function 9: Free choice. -/
   | freeChoice
@@ -98,6 +100,40 @@ def HaspelmathFunction.isDE : HaspelmathFunction → Bool
 def HaspelmathFunction.isFC : HaspelmathFunction → Bool
   | .comparative | .freeChoice => true
   | _ => false
+
+/-- The [haspelmath-1997] map function a licensing environment realizes, for
+    the polarity-relevant reading of an indefinite in that environment.
+    Partial: `none` for environments outside the map's function inventory
+    (the Ladusaw-tradition rows `few`, `atMost`, `superlative`, `onlyFocus`,
+    `tooTo`, `universalRestrictor`, `sinceTemporal`; also `nobody`,
+    `beforeClause`, `adversative`, whose placement between direct and
+    indirect negation is not verified against the book and is left unmapped).
+    Interpretation-light judgment calls, documented: the modal, imperative,
+    generic, and free-relative rows map to `freeChoice` — their
+    polarity-relevant realization — although the same environments host plain
+    irrealis uses of non-polarity indefinites; both comparative rows realize
+    the standard-of-comparison function regardless of NPI-licensability
+    (`comparativeNP` licenses no NPIs, [hoeksema-1983]). -/
+def _root_.Features.LicensingContext.haspelmathFunction :
+    Features.LicensingContext → Option HaspelmathFunction
+  | .negation => some .directNeg
+  | .withoutClause | .doubtVerb | .denyVerb => some .indirectNeg
+  | .question => some .question
+  | .conditionalAntecedent => some .conditional
+  | .comparativeS | .comparativeNP => some .comparative
+  | .modalPossibility | .modalNecessity | .imperative | .generic
+  | .freeRelative => some .freeChoice
+  | _ => none
+
+/-- The licensing environments realizing a map function — the preimage of
+    `Features.LicensingContext.haspelmathFunction`. Empty for the specificity
+    triangle (`specificKnown`, `specificUnknown`, `irrealis`), whose
+    realizations are positive or irrealis clauses outside the
+    licensing-context inventory (matching the Fragment convention that an
+    empty `licensingContexts` list means the item needs positive contexts). -/
+def HaspelmathFunction.contexts (f : HaspelmathFunction) :
+    Finset Features.LicensingContext :=
+  Finset.univ.filter (·.haspelmathFunction = some f)
 
 /-- BFS on the implicational map restricted to a given set of functions.
     Returns the set of nodes reachable from `start` through edges whose

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.NaturalLogic
 import Linglib.Features.LicensingContext
+import Linglib.Features.Indefinite
 import Linglib.Semantics.Polarity.Item
 
 /-!
@@ -348,6 +349,34 @@ theorem licenses_iff_signature (c : LicensingContext)
     c.licenses e ↔ LicensedBySignature e c := by
   unfold Features.LicensingContext.licenses
   rcases h with h | h <;> rw [h]
+
+/-! ### The Haspelmath map meets the licensing table
+
+`Features.LicensingContext.haspelmathFunction` (in `Features/Indefinite.lean`)
+classifies each licensing environment by the [haspelmath-1997] map function it
+realizes. The theorems here ground the map's stipulated polarity-side
+classifiers (`HaspelmathFunction.isDE`/`isFC`) in `contextProperties`. -/
+
+/-- [haspelmath-1997]'s free-choice region coincides exactly with the
+[kadmon-landman-1993] generic-indefinite mechanism class: a context realizes
+the `freeChoice` function iff its licensing mechanism is
+`byGenericIndefinite`. -/
+theorem haspelmathFunction_freeChoice_iff_genericIndefinite
+    (c : LicensingContext) :
+    c.haspelmathFunction = some .freeChoice ↔
+      (contextProperties c).mechanism = .byGenericIndefinite := by
+  cases c <;> decide
+
+/-- Every context realizing an NPI-region function (`HaspelmathFunction.isDE`:
+question through direct negation) either supplies Zwarts strength or is the
+entropy row — the map's classical NPI region is weak-NPI-licensable, though
+not uniformly DE (questions license by entropy, [van-rooy-2003-npi]). -/
+theorem haspelmathFunction_npi_region_licensable (c : LicensingContext)
+    (f : Indefinite.HaspelmathFunction) (hf : c.haspelmathFunction = some f)
+    (hDE : f.isDE = true) :
+    (contextProperties c).strawsonSignature.toDEStrength.isSome ∨
+      (contextProperties c).mechanism = .byEntropy := by
+  revert hf hDE; cases c <;> cases f <;> decide
 
 /-- A context is **Strawson-only** when no classical signature row holds
 ([von-fintel-1999]): only-focus, adversatives, temporal *since*,


### PR DESCRIPTION
Three-part grounding + cleanse of the Haspelmath substrate and studies, verified against the book (open-access OUP PDF in hand).

- **A2 adapter**: `c.haspelmathFunction : Option HaspelmathFunction` + derived `f.contexts` (Fintype preimage) + grounding theorems in `Licensing.lean` (FC region ≡ K&L `byGenericIndefinite` class exactly; NPI region supplies Zwarts strength or entropy).
- **Map geometry corrected to Fig. 4.4**: the old adjacency linearized the 2D map; function numbers in the enum docstrings fixed (6=indirectNeg, 7=directNeg, 8=comparative). Five paradigms book-verified (A.1, A.26, A.37–A.39, Table 4.1): German, Hungarian, Quechua (switched to the book's Ancash variety), Japanese (comparative belongs to *-mo* via *dare-yori-mo*; *-demo* = free choice only), Korean (*-to* covers comparative; *-na* = FC only, 'it may be' source so morphology reverted). Three previously stipulated rows were non-contiguous under the true geometry. Chierchia2006's *irgendwer* check now exempts specificUnknown explicitly (the K&S ignorance reading its eligibility encoding doesn't generate).
- **Register cleanse of both Haspelmath study files**: license headers, terse module docstrings (Main results + Implementation notes), `/-! ### -/` sections, one-sentence declaration docstrings with bare appendix refs. Aggregate/data-check decide theorems cut (form counts, WALS tables, summary stats; `specificKnown_directNeg_disjoint` was refuted by the book's own Table 4.1 — Swedish *någon* = 1234567); the 17 one-bit FragmentBridges compacted to three quantified ∈-Props; dead `fragmentSample` and the docstring's phantom ABA-ban claim removed from `Haspelmath1997.lean`.