### PR TITLE
refactor(Semantics/Polarity): one licensing relation, keystone subsumes

### DIFF
--- a/Linglib/Semantics/Polarity/Israel.lean
+++ b/Linglib/Semantics/Polarity/Israel.lean
@@ -1,53 +1,25 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Polarity.Item
 
 /-!
-# Semantics.Polarity.Israel
+# Israel's scalar model: canonicity predictions
 [israel-1996] [israel-2001] [israel-2011]
 
-Israel's theoretical predictions on polarity-sensitive items: the
-`predictCanonicity` function and `canonicityConsistent` validation
-predicate. The Israel scalar enums themselves
-(`ScalarValue`/`ScalarDirection`/`Canonicity`/`LikelihoodEffect`)
-live in `Typology/PolarityItem.lean` (Fragment-importable substrate);
-the *predictions* about how they relate to each other are theoretical
-content and live here.
-
-## Provenance
-
-Extracted from `Typology/PolarityItem.lean` after audit consensus
-that `predictCanonicity` is Israel's main empirical claim — not
-neutral typology — and belongs in `Theories/`. Sibling of
-`Semantics/Polarity/Licensing.lean` (the Ladusaw/K&L
-monotonicity theory hub).
-
-## Framework commitment
-
-Israel's central empirical claim ([israel-2001]) is that for
-emphatic polarity items, canonicality is determined principally by
-**likelihood effect** (propositional role): impeding roles
-(patient/theme) → canonical items, facilitating roles (agent/stimulus)
-→ inverted items. The pecuniary-paradox dissolution
-(*a red cent* NPI vs *for peanuts* PPI in the same monetary domain) is
-the canonical witness of role-likelihood mapping carrying explanatory
-weight that pure-monotonicity accounts (Ladusaw, K&L) lack.
-
-This file enshrines the Israel framework. Alternative scalar accounts
-([lahiri-1998] EVEN-based, [chierchia-2006] EXH+D-alternatives,
-Krifka 1995 STA) would live as sibling Theories files; the
-`Typology/PolarityItem.lean` Israel-shaped data fields would carry
-each framework's analysis as an optional projection.
-
-## Cross-framework gap (Israel ↔ Ladusaw)
-
-The cross-file gap with `Semantics/Polarity/Licensing.lean`
-remains unclosed by this restructure. The refutation theorem —
-showing a context where Israel's role-likelihood mapping and Ladusaw's
-monotonicity-licensing diverge in their predictions — is **planned**
-for `Studies/Israel2001.lean`. The natural witness
-is the pecuniary paradox above. NOTE: `Israel2001.lean §8` currently
-formalizes Israel↔Ladusaw *agreement* via a `ScaleDirection` bridge
-enum — that's the wrong direction; the refutation work is genuinely
-deferred.
+Israel's central empirical claim: for emphatic polarity items,
+canonical vs inverted is determined by likelihood effect (impeding
+roles → canonical, facilitating → inverted), dissolving the pecuniary
+paradox (*a red cent* NPI vs *for peanuts* PPI in one monetary domain)
+— explanatory weight that per-context monotonicity accounts lack. The
+scalar axes live on `Polarity.Item`; this file holds the predictions:
+`predictCanonicity` and the `canonicityConsistent` validation
+predicate (checked over the English lexicon and `Studies/Israel2001`).
+The Israel↔Ladusaw refutation theorem — a context where role-likelihood
+and monotonicity licensing diverge — remains deferred to
+`Studies/Israel2001.lean`.
 -/
 
 namespace Semantics.Polarity
@@ -63,13 +35,13 @@ namespace Semantics.Polarity
     effect determines WHETHER the item is canonical or inverted.
 
     **CAVEATS** (the function is a strong reading, not Israel verbatim):
-    - The `_, .fci => .unknown` case reflects an editorial decision that
-      the substrate declines to predict canonicity for FCIs; Israel 2001
+    - The pure-FC case returns `.unknown`: an editorial decision that the
+      substrate declines to predict canonicity for FCIs; Israel 2001
       mostly bracketed FCIs rather than asserting they have no canonicity.
     - Israel's role-likelihood mapping is most robust for emphatic
       strengtheners (NPIs) and PPIs; attenuators interact differently
       (he allows lexical exceptions). The function applies the impeding/
-      facilitating mapping uniformly across `PolarityType` regardless of
+      facilitating mapping uniformly across item classes regardless of
       `ScalarDirection`; downstream consumers should consult the
       `scalarDirection` field separately when distinguishing emphatic
       from attenuating items.

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -1,83 +1,58 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.NaturalLogic
 import Linglib.Features.LicensingContext
 import Linglib.Features.Indefinite
 import Linglib.Semantics.Polarity.Item
 
 /-!
-# Semantics.Polarity.Licensing
-[ladusaw-1979] [kadmon-landman-1993] [zwarts-1998] [vanderwouden-1997]
-[von-fintel-1999] [chierchia-2006]
-[horn-1996] [hoeksema-1983] [bhatt-pancheva-2004]
-[heim-2006] [iatridou-2000] [dayal-1996]
-[van-rooy-2003-npi]
+# Polarity licensing
+[ladusaw-1979] [kadmon-landman-1993] [zwarts-1998] [von-fintel-1999]
+[van-rooy-2003-npi] [hoeksema-1983] [bhatt-pancheva-2004] [heim-2006]
+[iatridou-2000] [dayal-1996] [horn-1996] [vanderwouden-1997]
 
-Monotonicity-based licensing infrastructure for polarity-sensitive items:
-the `LicensingContext` enum (~22 contexts), the `LicensingMechanism`
-classification (K&L domain-widening + strengthening, plus refinements
-for non-K&L licensing), the `ContextProperties` synthesis bundling
-DE-strength signatures with mechanism + Strawson-DE flagging, and the
-canonical `contextProperties` map projecting each context to its
-theoretical lineage.
+The monotonicity-based licensing theory for `Polarity.Item`:
+`contextProperties` assigns every `LicensingContext` its Strawson and
+classical entailment signatures, its [kadmon-landman-1993] licensing
+mechanism, and its citation lineage; `StrengthScale` is the polymorphic
+item↔context strength pattern with `zwartsScale` as its canonical
+instance; and the keystone `LicensingContext.licenses` dispatches on the
+row's mechanism — Zwarts strength on signature rows, free choice on
+generic-indefinite rows ([dayal-1996]), entropy on questions
+([van-rooy-2003-npi]). Per-paper classifiers (`Ladusaw1979`,
+`KadmonLandman1993`) project from `contextProperties` rather than
+parallel-stipulating; the grounded grade — deriving the signatures from
+the model witnesses of `Witnesses.lean` via the Kadmon–Landman
+strengthening chain — is the planned next step.
 
-## Provenance
+## Main declarations
 
-Split from `Core/Lexical/PolarityItem.lean` in the cleanup that
-dissolved `Core/Lexical/`. The Israel scalar machinery
-(`ScalarValue`/`ScalarDirection`/`Canonicity`/`LikelihoodEffect`)
-moved to the sibling file `Typology/PolarityItem.lean` (which also
-holds `PolarityItemEntry` and `predictCanonicity`); the cross-file
-gap between Israel's scalar model and Ladusaw/K&L's monotonicity
-model is documented there.
+* `LicensingMechanism`, `ContextProperties`, `contextProperties` — the
+  per-context theory table.
+* `StrengthScale`, `zwartsScale` — polymorphic strength licensing.
+* `LicensingContext.licenses` — the item↔context licensing keystone.
+* `IsStrawsonOnly` and the Haspelmath-map grounding theorems.
 
-## Framework commitment
+## Implementation notes
 
-The `contextProperties` map encodes the **monotonicity-based**
-licensing tradition: [ladusaw-1979] (DE-licensing), [zwarts-1998]
-(anti-additive/anti-morphic refinement), [kadmon-landman-1993]
-(domain widening + strengthening), [von-fintel-1999] (Strawson-DE
-extension), and the every-restrictor-as-LAA result (variously
-attributed to Zwarts 1981 / van Benthem 1986 / Sánchez Valencia 1991;
-none currently in `references.bib`).
-Per-paper classifiers (`Ladusaw1979.licensingStrength`,
-`KadmonLandman1993.klExplanation`) project from this single record
-rather than parallel-stipulating.
-
-The `LicensingMechanism` 5-way enum refines the original 3-way
-{byStrengthening, byGenericIndefinite, byOtherMechanism} into the
-substantively distinct cases:
-
-- `byStrengthening`: K&L-canonical DE + widening (covers Ladusaw 1979).
-- `byGenericIndefinite`: non-DE FC any (modals, generics, free relatives).
-- `byStrawsonDE`: licensing via Strawson entailment (superlatives) —
-  [von-fintel-1999] / Herdan & Sharvit (UNVERIFIED — bib entry missing).
-- `byEntropy`: entropy-based licensing (questions per [van-rooy-2003-npi]).
-- `strengtheningFails`: contexts that *don't* license despite surface
-  appearance (e.g., NP-comparatives that lack covert clausal structure).
-
-The earlier `byOtherMechanism` constructor used by some study files
-(e.g., `KadmonLandman1993.lean` for ungrammatical examples) maps to
-`strengtheningFails`; the legitimate non-K&L cases (entropy questions,
-Strawson-DE superlatives) get their own dedicated constructors.
-
-## Out of scope: Israel↔Ladusaw cross-framework gap
-
-This file's `contextProperties.signature` field is Ladusaw/Zwarts/P&W
-canonical: each context has *one* DE/anti-additive/anti-morphic
-signature, regardless of which item is being licensed. Israel's scalar
-model rejects this per-context signature framing — for him,
-polarity-sensitivity is determined by the item's scale + role, not by
-the context's monotonicity. The cross-framework gap is real and is
-NOT closed by this restructure; see `Typology/PolarityItem.lean` for
-the Israel-side machinery and the documented refutation-theorem TODO.
+The table's signatures are Ladusaw/Zwarts/von-Fintel canonical — one row
+per context regardless of item; [israel-2001]'s scalar model rejects
+exactly this framing (predictions in `Semantics/Polarity/Israel.lean`).
+The NP-comparative row licenses nothing ([hoeksema-1983]); surface NPIs
+in "than NP" route through the clausal row ([bhatt-pancheva-2004],
+[heim-2006]). The every-restrictor-as-LAA signature is standard but of
+contested attribution (Zwarts 1981 / van Benthem 1986 / Sánchez Valencia
+1991; none in `references.bib`).
 -/
 
 namespace Semantics.Polarity.Licensing
 
 open Features (LicensingContext)
 
--- ════════════════════════════════════════════════════
--- § 1. Licensing Mechanism (refined 5-way)
--- ════════════════════════════════════════════════════
+/-! ### Licensing Mechanism (refined 5-way) -/
 
 /-- The mechanism by which a context licenses NPIs.
 
@@ -105,9 +80,7 @@ inductive LicensingMechanism where
   | strengtheningFails
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 2. Context Properties (single source of truth)
--- ════════════════════════════════════════════════════
+/-! ### Context Properties (single source of truth) -/
 
 /-- The bundle of theory-relevant facts about a licensing context.
 
@@ -251,31 +224,12 @@ def contextProperties : LicensingContext → ContextProperties
       , citations := ["UNVERIFIED-bib-missing:herdan-sharvit", "von-fintel-1999"]
       , classicalSignature := none }
 
-/-- Zwarts-strength licensing, derived ([zwarts-1998], [gajewski-2011]):
-the context's Strawson-operative row supplies at least the item's required
-strength (the item's `licensor` field). `false` when either side is not
-strength-keyed — those
-items/contexts license via mechanism (`LicensingMechanism`), not
-signature. -/
-def strengthLicenses (e : Semantics.Polarity.Item)
-    (c : LicensingContext) : Bool :=
-  match (contextProperties c).strawsonSignature.toDEStrength, e.licensor with
-  | some supplied, some required =>
-      NaturalLogic.strengthSufficient supplied required
-  | _, _ => false
+/-! ### Strength scales
 
-/-- `strengthLicenses` as a proposition. -/
-abbrev LicensedBySignature (e : Semantics.Polarity.Item)
-    (c : LicensingContext) : Prop :=
-  strengthLicenses e c = true
-
-/-! ### Polymorphic strength scales
-
-`strengthLicenses` is the Zwarts/`DEStrength` instance of a general pattern: a
-theory of NPI strength is an *ordered carrier* `S` plus how items and contexts
-project onto it, with licensing = `≤` on `S`. Different theories of strength
-(Gajewski plain-vs-exhaustified, Giannakidou veridicality, gradient) instantiate
-it with different carriers — see `scratch/npi-api-design.md`. -/
+A theory of NPI strength is an *ordered carrier* `S` plus how items and
+contexts project onto it, with licensing = `≤` on `S`. Different theories of
+strength (Gajewski plain-vs-exhaustified, Giannakidou veridicality, gradient)
+instantiate different carriers. -/
 
 /-- A **strength scale** for NPI licensing: how items and contexts project onto
 an ordered strength carrier `S`. `none` on either side = "no strength here" (the
@@ -292,24 +246,19 @@ def StrengthScale.licenses {Item Context S : Type*} [Preorder S]
     (L : StrengthScale Item Context S) (i : Item) (c : Context) : Prop :=
   ∃ r ∈ L.required i, ∃ s ∈ L.supplied c, r ≤ s
 
-/-- The canonical Zwarts/[ladusaw-1979] scale: carrier `DEStrength`, item
-strength from `Item.licensor`, context strength from the row's
-Strawson signature. The first instance of `StrengthScale`. -/
+instance {Item Context S : Type*} [Preorder S]
+    [DecidableRel (α := S) (· ≤ ·)] (L : StrengthScale Item Context S)
+    (i : Item) (c : Context) : Decidable (L.licenses i c) := by
+  unfold StrengthScale.licenses; infer_instance
+
+/-- The canonical Zwarts scale ([ladusaw-1979], [zwarts-1998],
+[gajewski-2011]): carrier `DEStrength`, item strength from `Item.licensor`,
+context strength from the row's Strawson signature. -/
 def zwartsScale :
     StrengthScale Semantics.Polarity.Item LicensingContext
       NaturalLogic.DEStrength where
   required e := e.licensor
   supplied c := (contextProperties c).strawsonSignature.toDEStrength
-
-/-- The polymorphic scale subsumes the bespoke predicate: `zwartsScale.licenses`
-is exactly `LicensedBySignature` (derive-don't-duplicate). -/
-theorem zwartsScale_licenses_iff (e : Semantics.Polarity.Item)
-    (c : LicensingContext) :
-    zwartsScale.licenses e c ↔ LicensedBySignature e c := by
-  simp only [StrengthScale.licenses, zwartsScale, LicensedBySignature,
-    strengthLicenses, NaturalLogic.strengthSufficient]
-  cases (contextProperties c).strawsonSignature.toDEStrength <;>
-    cases e.licensor <;> simp
 
 /-! ### The licensing keystone -/
 
@@ -331,7 +280,7 @@ chain — is planned (N1 of the NPI-API sweep). -/
 def _root_.Features.LicensingContext.licenses (c : LicensingContext)
     (e : Semantics.Polarity.Item) : Prop :=
   match (contextProperties c).mechanism with
-  | .byStrengthening | .byStrawsonDE => LicensedBySignature e c
+  | .byStrengthening | .byStrawsonDE => zwartsScale.licenses e c
   | .byGenericIndefinite => e.isFCI
   | .byEntropy => e.licensor = some .weak
   | .strengtheningFails => False
@@ -339,16 +288,6 @@ def _root_.Features.LicensingContext.licenses (c : LicensingContext)
 instance (c : LicensingContext) (e : Semantics.Polarity.Item) :
     Decidable (c.licenses e) := by
   unfold Features.LicensingContext.licenses; split <;> infer_instance
-
-/-- On signature-mechanism rows the keystone is exactly Zwarts-strength
-licensing (`LicensedBySignature`). -/
-theorem licenses_iff_signature (c : LicensingContext)
-    (e : Semantics.Polarity.Item)
-    (h : (contextProperties c).mechanism = .byStrengthening ∨
-         (contextProperties c).mechanism = .byStrawsonDE) :
-    c.licenses e ↔ LicensedBySignature e c := by
-  unfold Features.LicensingContext.licenses
-  rcases h with h | h <;> rw [h]
 
 /-! ### The Haspelmath map meets the licensing table
 

--- a/Linglib/Semantics/Polarity/Marking.lean
+++ b/Linglib/Semantics/Polarity/Marking.lean
@@ -2,6 +2,9 @@ import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Polarity marking: strategy typology
+
+(A separate system from the `Polarity.Item` licensing API — the two share
+only the `Semantics.Polarity` namespace.)
 [turco-braun-dimroth-2014] [bluhdorn-lohnstein-2012] [sudhoff-2012]
 [hohle-1992] [holmberg-2016]
 

--- a/Linglib/Semantics/Polarity/Operator.lean
+++ b/Linglib/Semantics/Polarity/Operator.lean
@@ -1,5 +1,8 @@
 /-!
 # Polarity Operators
+
+(A separate system from the `Polarity.Item` licensing API — the two share
+only the `Semantics.Polarity` namespace.)
 [laka-1990] [turk-hirsch-2026]
 
 The two semantic operators that polarity heads spell out, as bare functions

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -637,8 +637,7 @@ context. The substrate makes this `decide`-checkable.
 -/
 
 open Semantics.Polarity (LicensingContext)
-open Semantics.Polarity.Licensing
-  (contextProperties IsStrawsonOnly LicensedBySignature)
+open Semantics.Polarity.Licensing (contextProperties IsStrawsonOnly)
 open English.PolarityItems
   (any ever yet anymore atAll inTheLeast aSingle whatsoever
    liftAFinger budgeAnInch inYears until_ either_npi)
@@ -660,29 +659,24 @@ theorem gaj2011_strongNPIs_excluded_from_strawson_only_contexts :
   cases ctx <;> simp_all [IsStrawsonOnly, liftAFinger, budgeAnInch, inYears,
     until_, either_npi, contextProperties]
 
-/-- The registry agrees with signature-derived licensing on the strong
-NPIs: every context a strong NPI lists supplies anti-additive strength
-(`strengthSufficient` of the row's Strawson DE strength against the
-item's derived [zwarts-1998] class). -/
-theorem gaj2011_strong_npis_licensedBySignature :
+/-- The registry agrees with keystone licensing on the strong NPIs: every
+context a strong NPI lists supplies anti-additive strength. -/
+theorem gaj2011_strong_npis_licensed :
     ∀ e ∈ [liftAFinger, budgeAnInch, inYears, until_, either_npi],
-      ∀ c ∈ e.licensingContexts, LicensedBySignature e c := by decide
+      ∀ c ∈ e.licensingContexts, c.licenses e := by decide
 
-/-- Same agreement for the weak NPIs, gated to the strength-keyed
-mechanisms: the FC and entropy rows in *any*'s list are licensed by their
-mechanism, not by DE strength. -/
-theorem gaj2011_weak_npis_licensedBySignature :
+/-- Same agreement for the weak NPIs — ungated: the keystone's mechanism
+dispatch covers the FC and entropy rows in *any*'s list that
+strength-only licensing had to exclude by hand. -/
+theorem gaj2011_weak_npis_licensed :
     ∀ e ∈ [any, ever, yet, anymore, atAll, inTheLeast, aSingle, whatsoever],
-      ∀ c ∈ e.licensingContexts,
-        ((contextProperties c).mechanism = .byStrengthening ∨
-         (contextProperties c).mechanism = .byStrawsonDE) →
-        LicensedBySignature e c := by decide
+      ∀ c ∈ e.licensingContexts, c.licenses e := by decide
 
 -- The strength cut as a derived prediction (Gajewski's few-contrast):
 -- *few* (weak DE) licenses *any* but not *in years*; *nobody*
 -- (anti-additive) licenses both.
-example : LicensedBySignature any .few := by decide
-example : ¬ LicensedBySignature inYears .few := by decide
-example : LicensedBySignature inYears .nobody := by decide
+example : Features.LicensingContext.few.licenses any := by decide
+example : ¬ Features.LicensingContext.few.licenses inYears := by decide
+example : Features.LicensingContext.nobody.licenses inYears := by decide
 
 end Gajewski2011

--- a/Linglib/Studies/IatridouZeijlstra2021.lean
+++ b/Linglib/Studies/IatridouZeijlstra2021.lean
@@ -1,3 +1,4 @@
+import Linglib.Semantics.NaturalLogic
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Semantics.Aspect.SubintervalProperty
 import Linglib.Core.Order.Interval
@@ -95,15 +96,6 @@ theorem pts_uts_mirror :
 -- § 2. Boundary Adverbial Structure
 -- ════════════════════════════════════════════════════
 
-/-- NPI strength classification. Strong NPIs require antiadditive
-    environments; weak NPIs require only DE environments.
-    [zwarts-1998] [gajewski-2011] -/
-inductive NPIStrength where
-  | strong  -- requires antiadditive (not, nobody, never)
-  | weak    -- requires DE (few, at most, before)
-  | none_   -- not an NPI
-  deriving DecidableEq, Repr
-
 /-- A boundary adverbial: a temporal expression that sets one boundary
     of a time span (PTS or UTS).
 
@@ -119,8 +111,10 @@ structure BoundaryAdverbial where
   boundary : BoundaryKind
   /-- Does this adverbial introduce subdomain alternatives? -/
   introducesDomainAlts : Bool
-  /-- Is this adverbial a (strong) NPI? -/
-  npiStrength : NPIStrength
+  /-- Minimum Zwarts strength of a licensing environment, in the shared
+      `Polarity.Item` vocabulary (`none` = not an NPI); strong NPIs
+      require anti-additivity ([zwarts-1998], [gajewski-2011]). -/
+  licensor : Option NaturalLogic.DEStrength := none
   /-- Is the adverbial always contrastively focused?
       [chierchia-2013]: domain widening requires contrastive focus
       under negation. *In years* is always contrastively focused;
@@ -146,7 +140,7 @@ def inYears : BoundaryAdverbial where
   timeSpan := .pts
   boundary := .left
   introducesDomainAlts := true
-  npiStrength := .strong
+  licensor := some .antiAdditive
   alwaysContrastive := true
   compatiblePerfect := [.existential]
 
@@ -159,7 +153,7 @@ def inTheLast5Years : BoundaryAdverbial where
   timeSpan := .pts
   boundary := .left
   introducesDomainAlts := false
-  npiStrength := .none_
+  licensor := none
   alwaysContrastive := false
   compatiblePerfect := [.existential, .universal]
 
@@ -171,7 +165,7 @@ def since2015 : BoundaryAdverbial where
   timeSpan := .pts
   boundary := .left
   introducesDomainAlts := false
-  npiStrength := .none_
+  licensor := none
   alwaysContrastive := false
 
 /-- *Until (5pm / I left)*: unified RB adverbial.
@@ -183,7 +177,7 @@ def until_ : BoundaryAdverbial where
   timeSpan := .uts
   boundary := .right
   introducesDomainAlts := true
-  npiStrength := .strong
+  licensor := some .antiAdditive
   alwaysContrastive := false  -- only contrastively focused under negation
 
 -- ════════════════════════════════════════════════════
@@ -203,7 +197,7 @@ theorem both_domain_wideners :
 
 /-- *In years* and *until* are both strong NPIs. -/
 theorem both_strong_npis :
-    inYears.npiStrength = .strong ∧ until_.npiStrength = .strong :=
+    inYears.licensor = some .antiAdditive ∧ until_.licensor = some .antiAdditive :=
   ⟨rfl, rfl⟩
 
 /-- *In years* is always contrastive; *until* is not. -/
@@ -443,14 +437,14 @@ def isDomainWidener (adv : BoundaryAdverbial) : Bool :=
 
 /-- Domain wideners among boundary adverbials are strong NPIs. -/
 theorem domain_widener_is_strong_npi :
-    (isDomainWidener inYears = true ∧ inYears.npiStrength = .strong) ∧
-    (isDomainWidener until_ = true ∧ until_.npiStrength = .strong) :=
+    (isDomainWidener inYears = true ∧ inYears.licensor = some .antiAdditive) ∧
+    (isDomainWidener until_ = true ∧ until_.licensor = some .antiAdditive) :=
   ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
 
 /-- Non-widener boundary adverbials are not NPIs. -/
 theorem non_widener_not_npi :
-    (isDomainWidener since2015 = false ∧ since2015.npiStrength = .none_) ∧
-    (isDomainWidener inTheLast5Years = false ∧ inTheLast5Years.npiStrength = .none_) :=
+    (isDomainWidener since2015 = false ∧ since2015.licensor = none) ∧
+    (isDomainWidener inTheLast5Years = false ∧ inTheLast5Years.licensor = none) :=
   ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
 
 

--- a/Linglib/Studies/Lahiri1998.lean
+++ b/Linglib/Studies/Lahiri1998.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Focus.Particles
 import Linglib.Semantics.Entailment.Basic
 import Linglib.Semantics.Entailment.Polarity
-import Linglib.Semantics.Polarity.Item
+import Linglib.Semantics.Polarity.Licensing
 import Linglib.Fragments.Hindi.PolarityItems
 
 /-!
@@ -727,20 +727,13 @@ theorem licensing_context_iff_grammatical :
       (d.grammatical → d.context.isSome) ∧
       (¬d.grammatical → d.context.isNone)) := by decide
 
-/-- All licensing contexts in the grammatical data are DE environments
-    (or questions, which license via negative bias rather than pure DE). -/
-def isDEOrQuestion : LicensingContext → Prop
-  | .negation            => True
-  | .conditionalAntecedent     => True
-  | .universalRestrictor => True
-  | .beforeClause       => True
-  | .question            => True
-  | .adversative         => True  -- Strawson-DE ([von-fintel-1999])
-  | .denyVerb            => True  -- semantically negative
-  | _                    => False
-
-instance : DecidablePred isDEOrQuestion := fun x => by
-  cases x <;> unfold isDEOrQuestion <;> infer_instance
+/-- A DE-or-question licenser, derived from `contextProperties`: the
+    context's Strawson row supplies Zwarts strength, or it licenses by
+    entropy (questions, which license via negative bias rather than
+    pure DE). -/
+abbrev isDEOrQuestion (c : LicensingContext) : Prop :=
+  ((Semantics.Polarity.Licensing.contextProperties c).strawsonSignature.toDEStrength).isSome ∨
+    (Semantics.Polarity.Licensing.contextProperties c).mechanism = .byEntropy
 
 /-- Predicate: a datum's context is some DE-or-question licenser. -/
 def hasDELicenser (d : HindiNPIDatum) : Prop :=


### PR DESCRIPTION
Predicate consolidation: the library now has exactly one item↔context licensing relation.

- `strengthLicenses`, `LicensedBySignature`, and their bridge theorems deleted; the keystone's signature arm is `zwartsScale.licenses` directly, with a general `Decidable` instance on `StrengthScale.licenses`.
- Gajewski2011 rerouted through `c.licenses e` (N4) — the weak-NPI agreement theorem loses its hand-written mechanism gate, since the keystone's dispatch covers the FC/entropy rows strength-only licensing had to exclude.
- `IatridouZeijlstra2021.NPIStrength` retired (N2): `BoundaryAdverbial` carries `licensor : Option DEStrength` in the shared vocabulary.
- Lahiri1998's `isDEOrQuestion` derived from `contextProperties` instead of a hand-enumerated context list.
- Register cleanse of `Licensing.lean`/`Israel.lean` (license headers, terse module docs, dead `Typology/PolarityItem.lean` references removed); one-sentence system-boundary notes in `Marking.lean`/`Operator.lean`.

Full `lake build Linglib` green (6618 jobs).