### PR TITLE
feat(Syntax/Reciprocal): derive reciprocal API from theories and fragments

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -781,6 +781,7 @@ import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.PropositionalLexemes
 import Linglib.Fragments.English.QuestionParticles
 import Linglib.Fragments.English.Questions
+import Linglib.Fragments.English.Reciprocals
 import Linglib.Fragments.English.Relativization
 import Linglib.Fragments.English.Scales
 import Linglib.Fragments.English.TemporalDeictic
@@ -2745,6 +2746,7 @@ import Linglib.Studies.WesterbeekKoolenMaes2015
 import Linglib.Studies.Westergaard2009
 import Linglib.Studies.White2014
 import Linglib.Studies.Williams2026
+import Linglib.Studies.Winter2018
 import Linglib.Studies.Wood2015
 import Linglib.Studies.Wood2023
 import Linglib.Studies.WoodinEtAl2024

--- a/Linglib/Fragments/Chichewa/Reciprocals.lean
+++ b/Linglib/Fragments/Chichewa/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.MorphRule
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Chicheŵa Reciprocal Fragment
@@ -41,5 +42,15 @@ def reflexivePrefix : MorphRule Bool :=
 /-- Reciprocal and reflexive are formally distinct in Chicheŵa. -/
 theorem recip_distinct_from_reflexive :
     reciprocalAffix.value ≠ reflexivePrefix.value := by decide
+
+open Reciprocal
+
+/-- The reciprocal suffix as a typological marker (distinct from the
+    reflexive *dzi-*). -/
+def anSuffix : ReciprocalMarker :=
+  { form := "-an-", strategy := .verbalAffix }
+
+/-- Marker inventory. -/
+def markers : List ReciprocalMarker := [anSuffix]
 
 end Chichewa.Reciprocals

--- a/Linglib/Fragments/English/Reciprocals.lean
+++ b/Linglib/Fragments/English/Reciprocals.lean
@@ -1,0 +1,35 @@
+import Linglib.Fragments.English.Pronouns
+import Linglib.Syntax.Reciprocal
+
+/-!
+# English Reciprocal Fragment
+[nordlinger-2023]
+
+English encodes reciprocity with the bipartite quantificational NP
+*each other* (bivalent; [nordlinger-2023] ex. 1b), with *one another* as
+a variant, plus a closed class of inherently reciprocal predicates
+(*quarrel*, *meet*, *kiss*; ex. 7). Both are formally distinct from the
+reflexive *themselves*. Pronoun entries live in
+`Fragments/English/Pronouns.lean`; the markers here derive their forms
+from those entries.
+-/
+
+namespace English.Reciprocals
+
+open Reciprocal
+
+/-- each other — bipartite quantificational reciprocal (form derived
+    from the pronoun entry `English.Pronouns.eachOther`). -/
+def eachOther : ReciprocalMarker :=
+  { form := Pronouns.eachOther.form, strategy := .bipartiteNP }
+
+/-- The closed class of inherently reciprocal predicates (*quarrel*,
+    *meet*; [nordlinger-2023] ex. 7). Lexicon-formed per [siloni-2012],
+    though *kiss*/*hug* resist the discontinuous construction (fn. 32). -/
+def lexicalClass : ReciprocalMarker :=
+  { form := "quarrel/meet (lexical class)", strategy := .lexical }
+
+/-- Marker inventory, primary strategy first. -/
+def markers : List ReciprocalMarker := [eachOther, lexicalClass]
+
+end English.Reciprocals

--- a/Linglib/Fragments/French/Reciprocals.lean
+++ b/Linglib/Fragments/French/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Reciprocal
 
 /-!
 # French Reciprocal Fragment
@@ -19,18 +20,22 @@ WALS Ch 106 classifying French as "mixed."
 
 namespace French.Reciprocals
 
-open Pronoun
+open Reciprocal
 
-/-- se — reflexive/reciprocal clitic (monovalent strategy). -/
-def se : PersonalPronoun :=
-  { form := "se", person := some .third }
+/-- se — reflexive/reciprocal clitic ([nordlinger-2023] ex. 28, 47). -/
+def se : ReciprocalMarker :=
+  { form := "se", strategy := .recipClitic
+  , readings := [.reciprocal, .reflexive] }
 
-/-- l'un l'autre — bipartite reciprocal NP (bivalent strategy). -/
-def lunLautre : PersonalPronoun :=
-  { form := "l'un l'autre", person := some .third, number := some .plural }
+/-- l'un l'autre — bipartite reciprocal NP. -/
+def lunLautre : ReciprocalMarker :=
+  { form := "l'un l'autre", strategy := .bipartiteNP }
 
 /-- The bipartite NP form is distinct from the clitic. -/
 theorem bipartite_distinct_from_clitic :
     lunLautre.form ≠ se.form := by decide
+
+/-- Marker inventory, primary strategy first. -/
+def markers : List ReciprocalMarker := [se, lunLautre]
 
 end French.Reciprocals

--- a/Linglib/Fragments/German/Reciprocals.lean
+++ b/Linglib/Fragments/German/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Reciprocal
 
 /-!
 # German Reciprocal Fragment
@@ -20,18 +21,24 @@ between reflexive and reciprocal uses.
 
 namespace German.Reciprocals
 
-open Pronoun
-
-/-- sich — reflexive/reciprocal pronoun (3rd person). -/
-def sich : PersonalPronoun :=
-  { form := "sich", person := some .third }
+open Reciprocal
 
 /-- einander — dedicated reciprocal pronoun. -/
-def einander : PersonalPronoun :=
-  { form := "einander", person := some .third, number := some .plural }
+def einander : ReciprocalMarker :=
+  { form := "einander", strategy := .recipPronoun }
+
+/-- sich — reflexive pronoun in reciprocal use ([siloni-2012] fn. 13
+    treats *sich*-reciprocals as syntactic reciprocal verbs). -/
+def sich : ReciprocalMarker :=
+  { form := "sich", strategy := .recipPronoun
+  , readings := [.reciprocal, .reflexive] }
 
 /-- The dedicated reciprocal form is distinct from the reflexive. -/
 theorem einander_distinct_from_sich :
     einander.form ≠ sich.form := by decide
+
+/-- Marker inventory: dedicated *einander* plus reflexive-identical
+    *sich* — jointly the WALS "mixed" configuration. -/
+def markers : List ReciprocalMarker := [einander, sich]
 
 end German.Reciprocals

--- a/Linglib/Fragments/Greek/StandardModern/Reciprocals.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.MorphRule
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Modern Greek Reciprocal Fragment
@@ -36,5 +37,21 @@ def nonactiveVoiceSuffix : MorphRule Bool :=
 /-- The Greek nonactive suffix is a voice operation (not valence). -/
 theorem nonactive_is_voice :
     nonactiveVoiceSuffix.category = .voice := rfl
+
+open Reciprocal
+
+/-- Nonactive voice morphology as a reciprocal marker (shared with
+    reflexives/middles; [nordlinger-2023] ex. 27). -/
+def nonactive : ReciprocalMarker :=
+  { form := "nonactive voice", strategy := .verbalAffix
+  , readings := [.reciprocal, .reflexive] }
+
+/-- o enas ton allon — distinct periphrastic reciprocal, whose existence
+    underlies the WALS "mixed" classification ([maslova-nedjalkov-2013]). -/
+def oEnasTonAllon : ReciprocalMarker :=
+  { form := "o enas ton allon", strategy := .bipartiteNP }
+
+/-- Marker inventory, primary strategy first. -/
+def markers : List ReciprocalMarker := [nonactive, oEnasTonAllon]
 
 end Greek.StandardModern.Reciprocals

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Reciprocal
 import Linglib.Semantics.Reference.Reciprocals
 import Linglib.Semantics.Reference.PluralityLicensing
 import Linglib.Data.UD.Basic
@@ -187,5 +188,17 @@ theorem reflexive_inflects :
     wide-scope (I-)reading is available.
     [dalrymple-haug-2024] §2. -/
 def singularAntecedentForcesWideScope : Bool := true
+
+open Reciprocal in
+/-- The reciprocal verbal suffix ([nordlinger-2023] ex. 19, citing
+    [siloni-2008]). -/
+def ozSuffix : ReciprocalMarker :=
+  { form := "-óz-", strategy := .verbalAffix }
+
+open Reciprocal in
+/-- Marker inventory, primary strategy first: *-óz-* plus the reciprocal
+    pronoun *egymás* (form derived from the pronoun entry above). -/
+def markers : List ReciprocalMarker :=
+  [ ozSuffix, { form := egymas.form, strategy := .recipPronoun } ]
 
 end Hungarian.Reciprocals

--- a/Linglib/Fragments/Icelandic/Reciprocals.lean
+++ b/Linglib/Fragments/Icelandic/Reciprocals.lean
@@ -1,29 +1,30 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Icelandic Reciprocal Fragment
 [nordlinger-2023]
 
-Icelandic uses a bipartite NP strategy: "hvor...annad" ('each...other'),
-where each part independently inflects for case. The first element "hvor"
-takes nominative (subject case), while "annad" takes the case assigned by
-the verb.
+Icelandic uses a bipartite NP strategy: "hvort annað" ('each other',
+neuter forms as in [nordlinger-2023] ex. 17a), where each part
+independently inflects for case — the quantifier agrees with the
+antecedent while the *annað* part takes the case assigned by its
+argument position ([hurst-nordlinger-2021]).
 
 This is a bivalent strategy: the bipartite NP fills the object position,
 preserving transitivity. Formally distinct from the reflexive "sig".
 
-[nordlinger-2023] ex. 17 (citing Hurst & Nordlinger 2021).
+[nordlinger-2023] ex. 17 (citing [hurst-nordlinger-2021]).
 -/
 
 namespace Icelandic.Reciprocals
 
-open Pronoun
+open Pronoun Reciprocal
 
-/-- hvor...annad — bipartite reciprocal NP 'each other'.
-
-    Each part inflects independently for case.  -/
-def hvorAnnad : PersonalPronoun :=
-  { form := "hvor...annad", person := some .third, number := some .plural }
+/-- hvort annað — bipartite reciprocal NP 'each other' (neuter citation
+    forms; both parts inflect independently for case and gender). -/
+def hvorAnnad : ReciprocalMarker :=
+  { form := "hvort annað", strategy := .bipartiteNP }
 
 /-- sig — reflexive pronoun (for contrast). -/
 def sig : PersonalPronoun :=
@@ -32,5 +33,8 @@ def sig : PersonalPronoun :=
 /-- Icelandic reciprocal is formally distinct from reflexive. -/
 theorem recip_distinct_from_reflexive :
     hvorAnnad.form ≠ sig.form := by decide
+
+/-- Marker inventory. -/
+def markers : List ReciprocalMarker := [hvorAnnad]
 
 end Icelandic.Reciprocals

--- a/Linglib/Fragments/Mandarin/Reciprocals.lean
+++ b/Linglib/Fragments/Mandarin/Reciprocals.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Morphology.Word
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Mandarin Reciprocal Fragment
@@ -44,5 +45,17 @@ def ziji : Word :=
 /-- Compound reciprocal form is distinct from reflexive. -/
 theorem recip_distinct_from_reflexive :
     daLaiDaQu.toForm ≠ ziji.form := by decide
+
+open Reciprocal
+
+/-- The V-lái-V-qù compound as a reciprocal marker (form derived from
+    `daLaiDaQu`). The adverbial *hùxiāng* is outside the strategy
+    vocabulary ([evans-2008]'s adverbial strategy). -/
+def compound : ReciprocalMarker :=
+  { form := daLaiDaQu.toForm, script := daLaiDaQu.script
+  , strategy := .compoundVerb }
+
+/-- Marker inventory. -/
+def markers : List ReciprocalMarker := [compound]
 
 end Mandarin.Reciprocals

--- a/Linglib/Fragments/Slavic/Czech/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Czech/Reciprocals.lean
@@ -1,28 +1,39 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Czech Reciprocal Fragment
-[nordlinger-2023] [siloni-2008]
+[nordlinger-2023] [siloni-2008] [siloni-2012]
 
-Czech uses the reflexive clitic "se" for reciprocal meaning (monovalent,
-identical to reflexive). Syntactically formed per [siloni-2008]:
-CANNOT form discontinuous reciprocals.
+Czech uses the reflexive clitic "se" for reciprocal meaning (monovalent),
+syntactically formed per [siloni-2008]/[siloni-2012]: it cannot form
+discontinuous reciprocals ([nordlinger-2023] ex. 29, p. 86).
 
-[nordlinger-2023] ex. 29.
-
-Czech is not in the WALS Ch 106 sample, but "se" is shared between
-reflexive and reciprocal uses, consistent with "identical to reflexive."
+Alongside "se", Czech has the periphrastic bipartite "jeden druhého"
+('one the-other'), attested in [siloni-2012]'s Czech examples (comparative
+ellipsis, depictives) — so the reciprocal-reflexive relation is the WALS
+"mixed" configuration (WALS Ch 106 itself has no Czech row).
 -/
 
 namespace Czech.Reciprocals
 
-open Pronoun
+open Reciprocal
 
-/-- se — reflexive/reciprocal clitic. -/
-def se : PersonalPronoun :=
-  { form := "se", person := some .third }
+/-- se — reflexive/reciprocal clitic ([nordlinger-2023] ex. 29). -/
+def se : ReciprocalMarker :=
+  { form := "se", strategy := .recipClitic
+  , readings := [.reciprocal, .reflexive] }
 
-/-- The same form serves both reciprocal and reflexive functions. -/
-def isIdenticalToReflexive : Bool := true
+/-- jeden druhého — bipartite periphrastic reciprocal 'one the-other'
+    ([siloni-2012]'s Czech examples). -/
+def jedenDruheho : ReciprocalMarker :=
+  { form := "jeden druhého", strategy := .bipartiteNP }
+
+/-- The periphrastic reciprocal is distinct from the clitic. -/
+theorem bipartite_distinct_from_clitic :
+    jedenDruheho.form ≠ se.form := by decide
+
+/-- Marker inventory, primary strategy first. -/
+def markers : List ReciprocalMarker := [se, jedenDruheho]
 
 end Czech.Reciprocals

--- a/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
@@ -1,26 +1,36 @@
 import Linglib.Syntax.Pronoun.Basic
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Russian Reciprocal Fragment
 [nordlinger-2023] [konig-kokutani-2006]
 
-Russian uses a dedicated reciprocal pronoun "drug druga" (друг друга,
-literally 'friend of friend'). This is an NP/argument strategy (bivalent):
-it occupies the object position and preserves transitivity. It is formally
-distinct from the reflexive "sebja" (себя).
+Russian uses the bipartite NP "drug druga" (друг друга, 'other other-ACC'),
+grouped with English *each other* as the bipartite quantifier strategy in
+[nordlinger-2023] §3.1 (ex. 9). It occupies the object position and
+preserves transitivity, and is formally distinct from the reflexive
+"sebja" (себя). The first element "drug" stays uninflected (nominative)
+while "druga" takes the case assigned by the verb.
 
-The first element "drug" agrees in case with the subject, while "druga"
-takes the case assigned by the verb.
+The verbal postfix "-sja" (-ся) additionally carries reflexive-identical
+reciprocal uses (monovalent; [nordlinger-2023] ex. 31).
 -/
 
 namespace Russian.Reciprocals
 
-open Pronoun
+open Pronoun Reciprocal
 
-/-- друг друга *drug druga* — reciprocal pronoun 'each other'. -/
-def drugDruga : PersonalPronoun :=
+/-- друг друга *drug druga* — bipartite reciprocal 'other other-ACC'
+    ([nordlinger-2023] ex. 9). -/
+def drugDruga : ReciprocalMarker :=
   { form := "drug druga", script := some "друг друга"
-  , person := some .third, number := some .plural }
+  , strategy := .bipartiteNP }
+
+/-- -ся *-sja* — verbal postfix, reflexive-identical reciprocal uses
+    ([nordlinger-2023] ex. 31). -/
+def sja : ReciprocalMarker :=
+  { form := "-sja", script := some "-ся", strategy := .verbalAffix
+  , readings := [.reciprocal, .reflexive] }
 
 /-- себя *sebja* — reflexive pronoun (for contrast). -/
 def sebja : PersonalPronoun :=
@@ -30,5 +40,8 @@ def sebja : PersonalPronoun :=
 /-- Russian reciprocal is formally distinct from reflexive. -/
 theorem recip_distinct_from_reflexive :
     drugDruga.form ≠ sebja.form := by decide
+
+/-- Marker inventory, primary strategy first. -/
+def markers : List ReciprocalMarker := [drugDruga, sja]
 
 end Russian.Reciprocals

--- a/Linglib/Fragments/Swahili/Reciprocals.lean
+++ b/Linglib/Fragments/Swahili/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.MorphRule
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Swahili Reciprocal Fragment
@@ -47,5 +48,15 @@ theorem recip_distinct_from_reflexive :
 theorem both_valence_changing :
     reciprocalAffix.category = .valence ∧
     reflexivePrefix.category = .valence := ⟨rfl, rfl⟩
+
+open Reciprocal
+
+/-- The reciprocal suffix as a typological marker (distinct from the
+    reflexive *-ji-*). -/
+def anSuffix : ReciprocalMarker :=
+  { form := "-an-", strategy := .verbalAffix }
+
+/-- Marker inventory. -/
+def markers : List ReciprocalMarker := [anSuffix]
 
 end Swahili.Reciprocals

--- a/Linglib/Fragments/Wambaya/Reciprocals.lean
+++ b/Linglib/Fragments/Wambaya/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Syntax.Reciprocal
 import Linglib.Morphology.Word
 
 /-!
@@ -26,7 +27,16 @@ namespace Wambaya.Reciprocals
 def rrMorpheme : Word :=
   { form :="-ngg-", cat := .PART, features := {}}
 
-/-- The same morpheme serves both reciprocal and reflexive functions. -/
-def isIdenticalToReflexive : Bool := true
+open Reciprocal in
+/-- The RR clitic as a typological marker: it serves both reciprocal and
+    reflexive functions (WALS "identical to reflexive" follows by
+    `Reciprocal.ofInventory`; form derived from `rrMorpheme`). -/
+def rr : ReciprocalMarker :=
+  { form := rrMorpheme.form, strategy := .recipClitic
+  , readings := [.reciprocal, .reflexive] }
+
+open Reciprocal in
+/-- Marker inventory. -/
+def markers : List ReciprocalMarker := [rr]
 
 end Wambaya.Reciprocals

--- a/Linglib/Semantics/Plurality/Reciprocal.lean
+++ b/Linglib/Semantics/Plurality/Reciprocal.lean
@@ -236,4 +236,301 @@ theorem weakReciprocity_imp_cumulative
     obtain ⟨x, hx, hRxy, _⟩ := hWR.2 y hy
     exact ⟨x, hx, hRxy⟩
 
+/-! ### Configurational typology
+
+The event-configuration typology of [evans-et-al-2011b] and
+[majid-et-al-2011]: six shapes of mutual relation (strong, pairwise,
+chain, radial, melee, ring) used in the video-stimulus elicitation
+studies. Each is rendered as an exact-extension condition on `(R, X)` —
+the relation coincides with the named configuration — so symmetry and
+participant-exhaustiveness are theorems rather than stipulations, and
+the shapes plug into the entailment lattice above: pairwise strengthens
+to `PartitionedStrongReciprocity`, ring yields `OneWayWeakReciprocity`,
+chain and radial yield `InclusiveAlternativeOrdering`, and melee is
+definitionally the failure of `InclusiveAlternativeOrdering` (some
+activity, but not everyone participates). The strong configuration is
+`StrongReciprocity` itself. -/
+
+/-- `y` immediately follows `x` in `l`. -/
+def Consecutive (l : List A) (x y : A) : Prop := (x, y) ∈ l.zip l.tail
+
+private lemma consecutive_cons {a : A} {l : List A} {x y : A}
+    (h : Consecutive l x y) : Consecutive (a :: l) x y := by
+  cases l with
+  | nil => simp [Consecutive] at h
+  | cons b t => exact List.mem_cons_of_mem _ h
+
+private lemma consecutive_mem {l : List A} {x y : A} (h : Consecutive l x y) :
+    x ∈ l ∧ y ∈ l :=
+  ⟨(List.of_mem_zip h).1, List.mem_of_mem_tail (List.of_mem_zip h).2⟩
+
+private lemma consecutive_ne {l : List A} (hnd : l.Nodup) {x y : A}
+    (h : Consecutive l x y) : x ≠ y := by
+  induction l with
+  | nil => simp [Consecutive] at h
+  | cons a t ih =>
+    cases t with
+    | nil => simp [Consecutive] at h
+    | cons b t' =>
+      have h' : (x, y) = (a, b) ∨ Consecutive (b :: t') x y := by
+        simpa [Consecutive] using h
+      rcases h' with heq | h'
+      · obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
+        intro hab
+        apply (List.nodup_cons.mp hnd).1
+        rw [hab]
+        exact List.mem_cons_self ..
+      · exact ih (List.nodup_cons.mp hnd).2 h'
+
+private lemma consecutive_asymm {l : List A} (hnd : l.Nodup) {x y : A}
+    (hxy : Consecutive l x y) : ¬ Consecutive l y x := by
+  induction l with
+  | nil => simp [Consecutive] at hxy
+  | cons a t ih =>
+    cases t with
+    | nil => simp [Consecutive] at hxy
+    | cons b t' =>
+      intro hyx
+      have hxy' : (x, y) = (a, b) ∨ Consecutive (b :: t') x y := by
+        simpa [Consecutive] using hxy
+      have hyx' : (y, x) = (a, b) ∨ Consecutive (b :: t') y x := by
+        simpa [Consecutive] using hyx
+      rcases hxy' with heq | hxy'
+      · obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
+        rcases hyx' with heq' | hyx'
+        · obtain ⟨h1, -⟩ := Prod.mk.inj heq'
+          apply (List.nodup_cons.mp hnd).1
+          rw [← h1]
+          exact List.mem_cons_self ..
+        · exact (List.nodup_cons.mp hnd).1 (consecutive_mem hyx').2
+      · rcases hyx' with heq' | hyx'
+        · obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq'
+          exact (List.nodup_cons.mp hnd).1 (consecutive_mem hxy').2
+        · exact ih (List.nodup_cons.mp hnd).2 hxy' hyx'
+
+private lemma getLast?_mem : ∀ {l : List A} {x : A}, l.getLast? = some x → x ∈ l
+  | [], _, h => by simp at h
+  | [a], x, h => by
+    obtain rfl : a = x := by simpa using h
+    simp
+  | _ :: b :: t, x, h => by
+    rw [List.getLast?_cons_cons] at h
+    exact List.mem_cons_of_mem _ (getLast?_mem h)
+
+private lemma mem_consecutive_or_getLast {l : List A} {x : A} (hx : x ∈ l) :
+    (∃ y, Consecutive l x y) ∨ l.getLast? = some x := by
+  induction l with
+  | nil => cases hx
+  | cons a t ih =>
+    cases t with
+    | nil =>
+      right
+      obtain rfl := List.mem_singleton.mp hx
+      simp
+    | cons b t' =>
+      rcases List.mem_cons.mp hx with rfl | hx'
+      · exact Or.inl ⟨b, by simp [Consecutive]⟩
+      · rcases ih hx' with ⟨y, hy⟩ | hlast
+        · exact Or.inl ⟨y, consecutive_cons hy⟩
+        · right; rw [List.getLast?_cons_cons]; exact hlast
+
+private lemma getLast?_consecutive : ∀ {l : List A}, 2 ≤ l.length →
+    ∀ {x : A}, l.getLast? = some x → ∃ y, Consecutive l y x
+  | [], hlen, _, _ => by simp at hlen
+  | [_], hlen, _, _ => by simp at hlen
+  | [a, b], _, x, hx => by
+    obtain rfl : b = x := by simpa using hx
+    exact ⟨a, by simp [Consecutive]⟩
+  | a :: b :: c :: t, _, x, hx => by
+    rw [List.getLast?_cons_cons] at hx
+    obtain ⟨y, hy⟩ :=
+      getLast?_consecutive (by simp only [List.length_cons]; omega) hx
+    exact ⟨y, consecutive_cons hy⟩
+
+/-- `R` is symmetric within `X`: every realized pair is mutual. -/
+def PairSymmetricOn (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∀ x ∈ X, ∀ y ∈ X, R x y → R y x
+
+/-- **Pairwise configuration** ([majid-et-al-2011]): the participants
+    split into two-member cells, and `R` holds exactly within cells
+    ("The people at the dinner party were married to one another"). -/
+def PairwiseConfig (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ P : Finset (Finset A),
+    (∀ c ∈ P, c.card = 2 ∧ c ⊆ X) ∧
+    (∀ a ∈ X, ∃ c ∈ P, a ∈ c) ∧
+    (∀ x y, R x y ↔ ∃ c ∈ P, x ∈ c ∧ y ∈ c ∧ x ≠ y)
+
+/-- **Chain configuration** ([majid-et-al-2011]): the participants form
+    a line and `R` holds exactly between adjacent members, directed
+    ("The graduating students followed one another up onto the stage"). -/
+def ChainConfig (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ l : List A, l.Nodup ∧ (∀ z, z ∈ l ↔ z ∈ X) ∧ 2 ≤ l.length ∧
+    ∀ x y, R x y ↔ Consecutive l x y
+
+/-- **Ring configuration** ([majid-et-al-2011]): a chain whose last
+    member acts on the first ("The children chased each other round in
+    a ring"). -/
+def RingConfig (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ l : List A, l.Nodup ∧ (∀ z, z ∈ l ↔ z ∈ X) ∧ 3 ≤ l.length ∧
+    ∀ x y, R x y ↔
+      (Consecutive l x y ∨ (l.getLast? = some x ∧ l.head? = some y))
+
+/-- **Radial configuration** ([majid-et-al-2011]): one central
+    participant acts (asymmetrically) on each of the others ("The
+    teacher and her pupils intimidated one another"). -/
+def RadialConfig (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ c ∈ X, 2 ≤ X.card ∧ ∀ x y, R x y ↔ (x = c ∧ y ∈ X ∧ y ≠ c)
+
+/-- **Melee configuration** ([majid-et-al-2011]): multiple asymmetrical
+    interactions without full saturation ("The drunks in the pub were
+    punching one another") — some activity, but participation fails to
+    be exhaustive, i.e. even `InclusiveAlternativeOrdering` (the weakest
+    scheme in the lattice above) fails. -/
+def MeleeConfig (R : A → A → Prop) (X : Finset A) : Prop :=
+  (∃ x ∈ X, ∃ y ∈ X, x ≠ y ∧ R x y) ∧ ¬ InclusiveAlternativeOrdering R X
+
+/-! #### Symmetry theorems -/
+
+/-- Strong reciprocity is symmetric on its plurality. -/
+theorem StrongReciprocity.pairSymmetricOn {R : A → A → Prop} {X : Finset A}
+    (h : StrongReciprocity R X) : PairSymmetricOn R X := by
+  intro x hx y hy hR
+  by_cases hxy : x = y
+  · exact hxy ▸ hR
+  · exact h y hy x hx hxy
+
+/-- The pairwise configuration is symmetric: partners are mutual. -/
+theorem PairwiseConfig.pairSymmetricOn {R : A → A → Prop} {X : Finset A}
+    (h : PairwiseConfig R X) : PairSymmetricOn R X := by
+  obtain ⟨P, -, -, hiff⟩ := h
+  intro x _ y _ hR
+  obtain ⟨c, hc, hxc, hyc, hne⟩ := (hiff x y).mp hR
+  exact (hiff y x).mpr ⟨c, hc, hyc, hxc, hne.symm⟩
+
+/-- The chain configuration is not symmetric: followers are not
+    followed back ([majid-et-al-2011]'s directed line). -/
+theorem ChainConfig.not_pairSymmetricOn {R : A → A → Prop} {X : Finset A}
+    (h : ChainConfig R X) : ¬ PairSymmetricOn R X := by
+  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
+  obtain - | ⟨a, - | ⟨b, t⟩⟩ := l
+  · simp at hlen
+  · simp at hlen
+  · intro hsym
+    have hcons : Consecutive (a :: b :: t) a b := by simp [Consecutive]
+    have haX : a ∈ X := (hmem a).mp (consecutive_mem hcons).1
+    have hbX : b ∈ X := (hmem b).mp (consecutive_mem hcons).2
+    exact consecutive_asymm hnd hcons
+      ((hiff b a).mp (hsym a haX b hbX ((hiff a b).mpr hcons)))
+
+/-- The ring configuration is not symmetric (for genuine rings of three
+    or more): the cycle is directed. -/
+theorem RingConfig.not_pairSymmetricOn {R : A → A → Prop} {X : Finset A}
+    (h : RingConfig R X) : ¬ PairSymmetricOn R X := by
+  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
+  obtain - | ⟨a, - | ⟨b, - | ⟨c, t⟩⟩⟩ := l
+  · simp at hlen
+  · simp at hlen
+  · simp at hlen
+  · intro hsym
+    have hcons : Consecutive (a :: b :: c :: t) a b := by simp [Consecutive]
+    have haX : a ∈ X := (hmem a).mp (consecutive_mem hcons).1
+    have hbX : b ∈ X := (hmem b).mp (consecutive_mem hcons).2
+    rcases (hiff b a).mp
+        (hsym a haX b hbX ((hiff a b).mpr (Or.inl hcons))) with hba | ⟨hlast, -⟩
+    · exact consecutive_asymm hnd hcons hba
+    · rw [List.getLast?_cons_cons, List.getLast?_cons_cons] at hlast
+      exact (List.nodup_cons.mp (List.nodup_cons.mp hnd).2).1
+        (getLast?_mem hlast)
+
+/-- The radial configuration is not symmetric: the center acts on the
+    periphery, never conversely ([majid-et-al-2011]). -/
+theorem RadialConfig.not_pairSymmetricOn [DecidableEq A]
+    {R : A → A → Prop} {X : Finset A}
+    (h : RadialConfig R X) : ¬ PairSymmetricOn R X := by
+  obtain ⟨c, hc, hcard, hiff⟩ := h
+  obtain ⟨y, hy, hyc⟩ := X.exists_mem_ne hcard c
+  intro hsym
+  exact hyc ((hiff y c).mp
+    (hsym c hc y hy ((hiff c y).mpr ⟨rfl, hy, hyc⟩))).1
+
+/-! #### Exhaustiveness theorems
+
+Participant-exhaustiveness is `InclusiveAlternativeOrdering` — the
+weakest scheme in the lattice. Every configuration except melee entails
+it (the strong configuration via `strong_imp_inclusiveAlternative`);
+melee denies it by definition. -/
+
+/-- Everyone at a pairwise event has a partner. -/
+theorem PairwiseConfig.inclusiveAlternativeOrdering [DecidableEq A]
+    {R : A → A → Prop} {X : Finset A}
+    (h : PairwiseConfig R X) : InclusiveAlternativeOrdering R X := by
+  obtain ⟨P, hcells, hcover, hiff⟩ := h
+  intro x hx
+  obtain ⟨c, hc, hxc⟩ := hcover x hx
+  have h2 : c.card = 2 := (hcells c hc).1
+  obtain ⟨y, hyc, hyx⟩ := c.exists_mem_ne (by omega) x
+  exact ⟨y, (hcells c hc).2 hyc, hyx.symm,
+    Or.inl ((hiff x y).mpr ⟨c, hc, hxc, hyc, hyx.symm⟩)⟩
+
+/-- Everyone in a chain follows or is followed. -/
+theorem ChainConfig.inclusiveAlternativeOrdering
+    {R : A → A → Prop} {X : Finset A}
+    (h : ChainConfig R X) : InclusiveAlternativeOrdering R X := by
+  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
+  intro x hx
+  rcases mem_consecutive_or_getLast ((hmem x).mpr hx) with ⟨y, hy⟩ | hlast
+  · exact ⟨y, (hmem y).mp (consecutive_mem hy).2,
+      consecutive_ne hnd hy, Or.inl ((hiff x y).mpr hy)⟩
+  · obtain ⟨y, hy⟩ := getLast?_consecutive hlen hlast
+    exact ⟨y, (hmem y).mp (consecutive_mem hy).1,
+      (consecutive_ne hnd hy).symm, Or.inr ((hiff y x).mpr hy)⟩
+
+/-- Everyone in a ring chases someone: the ring configuration yields
+    `OneWayWeakReciprocity` (which a chain does not — its last member
+    acts on nobody). -/
+theorem RingConfig.oneWayWeak {R : A → A → Prop} {X : Finset A}
+    (h : RingConfig R X) : OneWayWeakReciprocity R X := by
+  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
+  intro x hx
+  rcases mem_consecutive_or_getLast ((hmem x).mpr hx) with ⟨y, hy⟩ | hlast
+  · exact ⟨y, (hmem y).mp (consecutive_mem hy).2,
+      (hiff x y).mpr (Or.inl hy), consecutive_ne hnd hy⟩
+  · obtain - | ⟨a, t⟩ := l
+    · simp at hlen
+    · refine ⟨a, (hmem a).mp (List.mem_cons_self ..),
+        (hiff x a).mpr (Or.inr ⟨hlast, rfl⟩), fun hxa => ?_⟩
+      obtain - | ⟨b, t'⟩ := t
+      · simp at hlen
+      · rw [hxa, List.getLast?_cons_cons] at hlast
+        exact (List.nodup_cons.mp hnd).1 (getLast?_mem hlast)
+
+/-- The ring configuration participates everyone. -/
+theorem RingConfig.inclusiveAlternativeOrdering
+    {R : A → A → Prop} {X : Finset A}
+    (h : RingConfig R X) : InclusiveAlternativeOrdering R X :=
+  oneWay_imp_inclusiveAlternative R X h.oneWayWeak
+
+/-- Radial events participate everyone: the center acts on each
+    peripheral member. -/
+theorem RadialConfig.inclusiveAlternativeOrdering [DecidableEq A]
+    {R : A → A → Prop} {X : Finset A}
+    (h : RadialConfig R X) : InclusiveAlternativeOrdering R X := by
+  obtain ⟨c, hc, hcard, hiff⟩ := h
+  intro x hx
+  by_cases hxc : x = c
+  · subst hxc
+    obtain ⟨y, hy, hyx⟩ := X.exists_mem_ne hcard x
+    exact ⟨y, hy, hyx.symm, Or.inl ((hiff x y).mpr ⟨rfl, hy, hyx⟩)⟩
+  · exact ⟨c, hc, hxc, Or.inr ((hiff c x).mpr ⟨rfl, hx, hxc⟩)⟩
+
+/-! #### Lattice connections -/
+
+/-- The pairwise configuration realizes Partitioned Strong Reciprocity:
+    the pairing is the partition witness. -/
+theorem PairwiseConfig.partitionedStrong {R : A → A → Prop} {X : Finset A}
+    (h : PairwiseConfig R X) : PartitionedStrongReciprocity R X := by
+  obtain ⟨P, hcells, hcover, hiff⟩ := h
+  exact ⟨P, fun Y hY => (hcells Y hY).2, hcover,
+    fun Y hY x hx y hy hne => (hiff x y).mpr ⟨Y, hY, hx, hy, hne.symm⟩⟩
+
 end Semantics.Plurality.Reciprocal

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -172,11 +172,12 @@ def rpMandarin : RecipProfile :=
 
 /-- Wambaya: reciprocal clitic *-ngg-* (RR morpheme in the auxiliary),
     identical to reflexive. [nordlinger-2023] ex. 11 (citing
-    [nordlinger-1998], p. 142).
-    -- UNVERIFIED: coded bivalent following the file's original claim
-    that the RR clause retains transitive structure; ex. 11 glosses the
-    subject as NOM, so this needs checking against [nordlinger-1998] or
-    [evans-et-al-2007]. -/
+    [nordlinger-1998], p. 142). Coded bivalent because nominal subjects
+    retain ergative marking under reciprocalization
+    ([evans-et-al-2007]: transitivity is compromised but argument
+    structure undisturbed); the NOM subject in ex. 11 is a free
+    pronoun, which declines nominative/accusative regardless of
+    transitivity ([nordlinger-1998]). -/
 def rpWambaya : RecipProfile :=
   { language := "Wambaya", iso := "wmb"
   , primaryStrategy := .recipClitic
@@ -343,16 +344,17 @@ def ReciprocityType.exhaustive : ReciprocityType → Bool
   | .ring     => true
 
 /-- Whether a reciprocity type is symmetric: within each active pair,
-    if A acts on B then B acts on A. Chain and ring are directional
-    (A follows B does not entail B follows A). Radial IS symmetric —
-    the teacher intimidates each pupil AND each pupil intimidates the
-    teacher — it just doesn't cover all pairs. -/
+    if A acts on B then B acts on A. Only strong and pairwise are:
+    chain and ring are directional (A follows B does not entail B
+    follows A), and [majid-et-al-2011] define radial as one participant
+    acting *asymmetrically* with multiple others and melee as multiple
+    *asymmetrical* interactions without full saturation. -/
 def ReciprocityType.symmetric : ReciprocityType → Bool
   | .strong   => true
   | .pairwise => true
   | .chain    => false
-  | .radial   => true
-  | .melee    => true
+  | .radial   => false
+  | .melee    => false
   | .ring     => false
 
 /-- The six reciprocity types English *each other* can express

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -1,9 +1,21 @@
 import Linglib.Syntax.Reciprocal
 import Linglib.Studies.Siloni2012
 import Linglib.Data.WALS.Features.F106A
+import Linglib.Semantics.Plurality.Reciprocal
 import Linglib.Fragments.English.Pronouns
-import Linglib.Syntax.Binding.Basic
+import Linglib.Fragments.English.Reciprocals
+import Linglib.Fragments.Chichewa.Reciprocals
+import Linglib.Fragments.French.Reciprocals
+import Linglib.Fragments.German.Reciprocals
+import Linglib.Fragments.Greek.StandardModern.Reciprocals
+import Linglib.Fragments.Hungarian.Reciprocals
+import Linglib.Fragments.Icelandic.Reciprocals
+import Linglib.Fragments.Mandarin.Reciprocals
+import Linglib.Fragments.Slavic.Czech.Reciprocals
+import Linglib.Fragments.Slavic.Russian.Reciprocals
 import Linglib.Fragments.Swahili.Reciprocals
+import Linglib.Fragments.Wambaya.Reciprocals
+import Linglib.Syntax.Binding.Basic
 
 /-!
 # Nordlinger (2023) [nordlinger-2023]
@@ -17,19 +29,25 @@ constructions, which summarizes earlier classificatory work
 and organizes the empirical picture around strategy/valency correlations
 (§3.2) and Siloni's discontinuity asymmetry (§3.3).
 
-The underlying primitives (`RecipStrategy`, `RecipValency`,
+The underlying primitives (`ReciprocalMarker`, `RecipStrategy`, `RecipValency`,
 `RecipFormation`, `ReciprocalType`) live in `Syntax/Reciprocal.lean`,
 anchored on the earlier sources the review synthesizes — which preserves
-chronological dependency for `Studies/Siloni2012.lean`.
+chronological dependency for `Studies/Siloni2012.lean`. Each profile below
+records a marker *inventory*; the primary strategy and the WALS Ch 106
+reflexive-relation value are derived from it, and the WALS theorems check
+the derived values against the external WALS rows.
 
 ## Contents
 
-- `RecipProfile` per-language extended reciprocal profiles (12 languages)
-- Strategy-valency correlation theorems (§3.2)
+- `RecipProfile` per-language profiles (12 languages): marker inventory +
+  observed valency, formation, and discontinuity judgments
+- Strategy-valency correlation theorems (§3.2), including the derived
+  default-valency check against `RecipStrategy.defaultValency`
 - Siloni's discontinuity prediction checked against attested judgments (§3.3)
-- WALS Ch 106 grounding for `RecipProfile` (via `lookupISO`)
-- `ReciprocityType` semantic 6-way classification (§4)
-- `RecipMarkerPolysemy` extended readings (§4.2)
+- WALS Ch 106 grounding for the *derived* reflexive relation (via `lookupISO`)
+- `ReciprocityType` semantic 6-way classification (§4), realized as the
+  relation shapes of `Semantics.Plurality.Reciprocal`
+- Polysemous markers beyond the profile sample (§4.2)
 - Fragment grounding for English reciprocals
 -/
 
@@ -37,22 +55,27 @@ namespace Nordlinger2023
 
 open Reciprocal
 
+/-- Convert a WALS 106A value to `ReciprocalType` (study-local: WALS
+    grounding is this study's business, not the substrate's). -/
+def ofWALS106A : Data.WALS.F106A.ReciprocalType → ReciprocalType
+  | .noReciprocalConstruction => .noDedicated
+  | .distinctFromReflexive    => .distinctFromReflexive
+  | .mixed                    => .mixed
+  | .identicalToReflexive     => .identicalToReflexive
+
 /-! ### Reciprocal profiles -/
 
-/-- Extended reciprocal profile for a single language.
-
-    Captures the morphosyntactic strategy, valency effect, formation
-    locus, and attested discontinuity judgments from [nordlinger-2023]'s
-    review, going beyond the WALS 4-way reflexive-reciprocal
-    classification. -/
+/-- Per-language reciprocal profile: the marker inventory (primary strategy
+    first) plus the observed valency, formation locus, and discontinuity
+    judgments from [nordlinger-2023]'s review. The primary strategy and the
+    WALS Ch 106 reflexive relation are *derived* from the inventory. -/
 structure RecipProfile where
   language : String
   iso : String
-  /-- Primary reciprocal strategy ([nordlinger-2023] §3.1 inventory) -/
-  primaryStrategy : RecipStrategy
-  /-- Secondary strategy, if the language uses a second, different one -/
-  secondaryStrategy : Option RecipStrategy := none
-  /-- Valency effect of the primary strategy -/
+  /-- Marker inventory (primary strategy first), sourced from the
+      language's `Fragments/{Lang}/Reciprocals.lean`. -/
+  markers : List ReciprocalMarker
+  /-- Observed valency of the primary construction -/
   valency : RecipValency
   /-- Formation locus of verb-marked reciprocals ([siloni-2012]) -/
   formation : Option RecipFormation := none
@@ -60,36 +83,38 @@ structure RecipProfile where
       ([nordlinger-2023] §3.3 judgments), independent of `formation` so
       Siloni's prediction can be checked rather than stipulated -/
   discontinuousAttested : Option Bool := none
-  /-- Reciprocal-reflexive relationship (WALS Ch 106) -/
-  reflexiveRelation : ReciprocalType
   deriving Repr, DecidableEq
+
+/-- Primary strategy: the strategy of the inventory's first marker. -/
+def RecipProfile.primaryStrategy (p : RecipProfile) : Option RecipStrategy :=
+  p.markers.head?.map (·.strategy)
+
+/-- WALS Ch 106 reflexive relation, derived from the marker inventory. -/
+def RecipProfile.reflexiveRelation (p : RecipProfile) : ReciprocalType :=
+  ofInventory p.markers
 
 -- Language data: 12 reciprocal profiles from [nordlinger-2023]
 
 /-- English: bipartite NP *each other* (bivalent, distinct from reflexive;
-    [nordlinger-2023] ex. 1b). Lexical reciprocals (*quarrel*, *meet*,
-    ex. 7) are a secondary strategy; per [siloni-2012] these are
-    lexicon-formed, but *kiss*/*hug* resist the discontinuous
-    construction (fn. 32), so no formation-level discontinuity value is
-    recorded. Expresses all six reciprocity types (ex. 44). -/
+    [nordlinger-2023] ex. 1b) plus lexical reciprocals (*quarrel*, *meet*,
+    ex. 7). Per [siloni-2012] the lexical class is lexicon-formed, but
+    *kiss*/*hug* resist the discontinuous construction (fn. 32), so no
+    formation-level discontinuity value is recorded. Expresses all six
+    reciprocity types (ex. 44). -/
 def rpEnglish : RecipProfile :=
   { language := "English", iso := "eng"
-  , primaryStrategy := .bipartiteNP
-  , secondaryStrategy := some .lexical
-  , valency := .bivalent
-  , reflexiveRelation := .distinctFromReflexive }
+  , markers := English.Reciprocals.markers
+  , valency := .bivalent }
 
 /-- Russian: bipartite NP *drug druga* 'other other-ACC'
     ([nordlinger-2023] ex. 9, grouped with English *each other* as the
     bipartite strategy) plus reflexive-identical verbal postfix *-sja*
     (monovalent; ex. 31). Unlike French *se* (a separable clitic),
-    *-sja* is a bound suffix, so the secondary strategy is `verbalAffix`. -/
+    *-sja* is a bound suffix. Derived WALS value: mixed. -/
 def rpRussian : RecipProfile :=
   { language := "Russian", iso := "rus"
-  , primaryStrategy := .bipartiteNP
-  , secondaryStrategy := some .verbalAffix
-  , valency := .bivalent
-  , reflexiveRelation := .mixed }
+  , markers := Russian.Reciprocals.markers
+  , valency := .bivalent }
 
 /-- Swahili: verbal affix *-an-* (monovalent, distinct from reflexive
     *-ji-*; [nordlinger-2023] ex. 12). Forms discontinuous reciprocals
@@ -99,11 +124,10 @@ def rpRussian : RecipProfile :=
     The morphological rule is `Swahili.Reciprocals.reciprocalAffix`. -/
 def rpSwahili : RecipProfile :=
   { language := "Swahili", iso := "swh"
-  , primaryStrategy := .verbalAffix
+  , markers := Swahili.Reciprocals.markers
   , valency := .monovalent
   , formation := some .lexical
-  , discontinuousAttested := some true
-  , reflexiveRelation := .distinctFromReflexive }
+  , discontinuousAttested := some true }
 
 /-- Hungarian: verbal affix *-óz-* (monovalent; [nordlinger-2023]
     ex. 19, 30, citing [siloni-2008]). Lexicon-formed per [siloni-2012]'s
@@ -111,11 +135,10 @@ def rpSwahili : RecipProfile :=
     *-val* (ex. 38, from [dimitriadis-2008]). -/
 def rpHungarian : RecipProfile :=
   { language := "Hungarian", iso := "hun"
-  , primaryStrategy := .verbalAffix
+  , markers := Hungarian.Reciprocals.markers
   , valency := .monovalent
   , formation := some .lexical
-  , discontinuousAttested := some true
-  , reflexiveRelation := .distinctFromReflexive }
+  , discontinuousAttested := some true }
 
 /-- French: reciprocal clitic *se* (monovalent, reflexive-identical;
     [nordlinger-2023] ex. 28, 47) plus distinct bipartite *l'un l'autre*.
@@ -125,39 +148,36 @@ def rpHungarian : RecipProfile :=
     ungrammatical (ex. 39). -/
 def rpFrench : RecipProfile :=
   { language := "French", iso := "fra"
-  , primaryStrategy := .recipClitic
-  , secondaryStrategy := some .bipartiteNP
+  , markers := French.Reciprocals.markers
   , valency := .monovalent
   , formation := some .syntactic
-  , discontinuousAttested := some false
-  , reflexiveRelation := .mixed }
+  , discontinuousAttested := some false }
 
 /-- Greek (Modern): nonactive voice morphology (monovalent, reflexive-
-    identical in form) plus distinct constructions. Forms discontinuous
+    identical in form) plus a distinct periphrastic reciprocal (*o enas
+    ton allon* — its existence is implied by the WALS `mixed`
+    classification, [maslova-nedjalkov-2013]). Forms discontinuous
     reciprocals with *me* 'with': "O Giannis filithike me ti Maria"
     ([nordlinger-2023] ex. 27b, 36, from [dimitriadis-2008]) — hence
     lexicon-formed under Siloni's typology as presented in §3.3
     ([siloni-2012] itself does not discuss Greek). -/
 def rpGreek : RecipProfile :=
   { language := "Modern Greek", iso := "ell"
-  , primaryStrategy := .verbalAffix
+  , markers := Greek.StandardModern.Reciprocals.markers
   , valency := .monovalent
   , formation := some .lexical
-  , discontinuousAttested := some true
-  , reflexiveRelation := .mixed }
+  , discontinuousAttested := some true }
 
 /-- German: dedicated reciprocal pronoun *einander* alongside reflexive
-    *sich* in reciprocal use — the WALS "mixed" configuration. Both
-    fill the object slot, preserving bivalent syntax. The enum has no
-    case for reflexive-pronouns-used-reciprocally, so only the dedicated
-    pronoun strategy is recorded. [siloni-2012] fn. 13 suggests German
+    *sich* in reciprocal use — the two markers' readings now encode the
+    WALS "mixed" configuration. Both fill the object slot, preserving
+    bivalent syntax. [siloni-2012] fn. 13 suggests German
     *sich*-reciprocals are syntactic reciprocal verbs; the review does
     not take this up, so no formation value is recorded. -/
 def rpGerman : RecipProfile :=
   { language := "German", iso := "deu"
-  , primaryStrategy := .recipPronoun
-  , valency := .bivalent
-  , reflexiveRelation := .mixed }
+  , markers := German.Reciprocals.markers
+  , valency := .bivalent }
 
 /-- Mandarin: compound verb strategy *dǎ-lái-dǎ-qù*
     (beat-come-beat-go = 'beat each other'), single subject NP.
@@ -166,23 +186,21 @@ def rpGerman : RecipProfile :=
     multiclausal strategy. -/
 def rpMandarin : RecipProfile :=
   { language := "Mandarin", iso := "cmn"
-  , primaryStrategy := .compoundVerb
-  , valency := .monovalent
-  , reflexiveRelation := .distinctFromReflexive }
+  , markers := Mandarin.Reciprocals.markers
+  , valency := .monovalent }
 
 /-- Wambaya: reciprocal clitic *-ngg-* (RR morpheme in the auxiliary),
     identical to reflexive. [nordlinger-2023] ex. 11 (citing
-    [nordlinger-1998], p. 142). Coded bivalent because nominal subjects
-    retain ergative marking under reciprocalization
-    ([evans-et-al-2007]: transitivity is compromised but argument
-    structure undisturbed); the NOM subject in ex. 11 is a free
-    pronoun, which declines nominative/accusative regardless of
-    transitivity ([nordlinger-1998]). -/
+    [nordlinger-1998], p. 142). Bivalent: nominal subjects retain
+    ergative marking under reciprocalization ([evans-et-al-2007]:
+    transitivity is compromised but argument structure undisturbed);
+    the NOM subject in ex. 11 is a free pronoun, which declines
+    nominative/accusative regardless of transitivity
+    ([nordlinger-1998]). -/
 def rpWambaya : RecipProfile :=
   { language := "Wambaya", iso := "wmb"
-  , primaryStrategy := .recipClitic
-  , valency := .bivalent
-  , reflexiveRelation := .identicalToReflexive }
+  , markers := Wambaya.Reciprocals.markers
+  , valency := .bivalent }
 
 /-- Icelandic: bipartite NP *hvort annað*, each part independently
     inflected for case (*annað* takes the argument-position case,
@@ -191,32 +209,29 @@ def rpWambaya : RecipProfile :=
     [nordlinger-2023] ex. 17 (citing [hurst-nordlinger-2021]). -/
 def rpIcelandic : RecipProfile :=
   { language := "Icelandic", iso := "isl"
-  , primaryStrategy := .bipartiteNP
-  , valency := .bivalent
-  , reflexiveRelation := .distinctFromReflexive }
+  , markers := Icelandic.Reciprocals.markers
+  , valency := .bivalent }
 
 /-- Chicheŵa: verbal affix *-an-* (monovalent).
     [nordlinger-2023] ex. 20 (citing [dalrymple-et-al-1994]). -/
 def rpChichewa : RecipProfile :=
   { language := "Chicheŵa", iso := "nya"
-  , primaryStrategy := .verbalAffix
-  , valency := .monovalent
-  , reflexiveRelation := .distinctFromReflexive }
+  , markers := Chichewa.Reciprocals.markers
+  , valency := .monovalent }
 
 /-- Czech: reciprocal clitic *se* (monovalent, reflexive-identical;
     [nordlinger-2023] ex. 29, citing [siloni-2008]), alongside the
     periphrastic *jeden druhého* 'each other' attested in
-    [siloni-2012]'s Czech examples — so under WALS Ch 106 criteria the
-    reflexive relation is `mixed` (WALS itself has no Czech row).
-    Syntax-formed; discontinuous reciprocals are unavailable
-    ([nordlinger-2023] p. 86, with French). -/
+    [siloni-2012]'s Czech examples — the derived WALS value is
+    therefore `mixed` (WALS itself has no Czech row). Syntax-formed;
+    discontinuous reciprocals are unavailable ([nordlinger-2023] p. 86,
+    with French). -/
 def rpCzech : RecipProfile :=
   { language := "Czech", iso := "ces"
-  , primaryStrategy := .recipClitic
+  , markers := Czech.Reciprocals.markers
   , valency := .monovalent
   , formation := some .syntactic
-  , discontinuousAttested := some false
-  , reflexiveRelation := .mixed }
+  , discontinuousAttested := some false }
 
 def allRecipProfiles : List RecipProfile :=
   [ rpEnglish, rpRussian, rpSwahili, rpHungarian, rpFrench
@@ -231,26 +246,36 @@ def allRecipProfiles : List RecipProfile :=
     morphological markers "reduce the valency of the underlying verb by
     deleting the direct or indirect object."
 
-    In this sample: all nominal-strategy profiles are bivalent. The
+    In this sample: all nominal-primary profiles are bivalent. The
     correlation is a tendency — outside the sample, Tonga combines
     verbal marking with two argument NPs ([maslova-2008]) and Malagasy
     verb-marked reciprocals stay bivalent at f-structure ([hurst-2012]). -/
 theorem nominal_strategy_bivalent :
-    (allRecipProfiles.filter fun p => p.primaryStrategy.isNominal).all
-      fun p => p.valency == .bivalent := by decide
+    (allRecipProfiles.filter fun p => p.primaryStrategy.any (·.isNominal)).all
+      (fun p => p.valency == .bivalent) := by decide
 
 /-- Verbal affixes (Swahili *-an-*, Hungarian *-óz-*, Greek nonactive,
     Chicheŵa *-an-*) are uniformly monovalent in this sample. -/
 theorem verbal_affix_monovalent :
-    (allRecipProfiles.filter fun p => p.primaryStrategy == .verbalAffix).all
-      fun p => p.valency == .monovalent := by decide
+    (allRecipProfiles.filter
+        fun p => p.primaryStrategy == some .verbalAffix).all
+      (fun p => p.valency == .monovalent) := by decide
 
 /-- Converse of `nominal_strategy_bivalent`: monovalent reciprocal
     strategies are never nominal (NP/argument) in this sample
     ([nedjalkov-2007a], p. 21; [nordlinger-2023] §3.2). -/
 theorem monovalent_implies_verbal :
     (allRecipProfiles.filter fun p => p.valency == .monovalent).all
-      fun p => !p.primaryStrategy.isNominal := by decide
+      (fun p => !p.primaryStrategy.any (·.isNominal)) := by decide
+
+/-- Observed valency follows the strategy's default — derived in the
+    substrate from `Alternation.reciprocalization`'s detransitivizing
+    coding-frame effect — throughout the sample, except Wambaya, whose
+    ergative-retaining RR clause stays bivalent ([evans-et-al-2007]). -/
+theorem valency_follows_default_except_wambaya :
+    allRecipProfiles.all fun p =>
+      p.primaryStrategy.any (fun s => p.valency == s.defaultValency) ||
+        p.iso == "wmb" := by decide
 
 /-! ### Siloni's discontinuity prediction (§3.3) -/
 
@@ -269,11 +294,13 @@ theorem siloni_discontinuity_prediction :
       | some f, some d => f.allowsDiscontinuous == d
       | _, _ => true := by decide
 
-/-! ### WALS grounding -/
+/-! ### WALS grounding
 
-/-- Reciprocal profiles agree with WALS Ch 106 data where available.
-    Lookups use ISO 639-3 codes via `Datapoint.lookupISO`, so the join
-    between profile and WALS row is structural (no string-coincidence). -/
+The reflexive-relation value is *derived* from each profile's marker
+inventory (`ofInventory`), so these theorems check a computed value
+against the external WALS row — inventory facts vs WALS coding, joined
+structurally on ISO 639-3 via `Datapoint.lookupISO`. -/
+
 theorem rpEnglish_wals :
     (Data.WALS.F106A.lookupISO rpEnglish.iso).map (ofWALS106A ·.value) =
       some rpEnglish.reflexiveRelation := by decide
@@ -315,7 +342,7 @@ theorem rpWambaya_wals :
       ("The people at the dinner party were married to one another.")
     - `chain`: sequential, each with the next
       ("The graduating students followed one another up onto the stage.")
-    - `radial`: one central participant reciprocates with all others
+    - `radial`: one central participant acts on all others
       ("The teacher and her pupils intimidated one another.")
     - `melee`: widespread but not exhaustive reciprocation
       ("The drunks in the pub were punching one another.")
@@ -330,32 +357,22 @@ inductive ReciprocityType where
   | ring
   deriving DecidableEq, Repr
 
-/-- Whether a reciprocity type requires every participant to be involved
-    in at least one reciprocal pair. Radial IS participant-exhaustive —
-    the center reciprocates with each peripheral — but is not
-    pair-exhaustive (peripherals do not reciprocate with each other).
-    Melee is the only type where some participants may be uninvolved. -/
-def ReciprocityType.exhaustive : ReciprocityType → Bool
-  | .strong   => true
-  | .pairwise => true
-  | .chain    => true
-  | .radial   => true
-  | .melee    => false
-  | .ring     => true
-
-/-- Whether a reciprocity type is symmetric: within each active pair,
-    if A acts on B then B acts on A. Only strong and pairwise are:
-    chain and ring are directional (A follows B does not entail B
-    follows A), and [majid-et-al-2011] define radial as one participant
-    acting *asymmetrically* with multiple others and melee as multiple
-    *asymmetrical* interactions without full saturation. -/
-def ReciprocityType.symmetric : ReciprocityType → Bool
-  | .strong   => true
-  | .pairwise => true
-  | .chain    => false
-  | .radial   => false
-  | .melee    => false
-  | .ring     => false
+/-- The relation shape each configurational label denotes over a
+    participant plurality — [majid-et-al-2011]'s extensional schemas as
+    the exact-extension conditions of `Semantics.Plurality.Reciprocal`.
+    Symmetry and participant-exhaustiveness are theorems there
+    (`ChainConfig.not_pairSymmetricOn`,
+    `RadialConfig.inclusiveAlternativeOrdering`, melee failing
+    `InclusiveAlternativeOrdering` by definition, …), not stipulated
+    features of the labels. -/
+def ReciprocityType.Realizes {A : Type*} :
+    ReciprocityType → (A → A → Prop) → Finset A → Prop
+  | .strong,   R, X => Semantics.Plurality.Reciprocal.StrongReciprocity R X
+  | .pairwise, R, X => Semantics.Plurality.Reciprocal.PairwiseConfig R X
+  | .chain,    R, X => Semantics.Plurality.Reciprocal.ChainConfig R X
+  | .radial,   R, X => Semantics.Plurality.Reciprocal.RadialConfig R X
+  | .melee,    R, X => Semantics.Plurality.Reciprocal.MeleeConfig R X
+  | .ring,     R, X => Semantics.Plurality.Reciprocal.RingConfig R X
 
 /-- The six reciprocity types English *each other* can express
     ([evans-et-al-2011b], p. 8; [nordlinger-2023] ex. 44). -/
@@ -377,60 +394,31 @@ theorem english_expresses_all_types :
     valence reduction (transitive → intransitive), matching `rpSwahili`'s
     `verbalAffix` strategy + `monovalent` valency. -/
 theorem rpSwahili_grounded_in_fragment :
-    rpSwahili.primaryStrategy = .verbalAffix ∧
+    rpSwahili.primaryStrategy = some .verbalAffix ∧
     rpSwahili.valency = .monovalent ∧
     Swahili.Reciprocals.reciprocalAffix.category = .valence :=
   ⟨rfl, rfl, rfl⟩
 
-/-! ### Reciprocal marker polysemy (§4.2) -/
+/-! ### Polysemous markers beyond the sample (§4.2)
 
-/-- Extended readings of reciprocal markers beyond core reciprocal
-    meaning. [nordlinger-2023] §4.2: reciprocal markers are commonly
-    polysemous with reflexive (34% of the WALS sample,
-    [maslova-nedjalkov-2013]), collective/sociative, and iterative
-    meanings. -/
-inductive RecipMarkerPolysemy where
-  /-- Core mutual action reading. -/
-  | reciprocal
-  /-- Same-participant reading (overlap with reflexives). -/
-  | reflexive
-  /-- Joint action without mutual entailment. -/
-  | collective
-  /-- Joint/associative action ('together'). -/
-  | sociative
-  /-- Repeated action ('again and again'). -/
-  | iterative
-  deriving DecidableEq, Repr
-
-/-- Polysemy pattern: which readings a language's reciprocal
-    marker(s) can express. -/
-structure RecipPolysemyPattern where
-  language : String
-  readings : List RecipMarkerPolysemy
-  deriving Repr
-
-/-- French *se*: reciprocal + reflexive — "Pierre et Jean se sont
-    habillés" is ambiguous between 'dressed themselves' and 'dressed
-    each other' ([nordlinger-2023] ex. 47, citing [siloni-2012]). -/
-def polysemyFrench : RecipPolysemyPattern :=
-  { language := "French", readings := [.reciprocal, .reflexive] }
+Reflexive polysemy is carried by the profile inventories above (French
+*se*, German *sich*, Wambaya *-ngg-*, Russian *-sja*) and drives their
+derived WALS values. The review's further polysemy types are attested by
+markers outside the 12-language sample. -/
 
 /-- Yakut *-üs*: reciprocal + collective/sociative — *ölör-üs* 'kill
     each other' or 'kill somebody together' ([nordlinger-2023] ex. 49,
-    citing Nedjalkov 2007b). -/
-def polysemyYakut : RecipPolysemyPattern :=
-  { language := "Yakut", readings := [.reciprocal, .collective, .sociative] }
+    citing [nedjalkov-2007b]). -/
+def yakutUs : ReciprocalMarker :=
+  { form := "-üs", strategy := .verbalAffix
+  , readings := [.reciprocal, .collective, .sociative] }
 
-/-- East Futunan *fe-...-'aki*: reciprocal + iterative — *fe-tapa-'aki*
+/-- East Futunan *fe-...-ʼaki*: reciprocal + iterative — *fe-tapa-ʼaki*
     'sparkle again and again' ([nordlinger-2023] ex. 50, citing
-    Nedjalkov 2007b). -/
-def polysemyEastFutunan : RecipPolysemyPattern :=
-  { language := "East Futunan", readings := [.reciprocal, .iterative] }
-
-/-- Wambaya *-ngg-* (RR): reciprocal + reflexive (identical forms,
-    [nordlinger-1998]). -/
-def polysemyWambaya : RecipPolysemyPattern :=
-  { language := "Wambaya", readings := [.reciprocal, .reflexive] }
+    [nedjalkov-2007b]). -/
+def eastFutunanFeAki : ReciprocalMarker :=
+  { form := "fe-...-ʼaki", strategy := .verbalAffix
+  , readings := [.reciprocal, .iterative] }
 
 /-! ### Fragment connection: English reciprocal-reflexive distinction -/
 
@@ -442,7 +430,7 @@ open English.Pronouns in
     strategy. The WALS substrate anchor for the reflexive-reciprocal
     distinction is `rpEnglish_wals`. -/
 theorem english_profile_grounded :
-    rpEnglish.primaryStrategy = .bipartiteNP ∧
+    rpEnglish.primaryStrategy = some .bipartiteNP ∧
     rpEnglish.valency = .bivalent ∧
     Binding.bindingClassOf eachOther.toWord = some .reciprocal ∧
     Binding.bindingClassOf eachOther.toWord ≠ some .reflexive := by

--- a/Linglib/Studies/Winter2018.lean
+++ b/Linglib/Studies/Winter2018.lean
@@ -1,0 +1,205 @@
+import Linglib.Semantics.Plurality.Reciprocal
+
+/-!
+# Winter (2018): Symmetric Predicates and Reciprocal Alternations
+
+[winter-2018]
+
+Semantics & Pragmatics 11(1): 1–52.
+
+Reciprocal alternations pair a unary-collective predicate P (*Sue and Dan
+dated*) with a binary predicate R (*Sue dated Dan*). Winter's
+**Reciprocity-Symmetry Generalization** (RSG, def. 18): the alternation is
+*plain* — P(x+y) ⇔ R(x,y) ∧ R(y,x) (def. 7) — iff R is truth-conditionally
+symmetric. The RSG is not a logical necessity (an artificial ★Xhug refutes
+it, fn. 12); Winter derives it lexically: symmetric predicates take the
+collective meaning as *basic* and obtain the binary form as its symmetric
+image R := λx λy. P(x+y) (def. 22). This reverses the derivation direction
+of [dimitriadis-2008] and [siloni-2012], which map binary meanings to
+reciprocal ones (fn. 14) — a genuine divergence from
+`Studies/Siloni2012.lean`, where lexical reciprocal verbs are derived from
+transitive alternates by bundling.
+
+Non-symmetric reciprocals (*hug*, *fight*, *collide*) satisfy no plain
+equivalence; §3.3 charts their logical patterns (Pr₁–Pr₅, Table 3), of
+which only the weak disjunctive Pr₅ — P(x+y) ⇒ R(x,y) ∨ R(y,x) — is shared
+by all reciprocal alternations. Their full semantics is preferential
+(typicality-based, §3.5, supported by experimental judgment data on Dutch
+contact and communication verbs), beyond the event-free logical core
+formalized here.
+
+Sums of two distinct atoms are encoded as pair `Finset`s `{x, y}`,
+matching the `(R, X)` signature of `Semantics.Plurality.Reciprocal`.
+
+## Main declarations
+
+* `PlainReciprocity` (def. 7), `TCSymmetric`, `symmetricImage` (def. 22)
+* `symmetricImage_tcSymmetric`, `plainReciprocity_symmetricImage` —
+  the symmetric image is symmetric and plain: principle P1, which
+  derives the RSG for collective-basic predicates
+* `plainReciprocity_iff_pr1_pr2` — plain reciprocity decomposes exactly
+  into Pr₁ ∧ Pr₂
+* `exists_plainReciprocity_not_tcSymmetric` — plainR alone does not
+  force symmetry (fn. 12's ★Xhug): the RSG is a lexicon fact, not logic
+* `AlternationProfile` + `table3` — Table 3's per-verb Pr-patterns, with
+  the Pr₅ universal and the Pr₄ ⇒ Pr₁ consistency check
+-/
+
+namespace Winter2018
+
+variable {A : Type*} [DecidableEq A]
+
+/-- Def. (7), plain reciprocity: for distinct atoms, the collective holds
+    of the pair-sum iff the binary holds in both directions
+    ("A and B dated" ⇔ "A dated B and B dated A"). -/
+def PlainReciprocity (P : Finset A → Prop) (R : A → A → Prop) : Prop :=
+  ∀ x y : A, x ≠ y → (P {x, y} ↔ R x y ∧ R y x)
+
+/-- Truth-conditional symmetry of a binary predicate (§2.2; Strawson
+    effects like *sister*'s gender presupposition are factored out). -/
+def TCSymmetric (R : A → A → Prop) : Prop := ∀ x y, R x y ↔ R y x
+
+/-- Def. (22), the symmetric image of a collective predicate:
+    `R x y` iff `P` holds of the pair-sum (*similar to* from
+    collective *similar*). -/
+def symmetricImage (P : Finset A → Prop) : A → A → Prop :=
+  fun x y => P {x, y}
+
+/-- The symmetric image is truth-conditionally symmetric — by
+    commutativity of sum formation (Winter's point (i) on def. 7). -/
+theorem symmetricImage_tcSymmetric (P : Finset A → Prop) :
+    TCSymmetric (symmetricImage P) := by
+  intro x y
+  simp [symmetricImage, Finset.pair_comm]
+
+/-- Principle P1: the symmetric image stands in plain reciprocity with
+    its source collective. With `symmetricImage_tcSymmetric` this
+    derives the RSG for predicates whose binary form is the symmetric
+    image of a basic collective meaning. -/
+theorem plainReciprocity_symmetricImage (P : Finset A → Prop) :
+    PlainReciprocity P (symmetricImage P) := by
+  intro x y _
+  constructor
+  · exact fun h => ⟨h, by simpa [symmetricImage, Finset.pair_comm] using h⟩
+  · exact fun h => h.1
+
+/-- The RSG is not logically forced: a plain alternation with a
+    non-symmetric binary predicate exists (fn. 12's ★Xhug — a one-way
+    *hug* paired with the everywhere-false collective is vacuously
+    plain). The RSG is thus a generalization about natural-language
+    lexicons, not a consequence of the notion of reciprocity. -/
+theorem exists_plainReciprocity_not_tcSymmetric :
+    ∃ (R : Bool → Bool → Prop) (P : Finset Bool → Prop),
+      PlainReciprocity P R ∧ ¬ TCSymmetric R := by
+  refine ⟨fun x y => x = true ∧ y = false, fun _ => False, ?_, ?_⟩
+  · intro x y hxy
+    constructor
+    · exact False.elim
+    · rintro ⟨⟨rfl, rfl⟩, h₂, -⟩
+      exact Bool.noConfusion h₂
+  · intro h
+    have := (h true false).mp ⟨rfl, rfl⟩
+    exact Bool.noConfusion this.1
+
+/-! ### The Pr-patterns of non-plain alternations (§3.3) -/
+
+/-- (Pr₁): bidirectional `R` yields the collective. Fails for *hug*
+    (separate unidirectional hugs do not make a mutual hug). -/
+def Pr1 (P : Finset A → Prop) (R : A → A → Prop) : Prop :=
+  ∀ x y : A, x ≠ y → R x y → R y x → P {x, y}
+
+/-- (Pr₂): the collective yields `R` — in both directions, by sum
+    commutativity (`Pr2.both`). Holds for *be in love* and Hebrew
+    *makir*; experimental judgments refute it for *hug*-type verbs. -/
+def Pr2 (P : Finset A → Prop) (R : A → A → Prop) : Prop :=
+  ∀ x y : A, x ≠ y → P {x, y} → R x y
+
+/-- (Pr₄): one-directional `R` already yields the collective
+    (*break up*, *divorce*). -/
+def Pr4 (P : Finset A → Prop) (R : A → A → Prop) : Prop :=
+  ∀ x y : A, x ≠ y → R x y → P {x, y}
+
+/-- (Pr₅): the collective yields `R` in at least one direction — the
+    weak disjunctive pattern shared by ALL reciprocal alternations,
+    plain and non-plain alike. -/
+def Pr5 (P : Finset A → Prop) (R : A → A → Prop) : Prop :=
+  ∀ x y : A, x ≠ y → P {x, y} → (R x y ∨ R y x)
+
+/-- Pr₂ delivers both directions, since `{x, y} = {y, x}`. -/
+theorem Pr2.both {P : Finset A → Prop} {R : A → A → Prop}
+    (h : Pr2 P R) {x y : A} (hxy : x ≠ y) (hP : P {x, y}) :
+    R x y ∧ R y x :=
+  ⟨h x y hxy hP, h y x hxy.symm (Finset.pair_comm x y ▸ hP)⟩
+
+/-- Pr₄ is logically stronger than Pr₁ (§3.3). -/
+theorem Pr4.pr1 {P : Finset A → Prop} {R : A → A → Prop}
+    (h : Pr4 P R) : Pr1 P R :=
+  fun x y hxy hR _ => h x y hxy hR
+
+/-- Pr₂ is logically stronger than Pr₅. -/
+theorem Pr2.pr5 {P : Finset A → Prop} {R : A → A → Prop}
+    (h : Pr2 P R) : Pr5 P R :=
+  fun x y hxy hP => Or.inl (h x y hxy hP)
+
+/-- Plain reciprocity entails the weak universal Pr₅. -/
+theorem PlainReciprocity.pr5 {P : Finset A → Prop} {R : A → A → Prop}
+    (h : PlainReciprocity P R) : Pr5 P R :=
+  fun x y hxy hP => Or.inl ((h x y hxy).mp hP).1
+
+/-- Plain reciprocity decomposes exactly into Pr₁ together with Pr₂. -/
+theorem plainReciprocity_iff_pr1_pr2
+    {P : Finset A → Prop} {R : A → A → Prop} :
+    PlainReciprocity P R ↔ (Pr1 P R ∧ Pr2 P R) := by
+  constructor
+  · exact fun h => ⟨fun x y hxy hR hR' => (h x y hxy).mpr ⟨hR, hR'⟩,
+      fun x y hxy hP => ((h x y hxy).mp hP).1⟩
+  · rintro ⟨h1, h2⟩ x y hxy
+    exact ⟨fun hP => h2.both hxy hP, fun h => h1 x y hxy h.1 h.2⟩
+
+/-! ### Table 3: logical patterns per verb -/
+
+/-- A row of Winter's Table 3: which Pr-patterns a non-plain reciprocal
+    alternation exhibits (`none` where the paper leaves the cell
+    undetermined). Pr₃ — bidirectional `R` *plus simultaneity* yields
+    the collective — is event-level and recorded as data only. -/
+structure AlternationProfile where
+  predicate : String
+  pr1 : Option Bool
+  pr2 : Option Bool
+  pr3 : Bool
+  pr4 : Bool
+  pr5 : Bool
+  deriving DecidableEq, Repr
+
+def hug : AlternationProfile :=
+  ⟨"hug", some false, some false, true, false, true⟩
+def kiss : AlternationProfile :=
+  ⟨"kiss", some false, none, true, false, true⟩
+def fight : AlternationProfile :=
+  ⟨"fight", some false, some false, true, false, true⟩
+def breakUp : AlternationProfile :=
+  ⟨"break up", some true, some false, true, true, true⟩
+def divorce : AlternationProfile :=
+  ⟨"divorce", some true, some false, true, true, true⟩
+def collide : AlternationProfile :=
+  ⟨"collide", none, some false, true, false, true⟩
+def inLove : AlternationProfile :=
+  ⟨"be/fall in love", some false, some true, false, false, true⟩
+def talk : AlternationProfile :=
+  ⟨"talk", some false, some false, false, false, true⟩
+def makir : AlternationProfile :=
+  ⟨"makir (Hebrew 'know')", some false, some true, false, false, true⟩
+
+def table3 : List AlternationProfile :=
+  [hug, kiss, fight, breakUp, divorce, collide, inLove, talk, makir]
+
+/-- §3.3's universal: every alternation in Table 3 satisfies the weak
+    disjunctive Pr₅. -/
+theorem table3_pr5 : table3.all (·.pr5) := by decide
+
+/-- Data-logic consistency: rows claiming Pr₄ also claim Pr₁, as
+    `Pr4.pr1` requires (*break up*, *divorce*). -/
+theorem table3_pr4_consistent :
+    table3.all (fun r => !r.pr4 || r.pr1 == some true) := by decide
+
+end Winter2018

--- a/Linglib/Syntax/Reciprocal.lean
+++ b/Linglib/Syntax/Reciprocal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Data.WALS.Features.F106A
+import Linglib.Syntax.ArgumentStructure.Alternation
 
 /-!
 # Reciprocal constructions: morphosyntactic typology
@@ -13,16 +13,30 @@ reciprocal-reflexive formal relation (WALS Ch 106, [maslova-nedjalkov-2013]),
 the morphosyntactic locus of reciprocal marking ([nordlinger-2023]'s synthesis
 of [konig-kokutani-2006], [nedjalkov-2007a], and [evans-2008]), the valency
 effect, and the formation locus of reciprocal verbs ([siloni-2008],
-[siloni-2012]). Valency-reducing reciprocalization as an operation on coding
-frames is `Syntax.ArgumentStructure.Alternation.reciprocalization`.
+[siloni-2012]).
+
+The primitive for a language's exponence is the marker inventory
+(`ReciprocalMarker`): each marker carries its strategy and polysemy readings, and
+the WALS Ch 106 value is *computed* from the inventory (`ofInventory`) rather
+than stipulated per language. Strategy-level classifiers are projections:
+`isNominal` from the coding site, and the default valency effect from the
+coding-frame operation the strategy realizes
+(`Syntax.ArgumentStructure.Alternation.reciprocalization`).
 
 ## Main definitions
 
 * `ReciprocalType` — reciprocal/reflexive formal relation (WALS Ch 106).
-* `RecipStrategy` + `RecipStrategy.isNominal` — the morphosyntactic locus.
+* `RecipStrategy` + `codingSite`/`isNominal` — the morphosyntactic locus.
+* `RecipStrategy.alternation` / `defaultValency` — the realized coding-frame
+  operation and the valency effect it derives.
 * `RecipValency` — valency effect (bivalent vs monovalent).
 * `RecipFormation` + `RecipFormation.allowsDiscontinuous` — lexical vs syntactic.
-* `ofWALS106A` — WALS Ch 106 converter.
+* `RecipMarkerPolysemy`, `ReciprocalMarker`, `ofInventory` — marker inventories and
+  the derived WALS Ch 106 value.
+
+Per-language inventories live in `Fragments/{Lang}/Reciprocals.lean`;
+WALS-data grounding lives with the studies that use it (e.g.
+`Studies/Nordlinger2023.lean`), not here.
 -/
 
 namespace Reciprocal
@@ -77,25 +91,6 @@ inductive RecipStrategy where
   | compoundVerb
   deriving DecidableEq, Repr
 
-/-- Whether the strategy marks a (nonsubject) argument position, in the sense
-of [nordlinger-2023] §3.2's NP/argument vs verb-marked split (after
-[konig-kokutani-2006]'s nominal/verbal distinction).
-
-Deviation from [konig-kokutani-2006]: they group clitics with the nominal
-strategies, but this classifier places `recipClitic` on the verbal side
-because Romance/Slavic *se* is not an anaphoric object — it marks a
-valency-reducing operation on the verb ([siloni-2012]). Wambaya *-ngg-* is
-the documented exception: a bound clitic whose clause stays bivalent
-([evans-et-al-2007]). -/
-def RecipStrategy.isNominal : RecipStrategy → Bool
-  | .bipartiteNP     => true
-  | .recipPronoun    => true
-  | .recipClitic     => false
-  | .verbalAffix     => false
-  | .verbalAuxiliary => false
-  | .lexical         => false
-  | .compoundVerb    => false
-
 /-- Valency effect of the reciprocal construction ([nordlinger-2023] §3.2):
 syntactically bivalent constructions keep two overt argument slots, while
 monovalent ones express all reciprocants in the subject. NP/argument
@@ -112,6 +107,55 @@ inductive RecipValency where
   /-- The verb becomes intransitive; reciprocants form a single subject NP. -/
   | monovalent
   deriving DecidableEq, Repr
+
+/-- Where the reciprocal marking sits: an argument position, the
+verb/auxiliary complex, or a fused multipredicate structure (which
+[evans-2008] treats as multiclausal). -/
+inductive CodingSite where
+  | argument
+  | predicate
+  | multiclausal
+  deriving DecidableEq, Repr
+
+/-- Coding site of each strategy. Deviation from [konig-kokutani-2006]:
+they group clitics with the nominal strategies, but this projection places
+`recipClitic` on the predicate side because Romance/Slavic *se* is not an
+anaphoric object — it marks a valency-reducing operation on the verb
+([siloni-2012]). Wambaya *-ngg-* is the documented exception: a bound clitic
+whose clause stays bivalent ([evans-et-al-2007]). -/
+def RecipStrategy.codingSite : RecipStrategy → CodingSite
+  | .bipartiteNP | .recipPronoun => .argument
+  | .recipClitic | .verbalAffix | .verbalAuxiliary | .lexical => .predicate
+  | .compoundVerb => .multiclausal
+
+/-- Whether the strategy marks a (nonsubject) argument position, in the sense
+of [nordlinger-2023] §3.2's NP/argument vs verb-marked split — the projection
+`codingSite == .argument`. -/
+def RecipStrategy.isNominal (s : RecipStrategy) : Bool :=
+  s.codingSite == .argument
+
+open Syntax.ArgumentStructure.Alternation in
+/-- The coding-frame operation a strategy realizes: grammatical verb-marking
+strategies (clitic, affix, auxiliary, compound) apply [creissels-2025]'s
+denucleativizing `reciprocalization`; argument-position strategies leave the
+frame untouched, and inherently reciprocal lexical entries are not derived by
+a coding-frame operation at all (their formation is `RecipFormation`'s
+business). -/
+def RecipStrategy.alternation : RecipStrategy → Option ValencyAlternation
+  | .recipClitic | .verbalAffix | .verbalAuxiliary | .compoundVerb =>
+      some reciprocalization
+  | .bipartiteNP | .recipPronoun | .lexical => none
+
+/-- Default valency effect of a strategy, derived from the realized
+coding-frame operation: strategies applying `reciprocalization` inherit its
+detransitivizing effect (`derivedTransitive = some false`); argument
+strategies preserve the frame. A default, not a law — Wambaya's ergative-
+retaining clitic, Tonga's bivalent verbal marking ([maslova-2008]), and
+Malagasy's f-structure bivalency ([hurst-2006], [hurst-2012]) override it. -/
+def RecipStrategy.defaultValency (s : RecipStrategy) : RecipValency :=
+  match s.alternation with
+  | some a => if a.derivedTransitive = some false then .monovalent else .bivalent
+  | none   => .bivalent
 
 /-- Where reciprocal verbs are formed, per [siloni-2008] and [siloni-2012]
 (the lex-syn parameter of [reinhart-siloni-2005]):
@@ -139,13 +183,49 @@ def RecipFormation.allowsDiscontinuous : RecipFormation → Bool
   | .lexical   => true
   | .syntactic => false
 
-/-! ### WALS converter -/
+/-! ### Marker inventories -/
 
-/-- Convert a WALS 106A value to `ReciprocalType`. -/
-def ofWALS106A : Data.WALS.F106A.ReciprocalType → ReciprocalType
-  | .noReciprocalConstruction => .noDedicated
-  | .distinctFromReflexive    => .distinctFromReflexive
-  | .mixed                    => .mixed
-  | .identicalToReflexive     => .identicalToReflexive
+/-- Extended readings a reciprocal marker can carry beyond core reciprocity
+([nordlinger-2023] §4.2; [nedjalkov-2007b]): reflexive (the WALS Ch 106
+overlap), collective, sociative, and iterative. -/
+inductive RecipMarkerPolysemy where
+  /-- Core mutual action reading. -/
+  | reciprocal
+  /-- Same-participant reading (overlap with reflexives). -/
+  | reflexive
+  /-- Joint action without mutual entailment. -/
+  | collective
+  /-- Joint/associative action ('together'). -/
+  | sociative
+  /-- Repeated action ('again and again'). -/
+  | iterative
+  deriving DecidableEq, Repr
+
+/-- A reciprocal exponent: its form, morphosyntactic strategy, and the
+readings it covers. A language's reciprocal system is a `List ReciprocalMarker`
+(primary strategy first). -/
+structure ReciprocalMarker where
+  /-- Surface form (romanization or orthographic). -/
+  form : String
+  /-- Native-script form, when `form` is a romanization. -/
+  script : Option String := none
+  /-- Morphosyntactic strategy of the exponent. -/
+  strategy : RecipStrategy
+  /-- Readings the marker covers. -/
+  readings : List RecipMarkerPolysemy := [.reciprocal]
+  deriving DecidableEq, Repr
+
+/-- The WALS Ch 106 value computed from a marker inventory: no
+reciprocal-capable marker → `noDedicated`; all reciprocal markers also
+reflexive → `identicalToReflexive`; none reflexive → `distinctFromReflexive`;
+both kinds → `mixed`. (Purely iconic strategies, which WALS also counts as
+`noDedicated`, are outside the inventory vocabulary.) -/
+def ofInventory (inv : List ReciprocalMarker) : ReciprocalType :=
+  let recips := inv.filter (·.readings.contains .reciprocal)
+  if recips.isEmpty then .noDedicated
+  else if recips.all (·.readings.contains .reflexive) then .identicalToReflexive
+  else if recips.all (fun m => !m.readings.contains .reflexive) then
+    .distinctFromReflexive
+  else .mixed
 
 end Reciprocal

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17953,6 +17953,35 @@
   validated = {true},
   sources   = {Studies/Nordlinger2023.lean}
 }
+% REF: Winter, Y. (2018). Symmetric predicates and the semantics of reciprocal alternations. *Semantics & Pragmatics* 11(1): 1–52.
+@article{winter-2018,
+  author    = {Winter, Yoad},
+  year      = {2018},
+  title     = {Symmetric Predicates and the Semantics of Reciprocal Alternations},
+  journal   = {Semantics and Pragmatics},
+  volume    = {11},
+  number    = {1},
+  pages     = {1--52},
+  doi       = {10.3765/sp.11.1},
+  subfield  = {semantics},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Winter2018.lean}
+}% REF: Nedjalkov, V. P. (2007). Polysemy of reciprocal markers. In Nedjalkov (ed.), *Reciprocal Constructions*, 231–333. Benjamins.
+@incollection{nedjalkov-2007b,
+  author    = {Nedjalkov, Vladimir P.},
+  year      = {2007},
+  title     = {Polysemy of Reciprocal Markers},
+  booktitle = {Reciprocal Constructions},
+  editor    = {Nedjalkov, Vladimir P.},
+  publisher = {John Benjamins},
+  address   = {Amsterdam},
+  pages     = {231--333},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/Reciprocal.lean;Studies/Nordlinger2023.lean}
+}
 @article{sichel-2014,
   author    = {Sichel, Ivy},
   year      = {2014},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17937,6 +17937,22 @@
   validated = {true},
   sources   = {Studies/Siloni2012.lean}
 }
+% REF: Majid, A., Evans, N., Gaby, A., & Levinson, S. C. (2011). The semantics of reciprocal constructions across languages: An extensional approach. In Evans et al. (eds.), *Reciprocals and Semantic Typology*, 29–60. Benjamins.
+@incollection{majid-et-al-2011,
+  author    = {Majid, Asifa and Evans, Nicholas and Gaby, Alice and Levinson, Stephen C.},
+  year      = {2011},
+  title     = {The Semantics of Reciprocal Constructions across Languages: An Extensional Approach},
+  booktitle = {Reciprocals and Semantic Typology},
+  editor    = {Evans, Nicholas and Gaby, Alice and Levinson, Stephen C. and Majid, Asifa},
+  publisher = {John Benjamins},
+  address   = {Amsterdam},
+  pages     = {29--60},
+  doi       = {10.1075/tsl.98.02maj},
+  subfield  = {semantics},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Nordlinger2023.lean}
+}
 @article{sichel-2014,
   author    = {Sichel, Ivy},
   year      = {2014},


### PR DESCRIPTION
Recovers the two commits stranded when #1311 squash-merged early, unchanged in content.

- Evans/Majid configurations as relation shapes in `Semantics/Plurality/Reciprocal.lean` (symmetry/exhaustiveness as theorems wired to the DKMPK lattice); radial/melee corrected to asymmetric per Majid et al.
- `ReciprocalMarker` inventories in `Fragments/{Lang}/Reciprocals.lean` (12 languages, Pronoun-fragment style); WALS 106A value derived via `ofInventory`; WALS checks study-local; `isNominal`/default valency derived from coding site + `Alternation.reciprocalization`.
- New `Studies/Winter2018.lean`: plain reciprocity, symmetric image (P1 derives the RSG), plainR ⇔ Pr₁∧Pr₂, ★Xhug non-symmetry witness, Table 3 with the Pr₅ universal.