### PR TITLE
refactor(Syntax/Reciprocal): de-stutter names, mark predicates not forms

### DIFF
--- a/Linglib/Fragments/Chichewa/Reciprocals.lean
+++ b/Linglib/Fragments/Chichewa/Reciprocals.lean
@@ -47,10 +47,10 @@ open Reciprocal
 
 /-- The reciprocal suffix as a typological marker (distinct from the
     reflexive *dzi-*). -/
-def anSuffix : ReciprocalMarker :=
+def anSuffix : Marker :=
   { form := "-an-", strategy := .verbalAffix }
 
 /-- Marker inventory. -/
-def markers : List ReciprocalMarker := [anSuffix]
+def markers : List Marker := [anSuffix]
 
 end Chichewa.Reciprocals

--- a/Linglib/Fragments/English/Reciprocals.lean
+++ b/Linglib/Fragments/English/Reciprocals.lean
@@ -1,4 +1,5 @@
 import Linglib.Fragments.English.Pronouns
+import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Syntax.Reciprocal
 
 /-!
@@ -9,9 +10,12 @@ English encodes reciprocity with the bipartite quantificational NP
 *each other* (bivalent; [nordlinger-2023] ex. 1b), with *one another* as
 a variant, plus a closed class of inherently reciprocal predicates
 (*quarrel*, *meet*, *kiss*; ex. 7). Both are formally distinct from the
-reflexive *themselves*. Pronoun entries live in
-`Fragments/English/Pronouns.lean`; the markers here derive their forms
-from those entries.
+reflexive *themselves*. The bipartite marker derives its form from the
+pronoun entry in `Fragments/English/Pronouns.lean`; the lexical strategy
+has no exponent, so it is carried by the verb entries themselves
+(`lexicalReciprocals`), not by a marker — and correctly does not feed
+`Reciprocal.ofInventory` (WALS counts constructions, not lexical
+predicates).
 -/
 
 namespace English.Reciprocals
@@ -20,16 +24,19 @@ open Reciprocal
 
 /-- each other — bipartite quantificational reciprocal (form derived
     from the pronoun entry `English.Pronouns.eachOther`). -/
-def eachOther : ReciprocalMarker :=
+def eachOther : Marker :=
   { form := Pronouns.eachOther.form, strategy := .bipartiteNP }
 
-/-- The closed class of inherently reciprocal predicates (*quarrel*,
-    *meet*; [nordlinger-2023] ex. 7). Lexicon-formed per [siloni-2012],
-    though *kiss*/*hug* resist the discontinuous construction (fn. 32). -/
-def lexicalClass : ReciprocalMarker :=
-  { form := "quarrel/meet (lexical class)", strategy := .lexical }
+/-- The inherently reciprocal predicates (*quarrel*, *meet*;
+    [nordlinger-2023] ex. 7), referenced as verb entries — the lexical
+    strategy marks predicates, not forms. Lexicon-formed per
+    [siloni-2012], though *kiss*/*hug* resist the discontinuous
+    construction (fn. 32). Entries beyond *meet* pending in
+    `Predicates/Verbal.lean`. -/
+def lexicalReciprocals : List Predicates.Verbal.VerbEntry :=
+  [Predicates.Verbal.meet]
 
-/-- Marker inventory, primary strategy first. -/
-def markers : List ReciprocalMarker := [eachOther, lexicalClass]
+/-- Marker inventory. -/
+def markers : List Marker := [eachOther]
 
 end English.Reciprocals

--- a/Linglib/Fragments/French/Reciprocals.lean
+++ b/Linglib/Fragments/French/Reciprocals.lean
@@ -23,12 +23,12 @@ namespace French.Reciprocals
 open Reciprocal
 
 /-- se — reflexive/reciprocal clitic ([nordlinger-2023] ex. 28, 47). -/
-def se : ReciprocalMarker :=
+def se : Marker :=
   { form := "se", strategy := .recipClitic
   , readings := [.reciprocal, .reflexive] }
 
 /-- l'un l'autre — bipartite reciprocal NP. -/
-def lunLautre : ReciprocalMarker :=
+def lunLautre : Marker :=
   { form := "l'un l'autre", strategy := .bipartiteNP }
 
 /-- The bipartite NP form is distinct from the clitic. -/
@@ -36,6 +36,6 @@ theorem bipartite_distinct_from_clitic :
     lunLautre.form ≠ se.form := by decide
 
 /-- Marker inventory, primary strategy first. -/
-def markers : List ReciprocalMarker := [se, lunLautre]
+def markers : List Marker := [se, lunLautre]
 
 end French.Reciprocals

--- a/Linglib/Fragments/German/Reciprocals.lean
+++ b/Linglib/Fragments/German/Reciprocals.lean
@@ -24,12 +24,12 @@ namespace German.Reciprocals
 open Reciprocal
 
 /-- einander — dedicated reciprocal pronoun. -/
-def einander : ReciprocalMarker :=
+def einander : Marker :=
   { form := "einander", strategy := .recipPronoun }
 
 /-- sich — reflexive pronoun in reciprocal use ([siloni-2012] fn. 13
     treats *sich*-reciprocals as syntactic reciprocal verbs). -/
-def sich : ReciprocalMarker :=
+def sich : Marker :=
   { form := "sich", strategy := .recipPronoun
   , readings := [.reciprocal, .reflexive] }
 
@@ -39,6 +39,6 @@ theorem einander_distinct_from_sich :
 
 /-- Marker inventory: dedicated *einander* plus reflexive-identical
     *sich* — jointly the WALS "mixed" configuration. -/
-def markers : List ReciprocalMarker := [einander, sich]
+def markers : List Marker := [einander, sich]
 
 end German.Reciprocals

--- a/Linglib/Fragments/Greek/StandardModern/Reciprocals.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Reciprocals.lean
@@ -40,18 +40,21 @@ theorem nonactive_is_voice :
 
 open Reciprocal
 
-/-- Nonactive voice morphology as a reciprocal marker (shared with
-    reflexives/middles; [nordlinger-2023] ex. 27). -/
-def nonactive : ReciprocalMarker :=
-  { form := "nonactive voice", strategy := .verbalAffix
+/-- The nonactive suffix as a reciprocal marker — citation allomorph of
+    the paradigm realized by `nonactiveVoiceSuffix` (stem + *-ome*),
+    which also serves reflexive, passive, and middle voice
+    ([nordlinger-2023] ex. 27). The marker records the exponent's form;
+    the morphological rule itself is the fragment's `MorphRule`. -/
+def nonactive : Marker :=
+  { form := "-ome", strategy := .verbalAffix
   , readings := [.reciprocal, .reflexive] }
 
 /-- o enas ton allon — distinct periphrastic reciprocal, whose existence
     underlies the WALS "mixed" classification ([maslova-nedjalkov-2013]). -/
-def oEnasTonAllon : ReciprocalMarker :=
+def oEnasTonAllon : Marker :=
   { form := "o enas ton allon", strategy := .bipartiteNP }
 
 /-- Marker inventory, primary strategy first. -/
-def markers : List ReciprocalMarker := [nonactive, oEnasTonAllon]
+def markers : List Marker := [nonactive, oEnasTonAllon]
 
 end Greek.StandardModern.Reciprocals

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -192,13 +192,13 @@ def singularAntecedentForcesWideScope : Bool := true
 open Reciprocal in
 /-- The reciprocal verbal suffix ([nordlinger-2023] ex. 19, citing
     [siloni-2008]). -/
-def ozSuffix : ReciprocalMarker :=
+def ozSuffix : Marker :=
   { form := "-óz-", strategy := .verbalAffix }
 
 open Reciprocal in
 /-- Marker inventory, primary strategy first: *-óz-* plus the reciprocal
     pronoun *egymás* (form derived from the pronoun entry above). -/
-def markers : List ReciprocalMarker :=
+def markers : List Marker :=
   [ ozSuffix, { form := egymas.form, strategy := .recipPronoun } ]
 
 end Hungarian.Reciprocals

--- a/Linglib/Fragments/Icelandic/Reciprocals.lean
+++ b/Linglib/Fragments/Icelandic/Reciprocals.lean
@@ -23,7 +23,7 @@ open Pronoun Reciprocal
 
 /-- hvort annað — bipartite reciprocal NP 'each other' (neuter citation
     forms; both parts inflect independently for case and gender). -/
-def hvorAnnad : ReciprocalMarker :=
+def hvorAnnad : Marker :=
   { form := "hvort annað", strategy := .bipartiteNP }
 
 /-- sig — reflexive pronoun (for contrast). -/
@@ -35,6 +35,6 @@ theorem recip_distinct_from_reflexive :
     hvorAnnad.form ≠ sig.form := by decide
 
 /-- Marker inventory. -/
-def markers : List ReciprocalMarker := [hvorAnnad]
+def markers : List Marker := [hvorAnnad]
 
 end Icelandic.Reciprocals

--- a/Linglib/Fragments/Mandarin/Reciprocals.lean
+++ b/Linglib/Fragments/Mandarin/Reciprocals.lean
@@ -51,11 +51,11 @@ open Reciprocal
 /-- The V-lái-V-qù compound as a reciprocal marker (form derived from
     `daLaiDaQu`). The adverbial *hùxiāng* is outside the strategy
     vocabulary ([evans-2008]'s adverbial strategy). -/
-def compound : ReciprocalMarker :=
+def compound : Marker :=
   { form := daLaiDaQu.toForm, script := daLaiDaQu.script
   , strategy := .compoundVerb }
 
 /-- Marker inventory. -/
-def markers : List ReciprocalMarker := [compound]
+def markers : List Marker := [compound]
 
 end Mandarin.Reciprocals

--- a/Linglib/Fragments/Slavic/Czech/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Czech/Reciprocals.lean
@@ -20,13 +20,13 @@ namespace Czech.Reciprocals
 open Reciprocal
 
 /-- se — reflexive/reciprocal clitic ([nordlinger-2023] ex. 29). -/
-def se : ReciprocalMarker :=
+def se : Marker :=
   { form := "se", strategy := .recipClitic
   , readings := [.reciprocal, .reflexive] }
 
 /-- jeden druhého — bipartite periphrastic reciprocal 'one the-other'
     ([siloni-2012]'s Czech examples). -/
-def jedenDruheho : ReciprocalMarker :=
+def jedenDruheho : Marker :=
   { form := "jeden druhého", strategy := .bipartiteNP }
 
 /-- The periphrastic reciprocal is distinct from the clitic. -/
@@ -34,6 +34,6 @@ theorem bipartite_distinct_from_clitic :
     jedenDruheho.form ≠ se.form := by decide
 
 /-- Marker inventory, primary strategy first. -/
-def markers : List ReciprocalMarker := [se, jedenDruheho]
+def markers : List Marker := [se, jedenDruheho]
 
 end Czech.Reciprocals

--- a/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
+++ b/Linglib/Fragments/Slavic/Russian/Reciprocals.lean
@@ -22,13 +22,13 @@ open Pronoun Reciprocal
 
 /-- друг друга *drug druga* — bipartite reciprocal 'other other-ACC'
     ([nordlinger-2023] ex. 9). -/
-def drugDruga : ReciprocalMarker :=
+def drugDruga : Marker :=
   { form := "drug druga", script := some "друг друга"
   , strategy := .bipartiteNP }
 
 /-- -ся *-sja* — verbal postfix, reflexive-identical reciprocal uses
     ([nordlinger-2023] ex. 31). -/
-def sja : ReciprocalMarker :=
+def sja : Marker :=
   { form := "-sja", script := some "-ся", strategy := .verbalAffix
   , readings := [.reciprocal, .reflexive] }
 
@@ -42,6 +42,6 @@ theorem recip_distinct_from_reflexive :
     drugDruga.form ≠ sebja.form := by decide
 
 /-- Marker inventory, primary strategy first. -/
-def markers : List ReciprocalMarker := [drugDruga, sja]
+def markers : List Marker := [drugDruga, sja]
 
 end Russian.Reciprocals

--- a/Linglib/Fragments/Swahili/Reciprocals.lean
+++ b/Linglib/Fragments/Swahili/Reciprocals.lean
@@ -53,10 +53,10 @@ open Reciprocal
 
 /-- The reciprocal suffix as a typological marker (distinct from the
     reflexive *-ji-*). -/
-def anSuffix : ReciprocalMarker :=
+def anSuffix : Marker :=
   { form := "-an-", strategy := .verbalAffix }
 
 /-- Marker inventory. -/
-def markers : List ReciprocalMarker := [anSuffix]
+def markers : List Marker := [anSuffix]
 
 end Swahili.Reciprocals

--- a/Linglib/Fragments/Wambaya/Reciprocals.lean
+++ b/Linglib/Fragments/Wambaya/Reciprocals.lean
@@ -31,12 +31,12 @@ open Reciprocal in
 /-- The RR clitic as a typological marker: it serves both reciprocal and
     reflexive functions (WALS "identical to reflexive" follows by
     `Reciprocal.ofInventory`; form derived from `rrMorpheme`). -/
-def rr : ReciprocalMarker :=
+def rr : Marker :=
   { form := rrMorpheme.form, strategy := .recipClitic
   , readings := [.reciprocal, .reflexive] }
 
 open Reciprocal in
 /-- Marker inventory. -/
-def markers : List ReciprocalMarker := [rr]
+def markers : List Marker := [rr]
 
 end Wambaya.Reciprocals

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -29,8 +29,8 @@ constructions, which summarizes earlier classificatory work
 and organizes the empirical picture around strategy/valency correlations
 (§3.2) and Siloni's discontinuity asymmetry (§3.3).
 
-The underlying primitives (`ReciprocalMarker`, `RecipStrategy`, `RecipValency`,
-`RecipFormation`, `ReciprocalType`) live in `Syntax/Reciprocal.lean`,
+The underlying primitives (`Marker`, `Strategy`, `Valency`,
+`Formation`, `ReflexiveRelation`) live in `Syntax/Reciprocal.lean`,
 anchored on the earlier sources the review synthesizes — which preserves
 chronological dependency for `Studies/Siloni2012.lean`. Each profile below
 records a marker *inventory*; the primary strategy and the WALS Ch 106
@@ -42,7 +42,7 @@ the derived values against the external WALS rows.
 - `RecipProfile` per-language profiles (12 languages): marker inventory +
   observed valency, formation, and discontinuity judgments
 - Strategy-valency correlation theorems (§3.2), including the derived
-  default-valency check against `RecipStrategy.defaultValency`
+  default-valency check against `Strategy.defaultValency`
 - Siloni's discontinuity prediction checked against attested judgments (§3.3)
 - WALS Ch 106 grounding for the *derived* reflexive relation (via `lookupISO`)
 - `ReciprocityType` semantic 6-way classification (§4), realized as the
@@ -55,9 +55,9 @@ namespace Nordlinger2023
 
 open Reciprocal
 
-/-- Convert a WALS 106A value to `ReciprocalType` (study-local: WALS
+/-- Convert a WALS 106A value to `ReflexiveRelation` (study-local: WALS
     grounding is this study's business, not the substrate's). -/
-def ofWALS106A : Data.WALS.F106A.ReciprocalType → ReciprocalType
+def ofWALS106A : Data.WALS.F106A.ReciprocalType → ReflexiveRelation
   | .noReciprocalConstruction => .noDedicated
   | .distinctFromReflexive    => .distinctFromReflexive
   | .mixed                    => .mixed
@@ -74,11 +74,11 @@ structure RecipProfile where
   iso : String
   /-- Marker inventory (primary strategy first), sourced from the
       language's `Fragments/{Lang}/Reciprocals.lean`. -/
-  markers : List ReciprocalMarker
+  markers : List Marker
   /-- Observed valency of the primary construction -/
-  valency : RecipValency
+  valency : Valency
   /-- Formation locus of verb-marked reciprocals ([siloni-2012]) -/
-  formation : Option RecipFormation := none
+  formation : Option Formation := none
   /-- Attested availability of the discontinuous reciprocal construction
       ([nordlinger-2023] §3.3 judgments), independent of `formation` so
       Siloni's prediction can be checked rather than stipulated -/
@@ -86,11 +86,11 @@ structure RecipProfile where
   deriving Repr, DecidableEq
 
 /-- Primary strategy: the strategy of the inventory's first marker. -/
-def RecipProfile.primaryStrategy (p : RecipProfile) : Option RecipStrategy :=
+def RecipProfile.primaryStrategy (p : RecipProfile) : Option Strategy :=
   p.markers.head?.map (·.strategy)
 
 /-- WALS Ch 106 reflexive relation, derived from the marker inventory. -/
-def RecipProfile.reflexiveRelation (p : RecipProfile) : ReciprocalType :=
+def RecipProfile.reflexiveRelation (p : RecipProfile) : ReflexiveRelation :=
   ofInventory p.markers
 
 -- Language data: 12 reciprocal profiles from [nordlinger-2023]
@@ -409,14 +409,14 @@ markers outside the 12-language sample. -/
 /-- Yakut *-üs*: reciprocal + collective/sociative — *ölör-üs* 'kill
     each other' or 'kill somebody together' ([nordlinger-2023] ex. 49,
     citing [nedjalkov-2007b]). -/
-def yakutUs : ReciprocalMarker :=
+def yakutUs : Marker :=
   { form := "-üs", strategy := .verbalAffix
   , readings := [.reciprocal, .collective, .sociative] }
 
 /-- East Futunan *fe-...-ʼaki*: reciprocal + iterative — *fe-tapa-ʼaki*
     'sparkle again and again' ([nordlinger-2023] ex. 50, citing
     [nedjalkov-2007b]). -/
-def eastFutunanFeAki : ReciprocalMarker :=
+def eastFutunanFeAki : Marker :=
   { form := "fe-...-ʼaki", strategy := .verbalAffix
   , readings := [.reciprocal, .iterative] }
 

--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -30,7 +30,7 @@ embedding.
 
 ## Connections
 
-- `RecipFormation` from `Syntax/Reciprocal.lean` — extended with nine
+- `Formation` from `Syntax/Reciprocal.lean` — extended with nine
   predicted properties and per-language verification
 - `EntailmentProfile` — used to define θ-role bundling
 - `Verb.StratifiesOver` (`Semantics/Verb/Distributivity.lean`) — the same
@@ -63,7 +63,7 @@ inductive RecipClass where
   | syntacticVerb
   deriving DecidableEq, Repr
 
-def toRecipClass : RecipFormation → RecipClass
+def toRecipClass : Formation → RecipClass
   | .lexical  => .lexicalVerb
   | .syntactic => .syntacticVerb
 
@@ -130,7 +130,7 @@ structure PropertyCluster where
     drifted, derive event nominals, head idioms, license discontinuity.
     Cannot form ECM reciprocals or retain accusative on dative targets.
     Property (ix) calls the substrate classifier
-    `RecipFormation.allowsDiscontinuous`, so the two agree by
+    `Formation.allowsDiscontinuous`, so the two agree by
     construction. -/
 def lexicalProperties : PropertyCluster :=
   { singularEvent                := true
@@ -141,7 +141,7 @@ def lexicalProperties : PropertyCluster :=
   , retainsAccOnDativeSuppression := false
   , eventNominals                := true
   , phrasalIdioms                := true
-  , discontinuous                := RecipFormation.lexical.allowsDiscontinuous }
+  , discontinuous                := Formation.lexical.allowsDiscontinuous }
 
 /-- Predicted cluster for syntactically-formed reciprocal verbs.
     Productive, allow ECM and sub-events, can retain accusative on
@@ -156,13 +156,13 @@ def syntacticProperties : PropertyCluster :=
   , retainsAccOnDativeSuppression := true
   , eventNominals                := false
   , phrasalIdioms                := false
-  , discontinuous                := RecipFormation.syntactic.allowsDiscontinuous }
+  , discontinuous                := Formation.syntactic.allowsDiscontinuous }
 
 /-- Derive the predicted property cluster from formation locus.
     Cross-paper verification against [nordlinger-2023]'s `RecipProfile`
     classifications lives in `Studies/Nordlinger2023.lean` (the newer
     paper checks consistency with the older). -/
-def predictedProperties : RecipFormation → PropertyCluster
+def predictedProperties : Formation → PropertyCluster
   | .lexical  => lexicalProperties
   | .syntactic => syntacticProperties
 
@@ -194,13 +194,13 @@ theorem properties_complementary :
     `Verb.StratifiesOver`: *meet* has `¬ meet.StratifiesOver M agentRole`
     — it does not distribute over atomic agents, because the event is
     necessarily collective/atomic. -/
-def isSymmetricVerb (f : RecipFormation) : Prop := f = .lexical
+def isSymmetricVerb (f : Formation) : Prop := f = .lexical
 
 instance : DecidablePred isSymmetricVerb :=
   fun f => inferInstanceAs (Decidable (f = .lexical))
 
 theorem symmetric_iff_singular :
-    ∀ f : RecipFormation,
+    ∀ f : Formation,
       isSymmetricVerb f ↔ (predictedProperties f).singularEvent = true := by
   intro f; cases f <;> simp [isSymmetricVerb, predictedProperties,
     lexicalProperties, syntacticProperties]
@@ -277,7 +277,7 @@ theorem I_reading_iff_periphrastic :
 structure LangRecipVerb where
   language : String
   iso : String
-  formation : RecipFormation
+  formation : Formation
   deriving DecidableEq, Repr
 
 -- Class (ii): lexical reciprocal verbs (symmetric).
@@ -341,14 +341,14 @@ theorem syntactic_not_symmetric :
 
 /-- Step 1: Both reciprocal verb types give the subject two θ-roles
     (lexical via bundling §4.1, syntactic via parasitic assignment §4.2). -/
-theorem recip_verb_dual_role (f : RecipFormation) :
+theorem recip_verb_dual_role (f : Formation) :
     (toRecipClass f).subjectRoleCount = 2 := by
   cases f <;> rfl
 
 /-- Step 2: Singular-event verbs lack the sub-event reading (§2.2–2.3).
     Bridges `PropertyCluster.singularEvent` to
     `RecipClass.allowsSubEventReading`. -/
-theorem singular_event_no_subevents (f : RecipFormation)
+theorem singular_event_no_subevents (f : Formation)
     (h : (predictedProperties f).singularEvent = true) :
     (toRecipClass f).allowsSubEventReading = false := by
   cases f
@@ -389,7 +389,7 @@ theorem syntactic_no_I_reading :
   decide
 
 /-- Both paths converge: neither verb type allows the "I" reading. -/
-theorem no_I_reading_either_formation (f : RecipFormation) :
+theorem no_I_reading_either_formation (f : Formation) :
     (toRecipClass f).allowsIReading = false := by
   cases f
   · exact lexical_no_I_reading

--- a/Linglib/Syntax/Reciprocal.lean
+++ b/Linglib/Syntax/Reciprocal.lean
@@ -10,29 +10,25 @@ import Linglib.Syntax.ArgumentStructure.Alternation
 
 Cross-linguistic vocabulary for reciprocal constructions: the
 reciprocal-reflexive formal relation (WALS Ch 106, [maslova-nedjalkov-2013]),
-the morphosyntactic locus of reciprocal marking ([nordlinger-2023]'s synthesis
-of [konig-kokutani-2006], [nedjalkov-2007a], and [evans-2008]), the valency
-effect, and the formation locus of reciprocal verbs ([siloni-2008],
-[siloni-2012]).
+the marking strategy ([nordlinger-2023]'s synthesis of [konig-kokutani-2006],
+[nedjalkov-2007a], and [evans-2008]), the valency effect, and the formation
+locus of reciprocal verbs ([siloni-2008], [siloni-2012]).
 
-The primitive for a language's exponence is the marker inventory
-(`ReciprocalMarker`): each marker carries its strategy and polysemy readings, and
-the WALS Ch 106 value is *computed* from the inventory (`ofInventory`) rather
-than stipulated per language. Strategy-level classifiers are projections:
-`isNominal` from the coding site, and the default valency effect from the
-coding-frame operation the strategy realizes
+The exponence primitive is the marker (`Marker`): form, strategy, and polysemy
+readings. The WALS Ch 106 value is computed from a language's marker inventory
+(`ofInventory`), `isNominal` projects from the coding site, and the default
+valency effect derives from the coding-frame operation a strategy realizes
 (`Syntax.ArgumentStructure.Alternation.reciprocalization`).
 
 ## Main definitions
 
-* `ReciprocalType` — reciprocal/reflexive formal relation (WALS Ch 106).
-* `RecipStrategy` + `codingSite`/`isNominal` — the morphosyntactic locus.
-* `RecipStrategy.alternation` / `defaultValency` — the realized coding-frame
+* `ReflexiveRelation` — reciprocal/reflexive formal relation (WALS Ch 106).
+* `Strategy` + `codingSite`/`isNominal` — the morphosyntactic locus.
+* `Strategy.alternation` / `defaultValency` — the realized coding-frame
   operation and the valency effect it derives.
-* `RecipValency` — valency effect (bivalent vs monovalent).
-* `RecipFormation` + `RecipFormation.allowsDiscontinuous` — lexical vs syntactic.
-* `RecipMarkerPolysemy`, `ReciprocalMarker`, `ofInventory` — marker inventories and
-  the derived WALS Ch 106 value.
+* `Valency`, `Formation` + `Formation.allowsDiscontinuous`.
+* `Reading`, `Marker`, `ofInventory` — marker inventories and the derived
+  WALS Ch 106 value.
 
 Per-language inventories live in `Fragments/{Lang}/Reciprocals.lean`;
 WALS-data grounding lives with the studies that use it (e.g.
@@ -41,186 +37,131 @@ WALS-data grounding lives with the studies that use it (e.g.
 
 namespace Reciprocal
 
-/-- WALS Ch 106: how reciprocal situations are encoded relative to reflexives.
-The four values follow [maslova-nedjalkov-2013]'s classification. -/
-inductive ReciprocalType where
-  /-- "There are no non-iconic reciprocal constructions" — the language lacks
-      a dedicated grammatical reciprocal marker. -/
+/-- WALS Ch 106 relation between reciprocal and reflexive marking
+([maslova-nedjalkov-2013]). -/
+inductive ReflexiveRelation where
+  /-- "There are no non-iconic reciprocal constructions." -/
   | noDedicated
   /-- "All reciprocal constructions are formally distinct from reflexive
-      constructions" (e.g. English *each other* vs *themselves*). -/
+      constructions" (English *each other* vs *themselves*). -/
   | distinctFromReflexive
-  /-- "There are both reflexive and non-reflexive reciprocal constructions" —
-      a reflexive-identical strategy coexists with a formally distinct one
-      (e.g. German *sich* + *einander*). Common in Europe. -/
+  /-- "There are both reflexive and non-reflexive reciprocal constructions"
+      (German *sich* + *einander*). -/
   | mixed
   /-- "The reciprocal and reflexive constructions are formally identical"
-      (e.g. Imbabura Quechua *-ri-*). -/
+      (Imbabura Quechua *-ri-*). -/
   | identicalToReflexive
   deriving DecidableEq, Repr
 
-/-- Morphosyntactic strategy for encoding reciprocity, following the strategy
-inventory of [nordlinger-2023] §3.1, which compresses the structural
-typologies of [konig-kokutani-2006], [nedjalkov-2007a], and [evans-2008]
-(Evans's full typology is finer, splitting NP-marking into five subtypes and
-treating verb compounding as multiclausal). -/
-inductive RecipStrategy where
-  /-- Bipartite quantifier NP — English *each other*, Russian *drug druga*,
-      Icelandic *hvort annað* (parts independently inflected,
-      [hurst-nordlinger-2021]). -/
+/-- Morphosyntactic strategy for encoding reciprocity ([nordlinger-2023]
+§3.1's compression of [konig-kokutani-2006], [nedjalkov-2007a], and
+[evans-2008]). -/
+inductive Strategy where
+  /-- Bipartite quantifier NP (English *each other*, Icelandic *hvort annað*). -/
   | bipartiteNP
-  /-- Reciprocal pronoun — Hausa *jūnan-mù*. Free or bound pronominal form in
-      argument position. -/
+  /-- Reciprocal pronoun (Hausa *jūnan-mù*). -/
   | recipPronoun
-  /-- Reciprocal clitic — French/Czech *se*, Wambaya *-ngg-* (RR morpheme in
-      the auxiliary, [nordlinger-1998]). Intermediate between pronoun and
-      affix. -/
+  /-- Reciprocal clitic (French *se*, Wambaya *-ngg-*). -/
   | recipClitic
-  /-- Morphological marking on the verb — Swahili *-an-*, Hungarian *-óz-*,
-      Chicheŵa *-an-*. Typically derives a monovalent verb from a transitive
-      base. -/
+  /-- Verbal affix (Swahili *-an-*, Hungarian *-óz-*). -/
   | verbalAffix
-  /-- Reciprocal auxiliary — Warrwa *wanji-* 'exchange' replaces the regular
-      transitive auxiliary ([evans-2008]). -/
+  /-- Reciprocal auxiliary (Warrwa *wanji-* 'exchange', [evans-2008]). -/
   | verbalAuxiliary
-  /-- Inherently reciprocal predicate — English *quarrel*, *meet*. The
-      symmetric meaning is part of the verb's lexical semantics. -/
+  /-- Inherently reciprocal predicate (English *quarrel*, *meet*). -/
   | lexical
-  /-- Compound verb — Mandarin *dǎ-lái-dǎ-qù* (beat-come-beat-go = 'beat each
-      other', [konig-kokutani-2006]). -/
+  /-- Compound verb (Mandarin *dǎ-lái-dǎ-qù*, [konig-kokutani-2006]). -/
   | compoundVerb
   deriving DecidableEq, Repr
 
-/-- Valency effect of the reciprocal construction ([nordlinger-2023] §3.2):
-syntactically bivalent constructions keep two overt argument slots, while
-monovalent ones express all reciprocants in the subject. NP/argument
-strategies tend to preserve valency and verb-marked strategies to reduce it
-([nedjalkov-2007a]), but the correlation is a tendency, not absolute:
-Malagasy verb-marked reciprocals retain full valency at f-structure
-([hurst-2006], [hurst-2012]), and Tonga combines verbal marking with two
-argument NPs ([maslova-2008]). [maslova-2008]'s unary/binary distinction
-cross-cuts this one: English *each other* is bivalent yet unary (the object
-slot is filled by a fixed expression). -/
-inductive RecipValency where
+/-- Valency effect of the reciprocal construction ([nordlinger-2023] §3.2). -/
+inductive Valency where
   /-- Two overt syntactic argument slots preserved. -/
   | bivalent
-  /-- The verb becomes intransitive; reciprocants form a single subject NP. -/
+  /-- The reciprocants form a single subject NP. -/
   | monovalent
   deriving DecidableEq, Repr
 
-/-- Where the reciprocal marking sits: an argument position, the
-verb/auxiliary complex, or a fused multipredicate structure (which
-[evans-2008] treats as multiclausal). -/
+/-- Coding site of reciprocal marking: argument position, predicate, or
+fused multipredicate structure. -/
 inductive CodingSite where
   | argument
   | predicate
   | multiclausal
   deriving DecidableEq, Repr
 
-/-- Coding site of each strategy. Deviation from [konig-kokutani-2006]:
-they group clitics with the nominal strategies, but this projection places
-`recipClitic` on the predicate side because Romance/Slavic *se* is not an
-anaphoric object — it marks a valency-reducing operation on the verb
-([siloni-2012]). Wambaya *-ngg-* is the documented exception: a bound clitic
-whose clause stays bivalent ([evans-et-al-2007]). -/
-def RecipStrategy.codingSite : RecipStrategy → CodingSite
+/-- Coding site of each strategy. Clitics sit on the predicate side,
+following [siloni-2012] rather than [konig-kokutani-2006]'s nominal
+grouping. -/
+def Strategy.codingSite : Strategy → CodingSite
   | .bipartiteNP | .recipPronoun => .argument
   | .recipClitic | .verbalAffix | .verbalAuxiliary | .lexical => .predicate
   | .compoundVerb => .multiclausal
 
-/-- Whether the strategy marks a (nonsubject) argument position, in the sense
-of [nordlinger-2023] §3.2's NP/argument vs verb-marked split — the projection
-`codingSite == .argument`. -/
-def RecipStrategy.isNominal (s : RecipStrategy) : Bool :=
+/-- Whether the strategy marks a (nonsubject) argument position
+([nordlinger-2023] §3.2). -/
+def Strategy.isNominal (s : Strategy) : Bool :=
   s.codingSite == .argument
 
 open Syntax.ArgumentStructure.Alternation in
 /-- The coding-frame operation a strategy realizes: grammatical verb-marking
-strategies (clitic, affix, auxiliary, compound) apply [creissels-2025]'s
-denucleativizing `reciprocalization`; argument-position strategies leave the
-frame untouched, and inherently reciprocal lexical entries are not derived by
-a coding-frame operation at all (their formation is `RecipFormation`'s
-business). -/
-def RecipStrategy.alternation : RecipStrategy → Option ValencyAlternation
+strategies apply [creissels-2025]'s denucleativizing `reciprocalization`. -/
+def Strategy.alternation : Strategy → Option ValencyAlternation
   | .recipClitic | .verbalAffix | .verbalAuxiliary | .compoundVerb =>
       some reciprocalization
   | .bipartiteNP | .recipPronoun | .lexical => none
 
-/-- Default valency effect of a strategy, derived from the realized
-coding-frame operation: strategies applying `reciprocalization` inherit its
-detransitivizing effect (`derivedTransitive = some false`); argument
-strategies preserve the frame. A default, not a law — Wambaya's ergative-
-retaining clitic, Tonga's bivalent verbal marking ([maslova-2008]), and
-Malagasy's f-structure bivalency ([hurst-2006], [hurst-2012]) override it. -/
-def RecipStrategy.defaultValency (s : RecipStrategy) : RecipValency :=
+/-- Default valency effect, derived from the realized alternation's
+`derivedTransitive` field; a tendency that languages may override
+(Wambaya, Tonga, Malagasy — [maslova-2008], [hurst-2012]). -/
+def Strategy.defaultValency (s : Strategy) : Valency :=
   match s.alternation with
   | some a => if a.derivedTransitive = some false then .monovalent else .bivalent
   | none   => .bivalent
 
-/-- Where reciprocal verbs are formed, per [siloni-2008] and [siloni-2012]
-(the lex-syn parameter of [reinhart-siloni-2005]):
-
-- `lexical`: formed in the lexicon through "bundling" — two thematic roles
-  (agent, patient) merge into a single complex role, yielding symmetric verbs
-  whose reciprocity is a singular atomic event.
-- `syntactic`: formed in the course of the syntactic derivation (Romance and
-  some Slavic *se* verbs); reciprocity accumulates from sub-events.
-
-Siloni's discontinuity generalization: discontinuous reciprocal constructions
-(reciprocants split across subject and comitative argument) occur only with
-lexically formed reciprocal verbs. -/
-inductive RecipFormation where
+/-- Formation locus of reciprocal verbs: lexical θ-role bundling vs
+syntactic derivation ([siloni-2008], [siloni-2012];
+[reinhart-siloni-2005]'s lex-syn parameter). -/
+inductive Formation where
   | lexical
   | syntactic
   deriving DecidableEq, Repr
 
-/-- Whether the formation type licenses the discontinuous reciprocal
-construction ("John kissed with Mary") — available only for lexically formed
-reciprocal verbs ([siloni-2012] §7; [nordlinger-2023] §3.3). A language-level
-availability claim: individual lexical reciprocals may still resist it, e.g.
-English *kiss*/*hug* ([siloni-2012], fn. 32). -/
-def RecipFormation.allowsDiscontinuous : RecipFormation → Bool
+/-- Whether the formation licenses the discontinuous reciprocal
+construction — lexical only ([siloni-2012] §7; verb-level exceptions
+exist, fn. 32). -/
+def Formation.allowsDiscontinuous : Formation → Bool
   | .lexical   => true
   | .syntactic => false
 
 /-! ### Marker inventories -/
 
-/-- Extended readings a reciprocal marker can carry beyond core reciprocity
-([nordlinger-2023] §4.2; [nedjalkov-2007b]): reflexive (the WALS Ch 106
-overlap), collective, sociative, and iterative. -/
-inductive RecipMarkerPolysemy where
-  /-- Core mutual action reading. -/
+/-- Readings a reciprocal marker can carry ([nordlinger-2023] §4.2,
+[nedjalkov-2007b]). -/
+inductive Reading where
   | reciprocal
-  /-- Same-participant reading (overlap with reflexives). -/
   | reflexive
-  /-- Joint action without mutual entailment. -/
   | collective
-  /-- Joint/associative action ('together'). -/
   | sociative
-  /-- Repeated action ('again and again'). -/
   | iterative
   deriving DecidableEq, Repr
 
-/-- A reciprocal exponent: its form, morphosyntactic strategy, and the
-readings it covers. A language's reciprocal system is a `List ReciprocalMarker`
-(primary strategy first). -/
-structure ReciprocalMarker where
+/-- A reciprocal exponent: form, strategy, and the readings it covers. -/
+structure Marker where
   /-- Surface form (romanization or orthographic). -/
   form : String
   /-- Native-script form, when `form` is a romanization. -/
   script : Option String := none
   /-- Morphosyntactic strategy of the exponent. -/
-  strategy : RecipStrategy
+  strategy : Strategy
   /-- Readings the marker covers. -/
-  readings : List RecipMarkerPolysemy := [.reciprocal]
+  readings : List Reading := [.reciprocal]
   deriving DecidableEq, Repr
 
-/-- The WALS Ch 106 value computed from a marker inventory: no
-reciprocal-capable marker → `noDedicated`; all reciprocal markers also
-reflexive → `identicalToReflexive`; none reflexive → `distinctFromReflexive`;
-both kinds → `mixed`. (Purely iconic strategies, which WALS also counts as
-`noDedicated`, are outside the inventory vocabulary.) -/
-def ofInventory (inv : List ReciprocalMarker) : ReciprocalType :=
+/-- WALS Ch 106 value computed from a marker inventory: no
+reciprocal-capable marker → `noDedicated`; all also reflexive →
+`identicalToReflexive`; none reflexive → `distinctFromReflexive`;
+both kinds → `mixed`. -/
+def ofInventory (inv : List Marker) : ReflexiveRelation :=
   let recips := inv.filter (·.readings.contains .reciprocal)
   if recips.isEmpty then .noDedicated
   else if recips.all (·.readings.contains .reflexive) then .identicalToReflexive


### PR DESCRIPTION
Recovers the commit stranded when #1312 merged early, unchanged in content.

- De-stutter within `namespace Reciprocal`: `Strategy`, `Valency`, `Formation`, `Reading`, `Marker`, `ReflexiveRelation` (generated `Data.WALS.F106A.ReciprocalType` unchanged).
- No pseudo-markers: English lexical reciprocals are marked predicates (`lexicalReciprocals := [meet]` referencing the `VerbEntry`) and correctly excluded from `ofInventory`; Greek's marker cites the `-ome` allomorph of the fragment's `nonactiveVoiceSuffix` rather than a category name.
- Substrate decl docstrings trimmed to mathlib one-liners.