### PR TITLE
refactor(Syntax/Voice): dissolve ArgumentStructure/, two-axis voice area

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2785,7 +2785,6 @@ import Linglib.Syntax.Agreement.Controller
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Anaphora.Basic
 import Linglib.Syntax.Anaphora.Diagnostic
-import Linglib.Syntax.ArgumentStructure.Alternation
 import Linglib.Syntax.AuxiliaryVerbs
 import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Binding.Semantics
@@ -2936,6 +2935,7 @@ import Linglib.Syntax.RelativeClause.WALS
 import Linglib.Syntax.SynGraph
 import Linglib.Syntax.Tree.Basic
 import Linglib.Syntax.Tree.Cat
+import Linglib.Syntax.Voice.Alternation
 import Linglib.Syntax.Voice.Basic
 import Linglib.Syntax.Voice.Middle
 import Linglib.Syntax.WordGrammar.Inheritance.Basic

--- a/Linglib/Fragments/Dargwa/ComplexPredicates.lean
+++ b/Linglib/Fragments/Dargwa/ComplexPredicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.ArgumentStructure.Alternation
+import Linglib.Syntax.Voice.Alternation
 import Linglib.Semantics.Verb.Root.Template
 
 /-!
@@ -214,8 +214,8 @@ theorem tr_causative_elat_causee :
 
     This maps to [creissels-2025]'s `antipassivization`: A is
     maintained (becomes S), P is denucleativized. -/
-def antipassive : Syntax.ArgumentStructure.Alternation.ValencyAlternation :=
-  Syntax.ArgumentStructure.Alternation.antipassivization
+def antipassive : Voice.ValencyAlternation :=
+  Voice.antipassivization
 
 /-- Dargwa P-lability: many transitive verbs can be used intransitively
     without morphological marking ([sumbatova-2021] §4.7.3, ex. 87).
@@ -225,14 +225,14 @@ def antipassive : Syntax.ArgumentStructure.Alternation.ValencyAlternation :=
 
     Maps to [creissels-2025]'s `P_ambitransitivity`: uncoded
     decausativization where S = initial P. -/
-def pLability : Syntax.ArgumentStructure.Alternation.AmbitransitivityType :=
+def pLability : Voice.AmbitransitivityType :=
   .P_ambitransitivity
 
 /-- Dargwa causative (-aq) applied to intransitive bases maps to
     Creissels' causativization: S is maintained as P, a new A (causer)
     is introduced. -/
-def causativeAlternation : Syntax.ArgumentStructure.Alternation.ValencyAlternation :=
-  Syntax.ArgumentStructure.Alternation.causativization
+def causativeAlternation : Voice.ValencyAlternation :=
+  Voice.causativization
 
 /-- The antipassive is valency-decreasing (P is denucleativized). -/
 theorem antipassive_decreases :

--- a/Linglib/Studies/Bohnemeyer2004.lean
+++ b/Linglib/Studies/Bohnemeyer2004.lean
@@ -1,6 +1,6 @@
 import Linglib.Fragments.Mayan.Yukatek.VerbClasses
 import Linglib.Semantics.Lexical.EventStructure
-import Linglib.Syntax.ArgumentStructure.Alternation
+import Linglib.Syntax.Voice.Alternation
 
 /-!
 # Bohnemeyer 2004: Split intransitivity, linking, and lexical representation
@@ -363,12 +363,12 @@ theorem inactive_split_by_causation :
 /-! ### Bridge to detransitivization
 
 The three Yukatek detransitivizations are instances of the cross-linguistic
-valency-alternation typology (`Syntax/ArgumentStructure/Alternation.lean`).
+valency-alternation typology (`Syntax/Voice/Alternation.lean`).
 That substrate keeps passive and anticausative distinct by the fate of the
 initial A — passive *denucleativizes* it (retained in participant structure as
 a possible oblique agent), anticausative *suppresses* it (removed entirely). -/
 
-open Syntax.ArgumentStructure.Alternation
+open Voice
   (ValencyAlternation antipassivization decausativization passivization)
 
 /-- Detransitivization type in Yukatek, from rules (28)–(30).

--- a/Linglib/Studies/Chierchia1984.lean
+++ b/Linglib/Studies/Chierchia1984.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.ArgumentStructure.Alternation
+import Linglib.Syntax.Voice.Alternation
 import Linglib.Semantics.Modality.Kratzer.Flavor
 import Linglib.Semantics.Composition.TypeShifting
 import Linglib.Studies.Landau2015
@@ -402,7 +402,7 @@ The derivation has three steps:
    semantic controller.
 
 2. **What does the alternation do to that argument?** Passivization
-   denucleativizes A and maintains P (`Syntax.ArgumentStructure.Alternation.passivization`).
+   denucleativizes A and maintains P (`Voice.passivization`).
    Antipassivization (detransitivization) denucleativizes P and maintains A.
 
 3. **Does removing the controller break the CP?** If the alternation
@@ -410,9 +410,9 @@ The derivation has three steps:
    satisfied → the alternation is blocked.
 
 This replaces the stipulated `predictedPassivizable` case-split with a
-derivation from `Syntax.ArgumentStructure.Alternation.passivization` and `ControlType`. -/
+derivation from `Voice.passivization` and `ControlType`. -/
 
-open Syntax.ArgumentStructure.Alternation
+open Voice
 
 /-- Which TR-role serves as the controller, per [chierchia-1984]'s CP.
 

--- a/Linglib/Studies/Creissels2025.lean
+++ b/Linglib/Studies/Creissels2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.ArgumentStructure.Alternation
+import Linglib.Syntax.Voice.Alternation
 import Linglib.Semantics.Causation.Morphological
 import Linglib.Syntax.Voice.Basic
 import Linglib.Syntax.Minimalist.Verbal.Applicative
@@ -23,7 +23,7 @@ languages. The book proposes a unified framework based on:
   where the same morpheme marks multiple voice alternation types (§8.2)
 
 This study file bridges [creissels-2025]'s framework (formalized in
-`Syntax/ArgumentStructure/Alternation.lean`) to existing linglib infrastructure:
+`Syntax/Voice/Alternation.lean`) to existing linglib infrastructure:
 
 - `Semantics/Causation/Morphological.lean`: causativization and decausativization
 - `Typology/VoiceSystem.lean`: pivot-based voice system typology
@@ -32,7 +32,7 @@ This study file bridges [creissels-2025]'s framework (formalized in
 
 namespace Creissels2025
 
-open Syntax.ArgumentStructure.Alternation
+open Voice
 open Causation.Morphological
   (IntransitivizationType CausativeComplexity CausativeConstruction
    CausativizabilityData)

--- a/Linglib/Studies/KoontzGarboden2009.lean
+++ b/Linglib/Studies/KoontzGarboden2009.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Causation.Morphological
 import Linglib.Semantics.Lexical.EventStructure
 import Linglib.Fragments.Spanish.Predicates
-import Linglib.Syntax.ArgumentStructure.Alternation
+import Linglib.Syntax.Voice.Alternation
 
 -- ============================================================================
 -- § 0: Monotonicity Hypothesis Substrate
@@ -156,7 +156,7 @@ open Causation.Morphological
 open Semantics.Lexical.EventStructure
 open KoontzGarboden2009.Monotonicity
 open Minimalist (VerbHead)
-open Syntax.ArgumentStructure.Alternation
+open Voice
 
 -- ════════════════════════════════════════════════════
 -- § 1. The Reflexivization Operator (§2.2)

--- a/Linglib/Syntax/Minimalist/Verbal/Voice.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Voice.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Minimalist.Agree.Basic
 import Linglib.Syntax.Minimalist.Verbal.Decomposition
 import Linglib.Semantics.ArgumentStructure.Linking
+import Linglib.Syntax.Voice.Alternation
 
 /-!
 # Voice Head Flavors
@@ -74,6 +75,22 @@ inductive VoiceFlavor where
   | reflexive    -- [+θ, +D]: agent binds the internal argument (Romance se)
   | experiencer  -- [+θ, +D]: introduces an experiencer external argument (psych causatives)
   deriving DecidableEq, Repr
+
+/-- The coding-frame operation each Voice flavor realizes, projecting the
+    Minimalist head onto [creissels-2025]'s valency alternations
+    (`Syntax/Voice/Alternation.lean`): passive Voice denucleativizes A,
+    antipassive denucleativizes P, reflexive/causer/impersonal map to
+    their typological counterparts. `none` for flavors that leave the
+    coding frame intact (agentive, experiencer) or whose effect is not a
+    valency operation (expletive middle). -/
+def VoiceFlavor.alternation : VoiceFlavor → Option _root_.Voice.ValencyAlternation
+  | .causer      => some _root_.Voice.causativization
+  | .nonThematic => some _root_.Voice.decausativization
+  | .impersonal  => some _root_.Voice.iPassivization
+  | .passive     => some _root_.Voice.passivization
+  | .antipassive => some _root_.Voice.antipassivization
+  | .reflexive   => some _root_.Voice.reflexivization
+  | .agentive | .expletive | .experiencer => none
 
 /-- The default phasehood for each Voice flavor under the
     Collins-2005 / Chomsky-2001 baseline: agentive, causer, reflexive,

--- a/Linglib/Syntax/Reciprocal.lean
+++ b/Linglib/Syntax/Reciprocal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Syntax.ArgumentStructure.Alternation
+import Linglib.Syntax.Voice.Alternation
 
 /-!
 # Reciprocal constructions: morphosyntactic typology
@@ -18,7 +18,7 @@ The exponence primitive is the marker (`Marker`): form, strategy, and polysemy
 readings. The WALS Ch 106 value is computed from a language's marker inventory
 (`ofInventory`), `isNominal` projects from the coding site, and the default
 valency effect derives from the coding-frame operation a strategy realizes
-(`Syntax.ArgumentStructure.Alternation.reciprocalization`).
+(`Voice.reciprocalization`).
 
 ## Main definitions
 
@@ -102,7 +102,7 @@ def Strategy.codingSite : Strategy → CodingSite
 def Strategy.isNominal (s : Strategy) : Bool :=
   s.codingSite == .argument
 
-open Syntax.ArgumentStructure.Alternation in
+open Voice in
 /-- The coding-frame operation a strategy realizes: grammatical verb-marking
 strategies apply [creissels-2025]'s denucleativizing `reciprocalization`. -/
 def Strategy.alternation : Strategy → Option ValencyAlternation

--- a/Linglib/Syntax/Voice/Alternation.lean
+++ b/Linglib/Syntax/Voice/Alternation.lean
@@ -22,6 +22,15 @@ This file is substrate: it defines the alternation *types*. Per-paper data and
 cross-linguistic distributions live in the consuming study files (e.g.
 `Studies/Creissels2025.lean`).
 
+Within `Syntax/Voice/` this file owns the **valency axis** (what happens to
+the coding frame); `Basic.lean` owns the **pivot axis** (which argument is
+the privileged one — orthogonal to valency, as Austronesian symmetrical
+voice shows); `Middle.lean` is the interaction case. "Voice" in
+[creissels-2025]'s sense is the *coded* subset of the alternations here
+(`AlternationMarking.isVoice`); the Voice functional head of Minimalist
+syntax projects onto these operations via
+`VoiceFlavor.alternation` (`Syntax/Minimalist/Verbal/Voice.lean`).
+
 ## TR-roles
 
 [creissels-2025] §1.3.3 defines Transitivity-Related roles (A, P, S, X)
@@ -53,7 +62,7 @@ while [creissels-2025]'s voice alternations are *coded* (marked by
 verbal morphology). The `marking` field captures this.
 -/
 
-namespace Syntax.ArgumentStructure.Alternation
+namespace Voice
 
 open Features.Prominence (ArgumentRole)
 open Semantics.Lexical (DiathesisAlternation)
@@ -807,4 +816,4 @@ theorem p_ambi_is_uncoded_decausativization :
 theorem a_ambi_is_uncoded_antipassivization :
     antipassivization.involvesDenucleativization = true := rfl
 
-end Syntax.ArgumentStructure.Alternation
+end Voice

--- a/Linglib/Syntax/Voice/Basic.lean
+++ b/Linglib/Syntax/Voice/Basic.lean
@@ -7,7 +7,11 @@ import Linglib.Syntax.Extraction
 
 Theory-neutral types for cross-linguistic voice-system typology — how languages
 map argument roles to a privileged syntactic position (the "pivot") via voice
-alternation. Per-language data are bare `def voices : List VoiceEntry` and
+alternation. This is the **pivot axis** of the `Syntax/Voice/` area; the
+**valency axis** (coding-frame operations: passivization, antipassivization,
+causativization, …) is `Alternation.lean`, and the two are orthogonal —
+symmetrical voice remaps the pivot without changing valency, while e.g. a
+passive does both. Per-language data are bare `def voices : List VoiceEntry` and
 `def symmetry : VoiceSystemSymmetry` in `Fragments/<Lang>/…`; the queries below
 operate on the voice list.
 


### PR DESCRIPTION
Dissolves `Syntax/ArgumentStructure/` (residue of the dissolved Typology drawer; its sibling Reciprocal.lean moved out in #1311).

- `Alternation.lean` → `Syntax/Voice/Alternation.lean`, namespace `Voice`; the directory now states its two-axis division: valency axis (Alternation) vs pivot axis (Basic), Middle as the interaction case.
- New `VoiceFlavor.alternation` projects the Minimalist Voice head onto Creissels's coding-frame operations (passive → passivization, impersonal → iPassivization, nonThematic → decausativization, …), cross-wiring the third sense of "voice".