### PR TITLE
feat(Syntax/Minimalist): reciprocal Voice flavor, de-stutter Voice names

### DIFF
--- a/Linglib/Fragments/Finnish/Predicates.lean
+++ b/Linglib/Fragments/Finnish/Predicates.lean
@@ -14,7 +14,7 @@ Finnish verbs illustrate two phenomena that exercise linglib's infrastructure:
    Active: *Mies avasi oven.* 'The man opened the door.'
    "Passive": *Ovi avattiin.* 'The door was opened (by someone).'
 
-   This is formalized using `Voice.Flavor.impersonal`, distinct from both
+   This is formalized using `Flavor.impersonal`, distinct from both
    `nonThematic` (anticausative, no agent at all) and `agentive` (syntactically
    projected agent).
 
@@ -27,7 +27,7 @@ Finnish verbs illustrate two phenomena that exercise linglib's infrastructure:
 
 namespace Finnish.Predicates
 
-open Minimalist (Voice.Flavor Voice.Head Voice.agentive Voice.impersonal)
+open Minimalist.Voice (Flavor Head agentive impersonal)
 
 -- ============================================================================
 -- § 1: Verb Entry Type
@@ -94,12 +94,12 @@ def haluta : FinnishVerb :=
 -- ============================================================================
 
 /-- Active Finnish voice: agentive, projects a syntactic agent. -/
-def finnishActive : Voice.Head := Voice.agentive
+def finnishActive : Head := agentive
 
 /-- Finnish "passive" voice: impersonal, no syntactic agent specifier.
     The agent is existentially closed — someone performs the action,
     but the someone is not a syntactic argument. -/
-def finnishPassive : Voice.Head := Voice.impersonal
+def finnishPassive : Head := impersonal
 
 -- ============================================================================
 -- § 4: Verification Theorems

--- a/Linglib/Fragments/Finnish/Predicates.lean
+++ b/Linglib/Fragments/Finnish/Predicates.lean
@@ -14,7 +14,7 @@ Finnish verbs illustrate two phenomena that exercise linglib's infrastructure:
    Active: *Mies avasi oven.* 'The man opened the door.'
    "Passive": *Ovi avattiin.* 'The door was opened (by someone).'
 
-   This is formalized using `VoiceFlavor.impersonal`, distinct from both
+   This is formalized using `Voice.Flavor.impersonal`, distinct from both
    `nonThematic` (anticausative, no agent at all) and `agentive` (syntactically
    projected agent).
 
@@ -27,7 +27,7 @@ Finnish verbs illustrate two phenomena that exercise linglib's infrastructure:
 
 namespace Finnish.Predicates
 
-open Minimalist (VoiceFlavor VoiceHead voiceAgent voiceImpersonal)
+open Minimalist (Voice.Flavor Voice.Head Voice.agentive Voice.impersonal)
 
 -- ============================================================================
 -- § 1: Verb Entry Type
@@ -94,12 +94,12 @@ def haluta : FinnishVerb :=
 -- ============================================================================
 
 /-- Active Finnish voice: agentive, projects a syntactic agent. -/
-def finnishActive : VoiceHead := voiceAgent
+def finnishActive : Voice.Head := Voice.agentive
 
 /-- Finnish "passive" voice: impersonal, no syntactic agent specifier.
     The agent is existentially closed — someone performs the action,
     but the someone is not a syntactic argument. -/
-def finnishPassive : VoiceHead := voiceImpersonal
+def finnishPassive : Voice.Head := Voice.impersonal
 
 -- ============================================================================
 -- § 4: Verification Theorems
@@ -121,7 +121,7 @@ theorem passive_not_phase : ¬ finnishPassive.IsPhasal := by decide
 /-- Finnish "passive" is distinct from anticausative — both lack a syntactic
     agent, but impersonal Voice has semantics while nonThematic does not. -/
 theorem impersonal_vs_anticausative :
-    finnishPassive.HasSemantics ∧ ¬ Minimalist.voiceAnticausative.HasSemantics :=
+    finnishPassive.HasSemantics ∧ ¬ Minimalist.Voice.anticausative.HasSemantics :=
   by decide
 
 /-- All impersonal forms end in *-aan* or *-ään* (back or front harmony on

--- a/Linglib/Fragments/Indonesian/VoiceSystem.lean
+++ b/Linglib/Fragments/Indonesian/VoiceSystem.lean
@@ -48,7 +48,7 @@ agent is the surface subject) and expletive-like behavior
 namespace Indonesian.VoiceSystem
 
 open Voice (VoiceEntry PivotTarget VoiceSystemSymmetry)
-open Minimalist (VoiceParams ExternalArgSemantics VoiceFlavor)
+open Minimalist (Voice.Params Voice.ExternalArgSemantics Voice.Flavor)
 
 -- ============================================================================
 -- § 1: Voice Entries (descriptive, theory-neutral)
@@ -86,7 +86,7 @@ def symmetry : VoiceSystemSymmetry := .asymmetrical
 
 /-- *meN-* parameters: active Voice[+D, +λx].
     Projects a full DP external argument and introduces agent semantics. -/
-def menParams : VoiceParams :=
+def menParams : Voice.Params :=
   { selectsSpecifier := some true
   , extArgSemantics := some .thematicArgument }
 
@@ -102,7 +102,7 @@ def menParams : VoiceParams :=
     *di-* in the [+D, +∃x] cell — specifier selected, agent existentially
     bound — rather than the [+D, −λx] cell occupied by English passive
     and Romance anticausative SE. -/
-def diParams : VoiceParams :=
+def diParams : Voice.Params :=
   { selectsSpecifier := some true
   , extArgSemantics := some .thematicExistential }
 
@@ -111,7 +111,7 @@ def diParams : VoiceParams :=
     independent argument realization strategies (incorporation vs.
     functional application) and lexical semantic/pragmatic factors
     ([beavers-udayana-2022]: §3). -/
-def berParams : VoiceParams :=
+def berParams : Voice.Params :=
   { selectsSpecifier := none
   , extArgSemantics := none }
 
@@ -133,7 +133,7 @@ theorem ber_underspecified : berParams.isFullySpecified = false := rfl
 
 /-- *meN-* maps to the same cell as Minimalist agentive Voice. -/
 theorem men_is_agentive :
-    menParams = VoiceFlavor.agentive.toParams := rfl
+    menParams = Voice.Flavor.agentive.toParams := rfl
 
 /-- *di-* occupies the [+D, +∃x] cell — a specifier that introduces an
     existentially bound participant. This is distinct from English passive
@@ -144,9 +144,9 @@ theorem di_has_existential_agent :
 theorem di_selects_specifier :
     diParams.selectsSpecifier = some true := rfl
 
-/-- *ber-* is compatible with EVERY named VoiceFlavor — the defining
+/-- *ber-* is compatible with EVERY named Voice.Flavor — the defining
     property of an underspecified voice morpheme. -/
-theorem ber_compatible_with_all (f : VoiceFlavor) :
+theorem ber_compatible_with_all (f : Voice.Flavor) :
     berParams.isCompatibleWith f.toParams = true := by
   cases f <;> rfl
 

--- a/Linglib/Fragments/Indonesian/VoiceSystem.lean
+++ b/Linglib/Fragments/Indonesian/VoiceSystem.lean
@@ -48,7 +48,7 @@ agent is the surface subject) and expletive-like behavior
 namespace Indonesian.VoiceSystem
 
 open Voice (VoiceEntry PivotTarget VoiceSystemSymmetry)
-open Minimalist (Voice.Params Voice.ExternalArgSemantics Voice.Flavor)
+open Minimalist.Voice (Params ExternalArgSemantics Flavor)
 
 -- ============================================================================
 -- § 1: Voice Entries (descriptive, theory-neutral)
@@ -86,7 +86,7 @@ def symmetry : VoiceSystemSymmetry := .asymmetrical
 
 /-- *meN-* parameters: active Voice[+D, +λx].
     Projects a full DP external argument and introduces agent semantics. -/
-def menParams : Voice.Params :=
+def menParams : Params :=
   { selectsSpecifier := some true
   , extArgSemantics := some .thematicArgument }
 
@@ -102,7 +102,7 @@ def menParams : Voice.Params :=
     *di-* in the [+D, +∃x] cell — specifier selected, agent existentially
     bound — rather than the [+D, −λx] cell occupied by English passive
     and Romance anticausative SE. -/
-def diParams : Voice.Params :=
+def diParams : Params :=
   { selectsSpecifier := some true
   , extArgSemantics := some .thematicExistential }
 
@@ -111,7 +111,7 @@ def diParams : Voice.Params :=
     independent argument realization strategies (incorporation vs.
     functional application) and lexical semantic/pragmatic factors
     ([beavers-udayana-2022]: §3). -/
-def berParams : Voice.Params :=
+def berParams : Params :=
   { selectsSpecifier := none
   , extArgSemantics := none }
 
@@ -133,7 +133,7 @@ theorem ber_underspecified : berParams.isFullySpecified = false := rfl
 
 /-- *meN-* maps to the same cell as Minimalist agentive Voice. -/
 theorem men_is_agentive :
-    menParams = Voice.Flavor.agentive.toParams := rfl
+    menParams = Flavor.agentive.toParams := rfl
 
 /-- *di-* occupies the [+D, +∃x] cell — a specifier that introduces an
     existentially bound participant. This is distinct from English passive
@@ -144,9 +144,9 @@ theorem di_has_existential_agent :
 theorem di_selects_specifier :
     diParams.selectsSpecifier = some true := rfl
 
-/-- *ber-* is compatible with EVERY named Voice.Flavor — the defining
+/-- *ber-* is compatible with EVERY named Flavor — the defining
     property of an underspecified voice morpheme. -/
-theorem ber_compatible_with_all (f : Voice.Flavor) :
+theorem ber_compatible_with_all (f : Flavor) :
     berParams.isCompatibleWith f.toParams = true := by
   cases f <;> rfl
 

--- a/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
+++ b/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
@@ -342,10 +342,10 @@ theorem eqya_island_sensitive_derived :
 
 /-- =(y)a' co-occurs with passive voice morphology (*-njtz*).
     This is encoded as empirical data: `passiveOblExtraction.judgment =.licensed`.
-    The co-occurrence is *derivable* from VoiceHead field independence:
-    passive *-njtz* is conditioned by VoiceFlavor, while =(y)a' is
+    The co-occurrence is *derivable* from Voice.Head field independence:
+    passive *-njtz* is conditioned by Voice.Flavor, while =(y)a' is
     conditioned by features ([+oblique]). These are independent fields
-    in VoiceHead, so changing the flavor does not affect the features.
+    in Voice.Head, so changing the flavor does not affect the features.
     See `MinimalismOblExtraction.eqya_not_agent_focus` for the structural
     derivation.
     Elkins et al. §7.2, ex. (53)–(54). -/

--- a/Linglib/Fragments/Mayan/Mam/VoiceSystem.lean
+++ b/Linglib/Fragments/Mayan/Mam/VoiceSystem.lean
@@ -5,7 +5,7 @@ import Linglib.Syntax.Voice.Basic
 
 Theory-neutral typological profile of the Mam voice system.
 
-The Minimalist `VoiceHead`, `ClauseSpine`, and `MamDirHead` apparatus
+The Minimalist `Voice.Head`, `ClauseSpine`, and `MamDirHead` apparatus
 that previously lived in this file (=(y)a' analysis, antipassive)
 moved to:
 

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -42,7 +42,7 @@ namespace Morphology.DM.Allosemy
 
 open Morphology.DM (Categorizer CatHead)
 open Morphology.DM.CategorizerSemantics (NSemanticType)
-open Minimalist (Voice.Flavor Voice.Head)
+open Minimalist.Voice (Flavor Head)
 
 -- ════════════════════════════════════════════════════
 -- § 1. General Allosemy Framework
@@ -306,7 +306,7 @@ def VoiceAlloseme.fromComplement
   else if complementIsStative then .holder
   else .expletive
 
-/-- Bridge: Voice allosemes to syntactic `Voice.Flavor`.
+/-- Bridge: Voice allosemes to syntactic `Flavor`.
 
     [myler-2016]: syntactically, all four allosemes realize
     the same Voice_{D} — transitive Voice with a DP specifier.
@@ -315,7 +315,7 @@ def VoiceAlloseme.fromComplement
     agent/engineer → agentive (phase head, assigns θ);
     holder → experiencer (assigns θ, stative);
     expletive → expletive (no θ, no semantics). -/
-def VoiceAlloseme.toFlavor : VoiceAlloseme → Voice.Flavor
+def VoiceAlloseme.toFlavor : VoiceAlloseme → Flavor
   | .agent    => .agentive
   | .holder   => .experiencer
   | .engineer => .agentive
@@ -325,7 +325,7 @@ def VoiceAlloseme.toFlavor : VoiceAlloseme → Voice.Flavor
     the non-θ expletive maps to a non-θ flavor. -/
 theorem voice_alloseme_theta_consistent (a : VoiceAlloseme) :
     a.assignsTheta = true ↔
-      Voice.Head.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
+      Head.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
   cases a <;> decide
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -25,7 +25,7 @@ linglib already formalizes several cases of allosemy without naming them:
 
 - `CategorizerSemantics.NSemanticType`: n has three allosemes
   (relational/sortal/alienator), selected by `selectsD` and context
-- `Minimalist.VoiceFlavor`: Voice has six flavors (agentive/causer/
+- `Minimalist.Voice.Flavor`: Voice has six flavors (agentive/causer/
   nonThematic/expletive/impersonal/passive), each with different semantics
 - `RootType` / `RootClassification.changeType`: roots vary in whether
   they entail change, conditioning the semantics of the v that embeds them
@@ -42,7 +42,7 @@ namespace Morphology.DM.Allosemy
 
 open Morphology.DM (Categorizer CatHead)
 open Morphology.DM.CategorizerSemantics (NSemanticType)
-open Minimalist (VoiceFlavor VoiceHead)
+open Minimalist (Voice.Flavor Voice.Head)
 
 -- ════════════════════════════════════════════════════
 -- § 1. General Allosemy Framework
@@ -306,7 +306,7 @@ def VoiceAlloseme.fromComplement
   else if complementIsStative then .holder
   else .expletive
 
-/-- Bridge: Voice allosemes to syntactic `VoiceFlavor`.
+/-- Bridge: Voice allosemes to syntactic `Voice.Flavor`.
 
     [myler-2016]: syntactically, all four allosemes realize
     the same Voice_{D} — transitive Voice with a DP specifier.
@@ -315,7 +315,7 @@ def VoiceAlloseme.fromComplement
     agent/engineer → agentive (phase head, assigns θ);
     holder → experiencer (assigns θ, stative);
     expletive → expletive (no θ, no semantics). -/
-def VoiceAlloseme.toFlavor : VoiceAlloseme → VoiceFlavor
+def VoiceAlloseme.toFlavor : VoiceAlloseme → Voice.Flavor
   | .agent    => .agentive
   | .holder   => .experiencer
   | .engineer => .agentive
@@ -325,7 +325,7 @@ def VoiceAlloseme.toFlavor : VoiceAlloseme → VoiceFlavor
     the non-θ expletive maps to a non-θ flavor. -/
 theorem voice_alloseme_theta_consistent (a : VoiceAlloseme) :
     a.assignsTheta = true ↔
-      VoiceHead.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
+      Voice.Head.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
   cases a <;> decide
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -742,7 +742,7 @@ theorem deadjectival_source_target :
       domain of idiosyncratic interpretation.
 
    Formal consequence: categorizers are never phase heads,
-   while `VoiceHead.IsPhasal` can be `true`. -/
+   while `Voice.Head.IsPhasal` can be `true`. -/
 
 /-- Categorizers are never phase heads ([harley-2014] §4). -/
 def Categorizer.isPhaseHead : Categorizer → Bool
@@ -754,20 +754,20 @@ theorem categorizer_never_phase (c : Categorizer) :
 
 /-- Agentive Voice IS a phase head — it demarcates the boundary above which
     interpretation must be compositional ([harley-2014] §4). -/
-theorem agentive_voice_is_phase : voiceAgent.IsPhasal := by decide
+theorem agentive_voice_is_phase : Voice.agentive.IsPhasal := by decide
 
 /-- The phase-boundary asymmetry: Voice can be a phase head while
     categorizers never are. This is why idiosyncratic interpretation
     extends past categorizers but not past Voice ([harley-2014] §4). -/
 theorem phase_boundary_at_voice_not_categorizer (c : Categorizer) :
-    c.isPhaseHead = false ∧ voiceAgent.IsPhasal :=
+    c.isPhaseHead = false ∧ Voice.agentive.IsPhasal :=
   ⟨by cases c <;> rfl, by decide⟩
 
 /-- Voice introduces the external argument ([harley-2014] §4, following
     [kratzer-1996]). The categorizer does NOT introduce arguments —
     complement selection is a root property (§3). -/
 theorem voice_introduces_external_arg :
-    voiceAgent.HasD ∧ voiceAgent.AssignsTheta := by
+    Voice.agentive.HasD ∧ Voice.agentive.AssignsTheta := by
   refine ⟨?_, ?_⟩ <;> decide
 
 -- ============================================================================

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -56,7 +56,7 @@ in `VocabularyInsertion.lean`.
 
 namespace Morphology.DM
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Verb
 
 -- ============================================================================
@@ -742,7 +742,7 @@ theorem deadjectival_source_target :
       domain of idiosyncratic interpretation.
 
    Formal consequence: categorizers are never phase heads,
-   while `Voice.Head.IsPhasal` can be `true`. -/
+   while `Head.IsPhasal` can be `true`. -/
 
 /-- Categorizers are never phase heads ([harley-2014] §4). -/
 def Categorizer.isPhaseHead : Categorizer → Bool
@@ -754,20 +754,20 @@ theorem categorizer_never_phase (c : Categorizer) :
 
 /-- Agentive Voice IS a phase head — it demarcates the boundary above which
     interpretation must be compositional ([harley-2014] §4). -/
-theorem agentive_voice_is_phase : Voice.agentive.IsPhasal := by decide
+theorem agentive_voice_is_phase : agentive.IsPhasal := by decide
 
 /-- The phase-boundary asymmetry: Voice can be a phase head while
     categorizers never are. This is why idiosyncratic interpretation
     extends past categorizers but not past Voice ([harley-2014] §4). -/
 theorem phase_boundary_at_voice_not_categorizer (c : Categorizer) :
-    c.isPhaseHead = false ∧ Voice.agentive.IsPhasal :=
+    c.isPhaseHead = false ∧ agentive.IsPhasal :=
   ⟨by cases c <;> rfl, by decide⟩
 
 /-- Voice introduces the external argument ([harley-2014] §4, following
     [kratzer-1996]). The categorizer does NOT introduce arguments —
     complement selection is a root property (§3). -/
 theorem voice_introduces_external_arg :
-    Voice.agentive.HasD ∧ Voice.agentive.AssignsTheta := by
+    agentive.HasD ∧ agentive.AssignsTheta := by
   refine ⟨?_, ?_⟩ <;> decide
 
 -- ============================================================================

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -35,7 +35,7 @@ Theories in the literature differ along three dimensions:
 The `LinkingTheory` structure captures this variation by parameterizing
 over BOTH the verb representation type (`Verb`) and the structural
 context type (`Ctx`). Theories that ignore structure use `Unit` for
-`Ctx`; theories that care about Voice use `VoiceFlavor`; theories
+`Ctx`; theories that care about Voice use `Voice.Flavor`; theories
 with richer decompositions bring their own types.
 
 The role output is always `ThetaRole` — the shared vocabulary that
@@ -52,7 +52,7 @@ Accounts expressible via this interface (non-exhaustive):
 
 | Account | Ctx | compatible | predict uses verb? |
 |---------|-----|------------|-------------------|
-| Severing | VoiceFlavor | verb-constrained | no |
+| Severing | Voice.Flavor | verb-constrained | no |
 | Lexicalist | Unit | always [] | yes |
 | Zero morphology | (custom) | verb-constrained | yes |
 | First Phase Syntax | (custom) | verb-constrained | yes |
@@ -271,7 +271,7 @@ inductive ArgPosition where
     - `Ctx`: what the theory considers relevant about the syntactic
       structure beyond the verb itself:
       - `Unit` for theories that derive everything from the verb
-      - `VoiceFlavor` for the severing account
+      - `Voice.Flavor` for the severing account
       - A richer type for Ramchand, Goldberg, Pylkkänen, etc.
 
     The theory provides two functions:

--- a/Linglib/Semantics/ArgumentStructure/VoiceSemantics.lean
+++ b/Linglib/Semantics/ArgumentStructure/VoiceSemantics.lean
@@ -10,14 +10,14 @@ import Linglib.Semantics.Causation.CauserSort
 Voice heads are type-changing compositional functions: they take a VP
 denotation and return a clause-level meaning with modified argument
 structure. This file defines the semantic operations; the theta-role
-labels are projected from Voice flavor by `VoiceFlavor.thetaRole` in
+labels are projected from Voice flavor by `Voice.Flavor.thetaRole` in
 `Syntax/Minimalist/Verbal/Voice.lean`.
 
-## Independence from VoiceFlavor.thetaRole
+## Independence from Voice.Flavor.thetaRole
 
 The two are orthogonal projections from the syntactic voice head:
 
-- **`VoiceFlavor.thetaRole`** (Voice.lean): Voice → theta role label
+- **`Voice.Flavor.thetaRole`** (Voice.lean): Voice → theta role label
   (what the external argument IS)
 - **VoiceSemantics** (this file): Voice → compositional operation
   (what the voice head DOES)

--- a/Linglib/Semantics/Lexical/VerbSmuggling.lean
+++ b/Linglib/Semantics/Lexical/VerbSmuggling.lean
@@ -14,7 +14,7 @@ studies (QI, locative inversion, passives), not study-local helpers.
 ## Composition
 
 ```
-Verb.derivedUnaccusative  →  Verb.voiceFor : VoiceHead
+Verb.derivedUnaccusative  →  Verb.voiceFor : Voice.Head
 Verb.complementType       →  Verb.hasComplement : Bool
                                        ↓
                          Verb.derivedQI = licensesQI ∘ voiceFor ∘ hasComplement
@@ -40,8 +40,8 @@ def hasComplement (v : Verb) : Bool := v.complementType != .none
     Reads `derivedUnaccusative`, which consults `voiceType.assignsTheta`
     when present, so the bridge is grounded in the Voice-as-not-introducing-
     external-argument characterization ([kratzer-1996]). -/
-def voiceFor (v : Verb) : VoiceHead :=
-  if v.derivedUnaccusative then voiceAnticausative else voiceAgent
+def voiceFor (v : Verb) : Voice.Head :=
+  if v.derivedUnaccusative then Voice.anticausative else Voice.agentive
 
 /-- Derived prediction: does the verb license quotative inversion?
     Composes `voiceFor` and `hasComplement` through `licensesQI`
@@ -60,12 +60,12 @@ theorem derivedQI_iff (v : Verb) :
 
 /-- Unaccusative verbs project non-thematic (anticausative) Voice. -/
 theorem voiceFor_of_unaccusative (v : Verb)
-    (h : v.derivedUnaccusative = true) : v.voiceFor = voiceAnticausative := by
+    (h : v.derivedUnaccusative = true) : v.voiceFor = Voice.anticausative := by
   unfold voiceFor; simp [h]
 
 /-- Unergative verbs project agentive Voice. -/
 theorem voiceFor_of_unergative (v : Verb)
-    (h : v.derivedUnaccusative = false) : v.voiceFor = voiceAgent := by
+    (h : v.derivedUnaccusative = false) : v.voiceFor = Voice.agentive := by
   unfold voiceFor; simp [h]
 
 /-- An unaccusative verb with a complement licenses QI. The two

--- a/Linglib/Semantics/Lexical/VerbSmuggling.lean
+++ b/Linglib/Semantics/Lexical/VerbSmuggling.lean
@@ -14,7 +14,7 @@ studies (QI, locative inversion, passives), not study-local helpers.
 ## Composition
 
 ```
-Verb.derivedUnaccusative  →  Verb.voiceFor : Voice.Head
+Verb.derivedUnaccusative  →  Verb.voiceFor : Head
 Verb.complementType       →  Verb.hasComplement : Bool
                                        ↓
                          Verb.derivedQI = licensesQI ∘ voiceFor ∘ hasComplement
@@ -28,7 +28,7 @@ than the surface `unaccusative : Bool` annotation.
 
 namespace Verb
 
-open Minimalist
+open Minimalist Minimalist.Voice
 
 /-- A verb has a syntactic complement iff its `complementType` is anything
     other than `.none`. Used by smuggling derivations to check that there
@@ -40,8 +40,8 @@ def hasComplement (v : Verb) : Bool := v.complementType != .none
     Reads `derivedUnaccusative`, which consults `voiceType.assignsTheta`
     when present, so the bridge is grounded in the Voice-as-not-introducing-
     external-argument characterization ([kratzer-1996]). -/
-def voiceFor (v : Verb) : Voice.Head :=
-  if v.derivedUnaccusative then Voice.anticausative else Voice.agentive
+def voiceFor (v : Verb) : Head :=
+  if v.derivedUnaccusative then anticausative else agentive
 
 /-- Derived prediction: does the verb license quotative inversion?
     Composes `voiceFor` and `hasComplement` through `licensesQI`
@@ -60,12 +60,12 @@ theorem derivedQI_iff (v : Verb) :
 
 /-- Unaccusative verbs project non-thematic (anticausative) Voice. -/
 theorem voiceFor_of_unaccusative (v : Verb)
-    (h : v.derivedUnaccusative = true) : v.voiceFor = Voice.anticausative := by
+    (h : v.derivedUnaccusative = true) : v.voiceFor = anticausative := by
   unfold voiceFor; simp [h]
 
 /-- Unergative verbs project agentive Voice. -/
 theorem voiceFor_of_unergative (v : Verb)
-    (h : v.derivedUnaccusative = false) : v.voiceFor = Voice.agentive := by
+    (h : v.derivedUnaccusative = false) : v.voiceFor = agentive := by
   unfold voiceFor; simp [h]
 
 /-- An unaccusative verb with a complement licenses QI. The two

--- a/Linglib/Semantics/Verb/Basic.lean
+++ b/Linglib/Semantics/Verb/Basic.lean
@@ -131,7 +131,7 @@ def Verb.assertsSufficiency (v : Verb) : Bool :=
     - unaccusative / measure → theme
     - default → agent
 
-    Contrasts with the Kratzer severing prediction (`VoiceFlavor.thetaRole`),
+    Contrasts with the Kratzer severing prediction (`Voice.Flavor.thetaRole`),
     which derives the role from Voice flavor rather than verb-internal
     semantics. Studies comparing the two accounts can apply both to the
     same `Verb` and inspect divergence. -/

--- a/Linglib/Semantics/Verb/Defs.lean
+++ b/Linglib/Semantics/Verb/Defs.lean
@@ -65,7 +65,7 @@ open Features.LevinClassProfiles
 
     Captures the external-argument dimension of the verb's syntactic frame
     without committing to a specific syntactic framework. Maps to
-    `Minimalist.VoiceFlavor` via bridge theorems in interface files.
+    `Minimalist.Voice.Flavor` via bridge theorems in interface files.
 
     - `agentive`: External argument introduced (transitive/unergative)
     - `nonThematic`: No external argument (unaccusative/anticausative)

--- a/Linglib/Studies/AlonsoOvalleRoyer2024.lean
+++ b/Linglib/Studies/AlonsoOvalleRoyer2024.lean
@@ -391,7 +391,7 @@ theorem internal_adjunct_same (v : Bool) :
 /-! The full derivation chain connecting Chuj clause structure to
 MI flavor predictions:
 
-    Voice.Head.hasD → argPosition → accessibleBinders → predictedMIFlavors
+    Head.hasD → argPosition → accessibleBinders → predictedMIFlavors
 
 `hasD` is the structural claim: Voice heads with [D] introduce a
 specifier in Spec,VoiceP (above vP, hence above AspP). This DP's
@@ -399,20 +399,20 @@ event variable is bound by the speech act event (e₀), not by Asp's
 ∃e₂. Voice heads without [D] have no specifier — the highest DP is
 the internal argument (below AspP), accessible to both e₀ and e₂. -/
 
-open Minimalist (Voice.Head) in
+open Minimalist.Voice (Head) in
 
 /-- Derive argument position from Voice head: [+D] → external (above
 AspP), [-D] → internal (below AspP). This is the structural claim
 that replaces the stipulated position mapping. -/
-def argPositionOf (vh : Voice.Head) : ChujArgPosition :=
+def argPositionOf (vh : Head) : ChujArgPosition :=
   if vh.hasD then .external else .internal
 
-open Minimalist (Voice.Head) in
+open Minimalist.Voice (Head) in
 
 /-- End-to-end: Voice head determines MI flavor availability.
 Given a Voice head and verb volitionality, predict the MI flavors
 by composing the full derivation chain. -/
-def predictedMIFlavorsOf (vh : Voice.Head) (volitional : Bool) : List ModalFlavor :=
+def predictedMIFlavorsOf (vh : Head) (volitional : Bool) : List ModalFlavor :=
   predictedMIFlavors (argPositionOf vh) volitional
 
 open Coon2019 in

--- a/Linglib/Studies/AlonsoOvalleRoyer2024.lean
+++ b/Linglib/Studies/AlonsoOvalleRoyer2024.lean
@@ -391,7 +391,7 @@ theorem internal_adjunct_same (v : Bool) :
 /-! The full derivation chain connecting Chuj clause structure to
 MI flavor predictions:
 
-    VoiceHead.hasD → argPosition → accessibleBinders → predictedMIFlavors
+    Voice.Head.hasD → argPosition → accessibleBinders → predictedMIFlavors
 
 `hasD` is the structural claim: Voice heads with [D] introduce a
 specifier in Spec,VoiceP (above vP, hence above AspP). This DP's
@@ -399,20 +399,20 @@ event variable is bound by the speech act event (e₀), not by Asp's
 ∃e₂. Voice heads without [D] have no specifier — the highest DP is
 the internal argument (below AspP), accessible to both e₀ and e₂. -/
 
-open Minimalist (VoiceHead) in
+open Minimalist (Voice.Head) in
 
 /-- Derive argument position from Voice head: [+D] → external (above
 AspP), [-D] → internal (below AspP). This is the structural claim
 that replaces the stipulated position mapping. -/
-def argPositionOf (vh : VoiceHead) : ChujArgPosition :=
+def argPositionOf (vh : Voice.Head) : ChujArgPosition :=
   if vh.hasD then .external else .internal
 
-open Minimalist (VoiceHead) in
+open Minimalist (Voice.Head) in
 
 /-- End-to-end: Voice head determines MI flavor availability.
 Given a Voice head and verb volitionality, predict the MI flavors
 by composing the full derivation chain. -/
-def predictedMIFlavorsOf (vh : VoiceHead) (volitional : Bool) : List ModalFlavor :=
+def predictedMIFlavorsOf (vh : Voice.Head) (volitional : Bool) : List ModalFlavor :=
   predictedMIFlavors (argPositionOf vh) volitional
 
 open Coon2019 in

--- a/Linglib/Studies/BeaversUdayana2022.lean
+++ b/Linglib/Studies/BeaversUdayana2022.lean
@@ -89,7 +89,7 @@ namespace BeaversUdayana2022
 
 open Semantics.Lexical
 open Indonesian.VoiceSystem
-open Minimalist (VoiceParams VoiceFlavor ExternalArgSemantics)
+open Minimalist (Voice.Params Voice.Flavor Voice.ExternalArgSemantics)
 open Beavers2010
 open ArgumentStructure.Affectedness (AffectednessDegree)
 open Voice

--- a/Linglib/Studies/BeaversUdayana2022.lean
+++ b/Linglib/Studies/BeaversUdayana2022.lean
@@ -89,7 +89,7 @@ namespace BeaversUdayana2022
 
 open Semantics.Lexical
 open Indonesian.VoiceSystem
-open Minimalist (Voice.Params Voice.Flavor Voice.ExternalArgSemantics)
+open Minimalist.Voice (Params Flavor ExternalArgSemantics)
 open Beavers2010
 open ArgumentStructure.Affectedness (AffectednessDegree)
 open Voice

--- a/Linglib/Studies/Bruening2021.lean
+++ b/Linglib/Studies/Bruening2021.lean
@@ -199,7 +199,7 @@ symmetrically as V's selected arguments.
 
 ANALOGUE: Bruening's ι-head (def-implicit licensor) and ApplPass
 (licensor for implicit first object) have no current substrate primitives
-in `Syntax/Minimalist/`. `Voice.ExternalArgSemantics` includes
+in `Syntax/Minimalist/`. `Voice.Voice.ExternalArgSemantics` includes
 `thematicExistential` (the analogue of Bruening's ∃-head); a parallel
 `thematicIota` and a `Pass`-of-`Appl` head are substrate gaps. -/
 

--- a/Linglib/Studies/Collins2005.lean
+++ b/Linglib/Studies/Collins2005.lean
@@ -43,11 +43,11 @@ passive, satisfying UTAH).
 
 namespace Collins2005
 
-open Minimalist
+open Minimalist Minimalist.Voice
 
 /-! ## §1. Voice properties Collins defends
 
-The four core properties of `Voice.passive`: it does not assign an external
+The four core properties of `passive`: it does not assign an external
 θ-role (which v does, per §2 UTAH), it does check accusative Case (per §4
 Case dissociation), it is not a phase head (which is what permits smuggling
 per §5), and it has a D-feature (it is a Voice head, not an expletive). -/
@@ -55,22 +55,22 @@ per §5), and it has a D-feature (it is a Voice head, not an expletive). -/
 /-- [collins-2005] §2: passive Voice does *not* assign external θ.
     The external θ-role stays on v in both active and passive. -/
 theorem passive_voice_does_not_assign_theta :
-    ¬ Voice.passive.AssignsTheta := by decide
+    ¬ passive.AssignsTheta := by decide
 
 /-- [collins-2005] §4: passive Voice checks accusative Case. The
     Case feature dissociates from v and projects on the Voice head
     (whose lexical realization is *by*). -/
 theorem passive_voice_checks_case :
-    Voice.passive.ChecksCase := by decide
+    passive.ChecksCase := by decide
 
 /-- [collins-2005] §5: passive Voice is not a phase head, which is
     what permits PartP to smuggle past the external argument in Spec,vP. -/
 theorem passive_voice_not_phase :
-    ¬ Voice.passive.IsPhasal := by decide
+    ¬ passive.IsPhasal := by decide
 
 /-- [collins-2005] §5: passive Voice permits smuggling. -/
 theorem passive_permits_smuggling :
-    Voice.passive.permitsSmuggling = true := rfl
+    passive.permitsSmuggling = true := rfl
 
 /-! ## §2. Active vs. passive: feature dissociation (Collins §4 eq. 32)
 
@@ -86,17 +86,17 @@ head. The two heads are then in complementary distribution on
     θ-assignment but distribute the Case-checking feature differently. -/
 theorem active_passive_dissociation :
     -- Active: v assigns θ AND checks Case (Voice does not check Case)
-    (Voice.agentive.AssignsTheta ∧ ¬ Voice.agentive.ChecksCase) ∧
+    (agentive.AssignsTheta ∧ ¬ agentive.ChecksCase) ∧
     -- Passive: v does NOT assign θ; Voice (by) checks Case
-    (¬ Voice.passive.AssignsTheta ∧ Voice.passive.ChecksCase) := by decide
+    (¬ passive.AssignsTheta ∧ passive.ChecksCase) := by decide
 
 /-- The phase status correlates with where Case checking lives.
     Active v* is a strong phase (it checks Case); passive v is not
     (Case has dissociated to Voice). The non-phase status is what
     permits smuggling. -/
 theorem case_dissociation_explains_phase :
-    ¬ Voice.agentive.ChecksCase ∧ Voice.agentive.IsPhasal ∧
-    Voice.passive.ChecksCase ∧ ¬ Voice.passive.IsPhasal := by decide
+    ¬ agentive.ChecksCase ∧ agentive.IsPhasal ∧
+    passive.ChecksCase ∧ ¬ passive.IsPhasal := by decide
 
 /-! ## §3. PartP movement is XP-movement, not head movement
 
@@ -113,7 +113,7 @@ configuration. -/
     smuggling configuration: PartP = [Part V DP] moves *as a constituent*
     to Spec,VoiceP, taking the particle along with the verb. -/
 theorem particle_stranding_requires_xp_movement :
-    licensesPassiveSmuggling Voice.passive true = true := by
+    licensesPassiveSmuggling passive true = true := by
   simp only [licensesPassiveSmuggling, passive_permits_smuggling, Bool.true_and]
 
 /-- [collins-2005] §3 (18–19): pseudo-passives (`John was spoken to
@@ -121,7 +121,7 @@ theorem particle_stranding_requires_xp_movement :
     (P stays adjacent to V, not stranded after EA). Same XP-movement
     diagnostic as particles. -/
 theorem pseudo_passive_requires_xp_movement :
-    licensesPassiveSmuggling Voice.passive true = true :=
+    licensesPassiveSmuggling passive true = true :=
   particle_stranding_requires_xp_movement
 
 /-! ## §4. Without PartP there is nothing to smuggle -/
@@ -129,7 +129,7 @@ theorem pseudo_passive_requires_xp_movement :
 /-- The smuggling derivation requires PartP to be present (something to
     move). Without it, no derivation is licensed. -/
 theorem no_partP_no_passive :
-    licensesPassiveSmuggling Voice.passive false = false := by
+    licensesPassiveSmuggling passive false = false := by
   simp only [licensesPassiveSmuggling, Bool.and_false]
 
 /-! ## §5. Short passives (§6 of paper)
@@ -145,16 +145,16 @@ In the formal terms of this file, a short passive has the same Voice
 configuration as a long passive — the only difference is whether Spec,vP
 is filled by an overt DP or an empty pronominal. -/
 
-/-- Short passives use the same `Voice.passive` head as long passives —
+/-- Short passives use the same `passive` head as long passives —
     smuggling is licensed identically; the difference is only the
     realization of Spec,vP (overt DP vs. empty pronominal). -/
 theorem short_and_long_passive_share_voice :
     -- Both are licensed by the same Voice + PartP configuration
-    licensesPassiveSmuggling Voice.passive true = true ∧
+    licensesPassiveSmuggling passive true = true ∧
     -- Same Voice properties (no theta, checks Case, not phase)
-    ¬ Voice.passive.AssignsTheta ∧
-    Voice.passive.ChecksCase ∧
-    ¬ Voice.passive.IsPhasal := by
+    ¬ passive.AssignsTheta ∧
+    passive.ChecksCase ∧
+    ¬ passive.IsPhasal := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · exact particle_stranding_requires_xp_movement
   all_goals decide
@@ -177,13 +177,13 @@ not `[PP by DP]`. -/
     `[VoiceP PartP [Voice' by vP]]` and the coordination in (63b) is
     VoiceP-coordination with PartP-deletion (Collins §8 eq. 64). The
     substantive constraint is that both conjuncts use the same Voice
-    head, which `Voice.passive` represents. -/
+    head, which `passive` represents. -/
 theorem by_dp_coordination_requires_voiceP :
     -- Both coordinated `by-DP` units project the same passive Voice
-    Voice.passive = Voice.passive ∧
+    passive = passive ∧
     -- Voice properties are stable across the conjuncts
-    Voice.passive.ChecksCase ∧
-    ¬ Voice.passive.AssignsTheta := by
+    passive.ChecksCase ∧
+    ¬ passive.AssignsTheta := by
   refine ⟨rfl, ?_, ?_⟩ <;> decide
 
 /-! ## §7. Inverse-voice family membership
@@ -198,7 +198,7 @@ layer. Collins's passive instance is `Minimalist.passiveCanonical`. -/
 theorem passive_is_inverse_voice :
     Minimalist.passiveCanonical.kind = .passive ∧
     Minimalist.passiveCanonical.licensed = true ∧
-    Minimalist.passiveCanonical.voice = Voice.passive :=
+    Minimalist.passiveCanonical.voice = passive :=
   ⟨rfl, rfl, rfl⟩
 
 /-! ## §8. Transfer equations over the §3 diagnostic rows

--- a/Linglib/Studies/Collins2005.lean
+++ b/Linglib/Studies/Collins2005.lean
@@ -47,7 +47,7 @@ open Minimalist
 
 /-! ## §1. Voice properties Collins defends
 
-The four core properties of `voicePassive`: it does not assign an external
+The four core properties of `Voice.passive`: it does not assign an external
 θ-role (which v does, per §2 UTAH), it does check accusative Case (per §4
 Case dissociation), it is not a phase head (which is what permits smuggling
 per §5), and it has a D-feature (it is a Voice head, not an expletive). -/
@@ -55,22 +55,22 @@ per §5), and it has a D-feature (it is a Voice head, not an expletive). -/
 /-- [collins-2005] §2: passive Voice does *not* assign external θ.
     The external θ-role stays on v in both active and passive. -/
 theorem passive_voice_does_not_assign_theta :
-    ¬ voicePassive.AssignsTheta := by decide
+    ¬ Voice.passive.AssignsTheta := by decide
 
 /-- [collins-2005] §4: passive Voice checks accusative Case. The
     Case feature dissociates from v and projects on the Voice head
     (whose lexical realization is *by*). -/
 theorem passive_voice_checks_case :
-    voicePassive.ChecksCase := by decide
+    Voice.passive.ChecksCase := by decide
 
 /-- [collins-2005] §5: passive Voice is not a phase head, which is
     what permits PartP to smuggle past the external argument in Spec,vP. -/
 theorem passive_voice_not_phase :
-    ¬ voicePassive.IsPhasal := by decide
+    ¬ Voice.passive.IsPhasal := by decide
 
 /-- [collins-2005] §5: passive Voice permits smuggling. -/
 theorem passive_permits_smuggling :
-    voicePassive.permitsSmuggling = true := rfl
+    Voice.passive.permitsSmuggling = true := rfl
 
 /-! ## §2. Active vs. passive: feature dissociation (Collins §4 eq. 32)
 
@@ -86,17 +86,17 @@ head. The two heads are then in complementary distribution on
     θ-assignment but distribute the Case-checking feature differently. -/
 theorem active_passive_dissociation :
     -- Active: v assigns θ AND checks Case (Voice does not check Case)
-    (voiceAgent.AssignsTheta ∧ ¬ voiceAgent.ChecksCase) ∧
+    (Voice.agentive.AssignsTheta ∧ ¬ Voice.agentive.ChecksCase) ∧
     -- Passive: v does NOT assign θ; Voice (by) checks Case
-    (¬ voicePassive.AssignsTheta ∧ voicePassive.ChecksCase) := by decide
+    (¬ Voice.passive.AssignsTheta ∧ Voice.passive.ChecksCase) := by decide
 
 /-- The phase status correlates with where Case checking lives.
     Active v* is a strong phase (it checks Case); passive v is not
     (Case has dissociated to Voice). The non-phase status is what
     permits smuggling. -/
 theorem case_dissociation_explains_phase :
-    ¬ voiceAgent.ChecksCase ∧ voiceAgent.IsPhasal ∧
-    voicePassive.ChecksCase ∧ ¬ voicePassive.IsPhasal := by decide
+    ¬ Voice.agentive.ChecksCase ∧ Voice.agentive.IsPhasal ∧
+    Voice.passive.ChecksCase ∧ ¬ Voice.passive.IsPhasal := by decide
 
 /-! ## §3. PartP movement is XP-movement, not head movement
 
@@ -113,7 +113,7 @@ configuration. -/
     smuggling configuration: PartP = [Part V DP] moves *as a constituent*
     to Spec,VoiceP, taking the particle along with the verb. -/
 theorem particle_stranding_requires_xp_movement :
-    licensesPassiveSmuggling voicePassive true = true := by
+    licensesPassiveSmuggling Voice.passive true = true := by
   simp only [licensesPassiveSmuggling, passive_permits_smuggling, Bool.true_and]
 
 /-- [collins-2005] §3 (18–19): pseudo-passives (`John was spoken to
@@ -121,7 +121,7 @@ theorem particle_stranding_requires_xp_movement :
     (P stays adjacent to V, not stranded after EA). Same XP-movement
     diagnostic as particles. -/
 theorem pseudo_passive_requires_xp_movement :
-    licensesPassiveSmuggling voicePassive true = true :=
+    licensesPassiveSmuggling Voice.passive true = true :=
   particle_stranding_requires_xp_movement
 
 /-! ## §4. Without PartP there is nothing to smuggle -/
@@ -129,7 +129,7 @@ theorem pseudo_passive_requires_xp_movement :
 /-- The smuggling derivation requires PartP to be present (something to
     move). Without it, no derivation is licensed. -/
 theorem no_partP_no_passive :
-    licensesPassiveSmuggling voicePassive false = false := by
+    licensesPassiveSmuggling Voice.passive false = false := by
   simp only [licensesPassiveSmuggling, Bool.and_false]
 
 /-! ## §5. Short passives (§6 of paper)
@@ -145,16 +145,16 @@ In the formal terms of this file, a short passive has the same Voice
 configuration as a long passive — the only difference is whether Spec,vP
 is filled by an overt DP or an empty pronominal. -/
 
-/-- Short passives use the same `voicePassive` head as long passives —
+/-- Short passives use the same `Voice.passive` head as long passives —
     smuggling is licensed identically; the difference is only the
     realization of Spec,vP (overt DP vs. empty pronominal). -/
 theorem short_and_long_passive_share_voice :
     -- Both are licensed by the same Voice + PartP configuration
-    licensesPassiveSmuggling voicePassive true = true ∧
+    licensesPassiveSmuggling Voice.passive true = true ∧
     -- Same Voice properties (no theta, checks Case, not phase)
-    ¬ voicePassive.AssignsTheta ∧
-    voicePassive.ChecksCase ∧
-    ¬ voicePassive.IsPhasal := by
+    ¬ Voice.passive.AssignsTheta ∧
+    Voice.passive.ChecksCase ∧
+    ¬ Voice.passive.IsPhasal := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · exact particle_stranding_requires_xp_movement
   all_goals decide
@@ -177,13 +177,13 @@ not `[PP by DP]`. -/
     `[VoiceP PartP [Voice' by vP]]` and the coordination in (63b) is
     VoiceP-coordination with PartP-deletion (Collins §8 eq. 64). The
     substantive constraint is that both conjuncts use the same Voice
-    head, which `voicePassive` represents. -/
+    head, which `Voice.passive` represents. -/
 theorem by_dp_coordination_requires_voiceP :
     -- Both coordinated `by-DP` units project the same passive Voice
-    voicePassive = voicePassive ∧
+    Voice.passive = Voice.passive ∧
     -- Voice properties are stable across the conjuncts
-    voicePassive.ChecksCase ∧
-    ¬ voicePassive.AssignsTheta := by
+    Voice.passive.ChecksCase ∧
+    ¬ Voice.passive.AssignsTheta := by
   refine ⟨rfl, ?_, ?_⟩ <;> decide
 
 /-! ## §7. Inverse-voice family membership
@@ -198,7 +198,7 @@ layer. Collins's passive instance is `Minimalist.passiveCanonical`. -/
 theorem passive_is_inverse_voice :
     Minimalist.passiveCanonical.kind = .passive ∧
     Minimalist.passiveCanonical.licensed = true ∧
-    Minimalist.passiveCanonical.voice = voicePassive :=
+    Minimalist.passiveCanonical.voice = Voice.passive :=
   ⟨rfl, rfl, rfl⟩
 
 /-! ## §8. Transfer equations over the §3 diagnostic rows

--- a/Linglib/Studies/Coon2019.lean
+++ b/Linglib/Studies/Coon2019.lean
@@ -20,21 +20,21 @@ Glossed Chuj sentences with root, voice suffix, and grammaticality.
 
 ## Minimalist analysis (§§3–9)
 
-Voice heads as `Minimalist.VoiceHead` instances, event decomposition via
-`buildDecomposition`, existential closure (-aj), and division of labor /
+Voice heads as `Minimalist.Voice.Head` instances, event decomposition via
+`Voice.buildDecomposition`, existential closure (-aj), and division of labor /
 causative alternation proved from the Voice–root split.
 
 ## Bridge theorems (§§10–16)
 
 Connect the fragment's theory-neutral types (`CRootClass`, `ChujVoiceSuffix`,
-`isGrammatical`, etc.) to Minimalist VoiceHead properties and to the
+`isGrammatical`, etc.) to Minimalist Voice.Head properties and to the
 [beavers-etal-2021] root typology.
 
 ### Chuj fragment bridge (§§10–15)
 
 1. **Root class ↔ Root arity**: `CRootClass` maps to `RootClassification` values.
    √TV = selectsTheme, others = noTheme.
-2. **Voice suffix ↔ VoiceHead**: theta assignment, D feature, phase head.
+2. **Voice suffix ↔ Voice.Head**: theta assignment, D feature, phase head.
 3. **Paradigm predictions**: `isGrammatical` matches data attestation.
 4. **-aj predictions**: `hasImplicitExternal` / `triggersAj` match -aj
    distribution.
@@ -156,7 +156,7 @@ open Minimalist
 
 /-- Active transitive v/Voice⁰ (Ø): introduces overt agent in Spec,VoiceP,
     assigns ergative case, phase head (v*). -/
-def vØ : VoiceHead :=
+def vØ : Voice.Head :=
   { flavor := .agentive, hasD := true }
 
 /-- Agentive intransitive v/Voice⁰ (-w): introduces overt agent in
@@ -167,14 +167,14 @@ def vØ : VoiceHead :=
     Also models the null intransitive v/Voice⁰ for √ITV roots (p. 40):
     both introduce an agent and assign absolutive, differing only in
     overt (-w) vs null morphological realization. -/
-def v_w : VoiceHead :=
+def v_w : Voice.Head :=
   { flavor := .agentive, hasD := true, phaseOverride := some false }
 
 /-- Passive v/Voice⁰ (-ch): assigns θ-role to an implicit (existentially
     bound) external argument (p. 68–69). Agent-oriented adverbs and
     by-phrases are licensed, confirming semantic presence of agent.
     Only combines with √TV roots. -/
-def v_ch : VoiceHead :=
+def v_ch : Voice.Head :=
   { flavor := .agentive, hasD := false, phaseOverride := some false }
 
 /-- Agentless passive v/Voice⁰ (-j): verbalizes stem but introduces
@@ -183,7 +183,7 @@ def v_ch : VoiceHead :=
     argument"). No agent-oriented adverbs, no agentive by-phrases.
     Used with √TV (agentless passive) and non-transitive roots
     (inchoative/stative readings). -/
-def v_j : VoiceHead :=
+def v_j : Voice.Head :=
   { flavor := .nonThematic, hasD := false }
 
 -- ════════════════════════════════════════════════════
@@ -216,38 +216,38 @@ theorem only_vØ_is_phase :
     vØ.IsPhasal ∧ ¬ v_w.IsPhasal ∧ ¬ v_ch.IsPhasal ∧ ¬ v_j.IsPhasal := by decide
 
 -- ════════════════════════════════════════════════════
--- § 6. Verb Building (buildDecomposition)
+-- § 6. Verb Building (Voice.buildDecomposition)
 -- ════════════════════════════════════════════════════
 
 /-- √TV result + Ø → causative [vDO, vGO, vBE] (active transitive). -/
 theorem tv_res_active :
-    isCausative (buildDecomposition vØ resultLower) = true := by decide
+    isCausative (Voice.buildDecomposition vØ resultLower) = true := by decide
 
 /-- √TV result + -ch → causative [vDO, vGO, vBE] (passive with implicit agent).
     Event structure is still causative — the agent is semantically present. -/
 theorem tv_res_passive_ch :
-    isCausative (buildDecomposition v_ch resultLower) = true := by decide
+    isCausative (Voice.buildDecomposition v_ch resultLower) = true := by decide
 
 /-- √TV result + -j → inchoative [vGO, vBE] (agentless passive / anticausative).
     No agent at all — the event is a pure change-of-state (p. 70). -/
 theorem tv_res_agentless :
-    isInchoative (buildDecomposition v_j resultLower) = true := by decide
+    isInchoative (Voice.buildDecomposition v_j resultLower) = true := by decide
 
 /-- √ITV + v/Voice⁰ → activity [vDO] (intransitive).
     Uses v_w, which shares formal properties with the null intransitive
     v/Voice⁰ for √ITV (both are agentive, non-ERG-assigning; p. 40). -/
 theorem itv_intransitive :
-    isActivity (buildDecomposition v_w activityLower) = true := by decide
+    isActivity (Voice.buildDecomposition v_w activityLower) = true := by decide
 
 /-- √POS + -w → [vDO, vBE]: agent assumes a position (agentive stative).
     (p. 48, (23)): chot-w-i "The frog hopped." -/
 theorem pos_agentive :
-    buildDecomposition v_w positionalLower = [.vDO, .vBE] := by decide
+    Voice.buildDecomposition v_w positionalLower = [.vDO, .vBE] := by decide
 
 /-- √NOM + -w → activity [vDO] (denominal agentive intransitive).
     (p. 45, (16b)): chanhal-w-i "I danced." -/
 theorem nom_agentive :
-    isActivity (buildDecomposition v_w activityLower) = true := by decide
+    isActivity (Voice.buildDecomposition v_w activityLower) = true := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Existential Closure (-aj)
@@ -255,7 +255,7 @@ theorem nom_agentive :
 
 /-- Does this Voice head have an implicit (existentially bound) external
     argument? True when Voice assigns θ but has no overt specifier. -/
-def hasImplicitExternal (v : VoiceHead) : Bool :=
+def hasImplicitExternal (v : Voice.Head) : Bool :=
   decide v.AssignsTheta && !v.hasD
 
 /-- -aj (Existential Closure) surfaces when there is any implicit argument:
@@ -264,7 +264,7 @@ def hasImplicitExternal (v : VoiceHead) : Bool :=
 
     `implicitInternal` is true when a √TV root's theme is not filled
     by an overt DP (absolutive antipassive, not incorporation antipassive). -/
-def triggersAj (v : VoiceHead) (implicitInternal : Bool) : Bool :=
+def triggersAj (v : Voice.Head) (implicitInternal : Bool) : Bool :=
   hasImplicitExternal v || implicitInternal
 
 /-- -ch always triggers -aj (implicit external agent; p. 69). -/
@@ -303,11 +303,11 @@ theorem w_incorporation_no_aj :
     root's lower event structure. -/
 theorem w_cross_class :
     -- √TV (incorporation antipassive): activity
-    isActivity (buildDecomposition v_w activityLower) = true ∧
+    isActivity (Voice.buildDecomposition v_w activityLower) = true ∧
     -- √POS (positional verbalization): agent + state
-    buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
+    Voice.buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
     -- √NOM (denominal verbalization): activity
-    isActivity (buildDecomposition v_w activityLower) = true := by
+    isActivity (Voice.buildDecomposition v_w activityLower) = true := by
   exact ⟨by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
@@ -320,8 +320,8 @@ theorem w_cross_class :
     same Voice with different root → same external argument status. -/
 theorem minimalist_division_of_labor :
     -- Same result root: Ø gives causative, -j gives inchoative
-    isCausative (buildDecomposition vØ resultLower) = true ∧
-    isInchoative (buildDecomposition v_j resultLower) = true ∧
+    isCausative (Voice.buildDecomposition vØ resultLower) = true ∧
+    isInchoative (Voice.buildDecomposition v_j resultLower) = true ∧
     -- √TV has theme, √ITV does not — root determines internal arg
     rootTV_res.arity.hasInternalArg = true ∧
     rootITV.arity.hasInternalArg = false := ⟨by decide, by decide, rfl, rfl⟩
@@ -330,10 +330,10 @@ theorem minimalist_division_of_labor :
     (instantiation of `voice_determines_causativity_go_be` for Chuj heads).
     For result roots, causativity tracks exactly with θ-assignment. -/
 theorem chuj_causative_alternation_result :
-    (isCausative (buildDecomposition vØ resultLower) = true ↔ vØ.AssignsTheta) ∧
-    (isCausative (buildDecomposition v_w resultLower) = true ↔ v_w.AssignsTheta) ∧
-    (isCausative (buildDecomposition v_ch resultLower) = true ↔ v_ch.AssignsTheta) ∧
-    (isCausative (buildDecomposition v_j resultLower) = true ↔ v_j.AssignsTheta) :=
+    (isCausative (Voice.buildDecomposition vØ resultLower) = true ↔ vØ.AssignsTheta) ∧
+    (isCausative (Voice.buildDecomposition v_w resultLower) = true ↔ v_w.AssignsTheta) ∧
+    (isCausative (Voice.buildDecomposition v_ch resultLower) = true ↔ v_ch.AssignsTheta) ∧
+    (isCausative (Voice.buildDecomposition v_j resultLower) = true ↔ v_j.AssignsTheta) :=
   ⟨by decide, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
@@ -368,11 +368,11 @@ theorem bare_transitive_iff_theme (rc : CRootClass) :
   cases rc <;> rfl
 
 -- ════════════════════════════════════════════════════
--- § 11. Voice Suffix ↔ VoiceHead
+-- § 11. Voice Suffix ↔ Voice.Head
 -- ════════════════════════════════════════════════════
 
-/-- Map the phenomena's voice suffix to the Minimalist VoiceHead. -/
-def toVoiceHead : ChujVoiceSuffix → VoiceHead
+/-- Map the phenomena's voice suffix to the Minimalist Voice.Head. -/
+def toVoiceHead : ChujVoiceSuffix → Voice.Head
   | .null => vØ
   | .ch   => v_ch
   | .j    => v_j
@@ -470,13 +470,13 @@ theorem aj_full_distribution :
     √ITV + -w → activity (intransitive) -/
 theorem event_decomposition_matches_data :
     -- ex10a: √TV + Ø → causative
-    isCausative (buildDecomposition vØ resultLower) = true ∧
+    isCausative (Voice.buildDecomposition vØ resultLower) = true ∧
     -- ex59: √TV + -j → inchoative
-    isInchoative (buildDecomposition v_j resultLower) = true ∧
+    isInchoative (Voice.buildDecomposition v_j resultLower) = true ∧
     -- ex62: √TV + -ch → causative (agent still present)
-    isCausative (buildDecomposition v_ch resultLower) = true ∧
+    isCausative (Voice.buildDecomposition v_ch resultLower) = true ∧
     -- ex7a: √ITV + v_w → activity
-    isActivity (buildDecomposition v_w activityLower) = true :=
+    isActivity (Voice.buildDecomposition v_w activityLower) = true :=
   ⟨by decide, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
@@ -548,9 +548,9 @@ theorem w_verbalization_cross_class :
     isGrammatical .pos .w = true ∧
     isGrammatical .nom .w = true ∧
     -- √POS + -w → [vDO, vBE] (fragment)
-    buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
+    Voice.buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
     -- √NOM + -w → activity [vDO] (fragment)
-    isActivity (buildDecomposition v_w activityLower) = true :=
+    isActivity (Voice.buildDecomposition v_w activityLower) = true :=
   ⟨rfl, rfl, by decide, by decide⟩
 
 end Coon2019

--- a/Linglib/Studies/Coon2019.lean
+++ b/Linglib/Studies/Coon2019.lean
@@ -21,20 +21,20 @@ Glossed Chuj sentences with root, voice suffix, and grammaticality.
 ## Minimalist analysis (§§3–9)
 
 Voice heads as `Minimalist.Voice.Head` instances, event decomposition via
-`Voice.buildDecomposition`, existential closure (-aj), and division of labor /
+`buildDecomposition`, existential closure (-aj), and division of labor /
 causative alternation proved from the Voice–root split.
 
 ## Bridge theorems (§§10–16)
 
 Connect the fragment's theory-neutral types (`CRootClass`, `ChujVoiceSuffix`,
-`isGrammatical`, etc.) to Minimalist Voice.Head properties and to the
+`isGrammatical`, etc.) to Minimalist Head properties and to the
 [beavers-etal-2021] root typology.
 
 ### Chuj fragment bridge (§§10–15)
 
 1. **Root class ↔ Root arity**: `CRootClass` maps to `RootClassification` values.
    √TV = selectsTheme, others = noTheme.
-2. **Voice suffix ↔ Voice.Head**: theta assignment, D feature, phase head.
+2. **Voice suffix ↔ Head**: theta assignment, D feature, phase head.
 3. **Paradigm predictions**: `isGrammatical` matches data attestation.
 4. **-aj predictions**: `hasImplicitExternal` / `triggersAj` match -aj
    distribution.
@@ -152,11 +152,11 @@ theorem examples_grammaticality :
 -- § 3. Minimalist Voice Analysis ([coon-2019], ex. (78))
 -- ════════════════════════════════════════════════════
 
-open Minimalist
+open Minimalist Minimalist.Voice
 
 /-- Active transitive v/Voice⁰ (Ø): introduces overt agent in Spec,VoiceP,
     assigns ergative case, phase head (v*). -/
-def vØ : Voice.Head :=
+def vØ : Head :=
   { flavor := .agentive, hasD := true }
 
 /-- Agentive intransitive v/Voice⁰ (-w): introduces overt agent in
@@ -167,14 +167,14 @@ def vØ : Voice.Head :=
     Also models the null intransitive v/Voice⁰ for √ITV roots (p. 40):
     both introduce an agent and assign absolutive, differing only in
     overt (-w) vs null morphological realization. -/
-def v_w : Voice.Head :=
+def v_w : Head :=
   { flavor := .agentive, hasD := true, phaseOverride := some false }
 
 /-- Passive v/Voice⁰ (-ch): assigns θ-role to an implicit (existentially
     bound) external argument (p. 68–69). Agent-oriented adverbs and
     by-phrases are licensed, confirming semantic presence of agent.
     Only combines with √TV roots. -/
-def v_ch : Voice.Head :=
+def v_ch : Head :=
   { flavor := .agentive, hasD := false, phaseOverride := some false }
 
 /-- Agentless passive v/Voice⁰ (-j): verbalizes stem but introduces
@@ -183,7 +183,7 @@ def v_ch : Voice.Head :=
     argument"). No agent-oriented adverbs, no agentive by-phrases.
     Used with √TV (agentless passive) and non-transitive roots
     (inchoative/stative readings). -/
-def v_j : Voice.Head :=
+def v_j : Head :=
   { flavor := .nonThematic, hasD := false }
 
 -- ════════════════════════════════════════════════════
@@ -216,38 +216,38 @@ theorem only_vØ_is_phase :
     vØ.IsPhasal ∧ ¬ v_w.IsPhasal ∧ ¬ v_ch.IsPhasal ∧ ¬ v_j.IsPhasal := by decide
 
 -- ════════════════════════════════════════════════════
--- § 6. Verb Building (Voice.buildDecomposition)
+-- § 6. Verb Building (buildDecomposition)
 -- ════════════════════════════════════════════════════
 
 /-- √TV result + Ø → causative [vDO, vGO, vBE] (active transitive). -/
 theorem tv_res_active :
-    isCausative (Voice.buildDecomposition vØ resultLower) = true := by decide
+    isCausative (buildDecomposition vØ resultLower) = true := by decide
 
 /-- √TV result + -ch → causative [vDO, vGO, vBE] (passive with implicit agent).
     Event structure is still causative — the agent is semantically present. -/
 theorem tv_res_passive_ch :
-    isCausative (Voice.buildDecomposition v_ch resultLower) = true := by decide
+    isCausative (buildDecomposition v_ch resultLower) = true := by decide
 
 /-- √TV result + -j → inchoative [vGO, vBE] (agentless passive / anticausative).
     No agent at all — the event is a pure change-of-state (p. 70). -/
 theorem tv_res_agentless :
-    isInchoative (Voice.buildDecomposition v_j resultLower) = true := by decide
+    isInchoative (buildDecomposition v_j resultLower) = true := by decide
 
 /-- √ITV + v/Voice⁰ → activity [vDO] (intransitive).
     Uses v_w, which shares formal properties with the null intransitive
     v/Voice⁰ for √ITV (both are agentive, non-ERG-assigning; p. 40). -/
 theorem itv_intransitive :
-    isActivity (Voice.buildDecomposition v_w activityLower) = true := by decide
+    isActivity (buildDecomposition v_w activityLower) = true := by decide
 
 /-- √POS + -w → [vDO, vBE]: agent assumes a position (agentive stative).
     (p. 48, (23)): chot-w-i "The frog hopped." -/
 theorem pos_agentive :
-    Voice.buildDecomposition v_w positionalLower = [.vDO, .vBE] := by decide
+    buildDecomposition v_w positionalLower = [.vDO, .vBE] := by decide
 
 /-- √NOM + -w → activity [vDO] (denominal agentive intransitive).
     (p. 45, (16b)): chanhal-w-i "I danced." -/
 theorem nom_agentive :
-    isActivity (Voice.buildDecomposition v_w activityLower) = true := by decide
+    isActivity (buildDecomposition v_w activityLower) = true := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 7. Existential Closure (-aj)
@@ -255,7 +255,7 @@ theorem nom_agentive :
 
 /-- Does this Voice head have an implicit (existentially bound) external
     argument? True when Voice assigns θ but has no overt specifier. -/
-def hasImplicitExternal (v : Voice.Head) : Bool :=
+def hasImplicitExternal (v : Head) : Bool :=
   decide v.AssignsTheta && !v.hasD
 
 /-- -aj (Existential Closure) surfaces when there is any implicit argument:
@@ -264,7 +264,7 @@ def hasImplicitExternal (v : Voice.Head) : Bool :=
 
     `implicitInternal` is true when a √TV root's theme is not filled
     by an overt DP (absolutive antipassive, not incorporation antipassive). -/
-def triggersAj (v : Voice.Head) (implicitInternal : Bool) : Bool :=
+def triggersAj (v : Head) (implicitInternal : Bool) : Bool :=
   hasImplicitExternal v || implicitInternal
 
 /-- -ch always triggers -aj (implicit external agent; p. 69). -/
@@ -303,11 +303,11 @@ theorem w_incorporation_no_aj :
     root's lower event structure. -/
 theorem w_cross_class :
     -- √TV (incorporation antipassive): activity
-    isActivity (Voice.buildDecomposition v_w activityLower) = true ∧
+    isActivity (buildDecomposition v_w activityLower) = true ∧
     -- √POS (positional verbalization): agent + state
-    Voice.buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
+    buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
     -- √NOM (denominal verbalization): activity
-    isActivity (Voice.buildDecomposition v_w activityLower) = true := by
+    isActivity (buildDecomposition v_w activityLower) = true := by
   exact ⟨by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
@@ -320,8 +320,8 @@ theorem w_cross_class :
     same Voice with different root → same external argument status. -/
 theorem minimalist_division_of_labor :
     -- Same result root: Ø gives causative, -j gives inchoative
-    isCausative (Voice.buildDecomposition vØ resultLower) = true ∧
-    isInchoative (Voice.buildDecomposition v_j resultLower) = true ∧
+    isCausative (buildDecomposition vØ resultLower) = true ∧
+    isInchoative (buildDecomposition v_j resultLower) = true ∧
     -- √TV has theme, √ITV does not — root determines internal arg
     rootTV_res.arity.hasInternalArg = true ∧
     rootITV.arity.hasInternalArg = false := ⟨by decide, by decide, rfl, rfl⟩
@@ -330,10 +330,10 @@ theorem minimalist_division_of_labor :
     (instantiation of `voice_determines_causativity_go_be` for Chuj heads).
     For result roots, causativity tracks exactly with θ-assignment. -/
 theorem chuj_causative_alternation_result :
-    (isCausative (Voice.buildDecomposition vØ resultLower) = true ↔ vØ.AssignsTheta) ∧
-    (isCausative (Voice.buildDecomposition v_w resultLower) = true ↔ v_w.AssignsTheta) ∧
-    (isCausative (Voice.buildDecomposition v_ch resultLower) = true ↔ v_ch.AssignsTheta) ∧
-    (isCausative (Voice.buildDecomposition v_j resultLower) = true ↔ v_j.AssignsTheta) :=
+    (isCausative (buildDecomposition vØ resultLower) = true ↔ vØ.AssignsTheta) ∧
+    (isCausative (buildDecomposition v_w resultLower) = true ↔ v_w.AssignsTheta) ∧
+    (isCausative (buildDecomposition v_ch resultLower) = true ↔ v_ch.AssignsTheta) ∧
+    (isCausative (buildDecomposition v_j resultLower) = true ↔ v_j.AssignsTheta) :=
   ⟨by decide, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
@@ -368,11 +368,11 @@ theorem bare_transitive_iff_theme (rc : CRootClass) :
   cases rc <;> rfl
 
 -- ════════════════════════════════════════════════════
--- § 11. Voice Suffix ↔ Voice.Head
+-- § 11. Voice Suffix ↔ Head
 -- ════════════════════════════════════════════════════
 
-/-- Map the phenomena's voice suffix to the Minimalist Voice.Head. -/
-def toVoiceHead : ChujVoiceSuffix → Voice.Head
+/-- Map the phenomena's voice suffix to the Minimalist Head. -/
+def toVoiceHead : ChujVoiceSuffix → Head
   | .null => vØ
   | .ch   => v_ch
   | .j    => v_j
@@ -470,13 +470,13 @@ theorem aj_full_distribution :
     √ITV + -w → activity (intransitive) -/
 theorem event_decomposition_matches_data :
     -- ex10a: √TV + Ø → causative
-    isCausative (Voice.buildDecomposition vØ resultLower) = true ∧
+    isCausative (buildDecomposition vØ resultLower) = true ∧
     -- ex59: √TV + -j → inchoative
-    isInchoative (Voice.buildDecomposition v_j resultLower) = true ∧
+    isInchoative (buildDecomposition v_j resultLower) = true ∧
     -- ex62: √TV + -ch → causative (agent still present)
-    isCausative (Voice.buildDecomposition v_ch resultLower) = true ∧
+    isCausative (buildDecomposition v_ch resultLower) = true ∧
     -- ex7a: √ITV + v_w → activity
-    isActivity (Voice.buildDecomposition v_w activityLower) = true :=
+    isActivity (buildDecomposition v_w activityLower) = true :=
   ⟨by decide, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
@@ -548,9 +548,9 @@ theorem w_verbalization_cross_class :
     isGrammatical .pos .w = true ∧
     isGrammatical .nom .w = true ∧
     -- √POS + -w → [vDO, vBE] (fragment)
-    Voice.buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
+    buildDecomposition v_w positionalLower = [.vDO, .vBE] ∧
     -- √NOM + -w → activity [vDO] (fragment)
-    isActivity (Voice.buildDecomposition v_w activityLower) = true :=
+    isActivity (buildDecomposition v_w activityLower) = true :=
   ⟨rfl, rfl, by decide, by decide⟩
 
 end Coon2019

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -55,7 +55,7 @@ supporting its role as a case-assigner.
 
 namespace CoonMateoPedroPreminger2014
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Mayan (ABSPosition CaseLocus toCaseLocus MayanLang)
 
 -- § 1 uses `CaseLocus` and `toCaseLocus` from `Mayan.Params`.
@@ -175,7 +175,7 @@ theorem intransitive_subject_never_trapped (locus : CaseLocus) :
     marked variant of Voice⁰ is merged only when the normal derivation
     (with regular transitive Voice) would crash — i.e., when the subject
     must be A-bar extracted. -/
-def voiceAF : Voice.Head :=
+def voiceAF : Head :=
   { flavor := .agentive
   , hasD := true
   , phaseOverride := some false  -- intransitive v⁰: NOT phasal (Mam AF)
@@ -206,10 +206,10 @@ theorem af_frees_subject : AfCircumventsTrapping := by decide
     Voice checks case, the object receives case inside vP and need not
     move to the escape hatch. This is the paper's primary explanation
     for why AF circumvents the extraction ban. -/
-def CaseAloneFreesExtraction (v : Voice.Head) : Prop :=
+def CaseAloneFreesExtraction (v : Head) : Prop :=
   v.ChecksCase
 
-instance (v : Voice.Head) : Decidable (CaseAloneFreesExtraction v) := by
+instance (v : Head) : Decidable (CaseAloneFreesExtraction v) := by
   unfold CaseAloneFreesExtraction; infer_instance
 
 theorem af_case_frees : CaseAloneFreesExtraction voiceAF := by decide
@@ -222,7 +222,7 @@ theorem af_morphology_from_phase :
 
 /-- Contrast with regular transitive Voice: phasal, does NOT check case. -/
 theorem regular_voice_traps :
-    Voice.agentive.IsPhasal ∧ ¬ Voice.agentive.ChecksCase := by decide
+    agentive.IsPhasal ∧ ¬ agentive.ChecksCase := by decide
 
 -- ============================================================================
 -- § 6: Non-Finite Predictions
@@ -547,7 +547,7 @@ theorem factor3_necessary :
 
 /-- Agentive Voice is a phase head — this is factor I. -/
 theorem voice_phase_is_factor1 :
-    Voice.agentive.IsPhasal := by decide
+    agentive.IsPhasal := by decide
 
 /-- AF removes factor I: AF Voice is not phasal. With a non-phasal vP,
     there is no locality boundary trapping the subject. -/
@@ -730,27 +730,27 @@ theorem fullDP_end_to_end :
     the PIC. AF Voice is NOT a phase head, so it does not create a phase
     boundary — the complement remains accessible.
 
-    This connects `IsPhasal` on `Voice.Head` to the Phase module's
+    This connects `IsPhasal` on `Head` to the Phase module's
     `isPhaseHeadOf .C`/`isPhaseHeadOf .Voice` selectors. -/
 theorem voice_phase_bridge :
-    Voice.agentive.IsPhasal ∧ ¬ voiceAF.IsPhasal ∧
-    ¬ Voice.passive.IsPhasal ∧ ¬ Voice.anticausative.IsPhasal := by decide
+    agentive.IsPhasal ∧ ¬ voiceAF.IsPhasal ∧
+    ¬ passive.IsPhasal ∧ ¬ anticausative.IsPhasal := by decide
 
 /-- Phase headedness partitions Voice into {trapping, non-trapping}: a
     Voice head traps the subject iff it is a phase head AND does not
     itself check case (freeing Infl⁰ to do so). -/
-def VoiceTrapsSubject (v : Voice.Head) (locus : CaseLocus) : Prop :=
+def VoiceTrapsSubject (v : Head) (locus : CaseLocus) : Prop :=
   v.IsPhasal ∧ ¬ v.ChecksCase ∧ objectMustExitVP locus = true
 
-instance (v : Voice.Head) (locus : CaseLocus) :
+instance (v : Head) (locus : CaseLocus) :
     Decidable (VoiceTrapsSubject v locus) := by
   unfold VoiceTrapsSubject; infer_instance
 
 theorem agent_voice_traps_absNom :
-    VoiceTrapsSubject Voice.agentive .absNom := by decide
+    VoiceTrapsSubject agentive .absNom := by decide
 
 theorem agent_voice_free_absDef :
-    ¬ VoiceTrapsSubject Voice.agentive .absDef := by decide
+    ¬ VoiceTrapsSubject agentive .absDef := by decide
 
 theorem af_voice_never_traps (locus : CaseLocus) :
     ¬ VoiceTrapsSubject voiceAF locus := by
@@ -803,7 +803,7 @@ def kaqClauseSpine : ClauseSpine := ClauseSpine.cP
     agentive Voice is a phase head (flavor default), creating the locality
     boundary that traps the subject in HIGH-ABS Mayan languages
     (CMP 2014 §4–§5). -/
-def kaqVoice : Voice.Head :=
+def kaqVoice : Head :=
   { flavor := .agentive
   , hasD := true }
 
@@ -835,7 +835,7 @@ theorem af_mechanism_contrast :
 /-- Both languages share the underlying problem: agentive Voice is a
     phase head, creating a locality boundary that traps the subject. -/
 theorem shared_phase_problem :
-    Voice.agentive.IsPhasal ∧ kaqVoice.IsPhasal := by decide
+    agentive.IsPhasal ∧ kaqVoice.IsPhasal := by decide
 
 /-- Both Q'anjob'al and Kaqchikel are HIGH-ABS languages with extraction
     asymmetries: agent extraction is blocked without AF in both. -/

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -175,7 +175,7 @@ theorem intransitive_subject_never_trapped (locus : CaseLocus) :
     marked variant of Voice⁰ is merged only when the normal derivation
     (with regular transitive Voice) would crash — i.e., when the subject
     must be A-bar extracted. -/
-def voiceAF : VoiceHead :=
+def voiceAF : Voice.Head :=
   { flavor := .agentive
   , hasD := true
   , phaseOverride := some false  -- intransitive v⁰: NOT phasal (Mam AF)
@@ -206,10 +206,10 @@ theorem af_frees_subject : AfCircumventsTrapping := by decide
     Voice checks case, the object receives case inside vP and need not
     move to the escape hatch. This is the paper's primary explanation
     for why AF circumvents the extraction ban. -/
-def CaseAloneFreesExtraction (v : VoiceHead) : Prop :=
+def CaseAloneFreesExtraction (v : Voice.Head) : Prop :=
   v.ChecksCase
 
-instance (v : VoiceHead) : Decidable (CaseAloneFreesExtraction v) := by
+instance (v : Voice.Head) : Decidable (CaseAloneFreesExtraction v) := by
   unfold CaseAloneFreesExtraction; infer_instance
 
 theorem af_case_frees : CaseAloneFreesExtraction voiceAF := by decide
@@ -222,7 +222,7 @@ theorem af_morphology_from_phase :
 
 /-- Contrast with regular transitive Voice: phasal, does NOT check case. -/
 theorem regular_voice_traps :
-    voiceAgent.IsPhasal ∧ ¬ voiceAgent.ChecksCase := by decide
+    Voice.agentive.IsPhasal ∧ ¬ Voice.agentive.ChecksCase := by decide
 
 -- ============================================================================
 -- § 6: Non-Finite Predictions
@@ -547,7 +547,7 @@ theorem factor3_necessary :
 
 /-- Agentive Voice is a phase head — this is factor I. -/
 theorem voice_phase_is_factor1 :
-    voiceAgent.IsPhasal := by decide
+    Voice.agentive.IsPhasal := by decide
 
 /-- AF removes factor I: AF Voice is not phasal. With a non-phasal vP,
     there is no locality boundary trapping the subject. -/
@@ -730,27 +730,27 @@ theorem fullDP_end_to_end :
     the PIC. AF Voice is NOT a phase head, so it does not create a phase
     boundary — the complement remains accessible.
 
-    This connects `IsPhasal` on `VoiceHead` to the Phase module's
+    This connects `IsPhasal` on `Voice.Head` to the Phase module's
     `isPhaseHeadOf .C`/`isPhaseHeadOf .Voice` selectors. -/
 theorem voice_phase_bridge :
-    voiceAgent.IsPhasal ∧ ¬ voiceAF.IsPhasal ∧
-    ¬ voicePassive.IsPhasal ∧ ¬ voiceAnticausative.IsPhasal := by decide
+    Voice.agentive.IsPhasal ∧ ¬ voiceAF.IsPhasal ∧
+    ¬ Voice.passive.IsPhasal ∧ ¬ Voice.anticausative.IsPhasal := by decide
 
 /-- Phase headedness partitions Voice into {trapping, non-trapping}: a
     Voice head traps the subject iff it is a phase head AND does not
     itself check case (freeing Infl⁰ to do so). -/
-def VoiceTrapsSubject (v : VoiceHead) (locus : CaseLocus) : Prop :=
+def VoiceTrapsSubject (v : Voice.Head) (locus : CaseLocus) : Prop :=
   v.IsPhasal ∧ ¬ v.ChecksCase ∧ objectMustExitVP locus = true
 
-instance (v : VoiceHead) (locus : CaseLocus) :
+instance (v : Voice.Head) (locus : CaseLocus) :
     Decidable (VoiceTrapsSubject v locus) := by
   unfold VoiceTrapsSubject; infer_instance
 
 theorem agent_voice_traps_absNom :
-    VoiceTrapsSubject voiceAgent .absNom := by decide
+    VoiceTrapsSubject Voice.agentive .absNom := by decide
 
 theorem agent_voice_free_absDef :
-    ¬ VoiceTrapsSubject voiceAgent .absDef := by decide
+    ¬ VoiceTrapsSubject Voice.agentive .absDef := by decide
 
 theorem af_voice_never_traps (locus : CaseLocus) :
     ¬ VoiceTrapsSubject voiceAF locus := by
@@ -803,7 +803,7 @@ def kaqClauseSpine : ClauseSpine := ClauseSpine.cP
     agentive Voice is a phase head (flavor default), creating the locality
     boundary that traps the subject in HIGH-ABS Mayan languages
     (CMP 2014 §4–§5). -/
-def kaqVoice : VoiceHead :=
+def kaqVoice : Voice.Head :=
   { flavor := .agentive
   , hasD := true }
 
@@ -835,7 +835,7 @@ theorem af_mechanism_contrast :
 /-- Both languages share the underlying problem: agentive Voice is a
     phase head, creating a locality boundary that traps the subject. -/
 theorem shared_phase_problem :
-    voiceAgent.IsPhasal ∧ kaqVoice.IsPhasal := by decide
+    Voice.agentive.IsPhasal ∧ kaqVoice.IsPhasal := by decide
 
 /-- Both Q'anjob'al and Kaqchikel are HIGH-ABS languages with extraction
     asymmetries: agent extraction is blocked without AF in both. -/

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -133,7 +133,7 @@ open Minimalist SyntacticObject
 
 /-! ### Mam Voice substrate (Minimalist)
 
-This subsection houses the Minimalist `VoiceHead`, `ClauseSpine`, and
+This subsection houses the Minimalist `Voice.Head`, `ClauseSpine`, and
 `MamDirHead` definitions for Mam, formerly in
 `Linglib/Fragments/Mayan/Mam/VoiceSystem.lean`. Per CLAUDE.md
 "Per-language paper-specific apparatus lives in Studies, not
@@ -151,7 +151,7 @@ the per-language `Mam.VoiceSystem.voices`/`symmetry` defs.
     Ā-moved constituent. When an oblique DP moves through Spec,VoiceP,
     Agree values [uOblique] as [+oblique], which is then spelled out
     as =(y)a' at PF. -/
-def mamVoice : VoiceHead :=
+def mamVoice : Voice.Head :=
   { flavor := .agentive
   , hasD := true
   , features := .ofGramFeatures [.unvalued (.oblique false)] }
@@ -203,14 +203,14 @@ def mamVoiceVocab : Vocabulary := [eqYaVocab]
 /-- Mam passive Voice head: carries [uOblique] just like agentive Voice.
     [elkins-torrence-brown-2026] §7.2: =(y)a' co-occurs with
     passive *-njtz*. -/
-def mamPassiveVoice : VoiceHead :=
+def mamPassiveVoice : Voice.Head :=
   { flavor := .nonThematic
   , hasD := false
   , features := .ofGramFeatures [.unvalued (.oblique false)] }
 
 /-- Mam antipassive Voice head ([scott-2023] §2.5.4.1).
     Subject gets ABS not ERG; not a phase head. -/
-def mamAntipassiveVoice : VoiceHead :=
+def mamAntipassiveVoice : Voice.Head :=
   { flavor := .antipassive
   , hasD := true
   , features := ⊥ }

--- a/Linglib/Studies/ErlewineSommerlot2025.lean
+++ b/Linglib/Studies/ErlewineSommerlot2025.lean
@@ -332,10 +332,10 @@ theorem all_grammatical_derivations_consistent :
 -- § 8: Bridge to Core Minimalist Voice Theory
 -- ============================================================================
 
-/-! ### Connecting Malayic Voice/v to Core VoiceHead
+/-! ### Connecting Malayic Voice/v to Core Voice.Head
 
 [erlewine-sommerlot-2025]'s two-head system (Voice + v) maps onto
-Core's single `VoiceHead` type ([kratzer-1996], [schaefer-2008]).
+Core's single `Voice.Head` type ([kratzer-1996], [schaefer-2008]).
 
 - v_ACT (introduces agent) → agentive Voice flavor
 - v_PASS (no θ) → passive Voice flavor
@@ -351,26 +351,26 @@ to each Spell-out domain in `Linearization/Cyclic.lean`, but operates on
 `SyntacticObject` rather than terminal strings.
 -/
 
-/-- Map Malayic v-flavor to Core VoiceFlavor.
+/-- Map Malayic v-flavor to Core Voice.Flavor.
     v_ACT introduces the external argument → agentive.
     v_PASS licenses EA without θ → passive. -/
-def vFlavorToCore : LittleVFlavor → Minimalist.VoiceFlavor
+def vFlavorToCore : LittleVFlavor → Minimalist.Voice.Flavor
   | .act  => .agentive
   | .pass => .passive
 
-/-- Map each Malayic clause type to its Core VoiceHead equivalent.
+/-- Map each Malayic clause type to its Core Voice.Head equivalent.
     Active and object-extraction Voice are agentive (flavor-default phasal).
     `di-`passive and bare passive use `phaseOverride := some true` to express
     E&S 2025's claim that VoiceP is universally a phase, diverging from the
     Core default for passive Voice ([chomsky-2001], [collins-2005],
-    encoded in `VoiceFlavor.defaultPhasal`). -/
-def clauseToVoiceHead : VoiceConstruction → Minimalist.VoiceHead
+    encoded in `Voice.Flavor.defaultPhasal`). -/
+def clauseToVoiceHead : VoiceConstruction → Minimalist.Voice.Head
   | .active          => { flavor := .agentive, hasD := true }
   | .diPassive       => { flavor := .passive,  hasD := true, phaseOverride := some true }
   | .barePassive     => { flavor := .passive,  hasD := true, phaseOverride := some true }
   | .objectExtraction => { flavor := .agentive, hasD := true }
 
-/-- The VoiceFlavor component is consistent with the v-flavor mapping. -/
+/-- The Voice.Flavor component is consistent with the v-flavor mapping. -/
 theorem voice_flavor_consistent (ct : VoiceConstruction) :
     (clauseToVoiceHead ct).flavor = vFlavorToCore ct.vFlavor := by
   cases ct <;> rfl
@@ -383,13 +383,13 @@ theorem voice_always_phase (ct : VoiceConstruction) :
     passive Voice (following [collins-2005]) is not. -/
 theorem malayic_passive_phase_diverges :
     (clauseToVoiceHead .diPassive).IsPhasal ∧
-    ¬ Minimalist.voicePassive.IsPhasal := by decide
+    ¬ Minimalist.Voice.passive.IsPhasal := by decide
 
 /-- Active clause type maps to Core's agentive Voice, which IS a phase
     head — consistent across both analyses. -/
 theorem active_consistent_with_core :
     (clauseToVoiceHead .active).flavor = .agentive ∧
-    ((clauseToVoiceHead .active).IsPhasal ↔ Minimalist.voiceAgent.IsPhasal) := by
+    ((clauseToVoiceHead .active).IsPhasal ↔ Minimalist.Voice.agentive.IsPhasal) := by
   refine ⟨rfl, ?_⟩; decide
 
 end ErlewineSommerlot2025

--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -48,10 +48,8 @@ sits outside it — a linglib cross-reference Hewett does not draw.
 
 namespace Hewett2026
 
-open Minimalist (Voice.Flavor Voice.Head VerbHead Cat FeatureStatus
-  ActivationIndex ApplHead applHigh applLowRecipient Voice.buildDecomposition
-  Voice.agentive Voice.causer Voice.passive Voice.anticausative isCausative
-  low_licensed_with_any high_licensed_of_assignsTheta)
+open Minimalist (VerbHead Cat FeatureStatus ActivationIndex ApplHead applHigh applLowRecipient isCausative low_licensed_with_any high_licensed_of_assignsTheta)
+open Minimalist.Voice (Flavor Head buildDecomposition agentive causer passive anticausative)
 open Morphology.DM (CategorizedRoot Categorizer)
 open Morphology.MirrorPrinciple (MorphDomain)
 open Wood2015 (Construction)
@@ -80,14 +78,14 @@ inductive SemiticTemplate where
     v/Voice (p. 201), and deliberately leaves the inventory open (fn. 8); the
     mapping below follows the templates' traditional active, causative, and
     medio-passive glosses. -/
-def SemiticTemplate.toVoiceHead : SemiticTemplate → Voice.Head
-  | .XaYaZ => Voice.agentive
-  | .XaYYaZ | .hiXYiZ | .XiYeZ => Voice.causer
-  | .nXaYaZ | .huXYaZ | .XuYaZ => Voice.passive
-  | .tXaYYaZ => Voice.anticausative
+def SemiticTemplate.toVoiceHead : SemiticTemplate → Head
+  | .XaYaZ => agentive
+  | .XaYYaZ | .hiXYiZ | .XiYeZ => causer
+  | .nXaYaZ | .huXYaZ | .XuYaZ => passive
+  | .tXaYYaZ => anticausative
 
 /-- The Voice flavor a template realizes, derived from `toVoiceHead`. -/
-def SemiticTemplate.toVoiceFlavor (t : SemiticTemplate) : Voice.Flavor :=
+def SemiticTemplate.toVoiceFlavor (t : SemiticTemplate) : Flavor :=
   t.toVoiceHead.flavor
 
 /-- Templates are nonconcatenative, hence outside the Mirror Principle's scope as
@@ -292,7 +290,7 @@ def VerbalizedRoot.lSelectedP (vr : VerbalizedRoot) : Option SemiticPrep :=
   lSelect vr.rootLabel vr.template
 
 /-- The Voice flavor, determined by the template rather than the root. -/
-def VerbalizedRoot.voiceFlavor (vr : VerbalizedRoot) : Voice.Flavor :=
+def VerbalizedRoot.voiceFlavor (vr : VerbalizedRoot) : Flavor :=
   vr.template.toVoiceFlavor
 
 /-- Arity is template-invariant (root-level), unlike l-selection: c-selection and
@@ -344,14 +342,14 @@ passing, as a language where Voice is overt): Semitic templates and Icelandic -s
 relate to Voice differently. Each Semitic template *realizes* a single Voice flavor
 (including the θ-assigning ones); -st is a clitic that merely *co-occurs* with a
 Voice flavor without realizing it ([wood-2015]). Read as coverage sets over
-`Voice.Flavor`, the Semitic image and the set of flavors -st appears with overlap on
+`Flavor`, the Semitic image and the set of flavors -st appears with overlap on
 the non-thematic and agentive flavors (the latter because -st appears in agentive
 figure reflexives) but diverge elsewhere. The Icelandic set is derived from
 [wood-2015]'s `Construction.voiceFlavor`, so the theorem relates the two studies' actual
 mappings. -/
 
 /-- The Voice flavors Semitic templates realize: the image of `toVoiceFlavor`. -/
-def semiticVoiceFlavors : List Voice.Flavor :=
+def semiticVoiceFlavors : List Flavor :=
   [SemiticTemplate.XaYaZ.toVoiceFlavor, SemiticTemplate.XaYYaZ.toVoiceFlavor,
    SemiticTemplate.nXaYaZ.toVoiceFlavor, SemiticTemplate.tXaYYaZ.toVoiceFlavor]
 
@@ -361,7 +359,7 @@ theorem template_flavors_in_coverage (t : SemiticTemplate) :
 
 /-- The host-clause Voice flavors Icelandic -st co-occurs with, derived from
     [wood-2015]'s `Construction.voiceFlavor`. -/
-def icelandicStFlavors : List Voice.Flavor :=
+def icelandicStFlavors : List Flavor :=
   [Construction.anticausative.voiceFlavor, Construction.middle.voiceFlavor,
    Construction.reflexive.voiceFlavor, Construction.subjectExp.voiceFlavor]
 
@@ -376,14 +374,14 @@ theorem stType_flavors_in_coverage (st : Construction) :
     alone realizes the causer and passive flavors, Icelandic -st alone appears
     with the expletive Voice of the generic middle. -/
 theorem voice_coverage_complementary :
-    (.nonThematic : Voice.Flavor) ∈ semiticVoiceFlavors ∧
-    (.nonThematic : Voice.Flavor) ∈ icelandicStFlavors ∧
-    (.agentive : Voice.Flavor) ∈ semiticVoiceFlavors ∧
-    (.agentive : Voice.Flavor) ∈ icelandicStFlavors ∧
-    (.causer : Voice.Flavor) ∉ icelandicStFlavors ∧
-    (.passive : Voice.Flavor) ∉ icelandicStFlavors ∧
-    (.expletive : Voice.Flavor) ∈ icelandicStFlavors ∧
-    (.expletive : Voice.Flavor) ∉ semiticVoiceFlavors := by decide
+    (.nonThematic : Flavor) ∈ semiticVoiceFlavors ∧
+    (.nonThematic : Flavor) ∈ icelandicStFlavors ∧
+    (.agentive : Flavor) ∈ semiticVoiceFlavors ∧
+    (.agentive : Flavor) ∈ icelandicStFlavors ∧
+    (.causer : Flavor) ∉ icelandicStFlavors ∧
+    (.passive : Flavor) ∉ icelandicStFlavors ∧
+    (.expletive : Flavor) ∈ icelandicStFlavors ∧
+    (.expletive : Flavor) ∉ semiticVoiceFlavors := by decide
 
 /-- The Semitic XaYaZ ~ tXaYYaZ alternation instantiates [kratzer-1996]'s causative
     alternation: `toVoiceHead` maps the two templates to the canonical heads, so the
@@ -400,7 +398,7 @@ applicatives require Voice with event semantics, low applicatives are
 unconditional. Pulled back along `toVoiceHead`, the Voice-predicate chain
 `assignsTheta ⊂ hasSemantics = licenses high Appl ⊂ licenses low Appl = ⊤`
 yields: +θ templates ⊊ high-Appl-licensing templates ⊊ all templates. The general
-inclusions live in the substrate (`Voice.Head.AssignsTheta.hasSemantics`,
+inclusions live in the substrate (`Head.AssignsTheta.hasSemantics`,
 `high_licensed_of_assignsTheta`, `low_licensed_with_any`); this section
 instantiates them for the Semitic template space, paralleling the Icelandic
 asymmetry in `Wood2015.dative_voice_asymmetry`. -/
@@ -567,12 +565,12 @@ inventory). -/
 /-- Mono-eventive causative decomposition: θ-assigning Voice over a root structure
     lacking the becoming subevent vGO. -/
 def monoEventiveCausative : List VerbHead :=
-  Voice.buildDecomposition Voice.causer [.vCAUSE, .vBE]
+  buildDecomposition causer [.vCAUSE, .vBE]
 
 /-- Bi-eventive causative decomposition (analytic causatives): θ-assigning Voice
     over the full change-of-state root structure. -/
 def biEventiveCausative : List VerbHead :=
-  Voice.buildDecomposition Voice.causer [.vCAUSE, .vGO, .vBE]
+  buildDecomposition causer [.vCAUSE, .vGO, .vBE]
 
 /-- Mono-eventive causatives have CAUSE but lack GO. -/
 theorem mono_eventive_has_cause_no_go :

--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -48,9 +48,9 @@ sits outside it — a linglib cross-reference Hewett does not draw.
 
 namespace Hewett2026
 
-open Minimalist (VoiceFlavor VoiceHead VerbHead Cat FeatureStatus
-  ActivationIndex ApplHead applHigh applLowRecipient buildDecomposition
-  voiceAgent voiceCauser voicePassive voiceAnticausative isCausative
+open Minimalist (Voice.Flavor Voice.Head VerbHead Cat FeatureStatus
+  ActivationIndex ApplHead applHigh applLowRecipient Voice.buildDecomposition
+  Voice.agentive Voice.causer Voice.passive Voice.anticausative isCausative
   low_licensed_with_any high_licensed_of_assignsTheta)
 open Morphology.DM (CategorizedRoot Categorizer)
 open Morphology.MirrorPrinciple (MorphDomain)
@@ -80,14 +80,14 @@ inductive SemiticTemplate where
     v/Voice (p. 201), and deliberately leaves the inventory open (fn. 8); the
     mapping below follows the templates' traditional active, causative, and
     medio-passive glosses. -/
-def SemiticTemplate.toVoiceHead : SemiticTemplate → VoiceHead
-  | .XaYaZ => voiceAgent
-  | .XaYYaZ | .hiXYiZ | .XiYeZ => voiceCauser
-  | .nXaYaZ | .huXYaZ | .XuYaZ => voicePassive
-  | .tXaYYaZ => voiceAnticausative
+def SemiticTemplate.toVoiceHead : SemiticTemplate → Voice.Head
+  | .XaYaZ => Voice.agentive
+  | .XaYYaZ | .hiXYiZ | .XiYeZ => Voice.causer
+  | .nXaYaZ | .huXYaZ | .XuYaZ => Voice.passive
+  | .tXaYYaZ => Voice.anticausative
 
 /-- The Voice flavor a template realizes, derived from `toVoiceHead`. -/
-def SemiticTemplate.toVoiceFlavor (t : SemiticTemplate) : VoiceFlavor :=
+def SemiticTemplate.toVoiceFlavor (t : SemiticTemplate) : Voice.Flavor :=
   t.toVoiceHead.flavor
 
 /-- Templates are nonconcatenative, hence outside the Mirror Principle's scope as
@@ -292,7 +292,7 @@ def VerbalizedRoot.lSelectedP (vr : VerbalizedRoot) : Option SemiticPrep :=
   lSelect vr.rootLabel vr.template
 
 /-- The Voice flavor, determined by the template rather than the root. -/
-def VerbalizedRoot.voiceFlavor (vr : VerbalizedRoot) : VoiceFlavor :=
+def VerbalizedRoot.voiceFlavor (vr : VerbalizedRoot) : Voice.Flavor :=
   vr.template.toVoiceFlavor
 
 /-- Arity is template-invariant (root-level), unlike l-selection: c-selection and
@@ -344,14 +344,14 @@ passing, as a language where Voice is overt): Semitic templates and Icelandic -s
 relate to Voice differently. Each Semitic template *realizes* a single Voice flavor
 (including the θ-assigning ones); -st is a clitic that merely *co-occurs* with a
 Voice flavor without realizing it ([wood-2015]). Read as coverage sets over
-`VoiceFlavor`, the Semitic image and the set of flavors -st appears with overlap on
+`Voice.Flavor`, the Semitic image and the set of flavors -st appears with overlap on
 the non-thematic and agentive flavors (the latter because -st appears in agentive
 figure reflexives) but diverge elsewhere. The Icelandic set is derived from
 [wood-2015]'s `Construction.voiceFlavor`, so the theorem relates the two studies' actual
 mappings. -/
 
 /-- The Voice flavors Semitic templates realize: the image of `toVoiceFlavor`. -/
-def semiticVoiceFlavors : List VoiceFlavor :=
+def semiticVoiceFlavors : List Voice.Flavor :=
   [SemiticTemplate.XaYaZ.toVoiceFlavor, SemiticTemplate.XaYYaZ.toVoiceFlavor,
    SemiticTemplate.nXaYaZ.toVoiceFlavor, SemiticTemplate.tXaYYaZ.toVoiceFlavor]
 
@@ -361,7 +361,7 @@ theorem template_flavors_in_coverage (t : SemiticTemplate) :
 
 /-- The host-clause Voice flavors Icelandic -st co-occurs with, derived from
     [wood-2015]'s `Construction.voiceFlavor`. -/
-def icelandicStFlavors : List VoiceFlavor :=
+def icelandicStFlavors : List Voice.Flavor :=
   [Construction.anticausative.voiceFlavor, Construction.middle.voiceFlavor,
    Construction.reflexive.voiceFlavor, Construction.subjectExp.voiceFlavor]
 
@@ -376,14 +376,14 @@ theorem stType_flavors_in_coverage (st : Construction) :
     alone realizes the causer and passive flavors, Icelandic -st alone appears
     with the expletive Voice of the generic middle. -/
 theorem voice_coverage_complementary :
-    (.nonThematic : VoiceFlavor) ∈ semiticVoiceFlavors ∧
-    (.nonThematic : VoiceFlavor) ∈ icelandicStFlavors ∧
-    (.agentive : VoiceFlavor) ∈ semiticVoiceFlavors ∧
-    (.agentive : VoiceFlavor) ∈ icelandicStFlavors ∧
-    (.causer : VoiceFlavor) ∉ icelandicStFlavors ∧
-    (.passive : VoiceFlavor) ∉ icelandicStFlavors ∧
-    (.expletive : VoiceFlavor) ∈ icelandicStFlavors ∧
-    (.expletive : VoiceFlavor) ∉ semiticVoiceFlavors := by decide
+    (.nonThematic : Voice.Flavor) ∈ semiticVoiceFlavors ∧
+    (.nonThematic : Voice.Flavor) ∈ icelandicStFlavors ∧
+    (.agentive : Voice.Flavor) ∈ semiticVoiceFlavors ∧
+    (.agentive : Voice.Flavor) ∈ icelandicStFlavors ∧
+    (.causer : Voice.Flavor) ∉ icelandicStFlavors ∧
+    (.passive : Voice.Flavor) ∉ icelandicStFlavors ∧
+    (.expletive : Voice.Flavor) ∈ icelandicStFlavors ∧
+    (.expletive : Voice.Flavor) ∉ semiticVoiceFlavors := by decide
 
 /-- The Semitic XaYaZ ~ tXaYYaZ alternation instantiates [kratzer-1996]'s causative
     alternation: `toVoiceHead` maps the two templates to the canonical heads, so the
@@ -400,7 +400,7 @@ applicatives require Voice with event semantics, low applicatives are
 unconditional. Pulled back along `toVoiceHead`, the Voice-predicate chain
 `assignsTheta ⊂ hasSemantics = licenses high Appl ⊂ licenses low Appl = ⊤`
 yields: +θ templates ⊊ high-Appl-licensing templates ⊊ all templates. The general
-inclusions live in the substrate (`VoiceHead.AssignsTheta.hasSemantics`,
+inclusions live in the substrate (`Voice.Head.AssignsTheta.hasSemantics`,
 `high_licensed_of_assignsTheta`, `low_licensed_with_any`); this section
 instantiates them for the Semitic template space, paralleling the Icelandic
 asymmetry in `Wood2015.dative_voice_asymmetry`. -/
@@ -567,12 +567,12 @@ inventory). -/
 /-- Mono-eventive causative decomposition: θ-assigning Voice over a root structure
     lacking the becoming subevent vGO. -/
 def monoEventiveCausative : List VerbHead :=
-  buildDecomposition voiceCauser [.vCAUSE, .vBE]
+  Voice.buildDecomposition Voice.causer [.vCAUSE, .vBE]
 
 /-- Bi-eventive causative decomposition (analytic causatives): θ-assigning Voice
     over the full change-of-state root structure. -/
 def biEventiveCausative : List VerbHead :=
-  buildDecomposition voiceCauser [.vCAUSE, .vGO, .vBE]
+  Voice.buildDecomposition Voice.causer [.vCAUSE, .vGO, .vBE]
 
 /-- Mono-eventive causatives have CAUSE but lack GO. -/
 theorem mono_eventive_has_cause_no_go :

--- a/Linglib/Studies/Imanishi2020.lean
+++ b/Linglib/Studies/Imanishi2020.lean
@@ -49,7 +49,7 @@ Three strategies satisfy this:
 
 namespace Imanishi2020
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Mayan (MarkerSet ABSPosition)
 
 -- ============================================================================
@@ -210,26 +210,26 @@ theorem absPos_insufficient :
 /-- Passive Voice satisfies the RON: no θ-role assignment means no
     external argument is projected. -/
 theorem passive_satisfies_ron :
-    ¬ Voice.passive.AssignsTheta := by decide
+    ¬ passive.AssignsTheta := by decide
 
 /-- Agentive Voice violates the RON: it projects an external argument. -/
 theorem agentive_violates_ron :
-    Voice.agentive.AssignsTheta := by decide
+    agentive.AssignsTheta := by decide
 
 /-- A Voice head is compatible with the RON iff it does not assign a
     θ-role (and hence does not project an external argument). -/
-def RonCompatibleVoice (v : Voice.Head) : Prop :=
+def RonCompatibleVoice (v : Head) : Prop :=
   ¬ v.AssignsTheta
 
-instance (v : Voice.Head) : Decidable (RonCompatibleVoice v) := by
+instance (v : Head) : Decidable (RonCompatibleVoice v) := by
   unfold RonCompatibleVoice; infer_instance
 
-theorem passive_ron_compatible : RonCompatibleVoice Voice.passive := by decide
+theorem passive_ron_compatible : RonCompatibleVoice passive := by decide
 
-theorem agentive_ron_incompatible : ¬ RonCompatibleVoice Voice.agentive := by decide
+theorem agentive_ron_incompatible : ¬ RonCompatibleVoice agentive := by decide
 
 theorem anticausative_ron_compatible :
-    RonCompatibleVoice Voice.anticausative := by decide
+    RonCompatibleVoice anticausative := by decide
 
 -- ============================================================================
 -- § 8: Bridge to Existing Fragments

--- a/Linglib/Studies/Imanishi2020.lean
+++ b/Linglib/Studies/Imanishi2020.lean
@@ -210,26 +210,26 @@ theorem absPos_insufficient :
 /-- Passive Voice satisfies the RON: no θ-role assignment means no
     external argument is projected. -/
 theorem passive_satisfies_ron :
-    ¬ voicePassive.AssignsTheta := by decide
+    ¬ Voice.passive.AssignsTheta := by decide
 
 /-- Agentive Voice violates the RON: it projects an external argument. -/
 theorem agentive_violates_ron :
-    voiceAgent.AssignsTheta := by decide
+    Voice.agentive.AssignsTheta := by decide
 
 /-- A Voice head is compatible with the RON iff it does not assign a
     θ-role (and hence does not project an external argument). -/
-def RonCompatibleVoice (v : VoiceHead) : Prop :=
+def RonCompatibleVoice (v : Voice.Head) : Prop :=
   ¬ v.AssignsTheta
 
-instance (v : VoiceHead) : Decidable (RonCompatibleVoice v) := by
+instance (v : Voice.Head) : Decidable (RonCompatibleVoice v) := by
   unfold RonCompatibleVoice; infer_instance
 
-theorem passive_ron_compatible : RonCompatibleVoice voicePassive := by decide
+theorem passive_ron_compatible : RonCompatibleVoice Voice.passive := by decide
 
-theorem agentive_ron_incompatible : ¬ RonCompatibleVoice voiceAgent := by decide
+theorem agentive_ron_incompatible : ¬ RonCompatibleVoice Voice.agentive := by decide
 
 theorem anticausative_ron_compatible :
-    RonCompatibleVoice voiceAnticausative := by decide
+    RonCompatibleVoice Voice.anticausative := by decide
 
 -- ============================================================================
 -- § 8: Bridge to Existing Fragments

--- a/Linglib/Studies/Kalyakin2026.lean
+++ b/Linglib/Studies/Kalyakin2026.lean
@@ -48,7 +48,7 @@ vVPE's deletion domain, mismatches in Voice are tolerated.
 namespace Kalyakin2026
 
 open Semantics.Lexical
-open Minimalist
+open Minimalist Minimalist.Voice
 open Minimalist.Ellipsis
 
 -- ════════════════════════════════════════════════════
@@ -77,9 +77,9 @@ structure AlternationDatum where
   /-- Description -/
   description : String
   /-- Voice flavor of the antecedent -/
-  antecedentVoice : Voice.Flavor
+  antecedentVoice : Flavor
   /-- Voice flavor of the ellipsis site -/
-  targetVoice : Voice.Flavor
+  targetVoice : Flavor
   /-- Root event structure (shared between antecedent and target) -/
   rootStructure : List VerbHead
   /-- Is the alternation grammatical under the given ellipsis type? -/
@@ -123,8 +123,8 @@ def englishAlternationBlocked : AlternationDatum :=
     under different Voice flavors — this is the causative alternation
     from Voice.lean. -/
 theorem alternation_same_root :
-    Voice.buildDecomposition Voice.agentive [.vCAUSE, .vGO, .vBE] = [.vDO, .vCAUSE, .vGO, .vBE] ∧
-    Voice.buildDecomposition Voice.anticausative [.vCAUSE, .vGO, .vBE] = [.vCAUSE, .vGO, .vBE] := by
+    buildDecomposition agentive [.vCAUSE, .vGO, .vBE] = [.vDO, .vCAUSE, .vGO, .vBE] ∧
+    buildDecomposition anticausative [.vCAUSE, .vGO, .vBE] = [.vCAUSE, .vGO, .vBE] := by
   constructor <;> rfl
 
 /-- The causative alternation is tolerated under vVPE because
@@ -142,7 +142,7 @@ theorem causative_alternation_blocked_english :
     requires identity of the VP, which contains the shared root. -/
 theorem shared_vp_core :
     let root := [VerbHead.vCAUSE, VerbHead.vGO, VerbHead.vBE]
-    Voice.buildDecomposition Voice.agentive root ≠ Voice.buildDecomposition Voice.anticausative root ∧
+    buildDecomposition agentive root ≠ buildDecomposition anticausative root ∧
     root = root := by
   constructor
   · intro h; cases h
@@ -221,8 +221,8 @@ theorem vVPE_below_englishVPE :
     vVPE is grammatical — matches the prediction. -/
 theorem end_to_end_causative_chain :
     -- Step 1: Voice determines causativity (Kratzer/Cuervo)
-    isCausative (Voice.buildDecomposition Voice.agentive [.vCAUSE, .vGO, .vBE]) = true ∧
-    isInchoative (Voice.buildDecomposition Voice.anticausative [.vCAUSE, .vGO, .vBE]) = true ∧
+    isCausative (buildDecomposition agentive [.vCAUSE, .vGO, .vBE]) = true ∧
+    isInchoative (buildDecomposition anticausative [.vCAUSE, .vGO, .vBE]) = true ∧
     -- Step 2: vVPE tolerates the transitivity difference (Merchant)
     canMismatch vVPE transitivityMismatch ∧
     -- Step 3: Alternation under vVPE is grammatical (Kalyakin)

--- a/Linglib/Studies/Kalyakin2026.lean
+++ b/Linglib/Studies/Kalyakin2026.lean
@@ -77,9 +77,9 @@ structure AlternationDatum where
   /-- Description -/
   description : String
   /-- Voice flavor of the antecedent -/
-  antecedentVoice : VoiceFlavor
+  antecedentVoice : Voice.Flavor
   /-- Voice flavor of the ellipsis site -/
-  targetVoice : VoiceFlavor
+  targetVoice : Voice.Flavor
   /-- Root event structure (shared between antecedent and target) -/
   rootStructure : List VerbHead
   /-- Is the alternation grammatical under the given ellipsis type? -/
@@ -123,8 +123,8 @@ def englishAlternationBlocked : AlternationDatum :=
     under different Voice flavors — this is the causative alternation
     from Voice.lean. -/
 theorem alternation_same_root :
-    buildDecomposition voiceAgent [.vCAUSE, .vGO, .vBE] = [.vDO, .vCAUSE, .vGO, .vBE] ∧
-    buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE] = [.vCAUSE, .vGO, .vBE] := by
+    Voice.buildDecomposition Voice.agentive [.vCAUSE, .vGO, .vBE] = [.vDO, .vCAUSE, .vGO, .vBE] ∧
+    Voice.buildDecomposition Voice.anticausative [.vCAUSE, .vGO, .vBE] = [.vCAUSE, .vGO, .vBE] := by
   constructor <;> rfl
 
 /-- The causative alternation is tolerated under vVPE because
@@ -142,7 +142,7 @@ theorem causative_alternation_blocked_english :
     requires identity of the VP, which contains the shared root. -/
 theorem shared_vp_core :
     let root := [VerbHead.vCAUSE, VerbHead.vGO, VerbHead.vBE]
-    buildDecomposition voiceAgent root ≠ buildDecomposition voiceAnticausative root ∧
+    Voice.buildDecomposition Voice.agentive root ≠ Voice.buildDecomposition Voice.anticausative root ∧
     root = root := by
   constructor
   · intro h; cases h
@@ -221,8 +221,8 @@ theorem vVPE_below_englishVPE :
     vVPE is grammatical — matches the prediction. -/
 theorem end_to_end_causative_chain :
     -- Step 1: Voice determines causativity (Kratzer/Cuervo)
-    isCausative (buildDecomposition voiceAgent [.vCAUSE, .vGO, .vBE]) = true ∧
-    isInchoative (buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE]) = true ∧
+    isCausative (Voice.buildDecomposition Voice.agentive [.vCAUSE, .vGO, .vBE]) = true ∧
+    isInchoative (Voice.buildDecomposition Voice.anticausative [.vCAUSE, .vGO, .vBE]) = true ∧
     -- Step 2: vVPE tolerates the transitivity difference (Merchant)
     canMismatch vVPE transitivityMismatch ∧
     -- Step 3: Alternation under vVPE is grammatical (Kalyakin)

--- a/Linglib/Studies/Kratzer1996.lean
+++ b/Linglib/Studies/Kratzer1996.lean
@@ -9,7 +9,7 @@ import Linglib.Syntax.Minimalist.Verbal.Voice
 
 Two accounts of argument realization make predictions about external
 argument theta roles. The two predicates live next to the types they
-project from: severing in `VoiceFlavor.thetaRole`
+project from: severing in `Voice.Flavor.thetaRole`
 (`Syntax/Minimalist/Verbal/Voice.lean`) and lexicalist in
 `Verb.predictedSubjectTheta`
 (`Semantics/Lexical/VerbEntry.lean`). Both operate over proto-role
@@ -50,7 +50,7 @@ open English.Predicates.Verbal
 severing: transitive "John broke the vase" has agentive Voice with an
 agent in Spec,VoiceP; anticausative "The vase broke" has non-thematic
 Voice with no specifier. Both share the same VP core. Event-structure
-predictions are verified in `Core/Voice.lean` via `buildDecomposition`. -/
+predictions are verified in `Core/Voice.lean` via `Voice.buildDecomposition`. -/
 
 section TreeDerivations
 
@@ -149,7 +149,7 @@ theorem causative_pair_agent_contrast :
     non-thematic does not. This is [kratzer-1996]'s severing
     verified structurally on the tree derivations. -/
 theorem causative_pair_voice_contrast :
-    voiceAgent.AssignsTheta ∧ ¬ voiceAnticausative.AssignsTheta := by decide
+    Voice.agentive.AssignsTheta ∧ ¬ Voice.anticausative.AssignsTheta := by decide
 
 end TreeDerivations
 

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -42,7 +42,7 @@ Texas at Austin.
 - `eat_licenses_accomplishment` → `RootLicensesTemplate` (ArgDerivation)
 - `eat_argTemplate_is_consumption` → `LevinClass.argTemplate` (LevinClassProfiles)
 - `accomplishment_has_variant` → `Template.intransitiveVariant`
-- `anticausative_no_theta` / `middle_no_theta` → `VoiceHead` (Minimalist syntax)
+- `anticausative_no_theta` / `middle_no_theta` → `Voice.Head` (Minimalist syntax)
 -/
 
 namespace Krejci2012
@@ -351,11 +351,11 @@ theorem anticausative_blocks_bySelf :
 
 /-- Anticausative Voice does not assign a θ-role (no external argument). -/
 theorem anticausative_no_theta :
-    ¬ Minimalist.voiceAnticausative.AssignsTheta := by decide
+    ¬ Minimalist.Voice.anticausative.AssignsTheta := by decide
 
 /-- Middle Voice does not assign a θ-role. -/
 theorem middle_no_theta :
-    ¬ Minimalist.voiceMiddle.AssignsTheta := by decide
+    ¬ Minimalist.Voice.middle.AssignsTheta := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 10. Cross-Linguistic Causativizability

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -42,7 +42,7 @@ import Linglib.Fragments.Cantonese.ResultativeComplements
 
 - The substrate-level addition [liu-yip-2026]'s analysis *does* motivate
   is the bipartite split-aspect typing: `AspFlavor` and `AspHead`, landed in
-  `Syntax/Minimalist/Aspect.lean` parallel to `VoiceHead { flavor }`.
+  `Syntax/Minimalist/Aspect.lean` parallel to `Voice.Head { flavor }`.
   That commitment is independent of the analytical claims of this paper —
   it is consumed by [travis-2010], [macdonald-2008],
   [tsai-2008], [sybesma-2017], and [liu-yip-2026] jointly —

--- a/Linglib/Studies/Marantz1991.lean
+++ b/Linglib/Studies/Marantz1991.lean
@@ -472,11 +472,11 @@ theorem nonthematic_subject_with_acc :
 
 /-- Voice determines NP count: θ-assigning Voice adds an external argument.
     This bridges Voice theory to the configural case algorithm. -/
-def npCount (voice : VoiceHead) (internalArgs : Nat) : Nat :=
+def npCount (voice : Voice.Head) (internalArgs : Nat) : Nat :=
   if voice.AssignsTheta then 1 + internalArgs else internalArgs
 
-theorem agentive_two_nps : npCount voiceAgent 1 = 2 := rfl
-theorem anticausative_one_np : npCount voiceAnticausative 1 = 1 := rfl
+theorem agentive_two_nps : npCount Voice.agentive 1 = 2 := rfl
+theorem anticausative_one_np : npCount Voice.anticausative 1 = 1 := rfl
 
 -- ============================================================================
 -- § 8: Hindi Split Ergativity
@@ -647,29 +647,29 @@ theorem class2_unmarked_highest_accessibility :
 
 /-- Build NP list from Voice: if Voice assigns θ, include both subject
     and object; otherwise include only the theme. -/
-def npsFromVoice (voice : VoiceHead) : List NPInDomain :=
+def npsFromVoice (voice : Voice.Head) : List NPInDomain :=
   if voice.AssignsTheta then [⟨"subj", none⟩, ⟨"obj", none⟩]
   else [⟨"theme", none⟩]
 
 /-- End-to-end: agentive Voice → 2 NPs → object gets dependent ACC. -/
 theorem voice_to_case_transitive :
-    getCaseOf "obj" (assignCases .accusative (npsFromVoice voiceAgent)) = some .acc ∧
-    getSourceOf "obj" (assignCases .accusative (npsFromVoice voiceAgent)) = some .dependent := by
+    getCaseOf "obj" (assignCases .accusative (npsFromVoice Voice.agentive)) = some .acc ∧
+    getSourceOf "obj" (assignCases .accusative (npsFromVoice Voice.agentive)) = some .dependent := by
   native_decide
 
 /-- End-to-end: anticausative Voice → 1 NP → theme gets unmarked NOM. -/
 theorem voice_to_case_unaccusative :
-    getCaseOf "theme" (assignCases .accusative (npsFromVoice voiceAnticausative)) = some .nom ∧
-    getSourceOf "theme" (assignCases .accusative (npsFromVoice voiceAnticausative)) = some .unmarked := by
+    getCaseOf "theme" (assignCases .accusative (npsFromVoice Voice.anticausative)) = some .nom ∧
+    getSourceOf "theme" (assignCases .accusative (npsFromVoice Voice.anticausative)) = some .unmarked := by
   native_decide
 
 /-- The Burzio effect derived end-to-end: ACC presence tracks Voice's
     θ-assignment. This is the full chain: Voice → NP count → case. -/
 theorem burzio_from_voice :
     -- Agentive Voice: ACC on object
-    getCaseOf "obj" (assignCases .accusative (npsFromVoice voiceAgent)) = some .acc ∧
+    getCaseOf "obj" (assignCases .accusative (npsFromVoice Voice.agentive)) = some .acc ∧
     -- Non-thematic Voice: no ACC (sole NP gets NOM)
-    getCaseOf "theme" (assignCases .accusative (npsFromVoice voiceAnticausative)) = some .nom := by
+    getCaseOf "theme" (assignCases .accusative (npsFromVoice Voice.anticausative)) = some .nom := by
   native_decide
 
 -- ============================================================================

--- a/Linglib/Studies/Marantz1991.lean
+++ b/Linglib/Studies/Marantz1991.lean
@@ -284,7 +284,7 @@ end Minimalist
 
 namespace Marantz1991
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Syntax.Case
 open Georgian.Agreement
 
@@ -472,11 +472,11 @@ theorem nonthematic_subject_with_acc :
 
 /-- Voice determines NP count: θ-assigning Voice adds an external argument.
     This bridges Voice theory to the configural case algorithm. -/
-def npCount (voice : Voice.Head) (internalArgs : Nat) : Nat :=
+def npCount (voice : Head) (internalArgs : Nat) : Nat :=
   if voice.AssignsTheta then 1 + internalArgs else internalArgs
 
-theorem agentive_two_nps : npCount Voice.agentive 1 = 2 := rfl
-theorem anticausative_one_np : npCount Voice.anticausative 1 = 1 := rfl
+theorem agentive_two_nps : npCount agentive 1 = 2 := rfl
+theorem anticausative_one_np : npCount anticausative 1 = 1 := rfl
 
 -- ============================================================================
 -- § 8: Hindi Split Ergativity
@@ -647,29 +647,29 @@ theorem class2_unmarked_highest_accessibility :
 
 /-- Build NP list from Voice: if Voice assigns θ, include both subject
     and object; otherwise include only the theme. -/
-def npsFromVoice (voice : Voice.Head) : List NPInDomain :=
+def npsFromVoice (voice : Head) : List NPInDomain :=
   if voice.AssignsTheta then [⟨"subj", none⟩, ⟨"obj", none⟩]
   else [⟨"theme", none⟩]
 
 /-- End-to-end: agentive Voice → 2 NPs → object gets dependent ACC. -/
 theorem voice_to_case_transitive :
-    getCaseOf "obj" (assignCases .accusative (npsFromVoice Voice.agentive)) = some .acc ∧
-    getSourceOf "obj" (assignCases .accusative (npsFromVoice Voice.agentive)) = some .dependent := by
+    getCaseOf "obj" (assignCases .accusative (npsFromVoice agentive)) = some .acc ∧
+    getSourceOf "obj" (assignCases .accusative (npsFromVoice agentive)) = some .dependent := by
   native_decide
 
 /-- End-to-end: anticausative Voice → 1 NP → theme gets unmarked NOM. -/
 theorem voice_to_case_unaccusative :
-    getCaseOf "theme" (assignCases .accusative (npsFromVoice Voice.anticausative)) = some .nom ∧
-    getSourceOf "theme" (assignCases .accusative (npsFromVoice Voice.anticausative)) = some .unmarked := by
+    getCaseOf "theme" (assignCases .accusative (npsFromVoice anticausative)) = some .nom ∧
+    getSourceOf "theme" (assignCases .accusative (npsFromVoice anticausative)) = some .unmarked := by
   native_decide
 
 /-- The Burzio effect derived end-to-end: ACC presence tracks Voice's
     θ-assignment. This is the full chain: Voice → NP count → case. -/
 theorem burzio_from_voice :
     -- Agentive Voice: ACC on object
-    getCaseOf "obj" (assignCases .accusative (npsFromVoice Voice.agentive)) = some .acc ∧
+    getCaseOf "obj" (assignCases .accusative (npsFromVoice agentive)) = some .acc ∧
     -- Non-thematic Voice: no ACC (sole NP gets NOM)
-    getCaseOf "theme" (assignCases .accusative (npsFromVoice Voice.anticausative)) = some .nom := by
+    getCaseOf "theme" (assignCases .accusative (npsFromVoice anticausative)) = some .nom := by
   native_decide
 
 -- ============================================================================

--- a/Linglib/Studies/MartinRoseNichols2025.lean
+++ b/Linglib/Studies/MartinRoseNichols2025.lean
@@ -279,7 +279,7 @@ theorem causative_has_agentive_voice :
     -- Syntactic: causative heads (vDO + vCAUSE + vGO + vBE) per [cuervo-2003]
     isCausative [VerbHead.vDO, .vCAUSE, .vGO, .vBE] = true ∧
     -- Voice: agentive Voice assigns θ-role
-    voiceAgent.AssignsTheta := ⟨by decide, by decide, by decide⟩
+    Voice.agentive.AssignsTheta := ⟨by decide, by decide, by decide⟩
 
 /-- Anticausative structure (intransitive alternant of a change-of-state
     verb) drops the external argument while keeping CAUSE. The head-list
@@ -291,7 +291,7 @@ theorem anticausative_has_nonthematic_voice :
     -- Syntactic: inchoative heads (vCAUSE + vGO + vBE)
     isInchoative [VerbHead.vCAUSE, .vGO, .vBE] = true ∧
     -- Voice: non-thematic Voice has no semantics
-    ¬ voiceAnticausative.HasSemantics := ⟨by decide, by decide, by decide⟩
+    ¬ Voice.anticausative.HasSemantics := ⟨by decide, by decide, by decide⟩
 
 -- § 2: Thick/Thin ↔ Causation Type ↔ Voice
 
@@ -309,8 +309,8 @@ theorem production_aligns_agentive :
     -- Production requires concrete causer
     productionConstraint ThickThinClass.thickManner = .production ∧
     -- Agentive Voice introduces external argument
-    voiceAgent.AssignsTheta ∧
-    voiceAgent.HasD := by refine ⟨rfl, ?_, ?_⟩ <;> decide
+    Voice.agentive.AssignsTheta ∧
+    Voice.agentive.HasD := by refine ⟨rfl, ?_, ?_⟩ <;> decide
 
 -- § 3: Alternation ↔ Voice Alternation
 
@@ -321,8 +321,8 @@ theorem alternation_is_voice_alternation :
     -- Causative head-list extends anticausative by prepending vDO
     ([VerbHead.vDO, .vCAUSE, .vGO, .vBE] = .vDO :: [VerbHead.vCAUSE, .vGO, .vBE]) ∧
     -- The difference is whether Voice introduces an external argument
-    voiceAgent.AssignsTheta ∧
-    ¬ voiceAnticausative.AssignsTheta := ⟨rfl, by decide, by decide⟩
+    Voice.agentive.AssignsTheta ∧
+    ¬ Voice.anticausative.AssignsTheta := ⟨rfl, by decide, by decide⟩
 
 -- § 4: Empirical Bridge: ThickThin Data
 

--- a/Linglib/Studies/MartinRoseNichols2025.lean
+++ b/Linglib/Studies/MartinRoseNichols2025.lean
@@ -263,7 +263,7 @@ end MartinRoseNichols2025.ThickThin
 
 namespace MartinRoseNichols2025.Compare
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Semantics.Lexical.EventStructure
 open Causation.ProductionDependence
 open MartinRoseNichols2025.ThickThin
@@ -279,7 +279,7 @@ theorem causative_has_agentive_voice :
     -- Syntactic: causative heads (vDO + vCAUSE + vGO + vBE) per [cuervo-2003]
     isCausative [VerbHead.vDO, .vCAUSE, .vGO, .vBE] = true ∧
     -- Voice: agentive Voice assigns θ-role
-    Voice.agentive.AssignsTheta := ⟨by decide, by decide, by decide⟩
+    agentive.AssignsTheta := ⟨by decide, by decide, by decide⟩
 
 /-- Anticausative structure (intransitive alternant of a change-of-state
     verb) drops the external argument while keeping CAUSE. The head-list
@@ -291,7 +291,7 @@ theorem anticausative_has_nonthematic_voice :
     -- Syntactic: inchoative heads (vCAUSE + vGO + vBE)
     isInchoative [VerbHead.vCAUSE, .vGO, .vBE] = true ∧
     -- Voice: non-thematic Voice has no semantics
-    ¬ Voice.anticausative.HasSemantics := ⟨by decide, by decide, by decide⟩
+    ¬ anticausative.HasSemantics := ⟨by decide, by decide, by decide⟩
 
 -- § 2: Thick/Thin ↔ Causation Type ↔ Voice
 
@@ -309,8 +309,8 @@ theorem production_aligns_agentive :
     -- Production requires concrete causer
     productionConstraint ThickThinClass.thickManner = .production ∧
     -- Agentive Voice introduces external argument
-    Voice.agentive.AssignsTheta ∧
-    Voice.agentive.HasD := by refine ⟨rfl, ?_, ?_⟩ <;> decide
+    agentive.AssignsTheta ∧
+    agentive.HasD := by refine ⟨rfl, ?_, ?_⟩ <;> decide
 
 -- § 3: Alternation ↔ Voice Alternation
 
@@ -321,8 +321,8 @@ theorem alternation_is_voice_alternation :
     -- Causative head-list extends anticausative by prepending vDO
     ([VerbHead.vDO, .vCAUSE, .vGO, .vBE] = .vDO :: [VerbHead.vCAUSE, .vGO, .vBE]) ∧
     -- The difference is whether Voice introduces an external argument
-    Voice.agentive.AssignsTheta ∧
-    ¬ Voice.anticausative.AssignsTheta := ⟨rfl, by decide, by decide⟩
+    agentive.AssignsTheta ∧
+    ¬ anticausative.AssignsTheta := ⟨rfl, by decide, by decide⟩
 
 -- § 4: Empirical Bridge: ThickThin Data
 

--- a/Linglib/Studies/MartinSchaeferKastner2025.lean
+++ b/Linglib/Studies/MartinSchaeferKastner2025.lean
@@ -43,9 +43,9 @@ by three interacting factors:
 
 ## Bridges
 
-- `VoiceFlavor.nonThematic` ([schaefer-2008]): the anticausative voice
+- `Voice.Flavor.nonThematic` ([schaefer-2008]): the anticausative voice
   flavor — contributes no semantics. Both ±*se* anticausatives have this.
-- `VoiceFlavor.reflexive`: the reflexive voice flavor — assigns agent + theme
+- `Voice.Flavor.reflexive`: the reflexive voice flavor — assigns agent + theme
   to the sole DP. Only available with *se*.
 - `MannerSubmaxim.avoidAmbiguity`: the Manner sub-maxim driving the
   unmarked limited-control preference.
@@ -63,7 +63,7 @@ syncretism creates voice ambiguity that speakers must manage.
 
 namespace MartinSchaeferKastner2025
 
-open Minimalist (VoiceFlavor)
+open Minimalist (Voice.Flavor)
 open ArgumentStructure (EntailmentProfile)
 open ArgumentStructure.EntailmentProfile (PredictsUnaccusative)
 open Pragmatics.GriceanMaxims (MannerSubmaxim)
@@ -150,7 +150,7 @@ theorem movement_sufficient_not_necessary :
 /-- Voice flavors available for a form WITHOUT *se*.
     Only the anticausative (non-thematic) parse is available.
     The DP is a theme, not an agent. -/
-def bareVoiceOptions : List VoiceFlavor := [.nonThematic]
+def bareVoiceOptions : List Voice.Flavor := [.nonThematic]
 
 /-- Voice flavors available for a form WITH *se*.
     Both anticausative and reflexive parses are available —
@@ -162,7 +162,7 @@ def bareVoiceOptions : List VoiceFlavor := [.nonThematic]
     the reflexive reading (the entity acts on itself) and the
     anticausative reading (EFFECTOR = THEME, agentivity bleached
     by underspecification). -/
-def seVoiceOptions : List VoiceFlavor := [.nonThematic, .reflexive]
+def seVoiceOptions : List Voice.Flavor := [.nonThematic, .reflexive]
 
 /-- The *se*-marked form is ambiguous: it has strictly more voice parses. -/
 theorem se_is_ambiguous : seVoiceOptions.length > bareVoiceOptions.length := by decide
@@ -172,13 +172,13 @@ theorem bare_is_unambiguous : bareVoiceOptions = [.nonThematic] := rfl
 
 /-- Both forms share the anticausative parse. -/
 theorem shared_anticausative_parse :
-    VoiceFlavor.nonThematic ∈ bareVoiceOptions ∧
-    VoiceFlavor.nonThematic ∈ seVoiceOptions := ⟨List.mem_cons_self .., List.mem_cons_self ..⟩
+    Voice.Flavor.nonThematic ∈ bareVoiceOptions ∧
+    Voice.Flavor.nonThematic ∈ seVoiceOptions := ⟨List.mem_cons_self .., List.mem_cons_self ..⟩
 
 /-- The reflexive parse is available only with *se*. -/
 theorem reflexive_only_with_se :
-    VoiceFlavor.reflexive ∈ seVoiceOptions ∧
-    VoiceFlavor.reflexive ∉ bareVoiceOptions := by decide
+    Voice.Flavor.reflexive ∈ seVoiceOptions ∧
+    Voice.Flavor.reflexive ∉ bareVoiceOptions := by decide
 
 -- ============================================================================
 -- § 4: Agent Bias

--- a/Linglib/Studies/MartinSchaeferKastner2025.lean
+++ b/Linglib/Studies/MartinSchaeferKastner2025.lean
@@ -43,9 +43,9 @@ by three interacting factors:
 
 ## Bridges
 
-- `Voice.Flavor.nonThematic` ([schaefer-2008]): the anticausative voice
+- `Flavor.nonThematic` ([schaefer-2008]): the anticausative voice
   flavor — contributes no semantics. Both ±*se* anticausatives have this.
-- `Voice.Flavor.reflexive`: the reflexive voice flavor — assigns agent + theme
+- `Flavor.reflexive`: the reflexive voice flavor — assigns agent + theme
   to the sole DP. Only available with *se*.
 - `MannerSubmaxim.avoidAmbiguity`: the Manner sub-maxim driving the
   unmarked limited-control preference.
@@ -63,7 +63,7 @@ syncretism creates voice ambiguity that speakers must manage.
 
 namespace MartinSchaeferKastner2025
 
-open Minimalist (Voice.Flavor)
+open Minimalist.Voice (Flavor)
 open ArgumentStructure (EntailmentProfile)
 open ArgumentStructure.EntailmentProfile (PredictsUnaccusative)
 open Pragmatics.GriceanMaxims (MannerSubmaxim)
@@ -150,7 +150,7 @@ theorem movement_sufficient_not_necessary :
 /-- Voice flavors available for a form WITHOUT *se*.
     Only the anticausative (non-thematic) parse is available.
     The DP is a theme, not an agent. -/
-def bareVoiceOptions : List Voice.Flavor := [.nonThematic]
+def bareVoiceOptions : List Flavor := [.nonThematic]
 
 /-- Voice flavors available for a form WITH *se*.
     Both anticausative and reflexive parses are available —
@@ -162,7 +162,7 @@ def bareVoiceOptions : List Voice.Flavor := [.nonThematic]
     the reflexive reading (the entity acts on itself) and the
     anticausative reading (EFFECTOR = THEME, agentivity bleached
     by underspecification). -/
-def seVoiceOptions : List Voice.Flavor := [.nonThematic, .reflexive]
+def seVoiceOptions : List Flavor := [.nonThematic, .reflexive]
 
 /-- The *se*-marked form is ambiguous: it has strictly more voice parses. -/
 theorem se_is_ambiguous : seVoiceOptions.length > bareVoiceOptions.length := by decide
@@ -172,13 +172,13 @@ theorem bare_is_unambiguous : bareVoiceOptions = [.nonThematic] := rfl
 
 /-- Both forms share the anticausative parse. -/
 theorem shared_anticausative_parse :
-    Voice.Flavor.nonThematic ∈ bareVoiceOptions ∧
-    Voice.Flavor.nonThematic ∈ seVoiceOptions := ⟨List.mem_cons_self .., List.mem_cons_self ..⟩
+    Flavor.nonThematic ∈ bareVoiceOptions ∧
+    Flavor.nonThematic ∈ seVoiceOptions := ⟨List.mem_cons_self .., List.mem_cons_self ..⟩
 
 /-- The reflexive parse is available only with *se*. -/
 theorem reflexive_only_with_se :
-    Voice.Flavor.reflexive ∈ seVoiceOptions ∧
-    Voice.Flavor.reflexive ∉ bareVoiceOptions := by decide
+    Flavor.reflexive ∈ seVoiceOptions ∧
+    Flavor.reflexive ∉ bareVoiceOptions := by decide
 
 -- ============================================================================
 -- § 4: Agent Bias

--- a/Linglib/Studies/Merchant2013.lean
+++ b/Linglib/Studies/Merchant2013.lean
@@ -60,8 +60,8 @@ def pseudogapping : EllipsisType := ⟨.T, "pseudogapping"⟩
 /-- A voice mismatch datum across an ellipsis boundary. -/
 structure VoiceMismatchDatum where
   description : String
-  antecedentVoice : VoiceFlavor
-  targetVoice : VoiceFlavor
+  antecedentVoice : Voice.Flavor
+  targetVoice : Voice.Flavor
   ellipsisType : EllipsisType
   grammatical : Bool
   language : String := "English"
@@ -314,7 +314,7 @@ theorem voice_between_boundaries :
     are both grammatical, matching `canMismatch`. -/
 theorem end_to_end_voice_chain :
     -- Step 1: Active and passive are distinct Voice flavors
-    VoiceFlavor.agentive ≠ VoiceFlavor.passive ∧
+    Voice.Flavor.agentive ≠ Voice.Flavor.passive ∧
     -- Step 2: Voice is external to VPE's deletion domain
     canMismatch englishVPE voiceMismatch ∧
     -- Step 3: Empirical data matches

--- a/Linglib/Studies/Merchant2013.lean
+++ b/Linglib/Studies/Merchant2013.lean
@@ -32,7 +32,7 @@ the English paradigm.
 
 namespace Merchant2013
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Minimalist.Ellipsis
 
 -- ════════════════════════════════════════════════════
@@ -60,8 +60,8 @@ def pseudogapping : EllipsisType := ⟨.T, "pseudogapping"⟩
 /-- A voice mismatch datum across an ellipsis boundary. -/
 structure VoiceMismatchDatum where
   description : String
-  antecedentVoice : Voice.Flavor
-  targetVoice : Voice.Flavor
+  antecedentVoice : Flavor
+  targetVoice : Flavor
   ellipsisType : EllipsisType
   grammatical : Bool
   language : String := "English"
@@ -314,7 +314,7 @@ theorem voice_between_boundaries :
     are both grammatical, matching `canMismatch`. -/
 theorem end_to_end_voice_chain :
     -- Step 1: Active and passive are distinct Voice flavors
-    Voice.Flavor.agentive ≠ Voice.Flavor.passive ∧
+    Flavor.agentive ≠ Flavor.passive ∧
     -- Step 2: Voice is external to VPE's deletion domain
     canMismatch englishVPE voiceMismatch ∧
     -- Step 3: Empirical data matches

--- a/Linglib/Studies/MunozPerez2026.lean
+++ b/Linglib/Studies/MunozPerez2026.lean
@@ -243,7 +243,7 @@ theorem negative_controls_unacceptable :
 
 /-! ### Spanish Fission instantiation -/
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Morphology.DM
 open Spanish.PersonFeatures
 open Spanish.Predicates
@@ -471,7 +471,7 @@ yet stated as a Lean theorem.
 ## Todo
 
 * **MSK comparison as a real bridge theorem.** Analogously,
-  `MartinSchaeferKastner2025.seVoiceOptions : List Voice.Flavor` is a
+  `MartinSchaeferKastner2025.seVoiceOptions : List Flavor` is a
   list literal `[.nonThematic, .reflexive]`. A subset claim against any
   hand-written Muñoz list of flavors is decided by `decide` over list
   literals — no real Voice-flavor mechanism is engaged. A genuine

--- a/Linglib/Studies/MunozPerez2026.lean
+++ b/Linglib/Studies/MunozPerez2026.lean
@@ -19,7 +19,7 @@ A lens into the nature of anticausative SE" (*Glossa* 11(1)).
 * `spanishFissionRule` — instantiation of the generic
   `Morphology.DM.FissionRule` with Chilean-Spanish-specific data
 * `voice_semantically_vacuous` — re-export of
-  `Minimalist.nonThematic_no_semantics`
+  `Minimalist.Voice.nonThematic_no_semantics`
 * `three_way_synonymy_from_vacuity`,
   `fission_person_restriction`, `stylLE_requires_inchoative`,
   `unmarked_blocks_stylLE` — bridge theorems for the empirical
@@ -385,12 +385,12 @@ theorem syncretism_aligns_with_fission :
 
 /-! ### Three-way synonymy -/
 
-/-- Re-export of `Minimalist.nonThematic_no_semantics` in the Muñoz-Pérez
+/-- Re-export of `Minimalist.Voice.nonThematic_no_semantics` in the Muñoz-Pérez
     frame. SE is purely a PF marker — its presence or absence is
     phonological, not semantic. -/
 theorem voice_semantically_vacuous :
-    ¬ Minimalist.voiceAnticausative.HasSemantics :=
-  Minimalist.nonThematic_no_semantics
+    ¬ Minimalist.Voice.anticausative.HasSemantics :=
+  Minimalist.Voice.nonThematic_no_semantics
 
 /-- The empirical three-way synonymy is consistent with Voice
     vacuity: the three `.ok` judgments co-hold with the proof that
@@ -399,7 +399,7 @@ theorem three_way_synonymy_from_vacuity :
     romper_se_me.acceptability = .ok ∧
     romper_me_le.acceptability = .ok ∧
     romper_se_me_le.acceptability = .ok ∧
-    ¬ Minimalist.voiceAnticausative.HasSemantics := by
+    ¬ Minimalist.Voice.anticausative.HasSemantics := by
   refine ⟨rfl, rfl, rfl, ?_⟩; exact voice_semantically_vacuous
 
 /-! ### Fission verification -/
@@ -471,7 +471,7 @@ yet stated as a Lean theorem.
 ## Todo
 
 * **MSK comparison as a real bridge theorem.** Analogously,
-  `MartinSchaeferKastner2025.seVoiceOptions : List VoiceFlavor` is a
+  `MartinSchaeferKastner2025.seVoiceOptions : List Voice.Flavor` is a
   list literal `[.nonThematic, .reflexive]`. A subset claim against any
   hand-written Muñoz list of flavors is decided by `decide` over list
   literals — no real Voice-flavor mechanism is engaged. A genuine

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -23,7 +23,7 @@ predictions and cross-linguistic data from [myler-2016].
 
 namespace Myler2016
 
-open Minimalist
+open Minimalist Minimalist.Voice
 
 -- ════════════════════════════════════════════════════
 -- § 0. Copula substrate ([myler-2016]: the vacuous light verb)
@@ -42,13 +42,13 @@ inductive CopulaForm where
 
 /-- [myler-2016] (89): v ⇔ HAVE / ___Voice_{D},φ ; v ⇔ BE / elsewhere. The HAVE
     environment is transitive Voice — `hasD` with a thematic, non-passive flavor. -/
-def copulaVI (voice : Voice.Head) : CopulaForm :=
+def copulaVI (voice : Head) : CopulaForm :=
   if voice.hasD && voice.flavor != .nonThematic && voice.flavor != .passive
   then .have else .be
 
 open Morphology.DM.VI in
 /-- The copula VI as competing `VocabItem`s (HAVE specificity 2, BE elsewhere). -/
-def copulaVIRules : List (VocabItem Voice.Head Unit) :=
+def copulaVIRules : List (VocabItem Head Unit) :=
   [ { exponent := "have"
     , contextMatch := λ v => v.hasD && v.flavor != .nonThematic && v.flavor != .passive
     , specificity := 2 }
@@ -56,7 +56,7 @@ def copulaVIRules : List (VocabItem Voice.Head Unit) :=
 
 open Morphology.DM.VI in
 /-- The `VocabItem` formulation agrees with `copulaVI`. -/
-theorem copulaVI_agrees_vocabItem (v : Voice.Head) :
+theorem copulaVI_agrees_vocabItem (v : Head) :
     vocabularyInsertSimple copulaVIRules v =
     some (if copulaVI v = .have then "have" else "be") := by
   cases v with | mk flavor hasD _ checksCase features =>
@@ -65,7 +65,7 @@ theorem copulaVI_agrees_vocabItem (v : Voice.Head) :
     VocabItem.matches, List.mergeSort, List.findSome?]
 
 /-- HAVE ↔ Voice is transitive (external argument, not PF-only, not passive). -/
-theorem vi_characterization (v : Voice.Head) :
+theorem vi_characterization (v : Head) :
     copulaVI v = .have ↔
     (v.hasD = true ∧ v.flavor ≠ .nonThematic ∧ v.flavor ≠ .passive) := by
   cases v with | mk flavor hasD _ checksCase _ =>
@@ -211,7 +211,7 @@ theorem too_many_meanings_solution :
 
     Formally: the HAVE/BE distinction depends only on whether Voice is
     transitive, which is independent of the possession relation itself. -/
-theorem too_many_structures_solution (v : Voice.Head) :
+theorem too_many_structures_solution (v : Head) :
     copulaVI v = .have ↔
     (v.hasD = true ∧ v.flavor ≠ .nonThematic ∧ v.flavor ≠ .passive) :=
   vi_characterization v
@@ -229,19 +229,19 @@ theorem too_many_structures_solution (v : Voice.Head) :
     A language uses the have-verb strategy iff its possession construction
     has transitive Voice — exactly the `copulaVI` condition.
     Derived from `copulaVI`, not stipulated independently. -/
-def isHaveVerbLanguage (voice : Voice.Head) : Bool :=
+def isHaveVerbLanguage (voice : Head) : Bool :=
   copulaVI voice == .have
 
 /-- A language with transitive, θ-assigning Voice produces HAVE. -/
 theorem haveVerb_from_transitive_voice :
-    isHaveVerbLanguage Voice.agentive = true := rfl
+    isHaveVerbLanguage agentive = true := rfl
 
 /-- A language with intransitive Voice produces BE (locational/existential). -/
 theorem be_from_intransitive_voice :
-    isHaveVerbLanguage Voice.anticausative = false := rfl
+    isHaveVerbLanguage anticausative = false := rfl
 
 /-- `isHaveVerbLanguage` agrees with `copulaVI` by construction. -/
-theorem isHaveVerbLanguage_iff_copulaVI (v : Voice.Head) :
+theorem isHaveVerbLanguage_iff_copulaVI (v : Head) :
     isHaveVerbLanguage v = true ↔ copulaVI v = .have := by
   simp [isHaveVerbLanguage, beq_iff_eq]
 

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -42,13 +42,13 @@ inductive CopulaForm where
 
 /-- [myler-2016] (89): v ⇔ HAVE / ___Voice_{D},φ ; v ⇔ BE / elsewhere. The HAVE
     environment is transitive Voice — `hasD` with a thematic, non-passive flavor. -/
-def copulaVI (voice : VoiceHead) : CopulaForm :=
+def copulaVI (voice : Voice.Head) : CopulaForm :=
   if voice.hasD && voice.flavor != .nonThematic && voice.flavor != .passive
   then .have else .be
 
 open Morphology.DM.VI in
 /-- The copula VI as competing `VocabItem`s (HAVE specificity 2, BE elsewhere). -/
-def copulaVIRules : List (VocabItem VoiceHead Unit) :=
+def copulaVIRules : List (VocabItem Voice.Head Unit) :=
   [ { exponent := "have"
     , contextMatch := λ v => v.hasD && v.flavor != .nonThematic && v.flavor != .passive
     , specificity := 2 }
@@ -56,7 +56,7 @@ def copulaVIRules : List (VocabItem VoiceHead Unit) :=
 
 open Morphology.DM.VI in
 /-- The `VocabItem` formulation agrees with `copulaVI`. -/
-theorem copulaVI_agrees_vocabItem (v : VoiceHead) :
+theorem copulaVI_agrees_vocabItem (v : Voice.Head) :
     vocabularyInsertSimple copulaVIRules v =
     some (if copulaVI v = .have then "have" else "be") := by
   cases v with | mk flavor hasD _ checksCase features =>
@@ -65,7 +65,7 @@ theorem copulaVI_agrees_vocabItem (v : VoiceHead) :
     VocabItem.matches, List.mergeSort, List.findSome?]
 
 /-- HAVE ↔ Voice is transitive (external argument, not PF-only, not passive). -/
-theorem vi_characterization (v : VoiceHead) :
+theorem vi_characterization (v : Voice.Head) :
     copulaVI v = .have ↔
     (v.hasD = true ∧ v.flavor ≠ .nonThematic ∧ v.flavor ≠ .passive) := by
   cases v with | mk flavor hasD _ checksCase _ =>
@@ -211,7 +211,7 @@ theorem too_many_meanings_solution :
 
     Formally: the HAVE/BE distinction depends only on whether Voice is
     transitive, which is independent of the possession relation itself. -/
-theorem too_many_structures_solution (v : VoiceHead) :
+theorem too_many_structures_solution (v : Voice.Head) :
     copulaVI v = .have ↔
     (v.hasD = true ∧ v.flavor ≠ .nonThematic ∧ v.flavor ≠ .passive) :=
   vi_characterization v
@@ -229,19 +229,19 @@ theorem too_many_structures_solution (v : VoiceHead) :
     A language uses the have-verb strategy iff its possession construction
     has transitive Voice — exactly the `copulaVI` condition.
     Derived from `copulaVI`, not stipulated independently. -/
-def isHaveVerbLanguage (voice : VoiceHead) : Bool :=
+def isHaveVerbLanguage (voice : Voice.Head) : Bool :=
   copulaVI voice == .have
 
 /-- A language with transitive, θ-assigning Voice produces HAVE. -/
 theorem haveVerb_from_transitive_voice :
-    isHaveVerbLanguage voiceAgent = true := rfl
+    isHaveVerbLanguage Voice.agentive = true := rfl
 
 /-- A language with intransitive Voice produces BE (locational/existential). -/
 theorem be_from_intransitive_voice :
-    isHaveVerbLanguage voiceAnticausative = false := rfl
+    isHaveVerbLanguage Voice.anticausative = false := rfl
 
 /-- `isHaveVerbLanguage` agrees with `copulaVI` by construction. -/
-theorem isHaveVerbLanguage_iff_copulaVI (v : VoiceHead) :
+theorem isHaveVerbLanguage_iff_copulaVI (v : Voice.Head) :
     isHaveVerbLanguage v = true ↔ copulaVI v = .have := by
   simp [isHaveVerbLanguage, beq_iff_eq]
 

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -700,8 +700,8 @@ theorem passive_lacks_D : passiveV.features.hasD = false := rfl
     (anticausative for SE marking, passive for *by*-phrase licensing)
     but assignsTheta = false (no θ-role). -/
 theorem voice_hasD_ne_assignsTheta :
-    voiceAnticausative.HasD ∧ ¬ voiceAnticausative.AssignsTheta ∧
-    voicePassive.HasD ∧ ¬ voicePassive.AssignsTheta := by decide
+    Voice.anticausative.HasD ∧ ¬ Voice.anticausative.AssignsTheta ∧
+    Voice.passive.HasD ∧ ¬ Voice.passive.AssignsTheta := by decide
 
 -- ============================================================================
 -- § 9: Feature Failure (Assumption 19c)

--- a/Linglib/Studies/Olivier2026.lean
+++ b/Linglib/Studies/Olivier2026.lean
@@ -42,7 +42,7 @@ configuration. The AS prediction is then *derived* from the
 sibling file's `AuxiliarySwitchOccurs` predicate — not stipulated
 per case.
 
-The `Minimalist.TransferStyle` (KEEP/SHARE/DONATE) and `VoiceHead`
+The `Minimalist.TransferStyle` (KEEP/SHARE/DONATE) and `Voice.Head`
 infrastructure are imported but not parametrised at the
 phenomenon level — language-level KEEP-vs-SHARE variation lives
 in the AuxVerbs sibling's diachronic-French / Sardinian

--- a/Linglib/Studies/Ozaki2026.lean
+++ b/Linglib/Studies/Ozaki2026.lean
@@ -299,17 +299,17 @@ open Japanese.Predicates
 /-- Departure verbs predict no external argument: non-thematic Voice
     does not assign a θ-role ([kratzer-1996], [schaefer-2025]). -/
 theorem departure_no_external :
-    ¬ voiceAnticausative.AssignsTheta := by decide
+    ¬ Voice.anticausative.AssignsTheta := by decide
 
 /-- Departure verbs have inchoative event structure (vGO + vBE, no vDO).
-    Verified via `buildDecomposition` from `Core/Voice.lean`. -/
+    Verified via `Voice.buildDecomposition` from `Core/Voice.lean`. -/
 theorem departure_is_inchoative :
-    isInchoative (buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE]) = true := by
+    isInchoative (Voice.buildDecomposition Voice.anticausative [.vCAUSE, .vGO, .vBE]) = true := by
   native_decide
 
 /-- Non-thematic Voice assigns no θ-role. -/
 theorem departure_voice_no_theta :
-    ¬ voiceAnticausative.AssignsTheta := by decide
+    ¬ Voice.anticausative.AssignsTheta := by decide
 
 /-- ACC variant produces dependent ACC on source, unmarked NOM on leaver. -/
 theorem acc_derivation_correct :
@@ -331,16 +331,16 @@ theorem abl_source_from_lexical_p :
 
 /-- Anticausative Voice is not a phase head. -/
 theorem agree_acc_needs_phase_head :
-    ¬ voiceAnticausative.IsPhasal := by decide
+    ¬ Voice.anticausative.IsPhasal := by decide
 
 /-- Agentive Voice IS a phase head. -/
 theorem agentive_has_phase_head :
-    voiceAgent.IsPhasal := by decide
+    Voice.agentive.IsPhasal := by decide
 
 /-- The accusative unaccusative paradox. -/
 theorem accusative_unaccusative_paradox :
-    ¬ voiceAnticausative.AssignsTheta ∧
-    ¬ voiceAnticausative.IsPhasal ∧
+    ¬ Voice.anticausative.AssignsTheta ∧
+    ¬ Voice.anticausative.IsPhasal ∧
     getCaseOf "source" accVariantResult = some .acc ∧
     getSourceOf "source" accVariantResult = some .dependent := by
   refine ⟨?_, ?_, ?_, ?_⟩
@@ -372,7 +372,7 @@ theorem passive_data_matches_fragment :
 
 /-- Non-passivizability follows from Voice theory. -/
 theorem passive_follows_from_voice :
-    ¬ voiceAnticausative.AssignsTheta ∧
+    ¬ Voice.anticausative.AssignsTheta ∧
     Japanese.Predicates.hanareru.passivizable = false := by
   refine ⟨?_, rfl⟩; decide
 
@@ -415,7 +415,7 @@ theorem deru_stored_matches_derived :
 /-- Direct passive requires thematic Voice, which departure verbs lack. -/
 theorem direct_passive_requires_voice :
     PassiveType.requiresThematicVoice .direct = true ∧
-    ¬ voiceAnticausative.AssignsTheta := by
+    ¬ Voice.anticausative.AssignsTheta := by
   refine ⟨rfl, ?_⟩; decide
 
 end Ozaki2026

--- a/Linglib/Studies/Ozaki2026.lean
+++ b/Linglib/Studies/Ozaki2026.lean
@@ -292,24 +292,24 @@ theorem alternation_crosses_tsujimura_split :
 -- § Bridge: Dependent Case × Minimalist Syntax
 -- ============================================================================
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Syntax.Case
 open Japanese.Predicates
 
 /-- Departure verbs predict no external argument: non-thematic Voice
     does not assign a θ-role ([kratzer-1996], [schaefer-2025]). -/
 theorem departure_no_external :
-    ¬ Voice.anticausative.AssignsTheta := by decide
+    ¬ anticausative.AssignsTheta := by decide
 
 /-- Departure verbs have inchoative event structure (vGO + vBE, no vDO).
-    Verified via `Voice.buildDecomposition` from `Core/Voice.lean`. -/
+    Verified via `buildDecomposition` from `Core/Voice.lean`. -/
 theorem departure_is_inchoative :
-    isInchoative (Voice.buildDecomposition Voice.anticausative [.vCAUSE, .vGO, .vBE]) = true := by
+    isInchoative (buildDecomposition anticausative [.vCAUSE, .vGO, .vBE]) = true := by
   native_decide
 
 /-- Non-thematic Voice assigns no θ-role. -/
 theorem departure_voice_no_theta :
-    ¬ Voice.anticausative.AssignsTheta := by decide
+    ¬ anticausative.AssignsTheta := by decide
 
 /-- ACC variant produces dependent ACC on source, unmarked NOM on leaver. -/
 theorem acc_derivation_correct :
@@ -331,16 +331,16 @@ theorem abl_source_from_lexical_p :
 
 /-- Anticausative Voice is not a phase head. -/
 theorem agree_acc_needs_phase_head :
-    ¬ Voice.anticausative.IsPhasal := by decide
+    ¬ anticausative.IsPhasal := by decide
 
 /-- Agentive Voice IS a phase head. -/
 theorem agentive_has_phase_head :
-    Voice.agentive.IsPhasal := by decide
+    agentive.IsPhasal := by decide
 
 /-- The accusative unaccusative paradox. -/
 theorem accusative_unaccusative_paradox :
-    ¬ Voice.anticausative.AssignsTheta ∧
-    ¬ Voice.anticausative.IsPhasal ∧
+    ¬ anticausative.AssignsTheta ∧
+    ¬ anticausative.IsPhasal ∧
     getCaseOf "source" accVariantResult = some .acc ∧
     getSourceOf "source" accVariantResult = some .dependent := by
   refine ⟨?_, ?_, ?_, ?_⟩
@@ -372,7 +372,7 @@ theorem passive_data_matches_fragment :
 
 /-- Non-passivizability follows from Voice theory. -/
 theorem passive_follows_from_voice :
-    ¬ Voice.anticausative.AssignsTheta ∧
+    ¬ anticausative.AssignsTheta ∧
     Japanese.Predicates.hanareru.passivizable = false := by
   refine ⟨?_, rfl⟩; decide
 
@@ -415,7 +415,7 @@ theorem deru_stored_matches_derived :
 /-- Direct passive requires thematic Voice, which departure verbs lack. -/
 theorem direct_passive_requires_voice :
     PassiveType.requiresThematicVoice .direct = true ∧
-    ¬ Voice.anticausative.AssignsTheta := by
+    ¬ anticausative.AssignsTheta := by
   refine ⟨rfl, ?_⟩; decide
 
 end Ozaki2026

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -48,7 +48,7 @@ as formalized siblings; bibliography backlog).
 
 namespace Pietraszko2026
 
-open Minimalist SyntacticObject
+open Minimalist Minimalist.Voice SyntacticObject
 
 /-! ## Notes
 
@@ -93,13 +93,13 @@ namespace Sample
 /-- Voice with EPP feature (Pietraszko 2026): triggers subject movement
     to Spec,VoiceP. VoiceP is always phasal in Ndebele
     (`phaseOverride := some true`); the variation is on the EPP feature. -/
-def voiceWithEPP : Voice.Head :=
+def voiceWithEPP : Head :=
   { flavor := .agentive, hasD := true, phaseOverride := some true
   , features := .ofGramFeatures [.valued (.epp true)] }
 
 /-- Voice without EPP: subject trapped in vP, invisible to higher probes
     via PIC at the Voice phase boundary. -/
-def voiceWithoutEPP : Voice.Head :=
+def voiceWithoutEPP : Head :=
   { flavor := .agentive, hasD := true, phaseOverride := some true
   , features := ⊥ }
 
@@ -128,7 +128,7 @@ def aspToken : LIToken :=
   , id := idAsp }
 
 /-- A Voice head (the lexical leaf; Voice's phasehood and EPP are
-    metadata on the corresponding `Voice.Head`, not on the LIToken). -/
+    metadata on the corresponding `Head`, not on the LIToken). -/
 def voiceToken : LIToken :=
   { item := LexicalItem.simple .Voice [.v]
   , id := idVoice }
@@ -373,7 +373,7 @@ theorem voice_phase_attested_in_two_families :
 
 /-! ## §7. Four-cell phase-override typology
 
-Three concrete clients now exhaust the `(Voice.Flavor.defaultPhasal ×
+Three concrete clients now exhaust the `(Flavor.defaultPhasal ×
 phaseOverride : Option Bool)` typology cells:
 
 - agentive + default-phasal (no override): Collins/Chomsky baseline
@@ -385,12 +385,12 @@ phaseOverride : Option Bool)` typology cells:
 - passive + override-true: [erlewine-sommerlot-2025] (Malayic
   di-passive, bare passive)
 
-The typology theorem witnesses each cell with a concrete Voice.Head. -/
+The typology theorem witnesses each cell with a concrete Head. -/
 
 /-- **Cell 1**: agentive flavor + no override = Collins/Chomsky baseline
     (`Minimalist.Voice.agentive`). Inherits `IsPhasal` from `defaultPhasal`. -/
 theorem typology_cell_default_agentive :
-    Minimalist.Voice.agentive.flavor = Voice.Flavor.agentive ∧
+    Minimalist.Voice.agentive.flavor = Flavor.agentive ∧
     Minimalist.Voice.agentive.phaseOverride = none ∧
     Minimalist.Voice.agentive.IsPhasal := by decide
 
@@ -399,7 +399,7 @@ theorem typology_cell_default_agentive :
     Same observable phasehood as Cell 1 but with explicit override
     documenting the per-paper commitment. -/
 theorem typology_cell_pietraszko :
-    Sample.voiceWithEPP.flavor = Voice.Flavor.agentive ∧
+    Sample.voiceWithEPP.flavor = Flavor.agentive ∧
     Sample.voiceWithEPP.phaseOverride = some true ∧
     Sample.voiceWithEPP.IsPhasal := by decide
 
@@ -408,7 +408,7 @@ theorem typology_cell_pietraszko :
     in [coon-mateo-pedro-preminger-2014]. Override forces non-phasal
     against the agentive flavor default. -/
 theorem typology_cell_coon_intransitive :
-    Coon2019.v_w.flavor = Voice.Flavor.agentive ∧
+    Coon2019.v_w.flavor = Flavor.agentive ∧
     Coon2019.v_w.phaseOverride = some false ∧
     ¬ Coon2019.v_w.IsPhasal := by decide
 
@@ -418,7 +418,7 @@ theorem typology_cell_coon_intransitive :
     treats as non-phasal). -/
 theorem typology_cell_erlewine_sommerlot :
     (ErlewineSommerlot2025.clauseToVoiceHead
-       .diPassive).flavor = Voice.Flavor.passive ∧
+       .diPassive).flavor = Flavor.passive ∧
     (ErlewineSommerlot2025.clauseToVoiceHead
        .diPassive).phaseOverride = some true ∧
     (ErlewineSommerlot2025.clauseToVoiceHead

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -93,13 +93,13 @@ namespace Sample
 /-- Voice with EPP feature (Pietraszko 2026): triggers subject movement
     to Spec,VoiceP. VoiceP is always phasal in Ndebele
     (`phaseOverride := some true`); the variation is on the EPP feature. -/
-def voiceWithEPP : VoiceHead :=
+def voiceWithEPP : Voice.Head :=
   { flavor := .agentive, hasD := true, phaseOverride := some true
   , features := .ofGramFeatures [.valued (.epp true)] }
 
 /-- Voice without EPP: subject trapped in vP, invisible to higher probes
     via PIC at the Voice phase boundary. -/
-def voiceWithoutEPP : VoiceHead :=
+def voiceWithoutEPP : Voice.Head :=
   { flavor := .agentive, hasD := true, phaseOverride := some true
   , features := ⊥ }
 
@@ -128,7 +128,7 @@ def aspToken : LIToken :=
   , id := idAsp }
 
 /-- A Voice head (the lexical leaf; Voice's phasehood and EPP are
-    metadata on the corresponding `VoiceHead`, not on the LIToken). -/
+    metadata on the corresponding `Voice.Head`, not on the LIToken). -/
 def voiceToken : LIToken :=
   { item := LexicalItem.simple .Voice [.v]
   , id := idVoice }
@@ -373,11 +373,11 @@ theorem voice_phase_attested_in_two_families :
 
 /-! ## §7. Four-cell phase-override typology
 
-Three concrete clients now exhaust the `(VoiceFlavor.defaultPhasal ×
+Three concrete clients now exhaust the `(Voice.Flavor.defaultPhasal ×
 phaseOverride : Option Bool)` typology cells:
 
 - agentive + default-phasal (no override): Collins/Chomsky baseline
-  — `Minimalist.voiceAgent`
+  — `Minimalist.Voice.agentive`
 - agentive + override-true: Pietraszko 2026, this file —
   `Sample.voiceWithEPP`
 - agentive + override-false: [coon-2019] (Chol intransitive),
@@ -385,21 +385,21 @@ phaseOverride : Option Bool)` typology cells:
 - passive + override-true: [erlewine-sommerlot-2025] (Malayic
   di-passive, bare passive)
 
-The typology theorem witnesses each cell with a concrete VoiceHead. -/
+The typology theorem witnesses each cell with a concrete Voice.Head. -/
 
 /-- **Cell 1**: agentive flavor + no override = Collins/Chomsky baseline
-    (`Minimalist.voiceAgent`). Inherits `IsPhasal` from `defaultPhasal`. -/
+    (`Minimalist.Voice.agentive`). Inherits `IsPhasal` from `defaultPhasal`. -/
 theorem typology_cell_default_agentive :
-    Minimalist.voiceAgent.flavor = VoiceFlavor.agentive ∧
-    Minimalist.voiceAgent.phaseOverride = none ∧
-    Minimalist.voiceAgent.IsPhasal := by decide
+    Minimalist.Voice.agentive.flavor = Voice.Flavor.agentive ∧
+    Minimalist.Voice.agentive.phaseOverride = none ∧
+    Minimalist.Voice.agentive.IsPhasal := by decide
 
 /-- **Cell 2**: agentive flavor + `phaseOverride := some true` =
     Pietraszko 2026's Voice-with-EPP (this file's `Sample.voiceWithEPP`).
     Same observable phasehood as Cell 1 but with explicit override
     documenting the per-paper commitment. -/
 theorem typology_cell_pietraszko :
-    Sample.voiceWithEPP.flavor = VoiceFlavor.agentive ∧
+    Sample.voiceWithEPP.flavor = Voice.Flavor.agentive ∧
     Sample.voiceWithEPP.phaseOverride = some true ∧
     Sample.voiceWithEPP.IsPhasal := by decide
 
@@ -408,7 +408,7 @@ theorem typology_cell_pietraszko :
     in [coon-mateo-pedro-preminger-2014]. Override forces non-phasal
     against the agentive flavor default. -/
 theorem typology_cell_coon_intransitive :
-    Coon2019.v_w.flavor = VoiceFlavor.agentive ∧
+    Coon2019.v_w.flavor = Voice.Flavor.agentive ∧
     Coon2019.v_w.phaseOverride = some false ∧
     ¬ Coon2019.v_w.IsPhasal := by decide
 
@@ -418,7 +418,7 @@ theorem typology_cell_coon_intransitive :
     treats as non-phasal). -/
 theorem typology_cell_erlewine_sommerlot :
     (ErlewineSommerlot2025.clauseToVoiceHead
-       .diPassive).flavor = VoiceFlavor.passive ∧
+       .diPassive).flavor = Voice.Flavor.passive ∧
     (ErlewineSommerlot2025.clauseToVoiceHead
        .diPassive).phaseOverride = some true ∧
     (ErlewineSommerlot2025.clauseToVoiceHead

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -65,7 +65,7 @@ in the "Applicative diagnostics" section below.
 
 namespace Pylkkanen2008
 
-open Minimalist SyntacticObject
+open Minimalist Minimalist.Voice SyntacticObject
 open RootedTree
 
 /-! ### Voice projection (relocated from Minimalist/VoiceProjection.lean)
@@ -108,8 +108,8 @@ licensing (Case + smuggling) to Voice. The label "Voice" denotes
 different positions in the two systems.
 
 The orthogonality of the two predicates `IsExternalArgIntroducer` and
-`IsSmugglingProjection` (defined below) reflects this: a `Voice.Head`
-instance can satisfy one, both, or neither. Linglib's `Voice.Head`
+`IsSmugglingProjection` (defined below) reflects this: a `Head`
+instance can satisfy one, both, or neither. Linglib's `Head`
 structure encodes both axes (`assignsTheta` and `permitsSmuggling`)
 independently, accommodating both views simultaneously.
 
@@ -130,76 +130,76 @@ about what makes a Voice head "well-formed Voice." -/
 /-- **Pylkkänen / Kratzer view**: a Voice head is "doing its job" iff
     it introduces an external argument (assigns external θ).
     [kratzer-1996]: Voice = the head bearing the θ-relation. -/
-def IsExternalArgIntroducer (v : Voice.Head) : Prop :=
+def IsExternalArgIntroducer (v : Head) : Prop :=
   v.AssignsTheta
 
-instance (v : Voice.Head) : Decidable (IsExternalArgIntroducer v) := by
+instance (v : Head) : Decidable (IsExternalArgIntroducer v) := by
   unfold IsExternalArgIntroducer; infer_instance
 
 /-- **Collins / Storment view**: a Voice head is "doing its job" iff
     it permits smuggling (it is the structural landing site for a
     constituent moving past an in-situ external argument).
     [collins-2005], [storment-2026]. -/
-def IsSmugglingProjection (v : Voice.Head) : Prop :=
+def IsSmugglingProjection (v : Head) : Prop :=
   v.permitsSmuggling = true
 
-instance (v : Voice.Head) : Decidable (IsSmugglingProjection v) := by
+instance (v : Head) : Decidable (IsSmugglingProjection v) := by
   unfold IsSmugglingProjection; infer_instance
 
 /-! #### The two views are orthogonal
 
-Linglib's `Voice.Head` already encodes both axes. The question is
+Linglib's `Head` already encodes both axes. The question is
 whether they coincide for the canonical Voice instances.
 **Answer: they don't.** A Voice head can satisfy either one, both, or
 neither — the four corners of the orthogonality square. -/
 
-/-- `Voice.agentive` satisfies the Pylkkänen view (it introduces the agent
+/-- `agentive` satisfies the Pylkkänen view (it introduces the agent
     external argument) but **fails** the Collins/Storment view
     (agentive Voice is a strong phase head; smuggling is blocked). -/
 theorem voiceAgent_pylkkanen_yes_collins_no :
-    IsExternalArgIntroducer Voice.agentive ∧ ¬ IsSmugglingProjection Voice.agentive := by
+    IsExternalArgIntroducer agentive ∧ ¬ IsSmugglingProjection agentive := by
   decide
 
-/-- `Voice.passive` satisfies the Collins view (it is the smuggling
+/-- `passive` satisfies the Collins view (it is the smuggling
     landing site) but **fails** the Pylkkänen view (it does not
     introduce an external argument — the external arg is in Spec,vP
     per [collins-2005] §2 UTAH). The passive Voice head is
     *puzzling* on Pylkkänen's view: a Voice head with no θ-role to
     assign. -/
 theorem voicePassive_collins_yes_pylkkanen_no :
-    IsSmugglingProjection Voice.passive ∧ ¬ IsExternalArgIntroducer Voice.passive := by
+    IsSmugglingProjection passive ∧ ¬ IsExternalArgIntroducer passive := by
   decide
 
-/-- `Voice.anticausative` similarly fits the Collins view (smuggling
+/-- `anticausative` similarly fits the Collins view (smuggling
     target for the unaccusative-like derivation Storment uses for QI
     and LI) and fails the Pylkkänen view (no external argument). -/
 theorem voiceAnticausative_collins_yes_pylkkanen_no :
-    IsSmugglingProjection Voice.anticausative ∧
-    ¬ IsExternalArgIntroducer Voice.anticausative := by
+    IsSmugglingProjection anticausative ∧
+    ¬ IsExternalArgIntroducer anticausative := by
   decide
 
 /-- The two views are not equivalent: there exist Voice heads
     distinguishing them (in fact, the canonical instances above all do). -/
 theorem views_not_equivalent :
-    ¬ (∀ v : Voice.Head, IsExternalArgIntroducer v ↔ IsSmugglingProjection v) := by
+    ¬ (∀ v : Head, IsExternalArgIntroducer v ↔ IsSmugglingProjection v) := by
   intro h
-  -- Voice.agentive introduces external arg but blocks smuggling
-  have hExt : IsExternalArgIntroducer Voice.agentive := by decide
-  have hSmug : IsSmugglingProjection Voice.agentive := (h Voice.agentive).mp hExt
+  -- agentive introduces external arg but blocks smuggling
+  have hExt : IsExternalArgIntroducer agentive := by decide
+  have hSmug : IsSmugglingProjection agentive := (h agentive).mp hExt
   exact absurd hSmug (by decide)
 
 /-! #### What the disagreement amounts to
 
 In Pylkkänen's framework, every Voice head should be an
-`IsExternalArgIntroducer`. The fact that linglib's `Voice.passive` and
-`Voice.anticausative` are not means *Pylkkänen would not call these
+`IsExternalArgIntroducer`. The fact that linglib's `passive` and
+`anticausative` are not means *Pylkkänen would not call these
 "Voice"* — she would attribute the structural-licensing function to a
 different (perhaps unnamed) head.
 
 In Collins/Storment's framework, every Voice head should be an
-`IsSmugglingProjection`. The fact that linglib's `Voice.agentive` is not
+`IsSmugglingProjection`. The fact that linglib's `agentive` is not
 means *Collins/Storment would not call this "Voice"* — they would call
-it *v* (which `Voice.agentive`'s thematic role and phase status more
+it *v* (which `agentive`'s thematic role and phase status more
 closely match in their system).
 
 The disagreement is therefore partly *labeling*: which functional head
@@ -214,9 +214,9 @@ the phase/θ-role correlations Storment defends in §4 of his paper. -/
     satisfy both views. (Equivalently: introducing an external argument
     requires being a phase head, which blocks smuggling.) -/
 theorem views_jointly_unsatisfiable_for_canonical_voices :
-    ¬ (IsExternalArgIntroducer Voice.agentive ∧ IsSmugglingProjection Voice.agentive) ∧
-    ¬ (IsExternalArgIntroducer Voice.passive ∧ IsSmugglingProjection Voice.passive) ∧
-    ¬ (IsExternalArgIntroducer Voice.anticausative ∧ IsSmugglingProjection Voice.anticausative) := by
+    ¬ (IsExternalArgIntroducer agentive ∧ IsSmugglingProjection agentive) ∧
+    ¬ (IsExternalArgIntroducer passive ∧ IsSmugglingProjection passive) ∧
+    ¬ (IsExternalArgIntroducer anticausative ∧ IsSmugglingProjection anticausative) := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 /-! ### Applicative diagnostics (relocated from Minimalist/ApplicativeDiagnostics.lean)
@@ -1062,14 +1062,14 @@ theorem luganda_phase_predictions :
 Pylkkänen's Voice = external-argument introducer. Per the "Voice
 projection" section above, this is one of two
 competing views of Voice (the other being Collins/Storment's smuggling
-projection). Test Pylkkänen's view against the broader `Voice.Head`
+projection). Test Pylkkänen's view against the broader `Head`
 taxonomy in `Syntax/Minimalism/Voice.lean`: which Voice flavors
 *do* introduce external arguments? -/
 
 /-- Pylkkänen's view of Voice tested against all 8 named canonical
-    flavors: Voice.agentive, Voice.causer, Voice.reflexive, and
-    Voice.experiencer introduce external arguments; Voice.middle
-    (expletive), Voice.impersonal, Voice.anticausative, and Voice.passive
+    flavors: agentive, causer, reflexive, and
+    experiencer introduce external arguments; middle
+    (expletive), impersonal, anticausative, and passive
     do not. The Pylkkänen-coherent Voice flavors are exactly the
     θ-assigning ones. (`.antipassive` is defined as a flavor in the
     Voice taxonomy but lacks a canonical `voiceAntipassive` constant
@@ -1248,16 +1248,16 @@ theorem high_appl_licenses_unergative_denotational
 particular Appl head is licensed with a given Voice head: high
 applicatives require event-introducing Voice (`hasSemantics = true`);
 low applicatives are licensed with any Voice. Cross [pylkkanen-2008]'s
-high/low Appl typology with the `Voice.Head` taxonomy: which Voice
+high/low Appl typology with the `Head` taxonomy: which Voice
 flavors license high Appl, and which don't?
 
 This connects §14's Pylkkänen-Voice partition with the [pylkkanen-2008]
 Appl typology in a single matrix. -/
 
 /-- High Appl requires Voice with event semantics. The named Voice
-    flavors split: `Voice.agentive`/`Voice.causer`/`Voice.middle`/
-    `Voice.impersonal`/`Voice.reflexive`/`Voice.experiencer` carry event
-    semantics and license high Appl; `Voice.anticausative`/`Voice.passive`
+    flavors split: `agentive`/`causer`/`middle`/
+    `impersonal`/`reflexive`/`experiencer` carry event
+    semantics and license high Appl; `anticausative`/`passive`
     do not (they're event-semantically inert in this Voice taxonomy)
     and so don't license high Appl. -/
 theorem voice_appl_licensing_matrix :

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -108,8 +108,8 @@ licensing (Case + smuggling) to Voice. The label "Voice" denotes
 different positions in the two systems.
 
 The orthogonality of the two predicates `IsExternalArgIntroducer` and
-`IsSmugglingProjection` (defined below) reflects this: a `VoiceHead`
-instance can satisfy one, both, or neither. Linglib's `VoiceHead`
+`IsSmugglingProjection` (defined below) reflects this: a `Voice.Head`
+instance can satisfy one, both, or neither. Linglib's `Voice.Head`
 structure encodes both axes (`assignsTheta` and `permitsSmuggling`)
 independently, accommodating both views simultaneously.
 
@@ -130,76 +130,76 @@ about what makes a Voice head "well-formed Voice." -/
 /-- **Pylkkänen / Kratzer view**: a Voice head is "doing its job" iff
     it introduces an external argument (assigns external θ).
     [kratzer-1996]: Voice = the head bearing the θ-relation. -/
-def IsExternalArgIntroducer (v : VoiceHead) : Prop :=
+def IsExternalArgIntroducer (v : Voice.Head) : Prop :=
   v.AssignsTheta
 
-instance (v : VoiceHead) : Decidable (IsExternalArgIntroducer v) := by
+instance (v : Voice.Head) : Decidable (IsExternalArgIntroducer v) := by
   unfold IsExternalArgIntroducer; infer_instance
 
 /-- **Collins / Storment view**: a Voice head is "doing its job" iff
     it permits smuggling (it is the structural landing site for a
     constituent moving past an in-situ external argument).
     [collins-2005], [storment-2026]. -/
-def IsSmugglingProjection (v : VoiceHead) : Prop :=
+def IsSmugglingProjection (v : Voice.Head) : Prop :=
   v.permitsSmuggling = true
 
-instance (v : VoiceHead) : Decidable (IsSmugglingProjection v) := by
+instance (v : Voice.Head) : Decidable (IsSmugglingProjection v) := by
   unfold IsSmugglingProjection; infer_instance
 
 /-! #### The two views are orthogonal
 
-Linglib's `VoiceHead` already encodes both axes. The question is
+Linglib's `Voice.Head` already encodes both axes. The question is
 whether they coincide for the canonical Voice instances.
 **Answer: they don't.** A Voice head can satisfy either one, both, or
 neither — the four corners of the orthogonality square. -/
 
-/-- `voiceAgent` satisfies the Pylkkänen view (it introduces the agent
+/-- `Voice.agentive` satisfies the Pylkkänen view (it introduces the agent
     external argument) but **fails** the Collins/Storment view
     (agentive Voice is a strong phase head; smuggling is blocked). -/
 theorem voiceAgent_pylkkanen_yes_collins_no :
-    IsExternalArgIntroducer voiceAgent ∧ ¬ IsSmugglingProjection voiceAgent := by
+    IsExternalArgIntroducer Voice.agentive ∧ ¬ IsSmugglingProjection Voice.agentive := by
   decide
 
-/-- `voicePassive` satisfies the Collins view (it is the smuggling
+/-- `Voice.passive` satisfies the Collins view (it is the smuggling
     landing site) but **fails** the Pylkkänen view (it does not
     introduce an external argument — the external arg is in Spec,vP
     per [collins-2005] §2 UTAH). The passive Voice head is
     *puzzling* on Pylkkänen's view: a Voice head with no θ-role to
     assign. -/
 theorem voicePassive_collins_yes_pylkkanen_no :
-    IsSmugglingProjection voicePassive ∧ ¬ IsExternalArgIntroducer voicePassive := by
+    IsSmugglingProjection Voice.passive ∧ ¬ IsExternalArgIntroducer Voice.passive := by
   decide
 
-/-- `voiceAnticausative` similarly fits the Collins view (smuggling
+/-- `Voice.anticausative` similarly fits the Collins view (smuggling
     target for the unaccusative-like derivation Storment uses for QI
     and LI) and fails the Pylkkänen view (no external argument). -/
 theorem voiceAnticausative_collins_yes_pylkkanen_no :
-    IsSmugglingProjection voiceAnticausative ∧
-    ¬ IsExternalArgIntroducer voiceAnticausative := by
+    IsSmugglingProjection Voice.anticausative ∧
+    ¬ IsExternalArgIntroducer Voice.anticausative := by
   decide
 
 /-- The two views are not equivalent: there exist Voice heads
     distinguishing them (in fact, the canonical instances above all do). -/
 theorem views_not_equivalent :
-    ¬ (∀ v : VoiceHead, IsExternalArgIntroducer v ↔ IsSmugglingProjection v) := by
+    ¬ (∀ v : Voice.Head, IsExternalArgIntroducer v ↔ IsSmugglingProjection v) := by
   intro h
-  -- voiceAgent introduces external arg but blocks smuggling
-  have hExt : IsExternalArgIntroducer voiceAgent := by decide
-  have hSmug : IsSmugglingProjection voiceAgent := (h voiceAgent).mp hExt
+  -- Voice.agentive introduces external arg but blocks smuggling
+  have hExt : IsExternalArgIntroducer Voice.agentive := by decide
+  have hSmug : IsSmugglingProjection Voice.agentive := (h Voice.agentive).mp hExt
   exact absurd hSmug (by decide)
 
 /-! #### What the disagreement amounts to
 
 In Pylkkänen's framework, every Voice head should be an
-`IsExternalArgIntroducer`. The fact that linglib's `voicePassive` and
-`voiceAnticausative` are not means *Pylkkänen would not call these
+`IsExternalArgIntroducer`. The fact that linglib's `Voice.passive` and
+`Voice.anticausative` are not means *Pylkkänen would not call these
 "Voice"* — she would attribute the structural-licensing function to a
 different (perhaps unnamed) head.
 
 In Collins/Storment's framework, every Voice head should be an
-`IsSmugglingProjection`. The fact that linglib's `voiceAgent` is not
+`IsSmugglingProjection`. The fact that linglib's `Voice.agentive` is not
 means *Collins/Storment would not call this "Voice"* — they would call
-it *v* (which `voiceAgent`'s thematic role and phase status more
+it *v* (which `Voice.agentive`'s thematic role and phase status more
 closely match in their system).
 
 The disagreement is therefore partly *labeling*: which functional head
@@ -214,9 +214,9 @@ the phase/θ-role correlations Storment defends in §4 of his paper. -/
     satisfy both views. (Equivalently: introducing an external argument
     requires being a phase head, which blocks smuggling.) -/
 theorem views_jointly_unsatisfiable_for_canonical_voices :
-    ¬ (IsExternalArgIntroducer voiceAgent ∧ IsSmugglingProjection voiceAgent) ∧
-    ¬ (IsExternalArgIntroducer voicePassive ∧ IsSmugglingProjection voicePassive) ∧
-    ¬ (IsExternalArgIntroducer voiceAnticausative ∧ IsSmugglingProjection voiceAnticausative) := by
+    ¬ (IsExternalArgIntroducer Voice.agentive ∧ IsSmugglingProjection Voice.agentive) ∧
+    ¬ (IsExternalArgIntroducer Voice.passive ∧ IsSmugglingProjection Voice.passive) ∧
+    ¬ (IsExternalArgIntroducer Voice.anticausative ∧ IsSmugglingProjection Voice.anticausative) := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 /-! ### Applicative diagnostics (relocated from Minimalist/ApplicativeDiagnostics.lean)
@@ -687,7 +687,7 @@ contrast. -/
     satisfies `IsExternalArgIntroducer` (it does the job Pylkkänen
     attributes to Voice). -/
 theorem voice_introduces_external_arg_pylkkanen :
-    IsExternalArgIntroducer Minimalist.voiceAgent := by decide
+    IsExternalArgIntroducer Minimalist.Voice.agentive := by decide
 
 /-! ## §8. Voice-bundling for the English zero-causative
     ([pylkkanen-2008] Ch. 3 §3.3; -- UNVERIFIED: eq. number)
@@ -1062,27 +1062,27 @@ theorem luganda_phase_predictions :
 Pylkkänen's Voice = external-argument introducer. Per the "Voice
 projection" section above, this is one of two
 competing views of Voice (the other being Collins/Storment's smuggling
-projection). Test Pylkkänen's view against the broader `VoiceHead`
+projection). Test Pylkkänen's view against the broader `Voice.Head`
 taxonomy in `Syntax/Minimalism/Voice.lean`: which Voice flavors
 *do* introduce external arguments? -/
 
 /-- Pylkkänen's view of Voice tested against all 8 named canonical
-    flavors: voiceAgent, voiceCauser, voiceReflexive, and
-    voiceExperiencer introduce external arguments; voiceMiddle
-    (expletive), voiceImpersonal, voiceAnticausative, and voicePassive
+    flavors: Voice.agentive, Voice.causer, Voice.reflexive, and
+    Voice.experiencer introduce external arguments; Voice.middle
+    (expletive), Voice.impersonal, Voice.anticausative, and Voice.passive
     do not. The Pylkkänen-coherent Voice flavors are exactly the
     θ-assigning ones. (`.antipassive` is defined as a flavor in the
     Voice taxonomy but lacks a canonical `voiceAntipassive` constant
     in `Voice.lean`.) -/
 theorem pylkkanen_view_partitions_voice_flavors :
-    IsExternalArgIntroducer Minimalist.voiceAgent ∧
-    IsExternalArgIntroducer Minimalist.voiceCauser ∧
-    IsExternalArgIntroducer Minimalist.voiceReflexive ∧
-    IsExternalArgIntroducer Minimalist.voiceExperiencer ∧
-    ¬ IsExternalArgIntroducer Minimalist.voiceMiddle ∧
-    ¬ IsExternalArgIntroducer Minimalist.voiceImpersonal ∧
-    ¬ IsExternalArgIntroducer Minimalist.voiceAnticausative ∧
-    ¬ IsExternalArgIntroducer Minimalist.voicePassive := by
+    IsExternalArgIntroducer Minimalist.Voice.agentive ∧
+    IsExternalArgIntroducer Minimalist.Voice.causer ∧
+    IsExternalArgIntroducer Minimalist.Voice.reflexive ∧
+    IsExternalArgIntroducer Minimalist.Voice.experiencer ∧
+    ¬ IsExternalArgIntroducer Minimalist.Voice.middle ∧
+    ¬ IsExternalArgIntroducer Minimalist.Voice.impersonal ∧
+    ¬ IsExternalArgIntroducer Minimalist.Voice.anticausative ∧
+    ¬ IsExternalArgIntroducer Minimalist.Voice.passive := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
 /-! ## §15. Transitivity restriction grounded in EntailmentProfile
@@ -1248,26 +1248,26 @@ theorem high_appl_licenses_unergative_denotational
 particular Appl head is licensed with a given Voice head: high
 applicatives require event-introducing Voice (`hasSemantics = true`);
 low applicatives are licensed with any Voice. Cross [pylkkanen-2008]'s
-high/low Appl typology with the `VoiceHead` taxonomy: which Voice
+high/low Appl typology with the `Voice.Head` taxonomy: which Voice
 flavors license high Appl, and which don't?
 
 This connects §14's Pylkkänen-Voice partition with the [pylkkanen-2008]
 Appl typology in a single matrix. -/
 
 /-- High Appl requires Voice with event semantics. The named Voice
-    flavors split: `voiceAgent`/`voiceCauser`/`voiceMiddle`/
-    `voiceImpersonal`/`voiceReflexive`/`voiceExperiencer` carry event
-    semantics and license high Appl; `voiceAnticausative`/`voicePassive`
+    flavors split: `Voice.agentive`/`Voice.causer`/`Voice.middle`/
+    `Voice.impersonal`/`Voice.reflexive`/`Voice.experiencer` carry event
+    semantics and license high Appl; `Voice.anticausative`/`Voice.passive`
     do not (they're event-semantically inert in this Voice taxonomy)
     and so don't license high Appl. -/
 theorem voice_appl_licensing_matrix :
     -- High Appl licensed with event-bearing Voice flavors:
-    Minimalist.applHigh.Licensed Minimalist.voiceAgent ∧
-    Minimalist.applHigh.Licensed Minimalist.voiceCauser ∧
+    Minimalist.applHigh.Licensed Minimalist.Voice.agentive ∧
+    Minimalist.applHigh.Licensed Minimalist.Voice.causer ∧
     -- Low Appl is always licensed (independent of Voice semantics):
-    Minimalist.applLowRecipient.Licensed Minimalist.voiceAgent ∧
-    Minimalist.applLowRecipient.Licensed Minimalist.voicePassive ∧
-    Minimalist.applLowSource.Licensed Minimalist.voiceAnticausative := by decide
+    Minimalist.applLowRecipient.Licensed Minimalist.Voice.agentive ∧
+    Minimalist.applLowRecipient.Licensed Minimalist.Voice.passive ∧
+    Minimalist.applLowSource.Licensed Minimalist.Voice.anticausative := by decide
 
 /-! ## §17. WALS-vs-Pylkkänen divergence on English/Japanese applicatives
 

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -113,11 +113,11 @@ theorem voice_based_tripartite :
 /-- Under Agree, anticausative Voice is not a phase head, so it cannot
     serve as an ACC assigner. -/
 theorem agree_anticausative_not_phase :
-    ¬ voiceAnticausative.IsPhasal := by decide
+    ¬ Voice.anticausative.IsPhasal := by decide
 
 /-- Under Agree, agentive Voice (v*) is a phase head and can assign ACC. -/
 theorem agree_voice_is_phase_head :
-    voiceAgent.IsPhasal := by decide
+    Voice.agentive.IsPhasal := by decide
 
 -- ============================================================================
 -- § 3: Contrast with Dependent Case

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -71,7 +71,7 @@ namespace Scott2023
 
 section VoiceCase
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Syntax.Case
 
 -- ============================================================================
@@ -113,11 +113,11 @@ theorem voice_based_tripartite :
 /-- Under Agree, anticausative Voice is not a phase head, so it cannot
     serve as an ACC assigner. -/
 theorem agree_anticausative_not_phase :
-    ¬ Voice.anticausative.IsPhasal := by decide
+    ¬ anticausative.IsPhasal := by decide
 
 /-- Under Agree, agentive Voice (v*) is a phase head and can assign ACC. -/
 theorem agree_voice_is_phase_head :
-    Voice.agentive.IsPhasal := by decide
+    agentive.IsPhasal := by decide
 
 -- ============================================================================
 -- § 3: Contrast with Dependent Case

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -47,7 +47,7 @@ and `VendlerClass`, connecting to the affectedness hierarchy
   (`accomplishmentSubjectProfile`, `experiencerProfile`,
   `activitySubjectProfile`) rather than duplicating them, making the
   connection structural.
-- Passive voice connects to [collins-2005]'s `Voice.passive` —
+- Passive voice connects to [collins-2005]'s `passive` —
   Case-checking by Voice is the syntactic correlate of the preposition's
   semantic contribution.
 - Object affectedness derives from [beavers-2010]'s `profileToDegree`.
@@ -64,7 +64,7 @@ open ArgumentStructure.EntailmentProfile
 open ArgumentStructure.Affectedness
 open Features
 open Semantics.Lexical
-open Minimalist
+open Minimalist Minimalist.Voice
 
 -- ============================================================================
 -- § 1. Polymorphic Preposition Types
@@ -362,7 +362,7 @@ theorem par_de_different_causal_type :
     structural position for the preposition. The par/de choice is
     then determined by proto-agentivity. -/
 theorem passive_provides_case_position :
-    Voice.passive.ChecksCase ∧ ¬ Voice.passive.AssignsTheta := by decide
+    passive.ChecksCase ∧ ¬ passive.AssignsTheta := by decide
 
 -- ============================================================================
 -- § 8. Causal Chain Distances (§3.5)

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -47,7 +47,7 @@ and `VendlerClass`, connecting to the affectedness hierarchy
   (`accomplishmentSubjectProfile`, `experiencerProfile`,
   `activitySubjectProfile`) rather than duplicating them, making the
   connection structural.
-- Passive voice connects to [collins-2005]'s `voicePassive` —
+- Passive voice connects to [collins-2005]'s `Voice.passive` —
   Case-checking by Voice is the syntactic correlate of the preposition's
   semantic contribution.
 - Object affectedness derives from [beavers-2010]'s `profileToDegree`.
@@ -362,7 +362,7 @@ theorem par_de_different_causal_type :
     structural position for the preposition. The par/de choice is
     then determined by proto-agentivity. -/
 theorem passive_provides_case_position :
-    voicePassive.ChecksCase ∧ ¬ voicePassive.AssignsTheta := by decide
+    Voice.passive.ChecksCase ∧ ¬ Voice.passive.AssignsTheta := by decide
 
 -- ============================================================================
 -- § 8. Causal Chain Distances (§3.5)

--- a/Linglib/Studies/Storment2026.lean
+++ b/Linglib/Studies/Storment2026.lean
@@ -43,7 +43,7 @@ open Semantics.Lexical
 open English.Predicates.Verbal
 open Data.Examples
 open ArgumentStructure.AuxiliarySelection (TransitivityClass canonicalSelection)
-open Minimalist (Voice.Flavor Voice.Head Voice.anticausative Voice.agentive)
+open Minimalist.Voice (Flavor Head anticausative agentive)
 
 /-! ## §1 + §2. Lexical annotations and QI data
 
@@ -105,11 +105,11 @@ of [kratzer-1996]); permitting smuggling is equivalent to being
 non-phase, which is equivalent to not introducing an external argument. -/
 
 theorem mos_unaccusatives_nonThematic_voice :
-    ∀ v ∈ mosUnaccusatives, v.toVerb.voiceFor = Voice.anticausative := by
+    ∀ v ∈ mosUnaccusatives, v.toVerb.voiceFor = anticausative := by
   intro v hv; fin_cases hv <;> rfl
 
 theorem communication_unergatives_agentive_voice :
-    ∀ v ∈ communicationUnergatives, v.toVerb.voiceFor = Voice.agentive := by
+    ∀ v ∈ communicationUnergatives, v.toVerb.voiceFor = agentive := by
   intro v hv; fin_cases hv <;> rfl
 
 /-! ## §5. Auxiliary selection bridge
@@ -222,7 +222,7 @@ theorem li_blocks_transitive : Examples.li_kick.judgment = .unacceptable := rfl
     arrive projects non-thematic Voice, permitting VP-smuggling — the
     same mechanism that licenses QI. -/
 theorem li_arrive_smuggling_unified :
-    arrive.toVerb.voiceFor = Voice.anticausative ∧
+    arrive.toVerb.voiceFor = anticausative ∧
     LevinRappaportHovav1995.Examples.loc_arrive.judgment = .acceptable :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Studies/Storment2026.lean
+++ b/Linglib/Studies/Storment2026.lean
@@ -43,7 +43,7 @@ open Semantics.Lexical
 open English.Predicates.Verbal
 open Data.Examples
 open ArgumentStructure.AuxiliarySelection (TransitivityClass canonicalSelection)
-open Minimalist (VoiceFlavor VoiceHead voiceAnticausative voiceAgent)
+open Minimalist (Voice.Flavor Voice.Head Voice.anticausative Voice.agentive)
 
 /-! ## §1 + §2. Lexical annotations and QI data
 
@@ -105,11 +105,11 @@ of [kratzer-1996]); permitting smuggling is equivalent to being
 non-phase, which is equivalent to not introducing an external argument. -/
 
 theorem mos_unaccusatives_nonThematic_voice :
-    ∀ v ∈ mosUnaccusatives, v.toVerb.voiceFor = voiceAnticausative := by
+    ∀ v ∈ mosUnaccusatives, v.toVerb.voiceFor = Voice.anticausative := by
   intro v hv; fin_cases hv <;> rfl
 
 theorem communication_unergatives_agentive_voice :
-    ∀ v ∈ communicationUnergatives, v.toVerb.voiceFor = voiceAgent := by
+    ∀ v ∈ communicationUnergatives, v.toVerb.voiceFor = Voice.agentive := by
   intro v hv; fin_cases hv <;> rfl
 
 /-! ## §5. Auxiliary selection bridge
@@ -222,7 +222,7 @@ theorem li_blocks_transitive : Examples.li_kick.judgment = .unacceptable := rfl
     arrive projects non-thematic Voice, permitting VP-smuggling — the
     same mechanism that licenses QI. -/
 theorem li_arrive_smuggling_unified :
-    arrive.toVerb.voiceFor = voiceAnticausative ∧
+    arrive.toVerb.voiceFor = Voice.anticausative ∧
     LevinRappaportHovav1995.Examples.loc_arrive.judgment = .acceptable :=
   ⟨rfl, rfl⟩
 

--- a/Linglib/Studies/Wood2015.lean
+++ b/Linglib/Studies/Wood2015.lean
@@ -114,7 +114,7 @@ def Construction.site : Construction → Site
     the psych verbs the experiencer is an applicative dative, §5.4); figure
     reflexives and reciprocals are agentive (§4); the generic middle is
     expletive (§6.3). -/
-def Construction.voiceFlavor : Construction → VoiceFlavor
+def Construction.voiceFlavor : Construction → Voice.Flavor
   | .anticausative   => .nonThematic
   | .subjectExp      => .nonThematic
   | .inherent        => .nonThematic
@@ -140,7 +140,7 @@ inductive AnticausativeMarking where
     no head (`none`): it is a clitic in a specifier, not an exponent. *-na*
     spells out specifierless Voice{∅}; *-Ø* is the elsewhere Voice exponent
     (compatible with either Voice projection); *-ka* spells out v. -/
-def AnticausativeMarking.exponentOf : AnticausativeMarking → Option VoiceProjectionLocus
+def AnticausativeMarking.exponentOf : AnticausativeMarking → Option Voice.ProjectionLocus
   | .st       => none
   | .na       => some .voiceBare
   | .unmarked => some .voiceDOrBare
@@ -277,9 +277,9 @@ theorem st_not_single_voice_exponent :
     Voice does not (inchoative), but CAUSE is present in both ([wood-2015]
     Ch. 3, in [cuervo-2003] decomposition). -/
 theorem opna_alternation :
-    isCausative (buildDecomposition voiceAgent opnastInfo.rootStructure) = true ∧
-    isInchoative (buildDecomposition voiceAnticausative opnastInfo.rootStructure) = true ∧
-    hasCause (buildDecomposition voiceAnticausative opnastInfo.rootStructure) = true := by
+    isCausative (Voice.buildDecomposition Voice.agentive opnastInfo.rootStructure) = true ∧
+    isInchoative (Voice.buildDecomposition Voice.anticausative opnastInfo.rootStructure) = true ∧
+    hasCause (Voice.buildDecomposition Voice.anticausative opnastInfo.rootStructure) = true := by
   decide
 
 /-- The constructions occupy distinct cells of the ±D / ±λx Voice space
@@ -309,10 +309,10 @@ theorem st_blocked_from_specApplP :
     [wood-2015]'s Icelandic-specific claim that Icelandic lacks true high
     applicatives ([wood-2015] §5.2.1, §5.3.1). -/
 theorem dative_voice_asymmetry :
-    ¬ applHigh.Licensed voiceMiddle ∧
-    applHigh.Licensed voiceAgent ∧
-    applLowRecipient.Licensed voiceMiddle ∧
-    applLowRecipient.Licensed voiceAnticausative := by decide
+    ¬ applHigh.Licensed Voice.middle ∧
+    applHigh.Licensed Voice.agentive ∧
+    applLowRecipient.Licensed Voice.middle ∧
+    applLowRecipient.Licensed Voice.anticausative := by decide
 
 /-! ### Consistency over the verb roster -/
 

--- a/Linglib/Studies/Wood2015.lean
+++ b/Linglib/Studies/Wood2015.lean
@@ -62,7 +62,7 @@ derived from it.
 
 namespace Wood2015
 
-open Minimalist
+open Minimalist Minimalist.Voice
 open Icelandic.Predicates
 
 /-! ### The *-st* clitic and its merge site -/
@@ -114,7 +114,7 @@ def Construction.site : Construction → Site
     the psych verbs the experiencer is an applicative dative, §5.4); figure
     reflexives and reciprocals are agentive (§4); the generic middle is
     expletive (§6.3). -/
-def Construction.voiceFlavor : Construction → Voice.Flavor
+def Construction.voiceFlavor : Construction → Flavor
   | .anticausative   => .nonThematic
   | .subjectExp      => .nonThematic
   | .inherent        => .nonThematic
@@ -140,7 +140,7 @@ inductive AnticausativeMarking where
     no head (`none`): it is a clitic in a specifier, not an exponent. *-na*
     spells out specifierless Voice{∅}; *-Ø* is the elsewhere Voice exponent
     (compatible with either Voice projection); *-ka* spells out v. -/
-def AnticausativeMarking.exponentOf : AnticausativeMarking → Option Voice.ProjectionLocus
+def AnticausativeMarking.exponentOf : AnticausativeMarking → Option ProjectionLocus
   | .st       => none
   | .na       => some .voiceBare
   | .unmarked => some .voiceDOrBare
@@ -277,9 +277,9 @@ theorem st_not_single_voice_exponent :
     Voice does not (inchoative), but CAUSE is present in both ([wood-2015]
     Ch. 3, in [cuervo-2003] decomposition). -/
 theorem opna_alternation :
-    isCausative (Voice.buildDecomposition Voice.agentive opnastInfo.rootStructure) = true ∧
-    isInchoative (Voice.buildDecomposition Voice.anticausative opnastInfo.rootStructure) = true ∧
-    hasCause (Voice.buildDecomposition Voice.anticausative opnastInfo.rootStructure) = true := by
+    isCausative (buildDecomposition agentive opnastInfo.rootStructure) = true ∧
+    isInchoative (buildDecomposition anticausative opnastInfo.rootStructure) = true ∧
+    hasCause (buildDecomposition anticausative opnastInfo.rootStructure) = true := by
   decide
 
 /-- The constructions occupy distinct cells of the ±D / ±λx Voice space
@@ -309,10 +309,10 @@ theorem st_blocked_from_specApplP :
     [wood-2015]'s Icelandic-specific claim that Icelandic lacks true high
     applicatives ([wood-2015] §5.2.1, §5.3.1). -/
 theorem dative_voice_asymmetry :
-    ¬ applHigh.Licensed Voice.middle ∧
-    applHigh.Licensed Voice.agentive ∧
-    applLowRecipient.Licensed Voice.middle ∧
-    applLowRecipient.Licensed Voice.anticausative := by decide
+    ¬ applHigh.Licensed middle ∧
+    applHigh.Licensed agentive ∧
+    applLowRecipient.Licensed middle ∧
+    applLowRecipient.Licensed anticausative := by decide
 
 /-! ### Consistency over the verb roster -/
 

--- a/Linglib/Syntax/Minimalist/Movement/InverseVoice.lean
+++ b/Linglib/Syntax/Minimalist/Movement/InverseVoice.lean
@@ -43,7 +43,7 @@ inductive InverseVoiceKind where
     constraint). -/
 structure InverseVoiceConstruction where
   kind : InverseVoiceKind
-  voice : VoiceHead
+  voice : Voice.Head
   /-- True iff the constituent that smuggles to Spec,VoiceP contains
       at most one Case-needing DP (Storment §5 transitivity constraint).
       When false, the derivation crashes on Case licensing. -/
@@ -71,7 +71,7 @@ theorem InverseVoiceConstruction.licensed_iff (c : InverseVoiceConstruction) :
 /-- An agentive Voice can never appear in an inverse-voice construction:
     the family invariant fails. -/
 theorem InverseVoiceConstruction.agentive_voice_not_wellformed
-    (c : InverseVoiceConstruction) (h : c.voice = voiceAgent) :
+    (c : InverseVoiceConstruction) (h : c.voice = Voice.agentive) :
     c.voiceWellFormed = false := by
   unfold InverseVoiceConstruction.voiceWellFormed
   rw [h]; exact agentive_blocks_smuggling
@@ -94,14 +94,14 @@ their own study files before adding canonical instances here. -/
     permits smuggling of the VP containing the quotative operator. -/
 def qiCanonical : InverseVoiceConstruction where
   kind := .quotativeInversion
-  voice := voiceAnticausative
+  voice := Voice.anticausative
   satisfiesTransitivityConstraint := true
 
 /-- Locative inversion in its canonical form: same Voice mechanism as
     QI per [storment-2026], §6. -/
 def liCanonical : InverseVoiceConstruction where
   kind := .locativeInversion
-  voice := voiceAnticausative
+  voice := Voice.anticausative
   satisfiesTransitivityConstraint := true
 
 /-- The passive in its canonical form ([collins-2005]): Voice
@@ -111,7 +111,7 @@ def liCanonical : InverseVoiceConstruction where
     anticausative Voice projected by unaccusatives. -/
 def passiveCanonical : InverseVoiceConstruction where
   kind := .passive
-  voice := voicePassive
+  voice := Voice.passive
   satisfiesTransitivityConstraint := true
 
 /-- QI, LI, and passive are all licensed inverse-voice constructions.

--- a/Linglib/Syntax/Minimalist/Movement/Smuggling.lean
+++ b/Linglib/Syntax/Minimalist/Movement/Smuggling.lean
@@ -27,9 +27,9 @@ extraction. Agentive Voice (v*) is a phase head; its complement is frozen
 by PIC once the phase is complete. Non-thematic Voice (anticausative) is
 NOT a phase head, so its complement remains accessible.
 
-This connects to `VoiceHead.IsPhasal`:
-- `voiceAgent.IsPhasal` → vP is a phase → complement frozen → no smuggling
-- `¬ voiceAnticausative.IsPhasal` → vP is not a phase → complement extractable.
+This connects to `Voice.Head.IsPhasal`:
+- `Voice.agentive.IsPhasal` → vP is a phase → complement frozen → no smuggling
+- `¬ Voice.anticausative.IsPhasal` → vP is not a phase → complement extractable.
 
 [collins-2005] makes the same point: "neither the moved PartP nor
 an unaccusative vP are strong phases."
@@ -52,7 +52,7 @@ namespace Minimalist
 
     **Derived from `IsPhasal`**: this is not a new primitive but a
     direct consequence of phase theory applied to Voice. -/
-def VoiceHead.permitsSmuggling (v : VoiceHead) : Bool :=
+def Voice.Head.permitsSmuggling (v : Voice.Head) : Bool :=
   ! decide v.IsPhasal
 
 -- ============================================================================
@@ -60,47 +60,47 @@ def VoiceHead.permitsSmuggling (v : VoiceHead) : Bool :=
 -- ============================================================================
 
 /-- Agentive Voice blocks smuggling (v* is a phase head). -/
-theorem agentive_blocks_smuggling : voiceAgent.permitsSmuggling = false := rfl
+theorem agentive_blocks_smuggling : Voice.agentive.permitsSmuggling = false := rfl
 
 /-- Non-thematic Voice permits smuggling (not a phase head).
     This is why anticausative / unaccusative verbs allow complement fronting
     ([storment-2026]: quotative inversion; [collins-2005]: passive). -/
 theorem nonthematic_permits_smuggling :
-    voiceAnticausative.permitsSmuggling = true := rfl
+    Voice.anticausative.permitsSmuggling = true := rfl
 
 /-- Causer Voice blocks smuggling (phase head, like agentive). -/
-theorem causer_blocks_smuggling : voiceCauser.permitsSmuggling = false := rfl
+theorem causer_blocks_smuggling : Voice.causer.permitsSmuggling = false := rfl
 
 /-- Expletive (middle) Voice permits smuggling (not a phase head). -/
-theorem middle_permits_smuggling : voiceMiddle.permitsSmuggling = true := rfl
+theorem middle_permits_smuggling : Voice.middle.permitsSmuggling = true := rfl
 
 /-- Impersonal Voice permits smuggling (not a phase head).
     Finnish impersonal "passive" is structurally similar to anticausative. -/
 theorem impersonal_permits_smuggling :
-    voiceImpersonal.permitsSmuggling = true := rfl
+    Voice.impersonal.permitsSmuggling = true := rfl
 
 -- ============================================================================
 -- § 3: Structural Correspondence
 -- ============================================================================
 
 /-- Smuggling availability is the exact complement of phasehood. -/
-theorem smuggling_iff_not_phase (v : VoiceHead) :
+theorem smuggling_iff_not_phase (v : Voice.Head) :
     v.permitsSmuggling = ! decide v.IsPhasal := rfl
 
 /-- θ-assigning Voice that is also a phase head blocks smuggling.
     Agentive and causer Voice are both θ-assigners and phase heads,
     so they block complement extraction. -/
-theorem theta_blocks_smuggling (v : VoiceHead)
+theorem theta_blocks_smuggling (v : Voice.Head)
     (_h : v.AssignsTheta) (hp : v.IsPhasal) :
     v.permitsSmuggling = false := by
-  simp [VoiceHead.permitsSmuggling, hp]
+  simp [Voice.Head.permitsSmuggling, hp]
 
 /-- Non-θ Voice that is also non-phasal permits smuggling.
     This covers the canonical unaccusative case. -/
-theorem no_theta_permits_smuggling (v : VoiceHead)
+theorem no_theta_permits_smuggling (v : Voice.Head)
     (_h : ¬ v.AssignsTheta) (hp : ¬ v.IsPhasal) :
     v.permitsSmuggling = true := by
-  simp [VoiceHead.permitsSmuggling, hp]
+  simp [Voice.Head.permitsSmuggling, hp]
 
 -- ============================================================================
 -- § 4: Quotative Inversion as Smuggling Application
@@ -117,11 +117,11 @@ theorem no_theta_permits_smuggling (v : VoiceHead)
     `hasComplement` corresponds to `ComplementType ≠.none` at the
     VerbEntry level; the bridge in ArgumentStructure/Studies/Storment2026.lean verifies
     this against the English fragment. -/
-def licensesQI (voice : VoiceHead) (hasComplement : Bool) : Bool :=
+def licensesQI (voice : Voice.Head) (hasComplement : Bool) : Bool :=
   voice.permitsSmuggling && hasComplement
 
 /-- QI requires both conditions: smuggling + complement. -/
-theorem qi_requires_both (v : VoiceHead) (c : Bool) :
+theorem qi_requires_both (v : Voice.Head) (c : Bool) :
     licensesQI v c = true → v.permitsSmuggling = true ∧ c = true := by
   simp [licensesQI, Bool.and_eq_true]
 
@@ -129,7 +129,7 @@ theorem qi_requires_both (v : VoiceHead) (c : Bool) :
     This is why *"spoke Mary" is ungrammatical even though speak is
     a manner-of-speaking verb — agentive Voice makes vP a phase. -/
 theorem agentive_blocks_qi (c : Bool) :
-    licensesQI voiceAgent c = false := by
+    licensesQI Voice.agentive c = false := by
   simp [licensesQI, agentive_blocks_smuggling]
 
 /-- Non-thematic Voice with a complement licenses QI.
@@ -137,13 +137,13 @@ theorem agentive_blocks_qi (c : Bool) :
     whisper projects non-thematic Voice (theme subject), and the
     quote is the complement. -/
 theorem nonthematic_with_complement_licenses_qi :
-    licensesQI voiceAnticausative true = true := by
+    licensesQI Voice.anticausative true = true := by
   simp [licensesQI, nonthematic_permits_smuggling]
 
 /-- Non-thematic Voice without complement does NOT license QI.
     Bare unaccusative use ("Mary arrived") has no quote to smuggle. -/
 theorem nonthematic_without_complement_no_qi :
-    licensesQI voiceAnticausative false = false := by
+    licensesQI Voice.anticausative false = false := by
   simp [licensesQI]
 
 -- ============================================================================
@@ -166,11 +166,11 @@ theorem nonthematic_without_complement_no_qi :
     [collins-2005]: passive v is not v* — it assigns θ but does
     not check Case (dissociated onto Voice/*by*). Without Case-checking,
     v is not a strong phase head, so PartP is extractable. -/
-def licensesPassiveSmuggling (voice : VoiceHead) (hasPartP : Bool) : Bool :=
+def licensesPassiveSmuggling (voice : Voice.Head) (hasPartP : Bool) : Bool :=
   voice.permitsSmuggling && hasPartP
 
 /-- Passive smuggling requires both conditions. -/
-theorem passive_smuggling_requires_both (v : VoiceHead) (p : Bool) :
+theorem passive_smuggling_requires_both (v : Voice.Head) (p : Bool) :
     licensesPassiveSmuggling v p = true →
     v.permitsSmuggling = true ∧ p = true := by
   simp [licensesPassiveSmuggling, Bool.and_eq_true]
@@ -178,14 +178,14 @@ theorem passive_smuggling_requires_both (v : VoiceHead) (p : Bool) :
 /-- Passive Voice licenses smuggling when PartP is present.
     This is the canonical passive derivation from [collins-2005]. -/
 theorem passive_voice_licenses_smuggling :
-    licensesPassiveSmuggling voicePassive true = true := by
+    licensesPassiveSmuggling Voice.passive true = true := by
   decide
 
 /-- Agentive Voice blocks passive smuggling — v* is a phase head,
     so PartP is frozen by PIC. Active transitives do not undergo
     smuggling: the object gets Case from v directly. -/
 theorem active_blocks_smuggling (p : Bool) :
-    licensesPassiveSmuggling voiceAgent p = false := by
+    licensesPassiveSmuggling Voice.agentive p = false := by
   simp [licensesPassiveSmuggling, agentive_blocks_smuggling]
 
 /-- Passive smuggling and QI smuggling share the same structural
@@ -193,17 +193,17 @@ theorem active_blocks_smuggling (p : Bool) :
     constituent (PartP vs VP) and the Voice flavor (passive vs
     anticausative). -/
 theorem smuggling_shared_precondition :
-    voicePassive.permitsSmuggling = true ∧
-    voiceAnticausative.permitsSmuggling = true := by decide
+    Voice.passive.permitsSmuggling = true ∧
+    Voice.anticausative.permitsSmuggling = true := by decide
 
 /-- Passive Voice checks Case but does not assign θ (feature
     dissociation). This is what makes passive v defective (non-phase):
     Case-checking is the property that distinguishes v* from v
     ([chomsky-2001], [collins-2005] p. 96). -/
 theorem passive_dissociation_enables_smuggling :
-    voicePassive.ChecksCase ∧
-    ¬ voicePassive.IsPhasal ∧
-    voicePassive.permitsSmuggling = true := by
+    Voice.passive.ChecksCase ∧
+    ¬ Voice.passive.IsPhasal ∧
+    Voice.passive.permitsSmuggling = true := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Phase/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Basic.lean
@@ -61,7 +61,7 @@ commonly-checked phase categories, call `isPhaseHeadOf` directly:
 - SA as phase head: `isPhaseHeadOf .SA so` — SAP is the highest phase, allocutive
   probing from SA is root-only.
 
-**Voice/v* correspondence**: agentive Voice = v*, tracked by `VoiceHead.IsPhasal`
+**Voice/v* correspondence**: agentive Voice = v*, tracked by `Voice.Head.IsPhasal`
 (`Voice.lean`); recent clause-internal-Voice-phase clients are
 [erlewine-sommerlot-2025] (Malayic) and [pietraszko-2026] (Ndebele). -/
 

--- a/Linglib/Syntax/Minimalist/Verbal/Applicative.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Applicative.lean
@@ -103,15 +103,15 @@ def applLowSource : ApplHead := { applType := .lowSource }
 /-! ### Voice–applicative licensing ([pylkkanen-2008], [schaefer-2008]) -/
 
 /-- `appl.Licensed voice`: if `appl` requires event semantics, `voice` supplies them. -/
-def ApplHead.Licensed (appl : ApplHead) (voice : VoiceHead) : Prop :=
+def ApplHead.Licensed (appl : ApplHead) (voice : Voice.Head) : Prop :=
   appl.applType.RequiresEventSemantics → voice.HasSemantics
 
-instance (appl : ApplHead) (voice : VoiceHead) : Decidable (appl.Licensed voice) :=
+instance (appl : ApplHead) (voice : Voice.Head) : Decidable (appl.Licensed voice) :=
   inferInstanceAs (Decidable (_ → _))
 
 /-! ### Licensing predictions -/
 
-variable (v : VoiceHead)
+variable (v : Voice.Head)
 
 /-- High applicatives require event semantics. -/
 theorem high_requires_event : ApplType.RequiresEventSemantics .high := by decide
@@ -131,21 +131,21 @@ theorem high_licensed_of_assignsTheta (h : v.AssignsTheta) : applHigh.Licensed v
   fun _ => h.hasSemantics
 
 /-- Ethical datives (high Appl) are licensed with agentive Voice. -/
-theorem ethical_dative_with_agent : applHigh.Licensed voiceAgent := by decide
+theorem ethical_dative_with_agent : applHigh.Licensed Voice.agentive := by decide
 
 /-- High Appl is blocked with middle Voice (no event semantics) ([pylkkanen-2008]). -/
-theorem ethical_dative_blocked_in_middle : ¬ applHigh.Licensed voiceMiddle := by decide
+theorem ethical_dative_blocked_in_middle : ¬ applHigh.Licensed Voice.middle := by decide
 
 /-- Possessive datives (low Appl) survive in middles. -/
-theorem possessive_dative_survives_middle : applLowRecipient.Licensed voiceMiddle := by decide
+theorem possessive_dative_survives_middle : applLowRecipient.Licensed Voice.middle := by decide
 
 /-- Possessive datives survive in anticausatives. -/
 theorem possessive_dative_survives_anticausative :
-    applLowRecipient.Licensed voiceAnticausative := by decide
+    applLowRecipient.Licensed Voice.anticausative := by decide
 
 /-- The asymmetry: ethical blocked but possessive survives in middles. -/
 theorem ethical_possessive_middle_asymmetry :
-    ¬ applHigh.Licensed voiceMiddle ∧ applLowRecipient.Licensed voiceMiddle :=
+    ¬ applHigh.Licensed Voice.middle ∧ applLowRecipient.Licensed Voice.middle :=
   ⟨ethical_dative_blocked_in_middle, possessive_dative_survives_middle⟩
 
 /-! ### Case-based blocking of SpecApplP ([wood-2015]) -/

--- a/Linglib/Syntax/Minimalist/Verbal/Aspect.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Aspect.lean
@@ -9,7 +9,7 @@ import Linglib.Features.Aktionsart
 Substrate types for the bipartite split-aspect cartography that has emerged
 from work on Mandarin and Cantonese (and before them, English event-structure
 decomposition). Following the convention that `.Voice` is a single `Cat`
-constructor distinguished by `VoiceFlavor` (`Syntax/Minimalist/Verbal/Voice.lean`),
+constructor distinguished by `Voice.Flavor` (`Syntax/Minimalist/Verbal/Voice.lean`),
 we keep `Cat.Asp` as a single F2 constructor and represent the
 `AspP_outer` / `AspP_inner` distinction as `AspFlavor` on an `AspHead`
 record. This avoids a new constructor (no fValue collision below v at F1)
@@ -20,7 +20,7 @@ unchanged.
 
 - `AspFlavor` — outer / inner.
 - `AspHead` — the analytical record (flavor + selectional spec + optional
-  Probe + feature stack), parallel to `VoiceHead`.
+  Probe + feature stack), parallel to `Voice.Head`.
 - A small number of substrate predicates (`isOuter`, `isInner`, `defaultFLevel`).
 
 ## What does NOT live here
@@ -122,7 +122,7 @@ def AspFlavor.defaultFLevel : AspFlavor → Nat
 -- § 2. Aspect Heads
 -- ============================================================================
 
-/-- An aspect head, parallel to `VoiceHead`.
+/-- An aspect head, parallel to `Voice.Head`.
 
     Carries: (a) which flavor (outer/inner), (b) optional selectional
     requirement on the complement's dynamicity, (c) optional `Probe.Profile`

--- a/Linglib/Syntax/Minimalist/Verbal/Voice.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Voice.lean
@@ -2,6 +2,7 @@ import Linglib.Syntax.Minimalist.Agree.Basic
 import Linglib.Syntax.Minimalist.Verbal.Decomposition
 import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Syntax.Voice.Alternation
+import Linglib.Syntax.Reciprocal
 
 /-!
 # Voice Head Flavors
@@ -16,6 +17,8 @@ The key typology from [schaefer-2008]:
   requiring PF realization (anticausative SE in Romance; Muñoz [munoz-perez-2026])
 - **Expletive**: No specifier, no semantics (middle voice, dispositionals)
 - **Reflexive**: [+θ, +D] with reflexive binding (Romance *se*; [martin-schaefer-kastner-2025])
+- **Reciprocal**: [+θ, +D] with reciprocal binding (Romance/Slavic reciprocal *se*;
+  [siloni-2012]'s syntactic reciprocalization)
 - **Experiencer**: [+θ, +D] introducing an experiencer external argument (psych causatives)
 
 ## Key Claim
@@ -50,6 +53,7 @@ forms.
 -/
 
 namespace Minimalist
+namespace Voice
 
 -- ============================================================================
 -- § 1: Voice Flavors
@@ -64,7 +68,7 @@ namespace Minimalist
     reflexive Voice introduces an agent that binds the internal argument
     (Romance *se*; [martin-schaefer-kastner-2025]);
     experiencer Voice introduces an experiencer external argument. -/
-inductive VoiceFlavor where
+inductive Flavor where
   | agentive     -- Introduces external argument with agent θ-role ([kratzer-1996])
   | causer       -- Introduces causer ([schaefer-2008]: Voice_CAUSE)
   | nonThematic  -- Semantically vacuous, no θ-role (anticausative SE, Chuj -j)
@@ -73,6 +77,7 @@ inductive VoiceFlavor where
   | passive      -- Checks Case but does not assign θ ([collins-2005]: *by* heads VoiceP)
   | antipassive  -- Introduces agent with absolutive (not ergative) case; demotes object to oblique ([scott-2023])
   | reflexive    -- [+θ, +D]: agent binds the internal argument (Romance se)
+  | reciprocal   -- [+θ, +D]: agent in the reciprocal relation with the internal argument ([siloni-2012])
   | experiencer  -- [+θ, +D]: introduces an experiencer external argument (psych causatives)
   deriving DecidableEq, Repr
 
@@ -83,13 +88,14 @@ inductive VoiceFlavor where
     their typological counterparts. `none` for flavors that leave the
     coding frame intact (agentive, experiencer) or whose effect is not a
     valency operation (expletive middle). -/
-def VoiceFlavor.alternation : VoiceFlavor → Option _root_.Voice.ValencyAlternation
+def Flavor.alternation : Flavor → Option _root_.Voice.ValencyAlternation
   | .causer      => some _root_.Voice.causativization
   | .nonThematic => some _root_.Voice.decausativization
   | .impersonal  => some _root_.Voice.iPassivization
   | .passive     => some _root_.Voice.passivization
   | .antipassive => some _root_.Voice.antipassivization
   | .reflexive   => some _root_.Voice.reflexivization
+  | .reciprocal  => some _root_.Voice.reciprocalization
   | .agentive | .expletive | .experiencer => none
 
 /-- The default phasehood for each Voice flavor under the
@@ -97,22 +103,23 @@ def VoiceFlavor.alternation : VoiceFlavor → Option _root_.Voice.ValencyAlterna
     and experiencer Voice are phase heads (they assign a θ-role and
     project a specifier); the other flavors are non-phasal by default.
     Per-construction divergences from this baseline are encoded via
-    `VoiceHead.phaseOverride`. -/
-def VoiceFlavor.defaultPhasal : VoiceFlavor → Bool
-  | .agentive | .causer | .reflexive | .experiencer => true
+    `Head.phaseOverride`. -/
+def Flavor.defaultPhasal : Flavor → Bool
+  | .agentive | .causer | .reflexive | .reciprocal | .experiencer => true
   | .nonThematic | .expletive | .impersonal | .passive | .antipassive => false
 
 /-- Severing prediction ([kratzer-1996]): Voice flavor determines
     WHICH theta role the external argument gets, going beyond
-    `VoiceHead.AssignsTheta` (which only says WHETHER there is one).
+    `Head.AssignsTheta` (which only says WHETHER there is one).
 
     The current typology distinguishes agent, stimulus, and experiencer
     among θ-assigning flavors; non-θ flavors return `none`. -/
-def VoiceFlavor.thetaRole : VoiceFlavor → Option ThetaRole
+def Flavor.thetaRole : Flavor → Option ThetaRole
   | .agentive     => some .agent
   | .causer       => some .stimulus
   | .antipassive  => some .agent     -- agent still present, just with ABS case
   | .reflexive    => some .agent     -- agent that binds internal arg ([wood-2015])
+  | .reciprocal   => some .agent     -- agent in the mutual relation ([siloni-2012])
   | .experiencer  => some .experiencer  -- subject-experiencer ([wood-2015])
   | .nonThematic  => none
   | .expletive    => none
@@ -124,9 +131,9 @@ def VoiceFlavor.thetaRole : VoiceFlavor → Option ThetaRole
 -- ============================================================================
 
 /-- A Voice head with its properties. -/
-structure VoiceHead where
+structure Head where
   /-- The flavor determining argument introduction and semantics -/
-  flavor : VoiceFlavor
+  flavor : Flavor
   /-- [D] subcategorization feature: requires a specifier at PF -/
   hasD : Bool
   /-- Per-construction override of the flavor-default phasehood. `none`
@@ -157,52 +164,53 @@ the underlying Bool computations live in their `Decidable` instances. Use
 
 /-- This Voice head is phasal: per-construction override if present,
     else the flavor default. -/
-def VoiceHead.IsPhasal (v : VoiceHead) : Prop :=
+def Head.IsPhasal (v : Head) : Prop :=
   v.phaseOverride.getD v.flavor.defaultPhasal = true
 
-instance (v : VoiceHead) : Decidable v.IsPhasal :=
+instance (v : Head) : Decidable v.IsPhasal :=
   inferInstanceAs (Decidable (v.phaseOverride.getD v.flavor.defaultPhasal = true))
 
 /-- This Voice head introduces a θ-role.
 
-    Holds for `agentive`, `causer`, `antipassive`, `reflexive`, `experiencer`. -/
-def VoiceHead.AssignsTheta (v : VoiceHead) : Prop :=
+    Holds for `agentive`, `causer`, `antipassive`, `reflexive`,
+    `reciprocal`, `experiencer`. -/
+def Head.AssignsTheta (v : Head) : Prop :=
   v.flavor = .agentive ∨ v.flavor = .causer ∨ v.flavor = .antipassive ∨
-  v.flavor = .reflexive ∨ v.flavor = .experiencer
+  v.flavor = .reflexive ∨ v.flavor = .reciprocal ∨ v.flavor = .experiencer
 
-instance (v : VoiceHead) : Decidable v.AssignsTheta := by
-  unfold VoiceHead.AssignsTheta; infer_instance
+instance (v : Head) : Decidable v.AssignsTheta := by
+  unfold Head.AssignsTheta; infer_instance
 
 /-- This Voice head has semantic content.
 
     Holds for everything except `nonThematic` (purely PF, e.g. anticausative
     SE) and `expletive` (middle voice, no semantic contribution). -/
-def VoiceHead.HasSemantics (v : VoiceHead) : Prop :=
+def Head.HasSemantics (v : Head) : Prop :=
   v.flavor ≠ .nonThematic ∧ v.flavor ≠ .expletive
 
-instance (v : VoiceHead) : Decidable v.HasSemantics := by
-  unfold VoiceHead.HasSemantics; infer_instance
+instance (v : Head) : Decidable v.HasSemantics := by
+  unfold Head.HasSemantics; infer_instance
 
 /-- θ-assignment entails semantic content: every θ-assigning Voice head
     contributes event semantics. The converse fails — passive Voice has
     semantics without θ (`passive_has_semantics`, `passive_no_theta`). -/
-theorem VoiceHead.AssignsTheta.hasSemantics {v : VoiceHead} (h : v.AssignsTheta) :
+theorem Head.AssignsTheta.hasSemantics {v : Head} (h : v.AssignsTheta) :
     v.HasSemantics := by
-  unfold VoiceHead.HasSemantics
-  rcases h with h | h | h | h | h <;> rw [h] <;> exact ⟨nofun, nofun⟩
+  unfold Head.HasSemantics
+  rcases h with h | h | h | h | h | h <;> rw [h] <;> exact ⟨nofun, nofun⟩
 
 /-- This Voice head subcategorizes for a specifier (Prop wrapper over
     the `hasD : Bool` data field). -/
-def VoiceHead.HasD (v : VoiceHead) : Prop := v.hasD = true
+def Head.HasD (v : Head) : Prop := v.hasD = true
 
-instance (v : VoiceHead) : Decidable v.HasD :=
+instance (v : Head) : Decidable v.HasD :=
   inferInstanceAs (Decidable (v.hasD = true))
 
 /-- This Voice head checks Case (Prop wrapper over the
     `checksCase : Bool` data field). -/
-def VoiceHead.ChecksCase (v : VoiceHead) : Prop := v.checksCase = true
+def Head.ChecksCase (v : Head) : Prop := v.checksCase = true
 
-instance (v : VoiceHead) : Decidable v.ChecksCase :=
+instance (v : Head) : Decidable v.ChecksCase :=
   inferInstanceAs (Decidable (v.checksCase = true))
 
 -- ============================================================================
@@ -210,25 +218,25 @@ instance (v : VoiceHead) : Decidable v.ChecksCase :=
 -- ============================================================================
 
 /-- Agentive Voice (transitive/unergative): introduces agent, is a phase head. -/
-def voiceAgent : VoiceHead :=
+def agentive : Head :=
   { flavor := .agentive, hasD := true }
 
 /-- Causer Voice: introduces causer, is a phase head. -/
-def voiceCauser : VoiceHead :=
+def causer : Head :=
   { flavor := .causer, hasD := true }
 
 /-- Non-thematic Voice (anticausative): no θ-role, [D] for PF marking. -/
-def voiceAnticausative : VoiceHead :=
+def anticausative : Head :=
   { flavor := .nonThematic, hasD := true }
 
 /-- Expletive Voice (middle): no specifier, no semantics. -/
-def voiceMiddle : VoiceHead :=
+def middle : Head :=
   { flavor := .expletive, hasD := false }
 
 /-- Impersonal Voice (Finnish "passive"): demotes agent to an implicit
     generic human referent. Has semantics (existential closure over agent)
     but does not assign a θ-role to a syntactic specifier. -/
-def voiceImpersonal : VoiceHead :=
+def impersonal : Head :=
   { flavor := .impersonal, hasD := false }
 
 /-- Passive Voice: headed by *by*, checks Case but does
@@ -243,7 +251,7 @@ def voiceImpersonal : VoiceHead :=
     **Contested**: [legate-2003] argues passive v IS a phase head based
     on reconstruction and parasitic gap data. The current formalization
     follows [collins-2005] and [chomsky-2001]. -/
-def voicePassive : VoiceHead :=
+def passive : Head :=
   { flavor := .passive, hasD := true, checksCase := true }
 
 /-- Reflexive Voice: introduces an agent coreferent with the internal
@@ -251,15 +259,25 @@ def voicePassive : VoiceHead :=
     reflexive *se* ([martin-schaefer-kastner-2025]). NB [wood-2015]'s
     Icelandic reflexive *-st* is a clitic in SpecpP (a figure reflexive),
     **not** an exponent of this head — see `Wood2015`. -/
-def voiceReflexive : VoiceHead :=
+def reflexive : Head :=
   { flavor := .reflexive, hasD := true }
+
+/-- Reciprocal Voice: introduces an agent standing in the mutual relation
+    with the internal argument — [siloni-2012]'s *syntactic*
+    reciprocalization (class (iii): Romance/Slavic reciprocal *se*), the
+    reciprocal twin of `Voice.reflexive`. [+θ, +D], phase head. NB
+    lexicon-formed reciprocal verbs (Hebrew *hitnašek*, English
+    intransitive *kiss*; `Reciprocal.Formation.lexical`) are **not**
+    exponents of this head — they enter the syntax already symmetric. -/
+def reciprocal : Head :=
+  { flavor := .reciprocal, hasD := true }
 
 /-- Experiencer Voice: introduces an experiencer external argument in
     Spec,VoiceP. [+θ, +D], phase head. NB this is **not** [wood-2015]'s
     Icelandic dative-subject experiencer (e.g. *leiðast* 'be bored'), where
     Voice is non-thematic and the experiencer is an applied dative — see
     `Wood2015`. -/
-def voiceExperiencer : VoiceHead :=
+def experiencer : Head :=
   { flavor := .experiencer, hasD := true }
 
 -- ============================================================================
@@ -267,53 +285,57 @@ def voiceExperiencer : VoiceHead :=
 -- ============================================================================
 
 /-- Agentive Voice assigns a θ-role. -/
-theorem agentive_assigns_theta : voiceAgent.AssignsTheta := by decide
+theorem agentive_assigns_theta : agentive.AssignsTheta := by decide
 
 /-- Non-thematic Voice does NOT assign a θ-role (Muñoz Pérez's key claim). -/
-theorem nonThematic_no_theta : ¬ voiceAnticausative.AssignsTheta := by decide
+theorem nonThematic_no_theta : ¬ anticausative.AssignsTheta := by decide
 
 /-- Non-thematic Voice has no semantic contribution.
     This is the core claim of Muñoz [munoz-perez-2026]: SE is a PF phenomenon. -/
-theorem nonThematic_no_semantics : ¬ voiceAnticausative.HasSemantics := by decide
+theorem nonThematic_no_semantics : ¬ anticausative.HasSemantics := by decide
 
 /-- Agentive Voice is a phase head (v* = Voice_AG). -/
-theorem agentive_is_phase : voiceAgent.IsPhasal := by decide
+theorem agentive_is_phase : agentive.IsPhasal := by decide
 
 /-- Non-thematic Voice is NOT a phase head. -/
-theorem anticausative_not_phase : ¬ voiceAnticausative.IsPhasal := by decide
+theorem anticausative_not_phase : ¬ anticausative.IsPhasal := by decide
 
 /-- Impersonal Voice does NOT assign a θ-role (agent is existentially closed,
     not projected to a syntactic specifier). -/
-theorem impersonal_no_theta : ¬ voiceImpersonal.AssignsTheta := by decide
+theorem impersonal_no_theta : ¬ impersonal.AssignsTheta := by decide
 
 /-- Impersonal Voice HAS semantics: it contributes an existential closure
     over the agent variable, unlike non-thematic Voice which is vacuous. -/
-theorem impersonal_has_semantics : voiceImpersonal.HasSemantics := by decide
+theorem impersonal_has_semantics : impersonal.HasSemantics := by decide
 
 /-- Passive Voice does NOT assign a θ-role (v does). -/
-theorem passive_no_theta : ¬ voicePassive.AssignsTheta := by decide
+theorem passive_no_theta : ¬ passive.AssignsTheta := by decide
 
 /-- Passive Voice IS NOT a phase head. -/
-theorem passive_not_phase : ¬ voicePassive.IsPhasal := by decide
+theorem passive_not_phase : ¬ passive.IsPhasal := by decide
 
 /-- Passive Voice HAS semantic content (*by* mediates Case-checking). -/
-theorem passive_has_semantics : voicePassive.HasSemantics := by decide
+theorem passive_has_semantics : passive.HasSemantics := by decide
 
 /-- Passive Voice checks Case ([collins-2005], p. 96: feature dissociation). -/
-theorem passive_checks_case : voicePassive.ChecksCase := by decide
+theorem passive_checks_case : passive.ChecksCase := by decide
 
 /-- Reflexive Voice assigns a θ-role ([wood-2015]). -/
-theorem reflexive_assigns_theta : voiceReflexive.AssignsTheta := by decide
+theorem reflexive_assigns_theta : reflexive.AssignsTheta := by decide
+
+/-- Reciprocal Voice assigns a θ-role ([siloni-2012]: parasitic
+    assignment gives the subject both roles). -/
+theorem reciprocal_assigns_theta : reciprocal.AssignsTheta := by decide
 
 /-- Experiencer Voice assigns a θ-role ([wood-2015]). -/
-theorem experiencer_assigns_theta : voiceExperiencer.AssignsTheta := by decide
+theorem experiencer_assigns_theta : experiencer.AssignsTheta := by decide
 
 /-- Only θ-assigning Voice flavors assign θ-roles. The reverse direction
     of `AssignsTheta`'s definition. -/
-theorem theta_implies_active_flavor (v : VoiceHead) :
+theorem theta_implies_active_flavor (v : Head) :
     v.AssignsTheta →
     v.flavor = .agentive ∨ v.flavor = .causer ∨ v.flavor = .antipassive ∨
-    v.flavor = .reflexive ∨ v.flavor = .experiencer := id
+    v.flavor = .reflexive ∨ v.flavor = .reciprocal ∨ v.flavor = .experiencer := id
 
 -- ============================================================================
 -- § 5: Voice–VerbHead Bridge ([kratzer-1996] in [cuervo-2003] terms)
@@ -331,7 +353,7 @@ theorem theta_implies_active_flavor (v : VoiceHead) :
     - Voice_nonTh + [vCAUSE, vGO, vBE] → [vCAUSE, vGO, vBE] (anticausative)
     - Voice_AG + [] → [vDO] (unergative activity)
     - Voice_nonTh + [vBE] → [vBE] (stative) -/
-def buildDecomposition (voice : VoiceHead) (rootStructure : List VerbHead) :
+def buildDecomposition (voice : Head) (rootStructure : List VerbHead) :
     List VerbHead :=
   if voice.AssignsTheta then .vDO :: rootStructure
   else rootStructure
@@ -341,35 +363,35 @@ def buildDecomposition (voice : VoiceHead) (rootStructure : List VerbHead) :
 -- ============================================================================
 
 /-- θ-assigning Voice prepends vDO to the root structure. -/
-theorem theta_voice_prepends_vDO (v : VoiceHead) (root : List VerbHead)
+theorem theta_voice_prepends_vDO (v : Head) (root : List VerbHead)
     (h : v.AssignsTheta) :
     buildDecomposition v root = .vDO :: root := by
   simp [buildDecomposition, h]
 
 /-- Non-θ Voice leaves the root structure unchanged. -/
-theorem no_theta_passthrough (v : VoiceHead) (root : List VerbHead)
+theorem no_theta_passthrough (v : Head) (root : List VerbHead)
     (h : ¬ v.AssignsTheta) :
     buildDecomposition v root = root := by
   simp [buildDecomposition, h]
 
 /-- Causative pattern: agentive Voice + [vCAUSE, vGO, vBE] yields a causative decomposition. -/
 theorem agent_plus_change_is_causative :
-    isCausative (buildDecomposition voiceAgent [.vCAUSE, .vGO, .vBE]) = true := by
+    isCausative (buildDecomposition agentive [.vCAUSE, .vGO, .vBE]) = true := by
   decide
 
 /-- Inchoative pattern: non-thematic Voice + [vCAUSE, vGO, vBE] stays inchoative. -/
 theorem nonthematic_plus_change_is_inchoative :
-    isInchoative (buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE]) = true := by
+    isInchoative (buildDecomposition anticausative [.vCAUSE, .vGO, .vBE]) = true := by
   decide
 
 /-- Activity pattern: agentive Voice + [] yields an activity. -/
 theorem agent_plus_nothing_is_activity :
-    isActivity (buildDecomposition voiceAgent []) = true := by
+    isActivity (buildDecomposition agentive []) = true := by
   decide
 
 /-- State pattern: non-thematic Voice + [vBE] yields a state. -/
 theorem nonthematic_plus_state_is_state :
-    isState (buildDecomposition voiceAnticausative [.vBE]) = true := by
+    isState (buildDecomposition anticausative [.vBE]) = true := by
   decide
 
 /-- The causative alternation: same root structure [vCAUSE, vGO, vBE] is
@@ -378,23 +400,23 @@ theorem nonthematic_plus_state_is_state :
     This formalizes the [wood-2015]/[pylkkanen-2008] insight:
     CAUSE is independent of Voice. -/
 theorem causative_alternation :
-    isCausative (buildDecomposition voiceAgent [.vCAUSE, .vGO, .vBE]) = true ∧
-    isInchoative (buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE]) = true := by
+    isCausative (buildDecomposition agentive [.vCAUSE, .vGO, .vBE]) = true ∧
+    isInchoative (buildDecomposition anticausative [.vCAUSE, .vGO, .vBE]) = true := by
   decide
 
 /-- Voice determines causativity: if the root structure is [vCAUSE, vGO, vBE],
     then whether the result is causative iff Voice assigns a θ-role. -/
-theorem voice_determines_causativity (v : VoiceHead) :
+theorem voice_determines_causativity (v : Head) :
     isCausative (buildDecomposition v [.vCAUSE, .vGO, .vBE]) = true ↔
     v.AssignsTheta := by
   cases v with | mk flavor _ _ _ _ =>
-  cases flavor <;> simp [buildDecomposition, isCausative, VoiceHead.AssignsTheta]
+  cases flavor <;> simp [buildDecomposition, isCausative, Head.AssignsTheta]
 
 /-- CAUSE is present in both causative and anticausative decompositions.
     This is the independence claim: CAUSE is part of the root, not Voice. -/
 theorem cause_independent_of_voice :
-    hasCause (buildDecomposition voiceAgent [.vCAUSE, .vGO, .vBE]) = true ∧
-    hasCause (buildDecomposition voiceAnticausative [.vCAUSE, .vGO, .vBE]) = true := by
+    hasCause (buildDecomposition agentive [.vCAUSE, .vGO, .vBE]) = true ∧
+    hasCause (buildDecomposition anticausative [.vCAUSE, .vGO, .vBE]) = true := by
   decide
 
 -- ============================================================================
@@ -406,24 +428,24 @@ theorem cause_independent_of_voice :
     dissociate: v assigns θ (external argument in Spec,vP), while Voice/*by*
     checks Case. -/
 theorem active_theta_and_case_unified :
-    voiceAgent.AssignsTheta ∧ ¬ voiceAgent.ChecksCase := by decide
+    agentive.AssignsTheta ∧ ¬ agentive.ChecksCase := by decide
 
 /-- Passive: θ-assignment and Case-checking are dissociated.
     Voice does NOT assign θ (v does), but Voice DOES check Case. -/
 theorem passive_theta_case_dissociated :
-    ¬ voicePassive.AssignsTheta ∧ voicePassive.ChecksCase := by decide
+    ¬ passive.AssignsTheta ∧ passive.ChecksCase := by decide
 
 /-- UTAH compliance: the external argument is structurally present
     (`HasD`) in BOTH active and passive. The external argument occupies
     the same position (Spec,vP) regardless of voice — satisfying the
     Uniformity of Theta Assignment Hypothesis. -/
 theorem utah_active_passive :
-    voiceAgent.HasD ∧ voicePassive.HasD := by decide
+    agentive.HasD ∧ passive.HasD := by decide
 
 /-- Passive Voice does not prepend vDO: it does not assign θ, so
     `buildDecomposition` passes the root structure through unchanged. -/
 theorem passive_no_vDO (root : List VerbHead) :
-    buildDecomposition voicePassive root = root := by
+    buildDecomposition passive root = root := by
   simp [buildDecomposition, passive_no_theta]
 
 -- ============================================================================
@@ -434,12 +456,12 @@ theorem passive_no_vDO (root : List VerbHead) :
     In the [kratzer-1996]/Schäfer framework, agentive Voice replaces
     v*. Both agentive and causer Voice are phase heads. -/
 theorem agentive_voice_is_phase_head :
-    voiceAgent.IsPhasal ∧ voiceCauser.IsPhasal := by decide
+    agentive.IsPhasal ∧ causer.IsPhasal := by decide
 
 /-- Non-thematic and expletive Voice are NOT phase heads.
     Only θ-role-assigning Voice heads (agentive, causer) are phases. -/
 theorem nonthematic_voice_not_phase_head :
-    ¬ voiceAnticausative.IsPhasal ∧ ¬ voiceMiddle.IsPhasal := by decide
+    ¬ anticausative.IsPhasal ∧ ¬ middle.IsPhasal := by decide
 
 -- Voice phasehood does NOT track θ-role assignment in general.
 -- [erlewine-sommerlot-2025] (Malayic) treats every Voice — including passive
@@ -482,7 +504,7 @@ inductive ExternalArgSemantics where
     independent factors (argument realization, verb class, pragmatics).
     Indonesian *ber-* is fully underspecified ⟨none, none⟩
     ([beavers-udayana-2022]); Spanish *se* is underspecified for ±D. -/
-structure VoiceParams where
+structure Params where
   /-- Does Voice select a syntactic specifier (DP)?
       `some true` = [+D], `some false` = [−D], `none` = underspecified -/
   selectsSpecifier : Option Bool
@@ -491,7 +513,7 @@ structure VoiceParams where
   extArgSemantics : Option ExternalArgSemantics
   deriving DecidableEq, Repr
 
-/-- Map each named VoiceFlavor to its position in the ±D / ±λx
+/-- Map each named Flavor to its position in the ±D / ±λx
     parameter space.
 
     | Flavor | ±D | ±λx | Example |
@@ -499,6 +521,7 @@ structure VoiceParams where
     | agentive | +D | +λx (arg) | English active |
     | causer | +D | +λx (arg) | Psych causative |
     | reflexive | +D | +λx (arg) | Icelandic -st reflexive |
+    | reciprocal | +D | +λx (arg) | Romance reciprocal se |
     | experiencer | +D | +λx (arg) | Icelandic subject-exp -st |
     | nonThematic | +D | −λx | Romance anticausative SE |
     | expletive | −D | −λx | English dispositional middle |
@@ -506,78 +529,100 @@ structure VoiceParams where
     | passive | +D | −λx | English passive (*by*) |
 
     Note: `nonThematic` and `passive` occupy the same cell [+D, −λx].
-    They differ in Case-checking (`VoiceHead.checksCase`), which is
-    a property of the full `VoiceHead`, not of the parametric decomposition. -/
-def VoiceFlavor.toParams : VoiceFlavor → VoiceParams
+    They differ in Case-checking (`Head.checksCase`), which is
+    a property of the full `Head`, not of the parametric decomposition. -/
+def Flavor.toParams : Flavor → Params
   | .agentive     => { selectsSpecifier := some true,  extArgSemantics := some .thematicArgument }
   | .causer       => { selectsSpecifier := some true,  extArgSemantics := some .thematicArgument }
   | .antipassive  => { selectsSpecifier := some true,  extArgSemantics := some .thematicArgument }
   | .reflexive    => { selectsSpecifier := some true,  extArgSemantics := some .thematicArgument }
+  | .reciprocal   => { selectsSpecifier := some true,  extArgSemantics := some .thematicArgument }
   | .experiencer  => { selectsSpecifier := some true,  extArgSemantics := some .thematicArgument }
   | .nonThematic  => { selectsSpecifier := some true,  extArgSemantics := some .expletive }
   | .expletive    => { selectsSpecifier := some false, extArgSemantics := some .expletive }
   | .impersonal   => { selectsSpecifier := some false, extArgSemantics := some .thematicExistential }
   | .passive      => { selectsSpecifier := some true,  extArgSemantics := some .expletive }
 
-/-- The parametric decomposition of a VoiceHead, derived from its flavor. -/
-def VoiceHead.params (v : VoiceHead) : VoiceParams := v.flavor.toParams
+/-- The parametric decomposition of a Head, derived from its flavor. -/
+def Head.params (v : Head) : Params := v.flavor.toParams
 
 /-- Does this parameter setting assign a theta role?
     Returns `none` when underspecified. -/
-def VoiceParams.assignsTheta? (p : VoiceParams) : Option Bool :=
+def Params.assignsTheta? (p : Params) : Option Bool :=
   match p.extArgSemantics with
   | some .thematicArgument    => some true
   | some .thematicExistential => some true
   | some .expletive           => some false
   | none                      => none
 
-/-- Are two VoiceParams settings compatible?
+/-- Are two Params settings compatible?
     Two settings are compatible if they agree on all specified dimensions.
     An underspecified dimension (none) is compatible with anything. -/
-def VoiceParams.isCompatibleWith (p q : VoiceParams) : Bool :=
+def Params.isCompatibleWith (p q : Params) : Bool :=
   (p.selectsSpecifier.isNone || q.selectsSpecifier.isNone ||
    p.selectsSpecifier == q.selectsSpecifier) &&
   (p.extArgSemantics.isNone || q.extArgSemantics.isNone ||
    p.extArgSemantics == q.extArgSemantics)
 
 /-- Is this parameter setting fully specified (no underspecification)? -/
-def VoiceParams.isFullySpecified (p : VoiceParams) : Bool :=
+def Params.isFullySpecified (p : Params) : Bool :=
   p.selectsSpecifier.isSome && p.extArgSemantics.isSome
 
 -- ============================================================================
 -- § 10: Parametric Bridge Theorems
 -- ============================================================================
 
-/-- All named VoiceFlavors produce fully specified params. -/
-theorem flavor_params_fully_specified (f : VoiceFlavor) :
+/-- All named Flavors produce fully specified params. -/
+theorem flavor_params_fully_specified (f : Flavor) :
     f.toParams.isFullySpecified = true := by
   cases f <;> rfl
 
-/-- VoiceHead.assignsTheta is consistent with VoiceParams.assignsTheta?:
+/-- Head.assignsTheta is consistent with Params.assignsTheta?:
     for fully-specified params, they agree. -/
-theorem flavor_params_theta_consistent (f : VoiceFlavor) :
+theorem flavor_params_theta_consistent (f : Flavor) :
     f.toParams.assignsTheta? = some (match f with
-      | .agentive | .causer | .antipassive | .reflexive | .experiencer | .impersonal => true
+      | .agentive | .causer | .antipassive | .reflexive | .reciprocal | .experiencer
+      | .impersonal => true
       | .nonThematic | .expletive | .passive => false) := by
   cases f <;> rfl
 
 /-- Compatibility is reflexive. -/
-theorem params_compatible_refl (p : VoiceParams) :
+theorem params_compatible_refl (p : Params) :
     p.isCompatibleWith p = true := by
   cases p with | mk s e =>
   cases s with
   | none => cases e with | none => rfl | some e => cases e <;> rfl
   | some s => cases s <;> (cases e with | none => rfl | some e => cases e <;> rfl)
 
-/-- A fully underspecified VoiceParams is compatible with every
-    named VoiceFlavor — the key property for Indonesian *ber-*. -/
-theorem underspecified_compatible_with_all (f : VoiceFlavor) :
-    let ber : VoiceParams := { selectsSpecifier := none, extArgSemantics := none }
+/-- A fully underspecified Params is compatible with every
+    named Flavor — the key property for Indonesian *ber-*. -/
+theorem underspecified_compatible_with_all (f : Flavor) :
+    let ber : Params := { selectsSpecifier := none, extArgSemantics := none }
     ber.isCompatibleWith f.toParams = true := by
   cases f <;> rfl
 
 -- ============================================================================
--- § 11: Voice Projection Locus
+-- § 11: Voice and Reciprocal Formation ([siloni-2012])
+-- ============================================================================
+
+/-- The reciprocal-formation locus a flavor realizes: reciprocal Voice IS
+    [siloni-2012]'s syntactic reciprocalization (`Formation.syntactic`);
+    no Voice flavor realizes lexical formation (lexicon-formed reciprocal
+    verbs are not Voice-derived). -/
+def Flavor.recipFormation : Flavor → Option _root_.Reciprocal.Formation
+  | .reciprocal => some .syntactic
+  | _ => none
+
+/-- Voice-formed reciprocals license no discontinuous construction:
+    the formation locus that reciprocal Voice realizes is exactly the one
+    [siloni-2012] §7 excludes from discontinuity (French *\*Jean s'est
+    embrassé avec Marie*). -/
+theorem reciprocal_voice_no_discontinuous :
+    (Flavor.reciprocal.recipFormation.map
+      _root_.Reciprocal.Formation.allowsDiscontinuous) = some false := rfl
+
+-- ============================================================================
+-- § 12: Voice Projection Locus
 -- ============================================================================
 
 /-- Where a non-active morphological exponent realizes its host head, in
@@ -596,11 +641,11 @@ theorem underspecified_compatible_with_all (f : VoiceFlavor) :
     compatible with either Voice projection, with the actual setting
     determined by independent factors.
 
-    This enum is the projection-side complement of `VoiceParams`: where
-    `VoiceParams` parameterizes a Voice head's own ±D/±λx settings,
-    `VoiceProjectionLocus` classifies the projection an exponent picks
+    This enum is the projection-side complement of `Params`: where
+    `Params` parameterizes a Voice head's own ±D/±λx settings,
+    `ProjectionLocus` classifies the projection an exponent picks
     out. -/
-inductive VoiceProjectionLocus where
+inductive ProjectionLocus where
   /-- Voice carrying a [D] feature; projects a specifier
       ([wood-2015] Voice_{D}). -/
   | voiceD
@@ -614,4 +659,5 @@ inductive VoiceProjectionLocus where
   | vHead
   deriving DecidableEq, Repr
 
+end Voice
 end Minimalist

--- a/Linglib/Syntax/Voice/Alternation.lean
+++ b/Linglib/Syntax/Voice/Alternation.lean
@@ -29,7 +29,7 @@ voice shows); `Middle.lean` is the interaction case. "Voice" in
 [creissels-2025]'s sense is the *coded* subset of the alternations here
 (`AlternationMarking.isVoice`); the Voice functional head of Minimalist
 syntax projects onto these operations via
-`VoiceFlavor.alternation` (`Syntax/Minimalist/Verbal/Voice.lean`).
+`Voice.Flavor.alternation` (`Syntax/Minimalist/Verbal/Voice.lean`).
 
 ## TR-roles
 


### PR DESCRIPTION
Adds the reciprocal Voice flavor — [siloni-2012]'s *syntactic* reciprocalization (class (iii), Romance/Slavic reciprocal *se*) as the reciprocal twin of reflexive Voice — and de-stutters the head API into `Minimalist.Voice.{Flavor, Head, Params, ProjectionLocus}` with `Voice.agentive`-style canonical heads.

- `Flavor.reciprocal`: [+θ, +D], phasal, θ = agent, `alternation = reciprocalization`, params [+D, +λx].
- New `Flavor.recipFormation` ties reciprocal Voice to `Reciprocal.Formation.syntactic`, with the corollary that Voice-formed reciprocals license no discontinuous construction (Siloni §7); lexicon-formed reciprocal verbs are documented non-exponents.
- Parametric inversion (flavors as named cells of `Params`, derived classifiers, the antipassive phasehood anomaly) deferred to a follow-up.