### PR TITLE
fix(Studies): complete French/Galician import sweep to Fragments/Romance

### DIFF
--- a/Linglib/Studies/AghaJeretic2022.lean
+++ b/Linglib/Studies/AghaJeretic2022.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Homogeneity.Decided
 import Linglib.Semantics.Plurality.Distributivity
 import Linglib.Fragments.English.Auxiliaries
 import Linglib.Fragments.Javanese.Modals
-import Linglib.Fragments.French.Modals
+import Linglib.Fragments.Romance.French.Modals
 import Mathlib.Data.Fin.Basic
 
 /-!

--- a/Linglib/Studies/Aikhenvald2000.lean
+++ b/Linglib/Studies/Aikhenvald2000.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.NounCategorization.Basic
-import Linglib.Fragments.French.ClassifierSystem
+import Linglib.Fragments.Romance.French.ClassifierSystem
 import Linglib.Fragments.Italian.ClassifierSystem
 import Linglib.Fragments.Mandarin.ClassifierSystem
 import Linglib.Fragments.Japanese.ClassifierSystem

--- a/Linglib/Studies/Aikhenvald2004.lean
+++ b/Linglib/Studies/Aikhenvald2004.lean
@@ -1,7 +1,7 @@
 import Linglib.Data.WALS.Features.F77A
 import Linglib.Data.WALS.Features.F78A
 import Linglib.Semantics.Evidential.Basic
-import Linglib.Fragments.French.Evidentiality
+import Linglib.Fragments.Romance.French.Evidentiality
 import Linglib.Fragments.Japanese.Evidentiality
 import Linglib.Fragments.Turkish.Evidentiality
 import Linglib.Fragments.Slavic.Bulgarian.Evidentiality

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -40,7 +40,7 @@ import Linglib.Fragments.Magahi.Pronouns
 import Linglib.Fragments.Korean.Pronouns
 import Linglib.Fragments.Japanese.Pronouns
 import Linglib.Fragments.Tamil.Pronouns
-import Linglib.Fragments.Galician.Pronouns
+import Linglib.Fragments.Romance.Galician.Pronouns
 import Linglib.Fragments.Hindi.Pronouns
 import Linglib.Fragments.Maithili.Pronouns
 import Linglib.Fragments.Punjabi.Pronouns

--- a/Linglib/Studies/AlonsoOvalleRoyer2024.lean
+++ b/Linglib/Studies/AlonsoOvalleRoyer2024.lean
@@ -4,7 +4,7 @@ import Linglib.Studies.Coon2019
 import Linglib.Fragments.Chuj.ModalIndefinites
 import Linglib.Fragments.Spanish.ModalIndefinites
 import Linglib.Fragments.German.ModalIndefinites
-import Linglib.Fragments.French.ModalIndefinites
+import Linglib.Fragments.Romance.French.ModalIndefinites
 import Linglib.Fragments.Italian.ModalIndefinites
 
 /-!

--- a/Linglib/Studies/Chierchia1998.lean
+++ b/Linglib/Studies/Chierchia1998.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Kinds.NominalMappingParameter
 import Linglib.Studies.Aikhenvald2000
-import Linglib.Fragments.French.Nouns
+import Linglib.Fragments.Romance.French.Nouns
 import Linglib.Fragments.Mandarin.Nouns
 import Linglib.Fragments.Japanese.Nouns
 import Linglib.Fragments.Italian.Nouns

--- a/Linglib/Studies/Dryer2013Negation.lean
+++ b/Linglib/Studies/Dryer2013Negation.lean
@@ -1,7 +1,7 @@
 import Linglib.Syntax.Negation
 import Linglib.Fragments.English.Negation
 import Linglib.Fragments.German.Negation
-import Linglib.Fragments.French.Negation
+import Linglib.Fragments.Romance.French.Negation
 import Linglib.Fragments.Slavic.Russian.Negation
 import Linglib.Fragments.Finnish.Negation
 import Linglib.Fragments.Japanese.Negation

--- a/Linglib/Studies/GarassinoJacob2018.lean
+++ b/Linglib/Studies/GarassinoJacob2018.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Polarity.Marking
 import Linglib.Fragments.Italian.PolarityMarking
 import Linglib.Fragments.Spanish.PolarityMarking
-import Linglib.Fragments.French.PolarityMarking
+import Linglib.Fragments.Romance.French.PolarityMarking
 
 /-!
 # Garassino & Jacob (2018) [garassino-jacob-2018]

--- a/Linglib/Studies/Greco2020.lean
+++ b/Linglib/Studies/Greco2020.lean
@@ -6,7 +6,7 @@ import Linglib.Semantics.Negation.Defs
 import Linglib.Syntax.Negation
 import Linglib.Fragments.Italian.Negation
 import Linglib.Fragments.Spanish.Negation
-import Linglib.Fragments.French.Negation
+import Linglib.Fragments.Romance.French.Negation
 import Linglib.Semantics.Polarity.Item
 import Mathlib.Data.Fintype.Basic
 

--- a/Linglib/Studies/JereticEtAl2025.lean
+++ b/Linglib/Studies/JereticEtAl2025.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Alternatives.Source
 import Linglib.Semantics.Alternatives.Competition
 import Linglib.Semantics.Alternatives.Structural
 import Linglib.Pragmatics.AvoidAmbiguity
-import Linglib.Fragments.French.Determiners
+import Linglib.Fragments.Romance.French.Determiners
 import Linglib.Fragments.English.Determiners
 
 /-!

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Conditionals.Basic
 import Linglib.Semantics.Causation.Interpretation
 import Linglib.Semantics.Causation.Implicative
 import Linglib.Syntax.Negation
-import Linglib.Fragments.French.Negation
+import Linglib.Fragments.Romance.French.Negation
 import Linglib.Fragments.Mandarin.Negation
 import Linglib.Fragments.Januubi.Negation
 import Linglib.Fragments.ZarmaSonrai.Negation

--- a/Linglib/Studies/Maddieson2013.lean
+++ b/Linglib/Studies/Maddieson2013.lean
@@ -3,7 +3,7 @@ import Linglib.Fragments.German.Phonology
 import Linglib.Fragments.Finnish.Phonology
 import Linglib.Fragments.Turkish.Phonology
 import Linglib.Fragments.Slavic.Russian.Phonology
-import Linglib.Fragments.French.Phonology
+import Linglib.Fragments.Romance.French.Phonology
 import Linglib.Fragments.Spanish.Phonology
 import Linglib.Fragments.Japanese.Phonology
 import Linglib.Fragments.Mandarin.Phonology

--- a/Linglib/Studies/MartinSchaeferKastner2025.lean
+++ b/Linglib/Studies/MartinSchaeferKastner2025.lean
@@ -1,7 +1,7 @@
 import Linglib.Pragmatics.GriceanMaxims
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
-import Linglib.Fragments.French.Predicates
+import Linglib.Fragments.Romance.French.Predicates
 
 /-!
 # [martin-schaefer-kastner-2025] — The Lexical Pragmatics of Reflexive Marking

--- a/Linglib/Studies/Miestamo2005.lean
+++ b/Linglib/Studies/Miestamo2005.lean
@@ -7,7 +7,7 @@ import Linglib.Fragments.Italian.Negation
 import Linglib.Fragments.German.Negation
 import Linglib.Fragments.Japanese.Negation
 import Linglib.Fragments.Turkish.Negation
-import Linglib.Fragments.French.Negation
+import Linglib.Fragments.Romance.French.Negation
 import Linglib.Fragments.Burmese.Negation
 import Linglib.Fragments.Spanish.Negation
 import Linglib.Fragments.Mandarin.Negation

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Plurality.Reciprocal
 import Linglib.Fragments.English.Pronouns
 import Linglib.Fragments.English.Reciprocals
 import Linglib.Fragments.Chichewa.Reciprocals
-import Linglib.Fragments.French.Reciprocals
+import Linglib.Fragments.Romance.French.Reciprocals
 import Linglib.Fragments.German.Reciprocals
 import Linglib.Fragments.Greek.StandardModern.Reciprocals
 import Linglib.Fragments.Hungarian.Reciprocals

--- a/Linglib/Studies/RuytenbeekEtAl2017.lean
+++ b/Linglib/Studies/RuytenbeekEtAl2017.lean
@@ -1,6 +1,6 @@
 import Linglib.Discourse.SpeechAct
 import Linglib.Semantics.Mood.SpeechEvent
-import Linglib.Fragments.French.Modals
+import Linglib.Fragments.Romance.French.Modals
 
 /-!
 # [ruytenbeek-etal-2017]: Indirect Request Processing, Sentence Types

--- a/Linglib/Studies/Smith1997.lean
+++ b/Linglib/Studies/Smith1997.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Aspect.Basic
 import Linglib.Semantics.Aspect.Composition
 import Linglib.Features.Aktionsart
 import Linglib.Fragments.English.TenseAspect
-import Linglib.Fragments.French.TenseAspect
+import Linglib.Fragments.Romance.French.TenseAspect
 import Linglib.Fragments.Mandarin.TenseAspect
 import Linglib.Features.MassCount
 

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Intensional.WorldTimeIndex
 import Linglib.Semantics.Presupposition.Basic
-import Linglib.Fragments.French.Predicates
+import Linglib.Fragments.Romance.French.Predicates
 import Linglib.Semantics.ArgumentStructure.Affectedness
 import Linglib.Features.Aktionsart
 import Linglib.Syntax.Minimalist.Verbal.Voice

--- a/Linglib/Studies/Stassen1985.lean
+++ b/Linglib/Studies/Stassen1985.lean
@@ -17,7 +17,7 @@ import Linglib.Fragments.Thai.Comparison
 import Linglib.Fragments.Tagalog.Comparison
 import Linglib.Fragments.Arabic.ModernStandard.Comparison
 import Linglib.Fragments.Navajo.Comparison
-import Linglib.Fragments.French.Comparison
+import Linglib.Fragments.Romance.French.Comparison
 
 /-!
 # Stassen 1985: Comparison and Universal Grammar

--- a/Linglib/Studies/Stassen2013Comparison.lean
+++ b/Linglib/Studies/Stassen2013Comparison.lean
@@ -15,7 +15,7 @@ import Linglib.Fragments.Thai.Comparison
 import Linglib.Fragments.Tagalog.Comparison
 import Linglib.Fragments.Arabic.ModernStandard.Comparison
 import Linglib.Fragments.Navajo.Comparison
-import Linglib.Fragments.French.Comparison
+import Linglib.Fragments.Romance.French.Comparison
 
 /-!
 # Stassen (2013): WALS chapter 121 on comparative constructions

--- a/Linglib/Studies/TurcoBraunDimroth2014.lean
+++ b/Linglib/Studies/TurcoBraunDimroth2014.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Polarity.Marking
 import Mathlib.Tactic.NormNum
 import Linglib.Fragments.Dutch.Particles
 import Linglib.Fragments.German.PolarityMarking
-import Linglib.Fragments.French.PolarityMarking
+import Linglib.Fragments.Romance.French.PolarityMarking
 import Linglib.Fragments.Swedish.AnswerParticles
 import Linglib.Fragments.English.PolarityMarking
 import Linglib.Fragments.Spanish.PolarityMarking


### PR DESCRIPTION
#1320 moved `Fragments/{French,Galician}` into `Fragments/Romance/` but only part of the consumer import sweep was staged — 21 files on main still import the old paths, breaking the build. This lands the missing sweep edits (mechanical path rewrite only).