### PR TITLE
refactor(Semantics/Dynamic): CDRT State rename + spine unification

### DIFF
--- a/Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean
+++ b/Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean
@@ -87,18 +87,14 @@ section CDRT
 open Semantics.Dynamic.CDRT
 open Semantics.Dynamic.Core
 
--- (`Register E = Assignment E` is now true by abbrev unfolding —
--- the previous bridge theorem `cdrt_register_eq_assignment : … := rfl`
--- was retired when `Register` became `abbrev := Core.Assignment E`.)
-
 /-- Discourse referent introduction under closure = cylindrification.
 
 `closure(new n ;; φ) = cₙ(closure(φ))`: introducing dref `n`
 then continuing with `φ` equals cylindrifying `φ` at `n`. -/
 theorem cdrt_new_seq_eq_cylindrify {E : Type*} (n : Nat) (φ : DProp E) :
-    closure (toDRS (DProp.new n ;; φ)) =
-    cylindrify n (closure (toDRS φ)) := by
-  ext g; simp only [closure, toDRS, DProp.seq, DProp.new, cylindrify]
+    closure (DProp.new n ;; φ) =
+    cylindrify n (closure φ) := by
+  ext g; simp only [closure, DProp.seq, dseq, DProp.new, cylindrify]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, hφ⟩
     exact ⟨e, o, by convert hφ using 2; simp [Function.update_apply]⟩
@@ -107,7 +103,7 @@ theorem cdrt_new_seq_eq_cylindrify {E : Type*} (n : Nat) (φ : DProp E) :
 
 /-- CDRT equality condition on drefs = diagonal element. -/
 theorem cdrt_eq_dref_eq_diagonal {E : Type*} (i j : Nat) :
-    eq' (dref i : Dref (Register E) E) (dref j) = @diagonal E i j := by
+    eq' (dref i : Dref (State E) E) (dref j) = @diagonal E i j := by
   ext g; simp only [eq', dref, diagonal]
 
 end CDRT

--- a/Linglib/Semantics/Dynamic/CDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/CDRT/Basic.lean
@@ -2,195 +2,99 @@ import Linglib.Semantics.Dynamic.Connectives.CCP
 import Linglib.Semantics.Dynamic.Core.DynamicTy2
 
 /-!
-# Compositional DRT
+# Compositional DRT — states, drefs, and boxes
 [muskens-1996]
 
-Stub for Compositional DRT, which combines DRT with Montague grammar
-for fully compositional dynamic semantics.
+CDRT instantiates Dynamic Ty2 at the concrete state type
+`State E := Core.Assignment E` (`Nat → E`) — Muskens's type `s`. A
+*register* (discourse referent, his type `se`) is a map *from* states —
+here the projection `dref n` — not the state itself. Boxes (type `s(st)`)
+are `DProp E := Update (State E)`: the relational algebra of
+`Connectives/Defs.lean` specialized to CDRT states, so the connectives
+*are* `dseq`/`test`/`dneg`/`dimpl`/`ddisj` by definition rather than
+re-stipulation. Only `DProp.new` (ℕ-indexed random assignment) is a
+CDRT-specific primitive: the abstract `AssignmentStructure` cannot be
+instantiated at `Nat → E`.
 
-## Key Ideas
-
-Muskens' CDRT:
-- Uses type-theoretic framework compatible with Montague semantics
-- DRSs are encoded as state transformers
-- Fully compositional: meanings combine via function application
-- Bridges static (Montague) and dynamic (DRT) semantics
-
-## Semantic Architecture
-
-Instead of Update boxes, CDRT uses:
-- State type: assignment sequences
-- Dynamic propositions: relations between states
-- Compositional combination rules
-
-## Type System (Table 1, p. 155)
-
-| Type | Meaning |
-|------|---------|
-| e | Entities |
-| t | Truth values |
-| s | States (registers/assignments) |
-| π | Registers (discourse referents) |
-| s(st) | Box meanings (binary relations on states) |
+The compositional fragment (T₀ translations, generalized coordination,
+the paper's derivations) and the weakest-precondition calculus live in
+`Studies/Muskens1996.lean`.
 -/
 
 namespace Semantics.Dynamic.CDRT
 
--- Core Types
+open Semantics.Dynamic.Core.DynProp
 
-/--
-CDRT state: a register/assignment function.
+/-- CDRT state: Muskens's type `s`, concretely an assignment `Nat → E`.
+His *registers* are the maps from states (see `dref`), not the states —
+the earlier name `Register` for this type inverted the paper's
+terminology. The alias shares mathlib's `Function.update` simp set with
+H&K composition, DPL, Charlow continuations, and Spector's plural
+substrate. -/
+abbrev State (E : Type*) := Core.Assignment E
 
-Muskens names them "registers" but the type is `Core.Assignment E`;
-this alias preserves Muskens's vocabulary while sharing mathlib's
-`Function.update` simp set with H&K composition, DPL, Charlow continuations, and Spector's plural
-substrate.
--/
-abbrev Register (E : Type*) := Core.Assignment E
+/-- Register lookup as a Dynamic Ty2 dref: Muskens's type `se`,
+picking out the value stored at position `n`. -/
+def dref {E : Type*} (n : Nat) : Semantics.Dynamic.Core.Dref (State E) E :=
+  λ r => r n
 
-/--
-Dynamic proposition: relates input and output states.
+/-- Dynamic proposition (box, type `s(st)`): the relational `Update`
+specialized to CDRT states. -/
+abbrev DProp (E : Type*) := Update (State E)
 
-⟦φ⟧ : Register E → Register E → Prop
--/
-def DProp (E : Type*) := Register E → Register E → Prop
+/-- Static proposition: the spine's `Condition` at CDRT states. -/
+abbrev SProp (E : Type*) := Condition (State E)
 
-/--
-Static proposition (for embedding classical logic).
--/
-def SProp (E : Type*) := Register E → Prop
+/-- Embed a static proposition as a dynamic one: the spine's `test`. -/
+abbrev DProp.ofStatic {E : Type*} (p : SProp E) : DProp E := test p
 
--- Basic Constructions
-
-/--
-Embed a static proposition as a dynamic one (test).
-
-⟦p⟧(i, o) iff i = o ∧ p(i)
--/
-def DProp.ofStatic {E : Type*} (p : SProp E) : DProp E :=
-  λ i o => i = o ∧ p i
-
-/--
-Dynamic conjunction: relational composition.
-
-⟦φ; ψ⟧(i, o) iff ∃k. ⟦φ⟧(i, k) ∧ ⟦ψ⟧(k, o)
--/
-def DProp.seq {E : Type*} (φ ψ : DProp E) : DProp E :=
-  λ i o => ∃ k, φ i k ∧ ψ k o
+/-- Dynamic conjunction: the spine's relational composition `dseq`. -/
+abbrev DProp.seq {E : Type*} (φ ψ : DProp E) : DProp E := dseq φ ψ
 
 infixl:65 " ;; " => DProp.seq
 
-/--
-New discourse referent introduction.
-
-[new n] extends the register at position n with an arbitrary value.
--/
+/-- New discourse referent: `[new n]` extends the state at position `n`
+with an arbitrary value. CDRT's one native primitive. -/
 def DProp.new {E : Type*} (n : Nat) : DProp E :=
   λ i o => ∃ e : E, o = λ m => if m = n then e else i m
 
-/--
-Dynamic negation: test for failure.
+/-- Dynamic negation: the spine's `dneg`, re-entering the update algebra
+via `test`. -/
+abbrev DProp.neg {E : Type*} (φ : DProp E) : DProp E := test (dneg φ)
 
-⟦¬φ⟧(i, o) iff i = o ∧ ¬∃k. ⟦φ⟧(i, k)
--/
-def DProp.neg {E : Type*} (φ : DProp E) : DProp E :=
-  λ i o => i = o ∧ ¬∃ k, φ i k
+/-- Dynamic implication: the spine's `dimpl` via `test`. -/
+abbrev DProp.impl {E : Type*} (φ ψ : DProp E) : DProp E := test (dimpl φ ψ)
 
-/--
-Dynamic implication: if φ succeeds, ψ must succeed.
+/-- Dynamic disjunction as a test (SEM2, [muskens-1996] p. 148): the
+spine's `ddisj` via `test`. -/
+abbrev DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
+  test (Semantics.Dynamic.Core.DynProp.ddisj φ ψ)
 
-⟦φ → ψ⟧(i, o) iff i = o ∧ ∀k. (⟦φ⟧(i, k) → ∃m. ⟦ψ⟧(k, m))
--/
-def DProp.impl {E : Type*} (φ ψ : DProp E) : DProp E :=
-  λ i o => i = o ∧ ∀ k, φ i k → ∃ m, ψ k m
+/-- Truth at a state: the spine's `trueAt`. -/
+abbrev DProp.true_at {E : Type*} (φ : DProp E) (i : State E) : Prop :=
+  trueAt φ i
 
-/--
-Dynamic disjunction: φ or ψ.
-
-⟦φ or ψ⟧(i, o) iff i = o ∧ (∃k. ⟦φ⟧(i, k) ∨ ⟦ψ⟧(i, k))
-
-Disjunction is a test: it checks whether either disjunct is satisfiable
-without changing state. Corresponds to SEM2 ([muskens-1996], p. 148).
--/
-def DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
-  λ i o => i = o ∧ (∃ k, φ i k ∨ ψ i k)
-
--- Compositional Semantics
-
-/--
-Entity type: individuals.
--/
-abbrev CDRTEntity (E : Type*) := E
-
-/--
-Generalized quantifier type.
--/
-def GQ (E : Type*) := (E → DProp E) → DProp E
-
-/--
-Indefinite "a/an": introduces dref and applies predicate.
-
-⟦a⟧ = λP.λQ. new n; P(rn); Q(rn)
-
-where rn is the register lookup at n.
--/
-def indefinite {E : Type*} (n : Nat) (p : E → DProp E) (q : E → DProp E) : DProp E :=
-  DProp.new n ;; (λ i o => ∃ k, p (i n) i k ∧ q (k n) k o)
-
-/--
-Pronoun: lookup register value.
-
-⟦heₙ⟧ = rn (returns the value at register n)
--/
-def pronoun {E : Type*} (n : Nat) : Register E → E :=
-  λ r => r n
-
--- Truth and Entailment
-
-/--
-A dynamic proposition is TRUE at state i if it can transition somewhere.
--/
-def DProp.true_at {E : Type*} (φ : DProp E) (i : Register E) : Prop :=
-  ∃ o, φ i o
-
-/--
-Dynamic entailment: φ entails ψ if ψ is true after φ.
--/
+/-- Dynamic entailment: every output of `φ` can be extended by `ψ`. -/
 def DProp.entails {E : Type*} (φ ψ : DProp E) : Prop :=
   ∀ i o, φ i o → ψ.true_at o
 
--- General reduction lemmas for DProp constructors
+/-! ### Reduction lemmas -/
 
-/-- The output of a negated DProp always equals the input register. -/
-theorem DProp.neg_output {E : Type*} {φ : DProp E} {i o : Register E}
+/-- The output of a negated `DProp` always equals the input state. -/
+theorem DProp.neg_output {E : Type*} {φ : DProp E} {i o : State E}
     (h : DProp.neg φ i o) : o = i := h.1.symm
 
-/-- `DProp.impl` is true at `i` iff every antecedent extension satisfies the consequent. -/
-theorem DProp.impl_true_at {E : Type*} (φ ψ : DProp E) (i : Register E) :
+/-- `DProp.impl` is true at `i` iff every antecedent extension satisfies
+the consequent. -/
+theorem DProp.impl_true_at {E : Type*} (φ ψ : DProp E) (i : State E) :
     DProp.true_at (DProp.impl φ ψ) i ↔ ∀ k, φ i k → DProp.true_at ψ k := by
-  simp only [DProp.true_at, DProp.impl]
+  simp only [DProp.true_at, trueAt, DProp.impl, test, dimpl]
   exact ⟨λ ⟨_, rfl, h⟩ => h, λ h => ⟨i, rfl, h⟩⟩
 
-/-- A static DProp is true at `i` iff its static content holds. -/
-theorem DProp.ofStatic_true_at {E : Type*} (p : SProp E) (i : Register E) :
+/-- A static `DProp` is true at `i` iff its static content holds. -/
+theorem DProp.ofStatic_true_at {E : Type*} (p : SProp E) (i : State E) :
     DProp.true_at (DProp.ofStatic p) i ↔ p i := by
-  simp only [DProp.true_at, DProp.ofStatic]
+  simp only [DProp.true_at, trueAt, DProp.ofStatic, test]
   exact ⟨λ ⟨_, rfl, h⟩ => h, λ h => ⟨i, rfl, h⟩⟩
-
-/-! ## CDRT-as-Dynamic-Ty2
-
-CDRT's `Register E = Nat → E` is the same type as [muskens-1996]'s
-state space `S` in Dynamic Ty2 with discourse referents `Dref S E = S → E`.
-Drefs in CDRT are register-lookups; `DProp E` and `Update (Register E)` are
-*the same type*, so the embedding is a pair of identity functions.
--/
-
-/-- CDRT register lookup as a Dynamic Ty2 dref. -/
-def dref {E : Type*} (n : Nat) : Semantics.Dynamic.Core.Dref (Register E) E :=
-  λ r => r n
-
-/-- `DProp E` IS an Update over `Register E`. -/
-def toDRS {E : Type*} (φ : DProp E) :
-    Semantics.Dynamic.Core.DynProp.Update (Register E) := φ
 
 end Semantics.Dynamic.CDRT

--- a/Linglib/Semantics/Dynamic/Intensional.lean
+++ b/Linglib/Semantics/Dynamic/Intensional.lean
@@ -103,19 +103,20 @@ notation:max c "⟦" p "⟧" => IContext.update c p
 
 end IContext
 
-/-- Context-to-context transformer (sentence denotation). -/
-def DynProp (W : Type*) (E : Type*) := IContext W E → IContext W E
+/-- Context-to-context transformer (sentence denotation): the spine's
+`CCP` at ICDRT possibilities. -/
+abbrev DynProp (W : Type*) (E : Type*) := CCP (ICDRTAssignment W E × W)
 
 namespace DynProp
 
-/-- Identity (says nothing). Aliases `CCP.id`. -/
-def id : DynProp W E := λ c => c
+/-- Identity (says nothing): the spine's `CCP.id`. -/
+abbrev id : DynProp W E := CCP.id
 
-/-- Absurd (contradiction). Aliases `CCP.absurd`. -/
-def absurd : DynProp W E := λ _ => ∅
+/-- Absurd (contradiction): the spine's `CCP.absurd`. -/
+abbrev absurd : DynProp W E := CCP.absurd
 
 /-- Lift a classical proposition to a context filter. -/
-def ofProp (p : W → Prop) : DynProp W E := λ c => c.update p
+def ofProp (p : W → Prop) : DynProp W E := λ c => IContext.update c p
 
 end DynProp
 

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
@@ -27,9 +27,10 @@ Unlike DPL/DRT, no assignment component - US focuses on propositional content.
 abbrev State (W : Type*) := Set W
 
 /--
-Update function: how a sentence modifies a state.
+Update function: how a sentence modifies a state. This is the spine's
+`CCP W` (set-transformer context change potential) under Veltman's name.
 -/
-abbrev Update (W : Type*) := State W → State W
+abbrev Update (W : Type*) := Core.CCP W
 
 /--
 Propositional update: eliminate worlds where φ fails.

--- a/Linglib/Studies/Charlow2014.lean
+++ b/Linglib/Studies/Charlow2014.lean
@@ -53,7 +53,7 @@ the dichotomy. Each of DPL, DRT, CDRT supplies one stateful framework.
 
 namespace Charlow2014
 
-open Semantics.Dynamic.CDRT (DProp Register)
+open Semantics.Dynamic.CDRT (DProp State)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. The dichotomy
@@ -168,13 +168,13 @@ Donkey encoding: `cdrt_full_donkey` (`Cooper2023.lean §4`):
             (ofStatic (beats ·0 ·1))`.
 Truth equivalence: `full_donkey_equiv` (Cooper2023 §4) + Π-type
 classical reduction.
-Negation: `DProp.neg φ := λ i o => i = o ∧ ¬ ∃ k, φ i k`. Output
+Negation: `DProp.neg φ := test (dneg φ)` — a test. Output
 register equals input; drefs from inside negation are dropped
 (`neg_destroys_dref`, `dne_same_truth` in Cooper2023 §5). -/
 def cdrt : AnaphoraFramework farmer donkey owns beats where
   name := "CDRT (Muskens 1996)"
   strategy := .stateThreading
-  donkeyHolds := ∀ i : Register E,
+  donkeyHolds := ∀ i : State E,
     DProp.true_at (Cooper2023.cdrt_full_donkey
                     farmer donkey owns beats) i
   donkey_iff_classical := by

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -178,7 +178,8 @@ the second is type-dependency (witnesses as structure). Both reduce
 to the same classical truth conditions.
 -/
 
-open Semantics.Dynamic.CDRT (DProp Register SProp)
+open Semantics.Dynamic.CDRT (DProp State SProp)
+open Semantics.Dynamic.Core (trueAt dseq test dneg dimpl)
 open Semantics.TypeTheoretic (Ppty PPpty Parametric IsTrue IsFalse propT)
 open Cooper2023Ch7 (purify purifyUniv)
 
@@ -195,9 +196,10 @@ def ttr_exists (P : E → Prop) : Type := (x : E) × propT (P x)
 
 /-- **Equivalence 1**: CDRT dref introduction and TTR Σ-type have
 the same truth conditions. Both reduce to `∃ x, P x`. -/
-theorem exists_equiv (n : Nat) (P : E → Prop) (i : Register E) :
+theorem exists_equiv (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (cdrt_exists n P) i ↔ Nonempty (ttr_exists P) := by
-  simp only [DProp.true_at, cdrt_exists, DProp.seq, DProp.new, DProp.ofStatic, ttr_exists]
+  simp only [DProp.true_at, trueAt, cdrt_exists, DProp.seq, dseq, DProp.new,
+    DProp.ofStatic, test, ttr_exists]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, rfl, hp⟩
     exact ⟨⟨e, PLift.up (by simpa using hp)⟩⟩
@@ -224,10 +226,10 @@ def ttr_donkey (P Q : E → Prop) : Type :=
 
 /-- **Equivalence 2**: CDRT donkey implication and TTR Π-type have
 the same truth conditions. Both reduce to `∀ x, P x → Q x`. -/
-theorem donkey_equiv (n : Nat) (P Q : E → Prop) (i : Register E) :
+theorem donkey_equiv (n : Nat) (P Q : E → Prop) (i : State E) :
     DProp.true_at (cdrt_donkey n P Q) i ↔ Nonempty (ttr_donkey P Q) := by
-  simp only [DProp.true_at, cdrt_donkey, DProp.impl, DProp.seq, DProp.new,
-    DProp.ofStatic, ttr_donkey]
+  simp only [DProp.true_at, trueAt, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq,
+    DProp.new, DProp.ofStatic, test, ttr_donkey]
   constructor
   · rintro ⟨o, rfl, hall⟩
     refine ⟨λ x hpx => PLift.up ?_⟩
@@ -262,12 +264,12 @@ def ttr_full_donkey (farmer donkey_ : E → Prop) (owns beats : E → E → Prop
   (x : E) → farmer x → (y : E) → donkey_ y → owns x y → propT (beats x y)
 
 private theorem donkey_antecedent_iff
-    (farmer donkey_ : E → Prop) (owns : E → E → Prop) (i k : Register E) :
+    (farmer donkey_ : E → Prop) (owns : E → E → Prop) (i k : State E) :
     (DProp.new 0 ;; DProp.ofStatic (λ r => farmer (r 0)) ;;
      DProp.new 1 ;; DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1))) i k ↔
     ∃ x y, k = (λ m => if m = 1 then y else if m = 0 then x else i m) ∧
       farmer x ∧ donkey_ y ∧ owns x y := by
-  simp only [DProp.seq, DProp.new, DProp.ofStatic]
+  simp only [DProp.seq, dseq, DProp.new, DProp.ofStatic, test]
   constructor
   · rintro ⟨k₃, ⟨k₂, ⟨k₁, ⟨e₀, rfl⟩, rfl, hf⟩, ⟨e₁, rfl⟩⟩, rfl, hd, ho⟩
     exact ⟨e₀, e₁, rfl, by simpa, by simpa, by simpa⟩
@@ -279,7 +281,7 @@ private theorem donkey_antecedent_iff
 conditions in CDRT and TTR. -/
 theorem full_donkey_equiv
     (farmer donkey_ : E → Prop) (owns beats : E → E → Prop)
-    (i : Register E) :
+    (i : State E) :
     DProp.true_at (cdrt_full_donkey farmer donkey_ owns beats) i ↔
     Nonempty (ttr_full_donkey farmer donkey_ owns beats) := by
   simp only [cdrt_full_donkey]
@@ -349,17 +351,17 @@ incompatible DNE solutions" table. -/
 /-- In CDRT, negation destroys anaphoric potential. After `¬φ`, the
 output register is unchanged from input — any drefs introduced by φ
 are inaccessible. -/
-theorem neg_destroys_dref {φ : DProp E} (i o : Register E)
+theorem neg_destroys_dref {φ : DProp E} (i o : State E)
     (h : DProp.neg φ i o) : o = i :=
   DProp.neg_output h
 
 /-- Double negation preserves truth but not drefs. `¬¬(∃x.P(x))` has
 the same truth conditions as `∃x.P(x)`, but the output register is
 the *input* register (no binding). -/
-theorem dne_same_truth (n : Nat) (P : E → Prop) (i : Register E) :
+theorem dne_same_truth (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (DProp.neg (DProp.neg (cdrt_exists n P))) i ↔
     DProp.true_at (cdrt_exists n P) i := by
-  simp only [DProp.true_at, DProp.neg]
+  simp only [DProp.true_at, trueAt, DProp.neg, test, dneg]
   constructor
   · rintro ⟨_, rfl, h⟩
     exact Classical.byContradiction (λ hno => h ⟨i, rfl, hno⟩)
@@ -391,7 +393,7 @@ private def ownsP : Ent → Ent → Prop
 private def beatsP : Ent → Ent → Prop
   | .john, .fido => True | _, _ => False
 
-private def initReg : Register Ent := λ _ => .john
+private def initReg : State Ent := λ _ => .john
 
 /-- CDRT donkey sentence is true on this model. -/
 theorem cdrt_donkey_concrete :


### PR DESCRIPTION
Wave 2 of the Dynamic-API audit.

- CDRT: rename `Register` → `State` (the old name inverted Muskens's register/state terminology — `Nat → E` is his type s; registers are the maps from states, i.e. `dref`); `DProp` and its connectives are now definitionally the spine's `Update`/`dseq`/`test`/`dneg`/`dimpl`/`ddisj` instead of a re-stipulated algebra; the `toDRS` identity bridge and four zero-consumer defs are gone.
- `UpdateSemantics.Update W := Core.CCP W` and `Intensional.DynProp := CCP _` (id/absurd delegated) — two of the four duplicate relational encodings now literally are the spine.