### PR TITLE
refactor(Semantics/Dynamic): reuse Relation.Comp, dedup closure, CCP.guard

### DIFF
--- a/Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean
+++ b/Linglib/Core/Logic/CylindricAlgebra/DynamicSemantics.lean
@@ -94,7 +94,7 @@ then continuing with `φ` equals cylindrifying `φ` at `n`. -/
 theorem cdrt_new_seq_eq_cylindrify {E : Type*} (n : Nat) (φ : DProp E) :
     closure (DProp.new n ;; φ) =
     cylindrify n (closure φ) := by
-  ext g; simp only [closure, DProp.seq, dseq, DProp.new, cylindrify]
+  ext g; simp only [closure, DProp.seq, dseq, Relation.Comp, DProp.new, cylindrify]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, hφ⟩
     exact ⟨e, o, by convert hφ using 2; simp [Function.update_apply]⟩

--- a/Linglib/Semantics/Dynamic/CDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/CDRT/Basic.lean
@@ -70,9 +70,9 @@ spine's `ddisj` via `test`. -/
 abbrev DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
   test (Semantics.Dynamic.Core.DynProp.ddisj φ ψ)
 
-/-- Truth at a state: the spine's `trueAt`. -/
+/-- Truth at a state: the spine's `closure`. -/
 abbrev DProp.true_at {E : Type*} (φ : DProp E) (i : State E) : Prop :=
-  trueAt φ i
+  closure φ i
 
 /-- Dynamic entailment: every output of `φ` can be extended by `ψ`. -/
 def DProp.entails {E : Type*} (φ ψ : DProp E) : Prop :=
@@ -88,13 +88,13 @@ theorem DProp.neg_output {E : Type*} {φ : DProp E} {i o : State E}
 the consequent. -/
 theorem DProp.impl_true_at {E : Type*} (φ ψ : DProp E) (i : State E) :
     DProp.true_at (DProp.impl φ ψ) i ↔ ∀ k, φ i k → DProp.true_at ψ k := by
-  simp only [DProp.true_at, trueAt, DProp.impl, test, dimpl]
+  simp only [DProp.true_at, closure, DProp.impl, test, dimpl]
   exact ⟨λ ⟨_, rfl, h⟩ => h, λ h => ⟨i, rfl, h⟩⟩
 
 /-- A static `DProp` is true at `i` iff its static content holds. -/
 theorem DProp.ofStatic_true_at {E : Type*} (p : SProp E) (i : State E) :
     DProp.true_at (DProp.ofStatic p) i ↔ p i := by
-  simp only [DProp.true_at, trueAt, DProp.ofStatic, test]
+  simp only [DProp.true_at, closure, DProp.ofStatic, test]
   exact ⟨λ ⟨_, rfl, h⟩ => h, λ h => ⟨i, rfl, h⟩⟩
 
 end Semantics.Dynamic.CDRT

--- a/Linglib/Semantics/Dynamic/Connectives/CCP.lean
+++ b/Linglib/Semantics/Dynamic/Connectives/CCP.lean
@@ -13,10 +13,12 @@ PLA, DRT, DPL, and CDRT formalizations.
 The relational `Update S` ([groenendijk-stokhof-1991], [muskens-1996]) of
 `Connectives/Defs.lean` is the primary dynamic type; `CCP` connects to it
 via `lift R σ = { j | ∃ i ∈ σ, R i j }` and `lower φ i j = j ∈ φ {i}`,
-which form a Galois connection. The `IsDistributive` CCPs — those that
-process elements independently — are exactly the image of `lift`;
-non-distributive operations (`CCP.negTest`, `CCP.might`, `CCP.must`) test
-the *whole* input state rather than filtering per-element.
+which form a round-trip pair: `lower ∘ lift = id` everywhere
+(`lower_lift`), and `lift ∘ lower = id` exactly on the distributive CCPs
+(`lift_lower`). The `IsDistributive` CCPs — those that process elements
+independently — are exactly the image of `lift`; non-distributive
+operations (`CCP.negTest`, `CCP.might`, `CCP.must`) test the *whole*
+input state rather than filtering per-element.
 -/
 
 namespace Semantics.Dynamic.Core
@@ -91,6 +93,12 @@ def neg (φ : CCP P) : CCP P :=
   λ s => s \ φ s
 
 open Classical in
+/-- Whole-state test: pass the state through iff it satisfies `C` — the
+shared shape of `negTest`, `might`, `must`, and `impl`, the
+non-distributive tests that inspect the entire input state. -/
+noncomputable def guard (C : InfoStateOf P → Prop) : CCP P :=
+  λ s => if C s then s else ∅
+
 /--
 Test-based negation: passes (returns input) iff φ yields ∅.
 
@@ -100,16 +108,15 @@ coincide only when `φ s = ∅` or `φ s = s` — see
 `Studies/Beaver2001/ABLE.lean` for the proven divergence.
 -/
 noncomputable def negTest (φ : CCP P) : CCP P :=
-  λ s => if (φ s).Nonempty then ∅ else s
+  guard (λ s => ¬ (φ s).Nonempty)
 
-open Classical in
 /--
 Compatibility test ("might"): passes iff φ yields a nonempty result.
 
 might(φ)(s) = s if φ(s) ≠ ∅, else ∅
 -/
 noncomputable def might (φ : CCP P) : CCP P :=
-  λ s => if (φ s).Nonempty then s else ∅
+  guard (λ s => (φ s).Nonempty)
 
 open Classical in
 /--
@@ -118,7 +125,7 @@ Full support test ("must"): passes iff φ returns input unchanged.
 must(φ)(s) = s if φ(s) = s, else ∅
 -/
 noncomputable def must (φ : CCP P) : CCP P :=
-  λ s => if φ s = s then s else ∅
+  guard (λ s => φ s = s)
 
 open Classical in
 /--
@@ -127,7 +134,7 @@ Dynamic implication test: passes iff output of φ is preserved by ψ.
 impl(φ,ψ)(s) = s if φ(s) ⊆ ψ(φ(s)), else ∅
 -/
 noncomputable def impl (φ ψ : CCP P) : CCP P :=
-  λ s => if φ s ⊆ ψ (φ s) then s else ∅
+  guard (λ s => φ s ⊆ ψ (φ s))
 
 /--
 Dynamic disjunction via De Morgan: φ ∨ ψ = ¬(¬φ ; ¬ψ).
@@ -231,20 +238,20 @@ theorem test_eliminative {P : Type*} (u : CCP P) (h : IsTest u) :
   | inr hemp => rw [hemp] at hp; exact False.elim hp
 
 open Classical in
-theorem CCP.negTest_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.negTest φ) := by
-  intro s; simp only [CCP.negTest]; split <;> simp
+theorem CCP.guard_isTest {P : Type*} (C : Set P → Prop) : IsTest (CCP.guard C) := by
+  intro s; simp only [CCP.guard]; split <;> simp
 
-open Classical in
-theorem CCP.might_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.might φ) := by
-  intro s; simp only [CCP.might]; split <;> simp
+theorem CCP.negTest_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.negTest φ) :=
+  CCP.guard_isTest _
 
-open Classical in
-theorem CCP.must_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.must φ) := by
-  intro s; unfold CCP.must; split <;> simp
+theorem CCP.might_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.might φ) :=
+  CCP.guard_isTest _
 
-open Classical in
-theorem CCP.impl_isTest {P : Type*} (φ ψ : CCP P) : IsTest (CCP.impl φ ψ) := by
-  intro s; unfold CCP.impl; split <;> simp
+theorem CCP.must_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.must φ) :=
+  CCP.guard_isTest _
+
+theorem CCP.impl_isTest {P : Type*} (φ ψ : CCP P) : IsTest (CCP.impl φ ψ) :=
+  CCP.guard_isTest _
 
 open Classical in
 /-- Duality for the test pair: might φ = must-not (must-not φ). The
@@ -253,14 +260,12 @@ on eliminative updates). -/
 theorem CCP.might_eq_negTest_negTest {P : Type*} (φ : CCP P) :
     CCP.might φ = CCP.negTest (CCP.negTest φ) := by
   funext s
-  simp only [CCP.might, CCP.negTest]
-  split
-  · rw [if_neg Set.not_nonempty_empty]
-  · rename_i h
-    by_cases hs : s.Nonempty
-    · rw [if_pos hs]
-    · simp only [Set.not_nonempty_iff_eq_empty] at hs
-      rw [hs, if_neg Set.not_nonempty_empty]
+  by_cases h : (φ s).Nonempty
+  · simp [CCP.might, CCP.negTest, CCP.guard, h]
+  · by_cases hs : s.Nonempty
+    · simp [CCP.might, CCP.negTest, CCP.guard, h, hs]
+    · simp [CCP.might, CCP.negTest, CCP.guard, h, hs,
+        Set.not_nonempty_iff_eq_empty.mp hs]
 
 
 section GaloisContent
@@ -620,12 +625,12 @@ theorem might_not_isDistributive :
     show true ∈ s
     exact Or.inl rfl
   have hmem : false ∈ CCP.might φ s := by
-    simp only [CCP.might, hφ_nonempty, ↓reduceIte]
+    simp only [CCP.might, CCP.guard, hφ_nonempty, ↓reduceIte]
     show false ∈ s
     exact Or.inr rfl
   rw [hD s] at hmem
   obtain ⟨i, hi, hmem_i⟩ := hmem
-  simp only [CCP.might] at hmem_i
+  simp only [CCP.might, CCP.guard] at hmem_i
   split at hmem_i
   · next hne =>
     cases hi with
@@ -679,7 +684,7 @@ def lower (φ : CCP S) : Update S :=
 `lift (R₁ ⨟ R₂) = lift R₁ ;; lift R₂`. -/
 theorem lift_dseq (R₁ R₂ : Update S) :
     lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) := by
-  funext σ; ext k; simp only [lift, CCP.seq, dseq, Set.mem_setOf_eq]
+  funext σ; ext k; simp only [lift, CCP.seq, dseq, Relation.Comp, Set.mem_setOf_eq]
   constructor
   · rintro ⟨i, hi, j, hR₁, hR₂⟩
     exact ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩

--- a/Linglib/Semantics/Dynamic/Connectives/Defs.lean
+++ b/Linglib/Semantics/Dynamic/Connectives/Defs.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Logic.Relation
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.Use
@@ -130,12 +131,12 @@ theorem eq_of_test {C : Condition S} {i j : S} (h : test C i j) : i = j :=
 
 /-- Dynamic conjunction (sequencing): `D₁ ; D₂`.
 
-Relational composition: there exists an intermediate state `h`
-witnessing both transitions. This is [heim-1982]'s successive
-file change, [kamp-reyle-1993]'s Update sequencing, and
-[groenendijk-stokhof-1991]'s DPL conjunction. -/
+Mathlib's relational composition `Relation.Comp` at endorelations: there
+exists an intermediate state witnessing both transitions. This is
+[heim-1982]'s successive file change, [kamp-reyle-1993]'s Update
+sequencing, and [groenendijk-stokhof-1991]'s DPL conjunction. -/
 def dseq (D₁ D₂ : Update S) : Update S :=
-  λ i j => ∃ h, D₁ i h ∧ D₂ h j
+  Relation.Comp D₁ D₂
 
 infixl:65 " ⨟ " => dseq
 
@@ -172,16 +173,13 @@ section Truth
 
 variable {S : Type*}
 
-/-- A Update `D` is true relative to input `i` iff some output `j` satisfies `D`. -/
-def trueAt (D : Update S) (i : S) : Prop := ∃ j, D i j
-
-/-- A Update `D` is valid iff true at all inputs. -/
-def valid (D : Update S) : Prop := ∀ i, trueAt D i
+/-- An `Update` is valid iff satisfiable (`closure`) at every input. -/
+def valid (D : Update S) : Prop := ∀ i, closure D i
 
 /-- Dynamic entailment: `D₁ ⊨ D₂` iff every output of `D₁` can be
 extended by `D₂`. -/
 def entails (D₁ D₂ : Update S) : Prop :=
-  ∀ i, (∃ j, D₁ i j) → ∀ j, D₁ i j → ∃ k, D₂ j k
+  ∀ i j, D₁ i j → closure D₂ j
 
 scoped notation D₁ " ⊨ " D₂ => entails D₁ D₂
 
@@ -193,22 +191,16 @@ section Theorems
 
 variable {S : Type*}
 
-/-- Sequencing is associative. -/
+/-- Sequencing is associative: mathlib's `Relation.comp_assoc`. -/
 theorem dseq_assoc (D₁ D₂ D₃ : Update S) :
-    (D₁ ⨟ D₂) ⨟ D₃ = D₁ ⨟ (D₂ ⨟ D₃) := by
-  funext i j
-  simp only [dseq, eq_iff_iff]
-  constructor
-  · intro ⟨h, ⟨h', hD₁, hD₂⟩, hD₃⟩
-    exact ⟨h', hD₁, h, hD₂, hD₃⟩
-  · intro ⟨h', hD₁, h, hD₂, hD₃⟩
-    exact ⟨h, ⟨h', hD₁, hD₂⟩, hD₃⟩
+    (D₁ ⨟ D₂) ⨟ D₃ = D₁ ⨟ (D₂ ⨟ D₃) :=
+  Relation.comp_assoc
 
 /-- Test is left identity for sequencing (when condition holds everywhere). -/
 theorem test_dseq (C : Condition S) (D : Update S) (hC : ∀ i, C i) :
     test C ⨟ D = D := by
   funext i j
-  simp only [dseq, test, eq_iff_iff]
+  simp only [dseq, Relation.Comp, test, eq_iff_iff]
   constructor
   · intro ⟨h, ⟨hih, _⟩, hD⟩
     subst hih
@@ -222,7 +214,7 @@ a monoid. -/
 theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
     D ⨟ test C = D := by
   funext i j
-  simp only [dseq, test, eq_iff_iff]
+  simp only [dseq, Relation.Comp, test, eq_iff_iff]
   constructor
   · intro ⟨h, hD, hhj, _⟩
     subst hhj
@@ -279,7 +271,7 @@ theorem closure_closure (D : Update S) :
 theorem dseq_closure (D₁ D₂ : Update S) :
     closure (D₁ ⨟ D₂) = λ i => ∃ h, D₁ i h ∧ closure D₂ h := by
   funext i
-  simp only [closure, dseq, eq_iff_iff]
+  simp only [closure, dseq, Relation.Comp, eq_iff_iff]
   constructor
   · intro ⟨j, h, hD₁, hD₂⟩
     exact ⟨h, hD₁, j, hD₂⟩

--- a/Linglib/Semantics/Dynamic/Core/DynamicTy2.lean
+++ b/Linglib/Semantics/Dynamic/Core/DynamicTy2.lean
@@ -40,7 +40,7 @@ namespace Semantics.Dynamic.Core
 -- Semantics.Dynamic.Core continues to see Update, Condition, dseq, test, etc.
 export DynProp (Update Condition
   dseq test dneg dimpl ddisj closure
-  trueAt valid entails
+  valid entails
   dseq_assoc test_dseq dseq_test dneg_dneg_test closure_closure dseq_closure)
 
 /-!

--- a/Linglib/Semantics/Dynamic/DPL/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DPL/Basic.lean
@@ -379,7 +379,7 @@ theorem atom_eq_test {E : Type*} (p : Assignment E → Prop) :
 theorem conj_eq_dseq {E : Type*} (φ ψ : DPLRel E) :
     toDRS (DPLRel.conj φ ψ) = dseq (toDRS φ) (toDRS ψ) := by
   ext g h
-  simp only [toDRS, DPLRel.conj, dseq]
+  simp only [toDRS, DPLRel.conj, dseq, Relation.Comp]
 
 theorem neg_eq_test_dneg {E : Type*} (φ : DPLRel E) :
     toDRS (DPLRel.neg φ) = test (dneg (toDRS φ)) := by

--- a/Linglib/Semantics/Dynamic/Intensional.lean
+++ b/Linglib/Semantics/Dynamic/Intensional.lean
@@ -556,7 +556,7 @@ theorem toDynProp_eq_lift_fiberDRS (D : ICDRTUpdate W E) :
 theorem fiberDRS_seq (D₁ D₂ : ICDRTUpdate W E) :
     fiberDRS (ICDRTUpdate.seq D₁ D₂) = dseq (fiberDRS D₁) (fiberDRS D₂) := by
   funext p q; cases p; cases q
-  simp only [fiberDRS, ICDRTUpdate.seq, dseq, eq_iff_iff]
+  simp only [fiberDRS, ICDRTUpdate.seq, dseq, Relation.Comp, eq_iff_iff]
   constructor
   · rintro ⟨rfl, k, h1, h2⟩
     exact ⟨⟨k, _⟩, ⟨rfl, h1⟩, ⟨rfl, h2⟩⟩

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
@@ -87,7 +87,7 @@ Might is a TEST: it doesn't change the state (if it passes).
 theorem might_is_test {W : Type*} (φ : Update W) (s : State W)
     (h : (φ s).Nonempty) :
     Update.might φ s = s := by
-  simp [Update.might, Core.CCP.might, h]
+  simp [Update.might, Core.CCP.might, Core.CCP.guard, h]
 
 /--
 Order matters for epistemic might.
@@ -106,13 +106,15 @@ theorem might_order_matters {W : Type*} [DecidableEq W] [Nontrivial W] :
   obtain ⟨w₁, w₂, hne⟩ := exists_pair_ne W
   refine ⟨fun w => w = w₁, inferInstance, {w₁, w₂}, ?_, ?_⟩
   · -- "p and might(not p)" fails: after learning p, only w₁ remains, and ¬p w₁ is false
-    simp only [Update.conj, Core.CCP.seq, Update.prop, Update.might, Core.CCP.might]
+    simp only [Update.conj, Core.CCP.seq, Update.prop, Update.might, Core.CCP.might,
+      Core.CCP.guard]
     have h_not_nonempty :
         ¬({w ∈ {w ∈ ({w₁, w₂} : Set W) | w = w₁} | ¬w = w₁}).Nonempty := by
       rintro ⟨w, ⟨_, hw_p⟩, hw_np⟩; exact hw_np hw_p
     simp only [h_not_nonempty, ↓reduceIte]
   · -- "might(not p) and p" succeeds: might test passes on {w₁, w₂}, then p keeps w₁
-    simp only [Update.conj, Core.CCP.seq, Update.prop, Update.might, Core.CCP.might]
+    simp only [Update.conj, Core.CCP.seq, Update.prop, Update.might, Core.CCP.might,
+      Core.CCP.guard]
     have h_nonempty : ({w ∈ ({w₁, w₂} : Set W) | ¬w = w₁}).Nonempty :=
       ⟨w₂, Or.inr rfl, hne.symm⟩
     simp only [h_nonempty, ↓reduceIte]

--- a/Linglib/Studies/Beaver2001/ABLE.lean
+++ b/Linglib/Studies/Beaver2001/ABLE.lean
@@ -262,10 +262,10 @@ theorem not_neq_ccpNegTest :
     refine Set.mem_diff_of_mem (Or.inr rfl) ?_
     intro ⟨_, hf⟩; exact Bool.noConfusion hf
   rw [h] at this
-  simp only [eval, CCP.negTest] at this
+  simp only [eval, CCP.negTest, CCP.guard] at this
   have hne : ({ p : Bool | p ∈ ({true, false} : Set Bool) ∧ p = true}).Nonempty :=
     ⟨true, Or.inl rfl, rfl⟩
-  simp only [hne, ↓reduceIte] at this
+  simp only [hne, not_true, ↓reduceIte] at this
   exact this
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -358,7 +358,7 @@ def reify (p : PostSupp S (Update S)) : Update S := dseq p.val p.postsup
 /-- Truth of a bi-dimensional meaning at an assignment (eq. 56): the reified
 update is true at `i` in the substrate sense. -/
 def trueAt (p : PostSupp S (Update S)) (i : S) : Prop :=
-  Semantics.Dynamic.Core.trueAt p.reify i
+  Semantics.Dynamic.Core.closure p.reify i
 
 end PostSupp
 

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -179,7 +179,7 @@ to the same classical truth conditions.
 -/
 
 open Semantics.Dynamic.CDRT (DProp State SProp)
-open Semantics.Dynamic.Core (trueAt dseq test dneg dimpl)
+open Semantics.Dynamic.Core.DynProp (closure dseq test dneg dimpl)
 open Semantics.TypeTheoretic (Ppty PPpty Parametric IsTrue IsFalse propT)
 open Cooper2023Ch7 (purify purifyUniv)
 
@@ -198,7 +198,7 @@ def ttr_exists (P : E → Prop) : Type := (x : E) × propT (P x)
 the same truth conditions. Both reduce to `∃ x, P x`. -/
 theorem exists_equiv (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (cdrt_exists n P) i ↔ Nonempty (ttr_exists P) := by
-  simp only [DProp.true_at, trueAt, cdrt_exists, DProp.seq, dseq, DProp.new,
+  simp only [DProp.true_at, Semantics.Dynamic.Core.DynProp.closure, cdrt_exists, DProp.seq, dseq, Relation.Comp, DProp.new,
     DProp.ofStatic, test, ttr_exists]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, rfl, hp⟩
@@ -228,7 +228,7 @@ def ttr_donkey (P Q : E → Prop) : Type :=
 the same truth conditions. Both reduce to `∀ x, P x → Q x`. -/
 theorem donkey_equiv (n : Nat) (P Q : E → Prop) (i : State E) :
     DProp.true_at (cdrt_donkey n P Q) i ↔ Nonempty (ttr_donkey P Q) := by
-  simp only [DProp.true_at, trueAt, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq,
+  simp only [DProp.true_at, Semantics.Dynamic.Core.DynProp.closure, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq, Relation.Comp,
     DProp.new, DProp.ofStatic, test, ttr_donkey]
   constructor
   · rintro ⟨o, rfl, hall⟩
@@ -269,7 +269,7 @@ private theorem donkey_antecedent_iff
      DProp.new 1 ;; DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1))) i k ↔
     ∃ x y, k = (λ m => if m = 1 then y else if m = 0 then x else i m) ∧
       farmer x ∧ donkey_ y ∧ owns x y := by
-  simp only [DProp.seq, dseq, DProp.new, DProp.ofStatic, test]
+  simp only [DProp.seq, dseq, Relation.Comp, DProp.new, DProp.ofStatic, test]
   constructor
   · rintro ⟨k₃, ⟨k₂, ⟨k₁, ⟨e₀, rfl⟩, rfl, hf⟩, ⟨e₁, rfl⟩⟩, rfl, hd, ho⟩
     exact ⟨e₀, e₁, rfl, by simpa, by simpa, by simpa⟩
@@ -361,7 +361,7 @@ the *input* register (no binding). -/
 theorem dne_same_truth (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (DProp.neg (DProp.neg (cdrt_exists n P))) i ↔
     DProp.true_at (cdrt_exists n P) i := by
-  simp only [DProp.true_at, trueAt, DProp.neg, test, dneg]
+  simp only [DProp.true_at, Semantics.Dynamic.Core.DynProp.closure, DProp.neg, test, dneg]
   constructor
   · rintro ⟨_, rfl, h⟩
     exact Classical.byContradiction (λ hno => h ⟨i, rfl, hno⟩)

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -83,7 +83,7 @@ def existsAt (n : Nat) (φ : Update (Assignment E)) : Update (Assignment E) :=
 /-- Direct unfolding: `existsAt n φ g h ↔ ∃ d : E, φ (Function.update g n d) h`. -/
 theorem existsAt_iff (n : Nat) (φ : Update (Assignment E)) (g h : Assignment E) :
     existsAt n φ g h ↔ ∃ d : E, φ (Function.update g n d) h := by
-  simp only [existsAt, dseq, randomAssignAt]
+  simp only [existsAt, dseq, Relation.Comp, randomAssignAt]
   constructor
   · rintro ⟨k, ⟨d, rfl⟩, hφ⟩; exact ⟨d, hφ⟩
   · rintro ⟨d, hφ⟩; exact ⟨Function.update g n d, ⟨d, rfl⟩, hφ⟩
@@ -97,7 +97,7 @@ def forallAt (n : Nat) (φ : Update (Assignment E)) : Update (Assignment E) :=
 /-- Direct truth condition: `forallAt n φ g h ↔ g = h ∧ ∀ d, ∃ k, φ (Function.update g n d) k`. -/
 theorem forallAt_iff (n : Nat) (φ : Update (Assignment E)) (g h : Assignment E) :
     forallAt n φ g h ↔ g = h ∧ ∀ d : E, ∃ k, φ (Function.update g n d) k := by
-  simp only [forallAt, test, dneg, existsAt, dseq, randomAssignAt]
+  simp only [forallAt, test, dneg, existsAt, dseq, Relation.Comp, randomAssignAt]
   constructor
   · rintro ⟨rfl, hneg⟩
     refine ⟨rfl, fun d => ?_⟩

--- a/Linglib/Studies/Muskens1996.lean
+++ b/Linglib/Studies/Muskens1996.lean
@@ -181,7 +181,7 @@ theorem wp_test (C : Condition S) (χ : Condition S) :
 theorem wp_seq (D₁ D₂ : Update S) (χ : Condition S) :
     wp (dseq D₁ D₂) χ = wp D₁ (wp D₂ χ) := by
   ext i
-  simp only [wp, dseq]
+  simp only [wp, dseq, Relation.Comp]
   constructor
   · rintro ⟨j, ⟨h, hD₁, hD₂⟩, hχ⟩
     exact ⟨h, hD₁, j, hD₂, hχ⟩


### PR DESCRIPTION
Wave 3 of the Dynamic-API audit: reconcile the spine with mathlib.

- `dseq := Relation.Comp` and `dseq_assoc := Relation.comp_assoc`; consumer simp lists extended.
- `trueAt` deleted (η-equal to `closure`); `valid`/`entails` restated over `closure`, dropping `entails`' vacuous satisfiability guard.
- `CCP.guard` extracted as the shared shape of `negTest`/`might`/`must`/`impl`; four `_isTest` proofs collapse to `guard_isTest`.
- The CCP module doc's "Galois connection" overclaim reworded to the round-trip pair actually proven (`lower_lift`/`lift_lower`).