### PR TITLE
refactor(Semantics/Dynamic): Bool→Prop on the InfoState concrete layer

### DIFF
--- a/Linglib/Semantics/Dynamic/Connectives/CCP.lean
+++ b/Linglib/Semantics/Dynamic/Connectives/CCP.lean
@@ -565,17 +565,17 @@ theorem subset_subsistsIn {s s' : InfoState W E} (h : s ⊆ s') : s ⪯ s' := by
   intro p hp
   exact ⟨p, h hp, rfl, λ _ _ => rfl⟩
 
-/-- State s supports proposition φ iff φ holds at all worlds in s. -/
-def supports (s : InfoState W E) (φ : W → Bool) : Prop :=
-  ∀ p ∈ s, φ p.world
+/-- State s supports proposition φ iff φ holds at all worlds in s:
+`supportOf` at the world-evaluation satisfaction relation. -/
+def supports (s : InfoState W E) (φ : W → Prop) : Prop :=
+  supportOf (λ p ψ => ψ p.world) s φ
 
 scoped notation:50 s " ⊫ " φ => InfoState.supports s φ
 
 /-- Support is preserved by subset. -/
 theorem supports_mono {s s' : InfoState W E} (h : s ⊆ s')
-    (φ : W → Bool) (hsupp : s' ⊫ φ) : s ⊫ φ := by
-  intro p hp
-  exact hsupp p (h hp)
+    (φ : W → Prop) (hsupp : s' ⊫ φ) : s ⊫ φ :=
+  support_mono _ s' s φ h hsupp
 
 end InfoState
 

--- a/Linglib/Semantics/Dynamic/Core/Update.lean
+++ b/Linglib/Semantics/Dynamic/Core/Update.lean
@@ -16,7 +16,7 @@ open InfoState
 
 
 /-- Update state with proposition: keep only possibilities where φ holds. -/
-def InfoState.update {W E : Type*} (s : InfoState W E) (φ : W → Bool) : InfoState W E :=
+def InfoState.update {W E : Type*} (s : InfoState W E) (φ : W → Prop) : InfoState W E :=
   { p ∈ s | φ p.world }
 
 notation:max s "⟦" φ "⟧" => InfoState.update s φ
@@ -26,16 +26,16 @@ namespace InfoState
 variable {W E : Type*}
 
 /-- Propositional update is monotone in the state argument. -/
-theorem update_monotone (φ : W → Bool) : Monotone (· ⟦φ⟧ : InfoState W E → InfoState W E) :=
+theorem update_monotone (φ : W → Prop) : Monotone (· ⟦φ⟧ : InfoState W E → InfoState W E) :=
   sep_monotone _
 
 /-- Update is monotonic: larger states give larger results -/
-theorem update_mono {s s' : InfoState W E} (h : s ⊆ s') (φ : W → Bool) :
+theorem update_mono {s s' : InfoState W E} (h : s ⊆ s') (φ : W → Prop) :
     s⟦φ⟧ ⊆ s'⟦φ⟧ :=
   update_monotone φ h
 
 /-- Update is idempotent -/
-theorem update_update (s : InfoState W E) (φ : W → Bool) :
+theorem update_update (s : InfoState W E) (φ : W → Prop) :
     s⟦φ⟧⟦φ⟧ = s⟦φ⟧ := by
   ext p
   simp only [update, Set.mem_setOf_eq]
@@ -44,40 +44,39 @@ theorem update_update (s : InfoState W E) (φ : W → Bool) :
   · intro ⟨hs, hφ⟩; exact ⟨⟨hs, hφ⟩, hφ⟩
 
 /-- Sequential update = conjunction -/
-theorem update_seq (s : InfoState W E) (φ ψ : W → Bool) :
-    s⟦φ⟧⟦ψ⟧ = s⟦λ w => φ w && ψ w⟧ := by
+theorem update_seq (s : InfoState W E) (φ ψ : W → Prop) :
+    s⟦φ⟧⟦ψ⟧ = s⟦λ w => φ w ∧ ψ w⟧ := by
   ext p
-  simp only [update, Set.mem_setOf_eq, Bool.and_eq_true]
+  simp only [update, Set.mem_setOf_eq]
   constructor
   · intro ⟨⟨hs, hφ⟩, hψ⟩; exact ⟨hs, hφ, hψ⟩
   · intro ⟨hs, hφ, hψ⟩; exact ⟨⟨hs, hφ⟩, hψ⟩
 
 /-- Update preserves definedness -/
-theorem update_preserves_defined (s : InfoState W E) (φ : W → Bool) (x : Nat)
+theorem update_preserves_defined (s : InfoState W E) (φ : W → Prop) (x : Nat)
     (h : s.definedAt x) : s⟦φ⟧.definedAt x := by
   intro p q hp hq
   exact h p q hp.1 hq.1
 
 /-- s[φ] ⊫ φ -/
-theorem update_supports (s : InfoState W E) (φ : W → Bool) : s⟦φ⟧ ⊫ φ := by
+theorem update_supports (s : InfoState W E) (φ : W → Prop) : s⟦φ⟧ ⊫ φ := by
   intro p ⟨_, hφ⟩
   exact hφ
 
 /-- Dynamic entailment for propositions. -/
-def dynamicEntails (φ ψ : W → Bool) : Prop :=
+def dynamicEntails (φ ψ : W → Prop) : Prop :=
   ∀ s : InfoState W E, (s⟦φ⟧).consistent → s⟦φ⟧ ⊫ ψ
 
 /-- Any proposition dynamically entails itself -/
-theorem dynamicEntails_refl (φ : W → Bool) : dynamicEntails (W := W) (E := E) φ φ := by
+theorem dynamicEntails_refl (φ : W → Prop) : dynamicEntails (W := W) (E := E) φ φ := by
   intro s _
   exact update_supports s φ
 
 /-- φ dynamically entails φ ∧ ψ when φ entails ψ -/
-theorem dynamicEntails_conj (φ ψ : W → Bool)
+theorem dynamicEntails_conj (φ ψ : W → Prop)
     (h : dynamicEntails (W := W) (E := E) φ ψ) :
-    dynamicEntails (W := W) (E := E) φ (λ w => φ w && ψ w) := by
+    dynamicEntails (W := W) (E := E) φ (λ w => φ w ∧ ψ w) := by
   intro s hcons p hp
-  simp only [Bool.and_eq_true]
   constructor
   · exact update_supports s φ p hp
   · exact h s hcons p hp
@@ -137,19 +136,19 @@ def CCP.existsFull {W E : Type*} (x : Nat)
 /--
 Lift a classical proposition to a CCP.
 -/
-def CCP.ofProp {W E : Type*} (φ : W → Bool) : CCP (Possibility W E) :=
+def CCP.ofProp {W E : Type*} (φ : W → Prop) : CCP (Possibility W E) :=
   λ (s : InfoState W E) => s⟦φ⟧
 
 /--
 Lift a predicate on entities (via variable lookup).
 -/
-def CCP.ofPred1 {W E : Type*} (p : E → W → Bool) (x : Nat) : CCP (Possibility W E) :=
+def CCP.ofPred1 {W E : Type*} (p : E → W → Prop) (x : Nat) : CCP (Possibility W E) :=
   λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) poss.world }
 
 /--
 Lift a binary predicate.
 -/
-def CCP.ofPred2 {W E : Type*} (p : E → E → W → Bool) (x y : Nat) : CCP (Possibility W E) :=
+def CCP.ofPred2 {W E : Type*} (p : E → E → W → Prop) (x y : Nat) : CCP (Possibility W E) :=
   λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) (poss.assignment y) poss.world }
 
 

--- a/Linglib/Semantics/Dynamic/Effects/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/Effects/Bilateral.lean
@@ -83,49 +83,48 @@ For an atomic proposition p:
 - s[p]⁺ = { w ∈ s | p(w) } (keep worlds where p holds)
 - s[p]⁻ = { w ∈ s | ¬p(w) } (keep worlds where p fails)
 -/
-def atom (pred : W → Bool) : BilateralDen W E :=
+def atom (pred : W → Prop) : BilateralDen W E :=
   { positive := λ s => s.update pred
-  , negative := λ s => s.update (λ w => !pred w) }
+  , negative := λ s => s.update (λ w => ¬ pred w) }
 
 /-- Atomic positive and negative are complementary -/
-theorem atom_complementary (pred : W → Bool) (s : InfoState W E) :
+theorem atom_complementary (pred : W → Prop) (s : InfoState W E) :
     (atom pred).positive s ∪ (atom pred).negative s = s := by
   ext p
   simp only [atom, InfoState.update, Set.mem_union, Set.mem_setOf_eq]
   constructor
   · rintro (⟨h, _⟩ | ⟨h, _⟩) <;> exact h
   · intro h
-    cases hp : pred p.world
-    · right; exact ⟨h, by simp [hp]⟩
-    · left; exact ⟨h, by simp [hp]⟩
+    by_cases hp : pred p.world
+    · left; exact ⟨h, hp⟩
+    · right; exact ⟨h, hp⟩
 
 /-- Atomic positive and negative are disjoint -/
-theorem atom_disjoint (pred : W → Bool) (s : InfoState W E) :
+theorem atom_disjoint (pred : W → Prop) (s : InfoState W E) :
     (atom pred).positive s ∩ (atom pred).negative s = ∅ := by
   ext p
   constructor
   · intro ⟨⟨_, hp⟩, ⟨_, hnp⟩⟩
-    simp only [atom, InfoState.update, Set.mem_setOf_eq, Bool.not_eq_true] at hp hnp
-    simp_all
+    exact absurd hp hnp
   · intro h; exact h.elim
 
 /-- Atomic positive update is monotone. -/
-theorem atom_positive_monotone (pred : W → Bool) :
+theorem atom_positive_monotone (pred : W → Prop) :
     Monotone (atom pred).positive (α := InfoState W E) :=
   sep_monotone _
 
 /-- Atomic negative update is monotone. -/
-theorem atom_negative_monotone (pred : W → Bool) :
+theorem atom_negative_monotone (pred : W → Prop) :
     Monotone (atom pred).negative (α := InfoState W E) :=
   sep_monotone _
 
 /-- Atomic positive update is eliminative. -/
-theorem atom_positive_eliminative (pred : W → Bool) :
+theorem atom_positive_eliminative (pred : W → Prop) :
     IsEliminative (atom pred).positive (P := Possibility W E) :=
   sep_eliminative _
 
 /-- Atomic negative update is eliminative. -/
-theorem atom_negative_eliminative (pred : W → Bool) :
+theorem atom_negative_eliminative (pred : W → Prop) :
     IsEliminative (atom pred).negative (P := Possibility W E) :=
   sep_eliminative _
 
@@ -184,13 +183,15 @@ theorem unknownUpdate_neg (φ : BilateralDen W E) (s : InfoState W E) :
   simp only [unknownUpdate, neg, Set.mem_setOf_eq, and_comm (a := p ∉ φ.negative s)]
 
 /-- For atomic propositions, the unknown update is empty. -/
-theorem unknownUpdate_atom (pred : W → Bool) (s : InfoState W E) :
+theorem unknownUpdate_atom (pred : W → Prop) (s : InfoState W E) :
     unknownUpdate (atom pred) s = ∅ := by
   ext p
   simp only [unknownUpdate, atom, InfoState.update, Set.mem_setOf_eq,
-    Set.mem_empty_iff_false, iff_false, not_and, Bool.not_eq_true]
-  intro hp
-  cases pred p.world <;> simp_all
+    Set.mem_empty_iff_false, iff_false, not_and]
+  intro hp hpos hneg
+  by_cases h : pred p.world
+  · exact hpos hp h
+  · exact hneg hp h
 
 /--
 Assertability condition: φ is assertable at context c iff the unknown


### PR DESCRIPTION
Wave 3b of the Dynamic-API audit: the `Possibility W E` concrete layer joins the Prop-based generic layer above it.

- `InfoState.update`/`supports`/`dynamicEntails`/`CCP.ofProp`/`ofPred1`/`ofPred2` now take `W → Prop` (`∧` for `&&`); `BilateralDen.atom` likewise, with classical case splits replacing Bool case analysis.
- `InfoState.supports` deduped onto the generic `supportOf` (world-evaluation satisfaction), `supports_mono := support_mono`.