### PR TITLE
feat(Semantics/ArgumentStructure): Grimm depth + namespace flattening

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -25,7 +25,7 @@ open Semantics.Lexical
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Core.Order (Boundedness)
 open Semantics.Aspect.Incremental (VerbIncClass)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Features.LevinClassProfiles
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Fragments/Romance/French/Predicates.lean
+++ b/Linglib/Fragments/Romance/French/Predicates.lean
@@ -18,9 +18,7 @@ namespace French.Predicates
 
 open Semantics.Lexical
 open Features (Causative)
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
-  (accomplishmentSubjectProfile activitySubjectProfile)
+open ArgumentStructure
 open Features.LevinClassProfiles (experiencerProfile)
 
 /-- French verb entry: extends Verb with French inflectional paradigm. -/

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -30,7 +30,7 @@ namespace Spanish.Predicates
 
 open Minimalist
 open Semantics.Lexical
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 
 -- ============================================================================
 -- § 1: Anticausative Marking

--- a/Linglib/Morphology/RootTypology.lean
+++ b/Linglib/Morphology/RootTypology.lean
@@ -66,8 +66,7 @@ you nothing about whether it entails change, and vice versa.
 -/
 
 open Semantics.Lexical.EventStructure
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Features.ChangeOfState
 open Features
 

--- a/Linglib/Semantics/ArgumentStructure/Agentivity/CaseRegions.lean
+++ b/Linglib/Semantics/ArgumentStructure/Agentivity/CaseRegions.lean
@@ -8,10 +8,11 @@ import Linglib.Features.Case.Basic
 **connected region** of the agentivity lattice, spreading outwards from the
 maximal agent and maximal patient nodes (Figs. 6–7). This file assigns each
 `GrimmNode` its case region (`GrimmNode.toCaseRegion`), maps regions to
-morphological cases under accusative and ergative alignment, and proves the
-connectedness claim for the three core regions as order-convexity
-(`IsOrderConvex`). The dative region unifies recipients, experiencers, and
-benefactives (§5.1, Fig. 7).
+morphological cases under accusative and ergative alignment, and sharpens
+the connectedness claim: each core region is an order **interval** anchored
+at its pole (`toCaseRegion_eq_nomErg_iff` etc.), with order-convexity a
+corollary. The dative region unifies recipients, experiencers, and second
+arguments of two-place communication/service verbs (§5.1, Fig. 7).
 -/
 
 namespace ArgumentStructure.AgentivityLattice
@@ -21,8 +22,9 @@ namespace ArgumentStructure.AgentivityLattice
 /-- Case regions on the agentivity lattice. Per Grimm 2011 (abstract,
     §2.3, §4), a core case marker corresponds to a **connected region** of
     the lattice; the three core regions (`nomErg`, `accAbs`, `dative`) are
-    proved order-convex (`IsOrderConvex`) below. `oblique` is the residual
-    "middle region" (Grimm p.533) — not claimed to be connected. -/
+    order intervals anchored at the poles (`toCaseRegion_eq_nomErg_iff`
+    etc.). `oblique` is the residual "middle region" (Grimm p.532–533) —
+    not connected (`oblique_not_orderConvex`). -/
 inductive CaseRegion where
   /-- Nominative (accusative systems) / Ergative (ergative systems):
       the region spreading from maximal agent. Marks subjects. -/
@@ -76,7 +78,42 @@ def CaseRegion.toErgativeCase : CaseRegion → Case
   | .dative  => .dat
   | .oblique => .inst
 
-/-! ### Connectedness of core case regions (Grimm 2011 abstract + §4) -/
+/-! ### Core case regions are order intervals (Grimm 2011 abstract + §4)
+
+The abstract's central claim — a core case marker is a connected region
+"spreading outwards from the maximal agent and maximal patient nodes" — in
+sharpened form: each core region is an order **interval** anchored at its
+pole. NOM/ERG is the up-set of `minimalInstigator` (its top is
+`maximalAgent = ⊤`); ACC/ABS runs from `maximalPatient` up to the
+contact-verb patient; the dative sits above `sentientNonInstigatorNode`.
+Order-convexity ("connectedness") follows by transitivity. -/
+
+/-- The bottom of the NOM/ERG interval: instigation alone, at total
+    persistence — the minimal acceptable agent of *kill* (§2.3: natural
+    forces such as electricity or the explosion). -/
+def minimalInstigator : GrimmNode := ⟨⟨false, false, true, false⟩, ⊤⟩
+
+/-- **NOM/ERG is the up-set of the minimal instigator** — the interval from
+    `minimalInstigator` to `maximalAgent = ⊤`. -/
+theorem GrimmNode.toCaseRegion_eq_nomErg_iff (n : GrimmNode) :
+    n.toCaseRegion = .nomErg ↔ minimalInstigator ≤ n := by
+  revert n; decide
+
+/-- **ACC/ABS is the interval from the maximal patient to the contact-verb
+    patient**: ⊥ agentivity, persistence between `exPersBeginning` and
+    `quPersBeginning`. -/
+theorem GrimmNode.toCaseRegion_eq_accAbs_iff (n : GrimmNode) :
+    n.toCaseRegion = .accAbs ↔
+      maximalPatient ≤ n ∧ n ≤ TransitivityRank.contact.patientNode := by
+  revert n; decide
+
+/-- **The dative is the interval above `sentientNonInstigatorNode`**:
+    sentience without instigation, pinned at `quPersBeginning`. -/
+theorem GrimmNode.toCaseRegion_eq_dative_iff (n : GrimmNode) :
+    n.toCaseRegion = .dative ↔
+      sentientNonInstigatorNode ≤ n ∧
+      n ≤ ⟨⟨true, true, false, true⟩, .quPersBeginning⟩ := by
+  revert n; decide
 
 /-- A predicate on a partial order is **order-convex** if it is closed
     under intervals: whenever `P a` and `P b` and `a ≤ x ≤ b`, also `P x`.
@@ -85,75 +122,26 @@ def CaseRegion.toErgativeCase : CaseRegion → Case
 def IsOrderConvex {α : Type*} [LE α] (P : α → Prop) : Prop :=
   ∀ ⦃a b x : α⦄, P a → P b → a ≤ x → x ≤ b → P x
 
--- Characterisation lemmas (single `decide` over 80 GrimmNode elements each)
-
-private theorem GrimmNode.toCaseRegion_eq_nomErg_iff (n : GrimmNode) :
-    n.toCaseRegion = .nomErg ↔
-    n.agentivity.instigation = true ∧ n.persistence = .totalPersistence := by
-  rcases n with ⟨⟨v, s, i, m⟩, p⟩
-  cases v <;> cases s <;> cases i <;> cases m <;> cases p <;> decide
-
-private theorem GrimmNode.toCaseRegion_eq_accAbs_iff (n : GrimmNode) :
-    n.toCaseRegion = .accAbs ↔
-    n.agentivity = ⊥ ∧
-    (n.persistence = .exPersBeginning ∨ n.persistence = .quPersBeginning) := by
-  rcases n with ⟨⟨v, s, i, m⟩, p⟩
-  cases v <;> cases s <;> cases i <;> cases m <;> cases p <;> decide
-
-private theorem GrimmNode.toCaseRegion_eq_dative_iff (n : GrimmNode) :
-    n.toCaseRegion = .dative ↔
-    n.agentivity.sentience = true ∧ n.agentivity.instigation = false ∧
-    n.persistence = .quPersBeginning := by
-  rcases n with ⟨⟨v, s, i, m⟩, p⟩
-  cases v <;> cases s <;> cases i <;> cases m <;> cases p <;> decide
-
-/-- The `nomErg` region is order-convex: any node between two nomErg nodes
-    is itself nomErg. The region equals `{n | n.agentivity.instigation = true
-    ∧ n.persistence = .totalPersistence}`, the intersection of an upper set
-    (instigation = true) with the singleton at top persistence. -/
+/-- Connectedness of NOM/ERG, from the interval form. -/
 theorem nomErg_orderConvex :
     IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .nomErg) := by
   intro a b x ha hb hax hxb
-  rw [GrimmNode.toCaseRegion_eq_nomErg_iff] at *
-  refine ⟨AgentivityNode.le_instigation_mono hax.1 ha.1, ?_⟩
-  have hpers : (.totalPersistence : PersistenceLevel) ≤ x.persistence := ha.2 ▸ hax.2
-  exact le_antisymm le_top hpers
+  rw [GrimmNode.toCaseRegion_eq_nomErg_iff] at ha ⊢
+  exact ha.trans hax
 
-/-- The `accAbs` region is order-convex. It equals
-    `{n | n.agentivity = ⊥ ∧ n.persistence ∈ {.exPersBeginning, .quPersBeginning}}`
-    — the singleton at bottom agentivity intersected with the persistence
-    interval `[.exPersBeginning, .quPersBeginning]`. -/
+/-- Connectedness of ACC/ABS, from the interval form. -/
 theorem accAbs_orderConvex :
     IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .accAbs) := by
   intro a b x ha hb hax hxb
-  rw [GrimmNode.toCaseRegion_eq_accAbs_iff] at *
-  refine ⟨le_bot_iff.mp (hb.1 ▸ hxb.1), ?_⟩
-  -- x.persistence is in [a.persistence, b.persistence]; both endpoints in {exPB, qPB}.
-  -- Case-split on x.persistence (5 cases) using the bounds to rule out the other 3.
-  have hax_p : a.persistence ≤ x.persistence := hax.2
-  have hxb_p : x.persistence ≤ b.persistence := hxb.2
-  rcases ha.2 with hap | hap <;> rcases hb.2 with hbp | hbp <;>
-    rw [hap] at hax_p <;> rw [hbp] at hxb_p <;>
-    (try exact absurd (hax_p.trans hxb_p) (by decide)) <;>
-    (cases hxp : x.persistence <;> rw [hxp] at hax_p hxb_p <;>
-      first | (left; rfl) | (right; rfl) | exact absurd hax_p (by decide) |
-              exact absurd hxb_p (by decide))
+  rw [GrimmNode.toCaseRegion_eq_accAbs_iff] at ha hb ⊢
+  exact ⟨ha.1.trans hax, hxb.trans hb.2⟩
 
-/-- The `dative` region is order-convex. It equals
-    `{n | n.agentivity.sentience = true ∧ n.agentivity.instigation = false
-    ∧ n.persistence = .quPersBeginning}` — sentience upper set ∩ instigation
-    lower set ∩ persistence singleton. -/
+/-- Connectedness of the dative, from the interval form. -/
 theorem dative_orderConvex :
     IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .dative) := by
   intro a b x ha hb hax hxb
-  rw [GrimmNode.toCaseRegion_eq_dative_iff] at *
-  refine ⟨AgentivityNode.le_sentience_mono hax.1 ha.1,
-          AgentivityNode.ge_instigation_mono hxb.1 hb.2.1, ?_⟩
-  have h1 : x.persistence ≤ b.persistence := hxb.2
-  have h2 : a.persistence ≤ x.persistence := hax.2
-  rw [hb.2.2] at h1
-  rw [ha.2.2] at h2
-  exact le_antisymm h1 h2
+  rw [GrimmNode.toCaseRegion_eq_dative_iff] at ha hb ⊢
+  exact ⟨ha.1.trans hax, hxb.trans hb.2⟩
 
 /-- Counterexample showing `oblique` is NOT order-convex. With
     `a = ⟨{motion}, .quPersBeginning⟩` and `b = ⟨{motion, sentience, instigation},

--- a/Linglib/Semantics/ArgumentStructure/Agentivity/CaseRegions.lean
+++ b/Linglib/Semantics/ArgumentStructure/Agentivity/CaseRegions.lean
@@ -15,7 +15,7 @@ corollary. The dative region unifies recipients, experiencers, and second
 arguments of two-place communication/service verbs (§5.1, Fig. 7).
 -/
 
-namespace ArgumentStructure.AgentivityLattice
+namespace ArgumentStructure
 
 /-! ### Case regions (§4, Figs. 6–7) -/
 
@@ -198,4 +198,4 @@ theorem pursuit_patient_toCaseRegion :
 theorem sentientNonInstigator_in_dative :
     sentientNonInstigatorNode.toCaseRegion = .dative := rfl
 
-end ArgumentStructure.AgentivityLattice
+end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/Agentivity/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Agentivity/Defs.lean
@@ -54,7 +54,7 @@ The bridges to [dowty-1991]'s `EntailmentProfile` live in
 `Agentivity/CaseRegions.lean`.
 -/
 
-namespace ArgumentStructure.AgentivityLattice
+namespace ArgumentStructure
 
 /-! ### Agentivity primitives (Table 2, §2.1) -/
 
@@ -581,4 +581,4 @@ theorem persistence_chain :
     PersistenceLevel.quPersBeginning ≤ PersistenceLevel.totalPersistence := by
   decide
 
-end ArgumentStructure.AgentivityLattice
+end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -52,7 +52,7 @@ open Semantics.Lexical
 open Semantics.Lexical.EventStructure (Template)
 open Features.LevinClassProfiles
 open _root_.ArgumentStructure (EntailmentProfile)
-open _root_.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure
 open Root.Kinds
 
 -- ════════════════════════════════════════════════════
@@ -301,7 +301,7 @@ def deriveEnriched (re : Root.Kinds) (mc : MeaningComponents) : Option ArgTempla
     | .activity =>
       if mc.contact then
         -- Transitive activity: subject gets C from causal interaction
-        some { subjectProfile := ArgumentStructure.EntailmentProfile.accomplishmentSubjectProfile,
+        some { subjectProfile := ArgumentStructure.accomplishmentSubjectProfile,
                objectProfile := some Features.LevinClassProfiles.contactObject }
       else
         some base

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -27,15 +27,15 @@ with Proto-Patient dominance breaking ties.
 - `activitySubjectProfile` … `accomplishmentObjectProfile` — the
   [rappaport-hovav-levin-1998] template-level profile defaults (per-verb
   content lives in the class map, `Semantics/Lexical/LevinClassProfiles.lean`)
-- `AgentivityLattice.AgentivityNode.fromEntailmentProfile`,
-  `AgentivityLattice.PersistenceLevel.fromPatientProfile` — bridges from
+- `AgentivityNode.fromEntailmentProfile`,
+  `PersistenceLevel.fromPatientProfile` — bridges from
   profiles to [grimm-2011]'s agentivity lattice, with the consistency
   theorems relating the two dominance orders
 
 ## Implementation notes
 
 The ten entailments are not independent ([levin-2019] §2.1): volition
-presupposes sentience (`EntailmentProfile.WellFormedInternal`); causation,
+presupposes sentience (`WellFormedInternal`); causation,
 movement, and independent existence pair asymmetrically with Proto-Patient
 entailments (`WellFormedPair`); and the affectedness-related Proto-Patient
 entailments form an implicational hierarchy ([beavers-2010]). Their algebraic
@@ -132,6 +132,10 @@ def pPatientScore : Nat :=
   p.changeOfState.toNat + p.incrementalTheme.toNat +
   p.causallyAffected.toNat + p.stationary.toNat +
   p.dependentExistence.toNat
+
+end EntailmentProfile
+
+variable (p q subj obj : EntailmentProfile)
 
 /-! ### Lattice comparison -/
 
@@ -274,7 +278,7 @@ instance : DecidablePred IsForceRecipient := λ p => by
 /-- An effector carries at least two Proto-Agent entailments. -/
 theorem two_le_pAgentScore_of_isEffector (h : IsEffector p) :
     2 ≤ p.pAgentScore := by
-  simp [pAgentScore, h.1, h.2]
+  simp [EntailmentProfile.pAgentScore, h.1, h.2]
 
 /-! ### Template-level proto-role defaults
 
@@ -318,16 +322,12 @@ objects measure the event. -/
 def accomplishmentObjectProfile : EntailmentProfile :=
   { changeOfState := true, causallyAffected := true }
 
-end EntailmentProfile
-
 /-! ### Bridge to the Grimm agentivity lattice
 
 The Dowty→Grimm feature translation ([grimm-2011] §2.1, Tables 1–2) and the
 consistency theorems relating [dowty-1991]'s dominance orders to the lattice
 order of `Agentivity/Defs.lean`. The bridge lives here, with the profiles it
 translates, so the lattice substrate stays Mathlib-only. -/
-
-namespace AgentivityLattice
 
 /-- Map Dowty's P-Agent entailments to Grimm's agentivity features.
 
@@ -436,7 +436,6 @@ bridge, the lattice's feature count is monotone in the inclusion order
 `PAgentDominates` is precisely lattice order plus an independent-existence
 implication (§2.2). -/
 
-open EntailmentProfile
 
 /-- Feature count is monotone in the inclusion order ([grimm-2011] §2.3):
     ascending the Fig. 1 lattice never loses agentivity features. -/
@@ -485,6 +484,5 @@ theorem outranks_of_lattice_dominance (subj obj : EntailmentProfile)
       absurd ((pAgentDominates_iff obj subj).mp hqp).1
         (lt_iff_le_not_ge.mp hlt).2⟩
 
-end AgentivityLattice
 
 end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -1,3 +1,5 @@
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Tactic.DeriveFintype
 import Linglib.Semantics.ArgumentStructure.Agentivity.Defs
 
 /-!
@@ -73,9 +75,49 @@ structure EntailmentProfile where
   dependentExistence : Bool := false
   deriving DecidableEq, Repr
 
+/-- The ten proto-role entailments as a feature index ([dowty-1991]
+pp.572–573): five Proto-Agent, then five Proto-Patient. -/
+inductive ProtoRoleFeature where
+  | volition | sentience | causation | movement | independentExistence
+  | changeOfState | incrementalTheme | causallyAffected | stationary
+  | dependentExistence
+  deriving DecidableEq, Repr, Fintype
+
 namespace EntailmentProfile
 
 variable (p q subj obj : EntailmentProfile)
+
+/-- A profile as its feature-indicator function: the profile *is* a point
+of the Boolean cube on `ProtoRoleFeature`. -/
+def feature (p : EntailmentProfile) : ProtoRoleFeature → Bool
+  | .volition => p.volition
+  | .sentience => p.sentience
+  | .causation => p.causation
+  | .movement => p.movement
+  | .independentExistence => p.independentExistence
+  | .changeOfState => p.changeOfState
+  | .incrementalTheme => p.incrementalTheme
+  | .causallyAffected => p.causallyAffected
+  | .stationary => p.stationary
+  | .dependentExistence => p.dependentExistence
+
+/-- `EntailmentProfile` is the Boolean cube `ProtoRoleFeature → Bool`; the
+`Fintype` instance (and any order or Boolean-algebra structure a consumer
+needs) transports along this equivalence. -/
+def equivFeatures : EntailmentProfile ≃ (ProtoRoleFeature → Bool) where
+  toFun := feature
+  invFun g :=
+    { volition := g .volition, sentience := g .sentience
+      causation := g .causation, movement := g .movement
+      independentExistence := g .independentExistence
+      changeOfState := g .changeOfState
+      incrementalTheme := g .incrementalTheme
+      causallyAffected := g .causallyAffected, stationary := g .stationary
+      dependentExistence := g .dependentExistence }
+  left_inv p := by cases p; rfl
+  right_inv g := by funext f; cases f <;> rfl
+
+instance : Fintype EntailmentProfile := Fintype.ofEquiv _ equivFeatures.symm
 
 /-! ### Feature counting -/
 
@@ -428,6 +470,20 @@ theorem pAgentDominates_iff (p q : EntailmentProfile) :
     obtain ⟨h1, h2, h3, h4⟩ := grimm_agentivity_consistent_with_dowty q p hle
     exact ⟨fun hq => by simpa [hq] using h1, fun hq => by simpa [hq] using h2,
            fun hq => by simpa [hq] using h3, fun hq => by simpa [hq] using h4, hie⟩
+
+/-- [grimm-2011]'s Argument Selection Principle as lattice dominance: if
+    `subj`'s agentivity node strictly dominates `obj`'s and independent
+    existence is preserved, `subj` is selected — for every profile pair,
+    via `pAgentDominates_iff`, not per-verb checking. -/
+theorem outranks_of_lattice_dominance (subj obj : EntailmentProfile)
+    (hlt : AgentivityNode.fromEntailmentProfile obj <
+      AgentivityNode.fromEntailmentProfile subj)
+    (hIE : obj.independentExistence = true → subj.independentExistence = true) :
+    OutranksForSubject subj obj :=
+  .inl ⟨(pAgentDominates_iff subj obj).mpr ⟨hlt.le, hIE⟩,
+    fun hqp =>
+      absurd ((pAgentDominates_iff obj subj).mp hqp).1
+        (lt_iff_le_not_ge.mp hlt).2⟩
 
 end AgentivityLattice
 

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -62,8 +62,7 @@ Accounts expressible via this interface (non-exhaustive):
 
 -/
 
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 1. Theta Role Labels (derived convenience names)
@@ -237,7 +236,7 @@ theorem patient_maximal_pPatient :
 /-- All canonical profiles satisfy the well-formedness constraint:
     volition entails sentience. -/
 theorem canonical_profiles_wellformed (r : ThetaRole) :
-    (r.canonicalProfile).WellFormedInternal := by
+    WellFormedInternal r.canonicalProfile := by
   cases r <;> decide
 
 -- ════════════════════════════════════════════════════════════════════════

--- a/Linglib/Semantics/Causation/Morphological.lean
+++ b/Linglib/Semantics/Causation/Morphological.lean
@@ -75,7 +75,7 @@ namespace Causation.Morphological
 
 open Verb
 open Causation.Psych (CausalSource)
-open ArgumentStructure.AgentivityLattice (AgentivityNode)
+open ArgumentStructure (AgentivityNode)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Causer Type ([hafeez-2025], [comrie-1989])

--- a/Linglib/Semantics/Lexical/EventStructure.lean
+++ b/Linglib/Semantics/Lexical/EventStructure.lean
@@ -29,7 +29,7 @@ namespace Semantics.Lexical.EventStructure
 
 open Semantics.Lexical
 open _root_.ArgumentStructure (EntailmentProfile)
-open _root_.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure
 open Features
 
 /-! ### Event structure templates -/

--- a/Linglib/Semantics/Lexical/LevinClassProfiles.lean
+++ b/Linglib/Semantics/Lexical/LevinClassProfiles.lean
@@ -31,8 +31,7 @@ Individual verbs can override class-level profiles via explicit
 namespace Features.LevinClassProfiles
 
 open Semantics.Lexical
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 
 -- ════════════════════════════════════════════════════
 -- § 1. Argument Structure Templates
@@ -229,8 +228,7 @@ end Features.LevinClassProfiles
 
 namespace Semantics.Lexical
 open Features.LevinClassProfiles
-open _root_.ArgumentStructure (EntailmentProfile)
-open _root_.ArgumentStructure.EntailmentProfile
+open _root_.ArgumentStructure
 
 /-- Map a Levin class to its argument structure template.
     Returns `none` for classes whose profiles haven't been determined yet. -/
@@ -296,7 +294,7 @@ end Semantics.Lexical
 
 namespace Features.LevinClassProfiles
 open Semantics.Lexical
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Verb
 open Verb.Root.Kinds
 
@@ -490,18 +488,18 @@ theorem build_subject_agrees :
     profile is well-formed. -/
 theorem derived_subjects_wellformed :
     (toArgTemplate causativeResult).elim False
-      (·.subjectProfile.WellFormedInternal) ∧
+      (WellFormedInternal ·.subjectProfile) ∧
     (toArgTemplate pureManner).elim False
-      (·.subjectProfile.WellFormedInternal) ∧
+      (WellFormedInternal ·.subjectProfile) ∧
     (toArgTemplate pureResult).elim False
-      (·.subjectProfile.WellFormedInternal) ∧
+      (WellFormedInternal ·.subjectProfile) ∧
     (toArgTemplate propertyConcept).elim False
-      (·.subjectProfile.WellFormedInternal) := by
+      (WellFormedInternal ·.subjectProfile) := by
   refine ⟨?_, ?_, ?_, ?_⟩
-  · show resultChange.subjectProfile.WellFormedInternal; decide
-  · show selfMotion.subjectProfile.WellFormedInternal; decide
-  · show unaccusativeCoS.subjectProfile.WellFormedInternal; decide
-  · show perception.subjectProfile.WellFormedInternal; decide
+  · show WellFormedInternal resultChange.subjectProfile; decide
+  · show WellFormedInternal selfMotion.subjectProfile; decide
+  · show WellFormedInternal unaccusativeCoS.subjectProfile; decide
+  · show WellFormedInternal perception.subjectProfile; decide
 
 -- ════════════════════════════════════════════════════
 -- § 9. Grimm persistence placements
@@ -509,7 +507,8 @@ theorem derived_subjects_wellformed :
 
 section GrimmPlacements
 
-open ArgumentStructure.AgentivityLattice
+open ArgumentStructure
+
 
 /-! [grimm-2011]'s persistence bridge (`PersistenceLevel.fromPatientProfile`)
 evaluated on the class-level object profiles — the canonical placements

--- a/Linglib/Semantics/Verb/Denotation.lean
+++ b/Linglib/Semantics/Verb/Denotation.lean
@@ -44,7 +44,6 @@ participant roles.
 -/
 
 open ArgumentStructure
-open ArgumentStructure (EntailmentProfile)
 
 /-! ### The theta-grid (derived from the proto-role profiles) -/
 

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -61,7 +61,7 @@ two-feature simplification).
 namespace AndersonJM2006
 
 open ArgumentStructure.Linking (LinkingTheory ArgPosition)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open English.Predicates.Verbal
 
 -- ============================================================================
@@ -223,8 +223,8 @@ theorem Case.acc_abs_same_relation :
 
 namespace AndersonJM2006
 
+open ArgumentStructure
 open ArgumentStructure.Linking (LinkingTheory ArgPosition)
-open ArgumentStructure.EntailmentProfile
 open English.Predicates.Verbal
 
 -- ============================================================================

--- a/Linglib/Studies/Beavers2010.lean
+++ b/Linglib/Studies/Beavers2010.lean
@@ -35,8 +35,7 @@ derived corollary `MAP_subset` / `MapHolds.oblique_le`, via the substrate's
 
 namespace Beavers2010
 
-open ArgumentStructure.EntailmentProfile
-open ArgumentStructure.AgentivityLattice
+open ArgumentStructure
 open Features.LevinClassProfiles
 open ArgumentStructure.Affectedness (AffectednessDegree profileToDegree)
 open Semantics.Lexical (DiathesisAlternation)

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -60,7 +60,7 @@ namespace Bhadra2024
 open Semantics.Lexical
 open Semantics.Lexical.EventStructure
 open ArgumentStructure (EventRel)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open ArgumentStructure.Affectedness
 
 /-! ### The compositional verb root (eqs. 53–60)

--- a/Linglib/Studies/Dowty1991.lean
+++ b/Linglib/Studies/Dowty1991.lean
@@ -37,8 +37,7 @@ succeed and where they diverge from the modern approach.
 namespace Dowty1991
 
 open Semantics.Lexical
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Features.LevinClassProfiles
 open English.Predicates.Verbal
 
@@ -498,9 +497,9 @@ theorem break_object_it_divergence :
     creation verb. Recorded, not flipped. -/
 theorem eat_object_de_tension :
     matchesProfile Rows.eatObject consumptionObject = true ∧
-    ArgumentStructure.AgentivityLattice.PersistenceLevel.fromPatientProfile
+    PersistenceLevel.fromPatientProfile
       consumptionObject = .exPersBeginning ∧
-    ArgumentStructure.AgentivityLattice.PersistenceLevel.fromPatientProfile
+    PersistenceLevel.fromPatientProfile
       { consumptionObject with dependentExistence := true } = .exPersEnd := by
   refine ⟨by decide, by decide, by decide⟩
 

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -39,9 +39,7 @@ referential-property treatment the paper attributes to [grimm-2005].
 
 namespace Grimm2011
 
-open ArgumentStructure.AgentivityLattice
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Features.LevinClassProfiles
 open Features.Prominence
 open Aissen2003

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -16,15 +16,22 @@ referential-property treatment the paper attributes to [grimm-2005].
 
 ## Main results
 
-- `russian_dom_matches_lattice` / `spanish_dom_within_lattice`: for canonical
-  transitives the lattice predicts DOM for exactly {animate, human} — the
-  Russian pattern; Spanish marks a proper subset.
+- `kill_subject_range`: §2.3's closure claim — every node above *kill*'s
+  minimal agent is NOM/ERG, from the substrate's interval characterization
+  of the case regions (`toCaseRegion_eq_nomErg_iff`).
+- `russian_dom_matches_lattice` / `spanish_dom_within_lattice` /
+  `animate_dom_object_is_dative_node`: the lattice predicts DOM for exactly
+  {animate, human}, and the animate DOM object is literally the dative node.
 - `domPredicted_monotone`, `latticeDOM_isMonotone`,
   `latticeDOM_matches_aissen_type2`: the lattice derives [aissen-2003]'s
   monotonicity universal and reproduces OT Type 2.
-- `wellFormedPair_not_preserved`, `arrive_cross_theory`,
-  `kiss_flat_count_from_lattice`: what the lattice projection of
-  [dowty-1991]'s profiles loses and what it fixes.
+- `genitive_requires_entailment_free`: only the entailment-free object
+  profile reaches the genitive node — the §5.2 intensionality restriction
+  as a theorem over all [dowty-1991] profiles.
+- `wellFormedPair_not_preserved`, `kiss_outranking_from_dominance`,
+  `arrive_cross_theory`: what the lattice projection of Dowty's profiles
+  loses, and the ASP re-derived from dominance
+  (`outranks_of_lattice_dominance`) rather than checked per verb.
 - `lattice_diverges_from_dependent_case`: the semantic-case vs
   structural-case fault line on animate objects, made explicit against the
   dependent-case pipeline in `Studies/Aissen2003.lean`.
@@ -176,6 +183,26 @@ theorem instigation_is_the_dividing_feature :
     selfMotion.subjectProfile.causation = false ∧
     directedMotion.subjectProfile.causation = false := by decide
 
+/-! ### Acceptable-argument ranges (§2.3, p.528)
+
+Argument acceptability is closure-based: any node above a verb's minimal
+agent requirement qualifies. Since *kill*'s agent requires only instigation,
+its subject range at total persistence is the whole NOM/ERG interval — from
+natural forces to intentional agents. -/
+
+/-- Everything above *kill*'s minimal agent is NOM/ERG: upward closure plus
+    the interval characterization `toCaseRegion_eq_nomErg_iff`. -/
+theorem kill_subject_range {n : GrimmNode} (h : minimalInstigator ≤ n) :
+    n.toCaseRegion = .nomErg :=
+  (GrimmNode.toCaseRegion_eq_nomErg_iff n).mpr h
+
+/-- The range's endpoints, derived: electricity (instigation only) and the
+    assassin (⊤) are both acceptable *kill*-subjects. -/
+theorem kill_subject_endpoints :
+    minimalInstigator.toCaseRegion = .nomErg ∧
+    (⊤ : GrimmNode).toCaseRegion = .nomErg :=
+  ⟨kill_subject_range le_rfl, kill_subject_range le_top⟩
+
 /-! ### Accusative and ergative alignment (§4, Fig. 6)
 
 Morphological readout of the substrate region facts
@@ -242,6 +269,13 @@ theorem object_regions_by_animacy :
       = .dative ∧
     (objectNodeWithAnimacy .human .quPersBeginning).toCaseRegion
       = .dative := by decide
+
+/-- The animate DOM object at `quPersBeginning` IS `sentientNonInstigatorNode`
+    — one lattice point shared with recipients and experiencers (Fig. 7).
+    On this account DOM marking is dative marking (Spanish *a*). -/
+theorem animate_dom_object_is_dative_node :
+    objectNodeWithAnimacy .animate .quPersBeginning
+      = sentientNonInstigatorNode := rfl
 
 /-- DOM is predicted: the object node is in the transitivity region but
     outside ACC/ABS. -/
@@ -389,6 +423,27 @@ theorem specific_reading_in_accAbs :
 theorem nonspecific_reading_at_bottom :
     nonspecificIntensionalObject = ⊥ := rfl
 
+/-- Only the entailment-free P-Patient profile reaches the genitive node:
+    the lattice form of "the alternation is limited to intensional verbs"
+    (p.541), for every [dowty-1991] profile. -/
+theorem genitive_requires_entailment_free (p : EntailmentProfile) :
+    PersistenceLevel.fromPatientProfile p = .totalNonPersistence ↔
+      p.changeOfState = false ∧ p.incrementalTheme = false ∧
+      p.causallyAffected = false ∧ p.stationary = false ∧
+      p.dependentExistence = false := by
+  rcases p with ⟨v, s, c, m, ie, cos, it, ca, st, de⟩
+  cases v <;> cases s <;> cases c <;> cases m <;> cases ie <;>
+    cases cos <;> cases it <;> cases ca <;> cases st <;> cases de <;> decide
+
+/-- Limitation: [dowty-1991] (30e) codes de-dicto objects (*needs a car*)
+    with dependent existence, which the bridge reads as destruction — the
+    desire-class object lands at `exPersBeginning`, not at Grimm's ⊥
+    placement for *want*. Dowty's features cannot separate "never entailed
+    to exist" from "ceases to exist". -/
+theorem desire_object_bridge_tension :
+    desire.objectProfile.map PersistenceLevel.fromPatientProfile
+      = some .exPersBeginning := rfl
+
 /-! ### Grimm vs [dowty-1991]
 
 §2.1 recasts Dowty's ten entailments as four agentivity features plus
@@ -441,6 +496,14 @@ theorem kiss_subject_dominates :
     AgentivityNode.fromEntailmentProfile Dowty1991.kissObjectProfile <
       AgentivityNode.fromEntailmentProfile Dowty1991.kissSubjectProfile := by
   decide
+
+/-- Subject selection for *kiss* from lattice dominance alone
+    (`outranks_of_lattice_dominance`): the ASP mechanized, re-deriving
+    `Dowty1991.kiss_subject_outranks` without counting or `decide`. -/
+theorem kiss_outranking_from_dominance :
+    OutranksForSubject Dowty1991.kissSubjectProfile
+      Dowty1991.kissObjectProfile :=
+  outranks_of_lattice_dominance _ _ kiss_subject_dominates fun _ => rfl
 
 /-- Dowty's count comparison follows from lattice dominance via
     `featureCount_monotone` and `pAgentScore_decomposition`. -/

--- a/Linglib/Studies/Kim2024_UPH.lean
+++ b/Linglib/Studies/Kim2024_UPH.lean
@@ -57,7 +57,7 @@ open English.Predicates.Verbal
 open Pesetsky1995.PsychVerbs
 open SolstadBott2022
   (stimExpSubjectProfile stimExpObjectProfile expStimSubjectProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 
 -- ════════════════════════════════════════════════════
 -- § 1. Consistency Predicates

--- a/Linglib/Studies/KoontzGarboden2009.lean
+++ b/Linglib/Studies/KoontzGarboden2009.lean
@@ -233,8 +233,7 @@ def reflexivizationYieldsAnticausative : CauserSpec → Bool
     would carry more structure than K-G's underspecification account
     predicts. -/
 
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 
 /-- Derive `CauserSpec` from a proto-role entailment profile.
     Volition is the discriminating feature:

--- a/Linglib/Studies/MartinSchaeferKastner2025.lean
+++ b/Linglib/Studies/MartinSchaeferKastner2025.lean
@@ -65,7 +65,7 @@ namespace MartinSchaeferKastner2025
 
 open Minimalist.Voice (Flavor)
 open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile (PredictsUnaccusative)
+open ArgumentStructure (PredictsUnaccusative)
 open Pragmatics.GriceanMaxims (MannerSubmaxim)
 open French.Predicates
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -1112,6 +1112,7 @@ clash is now wired in via `Semantics/ArgumentStructure/ArgumentIntroduction.lean
 and consumed in §15c below (`low_appl_blocks_unergative_denotational`,
 `low_external_arg_clash`). -/
 
+
 open ArgumentStructure (EntailmentProfile)
 
 /-- A verb has an unsaturated theme argument iff its object entailment

--- a/Linglib/Studies/RappaportHovavLevin2024.lean
+++ b/Linglib/Studies/RappaportHovavLevin2024.lean
@@ -88,7 +88,7 @@ verbs ([levin-krejci-2019]), and *drown*.
 namespace RappaportHovavLevin2024
 
 open Semantics.Lexical.EventStructure
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Semantics.Lexical
 
 /-! ### Force-dynamic primitives -/
@@ -530,7 +530,6 @@ def WipingVerb.levinClass : WipingVerb → LevinClass := fun _ => wipingLevinCla
 section AgentivityBridge
 
 open Features.LevinClassProfiles
-open ArgumentStructure.AgentivityLattice
 
 /-- The two *sweep* senses pair with the two Levin 10.4 subclass templates:
     basic-*sweep* (moving entity unsaturated) with the manner subclass, whose

--- a/Linglib/Studies/SolstadBott2022.lean
+++ b/Linglib/Studies/SolstadBott2022.lean
@@ -58,8 +58,7 @@ of grammatical position.
 
 namespace SolstadBott2022
 
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open Discourse.Coherence
 open English.Predicates.Verbal
 

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -59,8 +59,7 @@ open Intensional (WorldTimeIndex)
 
 open Semantics.Presupposition
 open French.Predicates
-open ArgumentStructure (EntailmentProfile)
-open ArgumentStructure.EntailmentProfile
+open ArgumentStructure
 open ArgumentStructure.Affectedness
 open Features
 open Semantics.Lexical
@@ -444,7 +443,7 @@ theorem active_implies_pAgent_ge_1 (p : EntailmentProfile)
     p.pAgentScore ≥ 1 := by
   obtain ⟨v, s, c, m, ie, cos, it, ca, st, de⟩ := p
   simp only [hasActiveAgentEntailment] at h
-  simp only [pAgentScore]
+  simp only [EntailmentProfile.pAgentScore]
   cases v <;> cases c <;> cases m <;> simp_all (config := { decide := false }) <;> omega
 
 /-- Converse fails: experiencer profiles have pAgentScore ≥ 1 but no


### PR DESCRIPTION
Follow-up to #1331 (these landed on the branch after merge). Two parts:

- Deep claims derived, not checked: core case regions as order intervals anchored at the poles (`toCaseRegion_eq_nomErg_iff` etc., convexity now a corollary); the ASP as lattice dominance over all profile pairs (`outranks_of_lattice_dominance`); the §5.2 intensionality restriction as a ∀-profile theorem; the animate-DOM-object = dative-node identification; `EntailmentProfile` as the Boolean cube on a `ProtoRoleFeature` index.
- Namespace flattening: `AgentivityLattice` dissolved into `ArgumentStructure`; theory-level relations/predicates/template profiles moved to domain root — consumers need one `open ArgumentStructure`.