### PR TITLE
refactor(Semantics/ArgumentStructure): Agentivity cube; drop Node names

### DIFF
--- a/Linglib/Semantics/ArgumentStructure/Affectedness.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness.lean
@@ -45,7 +45,7 @@ here, since participation is carried by `θ`'s typing (in the paper both
 predicate's role inventory). Accordingly the file formalizes two of
 (62)'s three arrows; the rightmost is trivial under this typing. One of
 three `EntailmentProfile` projections
-(`AgentivityNode` P-Agent, this file P-Patient strength → MAP
+(`Agentivity` P-Agent, this file P-Patient strength → MAP
 (`Studies/Beavers2010.lean`), `PersistenceLevel` → case regions); distinct
 from the surface (`MeaningComponents.changeOfState`) and root
 (`LexKind.result`) change-of-state notions ([beavers-koontz-garboden-2020]).

--- a/Linglib/Semantics/ArgumentStructure/Agentivity/CaseRegions.lean
+++ b/Linglib/Semantics/ArgumentStructure/Agentivity/CaseRegions.lean
@@ -7,7 +7,7 @@ import Linglib.Features.Case.Basic
 [grimm-2011] §4's central claim: a core case marker corresponds to a
 **connected region** of the agentivity lattice, spreading outwards from the
 maximal agent and maximal patient nodes (Figs. 6–7). This file assigns each
-`GrimmNode` its case region (`GrimmNode.toCaseRegion`), maps regions to
+`ParticipantType` its case region (`ParticipantType.toCaseRegion`), maps regions to
 morphological cases under accusative and ergative alignment, and sharpens
 the connectedness claim: each core region is an order **interval** anchored
 at its pole (`toCaseRegion_eq_nomErg_iff` etc.), with order-convexity a
@@ -50,7 +50,7 @@ inductive CaseRegion where
     - dative: sentience (without instigation) + qualitative persistence
       (beginning) — recipients, experiencers, benefactives.
     - oblique: everything else. -/
-def GrimmNode.toCaseRegion (n : GrimmNode) : CaseRegion :=
+def ParticipantType.toCaseRegion (n : ParticipantType) : CaseRegion :=
   if n.agentivity.instigation && n.persistence == .totalPersistence then
     .nomErg
   else if n.agentivity == ⊥ &&
@@ -85,34 +85,34 @@ The abstract's central claim — a core case marker is a connected region
 sharpened form: each core region is an order **interval** anchored at its
 pole. NOM/ERG is the up-set of `minimalInstigator` (its top is
 `maximalAgent = ⊤`); ACC/ABS runs from `maximalPatient` up to the
-contact-verb patient; the dative sits above `sentientNonInstigatorNode`.
+contact-verb patient; the dative sits above `sentientNonInstigator`.
 Order-convexity ("connectedness") follows by transitivity. -/
 
 /-- The bottom of the NOM/ERG interval: instigation alone, at total
     persistence — the minimal acceptable agent of *kill* (§2.3: natural
     forces such as electricity or the explosion). -/
-def minimalInstigator : GrimmNode := ⟨⟨false, false, true, false⟩, ⊤⟩
+def minimalInstigator : ParticipantType := ⟨.mk false false true false, ⊤⟩
 
 /-- **NOM/ERG is the up-set of the minimal instigator** — the interval from
     `minimalInstigator` to `maximalAgent = ⊤`. -/
-theorem GrimmNode.toCaseRegion_eq_nomErg_iff (n : GrimmNode) :
+theorem ParticipantType.toCaseRegion_eq_nomErg_iff (n : ParticipantType) :
     n.toCaseRegion = .nomErg ↔ minimalInstigator ≤ n := by
   revert n; decide
 
 /-- **ACC/ABS is the interval from the maximal patient to the contact-verb
     patient**: ⊥ agentivity, persistence between `exPersBeginning` and
     `quPersBeginning`. -/
-theorem GrimmNode.toCaseRegion_eq_accAbs_iff (n : GrimmNode) :
+theorem ParticipantType.toCaseRegion_eq_accAbs_iff (n : ParticipantType) :
     n.toCaseRegion = .accAbs ↔
-      maximalPatient ≤ n ∧ n ≤ TransitivityRank.contact.patientNode := by
+      maximalPatient ≤ n ∧ n ≤ TransitivityRank.contact.patientType := by
   revert n; decide
 
-/-- **The dative is the interval above `sentientNonInstigatorNode`**:
+/-- **The dative is the interval above `sentientNonInstigator`**:
     sentience without instigation, pinned at `quPersBeginning`. -/
-theorem GrimmNode.toCaseRegion_eq_dative_iff (n : GrimmNode) :
+theorem ParticipantType.toCaseRegion_eq_dative_iff (n : ParticipantType) :
     n.toCaseRegion = .dative ↔
-      sentientNonInstigatorNode ≤ n ∧
-      n ≤ ⟨⟨true, true, false, true⟩, .quPersBeginning⟩ := by
+      sentientNonInstigator ≤ n ∧
+      n ≤ ⟨.mk true true false true, .quPersBeginning⟩ := by
   revert n; decide
 
 /-- A predicate on a partial order is **order-convex** if it is closed
@@ -124,23 +124,23 @@ def IsOrderConvex {α : Type*} [LE α] (P : α → Prop) : Prop :=
 
 /-- Connectedness of NOM/ERG, from the interval form. -/
 theorem nomErg_orderConvex :
-    IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .nomErg) := by
+    IsOrderConvex (fun n : ParticipantType => n.toCaseRegion = .nomErg) := by
   intro a b x ha hb hax hxb
-  rw [GrimmNode.toCaseRegion_eq_nomErg_iff] at ha ⊢
+  rw [ParticipantType.toCaseRegion_eq_nomErg_iff] at ha ⊢
   exact ha.trans hax
 
 /-- Connectedness of ACC/ABS, from the interval form. -/
 theorem accAbs_orderConvex :
-    IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .accAbs) := by
+    IsOrderConvex (fun n : ParticipantType => n.toCaseRegion = .accAbs) := by
   intro a b x ha hb hax hxb
-  rw [GrimmNode.toCaseRegion_eq_accAbs_iff] at ha hb ⊢
+  rw [ParticipantType.toCaseRegion_eq_accAbs_iff] at ha hb ⊢
   exact ⟨ha.1.trans hax, hxb.trans hb.2⟩
 
 /-- Connectedness of the dative, from the interval form. -/
 theorem dative_orderConvex :
-    IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .dative) := by
+    IsOrderConvex (fun n : ParticipantType => n.toCaseRegion = .dative) := by
   intro a b x ha hb hax hxb
-  rw [GrimmNode.toCaseRegion_eq_dative_iff] at ha hb ⊢
+  rw [ParticipantType.toCaseRegion_eq_dative_iff] at ha hb ⊢
   exact ⟨ha.1.trans hax, hxb.trans hb.2⟩
 
 /-- Counterexample showing `oblique` is NOT order-convex. With
@@ -150,11 +150,11 @@ theorem dative_orderConvex :
     Grimm (p.533): oblique is the residual region between maximal agent and
     maximal patient, not a positively-characterised connected case. -/
 theorem oblique_not_orderConvex :
-    ¬ IsOrderConvex (fun n : GrimmNode => n.toCaseRegion = .oblique) := by
+    ¬ IsOrderConvex (fun n : ParticipantType => n.toCaseRegion = .oblique) := by
   intro h
-  have habs := h (a := ⟨⟨false, false, false, true⟩, .quPersBeginning⟩)
-                 (b := ⟨⟨false, true, true, true⟩, .quPersBeginning⟩)
-                 (x := ⟨⟨false, true, false, true⟩, .quPersBeginning⟩)
+  have habs := h (a := ⟨.mk false false false true, .quPersBeginning⟩)
+                 (b := ⟨.mk false true true true, .quPersBeginning⟩)
+                 (x := ⟨.mk false true false true, .quPersBeginning⟩)
                  (by decide) (by decide) (by decide) (by decide)
   exact absurd habs (by decide)
 
@@ -172,17 +172,17 @@ theorem effectorAgent_toCaseRegion : effectorAgent.toCaseRegion = .nomErg := by 
 
 /-- The destroyed patient of Class I verbs (Fig. 5, Ip) sits in ACC/ABS. -/
 theorem resultativeEffective_patient_toCaseRegion :
-    (TransitivityRank.resultativeEffective.patientNode).toCaseRegion = .accAbs := by decide
+    (TransitivityRank.resultativeEffective.patientType).toCaseRegion = .accAbs := by decide
 
 /-- The affected-but-persisting patient of Class II verbs (Fig. 5, IIp) sits
     in ACC/ABS. -/
 theorem contact_patient_toCaseRegion :
-    (TransitivityRank.contact.patientNode).toCaseRegion = .accAbs := by decide
+    (TransitivityRank.contact.patientType).toCaseRegion = .accAbs := by decide
 
 /-- The possibly-nonexistent patient of Class III pursuit verbs (Fig. 5, IIIp)
     falls outside the core object region. -/
 theorem pursuit_patient_toCaseRegion :
-    (TransitivityRank.pursuit.patientNode).toCaseRegion = .oblique := by decide
+    (TransitivityRank.pursuit.patientType).toCaseRegion = .oblique := by decide
 
 /-! ### Dative polysemy (§5.1) -/
 
@@ -191,11 +191,11 @@ theorem pursuit_patient_toCaseRegion :
     semantic properties of **sentience** and **qualitative persistence
     (beginning)** (Fig. 7, p.536).
 
-    Because `recipientNode` and `experiencerNode` are abbrevs of
-    `sentientNonInstigatorNode`, the convergence is by construction; the
+    Because `recipientType` and `experiencerType` are abbrevs of
+    `sentientNonInstigator`, the convergence is by construction; the
     theorem below asserts only that this single lattice position falls in
     the dative case region. -/
 theorem sentientNonInstigator_in_dative :
-    sentientNonInstigatorNode.toCaseRegion = .dative := rfl
+    sentientNonInstigator.toCaseRegion = .dative := rfl
 
 end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/Agentivity/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Agentivity/Defs.lean
@@ -1,5 +1,8 @@
+import Mathlib.Order.BooleanAlgebra.Basic
+import Mathlib.Tactic.DeriveFintype
 import Mathlib.Order.Lattice
 import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Fintype.Prod
 
 /-!
@@ -33,21 +36,22 @@ innovations over Dowty:
 The carrier types here are implementation **supersets** of Grimm's lattices;
 the validity predicates carve out the paper's objects:
 
-- `AgentivityNode` is the full Boolean cube on the four agentivity
-  primitives (16 elements). Grimm's Fig. 1 lattice is its 12-node
-  `AgentivityNode.Valid` subset (volition → sentience).
+- `Agentivity` is the Boolean cube on `Agentivity.Feature` (16 elements),
+  with the pointwise `BooleanAlgebra`. Grimm's Fig. 1 lattice is its
+  12-element `Agentivity.Valid` subset (volition → sentience).
 - `PersistenceLevel` is exactly Grimm's five valid persistence levels
   (Fig. 2) — here the carrier *is* the paper's object.
-- `GrimmNode` is the full product carrier (80 elements). Grimm's Fig. 3
-  agentivity lattice is its 38-node `GrimmNode.Valid` subset
-  (`AgentivityValid` ∧ `CrossValid`).
+- `ParticipantType` (Grimm's "participant type": agentivity × persistence)
+  is the full product carrier (80 elements). Grimm's Fig. 3 lattice is its
+  38-element `ParticipantType.Valid` subset (`AgentivityValid` ∧
+  `CrossValid`).
 
 ## Mathlib integration
 
 All ordering infrastructure uses Mathlib typeclasses:
-- `AgentivityNode`: `Lattice`, `BoundedOrder`, `Fintype`
+- `Agentivity`: `BooleanAlgebra` (pointwise, from `Pi`), `Fintype`
 - `PersistenceLevel`: `Lattice`, `BoundedOrder`, `Fintype`
-- `GrimmNode`: `Lattice`, `BoundedOrder`, `Fintype`
+- `ParticipantType`: `Lattice`, `BoundedOrder`, `Fintype`
 
 The bridges to [dowty-1991]'s `EntailmentProfile` live in
 `EntailmentProfile.lean`; the case-region geometry lives in
@@ -56,98 +60,92 @@ The bridges to [dowty-1991]'s `EntailmentProfile` live in
 
 namespace ArgumentStructure
 
-/-! ### Agentivity primitives (Table 2, §2.1) -/
+/-! ### Agentivity (Table 2, §2.1) -/
 
 /-- The four agentivity primitives (Table 2 (agentive properties), p.520).
 
-    Each has an agentive (+) and non-agentive (∅) pole. The non-agentive
-    pole is not a separate feature — it is simply the absence of the
-    agentive property. This is the **privative opposition** that replaces
-    Dowty's two independent clusters.
-
-    The carrier is the full 16-element Boolean cube; Grimm's Fig. 1
-    lattice is the 12-node `Valid` subset. -/
-structure AgentivityNode where
+    Each has an agentive (+) and non-agentive (∅) pole; the non-agentive
+    pole is simply the absence of the property — the **privative
+    opposition** that replaces Dowty's two independent clusters. -/
+inductive Agentivity.Feature where
   /-- +volition: the participant intends to bring about the event. -/
-  volition    : Bool
+  | volition
   /-- +sentience: conscious involvement in the action or state. -/
-  sentience   : Bool
+  | sentience
   /-- +instigation: prior independent action whose effects can be
-      attributed to this argument. Replaces Dowty's "causation"
-      (p.521). -/
-  instigation : Bool
+      attributed to this argument. Replaces Dowty's "causation" (p.521). -/
+  | instigation
   /-- +motion: the argument is in motion during the event. -/
-  motion      : Bool
-  deriving DecidableEq, Repr
+  | motion
+  deriving DecidableEq, Repr, Fintype
 
-/-- Validity constraint: volition presupposes sentience
-    (p.521, following [dowty-1991] p.607). Carves Grimm's 12-node
-    Fig. 1 lattice out of the 16-element carrier. -/
-def AgentivityNode.Valid (a : AgentivityNode) : Prop :=
-  a.volition = true → a.sentience = true
+/-- An argument's agentivity: which of the four primitives it bears, as a
+    point of the Boolean cube on `Agentivity.Feature`. Order, lattice, and
+    Boolean-algebra structure are pointwise, so `a ≤ b` is feature-set
+    inclusion; Grimm's Fig. 1 lattice is the 12-element `Valid` subset of
+    the 16-element cube. -/
+def Agentivity := Agentivity.Feature → Bool
 
-instance (a : AgentivityNode) : Decidable a.Valid := by
-  unfold AgentivityNode.Valid; infer_instance
+namespace Agentivity
 
-/-- Number of positive agentivity features (= height in the lattice). -/
-def AgentivityNode.featureCount (a : AgentivityNode) : Nat :=
-  a.volition.toNat + a.sentience.toNat +
-  a.instigation.toNat + a.motion.toNat
+instance : DecidableEq Agentivity :=
+  inferInstanceAs (DecidableEq (Feature → Bool))
 
-/-- Equivalence with `Bool⁴` for `Fintype` derivation. -/
-def AgentivityNode.equiv : AgentivityNode ≃ (Bool × Bool × Bool × Bool) where
-  toFun a := (a.volition, a.sentience, a.instigation, a.motion)
-  invFun p := ⟨p.1, p.2.1, p.2.2.1, p.2.2.2⟩
-  left_inv a := by cases a; rfl
-  right_inv p := by obtain ⟨_, _, _, _⟩ := p; rfl
+instance : Fintype Agentivity := inferInstanceAs (Fintype (Feature → Bool))
 
-instance : Fintype AgentivityNode := Fintype.ofEquiv _ AgentivityNode.equiv.symm
+instance : BooleanAlgebra Agentivity :=
+  inferInstanceAs (BooleanAlgebra (Feature → Bool))
 
-/-- Subset inclusion ordering on agentivity features. `a ≤ b` iff every
-    feature of `a` is also a feature of `b`. Defined componentwise as
-    `Bool` implication; the `PartialOrder` axioms are verified by `decide`
-    over the 16-element `Fintype`. -/
-private def AgentivityNode.leBool (a b : AgentivityNode) : Bool :=
-  (!a.volition || b.volition) && (!a.sentience || b.sentience) &&
-  (!a.instigation || b.instigation) && (!a.motion || b.motion)
+instance : DecidableRel (α := Agentivity) (· ≤ ·) := fun a b =>
+  decidable_of_iff (∀ f, a f ≤ b f) Iff.rfl
 
-instance : PartialOrder AgentivityNode where
-  le a b := a.leBool b = true
-  le_refl a := by simp [AgentivityNode.leBool]
-  le_trans := by decide
-  le_antisymm := by decide
-
-instance : DecidableRel (α := AgentivityNode) (· ≤ ·) := fun a b =>
-  inferInstanceAs (Decidable (a.leBool b = true))
-
-instance : DecidableRel (α := AgentivityNode) (· < ·) := fun _ _ =>
+instance : DecidableRel (α := Agentivity) (· < ·) := fun _ _ =>
   decidable_of_iff' _ lt_iff_le_not_ge
 
-/-- Lattice: componentwise `∨` for join, `∧` for meet. -/
-instance : Lattice AgentivityNode where
-  sup a b := ⟨a.volition || b.volition, a.sentience || b.sentience,
-              a.instigation || b.instigation, a.motion || b.motion⟩
-  inf a b := ⟨a.volition && b.volition, a.sentience && b.sentience,
-              a.instigation && b.instigation, a.motion && b.motion⟩
-  le_sup_left := by decide
-  le_sup_right := by decide
-  sup_le := by decide
-  inf_le_left := by decide
-  inf_le_right := by decide
-  le_inf := by decide
+/-- Build an agentivity value from the four indicators, in Table 2 order. -/
+def mk (volition sentience instigation motion : Bool) : Agentivity
+  | .volition => volition
+  | .sentience => sentience
+  | .instigation => instigation
+  | .motion => motion
 
-instance : OrderBot AgentivityNode where
-  bot := ⟨false, false, false, false⟩
-  bot_le := by decide
+instance : Repr Agentivity :=
+  ⟨fun a _ => repr (a .volition, a .sentience, a .instigation, a .motion)⟩
 
-instance : OrderTop AgentivityNode where
-  top := ⟨true, true, true, true⟩
-  le_top := by decide
+@[simp] theorem mk_inj {v s i m v' s' i' m' : Bool} :
+    mk v s i m = mk v' s' i' m' ↔ v = v' ∧ s = s' ∧ i = i' ∧ m = m' := by
+  constructor
+  · intro h
+    exact ⟨congrFun h .volition, congrFun h .sentience,
+      congrFun h .instigation, congrFun h .motion⟩
+  · rintro ⟨rfl, rfl, rfl, rfl⟩; rfl
 
-/-- Characterisation of the inclusion order by componentwise implication.
-    Public interface to the private `leBool`; verified by `decide` over the
-    16 × 16 pairs. -/
-theorem AgentivityNode.le_iff (a b : AgentivityNode) :
+/-- Volition indicator. -/
+def volition (a : Agentivity) : Bool := a .volition
+
+/-- Sentience indicator. -/
+def sentience (a : Agentivity) : Bool := a .sentience
+
+/-- Instigation indicator. -/
+def instigation (a : Agentivity) : Bool := a .instigation
+
+/-- Motion indicator. -/
+def motion (a : Agentivity) : Bool := a .motion
+
+/-- Validity: volition presupposes sentience (p.521, following
+    [dowty-1991] p.607). Carves Grimm's 12-element Fig. 1 lattice out of
+    the 16-element cube. -/
+def Valid (a : Agentivity) : Prop := a.volition = true → a.sentience = true
+
+instance (a : Agentivity) : Decidable a.Valid := by
+  unfold Valid; infer_instance
+
+/-- Number of positive features (= height in the cube). -/
+def featureCount (a : Agentivity) : Nat :=
+  a.volition.toNat + a.sentience.toNat + a.instigation.toNat + a.motion.toNat
+
+/-- The inclusion order, componentwise. -/
+theorem le_iff (a b : Agentivity) :
     a ≤ b ↔
       (a.volition = true → b.volition = true) ∧
       (a.sentience = true → b.sentience = true) ∧
@@ -155,28 +153,7 @@ theorem AgentivityNode.le_iff (a b : AgentivityNode) :
       (a.motion = true → b.motion = true) := by
   revert a b; decide
 
--- Componentwise Bool monotonicity (extracted from leBool)
-
-theorem AgentivityNode.le_instigation_mono {a b : AgentivityNode}
-    (hab : a ≤ b) (h : a.instigation = true) : b.instigation = true := by
-  have hbool : a.leBool b = true := hab
-  cases hi : b.instigation
-  · simp [AgentivityNode.leBool, h, hi] at hbool
-  · rfl
-
-theorem AgentivityNode.le_sentience_mono {a b : AgentivityNode}
-    (hab : a ≤ b) (h : a.sentience = true) : b.sentience = true := by
-  have hbool : a.leBool b = true := hab
-  cases hi : b.sentience
-  · simp [AgentivityNode.leBool, h, hi] at hbool
-  · rfl
-
-theorem AgentivityNode.ge_instigation_mono {a b : AgentivityNode}
-    (hab : a ≤ b) (h : b.instigation = false) : a.instigation = false := by
-  have hbool : a.leBool b = true := hab
-  cases hi : a.instigation
-  · rfl
-  · simp [AgentivityNode.leBool, hi, h] at hbool
+end Agentivity
 
 /-! ### Persistence levels (§2.2, Fig. 2) -/
 
@@ -318,54 +295,54 @@ instance : Lattice PersistenceLevel where
     2. If the argument does not exist at the beginning (totalNonPersistence
        or exPersEnd), it cannot have any agentivity properties
        (`CrossValid`, p.526–527). -/
-structure GrimmNode where
-  agentivity  : AgentivityNode
+structure ParticipantType where
+  agentivity  : Agentivity
   persistence : PersistenceLevel
   deriving DecidableEq, Repr
 
 /-- The agentivity constraint: volition → sentience. -/
-def GrimmNode.AgentivityValid (n : GrimmNode) : Prop :=
+def ParticipantType.AgentivityValid (n : ParticipantType) : Prop :=
   n.agentivity.Valid
 
-instance (n : GrimmNode) : Decidable n.AgentivityValid := by
-  unfold GrimmNode.AgentivityValid; infer_instance
+instance (n : ParticipantType) : Decidable n.AgentivityValid := by
+  unfold ParticipantType.AgentivityValid; infer_instance
 
 /-- The cross-lattice constraint: if the argument does not exist at the
     beginning of the event, it cannot have any agentivity properties. -/
-def GrimmNode.CrossValid (n : GrimmNode) : Prop :=
+def ParticipantType.CrossValid (n : ParticipantType) : Prop :=
   n.persistence.exPersB = true ∨ n.agentivity = ⊥
 
-instance (n : GrimmNode) : Decidable n.CrossValid := by
-  unfold GrimmNode.CrossValid; infer_instance
+instance (n : ParticipantType) : Decidable n.CrossValid := by
+  unfold ParticipantType.CrossValid; infer_instance
 
 /-- Full validity: both constraints satisfied. Carves Grimm's 38-node
     Fig. 3 lattice out of the 80-element carrier. -/
-def GrimmNode.Valid (n : GrimmNode) : Prop :=
+def ParticipantType.Valid (n : ParticipantType) : Prop :=
   n.AgentivityValid ∧ n.CrossValid
 
-instance (n : GrimmNode) : Decidable n.Valid := by
-  unfold GrimmNode.Valid; infer_instance
+instance (n : ParticipantType) : Decidable n.Valid := by
+  unfold ParticipantType.Valid; infer_instance
 
 /-- Total feature count (agentivity + persistence). -/
-def GrimmNode.featureCount (n : GrimmNode) : Nat :=
+def ParticipantType.featureCount (n : ParticipantType) : Nat :=
   n.agentivity.featureCount + n.persistence.featureCount
 
-def GrimmNode.equiv : GrimmNode ≃ (AgentivityNode × PersistenceLevel) where
+def ParticipantType.equiv : ParticipantType ≃ (Agentivity × PersistenceLevel) where
   toFun n := (n.agentivity, n.persistence)
   invFun p := ⟨p.1, p.2⟩
   left_inv n := by cases n; rfl
   right_inv p := by cases p; rfl
 
-instance : Fintype GrimmNode := Fintype.ofEquiv _ GrimmNode.equiv.symm
+instance : Fintype ParticipantType := Fintype.ofEquiv _ ParticipantType.equiv.symm
 
 /-- Product order: componentwise `≤` on agentivity and persistence. -/
-instance : LE GrimmNode where
+instance : LE ParticipantType where
   le a b := a.agentivity ≤ b.agentivity ∧ a.persistence ≤ b.persistence
 
-instance : LT GrimmNode where
+instance : LT ParticipantType where
   lt a b := a ≤ b ∧ ¬ b ≤ a
 
-instance : PartialOrder GrimmNode where
+instance : PartialOrder ParticipantType where
   le_refl a := ⟨le_refl _, le_refl _⟩
   le_trans _ _ _ h g := ⟨le_trans h.1 g.1, le_trans h.2 g.2⟩
   le_antisymm a b h g := by
@@ -373,19 +350,19 @@ instance : PartialOrder GrimmNode where
     have := le_antisymm h.2 g.2
     cases a; cases b; simp_all
 
-instance : DecidableRel (α := GrimmNode) (· ≤ ·) := fun a b =>
+instance : DecidableRel (α := ParticipantType) (· ≤ ·) := fun a b =>
   inferInstanceAs (Decidable (a.agentivity ≤ b.agentivity ∧ a.persistence ≤ b.persistence))
 
-instance : OrderBot GrimmNode where
+instance : OrderBot ParticipantType where
   bot := ⟨⊥, ⊥⟩
   bot_le _ := ⟨bot_le, bot_le⟩
 
-instance : OrderTop GrimmNode where
+instance : OrderTop ParticipantType where
   top := ⟨⊤, ⊤⟩
   le_top _ := ⟨le_top, le_top⟩
 
 /-- Componentwise lattice: meet/join on each axis independently. -/
-instance : Lattice GrimmNode where
+instance : Lattice ParticipantType where
   sup a b := ⟨a.agentivity ⊔ b.agentivity, a.persistence ⊔ b.persistence⟩
   inf a b := ⟨a.agentivity ⊓ b.agentivity, a.persistence ⊓ b.persistence⟩
   le_sup_left _ _ := ⟨le_sup_left, le_sup_left⟩
@@ -399,35 +376,35 @@ instance : Lattice GrimmNode where
 
 /-- Maximal Agent (Fig. 4): all agentivity features,
     total persistence. The prototypical transitive subject. -/
-def maximalAgent : GrimmNode :=
-  ⟨⟨true, true, true, true⟩, .totalPersistence⟩
+def maximalAgent : ParticipantType :=
+  ⟨⊤, .totalPersistence⟩
 
 /-- Maximal Patient (Fig. 4): no agentivity features,
     existential persistence (beginning). The prototypical affected object
     that ceases to exist (break, destroy). -/
-def maximalPatient : GrimmNode :=
-  ⟨⟨false, false, false, false⟩, .exPersBeginning⟩
+def maximalPatient : ParticipantType :=
+  ⟨⊥, .exPersBeginning⟩
 
 /-- The "effector" participant type: instigation + motion, total
     persistence. The canonical agent of effective action verbs (kill, break).
     §3, labeled Ia/IIa in Fig. 5. -/
-def effectorAgent : GrimmNode :=
-  ⟨⟨false, false, true, true⟩, .totalPersistence⟩
+def effectorAgent : ParticipantType :=
+  ⟨.mk false false true true, .totalPersistence⟩
 
 /-- The lattice position {sentience} × qualitative persistence (beginning).
     Per Grimm 2011 §5.1, diverse uses of the dative converge on this single
     region — recipients, experiencers, and benefactives are aliases below. -/
-def sentientNonInstigatorNode : GrimmNode :=
-  ⟨⟨false, true, false, false⟩, .quPersBeginning⟩
+def sentientNonInstigator : ParticipantType :=
+  ⟨.mk false true false false, .quPersBeginning⟩
 
 /-- Dative experiencer of psych verbs (§5.1.1). Alias of
-    `sentientNonInstigatorNode` — the convergence with `recipientNode` is by
+    `sentientNonInstigator` — the convergence with `recipientType` is by
     construction, not a theorem. -/
-abbrev experiencerNode : GrimmNode := sentientNonInstigatorNode
+abbrev experiencerType : ParticipantType := sentientNonInstigator
 
-/-- Canonical dative recipient (Fig. 7). Alias of `sentientNonInstigatorNode`
+/-- Canonical dative recipient (Fig. 7). Alias of `sentientNonInstigator`
     — see the docstring there for the unified treatment. -/
-abbrev recipientNode : GrimmNode := sentientNonInstigatorNode
+abbrev recipientType : ParticipantType := sentientNonInstigator
 
 /-! ### Transitivity region (§3, Fig. 4) -/
 
@@ -437,11 +414,11 @@ abbrev recipientNode : GrimmNode := sentientNonInstigatorNode
     The transitivity region excludes totalNonPersistence and exPersEnd
     because the prototypical transitive event requires both participants
     to exist at the beginning (p.529–530). -/
-def GrimmNode.InTransitiveRegion (n : GrimmNode) : Prop :=
+def ParticipantType.InTransitiveRegion (n : ParticipantType) : Prop :=
   n.persistence.exPersB = true
 
-instance (n : GrimmNode) : Decidable n.InTransitiveRegion := by
-  unfold GrimmNode.InTransitiveRegion; infer_instance
+instance (n : ParticipantType) : Decidable n.InTransitiveRegion := by
+  unfold ParticipantType.InTransitiveRegion; infer_instance
 
 /-- Tsunoda's transitivity hierarchy (§3, example 8).
 
@@ -470,7 +447,7 @@ inductive TransitivityRank where
     (Fig. 5). The agent position for all three classes is `effectorAgent`
     (Fig. 5, Ia/IIa share the same agent node; Grimm doesn't separately
     label IIIa). -/
-def TransitivityRank.patientNode : TransitivityRank → GrimmNode
+def TransitivityRank.patientType : TransitivityRank → ParticipantType
   | .resultativeEffective => ⟨⊥, .exPersBeginning⟩     -- Ip
   | .contact              => ⟨⊥, .quPersBeginning⟩     -- IIp
   | .pursuit              => ⟨⊥, .totalNonPersistence⟩ -- IIIp
@@ -509,7 +486,7 @@ theorem maximalAgent_eq_top : maximalAgent = ⊤ := by decide
 theorem maximalAgent_valid : maximalAgent.Valid := by decide
 theorem maximalPatient_valid : maximalPatient.Valid := by decide
 theorem effectorAgent_valid : effectorAgent.Valid := by decide
-theorem experiencerNode_valid : experiencerNode.Valid := by decide
+theorem experiencerType_valid : experiencerType.Valid := by decide
 
 -- Maximal agent is at the top, maximal patient is lower
 
@@ -543,7 +520,7 @@ theorem maximalPatient_in_transitiveRegion :
 
     Formally: the set of acceptable agents for a verb with minimum
     requirement `minReq` is `{a | minReq ≤ a}`, which is an upper set. -/
-theorem agent_upward_closed (minReq a b : AgentivityNode)
+theorem agent_upward_closed (minReq a b : Agentivity)
     (ha : minReq ≤ a) (hab : a ≤ b) :
     minReq ≤ b :=
   le_trans ha hab

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -27,7 +27,7 @@ with Proto-Patient dominance breaking ties.
 - `activitySubjectProfile` … `accomplishmentObjectProfile` — the
   [rappaport-hovav-levin-1998] template-level profile defaults (per-verb
   content lives in the class map, `Semantics/Lexical/LevinClassProfiles.lean`)
-- `AgentivityNode.fromEntailmentProfile`,
+- `Agentivity.fromEntailmentProfile`,
   `PersistenceLevel.fromPatientProfile` — bridges from
   profiles to [grimm-2011]'s agentivity lattice, with the consistency
   theorems relating the two dominance orders
@@ -338,18 +338,18 @@ translates, so the lattice substrate stays Mathlib-only. -/
     - movement = motion
 
     Independent existence is handled by the persistence dimension. -/
-def AgentivityNode.fromEntailmentProfile (p : EntailmentProfile) : AgentivityNode :=
-  ⟨p.volition, p.sentience, p.causation, p.movement⟩
+def Agentivity.fromEntailmentProfile (p : EntailmentProfile) : Agentivity :=
+  .mk p.volition p.sentience p.causation p.movement
 
 /-- Two profiles project to the same agentivity node iff they agree on the four
 lattice features: the projection drops independent existence and all five
 Proto-Patient entailments ([grimm-2011] §2.1 recasts them on the persistence
 axis). -/
-theorem AgentivityNode.fromEntailmentProfile_eq_iff (p q : EntailmentProfile) :
-    AgentivityNode.fromEntailmentProfile p = AgentivityNode.fromEntailmentProfile q ↔
+theorem Agentivity.fromEntailmentProfile_eq_iff (p q : EntailmentProfile) :
+    Agentivity.fromEntailmentProfile p = Agentivity.fromEntailmentProfile q ↔
       p.volition = q.volition ∧ p.sentience = q.sentience ∧
       p.causation = q.causation ∧ p.movement = q.movement := by
-  simp [AgentivityNode.fromEntailmentProfile, AgentivityNode.mk.injEq]
+  simp [Agentivity.fromEntailmentProfile, Agentivity.mk_inj]
 
 /-- Map Dowty's P-Patient entailments to Grimm's persistence level.
 
@@ -379,14 +379,14 @@ def PersistenceLevel.fromPatientProfile (p : EntailmentProfile) : PersistenceLev
   else
     .totalNonPersistence                        -- seek, want
 
-/-- Map a full EntailmentProfile to a GrimmNode.
+/-- Map a full EntailmentProfile to a ParticipantType.
 
     The agentivity features come from the P-Agent entailments;
     the persistence level comes from the P-Patient entailments. -/
-def GrimmNode.fromSubjectProfile (p : EntailmentProfile) : GrimmNode :=
+def ParticipantType.fromSubjectProfile (p : EntailmentProfile) : ParticipantType :=
   ⟨.fromEntailmentProfile p, .totalPersistence⟩
 
-def GrimmNode.fromObjectProfile (p : EntailmentProfile) : GrimmNode :=
+def ParticipantType.fromObjectProfile (p : EntailmentProfile) : ParticipantType :=
   ⟨.fromEntailmentProfile p, .fromPatientProfile p⟩
 
 /-! ### Grimm ↔ Dowty ASP consistency -/
@@ -403,27 +403,27 @@ private theorem bImpl (a b : Bool) (h : a = true → b = true) :
     movement=motion). -/
 theorem grimm_agentivity_consistent_with_dowty
     (p q : EntailmentProfile)
-    (h : AgentivityNode.fromEntailmentProfile p ≤
-         AgentivityNode.fromEntailmentProfile q) :
+    (h : Agentivity.fromEntailmentProfile p ≤
+         Agentivity.fromEntailmentProfile q) :
     (!p.volition || q.volition) = true ∧
     (!p.sentience || q.sentience) = true ∧
     (!p.causation || q.causation) = true ∧
     (!p.movement || q.movement) = true := by
-  obtain ⟨h1, h2, h3, h4⟩ := (AgentivityNode.le_iff _ _).mp h
+  obtain ⟨h1, h2, h3, h4⟩ := (Agentivity.le_iff _ _).mp h
   exact ⟨bImpl _ _ h1, bImpl _ _ h2, bImpl _ _ h3, bImpl _ _ h4⟩
 
 /-- The Dowty→Grimm bridge is monotone: if one EntailmentProfile
     dominates another on P-Agent features, the corresponding
-    AgentivityNodes are ordered. -/
+    Agentivitys are ordered. -/
 theorem fromEntailmentProfile_monotone
     (p q : EntailmentProfile)
     (hv : p.volition = true → q.volition = true)
     (hs : p.sentience = true → q.sentience = true)
     (hc : p.causation = true → q.causation = true)
     (hm : p.movement = true → q.movement = true) :
-    AgentivityNode.fromEntailmentProfile p ≤
-    AgentivityNode.fromEntailmentProfile q :=
-  (AgentivityNode.le_iff _ _).mpr ⟨hv, hs, hc, hm⟩
+    Agentivity.fromEntailmentProfile p ≤
+    Agentivity.fromEntailmentProfile q :=
+  (Agentivity.le_iff _ _).mpr ⟨hv, hs, hc, hm⟩
 
 /-! ### Dominance is lattice order plus independent existence
 
@@ -439,16 +439,16 @@ implication (§2.2). -/
 
 /-- Feature count is monotone in the inclusion order ([grimm-2011] §2.3):
     ascending the Fig. 1 lattice never loses agentivity features. -/
-theorem AgentivityNode.featureCount_monotone : Monotone AgentivityNode.featureCount :=
+theorem Agentivity.featureCount_monotone : Monotone Agentivity.featureCount :=
   fun _ _ h =>
-    (by decide : ∀ a b : AgentivityNode, a ≤ b → a.featureCount ≤ b.featureCount) _ _ h
+    (by decide : ∀ a b : Agentivity, a ≤ b → a.featureCount ≤ b.featureCount) _ _ h
 
 /-- Dowty's flat P-Agent count decomposes through the bridge: the four
     lattice features ([grimm-2011] Table 2) plus independent existence,
     the one Table 1 entailment Grimm moves to the persistence axis (§2.1). -/
 theorem pAgentScore_decomposition (p : EntailmentProfile) :
     p.pAgentScore =
-      (AgentivityNode.fromEntailmentProfile p).featureCount +
+      (Agentivity.fromEntailmentProfile p).featureCount +
         p.independentExistence.toNat :=
   rfl
 
@@ -459,8 +459,8 @@ theorem pAgentScore_decomposition (p : EntailmentProfile) :
     `grimm_agentivity_consistent_with_dowty`. -/
 theorem pAgentDominates_iff (p q : EntailmentProfile) :
     PAgentDominates p q ↔
-      AgentivityNode.fromEntailmentProfile q ≤
-        AgentivityNode.fromEntailmentProfile p ∧
+      Agentivity.fromEntailmentProfile q ≤
+        Agentivity.fromEntailmentProfile p ∧
       (q.independentExistence = true → p.independentExistence = true) := by
   constructor
   · rintro ⟨hv, hs, hc, hm, hie⟩
@@ -475,8 +475,8 @@ theorem pAgentDominates_iff (p q : EntailmentProfile) :
     existence is preserved, `subj` is selected — for every profile pair,
     via `pAgentDominates_iff`, not per-verb checking. -/
 theorem outranks_of_lattice_dominance (subj obj : EntailmentProfile)
-    (hlt : AgentivityNode.fromEntailmentProfile obj <
-      AgentivityNode.fromEntailmentProfile subj)
+    (hlt : Agentivity.fromEntailmentProfile obj <
+      Agentivity.fromEntailmentProfile subj)
     (hIE : obj.independentExistence = true → subj.independentExistence = true) :
     OutranksForSubject subj obj :=
   .inl ⟨(pAgentDominates_iff subj obj).mpr ⟨hlt.le, hIE⟩,

--- a/Linglib/Semantics/Causation/Morphological.lean
+++ b/Linglib/Semantics/Causation/Morphological.lean
@@ -47,7 +47,7 @@ Agentivity decomposes into **intentionality × control** (following
 ## Bridges
 
 - `CauserType.toCausalSource` → `CausalSource` (psych causation)
-- `CauserType.toAgentivityNode` → `AgentivityNode` (agentivity lattice)
+- `CauserType.toAgentivity` → `Agentivity` (agentivity lattice)
 - `CauserType.volitionality` → `Volitionality` (root dimensions)
 - `CauserType.agentivityDegree` → `AgentivityDegree`
 - `CausativeConstruction` bundles complexity + mediation + causer/causee
@@ -75,7 +75,7 @@ namespace Causation.Morphological
 
 open Verb
 open Causation.Psych (CausalSource)
-open ArgumentStructure (AgentivityNode)
+open ArgumentStructure (Agentivity)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Causer Type ([hafeez-2025], [comrie-1989])
@@ -335,10 +335,10 @@ def CauserType.volitionality : CauserType → Volitionality
 /-- Intentional human causers map to the agentive pole of the lattice
     (volition + sentience + instigation); accidental humans retain
     sentience but lack volition; natural forces have instigation only. -/
-def CauserType.toAgentivityNode : CauserType → AgentivityNode
-  | .intentionalHuman => ⟨true, true, true, false⟩   -- V+S+I
-  | .accidentalHuman  => ⟨false, true, true, false⟩  -- S+I (sentient but not volitional)
-  | .naturalForce     => ⟨false, false, true, false⟩  -- I only
+def CauserType.toAgentivity : CauserType → Agentivity
+  | .intentionalHuman => .mk true true true false   -- V+S+I
+  | .accidentalHuman  => .mk false true true false  -- S+I (sentient but not volitional)
+  | .naturalForce     => .mk false false true false  -- I only
 
 -- ════════════════════════════════════════════════════
 -- § 9. Bridge Theorems
@@ -346,18 +346,18 @@ def CauserType.toAgentivityNode : CauserType → AgentivityNode
 
 /-- Intentional human causers have maximal agentivity among causer types. -/
 theorem intentional_max_agentivity :
-    (CauserType.toAgentivityNode .intentionalHuman).volition = true ∧
-    (CauserType.toAgentivityNode .intentionalHuman).sentience = true ∧
-    (CauserType.toAgentivityNode .intentionalHuman).instigation = true := ⟨rfl, rfl, rfl⟩
+    (CauserType.toAgentivity .intentionalHuman).volition = true ∧
+    (CauserType.toAgentivity .intentionalHuman).sentience = true ∧
+    (CauserType.toAgentivity .intentionalHuman).instigation = true := ⟨rfl, rfl, rfl⟩
 
 /-- Accidental human causers retain sentience but lack volition. -/
 theorem accidental_sentient_not_volitional :
-    (CauserType.toAgentivityNode .accidentalHuman).sentience = true ∧
-    (CauserType.toAgentivityNode .accidentalHuman).volition = false := ⟨rfl, rfl⟩
+    (CauserType.toAgentivity .accidentalHuman).sentience = true ∧
+    (CauserType.toAgentivity .accidentalHuman).volition = false := ⟨rfl, rfl⟩
 
 /-- Natural force causers have only instigation (no sentience, no volition). -/
 theorem naturalForce_instigation_only :
-    (CauserType.toAgentivityNode .naturalForce) = ⟨false, false, true, false⟩ := rfl
+    (CauserType.toAgentivity .naturalForce) = .mk false false true false := rfl
 
 /-- All causer types project to external `CausalSource`. -/
 theorem all_causers_external (ct : CauserType) :

--- a/Linglib/Studies/Beavers2010.lean
+++ b/Linglib/Studies/Beavers2010.lean
@@ -430,7 +430,7 @@ theorem changed_lower_than_unaffected :
     `degreeToPersistence` correspondence for potential change. Beavers'
     surface-contact classification ([beavers-2011] eq. (60c)); note
     [grimm-2011]'s own Fig. 5 instead places contact-verb objects at
-    quPersBeginning (`TransitivityRank.contact.patientNode`), a genuine
+    quPersBeginning (`TransitivityRank.contact.patientType`), a genuine
     cross-paper disagreement over whether contact entails impingement. -/
 theorem kick_grimm_beavers_consistent :
     PersistenceLevel.fromPatientProfile contactObject = .totalPersistence ∧
@@ -466,32 +466,32 @@ theorem grimm_beavers_monotone_canonical :
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
--- § 11. ArgTemplate → GrimmNode Bridge
+-- § 11. ArgTemplate → ParticipantType Bridge
 -- ════════════════════════════════════════════════════
 
 /-! Cross-framework bridge from Levin/RHL `ArgTemplate` (event-template
-    decomposition) to Grimm's `GrimmNode` (privative agentivity lattice) and
+    decomposition) to Grimm's `ParticipantType` (privative agentivity lattice) and
     Beavers' affectedness degree. Each canonical template is verified to
     project into the predicted positions in both systems, and the consistency
     of affectedness ↔ persistence is checked. -/
 
 
-/-- Project an ArgTemplate's subject profile to a GrimmNode. -/
+/-- Project an ArgTemplate's subject profile to a ParticipantType. -/
 def _root_.Features.LevinClassProfiles.ArgTemplate.subjectGrimm
-    (t : ArgTemplate) : GrimmNode :=
-  GrimmNode.fromSubjectProfile t.subjectProfile
+    (t : ArgTemplate) : ParticipantType :=
+  ParticipantType.fromSubjectProfile t.subjectProfile
 
-/-- Project an ArgTemplate's object profile (if any) to a GrimmNode. -/
+/-- Project an ArgTemplate's object profile (if any) to a ParticipantType. -/
 def _root_.Features.LevinClassProfiles.ArgTemplate.objectGrimm
-    (t : ArgTemplate) : Option GrimmNode :=
-  t.objectProfile.map GrimmNode.fromObjectProfile
+    (t : ArgTemplate) : Option ParticipantType :=
+  t.objectProfile.map ParticipantType.fromObjectProfile
 
 /-- Project an ArgTemplate's object to its affectedness degree. -/
 def _root_.Features.LevinClassProfiles.ArgTemplate.objectAffectedness
     (t : ArgTemplate) : Option AffectednessDegree :=
   t.objectProfile.map profileToDegree
 
--- ── Per-template GrimmNode verification ──
+-- ── Per-template ParticipantType verification ──
 
 /-- Manner-contact subject → full agent on the Grimm lattice. -/
 theorem mannerContact_subject_grimm :

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -51,19 +51,19 @@ Subjects populating a maximal chain: positional verbs at ⊥, then know/see
 (+volition, = ⊤). -/
 
 /-- sit/stand subject: ⊥, p.523. -/
-def sitAgentivity : AgentivityNode := ⊥
+def sitAgentivity : Agentivity := ⊥
 
 /-- know/see subject: sentience only, p.523–524. -/
-def knowAgentivity : AgentivityNode := ⟨false, true, false, false⟩
+def knowAgentivity : Agentivity := .mk false true false false
 
 /-- discover subject: sentience + instigation, p.524. -/
-def discoverAgentivity : AgentivityNode := ⟨false, true, true, false⟩
+def discoverAgentivity : Agentivity := .mk false true true false
 
 /-- look at subject: sentience + instigation + motion, p.524. -/
-def lookAtAgentivity : AgentivityNode := ⟨false, true, true, true⟩
+def lookAtAgentivity : Agentivity := .mk false true true true
 
 /-- assassinate subject: all four features, p.524. -/
-def assassinateAgentivity : AgentivityNode := ⊤
+def assassinateAgentivity : Agentivity := ⊤
 
 /-- Each verb adds one feature: a strict chain from ⊥ to ⊤. -/
 theorem canonical_verb_chain :
@@ -86,17 +86,17 @@ substrate facts (`Agentivity/CaseRegions.lean`). -/
 /-- Class I/II patients are in the transitivity region; Class III (pursuit)
     is outside. -/
 theorem tsunoda_region_membership :
-    (TransitivityRank.resultativeEffective.patientNode).InTransitiveRegion ∧
-    (TransitivityRank.contact.patientNode).InTransitiveRegion ∧
-    ¬ (TransitivityRank.pursuit.patientNode).InTransitiveRegion := by decide
+    (TransitivityRank.resultativeEffective.patientType).InTransitiveRegion ∧
+    (TransitivityRank.contact.patientType).InTransitiveRegion ∧
+    ¬ (TransitivityRank.pursuit.patientType).InTransitiveRegion := by decide
 
 /-- Patient nodes are ordered III ≤ I ≤ II: lower persistence, more
     affected. -/
 theorem tsunoda_patient_chain :
-    TransitivityRank.pursuit.patientNode ≤
-      TransitivityRank.resultativeEffective.patientNode ∧
-    TransitivityRank.resultativeEffective.patientNode ≤
-      TransitivityRank.contact.patientNode := by decide
+    TransitivityRank.pursuit.patientType ≤
+      TransitivityRank.resultativeEffective.patientType ∧
+    TransitivityRank.resultativeEffective.patientType ≤
+      TransitivityRank.contact.patientType := by decide
 
 /-! ### Case regions for canonical verb classes (§4)
 
@@ -110,64 +110,64 @@ ACC/ABS — [grimm-2011]'s own Fig. 5 keeps them inside at `quPersBeginning`. -/
     profile — a flagged mis-prediction (English gives contact objects plain
     ACC) inherited from the Fig. 5 deviation. -/
 theorem kick_case_regions :
-    (GrimmNode.fromSubjectProfile mannerContact.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile mannerContact.subjectProfile).toCaseRegion
       = .nomErg ∧
-    (GrimmNode.fromObjectProfile contactObject).toCaseRegion = .oblique := by
+    (ParticipantType.fromObjectProfile contactObject).toCaseRegion = .oblique := by
   decide
 
 /-- kick/eat objects are in the transitivity region; build objects (not
     existing at event start, p.529–530) are not. -/
 theorem kick_object_in_region :
-    (GrimmNode.fromObjectProfile contactObject).InTransitiveRegion ∧
-    (GrimmNode.fromObjectProfile consumptionObject).InTransitiveRegion ∧
-    ¬ (GrimmNode.fromObjectProfile creationObject).InTransitiveRegion := by
+    (ParticipantType.fromObjectProfile contactObject).InTransitiveRegion ∧
+    (ParticipantType.fromObjectProfile consumptionObject).InTransitiveRegion ∧
+    ¬ (ParticipantType.fromObjectProfile creationObject).InTransitiveRegion := by
   decide
 
 /-- build: subject → NOM/ERG; the created object (`exPersEnd`) → oblique. -/
 theorem build_case_regions :
-    (GrimmNode.fromSubjectProfile creation.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile creation.subjectProfile).toCaseRegion
       = .nomErg ∧
-    (GrimmNode.fromObjectProfile creationObject).toCaseRegion = .oblique := by
+    (ParticipantType.fromObjectProfile creationObject).toCaseRegion = .oblique := by
   decide
 
 /-- eat: subject → NOM/ERG; the consumed object → ACC/ABS, with destroyed
     objects. -/
 theorem eat_case_regions :
-    (GrimmNode.fromSubjectProfile consumption.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile consumption.subjectProfile).toCaseRegion
       = .nomErg ∧
-    (GrimmNode.fromObjectProfile consumptionObject).toCaseRegion
+    (ParticipantType.fromObjectProfile consumptionObject).toCaseRegion
       = .accAbs := by decide
 
 /-- buy/sell: subject → NOM/ERG. Buyer and seller share one profile — the
     [dowty-1991] §3.2 alternation tie. -/
 theorem possessionTransfer_case_region :
-    (GrimmNode.fromSubjectProfile possessionTransfer.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile possessionTransfer.subjectProfile).toCaseRegion
       = .nomErg := by decide
 
 /-- see: sentience without instigation → oblique. Experiencer *subjects*
     land outside the dative region — `fromSubjectProfile` fixes total
     persistence, the dative region needs `quPersBeginning`. -/
 theorem see_case_region :
-    (GrimmNode.fromSubjectProfile perception.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile perception.subjectProfile).toCaseRegion
       = .oblique := by decide
 
 /-- run: volition + sentience + motion without instigation → oblique,
     matching unergative behaviour in split-S systems. -/
 theorem run_case_region :
-    (GrimmNode.fromSubjectProfile selfMotion.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile selfMotion.subjectProfile).toCaseRegion
       = .oblique := by decide
 
 /-- arrive: motion only → oblique. -/
 theorem arrive_case_region :
-    (GrimmNode.fromSubjectProfile directedMotion.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile directedMotion.subjectProfile).toCaseRegion
       = .oblique := by decide
 
 /-- die: the sole argument, read as patient, → ACC/ABS; ergative readout
     ABS — the unaccusative pattern. -/
 theorem die_case_region :
-    (GrimmNode.fromObjectProfile disappearance.subjectProfile).toCaseRegion
+    (ParticipantType.fromObjectProfile disappearance.subjectProfile).toCaseRegion
       = .accAbs ∧
-    (GrimmNode.fromObjectProfile disappearance.subjectProfile).toCaseRegion.toErgativeCase
+    (ParticipantType.fromObjectProfile disappearance.subjectProfile).toCaseRegion.toErgativeCase
       = .abs := by decide
 
 /-- Instigation (Dowty's causation) exactly divides NOM/ERG subjects from
@@ -190,15 +190,15 @@ natural forces to intentional agents. -/
 
 /-- Everything above *kill*'s minimal agent is NOM/ERG: upward closure plus
     the interval characterization `toCaseRegion_eq_nomErg_iff`. -/
-theorem kill_subject_range {n : GrimmNode} (h : minimalInstigator ≤ n) :
+theorem kill_subject_range {n : ParticipantType} (h : minimalInstigator ≤ n) :
     n.toCaseRegion = .nomErg :=
-  (GrimmNode.toCaseRegion_eq_nomErg_iff n).mpr h
+  (ParticipantType.toCaseRegion_eq_nomErg_iff n).mpr h
 
 /-- The range's endpoints, derived: electricity (instigation only) and the
     assassin (⊤) are both acceptable *kill*-subjects. -/
 theorem kill_subject_endpoints :
     minimalInstigator.toCaseRegion = .nomErg ∧
-    (⊤ : GrimmNode).toCaseRegion = .nomErg :=
+    (⊤ : ParticipantType).toCaseRegion = .nomErg :=
   ⟨kill_subject_range le_rfl, kill_subject_range le_top⟩
 
 /-! ### Accusative and ergative alignment (§4, Fig. 6)
@@ -218,9 +218,9 @@ theorem ergative_alignment :
 
 /-- eat in an accusative system: NOM subject, ACC object. -/
 theorem eat_alignment :
-    (GrimmNode.fromSubjectProfile consumption.subjectProfile).toCaseRegion.toAccusativeCase
+    (ParticipantType.fromSubjectProfile consumption.subjectProfile).toCaseRegion.toAccusativeCase
       = .nom ∧
-    (GrimmNode.fromObjectProfile consumptionObject).toCaseRegion.toAccusativeCase
+    (ParticipantType.fromObjectProfile consumptionObject).toCaseRegion.toAccusativeCase
       = .acc := by decide
 
 /-! ### Differential object marking (§4, p.534; [grimm-2005])
@@ -237,9 +237,9 @@ transitivity region but outside ACC/ABS. Grimm himself (following
     inanimate ↦ ⊥. Instigation and motion are event-bound, so never
     contributed; denying animates volition keeps the hierarchy strict — a
     modelling choice, not Grimm's. -/
-def animacyToAgentivity : AnimacyLevel → AgentivityNode
-  | .human     => ⟨true, true, false, false⟩
-  | .animate   => ⟨false, true, false, false⟩
+def animacyToAgentivity : AnimacyLevel → Agentivity
+  | .human     => .mk true true false false
+  | .animate   => .mk false true false false
   | .inanimate => ⊥
 
 /-- All animacy-derived nodes satisfy volition → sentience. -/
@@ -254,7 +254,7 @@ theorem animacyToAgentivity_monotone : Monotone animacyToAgentivity :=
 
 /-- Animacy-derived agentivity × the verb's object persistence. -/
 def objectNodeWithAnimacy (a : AnimacyLevel) (p : PersistenceLevel) :
-    GrimmNode :=
+    ParticipantType :=
   ⟨animacyToAgentivity a, p⟩
 
 /-- The key non-circular derivation: at `quPersBeginning`, `toCaseRegion` —
@@ -268,12 +268,12 @@ theorem object_regions_by_animacy :
     (objectNodeWithAnimacy .human .quPersBeginning).toCaseRegion
       = .dative := by decide
 
-/-- The animate DOM object at `quPersBeginning` IS `sentientNonInstigatorNode`
+/-- The animate DOM object at `quPersBeginning` IS `sentientNonInstigator`
     — one lattice point shared with recipients and experiencers (Fig. 7).
     On this account DOM marking is dative marking (Spanish *a*). -/
 theorem animate_dom_object_is_dative_node :
     objectNodeWithAnimacy .animate .quPersBeginning
-      = sentientNonInstigatorNode := rfl
+      = sentientNonInstigator := rfl
 
 /-- DOM is predicted: the object node is in the transitivity region but
     outside ACC/ABS. -/
@@ -378,7 +378,7 @@ side of the same opposition.) -/
 
 /-- The subject profile lands in NOM/ERG. -/
 def SubjectInAgentRegion (p : EntailmentProfile) : Prop :=
-  (GrimmNode.fromSubjectProfile p).toCaseRegion = .nomErg
+  (ParticipantType.fromSubjectProfile p).toCaseRegion = .nomErg
 
 instance (p : EntailmentProfile) : Decidable (SubjectInAgentRegion p) := by
   unfold SubjectInAgentRegion; infer_instance
@@ -387,7 +387,7 @@ instance (p : EntailmentProfile) : Decidable (SubjectInAgentRegion p) := by
     maximal contrast (*matar*). -/
 theorem kill_type_maximal_contrast :
     SubjectInAgentRegion accomplishmentSubjectProfile ∧
-    (GrimmNode.fromObjectProfile accomplishmentObjectProfile).toCaseRegion
+    (ParticipantType.fromObjectProfile accomplishmentObjectProfile).toCaseRegion
       = .accAbs := by decide
 
 /-- Perception subjects fall outside NOM/ERG — reduced contrast (*ver*). -/
@@ -407,10 +407,10 @@ accusative under the specific reading and genitive under the non-specific
 one — a case contrast between two lattice nodes. -/
 
 /-- Specific reading: the object exists — `exPersBeginning`. -/
-def specificIntensionalObject : GrimmNode := ⟨⊥, .exPersBeginning⟩
+def specificIntensionalObject : ParticipantType := ⟨⊥, .exPersBeginning⟩
 
 /-- Non-specific reading: existence not entailed — total non-persistence. -/
-def nonspecificIntensionalObject : GrimmNode := ⟨⊥, .totalNonPersistence⟩
+def nonspecificIntensionalObject : ParticipantType := ⟨⊥, .totalNonPersistence⟩
 
 /-- The specific reading sits in the ACC/ABS region. -/
 theorem specific_reading_in_accAbs :
@@ -446,21 +446,21 @@ theorem desire_object_bridge_tension :
 
 §2.1 recasts Dowty's ten entailments as four agentivity features plus
 persistence; the projection kernel is
-`AgentivityNode.fromEntailmentProfile_eq_iff`. Below: what the recast loses
+`Agentivity.fromEntailmentProfile_eq_iff`. Below: what the recast loses
 (Dowty's pairing constraints) and what it fixes (the *arrive* anomaly) —
 cross-theory checks absorbed from `Studies/Dowty1991.lean`, since the
 comparison belongs to the later paper. -/
 
 /-- Dowty's `WellFormedPair` is invisible to the projection: a {C} and a
     {C, IE} subject project to the same node (IE is dropped,
-    `AgentivityNode.fromEntailmentProfile_eq_iff`), yet against a {CoS}
+    `Agentivity.fromEntailmentProfile_eq_iff`), yet against a {CoS}
     object only the first satisfies the IE→DE pairing constraint. -/
 theorem wellFormedPair_not_preserved :
     WellFormedPair { causation := true } { changeOfState := true } ∧
     ¬ WellFormedPair { causation := true, independentExistence := true }
         { changeOfState := true } ∧
-    GrimmNode.fromSubjectProfile { causation := true }
-      = GrimmNode.fromSubjectProfile
+    ParticipantType.fromSubjectProfile { causation := true }
+      = ParticipantType.fromSubjectProfile
           { causation := true, independentExistence := true } := by decide
 
 /-- The *arrive* anomaly resolved: Table 1, the priority ASP, and the
@@ -470,14 +470,14 @@ theorem arrive_cross_theory :
         directedMotion.subjectProfile.changeOfState = .unaccusative ∧
     PredictsUnaccusative directedMotion.subjectProfile ∧
     Dowty1991.flatPredictsUnaccusative directedMotion.subjectProfile = false ∧
-    (GrimmNode.fromSubjectProfile directedMotion.subjectProfile).toCaseRegion
+    (ParticipantType.fromSubjectProfile directedMotion.subjectProfile).toCaseRegion
       ≠ .nomErg := by decide
 
 /-- kick: ASP outranking and the lattice's subject region agree — NOM
     subject. -/
 theorem kick_asp_grimm_consistent :
     OutranksForSubject mannerContact.subjectProfile contactObject ∧
-    (GrimmNode.fromSubjectProfile mannerContact.subjectProfile).toCaseRegion.toAccusativeCase
+    (ParticipantType.fromSubjectProfile mannerContact.subjectProfile).toCaseRegion.toAccusativeCase
       = .nom := by decide
 
 /-- die: priority ASP, flat counting, and the lattice agree on
@@ -485,14 +485,14 @@ theorem kick_asp_grimm_consistent :
 theorem die_asp_grimm_consistent :
     PredictsUnaccusative disappearance.subjectProfile ∧
     Dowty1991.flatPredictsUnaccusative disappearance.subjectProfile = true ∧
-    (GrimmNode.fromObjectProfile disappearance.subjectProfile).toCaseRegion
+    (ParticipantType.fromObjectProfile disappearance.subjectProfile).toCaseRegion
       = .accAbs := by decide
 
 /-- kiss: the subject strictly dominates the object on the lattice —
     `Dowty1991.kiss_asymmetry_is_volition` as order. -/
 theorem kiss_subject_dominates :
-    AgentivityNode.fromEntailmentProfile Dowty1991.kissObjectProfile <
-      AgentivityNode.fromEntailmentProfile Dowty1991.kissSubjectProfile := by
+    Agentivity.fromEntailmentProfile Dowty1991.kissObjectProfile <
+      Agentivity.fromEntailmentProfile Dowty1991.kissSubjectProfile := by
   decide
 
 /-- Subject selection for *kiss* from lattice dominance alone
@@ -510,7 +510,7 @@ theorem kiss_flat_count_from_lattice :
       Dowty1991.kissSubjectProfile.pAgentScore := by
   rw [pAgentScore_decomposition, pAgentScore_decomposition]
   exact Nat.add_le_add
-    (AgentivityNode.featureCount_monotone kiss_subject_dominates.le) le_rfl
+    (Agentivity.featureCount_monotone kiss_subject_dominates.le) le_rfl
 
 /-! ### Grimm vs dependent case
 
@@ -537,22 +537,22 @@ chain's know/see node. (The *sweep* pair lives in
 
 /-- kick subject: full agent (⊤). -/
 theorem kick_subject_agentivity :
-    AgentivityNode.fromEntailmentProfile mannerContact.subjectProfile = ⊤ :=
-  rfl
+    Agentivity.fromEntailmentProfile mannerContact.subjectProfile = ⊤ := by
+  decide
 
 /-- run subject: {V, S, M} — no instigation. -/
 theorem run_subject_agentivity :
-    AgentivityNode.fromEntailmentProfile selfMotion.subjectProfile
-      = ⟨true, true, false, true⟩ := rfl
+    Agentivity.fromEntailmentProfile selfMotion.subjectProfile
+      = .mk true true false true := rfl
 
 /-- arrive subject: {M}. -/
 theorem arrive_subject_agentivity :
-    AgentivityNode.fromEntailmentProfile directedMotion.subjectProfile
-      = ⟨false, false, false, true⟩ := rfl
+    Agentivity.fromEntailmentProfile directedMotion.subjectProfile
+      = .mk false false false true := rfl
 
 /-- see subject: the chain's know/see node. -/
 theorem see_subject_agentivity :
-    AgentivityNode.fromEntailmentProfile perception.subjectProfile
+    Agentivity.fromEntailmentProfile perception.subjectProfile
       = knowAgentivity := rfl
 
 end Grimm2011

--- a/Linglib/Studies/RappaportHovavLevin2024.lean
+++ b/Linglib/Studies/RappaportHovavLevin2024.lean
@@ -546,19 +546,19 @@ theorem sweep_senses_match_templates :
 /-- Basic-*sweep* projects to {motion} on [grimm-2011]'s agentivity lattice —
     the lattice image of variable agentivity. -/
 theorem wipeManner_agentivity :
-    AgentivityNode.fromEntailmentProfile wipeManner.subjectProfile
-      = ⟨false, false, false, true⟩ := rfl
+    Agentivity.fromEntailmentProfile wipeManner.subjectProfile
+      = .mk false false false true := rfl
 
 /-- Broom-*sweep* projects to the full agent {V, S, I, M}. -/
 theorem wipeInstrument_agentivity :
-    AgentivityNode.fromEntailmentProfile wipeInstrument.subjectProfile
-      = ⟨true, true, true, true⟩ := rfl
+    Agentivity.fromEntailmentProfile wipeInstrument.subjectProfile
+      = ⊤ := by decide
 
 /-- Instrument lexicalization strictly raises agentivity on the lattice:
     the paper's obligatory-agentivity claim as strict lattice dominance. -/
 theorem instrument_lexicalization_increases_agentivity :
-    AgentivityNode.fromEntailmentProfile wipeManner.subjectProfile <
-      AgentivityNode.fromEntailmentProfile wipeInstrument.subjectProfile := by
+    Agentivity.fromEntailmentProfile wipeManner.subjectProfile <
+      Agentivity.fromEntailmentProfile wipeInstrument.subjectProfile := by
   decide
 
 end AgentivityBridge


### PR DESCRIPTION
Deeper cleanup following #1332: `Agentivity` is now literally the Boolean cube `Agentivity.Feature → Bool` — `DecidableEq`/`Fintype`/full `BooleanAlgebra` inherited pointwise from Pi instances, replacing ~60 lines of hand-rolled `Lattice`/`decide` structure (field access preserved via accessors; `.mk` replaces tuple literals).

- Renames: `AgentivityNode` → `Agentivity`, `GrimmNode` → `ParticipantType` (Grimm's own term), `patientNode` → `patientType`, `sentientNonInstigatorNode` → `sentientNonInstigator`.