### PR TITLE
feat(Semantics/Focus): anti-pied-piping (Branan-Erlewine 2023)

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2043,6 +2043,7 @@ import Linglib.Studies.BonehDoron2013
 import Linglib.Studies.Booth2022
 import Linglib.Studies.Borer2005
 import Linglib.Studies.Boylan2023
+import Linglib.Studies.BrananErlewine2023
 import Linglib.Studies.Brandom1994
 import Linglib.Studies.BrehenyEtAl2018
 import Linglib.Studies.BreissKatsudaKawahara2026

--- a/Linglib/Semantics/Focus/Realization.lean
+++ b/Linglib/Semantics/Focus/Realization.lean
@@ -26,10 +26,12 @@ universalist claim that every focus receives an overt reflex.
 
 String-vacuous operations (Hausa subject fronting) contribute no
 reflex: the reflex list carries only perceptible material, which is
-what makes `IsOvert` honest. Host-vs-focus tightness relations
-(and the overlap-weakening of [hartmann-zimmermann-2007]'s Ex-Situ
-Generalisation) are deferred until pied-piping data land; note
-`Mereology.Overlap` is vacuous over orders with a bottom, so that
+what makes `IsOvert` honest. With constituents ordered by containment,
+a reflex host and the focus stand in the exact / pied-piping /
+anti-pied-piping relations of [branan-erlewine-2023] (`ExactlyTargets`,
+`PiedPipes`, `AntiPiedPipes`). The overlap-weakening of
+[hartmann-zimmermann-2007]'s Ex-Situ Generalisation remains deferred;
+note `Mereology.Overlap` is vacuous over orders with a bottom, so that
 member must use `¬ Disjoint` or bot-free carriers.
 -/
 
@@ -53,6 +55,14 @@ inductive Reflex (C : Type*) where
   | prominence (host : C)
   deriving DecidableEq, Repr
 
+/-- The constituent a reflex marks: the displaced exponent, or the host
+of a morpheme, boundary, or prominence. -/
+def Reflex.host : Reflex C → C
+  | .displacement exponent => exponent
+  | .morpheme host => host
+  | .boundary edge => edge
+  | .prominence host => host
+
 /-- A focus realization: the focus constituent and the grammatical
 reflexes marking it. -/
 structure Realization (C : Type*) where
@@ -67,6 +77,53 @@ instance (r : Realization C) : Decidable r.IsOvert :=
   match h : r.reflexes with
   | []     => isFalse fun hne => hne h
   | _ :: _ => isTrue (by simp [Realization.IsOvert, h])
+
+/-! ### Host–focus containment
+
+With constituents ordered by containment, a reflex host stands in one of
+three relations to the focus: exact targeting, pied-piping (host properly
+contains the focus), or [branan-erlewine-2023]'s anti-pied-piping (host
+properly contained in the focus, attested in over sixty languages). -/
+
+section Containment
+
+variable [PartialOrder C] {r : Realization C}
+
+/-- Some reflex targets a constituent properly containing the focus —
+Ross's pied-piping, generalized from movement to all focus morphosyntax
+by [branan-erlewine-2023]. -/
+def Realization.PiedPipes (r : Realization C) : Prop :=
+  ∃ ρ ∈ r.reflexes, r.focus < ρ.host
+
+/-- Some reflex targets a proper subconstituent of the focus —
+[branan-erlewine-2023]'s anti-pied-piping. -/
+def Realization.AntiPiedPipes (r : Realization C) : Prop :=
+  ∃ ρ ∈ r.reflexes, ρ.host < r.focus
+
+/-- Every reflex targets the focus itself. -/
+def Realization.ExactlyTargets (r : Realization C) : Prop :=
+  ∀ ρ ∈ r.reflexes, ρ.host = r.focus
+
+instance [DecidableLT C] (r : Realization C) : Decidable r.PiedPipes :=
+  inferInstanceAs (Decidable (∃ _ ∈ _, _))
+
+instance [DecidableLT C] (r : Realization C) : Decidable r.AntiPiedPipes :=
+  inferInstanceAs (Decidable (∃ _ ∈ _, _))
+
+instance [DecidableEq C] (r : Realization C) : Decidable r.ExactlyTargets :=
+  inferInstanceAs (Decidable (∀ _ ∈ _, _))
+
+/-- A pied-piping realization does not exactly target its focus. -/
+theorem Realization.PiedPipes.not_exactlyTargets (h : r.PiedPipes) :
+    ¬ r.ExactlyTargets :=
+  fun he => let ⟨ρ, hm, hlt⟩ := h; absurd (he ρ hm).symm (ne_of_lt hlt)
+
+/-- An anti-pied-piping realization does not exactly target its focus. -/
+theorem Realization.AntiPiedPipes.not_exactlyTargets (h : r.AntiPiedPipes) :
+    ¬ r.ExactlyTargets :=
+  fun he => let ⟨ρ, hm, hlt⟩ := h; absurd (he ρ hm) (ne_of_lt hlt)
+
+end Containment
 
 /-- The universalist claim over a marking system `realize`: every focus
 receives an overt reflex. Hausa and Tangale each refute their

--- a/Linglib/Studies/BrananErlewine2023.lean
+++ b/Linglib/Studies/BrananErlewine2023.lean
@@ -1,0 +1,124 @@
+import Linglib.Semantics.Focus.Realization
+
+/-!
+# Branan and Erlewine 2023: Anti-pied-piping
+
+[branan-erlewine-2023] documents anti-pied-piping — focus morphosyntax
+(particle placement, focus movement) targeting a proper subpart of the
+logical focus — in over sixty languages from over forty language
+groups, and proposes that focus particles are morphosyntactic flags
+for abstract operators, severing the particle's pronounced position
+from the position of its semantic contribution. This file formalizes
+the introductory paradigm (their (1)–(8)): Japanese *mo* placement and
+Hungarian focus movement each attest exact targeting, pied-piping, and
+anti-pied-piping, stated over the host–focus containment relations of
+`Semantics/Focus/Realization.lean`.
+
+## Main declarations
+
+* `BrananErlewine2023.Node`: the clause skeleton of the paradigm.
+* `mo_attests_all_relations` / `movement_attests_all_relations`:
+  particle placement and focus movement each realize all three
+  host–focus relations.
+* `msf_tolerates_mismatches`: neither process strictly targets the
+  F-marked constituent — the shape of the paper's argument that focus
+  morphosyntax targets a particle phrase rather than F itself.
+
+## TODO
+
+* The leftmost-targeting generalization of their §3 (requires linear
+  order on constituents).
+* The particle-phrase theory of their §4 and the cross-linguistic
+  appendix as `Data/Examples` rows.
+-/
+
+namespace BrananErlewine2023
+
+open Semantics.Focus
+
+/-! ### The clause skeleton -/
+
+/-- Clause skeleton for the introductory paradigm: an attributive
+adjective within the object DP; verb and object within VP; subject and
+VP within S. -/
+inductive Node where
+  | s | sbj | vp | v | obj | att
+  deriving DecidableEq, Repr, Fintype
+
+/-- Constituent containment. -/
+def nle : Node → Node → Bool
+  | _, .s => true
+  | .v, .vp | .obj, .vp | .att, .vp | .vp, .vp => true
+  | .att, .obj | .obj, .obj => true
+  | .sbj, .sbj | .v, .v | .att, .att => true
+  | _, _ => false
+
+instance : PartialOrder Node where
+  le a b := nle a b = true
+  le_refl := by decide
+  le_trans := by decide
+  le_antisymm := by decide
+
+instance : DecidableLE Node := fun _ _ =>
+  inferInstanceAs (Decidable (_ = true))
+
+instance : DecidableLT Node := fun a b =>
+  inferInstanceAs (Decidable (a ≤ b ∧ ¬ b ≤ a))
+
+/-! ### The introductory paradigm
+
+Their (1)–(8): Japanese additive *mo* and Hungarian focus movement in
+all three host–focus configurations. -/
+
+/-- Their (2): Hanako-wa [hon]F*-mo* katta — *mo* on the focused object
+itself. -/
+def moExact : Realization Node := ⟨.obj, [.morpheme .obj]⟩
+
+/-- Their (4): Hanako-wa [[hon]F-o kai]*-mo* — *mo* on the VP properly
+containing the focused object (Kuroda's pied-piping datum). -/
+def moPiedPiped : Realization Node := ⟨.obj, [.morpheme .vp]⟩
+
+/-- Their (8): [[Ame]*-mo* furu]F — sentence focus with *mo* on the
+subject properly contained in it (Nagano's anti-pied-piping datum). -/
+def moAntiPiedPiped : Realization Node := ⟨.s, [.morpheme .sbj]⟩
+
+/-- Their (1): Hungarian movement of exactly the focused argument to
+the immediately preverbal focus position. -/
+def movementExact : Realization Node := ⟨.obj, [.displacement .obj]⟩
+
+/-- Their (3): [a [használt]F autót] adta el — the whole object DP moves
+for a focus on the attributive adjective (Kenesei's pied-piping
+datum). -/
+def movementPiedPiped : Realization Node := ⟨.att, [.displacement .obj]⟩
+
+/-- Their (7): Péter [a Hamletet] [olvasta fel _ a kertben]F — predicate
+focus with movement of the object properly contained in it (Kenesei's
+anti-pied-piping datum). -/
+def movementAntiPiedPiped : Realization Node := ⟨.vp, [.displacement .obj]⟩
+
+/-! ### All three relations, in both processes -/
+
+/-- Japanese *mo* placement attests all three host–focus relations
+(their (2)/(4)/(8)). -/
+theorem mo_attests_all_relations :
+    moExact.ExactlyTargets ∧ moPiedPiped.PiedPipes ∧
+    moAntiPiedPiped.AntiPiedPipes := by decide
+
+/-- Hungarian focus movement attests all three host–focus relations
+(their (1)/(3)/(7)). -/
+theorem movement_attests_all_relations :
+    movementExact.ExactlyTargets ∧ movementPiedPiped.PiedPipes ∧
+    movementAntiPiedPiped.AntiPiedPipes := by decide
+
+/-- Neither particle placement nor focus movement strictly targets the
+F-marked constituent: each tolerates mismatches in both directions. -/
+theorem msf_tolerates_mismatches :
+    ¬ moPiedPiped.ExactlyTargets ∧ ¬ moAntiPiedPiped.ExactlyTargets ∧
+    ¬ movementPiedPiped.ExactlyTargets ∧
+    ¬ movementAntiPiedPiped.ExactlyTargets :=
+  ⟨mo_attests_all_relations.2.1.not_exactlyTargets,
+   mo_attests_all_relations.2.2.not_exactlyTargets,
+   movement_attests_all_relations.2.1.not_exactlyTargets,
+   movement_attests_all_relations.2.2.not_exactlyTargets⟩
+
+end BrananErlewine2023

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -31855,6 +31855,21 @@
 %  Martínez Vera 2026 cite chain (verum/contrast/evidentiality, Quechuan
 %  evidentials, focus apparatus, methodology)
 
+@article{branan-erlewine-2023,
+  author    = {Branan, Kenyon and Erlewine, Michael Yoshitaka},
+  year      = {2023},
+  title     = {Anti-pied-piping},
+  journal   = {Language},
+  volume    = {99},
+  number    = {3},
+  pages     = {603--653},
+  doi       = {10.1353/lan.2023.a907013},
+  subfield  = {semantics/focus},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Studies/BrananErlewine2023.lean;Semantics/Focus/Realization.lean}
+}
+
 @article{martinez-vera-2026,
   author    = {Mart{\'i}nez Vera, Gabriel},
   year      = {2026},


### PR DESCRIPTION
Adds the host-vs-focus containment axis the Realization API had deferred until pied-piping data landed.

- `Reflex.host` + `ExactlyTargets`/`PiedPipes`/`AntiPiedPipes` over a containment `PartialOrder`, with decidability instances and the two mismatch-excludes-exact lemmas.
- `Studies/BrananErlewine2023.lean`: the paper's introductory paradigm (exx. 1–8) — Japanese *mo* placement and Hungarian focus movement each attest all three relations, so neither process strictly targets F.
- Verified bib entry `branan-erlewine-2023` (Language 99(3): 603–653, DOI checked against the author page and the Helsinki research portal).