### PR TITLE
docs(Fragments/Mayan/Kaqchikel): mathlib-register docstrings

### DIFF
--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -5,24 +5,16 @@ import Linglib.Fragments.Mayan.Params
 /-!
 # Kaqchikel Agreement Fragment
 
-Theory-neutral typological metadata for Kaqchikel (K'ichean, Mayan)
-agreement morphology, from [preminger-2014] (whose Kichean data ground
-the book's argument): paradigm exponents, person-number cells, and
-argument positions.
+Typological metadata for Kaqchikel (K'ichean, Mayan) agreement
+morphology, following [preminger-2014]: paradigm exponents,
+person-number cells, and argument positions.
 
-Kaqchikel cross-references both transitive arguments: Set A (ERG)
-prefixes on Voice/v index the transitive agent, and Set B (ABS)
-pre-stem markers on Infl/T index the absolutive argument (transitive
-patient or intransitive S). Morpheme order is aspect–ABS–ERG–stem
-([preminger-2014] (12)): Set B precedes Set A. This contrasts with San
-Juan Atitán Mam, where Infl's φ-probe is blocked in transitives and the
-patient goes unagreed ([scott-2023]; see `Mam/Agreement.lean`) — the
-non-differential/differential contrast pair consumed by
-`Studies/Aissen2003Agreement.lean`. In AF constructions the two
-agreement slots collapse to a single marker drawn from the Set B
-paradigm; the empirical AF agreement table ([preminger-2014] §3.2,
-table (22)) and the two-probe choice rule that predicts it live in
-`Studies/Preminger2014.lean`.
+Kaqchikel cross-references both transitive arguments. Set A (ERG)
+prefixes index the transitive agent; Set B (ABS) pre-stem markers
+index the absolutive argument (transitive patient or intransitive S);
+morpheme order is aspect–ABS–ERG–stem, so Set B precedes Set A
+([preminger-2014] (12)). In Agent Focus constructions the two slots
+collapse to a single marker drawn from the Set B paradigm.
 
 ## Main declarations
 
@@ -39,7 +31,13 @@ table (22)) and the two-probe choice rule that predicts it live in
 
 Hosting Set A on Voice/v and Set B on Infl/T follows the standard
 high-abs analysis (consistent with [preminger-2014] and
-[coon-mateo-pedro-preminger-2014]). The non-perfective `accCase`
+[coon-mateo-pedro-preminger-2014]). Kaqchikel indexes every core
+argument, in contrast with San Juan Atitán Mam, where Infl's φ-probe
+is blocked in transitives and the patient goes unagreed ([scott-2023];
+see `Mam/Agreement.lean`) — the non-differential/differential pair
+consumed by `Studies/Aissen2003Agreement.lean`. The AF agreement table
+([preminger-2014] §3.2, table (22)) and the choice rule that predicts
+it live in `Studies/Preminger2014.lean`. The non-perfective `accCase`
 records [imanishi-2014]'s analysis of the progressive *ajin*
 construction — an analysis, not consensus typology; the derivation
 lives with `Mayan.accCaseKaqchikel` in `Fragments/Mayan/Params.lean`.

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -41,6 +41,7 @@ it live in `Studies/Preminger2014.lean`. The non-perfective `accCase`
 records [imanishi-2014]'s analysis of the progressive *ajin*
 construction — an analysis, not consensus typology; the derivation
 lives with `Mayan.accCaseKaqchikel` in `Fragments/Mayan/Params.lean`.
+Parenthesized exponent segments drop in certain phonological contexts.
 Person-number cells come from the canonical `Agreement.Cell`
 (`Syntax/Agreement/Paradigm.lean`).
 -/
@@ -53,64 +54,43 @@ open Features.Prominence (ArgumentRole)
 
 /-! ### ABS position (HIGH-ABS) -/
 
-/-- Kaqchikel's absolutive morphemes appear in HIGH position (between
-    the aspect marker and the verb stem): aspect–ABS–ERG–stem
-    ([preminger-2014] (12)). -/
+/-- HIGH-ABS: the absolutive markers sit between the aspect marker and the stem. -/
 def absPosition : Mayan.ABSPosition := .high
 
 /-! ### Set A (ERG) exponents -/
 
-/-- Set A (ERG) markers: prefixes on Voice/v cross-referencing the
-    transitive agent ([preminger-2014] Ch. 3, table (29)).
-    Parenthesized segments are dropped in certain phonological
-    contexts. -/
+/-- Set A (ERG) markers ([preminger-2014] table (29)). -/
 def setAExponent : ExponentTable :=
   [(.pn .first .Sing, "n/w-"), (.pn .second .Sing, "a(w)-"), (.pn .third .Sing, "r(u)/u-"),
    (.pn .first .Plur, "q(a)-"), (.pn .second .Plur, "i(w)-"), (.pn .third .Plur, "k(i)-")]
 
 /-! ### Set B (ABS) exponents -/
 
-/-- Set B (ABS) markers: pre-stem markers on Infl/T cross-referencing
-    the absolutive argument ([preminger-2014] table (29)). The 3SG form
-    (∅) is also the Elsewhere entry — the default when no more specific
-    entry matches, as in the failure case of obligatory agreement
-    (Ch. 5). Citation forms: 1SG and 2SG are *i(n)-* and *a(t)-*, whose
-    parenthesized segments drop in certain phonological contexts (e.g.,
-    1SG surfaces as *i-* in *x-i-tz'et-ö*); the grapheme *j* (as in
-    *oj-*) is a voiceless velar fricative. -/
+/-- Set B (ABS) markers; ∅ 3SG doubles as the Elsewhere default
+    ([preminger-2014] table (29), Ch. 5). -/
 def setBExponent : ExponentTable :=
   [(.pn .first .Sing, "in-"), (.pn .second .Sing, "at-"), (.pn .third .Sing, "∅"),
    (.pn .first .Plur, "oj-"), (.pn .second .Plur, "ix-"), (.pn .third .Plur, "e-")]
 
 /-! ### Argument positions -/
 
-/-- Argument positions in a Kaqchikel clause. Aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
-    cross-framework code shares one inventory. Use the canonical
-    constructor names `.A` (transitive agent), `.P` (transitive
-    patient), `.S` (intransitive subject) directly. -/
+/-- Argument positions, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
 abbrev ArgPosition := Features.Prominence.ArgumentRole
 
-/-- Perfective (ergative) case assignment for Kaqchikel — definitionally
-    `Mayan.ergCaseKaqchikel`, derived from `Alignment.ergative.assignCase`
-    in `Syntax/Case/Alignment.lean`: A → ERG, S/P → ABS. -/
+/-- Perfective (ergative) case assignment: `Mayan.ergCaseKaqchikel`
+    (A → ERG, S/P → ABS). -/
 abbrev ArgPosition.case : ArgPosition → Case :=
   Mayan.ergCaseKaqchikel
 
-/-- Non-perfective (PROG *ajin*) case assignment — definitionally
-    `Mayan.accCaseKaqchikel`: [imanishi-2014]'s inverted pattern
-    (S/A → ABS, P → ERG/GEN); see `Fragments/Mayan/Params.lean` for the
-    derivation and [imanishi-2020] for the parameterization. -/
+/-- Non-perfective (PROG *ajin*) case assignment: `Mayan.accCaseKaqchikel`
+    (S/A → ABS, P → ERG/GEN, per [imanishi-2014]). -/
 abbrev ArgPosition.accCase : ArgPosition → Case :=
   Mayan.accCaseKaqchikel
 
-/-- Does this position participate in φ-Agree?
-    In Kaqchikel, ALL core argument positions trigger agreement:
-    agent via Set A on Voice/v, patient and intranS via Set B on
-    Infl/T. This contrasts with San Juan Atitán Mam, where the patient
-    is NOT agreed with (Infl's probe is blocked by VoiceP;
-    [scott-2023]). Ditransitive R/T default to participating
-    (Kaqchikel ditransitive agreement not modeled in this fragment). -/
+/-- Every position triggers φ-agreement — Kaqchikel is non-differential
+    (contrast `Mam.ArgPosition.IsPhiAgreed`); R/T default to
+    participating. -/
 def ArgPosition.IsPhiAgreed : ArgPosition → Prop
   | .A | .P | .S | .R | .T => True
 
@@ -120,11 +100,8 @@ instance : DecidablePred ArgPosition.IsPhiAgreed := fun p =>
 
 /-! ### Verification: argument positions
 
-The per-position case facts are the ergative-alignment facts
-(`Alignment.ergative`) — Kaqchikel's perfective case function is
-`Alignment.ergative.assignCase` by definition, so each theorem below is
-a re-export of the substrate lemma, and the family-level statement
-(every standard Mayan language shares them) is
+Each fact below re-exports its `Alignment.ergative` lemma; the
+family-level statement is
 `CoonMateoPedroPreminger2014.mayan_perfective_ergative`. -/
 
 /-- Agent gets ERG (from Voice). -/
@@ -150,8 +127,7 @@ theorem all_positions_agreed (p : ArgPosition) (_ : p ∈ ArgumentRole.core) :
 
 /-! ### Case inventory ([blake-1994]) -/
 
-/-- The Kaqchikel case inventory, derived from the core argument
-    positions' case values: {ERG, ABS}. -/
+/-- The case inventory realized by the core positions: {ERG, ABS}. -/
 def caseInventory : Finset Case := (ArgumentRole.core.map ArgPosition.case).toFinset
 
 /-- The inventory covers all argument positions: every position's case


### PR DESCRIPTION
Rescues two docs commits stranded by #1341's squash (merged mid-push): the Agreement module intro brought to mathlib register (object-only intro; contrasts and file pointers under Implementation notes) and all declaration docstrings reduced to one-liners.