### PR TITLE
docs(Fragments/Mayan): mathlib-register docstring sweep

### DIFF
--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -3,16 +3,30 @@ import Linglib.Syntax.Extraction
 import Linglib.Fragments.Mayan.Params
 
 /-!
-# Chol Agreement and Case Fragment [coon-2013] [imanishi-2020]
+# Chol Agreement and Case Fragment
 
 Agreement morphology and case assignment for Chol (Cholan, Mayan), a
 **low absolutive** language with aspect-based split alignment. Per
-[vazquez-alvarez-2011] §1.9.4, Chol is "an ergative
-language" in which "the ergative pattern is split in all non-perfective
-aspects, resulting in nominative-accusative alignment" — Set A indicates
-both transitive and intransitive subjects in non-perfective.
+[vazquez-alvarez-2011] §1.9.4, Chol is "an ergative language" in which
+"the ergative pattern is split in all non-perfective aspects, resulting in
+nominative-accusative alignment" — Set A indicates both transitive and
+intransitive subjects in non-perfective. The formal-syntactic analyses of
+[coon-2013] and [imanishi-2020] reanalyse this surface pattern.
 
-## Descriptive vs analytical framing of the non-perfective pattern
+## Main declarations
+
+* `Chol.ArgPosition` with `.case`, `.accCase`: argument positions and
+  their perfective (ergative) and non-perfective (extended-ergative) case.
+* `Chol.absPosition`: LOW-ABS morpheme placement.
+* `Chol.setAExponent`, `Chol.setBExponent`: the Set A (ERG/GEN) and Set B
+  (ABS) exponent tables ([vazquez-alvarez-2011] Table 10).
+* `Chol.extractionStrategy`, `Chol.absObjectInNonFinite`,
+  `Chol.absIntranSInNonFinite`: the (unmarked) extraction profile and
+  non-finite absolutive availability.
+
+## Implementation notes
+
+### Descriptive vs analytical framing of the non-perfective pattern
 
 The descriptive grammar ([vazquez-alvarez-2011]) characterizes the
 non-perfective alignment as **nominative-accusative**: Set A as a
@@ -37,7 +51,7 @@ a descriptive-grammar implementation would return `.nom`. The label
 "extended ergative" is Coon's coinage, generalizing one subtype of
 [dixon-1994]'s split-ergative-on-TAM-lines pattern.
 
-## Morpheme order and word-class status
+### Morpheme order and word-class status
 
 Per [vazquez-alvarez-2011] §3.4: in Chol "the aspect
 markers are auxiliaries" — `tyi` (perfective) and `mi` (imperfective)
@@ -53,28 +67,28 @@ Schematic order: `[Aux] [ERG-modifier*-ROOT-DERIV-STATUS-ABS]`, with
 the bracketed verbal complex as a single phonological unit. Contrasts
 with Kaqchikel's `[Aux] [ABS-ERG-Stem]` (high-ABS).
 
-## The Two Agreement Paradigms (Set A / Set B)
+### The two agreement paradigms (Set A / Set B)
 
 - **Set A** (ergative in perfective; nominative-or-genitive in
   non-perfective; possessive on nominals): prefixes
 - **Set B** (absolutive in perfective; accusative in non-perfective):
   suffixes
 
-## Case Licensing (analytical, per [coon-2013])
+### Case licensing (analytical, per [coon-2013])
 
 - **ERG**: inherent from transitive *v*
 - **ABS** (transitive): structural from Voice (low absolutive)
 - **ABS** (intransitive): structural from Infl
 - **GEN** (non-perfective S/A): from D under nominalization
 
-## Accusative Side (Non-Perfective)
+### Accusative side (non-perfective)
 
 In non-perfective aspect, the aspectual predicate *choñkol* embeds a
 nominalized clause. The RON does NOT hold: the external argument may be
 generated inside the nominalized clause. Result (Coon analysis):
 S/A = GEN (from D), O = ABS (from Voice).
 
-## What this fragment doesn't model
+### What this fragment doesn't model
 
 Per [vazquez-alvarez-2011] §1.9.4, Chol exhibits all
 four Dixon alignment types: ergative-absolutive, nominative-accusative, **Split-S**
@@ -92,83 +106,57 @@ namespace Chol
 open Mayan (ExponentTable)
 open Agreement
 
--- ============================================================================
--- § 1: Argument Positions (alias to canonical SAP type)
--- ============================================================================
+/-! ### Argument positions -/
 
-/-- Argument positions in a Chol clause. Aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
-    cross-framework code shares one inventory. Use the canonical
-    constructor names `.A` / `.P` / `.S` directly. -/
+/-- Argument positions in a Chol clause, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
 abbrev ArgPosition := Features.Prominence.ArgumentRole
 
-/-- Perfective case assignment for Chol. Definitionally equal to
-    `Mayan.ergCaseChol`, which derives from
-    `Alignment.ergative.assignCase` in
-    `Syntax/Case/Alignment.lean` — the foundation makes the
-    pattern (A → ERG, S/P → ABS) explicit; the per-language wrapper
-    preserves dot-notation `position.case` for consumers, uniform
-    with the other Mayan fragments. -/
+/-- Perfective (ergative) case assignment: `Mayan.ergCaseChol`
+    (A → ERG, S/P → ABS). -/
 abbrev ArgPosition.case : ArgPosition → Case := Mayan.ergCaseChol
 
-/-- Non-perfective case assignment for Chol. Definitionally equal to
-    `Mayan.accCaseChol`, derived from
-    `Alignment.extendedErgative.assignCase`. The "extended ergative"
-    pattern (S/A → GEN, P → ABS) is shared with Q'anjob'al — both
-    fragments call into the same `caseExtErg` substrate. -/
+/-- Non-perfective (extended-ergative) case assignment: `Mayan.accCaseChol`
+    (S/A → GEN, P → ABS), shared with Q'anjob'al. -/
 abbrev ArgPosition.accCase : ArgPosition → Case := Mayan.accCaseChol
 
--- ============================================================================
--- § 2: Absolutive Position (LOW-ABS)
--- ============================================================================
+/-! ### Absolutive position (LOW-ABS) -/
 
-/-- Chol's absolutive morphemes appear in low position (at the end of
-    the verb stem, post-stem). Observable from morpheme order:
-    ASP-ERG-ROOT-(DERIV)-SUFFIX-ABS. -/
+/-- Chol's absolutive morphemes appear in low (post-stem) position, from
+    the morpheme order ASP-ERG-ROOT-(DERIV)-SUFFIX-ABS. -/
 def absPosition : Mayan.ABSPosition := .low
 
--- ============================================================================
--- § 3: Extraction Data
--- ============================================================================
+/-! ### Extraction data -/
 
-/-- Chol's extraction data: no special morphology for any extraction
-    (`extractionStrategy = .unmarked`). Unlike Q'anjob'al, Chol requires
-    **no Agent Focus morphology** for A-extraction (the diagnostic for
-    "lacking syntactic ergativity" in the [coon-mateo-pedro-preminger-2014]
-    sense). Per-position extractability follows trivially (every argument
-    extracts freely), so the marked-positions list is empty — the contrast
-    with Q'anjob'al lives at the strategy.
-
-    The resulting ambiguity (when both arguments are 3rd person) is a
-    natural consequence of the absence of AF marking:
+/-- Chol requires **no Agent Focus morphology** for any extraction
+    (`extractionStrategy = .unmarked`) — unlike Q'anjob'al, the diagnostic
+    for "lacking syntactic ergativity" in the
+    [coon-mateo-pedro-preminger-2014] sense. Every argument extracts freely,
+    so the marked-positions list is empty; the resulting ambiguity when both
+    arguments are 3rd person follows from the absent AF marking:
     `Maxki₁ tyi y-il-ä (___₁) jiñi wiñik (___₁)?`
     'Who saw the man?' / 'Who did the man see?' -/
 def extractionStrategy : Extraction.ExtractionMarkingStrategy := .unmarked
 def extractionMarkedPositions : List Extraction.ExtractionTarget := []
 def extractionDistinguishesPosition : Bool := false
 
--- ============================================================================
--- § 4: Non-Finite Absolutive Availability
--- ============================================================================
+/-! ### Non-finite absolutive availability -/
 
-/-- In Chol non-finite embedded clauses (aspectless), absolutive objects
-    ARE available. This follows from Chol being LOW-ABS: v⁰ assigns case
-    to the object without needing Infl⁰.
+/-- In Chol non-finite (aspectless) embedded clauses, absolutive objects
+    are available — Chol is LOW-ABS, so v⁰ licenses the object without Infl⁰.
 
     `Mejl [i-k'el-oñ]` 'She can see me.' (ABS object ✓)
     `Choñkol [k-mek'-ety]` 'I am hugging you.' (ABS object ✓) -/
 def absObjectInNonFinite : Bool := true
 
-/-- Absolutive intransitive subjects are NOT available in Chol non-finite
-    clauses: they must be marked with the ergative/possessive prefix instead.
+/-- Absolutive intransitive subjects are not available in Chol non-finite
+    clauses — they take the ergative/possessive prefix instead.
 
     `Choñkol [k-ts'äm-el]` 'I am bathing.' (ERG prefix, not ABS)
     `*Choñkol [ts'äm-i-yoñ]` intended: 'I am bathing.' (ABS ✗) -/
 def absIntranSInNonFinite : Bool := false
 
--- ============================================================================
--- § 5: Person-Number Paradigm (Tables 9-10 of [vazquez-alvarez-2011])
--- ============================================================================
+/-! ### Person-number paradigm ([vazquez-alvarez-2011] Tables 9-10) -/
 
 /-- Set A (ergative/possessive/genitive) markers: pre-consonantal allomorphs
     ([vazquez-alvarez-2011] Table 10, p. 83). Note the morphophonemic

--- a/Linglib/Fragments/Mayan/Chol/ClassifierSystem.lean
+++ b/Linglib/Fragments/Mayan/Chol/ClassifierSystem.lean
@@ -3,19 +3,21 @@ import Linglib.Fragments.Mayan.Chol.Classifiers
 
 /-!
 # Ch'ol noun-categorization system
-[aikhenvald-2000] (typological schema); [bale-coon-2014] (Ch'ol empirical anchor)
 
-Classifier-system metadata for Ch'ol (ISO `ctu`). The lexical classifier
-inventory lives in `Fragments/Mayan/Chol/Classifiers.lean`; this file
-aggregates that inventory into a `System` summary.
+Classifier-system metadata for Ch'ol (ISO `ctu`), aggregating the lexical
+classifier inventory into a `System` summary against [aikhenvald-2000]'s
+typological schema, with Ch'ol as the empirical anchor ([bale-coon-2014]).
 
-Per-language claims (consensus, see [bale-coon-2014],
-[bale-et-al-2019], [little-moroney-royer-2022]): suffix
-realization on the numeral stem; classifier obligatory with Ch'ol-native
-numerals; Spanish loan numerals are ungrammatical *with* CLF; *-p'ej*
-serves as the generic default; CLF/PL co-occurrence is attested.
-Theoretical-strategy assignments (CLF-for-NUM vs CLF-for-N) live in the
-paper-anchored Studies that consume this profile.
+## Implementation notes
+
+The lexical classifier inventory lives in
+`Fragments/Mayan/Chol/Classifiers.lean`; this file aggregates it.
+Per-language claims (consensus, see [bale-coon-2014], [bale-et-al-2019],
+[little-moroney-royer-2022]): suffix realization on the numeral stem;
+classifier obligatory with Ch'ol-native numerals; Spanish loan numerals are
+ungrammatical *with* CLF; *-p'ej* serves as the generic default; CLF/PL
+co-occurrence is attested. Theoretical-strategy assignments (CLF-for-NUM vs
+CLF-for-N) live in the paper-anchored Studies that consume this profile.
 -/
 
 namespace Chol

--- a/Linglib/Fragments/Mayan/Chol/Classifiers.lean
+++ b/Linglib/Fragments/Mayan/Chol/Classifiers.lean
@@ -2,27 +2,32 @@ import Linglib.Features.NounCategorization.Basic
 
 /-!
 # Ch'ol Numeral Classifier Lexicon
-[little-moroney-royer-2022] [bale-coon-2014] [arcos-lopez-2009]
 
 Typed classifier entries for Ch'ol (Cholan, Mayan), a classifier-for-numeral
-language. Classifiers in Ch'ol are bound morphemes suffixed to the numeral
-stem and are obligatory with all Mayan-based numerals (1–6 and vigesimal
-system). Spanish-borrowed numerals (7+) already encode a measure function
-and do not take classifiers.
+language ([little-moroney-royer-2022]; [bale-coon-2014]). Classifiers in
+Ch'ol are bound morphemes suffixed to the numeral stem, obligatory with all
+Mayan-based numerals (1–6 and the vigesimal system); Spanish-borrowed
+numerals (7+) already encode a measure function and take no classifier.
 
-## Classifier selection
+## Main declarations
+
+* `Chol.Classifiers.pej`, `kojty`, `tyikil`, `kej`, `tsijty`, `bujch`: the
+  classifier entries ([little-moroney-royer-2022] Table 4).
+* `Chol.Classifiers.allClassifiers`, `defaultClassifier`: the inventory and
+  its generic default (*-p'ej*).
+
+## Implementation notes
 
 Ch'ol classifiers are largely derived from positional and transitive verb
-roots ([arcos-lopez-2009]; [bale-et-al-2019]). The position or
-shape of the noun is relevant: the same noun can be counted with different
-classifiers depending on its configuration (e.g., one long tree vs. one
-fallen tree). [arcos-lopez-2009] identifies at least 180 classifiers.
-
-## CLF-for-NUM semantics
+roots ([arcos-lopez-2009]; [bale-et-al-2019]); the position or shape of the
+noun is relevant, so the same noun can be counted with different classifiers
+depending on its configuration (e.g. one long tree vs. one fallen tree).
+[arcos-lopez-2009] identifies at least 180 classifiers.
 
 In the CLF-for-NUM analysis ([little-moroney-royer-2022] §4;
-[bale-coon-2014]), each classifier denotes a measure function μ
-that the numeral requires as its first argument:
+[bale-coon-2014]), each classifier denotes a measure function μ that the
+numeral requires as its first argument:
+
   ⟦ux⟧ = λm λP λx. [P(x) ∧ m(x) = 3]
   ⟦-kojty⟧ = μ_# (atom-counting measure for animals)
 -/
@@ -31,9 +36,7 @@ namespace Chol.Classifiers
 
 open NounCategorization (ClassifierEntry SemanticParameter ShapeDimension)
 
--- ============================================================================
--- Numeral classifiers (Table 4 of [little-moroney-royer-2022])
--- ============================================================================
+/-! ### Numeral classifiers ([little-moroney-royer-2022] Table 4) -/
 
 /-- -p'ej — inanimate/generic default classifier. Semantically bleached
     for inanimates; also the base of vigesimal classifiers (-k'al for 20,
@@ -68,18 +71,14 @@ def bujch : ClassifierEntry :=
   { form := "-bujch", gloss := "seated/propped"
   , semantics := [.arrangement] }
 
--- ============================================================================
--- Inventory
--- ============================================================================
+/-! ### Inventory -/
 
 def allClassifiers : List ClassifierEntry :=
   [pej, kojty, tyikil, kej, tsijty, bujch]
 
 def defaultClassifier : ClassifierEntry := pej
 
--- ============================================================================
--- Verification
--- ============================================================================
+/-! ### Verification -/
 
 /-- The default classifier is marked as default. -/
 theorem default_is_default : defaultClassifier.isDefault = true := rfl

--- a/Linglib/Fragments/Mayan/Kiche/Adposition.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Adposition.lean
@@ -1,38 +1,32 @@
 import Linglib.Syntax.Category.Adposition.Order
 
 /-!
-# K'iche' adposition order [mondloch-2017] [clemens-coon-2018]
+# K'iche' Adposition Order
 
-K'iche' is not coded in WALS Ch 85 (ISO `quc` is absent), so the
-classification is grammar-grounded from [mondloch-2017] rather
-than via `AdpositionOrder.ofWALS`. Mondloch documents prepositional
-constructions in K'iche' (preposition + NP order, consistent with the
-language's verb-initial/head-initial profile per Greenberg's U3).
+Grammar-grounded adposition-order classification for K'iche' (K'ichean
+Mayan) from [mondloch-2017], who documents prepositional constructions
+(preposition + NP order, consistent with the language's
+verb-initial/head-initial profile per Greenberg's U3). K'iche' is not
+coded in WALS Ch 85 (ISO `quc` is absent), so the value is a direct
+override rather than via `AdpositionOrder.ofWALS`.
 
-## A contested classification
+## Implementation notes
 
 Mayanist literature debates whether K'iche' truly has *adpositions* or
-only **relational nouns** that fill an adposition-like role
-syntactically (Aissen 1992, Coon 2010). Under the
-relational-noun analysis, K'iche' would arguably be coded as
-`.noAdpositions` rather than `.prepositional`. [clemens-coon-2018]
-surveys derivational accounts of Mayan verb-initiality and the
-related head-direction debates.
-
-The Fragment commits to `.prepositional` because Mondloch describes
-preposition-like constructions; the relational-noun reading would
-give `.noAdpositions`. Either choice is consistent with the broader
-head-initial profile (`.headInitial` either way under
-`AdpositionOrder.headDirection`).
+only **relational nouns** filling an adposition-like role syntactically
+(Aissen 1992, Coon 2010). Under the relational-noun analysis K'iche'
+would arguably be coded `.noAdpositions` rather than `.prepositional`.
+[clemens-coon-2018] surveys derivational accounts of Mayan
+verb-initiality and the related head-direction debates. The Fragment
+commits to `.prepositional` because Mondloch describes preposition-like
+constructions; either choice is head-initial under
+`AdpositionOrder.headDirection`.
 -/
 
 namespace Kiche
 
-/-- K'iche' adposition order, grammar-grounded from
-    [mondloch-2017] (prepositional constructions). Not in WALS
-    Ch 85 — direct override rather than `AdpositionOrder.ofWALS "quc"`
-    (which would return `.notInWALS`). The `.prepositional` choice is
-    contested across Mayanist literature; see module docstring. -/
+/-- K'iche' adposition order, grammar-grounded as `.prepositional` from
+    [mondloch-2017]; not in WALS Ch 85, so a direct override. -/
 def adposition : Adposition.AdpositionOrder := .prepositional
 
 end Kiche

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -6,77 +6,51 @@ import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Extraction
 
 /-!
-# K'iche' Agreement Fragment [mondloch-2017]
+# K'iche' Agreement Fragment
 
 Theory-neutral typological metadata for K'iche' (K'ichean Mayan)
-agreement morphology, following [mondloch-2017] Lessons 4, 7–8,
-9, 15. K'iche' is uniformly ergative-absolutive (Set B = ABS, Set A
-= ERG); unlike its sister Kaqchikel it has no construction-specific
+agreement morphology, following [mondloch-2017] Lessons 4, 7–8, 9, 15.
+K'iche' has ergative-absolutive alignment realized through two verbal
+agreement paradigms: Set B (absolutive) cross-references intransitive S
+and transitive P and appears between the aspect marker and the root;
+Set A (ergative) cross-references transitive A, appears between the
+object marker and the root, and is identical to the possessive prefixes.
+Unlike its sister Kaqchikel, K'iche' has no construction-specific
 inverted alignment.
 
-## The System
+## Main declarations
 
-K'iche' has an **ergative-absolutive** alignment system realized through
-two agreement paradigms on the verb:
+* `Kiche.PhiFeatures`: person/number/formality bundles, with `HasPerson`
+  and `HasNumber` instances and the informal shorthand `Kiche.phi`.
+* `Kiche.setBMarker`, `Kiche.setAPreC`, `Kiche.setAPreV`: the Set B
+  (absolutive) and Set A (ergative, pre-consonantal / pre-vocalic)
+  exponents.
+* `Kiche.ArgPosition.agreementSet`, `Kiche.ArgPosition.case`: the
+  agreement set and case each argument position triggers.
+* `Kiche.independentPronoun`: the free personal pronouns.
+* `Kiche.setAExponent`, `Kiche.setBExponent`: canonical φ-cell exponent
+  tables for cross-Mayan consumption.
+* `Kiche.extractionStrategy`: the Agent-Focus extraction profile.
 
-- **Set B** (ABS): absolutive markers that cross-reference the sole
-  argument of intransitives (S) and the object of transitives (P).
-  These appear between the aspect marker and the verb root.
-- **Set A** (ERG): ergative markers that cross-reference the subject
-  of transitives (A). These appear between the object marker and the
-  root. Set A markers are identical to the possessive pronouns used
-  before consonant-initial nouns (Lesson 7).
+## Implementation notes
 
-## Paradigms
-
-### Set B (Absolutive) — Lesson 9
-
-| Person | Singular | Plural |
-|--------|----------|--------|
-| 1      | in-      | oj-    |
-| 2      | at-      | ix-    |
-| 3      | Ø-       | ee-    |
-| 2.FORM | la (postverbal) | alaq (postverbal) |
-
-### Set A (Ergative, preconsonantal) — Lessons 7, 15
-
-| Person | Singular | Plural |
-|--------|----------|--------|
-| 1      | nu‑ / in‑  | qa-    |
-| 2      | a-       | i-     |
-| 3      | u-       | ki-    |
-| 2.FORM | la (postverbal) | alaq (postverbal) |
-
-### Set A (Ergative, prevocalic) — Lesson 8
-
-| Person | Singular | Plural |
-|--------|----------|--------|
-| 1      | w-       | q-     |
-| 2      | aw-      | iw-    |
-| 3      | r-       | k-     |
-| 2.FORM | la (postverbal) | alaq (postverbal) |
-
-## Alignment
-
-The alignment is ergative-absolutive: Set B groups S and P together
-(both trigger the same paradigm), while A triggers a distinct paradigm
-(Set A). This contrasts with Mam, which shows morphologically
-**tripartite** alignment (S, A, and P each trigger distinct patterns;
-[scott-2023]).
-
-## Formal address
-
-K'iche' has two levels of formality for 2nd person: informal and
-formal. The formal forms (laal SG, alaq PL) are syntactically
-postverbal and do not participate in the prefix paradigm.
+The alignment is ergative-absolutive: Set B groups S and P (both trigger
+the same paradigm) while A triggers Set A. This contrasts with Mam,
+which is morphologically tripartite (S, A, P each distinct;
+[scott-2023]). K'iche' has two 2nd-person formality levels; the formal
+forms (laal SG, alaq PL) are syntactically postverbal and pattern
+outside the prefix paradigm. K'iche' is HIGH-ABS (Set B pre-stem on
+Infl), and its case wiring reuses `Mayan.ergCaseKiche` (from
+`Alignment.ergative`); the canonical φ-cell exponent tables key on
+`Agreement.Cell` for cross-Mayan consumption. Agent-Focus Antipassive
+marks A-extraction with the voice marker *-n*, shared with the
+Absolutive Antipassive ([mondloch-2017] Lesson 22).
 -/
 
 
 namespace Kiche
 
--- ============================================================================
--- § 1: Person/Number/Formality Features
--- ============================================================================
+/-! ### Person, number, and formality features -/
 
 /-- Formality level for 2nd person. K'iche'-specific: the formal
     forms (laal SG, alaq PL) are postverbal and pattern outside the
@@ -103,9 +77,7 @@ instance : HasPerson PhiFeatures := ⟨fun φ => some φ.person⟩
 abbrev phi (p : Person) (n : Number) : PhiFeatures :=
   ⟨p, n, .informal⟩
 
--- ============================================================================
--- § 2: Set B (Absolutive) Markers — Lesson 9
--- ============================================================================
+/-! ### Set B (absolutive) markers -/
 
 /-- Set B (absolutive) agreement markers.
     These are verbal prefixes (or postverbal particles for formal forms)
@@ -128,9 +100,7 @@ def setBMarker : PhiFeatures → String
   | ⟨.third,  _, .informal⟩   => "ee-"
   | ⟨_, _, .formal⟩            => "Ø"
 
--- ============================================================================
--- § 3: Set A (Ergative) Markers — Lessons 7, 15
--- ============================================================================
+/-! ### Set A (ergative) markers -/
 
 /-- Set A (ergative) markers before consonant-initial roots.
     These cross-reference A (transitive subject) and are identical to
@@ -170,9 +140,7 @@ def setAPreV : PhiFeatures → String
   | ⟨.third,  _, .informal⟩   => "k-"
   | ⟨_, _, .formal⟩            => "Ø"
 
--- ============================================================================
--- § 4: Morphological Positions (Prop-valued)
--- ============================================================================
+/-! ### Morphological positions -/
 
 /-- Is a Set B marker a prefix (appearing before the root) or a
     postverbal particle? Formal forms are postverbal; all others
@@ -189,9 +157,7 @@ def SetAIsPrefix (φ : PhiFeatures) : Prop := φ.formality = .informal
 instance (φ : PhiFeatures) : Decidable (SetAIsPrefix φ) :=
   inferInstanceAs (Decidable (φ.formality = .informal))
 
--- ============================================================================
--- § 5: Argument Positions and Alignment (substrate-anchored)
--- ============================================================================
+/-! ### Argument positions and alignment -/
 
 /-- Argument positions in a K'iche' clause. Aliased to the canonical
     `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
@@ -222,9 +188,7 @@ def ArgPosition.agreementSet : ArgPosition → AgreementSet
 abbrev ArgPosition.case : ArgPosition → Case :=
   Mayan.ergCaseKiche
 
--- ============================================================================
--- § 6: Alignment Theorems
--- ============================================================================
+/-! ### Alignment theorems -/
 
 /-- K'iche' groups S and P together (both trigger Set B):
     ergative-absolutive alignment. -/
@@ -247,9 +211,7 @@ theorem erg_abs_pattern :
 theorem kiche_not_tripartite :
     ArgPosition.case .S = ArgPosition.case .P := rfl
 
--- ============================================================================
--- § 7: Set B Per-Cell Verification
--- ============================================================================
+/-! ### Set B per-cell verification -/
 
 /-- 1SG absolutive: in- -/
 theorem setB_1sg : setBMarker (phi .first .singular) = "in-" := rfl
@@ -268,9 +230,7 @@ theorem setB_2sg_form : setBMarker ⟨.second, .singular, .formal⟩ = "la" := r
 /-- 2PL.FORM: alaq (postverbal) -/
 theorem setB_2pl_form : setBMarker ⟨.second, .plural, .formal⟩ = "alaq" := rfl
 
--- ============================================================================
--- § 8: Set A Per-Cell Verification
--- ============================================================================
+/-! ### Set A per-cell verification -/
 
 /-- 1SG ergative (preC): nu‑ or in‑ -/
 theorem setA_1sg : setAPreC (phi .first .singular) = "nu-/in-" := rfl
@@ -292,9 +252,7 @@ theorem setA_preV_2sg : setAPreV (phi .second .singular) = "aw-" := rfl
 /-- 3SG ergative (preV): r- -/
 theorem setA_preV_3sg : setAPreV (phi .third .singular) = "r-" := rfl
 
--- ============================================================================
--- § 9: Set A / Set B Identity (Possessives = Set A)
--- ============================================================================
+/-! ### Possessives equal Set A -/
 
 /-- Set A markers are identical to possessive pronouns: the transitive
     subject markers (Lesson 15) are the same forms as the possessive
@@ -309,9 +267,7 @@ theorem possessives_equal_setA :
     setAPreC (phi .third .plural) = "ki-" :=
   ⟨rfl, rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 10: Formal Markers Are Postverbal
--- ============================================================================
+/-! ### Formal markers are postverbal -/
 
 /-- All informal Set B markers are prefixes. -/
 theorem setB_informal_prefix :
@@ -329,9 +285,7 @@ theorem setB_formal_postverbal :
     ¬ SetBIsPrefix ⟨.second, .plural, .formal⟩ :=
   ⟨by decide, by decide⟩
 
--- ============================================================================
--- § 11: Independent Pronouns — Lesson 4
--- ============================================================================
+/-! ### Independent pronouns -/
 
 /-- Independent (free) personal pronouns. These are used in nonverbal
     sentences and as emphatic/contrastive pronouns in verbal sentences.
@@ -363,9 +317,7 @@ theorem pronoun_setB_correspondence :
     independentPronoun (phi .second .plural) = "ix"  :=
   ⟨rfl, rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 12: Cross-Mayan Canonical Wrappers
--- ============================================================================
+/-! ### Cross-Mayan canonical wrappers -/
 
 open Mayan (MarkerLinearity ExponentTable)
 open Agreement
@@ -373,7 +325,7 @@ open Agreement
 /-- K'iche' is HIGH-ABS: Set B markers appear pre-stem on Infl. -/
 def absPosition : Mayan.ABSPosition := .high
 
-/-- Set A linearity: prefixal (per Mondloch Lessons 7-8). -/
+/-- Set A linearity: prefixal ([mondloch-2017] Lessons 7–8). -/
 def setALinearity : MarkerLinearity := .prefixal
 
 /-- Set B linearity: prefixal (HIGH-ABS K'ichean morphology). -/
@@ -404,15 +356,13 @@ def setBExponent : ExponentTable :=
     pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "∅" := rfl
 
-/-- K'iche''s extraction profile (language "K'iche'"): Agent-Focus
-    Antipassive is productive ([mondloch-2017] Lesson 22, with parallel
-    coverage at Lessons 30 + 33 for radical TV and perfect aspect). The
-    voice marker is *-n* (shared morphologically with the Absolutive
-    Antipassive of Lesson 21; the AF vs absolutive-antipassive alternation
-    is *syntactic* — both arguments overt for AF, object suppressed for
-    absolutive antipassive — not morphological). HIGH-ABS K'ichean,
-    structurally analogous to Kaqchikel. Notes: AF (-n) for A-extraction;
-    HIGH-ABS K'ichean (Mondloch 2017 Lesson 22). -/
+/-- K'iche' extraction profile: Agent-Focus Antipassive marks A-extraction
+    ([mondloch-2017] Lesson 22; also Lessons 30, 33 for radical transitives
+    and perfect aspect). The voice marker *-n* is shared with the
+    Absolutive Antipassive (Lesson 21); the two differ syntactically — both
+    arguments overt under AF, object suppressed under the antipassive — not
+    morphologically. HIGH-ABS K'ichean, structurally analogous to
+    Kaqchikel. -/
 def extractionStrategy : Extraction.ExtractionMarkingStrategy := .dedicatedMorpheme
 def extractionMarkedPositions : List Extraction.ExtractionTarget := [.subject]
 def extractionDistinguishesPosition : Bool := true

--- a/Linglib/Fragments/Mayan/Kiche/ExtractionMorphology.lean
+++ b/Linglib/Fragments/Mayan/Kiche/ExtractionMorphology.lean
@@ -1,43 +1,43 @@
 import Linglib.Syntax.Extraction
 
 /-!
-# K'iche' Extraction Morphology Fragment
-[mendes-ranero-2021] [elkins-torrence-brown-2026] [mondloch-2017]
+# K'iche' Extraction Morphology
 
 Theory-neutral data on the extraction particle *wi* (the "fronting
-particle") in K'iche' and Kaqchikel (K'ichean Mayan).
-
-## The Phenomenon
-
+particle") in K'iche' and Kaqchikel (K'ichean Mayan), following
+[mendes-ranero-2021], [elkins-torrence-brown-2026], and [mondloch-2017].
 When a low adjunct (locative, instrumental, comitative, indirect object)
-undergoes Ā-extraction in K'ichean languages, the particle *wi* appears
-as a verbal enclitic. M&R analyze *wi* as the result of Chain Reduction
-via Substitution: the lower copy of the moved adjunct (bearing [APPL])
-is substituted by *wi* rather than being deleted.
+undergoes Ā-extraction, *wi* appears as a verbal enclitic;
+[mendes-ranero-2021] analyze it as Chain Reduction via Substitution,
+with the lower copy of the moved adjunct (bearing [APPL]) substituted by
+*wi* rather than deleted.
 
-## Key Properties
+## Main declarations
 
-1. **Trigger**: Low adjuncts only — those introduced in Spec,ApplP
-   (instrumentals, locatives, comitatives, indirect objects).
-   Temporal and reason adjuncts do NOT trigger *wi*.
-2. **Obligatoriness**: Obligatory in K'iche', optional in Patzún
-   Kaqchikel, absent in some Kaqchikel dialects (e.g. Tecpán).
-3. **Fronting Particle Generalization** (definition 5 of M&R, first
-   observed by Can Pixabaj 2015): In long-distance extraction from a
-   single embedded clause, the presence of *wi* in the matrix clause
-   is contingent on the presence of an overt complementizer in the
-   embedded clause. Embedded CPs yield *wi* on both predicates;
-   embedded AspPs yield *wi* only on the embedded predicate.
-4. **Not a pronoun, applicative head, movement trigger, or AF morpheme**
-   (M&R §4 rejects all four alternative analyses).
+* `Kiche.KicheExtractionDatum`, `Kiche.allData`: the *wi*-distribution
+  data points.
+* `Kiche.KicheLongDistanceDatum`, `Kiche.ldData`: long-distance
+  extraction data across embedded CP vs AspP.
+* `Kiche.fronting_particle_generalization`: matrix *wi* is contingent on
+  an overt embedded complementizer.
+* `Kiche.kicheanExtractionStrategy`: the extraction profile.
 
+## Implementation notes
+
+*wi* triggers only on low adjuncts introduced in Spec,ApplP
+(instrumentals, locatives, comitatives, indirect objects); temporal and
+reason adjuncts do not trigger it. It is obligatory in K'iche', optional
+in Patzún Kaqchikel, and absent in some Kaqchikel dialects (e.g.
+Tecpán). [mendes-ranero-2021] §4 argues *wi* is not a pronoun,
+applicative head, movement trigger, or AF morpheme. The Fronting
+Particle Generalization ([mendes-ranero-2021] definition (5), first
+observed by Can Pixabaj 2015) is stated and checked at
+`fronting_particle_generalization`.
 -/
 
 namespace Kiche
 
--- ============================================================================
--- § 1: Extracted Argument Types
--- ============================================================================
+/-! ### Extracted argument types -/
 
 /-- Types of extracted arguments relevant for *wi* distribution. -/
 inductive ExtractedArgType where
@@ -54,9 +54,7 @@ def ExtractedArgType.isOblique : ExtractedArgType → Bool
   | .obliqueSpatial | .obliqueTemporal | .obliqueReason | .obliqueInstrumental => true
   | .subject | .object => false
 
--- ============================================================================
--- § 2: *wi* Distribution Data
--- ============================================================================
+/-! ### *wi* distribution data -/
 
 /-- A K'iche' extraction data point: what is extracted and whether *wi*
     appears after the verb. -/
@@ -67,8 +65,7 @@ structure KicheExtractionDatum where
   wiLicensed : Bool
   deriving Repr
 
-/-- Spatial oblique extraction: *wi* licensed.
-    "Where did you go yesterday?" — *wi* appears at extraction site.
+/-- Spatial oblique extraction ("Where did you go yesterday?"): *wi* licensed.
     [mondloch-2017] Lesson 14; [mendes-ranero-2021] §2, ex. (9a). -/
 def spatialOblExtraction : KicheExtractionDatum :=
   { label := "Spatial oblique extraction (wi)"
@@ -76,18 +73,16 @@ def spatialOblExtraction : KicheExtractionDatum :=
   , extractedType := .obliqueSpatial
   , wiLicensed := true }
 
-/-- Instrumental oblique extraction: *wi* licensed.
-    "With what did they eat their food?" — *wi* at extraction site.
-    [mendes-ranero-2021] §2, ex. (9b). -/
+/-- Instrumental oblique extraction ("With what did they eat their food?"):
+    *wi* licensed. [mendes-ranero-2021] §2, ex. (9b). -/
 def instrumentalOblExtraction : KicheExtractionDatum :=
   { label := "Instrumental oblique extraction (wi)"
   , reference := "Mendes & Ranero 2021, §2, ex. (9b)"
   , extractedType := .obliqueInstrumental
   , wiLicensed := true }
 
-/-- Temporal oblique extraction: *wi* NOT licensed.
-    "When did you eat beans?" — no *wi*. Parallel to Mam: temporal
-    obliques are exempt in both language groups.
+/-- Temporal oblique extraction ("When did you eat beans?"): *wi* NOT
+    licensed — parallel to Mam, where temporal obliques are also exempt.
     [mendes-ranero-2021] §2, ex. (12c). -/
 def temporalOblExtraction : KicheExtractionDatum :=
   { label := "Temporal oblique extraction (no wi)"
@@ -95,27 +90,24 @@ def temporalOblExtraction : KicheExtractionDatum :=
   , extractedType := .obliqueTemporal
   , wiLicensed := false }
 
-/-- Reason oblique extraction: *wi* NOT licensed.
-    "Why did Juan work?" — no *wi*. KEY CONTRAST with Mam: SJO
-    =(y)a' IS licensed with reason extraction.
-    [mendes-ranero-2021] §2 (adapted from Elkins et al. Table 3). -/
+/-- Reason oblique extraction ("Why did Juan work?"): *wi* NOT licensed —
+    key contrast with Mam, where SJO =(y)a' IS licensed with reason
+    extraction. [mendes-ranero-2021] §2 (adapted from Elkins et al. Table 3). -/
 def reasonOblExtraction : KicheExtractionDatum :=
   { label := "Reason oblique extraction (no wi)"
   , reference := "Mendes & Ranero 2021, §2; Elkins et al. Table 3"
   , extractedType := .obliqueReason
   , wiLicensed := false }
 
-/-- Subject extraction: *wi* NOT licensed (Agent Focus instead).
-    "Who bought it?" — AF morphology *-Vk* instead of *wi*.
-    [mendes-ranero-2021] §2, item (6c). -/
+/-- Subject extraction ("Who bought it?"): *wi* NOT licensed — Agent Focus
+    morphology *-Vk* appears instead. [mendes-ranero-2021] §2, item (6c). -/
 def subjectExtraction : KicheExtractionDatum :=
   { label := "Subject extraction (AF, no wi)"
   , reference := "Mendes & Ranero 2021, §2, item (6c)"
   , extractedType := .subject
   , wiLicensed := false }
 
-/-- Object extraction: *wi* NOT licensed.
-    "What did you buy?" — no *wi*.
+/-- Object extraction ("What did you buy?"): *wi* NOT licensed.
     [elkins-torrence-brown-2026]. -/
 def objectExtraction : KicheExtractionDatum :=
   { label := "Object extraction (no wi)"
@@ -132,15 +124,12 @@ def allData : List KicheExtractionDatum :=
   , subjectExtraction
   , objectExtraction ]
 
--- ============================================================================
--- § 3: Generalizations
--- ============================================================================
+/-! ### Generalizations -/
 
 /-- Among the formalized data points, *wi* is licensed exactly for
-    spatial and instrumental obliques. The full set of *wi*-triggering
-    obliques includes comitatives and indirect objects as well
-    ([mendes-ranero-2021] §2; [elkins-torrence-brown-2026]
-    Table 3), but those are not yet formalized here. -/
+    spatial and instrumental obliques; the full trigger set also includes
+    comitatives and indirect objects ([mendes-ranero-2021] §2;
+    [elkins-torrence-brown-2026] Table 3), not yet formalized here. -/
 theorem wi_subset_of_obliques :
     allData.all (λ d =>
       d.wiLicensed == (d.extractedType == .obliqueSpatial ||
@@ -156,15 +145,11 @@ theorem wi_not_core_args :
     nor =(y)a' (Mam) appears with temporal oblique extraction. -/
 theorem temporal_exempt : temporalOblExtraction.wiLicensed = false := rfl
 
--- ============================================================================
--- § 4: Embedded Clause Types and the Fronting Particle Generalization
---      ([mendes-ranero-2021], definition (5); Can Pixabaj 2015)
--- ============================================================================
+/-! ### Embedded clause types and the Fronting Particle Generalization -/
 
-/-- Embedded clause types relevant for long-distance *wi* distribution.
-    The crucial distinction is whether the embedded clause has an overt
-    complementizer (= CP) or not (= AspP, a structurally reduced clause).
-    [mendes-ranero-2021] §2, exx. (17)–(20), (34)–(37). -/
+/-- Embedded clause types for long-distance *wi* distribution: whether the
+    embedded clause has an overt complementizer (CP) or not (a structurally
+    reduced AspP). [mendes-ranero-2021] §2, exx. (17)–(20), (34)–(37). -/
 inductive KicheEmbeddedClauseType where
   /-- Full CP with overt complementizer *chi*. -/
   | cp
@@ -208,36 +193,24 @@ def ldFromAspP : KicheLongDistanceDatum :=
 
 def ldData : List KicheLongDistanceDatum := [ldFromCP, ldFromAspP]
 
-/-- **The Fronting Particle Generalization** ([mendes-ranero-2021],
-    definition (5); first discussed by Can Pixabaj 2015):
-
-    In long-distance A'-extraction of low adjuncts from a single
-    embedded clause, the presence of *wi* in the matrix clause is
-    contingent on the presence of an overt complementizer in the
-    embedded clause.
-
-    Structural explanation (M&R §3): C⁰ is a phase head, so when the
-    embedded clause is a CP, the extracted adjunct must stop over in
-    the embedded Spec,CP. Chain Reduction via Substitution applies to
-    this intermediate copy, yielding *wi* on the matrix predicate. When
-    the embedded clause is an AspP (no C⁰, no phase boundary), the
-    adjunct moves directly to the matrix Spec,CP — no intermediate copy,
-    no matrix *wi*. -/
+/-- The Fronting Particle Generalization ([mendes-ranero-2021] definition
+    (5); first discussed by Can Pixabaj 2015): in long-distance
+    Ā-extraction of a low adjunct from a single embedded clause, matrix
+    *wi* is contingent on an overt complementizer in the embedded clause.
+    Structurally ([mendes-ranero-2021] §3), C⁰ is a phase head — an
+    embedded CP forces a stopover in embedded Spec,CP whose intermediate
+    copy undergoes Chain Reduction via Substitution (matrix *wi*), while an
+    embedded AspP has no phase boundary and the adjunct moves directly to
+    matrix Spec,CP (no matrix *wi*). -/
 theorem fronting_particle_generalization :
     ldData.all (λ d => d.embeddedType.hasComp == d.wiOnMatrix) = true := by
   decide
 
--- ============================================================================
--- § 5: Extraction Profile
--- ============================================================================
+/-! ### Extraction profile -/
 
-/-- K'ichean extraction profile (language "K'ichean (K'iche', Kaqchikel,
-    Tz'utujil)"): *wi* marks oblique extraction via copy spellout at the
-    foot of the Ā-chain. Notes: Fronting particle wi (Chain Reduction via
-    Substitution); triggered by low adjuncts (spatial, instrumental, etc.);
-    temporal and reason exempt; obligatory in K'iche', optional in Patzún
-    Kaqchikel; FPG: matrix wi contingent on overt complementizer in
-    embedded clause. -/
+/-- K'ichean extraction profile: *wi* marks oblique extraction via copy
+    spellout at the foot of the Ā-chain, distinguishing obliques from core
+    arguments ([mendes-ranero-2021]). -/
 def kicheanExtractionStrategy : Extraction.ExtractionMarkingStrategy := .dedicatedMorpheme
 def kicheanExtractionMarkedPositions : List Extraction.ExtractionTarget := [.oblique]
 def kicheanExtractionDistinguishesPosition : Bool := true

--- a/Linglib/Fragments/Mayan/Kiche/VoiceSystem.lean
+++ b/Linglib/Fragments/Mayan/Kiche/VoiceSystem.lean
@@ -2,72 +2,51 @@ import Linglib.Syntax.Voice.Basic
 import Linglib.Fragments.Mayan.Kiche.Agreement
 
 /-!
-# K'iche' Voice System Fragment [mondloch-2017]
+# K'iche' Voice System
 
-The five transitive voice alternations of K'iche', following
-[mondloch-2017] Lessons 15–22, 26–30.
+The five transitive voice alternations of K'iche' (K'ichean Mayan),
+following [mondloch-2017] Lessons 15–22, 26–30: active, simple passive,
+absolutive antipassive, agent-focus antipassive, and completed passive.
+Agent-Focus Antipassive is the voice used for subject extraction, which
+is why an extracted agent triggers AF morphology rather than the fronting
+particle *wi*.
 
-## Voice Inventory
+## Main declarations
 
-K'iche' has five voices for transitive verbs (plus an instrumental
-voice not covered in the grammar):
+* `Kiche.KicheVoice`, `Kiche.allVoices`: the five transitive voices.
+* `Kiche.dtvVoiceMarker`, `Kiche.rtvVoiceMarker`: voice-marker exponents
+  for derived vs radical transitive verbs.
+* `Kiche.ActiveVerbForm`, `Kiche.PassiveVerbForm`,
+  `Kiche.AntipassiveVerbForm`: morphological templates per voice.
+* `Kiche.KicheVoice.RealizesAgent`, `.RealizesPatient`,
+  `.ConjugatesIntransitively`: argument-realization predicates per voice.
+* `Kiche.subjectExtractionVoice`: Agent Focus as the subject-extraction
+  voice.
+* `Kiche.Negation`, `Kiche.negNonverbal`, `Kiche.negVerbal`: the
+  na...taj/ta circumfixal negation.
 
-1. **Active Voice** (Lessons 15–18, 26–27): Subject (A), verb, and
-   object (P) are all expressed. Voice marker: **-j** for derived
-   transitive verbs (DTVs), **-Ø** for radical transitive verbs (RTVs).
-   Template: `aspect + P(SetB) + A(SetA) + root + voice`.
+## Implementation notes
 
-2. **Simple Passive** (Lessons 19–20, 28–29): P is promoted to subject
-   (triggers Set B); A is demoted to an oblique (introduced by
-   *rumaal/kumaal* 'by'). Voice marker: **-x** (DTVs), **-Vtaj**
-   (RTVs). Template: `aspect + S(SetB) + root + passive`.
-
-3. **Absolutive Antipassive** (Lesson 21): A is kept as subject
-   (triggers Set B as if intransitive); P is suppressed entirely.
-   Voice marker: **-n** (DTVs). Verb conjugates like an intransitive.
-   Template: `aspect + S(SetB) + root + antipass`.
-
-4. **Agent-Focus Antipassive** (Lessons 22, 30): The subject (A) is
-   focused/emphasized. P triggers Set B, A appears as a separated
-   pronoun before the verb. Voice marker: **-n** (DTVs), **-Vk** (RTVs).
-   This is the voice used for **subject extraction** (wh-questions about
-   the agent), which is why subject extraction triggers Agent Focus
-   morphology rather than *wi*.
-
-5. **Completed Passive** (Lessons 20, 29): Like Simple Passive but with
-   completed aspect. Voice marker: **-taaj** (DTVs for completed
-   aspect only).
-
-## Verb Classes
-
-- **Derived Transitive Verbs (DTVs)**: Polysyllabic roots ending in
-  vowels (e.g., *kuna* 'to cure', *tzuku* 'to look for').
-- **Radical Transitive Verbs (RTVs)**: Monosyllabic roots ending in
-  consonants (e.g., *b'an* 'to do', *ch'ay* 'to hit').
-
-## Aspect Markers
-
-- **Incomplete**: k- (ka- before consonant clusters)
-- **Completed**: x-
-
-## Connection to Extraction Morphology
-
-Agent Focus Antipassive (voice 4) is the morphological strategy used for
-**subject extraction** in K'iche'. When the agent is extracted via
-Ā-movement (e.g., 'Who bought it?'), the verb appears in Agent Focus
-voice with the **-n** or **-Vk** marker, not with the fronting particle *wi*.
-This is why `subjectExtraction.wiLicensed = false` in
-`ExtractionMorphology.lean` — subject extraction uses Agent Focus, not
-*wi*.
+Verb classes split derived transitives (DTVs: polysyllabic vowel-final
+roots, e.g. *kuna* 'to cure') from radical transitives (RTVs:
+monosyllabic consonant-final roots, e.g. *b'an* 'to do'), which take
+different voice-marker allomorphs. Aspect is incomplete *k-* (*ka-*
+before clusters) or completed *x-*. The passive demotes the agent to an
+oblique introduced by *rumaal/kumaal* 'by'. An instrumental voice exists
+but is not covered here. Agent-Focus Antipassive is the strategy for
+subject extraction ([mondloch-2017] Lesson 22; [mendes-ranero-2021] §2),
+so `subjectExtraction.wiLicensed = false` in `ExtractionMorphology.lean` —
+the extracted agent takes AF morphology, not *wi*. The word-order profile
+lives in `WordOrder.lean`; the transitive/intransitive/passive
+conjugation contrast [mondloch-2017] draws (Lesson 9) is paper-specific
+apparatus that nothing here consumes.
 -/
 
 namespace Kiche
 
--- ============================================================================
--- § 1: Verb Classes
--- ============================================================================
+/-! ### Verb classes -/
 
-/-- K'iche' transitive verb classes., Lesson 15. -/
+/-- K'iche' transitive verb classes ([mondloch-2017] Lesson 15). -/
 inductive TransVerbClass where
   /-- Derived: polysyllabic roots ending in vowels. -/
   | derived
@@ -75,12 +54,10 @@ inductive TransVerbClass where
   | radical
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 2: Voice Alternations
--- ============================================================================
+/-! ### Voice alternations -/
 
-/-- The five transitive voices of K'iche'.,
-    Lessons 15–22, 26–30. -/
+/-- The five transitive voices of K'iche' ([mondloch-2017]
+    Lessons 15–22, 26–30). -/
 inductive KicheVoice where
   /-- Active Voice: A and P both expressed. -/
   | active
@@ -99,14 +76,12 @@ inductive KicheVoice where
 def allVoices : List KicheVoice :=
   [.active, .simplePassive, .absolutiveAntipassive, .agentFocus, .completedPassive]
 
--- ============================================================================
--- § 3: Voice Markers
--- ============================================================================
+/-! ### Voice markers -/
 
-/-- The voice marker suffix for derived transitive verbs (DTVs).
-   : Active = -j (Lesson 15), Simple Passive = -x
-    (Lesson 19), Antipassive = -n (Lesson 21), Agent Focus = -n
-    (Lesson 22), Completed Passive = -taaj (Lesson 20). -/
+/-- Voice-marker suffix for derived transitive verbs (DTVs), per
+    [mondloch-2017]: active *-j* (Lesson 15), simple passive *-x*
+    (Lesson 19), antipassive *-n* (Lesson 21), Agent Focus *-n*
+    (Lesson 22), completed passive *-taaj* (Lesson 20). -/
 def dtvVoiceMarker : KicheVoice → String
   | .active                 => "-j"
   | .simplePassive          => "-x"
@@ -114,10 +89,9 @@ def dtvVoiceMarker : KicheVoice → String
   | .agentFocus             => "-n"
   | .completedPassive       => "-taaj"
 
-/-- The voice marker suffix for radical transitive verbs (RTVs).
-   : Active = Ø (Lesson 26), Simple Passive = -Vtaj
-    (Lesson 28, where V is a copy of the root vowel), Agent Focus = -Vk
-    (Lesson 30). -/
+/-- Voice-marker suffix for radical transitive verbs (RTVs), per
+    [mondloch-2017]: active Ø (Lesson 26), simple passive *-Vtaj*
+    (Lesson 28, V copying the root vowel), Agent Focus *-Vk* (Lesson 30). -/
 def rtvVoiceMarker : KicheVoice → String
   | .active                 => "Ø"
   | .simplePassive          => "-Vtaj"
@@ -125,30 +99,24 @@ def rtvVoiceMarker : KicheVoice → String
   | .agentFocus             => "-Vk"
   | .completedPassive       => "-Vtaj"
 
--- ============================================================================
--- § 4: Aspect Markers
--- ============================================================================
+/-! ### Aspect markers -/
 
-/-- K'iche' aspect markers., Lesson 9. -/
+/-- K'iche' aspect markers ([mondloch-2017] Lesson 9). -/
 inductive Aspect where
   | incomplete  -- k- (ka- before clusters)
   | completed   -- x-
   deriving DecidableEq, Repr
 
-/-- The morphological form of the aspect marker.
-   , Lesson 9: k- (ka-) for incomplete, x- for
-    completed. -/
+/-- The morphological form of the aspect marker ([mondloch-2017]
+    Lesson 9): k- (ka-) for incomplete, x- for completed. -/
 def aspectMarker : Aspect → String
   | .incomplete => "k-"
   | .completed  => "x-"
 
--- ============================================================================
--- § 5: Morphological Templates
--- ============================================================================
+/-! ### Morphological templates -/
 
-/-- The transitive active voice template:
-    aspect + P(Set B) + A(Set A) + root + voice marker.
-   , Lesson 15. -/
+/-- Transitive active voice template: aspect + P(Set B) + A(Set A) + root +
+    voice marker ([mondloch-2017] Lesson 15). -/
 structure ActiveVerbForm where
   aspect : Aspect
   object : PhiFeatures  -- P: cross-referenced by Set B
@@ -157,10 +125,8 @@ structure ActiveVerbForm where
   verbClass : TransVerbClass
   deriving Repr
 
-/-- The passive voice template:
-    aspect + S(Set B) + root + passive marker.
-    The agent appears as an oblique (rumaal/kumaal).
-   , Lesson 19. -/
+/-- Passive voice template: aspect + S(Set B) + root + passive marker, with
+    the agent as an oblique (rumaal/kumaal) ([mondloch-2017] Lesson 19). -/
 structure PassiveVerbForm where
   aspect : Aspect
   subject : PhiFeatures  -- promoted P, cross-referenced by Set B
@@ -168,10 +134,9 @@ structure PassiveVerbForm where
   verbClass : TransVerbClass
   deriving Repr
 
-/-- The antipassive voice template:
-    aspect + S(Set B) + root + antipassive marker.
-    P is suppressed. Verb conjugates like an intransitive.
-   , Lesson 21. -/
+/-- Antipassive voice template: aspect + S(Set B) + root + antipassive
+    marker; P is suppressed and the verb conjugates like an intransitive
+    ([mondloch-2017] Lesson 21). -/
 structure AntipassiveVerbForm where
   aspect : Aspect
   subject : PhiFeatures  -- A, cross-referenced by Set B (as intransitive)
@@ -179,9 +144,7 @@ structure AntipassiveVerbForm where
   verbClass : TransVerbClass
   deriving Repr
 
--- ============================================================================
--- § 6: Argument Realization per Voice
--- ============================================================================
+/-! ### Argument realization per voice -/
 
 /-- Does this voice realize A (the transitive agent) as a full
     agreement-bearing argument? In Active and Agent Focus, yes. In
@@ -220,22 +183,18 @@ def KicheVoice.ConjugatesIntransitively : KicheVoice → Prop
 instance : DecidablePred KicheVoice.ConjugatesIntransitively := fun v => by
   cases v <;> unfold KicheVoice.ConjugatesIntransitively <;> infer_instance
 
--- ============================================================================
--- § 7: Agent Focus and Subject Extraction
--- ============================================================================
+/-! ### Agent Focus and subject extraction -/
 
-/-- Agent Focus is the voice used for subject extraction in K'iche'.
-    When 'who' questions target the agent, the verb appears in Agent
-    Focus, not Active Voice. This is why *wi* is not licensed for
-    subject extraction — Agent Focus morphology is used instead.
-   , Lesson 22; [mendes-ranero-2021], §2. -/
+/-- Agent Focus is the voice used for subject extraction in K'iche': 'who'
+    questions targeting the agent take AF, not Active, which is why *wi* is
+    not licensed for subject extraction ([mondloch-2017] Lesson 22;
+    [mendes-ranero-2021] §2). -/
 def subjectExtractionVoice : KicheVoice := .agentFocus
 
-/-- Agent Focus Antipassive shares the same marker as Absolutive
-    Antipassive for DTVs (-n), but their functions are distinct.
-   , Lesson 22 notes: "In spite of the confusingly
-    similar structure between the two voices, their meanings are quite
-    different." -/
+/-- Agent Focus and Absolutive Antipassive share the DTV marker *-n* but
+    differ in function — [mondloch-2017] Lesson 22: "In spite of the
+    confusingly similar structure between the two voices, their meanings
+    are quite different." -/
 theorem af_marker_eq_antip_marker :
     dtvVoiceMarker .agentFocus = dtvVoiceMarker .absolutiveAntipassive := rfl
 
@@ -245,17 +204,9 @@ theorem rtv_af_marker_neq_antip :
     rtvVoiceMarker .agentFocus ≠ rtvVoiceMarker .absolutiveAntipassive := by
   decide
 
--- ============================================================================
--- § 8: Voice System Profile
--- ============================================================================
+/-! ### Voice system profile -/
 
 namespace VoiceSystem
-
-/-! ### K'iche' voice system profile
-
-Five voices, asymmetrical (Active is the basic form): 5 voices
-(+ instrumental, not covered); Active is basic ([mondloch-2017]);
-Agent Focus used for subject extraction. -/
 
 /-- The five voices of K'iche'. -/
 def voices : List Voice.VoiceEntry :=
@@ -270,9 +221,7 @@ def symmetry : Voice.VoiceSystemSymmetry := .asymmetrical
 
 end VoiceSystem
 
--- ============================================================================
--- § 9: Voice System Theorems
--- ============================================================================
+/-! ### Voice system theorems -/
 
 /-- K'iche' has 5 voices. -/
 theorem kiche_voice_count : Voice.voiceCount Kiche.VoiceSystem.voices = 5 := rfl
@@ -286,9 +235,7 @@ theorem kiche_asymmetrical :
 theorem kiche_not_simple_active_passive :
     ¬ Voice.isActivePassive Kiche.VoiceSystem.voices := by decide
 
--- ============================================================================
--- § 10: DTV Voice Marker Verification
--- ============================================================================
+/-! ### DTV voice-marker verification -/
 
 theorem dtv_active_marker : dtvVoiceMarker .active = "-j" := rfl
 theorem dtv_passive_marker : dtvVoiceMarker .simplePassive = "-x" := rfl
@@ -296,14 +243,11 @@ theorem dtv_antip_marker : dtvVoiceMarker .absolutiveAntipassive = "-n" := rfl
 theorem dtv_af_marker : dtvVoiceMarker .agentFocus = "-n" := rfl
 theorem dtv_comppass_marker : dtvVoiceMarker .completedPassive = "-taaj" := rfl
 
--- ============================================================================
--- § 11: Negation Template — Lesson 13
--- ============================================================================
+/-! ### Negation template -/
 
-/-- K'iche' negation uses a circumfixal pattern: **na...taj/ta**.
-    The first element *na* precedes the negated constituent; the second
-    element *taj* (or *ta* before verbs) follows it.
-   , Lesson 13. -/
+/-- K'iche' circumfixal negation na...taj/ta: *na* precedes the negated
+    constituent, *taj* (or *ta* before verbs) follows it ([mondloch-2017]
+    Lesson 13). -/
 structure Negation where
   proclitic : String := "na"
   enclitic : String
@@ -319,11 +263,5 @@ def negVerbal : Negation := { enclitic := "ta" }
 /-- Both negation forms share the proclitic *na*. -/
 theorem neg_same_proclitic :
     negNonverbal.proclitic = negVerbal.proclitic := rfl
-
--- The substrate-typed word-order profile lives in
--- `Fragments/Mayan/Kiche/WordOrder.lean`. The transitive vs intransitive
--- vs passive distinction Mondloch draws (Lesson 9) is paper-specific
--- apparatus and would belong in a `Studies/Mondloch2017.lean`
--- if a study file were written; nothing currently consumes it.
 
 end Kiche

--- a/Linglib/Fragments/Mayan/Kiche/WordOrder.lean
+++ b/Linglib/Fragments/Mayan/Kiche/WordOrder.lean
@@ -1,40 +1,36 @@
 import Linglib.Features.WordOrder
 
 /-!
-# K'iche' word-order profile [mondloch-2017] [clemens-coon-2018]
+# K'iche' Word-Order Profile
 
-K'iche' is not coded in WALS Chs 81/82/83 (ISO `quc` is absent), so
-the profile is grammar-grounded from [mondloch-2017] rather than
-via `WordOrderProfile.ofWALS`. Mondloch documents verb-initial order:
-VS for intransitives and VOS for transitives.
+Grammar-grounded word-order profile for K'iche' (K'ichean Mayan) from
+[mondloch-2017], who documents verb-initial order: VS for intransitives
+and VOS for transitives. K'iche' is not coded in WALS Chs 81/82/83 (ISO
+`quc` is absent), so the fields override `.notInWALS` rather than
+deriving via `WordOrderProfile.ofWALS`.
 
-## A contested classification
+## Implementation notes
 
-The `.vos` choice follows Mondloch's preferred-order analysis. The
-broader Mayanist literature on basic word order in K'iche'an (and
-Mayan more generally) is contested: K'iche' admits both VOS and VSO
-for transitive clauses, with subject-initial orders increasingly
-attested under Spanish contact. Sister-language WALS codings
-illustrate the divergence — Kaqchikel `cak` is `.vos` in Ch 81,
-Tzutujil `tzj` is `.noDominantOrder`, Mam `mam` is `.vso` (different
-branch but verb-initial). [clemens-coon-2018] surveys
-derivational accounts of verb-initiality across Mayan; an alternative
+The `.vos` basic order follows Mondloch's preferred-order analysis.
+Basic word order in K'iche'an (and Mayan generally) is contested:
+K'iche' admits both VOS and VSO for transitives, with subject-initial
+orders increasingly attested under Spanish contact. Sister-language
+WALS codings illustrate the divergence — Kaqchikel `cak` is `.vos` in
+Ch 81, Tzutujil `tzj` is `.noDominantOrder`, Mam `mam` is `.vso`
+(different branch but verb-initial). [clemens-coon-2018] surveys
+derivational accounts of Mayan verb-initiality; an alternative
 substrate commitment would be `.noDominant` (parallel to Tzutujil) or
-`.vso` per a corpus analysis. The Fragment commits to `.vos` because
-that is Mondloch's explicit description; consumers wanting a different
-basic-order claim should override. The `.vs` svOrder + `.vo` ovOrder
-commitments are robust across the contestation (K'iche' is verb-
-initial in both intransitive and transitive clauses).
+`.vso` per a corpus analysis. The `.vs`/`.vo` commitments are robust
+across the contestation — K'iche' is verb-initial in both intransitive
+and transitive clauses.
 -/
 
 namespace Kiche
 
-/-- K'iche' word-order profile, grammar-grounded from
-    [mondloch-2017] ("the preferred word order appears to be:
-    verb-subject", with VOS for transitives). Not in WALS Chs
-    81/82/83 — fields override `.notInWALS`. The `.vos` basic-order
-    commitment is contested across Mayanist literature; see module
-    docstring. -/
+/-- K'iche' word-order profile, grammar-grounded from [mondloch-2017]
+    ("the preferred word order appears to be: verb-subject", VOS for
+    transitives); not in WALS Chs 81/82/83, so fields override
+    `.notInWALS`. -/
 def wordOrder : WordOrder.WordOrderProfile :=
   { basicOrder := .vos
     svOrder := .vs

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -6,72 +6,62 @@ import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Extraction
 
 /-!
-# Mam Agreement Fragment [scott-2023]
-[deal-2024] [woolford-1997] [blake-1994]
+# Mam Agreement Fragment
 
-Agreement morphology and pronoun realization data for **San Juan Atitán
-Mam (SJA Mam)**, the dialect analyzed in [scott-2023]. Per Scott's
-Chapter 3 (titled "Object licensing and agreement: SJA Mam is a
-**tripartite high-abs language**"), SJA Mam exhibits morphologically
-tripartite agreement alignment: S, A, and O each trigger distinct
-marking patterns on the verb.
+Agreement morphology and pronoun realization data for San Juan Atitán
+Mam (SJA Mam, Mayan), following [scott-2023]. SJA Mam has morphologically
+tripartite agreement alignment — S, A, and O each trigger distinct
+verbal marking (Scott's ch. 3, "Object licensing and agreement: SJA Mam
+is a tripartite high-abs language") — realized through two paradigms:
+Set A (ERG) prefixes on Voice cross-referencing the transitive agent,
+and Set B (ABS) preverbal markers on Infl cross-referencing the
+absolutive (intransitive S). Transitive objects are cross-referenced by
+neither set: they co-occur with default Set B (tz'=) and require full
+overt pronouns, though some speakers accept agreeing Set B for objects
+as a more formal variant ([scott-2023] ch. 3, ex. 156).
 
-## Dialect-specificity and the analytical contrast
+## Main declarations
 
-This fragment encodes Scott's analysis of SJA Mam specifically. Other
-Mam dialects (notably Ixtahuacán Mam, the variety described in England
-1983b and used by [zavala-maldonado-2017] §4-5) have been
-characterized as **ergative with a neutral pattern in aspectless
-dependent clauses** — NOT tripartite. Per Zavala 2017 §4 (p. 237),
-"Ch'orti' is the only Mayan language that exhibits three sets of
-pronominal markers" — making Ch'orti' the canonical tripartite Mayan
-language under that framing.
+* `Mam.setAExponent`, `Mam.setBExponent`: the Set A (ERG) and Set B
+  (ABS) exponent tables ([scott-2023] Tables 2.8, 3.5).
+* `Mam.ArgPosition` with `.case`, `.IsPhiAgreed`, `.CanBeReduced`:
+  argument positions, their tripartite case values, φ-agreement status,
+  and reduction eligibility.
+* `Mam.PhiDimension` with `.Copied`, `agreedDimensions`,
+  `baseDimensions`, `encliticDimensions`: the φ-feature redundancy
+  calculus behind pronoun reduction.
+* `Mam.realizedPronoun`: pronoun realization by argument position, as a
+  selection among the shared `PersonalPronoun` entries.
+* `Mam.caseInventory`: the {ERG, ACC, ABS} inventory, validated against
+  [blake-1994]'s hierarchy.
+* `Mam.absPosition`, `Mam.extractionStrategy`: HIGH-ABS morpheme
+  placement and the AF-based extraction profile.
 
-Scott's tripartite analysis of SJA Mam is an **analytical contribution**
-that uses a high-abs / Voice Licensing / Ergative Extraction Constraint
-framework (her ch. 3 §3.4) to argue for tripartite case (ERG, ACC, ABS)
-even though Mam lacks independent DP case morphology. Per Scott §1.2.4
-(Mam dialect variation, p. 11) and Table 1.2 (Mam dialect groups,
-citing Simon 2019), Mam dialects vary substantially; the SJA Mam
-analysis may not extend directly to Ixtahuacán Mam.
+## Implementation notes
 
-## The System
+This fragment encodes Scott's tripartite analysis of SJA Mam
+specifically — an analytical contribution using a high-abs / Voice
+Licensing / Ergative Extraction Constraint framework ([scott-2023] ch. 3
+§3.4) to argue for tripartite case (ERG, ACC, ABS) even though Mam lacks
+independent DP case morphology; case is visible only through agreement.
+Other Mam dialects (notably Ixtahuacán Mam, described in England 1983b
+and used by [zavala-maldonado-2017] §4-5) are characterized as ergative
+with a neutral pattern in aspectless dependent clauses — not tripartite;
+per [zavala-maldonado-2017] §4 (p. 237), "Ch'orti' is the only Mayan
+language that exhibits three sets of pronominal markers", the canonical
+tripartite Mayan language under that framing. Per [scott-2023] §1.2.4
+and Table 1.2 (citing Simon 2019), Mam dialects vary substantially, so
+the SJA analysis may not extend to Ixtahuacán Mam.
 
-Mam has two agreement paradigms on the verb:
-- **Set A** (ERG): prefixes on Voice cross-referencing the transitive agent
-- **Set B** (ABS): preverbal markers on Infl cross-referencing the absolutive
-  argument (intransitive S). In transitives, Infl's φ-probe is blocked by
-  transitive VoiceP and default Set B (∅/tz'=)
-  appears instead.
-
-In the default construction, transitive *objects* are not cross-referenced
-by either set — they co-occur with default Set B (tz'=) and require
-full overt pronouns. However, some speakers accept agreeing Set B
-for objects as a more formal variant ([scott-2023], ch. 3, ex. 156).
-
-## Case Licensing (per Scott's analysis)
-
-Case is NOT assigned via dependent case. Instead:
-- **ERG**: inherent case from Voice
-- **ACC**: structural case from Voice (object licensing; low-abs syntax)
-- **ABS**: structural case from Infl (high-abs morphology; for intransitive S)
-
-This gives a tripartite underlying Case system (ERG, ACC, ABS) despite
-Mam having no independent case morphology on DPs — case is visible only
-through agreement patterns. This tripartite analysis is dialect-specific
-to SJA Mam per Scott; alternative analyses (for other Mam dialects or
-under different theoretical frameworks) characterize Mam as ergative
-with neutral patterns in dependent clauses (England 1983b;
-[zavala-maldonado-2017] §4-5).
-
-## Argument Positions
-
-| Position | Case | Agreement | Pronoun |
-|----------|------|-----------|---------|
-| A (transitive agent) | ERG (from Voice) | Set A | reduced/null |
-| S (intransitive subj) | ABS (from Infl) | Set B | reduced/null |
-| P (transitive patient) | ACC (from Voice) | default Set B | **overt** |
-
+Case is not dependent case ([scott-2023]; cf. [woolford-1997],
+[deal-2024]): ERG is inherent case from Voice, ACC structural case from
+Voice (object licensing, low-abs syntax), ABS structural case from Infl
+(high-abs morphology, for intransitive S). In transitives, Infl's φ-probe
+is blocked by transitive VoiceP and default Set B (∅/tz'=) surfaces.
+Person-number cells are the canonical φ-cells `Agreement.Cell`
+(`Syntax/Agreement/Paradigm.lean`), built with `Agreement.Cell.pn` (the
+six-cell inventory `Agreement.Cell.pnCells`); per-cell pronoun feature
+values live in `Mam.ScottFeatures` (`Fragments/Mayan/Mam/Pronouns.lean`).
 -/
 
 namespace Mam
@@ -80,82 +70,50 @@ open Mayan (MarkerLinearity ExponentTable)
 open Agreement
 open Features.Prominence (ArgumentRole)
 
--- ============================================================================
--- § 1: Person-Number Inventory
--- ============================================================================
+/-! ### Agreement marker paradigms -/
 
--- Person-number values are the canonical φ-cells `Agreement.Cell`
--- (six relevant cells: three persons × two numbers). Build them with
--- `Agreement.Cell.pn` (e.g. `.pn .first .Sing`); the six-cell inventory
--- is `Agreement.Cell.pnCells`.
-
--- ============================================================================
--- § 2: Agreement Marker Paradigms (theory-neutral)
--- ============================================================================
-
-/-- Set A (ERG) markers per cell: prefixes/proclitics on the verb that
-    cross-reference the transitive agent ([scott-2023], Table 2.8).
-    All six cells have distinct exponents (with t- syncretism for 2sg/3sg
-    and ky- syncretism for 2pl/3pl). -/
+/-- Set A (ERG) markers cross-referencing the transitive agent
+    ([scott-2023] Table 2.8); t- is syncretic for 2/3SG, ky- for 2/3PL. -/
 def setAExponent : ExponentTable :=
   [(.pn .first .Sing, "n-/w-"), (.pn .second .Sing, "t-"), (.pn .third .Sing, "t-"),
    (.pn .first .Plur, "q-"), (.pn .second .Plur, "ky-"), (.pn .third .Plur, "ky-")]
 
-/-- Set B (ABS) markers per cell ([scott-2023], Table 3.5).
-    The 2/3SG form tz'= is the **default** — it appears both for real
-    agreement with a 2/3SG intransitive S and for default Set B in
-    transitives when Infl's probe is blocked by VoiceP.
-
-    Per Scott's DM analysis, 2sg and 3sg are NOT specific entries; they
-    surface via the Elsewhere fallback. The total function below
-    returns "tz'=" for both, but downstream Vocabulary construction
-    should treat them as derived from the Elsewhere entry. See
-    `setBSpecificCells` for the cells that have actual specific
-    Vocabulary Items in the DM analysis. -/
+/-- Set B (ABS) markers ([scott-2023] Table 3.5). The 2/3SG form tz'= is
+    the Elsewhere default: it realizes both real 2/3SG intransitive-S
+    agreement and default Set B in transitives when Infl's probe is
+    blocked by VoiceP. Per Scott's DM analysis 2SG and 3SG are not
+    specific Vocabulary Items but surface via Elsewhere fallback (see
+    `setBSpecificCells`). -/
 def setBExponent : ExponentTable :=
   [(.pn .first .Sing, "chin"), (.pn .second .Sing, "tz'="), (.pn .third .Sing, "tz'="),
    (.pn .first .Plur, "qo"), (.pn .second .Plur, "chi"), (.pn .third .Plur, "chi")]
 
-/-- The four Set B cells that have specific Vocabulary Items (per
-    Scott's DM analysis). 2sg and 3sg are NOT included — they fall
-    through to the Elsewhere entry. -/
+/-- The four Set B cells with specific Vocabulary Items ([scott-2023]);
+    2SG and 3SG fall through to the Elsewhere entry. -/
 def setBSpecificCells : List Cell :=
   [.pn .first .Sing, .pn .first .Plur, .pn .second .Plur, .pn .third .Plur]
 
-/-- The default (Elsewhere) Set B marker. Surfaces in transitives when
-    Infl's probe is blocked, and also for 2/3SG intransitive S. -/
+/-- The Elsewhere Set B marker, surfacing in transitives when Infl's
+    probe is blocked and for 2/3SG intransitive S. -/
 def defaultSetB : String := "tz'="
 
--- ============================================================================
--- § 2: Argument Positions and Agreement Status (substrate-anchored)
--- ============================================================================
+/-! ### Argument positions and agreement status -/
 
-/-- Argument positions in a Mam clause ([scott-2023] ch. 3).
-    Aliased to the canonical `Features.Prominence.ArgumentRole`
-    (S/A/P/R/T) so cross-Mayan and cross-framework code shares one
-    inventory. Use the canonical constructor names `.A` / `.P` / `.S`
-    directly. -/
+/-- Argument positions, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T) ([scott-2023] ch. 3). -/
 abbrev ArgPosition := Features.Prominence.ArgumentRole
 
-/-- The case each argument position receives. Definitionally equal to
-    `Mayan.ergCaseMam`, which derives from
-    `Alignment.tripartite.assignCase` in
-    `Syntax/Case/Alignment.lean`: A → ERG (inherent from Voice),
-    P → ACC (structural from Voice), S → ABS (structural from Infl).
-    The three distinct cases are tripartite alignment per Scott's
-    analysis (ch. 3 §3.4). -/
+/-- Tripartite case assignment: `Mayan.ergCaseMam` (A → ERG inherent
+    from Voice, P → ACC structural from Voice, S → ABS structural from
+    Infl; [scott-2023] ch. 3 §3.4). -/
 abbrev ArgPosition.case : ArgPosition → Case :=
   Mayan.ergCaseMam
 
-/-- Does this argument position participate in φ-Agree?
-
-    Agent: Voice probes for φ, finds agent in Spec,VoiceP → Set A
-    Intransitive S: Infl probes for φ, finds S → Set B
-    Patient: Infl's φ-probe has a disjunctive satisfaction condition
-    [SAT: φ or Voice_TR]. In transitives, the
-    probe encounters transitive Voice and stops — no φ-features are
-    copied, and default Set B (the Elsewhere form) surfaces.
-    Ditransitive R/T default to participating (not modeled). -/
+/-- Whether a position triggers φ-Agree. A is probed by Voice (→ Set A),
+    S by Infl (→ Set B); the transitive patient is not, because Infl's
+    φ-probe has a disjunctive satisfaction condition [SAT: φ or Voice_TR]
+    and stops at transitive Voice before copying features, so default Set
+    B surfaces. R/T default to participating (not modeled). -/
 def ArgPosition.IsPhiAgreed : ArgPosition → Prop
   | .A => True   -- φ-Agreed by Voice → Set A
   | .P => False  -- NOT φ-Agreed: Infl probe blocked by Voice_TR
@@ -164,32 +122,25 @@ def ArgPosition.IsPhiAgreed : ArgPosition → Prop
 instance : DecidablePred ArgPosition.IsPhiAgreed := fun p => by
   cases p <;> unfold ArgPosition.IsPhiAgreed <;> infer_instance
 
--- ============================================================================
--- § 3: Pronoun Realization
--- ============================================================================
+/-! ### Pronoun reduction eligibility -/
 
-/-- Can a pronoun in this argument position undergo reduction?
-
-    Scott's analysis (ch. 4, §4.4.3): first person pronouns in
-    agreed-with positions are reduced via an impoverishment rule that
-    deletes [±singular] in the context of [+author]^F (where F marks
-    that the feature has been agreed with). This bleeds insertion of
-    the pronominal base morphemes *qin* ([+author,+singular]) and *qo*
-    ([+author,-singular]), leaving only the disagreement enclitic =i.
-
-    Non-first person pronouns are NOT reduced — their subj/poss forms
-    are identical to their independent forms (Table 4.25, p. 200).
-    Whether actual reduction occurs depends on person (see
-    `realizedPronoun`), but only agreed-with positions are eligible. -/
+/-- Whether a pronoun here is eligible for reduction (≡ φ-agreement).
+    Under Scott's analysis (ch. 4 §4.4.3), agreed-with first-person
+    pronouns undergo an impoverishment rule deleting [±singular] in the
+    context of [+author]^F (F = agreed-with), bleeding the base morphemes
+    *qin* [+author,+sg] and *qo* [+author,−sg] and leaving only the
+    disagreement enclitic =i; non-first-person pronouns are not reduced,
+    their subject/possessor forms matching the independent ones
+    ([scott-2023] Table 4.25, p. 200). Only agreed-with positions are
+    eligible; whether reduction actually applies depends on person (see
+    `realizedPronoun`). -/
 def ArgPosition.CanBeReduced (pos : ArgPosition) : Prop :=
   pos.IsPhiAgreed
 
 instance : DecidablePred ArgPosition.CanBeReduced := fun pos => by
   unfold ArgPosition.CanBeReduced; exact inferInstance
 
--- ============================================================================
--- § 4: Per-Position Verification
--- ============================================================================
+/-! ### Per-position verification -/
 
 -- The per-position case facts are the tripartite-alignment facts
 -- (`Alignment.tripartite`) — SJA Mam's case function is
@@ -205,28 +156,23 @@ theorem P_case : ArgPosition.case .P = .acc := Alignment.tripartite.assignCase_P
 /-- Intransitive S gets ABS (structural, from Infl). -/
 theorem S_case : ArgPosition.case .S = .abs := Alignment.tripartite.assignCase_S
 
-/-- Three distinct underlying cases — morphologically tripartite.
-    Inherits from `Alignment.tripartite_distinguishes_all` via the
-    substrate connection. -/
+/-- Three distinct underlying cases (morphologically tripartite),
+    inherited from `Alignment.tripartite_distinguishes_all`. -/
 theorem tripartite_alignment :
     ArgPosition.case .A ≠ ArgPosition.case .P ∧
     ArgPosition.case .A ≠ ArgPosition.case .S ∧
     ArgPosition.case .P ≠ ArgPosition.case .S :=
   Alignment.tripartite_distinguishes_all
 
-/-- Reduction eligibility ≡ φ-agreement: an argument position is
-    eligible for pronoun reduction iff it triggers agreement on the
-    verb. By `CanBeReduced := IsPhiAgreed`, this is reflexivity. -/
+/-- Reduction eligibility coincides with φ-agreement — reflexivity,
+    since `CanBeReduced := IsPhiAgreed`. -/
 theorem reduction_eligible_iff_phi_agreed (pos : ArgPosition) :
     pos.CanBeReduced ↔ pos.IsPhiAgreed :=
   Iff.rfl
 
--- ============================================================================
--- § 5: Case Inventory Validation ([blake-1994])
--- ============================================================================
+/-! ### Case inventory ([blake-1994]) -/
 
-/-- The SJA Mam case inventory, derived from the core argument
-    positions' case values: {ERG, ACC, ABS}. -/
+/-- The case inventory realized by the core positions: {ERG, ACC, ABS}. -/
 def caseInventory : Finset Case := (ArgumentRole.core.map ArgPosition.case).toFinset
 
 /-- The inventory covers all argument positions. -/
@@ -237,25 +183,22 @@ theorem inventory_covers_positions :
 -- (all are core cases at rank 6, trivially no gaps).
 example : Case.IsValidInventory caseInventory := by decide
 
--- ============================================================================
--- § 6: Pronoun Internal Structure ([scott-2023], ch. 4)
--- ============================================================================
+/-! ### Pronoun internal structure ([scott-2023] ch. 4) -/
 
-/-- φ-dimensions of the SJA Mam pronominal system ([scott-2023] Table 4.4,
-    adopting [harbour-2016]'s bivalent features): [±author], [±participant],
-    [±singular]. Per-cell *values* live in `Mam.ScottFeatures`
-    (`Fragments/Mayan/Mam/Pronouns.lean`, where the disagreement
-    distribution of the =i enclitic is verified); this enum names the
-    *dimensions*, for the redundancy calculus below. -/
+/-- The three φ-dimensions of the SJA Mam pronominal system ([scott-2023]
+    Table 4.4, after [harbour-2016]'s bivalent features): [±author],
+    [±participant], [±singular]. This enum names the dimensions for the
+    redundancy calculus below; per-cell values live in `Mam.ScottFeatures`
+    (`Fragments/Mayan/Mam/Pronouns.lean`). -/
 inductive PhiDimension where
   | author
   | participant
   | singular
   deriving DecidableEq, Repr
 
-/-- Dimensions referenced by Set A/Set B agreement vocabulary items: only
-    [±author] and [±singular] (Tables 4.7-4.8) — agreement never copies
-    [±participant]. -/
+/-- Dimensions referenced by Set A and Set B agreement Vocabulary Items —
+    [±author] and [±singular] only ([scott-2023] Tables 4.7-4.8);
+    agreement never copies [±participant]. -/
 def agreedDimensions : List PhiDimension := [.author, .singular]
 
 /-- Dimensions realized by the pronominal base morphemes *qin*
@@ -272,25 +215,25 @@ def PhiDimension.Copied (d : PhiDimension) : Prop := d ∈ agreedDimensions
 instance : DecidablePred PhiDimension.Copied := fun d => by
   unfold PhiDimension.Copied; infer_instance
 
-/-- The pronominal base is fully redundant under agreement: every dimension
-    it realizes is copied — the configuration in which impoverishment bleeds
-    base insertion (§4.4). -/
+/-- The pronominal base is fully redundant under agreement — every
+    dimension it realizes is copied, the configuration in which
+    impoverishment bleeds base insertion ([scott-2023] §4.4). -/
 theorem base_is_redundant : ∀ d ∈ baseDimensions, d.Copied := by decide
 
 /-- The =i enclitic is not fully redundant: [±participant] is never copied
     by agreement — so the enclitic survives reduction. -/
 theorem enclitic_survives : ¬ (∀ d ∈ encliticDimensions, d.Copied) := by decide
 
-/-- Pronoun realization by argument position ([scott-2023], her (3)/(8):
-    nominative alignment of reduction). φ-agreed positions (A, S — and
-    possessors) take the subject/possessor series; the unagreed object
-    position takes the independent series. The impoverishment rule
-    (ex. 84/94) `[±singular] → ∅ / [+author]^F` targets [+author] features
-    bearing the agreed-with diacritic F, bleeding insertion of the bases
-    *qin*/*qo* — so agreed-with first person surfaces as bare *=i*
-    (or ∅ for 1PL.INCL), while everything else keeps its independent
-    form. Realization is *selection among the API's `PersonalPronoun`
-    entries*, not a separate form classification. -/
+/-- Pronoun realization by argument position — the nominative alignment
+    of reduction ([scott-2023] (3)/(8)). φ-agreed positions (A, S, and
+    possessors) take the subject/possessor series, the unagreed object
+    the independent series. The impoverishment rule
+    `[±singular] → ∅ / [+author]^F` (ex. 84/94) targets [+author] under
+    the agreed-with diacritic F, bleeding the bases *qin*/*qo*, so
+    agreed-with first person surfaces as bare *=i* (∅ for 1PL.INCL) while
+    everything else keeps its independent form. Realization selects among
+    the shared `PersonalPronoun` entries, not a separate form
+    classification. -/
 def realizedPronoun (pos : ArgPosition) (c : PronCell) : Option PersonalPronoun :=
   if pos.IsPhiAgreed then subjPoss c else independent c
 
@@ -335,13 +278,11 @@ theorem patient_takes_independent (c : PronCell) :
     realizedPronoun .P c = independent c := by
   cases c <;> decide
 
--- ============================================================================
--- § 7: Mayan Absolutive Parameter
--- ============================================================================
+/-! ### Mayan absolutive parameter -/
 
-/-- Mam is HIGH-ABS: Set B (absolutive) markers appear pre-stem on Infl,
-    immediately following the aspect marker. Morpheme template:
-    ASP-**ABS**-ERG-ROOT-SUFFIX ([scott-2023], §2.5.1). -/
+/-- HIGH-ABS: Set B (absolutive) markers sit pre-stem on Infl, right
+    after the aspect marker — template ASP-**ABS**-ERG-ROOT-SUFFIX
+    ([scott-2023] §2.5.1). -/
 def absPosition : Mayan.ABSPosition := .high
 
 /-- HIGH-ABS yields ABS=NOM case locus: Infl assigns case to the
@@ -356,31 +297,20 @@ def setALinearity : MarkerLinearity := .prefixal
     per [scott-2023] §2.5.1). -/
 def setBLinearity : MarkerLinearity := .prefixal
 
-/-- Mam's extraction strategy: AF morphology is productive in SJA Mam
-    ([scott-2023] §2.5.4.1 ex. 169 + §2.7.1 syntactic ergativity).
-    The construction combines the antipassive suffix *-(a)n* with the
-    AF-specific suffix *-ta* (e.g., `b'yo-n-ta` 'hit-AP-AF'), making
-    SJA Mam's AF morphologically distinct from K'iche''s (which uses
-    bare antipassive *-n* in AF contexts per [mondloch-2017]
-    Lesson 22 — no extra AF morpheme).
-
-    For the cross-Mayan typology, we mark the strategy as
-    `dedicatedMorpheme` (the descriptive surface category) to parallel
-    Q'anjob'al/Kaqchikel/K'iche'. The analytical claim that AF is an
-    SSAL repair (Erlewine-line) lives in
-    `Studies/Erlewine2016.lean`; rival accounts
-    (Coon-Mateo Pedro-Preminger absolutive licensing, Coon-Keine
-    Feature Gluttony) are not encoded in the typology enum.
-
-    Language: "Mam (SJA)". Notes: AF (-(a)n + -ta) for A-extraction;
-    HIGH-ABS tripartite Mam (Scott 2023 §2.5.4.1). -/
+/-- Mam's extraction strategy, marked `dedicatedMorpheme` for the
+    cross-Mayan typology (parallel to Q'anjob'al, Kaqchikel, K'iche').
+    AF is productive in SJA Mam ([scott-2023] §2.5.4.1 ex. 169, §2.7.1)
+    and combines the antipassive suffix *-(a)n* with an AF-specific
+    suffix *-ta* (`b'yo-n-ta` 'hit-AP-AF'), morphologically distinct from
+    K'iche''s bare antipassive *-n* ([mondloch-2017] Lesson 22). The
+    SSAL-repair analysis (Erlewine-line) lives in `Studies/Erlewine2016.lean`;
+    rival accounts (Coon-Mateo Pedro-Preminger absolutive licensing,
+    Coon-Keine Feature Gluttony) are not encoded in the enum. -/
 def extractionStrategy : Extraction.ExtractionMarkingStrategy := .dedicatedMorpheme
 def extractionMarkedPositions : List Extraction.ExtractionTarget := [.subject]
 def extractionDistinguishesPosition : Bool := true
 
--- ============================================================================
--- § 8: Theory-Neutral Marker Verification
--- ============================================================================
+/-! ### Marker verification -/
 
 /-- Set A 1SG marker. -/
 theorem setA_1sg : setAExponent.realize (.pn .first .Sing) = some "n-/w-" := rfl
@@ -394,12 +324,11 @@ theorem setB_1sg : setBExponent.realize (.pn .first .Sing) = some "chin" := rfl
 /-- Set B 3SG marker is the default "tz'=". -/
 theorem setB_3sg : setBExponent.realize (.pn .third .Sing) = some defaultSetB := rfl
 
-/-- A controller's φ-features index the agreement paradigm directly: a 1sg agent
-    selects its first-person-singular ergative prefix. The Set A table
-    (`setAExponent`) is keyed by canonical φ-cells, so a pronoun's `Word.agrCell`
-    drives agreement realization in one shared feature space ([corbett-1998];
-    [scott-2023] Ch. 2). The realizational account (impoverishment /
-    Elsewhere; [scott-2023] Ch. 4) is theory and stays in the study. -/
+/-- A controller's φ-features index the agreement paradigm directly: the
+    Set A table is keyed by canonical φ-cells, so a pronoun's
+    `Word.agrCell` drives realization in one shared feature space
+    ([corbett-1998]; [scott-2023] Ch. 2). The realizational account
+    (impoverishment, Elsewhere; [scott-2023] Ch. 4) stays in the study. -/
 theorem erg_1sg_from_phi :
     setAExponent.realizeFor
       { form :="", cat := .PRON, features := { person := some .first, number := some .Sing }} = some "n-/w-" := by

--- a/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
+++ b/Linglib/Fragments/Mayan/Mam/ExtractionMorphology.lean
@@ -2,63 +2,62 @@ import Linglib.Syntax.Extraction
 import Linglib.Data.UD.Basic
 
 /-!
-# Mam Extraction Morphology Fragment [elkins-torrence-brown-2026]
+# Mam Extraction Morphology Fragment
 
-Theory-neutral data on extraction morphology in San Juan Ostuncalco (SJO) Mam,
-a Mayan language spoken in the Western Highlands of Guatemala.
+Theory-neutral data on extraction morphology in San Juan Ostuncalco
+(SJO) Mam (Mayan, Western Highlands of Guatemala), following
+[elkins-torrence-brown-2026]. When an oblique undergoes Ā-movement
+(wh-movement, focus fronting, relativization), the optional enclitic
+=(y)a' may appear on the verbal complex — on Voice⁰ or Dir⁰
+(directional auxiliary). Its distribution is conditioned by clause size
+(licensed only where Voice⁰ projects; impossible in VP-sized infinitival
+complements, [elkins-torrence-brown-2026] §6) and by extraction target
+(oblique extraction only — subject extraction triggers Agent Focus *-a*,
+object extraction triggers neither, §3.1; temporal 'when' obliques also
+do not trigger it, §8.1).
 
-## The Phenomenon
+The central finding is multiple spellout: in long-distance extraction
+through full CPs and aspectless clauses, =(y)a' can appear on both the
+matrix and embedded predicates — one per Voice/Dir head along the
+successive-cyclic movement path (Table 4, §6.2).
 
-When an oblique argument undergoes Ā-movement (wh-movement, focus fronting,
-relativization) in Mam, the **optional** enclitic =(y)a' may appear on the
-verbal complex — specifically on Voice⁰ or Dir⁰ (directional auxiliary).
-Its distribution is conditioned by two factors:
+## Main declarations
 
-1. **Clause size**: =(y)a' is licensed only in clauses that project Voice⁰.
-   In infinitival complements (VP-sized, lacking Voice), =(y)a' is impossible
-   even when an oblique has extracted (Elkins et al. §6).
+* `Mam.MamClauseType` with `.projectsVoice`: the three clause sizes
+  (full CP, aspectless, infinitival) and whether each projects Voice.
+* `Mam.MamExtractionDatum`, `Mam.monoData`: monoclausal extraction data
+  points and their pooled list.
+* `Mam.MamLongDistanceDatum`, `Mam.ldData`: long-distance data tracking
+  =(y)a' on the matrix and embedded predicates independently (Table 4).
+* `Mam.eqya_iff_voice_and_oblique`: the core generalization — =(y)a' is
+  licensed iff the clause projects Voice and a non-temporal oblique
+  extracts.
+* `Mam.MovementReflex` with `.islandSensitive`: island sensitivity
+  derived from movement being phase-bounded rather than stipulated.
+* `Mam.mamExtractionStrategy`: the oblique-marking extraction profile.
 
-2. **Extraction target**: =(y)a' marks specifically *oblique* extraction.
-   Subject extraction triggers Agent Focus (*-a*), not =(y)a'. Object
-   extraction triggers neither (§3.1). Temporal obliques ('when') also do
-   not trigger =(y)a' (§8.1).
+## Implementation notes
 
-## Key Empirical Finding: Multiple Spellout
-
-In long-distance extraction through full CPs and aspectless clauses, =(y)a'
-can appear on BOTH the matrix and embedded predicates — one per Voice/Dir
-head along the successive-cyclic movement path (Table 4, §6.2).
-
-## Data Sources
-
-All data from [elkins-torrence-brown-2026], "Wh-movement paths and oblique
-extraction in Mam (Mayan)". Examples cited by section/example number.
-
+All data is from [elkins-torrence-brown-2026], "Wh-movement paths and
+oblique extraction in Mam (Mayan)", cited by section/example number.
 -/
 
 namespace Mam
 
--- ============================================================================
--- § 1: Clause Types
--- ============================================================================
+/-! ### Clause types -/
 
-/-- The three clause sizes relevant for =(y)a' distribution in Mam.
-    These correspond to different structural sizes of the verbal domain
-    ([elkins-torrence-brown-2026] §6.1, following [coon-2019] and [elkins-torrence-brown-2026]):
-
-    - `fullCP`: Full finite clause with aspect — projects Voice
-    - `aspectless`: VoiceP-sized complement (no aspect) — projects Voice
-    - `infinitival`: VP-sized complement — does NOT project Voice -/
+/-- The three clause sizes relevant for =(y)a' distribution — different
+    structural sizes of the verbal domain ([elkins-torrence-brown-2026]
+    §6.1, following [coon-2019]). -/
 inductive MamClauseType where
-  /-- Full finite clause with aspect marking. Projects the full verbal
-      spine including Voice. =(y)a' licensed on oblique extraction. -/
+  /-- Full finite clause with aspect; projects Voice, so =(y)a' is
+      licensed on oblique extraction. -/
   | fullCP
-  /-- VoiceP-sized complement: lacks aspect but projects Voice.
-      =(y)a' licensed on oblique extraction (Elkins et al. §6.1,
-      following [elkins-torrence-brown-2026]). -/
+  /-- VoiceP-sized complement: no aspect but projects Voice, so =(y)a'
+      is licensed ([elkins-torrence-brown-2026] §6.1). -/
   | aspectless
-  /-- VP-sized infinitival complement: no Voice projected.
-      =(y)a' impossible — no Voice⁰ to host [oblique] (Elkins et al. §6.1). -/
+  /-- VP-sized infinitival complement: no Voice projected, so =(y)a' is
+      impossible — no Voice⁰ to host [oblique] ([elkins-torrence-brown-2026] §6.1). -/
   | infinitival
   deriving DecidableEq, Repr
 
@@ -68,15 +67,11 @@ def MamClauseType.projectsVoice : MamClauseType → Bool
   | .aspectless => true
   | .infinitival => false
 
--- ============================================================================
--- § 2: Extraction Judgments
--- ============================================================================
+/-! ### Extraction judgments -/
 
-/-- Judgment on the status of =(y)a' in a given configuration.
-    Note: =(y)a' is an **optional** enclitic.
-    `licensed` means =(y)a' may grammatically appear; `blocked` means it may
-    not. The optionality of =(y)a' when licensed is orthogonal to its
-    distributional constraints. -/
+/-- Status of =(y)a' in a configuration — `licensed` (may grammatically
+    appear; it is an optional enclitic) or `blocked`; optionality when
+    licensed is orthogonal to the distributional constraints. -/
 inductive MamExtractionJudgment where
   /-- =(y)a' is licensed (may appear) in this configuration -/
   | licensed
@@ -84,9 +79,7 @@ inductive MamExtractionJudgment where
   | blocked
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 3: Monoclausal Data
--- ============================================================================
+/-! ### Monoclausal data -/
 
 /-- A monoclausal extraction data point: a clause type, what is extracted,
     and whether =(y)a' is licensed. -/
@@ -99,13 +92,11 @@ structure MamExtractionDatum where
   clauseType : MamClauseType
   /-- Is an oblique being extracted? -/
   obliqueExtracted : Bool
-  /-- Is the extracted oblique temporal ('when')?
-      Temporal obliques do not trigger =(y)a' even when they are
-      genuinely oblique and genuinely extracted (§8.1, ex. 56).
-      This is currently **unexplained** — the paper notes it as an
-      open question: "we leave an account of this for future work"
-      (§8.1). We encode the exemption honestly rather than hiding it
-      by setting `obliqueExtracted := false` for temporals. -/
+  /-- Is the extracted oblique temporal ('when')? Temporal obliques do not
+      trigger =(y)a' though genuinely oblique and extracted (§8.1, ex. 56)
+      — encoded honestly rather than as `obliqueExtracted := false`. The
+      paper leaves this unexplained: "we leave an account of this for
+      future work" (§8.1). -/
   isTemporal : Bool := false
   /-- Judgment on =(y)a' -/
   judgment : MamExtractionJudgment
@@ -151,15 +142,10 @@ def passiveOblExtraction : MamExtractionDatum :=
   , obliqueExtracted := true
   , judgment := .licensed }
 
-/-- Temporal oblique extraction: =(y)a' BLOCKED.
-    "When" (*b'iix taq*) does not trigger =(y)a', unlike spatial and
-    other obliques. Elkins et al. §8.1, ex. (56).
-
-    Note: temporal obliques ARE obliques and ARE extracted — we encode
-    this honestly with `obliqueExtracted := true, isTemporal := true`
-    rather than pretending they're not obliques. The exemption is
-    unexplained; the paper notes: "we leave an account of this for
-    future work" (§8.1). -/
+/-- Temporal oblique extraction: =(y)a' BLOCKED. "When" (*b'iix taq*) does
+    not trigger =(y)a', unlike spatial and other obliques (§8.1, ex. (56));
+    encoded honestly as `obliqueExtracted := true, isTemporal := true`.
+    Unexplained: "we leave an account of this for future work" (§8.1). -/
 def temporalOblExtraction : MamExtractionDatum :=
   { label := "Temporal oblique wh-extraction (no MVMT)"
   , reference := "§8.1, ex. (56)"
@@ -176,9 +162,7 @@ def monoData : List MamExtractionDatum :=
   , passiveOblExtraction
   , temporalOblExtraction ]
 
--- ============================================================================
--- § 4: Long-Distance (Biclausal) Data — Table 4
--- ============================================================================
+/-! ### Long-distance data (Table 4) -/
 
 /-- A long-distance extraction data point: tracks =(y)a' status on both
     the matrix and embedded predicates independently. This captures the
@@ -237,9 +221,7 @@ def ldEmbeddedQuestion : MamLongDistanceDatum :=
 def ldData : List MamLongDistanceDatum :=
   [ ldFullCP, ldAspectless, ldInfinitival, ldEmbeddedQuestion ]
 
--- ============================================================================
--- § 5: Per-Datum Verification (Monoclausal)
--- ============================================================================
+/-! ### Per-datum verification -/
 
 theorem trans_obl_licensed : transOblExtraction.judgment = .licensed := rfl
 theorem trans_subj_blocked : transSubjExtraction.judgment = .blocked := rfl
@@ -247,9 +229,7 @@ theorem trans_obj_blocked : transObjExtraction.judgment = .blocked := rfl
 theorem passive_obl_licensed : passiveOblExtraction.judgment = .licensed := rfl
 theorem temporal_obl_blocked : temporalOblExtraction.judgment = .blocked := rfl
 
--- ============================================================================
--- § 6: Generalizations
--- ============================================================================
+/-! ### Generalizations -/
 
 /-- Core generalization (monoclausal): =(y)a' is licensed iff the clause
     projects Voice AND a non-temporal oblique is extracted.
@@ -287,31 +267,20 @@ theorem temporal_is_oblique_but_exempt :
     temporalOblExtraction.isTemporal = true ∧
     temporalOblExtraction.judgment = .blocked := ⟨rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 7: Island Sensitivity — Derived from Movement Analysis
--- ============================================================================
+/-! ### Island sensitivity -/
 
-/-- A morphological reflex of syntactic Ā-movement inherits movement's
-    locality properties. Since Ā-movement is phase-bounded (Phase
-    Impenetrability Condition; Phase.lean), any morpheme that requires
-    movement through a probe's specifier is island-sensitive.
-
-    This replaces a stipulated `Bool` with a derivation from two
-    independent properties:
-    1. The morpheme requires Ā-movement (established by the Agree analysis)
-    2. Movement is phase-bounded (from PIC)
-
-    References:
-    - [chomsky-2000] on PIC
-    - [elkins-torrence-brown-2026] §7.1 on =(y)a' island sensitivity -/
+/-- A morphological reflex of Ā-movement inherits movement's locality:
+    since Ā-movement is phase-bounded (Phase Impenetrability Condition,
+    `Phase.lean`), any morpheme requiring movement through a probe's
+    specifier is island-sensitive. Deriving island sensitivity from these
+    two properties replaces a stipulated `Bool` ([chomsky-2000] on PIC;
+    [elkins-torrence-brown-2026] §7.1). -/
 structure MovementReflex where
-  /-- The morpheme is a spellout of features valued via Agree with
-      a constituent that has undergone Ā-movement through the probe's
-      specifier. Established by the Agree analysis in §5. -/
+  /-- Spellout of features valued via Agree with an Ā-moved constituent
+      (Agree analysis, §5). -/
   requiresMovement : Bool
-  /-- Movement is bounded by phases (PIC; Phase.lean).
-      Islands are configurations where the phase edge is unavailable,
-      blocking successive-cyclic movement. -/
+  /-- Movement is phase-bounded (PIC, `Phase.lean`); islands are
+      configurations where the phase edge is unavailable. -/
   movementPhaseBounded : Bool
   deriving DecidableEq, Repr
 
@@ -336,33 +305,22 @@ def eqyaIslandSensitive : Bool := eqyaMovementReflex.islandSensitive
 theorem eqya_island_sensitive_derived :
     eqyaMovementReflex.islandSensitive = true := rfl
 
--- ============================================================================
--- § 8: Against Agent Focus (§7.2)
--- ============================================================================
+/-! ### Against Agent Focus -/
 
-/-- =(y)a' co-occurs with passive voice morphology (*-njtz*).
-    This is encoded as empirical data: `passiveOblExtraction.judgment =.licensed`.
-    The co-occurrence is *derivable* from Voice.Head field independence:
-    passive *-njtz* is conditioned by Voice.Flavor, while =(y)a' is
-    conditioned by features ([+oblique]). These are independent fields
-    in Voice.Head, so changing the flavor does not affect the features.
-    See `MinimalismOblExtraction.eqya_not_agent_focus` for the structural
-    derivation.
-    Elkins et al. §7.2, ex. (53)–(54). -/
+/-- =(y)a' co-occurs with passive morphology *-njtz* ([elkins-torrence-brown-2026]
+    §7.2, ex. (53)–(54)): passive is conditioned by `Voice.Flavor` and
+    =(y)a' by [+oblique] features — independent fields in `Voice.Head`, so
+    the flavor does not affect the features (structural derivation in
+    `MinimalismOblExtraction.eqya_not_agent_focus`). -/
 theorem passive_oblique_cooccurrence :
     passiveOblExtraction.judgment = .licensed := rfl
 
--- ============================================================================
--- § 9: Extraction Profile
--- ============================================================================
+/-! ### Extraction profile -/
 
-/-- Mam extraction strategy: dedicated morpheme strategy, marks oblique only.
-    Excludes temporal obliques (§8.1).
-
-    Language: "Mam (SJO)". Notes: Optional enclitic =(y)a' on Voice⁰/Dir⁰
-    marks oblique extraction; absent for subject (AF) and object extraction;
-    conditioned by clause size (requires Voice projection); temporal obliques
-    exempt (§8.1); island-sensitive (§7.1). -/
+/-- Mam's extraction profile: a dedicated morpheme (=(y)a') marking oblique
+    extraction only — absent for subject (AF) and object extraction,
+    conditioned by clause size, exempting temporal obliques (§8.1),
+    island-sensitive (§7.1). -/
 def mamExtractionStrategy : Extraction.ExtractionMarkingStrategy := .dedicatedMorpheme
 def mamExtractionMarkedPositions : List Extraction.ExtractionTarget := [.oblique]
 def mamExtractionDistinguishesPosition : Bool := true

--- a/Linglib/Fragments/Mayan/Mam/Pronouns.lean
+++ b/Linglib/Fragments/Mayan/Mam/Pronouns.lean
@@ -1,44 +1,53 @@
 import Linglib.Syntax.Category.Pronoun.Basic
 
-/-! # San Juan Atitán Mam Pronouns
+/-!
+# San Juan Atitán Mam Pronouns
 
-Pronoun lexicon for San Juan Atitán Mam (SJA Mam, Mayan), from [scott-2023]
-ch. 4. Scott's central claim is that the reduced subject/possessor forms are
-**true pronouns** in argument position — not agreement markers (contra her own
-Scott 2020 analysis) and not a special clitic series (she explicitly prefers an
-impoverishment derivation over "positing a unique series of 'clitic' pronouns",
-p. 162, citing the Agree-affects-pronouns family: Cardinaletti & Starke, Nevins,
-Kramer, Stegovec, Yuan). The entries therefore live here as `PersonalPronoun`
-values flowing through the shared Pronoun API.
+Pronoun lexicon for San Juan Atitán Mam (SJA Mam, Mayan), from
+[scott-2023] ch. 4, as `PersonalPronoun` values flowing through the
+shared Pronoun API. Scott's central claim is that the reduced
+subject/possessor forms are true pronouns in argument position — not
+agreement markers (contra her own Scott 2020) and not a special clitic
+series — so the entries live here rather than in an agreement paradigm.
 
-Two series (her Table 4.1 / 4.9, p. 160 / 185):
+Two series (Table 4.1 / 4.9, p. 160 / 185): the independent forms
+*qini* (= *qin+=i*), *qoy* (= *qo'+=y*), *qo*, *=i*, *qi* (= *q+=i*),
+3SG ∅, *qa*, and the reduced subject/possessor forms, where first-person
+cells lose their base morphemes (*qin* [+author,+sg], *qo* [+author,−sg],
+Table 4.10) via an impoverishment rule conditioned on agreement (§4.4)
+while 2nd/3rd cells match the independent series. The disagreement
+enclitic *=i* (gloss DISAGR; [noyer-1992], [harbour-2016]; §4.3.3)
+realizes disagreeing [±author]/[±participant] values.
 
-* **Independent** ("most morphosyntactically rich", her fn. 2 — the 2SG
-  "independent" form is the enclitic *=i* itself): *qini* (= *qin+=i*),
-  *qoy* (= *qo'+=y*), *qo*, *=i*, *qi* (= *q+=i*), 3SG ∅, *qa*.
-* **Subject/possessor** (reduced): first-person cells lose their base
-  morphemes (*qin* [+author,+sg], *qo* [+author,−sg], Table 4.10) via an
-  impoverishment rule conditioned on agreement (§4.4); 2nd/3rd cells are
-  identical to the independent series.
+## Main declarations
 
-The disagreement enclitic *=i* (gloss DISAGR; [noyer-1992], [harbour-2016];
-her §4.3.3) realizes *disagreeing* values of [±author]/[±participant] —
-`enclitic_iff_disagrees` verifies the XOR distribution across the paradigm.
-`reduction_iff_author` verifies that the two series differ exactly at
-[+author] cells.
+* `Mam.iDisagr`, `Mam.qini`, `Mam.qoy`, `Mam.qo`, `Mam.qi`, `Mam.qa`:
+  the pronoun lexical entries.
+* `Mam.PronCell` with `.person`, `.number`, `.toPerson`, `.features`,
+  `.Disagrees`: the paradigm cells and their φ-feature values.
+* `Mam.independent`, `Mam.subjPoss`: the independent and reduced series
+  by cell.
+* `Mam.enclitic_iff_disagrees`, `Mam.reduction_iff_author`,
+  `Mam.reduced_residue`: the enclitic-distribution and reduction
+  generalizations, verified across the paradigm.
 
-Feature values follow her Table 4.4 (p. 183). NB the convention:
-Harbour's [±participant] "functions more like a [+/−hearer] or
-[+/−addressee] feature" (p. 182), so 1EXCL is [−participant] — this
-deliberately diverges from `Person.Features`, whose `wellFormed`
-invariant (author → participant) encodes the speech-act-participant
-convention; hence the fragment-local `ScottFeatures`.
+## Implementation notes
 
+Feature values follow Table 4.4 (p. 183). Harbour's [±participant]
+"functions more like a [+/−hearer] or [+/−addressee] feature" (p. 182),
+so 1EXCL is [−participant] — this deliberately diverges from
+`Person.Features`, whose `wellFormed` invariant (author → participant)
+encodes the speech-act-participant convention; hence the fragment-local
+`ScottFeatures`. Scott prefers the impoverishment derivation over
+"positing a unique series of 'clitic' pronouns" (p. 162), citing the
+Agree-affects-pronouns family (Cardinaletti & Starke, Nevins, Kramer,
+Stegovec, Yuan). The independent series is "most morphosyntactically
+rich" (fn. 2), the 2SG independent form being the enclitic *=i* itself.
 Wordhood: *=i* is a morphological enclitic with promiscuous attachment
-(nouns, verbs, pronouns, other clitics; allomorphs <i>/<y>, =ni after [m]);
-whether *qi*/*qa* are words or enclitics is left open by Scott (p. 163, her
-p. 39) — none of this is a Cardinaletti–Starke deficiency classification,
-so `strength` is left unset throughout.
+(nouns, verbs, pronouns, other clitics; allomorphs <i>/<y>, =ni after
+[m]); whether *qi*/*qa* are words or enclitics Scott leaves open
+(p. 163, her p. 39). None of this is a Cardinaletti–Starke deficiency
+classification, so `strength` is left unset throughout.
 -/
 
 set_option autoImplicit false
@@ -48,9 +57,9 @@ namespace Mam
 /-! ### Lexical entries -/
 
 /-- *=i* — the disagreement enclitic pronoun (DISAGR): realizes disagreeing
-    [±author]/[±participant] values, hence φ-underspecified (it serves 1SG,
-    1PL.EXCL, 2SG, and — with the plural piece *q* — 2PL; Table 4.11).
-    Doubles as the 2SG "independent" form (her fn. 2). -/
+    [±author]/[±participant] values, so φ-underspecified — it serves 1SG,
+    1PL.EXCL, 2SG, and (with the plural piece *q*) 2PL, and doubles as the
+    2SG "independent" form (Table 4.11, fn. 2). -/
 def iDisagr : PersonalPronoun :=
   { form := "=i", person := none, number := none }
 

--- a/Linglib/Fragments/Mayan/Mam/Relativization.lean
+++ b/Linglib/Fragments/Mayan/Mam/Relativization.lean
@@ -1,17 +1,16 @@
 import Linglib.Syntax.RelativeClause.WALS
 
 /-!
-# Mam relativization profile
-[elkins-torrence-brown-2026]
+# Mam Relativization Profile
 
-Relativization typology for Mam (ISO `mam`).
+Relativization typology for Mam (ISO `mam`, Mayan), following
+[elkins-torrence-brown-2026]: subjects relativize by gap (with Agent
+Focus morphology) and obliques by gap (the *=(y)a'* clitic marking
+oblique extraction), in a postnominal relative clause.
 -/
 
 namespace Mam
 
-/-! Mam relativization: gap on subjects (with Agent Focus morphology);
-    *=(y)a'* clitic marks oblique extraction; postnominal RC; Mayan;
-    [elkins-torrence-brown-2026]. -/
 namespace Relativization
 def subjStrategy : RelativeClause.SubjStrategy := .gap
 def oblStrategy : RelativeClause.OblStrategy := .gap

--- a/Linglib/Fragments/Mayan/Mam/VoiceSystem.lean
+++ b/Linglib/Fragments/Mayan/Mam/VoiceSystem.lean
@@ -1,46 +1,42 @@
 import Linglib.Syntax.Voice.Basic
 
 /-!
-# Mam Voice System Profile (theory-neutral)
+# Mam Voice System Profile
 
-Theory-neutral typological profile of the Mam voice system.
+Theory-neutral typological profile of the Mam voice system: a voice
+inventory any framework can consume via the `Voice.*` queries. Unlike
+Toba Batak's symmetrical pivot system, Mam is three-way asymmetrical —
+agentive voice is basic (a phase head, overt agent), while passive and
+antipassive are derived (non-phase, implicit agent); the antipassive
+demotes the object to oblique and the subject takes ABS ([scott-2023]).
+Voice does not determine the pivot for extraction; instead it carries
+[uOblique], which conditions the extraction morphology =(y)a'.
+
+## Main declarations
+
+* `Mam.VoiceSystem.voices`: the agentive, passive, and antipassive
+  voice entries.
+* `Mam.VoiceSystem.symmetry`: the asymmetrical classification.
+
+## Implementation notes
 
 The Minimalist `Voice.Head`, `ClauseSpine`, and `MamDirHead` apparatus
-that previously lived in this file (=(y)a' analysis, antipassive)
-moved to:
-
-- `Studies/ElkinsTorrenceBrown2026.lean` — primary
-  anchor for the Minimalist treatment of =(y)a' / oblique extraction
-  ([elkins-torrence-brown-2026]); also houses the antipassive
-  Voice apparatus from [scott-2023] §2.5.4.1.
-- Cross-Studies consumer:
-  `Studies/Scott2023.lean` imports the Minimalist
-  Mam Voice from ETB2026 to compare φ-Agree and oblique-Agree pipelines.
-
-This Fragment file retains only `VoiceSystem.voices` / `VoiceSystem.symmetry` —
-a theory-neutral voice inventory any framework can consume via the
-`Voice.*` queries.
-
-**Variety note**: SJO Mam (San Juan Ostuncalco, [elkins-torrence-brown-2026])
-and SJA Mam (San Juan Atitán, [scott-2023]) are distinct varieties.
-The voice system profile abstracts over the variety distinction.
+(=(y)a' analysis, antipassive) that previously lived here now lives in
+`Studies/ElkinsTorrenceBrown2026.lean` — the primary anchor for the
+Minimalist treatment of =(y)a' / oblique extraction
+([elkins-torrence-brown-2026]), which also houses the antipassive Voice
+apparatus from [scott-2023] §2.5.4.1; `Studies/Scott2023.lean` imports
+that Mam Voice to compare φ-Agree and oblique-Agree pipelines. SJO Mam
+(San Juan Ostuncalco, [elkins-torrence-brown-2026]) and SJA Mam (San
+Juan Atitán, [scott-2023]) are distinct varieties; this profile
+abstracts over the distinction.
 -/
 
 namespace Mam
 
 namespace VoiceSystem
 
-/-! ### Mam voice system: three-way asymmetrical (agentive / passive / antipassive)
-
-Unlike Toba Batak's symmetrical pivot system, Mam's agentive voice
-is the basic form (phase head, overt agent) and passive/antipassive
-are derived (non-phase, implicit agent). Voice does not determine
-pivot for extraction — instead, Voice carries [uOblique] which
-conditions extraction morphology (=(y)a').
-
-Agentive is basic (phase head); passive/antipassive are derived.
-Antipassive demotes object to oblique, subject gets ABS ([scott-2023]).
-Voice data from SJA ([scott-2023]) and SJO ([elkins-torrence-brown-2026]). -/
+/-! ### Voice inventory -/
 
 /-- The voices of Mam: agentive (basic), passive, antipassive. -/
 def voices : List Voice.VoiceEntry :=

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -7,46 +7,52 @@ import Linglib.Morphology.Word
 
 /-!
 # Shared Mayan Fragment Infrastructure
-[coon-mateo-pedro-preminger-2014] [imanishi-2020] [tada-1993] [coon-2013]
 
-Types and parameters shared across Mayan language fragments (Q'anjob'al,
-Chol, Kaqchikel, K'iche', Mam, etc.).
+Types and parameters shared across the Mayan language fragments
+(Q'anjob'al, Chol, Kaqchikel, K'iche', Mam, etc.), following
+[coon-mateo-pedro-preminger-2014], [imanishi-2020], [tada-1993], and
+[coon-2013].
 
-## The Mayan Absolutive Parameter
+The **Mayan Absolutive Parameter** is the observable position of
+absolutive agreement morphemes relative to the verb stem. HIGH-ABS
+languages place absolutive immediately after the aspect marker (pre-stem;
+template ASP-ABS-ERG-ROOT-SUFFIX; Highland Guatemala); LOW-ABS languages
+place it after the stem (post-stem; template ASP-ERG-ROOT-SUFFIX-ABS;
+Lowland Mexico). Extending [tada-1993],
+[coon-mateo-pedro-preminger-2014] observe that this correlates with
+extraction asymmetries: HIGH-ABS languages overwhelmingly exhibit
+syntactic ergativity while LOW-ABS languages do not.
 
-The position of absolutive agreement morphemes relative to the verb stem
-is an observable morphological parameter:
+## Main declarations
 
-- **HIGH-ABS**: absolutive immediately follows the aspect marker (pre-stem).
-  Template: ASP-ABS-ERG-ROOT-SUFFIX. Highland Guatemala languages.
-- **LOW-ABS**: absolutive follows the verb stem (post-stem).
-  Template: ASP-ERG-ROOT-SUFFIX-ABS. Lowland Mexico languages.
+* `Mayan.ABSPosition`, `Mayan.CaseLocus`, `Mayan.toCaseLocus`: the
+  absolutive parameter and its case-locus interpretation.
+* `Mayan.MarkerSet`: the Set A / Set B agreement paradigms.
+* `Mayan.caseChol`, `Mayan.caseQanjobalan`, `Mayan.caseKaqchikel`,
+  `Mayan.caseKiche`, `Mayan.caseMam`, `Mayan.caseTseltalan`: per-branch
+  aspect-driven case assignment, with `erg…`/`acc…` aspect projections.
+* `Mayan.VerbForm`: transitive vs Agent Focus, and its agreement slots.
+* `Mayan.ExponentTable`, `Mayan.ExponentTable.IsThirdSgZero`: agreement
+  paradigms over φ-cells and the null-3sg predicate.
+* `Mayan.MarkerLinearity`: prefixal / suffixal / either marker linearity.
+* `Mayan.MayanLang`, `Mayan.MayanLang.isStandard`, `Mayan.caseAt`: the
+  language registry and the case-assignment dispatcher.
 
-[coon-mateo-pedro-preminger-2014] observe (extending [tada-1993])
-that this correlates with extraction asymmetries: overwhelmingly, HIGH-ABS
-languages exhibit syntactic ergativity while LOW-ABS languages do not.
+## Implementation notes
 
-## Case Locus (theoretical interpretation)
-
-The observable `ABSPosition` receives a theoretical interpretation in
-terms of which functional head assigns case to the transitive object:
-
-- **ABS=NOM** (HIGH-ABS): Infl⁰ assigns case (= nominative) to transitive
-  objects. "Absolutive" is a cover term for nominative.
-- **ABS=DEF** (LOW-ABS): v⁰ assigns case (= accusative) to transitive
-  objects. "Absolutive" is a cover term for accusative.
-
-Both types assign ergative uniformly (via transitive v⁰) and nominative
-to intransitive subjects (via Infl⁰).
+The observable `ABSPosition` receives a theoretical interpretation as
+`CaseLocus`, the functional head assigning case to transitive objects:
+ABS=NOM (HIGH-ABS) has Infl⁰ assign nominative, ABS=DEF (LOW-ABS) has v⁰
+assign accusative, with "absolutive" a cover term either way
+([legate-2008]). Both types assign ergative uniformly (via transitive
+v⁰) and nominative to intransitive subjects (via Infl⁰).
 -/
 
 namespace Mayan
 
 open Agreement
 
--- ============================================================================
--- § 1: Mayan Absolutive Parameter (observable)
--- ============================================================================
+/-! ### Mayan absolutive parameter -/
 
 /-- The position of absolutive agreement morphemes relative to the verb
     stem. Observable from the linear order of morphemes in the verb-aspect
@@ -56,9 +62,7 @@ inductive ABSPosition where
   | low   -- ABS on verb stem (post-stem)
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 2: Case Locus (theoretical interpretation)
--- ============================================================================
+/-! ### Case locus -/
 
 /-- Abstract case assignment locus for transitive objects.
 
@@ -77,9 +81,7 @@ def toCaseLocus : ABSPosition → CaseLocus
   | .high => .absNom
   | .low  => .absDef
 
--- ============================================================================
--- § 3: Agreement Marker Paradigms
--- ============================================================================
+/-! ### Agreement marker paradigms -/
 
 /-- The two agreement marker paradigms found in Mayan languages.
     Set A and set B are the traditional Mayanist labels for the two
@@ -97,103 +99,69 @@ inductive MarkerSet where
   | setB
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 4: Aspect-Conditioned Case Assignment in Cholan vs Q'anjob'alan
--- ============================================================================
+/-! ### Aspect-conditioned case: three branches, two split triggers
 
-/-! ## Three different major Mayan branches; two different cut-off patterns
+Per [aissen-england-zavala-2017] and [koizumi-2023] Ch. 2 (citing
+Campbell & Kaufman 1985), these languages sit in three different major
+branches: Chol in Greater Tseltalan (Western), Q'anjob'al in Greater
+Q'anjob'alan (Western), Kaqchikel in K'ichean-Mamean (Eastern). The
+"extended ergative" non-perfective pattern (Set A on non-perfective
+subjects) arose independently in all three — convergent
+grammaticalization of nominalized aspectual constructions, not common
+inheritance — but the trigger for the split differs.
 
-Per [aissen-england-zavala-2017] (Routledge handbook) and
-[koizumi-2023] Ch. 2 (citing Campbell & Kaufman 1985), the
-canonical Mayan family classification places these languages in
-**three different major branches**:
+**Cholan (aspect category)**, per [vazquez-alvarez-2011] §1.9.4,
+[imanishi-2020] §2.2, [zavala-maldonado-2017] §3: Chol, Chontal, and
+other Cholan languages split by aspect — ergative in perfective,
+accusative in all non-perfective aspects. Vázquez Álvarez 2011 §1.9.4:
+"the ergative pattern is split in all non-perfective aspects."
 
-- Chol → Cholan group → **Greater Tseltalan** (Western Mayan)
-- Q'anjob'al → Q'anjob'al group → **Greater Q'anjob'alan** (Western Mayan)
-- Kaqchikel → K'ichean group → **K'ichean-Mamean** (Eastern Mayan)
+**Q'anjob'alan (syntactic dependency)**, per [mateo-toledo-2008] §1.1.1,
+[imanishi-2020] §2.2, [zavala-maldonado-2017] §3 (citing Francisco
+Pascual 2007): Q'anjob'al, Akateko, Popti', Chuj split in dependent
+clauses lacking aspect markers, not by aspect category. Mateo Toledo
+2008 §1.1.1: "split ergativity occurs in any clause without an overt
+preverbal aspect marker." Seven syntactic contexts trigger it (Francisco
+Pascual 2007): aspectless complements, purpose clauses, coordinate
+clauses, preverbal depictives, resultatives, manner adverbs, and
+preverbal aspectual/modal auxiliaries (e.g. the progressive `lanan`).
+The imperfective `chi-` IS an aspect marker, so IMP clauses keep
+canonical ergative; only PROG (matrix `lanan`, not a preverbal aspect
+marker) triggers the split. `caseQanjobalan` approximates the syntactic
+trigger via `.Prog`; the other six contexts can't be encoded at this
+granularity.
 
-The "extended ergative" non-perfective pattern arose **independently**
-in three different major branches — convergent grammaticalization of
-nominalized aspectual constructions, not common inheritance.
-
-But while the surface alignment is similar (Set A on subjects in
-non-perfective contexts), the **trigger for the split differs**:
-
-**Cholan trigger (aspect category)** — per
-[vazquez-alvarez-2011] §1.9.4, [imanishi-2020] §2.2,
-and [zavala-maldonado-2017] §3:
-
-  Chol, Chontal, and other Cholan languages exhibit **aspect-based**
-  split ergativity. The split is triggered by aspect category:
-  ergative in **perfective**, accusative in **all non-perfective**
-  aspects (imperfective, progressive, etc.). Per Vázquez Álvarez 2011
-  §1.9.4: "the ergative pattern is split in all non-perfective aspects."
-
-**Q'anjob'alan trigger (syntactic dependency)** — per
-[mateo-toledo-2008] §1.1.1, [imanishi-2020] §2.2,
-and [zavala-maldonado-2017] §3 (citing Francisco Pascual 2007):
-
-  Q'anjob'al, Akateko, Popti', Chuj, etc. exhibit a **syntactic** split
-  triggered by **dependent clauses lacking aspect markers** — NOT by
-  aspect category. Mateo Toledo 2008 §1.1.1: "split ergativity occurs
-  in any clause without an overt preverbal aspect marker." Seven
-  syntactic constructions trigger the split (per Francisco Pascual
-  2007), including: aspectless complements, purpose clauses,
-  coordinate clauses, preverbal depictives, preverbal resultatives,
-  preverbal manner adverbs, and **preverbal aspectual/modal auxiliaries
-  (e.g., the progressive `lanan`)**. The Q'anjob'al imperfective
-  marker `chi-` IS an aspect marker, so IMP clauses keep canonical
-  ergative — only PROG (which uses `lanan` matrix predicate, not a
-  preverbal aspect marker) triggers the split.
-
-The Aspect-indexed function below approximates the syntactic trigger
-via `.Prog` for Q'anjob'alan; the other 6 syntactic-dependency
-contexts can't be encoded at this granularity.
-
-## Why `.gen` not `.nom`?
+### Why `.gen` not `.nom`?
 
 Both descriptive grammars ([vazquez-alvarez-2011] §1.9.4 for Chol,
 [mateo-toledo-2008] §1.1.1 for Q'anjob'al) characterize the
-non-perfective alignment as **nominative-accusative** (Set A as
-nominative-like). The substrate's `Alignment.extendedErgative.assignCase`
-returns `.gen` (from Coon's analytical view: Set A on subjects in
-non-perfective is genitive licensed by D under nominalization). The
-morphological identity of Set A with possessive markers across Mayan
-makes `.gen` analytically defensible, but it's a theoretical choice;
-a descriptive-grammar implementation would return `.nom`.
+non-perfective alignment as nominative-accusative (Set A as
+nominative-like). `Alignment.extendedErgative.assignCase` returns `.gen`
+on Coon's view (Set A on non-perfective subjects is genitive licensed by
+D under nominalization); the morphological identity of Set A with
+possessive markers makes `.gen` defensible, but it is a theoretical
+choice — a descriptive-grammar implementation would return `.nom`.
+[zavala-maldonado-2017] §3 (p. 235) calls Coon's no-split re-analysis
+"unconvincing": the split-ergative pattern is the descriptive consensus. -/
 
-[zavala-maldonado-2017] §3 (p. 235) calls Coon's no-split
-re-analysis "unconvincing" — the split-ergative pattern is the
-descriptive consensus, with Coon's nominalization analysis being one
-analytical framing among several. -/
-
-/-- Cholan aspect-driven case assignment.
-
-    Per [vazquez-alvarez-2011] §1.9.4 + [zavala-maldonado-2017]
-    §3: ergative in perfective; accusative-like (extended-ergative) in
-    ALL non-perfective aspects (imperfective, progressive, prospective,
-    habitual, iterative). Used by Chol; presumably also Chontal,
-    Ch'orti', Cholti per the Cholan-branch generalization in
-    [aissen-england-zavala-2017]. -/
+/-- Cholan aspect-driven case assignment ([vazquez-alvarez-2011] §1.9.4;
+    [zavala-maldonado-2017] §3): ergative in perfective, extended-ergative
+    (accusative-like) in all non-perfective aspects. Used by Chol;
+    presumably also Chontal, Ch'orti', Cholti per the Cholan-branch
+    generalization ([aissen-england-zavala-2017]). -/
 def caseChol : UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Perf, r => Alignment.ergative.assignCase r
   | .Imp, r | .Prog, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.extendedErgative.assignCase r
 
-/-- Q'anjob'alan aspect-driven case assignment.
-
-    Per [mateo-toledo-2008] §1.1.1 + [zavala-maldonado-2017]
-    §3: split is triggered by **dependent clauses lacking aspect
-    markers**, not by aspect category. The aspect-indexed function below
-    approximates this with `.Prog` (since the progressive uses the
-    `lanan` matrix predicate construction, which is one of the seven
-    split-triggering syntactic contexts per Francisco Pascual 2007).
-    Other non-perfective aspects (`.Imp` with `chi-` marker, etc.) keep
-    the canonical ergative pattern — they ARE aspect-marked.
-
-    DIFFERS FROM CHOLAN: Chol's IMP `mi-` marker triggers the
-    accusative split (per Vázquez Álvarez 2011 §1.9.4); Q'anjob'al's
-    IMP `chi-` does NOT (per Mateo Toledo 2008 §1.1.1). -/
+/-- Q'anjob'alan aspect-driven case assignment ([mateo-toledo-2008]
+    §1.1.1; [zavala-maldonado-2017] §3): the split is triggered by
+    dependent clauses lacking aspect markers, not by aspect category. This
+    function approximates that via `.Prog` (the `lanan` progressive is one
+    of Francisco Pascual 2007's seven split contexts); other non-perfective
+    aspects (e.g. `.Imp` with the `chi-` marker) keep canonical ergative.
+    Contrast Cholan, where the IMP `mi-` marker does trigger the accusative
+    split. -/
 def caseQanjobalan : UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Prog, r => Alignment.extendedErgative.assignCase r
   | .Perf, r | .Imp, r | .Prosp, r | .Hab, r | .Iter, r =>
@@ -220,32 +188,23 @@ abbrev ergCaseQanjobalan : Features.Prominence.ArgumentRole → Case :=
 abbrev accCaseQanjobalan : Features.Prominence.ArgumentRole → Case :=
   caseQanjobalan .Prog
 
-/-- Kaqchikel (K'ichean / K'ichean-Mamean = Eastern Mayan) aspect-driven
-    case assignment.
-
-    Per [imanishi-2014] §3.3.1 ("Kaqchikel: ERG=OBJ", p. 122) and
-    [imanishi-2020] §2.2: Kaqchikel exhibits a cross-linguistically
-    rare INVERTED alignment in PROG sentences with the `ajin` matrix
-    predicate — the OBJECT (not the subject) is cross-referenced by
-    Set A (ergative/genitive). This is the OPPOSITE of the
-    Cholan/Q'anjob'alan extended-ergative pattern.
-
-    Imanishi 2014 derives this from the Unaccusative Requirement on
-    Nominalization + phase head ergative Case: the object becomes the
-    only Case-less DP in the passivized nominalized clause and receives
-    ERG/GEN from D as phase head. The subject is base-generated outside
-    (in matrix Spec-PredP headed by `ajin`) and gets ABS from Infl.
-
-    The pattern is **construction-specific** (PROG `ajin` and certain
-    embedding-verb constructions), not a broader Kaqchikel-non-perfective
-    generalization. Other aspects in Kaqchikel (perfective, imperfective)
-    keep canonical ergative alignment per Imanishi 2014 Table 3.1 (p. 95).
-
-    Dialectal variation: per [imanishi-2014] fn. 26 (p. 141), some
-    Kaqchikel varieties / consultants don't accept all the patterns
-    documented in [garcia-matzar-rodriguez-guajan-1997]. The
-    inverted-pattern claim is grounded in Imanishi's primary fieldwork
-    on a specific Kaqchikel variety. -/
+/-- Kaqchikel (K'ichean-Mamean = Eastern Mayan) aspect-driven case
+    assignment. Per [imanishi-2014] §3.3.1 ("Kaqchikel: ERG=OBJ", p. 122)
+    and [imanishi-2020] §2.2, Kaqchikel shows a cross-linguistically rare
+    INVERTED alignment in PROG sentences with the `ajin` matrix predicate:
+    the OBJECT, not the subject, is cross-referenced by Set A (ERG/GEN) —
+    the opposite of the Cholan/Q'anjob'alan extended-ergative pattern.
+    Imanishi 2014 derives it from the Unaccusative Requirement on
+    Nominalization plus phase-head ergative Case: the object is the only
+    Case-less DP in the passivized nominalized clause and gets ERG/GEN from
+    D, while the subject is base-generated in matrix Spec-PredP (headed by
+    `ajin`) and gets ABS from Infl. The pattern is construction-specific
+    (PROG `ajin` and certain embedding-verb constructions), not a
+    Kaqchikel-non-perfective generalization; other aspects keep canonical
+    ergative (Imanishi 2014 Table 3.1, p. 95). Per [imanishi-2014] fn. 26
+    (p. 141), some varieties/consultants reject patterns in
+    [garcia-matzar-rodriguez-guajan-1997]; the claim rests on Imanishi's
+    fieldwork on a specific variety. -/
 def caseKaqchikel : UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Prog, r => Alignment.invertedErgative.assignCase r
   | .Perf, r | .Imp, r | .Prosp, r | .Hab, r | .Iter, r =>
@@ -265,18 +224,15 @@ abbrev ergCaseKaqchikel : Features.Prominence.ArgumentRole → Case :=
 abbrev accCaseKaqchikel : Features.Prominence.ArgumentRole → Case :=
   caseKaqchikel .Prog
 
-/-- K'iche' (K'ichean) case assignment.
-
-    Per [mondloch-2017] (Lessons 9, 15): K'iche' is a uniformly
-    **ergative-absolutive** language without an aspect-conditioned
-    split — Set A (ergative) cross-references A across all aspects;
-    Set B (absolutive) cross-references S and P. This contrasts with
-    its sister Kaqchikel, which has the construction-specific
-    inverted pattern in PROG `ajin`. Per [imanishi-2014] fn. 26
-    p. 141, dialectal variation in K'ichean languages is non-trivial,
-    but Mondloch documents no analogous K'iche' split. The aspect
-    parameter is retained for shape-uniformity with the other Mayan
-    `case*` functions; all aspects map to canonical ergative. -/
+/-- K'iche' (K'ichean) case assignment. Per [mondloch-2017] (Lessons 9,
+    15), K'iche' is uniformly ergative-absolutive with no aspect-conditioned
+    split — Set A (ERG) cross-references A across all aspects, Set B (ABS)
+    cross-references S and P. This contrasts with its sister Kaqchikel's
+    construction-specific inverted PROG `ajin` pattern; per [imanishi-2014]
+    fn. 26 p. 141 K'ichean dialectal variation is non-trivial, but Mondloch
+    documents no analogous K'iche' split. The aspect parameter is retained
+    for shape-uniformity with the other Mayan `case*` functions; all aspects
+    map to canonical ergative. -/
 def caseKiche : UD.Aspect → Features.Prominence.ArgumentRole → Case
   | _, r => Alignment.ergative.assignCase r
 
@@ -286,27 +242,18 @@ abbrev ergCaseKiche : Features.Prominence.ArgumentRole → Case :=
   caseKiche .Perf
 
 /-- San Juan Atitán Mam (K'ichean-Mamean / Eastern Mayan) case assignment.
-
-    Per [scott-2023] ch. 3: SJA Mam is **morphologically
-    tripartite** — A → ERG (Set A on Voice), P → ACC (no agreement;
-    overt pronoun required), S → ABS (Set B on Infl). Mam lacks
-    independent DP case morphology; the tripartite analysis is
-    recoverable only from agreement patterns. Per Scott's analysis
-    (ch. 3 §3.4), the underlying abstract Cases are nonetheless
-    distinct: ERG (inherent from Voice), ACC (structural from Voice),
-    ABS (structural from Infl).
-
-    Other Mam dialects (notably Ixtahuacán Mam per England 1983b /
-    [zavala-maldonado-2017] §4–5) have been characterized as
-    ergative with neutral patterns in dependent clauses, NOT
-    tripartite. This substrate encodes Scott's SJA Mam analysis;
-    alternative-dialect fragments would need a different
-    parameterization.
-
-    Mam shows no aspect-conditioned alignment split (per Scott
-    ch. 3, the tripartite pattern is uniform). The aspect parameter
-    is retained for shape-uniformity with the other Mayan `case*`
-    functions; all aspects map to tripartite. -/
+    Per [scott-2023] ch. 3, SJA Mam is morphologically tripartite — A → ERG
+    (Set A on Voice), P → ACC (no agreement; overt pronoun required), S →
+    ABS (Set B on Infl). Mam lacks independent DP case morphology, so the
+    tripartite analysis is recoverable only from agreement; per Scott ch. 3
+    §3.4 the underlying abstract Cases are nonetheless distinct: ERG
+    (inherent from Voice), ACC (structural from Voice), ABS (structural from
+    Infl). Other Mam dialects (notably Ixtahuacán Mam per England 1983b /
+    [zavala-maldonado-2017] §4–5) have been characterized as ergative with
+    neutral patterns in dependent clauses, not tripartite; this substrate
+    encodes Scott's SJA Mam analysis. Mam shows no aspect-conditioned split
+    (Scott ch. 3), so the aspect parameter is retained only for
+    shape-uniformity; all aspects map to tripartite. -/
 def caseMam : UD.Aspect → Features.Prominence.ArgumentRole → Case
   | _, r => Alignment.tripartite.assignCase r
 
@@ -330,11 +277,9 @@ def caseTseltalan : UD.Aspect → Features.Prominence.ArgumentRole → Case
 abbrev ergCaseTseltalan : Features.Prominence.ArgumentRole → Case :=
   caseTseltalan .Perf
 
--- ============================================================================
--- § 5: Person-Number Paradigm
--- ============================================================================
+/-! ### Person-number paradigm
 
-/-! The pan-Mayan person/number agreement paradigm is keyed by the canonical
+The pan-Mayan person/number agreement paradigm is keyed by the canonical
     φ-cell `Agreement.Cell` (the same φ a `Pronoun`/`Word` carries): the six
     cells covering the cross-Mayan consensus (Cholan, K'ichean, Q'anjob'alan,
     Tseltalan; [kaufman-norman-1984] Tables 7-8) are exactly
@@ -344,9 +289,7 @@ abbrev ergCaseTseltalan : Features.Prominence.ArgumentRole → Case :=
     Languages with a 1pl inclusive/exclusive split (Chol's `-on lojon` 1plExcl,
     [kaufman-norman-1984] p. 91) refine at the per-language level. -/
 
--- ============================================================================
--- § 6: Verb Form (transitive vs Agent Focus)
--- ============================================================================
+/-! ### Verb form (transitive vs Agent Focus) -/
 
 /-- The two verb forms relevant to Mayan agreement morphology.
     Used by HIGH-ABS languages with an Agent Focus alternation
@@ -377,9 +320,7 @@ def VerbForm.hasAFSuffix : VerbForm → Bool
 def VerbForm.agreementSlots (f : VerbForm) : Nat :=
   1 + if f.hasSetA then 1 else 0
 
--- ============================================================================
--- § 7: Exponent Tables
--- ============================================================================
+/-! ### Exponent tables -/
 
 /-- An exponent table: a descriptive agreement paradigm over canonical φ-cells
     (`Agreement.Cell`), mapping each person/number cell to its surface string.
@@ -387,20 +328,17 @@ def VerbForm.agreementSlots (f : VerbForm) : Nat :=
     typology theorems quantify over it. -/
 abbrev ExponentTable := Agreement.Paradigm String
 
-/-- Decidable predicate: the third-person singular slot is morphologically
-    null. An invariant of the **standard** Mayan branches per
-    [kaufman-norman-1984] Table 8 — Set B 3sg null reconstructs to
-    proto-Cholan and proto-Mayan. **Not strictly pan-Mayan**: SJA Mam's
-    default Set B `tz'=` surfaces in the 3sg slot per [scott-2023]
-    §3.3.2; the cross-Mayan theorem `mayan_p3sg_abs_null` quantifies
-    only over `MayanLang.isStandard = true`. The predicate is
-    **notation-agnostic** — surface notation varies by linearity:
-    `"-∅"` for suffixal Set B (Cholan, Q'anjob'alan, Tseltal, Tsotsil),
-    `"∅"` for prefixal Set B (Kaqchikel and other K'ichean HIGH-ABS
-    languages), `"∅-"` for prefixal-with-trailing-dash convention. All
-    resolve to the same morphological claim: no overt 3sg exponent. The
-    disjunction form is kernel-decidable (unlike a `String.replace`
-    normalization, which is opaque to `decide`). -/
+/-- Decidable predicate: the third-person singular Set B slot is
+    morphologically null. An invariant of the standard Mayan branches per
+    [kaufman-norman-1984] Table 8 (reconstructing to proto-Cholan and
+    proto-Mayan), but not strictly pan-Mayan — SJA Mam's default Set B
+    `tz'=` surfaces in the 3sg slot per [scott-2023] §3.3.2, so
+    `mayan_p3sg_abs_null` quantifies only over `isStandard = true`. The
+    predicate is notation-agnostic: `"-∅"` (suffixal Set B: Cholan,
+    Q'anjob'alan, Tseltal, Tsotsil), `"∅"` (prefixal Set B: Kaqchikel and
+    other K'ichean HIGH-ABS), and `"∅-"` all encode "no overt 3sg
+    exponent". The disjunction form is kernel-decidable, unlike a
+    `String.replace` normalization. -/
 def ExponentTable.IsThirdSgZero (e : ExponentTable) : Prop :=
   e.realize (.pn .third .Sing) = some "-∅" ∨
   e.realize (.pn .third .Sing) = some "∅" ∨
@@ -409,9 +347,7 @@ def ExponentTable.IsThirdSgZero (e : ExponentTable) : Prop :=
 instance (e : ExponentTable) : Decidable e.IsThirdSgZero := by
   unfold ExponentTable.IsThirdSgZero; exact inferInstance
 
--- ============================================================================
--- § 7b: Marker Linearity
--- ============================================================================
+/-! ### Marker linearity -/
 
 /-- The morphological linearity of an agreement marker on the verb stem.
 
@@ -427,9 +363,7 @@ inductive MarkerLinearity where
   | either   -- prefixal-or-suffixal (Tsotsil Set B)
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 8: Mayan Language Registry + caseAt Dispatcher
--- ============================================================================
+/-! ### Language registry and case dispatcher -/
 
 /-- The Mayan languages with consolidated Fragment files. Yukatek has
     substrate work pending and is not yet in the registry; it'll be
@@ -444,22 +378,16 @@ inductive MayanLang where
 def MayanLang.all : List MayanLang :=
   [.Chol, .Qanjobal, .Kaqchikel, .Tseltal, .Tsotsil, .Mam, .Kiche]
 
-/-- The Mayan languages with the **standard ergative-absolutive base**
-    (perfective ergative; Set B 3sg null per K&N reconstruction).
-
-    Mam is the **exception**: per [scott-2023], San Juan Atitán
-    Mam is morphologically **tripartite** (S, A, P each receive
-    distinct case and agreement), and its Set B 3sg surfaces as the
-    default `tz'=` form rather than null. The substrate exposes this
-    as a falsification of pan-Mayan invariants when Mam is in scope —
-    `mayan_p3sg_abs_null` and `mayan_perfective_ergative` quantify
-    only over `isStandard = true` languages.
-
-    Whether Mam is "really" tripartite vs ergative-with-neutral-objects
-    is a contested analytical question (cf. England 1983b vs Scott
-    2023; Zavala 2017 §4 calls Ch'orti' the only tripartite Mayan).
-    The substrate adopts Scott's analysis as recorded in
-    `Mam/Agreement.lean`. -/
+/-- The Mayan languages with the standard ergative-absolutive base
+    (perfective ergative; Set B 3sg null per K&N reconstruction). Mam is
+    the exception: per [scott-2023], San Juan Atitán Mam is morphologically
+    tripartite (S, A, P each distinct in case and agreement), with Set B
+    3sg surfacing as the default `tz'=` rather than null — so
+    `mayan_p3sg_abs_null` and `mayan_perfective_ergative` quantify only over
+    `isStandard = true`. Whether Mam is "really" tripartite vs
+    ergative-with-neutral-objects is contested (cf. England 1983b vs Scott
+    2023; Zavala 2017 §4 calls Ch'orti' the only tripartite Mayan); the
+    substrate adopts Scott's analysis, recorded in `Mam/Agreement.lean`. -/
 def MayanLang.isStandard : MayanLang → Bool
   | .Mam => false
   | _    => true

--- a/Linglib/Fragments/Mayan/Qanjobal/AgentFocus.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/AgentFocus.lean
@@ -5,65 +5,52 @@ import Linglib.Fragments.Mayan.Params
 
 /-!
 # Q'anjob'al Agent Focus and Extraction Fragment
-[coon-mateo-pedro-preminger-2014]
 
-Morphological data on Q'anjob'al (Q'anjob'alan, Mayan) related to
-extraction asymmetries, Agent Focus, and the Crazy Antipassive.
+Morphological data on Q'anjob'al (Q'anjob'alan, Mayan) extraction
+asymmetries, Agent Focus, and the Crazy Antipassive, following
+[coon-mateo-pedro-preminger-2014]. Q'anjob'al shows an extraction
+asymmetry: the intransitive subject (S) and transitive object (P)
+extract freely, but the transitive subject (A) cannot be extracted
+without Agent Focus. Agent Focus replaces the regular transitive form
+with a verb bearing the AF suffix *-on*, the intransitive status suffix
+*-i* (not transitive *-V'*), and no Set A agreement — used for
+*wh*-questions, focus, and relativization targeting the agent.
 
-## Person Morphology (table (13))
+## Main declarations
 
-Q'anjob'al has two agreement paradigms head-marked on the predicate:
-- **Set A (ERG)**: prefixes with pre-consonantal and pre-vocalic allomorphs
-- **Set B (ABS)**: suffixes; 3rd person is null (∅)
+* `Qanjobal.StatusSuffix` with `.form`: the ITV and TV status suffixes.
+* `Qanjobal.VerbMorphology` with `regularTransitive`, `agentFocusForm`:
+  the AF-suffix, status-suffix, and Set A properties of a verb form.
+* `Qanjobal.VerbMorphology.toMayanVerbForm`: projection to the pan-Mayan
+  `Mayan.VerbForm` for cross-Mayan typology.
+* `Qanjobal.crazyAntipassiveForm`: the Crazy Antipassive, morphologically
+  identical to Agent Focus.
+* `Qanjobal.PersonRestriction` with `.requiresAF`, `.requiresCrazyAP`:
+  the 3rd-person restriction on Agent Focus.
+* `Qanjobal.extractionStrategy`: the AF-based extraction profile.
 
-## Status Suffixes (table (14))
+## Implementation notes
 
-The verb stem's final suffix encodes transitivity:
-- Intransitive: *-i* (ITV)
-- Transitive: *-V'* (TV)
-
-These surface only phrase-finally; non-final forms omit them.
-
-## Morpheme Order (HIGH-ABS)
-
-Template: ASP - ABS - ERG - ROOT - (DERIV) - SUFFIX
-
-Absolutive immediately follows the aspect marker (pre-stem position),
-confirming Q'anjob'al as a HIGH-ABS language.
-
-## Extraction Asymmetries
-
-- S (intransitive subject): extracts freely
-- P (transitive object): extracts freely
-- A (transitive subject): **banned** without Agent Focus
-
-## Agent Focus
-
-AF suffix *-on* attaches to the verb stem. The verb carries the
-intransitive status suffix *-i* (not transitive *-V'*). Absolutive
-agreement co-indexes the notional object (not the subject). Used
-for *wh*-questions, focus, and relativization targeting the agent.
-
-## Crazy Antipassive
-
-The same *-on* morpheme appears in non-finite embedded transitives:
-`Chi uj [hin y-il-on-i] ix Malin` 'Maria can see me.'
-Analyzed as the same case-assigning mechanism in environments where
-Infl⁰ is absent.
+Q'anjob'al head-marks two agreement paradigms on the predicate: Set A
+(ERG) prefixes with pre-consonantal and pre-vocalic allomorphs, and Set
+B (ABS) suffixes with null 3rd person (∅); the tables live in
+`Qanjobal/Agreement.lean`. The verb stem's final suffix encodes
+transitivity (intransitive ITV *-i*, transitive TV *-V'*) and surfaces
+only phrase-finally. Morpheme order is ASP-ABS-ERG-ROOT-(DERIV)-SUFFIX,
+with the absolutive immediately after the aspect marker (pre-stem),
+confirming Q'anjob'al as HIGH-ABS. In Agent Focus, absolutive agreement
+co-indexes the notional object rather than the subject. The Crazy
+Antipassive reuses the same *-on* morpheme in non-finite embedded
+transitives (where Infl⁰ is absent), analyzed as the same case-assigning
+mechanism. Tables and examples cite [coon-mateo-pedro-preminger-2014]
+tables (13) and (14).
 -/
 
 namespace Qanjobal
 
 open Minimalist
 
--- Person-number paradigm (keyed by the canonical φ-cell `Agreement.Cell`)
--- and Set A / Set B exponent tables (`setAExponent`, `setAExponentPreC`,
--- `setAExponentPreV`, `setBExponent`) live in Qanjobal/Agreement.lean —
--- agreement morphology is general, not AF-specific.
-
--- ============================================================================
--- § 1: Status Suffixes
--- ============================================================================
+/-! ### Status suffixes -/
 
 /-- Verb status suffixes encode transitivity. Surface only phrase-finally. -/
 inductive StatusSuffix where
@@ -81,9 +68,7 @@ def StatusSuffix.form : StatusSuffix → String
 -- `Extraction.Marks extractionMarkedPositions .subject` (subject = .agent's
 -- default position per `Extraction.ArgumentRole.defaultPosition`).
 
--- ============================================================================
--- § 2: Agent Focus Construction
--- ============================================================================
+/-! ### Agent Focus construction -/
 
 /-- Morphological properties of a Q'anjob'al verb form. -/
 structure VerbMorphology where
@@ -129,10 +114,9 @@ theorem af_permits_extraction :
     agentFocusForm.permitsAgentExtraction = true ∧
     regularTransitive.permitsAgentExtraction = false := ⟨rfl, rfl⟩
 
-/-- Project Q'anjob'al's `VerbMorphology` (which carries the
-    Q'anjob'al-specific `statusSuffix` field) down to the pan-Mayan
-    `Mayan.VerbForm` for cross-Mayan typology theorems. The
-    `hasAFSuffix` flag is the discriminator: AF morphology = AF form. -/
+/-- Project `VerbMorphology` down to the pan-Mayan `Mayan.VerbForm` for
+    cross-Mayan typology; the `hasAFSuffix` flag discriminates AF form
+    from transitive. -/
 def VerbMorphology.toMayanVerbForm (v : VerbMorphology) : Mayan.VerbForm :=
   if v.hasAFSuffix then .agentFocus else .transitive
 
@@ -150,9 +134,7 @@ theorem hasSetA_consistent_with_projection :
     regularTransitive.toMayanVerbForm.hasSetA = regularTransitive.hasSetA :=
   ⟨rfl, rfl⟩
 
--- ============================================================================
--- § 3: Crazy Antipassive
--- ============================================================================
+/-! ### Crazy Antipassive -/
 
 /-- The Crazy Antipassive uses the same *-on* morpheme as AF, but in
     non-finite embedded transitives rather than extraction contexts. Both
@@ -169,9 +151,7 @@ def crazyAntipassiveForm : VerbMorphology :=
 theorem crazy_ap_is_af_form :
     crazyAntipassiveForm = agentFocusForm := rfl
 
--- ============================================================================
--- § 4: Person Restriction on AF
--- ============================================================================
+/-! ### Person restriction on Agent Focus -/
 
 /-- In Q'anjob'al, AF is restricted to clauses with **3rd person** agents.
     1st and 2nd person agents use the regular transitive form even when
@@ -210,9 +190,7 @@ theorem crazy_ap_all_persons :
     PersonRestriction.second.requiresCrazyAP = true ∧
     PersonRestriction.third.requiresCrazyAP = true := ⟨rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 5: Extraction Profile
--- ============================================================================
+/-! ### Extraction profile -/
 
 /-- Q'anjob'al's extraction data: dedicated AF morphology (*-on*) marks
     3rd person agent (subject) extraction ([coon-mateo-pedro-preminger-2014]). -/

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -2,69 +2,66 @@ import Linglib.Features.Case.Basic
 import Linglib.Fragments.Mayan.Params
 
 /-!
-# Q'anjob'al Agreement and Case Fragment [mateo-toledo-2008] [imanishi-2020]
+# Q'anjob'al Agreement and Case Fragment
 
 Agreement morphology and case assignment for Q'anjob'al (Q'anjob'alan,
-Mayan), a **high absolutive** VSO language with aspect-based split
-ergativity. Per [mateo-toledo-2008] p. 9, Q'anjob'al is in the
+Mayan), following [mateo-toledo-2008] and [imanishi-2020]: a high
+absolutive VSO language with aspect-based split ergativity. Q'anjob'al
+has the same Set A (ergative) / Set B (absolutive) paradigm as other
+Mayan languages. Per [mateo-toledo-2008] p. 9 it sits in the
 "Q'anjob'alan group, Q'anjob'alan branch, Western division" of the
 Mayan family (citing England 1992:21, Kaufman 1974) — sister to the
 Cholan-Tzeltalan branch (where Chol lives) within Western Mayan.
 
-## The System
+## Main declarations
 
-Q'anjob'al has the same Set A (ergative) / Set B (absolutive) paradigm
-as other Mayan languages. Per [mateo-toledo-2008] §1.3, ex. (35),
-the verbal predicate structure is:
+* `Qanjobal.setAExponentPreC`, `Qanjobal.setAExponentPreV`,
+  `Qanjobal.setBExponent`: Set A pre-consonantal and pre-vocalic
+  ergative allomorphs and the Set B absolutive suffixes
+  ([coon-mateo-pedro-preminger-2014] table (13)).
+* `Qanjobal.ArgPosition` with `.case`, `.accCase`: argument positions
+  and their perfective and non-perfective case, shared with Chol via
+  `Mayan.ergCaseQanjobalan` / `Mayan.accCaseQanjobalan`.
+* `Qanjobal.absPosition`: HIGH-ABS morpheme placement.
 
-  `Asp + (Particle) + Abs + (Particle) + Erg-Verb + (Particle) + (DIRs)`
+## Implementation notes
 
-i.e., `[Asp] [Abs Erg-Verb]` — the **high absolutive** template. Compares
-to Chol's low-absolutive `[Aux] [Erg-Verb-Abs]` (per
-[vazquez-alvarez-2011] §3.4).
+Per [mateo-toledo-2008] §1.3, ex. (35), the verbal predicate structure
+is `Asp + (Particle) + Abs + (Particle) + Erg-Verb + (Particle) +
+(DIRs)`, i.e. `[Asp] [Abs Erg-Verb]` — the high absolutive template,
+against Chol's low-absolutive `[Aux] [Erg-Verb-Abs]`
+([vazquez-alvarez-2011] §3.4).
 
-## Cross-language difference: aspect-marker word class
+One real Cholan/Q'anjob'alan difference the shared substrate
+`caseExtErg` does not capture is aspect-marker word class: Chol markers
+are auxiliaries (independent words *tyi* perfective, *mi* imperfective;
+[vazquez-alvarez-2011] §3.4), whereas Q'anjob'al markers are clitics or
+"grammaticized particles" (*(ma)x-* completive, *chi/ch-* incompletive,
+*(ho)q-* irrealis; [mateo-toledo-2008] §1.1.2, Kaufman 1990:71,
+Robertson 1992:57). The alignment behavior is nonetheless the same —
+split ergativity in any clause without an overt preverbal aspect marker
+([mateo-toledo-2008] §1.1.1, citing Mateo 2004a/2007b), attributed to
+nominalization following Larsen & Norman 1979 — so `Mayan.caseExtErg`
+captures the alignment convergence, not the morpheme-class convergence.
 
-A real difference between Cholan and Q'anjob'alan that the shared
-substrate `caseExtErg` does NOT capture: aspect-marker morphological
-status differs.
-
-- **Chol** ([vazquez-alvarez-2011] §3.4): aspect markers are
-  **auxiliaries** (independent words: `tyi` perfective, `mi` imperfective).
-- **Q'anjob'al** ([mateo-toledo-2008] §1.1.2 + Kaufman 1990:71,
-  Robertson 1992:57): aspect markers are **clitics** / "grammaticized
-  particles" (`(ma)x-` completive, `chi/ch-` incompletive, `(ho)q-`
-  irrealis).
-
-Despite this morphological difference, the alignment behavior is the
-same: split ergativity in any clause without an overt preverbal aspect
-marker (per [mateo-toledo-2008] §1.1.1, citing Mateo 2004a/2007b),
-attributed to nominalization following Larsen & Norman 1979. The shared
-case-assignment table in `Mayan.caseExtErg` captures the
-*alignment* convergence, not the *morpheme-class* convergence.
-
-## Descriptive vs analytical framing of the non-perfective pattern
-
-Identical situation to Chol. [mateo-toledo-2008] §1.1.1 (p. 50)
-characterizes Q'anjob'al's non-perfective alignment as
-"nominative-accusative system (Dixon 1994:104)" — Set A/ergative
-morphemes mark BOTH transitive and intransitive subjects in aspectless
-contexts. The "extended ergative / Set A = GEN-from-D" framing is from
-formal-syntactic analyses (Coon 2013, Imanishi 2020), where Set A is
-analyzed as genitive licensed by D under nominalization. The substrate's
-`extendedErgative.assignCase` returns `.gen` (analytical view); a
+The non-perfective pattern has a descriptive and an analytical framing
+(as in Chol). [mateo-toledo-2008] §1.1.1 (p. 50) describes it as a
+"nominative-accusative system (Dixon 1994:104)" — Set A ergative
+morphemes mark both transitive and intransitive subjects in aspectless
+contexts — while the "extended ergative / Set A = GEN-from-D" framing
+comes from formal-syntactic analyses (Coon 2013, Imanishi 2020) where
+Set A is genitive licensed by D under nominalization. The substrate's
+`extendedErgative.assignCase` returns `.gen` (the analytical view); a
 descriptive-grammar implementation would return `.nom`.
 
-## Why the shared substrate works
-
-[mateo-toledo-2008] footnote 3 (p. 50): "in Q'anjob'alan languages,
-split ergativity is associated with the lack of an aspect marker (that
-is likely to be driven by nominalization, see Larsen and Norman 1979)."
-This is the same nominalization-driven mechanism Coon (2013) argues for
-Chol. The two languages converge on the alignment pattern via
-independent grammaticalization (sister branches of Western Mayan, no
-common-inheritance unit), which is why the substrate is named
-`caseExtErg` (the typological convergence) rather than after a single
+The shared substrate works because both languages converge via
+independent grammaticalization. [mateo-toledo-2008] fn. 3 (p. 50): "in
+Q'anjob'alan languages, split ergativity is associated with the lack of
+an aspect marker (that is likely to be driven by nominalization, see
+Larsen and Norman 1979)" — the same mechanism Coon (2013) argues for
+Chol. They are sister branches of Western Mayan with no
+common-inheritance unit, which is why the substrate is named
+`caseExtErg` (the typological convergence) rather than after one
 language family.
 -/
 
@@ -73,38 +70,28 @@ namespace Qanjobal
 open Mayan (ExponentTable)
 open Agreement
 
--- ============================================================================
--- § 1: Argument Positions (alias to canonical SAP type)
--- ============================================================================
+/-! ### Argument positions -/
 
-/-- Argument positions in a Q'anjob'al clause. Aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
-    cross-framework code shares one inventory. Use the canonical
-    constructor names `.A` / `.P` / `.S` directly. -/
+/-- Argument positions, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
 abbrev ArgPosition := Features.Prominence.ArgumentRole
 
-/-- Perfective case assignment for Q'anjob'al. Shared with Chol via
+/-- Perfective case assignment, shared with Chol via
     `Mayan.ergCaseQanjobalan` (= `Alignment.ergative.assignCase`). -/
 abbrev ArgPosition.case : ArgPosition → Case := Mayan.ergCaseQanjobalan
 
-/-- Non-perfective case assignment for Q'anjob'al. Shared with Chol via
-    `Mayan.accCaseQanjobalan` (= `Alignment.extendedErgative.assignCase`).
-    The shared substrate makes the Chol/Q'anjob'al accusative-side parallel
-    explicit by construction rather than coincidentally true. -/
+/-- Non-perfective case assignment, shared with Chol via
+    `Mayan.accCaseQanjobalan` (= `Alignment.extendedErgative.assignCase`) —
+    making the accusative-side parallel true by construction. -/
 abbrev ArgPosition.accCase : ArgPosition → Case := Mayan.accCaseQanjobalan
 
--- ============================================================================
--- § 2: Absolutive Position (HIGH-ABS)
--- ============================================================================
+/-! ### Absolutive position (HIGH-ABS) -/
 
-/-- Q'anjob'al's absolutive morphemes appear in high position (on the
-    aspect marker, pre-stem). Observable from morpheme order:
-    ASP-ABS-ERG-ROOT-SUFFIX. -/
+/-- HIGH-ABS: absolutive morphemes sit on the aspect marker (pre-stem),
+    from the morpheme order ASP-ABS-ERG-ROOT-SUFFIX. -/
 def absPosition : Mayan.ABSPosition := .high
 
--- ============================================================================
--- § 3: Person-Number Paradigm (table (13))
--- ============================================================================
+/-! ### Person-number paradigm -/
 
 /-- Set A (ergative/possessive) markers: pre-consonantal allomorphs
     ([coon-mateo-pedro-preminger-2014] table (13)). -/

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -3,34 +3,36 @@ import Linglib.Syntax.Extraction
 
 /-!
 # Tseltal Agreement Fragment
-[polian-2013] [aissen-polian-2025]
 
-Agreement morphology for Tseltal (Tseltalan, Mayan). Tseltal and Tsotsil
-are closely related languages within the Tseltalan subgroup of Western
-Mayan. They share most syntactic properties relevant to possessor
-extraction ([aissen-polian-2025]).
+Agreement morphology for Tseltal (Tseltalan, Mayan). Tseltal and Tsotsil are
+closely related within the Tseltalan subgroup of Western Mayan, sharing most
+syntactic properties relevant to possessor extraction ([aissen-polian-2025];
+[polian-2013]).
 
-## The System
+## Main declarations
 
-Tseltal has the same two agreement paradigms as Tsotsil:
-- **Set A** (ERG/GEN): prefixes cross-referencing transitive agent and possessor.
-- **Set B** (ABS): consistently suffixal in Tseltal, cross-referencing the
-  absolutive argument (intransitive subject and transitive patient).
+* `Tseltal.ArgPosition` with `.case`, `.accCase`: argument positions and
+  their case (ergative-absolutive, no aspect split).
+* `Tseltal.setALinearity`, `Tseltal.setBLinearity`: prefixal Set A,
+  consistently suffixal Set B.
+* `Tseltal.setAExponent`, `Tseltal.setBExponent`: Oxchuc Tseltal exponent
+  tables ([polian-2013]).
+* `Tseltal.extractionStrategy`: unmarked extraction (no Agent Focus).
 
-The key difference from Tsotsil is Set B position: Tseltal Set B markers
-are consistently suffixal, whereas Tsotsil Set B markers can be prefixal
-or suffixal depending on context.
+## Implementation notes
 
-3rd person singular Set B has no overt exponent (∅).
-
-Grammatical function classification is shared across Tseltalan — see
-`Mayan.Tseltalan` for the shared definitions.
-
-## Alignment
+Tseltal has the same two agreement paradigms as Tsotsil: Set A (ERG/GEN)
+prefixes cross-reference the transitive agent and possessor; Set B (ABS)
+markers, consistently suffixal in Tseltal, cross-reference the absolutive
+argument (intransitive subject and transitive patient). The key difference
+from Tsotsil is Set B position — consistently suffixal in Tseltal, prefixal
+or suffixal by context in Tsotsil. 3rd person singular Set B has no overt
+exponent (∅). Grammatical-function classification is shared across Tseltalan
+(`Mayan.Tseltalan`).
 
 Tseltalan languages are uniformly **ergative-absolutive** with no
-aspect-conditioned split (in contrast with Cholan; per [polian-2013]).
-Set A indicates A; Set B indicates S and P alike.
+aspect-conditioned split (in contrast with Cholan; per [polian-2013]): Set A
+indicates A, Set B indicates S and P alike.
 -/
 
 namespace Tseltal
@@ -41,63 +43,51 @@ open Agreement
 -- Re-export shared Tseltalan types
 export Mayan.Tseltalan (GramFunction)
 
--- ============================================================================
--- § 1: Argument Positions (alias to canonical SAP type)
--- ============================================================================
+/-! ### Argument positions -/
 
-/-- Argument positions in a Tseltal clause. Aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
-    cross-framework code shares one inventory. -/
+/-- Argument positions in a Tseltal clause, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
 abbrev ArgPosition := Features.Prominence.ArgumentRole
 
-/-- Case assignment for Tseltal. Definitionally equal to
-    `Mayan.caseTseltalan .Perf`, which derives from
-    `Alignment.ergative.assignCase`. Tseltalan has no aspect-conditioned
-    split, so a single case function suffices for both perfective and
-    non-perfective. -/
+/-- Case assignment for Tseltal: `Mayan.caseTseltalan .Perf`
+    (A → ERG, S/P → ABS). No aspect-conditioned split, so a single function
+    covers perfective and non-perfective. -/
 abbrev ArgPosition.case : ArgPosition → Case :=
   Mayan.caseTseltalan .Perf
 
-/-- Non-perfective case assignment for Tseltal. Identical to perfective
-    (no aspect split per [polian-2013]). Provided for cross-Mayan
-    shape-uniformity with the other Mayan fragments. -/
+/-- Non-perfective case assignment for Tseltal: identical to perfective
+    (no aspect split, [polian-2013]); provided for cross-Mayan
+    shape-uniformity. -/
 abbrev ArgPosition.accCase : ArgPosition → Case :=
   Mayan.caseTseltalan .Imp
 
--- ============================================================================
--- § 2: Absolutive Position (LOW-ABS)
--- ============================================================================
+/-! ### Absolutive position (LOW-ABS) -/
 
 /-- Tseltal's absolutive morphemes appear in low (post-stem) position,
     consistent with Tseltalan being LOW-ABS. -/
 def absPosition : Mayan.ABSPosition := .low
 
--- ============================================================================
--- § 3: Agreement Marker Linearity
--- ============================================================================
+/-! ### Agreement marker linearity -/
 
 /-- Set A markers in Tseltal are prefixal (per [aissen-polian-2025]
     Table 1; pan-Mayan invariant). -/
 def setALinearity : MarkerLinearity := .prefixal
 
-/-- Set B markers in Tseltal are consistently suffixal. Contrasts with
-    Tsotsil Set B, which is prefixal or suffixal depending on context
-    ([aissen-polian-2025] Table 1, footnote 9). -/
+/-- Set B markers in Tseltal are consistently suffixal, contrasting with
+    Tsotsil (prefixal or suffixal by context; [aissen-polian-2025] Table 1,
+    footnote 9). -/
 def setBLinearity : MarkerLinearity := .suffixal
 
--- ============================================================================
--- § 4: Set A/B Exponents (Oxchuc Tseltal)
--- ============================================================================
+/-! ### Set A/B exponents (Oxchuc Tseltal) -/
 
-/-- Set A (ERG/GEN) exponents for Oxchuc Tseltal ([polian-2013]).
-    Prefixes on the verb or possessed noun. Forms shown as
-    `pre-C/pre-V` allomorph pairs. -/
+/-- Set A (ERG/GEN) exponents for Oxchuc Tseltal ([polian-2013]): prefixes
+    on the verb or possessed noun, shown as `pre-C/pre-V` allomorph pairs. -/
 def setAExponent : ExponentTable :=
   [(.pn .first .Sing, "k-/j-"), (.pn .second .Sing, "a-/aw-"), (.pn .third .Sing, "s-/y-"),
    (.pn .first .Plur, "k-/j-"), (.pn .second .Plur, "a-/aw-"), (.pn .third .Plur, "s-/y-")]
 
-/-- Set B (ABS) exponents for Oxchuc Tseltal ([polian-2013]).
-    Suffixes on the verb stem. 3rd person singular is null (`-∅`). -/
+/-- Set B (ABS) exponents for Oxchuc Tseltal ([polian-2013]): suffixes on
+    the verb stem; 3rd person singular is null (`-∅`). -/
 def setBExponent : ExponentTable :=
   [(.pn .first .Sing, "-on"), (.pn .second .Sing, "-at"), (.pn .third .Sing, "-∅"),
    (.pn .first .Plur, "-otik"), (.pn .second .Plur, "-ex"), (.pn .third .Plur, "-ik")]
@@ -111,9 +101,7 @@ theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" :=
     prefixal-or-suffixal); the marker set assignment is identical. -/
 theorem setB_is_suffixal : setBLinearity = .suffixal := rfl
 
--- ============================================================================
--- § 5: Extraction Profile
--- ============================================================================
+/-! ### Extraction profile -/
 
 /-- Tseltal's extraction data: no Agent Focus morphology required for
     A-extraction (`extractionStrategy = .unmarked`), consistent with

--- a/Linglib/Fragments/Mayan/Tseltal/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Possession.lean
@@ -2,19 +2,27 @@ import Linglib.Features.Possession
 
 /-!
 # Tseltal possession profile
-[stassen-2009] [nichols-1986] [heine-1997] [aissen-polian-2025]
 
-Per-language possession data for Tseltal (Mayan; ISO `tzh`), per the
-project's "per-language data flows through Fragments" rule, as bare
-field-by-field `def`s. Substrate types (`PredicativeStrategy`,
-`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
-Cross-linguistic theorems consuming these values live in
-`Studies/NicholsBickel2013.lean`.
+Per-language possession data for Tseltal (Mayan; ISO `tzh`) as bare
+field-by-field `def`s, following the project's "per-language data flows
+through Fragments" rule ([stassen-2009]; [nichols-1986]; [heine-1997];
+[aissen-polian-2025]).
+
+## Main declarations
+
+* `obligatoryPossession`, `possessiveClassification`, `predicativeStrategy`,
+  `adnominalStrategy`, `affixPosition`: the five possession-profile values.
+
+## Implementation notes
+
+The substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`; the cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
 
 Examples: *ay chenek' ta oxom* 'EXIS bean P pot', *s-be-lal te j-na=e*
 'A3-road-NCLS DET A1-house=ENC'. Existential *ay* + possessive pivot for
-predicative; Set A prefixes on possessum for adnominal (head-marking);
-three noun classes as in Tsotsil [aissen-polian-2025].
+predicative; Set A prefixes on possessum for adnominal (head-marking); three
+noun classes as in Tsotsil ([aissen-polian-2025]).
 -/
 
 set_option autoImplicit false

--- a/Linglib/Fragments/Mayan/Tseltalan.lean
+++ b/Linglib/Fragments/Mayan/Tseltalan.lean
@@ -3,14 +3,23 @@ import Linglib.Features.Prominence
 
 /-!
 # Shared Tseltalan Infrastructure
-[aissen-polian-2025] [polian-2013]
 
-Descriptive types shared across the Tseltalan subgroup (Tsotsil, Tseltal).
-Both languages share agreement paradigm assignment and grammatical function
-classification. They differ in agreement exponents and Set B marker
-position (Tsotsil: prefixal/suffixal; Tseltal: consistently suffixal).
+Descriptive types shared across the Tseltalan subgroup, Tsotsil and Tseltal
+([aissen-polian-2025]; [polian-2013]). Both languages share agreement
+paradigm assignment and grammatical-function classification; they differ in
+agreement exponents and Set B marker position (Tsotsil prefixal or suffixal,
+Tseltal consistently suffixal).
 
-## Agreement System (Table 1 of [aissen-polian-2025])
+## Main declarations
+
+* `Mayan.Tseltalan.GramFunction` with `.markerSet` and `.toArgumentRole?`:
+  the shared Split-S grammatical functions, their Set A / Set B assignment,
+  and projection to the canonical `ArgumentRole`.
+* `Mayan.Tseltalan.absPosition`: the subgroup-level LOW-ABS constant.
+
+## Implementation notes
+
+Agreement system ([aissen-polian-2025] Table 1):
 
 | Form   | Function | Tseltal  | Tsotsil          |
 |--------|----------|----------|------------------|
@@ -22,24 +31,11 @@ namespace Mayan.Tseltalan
 
 open Mayan (MarkerSet)
 
--- ============================================================================
--- § 1: Grammatical Functions
--- ============================================================================
+/-! ### Grammatical functions -/
 
-/-- Grammatical functions in Tseltalan, determining which agreement
-    marker set cross-references each argument.
-
-    These are traditional Mayanist descriptive categories
-    (footnote 9 of [aissen-polian-2025]).
-
-    | Function                           | Marker Set |
-    |------------------------------------|------------|
-    | A (transitive subject)             | Set A      |
-    | S_A (agentive intransitive subject)| Set B      |
-    | S_O (patientive intransitive subj) | Set B      |
-    | O (transitive/ditransitive object) | Set B      |
-    | G (applied argument)               | Set B      |
-    | Possessor (genitive)               | Set A      | -/
+/-- Grammatical functions in Tseltalan — traditional Mayanist descriptive
+    categories (footnote 9 of [aissen-polian-2025]) — determining which
+    agreement marker set cross-references each argument. -/
 inductive GramFunction where
   | A    -- transitive subject (agent)
   | S_A  -- intransitive subject (agentive)
@@ -49,9 +45,9 @@ inductive GramFunction where
   | psr  -- possessor (genitive)
   deriving DecidableEq, Repr
 
-/-- The marker set that cross-references each grammatical function.
-    Set A = ergative/genitive; Set B = absolutive.
-    Shared across Tseltalan ([aissen-polian-2025], [polian-2013]). -/
+/-- The marker set cross-referencing each grammatical function (Set A =
+    ergative/genitive, Set B = absolutive); shared across Tseltalan
+    ([aissen-polian-2025], [polian-2013]). -/
 def GramFunction.markerSet : GramFunction → MarkerSet
   | .A   => .setA
   | .S_A => .setB
@@ -60,9 +56,7 @@ def GramFunction.markerSet : GramFunction → MarkerSet
   | .G   => .setB
   | .psr => .setA
 
--- ============================================================================
--- § 2: Shared Theorems
--- ============================================================================
+/-! ### Shared theorems -/
 
 /-- Ergative-genitive homophony: Set A cross-references both transitive
     agents and possessors. A pan-Mayan pattern. -/
@@ -76,40 +70,25 @@ theorem abs_uniform :
     GramFunction.O.markerSet = .setB ∧
     GramFunction.G.markerSet = .setB := ⟨rfl, rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 3: Absolutive Position (LOW-ABS)
--- ============================================================================
+/-! ### Absolutive position (LOW-ABS) -/
 
-/-- Tseltalan absolutive morphemes appear in low (post-stem) position.
-    Both Tsotsil and Tseltal share this LOW-ABS classification — see
-    `Tsotsil.absPosition` and `Tseltal.absPosition`
-    for the per-language definitions, which are definitionally equal to this
-    subgroup-level constant. The LOW-ABS classification refers to the
-    structural position of the licensing head, not the linear position
-    of every Set B exponent (which varies by language and context).
+/-- Tseltalan absolutive morphemes appear in low (post-stem) position; both
+    Tsotsil and Tseltal inherit this LOW-ABS constant. LOW-ABS refers to the
+    structural position of the licensing head, not the linear position of
+    every Set B exponent (which varies by language and context).
     [aissen-polian-2025] p. 97; [polian-2013]. -/
 def absPosition : Mayan.ABSPosition := .low
 
--- ============================================================================
--- § 4: Projection to Canonical ArgumentRole
--- ============================================================================
+/-! ### Projection to canonical ArgumentRole -/
 
-/-- Project the Tseltalan-specific Split-S grammatical function down to
-    the canonical pan-linguistic `ArgumentRole` (S/A/P/R/T) used across
-    linglib. The projection is **partial** (`Option`-valued):
-
-    - `.A → .A`, `.O → .P`, `.G → .R`: verbal arguments map cleanly.
-    - `.S_A`, `.S_O → .S`: agentivity distinction is collapsed (lossy
-      but expected for cross-Mayan typology theorems that don't track
-      Split-S granularity).
-    - `.psr → none`: possessors are DP-internal, with no `ArgumentRole`
-      analog. Cross-Mayan typology theorems quantify over verbal
-      arguments only.
-
-    Tseltal/Tsotsil consumers of cross-Mayan theorems use this projection
-    to feed Tseltalan agreement data into the canonical inventory; the
-    Aissen-Polian possessor-extraction analysis continues to use
-    `GramFunction` directly for its DP-internal claims. -/
+/-- Project the Tseltalan Split-S grammatical function to the canonical
+    `ArgumentRole` (S/A/P/R/T). Partial (`Option`-valued): `.A → .A`,
+    `.O → .P`, `.G → .R` map cleanly; `.S_A`, `.S_O → .S` collapses the
+    agentivity distinction (lossy but expected for cross-Mayan theorems that
+    don't track Split-S); `.psr → none`, since possessors are DP-internal
+    with no `ArgumentRole` analog. Cross-Mayan consumers use this projection;
+    the Aissen-Polian possessor-extraction analysis uses `GramFunction`
+    directly for its DP-internal claims. -/
 def GramFunction.toArgumentRole? : GramFunction → Option Features.Prominence.ArgumentRole
   | .A   => some .A
   | .S_A => some .S

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -3,30 +3,31 @@ import Linglib.Syntax.Extraction
 
 /-!
 # Tsotsil Agreement Fragment
-[polian-2013] [aissen-polian-2025]
 
-Agreement morphology for Zinacantec Tsotsil (Tseltalan, Mayan).
+Agreement morphology for Zinacantec Tsotsil (Tseltalan, Mayan)
+([polian-2013]; [aissen-polian-2025]).
 
-## The System
+## Main declarations
 
-Tsotsil has two agreement paradigms on the verb:
-- **Set A** (ERG/GEN): prefixes cross-referencing the transitive agent
-  (ergative) and the possessor (genitive). Ergative and genitive are
-  homophonous ([polian-2013]).
-- **Set B** (ABS): prefixes or suffixes cross-referencing the absolutive
-  argument (intransitive subject and transitive patient). Position varies
-  by dialect and morphosyntactic context; in Zinacantec Tsotsil, Set B
-  markers occur either prefixally or suffixally.
+* `Tsotsil.ArgPosition` with `.case`, `.accCase`: argument positions and
+  their case (ergative-absolutive, no aspect split).
+* `Tsotsil.setALinearity`, `Tsotsil.setBLinearity`: prefixal Set A,
+  prefixal-or-suffixal Set B.
+* `Tsotsil.setAExponent`, `Tsotsil.setBExponent`: Zinacantec Tsotsil
+  exponent tables ([polian-2013]).
+* `Tsotsil.extractionStrategy`: unmarked extraction (no Agent Focus).
 
+## Implementation notes
+
+Tsotsil has two agreement paradigms on the verb: Set A (ERG/GEN) prefixes
+cross-reference the transitive agent (ergative) and possessor (genitive),
+which are homophonous ([polian-2013]); Set B (ABS) markers cross-reference
+the absolutive argument (intransitive subject and transitive patient), and
+occur prefixally or suffixally by dialect and morphosyntactic context.
 Canonical word order is VOA (verb-initial), though both arguments are
-usually unpronounced unless topicalized or focused.
-
-3rd person singular Set B has no overt exponent (∅).
-
-Grammatical function classification is shared across Tseltalan — see
-`Mayan.Tseltalan` for the shared definitions.
-
-## Alignment
+usually unpronounced unless topicalized or focused. 3rd person singular Set
+B has no overt exponent (∅). Grammatical-function classification is shared
+across Tseltalan (`Mayan.Tseltalan`).
 
 Tseltalan languages are uniformly **ergative-absolutive** with no
 aspect-conditioned split (in contrast with Cholan; per [polian-2013]).
@@ -40,68 +41,54 @@ open Agreement
 -- Re-export shared Tseltalan types
 export Mayan.Tseltalan (GramFunction)
 
--- ============================================================================
--- § 1: Argument Positions (alias to canonical SAP type)
--- ============================================================================
+/-! ### Argument positions -/
 
-/-- Argument positions in a Tsotsil clause. Aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
-    cross-framework code shares one inventory. -/
+/-- Argument positions in a Tsotsil clause, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
 abbrev ArgPosition := Features.Prominence.ArgumentRole
 
-/-- Case assignment for Tsotsil. Definitionally equal to
-    `Mayan.caseTseltalan .Perf`, which derives from
-    `Alignment.ergative.assignCase`. Tseltalan has no aspect-conditioned
-    split. -/
+/-- Case assignment for Tsotsil: `Mayan.caseTseltalan .Perf`
+    (A → ERG, S/P → ABS); Tseltalan has no aspect-conditioned split. -/
 abbrev ArgPosition.case : ArgPosition → Case :=
   Mayan.caseTseltalan .Perf
 
-/-- Non-perfective case assignment for Tsotsil. Identical to perfective
-    (no aspect split per [polian-2013]). -/
+/-- Non-perfective case assignment for Tsotsil: identical to perfective
+    (no aspect split, [polian-2013]). -/
 abbrev ArgPosition.accCase : ArgPosition → Case :=
   Mayan.caseTseltalan .Imp
 
--- ============================================================================
--- § 2: Absolutive Position (LOW-ABS)
--- ============================================================================
+/-! ### Absolutive position (LOW-ABS) -/
 
-/-- Tsotsil's absolutive morphemes appear in low (post-stem) position
-    when suffixal, consistent with Tseltalan being LOW-ABS. The
-    prefixal-or-suffixal alternation is conditioned by morphosyntactic
-    context (see `setBLinearity`); the LOW-ABS classification refers to
-    the structural position of the licensing head, not the linear
+/-- Tsotsil's absolutive morphemes appear in low (post-stem) position when
+    suffixal (Tseltalan is LOW-ABS). The prefixal-or-suffixal alternation is
+    conditioned by morphosyntactic context (see `setBLinearity`); LOW-ABS
+    refers to the structural position of the licensing head, not the linear
     position of every Set B exponent. -/
 def absPosition : Mayan.ABSPosition := .low
 
--- ============================================================================
--- § 3: Agreement Marker Linearity
--- ============================================================================
+/-! ### Agreement marker linearity -/
 
 /-- Set A markers in Tsotsil are prefixal (per [aissen-polian-2025]
     Table 1; pan-Mayan invariant). -/
 def setALinearity : MarkerLinearity := .prefixal
 
-/-- Set B markers in Tsotsil are prefixal or suffixal, depending on
-    dialect and morphosyntactic context ([aissen-polian-2025]
-    Table 1). The Tsotsil-vs-Tseltal contrast in Set B linearity is the
-    headline Tseltalan-internal divergence. -/
+/-- Set B markers in Tsotsil are prefixal or suffixal by dialect and
+    morphosyntactic context ([aissen-polian-2025] Table 1) — the headline
+    Tseltalan-internal divergence from Tseltal. -/
 def setBLinearity : MarkerLinearity := .either
 
--- ============================================================================
--- § 4: Set A/B Exponents (Zinacantec Tsotsil)
--- ============================================================================
+/-! ### Set A/B exponents (Zinacantec Tsotsil) -/
 
-/-- Set A (ERG/GEN) exponents for Zinacantec Tsotsil
-    ([polian-2013]). Prefixes on the verb (for ERG) or the possessed
-    noun (for GEN). Forms vary by following segment; shown as
-    `pre-C/pre-V` allomorph pairs. -/
+/-- Set A (ERG/GEN) exponents for Zinacantec Tsotsil ([polian-2013]):
+    prefixes on the verb (ERG) or possessed noun (GEN), varying by following
+    segment, shown as `pre-C/pre-V` allomorph pairs. -/
 def setAExponent : ExponentTable :=
   [(.pn .first .Sing, "k-/j-"), (.pn .second .Sing, "a-/av-"), (.pn .third .Sing, "s-/y-"),
    (.pn .first .Plur, "k-/j-"), (.pn .second .Plur, "a-/av-"), (.pn .third .Plur, "s-/y-")]
 
-/-- Set B (ABS) exponents for Zinacantec Tsotsil ([polian-2013]).
-    3rd person singular has no overt exponent (`-∅`). Some forms show
-    allomorphic alternation depending on suffix harmony. -/
+/-- Set B (ABS) exponents for Zinacantec Tsotsil ([polian-2013]): 3rd person
+    singular has no overt exponent (`-∅`); some forms alternate by suffix
+    harmony. -/
 def setBExponent : ExponentTable :=
   [(.pn .first .Sing, "-on/-un"), (.pn .second .Sing, "-ot/-at"), (.pn .third .Sing, "-∅"),
    (.pn .first .Plur, "-otik/-utik"), (.pn .second .Plur, "-oxuk"), (.pn .third .Plur, "-ik")]
@@ -111,13 +98,11 @@ def setBExponent : ExponentTable :=
     pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
--- ============================================================================
--- § 5: Extraction Profile
--- ============================================================================
+/-! ### Extraction profile -/
 
-/-- Tsotsil's extraction profile (language "Tsotsil"): no Agent Focus
-    morphology required for A-extraction, consistent with Tsotsil being
-    LOW-ABS. Notes: LOW-ABS Tseltalan; no AF morphology. -/
+/-- Tsotsil requires no Agent Focus morphology for A-extraction
+    (`extractionStrategy = .unmarked`), consistent with Tsotsil being
+    LOW-ABS. -/
 def extractionStrategy : Extraction.ExtractionMarkingStrategy := .unmarked
 def extractionMarkedPositions : List Extraction.ExtractionTarget := []
 def extractionDistinguishesPosition : Bool := false

--- a/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
@@ -2,20 +2,28 @@ import Linglib.Features.Possession
 
 /-!
 # Tsotsil possession profile
-[stassen-2009] [nichols-1986] [heine-1997] [aissen-polian-2025]
 
-Per-language possession data for Tsotsil (Mayan; ISO `tzo`), per the
-project's "per-language data flows through Fragments" rule, as bare
-field-by-field `def`s. Substrate types (`PredicativeStrategy`,
-`AdnominalMarking`, …) live in `Linglib/Features/Possession.lean`.
-Cross-linguistic theorems consuming these values live in
-`Studies/NicholsBickel2013.lean`.
+Per-language possession data for Tsotsil (Mayan; ISO `tzo`) as bare
+field-by-field `def`s, following the project's "per-language data flows
+through Fragments" rule ([stassen-2009]; [nichols-1986]; [heine-1997];
+[aissen-polian-2025]).
+
+## Main declarations
+
+* `obligatoryPossession`, `possessiveClassification`, `predicativeStrategy`,
+  `adnominalStrategy`, `affixPosition`: the five possession-profile values.
+
+## Implementation notes
+
+The substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
+`Linglib/Features/Possession.lean`; the cross-linguistic theorems consuming
+these values live in `Studies/NicholsBickel2013.lean`.
 
 Examples: *oy s-k'ox barko* 'EXIS A3-little.boat', *s-me' Xun* 'A3-mother
 Juan' = "Juan's mother", *y-ak'-il li mok=e* 'A3-vine-NCLS DET fence=ENC'.
 Existential *oy* + possessive pivot for predicative; Set A prefixes on
 possessum for adnominal (head-marking); three noun classes: must/may/cannot
-be possessed [aissen-polian-2025].
+be possessed ([aissen-polian-2025]).
 -/
 
 set_option autoImplicit false

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -5,17 +5,23 @@ import Linglib.Fragments.Mayan.Yukatek.Roots
 /-!
 # Yukatek Maya Derivational Operator Inventory
 
-[lucy-1994] [bohnemeyer-2004]
-[beavers-koontz-garboden-2020]
-
 The four derivational suffixes that determine Yukatek root salience
-classes ([lucy-1994]). The first three are transitivisers, used
-diagnostically to identify a root's salience profile; the fourth
-(`-tal`, allomorph `-lah`) is the positional inchoative that carves out a separate
-class of stative roots.
+classes ([lucy-1994]). The first three (`=t`, `=∅`, `=s`) are
+transitivisers, used diagnostically to identify a root's salience profile;
+the fourth (`-tal`, allomorph `-lah`) is the positional inchoative that
+carves out a separate class of stative roots.
 
-[lucy-1994] characterises the diagnostic by which of `=t`, `=∅`,
-or `=s` is required to form a transitive stem from an underived root:
+## Main declarations
+
+* `Yukatek.Operators.affectiveT`, `zeroDeriv`, `causativeS`,
+  `positionalTal`: the four derivational operators.
+* `Yukatek.Operators.inventory`: [lucy-1994]'s diagnostic transitiviser
+  inventory.
+
+## Implementation notes
+
+[lucy-1994] characterises the diagnostic by which of `=t`, `=∅`, or `=s`
+is required to form a transitive stem from an underived root:
 
 | Required suffix | Lucy's class           | Lexical content of root                                    |
 |-----------------|------------------------|------------------------------------------------------------|
@@ -23,13 +29,15 @@ or `=s` is required to form a transitive stem from an underived root:
 | `=∅` (root)     | agent-patient salient  | lexically transitive ("require two arguments")            |
 | `=s` (CAUS)     | patient-salient        | spontaneous state change; one (patient) argument salient   |
 
-The structural conditions are over (B&K-G kind signature × Coon
-arity): zero derivation tracks root transitivity
-(`Root.Arity.selectsTheme`); the two intransitive transitivisers split
-by signature (manner vs result). Each condition is the corresponding
-named predicate of `Roots/SalienceClass.lean` applied to the root's
-signature and the fragment's `arity` assignment, so operator
-applicability matches predicted salience by construction.
+The structural conditions range over B&K-G kind signature × Coon arity
+([beavers-koontz-garboden-2020]): zero derivation tracks root transitivity
+(`Root.Arity.selectsTheme`); the two intransitive transitivisers split by
+signature (manner vs result). Each condition is the corresponding named
+predicate of `Roots/SalienceClass.lean` applied to the root's signature and
+the fragment's `arity` assignment, so operator applicability matches
+predicted salience by construction. The salience classes these suffixes
+diagnose interface with [bohnemeyer-2004]'s Yukatek stem classes
+(`VerbClasses.lean`).
 -/
 
 namespace Yukatek.Operators

--- a/Linglib/Fragments/Mayan/Yukatek/Roots.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Roots.lean
@@ -4,17 +4,25 @@ import Linglib.Semantics.Verb.Root.Arity
 /-!
 # Yukatek Maya Roots as B&K-G Entailment Sets
 
-[lucy-1994] [beavers-koontz-garboden-2020]
+A representative cross-section of Yukatek roots drawn from [lucy-1994]
+ex. (1), (2), (4), and (7), encoded as [beavers-koontz-garboden-2020]-style
+entailment sets. The selection covers all four salience profiles
+[lucy-1994] identifies in Yukatek: agent-salient, agent-patient salient,
+patient-salient, and positional.
 
-A representative cross-section of Yukatek roots, drawn from the lists
-in [lucy-1994] ex. (1), (2), (4), and (7), and encoded as
-[beavers-koontz-garboden-2020]-style entailment sets.
+## Main declarations
 
-The selection covers all four salience profiles that [lucy-1994]
-identifies in Yukatek (agent-salient, agent-patient salient,
-patient-salient, positional). The roots feed into the operator
-inventory in `Operators.lean` and the orbit-derivation in
-`Studies/Lucy1994.lean`.
+* the root defs (`siit`, `kuc`, `kiim`, `cin`, …): Yukatek roots grouped
+  by salience class, each a set of B&K-G kind atoms.
+* `Yukatek.Roots.arity`: Coon arity — the root transitives (`=∅` class)
+  select a theme; every other sampled root is intransitive.
+* `Yukatek.Roots.agentSalientRoots`, `agentPatientSalientRoots`,
+  `patientSalientRoots`, `motionRoots`, `positionalRoots`: the class lists.
+
+## Implementation notes
+
+The roots feed the operator inventory in `Operators.lean` and the
+orbit-derivation in `Studies/Lucy1994.lean`.
 
 | Source          | Root      | gloss              | profile              | Lucy class            |
 |-----------------|-----------|--------------------|----------------------|------------------------|
@@ -30,43 +38,37 @@ inventory in `Operators.lean` and the orbit-derivation in
 | ex. (7)         | `cin`       | "bend"             | state                | positional             |
 | (Yukatek lex.)  | `kul`       | "sit"              | state                | positional             |
 
-The patient-salient list also includes `'ah` "wake", `wen` "sleep",
-`siih` "be born", `tú'ub'` "be forgotten", `k'a'ah` "remember",
-`čú'un` "begin", `č'en` "stop, cease", `hó'op'` "begin", `hé'el` "rest",
-`p'át` "remain"; the agent-salient list includes `mìis` "sweep",
-`ć'eh` "shout", `paak` "weed". For the motion-roots non-class
-argument we add a small representative subset: `máan` "pass", `tàal`
-"come", `b'in` "go", `nàak` "ascend", `lìik'` "rise". These are all
-encoded with `becomesState` atoms (no `.motion` atom; see
-`motion_roots_not_separate_class` for why "motion" is *not* a B&K-G
-feature in Lucy's analysis).
+Beyond the tabulated core, the patient-salient list also includes `'ah`
+"wake", `wen` "sleep", `siih` "be born", `tú'ub'` "be forgotten",
+`k'a'ah` "remember", `čú'un` "begin", `č'en` "stop, cease", `hó'op'`
+"begin", `hé'el` "rest", `p'át` "remain"; the agent-salient list includes
+`mìis` "sweep", `ć'eh` "shout", `paak` "weed". A small representative
+subset of motion roots is added: `máan` "pass", `tàal` "come", `b'in`
+"go", `nàak` "ascend", `lìik'` "rise". All are encoded with `becomesState`
+atoms (no `.motion` atom; see `motion_roots_not_separate_class` for why
+"motion" is not a B&K-G feature in Lucy's analysis).
 
-**Important orthographic note.** Yukatek `háan` "stop/cease/heal" and
-`hàan` "eat" differ in vowel tone (high vs. low). They are distinct
-roots with distinct lexical content. We disambiguate by suffixing the
-gloss: `haanCease` here is the patient-salient cessation root;
-`Yukatek.haanEat` (in `VerbClasses.lean`) is the
-inactive-class but internally-caused "eat" verb that
-[bohnemeyer-2004] ex. (9) takes as the key applicative exception.
+Yukatek `háan` "stop/cease/heal" and `hàan` "eat" differ in vowel tone
+(high vs. low): distinct roots with distinct lexical content, disambiguated
+by suffixing the gloss. `haanCease` here is the patient-salient cessation
+root; `Yukatek.haanEat` (in `VerbClasses.lean`) is the inactive-class but
+internally-caused "eat" verb that [bohnemeyer-2004] ex. (9) takes as the
+key applicative exception.
 
-The transcription uses ASCII glosses (no IPA diacritics) for ease of
-identifier use; original orthography is preserved in docstrings.
+The transcription uses ASCII glosses (no IPA diacritics) for identifier
+ease; original orthography is preserved in docstrings.
 -/
 
 namespace Yukatek.Roots
 
 open Verb
 
--- ════════════════════════════════════════════════════
--- § 1. Agent-Salient Roots (manner only, take `=t`)
--- ════════════════════════════════════════════════════
+/-! ### Agent-salient roots (manner only, take `=t`) -/
 
-/-- síit' "jump" — manner-of-action activity ([lucy-1994] ex. 1a).
-    Underived intransitive; takes affective `=t` to transitivise.
-    No `.motion` atom: per [lucy-1994], motion is *not* a B&K-G
-    feature in Yukatek (cf. `motion_roots_not_separate_class`); jumping
-    qualifies as a manner-of-action irrespective of whether it
-    incidentally involves displacement. -/
+/-- síit' "jump" — manner-of-action activity, underived intransitive
+    ([lucy-1994] ex. 1a). No `.motion` atom: jumping is manner-of-action
+    regardless of incidental displacement (cf.
+    `motion_roots_not_separate_class`). -/
 def siit : Root := ⟨"siit'", {.hasManner "jumping"}, none, {}⟩
 
 /-- ¢'iib "write" — manner-of-action activity ([lucy-1994] p. 628). -/
@@ -105,15 +107,12 @@ def kuc : Root := ⟨"kuc", {.hasManner "carrying"}, none, {}⟩
 def pis : Root := ⟨"pis", {.hasManner "measuring"}, none, {}⟩
 
 /-- lo'š "punch" — manner-of-action, lexically transitive
-    ([lucy-1994] p. 629). Surface-contact manner without entailed
-    result, like B&K-G's *hit*-type. No `.contact` atom: contact is
-    implicit in the manner of striking rather than a B&K-G feature in
-    Lucy's typology. -/
+    ([lucy-1994] p. 629). Surface-contact manner without entailed result,
+    like B&K-G's *hit*-type; no `.contact` atom (contact is implicit in
+    the manner of striking, not a B&K-G feature in Lucy's typology). -/
 def los : Root := ⟨"los", {.hasManner "striking"}, none, {}⟩
 
--- ════════════════════════════════════════════════════
--- § 3. Patient-Salient Roots (result only, take `=s`)
--- ════════════════════════════════════════════════════
+/-! ### Patient-salient roots (result only, take `=s`) -/
 
 /-- kíim "die" — spontaneous state change ([lucy-1994] ex. 1c, 2). -/
 def kiim : Root := ⟨"kiim", {.becomesState "dead"}, none, {}⟩
@@ -125,11 +124,9 @@ def kiim : Root := ⟨"kiim", {.becomesState "dead"}, none, {}⟩
     and [bohnemeyer-2004] ex. (9). -/
 def haanCease : Root := ⟨"háan", {.becomesState "stopped"}, none, {}⟩
 
-/-- lúub' "fall" ([lucy-1994] ex. 4, Table 4). A "motion verb" by
-    any reasonable cross-linguistic notional taxonomy, but patterns
-    morphologically with other patient-salient change-of-state roots
-    in Yukatek. No `.motion` atom: motion is the *issue*, not a
-    feature — see `motion_roots_not_separate_class`. -/
+/-- lúub' "fall" ([lucy-1994] ex. 4, Table 4). Notionally a motion verb,
+    but patterns morphologically with the patient-salient change-of-state
+    roots; no `.motion` atom (see `motion_roots_not_separate_class`). -/
 def luub : Root := ⟨"luub'", {.becomesState "fallen"}, none, {}⟩
 
 /-- 'ok "enter, intrude" ([lucy-1994] ex. 4, Table 4). Another
@@ -194,9 +191,7 @@ def naak : Root := ⟨"nàak", {.becomesState "ascended"}, none, {}⟩
 /-- lìik' "rise" ([lucy-1994] Table 4). -/
 def liik : Root := ⟨"lìik'", {.becomesState "risen"}, none, {}⟩
 
--- ════════════════════════════════════════════════════
--- § 4. Positional Roots (state only, take `-tal`)
--- ════════════════════════════════════════════════════
+/-! ### Positional roots (state only, take `-tal`) -/
 
 /-- čin "bow, bend down, bend over" ([lucy-1994] ex. 5, 7).
     Positional root; takes `-tal` (or `-lah`) for the inchoative stem. -/
@@ -339,9 +334,7 @@ theorem cin_closed_signature :
 theorem kul_closed_signature :
     kul.closedKinds = {.state} := by decide
 
--- ════════════════════════════════════════════════════
--- § 7. Class Lists
--- ════════════════════════════════════════════════════
+/-! ### Class lists -/
 
 /-- The agent-salient roots in this fragment: roots with manner only,
     expected to take affective `=t`. -/

--- a/Linglib/Fragments/Mayan/Yukatek/VerbClasses.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/VerbClasses.lean
@@ -7,14 +7,30 @@ import Linglib.Syntax.Case.Alignment
 /-!
 # Yukatek Maya Verb Classes and Status System
 
-[bohnemeyer-2004] [lucy-1994]
-
 Yukatek Maya has a typologically rare split-intransitive pattern of
-argument marking controlled by overt aspect-mood marking. The system
-comprises five verb stem classes distinguished by their status
-inflection patterns (allomorphy of aspect-mood suffixes).
+argument marking controlled by overt aspect-mood marking
+([bohnemeyer-2004]; [lucy-1994]). The system comprises five verb stem
+classes distinguished by status inflection patterns (allomorphy of
+aspect-mood suffixes) and four status categories encoding viewpoint aspect
+and modal assertiveness. The split in argument marking tracks the aspectual
+value: perfective status marks S like U (ergative), imperfective status
+marks S like A (accusative).
 
-## Verb Stem Classes
+## Main declarations
+
+* `Yukatek.VerbStemClass`: the five stem classes, with `eventType`,
+  `isIntransitive`, `toTemplate` (R&H templates), and `toSalienceClass`
+  ([lucy-1994]'s 4-way cut).
+* `Yukatek.StatusCategory`: the four status categories, with
+  `viewpointAspect` and `isAssertive`.
+* `Yukatek.sArgumentMarker`: which marker set cross-references the
+  intransitive subject, given the status category.
+* `Yukatek.yukatekSplit`: the aspect-conditioned split as an
+  `Alignment.SplitErgativity`, shared with Hindi and Georgian.
+
+## Implementation notes
+
+Verb stem classes ([bohnemeyer-2004] Table 3; [lucy-1994]):
 
 | Class | Event type | Examples |
 |-------|-----------|----------|
@@ -24,8 +40,6 @@ inflection patterns (allomorphy of aspect-mood suffixes).
 | positional | state change (spatial config.) | sit, stand, hang, be round |
 | transitive active | transitive | hit, chip, eat |
 
-## Status Categories
-
 Status marking encodes both viewpoint aspect and modal assertiveness
 ([bohnemeyer-2004] Table 2):
 
@@ -33,10 +47,6 @@ Status marking encodes both viewpoint aspect and modal assertiveness
 - **subjunctive**: +perfective, −assertive → ergative (S = U)
 - **incompletive**: −perfective, +assertive → accusative (S = A)
 - **imperative**: directive mood
-
-The split in argument marking is associated with the aspectual value:
-perfective status → S marked like U (ergative); imperfective status →
-S marked like A (accusative).
 -/
 
 namespace Yukatek
@@ -46,9 +56,7 @@ open Semantics.Aspect (ViewpointAspectB)
 open ArgumentStructure.EventStructure (EventType InternalExternalCause)
 open Mayan (MarkerSet)
 
--- ════════════════════════════════════════════════════
--- § 1. Verb Stem Classes
--- ════════════════════════════════════════════════════
+/-! ### Verb stem classes -/
 
 /-- The five verb stem classes of Yukatek Maya, distinguished by
     status inflection patterns ([bohnemeyer-2004] Table 3;
@@ -61,13 +69,11 @@ inductive VerbStemClass where
   | transitiveActive -- transitive roots: hit, chip, eat
   deriving DecidableEq, Repr
 
-/-- Event type encoded by each verb stem class.
-    Active stems encode processes; all others encode state changes.
-
-    [bohnemeyer-2004] §5: degree achievement verbs regularly appear
-    in the inactive and inchoative classes despite being atelic. Their
-    event structure encodes state change — the process/state-change
-    distinction, not telicity, motivates class membership. -/
+/-- Event type per verb stem class: active stems encode processes, all
+    others state changes. Per [bohnemeyer-2004] §5, atelic degree
+    achievements still fall in the inactive and inchoative classes — class
+    membership tracks the process vs state-change distinction, not
+    telicity. -/
 def VerbStemClass.eventType : VerbStemClass → EventType
   | .active => .process
   | .inactive => .stateChange
@@ -80,9 +86,7 @@ def VerbStemClass.isIntransitive : VerbStemClass → Bool
   | .transitiveActive => false
   | _ => true
 
--- ════════════════════════════════════════════════════
--- § 2. Status Categories
--- ════════════════════════════════════════════════════
+/-! ### Status categories -/
 
 /-- The four status categories of Yukatek Maya, encoding viewpoint
     aspect and modal assertiveness ([bohnemeyer-2004] Table 2). -/
@@ -93,9 +97,7 @@ inductive StatusCategory where
   | imperative    -- directive mood
   deriving DecidableEq, Repr
 
-/-- Aspectual value of a status category.
-    Completive and subjunctive are perfective; incompletive is
-    imperfective. Imperative has no clear aspectual value. -/
+/-- Aspectual value of a status category (the imperative has none). -/
 def StatusCategory.viewpointAspect : StatusCategory → Option ViewpointAspectB
   | .completive => some .perfective
   | .subjunctive => some .perfective
@@ -108,17 +110,13 @@ def StatusCategory.isAssertive : StatusCategory → Bool
   | .incompletive => true
   | _ => false
 
--- ════════════════════════════════════════════════════
--- § 3. Argument Marking Pattern
--- ════════════════════════════════════════════════════
+/-! ### Argument marking pattern -/
 
 /-- Which marker set cross-references the sole argument (S) of an
-    intransitive verb, given the status category.
-
-    [bohnemeyer-2004] Table 2:
-    - Perfective status (completive/subjunctive): S = U → set-B (ergative)
-    - Imperfective status (incompletive): S = A → set-A (accusative)
-    - Imperative: not discussed in the split analysis (Table 2 omits it) -/
+    intransitive verb, given the status category ([bohnemeyer-2004]
+    Table 2). Perfective status gives set-B (ergative, S = U), imperfective
+    set-A (accusative, S = A); the imperative is omitted from Table 2's
+    split analysis. -/
 def sArgumentMarker : StatusCategory → Option MarkerSet
   | .completive => some .setB    -- ergative: S patterns with U
   | .subjunctive => some .setB   -- ergative: S patterns with U
@@ -133,12 +131,10 @@ theorem perfective_ergative :
 theorem imperfective_accusative :
     sArgumentMarker .incompletive = some .setA := rfl
 
--- ════════════════════════════════════════════════════
--- § 4. Representative Verb Entries
--- ════════════════════════════════════════════════════
+/-! ### Representative verb entries -/
 
-/-- A Yukatek verb entry for the split intransitivity analysis.
-    Records stem class and causation type of the intransitive base. -/
+/-- A Yukatek verb entry for the split-intransitivity analysis: stem class
+    and causation type of the intransitive base. -/
 structure YukatekVerb where
   gloss : String
   stemClass : VerbStemClass
@@ -199,20 +195,15 @@ def tsuuk : YukatekVerb := ⟨"rot", .inactive, .external⟩
 -- Transitive active
 def haats : YukatekVerb := ⟨"hit", .transitiveActive, .internal⟩
 
--- ════════════════════════════════════════════════════
--- § 5. Bridge to Event Structure Templates
--- ════════════════════════════════════════════════════
+/-! ### Event-structure templates -/
 
 open ArgumentStructure.EventStructure (Template)
 
-/-- Map Yukatek verb stem classes to R&H event structure templates.
-    This connects the language-specific classification to the
-    theory-level decomposition in `EventStructure.lean`.
-
-    - Active → activity [x ACT]
-    - Inactive/inchoative → achievement [BECOME [x ⟨STATE⟩]]
-    - Positional → achievement (externally-caused spatial config.)
-    - Transitive active → accomplishment [[x ACT] CAUSE [BECOME [y ⟨STATE⟩]]] -/
+/-- Yukatek verb stem classes to R&H event-structure templates
+    (`EventStructure.lean`): active → activity [x ACT], inactive and
+    inchoative → achievement [BECOME [x ⟨STATE⟩]], positional → achievement
+    (externally-caused spatial config.), transitive active →
+    accomplishment [[x ACT] CAUSE [BECOME [y ⟨STATE⟩]]]. -/
 def VerbStemClass.toTemplate : VerbStemClass → Template
   | .active => .activity
   | .inactive => .achievement
@@ -226,9 +217,7 @@ theorem eventType_consistent (c : VerbStemClass) :
     c.eventType = c.toTemplate.eventType := by
   cases c <;> rfl
 
--- ════════════════════════════════════════════════════
--- § 5.5. Bridge to [lucy-1994] Salience Classes
--- ════════════════════════════════════════════════════
+/-! ### Salience classes ([lucy-1994]) -/
 
 /-- Map [bohnemeyer-2004]'s 5-way Yukatek stem classification to
     [lucy-1994]'s 4-way salience cut. The 5-way is a refinement:
@@ -292,17 +281,13 @@ theorem toSalienceClass_fiber_agentPatient (s : VerbStemClass) :
     s.toSalienceClass = .agentPatient ↔ s = .transitiveActive := by
   cases s <;> simp [VerbStemClass.toSalienceClass]
 
--- ════════════════════════════════════════════════════
--- § 6. Split-Ergative System
--- ════════════════════════════════════════════════════
+/-! ### Split-ergative system -/
 
-/-- Yukatek split-ergative system, parameterized by status category.
-    Perfective status (completive/subjunctive) triggers ergative alignment;
-    imperfective status (incompletive) triggers accusative alignment.
-    Imperative is treated as ergative (completive-like default).
-
-    This instantiates the same `Alignment.SplitErgativity` type used by Hindi
-    and Georgian, enabling cross-linguistic comparison. -/
+/-- Yukatek split-ergative system, parameterized by status category:
+    perfective status (completive/subjunctive) triggers ergative alignment,
+    imperfective (incompletive) accusative; the imperative defaults to
+    ergative. Instantiates the same `Alignment.SplitErgativity` used by
+    Hindi and Georgian. -/
 def yukatekSplit : Alignment.SplitErgativity StatusCategory :=
   { ergCondition := λ s => match s.viewpointAspect with
       | some .perfective => true


### PR DESCRIPTION
Family-wide register sweep over the remaining 24 Mayan fragment files (Kaqchikel's three landed in #1341/#1343): ASCII banners → `/-! ### -/`, module docstrings restructured to intro + Main declarations + Implementation notes, data-def docstrings reduced to one-liners. Docs-only — code verified byte-identical modulo comments across all 24 files; every [key] citation and location cite preserved.