### PR TITLE
docs(Fragments/Mayan): handbook chapter anchors + Tseltal data fix

### DIFF
--- a/Linglib/Fragments/Mayan/Kaqchikel/Focus.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Focus.lean
@@ -26,9 +26,11 @@ Focus fronting is one of four AF triggers ([erlewine-2016] §2.2); the
 others (wh-questions, relative clauses, argument existentials) differ
 only in the fronted phrase's own marking and are not separately
 encoded. Preverbal subject-initial orders are topicalization, not
-focus (no *ja*, no AF). Whether Kaqchikel has unmarked in-situ
-information focus is outside the source's data, so no
-`EveryFocusPerceptible` claim is made.
+focus (no *ja*, no AF). Across Mayan, information focus stays in situ
+and unmarked except for the transitive subject, which in AF-languages
+must front and trigger AF ([aissen-2017]); Kaqchikel-specific in-situ
+data are not in the sources here, so `focusRealize` covers the fronted
+construction only and no `EveryFocusPerceptible` claim is made.
 -/
 
 namespace Kaqchikel

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -301,8 +301,8 @@ inductive VerbForm where
   deriving DecidableEq, Repr
 
 /-- Whether the form bears Set A agreement (ergative cross-reference).
-    Canonical transitive: yes. AF: no (the agent loses Set A under
-    [coon-mateo-pedro-preminger-2014]'s analysis). -/
+    Canonical transitive: yes; AF forms "are morphologically intransitive
+    and bear only a Set B (absolutive) affix" ([polian-2017] p. 222). -/
 def VerbForm.hasSetA : VerbForm → Bool
   | .transitive => true
   | .agentFocus => false
@@ -334,9 +334,10 @@ abbrev ExponentTable := Agreement.Paradigm String
     proto-Mayan), but not strictly pan-Mayan — SJA Mam's default Set B
     `tz'=` surfaces in the 3sg slot per [scott-2023] §3.3.2, so
     `mayan_p3sg_abs_null` quantifies only over `isStandard = true`. The
-    predicate is notation-agnostic: `"-∅"` (suffixal Set B: Cholan,
-    Q'anjob'alan, Tseltal, Tsotsil), `"∅"` (prefixal Set B: Kaqchikel and
-    other K'ichean HIGH-ABS), and `"∅-"` all encode "no overt 3sg
+    predicate is notation-agnostic: `"-∅"` (suffix-notated Set B: Cholan,
+    Q'anjob'alan, Tseltal, and Tsotsil — whose system also has a prefixal
+    subset, see `Tsotsil.setBLinearity`), `"∅"` (prefixal Set B: Kaqchikel
+    and other K'ichean HIGH-ABS), and `"∅-"` all encode "no overt 3sg
     exponent". The disjunction form is kernel-decidable, unlike a
     `String.replace` normalization. -/
 def ExponentTable.IsThirdSgZero (e : ExponentTable) : Prop :=

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -86,8 +86,8 @@ def setBLinearity : MarkerLinearity := .suffixal
 /-- Set A (ERG/GEN) exponents for Oxchuc Tseltal ([polian-2013]): prefixes
     on the verb or possessed noun, shown as `pre-C/pre-V` allomorph pairs. -/
 def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, "k-/j-"), (.pn .second .Sing, "a-/aw-"), (.pn .third .Sing, "s-/y-"),
-   (.pn .first .Plur, "k-/j-"), (.pn .second .Plur, "a-/aw-"), (.pn .third .Plur, "s-/y-")]
+  [(.pn .first .Sing, "j-/k-"), (.pn .second .Sing, "a-/aw-"), (.pn .third .Sing, "s-/y-"),
+   (.pn .first .Plur, "j-/k-"), (.pn .second .Plur, "a-/aw-"), (.pn .third .Plur, "s-/y-")]
 
 /-- Set B (ABS) exponents for Oxchuc Tseltal ([polian-2013]): suffixes on
     the verb stem; 3rd person singular is null (`-∅`). -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19938,6 +19938,36 @@
   validated = {true},
   sources   = {Fragments/Mayan/Params.lean;Fragments/Mayan/Chol/Agreement.lean;Fragments/Mayan/Qanjobal/Agreement.lean}
 }% REF: Zavala Maldonado, R. (2017). Alignment patterns. In Aissen et al. (eds.) The Mayan Languages, pp. 226-258.
+@incollection{polian-2017,
+  author    = {Polian, Gilles},
+  year      = {2017},
+  title     = {Morphology},
+  editor    = {Aissen, Judith and England, Nora C. and Zavala Maldonado, Roberto},
+  booktitle = {The {M}ayan Languages},
+  publisher = {Routledge},
+  address   = {New York},
+  series    = {Routledge Language Family Series},
+  pages     = {201--225},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Mayan/Params.lean}
+}% REF: Polian, G. (2017). Morphology. In Aissen et al. (eds.) The Mayan Languages, pp. 201-225.
+@incollection{aissen-2017,
+  author    = {Aissen, Judith},
+  year      = {2017},
+  title     = {Information structure in {M}ayan},
+  editor    = {Aissen, Judith and England, Nora C. and Zavala Maldonado, Roberto},
+  booktitle = {The {M}ayan Languages},
+  publisher = {Routledge},
+  address   = {New York},
+  series    = {Routledge Language Family Series},
+  pages     = {293--324},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Mayan/Kaqchikel/Focus.lean}
+}% REF: Aissen, J. (2017). Information structure in Mayan. In Aissen et al. (eds.) The Mayan Languages, pp. 293-324.
 % REF: Coon, J., Mateo Pedro, P. & Preminger, O. (2014). The role of Case in A-bar extraction asymmetries.
 @article{coon-mateo-pedro-preminger-2014,
   author    = {Coon, Jessica and Mateo Pedro, Pedro and Preminger, Omer},


### PR DESCRIPTION
Read-then-cite pass over The Mayan Languages (Aissen/England/Zavala 2017), chapters 8, 11, 22 — deliberately light-touch (one key per file, replacing weaker cites where redundant).

- New verified bib entries `polian-2017` (Morphology, 201–225) and `aissen-2017` (Information structure in Mayan, 293–324).
- `Mayan.VerbForm.hasSetA` now cites Polian's family-consensus characterization (AF forms bear only Set B) instead of one analysis; Kaqchikel/Focus's in-situ caveat sharpened to the family generalization (in-situ information focus unmarked except transitive subjects in AF-languages).
- Two data corrections from the ch 22 read: Tseltal 1sg/1pl Set A allomorph order was inverted (Polian Table 22.6: *j-* preconsonantal, *k-* prevocalic); Params' notation note no longer implies Tsotsil Set B is suffixal-only (its system has both subsets — `Tsotsil.setBLinearity = .either` confirmed, closing the deferred linearity question).