### PR TITLE
refactor(Fragments/Mayan): rename MayanLang to Mayan; verb templates

### DIFF
--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -202,7 +202,7 @@ def setBExponent : ExponentTable :=
     Mayan branches (Cholan, Q'anjob'alan, Tseltalan, K'ichean) per
     [kaufman-norman-1984] Table 8 reconstruction. **Not** universally
     pan-Mayan: Mam's default Set B `tz'=` surfaces in the 3sg slot
-    ([scott-2023]), and `MayanLang.isStandard` excludes Mam from
+    ([scott-2023]), and `Mayan.isStandard` excludes Mam from
     the relevant cross-Mayan theorem (`mayan_p3sg_abs_null`). -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -351,7 +351,7 @@ def setBExponent : ExponentTable :=
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
-    pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
+    pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "∅" := rfl
 
 end Kiche

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -405,4 +405,36 @@ def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Mam,       asp, r => caseMam asp r
   | .Kiche,     asp, r => caseKiche asp r
 
+/-! ### Verb templates -/
+
+/-- A position class in the Mayan verbal complex, in the traditional
+    Mayanist categories (so Set A and Set B stay distinct — a cut
+    `Morphology.MorphCategory` cannot draw). -/
+inductive VerbSlot where
+  | aspect
+  | setB
+  | setA
+  | root
+  | status
+  deriving DecidableEq, Repr
+
+/-- The verbal-complex template, stem-inclusive and left-to-right, in
+    canonical transitive citation form. Per-language morpheme orders as
+    documented in each fragment ([preminger-2014] (12) for the K'ichean
+    shape, [vazquez-alvarez-2011] §3.4 for Chol, [polian-2017] for
+    Tseltalan and the Mam status-suffix loss); Tsotsil's prefixal Set B
+    subset is recorded at `Tsotsil.setBLinearity`. -/
+def template : Mayan → List VerbSlot
+  | .Kaqchikel | .Kiche | .Qanjobal => [.aspect, .setB, .setA, .root, .status]
+  | .Mam => [.aspect, .setB, .setA, .root]
+  | .Chol => [.aspect, .setA, .root, .status, .setB]
+  | .Tseltal | .Tsotsil => [.aspect, .setA, .root, .setB]
+
+/-- The absolutive-position classifier derived from the template: HIGH
+    iff Set B precedes the root. `absPosition_matches_template` in
+    `Studies/CoonMateoPedroPreminger2014.lean` checks it against the
+    fragments' analytical `absPosition` values. -/
+def templateABSPosition (l : Mayan) : ABSPosition :=
+  if .setB ∈ (template l).takeWhile (· ≠ .root) then .high else .low
+
 end Mayan

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -35,8 +35,8 @@ syntactic ergativity while LOW-ABS languages do not.
 * `Mayan.ExponentTable`, `Mayan.ExponentTable.IsThirdSgZero`: agreement
   paradigms over φ-cells and the null-3sg predicate.
 * `Mayan.MarkerLinearity`: prefixal / suffixal / either marker linearity.
-* `Mayan.MayanLang`, `Mayan.MayanLang.isStandard`, `Mayan.caseAt`: the
-  language registry and the case-assignment dispatcher.
+* `Mayan`, `Mayan.isStandard`, `Mayan.caseAt`: the language registry
+  and the case-assignment dispatcher.
 
 ## Implementation notes
 
@@ -47,6 +47,14 @@ assign accusative, with "absolutive" a cover term either way
 ([legate-2008]). Both types assign ergative uniformly (via transitive
 v⁰) and nominative to intransitive subjects (via Infl⁰).
 -/
+
+/-- The Mayan languages with consolidated Fragment files. Yukatek has
+    substrate work pending and is not yet in the registry; it'll be
+    added once `caseYukatek` and the consolidated Agreement.lean shape
+    are in place. -/
+inductive Mayan where
+  | Chol | Qanjobal | Kaqchikel | Tseltal | Tsotsil | Mam | Kiche
+  deriving DecidableEq, Repr
 
 namespace Mayan
 
@@ -365,17 +373,9 @@ inductive MarkerLinearity where
 
 /-! ### Language registry and case dispatcher -/
 
-/-- The Mayan languages with consolidated Fragment files. Yukatek has
-    substrate work pending and is not yet in the registry; it'll be
-    added once `caseYukatek` and the consolidated Agreement.lean shape
-    are in place. -/
-inductive MayanLang where
-  | Chol | Qanjobal | Kaqchikel | Tseltal | Tsotsil | Mam | Kiche
-  deriving DecidableEq, Repr
-
 /-- All registered Mayan languages, useful for cross-Mayan typology
-    theorems quantified by `∀ lang ∈ MayanLang.all`. -/
-def MayanLang.all : List MayanLang :=
+    theorems quantified by `∀ lang ∈ Mayan.all`. -/
+def all : List Mayan :=
   [.Chol, .Qanjobal, .Kaqchikel, .Tseltal, .Tsotsil, .Mam, .Kiche]
 
 /-- The Mayan languages with the standard ergative-absolutive base
@@ -388,15 +388,15 @@ def MayanLang.all : List MayanLang :=
     ergative-with-neutral-objects is contested (cf. England 1983b vs Scott
     2023; Zavala 2017 §4 calls Ch'orti' the only tripartite Mayan); the
     substrate adopts Scott's analysis, recorded in `Mam/Agreement.lean`. -/
-def MayanLang.isStandard : MayanLang → Bool
+def isStandard : Mayan → Bool
   | .Mam => false
   | _    => true
 
 /-- Aspect-driven case assignment dispatched by language. Routes to the
     existing per-branch `case*` substrate functions; the dispatcher is
     the consolidation point that lets cross-Mayan theorems quantify
-    over `MayanLang` rather than enumerate per-language `rfl` facts. -/
-def caseAt : MayanLang → UD.Aspect → Features.Prominence.ArgumentRole → Case
+    over `Mayan` rather than enumerate per-language `rfl` facts. -/
+def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Chol,      asp, r => caseChol asp r
   | .Qanjobal,  asp, r => caseQanjobalan asp r
   | .Kaqchikel, asp, r => caseKaqchikel asp r

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -97,7 +97,7 @@ def setBExponent : ExponentTable :=
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
-    pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
+    pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-- Tseltal Set B differs from Tsotsil in linearity (suffixal vs

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -98,7 +98,7 @@ def setBExponent : ExponentTable :=
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
-    pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
+    pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-! ### Extraction marking -/

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -58,7 +58,7 @@ supporting its role as a case-assigner.
 namespace CoonMateoPedroPreminger2014
 
 open Minimalist Minimalist.Voice
-open Mayan (ABSPosition CaseLocus toCaseLocus MayanLang)
+open Mayan (ABSPosition CaseLocus toCaseLocus)
 
 -- § 1 uses `CaseLocus` and `toCaseLocus` from `Mayan.Params`.
 
@@ -359,7 +359,7 @@ theorem fragments_ground_tada :
 /-- Absolutive structural position (HIGH-ABS / LOW-ABS) indexed by Mayan
     language, routed to the per-language Fragment value. The substantive
     parameter for Tada's Generalization. -/
-def absPositionOf : MayanLang → ABSPosition
+def absPositionOf : Mayan → ABSPosition
   | .Chol      => Chol.absPosition
   | .Qanjobal  => Qanjobal.absPosition
   | .Kaqchikel => Kaqchikel.absPosition
@@ -370,13 +370,13 @@ def absPositionOf : MayanLang → ABSPosition
 
 /-- **Tada's Generalization, parameterized form**: a Mayan language
     exhibits syntactic ergativity (the analytical predicate from §4)
-    **iff** it is HIGH-ABS. Quantified over `Mayan.MayanLang`
+    **iff** it is HIGH-ABS. Quantified over `Mayan`
     via the Fragment-routed `absPositionOf` dispatcher.
 
     Replaces the per-language enumeration in `fragments_ground_tada`
-    with a single quantified theorem that scales as the `MayanLang`
+    with a single quantified theorem that scales as the `Mayan`
     registry grows. -/
-theorem mayan_tada (lang : MayanLang) :
+theorem mayan_tada (lang : Mayan) :
     hasSyntacticErgativity (toCaseLocus (absPositionOf lang)) = true ↔
       absPositionOf lang = ABSPosition.high := by
   cases lang <;> decide
@@ -608,12 +608,12 @@ theorem attested_cells :
     base assigns case canonically ergatively (A → ERG, S/P → ABS) in the
     perfective. The `isStandard` hypothesis scopes around San Juan Atitán
     Mam, whose perfective is morphologically tripartite (see
-    `Mayan.MayanLang.isStandard` and `Studies/Scott2023.lean`). -/
+    `Mayan.isStandard` and `Studies/Scott2023.lean`). -/
 theorem mayan_perfective_ergative
-    (lang : MayanLang) (h : lang.isStandard = true)
+    (lang : Mayan) (h : lang.isStandard = true)
     (r : Features.Prominence.ArgumentRole) :
     Mayan.caseAt lang .Perf r = Alignment.ergative.assignCase r := by
-  cases lang <;> first | rfl | (simp [Mayan.MayanLang.isStandard] at h)
+  cases lang <;> first | rfl | (simp [Mayan.isStandard] at h)
 
 -- ============================================================================
 -- § 12: Person-Conditioned AF (bridge)

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -381,6 +381,14 @@ theorem mayan_tada (lang : Mayan) :
       absPositionOf lang = ABSPosition.high := by
   cases lang <;> decide
 
+/-- The analytical high/low-ABS classification matches the morphological
+    verb template: a language is HIGH-ABS iff Set B precedes the root in
+    `Mayan.template` — the observable ground of the absolutive
+    parameter. -/
+theorem absPosition_matches_template (lang : Mayan) :
+    absPositionOf lang = Mayan.templateABSPosition lang := by
+  cases lang <;> rfl
+
 /-- Q'anjob'al's extraction data is consistent with the prediction:
     agent extraction is marked (requires AF morphology in regular
     transitives). The substantive claim lives at `extractionProfile`'s


### PR DESCRIPTION
Two pieces of the Mayan Fragment API ledger:

- `Mayan.MayanLang` → `Mayan` (top-level inductive, existing namespace becomes the type's namespace — the `List`/`Nat` idiom): `l : Mayan`, `l.isStandard`, `Mayan.all`, `caseAt : Mayan → …`.
- B1b: `Mayan.VerbSlot` + `Mayan.template` give each language its verbal-complex slot order once (canonical transitive citation form, sourced from the fragments' documented morpheme orders), and `templateABSPosition` derives high/low-ABS from whether Set B precedes the root. `CMP2014.absPosition_matches_template` checks the derived classifier against the fragments' analytical `absPosition` values — the absolutive parameter now has its observable morphological ground. The lossy `AffixTemplate` projection is deliberately deferred (no consumer; either controller choice for Set B would encode a falsehood).

K3 (Chol classifier merge) retracted: `{Lang}/ClassifierSystem.lean` is a cross-language convention (Armenian/Italian/Shan), not a Chol wart.