### PR TITLE
refactor(Fragments/Mayan): Mayan registry, verb templates, Yukatek

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1075,6 +1075,7 @@ import Linglib.Fragments.Mayan.Tseltal.Possession
 import Linglib.Fragments.Mayan.Tseltalan
 import Linglib.Fragments.Mayan.Tsotsil.Agreement
 import Linglib.Fragments.Mayan.Tsotsil.Possession
+import Linglib.Fragments.Mayan.Yukatek.Agreement
 import Linglib.Fragments.Mayan.Yukatek.Operators
 import Linglib.Fragments.Mayan.Yukatek.Roots
 import Linglib.Fragments.Mayan.Yukatek.VerbClasses

--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -202,7 +202,7 @@ def setBExponent : ExponentTable :=
     Mayan branches (Cholan, Q'anjob'alan, Tseltalan, K'ichean) per
     [kaufman-norman-1984] Table 8 reconstruction. **Not** universally
     pan-Mayan: Mam's default Set B `tz'=` surfaces in the 3sg slot
-    ([scott-2023]), and `MayanLang.isStandard` excludes Mam from
+    ([scott-2023]), and `Mayan.isStandard` excludes Mam from
     the relevant cross-Mayan theorem (`mayan_p3sg_abs_null`). -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -351,7 +351,7 @@ def setBExponent : ExponentTable :=
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
-    pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
+    pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "∅" := rfl
 
 end Kiche

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -406,4 +406,36 @@ def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Mam,       asp, r => caseMam asp r
   | .Kiche,     asp, r => caseKiche asp r
 
+/-! ### Verb templates -/
+
+/-- A position class in the Mayan verbal complex, in the traditional
+    Mayanist categories (so Set A and Set B stay distinct — a cut
+    `Morphology.MorphCategory` cannot draw). -/
+inductive VerbSlot where
+  | aspect
+  | setB
+  | setA
+  | root
+  | status
+  deriving DecidableEq, Repr
+
+/-- The verbal-complex template, stem-inclusive and left-to-right, in
+    canonical transitive citation form. Per-language morpheme orders as
+    documented in each fragment ([preminger-2014] (12) for the K'ichean
+    shape, [vazquez-alvarez-2011] §3.4 for Chol, [polian-2017] for
+    Tseltalan and the Mam status-suffix loss); Tsotsil's prefixal Set B
+    subset is recorded at `Tsotsil.setBLinearity`. -/
+def template : Mayan → List VerbSlot
+  | .Kaqchikel | .Kiche | .Qanjobal => [.aspect, .setB, .setA, .root, .status]
+  | .Mam => [.aspect, .setB, .setA, .root]
+  | .Chol => [.aspect, .setA, .root, .status, .setB]
+  | .Tseltal | .Tsotsil => [.aspect, .setA, .root, .setB]
+
+/-- The absolutive-position classifier derived from the template: HIGH
+    iff Set B precedes the root. `absPosition_matches_template` in
+    `Studies/CoonMateoPedroPreminger2014.lean` checks it against the
+    fragments' analytical `absPosition` values. -/
+def templateABSPosition (l : Mayan) : ABSPosition :=
+  if .setB ∈ (template l).takeWhile (· ≠ .root) then .high else .low
+
 end Mayan

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -35,8 +35,8 @@ syntactic ergativity while LOW-ABS languages do not.
 * `Mayan.ExponentTable`, `Mayan.ExponentTable.IsThirdSgZero`: agreement
   paradigms over φ-cells and the null-3sg predicate.
 * `Mayan.MarkerLinearity`: prefixal / suffixal / either marker linearity.
-* `Mayan.MayanLang`, `Mayan.MayanLang.isStandard`, `Mayan.caseAt`: the
-  language registry and the case-assignment dispatcher.
+* `Mayan`, `Mayan.isStandard`, `Mayan.caseAt`: the language registry
+  and the case-assignment dispatcher.
 
 ## Implementation notes
 
@@ -47,6 +47,14 @@ assign accusative, with "absolutive" a cover term either way
 ([legate-2008]). Both types assign ergative uniformly (via transitive
 v⁰) and nominative to intransitive subjects (via Infl⁰).
 -/
+
+/-- The Mayan languages with consolidated Fragment files. Yukatek has
+    substrate work pending and is not yet in the registry; it'll be
+    added once `caseYukatek` and the consolidated Agreement.lean shape
+    are in place. -/
+inductive Mayan where
+  | Chol | Qanjobal | Kaqchikel | Tseltal | Tsotsil | Mam | Kiche
+  deriving DecidableEq, Repr
 
 namespace Mayan
 
@@ -366,17 +374,9 @@ inductive MarkerLinearity where
 
 /-! ### Language registry and case dispatcher -/
 
-/-- The Mayan languages with consolidated Fragment files. Yukatek has
-    substrate work pending and is not yet in the registry; it'll be
-    added once `caseYukatek` and the consolidated Agreement.lean shape
-    are in place. -/
-inductive MayanLang where
-  | Chol | Qanjobal | Kaqchikel | Tseltal | Tsotsil | Mam | Kiche
-  deriving DecidableEq, Repr
-
 /-- All registered Mayan languages, useful for cross-Mayan typology
-    theorems quantified by `∀ lang ∈ MayanLang.all`. -/
-def MayanLang.all : List MayanLang :=
+    theorems quantified by `∀ lang ∈ Mayan.all`. -/
+def all : List Mayan :=
   [.Chol, .Qanjobal, .Kaqchikel, .Tseltal, .Tsotsil, .Mam, .Kiche]
 
 /-- The Mayan languages with the standard ergative-absolutive base
@@ -389,15 +389,15 @@ def MayanLang.all : List MayanLang :=
     ergative-with-neutral-objects is contested (cf. England 1983b vs Scott
     2023; Zavala 2017 §4 calls Ch'orti' the only tripartite Mayan); the
     substrate adopts Scott's analysis, recorded in `Mam/Agreement.lean`. -/
-def MayanLang.isStandard : MayanLang → Bool
+def isStandard : Mayan → Bool
   | .Mam => false
   | _    => true
 
 /-- Aspect-driven case assignment dispatched by language. Routes to the
     existing per-branch `case*` substrate functions; the dispatcher is
     the consolidation point that lets cross-Mayan theorems quantify
-    over `MayanLang` rather than enumerate per-language `rfl` facts. -/
-def caseAt : MayanLang → UD.Aspect → Features.Prominence.ArgumentRole → Case
+    over `Mayan` rather than enumerate per-language `rfl` facts. -/
+def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Chol,      asp, r => caseChol asp r
   | .Qanjobal,  asp, r => caseQanjobalan asp r
   | .Kaqchikel, asp, r => caseKaqchikel asp r

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -48,12 +48,9 @@ assign accusative, with "absolutive" a cover term either way
 v⁰) and nominative to intransitive subjects (via Infl⁰).
 -/
 
-/-- The Mayan languages with consolidated Fragment files. Yukatek has
-    substrate work pending and is not yet in the registry; it'll be
-    added once `caseYukatek` and the consolidated Agreement.lean shape
-    are in place. -/
+/-- The Mayan languages with consolidated Fragment files. -/
 inductive Mayan where
-  | Chol | Qanjobal | Kaqchikel | Tseltal | Tsotsil | Mam | Kiche
+  | Chol | Qanjobal | Kaqchikel | Tseltal | Tsotsil | Mam | Kiche | Yukatek
   deriving DecidableEq, Repr
 
 namespace Mayan
@@ -285,6 +282,24 @@ def caseTseltalan : UD.Aspect → Features.Prominence.ArgumentRole → Case
 abbrev ergCaseTseltalan : Features.Prominence.ArgumentRole → Case :=
   caseTseltalan .Perf
 
+/-- Yucatecan aspect/status-driven case assignment ([hofling-2017] p. 692:
+    Set A marks transitive subjects and incompletive intransitive
+    subjects; Set B marks transitive objects and completive intransitive
+    subjects): ergative in the completive (perfective),
+    extended-ergative in the incompletive aspects. -/
+def caseYukatek : UD.Aspect → Features.Prominence.ArgumentRole → Case
+  | .Perf, r => Alignment.ergative.assignCase r
+  | .Imp, r | .Prog, r | .Prosp, r | .Hab, r | .Iter, r =>
+    Alignment.extendedErgative.assignCase r
+
+/-- Yucatec completive ergative-absolutive case. -/
+abbrev ergCaseYukatek : Features.Prominence.ArgumentRole → Case :=
+  caseYukatek .Perf
+
+/-- Yucatec incompletive extended-ergative case. -/
+abbrev accCaseYukatek : Features.Prominence.ArgumentRole → Case :=
+  caseYukatek .Imp
+
 /-! ### Person-number paradigm
 
 The pan-Mayan person/number agreement paradigm is keyed by the canonical
@@ -377,7 +392,7 @@ inductive MarkerLinearity where
 /-- All registered Mayan languages, useful for cross-Mayan typology
     theorems quantified by `∀ lang ∈ Mayan.all`. -/
 def all : List Mayan :=
-  [.Chol, .Qanjobal, .Kaqchikel, .Tseltal, .Tsotsil, .Mam, .Kiche]
+  [.Chol, .Qanjobal, .Kaqchikel, .Tseltal, .Tsotsil, .Mam, .Kiche, .Yukatek]
 
 /-- The Mayan languages with the standard ergative-absolutive base
     (perfective ergative; Set B 3sg null per K&N reconstruction). Mam is
@@ -405,6 +420,7 @@ def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
   | .Tsotsil,   asp, r => caseTseltalan asp r
   | .Mam,       asp, r => caseMam asp r
   | .Kiche,     asp, r => caseKiche asp r
+  | .Yukatek,   asp, r => caseYukatek asp r
 
 /-! ### Verb templates -/
 
@@ -428,7 +444,7 @@ inductive VerbSlot where
 def template : Mayan → List VerbSlot
   | .Kaqchikel | .Kiche | .Qanjobal => [.aspect, .setB, .setA, .root, .status]
   | .Mam => [.aspect, .setB, .setA, .root]
-  | .Chol => [.aspect, .setA, .root, .status, .setB]
+  | .Chol | .Yukatek => [.aspect, .setA, .root, .status, .setB]
   | .Tseltal | .Tsotsil => [.aspect, .setA, .root, .setB]
 
 /-- The absolutive-position classifier derived from the template: HIGH

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -97,7 +97,7 @@ def setBExponent : ExponentTable :=
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
-    pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
+    pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-- Tseltal Set B differs from Tsotsil in linearity (suffixal vs

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -98,7 +98,7 @@ def setBExponent : ExponentTable :=
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
-    pan-Mayan: see Mam exception via `MayanLang.isStandard`. -/
+    pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
 
 /-! ### Extraction marking -/

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -1,0 +1,84 @@
+import Linglib.Features.Case.Basic
+import Linglib.Features.Prominence
+import Linglib.Fragments.Mayan.Params
+
+/-!
+# Yucatec Maya Agreement Fragment
+
+Typological metadata for Yucatec Maya (Yucatecan, Mayan) agreement
+morphology, following [hofling-2017]: paradigm exponents and argument
+positions.
+
+Yucatec person markers divide into Set A prefixes/proclitics and Set B
+suffixes. Set A marks transitive subjects, intransitive subjects in the
+incompletive status, and possessors; Set B marks transitive objects,
+intransitive subjects in the completive and dependent statuses, and
+stative subjects — the Yucatecan status-based split. The verbal complex
+runs aspect–Set A–root–status–Set B (*táan u-muk-ik-en* 's/he is
+burying me', [hofling-2017] Table 24.15): Yucatec is LOW-ABS.
+
+## Main declarations
+
+* `Yukatek.setAExponent`, `Yukatek.setBExponent`: the Set A and Set B
+  exponent tables ([hofling-2017] Tables 24.8, 24.12).
+* `Yukatek.absPosition`: LOW-ABS morpheme placement.
+* `Yukatek.ArgPosition` with `.case`, `.accCase`: argument positions and
+  their completive (ergative) and incompletive (extended-ergative) case.
+
+## Implementation notes
+
+The six-cell tables use the exclusive base for 1PL (*k-* Set A, *-o'on*
+Set B; the inclusives add *-e'ex*) and the table's parenthesized
+prevocalic allomorphs (*inw-*, *aw-*, *uy-*). Plural 2nd/3rd Set A
+combine the singular prefix with *-e'ex* and *-o'ob'*. Set B 3SG is
+written `-∅` per the family convention (`-Ø` in the source). Case wiring
+reuses `Mayan.caseYukatek`; the AF construction (marked by the absence
+of expected morphology, [aissen-2017] rather than a dedicated morpheme)
+is not yet encoded.
+-/
+
+namespace Yukatek
+
+open Mayan (ExponentTable)
+open Agreement
+
+/-! ### ABS position (LOW-ABS) -/
+
+/-- LOW-ABS: the Set B suffixes follow the stem and status suffix. -/
+def absPosition : Mayan.ABSPosition := .low
+
+/-! ### Set A exponents -/
+
+/-- Set A markers ([hofling-2017] Table 24.8). -/
+def setAExponent : ExponentTable :=
+  [(.pn .first .Sing, "in(w)-"), (.pn .second .Sing, "a(w)-"), (.pn .third .Sing, "u(y)-"),
+   (.pn .first .Plur, "k-"), (.pn .second .Plur, "a(w)-...-e'ex"),
+   (.pn .third .Plur, "u(y)-...-o'ob'")]
+
+/-! ### Set B exponents -/
+
+/-- Set B markers; ∅ 3SG ([hofling-2017] Table 24.12). -/
+def setBExponent : ExponentTable :=
+  [(.pn .first .Sing, "-en"), (.pn .second .Sing, "-ech"), (.pn .third .Sing, "-∅"),
+   (.pn .first .Plur, "-o'on"), (.pn .second .Plur, "-e'ex"), (.pn .third .Plur, "-o'ob'")]
+
+/-- 3rd person absolutive is null, as across the standard Mayan
+    branches ([kaufman-norman-1984] Table 8). -/
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
+
+/-! ### Argument positions -/
+
+/-- Argument positions, aliased to the canonical
+    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := Features.Prominence.ArgumentRole
+
+/-- Completive (ergative) case assignment: `Mayan.ergCaseYukatek`
+    (A → ERG, S/P → ABS). -/
+abbrev ArgPosition.case : ArgPosition → Case := Mayan.ergCaseYukatek
+
+/-- Incompletive (extended-ergative) case assignment:
+    `Mayan.accCaseYukatek` (S/A → Set A, P → Set B; [hofling-2017]
+    p. 692). -/
+abbrev ArgPosition.accCase : ArgPosition → Case := Mayan.accCaseYukatek
+
+end Yukatek

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -58,7 +58,7 @@ supporting its role as a case-assigner.
 namespace CoonMateoPedroPreminger2014
 
 open Minimalist Minimalist.Voice
-open Mayan (ABSPosition CaseLocus toCaseLocus MayanLang)
+open Mayan (ABSPosition CaseLocus toCaseLocus)
 
 -- § 1 uses `CaseLocus` and `toCaseLocus` from `Mayan.Params`.
 
@@ -359,7 +359,7 @@ theorem fragments_ground_tada :
 /-- Absolutive structural position (HIGH-ABS / LOW-ABS) indexed by Mayan
     language, routed to the per-language Fragment value. The substantive
     parameter for Tada's Generalization. -/
-def absPositionOf : MayanLang → ABSPosition
+def absPositionOf : Mayan → ABSPosition
   | .Chol      => Chol.absPosition
   | .Qanjobal  => Qanjobal.absPosition
   | .Kaqchikel => Kaqchikel.absPosition
@@ -370,13 +370,13 @@ def absPositionOf : MayanLang → ABSPosition
 
 /-- **Tada's Generalization, parameterized form**: a Mayan language
     exhibits syntactic ergativity (the analytical predicate from §4)
-    **iff** it is HIGH-ABS. Quantified over `Mayan.MayanLang`
+    **iff** it is HIGH-ABS. Quantified over `Mayan`
     via the Fragment-routed `absPositionOf` dispatcher.
 
     Replaces the per-language enumeration in `fragments_ground_tada`
-    with a single quantified theorem that scales as the `MayanLang`
+    with a single quantified theorem that scales as the `Mayan`
     registry grows. -/
-theorem mayan_tada (lang : MayanLang) :
+theorem mayan_tada (lang : Mayan) :
     hasSyntacticErgativity (toCaseLocus (absPositionOf lang)) = true ↔
       absPositionOf lang = ABSPosition.high := by
   cases lang <;> decide
@@ -608,12 +608,12 @@ theorem attested_cells :
     base assigns case canonically ergatively (A → ERG, S/P → ABS) in the
     perfective. The `isStandard` hypothesis scopes around San Juan Atitán
     Mam, whose perfective is morphologically tripartite (see
-    `Mayan.MayanLang.isStandard` and `Studies/Scott2023.lean`). -/
+    `Mayan.isStandard` and `Studies/Scott2023.lean`). -/
 theorem mayan_perfective_ergative
-    (lang : MayanLang) (h : lang.isStandard = true)
+    (lang : Mayan) (h : lang.isStandard = true)
     (r : Features.Prominence.ArgumentRole) :
     Mayan.caseAt lang .Perf r = Alignment.ergative.assignCase r := by
-  cases lang <;> first | rfl | (simp [Mayan.MayanLang.isStandard] at h)
+  cases lang <;> first | rfl | (simp [Mayan.isStandard] at h)
 
 -- ============================================================================
 -- § 12: Person-Conditioned AF (bridge)

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -13,6 +13,7 @@ import Linglib.Fragments.Mayan.Mam.Agreement
 import Linglib.Fragments.Mayan.Mam.Extraction
 import Linglib.Fragments.Mayan.Kiche.Agreement
 import Linglib.Fragments.Mayan.Kiche.Extraction
+import Linglib.Fragments.Mayan.Yukatek.Agreement
 
 /-!
 # Coon, Mateo Pedro & Preminger (2014) [coon-mateo-pedro-preminger-2014]
@@ -367,6 +368,7 @@ def absPositionOf : Mayan → ABSPosition
   | .Tsotsil   => Tsotsil.absPosition
   | .Mam       => Mam.absPosition
   | .Kiche     => Kiche.absPosition
+  | .Yukatek   => Yukatek.absPosition
 
 /-- **Tada's Generalization, parameterized form**: a Mayan language
     exhibits syntactic ergativity (the analytical predicate from §4)

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -381,6 +381,14 @@ theorem mayan_tada (lang : Mayan) :
       absPositionOf lang = ABSPosition.high := by
   cases lang <;> decide
 
+/-- The analytical high/low-ABS classification matches the morphological
+    verb template: a language is HIGH-ABS iff Set B precedes the root in
+    `Mayan.template` — the observable ground of the absolutive
+    parameter. -/
+theorem absPosition_matches_template (lang : Mayan) :
+    absPositionOf lang = Mayan.templateABSPosition lang := by
+  cases lang <;> rfl
+
 /-- Q'anjob'al's extraction data is consistent with the prediction:
     agent extraction is marked (requires AF morphology in regular
     transitives). The substantive claim lives at `extractionProfile`'s

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19968,6 +19968,21 @@
   validated = {true},
   sources   = {Fragments/Mayan/Kaqchikel/Focus.lean}
 }% REF: Aissen, J. (2017). Information structure in Mayan. In Aissen et al. (eds.) The Mayan Languages, pp. 293-324.
+@incollection{hofling-2017,
+  author    = {Hofling, Charles Andrew},
+  year      = {2017},
+  title     = {Comparative {M}aya ({Y}ucatec, {L}acandon, {I}tzaj, and {M}opan {M}aya)},
+  editor    = {Aissen, Judith and England, Nora C. and Zavala Maldonado, Roberto},
+  booktitle = {The {M}ayan Languages},
+  publisher = {Routledge},
+  address   = {New York},
+  series    = {Routledge Language Family Series},
+  pages     = {685--760},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Mayan/Yukatek/Agreement.lean;Fragments/Mayan/Params.lean}
+}% REF: Hofling, C. A. (2017). Comparative Maya. In Aissen et al. (eds.) The Mayan Languages, pp. 685-760.
 % REF: Coon, J., Mateo Pedro, P. & Preminger, O. (2014). The role of Case in A-bar extraction asymmetries.
 @article{coon-mateo-pedro-preminger-2014,
   author    = {Coon, Jessica and Mateo Pedro, Pedro and Preminger, Omer},


### PR DESCRIPTION
Supersedes #1348 (same first two commits, rebased onto current main, plus the Yukatek extension).

- `Mayan.MayanLang` → `Mayan` (top-level inductive; the namespace becomes the type's namespace).
- `Mayan.VerbSlot` + `Mayan.template` (per-language verbal-complex slot order, canonical transitive citation form) with `templateABSPosition` derived; `CMP2014.absPosition_matches_template` grounds the absolutive parameter in morpheme order for every registered language.
- New `Fragments/Mayan/Yukatek/Agreement.lean` from [hofling-2017] (Tables 24.8/24.12/24.15, read from the volume): Set A/B paradigms, LOW-ABS, status-based split via new `Mayan.caseYukatek`; Yukatek joins the `Mayan` registry, so `mayan_tada`, `mayan_perfective_ergative`, and the template correlation now quantify over eight languages. K3 (Chol classifier merge) retracted — `ClassifierSystem.lean` is a cross-language convention.