### PR TITLE
refactor(Studies/Cummins2015): rewrite against book on the OT engine

### DIFF
--- a/Linglib/Semantics/Quantification/Numerals/Precision.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Precision.lean
@@ -82,6 +82,13 @@ def haloWidth (n : Nat) : ℚ :=
 def inferPrecisionMode (n : Nat) : PrecisionMode :=
   if Roundness.roundnessScore n ≥ 2 then .approximate else .exact
 
+/-- Every multiple of 10 is inferred `.approximate`: its roundness score is at
+least 2 (`Roundness.score_ge_two_of_div10`). -/
+theorem inferPrecisionMode_eq_approximate_of_ten_dvd {n : ℕ} (h : 10 ∣ n) :
+    inferPrecisionMode n = .approximate := by
+  unfold inferPrecisionMode
+  exact if_pos (Roundness.score_ge_two_of_div10 n h)
+
 /-- `PrecisionMode` is the two-point instance of the QUD-layer
 `PrecisionProjection` family: `f_e` is `PrecisionProjection.exact`; `f_a`
 at grain `g` rounds within the width-`g` grain (the lower representative

--- a/Linglib/Semantics/Quantification/Numerals/Roundness.lean
+++ b/Linglib/Semantics/Quantification/Numerals/Roundness.lean
@@ -51,6 +51,13 @@ def Has2_5ness (n : ℕ) : Prop :=
 instance (n : ℕ) : Decidable (Has2_5ness n) :=
   inferInstanceAs (Decidable (∃ b < 11, 1 ≤ b ∧ ∃ m < 10, 1 ≤ m ∧ 2 * n = m * 5 * 10 ^ b))
 
+/-- Any k-ness forces divisibility by 10: the witness exponent is at least 1. -/
+theorem HasKness.ten_dvd {n k : ℕ} (h : HasKness n k) : 10 ∣ n := by
+  obtain ⟨b, -, hb, m, -, -, rfl⟩ := h
+  obtain ⟨b', rfl⟩ := Nat.exists_eq_add_of_le hb
+  exact ⟨m * k * 10 ^ b', by simp [Nat.pow_add, Nat.pow_one, Nat.mul_comm,
+    Nat.mul_assoc, Nat.mul_left_comm]⟩
+
 /-! ### Roundness score
 
 The six graded roundness properties of [sigurd-1988] and
@@ -145,6 +152,12 @@ example : contextualRoundnessScore 120 12 = 4 := by decide
 example : roundnessInContext 48 12 = 2 := by decide
 example : roundnessInContext 48 10 = 0 := by decide
 example : roundnessInContext 100 10 = 6 := by decide
+
+/-- The roundness score never exceeds `maxRoundnessScore`: each of the six
+properties contributes at most 1. -/
+theorem roundnessScore_le_max (n : ℕ) : roundnessScore n ≤ maxRoundnessScore := by
+  unfold roundnessScore maxRoundnessScore
+  split_ifs <;> omega
 
 /-- Multiples of 10 have roundness score ≥ 2 (multiple-of-5 and
 multiple-of-10 both hold). The keystone for downstream sorry-free proofs. -/

--- a/Linglib/Studies/BeltramaSchwarz2024.lean
+++ b/Linglib/Studies/BeltramaSchwarz2024.lean
@@ -269,12 +269,11 @@ def impreciseReadingAvailable (n : Nat) : Prop :=
 instance (n : Nat) : Decidable (impreciseReadingAvailable n) :=
   inferInstanceAs (Decidable (inferPrecisionMode n = .approximate))
 
-/-- Any multiple of 10 carries an imprecise reading (general; derived from the
-    roundness keystone). -/
+/-- Any multiple of 10 carries an imprecise reading — the substrate lemma
+    `inferPrecisionMode_eq_approximate_of_ten_dvd` under this file's naming. -/
 theorem div10_enables_imprecision (n : ℕ) (h10 : 10 ∣ n) :
-    impreciseReadingAvailable n := by
-  unfold impreciseReadingAvailable inferPrecisionMode
-  exact if_pos (Semantics.Numerals.Roundness.score_ge_two_of_div10 n h10)
+    impreciseReadingAvailable n :=
+  inferPrecisionMode_eq_approximate_of_ten_dvd h10
 
 /-- Roundness gates the persona effect: the round numeral supports imprecision,
     the displayed value does not. -/

--- a/Linglib/Studies/Cummins2015.lean
+++ b/Linglib/Studies/Cummins2015.lean
@@ -1,329 +1,277 @@
-import Mathlib.Data.Rat.Defs
-import Linglib.Core.Optimization.Pareto
-import Linglib.Core.Order.PullbackPreorder
-import Linglib.Core.Order.Satisfaction
-import Linglib.Semantics.Quantification.Numerals.Roundness
-import Linglib.Fragments.English.NumeralModifiers
+import Linglib.Phonology.OptimalityTheory.Tableau
 import Linglib.Semantics.Quantification.Numerals.Precision
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Data.Nat.Dist
 
 /-!
-# [cummins-2015]: OT Constraints, k-ness, NSAL, and RSA Cost
-[cummins-2015] [kao-etal-2014-hyperbole] [lasersohn-1999] [woodin-etal-2023]
+# [cummins-2015]: OT constraints on numerically quantified expressions
+[cummins-2015] [jansen-pollmann-2001] [prince-smolensky-1993]
 
-Self-contained study of [cummins-2015]: an Optimality-Theoretic
-constraint system for numeral production plus the bridges to graded
-roundness, RSA cost, and the [kao-etal-2014-hyperbole] `PrecisionMode`
-switch.
+[cummins-2015] models the choice of numerically quantified expressions as
+classical Optimality Theory: six violable constraints — informativeness
+(INFO), quantifier simplicity (QSIMP), numeral salience (NSAL), granularity
+(GRAN), numeral priming (NPRI), and quantifier priming (QPRI) — evaluate
+candidate expressions against a context, and each speaker's total ranking
+deterministically selects a winner, so apparent probabilistic variation is
+cross-speaker (and cross-context) ranking variation.
 
-## OT Constraints
+The constraint set runs through the project OT engine: the book's worked
+three-constraint tableaux (INFO, NSAL, NPRI over rival `more than n` bounds,
+with and without a primed numeral) are decide-checked `Tableau.optimal`
+computations, and the book's harmonic-bounding argument — a candidate incurring
+a subset of a rival's violations is preferred under any constraint ranking —
+is proved for arbitrary constraint systems and instantiated in the toy system.
 
-Speakers choose among candidate numeral expressions by trading off four
-constraints:
-
-1. **INFO** (informativeness): prefer smaller admitted set
-2. **Granularity**: match contextual precision level
-3. **QSIMP** (quantifier simplicity): prefer bare numerals
-4. **NSAL** (numeral salience): prefer round/salient numerals
-
-The empirical bridge to the k-ness model is `nsalViolations`: NSAL
-violations equal `maxRoundnessScore - roundnessScore(n)`, so rounder
-numbers incur fewer NSAL violations.
-
-A `ViolationProfile` is `Core.Optimization.Profile Nat 4` (i.e. `Fin 4 → Nat`),
-matching the codebase's standard violation-profile abstraction. Profile
-indices fix the constraint order: 0 = INFO, 1 = Granularity, 2 = QSIMP,
-3 = NSAL.
-
-Two preorders on profiles are exposed, both as `Core.Order.PullbackPreorder`
-instances so they fit the schema established in `Core/Optimization/Pareto.lean`:
-
-| view              | feature                          | feature-space order |
-|-------------------|----------------------------------|---------------------|
-| `paretoPreorder`  | `id : ViolationProfile → ViolationProfile` | pointwise `≤` |
-| `qualPreorder`    | `nonzeroSetOf : … → Finset (Fin 4)` | subset `⊆` |
-
-`paretoPreorder_le_implies_qualPreorder_le` is a one-line application of
-`PullbackPreorder.coarsen_via_monotone` with `nonzeroSetOf` as the
-connecting monotone map. The legacy criterion-based view via
-`SatisfactionOrdering` is preserved as `cumminsOrdering`.
-
-## Downstream Bridges
-
-1. **NSAL as RSA cost** — the OT violation count, normalised to `[0, 1]`,
-   serves as the RSA `cost : U → ℚ` parameter. Round numerals are cheap;
-   non-round are expensive.
-2. **k-ness as `PrecisionMode` threshold** — `roundnessScore ≥ 2` triggers
-   `.approximate` mode, grounding the binary meaning-projection switch
-   (`f_e` vs `f_a`) of [kao-etal-2014-hyperbole] — the projection component
-   only, not that paper's joint goal inference. The pragmatic halo width
-   ([lasersohn-1999], [krifka-2007]) is also wider for round
-   numerals.
-
-The lexical bridge to `English.NumeralModifiers` documents the
-expected interaction between `requiresRound` modifiers and high k-ness
-anchors.
+NSAL follows the book: one violation per missing [jansen-pollmann-2001] k-ness
+type (10-, 5-, 2-, 2.5-ness; max 4). `kTypeCount` uses the substrate predicates,
+whose witness search starts at base exponent 1 rather than
+[jansen-pollmann-2001]'s 0 (`Studies/JansenPollmann2001.lean` records the
+divergence); the book leaves the exact roundness inventory open. The
+substrate's six-property `roundnessScore` decomposes as `kTypeCount` plus the
+two raw divisibility indicators (`roundnessScore_eq_kTypeCount_add`) — the
+properties the book sets aside as non-diagnostic of salience.
 -/
 
 namespace Cummins2015
 
-open Semantics.Numerals.Roundness
-open Core.Optimization (Profile)
-open Core.Order (PullbackPreorder SatisfactionOrdering)
-open Semantics.Numerals.Precision
+open Constraints OptimalityTheory Semantics.Numerals.Roundness
+open Semantics.Numerals.Precision (inferPrecisionMode
+  inferPrecisionMode_eq_approximate_of_ten_dvd)
 
--- ============================================================================
--- § 1: Numeral candidates
--- ============================================================================
+/-! ### NSAL: numeral salience as missing k-ness types -/
 
-/-- Form of the numeral expression. Bare numerals are simplest; modified
-    forms add complexity (and pay a QSIMP cost). -/
-inductive QuantifierForm where
-  | bare        -- "100"
-  | modified    -- "about 100", "approximately 100"
-  | interval    -- "between 90 and 110"
-  deriving Repr, DecidableEq
+/-- Count of [jansen-pollmann-2001] k-ness types (10-, 5-, 2-, 2.5-ness) that
+`n` exhibits (0–4). [cummins-2015] takes an entirely round number to be one
+exhibiting all four. -/
+def kTypeCount (n : ℕ) : ℕ :=
+  (if HasKness n 1 then 1 else 0) + (if HasKness n 5 then 1 else 0) +
+  (if HasKness n 2 then 1 else 0) + (if Has2_5ness n then 1 else 0)
 
-/-- A candidate numeral expression for OT evaluation. -/
-structure NumeralCandidate where
-  numeral : Nat
-  form : QuantifierForm
-  contextGranularity : Nat
-  deriving Repr
+theorem kTypeCount_le_four (n : ℕ) : kTypeCount n ≤ 4 := by
+  unfold kTypeCount; split_ifs <;> omega
 
-/-- Infer granularity from a numeral's trailing zeros: 100 → 2, 110 → 1, 111 → 0. -/
-def inferGranularity (n : ℕ) : ℕ :=
-  if n = 0 then 0
-  else if 1000 ∣ n then 3
-  else if 100 ∣ n then 2
-  else if 10 ∣ n then 1
-  else 0
+/-- NSAL violations ([cummins-2015]'s numeral salience constraint): one per
+missing k-ness type. Entirely round numbers (100, 1000) incur none; numbers
+with no k-ness incur the maximum of four. -/
+def nsalViolations (n : ℕ) : ℕ := 4 - kTypeCount n
 
--- ============================================================================
--- § 2: Per-constraint violation functions
--- ============================================================================
+/-- NSAL violations complement the k-type count. -/
+theorem nsalViolations_add_kTypeCount (n : ℕ) :
+    nsalViolations n + kTypeCount n = 4 := by
+  have := kTypeCount_le_four n
+  unfold nsalViolations; omega
 
-/-- INFO: violations = `|admittedSet| - 1`. Less informative expressions
-    (which admit more values) incur more violations. -/
-def infoViolations (admittedCount : Nat) : Nat :=
-  admittedCount - 1
-
-/-- Granularity: violations = `|contextGranularity − utteranceGranularity|`. -/
-def granularityViolations (contextGranularity uttGranularity : Nat) : Nat :=
-  if contextGranularity ≥ uttGranularity
-  then contextGranularity - uttGranularity
-  else uttGranularity - contextGranularity
-
-/-- QSIMP: bare = 0, modified = 1, interval = 2. -/
-def qsimpViolations : QuantifierForm → Nat
-  | .bare     => 0
-  | .modified => 1
-  | .interval => 2
-
-/-- NSAL: violations = `maxRoundnessScore - roundnessScore(n)`. Maximally
-    round numbers (score 6) → 0; non-round (score 0) → 6. The complement
-    of the graded roundness score, which is the load-bearing connection
-    between the OT account and the k-ness model. -/
-def nsalViolations (n : Nat) : Nat :=
-  maxRoundnessScore - roundnessScore n
-
-/-- NSAL violations are the complement of roundness score. -/
-theorem nsal_is_complement (n : Nat) (h : roundnessScore n ≤ maxRoundnessScore) :
-    nsalViolations n + roundnessScore n = maxRoundnessScore := by
-  unfold nsalViolations maxRoundnessScore at *
-  omega
-
-/-- A rounder numeral always has fewer NSAL violations. -/
-theorem round_beats_nonround_nsal (n₁ n₂ : Nat)
-    (h : roundnessScore n₁ > roundnessScore n₂)
-    (h1 : roundnessScore n₁ ≤ maxRoundnessScore)
-    (h2 : roundnessScore n₂ ≤ maxRoundnessScore) :
-    nsalViolations n₁ < nsalViolations n₂ := by
+/-- Salience comparisons invert k-type comparisons: strictly more k-ness types
+is strictly fewer NSAL violations. -/
+theorem nsalViolations_lt_iff {n₁ n₂ : ℕ} :
+    nsalViolations n₁ < nsalViolations n₂ ↔ kTypeCount n₂ < kTypeCount n₁ := by
+  have h₁ := kTypeCount_le_four n₁
+  have h₂ := kTypeCount_le_four n₂
   unfold nsalViolations
   omega
 
-#guard nsalViolations 100 = 0    -- maximally round → 0 violations
-#guard nsalViolations 1000 = 0   -- maximally round → 0 violations
-#guard nsalViolations 7 = 6      -- non-round → 6 violations
-#guard nsalViolations 50 = 1     -- highly round → 1 violation
-#guard nsalViolations 110 = 4    -- slightly round → 4 violations
+/-- The substrate's six-property roundness score is the k-type count plus the
+two raw divisibility indicators [cummins-2015] sets aside as non-diagnostic. -/
+theorem roundnessScore_eq_kTypeCount_add (n : ℕ) :
+    roundnessScore n =
+      kTypeCount n + ((if 5 ∣ n then 1 else 0) + (if 10 ∣ n then 1 else 0)) := by
+  unfold roundnessScore kTypeCount
+  split_ifs <;> omega
 
--- ============================================================================
--- § 3: ViolationProfile as Profile Nat 4
--- ============================================================================
+example : nsalViolations 100 = 0 := by decide
+example : nsalViolations 1000 = 0 := by decide
+example : nsalViolations 50 = 1 := by decide   -- lacks 2-ness only
+example : nsalViolations 90 = 3 := by decide   -- 10-ness only
+example : nsalViolations 102 = 4 := by decide  -- no k-ness at all
 
-/-- A `ViolationProfile` is a `Profile Nat 4` — a 4-vector of violation
-    counts indexed by `Fin 4`. Index order: 0 = INFO, 1 = Granularity,
-    2 = QSIMP, 3 = NSAL. Reusing `Core.Optimization.Profile` means the
-    abstractions in `Core/Optimization/Pareto.lean` (Pareto preorder,
-    qualitative coarsening, `coarsen_via_monotone`) apply directly without
-    an extra projection layer. -/
-abbrev ViolationProfile : Type := Profile Nat 4
+/-! ### Candidates, contexts, and the six constraints -/
 
-/-- Compute the violation profile for a candidate. Indices: 0 = INFO,
-    1 = Granularity, 2 = QSIMP, 3 = NSAL. -/
-def violationProfile (c : NumeralCandidate) (admittedCount : Nat) : ViolationProfile
-  | 0 => infoViolations admittedCount
-  | 1 => granularityViolations c.contextGranularity (inferGranularity c.numeral)
-  | 2 => qsimpViolations c.form
-  | 3 => nsalViolations c.numeral
+/-- Quantifier form of a candidate numerical expression. -/
+inductive QuantifierForm where
+  | bare | exactly | about | moreThan | atLeast
+  deriving DecidableEq
 
--- ============================================================================
--- § 4: Pareto + qualitative PullbackPreorders
--- ============================================================================
+/-- Degrees of complexity for QSIMP: bare numerals are simplest; each overt
+modifier adds a degree; superlative bounds cost more than comparative ones,
+the experimentally supported asymmetry [cummins-2015] adopts to separate the
+two single-bound families. -/
+def QuantifierForm.complexity : QuantifierForm → ℕ
+  | .bare => 0
+  | .exactly | .about | .moreThan => 1
+  | .atLeast => 2
 
-/-- **Pointwise Pareto preorder on violation profiles** as a `PullbackPreorder`
-    with the identity feature: `v ≤ v'` iff every component of `v` is `≤` the
-    corresponding component of `v'`. The partial-order *backbone* that lex-OT
-    extends; lex breaks ties using the constraint ranking. -/
-def paretoPreorder : PullbackPreorder ViolationProfile ViolationProfile :=
-  PullbackPreorder.ofProj id (fun a a' =>
-    show Decidable (∀ i, a i ≤ a' i) from inferInstance)
+/-- A candidate numerical expression: a quantifier form applied to a numeral. -/
+structure Candidate where
+  form : QuantifierForm
+  numeral : ℕ
+  deriving DecidableEq
 
-/-- **Qualitative coarsening as a `PullbackPreorder`**: feature is the set of
-    violated constraint indices, feature-space order is `Finset.⊆`. The
-    underlying preorder is identical in extension to `cumminsOrdering`'s, but
-    presented as a feature pullback so the same `coarsen_via_monotone` schema
-    applies. -/
-def qualPreorder : PullbackPreorder ViolationProfile (Finset (Fin 4)) :=
-  PullbackPreorder.ofProj
-    Core.Optimization.nonzeroSetOf
-    (fun _ _ => inferInstance)
+/-- Utterance context: the speaker's knowledge (a lower bound on the value
+under discussion, the shape of the book's worked examples), the contextually
+set granularity level, and the primed numeral and quantifier, if any. -/
+structure Context where
+  lowerBound : ℕ
+  granularity : ℕ
+  primedNumeral : Option ℕ := none
+  primedForm : Option QuantifierForm := none
 
-/-- **Pointwise dominance ⇒ qualitative dominance.** A one-line corollary of
-    `PullbackPreorder.coarsen_via_monotone` with the violated-index extractor
-    as the connecting monotone map — identical in shape to
-    `paretoPullbackPreorder_le_implies_supportPullbackPreorder_le` in
-    `Core/Optimization/Pareto.lean`. -/
-theorem paretoPreorder_le_implies_qualPreorder_le
-    {v v' : ViolationProfile} (h : paretoPreorder.le v v') :
-    qualPreorder.le v v' :=
-  PullbackPreorder.coarsen_via_monotone
-    paretoPreorder qualPreorder
-    Core.Optimization.nonzeroSetOf
-    (Core.Optimization.nonzeroSetOf_monotone (fun _ => Nat.zero_le _))
-    (fun _ => rfl) h
+/-- INFO ([cummins-2015]'s informativeness constraint): one violation per value
+the expression admits that the speaker's knowledge `value ≥ ctx.lowerBound`
+already excludes. Bounds admit the known-false values below the speaker's own
+bound; point forms admit only their numeral. -/
+def infoViolations (ctx : Context) : Constraint Candidate := fun c =>
+  match c.form with
+  | .moreThan => ctx.lowerBound - (c.numeral + 1)
+  | .atLeast => ctx.lowerBound - c.numeral
+  | _ => 0
 
--- ============================================================================
--- § 5: Bridge to SatisfactionOrdering (legacy criterion-based view)
--- ============================================================================
+/-- QSIMP: one violation per degree of quantifier complexity. -/
+def qsimpViolations : Constraint Candidate := fun c => c.form.complexity
 
-/-- The four OT constraints as a criterion type. Field order matches
-    `ViolationProfile` indices (info ↔ 0, …, nsal ↔ 3). -/
-inductive NumeralConstraint where
-  | info | granularity | qsimp | nsal
-  deriving Repr, DecidableEq
+/-- NSAL over candidates: `nsalViolations` pulled back along the numeral. -/
+def nsal : Constraint Candidate := Constraint.comap Candidate.numeral nsalViolations
 
-/-- Coarse-grain a violation profile: a constraint is "satisfied" iff it
-    has 0 violations. Bool-valued for `SatisfactionOrdering`. -/
-def constraintSatisfied (v : ViolationProfile) : NumeralConstraint → Bool
-  | .info        => v 0 == 0
-  | .granularity => v 1 == 0
-  | .qsimp       => v 2 == 0
-  | .nsal        => v 3 == 0
+/-- Decimal granularity level of a numeral: the finest base-10 scale on which
+it sits (trailing zeros, capped at the thousands level). The book's granularity
+is scale-relative; on the base-10 scales of the bare-number domain the level is
+the trailing-zero count. -/
+def granularityLevel (n : ℕ) : ℕ :=
+  if n = 0 then 0
+  else if 1000 ∣ n then 3 else if 100 ∣ n then 2 else if 10 ∣ n then 1 else 0
 
-/-- A `SatisfactionOrdering` over violation profiles using the four
-    [cummins-2015] constraints. Coarsens the OT system: a candidate
-    "satisfies" a constraint iff it incurs 0 violations. The resulting
-    ordering is weaker than lex-OT (which discriminates by violation
-    degree) but captures the structural backbone: a candidate that
-    satisfies a strict superset of constraints is always OT-preferred. -/
-def cumminsOrdering : SatisfactionOrdering ViolationProfile NumeralConstraint :=
-  SatisfactionOrdering.ofCriteria constraintSatisfied
-    [.info, .granularity, .qsimp, .nsal]
+/-- GRAN ([cummins-2015]'s granularity constraint): one violation per level of
+mismatch between the contextually set granularity and the level used. -/
+def granViolations (ctx : Context) : Constraint Candidate := fun c =>
+  Nat.dist ctx.granularity (granularityLevel c.numeral)
 
-/-- A candidate with zero violations everywhere is at-least-as-good as any
-    other under the satisfaction ordering. -/
-theorem zero_violations_best (v : ViolationProfile) :
-    cumminsOrdering.le (fun _ => 0) v := by
-  intro p _
-  cases p <;> rfl
+/-- NPRI ([cummins-2015]'s numeral priming constraint): a violation iff a
+numeral is primed in the preceding context and a different one is used.
+Unprimed contexts violate nothing. -/
+def npriViolations (ctx : Context) : Constraint Candidate := fun c =>
+  match ctx.primedNumeral with
+  | none => 0
+  | some p => if c.numeral = p then 0 else 1
 
--- ============================================================================
--- § 1: NSAL violations as a normalised RSA cost
--- ============================================================================
+/-- QPRI ([cummins-2015]'s quantifier priming constraint): a violation iff a
+quantifier is primed in the preceding context and a different one is used. -/
+def qpriViolations (ctx : Context) : Constraint Candidate := fun c =>
+  match ctx.primedForm with
+  | none => 0
+  | some f => if c.form = f then 0 else 1
 
-/-- NSAL violations as a normalised RSA cost ∈ `[0, 1]`. Bridges the OT NSAL
-    constraint to the RSA `cost` parameter: round numerals are "cheap"
-    (≈ 0), non-round are "expensive" (≈ 1). The denominator is
-    `maxRoundnessScore`, so the codomain is exactly `[0, 1]`. -/
-def nsalAsRSACost (n : Nat) : ℚ :=
-  nsalViolations n / maxRoundnessScore
+/-- The six-constraint system, indexed in the book's enumeration order:
+0 = INFO, 1 = QSIMP, 2 = NSAL, 3 = GRAN, 4 = NPRI, 5 = QPRI. -/
+def con (ctx : Context) : CON Candidate 6 :=
+  ![infoViolations ctx, qsimpViolations, nsal,
+    granViolations ctx, npriViolations ctx, qpriViolations ctx]
 
-/-- Maximally round numerals are free (zero cost). Reduces to the
-    `Nat`-level fact `nsalViolations 100 = 0` (closed by `decide`) plus
-    `0 / x = 0` over ℚ. -/
-theorem maximally_round_free :
-    nsalAsRSACost 100 = 0 ∧ nsalAsRSACost 1000 = 0 := by
-  unfold nsalAsRSACost
-  have h100 : nsalViolations 100 = 0 := by decide
-  have h1000 : nsalViolations 1000 = 0 := by decide
-  refine ⟨?_, ?_⟩
-  · rw [h100]; simp
-  · rw [h1000]; simp
+/-- The book's count of possible idiolects: six constraints admit 720 total
+rankings. -/
+theorem card_rankings : Fintype.card (Ranking 6) = 720 := by
+  rw [Fintype.card_perm, Fintype.card_fin]; rfl
 
-/-- Round numerals incur strictly lower RSA cost than non-round ones.
-    `Nat`-level reduction of `nsalViolations` followed by `norm_num` over ℚ. -/
-theorem round_cheaper_in_rsa :
-    nsalAsRSACost 100 < nsalAsRSACost 99 := by
-  unfold nsalAsRSACost maxRoundnessScore
-  have h100 : nsalViolations 100 = 0 := by decide
-  have h99 : nsalViolations 99 = 6 := by decide
-  rw [h100, h99]
-  norm_num
+/-! ### The worked tableaux
 
--- ============================================================================
--- § 2: k-ness grounds Kao et al.'s `PrecisionMode`
--- ============================================================================
+The book's toy system: INFO, NSAL, and NPRI adjudicate between rival `more
+than n` bounds for a speaker who knows `value ≥ 103` (representative
+numerals; the shape follows the book's example, where the informative bound's
+numeral incurs the maximum four NSAL violations). `more than 102` is maximally
+informative but non-salient; `more than 100` is salient but under-informative.
+Unprimed, INFO-top speakers pick the former and NSAL-top speakers the latter;
+priming 102 leaves only NSAL-top speakers on the round bound. Each ranking
+selects a singleton — the book's deterministic-output point — and the factorial
+typology has exactly the two idiolect types. -/
 
-/-! `inferPrecisionMode` (in `Numerals.Precision`) is defined by
-`roundnessScore n ≥ 2 → .approximate`. This subsection records the
-grounding theorems for representative numerals plus the general bridge
-that *every* multiple of 10 falls in `.approximate` mode. -/
+/-- The `more than n` candidate. -/
+def mt (n : ℕ) : Candidate := ⟨.moreThan, n⟩
 
-/-- 100 is round (score 6) → `.approximate` mode. -/
-theorem precision_100_approximate :
-    inferPrecisionMode 100 = .approximate := by decide
+/-- Unprimed context: the speaker knows `value ≥ 103`; hundreds granularity. -/
+def unprimed : Context := { lowerBound := 103, granularity := 2 }
 
-/-- 7 is non-round (score 0) → `.exact` mode. -/
-theorem precision_7_exact :
-    inferPrecisionMode 7 = .exact := by decide
+/-- The same context with `102` primed in the preceding turn. -/
+def primed : Context := { unprimed with primedNumeral := some 102 }
 
-/-- **General bridge.** Every multiple of 10 is interpreted in
-    `.approximate` mode. Follows from `score_ge_two_of_div10`: the score is
-    at least 2, so the `roundnessScore n ≥ 2` branch of `inferPrecisionMode`
-    fires. -/
-theorem multipleOf10_implies_approximate (n : ℕ) (hr : 10 ∣ n) :
-    inferPrecisionMode n = .approximate := by
-  unfold inferPrecisionMode
-  have hs := Semantics.Numerals.Roundness.score_ge_two_of_div10 n hr
-  split
-  · rfl
-  · omega
+theorem unprimed_optimal_of_info_top :
+    (Tableau.ofRanking [mt 100, mt 102]
+      [infoViolations unprimed, nsal, npriViolations unprimed]).optimal
+      = {mt 102} := by decide
 
--- ============================================================================
--- § 3: Wider halo for round numerals
--- ============================================================================
+theorem unprimed_optimal_of_nsal_top :
+    (Tableau.ofRanking [mt 100, mt 102]
+      [nsal, infoViolations unprimed, npriViolations unprimed]).optimal
+      = {mt 100} := by decide
 
-/-- Pragmatic halo width is strictly wider for round numerals (100) than
-    for non-round (7) — the quantitative content of [lasersohn-1999]'s
-    halo intuition under the k-ness operationalisation. -/
-theorem round_wider_halo :
-    haloWidth 100 > haloWidth 7 := by
-  unfold haloWidth
-  have h100 : Semantics.Numerals.Roundness.roundnessScore 100 = 6 := by decide
-  have h7 : Semantics.Numerals.Roundness.roundnessScore 7 = 0 := by decide
-  rw [h100, h7]
-  norm_num
+theorem primed_optimal_of_nsal_top :
+    (Tableau.ofRanking [mt 100, mt 102]
+      [nsal, npriViolations primed, infoViolations primed]).optimal
+      = {mt 100} := by decide
 
--- ============================================================================
--- § 4: Fragment bridge — tolerance modifiers do not formally require roundness
--- ============================================================================
+theorem primed_optimal_of_npri_over_nsal :
+    (Tableau.ofRanking [mt 100, mt 102]
+      [npriViolations primed, nsal, infoViolations primed]).optimal
+      = {mt 102} := by decide
 
-/-- The lexical entry for "approximately" carries `requiresRound = false`.
-    [cummins-2015] predicts that combinations with low-k anchors are
-    *grammatical but marked* — naturalness correlates with k-ness rather than
-    being a hard constraint. -/
-theorem approximately_tolerates_nonround :
-    English.NumeralModifiers.approximately.requiresRound = false := rfl
+/-- Both candidates surface across the six rankings — the book's point that a
+deterministic OT system yields apparent variability via ranking variation. -/
+theorem toy_factorialTypologySize :
+    factorialTypologySize [mt 100, mt 102]
+      [infoViolations unprimed, nsal, npriViolations unprimed] = 2 := by decide
+
+/-! ### Harmonic bounding -/
+
+/-- Pointwise violation dominance survives every ranking ([cummins-2015]'s
+harmonic-bounding argument, one half): reordering coordinates preserves
+pointwise `≤`, and pointwise `≤` entails lexicographic `≤`. -/
+theorem profile_le_of_pointwise_le {C : Type*} {n : ℕ} (con : CON C n)
+    (r : Ranking n) {c d : C} (h : ∀ i, con i c ≤ con i d) :
+    buildViolationProfile (fun p => con (r p)) c
+      ≤ buildViolationProfile (fun p => con (r p)) d :=
+  Pi.toLex_monotone fun p => h (r p)
+
+/-- A strictly harmonically bounded candidate — one incurring at least a
+rival's violations everywhere and strictly more somewhere — is optimal under
+no ranking whenever its bounder competes ([cummins-2015]: "preferred under any
+constraint ranking"). -/
+theorem not_mem_optimal_of_strictBounded {C : Type*} [DecidableEq C] {n : ℕ}
+    {con : CON C n} {r : Ranking n} {cands : List C} {hne : cands ≠ []}
+    {c d : C} (hc : c ∈ cands) (hle : ∀ i, con i c ≤ con i d)
+    (hlt : ∃ i, con i c < con i d) :
+    d ∉ (Tableau.ofPerm con r cands hne).optimal := by
+  intro hd
+  have hne' : (fun p => con (r p) c) ≠ (fun p => con (r p) d) := by
+    obtain ⟨j, hj⟩ := hlt
+    intro heq
+    have := congrFun heq (r.symm j)
+    rw [Equiv.apply_symm_apply] at this
+    exact absurd this hj.ne
+  exact absurd (Tableau.le_of_mem_optimal hd (List.mem_toFinset.mpr hc))
+    (not_le.mpr (Pi.toLex_strictMono
+      (lt_of_le_of_ne (fun p => hle (r p)) hne')))
+
+/-- Instance in the full six-constraint system: `more than 100` harmonically
+bounds `more than 90` in the unprimed context (weakly better on all six
+constraints, strictly on INFO, NSAL, and GRAN), so `more than 90` wins under
+none of the 720 rankings. -/
+theorem moreThan90_never_optimal (r : Ranking 6) :
+    mt 90 ∉ (Tableau.ofPerm (con unprimed) r [mt 90, mt 100, mt 102]).optimal :=
+  not_mem_optimal_of_strictBounded (c := mt 100) (by decide) (by decide)
+    (by decide)
+
+/-! ### Round numerals and approximate construal -/
+
+/-- Fully salient numerals admit the approximate construal: zero NSAL
+violations force 10-ness, hence divisibility by 10, which the precision
+substrate maps to `.approximate` — the association between round numbers and
+approximate readings that [cummins-2015] inherits from the imprecision
+literature. -/
+theorem inferPrecisionMode_eq_approximate_of_nsalViolations_eq_zero {n : ℕ}
+    (h : nsalViolations n = 0) : inferPrecisionMode n = .approximate := by
+  have h10 : HasKness n 1 := by
+    by_contra hk
+    unfold nsalViolations kTypeCount at h
+    rw [if_neg hk] at h
+    split_ifs at h
+  exact inferPrecisionMode_eq_approximate_of_ten_dvd h10.ten_dvd
 
 end Cummins2015


### PR DESCRIPTION
Deep audit of this 2026-04-18-era file against the book, then a from-scratch rewrite: the constraint system now runs through `OptimalityTheory.Tableau` (the book's toy tableaux as decide-checked winner sets, harmonic bounding proved for all rankings, all six constraints including priming rather than four), NSAL follows the book's four Jansen & Pollmann k-ness types, and the dangling RSA-cost and fragment bridges are cut.

- promotes `roundnessScore_le_max` + `HasKness.ten_dvd` to Roundness and `inferPrecisionMode_eq_approximate_of_ten_dvd` to Precision; `BeltramaSchwarz2024` now delegates to the promoted lemma instead of re-deriving it