### PR TITLE
feat(Core/Logic/Bilattice): negation mixin and Avron Prop 4.7

### DIFF
--- a/Linglib/Core/Logic/Bilattice/Interlaced.lean
+++ b/Linglib/Core/Logic/Bilattice/Interlaced.lean
@@ -43,11 +43,18 @@ product of two lattices is interlaced — is `Core.Logic.Bilattice.Product`.
 * `Bilattice.decompose` — Thm 4.3: `Know B ≃o Iic t × Iic f`
 * `Bilattice.le_iff_kInf_top_kInf_bot` — Thm 4.3, truth side: `x ≤ y` iff the
   `t`-components grow and the `f`-components shrink in the knowledge order
+* `Bilattice.Negation` — negation mixin ([avron-1996] Def 2.3), with the
+  derived bounds/De Morgan/knowledge-homomorphism equations
+* `Bilattice.negIicIso`, `neg_kInf_top` — Prop 4.7: with a negation the two
+  ideals are isomorphic (`λ x, ∼x : L_B ≃o R_B`) and the decomposition is a
+  diagonal product
 
 ## TODO
 
-The negation transport `λ x, ∼x : L_B ≅ R_B` ([avron-1996] Prop 4.7) and the
-uniqueness of the factors up to isomorphism (ibid. Thm 4.3).
+Package [avron-1996] Prop 4.7's full equivalence `⟨B, ∼⟩ ≅ L_B ⊙ L_B` (its two
+proof steps are `negIicIso` and `neg_kInf_top`); abstract uniqueness of the
+factors up to isomorphism (ibid. Thm 4.3; the concrete half for products is
+`Bilattice.Product.decomposeProdIso`).
 -/
 
 universe u
@@ -153,6 +160,110 @@ class Interlaced (B : Type u) [Lattice B] [Lattice (Know B)] : Prop where
   kInf_tmono : ∀ {x y : B}, x ≤ y → ∀ z, (x ⊗ z) ≤ (y ⊗ z)
   /-- knowledge join `⊕` is `≤_t`-monotone -/
   kSup_tmono : ∀ {x y : B}, x ≤ y → ∀ z, (x ⊕ z) ≤ (y ⊕ z)
+
+/-! ### Negation
+
+A **negation** on a bilattice ([avron-1996] Def 2.3) is an involution reversing
+the truth order and preserving the knowledge order. The note following Def 2.3
+derives the equations used below: negation exchanges the truth bounds
+(`∼t = f`), anti-commutes with the truth lattice operations (De Morgan), and is
+an automorphism of the knowledge lattice. -/
+
+section Negation
+
+section Defs
+
+variable [Preorder B] [Preorder (Know B)]
+
+/-- A **negation** ([avron-1996] Def 2.3): an involution (i) that reverses the
+truth order (ii) and preserves the knowledge order (iii). -/
+class Negation (B : Type u) [Preorder B] [Preorder (Know B)] : Type u where
+  /-- The negation operation `∼`. -/
+  neg : B → B
+  /-- Negation is an involution ([avron-1996] Def 2.3(i)). -/
+  neg_neg : ∀ a : B, neg (neg a) = a
+  /-- Negation reverses the truth order ([avron-1996] Def 2.3(ii)). -/
+  neg_le_neg : ∀ {a b : B}, a ≤ b → neg b ≤ neg a
+  /-- Negation preserves the knowledge order ([avron-1996] Def 2.3(iii)). -/
+  neg_kLE_neg : ∀ {a b : B}, a ≤ₖ b → neg a ≤ₖ neg b
+
+export Negation (neg neg_neg neg_le_neg neg_kLE_neg)
+
+attribute [simp] Negation.neg_neg
+
+variable [Negation B]
+
+theorem neg_le_neg_iff {a b : B} : neg b ≤ neg a ↔ a ≤ b :=
+  ⟨fun h => by simpa only [neg_neg] using neg_le_neg h, neg_le_neg⟩
+
+theorem neg_kLE_neg_iff {a b : B} : neg a ≤ₖ neg b ↔ a ≤ₖ b :=
+  ⟨fun h => by simpa only [neg_neg] using neg_kLE_neg h, neg_kLE_neg⟩
+
+/-- Negation as an antitone automorphism of the truth order, `B ≃o Bᵒᵈ`. -/
+def Negation.dualIso : B ≃o Bᵒᵈ where
+  toFun a := OrderDual.toDual (neg a)
+  invFun a := neg (OrderDual.ofDual a)
+  left_inv := neg_neg
+  right_inv _ := congrArg OrderDual.toDual (neg_neg _)
+  map_rel_iff' := neg_le_neg_iff
+
+/-- Negation as an automorphism of the knowledge order. -/
+def Negation.knowIso : Know B ≃o Know B where
+  toFun X := toKnow (neg (ofKnow X))
+  invFun X := toKnow (neg (ofKnow X))
+  left_inv _ := congrArg toKnow (neg_neg _)
+  right_inv _ := congrArg toKnow (neg_neg _)
+  map_rel_iff' := neg_kLE_neg_iff
+
+end Defs
+
+section Bounds
+
+variable [PartialOrder B] [Preorder (Know B)] [BoundedOrder B] [Negation B]
+
+/-- Negation exchanges the truth bounds, `∼t = f` (note following
+[avron-1996] Def 2.3). -/
+@[simp] theorem neg_top : neg (⊤ : B) = ⊥ :=
+  le_antisymm (by simpa only [neg_neg] using neg_le_neg (le_top : neg (⊥ : B) ≤ ⊤)) bot_le
+
+/-- Negation exchanges the truth bounds, `∼f = t` (note following
+[avron-1996] Def 2.3). -/
+@[simp] theorem neg_bot : neg (⊥ : B) = ⊤ :=
+  le_antisymm le_top (by simpa only [neg_neg] using neg_le_neg (bot_le : (⊥ : B) ≤ neg ⊤))
+
+end Bounds
+
+section DeMorgan
+
+variable [Lattice B] [Preorder (Know B)] [Negation B]
+
+/-- De Morgan: `∼(a ∧ b) = ∼a ∨ ∼b` (note following [avron-1996] Def 2.3). -/
+theorem neg_inf (a b : B) : neg (a ⊓ b) = neg a ⊔ neg b :=
+  OrderDual.toDual.injective (Negation.dualIso.map_inf a b)
+
+/-- De Morgan: `∼(a ∨ b) = ∼a ∧ ∼b` (note following [avron-1996] Def 2.3). -/
+theorem neg_sup (a b : B) : neg (a ⊔ b) = neg a ⊓ neg b :=
+  OrderDual.toDual.injective (Negation.dualIso.map_sup a b)
+
+end DeMorgan
+
+section KnowHom
+
+variable [Preorder B] [Lattice (Know B)] [Negation B]
+
+/-- Negation is a homomorphism of the knowledge meet, `∼(a ⊗ b) = ∼a ⊗ ∼b`
+(note following [avron-1996] Def 2.3). -/
+theorem neg_kInf (a b : B) : neg (a ⊗ b) = neg a ⊗ neg b :=
+  toKnow.injective (Negation.knowIso.map_inf (toKnow a) (toKnow b))
+
+/-- Negation is a homomorphism of the knowledge join, `∼(a ⊕ b) = ∼a ⊕ ∼b`
+(note following [avron-1996] Def 2.3). -/
+theorem neg_kSup (a b : B) : (neg (a ⊕ b) : B) = neg a ⊕ neg b :=
+  toKnow.injective (Negation.knowIso.map_sup (toKnow a) (toKnow b))
+
+end KnowHom
+
+end Negation
 
 /-! ### Representation (Avron Thm 4.3, interlaced case)
 
@@ -429,6 +540,35 @@ theorem le_iff_kInf_top_kInf_bot {x y : B} :
       _ ≤ ((y ⊗ ⊥) ⊕ (y ⊗ ⊤) : B) := Interlaced.kSup_tmono e₂ _
       _ = ((y ⊗ ⊤) ⊕ (y ⊗ ⊥) : B) := kSup_comm _ _
       _ = y := decomp_kSup y
+
+/-! #### Negation and the decomposition (Avron Prop 4.7)
+
+With a negation, the two decomposition factors are isomorphic and the
+decomposition is a *diagonal* product: [avron-1996] Prop 4.7 exhibits
+`⟨B, ∼⟩ ≅ L_B ⊙ L_B` with Ginsberg's swap negation, via `x ↦ (x ⊗ t, x ⊗ f)`
+followed by `(x, y) ↦ (x, ∼y)`. Formalized here: the ideal isomorphism
+`λ x, ∼x : L_B ≃o R_B` (`negIicIso`) and the transport equation
+`∼x ⊗ t = ∼(x ⊗ f)` (`neg_kInf_top`) — the two steps of Avron's proof. -/
+
+omit [Interlaced B] [BoundedOrder (Know B)] in
+/-- [avron-1996] Prop 4.7, key step: negation is an isomorphism between the
+knowledge ideals `L_B = Iic t` and `R_B = Iic f`. -/
+def negIicIso [Negation B] : Set.Iic kT ≃o Set.Iic kF where
+  toFun x := ⟨toKnow (neg (ofKnow x.1)), by
+    simpa only [Set.mem_Iic, kLE_def, toKnow_ofKnow, neg_top] using
+      neg_kLE_neg (show ofKnow x.1 ≤ₖ (⊤ : B) from x.2)⟩
+  invFun y := ⟨toKnow (neg (ofKnow y.1)), by
+    simpa only [Set.mem_Iic, kLE_def, toKnow_ofKnow, neg_bot] using
+      neg_kLE_neg (show ofKnow y.1 ≤ₖ (⊥ : B) from y.2)⟩
+  left_inv x := Subtype.ext (congrArg toKnow (neg_neg _))
+  right_inv y := Subtype.ext (congrArg toKnow (neg_neg _))
+  map_rel_iff' := neg_kLE_neg_iff
+
+omit [Interlaced B] [BoundedOrder (Know B)] in
+/-- [avron-1996] Prop 4.7, transport step (the map `(x, y) ↦ (x, ∼y)`):
+negation exchanges the two decomposition components, `∼x ⊗ t = ∼(x ⊗ f)`. -/
+theorem neg_kInf_top [Negation B] (x : B) : (neg x ⊗ ⊤ : B) = neg (x ⊗ ⊥) := by
+  rw [neg_kInf, neg_bot]
 
 end Representation
 

--- a/Linglib/Core/Logic/Bilattice/Product.lean
+++ b/Linglib/Core/Logic/Bilattice/Product.lean
@@ -38,6 +38,13 @@ term names an older single-factor lineage, so this file keeps Avron's name.
 * `Product.neg` — Ginsberg negation on the diagonal `L ⊙ L`
 -/
 
+/-- Componentwise product of order isomorphisms. `[UPSTREAM]` candidate:
+mathlib has `Equiv.prodCongr` but no order-iso version. -/
+def OrderIso.prodCongr {α β γ δ : Type*} [Preorder α] [Preorder β] [Preorder γ]
+    [Preorder δ] (e₁ : α ≃o β) (e₂ : γ ≃o δ) : α × γ ≃o β × δ where
+  toEquiv := e₁.toEquiv.prodCongr e₂.toEquiv
+  map_rel_iff' := and_congr e₁.map_rel_iff e₂.map_rel_iff
+
 namespace Bilattice
 
 /-- The Ginsberg–Fitting product `L ⊙ R` ([avron-1996] Def 2.4): pairs of
@@ -64,6 +71,9 @@ def con (x : L ⊙ R) : R := OrderDual.ofDual x.2
 @[simp] theorem pro_mk (a : L) (b : R) : pro (mk a b) = a := rfl
 @[simp] theorem con_mk (a : L) (b : R) : con (mk a b) = b := rfl
 @[simp] theorem mk_pro_con (x : L ⊙ R) : mk x.pro x.con = x := rfl
+
+@[ext] theorem ext {x y : L ⊙ R} (h₁ : x.pro = y.pro) (h₂ : x.con = y.con) : x = y :=
+  Prod.ext h₁ (congrArg OrderDual.toDual h₂)
 
 /-! ### The truth order
 
@@ -166,6 +176,8 @@ On the diagonal `L ⊙ L`, Ginsberg's negation swaps the coordinates: an
 involution reversing the truth order and preserving the knowledge order
 ([ginsberg-1988]; [avron-1996] Thm 2.5(2)). -/
 
+section Negation
+
 /-- Ginsberg negation on `L ⊙ L`: swap evidence for/against. -/
 def neg (x : L ⊙ L) : L ⊙ L := mk x.con x.pro
 
@@ -179,6 +191,56 @@ theorem neg_le_neg {x y : L ⊙ L} (h : x ≤ y) : neg y ≤ neg x := ⟨h.2, h.
 
 /-- Negation preserves the knowledge order ([avron-1996] Def 2.3(iii)). -/
 theorem neg_kLE_neg {x y : L ⊙ L} (h : x ≤ₖ y) : neg x ≤ₖ neg y := ⟨h.2, h.1⟩
+
+/-- **Ginsberg's swap is a negation on the diagonal** ([avron-1996] Thm 2.5(2)). -/
+instance : Negation (L ⊙ L) where
+  neg := neg
+  neg_neg := neg_neg
+  neg_le_neg := neg_le_neg
+  neg_kLE_neg := neg_kLE_neg
+
+end Negation
+
+/-! ### Recovering the factors
+
+The abstract decomposition applied to a product recovers its factors: the
+knowledge ideals below the truth bounds are order-isomorphic to `L` and `R`
+(`iicKTopIso`/`iicKBotIso`), so `Bilattice.decompose` closes the representation
+loop, `Know (L ⊙ R) ≃o L × R` (`decomposeProdIso`) — the concrete half of
+[avron-1996] Thm 4.3's uniqueness clause. -/
+
+section FactorRecovery
+
+variable [PartialOrder L] [PartialOrder R] [BoundedOrder L] [BoundedOrder R]
+
+/-- The knowledge ideal below the truth top is the evidence-for factor,
+`L_{L ⊙ R} ≃o L`. -/
+def iicKTopIso : Set.Iic (toKnow (⊤ : L ⊙ R)) ≃o L where
+  toFun x := (ofKnow x.1).pro
+  invFun a := ⟨toKnow (mk a ⊥), ⟨le_top, le_rfl⟩⟩
+  left_inv x := Subtype.ext (ext rfl
+    (le_bot_iff.mp (show (ofKnow x.1).con ≤ ⊥ from x.2.2)).symm)
+  right_inv _ := rfl
+  map_rel_iff' {x _} := ⟨fun h => ⟨h, (le_bot_iff.mp x.2.2).le.trans bot_le⟩, And.left⟩
+
+/-- The knowledge ideal below the truth bottom is the evidence-against factor,
+`R_{L ⊙ R} ≃o R`. -/
+def iicKBotIso : Set.Iic (toKnow (⊥ : L ⊙ R)) ≃o R where
+  toFun x := (ofKnow x.1).con
+  invFun b := ⟨toKnow (mk ⊥ b), ⟨le_rfl, le_top⟩⟩
+  left_inv x := Subtype.ext (ext
+    (le_bot_iff.mp (show (ofKnow x.1).pro ≤ ⊥ from x.2.1)).symm rfl)
+  right_inv _ := rfl
+  map_rel_iff' {x _} := ⟨fun h => ⟨(le_bot_iff.mp x.2.1).le.trans bot_le, h⟩, And.right⟩
+
+end FactorRecovery
+
+/-- **The representation loop closed**: `Bilattice.decompose` applied to a
+product recovers the factors, `Know (L ⊙ R) ≃o L × R` — the concrete half of
+[avron-1996] Thm 4.3's uniqueness clause. -/
+def decomposeProdIso [Lattice L] [Lattice R] [BoundedOrder L] [BoundedOrder R] :
+    Know (L ⊙ R) ≃o L × R :=
+  decompose.trans (iicKTopIso.prodCongr iicKBotIso)
 
 end Product
 


### PR DESCRIPTION
Adds the `Bilattice.Negation` mixin ([avron-1996] Def 2.3, verified against the paper: involution + reverses ≤t + preserves ≤k) with the derived laws from the note following Def 2.3 (`neg_top`/`neg_bot`, De Morgan via a `B ≃o Bᵒᵈ` packaging, knowledge-lattice homomorphism), and formalizes Prop 4.7's two proof steps: `negIicIso : Iic t ≃o Iic f` and the transport equation `∼x ⊗ t = ∼(x ⊗ f)`.

- `Negation (L ⊙ L)` instance (Thm 2.5(2): Ginsberg's swap)
- factor recovery `iicKTopIso`/`iicKBotIso` + `decomposeProdIso : Know (L ⊙ R) ≃o L × R` — the concrete half of Thm 4.3's uniqueness clause, closing the decompose↔construction loop
- `OrderIso.prodCongr` helper ([UPSTREAM] candidate; mathlib gap)