### PR TITLE
feat(Studies/Schoter1996): partitions, guard, presumably, weighting

### DIFF
--- a/Linglib/Core/Logic/Bilattice/Basic.lean
+++ b/Linglib/Core/Logic/Bilattice/Basic.lean
@@ -45,6 +45,22 @@ def conf (compl : S → S) (x : Evidential S) : Evidential S :=
 @[reducible] def Consistent [Preorder S] (compl : S → S) (x : Evidential S) : Prop :=
   x ≤ₖ conf compl x
 
+/-- The classical fragment: `x = −x`, the fixed points of conflation
+([fitting-1994]; [schoter-1996]'s `CLAS`). -/
+@[reducible] def IsClassical (compl : S → S) (x : Evidential S) : Prop :=
+  x = conf compl x
+
+/-- Over an order-reversing involution `compl`, consistency reduces to a single
+inequality: the evidence-against is below the complement of the evidence-for
+([schoter-1996]'s `CONS = {⟨a, b⟩ | a ≤ b′}`). -/
+theorem consistent_iff_con_le [Preorder S] {compl : S → S} (hanti : Antitone compl)
+    (hinv : Function.Involutive compl) {x : Evidential S} :
+    Consistent compl x ↔ x.con ≤ compl x.pro := by
+  refine ⟨And.right, fun h => ⟨?_, h⟩⟩
+  have h' := hanti h
+  rw [hinv x.pro] at h'
+  exact h'
+
 end Evidential
 
 /-- [belnap-1977]'s four-valued bilattice `FOUR = Bool ⊙ Bool`, `(for, against)`
@@ -66,8 +82,15 @@ def I : FOUR := .mk true true
 @[reducible] def conf (x : FOUR) : FOUR := Evidential.conf (! ·) x
 /-- The consistent (non-glut) fragment of `FOUR` — equivalently `x ≠ I`. -/
 @[reducible] def Consistent (x : FOUR) : Prop := Evidential.Consistent (! ·) x
+/-- The classical fragment of `FOUR` — equivalently `{F, T}`. -/
+@[reducible] def IsClassical (x : FOUR) : Prop := Evidential.IsClassical (! ·) x
 
 @[simp] theorem consistent_iff (x : FOUR) : Consistent x ↔ x ≠ I := by
+  obtain ⟨a, b⟩ := x; cases a <;> cases b <;> decide
+
+/-- The classical fragment of `FOUR` is `{F, T}` ([fitting-1994];
+[schoter-1996]). -/
+@[simp] theorem isClassical_iff (x : FOUR) : IsClassical x ↔ x = F ∨ x = T := by
   obtain ⟨a, b⟩ := x; cases a <;> cases b <;> decide
 
 end FOUR

--- a/Linglib/Core/Logic/Bilattice/Product.lean
+++ b/Linglib/Core/Logic/Bilattice/Product.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Logic.Bilattice.Interlaced
+import Mathlib.Data.Fintype.Prod
 
 /-!
 # The Ginsberg–Fitting product bilattice
@@ -98,6 +99,8 @@ instance [Preorder L] [Preorder R] [DecidableLE L] [DecidableLE R] :
   inferInstanceAs (DecidableLE (L × Rᵒᵈ))
 instance [DecidableEq L] [DecidableEq R] : DecidableEq (L ⊙ R) :=
   inferInstanceAs (DecidableEq (L × Rᵒᵈ))
+instance [Fintype L] [Fintype R] : Fintype (L ⊙ R) :=
+  inferInstanceAs (Fintype (L × Rᵒᵈ))
 
 /-- The truth order in plain coordinates: more for, less against
 ([avron-1996] Def 2.4(ii)). -/

--- a/Linglib/Studies/Schoter1996.lean
+++ b/Linglib/Studies/Schoter1996.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Logic.Bilattice.Basic
 import Mathlib.Order.Fin.Basic
+import Mathlib.Data.Bool.Basic
 
 /-!
 # Schöter's evidential bilattices: `PRESUP` and the evidential progression
@@ -8,35 +9,43 @@ import Mathlib.Order.Fin.Basic
 [schoter-1996]'s Evidential Bilattice Logic analyzes natural-language entailment,
 implicature, and presupposition by climbing a progression of evidential
 bilattices `S ⊙ S` (`Bilattice.Evidential`): `classical ⊂` Kleene-3 `⊂ FOUR ⊂
-PRESUP`. A value is a pair `(for, against)` of degrees of evidence drawn from a
-chain `S`.
+PRESUP` (Fig. 1). A value is a pair `(for, against)` of degrees of evidence
+drawn from a chain `S` — the paper writes `⟨a, b⟩` for `(against, for)`
+(reversing Fitting's coordinate order, as its fn. to §2.1 notes); this file
+keeps the library's `(for, against)` = Fitting order throughout.
 
 This file is the second consumer of the `Bilattice` substrate (the first is
 `Studies.Fitting1994`, which shows Kleene-3 = the consistent fragment of `FOUR`).
-It adds the top of Schöter's progression:
+It formalizes the paper's *value level*:
 
-* **`PRESUP := Evidential (Fin 3)`** — evidence from the 3-chain `0 < ½ < 1`,
-  adding *defeasible* (presumed) values `P⁺`/`P⁻` above `FOUR`.
+* **`PRESUP := Evidential (Fin 3)`** — evidence from the 3-chain `0 < ½ < 1`
+  (§2.1): the nine values `U, T, F, I, P⁺, P⁻, C, D⁺, D⁻`. The orderings and
+  inversions of Defs 1–2 are the substrate's `≤`/`≤ₖ`, `Product.neg`, and
+  `Evidential.conf`; the meets and joins of Def 3 are `⊓`/`⊔`/`⊗`/`⊕`.
 * **`embed : FOUR → PRESUP`** — `FOUR` is a sub-bilattice of `PRESUP`
   (order-preserving in both `≤` and `≤ₖ`): Schöter's "`FOUR` is a sublattice
   of all bilattices."
-* the presupposition gap `U` and a defeasible presumption `P⁺` are both
-  *consistent* (non-glut); only the overdefined `I` is excluded — so the
-  gap-based presupposition logic survives and gains a defeasible layer.
+* **partitions of the evidential space** (§2.2) — `Bilattice.Evidential`'s
+  consistent/classical fragments plus the paper's designated (`Designated`)
+  and semi-designated (`SemiDesignated`) subspaces, with their order-theoretic
+  characterizations and the closure facts of §2.2.
+* **value-level connectives** — Fitting's guard `φ : ψ` (Def 4), the
+  semi-designation function `σ` (Def 5), the value-level `presumably` operator
+  `π` (Def 14, clause 2), and the evidential-weighting function `f⋆` (Def 16)
+  onto the constants of [ginsberg-1988]'s `DEFAULT` bilattice.
 
-Scope: the value space and the progression. Schöter's inference apparatus
-(assertion/evaluation/inference, evidential links, the implemented engine,
-`FOEBL`/`FOMEBL`) is out of scope.
+Scope: the value space, the progression, and the value-level operators.
+Schöter's epistemic-state apparatus (setups, evidential links, assertion /
+evaluation / closure, `FOEBL`/`FOMEBL`, and the §4 data analyses that run on
+the implemented engine) is out of scope.
 -/
 
 open Bilattice
 
 namespace Schoter1996
 
--- UNVERIFIED: whether "PRESUP" is Schöter's own label for the 9-valued
--- bilattice or a formalization-local name for it.
-/-- Schöter's `PRESUP`: the evidential bilattice over the 3-chain `Fin 3 ~
-{0, ½, 1}` — `FOUR` with defeasible/presumed values added. -/
+/-- Schöter's `PRESUP` (§2.1): the evidential bilattice over the 3-chain
+`Fin 3 ~ {0, ½, 1}` — `FOUR` with defeasible/presumed values added. -/
 abbrev PRESUP := Evidential (Fin 3)
 
 namespace PRESUP
@@ -53,6 +62,15 @@ def I : PRESUP := .mk 2 2
 def Pplus : PRESUP := .mk 1 0
 /-- Presumably false. -/
 def Pminus : PRESUP := .mk 0 1
+/-- Confused: conflicting defeasible evidence — "not as strong a contradiction
+as `I`" (§2.1). -/
+def C : PRESUP := .mk 1 1
+/-- Defeated default `D⁺`: default evidence for falsity overridden by definite
+evidence for truth (§2.1). -/
+def Dplus : PRESUP := .mk 2 1
+/-- Defeated default `D⁻`: default evidence for truth overridden by definite
+negative evidence (§2.1). -/
+def Dminus : PRESUP := .mk 1 2
 
 /-- Conflation on `PRESUP`, complementing on the chain by `Fin.rev`. -/
 @[reducible] def conf (x : PRESUP) : PRESUP := Evidential.conf Fin.rev x
@@ -85,5 +103,164 @@ theorem gap_and_presumption_consistent :
     PRESUP.Consistent PRESUP.U ∧ PRESUP.Consistent PRESUP.Pplus
       ∧ ¬ PRESUP.Consistent PRESUP.I := by
   decide
+
+/-! ### Partitions of the evidential space (§2.2)
+
+The classical and consistent subspaces are Fitting's (`Evidential.IsClassical`,
+`Evidential.Consistent`); the designated and semi-designated subspaces are the
+paper's, with their footnote characterizations `DES = {x | t ≤ₖ x}` and
+`SEMI = {x | ¬x ≤ x, U <ₖ x}` proved as order-theoretic facts. -/
+
+section Partitions
+
+variable {S : Type*} [LinearOrder S] [BoundedOrder S]
+
+/-- Designated values (§2.2): maximal positive evidence, `DES = {⟨a, b⟩ | b = 1}`. -/
+@[reducible] def Designated (x : Evidential S) : Prop := x.pro = ⊤
+
+/-- Semi-designated values (§2.2): some positive evidence, at least as strong
+as the negative evidence — `SEMI = {⟨a, b⟩ | a ≤ b, 0 < b}`. -/
+@[reducible] def SemiDesignated (x : Evidential S) : Prop :=
+  x.con ≤ x.pro ∧ ⊥ < x.pro
+
+/-- The footnote characterization of designation: a value is designated iff it
+is knowledge-above the truth top, `DES = {x | t ≤ₖ x}` (§2.2). -/
+theorem designated_iff_top_kLE {x : Evidential S} :
+    Designated x ↔ (⊤ : Evidential S) ≤ₖ x :=
+  ⟨fun h => ⟨h.ge, bot_le⟩, fun h => le_antisymm le_top h.1⟩
+
+/-- The footnote characterization of semi-designation: a value is
+semi-designated iff it is truer than its negation and contains some
+information, `SEMI = {x | ¬x ≤ x, U <ₖ x}` (§2.2). -/
+theorem semiDesignated_iff {x : Evidential S} :
+    SemiDesignated x ↔ Product.neg x ≤ x ∧ (⊥ : Know (Evidential S)) < toKnow x := by
+  constructor
+  · rintro ⟨hle, hlt⟩
+    exact ⟨⟨hle, hle⟩, bot_lt_iff_ne_bot.mpr fun h => hlt.ne' (congrArg Prod.fst h)⟩
+  · rintro ⟨hneg, hlt⟩
+    refine ⟨hneg.1, bot_lt_iff_ne_bot.mpr fun hp => hlt.ne' ?_⟩
+    exact Prod.ext hp (le_bot_iff.mp (hneg.1.trans hp.le))
+
+/-- `PRESUP`'s designated subspace is `{T, D⁺, I}` (§2.2). -/
+theorem designated_cases :
+    ∀ x : PRESUP, Designated x ↔ x = PRESUP.T ∨ x = PRESUP.Dplus ∨ x = PRESUP.I := by
+  decide
+
+/-- `PRESUP`'s semi-designated subspace is `{P⁺, C, T, D⁺, I}` (§2.2). -/
+theorem semiDesignated_cases :
+    ∀ x : PRESUP, SemiDesignated x ↔ x = PRESUP.Pplus ∨ x = PRESUP.C ∨ x = PRESUP.T
+      ∨ x = PRESUP.Dplus ∨ x = PRESUP.I := by
+  decide
+
+/-- On `FOUR` — no defeasible evidence — semi-designation collapses to
+designation, `SEMI = DES` (§2.2). -/
+theorem four_semiDesignated_iff_designated :
+    ∀ x : FOUR, SemiDesignated x ↔ Designated x := by
+  decide
+
+/-- The consistent fragment of `FOUR` is closed under negation, the truth
+operations, and consensus `⊗` (§2.2). -/
+theorem four_consistent_closed :
+    ∀ x y : FOUR, FOUR.Consistent x → FOUR.Consistent y →
+      FOUR.Consistent (Product.neg x) ∧ FOUR.Consistent (x ⊓ y)
+        ∧ FOUR.Consistent (x ⊔ y) ∧ FOUR.Consistent (x ⊗ y) := by
+  decide
+
+/-- ...but not under gullibility `⊕`: credulously combining consistent evidence
+can produce the glut — paraconsistency is localized rather than absent. -/
+theorem four_consistent_not_closed_kSup :
+    ¬ ∀ x y : FOUR, FOUR.Consistent x → FOUR.Consistent y →
+      FOUR.Consistent (x ⊕ y) := by
+  decide
+
+/-- The classical fragment of `FOUR` is closed under negation and the truth
+operations (§2.2): the classical subspace supports classical logic. -/
+theorem four_isClassical_closed :
+    ∀ x y : FOUR, FOUR.IsClassical x → FOUR.IsClassical y →
+      FOUR.IsClassical (Product.neg x) ∧ FOUR.IsClassical (x ⊓ y)
+        ∧ FOUR.IsClassical (x ⊔ y) := by
+  decide
+
+end Partitions
+
+/-! ### Value-level connectives (Defs 4, 5, 14, 16)
+
+The recursive evaluation clauses of Def 14 are value-functional except for the
+inference-link connective: clause 1 is `Product.neg`, clauses 3–4 are `⊓`/`⊔`,
+clause 5 is Fitting's guard, and clause 2 (the `presumably` operator `π`) is
+built from the guard and the semi-designation function `σ`. -/
+
+section Connectives
+
+variable {S : Type*} [LinearOrder S] [BoundedOrder S]
+
+/-- Fitting's guard connective `φ : ψ` ([schoter-1996] Def 4): the value of the
+second coordinate, attenuated by the positive evidence for the first. -/
+def guard (x y : Evidential S) : Evidential S := .mk (x.pro ⊓ y.pro) (x.pro ⊓ y.con)
+
+omit [BoundedOrder S] in
+/-- The guard is monotone in the knowledge order (in both arguments), as Def 4
+notes — though it is not a lattice-theoretic connective. -/
+theorem guard_kLE_guard {x x' y y' : Evidential S} (hx : x ≤ₖ x') (hy : y ≤ₖ y') :
+    guard x y ≤ₖ guard x' y' :=
+  ⟨inf_le_inf hx.1 hy.1, inf_le_inf hx.1 hy.2⟩
+
+/-- If the guard's first coordinate is at least true on `≤ₖ`, the guard is its
+second coordinate (Def 4). -/
+theorem guard_of_top_kLE {x : Evidential S} (h : (⊤ : Evidential S) ≤ₖ x)
+    (y : Evidential S) : guard x y = y := by
+  have hp : x.pro = ⊤ := le_antisymm le_top h.1
+  simp [guard, hp]
+
+/-- With no positive evidence for the first coordinate, the guard is `U`
+(Def 4). -/
+theorem guard_of_pro_bot {x : Evidential S} (h : x.pro = ⊥) (y : Evidential S) :
+    guard x y = .mk ⊥ ⊥ := by
+  simp [guard, h]
+
+/-- The semi-designation function `σ` ([schoter-1996] Def 5): `T` on the
+semi-designated values, `F` elsewhere. -/
+def semiDesignation (x : Evidential S) : Evidential S :=
+  if SemiDesignated x then .mk ⊤ ⊥ else .mk ⊥ ⊤
+
+/-- The value-level `presumably` operator `π` ([schoter-1996] Def 14, clause 2):
+`σ(v) : T ⊕ σ(¬v) : F` — presumably-true if the value is semi-designated,
+presumably-false if its negation is, informationally unified. -/
+def presumably (v : Evidential S) : Evidential S :=
+  (guard (semiDesignation v) (.mk ⊤ ⊥) ⊕
+    guard (semiDesignation (Product.neg v)) (.mk ⊥ ⊤) : Evidential S)
+
+example : presumably PRESUP.Pplus = PRESUP.T := by decide
+example : presumably PRESUP.T = PRESUP.T := by decide
+example : presumably PRESUP.F = PRESUP.F := by decide
+example : presumably PRESUP.U = PRESUP.U := by decide
+example : presumably PRESUP.I = PRESUP.I := by decide
+
+/-- The evidential-weighting function `f⋆` ([schoter-1996] Def 16): suppresses
+the dominated evidence, so only the dominant evidence figures in evaluation. -/
+def weight (x : Evidential S) : Evidential S :=
+  if x.con < x.pro then .mk x.pro ⊥ else if x.pro < x.con then .mk ⊥ x.con else x
+
+/-- Weighting evaluates a defeated default as the definite value that defeated
+it (Def 16): `f⋆(D⁺) = T`. -/
+theorem weight_dplus : weight PRESUP.Dplus = PRESUP.T := by decide
+
+/-- `f⋆(D⁻) = F`. -/
+theorem weight_dminus : weight PRESUP.Dminus = PRESUP.F := by decide
+
+/-- `f⋆` maps `PRESUP` onto the seven constants of [ginsberg-1988]'s `DEFAULT`
+bilattice (Def 16). -/
+theorem weight_mem_default :
+    ∀ x : PRESUP, weight x ∈ [PRESUP.U, PRESUP.Pminus, PRESUP.Pplus, PRESUP.C,
+      PRESUP.F, PRESUP.T, PRESUP.I] := by
+  decide
+
+/-- The weighting is *not* a bilattice homomorphism onto `DEFAULT` (Def 16):
+it fails to commute with gullibility `⊕`. -/
+theorem weight_not_kSup_hom :
+    ¬ ∀ x y : PRESUP, weight (x ⊕ y) = (weight x ⊕ weight y : PRESUP) := by
+  decide
+
+end Connectives
 
 end Schoter1996


### PR DESCRIPTION
Formalizes the value level of Schöter's EBL, verified against the paper: the three missing PRESUP values (C, D⁺, D⁻), the §2.2 partitions (designated/semi-designated with their footnote order-theoretic characterizations, plus closure and non-closure facts for the consistent and classical fragments of FOUR), Fitting's guard connective (Def 4), the semi-designation function σ (Def 5), the value-level presumably operator π (Def 14 clause 2), and the evidential weighting f⋆ (Def 16) onto Ginsberg's DEFAULT constants with its non-homomorphicity witnessed.

- resolves the UNVERIFIED flag: "PRESUP" is Schöter's own name (§2.1); coordinate-order note added (paper's ⟨a,b⟩ = ⟨against, for⟩, reversed from Fitting)
- substrate: `Evidential.IsClassical` (CLAS) + single-inequality CONS characterization in Basic; `Fintype (L ⊙ R)` instance so ∀-over-FOUR/PRESUP facts can decide