### PR TITLE
feat(Studies/Schoter1996Thesis): guard as presupposition operator

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2638,6 +2638,7 @@ import Linglib.Studies.Schlenker2009
 import Linglib.Studies.SchlenkerEtAl2026
 import Linglib.Studies.SchlotterbeckWang2023
 import Linglib.Studies.Schoter1996
+import Linglib.Studies.Schoter1996Thesis
 import Linglib.Studies.Schwab2022
 import Linglib.Studies.Schwarz2009
 import Linglib.Studies.Schwarzer2026

--- a/Linglib/Core/Logic/Bilattice/Basic.lean
+++ b/Linglib/Core/Logic/Bilattice/Basic.lean
@@ -61,6 +61,37 @@ theorem consistent_iff_con_le [Preorder S] {compl : S → S} (hanti : Antitone c
   rw [hinv x.pro] at h'
   exact h'
 
+section Guard
+
+variable [SemilatticeInf S]
+
+/-- Fitting's guard connective `φ : ψ` ([schoter-1996] Def 4): the value of the
+second coordinate, attenuated by the positive evidence for the first. -/
+def guard (x y : Evidential S) : Evidential S := .mk (x.pro ⊓ y.pro) (x.pro ⊓ y.con)
+
+/-- The guard is monotone in the knowledge order (in both arguments), as
+[schoter-1996] Def 4 notes — though it is not a lattice-theoretic connective. -/
+theorem guard_kLE_guard {x x' y y' : Evidential S} (hx : x ≤ₖ x') (hy : y ≤ₖ y') :
+    guard x y ≤ₖ guard x' y' :=
+  ⟨inf_le_inf hx.1 hy.1, inf_le_inf hx.1 hy.2⟩
+
+variable [BoundedOrder S]
+
+/-- If the guard's first coordinate is at least true on `≤ₖ`, the guard is its
+second coordinate ([schoter-1996] Def 4). -/
+theorem guard_of_top_kLE {x : Evidential S} (h : (⊤ : Evidential S) ≤ₖ x)
+    (y : Evidential S) : guard x y = y := by
+  have hp : x.pro = ⊤ := le_antisymm le_top h.1
+  simp [guard, hp]
+
+/-- With no positive evidence for the first coordinate, the guard is `U`
+([schoter-1996] Def 4). -/
+theorem guard_of_pro_bot {x : Evidential S} (h : x.pro = ⊥) (y : Evidential S) :
+    guard x y = .mk ⊥ ⊥ := by
+  simp [guard, h]
+
+end Guard
+
 end Evidential
 
 /-- [belnap-1977]'s four-valued bilattice `FOUR = Bool ⊙ Bool`, `(for, against)`

--- a/Linglib/Studies/Schoter1996.lean
+++ b/Linglib/Studies/Schoter1996.lean
@@ -192,31 +192,9 @@ built from the guard and the semi-designation function `σ`. -/
 
 section Connectives
 
+open Evidential (guard)
+
 variable {S : Type*} [LinearOrder S] [BoundedOrder S]
-
-/-- Fitting's guard connective `φ : ψ` ([schoter-1996] Def 4): the value of the
-second coordinate, attenuated by the positive evidence for the first. -/
-def guard (x y : Evidential S) : Evidential S := .mk (x.pro ⊓ y.pro) (x.pro ⊓ y.con)
-
-omit [BoundedOrder S] in
-/-- The guard is monotone in the knowledge order (in both arguments), as Def 4
-notes — though it is not a lattice-theoretic connective. -/
-theorem guard_kLE_guard {x x' y y' : Evidential S} (hx : x ≤ₖ x') (hy : y ≤ₖ y') :
-    guard x y ≤ₖ guard x' y' :=
-  ⟨inf_le_inf hx.1 hy.1, inf_le_inf hx.1 hy.2⟩
-
-/-- If the guard's first coordinate is at least true on `≤ₖ`, the guard is its
-second coordinate (Def 4). -/
-theorem guard_of_top_kLE {x : Evidential S} (h : (⊤ : Evidential S) ≤ₖ x)
-    (y : Evidential S) : guard x y = y := by
-  have hp : x.pro = ⊤ := le_antisymm le_top h.1
-  simp [guard, hp]
-
-/-- With no positive evidence for the first coordinate, the guard is `U`
-(Def 4). -/
-theorem guard_of_pro_bot {x : Evidential S} (h : x.pro = ⊥) (y : Evidential S) :
-    guard x y = .mk ⊥ ⊥ := by
-  simp [guard, h]
 
 /-- The semi-designation function `σ` ([schoter-1996] Def 5): `T` on the
 semi-designated values, `F` elsewhere. -/

--- a/Linglib/Studies/Schoter1996Thesis.lean
+++ b/Linglib/Studies/Schoter1996Thesis.lean
@@ -1,0 +1,60 @@
+import Linglib.Core.Logic.Bilattice.Basic
+
+/-!
+# Schöter's thesis: the guard as a presupposition operator
+[schoter-1996-thesis]
+
+[schoter-1996-thesis] (the dissertation behind [schoter-1996]) analyzes
+presupposition in EBL two ways: as defeasible inference links (the route its
+§6.2.3 shares with [schoter-1996] §4), and — in material not carried over to
+the paper — through Fitting's guard connective `φ : ψ`
+(`Bilattice.Evidential.guard`), read as "`ψ` presupposing `φ`". The guard
+encodes Burton-Roberts' *truth-gap intuition*: the compound has a value only
+when the presupposition is at least true, and is otherwise the gap `U`,
+whatever the carrier's value. Its Table 6.1 gives the guard's four-valued
+table on `FOUR`.
+
+The thesis's *salient presuppositional intuition* — a presupposition is
+implied equally by a sentence and by its negation — holds for the guard by
+construction: negating the carrier commutes with guarding (`guard_neg`, a
+definitional equality), so the presuppositional component is untouched by
+negation. This is the projection-under-negation test at the value level.
+
+## Main results
+
+* `guard_table` — the guard's four-valued table on `FOUR` (Table 6.1)
+* `guard_undefined_of_failure` — presupposition failure yields the gap `U`,
+  whatever the carrier (the truth-gap intuition)
+* `guard_neg` — the guard commutes with negation of the carrier
+  (the salient presuppositional intuition, by `rfl`)
+-/
+
+open Bilattice
+open Bilattice.Evidential (guard)
+
+namespace Schoter1996Thesis
+
+open FOUR (U T F I)
+
+/-- The guard's four-valued table on `FOUR` ([schoter-1996-thesis] Table 6.1):
+a true or overdefined presupposition passes the carrier through; an unknown or
+false presupposition gaps the compound. -/
+theorem guard_table :
+    ∀ y : FOUR, guard T y = y ∧ guard U y = U ∧ guard F y = U ∧ guard I y = y := by
+  decide
+
+/-- The truth-gap intuition ([schoter-1996-thesis] §6.2.3): when the
+presupposition is false, the compound is the gap `U` whatever the carrier's
+value. -/
+theorem guard_undefined_of_failure {S : Type*} [SemilatticeInf S] [BoundedOrder S]
+    (ψ : Evidential S) : guard (.mk ⊥ ⊤) ψ = .mk ⊥ ⊥ :=
+  Evidential.guard_of_pro_bot rfl ψ
+
+/-- The salient presuppositional intuition ([schoter-1996-thesis] §6.2.3): the
+guard commutes with negation of the carrier, so a sentence and its negation
+carry the same presuppositional component — projection under negation, by
+construction. -/
+theorem guard_neg {S : Type*} [SemilatticeInf S] (x y : Evidential S) :
+    guard x (Product.neg y) = Product.neg (guard x y) := rfl
+
+end Schoter1996Thesis

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -35828,6 +35828,16 @@
   sources   = {Studies/Fitting1994.lean}
 }
 
+@phdthesis{schoter-1996-thesis,
+  author    = {Sch{\"o}ter, Andreas},
+  title     = {The Computational Application of Bilattice Logic to Natural Reasoning},
+  school    = {University of Edinburgh},
+  year      = {1996},
+  subfield  = {semantics/presupposition},
+  role      = {formalized},
+  sources   = {Studies/Schoter1996Thesis.lean}
+}
+
 @article{schoter-1996,
   author    = {Sch{\"o}ter, Andreas},
   year      = {1996},


### PR DESCRIPTION
Formalizes the guard-based presupposition analysis from Schöter's dissertation (§6.2.3, material not carried over to the JoLLI paper): the four-valued guard table (Table 6.1), the truth-gap intuition (presupposition failure gaps the compound whatever the carrier), and the salient presuppositional intuition as a definitional equality — `guard x (neg y) = neg (guard x y)`, projection under negation by `rfl`.

- graduates `guard` from Studies/Schoter1996 to `Bilattice.Evidential` (two paper-anchored consumers)
- adds verified @phdthesis bib entry `schoter-1996-thesis`