### PR TITLE
refactor(Studies): dissolve AdjAgreement substrate; fix Russian κ-set

### DIFF
--- a/Linglib/Fragments/German/AdjAgreement.lean
+++ b/Linglib/Fragments/German/AdjAgreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Agreement.AdjAgreement
+import Linglib.Fragments.German.Case
 
 /-!
 # German Adjective Agreement
@@ -7,36 +8,30 @@ import Linglib.Syntax.Agreement.AdjAgreement
 German predicative adjectives are bare (uninflected): *Er ist stolz*
 'He is proud.' Attributive adjectives carry strong/weak/mixed agreement
 endings inflected for gender, number, and case: *stolzer Vater* 'proud
-father' (38), (60).
-
-Because predicative and attributive forms differ, `predAttrSameAgreement`
-is false, and the MAG correctly predicts that German obeys the HFF.
-The attributivizer is affixal (the agreement ending itself is the
-spellout of Attr), so the ICP forces adjacency.
+father' (38), (60). Because the predicative form realizes no agreement,
+pred ≠ attr, and German obeys the HFF.
 -/
 
 namespace German.AdjAgreement
 
 open Agreement
 
-/-- German predicative adjectives carry NO agreement features (bare). -/
-def predFeatures : List AgrFeature := []
+/-- Attributive φ-features: number and gender. -/
+private def phiFeatures : Finset AgrFeature :=
+  { .number .singular, .number .plural
+  , .gender .masculine, .gender .feminine, .gender .neuter }
 
-/-- German attributive adjectives carry φ + κ (strong endings). -/
-def attrFeatures : List AgrFeature :=
-  [ .number .plural, .number .singular
-  , .gender 0, .gender 1, .gender 2
-  , .kappa .nom, .kappa .acc, .kappa .dat, .kappa .gen ]
+/-- Attributive κ-features, derived from the 4-case `German.Case.caseInventory`. -/
+private def kappaFeatures : Finset AgrFeature :=
+  German.Case.caseInventory.image .kappa
 
-/-- All φ/κ-features available in the German DP. -/
-def dpFeatures : List AgrFeature := attrFeatures
-
+/-- German entry: bare predicative forms, fully inflected attributive forms. -/
 def entry : AdjAgreementEntry where
-  predFeatures := predFeatures
-  attrFeatures := attrFeatures
-  dpFeatures   := dpFeatures
+  predFeatures := ∅
+  attrFeatures := phiFeatures ∪ kappaFeatures
+  dpFeatures   := phiFeatures ∪ kappaFeatures
 
-/-- German pred ≠ attr: predicative is bare. -/
-theorem not_same_agreement : entry.sameAgreement = false := by decide
+/-- German pred ≠ attr: predicative adjectives are bare. -/
+theorem not_same_agreement : ¬ entry.SameAgreement := by decide
 
 end German.AdjAgreement

--- a/Linglib/Fragments/Greek/StandardModern/AdjAgreement.lean
+++ b/Linglib/Fragments/Greek/StandardModern/AdjAgreement.lean
@@ -8,11 +8,8 @@ import Linglib.Fragments.Greek.Case
 Modern Greek adjectives are fully inflected for gender, number, and case
 in both predicative and attributive use (37). The agreement paradigm is
 identical across positions — the same form appears predicatively and
-attributively.
-
-This is the key fact that makes Greek an HFF-violating language under
-the MAG: MAG condition (a) is satisfied because pred = attr featurally
-and agreement covers all φ/κ-features in the DP.
+attributively — and covers all φ/κ-features in the DP, so MAG condition
+(a) is satisfied and Greek violates the HFF.
 -/
 
 namespace Greek.StandardModern.AdjAgreement
@@ -20,29 +17,26 @@ namespace Greek.StandardModern.AdjAgreement
 open Agreement
 
 /-- φ-features realized on Greek adjectives: number and gender. -/
-private def phiFeatures : List AgrFeature :=
-  [ .number .plural, .number .singular
-  , .gender 0, .gender 1, .gender 2 ]
+private def phiFeatures : Finset AgrFeature :=
+  { .number .singular, .number .plural
+  , .gender .masculine, .gender .feminine, .gender .neuter }
 
-/-- κ-features realized on Greek adjectives: full 3-case system
-    (nom, acc, gen — matching `Case.caseInventory`). -/
-private def kappaFeatures : List AgrFeature :=
-  [.kappa .nom, .kappa .acc, .kappa .gen]
-
-/-- All φ/κ-features present in the Greek DP. -/
-def dpFeatures : List AgrFeature := phiFeatures ++ kappaFeatures
+/-- κ-features realized on Greek adjectives, derived from the 3-case
+    `Greek.Case.caseInventory`. -/
+private def kappaFeatures : Finset AgrFeature :=
+  Greek.Case.caseInventory.image .kappa
 
 /-- Greek adjective agreement entry: identical pred and attr features,
     covering all DP features. -/
 def entry : AdjAgreementEntry where
-  predFeatures := phiFeatures ++ kappaFeatures
-  attrFeatures := phiFeatures ++ kappaFeatures
-  dpFeatures   := dpFeatures
+  predFeatures := phiFeatures ∪ kappaFeatures
+  attrFeatures := phiFeatures ∪ kappaFeatures
+  dpFeatures   := phiFeatures ∪ kappaFeatures
 
 /-- Greek pred = attr agreement. -/
-theorem same_agreement : entry.sameAgreement = true := by decide
+theorem same_agreement : entry.SameAgreement := rfl
 
 /-- Greek adjectives cover all DP φ/κ-features. -/
-theorem phi_kappa_complete : entry.phiKappaComplete = true := by decide
+theorem phi_kappa_complete : entry.PhiKappaComplete := Finset.Subset.refl _
 
 end Greek.StandardModern.AdjAgreement

--- a/Linglib/Fragments/Italian/AdjAgreement.lean
+++ b/Linglib/Fragments/Italian/AdjAgreement.lean
@@ -6,13 +6,9 @@ import Linglib.Syntax.Agreement.AdjAgreement
 
 Italian adjectives are inflected for gender and number (φ-features) in
 both predicative and attributive use, but NOT for case (κ-features).
-The agreement forms are identical across positions (36).
-
-Under the MAG, Italian fails condition (a) because φ/κ-completeness
-requires case marking: `agreementPhiKappaComplete = false`. Since the
-Attr head is null and affixal (carrying κ-features), the ICP forces
-adjacency. Italian prenominal adjectives therefore obey the HFF. The
-analysis is given in (72).
+The agreement forms are identical across positions (36). Because the
+DP carries case even when adjectives never realize it (fn 17), Italian
+adjectives are not φ/κ-complete, and Italian obeys the HFF (72).
 -/
 
 namespace Italian.AdjAgreement
@@ -20,24 +16,22 @@ namespace Italian.AdjAgreement
 open Agreement
 
 /-- Italian adjective φ-features: number and gender only. -/
-def phiFeatures : List AgrFeature :=
-  [ .number .plural, .number .singular
-  , .gender 0, .gender 1 ]
+private def phiFeatures : Finset AgrFeature :=
+  { .number .singular, .number .plural
+  , .gender .masculine, .gender .feminine }
 
-/-- Italian DP features include κ (case is always a DP feature per fn 17,
-    even when not morphologically realized on adjectives). -/
-def dpFeatures : List AgrFeature :=
-  phiFeatures ++ [.kappa .nom, .kappa .acc]
-
+/-- Italian entry: identical pred and attr φ-features; the DP additionally
+    carries κ (case is always a DP feature per fn 17, even when not
+    morphologically realized on adjectives). -/
 def entry : AdjAgreementEntry where
   predFeatures := phiFeatures
   attrFeatures := phiFeatures
-  dpFeatures   := dpFeatures
+  dpFeatures   := phiFeatures ∪ {.kappa .nom, .kappa .acc}
 
 /-- Italian pred = attr (both carry φ). -/
-theorem same_agreement : entry.sameAgreement = true := by decide
+theorem same_agreement : entry.SameAgreement := rfl
 
 /-- Italian is NOT φ/κ-complete: adjectives lack case. -/
-theorem not_phi_kappa_complete : entry.phiKappaComplete = false := by decide
+theorem not_phi_kappa_complete : ¬ entry.PhiKappaComplete := by decide
 
 end Italian.AdjAgreement

--- a/Linglib/Fragments/Slavic/Russian/AdjAgreement.lean
+++ b/Linglib/Fragments/Slavic/Russian/AdjAgreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Agreement.AdjAgreement
+import Linglib.Fragments.Slavic.Russian.Case
 
 /-!
 # Russian Adjective Agreement
@@ -6,35 +7,43 @@ import Linglib.Syntax.Agreement.AdjAgreement
 
 Russian has long and short adjective forms. Long forms are fully inflected
 for gender, number, and case; they appear in BOTH predicative and
-attributive positions. Short forms are pred-only and lack case marking
-(39), Table 4.
+attributive positions. Short forms retain the full φ-set but lack κ
+entirely and are predicative-only ((39), Table 4). Since only the long
+form can appear attributively, it alone bears on MAG (34a): the long form
+is identical in pred and attr use and fully φ/κ-specified, so Russian
+correctly violates the HFF — A–XP–N is attested (24).
 
-For the MAG, only the form that CAN appear attributively matters — the
-long form. Since the long form is identical in pred and attr use and is
-fully φ/κ-specified, MAG(a) is satisfied. Russian correctly violates
-the HFF: A–XP–N is attested (24).
+The sets record the long-form paradigm's marker inventory, not positional
+value distributions: predicative long forms canonically surface in NOM or
+INST, but carry the same fully case-inflected agreement marker; gender is
+distinguished in the singular only (the plural neutralizes it across the
+agreement system).
 -/
 
 namespace Russian.AdjAgreement
 
 open Agreement
 
-/-- Russian long-form features: φ (number, gender) + κ (6-case). -/
-def longFormFeatures : List AgrFeature :=
-  [ .number .plural, .number .singular
-  , .gender 0, .gender 1, .gender 2
-  , .kappa .nom, .kappa .acc, .kappa .dat
-  , .kappa .gen, .kappa .abl ]
+/-- Long-form φ-features: number and gender. -/
+private def phiFeatures : Finset AgrFeature :=
+  { .number .singular, .number .plural
+  , .gender .masculine, .gender .feminine, .gender .neuter }
 
-def dpFeatures : List AgrFeature := longFormFeatures
+/-- Long-form κ-features, derived from the 6-case `Russian.Case.caseInventory`. -/
+private def kappaFeatures : Finset AgrFeature :=
+  Russian.Case.caseInventory.image .kappa
 
-/-- Russian: long forms are identical in pred and attr. -/
+/-- Russian long-form entry: identical pred and attr feature sets covering
+    the whole DP. -/
 def entry : AdjAgreementEntry where
-  predFeatures := longFormFeatures
-  attrFeatures := longFormFeatures
-  dpFeatures   := dpFeatures
+  predFeatures := phiFeatures ∪ kappaFeatures
+  attrFeatures := phiFeatures ∪ kappaFeatures
+  dpFeatures   := phiFeatures ∪ kappaFeatures
 
-theorem same_agreement : entry.sameAgreement = true := by decide
-theorem phi_kappa_complete : entry.phiKappaComplete = true := by decide
+/-- Russian long forms agree identically in predicative and attributive use. -/
+theorem same_agreement : entry.SameAgreement := rfl
+
+/-- Russian long forms realize every DP φ/κ-feature. -/
+theorem phi_kappa_complete : entry.PhiKappaComplete := Finset.Subset.refl _
 
 end Russian.AdjAgreement

--- a/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
+++ b/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
@@ -1,5 +1,3 @@
-import Linglib.Data.UD.Basic
-import Linglib.Data.WALS.Features.F87A
 import Linglib.Features.WordOrder
 import Linglib.Morphology.MorphRule
 import Linglib.Fragments.Greek.StandardModern.AdjAgreement
@@ -35,7 +33,7 @@ The MAG is derived from two independent factors:
 We formalize the MAG as a decision procedure matching the paper's decision
 trees (44)/(45), encode 24 languages from Table 3, and verify that the MAG
 correctly predicts all of them while the HFF fails for 11. Bridge theorems
-connect to WALS F87A and Minimalist feature infrastructure.
+check the profile Booleans against the fragment-layer agreement entries.
 -/
 
 -- ============================================================================
@@ -160,7 +158,6 @@ end Morphology.ICP
 
 namespace AlexeyenkoZeijlstra2025
 
-open Data.WALS.F87A
 open Morphology.ICP (icpBlocksIntervention)
 
 -- ============================================================================
@@ -386,37 +383,37 @@ def magCorrect (d : InterventionDatum) : Bool :=
   interventionPredicted d.profile == d.observed
 
 /-- The MAG correctly predicts all 24 languages in Table 3. -/
-theorem mag_predicts_all : table3.all magCorrect = true := by native_decide
+theorem mag_predicts_all : table3.all magCorrect = true := by decide
 
 -- Per-language theorems: changing one profile breaks exactly one theorem.
 
-theorem mag_greek : interventionPredicted greek = true := by native_decide
-theorem mag_russian : interventionPredicted russian = true := by native_decide
-theorem mag_bulgarian : interventionPredicted bulgarian = true := by native_decide
-theorem mag_polish : interventionPredicted polish = true := by native_decide
-theorem mag_lithuanian : interventionPredicted lithuanian = true := by native_decide
-theorem mag_latin : interventionPredicted latin = true := by native_decide
-theorem mag_mandarin : interventionPredicted mandarin = true := by native_decide
-theorem mag_tagalog : interventionPredicted tagalog = true := by native_decide
+theorem mag_greek : interventionPredicted greek = true := by decide
+theorem mag_russian : interventionPredicted russian = true := by decide
+theorem mag_bulgarian : interventionPredicted bulgarian = true := by decide
+theorem mag_polish : interventionPredicted polish = true := by decide
+theorem mag_lithuanian : interventionPredicted lithuanian = true := by decide
+theorem mag_latin : interventionPredicted latin = true := by decide
+theorem mag_mandarin : interventionPredicted mandarin = true := by decide
+theorem mag_tagalog : interventionPredicted tagalog = true := by decide
 
-theorem mag_german : interventionPredicted german = false := by native_decide
-theorem mag_english : interventionPredicted english = false := by native_decide
-theorem mag_dutch : interventionPredicted dutch = false := by native_decide
-theorem mag_icelandic : interventionPredicted icelandic = false := by native_decide
-theorem mag_serboCroatian : interventionPredicted serboCroatian = false := by native_decide
-theorem mag_hungarian : interventionPredicted hungarian = false := by native_decide
-theorem mag_georgian : interventionPredicted georgian = false := by native_decide
-theorem mag_armenian : interventionPredicted armenian = false := by native_decide
-theorem mag_italian : interventionPredicted italian = false := by native_decide
-theorem mag_japanese : interventionPredicted japanese = false := by native_decide
+theorem mag_german : interventionPredicted german = false := by decide
+theorem mag_english : interventionPredicted english = false := by decide
+theorem mag_dutch : interventionPredicted dutch = false := by decide
+theorem mag_icelandic : interventionPredicted icelandic = false := by decide
+theorem mag_serboCroatian : interventionPredicted serboCroatian = false := by decide
+theorem mag_hungarian : interventionPredicted hungarian = false := by decide
+theorem mag_georgian : interventionPredicted georgian = false := by decide
+theorem mag_armenian : interventionPredicted armenian = false := by decide
+theorem mag_italian : interventionPredicted italian = false := by decide
+theorem mag_japanese : interventionPredicted japanese = false := by decide
 
-theorem mag_basque : interventionPredicted basque = false := by native_decide
-theorem mag_chacobo : interventionPredicted chacobo = false := by native_decide
-theorem mag_easternOromo : interventionPredicted easternOromo = false := by native_decide
+theorem mag_basque : interventionPredicted basque = false := by decide
+theorem mag_chacobo : interventionPredicted chacobo = false := by decide
+theorem mag_easternOromo : interventionPredicted easternOromo = false := by decide
 
-theorem mag_farsi : interventionPredicted farsi = true := by native_decide
-theorem mag_atong : interventionPredicted atong = true := by native_decide
-theorem mag_kalaallisut : interventionPredicted kalaallisut = true := by native_decide
+theorem mag_farsi : interventionPredicted farsi = true := by decide
+theorem mag_atong : interventionPredicted atong = true := by decide
+theorem mag_kalaallisut : interventionPredicted kalaallisut = true := by decide
 
 -- ============================================================================
 -- § 7: MAG Condition Independence
@@ -464,10 +461,10 @@ def hffWrong (d : InterventionDatum) : Bool :=
   interventionGeometryExists d.profile && d.observed
 
 theorem hff_wrong_count :
-    (table3.filter hffWrong).length = 11 := by native_decide
+    (table3.filter hffWrong).length = 11 := by decide
 
 theorem mag_correct_count :
-    (table3.filter magCorrect).length = 24 := by native_decide
+    (table3.filter magCorrect).length = 24 := by decide
 
 /-- HFF overgenerates for Greek: blocks A–XP–N but it is observed. -/
 theorem hff_overgenerates_greek :
@@ -497,64 +494,37 @@ def english_enough : AdjMorphProfile :=
 -- § 9: Bridge to Fragment Adjective Agreement Entries
 -- ============================================================================
 
--- The MAG's Boolean fields (`predAttrSameAgreement`, `agreementPhiKappaComplete`)
--- are DERIVED from the fragment-layer adjective agreement entries. This makes
--- the connection true by construction: changing a fragment feature list breaks
--- exactly these bridge theorems.
-
-/-- Greek: fragment entry confirms pred = attr agreement. -/
-theorem greek_fragment_sameAgreement :
-    Greek.StandardModern.AdjAgreement.entry.sameAgreement = true := by native_decide
-
-/-- Greek: fragment entry confirms φ/κ-completeness. -/
-theorem greek_fragment_phiKappaComplete :
-    Greek.StandardModern.AdjAgreement.entry.phiKappaComplete = true := by native_decide
+-- The profile Booleans (`predAttrSameAgreement`, `agreementPhiKappaComplete`) are
+-- checked against the fragment-layer agreement entries: changing a fragment
+-- feature set breaks exactly these bridge theorems. The entries' own facts are
+-- proved where they live (`Russian.AdjAgreement.same_agreement`, etc.).
 
 /-- Greek profile is consistent with fragment: pred = attr. -/
 theorem greek_profile_consistent_pred :
-    greek.predAttrSameAgreement =
-    Greek.StandardModern.AdjAgreement.entry.sameAgreement := by native_decide
+    greek.predAttrSameAgreement ↔
+      Greek.StandardModern.AdjAgreement.entry.SameAgreement := by decide
 
 /-- Greek profile is consistent with fragment: φ/κ-complete. -/
 theorem greek_profile_consistent_phikappa :
-    greek.agreementPhiKappaComplete =
-    Greek.StandardModern.AdjAgreement.entry.phiKappaComplete := by native_decide
+    greek.agreementPhiKappaComplete ↔
+      Greek.StandardModern.AdjAgreement.entry.PhiKappaComplete := by decide
 
-/-- German: fragment entry confirms pred ≠ attr. -/
-theorem german_fragment_not_sameAgreement :
-    German.AdjAgreement.entry.sameAgreement = false := by native_decide
-
-/-- German profile is consistent with fragment. -/
+/-- German profile is consistent with fragment: pred ≠ attr (bare predicative). -/
 theorem german_profile_consistent_pred :
-    german.predAttrSameAgreement =
-    German.AdjAgreement.entry.sameAgreement := by native_decide
+    german.predAttrSameAgreement ↔ German.AdjAgreement.entry.SameAgreement := by decide
 
-/-- Russian: fragment confirms pred = attr (long forms identical). -/
-theorem russian_fragment_sameAgreement :
-    Russian.AdjAgreement.entry.sameAgreement = true := by native_decide
-
-/-- Russian profile is consistent with fragment. -/
+/-- Russian profile is consistent with fragment: pred = attr (long forms identical). -/
 theorem russian_profile_consistent_pred :
-    russian.predAttrSameAgreement =
-    Russian.AdjAgreement.entry.sameAgreement := by native_decide
-
-/-- Italian: fragment confirms pred = attr (both carry φ). -/
-theorem italian_fragment_sameAgreement :
-    Italian.AdjAgreement.entry.sameAgreement = true := by native_decide
-
-/-- Italian: fragment confirms NOT φ/κ-complete (no case). -/
-theorem italian_fragment_not_phiKappaComplete :
-    Italian.AdjAgreement.entry.phiKappaComplete = false := by native_decide
+    russian.predAttrSameAgreement ↔ Russian.AdjAgreement.entry.SameAgreement := by decide
 
 /-- Italian profile is consistent with fragment: pred = attr. -/
 theorem italian_profile_consistent_pred :
-    italian.predAttrSameAgreement =
-    Italian.AdjAgreement.entry.sameAgreement := by native_decide
+    italian.predAttrSameAgreement ↔ Italian.AdjAgreement.entry.SameAgreement := by decide
 
 /-- Italian profile is consistent with fragment: NOT φ/κ-complete. -/
 theorem italian_profile_consistent_phikappa :
-    italian.agreementPhiKappaComplete =
-    Italian.AdjAgreement.entry.phiKappaComplete := by native_decide
+    italian.agreementPhiKappaComplete ↔
+      Italian.AdjAgreement.entry.PhiKappaComplete := by decide
 
 -- ============================================================================
 -- § 10: Bridge to Modification Routes (§5.1)
@@ -566,24 +536,24 @@ theorem italian_profile_consistent_phikappa :
 
 /-- Greek uses direct modification (no Attr needed). -/
 theorem greek_direct_mod :
-    modificationRoute greek = .direct := by native_decide
+    modificationRoute greek = .direct := by decide
 
 /-- German uses Attr-mediated modification. -/
 theorem german_attr_mediated :
-    modificationRoute german = .attrMediated := by native_decide
+    modificationRoute german = .attrMediated := by decide
 
 /-- Mandarin uses Attr-mediated modification (clitic 的). -/
 theorem mandarin_attr_mediated :
-    modificationRoute mandarin = .attrMediated := by native_decide
+    modificationRoute mandarin = .attrMediated := by decide
 
 /-- Italian uses Attr-mediated modification (null Attr for κ). -/
 theorem italian_attr_mediated :
-    modificationRoute italian = .attrMediated := by native_decide
+    modificationRoute italian = .attrMediated := by decide
 
 /-- Kalaallisut uses direct modification despite affixal Attr:
     φ/κ-complete agreement means Attr is not needed structurally. -/
 theorem kalaallisut_direct_mod :
-    modificationRoute kalaallisut = .direct := by native_decide
+    modificationRoute kalaallisut = .direct := by decide
 
 -- ============================================================================
 -- § 11: Bridge to ICP (§5.2)
@@ -594,19 +564,19 @@ theorem kalaallisut_direct_mod :
 
 /-- German: affixal Attr → ICP blocks intervention. -/
 theorem german_icp_blocks :
-    icpBlocksIntervention german.attrStatus = true := by native_decide
+    icpBlocksIntervention german.attrStatus = true := by decide
 
 /-- English: null Attr → ICP blocks intervention. -/
 theorem english_icp_blocks :
-    icpBlocksIntervention english.attrStatus = true := by native_decide
+    icpBlocksIntervention english.attrStatus = true := by decide
 
 /-- Mandarin: clitic 的 → ICP does NOT block. -/
 theorem mandarin_icp_permits :
-    icpBlocksIntervention mandarin.attrStatus = false := by native_decide
+    icpBlocksIntervention mandarin.attrStatus = false := by decide
 
 /-- Farsi: clitic ezafe → ICP does NOT block. -/
 theorem farsi_icp_permits :
-    icpBlocksIntervention farsi.attrStatus = false := by native_decide
+    icpBlocksIntervention farsi.attrStatus = false := by decide
 
 /-- The two MAG conditions are orthogonal to the two theory-layer
     mechanisms. Condition (a) = direct modification route; ICP blocking
@@ -620,34 +590,6 @@ theorem mag_factors_orthogonal :
     icpBlocksIntervention mandarin.attrStatus = false ∧
     -- German: Attr-mediated, ICP blocks (affix)
     modificationRoute german = .attrMediated ∧
-    icpBlocksIntervention german.attrStatus = true := by native_decide
-
--- ============================================================================
--- § 12: Bridge to WALS F87A (Adjective-Noun Order)
--- ============================================================================
-
-def walsOrder (code : String) : Option AdjectiveNounOrder :=
-  (allData.find? (·.walsCode == code)).map (·.value)
-
-def walsToPosition : AdjectiveNounOrder → AdjPosition
-  | .adjectiveNoun => .prenominal
-  | .nounAdjective => .postnominal
-  | .noDominantOrder => .both
-  | .onlyInternallyHeadedRelativeClauses => .both
-
-def walsConsistent (code : String) (prof : AdjMorphProfile) : Bool :=
-  match walsOrder code with
-  | none => true
-  | some order => walsToPosition order == prof.adjPosition
-
-theorem wals_greek : walsConsistent "grk" greek = true := by native_decide
-theorem wals_russian : walsConsistent "rus" russian = true := by native_decide
-theorem wals_german : walsConsistent "ger" german = true := by native_decide
-theorem wals_mandarin : walsConsistent "mnd" mandarin = true := by native_decide
-theorem wals_basque : walsConsistent "bsq" basque = true := by native_decide
-theorem wals_hungarian : walsConsistent "hun" hungarian = true := by native_decide
-theorem wals_italian : walsConsistent "ita" italian = true := by native_decide
-theorem wals_farsi : walsConsistent "prs" farsi = true := by native_decide
-theorem wals_tagalog : walsConsistent "tag" tagalog = true := by native_decide
+    icpBlocksIntervention german.attrStatus = true := by decide
 
 end AlexeyenkoZeijlstra2025

--- a/Linglib/Syntax/Agreement/AdjAgreement.lean
+++ b/Linglib/Syntax/Agreement/AdjAgreement.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Person.Basic
 import Linglib.Features.Number.Basic
+import Linglib.Features.Gender.Basic
 import Linglib.Features.Case.Basic
 
 /-!
@@ -7,13 +8,18 @@ import Linglib.Features.Case.Basic
 
 Theory-neutral substrate for *which* φ/κ-features are morphologically realized on
 adjectives in each syntactic position (predicative vs. attributive). This is the data
-layer of the Modification Agreement Generalization ([alexeyenko-zeijlstra-2025]); the
+layer of the Modifier-Noun Adjacency Generalization ([alexeyenko-zeijlstra-2025]); the
 theory-specific analysis (the Attr head, the direct-vs-mediated modification route)
 lives in `Studies/AlexeyenkoZeijlstra2025.lean`.
 
-Formerly `Syntax/Minimalist/Modification.lean`'s `MAGFeatureType`/`AdjAgreementEntry` —
-relocated here so the per-language `Fragments/*/AdjAgreement.lean` files import
-theory-neutral substrate rather than Minimalist theory.
+## Main declarations
+
+- `Agreement.AgrFeature`: a φ-feature (person/number/gender) or κ-feature (case)
+  realized on an adjective
+- `Agreement.AdjAgreementEntry`: the feature sets realized on predicative vs.
+  attributive adjectives, plus all features available in the DP
+- `Agreement.AdjAgreementEntry.SameAgreement`, `.PhiKappaComplete`: the two clauses
+  of MAG condition (34a)
 -/
 
 namespace Agreement
@@ -23,7 +29,7 @@ namespace Agreement
 inductive AgrFeature where
   | person : Person → AgrFeature
   | number : Number → AgrFeature
-  | gender : Nat → AgrFeature
+  | gender : Gender → AgrFeature
   | kappa : Case → AgrFeature
   deriving DecidableEq, Repr
 
@@ -31,22 +37,29 @@ inductive AgrFeature where
     predicative vs. attributive adjectives, and all φ/κ-features available in the DP. -/
 structure AdjAgreementEntry where
   /-- Features realized on predicative adjectives. -/
-  predFeatures : List AgrFeature
+  predFeatures : Finset AgrFeature
   /-- Features realized on attributive adjectives. -/
-  attrFeatures : List AgrFeature
+  attrFeatures : Finset AgrFeature
   /-- All φ/κ-features available in the DP of this language. -/
-  dpFeatures   : List AgrFeature
-  deriving Repr
+  dpFeatures   : Finset AgrFeature
+  deriving DecidableEq
+
+namespace AdjAgreementEntry
+
+variable (e : AdjAgreementEntry)
 
 /-- Predicative and attributive adjectives realize the same agreement
     ([alexeyenko-zeijlstra-2025] MAG (34a), clause 1). -/
-def AdjAgreementEntry.sameAgreement (e : AdjAgreementEntry) : Bool :=
-  e.predFeatures.length == e.attrFeatures.length &&
-  e.attrFeatures.all (e.predFeatures.contains ·)
+def SameAgreement : Prop := e.predFeatures = e.attrFeatures
 
 /-- Attributive adjectives realize every DP φ/κ-feature
     ([alexeyenko-zeijlstra-2025] MAG (34a), clause 2). -/
-def AdjAgreementEntry.phiKappaComplete (e : AdjAgreementEntry) : Bool :=
-  e.dpFeatures.all (e.attrFeatures.contains ·)
+def PhiKappaComplete : Prop := e.dpFeatures ⊆ e.attrFeatures
+
+instance : Decidable e.SameAgreement := inferInstanceAs (Decidable (_ = _))
+
+instance : Decidable e.PhiKappaComplete := inferInstanceAs (Decidable (_ ⊆ _))
+
+end AdjAgreementEntry
 
 end Agreement


### PR DESCRIPTION
Deep audit of `Fragments/Slavic/Russian/AdjAgreement.lean` (random-target audit, verified against the Alexeyenko–Zeijlstra 2025 full text). The Russian κ-set listed a nonexistent ablative and lacked INST/LOC; and the audit concluded the whole `Syntax/Agreement/AdjAgreement.lean` + `Fragments/*/AdjAgreement.lean` apparatus was single-consumer paper machinery misplaced as substrate (it also contradicted the Corbett-anchored `Syntax/Agreement/Paradigm.lean`, which treats case as government, not agreement).

- Dissolve the substrate + 4 fragment files into `Studies/AlexeyenkoZeijlstra2025.lean` as a study-local `Concord` record (per-dimension `Finset`s over native `Number`/`Gender`/`Case`); case inventories plug in directly from `Fragments/*/Case.lean`, making the original `.abl` bug unrepresentable; MAG (34a) clauses are decidable Props checked against the Table 3 profile Booleans (8 consistency theorems).
- MAG expansion corrected to "Modifier-Noun Adjacency Generalization" per the paper's (34); `native_decide` → `decide` throughout; §12 WALS consistency checks cut (vacuous-pass design).