### PR TITLE
refactor(Semantics/Questions): cleanse Relevance, bridge entailment to ≤

### DIFF
--- a/Linglib/Semantics/Questions/Basic.lean
+++ b/Linglib/Semantics/Questions/Basic.lean
@@ -38,8 +38,8 @@ derivatives (`compl_eq`, `proj`, `nonInfo`, the division law), and the
 LEM-fails witness.
 
 For Hamblin constructions (`polar`, `which`), see
-`Core/Question/Hamblin.lean`. For partial-answerhood and Roberts
-QUD-relevance predicates, see `Core/Question/Relevance.lean`. For
+`Semantics/Questions/Hamblin.lean`. For partial-answerhood and Roberts
+QUD-relevance predicates, see `Semantics/Questions/Relevance.lean`. For
 the `Setoid → Question` embedding (used by `State`), see
 `Semantics/Questions/Partition/Basic.lean`.
 

--- a/Linglib/Semantics/Questions/DecisionTheory.lean
+++ b/Linglib/Semantics/Questions/DecisionTheory.lean
@@ -7,18 +7,16 @@ import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.GroupWithZero.Finset
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring
-import Linglib.Semantics.Questions.Relevance
 
 /-!
 # Core Decision Theory
 [van-rooy-2003] [blackwell-1953]
 
 Theory-neutral decision-theoretic infrastructure: decision problems, expected
-utility, maximin, and mention-some/mention-all classification.
-
-Promoted from `Semantics.Questions.DecisionTheory` so that any module
-(RSA, causal decision theory, explanation models) can use decision problems
-without pulling in question-semantic types.
+utility, maximin, and mention-some/mention-all classification. No
+question-semantic imports: any module (RSA, causal decision theory,
+explanation models) can use decision problems without pulling in the
+`Question` cone.
 
 ## Design: Fintype + Finset
 

--- a/Linglib/Semantics/Questions/Partition/Binary.lean
+++ b/Linglib/Semantics/Questions/Partition/Binary.lean
@@ -17,7 +17,7 @@ P-preserving coarsening of a given partition:
   Universality property: any q'-refinement that preserves P also refines
   this construction.
 
-Used by `Core/Question/Partition/Negativity.lean` for Merin's epistemic
+Used by `Semantics/Questions/Partition/Negativity.lean` for Merin's epistemic
 characterization of negative attributes.
 -/
 

--- a/Linglib/Semantics/Questions/Partition/Constructors.lean
+++ b/Linglib/Semantics/Questions/Partition/Constructors.lean
@@ -20,7 +20,7 @@ This induces a **partition** of logical space.
 ## Architecture
 
 `GSQuestion` is an abbreviation for `QUD`. All partition lattice operations
-(refinement, coarsening, cells) are defined in `Core/Question/Partition/`
+(refinement, coarsening, cells) are defined in `Semantics/Questions/Partition/`
 and apply to any equivalence-relation partition, not just question
 denotations.
 

--- a/Linglib/Semantics/Questions/Partition/QUD.lean
+++ b/Linglib/Semantics/Questions/Partition/QUD.lean
@@ -22,9 +22,9 @@ the Bool-view (`sameAnswer`), and the `ProductQUD` projections.
 
 ## Place in the Question API
 
-`QUD M` lives inside `Core/Question/` (rather than a parallel
-`Core/QUD/` directory) as the construction-side API for partition-shaped
-questions. The inquisitive `Question W` (`Core/Question/Basic.lean`) is
+`QUD M` lives inside `Semantics/Questions/` (rather than a parallel
+top-level QUD directory) as the construction-side API for partition-shaped
+questions. The inquisitive `Question W` (`Semantics/Questions/Basic.lean`) is
 the consumer-side type with the richer lattice and answerhood structure;
 `Question.fromSetoid` (`Semantics/Questions/Partition/Basic.lean`) is the
 canonical bridge from a `Setoid` (or `QUD`) into an inquisitive

--- a/Linglib/Semantics/Questions/Relevance.lean
+++ b/Linglib/Semantics/Questions/Relevance.lean
@@ -68,8 +68,8 @@ def questionEntails (P Q : Question W) : Prop :=
 def isSubquestion (q parent : Question W) : Prop :=
   questionEntails parent q
 
-/-- A move is relevant to the QUD if some alternative partially answers
-it or one of the subquestions. -/
+/-- A move is relevant if one of its alternatives partially answers the
+QUD or one of the subquestions. -/
 def moveRelevant (den qud : Question W) (subquestions : List (Question W)) : Prop :=
   ∃ a ∈ alt den,
     partiallyAnswers qud a ∨ ∃ q ∈ subquestions, partiallyAnswers q a
@@ -133,8 +133,8 @@ theorem isSubquestion_trans
     isSubquestion P R :=
   questionEntails_trans hQR hPQ
 
-/-- A move one of whose alternatives partially answers the QUD is
-relevant. -/
+/-- A move is relevant if one of its alternatives partially answers the
+QUD directly, with no subquestions. -/
 theorem moveRelevant_of_partiallyAnswers
     {den qud : Question W} {a : Set W} (ha : a ∈ alt den)
     (h : partiallyAnswers qud a) :

--- a/Linglib/Semantics/Questions/Relevance.lean
+++ b/Linglib/Semantics/Questions/Relevance.lean
@@ -12,13 +12,14 @@ maximal-resolving propositions): `partiallyAnswers`, `questionEntails`,
 `questionEntails` coincides with the inquisitive lattice order under
 finiteness (`questionEntails_iff_le`). On polar questions the predicates
 reduce to plain `Set` inclusions via the `_polar_iff` lemmas, so consumers
-can `rw` and then `decide`; the residual subset checks fire from
+can `rw` and then `decide` after activating the local-instance
 `Set.decidableSubsetOfFintype` below.
 
 ## Fidelity notes
 
 `partiallyAnswers` is the non-contextual core of [roberts-2012] (3a),
-which relativizes both entailments to the common ground. `questionEntails`
+which relativizes both entailments to the common ground; `∅` vacuously
+answers everything, as there. `questionEntails` is [roberts-2012] (8) and
 matches [groenendijk-stokhof-1984] entailment only where alternatives are
 complete answers (partition and polar contents; not mention-some `which`)
 — [roberts-2012]'s own caveat. `moveRelevant` is existential answerhood
@@ -26,19 +27,26 @@ relevance: the partial-answer clause of Roberts's Relevance (15), weaker
 than her strategy clause for interrogative moves; it is the proxy
 [ippolito-kiss-williams-2025] use for their relevance assumption (iii),
 consumed by the discourse *only* definedness condition in their (16).
-These are all answerhood ("aboutness") notions — distinct from
-inquisitive-semantics compliance ([ciardelli-groenendijk-roelofsen-2018],
-not formalized here) and from decision-theoretic relevance
-(`Studies/VanRooy2003.lean`, which consumes `CoversAltsOf`).
+That the `subquestions` argument really lists subquestions of the QUD is
+the caller's obligation. `CoversAltsOf`'s nonemptiness bars `⊥`-style
+vacuous covering. These are all answerhood ("aboutness") notions —
+distinct from inquisitive-semantics compliance
+([ciardelli-groenendijk-roelofsen-2018], not formalized here) and from
+decision-theoretic relevance (`Studies/VanRooy2003.lean`, which consumes
+`CoversAltsOf`).
 -/
 
 /-! ### `Set ⊆ Set` decidability for finite types
 
-Mathlib provides subset decidability only for `Finset`; for `Set` it is
-derivable from `Fintype` plus per-set `DecidablePred` membership witnesses.
-[UPSTREAM] candidate. -/
+Deliberately a `def`, not an `instance`: mathlib omits global `Decidable`
+instances on `Set` relations (cf. the loop warning on
+`Set.decidableMemOfFintype`), and its idiom is `Set.toFinset` transport or
+a local instance. Consumers that `decide` subset goals opt in via
+`attribute [local instance] Set.decidableSubsetOfFintype`. -/
 
-instance Set.decidableSubsetOfFintype {α : Type*} [Fintype α]
+/-- `Decidable (s ⊆ t)` from `Fintype` plus decidable membership.
+Not an instance; activate locally. -/
+def Set.decidableSubsetOfFintype {α : Type*} [Fintype α]
     (s t : Set α) [DecidablePred (· ∈ s)] [DecidablePred (· ∈ t)] :
     Decidable (s ⊆ t) :=
   show Decidable (∀ ⦃a⦄, a ∈ s → a ∈ t) from inferInstance
@@ -47,45 +55,38 @@ namespace Question
 
 variable {W : Type*}
 
-/-- `σ` **partially answers** `P`: it settles some alternative positively
-    (`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`). [roberts-2012] (3a); `σ = ∅`
-    vacuously answers everything, as there. -/
+/-- `σ` partially answers `P` if it settles some alternative positively
+(`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`). -/
 def partiallyAnswers (P : Question W) (σ : Set W) : Prop :=
   ∃ p ∈ alt P, σ ⊆ p ∨ σ ⊆ pᶜ
 
-/-- **Question entailment**: every alternative of `P` entails some
-    alternative of `Q`. [roberts-2012] (8), after
-    [groenendijk-stokhof-1984]. -/
+/-- Every alternative of `P` entails some alternative of `Q`. -/
 def questionEntails (P Q : Question W) : Prop :=
   ∀ p ∈ alt P, ∃ q ∈ alt Q, p ⊆ q
 
-/-- `q` is a **subquestion** of `parent`: answering `parent` settles `q`
-    ([roberts-2012]). -/
+/-- `q` is a subquestion of `parent` if answering `parent` settles `q`. -/
 def isSubquestion (q parent : Question W) : Prop :=
   questionEntails parent q
 
-/-- A move `den` is **relevant** to the QUD if some alternative partially
-    answers the QUD or one of `subquestions` ([roberts-2012] (15), see
-    the fidelity notes above). That `subquestions` really are subquestions
-    of the QUD is the caller's obligation. -/
+/-- A move is relevant to the QUD if some alternative partially answers
+it or one of the subquestions. -/
 def moveRelevant (den qud : Question W) (subquestions : List (Question W)) : Prop :=
   ∃ a ∈ alt den,
     partiallyAnswers qud a ∨ ∃ q ∈ subquestions, partiallyAnswers q a
 
-/-- Dual of `questionEntails`: every **nonempty** alternative of `Q`
-    contains a nonempty alternative of `P`. Equivalent to
-    `questionEntails P Q` on partitions, independent in general; the
-    nonemptiness bars `⊥`-style vacuous covering, matching
-    `VanRooy2003.IsDecisionRelevant`'s substantive witnesses. -/
+/-- Every nonempty alternative of `Q` contains a nonempty alternative of
+`P`: the dual of `questionEntails`. -/
 def CoversAltsOf (P Q : Question W) : Prop :=
   ∀ q ∈ alt Q, q.Nonempty → ∃ p ∈ alt P, p.Nonempty ∧ p ⊆ q
+
+variable {P Q R : Question W}
 
 /-! ### Reflexivity / transitivity -/
 
 theorem questionEntails_refl (P : Question W) : questionEntails P P :=
   fun p hp => ⟨p, hp, subset_rfl⟩
 
-theorem questionEntails_trans {P Q R : Question W}
+theorem questionEntails_trans
     (hPQ : questionEntails P Q) (hQR : questionEntails Q R) :
     questionEntails P R := by
   intro p hp
@@ -95,9 +96,9 @@ theorem questionEntails_trans {P Q R : Question W}
 
 /-! ### Lattice ↔ entailment -/
 
-/-- Inquisitive entailment `P ≤ Q` implies `questionEntails P Q`.
-    `Q.props.Finite` guarantees maximal extensions exist. -/
-theorem questionEntails_of_le {P Q : Question W} (h : P ≤ Q)
+/-- Inquisitive entailment `P ≤ Q` implies question entailment;
+finiteness supplies maximal extensions. -/
+theorem questionEntails_of_le (h : P ≤ Q)
     (hQ : Q.props.Finite) : questionEntails P Q := by
   intro p hp
   have hpP : p ∈ P.props := alt_subset_props P hp
@@ -105,7 +106,7 @@ theorem questionEntails_of_le {P Q : Question W} (h : P ≤ Q)
   exact exists_alt_above Q hQ hpQ
 
 /-- Converse of `questionEntails_of_le`, under finiteness of `P.props`. -/
-theorem le_of_questionEntails {P Q : Question W} (hP : P.props.Finite)
+theorem le_of_questionEntails (hP : P.props.Finite)
     (h : questionEntails P Q) : P ≤ Q := by
   rw [le_def]
   intro s hs
@@ -113,28 +114,27 @@ theorem le_of_questionEntails {P Q : Question W} (hP : P.props.Finite)
   obtain ⟨q, hq, hpq⟩ := h p hp
   exact Q.downward_closed q (alt_subset_props Q hq) s (hsp.trans hpq)
 
-/-- Under finiteness, Roberts question entailment and the inquisitive
-    lattice order are the same relation. -/
-theorem questionEntails_iff_le {P Q : Question W}
-    (hP : P.props.Finite) (hQ : Q.props.Finite) :
+/-- Question entailment coincides with the inquisitive lattice order
+under finiteness. -/
+theorem questionEntails_iff_le (hP : P.props.Finite) (hQ : Q.props.Finite) :
     questionEntails P Q ↔ P ≤ Q :=
   ⟨le_of_questionEntails hP, (questionEntails_of_le · hQ)⟩
 
 /-- Variant of `questionEntails_of_le` for finite world types. -/
-theorem questionEntails_of_le' [Finite W]
-    {P Q : Question W} (h : P ≤ Q) : questionEntails P Q :=
+theorem questionEntails_of_le' [Finite W] (h : P ≤ Q) :
+    questionEntails P Q :=
   questionEntails_of_le h Q.props.toFinite
 
 theorem isSubquestion_refl (P : Question W) : isSubquestion P P :=
   questionEntails_refl P
 
-theorem isSubquestion_trans {q r s : Question W}
-    (hqr : isSubquestion q r) (hrs : isSubquestion r s) :
-    isSubquestion q s :=
-  questionEntails_trans hrs hqr
+theorem isSubquestion_trans
+    (hPQ : isSubquestion P Q) (hQR : isSubquestion Q R) :
+    isSubquestion P R :=
+  questionEntails_trans hQR hPQ
 
-/-- A move whose alternative directly partially answers the QUD is
-    relevant, with no subquestions needed. -/
+/-- A move one of whose alternatives partially answers the QUD is
+relevant. -/
 theorem moveRelevant_of_partiallyAnswers
     {den qud : Question W} {a : Set W} (ha : a ∈ alt den)
     (h : partiallyAnswers qud a) :
@@ -144,8 +144,8 @@ theorem moveRelevant_of_partiallyAnswers
 /-! ### Iff-rewrite lemmas for `polar`
 
 These reduce the predicates on polar questions to plain `Set` inclusions,
-so consumers can `rw` and then `decide` via `Set.decidableSubsetOfFintype`
-plus per-set `DecidablePred`. -/
+so consumers can `rw` and then `decide` (with the subset decidability
+above as a local instance). -/
 
 theorem partiallyAnswers_polar_iff {p σ : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :

--- a/Linglib/Semantics/Questions/Relevance.lean
+++ b/Linglib/Semantics/Questions/Relevance.lean
@@ -5,84 +5,85 @@ import Mathlib.Data.Fintype.Powerset
 # Roberts (2012) QUD relevance — Prop predicates on `Question`
 [roberts-2012] [groenendijk-stokhof-1984]
 
-Mathlib-style Prop predicates with `Decidable` instances. Successor of an
-earlier Bool/List `partiallyAnswers`/`questionEntails`/`isSubquestion`/
-`moveRelevant` API (now removed) that operated on a Hamblin
-list-of-alternatives `Question` type.
+Answerhood-based relevance predicates ranging over `alt P` (the
+maximal-resolving propositions): `partiallyAnswers`, `questionEntails`,
+`isSubquestion`, `moveRelevant`, and the dual `CoversAltsOf`.
 
-The predicates operate directly on `Question`, ranging over `alt P`
-(the maximal-resolving propositions). For computability, an `Question`
-must expose a finite alternative-list witness via `HasAltList`. The
-canonical witness for a polar question is `HasAltList.polar`; for an
-arbitrary Hamblin issue, define a `HasAltList` instance via the
-`ofList` smart constructor (`Core/Question/Hamblin.lean`).
+`questionEntails` coincides with the inquisitive lattice order under
+finiteness (`questionEntails_iff_le`). On polar questions the predicates
+reduce to plain `Set` inclusions via the `_polar_iff` lemmas, so consumers
+can `rw` and then `decide`; the residual subset checks fire from
+`Set.decidableSubsetOfFintype` below.
 
-Decidability of `σ ⊆ p` for `σ p : Set W` is *not* automatic in mathlib
-(unlike `Finset`). The local instance `Set.decidableSubsetOfFintype` below
-plugs the gap: it derives `Decidable (s ⊆ t)` from `[Fintype W]` plus
-`DecidablePred (· ∈ s)` and `DecidablePred (· ∈ t)`. Consumers building
-`Set W` from `W → Bool` predicates get the per-set `DecidablePred` for
-free.
+## Fidelity notes
 
-Note that the `[∀ p, Decidable (σ ⊆ p ∨ σ ⊆ pᶜ)]` hypothesis on the
-instances below ranges over **all** `p : Set W` — Lean cannot synthesize
-this universally because `DecidablePred (· ∈ p)` is not derivable for
-arbitrary `p`. Consumers should either supply this hypothesis at the
-call site (typically via `decide_partiallyAnswers_polar` for polar
-questions) or invoke a specialized decision procedure tied to the
-specific alternative list.
+`partiallyAnswers` is the non-contextual core of [roberts-2012] (3a),
+which relativizes both entailments to the common ground. `questionEntails`
+matches [groenendijk-stokhof-1984] entailment only where alternatives are
+complete answers (partition and polar contents; not mention-some `which`)
+— [roberts-2012]'s own caveat. `moveRelevant` is existential answerhood
+relevance: the partial-answer clause of Roberts's Relevance (15), weaker
+than her strategy clause for interrogative moves; it is the proxy
+[ippolito-kiss-williams-2025] use for their relevance assumption (iii),
+consumed by the discourse *only* definedness condition in their (16).
+These are all answerhood ("aboutness") notions — distinct from
+inquisitive-semantics compliance ([ciardelli-groenendijk-roelofsen-2018],
+not formalized here) and from decision-theoretic relevance
+(`Studies/VanRooy2003.lean`, which consumes `CoversAltsOf`).
 -/
+
+/-! ### `Set ⊆ Set` decidability for finite types
+
+Mathlib provides subset decidability only for `Finset`; for `Set` it is
+derivable from `Fintype` plus per-set `DecidablePred` membership witnesses.
+[UPSTREAM] candidate. -/
+
+instance Set.decidableSubsetOfFintype {α : Type*} [Fintype α]
+    (s t : Set α) [DecidablePred (· ∈ s)] [DecidablePred (· ∈ t)] :
+    Decidable (s ⊆ t) :=
+  show Decidable (∀ ⦃a⦄, a ∈ s → a ∈ t) from inferInstance
 
 namespace Question
 
-universe u
-variable {W : Type u}
+variable {W : Type*}
 
-/-- `σ` partially answers `P`: settles at least one alternative either
-    positively (`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`).
-    [roberts-2012] Def. 3a. -/
+/-- `σ` **partially answers** `P`: it settles some alternative positively
+    (`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`). [roberts-2012] (3a); `σ = ∅`
+    vacuously answers everything, as there. -/
 def partiallyAnswers (P : Question W) (σ : Set W) : Prop :=
   ∃ p ∈ alt P, σ ⊆ p ∨ σ ⊆ pᶜ
 
-/-- Question entailment: every alternative of `P` entails some alternative
-    of `Q`. [roberts-2012] Def. 8 (after
-    [groenendijk-stokhof-1984]). At the partition level this is
-    `QUD.refines`: `P` refines `Q` iff knowing `P`'s answer determines
-    `Q`'s answer. -/
+/-- **Question entailment**: every alternative of `P` entails some
+    alternative of `Q`. [roberts-2012] (8), after
+    [groenendijk-stokhof-1984]. -/
 def questionEntails (P Q : Question W) : Prop :=
   ∀ p ∈ alt P, ∃ q ∈ alt Q, p ⊆ q
 
-/-- `q` is a **subquestion** of `parent`: answering `parent` settles `q`. -/
+/-- `q` is a **subquestion** of `parent`: answering `parent` settles `q`
+    ([roberts-2012]). -/
 def isSubquestion (q parent : Question W) : Prop :=
   questionEntails parent q
 
-/-- A discourse move `den` is **relevant** to the QUD if some alternative
-    partially answers the QUD or any of the subquestions. The
-    QUD-relevance idea traces to [roberts-2012]; the present
-    formulation is the one [ippolito-kiss-williams-2025] ex. (16)
-    assumption iii uses for discourse *only*'s definedness condition. -/
+/-- A move `den` is **relevant** to the QUD if some alternative partially
+    answers the QUD or one of `subquestions` ([roberts-2012] (15), see
+    the fidelity notes above). That `subquestions` really are subquestions
+    of the QUD is the caller's obligation. -/
 def moveRelevant (den qud : Question W) (subquestions : List (Question W)) : Prop :=
   ∃ a ∈ alt den,
     partiallyAnswers qud a ∨ ∃ q ∈ subquestions, partiallyAnswers q a
 
-/-- The dual of `questionEntails`: every **nonempty** alternative of
-    `Q` is *covered* by a nonempty alternative of `P`.
-
-    On partition questions this is equivalent to `questionEntails P Q`;
-    for general inquisitive `Question W`, the two directions are
-    independent. The decision-relevance preservation theorem in
-    `Studies.VanRooy2003` requires this
-    dual form, not `questionEntails`. The nonempty clause matches
-    `VanRooy2003.IsDecisionRelevant`'s requirement that witnessing alternatives
-    be substantive — without it, `⊥`-style questions trivially
-    "cover" anything via the empty set. -/
+/-- Dual of `questionEntails`: every **nonempty** alternative of `Q`
+    contains a nonempty alternative of `P`. Equivalent to
+    `questionEntails P Q` on partitions, independent in general; the
+    nonemptiness bars `⊥`-style vacuous covering, matching
+    `VanRooy2003.IsDecisionRelevant`'s substantive witnesses. -/
 def CoversAltsOf (P Q : Question W) : Prop :=
   ∀ q ∈ alt Q, q.Nonempty → ∃ p ∈ alt P, p.Nonempty ∧ p ⊆ q
 
 /-! ### Reflexivity / transitivity -/
 
 theorem questionEntails_refl (P : Question W) : questionEntails P P :=
-  fun p hp => ⟨p, hp, Set.Subset.refl p⟩
+  fun p hp => ⟨p, hp, subset_rfl⟩
 
 theorem questionEntails_trans {P Q R : Question W}
     (hPQ : questionEntails P Q) (hQR : questionEntails Q R) :
@@ -92,16 +93,10 @@ theorem questionEntails_trans {P Q R : Question W}
   obtain ⟨r, hr, hqr⟩ := hQR q hq
   exact ⟨r, hr, hpq.trans hqr⟩
 
-/-! ### Lattice → entailment
+/-! ### Lattice ↔ entailment -/
 
-The workhorse: `P ≤ Q` in the inquisitive lattice (`P.props ⊆ Q.props`)
-implies `questionEntails P Q`. Every alternative of `P` resolves `Q`
-and therefore extends to a maximal `Q`-resolving proposition. -/
-
-/-- `P ≤ Q` (inquisitive entailment) implies `questionEntails P Q`
-    (Roberts question entailment). The bridge from the lattice order
-    to the alternative-set quantification. Requires `Q.props.Finite`
-    to guarantee maximal extensions exist. -/
+/-- Inquisitive entailment `P ≤ Q` implies `questionEntails P Q`.
+    `Q.props.Finite` guarantees maximal extensions exist. -/
 theorem questionEntails_of_le {P Q : Question W} (h : P ≤ Q)
     (hQ : Q.props.Finite) : questionEntails P Q := by
   intro p hp
@@ -109,13 +104,26 @@ theorem questionEntails_of_le {P Q : Question W} (h : P ≤ Q)
   have hpQ : p ∈ Q.props := (le_def.mp h) hpP
   exact exists_alt_above Q hQ hpQ
 
-/-- Variant of `questionEntails_of_le` with `[Fintype W] [DecidableEq W]`
-    discharging the finiteness hypothesis (via `Fintype (Set W)` then
-    `Set.toFinite`). Convenient for finite-world studies. -/
-theorem questionEntails_of_le' [Fintype W] [DecidableEq W]
-    {P Q : Question W} (h : P ≤ Q) : questionEntails P Q := by
-  haveI : Finite (Set W) := Finite.of_fintype _
-  exact questionEntails_of_le h (Set.toFinite Q.props)
+/-- Converse of `questionEntails_of_le`, under finiteness of `P.props`. -/
+theorem le_of_questionEntails {P Q : Question W} (hP : P.props.Finite)
+    (h : questionEntails P Q) : P ≤ Q := by
+  rw [le_def]
+  intro s hs
+  obtain ⟨p, hp, hsp⟩ := exists_alt_above P hP hs
+  obtain ⟨q, hq, hpq⟩ := h p hp
+  exact Q.downward_closed q (alt_subset_props Q hq) s (hsp.trans hpq)
+
+/-- Under finiteness, Roberts question entailment and the inquisitive
+    lattice order are the same relation. -/
+theorem questionEntails_iff_le {P Q : Question W}
+    (hP : P.props.Finite) (hQ : Q.props.Finite) :
+    questionEntails P Q ↔ P ≤ Q :=
+  ⟨le_of_questionEntails hP, (questionEntails_of_le · hQ)⟩
+
+/-- Variant of `questionEntails_of_le` for finite world types. -/
+theorem questionEntails_of_le' [Finite W]
+    {P Q : Question W} (h : P ≤ Q) : questionEntails P Q :=
+  questionEntails_of_le h Q.props.toFinite
 
 theorem isSubquestion_refl (P : Question W) : isSubquestion P P :=
   questionEntails_refl P
@@ -126,182 +134,36 @@ theorem isSubquestion_trans {q r s : Question W}
   questionEntails_trans hrs hqr
 
 /-- A move whose alternative directly partially answers the QUD is
-    relevant (no subquestions needed). -/
-theorem partiallyAnswers_imp_moveRelevant
+    relevant, with no subquestions needed. -/
+theorem moveRelevant_of_partiallyAnswers
     {den qud : Question W} {a : Set W} (ha : a ∈ alt den)
     (h : partiallyAnswers qud a) :
     moveRelevant den qud [] :=
   ⟨a, ha, Or.inl h⟩
 
-/-! ### Generic `Set ⊆ Set` decidability for finite types
-
-Mathlib provides `Set.Subset` decidability only via `Finset`. For `Question`
-consumers that build alternatives as `Set W` from `Bool`-valued predicates,
-the gap is plugged by deriving from `Fintype W` plus per-set `DecidablePred`
-witnesses. -/
-
-instance Set.decidableSubsetOfFintype {α : Type*} [Fintype α]
-    (s t : Set α) [DecidablePred (· ∈ s)] [DecidablePred (· ∈ t)] :
-    Decidable (s ⊆ t) :=
-  show Decidable (∀ ⦃a⦄, a ∈ s → a ∈ t) from inferInstance
-
-/-! ### Decidability via `HasAltList` -/
-
-/-- A finite-presentation witness for a `Question`'s alternatives. The
-    `altList` is a `List (Set W)` whose elements correspond bijectively
-    (modulo set-equality) to `alt P`. -/
-class HasAltList (P : Question W) where
-  /-- The finite list of alternatives. -/
-  altList : List (Set W)
-  /-- The list exhausts `alt P`. -/
-  mem_altList : ∀ p, p ∈ alt P ↔ p ∈ altList
-
-/-- `partiallyAnswers` decides via the alternative list, given
-    decidability of each alternative-subset / complement-subset check. -/
-instance partiallyAnswers_decidable
-    (P : Question W) [HP : HasAltList P] (σ : Set W)
-    [∀ p : Set W, Decidable (σ ⊆ p ∨ σ ⊆ pᶜ)] :
-    Decidable (partiallyAnswers P σ) :=
-  decidable_of_iff (∃ p ∈ HP.altList, σ ⊆ p ∨ σ ⊆ pᶜ) <| by
-    refine ⟨?_, ?_⟩
-    · rintro ⟨p, hp, hor⟩
-      exact ⟨p, (HP.mem_altList p).mpr hp, hor⟩
-    · rintro ⟨p, hp, hor⟩
-      exact ⟨p, (HP.mem_altList p).mp hp, hor⟩
-
-/-- `questionEntails` decides via the alternative lists, given
-    decidability of pairwise subset checks. -/
-instance questionEntails_decidable
-    (P Q : Question W) [HP : HasAltList P] [HQ : HasAltList Q]
-    [∀ p q : Set W, Decidable (p ⊆ q)] :
-    Decidable (questionEntails P Q) :=
-  decidable_of_iff (∀ p ∈ HP.altList, ∃ q ∈ HQ.altList, p ⊆ q) <| by
-    constructor
-    · intro h p hp
-      obtain ⟨q, hq, hpq⟩ := h p ((HP.mem_altList p).mp hp)
-      exact ⟨q, (HQ.mem_altList q).mpr hq, hpq⟩
-    · intro h p hp
-      obtain ⟨q, hq, hpq⟩ := h p ((HP.mem_altList p).mpr hp)
-      exact ⟨q, (HQ.mem_altList q).mp hq, hpq⟩
-
-instance isSubquestion_decidable
-    (q parent : Question W) [HasAltList q] [HasAltList parent]
-    [∀ p₁ p₂ : Set W, Decidable (p₁ ⊆ p₂)] :
-    Decidable (isSubquestion q parent) :=
-  questionEntails_decidable parent q
-
-/-- `moveRelevant` decides via the move's alternative list, given
-    decidability of partial answerhood against the QUD and each
-    subquestion. -/
-instance moveRelevant_decidable
-    (den qud : Question W) (subquestions : List (Question W))
-    [HD : HasAltList den]
-    [∀ a : Set W, Decidable (partiallyAnswers qud a)]
-    [∀ q : Question W, ∀ a : Set W, Decidable (partiallyAnswers q a)] :
-    Decidable (moveRelevant den qud subquestions) :=
-  decidable_of_iff
-    (∃ a ∈ HD.altList,
-      partiallyAnswers qud a ∨ ∃ q ∈ subquestions, partiallyAnswers q a) <| by
-    refine ⟨?_, ?_⟩
-    · rintro ⟨a, ha, h⟩
-      exact ⟨a, (HD.mem_altList a).mpr ha, h⟩
-    · rintro ⟨a, ha, h⟩
-      exact ⟨a, (HD.mem_altList a).mp ha, h⟩
-
-/-! ### `HasAltList` constructors -/
-
-/-- `HasAltList` witness for a polar question whose proposition is
-    non-trivial (neither `∅` nor `Set.univ`). The two alternatives are
-    `p` and `pᶜ`. Not an `instance`: nontriviality must be supplied. -/
-@[reducible]
-def HasAltList.polar (p : Set W) [DecidablePred (· ∈ p)]
-    (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
-    HasAltList (Question.polar p) where
-  altList := [p, pᶜ]
-  mem_altList q := by
-    rw [alt_polar_of_nontrivial hne hnu]
-    simp only [Set.mem_insert_iff, Set.mem_singleton_iff, List.mem_cons,
-               List.not_mem_nil, or_false]
-
-/-- `HasAltList` witness for a Hamblin question built from an explicit
-    alternative list under pairwise disjointness + nonempty cells.
-    The Hamblin construction `Question.ofList L` has `alt = {p | p ∈ L}`
-    by `alt_ofList_of_pairwise_disjoint_nonempty`. Not an `instance`:
-    the structural hypotheses must be supplied at the call site. -/
-@[reducible]
-def HasAltList.ofList (L : List (Set W)) (hL : L ≠ [])
-    (hdisj : ∀ p₁ ∈ L, ∀ p₂ ∈ L, p₁ ≠ p₂ → Disjoint p₁ p₂)
-    (hne : ∀ p ∈ L, p ≠ ∅) :
-    HasAltList (Question.ofList L) where
-  altList := L
-  mem_altList q := by
-    rw [alt_ofList_of_pairwise_disjoint_nonempty L hL hdisj hne]
-    rfl
-
-/-- `HasAltList` witness for a Hamblin question built from an explicit
-    alternative list under the antichain condition (no cell contained
-    in another) + nonempty cells. Weaker than `HasAltList.ofList` —
-    cells may overlap as long as none is a subset of another distinct
-    cell. Useful for Hamblin alternatives whose truth-sets share worlds
-    (e.g., two polar question alternatives with overlap). -/
-@[reducible]
-def HasAltList.ofListAntichain (L : List (Set W)) (hL : L ≠ [])
-    (hac : ∀ p₁ ∈ L, ∀ p₂ ∈ L, p₁ ≠ p₂ → ¬ p₁ ⊆ p₂)
-    (hne : ∀ p ∈ L, p ≠ ∅) :
-    HasAltList (Question.ofList L) where
-  altList := L
-  mem_altList q := by
-    rw [alt_ofList_of_antichain_nonempty L hL hac hne]
-    rfl
-
 /-! ### Iff-rewrite lemmas for `polar`
 
-These reduce `partiallyAnswers`/`questionEntails`/`moveRelevant` on
-polar questions to plain `Set` operations, so consumers can `rw` and
-then `decide` (the residual `Set` subset checks fire from
-`Set.decidableSubsetOfFintype` plus per-set `DecidablePred`). -/
+These reduce the predicates on polar questions to plain `Set` inclusions,
+so consumers can `rw` and then `decide` via `Set.decidableSubsetOfFintype`
+plus per-set `DecidablePred`. -/
 
 theorem partiallyAnswers_polar_iff {p σ : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     partiallyAnswers (Question.polar p) σ ↔ σ ⊆ p ∨ σ ⊆ pᶜ := by
-  unfold partiallyAnswers
-  rw [alt_polar_of_nontrivial hne hnu]
-  simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
-  refine ⟨?_, ?_⟩
-  · rintro ⟨q, (rfl | rfl), hq⟩
-    · exact hq
-    · rcases hq with h | h
-      · exact Or.inr h
-      · exact Or.inl (h.trans (compl_compl p).subset)
-  · rintro (h | h)
-    · exact ⟨p, Or.inl rfl, Or.inl h⟩
-    · exact ⟨p, Or.inl rfl, Or.inr h⟩
+  simp only [partiallyAnswers, alt_polar_of_nontrivial hne hnu,
+    Set.mem_insert_iff, Set.mem_singleton_iff, exists_eq_or_imp,
+    exists_eq_left, compl_compl]
+  tauto
 
 theorem questionEntails_polar_polar_iff {p q : Set W}
     (hne_p : p ≠ ∅) (hnu_p : p ≠ Set.univ)
     (hne_q : q ≠ ∅) (hnu_q : q ≠ Set.univ) :
     questionEntails (Question.polar p) (Question.polar q) ↔
       (p ⊆ q ∨ p ⊆ qᶜ) ∧ (pᶜ ⊆ q ∨ pᶜ ⊆ qᶜ) := by
-  unfold questionEntails
-  rw [alt_polar_of_nontrivial hne_p hnu_p,
-      alt_polar_of_nontrivial hne_q hnu_q]
-  simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
-  refine ⟨?_, ?_⟩
-  · intro h
-    refine ⟨?_, ?_⟩
-    · obtain ⟨r, (rfl | rfl), hr⟩ := h p (Or.inl rfl)
-      · exact Or.inl hr
-      · exact Or.inr hr
-    · obtain ⟨r, (rfl | rfl), hr⟩ := h pᶜ (Or.inr rfl)
-      · exact Or.inl hr
-      · exact Or.inr hr
-  · rintro ⟨hp, hpc⟩ r (rfl | rfl)
-    · rcases hp with h | h
-      · exact ⟨q, Or.inl rfl, h⟩
-      · exact ⟨qᶜ, Or.inr rfl, h⟩
-    · rcases hpc with h | h
-      · exact ⟨q, Or.inl rfl, h⟩
-      · exact ⟨qᶜ, Or.inr rfl, h⟩
+  simp only [questionEntails, alt_polar_of_nontrivial hne_p hnu_p,
+    alt_polar_of_nontrivial hne_q hnu_q, Set.mem_insert_iff,
+    Set.mem_singleton_iff, forall_eq_or_imp, forall_eq, exists_eq_or_imp,
+    exists_eq_left]
 
 theorem moveRelevant_polar_iff {p : Set W} {qud : Question W}
     {subquestions : List (Question W)}
@@ -309,15 +171,8 @@ theorem moveRelevant_polar_iff {p : Set W} {qud : Question W}
     moveRelevant (Question.polar p) qud subquestions ↔
       (partiallyAnswers qud p ∨ ∃ Q ∈ subquestions, partiallyAnswers Q p) ∨
       (partiallyAnswers qud pᶜ ∨ ∃ Q ∈ subquestions, partiallyAnswers Q pᶜ) := by
-  unfold moveRelevant
-  rw [alt_polar_of_nontrivial hne hnu]
-  simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
-  refine ⟨?_, ?_⟩
-  · rintro ⟨a, (rfl | rfl), h⟩
-    · exact Or.inl h
-    · exact Or.inr h
-  · rintro (h | h)
-    · exact ⟨p, Or.inl rfl, h⟩
-    · exact ⟨pᶜ, Or.inr rfl, h⟩
+  simp only [moveRelevant, alt_polar_of_nontrivial hne hnu,
+    Set.mem_insert_iff, Set.mem_singleton_iff, exists_eq_or_imp,
+    exists_eq_left]
 
 end Question

--- a/Linglib/Semantics/Questions/Resolution.lean
+++ b/Linglib/Semantics/Questions/Resolution.lean
@@ -38,9 +38,9 @@ Given a state `σ : Set W` and a question `Q : Question W`:
   weak / intermediate / strong / relativized exhaustivity ladder
   ([heim-1994], [george-2011], [xiang-2022]).
 
-- **partiallyResolves**: re-export of `Question.Relevance.partiallyAnswers`
-  ([roberts-2012] Def. 3a). σ settles at least one alternative either
-  positively (`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`).
+- **`Question.partiallyAnswers`** (`Relevance.lean`, [roberts-2012] (3a)):
+  σ settles at least one alternative either positively (`σ ⊆ p`) or
+  negatively (`σ ⊆ pᶜ`); bridged below by `resolves_imp_partiallyAnswers`.
 
 - **CompletelyResolves**: σ entails every alternative —
   `∀ p ∈ alt Q, σ ⊆ p`. The over-strong "intersection" reading; mostly

--- a/Linglib/Semantics/Questions/Support.lean
+++ b/Linglib/Semantics/Questions/Support.lean
@@ -40,9 +40,9 @@ canonical one).
 
 ## Specialisations
 
-* `Question.Relevance` — `partiallyAnswers` and `moveRelevant`
-  (Roberts QUD-relevance) over `Question W`. Specific notions, not a
-  typeclass.
+* `Relevance.lean` — `Question.partiallyAnswers` and
+  `Question.moveRelevant` (Roberts QUD-relevance) over `Question W`.
+  Specific notions, not a typeclass.
 * `Semantics.Questions.Resolution` — `Resolves`, `MentionSome`,
   `MentionAll` over `Set W → Question W`. Each is a candidate `Support`
   instance for the inquisitive substrate.

--- a/Linglib/Studies/Booth2022.lean
+++ b/Linglib/Studies/Booth2022.lean
@@ -23,7 +23,7 @@ combine both.
 
 ## Substrate alignment
 
-- `Question W` (`Core/Question/Basic.lean`) supplies subset-closed
+- `Question W` (`Semantics/Questions/Basic.lean`) supplies subset-closed
   families of states with `∅`-membership — Booth Definition 10's `P°`
   constraint becomes a `Question`. `BilatInqProp` is then paired
   `Questions` plus a no-substantive-overlap field.

--- a/Linglib/Studies/FarkasRoelofsen2017.lean
+++ b/Linglib/Studies/FarkasRoelofsen2017.lean
@@ -72,7 +72,7 @@ to give a uniform account of the six sentence types in (3)–(8):
 - Full inquisitive-semantic compositional machinery of §4.2 (how
   clause-type markers combine with sentence radicals at the type level).
   The proposition-as-set-of-alternatives apparatus is available in
-  `Core/Question/`; this study uses bare `Set W` for content because
+  `Semantics/Questions/`; this study uses bare `Set W` for content because
   the paper-anchored felicity claims do not require alternative-set
   arithmetic.
 - Sections 6–7 of the paper (extensions: alternative-question marking,

--- a/Linglib/Studies/Ginzburg2012/Basic.lean
+++ b/Linglib/Studies/Ginzburg2012/Basic.lean
@@ -674,7 +674,7 @@ as *partitions* of worlds (Hamblin/Groenendijk-Stokhof style); KOS
 treats QUD entries as `InfoStruc`s carrying the question + FECs.
 
 Structural agreement: the push/pop semantics agree. We use the partition
-substrate from `Core/Question/Partition/QUD.lean` to demonstrate. -/
+substrate from `Semantics/Questions/Partition/QUD.lean` to demonstrate. -/
 
 /-- Both Roberts QUD-stack semantics and KOS InfoStruc-stack semantics
 push and pop in the same way: the topmost question is the most recent. -/

--- a/Linglib/Studies/Roberts2012.lean
+++ b/Linglib/Studies/Roberts2012.lean
@@ -40,11 +40,12 @@ q_ai (H beans?) q_aii (H tofu?) q_bi (R beans?) q_bii (R tofu?)
 
 ## Representation
 
-This file uses `Question` (Set-based, with `Prop` + `Decidable` Roberts QUD
-predicates from `Core/Question/Relevance.lean`). Non-polar issues are built via
-`Question.ofList` and `⊓`; entailment for these uses the `HasAltList` infrastructure
-from `Core/Question/Hamblin.lean`. Set-based partitions live in
-`Core/Question/Partition.lean` (`Question.IsPartition`, backed by
+This file uses `Question` (Set-based, with the `Prop` Roberts QUD predicates
+from `Semantics/Questions/Relevance.lean`, reduced to decidable `Set`
+inclusions via the `_polar_iff` lemmas). Non-polar issues are built via
+`Question.ofList` and `⊓`; entailment for these goes through the lattice
+route (`questionEntails_of_le'`). Set-based partitions live in
+`Semantics/Questions/Partition/` (`Question.IsPartition`, backed by
 `Setoid.IsPartition`).
 -/
 

--- a/Linglib/Studies/Roberts2012.lean
+++ b/Linglib/Studies/Roberts2012.lean
@@ -54,6 +54,9 @@ namespace Roberts2012
 open Question
 open Discourse (QUDStack Strategy moveRelevantToStrategy)
 
+-- `decide` on `Set`-subset goals from the `_polar_iff` reductions.
+attribute [local instance] Set.decidableSubsetOfFintype
+
 -- ════════════════════════════════════════════════════
 -- § D₀ World Space
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/VanRooy2003.lean
+++ b/Linglib/Studies/VanRooy2003.lean
@@ -252,7 +252,7 @@ is reflexive (`questionEntails_refl`) and transitive
     direction is now `Core.DecisionTheory.questionUtility_split_ge` (a finer
     partition has `EUV ≥` the coarser one, for every decision problem). The
     remaining gap to the full `questionEntails`-level *iff* is (i) a
-    `Question W → Finset (Finset W)` partition-cell bridge via `HasAltList`, and
+    `Question W → Finset (Finset W)` finite-alternatives partition-cell adapter, and
     (ii) the [blackwell-1953] converse
     `ProbabilityTheory.isGarblingOf_of_blackwellDominates`. -/
 theorem decisionRelevance_preserved_under_cover
@@ -277,7 +277,7 @@ of [blackwell-1953]". We state it over [groenendijk-stokhof-1984] partition cell
 with a proper prior.
 
 (The lift to the type-level `Question.questionEntails`/`Question W` is the remaining
-mechanical step: a `HasAltList Q → Finset (Finset W)` adapter via `Set.Finite.toFinset`,
+mechanical step: an `alt Q → Finset (Finset W)` adapter via `Set.Finite.toFinset`,
 discharging `questionEntails` against this cell refinement.) -/
 
 /-- **[van-rooy-2003] §4.1 Fact, the `⟹` ("only if") direction** (p. 743): a finer question


### PR DESCRIPTION
Deep-audit cleanse of the Roberts (2012) QUD relevance module.

- trim the unreachable `HasAltList`/`Decidable` layer (no instance was ever constructible; consumers use the `_polar_iff` + lattice routes); keep the live `Set.decidableSubsetOfFintype`, re-namespaced and marked [UPSTREAM]
- add `le_of_questionEntails`/`questionEntails_iff_le` (Roberts entailment ≡ inquisitive ≤ under finiteness); weaken `questionEntails_of_le'` to `[Finite W]`
- drop `DecisionTheory`'s vestigial Relevance import; sweep stale `Core/Question/` docstring paths; module-docstring fidelity notes verified against the Roberts 2012 and IKW 2025 PDFs