### PR TITLE
refactor(Semantics/Questions): unify answerhood square under Question

### DIFF
--- a/Linglib/Discourse/QUD/Basic.lean
+++ b/Linglib/Discourse/QUD/Basic.lean
@@ -101,19 +101,19 @@ variable {W : Type*}
 QUD or one of the subquestions. -/
 def moveRelevant (den qud : Question W) (subquestions : List (Question W)) : Prop :=
   ∃ a ∈ Question.alt den,
-    Question.partiallyAnswers qud a ∨
-      ∃ q ∈ subquestions, Question.partiallyAnswers q a
+    Question.PartiallyAnswers a qud ∨
+      ∃ q ∈ subquestions, Question.PartiallyAnswers a q
 
 /-- A discourse move is relevant to a strategy if some alternative of
     `den` partially answers some question in the strategy. -/
 def moveRelevantToStrategy (den : Question W) (strat : Strategy W) : Prop :=
-  ∃ a ∈ Question.alt den, ∃ q ∈ strat.allQuestions, Question.partiallyAnswers q a
+  ∃ a ∈ Question.alt den, ∃ q ∈ strat.allQuestions, Question.PartiallyAnswers a q
 
 /-- A move is relevant if one of its alternatives partially answers the
 QUD directly, with no subquestions. -/
 theorem moveRelevant_of_partiallyAnswers
     {den qud : Question W} {a : Set W} (ha : a ∈ Question.alt den)
-    (h : Question.partiallyAnswers qud a) :
+    (h : Question.PartiallyAnswers a qud) :
     moveRelevant den qud [] :=
   ⟨a, ha, Or.inl h⟩
 
@@ -134,10 +134,10 @@ theorem moveRelevant_polar_iff {p : Set W} {qud : Question W}
     {subquestions : List (Question W)}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     moveRelevant (Question.polar p) qud subquestions ↔
-      (Question.partiallyAnswers qud p ∨
-        ∃ Q ∈ subquestions, Question.partiallyAnswers Q p) ∨
-      (Question.partiallyAnswers qud pᶜ ∨
-        ∃ Q ∈ subquestions, Question.partiallyAnswers Q pᶜ) := by
+      (Question.PartiallyAnswers p qud ∨
+        ∃ Q ∈ subquestions, Question.PartiallyAnswers p Q) ∨
+      (Question.PartiallyAnswers pᶜ qud ∨
+        ∃ Q ∈ subquestions, Question.PartiallyAnswers pᶜ Q) := by
   simp only [moveRelevant, Question.alt_polar_of_nontrivial hne hnu,
     Set.mem_insert_iff, Set.mem_singleton_iff, exists_eq_or_imp,
     exists_eq_left]

--- a/Linglib/Semantics/Questions/Exhaustivity.lean
+++ b/Linglib/Semantics/Questions/Exhaustivity.lean
@@ -47,7 +47,6 @@ universe u
 variable {W : Type u}
 
 open Question
-open Semantics.Questions.Resolution
 
 /-! ### Weak exhaustivity (Heim 1994 / Karttunen 1977) -/
 

--- a/Linglib/Semantics/Questions/Resolution.lean
+++ b/Linglib/Semantics/Questions/Resolution.lean
@@ -6,10 +6,11 @@ import Linglib.Semantics.Questions.Hamblin
 [ciardelli-groenendijk-roelofsen-2018] [theiler-etal-2018] [roberts-2012] [groenendijk-stokhof-1984]
 
 Canonical Prop-valued answerhood predicates over the inquisitive
-substrate (`Question W`). One topical home for the "what does it
-mean for a state σ to answer a question Q?" question, with definitions
-chosen to match modern (CGR 2018) formal-semantics consensus rather
-than the historical Hamblin/Karttunen/G&S conventions.
+substrate (`Question W`), all in the `Question` namespace with the state
+argument first. One topical home for the "what does it mean for a state
+σ to answer a question Q?" question, with definitions chosen to match
+modern (CGR 2018) formal-semantics consensus rather than the historical
+Hamblin/Karttunen/G&S conventions.
 
 ## The notions formalised
 
@@ -37,11 +38,11 @@ Given a state `σ : Set W` and a question `Q : Question W`:
   weak / intermediate / strong / relativized exhaustivity ladder
   ([heim-1994], [george-2011], [xiang-2022]).
 
-- **`Question.partiallyAnswers`** ([roberts-2012] (3a), its non-contextual
-  core — the paper relativizes entailment to the common ground): σ settles
-  at least one alternative either positively (`σ ⊆ p`) or negatively
+- **PartiallyAnswers** ([roberts-2012] (3a), its non-contextual core —
+  the paper relativizes entailment to the common ground): σ settles at
+  least one alternative either positively (`σ ⊆ p`) or negatively
   (`σ ⊆ pᶜ`); `∅` vacuously answers everything, as there. Bridged by
-  `resolves_imp_partiallyAnswers`.
+  `Resolves.partiallyAnswers`.
 
 - **CompletelyResolves**: σ entails every alternative —
   `∀ p ∈ alt Q, σ ⊆ p`. The over-strong "intersection" reading; mostly
@@ -49,7 +50,7 @@ Given a state `σ : Set W` and a question `Q : Question W`:
   comparison point with `MentionAll`.
 
 The four form the quantifier × polarity square of answerhood: `Resolves`
-(∃, positive), `partiallyAnswers` (∃, either), `CompletelyResolves`
+(∃, positive), `PartiallyAnswers` (∃, either), `CompletelyResolves`
 (∀, positive), `MentionAll` (∀, either).
 
 ## Why this file
@@ -68,110 +69,74 @@ namespace Question
 
 variable {W : Type*}
 
-/-- `σ` partially answers `P` if it settles some alternative positively
-(`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`). -/
-def partiallyAnswers (P : Question W) (σ : Set W) : Prop :=
-  ∃ p ∈ alt P, σ ⊆ p ∨ σ ⊆ pᶜ
-
-theorem partiallyAnswers_polar_iff {p σ : Set W}
-    (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
-    partiallyAnswers (polar p) σ ↔ σ ⊆ p ∨ σ ⊆ pᶜ := by
-  simp only [partiallyAnswers, alt_polar_of_nontrivial hne hnu,
-    Set.mem_insert_iff, Set.mem_singleton_iff, exists_eq_or_imp,
-    exists_eq_left, compl_compl]
-  tauto
-
-end Question
-
-namespace Semantics.Questions.Resolution
-
-universe u
-variable {W : Type u}
-
-open Question
-
-/-- `σ` **resolves** `Q`: settles at least one alternative.
-    The standard inquisitive resolution relation
-    ([ciardelli-groenendijk-roelofsen-2018]). The
-    [groenendijk-stokhof-1984] Ch. VI §5 "mention-some" notion is
-    this same predicate; the literature's `MentionSome` is just
-    `Resolves` applied to a singleton-witness. -/
+/-- `σ` resolves `Q` if it settles at least one alternative. The standard
+inquisitive resolution relation ([ciardelli-groenendijk-roelofsen-2018]);
+the [groenendijk-stokhof-1984] "mention-some" notion is this same
+predicate. -/
 def Resolves (σ : Set W) (Q : Question W) : Prop :=
   ∃ p ∈ alt Q, σ ⊆ p
 
-/-- **Mention-all** answer: σ decides every alternative.
-    For each alternative `p`, σ either entails `p` (`σ ⊆ p`) or rules
-    `p` out (`σ ⊆ pᶜ`). On partition questions this is equivalent to σ
-    being contained in a single cell. -/
+/-- `σ` partially answers `Q` if it settles some alternative positively
+(`σ ⊆ p`) or negatively (`σ ⊆ pᶜ`). -/
+def PartiallyAnswers (σ : Set W) (Q : Question W) : Prop :=
+  ∃ p ∈ alt Q, σ ⊆ p ∨ σ ⊆ pᶜ
+
+/-- `σ` mention-all answers `Q` if it decides every alternative, either
+entailing it or ruling it out. -/
 def MentionAll (σ : Set W) (Q : Question W) : Prop :=
   ∀ p ∈ alt Q, σ ⊆ p ∨ σ ⊆ pᶜ
 
-/-- **Completely resolves**: σ entails every alternative simultaneously.
-    `∀ p ∈ alt Q, σ ⊆ p`, equivalent to `σ ⊆ ⋂ alt Q`. Vacuous for
-    questions whose alternatives have empty intersection (most
-    interesting questions). Included to make the contrast with
-    `MentionAll` explicit. -/
+/-- `σ` completely resolves `Q` if it entails every alternative
+simultaneously; vacuous for questions with disjoint alternatives. -/
 def CompletelyResolves (σ : Set W) (Q : Question W) : Prop :=
   ∀ p ∈ alt Q, σ ⊆ p
 
+variable {σ : Set W} {Q : Question W}
+
 /-! ### Basic relationships -/
 
-/-- Resolving implies partially answering the question (the positive
-    disjunct of `Question.partiallyAnswers` fires). -/
-theorem resolves_imp_partiallyAnswers
-    (σ : Set W) (Q : Question W) :
-    Resolves σ Q → Question.partiallyAnswers Q σ := by
-  rintro ⟨p, hp, hsub⟩
-  exact ⟨p, hp, Or.inl hsub⟩
+/-- Resolving implies partially answering: the positive disjunct fires. -/
+theorem Resolves.partiallyAnswers (h : Resolves σ Q) :
+    PartiallyAnswers σ Q :=
+  let ⟨p, hp, hsub⟩ := h
+  ⟨p, hp, Or.inl hsub⟩
 
-/-- Completely resolving implies mention-all (the positive disjunct fires
-    at every alternative). -/
-theorem completelyResolves_imp_mentionAll
-    (σ : Set W) (Q : Question W) :
-    CompletelyResolves σ Q → MentionAll σ Q :=
-  fun h p hp => Or.inl (h p hp)
+/-- Completely resolving implies mention-all: the positive disjunct fires
+at every alternative. -/
+theorem CompletelyResolves.mentionAll (h : CompletelyResolves σ Q) :
+    MentionAll σ Q :=
+  fun p hp => Or.inl (h p hp)
 
 /-! ### Bridge to `Question.Support`
 
 `Resolves σ Q` (alt-witnessed) and `Support.supports σ Q := σ ∈ Q.props`
 (CGR support, downward-closed) are two views on the same intuitive
-notion. The CGR side is the foundational definition (a state supports
-the issue iff it is a resolving proposition); `Resolves` is the
+notion. The CGR side is the foundational definition; `Resolves` is the
 alt-witnessed corollary, equivalent under finiteness of `Q.props`. -/
 
-/-- `Resolves` (alt-witness) implies `Support.supports` (CGR
-    membership): an alt is a resolving proposition, so any state below
-    an alt is a resolving proposition by `downward_closed`. -/
-theorem resolves_imp_supports (σ : Set W) (Q : Question W) :
-    Resolves σ Q → Question.Support.supports σ Q := by
-  rintro ⟨p, hp, hsub⟩
-  exact Q.downward_closed p (Question.alt_subset_props _ hp) σ hsub
+/-- An alt witness is a resolving proposition, so any state below it is
+one by downward closure. -/
+theorem Resolves.supports (h : Resolves σ Q) : Support.supports σ Q :=
+  let ⟨p, hp, hsub⟩ := h
+  Q.downward_closed p (alt_subset_props _ hp) σ hsub
 
-/-- Under finiteness of `Q.props`, `Support.supports` (CGR membership)
-    yields an alt witness via `Question.exists_alt_above` — recovering
-    `Resolves`. The two notions are equivalent when alternatives form
-    a finite antichain (the typical empirical case). -/
-theorem supports_imp_resolves (σ : Set W) (Q : Question W)
-    (hFin : Q.props.Finite) :
-    Question.Support.supports σ Q → Resolves σ Q := by
-  intro hσ
-  exact Question.exists_alt_above Q hFin hσ
+/-- Under finiteness of `Q.props`, CGR support yields an alt witness via
+`exists_alt_above`. -/
+theorem resolves_of_supports (hFin : Q.props.Finite)
+    (h : Support.supports σ Q) : Resolves σ Q :=
+  exists_alt_above Q hFin h
 
-/-- Equivalence of `Resolves` and `Support.supports` under finiteness. -/
-theorem resolves_iff_supports (σ : Set W) (Q : Question W)
-    (hFin : Q.props.Finite) :
-    Resolves σ Q ↔ Question.Support.supports σ Q :=
-  ⟨resolves_imp_supports σ Q, supports_imp_resolves σ Q hFin⟩
+/-- `Resolves` and `Support.supports` coincide under finiteness. -/
+theorem resolves_iff_supports (hFin : Q.props.Finite) :
+    Resolves σ Q ↔ Support.supports σ Q :=
+  ⟨Resolves.supports, resolves_of_supports hFin⟩
 
-/-! ### Per-constructor characterizations
+/-! ### Polar reduction
 
-Iff lemmas for the inquisitive constructors `polar` and `which`. These
-are the joints that consumer-side study files build on. -/
+Iff lemmas reducing the square on nontrivial `polar p` to plain `Set`
+inclusions — the joints consumer-side study files build on. -/
 
-/-- `Resolves σ (polar p)`: σ entails `p` or σ entails `pᶜ`. (For
-    nontrivial polar; the trivial cases collapse to ⊤.) -/
-theorem Resolves_polar_iff_of_nontrivial {p : Set W} (σ : Set W)
-    (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
+theorem resolves_polar_iff {p : Set W} (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     Resolves σ (polar p) ↔ σ ⊆ p ∨ σ ⊆ pᶜ := by
   unfold Resolves
   constructor
@@ -183,8 +148,15 @@ theorem Resolves_polar_iff_of_nontrivial {p : Set W} (σ : Set W)
     · exact ⟨p, (mem_alt_polar_of_nontrivial hne hnu p).mpr (Or.inl rfl), h⟩
     · exact ⟨pᶜ, (mem_alt_polar_of_nontrivial hne hnu pᶜ).mpr (Or.inr rfl), h⟩
 
-/-- `MentionAll σ (polar p)`: σ decides `p`. (For nontrivial polar.) -/
-theorem MentionAll_polar_iff_of_nontrivial {p : Set W} (σ : Set W)
+theorem partiallyAnswers_polar_iff {p : Set W}
+    (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
+    PartiallyAnswers σ (polar p) ↔ σ ⊆ p ∨ σ ⊆ pᶜ := by
+  simp only [PartiallyAnswers, alt_polar_of_nontrivial hne hnu,
+    Set.mem_insert_iff, Set.mem_singleton_iff, exists_eq_or_imp,
+    exists_eq_left, compl_compl]
+  tauto
+
+theorem mentionAll_polar_iff {p : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     MentionAll σ (polar p) ↔ σ ⊆ p ∨ σ ⊆ pᶜ := by
   unfold MentionAll
@@ -200,28 +172,21 @@ theorem MentionAll_polar_iff_of_nontrivial {p : Set W} (σ : Set W)
       · right; rw [compl_compl]; exact h
       · left; exact h
 
-/-! ### Decidability for polar questions
+/-! ### Decidability for polar questions -/
 
-Under standard finiteness + decidability hypotheses, the substrate
-predicates `Resolves`, `MentionAll`, `CompletelyResolves` for a
-nontrivial `polar p` question are all decidable. These reduce to
-"`σ ⊆ p ∨ σ ⊆ pᶜ`" via the per-constructor characterizations above. -/
-
-/-- `Resolves σ (polar p)` is decidable when `σ ⊆ p` and `σ ⊆ pᶜ` are
-    decidable and `p`'s nontriviality is given. -/
+/-- `Resolves σ (polar p)` is decidable when the two inclusions are. -/
 def Resolves.decidable_polar {p σ : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ)
     [Decidable (σ ⊆ p)] [Decidable (σ ⊆ pᶜ)] :
     Decidable (Resolves σ (polar p)) :=
-  decidable_of_iff _ (Resolves_polar_iff_of_nontrivial σ hne hnu).symm
+  decidable_of_iff _ (resolves_polar_iff hne hnu).symm
 
-/-- `MentionAll σ (polar p)` is decidable under the same hypotheses as
-    `Resolves`. The two are equivalent on polar questions: deciding
-    `p` is the only requirement. -/
+/-- `MentionAll σ (polar p)` is decidable under the same hypotheses:
+on polar questions it coincides with `Resolves`. -/
 def MentionAll.decidable_polar {p σ : Set W}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ)
     [Decidable (σ ⊆ p)] [Decidable (σ ⊆ pᶜ)] :
     Decidable (MentionAll σ (polar p)) :=
-  decidable_of_iff _ (MentionAll_polar_iff_of_nontrivial σ hne hnu).symm
+  decidable_of_iff _ (mentionAll_polar_iff hne hnu).symm
 
-end Semantics.Questions.Resolution
+end Question

--- a/Linglib/Semantics/Questions/Support.lean
+++ b/Linglib/Semantics/Questions/Support.lean
@@ -40,12 +40,12 @@ canonical one).
 
 ## Specialisations
 
-* `Question.partiallyAnswers` (`Resolution.lean`) and
+* `Question.PartiallyAnswers` (`Resolution.lean`) and
   `Discourse.moveRelevant` (`Discourse/QUD/Basic.lean`) — Roberts
   QUD-relevance over `Question W`. Specific notions, not a typeclass.
-* `Semantics.Questions.Resolution` — `Resolves`, `MentionSome`,
-  `MentionAll` over `Set W → Question W`. Each is a candidate `Support`
-  instance for the inquisitive substrate.
+* `Question.Resolves` / `Question.MentionAll` (`Resolution.lean`) over
+  `Set W → Question W`. Each is a candidate `Support` instance for the
+  inquisitive substrate.
 * `Studies/IppolitoKissWilliams2022.lean` — IKW
   evidential SUPPORT (introduced in [ippolito-kiss-williams-2022],
   reused by [ippolito-kiss-williams-2025]): doxastic +

--- a/Linglib/Studies/CiardelliGroenendijkRoelofsen2018.lean
+++ b/Linglib/Studies/CiardelliGroenendijkRoelofsen2018.lean
@@ -109,7 +109,7 @@ namespace CiardelliGroenendijkRoelofsen2018
 universe u
 variable {W : Type u}
 
-open Question Semantics.Questions.Resolution
+open Question
 
 /-! ### §2.4.1 Truth and support
 

--- a/Linglib/Studies/Dayal2016.lean
+++ b/Linglib/Studies/Dayal2016.lean
@@ -60,7 +60,7 @@ holds (`IsExhaustivelyResolvable`).
 
 namespace Dayal2016
 
-open Question Semantics.Questions.Resolution
+open Question
 open Semantics.Questions.Exhaustivity
 
 variable {W : Type*}

--- a/Linglib/Studies/Fox2018.lean
+++ b/Linglib/Studies/Fox2018.lean
@@ -66,7 +66,7 @@ informative true Hamblin alternative.
 
 namespace Fox2018
 
-open Question Semantics.Questions.Resolution
+open Question
 open Semantics.Questions.Exhaustivity
 
 variable {W : Type*}

--- a/Linglib/Studies/George2011.lean
+++ b/Linglib/Studies/George2011.lean
@@ -77,7 +77,7 @@ of all alternatives true at `w`.
 
 namespace George2011
 
-open Question Semantics.Questions.Resolution
+open Question
 open Semantics.Questions.Exhaustivity
 
 variable {W : Type*}

--- a/Linglib/Studies/Heim1994.lean
+++ b/Linglib/Studies/Heim1994.lean
@@ -66,7 +66,7 @@ contexts).
 
 namespace Heim1994
 
-open Question Semantics.Questions.Resolution
+open Question
 open Semantics.Questions.Exhaustivity
 
 variable {W : Type*}

--- a/Linglib/Studies/Karttunen1977.lean
+++ b/Linglib/Studies/Karttunen1977.lean
@@ -21,7 +21,7 @@ meaning postulate (§2.4 fn 11) for `know` is exactly
 `Exhaustivity.weakAnswer Q w` — the conjunction (intersection) of
 all true alternatives.
 
-The substrate joints (`alt_polar_iff`, `Resolves_polar_iff`,
+The substrate joints (`alt_polar_iff`, `resolves_polar_iff`,
 `trueAlternatives_polar_iff_of_nontrivial`, `weakAnswer_polar_of_pos`,
 `weakAnswer_polar_of_neg`) live in `Question.Hamblin`,
 `Resolution.lean`, and `Exhaustivity.lean`. This file uses them to
@@ -55,7 +55,7 @@ substrate is in place.
 
 namespace Karttunen1977
 
-open Question Semantics.Questions.Resolution
+open Question
 open Semantics.Questions.Exhaustivity
 
 variable {W : Type*}

--- a/Linglib/Studies/Roberts2012.lean
+++ b/Linglib/Studies/Roberts2012.lean
@@ -20,7 +20,7 @@ formal theory of pragmatics" (Semantics & Pragmatics 5(6): 1–69).
 2. **Strategy of inquiry** — recursive question decomposition (`Strategy`):
    answering all subquestions answers the parent.
 3. **Negative partial answerhood** — a proposition partially answers a question
-   by ruling out an alternative, not just confirming one (`partiallyAnswers`).
+   by ruling out an alternative, not just confirming one (`PartiallyAnswers`).
 4. **Q-A congruence** — the focus alternatives of an answer equal the QUD
    alternatives (grounded by the Rooth–Hamblin type identity).
 
@@ -43,7 +43,7 @@ q_ai (H beans?) q_aii (H tofu?) q_bi (R beans?) q_bii (R tofu?)
 ## Representation
 
 This file uses `Question` (Set-based, with `Question.Entails` from
-`Entailment.lean`, `Question.partiallyAnswers` from `Resolution.lean`, and
+`Entailment.lean`, `Question.PartiallyAnswers` from `Resolution.lean`, and
 `Discourse.moveRelevant`, all reduced to decidable `Set` inclusions via
 the `_polar_iff` lemmas). Non-polar issues are built via
 `Question.ofList` and `⊓`; entailment for these goes through the lattice
@@ -563,14 +563,14 @@ theorem stack_3_qud : stack_3.immediateQUD = some q_a := rfl
 /-- "Hannah didn't eat beans" (`hannahBeansᶜ`) negatively partially answers
     "Did Hannah eat beans?" — it rules out the `hannahBeans` alternative. -/
 theorem neg_hb_partially_answers_qai :
-    partiallyAnswers q_ai (hannahBeansᶜ : Set D0World) := by
+    PartiallyAnswers (hannahBeansᶜ : Set D0World) q_ai := by
   rw [partiallyAnswers_polar_iff hb_ne_empty hb_ne_univ]
   decide
 
 /-- "Hannah didn't eat beans" also partially answers "What did Hannah eat?" —
     it rules out the `qa_c1` (Hannah-beans-only) alternative. -/
 theorem neg_hb_partially_answers_qa :
-    partiallyAnswers q_a (hannahBeansᶜ : Set D0World) := by
+    PartiallyAnswers (hannahBeansᶜ : Set D0World) q_a := by
   refine ⟨qa_c1, qa_c1_in_alt, Or.inr ?_⟩
   intro w hw hw'
   exact hw hw'.1
@@ -581,14 +581,14 @@ theorem neg_hb_partially_answers_qa :
 
 /-- "Hannah ate beans" positively partially answers q_ai. -/
 theorem hb_partially_answers_qai :
-    partiallyAnswers q_ai hannahBeans := by
+    PartiallyAnswers hannahBeans q_ai := by
   rw [partiallyAnswers_polar_iff hb_ne_empty hb_ne_univ]
   decide
 
 /-- "Hannah ate beans" partially answers the Big Question — it rules out
     the `{w_zero}` (all-false) alternative. -/
 theorem hb_partially_answers_q1 :
-    partiallyAnswers q_1 hannahBeans := by
+    PartiallyAnswers hannahBeans q_1 := by
   refine ⟨{w_zero}, singleton_w_zero_in_alt_q1, Or.inr ?_⟩
   intro w hw hw'
   rw [Set.mem_singleton_iff] at hw'

--- a/Linglib/Studies/Umbach2004.lean
+++ b/Linglib/Studies/Umbach2004.lean
@@ -359,7 +359,7 @@ def roomYesDishesNo : Set CDWorld := {x | roomDishesEquiv x .roomOnly}
     the confirm+deny pattern corresponds to one cell of the implicit
     conjunctive question. -/
 theorem confirm_deny_is_partial_answer :
-    Question.partiallyAnswers roomDishesQUD roomYesDishesNo :=
+    Question.PartiallyAnswers roomYesDishesNo roomDishesQUD :=
   ⟨roomYesDishesNo,
    Question.class_mem_alt_fromSetoid roomDishesEquiv
      (Setoid.mem_classes roomDishesEquiv .roomOnly),

--- a/Linglib/Studies/Xiang2022.lean
+++ b/Linglib/Studies/Xiang2022.lean
@@ -66,7 +66,7 @@ defer that lift and work with the propositional projection here.
 
 namespace Xiang2022
 
-open Question Semantics.Questions.Resolution
+open Question
 open Semantics.Questions.Exhaustivity
 
 variable {W : Type*}


### PR DESCRIPTION
Unify the answerhood square in one namespace, argument order, and casing: `Question.Resolves σ Q` / `PartiallyAnswers σ Q` / `MentionAll σ Q` / `CompletelyResolves σ Q` (state-first; `partiallyAnswers Q σ` flipped, `Semantics.Questions.Resolution` namespace dissolved, 7 studies' open-lines simplified).

- bridge lemmas dot-style: `Resolves.partiallyAnswers`, `Resolves.supports`, `CompletelyResolves.mentionAll`
- polar reductions uniformly `*_polar_iff` (drop `_of_nontrivial`, fix UpperCamel lemma casings)