### PR TITLE
feat(Core/Order): KleeneLattice class; Trivalent carrier and namespace

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -196,7 +196,7 @@ import Linglib.Core.Logic.Team.Definability
 import Linglib.Core.Logic.Temporal.Basic
 import Linglib.Core.Logic.Temporal.Defs
 import Linglib.Core.Logic.Temporal.Soundness
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.TweetyNixon
 import Linglib.Core.ModelTheory.Trivalent
 import Linglib.Core.Optimization.Decoder

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -226,6 +226,7 @@ import Linglib.Core.Order.ComparativeProbability.Entailments
 import Linglib.Core.Order.ComparativeProbability.Patterns
 import Linglib.Core.Order.ComparativeProbability.Representability
 import Linglib.Core.Order.ComparativeProbability.Systems
+import Linglib.Core.Order.DeMorganAlgebra
 import Linglib.Core.Order.ComparativeScale
 import Linglib.Core.Order.Comparison
 import Linglib.Core.Order.Flat

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -226,7 +226,8 @@ import Linglib.Core.Order.ComparativeProbability.Entailments
 import Linglib.Core.Order.ComparativeProbability.Patterns
 import Linglib.Core.Order.ComparativeProbability.Representability
 import Linglib.Core.Order.ComparativeProbability.Systems
-import Linglib.Core.Order.DeMorganAlgebra
+import Linglib.Core.Order.DeMorganAlgebra.Defs
+import Linglib.Core.Order.DeMorganAlgebra.Basic
 import Linglib.Core.Order.ComparativeScale
 import Linglib.Core.Order.Comparison
 import Linglib.Core.Order.Flat

--- a/Linglib/Core/Logic/Duality.lean
+++ b/Linglib/Core/Logic/Duality.lean
@@ -1,17 +1,17 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Mathlib.Data.Finset.Lattice.Fold
 
 /-!
-# Aggregation of `Truth3` Lists by Projection Type
+# Aggregation of `Trivalent` Lists by Projection Type
 [barwise-cooper-1981]
 
 Universal vs existential aggregation as the `⊓`/`⊔` projections of the
 ∃ ⊣ Δ ⊣ ∀ adjunction, parameterized by `ProjectionType` (declared in
-`Truth3.lean`).
+`Trivalent.lean`).
 
-## § 1. Truth3 Aggregation
+## § 1. Trivalent Aggregation
 
-- `aggregate (d : ProjectionType) : List Truth3 → Truth3` — fold by
+- `aggregate (d : ProjectionType) : List Trivalent → Trivalent` — fold by
   projection type. Conjunctive: `⊓`-fold from `⊤`. Disjunctive: `⊔`-fold
   from `⊥`.
 
@@ -27,28 +27,28 @@ namespace Trivalent
 /-- Aggregate a list according to projection type.
     Conjunctive (∀-like): `⊓`-fold from `⊤`.
     Disjunctive (∃-like): `⊔`-fold from `⊥`. -/
-def aggregate (d : ProjectionType) (l : List Truth3) : Truth3 :=
+def aggregate (d : ProjectionType) (l : List Trivalent) : Trivalent :=
   match d with
   | .disjunctive => l.foldl (· ⊔ ·) ⊥
   | .conjunctive => l.foldl (· ⊓ ·) ⊤
 
 /-- Existential (disjunctive) aggregation: true if ANY true. -/
-def existsAny (l : List Truth3) : Truth3 := aggregate .disjunctive l
+def existsAny (l : List Trivalent) : Trivalent := aggregate .disjunctive l
 
 /-- Universal (conjunctive) aggregation: true only if ALL true. -/
-def forallAll (l : List Truth3) : Truth3 := aggregate .conjunctive l
+def forallAll (l : List Trivalent) : Trivalent := aggregate .conjunctive l
 
-theorem foldl_sup_of_true (l : List Truth3) : l.foldl (· ⊔ ·) Truth3.true = .true := by
+theorem foldl_sup_of_true (l : List Trivalent) : l.foldl (· ⊔ ·) Trivalent.true = .true := by
   induction l with
   | nil => rfl
-  | cons hd tl ih => simp only [List.foldl_cons, Truth3.true_sup, ih]
+  | cons hd tl ih => simp only [List.foldl_cons, Trivalent.true_sup, ih]
 
-theorem foldl_inf_of_false (l : List Truth3) : l.foldl (· ⊓ ·) Truth3.false = .false := by
+theorem foldl_inf_of_false (l : List Trivalent) : l.foldl (· ⊓ ·) Trivalent.false = .false := by
   induction l with
   | nil => rfl
-  | cons hd tl ih => simp only [List.foldl_cons, Truth3.false_inf, ih]
+  | cons hd tl ih => simp only [List.foldl_cons, Trivalent.false_inf, ih]
 
-theorem foldl_sup_mem_true (l : List Truth3) (acc : Truth3) (h : Truth3.true ∈ l) :
+theorem foldl_sup_mem_true (l : List Trivalent) (acc : Trivalent) (h : Trivalent.true ∈ l) :
     l.foldl (· ⊔ ·) acc = .true := by
   induction l generalizing acc with
   | nil => simp at h
@@ -58,11 +58,11 @@ theorem foldl_sup_mem_true (l : List Truth3) (acc : Truth3) (h : Truth3.true ∈
     cases h with
     | inl heq =>
       subst heq
-      simp only [Truth3.sup_true, foldl_sup_of_true]
+      simp only [Trivalent.sup_true, foldl_sup_of_true]
     | inr hmem =>
       exact ih (acc ⊔ hd) hmem
 
-theorem foldl_inf_mem_false (l : List Truth3) (acc : Truth3) (h : Truth3.false ∈ l) :
+theorem foldl_inf_mem_false (l : List Trivalent) (acc : Trivalent) (h : Trivalent.false ∈ l) :
     l.foldl (· ⊓ ·) acc = .false := by
   induction l generalizing acc with
   | nil => simp at h
@@ -72,11 +72,11 @@ theorem foldl_inf_mem_false (l : List Truth3) (acc : Truth3) (h : Truth3.false �
     cases h with
     | inl heq =>
       subst heq
-      simp only [Truth3.inf_false, foldl_inf_of_false]
+      simp only [Trivalent.inf_false, foldl_inf_of_false]
     | inr hmem =>
       exact ih (acc ⊓ hd) hmem
 
-theorem existential_robust (l : List Truth3) (h : l.any (· == .true)) :
+theorem existential_robust (l : List Trivalent) (h : l.any (· == .true)) :
     existsAny l = .true := by
   simp only [existsAny, aggregate, List.any_eq_true] at *
   obtain ⟨x, hx_mem, hx_eq⟩ := h
@@ -85,7 +85,7 @@ theorem existential_robust (l : List Truth3) (h : l.any (· == .true)) :
   | false => exact absurd hx_eq (by decide)
   | indet => exact absurd hx_eq (by decide)
 
-theorem universal_fragile (l : List Truth3) (h : l.any (· == .false)) :
+theorem universal_fragile (l : List Trivalent) (h : l.any (· == .false)) :
     forallAll l = .false := by
   simp only [forallAll, aggregate, List.any_eq_true] at *
   obtain ⟨x, hx_mem, hx_eq⟩ := h
@@ -94,20 +94,20 @@ theorem universal_fragile (l : List Truth3) (h : l.any (· == .false)) :
   | true => exact absurd hx_eq (by decide)
   | indet => exact absurd hx_eq (by decide)
 
-def const {α : Type*} (t : Truth3) : α → Truth3 := λ _ => t
+def const {α : Type*} (t : Trivalent) : α → Trivalent := λ _ => t
 
-def exists' {α : Type*} (P : α → Truth3) (l : List α) : Truth3 :=
+def exists' {α : Type*} (P : α → Trivalent) (l : List α) : Trivalent :=
   existsAny (l.map P)
 
-def forall' {α : Type*} (P : α → Truth3) (l : List α) : Truth3 :=
+def forall' {α : Type*} (P : α → Trivalent) (l : List α) : Trivalent :=
   forallAll (l.map P)
 
 -- ════════════════════════════════════════════════════
--- § 1.5  Aggregation Pushforward through Truth3.ofBool
+-- § 1.5  Aggregation Pushforward through Trivalent.ofBool
 -- ════════════════════════════════════════════════════
 
 /-! The aggregation operators defined in § 1 are `List.foldl` over the
-    `Truth3` lattice. Their behavior is determined by two algebraic
+    `Trivalent` lattice. Their behavior is determined by two algebraic
     facts:
 
     1. **Idempotency** (`sup_idem`, `inf_idem`): every element of a
@@ -116,8 +116,8 @@ def forall' {α : Type*} (P : α → Truth3) (l : List α) : Truth3 :=
        .indet` gets absorbed by `.indet` after the first step (identity
        element transition).
 
-    2. **Lattice homomorphism** (`Truth3.ofBoolHom`): `ofBool` embeds
-       `Bool` into the `{⊥, ⊤}` sublattice of `Truth3`, preserving both
+    2. **Lattice homomorphism** (`Trivalent.ofBoolHom`): `ofBool` embeds
+       `Bool` into the `{⊥, ⊤}` sublattice of `Trivalent`, preserving both
        `⊔` and `⊓`. Folding lattice operations over `bs.map ofBool`
        reduces to folding the corresponding Boolean operations
        (`||`/`&&`) over `bs` — which is always definite, so the
@@ -142,7 +142,7 @@ private theorem foldl_idem_const {α : Type*} (f : α → α → α) (a : α)
     the algebraic reason "local-scope" trivalent semantics erases
     quantifier strength. -/
 theorem aggregate_replicate_indet (d : ProjectionType) (n : Nat) (hn : n > 0) :
-    aggregate d (List.replicate n Truth3.indet) = .indet := by
+    aggregate d (List.replicate n Trivalent.indet) = .indet := by
   cases n with
   | zero => omega
   | succ k =>
@@ -150,39 +150,39 @@ theorem aggregate_replicate_indet (d : ProjectionType) (n : Nat) (hn : n > 0) :
     cases d with
     | conjunctive =>
       -- ⊤ ⊓ .indet = .indet, then inf_idem
-      change (List.replicate k Truth3.indet).foldl (· ⊓ ·) Truth3.indet = Truth3.indet
-      exact foldl_idem_const (· ⊓ ·) Truth3.indet (inf_idem _) k
+      change (List.replicate k Trivalent.indet).foldl (· ⊓ ·) Trivalent.indet = Trivalent.indet
+      exact foldl_idem_const (· ⊓ ·) Trivalent.indet (inf_idem _) k
     | disjunctive =>
       -- ⊥ ⊔ .indet = .indet, then sup_idem
-      change (List.replicate k Truth3.indet).foldl (· ⊔ ·) Truth3.indet = Truth3.indet
-      exact foldl_idem_const (· ⊔ ·) Truth3.indet (sup_idem _) k
+      change (List.replicate k Trivalent.indet).foldl (· ⊔ ·) Trivalent.indet = Trivalent.indet
+      exact foldl_idem_const (· ⊔ ·) Trivalent.indet (sup_idem _) k
 
-/-- Sup-fold with `Truth3.ofBool` accumulator commutes with `||`-fold
+/-- Sup-fold with `Trivalent.ofBool` accumulator commutes with `||`-fold
     via the lattice-homomorphism property of `ofBool`. -/
 private theorem foldl_sup_ofBool_acc (bs : List Bool) (acc : Bool) :
-    (bs.map Truth3.ofBool).foldl (· ⊔ ·) (Truth3.ofBool acc) =
-    Truth3.ofBool (bs.foldl (· || ·) acc) := by
+    (bs.map Trivalent.ofBool).foldl (· ⊔ ·) (Trivalent.ofBool acc) =
+    Trivalent.ofBool (bs.foldl (· || ·) acc) := by
   induction bs generalizing acc with
   | nil => rfl
   | cons b bs ih =>
-    simp only [List.map_cons, List.foldl_cons, Truth3.ofBool_sup]
+    simp only [List.map_cons, List.foldl_cons, Trivalent.ofBool_sup]
     exact ih (acc || b)
 
-/-- Inf-fold with `Truth3.ofBool` accumulator commutes with `&&`-fold. -/
+/-- Inf-fold with `Trivalent.ofBool` accumulator commutes with `&&`-fold. -/
 private theorem foldl_inf_ofBool_acc (bs : List Bool) (acc : Bool) :
-    (bs.map Truth3.ofBool).foldl (· ⊓ ·) (Truth3.ofBool acc) =
-    Truth3.ofBool (bs.foldl (· && ·) acc) := by
+    (bs.map Trivalent.ofBool).foldl (· ⊓ ·) (Trivalent.ofBool acc) =
+    Trivalent.ofBool (bs.foldl (· && ·) acc) := by
   induction bs generalizing acc with
   | nil => rfl
   | cons b bs ih =>
-    simp only [List.map_cons, List.foldl_cons, Truth3.ofBool_inf]
+    simp only [List.map_cons, List.foldl_cons, Trivalent.ofBool_inf]
     exact ih (acc && b)
 
 /-- `List.foldl (· || ·) false = List.any id`. -/
 private theorem foldl_or_false_eq_any (bs : List Bool) :
-    bs.foldl (· || ·) false = bs.any id := by
+    bs.foldl (· || ·) Bool.false = bs.any id := by
   suffices ∀ acc, bs.foldl (· || ·) acc = (acc || bs.any id) from by
-    simp only [this false, Bool.false_or]
+    simp only [this Bool.false, Bool.false_or]
   intro acc
   induction bs generalizing acc with
   | nil => simp only [List.foldl_nil, List.any_nil, Bool.or_false]
@@ -191,45 +191,45 @@ private theorem foldl_or_false_eq_any (bs : List Bool) :
 
 /-- `List.foldl (· && ·) true = List.all id`. -/
 private theorem foldl_and_true_eq_all (bs : List Bool) :
-    bs.foldl (· && ·) true = bs.all id := by
+    bs.foldl (· && ·) Bool.true = bs.all id := by
   suffices ∀ acc, bs.foldl (· && ·) acc = (acc && bs.all id) from by
-    simp only [this true, Bool.true_and]
+    simp only [this Bool.true, Bool.true_and]
   intro acc
   induction bs generalizing acc with
   | nil => simp only [List.foldl_nil, List.all_nil, Bool.and_true]
   | cons b bs ih =>
     simp only [List.foldl_cons, List.all_cons, id, ih (acc && b), Bool.and_assoc]
 
-/-- Existential aggregation through `Truth3.ofBool` reduces to Boolean
+/-- Existential aggregation through `Trivalent.ofBool` reduces to Boolean
     disjunction. Witness of the lattice-homomorphism property of
-    `Truth3.ofBoolHom` propagating through fold. -/
+    `Trivalent.ofBoolHom` propagating through fold. -/
 theorem aggregate_existential_map_ofBool (bs : List Bool) :
-    aggregate .disjunctive (bs.map Truth3.ofBool) = Truth3.ofBool (bs.any id) := by
-  show (bs.map Truth3.ofBool).foldl (· ⊔ ·) ⊥ = Truth3.ofBool (bs.any id)
-  have h : (⊥ : Truth3) = Truth3.ofBool false := rfl
+    aggregate .disjunctive (bs.map Trivalent.ofBool) = Trivalent.ofBool (bs.any id) := by
+  show (bs.map Trivalent.ofBool).foldl (· ⊔ ·) ⊥ = Trivalent.ofBool (bs.any id)
+  have h : (⊥ : Trivalent) = Trivalent.ofBool Bool.false := rfl
   rw [h, foldl_sup_ofBool_acc, foldl_or_false_eq_any]
 
-/-- Universal aggregation through `Truth3.ofBool` reduces to Boolean
+/-- Universal aggregation through `Trivalent.ofBool` reduces to Boolean
     conjunction. -/
 theorem aggregate_universal_map_ofBool (bs : List Bool) :
-    aggregate .conjunctive (bs.map Truth3.ofBool) = Truth3.ofBool (bs.all id) := by
-  show (bs.map Truth3.ofBool).foldl (· ⊓ ·) ⊤ = Truth3.ofBool (bs.all id)
-  have h : (⊤ : Truth3) = Truth3.ofBool true := rfl
+    aggregate .conjunctive (bs.map Trivalent.ofBool) = Trivalent.ofBool (bs.all id) := by
+  show (bs.map Trivalent.ofBool).foldl (· ⊓ ·) ⊤ = Trivalent.ofBool (bs.all id)
+  have h : (⊤ : Trivalent) = Trivalent.ofBool Bool.true := rfl
   rw [h, foldl_inf_ofBool_acc, foldl_and_true_eq_all]
 
-/-- Aggregation through `Truth3.ofBool` never produces `.indet` —
+/-- Aggregation through `Trivalent.ofBool` never produces `.indet` —
     Boolean inputs leave the gap-free sublattice `{⊥, ⊤}` invariant.
     The algebraic basis for "global-scope" trivalent semantics where
     the quantifier sees only Boolean values. -/
 theorem aggregate_map_ofBool_ne_indet (d : ProjectionType) (bs : List Bool) :
-    aggregate d (bs.map Truth3.ofBool) ≠ .indet := by
+    aggregate d (bs.map Trivalent.ofBool) ≠ .indet := by
   cases d with
   | disjunctive =>
     rw [aggregate_existential_map_ofBool]
-    cases bs.any id <;> exact Truth3.noConfusion
+    cases bs.any id <;> exact Trivalent.noConfusion
   | conjunctive =>
     rw [aggregate_universal_map_ofBool]
-    cases bs.all id <;> exact Truth3.noConfusion
+    cases bs.all id <;> exact Trivalent.noConfusion
 
 /-- Mixed Boolean inputs (some true, some false) split the duality
     types: existential aggregation gives `.true`, universal gives
@@ -238,12 +238,12 @@ theorem aggregate_map_ofBool_ne_indet (d : ProjectionType) (bs : List Bool) :
     quantifier-strength contrast on mixed scenarios. -/
 theorem aggregate_map_ofBool_mixed (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    aggregate .disjunctive (bs.map Truth3.ofBool) = .true ∧
-    aggregate .conjunctive   (bs.map Truth3.ofBool) = .false := by
+    aggregate .disjunctive (bs.map Trivalent.ofBool) = .true ∧
+    aggregate .conjunctive   (bs.map Trivalent.ofBool) = .false := by
   refine ⟨?_, ?_⟩
-  · rw [aggregate_existential_map_ofBool, show bs.any id = true from h_some_true]; rfl
+  · rw [aggregate_existential_map_ofBool, show bs.any id = Bool.true from h_some_true]; rfl
   · rw [aggregate_universal_map_ofBool]
-    have h_not_all : bs.all id = false := by
+    have h_not_all : bs.all id = Bool.false := by
       rw [Bool.eq_false_iff]
       intro h_all
       obtain ⟨x, hx_mem, hx_eq⟩ := List.any_eq_true.mp h_some_false
@@ -284,8 +284,8 @@ theorem aggregate_map_ofBool_mixed (bs : List Bool)
     on `∅`), `.false` if `P` fails at every element of nonempty `s`,
     `.indet` (mixed) otherwise. The supervaluation's universal/existential
     decision pair `(∀, ∃)` is the kernel; the if-chain classifies it into
-    `Truth3`. -/
-def dist {α : Type*} (s : Finset α) (P : α → Prop) [DecidablePred P] : Truth3 :=
+    `Trivalent`. -/
+def dist {α : Type*} (s : Finset α) (P : α → Prop) [DecidablePred P] : Trivalent :=
   if ∀ a ∈ s, P a then .true
   else if ∃ a ∈ s, P a then .indet
   else .false
@@ -294,7 +294,7 @@ def dist {α : Type*} (s : Finset α) (P : α → Prop) [DecidablePred P] : Trut
     no `[DecidableEq α]` required. Same trichotomy: `.true` on (vacuously
     or genuinely) all-`P`, `.false` on nonempty-but-no-`P`, `.indet` mixed.
     Agrees with `dist l.toFinset P` when `[DecidableEq α]` is available. -/
-def distList {α : Type*} (l : List α) (P : α → Prop) [DecidablePred P] : Truth3 :=
+def distList {α : Type*} (l : List α) (P : α → Prop) [DecidablePred P] : Trivalent :=
   if ∀ a ∈ l, P a then .true
   else if ∃ a ∈ l, P a then .indet
   else .false
@@ -401,7 +401,7 @@ theorem dist_eq_indet_iff {α : Type*} (s : Finset α) (P : α → Prop) [Decida
 -- § 2. Prop-valued Quantifier Projection
 -- ════════════════════════════════════════════════════
 
-/-! The `Truth3` aggregation above (§ 1) is the decidable/three-valued
+/-! The `Trivalent` aggregation above (§ 1) is the decidable/three-valued
     version of quantifier projection. The classical `Prop`-valued
     counterparts are just `∃` and `∀` from Lean core — the left and
     right adjoints to the diagonal in the adjunction ∃ ⊣ Δ ⊣ ∀.

--- a/Linglib/Core/Logic/Duality.lean
+++ b/Linglib/Core/Logic/Duality.lean
@@ -22,7 +22,7 @@ from Lean core. De Morgan duality uses `not_forall`/`not_exists` from
 Mathlib.
 -/
 
-namespace Core.Duality
+namespace Trivalent
 
 /-- Aggregate a list according to projection type.
     Conjunctive (∀-like): `⊓`-fold from `⊤`.
@@ -430,4 +430,4 @@ theorem dist_eq_indet_iff {α : Type*} (s : Finset α) (P : α → Prop) [Decida
     characterization, sequential update with pruning).
 -/
 
-end Core.Duality
+end Trivalent

--- a/Linglib/Core/Logic/Orthologic.lean
+++ b/Linglib/Core/Logic/Orthologic.lean
@@ -108,12 +108,12 @@ theorem sound {φ ψ : Formula Var} (h : φ ⊢ ψ) (v : Var → L) :
   | refl φ => exact le_refl _
   | and_le_left φ ψ => exact inf_le_left
   | and_le_right φ ψ => exact inf_le_right
-  | le_negNeg φ => exact (OrthocomplementedLattice.compl_compl _).ge
-  | negNeg_le φ => exact (OrthocomplementedLattice.compl_compl _).le
+  | le_negNeg φ => exact (LatticeWithInvolution.compl_compl _).ge
+  | negNeg_le φ => exact (LatticeWithInvolution.compl_compl _).le
   | contradiction φ ψ => exact (OrthocomplementedLattice.inf_compl_eq_bot _).le.trans bot_le
   | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
   | le_and _ _ ih₁ ih₂ => exact le_inf ih₁ ih₂
-  | neg_le_neg _ ih => exact OrthocomplementedLattice.compl_antitone ih
+  | neg_le_neg _ ih => exact LatticeWithInvolution.compl_le_compl ih
 
 /-! ### Provability lemmas for the lattice structure
 
@@ -210,7 +210,7 @@ instance : BoundedOrder (LindenbaumTarski Var) where
 instance : OrthocomplementedLattice (LindenbaumTarski Var) where
   compl_compl a := Quotient.inductionOn a fun x =>
     Quotient.sound ⟨Derivable.negNeg_le x, Derivable.le_negNeg x⟩
-  compl_antitone {a b} := Quotient.inductionOn₂ a b
+  compl_le_compl {a b} := Quotient.inductionOn₂ a b
     (fun _ _ h => mk_le_mk.mpr (Derivable.neg_le_neg (mk_le_mk.mp h)))
   inf_compl_le_bot a := Quotient.inductionOn a fun x => mk_le_mk.mpr (Formula.and_compl_le_bot x)
   top_le_sup_compl a := Quotient.inductionOn a fun x => mk_le_mk.mpr (Formula.top_le_or_compl x)

--- a/Linglib/Core/Logic/Trivalent.lean
+++ b/Linglib/Core/Logic/Trivalent.lean
@@ -9,7 +9,7 @@ import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Order.MinMax
 import Mathlib.Data.Sign.Defs
-import Linglib.Core.Order.DeMorganAlgebra
+import Linglib.Core.Order.DeMorganAlgebra.Defs
 import Linglib.Core.Order.Flat
 
 /-!
@@ -23,7 +23,7 @@ connective families — Weak Kleene ([bochvar-1937]), Middle Kleene ([peters-197
 conditional assertion ([belnap-1970]) — and the partiality operators ∂ and 𝒜 of
 [beaver-krahmer-2001].
 
-The upstreamable algebra is the `Order.KleeneAlgebra` class (`Core/Order/DeMorganAlgebra.lean`),
+The upstreamable algebra is the `Order.KleeneAlgebra` class (`Core/Order/DeMorganAlgebra/Defs.lean`),
 of which `Trivalent` is the canonical non-Boolean instance. The dedicated carrier with
 truth-named constructors is this library's ergonomic choice; the name follows the
 `Boolean` precedent — an adjective nominalized as its truth-value type — with the
@@ -136,7 +136,7 @@ instance : Compl Trivalent := ⟨neg⟩
 /-- `Trivalent` is the canonical non-Boolean Kleene algebra (`Order.KleeneAlgebra`): a
 distributive chain with `neg` as the involutive antitone complement, failing
 complementation (`inf_compl_indet_ne_bot`). The `ᶜ` instance gives access to the class
-API (`Core/Order/DeMorganAlgebra.lean`); `neg` remains the simp-normal form. -/
+API (`Core/Order/DeMorganAlgebra/Defs.lean`); `neg` remains the simp-normal form. -/
 instance : Order.KleeneAlgebra Trivalent where
   __ := (inferInstance : DistribLattice Trivalent)
   __ := (inferInstance : BoundedOrder Trivalent)

--- a/Linglib/Core/Logic/Trivalent.lean
+++ b/Linglib/Core/Logic/Trivalent.lean
@@ -23,7 +23,7 @@ connective families — Weak Kleene ([bochvar-1937]), Middle Kleene ([peters-197
 conditional assertion ([belnap-1970]) — and the partiality operators ∂ and 𝒜 of
 [beaver-krahmer-2001].
 
-The upstreamable algebra is the `KleeneLattice` class (`Core/Order/DeMorganAlgebra.lean`),
+The upstreamable algebra is the `Order.KleeneAlgebra` class (`Core/Order/DeMorganAlgebra.lean`),
 of which `Trivalent` is the canonical non-Boolean instance. The dedicated carrier with
 truth-named constructors is this library's ergonomic choice; the name follows the
 `Boolean` precedent — an adjective nominalized as its truth-value type — with the
@@ -36,8 +36,8 @@ truth-named constructors is this library's ergonomic choice; the name follows th
   `BoundedOrder`; `Prop3 W` — trivalent propositions `W → Trivalent`.
 - `Trivalent.neg` — Strong Kleene negation: involutive (`neg_neg`), antitone
   (`neg_antitone`), De Morgan (`neg_inf`/`neg_sup`), satisfying the Kleene law
-  (`inf_neg_le_sup_neg`) — so `Trivalent` is a `KleeneLattice`, the canonical non-Boolean
-  instance (`inf_compl_indet_ne_bot`).
+  (`inf_neg_le_sup_neg`) — so `Trivalent` is an `Order.KleeneAlgebra`, the canonical
+  non-Boolean instance (`inf_compl_indet_ne_bot`).
 - `Trivalent.meetWeak`/`joinWeak`, `meetMiddle`/`joinMiddle`, `meetBelnap`/`joinBelnap`,
   `xor` — the rival connective families.
 - `Trivalent.presuppose`, `Trivalent.metaAssert` — the ∂ and 𝒜 operators of
@@ -133,11 +133,11 @@ theorem inf_neg_le_sup_neg (a b : Trivalent) : a ⊓ neg a ≤ b ⊔ neg b := by
 
 instance : Compl Trivalent := ⟨neg⟩
 
-/-- `Trivalent` is the canonical non-Boolean `KleeneLattice`: a distributive chain with
-`neg` as the involutive antitone complement, failing complementation
-(`inf_compl_indet_ne_bot`). The `ᶜ` instance gives access to the class API
-(`Core/Order/DeMorganAlgebra.lean`); `neg` remains the simp-normal form. -/
-instance : KleeneLattice Trivalent where
+/-- `Trivalent` is the canonical non-Boolean Kleene algebra (`Order.KleeneAlgebra`): a
+distributive chain with `neg` as the involutive antitone complement, failing
+complementation (`inf_compl_indet_ne_bot`). The `ᶜ` instance gives access to the class
+API (`Core/Order/DeMorganAlgebra.lean`); `neg` remains the simp-normal form. -/
+instance : Order.KleeneAlgebra Trivalent where
   __ := (inferInstance : DistribLattice Trivalent)
   __ := (inferInstance : BoundedOrder Trivalent)
   compl := neg

--- a/Linglib/Core/Logic/Trivalent.lean
+++ b/Linglib/Core/Logic/Trivalent.lean
@@ -15,7 +15,7 @@ import Linglib.Core.Order.Flat
 /-!
 # Three-valued truth
 
-`Truth3` is the three-element bounded chain `false < indet < true`: the value space of
+`Trivalent` is the three-element bounded chain `false < indet < true`: the value space of
 strong Kleene logic ([kleene-1952]), the bilattice literature's THREE ([fitting-1994]),
 and the consistent fragment of Belnap's FOUR. Strong Kleene conjunction and disjunction
 are the chain's `⊓`/`⊔`; the carrier is logic-neutral, hosting the rival trivalent
@@ -24,31 +24,33 @@ conditional assertion ([belnap-1970]) — and the partiality operators ∂ and �
 [beaver-krahmer-2001].
 
 The upstreamable algebra is the `KleeneLattice` class (`Core/Order/DeMorganAlgebra.lean`),
-of which `Truth3` is the canonical non-Boolean instance. The dedicated carrier with
-truth-named constructors is this library's ergonomic choice, which is why it lives under
-the `Trivalent` namespace rather than at root.
+of which `Trivalent` is the canonical non-Boolean instance. The dedicated carrier with
+truth-named constructors is this library's ergonomic choice; the name follows the
+`Boolean` precedent — an adjective nominalized as its truth-value type — with the
+`Trivalent` namespace hosting the whole trivalent development (this file's algebra,
+`Core/ModelTheory/Trivalent.lean`'s formulas).
 
 ## Main definitions
 
-- `Truth3` — three-valued truth (`.true`, `.false`, `.indet`), a `LinearOrder` and
-  `BoundedOrder`; `Prop3 W` — trivalent propositions `W → Truth3`.
-- `Truth3.neg` — Strong Kleene negation: involutive (`neg_neg`), antitone
+- `Trivalent` — three-valued truth (`.true`, `.false`, `.indet`), a `LinearOrder` and
+  `BoundedOrder`; `Prop3 W` — trivalent propositions `W → Trivalent`.
+- `Trivalent.neg` — Strong Kleene negation: involutive (`neg_neg`), antitone
   (`neg_antitone`), De Morgan (`neg_inf`/`neg_sup`), satisfying the Kleene law
-  (`inf_neg_le_sup_neg`) — so `Truth3` is a `KleeneLattice`, the canonical non-Boolean
+  (`inf_neg_le_sup_neg`) — so `Trivalent` is a `KleeneLattice`, the canonical non-Boolean
   instance (`inf_compl_indet_ne_bot`).
-- `Truth3.meetWeak`/`joinWeak`, `meetMiddle`/`joinMiddle`, `meetBelnap`/`joinBelnap`,
+- `Trivalent.meetWeak`/`joinWeak`, `meetMiddle`/`joinMiddle`, `meetBelnap`/`joinBelnap`,
   `xor` — the rival connective families.
-- `Truth3.presuppose`, `Truth3.metaAssert` — the ∂ and 𝒜 operators of
+- `Trivalent.presuppose`, `Trivalent.metaAssert` — the ∂ and 𝒜 operators of
   [beaver-krahmer-2001].
-- `Truth3.ofBool`, `Truth3.ofBoolHom` — `Bool` embeds as a bounded lattice homomorphism.
+- `Trivalent.ofBool`, `Trivalent.ofBoolHom` — `Bool` embeds as a bounded lattice homomorphism.
 
 ## Main results
 
-- `Truth3.orderIsoSignType` — the truth order's mathlib carrier is `SignType`
-  (`-1 < 0 < 1`), the iso commuting with negation; `Truth3.equivFlatBool` — the same
+- `Trivalent.orderIsoSignType` — the truth order's mathlib carrier is `SignType`
+  (`-1 < 0 < 1`), the iso commuting with negation; `Trivalent.equivFlatBool` — the same
   carrier under the *knowledge* order is `Flat Bool`. Together: the Kleene bilattice.
-- `Truth3.toFlat_inf_mono_left` etc. — Strong Kleene `⊓`/`⊔` are interlaced
-  (knowledge-monotone); Weak Kleene is not (`Truth3.meetWeak_not_truthMono`).
+- `Trivalent.toFlat_inf_mono_left` etc. — Strong Kleene `⊓`/`⊔` are interlaced
+  (knowledge-monotone); Weak Kleene is not (`Trivalent.meetWeak_not_truthMono`).
 
 ## References
 
@@ -56,42 +58,40 @@ the `Trivalent` namespace rather than at root.
 [cobreros-etal-2012] [wang-davidson-2026]
 -/
 
-namespace Trivalent
-
 /-- Three-valued truth: the 3-element bounded chain `false < indet < true`.
 Strong Kleene logic ([kleene-1952]) corresponds to the order-derived operations:
 conjunction is `⊓` (= `min`), disjunction `⊔` (= `max`), and `neg` the
 order-reversing involution. -/
-inductive Truth3 where
+inductive Trivalent where
   | true
   | false
   | indet
   deriving Repr, DecidableEq, Inhabited, Fintype
 
-namespace Truth3
+namespace Trivalent
 
 /-! ### The truth order -/
 
 /-- The less-than-or-equal relation on truth values: `false < indet < true`. -/
-protected inductive LE : Truth3 → Truth3 → Prop
-  | of_false (a) : Truth3.LE .false a
-  | indet : Truth3.LE .indet .indet
-  | of_true (a) : Truth3.LE a .true
+protected inductive LE : Trivalent → Trivalent → Prop
+  | of_false (a) : Trivalent.LE .false a
+  | indet : Trivalent.LE .indet .indet
+  | of_true (a) : Trivalent.LE a .true
 
-instance : LE Truth3 := ⟨Truth3.LE⟩
+instance : LE Trivalent := ⟨Trivalent.LE⟩
 
-instance instDecidableLE : DecidableLE Truth3 := λ a b => by
+instance instDecidableLE : DecidableLE Trivalent := λ a b => by
   cases a <;> cases b <;>
     first | exact isTrue (by constructor) | exact isFalse (by rintro ⟨_⟩)
 
-instance : LinearOrder Truth3 where
+instance : LinearOrder Trivalent where
   le_refl a := by cases a <;> constructor
   le_trans := by decide
   le_antisymm := by decide
   le_total := by decide
   toDecidableLE := instDecidableLE
 
-instance : BoundedOrder Truth3 where
+instance : BoundedOrder Trivalent where
   top := .true
   le_top a := by exact .of_true a
   bot := .false
@@ -104,67 +104,67 @@ operations directly. Negation is the remaining primitive. -/
 
 /-- Strong Kleene negation: the order-reversing involution swapping `false` and
 `true`, fixing `indet`. -/
-def neg : Truth3 → Truth3
+def neg : Trivalent → Trivalent
   | .true  => .false
   | .indet => .indet
   | .false => .true
 
-@[simp] theorem neg_neg (a : Truth3) : neg (neg a) = a := by cases a <;> rfl
+@[simp] theorem neg_neg (a : Trivalent) : neg (neg a) = a := by cases a <;> rfl
 
 @[simp] theorem neg_indet : neg .indet = .indet := rfl
 
-theorem neg_involutive : Function.Involutive (neg : Truth3 → Truth3) := neg_neg
+theorem neg_involutive : Function.Involutive (neg : Trivalent → Trivalent) := neg_neg
 
 /-- Strong Kleene negation is antitone (order-reversing). -/
 theorem neg_antitone : Antitone neg := λ a b h => by
   revert h; cases a <;> cases b <;> decide
 
 /-- De Morgan: negation swaps meet and join — from antitonicity alone. -/
-@[simp] theorem neg_inf (a b : Truth3) : neg (a ⊓ b) = neg a ⊔ neg b :=
+@[simp] theorem neg_inf (a b : Trivalent) : neg (a ⊓ b) = neg a ⊔ neg b :=
   neg_antitone.map_min
 
 /-- De Morgan: negation swaps join and meet. -/
-@[simp] theorem neg_sup (a b : Truth3) : neg (a ⊔ b) = neg a ⊓ neg b :=
+@[simp] theorem neg_sup (a b : Trivalent) : neg (a ⊔ b) = neg a ⊓ neg b :=
   neg_antitone.map_max
 
 /-- The Kleene law `a ⊓ ¬a ≤ b ⊔ ¬b`. -/
-theorem inf_neg_le_sup_neg (a b : Truth3) : a ⊓ neg a ≤ b ⊔ neg b := by
+theorem inf_neg_le_sup_neg (a b : Trivalent) : a ⊓ neg a ≤ b ⊔ neg b := by
   cases a <;> cases b <;> decide
 
-instance : Compl Truth3 := ⟨neg⟩
+instance : Compl Trivalent := ⟨neg⟩
 
-/-- `Truth3` is the canonical non-Boolean `KleeneLattice`: a distributive chain with
+/-- `Trivalent` is the canonical non-Boolean `KleeneLattice`: a distributive chain with
 `neg` as the involutive antitone complement, failing complementation
 (`inf_compl_indet_ne_bot`). The `ᶜ` instance gives access to the class API
 (`Core/Order/DeMorganAlgebra.lean`); `neg` remains the simp-normal form. -/
-instance : KleeneLattice Truth3 where
-  __ := (inferInstance : DistribLattice Truth3)
-  __ := (inferInstance : BoundedOrder Truth3)
+instance : KleeneLattice Trivalent where
+  __ := (inferInstance : DistribLattice Trivalent)
+  __ := (inferInstance : BoundedOrder Trivalent)
   compl := neg
   compl_compl := neg_neg
   compl_antitone := λ h => neg_antitone h
   inf_compl_le_sup_compl := inf_neg_le_sup_neg
 
-/-- `Truth3` is not complemented — `indet` witnesses the gap between Kleene and Boolean
-(so `Truth3` is no `OrthocomplementedLattice` either). -/
-theorem inf_compl_indet_ne_bot : Truth3.indet ⊓ Truth3.indetᶜ ≠ ⊥ := by decide
+/-- `Trivalent` is not complemented — `indet` witnesses the gap between Kleene and Boolean
+(so `Trivalent` is no `OrthocomplementedLattice` either). -/
+theorem inf_compl_indet_ne_bot : Trivalent.indet ⊓ Trivalent.indetᶜ ≠ ⊥ := by decide
 
 /-! ### Constructor-literal simp lemmas
 
 Inherited from `BoundedOrder` + `Lattice` + `LinearOrder`, restated with the
 constructor literals (`⊤ = .true`, `⊥ = .false`) that goals actually mention. -/
 
-@[simp] theorem sup_true (a : Truth3) : a ⊔ .true = .true := sup_top_eq a
-@[simp] theorem true_sup (a : Truth3) : Truth3.true ⊔ a = .true := top_sup_eq a
-@[simp] theorem inf_false (a : Truth3) : a ⊓ .false = .false := inf_bot_eq a
-@[simp] theorem false_inf (a : Truth3) : Truth3.false ⊓ a = .false := bot_inf_eq a
+@[simp] theorem sup_true (a : Trivalent) : a ⊔ .true = .true := sup_top_eq a
+@[simp] theorem true_sup (a : Trivalent) : Trivalent.true ⊔ a = .true := top_sup_eq a
+@[simp] theorem inf_false (a : Trivalent) : a ⊓ .false = .false := inf_bot_eq a
+@[simp] theorem false_inf (a : Trivalent) : Trivalent.false ⊓ a = .false := bot_inf_eq a
 
 /-- `indet` propagates through `⊓` unless dominated by `false`. -/
-theorem indet_inf (a : Truth3) (h : a ≠ .false) : .indet ⊓ a = .indet := by
+theorem indet_inf (a : Trivalent) (h : a ≠ .false) : .indet ⊓ a = .indet := by
   cases a <;> first | rfl | exact absurd rfl h
 
 /-- `indet` propagates through `⊔` unless dominated by `true`. -/
-theorem indet_sup (a : Truth3) (h : a ≠ .true) : .indet ⊔ a = .indet := by
+theorem indet_sup (a : Trivalent) (h : a ≠ .true) : .indet ⊔ a = .indet := by
   cases a <;> first | rfl | exact absurd rfl h
 
 /-! ### Designated values
@@ -182,7 +182,7 @@ inductive Designation where
   deriving Repr, DecidableEq, Inhabited, Fintype
 
 /-- The threshold (least designated value) of a standard. -/
-def Designation.threshold : Designation → Truth3
+def Designation.threshold : Designation → Trivalent
   | .k3 => .true
   | .lp => .indet
 
@@ -199,48 +199,48 @@ def Designation.dual : Designation → Designation
 
 /-- `v` is designated at `d` iff it clears the threshold — the designated set is the
 principal filter above `d.threshold`. -/
-def designated (d : Designation) (v : Truth3) : Prop := d.threshold ≤ v
+def designated (d : Designation) (v : Trivalent) : Prop := d.threshold ≤ v
 
-instance (d : Designation) (v : Truth3) : Decidable (designated d v) :=
+instance (d : Designation) (v : Trivalent) : Decidable (designated d v) :=
   inferInstanceAs (Decidable (_ ≤ _))
 
 /-- K3-designation is truth. -/
-@[simp] theorem designated_k3_iff (v : Truth3) : designated .k3 v ↔ v = .true := by
+@[simp] theorem designated_k3_iff (v : Trivalent) : designated .k3 v ↔ v = .true := by
   cases v <;> decide
 
 /-- LP-designation is non-falsity. -/
-@[simp] theorem designated_lp_iff (v : Truth3) : designated .lp v ↔ v ≠ .false := by
+@[simp] theorem designated_lp_iff (v : Trivalent) : designated .lp v ↔ v ≠ .false := by
   cases v <;> decide
 
 /-- K3/LP duality via negation: negation swaps the standards (the antitone involution
 `neg` fixes `indet`, exchanging the two principal filters' complements). -/
-theorem designated_neg_iff (d : Designation) (v : Truth3) :
+theorem designated_neg_iff (d : Designation) (v : Trivalent) :
     designated d.dual (neg v) ↔ ¬ designated d v := by
   cases d <;> cases v <;> decide
 
 /-- Designation distributes over `⊓`: the designated set is a filter (`le_inf_iff`). -/
-theorem designated_inf (d : Designation) (v w : Truth3) :
+theorem designated_inf (d : Designation) (v w : Trivalent) :
     designated d (v ⊓ w) ↔ designated d v ∧ designated d w := le_inf_iff
 
 /-- Designation distributes over `⊔`: thresholds are prime on a chain (`le_sup_iff`). -/
-theorem designated_sup (d : Designation) (v w : Truth3) :
+theorem designated_sup (d : Designation) (v w : Trivalent) :
     designated d (v ⊔ w) ↔ designated d v ∨ designated d w := le_sup_iff
 
 /-- K3 is the stronger standard: its threshold dominates LP's. -/
-theorem designated_lp_of_k3 {v : Truth3} (h : designated .k3 v) : designated .lp v :=
+theorem designated_lp_of_k3 {v : Trivalent} (h : designated .k3 v) : designated .lp v :=
   le_trans (by decide) h
 
 /-! ### Conversion from Bool -/
 
 /-- The two-valued fragment: `Bool.true ↦ .true`, `Bool.false ↦ .false`. -/
-def ofBool : Bool → Truth3
+def ofBool : Bool → Trivalent
   | Bool.true => .true
   | Bool.false => .false
 
-instance : Coe Bool Truth3 := ⟨ofBool⟩
+instance : Coe Bool Trivalent := ⟨ofBool⟩
 
 /-- A value is defined when it is not `indet`. -/
-def isDefined : Truth3 → Prop
+def isDefined : Trivalent → Prop
   | .true => True
   | .false => True
   | .indet => False
@@ -249,19 +249,19 @@ instance : DecidablePred isDefined := λ v => by
   cases v <;> unfold isDefined <;> infer_instance
 
 /-- Project to `Bool`, sending `indet` to `false`. -/
-def toBoolOrFalse : Truth3 → Bool
+def toBoolOrFalse : Trivalent → Bool
   | .true => Bool.true
   | .false => Bool.false
   | .indet => Bool.false
 
-/-- `Truth3.ofBool` preserves `⊓`/`&&`. -/
+/-- `Trivalent.ofBool` preserves `⊓`/`&&`. -/
 @[simp] theorem ofBool_inf (a b : Bool) :
-    Truth3.ofBool a ⊓ Truth3.ofBool b = Truth3.ofBool (a && b) := by
+    Trivalent.ofBool a ⊓ Trivalent.ofBool b = Trivalent.ofBool (a && b) := by
   cases a <;> cases b <;> decide
 
-/-- `Truth3.ofBool` preserves `⊔`/`||`. -/
+/-- `Trivalent.ofBool` preserves `⊔`/`||`. -/
 @[simp] theorem ofBool_sup (a b : Bool) :
-    Truth3.ofBool a ⊔ Truth3.ofBool b = Truth3.ofBool (a || b) := by
+    Trivalent.ofBool a ⊔ Trivalent.ofBool b = Trivalent.ofBool (a || b) := by
   cases a <;> cases b <;> decide
 
 /-- Negation agrees with Bool. -/
@@ -273,9 +273,9 @@ theorem designated_ofBool (d : Designation) (b : Bool) :
     designated d (ofBool b) ↔ b = Bool.true := by
   cases d <;> cases b <;> decide
 
-/-- `Truth3.ofBool` as a bounded lattice homomorphism, onto the `{⊥, ⊤}` sublattice
-of `Truth3` — so consumers can appeal to the general `LatticeHom` API. -/
-def ofBoolHom : BoundedLatticeHom Bool Truth3 where
+/-- `Trivalent.ofBool` as a bounded lattice homomorphism, onto the `{⊥, ⊤}` sublattice
+of `Trivalent` — so consumers can appeal to the general `LatticeHom` API. -/
+def ofBoolHom : BoundedLatticeHom Bool Trivalent where
   toFun := ofBool
   map_sup' a b := (ofBool_sup a b).symm
   map_inf' a b := (ofBool_inf a b).symm
@@ -288,7 +288,7 @@ def ofBoolHom : BoundedLatticeHom Bool Truth3 where
 undefined when either operand is. Unlike `⊔`, XOR cannot "see past" an undefined
 operand — `.true ⊔ .indet = .true`, but `xor .true .indet = .indet`
 ([wang-davidson-2026], Figure 2). -/
-def xor : Truth3 → Truth3 → Truth3
+def xor : Trivalent → Trivalent → Trivalent
   | .true, .false => .true
   | .false, .true => .true
   | .true, .true => .false
@@ -296,20 +296,20 @@ def xor : Truth3 → Truth3 → Truth3
   | _, _ => .indet
 
 /-- XOR is commutative. -/
-theorem xor_comm (a b : Truth3) : xor a b = xor b a := by
+theorem xor_comm (a b : Trivalent) : xor a b = xor b a := by
   cases a <;> cases b <;> rfl
 
 /-- XOR decomposes as (a ∨ b) ∧ ¬(a ∧ b) under Strong Kleene. -/
-theorem xor_eq_sup_inf_neg (a b : Truth3) :
+theorem xor_eq_sup_inf_neg (a b : Trivalent) :
     xor a b = (a ⊔ b) ⊓ neg (a ⊓ b) := by
   cases a <;> cases b <;> rfl
 
 /-- XOR propagates indet unconditionally from the left. -/
-theorem xor_indet_left (a : Truth3) : xor .indet a = .indet := by
+theorem xor_indet_left (a : Trivalent) : xor .indet a = .indet := by
   cases a <;> rfl
 
 /-- XOR propagates indet unconditionally from the right. -/
-theorem xor_indet_right (a : Truth3) : xor a .indet = .indet := by
+theorem xor_indet_right (a : Trivalent) : xor a .indet = .indet := by
   cases a <;> rfl
 
 /-- XOR agrees with Bool XOR on defined inputs. -/
@@ -319,7 +319,7 @@ theorem xor_ofBool (a b : Bool) : xor (ofBool a) (ofBool b) = ofBool (a ^^ b) :=
 /-- XOR is undefined iff at least one operand is — so exclusive disjunction never
 filters undefinedness, in contrast with `⊔` (`.true ⊔ .indet = .true`)
 ([wang-davidson-2026]). -/
-theorem xor_indet_iff (a b : Truth3) :
+theorem xor_indet_iff (a b : Trivalent) :
     xor a b = .indet ↔ a = .indet ∨ b = .indet := by
   cases a <;> cases b <;> simp [xor]
 
@@ -331,19 +331,19 @@ negation fixing the midpoint is `SignType` (`-1 < 0 < 1`). -/
 /-- The truth-order carrier iso: `false ↔ -1`, `indet ↔ 0`, `true ↔ 1`, with Kleene
 negation corresponding to `SignType` negation (`orderIsoSignType_neg`). The
 knowledge-order counterpart is `equivFlatBool`. -/
-def orderIsoSignType : Truth3 ≃o SignType where
+def orderIsoSignType : Trivalent ≃o SignType where
   toFun := λ | .false => .neg | .indet => .zero | .true => .pos
   invFun := λ | .neg => .false | .zero => .indet | .pos => .true
   left_inv a := by cases a <;> rfl
   right_inv s := by cases s <;> rfl
   map_rel_iff' {a b} := by cases a <;> cases b <;> decide
 
-@[simp] theorem orderIsoSignType_neg (a : Truth3) :
+@[simp] theorem orderIsoSignType_neg (a : Trivalent) :
     orderIsoSignType (neg a) = -orderIsoSignType a := by cases a <;> rfl
 
 /-- `SignType` multiplication transports to the Strong Kleene *biconditional*, so
-`Truth3.xor` is its negation. -/
-theorem orderIsoSignType_xor (a b : Truth3) :
+`Trivalent.xor` is its negation. -/
+theorem orderIsoSignType_xor (a b : Trivalent) :
     orderIsoSignType (xor a b) = -(orderIsoSignType a * orderIsoSignType b) := by
   cases a <;> cases b <;> rfl
 
@@ -356,7 +356,7 @@ paradox-prone statements. `metaAssert` and `presuppose` are the 𝒜 and ∂ ope
 of [beaver-krahmer-2001] §2. -/
 
 /-- Weak Kleene disjunction: indet is absorbing (both operands must be defined). -/
-def joinWeak : Truth3 → Truth3 → Truth3
+def joinWeak : Trivalent → Trivalent → Trivalent
   | .true, .true => .true
   | .true, .false => .true
   | .false, .true => .true
@@ -364,22 +364,22 @@ def joinWeak : Truth3 → Truth3 → Truth3
   | _, _ => .indet
 
 /-- Weak Kleene conjunction: indet is absorbing. -/
-def meetWeak : Truth3 → Truth3 → Truth3
+def meetWeak : Trivalent → Trivalent → Trivalent
   | .true, .true => .true
   | .true, .false => .false
   | .false, .true => .false
   | .false, .false => .false
   | _, _ => .indet
 
-theorem joinWeak_comm (a b : Truth3) : joinWeak a b = joinWeak b a := by
+theorem joinWeak_comm (a b : Trivalent) : joinWeak a b = joinWeak b a := by
   cases a <;> cases b <;> rfl
 
-theorem meetWeak_comm (a b : Truth3) : meetWeak a b = meetWeak b a := by
+theorem meetWeak_comm (a b : Trivalent) : meetWeak a b = meetWeak b a := by
   cases a <;> cases b <;> rfl
 
 /-- Meta-assertion: the 𝒜 (assertion) operator of [beaver-krahmer-2001] §2, closing
 a trivalent value to bivalent by treating undefinedness as falsity. -/
-def metaAssert : Truth3 → Truth3
+def metaAssert : Trivalent → Trivalent
   | .true => .true
   | .false => .false
   | .indet => .false
@@ -389,20 +389,20 @@ def metaAssert : Truth3 → Truth3
 @[simp] theorem metaAssert_indet : metaAssert .indet = .false := rfl
 
 /-- Meta-assertion always produces a defined value. -/
-theorem metaAssert_defined (v : Truth3) : (metaAssert v).isDefined := by
+theorem metaAssert_defined (v : Trivalent) : (metaAssert v).isDefined := by
   cases v <;> trivial
 
 /-- Meta-assertion is idempotent. -/
-theorem metaAssert_idempotent (v : Truth3) : metaAssert (metaAssert v) = metaAssert v := by
+theorem metaAssert_idempotent (v : Trivalent) : metaAssert (metaAssert v) = metaAssert v := by
   cases v <;> rfl
 
 /-- Meta-assertion preserves defined values. -/
-theorem metaAssert_of_defined (v : Truth3) (h : v.isDefined) : metaAssert v = v := by
+theorem metaAssert_of_defined (v : Trivalent) (h : v.isDefined) : metaAssert v = v := by
   cases v with | true => rfl | false => rfl | indet => exact absurd h id
 
 /-- Presupposition: the ∂ operator of [beaver-krahmer-2001] §2, the companion of
 `metaAssert` — asserts a true value, undefined otherwise (`T ↦ T`, `F ↦ #`, `# ↦ #`). -/
-def presuppose : Truth3 → Truth3
+def presuppose : Trivalent → Trivalent
   | .true => .true
   | _ => .indet
 
@@ -412,7 +412,7 @@ def presuppose : Truth3 → Truth3
 
 /-- Meta-asserting a presupposed value falsifies undefinedness: `𝒜 ∘ ∂` sends
 exactly `.true` to `.true`. -/
-theorem metaAssert_presuppose (v : Truth3) :
+theorem metaAssert_presuppose (v : Trivalent) :
     metaAssert (presuppose v) = if v = .true then .true else .false := by
   cases v <;> rfl
 
@@ -425,51 +425,51 @@ operand absorbs; a defined one proceeds by Strong Kleene. -/
 /-- Middle Kleene conjunction: left-undefined absorbs, left-defined proceeds by
 Strong Kleene. Asymmetric — `meetMiddle .false .indet = .false` but
 `meetMiddle .indet .false = .indet` ([peters-1979]). -/
-def meetMiddle : Truth3 → Truth3 → Truth3
+def meetMiddle : Trivalent → Trivalent → Trivalent
   | .indet, _ => .indet
   | a, b => a ⊓ b
 
 /-- Middle Kleene disjunction: left-undefined absorbs, left-defined proceeds by
 Strong Kleene — a defined first disjunct can settle the result even when the second
 is undefined, the left-to-right filtering pattern ([peters-1979]). -/
-def joinMiddle : Truth3 → Truth3 → Truth3
+def joinMiddle : Trivalent → Trivalent → Trivalent
   | .indet, _ => .indet
   | a, b => a ⊔ b
 
 /-- Middle Kleene conjunction is not commutative. -/
-theorem meetMiddle_not_comm : ¬ ∀ a b : Truth3, meetMiddle a b = meetMiddle b a :=
+theorem meetMiddle_not_comm : ¬ ∀ a b : Trivalent, meetMiddle a b = meetMiddle b a :=
   λ h => absurd (h .false .indet) (by decide)
 
 /-- Middle Kleene disjunction is not commutative. -/
-theorem joinMiddle_not_comm : ¬ ∀ a b : Truth3, joinMiddle a b = joinMiddle b a :=
+theorem joinMiddle_not_comm : ¬ ∀ a b : Trivalent, joinMiddle a b = joinMiddle b a :=
   λ h => absurd (h .true .indet) (by decide)
 
 /-- When the left operand is defined, Middle Kleene conjunction equals Strong Kleene. -/
-theorem meetMiddle_eq_inf_of_left_defined (a b : Truth3) (h : a.isDefined) :
+theorem meetMiddle_eq_inf_of_left_defined (a b : Trivalent) (h : a.isDefined) :
     meetMiddle a b = a ⊓ b := by
   cases a with | true => rfl | false => rfl | indet => exact absurd h id
 
 /-- When the left operand is defined, Middle Kleene disjunction equals Strong Kleene. -/
-theorem joinMiddle_eq_sup_of_left_defined (a b : Truth3) (h : a.isDefined) :
+theorem joinMiddle_eq_sup_of_left_defined (a b : Trivalent) (h : a.isDefined) :
     joinMiddle a b = a ⊔ b := by
   cases a with | true => rfl | false => rfl | indet => exact absurd h id
 
 /-- Left-undefined absorbs Middle Kleene conjunction. -/
-theorem meetMiddle_indet_left (a : Truth3) : meetMiddle .indet a = .indet := rfl
+theorem meetMiddle_indet_left (a : Trivalent) : meetMiddle .indet a = .indet := rfl
 
 /-- Left-undefined absorbs Middle Kleene disjunction. -/
-theorem joinMiddle_indet_left (a : Truth3) : joinMiddle .indet a = .indet := rfl
+theorem joinMiddle_indet_left (a : Trivalent) : joinMiddle .indet a = .indet := rfl
 
 /-- `true` is a left identity for Middle Kleene conjunction. -/
-theorem meetMiddle_true_left (a : Truth3) : meetMiddle .true a = a := by cases a <;> rfl
+theorem meetMiddle_true_left (a : Trivalent) : meetMiddle .true a = a := by cases a <;> rfl
 
 /-- `false` is a left zero for Middle Kleene conjunction — the key asymmetry against
 Weak Kleene, where `meetWeak .false .indet = .indet`. -/
-theorem meetMiddle_false_left (a : Truth3) : meetMiddle .false a = .false := by
+theorem meetMiddle_false_left (a : Trivalent) : meetMiddle .false a = .false := by
   cases a <;> rfl
 
 /-- `false` is a left identity for Middle Kleene disjunction. -/
-theorem joinMiddle_false_left (a : Truth3) : joinMiddle .false a = a := by cases a <;> rfl
+theorem joinMiddle_false_left (a : Trivalent) : joinMiddle .false a = a := by cases a <;> rfl
 
 /-- Middle Kleene conjunction agrees with Bool on defined inputs. -/
 theorem meetMiddle_ofBool (a b : Bool) :
@@ -490,38 +490,38 @@ dominated) and Weak Kleene (indet always propagates). -/
 
 /-- Belnap conjunction: undefined operands are skipped; `indet` is the identity
 ([belnap-1970], (8)). -/
-def meetBelnap : Truth3 → Truth3 → Truth3
+def meetBelnap : Trivalent → Trivalent → Trivalent
   | .indet, b => b
   | a, .indet => a
   | a, b => a ⊓ b
 
 /-- Belnap disjunction: undefined operands are skipped; `indet` is the identity
 ([belnap-1970], (9)). -/
-def joinBelnap : Truth3 → Truth3 → Truth3
+def joinBelnap : Trivalent → Trivalent → Trivalent
   | .indet, b => b
   | a, .indet => a
   | a, b => a ⊔ b
 
 /-- `indet` is a left identity for Belnap conjunction. -/
-theorem meetBelnap_indet_left (a : Truth3) : meetBelnap .indet a = a := rfl
+theorem meetBelnap_indet_left (a : Trivalent) : meetBelnap .indet a = a := rfl
 
 /-- `indet` is a right identity for Belnap conjunction. -/
-theorem meetBelnap_indet_right (a : Truth3) : meetBelnap a .indet = a := by
+theorem meetBelnap_indet_right (a : Trivalent) : meetBelnap a .indet = a := by
   cases a <;> rfl
 
 /-- Belnap conjunction is commutative. -/
-theorem meetBelnap_comm (a b : Truth3) : meetBelnap a b = meetBelnap b a := by
+theorem meetBelnap_comm (a b : Trivalent) : meetBelnap a b = meetBelnap b a := by
   cases a <;> cases b <;> rfl
 
 /-- `indet` is a left identity for Belnap disjunction. -/
-theorem joinBelnap_indet_left (a : Truth3) : joinBelnap .indet a = a := rfl
+theorem joinBelnap_indet_left (a : Trivalent) : joinBelnap .indet a = a := rfl
 
 /-- `indet` is a right identity for Belnap disjunction. -/
-theorem joinBelnap_indet_right (a : Truth3) : joinBelnap a .indet = a := by
+theorem joinBelnap_indet_right (a : Trivalent) : joinBelnap a .indet = a := by
   cases a <;> rfl
 
 /-- Belnap disjunction is commutative. -/
-theorem joinBelnap_comm (a b : Truth3) : joinBelnap a b = joinBelnap b a := by
+theorem joinBelnap_comm (a b : Trivalent) : joinBelnap a b = joinBelnap b a := by
   cases a <;> cases b <;> rfl
 
 /-- Belnap conjunction agrees with Bool on defined inputs. -/
@@ -536,7 +536,7 @@ theorem joinBelnap_ofBool (a b : Bool) :
 
 /-! ### The knowledge order: `Flat Bool` and the Kleene bilattice
 
-`Truth3`'s native order is the *truth* order `false < indet < true`; `Flat Bool`
+`Trivalent`'s native order is the *truth* order `false < indet < true`; `Flat Bool`
 (`equivFlatBool`) carries the *knowledge* order `⊥ ⊑ true`, `⊥ ⊑ false`. Two orders
 on one carrier is a *bilattice*. Strong Kleene `∧`/`∨` are the truth-order lattice
 operations `⊓`/`⊔`; what makes them canonical is **interlacing** — they are monotone
@@ -545,27 +545,27 @@ Kleene is not (`meetWeak_not_truthMono`).
 
 `Flat Bool`'s `SemilatticeInf` meet `⊓` is the *consensus* `⊗`; its partial join
 (`PartialUnify`) is the *gullibility* `⊕`, partial because three values lack the `⊤`
-("both") of a full four-valued bilattice — so `Truth3` is the *consistent fragment*
+("both") of a full four-valued bilattice — so `Trivalent` is the *consistent fragment*
 of that bilattice. -/
 
 section KnowledgeOrder
 
-/-- The carrier bijection `Truth3 ≃ Flat Bool`: `indet ↔ ⊥`, `true ↔ some true`,
+/-- The carrier bijection `Trivalent ≃ Flat Bool`: `indet ↔ ⊥`, `true ↔ some true`,
 `false ↔ some false`. `Flat Bool` carries the knowledge order, distinct from the
 truth order — the two orders of the Kleene bilattice. -/
-def toFlat : Truth3 → Flat Bool
+def toFlat : Trivalent → Flat Bool
   | .indet => none
   | .true => some Bool.true
   | .false => some Bool.false
 
 /-- Inverse of `toFlat`. -/
-def ofFlat : Flat Bool → Truth3
+def ofFlat : Flat Bool → Trivalent
   | none => .indet
   | some Bool.true => .true
   | some Bool.false => .false
 
-/-- `Truth3` and the flat domain `Flat Bool` share a carrier. -/
-def equivFlatBool : Truth3 ≃ Flat Bool where
+/-- `Trivalent` and the flat domain `Flat Bool` share a carrier. -/
+def equivFlatBool : Trivalent ≃ Flat Bool where
   toFun := toFlat
   invFun := ofFlat
   left_inv a := by cases a <;> rfl
@@ -575,21 +575,21 @@ def equivFlatBool : Truth3 ≃ Flat Bool where
 `false ≤ indet`, but in the knowledge order the committed value `false` is not below
 the uncommitted `indet = ⊥`. -/
 theorem truthOrder_ne_knowledgeOrder :
-    Truth3.false ≤ Truth3.indet ∧ ¬ toFlat .false ≤ toFlat .indet := by decide
+    Trivalent.false ≤ Trivalent.indet ∧ ¬ toFlat .false ≤ toFlat .indet := by decide
 
 /-- Strong Kleene negation is regular (knowledge-monotone); being unary, it is in
 fact the unique monotone extension of Boolean `not`. -/
-theorem toFlat_neg_mono {a b : Truth3} (h : toFlat a ≤ toFlat b) :
+theorem toFlat_neg_mono {a b : Trivalent} (h : toFlat a ≤ toFlat b) :
     toFlat (neg a) ≤ toFlat (neg b) := by
   cases a <;> cases b <;> revert h <;> decide
 
 /-- Strong Kleene conjunction is regular (knowledge-monotone in each argument). -/
-theorem toFlat_inf_mono_left {a a' : Truth3} (b : Truth3)
+theorem toFlat_inf_mono_left {a a' : Trivalent} (b : Trivalent)
     (h : toFlat a ≤ toFlat a') : toFlat (a ⊓ b) ≤ toFlat (a' ⊓ b) := by
   cases a <;> cases a' <;> cases b <;> revert h <;> decide
 
 /-- Strong Kleene disjunction is regular (knowledge-monotone in each argument). -/
-theorem toFlat_sup_mono_left {a a' : Truth3} (b : Truth3)
+theorem toFlat_sup_mono_left {a a' : Trivalent} (b : Trivalent)
     (h : toFlat a ≤ toFlat a') : toFlat (a ⊔ b) ≤ toFlat (a' ⊔ b) := by
   cases a <;> cases a' <;> cases b <;> revert h <;> decide
 
@@ -597,17 +597,15 @@ theorem toFlat_sup_mono_left {a a' : Truth3} (b : Truth3)
 (`indet ≤ true`, yet `meetWeak .indet .false = .indet ≰ .false`), so unlike Strong
 Kleene `⊓` it is not a bilattice operation. -/
 theorem meetWeak_not_truthMono :
-    ¬ ∀ a a' b : Truth3, a ≤ a' → meetWeak a b ≤ meetWeak a' b :=
+    ¬ ∀ a a' b : Trivalent, a ≤ a' → meetWeak a b ≤ meetWeak a' b :=
   λ h => absurd (h .indet .true .false (by decide)) (by decide)
 
 /-- Weak Kleene disjunction is likewise not interlaced. -/
 theorem joinWeak_not_truthMono :
-    ¬ ∀ a a' b : Truth3, a ≤ a' → joinWeak a b ≤ joinWeak a' b :=
+    ¬ ∀ a a' b : Trivalent, a ≤ a' → joinWeak a b ≤ joinWeak a' b :=
   λ h => absurd (h .false .indet .true (by decide)) (by decide)
 
 end KnowledgeOrder
-
-end Truth3
 
 /-! ### Trivalent propositions -/
 
@@ -618,24 +616,24 @@ inductive ProjectionType where
   | disjunctive
   deriving Repr, DecidableEq
 
-/-- Three-valued propositions: functions from worlds to `Truth3`. -/
-abbrev Prop3 (W : Type*) := W → Truth3
+/-- Three-valued propositions: functions from worlds to `Trivalent`. -/
+abbrev Prop3 (W : Type*) := W → Trivalent
 
 namespace Prop3
 
 variable {W : Type*}
 
-/-! `Prop3 W := W → Truth3` is a `Pi` type: `Lattice (W → Truth3)` auto-derives from
+/-! `Prop3 W := W → Trivalent` is a `Pi` type: `Lattice (W → Trivalent)` auto-derives from
 `Pi.instLattice`, so `(p ⊔ q) w = p w ⊔ q w` and `(p ⊓ q) w = p w ⊓ q w` come for
 free from `Pi.sup_apply`/`Pi.inf_apply` — use `⊔`/`⊓` directly rather than bespoke
-wrappers. The only Truth3-specific operation needing a pointwise lift is
+wrappers. The only Trivalent-specific operation needing a pointwise lift is
 `metaAssert`: there is no `Pi` analogue of a unary collapsing operator. -/
 
 /-- Pointwise meta-assertion (Beaver-Krahmer 𝒜 operator). -/
-def metaAssert (p : Prop3 W) : Prop3 W := λ w => Truth3.metaAssert (p w)
+def metaAssert (p : Prop3 W) : Prop3 W := λ w => Trivalent.metaAssert (p w)
 
 @[simp] theorem metaAssert_apply (p : Prop3 W) (w : W) :
-    Prop3.metaAssert p w = Truth3.metaAssert (p w) := rfl
+    Prop3.metaAssert p w = Trivalent.metaAssert (p w) := rfl
 
 end Prop3
 

--- a/Linglib/Core/Logic/Trivalent.lean
+++ b/Linglib/Core/Logic/Trivalent.lean
@@ -142,7 +142,7 @@ instance : Order.KleeneAlgebra Trivalent where
   __ := (inferInstance : BoundedOrder Trivalent)
   compl := neg
   compl_compl := neg_neg
-  compl_antitone := λ h => neg_antitone h
+  compl_le_compl := λ h => neg_antitone h
   inf_compl_le_sup_compl := inf_neg_le_sup_neg
 
 /-- `Trivalent` is not complemented — `indet` witnesses the gap between Kleene and Boolean

--- a/Linglib/Core/Logic/Truth3.lean
+++ b/Linglib/Core/Logic/Truth3.lean
@@ -9,6 +9,7 @@ import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Order.MinMax
 import Mathlib.Data.Sign.Defs
+import Linglib.Core.Order.DeMorganAlgebra
 import Linglib.Core.Order.Flat
 
 /-!
@@ -22,9 +23,10 @@ connective families — Weak Kleene ([bochvar-1937]), Middle Kleene ([peters-197
 conditional assertion ([belnap-1970]) — and the partiality operators ∂ and 𝒜 of
 [beaver-krahmer-2001].
 
-`[UPSTREAM]` candidate, as a unit with `Core.Order.Flat` (its only non-mathlib import):
-mathlib has neither a three-valued truth carrier nor a De Morgan/Kleene lattice class,
-for which `Truth3` is the canonical finite instance.
+The upstreamable algebra is the `KleeneLattice` class (`Core/Order/DeMorganAlgebra.lean`),
+of which `Truth3` is the canonical non-Boolean instance. The dedicated carrier with
+truth-named constructors is this library's ergonomic choice, which is why it lives under
+the `Trivalent` namespace rather than at root.
 
 ## Main definitions
 
@@ -32,7 +34,8 @@ for which `Truth3` is the canonical finite instance.
   `BoundedOrder`; `Prop3 W` — trivalent propositions `W → Truth3`.
 - `Truth3.neg` — Strong Kleene negation: involutive (`neg_neg`), antitone
   (`neg_antitone`), De Morgan (`neg_inf`/`neg_sup`), satisfying the Kleene law
-  (`inf_neg_le_sup_neg`).
+  (`inf_neg_le_sup_neg`) — so `Truth3` is a `KleeneLattice`, the canonical non-Boolean
+  instance (`inf_compl_indet_ne_bot`).
 - `Truth3.meetWeak`/`joinWeak`, `meetMiddle`/`joinMiddle`, `meetBelnap`/`joinBelnap`,
   `xor` — the rival connective families.
 - `Truth3.presuppose`, `Truth3.metaAssert` — the ∂ and 𝒜 operators of
@@ -53,7 +56,7 @@ for which `Truth3` is the canonical finite instance.
 [cobreros-etal-2012] [wang-davidson-2026]
 -/
 
-namespace Core.Duality
+namespace Trivalent
 
 /-- Three-valued truth: the 3-element bounded chain `false < indet < true`.
 Strong Kleene logic ([kleene-1952]) corresponds to the order-derived operations:
@@ -124,12 +127,27 @@ theorem neg_antitone : Antitone neg := λ a b h => by
 @[simp] theorem neg_sup (a b : Truth3) : neg (a ⊔ b) = neg a ⊓ neg b :=
   neg_antitone.map_max
 
-/-- The Kleene law `a ⊓ ¬a ≤ b ⊔ ¬b`: with distributivity, involutivity, and the De
-Morgan laws, `Truth3` is the three-element Kleene algebra — the canonical example.
-Mathlib has no De Morgan/Kleene *lattice* class (its `KleeneAlgebra` is the
-star-semiring); `Truth3` would be the textbook instance of one. -/
+/-- The Kleene law `a ⊓ ¬a ≤ b ⊔ ¬b`. -/
 theorem inf_neg_le_sup_neg (a b : Truth3) : a ⊓ neg a ≤ b ⊔ neg b := by
   cases a <;> cases b <;> decide
+
+instance : Compl Truth3 := ⟨neg⟩
+
+/-- `Truth3` is the canonical non-Boolean `KleeneLattice`: a distributive chain with
+`neg` as the involutive antitone complement, failing complementation
+(`inf_compl_indet_ne_bot`). The `ᶜ` instance gives access to the class API
+(`Core/Order/DeMorganAlgebra.lean`); `neg` remains the simp-normal form. -/
+instance : KleeneLattice Truth3 where
+  __ := (inferInstance : DistribLattice Truth3)
+  __ := (inferInstance : BoundedOrder Truth3)
+  compl := neg
+  compl_compl := neg_neg
+  compl_antitone := λ h => neg_antitone h
+  inf_compl_le_sup_compl := inf_neg_le_sup_neg
+
+/-- `Truth3` is not complemented — `indet` witnesses the gap between Kleene and Boolean
+(so `Truth3` is no `OrthocomplementedLattice` either). -/
+theorem inf_compl_indet_ne_bot : Truth3.indet ⊓ Truth3.indetᶜ ≠ ⊥ := by decide
 
 /-! ### Constructor-literal simp lemmas
 
@@ -621,4 +639,4 @@ def metaAssert (p : Prop3 W) : Prop3 W := λ w => Truth3.metaAssert (p w)
 
 end Prop3
 
-end Core.Duality
+end Trivalent

--- a/Linglib/Core/ModelTheory/Trivalent.lean
+++ b/Linglib/Core/ModelTheory/Trivalent.lean
@@ -34,7 +34,6 @@ notation); consequence follows linglib's list-based `MixedConsequence` rather th
 
 namespace Trivalent
 
-open Core.Duality (Truth3)
 open Core.Logic.Consequence (MixedConsequence)
 
 /-- Propositional formulas over an atom type

--- a/Linglib/Core/ModelTheory/Trivalent.lean
+++ b/Linglib/Core/ModelTheory/Trivalent.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Consequence
 
 /-!
 # Trivalent propositional logic
 
-Propositional syntax (`Trivalent.Formula`) evaluated into `Truth3` by the strong Kleene
-tables (`Formula.eval`), with realization at a `Truth3.Designation` threshold
+Propositional syntax (`Trivalent.Formula`) evaluated into `Trivalent` by the strong Kleene
+tables (`Formula.eval`), with realization at a `Trivalent.Designation` threshold
 (`Formula.Realize`, notation `M ⊨[d] φ`) and consequence instantiating
 `Core.Logic.Consequence.MixedConsequence`. The `k3` diagonal is strong Kleene logic and
 the `lp` diagonal Priest's Logic of Paradox — same tables, different designated values
@@ -44,7 +44,7 @@ inductive Formula (Atom : Type*) where
   | conj : Formula Atom → Formula Atom → Formula Atom
 
 /-- A trivalent model: a truth value for each atom. -/
-abbrev Model (Atom : Type*) := Atom → Truth3
+abbrev Model (Atom : Type*) := Atom → Trivalent
 
 namespace Formula
 
@@ -52,46 +52,46 @@ variable {Atom : Type*}
 
 /-- Evaluation by the strong Kleene tables — the semantic core shared by K3 and LP,
 which differ only in designation. -/
-def eval (M : Model Atom) : Formula Atom → Truth3
+def eval (M : Model Atom) : Formula Atom → Trivalent
   | .atom a => M a
-  | .neg φ => Truth3.neg (eval M φ)
+  | .neg φ => Trivalent.neg (eval M φ)
   | .conj φ ψ => eval M φ ⊓ eval M ψ
 
 @[simp] theorem eval_atom (M : Model Atom) (a : Atom) : eval M (.atom a) = M a := rfl
 
 @[simp] theorem eval_neg (M : Model Atom) (φ : Formula Atom) :
-    eval M (.neg φ) = Truth3.neg (eval M φ) := rfl
+    eval M (.neg φ) = Trivalent.neg (eval M φ) := rfl
 
 @[simp] theorem eval_conj (M : Model Atom) (φ ψ : Formula Atom) :
     eval M (.conj φ ψ) = eval M φ ⊓ eval M ψ := rfl
 
 /-- Realization at a designation standard: the evaluation clears the threshold.
 `Realize M .k3` is strong Kleene satisfaction, `Realize M .lp` Priest's LP. -/
-def Realize (M : Model Atom) (d : Truth3.Designation) (φ : Formula Atom) : Prop :=
-  Truth3.designated d (eval M φ)
+def Realize (M : Model Atom) (d : Trivalent.Designation) (φ : Formula Atom) : Prop :=
+  Trivalent.designated d (eval M φ)
 
 @[inherit_doc] scoped notation:50 M " ⊨[" d "] " φ => Formula.Realize M d φ
 
-@[simp] theorem realize_atom (M : Model Atom) (d : Truth3.Designation) (a : Atom) :
-    (M ⊨[d] Formula.atom a) ↔ Truth3.designated d (M a) := Iff.rfl
+@[simp] theorem realize_atom (M : Model Atom) (d : Trivalent.Designation) (a : Atom) :
+    (M ⊨[d] Formula.atom a) ↔ Trivalent.designated d (M a) := Iff.rfl
 
 /-- The K3/LP duality at formula level: negation swaps the standards. -/
-@[simp] theorem realize_neg (M : Model Atom) (d : Truth3.Designation) (φ : Formula Atom) :
+@[simp] theorem realize_neg (M : Model Atom) (d : Trivalent.Designation) (φ : Formula Atom) :
     (M ⊨[d] Formula.neg φ) ↔ ¬(M ⊨[d.dual] φ) := by
-  have h := Truth3.designated_neg_iff d.dual (eval M φ)
-  rwa [Truth3.Designation.dual_dual] at h
+  have h := Trivalent.designated_neg_iff d.dual (eval M φ)
+  rwa [Trivalent.Designation.dual_dual] at h
 
 /-- Realization distributes over conjunction at either standard. -/
-@[simp] theorem realize_conj (M : Model Atom) (d : Truth3.Designation)
+@[simp] theorem realize_conj (M : Model Atom) (d : Trivalent.Designation)
     (φ ψ : Formula Atom) :
     (M ⊨[d] Formula.conj φ ψ) ↔ (M ⊨[d] φ) ∧ (M ⊨[d] ψ) :=
-  Truth3.designated_inf d (eval M φ) (eval M ψ)
+  Trivalent.designated_inf d (eval M φ) (eval M ψ)
 
 end Formula
 
 open scoped Formula in
 /-- Mixed consequence over designation standards: premises at `m`, conclusion at `n`. -/
-abbrev Consequence {Atom : Type*} (m n : Truth3.Designation)
+abbrev Consequence {Atom : Type*} (m n : Trivalent.Designation)
     (Γ : List (Formula Atom)) (φ : Formula Atom) : Prop :=
   MixedConsequence (Formula.Realize (Atom := Atom)) m n Γ φ
 
@@ -103,10 +103,10 @@ variable {Atom : Type*}
 
 /-- In the all-indeterminate model every formula evaluates to `indet`. -/
 theorem eval_allIndet (φ : Formula Atom) :
-    Formula.eval (λ _ : Atom => Truth3.indet) φ = Truth3.indet := by
+    Formula.eval (λ _ : Atom => Trivalent.indet) φ = Trivalent.indet := by
   induction φ with
   | atom _ => rfl
-  | neg ψ ih => simp [ih, Truth3.neg]
+  | neg ψ ih => simp [ih, Trivalent.neg]
   | conj ψ χ ihψ ihχ => simp [ihψ, ihχ]
 
 /-- K3 has no tautologies: nothing is designated in the all-indeterminate model
@@ -114,13 +114,13 @@ theorem eval_allIndet (φ : Formula Atom) :
 theorem k3_no_tautologies [Nonempty Atom] (φ : Formula Atom) :
     ¬(∀ M : Model Atom, M ⊨[.k3] φ) := by
   intro h
-  have := h (λ _ => Truth3.indet)
+  have := h (λ _ => Trivalent.indet)
   simp [Formula.Realize, eval_allIndet] at this
 
 /-- Every formula is LP-satisfiable: the all-indeterminate model designates everything
 ([cobreros-etal-2012], Theorem 2). -/
 theorem lp_all_satisfiable (φ : Formula Atom) :
-    (λ _ : Atom => Truth3.indet) ⊨[.lp] φ := by
+    (λ _ : Atom => Trivalent.indet) ⊨[.lp] φ := by
   simp [Formula.Realize, eval_allIndet]
 
 /-- Explosion fails in LP: `{a ∧ ¬a} ⊭ b`, with countermodel `M a = indet`,
@@ -129,10 +129,10 @@ theorem lp_no_explosion :
     ∃ (φ ψ : Formula Bool), ¬Consequence .lp .lp [.conj φ (.neg φ)] ψ := by
   refine ⟨.atom Bool.true, .atom Bool.false, ?_⟩
   intro h
-  have := h (λ b => if b then Truth3.indet else Truth3.false)
+  have := h (λ b => if b then Trivalent.indet else Trivalent.false)
     (λ γ hγ => by
       simp at hγ; subst hγ
-      simp [Formula.Realize, Truth3.neg])
+      simp [Formula.Realize, Trivalent.neg])
   simp [Formula.Realize] at this
 
 end Trivalent

--- a/Linglib/Core/Order/DeMorganAlgebra.lean
+++ b/Linglib/Core/Order/DeMorganAlgebra.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.BooleanAlgebra.Basic
+
+/-!
+# De Morgan algebras and Kleene lattices
+
+`LatticeWithInvolution` is a bounded lattice with an involutive antitone complement `ᶜ` —
+the common reduct of `OrthocomplementedLattice` (which adds the complementation laws) and
+`DeMorganAlgebra` (which adds distributivity instead). The De Morgan laws are proved once
+here, from involution and antitonicity alone. A `KleeneLattice` is a De Morgan algebra
+satisfying the Kleene law `a ⊓ aᶜ ≤ b ⊔ bᶜ`: every `BooleanAlgebra` qualifies (the law
+degenerates through `⊥`), and the three-element chain `Trivalent.Truth3` is the canonical
+non-Boolean example.
+
+Mathlib has no De Morgan/Kleene *lattice* class (its `KleeneAlgebra` is the
+star-semiring); `[UPSTREAM]` candidate for `Mathlib/Order/DeMorganAlgebra.lean`. The
+`Lattice`/`Algebra` suffix split tracks the literature (Kalman's Kleene lattices) and
+avoids the star-semiring collision, on the `Order.Ideal` vs ring `Ideal` precedent.
+
+## Main definitions
+
+* `LatticeWithInvolution` — bounded lattice + involutive antitone `ᶜ`; De Morgan
+  (`compl_sup`/`compl_inf`), `compl_bot`/`compl_top`, and the injectivity/order lemmas
+  are derived here.
+* `DeMorganAlgebra` — a distributive `LatticeWithInvolution`.
+* `KleeneLattice` — a `DeMorganAlgebra` with the Kleene law
+  (`inf_compl_le_sup_compl`); every `BooleanAlgebra` is an instance.
+-/
+
+/-- A bounded lattice with an involutive, order-reversing complement — the common reduct
+of `OrthocomplementedLattice` and `DeMorganAlgebra`. `Compl` is pure notation, so `ᶜ`
+carries no complementation laws here: `a ⊓ aᶜ = ⊥` may fail. -/
+class LatticeWithInvolution (α : Type*) extends Lattice α, BoundedOrder α, Compl α where
+  /-- Complement is involutive: `aᶜᶜ = a`. -/
+  compl_compl (a : α) : aᶜᶜ = a
+  /-- Complement is order-reversing. -/
+  compl_antitone {a b : α} : a ≤ b → bᶜ ≤ aᶜ
+
+namespace LatticeWithInvolution
+
+variable {α : Type*} [LatticeWithInvolution α] {a b : α}
+
+theorem compl_le_compl_iff_le : aᶜ ≤ bᶜ ↔ b ≤ a :=
+  ⟨fun h => compl_compl b ▸ compl_compl a ▸ compl_antitone h, fun h => compl_antitone h⟩
+
+theorem compl_injective : Function.Injective (compl : α → α) := fun _ _ h => by
+  have := congrArg compl h
+  rwa [compl_compl, compl_compl] at this
+
+theorem compl_surjective : Function.Surjective (compl : α → α) :=
+  fun a => ⟨aᶜ, compl_compl a⟩
+
+theorem compl_eq_iff_eq_compl : aᶜ = b ↔ a = bᶜ :=
+  ⟨fun h => by rw [← h, compl_compl], fun h => by rw [h, compl_compl]⟩
+
+/-- Orthogonality is symmetric: `a ≤ bᶜ ↔ b ≤ aᶜ`. -/
+theorem le_compl_comm : a ≤ bᶜ ↔ b ≤ aᶜ :=
+  ⟨fun h => compl_compl b ▸ compl_antitone h, fun h => compl_compl a ▸ compl_antitone h⟩
+
+/-- De Morgan: complement of a join is the meet of complements — from involution and
+antitonicity alone; no distributivity or complementation is used. -/
+theorem compl_sup (a b : α) : (a ⊔ b)ᶜ = aᶜ ⊓ bᶜ := by
+  apply le_antisymm
+  · exact le_inf (compl_antitone le_sup_left) (compl_antitone le_sup_right)
+  · have ha : a ≤ (aᶜ ⊓ bᶜ)ᶜ := by
+      have h : aᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_antitone inf_le_left
+      rwa [compl_compl] at h
+    have hb : b ≤ (aᶜ ⊓ bᶜ)ᶜ := by
+      have h : bᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_antitone inf_le_right
+      rwa [compl_compl] at h
+    have h := compl_antitone (sup_le ha hb)
+    rwa [compl_compl] at h
+
+/-- De Morgan: complement of a meet is the join of complements. -/
+theorem compl_inf (a b : α) : (a ⊓ b)ᶜ = aᶜ ⊔ bᶜ := by
+  have h := compl_sup aᶜ bᶜ
+  rw [compl_compl, compl_compl] at h
+  rw [← h, compl_compl]
+
+@[simp] theorem compl_bot : (⊥ : α)ᶜ = ⊤ :=
+  le_antisymm le_top (compl_compl (⊤ : α) ▸ compl_antitone bot_le)
+
+@[simp] theorem compl_top : (⊤ : α)ᶜ = ⊥ := by
+  have h : (⊤ : α)ᶜ ≤ ⊥ᶜᶜ := compl_antitone le_top
+  rw [compl_compl] at h
+  exact le_antisymm h bot_le
+
+end LatticeWithInvolution
+
+/-- A De Morgan algebra: a distributive bounded lattice with an involutive antitone
+complement. Unlike `BooleanAlgebra`, complementation may fail (`a ⊓ aᶜ ≠ ⊥`). -/
+class DeMorganAlgebra (α : Type*) extends DistribLattice α, LatticeWithInvolution α
+
+/-- A Kleene lattice: a De Morgan algebra satisfying the Kleene law. Named against
+mathlib's star-semiring `KleeneAlgebra`; this is Kalman's lattice notion, the variety of
+strong Kleene logic. -/
+class KleeneLattice (α : Type*) extends DeMorganAlgebra α where
+  /-- The Kleene law: contradictions lie below excluded middles. -/
+  inf_compl_le_sup_compl (a b : α) : a ⊓ aᶜ ≤ b ⊔ bᶜ
+
+/-- Every Boolean algebra is a Kleene lattice: the Kleene law degenerates through `⊥`.
+Low priority so Boolean API is preferred where applicable. -/
+instance (priority := 100) BooleanAlgebra.toKleeneLattice {α : Type*} [BooleanAlgebra α] :
+    KleeneLattice α where
+  compl_compl := compl_compl
+  compl_antitone := fun h => compl_le_compl h
+  inf_compl_le_sup_compl a _ := (BooleanAlgebra.inf_compl_le_bot a).trans _root_.bot_le

--- a/Linglib/Core/Order/DeMorganAlgebra.lean
+++ b/Linglib/Core/Order/DeMorganAlgebra.lean
@@ -13,7 +13,7 @@ the common reduct of `OrthocomplementedLattice` (which adds the complementation 
 `DeMorganAlgebra` (which adds distributivity instead). The De Morgan laws are proved once
 here, from involution and antitonicity alone. A `KleeneLattice` is a De Morgan algebra
 satisfying the Kleene law `a ⊓ aᶜ ≤ b ⊔ bᶜ`: every `BooleanAlgebra` qualifies (the law
-degenerates through `⊥`), and the three-element chain `Trivalent.Truth3` is the canonical
+degenerates through `⊥`), and the three-element chain `Trivalent` is the canonical
 non-Boolean example.
 
 Mathlib has no De Morgan/Kleene *lattice* class (its `KleeneAlgebra` is the

--- a/Linglib/Core/Order/DeMorganAlgebra.lean
+++ b/Linglib/Core/Order/DeMorganAlgebra.lean
@@ -24,6 +24,10 @@ lattice notion, not the regular-expression star-semiring that holds mathlib's ro
 algebras are here bounded, as in Balbes-Dwinger (the nLab entry defines the unbounded
 variant). `[UPSTREAM]` candidate for `Mathlib/Order/DeMorganAlgebra.lean`.
 
+TODO: a `Basic.lean` companion with the `OrderDual`/`Prod`/`Pi` instances and the
+`OrderIso α αᵒᵈ` bundling of the involution, mirroring mathlib's `Defs`/`Basic` split
+for `BooleanAlgebra`.
+
 ## Main definitions
 
 * `LatticeWithInvolution` — bounded lattice + involutive antitone `ᶜ`; De Morgan
@@ -41,18 +45,23 @@ class LatticeWithInvolution (α : Type*) extends Lattice α, BoundedOrder α, Co
   /-- Complement is involutive: `aᶜᶜ = a`. -/
   compl_compl (a : α) : aᶜᶜ = a
   /-- Complement is order-reversing. -/
-  compl_antitone {a b : α} : a ≤ b → bᶜ ≤ aᶜ
+  compl_le_compl {a b : α} : a ≤ b → bᶜ ≤ aᶜ
 
 namespace LatticeWithInvolution
 
 variable {α : Type*} [LatticeWithInvolution α] {a b : α}
 
-theorem compl_le_compl_iff_le : aᶜ ≤ bᶜ ↔ b ≤ a :=
-  ⟨fun h => compl_compl b ▸ compl_compl a ▸ compl_antitone h, fun h => compl_antitone h⟩
+/-- The complement is antitone (bundled form of the `compl_le_compl` field). -/
+theorem compl_anti : Antitone (compl : α → α) := fun _ _ h => compl_le_compl h
+
+@[simp] theorem compl_le_compl_iff_le : aᶜ ≤ bᶜ ↔ b ≤ a :=
+  ⟨fun h => compl_compl b ▸ compl_compl a ▸ compl_le_compl h, fun h => compl_le_compl h⟩
 
 theorem compl_injective : Function.Injective (compl : α → α) := fun _ _ h => by
   have := congrArg compl h
   rwa [compl_compl, compl_compl] at this
+
+@[simp] theorem compl_inj_iff : aᶜ = bᶜ ↔ a = b := compl_injective.eq_iff
 
 theorem compl_surjective : Function.Surjective (compl : α → α) :=
   fun a => ⟨aᶜ, compl_compl a⟩
@@ -62,33 +71,33 @@ theorem compl_eq_iff_eq_compl : aᶜ = b ↔ a = bᶜ :=
 
 /-- Orthogonality is symmetric: `a ≤ bᶜ ↔ b ≤ aᶜ`. -/
 theorem le_compl_comm : a ≤ bᶜ ↔ b ≤ aᶜ :=
-  ⟨fun h => compl_compl b ▸ compl_antitone h, fun h => compl_compl a ▸ compl_antitone h⟩
+  ⟨fun h => compl_compl b ▸ compl_le_compl h, fun h => compl_compl a ▸ compl_le_compl h⟩
 
 /-- De Morgan: complement of a join is the meet of complements — from involution and
 antitonicity alone; no distributivity or complementation is used. -/
-theorem compl_sup (a b : α) : (a ⊔ b)ᶜ = aᶜ ⊓ bᶜ := by
+@[simp] theorem compl_sup (a b : α) : (a ⊔ b)ᶜ = aᶜ ⊓ bᶜ := by
   apply le_antisymm
-  · exact le_inf (compl_antitone le_sup_left) (compl_antitone le_sup_right)
+  · exact le_inf (compl_le_compl le_sup_left) (compl_le_compl le_sup_right)
   · have ha : a ≤ (aᶜ ⊓ bᶜ)ᶜ := by
-      have h : aᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_antitone inf_le_left
+      have h : aᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_le_compl inf_le_left
       rwa [compl_compl] at h
     have hb : b ≤ (aᶜ ⊓ bᶜ)ᶜ := by
-      have h : bᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_antitone inf_le_right
+      have h : bᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_le_compl inf_le_right
       rwa [compl_compl] at h
-    have h := compl_antitone (sup_le ha hb)
+    have h := compl_le_compl (sup_le ha hb)
     rwa [compl_compl] at h
 
 /-- De Morgan: complement of a meet is the join of complements. -/
-theorem compl_inf (a b : α) : (a ⊓ b)ᶜ = aᶜ ⊔ bᶜ := by
+@[simp] theorem compl_inf (a b : α) : (a ⊓ b)ᶜ = aᶜ ⊔ bᶜ := by
   have h := compl_sup aᶜ bᶜ
   rw [compl_compl, compl_compl] at h
   rw [← h, compl_compl]
 
 @[simp] theorem compl_bot : (⊥ : α)ᶜ = ⊤ :=
-  le_antisymm le_top (compl_compl (⊤ : α) ▸ compl_antitone bot_le)
+  le_antisymm le_top (compl_compl (⊤ : α) ▸ compl_le_compl bot_le)
 
 @[simp] theorem compl_top : (⊤ : α)ᶜ = ⊥ := by
-  have h : (⊤ : α)ᶜ ≤ ⊥ᶜᶜ := compl_antitone le_top
+  have h : (⊤ : α)ᶜ ≤ ⊥ᶜᶜ := compl_le_compl le_top
   rw [compl_compl] at h
   exact le_antisymm h bot_le
 
@@ -110,5 +119,5 @@ Low priority so Boolean API is preferred where applicable. -/
 instance (priority := 100) BooleanAlgebra.toOrderKleeneAlgebra {α : Type*}
     [BooleanAlgebra α] : Order.KleeneAlgebra α where
   compl_compl := compl_compl
-  compl_antitone := fun h => compl_le_compl h
+  compl_le_compl := fun h => compl_le_compl h
   inf_compl_le_sup_compl a _ := (BooleanAlgebra.inf_compl_le_bot a).trans _root_.bot_le

--- a/Linglib/Core/Order/DeMorganAlgebra.lean
+++ b/Linglib/Core/Order/DeMorganAlgebra.lean
@@ -6,20 +6,23 @@ Authors: Robert Hawkins
 import Mathlib.Order.BooleanAlgebra.Basic
 
 /-!
-# De Morgan algebras and Kleene lattices
+# De Morgan algebras and Kleene algebras
 
 `LatticeWithInvolution` is a bounded lattice with an involutive antitone complement `ᶜ` —
 the common reduct of `OrthocomplementedLattice` (which adds the complementation laws) and
 `DeMorganAlgebra` (which adds distributivity instead). The De Morgan laws are proved once
-here, from involution and antitonicity alone. A `KleeneLattice` is a De Morgan algebra
-satisfying the Kleene law `a ⊓ aᶜ ≤ b ⊔ bᶜ`: every `BooleanAlgebra` qualifies (the law
-degenerates through `⊥`), and the three-element chain `Trivalent` is the canonical
-non-Boolean example.
+here, from involution and antitonicity alone. An `Order.KleeneAlgebra` is a De Morgan
+algebra satisfying the Kleene law `a ⊓ aᶜ ≤ b ⊔ bᶜ`: every `BooleanAlgebra` qualifies
+(the law degenerates through `⊥`), and the three-element chain `Trivalent` is the
+canonical non-Boolean example. These are the involution branch between mathlib's
+`DistribLattice` and `BooleanAlgebra`, beside the existing pseudocomplement branch
+(`HeytingAlgebra`).
 
-Mathlib has no De Morgan/Kleene *lattice* class (its `KleeneAlgebra` is the
-star-semiring); `[UPSTREAM]` candidate for `Mathlib/Order/DeMorganAlgebra.lean`. The
-`Lattice`/`Algebra` suffix split tracks the literature (Kalman's Kleene lattices) and
-avoids the star-semiring collision, on the `Order.Ideal` vs ring `Ideal` precedent.
+Naming follows the literature exactly ("De Morgan algebra", "Kleene algebra" — the
+lattice notion, not the regular-expression star-semiring that holds mathlib's root
+`KleeneAlgebra`), disambiguated by namespace on the `Order.Frame` precedent. De Morgan
+algebras are here bounded, as in Balbes-Dwinger (the nLab entry defines the unbounded
+variant). `[UPSTREAM]` candidate for `Mathlib/Order/DeMorganAlgebra.lean`.
 
 ## Main definitions
 
@@ -27,7 +30,7 @@ avoids the star-semiring collision, on the `Order.Ideal` vs ring `Ideal` precede
   (`compl_sup`/`compl_inf`), `compl_bot`/`compl_top`, and the injectivity/order lemmas
   are derived here.
 * `DeMorganAlgebra` — a distributive `LatticeWithInvolution`.
-* `KleeneLattice` — a `DeMorganAlgebra` with the Kleene law
+* `Order.KleeneAlgebra` — a `DeMorganAlgebra` with the Kleene law
   (`inf_compl_le_sup_compl`); every `BooleanAlgebra` is an instance.
 -/
 
@@ -95,17 +98,17 @@ end LatticeWithInvolution
 complement. Unlike `BooleanAlgebra`, complementation may fail (`a ⊓ aᶜ ≠ ⊥`). -/
 class DeMorganAlgebra (α : Type*) extends DistribLattice α, LatticeWithInvolution α
 
-/-- A Kleene lattice: a De Morgan algebra satisfying the Kleene law. Named against
-mathlib's star-semiring `KleeneAlgebra`; this is Kalman's lattice notion, the variety of
-strong Kleene logic. -/
-class KleeneLattice (α : Type*) extends DeMorganAlgebra α where
+/-- A Kleene algebra (the lattice notion, Kalman's variety of strong Kleene logic — not
+the regular-expression star-semiring at root `KleeneAlgebra`): a De Morgan algebra
+satisfying the Kleene law. -/
+class Order.KleeneAlgebra (α : Type*) extends DeMorganAlgebra α where
   /-- The Kleene law: contradictions lie below excluded middles. -/
   inf_compl_le_sup_compl (a b : α) : a ⊓ aᶜ ≤ b ⊔ bᶜ
 
-/-- Every Boolean algebra is a Kleene lattice: the Kleene law degenerates through `⊥`.
+/-- Every Boolean algebra is a Kleene algebra: the Kleene law degenerates through `⊥`.
 Low priority so Boolean API is preferred where applicable. -/
-instance (priority := 100) BooleanAlgebra.toKleeneLattice {α : Type*} [BooleanAlgebra α] :
-    KleeneLattice α where
+instance (priority := 100) BooleanAlgebra.toOrderKleeneAlgebra {α : Type*}
+    [BooleanAlgebra α] : Order.KleeneAlgebra α where
   compl_compl := compl_compl
   compl_antitone := fun h => compl_le_compl h
   inf_compl_le_sup_compl a _ := (BooleanAlgebra.inf_compl_le_bot a).trans _root_.bot_le

--- a/Linglib/Core/Order/DeMorganAlgebra/Basic.lean
+++ b/Linglib/Core/Order/DeMorganAlgebra/Basic.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.Hom.Basic
+import Linglib.Core.Order.DeMorganAlgebra.Defs
+
+/-!
+# De Morgan and Kleene algebras: instances
+
+`OrderDual`, `Prod`, and `Pi` instances for `LatticeWithInvolution`, `DeMorganAlgebra`,
+and `Order.KleeneAlgebra`, plus the involution bundled as an order isomorphism
+`α ≃o αᵒᵈ` — the `Defs`/`Basic` split mathlib uses for `BooleanAlgebra`
+(cf. `OrderIso.compl` there, which this generalizes past complementation).
+-/
+
+open LatticeWithInvolution OrderDual
+
+variable {α β : Type*}
+
+/-! ### OrderDual -/
+
+instance [LatticeWithInvolution α] : LatticeWithInvolution αᵒᵈ where
+  compl a := toDual (ofDual a)ᶜ
+  compl_compl a := congrArg toDual (compl_compl (ofDual a))
+  compl_le_compl h := compl_le_compl (α := α) h
+
+instance [DeMorganAlgebra α] : DeMorganAlgebra αᵒᵈ where
+  __ := (inferInstance : DistribLattice αᵒᵈ)
+  __ := (inferInstance : LatticeWithInvolution αᵒᵈ)
+
+instance [Order.KleeneAlgebra α] : Order.KleeneAlgebra αᵒᵈ where
+  inf_compl_le_sup_compl a b :=
+    Order.KleeneAlgebra.inf_compl_le_sup_compl (ofDual b) (ofDual a)
+
+/-! ### Prod -/
+
+instance [LatticeWithInvolution α] [LatticeWithInvolution β] :
+    LatticeWithInvolution (α × β) where
+  compl p := (p.1ᶜ, p.2ᶜ)
+  compl_compl p := Prod.ext (compl_compl p.1) (compl_compl p.2)
+  compl_le_compl h := ⟨compl_le_compl h.1, compl_le_compl h.2⟩
+
+instance [DeMorganAlgebra α] [DeMorganAlgebra β] : DeMorganAlgebra (α × β) where
+  __ := (inferInstance : DistribLattice (α × β))
+  __ := (inferInstance : LatticeWithInvolution (α × β))
+
+instance [Order.KleeneAlgebra α] [Order.KleeneAlgebra β] :
+    Order.KleeneAlgebra (α × β) where
+  inf_compl_le_sup_compl a b :=
+    ⟨Order.KleeneAlgebra.inf_compl_le_sup_compl a.1 b.1,
+     Order.KleeneAlgebra.inf_compl_le_sup_compl a.2 b.2⟩
+
+/-! ### Pi -/
+
+instance {ι : Type*} {π : ι → Type*} [∀ i, LatticeWithInvolution (π i)] :
+    LatticeWithInvolution (∀ i, π i) where
+  compl f i := (f i)ᶜ
+  compl_compl f := funext λ i => compl_compl (f i)
+  compl_le_compl h i := compl_le_compl (h i)
+
+instance {ι : Type*} {π : ι → Type*} [∀ i, DeMorganAlgebra (π i)] :
+    DeMorganAlgebra (∀ i, π i) where
+  __ := (inferInstance : DistribLattice (∀ i, π i))
+  __ := (inferInstance : LatticeWithInvolution (∀ i, π i))
+
+instance {ι : Type*} {π : ι → Type*} [∀ i, Order.KleeneAlgebra (π i)] :
+    Order.KleeneAlgebra (∀ i, π i) where
+  inf_compl_le_sup_compl f g i :=
+    Order.KleeneAlgebra.inf_compl_le_sup_compl (f i) (g i)
+
+/-! ### The involution as an order isomorphism -/
+
+/-- The involution bundled as an order isomorphism onto the order dual — the
+generalization of mathlib's `OrderIso.compl` from `BooleanAlgebra` to any
+`LatticeWithInvolution`. -/
+def LatticeWithInvolution.complOrderIso (α : Type*) [LatticeWithInvolution α] :
+    α ≃o αᵒᵈ where
+  toFun a := toDual aᶜ
+  invFun a := (ofDual a)ᶜ
+  left_inv := compl_compl
+  right_inv a := congrArg toDual (compl_compl (ofDual a))
+  map_rel_iff' := compl_le_compl_iff_le

--- a/Linglib/Core/Order/DeMorganAlgebra/Defs.lean
+++ b/Linglib/Core/Order/DeMorganAlgebra/Defs.lean
@@ -22,11 +22,8 @@ Naming follows the literature exactly ("De Morgan algebra", "Kleene algebra" —
 lattice notion, not the regular-expression star-semiring that holds mathlib's root
 `KleeneAlgebra`), disambiguated by namespace on the `Order.Frame` precedent. De Morgan
 algebras are here bounded, as in Balbes-Dwinger (the nLab entry defines the unbounded
-variant). `[UPSTREAM]` candidate for `Mathlib/Order/DeMorganAlgebra.lean`.
-
-TODO: a `Basic.lean` companion with the `OrderDual`/`Prod`/`Pi` instances and the
-`OrderIso α αᵒᵈ` bundling of the involution, mirroring mathlib's `Defs`/`Basic` split
-for `BooleanAlgebra`.
+variant). `[UPSTREAM]` candidate for `Mathlib/Order/DeMorganAlgebra/`; the `OrderDual`/`Prod`/`Pi`
+instances and the `OrderIso α αᵒᵈ` bundling live in `DeMorganAlgebra/Basic.lean`.
 
 ## Main definitions
 

--- a/Linglib/Core/Order/Orthoframe.lean
+++ b/Linglib/Core/Order/Orthoframe.lean
@@ -88,7 +88,7 @@ theorem extent_bot_eq_empty [Std.Irrefl r] : (⊥ : Concept S S r).extent = ∅ 
 instance instOrthocomplementedLattice [Std.Symm r] [Std.Irrefl r] :
     OrthocomplementedLattice (Concept S S r) where
   compl_compl c := Concept.ext <| by simp [Order.upperPolar_eq_lowerPolar]
-  compl_antitone {c d} h := by
+  compl_le_compl {c d} h := by
     show d.intent ⊆ c.intent
     rw [← c.upperPolar_extent, ← d.upperPolar_extent]; exact upperPolar_anti r h
   inf_compl_le_bot c := fun x hx => absurd (rel_extent_intent hx.1 hx.2) (Std.Irrefl.irrefl x)

--- a/Linglib/Core/Order/Orthoframe/Representation.lean
+++ b/Linglib/Core/Order/Orthoframe/Representation.lean
@@ -45,8 +45,8 @@ abbrev Point (V : Set L) : Type _ := {a : L // a ∈ V ∧ a ≠ ⊥}
 def ofOrtholattice (V : Set L) : Orthoframe (Point V) where
   ortho a b := a.1 ≤ b.1ᶜ
   ortho_symm := ⟨fun a b h => by
-    have := OrthocomplementedLattice.compl_antitone h
-    rwa [OrthocomplementedLattice.compl_compl] at this⟩
+    have := LatticeWithInvolution.compl_le_compl h
+    rwa [LatticeWithInvolution.compl_compl] at this⟩
   ortho_irrefl := ⟨fun a h => a.2.2 <| le_bot_iff.mp <|
     (le_inf le_rfl h).trans (OrthocomplementedLattice.inf_compl_le_bot a.1)⟩
 
@@ -78,12 +78,12 @@ theorem upperPolar_Iic (hV : JoinDense V) (x : L) :
 theorem isExtent_Iic (hV : JoinDense V) (a : L) :
     IsExtent (ofOrtholattice V).ortho {b : Point V | b.1 ≤ a} := by
   have key : {d : Point V | a ≤ d.1ᶜ} = {d : Point V | d.1 ≤ aᶜ} := by
-    ext d; exact OrthocomplementedLattice.le_compl_comm
+    ext d; exact LatticeWithInvolution.le_compl_comm
   rw [isExtent_iff, upperPolar_Iic hV a, key,
       ← upperPolar_eq_lowerPolar (ofOrtholattice V).ortho, upperPolar_Iic hV aᶜ]
   ext e
-  rw [Set.mem_setOf_eq, Set.mem_setOf_eq, OrthocomplementedLattice.le_compl_comm,
-      OrthocomplementedLattice.compl_compl]
+  rw [Set.mem_setOf_eq, Set.mem_setOf_eq, LatticeWithInvolution.le_compl_comm,
+      LatticeWithInvolution.compl_compl]
 
 /-- The representation map's extent is exactly `{b ∈ V\{0} | b ≤ a}` (Thm 4.13). -/
 theorem represent_extent (hV : JoinDense V) (a : L) :
@@ -138,17 +138,17 @@ theorem represent_compl (hV : JoinDense V) (a : L) :
   simp only [represent_extent hV]
   rw [upperPolar_Iic hV]
   ext b
-  exact OrthocomplementedLattice.le_compl_comm
+  exact LatticeWithInvolution.le_compl_comm
 
 /-- `represent` preserves joins (from `⊓`- and `ᶜ`-preservation via De Morgan). -/
 theorem represent_sup (hV : JoinDense V) (a a' : L) :
     represent V (a ⊔ a') = represent V a ⊔ represent V a' := by
   rw [show a ⊔ a' = (aᶜ ⊓ a'ᶜ)ᶜ by
-        rw [OrthocomplementedLattice.compl_inf, OrthocomplementedLattice.compl_compl,
-            OrthocomplementedLattice.compl_compl],
+        rw [LatticeWithInvolution.compl_inf, LatticeWithInvolution.compl_compl,
+            LatticeWithInvolution.compl_compl],
       represent_compl hV, represent_inf hV, represent_compl hV, represent_compl hV,
-      OrthocomplementedLattice.compl_inf, OrthocomplementedLattice.compl_compl,
-      OrthocomplementedLattice.compl_compl]
+      LatticeWithInvolution.compl_inf, LatticeWithInvolution.compl_compl,
+      LatticeWithInvolution.compl_compl]
 
 /-! ### The representation isomorphism (complete case, Theorem 4.13) -/
 

--- a/Linglib/Core/Order/Ortholattice.lean
+++ b/Linglib/Core/Order/Ortholattice.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Order.BooleanAlgebra.Basic
 import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.Disjoint
@@ -31,7 +36,7 @@ The canonical examples are:
 ## Main results
 
 * De Morgan laws (`compl_sup`, `compl_inf`), `compl_injective`, `compl_surjective`,
-  `compl_le_compl_iff_le` — inherited from `LatticeWithInvolution` and re-exported.
+  `compl_le_compl_iff_le` — inherited from `LatticeWithInvolution` (use those names).
 * `instBooleanOrtho`: every `BooleanAlgebra` is an `OrthocomplementedLattice`
   (low priority so Boolean instances aren't obscured).
 * `instComplementedLattice`: every ortholattice is `ComplementedLattice`
@@ -75,11 +80,7 @@ class OrthocomplementedLattice (α : Type*) extends LatticeWithInvolution α whe
 namespace OrthocomplementedLattice
 
 /- The involutive-antitone consequences (De Morgan, injectivity, `le_compl_comm`, …) are
-inherited from the shared base `LatticeWithInvolution`; re-exported here so consumers can
-keep the `OrthocomplementedLattice.*` names. -/
-export LatticeWithInvolution (compl_compl compl_antitone compl_le_compl_iff_le
-  compl_injective compl_surjective compl_eq_iff_eq_compl le_compl_comm
-  compl_sup compl_inf compl_bot compl_top)
+inherited from the shared base: use the `LatticeWithInvolution.*` names. -/
 
 variable {α : Type*} [OrthocomplementedLattice α] {a b : α}
 
@@ -112,7 +113,7 @@ end OrthocomplementedLattice
 instance (priority := 100) instBooleanOrtho {α : Type*} [BooleanAlgebra α] :
     OrthocomplementedLattice α where
   compl_compl := _root_.compl_compl
-  compl_antitone := fun h => _root_.compl_le_compl h
+  compl_le_compl := fun h => _root_.compl_le_compl h
   inf_compl_le_bot := BooleanAlgebra.inf_compl_le_bot
   top_le_sup_compl := BooleanAlgebra.top_le_sup_compl
 

--- a/Linglib/Core/Order/Ortholattice.lean
+++ b/Linglib/Core/Order/Ortholattice.lean
@@ -1,6 +1,7 @@
 import Mathlib.Order.BooleanAlgebra.Basic
 import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.Disjoint
+import Linglib.Core.Order.DeMorganAlgebra
 
 /-!
 # Orthocomplemented Lattices
@@ -23,13 +24,14 @@ The canonical examples are:
 
 ## Main definitions
 
-* `OrthocomplementedLattice α` — typeclass extending `Lattice α`,
-  `BoundedOrder α`, `Compl α` with the four ortholattice axioms.
+* `OrthocomplementedLattice α` — typeclass extending `LatticeWithInvolution α`
+  (the shared involutive-antitone-`ᶜ` base, `Core/Order/DeMorganAlgebra.lean`)
+  with non-contradiction and excluded middle.
 
 ## Main results
 
-* De Morgan laws (`compl_sup`, `compl_inf`).
-* `compl_injective`, `compl_surjective`, `compl_le_compl_iff_le`.
+* De Morgan laws (`compl_sup`, `compl_inf`), `compl_injective`, `compl_surjective`,
+  `compl_le_compl_iff_le` — inherited from `LatticeWithInvolution` and re-exported.
 * `instBooleanOrtho`: every `BooleanAlgebra` is an `OrthocomplementedLattice`
   (low priority so Boolean instances aren't obscured).
 * `instComplementedLattice`: every ortholattice is `ComplementedLattice`
@@ -58,24 +60,26 @@ provides every ingredient (`Submodule.orthogonal`, `inf_orthogonal_eq_bot`,
 `OrthocomplementedLattice` instance because the typeclass is missing.
 -/
 
-/-- An *orthocomplemented lattice* (ortholattice) is a bounded lattice
-    `α` equipped with an involutive, order-reversing complement `ᶜ`
-    satisfying non-contradiction (`a ⊓ aᶜ ≤ ⊥`) and excluded middle
+/-- An *orthocomplemented lattice* (ortholattice) is a `LatticeWithInvolution`
+    additionally satisfying non-contradiction (`a ⊓ aᶜ ≤ ⊥`) and excluded middle
     (`⊤ ≤ a ⊔ aᶜ`).
 
     Every `BooleanAlgebra` is an ortholattice. The converse fails:
     ortholattices need not be distributive. -/
-class OrthocomplementedLattice (α : Type*) extends Lattice α, BoundedOrder α, Compl α where
-  /-- Complement is involutive: `aᶜᶜ = a`. -/
-  compl_compl (a : α) : aᶜᶜ = a
-  /-- Complement is order-reversing. -/
-  compl_antitone {a b : α} : a ≤ b → bᶜ ≤ aᶜ
+class OrthocomplementedLattice (α : Type*) extends LatticeWithInvolution α where
   /-- Non-contradiction: `a ⊓ aᶜ ≤ ⊥`. -/
   inf_compl_le_bot (a : α) : a ⊓ aᶜ ≤ ⊥
   /-- Excluded middle: `⊤ ≤ a ⊔ aᶜ`. -/
   top_le_sup_compl (a : α) : ⊤ ≤ a ⊔ aᶜ
 
 namespace OrthocomplementedLattice
+
+/- The involutive-antitone consequences (De Morgan, injectivity, `le_compl_comm`, …) are
+inherited from the shared base `LatticeWithInvolution`; re-exported here so consumers can
+keep the `OrthocomplementedLattice.*` names. -/
+export LatticeWithInvolution (compl_compl compl_antitone compl_le_compl_iff_le
+  compl_injective compl_surjective compl_eq_iff_eq_compl le_compl_comm
+  compl_sup compl_inf compl_bot compl_top)
 
 variable {α : Type*} [OrthocomplementedLattice α] {a b : α}
 
@@ -88,61 +92,6 @@ theorem inf_compl_eq_bot (a : α) : a ⊓ aᶜ = ⊥ :=
 @[simp]
 theorem sup_compl_eq_top (a : α) : a ⊔ aᶜ = ⊤ :=
   le_antisymm le_top (OrthocomplementedLattice.top_le_sup_compl a)
-
-@[simp]
-theorem compl_bot : (⊥ : α)ᶜ = ⊤ := by
-  have h := sup_compl_eq_top (⊥ : α); rwa [bot_sup_eq] at h
-
-@[simp]
-theorem compl_top : (⊤ : α)ᶜ = ⊥ := by
-  have h := inf_compl_eq_bot (⊤ : α); rwa [top_inf_eq] at h
-
-/-! ### Order Properties -/
-
-theorem compl_le_compl_iff_le : aᶜ ≤ bᶜ ↔ b ≤ a :=
-  ⟨fun h => OrthocomplementedLattice.compl_compl b ▸
-            OrthocomplementedLattice.compl_compl a ▸
-            OrthocomplementedLattice.compl_antitone h,
-   fun h => OrthocomplementedLattice.compl_antitone h⟩
-
-theorem compl_injective : Function.Injective (compl : α → α) :=
-  fun _ _ h => by
-    have := congrArg compl h
-    rwa [OrthocomplementedLattice.compl_compl, OrthocomplementedLattice.compl_compl] at this
-
-theorem compl_surjective : Function.Surjective (compl : α → α) :=
-  fun a => ⟨aᶜ, OrthocomplementedLattice.compl_compl a⟩
-
-theorem compl_eq_iff_eq_compl : aᶜ = b ↔ a = bᶜ := by
-  constructor
-  · intro h; rw [← h, OrthocomplementedLattice.compl_compl]
-  · intro h; rw [h, OrthocomplementedLattice.compl_compl]
-
-/-- Orthogonality is symmetric: `a ≤ bᶜ ↔ b ≤ aᶜ`. -/
-theorem le_compl_comm : a ≤ bᶜ ↔ b ≤ aᶜ :=
-  ⟨fun h => compl_compl b ▸ compl_antitone h, fun h => compl_compl a ▸ compl_antitone h⟩
-
-/-! ### De Morgan Laws -/
-
-theorem compl_sup (a b : α) : (a ⊔ b)ᶜ = aᶜ ⊓ bᶜ := by
-  apply le_antisymm
-  · exact le_inf (compl_antitone le_sup_left) (compl_antitone le_sup_right)
-  · have ha : a ≤ (aᶜ ⊓ bᶜ)ᶜ := by
-      have h1 : aᶜ ⊓ bᶜ ≤ aᶜ := inf_le_left
-      have h2 : aᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_antitone h1
-      rwa [OrthocomplementedLattice.compl_compl] at h2
-    have hb : b ≤ (aᶜ ⊓ bᶜ)ᶜ := by
-      have h1 : aᶜ ⊓ bᶜ ≤ bᶜ := inf_le_right
-      have h2 : bᶜᶜ ≤ (aᶜ ⊓ bᶜ)ᶜ := compl_antitone h1
-      rwa [OrthocomplementedLattice.compl_compl] at h2
-    have hab : a ⊔ b ≤ (aᶜ ⊓ bᶜ)ᶜ := sup_le ha hb
-    have h3 : (aᶜ ⊓ bᶜ)ᶜᶜ ≤ (a ⊔ b)ᶜ := compl_antitone hab
-    rwa [OrthocomplementedLattice.compl_compl] at h3
-
-theorem compl_inf (a b : α) : (a ⊓ b)ᶜ = aᶜ ⊔ bᶜ := by
-  have h := compl_sup aᶜ bᶜ
-  rw [OrthocomplementedLattice.compl_compl, OrthocomplementedLattice.compl_compl] at h
-  rw [← h, OrthocomplementedLattice.compl_compl]
 
 /-! ### IsCompl and ComplementedLattice -/
 

--- a/Linglib/Core/Order/Ortholattice.lean
+++ b/Linglib/Core/Order/Ortholattice.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Order.BooleanAlgebra.Basic
 import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.Disjoint
-import Linglib.Core.Order.DeMorganAlgebra
+import Linglib.Core.Order.DeMorganAlgebra.Defs
 
 /-!
 # Orthocomplemented Lattices
@@ -30,7 +30,7 @@ The canonical examples are:
 ## Main definitions
 
 * `OrthocomplementedLattice α` — typeclass extending `LatticeWithInvolution α`
-  (the shared involutive-antitone-`ᶜ` base, `Core/Order/DeMorganAlgebra.lean`)
+  (the shared involutive-antitone-`ᶜ` base, `Core/Order/DeMorganAlgebra/Defs.lean`)
   with non-contradiction and excluded middle.
 
 ## Main results

--- a/Linglib/Data/Generalizations/HomogeneityGap.lean
+++ b/Linglib/Data/Generalizations/HomogeneityGap.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Features.Polarity
 import Linglib.Data.Examples.Schema
 import Linglib.Data.Examples.KrizChemla2015
@@ -26,7 +26,7 @@ polarity × scenario grid. The `Predict` signatures differ (`Polarity` vs
 
 * `GapScenario` — ALL / NONE / GAP scenario triad.
 * `GapPredict` — signature a rival account must implement:
-  `Polarity → GapScenario → Truth3`.
+  `Polarity → GapScenario → Trivalent`.
 * `GapDatum` — typed empirical datum lifted from `LinguisticExample`
   rows by `fromExample` (paperFeatures keys `polarity`, `condition`,
   `gap_detected`; rows with an `embedding` key other than `unembedded`
@@ -41,7 +41,6 @@ paper's study file, not here.
 
 namespace Generalizations.HomogeneityGap
 
-open Trivalent (Truth3)
 open Data.Examples (LinguisticExample SourceRef)
 open Features (Polarity)
 
@@ -64,7 +63,7 @@ Prediction signature for accounts of the unembedded homogeneity gap:
 given the sentence polarity and the scenario, the trivalent value the
 account assigns.
 -/
-abbrev GapPredict := Polarity → GapScenario → Truth3
+abbrev GapPredict := Polarity → GapScenario → Trivalent
 
 /--
 Empirical datum lifted from a paper-anchored `LinguisticExample`:
@@ -74,7 +73,7 @@ this `(polarity, scenario)` cell.
 structure GapDatum where
   polarity : Polarity
   scenario : GapScenario
-  observed : Truth3
+  observed : Trivalent
   source   : SourceRef
   deriving Repr, DecidableEq
 
@@ -98,7 +97,7 @@ Observed trivalent value for a baseline cell, determined by polarity:
 a positive sentence is true in ALL and false in NONE; a negative one
 the reverse.
 -/
-def baselineTruth (p : Polarity) (s : GapScenario) : Truth3 :=
+def baselineTruth (p : Polarity) (s : GapScenario) : Trivalent :=
   match p, s with
   | .positive, .all => .true
   | .negative, .all => .false
@@ -114,7 +113,7 @@ neither key are not pool cells — they carry study-local refinements
 (removers, borderline-response items, issue-relativized judgments) and
 are excluded rather than assigned a fabricated value.
 -/
-def gapTruth (features : List (String × String)) : Option Truth3 :=
+def gapTruth (features : List (String × String)) : Option Trivalent :=
   if (features.lookup "gap_detected").getD "false" == "true" then
     some .indet
   else match features.lookup "classical_value" with

--- a/Linglib/Data/Generalizations/HomogeneityGap.lean
+++ b/Linglib/Data/Generalizations/HomogeneityGap.lean
@@ -41,7 +41,7 @@ paper's study file, not here.
 
 namespace Generalizations.HomogeneityGap
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Data.Examples (LinguisticExample SourceRef)
 open Features (Polarity)
 

--- a/Linglib/Data/Generalizations/HomogeneityProjection.lean
+++ b/Linglib/Data/Generalizations/HomogeneityProjection.lean
@@ -74,7 +74,7 @@ mapping would be wrong for at least one consumer.
 
 namespace Generalizations.HomogeneityProjection
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Data.Examples (LinguisticExample SourceRef)
 
 /-! ### Substrate -/

--- a/Linglib/Data/Generalizations/HomogeneityProjection.lean
+++ b/Linglib/Data/Generalizations/HomogeneityProjection.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Data.Examples.Schema
 import Linglib.Data.Examples.KrizChemla2015
 
@@ -21,7 +21,7 @@ generalisation predates any one formal account, justifying a theory-neutral
   (TRUE / FALSE / GAP / GAP? / GAP??).
 * `ProjectionPredict` — the shared signature any account of homogeneity
   projection must satisfy; given an `(operator, scenario)` pair, predict a
-  trivalent `Truth3` value.
+  trivalent `Trivalent` value.
 * `ProjectionDatum` — typed empirical datum; lifted from the raw
   `LinguisticExample` rows by `fromExample`.
 * `Examples` (generator-managed) — pooled stimulus rows from each paper
@@ -74,7 +74,6 @@ mapping would be wrong for at least one consumer.
 
 namespace Generalizations.HomogeneityProjection
 
-open Trivalent (Truth3)
 open Data.Examples (LinguisticExample SourceRef)
 
 /-! ### Substrate -/
@@ -110,9 +109,9 @@ inductive GapScenario where
 /--
 Theoretical-prediction signature any account of homogeneity projection
 must satisfy: given an embedder label and a scenario, predict the
-trivalent `Truth3` value the account commits to.
+trivalent `Trivalent` value the account commits to.
 -/
-abbrev ProjectionPredict := EmbeddingOperator → GapScenario → Truth3
+abbrev ProjectionPredict := EmbeddingOperator → GapScenario → Trivalent
 
 /--
 Empirical datum derived from a paper-anchored `LinguisticExample`.
@@ -122,7 +121,7 @@ Empirical datum derived from a paper-anchored `LinguisticExample`.
 structure ProjectionDatum where
   operator : EmbeddingOperator
   scenario : GapScenario
-  observed : Truth3
+  observed : Trivalent
   source   : SourceRef
   deriving Repr, DecidableEq
 
@@ -152,7 +151,7 @@ def parseScenario : String → Option GapScenario
   | _       => none
 
 /--
-Compute the observed `Truth3` value for a `(scenario, gapDetected)` cell.
+Compute the observed `Trivalent` value for a `(scenario, gapDetected)` cell.
 
 Baseline conditions are unambiguous: `TRUE → .true`, `FALSE → .false`.
 For gap-bearing scenarios, gap detection means the empirical distribution
@@ -160,7 +159,7 @@ peaks on the trivalent middle (`.indet`); a non-detection on a
 gap-bearing scenario means an alternative reading (typically an at-least
 reading for non-monotonic embedders) rendered the sentence non-gappy.
 -/
-def observedTruth (scenario : GapScenario) (gapDetected : Bool) : Truth3 :=
+def observedTruth (scenario : GapScenario) (gapDetected : Bool) : Trivalent :=
   match scenario, gapDetected with
   | .trueScenario,  _    => .true
   | .falseScenario, _    => .false

--- a/Linglib/Pragmatics/Implicature/Defs.lean
+++ b/Linglib/Pragmatics/Implicature/Defs.lean
@@ -25,7 +25,7 @@ The ontology of "what an implicature is" is contested in the literature:
   change in degrees of belief, not a discrete proposition. Instantiated
   by `S := ℝ≥0` or similar graded type.
 - **Trivalent** accounts (presupposition-bearing, partial) instantiate
-  with `S := Truth3`.
+  with `S := Truth`.
 
 Parameterizing rather than committing lets each mechanism use its
 native output type. The categorical Gricean diagnostics
@@ -158,7 +158,7 @@ A pragmatic inference, parameterized by:
 - **`W`** — the world type
 - **`S`** — the strength type (default `Prop` for the discrete /
   Gricean / grammaticalist ontology; instantiate with `ℝ≥0` for
-  graded / RSA-style; with `Truth3` for trivalent)
+  graded / RSA-style; with `Truth` for trivalent)
 
 Every value carries:
 - `kind`      — taxonomic classification

--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -43,7 +43,7 @@ namespace Semantics.Conditionals.Counterfactual
 open Intensional (WorldTimeIndex)
 
 open Semantics.Conditionals
-open Core.Duality (Truth3 ProjectionType dist)
+open Trivalent (Truth3 ProjectionType dist)
 
 
 open Core.Order (SimilarityOrdering)
@@ -97,7 +97,7 @@ This predicts:
   some students' closest study-worlds have passing, others don't
 -/
 
--- Three-valued truth from Core.Duality.Truth3
+-- Three-valued truth from Trivalent.Truth3
 
 /--
 Selectional counterfactual semantics (Stalnaker + supervaluation).
@@ -113,7 +113,7 @@ def selectionalCounterfactual {W : Type*} [DecidableEq W] [Fintype W]
     ¬ B w' then .false
   else .indet
 
-/-- **`selectionalCounterfactual` IS Fine super-truth** (`Core.Duality.dist`)
+/-- **`selectionalCounterfactual` IS Fine super-truth** (`Trivalent.dist`)
     on the Finset of closest worlds with the consequent as Boolean predicate.
 
     Bridge documenting the equivalence — keeps the bespoke 3-way if-chain
@@ -124,8 +124,8 @@ theorem selectionalCounterfactual_eq_dist {W : Type*} [DecidableEq W] [Fintype W
     (sim : SimilarityOrdering W) (A B : W → Prop)
     [DecidablePred A] [DecidablePred B] (w : W) :
     selectionalCounterfactual sim A B w =
-    Core.Duality.dist (sim.closestWorlds w (Finset.univ.filter A)) B := by
-  unfold selectionalCounterfactual Core.Duality.dist
+    Trivalent.dist (sim.closestWorlds w (Finset.univ.filter A)) B := by
+  unfold selectionalCounterfactual Trivalent.dist
   set s := sim.closestWorlds w (Finset.univ.filter A)
   by_cases h_all : ∀ w' ∈ s, B w'
   · rw [if_pos h_all, if_pos h_all]
@@ -306,7 +306,7 @@ theorem selectional_as_supervaluation {W : Type*} [DecidableEq W] [Fintype W]
 /-!
 ## Connection to Aggregation Pushforward
 
-`projectTruthValues` delegates directly to `Core.Duality.aggregate`, so
+`projectTruthValues` delegates directly to `Trivalent.aggregate`, so
 `embeddedSelectional_determinate` and `strength_determines_pattern` (in
 `QuantifierEmbedding.lean`) are thin wrappers around
 `Duality.aggregate_map_ofBool_ne_indet` and `Duality.aggregate_map_ofBool_mixed`
@@ -322,9 +322,9 @@ is invisible.
     the global aggregation pattern: mixed Bool inputs split duality types. -/
 theorem selectional_is_global_architecture (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    Core.Duality.aggregate .disjunctive (bs.map Truth3.ofBool) = .true ∧
-    Core.Duality.aggregate .conjunctive (bs.map Truth3.ofBool) = .false :=
-  Core.Duality.aggregate_map_ofBool_mixed bs h_some_true h_some_false
+    Trivalent.aggregate .disjunctive (bs.map Truth3.ofBool) = .true ∧
+    Trivalent.aggregate .conjunctive (bs.map Truth3.ofBool) = .false :=
+  Trivalent.aggregate_map_ofBool_mixed bs h_some_true h_some_false
 
 -- ════════════════════════════════════════════════════
 -- Might Counterfactuals: Lewis vs Stalnaker

--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Conditionals.WillConditional
 import Linglib.Semantics.Modality.Selectional
 import Linglib.Semantics.Supervaluation.Basic
 import Linglib.Semantics.Conditionals.SelectionFunction
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Duality
 
 /-!
@@ -43,7 +43,7 @@ namespace Semantics.Conditionals.Counterfactual
 open Intensional (WorldTimeIndex)
 
 open Semantics.Conditionals
-open Trivalent (Truth3 ProjectionType dist)
+open Trivalent (ProjectionType dist)
 
 
 open Core.Order (SimilarityOrdering)
@@ -97,7 +97,7 @@ This predicts:
   some students' closest study-worlds have passing, others don't
 -/
 
--- Three-valued truth from Trivalent.Truth3
+-- Three-valued truth from Trivalent.Trivalent
 
 /--
 Selectional counterfactual semantics (Stalnaker + supervaluation).
@@ -106,7 +106,7 @@ Returns a three-valued truth value based on agreement across selection functions
 -/
 def selectionalCounterfactual {W : Type*} [DecidableEq W] [Fintype W]
     (sim : SimilarityOrdering W) (A B : W → Prop)
-    [DecidablePred A] [DecidablePred B] (w : W) : Truth3 :=
+    [DecidablePred A] [DecidablePred B] (w : W) : Trivalent :=
   if ∀ w' ∈ sim.closestWorlds w (Finset.univ.filter A),
     B w' then .true
   else if ∀ w' ∈ sim.closestWorlds w (Finset.univ.filter A),
@@ -322,8 +322,8 @@ is invisible.
     the global aggregation pattern: mixed Bool inputs split duality types. -/
 theorem selectional_is_global_architecture (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    Trivalent.aggregate .disjunctive (bs.map Truth3.ofBool) = .true ∧
-    Trivalent.aggregate .conjunctive (bs.map Truth3.ofBool) = .false :=
+    Trivalent.aggregate .disjunctive (bs.map Trivalent.ofBool) = .true ∧
+    Trivalent.aggregate .conjunctive (bs.map Trivalent.ofBool) = .false :=
   Trivalent.aggregate_map_ofBool_mixed bs h_some_true h_some_false
 
 -- ════════════════════════════════════════════════════
@@ -540,8 +540,8 @@ The supervaluation variant (`selectionalCounterfactual` above) generalises
 this to handle ties: each "legitimate" selection function corresponds to a
 choice point, and we supervaluate over them. The bridge below shows that
 when the supervaluation's closest-worlds set is the singleton chosen by a
-selection function, the supervaluation analysis (`Truth3`) reduces to the
-single-function analysis (`Bool`) under `Truth3.ofBool`. -/
+selection function, the supervaluation analysis (`Trivalent`) reduces to the
+single-function analysis (`Bool`) under `Trivalent.ofBool`. -/
 
 /-- **Stalnaker's single-selection-function counterfactual** [stalnaker-1968].
     `A □→ B` is true at `w` iff `B` holds at `s(w, ‖A‖)`. The counterfactual
@@ -561,9 +561,9 @@ instance stalnakerCounterfactual_decidable {W : Type*} (s : Semantics.Conditiona
 /-- **Bridge: Stalnaker = supervaluation when closest is a singleton.**
 
     When the supervaluation's closest-worlds set is the singleton
-    `{s.sel w ‖A‖}`, the supervaluation analysis (`Truth3`) reduces
+    `{s.sel w ‖A‖}`, the supervaluation analysis (`Trivalent`) reduces
     to the single-selection-function analysis (`Bool`) under
-    `Truth3.ofBool`. The supervaluation gap arises only with ties; once
+    `Trivalent.ofBool`. The supervaluation gap arises only with ties; once
     ties are resolved by the selection function, both analyses coincide. -/
 theorem stalnaker_eq_selectional_singleton {W : Type*} [DecidableEq W] [Fintype W]
     (s : Semantics.Conditionals.SelectionFunction W) (sim : SimilarityOrdering W)
@@ -571,7 +571,7 @@ theorem stalnaker_eq_selectional_singleton {W : Type*} [DecidableEq W] [Fintype 
     (h_singleton : sim.closestWorlds w (Finset.univ.filter A)
                    = {s.sel w {w' | A w'}}) :
     selectionalCounterfactual sim A B w =
-    Truth3.ofBool (decide (stalnakerCounterfactual s A B w)) := by
+    Trivalent.ofBool (decide (stalnakerCounterfactual s A B w)) := by
   unfold selectionalCounterfactual stalnakerCounterfactual
     Semantics.Conditionals.selectionConditional
   rw [h_singleton]
@@ -580,14 +580,14 @@ theorem stalnaker_eq_selectional_singleton {W : Type*} [DecidableEq W] [Fintype 
     have h1 : (∀ w' ∈ ({s.sel w {w' | A w'}} : Finset W), B w') := by
       intro w' hw'; rw [Finset.mem_singleton] at hw'; rw [hw']; exact hB
     rw [if_pos h1]
-    simp only [hB, decide_true, Truth3.ofBool]
+    simp only [hB, decide_true, Trivalent.ofBool]
   · -- Both sides equal .false
     have h1 : ¬ (∀ w' ∈ ({s.sel w {w' | A w'}} : Finset W), B w') := by
       intro h; exact hB (h _ (Finset.mem_singleton.mpr rfl))
     have h2 : (∀ w' ∈ ({s.sel w {w' | A w'}} : Finset W), ¬ B w') := by
       intro w' hw'; rw [Finset.mem_singleton] at hw'; rw [hw']; exact hB
     rw [if_neg h1, if_pos h2]
-    simp only [hB, decide_false, Truth3.ofBool]
+    simp only [hB, decide_false, Trivalent.ofBool]
 
 /-! ## Bridge: Stalnaker counterfactual = will-conditional over the universe
 
@@ -644,18 +644,18 @@ theorem stalnakerCounterfactual_eq_wouldConditional_universe
       s A B Set.univ w :=
   stalnakerCounterfactual_eq_willConditional_universe s A B w
 
-/-- **Truth3 ↔ would-conditional bridge** [cariani-santorio-2018]
+/-- **Trivalent ↔ would-conditional bridge** [cariani-santorio-2018]
     §5.3.1 + §5.3.2: composing `stalnaker_eq_selectional_singleton`
-    (Truth3 ↔ Bool stalnakerCounterfactual under singleton-closest) with
+    (Trivalent ↔ Bool stalnakerCounterfactual under singleton-closest) with
     `stalnakerCounterfactual_eq_wouldConditional_universe` (Bool ↔ Prop
     would-conditional under universe parameter) gives a direct bridge
     from the supervaluation-valued `selectionalCounterfactual` to the
     Prop-valued *would*-conditional of `WillConditional`.
 
-    Under the same `h_singleton` hypothesis that resolves the Truth3
+    Under the same `h_singleton` hypothesis that resolves the Trivalent
     gap (the closest-worlds set is exactly Stalnaker's selected world),
     the supervaluation analysis lands at `.true` iff the would-conditional
-    holds. The two layers — Truth3 supervaluation over `Finset` and Prop
+    holds. The two layers — Trivalent supervaluation over `Finset` and Prop
     selection-function over `Set` — collapse to the same content. -/
 theorem selectional_eq_wouldConditional_singleton_universe
     {W : Type*} [DecidableEq W] [Fintype W]
@@ -669,8 +669,8 @@ theorem selectional_eq_wouldConditional_singleton_universe
   rw [stalnaker_eq_selectional_singleton s sim A B w h_singleton]
   rw [← stalnakerCounterfactual_eq_wouldConditional_universe s A B w]
   by_cases h : stalnakerCounterfactual s A B w
-  · simp [decide_eq_true h, Truth3.ofBool, h]
-  · simp [decide_eq_false h, Truth3.ofBool, h]
+  · simp [decide_eq_true h, Trivalent.ofBool, h]
+  · simp [decide_eq_false h, Trivalent.ofBool, h]
 
 /-- A Stalnakerian selection function on `Fin 3` that prefers `1`
     whenever Centering does not force the centre. Used to witness the

--- a/Linglib/Semantics/Conditionals/Counterfactual/Implicature.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/Implicature.lean
@@ -42,7 +42,7 @@ that can be cited (in the contrastive direction) by the
 
 namespace Semantics.Conditionals.Counterfactual
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 /-- Under the implicature approach with all-true individual results,
     "every" is predicted true — the OPPOSITE of the observed data

--- a/Linglib/Semantics/Conditionals/Counterfactual/Implicature.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/Implicature.lean
@@ -42,7 +42,6 @@ that can be cited (in the contrastive direction) by the
 
 namespace Semantics.Conditionals.Counterfactual
 
-open Trivalent (Truth3)
 
 /-- Under the implicature approach with all-true individual results,
     "every" is predicted true — the OPPOSITE of the observed data
@@ -55,7 +54,7 @@ open Trivalent (Truth3)
     conjunctive projection over mixed (not uniformly true) individual
     results. -/
 theorem implicature_wrong_for_every :
-    projectTruthValues .conjunctive [Truth3.true, Truth3.true] = .true := by
+    projectTruthValues .conjunctive [Trivalent.true, Trivalent.true] = .true := by
   decide
 
 /-- Implicature predicts "not-every" = FALSE (since not-every(all-true)
@@ -64,7 +63,7 @@ theorem implicature_wrong_for_every :
     `implicature_wrong_for_every`. -/
 theorem implicature_wrong_for_notEvery :
     projectTruthValues .disjunctive
-      ([Truth3.true, Truth3.true].map Truth3.neg) = .false := by
+      ([Trivalent.true, Trivalent.true].map Trivalent.neg) = .false := by
   decide
 
 end Semantics.Conditionals.Counterfactual

--- a/Linglib/Semantics/Conditionals/Counterfactual/QuantifierEmbedding.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/QuantifierEmbedding.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Conditionals.Counterfactual
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Duality
 
 /-!
@@ -60,7 +60,7 @@ in [ramotowska-marty-romoli-santorio-2025].
 
 namespace Semantics.Conditionals.Counterfactual
 
-open Trivalent (Truth3 ProjectionType)
+open Trivalent (ProjectionType)
 
 /-- Quantifier strength IS projection type. Strong quantifiers (every,
     no) use conjunctive projection; weak quantifiers (some, not-every)
@@ -81,25 +81,25 @@ For a list of three-valued results:
 - Disjunctive projection: TRUE iff any TRUE, FALSE iff all FALSE
 
 Implementation delegates to `Trivalent.aggregate`, which computes
-the meet (⋀) or join (⋁) in the Truth3 lattice via foldl. -/
-def projectTruthValues (proj : ProjectionType) (results : List Truth3) : Truth3 :=
+the meet (⋀) or join (⋁) in the Trivalent lattice via foldl. -/
+def projectTruthValues (proj : ProjectionType) (results : List Trivalent) : Trivalent :=
   Trivalent.aggregate proj results
 
 /-- Conjunctive projection is fragile: one false element yields false. -/
-theorem conjunctive_fragile (results : List Truth3)
+theorem conjunctive_fragile (results : List Trivalent)
     (h : results.any (· == .false)) :
     projectTruthValues .conjunctive results ≠ .true := by
   show Trivalent.forallAll results ≠ .true
-  rw [Trivalent.universal_fragile results h]; exact Truth3.noConfusion
+  rw [Trivalent.universal_fragile results h]; exact Trivalent.noConfusion
 
 /-- Disjunctive projection is robust: one true element yields true. -/
-theorem disjunctive_robust (results : List Truth3)
+theorem disjunctive_robust (results : List Trivalent)
     (h : results.any (· == .true)) :
     projectTruthValues .disjunctive results = .true :=
   Trivalent.existential_robust results h
 
 /-- `projectTruthValues` and `aggregate` are the same operation. -/
-theorem projectTruthValues_eq_aggregate (proj : ProjectionType) (l : List Truth3) :
+theorem projectTruthValues_eq_aggregate (proj : ProjectionType) (l : List Trivalent) :
     projectTruthValues proj l = Trivalent.aggregate proj l := rfl
 
 /-! ### The four embedded-quantifier operators -/
@@ -107,18 +107,18 @@ theorem projectTruthValues_eq_aggregate (proj : ProjectionType) (l : List Truth3
 /-- Evaluate embedded counterfactual under a quantifier via projection.
     Strong quantifiers (every, no) use conjunctive projection;
     weak quantifiers (some, not every) use disjunctive projection. -/
-def embeddedSelectional (s : QStrength) (results : List Truth3) : Truth3 :=
+def embeddedSelectional (s : QStrength) (results : List Trivalent) : Trivalent :=
   projectTruthValues s.toProjection results
 
 /-- "No" quantifier: conjunctive projection over NEGATED individual
     results. "No X would V" = "Every X would NOT V". -/
-def noSelectional (results : List Truth3) : Truth3 :=
-  projectTruthValues .conjunctive (results.map Truth3.neg)
+def noSelectional (results : List Trivalent) : Trivalent :=
+  projectTruthValues .conjunctive (results.map Trivalent.neg)
 
 /-- "Not every" quantifier: disjunctive projection over NEGATED
     individual results. "Not every X would V" = "∃X. ¬(X would V)". -/
-def notEverySelectional (results : List Truth3) : Truth3 :=
-  projectTruthValues .disjunctive (results.map Truth3.neg)
+def notEverySelectional (results : List Trivalent) : Trivalent :=
+  projectTruthValues .disjunctive (results.map Trivalent.neg)
 
 /-! ### Selectional Theory: Embedded Determinacy
 
@@ -126,12 +126,12 @@ def notEverySelectional (results : List Truth3) : Truth3 :=
 selectional counterfactuals are DETERMINATE even though unembedded
 ones can be indeterminate. This is because the quantifier operates
 INSIDE the scope of the selection function — within each selected
-world, individual results are Bool (true/false), not Truth3. -/
+world, individual results are Bool (true/false), not Trivalent. -/
 
 /-- **Embedded selectional determinacy**: when individual results are
     all determinate (Bool), the projected result is always determinate. -/
 theorem embeddedSelectional_determinate (s : QStrength) (bs : List Bool) :
-    embeddedSelectional s (bs.map Truth3.ofBool) ≠ .indet :=
+    embeddedSelectional s (bs.map Trivalent.ofBool) ≠ .indet :=
   Trivalent.aggregate_map_ofBool_ne_indet s bs
 
 /-- **Strength determines pattern**: under selectional semantics with
@@ -141,16 +141,16 @@ theorem embeddedSelectional_determinate (s : QStrength) (bs : List Bool) :
 theorem strength_determines_pattern (bs : List Bool)
     (h_some_true : bs.any id)
     (h_some_false : bs.any (!·)) :
-    embeddedSelectional .strong (bs.map Truth3.ofBool) = .false ∧
-    embeddedSelectional .weak (bs.map Truth3.ofBool) = .true :=
+    embeddedSelectional .strong (bs.map Trivalent.ofBool) = .false ∧
+    embeddedSelectional .weak (bs.map Trivalent.ofBool) = .true :=
   let ⟨h_exist, h_univ⟩ := Trivalent.aggregate_map_ofBool_mixed bs h_some_true h_some_false
   ⟨h_univ, h_exist⟩
 
 private theorem map_neg_map_ofBool (bs : List Bool) :
-    (bs.map Truth3.ofBool).map Truth3.neg = (bs.map (!·)).map Truth3.ofBool := by
+    (bs.map Trivalent.ofBool).map Trivalent.neg = (bs.map (!·)).map Trivalent.ofBool := by
   induction bs with
   | nil => rfl
-  | cons b bs ih => simp only [List.map, Truth3.neg_ofBool, ih]
+  | cons b bs ih => simp only [List.map, Trivalent.neg_ofBool, ih]
 
 private theorem any_map_not_id (bs : List Bool) :
     (bs.map (!·)).any id = bs.any (!·) := by
@@ -167,7 +167,7 @@ private theorem any_map_not_not (bs : List Bool) :
 /-- **"No" in mixed scenario gives FALSE** under selectional semantics. -/
 theorem no_mixed (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    noSelectional (bs.map Truth3.ofBool) = .false := by
+    noSelectional (bs.map Trivalent.ofBool) = .false := by
   unfold noSelectional
   rw [map_neg_map_ofBool]
   have h1 : (bs.map (!·)).any id := by rw [any_map_not_id]; exact h_some_false
@@ -177,7 +177,7 @@ theorem no_mixed (bs : List Bool)
 /-- **"Not every" in mixed scenario gives TRUE** under selectional semantics. -/
 theorem notEvery_mixed (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    notEverySelectional (bs.map Truth3.ofBool) = .true := by
+    notEverySelectional (bs.map Trivalent.ofBool) = .true := by
   unfold notEverySelectional
   rw [map_neg_map_ofBool]
   have h1 : (bs.map (!·)).any id := by rw [any_map_not_id]; exact h_some_false
@@ -190,10 +190,10 @@ theorem notEvery_mixed (bs : List Bool)
     yield `.true`. -/
 theorem all_four_quantifiers_mixed (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    embeddedSelectional .strong (bs.map Truth3.ofBool) = .false ∧
-    embeddedSelectional .weak (bs.map Truth3.ofBool) = .true ∧
-    noSelectional (bs.map Truth3.ofBool) = .false ∧
-    notEverySelectional (bs.map Truth3.ofBool) = .true :=
+    embeddedSelectional .strong (bs.map Trivalent.ofBool) = .false ∧
+    embeddedSelectional .weak (bs.map Trivalent.ofBool) = .true ∧
+    noSelectional (bs.map Trivalent.ofBool) = .false ∧
+    notEverySelectional (bs.map Trivalent.ofBool) = .true :=
   ⟨(strength_determines_pattern bs h_some_true h_some_false).1,
    (strength_determines_pattern bs h_some_true h_some_false).2,
    no_mixed bs h_some_true h_some_false,
@@ -214,12 +214,12 @@ The theories agree on "every" and "not every" but DISAGREE on
 
 /-- Universal theory embedded predictions: all individual CFs false. -/
 theorem universal_all_false (n : Nat) (hn : n > 0) :
-    projectTruthValues .conjunctive (List.replicate n Truth3.false) = .false ∧
-    projectTruthValues .disjunctive (List.replicate n Truth3.false) = .false := by
+    projectTruthValues .conjunctive (List.replicate n Trivalent.false) = .false ∧
+    projectTruthValues .disjunctive (List.replicate n Trivalent.false) = .false := by
   refine ⟨?_, ?_⟩
   · exact Trivalent.foldl_inf_mem_false _ ⊤ (List.mem_replicate.mpr ⟨by omega, rfl⟩)
-  · show (List.replicate n (⊥ : Truth3)).foldl (· ⊔ ·) ⊥ = ⊥
-    have : ∀ k, (List.replicate k (⊥ : Truth3)).foldl (· ⊔ ·) ⊥ = ⊥ := by
+  · show (List.replicate n (⊥ : Trivalent)).foldl (· ⊔ ·) ⊥ = ⊥
+    have : ∀ k, (List.replicate k (⊥ : Trivalent)).foldl (· ⊔ ·) ⊥ = ⊥ := by
       intro k; induction k with
       | zero => rfl
       | succ k ih => simp only [List.replicate_succ, List.foldl_cons, sup_idem, ih]

--- a/Linglib/Semantics/Conditionals/Counterfactual/QuantifierEmbedding.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/QuantifierEmbedding.lean
@@ -60,7 +60,7 @@ in [ramotowska-marty-romoli-santorio-2025].
 
 namespace Semantics.Conditionals.Counterfactual
 
-open Core.Duality (Truth3 ProjectionType)
+open Trivalent (Truth3 ProjectionType)
 
 /-- Quantifier strength IS projection type. Strong quantifiers (every,
     no) use conjunctive projection; weak quantifiers (some, not-every)
@@ -80,27 +80,27 @@ For a list of three-valued results:
 - Conjunctive projection: TRUE iff all TRUE, FALSE iff any FALSE
 - Disjunctive projection: TRUE iff any TRUE, FALSE iff all FALSE
 
-Implementation delegates to `Core.Duality.aggregate`, which computes
+Implementation delegates to `Trivalent.aggregate`, which computes
 the meet (⋀) or join (⋁) in the Truth3 lattice via foldl. -/
 def projectTruthValues (proj : ProjectionType) (results : List Truth3) : Truth3 :=
-  Core.Duality.aggregate proj results
+  Trivalent.aggregate proj results
 
 /-- Conjunctive projection is fragile: one false element yields false. -/
 theorem conjunctive_fragile (results : List Truth3)
     (h : results.any (· == .false)) :
     projectTruthValues .conjunctive results ≠ .true := by
-  show Core.Duality.forallAll results ≠ .true
-  rw [Core.Duality.universal_fragile results h]; exact Truth3.noConfusion
+  show Trivalent.forallAll results ≠ .true
+  rw [Trivalent.universal_fragile results h]; exact Truth3.noConfusion
 
 /-- Disjunctive projection is robust: one true element yields true. -/
 theorem disjunctive_robust (results : List Truth3)
     (h : results.any (· == .true)) :
     projectTruthValues .disjunctive results = .true :=
-  Core.Duality.existential_robust results h
+  Trivalent.existential_robust results h
 
 /-- `projectTruthValues` and `aggregate` are the same operation. -/
 theorem projectTruthValues_eq_aggregate (proj : ProjectionType) (l : List Truth3) :
-    projectTruthValues proj l = Core.Duality.aggregate proj l := rfl
+    projectTruthValues proj l = Trivalent.aggregate proj l := rfl
 
 /-! ### The four embedded-quantifier operators -/
 
@@ -132,7 +132,7 @@ world, individual results are Bool (true/false), not Truth3. -/
     all determinate (Bool), the projected result is always determinate. -/
 theorem embeddedSelectional_determinate (s : QStrength) (bs : List Bool) :
     embeddedSelectional s (bs.map Truth3.ofBool) ≠ .indet :=
-  Core.Duality.aggregate_map_ofBool_ne_indet s bs
+  Trivalent.aggregate_map_ofBool_ne_indet s bs
 
 /-- **Strength determines pattern**: under selectional semantics with
     mixed Bool individual results (some true, some false):
@@ -143,7 +143,7 @@ theorem strength_determines_pattern (bs : List Bool)
     (h_some_false : bs.any (!·)) :
     embeddedSelectional .strong (bs.map Truth3.ofBool) = .false ∧
     embeddedSelectional .weak (bs.map Truth3.ofBool) = .true :=
-  let ⟨h_exist, h_univ⟩ := Core.Duality.aggregate_map_ofBool_mixed bs h_some_true h_some_false
+  let ⟨h_exist, h_univ⟩ := Trivalent.aggregate_map_ofBool_mixed bs h_some_true h_some_false
   ⟨h_univ, h_exist⟩
 
 private theorem map_neg_map_ofBool (bs : List Bool) :
@@ -217,7 +217,7 @@ theorem universal_all_false (n : Nat) (hn : n > 0) :
     projectTruthValues .conjunctive (List.replicate n Truth3.false) = .false ∧
     projectTruthValues .disjunctive (List.replicate n Truth3.false) = .false := by
   refine ⟨?_, ?_⟩
-  · exact Core.Duality.foldl_inf_mem_false _ ⊤ (List.mem_replicate.mpr ⟨by omega, rfl⟩)
+  · exact Trivalent.foldl_inf_mem_false _ ⊤ (List.mem_replicate.mpr ⟨by omega, rfl⟩)
   · show (List.replicate n (⊥ : Truth3)).foldl (· ⊔ ·) ⊥ = ⊥
     have : ∀ k, (List.replicate k (⊥ : Truth3)).foldl (· ⊔ ·) ⊥ = ⊥ := by
       intro k; induction k with

--- a/Linglib/Semantics/Dynamic/PPCDRT/Anaphora.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Anaphora.lean
@@ -112,7 +112,7 @@ theorem groupIdentityCond_iff_bidir_coverCond (uAnaph uAnt : Nat)
 
 /-- Reciprocity (`∂(∪u = ∪u') ∧ ∂(u ≠ u')`): group identity plus
     per-state distinctness. The presupposition wrappers are realized
-    semantically when consumers project to `Truth3`. -/
+    semantically when consumers project to `Truth`. -/
 def reciprocityCond (uAnaph uAnt : Nat) : PPDRSCond E := λ S Δ =>
   groupIdentityCond uAnaph uAnt S Δ ∧
   ∀ s ∈ S, ∀ d_a d_b, s uAnaph = some d_a → s uAnt = some d_b → d_a ≠ d_b

--- a/Linglib/Semantics/Exhaustification/Trivalent.lean
+++ b/Linglib/Semantics/Exhaustification/Trivalent.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Exhaustification.InnocentExclusion
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Mathlib.Tactic.DeriveFintype
 
 /-!
@@ -40,12 +40,12 @@ consistent with Type B (EXH¹).
 This file is generic infrastructure, not a paper replication.
 The IE computation reuses `Exhaustification.innocent.excluded`
 (mathlib-canonical Finset version). The trivalent layer wraps the
-bivalent IE result with `Truth3` semantics.
+bivalent IE result with `_root_.Trivalent` semantics.
 -/
 
 namespace Exhaustification.Trivalent
 
-open _root_.Trivalent (Truth3 Prop3)
+open _root_.Trivalent (Prop3)
 open Exhaustification (innocent predToFinset altsFromPreds)
 
 
@@ -61,9 +61,9 @@ open Exhaustification (innocent predToFinset altsFromPreds)
     entailment, consistency, and maximality are all defined bivalently.
     The trivalent layer applies only *after* IE is computed.
 
-    Pointwise lift of `Truth3.toBoolOrFalse`. -/
-def classicalPart {W : Type} (p : W → Truth3) : W → Bool :=
-  Truth3.toBoolOrFalse ∘ p
+    Pointwise lift of `_root_.Trivalent.toBoolOrFalse`. -/
+def classicalPart {W : Type} (p : W → _root_.Trivalent) : W → Bool :=
+  _root_.Trivalent.toBoolOrFalse ∘ p
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -81,8 +81,8 @@ def classicalPart {W : Type} (p : W → Truth3) : W → Bool :=
 
     Type B in [wang-davidson-2026]: predicts no effect of
     exclusivity on presupposition filtering. -/
-def exh1 {W : Type} [Fintype W] [DecidableEq W] (alts : List (W → Truth3))
-    (p : W → Truth3) : W → Truth3 :=
+def exh1 {W : Type} [Fintype W] [DecidableEq W] (alts : List (W → _root_.Trivalent))
+    (p : W → _root_.Trivalent) : W → _root_.Trivalent :=
   let φF := predToFinset (classicalPart p)
   let altSet := altsFromPreds (alts.map classicalPart)
   let excluded := innocent.excluded altSet φF
@@ -114,8 +114,8 @@ def exh1 {W : Type} [Fintype W] [DecidableEq W] (alts : List (W → Truth3))
 
     Type A in [wang-davidson-2026]: predicts that increasing
     exclusivity reduces presupposition filtering. -/
-def exh2 {W : Type} [Fintype W] [DecidableEq W] (alts : List (W → Truth3))
-    (p : W → Truth3) : W → Truth3 :=
+def exh2 {W : Type} [Fintype W] [DecidableEq W] (alts : List (W → _root_.Trivalent))
+    (p : W → _root_.Trivalent) : W → _root_.Trivalent :=
   let φF := predToFinset (classicalPart p)
   let altSet := altsFromPreds (alts.map classicalPart)
   let excluded := innocent.excluded altSet φF
@@ -143,13 +143,13 @@ def exh2 {W : Type} [Fintype W] [DecidableEq W] (alts : List (W → Truth3))
 /-- EXH¹ preserves the presupposition of the prejacent:
     if φ(w) = #, then EXH¹(φ)(w) = #. -/
 theorem exh1_preserves_presup {W : Type} [Fintype W] [DecidableEq W]
-    (alts : List (W → Truth3)) (p : W → Truth3) (w : W)
+    (alts : List (W → _root_.Trivalent)) (p : W → _root_.Trivalent) (w : W)
     (h : p w = .indet) : exh1 alts p w = .indet := by
   unfold exh1; simp only [h]
 
 /-- EXH² also preserves the prejacent's presupposition. -/
 theorem exh2_preserves_presup {W : Type} [Fintype W] [DecidableEq W]
-    (alts : List (W → Truth3)) (p : W → Truth3) (w : W)
+    (alts : List (W → _root_.Trivalent)) (p : W → _root_.Trivalent) (w : W)
     (h : p w = .indet) : exh2 alts p w = .indet := by
   unfold exh2; split <;> simp_all
 

--- a/Linglib/Semantics/Exhaustification/Trivalent.lean
+++ b/Linglib/Semantics/Exhaustification/Trivalent.lean
@@ -45,7 +45,7 @@ bivalent IE result with `Truth3` semantics.
 
 namespace Exhaustification.Trivalent
 
-open Core.Duality (Truth3 Prop3)
+open _root_.Trivalent (Truth3 Prop3)
 open Exhaustification (innocent predToFinset altsFromPreds)
 
 

--- a/Linglib/Semantics/Homogeneity/Basic.lean
+++ b/Linglib/Semantics/Homogeneity/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Questions.Partition.QUD
 import Linglib.Semantics.Supervaluation.Basic
 
@@ -11,7 +11,7 @@ The framework is anchored on [kriz-2015] (Križ's dissertation); the
 published [kriz-2016] is the first detailed application to plural
 definites and `all`. Both rely on Fine's supervaluation ([fine-1975])
 and Beaver-Krahmer's assertion operator ([beaver-krahmer-2001], encoded
-here as `Truth3.metaAssert`).
+here as `Trivalent.metaAssert`).
 
 ## Layered structure
 
@@ -37,7 +37,7 @@ The shared structure is supervaluation over specification points.
 - §1 **Trivalent Sentence Denotations**: `SentenceTV`, `posExt`/`negExt`/`gapExt`,
    `isHomogeneous`, `isBivalent`.
 - §2 **Supervaluation as Homogeneity Source**: `supervaluationTV` via `SpecSpace`.
-- §3 **Homogeneity Removal**: `removeGap = Truth3.metaAssert ∘ ·` lifted pointwise;
+- §3 **Homogeneity Removal**: `removeGap = Trivalent.metaAssert ∘ ·` lifted pointwise;
    preserves the positive extension while collapsing the gap into the negative.
 - §4 **Pragmatic Usability**: `sufficientlyTrue`, `addressesIssue`, `usable`.
 - §5 **Communicated Content**: `communicatedContent` + `bivalentPred` bridge.
@@ -53,7 +53,6 @@ The shared structure is supervaluation over specification points.
 
 namespace Semantics.Homogeneity
 
-open Trivalent (Truth3)
 open Semantics.Supervaluation (SpecSpace superTrue superTrue_true_iff superTrue_false_iff
   superTrue_indet_iff fidelity)
 
@@ -65,7 +64,7 @@ variable {W : Type*}
 
 /-- A trivalent sentence denotation: maps worlds to truth values.
     This is the general type for any sentence that may exhibit homogeneity. -/
-abbrev SentenceTV (W : Type*) := W → Truth3
+abbrev SentenceTV (W : Type*) := W → Trivalent
 
 /-- Positive extension: worlds where the sentence is true. -/
 def posExt (S : SentenceTV W) : Set W := {w | S w = .true}
@@ -177,13 +176,13 @@ theorem supervaluationTV_gap_iff {Spec W : Type*} (eval : W → Spec → Prop)
     Semantically, removal collapses the gap into the negative extension:
     gap-worlds become false-worlds, preserving the positive extension. The
     pointwise operator is exactly the assertion operator 𝒜 of
-    [beaver-krahmer-2001], available as `Truth3.metaAssert`. -/
+    [beaver-krahmer-2001], available as `Trivalent.metaAssert`. -/
 
 /-- Remove homogeneity: collapse gap into negative extension.
-    Defined as `Truth3.metaAssert` lifted pointwise — see `Truth3.lean`
+    Defined as `Trivalent.metaAssert` lifted pointwise — see `Trivalent.lean`
     for the underlying assertion operator. -/
 def removeGap (S : SentenceTV W) : SentenceTV W :=
-  λ w => Truth3.metaAssert (S w)
+  λ w => Trivalent.metaAssert (S w)
 
 /-- Removal produces a bivalent sentence. -/
 theorem removeGap_bivalent (S : SentenceTV W) :
@@ -216,7 +215,7 @@ theorem removeGap_not_homogeneous (S : SentenceTV W) :
 /-! The pragmatic mechanism that derives non-maximal readings from
     the homogeneity gap. Two independent principles interact:
 
-    1. **Sufficient Truth**: weakens Quality to "true enough for current purposes"
+    1. **Sufficient Trivalent**: weakens Quality to "true enough for current purposes"
     2. **Addressing an Question**: restricts which sentences can be used for which
        issues, based on alignment between truth-value boundaries and issue cells
 
@@ -224,7 +223,7 @@ theorem removeGap_not_homogeneous (S : SentenceTV W) :
     (i) a literally-true world is in the same issue cell, and (ii) no cell
     straddles the true/false boundary. -/
 
-/-- Sufficient Truth: S is "true enough" at world w relative to issue I
+/-- Sufficient Trivalent: S is "true enough" at world w relative to issue I
     iff there is a world w' that is I-equivalent to w where S is literally true.
 
     This weakens the standard maxim of quality: a speaker need not assert
@@ -252,7 +251,7 @@ def usable (q : QUD W) (S : SentenceTV W) (w : W) : Prop :=
   S w ≠ .false ∧ sufficientlyTrue q S w ∧ addressesIssue q S
 
 /-- For bivalent sentences, usability reduces to literal truth + addressing.
-    Sufficient Truth adds nothing because there are no gap-worlds. -/
+    Sufficient Trivalent adds nothing because there are no gap-worlds. -/
 theorem bivalent_usable_iff_true (q : QUD W) (S : SentenceTV W)
     (hbiv : isBivalent S) (w : W) :
     usable q S w ↔ S w = .true ∧ addressesIssue q S := by
@@ -487,7 +486,7 @@ instance (a b : Finset Atom) : Decidable (overlaps a b) :=
     of the universe of discourse). For distributive predicates, singletons
     suffice; for collective predicates, larger groups are needed. -/
 def generalisedTV (P : Finset Atom → Prop) [DecidablePred P]
-    (domain : Finset (Finset Atom)) (a : Finset Atom) : Truth3 :=
+    (domain : Finset (Finset Atom)) (a : Finset Atom) : Trivalent :=
   if P a then .true
   else if ∃ b ∈ domain, overlaps a b ∧ P b then .indet
   else .false

--- a/Linglib/Semantics/Homogeneity/Basic.lean
+++ b/Linglib/Semantics/Homogeneity/Basic.lean
@@ -53,7 +53,7 @@ The shared structure is supervaluation over specification points.
 
 namespace Semantics.Homogeneity
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Semantics.Supervaluation (SpecSpace superTrue superTrue_true_iff superTrue_false_iff
   superTrue_indet_iff fidelity)
 

--- a/Linglib/Semantics/Modality/Orthologic/Lifting.lean
+++ b/Linglib/Semantics/Modality/Orthologic/Lifting.lean
@@ -144,7 +144,7 @@ theorem eB_compl (a : B) : eB aᶜ = (eB a)ᶜ := by
 theorem eB_sup (a a' : B) : eB (a ⊔ a') = eB a ⊔ eB a' := by
   rw [show a ⊔ a' = (aᶜ ⊓ a'ᶜ)ᶜ by rw [_root_.compl_inf, compl_compl, compl_compl],
       eB_compl, eB_inf, eB_compl, eB_compl,
-      OrthocomplementedLattice.compl_inf, OrthocomplementedLattice.compl_compl,
-      OrthocomplementedLattice.compl_compl]
+      LatticeWithInvolution.compl_inf, LatticeWithInvolution.compl_compl,
+      LatticeWithInvolution.compl_compl]
 
 end Orthologic

--- a/Linglib/Semantics/Plurality/Trivalent.lean
+++ b/Linglib/Semantics/Plurality/Trivalent.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.Logic.Duality
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Homogeneity.Basic
 import Linglib.Semantics.Plurality.Basic
 import Linglib.Semantics.Plurality.Cover
@@ -67,7 +67,6 @@ The bivalent bridge to [kriz-2016]'s `addressesIssue` is proved in
 
 namespace Semantics.Plurality.Trivalent
 
-open _root_.Trivalent (Truth3)
 open Semantics.Homogeneity (isStronglyRelevantProp stronglyRelevantSet
   exact_all_relevant)
 open Semantics.Plurality
@@ -89,7 +88,7 @@ fails at every atom, gap otherwise. The [van-fraassen-1966]
 supervaluation framing (each atom as a specification point) is
 documented by `Semantics.Supervaluation.superTrue_eq_dist`. -/
 @[reducible] def pluralTruthValue (P : Atom → W → Prop)
-    [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) : Truth3 :=
+    [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) : _root_.Trivalent :=
   Trivalent.dist x (fun a => P a w)
 
 @[simp]
@@ -203,7 +202,7 @@ def candidateSet (P : Atom → W → Prop) [∀ a w, Decidable (P a w)]
     (tol : Tolerance Atom) (x : Finset Atom) : Set (W → Prop) :=
   { p | ∃ z ∈ x.powerset, z.Nonempty ∧ tol.rel z x ∧ p = candidateProp P z }
 
-/-! ### Truth-on-all-readings trichotomy -/
+/-! ### _root_.Trivalent-on-all-readings trichotomy -/
 
 /-- All candidates in the set hold at `w`. -/
 def trueOnAll (candidates : Set (W → Prop)) (w : W) : Prop :=
@@ -242,7 +241,7 @@ theorem fullCandidateSet_eq_candidateSet_trivial (P : Atom → W → Prop)
 theorem identity_tolerant_iff_eq (x z : Finset Atom) :
     Tolerance.identity.rel z x ↔ z = x := Iff.rfl
 
-/-! ### Truth-on-all ↔ trivalent semantics
+/-! ### _root_.Trivalent-on-all ↔ trivalent semantics
 
 Three correspondence lemmas connecting `trueOnAll` / `falseOnAll` /
 `gapOnCandidates` over the (cover-cell) candidate set to the trivalent
@@ -410,7 +409,7 @@ empirically critical in non-monotonic contexts and was K&S's headline
 departure from Malamud; the divergence theorem below makes the prose claim
 kernel-checked. -/
 
-/-- Truth-on-all trichotomy: a candidate set is true-on-all, false-on-all,
+/-- _root_.Trivalent-on-all trichotomy: a candidate set is true-on-all, false-on-all,
     or mixed (gap). Classical disjunction over decidable cases. -/
 theorem candidateConjunction_trichotomy (candidates : Set (W → Prop)) (w : W)
     [Decidable (trueOnAll candidates w)]

--- a/Linglib/Semantics/Plurality/Trivalent.lean
+++ b/Linglib/Semantics/Plurality/Trivalent.lean
@@ -26,7 +26,7 @@ made kernel-checked in `malamud_strictly_weaker_when_mixed`.
 
 ## Main declarations
 
-* `pluralTruthValue` — trivalent K&S denotation via `Core.Duality.dist`.
+* `pluralTruthValue` — trivalent K&S denotation via `Trivalent.dist`.
 * `inGap`, `homogeneity_gap_symmetric`, `pluralTruthValue_neg` — the
   homogeneity theorem.
 * `candidateProp`, `fullCandidateSet`, `candidateSet` — the (cover-cell)
@@ -67,7 +67,7 @@ The bivalent bridge to [kriz-2016]'s `addressesIssue` is proved in
 
 namespace Semantics.Plurality.Trivalent
 
-open Core.Duality (Truth3)
+open _root_.Trivalent (Truth3)
 open Semantics.Homogeneity (isStronglyRelevantProp stronglyRelevantSet
   exact_all_relevant)
 open Semantics.Plurality
@@ -90,26 +90,26 @@ supervaluation framing (each atom as a specification point) is
 documented by `Semantics.Supervaluation.superTrue_eq_dist`. -/
 @[reducible] def pluralTruthValue (P : Atom → W → Prop)
     [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) : Truth3 :=
-  Core.Duality.dist x (fun a => P a w)
+  Trivalent.dist x (fun a => P a w)
 
 @[simp]
 theorem pluralTruthValue_eq_true_iff (P : Atom → W → Prop)
     [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :
     pluralTruthValue P x w = .true ↔ allSatisfy P x w :=
-  Core.Duality.dist_eq_true_iff x _
+  Trivalent.dist_eq_true_iff x _
 
 @[simp]
 theorem pluralTruthValue_eq_false_iff (P : Atom → W → Prop)
     [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :
     pluralTruthValue P x w = .false ↔ x.Nonempty ∧ noneSatisfy P x w :=
-  Core.Duality.dist_eq_false_iff x _
+  Trivalent.dist_eq_false_iff x _
 
 @[simp]
 theorem pluralTruthValue_eq_gap_iff (P : Atom → W → Prop)
     [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :
     pluralTruthValue P x w = .indet ↔
     (∃ a ∈ x, P a w) ∧ (∃ a ∈ x, ¬ P a w) :=
-  Core.Duality.dist_eq_indet_iff x _
+  Trivalent.dist_eq_indet_iff x _
 
 theorem allSatisfy_imp_noneSatisfy_neg (P : Atom → W → Prop)
     [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Part
 
@@ -22,7 +22,7 @@ points. References: [heim-1983], [schlenker-2009], [von-fintel-1999],
   filtering / Karttunen (`andFilter`, `impFilter`, `orFilter`), K&P
   symmetric disjunction (`orKPSymmetric`), positive-antecedent
   disjunction (`orPositive`, a documented rival), Strong Kleene
-  (`andStrong`, `orStrong` — the `Truth3` lattice meet/join), and Belnap
+  (`andStrong`, `orStrong` — the `Trivalent` lattice meet/join), and Belnap
   conditional assertion (`andBelnap`, `orBelnap`; the
   flexible-accommodation `andFlex`/`orFlex` are definitionally the same
   operators). Classical `and`/`or` are simultaneously Weak Kleene; the
@@ -50,9 +50,9 @@ points. References: [heim-1983], [schlenker-2009], [von-fintel-1999],
 (dynamic world-assignment pairs).
 
 The choice of connective system (how gaps behave under ∧/∨) is orthogonal
-to the representation type — see `Truth3.GapPolicy`. Connectives are
+to the representation type — see `Trivalent.GapPolicy`. Connectives are
 paired with `eval_*` bridge theorems mapping each to the corresponding
-`Truth3` operator on the evaluation.
+`Trivalent` operator on the evaluation.
 
 `open Classical` is in scope at the namespace level because most
 theorems case-split on `Prop`-valued fields. Mathlib uses the same
@@ -63,14 +63,14 @@ idiom in logic-heavy files such as `Mathlib/Order/Filter/Basic.lean`.
 * `PartialProp W = PartialValue W Prop` unification: `PartialValue` already generalizes
   `PartialProp` at the type level; unifying would let the connective zoo lift
   to arbitrary at-issue carriers.
-* `evalLift : (Truth3 → Truth3 → Truth3) → (PartialProp W → PartialProp W → PartialProp W)`
+* `evalLift : (Trivalent → Trivalent → Trivalent) → (PartialProp W → PartialProp W → PartialProp W)`
   would collapse `xor`, `andBelnap`, `orBelnap` into
   one definition each, with one bridge theorem instead of eight.
 -/
 
 namespace Semantics.Presupposition
 
-open Trivalent
+open Trivalent (Prop3)
 
 /-- A presupposed value: a value that is only defined when its
 presupposition holds.
@@ -257,7 +257,7 @@ def imp (p q : PartialProp W) : PartialProp W where
 
 /-- Exclusive disjunction: both presuppositions must hold (no filtering).
 
-    Under Strong Kleene, `Truth3.xor` propagates undefinedness
+    Under Strong Kleene, `Trivalent.xor` propagates undefinedness
     unconditionally (`xor_indet_iff`), so exclusive disjunction never
     filters presupposition failure from either disjunct.
     [wang-davidson-2026] -/
@@ -337,7 +337,7 @@ def orKPSymmetric (p q : PartialProp W) : PartialProp W where
 
 /-- Strong Kleene disjunction ([kleene-1952]): defined iff both disjuncts
     are defined or either is defined-and-true (`T ∨ # = T`, `F ∨ # = #`).
-    This is the `Truth3` lattice join — see `eval_orStrong`. -/
+    This is the `Trivalent` lattice join — see `eval_orStrong`. -/
 def orStrong (p q : PartialProp W) : PartialProp W where
   presup := fun w => (p.presup w ∧ q.presup w) ∨
     (p.presup w ∧ p.assertion w) ∨ (q.presup w ∧ q.assertion w)
@@ -346,7 +346,7 @@ def orStrong (p q : PartialProp W) : PartialProp W where
 
 /-- Strong Kleene conjunction: defined iff both conjuncts are defined or
     either is defined-and-false (`F ∧ # = F`, `T ∧ # = #`). This is the
-    `Truth3` lattice meet — see `eval_andStrong`. -/
+    `Trivalent` lattice meet — see `eval_andStrong`. -/
 def andStrong (p q : PartialProp W) : PartialProp W where
   presup := fun w => (p.presup w ∧ q.presup w) ∨
     (p.presup w ∧ ¬p.assertion w) ∨ (q.presup w ∧ ¬q.assertion w)
@@ -567,18 +567,18 @@ theorem impFilter_presup_eq_andFilter_presup (p q : PartialProp W) :
 @[simp] theorem eval_isDefined (p : PartialProp W) (w : W) :
     (p.eval w).isDefined ↔ p.presup w := by
   by_cases hp : p.presup w <;> by_cases ha : p.assertion w <;>
-    simp [eval, hp, ha, Truth3.isDefined]
+    simp [eval, hp, ha, Trivalent.isDefined]
 
 /-- Negation evaluation. -/
 theorem eval_neg (p : PartialProp W) (w : W) :
-    (neg p).eval w = Truth3.neg (p.eval w) := by
+    (neg p).eval w = Trivalent.neg (p.eval w) := by
   simp only [eval, neg]
   by_cases hp : p.presup w
   · simp only [if_pos hp]
     by_cases ha : p.assertion w
-    · simp [if_pos ha, if_neg (not_not.mpr ha), Truth3.neg]
-    · simp [if_neg ha, if_pos ha, Truth3.neg]
-  · simp [if_neg hp, Truth3.neg]
+    · simp [if_pos ha, if_neg (not_not.mpr ha), Trivalent.neg]
+    · simp [if_neg ha, if_pos ha, Trivalent.neg]
+  · simp [if_neg hp, Trivalent.neg]
 
 /-- Classical conjunction evaluation (both defined). -/
 theorem eval_and (p q : PartialProp W) (w : W)
@@ -609,7 +609,7 @@ theorem eval_impFilter_antecedent_true (p q : PartialProp W) (w : W)
   · have hass : ¬(impFilter p q).assertion w := fun h => hqa (h ha)
     simp only [eval, if_pos hpresup, if_neg hass, if_neg hqa]
 
-/-- `orStrong` evaluates to the `Truth3` lattice join pointwise: Strong
+/-- `orStrong` evaluates to the `Trivalent` lattice join pointwise: Strong
     Kleene disjunction is ⊔ in the `false < indet < true` order,
     unconditionally. -/
 theorem eval_orStrong (p q : PartialProp W) (w : W) :
@@ -618,7 +618,7 @@ theorem eval_orStrong (p q : PartialProp W) (w : W) :
     by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
     simp [eval, orStrong, hp, hq, ha, hb] <;> decide
 
-/-- `andStrong` evaluates to the `Truth3` lattice meet pointwise,
+/-- `andStrong` evaluates to the `Trivalent` lattice meet pointwise,
     unconditionally. -/
 theorem eval_andStrong (p q : PartialProp W) (w : W) :
     (andStrong p q).eval w = p.eval w ⊓ q.eval w := by
@@ -628,30 +628,30 @@ theorem eval_andStrong (p q : PartialProp W) (w : W) :
 
 /-- **Karttunen filtering conjunction is Peters' middle Kleene**
     ([peters-1979]): `andFilter` evaluates to the asymmetric
-    `Truth3.meetMiddle` on both dimensions, unconditionally. -/
+    `Trivalent.meetMiddle` on both dimensions, unconditionally. -/
 theorem eval_andFilter (p q : PartialProp W) (w : W) :
-    (andFilter p q).eval w = Truth3.meetMiddle (p.eval w) (q.eval w) := by
+    (andFilter p q).eval w = Trivalent.meetMiddle (p.eval w) (q.eval w) := by
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;>
     by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
-    simp [eval, andFilter, Truth3.meetMiddle, hp, hq, ha, hb] <;> decide
+    simp [eval, andFilter, Trivalent.meetMiddle, hp, hq, ha, hb] <;> decide
 
 /-- **Karttunen filtering disjunction is Peters' middle Kleene**
     ([peters-1979]): `orFilter` evaluates to the asymmetric
-    `Truth3.joinMiddle` on both dimensions, unconditionally. -/
+    `Trivalent.joinMiddle` on both dimensions, unconditionally. -/
 theorem eval_orFilter (p q : PartialProp W) (w : W) :
-    (orFilter p q).eval w = Truth3.joinMiddle (p.eval w) (q.eval w) := by
+    (orFilter p q).eval w = Trivalent.joinMiddle (p.eval w) (q.eval w) := by
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;>
     by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
-    simp [eval, orFilter, Truth3.joinMiddle, hp, hq, ha, hb] <;> decide
+    simp [eval, orFilter, Trivalent.joinMiddle, hp, hq, ha, hb] <;> decide
 
-/-- Exclusive disjunction evaluation matches `Truth3.xor` when both defined. -/
+/-- Exclusive disjunction evaluation matches `Trivalent.xor` when both defined. -/
 theorem eval_xor (p q : PartialProp W) (w : W)
     (hp : p.presup w) (hq : q.presup w) :
-    (xor p q).eval w = Truth3.xor (p.eval w) (q.eval w) := by
+    (xor p q).eval w = Trivalent.xor (p.eval w) (q.eval w) := by
   have hpq : p.presup w ∧ q.presup w := ⟨hp, hq⟩
   simp only [eval, xor, if_pos hp, if_pos hq, if_pos hpq]
   by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
-    simp [ha, hb, Truth3.xor]
+    simp [ha, hb, Trivalent.xor]
 
 /-- Exclusive disjunction never filters: when either presupposition fails,
     the result is undefined. [wang-davidson-2026] -/
@@ -711,27 +711,27 @@ theorem andFlex_presup_weaker (p q : PartialProp W) (w : W)
 
 /-! ### Eval: Weak Kleene / Belnap -/
 
-/-- `or` evaluates to `Truth3.joinWeak` pointwise (classical disjunction
+/-- `or` evaluates to `Trivalent.joinWeak` pointwise (classical disjunction
     is Weak Kleene). -/
 theorem eval_or (p q : PartialProp W) (w : W) :
-    (or p q).eval w = Truth3.joinWeak (p.eval w) (q.eval w) := by
-  simp only [eval, or, Truth3.joinWeak]
+    (or p q).eval w = Trivalent.joinWeak (p.eval w) (q.eval w) := by
+  simp only [eval, or, Trivalent.joinWeak]
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq] <;>
     by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
     simp [ha, hb]
 
-/-- Belnap conjunction evaluates to `Truth3.meetBelnap` pointwise. -/
+/-- Belnap conjunction evaluates to `Trivalent.meetBelnap` pointwise. -/
 theorem eval_andBelnap (p q : PartialProp W) (w : W) :
-    (andBelnap p q).eval w = Truth3.meetBelnap (p.eval w) (q.eval w) := by
-  simp only [eval, andBelnap, Truth3.meetBelnap]
+    (andBelnap p q).eval w = Trivalent.meetBelnap (p.eval w) (q.eval w) := by
+  simp only [eval, andBelnap, Trivalent.meetBelnap]
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq] <;>
     by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
     simp [ha, hb]
 
-/-- Belnap disjunction evaluates to `Truth3.joinBelnap` pointwise. -/
+/-- Belnap disjunction evaluates to `Trivalent.joinBelnap` pointwise. -/
 theorem eval_orBelnap (p q : PartialProp W) (w : W) :
-    (orBelnap p q).eval w = Truth3.joinBelnap (p.eval w) (q.eval w) := by
-  simp only [eval, orBelnap, Truth3.joinBelnap]
+    (orBelnap p q).eval w = Trivalent.joinBelnap (p.eval w) (q.eval w) := by
+  simp only [eval, orBelnap, Trivalent.joinBelnap]
   by_cases hp : p.presup w <;> by_cases hq : q.presup w <;> simp [hp, hq] <;>
     by_cases ha : p.assertion w <;> by_cases hb : q.assertion w <;>
     simp [ha, hb]

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -70,7 +70,7 @@ idiom in logic-heavy files such as `Mathlib/Order/Filter/Basic.lean`.
 
 namespace Semantics.Presupposition
 
-open Core.Duality
+open Trivalent
 
 /-- A presupposed value: a value that is only defined when its
 presupposition holds.

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -247,7 +247,7 @@ inductive DoubleMono where
     This is the monotonicity-theoretic explanation of why quantifier
     STRENGTH (not polarity) determines truth-value judgments for
     counterfactuals and other trivalent phenomena. -/
-def DoubleMono.toProjectionType : DoubleMono → Core.Duality.ProjectionType
+def DoubleMono.toProjectionType : DoubleMono → Trivalent.ProjectionType
   | .downUp | .downDown => .conjunctive
   | .upUp   | .upDown   => .disjunctive
 

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -3,7 +3,7 @@ import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Sublattice
 import Mathlib.Order.BooleanAlgebra.Basic
 import Linglib.Semantics.NaturalLogic
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 
 /-!
 # Generalized Quantifier Definitions

--- a/Linglib/Semantics/Supervaluation/Basic.lean
+++ b/Linglib/Semantics/Supervaluation/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Duality
 import Mathlib.Data.Finset.Basic
 
@@ -36,7 +36,6 @@ simplified complete-point-only representation.
 
 namespace Semantics.Supervaluation
 
-open Trivalent (Truth3)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Specification Spaces
@@ -75,14 +74,14 @@ def SpecSpace.singleton {Spec : Type*} [DecidableEq Spec] (s : Spec) : SpecSpace
 
 /-- Supervaluation operator. Maps a Prop-valued predicate over
     specifications to a three-valued truth value:
-    - `Truth3.true` if the predicate holds at ALL admissible specifications
-    - `Truth3.false` if the predicate fails at ALL admissible specifications
-    - `Truth3.indet` otherwise (the borderline case) -/
+    - `Trivalent.true` if the predicate holds at ALL admissible specifications
+    - `Trivalent.false` if the predicate fails at ALL admissible specifications
+    - `Trivalent.indet` otherwise (the borderline case) -/
 def superTrue {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
-    (S : SpecSpace Spec) : Truth3 :=
-  if ∀ s ∈ S.admissible, eval s then Truth3.true
-  else if ∀ s ∈ S.admissible, ¬ eval s then Truth3.false
-  else Truth3.indet
+    (S : SpecSpace Spec) : Trivalent :=
+  if ∀ s ∈ S.admissible, eval s then Trivalent.true
+  else if ∀ s ∈ S.admissible, ¬ eval s then Trivalent.false
+  else Trivalent.indet
 
 /-- The D (definitely) operator. DA is true iff A is true at ALL
     admissible specifications — i.e., A is super-true. In modal logic
@@ -112,7 +111,7 @@ instance indefinite.instDecidable {Spec : Type*} (eval : Spec → Prop)
 /-- Super-truth ↔ universally true across the space. -/
 theorem superTrue_true_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue eval S = Truth3.true ↔ ∀ s ∈ S.admissible, eval s := by
+    superTrue eval S = Trivalent.true ↔ ∀ s ∈ S.admissible, eval s := by
   unfold superTrue
   refine ⟨fun h => ?_, fun h => if_pos h⟩
   by_cases hall : ∀ s ∈ S.admissible, eval s
@@ -123,7 +122,7 @@ theorem superTrue_true_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred 
 /-- Super-falsity ↔ universally false across the space. -/
 theorem superTrue_false_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue eval S = Truth3.false ↔ ∀ s ∈ S.admissible, ¬ eval s := by
+    superTrue eval S = Trivalent.false ↔ ∀ s ∈ S.admissible, ¬ eval s := by
   unfold superTrue
   refine ⟨fun h => ?_, fun haf => ?_⟩
   · have hnt : ¬(∀ s ∈ S.admissible, eval s) := by
@@ -140,7 +139,7 @@ theorem superTrue_false_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred
 /-- Indefiniteness ↔ witnesses on both sides. -/
 theorem superTrue_indet_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue eval S = Truth3.indet ↔
+    superTrue eval S = Trivalent.indet ↔
       (∃ s ∈ S.admissible, eval s) ∧ (∃ s ∈ S.admissible, ¬ eval s) := by
   unfold superTrue
   refine ⟨fun h => ?_, fun ⟨⟨st, hst, hvt⟩, ⟨sf, hsf, hvf⟩⟩ => ?_⟩
@@ -196,7 +195,7 @@ theorem superTrue_eq_dist {Spec : Type*} (eval : Spec → Prop) [DecidablePred e
 /-- D = super-truth projected to its `Prop` characterization. -/
 theorem definitely_iff_superTrue {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    definitely eval S ↔ superTrue eval S = Truth3.true := by
+    definitely eval S ↔ superTrue eval S = Trivalent.true := by
   rw [superTrue_true_iff]; rfl
 
 -- ════════════════════════════════════════════════════
@@ -207,14 +206,14 @@ theorem definitely_iff_superTrue {Spec : Type*} (eval : Spec → Prop) [Decidabl
     precisification, hence true on ALL. Classical tautologies survive. -/
 theorem excludedMiddle_superTrue {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue (fun s => eval s ∨ ¬ eval s) S = Truth3.true :=
+    superTrue (fun s => eval s ∨ ¬ eval s) S = Trivalent.true :=
   (superTrue_true_iff _ S).mpr (fun s _ => Decidable.em _)
 
 /-- **Non-contradiction is super-false.** P ∧ ¬P is false on every
     precisification, hence false on ALL. -/
 theorem nonContradiction_superFalse {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue (fun s => eval s ∧ ¬ eval s) S = Truth3.false :=
+    superTrue (fun s => eval s ∧ ¬ eval s) S = Trivalent.false :=
   (superTrue_false_iff _ S).mpr (fun _ _ ⟨h, hn⟩ => hn h)
 
 /-- **Complementary predicates.** If P and Q never hold simultaneously at
@@ -225,7 +224,7 @@ theorem nonContradiction_superFalse {Spec : Type*} (eval : Spec → Prop) [Decid
 theorem complementary_superFalse {Spec : Type*}
     (P Q : Spec → Prop) [DecidablePred P] [DecidablePred Q]
     (S : SpecSpace Spec) (hcomp : ∀ s ∈ S.admissible, ¬ (P s ∧ Q s)) :
-    superTrue (fun s => P s ∧ Q s) S = Truth3.false :=
+    superTrue (fun s => P s ∧ Q s) S = Trivalent.false :=
   (superTrue_false_iff _ S).mpr hcomp
 
 /-- **Conjunction with self.** P ∧ P has the same super-truth value as P.
@@ -251,7 +250,7 @@ theorem conjunction_self {Spec : Type*} (eval : Spec → Prop) [DecidablePred ev
 theorem classical_implies_superValid {Spec : Type*}
     (eval : Spec → Prop) [DecidablePred eval]
     (htaut : ∀ s, eval s) (S : SpecSpace Spec) :
-    superTrue eval S = Truth3.true :=
+    superTrue eval S = Trivalent.true :=
   (superTrue_true_iff eval S).mpr (fun s _ => htaut s)
 
 /-- Converse: super-valid → classical tautology. The key step: each
@@ -259,7 +258,7 @@ theorem classical_implies_superValid {Spec : Type*}
     super-true in the singleton `{s}`, then `eval s` holds. -/
 theorem superValid_implies_classical {Spec : Type*} [DecidableEq Spec]
     (eval : Spec → Prop) [DecidablePred eval]
-    (hvalid : ∀ S : SpecSpace Spec, superTrue eval S = Truth3.true) :
+    (hvalid : ∀ S : SpecSpace Spec, superTrue eval S = Trivalent.true) :
     ∀ s, eval s := by
   intro s
   exact (superTrue_true_iff eval (.singleton s)).mp (hvalid _) s
@@ -270,7 +269,7 @@ theorem superValid_implies_classical {Spec : Type*} [DecidableEq Spec]
     truth but not to logic. -/
 theorem superValid_iff_classical {Spec : Type*} [DecidableEq Spec]
     (eval : Spec → Prop) [DecidablePred eval] :
-    (∀ S : SpecSpace Spec, superTrue eval S = Truth3.true) ↔ (∀ s, eval s) :=
+    (∀ S : SpecSpace Spec, superTrue eval S = Trivalent.true) ↔ (∀ s, eval s) :=
   ⟨superValid_implies_classical eval, fun h S => classical_implies_superValid eval h S⟩
 
 -- ════════════════════════════════════════════════════
@@ -281,8 +280,8 @@ theorem superValid_iff_classical {Spec : Type*} [DecidableEq Spec]
     across all specification spaces. -/
 def superConsequence {Spec : Type*}
     (evalA evalB : Spec → Prop) [DecidablePred evalA] [DecidablePred evalB] : Prop :=
-  ∀ S : SpecSpace Spec, superTrue evalA S = Truth3.true →
-    superTrue evalB S = Truth3.true
+  ∀ S : SpecSpace Spec, superTrue evalA S = Trivalent.true →
+    superTrue evalB S = Trivalent.true
 
 /-- Forward: classical consequence → super-consequence. -/
 theorem classical_implies_superConsequence {Spec : Type*}
@@ -298,7 +297,7 @@ theorem superConsequence_implies_classical {Spec : Type*} [DecidableEq Spec]
     (h : superConsequence evalA evalB) :
     ∀ s, evalA s → evalB s := by
   intro s hAs
-  have hA : superTrue evalA (.singleton s) = Truth3.true :=
+  have hA : superTrue evalA (.singleton s) = Trivalent.true :=
     (superTrue_true_iff evalA _).mpr
       (fun s' hs' => by have := Finset.mem_singleton.mp hs'; subst this; exact hAs)
   exact (superTrue_true_iff evalB _).mp (h _ hA) s (Finset.mem_singleton.mpr rfl)
@@ -324,16 +323,16 @@ theorem superConsequence_iff_classical {Spec : Type*} [DecidableEq Spec]
 /-- Restricting the specification space preserves super-truth. -/
 theorem stability_superTrue {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S T : SpecSpace Spec) (hsub : T.admissible ⊆ S.admissible)
-    (hst : superTrue eval S = Truth3.true) :
-    superTrue eval T = Truth3.true :=
+    (hst : superTrue eval S = Trivalent.true) :
+    superTrue eval T = Trivalent.true :=
   (superTrue_true_iff eval T).mpr
     (fun s hs => (superTrue_true_iff eval S).mp hst s (hsub hs))
 
 /-- Restricting the specification space preserves super-falsity. -/
 theorem stability_superFalse {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S T : SpecSpace Spec) (hsub : T.admissible ⊆ S.admissible)
-    (hsf : superTrue eval S = Truth3.false) :
-    superTrue eval T = Truth3.false :=
+    (hsf : superTrue eval S = Trivalent.false) :
+    superTrue eval T = Trivalent.false :=
   (superTrue_false_iff eval T).mpr
     (fun s hs => (superTrue_false_iff eval S).mp hsf s (hsub hs))
 
@@ -341,11 +340,11 @@ theorem stability_superFalse {Spec : Type*} (eval : Spec → Prop) [DecidablePre
     If A is definite (true or false) in S, it stays definite in T ⊆ S. -/
 theorem stability_definite {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S T : SpecSpace Spec) (hsub : T.admissible ⊆ S.admissible)
-    (hdef : superTrue eval S ≠ Truth3.indet) :
-    superTrue eval T ≠ Truth3.indet := by
+    (hdef : superTrue eval S ≠ Trivalent.indet) :
+    superTrue eval T ≠ Trivalent.indet := by
   match hs : superTrue eval S with
-  | .true => rw [stability_superTrue eval S T hsub hs]; exact Truth3.noConfusion
-  | .false => rw [stability_superFalse eval S T hsub hs]; exact Truth3.noConfusion
+  | .true => rw [stability_superTrue eval S T hsub hs]; exact Trivalent.noConfusion
+  | .false => rw [stability_superFalse eval S T hsub hs]; exact Trivalent.noConfusion
   | .indet => exact absurd hs hdef
 
 /-- **Stability as antitonicity**: super-truth is preserved under
@@ -354,24 +353,24 @@ theorem stability_definite {Spec : Type*} (eval : Spec → Prop) [DecidablePred 
     `T.admissible ⊆ S.admissible`) preserves super-truth.
 
     This is Mathlib's `Antitone` applied to `superTrue eval` with
-    the codomain ordered by `Truth3.true ≤ · ≤ Truth3.true` (super-truth
+    the codomain ordered by `Trivalent.true ≤ · ≤ Trivalent.true` (super-truth
     entails super-truth). The theorem says: if `superTrue eval S = .true`
     and `S ≤ T` (T is more precise), then `superTrue eval T = .true`.
 
-    The full antitonicity on `Truth3`'s lattice ordering does NOT hold
+    The full antitonicity on `Trivalent`'s lattice ordering does NOT hold
     (restriction can turn `indet` into `true`), but this weaker
     preservation-of-definiteness property is what matters for Fine. -/
 theorem stability_antitone_superTrue {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     {S T : SpecSpace Spec} (hle : S ≤ T)
-    (h : superTrue eval S = Truth3.true) :
-    superTrue eval T = Truth3.true :=
+    (h : superTrue eval S = Trivalent.true) :
+    superTrue eval T = Trivalent.true :=
   stability_superTrue eval S T hle h
 
 /-- Dual: super-falsity is also preserved under the information ordering. -/
 theorem stability_antitone_superFalse {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     {S T : SpecSpace Spec} (hle : S ≤ T)
-    (h : superTrue eval S = Truth3.false) :
-    superTrue eval T = Truth3.false :=
+    (h : superTrue eval S = Trivalent.false) :
+    superTrue eval T = Trivalent.false :=
   stability_superFalse eval S T hle h
 
 -- ════════════════════════════════════════════════════
@@ -389,7 +388,7 @@ theorem stability_antitone_superFalse {Spec : Type*} (eval : Spec → Prop) [Dec
     (the disjunction holds) or D is true and A holds at all points. -/
 theorem D_implies_A {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue (fun s => ¬ definitely eval S ∨ eval s) S = Truth3.true := by
+    superTrue (fun s => ¬ definitely eval S ∨ eval s) S = Trivalent.true := by
   apply (superTrue_true_iff _ S).mpr
   intro s hs
   by_cases hd : definitely eval S
@@ -402,7 +401,7 @@ theorem D_implies_A {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     So `A → DA` is false at `true`, hence not super-true. -/
 theorem A_not_implies_DA :
     ∃ (eval : Bool → Prop) (_ : DecidablePred eval) (S : SpecSpace Bool),
-      superTrue (fun s => ¬ eval s ∨ definitely eval S) S ≠ Truth3.true := by
+      superTrue (fun s => ¬ eval s ∨ definitely eval S) S ≠ Trivalent.true := by
   refine ⟨fun b => b = true, inferInstance,
           ⟨{true, false}, ⟨true, by simp⟩⟩, ?_⟩
   intro h
@@ -418,8 +417,8 @@ theorem A_not_implies_DA :
     but A → DA is not a logical truth. -/
 theorem DA_consequence_of_A {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval] :
     ∀ S : SpecSpace Spec,
-      superTrue eval S = Truth3.true →
-      superTrue (fun _ => definitely eval S) S = Truth3.true := by
+      superTrue eval S = Trivalent.true →
+      superTrue (fun _ => definitely eval S) S = Trivalent.true := by
   intro S hA
   apply (superTrue_true_iff _ S).mpr
   intro _ _
@@ -435,7 +434,7 @@ theorem DA_consequence_of_A {Spec : Type*} (eval : Spec → Prop) [DecidablePred
     evaluation. -/
 theorem fidelity {Spec : Type*} [DecidableEq Spec]
     (eval : Spec → Prop) [DecidablePred eval] (s : Spec) :
-    superTrue eval (.singleton s) ≠ Truth3.indet := by
+    superTrue eval (.singleton s) ≠ Trivalent.indet := by
   intro h
   have hi := (superTrue_indet_iff eval (.singleton s)).mp h
   obtain ⟨⟨st, hst, hvt⟩, ⟨sf, hsf, hvf⟩⟩ := hi

--- a/Linglib/Semantics/Supervaluation/Basic.lean
+++ b/Linglib/Semantics/Supervaluation/Basic.lean
@@ -36,7 +36,7 @@ simplified complete-point-only representation.
 
 namespace Semantics.Supervaluation
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Specification Spaces
@@ -162,10 +162,10 @@ theorem superTrue_indet_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred
     have hnf : ¬(∀ s ∈ S.admissible, ¬ eval s) := fun h => h st hst hvt
     rw [if_neg hnt, if_neg hnf]
 
-/-- **`superTrue` is `Core.Duality.dist` on the admissible Finset.**
+/-- **`superTrue` is `Trivalent.dist` on the admissible Finset.**
 
     The bridge between Fine 1975 supervaluation (this file) and the
-    canonical trivalent classifier (`Core.Duality.dist` in
+    canonical trivalent classifier (`Trivalent.dist` in
     `Linglib/Core/Logic/Duality.lean`). Both are van Fraassen 1966's
     supervaluation construction; `dist` is the more general form
     parameterized over an arbitrary `Finset α + (α → Prop)`, while
@@ -177,8 +177,8 @@ theorem superTrue_indet_iff {Spec : Type*} (eval : Spec → Prop) [DecidablePred
     construction so the empty case never arises here. -/
 theorem superTrue_eq_dist {Spec : Type*} (eval : Spec → Prop) [DecidablePred eval]
     (S : SpecSpace Spec) :
-    superTrue eval S = Core.Duality.dist S.admissible eval := by
-  unfold superTrue Core.Duality.dist
+    superTrue eval S = Trivalent.dist S.admissible eval := by
+  unfold superTrue Trivalent.dist
   by_cases h_all : ∀ a ∈ S.admissible, eval a
   · rw [if_pos h_all, if_pos h_all]
   · rw [if_neg h_all, if_neg h_all]

--- a/Linglib/Semantics/Supervaluation/TCS.lean
+++ b/Linglib/Semantics/Supervaluation/TCS.lean
@@ -127,7 +127,7 @@ is addressed in that Studies file's §8-§9.
 
 namespace Semantics.Supervaluation.TCS
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Core.Logic.Modal
   (AccessRel IsKTBFrame IsSerial box diamond box_T Logic)
 open Core.Logic.Consequence (MixedConsequence SatImplies IsSelfDual

--- a/Linglib/Semantics/Supervaluation/TCS.lean
+++ b/Linglib/Semantics/Supervaluation/TCS.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Supervaluation.Basic
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Consequence
 import Linglib.Core.ModelTheory.Trivalent
 import Linglib.Core.Logic.Modal.Basic
@@ -127,7 +127,6 @@ is addressed in that Studies file's §8-§9.
 
 namespace Semantics.Supervaluation.TCS
 
-open Trivalent (Truth3)
 open Core.Logic.Modal
   (AccessRel IsKTBFrame IsSerial box diamond box_T Logic)
 open Core.Logic.Consequence (MixedConsequence SatImplies IsSelfDual
@@ -359,7 +358,7 @@ def toleranceSpace (M : TModel D Pred) (P : Pred) (a : D)
 theorem StrictAt.iff_superTrue (M : TModel D Pred) (P : Pred) (a : D)
     [DecidablePred (M.sim P a)] :
     StrictAt M P a ↔
-      superTrue (M.interp P) (toleranceSpace M P a) = Truth3.true := by
+      superTrue (M.interp P) (toleranceSpace M P a) = Trivalent.true := by
   rw [superTrue_true_iff]
   refine ⟨λ h d hd => h d (Finset.mem_filter.mp hd).2,
           λ h d hd => h d (Finset.mem_filter.mpr ⟨Finset.mem_univ d, hd⟩)⟩
@@ -368,7 +367,7 @@ theorem StrictAt.iff_superTrue (M : TModel D Pred) (P : Pred) (a : D)
 theorem TolerantAt.not_iff_superFalse (M : TModel D Pred) (P : Pred) (a : D)
     [DecidablePred (M.sim P a)] :
     ¬ TolerantAt M P a ↔
-      superTrue (M.interp P) (toleranceSpace M P a) = Truth3.false := by
+      superTrue (M.interp P) (toleranceSpace M P a) = Trivalent.false := by
   rw [superTrue_false_iff]
   refine ⟨?_, ?_⟩
   · intro h d hd hpd
@@ -385,7 +384,7 @@ theorem TolerantAt.not_iff_superFalse (M : TModel D Pred) (P : Pred) (a : D)
 theorem IsBorderline.iff_superTrue_indet (M : TModel D Pred) (P : Pred) (a : D)
     [DecidablePred (M.sim P a)] :
     IsBorderline M P a ↔
-      superTrue (M.interp P) (toleranceSpace M P a) = Truth3.indet := by
+      superTrue (M.interp P) (toleranceSpace M P a) = Trivalent.indet := by
   rw [IsBorderline.iff_both_witnesses, superTrue_indet_iff]
   refine ⟨?_, ?_⟩
   · rintro ⟨⟨d, hsd, hpd⟩, ⟨e, hse, hne⟩⟩
@@ -775,51 +774,51 @@ attribute [local instance] Classical.propDecidable
 noncomputable def toMV (M : TModel D Pred) : Trivalent.Model (TCSAtom Pred D) := λ α =>
   match α with
   | .pred P a =>
-    if StrictAt M P a then Truth3.true
-    else if TolerantAt M P a then Truth3.indet
-    else Truth3.false
-  | .sim P a b => if M.sim P a b then Truth3.true else Truth3.false
+    if StrictAt M P a then Trivalent.true
+    else if TolerantAt M P a then Trivalent.indet
+    else Trivalent.false
+  | .sim P a b => if M.sim P a b then Trivalent.true else Trivalent.false
 
 theorem toMV_pred_true_iff (M : TModel D Pred) (P : Pred) (a : D) :
-    toMV M (.pred P a) = Truth3.true ↔ StrictAt M P a := by
+    toMV M (.pred P a) = Trivalent.true ↔ StrictAt M P a := by
   unfold toMV
   by_cases hs : StrictAt M P a
   · simp [hs]
   · simp only [if_neg hs]
     refine ⟨λ h => absurd ?_ hs, λ h => absurd h hs⟩
     by_cases ht : TolerantAt M P a
-    · rw [if_pos ht] at h; exact Truth3.noConfusion h
-    · rw [if_neg ht] at h; exact Truth3.noConfusion h
+    · rw [if_pos ht] at h; exact Trivalent.noConfusion h
+    · rw [if_neg ht] at h; exact Trivalent.noConfusion h
 
 theorem toMV_pred_false_iff (M : TModel D Pred) (P : Pred) (a : D) :
-    toMV M (.pred P a) = Truth3.false ↔ ¬ TolerantAt M P a := by
+    toMV M (.pred P a) = Trivalent.false ↔ ¬ TolerantAt M P a := by
   unfold toMV
   by_cases hs : StrictAt M P a
   · simp only [if_pos hs]
-    exact ⟨λ h => Truth3.noConfusion h,
+    exact ⟨λ h => Trivalent.noConfusion h,
            λ h => absurd (StrictAt.imp_tolerant M P a hs) h⟩
   · simp only [if_neg hs]
     by_cases ht : TolerantAt M P a
     · simp only [if_pos ht]
-      exact ⟨λ h => Truth3.noConfusion h, λ h => absurd ht h⟩
+      exact ⟨λ h => Trivalent.noConfusion h, λ h => absurd ht h⟩
     · simp only [if_neg ht]
       refine Iff.intro (λ _ => ht) (λ _ => ?_)
       trivial
 
 theorem toMV_sim_true_iff (M : TModel D Pred) (P : Pred) (a b : D) :
-    toMV M (.sim P a b) = Truth3.true ↔ M.sim P a b := by
+    toMV M (.sim P a b) = Trivalent.true ↔ M.sim P a b := by
   unfold toMV
   by_cases h : M.sim P a b
   · simp [h]
   · simp only [if_neg h]
-    exact ⟨λ heq => Truth3.noConfusion heq, λ hh => absurd hh h⟩
+    exact ⟨λ heq => Trivalent.noConfusion heq, λ hh => absurd hh h⟩
 
 theorem toMV_sim_false_iff (M : TModel D Pred) (P : Pred) (a b : D) :
-    toMV M (.sim P a b) = Truth3.false ↔ ¬ M.sim P a b := by
+    toMV M (.sim P a b) = Trivalent.false ↔ ¬ M.sim P a b := by
   unfold toMV
   by_cases h : M.sim P a b
   · simp only [if_pos h]
-    exact ⟨λ heq => Truth3.noConfusion heq, λ hn => absurd h hn⟩
+    exact ⟨λ heq => Trivalent.noConfusion heq, λ hn => absurd h hn⟩
   · simp [h]
 
 /-- **Lemma 4** (p. 361, formula-level): for every T-model `M` and TCS
@@ -840,7 +839,7 @@ theorem tcs_lp_k3_correspondence (M : TModel D Pred) (φ : TCSFormula Pred D) :
     | pred P a =>
       refine ⟨?_, ?_⟩
       · -- tolerant ↔ LP-designated
-        simp only [Sat.atom_tolerant_pred, Trivalent.Formula.Realize, Truth3.designated_lp_iff, Trivalent.Formula.eval]
+        simp only [Sat.atom_tolerant_pred, Trivalent.Formula.Realize, Trivalent.designated_lp_iff, Trivalent.Formula.eval]
         constructor
         · intro h heq
           have := (toMV_pred_false_iff M P a).mp heq
@@ -849,32 +848,32 @@ theorem tcs_lp_k3_correspondence (M : TModel D Pred) (φ : TCSFormula Pred D) :
           by_contra hnot
           exact h ((toMV_pred_false_iff M P a).mpr hnot)
       · -- strict ↔ K3-designated
-        simp only [Sat.atom_strict_pred, Trivalent.Formula.Realize, Truth3.designated_k3_iff, Trivalent.Formula.eval]
+        simp only [Sat.atom_strict_pred, Trivalent.Formula.Realize, Trivalent.designated_k3_iff, Trivalent.Formula.eval]
         exact (toMV_pred_true_iff M P a).symm
     | sim P a b =>
       refine ⟨?_, ?_⟩
       · -- For sim atoms: Sat M m (sim) = M.sim P a b regardless of m.
         -- LP-sat: Trivalent.Formula.eval = sim ? .true : .false; LP-designated iff true iff sim.
-        simp only [Sat.atom_sim, Trivalent.Formula.Realize, Truth3.designated_lp_iff, Trivalent.Formula.eval, toMV]
+        simp only [Sat.atom_sim, Trivalent.Formula.Realize, Trivalent.designated_lp_iff, Trivalent.Formula.eval, toMV]
         by_cases hsim : M.sim P a b
         · simp only [if_pos hsim]
-          exact ⟨λ _ h => Truth3.noConfusion h, λ _ => hsim⟩
+          exact ⟨λ _ h => Trivalent.noConfusion h, λ _ => hsim⟩
         · simp only [if_neg hsim]
           exact ⟨λ h => absurd h hsim, λ h => absurd rfl h⟩
-      · simp only [Sat.atom_sim, Trivalent.Formula.Realize, Truth3.designated_k3_iff, Trivalent.Formula.eval, toMV]
+      · simp only [Sat.atom_sim, Trivalent.Formula.Realize, Trivalent.designated_k3_iff, Trivalent.Formula.eval, toMV]
         by_cases hsim : M.sim P a b
         · simp only [if_pos hsim]
           refine Iff.intro (λ _ => ?_) (λ _ => hsim)
           trivial
         · simp only [if_neg hsim]
-          exact ⟨λ h => absurd h hsim, λ h => Truth3.noConfusion h⟩
+          exact ⟨λ h => absurd h hsim, λ h => Trivalent.noConfusion h⟩
   | neg ψ ih =>
     obtain ⟨iht, ihs⟩ := ih
     refine ⟨?_, ?_⟩
     · -- tolerant (¬ψ) ↔ LP-designated of neg
-      simp only [Sat.neg_eq, SatMode.dual, Trivalent.Formula.realize_neg, Truth3.Designation.dual_lp, Truth3.Designation.dual_k3]
+      simp only [Sat.neg_eq, SatMode.dual, Trivalent.Formula.realize_neg, Trivalent.Designation.dual_lp, Trivalent.Designation.dual_k3]
       exact not_congr ihs
-    · simp only [Sat.neg_eq, SatMode.dual, Trivalent.Formula.realize_neg, Truth3.Designation.dual_lp, Truth3.Designation.dual_k3]
+    · simp only [Sat.neg_eq, SatMode.dual, Trivalent.Formula.realize_neg, Trivalent.Designation.dual_lp, Trivalent.Designation.dual_k3]
       exact not_congr iht
   | conj ψ χ ihψ ihχ =>
     obtain ⟨ihtψ, ihsψ⟩ := ihψ
@@ -1020,7 +1019,7 @@ theorem tcs_vs_supervaluation_borderline_contradiction
     (hb : IsBorderline M P a) :
     Sat M .tolerant (.conj (.atom (.pred P a)) (.neg (.atom (.pred P a)))) ∧
     superTrue (fun d => M.interp P d ∧ ¬ M.interp P d) (toleranceSpace M P a)
-      = Truth3.false := by
+      = Trivalent.false := by
   refine ⟨?_, nonContradiction_superFalse _ _⟩
   -- TCS side: tolerant(P) ∧ tolerant(¬P)
   -- tolerant(¬P) = ¬strict(P), which holds because borderline.

--- a/Linglib/Studies/AghaJeretic2022.lean
+++ b/Linglib/Studies/AghaJeretic2022.lean
@@ -69,7 +69,7 @@ semantics), and extends it to explain the neg-raising asymmetry between
 
 namespace AghaJeretic2022
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Generalizations.HomogeneityGap (GapDatum GapScenario GapPredict fromExample)
 open Semantics.Homogeneity (negRaising_iff_subsingleton)
 
@@ -82,7 +82,7 @@ open Semantics.Homogeneity (negRaising_iff_subsingleton)
 *should* gets trivalent semantics via plural predication over worlds, while
 *must* remains bivalent (standard ∀ quantification).
 
-We model the modal domain as a `List World` and use `Core.Duality.Truth3`
+We model the modal domain as a `List World` and use `Trivalent.Truth3`
 for the three-valued output. -/
 
 variable {World : Type}
@@ -100,7 +100,7 @@ def mustEval (domain : List World) (p : World → Bool) : Truth3 :=
 
     Body uses an explicit 4-way if-chain to support `split`-based proofs
     in this file. The bridge theorem `shouldEval_eq_distList` (below)
-    formalizes the equivalence with `Core.Duality.distList` for nonempty
+    formalizes the equivalence with `Trivalent.distList` for nonempty
     domains. Refactoring the body to call `distList` directly requires
     rewriting ~3 dense proof scripts; tracked as future work. -/
 def shouldEval (domain : List World) (p : World → Bool) : Truth3 :=
@@ -736,7 +736,7 @@ theorem five_parallels : sharedProperties.length = 5 := rfl
 /-! ## Local vs Global Aggregation
 
 The should/must contrast is an instance of the local/global aggregation
-distinction in `Core.Duality`. When modal sentences are embedded under
+distinction in `Trivalent`. When modal sentences are embedded under
 quantifiers ("Every student should/must pass"):
 
 - **should** (local): each individual's modal domain is mixed → `.indet`.
@@ -747,7 +747,7 @@ quantifiers ("Every student should/must pass"):
   The quantifier sees Bools. By `aggregate_map_ofBool_mixed`, mixed
   inputs yield `.true` for ∃ and `.false` for ∀ — the strength effect. -/
 
-open Core.Duality (ProjectionType aggregate
+open Trivalent (ProjectionType aggregate
   aggregate_replicate_indet aggregate_map_ofBool_mixed aggregate_map_ofBool_ne_indet)
 
 /-- `shouldEval` for a mixed nonempty domain produces `.indet`. -/
@@ -789,7 +789,7 @@ theorem must_always_determinate (d : ProjectionType) (bs : List Bool) :
 
 The paper's central formal claim is that weak necessity IS plural predication.
 We prove this by showing `shouldEval` equals `dist` (the distributive operator
-for plural predication from `Core.Duality`) applied to the evaluation of each
+for plural predication from `Trivalent`) applied to the evaluation of each
 world in the domain.
 
 `dist results` returns:
@@ -799,12 +799,12 @@ world in the domain.
 
 This is exactly what `shouldEval` computes, with `results = domain.map p`. -/
 
-open Core.Duality (distList)
+open Trivalent (distList)
 
 /-- **shouldEval = DIST over worlds.**
 
     `shouldEval D p = distList D p` for nonempty D — the canonical
-    `Core.Duality.distList` (Fine super-truth specialized to a List
+    `Trivalent.distList` (Fine super-truth specialized to a List
     domain with a Boolean predicate) IS what weak necessity computes.
 
     This is the formal proof that weak necessity IS plural predication:

--- a/Linglib/Studies/AghaJeretic2022.lean
+++ b/Linglib/Studies/AghaJeretic2022.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.Logic.Duality
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Data.Examples.AghaJeretic2022
 import Linglib.Data.Generalizations.HomogeneityGap
 import Linglib.Semantics.Modality.Directive
@@ -69,7 +69,6 @@ semantics), and extends it to explain the neg-raising asymmetry between
 
 namespace AghaJeretic2022
 
-open Trivalent (Truth3)
 open Generalizations.HomogeneityGap (GapDatum GapScenario GapPredict fromExample)
 open Semantics.Homogeneity (negRaising_iff_subsingleton)
 
@@ -82,7 +81,7 @@ open Semantics.Homogeneity (negRaising_iff_subsingleton)
 *should* gets trivalent semantics via plural predication over worlds, while
 *must* remains bivalent (standard ∀ quantification).
 
-We model the modal domain as a `List World` and use `Trivalent.Truth3`
+We model the modal domain as a `List World` and use `Trivalent.Trivalent`
 for the three-valued output. -/
 
 variable {World : Type}
@@ -90,8 +89,8 @@ variable {World : Type}
 /-- Strong necessity: standard ∀ quantification over the modal domain.
     Bivalent — always true or false, never indeterminate.
     `must_D := λp. ∀w ∈ D. p(w)` -/
-def mustEval (domain : List World) (p : World → Bool) : Truth3 :=
-  Truth3.ofBool (domain.all p)
+def mustEval (domain : List World) (p : World → Bool) : Trivalent :=
+  Trivalent.ofBool (domain.all p)
 
 /-- Weak necessity: trivalent plural predication over the modal domain.
     Returns tt if all worlds satisfy p, ff if none do, unk otherwise.
@@ -103,11 +102,11 @@ def mustEval (domain : List World) (p : World → Bool) : Truth3 :=
     formalizes the equivalence with `Trivalent.distList` for nonempty
     domains. Refactoring the body to call `distList` directly requires
     rewriting ~3 dense proof scripts; tracked as future work. -/
-def shouldEval (domain : List World) (p : World → Bool) : Truth3 :=
-  if domain.isEmpty then Truth3.false
-  else if domain.all p then Truth3.true
-  else if domain.all (fun w => !p w) then Truth3.false
-  else Truth3.indet
+def shouldEval (domain : List World) (p : World → Bool) : Trivalent :=
+  if domain.isEmpty then Trivalent.false
+  else if domain.all p then Trivalent.true
+  else if domain.all (fun w => !p w) then Trivalent.false
+  else Trivalent.indet
 
 -- ============================================================================
 -- §2. Core Properties of the Trivalent Semantics
@@ -117,33 +116,33 @@ def shouldEval (domain : List World) (p : World → Bool) : Truth3 :=
 
 /-- `must` never returns the indeterminate value. -/
 theorem must_bivalent (domain : List World) (p : World → Bool) :
-    mustEval domain p = Truth3.true ∨ mustEval domain p = Truth3.false := by
-  unfold mustEval Truth3.ofBool
+    mustEval domain p = Trivalent.true ∨ mustEval domain p = Trivalent.false := by
+  unfold mustEval Trivalent.ofBool
   cases domain.all p <;> simp
 
 /-! ### should is homogeneous: it can return ★ -/
 
 /-- In a mixed domain, `should` returns ★ (indeterminate). -/
 theorem should_mixed :
-    shouldEval [true, false] id = Truth3.indet := by native_decide
+    shouldEval [true, false] id = Trivalent.indet := by native_decide
 
 /-- In a uniform-true domain, `should` returns tt. -/
 theorem should_all_true :
-    shouldEval [true, true, true] id = Truth3.true := by native_decide
+    shouldEval [true, true, true] id = Trivalent.true := by native_decide
 
 /-- In a uniform-false domain, `should` returns ff. -/
 theorem should_all_false :
-    shouldEval [false, false] id = Truth3.false := by native_decide
+    shouldEval [false, false] id = Trivalent.false := by native_decide
 
 /-- `must` returns ff in the mixed case (no gap). -/
 theorem must_mixed :
-    mustEval [true, false] id = Truth3.false := by native_decide
+    mustEval [true, false] id = Trivalent.false := by native_decide
 
 /-- When positive, `should` and `must` agree. -/
 theorem should_must_agree_positive (domain : List World) (p : World → Bool)
     (h : domain.all p = true) (hne : domain.isEmpty = false) :
     shouldEval domain p = mustEval domain p := by
-  simp [shouldEval, mustEval, Truth3.ofBool, h, hne]
+  simp [shouldEval, mustEval, Trivalent.ofBool, h, hne]
 
 -- ============================================================================
 -- §3. Negation Symmetry (the formal core of homogeneity)
@@ -180,8 +179,8 @@ private theorem list_all_neg_false_of_pos {α : Type} {l : List α} {p : α → 
 /-- If `shouldEval D p = tt`, then `shouldEval D (¬p) = ff`.
     No overlap between positive and negative extensions of the plurality. -/
 theorem shouldEval_tt_neg_ff (domain : List World) (p : World → Bool)
-    (h : shouldEval domain p = Truth3.true) :
-    shouldEval domain (fun w => !(p w)) = Truth3.false := by
+    (h : shouldEval domain p = Trivalent.true) :
+    shouldEval domain (fun w => !(p w)) = Trivalent.false := by
   unfold shouldEval at h ⊢
   split at h
   · exact absurd h (by decide)
@@ -196,8 +195,8 @@ theorem shouldEval_tt_neg_ff (domain : List World) (p : World → Bool)
 /-- If `shouldEval D p = ff` (non-empty D), then `shouldEval D (¬p) = tt`.
     Symmetric: universal denial of p means universal affirmation of ¬p. -/
 theorem shouldEval_ff_neg_tt (domain : List World) (p : World → Bool)
-    (h : shouldEval domain p = Truth3.false) (hne : domain.isEmpty = false) :
-    shouldEval domain (fun w => !(p w)) = Truth3.true := by
+    (h : shouldEval domain p = Trivalent.false) (hne : domain.isEmpty = false) :
+    shouldEval domain (fun w => !(p w)) = Trivalent.true := by
   unfold shouldEval at h ⊢
   split at h
   · rename_i he; exact absurd he (by simp [hne])
@@ -212,8 +211,8 @@ theorem shouldEval_ff_neg_tt (domain : List World) (p : World → Bool)
 /-- If `shouldEval D p = unk`, then `shouldEval D (¬p) = unk`.
     The gap is symmetric under negation — the core homogeneity property. -/
 theorem shouldEval_unk_symmetric (domain : List World) (p : World → Bool)
-    (h : shouldEval domain p = Truth3.indet) :
-    shouldEval domain (fun w => !(p w)) = Truth3.indet := by
+    (h : shouldEval domain p = Trivalent.indet) :
+    shouldEval domain (fun w => !(p w)) = Trivalent.indet := by
   unfold shouldEval at h ⊢
   split at h
   · exact absurd h (by decide)
@@ -326,11 +325,11 @@ theorem necessarily_removes_homogeneity :
 
 /-- `shouldEval` with homogeneity removal (= explicit quantifier insertion)
     reduces to `mustEval` — the gap disappears. -/
-def shouldWithRemoval (domain : List World) (p : World → Bool) : Truth3 :=
+def shouldWithRemoval (domain : List World) (p : World → Bool) : Trivalent :=
   mustEval domain p
 
 theorem removal_eliminates_gap :
-    shouldWithRemoval [true, false] id = Truth3.false := by native_decide
+    shouldWithRemoval [true, false] id = Trivalent.false := by native_decide
 
 -- ============================================================================
 -- §6. Exception Tolerance (§3.3)
@@ -446,7 +445,7 @@ theorem existential_multiple_minimal_witnesses :
 
 /-- X applied to must yields the domain itself (= should's denotation).
     The resulting plurality is then subject to plural predication semantics. -/
-def applyX (domain : List World) (p : World → Bool) : Truth3 :=
+def applyX (domain : List World) (p : World → Bool) : Trivalent :=
   shouldEval domain p
 
 /-- X(must) = should. -/
@@ -559,7 +558,7 @@ abbrev BridgeWorld := Fin 4
 
 /-- `Directive.weakNecessity` is bivalent: as a Prop, it is classically
     true or false — never indeterminate. This contrasts with `shouldEval`,
-    which can return `Truth3.indet`. -/
+    which can return `Trivalent.indet`. -/
 theorem directive_bivalent
     (f : ModalBase BridgeWorld)
     (g g' : OrderingSource BridgeWorld)
@@ -572,11 +571,11 @@ end DirectiveBridge
 
 /-- `shouldEval` CAN return unk — the gap that domain restriction misses. -/
 theorem shouldEval_can_gap :
-    ∃ (D : List Bool) (p : Bool → Bool), shouldEval D p = Truth3.indet :=
+    ∃ (D : List Bool) (p : Bool → Bool), shouldEval D p = Trivalent.indet :=
   ⟨[true, false], id, by native_decide⟩
 
 /-- Domain restriction as a `GapPredict`: *should* = ∀ over the refined
-    domain, with negation as Strong Kleene `Truth3.neg`. Bivalent on every
+    domain, with negation as Strong Kleene `Trivalent.neg`. Bivalent on every
     cell. -/
 def domainRestrictionPredict : GapPredict := fun pol s =>
   match pol with
@@ -762,7 +761,7 @@ theorem shouldEval_indet (domain : List World) (p : World → Bool)
     have mixed modal domains, all produce `.indet`. Any quantifier
     aggregating these gaps returns `.indet` — strength is invisible. -/
 theorem should_erases_strength (n : Nat) (hn : n > 0) (d : ProjectionType) :
-    aggregate d (List.replicate n Truth3.indet) = .indet :=
+    aggregate d (List.replicate n Trivalent.indet) = .indet :=
   aggregate_replicate_indet d n hn
 
 /-- **must produces the strength effect under embedding**: when n
@@ -771,14 +770,14 @@ theorem should_erases_strength (n : Nat) (hn : n > 0) (d : ProjectionType) :
     weak quantifiers. -/
 theorem must_strength_effect (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    aggregate .disjunctive (bs.map Truth3.ofBool) = .true ∧
-    aggregate .conjunctive (bs.map Truth3.ofBool) = .false :=
+    aggregate .disjunctive (bs.map Trivalent.ofBool) = .true ∧
+    aggregate .conjunctive (bs.map Trivalent.ofBool) = .false :=
   aggregate_map_ofBool_mixed bs h_some_true h_some_false
 
 /-- **must is always determinate under embedding**: aggregation over
     `ofBool` values never produces a gap, regardless of duality type. -/
 theorem must_always_determinate (d : ProjectionType) (bs : List Bool) :
-    aggregate d (bs.map Truth3.ofBool) ≠ .indet :=
+    aggregate d (bs.map Trivalent.ofBool) ≠ .indet :=
   aggregate_map_ofBool_ne_indet d bs
 
 -- ============================================================================
@@ -858,13 +857,13 @@ theorem shouldEval_eq_distList (domain : List World) (p : World → Bool)
 
 /-- `mustEval` is `ofBool ∘ List.all`, confirming must stays bivalent. -/
 theorem mustEval_eq_ofBool (domain : List World) (p : World → Bool) :
-    mustEval domain p = Truth3.ofBool (domain.all p) := rfl
+    mustEval domain p = Trivalent.ofBool (domain.all p) := rfl
 
 -- ============================================================================
--- §17. Sufficient Truth and Exception Tolerance (Appendix 1, def 44–46)
+-- §17. Sufficient Trivalent and Exception Tolerance (Appendix 1, def 44–46)
 -- ============================================================================
 
-/-! ## Sufficient Truth ([kriz-2016], A&J Appendix 1)
+/-! ## Sufficient Trivalent ([kriz-2016], A&J Appendix 1)
 
 Formalizes the mechanism by which indeterminate (★) sentences are rescued
 to "true enough" relative to an Question (= QUD). A sentence S is
@@ -880,10 +879,10 @@ satisfying world — they are "irrelevant" to the QUD.
 of I contains both worlds where S is true and worlds where S is false.
 In other words, S must not split any Question cell. -/
 
-/-- Sufficient Truth (Križ 2016, A&J def 44).
+/-- Sufficient Trivalent (Križ 2016, A&J def 44).
     S is true enough at w w.r.t. issue I iff (i) S is not false at w,
     and (ii) some I-equivalent world makes S true. -/
-def sufficientTruth {W : Type} (S : W → Truth3) (sameCell : W → W → Bool)
+def sufficientTruth {W : Type} (S : W → Trivalent) (sameCell : W → W → Bool)
     (w : W) (worlds : List W) : Bool :=
   S w != .false &&
   worlds.any (fun u => sameCell w u && (S u == .true))
@@ -902,9 +901,9 @@ theorem sufficient_truth_rescues_gap :
     -- w0: all exercises done (S true), w1: most done, still passes (S gap)
     -- QUD1: "how to get a perfect grade?" — w0 ≡ w1 (same answer)
     sufficientTruth
-      (fun w => if w == (0 : Fin 3) then Truth3.true
-                else if w == 1 then Truth3.indet
-                else Truth3.false)
+      (fun w => if w == (0 : Fin 3) then Trivalent.true
+                else if w == 1 then Trivalent.indet
+                else Trivalent.false)
       (fun w u => w != 2 && u != 2)  -- QUD1: w0 ≡ w1, w2 alone
       1  -- evaluate at the gap world
       [0, 1, 2]
@@ -913,9 +912,9 @@ theorem sufficient_truth_rescues_gap :
 theorem strict_qud_blocks_rescue :
     -- QUD2: "minimal requirements?" — every world in its own cell
     sufficientTruth
-      (fun w => if w == (0 : Fin 3) then Truth3.true
-                else if w == 1 then Truth3.indet
-                else Truth3.false)
+      (fun w => if w == (0 : Fin 3) then Trivalent.true
+                else if w == 1 then Trivalent.indet
+                else Trivalent.false)
       (fun w u => w == u)  -- QUD2: exact (identity)
       1  -- evaluate at the gap world
       [0, 1, 2]
@@ -1079,7 +1078,7 @@ theorem bivalent_iff_negRaising {W : Type*} (A : Set W) :
     `bivalent_iff_negRaising` the neg-raising inference fails there too — the
     homogeneity gap and the neg-raising failure are the same condition. -/
 theorem gap_witness_not_subsingleton :
-    shouldEval [true, false] id = Truth3.indet ∧
+    shouldEval [true, false] id = Trivalent.indet ∧
     ¬ ({true, false} : Set Bool).Subsingleton := by
   refine ⟨by decide, fun h => ?_⟩
   have : (true : Bool) = false :=

--- a/Linglib/Studies/BarLev2021.lean
+++ b/Linglib/Studies/BarLev2021.lean
@@ -889,7 +889,7 @@ theorem kriz_bare_kids_onlyKelly_gap :
 /-- Križ's Strong-Kleene negation of a gap is also a gap. So the negation
     "the kids didn't laugh" at `onlyKelly` is `.indet` under Križ. -/
 theorem kriz_neg_bare_kids_onlyKelly_gap :
-    Core.Duality.Truth3.neg
+    Trivalent.Truth3.neg
       (Kriz2016.barePluralTV laughed theKids
         .onlyKelly) = .indet := by
   rw [kriz_bare_kids_onlyKelly_gap]; decide
@@ -915,7 +915,7 @@ theorem barlev_neg_someLaughed_onlyKelly_false :
     formal disagreement that §11 §`positive_negative_asymmetry` describes
     in prose. -/
 theorem kriz_vs_barlev_negative_nonmax :
-    Core.Duality.Truth3.neg
+    Trivalent.Truth3.neg
       (Kriz2016.barePluralTV laughed theKids
         .onlyKelly) = .indet ∧
     ¬ ¬ someLaughed .onlyKelly :=

--- a/Linglib/Studies/BarLev2021.lean
+++ b/Linglib/Studies/BarLev2021.lean
@@ -889,7 +889,7 @@ theorem kriz_bare_kids_onlyKelly_gap :
 /-- Križ's Strong-Kleene negation of a gap is also a gap. So the negation
     "the kids didn't laugh" at `onlyKelly` is `.indet` under Križ. -/
 theorem kriz_neg_bare_kids_onlyKelly_gap :
-    Trivalent.Truth3.neg
+    Trivalent.neg
       (Kriz2016.barePluralTV laughed theKids
         .onlyKelly) = .indet := by
   rw [kriz_bare_kids_onlyKelly_gap]; decide
@@ -915,7 +915,7 @@ theorem barlev_neg_someLaughed_onlyKelly_false :
     formal disagreement that §11 §`positive_negative_asymmetry` describes
     in prose. -/
 theorem kriz_vs_barlev_negative_nonmax :
-    Trivalent.Truth3.neg
+    Trivalent.neg
       (Kriz2016.barePluralTV laughed theKids
         .onlyKelly) = .indet ∧
     ¬ ¬ someLaughed .onlyKelly :=

--- a/Linglib/Studies/Beaver2001/Basic.lean
+++ b/Linglib/Studies/Beaver2001/Basic.lean
@@ -67,7 +67,7 @@ partially addressed by the `QuantifierProjection` type in
 namespace Beaver2001
 
 open Semantics.Presupposition
-open Core.Duality
+open Trivalent
 open CommonGround
 
 variable {W : Type*}

--- a/Linglib/Studies/Beaver2001/Basic.lean
+++ b/Linglib/Studies/Beaver2001/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Presupposition.Context
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Presupposition.Accommodation
 import Linglib.Semantics.Presupposition.LocalContext
 import Linglib.Studies.Beaver2001.ABLE
@@ -67,7 +67,7 @@ partially addressed by the `QuantifierProjection` type in
 namespace Beaver2001
 
 open Semantics.Presupposition
-open Trivalent
+open Trivalent (joinMiddle)
 open CommonGround
 
 variable {W : Type*}
@@ -97,7 +97,7 @@ This uniformity is empirically too strong: "if p then q" presupposes
 
 /-- SK disjunction is symmetric for presupposition projection.
     [beaver-2001] Ch. 2: the correct empirical prediction. -/
-theorem sk_disjunction_symmetric (a b : Truth3) :
+theorem sk_disjunction_symmetric (a b : Trivalent) :
     a ⊔ b = b ⊔ a := by
   cases a <;> cases b <;> rfl
 
@@ -105,8 +105,8 @@ theorem sk_disjunction_symmetric (a b : Truth3) :
     [beaver-2001] Ch. 2: MK captures left-to-right processing
     but overpredicts asymmetry for disjunction. -/
 theorem mk_disjunction_asymmetric :
-    ∃ a b : Truth3, Truth3.joinMiddle a b ≠ Truth3.joinMiddle b a :=
-  ⟨.true, .indet, by simp [Truth3.joinMiddle]⟩
+    ∃ a b : Trivalent, Trivalent.joinMiddle a b ≠ Trivalent.joinMiddle b a :=
+  ⟨.true, .indet, by simp [Trivalent.joinMiddle]⟩
 
 /-- Fact 2.1, negation: SK negation preserves presupposition.
     The presupposition of ¬φ is exactly π(φ). Re-export of

--- a/Linglib/Studies/Belnap1970.lean
+++ b/Linglib/Studies/Belnap1970.lean
@@ -72,7 +72,6 @@ set_option autoImplicit false
 namespace Belnap1970
 
 open Semantics.Presupposition (PartialProp)
-open Trivalent (Truth3)
 open Aristotelian (Square SquareRelations)
 open Quantification
 open Semantics.Montague (ToyEntity)

--- a/Linglib/Studies/Belnap1970.lean
+++ b/Linglib/Studies/Belnap1970.lean
@@ -72,7 +72,7 @@ set_option autoImplicit false
 namespace Belnap1970
 
 open Semantics.Presupposition (PartialProp)
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Aristotelian (Square SquareRelations)
 open Quantification
 open Semantics.Montague (ToyEntity)

--- a/Linglib/Studies/CarianiGoldstein2020.lean
+++ b/Linglib/Studies/CarianiGoldstein2020.lean
@@ -36,7 +36,7 @@ not yet present in linglib and are left as future work.
 
 namespace CarianiGoldstein2020
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Core.Order (SimilarityOrdering)
 open Santorio2018 (DecAlt homogeneityEval)
 

--- a/Linglib/Studies/CarianiGoldstein2020.lean
+++ b/Linglib/Studies/CarianiGoldstein2020.lean
@@ -36,7 +36,6 @@ not yet present in linglib and are left as future work.
 
 namespace CarianiGoldstein2020
 
-open Trivalent (Truth3)
 open Core.Order (SimilarityOrdering)
 open Santorio2018 (DecAlt homogeneityEval)
 
@@ -51,12 +50,12 @@ open Santorio2018 (DecAlt homogeneityEval)
     fail, undefined otherwise. -/
 def cgConditional {W : Type*} [DecidableEq W] [Fintype W]
     (sim : SimilarityOrdering W) (alts : List (DecAlt W))
-    (C : W → Prop) [DecidablePred C] (w : W) : Truth3 :=
+    (C : W → Prop) [DecidablePred C] (w : W) : Trivalent :=
   homogeneityEval sim alts C w
 
 
 -- ════════════════════════════════════════════════════
--- § 2. Truth-conditional coincidence with Santorio
+-- § 2. Trivalent-conditional coincidence with Santorio
 -- ════════════════════════════════════════════════════
 
 /-- **C&G ↔ Santorio coincidence.** [cariani-goldstein-2020]'s

--- a/Linglib/Studies/CiardelliZhangChampollion2018.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018.lean
@@ -39,7 +39,7 @@ counterfactuals; the discriminating contrast (Tables 7–8, p. 607):
    Hamming-distance similarity ordering at the actual world `uu`, all
    three closest-worlds operators in linglib —
    `universalCounterfactual` (Lewis/Stalnaker), `selectionalCounterfactual`
-   (Stalnaker + supervaluation, returns `Truth3.true`), and
+   (Stalnaker + supervaluation, returns `Trivalent.true`), and
    `homogeneityCounterfactual` (von Fintel/Križ, returns `assertion =
    some true` with satisfied presupposition) — all predict `¬(A ∧ B) >
    OFF` true. This is the empirically falsified prediction (~20% true,
@@ -98,7 +98,6 @@ open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual
   (universalCounterfactual selectionalCounterfactual homogeneityCounterfactual
    PresupStatus PresupResult)
-open Trivalent (Truth3)
 
 /-! ## The switches scenario -/
 

--- a/Linglib/Studies/CiardelliZhangChampollion2018.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018.lean
@@ -98,7 +98,7 @@ open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual
   (universalCounterfactual selectionalCounterfactual homogeneityCounterfactual
    PresupStatus PresupResult)
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 /-! ## The switches scenario -/
 

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -63,7 +63,6 @@ previous embedding inside `Semantics/Supervaluation/TCS.lean`.
 namespace CobrerosEtAl2012
 
 open Semantics.Supervaluation.TCS
-open Trivalent (Truth3)
 open Semantics.Supervaluation (SpecSpace superTrue)
 
 -- ════════════════════════════════════════════════════
@@ -251,7 +250,7 @@ theorem d_no_tolerant_contradiction :
 
     On the same tolerance neighborhood `{d | b ~ d}`:
     - **TCS** says `tall(b) ∧ ¬ tall(b)` is **tolerantly true**
-    - **Fine 1975 supervaluation** says it is **super-FALSE** (= `Truth3.false`)
+    - **Fine 1975 supervaluation** says it is **super-FALSE** (= `Trivalent.false`)
 
     The frameworks disagree on the *formal-validity-side* verdict.
     Caveat (per the file docstring): the paper's headline contrast on
@@ -264,7 +263,7 @@ theorem tcs_supervaluation_disagree_concrete :
       (.conj (.atom (.pred .tall .b)) (.neg (.atom (.pred .tall .b)))) ∧
     superTrue (λ e => soritesModel.interp .tall e && !soritesModel.interp .tall e)
       (toleranceSpace soritesModel .tall .b)
-      = Truth3.false :=
+      = Trivalent.false :=
   tcs_vs_supervaluation_borderline_contradiction
     soritesModel .tall .b b_is_borderline
 

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -63,7 +63,7 @@ previous embedding inside `Semantics/Supervaluation/TCS.lean`.
 namespace CobrerosEtAl2012
 
 open Semantics.Supervaluation.TCS
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Semantics.Supervaluation (SpecSpace superTrue)
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Coppock2018.lean
+++ b/Linglib/Studies/Coppock2018.lean
@@ -73,7 +73,7 @@ via the paper's translation: radically counterstance-contingent = strongly discr
 
 namespace Coppock2018
 
-open Core.Duality (Truth3 Prop3)
+open Trivalent (Truth3 Prop3)
 open Core.Logic.Modal (AccessRel box)
 open Semantics.Presupposition (PartialProp)
 

--- a/Linglib/Studies/Coppock2018.lean
+++ b/Linglib/Studies/Coppock2018.lean
@@ -3,7 +3,7 @@ import Mathlib.Data.Setoid.Basic
 import Mathlib.Order.BooleanSubalgebra
 import Mathlib.Order.Hom.CompleteLattice
 import Linglib.Core.Logic.Modal.Defs
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
@@ -14,8 +14,8 @@ import Linglib.Semantics.Presupposition.Basic
 that settle matters of opinion as well as fact — **replace** possible worlds as circumstances
 of evaluation, rather than supplementing them with a judge as in world-judge relativism
 ([lasersohn-2005]). A proposition is a function from outlooks to three truth values
-(`Prop3 Ω`, with [coppock-2018]'s Weak Kleene connectives available as `Truth3.meetWeak`/
-`Truth3.joinWeak`/`Truth3.neg`); it is *objective* when its truth value never splits within
+(`Prop3 Ω`, with [coppock-2018]'s Weak Kleene connectives available as `Trivalent.meetWeak`/
+`Trivalent.joinWeak`/`Trivalent.neg`); it is *objective* when its truth value never splits within
 a world's refinement class, *discretionary* when it does, and *strongly discretionary* when
 it splits within every world's class. Faultless disagreement ([kolbel-2003]) then falls out:
 two agents can accept and reject the same strongly discretionary proposition at one outlook
@@ -73,7 +73,7 @@ via the paper's translation: radically counterstance-contingent = strongly discr
 
 namespace Coppock2018
 
-open Trivalent (Truth3 Prop3)
+open Trivalent (Prop3)
 open Core.Logic.Modal (AccessRel box)
 open Semantics.Presupposition (PartialProp)
 

--- a/Linglib/Studies/Fine1975.lean
+++ b/Linglib/Studies/Fine1975.lean
@@ -4,7 +4,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 
 /-!
-# Fine (1975): Vagueness, Truth and Logic [fine-1975]
+# Fine (1975): Vagueness, Trivalent and Logic [fine-1975]
 [kamp-1975]
 
 Supervaluationism applied to gradable predicates: a vague sentence is
@@ -23,7 +23,7 @@ gradable adjectives, and proves results specific to degree semantics:
 - § 2: Comparative entailment (monotonicity of positive predicate)
 - § 3: Sorites resolution
 - § 4: External penumbral connections (pink/red — multi-predicate)
-- § 5: Bridge — `inGapRegion` ↔ `Truth3.indet`
+- § 5: Bridge — `inGapRegion` ↔ `Trivalent.indet`
 - § 6: Higher-order D operator
 
 ## Connection to Kamp (1975)
@@ -43,7 +43,6 @@ is the existential dual of supervaluation. See
 
 namespace Fine1975
 
-open Trivalent (Truth3)
 open Degree (Degree Threshold Degree.toNat Threshold.toNat)
 open Degree (ThresholdPair inGapRegion)
 open Semantics.Supervaluation (SpecSpace superTrue definitely indefinite)
@@ -60,7 +59,7 @@ def mkSpec {max : Nat} (S : Finset (Threshold max)) (hne : S.Nonempty) :
 /-- Supervaluation of a degree predicate: fix a degree, vary the threshold. -/
 def superTrueAt {max : Nat} (meaning : Degree max → Threshold max → Prop)
     [∀ d θ, Decidable (meaning d θ)] (d : Degree max)
-    (S : SpecSpace (Threshold max)) : Truth3 :=
+    (S : SpecSpace (Threshold max)) : Trivalent :=
   superTrue (meaning d) S
 
 -- ════════════════════════════════════════════════════
@@ -75,8 +74,8 @@ def superTrueAt {max : Nat} (meaning : Degree max → Threshold max → Prop)
 theorem comparative_entailment {max : Nat}
     (d₁ d₂ : Degree max) (S : SpecSpace (Threshold max))
     (hgt : d₂.toNat < d₁.toNat)
-    (hd₂ : superTrueAt (fun d θ => d.toNat > θ.toNat) d₂ S = Truth3.true) :
-    superTrueAt (fun d θ => d.toNat > θ.toNat) d₁ S = Truth3.true := by
+    (hd₂ : superTrueAt (fun d θ => d.toNat > θ.toNat) d₂ S = Trivalent.true) :
+    superTrueAt (fun d θ => d.toNat > θ.toNat) d₁ S = Trivalent.true := by
   unfold superTrueAt at *
   rw [Semantics.Supervaluation.superTrue_true_iff] at hd₂ ⊢
   intro θ hθ
@@ -143,25 +142,25 @@ theorem pink_red_complementary {max : Nat} (d : Degree max) (θ : Threshold max)
     logic, `indet ∧ indet = indet`; supervaluation gives `false`. -/
 theorem pink_and_red_superFalse {max : Nat} (d : Degree max)
     (S : SpecSpace (Threshold max)) :
-    superTrue (fun θ => isPink d θ ∧ isRed d θ) S = Truth3.false :=
+    superTrue (fun θ => isPink d θ ∧ isRed d θ) S = Trivalent.false :=
   (Semantics.Supervaluation.superTrue_false_iff _ S).mpr
     (fun θ _ => pink_red_complementary d θ)
 
 /-- Both "pink" and "red" can individually be indefinite (borderline). -/
 theorem pink_indefinite_example :
     superTrue (isPink (max := 10) ⟨5, by omega⟩)
-      ⟨{⟨3, by omega⟩, ⟨7, by omega⟩}, ⟨⟨3, by omega⟩, by simp⟩⟩ = Truth3.indet := by
+      ⟨{⟨3, by omega⟩, ⟨7, by omega⟩}, ⟨⟨3, by omega⟩, by simp⟩⟩ = Trivalent.indet := by
   decide
 
 -- ════════════════════════════════════════════════════
--- § 5. Bridge: Gap Region ↔ Truth3.indet
+-- § 5. Bridge: Gap Region ↔ Trivalent.indet
 -- ════════════════════════════════════════════════════
 
 /-! The `inGapRegion` function in `Adjective.Theory` computes whether a
     degree falls between two thresholds (the "borderline" zone for contrary
     antonyms). A `ThresholdPair` with `neg ≤ pos` is a two-element
     specification space, and the gap region is exactly the set of degrees
-    that receive `Truth3.indet` under supervaluation. -/
+    that receive `Trivalent.indet` under supervaluation. -/
 
 /-- The specification space induced by a threshold pair. -/
 def specOfPair {max : Nat} (tp : ThresholdPair max) : SpecSpace (Threshold max) :=

--- a/Linglib/Studies/Fine1975.lean
+++ b/Linglib/Studies/Fine1975.lean
@@ -43,7 +43,7 @@ is the existential dual of supervaluation. See
 
 namespace Fine1975
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Degree (Degree Threshold Degree.toNat Threshold.toNat)
 open Degree (ThresholdPair inGapRegion)
 open Semantics.Supervaluation (SpecSpace superTrue definitely indefinite)

--- a/Linglib/Studies/Fitting1994.lean
+++ b/Linglib/Studies/Fitting1994.lean
@@ -32,7 +32,7 @@ route to natural-language entailment, implicature, and presupposition is
   of `FOUR`'s truth meet/join
 -/
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Bilattice
 open Bilattice.FOUR (U T F Consistent)
 

--- a/Linglib/Studies/Fitting1994.lean
+++ b/Linglib/Studies/Fitting1994.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Bilattice.Basic
 
 /-!
@@ -12,10 +12,10 @@ Kleene values are exactly those `x` with `x ≤_k −x` — the *consistent*
 (non-glut) values.
 
 `FOUR` and its two orders / negation / conflation are the shared substrate in
-`Core.Logic.Bilattice`. Here we prove the slicing for linglib's `Truth3`
-(Kleene's three-valued logic, [kleene-1952]): `ofTruth3` embeds `Truth3` onto the
-consistent fragment of `FOUR`, matching the truth order (`Truth3`'s `≤` vs
-`FOUR`'s `≤`), the knowledge order (`Truth3.toFlat`, i.e. `Flat Bool`, vs
+`Core.Logic.Bilattice`. Here we prove the slicing for linglib's `Trivalent`
+(Kleene's three-valued logic, [kleene-1952]): `ofTruth` embeds `Trivalent` onto the
+consistent fragment of `FOUR`, matching the truth order (`Trivalent`'s `≤` vs
+`FOUR`'s `≤`), the knowledge order (`Trivalent.toFlat`, i.e. `Flat Bool`, vs
 `FOUR`'s `≤ₖ`), and negation. So the gap logic linglib uses for presupposition
 is the `I`-free slice; the glut `I` is what trivalence excludes. The bilattice
 route to natural-language entailment, implicature, and presupposition is
@@ -23,36 +23,35 @@ route to natural-language entailment, implicature, and presupposition is
 
 ## Main results
 
-* `Fitting1994.ofTruth3` — the embedding `Truth3 → FOUR`
-* `Fitting1994.ofTruth3_consistent`, `consistent_range` — its image is exactly
+* `Fitting1994.ofTruth` — the embedding `Trivalent → FOUR`
+* `Fitting1994.ofTruth_consistent`, `consistent_range` — its image is exactly
   the consistent fragment
-* `le_ofTruth3`, `kLE_ofTruth3`, `neg_ofTruth3`, `inf_ofTruth3`/`sup_ofTruth3`
-  — `Truth3` is the consistent fragment of `FOUR` as a bilattice *logic*: both
+* `le_ofTruth`, `kLE_ofTruth`, `neg_ofTruth`, `inf_ofTruth`/`sup_ofTruth`
+  — `Trivalent` is the consistent fragment of `FOUR` as a bilattice *logic*: both
   orders, negation, and the strong-Kleene connectives `∧`/`∨` as restrictions
   of `FOUR`'s truth meet/join
 -/
 
-open Trivalent (Truth3)
 open Bilattice
 open Bilattice.FOUR (U T F Consistent)
 
 namespace Fitting1994
 
-/-- The embedding of `Truth3` (Kleene-3) into `FOUR`: `indet ↦ ⊥`, `true ↦ T`,
+/-- The embedding of `Trivalent` (Kleene-3) into `FOUR`: `indet ↦ ⊥`, `true ↦ T`,
 `false ↦ F`. Its image is exactly the consistent fragment. -/
-def ofTruth3 : Truth3 → FOUR
+def ofTruth : Trivalent → FOUR
   | .indet => U
   | .true  => T
   | .false => F
 
-theorem ofTruth3_injective : Function.Injective ofTruth3 := by
+theorem ofTruth_injective : Function.Injective ofTruth := by
   intro a b; cases a <;> cases b <;> decide
 
-theorem ofTruth3_consistent (a : Truth3) : Consistent (ofTruth3 a) := by
+theorem ofTruth_consistent (a : Trivalent) : Consistent (ofTruth a) := by
   cases a <;> decide
 
-/-- The image of `ofTruth3` is the whole consistent fragment. -/
-theorem consistent_range {x : FOUR} (hx : Consistent x) : ∃ a, ofTruth3 a = x := by
+/-- The image of `ofTruth` is the whole consistent fragment. -/
+theorem consistent_range {x : FOUR} (hx : Consistent x) : ∃ a, ofTruth a = x := by
   obtain ⟨a, b⟩ := x
   cases a <;> cases b
   · exact ⟨.indet, rfl⟩
@@ -60,33 +59,33 @@ theorem consistent_range {x : FOUR} (hx : Consistent x) : ∃ a, ofTruth3 a = x 
   · exact ⟨.true, rfl⟩
   · exact absurd hx (by decide)
 
-/-- **Truth-order match**: `Truth3`'s truth order is `FOUR`'s, on the fragment. -/
-theorem le_ofTruth3 (a b : Truth3) : a ≤ b ↔ ofTruth3 a ≤ ofTruth3 b := by
+/-- **Trivalent-order match**: `Trivalent`'s truth order is `FOUR`'s, on the fragment. -/
+theorem le_ofTruth (a b : Trivalent) : a ≤ b ↔ ofTruth a ≤ ofTruth b := by
   cases a <;> cases b <;> decide
 
-/-- **Knowledge-order match**: `Truth3`'s knowledge order (`Truth3.toFlat`, i.e.
+/-- **Knowledge-order match**: `Trivalent`'s knowledge order (`Trivalent.toFlat`, i.e.
 `Flat Bool`) is `FOUR`'s knowledge order on the fragment. -/
-theorem kLE_ofTruth3 (a b : Truth3) :
-    Truth3.toFlat a ≤ Truth3.toFlat b ↔ ofTruth3 a ≤ₖ ofTruth3 b := by
+theorem kLE_ofTruth (a b : Trivalent) :
+    Trivalent.toFlat a ≤ Trivalent.toFlat b ↔ ofTruth a ≤ₖ ofTruth b := by
   cases a <;> cases b <;> decide
 
 /-- **Negation match**: Kleene negation is `FOUR`-negation on the fragment. -/
-theorem neg_ofTruth3 (a : Truth3) :
-    ofTruth3 (Truth3.neg a) = Product.neg (ofTruth3 a) := by
+theorem neg_ofTruth (a : Trivalent) :
+    ofTruth (Trivalent.neg a) = Product.neg (ofTruth a) := by
   cases a <;> rfl
 
-/-- **Connective match, conjunction**: strong-Kleene `∧` (`Truth3`'s `⊓ = min`)
+/-- **Connective match, conjunction**: strong-Kleene `∧` (`Trivalent`'s `⊓ = min`)
 is the restriction of `FOUR`'s truth meet to the consistent fragment — the
 fragment is a fragment *as a logic*, not just as a pair of posets
 ([fitting-1994]). -/
-theorem inf_ofTruth3 (a b : Truth3) :
-    ofTruth3 (a ⊓ b) = ofTruth3 a ⊓ ofTruth3 b := by
+theorem inf_ofTruth (a b : Trivalent) :
+    ofTruth (a ⊓ b) = ofTruth a ⊓ ofTruth b := by
   cases a <;> cases b <;> decide
 
-/-- **Connective match, disjunction**: strong-Kleene `∨` (`Truth3`'s `⊔ = max`)
+/-- **Connective match, disjunction**: strong-Kleene `∨` (`Trivalent`'s `⊔ = max`)
 is the restriction of `FOUR`'s truth join to the consistent fragment. -/
-theorem sup_ofTruth3 (a b : Truth3) :
-    ofTruth3 (a ⊔ b) = ofTruth3 a ⊔ ofTruth3 b := by
+theorem sup_ofTruth (a b : Trivalent) :
+    ofTruth (a ⊔ b) = ofTruth a ⊔ ofTruth b := by
   cases a <;> cases b <;> decide
 
 end Fitting1994

--- a/Linglib/Studies/Grove2022.lean
+++ b/Linglib/Studies/Grove2022.lean
@@ -76,7 +76,7 @@ set_option autoImplicit false
 
 namespace Grove2022
 
-open Core.Duality (Truth3 Prop3)
+open Trivalent (Truth3 Prop3)
 open Semantics.Presupposition (PartialProp)
 
 /-! ## Part I — Apparatus -/

--- a/Linglib/Studies/Grove2022.lean
+++ b/Linglib/Studies/Grove2022.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Studies.Heim1992Projection
 
@@ -37,7 +37,7 @@ plus attitude-verb examples (Part II).
 * `evalI` — evaluation `(·)^ž` (eq. 20)
 * `forallP` / `existsP` — presuppositional quantifiers (eq. 27)
 * `believe` — doxastic attitude verb (eq. 28)
-* Bridges to `Truth3`, `Prop3`, `PartialProp`
+* Bridges to `Trivalent`, `Prop3`, `PartialProp`
 
 ## Part II — Empirical predictions (Grove §3, §4.2)
 
@@ -76,7 +76,7 @@ set_option autoImplicit false
 
 namespace Grove2022
 
-open Trivalent (Truth3 Prop3)
+open Trivalent (Prop3)
 open Semantics.Presupposition (PartialProp)
 
 /-! ## Part I — Apparatus -/
@@ -255,59 +255,59 @@ end AttitudeVerbs
 
 /-! ### §6 Bridges to existing linglib types
 
-`Option Bool`, `Truth3`, and `PartialProp W` are three representations of
+`Option Bool`, `Trivalent`, and `PartialProp W` are three representations of
 possibly-undefined truth values. These conversions connect Grove's
 formalisation to the rest of the presupposition infrastructure. -/
 
 section Bridges
 
-/-- Convert `Option Bool` to `Truth3`. -/
-def toTruth3 : Option Bool → Truth3
+/-- Convert `Option Bool` to `Trivalent`. -/
+def toTruth : Option Bool → Trivalent
   | some true => .true
   | some false => .false
   | none => .indet
 
-/-- Convert `Truth3` to `Option Bool`. -/
-def ofTruth3 : Truth3 → Option Bool
+/-- Convert `Trivalent` to `Option Bool`. -/
+def ofTruth : Trivalent → Option Bool
   | .true => some true
   | .false => some false
   | .indet => none
 
-theorem roundtrip_truth3 (v : Truth3) : toTruth3 (ofTruth3 v) = v := by
+theorem roundtrip_truth3 (v : Trivalent) : toTruth (ofTruth v) = v := by
   cases v <;> rfl
 
-theorem roundtrip_option (v : Option Bool) : ofTruth3 (toTruth3 v) = v := by
+theorem roundtrip_option (v : Option Bool) : ofTruth (toTruth v) = v := by
   cases v with
   | none => rfl
   | some b => cases b <;> rfl
 
-/-- Middle Kleene implication on `Truth3`. -/
-def impMK : Truth3 → Truth3 → Truth3
+/-- Middle Kleene implication on `Trivalent`. -/
+def impMK : Trivalent → Trivalent → Trivalent
   | .indet, _ => .indet
   | .false, _ => .true
   | .true, ψ => ψ
 
-/-- `materialCond` corresponds to middle Kleene implication on `Truth3`. -/
+/-- `materialCond` corresponds to middle Kleene implication on `Trivalent`. -/
 theorem materialCond_eq_truth3 (p q : Option Bool) :
-    toTruth3 (materialCond p q) = impMK (toTruth3 p) (toTruth3 q) := by
+    toTruth (materialCond p q) = impMK (toTruth p) (toTruth q) := by
   cases p with
   | none => rfl
   | some b => cases b <;> cases q with
     | none => rfl
     | some c => cases c <;> rfl
 
-/-- `meetWK` corresponds to `Truth3.meetWeak`. -/
+/-- `meetWK` corresponds to `Trivalent.meetWeak`. -/
 theorem meetWK_eq_truth3 (p q : Option Bool) :
-    toTruth3 (meetWK p q) = Truth3.meetWeak (toTruth3 p) (toTruth3 q) := by
+    toTruth (meetWK p q) = Trivalent.meetWeak (toTruth p) (toTruth q) := by
   cases p with
   | none => cases q with | none => rfl | some c => cases c <;> rfl
   | some b => cases b <;> cases q with
     | none => rfl
     | some c => cases c <;> rfl
 
-/-- `joinWK` corresponds to `Truth3.joinWeak`. -/
+/-- `joinWK` corresponds to `Trivalent.joinWeak`. -/
 theorem joinWK_eq_truth3 (p q : Option Bool) :
-    toTruth3 (joinWK p q) = Truth3.joinWeak (toTruth3 p) (toTruth3 q) := by
+    toTruth (joinWK p q) = Trivalent.joinWeak (toTruth p) (toTruth q) := by
   cases p with
   | none => cases q with | none => rfl | some c => cases c <;> rfl
   | some b => cases b <;> cases q with
@@ -317,7 +317,7 @@ theorem joinWK_eq_truth3 (p q : Option Bool) :
 /-- Convert `Iₚ W Bool` to `Prop3 W` (world-indexed three-valued
 proposition). -/
 def toProp3 {W : Type} (φ : Iₚ W Bool) : Prop3 W :=
-  λ w => toTruth3 (φ w)
+  λ w => toTruth (φ w)
 
 /-- Convert `Iₚ W Bool` to `PartialProp W`. The presupposition field is
 `isSome` (defined?), and the assertion is the Bool value (defaulting

--- a/Linglib/Studies/HaugDalrymple2020.lean
+++ b/Linglib/Studies/HaugDalrymple2020.lean
@@ -70,7 +70,7 @@ namespace HaugDalrymple2020
 open Semantics.Reference.Reciprocals
 open Semantics.Dynamic.PPCDRT
 open Core
-open Core.Duality
+open Trivalent
 open Semantics.Plurality.Cumulativity
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/HaugDalrymple2020.lean
+++ b/Linglib/Studies/HaugDalrymple2020.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Dynamic.PPCDRT.Cumulativity
 import Linglib.Semantics.Plurality.Cumulativity
 import Linglib.Semantics.Homogeneity.Basic
 import Linglib.Semantics.Supervaluation.Basic
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 
 /-!
 # Haug & Dalrymple (2020) [haug-dalrymple-2020]
@@ -32,7 +32,7 @@ the PPCDRT substrate (`Semantics/Dynamic/PPCDRT/`):
 | §4.4    | Multiple reciprocals                   | Two-reciprocal witness     |
 | §4.5    | Subgroup readings (forks, gravity)     | Weak-vs-strong contrast    |
 | §4.6    | Collective antecedents                 | Distinctness neutralization |
-| §5      | Quantified antecedents + truth-value gap | `Truth3` via `removeGap` |
+| §5      | Quantified antecedents + truth-value gap | `Trivalent` via `removeGap` |
 | §6      | Maximize Anaphora as a principle       | `R_u` + `maximizeAnaphora` |
 | §6.2    | Multi-reciprocal pairwise prediction   | `R_u` over two reciprocals |
 | §6.3    | MA interacting with scope              | Tracy/Matty/Chris case     |
@@ -49,7 +49,7 @@ the §5.2 empirical-fit table; the §7 typological excursus.
 - [champollion-bumford-henderson-2019] for the §5 supervaluationist
   truth-value-gap analysis — realised via
   `Semantics/Homogeneity/Basic.lean`'s `removeGap` /
-  `Truth3.metaAssert`.
+  `Trivalent.metaAssert`.
 - [kriz-2015] for the homogeneity background; same substrate.
 - [langendoen-1978] for the reciprocity-as-cumulativity link —
   realised via `PPCDRT/Cumulativity.lean`'s
@@ -70,7 +70,7 @@ namespace HaugDalrymple2020
 open Semantics.Reference.Reciprocals
 open Semantics.Dynamic.PPCDRT
 open Core
-open Trivalent
+open Trivalent (dist metaAssert)
 open Semantics.Plurality.Cumulativity
 
 -- ════════════════════════════════════════════════════════════════
@@ -475,7 +475,7 @@ theorem collective_groupIdentity_no_distinct :
       exact ⟨assign3 .matty .matty .matty, .inr (.inr rfl), assign3_u₁ ..⟩
 
 -- ════════════════════════════════════════════════════════════════
--- § 9: §5 Quantified Antecedents + Truth-Value Gap
+-- § 9: §5 Quantified Antecedents + Trivalent-Value Gap
 -- (paper eq 99, 109; [champollion-bumford-henderson-2019]; [kriz-2015])
 -- ════════════════════════════════════════════════════════════════
 
@@ -487,15 +487,15 @@ theorem collective_groupIdentity_no_distinct :
     [champollion-bumford-henderson-2019], following [kriz-2015],
     for the supervaluationist machinery.
 
-    Here we encode the truth-value gap directly via `Truth3`, exploiting
+    Here we encode the truth-value gap directly via `Trivalent`, exploiting
     the existing `Semantics/Homogeneity/Basic.lean` substrate
-    (`removeGap`, `Truth3.metaAssert`). -/
+    (`removeGap`, `Trivalent.metaAssert`). -/
 
 /-- The truth value of a quantified-antecedent reciprocal sentence,
     given its truth on the maximal-set reading and on the reference-set
     reading. Paper eq 109. -/
 def quantifiedReciprocalTV (maximalSetReading refSetReading : Prop)
-    [Decidable maximalSetReading] [Decidable refSetReading] : Truth3 :=
+    [Decidable maximalSetReading] [Decidable refSetReading] : Trivalent :=
   if maximalSetReading ∧ refSetReading then .true
   else if ¬ maximalSetReading ∧ ¬ refSetReading then .false
   else .indet

--- a/Linglib/Studies/HollidayMandelkern2024.lean
+++ b/Linglib/Studies/HollidayMandelkern2024.lean
@@ -223,7 +223,7 @@ def pRightReg : pathFrame.Regular := pathFrame.regOf pRight regular_right
 def pMidReg : pathFrame.Regular := pathFrame.regOf pMid regular_mid
 
 section TypeclassLevel
-open OrthocomplementedLattice
+open OrthocomplementedLattice LatticeWithInvolution
 
 /-- Double negation on `pLeftReg` from the typeclass: `(pLeftReg)ᶜᶜ = pLeftReg`.
     Replaces the pointwise `doubleNeg_left` proof — abstract typeclass result,

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -54,7 +54,7 @@ open Exhaustification.FreeChoice (Ctx existsInDomain
 open Ladusaw1979 (licensingStrength)
 open Semantics.Supervaluation (SpecSpace superTrue superTrue_true_iff
   superTrue_indet_iff)
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 /-! ### The strengthening condition
 

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -54,7 +54,6 @@ open Exhaustification.FreeChoice (Ctx existsInDomain
 open Ladusaw1979 (licensingStrength)
 open Semantics.Supervaluation (SpecSpace superTrue superTrue_true_iff
   superTrue_indet_iff)
-open Trivalent (Truth3)
 
 /-! ### The strengthening condition
 
@@ -503,7 +502,7 @@ traditional GEN operator's hidden normalcy parameter
 (`Semantics/Genericity/Generics.lean`) is, on this view, a choice of
 precisification; exception tolerance is the freedom to choose another. -/
 
-/-- Truth under one precisification: every entity in the induced domain
+/-- Trivalent under one precisification: every entity in the induced domain
 satisfies the scope. -/
 def genericTrue {Property Entity : Type*} (apply : Property → Set Entity)
     (scope : Entity → Prop) (v : Set Property) : Prop :=
@@ -585,7 +584,7 @@ theorem genericSuperTrue_iff_superTrue {Property Entity : Type*}
     (scope : Entity → Prop) [DecidablePred (genericTrue apply scope)]
     (V : Finset (Set Property)) (hV : ↑V = X.precisifications) :
     genericSuperTrue X apply scope ↔
-      superTrue (genericTrue apply scope) (X.toSpecSpace V hV) = Truth3.true := by
+      superTrue (genericTrue apply scope) (X.toSpecSpace V hV) = Trivalent.true := by
   rw [superTrue_true_iff]
   exact ⟨λ h v hv => h v (VagueRestriction.mem_toSpecSpace.mp hv),
          λ h v hv => h v (VagueRestriction.mem_toSpecSpace.mpr hv)⟩
@@ -599,7 +598,7 @@ theorem genericSubTrue_not_superTrue_iff_indet {Property Entity : Type*}
     (scope : Entity → Prop) [DecidablePred (genericTrue apply scope)]
     (V : Finset (Set Property)) (hV : ↑V = X.precisifications) :
     genericSubTrue X apply scope ∧ ¬genericSuperTrue X apply scope ↔
-      superTrue (genericTrue apply scope) (X.toSpecSpace V hV) = Truth3.indet := by
+      superTrue (genericTrue apply scope) (X.toSpecSpace V hV) = Trivalent.indet := by
   rw [superTrue_indet_iff]
   constructor
   · rintro ⟨⟨v, hv, hvt⟩, hns⟩

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -102,7 +102,7 @@ end Bridge
     `meet indet indet = indet`. This preserves `φ ∧ φ ≡ φ` but fails
     to make contradictions false. Supervaluationism resolves both. -/
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 /-- **Kamp's dilemma**: no truth-functional binary operator can
     simultaneously be idempotent (`F(x,x) = x`) and make borderline

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Modification.Adjective
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Mathlib.Data.Set.Basic
 
 /-!
@@ -98,11 +98,10 @@ end Bridge
     inputs are identical. This is wrong: `φ ∧ φ` should have the same
     value as `φ`.
 
-    Strong Kleene logic (`⊓` on `Truth3`) makes the symmetric choice:
+    Strong Kleene logic (`⊓` on `Trivalent`) makes the symmetric choice:
     `meet indet indet = indet`. This preserves `φ ∧ φ ≡ φ` but fails
     to make contradictions false. Supervaluationism resolves both. -/
 
-open Trivalent (Truth3)
 
 /-- **Kamp's dilemma**: no truth-functional binary operator can
     simultaneously be idempotent (`F(x,x) = x`) and make borderline
@@ -113,11 +112,11 @@ open Trivalent (Truth3)
     contradiction requirement demands `F(½,½) = 0`. This is what
     motivates the move to supervaluation. -/
 theorem kleene_dilemma :
-    ¬∃ (meet : Truth3 → Truth3 → Truth3),
+    ¬∃ (meet : Trivalent → Trivalent → Trivalent),
       (∀ x, meet x x = x) ∧
-      (meet .indet (Truth3.neg .indet) = .false) := by
+      (meet .indet (Trivalent.neg .indet) = .false) := by
   intro ⟨meet, hidem, hcontra⟩
-  have : Truth3.neg .indet = .indet := rfl
+  have : Trivalent.neg .indet = .indet := rfl
   rw [this] at hcontra
   have := hidem .indet
   rw [hcontra] at this

--- a/Linglib/Studies/Kriz2016.lean
+++ b/Linglib/Studies/Kriz2016.lean
@@ -97,7 +97,7 @@ Adding "all" blocks non-maximal use entirely.
 
 namespace Kriz2016
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Semantics.Plurality
 open Semantics.Plurality.Distributivity
 open Semantics.Plurality.Trivalent
@@ -602,7 +602,7 @@ theorem model_matches_gap_row :
 
     - [fine-1975]: varying the *threshold* for vague predicates
     - [kriz-2016]: varying the *atom* for plural predicates
-    - `dist` in `Core.Duality`: a third implementation of the same pattern
+    - `dist` in `Trivalent`: a third implementation of the same pattern
       over `List Bool`
     - `selectional_eq_dist` in `Counterfactual.lean`: closest worlds
     - [haug-dalrymple-2020] §5 (paper eq 109): varying the

--- a/Linglib/Studies/Kriz2016.lean
+++ b/Linglib/Studies/Kriz2016.lean
@@ -45,7 +45,7 @@ Smith didn't) arise from the interaction of two independent components:
 
 The semantic effect of `all` is to remove the extension gap, making positive
 and negative extensions complementary. This prevents non-maximal readings
-because the pragmatic mechanism (Sufficient Truth + Addressing) has no gap
+because the pragmatic mechanism (Sufficient Trivalent + Addressing) has no gap
 to exploit.
 
 ## §4.4 caveat — homogeneity is NOT a presupposition
@@ -97,7 +97,6 @@ Adding "all" blocks non-maximal use entirely.
 
 namespace Kriz2016
 
-open Trivalent (Truth3)
 open Semantics.Plurality
 open Semantics.Plurality.Distributivity
 open Semantics.Plurality.Trivalent
@@ -146,7 +145,7 @@ theorem all_not_homogeneous (P : Atom → W → Prop) [∀ a w, Decidable (P a w
 omit [DecidableEq Atom] in
 /-- A bare plural is homogeneous whenever a gap-world exists: the existence
 of a world where some-but-not-all atoms satisfy P makes the sentence
-homogeneous, enabling non-maximal readings via Sufficient Truth. -/
+homogeneous, enabling non-maximal readings via Sufficient Trivalent. -/
 theorem bare_plural_homogeneous (P : Atom → W → Prop) [∀ a w, Decidable (P a w)] (x : Finset Atom)
     (w : W) (hGap : barePluralTV P x w = .indet) :
     isHomogeneous (barePluralTV P x) := by
@@ -190,11 +189,11 @@ theorem removeGap_plural_true_iff (P : Atom → W → Prop) [∀ a w, Decidable 
     removeGap (fun w => pluralTruthValue P x w) w = .true ↔
     allSatisfy P x w := by
   rw [← pluralTruthValue_eq_true_iff]
-  show Truth3.metaAssert (pluralTruthValue P x w) = .true ↔
+  show Trivalent.metaAssert (pluralTruthValue P x w) = .true ↔
        pluralTruthValue P x w = .true
   generalize pluralTruthValue P x w = t
   cases t <;>
-    simp only [Truth3.metaAssert_true, Truth3.metaAssert_false, Truth3.metaAssert_indet,
+    simp only [Trivalent.metaAssert_true, Trivalent.metaAssert_false, Trivalent.metaAssert_indet,
       iff_self, reduceCtorEq]
 
 /-- `bivalentPred` of an `all`-sentence is true iff `allSatisfy` holds.
@@ -407,7 +406,7 @@ def coarseQ : QUD ProfWorld := QUD.ofDecEq receptionGrade
 Each world is its own cell. -/
 def fineQ : QUD ProfWorld := QUD.ofDecEq id
 
--- Truth values at each world
+-- Trivalent values at each world
 
 theorem bare_allSmiled :
     barePluralTV smiled profs .allSmiled = .true := by decide
@@ -635,7 +634,7 @@ omit [DecidableEq Atom] in
 theorem homogeneity_gap_is_indefiniteness (P : Atom → W → Prop) [∀ a w, Decidable (P a w)]
     (x : Finset Atom) (hne : x.Nonempty) (w : W)
     (hgap : barePluralTV P x w = .indet) :
-    superTrue (fun a => P a w) ⟨x, hne⟩ = Truth3.indet := by
+    superTrue (fun a => P a w) ⟨x, hne⟩ = Trivalent.indet := by
   rw [← barePluralTV_eq_superTrue P x hne w]; exact hgap
 
 omit [DecidableEq Atom] in
@@ -821,11 +820,11 @@ candidate spec-point instantiation.
 However, `Cohen1999` uses the word "homogeneity"
 for a *different* equation: presupposition failure when conditional probabilities
 diverge across partitions of the domain. Cohen's homogeneity returns
-"undefined" via *presupposition failure*; Križ's returns `Truth3.indet` via
+"undefined" via *presupposition failure*; Križ's returns `Trivalent.indet` via
 *supervaluation gap on subkinds*.
 
 A formal `kriz_vs_cohen_generic_homogeneity` divergence theorem would require
-lifting Cohen's presupposition-style machinery into the `Truth3` framework —
+lifting Cohen's presupposition-style machinery into the `Trivalent` framework —
 not done here. The substrate docstring's claim that "the framework extends to
 generics" should be read with this caveat: it extends to a Križ-style
 treatment of generics, which is NOT what `Cohen1999` formalizes. -/

--- a/Linglib/Studies/KrizSpector2021.lean
+++ b/Linglib/Studies/KrizSpector2021.lean
@@ -36,7 +36,7 @@ showing they agree on the bivalent fragment.
 
 namespace KrizSpector2021
 
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 open Semantics.Plurality
 open Semantics.Plurality.Distributivity
 open Semantics.Plurality.Trivalent

--- a/Linglib/Studies/KrizSpector2021.lean
+++ b/Linglib/Studies/KrizSpector2021.lean
@@ -36,7 +36,6 @@ showing they agree on the bivalent fragment.
 
 namespace KrizSpector2021
 
-open Trivalent (Truth3)
 open Semantics.Plurality
 open Semantics.Plurality.Distributivity
 open Semantics.Plurality.Trivalent

--- a/Linglib/Studies/LassiterGoodman2017PMF.lean
+++ b/Linglib/Studies/LassiterGoodman2017PMF.lean
@@ -99,7 +99,7 @@ L&G's probabilistic resolution of the sorites and characterisation of
 borderline cases are *one* of several formalised positions in linglib:
 
 * `Studies/Fine1975.lean` — supervaluation,
-  borderline mapped to `Truth3.indet`, sorites resolved by super-falsity
+  borderline mapped to `Trivalent.indet`, sorites resolved by super-falsity
   of the inductive premise.
 * `Linglib/Semantics/Supervaluation/TCS.lean` —
   Cobreros-Égré-Ripley-van-Rooij Tolerant/Strict/Classical, sorites
@@ -189,7 +189,7 @@ is intermediate exactly when the threshold posterior straddles the
 height being judged.
 
 **Cross-framework note**: this characterisation is contested.
-Supervaluation (`Fine1975.lean`) maps borderline to `Truth3.indet`;
+Supervaluation (`Fine1975.lean`) maps borderline to `Trivalent.indet`;
 epistemicism denies the very framing (borderline cases have determinate
 Boolean truth values we don't know); TCS predicts borderline
 contradictions are tolerantly *true*, with empirical support from

--- a/Linglib/Studies/RamotowskaEtAl2025.lean
+++ b/Linglib/Studies/RamotowskaEtAl2025.lean
@@ -382,12 +382,11 @@ def experiment2PluralDefiniteResults : List PluralDefiniteDatum :=
 open Semantics.Conditionals.Counterfactual
   (embeddedSelectional noSelectional notEverySelectional QStrength
    all_four_quantifiers_mixed)
-open Trivalent (Truth3)
 
 /-- Bridge: map study quantifiers to formal selectional predictions.
     Each quantifier maps to the corresponding projection operation
     from the theory layer (`Counterfactual.lean`). -/
-def Quantifier.selectionalResult (q : Quantifier) (results : List Truth3) : Truth3 :=
+def Quantifier.selectionalResult (q : Quantifier) (results : List Trivalent) : Trivalent :=
   match q with
   | .every    => embeddedSelectional .strong results
   | .some     => embeddedSelectional .weak results
@@ -403,7 +402,7 @@ study file's simple strength-based classification. The classification is
 not stipulated — it is derived from the formal theory by construction. -/
 theorem selectional_prediction_grounded (q : Quantifier) (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    (q.selectionalResult (bs.map Truth3.ofBool) == .true) = selectionalPredictedHigh q := by
+    (q.selectionalResult (bs.map Trivalent.ofBool) == .true) = selectionalPredictedHigh q := by
   obtain ⟨h1, h2, h3, h4⟩ := all_four_quantifiers_mixed bs h_some_true h_some_false
   cases q <;>
     simp only [Quantifier.selectionalResult, selectionalPredictedHigh,
@@ -443,7 +442,7 @@ applied to two different inputs:
     must resort to QUD × polarity to distinguish conditions. -/
 theorem homogeneity_erases_strength (n : Nat) (hn : n > 0) :
     ∀ proj : ProjectionType,
-    embeddedSelectional proj (List.replicate n Truth3.indet) = .indet := by
+    embeddedSelectional proj (List.replicate n Trivalent.indet) = .indet := by
   intro proj
   unfold embeddedSelectional
   rw [projectTruthValues_eq_aggregate]
@@ -457,8 +456,8 @@ theorem homogeneity_erases_strength (n : Nat) (hn : n > 0) :
     theorem to `Duality.aggregate_map_ofBool_mixed`. -/
 theorem selectional_strength_effect (bs : List Bool)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·)) :
-    embeddedSelectional .weak (bs.map Truth3.ofBool) = .true ∧
-    embeddedSelectional .strong (bs.map Truth3.ofBool) = .false := by
+    embeddedSelectional .weak (bs.map Trivalent.ofBool) = .true ∧
+    embeddedSelectional .strong (bs.map Trivalent.ofBool) = .false := by
   unfold embeddedSelectional QStrength.toProjection
   constructor <;> rw [projectTruthValues_eq_aggregate]
   · exact (aggregate_map_ofBool_mixed bs h_some_true h_some_false).1
@@ -471,7 +470,7 @@ theorem selectional_strength_effect (bs : List Bool)
     judgments (no "undefined"), matching the experimental pattern of
     extreme slider values (< 4 or > 82). -/
 theorem selectional_always_determinate (proj : ProjectionType) (bs : List Bool) :
-    embeddedSelectional proj (bs.map Truth3.ofBool) ≠ .indet := by
+    embeddedSelectional proj (bs.map Trivalent.ofBool) ≠ .indet := by
   unfold embeddedSelectional
   rw [projectTruthValues_eq_aggregate]
   exact aggregate_map_ofBool_ne_indet proj bs
@@ -517,13 +516,13 @@ gets a foothold.
     returns `.indet`. Strength, polarity, and QUD are all invisible at
     the semantic level — the quantifier cannot see past the gap. -/
 theorem pd_all_quantifiers_gap (n : Nat) (hn : n > 0) (d : ProjectionType) :
-    aggregate d (List.replicate n Truth3.indet) = .indet :=
+    aggregate d (List.replicate n Trivalent.indet) = .indet :=
   aggregate_replicate_indet d n hn
 
 /-- **Counterfactuals are GLOBAL**: in mixed scenarios, every quantifier
     returns a determinate value. There is no gap for pragmatics to exploit. -/
 theorem cf_all_quantifiers_determinate (d : ProjectionType) (bs : List Bool) :
-    aggregate d (bs.map Truth3.ofBool) ≠ .indet :=
+    aggregate d (bs.map Trivalent.ofBool) ≠ .indet :=
   aggregate_map_ofBool_ne_indet d bs
 
 /-- **The dissociation**: for the same mixed input (n individuals, some
@@ -541,9 +540,9 @@ theorem scope_determines_qud_sensitivity (n : Nat) (hn : n > 0)
     (h_some_true : bs.any id) (h_some_false : bs.any (!·))
     (d : ProjectionType) :
     -- PDs: gap (pragmatic resolution needed, QUD-sensitive)
-    aggregate d (List.replicate n Truth3.indet) = .indet ∧
+    aggregate d (List.replicate n Trivalent.indet) = .indet ∧
     -- CFs: determinate (no pragmatic resolution, QUD-insensitive)
-    aggregate d (bs.map Truth3.ofBool) ≠ .indet :=
+    aggregate d (bs.map Trivalent.ofBool) ≠ .indet :=
   ⟨aggregate_replicate_indet d n hn, aggregate_map_ofBool_ne_indet d bs⟩
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/RamotowskaEtAl2025.lean
+++ b/Linglib/Studies/RamotowskaEtAl2025.lean
@@ -382,7 +382,7 @@ def experiment2PluralDefiniteResults : List PluralDefiniteDatum :=
 open Semantics.Conditionals.Counterfactual
   (embeddedSelectional noSelectional notEverySelectional QStrength
    all_four_quantifiers_mixed)
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 /-- Bridge: map study quantifiers to formal selectional predictions.
     Each quantifier maps to the corresponding projection operation
@@ -414,7 +414,7 @@ theorem selectional_prediction_grounded (q : Quantifier) (bs : List Bool)
 -- Architectural Explanation: Local vs Global Trivalence
 -- ════════════════════════════════════════════════════════════════
 
-open Core.Duality (aggregate ProjectionType
+open Trivalent (aggregate ProjectionType
   aggregate_replicate_indet aggregate_map_ofBool_mixed aggregate_map_ofBool_ne_indet)
 open Semantics.Conditionals.Counterfactual (projectTruthValues_eq_aggregate)
 
@@ -423,7 +423,7 @@ open Semantics.Conditionals.Counterfactual (projectTruthValues_eq_aggregate)
 
 The paper's deepest insight (§2.2): whether gaps arise LOCALLY (before
 the quantifier) or GLOBALLY (after the quantifier) determines whether
-quantifier strength matters. The algebra is `Core.Duality.aggregate`
+quantifier strength matters. The algebra is `Trivalent.aggregate`
 applied to two different inputs:
 
 - **Homogeneity** uses local scope: each individual's counterfactual
@@ -533,7 +533,7 @@ theorem cf_all_quantifiers_determinate (d : ProjectionType) (bs : List Bool) :
     on the QUD partition. CFs have no gap to resolve.
 
     This is a direct corollary of the local/global aggregation
-    decomposition in `Core.Duality`: local scope produces gaps that pass
+    decomposition in `Trivalent`: local scope produces gaps that pass
     through quantifiers; global scope produces Bools that quantifiers
     can distinguish. -/
 theorem scope_determines_qud_sensitivity (n : Nat) (hn : n > 0)
@@ -553,7 +553,7 @@ theorem scope_determines_qud_sensitivity (n : Nat) (hn : n > 0)
 /-!
 ## Related Phenomena
 
-1. **Local vs Global Aggregation** (`Core.Duality.aggregate_*`):
+1. **Local vs Global Aggregation** (`Trivalent.aggregate_*`):
    The paper's deepest architectural insight is formalized as two
    facts about `aggregate`. `homogeneity_erases_strength` derives that
    local gaps make strength invisible; `selectional_strength_effect`

--- a/Linglib/Studies/Santorio2018.lean
+++ b/Linglib/Studies/Santorio2018.lean
@@ -49,7 +49,7 @@ predicate.
    declines the trivalent collapse: "To switch to a Križ-style
    framework, we would need to divorce homogeneity from the
    distributivity operator and move to a trivalent semantics." We
-   render DIST_π via `Core.Duality.Truth3` / `distList` because it is
+   render DIST_π via `Trivalent.Truth3` / `distList` because it is
    ergonomic and faithful on the all/none/mixed verdicts; the
    divergence is in how the homogeneity failure is *typed* (gap vs.
    presupposition failure).
@@ -126,7 +126,7 @@ follow-up.
 
 namespace Santorio2018
 
-open Core.Duality (Truth3 distList)
+open Trivalent (Truth3 distList)
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
@@ -233,7 +233,7 @@ def disjunctiveCounterfactual (sim : SimilarityOrdering W)
 theorem sda_iff_homogeneity_true (sim : SimilarityOrdering W)
     (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C] (w : W) :
     sdaEval sim alts C w ↔ homogeneityEval sim alts C w = .true := by
-  unfold sdaEval homogeneityEval Core.Duality.distList
+  unfold sdaEval homogeneityEval Trivalent.distList
   generalize altConditionalResults sim alts C w = rs
   refine ⟨fun h => ?_, fun h => ?_⟩
   · have hall : ∀ b ∈ rs, b = true := by

--- a/Linglib/Studies/Santorio2018.lean
+++ b/Linglib/Studies/Santorio2018.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.List.Sublists
 import Linglib.Semantics.Conditionals.Counterfactual
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Duality
 import Linglib.Semantics.Truthmaker.Inexact
 import Linglib.Semantics.Truthmaker.Basic
@@ -49,7 +49,7 @@ predicate.
    declines the trivalent collapse: "To switch to a Križ-style
    framework, we would need to divorce homogeneity from the
    distributivity operator and move to a trivalent semantics." We
-   render DIST_π via `Trivalent.Truth3` / `distList` because it is
+   render DIST_π via `Trivalent.Trivalent` / `distList` because it is
    ergonomic and faithful on the all/none/mixed verdicts; the
    divergence is in how the homogeneity failure is *typed* (gap vs.
    presupposition failure).
@@ -126,7 +126,7 @@ follow-up.
 
 namespace Santorio2018
 
-open Trivalent (Truth3 distList)
+open Trivalent (distList)
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
@@ -176,7 +176,7 @@ def altConditionalResults (sim : SimilarityOrdering W)
     over per-alternative conditional results (faithfulness note 1). -/
 def homogeneityEval (sim : SimilarityOrdering W)
     (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C]
-    (w : W) : Truth3 :=
+    (w : W) : Trivalent :=
   distList (altConditionalResults sim alts C w) (· = true)
 
 /-- **SDA reading** (Simplification of Disjunctive Antecedents):
@@ -483,7 +483,7 @@ private def spainAlts : List (DecAlt McKayVanInwagen1977.SpainWorld) :=
 
 /-- [santorio-2018]'s homogeneity verdict on the
     [mckay-vaninwagen-1977] Spain scenario: `.indet` (mixed
-    results across the two alternatives), demonstrating the `Truth3`
+    results across the two alternatives), demonstrating the `Trivalent`
     middle column. -/
 theorem spain_homogeneity_gap :
     homogeneityEval McKayVanInwagen1977.spainSim

--- a/Linglib/Studies/Spector2025.lean
+++ b/Linglib/Studies/Spector2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Core.Logic.Assignment
 
 /-!
@@ -53,7 +53,7 @@ undefined if classically true but `g(x)` is not a witness.
 namespace Spector2025
 
 open Core
-open Trivalent
+open Trivalent (ofBool isDefined meetMiddle joinMiddle)
 
 universe u
 
@@ -72,20 +72,20 @@ abbrev Interp (W : Type*) (D : Type u) := W → D → Bool
     - `0` if `g(x) ≠ #` and `g(x) ∉ I(P,w)`
     - `#` if `g(x) = #` -/
 def evalPred (I : Interp W D) (g : PartialAssign D) (x : Nat)
-    (w : W) : Truth3 :=
+    (w : W) : Trivalent :=
   match g x with
-  | some d => Truth3.ofBool (I w d)
+  | some d => Trivalent.ofBool (I w d)
   | none => .indet
 
-/-- The `U(x)` predicate as a Truth3 value.
+/-- The `U(x)` predicate as a Trivalent value.
     Always bivalent: `true` if valued, `false` if not. -/
-def valuedT3 (g : PartialAssign D) (x : Nat) : Truth3 :=
-  Truth3.ofBool (g.valued x)
+def valuedT3 (g : PartialAssign D) (x : Nat) : Trivalent :=
+  Trivalent.ofBool (g.valued x)
 
 /-- `U(x)` is never undefined. -/
 theorem valuedT3_defined (g : PartialAssign D) (x : Nat) :
     (valuedT3 g x).isDefined := by
-  simp [valuedT3, PartialAssign.valued, Truth3.isDefined]
+  simp [valuedT3, PartialAssign.valued, Trivalent.isDefined]
   cases g x <;> trivial
 
 /-- When `g` values `x`, evaluating a predicate at `x` is bivalent. -/
@@ -95,7 +95,7 @@ theorem evalPred_valued (I : Interp W D) (g : PartialAssign D) (x : Nat) (w : W)
   simp [evalPred, PartialAssign.valued] at *
   cases hg : g x with
   | none => simp [hg] at h
-  | some d => simp [Truth3.ofBool, Truth3.isDefined]; cases I w d <;> trivial
+  | some d => simp [Trivalent.ofBool, Trivalent.isDefined]; cases I w d <;> trivial
 
 /-- When `g` does not value `x`, evaluating a predicate at `x` is undefined. -/
 theorem evalPred_unvalued (I : Interp W D) (g : PartialAssign D) (x : Nat) (w : W)
@@ -107,7 +107,7 @@ theorem evalPred_unvalued (I : Interp W D) (g : PartialAssign D) (x : Nat) (w : 
   | some _ => simp [hg] at h
 
 -- ════════════════════════════════════════════════════════════════
--- Truth at a World
+-- Trivalent at a World
 -- §2.1, definition (6)
 -- ════════════════════════════════════════════════════════════════
 
@@ -118,7 +118,7 @@ theorem evalPred_unvalued (I : Interp W D) (g : PartialAssign D) (x : Nat) (w : 
     if and only if there is an assignment function g such that
     ⟦φ⟧^{w,g} = 1." This bridges trivalent assignment-level
     semantics to world-level truth conditions. -/
-def trueAtWorld (φ : W → PartialAssign D → Truth3) (w : W) : Prop :=
+def trueAtWorld (φ : W → PartialAssign D → Trivalent) (w : W) : Prop :=
   ∃ g : PartialAssign D, φ w g = .true
 
 -- ════════════════════════════════════════════════════════════════
@@ -152,16 +152,16 @@ def nullCtx : Ctx W D := λ _ _ => True
     §2.2.1: "if a sentence S is accepted as true in context C, then the
     resulting context is simply C intersected with the set of
     world-assignment pairs where S is true." -/
-def stalnakerUpdate (C : Ctx W D) (S : W → PartialAssign D → Truth3) :
+def stalnakerUpdate (C : Ctx W D) (S : W → PartialAssign D → Trivalent) :
     Ctx W D :=
   λ w g => C w g ∧ S w g = .true
 
 /-- Two trivalent sentences agree throughout a context. -/
-def agreeIn (C : Ctx W D) (S1 S2 : W → PartialAssign D → Truth3) : Prop :=
+def agreeIn (C : Ctx W D) (S1 S2 : W → PartialAssign D → Trivalent) : Prop :=
   ∀ w g, C w g → S1 w g = S2 w g
 
 /-- A trivalent sentence over world-assignment pairs. -/
-abbrev Sent (W : Type*) (D : Type u) := W → PartialAssign D → Truth3
+abbrev Sent (W : Type*) (D : Type u) := W → PartialAssign D → Trivalent
 
 /-- A sentence frame: a sentence with a hole for a sub-sentence. -/
 abbrev Frame (W : Type*) (D : Type u) := Sent W D → Sent W D
@@ -183,7 +183,7 @@ abbrev Frame (W : Type*) (D : Type u) := Sent W D → Sent W D
 def transparent (C : Ctx W D) (frame : Frame W D)
     (presup : Sent W D) : Prop :=
   ∀ φ : Sent W D,
-    agreeIn C (frame (λ w g => Truth3.meetMiddle (presup w g) (φ w g)))
+    agreeIn C (frame (λ w g => Trivalent.meetMiddle (presup w g) (φ w g)))
               (frame φ)
 
 /-- Transparency holds trivially when the presupposition is always true
@@ -196,7 +196,7 @@ theorem transparent_of_presup_true (C : Ctx W D) (frame : Frame W D)
     transparent C frame presup := by
   intro φ w g hC
   exact hframe _ _
-    (λ w' g' hC' => by simp [Truth3.meetMiddle_true_left, hpresup w' g' hC']) w g hC
+    (λ w' g' hC' => by simp [Trivalent.meetMiddle_true_left, hpresup w' g' hC']) w g hC
 
 /-- The Novelty Condition: an existential quantifier introducing
     variable x can only occur once in a discourse.
@@ -220,7 +220,7 @@ def noveltyCondition (usedVars : List Nat) (newVar : Nat) : Prop :=
 §6.3 observes that the Transparency proofs are
 parametric in the assignment type — the same Middle Kleene reasoning
 works for individual assignments `g` and plural assignments `G`.
-We factor this out: the proofs below are stated over abstract Truth3
+We factor this out: the proofs below are stated over abstract Trivalent
 values, independent of assignment representation.
 -/
 
@@ -232,23 +232,23 @@ values, independent of assignment representation.
     - `E = false`: `meetMiddle false _ = false` (left zero)
     - `E = #`: `meetMiddle # _ = #` (left absorbs)
     - `E = true`: witness gives `presup = true`, so `meetMiddle true φ = φ` -/
-theorem conj_transparency_parametric : ∀ (E presup φ : Truth3),
+theorem conj_transparency_parametric : ∀ (E presup φ : Trivalent),
     (E = .true → presup = .true) →
-    Truth3.meetMiddle E (Truth3.meetMiddle presup φ) =
-    Truth3.meetMiddle E φ
-  | .true, _, φ, hw => by rw [hw rfl, Truth3.meetMiddle_true_left, Truth3.meetMiddle_true_left]
-  | .false, _, _, _ => by simp [Truth3.meetMiddle]
+    Trivalent.meetMiddle E (Trivalent.meetMiddle presup φ) =
+    Trivalent.meetMiddle E φ
+  | .true, _, φ, hw => by rw [hw rfl, Trivalent.meetMiddle_true_left, Trivalent.meetMiddle_true_left]
+  | .false, _, _, _ => by simp [Trivalent.meetMiddle]
   | .indet, _, _, _ => rfl
 
 /-- Parametric bathroom Transparency: `joinMiddle negE (meetMiddle presup φ) =
     joinMiddle negE φ` whenever `negE = false → presup = true`. -/
-theorem disj_transparency_parametric : ∀ (negE presup φ : Truth3),
+theorem disj_transparency_parametric : ∀ (negE presup φ : Trivalent),
     (negE = .false → presup = .true) →
-    Truth3.joinMiddle negE (Truth3.meetMiddle presup φ) =
-    Truth3.joinMiddle negE φ
-  | .true, _, _, _ => by simp [Truth3.joinMiddle]
+    Trivalent.joinMiddle negE (Trivalent.meetMiddle presup φ) =
+    Trivalent.joinMiddle negE φ
+  | .true, _, _, _ => by simp [Trivalent.joinMiddle]
   | .indet, _, _, _ => rfl
-  | .false, _, φ, hw => by rw [hw rfl, Truth3.meetMiddle_true_left]
+  | .false, _, φ, hw => by rw [hw rfl, Trivalent.meetMiddle_true_left]
 
 -- ════════════════════════════════════════════════════════════════
 -- §3.2: Anaphora in Conjunctive Sentences
@@ -284,12 +284,12 @@ The frame is `F(ψ) = ∃xT(x) ∧ ψ`, and the presupposition is `U(x)`.
 
     Derived from `conj_transparency_parametric`. -/
 theorem forward_conj_transparency
-    (E presup : W → PartialAssign D → Truth3)
+    (E presup : W → PartialAssign D → Trivalent)
     (hwitness : ∀ w g, E w g = .true → presup w g = .true)
     (C : Ctx W D) :
     ∀ (φ : Sent W D) (w : W) (g : PartialAssign D), C w g →
-      Truth3.meetMiddle (E w g) (Truth3.meetMiddle (presup w g) (φ w g)) =
-      Truth3.meetMiddle (E w g) (φ w g) :=
+      Trivalent.meetMiddle (E w g) (Trivalent.meetMiddle (presup w g) (φ w g)) =
+      Trivalent.meetMiddle (E w g) (φ w g) :=
   fun φ w g _ => conj_transparency_parametric (E w g) (presup w g) (φ w g) (hwitness w g)
 
 /-- Reverse conjunction Transparency FAILS: `P(x̲) ∧ ∃xT(x)` does NOT
@@ -301,16 +301,16 @@ theorem forward_conj_transparency
     and `meetMiddle false # = false`). The key asymmetry of Middle Kleene:
     `meetMiddle false # = false` but `meetMiddle # _ = #`. -/
 theorem reverse_conj_transparency_fails :
-    ∃ (W : Type) (D : Type) (E presup φ : W → PartialAssign D → Truth3)
+    ∃ (W : Type) (D : Type) (E presup φ : W → PartialAssign D → Trivalent)
       (w : W) (g : PartialAssign D),
-      Truth3.meetMiddle (Truth3.meetMiddle (presup w g) (φ w g)) (E w g) ≠
-      Truth3.meetMiddle (φ w g) (E w g) := by
+      Trivalent.meetMiddle (Trivalent.meetMiddle (presup w g) (φ w g)) (E w g) ≠
+      Trivalent.meetMiddle (φ w g) (E w g) := by
   -- presup = U(x) = false (unvalued), φ = P(x) = # (unvalued), E = ∃xT(x) = true
   -- LHS: meetMiddle (meetMiddle false #) true = meetMiddle false true = false
   -- RHS: meetMiddle # true = #
   refine ⟨Unit, Unit, λ _ _ => .true, λ _ _ => .false, λ _ _ => .indet,
           (), λ _ => none, ?_⟩
-  simp [Truth3.meetMiddle]
+  simp [Trivalent.meetMiddle]
 
 end Conjunction
 
@@ -346,12 +346,12 @@ is `U(x)`.
     witness condition) means `g` values `x`, making `U(x)` redundant.
     Derived from `disj_transparency_parametric`. -/
 theorem bathroom_transparency
-    (negE presup : W → PartialAssign D → Truth3)
+    (negE presup : W → PartialAssign D → Trivalent)
     (hwitness : ∀ w g, negE w g = .false → presup w g = .true)
     (C : Ctx W D) :
     ∀ (φ : Sent W D) (w : W) (g : PartialAssign D), C w g →
-      Truth3.joinMiddle (negE w g) (Truth3.meetMiddle (presup w g) (φ w g)) =
-      Truth3.joinMiddle (negE w g) (φ w g) :=
+      Trivalent.joinMiddle (negE w g) (Trivalent.meetMiddle (presup w g) (φ w g)) =
+      Trivalent.joinMiddle (negE w g) (φ w g) :=
   fun φ w g _ => disj_transparency_parametric (negE w g) (presup w g) (φ w g) (hwitness w g)
 
 /-- Reverse bathroom Transparency FAILS: `H(x̲) ∨ ¬∃xB(x)` does NOT
@@ -363,21 +363,21 @@ theorem bathroom_transparency
     `U(x) = false`, so `meetMiddle false # = false`, and
     `joinMiddle false (¬∃xB(x))` can be `true` — a difference. -/
 theorem reverse_bathroom_transparency_fails :
-    ∃ (W : Type) (D : Type) (negE presup φ : W → PartialAssign D → Truth3)
+    ∃ (W : Type) (D : Type) (negE presup φ : W → PartialAssign D → Trivalent)
       (w : W) (g : PartialAssign D),
-      Truth3.joinMiddle (Truth3.meetMiddle (presup w g) (φ w g)) (negE w g) ≠
-      Truth3.joinMiddle (φ w g) (negE w g) := by
+      Trivalent.joinMiddle (Trivalent.meetMiddle (presup w g) (φ w g)) (negE w g) ≠
+      Trivalent.joinMiddle (φ w g) (negE w g) := by
   -- presup = false (U(x) unvalued), φ = # (P(x) unvalued), negE = true
   -- LHS: joinMiddle (meetMiddle false #) true = joinMiddle false true = true
   -- RHS: joinMiddle # true = #
   refine ⟨Unit, Unit, λ _ _ => .true, λ _ _ => .false, λ _ _ => .indet,
           (), λ _ => none, ?_⟩
-  simp [Truth3.joinMiddle, Truth3.meetMiddle]
+  simp [Trivalent.joinMiddle, Trivalent.meetMiddle]
 
 end Bathroom
 
 -- ════════════════════════════════════════════════════════════════
--- §2.1: Semantic Adequacy — Bathroom Truth Conditions
+-- §2.1: Semantic Adequacy — Bathroom Trivalent Conditions
 -- ════════════════════════════════════════════════════════════════
 
 section BathroomTruthConditions
@@ -424,14 +424,14 @@ variable {D : Type} {W : Type}
     - `F(x)`: `evalPred F g 0 w` (true/false/`#` depending on `g(0)`)
     - Overall: `joinMiddle (neg (∃xB(x))) (F(x))` -/
 def bathroomSent (B F : Interp W D) (dom : List D)
-    (w : W) (g : PartialAssign D) : Truth3 :=
-  let existsB : Truth3 :=
+    (w : W) (g : PartialAssign D) : Trivalent :=
+  let existsB : Trivalent :=
     if evalPred B g 0 w = .true then .true
     else if dom.all (λ d => B w d == false) then .false
     else .indet
-  let negExistsB := Truth3.neg existsB
+  let negExistsB := Trivalent.neg existsB
   let fx := evalPred F g 0 w
-  Truth3.joinMiddle negExistsB fx
+  Trivalent.joinMiddle negExistsB fx
 
 /-- Classical truth of `¬∃xB(x) ∨ ∃x(B(x) ∧ F(x))`: either no element
     satisfies `B`, or some element satisfies both `B` and `F`. -/
@@ -460,14 +460,14 @@ theorem bathroom_classical_to_trivalent (B F : Interp W D) (dom : List D) (w : W
     have hne : ¬(evalPred B PartialAssign.empty 0 w = .true) := by
       simp only [evalPred, PartialAssign.empty]; decide
     rw [if_neg hne, if_pos hnoB]
-    simp [Truth3.neg, Truth3.joinMiddle]
+    simp [Trivalent.neg, Trivalent.joinMiddle]
   · -- Case 2: witness d with B(d) and F(d). Set g(0) = some d.
     refine ⟨λ _ => some d, ?_⟩
     simp only [bathroomSent]
     have heval : evalPred B (λ _ => some d) 0 w = .true := by
-      simp only [evalPred, Truth3.ofBool, hBd]
+      simp only [evalPred, Trivalent.ofBool, hBd]
     rw [if_pos heval]
-    simp [evalPred, Truth3.ofBool, hFd, Truth3.neg, Truth3.joinMiddle]
+    simp [evalPred, Trivalent.ofBool, hFd, Trivalent.neg, Trivalent.joinMiddle]
 
 /-- **Direction 2**: If the trivalent bathroom sentence is true at `w`,
     then the classical disjunction holds.
@@ -502,7 +502,7 @@ theorem bathroom_trivalent_to_classical (B F : Interp W D) (dom : List D) (w : W
       rw [if_neg hne2] at hg
       -- hg : joinMiddle (neg .indet) _ = .true, i.e. joinMiddle .indet _ = .true
       -- but joinMiddle .indet _ = .indet, contradiction
-      simp only [Truth3.neg, Truth3.joinMiddle] at hg
+      simp only [Trivalent.neg, Trivalent.joinMiddle] at hg
       exact absurd hg (by decide)
     · -- existsB = .false, negExistsB = .true → classical left disjunct
       exact Or.inl hall
@@ -511,24 +511,24 @@ theorem bathroom_trivalent_to_classical (B F : Interp W D) (dom : List D) (w : W
     | false =>
       -- evalPred B g 0 w = .false ≠ .true
       have hne : ¬(evalPred B g 0 w = .true) := by
-        simp only [evalPred, hg0, Truth3.ofBool, hBd]; decide
+        simp only [evalPred, hg0, Trivalent.ofBool, hBd]; decide
       rw [if_neg hne] at hg
       cases hall : List.all dom (fun d => B w d == false)
       · have hne2 : ¬((List.all dom fun d => B w d == false) = true) := by
           rw [hall]; decide
         rw [if_neg hne2] at hg
-        simp only [Truth3.neg, Truth3.joinMiddle] at hg
+        simp only [Trivalent.neg, Trivalent.joinMiddle] at hg
         exact absurd hg (by decide)
       · exact Or.inl hall
     | true =>
       -- evalPred B g 0 w = .true: g(0) witnesses B
       have heval : evalPred B g 0 w = .true := by
-        simp only [evalPred, hg0, Truth3.ofBool, hBd]
+        simp only [evalPred, hg0, Trivalent.ofBool, hBd]
       rw [if_pos heval] at hg
       -- existsB = .true, negExistsB = .false, joinMiddle .false fx = fx
-      simp only [Truth3.neg, Truth3.joinMiddle] at hg
+      simp only [Trivalent.neg, Trivalent.joinMiddle] at hg
       -- hg says evalPred F g 0 w = .true
-      simp only [evalPred, hg0, Truth3.ofBool] at hg
+      simp only [evalPred, hg0, Trivalent.ofBool] at hg
       cases hFd : F w d
       · simp only [hFd] at hg; exact absurd hg (by decide)
       · exact Or.inr ⟨d, hdom d, hBd, hFd⟩
@@ -563,13 +563,13 @@ end BathroomTruthConditions
 
     The identity frame `F(ψ) = ψ` represents a bare sentence. -/
 theorem bare_pronoun_fails_null :
-    ∃ (W : Type) (D : Type) (presup φ : W → PartialAssign D → Truth3)
+    ∃ (W : Type) (D : Type) (presup φ : W → PartialAssign D → Trivalent)
       (w : W) (g : PartialAssign D),
       True  -- null context membership
-      ∧ Truth3.meetMiddle (presup w g) (φ w g) ≠ φ w g := by
+      ∧ Trivalent.meetMiddle (presup w g) (φ w g) ≠ φ w g := by
   refine ⟨Unit, Unit, λ _ _ => .false, λ _ _ => .true,
           (), λ _ => none, trivial, ?_⟩
-  simp [Truth3.meetMiddle]
+  simp [Trivalent.meetMiddle]
 
 /-! ### Empirical coverage from §3
 
@@ -639,7 +639,7 @@ variable {D : Type*} {W : Type*}
 open Classical
 
 /-- Plural sentence: evaluated relative to a world and a plural assignment. -/
-abbrev PSent (W : Type*) (D : Type*) := W → PluralAssign D → Truth3
+abbrev PSent (W : Type*) (D : Type*) := W → PluralAssign D → Trivalent
 
 /-- Alias for `PluralAssign.singularAt` — `G` assigns `x` uniquely to `d`.
     §6.2: `|G(x)| = 1` with `G(x) = d`. -/
@@ -652,16 +652,16 @@ abbrev singularAt (G : PluralAssign D) (x : Nat) (d : D) : Prop :=
     - `0` if `|G(x)| = 1` and `G(x) ∉ I(P,w)`
     - `#` if `|G(x)| ≠ 1` -/
 noncomputable def evalPredPlural (I : Interp W D) (G : PluralAssign D)
-    (x : Nat) (w : W) : Truth3 :=
+    (x : Nat) (w : W) : Trivalent :=
   if h : ∃ d, singularAt G x d then
-    Truth3.ofBool (I w (Classical.choose h))
+    Trivalent.ofBool (I w (Classical.choose h))
   else .indet
 
-/-- The `atomic(x)` predicate as a Truth3 value.
+/-- The `atomic(x)` predicate as a Trivalent value.
     §6.3: `⟦atomic(x)⟧^{w,G} = 1` if `|G(x)| = 1`,
     `0` otherwise. Always bivalent (never `#`). Replaces `U(x)` from
     the simplified system. -/
-noncomputable def atomicT3 (G : PluralAssign D) (x : Nat) : Truth3 :=
+noncomputable def atomicT3 (G : PluralAssign D) (x : Nat) : Trivalent :=
   if G.singular x then .true else .false
 
 /-- `atomic(x)` is always defined (bivalent). -/
@@ -669,8 +669,8 @@ theorem atomicT3_defined (G : PluralAssign D) (x : Nat) :
     (atomicT3 G x).isDefined := by
   unfold atomicT3
   by_cases h : G.singular x
-  · simp [h, Truth3.isDefined]
-  · simp [h, Truth3.isDefined]
+  · simp [h, Trivalent.isDefined]
+  · simp [h, Trivalent.isDefined]
 
 /-- Plural existential quantifier with witness condition.
     §6.2:
@@ -678,7 +678,7 @@ theorem atomicT3_defined (G : PluralAssign D) (x : Nat) :
     - `0` if for every atomic `a ∈ D`, `G_{x=a} ≠ ∅` and `⟦φ⟧^{w,G_{x=a}} = 0`
     - `#` otherwise -/
 noncomputable def existsPlural (x : Nat) (φ : PSent W D) (dom : Set D)
-    (w : W) (G : PluralAssign D) : Truth3 :=
+    (w : W) (G : PluralAssign D) : Trivalent :=
   if φ w G = .true then .true
   else if (∀ a ∈ dom, (G.restrict x a).IsNonempty) ∧
           (∀ a ∈ dom, φ w (G.restrict x a) = .false) then .false
@@ -690,7 +690,7 @@ noncomputable def existsPlural (x : Nat) (φ : PSent W D) (dom : Set D)
     - `0` if the coverage condition holds and some `a` gives `⟦φ⟧^{w,G_{x=a}} = 0`
     - `#` otherwise -/
 noncomputable def forallPlural (x : Nat) (φ : PSent W D) (dom : Set D)
-    (w : W) (G : PluralAssign D) : Truth3 :=
+    (w : W) (G : PluralAssign D) : Trivalent :=
   if (∀ a ∈ dom, (G.restrict x a).IsNonempty) ∧
      (∀ a ∈ dom, φ w (G.restrict x a) = .true) then .true
   else if (∀ a ∈ dom, (G.restrict x a).IsNonempty) ∧
@@ -710,21 +710,21 @@ variable {D : Type*} {W : Type*}
 /-- Forward conjunction Transparency in the plural system, derived from
     the parametric version. -/
 theorem plural_forward_conj_transparency
-    (E presup : W → PluralAssign D → Truth3)
+    (E presup : W → PluralAssign D → Trivalent)
     (hwitness : ∀ w G, E w G = .true → presup w G = .true) :
-    ∀ (φ : W → PluralAssign D → Truth3) (w : W) (G : PluralAssign D),
-      Truth3.meetMiddle (E w G) (Truth3.meetMiddle (presup w G) (φ w G)) =
-      Truth3.meetMiddle (E w G) (φ w G) :=
+    ∀ (φ : W → PluralAssign D → Trivalent) (w : W) (G : PluralAssign D),
+      Trivalent.meetMiddle (E w G) (Trivalent.meetMiddle (presup w G) (φ w G)) =
+      Trivalent.meetMiddle (E w G) (φ w G) :=
   fun φ w G => conj_transparency_parametric (E w G) (presup w G) (φ w G) (hwitness w G)
 
 /-- Bathroom Transparency in the plural system, derived from
     the parametric version. -/
 theorem plural_bathroom_transparency
-    (negE presup : W → PluralAssign D → Truth3)
+    (negE presup : W → PluralAssign D → Trivalent)
     (hwitness : ∀ w G, negE w G = .false → presup w G = .true) :
-    ∀ (φ : W → PluralAssign D → Truth3) (w : W) (G : PluralAssign D),
-      Truth3.joinMiddle (negE w G) (Truth3.meetMiddle (presup w G) (φ w G)) =
-      Truth3.joinMiddle (negE w G) (φ w G) :=
+    ∀ (φ : W → PluralAssign D → Trivalent) (w : W) (G : PluralAssign D),
+      Trivalent.joinMiddle (negE w G) (Trivalent.meetMiddle (presup w G) (φ w G)) =
+      Trivalent.joinMiddle (negE w G) (φ w G) :=
   fun φ w G => disj_transparency_parametric (negE w G) (presup w G) (φ w G) (hwitness w G)
 
 end PluralTransparency
@@ -755,15 +755,15 @@ antecedent of a singular pronoun.
     is false (since `atomic(x)` is false when `|G(x)| > 1`) while
     the second is true. -/
 theorem universal_doesnt_license_anaphora :
-    ∃ (D : Type) (presup φ : PluralAssign D → Truth3)
+    ∃ (D : Type) (presup φ : PluralAssign D → Trivalent)
       (G : PluralAssign D),
       -- presup = atomic(x) = false (two values for x)
       -- φ = tautology = true
-      Truth3.meetMiddle (presup G) (φ G) ≠ φ G := by
+      Trivalent.meetMiddle (presup G) (φ G) ≠ φ G := by
   -- D = Bool, G has two assignments: one mapping x to true, one to false
   -- So |G(x)| = 2, atomic(x) = false
   refine ⟨Bool, λ _ => .false, λ _ => .true, ⟨λ _ => True⟩, ?_⟩
-  simp [Truth3.meetMiddle]
+  simp [Trivalent.meetMiddle]
 
 end UniversalAnaphora
 
@@ -839,7 +839,7 @@ theorem covariation_fails_individual :
 end Covariation
 
 -- ════════════════════════════════════════════════════════════════
--- §7: Weak and Strong Truth
+-- §7: Weak and Strong Trivalent
 -- ════════════════════════════════════════════════════════════════
 
 section WeakStrongTruth
@@ -851,10 +851,10 @@ variable {D : Type*} {W : Type*}
 
 §7: Two modes of interpretation for donkey sentences:
 
-- **Weak Truth**: `S` is weakly true at `w` if ∃G such that `S` is true
+- **Weak Trivalent**: `S` is weakly true at `w` if ∃G such that `S` is true
   at `(w,G)`. Generates *existential* (weak) readings.
 
-- **Strong Truth**: `S` is strongly true at `w` if ∃G true at `(w,G)`
+- **Strong Trivalent**: `S` is strongly true at `w` if ∃G true at `(w,G)`
   AND no `G'` makes `S` false at `(w,G')`. Generates *universal* (strong)
   readings. Similar to [elliott-2023]'s strengthened reading and
   [champollion-bumford-henderson-2019]'s homogeneity approach.
@@ -898,7 +898,7 @@ file.
 end WeakStrongTruth
 
 -- ════════════════════════════════════════════════════════════════
--- §7: The Strong Truth Operator O
+-- §7: The Strong Trivalent Operator O
 -- ════════════════════════════════════════════════════════════════
 
 section StrongTruthOperator
@@ -908,26 +908,26 @@ variable {D : Type*} {W : Type*}
 open Classical
 
 /-!
-### The Strong Truth Operator
+### The Strong Trivalent Operator
 
-§7 (55): The operator `O` internalizes Strong Truth
+§7 (55): The operator `O` internalizes Strong Trivalent
 as an embeddable operator in the object language:
 
     ⟦O(S)⟧^{w,G} = 1 if ⟦S⟧^{w,G} = 1 and ¬∃G'. ⟦S⟧^{w,G'} = 0
     ⟦O(S)⟧^{w,G} = 0 if ⟦S⟧^{w,G} = 0 and ¬∃G'. ⟦S⟧^{w,G'} = 1
     ⟦O(S)⟧^{w,G} = # otherwise
 
-This allows Strong Truth to be applied at specific syntactic positions
+This allows Strong Trivalent to be applied at specific syntactic positions
 rather than globally. Key properties:
 - If S₁ ≡ S₂ (logically equivalent), then O(S₁) ≡ O(S₂)
 - O can *violate* Transparency when embedded, which is desirable:
   `∃xS(x) ∧ O(H(x̲))` is correctly predicted to be infelicitous
 -/
 
-/-- The Strong Truth Operator O.
+/-- The Strong Trivalent Operator O.
     §7 (55). -/
 noncomputable def strongTruthOp (φ : PSent W D)
-    (w : W) (G : PluralAssign D) : Truth3 :=
+    (w : W) (G : PluralAssign D) : Trivalent :=
   if φ w G = .true ∧ ¬∃ G', φ w G' = .false then .true
   else if φ w G = .false ∧ ¬∃ G', φ w G' = .true then .false
   else .indet
@@ -951,7 +951,7 @@ theorem strongTruthOp_true_implies (φ : PSent W D) (w : W)
   · split at h <;> simp_all
 
 /-- Strong truth at w ↔ weak truth of O(S) at w.
-    Embedding O at matrix level recovers the Strong Truth interpretation. -/
+    Embedding O at matrix level recovers the Strong Trivalent interpretation. -/
 theorem strongTruthOp_weakTruth_iff_strongTruth (φ : PSent W D) (w : W) :
     weakTruthP (strongTruthOp φ) w ↔ strongTruthP φ w := by
   constructor
@@ -1017,7 +1017,7 @@ grep-able anchors.
   Spector's Tables 4–5 use 7 individuals; a 4-individual `decide`-checked
   variant would suffice.
 
-- **§7 Strong Truth examples (47), (54).** The operator `O` is defined
+- **§7 Strong Trivalent examples (47), (54).** The operator `O` is defined
   and proved equivalence-preserving (`strongTruthOp_preserves_equiv`,
   `strongTruthOp_weakTruth_iff_strongTruth`); the central motivating
   examples (`Either it's not the case that Sue has a credit card and bought

--- a/Linglib/Studies/Spector2025.lean
+++ b/Linglib/Studies/Spector2025.lean
@@ -53,7 +53,7 @@ undefined if classically true but `g(x)` is not a witness.
 namespace Spector2025
 
 open Core
-open Core.Duality
+open Trivalent
 
 universe u
 

--- a/Linglib/Studies/Stalnaker1981.lean
+++ b/Linglib/Studies/Stalnaker1981.lean
@@ -33,7 +33,6 @@ namespace Stalnaker1981
 
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual
-open Trivalent (Truth3)
 
 -- ════════════════════════════════════════════════════
 -- § 1. The Bizet–Verdi Example: Indeterminacy from Ties

--- a/Linglib/Studies/Stalnaker1981.lean
+++ b/Linglib/Studies/Stalnaker1981.lean
@@ -33,7 +33,7 @@ namespace Stalnaker1981
 
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual
-open Core.Duality (Truth3)
+open Trivalent (Truth3)
 
 -- ════════════════════════════════════════════════════
 -- § 1. The Bizet–Verdi Example: Indeterminacy from Ties

--- a/Linglib/Studies/WangDavidson2026.lean
+++ b/Linglib/Studies/WangDavidson2026.lean
@@ -68,7 +68,7 @@ Type B (EXH¹).
 
 namespace WangDavidson2026
 
-open Core.Duality (Truth3 Prop3)
+open Trivalent (Truth3 Prop3)
 open Semantics.Presupposition (PartialProp)
 open Exhaustification (innocent predToFinset altsFromPreds)
 open Exhaustification.Trivalent

--- a/Linglib/Studies/WangDavidson2026.lean
+++ b/Linglib/Studies/WangDavidson2026.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Exhaustification.InnocentExclusion
 import Linglib.Semantics.Exhaustification.Trivalent
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Presupposition.Basic
 import Mathlib.Tactic.DeriveFintype
 
@@ -35,9 +35,9 @@ These divide into two classes:
   (EXH¹ + any projection)
 
 The core mechanism: under Strong Kleene, inclusive disjunction
-(`⊔` on `Truth3`) can return `.true` even when one disjunct is
+(`⊔` on `Trivalent`) can return `.true` even when one disjunct is
 undefined — so a true first disjunct "filters" the second's
-presupposition failure. Exclusive disjunction (`Truth3.xor`)
+presupposition failure. Exclusive disjunction (`Trivalent.xor`)
 cannot: it returns `.indet` whenever either input is `.indet`.
 
 ### Feed-forward assumption (§5)
@@ -68,7 +68,7 @@ Type B (EXH¹).
 
 namespace WangDavidson2026
 
-open Trivalent (Truth3 Prop3)
+open Trivalent (Prop3)
 open Semantics.Presupposition (PartialProp)
 open Exhaustification (innocent predToFinset altsFromPreds)
 open Exhaustification.Trivalent
@@ -86,17 +86,17 @@ undefined disjunct when the other is true. Exclusive cannot.
 
 This single fact drives the Type A prediction for bivalent EXH + SK:
 since `bivalent_exh_yields_xor` shows Exh strengthens ∨ to ⊻,
-and `Truth3.xor_indet_iff` shows ⊻ propagates undefinedness
+and `Trivalent.xor_indet_iff` shows ⊻ propagates undefinedness
 unconditionally, exhaustification eliminates filtering.
 -/
 
 /-- Inclusive disjunction allows filtering: a true first disjunct
     absorbs the second's presupposition failure. -/
-theorem sk_inclusive_filters : (Truth3.true ⊔ Truth3.indet) = .true := rfl
+theorem sk_inclusive_filters : (Trivalent.true ⊔ Trivalent.indet) = .true := rfl
 
 /-- Exclusive disjunction does not filter: even when one disjunct
     is true, an undefined partner makes the result undefined. -/
-theorem sk_exclusive_no_filter : Truth3.xor .true .indet = .indet := rfl
+theorem sk_exclusive_no_filter : Trivalent.xor .true .indet = .indet := rfl
 
 /-- The filtering contrast is symmetric: both `join` and `xor` are
     commutative, so the direction doesn't matter for SK.
@@ -105,7 +105,7 @@ theorem sk_exclusive_no_filter : Truth3.xor .true .indet = .indet := rfl
     projection" — filtering is equally (un)available in both
     directions. -/
 theorem sk_filtering_symmetric :
-    (Truth3.indet ⊔ Truth3.true) = .true ∧ Truth3.xor .indet .true = .indet :=
+    (Trivalent.indet ⊔ Trivalent.true) = .true ∧ Trivalent.xor .indet .true = .indet :=
   ⟨rfl, rfl⟩
 
 
@@ -120,10 +120,10 @@ theorem sk_filtering_symmetric :
 filters presupposition failure from either disjunct. This mirrors
 the SK XOR truth table (Figure 2 in the paper).
 
-Note: SK *inclusive* filtering (`.true ⊔ .indet = .true` on `Truth3`)
+Note: SK *inclusive* filtering (`.true ⊔ .indet = .true` on `Trivalent`)
 is an emergent property of the SK truth table, not a `PartialProp`
 connective. The contrast is between `⊔` (filters) and
-`Truth3.xor` (does not filter), verified in §1 above.
+`Trivalent.xor` (does not filter), verified in §1 above.
 -/
 
 section PartialPropBridge
@@ -209,8 +209,8 @@ theorem exh2_always_typeA (proj : ProjectionTheory) :
 
 The bridge from bivalent EXH to the SK prediction:
 1. `bivalent_exh_yields_xor`: Exh(Alt)(p∨q) = p ⊕ q
-2. The exclusive truth conditions, when lifted to Truth3 via SK,
-   yield `Truth3.xor` — which propagates `#` unconditionally
+2. The exclusive truth conditions, when lifted to Trivalent via SK,
+   yield `Trivalent.xor` — which propagates `#` unconditionally
 3. Therefore: bivalent EXH + SK → no filtering (Type A prediction)
 
 This chain depends on the **feed-forward assumption** (§5):
@@ -244,9 +244,9 @@ theorem bivalent_exh_yields_xor :
 /-- The classical exclusive disjunction (Bool XOR) agrees with
     Strong Kleene XOR on defined inputs. -/
 theorem bool_xor_lifts_to_sk (a b : Bool) :
-    Truth3.xor (Truth3.ofBool a) (Truth3.ofBool b) =
-    Truth3.ofBool (a ^^ b) :=
-  Truth3.xor_ofBool a b
+    Trivalent.xor (Trivalent.ofBool a) (Trivalent.ofBool b) =
+    Trivalent.ofBool (a ^^ b) :=
+  Trivalent.xor_ofBool a b
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -270,12 +270,12 @@ inductive BathWorld where
   deriving Repr, DecidableEq, Fintype
 
 /-- p: always defined (no presupposition). -/
-def pT3 : BathWorld → Truth3
+def pT3 : BathWorld → Trivalent
   | .pOnly => .true
   | _ => .false
 
 /-- q: presupposes ¬p (defined only when p is false). -/
-def qT3 : BathWorld → Truth3
+def qT3 : BathWorld → Trivalent
   | .pOnly => .indet  -- presupposition failure
   | .qOnly => .true
   | .neither => .false
@@ -289,13 +289,13 @@ theorem inclusive_allows_filtering :
 /-- Exclusive disjunction does NOT allow filtering:
     at `pOnly`, `xor` returns undefined because q's value is unknown. -/
 theorem exclusive_no_filtering :
-    Truth3.xor (pT3 .pOnly) (qT3 .pOnly) = .indet := by rfl
+    Trivalent.xor (pT3 .pOnly) (qT3 .pOnly) = .indet := by rfl
 
 /-- Inclusive disjunction as Prop3 (Strong Kleene). -/
-def inclDisj : BathWorld → Truth3 := fun w => pT3 w ⊔ qT3 w
+def inclDisj : BathWorld → Trivalent := fun w => pT3 w ⊔ qT3 w
 
 /-- Exclusive disjunction as Prop3 (Strong Kleene). -/
-def exclDisj : BathWorld → Truth3 := fun w => Truth3.xor (pT3 w) (qT3 w)
+def exclDisj : BathWorld → Trivalent := fun w => Trivalent.xor (pT3 w) (qT3 w)
 
 /-- Inclusive disjunction is defined at pOnly (filtering). -/
 theorem incl_defined_at_pOnly : inclDisj .pOnly = .true := by rfl
@@ -306,7 +306,7 @@ theorem excl_undef_at_pOnly : exclDisj .pOnly = .indet := by rfl
 /-- Alternative set for the bathroom disjunction: {p∨q, p, q, p∧q}.
     The conjunction alternative `p ∧ q` is the only IE alternative
     (by [fox-2007]). -/
-def bathAlts : List (BathWorld → Truth3) :=
+def bathAlts : List (BathWorld → Trivalent) :=
   [ inclDisj, pT3, qT3
   , fun w => pT3 w ⊓ qT3 w ]
 
@@ -421,14 +421,14 @@ theorem null_result_challenges_typeA :
     truth conditions → SK propagates undefinedness → Type A predicted →
     experiment finds no effect → challenges bivalent EXH + SK.
 
-    This links `bivalent_exh_yields_xor`, `Truth3.xor_indet_iff`,
+    This links `bivalent_exh_yields_xor`, `Trivalent.xor_indet_iff`,
     the Type A classification, and the null experimental result. -/
 theorem end_to_end_bivalent_sk_challenged :
     -- (1) Bivalent EXH yields exclusive disjunction
     (innocent.exh disjAltsF pOrQF
       = predToFinset (fun w => pOrQ w && !pAndQ w)) ∧
     -- (2) SK XOR propagates undefinedness
-    (Truth3.xor .true .indet = .indet) ∧
+    (Trivalent.xor .true .indet = .indet) ∧
     -- (3) This combination is classified Type A
     (classify .bivalent .strongKleene = .typeA) ∧
     -- (4) The experiment finds no effect (challenging Type A)

--- a/Linglib/Studies/Yagi2025.lean
+++ b/Linglib/Studies/Yagi2025.lean
@@ -76,7 +76,7 @@ definition with disjunction-update survival.
 
 namespace Yagi2025
 
-open Core.Duality
+open Trivalent
 open Semantics.Presupposition
 
 /-! ## World type

--- a/Linglib/Studies/Yagi2025.lean
+++ b/Linglib/Studies/Yagi2025.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Presupposition.Basic
-import Linglib.Core.Logic.Truth3
+import Linglib.Core.Logic.Trivalent
 import Linglib.Semantics.Dynamic.UpdateSemantics.Basic
 import Linglib.Studies.Geurts2005
 import Linglib.Studies.Karttunen1973
@@ -48,7 +48,7 @@ definition with disjunction-update survival.
 
 ## Connective inventory used
 
-- `⊔` on `Truth3` (Strong Kleene): never false (`strong_kleene_never_false`)
+- `⊔` on `Trivalent` (Strong Kleene): never false (`strong_kleene_never_false`)
 - `PartialProp.or` (classical): never defined (`classical_never_defined`)
 - `PartialProp.orPositive` (symmetric, positive-antecedent filtering of
   [kalomoiros-schwarz-2021]): wrong presupposition
@@ -76,7 +76,7 @@ definition with disjunction-update survival.
 
 namespace Yagi2025
 
-open Trivalent
+open Trivalent (isDefined metaAssert Prop3)
 open Semantics.Presupposition
 
 /-! ## World type
@@ -336,7 +336,7 @@ theorem truthSet_exhausted :
             by simp [Geurts2005.fromPartialProp], ?_⟩
     exact ⟨trivial, rfl⟩
 
-/-- Truth-set uninformativity via Geurts (the *consequence* of Yagi §2.4,
+/-- Trivalent-set uninformativity via Geurts (the *consequence* of Yagi §2.4,
 not Schlenker's actual local-context derivation): the disjunction is true
 throughout the stipulated `truthSet`. Discharged via the substrate's
 `exhaustivity_implies_uninformative`. A faithful Schlenker formalisation
@@ -387,7 +387,7 @@ only presupposes `¬𝒜ψ_q → p` per Yagi (11), not `p ∨ q`. -/
 theorem metaAssert_always_defined : ∀ w, (metaAssertDisj w).isDefined := by
   intro w; cases w <;>
     simp [metaAssertDisj, PartialProp.eval, kingOpensParl, presConductsCeremony,
-      hasKing, hasPresident, Truth3.isDefined]
+      hasKing, hasPresident, Trivalent.isDefined]
 
 /-- The meta-assertion disjunction is bivalent — no gap, no presupposition
 via the standard gap mechanism. -/

--- a/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
+++ b/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
@@ -52,7 +52,7 @@ The DCR→SDA trajectory supports homogeneity-based accounts
 
 namespace ZaniCiardelliSanfelici2026
 
-open Trivalent (Truth3 ProjectionType)
+open Trivalent (ProjectionType)
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 open Santorio2018

--- a/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
+++ b/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
@@ -52,7 +52,7 @@ The DCR→SDA trajectory supports homogeneity-based accounts
 
 namespace ZaniCiardelliSanfelici2026
 
-open Core.Duality (Truth3 ProjectionType)
+open Trivalent (Truth3 ProjectionType)
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 open Santorio2018


### PR DESCRIPTION
Three moves from the mathlib-reviewer consultation on the trivalent stack (all cone-verified; full library build green, 6618 jobs):

**KleeneLattice class** (`Core/Order/DeMorganAlgebra.lean`): mathlib lacks a De Morgan/Kleene *lattice* class (its `KleeneAlgebra` is the star-semiring), and this repo derived the involutive-antitone-`Compl` template independently in `OrthocomplementedLattice` and `Bilattice.Negation`. The new `LatticeWithInvolution` base (involution + antitone; De Morgan and the order/injectivity lemmas derived once — no distributivity needed) grounds `DeMorganAlgebra` (+ distributivity), `KleeneLattice` (+ the Kleene law), and the refactored `OrthocomplementedLattice` (duplicated De Morgan block deleted; names preserved via `export`). `BooleanAlgebra → KleeneLattice` blanket instance. `[UPSTREAM]` candidate.

**Trivalent namespace unification**: the trivalent development now spans one root namespace `Trivalent` (`FirstOrder`-style), covering the value algebra, `Duality.lean`'s aggregation, and the ModelTheory-register formula layer. `Core.Duality` retired.

**Carrier renamed `Truth3` → `Trivalent`** (the type itself, at root, on the `Boolean` precedent — an adjective nominalized as its truth-value type; `Trinary`/`ternary` rejected as arity terms, `Truth3` as a coinage the literature doesn't use). The carrier is the canonical non-Boolean `KleeneLattice` instance (`inf_compl_indet_ne_bot` witnesses Kleene-not-Boolean); `neg` stays simp-normal, `ᶜ` is class-API access. Wholesale `open Trivalent` converted to selective opens where the truth-named constructors would shadow `Bool`'s.

**Post-review additions**: verification reviewer's must-fixes applied (`@[simp]` parity on the De Morgan lemmas, field renamed `compl_antitone` → `compl_le_compl` per mathlib field-naming, Ortholattice license header, ortho `export` dissolved with consumers migrated to `LatticeWithInvolution.*`); class renamed `Order.KleeneAlgebra` (nLab's exact name, `Order.Frame` collision precedent); layout restructured to the `Order/BooleanAlgebra/` directory shape — `Core/Order/DeMorganAlgebra/{Defs,Basic}.lean`, with Basic providing `OrderDual`/`Prod`/`Pi` instances for all three classes and `complOrderIso : α ≃o αᵒᵈ` (generalizing mathlib's Boolean-only `OrderIso.compl`). Diamond verified clean by 12 executed defeq probes.