### PR TITLE
refactor(Negation): dissolve NegationProfile; fix Miestamo2005 codings

### DIFF
--- a/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
@@ -5,28 +5,21 @@ import Linglib.Syntax.Negation
 
 The MSA standard-negation inventory — four preverbal particles (*laa*, *lam*,
 *lan*, *maa*) plus the inflecting copular verb *lays-a* 'to not be' — typed
-against `Syntax.Negation` and bundled into a `NegationSystem` and a
-`NegationProfile`.
+against `Syntax.Negation` and bundled into a `NegationSystem`.
 
 ## Main definitions
 
 * `negMarkers` — the five sentential negators.
 * `negationSystem` — markers plus WALS Ch 112A/143A/144A datapoints (`ofISO "arb"`).
-* `negationProfile` — the WALS Ch 112–115 typology coding.
 
 ## Implementation notes
 
 *lam* / *lan* condition a mood shift (jussive / subjunctive) on an otherwise
 finite verb, and *lays-a* supplies a finite copula where the affirmative is
-verbless — read here as Miestamo's A/Fin, extending it from a verb *losing*
-finiteness to a clause *gaining* it. So MSA negation is WALS Ch 113 `.both`
-(symmetric *laa* / *maa* plus asymmetric *lam* / *lan* / *lays-a*) with the
-Ch 114 `.finAndCat` subtype.
-
-MSA (`arb`) is absent from [miestamo-2005] and from WALS Ch 113A/114A
-(which carry only Egyptian `arz`), so `symmetry` and `asymmetrySubtype` are a
-project-internal extrapolation, not Miestamo's own coding; the position fields
-(Ch 143A/144A) are WALS-pulled by `NegationSystem.ofISO`.
+verbless. MSA (`arb`) is absent from [miestamo-2005] and from WALS
+Ch 113A/114A (which carry only Egyptian `arz`), so no symmetric/asymmetric
+coding is recorded here; the position fields (Ch 143A/144A) are WALS-pulled
+by `NegationSystem.ofISO`.
 
 ## References
 
@@ -71,18 +64,5 @@ def negMarkers : List NegMarkerEntry :=
     pulled from `Data.WALS` by ISO code `arb`). -/
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "arb" negMarkers
-
-/-- Modern Standard Arabic negation profile (WALS Ch 112-115 + Greco/JinKoenig
-    fields); see the module docstring for the `.both` / `.finAndCat` rationale. -/
-def negationProfile : NegationProfile :=
-  { language := "Arabic (Modern Standard)"
-  , iso := "arb"
-  , morphemeType := .particle
-  , symmetry := .both
-  , asymmetrySubtype := .finAndCat
-  , negIndefinite := none
-  , negMarkers := negMarkers.map (·.form)
-  , negIsHead := none
-  , enAttested := none }
 
 end Arabic.ModernStandard.Negation

--- a/Linglib/Fragments/Burmese/Negation.lean
+++ b/Linglib/Fragments/Burmese/Negation.lean
@@ -109,16 +109,4 @@ theorem affirmative_forms_distinct :
     affForms.length = 3 ∧ affForms.eraseDups.length = 3 := by
   exact ⟨rfl, by decide⟩
 
-/-- Burmese negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Burmese"
-  , iso := "mya"
-  , morphemeType := .doubleNeg
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .otherCategories
-  , negIndefinite := Option.none
-  , negMarkers := ["ma-", "-bu"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Burmese.Negation

--- a/Linglib/Fragments/English/Negation.lean
+++ b/Linglib/Fragments/English/Negation.lean
@@ -112,16 +112,4 @@ theorem symmetric_no_dosupport :
     (allExamples.filter (·.symmetric)).all (fun e => !e.doSupport) = true := by
   decide
 
-/-- English negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "English"
-  , iso := "eng"
-  , morphemeType := .particle
-  , symmetry := .both
-  , asymmetrySubtype := .otherCategories
-  , negIndefinite := some .mixed
-  , negMarkers := ["not"]
-  , negIsHead := none
-  , enAttested := none }
-
 end English.Negation

--- a/Linglib/Fragments/Finnish/Negation.lean
+++ b/Linglib/Fragments/Finnish/Negation.lean
@@ -131,16 +131,4 @@ theorem connegative_negates : connegativeRule.semEffect true = false := rfl
 theorem neg_aux_respects_bybee :
     MorphCategory.RelevanceLT .negation (.agreement .subj) := by decide
 
-/-- Finnish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Finnish"
-  , iso := "fin"
-  , morphemeType := .auxVerb
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finiteness
-  , negIndefinite := some .cooccur
-  , negMarkers := ["e-"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Finnish.Negation

--- a/Linglib/Fragments/German/Negation.lean
+++ b/Linglib/Fragments/German/Negation.lean
@@ -102,16 +102,4 @@ def allExamples : List NegExample :=
 /-- All five tenses are available under negation (no paradigmatic gaps). -/
 theorem all_tenses_available : allExamples.length = 5 := by decide
 
-/-- German negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "German"
-  , iso := "deu"
-  , morphemeType := .particle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , negIndefinite := some .preclude
-  , negMarkers := ["nicht"]
-  , negIsHead := none
-  , enAttested := none }
-
 end German.Negation

--- a/Linglib/Fragments/Hixkaryana/Negation.lean
+++ b/Linglib/Fragments/Hixkaryana/Negation.lean
@@ -74,16 +74,4 @@ theorem copula_as_finite :
     allExamples.all (·.copulaFinite) = true := by
   decide
 
-/-- Hixkaryana negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Hixkaryana"
-  , iso := "hix"
-  , morphemeType := .affix
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finiteness
-  , negIndefinite := Option.none
-  , negMarkers := ["-hira"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Hixkaryana.Negation

--- a/Linglib/Fragments/Italian/Negation.lean
+++ b/Linglib/Fragments/Italian/Negation.lean
@@ -96,16 +96,4 @@ def enTriggerNegators : List ENTriggerNegator :=
 theorem en_negator_is_standard :
     enTriggerNegators.all (·.enNegatorForm == non.form) = true := by decide
 
-/-- Italian negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Italian"
-  , iso := "ita"
-  , morphemeType := .particle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , negIndefinite := some .mixed
-  , negMarkers := ["non"]
-  , negIsHead := some true
-  , enAttested := some true }
-
 end Italian.Negation

--- a/Linglib/Fragments/Japanese/Negation.lean
+++ b/Linglib/Fragments/Japanese/Negation.lean
@@ -130,16 +130,4 @@ theorem tense_moves_to_suffix :
     japaneseNegDistribution.negativeOnSuffix.contains .tense = true := by
   decide
 
-/-- Japanese negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Japanese"
-  , iso := "jpn"
-  , morphemeType := .affix
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finAndCat
-  , negIndefinite := some .cooccur
-  , negMarkers := ["-nai", "-nakat-"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Japanese.Negation

--- a/Linglib/Fragments/Mandarin/Negation.lean
+++ b/Linglib/Fragments/Mandarin/Negation.lean
@@ -219,16 +219,4 @@ theorem regret_uses_deontic_neg :
       e.triggerClass == "REGRET" || e.triggerClass == "COMPLAIN")).all
       (·.enNegatorForm == "bùgāi") = true := by decide
 
-/-- Mandarin Chinese negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Mandarin Chinese"
-  , iso := "cmn"
-  , morphemeType := .particle
-  , symmetry := .both
-  , asymmetrySubtype := .finiteness
-  , negIndefinite := some .cooccur
-  , negMarkers := ["bu", "mei"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Mandarin.Negation

--- a/Linglib/Fragments/Maori/Negation.lean
+++ b/Linglib/Fragments/Maori/Negation.lean
@@ -86,16 +86,4 @@ theorem all_asymmetric :
     allExamples.all (fun e => !e.symmetric) = true := by
   decide
 
-/-- Maori negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Maori"
-  , iso := "mri"
-  , morphemeType := .wordUnclear
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finiteness
-  , negIndefinite := Option.none
-  , negMarkers := ["kaahore"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Maori.Negation

--- a/Linglib/Fragments/Quechua/Negation.lean
+++ b/Linglib/Fragments/Quechua/Negation.lean
@@ -100,16 +100,4 @@ theorem asymmetric_iff_chu :
     allExamples.all (fun e => e.symmetric == !e.requiresChu) = true := by
   decide
 
-/-- Quechua (Imbabura) negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Quechua (Imbabura)"
-  , iso := "qvi"
-  , morphemeType := .particle
-  , symmetry := .both
-  , asymmetrySubtype := .realityStatus
-  , negIndefinite := some .cooccur
-  , negMarkers := ["mana"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Quechua.Negation

--- a/Linglib/Fragments/Romance/French/Negation.lean
+++ b/Linglib/Fragments/Romance/French/Negation.lean
@@ -177,16 +177,4 @@ theorem high_entrenchment_uses_ne_alone :
     *ne...pas*, but without the reinforcer. -/
 theorem en_marker_is_ne_clitic : enMarker = neClitic := rfl
 
-/-- French negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "French"
-  , iso := "fra"
-  , morphemeType := .particle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , negIndefinite := some .mixed
-  , negMarkers := ["ne", "pas"]
-  , negIsHead := some true
-  , enAttested := some true }
-
 end French.Negation

--- a/Linglib/Fragments/Slavic/Czech/Negation.lean
+++ b/Linglib/Fragments/Slavic/Czech/Negation.lean
@@ -123,16 +123,4 @@ def allConcordExamples : List NegConcordExample := [nikdo, nic, nikdy]
 
 theorem all_examples_count : allExamples.length = 4 := by decide
 
-/-- Czech negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Czech"
-  , iso := "ces"
-  , morphemeType := .affix
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , negIndefinite := some .cooccur
-  , negMarkers := ["ne-"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Czech.Negation

--- a/Linglib/Fragments/Slavic/Russian/Negation.lean
+++ b/Linglib/Fragments/Slavic/Russian/Negation.lean
@@ -119,16 +119,4 @@ theorem ne_form : ne.form = "не" := rfl
 
 theorem all_examples_count : allExamples.length = 4 := by decide
 
-/-- Russian negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Russian"
-  , iso := "rus"
-  , morphemeType := .particle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , negIndefinite := some .cooccur
-  , negMarkers := ["ne"]
-  , negIsHead := none
-  , enAttested := none }
-
 end Russian.Negation

--- a/Linglib/Fragments/Spanish/Negation.lean
+++ b/Linglib/Fragments/Spanish/Negation.lean
@@ -119,16 +119,4 @@ def postverbalNada : NegConcordExample :=
 /-- All five tenses are available under negation (no paradigmatic gaps). -/
 theorem all_tenses_available : allExamples.length = 5 := by decide
 
-/-- Spanish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Spanish"
-  , iso := "spa"
-  , morphemeType := .particle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , negIndefinite := some .mixed
-  , negMarkers := ["no"]
-  , negIsHead := some false
-  , enAttested := some true }
-
 end Spanish.Negation

--- a/Linglib/Fragments/Turkish/Negation.lean
+++ b/Linglib/Fragments/Turkish/Negation.lean
@@ -5,8 +5,8 @@ import Linglib.Syntax.Negation
 [miestamo-2005] [haspelmath-2013] [dryer-haspelmath-2013]
 
 Turkish expresses standard negation with the verbal suffix *-mA-*
-(/-ma-/ or /-me-/ depending on vowel harmony). The suffix is inserted
-between the verb stem and the TAM suffix.
+(*-ma-* ~ *-me-* by vowel harmony). The suffix is inserted between the
+verb stem and the TAM suffix.
 
 ## SymAsy: Symmetric and Asymmetric
 
@@ -23,7 +23,10 @@ But the **aorist** is asymmetric (A/Cat): the affirmative aorist marker
 | **Aorist** | *gel-ir* | *gel-me-z* | **No** |
 
 The aorist asymmetry is a paradigmatic change: a different morphological
-marker appears, not just insertion of the negative morpheme.
+marker appears, not just insertion of the negative morpheme. It is
+sharpest outside 3sg: the negative aorist drops the marker entirely in
+1sg *gelmem* and 1pl *gelmeyiz*, retaining *-z* only in the second and
+third persons.
 -/
 
 namespace Turkish.Negation
@@ -41,7 +44,10 @@ def negSuffix : NegMarkerEntry :=
   , morphemeType := .affix
   , position := .morphological }
 
-/-- The Turkish negation system: a single verbal affix.
+/-- Turkish standard (verbal) negation: a single verbal affix.
+    Nonverbal predication negates with copular *değil* and the
+    existential with suppletive *yok* (for *var*), both outside
+    standard negation in [miestamo-2005]'s sense.
     The Fragment-side joint consumed by `Studies/Dryer2013Negation.lean`. -/
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "tur" [negSuffix]
@@ -55,7 +61,7 @@ structure NegParadigmEntry where
   glossNeg : String
   /-- Is this construction symmetric (neg = aff + neg marker, no other change)? -/
   symmetric : Bool
-  deriving Repr, BEq, Inhabited
+  deriving Repr
 
 /-- Paradigm for *gelmek* 'come' (3sg forms). -/
 def gelParadigm : List NegParadigmEntry :=
@@ -81,30 +87,9 @@ def gelParadigm : List NegParadigmEntry :=
     , symmetric := false }
   ]
 
-/-! ## Verification -/
-
-theorem gel_paradigm_size : gelParadigm.length = 5 := by decide
-
-/-- Most constructions are symmetric. -/
-theorem mostly_symmetric :
-    (gelParadigm.filter (·.symmetric)).length = 4 := by decide
-
-/-- The aorist is the only asymmetric construction. -/
+/-- The aorist is the only asymmetric construction in the paradigm. -/
 theorem aorist_asymmetric :
-    (gelParadigm.filter (fun e => !e.symmetric)).length = 1 ∧
-    (gelParadigm.filter (fun e => !e.symmetric)).head!.formLabel = "aorist" := by
-  exact ⟨by decide, rfl⟩
-
-/-- Turkish negation profile (WALS Ch 112-115 + Greco/JinKoenig fields). -/
-def negationProfile : Syntax.Negation.NegationProfile :=
-  { language := "Turkish"
-  , iso := "tur"
-  , morphemeType := .affix
-  , symmetry := .both
-  , asymmetrySubtype := .otherCategories
-  , negIndefinite := some .cooccur
-  , negMarkers := ["-mA-"]
-  , negIsHead := none
-  , enAttested := none }
+    (gelParadigm.filter (fun e => !e.symmetric)).map (·.formLabel)
+      = ["aorist"] := rfl
 
 end Turkish.Negation

--- a/Linglib/Fragments/Turkish/TAM.lean
+++ b/Linglib/Fragments/Turkish/TAM.lean
@@ -86,28 +86,10 @@ inductive CopulaSuffix where
 -- § Verification
 -- ============================================================================
 
-theorem entry_count : entries.length = 8 := by decide
-
-/-- Exactly one TAM category has asymmetric negation. -/
-theorem one_asymmetric :
-    (entries.filter (! ·.isNegSymmetric)).length = 1 := by decide
-
-/-- The asymmetric category is the aorist. -/
+/-- The aorist is the only TAM category with asymmetric negation;
+    all others use regular `-mA-` insertion (cf. `Negation.aorist_asymmetric`
+    for the surface-form counterpart). -/
 theorem asymmetric_is_aorist :
-    ((entries.filter (! ·.isNegSymmetric)).head!.category == TAMCategory.aorist) = true := by
-  decide
-
-/-- All non-aorist categories use regular -mA- negation. -/
-theorem non_aorist_symmetric :
-    (entries.filter (fun e => e.category != TAMCategory.aorist)).all
-      (·.isNegSymmetric) = true := by
-  decide
-
-/-- Cross-file bridge: TAM and Negation agree that the aorist is asymmetric.
-    TAM: `asymmetric_is_aorist`, Negation: `aorist_asymmetric`. -/
-theorem tam_negation_aorist_agreement :
-    ((entries.filter (! ·.isNegSymmetric)).head!.category == TAMCategory.aorist) = true ∧
-    (Negation.gelParadigm.filter (fun e => !e.symmetric)).head!.formLabel = "aorist" :=
-  ⟨by decide, rfl⟩
+    (entries.filter (! ·.isNegSymmetric)).map (·.category) = [.aorist] := rfl
 
 end Turkish.TAM

--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -562,14 +562,13 @@ motivated criteria but, for the strategies linglib's
 Miestamo's `.toNegMorphemeType = .auxVerb`.
 
 Composition with [miestamo-2005]'s
-`verbal_constructional_always_derived` (in
+`afin_verbal_implies_constructional` (in
 `Linglib/Studies/Miestamo2005.lean`) then
 yields: any `NegStrategy` Anderson places at the auxiliary cline
-stage, in any Miestamo datum showing constructional asymmetry,
-has its asymmetry classified as `.derived` rather than
-`.independent` — a falsifiable empirical prediction whose chain
+stage, in any Miestamo A/Fin datum, shows constructional
+asymmetry — a falsifiable empirical prediction whose chain
 runs Anderson's cline → Miestamo's morpheme type → Miestamo's
-asymmetry source.
+asymmetry dimension.
 
 The earlier `anderson_miestamo_agree_on_neg_morphology` theorem
 in this slot (0.230.573) was a stapled conjunction of three

--- a/Linglib/Studies/Dryer2013Negation.lean
+++ b/Linglib/Studies/Dryer2013Negation.lean
@@ -25,18 +25,12 @@ WALS chapters by Matthew S. Dryer covering negation typology:
 - Ch 143A: Order of Negative Morpheme and Verb
 - Ch 144A: Position of Negative Word with Respect to Subject, Object, Verb
 
-Per the project's "WALS goes to `Linglib/Typology/`" rule, the WALS aggregate
-distributions live in the substrate (`Linglib/Typology/Negation.lean`). This
-study file holds **cross-linguistic generalisations** that consume the
-Fragment-side `negationProfile` data with non-trivial semantic content
-(`bipartite_implies_asymmetric`, `aux_verb_implies_afin`, etc.).
-
-Per-language Fragment-vs-WALS data-equality theorems are **deliberately
-absent**: `Fragments.{Lang}.Negation.negationProfile` already encodes the
-typed value at definition site, and verifying it equals
-`Data.WALS.lookup "iso"` is "encoding conclusions as definitions" — the
-two would have to diverge for the theorem to fail, and the substrate's
-`NegationSystem.ofISO` already populates from the same WALS source.
+This study file holds **cross-linguistic generalisations** over a
+15-language Fragment sample. Each language contributes its Fragment-side
+`negationSystem` joint, whose WALS Ch 112A/143A/144A datapoints and ISO key
+are populated from `Data.WALS` by `NegationSystem.ofISO`; the Ch 113-115
+values are read off the `Data.WALS` rows via the `Syntax.Negation` per-ISO
+accessors. No WALS value is hand-encoded here.
 
 Ch 113-115 (Miestamo's symmetric/asymmetric chapters) are grounded in
 `Studies/Miestamo2005.lean`.
@@ -48,97 +42,80 @@ namespace Dryer2013Negation
 
 open Syntax.Negation
 
--- ============================================================================
--- §1. The 15-language Fragment sample
--- ============================================================================
-
-/-- The 15-language sample drawn from per-language Fragment Negation files.
+/-- The 15-language sample: the Fragment-side `negationSystem` joints.
     Sample shrunk from the dissolved file's 19 (dropped Izi, KolymaYukaghir,
-    Rama, Nelemwa — none of which had Fragment files in the project). -/
-def allLanguages : List NegationProfile :=
-  [ English.Negation.negationProfile
-  , German.Negation.negationProfile
-  , French.Negation.negationProfile
-  , Russian.Negation.negationProfile
-  , Finnish.Negation.negationProfile
-  , Japanese.Negation.negationProfile
-  , Mandarin.Negation.negationProfile
-  , Turkish.Negation.negationProfile
-  , Czech.Negation.negationProfile
-  , Spanish.Negation.negationProfile
-  , Italian.Negation.negationProfile
-  , Burmese.Negation.negationProfile
-  , Maori.Negation.negationProfile
-  , Hixkaryana.Negation.negationProfile
-  , Quechua.Negation.negationProfile ]
+    Rama, Nelemwa — none of which had Fragment files in the project).
+    Czech is absent from the WALS Ch 113A-115A samples, so Ch 113-115
+    claims hold vacuously for it. -/
+def sample : List NegationSystem :=
+  [ English.Negation.negationSystem
+  , German.Negation.negationSystem
+  , French.Negation.negationSystem
+  , Russian.Negation.negationSystem
+  , Finnish.Negation.negationSystem
+  , Japanese.Negation.negationSystem
+  , Mandarin.Negation.negationSystem
+  , Turkish.Negation.negationSystem
+  , Czech.Negation.negationSystem
+  , Spanish.Negation.negationSystem
+  , Italian.Negation.negationSystem
+  , Burmese.Negation.negationSystem
+  , Maori.Negation.negationSystem
+  , Hixkaryana.Negation.negationSystem
+  , Quechua.Negation.negationSystem ]
 
--- ============================================================================
--- §2. Sample-level distributions
--- ============================================================================
+/-- WALS Ch 113A codes the language as having asymmetric negation
+    (`asymmetric` or `both`). -/
+def walsHasAsymmetric (iso : String) : Bool :=
+  (symmetryOfISO iso).any (fun v => v == .asymmetric || v == .both)
 
-/-- Sample size. -/
-theorem sample_size : allLanguages.length = 15 := by native_decide
+/-! ### Cross-linguistic generalisations -/
 
-/-- Morpheme type distribution in the sample. -/
-theorem sample_affix_count : countByMorphemeType allLanguages .affix = 4 := by
-  native_decide
-theorem sample_particle_count :
-    countByMorphemeType allLanguages .particle = 8 := by native_decide
-theorem sample_auxverb_count :
-    countByMorphemeType allLanguages .auxVerb = 1 := by native_decide
-theorem sample_double_count :
-    countByMorphemeType allLanguages .doubleNeg = 1 := by native_decide
-theorem sample_unclear_count :
-    countByMorphemeType allLanguages .wordUnclear = 1 := by native_decide
-theorem sample_variation_count :
-    countByMorphemeType allLanguages .variation = 0 := by native_decide
-
-/-- Symmetry distribution in the sample. -/
-theorem sample_symmetry_counts :
-    countBySymmetry allLanguages .symmetric = 6 ∧
-    countBySymmetry allLanguages .asymmetric = 5 ∧
-    countBySymmetry allLanguages .both = 4 := by
-  native_decide
-
--- ============================================================================
--- §3. Cross-linguistic generalisations
--- ============================================================================
-
+set_option maxRecDepth 8192 in
 /-- In the sample, every language with bipartite ("double") negation
-    morphemes has asymmetric negation. If negation requires two markers
-    whose placement changes the clause structure, the negative clause
-    structurally differs from the affirmative. -/
+    morphemes (Ch 112A) has asymmetric negation (Ch 113A). If negation
+    requires two markers whose placement changes the clause structure, the
+    negative clause structurally differs from the affirmative.
+    (Scoped `maxRecDepth`: kernel evaluation recurses through the
+    1157-row Ch 112A table.) -/
 theorem bipartite_implies_asymmetric :
-    let bipartite := allLanguages.filter (·.hasMorphemeType .doubleNeg)
-    bipartite.all (·.hasAsymmetric) = true := by
-  native_decide
+    sample.all (fun s =>
+      s.wals112A != some .doubleNegation || walsHasAsymmetric s.iso) = true := by
+  decide
 
-/-- In the sample, every language classified as symmetric-only (Ch 113)
-    has a non-assignable asymmetry subtype (Ch 114). -/
+/-- In the sample, every language classified as symmetric-only (Ch 113A)
+    has a non-assignable asymmetry subtype (Ch 114A). -/
 theorem symmetric_implies_nonassignable :
-    let symmetric := allLanguages.filter (·.symmetry == .symmetric)
-    symmetric.all (·.asymmetrySubtype == .nonAssignable) = true := by
-  native_decide
+    sample.all (fun s =>
+      symmetryOfISO s.iso != some .symmetric ||
+      asymmetrySubtypeOfISO s.iso == some .nonAssignable) = true := by
+  decide
 
-/-- In the sample, no language classified as asymmetric or both has a
-    non-assignable subtype. -/
+/-- In the sample, no language classified as asymmetric or both (Ch 113A)
+    has a non-assignable subtype (Ch 114A). -/
 theorem asymmetric_implies_assignable :
-    let asymmetric := allLanguages.filter (·.hasAsymmetric)
-    asymmetric.all (·.asymmetrySubtype != .nonAssignable) = true := by
-  native_decide
+    sample.all (fun s =>
+      !walsHasAsymmetric s.iso ||
+      (asymmetrySubtypeOfISO s.iso).any (· != .nonAssignable)) = true := by
+  decide
 
-/-- Negative auxiliary verbs (Ch 112) are always associated with asymmetric
-    negation of subtype A/Fin: the auxiliary becomes the finite element, and
-    the lexical verb is deficitized. Finnish illustrates this perfectly. -/
+set_option maxRecDepth 8192 in
+/-- Negative auxiliary verbs (Ch 112A) are always associated with asymmetric
+    negation of subtype A/Fin (Ch 114A): the auxiliary becomes the finite
+    element, and the lexical verb is deficitized. Finnish illustrates this
+    perfectly. (Scoped `maxRecDepth` as in `bipartite_implies_asymmetric`.) -/
 theorem aux_verb_implies_afin :
-    let auxLangs := allLanguages.filter (·.hasMorphemeType .auxVerb)
-    auxLangs.all (·.asymmetrySubtype == .finiteness) = true := by
-  native_decide
+    sample.all (fun s =>
+      s.wals112A != some .negativeAuxiliaryVerb ||
+      asymmetrySubtypeOfISO s.iso == some .finiteness) = true := by
+  decide
 
-/-- All Slavic languages in the sample (Russian, Czech) show negative concord. -/
-theorem slavic_neg_concord :
-    Russian.Negation.negationProfile.hasNegConcord = true ∧
-    Czech.Negation.negationProfile.hasNegConcord = true := by
-  exact ⟨by native_decide, by native_decide⟩
+/-- Russian shows negative concord (Ch 115A: negative indefinites co-occur
+    with predicate negation). Czech, the sample's other Slavic language, is
+    not in the Ch 115A sample; its obligatory concord is illustrated by
+    `Czech.Negation.allConcordExamples`. -/
+theorem russian_neg_concord :
+    negIndefiniteOfISO Russian.Negation.negationSystem.iso = some .cooccur := by
+  decide
 
 end Dryer2013Negation

--- a/Linglib/Studies/Greco2020.lean
+++ b/Linglib/Studies/Greco2020.lean
@@ -3,10 +3,6 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Semantics.Negation.Expletive
 import Linglib.Semantics.Negation.CzechNegation
 import Linglib.Semantics.Negation.Defs
-import Linglib.Syntax.Negation
-import Linglib.Fragments.Italian.Negation
-import Linglib.Fragments.Spanish.Negation
-import Linglib.Fragments.Romance.French.Negation
 import Linglib.Semantics.Polarity.Item
 import Mathlib.Data.Fintype.Basic
 
@@ -53,7 +49,7 @@ the representation [CP ... [X° non] ... [FocP [TP ...] Foc° ...]]:
 - `Semantics.Negation` — framework-agnostic EN types (ENType, ENStrength, PolarityLicensing)
 - `Minimalist.NegScope` — merge position, scope, classification chain (defined below)
 - `ENEnvironment` (below) — the eleven Italian EN environments of Tables 1–2
-- `Syntax.Negation.NegationProfile.negIsHead` — head status
+- `SnegAttestation` (below) — per-language head status, Greco's own classification
 - `Minimalist.fValue` / `isCPArea` — f-value classification
 - `Italian.Negation.enTriggerNegators` — the consensus EN trigger inventory
   ([jin-koenig-2021]); Greco's construction-level classification is finer-grained
@@ -318,14 +314,6 @@ namespace Greco2020
 open Minimalist (Cat fValue isCPArea)
 open Minimalist.NegScope (NegMergePosition)
 open Semantics.Negation (ENStrength PolarityLicensing PolarityClass weakENProfile strongENProfile)
-open Syntax.Negation (NegationProfile)
-
-/-- Italian negation profile (re-exported from Fragments for local use). -/
-private abbrev italian : NegationProfile := Italian.Negation.negationProfile
-/-- Spanish negation profile (re-exported from Fragments for local use). -/
-private abbrev spanish : NegationProfile := Spanish.Negation.negationProfile
-/-- French negation profile (re-exported from Fragments for local use). -/
-private abbrev french : NegationProfile := French.Negation.negationProfile
 
 /-! ### Tables 1–2: the eleven Italian EN environments
 
@@ -418,48 +406,38 @@ def spanishSnegConditions : SnegConditions :=
 theorem spanish_no_snegs :
     spanishSnegConditions.yieldsSnegs = false := by decide
 
-/-! ### Cross-linguistic predictions — connect to NegationProfile -/
+/-! ### Cross-linguistic predictions -/
 
-/-- Sneg attestation datum: links a language's negation profile to
-    whether surprise negation is attested. -/
+/-- Sneg attestation datum: [greco-2020]'s head-status classification of a
+    language's negative marker, paired with whether surprise negation is
+    attested. -/
 structure SnegAttestation where
   language : String
   attested : Bool
-  negIsHead : Option Bool
+  negIsHead : Bool
   deriving DecidableEq, Repr
 
+/-- Italian *non* is X° (clitic); Snegs attested. -/
 def italianSnegs : SnegAttestation :=
-  { language := "Italian", attested := true, negIsHead := italian.negIsHead }
+  { language := "Italian", attested := true, negIsHead := true }
 
+/-- Spanish *no* is XP (can be focused and coordinated); no Snegs. -/
 def spanishSnegs : SnegAttestation :=
-  { language := "Spanish", attested := false, negIsHead := spanish.negIsHead }
+  { language := "Spanish", attested := false, negIsHead := false }
 
+/-- Brazilian Portuguese *não* is X°; Snegs attested. -/
 def brazilianPortugueseSnegs : SnegAttestation :=
   { language := "Brazilian Portuguese", attested := true
-  , negIsHead := some true }
+  , negIsHead := true }
 
 def allSnegAttestations : List SnegAttestation :=
   [italianSnegs, spanishSnegs, brazilianPortugueseSnegs]
 
-/-- Greco's prediction: Snegs are attested only when negIsHead = true. -/
+/-- Greco's prediction: Snegs are attested only when the negative marker is
+    a head. (Head status is necessary, not sufficient — French *ne* is X°
+    yet lacks Snegs because factor (iii) fails; see `frenchSnegConditions`.) -/
 theorem sneg_requires_head :
-    allSnegAttestations.all (λ s =>
-      if s.attested then s.negIsHead == some true else true) = true := by decide
-
-/-- Converse: head-status neg predicts Sneg availability (in our sample). -/
-theorem head_predicts_snegs :
-    allSnegAttestations.all (λ s =>
-      if s.negIsHead == some false then !s.attested else true) = true := by decide
-
-/-- The Italian Sneg attestation derives its head status from the
-    NegationProfile, not by stipulation. -/
-theorem italian_snegs_from_profile :
-    italianSnegs.negIsHead = italian.negIsHead := rfl
-
-/-- The Spanish Sneg attestation derives its head status from the
-    NegationProfile. -/
-theorem spanish_snegs_from_profile :
-    spanishSnegs.negIsHead = spanish.negIsHead := rfl
+    allSnegAttestations.all (λ s => !s.attested || s.negIsHead) = true := by decide
 
 /-! ### Phase theory connection -/
 

--- a/Linglib/Studies/Miestamo2005.lean
+++ b/Linglib/Studies/Miestamo2005.lean
@@ -1,7 +1,4 @@
 import Linglib.Syntax.Negation
-import Linglib.Data.WALS.Features.F113A
-import Linglib.Data.WALS.Features.F114A
-import Linglib.Data.WALS.Features.F115A
 import Linglib.Fragments.Finnish.Negation
 import Linglib.Fragments.Italian.Negation
 import Linglib.Fragments.German.Negation
@@ -23,212 +20,203 @@ import Linglib.Fragments.Quechua.Negation
 [miestamo-2005]
 
 [miestamo-2005] refines the WALS symmetric/asymmetric classification
-(Ch 113-114) with two orthogonal theoretical distinctions:
+(Ch 113-114) with the orthogonal distinction between **constructional**
+and **paradigmatic** asymmetry:
 
-## 1. Constructional vs Paradigmatic Asymmetry
+- **Constructional**: the *structure* of the negative clause differs from
+  the affirmative beyond adding the negation marker — added finite
+  elements (Finnish neg aux + connegative, A/Fin) and marker
+  *replacement* (Turkish aorist `-(I)r` → `-z`; replacement asymmetry is
+  constructional A/Cat).
 
-WALS Ch 113 collapses these into a single "asymmetric" category, but Miestamo
-decomposes asymmetry into two independent dimensions:
+- **Paradigmatic**: the *paradigm* of available distinctions differs in
+  the negative — neutralization (Burmese *-bu* collapses three TAM
+  distinctions to one; English negatives lack the periphrastic emphatic,
+  A/Emph/Neutr) or displacement (Imbabura Quechua negatives require the
+  validator *-chu*, A/NonReal/Displc).
 
-- **Constructional**: the syntactic *structure* of the negative clause differs
-  from the affirmative beyond just adding the negation marker. E.g., Finnish
-  uses a negative auxiliary + connegative, restructuring the clause.
+The dimensions are orthogonal: Finnish is constructional-only, Imbabura
+Quechua paradigmatic-only, Burmese both.
 
-- **Paradigmatic**: the *paradigm* (set of available formal distinctions) is
-  different in the negative. E.g., Burmese *-bu* replaces all TAM suffixes,
-  collapsing three distinctions to one.
+## Derived vs independent asymmetry
 
-These are orthogonal: a language can have constructional asymmetry with full
-paradigmatic symmetry (Finnish), or paradigmatic asymmetry without major
-constructional changes (Turkish aorist).
+When a language shows multiple asymmetries, one may be **derived** from
+another rather than being a direct consequence of negation: Maung's TAM
+neutralization follows from its obligatory irrealis-marking (A/NonReal),
+and Imbabura Quechua's ban on other validators follows from the
+A/NonReal validator *-chu*. Derivedness relates asymmetries *to each
+other*, not asymmetries to marker types; it is noted in datum docstrings
+where relevant rather than carried as a field (no sample language here
+has an independent multiple asymmetry).
 
-## 2. Derived vs Independent Asymmetry
+## WALS consistency
 
-- **Derived**: the asymmetry is a structural consequence of the negation
-  marker's properties. A negative *verb* necessarily creates A/Fin because
-  it takes over the finite verb slot — the asymmetry follows from the
-  morphological type.
+Datum codings follow the book's Appendix III analyses. They agree with
+the (later, same-author) WALS Ch 112A-114A codings for every sample
+language except English: the book analyses English SN as symmetric
+AUX+*not* with paradigmatic A/Emph/Neutr asymmetry, where WALS Ch 114A
+codes English A/Cat (`english_subtype_diverges_from_wals`). Czech is
+absent from the book's sample and from WALS Ch 113A-115A; its datum
+applies the book's criteria.
 
-- **Independent**: the asymmetry is not structurally predictable from the
-  negation marker type. E.g., Burmese TAM neutralization does not follow
-  from having a circumfix — other circumfixing languages maintain TAM.
+## Quantitative data
 
-## WALS Consistency
-
-Every datum here is consistent with the coarser WALS classification:
-- Symmetric-only → no constructional or paradigmatic asymmetry
-- Asymmetric A/Fin → constructional asymmetry (almost always; 44/45 in Table 5)
-- Asymmetric A/Cat → paradigmatic or constructional or both
-- SymAsy → some constructions symmetric, others asymmetric
-
-## Quantitative Data
-
-The book's representative sample (RS) covers **179 languages** (Table 3, p. 171):
-Sym 72 (40%), SymAsy 76 (42%), Asy 31 (17%).
-Note: the WALS Ch 113 sample (also by Miestamo) covers 297 languages with
-different numbers; those are captured separately via `Data.WALS.F113A`.
+The book's representative sample (RS) covers **179 languages** (Table 3,
+p. 171): Sym 72 (40%), SymAsy 76 (42%), Asy 31 (17%). The WALS Ch 113
+sample (also by Miestamo) covers 297 languages with different numbers;
+those live in `Data.WALS.F113A`.
 -/
 
 namespace Miestamo2005
 
 open Syntax.Negation
-  (NegSymmetry AsymmetrySubtype NegMorphemeType NegationProfile)
+  (NegSymmetry AsymmetrySubtype NegMorphemeType
+   morphemeTypeOfISO symmetryOfISO asymmetrySubtypeOfISO)
 
--- ============================================================================
--- § 1.5: Miestamo's two asymmetry dimensions (beyond WALS)
--- ============================================================================
+/-! ## Miestamo's asymmetry dimensions (beyond WALS) -/
 
 /-- [miestamo-2005]'s two dimensions of asymmetry. WALS Ch 113 collapses
     these into a single symmetric/asymmetric distinction; Miestamo decomposes
     asymmetry into two independent dimensions. Local to this study file
     because the dimensions are framework-distinctive. -/
 inductive AsymmetryDimension where
-  /-- The negative clause has a different syntactic structure than the
-      affirmative, beyond just the negation marker. E.g., Finnish neg aux
-      restructures the clause; Japanese *-nai* changes verb to i-adjective. -/
+  /-- The negative clause differs structurally from the affirmative beyond
+      the negation marker: added finite elements (A/Fin) or marker
+      replacement (replacement asymmetry is constructional A/Cat). -/
   | constructional
-  /-- The negative paradigm has fewer formal distinctions than the
-      affirmative. E.g., Burmese *-bu* neutralizes TAM; Turkish aorist
-      uses a different marker. -/
+  /-- The negative paradigm makes different formal distinctions than the
+      affirmative: neutralization (Burmese TAM, English A/Emph) or
+      displacement (Quechua validators). -/
   | paradigmatic
   deriving DecidableEq, BEq, Repr
 
-/-- Whether the asymmetry is derived from the negation marker type
-    or independent of it ([miestamo-2005]). -/
-inductive AsymmetrySource where
-  /-- The asymmetry follows structurally from the negation marker's
-      properties. A negative verb necessarily creates A/Fin. -/
-  | derived
-  /-- The asymmetry is not predictable from the marker type alone.
-      E.g., TAM neutralization in Burmese is independent of circumfixing. -/
-  | independent
-  deriving DecidableEq, BEq, Repr
+/-! ## Datum -/
 
--- ============================================================================
--- § 2: Extended Datum
--- ============================================================================
-
-/-- A Miestamo-style negation profile extending the WALS classification. -/
+/-- A Miestamo-style negation datum: the WALS-chapter classification plus
+    the book's constructional/paradigmatic dimension coding (Appendix III). -/
 structure MiestamoDatum where
   language : String
+  /-- ISO 639-3 code; the key for the WALS-consistency checks. -/
+  iso : String
   /-- WALS Ch 112: morpheme type -/
   morphemeType : NegMorphemeType
   /-- WALS Ch 113: symmetric/asymmetric/both -/
   symmetry : NegSymmetry
   /-- WALS Ch 114: asymmetry subtype -/
   asymmetrySubtype : AsymmetrySubtype
-  /-- Miestamo: which dimensions of asymmetry are present -/
+  /-- Which dimensions of asymmetry are present (Appendix III C/P columns) -/
   asymmetryDimensions : List AsymmetryDimension
-  /-- Miestamo: is the asymmetry derived or independent? -/
-  asymmetrySource : Option AsymmetrySource
   /-- Negation marker form(s), derived from Fragment where available -/
   negMarkers : List String
   /-- Brief description of the asymmetry (if any) -/
   asymmetryDescription : String := ""
   deriving Repr, BEq
 
--- ============================================================================
--- § 3: Per-Language Data (Fragment-derived where possible)
--- ============================================================================
+/-! ## Per-language data (Fragment-derived where possible)
 
-/-- Finnish: constructional A/Fin, derived. Neg aux *ei* restructures clause.
-    Form derived from `Finnish.Negation.negParadigm`. -/
+Codings follow the book's Appendix III rows; deviations from WALS or
+gaps in the book's sample are flagged in the datum docstrings. -/
+
+/-- Finnish: constructional A/Fin/NegVerb. The negative auxiliary is the
+    finite element; the lexical verb appears as a nonfinite connegative.
+    Forms derived from `Finnish.Negation.negParadigm`. -/
 def finnish : MiestamoDatum :=
   { language := "Finnish"
+  , iso := "fin"
   , morphemeType := .auxVerb
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , asymmetrySource := some .derived
   , negMarkers := Finnish.Negation.negParadigm.map (·.form)
-  , asymmetryDescription := "Negative auxiliary becomes finite verb; " ++
-      "lexical verb appears as connegative (A/Fin). " ++
-      "Derived: neg aux being a verb structurally entails finiteness change." }
+  , asymmetryDescription := "A/Fin/NegVerb: the negative auxiliary carries " ++
+      "finiteness; the lexical verb is a nonfinite connegative." }
 
-/-- German: symmetric, no asymmetry. Particle *nicht*.
+/-- German: symmetric. Particle *nicht*.
     Form derived from `German.Negation.nicht.form`. -/
 def german : MiestamoDatum :=
   { language := "German"
+  , iso := "deu"
   , morphemeType := .particle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , asymmetrySource := none
   , negMarkers := [German.Negation.nicht.form]
   , asymmetryDescription := "Symmetric: adding nicht introduces no " ++
       "structural or paradigmatic changes." }
 
-/-- Japanese: constructional + paradigmatic, A/Fin+A/Cat.
-    Suffix *-nai* changes verb to i-adjective (constructional) and shifts
-    tense marking to the suffix (paradigmatic).
+/-- Japanese: constructional A/Fin + A/Cat. Plain *-nai* adjectivalizes
+    the verb (A/Fin/Neg-LV); the polite nonpast replaces TAM material
+    (A/Cat/TAM); the polite past adds a finite element. Appendix III codes
+    all three constructions as constructional, with no paradigmatic row.
     Form derived from `Japanese.Negation.negSuffix.form`. -/
 def japanese : MiestamoDatum :=
   { language := "Japanese"
+  , iso := "jpn"
   , morphemeType := .affix
   , symmetry := .asymmetric
   , asymmetrySubtype := .finAndCat
-  , asymmetryDimensions := [.constructional, .paradigmatic]
-  , asymmetrySource := some .independent
+  , asymmetryDimensions := [.constructional]
   , negMarkers := [Japanese.Negation.negSuffix.form]
-  , asymmetryDescription := "Constructional: -nai turns verb into i-adjective. " ++
-      "Paradigmatic: tense/mood marked on -nai, not on stem. " ++
-      "Independent: affix type does not predict category change." }
+  , asymmetryDescription := "A/Fin/Neg-LV: -nai turns the verb into an " ++
+      "i-adjective; A/Cat/TAM: the polite nonpast replaces TAM material. " ++
+      "All constructional in Appendix III." }
 
-/-- Turkish: SymAsy with paradigmatic A/Cat (aorist only).
-    Most constructions symmetric; aorist negative uses *-z* instead of *-(I)r*.
-    Form derived from `Turkish.Negation.negSuffix.form`. -/
+/-- Turkish: SymAsy with constructional A/Cat/TAM in the aorist only.
+    The aorist suffix changes to *-z* in the 2nd/3rd persons and is
+    omitted in the 1st (Appendix II ex. 260); negation is symmetric
+    elsewhere. Form derived from `Turkish.Negation.negSuffix.form`. -/
 def turkish : MiestamoDatum :=
   { language := "Turkish"
+  , iso := "tur"
   , morphemeType := .affix
   , symmetry := .both
   , asymmetrySubtype := .otherCategories
-  , asymmetryDimensions := [.paradigmatic]
-  , asymmetrySource := some .independent
+  , asymmetryDimensions := [.constructional]
   , negMarkers := [Turkish.Negation.negSuffix.form]
-  , asymmetryDescription := "Paradigmatic: aorist marker -(I)r → -z under negation. " ++
-      "Most other TAM constructions are symmetric. " ++
-      "Independent: suffix type does not predict aorist change." }
+  , asymmetryDescription := "Constructional A/Cat/TAM: aorist -(I)r → -z " ++
+      "under negation (2nd/3rd persons; omitted in the 1st). " ++
+      "Most other TAM constructions are symmetric." }
 
 /-- French: symmetric. Bipartite *ne...pas* introduces no structural change.
     Forms derived from `French.Negation`. -/
 def french : MiestamoDatum :=
   { language := "French"
+  , iso := "fra"
   , morphemeType := .particle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , asymmetrySource := none
   , negMarkers := [French.Negation.neClitic,
                     French.Negation.pasReinforcer]
   , asymmetryDescription := "Symmetric: ne...pas adds negation without " ++
       "changing clause structure or paradigm. " ++
       "Jespersen cycle: ne dropping in colloquial speech." }
 
-/-- Burmese: constructional + paradigmatic A/Cat, independent.
-    Circumfix *ma-...-bu* replaces TAM markers.
+/-- Burmese: constructional + paradigmatic A/Cat, in one construction
+    (Appendix III type B): the circumfix replaces the TAM slot and
+    neutralizes the actual/potential distinction (A/Cat/TAM/Neutr).
     Forms derived from `Burmese.Negation`. -/
 def burmese : MiestamoDatum :=
   { language := "Burmese"
+  , iso := "mya"
   , morphemeType := .doubleNeg
   , symmetry := .asymmetric
   , asymmetrySubtype := .otherCategories
   , asymmetryDimensions := [.constructional, .paradigmatic]
-  , asymmetrySource := some .independent
   , negMarkers := [Burmese.Negation.negPrefix,
                     Burmese.Negation.negSuffix]
-  , asymmetryDescription := "Constructional: circumfix changes word structure. " ++
-      "Paradigmatic: -bu replaces TAM suffixes, neutralizing 3 distinctions to 1. " ++
-      "Independent: circumfix type does not predict TAM neutralization." }
+  , asymmetryDescription := "Constructional: ma-...-bu replaces the TAM slot. " ++
+      "Paradigmatic: -bu neutralizes TAM distinctions (A/Cat/TAM/Neutr)." }
 
 /-- Italian: symmetric. Particle *non*, no structural change.
     Form derived from `Italian.Negation.non.form`. -/
 def italian : MiestamoDatum :=
   { language := "Italian"
+  , iso := "ita"
   , morphemeType := .particle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , asymmetrySource := none
   , negMarkers := [Italian.Negation.non.form]
   , asymmetryDescription := "Symmetric: non adds negation without " ++
       "structural or paradigmatic change." }
@@ -237,11 +225,11 @@ def italian : MiestamoDatum :=
     Form derived from `Spanish.Negation.no.form`. -/
 def spanish : MiestamoDatum :=
   { language := "Spanish"
+  , iso := "spa"
   , morphemeType := .particle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , asymmetrySource := none
   , negMarkers := [Spanish.Negation.no.form]
   , asymmetryDescription := "Symmetric: no adds negation without " ++
       "structural or paradigmatic change. " ++
@@ -250,159 +238,186 @@ def spanish : MiestamoDatum :=
 /-- Mandarin Chinese: SymAsy with constructional A/Fin.
     Non-perfectives negated by *bù* (symmetric). Perfectives negated by
     *méi(yǒu)*: the existential verb *yǒu* is introduced as the finite
-    element (FE), the lexical verb loses finite status (A/Fin/Neg-FE).
-    When *méi* occurs without *yǒu*, it functions as a negative existential
-    verb (A/Fin/NegVerb). [miestamo-2005] pp. 90–91, example 51.
-    Forms derived from `Mandarin.Negation`. -/
+    element (A/Fin/Neg-FE); when *méi* occurs without *yǒu*, it functions
+    as a negative existential verb (A/Fin/NegVerb). [miestamo-2005]
+    pp. 90-91, example (51). Forms derived from `Mandarin.Negation`. -/
 def mandarin : MiestamoDatum :=
   { language := "Mandarin Chinese"
+  , iso := "cmn"
   , morphemeType := .particle
   , symmetry := .both
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , asymmetrySource := some .independent
   , negMarkers := [Mandarin.Negation.bu.form,
                     Mandarin.Negation.mei.form]
   , asymmetryDescription := "Constructional: méi(yǒu) introduces the " ++
-      "existential verb yǒu as the finite element; the lexical verb " ++
-      "loses finite status (A/Fin/Neg-FE). bù constructions are symmetric. " ++
-      "Independent: particle type does not predict A/Fin restructuring." }
+      "existential verb yǒu as the finite element (A/Fin/Neg-FE); " ++
+      "méi alone is a negative existential verb (A/Fin/NegVerb). " ++
+      "bù constructions are symmetric." }
 
-/-- English: SymAsy with constructional A/Cat (do-support).
-    With modals/be/have, negation is symmetric; with lexical verbs,
-    *do*-support introduces a structural change (constructional asymmetry).
+/-- English: SymAsy with paradigmatic A/Emph/Neutr. Appendix III codes
+    AUX+*not* as symmetric (with *do* as the finite AUX host) and locates
+    the asymmetry in the paradigm: the periphrastic emphatic (*I DO eat*)
+    is unavailable in negatives. WALS Ch 114A instead codes English A/Cat;
+    see `english_subtype_diverges_from_wals`.
     Form derived from `English.Negation.not.form`. -/
 def english : MiestamoDatum :=
   { language := "English"
+  , iso := "eng"
   , morphemeType := .particle
   , symmetry := .both
-  , asymmetrySubtype := .otherCategories
-  , asymmetryDimensions := [.constructional]
-  , asymmetrySource := some .independent
+  , asymmetrySubtype := .emphasis
+  , asymmetryDimensions := [.paradigmatic]
   , negMarkers := [English.Negation.not.form]
-  , asymmetryDescription := "Constructional: do-support introduces auxiliary do " ++
-      "with lexical verbs (He eats → He does not eat). " ++
-      "Symmetric with modals/be/have. " ++
-      "Independent: particle type does not predict do-support." }
+  , asymmetryDescription := "Paradigmatic A/Emph/Neutr: the periphrastic " ++
+      "emphatic is unavailable in negatives (simple tenses). " ++
+      "AUX+not constructions themselves are symmetric." }
 
 /-- Russian: symmetric. Particle *не* (*ne*), no structural change.
     Form derived from `Russian.Negation.ne.form`. -/
 def russian : MiestamoDatum :=
   { language := "Russian"
+  , iso := "rus"
   , morphemeType := .particle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , asymmetrySource := none
   , negMarkers := [Russian.Negation.ne.form]
   , asymmetryDescription := "Symmetric: не adds negation without " ++
       "structural or paradigmatic change. " ++
       "Obligatory negative concord (Slavic pattern)." }
 
-/-- Czech: symmetric. Prefix *ne-*, no structural change.
+/-- Czech: symmetric. Prefix *ne-*, no structural change. Not in the
+    book's RS (nor the WALS Ch 113A-115A samples); coded here by applying
+    the book's criteria to symmetric *ne-* prefixation.
     Form derived from `Czech.Negation.negPrefix`. -/
 def czech : MiestamoDatum :=
   { language := "Czech"
+  , iso := "ces"
   , morphemeType := .affix
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , asymmetrySource := none
   , negMarkers := [Czech.Negation.negPrefix]
   , asymmetryDescription := "Symmetric: ne- prefix adds negation without " ++
       "structural or paradigmatic change. " ++
       "Obligatory negative concord (Slavic pattern)." }
 
-/-- Maori: constructional A/Fin, source unclear.
-    *Kāhore* functions as a quasi-auxiliary, changing the finiteness
-    structure. WALS classifies morpheme type as wordUnclear.
+/-- Maori: constructional A/Fin/NegVerb. *Kāhore* is the finite element
+    and the lexical clause is subordinated. WALS Ch 112A codes the
+    morpheme type as wordUnclear.
     Form derived from `Maori.Negation.kahore.form`. -/
 def maori : MiestamoDatum :=
   { language := "Maori"
+  , iso := "mri"
   , morphemeType := .wordUnclear
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , asymmetrySource := some .derived
   , negMarkers := [Maori.Negation.kahore.form]
-  , asymmetryDescription := "Constructional: kāhore takes the TAM position, " ++
-      "verb appears in nominalized form (A/Fin). " ++
-      "Derived: quasi-auxiliary status structurally entails finiteness change." }
+  , asymmetryDescription := "Constructional A/Fin/NegVerb: kāhore takes the " ++
+      "TAM position, the verb appears in nominalized form." }
 
-/-- Hixkaryana: constructional A/Fin, independent.
-    Suffix *-hira* deverbalizes the verb; a copula becomes the finite
-    element. Form derived from `Hixkaryana.Negation.hira.form`. -/
+/-- Hixkaryana: constructional A/Fin/Neg-LV. Suffix *-hɨra* deverbalizes
+    the verb; a copula becomes the finite element.
+    Form derived from `Hixkaryana.Negation.hira.form`. -/
 def hixkaryana : MiestamoDatum :=
   { language := "Hixkaryana"
+  , iso := "hix"
   , morphemeType := .affix
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , asymmetrySource := some .independent
   , negMarkers := [Hixkaryana.Negation.hira.form]
-  , asymmetryDescription := "Constructional: -hira deverbalizes the verb, " ++
-      "copula becomes the finite element (A/Fin). " ++
-      "Independent: affix type does not predict deverbalization." }
+  , asymmetryDescription := "Constructional A/Fin/Neg-LV: -hira deverbalizes " ++
+      "the verb, a copula becomes the finite element." }
 
-/-- Imbabura Quechua: SymAsy with paradigmatic A/NonReal, independent.
-    Particle *mana*; validator enclitic *-chu* obligatory in some negative
-    constructions. *-chu* also appears in polar interrogatives — it is a
-    general "validator" expressing assertion authority ([miestamo-2005]
-    p. 158). Some constructions symmetric, others require *-chu*.
-    Form derived from `Quechua.Negation.mana.form`. -/
+/-- Imbabura Quechua: SymAsy with paradigmatic A/NonReal/Displc.
+    *Mana* constructions are symmetric; negatives require the validator
+    enclitic *-chu*, which also marks interrogatives. Since only one
+    validator may occur per sentence, the further ban on other validators
+    is an asymmetry the book classifies as *derived* from this one
+    (p. 158). Form derived from `Quechua.Negation.mana.form`. -/
 def imbaburaQuechua : MiestamoDatum :=
   { language := "Quechua (Imbabura)"
+  , iso := "qvi"
   , morphemeType := .particle
   , symmetry := .both
   , asymmetrySubtype := .realityStatus
   , asymmetryDimensions := [.paradigmatic]
-  , asymmetrySource := some .independent
   , negMarkers := [Quechua.Negation.mana.form]
-  , asymmetryDescription := "Paradigmatic: negative requires -chu validator " ++
-      "enclitic, a category absent from the affirmative paradigm (A/NonReal). " ++
-      "No constructional change: clause structure is preserved. " ++
-      "Independent: particle type does not predict validator requirement." }
+  , asymmetryDescription := "Paradigmatic A/NonReal/Displc: negatives require " ++
+      "the -chu validator, a category shared with interrogatives; other " ++
+      "validators are displaced (derived asymmetry). " ++
+      "Clause structure is preserved." }
 
 def allData : List MiestamoDatum :=
   [finnish, german, japanese, turkish, french, burmese, italian, spanish,
    mandarin, english, russian, czech, maori, hixkaryana, imbaburaQuechua]
 
--- ============================================================================
--- § 4: WALS Consistency
--- ============================================================================
+/-! ## WALS consistency
 
-section WALSConsistency
+The book's codings against the (later, same-author) WALS chapter rows,
+read via the `Syntax.Negation` per-ISO accessors. Languages absent from
+a chapter's WALS sample (Czech throughout) pass vacuously. -/
+
+set_option maxRecDepth 8192 in
+/-- Datum morpheme types agree with WALS Ch 112A wherever coded.
+    (Scoped `maxRecDepth`: kernel evaluation recurses through the
+    1157-row Ch 112A table.) -/
+theorem morphemeType_matches_wals :
+    allData.all (fun d =>
+      (morphemeTypeOfISO d.iso).all (· == d.morphemeType)) = true := by
+  decide
+
+/-- Datum symmetry codings agree with WALS Ch 113A wherever coded. -/
+theorem symmetry_matches_wals :
+    allData.all (fun d =>
+      (symmetryOfISO d.iso).all (· == d.symmetry)) = true := by
+  decide
+
+/-- Datum subtype codings agree with WALS Ch 114A wherever coded — except
+    English, where the book's A/Emph analysis diverges from WALS's A/Cat. -/
+theorem subtype_matches_wals_except_english :
+    allData.all (fun d =>
+      d.language == "English" ||
+      (asymmetrySubtypeOfISO d.iso).all (· == d.asymmetrySubtype)) = true := by
+  decide
+
+/-- The book vs WALS on English: Appendix III codes English SN as
+    symmetric AUX+*not* with paradigmatic A/Emph/Neutr asymmetry; WALS
+    Ch 114A codes English A/Cat. -/
+theorem english_subtype_diverges_from_wals :
+    english.asymmetrySubtype = .emphasis ∧
+    asymmetrySubtypeOfISO english.iso = some .otherCategories :=
+  ⟨rfl, by decide⟩
+
+/-! ## Structural sanity of the coding -/
 
 /-- Symmetric languages have no asymmetry dimensions. -/
 theorem symmetric_no_dimensions :
     (allData.filter (·.symmetry == .symmetric)).all
       (fun d => d.asymmetryDimensions.isEmpty) = true := by
-  native_decide
-
-/-- Symmetric languages have no asymmetry source. -/
-theorem symmetric_no_source :
-    (allData.filter (·.symmetry == .symmetric)).all
-      (fun d => d.asymmetrySource.isNone) = true := by
-  native_decide
+  decide
 
 /-- Asymmetric languages have at least one asymmetry dimension. -/
 theorem asymmetric_has_dimensions :
     (allData.filter (·.symmetry == .asymmetric)).all
       (fun d => !d.asymmetryDimensions.isEmpty) = true := by
-  native_decide
-
-/-- Asymmetric languages have an asymmetry source. -/
-theorem asymmetric_has_source :
-    (allData.filter (·.symmetry == .asymmetric)).all
-      (fun d => d.asymmetrySource.isSome) = true := by
-  native_decide
+  decide
 
 /-- SymAsy languages have at least one asymmetry dimension
     (for their asymmetric constructions). -/
 theorem symasy_has_dimensions :
     (allData.filter (·.symmetry == .both)).all
       (fun d => !d.asymmetryDimensions.isEmpty) = true := by
-  native_decide
+  decide
+
+/-- Symmetric-only (WALS) implies nonAssignable asymmetry subtype. -/
+theorem symmetric_implies_nonassignable :
+    (allData.filter (·.symmetry == .symmetric)).all
+      (fun d => d.asymmetrySubtype == .nonAssignable) = true := by
+  decide
 
 /-- A/Fin with a *verbal* negator implies constructional asymmetry:
     the negative verb takes over the finite verb slot, necessarily
@@ -414,278 +429,29 @@ theorem afin_verbal_implies_constructional :
        d.asymmetrySubtype == .finAndNonReal) &&
       d.morphemeType == .auxVerb)).all
       (fun d => d.asymmetryDimensions.contains .constructional) = true := by
-  native_decide
+  decide
 
 /-- All A/Fin languages in our sample have constructional asymmetry,
-    regardless of negation marker type. Even Mandarin's particle-type
-    méi(yǒu) introduces structural changes (existential verb as FE). -/
+    regardless of negation marker type — matching Table 5, where A/Fin
+    is constructional in 44 of 45 RS languages. -/
 theorem afin_always_constructional_in_sample :
     (allData.filter (fun d =>
       d.asymmetrySubtype == .finiteness ||
       d.asymmetrySubtype == .finAndCat ||
       d.asymmetrySubtype == .finAndNonReal)).all
       (fun d => d.asymmetryDimensions.contains .constructional) = true := by
-  native_decide
+  decide
 
-/-- Symmetric-only (WALS) implies nonAssignable asymmetry subtype. -/
-theorem symmetric_implies_nonassignable :
-    (allData.filter (·.symmetry == .symmetric)).all
-      (fun d => d.asymmetrySubtype == .nonAssignable) = true := by
-  native_decide
-
-/-- Morpheme types are consistent with WALS Typology profiles. -/
-theorem finnish_morpheme_consistent :
-    finnish.morphemeType = Finnish.Negation.negationProfile.morphemeType := rfl
-theorem german_morpheme_consistent :
-    german.morphemeType = German.Negation.negationProfile.morphemeType := rfl
-theorem japanese_morpheme_consistent :
-    japanese.morphemeType = Japanese.Negation.negationProfile.morphemeType := rfl
-theorem turkish_morpheme_consistent :
-    turkish.morphemeType = Turkish.Negation.negationProfile.morphemeType := rfl
-theorem italian_morpheme_consistent :
-    italian.morphemeType = Italian.Negation.negationProfile.morphemeType := rfl
-theorem burmese_morpheme_consistent :
-    burmese.morphemeType = Burmese.Negation.negationProfile.morphemeType := rfl
-theorem french_morpheme_consistent :
-    french.morphemeType = French.Negation.negationProfile.morphemeType := rfl
-theorem spanish_morpheme_consistent :
-    spanish.morphemeType = Spanish.Negation.negationProfile.morphemeType := rfl
-theorem mandarin_morpheme_consistent :
-    mandarin.morphemeType = Mandarin.Negation.negationProfile.morphemeType := rfl
-theorem english_morpheme_consistent :
-    english.morphemeType = English.Negation.negationProfile.morphemeType := rfl
-theorem russian_morpheme_consistent :
-    russian.morphemeType = Russian.Negation.negationProfile.morphemeType := rfl
-theorem czech_morpheme_consistent :
-    czech.morphemeType = Czech.Negation.negationProfile.morphemeType := rfl
-theorem maori_morpheme_consistent :
-    maori.morphemeType = Maori.Negation.negationProfile.morphemeType := rfl
-theorem hixkaryana_morpheme_consistent :
-    hixkaryana.morphemeType = Hixkaryana.Negation.negationProfile.morphemeType := rfl
-theorem imbaburaQuechua_morpheme_consistent :
-    imbaburaQuechua.morphemeType = Quechua.Negation.negationProfile.morphemeType := rfl
-
-/-- Symmetry values are consistent with WALS Typology profiles. -/
-theorem finnish_symmetry_consistent :
-    finnish.symmetry = Finnish.Negation.negationProfile.symmetry := rfl
-theorem german_symmetry_consistent :
-    german.symmetry = German.Negation.negationProfile.symmetry := rfl
-theorem japanese_symmetry_consistent :
-    japanese.symmetry = Japanese.Negation.negationProfile.symmetry := rfl
-theorem turkish_symmetry_consistent :
-    turkish.symmetry = Turkish.Negation.negationProfile.symmetry := rfl
-theorem italian_symmetry_consistent :
-    italian.symmetry = Italian.Negation.negationProfile.symmetry := rfl
-theorem burmese_symmetry_consistent :
-    burmese.symmetry = Burmese.Negation.negationProfile.symmetry := rfl
-theorem french_symmetry_consistent :
-    french.symmetry = French.Negation.negationProfile.symmetry := rfl
-theorem spanish_symmetry_consistent :
-    spanish.symmetry = Spanish.Negation.negationProfile.symmetry := rfl
-theorem mandarin_symmetry_consistent :
-    mandarin.symmetry = Mandarin.Negation.negationProfile.symmetry := rfl
-theorem english_symmetry_consistent :
-    english.symmetry = English.Negation.negationProfile.symmetry := rfl
-theorem russian_symmetry_consistent :
-    russian.symmetry = Russian.Negation.negationProfile.symmetry := rfl
-theorem czech_symmetry_consistent :
-    czech.symmetry = Czech.Negation.negationProfile.symmetry := rfl
-theorem maori_symmetry_consistent :
-    maori.symmetry = Maori.Negation.negationProfile.symmetry := rfl
-theorem hixkaryana_symmetry_consistent :
-    hixkaryana.symmetry = Hixkaryana.Negation.negationProfile.symmetry := rfl
-theorem imbaburaQuechua_symmetry_consistent :
-    imbaburaQuechua.symmetry = Quechua.Negation.negationProfile.symmetry := rfl
-
-/-- Asymmetry subtypes are consistent with WALS Typology profiles. -/
-theorem finnish_subtype_consistent :
-    finnish.asymmetrySubtype = Finnish.Negation.negationProfile.asymmetrySubtype := rfl
-theorem german_subtype_consistent :
-    german.asymmetrySubtype = German.Negation.negationProfile.asymmetrySubtype := rfl
-theorem japanese_subtype_consistent :
-    japanese.asymmetrySubtype = Japanese.Negation.negationProfile.asymmetrySubtype := rfl
-theorem turkish_subtype_consistent :
-    turkish.asymmetrySubtype = Turkish.Negation.negationProfile.asymmetrySubtype := rfl
-theorem italian_subtype_consistent :
-    italian.asymmetrySubtype = Italian.Negation.negationProfile.asymmetrySubtype := rfl
-theorem burmese_subtype_consistent :
-    burmese.asymmetrySubtype = Burmese.Negation.negationProfile.asymmetrySubtype := rfl
-theorem french_subtype_consistent :
-    french.asymmetrySubtype = French.Negation.negationProfile.asymmetrySubtype := rfl
-theorem spanish_subtype_consistent :
-    spanish.asymmetrySubtype = Spanish.Negation.negationProfile.asymmetrySubtype := rfl
-theorem mandarin_subtype_consistent :
-    mandarin.asymmetrySubtype = Mandarin.Negation.negationProfile.asymmetrySubtype := rfl
-theorem english_subtype_consistent :
-    english.asymmetrySubtype = English.Negation.negationProfile.asymmetrySubtype := rfl
-theorem russian_subtype_consistent :
-    russian.asymmetrySubtype = Russian.Negation.negationProfile.asymmetrySubtype := rfl
-theorem czech_subtype_consistent :
-    czech.asymmetrySubtype = Czech.Negation.negationProfile.asymmetrySubtype := rfl
-theorem maori_subtype_consistent :
-    maori.asymmetrySubtype = Maori.Negation.negationProfile.asymmetrySubtype := rfl
-theorem hixkaryana_subtype_consistent :
-    hixkaryana.asymmetrySubtype = Hixkaryana.Negation.negationProfile.asymmetrySubtype := rfl
-theorem imbaburaQuechua_subtype_consistent :
-    imbaburaQuechua.asymmetrySubtype = Quechua.Negation.negationProfile.asymmetrySubtype := rfl
-
-end WALSConsistency
-
--- ============================================================================
--- § 5: Fragment Bridges
--- ============================================================================
-
-section FragmentBridges
-
-/-- Finnish negation markers derive from the Fragment paradigm. -/
-theorem finnish_markers_from_fragment :
-    finnish.negMarkers =
-      Finnish.Negation.negParadigm.map (·.form) := rfl
-
-/-- Finnish has 6 neg aux forms (3 persons x 2 numbers). -/
-theorem finnish_marker_count :
-    finnish.negMarkers.length = 6 := by native_decide
-
-/-- German negation marker derives from Fragment. -/
-theorem german_marker_from_fragment :
-    german.negMarkers = [German.Negation.nicht.form] := rfl
-
-/-- German marker is *nicht*. -/
-theorem german_marker_is_nicht :
-    german.negMarkers = ["nicht"] := rfl
-
-/-- Japanese negation marker derives from Fragment. -/
-theorem japanese_marker_from_fragment :
-    japanese.negMarkers = [Japanese.Negation.negSuffix.form] := rfl
-
-/-- Japanese marker is *-nai*. -/
-theorem japanese_marker_is_nai :
-    japanese.negMarkers = ["-nai"] := rfl
-
-/-- Turkish negation marker derives from Fragment. -/
-theorem turkish_marker_from_fragment :
-    turkish.negMarkers = [Turkish.Negation.negSuffix.form] := rfl
-
-/-- Turkish marker is *-mA-*. -/
-theorem turkish_marker_is_mA :
-    turkish.negMarkers = ["-mA-"] := rfl
-
-/-- French negation markers derive from Fragment. -/
-theorem french_markers_from_fragment :
-    french.negMarkers = [French.Negation.neClitic,
-                          French.Negation.pasReinforcer] := rfl
-
-/-- French markers are *ne* and *pas*. -/
-theorem french_markers_are_ne_pas :
-    french.negMarkers = ["ne", "pas"] := rfl
-
-/-- Burmese negation markers derive from Fragment. -/
-theorem burmese_markers_from_fragment :
-    burmese.negMarkers = [Burmese.Negation.negPrefix,
-                           Burmese.Negation.negSuffix] := rfl
-
-/-- Burmese markers are *ma-* and *-bu*. -/
-theorem burmese_markers_are_ma_bu :
-    burmese.negMarkers = ["ma-", "-bu"] := rfl
-
-/-- Italian negation marker derives from Fragment. -/
-theorem italian_marker_from_fragment :
-    italian.negMarkers = [Italian.Negation.non.form] := rfl
-
-/-- Italian marker is *non*. -/
-theorem italian_marker_is_non :
-    italian.negMarkers = ["non"] := rfl
-
-/-- Spanish negation marker derives from Fragment. -/
-theorem spanish_marker_from_fragment :
-    spanish.negMarkers = [Spanish.Negation.no.form] := rfl
-
-/-- Spanish marker is *no*. -/
-theorem spanish_marker_is_no :
-    spanish.negMarkers = ["no"] := rfl
-
-/-- Mandarin negation markers derive from Fragment. -/
-theorem mandarin_markers_from_fragment :
-    mandarin.negMarkers = [Mandarin.Negation.bu.form,
-                            Mandarin.Negation.mei.form] := rfl
-
-/-- Mandarin markers are *bù* and *méi*. -/
-theorem mandarin_markers_are_bu_mei :
-    mandarin.negMarkers = ["bù", "méi"] := rfl
-
-/-- English negation marker derives from Fragment. -/
-theorem english_marker_from_fragment :
-    english.negMarkers = [English.Negation.not.form] := rfl
-
-/-- English marker is *not*. -/
-theorem english_marker_is_not :
-    english.negMarkers = ["not"] := rfl
-
-/-- Russian negation marker derives from Fragment. -/
-theorem russian_marker_from_fragment :
-    russian.negMarkers = [Russian.Negation.ne.form] := rfl
-
-/-- Russian marker is *не*. -/
-theorem russian_marker_is_ne :
-    russian.negMarkers = ["не"] := rfl
-
-/-- Czech negation marker derives from Fragment. -/
-theorem czech_marker_from_fragment :
-    czech.negMarkers = [Czech.Negation.negPrefix] := rfl
-
-/-- Czech marker is *ne-*. -/
-theorem czech_marker_is_ne :
-    czech.negMarkers = ["ne-"] := rfl
-
-/-- Maori negation word derives from Fragment. -/
-theorem maori_marker_from_fragment :
-    maori.negMarkers = [Maori.Negation.kahore.form] := rfl
-
-/-- Maori marker is *kāhore*. -/
-theorem maori_marker_is_kahore :
-    maori.negMarkers = ["kāhore"] := rfl
-
-/-- Hixkaryana negation suffix derives from Fragment. -/
-theorem hixkaryana_marker_from_fragment :
-    hixkaryana.negMarkers = [Hixkaryana.Negation.hira.form] := rfl
-
-/-- Hixkaryana marker is *-hira*. -/
-theorem hixkaryana_marker_is_hira :
-    hixkaryana.negMarkers = ["-hira"] := rfl
-
-/-- Imbabura Quechua negation particle derives from Fragment. -/
-theorem imbaburaQuechua_marker_from_fragment :
-    imbaburaQuechua.negMarkers = [Quechua.Negation.mana.form] := rfl
-
-/-- Imbabura Quechua marker is *mana*. -/
-theorem imbaburaQuechua_marker_is_mana :
-    imbaburaQuechua.negMarkers = ["mana"] := rfl
-
-end FragmentBridges
-
--- ============================================================================
--- § 6: Theoretical Predictions
--- ============================================================================
-
-section Predictions
-
-/-- Derived asymmetry: negative auxiliary verbs always produce
-    constructional A/Fin asymmetry. The asymmetry is derived because
-    a verb-type negator structurally entails finiteness restructuring. -/
-theorem neg_aux_implies_derived_constructional :
-    (allData.filter (·.morphemeType == .auxVerb)).all
-      (fun d => d.asymmetrySource == some .derived ∧
-                d.asymmetryDimensions.contains .constructional) = true := by
-  native_decide
+/-! ## Theoretical predictions -/
 
 /-- Particles that are symmetric-only have no asymmetry dimensions.
-    Mandarin and English are SymAsy particles with constructional asymmetry
-    (méi(yǒu) introduces A/Fin; do-support introduces A/Cat). -/
+    Mandarin and English are SymAsy particles with asymmetry elsewhere
+    (méi(yǒu) introduces A/Fin; the emphatic paradigm is neutralized). -/
 theorem symmetric_particles_no_dimensions :
     (allData.filter (fun d => d.morphemeType == .particle &&
       d.symmetry == .symmetric)).all
       (fun d => d.asymmetryDimensions.isEmpty) = true := by
-  native_decide
+  decide
 
 /-- Affixes can produce symmetric, asymmetric, or SymAsy negation. -/
 theorem affixes_variable :
@@ -702,18 +468,17 @@ theorem finnish_no_paradigmatic_asymmetry :
 theorem burmese_both_dimensions :
     burmese.asymmetryDimensions = [.constructional, .paradigmatic] := rfl
 
-/-- Turkish has paradigmatic-only asymmetry: the aorist marker changes
-    but the clause structure does not. -/
-theorem turkish_paradigmatic_only :
-    turkish.asymmetryDimensions = [.paradigmatic] := rfl
+/-- Turkish has constructional-only asymmetry: the aorist marker is
+    replaced (or omitted), but no distinctions are neutralized. -/
+theorem turkish_constructional_only :
+    turkish.asymmetryDimensions = [.constructional] := rfl
 
-end Predictions
+/-- Imbabura Quechua has paradigmatic-only asymmetry: the validator
+    requirement changes the paradigm, not the clause structure. -/
+theorem quechua_paradigmatic_only :
+    imbaburaQuechua.asymmetryDimensions = [.paradigmatic] := rfl
 
--- ============================================================================
--- § 7: Fragment Cross-Validation
--- ============================================================================
-
-section CrossValidation
+/-! ## Fragment cross-validation -/
 
 /-- Finnish Fragment inflection distribution is consistent with
     constructional A/Fin: categories split across neg aux and main verb. -/
@@ -721,64 +486,42 @@ theorem finnish_split_confirms_constructional :
     let dist := Finnish.Negation.finnishNegDistribution
     dist.onAux.length > 0 ∧ dist.onLex.length > 0 ∧
     finnish.asymmetryDimensions.contains .constructional := by
-  exact ⟨by native_decide, by native_decide, by native_decide⟩
+  refine ⟨?_, ?_, ?_⟩ <;> decide
 
-/-- Japanese Fragment distribution confirms constructional + paradigmatic:
-    tense moves from stem to suffix (both structural and paradigmatic change). -/
+/-- Japanese Fragment distribution shows the tense shift from stem to
+    suffix that Appendix III codes as constructional replacement
+    (A/Cat/TAM) alongside the A/Fin adjectivalization. -/
 theorem japanese_distribution_confirms_asymmetry :
     let dist := Japanese.Negation.japaneseNegDistribution
     dist.affirmativeOnStem.contains .tense = true ∧
     dist.negativeOnStem.contains .tense = false ∧
     dist.negativeOnSuffix.contains .tense = true ∧
-    japanese.asymmetryDimensions.contains .constructional ∧
-    japanese.asymmetryDimensions.contains .paradigmatic := by
-  exact ⟨by native_decide, by native_decide, by native_decide,
-         by native_decide, by native_decide⟩
+    japanese.asymmetryDimensions.contains .constructional := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
-/-- Turkish Fragment confirms SymAsy: 4 of 5 constructions are symmetric,
-    only the aorist is asymmetric. -/
+/-- Turkish Fragment confirms SymAsy: the aorist is the only asymmetric
+    construction in the *gelmek* paradigm. -/
 theorem turkish_fragment_confirms_symasy :
-    (Turkish.Negation.gelParadigm.filter (·.symmetric)).length = 4 ∧
-    (Turkish.Negation.gelParadigm.filter (fun e => !e.symmetric)).length = 1 ∧
-    turkish.symmetry == .both := by
-  exact ⟨by native_decide, by native_decide, rfl⟩
-
-/-- German Fragment confirms symmetric: all tenses available, negation is
-    just adding *nicht*. -/
-theorem german_fragment_confirms_symmetric :
-    German.Negation.allExamples.length = 5 ∧
-    german.asymmetryDimensions.isEmpty := by
-  exact ⟨by native_decide, rfl⟩
+    (Turkish.Negation.gelParadigm.filter (fun e => !e.symmetric)).map
+      (·.formLabel) = ["aorist"] ∧
+    turkish.symmetry == .both :=
+  ⟨Turkish.Negation.aorist_asymmetric, rfl⟩
 
 /-- Burmese Fragment confirms paradigmatic asymmetry: TAM neutralized
     (3 affirmative distinctions → 1 negative form). -/
 theorem burmese_fragment_confirms_paradigmatic :
     Burmese.Negation.burmeseTAM.affirmativeTAM.length = 3 ∧
     Burmese.Negation.burmeseTAM.negativeTAM.length = 1 ∧
-    burmese.asymmetryDimensions.contains .paradigmatic := by
-  exact ⟨rfl, rfl, by native_decide⟩
+    burmese.asymmetryDimensions.contains .paradigmatic :=
+  ⟨rfl, rfl, by decide⟩
 
-/-- French Fragment confirms symmetric: all tenses available under negation. -/
-theorem french_fragment_confirms_symmetric :
-    French.Negation.allExamples.length = 5 ∧
-    french.asymmetryDimensions.isEmpty := by
-  exact ⟨by native_decide, rfl⟩
-
-/-- Spanish Fragment confirms symmetric: all tenses available, *no* adds
-    negation without structural change. -/
-theorem spanish_fragment_confirms_symmetric :
-    Spanish.Negation.allExamples.length = 5 ∧
-    spanish.asymmetryDimensions.isEmpty := by
-  exact ⟨by native_decide, rfl⟩
-
-/-- Mandarin Fragment confirms SymAsy: 3 bù (symmetric) + 2 méi (asymmetric)
-    constructions, matching the constructional A/Fin classification. -/
+/-- Mandarin Fragment confirms SymAsy: the example set contains both
+    symmetric (bù) and asymmetric (méi) constructions. -/
 theorem mandarin_fragment_confirms_symasy :
-    (Mandarin.Negation.allExamples.filter (·.symmetric)).length = 3 ∧
-    (Mandarin.Negation.allExamples.filter (fun e => !e.symmetric)).length = 2 ∧
-    mandarin.symmetry == .both ∧
-    mandarin.asymmetryDimensions == [.constructional] := by
-  exact ⟨by native_decide, by native_decide, rfl, rfl⟩
+    Mandarin.Negation.allExamples.any (·.symmetric) = true ∧
+    Mandarin.Negation.allExamples.any (fun e => !e.symmetric) = true ∧
+    mandarin.symmetry == .both := by
+  refine ⟨?_, ?_, rfl⟩ <;> decide
 
 /-- Mandarin méi-yǒu connects to AspectComparison: the same particle is
     formalized as a cross-domain negative perfective there. -/
@@ -787,114 +530,44 @@ theorem mandarin_meiyou_cross_module :
     Mandarin.AspectComparison.meiyou.pinyin = "méi-yǒu" :=
   ⟨rfl, rfl⟩
 
-/-- English Fragment confirms SymAsy: 3 symmetric (modal, copula, aux have)
-    + 2 asymmetric (lexical verb with do-support). -/
-theorem english_fragment_confirms_symasy :
-    (English.Negation.allExamples.filter (·.symmetric)).length = 3 ∧
-    (English.Negation.allExamples.filter (fun e => !e.symmetric)).length = 2 ∧
-    english.symmetry == .both := by
-  exact ⟨by native_decide, by native_decide, rfl⟩
-
-/-- English do-support is exactly the asymmetric constructions. -/
+/-- English do-support is exactly the asymmetric constructions in the
+    Fragment's construction-level coding. The book instead treats AUX+not
+    as symmetric and locates English asymmetry in the emphatic paradigm
+    (see `english`); the fragment fact is stable under either construal. -/
 theorem english_dosupport_is_asymmetry :
     English.Negation.allExamples.all
       (fun e => e.symmetric == !e.doSupport) = true := by
-  native_decide
-
-/-- Russian Fragment confirms symmetric: all constructions available,
-    *не* adds negation without structural change. -/
-theorem russian_fragment_confirms_symmetric :
-    Russian.Negation.allExamples.length = 4 ∧
-    russian.asymmetryDimensions.isEmpty := by
-  exact ⟨by native_decide, rfl⟩
-
-/-- Russian negative concord: all n-words co-occur with *не*. -/
-theorem russian_concord_confirms_cooccur :
-    Russian.Negation.allConcordExamples.all
-      (fun e => (e.sentence.splitOn "не").length > 1) = true := by
-  native_decide
-
-/-- Czech Fragment confirms symmetric: all constructions available,
-    prefix *ne-* adds negation without structural change. -/
-theorem czech_fragment_confirms_symmetric :
-    Czech.Negation.allExamples.length = 4 ∧
-    czech.asymmetryDimensions.isEmpty := by
-  exact ⟨by native_decide, rfl⟩
-
-/-- Czech negative concord: all n-words co-occur with *ne-* prefix. -/
-theorem czech_concord_confirms_cooccur :
-    Czech.Negation.allConcordExamples.all
-      (fun e => (e.sentence.splitOn "ne").length > 1) = true := by
-  native_decide
+  decide
 
 /-- Maori Fragment confirms asymmetric: all constructions are A/Fin. -/
 theorem maori_fragment_confirms_asymmetric :
     Maori.Negation.allExamples.all (fun e => !e.symmetric) = true ∧
     maori.asymmetryDimensions.contains .constructional := by
-  exact ⟨by native_decide, by native_decide⟩
+  refine ⟨?_, ?_⟩ <;> decide
 
 /-- Hixkaryana Fragment confirms asymmetric A/Fin with copula finite. -/
 theorem hixkaryana_fragment_confirms_asymmetric :
     Hixkaryana.Negation.allExamples.all (fun e => !e.symmetric) = true ∧
     Hixkaryana.Negation.allExamples.all (·.copulaFinite) = true ∧
     hixkaryana.asymmetryDimensions.contains .constructional := by
-  exact ⟨by native_decide, by native_decide, by native_decide⟩
+  refine ⟨?_, ?_, ?_⟩ <;> decide
 
-/-- Imbabura Quechua Fragment confirms SymAsy: 1 symmetric + 2 asymmetric
-    constructions, with asymmetric = requiring -chu. -/
-theorem imbaburaQuechua_fragment_confirms_symasy :
-    (Quechua.Negation.allExamples.filter (·.symmetric)).length = 1 ∧
-    (Quechua.Negation.allExamples.filter (fun e => !e.symmetric)).length = 2 ∧
-    imbaburaQuechua.symmetry == .both := by
-  exact ⟨by native_decide, by native_decide, rfl⟩
-
-/-- Imbabura Quechua: -chu requirement is exactly the asymmetric constructions. -/
+/-- Imbabura Quechua Fragment confirms SymAsy, with the *-chu*
+    requirement marking exactly the asymmetric constructions. -/
 theorem imbaburaQuechua_chu_is_asymmetry :
+    Quechua.Negation.allExamples.any (·.symmetric) = true ∧
     Quechua.Negation.allExamples.all
-      (fun e => e.symmetric == !e.requiresChu) = true := by
-  native_decide
+      (fun e => e.symmetric == !e.requiresChu) = true ∧
+    imbaburaQuechua.symmetry == .both := by
+  refine ⟨?_, ?_, rfl⟩ <;> decide
 
-end CrossValidation
-
--- ============================================================================
--- § 8: Summary Statistics (linglib sample)
--- ============================================================================
-
-theorem sample_size : allData.length = 15 := by native_decide
-
-theorem symmetric_count :
-    (allData.filter (·.symmetry == .symmetric)).length = 6 := by native_decide
-theorem asymmetric_count :
-    (allData.filter (·.symmetry == .asymmetric)).length = 5 := by native_decide
-theorem symasy_count :
-    (allData.filter (·.symmetry == .both)).length = 4 := by native_decide
-
-theorem constructional_count :
-    (allData.filter (fun d => d.asymmetryDimensions.contains .constructional)).length = 7 := by
-  native_decide
-theorem paradigmatic_count :
-    (allData.filter (fun d => d.asymmetryDimensions.contains .paradigmatic)).length = 4 := by
-  native_decide
-theorem both_dimensions_count :
-    (allData.filter (fun d =>
-      d.asymmetryDimensions.contains .constructional &&
-      d.asymmetryDimensions.contains .paradigmatic)).length = 2 := by
-  native_decide
-
-theorem derived_count :
-    (allData.filter (·.asymmetrySource == some .derived)).length = 2 := by native_decide
-theorem independent_count :
-    (allData.filter (·.asymmetrySource == some .independent)).length = 7 := by native_decide
-
--- ============================================================================
--- § 9: Miestamo's 179-Language Survey Distribution (Table 3)
--- ============================================================================
+/-! ## Miestamo's 179-language survey distribution (Table 3) -/
 
 /-- Distribution from [miestamo-2005]'s 179-language representative
     sample (RS). These are the headline empirical results of Ch 4's
     typological survey. Note: the WALS Ch 113 sample (also by Miestamo)
     covers 297 languages with different numbers; those are captured
-    separately in `Typology.lean` via `Data.WALS.F113A`. -/
+    separately via `Data.WALS.F113A`. -/
 structure SurveyDistribution where
   totalLanguages : Nat
   symmetricOnly : Nat
@@ -918,7 +591,7 @@ def miestamo179 : SurveyDistribution :=
 theorem symasy_plurality :
     miestamo179.symAsy > miestamo179.symmetricOnly ∧
     miestamo179.symAsy > miestamo179.asymmetricOnly := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-- Purely asymmetric negation (type Asy) is the least common type.
     [miestamo-2005] p. 171: "symmetric negation is more common in
@@ -926,13 +599,13 @@ theorem symasy_plurality :
 theorem asymmetric_minority :
     miestamo179.asymmetricOnly < miestamo179.symmetricOnly ∧
     miestamo179.asymmetricOnly < miestamo179.symAsy := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-- Languages with any symmetric construction (S column in Table 3:
     Sym + SymAsy = 148, 83%) greatly outnumber purely asymmetric. -/
 theorem symmetric_constructions_common :
     miestamo179.symmetricOnly + miestamo179.symAsy > miestamo179.asymmetricOnly := by
-  native_decide
+  decide
 
 /-- Asymmetry subtype frequencies from [miestamo-2005] Table 5
     (p. 173). A/Cat is most common, A/Emph least common.
@@ -949,29 +622,24 @@ structure SubtypeDistribution where
 def subtypeDist : SubtypeDistribution :=
   { aFin := 45, aNonReal := 23, aEmph := 4, aCat := 59 }
 
-theorem acat_most_common : subtypeDist.aCat > subtypeDist.aFin := by native_decide
+theorem acat_most_common : subtypeDist.aCat > subtypeDist.aFin := by decide
+
 theorem aemph_least_common :
     subtypeDist.aEmph < subtypeDist.aNonReal ∧
     subtypeDist.aEmph < subtypeDist.aFin ∧
     subtypeDist.aEmph < subtypeDist.aCat := by
-  exact ⟨by native_decide, by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide, by decide⟩
 
--- ============================================================================
--- § 10: Implicational Universals
--- ============================================================================
+/-! ## Implicational universals -/
 
-section Universals
-
-/-- A/NonReal asymmetry is always paradigmatic, never constructional.
-    The irrealis category is a paradigmatic distinction (a new cell in the
-    paradigm), not a structural restructuring of the clause. -/
+/-- A/NonReal asymmetry in our sample is paradigmatic. -/
 theorem anonreal_implies_paradigmatic :
     (allData.filter (fun d =>
       d.asymmetrySubtype == .realityStatus ||
       d.asymmetrySubtype == .finAndNonReal ||
       d.asymmetrySubtype == .nonRealAndCat)).all
       (fun d => d.asymmetryDimensions.contains .paradigmatic) = true := by
-  native_decide
+  decide
 
 /-- A/NonReal asymmetry in our sample is never constructional.
     Note: this is a sample limitation (we have only 1 A/NonReal language).
@@ -982,30 +650,16 @@ theorem anonreal_never_constructional :
     (allData.filter (fun d =>
       d.asymmetrySubtype == .realityStatus)).all
       (fun d => !d.asymmetryDimensions.contains .constructional) = true := by
-  native_decide
+  decide
 
 /-- Symmetric-only negation never has paradigmatic asymmetry.
     By definition: if the paradigm is unchanged, negation is symmetric. -/
 theorem symmetric_no_paradigmatic :
     (allData.filter (·.symmetry == .symmetric)).all
       (fun d => !d.asymmetryDimensions.contains .paradigmatic) = true := by
-  native_decide
+  decide
 
-/-- Constructional asymmetry with a verbal negator is always derived:
-    a verb-type negator structurally entails finiteness restructuring,
-    so the asymmetry follows from the marker's properties. -/
-theorem verbal_constructional_always_derived :
-    (allData.filter (fun d =>
-      d.morphemeType == .auxVerb &&
-      d.asymmetryDimensions.contains .constructional)).all
-      (fun d => d.asymmetrySource == some .derived) = true := by
-  native_decide
-
-end Universals
-
--- ============================================================================
--- § 11: Bridge to Auxiliary Verb Literature
--- ============================================================================
+/-! ## Bridge to auxiliary verb literature -/
 
 section NegAuxBridge
 
@@ -1018,14 +672,13 @@ open Syntax.Negation (NegStrategy)
 theorem finnish_strategy_morpheme_consistent :
     NegStrategy.negVerb.toNegMorphemeType = finnish.morphemeType := rfl
 
-/-- Verbal negation strategy always implies constructional asymmetry
-    in both the auxiliary literature (creates an AVC) and the negation
-    typology (derived A/Fin). -/
+/-- Verbal negation strategy implies constructional asymmetry in both
+    the auxiliary literature (creates an AVC) and the negation typology
+    (A/Fin). -/
 theorem neg_verb_implies_avc_and_afin :
     NegStrategy.negVerb.isVerbal = true ∧
-    finnish.asymmetryDimensions.contains .constructional ∧
-    finnish.asymmetrySource == some .derived := by
-  exact ⟨rfl, by native_decide, rfl⟩
+    finnish.asymmetryDimensions.contains .constructional := by
+  exact ⟨rfl, by decide⟩
 
 end NegAuxBridge
 

--- a/Linglib/Studies/VanDerAuweraVanAlsenoy2016.lean
+++ b/Linglib/Studies/VanDerAuweraVanAlsenoy2016.lean
@@ -33,8 +33,7 @@ open Features.NegativeConcord (NWordStatus)
 
 /-- Whether the negative-indefinite system shows negative concord
     ([van-der-auwera-van-alsenoy-2016]): WALS 115A `cooccur` (concord) and `mixed`
-    (position-dependent) do; `preclude` (double negation) and `negExistential` do not.
-    Broader than `NegationProfile.hasNegConcord`, which tests `cooccur` only. -/
+    (position-dependent) do; `preclude` (double negation) and `negExistential` do not. -/
 def hasNegativeConcord : NegIndefiniteStrategy → Bool
   | .cooccur | .mixed => true
   | .preclude | .negExistential => false

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -19,8 +19,7 @@ asymmetric status, asymmetry subtype, and negative-indefinite strategy.
 Mirrors the `Linglib/Features/Possession.lean` (Possession), `Question.lean`
 (Question), and `Case.lean` (Case) substrate-extension pattern: the
 substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
-`NegationSystem`), (b) the WALS-bundled per-language `NegationProfile`,
-(c) WALS converters and sample-counting helpers.
+`NegationSystem`), (b) WALS converters and per-ISO accessors.
 
 ## What lives here
 
@@ -44,21 +43,18 @@ substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
   ([anderson-2006], [heine-1993]), with bridges to Anderson's AVC
   patterns (`expectedInflPattern`), Heine's grammaticalization cline
   (`toGramStage`), and WALS Ch 112 (`toNegMorphemeType`).
-- `NegationProfile` — sibling per-language schema bundling Ch 112-115 +
-  Greco's `negIsHead` + JinKoenig's `enAttested`. Each Fragment exposes
-  `def negationProfile : NegationProfile` alongside `def negationSystem`:
-  the marker-side joint is independent from the typology-feature joint.
-- `ofWALS112A`/`fromWALS113A`/`114A`/`115A`/`143A` converters.
-- `countByMorphemeType`/`countBySymmetry` sample-counting helpers (consumed by
-  `Studies/Dryer2013Negation.lean`).
+- `ofWALS112A`/`fromWALS113A`/`114A`/`115A`/`143A` converters, and the
+  per-ISO accessors `morphemeTypeOfISO`/`symmetryOfISO`/
+  `asymmetrySubtypeOfISO`/`negIndefiniteOfISO` (study-consumed; `none`
+  when the language is not in the chapter's WALS sample).
 
 ## Theory-laden caveats
 
 `NegSymmetry` and `AsymmetrySubtype` are **WALS Ch 113/114** values
 ([dryer-haspelmath-2013]). [miestamo-2005]'s richer
-two-dimension framework (constructional vs paradigmatic asymmetry,
-derived vs independent source) lives in `Studies/Miestamo2005.lean`
-because it goes beyond what WALS encodes.
+two-dimension framework (constructional vs paradigmatic asymmetry)
+lives in `Studies/Miestamo2005.lean` because it goes beyond what
+WALS encodes.
 
 ## Out of scope
 
@@ -197,7 +193,7 @@ inductive NegMorphemePosition where
 /-- One language's standard sentential negation marker. -/
 structure NegMarkerEntry where
   /-- Surface form. For affixal negation this is an abstract citation form
-      (e.g., Turkish `-mE-` for the harmony-conditioned `-ma-` / `-me-`
+      (e.g., Turkish `-mA-` for the harmony-conditioned `-ma-` ~ `-me-`
       alternants). For tonal/morphological negation use `position :=
       .morphological` and document the realization in the `def` docstring. -/
   form : String
@@ -220,6 +216,9 @@ structure NegMarkerEntry where
     F112A/F143A/F144A take one value per language regardless of how many
     markers the language has. -/
 structure NegationSystem where
+  /-- ISO 639-3 code; populated by `NegationSystem.ofISO` and the key
+      for the per-ISO WALS accessors below. -/
+  iso : String := ""
   /-- Standard negation marker(s). Order is editorial; Fragment files
       should put the unmarked / default-context marker first. -/
   markers : List NegMarkerEntry
@@ -235,42 +234,6 @@ structure NegationSystem where
   wals144A :
     Option Data.WALS.F144A.PositionOfNegativeWordWithRespectToSubjectObjectAndVerb
     := none
-  deriving Repr
-
-/-! ### NegationProfile (Fragment typology-feature joint) -/
-
-/-- A language's negation profile across WALS Chapters 112-115, plus
-    fields from [greco-2020] (`negIsHead`) and [jin-koenig-2021]
-    (`enAttested`).
-
-    Sibling Fragment-side joint to `NegationSystem`: every
-    `Fragments/{Lang}/Negation.lean` exposes `def negationProfile :
-    NegationProfile`. The two joints are independent because the data
-    partition is real: `negationSystem.markers` is consumed by lexical
-    code; `negationProfile` is consumed by typology studies. -/
-structure NegationProfile where
-  /-- Language name. -/
-  language : String
-  /-- ISO 639-3 code. -/
-  iso : String := ""
-  /-- Ch 112: how standard negation is expressed. -/
-  morphemeType : NegMorphemeType
-  /-- Ch 113: symmetric, asymmetric, or both. -/
-  symmetry : NegSymmetry
-  /-- Ch 114: asymmetry subtype (`nonAssignable` if symmetric only). -/
-  asymmetrySubtype : AsymmetrySubtype
-  /-- Ch 115: strategy for negative indefinites, if attested. -/
-  negIndefinite : Option NegIndefiniteStrategy := none
-  /-- Illustrative negative marker form(s). -/
-  negMarkers : List String := []
-  /-- Is the negation marker a syntactic head (X°) rather than a phrase (XP)?
-      Relevant for [greco-2020]: only head-status markers can merge in
-      CP to produce surprise negation. -/
-  negIsHead : Option Bool := none
-  /-- Is expletive negation attested in this language?
-      [jin-koenig-2021] (722-language survey: EN in 74 languages)
-      and [rett-2026]. -/
-  enAttested : Option Bool := none
   deriving Repr
 
 /-! ### Expletive negation triggers -/
@@ -355,39 +318,30 @@ def fromWALS143A : Data.WALS.F143A.NegVerbOrder → NegVerbPosition
     pulling F112A / F143A / F144A values from the `Data.WALS` data. -/
 def NegationSystem.ofISO (iso : String) (markers : List NegMarkerEntry) :
     NegationSystem :=
-  { markers
+  { iso
+  , markers
   , wals112A := (Data.WALS.F112A.lookupISO iso).map (·.value)
   , wals143A := (Data.WALS.F143A.lookupISO iso).map (·.value)
   , wals144A := (Data.WALS.F144A.lookupISO iso).map (·.value)
   }
 
-/-! ### NegationProfile helpers (Fragment-consumed) -/
+/-! ### Per-ISO WALS accessors (study-consumed) -/
 
-/-- Does a language use a given morpheme type? -/
-def NegationProfile.hasMorphemeType (p : NegationProfile)
-    (t : NegMorphemeType) : Bool :=
-  p.morphemeType == t
+/-- WALS Ch 112A value for a language, as `NegMorphemeType`. -/
+def morphemeTypeOfISO (iso : String) : Option NegMorphemeType :=
+  (Data.WALS.F112A.lookupISO iso).map (ofWALS112A ·.value)
 
-/-- Does a language have symmetric negation (either symmetric only or both)? -/
-def NegationProfile.hasSymmetric (p : NegationProfile) : Bool :=
-  p.symmetry == .symmetric || p.symmetry == .both
+/-- WALS Ch 113A value for a language, as `NegSymmetry`. -/
+def symmetryOfISO (iso : String) : Option NegSymmetry :=
+  (Data.WALS.F113A.lookupISO iso).map (fromWALS113A ·.value)
 
-/-- Does a language have asymmetric negation (either asymmetric only or both)? -/
-def NegationProfile.hasAsymmetric (p : NegationProfile) : Bool :=
-  p.symmetry == .asymmetric || p.symmetry == .both
+/-- WALS Ch 114A value for a language, as `AsymmetrySubtype`. -/
+def asymmetrySubtypeOfISO (iso : String) : Option AsymmetrySubtype :=
+  (Data.WALS.F114A.lookupISO iso).map (fromWALS114A ·.value)
 
-/-- Does a language show negative concord? -/
-def NegationProfile.hasNegConcord (p : NegationProfile) : Bool :=
-  p.negIndefinite == some .cooccur
-
-/-- Count of languages in a sample with a given morpheme type. -/
-def countByMorphemeType (langs : List NegationProfile)
-    (t : NegMorphemeType) : Nat :=
-  (langs.filter (·.hasMorphemeType t)).length
-
-/-- Count of languages in a sample with a given symmetry type. -/
-def countBySymmetry (langs : List NegationProfile) (s : NegSymmetry) : Nat :=
-  (langs.filter (·.symmetry == s)).length
+/-- WALS Ch 115A value for a language, as `NegIndefiniteStrategy`. -/
+def negIndefiniteOfISO (iso : String) : Option NegIndefiniteStrategy :=
+  (Data.WALS.F115A.lookupISO iso).map (fromWALS115A ·.value)
 
 /-! ### Negation strategy and the AVC bridge
 [anderson-2006] [heine-1993] [miestamo-2005]
@@ -407,7 +361,7 @@ open Grammaticalization (GramStage)
 inductive NegStrategy where
   /-- Negative auxiliary verb that inflects (Finnish *ei*, Komi *oz*). -/
   | negVerb
-  /-- Bound negative morpheme (e.g., Turkish *-mE-*). -/
+  /-- Bound negative morpheme (e.g., Turkish *-mA-*). -/
   | negAffix
   /-- Free negative particle (English *not*, Italian *non*). -/
   | negParticle


### PR DESCRIPTION
Dissolves the hand-stipulated `NegationProfile` XProfile: fragments keep the `negationSystem` marker joint (now carrying `iso`); studies read WALS Ch 112A-115A values via new per-ISO accessors in `Syntax.Negation`; Greco 2020's negIsHead classification goes study-local; the 45 per-language rfl consistency bridges in Miestamo2005 collapse to 3 consolidated WALS checks. Also corrects Miestamo2005 codings against the book (Appendix III): Turkish aorist and Japanese are constructional (not paradigmatic), English is A/Emph paradigmatic (WALS divergence now an explicit theorem), and the derived/independent `asymmetrySource` field misread §3.3.6 and is removed.

- Burmese/Maori profiles omitted WALS 115A values that the accessor path now surfaces; Czech (absent from Miestamo's RS and WALS 113A-115A) is flagged as criteria-applied extrapolation
- Turkish fragment: audit golf (single list-equality theorem replaces three count theorems, docstring scope/notation fixes)
- All `native_decide` in the touched studies replaced with `decide` (scoped `maxRecDepth` for the 1157-row Ch 112A table)