### PR TITLE
refactor(Fragments/Greek/StandardModern): complementizers audit cleanse

### DIFF
--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -10,25 +10,29 @@ entries, and the matrix verbs that select them (with the attitude and
 stativity metadata [angelopoulos-2026]'s data turns on).
 
 [angelopoulos-2026]-specific apparatus — the [n]-feature/light-noun
-selection (§3.1), the content/situation typing, and the stativity
-generalizations — lives in `Studies/Angelopoulos2026.lean` as
-projections over these entries.
+selection (§3.1), the content/situation typing, the attested selection
+classes, and the stativity generalizations — lives in
+`Studies/Angelopoulos2026.lean` as projections over these entries.
 -/
 
 namespace Greek.StandardModern.Complementizers
 
 /-- *oti* — indicative declarative complementizer ([christidis-1982],
-    [roussou-2010]); selected by verbs of saying / belief / knowledge. -/
+    [roussou-2010]); selected by verbs of saying / belief / knowledge.
+    Factivity of *oti*-clauses tracks the matrix verb (*kséro* vs
+    *léo*), so no lexical `factive` value is recorded. -/
 def oti : Complementizer where
   form := "oti"
   position := some .detached
   noonanType := some .indicative
   clauseForm := some .declarative
-  factive := some false
 
 /-- *pu* — factive complementizer ([christidis-1982], [roussou-2019]);
-    selected by emotive factives. Doubles as adverbial / relative /
-    interrogative *where*; the entry records the complement use. -/
+    selected by emotive factives, and by perception/memory verbs on
+    direct-perception readings ([angelopoulos-2026] fn. 16). Doubles as
+    adverbial / relative / interrogative *where* ([angelopoulos-2026]
+    unifies the uses via a PLACE noun); the entry records the
+    complement use. -/
 def pu : Complementizer where
   form := "pu"
   position := some .detached
@@ -36,8 +40,10 @@ def pu : Complementizer where
   clauseForm := some .declarative
   factive := some true
 
-/-- *na* — subjunctive ([grano-2024]); the substantive mood entries are
-    in `MoodChoice.lean`, exposed here for inventory completeness. -/
+/-- *na* — subjunctive ([grano-2024]); the *na*-selecting mood-choice
+    verbs are in `MoodChoice.lean`. Whether *na* heads C or a Mood
+    projection is debated; the schema is head-agnostic, and
+    [angelopoulos-2026] sets *na* aside. -/
 def na : Complementizer where
   form := "na"
   position := some .detached
@@ -46,12 +52,10 @@ def na : Complementizer where
 /-- The complementizer inventory. -/
 def complementizers : List Complementizer := [oti, pu, na]
 
--- ════════════════════════════════════════════════════════════════
--- § 2. Matrix Verbs Selecting *oti*
--- ════════════════════════════════════════════════════════════════
---
--- Verbs of saying / belief / knowledge / understanding. All take
--- *oti*-complements per [angelopoulos-2026] ex. 1a, 3, 36, etc.
+/-! ### Matrix verbs selecting *oti*
+
+Verbs of saying / belief / knowledge / understanding
+([angelopoulos-2026] ex. 1a, 3, 36). -/
 
 /-- *léo* (λέω) 'say' — past tense *ípe* in [angelopoulos-2026]
     ex. 1a. Speech-act verb, eventive (activity). -/
@@ -61,13 +65,13 @@ def leo : Verb where
   speechActVerb := true
   vendlerClass := some .activity
 
-/-- *pistévo* (πιστεύω) 'believe' — doxastic, stative. -/
+/-- *pistévo* (πιστεύω) 'believe' — doxastic, stative; the impersonal
+    passive *pistévetai oti* is standard. -/
 def pistevo : Verb where
   form := "pistévo"
   frames := [Frame.finiteClause]
   attitude := some (.doxastic .nonVeridical)
   vendlerClass := some .state
-  passivizable := false
   opaqueContext := true
 
 /-- *kséro* (ξέρω) 'know' (alongside *gnorízo*) — factive doxastic,
@@ -77,10 +81,9 @@ def ksero : Verb where
   frames := [Frame.finiteClause]
   attitude := some (.doxastic .veridical)
   vendlerClass := some .state
-  opaqueContext := false  -- factive ⇒ no opacity
 
 /-- *katalavéno* (καταλαβαίνω) 'understand' — eventive (allows
-    manner adverbs in [angelopoulos-2026] ex. 21b, 22a),
+    manner adverbs in [angelopoulos-2026] ex. 21b),
     factive doxastic. -/
 def katalaveno : Verb where
   form := "katalavéno"
@@ -103,12 +106,10 @@ def eksigo : Verb where
   frames := [Frame.finiteClause]
   vendlerClass := some .accomplishment
 
--- ════════════════════════════════════════════════════════════════
--- § 3. Matrix Verbs Selecting *pu*
--- ════════════════════════════════════════════════════════════════
---
--- Emotive-factive predicates. Stative when taking *pu*-complements
--- ([angelopoulos-2026] §2.3 stativity restriction).
+/-! ### Matrix verbs selecting *pu*
+
+Emotive-factive predicates, stative under [angelopoulos-2026]'s §2.3
+stativity restriction. -/
 
 /-- *metanióno* (μετανιώνω) 'regret' — preferential (negative
     valence), stative. [angelopoulos-2026] ex. 1b, 20. -/
@@ -119,7 +120,7 @@ def metaniono : Verb where
   vendlerClass := some .state
 
 /-- *aréso* (αρέσω) 'appeal to / be liked by' — Class III experiencer,
-    stative ([angelopoulos-2026] ex. 13, 14; [landau-2009]). -/
+    stative ([angelopoulos-2026] ex. 13, 14; [landau-2010]). -/
 def areso : Verb where
   form := "aréso"
   frames := [Frame.finiteClause]
@@ -135,34 +136,47 @@ def xerome : Verb where
   attitude := some (.preferential (.degreeComparison .positive))
   vendlerClass := some .state
 
--- ════════════════════════════════════════════════════════════════
--- § 4. Verbs Compatible with Both *oti* and *pu*
--- ════════════════════════════════════════════════════════════════
---
--- Verbs whose stativity matters: with *oti* they are eventive,
--- with *pu* they shift to stative interpretation
--- ([angelopoulos-2026] ex. 22, fn 16). Polysemy handled via
--- sense tags rather than separate entries — the eventive sense is
--- the citation form here; the stative/perception sense is left
--- to be tracked in the consuming Studies file.
+/-! ### Verbs compatible with both *oti* and *pu*
 
-/-- *thimáme* (θυμάμαι) 'remember' — ambiguous between direct-
-    perception (eventive, with *oti*) and stative recollection
-    (with *pu*). Citation form is the eventive one;
-    [angelopoulos-2026] ex. 22 contrasts the two. -/
+Eventive with *oti*, stative with *pu* ([angelopoulos-2026] ex. 19,
+22–23, fn. 16). Both complements are finite indicative clauses, so the
+polysemy rides on sense-tagged entry pairs (`SenseTag.stative`, the
+`suivreStat` pattern) rather than frame-keyed `Verb.readings` rows. -/
+
+/-- *thimáme* (θυμάμαι) 'remember' — eventive direct-perception sense,
+    the one available with *oti* ([angelopoulos-2026] ex. 22); the
+    stative recollection sense is `thimameStat`. -/
 def thimame : Verb where
   form := "thimáme"
   frames := [Frame.finiteClause]
   attitude := some (.doxastic .veridical)
-  vendlerClass := some .achievement  -- eventive (perception) sense
+  vendlerClass := some .achievement
 
-/-- *thimóno* (θυμώνω) 'get/be angry' — eventive (achievement)
-    normally; stative when taking *pu* ([angelopoulos-2026]
-    ex. 19, 23). -/
+/-- *thimáme* — stative recollection sense, the one available with
+    *pu* ([angelopoulos-2026] ex. 22, fn. 16). -/
+def thimameStat : Verb where
+  form := "thimáme"
+  frames := [Frame.finiteClause]
+  senseTag := .stative
+  attitude := some (.doxastic .veridical)
+  vendlerClass := some .state
+
+/-- *thimóno* (θυμώνω) 'get angry' — eventive (achievement) sense, the
+    one available with *oti*; the stative sense is `thimonoStat`
+    ([angelopoulos-2026] ex. 19, 23). -/
 def thimono : Verb where
   form := "thimóno"
   frames := [Frame.finiteClause]
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .achievement
+
+/-- *thimóno* — stative 'be angry' sense, the one available with *pu*
+    ([angelopoulos-2026] ex. 19, 23). -/
+def thimonoStat : Verb where
+  form := "thimóno"
+  frames := [Frame.finiteClause]
+  senseTag := .stative
+  attitude := some (.preferential (.degreeComparison .negative))
+  vendlerClass := some .state
 
 end Greek.StandardModern.Complementizers

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -36,13 +36,17 @@ yields either composition mode.
 ## Main declarations
 
 - `bearsN` — the §3.1 [n]-feature datum over the fragment entries
+- `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`, `factivity_anti_aligned` —
+  the attested selection classes (§1–§2.3) and the emotive/cognitive
+  factivity split they carry
 - `NounHost`, `ClausePosition`, `licensedIn` — the incorporation
   mechanism and the derived argument-position asymmetry
 - `selectsClause`, `pu_requires_stative` — the §4.1 stativity locus
 - `clauseSort` — *oti* = content, *pu* = situation, consuming
   `Bondarenko2022.NominalSort` (§3.2 ex. 33–34)
 - `bareOtiAttested`, `transparency_conflates_axes` — the §7.3
-  counterclaim against `Bondarenko2022.transparentSSMapping`
+  counterclaim against `Bondarenko2022.transparentSSMapping`, stated
+  over `Bondarenko2022.CompositionPath`
 
 Typed paradigm sentences (ex. 1, 31–34) live in `Angelopoulos2026.Examples`,
 generated from `Data/Examples/Angelopoulos2026.json`.
@@ -51,7 +55,7 @@ generated from `Data/Examples/Angelopoulos2026.json`.
 namespace Angelopoulos2026
 
 open Greek.StandardModern.Complementizers
-open Bondarenko2022 (NominalSort)
+open Bondarenko2022 (NominalSort CompositionPath)
 
 /-! ### Reversed selection: the [n]-feature (§3.1) -/
 
@@ -64,6 +68,38 @@ def bearsN (c : Complementizer) : Prop := c = oti ∨ c = pu
 
 instance : DecidablePred bearsN := fun c => by
   unfold bearsN; infer_instance
+
+/-! ### The attested selection classes (§1–§2.3) -/
+
+/-- Matrix verbs attested with *oti* only (ex. 1a, 3–4, 21): saying,
+belief, knowledge. Study-local lists: the analysis derives selection
+from light-noun incorporation and aspectual-head selection (§3.1,
+§4.1), so no verb-level feature records it. -/
+def otiOnlyVerbs : List Verb :=
+  [leo, pistevo, ksero, katalaveno, sinidhitopio, eksigo]
+
+/-- Matrix verbs attested with *pu* only (ex. 1b, 13–14, 20): the
+emotive factives. -/
+def puOnlyVerbs : List Verb := [metaniono, areso, xerome]
+
+/-- Verbs attested with both (ex. 19, 22–23), as (eventive *oti*-sense,
+stative *pu*-sense) pairs of sense-tagged fragment entries. -/
+def dualVerbs : List (Verb × Verb) :=
+  [(thimame, thimameStat), (thimono, thimonoStat)]
+
+/-- The emotive/cognitive factivity split: verb-level and C-level
+factivity are anti-aligned on the sample. The complement-presupposing
+verbs (`Verb.factivePresup`: *kséro*, *katalavéno*, *sinidhitopió*)
+select *oti*, which records no lexical factive presupposition, while
+the *pu*-only emotive factives all escape `factivePresup` (preferential
+rather than veridical-doxastic attitude) yet select lexically factive
+*pu*. Complement factivity thus has two independent sources — verb and
+complementizer — which the Greek data tease apart. -/
+theorem factivity_anti_aligned :
+    oti.factive = none ∧ pu.factive = some true ∧
+    (∀ v ∈ [ksero, katalaveno, sinidhitopio], v.factivePresup = true) ∧
+    (∀ v ∈ puOnlyVerbs, v.factivePresup = false) := by
+  decide
 
 /-! ### Incorporation licensing and the argument asymmetry (§3.1) -/
 
@@ -142,9 +178,16 @@ theorem pu_requires_stative (h : AspectualHead)
   · exact absurd (show pu = oti from hp) (by decide)
 
 /-- The verb-level reflex over the fragment sample: the *pu*-only
-matrix verbs (ex. 1b, 13–14, 20) are all stative. -/
+matrix verbs are all stative. -/
 theorem pu_only_verbs_stative :
-    ∀ v ∈ [metaniono, areso, xerome], v.vendlerClass = some .state := by
+    ∀ v ∈ puOnlyVerbs, v.vendlerClass = some .state := by
+  decide
+
+/-- The dual verbs realize the same restriction sense-internally:
+stative *pu*-sense, non-stative *oti*-sense (ex. 19, 22–23). -/
+theorem dual_verbs_stative_with_pu :
+    ∀ p ∈ dualVerbs, p.2.vendlerClass = some .state ∧
+      p.1.vendlerClass ≠ some .state := by
   decide
 
 /-! ### Content vs situation (§3.2) -/
@@ -178,27 +221,23 @@ inductive SynPosition where
   | adjunct
   deriving DecidableEq, Repr
 
-/-- Composition mode — the other axis. -/
-inductive CompMode where
-  | pm
-  | fa
-  deriving DecidableEq, Repr
-
-/-- The paper's claim for bare *oti*-clauses (§2 diagnostics + §7.3):
-complement position composing via PM is attested (the explanans
-reading); FA requires the nominalizing D (§7.3 ex. 57), so bare
-clauses never compose via FA from either position. -/
-def bareOtiAttested : SynPosition → CompMode → Prop
-  | .complement, .pm => True
-  | .complement, .fa => False
-  | .adjunct,    .pm => True
-  | .adjunct,    .fa => False
+/-- The paper's claim for bare *oti*-clauses (§2 diagnostics + §7.3),
+on the composition axis of [bondarenko-2022]'s `CompositionPath` (PM
+with the verb's situation argument = `viaSituation`, FA into a DP slot
+= `viaDPArgument`): complement position composing via PM is attested
+(the explanans reading); FA requires the nominalizing D (§7.3 ex. 57),
+so bare clauses never compose via FA from either position. -/
+def bareOtiAttested : SynPosition → CompositionPath → Prop
+  | .complement, .viaSituation  => True
+  | .complement, .viaDPArgument => False
+  | .adjunct,    .viaSituation  => True
+  | .adjunct,    .viaDPArgument => False
 
 /-- [bondarenko-2022]'s transparent mapping restated on the split
 axes: a bare clause composing via PM must be a syntactic adjunct
 (the composition path is reflected in syntax). -/
-def transparentBare : SynPosition → CompMode → Prop
-  | .adjunct, .pm => True
+def transparentBare : SynPosition → CompositionPath → Prop
+  | .adjunct, .viaSituation => True
   | _, _ => False
 
 /-- The §7.3 divergence: bare *oti*-clauses occupy complement position
@@ -209,8 +248,8 @@ layer and Faure's case-less-DP treatment, §3.1) and are internal
 ARGUMENTS (clitic doubling, passivization, derived subjects,
 §2.1–2.2). [bondarenko-2022] can deny either premise. -/
 theorem diverges_from_transparent_mapping :
-    bareOtiAttested .complement .pm ∧
-    ¬ transparentBare .complement .pm :=
+    bareOtiAttested .complement .viaSituation ∧
+    ¬ transparentBare .complement .viaSituation :=
   ⟨trivial, fun h => h⟩
 
 /-- Against `Bondarenko2022.transparentSSMapping` directly: Bondarenko
@@ -221,7 +260,7 @@ argumenthood for bare clauses WITHOUT FA — the identification of the
 two axes is what fails. -/
 theorem transparency_conflates_axes :
     ¬ Bondarenko2022.transparentSSMapping .bareArgument ∧
-    bareOtiAttested .complement .pm :=
+    bareOtiAttested .complement .viaSituation :=
   ⟨Bondarenko2022.bare_argument_predicted_impossible, trivial⟩
 
 end Angelopoulos2026

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -34530,6 +34530,21 @@
   sources   = {Fragments/Greek/StandardModern/Complementizers.lean}
 }
 
+@book{landau-2010,
+  author    = {Landau, Idan},
+  year      = {2010},
+  title     = {The Locative Syntax of Experiencers},
+  series    = {Linguistic Inquiry Monographs},
+  number    = {53},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA},
+  isbn      = {978-0-262-01330-7},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {cited},
+  sources   = {Fragments/Greek/StandardModern/Complementizers.lean}
+}
+
 @incollection{zeijlstra-2020,
   author    = {Zeijlstra, Hedde},
   year      = {2020},


### PR DESCRIPTION
Deep-audit cleanse of the Greek complementizer fragment + its Angelopoulos2026 study; every paper-location citation verified against the paper.

- fix broken `[landau-2009]` key (verified `landau-2010` bib entry), drop the wrong ex. 22a cite on *katalaveno*, record `oti.factive := none` per the schema's own convention
- sense-tagged stative entries for *thimame*/*thimono* (`suivreStat` pattern); typed selection classes + the emotive/cognitive factivity anti-alignment theorem; `CompMode` retired for `Bondarenko2022.CompositionPath`