### PR TITLE
feat(Core): Finset.argmax and PMF.uniformOfArgmax choice rule

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -262,9 +262,11 @@ import Linglib.Core.Order.SimilarityOrdering
 import Linglib.Core.Order.StrictBounds
 import Linglib.Core.Order.TotalPreorder
 import Linglib.Core.Order.Tree
+import Linglib.Core.Order.Argmax
 import Linglib.Core.Order.TreePath
 import Linglib.Core.Order.UpperLower.Closure
 import Linglib.Core.Probability.BayesianUpdate
+import Linglib.Core.Probability.Choice.Argmax
 import Linglib.Core.Probability.Choice.ChoiceApproximations
 import Linglib.Core.Probability.Choice.GumbelLuce
 import Linglib.Core.Probability.Choice.RankOrderings

--- a/Linglib/Core/Order/Argmax.lean
+++ b/Linglib/Core/Order/Argmax.lean
@@ -1,0 +1,59 @@
+import Mathlib.Data.Finset.Max
+
+/-!
+# The argmax set of a function on a finset
+
+`Finset.argmax s f` is the finset of elements of `s` at which `f` attains its
+maximum over `s`. Mathlib has only the tie-breaking `List.argmax : List α →
+Option α`; the set-valued form is the natural companion of `Finset.max'` and
+`Finset.exists_max_image`, and the carrier for argmax *correspondences*
+(set-valued best responses) in game-theoretic consumers.
+
+[UPSTREAM] candidate: `Mathlib.Data.Finset.Max`.
+
+## Main definitions
+
+* `Finset.argmax s f` — the score-maximal elements of `s`.
+
+## Main statements
+
+* `mem_argmax` — membership characterization (simp normal form).
+* `argmax_nonempty` — nonempty on nonempty input (via `exists_max_image`).
+* `argmax_comp_strictMono` — invariance under strictly monotone rescaling.
+-/
+
+set_option autoImplicit false
+
+namespace Finset
+
+variable {α β γ : Type*} [LinearOrder β] [LinearOrder γ] {s : Finset α}
+  {f : α → β} {a : α}
+
+/-- The elements of `s` at which `f` attains its maximum over `s`. -/
+def argmax (s : Finset α) (f : α → β) : Finset α :=
+  s.filter fun a => ∀ b ∈ s, f b ≤ f a
+
+@[simp]
+theorem mem_argmax : a ∈ s.argmax f ↔ a ∈ s ∧ ∀ b ∈ s, f b ≤ f a :=
+  mem_filter
+
+theorem argmax_subset : s.argmax f ⊆ s :=
+  filter_subset _ _
+
+theorem argmax_nonempty (hs : s.Nonempty) : (s.argmax f).Nonempty := by
+  obtain ⟨a, ha, hmax⟩ := s.exists_max_image f hs
+  exact ⟨a, mem_argmax.mpr ⟨ha, hmax⟩⟩
+
+/-- The argmax set is invariant under strictly monotone rescaling of the
+score — inverse-temperature changes do not move the argmax. -/
+theorem argmax_comp_strictMono {g : β → γ} (hg : StrictMono g) :
+    s.argmax (g ∘ f) = s.argmax f := by
+  ext a
+  simp only [mem_argmax, Function.comp_apply, hg.le_iff_le]
+
+@[simp]
+theorem argmax_const (c : β) : s.argmax (fun _ => c) = s := by
+  ext a
+  simp
+
+end Finset

--- a/Linglib/Core/Probability/Choice/Argmax.lean
+++ b/Linglib/Core/Probability/Choice/Argmax.lean
@@ -1,0 +1,88 @@
+import Mathlib.Probability.Distributions.Uniform
+import Linglib.Core.Order.Argmax
+
+/-!
+# Uniform-over-argmax choice rule
+
+`PMF.uniformOfArgmax score` is the PMF uniform over the score-maximal
+elements (`Finset.argmax`). It is the hard-choice sibling of `PMF.softmax`
+(`Core/Probability/Softmax.lean`): as the inverse temperature inside a
+softmax score grows without bound, softmax mass concentrates on the argmax
+set (`Core/Probability/SoftmaxLimits.lean` proves the ℝ-level limit).
+Iterated-best-response models ([franke-2011]) use this rule where RSA
+([frank-goodman-2012]) uses softmax.
+
+## Main definitions
+
+* `PMF.uniformOfArgmax score` — uniform PMF over `Finset.univ.argmax score`.
+
+## Main statements
+
+* `support_uniformOfArgmax` — the support is the argmax set.
+* `uniformOfArgmax_apply_pos_iff` — positive mass iff score-maximal.
+* `uniformOfArgmax_comp_strictMono` — invariance under strictly monotone
+  rescaling of the score (inverse-temperature invariance).
+-/
+
+set_option autoImplicit false
+
+open scoped ENNReal
+
+namespace PMF
+
+variable {α β γ : Type*} [Fintype α] [Nonempty α] [LinearOrder β] [LinearOrder γ]
+
+/-! ## Definition -/
+
+/-- The **argmax choice rule**: uniform distribution over the score-maximal
+elements. Hard-choice counterpart of `PMF.softmax`; the selection rule of
+iterated-best-response models ([franke-2011]). -/
+noncomputable def uniformOfArgmax (score : α → β) : PMF α :=
+  uniformOfFinset (Finset.univ.argmax score)
+    (Finset.argmax_nonempty Finset.univ_nonempty)
+
+/-! ## API -/
+
+/-- The support of the argmax choice rule is the argmax set. -/
+@[simp]
+theorem support_uniformOfArgmax (score : α → β) :
+    (uniformOfArgmax score).support = ↑(Finset.univ.argmax score) :=
+  support_uniformOfFinset _
+
+/-- The argmax choice rule assigns positive mass exactly to the
+score-maximal elements. -/
+theorem uniformOfArgmax_apply_pos_iff (score : α → β) (a : α) :
+    0 < uniformOfArgmax score a ↔ ∀ b, score b ≤ score a := by
+  rw [pos_iff_ne_zero, ← mem_support_iff, support_uniformOfArgmax]
+  simp
+
+/-- Mass of a score-maximal element: one over the size of the argmax set. -/
+theorem uniformOfArgmax_apply_of_max (score : α → β) (a : α)
+    (ha : ∀ b, score b ≤ score a) :
+    uniformOfArgmax score a = ((Finset.univ.argmax score).card : ℝ≥0∞)⁻¹ :=
+  uniformOfFinset_apply_of_mem _
+    (Finset.mem_argmax.mpr ⟨Finset.mem_univ a, fun b _ => ha b⟩)
+
+/-- Non-maximal elements get zero mass. -/
+theorem uniformOfArgmax_apply_of_not_max (score : α → β) (a : α)
+    (ha : ¬ ∀ b, score b ≤ score a) :
+    uniformOfArgmax score a = 0 :=
+  uniformOfFinset_apply_of_notMem _ (by simpa using ha)
+
+/-- The argmax choice rule is invariant under strictly monotone rescaling of
+the score: changing the inverse temperature does not move the hard choice. -/
+theorem uniformOfArgmax_comp_strictMono (score : α → β) {g : β → γ}
+    (hg : StrictMono g) :
+    uniformOfArgmax (g ∘ score) = uniformOfArgmax score := by
+  simp only [uniformOfArgmax]
+  congr 1
+  exact Finset.argmax_comp_strictMono hg
+
+/-- A constant score yields the uniform distribution. -/
+theorem uniformOfArgmax_const (c : β) :
+    uniformOfArgmax (fun _ : α => c) = uniformOfFintype α := by
+  simp only [uniformOfArgmax, uniformOfFintype]
+  congr 1
+  simp
+
+end PMF


### PR DESCRIPTION
Set-valued `Finset.argmax` (mathlib has only the tie-breaking `List.argmax : Option α`) beside `Finset.exists_max_image`, plus `PMF.uniformOfArgmax` as a thin `uniformOfFinset` wrapper — the hard-choice counterpart of `PMF.softmax` and the IBR selection rule, with strict-mono (inverse-temperature) invariance. First increment of the game-theoretic-pragmatics consolidation (`scratch/gtp-consolidation-spec.md`).