### PR TITLE
feat(Pragmatics/SignalingGame): InterpGame specialization; rewire Burnett2019

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1461,6 +1461,7 @@ import Linglib.Pragmatics.RelevanceTheory.Nonliteral
 import Linglib.Pragmatics.RelevanceTheory.Ostension
 import Linglib.Pragmatics.RelevanceTheory.Relevance
 import Linglib.Pragmatics.SignalingGame.Basic
+import Linglib.Pragmatics.SignalingGame.Interpretation
 import Linglib.Pragmatics.SocialMeaning.EckertMontague
 import Linglib.Pragmatics.SocialMeaning.IndexicalField
 import Linglib.Pragmatics.SocialMeaning.PropertySpace

--- a/Linglib/Pragmatics/SignalingGame/Basic.lean
+++ b/Linglib/Pragmatics/SignalingGame/Basic.lean
@@ -5,14 +5,15 @@ import Linglib.Core.Order.Argmax
 /-!
 # Signaling games
 
-The shared carrier for game-theoretic pragmatics: a sender who privately
-knows her type `t : T` chooses a message `m : M`; a receiver observes `m`
-and chooses an action `a : A`; utilities depend on all three (the message
-argument carries signalling costs). Lewisian conventions ([lewis-1969]),
-credible communication ([van-rooy-2003]), and iterated-best-response
-pragmatics ([franke-2011]) are all analyses of this carrier; interpretation
-games arise as the specialization `A = T` with matching utility
-(conditions C1/C2 of [franke-2011]'s Theorem 1).
+The shared carrier for game-theoretic pragmatics ([benz-stevens-2018] is
+the field review): a sender who privately knows her type `t : T` chooses a
+message `m : M`; a receiver observes `m` and chooses an action `a : A`;
+utilities depend on all three (the message argument carries signalling
+costs). Lewisian conventions ([lewis-1969]), games of partial information,
+optimal-answer models, and iterated-best-response pragmatics
+([franke-2011]) are all analyses of this carrier; interpretation games
+arise as the specialization `A = T` with matching utility (conditions
+C1/C2 of [franke-2011]'s Theorem 1).
 
 Pure strategies are plain functions (`σ : T → M`, `ρ : M → A`); mixed
 strategies are Kleisli arrows into `PMF` and live with the consumers that
@@ -131,11 +132,10 @@ theorem posterior_of_injective [Fintype T] [DecidableEq T] [DecidableEq M] (σ :
 
 /-! ## Conventional vs speaker's meaning
 
-The Gricean contrast in signaling terms ([lewis-1969], [van-rooy-2003]):
-*conventional* meaning is an exogenous interpretation function; the
-*speaker's* meaning of `σ t` is the cell of the partition that the sender
-strategy induces on types; what the receiver can infer is their
-intersection. -/
+The Gricean contrast in signaling terms ([lewis-1969]): *conventional*
+meaning is an exogenous interpretation function; the *speaker's* meaning of
+`σ t` is the cell of the partition that the sender strategy induces on
+types; what the receiver can infer is their intersection. -/
 
 /-- Conventional meaning: an exogenous interpretation function from
 messages to propositions over types. -/

--- a/Linglib/Pragmatics/SignalingGame/Interpretation.lean
+++ b/Linglib/Pragmatics/SignalingGame/Interpretation.lean
@@ -1,0 +1,119 @@
+import Linglib.Pragmatics.SignalingGame.Basic
+
+/-!
+# Interpretation games
+
+The interpretation-game specialization of `SignalingGame`: receiver actions
+are type guesses (`A = T`) and both players are paid by the match indicator —
+conditions C1 and C2 of [franke-2011]'s Theorem 1, made true by construction
+in `InterpGame.toSignalingGame`. The extra datum an interpretation game
+carries is the semantic `meaning` relation between messages and types, which
+drives the literal listener and the pragmatic dynamics; it does not enter
+the utilities.
+
+General/specialized file split on the mathlib `Kernel.Defs` /
+`Kernel.Deterministic` pattern: `Basic.lean` states the general carrier,
+this file the specialization with its own ergonomic profile, connected by
+construction (`toSignalingGame`) rather than by a bridge theorem.
+
+## Main definitions
+
+* `InterpGame` — meaning relation and prior; messages denote sets of types.
+* `InterpGame.trueStates` / `trueMessages` — extension of a message / the
+  messages true at a type.
+* `InterpGame.literal` — the literal listener, uniform over the extension.
+* `InterpGame.toSignalingGame` — Franke's C1/C2 reduction, with a
+  `Cooperative` instance.
+
+## Main statements
+
+* `bestResponseSet_toSignalingGame` — under matching utility the receiver's
+  best-response set is the argmax of his beliefs: interpretation is
+  maximum-a-posteriori estimation.
+-/
+
+set_option autoImplicit false
+
+/-- An interpretation game: a semantic `meaning` relation between messages
+and types, and a prior over types. The receiver's task is to guess the
+sender's type; utilities are fixed by the `toSignalingGame` reduction. -/
+structure InterpGame (T M : Type*) where
+  /-- Semantic meaning: is message `m` true at type `t`? -/
+  meaning : M → T → Prop
+  /-- Prior probability over types. -/
+  prior : T → ℚ
+  [meaningDecidable : ∀ m, DecidablePred (meaning m)]
+
+attribute [instance] InterpGame.meaningDecidable
+
+namespace InterpGame
+
+variable {T M : Type*} (G : InterpGame T M)
+
+/-! ## Extensions and the literal listener -/
+
+section Extension
+
+variable [Fintype T]
+
+/-- The extension of message `m`: the types at which it is true. -/
+def trueStates (m : M) : Finset T :=
+  Finset.univ.filter (G.meaning m)
+
+@[simp]
+theorem mem_trueStates {m : M} {t : T} : t ∈ G.trueStates m ↔ G.meaning m t := by
+  simp [trueStates]
+
+/-- The literal listener: uniform over the extension of the message — the
+level-0 receiver of [franke-2011] (eq. (73)) in its Bayesian heavy-system
+rendering. -/
+def literal (m : M) (t : T) : ℚ :=
+  if G.meaning m t then ((G.trueStates m).card : ℚ)⁻¹ else 0
+
+end Extension
+
+/-- The messages true at type `t`. -/
+def trueMessages [Fintype M] (t : T) : Finset M :=
+  Finset.univ.filter (G.meaning · t)
+
+@[simp]
+theorem mem_trueMessages [Fintype M] {t : T} {m : M} :
+    m ∈ G.trueMessages t ↔ G.meaning m t := by
+  simp [trueMessages]
+
+/-! ## The signaling-game reduction -/
+
+variable [DecidableEq T]
+
+/-- Franke's reduction: the signaling game with actions = types (C1) and
+matching utility for both players (C2). The meaning relation does not enter
+the utilities — it constrains the *dynamics* (literal listener, truthful
+speakers), not the payoffs. -/
+def toSignalingGame : SignalingGame T M T where
+  senderUtility t _ a := if a = t then 1 else 0
+  receiverUtility t _ a := if a = t then 1 else 0
+  prior := G.prior
+
+/-- Interpretation games are cooperative: C2 gives both players the same
+matching utility. -/
+instance : G.toSignalingGame.Cooperative :=
+  ⟨fun _ _ _ => rfl⟩
+
+/-- Under matching utility, the expected receiver utility of guessing `a`
+is exactly the belief in `a`. -/
+@[simp]
+theorem receiverEU_toSignalingGame [Fintype T] (μ : T → ℚ) (m : M) (a : T) :
+    G.toSignalingGame.receiverEU μ m a = μ a := by
+  simp [SignalingGame.receiverEU, toSignalingGame, mul_ite]
+
+/-- **Interpretation is MAP estimation**: in an interpretation game the
+receiver's best responses to beliefs `μ` are exactly the
+maximum-a-posteriori types. -/
+theorem bestResponseSet_toSignalingGame [Fintype T] (μ : T → ℚ) (m : M) :
+    G.toSignalingGame.bestResponseSet μ m = Finset.univ.argmax μ := by
+  unfold SignalingGame.bestResponseSet
+  congr 1
+  funext a
+  exact G.receiverEU_toSignalingGame μ m a
+
+end InterpGame

--- a/Linglib/Studies/Burnett2019.lean
+++ b/Linglib/Studies/Burnett2019.lean
@@ -1,6 +1,6 @@
 import Linglib.Pragmatics.RSA.Canonical
 import Linglib.Pragmatics.SocialMeaning.EckertMontague
-import Linglib.Pragmatics.IBR.Basic
+import Linglib.Pragmatics.SignalingGame.Interpretation
 import Linglib.Pragmatics.SocialMeaning.IndexicalField
 import Linglib.Studies.Eckert2008
 import Linglib.Studies.Labov2012
@@ -1007,19 +1007,17 @@ theorem smg_matches_labov_direction :
 
 /-! Burnett's Social Meaning Game (SMG): a signalling game in which a
 speaker's variant choice conveys social information about their persona.
-The SMG reuses [franke-2011]'s IBR machinery — the naive listener,
-strategic speaker, and uncovering listener are all instances of IBR
-reasoning applied to a social-meaning interpretation game.
+The SMG is an interpretation game in [franke-2011]'s sense — the naive
+listener, strategic speaker, and uncovering listener are level-k agents
+over a social-meaning interpretation game.
 
-The key design choice: `toInterpGame` converts any SMG into Franke's
-`InterpGame`, so SMG agents reuse the existing IBR iteration machinery.
-The grounding theorem `naiveListener_eq_L0` verifies that this reuse
-is semantically correct: the SMG L₀ definition produces the same
-results as running Franke's L₀ on the converted game. -/
+The key design choice: `toInterpGame` converts any SMG into an
+`InterpGame` on the shared signaling-game carrier, so SMG agents reuse
+the substrate's machinery. The grounding theorem `naiveListener_eq_literal`
+verifies that the SMG L₀ definition IS the carrier's literal listener on
+the converted game. -/
 
 section smgDefs
-
-open RSA.IBR
 
 /-- A Social Meaning Game (Burnett Def. 4.1): a signalling game where
     variant choice conveys social information.
@@ -1044,33 +1042,28 @@ structure SocialMeaningGame (P V : Type)
   /-- Social evaluation: how much persona `t` values variant `v`. -/
   socialEval : P → V → ℚ
 
-/-- Convert a Social Meaning Game to Franke's interpretation game.
-
-    This is the key architectural bridge: SMG analysis reuses the
-    existing IBR machinery from [franke-2011] rather than reimplementing
-    iterated best response.
+/-- Convert a Social Meaning Game to an interpretation game
+([franke-2011]) on the shared signaling-game carrier.
 
     The mapping:
-    - States = Personae (what the listener tries to infer)
+    - Types = Personae (what the listener tries to infer)
     - Messages = Variants (what the speaker chooses)
     - meaning = SMG meaning (EM field compatibility)
     - prior = SMG prior over personae -/
 def SocialMeaningGame.toInterpGame {P V : Type}
     [Fintype P] [Fintype V]
     [DecidableEq P] [DecidableEq V]
-    (smg : SocialMeaningGame P V) : InterpGame :=
-  { State := P
-    Message := V
-    meaning := smg.meaning
-    prior := smg.prior }
+    (smg : SocialMeaningGame P V) : InterpGame P V where
+  meaning := fun v p => smg.meaning v p = true
+  prior := smg.prior
 
 /-- The naive listener (Burnett Def. 4.2): L₀(t | v) = 1/|⟦v⟧| if
     ⟦v⟧(t), 0 otherwise.
 
     This is Franke's literal L₀ — uniform over compatible types, NOT
     Bayesian conditioning on the prior. The prior is passed through to
-    `toInterpGame` but Franke's `HearerStrategy.literal` ignores it,
-    distributing probability uniformly over `trueStates`.
+    `toInterpGame` but `InterpGame.literal` ignores it, distributing
+    probability uniformly over `trueStates`.
 
     The Bayesian L₀ (L₀(t | v) ∝ Pr(t) · ⟦v⟧(t)) is what Burnett's
     RSA model uses (eq. 11). That prior-weighted version lives in the
@@ -1080,15 +1073,15 @@ def naiveListener {P V : Type}
     [DecidableEq P] [DecidableEq V]
     (smg : SocialMeaningGame P V)
     (v : V) (t : P) : ℚ :=
-  (L0 smg.toInterpGame).respond v t
+  smg.toInterpGame.literal v t
 
-/-- **Grounding theorem**: The SMG naive listener IS Franke's L₀
-    applied to the converted game. True by construction. -/
-theorem naiveListener_eq_L0 {P V : Type}
+/-- **Grounding theorem**: The SMG naive listener IS the carrier's literal
+    listener applied to the converted game. True by construction. -/
+theorem naiveListener_eq_literal {P V : Type}
     [Fintype P] [Fintype V]
     [DecidableEq P] [DecidableEq V]
     (smg : SocialMeaningGame P V) :
-    naiveListener smg = fun v t => (L0 smg.toInterpGame).respond v t := rfl
+    naiveListener smg = fun v t => smg.toInterpGame.literal v t := rfl
 
 /-- The strategic speaker (simplified): S₁(v | t) ∝ μ(t, v) · ⟦v⟧(t).
 

--- a/Linglib/Studies/Burnett2019.lean
+++ b/Linglib/Studies/Burnett2019.lean
@@ -1002,25 +1002,28 @@ theorem smg_matches_labov_direction :
    by native_decide, by native_decide⟩
 
 -- ============================================================================
--- §8. Social Meaning Games (Definitions 4.1–4.4)
+-- §8. Social Meaning Games (Definitions 4.1 and 4.3)
 -- ============================================================================
 
 /-! Burnett's Social Meaning Game (SMG): a signalling game in which a
 speaker's variant choice conveys social information about their persona.
-The SMG is an interpretation game in [franke-2011]'s sense — the naive
-listener, strategic speaker, and uncovering listener are level-k agents
-over a social-meaning interpretation game.
+An SMG is an interpretation game in [franke-2011]'s sense, extended with
+the speaker's value function μ over personae ([burnett-2019] Def. 4.3).
+`toInterpGame` converts any SMG onto the shared signaling-game carrier.
 
-The key design choice: `toInterpGame` converts any SMG into an
-`InterpGame` on the shared signaling-game carrier, so SMG agents reuse
-the substrate's machinery. The grounding theorem `naiveListener_eq_literal`
-verifies that the SMG L₀ definition IS the carrier's literal listener on
-the converted game. -/
+Burnett's own agent dynamics — the informativity speaker (eqs. (12)–(13)),
+soft-max persona selection (eqs. (14)–(15)), the Bayesian *naive listener*
+(eq. (18)) and the value-inferring *uncovering listener* (eq. (20)) — are
+not formalized in this section; the quantitative eq.-(13)-style speaker
+lives in the `Sk` pipeline of §3. What this section verifies is the
+structural layer: the carrier's *literal* listener on the converted game
+captures the exclusion behavior of the meaning function. -/
 
 section smgDefs
 
-/-- A Social Meaning Game (Burnett Def. 4.1): a signalling game where
-    variant choice conveys social information.
+/-- A Social Meaning Game ([burnett-2019] Def. 4.1, extended per Def. 4.3
+    with the value function): a signalling game where variant choice
+    conveys social information.
 
     - `P`: persona types (social categories the listener is trying to infer)
     - `V`: variant types (linguistic forms the speaker chooses)
@@ -1028,8 +1031,9 @@ section smgDefs
     - `meaning`: whether a variant is compatible with a persona
       (derived from the EM field: `v` means `t` iff the EM lift of `v`
       includes persona `t`)
-    - `socialEval`: the speaker's utility μ(t, v) — how much persona `t`
-      values being associated with variant `v` -/
+    - `socialEval`: Def. 4.3's μ — the value the speaker assigns to
+      constructing each persona in the context (persona-only, as in the
+      paper) -/
 structure SocialMeaningGame (P V : Type)
     [Fintype P] [Fintype V]
     [DecidableEq P] [DecidableEq V] where
@@ -1039,8 +1043,9 @@ structure SocialMeaningGame (P V : Type)
   prior_nonneg : ∀ (t : P), 0 ≤ prior t
   /-- Semantic meaning: is variant `v` compatible with persona `t`? -/
   meaning : V → P → Bool
-  /-- Social evaluation: how much persona `t` values variant `v`. -/
-  socialEval : P → V → ℚ
+  /-- Def. 4.3's value function μ: how much the speaker values
+      constructing persona `t` in the context. -/
+  socialEval : P → ℚ
 
 /-- Convert a Social Meaning Game to an interpretation game
 ([franke-2011]) on the shared signaling-game carrier.
@@ -1057,69 +1062,6 @@ def SocialMeaningGame.toInterpGame {P V : Type}
   meaning := fun v p => smg.meaning v p = true
   prior := smg.prior
 
-/-- The naive listener (Burnett Def. 4.2): L₀(t | v) = 1/|⟦v⟧| if
-    ⟦v⟧(t), 0 otherwise.
-
-    This is Franke's literal L₀ — uniform over compatible types, NOT
-    Bayesian conditioning on the prior. The prior is passed through to
-    `toInterpGame` but `InterpGame.literal` ignores it, distributing
-    probability uniformly over `trueStates`.
-
-    The Bayesian L₀ (L₀(t | v) ∝ Pr(t) · ⟦v⟧(t)) is what Burnett's
-    RSA model uses (eq. 11). That prior-weighted version lives in the
-    `meaningE` / `L0k` pipeline of §3, not here. -/
-def naiveListener {P V : Type}
-    [Fintype P] [Fintype V]
-    [DecidableEq P] [DecidableEq V]
-    (smg : SocialMeaningGame P V)
-    (v : V) (t : P) : ℚ :=
-  smg.toInterpGame.literal v t
-
-/-- **Grounding theorem**: The SMG naive listener IS the carrier's literal
-    listener applied to the converted game. True by construction. -/
-theorem naiveListener_eq_literal {P V : Type}
-    [Fintype P] [Fintype V]
-    [DecidableEq P] [DecidableEq V]
-    (smg : SocialMeaningGame P V) :
-    naiveListener smg = fun v t => smg.toInterpGame.literal v t := rfl
-
-/-- The strategic speaker (simplified): S₁(v | t) ∝ μ(t, v) · ⟦v⟧(t).
-
-    This normalizes raw social evaluation scores over compatible variants,
-    producing a closed-form rational speaker. This is a simplification of
-    Burnett's Def. 4.3 / eq. (13), which uses soft-max over log-L₀:
-    P_S(v | π) ∝ exp(α · ln(L₀(π | v))). The full RSA formulation with
-    belief-based S₁ scoring lives in the `Sk` speaker of §3, not here.
-
-    Unlike Franke's best-response speaker (which maximizes hearer success),
-    the SMG speaker maximizes *social* utility: a persona chooses variants
-    that make the listener more likely to infer a desirable persona. -/
-def strategicSpeaker {P V : Type}
-    [Fintype P] [Fintype V]
-    [DecidableEq P] [DecidableEq V]
-    (smg : SocialMeaningGame P V)
-    (t : P) (v : V) : ℚ :=
-  if smg.meaning v t then
-    let numerator := smg.socialEval t v
-    let denominator := Finset.univ.sum fun v' =>
-      if smg.meaning v' t then smg.socialEval t v' else 0
-    if denominator == 0 then 0 else numerator / denominator
-  else 0
-
-/-- The uncovering listener (Burnett Def. 4.4): L₁(t | v) ∝ Pr(t) · S₁(v | t).
-
-    The listener uses Bayes' rule to infer the speaker's persona from
-    the observed variant choice, using the strategic speaker's production
-    probabilities as the likelihood. -/
-def uncoveringListener {P V : Type}
-    [Fintype P] [Fintype V]
-    [DecidableEq P] [DecidableEq V]
-    (smg : SocialMeaningGame P V)
-    (v : V) (t : P) : ℚ :=
-  let numerator := strategicSpeaker smg t v * smg.prior t
-  let denominator := Finset.univ.sum fun t' => strategicSpeaker smg t' v * smg.prior t'
-  if denominator == 0 then 0 else numerator / denominator
-
 /-- Construct a Social Meaning Game from a grounded field, prior, and
     social evaluation function.
 
@@ -1133,7 +1075,7 @@ def fromGroundedField {V : Type} [Fintype V] [DecidableEq V]
     [Fintype personaeSets] [DecidableEq personaeSets]
     (prior : personaeSets → ℚ)
     (prior_nonneg : ∀ (t : personaeSets), 0 ≤ prior t)
-    (socialEval : personaeSets → V → ℚ) :
+    (socialEval : personaeSets → ℚ) :
     SocialMeaningGame personaeSets V :=
   { prior := prior
     prior_nonneg := prior_nonneg
@@ -1142,11 +1084,13 @@ def fromGroundedField {V : Type} [Fintype V] [DecidableEq V]
 
 end smgDefs
 
-/-! The SMG's `naiveListener` is Franke's literal L₀ — *uniform* over
+/-! The carrier's literal listener on the converted game is *uniform* over
 compatible personae. This captures the exclusion structure (which
 personae are ruled out by each variant) but not the prior-weighted
-refinement. The *quantitative* predictions (69% -in' for cool guy,
-style shifting) use the belief-based speaker `Sk` of §3 (Burnett eq. 13:
+refinement — [burnett-2019]'s naive listener proper (eq. (18)) is
+Bayesian over the speaker's production rule. The *quantitative*
+predictions (≈69% -in' for cool guy at α = α′ = 6, eq. (15); style
+shifting) use the belief-based speaker `Sk` of §3 (Burnett eq. (13):
 P_S(m|π) ∝ L₀(π|m)^α), which incorporates the context-specific prior
 into the meaning function to recover Bayesian conditioning. We
 construct an SMG from the study's types and prove structural
@@ -1168,16 +1112,15 @@ def obamaValues : Persona → ℚ
   | .asshole     => 0
 
 /-- The (ING) Social Meaning Game for the casual context
-    ([burnett-2019], Def. 4.1 + Table 2 + Table 6).
+    ([burnett-2019], Defs. 4.1/4.3 + Table 2 + Table 6).
 
     This connects the study's types to the §8 game structure,
-    exercising `SocialMeaningGame`, `naiveListener`, and
-    `toInterpGame`. -/
+    exercising `SocialMeaningGame` and `toInterpGame`. -/
 def casualSMG : SocialMeaningGame Persona INGVariant where
   prior := casualPrior
   prior_nonneg := by intro p; cases p <;> norm_num [casualPrior]
   meaning := ingMeaning
-  socialEval := fun p _ => obamaValues p
+  socialEval := obamaValues
 
 /-- The SMG meaning is grounded in the Eckert–Montague intersection
     lift — connecting the game structure to the compositional
@@ -1186,33 +1129,33 @@ theorem smg_meaning_grounded (v : INGVariant) (p : Persona) :
     casualSMG.meaning v p = emMeaningMI ingField v p.toFinset :=
   ingMeaning_eq_emMeaningMI v p
 
-/-- The naive listener excludes stern leader after hearing *-in'*
+/-- The literal listener excludes stern leader after hearing *-in'*
     (incompatible: stern leader = {competent, aloof} shares no
     property with [-in'] = {incompetent, friendly}). -/
 theorem smg_L0_in'_excludes_sternLeader :
-    naiveListener casualSMG .apical .sternLeader = 0 := by
+    casualSMG.toInterpGame.literal .apical .sternLeader = 0 := by
   native_decide
 
-/-- The naive listener excludes doofus after hearing *-ing*
+/-- The literal listener excludes doofus after hearing *-ing*
     (incompatible: doofus = {incompetent, friendly} shares no
     property with [-ing] = {competent, aloof}). -/
 theorem smg_L0_ing_excludes_doofus :
-    naiveListener casualSMG .velar .doofus = 0 := by
+    casualSMG.toInterpGame.literal .velar .doofus = 0 := by
   native_decide
 
-/-- The naive listener assigns equal probability (1/3) to all
-    compatible personae. Franke's literal L₀ is uniform over ⟦v⟧:
-    since 3 personae are compatible with each variant, each gets 1/3.
+/-- The literal listener assigns equal probability (1/3) to all
+    compatible personae — uniform over ⟦v⟧: since 3 personae are
+    compatible with each variant, each gets 1/3.
 
     This is the structural content of the meaning function: each variant
     partitions personae into compatible (1/3) and incompatible (0). -/
 theorem smg_L0_uniform_compatible :
-    naiveListener casualSMG .velar .coolGuy = 1/3 ∧
-    naiveListener casualSMG .velar .sternLeader = 1/3 ∧
-    naiveListener casualSMG .velar .asshole = 1/3 ∧
-    naiveListener casualSMG .apical .coolGuy = 1/3 ∧
-    naiveListener casualSMG .apical .asshole = 1/3 ∧
-    naiveListener casualSMG .apical .doofus = 1/3 := by
+    casualSMG.toInterpGame.literal .velar .coolGuy = 1/3 ∧
+    casualSMG.toInterpGame.literal .velar .sternLeader = 1/3 ∧
+    casualSMG.toInterpGame.literal .velar .asshole = 1/3 ∧
+    casualSMG.toInterpGame.literal .apical .coolGuy = 1/3 ∧
+    casualSMG.toInterpGame.literal .apical .asshole = 1/3 ∧
+    casualSMG.toInterpGame.literal .apical .doofus = 1/3 := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
 
 end smgBridge

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -22,6 +22,20 @@
 % ══════════════════════════════════════════════════════════════════════════════
 %  pragmatics/rsa
 
+@article{benz-stevens-2018,
+  author    = {Benz, Anton and Stevens, Jon},
+  year      = {2018},
+  title     = {Game-Theoretic Approaches to Pragmatics},
+  journal   = {Annual Review of Linguistics},
+  volume    = {4},
+  pages     = {173--191},
+  doi       = {10.1146/annurev-linguistics-011817-045641},
+  subfield  = {pragmatics/rsa},
+  validated = {true},
+  role      = {cited},
+  sources   = {Pragmatics/SignalingGame/Basic.lean}
+}
+
 @inproceedings{spinoso-di-piano-etal-2025,
   author    = {Spinoso-Di Piano, Cesare and Austin, David Eric and Piantanida, Pablo and Cheung, Jackie Chi Kit},
   year      = {2025},


### PR DESCRIPTION
Phase C of the game-theoretic-pragmatics consolidation (`scratch/gtp-consolidation-spec.md`).

- `Pragmatics/SignalingGame/Interpretation.lean`: `InterpGame T M` with Prop-valued meaning + `[DecidablePred]`, extensions, literal listener, and `toSignalingGame` making Franke's Theorem-1 conditions C1/C2 true by construction (with a `Cooperative` instance). Main theorem: `bestResponseSet_toSignalingGame` — under matching utility, interpretation is MAP estimation (`bestResponseSet μ m = univ.argmax μ`).
- `Studies/Burnett2019`: SMG now converts to the new carrier (`toInterpGame : InterpGame P V`); `naiveListener` is the carrier's literal listener; grounding theorem renamed `naiveListener_eq_literal`, still `rfl`. Drops the `Pragmatics.IBR` import.

`Pragmatics/IBR/` still carries its own legacy `RSA.IBR.InterpGame` for Franke2011 until Phase D dissolves it.