### PR TITLE
docs(Phonology/Autosegmental): split jardine-2016 diss from article

### DIFF
--- a/Linglib/Phonology/Autosegmental/ASL.lean
+++ b/Linglib/Phonology/Autosegmental/ASL.lean
@@ -36,7 +36,7 @@ namespace Autosegmental
 variable {S : Type*} {α β : Type*}
 
 /-- A banned-subgraph grammar as an AR **object-property**: the ARs free of every
-    forbidden pattern in `B` ([jardine-2016] Ch. 5's `L^NL_G`, packaged for `AR`). -/
+    forbidden pattern in `B` ([jardine-2016-diss] Ch. 5's `L^NL_G`, packaged for `AR`). -/
 def isFreeOf (B : List (Graph α β)) (A : AR α β) : Prop := A.toGraph.Free B
 
 instance [DecidableEq α] [DecidableEq β] (B : List (Graph α β)) (A : AR α β) :

--- a/Linglib/Phonology/Autosegmental/Correspondence.lean
+++ b/Linglib/Phonology/Autosegmental/Correspondence.lean
@@ -8,7 +8,7 @@ import Linglib.Phonology.Autosegmental.Embedding
 /-!
 # Phonological transformations as correspondence-graph relations
 
-[jardine-2016] (Ch. 7) models a phonological *process* not as a function but as a
+[jardine-2016-diss] (Ch. 7) models a phonological *process* not as a function but as a
 **relation** between input and output, presented by a set of **correspondence graphs**
 and carved out of GEN by **banned-subgraph constraints** (markedness + faithfulness) —
 which is what makes the relation *local*.
@@ -18,7 +18,7 @@ upper tier is the input string, the lower tier the output string, and the associ
 links are the input↔output **correspondence arcs**. (Precedence is carried by the tier
 order; Jardine's separate precedence/correspondence arc-labeling `ℓ_A` is here the
 structural split between tier-order and links.) The banned-subgraph grammar is
-`Graph.Free` ([jardine-2016] Ch. 5's `L^NL_G`).
+`Graph.Free` ([jardine-2016-diss] Ch. 5's `L^NL_G`).
 
 This is the *process* layer of the substrate's three-layer spec (objects `AR`,
 precedence-morphisms `PrecAR`, processes here). The autosegmental case — correspondence
@@ -35,7 +35,7 @@ arc-labelled-subgraph refinement he flags in Ch. 7 fn. 7; that is deferred.
 
 * `Correspondence.input`/`output` — the two strings a correspondence graph relates.
 * `Correspondence.rel` — `R(CG)`, the string relation of a set of correspondence graphs
-  ([jardine-2016] Def. 25).
+  ([jardine-2016-diss] Def. 25).
 * `Correspondence.specifiedBy` — `CG(φ)`, a process presented by a banned-subgraph grammar.
 * `Correspondence.IsLocal` — a relation presented by a finite banned-subgraph grammar.
 -/
@@ -51,7 +51,7 @@ def input (G : Graph S T) : List S := G.upper.toList
 /-- The **output** string of a correspondence graph: its lower tier. -/
 def output (G : Graph S T) : List T := G.lower.toList
 
-/-- **R(CG)** ([jardine-2016] Def. 25): the string relation realized by a set `CG` of
+/-- **R(CG)** ([jardine-2016-diss] Def. 25): the string relation realized by a set `CG` of
     correspondence graphs — the input/output pairs of its members. -/
 def rel (CG : Graph S T → Prop) (w : List S) (v : List T) : Prop :=
   ∃ G, CG G ∧ input G = w ∧ output G = v
@@ -71,7 +71,7 @@ instance [DecidableEq S] [DecidableEq T] (φ : List (Graph S T)) (G : Graph S T)
     Decidable (specifiedBy φ G) := inferInstanceAs (Decidable (G.Free φ))
 
 /-- A string relation is **local** when presented by a finite banned-subgraph grammar
-    over correspondence graphs — the locality of phonological processes [jardine-2016]. -/
+    over correspondence graphs — the locality of phonological processes [jardine-2016-diss]. -/
 def IsLocal (R : List S → List T → Prop) : Prop :=
   ∃ φ : List (Graph S T), R = rel (specifiedBy φ)
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -29556,6 +29556,17 @@
 % REF: Jardine (2016). Computationally, tone is different. Phonology
 % 33(2):247-283. DOI 10.1017/S0952675716000129. Demonstrates that tone
 % phenomena are non-subsequential — the canonical "outside subregular" result.
+@phdthesis{jardine-2016-diss,
+  author    = {Jardine, Adam},
+  year      = {2016},
+  title     = {Locality and Non-linear Representations in Tonal Phonology},
+  school    = {University of Delaware},
+  subfield  = {phonology/autosegmental},
+  validated = {true},
+  role      = {cited},
+  sources   = {Phonology/Autosegmental/Correspondence.lean; Phonology/Autosegmental/ASL.lean}
+}
+
 @article{jardine-2016,
   author    = {Jardine, Adam},
   year      = {2016},


### PR DESCRIPTION
`[jardine-2016]` resolves to the Phonology 33 article, but ASL.lean and Correspondence.lean cite it with dissertation coordinates (Ch. 5, Ch. 7, Def. 25 — all verified against the dissertation text). Adds `jardine-2016-diss` (Locality and Non-linear Representations in Tonal Phonology, U. Delaware) and repoints those six citations; Realization/Plateauing/Surfacing correctly cite the article (its §4.4 and (40) verified) and are untouched.