### PR TITLE
feat(Phonology/Autosegmental): labeled mixed graph foundation

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -57,6 +57,7 @@ import Linglib.Core.Categorical.AgentCat
 import Linglib.Core.Categorical.PartitionCat
 import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple
 import Linglib.Core.Combinatorics.Antimatroid
+import Linglib.Core.Combinatorics.MixedGraph
 import Linglib.Core.Combinatorics.RootedTree.Aut
 import Linglib.Core.Combinatorics.RootedTree.ContractUnary
 import Linglib.Core.Computability.ContextFreeGrammar.Closure

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1352,6 +1352,7 @@ import Linglib.Phonology.Autosegmental.Hull
 import Linglib.Phonology.Autosegmental.Inclusion
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Autosegmental.Melody
+import Linglib.Phonology.Autosegmental.MixedGraph
 import Linglib.Phonology.Autosegmental.MultiAR
 import Linglib.Phonology.Autosegmental.NonCrossing
 import Linglib.Phonology.Autosegmental.Realization

--- a/Linglib/Core/Combinatorics/MixedGraph.lean
+++ b/Linglib/Core/Combinatorics/MixedGraph.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Combinatorics.Digraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Basic
+
+/-!
+# Mixed graphs
+
+A **mixed graph** `G = (V, E, A)` has both undirected edges `E` and directed arcs
+`A` on one vertex set: a `SimpleGraph` and a `Digraph` bundled over `V`. Mathlib
+has both halves but no bundle. Candidate for
+`Mathlib/Combinatorics/MixedGraph/Basic.lean`.
+
+## Main definitions
+
+* `MixedGraph V`: the bundle.
+* `SimpleGraph.toMixedGraph` / `Digraph.toMixedGraph`: the degenerate cases —
+  a simple graph is a mixed graph with no arcs, a digraph one with no edges.
+-/
+
+/-- A mixed graph: undirected edges and directed arcs on one vertex type. -/
+@[ext]
+structure MixedGraph (V : Type*) where
+  /-- The undirected edges. -/
+  edges : SimpleGraph V
+  /-- The directed arcs. -/
+  arcs : Digraph V
+
+variable {V : Type*}
+
+/-- A simple graph is a mixed graph with no arcs. -/
+def SimpleGraph.toMixedGraph (G : SimpleGraph V) : MixedGraph V := ⟨G, ⊥⟩
+
+/-- A digraph is a mixed graph with no edges. -/
+def Digraph.toMixedGraph (D : Digraph V) : MixedGraph V := ⟨⊥, D⟩

--- a/Linglib/Fragments/Laal/Prosody.lean
+++ b/Linglib/Fragments/Laal/Prosody.lean
@@ -7,7 +7,7 @@ Authors: Robert Hawkins
 /-!
 # Laal prosodic fragment
 
-[lionnet-2022-laal]
+[lionnet-2022]
 
 Theory-neutral tone data for Laal (language isolate, southern Chad): the three
 contrastive tone heights H/M/L, the attested stem-level tone melodies (Table 2),

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Logic.Relation
+import Mathlib.Logic.Equiv.Basic
+
+/-!
+# Labeled mixed graphs — the autosegmental foundation
+
+A labeled mixed graph `⟨V, E, A, ℓ⟩` ([jardine-heinz-2015] §2; [jardine-2016-diss]
+§4.1) is the literature's most general autosegmental object: labeled nodes, a
+symmetric association relation `E`, and a directed precedence relation `A`.
+Rendered as pure relations over a vertex-type parameter (the `SimpleGraph`
+pattern), it is a finite relational structure in the model-theoretic-phonology
+sense — unary label predicates plus two binary relations — the format in which
+notational-equivalence results are proved ([jardine-danis-iacoponi-2021],
+[oakden-2020]). Nothing else is stored: in particular no ambient cross-tier
+order, which is structure the object does not have.
+
+Tiers are not part of the object. A tier assignment `t : S → ι` on the alphabet
+induces the node partition, and [jardine-2016-diss] §4.2's well-formedness axioms
+carve the autosegmental representations out of the raw graphs relative to it.
+
+Concatenation is [jardine-heinz-2015] Definition 2 *minus its `R_ID` melody
+merge* (the OCP repair, modeled separately as `OCP.collapse`, matching
+`AR.lean`): the sum of the vertex types with, per tier class, bridging arcs from
+the first factor's precedence-maximal nodes to the second factor's
+precedence-minimal ones. The monoid laws hold up to structure-preserving
+equivalence (`MixedGraph.Iso`), not up to equality — strictness belongs to the
+tiered normal form, not to the foundation.
+
+## Main definitions
+
+* `MixedGraph V S`: association `Assoc` (symmetric), precedence `Prec`,
+  labeling `label : V → S`; `PrecPath` is the transitive closure of `Prec`.
+* The [jardine-2016-diss] §4.2 axioms, relative to a tier assignment where tiers
+  matter: `IsTierOrdered` (Axioms 1–2), `NoInternalAssoc` (Axiom 3),
+  `IsSaturated` (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`),
+  `IsPlanar` (Axiom 5, the No-Crossing Constraint in its general path form),
+  `IsOCPClean` (Axiom 6).
+* `MixedGraph.Iso`: label- and relation-preserving equivalence.
+* `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum.
+
+## Main results
+
+* `concat_empty_iso` / `empty_concat_iso`: the unit laws up to `Iso`
+  ([jardine-heinz-2015] Theorem 1).
+
+## TODO
+
+* Associativity up to `Iso` ([jardine-heinz-2015] Theorem 3; conditional on the
+  tier classes being precedence chains, per the paper's Lemma 1 remark).
+* Axiom preservation under `concat` ([jardine-heinz-2015] Theorem 4 and its
+  Axiom 1–3 analogues).
+* The normal-form equivalence: every graph satisfying Axioms 1–3 is isomorphic
+  to a tier-indexed family of `LabeledTuple`s with per-pair links — the strict
+  tiered presentation `MultiAR` builds on — with `IsPlanar` reducing to the
+  per-pair NCC.
+-/
+
+namespace Autosegmental
+
+variable {V V₁ V₂ V₃ S ι : Type*}
+
+/-- A labeled mixed graph `⟨V, E, A, ℓ⟩`: a symmetric association relation, a
+    directed precedence relation, and a labeling of the vertices. -/
+structure MixedGraph (V S : Type*) where
+  /-- The association relation (`E`), undirected. -/
+  Assoc : V → V → Prop
+  /-- Association is symmetric. -/
+  assoc_symm : Std.Symm Assoc
+  /-- The precedence relation (`A`), directed. -/
+  Prec : V → V → Prop
+  /-- The labeling (`ℓ`). -/
+  label : V → S
+
+namespace MixedGraph
+
+/-- The precedence-path relation: the transitive closure of `Prec`. -/
+def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.Prec
+
+/-- The tier of a vertex under a tier assignment on the alphabet. -/
+def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
+
+/-! ### The §4.2 axioms -/
+
+section Axioms
+variable (t : S → ι) (G : MixedGraph V S)
+
+/-- Axioms 1–2 ([jardine-2016-diss] §4.2): precedence stays within a tier,
+    precedence paths totally order each tier class, and no path returns to its
+    origin. -/
+def IsTierOrdered : Prop :=
+  (∀ ⦃v w⦄, G.Prec v w → G.tier t v = G.tier t w) ∧
+    (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.PrecPath v w ∨ G.PrecPath w v) ∧
+    ∀ v, ¬ G.PrecPath v v
+
+/-- Axiom 3: association never links precedence-path-related (tier-internal)
+    vertices. Tier-free — stated on paths alone, as in the dissertation. -/
+def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.Assoc v w → ¬ G.PrecPath v w
+
+/-- Axiom 4 (full specification): every vertex participates in an association.
+    [goldsmith-1976]'s original well-formedness condition; stated but
+    deliberately not imposed — floating elements are well-formed, as in
+    `AR.lean`. -/
+def IsSaturated : Prop := ∀ v, ∃ w, G.Assoc v w
+
+/-- Axiom 5, the No-Crossing Constraint in [jardine-2016-diss]'s general path
+    form: no two association edges whose endpoints straddle in opposite
+    precedence order. -/
+def IsPlanar : Prop :=
+  ∀ ⦃v v' w w'⦄, G.Assoc v v' → G.Assoc w w' → G.PrecPath v w → ¬ G.PrecPath w' v'
+
+/-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m`
+    bear distinct labels. -/
+def IsOCPClean (m : ι) : Prop :=
+  ∀ ⦃v w⦄, G.Prec v w → G.tier t v = m → G.label v ≠ G.label w
+
+end Axioms
+
+/-! ### Isomorphism -/
+
+/-- A label- and relation-preserving equivalence of labeled mixed graphs. -/
+structure Iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) extends V₁ ≃ V₂ where
+  assoc_iff : ∀ v w, G₂.Assoc (toEquiv v) (toEquiv w) ↔ G₁.Assoc v w
+  prec_iff : ∀ v w, G₂.Prec (toEquiv v) (toEquiv w) ↔ G₁.Prec v w
+  label_comp : ∀ v, G₂.label (toEquiv v) = G₁.label v
+
+/-- The identity isomorphism. -/
+def Iso.refl (G : MixedGraph V S) : Iso G G :=
+  ⟨Equiv.refl V, fun _ _ => Iff.rfl, fun _ _ => Iff.rfl, fun _ => rfl⟩
+
+/-- Inverse isomorphism. -/
+def Iso.symm {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) : Iso G₂ G₁ where
+  toEquiv := e.toEquiv.symm
+  assoc_iff v w := by
+    conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
+      show w = e.toEquiv (e.toEquiv.symm w) from (e.toEquiv.apply_symm_apply w).symm]
+    exact (e.assoc_iff _ _).symm
+  prec_iff v w := by
+    conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
+      show w = e.toEquiv (e.toEquiv.symm w) from (e.toEquiv.apply_symm_apply w).symm]
+    exact (e.prec_iff _ _).symm
+  label_comp v := by
+    conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm]
+    exact (e.label_comp _).symm
+
+/-- Composition of isomorphisms. -/
+def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : MixedGraph V₃ S}
+    (e : Iso G₁ G₂) (f : Iso G₂ G₃) : Iso G₁ G₃ where
+  toEquiv := e.toEquiv.trans f.toEquiv
+  assoc_iff v w := (f.assoc_iff _ _).trans (e.assoc_iff v w)
+  prec_iff v w := (f.prec_iff _ _).trans (e.prec_iff v w)
+  label_comp v := (f.label_comp _).trans (e.label_comp v)
+
+/-! ### The empty graph -/
+
+/-- The empty mixed graph, on the empty vertex type. -/
+def empty (S : Type*) : MixedGraph PEmpty S where
+  Assoc _ _ := False
+  assoc_symm := ⟨fun _ _ h => h.elim⟩
+  Prec _ _ := False
+  label v := v.elim
+
+/-! ### Tier-bridging concatenation
+
+Per tier class, concatenation adds bridging arcs from the first factor's
+precedence-maximal vertices of that class to the second factor's
+precedence-minimal ones. On graphs whose tier classes are precedence chains
+(Axioms 1–2) this is [jardine-heinz-2015]'s last-to-first bridge; on raw graphs
+it is total (a maximal-to-minimal complete bridge), where the paper's
+`first`/`last` are partial. -/
+
+section Concat
+variable (t : S → ι)
+
+/-- `v` is precedence-maximal within its tier class. -/
+def IsTierMax (G : MixedGraph V S) (v : V) : Prop :=
+  ∀ ⦃w⦄, G.tier t w = G.tier t v → ¬ G.PrecPath v w
+
+/-- `v` is precedence-minimal within its tier class. -/
+def IsTierMin (G : MixedGraph V S) (v : V) : Prop :=
+  ∀ ⦃w⦄, G.tier t w = G.tier t v → ¬ G.PrecPath w v
+
+/-- Concatenation ([jardine-heinz-2015] Definition 2, minus the `R_ID` melody
+    merge): the vertex sum, with association and precedence inherited blockwise
+    and a bridging arc from each tier-maximal vertex of `G₁` to each same-tier
+    tier-minimal vertex of `G₂`. -/
+def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
+  Assoc v w :=
+    match v, w with
+    | .inl v, .inl w => G₁.Assoc v w
+    | .inr v, .inr w => G₂.Assoc v w
+    | _, _ => False
+  assoc_symm := ⟨by
+    intro v w h
+    cases v <;> cases w <;> simp_all only
+    exacts [G₁.assoc_symm.symm _ _ h, G₂.assoc_symm.symm _ _ h]⟩
+  Prec v w :=
+    match v, w with
+    | .inl v, .inl w => G₁.Prec v w
+    | .inr v, .inr w => G₂.Prec v w
+    | .inl v, .inr w =>
+        G₁.tier t v = G₂.tier t w ∧ IsTierMax t G₁ v ∧ IsTierMin t G₂ w
+    | .inr _, .inl _ => False
+  label := Sum.elim G₁.label G₂.label
+
+@[simp] theorem concat_label_inl (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₁) :
+    (concat t G₁ G₂).label (.inl v) = G₁.label v := rfl
+
+@[simp] theorem concat_label_inr (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₂) :
+    (concat t G₁ G₂).label (.inr v) = G₂.label v := rfl
+
+@[simp] theorem concat_assoc_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₁} :
+    (concat t G₁ G₂).Assoc (.inl v) (.inl w) ↔ G₁.Assoc v w := Iff.rfl
+
+@[simp] theorem concat_assoc_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₂} :
+    (concat t G₁ G₂).Assoc (.inr v) (.inr w) ↔ G₂.Assoc v w := Iff.rfl
+
+/-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
+
+/-- Concatenation with the empty graph on the right, up to isomorphism. -/
+def concat_empty_iso (G : MixedGraph V S) : Iso (concat t G (empty S)) G where
+  toEquiv := Equiv.sumEmpty V PEmpty
+  assoc_iff v w := by
+    rcases v with v | v
+    · rcases w with w | w
+      · exact Iff.rfl
+      · exact w.elim
+    · exact v.elim
+  prec_iff v w := by
+    rcases v with v | v
+    · rcases w with w | w
+      · exact Iff.rfl
+      · exact w.elim
+    · exact v.elim
+  label_comp v := by
+    rcases v with v | v
+    · rfl
+    · exact v.elim
+
+/-- Concatenation with the empty graph on the left, up to isomorphism. -/
+def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
+  toEquiv := Equiv.emptySum PEmpty V
+  assoc_iff v w := by
+    rcases v with v | v
+    · exact v.elim
+    · rcases w with w | w
+      · exact w.elim
+      · exact Iff.rfl
+  prec_iff v w := by
+    rcases v with v | v
+    · exact v.elim
+    · rcases w with w | w
+      · exact w.elim
+      · exact Iff.rfl
+  label_comp v := by
+    rcases v with v | v
+    · exact v.elim
+    · rfl
+
+end Concat
+
+end MixedGraph
+
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -508,6 +508,20 @@ def tensor (X Y : Representation t) : Representation t :=
     MixedGraph.isTierOrdered_concat t X.property.1 Y.property.1,
     MixedGraph.noInternalAssoc_concat t X.property.2 Y.property.2⟩
 
+/-- Under the structural axioms the tier map properly colors the association
+    graph: same-tier vertices are precedence-related (Axioms 1–2) and associated
+    vertices never are (Axiom 3), so associated vertices lie on distinct tiers.
+    Goldsmith's bipartite two-tier geometry is the two-colorable case. -/
+def tierColoring (X : Representation t) : X.obj.graph.edges.Coloring ι :=
+  SimpleGraph.Coloring.mk (X.obj.graph.tier t) fun {_ _} hadj htier =>
+    (X.property.1.2.1 hadj.ne htier).elim (X.property.2 hadj) (X.property.2 hadj.symm)
+
+/-- A representation's association graph is colorable by its tiers: tier arity
+    bounds the chromatic number of the association pattern. -/
+theorem edges_colorable [Fintype ι] (X : Representation t) :
+    X.obj.graph.edges.Colorable (Fintype.card ι) :=
+  (tierColoring X).colorable
+
 /-- A graph isomorphism as an isomorphism of representations. -/
 def mkIso {X Y : Representation t} (e : MixedGraph.Iso X.obj.graph Y.obj.graph) : X ≅ Y :=
   InducedCategory.isoMk

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -45,7 +45,9 @@ strictness belongs to the tiered normal form, not to the foundation.
   matter: `IsTierOrdered` (Axioms 1–2), `NoInternalAssoc` (Axiom 3), `IsSaturated`
   (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`), `IsPlanar`
   (Axiom 5, the No-Crossing Constraint in its general path form), `IsOCPClean`
-  (Axiom 6).
+  (Axiom 6). Numbering follows the dissertation; [jardine-heinz-2015] numbers the
+  NCC and OCP as its Axioms 4 and 5 and has no saturation axiom, which is why
+  `AR.lean`'s citations differ.
 * `MixedGraph.Hom` / `MixedGraph.Iso`: label- and relation-preserving maps and
   equivalences; faces project to the stock `SimpleGraph.Hom`/`Iso` and
   `RelHom`/`RelIso`.
@@ -227,8 +229,11 @@ arc from every `G₁`-vertex of a class to every same-class `G₂`-vertex. This 
 the signature of [jardine-2019]'s own formulation — arcs represent *the order* on
 each string, not its successor steps — under which [jardine-heinz-2015]
 Definition 2's last-to-first successor bridge becomes the complete same-class
-bridge (the two signatures are interdefinable over these structures,
-[jardine-2017-complexity]). The order form makes the bridge total (the paper's
+bridge: the two composites agree in precedence-closure, the relation the axioms
+and results here consume (on the definability relationship between the two
+signatures cf. [jardine-2017-complexity]; note that subgraph-based notions such
+as `ASL.lean`'s forbidden-factor grammars are signature-sensitive and do not
+transfer for free). The order form makes the bridge total (the paper's
 `first`/`last` are partial) and functorial, and its monoid laws unconditional
 where the successor form's associativity is conditional on the tier classes being
 string graphs (the paper's Lemma 1 remark). -/

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -3,23 +3,22 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Combinatorics.Digraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
+import Linglib.Core.Combinatorics.MixedGraph
 
 /-!
 # Labeled mixed graphs — the autosegmental foundation
 
 A labeled mixed graph `⟨V, E, A, ℓ⟩` ([jardine-heinz-2015] §2; [jardine-2016-diss]
-§4.1) is the literature's most general autosegmental object: labeled nodes, undirected
-association edges `E`, and directed precedence arcs `A`. Both graph components are
-stock mathlib objects — `E` is exactly a `SimpleGraph` (the dissertation's edges are
-cardinality-two sets: symmetric and loopless), `A` exactly a `Digraph` — so a labeled
-mixed graph is a `SimpleGraph`, a `Digraph`, and a labeling on one vertex type. As
-pure relations over a vertex-type parameter it is a finite relational structure in
-the model-theoretic-phonology sense — the format in which notational-equivalence
-results are proved ([jardine-danis-iacoponi-2021], [oakden-2020]) — and stores no
-ambient cross-tier order, which is structure the object does not have.
+§4.1) is the literature's most general autosegmental object: a mixed graph
+(`Core/Combinatorics/MixedGraph.lean` — undirected association edges `E`, here a
+`SimpleGraph` since the dissertation's edges are cardinality-two sets, and directed
+precedence arcs `A`, a `Digraph`) together with a vertex labeling. As pure relations
+over a vertex-type parameter it is a finite relational structure in the
+model-theoretic-phonology sense — the format in which notational-equivalence results
+are proved ([jardine-danis-iacoponi-2021], [oakden-2020]) — and stores no ambient
+cross-tier order, which is structure the object does not have.
 
 Tiers are not part of the object. A tier assignment `t : S → ι` on the alphabet
 induces the node partition, and [jardine-2016-diss] §4.2's well-formedness axioms
@@ -27,24 +26,24 @@ carve the autosegmental representations out of the raw graphs relative to it.
 
 Concatenation is [jardine-heinz-2015] Definition 2 *minus its `R_ID` melody merge*
 (the OCP repair, modeled separately as `OCP.collapse`, matching `AR.lean`): on
-association it is the stock disjoint sum `⊕g`; on precedence it is the blockwise sum
-plus, per tier class, bridging arcs from the first factor's precedence-maximal
-vertices to the second factor's precedence-minimal ones. The monoid laws hold up to
-structure-preserving equivalence (`MixedGraph.Iso`), not up to equality — strictness
-belongs to the tiered normal form, not to the foundation.
+edges it is the stock disjoint sum `⊕g`; on arcs it is the blockwise sum plus, per
+tier class, bridging arcs from the first factor's precedence-maximal vertices to
+the second factor's precedence-minimal ones. The monoid laws hold up to
+structure-preserving equivalence (`MixedGraph.Iso`), not up to equality —
+strictness belongs to the tiered normal form, not to the foundation.
 
 ## Main definitions
 
-* `MixedGraph V S`: association `assoc : SimpleGraph V`, precedence
-  `prec : Digraph V`, labeling `label : V → S`; `PrecPath` is the transitive
-  closure of the arcs.
+* `Autosegmental.MixedGraph V S`: a `MixedGraph V` with a labeling `label : V → S`
+  (the owner-relative name: within this namespace, the labeled object, following
+  the dissertation's own usage). `PrecPath` is the transitive closure of the arcs.
 * The [jardine-2016-diss] §4.2 axioms, relative to a tier assignment where tiers
   matter: `IsTierOrdered` (Axioms 1–2), `NoInternalAssoc` (Axiom 3), `IsSaturated`
   (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`), `IsPlanar`
   (Axiom 5, the No-Crossing Constraint in its general path form), `IsOCPClean`
   (Axiom 6).
 * `MixedGraph.Iso`: label- and relation-preserving equivalence;
-  `Iso.assocIso`/`Iso.precIso` project to the stock `SimpleGraph.Iso`/`RelIso`.
+  `Iso.edgesIso`/`Iso.arcsIso` project to the stock `SimpleGraph.Iso`/`RelIso`.
 * `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum.
 
 ## Main results
@@ -54,10 +53,10 @@ belongs to the tiered normal form, not to the foundation.
 
 ## TODO
 
-* Associativity up to `Iso` ([jardine-heinz-2015] Theorem 3; the association
-  component is stock `SimpleGraph.Iso.sumAssoc`, the precedence component is the
-  bridge algebra — conditional on the tier classes being precedence chains, per
-  the paper's Lemma 1 remark).
+* Associativity up to `Iso` ([jardine-heinz-2015] Theorem 3; the edge component is
+  stock `SimpleGraph.Iso.sumAssoc`, the arc component is the bridge algebra —
+  conditional on the tier classes being precedence chains, per the paper's Lemma 1
+  remark).
 * Axiom preservation under `concat` ([jardine-heinz-2015] Theorem 4 and its
   Axiom 1–3 analogues).
 * The normal-form equivalence: every graph satisfying Axioms 1–3 is isomorphic to
@@ -69,20 +68,15 @@ namespace Autosegmental
 
 variable {V V₁ V₂ V₃ S ι : Type*}
 
-/-- A labeled mixed graph `⟨V, E, A, ℓ⟩`: a simple graph of association edges, a
-    digraph of precedence arcs, and a labeling, on one vertex type. -/
-structure MixedGraph (V S : Type*) where
-  /-- The association edges (`E`): symmetric and loopless. -/
-  assoc : SimpleGraph V
-  /-- The precedence arcs (`A`). -/
-  prec : Digraph V
+/-- A labeled mixed graph `⟨V, E, A, ℓ⟩`: a mixed graph with a vertex labeling. -/
+structure MixedGraph (V S : Type*) extends _root_.MixedGraph V where
   /-- The labeling (`ℓ`). -/
   label : V → S
 
 namespace MixedGraph
 
 /-- The precedence-path relation: the transitive closure of the arcs. -/
-def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.prec.Adj
+def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.arcs.Adj
 
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
 def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
@@ -96,30 +90,30 @@ variable (t : S → ι) (G : MixedGraph V S)
     precedence paths totally order each tier class, and no path returns to its
     origin. -/
 def IsTierOrdered : Prop :=
-  (∀ ⦃v w⦄, G.prec.Adj v w → G.tier t v = G.tier t w) ∧
+  (∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) ∧
     (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.PrecPath v w ∨ G.PrecPath w v) ∧
     ∀ v, ¬ G.PrecPath v v
 
 /-- Axiom 3: association never links precedence-path-related (tier-internal)
     vertices. Tier-free — stated on paths alone, as in the dissertation. -/
-def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.assoc.Adj v w → ¬ G.PrecPath v w
+def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.edges.Adj v w → ¬ G.PrecPath v w
 
 /-- Axiom 4 (full specification): every vertex participates in an association.
     [goldsmith-1976]'s original well-formedness condition; stated but deliberately
     not imposed — floating elements are well-formed, as in `AR.lean`. -/
-def IsSaturated : Prop := ∀ v, ∃ w, G.assoc.Adj v w
+def IsSaturated : Prop := ∀ v, ∃ w, G.edges.Adj v w
 
 /-- Axiom 5, the No-Crossing Constraint in [jardine-2016-diss]'s general path
     form: no two association edges whose endpoints straddle in opposite precedence
     order. -/
 def IsPlanar : Prop :=
-  ∀ ⦃v v' w w'⦄, G.assoc.Adj v v' → G.assoc.Adj w w' → G.PrecPath v w →
+  ∀ ⦃v v' w w'⦄, G.edges.Adj v v' → G.edges.Adj w w' → G.PrecPath v w →
     ¬ G.PrecPath w' v'
 
 /-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m` bear
     distinct labels. -/
 def IsOCPClean (m : ι) : Prop :=
-  ∀ ⦃v w⦄, G.prec.Adj v w → G.tier t v = m → G.label v ≠ G.label w
+  ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = m → G.label v ≠ G.label w
 
 end Axioms
 
@@ -127,19 +121,19 @@ end Axioms
 
 /-- A label- and relation-preserving equivalence of labeled mixed graphs. -/
 structure Iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) extends V₁ ≃ V₂ where
-  assoc_iff : ∀ v w, G₂.assoc.Adj (toEquiv v) (toEquiv w) ↔ G₁.assoc.Adj v w
-  prec_iff : ∀ v w, G₂.prec.Adj (toEquiv v) (toEquiv w) ↔ G₁.prec.Adj v w
+  edges_iff : ∀ v w, G₂.edges.Adj (toEquiv v) (toEquiv w) ↔ G₁.edges.Adj v w
+  arcs_iff : ∀ v w, G₂.arcs.Adj (toEquiv v) (toEquiv w) ↔ G₁.arcs.Adj v w
   label_comp : ∀ v, G₂.label (toEquiv v) = G₁.label v
 
-/-- The association face of an isomorphism, as a stock `SimpleGraph.Iso`. -/
-def Iso.assocIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
-    G₁.assoc ≃g G₂.assoc :=
-  ⟨e.toEquiv, fun {v w} => e.assoc_iff v w⟩
+/-- The edge face of an isomorphism, as a stock `SimpleGraph.Iso`. -/
+def Iso.edgesIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
+    G₁.edges ≃g G₂.edges :=
+  ⟨e.toEquiv, fun {v w} => e.edges_iff v w⟩
 
-/-- The precedence face of an isomorphism, as a stock `RelIso`. -/
-def Iso.precIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
-    G₁.prec.Adj ≃r G₂.prec.Adj :=
-  ⟨e.toEquiv, fun {v w} => e.prec_iff v w⟩
+/-- The arc face of an isomorphism, as a stock `RelIso`. -/
+def Iso.arcsIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
+    G₁.arcs.Adj ≃r G₂.arcs.Adj :=
+  ⟨e.toEquiv, fun {v w} => e.arcs_iff v w⟩
 
 /-- The identity isomorphism. -/
 def Iso.refl (G : MixedGraph V S) : Iso G G :=
@@ -148,14 +142,14 @@ def Iso.refl (G : MixedGraph V S) : Iso G G :=
 /-- Inverse isomorphism. -/
 def Iso.symm {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) : Iso G₂ G₁ where
   toEquiv := e.toEquiv.symm
-  assoc_iff v w := by
+  edges_iff v w := by
     conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
       show w = e.toEquiv (e.toEquiv.symm w) from (e.toEquiv.apply_symm_apply w).symm]
-    exact (e.assoc_iff _ _).symm
-  prec_iff v w := by
+    exact (e.edges_iff _ _).symm
+  arcs_iff v w := by
     conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
       show w = e.toEquiv (e.toEquiv.symm w) from (e.toEquiv.apply_symm_apply w).symm]
-    exact (e.prec_iff _ _).symm
+    exact (e.arcs_iff _ _).symm
   label_comp v := by
     conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm]
     exact (e.label_comp _).symm
@@ -164,14 +158,14 @@ def Iso.symm {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁
 def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : MixedGraph V₃ S}
     (e : Iso G₁ G₂) (f : Iso G₂ G₃) : Iso G₁ G₃ where
   toEquiv := e.toEquiv.trans f.toEquiv
-  assoc_iff v w := (f.assoc_iff _ _).trans (e.assoc_iff v w)
-  prec_iff v w := (f.prec_iff _ _).trans (e.prec_iff v w)
+  edges_iff v w := (f.edges_iff _ _).trans (e.edges_iff v w)
+  arcs_iff v w := (f.arcs_iff _ _).trans (e.arcs_iff v w)
   label_comp v := (f.label_comp _).trans (e.label_comp v)
 
 /-! ### The empty graph -/
 
-/-- The empty mixed graph, on the empty vertex type. -/
-def empty (S : Type*) : MixedGraph PEmpty S := ⟨⊥, ⊥, PEmpty.elim⟩
+/-- The empty labeled mixed graph, on the empty vertex type. -/
+def empty (S : Type*) : MixedGraph PEmpty S := ⟨⟨⊥, ⊥⟩, PEmpty.elim⟩
 
 /-! ### Tier-bridging concatenation
 
@@ -194,16 +188,16 @@ def IsTierMin (G : MixedGraph V S) (v : V) : Prop :=
   ∀ ⦃w⦄, G.tier t w = G.tier t v → ¬ G.PrecPath w v
 
 /-- Concatenation ([jardine-heinz-2015] Definition 2, minus the `R_ID` melody
-    merge): stock disjoint sum on association; blockwise sum on precedence plus a
-    bridging arc from each tier-maximal vertex of `G₁` to each same-tier
-    tier-minimal vertex of `G₂`. -/
+    merge): stock disjoint sum on edges; blockwise sum on arcs plus a bridging arc
+    from each tier-maximal vertex of `G₁` to each same-tier tier-minimal vertex of
+    `G₂`. -/
 def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
-  assoc := G₁.assoc ⊕g G₂.assoc
-  prec :=
+  edges := G₁.edges ⊕g G₂.edges
+  arcs :=
     ⟨fun v w =>
       match v, w with
-      | .inl v, .inl w => G₁.prec.Adj v w
-      | .inr v, .inr w => G₂.prec.Adj v w
+      | .inl v, .inl w => G₁.arcs.Adj v w
+      | .inr v, .inr w => G₂.arcs.Adj v w
       | .inl v, .inr w => G₁.tier t v = G₂.tier t w ∧ IsTierMax t G₁ v ∧ IsTierMin t G₂ w
       | .inr _, .inl _ => False⟩
   label := Sum.elim G₁.label G₂.label
@@ -214,27 +208,27 @@ def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V
 @[simp] theorem concat_label_inr (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₂) :
     (concat t G₁ G₂).label (.inr v) = G₂.label v := rfl
 
-@[simp] theorem concat_assoc_eq (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
-    (concat t G₁ G₂).assoc = G₁.assoc ⊕g G₂.assoc := rfl
+@[simp] theorem concat_edges (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
+    (concat t G₁ G₂).edges = G₁.edges ⊕g G₂.edges := rfl
 
-@[simp] theorem concat_prec_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₁} :
-    (concat t G₁ G₂).prec.Adj (.inl v) (.inl w) ↔ G₁.prec.Adj v w := Iff.rfl
+@[simp] theorem concat_arcs_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₁} :
+    (concat t G₁ G₂).arcs.Adj (.inl v) (.inl w) ↔ G₁.arcs.Adj v w := Iff.rfl
 
-@[simp] theorem concat_prec_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₂} :
-    (concat t G₁ G₂).prec.Adj (.inr v) (.inr w) ↔ G₂.prec.Adj v w := Iff.rfl
+@[simp] theorem concat_arcs_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₂} :
+    (concat t G₁ G₂).arcs.Adj (.inr v) (.inr w) ↔ G₂.arcs.Adj v w := Iff.rfl
 
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
 
 /-- Concatenation with the empty graph on the right, up to isomorphism. -/
 def concat_empty_iso (G : MixedGraph V S) : Iso (concat t G (empty S)) G where
   toEquiv := Equiv.sumEmpty V PEmpty
-  assoc_iff v w := by
+  edges_iff v w := by
     rcases v with v | v
     · rcases w with w | w
       · simp [Equiv.sumEmpty]
       · exact w.elim
     · exact v.elim
-  prec_iff v w := by
+  arcs_iff v w := by
     rcases v with v | v
     · rcases w with w | w
       · exact Iff.rfl
@@ -248,13 +242,13 @@ def concat_empty_iso (G : MixedGraph V S) : Iso (concat t G (empty S)) G where
 /-- Concatenation with the empty graph on the left, up to isomorphism. -/
 def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
   toEquiv := Equiv.emptySum PEmpty V
-  assoc_iff v w := by
+  edges_iff v w := by
     rcases v with v | v
     · exact v.elim
     · rcases w with w | w
       · exact w.elim
       · simp [Equiv.emptySum]
-  prec_iff v w := by
+  arcs_iff v w := by
     rcases v with v | v
     · exact v.elim
     · rcases w with w | w

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -3,44 +3,48 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Combinatorics.Digraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
-import Mathlib.Logic.Equiv.Basic
 
 /-!
 # Labeled mixed graphs — the autosegmental foundation
 
 A labeled mixed graph `⟨V, E, A, ℓ⟩` ([jardine-heinz-2015] §2; [jardine-2016-diss]
-§4.1) is the literature's most general autosegmental object: labeled nodes, a
-symmetric association relation `E`, and a directed precedence relation `A`.
-Rendered as pure relations over a vertex-type parameter (the `SimpleGraph`
-pattern), it is a finite relational structure in the model-theoretic-phonology
-sense — unary label predicates plus two binary relations — the format in which
-notational-equivalence results are proved ([jardine-danis-iacoponi-2021],
-[oakden-2020]). Nothing else is stored: in particular no ambient cross-tier
-order, which is structure the object does not have.
+§4.1) is the literature's most general autosegmental object: labeled nodes, undirected
+association edges `E`, and directed precedence arcs `A`. Both graph components are
+stock mathlib objects — `E` is exactly a `SimpleGraph` (the dissertation's edges are
+cardinality-two sets: symmetric and loopless), `A` exactly a `Digraph` — so a labeled
+mixed graph is a `SimpleGraph`, a `Digraph`, and a labeling on one vertex type. As
+pure relations over a vertex-type parameter it is a finite relational structure in
+the model-theoretic-phonology sense — the format in which notational-equivalence
+results are proved ([jardine-danis-iacoponi-2021], [oakden-2020]) — and stores no
+ambient cross-tier order, which is structure the object does not have.
 
 Tiers are not part of the object. A tier assignment `t : S → ι` on the alphabet
 induces the node partition, and [jardine-2016-diss] §4.2's well-formedness axioms
 carve the autosegmental representations out of the raw graphs relative to it.
 
-Concatenation is [jardine-heinz-2015] Definition 2 *minus its `R_ID` melody
-merge* (the OCP repair, modeled separately as `OCP.collapse`, matching
-`AR.lean`): the sum of the vertex types with, per tier class, bridging arcs from
-the first factor's precedence-maximal nodes to the second factor's
-precedence-minimal ones. The monoid laws hold up to structure-preserving
-equivalence (`MixedGraph.Iso`), not up to equality — strictness belongs to the
-tiered normal form, not to the foundation.
+Concatenation is [jardine-heinz-2015] Definition 2 *minus its `R_ID` melody merge*
+(the OCP repair, modeled separately as `OCP.collapse`, matching `AR.lean`): on
+association it is the stock disjoint sum `⊕g`; on precedence it is the blockwise sum
+plus, per tier class, bridging arcs from the first factor's precedence-maximal
+vertices to the second factor's precedence-minimal ones. The monoid laws hold up to
+structure-preserving equivalence (`MixedGraph.Iso`), not up to equality — strictness
+belongs to the tiered normal form, not to the foundation.
 
 ## Main definitions
 
-* `MixedGraph V S`: association `Assoc` (symmetric), precedence `Prec`,
-  labeling `label : V → S`; `PrecPath` is the transitive closure of `Prec`.
+* `MixedGraph V S`: association `assoc : SimpleGraph V`, precedence
+  `prec : Digraph V`, labeling `label : V → S`; `PrecPath` is the transitive
+  closure of the arcs.
 * The [jardine-2016-diss] §4.2 axioms, relative to a tier assignment where tiers
-  matter: `IsTierOrdered` (Axioms 1–2), `NoInternalAssoc` (Axiom 3),
-  `IsSaturated` (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`),
-  `IsPlanar` (Axiom 5, the No-Crossing Constraint in its general path form),
-  `IsOCPClean` (Axiom 6).
-* `MixedGraph.Iso`: label- and relation-preserving equivalence.
+  matter: `IsTierOrdered` (Axioms 1–2), `NoInternalAssoc` (Axiom 3), `IsSaturated`
+  (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`), `IsPlanar`
+  (Axiom 5, the No-Crossing Constraint in its general path form), `IsOCPClean`
+  (Axiom 6).
+* `MixedGraph.Iso`: label- and relation-preserving equivalence;
+  `Iso.assocIso`/`Iso.precIso` project to the stock `SimpleGraph.Iso`/`RelIso`.
 * `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum.
 
 ## Main results
@@ -50,36 +54,35 @@ tiered normal form, not to the foundation.
 
 ## TODO
 
-* Associativity up to `Iso` ([jardine-heinz-2015] Theorem 3; conditional on the
-  tier classes being precedence chains, per the paper's Lemma 1 remark).
+* Associativity up to `Iso` ([jardine-heinz-2015] Theorem 3; the association
+  component is stock `SimpleGraph.Iso.sumAssoc`, the precedence component is the
+  bridge algebra — conditional on the tier classes being precedence chains, per
+  the paper's Lemma 1 remark).
 * Axiom preservation under `concat` ([jardine-heinz-2015] Theorem 4 and its
   Axiom 1–3 analogues).
-* The normal-form equivalence: every graph satisfying Axioms 1–3 is isomorphic
-  to a tier-indexed family of `LabeledTuple`s with per-pair links — the strict
-  tiered presentation `MultiAR` builds on — with `IsPlanar` reducing to the
-  per-pair NCC.
+* The normal-form equivalence: every graph satisfying Axioms 1–3 is isomorphic to
+  a tier-indexed family of `LabeledTuple`s with per-pair links — the strict tiered
+  presentation `MultiAR` builds on — with `IsPlanar` reducing to the per-pair NCC.
 -/
 
 namespace Autosegmental
 
 variable {V V₁ V₂ V₃ S ι : Type*}
 
-/-- A labeled mixed graph `⟨V, E, A, ℓ⟩`: a symmetric association relation, a
-    directed precedence relation, and a labeling of the vertices. -/
+/-- A labeled mixed graph `⟨V, E, A, ℓ⟩`: a simple graph of association edges, a
+    digraph of precedence arcs, and a labeling, on one vertex type. -/
 structure MixedGraph (V S : Type*) where
-  /-- The association relation (`E`), undirected. -/
-  Assoc : V → V → Prop
-  /-- Association is symmetric. -/
-  assoc_symm : Std.Symm Assoc
-  /-- The precedence relation (`A`), directed. -/
-  Prec : V → V → Prop
+  /-- The association edges (`E`): symmetric and loopless. -/
+  assoc : SimpleGraph V
+  /-- The precedence arcs (`A`). -/
+  prec : Digraph V
   /-- The labeling (`ℓ`). -/
   label : V → S
 
 namespace MixedGraph
 
-/-- The precedence-path relation: the transitive closure of `Prec`. -/
-def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.Prec
+/-- The precedence-path relation: the transitive closure of the arcs. -/
+def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.prec.Adj
 
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
 def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
@@ -93,30 +96,30 @@ variable (t : S → ι) (G : MixedGraph V S)
     precedence paths totally order each tier class, and no path returns to its
     origin. -/
 def IsTierOrdered : Prop :=
-  (∀ ⦃v w⦄, G.Prec v w → G.tier t v = G.tier t w) ∧
+  (∀ ⦃v w⦄, G.prec.Adj v w → G.tier t v = G.tier t w) ∧
     (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.PrecPath v w ∨ G.PrecPath w v) ∧
     ∀ v, ¬ G.PrecPath v v
 
 /-- Axiom 3: association never links precedence-path-related (tier-internal)
     vertices. Tier-free — stated on paths alone, as in the dissertation. -/
-def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.Assoc v w → ¬ G.PrecPath v w
+def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.assoc.Adj v w → ¬ G.PrecPath v w
 
 /-- Axiom 4 (full specification): every vertex participates in an association.
-    [goldsmith-1976]'s original well-formedness condition; stated but
-    deliberately not imposed — floating elements are well-formed, as in
-    `AR.lean`. -/
-def IsSaturated : Prop := ∀ v, ∃ w, G.Assoc v w
+    [goldsmith-1976]'s original well-formedness condition; stated but deliberately
+    not imposed — floating elements are well-formed, as in `AR.lean`. -/
+def IsSaturated : Prop := ∀ v, ∃ w, G.assoc.Adj v w
 
 /-- Axiom 5, the No-Crossing Constraint in [jardine-2016-diss]'s general path
-    form: no two association edges whose endpoints straddle in opposite
-    precedence order. -/
+    form: no two association edges whose endpoints straddle in opposite precedence
+    order. -/
 def IsPlanar : Prop :=
-  ∀ ⦃v v' w w'⦄, G.Assoc v v' → G.Assoc w w' → G.PrecPath v w → ¬ G.PrecPath w' v'
+  ∀ ⦃v v' w w'⦄, G.assoc.Adj v v' → G.assoc.Adj w w' → G.PrecPath v w →
+    ¬ G.PrecPath w' v'
 
-/-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m`
-    bear distinct labels. -/
+/-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m` bear
+    distinct labels. -/
 def IsOCPClean (m : ι) : Prop :=
-  ∀ ⦃v w⦄, G.Prec v w → G.tier t v = m → G.label v ≠ G.label w
+  ∀ ⦃v w⦄, G.prec.Adj v w → G.tier t v = m → G.label v ≠ G.label w
 
 end Axioms
 
@@ -124,9 +127,19 @@ end Axioms
 
 /-- A label- and relation-preserving equivalence of labeled mixed graphs. -/
 structure Iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) extends V₁ ≃ V₂ where
-  assoc_iff : ∀ v w, G₂.Assoc (toEquiv v) (toEquiv w) ↔ G₁.Assoc v w
-  prec_iff : ∀ v w, G₂.Prec (toEquiv v) (toEquiv w) ↔ G₁.Prec v w
+  assoc_iff : ∀ v w, G₂.assoc.Adj (toEquiv v) (toEquiv w) ↔ G₁.assoc.Adj v w
+  prec_iff : ∀ v w, G₂.prec.Adj (toEquiv v) (toEquiv w) ↔ G₁.prec.Adj v w
   label_comp : ∀ v, G₂.label (toEquiv v) = G₁.label v
+
+/-- The association face of an isomorphism, as a stock `SimpleGraph.Iso`. -/
+def Iso.assocIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
+    G₁.assoc ≃g G₂.assoc :=
+  ⟨e.toEquiv, fun {v w} => e.assoc_iff v w⟩
+
+/-- The precedence face of an isomorphism, as a stock `RelIso`. -/
+def Iso.precIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
+    G₁.prec.Adj ≃r G₂.prec.Adj :=
+  ⟨e.toEquiv, fun {v w} => e.prec_iff v w⟩
 
 /-- The identity isomorphism. -/
 def Iso.refl (G : MixedGraph V S) : Iso G G :=
@@ -158,11 +171,7 @@ def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : Mixe
 /-! ### The empty graph -/
 
 /-- The empty mixed graph, on the empty vertex type. -/
-def empty (S : Type*) : MixedGraph PEmpty S where
-  Assoc _ _ := False
-  assoc_symm := ⟨fun _ _ h => h.elim⟩
-  Prec _ _ := False
-  label v := v.elim
+def empty (S : Type*) : MixedGraph PEmpty S := ⟨⊥, ⊥, PEmpty.elim⟩
 
 /-! ### Tier-bridging concatenation
 
@@ -185,26 +194,18 @@ def IsTierMin (G : MixedGraph V S) (v : V) : Prop :=
   ∀ ⦃w⦄, G.tier t w = G.tier t v → ¬ G.PrecPath w v
 
 /-- Concatenation ([jardine-heinz-2015] Definition 2, minus the `R_ID` melody
-    merge): the vertex sum, with association and precedence inherited blockwise
-    and a bridging arc from each tier-maximal vertex of `G₁` to each same-tier
+    merge): stock disjoint sum on association; blockwise sum on precedence plus a
+    bridging arc from each tier-maximal vertex of `G₁` to each same-tier
     tier-minimal vertex of `G₂`. -/
 def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
-  Assoc v w :=
-    match v, w with
-    | .inl v, .inl w => G₁.Assoc v w
-    | .inr v, .inr w => G₂.Assoc v w
-    | _, _ => False
-  assoc_symm := ⟨by
-    intro v w h
-    cases v <;> cases w <;> simp_all only
-    exacts [G₁.assoc_symm.symm _ _ h, G₂.assoc_symm.symm _ _ h]⟩
-  Prec v w :=
-    match v, w with
-    | .inl v, .inl w => G₁.Prec v w
-    | .inr v, .inr w => G₂.Prec v w
-    | .inl v, .inr w =>
-        G₁.tier t v = G₂.tier t w ∧ IsTierMax t G₁ v ∧ IsTierMin t G₂ w
-    | .inr _, .inl _ => False
+  assoc := G₁.assoc ⊕g G₂.assoc
+  prec :=
+    ⟨fun v w =>
+      match v, w with
+      | .inl v, .inl w => G₁.prec.Adj v w
+      | .inr v, .inr w => G₂.prec.Adj v w
+      | .inl v, .inr w => G₁.tier t v = G₂.tier t w ∧ IsTierMax t G₁ v ∧ IsTierMin t G₂ w
+      | .inr _, .inl _ => False⟩
   label := Sum.elim G₁.label G₂.label
 
 @[simp] theorem concat_label_inl (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₁) :
@@ -213,11 +214,14 @@ def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V
 @[simp] theorem concat_label_inr (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₂) :
     (concat t G₁ G₂).label (.inr v) = G₂.label v := rfl
 
-@[simp] theorem concat_assoc_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₁} :
-    (concat t G₁ G₂).Assoc (.inl v) (.inl w) ↔ G₁.Assoc v w := Iff.rfl
+@[simp] theorem concat_assoc_eq (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
+    (concat t G₁ G₂).assoc = G₁.assoc ⊕g G₂.assoc := rfl
 
-@[simp] theorem concat_assoc_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₂} :
-    (concat t G₁ G₂).Assoc (.inr v) (.inr w) ↔ G₂.Assoc v w := Iff.rfl
+@[simp] theorem concat_prec_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₁} :
+    (concat t G₁ G₂).prec.Adj (.inl v) (.inl w) ↔ G₁.prec.Adj v w := Iff.rfl
+
+@[simp] theorem concat_prec_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₂} :
+    (concat t G₁ G₂).prec.Adj (.inr v) (.inr w) ↔ G₂.prec.Adj v w := Iff.rfl
 
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
 
@@ -227,7 +231,7 @@ def concat_empty_iso (G : MixedGraph V S) : Iso (concat t G (empty S)) G where
   assoc_iff v w := by
     rcases v with v | v
     · rcases w with w | w
-      · exact Iff.rfl
+      · simp [Equiv.sumEmpty]
       · exact w.elim
     · exact v.elim
   prec_iff v w := by
@@ -249,7 +253,7 @@ def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
     · exact v.elim
     · rcases w with w | w
       · exact w.elim
-      · exact Iff.rfl
+      · simp [Equiv.emptySum]
   prec_iff v w := by
     rcases v with v | v
     · exact v.elim

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -339,7 +339,11 @@ def isRepresentation : ObjectProperty (MixedGraphCat S) := fun X =>
   X.graph.IsTierOrdered t ∧ X.graph.NoInternalAssoc
 
 /-- The category of autosegmental representations over a tier assignment: the
-    full subcategory of labeled mixed graphs satisfying the structural axioms. -/
+    full subcategory of labeled mixed graphs satisfying the structural axioms.
+    These are the formal literature's **ARs** — [jardine-2019] and
+    [chandlee-jardine-2019] introduce "autosegmental representation" once and
+    use `AR` as the type-name throughout; this category takes that name once the
+    bipartite strict carrier currently called `AR` is dissolved into it. -/
 abbrev Representation := (isRepresentation t).FullSubcategory
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
@@ -11,11 +12,13 @@ import Linglib.Core.Combinatorics.MixedGraph
 /-!
 # Labeled mixed graphs — the autosegmental foundation
 
-A labeled mixed graph `⟨V, E, A, ℓ⟩` ([jardine-heinz-2015] §2; [jardine-2016-diss]
-§4.1) is the literature's most general autosegmental object: a mixed graph
-(`Core/Combinatorics/MixedGraph.lean` — undirected association edges `E`, here a
-`SimpleGraph` since the dissertation's edges are cardinality-two sets, and directed
-precedence arcs `A`, a `Digraph`) together with a vertex labeling. As pure relations
+A labeled mixed graph `⟨V, E, A, ℓ⟩` ([jardine-2019] §5; [jardine-heinz-2015] §2;
+[jardine-2016-diss] §4.1) is the literature's most general autosegmental object: a
+mixed graph (`Core/Combinatorics/MixedGraph.lean` — undirected association edges
+`E ⊆ [V]²`, here a `SimpleGraph` since the edges are two-element subsets, and
+directed arcs `A ⊆ V × V` "representing the order on each string", a `Digraph`)
+together with a total vertex labeling. The raw graphs are [jardine-2019]'s
+`GR(Γ)`, here the category `MixedGraphCat`. As pure relations
 over a vertex-type parameter it is a finite relational structure in the
 model-theoretic-phonology sense — the format in which notational-equivalence results
 are proved ([jardine-danis-iacoponi-2021], [oakden-2020]) — and stores no ambient
@@ -175,6 +178,11 @@ def Iso.arcsIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G
     G₁.arcs.Adj ≃r G₂.arcs.Adj :=
   ⟨e.toEquiv, fun {v w} => e.arcs_iff v w⟩
 
+/-- An isomorphism as a morphism. -/
+def Iso.toHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) : Hom G₁ G₂ :=
+  ⟨e.toEquiv, fun _ _ h => (e.edges_iff _ _).mpr h, fun _ _ h => (e.arcs_iff _ _).mpr h,
+    e.label_comp⟩
+
 /-- The identity isomorphism. -/
 def Iso.refl (G : MixedGraph V S) : Iso G G :=
   ⟨Equiv.refl V, fun _ _ => Iff.rfl, fun _ _ => Iff.rfl, fun _ => rfl⟩
@@ -207,30 +215,31 @@ def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : Mixe
 /-- The empty labeled mixed graph, on the empty vertex type. -/
 def empty (S : Type*) : MixedGraph PEmpty S := ⟨⟨⊥, ⊥⟩, PEmpty.elim⟩
 
+theorem empty_isTierOrdered (t : S → ι) : (empty S).IsTierOrdered t :=
+  ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
+
+theorem empty_noInternalAssoc : (empty S).NoInternalAssoc := fun v => v.elim
+
 /-! ### Tier-bridging concatenation
 
-Per tier class, concatenation adds bridging arcs from the first factor's
-precedence-maximal vertices of that class to the second factor's
-precedence-minimal ones. On graphs whose tier classes are precedence chains
-(Axioms 1–2) this is [jardine-heinz-2015]'s last-to-first bridge; on raw graphs
-it is total (a maximal-to-minimal complete bridge), where the paper's
-`first`/`last` are partial. -/
+Per tier class, concatenation is the ordinal sum: blockwise arcs plus a bridging
+arc from every `G₁`-vertex of a class to every same-class `G₂`-vertex. This is
+the signature of [jardine-2019]'s own formulation — arcs represent *the order* on
+each string, not its successor steps — under which [jardine-heinz-2015]
+Definition 2's last-to-first successor bridge becomes the complete same-class
+bridge (the two signatures are interdefinable over these structures,
+[jardine-2017-complexity]). The order form makes the bridge total (the paper's
+`first`/`last` are partial) and functorial, and its monoid laws unconditional
+where the successor form's associativity is conditional on the tier classes being
+string graphs (the paper's Lemma 1 remark). -/
 
 section Concat
 variable (t : S → ι)
 
-/-- `v` is precedence-maximal within its tier class. -/
-def IsTierMax (G : MixedGraph V S) (v : V) : Prop :=
-  ∀ ⦃w⦄, G.tier t w = G.tier t v → ¬ G.PrecPath v w
-
-/-- `v` is precedence-minimal within its tier class. -/
-def IsTierMin (G : MixedGraph V S) (v : V) : Prop :=
-  ∀ ⦃w⦄, G.tier t w = G.tier t v → ¬ G.PrecPath w v
-
 /-- Concatenation ([jardine-heinz-2015] Definition 2, minus the `R_ID` melody
-    merge): stock disjoint sum on edges; blockwise sum on arcs plus a bridging arc
-    from each tier-maximal vertex of `G₁` to each same-tier tier-minimal vertex of
-    `G₂`. -/
+    merge, in the precedence signature): stock disjoint sum on edges; on arcs the
+    per-tier ordinal sum — blockwise arcs plus a bridge from each `G₁`-vertex to
+    each same-tier `G₂`-vertex. -/
 def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
   edges := G₁.edges ⊕g G₂.edges
   arcs :=
@@ -238,7 +247,7 @@ def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V
       match v, w with
       | .inl v, .inl w => G₁.arcs.Adj v w
       | .inr v, .inr w => G₂.arcs.Adj v w
-      | .inl v, .inr w => G₁.tier t v = G₂.tier t w ∧ IsTierMax t G₁ v ∧ IsTierMin t G₂ w
+      | .inl v, .inr w => G₁.tier t v = G₂.tier t w
       | .inr _, .inl _ => False⟩
   label := Sum.elim G₁.label G₂.label
 
@@ -299,6 +308,139 @@ def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
     · exact v.elim
     · rfl
 
+/-! #### Precedence paths in a concatenation
+
+Paths never return from the second block to the first, so blockwise paths
+decompose into factor paths. -/
+
+private lemma precPath_inr_cases {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {b : V₂}
+    {y : V₁ ⊕ V₂} (h : (concat t G₁ G₂).PrecPath (.inr b) y) :
+    ∃ b', y = .inr b' ∧ G₂.PrecPath b b' := by
+  induction h with
+  | @single y' h =>
+      cases y' with
+      | inl a => exact (h : False).elim
+      | inr b' => exact ⟨b', rfl, .single (h : G₂.arcs.Adj b b')⟩
+  | @tail y' y'' _ h ih =>
+      obtain ⟨b'', rfl, hp⟩ := ih
+      cases y'' with
+      | inl a => exact (h : False).elim
+      | inr b' => exact ⟨b', rfl, hp.tail (h : G₂.arcs.Adj b'' b')⟩
+
+private lemma precPath_inl_cases {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {a : V₁}
+    {y : V₁ ⊕ V₂} (h : (concat t G₁ G₂).PrecPath (.inl a) y) :
+    (∃ a', y = .inl a' ∧ G₁.PrecPath a a') ∨ ∃ b, y = .inr b := by
+  induction h with
+  | @single y' h =>
+      cases y' with
+      | inl a' => exact Or.inl ⟨a', rfl, .single (h : G₁.arcs.Adj a a')⟩
+      | inr b => exact Or.inr ⟨b, rfl⟩
+  | @tail y' y'' _ h ih =>
+      rcases ih with ⟨a'', rfl, hp⟩ | ⟨b, rfl⟩
+      · cases y'' with
+        | inl a' => exact Or.inl ⟨a', rfl, hp.tail (h : G₁.arcs.Adj a'' a')⟩
+        | inr b => exact Or.inr ⟨b, rfl⟩
+      · cases y'' with
+        | inl a' => exact (h : False).elim
+        | inr b' => exact Or.inr ⟨b', rfl⟩
+
+@[simp] theorem concat_precPath_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
+    {a a' : V₁} : (concat t G₁ G₂).PrecPath (.inl a) (.inl a') ↔ G₁.PrecPath a a' := by
+  constructor
+  · intro h
+    rcases precPath_inl_cases t h with ⟨x, hx, hp⟩ | ⟨b, hb⟩
+    · cases hx; exact hp
+    · exact absurd hb (by simp)
+  · intro h
+    exact Relation.TransGen.lift Sum.inl (fun _ _ hab => hab) h
+
+@[simp] theorem concat_precPath_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
+    {b b' : V₂} : (concat t G₁ G₂).PrecPath (.inr b) (.inr b') ↔ G₂.PrecPath b b' := by
+  constructor
+  · intro h
+    obtain ⟨x, hx, hp⟩ := precPath_inr_cases t h
+    cases hx; exact hp
+  · intro h
+    exact Relation.TransGen.lift Sum.inr (fun _ _ hab => hab) h
+
+@[simp] theorem concat_not_precPath_inr_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
+    {b : V₂} {a : V₁} : ¬ (concat t G₁ G₂).PrecPath (.inr b) (.inl a) := fun h => by
+  obtain ⟨_, hx, _⟩ := precPath_inr_cases t h
+  exact absurd hx (by simp)
+
+/-! #### Axiom preservation ([jardine-heinz-2015] Theorem 4's structural half) -/
+
+/-- Concatenation preserves Axioms 1–2. -/
+theorem isTierOrdered_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
+    (h₁ : G₁.IsTierOrdered t) (h₂ : G₂.IsTierOrdered t) :
+    (concat t G₁ G₂).IsTierOrdered t := by
+  refine ⟨?_, ?_, ?_⟩
+  · rintro (v | v) (w | w) h
+    exacts [h₁.1 h, h, h.elim, h₂.1 h]
+  · rintro (v | v) (w | w) hne htier
+    · rcases h₁.2.1 (by simpa using hne) htier with hp | hp
+      · exact Or.inl ((concat_precPath_inl_inl t).mpr hp)
+      · exact Or.inr ((concat_precPath_inl_inl t).mpr hp)
+    · exact Or.inl (.single htier)
+    · exact Or.inr (.single htier.symm)
+    · rcases h₂.2.1 (by simpa using hne) htier with hp | hp
+      · exact Or.inl ((concat_precPath_inr_inr t).mpr hp)
+      · exact Or.inr ((concat_precPath_inr_inr t).mpr hp)
+  · rintro (v | v) h
+    · exact h₁.2.2 v ((concat_precPath_inl_inl t).mp h)
+    · exact h₂.2.2 v ((concat_precPath_inr_inr t).mp h)
+
+/-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross edges,
+    and blockwise paths are factor paths. -/
+theorem noInternalAssoc_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
+    (h₁ : G₁.NoInternalAssoc) (h₂ : G₂.NoInternalAssoc) :
+    (concat t G₁ G₂).NoInternalAssoc := by
+  rintro (v | v) (w | w) hadj hp
+  · exact h₁ hadj ((concat_precPath_inl_inl t).mp hp)
+  · exact absurd hadj (by simp)
+  · exact absurd hadj (by simp)
+  · exact h₂ hadj ((concat_precPath_inr_inr t).mp hp)
+
+/-! #### Functoriality of concatenation -/
+
+/-- Concatenation of morphisms is `Sum.map`: blockwise preservation from the
+    factors, and label preservation transports the bridge's tier equality. Domain and codomain
+    of each factor may have independent vertex types, as morphisms in `MixedGraphCat S` do. -/
+def Hom.sumMap {V₁' V₂' : Type*} {G₁ : MixedGraph V₁ S} {G₁' : MixedGraph V₁' S}
+    {G₂ : MixedGraph V₂ S} {G₂' : MixedGraph V₂' S}
+    (f : Hom G₁ G₁') (g : Hom G₂ G₂') : Hom (concat t G₁ G₂) (concat t G₁' G₂') where
+  toFun := Sum.map f.toFun g.toFun
+  edge_map := by
+    rintro (v | v) (w | w) h
+    · exact f.edge_map h
+    · exact absurd h (by simp)
+    · exact absurd h (by simp)
+    · exact g.edge_map h
+  arc_map := by
+    rintro (v | v) (w | w) h
+    · exact f.arc_map h
+    · exact (congrArg t (f.label_comp v)).trans (h.trans (congrArg t (g.label_comp w)).symm)
+    · exact h.elim
+    · exact g.arc_map h
+  label_comp := by
+    rintro (v | v)
+    · exact f.label_comp v
+    · exact g.label_comp v
+
+/-! #### Associativity up to isomorphism ([jardine-heinz-2015] Theorem 3) -/
+
+/-- Concatenation is associative up to isomorphism, over `Equiv.sumAssoc`; the
+    edge face is the stock `SimpleGraph.Iso.sumAssoc`, and every arc case holds
+    definitionally in the order signature. -/
+def concat_assoc_iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (G₃ : MixedGraph V₃ S) :
+    Iso (concat t (concat t G₁ G₂) G₃) (concat t G₁ (concat t G₂ G₃)) where
+  toEquiv := Equiv.sumAssoc V₁ V₂ V₃
+  edges_iff v w := SimpleGraph.Iso.sumAssoc.map_rel_iff
+  arcs_iff v w := by
+    rcases v with (a | b) | c <;> rcases w with (a' | b') | c' <;> exact Iff.rfl
+  label_comp v := by
+    rcases v with (a | b) | c <;> rfl
+
 end Concat
 
 end MixedGraph
@@ -345,5 +487,103 @@ def isRepresentation : ObjectProperty (MixedGraphCat S) := fun X =>
     use `AR` as the type-name throughout; this category takes that name once the
     bipartite strict carrier currently called `AR` is dissolved into it. -/
 abbrev Representation := (isRepresentation t).FullSubcategory
+
+/-! ### The monoidal structure: morpheme concatenation -/
+
+namespace Representation
+
+open MonoidalCategory
+
+variable {t}
+
+/-- The tensor unit: the empty representation. -/
+def unit : Representation t :=
+  ⟨⟨PEmpty, MixedGraph.empty S⟩, MixedGraph.empty_isTierOrdered t,
+    MixedGraph.empty_noInternalAssoc⟩
+
+/-- The tensor: morpheme concatenation, staying in the axiom class by
+    `isTierOrdered_concat`/`noInternalAssoc_concat`. -/
+def tensor (X Y : Representation t) : Representation t :=
+  ⟨⟨X.obj.V ⊕ Y.obj.V, MixedGraph.concat t X.obj.graph Y.obj.graph⟩,
+    MixedGraph.isTierOrdered_concat t X.property.1 Y.property.1,
+    MixedGraph.noInternalAssoc_concat t X.property.2 Y.property.2⟩
+
+/-- A graph isomorphism as an isomorphism of representations. -/
+def mkIso {X Y : Representation t} (e : MixedGraph.Iso X.obj.graph Y.obj.graph) : X ≅ Y :=
+  InducedCategory.isoMk
+    ⟨e.toHom, e.symm.toHom,
+      MixedGraph.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v),
+      MixedGraph.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)⟩
+
+/-- The tensor on morphisms, as a representation morphism. -/
+def tensorHomAux {X₁ Y₁ X₂ Y₂ : Representation t} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
+    tensor X₁ X₂ ⟶ tensor Y₁ Y₂ :=
+  InducedCategory.homMk (MixedGraph.Hom.sumMap (G₁ := X₁.obj.graph) (G₁' := Y₁.obj.graph)
+    (G₂ := X₂.obj.graph) (G₂' := Y₂.obj.graph) t f.hom g.hom)
+
+/-- Left whiskering, as a representation morphism. -/
+def whiskerLeftAux (X : Representation t) {Y₁ Y₂ : Representation t} (f : Y₁ ⟶ Y₂) :
+    tensor X Y₁ ⟶ tensor X Y₂ :=
+  InducedCategory.homMk (MixedGraph.Hom.sumMap (G₁ := X.obj.graph) (G₁' := X.obj.graph)
+    (G₂ := Y₁.obj.graph) (G₂' := Y₂.obj.graph) t (MixedGraph.Hom.id X.obj.graph) f.hom)
+
+/-- Right whiskering, as a representation morphism. -/
+def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Representation t) :
+    tensor X₁ Y ⟶ tensor X₂ Y :=
+  InducedCategory.homMk (MixedGraph.Hom.sumMap (G₁ := X₁.obj.graph) (G₁' := X₂.obj.graph)
+    (G₂ := Y.obj.graph) (G₂' := Y.obj.graph) t f.hom (MixedGraph.Hom.id Y.obj.graph))
+
+@[simps] instance instMonoidalStruct : MonoidalCategoryStruct (Representation t) where
+  tensorObj := tensor
+  tensorUnit := unit
+  tensorHom := tensorHomAux
+  whiskerLeft := whiskerLeftAux
+  whiskerRight := whiskerRightAux
+  associator X Y Z := mkIso (MixedGraph.concat_assoc_iso t X.obj.graph Y.obj.graph Z.obj.graph)
+  leftUnitor X := mkIso (MixedGraph.empty_concat_iso t X.obj.graph)
+  rightUnitor X := mkIso (MixedGraph.concat_empty_iso t X.obj.graph)
+
+/-- The category of autosegmental representations is monoidal under morpheme
+    concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as coherence,
+    with every proof a componentwise `rfl` over the concrete sum maps. -/
+instance : MonoidalCategory (Representation t) :=
+  MonoidalCategory.ofTensorHom
+    (id_tensorHom_id := fun _ _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
+    (id_tensorHom := fun _ _ _ _ => rfl)
+    (tensorHom_id := fun _ _ => rfl)
+    (tensorHom_comp_tensorHom := fun _ _ _ _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
+    (associator_naturality := fun _ _ _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by
+        rcases (v : _ ⊕ _) with v | v
+        · rcases (v : _ ⊕ _) with v | v <;> rfl
+        · rfl)))
+    (leftUnitor_naturality := fun _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by
+        rcases (v : _ ⊕ _) with v | v
+        · exact v.elim
+        · rfl)))
+    (rightUnitor_naturality := fun _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by
+        rcases (v : _ ⊕ _) with v | v
+        · rfl
+        · exact v.elim)))
+    (pentagon := fun _ _ _ _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by
+        rcases (v : _ ⊕ _) with v | v
+        · rcases (v : _ ⊕ _) with v | v
+          · rcases (v : _ ⊕ _) with v | v <;> rfl
+          · rfl
+        · rfl)))
+    (triangle := fun _ _ => InducedCategory.hom_ext
+      (MixedGraph.Hom.ext (funext fun v => by
+        rcases (v : _ ⊕ _) with v | v
+        · rcases (v : _ ⊕ _) with v | v
+          · rfl
+          · exact v.elim
+        · rfl)))
+
+end Representation
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
 import Linglib.Core.Combinatorics.MixedGraph
@@ -42,9 +43,14 @@ strictness belongs to the tiered normal form, not to the foundation.
   (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`), `IsPlanar`
   (Axiom 5, the No-Crossing Constraint in its general path form), `IsOCPClean`
   (Axiom 6).
-* `MixedGraph.Iso`: label- and relation-preserving equivalence;
-  `Iso.edgesIso`/`Iso.arcsIso` project to the stock `SimpleGraph.Iso`/`RelIso`.
+* `MixedGraph.Hom` / `MixedGraph.Iso`: label- and relation-preserving maps and
+  equivalences; faces project to the stock `SimpleGraph.Hom`/`Iso` and
+  `RelHom`/`RelIso`.
 * `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum.
+* `MixedGraphCat S`: **the category of labeled mixed graphs** (vertex type
+  bundled with a graph); `Representation t` is **the category of autosegmental
+  representations** — the full subcategory of the structural axiom class
+  (Axioms 1–3), the category autosegmental phonology actually works in.
 
 ## Main results
 
@@ -116,6 +122,40 @@ def IsOCPClean (m : ι) : Prop :=
   ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = m → G.label v ≠ G.label w
 
 end Axioms
+
+/-! ### Morphisms -/
+
+/-- A label- and relation-preserving map of labeled mixed graphs. -/
+@[ext]
+structure Hom (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) where
+  /-- The vertex map. -/
+  toFun : V₁ → V₂
+  /-- Association edges are preserved. -/
+  edge_map : ∀ ⦃v w⦄, G₁.edges.Adj v w → G₂.edges.Adj (toFun v) (toFun w)
+  /-- Precedence arcs are preserved. -/
+  arc_map : ∀ ⦃v w⦄, G₁.arcs.Adj v w → G₂.arcs.Adj (toFun v) (toFun w)
+  /-- Labels are preserved. -/
+  label_comp : ∀ v, G₂.label (toFun v) = G₁.label v
+
+/-- The edge face of a morphism, a stock graph homomorphism. -/
+def Hom.edgesHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (f : Hom G₁ G₂) :
+    G₁.edges →g G₂.edges :=
+  ⟨f.toFun, fun h => f.edge_map h⟩
+
+/-- The arc face of a morphism, a stock relation homomorphism. -/
+def Hom.arcsHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (f : Hom G₁ G₂) :
+    G₁.arcs.Adj →r G₂.arcs.Adj :=
+  ⟨f.toFun, fun h => f.arc_map h⟩
+
+/-- The identity morphism. -/
+def Hom.id (G : MixedGraph V S) : Hom G G :=
+  ⟨_root_.id, fun _ _ h => h, fun _ _ h => h, fun _ => rfl⟩
+
+/-- Composition of morphisms. -/
+def Hom.comp {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : MixedGraph V₃ S}
+    (f : Hom G₁ G₂) (g : Hom G₂ G₃) : Hom G₁ G₃ :=
+  ⟨g.toFun ∘ f.toFun, fun _ _ h => g.edge_map (f.edge_map h),
+    fun _ _ h => g.arc_map (f.arc_map h), fun v => (g.label_comp _).trans (f.label_comp v)⟩
 
 /-! ### Isomorphism -/
 
@@ -262,5 +302,44 @@ def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
 end Concat
 
 end MixedGraph
+
+/-! ### The category of labeled mixed graphs -/
+
+open CategoryTheory
+
+universe u v
+
+/-- An object of the category of labeled mixed graphs over `S`: a vertex type
+    bundled with a labeled mixed graph on it. -/
+structure MixedGraphCat (S : Type v) : Type (max (u + 1) v) where
+  /-- The vertex type. -/
+  V : Type u
+  /-- The labeled mixed graph. -/
+  graph : MixedGraph V S
+
+namespace MixedGraphCat
+
+instance : Category (MixedGraphCat S) where
+  Hom X Y := MixedGraph.Hom X.graph Y.graph
+  id X := MixedGraph.Hom.id X.graph
+  comp f g := f.comp g
+  id_comp _ := MixedGraph.Hom.ext rfl
+  comp_id _ := MixedGraph.Hom.ext rfl
+  assoc _ _ _ := MixedGraph.Hom.ext rfl
+
+end MixedGraphCat
+
+/-! ### The category of autosegmental representations -/
+
+variable (t : S → ι)
+
+/-- The structural axiom class ([jardine-2016-diss] §4.2, Axioms 1–3) as an
+    object property of the graph category. -/
+def isRepresentation : ObjectProperty (MixedGraphCat S) := fun X =>
+  X.graph.IsTierOrdered t ∧ X.graph.NoInternalAssoc
+
+/-- The category of autosegmental representations over a tier assignment: the
+    full subcategory of labeled mixed graphs satisfying the structural axioms. -/
+abbrev Representation := (isRepresentation t).FullSubcategory
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MultiAR.lean
+++ b/Linglib/Phonology/Autosegmental/MultiAR.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Finset.Image
 import Mathlib.Data.Fintype.Pi
 import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple
 import Linglib.Core.Data.Fin.Tuple.Basic
+import Linglib.Phonology.Autosegmental.MixedGraph
 import Linglib.Phonology.Autosegmental.NonCrossing
 
 /-!
@@ -396,5 +397,126 @@ instance : MonoidalCategory (MultiAR τ) :=
     (triangle := by intros; simp [eqToHom_trans])
 
 end MultiAR
+
+/-! ### Interpretation into the labeled mixed graph foundation
+
+The tiered presentation denotes a labeled mixed graph (`MixedGraph.lean`) by
+construction: vertices are per-tier positions, the alphabet is the
+tier-partitioned `Σ i, τ i` with tier assignment `Sigma.fst`, arcs are within-tier
+successors, and edges symmetrize the per-pair links. The structural §4.2 axioms
+hold as properties of the construction (`toMixedGraph_isTierOrdered`,
+`toMixedGraph_noInternalAssoc`), and the foundational path-form No-Crossing
+Constraint agrees with the per-pair `IsPlanar` exactly on orientation-normalized
+presentations (`toMixedGraph_isPlanar_iff`) — links between two tiers must be
+stored in one orientation bucket, since the path form also sees crossings between
+an `(i, j)` link and a `(j, i)` link, which the per-pair check cannot couple. -/
+
+namespace MultiGraph
+
+/-- The labeled mixed graph a tiered presentation denotes: per-tier positions as
+    vertices, within-tier successor arcs, symmetrized per-pair links as edges. -/
+def toMixedGraph (M : MultiGraph τ) :
+    MixedGraph ((i : Fin n) × Fin (M.tiers i).len) ((i : Fin n) × τ i) where
+  edges :=
+    { Adj := fun v w => v ≠ w ∧
+        (((v.2 : ℕ), (w.2 : ℕ)) ∈ M.links v.1 w.1 ∨ ((w.2 : ℕ), (v.2 : ℕ)) ∈ M.links w.1 v.1)
+      symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.symm⟩⟩
+      loopless := ⟨fun _ h => h.1 rfl⟩ }
+  arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) + 1 = (w.2 : ℕ)⟩
+  label v := ⟨v.1, (M.tiers v.1).label v.2⟩
+
+variable {M : MultiGraph τ}
+
+@[simp] theorem toMixedGraph_tier (v : (i : Fin n) × Fin (M.tiers i).len) :
+    M.toMixedGraph.tier Sigma.fst v = v.1 := rfl
+
+/-- Precedence paths in the interpretation are exactly same-tier position order. -/
+theorem toMixedGraph_precPath {v w : (i : Fin n) × Fin (M.tiers i).len} :
+    M.toMixedGraph.PrecPath v w ↔ v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ) := by
+  constructor
+  · intro h
+    induction h with
+    | single h => obtain ⟨h1, h2⟩ := h; exact ⟨h1, by omega⟩
+    | tail _ h ih =>
+        obtain ⟨ih1, ih2⟩ := ih; obtain ⟨h1, h2⟩ := h
+        exact ⟨ih1.trans h1, by omega⟩
+  · obtain ⟨i, p⟩ := v
+    obtain ⟨j, q⟩ := w
+    rintro ⟨(rfl : i = j), hlt⟩
+    dsimp only at hlt
+    obtain ⟨d, hd⟩ : ∃ d, (p : ℕ) + d + 1 = (q : ℕ) := ⟨(q : ℕ) - (p : ℕ) - 1, by omega⟩
+    clear hlt
+    induction d generalizing q with
+    | zero => exact .single ⟨rfl, hd⟩
+    | succ d ih =>
+        have hm : (p : ℕ) + d + 1 < (M.tiers i).len := by have := q.isLt; omega
+        exact .tail (ih ⟨(p : ℕ) + d + 1, hm⟩ rfl) ⟨rfl, by omega⟩
+
+/-- Axioms 1–2 hold by construction: successor arcs are tier-internal chains. -/
+theorem toMixedGraph_isTierOrdered : M.toMixedGraph.IsTierOrdered Sigma.fst := by
+  refine ⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => ?_⟩
+  · obtain ⟨i, p⟩ := v
+    obtain ⟨j, q⟩ := w
+    obtain rfl : i = j := htier
+    rcases Nat.lt_trichotomy (p : ℕ) (q : ℕ) with h | h | h
+    · exact Or.inl (toMixedGraph_precPath.mpr ⟨rfl, h⟩)
+    · exact absurd (by simp [Fin.ext h]) hne
+    · exact Or.inr (toMixedGraph_precPath.mpr ⟨rfl, h⟩)
+  · rw [toMixedGraph_precPath] at h
+    omega
+
+/-- Axiom 3 holds by construction on diagonal-free presentations: edges land
+    across tier-pairs, paths stay within a tier. -/
+theorem toMixedGraph_noInternalAssoc (hdiag : ∀ i, M.links i i = ∅) :
+    M.toMixedGraph.NoInternalAssoc := by
+  rintro v w ⟨hne, hmem⟩ hpath
+  rw [toMixedGraph_precPath] at hpath
+  obtain ⟨i, p⟩ := v
+  obtain ⟨j, q⟩ := w
+  obtain rfl : i = j := hpath.1
+  rcases hmem with hm | hm <;> simp [hdiag i] at hm
+
+/-- The foundational path-form No-Crossing Constraint agrees with the per-pair
+    `IsPlanar` on in-bounds, orientation-normalized presentations (links between
+    two tiers stored in one orientation bucket — which also rules out diagonal
+    links). Without normalization the path form is strictly stronger: it couples
+    an `(i, j)` link with a `(j, i)` link between the same two tiers. -/
+theorem toMixedGraph_isPlanar_iff (hb : M.InBounds)
+    (hor : ∀ i j, M.links i j ≠ ∅ → M.links j i = ∅) :
+    M.toMixedGraph.IsPlanar ↔ M.IsPlanar := by
+  have hdiag : ∀ i, M.links i i = ∅ := fun i => by
+    by_contra h
+    exact h (hor i i h)
+  constructor
+  · intro h i j
+    rw [isNonCrossing_iff]
+    rintro ⟨a, b⟩ h₁ ⟨c, d⟩ h₂ hac
+    by_contra hbd
+    have hij : i ≠ j := by
+      rintro rfl
+      simp [hdiag i] at h₁
+    obtain ⟨ha, hb'⟩ := hb i j _ h₁
+    obtain ⟨hc, hd⟩ := hb i j _ h₂
+    exact h (v := ⟨i, ⟨a, ha⟩⟩) (v' := ⟨j, ⟨b, hb'⟩⟩) (w := ⟨i, ⟨c, hc⟩⟩) (w' := ⟨j, ⟨d, hd⟩⟩)
+      ⟨by simp [hij], Or.inl h₁⟩ ⟨by simp [hij], Or.inl h₂⟩
+      (toMixedGraph_precPath.mpr ⟨rfl, hac⟩)
+      (toMixedGraph_precPath.mpr ⟨rfl, not_le.mp hbd⟩)
+  · rintro h v v' w w' ⟨hne₁, hm₁⟩ ⟨hne₂, hm₂⟩ hp hp'
+    rw [toMixedGraph_precPath] at hp hp'
+    obtain ⟨i, a⟩ := v
+    obtain ⟨j, b⟩ := v'
+    obtain ⟨i', c⟩ := w
+    obtain ⟨j', d⟩ := w'
+    obtain rfl : i = i' := hp.1
+    obtain rfl : j = j' := hp'.1.symm
+    have hac : (a : ℕ) < (c : ℕ) := hp.2
+    have hdb : (d : ℕ) < (b : ℕ) := hp'.2
+    rcases hm₁ with hm₁ | hm₁ <;> rcases hm₂ with hm₂ | hm₂
+    · exact absurd (isNonCrossing_iff.mp (h i j) _ hm₁ _ hm₂ hac) (by omega)
+    · exact absurd hm₂ (by simp [hor i j (Finset.ne_empty_of_mem hm₁)])
+    · exact absurd hm₁ (by simp [hor i j (Finset.ne_empty_of_mem hm₂)])
+    · exact absurd (isNonCrossing_iff.mp (h j i) _ hm₂ _ hm₁ hdb) (by omega)
+
+end MultiGraph
 
 end Autosegmental

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -11,7 +11,7 @@ import Linglib.Fragments.Laal.Prosody
 /-!
 # Lionnet (2022): The features and geometry of tone in Laal
 
-[lionnet-2022-laal]
+[lionnet-2022]
 
 Laal (isolate, southern Chad) has three contrastive tone heights H/M/L. Lionnet
 argues for a subtonal analysis à la [yip-1980]/[pulleyblank-1986] (two register

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -29556,6 +29556,21 @@
 % REF: Jardine (2016). Computationally, tone is different. Phonology
 % 33(2):247-283. DOI 10.1017/S0952675716000129. Demonstrates that tone
 % phenomena are non-subsequential — the canonical "outside subregular" result.
+@inproceedings{jardine-2017-complexity,
+  author    = {Jardine, Adam},
+  year      = {2017},
+  title     = {On the Logical Complexity of Autosegmental Representations},
+  booktitle = {Proceedings of the 15th Meeting on the Mathematics of Language},
+  pages     = {22--35},
+  publisher = {Association for Computational Linguistics},
+  address   = {London, UK},
+  doi       = {10.18653/v1/W17-3403},
+  subfield  = {phonology/autosegmental},
+  validated = {true},
+  role      = {cited},
+  sources   = {Phonology/Autosegmental/MixedGraph.lean}
+}
+
 @article{jardine-2016,
   author    = {Jardine, Adam},
   year      = {2016},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -24685,18 +24685,6 @@
   sources   = {Phonology/Tone/Basic.lean;Studies/Lionnet2022Laal.lean}
 }
 
-@article{lionnet-2022-laal,
-  author    = {Lionnet, Florian},
-  year      = {2022},
-  title     = {The features and geometry of tone in {L}aal},
-  journal   = {Phonology},
-  volume    = {39},
-  number    = {2},
-  pages     = {251--292},
-  doi       = {10.1017/S0952675723000040},
-  subfield  = {phonology},
-  role      = {formalized},
-  sources   = {Studies/Lionnet2022Laal.lean}
 }
 
 @incollection{bye-svenonius-2012,


### PR DESCRIPTION
`MixedGraph V S` — the literature's most general autosegmental object ([jardine-heinz-2015] §2; the dissertation's ⟨V, E, A, ℓ⟩) as pure Prop-valued relations over a vertex-type parameter (the `SimpleGraph` pattern): symmetric association, directed precedence, labeling. No ambient order stored.

- the §4.2 axioms relative to a tier assignment `t : S → ι`: `IsTierOrdered` (Ax 1–2), `NoInternalAssoc` (Ax 3), `IsSaturated` (Ax 4, stated not imposed), `IsPlanar` (Ax 5, general path form), `IsOCPClean` (Ax 6)
- `Iso` (label/relation-preserving equivalence) with refl/symm/trans; `concat t` on the vertex sum with per-tier maximal-to-minimal bridging (Definition 2 minus its R_ID melody merge = `OCP.collapse`, matching AR.lean's decomposition); unit laws up to `Iso`
- TODO: associativity up to Iso (conditional per the paper's Lemma 1 remark), axiom preservation (Thm 4 analogues), and the normal-form equivalence to the tiered presentation