### PR TITLE
feat(Phonology/Autosegmental): broad homs and the coproduct

### DIFF
--- a/Linglib/Core/Combinatorics/MixedGraph.lean
+++ b/Linglib/Core/Combinatorics/MixedGraph.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Combinatorics.Digraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Logic.Relation
 
 /-!
 # Mixed graphs
@@ -19,6 +20,7 @@ has both halves but no bundle. Candidate for
 * `MixedGraph V`: the bundle.
 * `SimpleGraph.toMixedGraph` / `Digraph.toMixedGraph`: the degenerate cases —
   a simple graph is a mixed graph with no arcs, a digraph one with no edges.
+* `MixedGraph.PrecPath`: the transitive closure of the arcs.
 -/
 
 /-- A mixed graph: undirected edges and directed arcs on one vertex type. -/
@@ -36,3 +38,6 @@ def SimpleGraph.toMixedGraph (G : SimpleGraph V) : MixedGraph V := ⟨G, ⊥⟩
 
 /-- A digraph is a mixed graph with no edges. -/
 def Digraph.toMixedGraph (D : Digraph V) : MixedGraph V := ⟨⊥, D⟩
+
+/-- The precedence-path relation: the transitive closure of the arcs. -/
+def MixedGraph.PrecPath (G : MixedGraph V) : V → V → Prop := Relation.TransGen G.arcs.Adj

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -80,8 +80,8 @@ def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
 section Axioms
 variable (t : S → ι) (G : MixedGraph V S)
 
-/-- Axioms 1–2 ([jardine-2016-diss] §4.2): per tier, the arcs are a strict
-    linear order — tier-internal, total, irreflexive, transitive. This is
+/-- Axioms 1–2 ([jardine-2016-diss] §4.2): the arcs are tier-internal and a
+    fiberwise `IsStrictTotalOrder`, stated as flat conjuncts. This is
     [jardine-2019]'s reading that `A` represents *the order* on each string; the
     arcs coincide with their path closure (`IsTierOrdered.precPath_iff`), so no
     closure operator appears in the axioms. -/

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -53,6 +53,18 @@ out of the raw graphs relative to it.
 * `Representation.tierColoring`: the tier map properly colors the association
   graph, so tier arity bounds its chromatic number (`edges_colorable`).
 
+## Implementation notes
+
+`concat` bridges *every* same-tier pair, so its arcs are order-closed
+representatives: [jardine-2019]'s operative concatenation bridges one partial
+`(last, first)` pair per tier, and the two forms are interconvertible as Hasse
+diagram ↔ transitive closure on the finite per-tier strict orders. The complete
+bridge is total and functorial where `first`/`last` are partial and not
+hom-preserved, and its monoid laws are unconditional where the successor form's
+associativity requires string-graph tier classes ([jardine-heinz-2015]'s Lemma 1
+remark). The choice is not free elsewhere: subgraph-based notions such as
+`ASL.lean`'s forbidden factors are signature-sensitive ([jardine-2017-complexity]).
+
 ## TODO
 
 * The normal-form equivalence with the strict tuple presentation, with
@@ -226,21 +238,10 @@ theorem empty_noInternalAssoc : NoInternalAssoc (empty S).graph := fun v => v.el
 
 /-! ### Tier-bridging concatenation
 
-Per tier class, concatenation is the ordinal sum: blockwise arcs plus a bridging
-arc from every `X`-vertex of a class to every same-class `Y`-vertex.
-[jardine-2019] glosses `A` as representing *the order* on each string, but its
-operative concatenation bridges a single pair per tier — `(last X Γᵢ, first Y Γᵢ)`,
-with `first`/`last` partial — so its composites carry generator-style arcs. This
-axiom class instead takes the order-*closed* representative of that same
-precedence relation (interconvertible with the generator form via Hasse diagram ↔
-transitive closure on the finite per-tier strict orders); the complete same-class
-bridge is chosen because it is total and functorial where `first`/`last` are
-partial and not hom-preserved, and its monoid laws unconditional where the
-successor form's associativity is conditional on the tier classes being string
-graphs (the paper's Lemma 1 remark). On the definability relationship between the
-two signatures cf. [jardine-2017-complexity]; subgraph-based notions such as
-`ASL.lean`'s forbidden-factor grammars are signature-sensitive and do not transfer
-for free. -/
+Per tier class, concatenation is the ordinal sum: blockwise arcs plus a bridge
+from every `X`-vertex to every same-tier `Y`-vertex. On the choice of the
+complete bridge over [jardine-2019]'s partial `(last, first)` pair, see the
+implementation notes above. -/
 
 section Concat
 variable (t : S → ι)
@@ -254,8 +255,7 @@ def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
   graph :=
     { edges := X.graph.edges ⊕g Y.graph.edges
       arcs :=
-        ⟨fun v w =>
-          match v, w with
+        ⟨fun
           | .inl v, .inl w => X.graph.arcs.Adj v w
           | .inr v, .inr w => Y.graph.arcs.Adj v w
           | .inl v, .inr w => X.tier t v = Y.tier t w
@@ -401,8 +401,7 @@ def sum (X Y : MixedGraphCat S) : MixedGraphCat S where
   graph :=
     { edges := X.graph.edges ⊕g Y.graph.edges
       arcs :=
-        ⟨fun v w =>
-          match v, w with
+        ⟨fun
           | .inl v, .inl w => X.graph.arcs.Adj v w
           | .inr v, .inr w => Y.graph.arcs.Adj v w
           | _, _ => False⟩ }

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -68,7 +68,7 @@ variable {V S ι : Type*}
 /-! ### The §4.2 axioms -/
 
 section Axioms
-variable (G : _root_.MixedGraph V)
+variable (G : MixedGraph V)
 
 /-- Axioms 1–2 ([jardine-2016-diss] §4.2), relative to a vertex coloring `c`
     (the tier partition): the arcs are tier-internal and a fiberwise
@@ -107,7 +107,7 @@ end Axioms
 
 /-- On the axiom class, precedence paths coincide with the arcs — the
     dissertation's `≺`. -/
-theorem IsTierOrdered.precPath_iff {G : _root_.MixedGraph V} {c : V → ι}
+theorem IsTierOrdered.precPath_iff {G : MixedGraph V} {c : V → ι}
     (h : IsTierOrdered G c) {v w : V} : G.PrecPath v w ↔ G.arcs.Adj v w := by
   constructor
   · intro hp
@@ -119,7 +119,7 @@ theorem IsTierOrdered.precPath_iff {G : _root_.MixedGraph V} {c : V → ι}
 /-- The named form of the flat axioms: on each tier the arcs are a strict total
     order (`LinearOrder`'s own pattern — flat fields, derived class). Feeds
     `linearOrderOfSTO` for sorting the fibers. -/
-theorem IsTierOrdered.isStrictTotalOrder {G : _root_.MixedGraph V} {c : V → ι}
+theorem IsTierOrdered.isStrictTotalOrder {G : MixedGraph V} {c : V → ι}
     (h : IsTierOrdered G c) (i : ι) :
     IsStrictTotalOrder {v // c v = i} (fun a b => G.arcs.Adj a b) where
   trichotomous a b hab hba := by
@@ -138,7 +138,7 @@ structure MixedGraphCat (S : Type v) : Type (max (u + 1) v) where
   /-- The vertex type. -/
   V : Type u
   /-- The mixed graph: undirected association edges and directed order arcs. -/
-  graph : _root_.MixedGraph V
+  graph : MixedGraph V
   /-- The labeling (`ℓ`). -/
   label : V → S
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
+import Mathlib.CategoryTheory.Widesubcategory
 import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
 import Linglib.Core.Combinatorics.MixedGraph
@@ -48,10 +51,14 @@ strictness belongs to the tiered normal form, not to the foundation.
   (Axiom 6). Numbering follows the dissertation; [jardine-heinz-2015] numbers the
   NCC and OCP as its Axioms 4 and 5 and has no saturation axiom, which is why
   `AR.lean`'s citations differ.
-* `MixedGraph.Hom` / `MixedGraph.Iso`: label- and relation-preserving maps and
-  equivalences; faces project to the stock `SimpleGraph.Hom`/`Iso` and
-  `RelHom`/`RelIso`.
-* `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum.
+* `MixedGraph.Hom`: label- and association-preserving maps — the broad morphism
+  class, deliberately precedence-forgetting; `precPreserving` is the wide
+  morphism class of full-structure (model-theoretic) homomorphisms, and
+  `MixedGraph.Iso` the full-structure equivalences, with faces projecting to the
+  stock `SimpleGraph.Hom`/`Iso` and `RelIso`.
+* `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum;
+  `MixedGraph.sum` is the bridge-free blockwise sum, the categorical coproduct
+  of the broad category (`HasInitial`/`HasBinaryCoproducts` on `MixedGraphCat`).
 * `MixedGraphCat S`: **the category of labeled mixed graphs** (vertex type
   bundled with a graph); `Representation t` is **the category of autosegmental
   representations** — the full subcategory of the structural axiom class
@@ -61,6 +68,11 @@ strictness belongs to the tiered normal form, not to the foundation.
 
 * `concat_empty_iso` / `empty_concat_iso`: the unit laws up to `Iso`
   ([jardine-heinz-2015] Theorem 1).
+* `not_isTierOrdered_sum`: **Axiom 2 forces the bridges** — the bridge-free
+  coproduct leaves the axiom class whenever the factors share a tier, so
+  `concat`'s bridging arcs are the minimal repair keeping concatenation inside
+  `Representation`. The precise content of [jardine-heinz-2015]'s "modification
+  of the disjoint union".
 
 ## TODO
 
@@ -130,15 +142,17 @@ end Axioms
 
 /-! ### Morphisms -/
 
-/-- A label- and relation-preserving map of labeled mixed graphs. -/
+/-- A label- and association-preserving map of labeled mixed graphs. Precedence
+    is deliberately *not* required — reassociation analyses move material across
+    the order — so this is the broad morphism class where the coproduct and the
+    OCP repair live; the precedence-preserving maps form the wide morphism class
+    `precPreserving` (the legacy `AR.Hom` vs `PrecAR` split, at the foundation). -/
 @[ext]
 structure Hom (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) where
   /-- The vertex map. -/
   toFun : V₁ → V₂
   /-- Association edges are preserved. -/
   edge_map : ∀ ⦃v w⦄, G₁.edges.Adj v w → G₂.edges.Adj (toFun v) (toFun w)
-  /-- Precedence arcs are preserved. -/
-  arc_map : ∀ ⦃v w⦄, G₁.arcs.Adj v w → G₂.arcs.Adj (toFun v) (toFun w)
   /-- Labels are preserved. -/
   label_comp : ∀ v, G₂.label (toFun v) = G₁.label v
 
@@ -147,20 +161,15 @@ def Hom.edgesHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (f : Hom 
     G₁.edges →g G₂.edges :=
   ⟨f.toFun, fun h => f.edge_map h⟩
 
-/-- The arc face of a morphism, a stock relation homomorphism. -/
-def Hom.arcsHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (f : Hom G₁ G₂) :
-    G₁.arcs.Adj →r G₂.arcs.Adj :=
-  ⟨f.toFun, fun h => f.arc_map h⟩
-
 /-- The identity morphism. -/
 def Hom.id (G : MixedGraph V S) : Hom G G :=
-  ⟨_root_.id, fun _ _ h => h, fun _ _ h => h, fun _ => rfl⟩
+  ⟨_root_.id, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Composition of morphisms. -/
 def Hom.comp {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : MixedGraph V₃ S}
     (f : Hom G₁ G₂) (g : Hom G₂ G₃) : Hom G₁ G₃ :=
   ⟨g.toFun ∘ f.toFun, fun _ _ h => g.edge_map (f.edge_map h),
-    fun _ _ h => g.arc_map (f.arc_map h), fun v => (g.label_comp _).trans (f.label_comp v)⟩
+    fun v => (g.label_comp _).trans (f.label_comp v)⟩
 
 /-! ### Isomorphism -/
 
@@ -182,8 +191,7 @@ def Iso.arcsIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G
 
 /-- An isomorphism as a morphism. -/
 def Iso.toHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) : Hom G₁ G₂ :=
-  ⟨e.toEquiv, fun _ _ h => (e.edges_iff _ _).mpr h, fun _ _ h => (e.arcs_iff _ _).mpr h,
-    e.label_comp⟩
+  ⟨e.toEquiv, fun _ _ h => (e.edges_iff _ _).mpr h, e.label_comp⟩
 
 /-- The identity isomorphism. -/
 def Iso.refl (G : MixedGraph V S) : Iso G G :=
@@ -421,12 +429,6 @@ def Hom.sumMap {V₁' V₂' : Type*} {G₁ : MixedGraph V₁ S} {G₁' : MixedGr
     · exact absurd h (by simp)
     · exact absurd h (by simp)
     · exact g.edge_map h
-  arc_map := by
-    rintro (v | v) (w | w) h
-    · exact f.arc_map h
-    · exact (congrArg t (f.label_comp v)).trans (h.trans (congrArg t (g.label_comp w)).symm)
-    · exact h.elim
-    · exact g.arc_map h
   label_comp := by
     rintro (v | v)
     · exact f.label_comp v
@@ -447,6 +449,82 @@ def concat_assoc_iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (G₃
     rcases v with (a | b) | c <;> rfl
 
 end Concat
+
+/-! ### The bridge-free sum, and why the bridges exist
+
+The plain blockwise sum carries no bridging arcs. It is the categorical
+coproduct of the broad category (`MixedGraphCat`), but it does **not** stay in
+the axiom class: whenever both factors occupy a common tier, Axiom 2's totality
+fails across the seam (`not_isTierOrdered_sum`) — `concat`'s bridges are the
+minimal repair that keeps concatenation inside `Representation`. -/
+
+/-- The bridge-free blockwise sum. -/
+def sum (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
+  edges := G₁.edges ⊕g G₂.edges
+  arcs :=
+    ⟨fun v w =>
+      match v, w with
+      | .inl v, .inl w => G₁.arcs.Adj v w
+      | .inr v, .inr w => G₂.arcs.Adj v w
+      | _, _ => False⟩
+  label := Sum.elim G₁.label G₂.label
+
+@[simp] theorem sum_edges (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
+    (G₁.sum G₂).edges = G₁.edges ⊕g G₂.edges := rfl
+
+private lemma sum_precPath_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {a : V₁}
+    {y : V₁ ⊕ V₂} (h : (G₁.sum G₂).PrecPath (.inl a) y) : ∃ a', y = .inl a' := by
+  induction h with
+  | @single y' h =>
+      cases y' with
+      | inl a' => exact ⟨a', rfl⟩
+      | inr b => exact (h : False).elim
+  | @tail y' y'' _ h ih =>
+      obtain ⟨a'', rfl⟩ := ih
+      cases y'' with
+      | inl a' => exact ⟨a', rfl⟩
+      | inr b => exact (h : False).elim
+
+private lemma sum_precPath_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {b : V₂}
+    {y : V₁ ⊕ V₂} (h : (G₁.sum G₂).PrecPath (.inr b) y) : ∃ b', y = .inr b' := by
+  induction h with
+  | @single y' h =>
+      cases y' with
+      | inl a => exact (h : False).elim
+      | inr b' => exact ⟨b', rfl⟩
+  | @tail y' y'' _ h ih =>
+      obtain ⟨b'', rfl⟩ := ih
+      cases y'' with
+      | inl a => exact (h : False).elim
+      | inr b' => exact ⟨b', rfl⟩
+
+/-- Copairing out of the bridge-free sum. -/
+def sumDesc {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {H : MixedGraph V₃ S}
+    (f : Hom G₁ H) (g : Hom G₂ H) : Hom (G₁.sum G₂) H where
+  toFun := Sum.elim f.toFun g.toFun
+  edge_map := by
+    rintro (v | v) (w | w) h
+    · exact f.edge_map h
+    · exact absurd h (by simp)
+    · exact absurd h (by simp)
+    · exact g.edge_map h
+  label_comp := by
+    rintro (v | v)
+    · exact f.label_comp v
+    · exact g.label_comp v
+
+/-- **Axiom 2 forces the bridges**: the bridge-free sum of two graphs occupying a
+    common tier is never tier-ordered — same-tier vertices from the two factors
+    are precedence-unrelated across the seam. -/
+theorem not_isTierOrdered_sum (t : S → ι) {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
+    (v : V₁) (w : V₂) (htier : G₁.tier t v = G₂.tier t w) :
+    ¬ (G₁.sum G₂).IsTierOrdered t := by
+  intro h
+  rcases h.2.1 (v := .inl v) (w := .inr w) (by simp) htier with hp | hp
+  · obtain ⟨a', ha⟩ := sum_precPath_inl hp
+    exact absurd ha (by simp)
+  · obtain ⟨b', hb⟩ := sum_precPath_inr hp
+    exact absurd hb (by simp)
 
 end MixedGraph
 
@@ -474,7 +552,61 @@ instance : Category (MixedGraphCat S) where
   comp_id _ := MixedGraph.Hom.ext rfl
   assoc _ _ _ := MixedGraph.Hom.ext rfl
 
+open Limits
+
+/-- The empty graph object. -/
+def empty (S : Type v) : MixedGraphCat S := ⟨PEmpty, MixedGraph.empty S⟩
+
+instance (Y : MixedGraphCat S) : Subsingleton (empty S ⟶ Y) :=
+  ⟨fun _ _ => MixedGraph.Hom.ext (funext fun v => v.elim)⟩
+
+instance (Y : MixedGraphCat S) : Nonempty (empty S ⟶ Y) :=
+  ⟨⟨PEmpty.elim, fun v => v.elim, fun v => v.elim⟩⟩
+
+instance : HasInitial (MixedGraphCat S) := hasInitial_of_unique (empty S)
+
+/-- The bridge-free sum object. -/
+def sumObj (X Y : MixedGraphCat S) : MixedGraphCat S := ⟨X.V ⊕ Y.V, X.graph.sum Y.graph⟩
+
+/-- Left coprojection. -/
+def inl (X Y : MixedGraphCat S) : X ⟶ sumObj X Y :=
+  ⟨Sum.inl, fun _ _ h => h, fun _ => rfl⟩
+
+/-- Right coprojection. -/
+def inr (X Y : MixedGraphCat S) : Y ⟶ sumObj X Y :=
+  ⟨Sum.inr, fun _ _ h => h, fun _ => rfl⟩
+
+/-- Copairing out of the bridge-free sum. -/
+def desc {X Y T : MixedGraphCat S} (f : X ⟶ T) (g : Y ⟶ T) : sumObj X Y ⟶ T :=
+  MixedGraph.sumDesc (f : MixedGraph.Hom _ _) (g : MixedGraph.Hom _ _)
+
+/-- The bridge-free sum is the categorical coproduct of the broad category
+    (contrast `MixedGraph.not_isTierOrdered_sum`: it leaves the axiom class,
+    which is why `Representation`'s tensor is the bridged `concat` instead). -/
+instance (X Y : MixedGraphCat S) : HasBinaryCoproduct X Y :=
+  HasColimit.mk
+    { cocone := BinaryCofan.mk (inl X Y) (inr X Y)
+      isColimit := BinaryCofan.IsColimit.mk _ (fun f g => desc f g)
+        (fun f g => MixedGraph.Hom.ext rfl)
+        (fun f g => MixedGraph.Hom.ext rfl)
+        (fun f g m h₁ h₂ => MixedGraph.Hom.ext (funext fun v => by
+          rcases v with v | v
+          · exact congrArg (fun φ => MixedGraph.Hom.toFun φ v) h₁
+          · exact congrArg (fun φ => MixedGraph.Hom.toFun φ v) h₂)) }
+
+instance : HasBinaryCoproducts (MixedGraphCat S) := hasBinaryCoproducts_of_hasColimit_pair _
+
 end MixedGraphCat
+
+/-- Precedence preservation as a morphism property: the maps that also preserve
+    arcs — the model-theoretic full-structure homomorphisms, the foundation
+    counterpart of the legacy `PrecAR` wide subcategory. -/
+def precPreserving : MorphismProperty (MixedGraphCat S) := fun X Y f =>
+  ∀ ⦃v w⦄, X.graph.arcs.Adj v w → Y.graph.arcs.Adj (f.toFun v) (f.toFun w)
+
+instance : (precPreserving (S := S)).IsMultiplicative where
+  id_mem _ := fun _ _ h => h
+  comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
 
 /-! ### The category of autosegmental representations -/
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -73,7 +73,7 @@ variable (G : MixedGraph V)
     is Axiom 1 relative to it: the arcs are tier-internal and strictly totally
     order each fiber. This is [jardine-2019]'s reading that `A` represents *the
     order* on each string; the arcs coincide with their path closure
-    (`IsTierOrdered.precPath_iff`), so no closure operator appears in the
+    (`IsTierOrdered.precPath_eq`), so no closure operator appears in the
     axioms. -/
 structure IsTierOrdered (c : V → ι) : Prop where
   /-- Arcs never leave a tier. -/
@@ -107,26 +107,20 @@ def IsOCPClean (ℓ : V → S) (t : S → ι) (m : ι) : Prop :=
 
 end Axioms
 
+variable {G : MixedGraph V} {c : V → ι}
+
 /-- On the axiom class, precedence paths coincide with the arcs — the
     dissertation's `≺`. -/
-theorem IsTierOrdered.precPath_iff {G : MixedGraph V} {c : V → ι}
-    (h : IsTierOrdered G c) {v w : V} : G.PrecPath v w ↔ G.arcs.Adj v w := by
-  constructor
-  · intro hp
-    induction hp with
-    | single hb => exact hb
-    | tail _ hb ih => exact h.trans ih hb
-  · exact .single
+theorem IsTierOrdered.precPath_eq (h : IsTierOrdered G c) : G.PrecPath = G.arcs.Adj :=
+  haveI : IsTrans V G.arcs.Adj := ⟨h.trans⟩
+  Relation.transGen_eq_self
 
 /-- The classed form of the axioms: on each tier the arcs are a strict total
     order. Feeds `linearOrderOfSTO` for sorting the fibers. -/
-theorem IsTierOrdered.isStrictTotalOrder {G : MixedGraph V} {c : V → ι}
-    (h : IsTierOrdered G c) (i : ι) :
-    IsStrictTotalOrder {v // c v = i} (fun a b => G.arcs.Adj a b) where
-  trichotomous a b hab hba := by
-    by_contra hne
-    rcases h.total (fun hv => hne (Subtype.ext hv)) (a.2.trans b.2.symm) with hp | hp
-    exacts [hab hp, hba hp]
+theorem IsTierOrdered.isStrictTotalOrder (h : IsTierOrdered G c) (i : ι) :
+    IsStrictTotalOrder {v // c v = i} (G.arcs.Adj · ·) where
+  trichotomous a b hab hba :=
+    Subtype.ext <| of_not_not fun hne => (h.total hne (a.2.trans b.2.symm)).elim hab hba
   irrefl a := h.irrefl a
   trans _ _ _ hab hbc := h.trans hab hbc
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -52,17 +52,6 @@ relative to it.
 * `Representation.tierColoring`: the tier map properly colors the association
   graph, so tier arity bounds its chromatic number (`edges_colorable`).
 
-## Implementation notes
-
-The graph components reuse `SimpleGraph` (edges are two-element sets, so
-association is symmetric and loopless) and `Digraph`, bundled in
-`Core/Combinatorics/MixedGraph.lean`; no cross-tier order is stored. Morphisms
-default to the broad precedence-forgetting class, where the coproduct and the
-OCP repair live.
-Subgraph-based notions (`ASL.lean`) are signature-sensitive and do not transfer
-to the order signature for free. Monoid laws hold up to `Iso`; strictness
-belongs to the tiered normal form (`MultiAR.lean`).
-
 ## TODO
 
 * The normal-form equivalence with the strict tuple presentation, with
@@ -73,7 +62,8 @@ namespace Autosegmental
 
 variable {V V₁ V₂ V₃ S ι : Type*}
 
-/-- A labeled mixed graph `⟨V, E, A, ℓ⟩`: a mixed graph with a vertex labeling. -/
+/-- A labeled mixed graph `⟨V, E, A, ℓ⟩` is a mixed graph with a vertex labeling;
+    the literature's edges are two-element sets, so `SimpleGraph` is exact. -/
 structure MixedGraph (V S : Type*) extends _root_.MixedGraph V where
   /-- The labeling (`ℓ`). -/
   label : V → S

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -7,7 +7,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
-import Mathlib.CategoryTheory.Widesubcategory
+import Mathlib.CategoryTheory.MorphismProperty.Composition
 import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
 import Linglib.Core.Combinatorics.MixedGraph
@@ -226,10 +226,10 @@ def Iso.trans (e : Iso X Y) (f : Iso Y Z) : Iso X Z where
 /-- The empty labeled mixed graph, on the empty vertex type. -/
 def empty (S : Type*) : MixedGraphCat S := ⟨PEmpty, ⟨⊥, ⊥⟩, PEmpty.elim⟩
 
-theorem empty_isTierOrdered (t : S → ι) : IsTierOrdered (empty S).graph ((empty S).tier t) :=
+theorem isTierOrdered_empty (t : S → ι) : IsTierOrdered (empty S).graph ((empty S).tier t) :=
   ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
 
-theorem empty_noInternalAssoc : NoInternalAssoc (empty S).graph := fun v => v.elim
+theorem noInternalAssoc_empty : NoInternalAssoc (empty S).graph := fun v => v.elim
 
 /-! ### Tier-bridging concatenation
 
@@ -268,6 +268,12 @@ def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
 
 @[simp] theorem concat_arcs_inr_inr {v w : Y.V} :
     (concat t X Y).graph.arcs.Adj (.inr v) (.inr w) ↔ Y.graph.arcs.Adj v w := Iff.rfl
+
+@[simp] theorem concat_arcs_inl_inr {v : X.V} {w : Y.V} :
+    (concat t X Y).graph.arcs.Adj (.inl v) (.inr w) ↔ X.tier t v = Y.tier t w := Iff.rfl
+
+@[simp] theorem not_concat_arcs_inr_inl {v : Y.V} {w : X.V} :
+    ¬ (concat t X Y).graph.arcs.Adj (.inr v) (.inl w) := fun h => h
 
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
 
@@ -402,6 +408,22 @@ def sum (X Y : MixedGraphCat S) : MixedGraphCat S where
 
 @[simp] theorem sum_edges : (sum X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
 
+@[simp] theorem sum_label_inl (v : X.V) : (sum X Y).label (.inl v) = X.label v := rfl
+
+@[simp] theorem sum_label_inr (v : Y.V) : (sum X Y).label (.inr v) = Y.label v := rfl
+
+@[simp] theorem sum_arcs_inl_inl {v w : X.V} :
+    (sum X Y).graph.arcs.Adj (.inl v) (.inl w) ↔ X.graph.arcs.Adj v w := Iff.rfl
+
+@[simp] theorem sum_arcs_inr_inr {v w : Y.V} :
+    (sum X Y).graph.arcs.Adj (.inr v) (.inr w) ↔ Y.graph.arcs.Adj v w := Iff.rfl
+
+@[simp] theorem not_sum_arcs_inl_inr {v : X.V} {w : Y.V} :
+    ¬ (sum X Y).graph.arcs.Adj (.inl v) (.inr w) := fun h => h
+
+@[simp] theorem not_sum_arcs_inr_inl {v : Y.V} {w : X.V} :
+    ¬ (sum X Y).graph.arcs.Adj (.inr v) (.inl w) := fun h => h
+
 /-- Copairing out of the bridge-free sum. -/
 def sumDesc (f : Hom X Z) (g : Hom Y Z) : Hom (sum X Y) Z where
   toFun := Sum.elim f.toFun g.toFun
@@ -417,10 +439,10 @@ def sumDesc (f : Hom X Z) (g : Hom Y Z) : Hom (sum X Y) Z where
     are precedence-unrelated across the seam. -/
 theorem not_isTierOrdered_sum (t : S → ι) (v : X.V) (w : Y.V)
     (htier : X.tier t v = Y.tier t w) :
-    ¬ IsTierOrdered (sum X Y).graph ((sum X Y).tier t) := fun h =>
-  (h.total (v := .inl v) (w := .inr w) (by simp) htier).elim (fun hp => hp) fun hp => hp
+    ¬ IsTierOrdered (sum X Y).graph ((sum X Y).tier t) := fun h => by
+  simpa using h.total (v := .inl v) (w := .inr w) Sum.inl_ne_inr htier
 
-/-! ### The category of labeled mixed graphs -/
+/-! ### Category structure, initial object, and coproducts -/
 
 open CategoryTheory Limits
 
@@ -448,17 +470,13 @@ def inl (X Y : MixedGraphCat S) : X ⟶ sum X Y :=
 def inr (X Y : MixedGraphCat S) : Y ⟶ sum X Y :=
   ⟨Sum.inr, fun _ _ h => h, fun _ => rfl⟩
 
-/-- Copairing out of the bridge-free sum. -/
-def desc (f : X ⟶ Z) (g : Y ⟶ Z) : sum X Y ⟶ Z :=
-  sumDesc f g
-
 /-- The bridge-free sum is the categorical coproduct of the broad category
     (contrast `not_isTierOrdered_sum`: it leaves the axiom class, which is why
     `Representation`'s tensor is the bridged `concat` instead). -/
 instance (X Y : MixedGraphCat S) : HasBinaryCoproduct X Y :=
   HasColimit.mk
     { cocone := BinaryCofan.mk (inl X Y) (inr X Y)
-      isColimit := BinaryCofan.IsColimit.mk _ (fun f g => desc f g)
+      isColimit := BinaryCofan.IsColimit.mk _ (fun f g => sumDesc f g)
         (fun f g => Hom.ext rfl)
         (fun f g => Hom.ext rfl)
         (fun f g m h₁ h₂ => Hom.ext (funext fun v => by
@@ -475,10 +493,10 @@ open CategoryTheory
 /-- Precedence preservation as a morphism property: the maps that also preserve
     arcs — the model-theoretic full-structure homomorphisms, the foundation
     counterpart of the legacy `PrecAR` wide subcategory. -/
-def precPreserving : MorphismProperty (MixedGraphCat S) := fun X Y f =>
+def MixedGraphCat.precPreserving : MorphismProperty (MixedGraphCat S) := fun X Y f =>
   ∀ ⦃v w⦄, X.graph.arcs.Adj v w → Y.graph.arcs.Adj (f.toFun v) (f.toFun w)
 
-instance : (precPreserving (S := S)).IsMultiplicative where
+instance : (MixedGraphCat.precPreserving (S := S)).IsMultiplicative where
   id_mem _ := fun _ _ h => h
   comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
 
@@ -542,8 +560,8 @@ theorem hom_ext {X Y : Representation t} {f g : X ⟶ Y}
       MixedGraphCat.isTierOrdered_concat t X.property.1 Y.property.1,
       MixedGraphCat.noInternalAssoc_concat t X.property.2 Y.property.2⟩
   tensorUnit :=
-    ⟨MixedGraphCat.empty S, MixedGraphCat.empty_isTierOrdered t,
-      MixedGraphCat.empty_noInternalAssoc⟩
+    ⟨MixedGraphCat.empty S, MixedGraphCat.isTierOrdered_empty t,
+      MixedGraphCat.noInternalAssoc_empty⟩
   tensorHom f g := InducedCategory.homMk (MixedGraphCat.Hom.concatMap t f.hom g.hom)
   whiskerLeft X _ _ f :=
     InducedCategory.homMk (MixedGraphCat.Hom.concatMap t (MixedGraphCat.Hom.id X.obj) f.hom)

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -104,18 +104,29 @@ def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.arcs
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
 def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
 
+/-- Tier equality propagates along precedence paths once arcs are tier-internal. -/
+lemma precPath_tier {t : S → ι} {G : MixedGraph V S}
+    (harc : ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) {v w : V}
+    (h : G.PrecPath v w) : G.tier t v = G.tier t w := by
+  induction h with
+  | single h => exact harc h
+  | tail _ h ih => exact ih.trans (harc h)
+
 /-! ### The §4.2 axioms -/
 
 section Axioms
 variable (t : S → ι) (G : MixedGraph V S)
 
 /-- Axioms 1–2 ([jardine-2016-diss] §4.2): precedence stays within a tier,
-    precedence paths totally order each tier class, and no path returns to its
-    origin. -/
+    precedence paths totally order each tier class, no path returns to its
+    origin, and the arcs are path-closed — [jardine-2019]'s reading that `A`
+    represents *the order* on each string, so per tier the arcs are exactly a
+    strict total order. Closure is what makes the tuple normal form arc-exact. -/
 def IsTierOrdered : Prop :=
   (∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) ∧
     (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.PrecPath v w ∨ G.PrecPath w v) ∧
-    ∀ v, ¬ G.PrecPath v v
+    (∀ v, ¬ G.PrecPath v v) ∧
+    ∀ ⦃v w⦄, G.PrecPath v w → G.arcs.Adj v w
 
 /-- Axiom 3: association never links precedence-path-related (tier-internal)
     vertices. Tier-free — stated on paths alone, as in the dissertation. -/
@@ -226,7 +237,7 @@ def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : Mixe
 def empty (S : Type*) : MixedGraph PEmpty S := ⟨⟨⊥, ⊥⟩, PEmpty.elim⟩
 
 theorem empty_isTierOrdered (t : S → ι) : (empty S).IsTierOrdered t :=
-  ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
+  ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
 
 theorem empty_noInternalAssoc : (empty S).NoInternalAssoc := fun v => v.elim
 
@@ -383,13 +394,16 @@ private lemma precPath_inl_cases {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V
 
 /-! #### Axiom preservation ([jardine-heinz-2015] Theorem 4's structural half) -/
 
-/-- Concatenation preserves Axioms 1–2. -/
+/-- Concatenation preserves Axioms 1–2, including path-closure: a cross-seam
+    path forces tier equality, which is already a bridge arc. -/
 theorem isTierOrdered_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
     (h₁ : G₁.IsTierOrdered t) (h₂ : G₂.IsTierOrdered t) :
     (concat t G₁ G₂).IsTierOrdered t := by
-  refine ⟨?_, ?_, ?_⟩
-  · rintro (v | v) (w | w) h
+  have hint : ∀ ⦃v w⦄, (concat t G₁ G₂).arcs.Adj v w →
+      (concat t G₁ G₂).tier t v = (concat t G₁ G₂).tier t w := by
+    rintro (v | v) (w | w) h
     exacts [h₁.1 h, h, h.elim, h₂.1 h]
+  refine ⟨hint, ?_, ?_, ?_⟩
   · rintro (v | v) (w | w) hne htier
     · rcases h₁.2.1 (by simpa using hne) htier with hp | hp
       · exact Or.inl ((concat_precPath_inl_inl t).mpr hp)
@@ -400,8 +414,13 @@ theorem isTierOrdered_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ 
       · exact Or.inl ((concat_precPath_inr_inr t).mpr hp)
       · exact Or.inr ((concat_precPath_inr_inr t).mpr hp)
   · rintro (v | v) h
-    · exact h₁.2.2 v ((concat_precPath_inl_inl t).mp h)
-    · exact h₂.2.2 v ((concat_precPath_inr_inr t).mp h)
+    · exact h₁.2.2.1 v ((concat_precPath_inl_inl t).mp h)
+    · exact h₂.2.2.1 v ((concat_precPath_inr_inr t).mp h)
+  · rintro (v | v) (w | w) h
+    · exact h₁.2.2.2 ((concat_precPath_inl_inl t).mp h)
+    · exact precPath_tier hint h
+    · exact absurd h (concat_not_precPath_inr_inl t)
+    · exact h₂.2.2.2 ((concat_precPath_inr_inr t).mp h)
 
 /-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross edges,
     and blockwise paths are factor paths. -/

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -44,7 +44,7 @@ out of the raw graphs relative to it.
 
 ## Main results
 
-* `concat_empty_iso`, `empty_concat_iso`, `concat_assoc_iso`,
+* `concatEmptyIso`, `emptyConcatIso`, `concatAssocIso`,
   `isTierOrdered_concat`, `noInternalAssoc_concat`, `isPlanar_concat`:
   [jardine-heinz-2015] Theorems 1, 3 and 4 up to `Iso`, unconditional in the
   order signature; `isPlanar_concat` is [jardine-2019]'s NCC-preservation.
@@ -278,44 +278,34 @@ def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
 
 /-- Concatenation with the empty graph on the right, up to isomorphism. -/
-def concat_empty_iso (X : MixedGraphCat S) : Iso (concat t X (empty S)) X where
+def concatEmptyIso (X : MixedGraphCat S) : Iso (concat t X (empty S)) X where
   toEquiv := Equiv.sumEmpty X.V PEmpty
-  edges_iff v w := by
-    rcases v with v | v
-    · rcases w with w | w
-      · exact Iff.rfl
-      · exact w.elim
-    · exact v.elim
-  arcs_iff v w := by
-    rcases v with v | v
-    · rcases w with w | w
-      · exact Iff.rfl
-      · exact w.elim
-    · exact v.elim
-  label_comp v := by
-    rcases v with v | v
-    · rfl
-    · exact v.elim
+  edges_iff
+    | .inl _, .inl _ => Iff.rfl
+    | .inl _, .inr w => w.elim
+    | .inr v, _ => v.elim
+  arcs_iff
+    | .inl _, .inl _ => Iff.rfl
+    | .inl _, .inr w => w.elim
+    | .inr v, _ => v.elim
+  label_comp
+    | .inl _ => rfl
+    | .inr v => v.elim
 
 /-- Concatenation with the empty graph on the left, up to isomorphism. -/
-def empty_concat_iso (X : MixedGraphCat S) : Iso (concat t (empty S) X) X where
+def emptyConcatIso (X : MixedGraphCat S) : Iso (concat t (empty S) X) X where
   toEquiv := Equiv.emptySum PEmpty X.V
-  edges_iff v w := by
-    rcases v with v | v
-    · exact v.elim
-    · rcases w with w | w
-      · exact w.elim
-      · exact Iff.rfl
-  arcs_iff v w := by
-    rcases v with v | v
-    · exact v.elim
-    · rcases w with w | w
-      · exact w.elim
-      · exact Iff.rfl
-  label_comp v := by
-    rcases v with v | v
-    · exact v.elim
-    · rfl
+  edges_iff
+    | .inl v, _ => v.elim
+    | .inr _, .inl w => w.elim
+    | .inr _, .inr _ => Iff.rfl
+  arcs_iff
+    | .inl v, _ => v.elim
+    | .inr _, .inl w => w.elim
+    | .inr _, .inr _ => Iff.rfl
+  label_comp
+    | .inl v => v.elim
+    | .inr _ => rfl
 
 /-! #### Axiom preservation ([jardine-heinz-2015] Theorem 4's structural half) -/
 
@@ -336,25 +326,21 @@ theorem isTierOrdered_concat
       exacts [Or.inl hp, Or.inr hp]
   · rintro (v | v) h
     exacts [h₁.irrefl v h, h₂.irrefl v h]
-  · rintro (u | u) (v | v) (w | w) huv hvw
-    · exact h₁.trans huv hvw
-    · exact (h₁.tier_eq huv).trans hvw
-    · exact (hvw : False).elim
-    · exact huv.trans (h₂.tier_eq hvw)
-    · exact (huv : False).elim
-    · exact (huv : False).elim
-    · exact (hvw : False).elim
-    · exact h₂.trans huv hvw
+  · rintro (u | u) (v | v) (w | w) huv hvw <;>
+      first
+        | exact h₁.trans huv hvw
+        | exact h₂.trans huv hvw
+        | exact (h₁.tier_eq huv).trans hvw
+        | exact huv.trans (h₂.tier_eq hvw)
+        | exact (huv : False).elim
+        | exact (hvw : False).elim
 
 /-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross
     edges. -/
 theorem noInternalAssoc_concat (h₁ : NoInternalAssoc X.graph) (h₂ : NoInternalAssoc Y.graph) :
     NoInternalAssoc (concat t X Y).graph := by
   rintro (v | v) (w | w) hadj harc
-  · exact h₁ hadj harc
-  · exact absurd hadj (by simp)
-  · exact absurd hadj (by simp)
-  · exact h₂ hadj harc
+  exacts [h₁ hadj harc, absurd hadj (by simp), absurd hadj (by simp), h₂ hadj harc]
 
 /-- Concatenation preserves the No-Crossing Constraint ([jardine-2019]'s
     headline [jardine-heinz-2015] result): plain factor planarity suffices.
@@ -363,49 +349,34 @@ theorem noInternalAssoc_concat (h₁ : NoInternalAssoc X.graph) (h₂ : NoIntern
     return arc runs `inr → inl` and does not exist. -/
 theorem isPlanar_concat (h₁ : IsPlanar X.graph) (h₂ : IsPlanar Y.graph) :
     IsPlanar (concat t X Y).graph := by
-  rintro (v | v) (v' | v') (w | w) (w' | w') hvv' hww' hvw hw'v'
-  · exact h₁ hvv' hww' hvw hw'v'
-  · exact absurd hww' (by simp)
-  · exact absurd hww' (by simp)
-  · exact (hw'v' : False).elim
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact absurd hvv' (by simp)
-  · exact (hvw : False).elim
-  · exact absurd hww' (by simp)
-  · exact absurd hww' (by simp)
-  · exact h₂ hvv' hww' hvw hw'v'
+  rintro (v | v) (v' | v') (w | w) (w' | w') hvv' hww' hvw hw'v' <;>
+    first
+      | exact h₁ hvv' hww' hvw hw'v'
+      | exact h₂ hvv' hww' hvw hw'v'
+      | exact (hvw : False).elim
+      | exact (hw'v' : False).elim
+      | simp_all
 
 /-! #### Functoriality of concatenation -/
 
 /-- Concatenation of morphisms is `Sum.map`: blockwise preservation from the
-    factors, and label preservation transports the bridge's tier equality. Domain and codomain
-    of each factor may have independent vertex types, as morphisms in `MixedGraphCat S` do. -/
-def Hom.sumMap {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
+    factors; label preservation transports the bridge's tier equality. -/
+def Hom.concatMap {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
     (f : Hom X₁ Y₁) (g : Hom X₂ Y₂) : Hom (concat t X₁ X₂) (concat t Y₁ Y₂) where
   toFun := Sum.map f.toFun g.toFun
   edge_map := by
     rintro (v | v) (w | w) h
-    · exact f.edge_map h
-    · exact absurd h (by simp)
-    · exact absurd h (by simp)
-    · exact g.edge_map h
+    exacts [f.edge_map h, absurd h (by simp), absurd h (by simp), g.edge_map h]
   label_comp := by
     rintro (v | v)
-    · exact f.label_comp v
-    · exact g.label_comp v
+    exacts [f.label_comp v, g.label_comp v]
 
 /-! #### Associativity up to isomorphism ([jardine-heinz-2015] Theorem 3) -/
 
 /-- Concatenation is associative up to isomorphism, over `Equiv.sumAssoc`; the
     edge face is the stock `SimpleGraph.Iso.sumAssoc`, and every arc case holds
     definitionally in the order signature. -/
-def concat_assoc_iso (X Y Z : MixedGraphCat S) :
+def concatAssocIso (X Y Z : MixedGraphCat S) :
     Iso (concat t (concat t X Y) Z) (concat t X (concat t Y Z)) where
   toEquiv := Equiv.sumAssoc X.V Y.V Z.V
   edges_iff v w := SimpleGraph.Iso.sumAssoc.map_rel_iff
@@ -444,14 +415,10 @@ def sumDesc (f : Hom X Z) (g : Hom Y Z) : Hom (sum X Y) Z where
   toFun := Sum.elim f.toFun g.toFun
   edge_map := by
     rintro (v | v) (w | w) h
-    · exact f.edge_map h
-    · exact absurd h (by simp)
-    · exact absurd h (by simp)
-    · exact g.edge_map h
+    exacts [f.edge_map h, absurd h (by simp), absurd h (by simp), g.edge_map h]
   label_comp := by
     rintro (v | v)
-    · exact f.label_comp v
-    · exact g.label_comp v
+    exacts [f.label_comp v, g.label_comp v]
 
 /-- **Axiom 2 forces the bridges**: the bridge-free sum of two graphs occupying a
     common tier is never tier-ordered — same-tier vertices from the two factors
@@ -584,19 +551,19 @@ def mkIso {X Y : Representation t} (e : MixedGraphCat.Iso X.obj Y.obj) : X ≅ Y
 /-- The tensor on morphisms, as a representation morphism. -/
 def tensorHomAux {X₁ Y₁ X₂ Y₂ : Representation t} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
     tensor X₁ X₂ ⟶ tensor Y₁ Y₂ :=
-  InducedCategory.homMk (MixedGraphCat.Hom.sumMap (X₁ := X₁.obj) (Y₁ := Y₁.obj)
+  InducedCategory.homMk (MixedGraphCat.Hom.concatMap (X₁ := X₁.obj) (Y₁ := Y₁.obj)
     (X₂ := X₂.obj) (Y₂ := Y₂.obj) t f.hom g.hom)
 
 /-- Left whiskering, as a representation morphism. -/
 def whiskerLeftAux (X : Representation t) {Y₁ Y₂ : Representation t} (f : Y₁ ⟶ Y₂) :
     tensor X Y₁ ⟶ tensor X Y₂ :=
-  InducedCategory.homMk (MixedGraphCat.Hom.sumMap (X₁ := X.obj) (Y₁ := X.obj)
+  InducedCategory.homMk (MixedGraphCat.Hom.concatMap (X₁ := X.obj) (Y₁ := X.obj)
     (X₂ := Y₁.obj) (Y₂ := Y₂.obj) t (MixedGraphCat.Hom.id X.obj) f.hom)
 
 /-- Right whiskering, as a representation morphism. -/
 def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Representation t) :
     tensor X₁ Y ⟶ tensor X₂ Y :=
-  InducedCategory.homMk (MixedGraphCat.Hom.sumMap (X₁ := X₁.obj) (Y₁ := X₂.obj)
+  InducedCategory.homMk (MixedGraphCat.Hom.concatMap (X₁ := X₁.obj) (Y₁ := X₂.obj)
     (X₂ := Y.obj) (Y₂ := Y.obj) t f.hom (MixedGraphCat.Hom.id Y.obj))
 
 @[simps] instance instMonoidalStruct : MonoidalCategoryStruct (Representation t) where
@@ -605,9 +572,9 @@ def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Repr
   tensorHom := tensorHomAux
   whiskerLeft := whiskerLeftAux
   whiskerRight := whiskerRightAux
-  associator X Y Z := mkIso (MixedGraphCat.concat_assoc_iso t X.obj Y.obj Z.obj)
-  leftUnitor X := mkIso (MixedGraphCat.empty_concat_iso t X.obj)
-  rightUnitor X := mkIso (MixedGraphCat.concat_empty_iso t X.obj)
+  associator X Y Z := mkIso (MixedGraphCat.concatAssocIso t X.obj Y.obj Z.obj)
+  leftUnitor X := mkIso (MixedGraphCat.emptyConcatIso t X.obj)
+  rightUnitor X := mkIso (MixedGraphCat.concatEmptyIso t X.obj)
 
 /-- The category of autosegmental representations is monoidal under morpheme
     concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as coherence,

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -61,8 +61,6 @@ out of the raw graphs relative to it.
 
 namespace Autosegmental
 
-universe u v
-
 variable {V S ι : Type*}
 
 /-! ### The §4.2 axioms -/
@@ -72,15 +70,19 @@ variable (G : MixedGraph V)
 
 /-- Axioms 1–2 ([jardine-2016-diss] §4.2), relative to a vertex coloring `c`
     (the tier partition): the arcs are tier-internal and a fiberwise
-    `IsStrictTotalOrder`, stated as flat conjuncts. This is [jardine-2019]'s
-    reading that `A` represents *the order* on each string; the arcs coincide with
-    their path closure (`IsTierOrdered.precPath_iff`), so no closure operator
-    appears in the axioms. -/
-def IsTierOrdered (c : V → ι) : Prop :=
-  (∀ ⦃v w⦄, G.arcs.Adj v w → c v = c w) ∧
-    (∀ ⦃v w⦄, v ≠ w → c v = c w → G.arcs.Adj v w ∨ G.arcs.Adj w v) ∧
-    (∀ v, ¬ G.arcs.Adj v v) ∧
-    ∀ ⦃u v w⦄, G.arcs.Adj u v → G.arcs.Adj v w → G.arcs.Adj u w
+    `IsStrictTotalOrder`. This is [jardine-2019]'s reading that `A` represents
+    *the order* on each string; the arcs coincide with their path closure
+    (`IsTierOrdered.precPath_iff`), so no closure operator appears in the
+    axioms. -/
+structure IsTierOrdered (c : V → ι) : Prop where
+  /-- Arcs never leave a tier. -/
+  tier_eq : ∀ ⦃v w⦄, G.arcs.Adj v w → c v = c w
+  /-- Distinct same-tier vertices are arc-comparable. -/
+  total : ∀ ⦃v w⦄, v ≠ w → c v = c w → G.arcs.Adj v w ∨ G.arcs.Adj w v
+  /-- No vertex precedes itself. -/
+  irrefl : ∀ v, ¬ G.arcs.Adj v v
+  /-- Arcs compose. -/
+  trans : ∀ ⦃u v w⦄, G.arcs.Adj u v → G.arcs.Adj v w → G.arcs.Adj u w
 
 /-- Axiom 3: association never links precedence-path-related (tier-internal)
     vertices. Tier-free — stated on arcs alone, as in the dissertation. -/
@@ -113,30 +115,29 @@ theorem IsTierOrdered.precPath_iff {G : MixedGraph V} {c : V → ι}
   · intro hp
     induction hp with
     | single hb => exact hb
-    | tail _ hb ih => exact h.2.2.2 ih hb
+    | tail _ hb ih => exact h.trans ih hb
   · exact .single
 
-/-- The named form of the flat axioms: on each tier the arcs are a strict total
-    order (`LinearOrder`'s own pattern — flat fields, derived class). Feeds
-    `linearOrderOfSTO` for sorting the fibers. -/
+/-- The classed form of the axioms: on each tier the arcs are a strict total
+    order. Feeds `linearOrderOfSTO` for sorting the fibers. -/
 theorem IsTierOrdered.isStrictTotalOrder {G : MixedGraph V} {c : V → ι}
     (h : IsTierOrdered G c) (i : ι) :
     IsStrictTotalOrder {v // c v = i} (fun a b => G.arcs.Adj a b) where
   trichotomous a b hab hba := by
     by_contra hne
-    rcases h.2.1 (fun hv => hne (Subtype.ext hv)) (a.2.trans b.2.symm) with hp | hp
+    rcases h.total (fun hv => hne (Subtype.ext hv)) (a.2.trans b.2.symm) with hp | hp
     exacts [hab hp, hba hp]
-  irrefl a := h.2.2.1 a
-  trans _ _ _ hab hbc := h.2.2.2 hab hbc
+  irrefl a := h.irrefl a
+  trans _ _ _ hab hbc := h.trans hab hbc
 
 /-! ### The category of labeled mixed graphs -/
 
 /-- An object of the category of labeled mixed graphs over `S`: a vertex type
     with a mixed graph `⟨V, E, A⟩` on it and a labeling `ℓ : V → S` — the
     literature's labeled mixed graph `⟨V, E, A, ℓ⟩` / [jardine-2019]'s `GR(Γ)`. -/
-structure MixedGraphCat (S : Type v) : Type (max (u + 1) v) where
+structure MixedGraphCat (S : Type*) where
   /-- The vertex type. -/
-  V : Type u
+  V : Type*
   /-- The mixed graph: undirected association edges and directed order arcs. -/
   graph : MixedGraph V
   /-- The labeling (`ℓ`). -/
@@ -225,7 +226,7 @@ def Iso.trans {X Y Z : MixedGraphCat S} (e : Iso X Y) (f : Iso Y Z) : Iso X Z wh
 /-! ### The empty graph -/
 
 /-- The empty labeled mixed graph, on the empty vertex type. -/
-def empty (S : Type v) : MixedGraphCat S := ⟨PEmpty, ⟨⊥, ⊥⟩, PEmpty.elim⟩
+def empty (S : Type*) : MixedGraphCat S := ⟨PEmpty, ⟨⊥, ⊥⟩, PEmpty.elim⟩
 
 theorem empty_isTierOrdered (t : S → ι) : IsTierOrdered (empty S).graph ((empty S).tier t) :=
   ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
@@ -336,25 +337,25 @@ theorem isTierOrdered_concat {X Y : MixedGraphCat S}
     IsTierOrdered (concat t X Y).graph ((concat t X Y).tier t) := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · rintro (v | v) (w | w) h
-    exacts [h₁.1 h, h, h.elim, h₂.1 h]
+    exacts [h₁.tier_eq h, h, h.elim, h₂.tier_eq h]
   · rintro (v | v) (w | w) hne htier
-    · rcases h₁.2.1 (by rintro rfl; exact hne rfl) htier with hp | hp
+    · rcases h₁.total (by rintro rfl; exact hne rfl) htier with hp | hp
       exacts [Or.inl hp, Or.inr hp]
     · exact Or.inl htier
     · exact Or.inr htier.symm
-    · rcases h₂.2.1 (by rintro rfl; exact hne rfl) htier with hp | hp
+    · rcases h₂.total (by rintro rfl; exact hne rfl) htier with hp | hp
       exacts [Or.inl hp, Or.inr hp]
   · rintro (v | v) h
-    exacts [h₁.2.2.1 v h, h₂.2.2.1 v h]
+    exacts [h₁.irrefl v h, h₂.irrefl v h]
   · rintro (u | u) (v | v) (w | w) huv hvw
-    · exact h₁.2.2.2 huv hvw
-    · exact (h₁.1 huv).trans hvw
+    · exact h₁.trans huv hvw
+    · exact (h₁.tier_eq huv).trans hvw
     · exact (hvw : False).elim
-    · exact huv.trans (h₂.1 hvw)
+    · exact huv.trans (h₂.tier_eq hvw)
     · exact (huv : False).elim
     · exact (huv : False).elim
     · exact (hvw : False).elim
-    · exact h₂.2.2.2 huv hvw
+    · exact h₂.trans huv hvw
 
 /-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross
     edges. -/
@@ -471,7 +472,7 @@ def sumDesc {X Y T : MixedGraphCat S} (f : Hom X T) (g : Hom Y T) : Hom (sum X Y
 theorem not_isTierOrdered_sum (t : S → ι) {X Y : MixedGraphCat S}
     (v : X.V) (w : Y.V) (htier : X.tier t v = Y.tier t w) :
     ¬ IsTierOrdered (sum X Y).graph ((sum X Y).tier t) := fun h =>
-  (h.2.1 (v := .inl v) (w := .inr w) (by simp) htier).elim (fun hp => hp) fun hp => hp
+  (h.total (v := .inl v) (w := .inr w) (by simp) htier).elim (fun hp => hp) fun hp => hp
 
 /-! ### The category of labeled mixed graphs -/
 
@@ -578,7 +579,7 @@ def tensor (X Y : Representation t) : Representation t :=
     Goldsmith's bipartite two-tier geometry is the two-colorable case. -/
 def tierColoring (X : Representation t) : X.obj.graph.edges.Coloring ι :=
   SimpleGraph.Coloring.mk (X.obj.tier t) fun {_ _} hadj htier =>
-    (X.property.1.2.1 hadj.ne htier).elim (X.property.2 hadj) (X.property.2 hadj.symm)
+    (X.property.1.total hadj.ne htier).elim (X.property.2 hadj) (X.property.2 hadj.symm)
 
 /-- A representation's association graph is colorable by its tiers: tier arity
     bounds the chromatic number of the association pattern. -/

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -76,35 +76,25 @@ def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.arcs
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
 def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
 
-/-- Tier equality propagates along precedence paths once arcs are tier-internal;
-    stated as a lemma because use sites have destructured endpoints, on which
-    `induction` cannot fire. -/
-lemma precPath_tier {t : S → ι} {G : MixedGraph V S}
-    (harc : ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) {v w : V}
-    (h : G.PrecPath v w) : G.tier t v = G.tier t w := by
-  induction h with
-  | single h => exact harc h
-  | tail _ h ih => exact ih.trans (harc h)
-
 /-! ### The §4.2 axioms -/
 
 section Axioms
 variable (t : S → ι) (G : MixedGraph V S)
 
-/-- Axioms 1–2 ([jardine-2016-diss] §4.2): precedence stays within a tier,
-    precedence paths totally order each tier class, no path returns to its
-    origin, and the arcs are path-closed — [jardine-2019]'s reading that `A`
-    represents *the order* on each string, so per tier the arcs are exactly a
-    strict total order. Closure is what makes the tuple normal form arc-exact. -/
+/-- Axioms 1–2 ([jardine-2016-diss] §4.2): per tier, the arcs are a strict
+    linear order — tier-internal, total, irreflexive, transitive. This is
+    [jardine-2019]'s reading that `A` represents *the order* on each string; the
+    arcs coincide with their path closure (`IsTierOrdered.precPath_iff`), so no
+    closure operator appears in the axioms. -/
 def IsTierOrdered : Prop :=
   (∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) ∧
-    (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.PrecPath v w ∨ G.PrecPath w v) ∧
-    (∀ v, ¬ G.PrecPath v v) ∧
-    ∀ ⦃v w⦄, G.PrecPath v w → G.arcs.Adj v w
+    (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.arcs.Adj v w ∨ G.arcs.Adj w v) ∧
+    (∀ v, ¬ G.arcs.Adj v v) ∧
+    ∀ ⦃u v w⦄, G.arcs.Adj u v → G.arcs.Adj v w → G.arcs.Adj u w
 
 /-- Axiom 3: association never links precedence-path-related (tier-internal)
     vertices. Tier-free — stated on paths alone, as in the dissertation. -/
-def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.edges.Adj v w → ¬ G.PrecPath v w
+def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.edges.Adj v w → ¬ G.arcs.Adj v w
 
 /-- Axiom 4 (full specification): every vertex participates in an association.
     [goldsmith-1976]'s original well-formedness condition; stated but deliberately
@@ -115,8 +105,8 @@ def IsSaturated : Prop := ∀ v, ∃ w, G.edges.Adj v w
     form: no two association edges whose endpoints straddle in opposite precedence
     order. -/
 def IsPlanar : Prop :=
-  ∀ ⦃v v' w w'⦄, G.edges.Adj v v' → G.edges.Adj w w' → G.PrecPath v w →
-    ¬ G.PrecPath w' v'
+  ∀ ⦃v v' w w'⦄, G.edges.Adj v v' → G.edges.Adj w w' → G.arcs.Adj v w →
+    ¬ G.arcs.Adj w' v'
 
 /-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m` bear
     distinct labels. -/
@@ -124,6 +114,17 @@ def IsOCPClean (m : ι) : Prop :=
   ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = m → G.label v ≠ G.label w
 
 end Axioms
+
+/-- On the axiom class, precedence paths coincide with the arcs — the
+    dissertation's `≺`. -/
+theorem IsTierOrdered.precPath_iff {t : S → ι} {G : MixedGraph V S}
+    (h : G.IsTierOrdered t) {v w : V} : G.PrecPath v w ↔ G.arcs.Adj v w := by
+  constructor
+  · intro hp
+    induction hp with
+    | single hb => exact hb
+    | tail _ hb ih => exact h.2.2.2 ih hb
+  · exact .single
 
 /-! ### Morphisms -/
 
@@ -306,106 +307,45 @@ def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
     · exact v.elim
     · rfl
 
-/-! #### Precedence paths in a concatenation
-
-Paths never return from the second block to the first, so blockwise paths
-decompose into factor paths. -/
-
-private lemma precPath_inr_cases {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {b : V₂}
-    {y : V₁ ⊕ V₂} (h : (concat t G₁ G₂).PrecPath (.inr b) y) :
-    ∃ b', y = .inr b' ∧ G₂.PrecPath b b' := by
-  induction h with
-  | @single y' h =>
-      cases y' with
-      | inl a => exact (h : False).elim
-      | inr b' => exact ⟨b', rfl, .single (h : G₂.arcs.Adj b b')⟩
-  | @tail y' y'' _ h ih =>
-      obtain ⟨b'', rfl, hp⟩ := ih
-      cases y'' with
-      | inl a => exact (h : False).elim
-      | inr b' => exact ⟨b', rfl, hp.tail (h : G₂.arcs.Adj b'' b')⟩
-
-private lemma precPath_inl_cases {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {a : V₁}
-    {y : V₁ ⊕ V₂} (h : (concat t G₁ G₂).PrecPath (.inl a) y) :
-    (∃ a', y = .inl a' ∧ G₁.PrecPath a a') ∨ ∃ b, y = .inr b := by
-  induction h with
-  | @single y' h =>
-      cases y' with
-      | inl a' => exact Or.inl ⟨a', rfl, .single (h : G₁.arcs.Adj a a')⟩
-      | inr b => exact Or.inr ⟨b, rfl⟩
-  | @tail y' y'' _ h ih =>
-      rcases ih with ⟨a'', rfl, hp⟩ | ⟨b, rfl⟩
-      · cases y'' with
-        | inl a' => exact Or.inl ⟨a', rfl, hp.tail (h : G₁.arcs.Adj a'' a')⟩
-        | inr b => exact Or.inr ⟨b, rfl⟩
-      · cases y'' with
-        | inl a' => exact (h : False).elim
-        | inr b' => exact Or.inr ⟨b', rfl⟩
-
-@[simp] theorem concat_precPath_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
-    {a a' : V₁} : (concat t G₁ G₂).PrecPath (.inl a) (.inl a') ↔ G₁.PrecPath a a' := by
-  constructor
-  · intro h
-    rcases precPath_inl_cases t h with ⟨x, hx, hp⟩ | ⟨b, hb⟩
-    · cases hx; exact hp
-    · exact absurd hb (by simp)
-  · intro h
-    exact Relation.TransGen.lift Sum.inl (fun _ _ hab => hab) h
-
-@[simp] theorem concat_precPath_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
-    {b b' : V₂} : (concat t G₁ G₂).PrecPath (.inr b) (.inr b') ↔ G₂.PrecPath b b' := by
-  constructor
-  · intro h
-    obtain ⟨x, hx, hp⟩ := precPath_inr_cases t h
-    cases hx; exact hp
-  · intro h
-    exact Relation.TransGen.lift Sum.inr (fun _ _ hab => hab) h
-
-@[simp] theorem concat_not_precPath_inr_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
-    {b : V₂} {a : V₁} : ¬ (concat t G₁ G₂).PrecPath (.inr b) (.inl a) := fun h => by
-  obtain ⟨_, hx, _⟩ := precPath_inr_cases t h
-  exact absurd hx (by simp)
-
 /-! #### Axiom preservation ([jardine-heinz-2015] Theorem 4's structural half) -/
 
-/-- Concatenation preserves Axioms 1–2, including path-closure: a cross-seam
-    path forces tier equality, which is already a bridge arc. -/
+/-- Concatenation preserves Axioms 1–2; transitivity through the seam holds
+    because arcs are tier-internal. -/
 theorem isTierOrdered_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
     (h₁ : G₁.IsTierOrdered t) (h₂ : G₂.IsTierOrdered t) :
     (concat t G₁ G₂).IsTierOrdered t := by
-  have hint : ∀ ⦃v w⦄, (concat t G₁ G₂).arcs.Adj v w →
-      (concat t G₁ G₂).tier t v = (concat t G₁ G₂).tier t w := by
-    rintro (v | v) (w | w) h
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rintro (v | v) (w | w) h
     exacts [h₁.1 h, h, h.elim, h₂.1 h]
-  refine ⟨hint, ?_, ?_, ?_⟩
   · rintro (v | v) (w | w) hne htier
     · rcases h₁.2.1 (by simpa using hne) htier with hp | hp
-      · exact Or.inl ((concat_precPath_inl_inl t).mpr hp)
-      · exact Or.inr ((concat_precPath_inl_inl t).mpr hp)
-    · exact Or.inl (.single htier)
-    · exact Or.inr (.single htier.symm)
+      exacts [Or.inl hp, Or.inr hp]
+    · exact Or.inl htier
+    · exact Or.inr htier.symm
     · rcases h₂.2.1 (by simpa using hne) htier with hp | hp
-      · exact Or.inl ((concat_precPath_inr_inr t).mpr hp)
-      · exact Or.inr ((concat_precPath_inr_inr t).mpr hp)
+      exacts [Or.inl hp, Or.inr hp]
   · rintro (v | v) h
-    · exact h₁.2.2.1 v ((concat_precPath_inl_inl t).mp h)
-    · exact h₂.2.2.1 v ((concat_precPath_inr_inr t).mp h)
-  · rintro (v | v) (w | w) h
-    · exact h₁.2.2.2 ((concat_precPath_inl_inl t).mp h)
-    · exact precPath_tier hint h
-    · exact absurd h (concat_not_precPath_inr_inl t)
-    · exact h₂.2.2.2 ((concat_precPath_inr_inr t).mp h)
+    exacts [h₁.2.2.1 v h, h₂.2.2.1 v h]
+  · rintro (u | u) (v | v) (w | w) huv hvw
+    · exact h₁.2.2.2 huv hvw
+    · exact (h₁.1 huv).trans hvw
+    · exact (hvw : False).elim
+    · exact huv.trans (h₂.1 hvw)
+    · exact (huv : False).elim
+    · exact (huv : False).elim
+    · exact (hvw : False).elim
+    · exact h₂.2.2.2 huv hvw
 
-/-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross edges,
-    and blockwise paths are factor paths. -/
+/-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross
+    edges. -/
 theorem noInternalAssoc_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
     (h₁ : G₁.NoInternalAssoc) (h₂ : G₂.NoInternalAssoc) :
     (concat t G₁ G₂).NoInternalAssoc := by
-  rintro (v | v) (w | w) hadj hp
-  · exact h₁ hadj ((concat_precPath_inl_inl t).mp hp)
+  rintro (v | v) (w | w) hadj harc
+  · exact h₁ hadj harc
   · exact absurd hadj (by simp)
   · exact absurd hadj (by simp)
-  · exact h₂ hadj ((concat_precPath_inr_inr t).mp hp)
+  · exact h₂ hadj harc
 
 /-! #### Functoriality of concatenation -/
 
@@ -465,32 +405,6 @@ def sum (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁
 @[simp] theorem sum_edges (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
     (G₁.sum G₂).edges = G₁.edges ⊕g G₂.edges := rfl
 
-private lemma sum_precPath_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {a : V₁}
-    {y : V₁ ⊕ V₂} (h : (G₁.sum G₂).PrecPath (.inl a) y) : ∃ a', y = .inl a' := by
-  induction h with
-  | @single y' h =>
-      cases y' with
-      | inl a' => exact ⟨a', rfl⟩
-      | inr b => exact (h : False).elim
-  | @tail y' y'' _ h ih =>
-      obtain ⟨a'', rfl⟩ := ih
-      cases y'' with
-      | inl a' => exact ⟨a', rfl⟩
-      | inr b => exact (h : False).elim
-
-private lemma sum_precPath_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {b : V₂}
-    {y : V₁ ⊕ V₂} (h : (G₁.sum G₂).PrecPath (.inr b) y) : ∃ b', y = .inr b' := by
-  induction h with
-  | @single y' h =>
-      cases y' with
-      | inl a => exact (h : False).elim
-      | inr b' => exact ⟨b', rfl⟩
-  | @tail y' y'' _ h ih =>
-      obtain ⟨b'', rfl⟩ := ih
-      cases y'' with
-      | inl a => exact (h : False).elim
-      | inr b' => exact ⟨b', rfl⟩
-
 /-- Copairing out of the bridge-free sum. -/
 def sumDesc {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {H : MixedGraph V₃ S}
     (f : Hom G₁ H) (g : Hom G₂ H) : Hom (G₁.sum G₂) H where
@@ -511,13 +425,8 @@ def sumDesc {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {H : MixedGrap
     are precedence-unrelated across the seam. -/
 theorem not_isTierOrdered_sum (t : S → ι) {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
     (v : V₁) (w : V₂) (htier : G₁.tier t v = G₂.tier t w) :
-    ¬ (G₁.sum G₂).IsTierOrdered t := by
-  intro h
-  rcases h.2.1 (v := .inl v) (w := .inr w) (by simp) htier with hp | hp
-  · obtain ⟨a', ha⟩ := sum_precPath_inl hp
-    exact absurd ha (by simp)
-  · obtain ⟨b', hb⟩ := sum_precPath_inr hp
-    exact absurd hb (by simp)
+    ¬ (G₁.sum G₂).IsTierOrdered t := fun h =>
+  (h.2.1 (v := .inl v) (w := .inr w) (by simp) htier).elim (fun hp => hp) fun hp => hp
 
 end MixedGraph
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -45,8 +45,9 @@ out of the raw graphs relative to it.
 ## Main results
 
 * `concat_empty_iso`, `empty_concat_iso`, `concat_assoc_iso`,
-  `isTierOrdered_concat`, `noInternalAssoc_concat`: [jardine-heinz-2015]
-  Theorems 1, 3 and 4 up to `Iso`, unconditional in the order signature.
+  `isTierOrdered_concat`, `noInternalAssoc_concat`, `isPlanar_concat`:
+  [jardine-heinz-2015] Theorems 1, 3 and 4 up to `Iso`, unconditional in the
+  order signature; `isPlanar_concat` is [jardine-2019]'s NCC-preservation.
 * `not_isTierOrdered_sum`: the bridge-free coproduct leaves the axiom class
   whenever the factors share a tier — Axiom 2 forces `concat`'s bridges.
 * `Representation.tierColoring`: the tier map properly colors the association
@@ -234,18 +235,20 @@ theorem empty_noInternalAssoc : NoInternalAssoc (empty S).graph := fun v => v.el
 /-! ### Tier-bridging concatenation
 
 Per tier class, concatenation is the ordinal sum: blockwise arcs plus a bridging
-arc from every `X`-vertex of a class to every same-class `Y`-vertex. This is
-the signature of [jardine-2019]'s own formulation — arcs represent *the order* on
-each string, not its successor steps — under which [jardine-heinz-2015]
-Definition 2's last-to-first successor bridge becomes the complete same-class
-bridge: the two composites agree in precedence-closure, the relation the axioms
-and results here consume (on the definability relationship between the two
-signatures cf. [jardine-2017-complexity]; note that subgraph-based notions such
-as `ASL.lean`'s forbidden-factor grammars are signature-sensitive and do not
-transfer for free). The order form makes the bridge total (the paper's
-`first`/`last` are partial) and functorial, and its monoid laws unconditional
-where the successor form's associativity is conditional on the tier classes being
-string graphs (the paper's Lemma 1 remark). -/
+arc from every `X`-vertex of a class to every same-class `Y`-vertex.
+[jardine-2019] glosses `A` as representing *the order* on each string, but its
+operative concatenation bridges a single pair per tier — `(last X Γᵢ, first Y Γᵢ)`,
+with `first`/`last` partial — so its composites carry generator-style arcs. This
+axiom class instead takes the order-*closed* representative of that same
+precedence relation (interconvertible with the generator form via Hasse diagram ↔
+transitive closure on the finite per-tier strict orders); the complete same-class
+bridge is chosen because it is total and functorial where `first`/`last` are
+partial and not hom-preserved, and its monoid laws unconditional where the
+successor form's associativity is conditional on the tier classes being string
+graphs (the paper's Lemma 1 remark). On the definability relationship between the
+two signatures cf. [jardine-2017-complexity]; subgraph-based notions such as
+`ASL.lean`'s forbidden-factor grammars are signature-sensitive and do not transfer
+for free. -/
 
 section Concat
 variable (t : S → ι)
@@ -363,6 +366,31 @@ theorem noInternalAssoc_concat {X Y : MixedGraphCat S}
   · exact absurd hadj (by simp)
   · exact absurd hadj (by simp)
   · exact h₂ hadj harc
+
+/-- Concatenation preserves the No-Crossing Constraint ([jardine-2019]'s
+    headline [jardine-heinz-2015] result): plain factor planarity suffices.
+    Association edges are blockwise, so a straddle needs both edges in one block —
+    reducing to the factor's `IsPlanar` — or one per block, where the required
+    return arc runs `inr → inl` and does not exist. -/
+theorem isPlanar_concat {X Y : MixedGraphCat S}
+    (h₁ : IsPlanar X.graph) (h₂ : IsPlanar Y.graph) : IsPlanar (concat t X Y).graph := by
+  rintro (v | v) (v' | v') (w | w) (w' | w') hvv' hww' hvw hw'v'
+  · exact h₁ hvv' hww' hvw hw'v'
+  · exact absurd hww' (by simp)
+  · exact absurd hww' (by simp)
+  · exact (hw'v' : False).elim
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact absurd hvv' (by simp)
+  · exact (hvw : False).elim
+  · exact absurd hww' (by simp)
+  · exact absurd hww' (by simp)
+  · exact h₂ hvv' hww' hvw hw'v'
 
 /-! #### Functoriality of concatenation -/
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -507,18 +507,6 @@ open MonoidalCategory
 
 variable {t}
 
-/-- The tensor unit: the empty representation. -/
-def unit : Representation t :=
-  ⟨MixedGraphCat.empty S, MixedGraphCat.empty_isTierOrdered t,
-    MixedGraphCat.empty_noInternalAssoc⟩
-
-/-- The tensor: morpheme concatenation, staying in the axiom class by
-    `isTierOrdered_concat`/`noInternalAssoc_concat`. -/
-def tensor (X Y : Representation t) : Representation t :=
-  ⟨MixedGraphCat.concat t X.obj Y.obj,
-    MixedGraphCat.isTierOrdered_concat t X.property.1 Y.property.1,
-    MixedGraphCat.noInternalAssoc_concat t X.property.2 Y.property.2⟩
-
 /-- Under the structural axioms the tier map properly colors the association
     graph: same-tier vertices are precedence-related (Axioms 1–2) and associated
     vertices never are (Axiom 3), so associated vertices lie on distinct tiers.
@@ -545,30 +533,22 @@ theorem hom_ext {X Y : Representation t} {f g : X ⟶ Y}
     (h : ∀ v, f.hom.toFun v = g.hom.toFun v) : f = g :=
   InducedCategory.hom_ext (MixedGraphCat.Hom.ext (funext h))
 
-/-- The tensor on morphisms, as a representation morphism. -/
-def tensorHomAux {X₁ Y₁ X₂ Y₂ : Representation t} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
-    tensor X₁ X₂ ⟶ tensor Y₁ Y₂ :=
-  InducedCategory.homMk (MixedGraphCat.Hom.concatMap (X₁ := X₁.obj) (Y₁ := Y₁.obj)
-    (X₂ := X₂.obj) (Y₂ := Y₂.obj) t f.hom g.hom)
-
-/-- Left whiskering, as a representation morphism. -/
-def whiskerLeftAux (X : Representation t) {Y₁ Y₂ : Representation t} (f : Y₁ ⟶ Y₂) :
-    tensor X Y₁ ⟶ tensor X Y₂ :=
-  InducedCategory.homMk (MixedGraphCat.Hom.concatMap (X₁ := X.obj) (Y₁ := X.obj)
-    (X₂ := Y₁.obj) (Y₂ := Y₂.obj) t (MixedGraphCat.Hom.id X.obj) f.hom)
-
-/-- Right whiskering, as a representation morphism. -/
-def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Representation t) :
-    tensor X₁ Y ⟶ tensor X₂ Y :=
-  InducedCategory.homMk (MixedGraphCat.Hom.concatMap (X₁ := X₁.obj) (Y₁ := X₂.obj)
-    (X₂ := Y.obj) (Y₂ := Y.obj) t f.hom (MixedGraphCat.Hom.id Y.obj))
-
+/-- Monoidal structure: morpheme concatenation as tensor, the empty
+    representation as unit; the axiom class is closed under both by
+    `isTierOrdered_concat`/`noInternalAssoc_concat`. -/
 @[simps] instance instMonoidalStruct : MonoidalCategoryStruct (Representation t) where
-  tensorObj := tensor
-  tensorUnit := unit
-  tensorHom := tensorHomAux
-  whiskerLeft := whiskerLeftAux
-  whiskerRight := whiskerRightAux
+  tensorObj X Y :=
+    ⟨MixedGraphCat.concat t X.obj Y.obj,
+      MixedGraphCat.isTierOrdered_concat t X.property.1 Y.property.1,
+      MixedGraphCat.noInternalAssoc_concat t X.property.2 Y.property.2⟩
+  tensorUnit :=
+    ⟨MixedGraphCat.empty S, MixedGraphCat.empty_isTierOrdered t,
+      MixedGraphCat.empty_noInternalAssoc⟩
+  tensorHom f g := InducedCategory.homMk (MixedGraphCat.Hom.concatMap t f.hom g.hom)
+  whiskerLeft X _ _ f :=
+    InducedCategory.homMk (MixedGraphCat.Hom.concatMap t (MixedGraphCat.Hom.id X.obj) f.hom)
+  whiskerRight f Y :=
+    InducedCategory.homMk (MixedGraphCat.Hom.concatMap t f.hom (MixedGraphCat.Hom.id Y.obj))
   associator X Y Z := mkIso (MixedGraphCat.concatAssocIso t X.obj Y.obj Z.obj)
   leftUnitor X := mkIso (MixedGraphCat.emptyConcatIso t X.obj)
   rightUnitor X := mkIso (MixedGraphCat.concatEmptyIso t X.obj)

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -13,78 +13,58 @@ import Mathlib.Logic.Relation
 import Linglib.Core.Combinatorics.MixedGraph
 
 /-!
-# Labeled mixed graphs — the autosegmental foundation
+# Labeled mixed graphs
 
-A labeled mixed graph `⟨V, E, A, ℓ⟩` ([jardine-2019] §5; [jardine-heinz-2015] §2;
-[jardine-2016-diss] §4.1) is the literature's most general autosegmental object: a
-mixed graph (`Core/Combinatorics/MixedGraph.lean` — undirected association edges
-`E ⊆ [V]²`, here a `SimpleGraph` since the edges are two-element subsets, and
-directed arcs `A ⊆ V × V` "representing the order on each string", a `Digraph`)
-together with a total vertex labeling. The raw graphs are [jardine-2019]'s
-`GR(Γ)`, here the category `MixedGraphCat`. As pure relations
-over a vertex-type parameter it is a finite relational structure in the
-model-theoretic-phonology sense — the format in which notational-equivalence results
-are proved ([jardine-danis-iacoponi-2021], [oakden-2020]) — and stores no ambient
-cross-tier order, which is structure the object does not have.
-
-Tiers are not part of the object. A tier assignment `t : S → ι` on the alphabet
-induces the node partition, and [jardine-2016-diss] §4.2's well-formedness axioms
-carve the autosegmental representations out of the raw graphs relative to it.
-
-Concatenation is [jardine-heinz-2015] Definition 2 *minus its `R_ID` melody merge*
-(the OCP repair, modeled separately as `OCP.collapse`, matching `AR.lean`): on
-edges it is the stock disjoint sum `⊕g`; on arcs it is the blockwise sum plus, per
-tier class, bridging arcs from the first factor's precedence-maximal vertices to
-the second factor's precedence-minimal ones. The monoid laws hold up to
-structure-preserving equivalence (`MixedGraph.Iso`), not up to equality —
-strictness belongs to the tiered normal form, not to the foundation.
+A labeled mixed graph `⟨V, E, A, ℓ⟩` is the general autosegmental object
+([jardine-2019] §5; [jardine-heinz-2015] §2; [jardine-2016-diss] §4.1): a
+`MixedGraph` — association edges as a `SimpleGraph`, order arcs as a `Digraph` —
+with a vertex labeling, and no further structure. Tiers are not part of the
+object: a tier assignment `t : S → ι` induces the node partition, and the
+dissertation's §4.2 axioms carve the autosegmental representations out of the
+raw graphs relative to it.
 
 ## Main definitions
 
-* `Autosegmental.MixedGraph V S`: a `MixedGraph V` with a labeling `label : V → S`
-  (the owner-relative name: within this namespace, the labeled object, following
-  the dissertation's own usage). `PrecPath` is the transitive closure of the arcs.
-* The [jardine-2016-diss] §4.2 axioms, relative to a tier assignment where tiers
-  matter: `IsTierOrdered` (Axioms 1–2), `NoInternalAssoc` (Axiom 3), `IsSaturated`
-  (Axiom 4 — stated, deliberately not imposed, as in `AR.lean`), `IsPlanar`
-  (Axiom 5, the No-Crossing Constraint in its general path form), `IsOCPClean`
-  (Axiom 6). Numbering follows the dissertation; [jardine-heinz-2015] numbers the
-  NCC and OCP as its Axioms 4 and 5 and has no saturation axiom, which is why
-  `AR.lean`'s citations differ.
-* `MixedGraph.Hom`: label- and association-preserving maps — the broad morphism
-  class, deliberately precedence-forgetting; `precPreserving` is the wide
-  morphism class of full-structure (model-theoretic) homomorphisms, and
-  `MixedGraph.Iso` the full-structure equivalences, with faces projecting to the
-  stock `SimpleGraph.Hom`/`Iso` and `RelIso`.
-* `MixedGraph.concat t`: tier-bridging concatenation on the vertex sum;
-  `MixedGraph.sum` is the bridge-free blockwise sum, the categorical coproduct
-  of the broad category (`HasInitial`/`HasBinaryCoproducts` on `MixedGraphCat`).
-* `MixedGraphCat S`: **the category of labeled mixed graphs** (vertex type
-  bundled with a graph); `Representation t` is **the category of autosegmental
-  representations** — the full subcategory of the structural axiom class
-  (Axioms 1–3), the category autosegmental phonology actually works in.
+* `Autosegmental.MixedGraph V S`: the labeled mixed graph; `PrecPath` is the
+  transitive closure of its arcs.
+* `IsTierOrdered`, `NoInternalAssoc`, `IsSaturated`, `IsPlanar`, `IsOCPClean`:
+  the §4.2 axioms (1–2, 3, 4, 5, 6; [jardine-heinz-2015] numbers the NCC and OCP
+  as 4 and 5 and has no saturation axiom). Saturation is stated but not imposed,
+  as in `AR.lean`; tier-orderedness includes path-closure, [jardine-2019]'s
+  reading that `A` represents the order.
+* `MixedGraph.Hom`: label- and association-preserving maps; `precPreserving`
+  marks the full-structure homomorphisms, `MixedGraph.Iso` the full-structure
+  equivalences.
+* `MixedGraph.concat t`: concatenation — the vertex sum with a same-tier bridge,
+  [jardine-heinz-2015] Definition 2 in the order signature, minus its `R_ID`
+  merge (`OCP.collapse`); `MixedGraph.sum` is the bridge-free coproduct.
+* `MixedGraphCat S`: the category of labeled mixed graphs ([jardine-2019]'s
+  `GR(Γ)`), with `HasInitial` and `HasBinaryCoproducts`; `Representation t` is
+  the category of autosegmental representations — the full subcategory on
+  Axioms 1–3, monoidal under `concat`.
 
 ## Main results
 
-* `concat_empty_iso` / `empty_concat_iso`: the unit laws up to `Iso`
-  ([jardine-heinz-2015] Theorem 1).
-* `not_isTierOrdered_sum`: **Axiom 2 forces the bridges** — the bridge-free
-  coproduct leaves the axiom class whenever the factors share a tier, so
-  `concat`'s bridging arcs are the minimal repair keeping concatenation inside
-  `Representation`. The precise content of [jardine-heinz-2015]'s "modification
-  of the disjoint union".
+* `concat_empty_iso`, `empty_concat_iso`, `concat_assoc_iso`,
+  `isTierOrdered_concat`, `noInternalAssoc_concat`: [jardine-heinz-2015]
+  Theorems 1, 3 and 4 up to `Iso`, unconditional in the order signature.
+* `not_isTierOrdered_sum`: the bridge-free coproduct leaves the axiom class
+  whenever the factors share a tier — Axiom 2 forces `concat`'s bridges.
+* `Representation.tierColoring`: the tier map properly colors the association
+  graph, so tier arity bounds its chromatic number (`edges_colorable`).
+
+## Implementation notes
+
+The object stores no cross-tier order, and morphisms default to the broad
+precedence-forgetting class, where the coproduct and the OCP repair live.
+Subgraph-based notions (`ASL.lean`) are signature-sensitive and do not transfer
+to the order signature for free. Monoid laws hold up to `Iso`; strictness
+belongs to the tiered normal form (`MultiAR.lean`).
 
 ## TODO
 
-* Associativity up to `Iso` ([jardine-heinz-2015] Theorem 3; the edge component is
-  stock `SimpleGraph.Iso.sumAssoc`, the arc component is the bridge algebra —
-  conditional on the tier classes being precedence chains, per the paper's Lemma 1
-  remark).
-* Axiom preservation under `concat` ([jardine-heinz-2015] Theorem 4 and its
-  Axiom 1–3 analogues).
-* The normal-form equivalence: every graph satisfying Axioms 1–3 is isomorphic to
-  a tier-indexed family of `LabeledTuple`s with per-pair links — the strict tiered
-  presentation `MultiAR` builds on — with `IsPlanar` reducing to the per-pair NCC.
+* The normal-form equivalence with the strict tuple presentation, with
+  `IsPlanar` reducing to the per-pair NCC on normal forms.
 -/
 
 namespace Autosegmental

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -578,36 +578,23 @@ def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Repr
     with every proof a componentwise `rfl` over the concrete sum maps. -/
 instance : MonoidalCategory (Representation t) :=
   MonoidalCategory.ofTensorHom
-    (id_tensorHom_id := fun _ _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v <;> rfl)
+    (id_tensorHom_id := fun _ _ => hom_ext (congrFun Sum.map_id_id))
     (id_tensorHom := fun _ _ _ _ => rfl)
     (tensorHom_id := fun _ _ => rfl)
-    (tensorHom_comp_tensorHom := fun _ _ _ _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v <;> rfl)
+    (tensorHom_comp_tensorHom := fun _ _ _ _ => hom_ext (congrFun (Sum.map_comp_map _ _ _ _)))
     (associator_naturality := fun _ _ _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v
-      · rcases (v : _ ⊕ _) with v | v <;> rfl
-      · rfl)
+      repeat' rcases (v : _ ⊕ _) with v | v
+      all_goals first | rfl | exact v.elim)
     (leftUnitor_naturality := fun _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v
-      · exact v.elim
-      · rfl)
+      rcases (v : _ ⊕ _) with v | v <;> first | rfl | exact v.elim)
     (rightUnitor_naturality := fun _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v
-      · rfl
-      · exact v.elim)
+      rcases (v : _ ⊕ _) with v | v <;> first | rfl | exact v.elim)
     (pentagon := fun _ _ _ _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v
-      · rcases (v : _ ⊕ _) with v | v
-        · rcases (v : _ ⊕ _) with v | v <;> rfl
-        · rfl
-      · rfl)
+      repeat' rcases (v : _ ⊕ _) with v | v
+      all_goals first | rfl | exact v.elim)
     (triangle := fun _ _ => hom_ext fun v => by
-      rcases (v : _ ⊕ _) with v | v
-      · rcases (v : _ ⊕ _) with v | v
-        · rfl
-        · exact v.elim
-      · rfl)
+      repeat' rcases (v : _ ⊕ _) with v | v
+      all_goals first | rfl | exact v.elim)
 
 end Representation
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -68,10 +68,11 @@ variable {V S ι : Type*}
 section Axioms
 variable (G : MixedGraph V)
 
-/-- Axioms 1–2 ([jardine-2016-diss] §4.2), relative to a vertex coloring `c`
-    (the tier partition): the arcs are tier-internal and a fiberwise
-    `IsStrictTotalOrder`. This is [jardine-2019]'s reading that `A` represents
-    *the order* on each string; the arcs coincide with their path closure
+/-- Axioms 1–2 ([jardine-2016-diss] §4.2). Axiom 2's tier partition enters as
+    the coloring `c` — data, not a proposition — and what remains propositional
+    is Axiom 1 relative to it: the arcs are tier-internal and strictly totally
+    order each fiber. This is [jardine-2019]'s reading that `A` represents *the
+    order* on each string; the arcs coincide with their path closure
     (`IsTierOrdered.precPath_iff`), so no closure operator appears in the
     axioms. -/
 structure IsTierOrdered (c : V → ι) : Prop where
@@ -97,8 +98,7 @@ def IsSaturated : Prop := ∀ v, ∃ w, G.edges.Adj v w
     form: no two association edges whose endpoints straddle in opposite precedence
     order. -/
 def IsPlanar : Prop :=
-  ∀ ⦃v v' w w'⦄, G.edges.Adj v v' → G.edges.Adj w w' → G.arcs.Adj v w →
-    ¬ G.arcs.Adj w' v'
+  ∀ ⦃v v' w w'⦄, G.edges.Adj v v' → G.edges.Adj w w' → G.arcs.Adj v w → ¬ G.arcs.Adj w' v'
 
 /-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m` bear
     distinct labels. Needs the labeling `ℓ` and its tier assignment `t`. -/

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -139,6 +139,8 @@ structure MixedGraphCat (S : Type*) where
 
 namespace MixedGraphCat
 
+variable {X Y Z : MixedGraphCat S}
+
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
 def tier (t : S → ι) (X : MixedGraphCat S) : X.V → ι := t ∘ X.label
 
@@ -159,7 +161,7 @@ structure Hom (X Y : MixedGraphCat S) where
   label_comp : ∀ v, Y.label (toFun v) = X.label v
 
 /-- The edge face of a morphism, a stock graph homomorphism. -/
-def Hom.edgesHom {X Y : MixedGraphCat S} (f : Hom X Y) : X.graph.edges →g Y.graph.edges :=
+def Hom.edgesHom (f : Hom X Y) : X.graph.edges →g Y.graph.edges :=
   ⟨f.toFun, fun h => f.edge_map h⟩
 
 /-- The identity morphism. -/
@@ -167,7 +169,7 @@ def Hom.id (X : MixedGraphCat S) : Hom X X :=
   ⟨_root_.id, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Composition of morphisms. -/
-def Hom.comp {X Y Z : MixedGraphCat S} (f : Hom X Y) (g : Hom Y Z) : Hom X Z :=
+def Hom.comp (f : Hom X Y) (g : Hom Y Z) : Hom X Z :=
   ⟨g.toFun ∘ f.toFun, fun _ _ h => g.edge_map (f.edge_map h),
     fun v => (g.label_comp _).trans (f.label_comp v)⟩
 
@@ -175,20 +177,23 @@ def Hom.comp {X Y Z : MixedGraphCat S} (f : Hom X Y) (g : Hom Y Z) : Hom X Z :=
 
 /-- A label- and relation-preserving equivalence of labeled mixed graphs. -/
 structure Iso (X Y : MixedGraphCat S) extends X.V ≃ Y.V where
+  /-- Association edges correspond. -/
   edges_iff : ∀ v w, Y.graph.edges.Adj (toEquiv v) (toEquiv w) ↔ X.graph.edges.Adj v w
+  /-- Order arcs correspond. -/
   arcs_iff : ∀ v w, Y.graph.arcs.Adj (toEquiv v) (toEquiv w) ↔ X.graph.arcs.Adj v w
+  /-- Labels are preserved. -/
   label_comp : ∀ v, Y.label (toEquiv v) = X.label v
 
 /-- The edge face of an isomorphism, as a stock `SimpleGraph.Iso`. -/
-def Iso.edgesIso {X Y : MixedGraphCat S} (e : Iso X Y) : X.graph.edges ≃g Y.graph.edges :=
-  ⟨e.toEquiv, fun {v w} => e.edges_iff v w⟩
+def Iso.edgesIso (e : Iso X Y) : X.graph.edges ≃g Y.graph.edges :=
+  ⟨e.toEquiv, e.edges_iff _ _⟩
 
 /-- The arc face of an isomorphism, as a stock `RelIso`. -/
-def Iso.arcsIso {X Y : MixedGraphCat S} (e : Iso X Y) : X.graph.arcs.Adj ≃r Y.graph.arcs.Adj :=
-  ⟨e.toEquiv, fun {v w} => e.arcs_iff v w⟩
+def Iso.arcsIso (e : Iso X Y) : X.graph.arcs.Adj ≃r Y.graph.arcs.Adj :=
+  ⟨e.toEquiv, e.arcs_iff _ _⟩
 
 /-- An isomorphism as a morphism. -/
-def Iso.toHom {X Y : MixedGraphCat S} (e : Iso X Y) : Hom X Y :=
+def Iso.toHom (e : Iso X Y) : Hom X Y :=
   ⟨e.toEquiv, fun _ _ h => (e.edges_iff _ _).mpr h, e.label_comp⟩
 
 /-- The identity isomorphism. -/
@@ -196,22 +201,14 @@ def Iso.refl (X : MixedGraphCat S) : Iso X X :=
   ⟨Equiv.refl X.V, fun _ _ => Iff.rfl, fun _ _ => Iff.rfl, fun _ => rfl⟩
 
 /-- Inverse isomorphism. -/
-def Iso.symm {X Y : MixedGraphCat S} (e : Iso X Y) : Iso Y X where
+def Iso.symm (e : Iso X Y) : Iso Y X where
   toEquiv := e.toEquiv.symm
-  edges_iff v w := by
-    conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
-      show w = e.toEquiv (e.toEquiv.symm w) from (e.toEquiv.apply_symm_apply w).symm]
-    exact (e.edges_iff _ _).symm
-  arcs_iff v w := by
-    conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
-      show w = e.toEquiv (e.toEquiv.symm w) from (e.toEquiv.apply_symm_apply w).symm]
-    exact (e.arcs_iff _ _).symm
-  label_comp v := by
-    conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm]
-    exact (e.label_comp _).symm
+  edges_iff v w := by simpa using (e.edges_iff (e.toEquiv.symm v) (e.toEquiv.symm w)).symm
+  arcs_iff v w := by simpa using (e.arcs_iff (e.toEquiv.symm v) (e.toEquiv.symm w)).symm
+  label_comp v := by simpa using (e.label_comp (e.toEquiv.symm v)).symm
 
 /-- Composition of isomorphisms. -/
-def Iso.trans {X Y Z : MixedGraphCat S} (e : Iso X Y) (f : Iso Y Z) : Iso X Z where
+def Iso.trans (e : Iso X Y) (f : Iso Y Z) : Iso X Z where
   toEquiv := e.toEquiv.trans f.toEquiv
   edges_iff v w := (f.edges_iff _ _).trans (e.edges_iff v w)
   arcs_iff v w := (f.arcs_iff _ _).trans (e.arcs_iff v w)
@@ -265,19 +262,17 @@ def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
           | .inr _, .inl _ => False⟩ }
   label := Sum.elim X.label Y.label
 
-@[simp] theorem concat_label_inl (X Y : MixedGraphCat S) (v : X.V) :
-    (concat t X Y).label (.inl v) = X.label v := rfl
+@[simp] theorem concat_label_inl (v : X.V) : (concat t X Y).label (.inl v) = X.label v := rfl
 
-@[simp] theorem concat_label_inr (X Y : MixedGraphCat S) (v : Y.V) :
-    (concat t X Y).label (.inr v) = Y.label v := rfl
+@[simp] theorem concat_label_inr (v : Y.V) : (concat t X Y).label (.inr v) = Y.label v := rfl
 
-@[simp] theorem concat_edges (X Y : MixedGraphCat S) :
+@[simp] theorem concat_edges :
     (concat t X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
 
-@[simp] theorem concat_arcs_inl_inl {X Y : MixedGraphCat S} {v w : X.V} :
+@[simp] theorem concat_arcs_inl_inl {v w : X.V} :
     (concat t X Y).graph.arcs.Adj (.inl v) (.inl w) ↔ X.graph.arcs.Adj v w := Iff.rfl
 
-@[simp] theorem concat_arcs_inr_inr {X Y : MixedGraphCat S} {v w : Y.V} :
+@[simp] theorem concat_arcs_inr_inr {v w : Y.V} :
     (concat t X Y).graph.arcs.Adj (.inr v) (.inr w) ↔ Y.graph.arcs.Adj v w := Iff.rfl
 
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
@@ -326,7 +321,7 @@ def empty_concat_iso (X : MixedGraphCat S) : Iso (concat t (empty S) X) X where
 
 /-- Concatenation preserves Axioms 1–2; transitivity through the seam holds
     because arcs are tier-internal. -/
-theorem isTierOrdered_concat {X Y : MixedGraphCat S}
+theorem isTierOrdered_concat
     (h₁ : IsTierOrdered X.graph (X.tier t)) (h₂ : IsTierOrdered Y.graph (Y.tier t)) :
     IsTierOrdered (concat t X Y).graph ((concat t X Y).tier t) := by
   refine ⟨?_, ?_, ?_, ?_⟩
@@ -353,8 +348,7 @@ theorem isTierOrdered_concat {X Y : MixedGraphCat S}
 
 /-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross
     edges. -/
-theorem noInternalAssoc_concat {X Y : MixedGraphCat S}
-    (h₁ : NoInternalAssoc X.graph) (h₂ : NoInternalAssoc Y.graph) :
+theorem noInternalAssoc_concat (h₁ : NoInternalAssoc X.graph) (h₂ : NoInternalAssoc Y.graph) :
     NoInternalAssoc (concat t X Y).graph := by
   rintro (v | v) (w | w) hadj harc
   · exact h₁ hadj harc
@@ -367,8 +361,8 @@ theorem noInternalAssoc_concat {X Y : MixedGraphCat S}
     Association edges are blockwise, so a straddle needs both edges in one block —
     reducing to the factor's `IsPlanar` — or one per block, where the required
     return arc runs `inr → inl` and does not exist. -/
-theorem isPlanar_concat {X Y : MixedGraphCat S}
-    (h₁ : IsPlanar X.graph) (h₂ : IsPlanar Y.graph) : IsPlanar (concat t X Y).graph := by
+theorem isPlanar_concat (h₁ : IsPlanar X.graph) (h₂ : IsPlanar Y.graph) :
+    IsPlanar (concat t X Y).graph := by
   rintro (v | v) (v' | v') (w | w) (w' | w') hvv' hww' hvw hw'v'
   · exact h₁ hvv' hww' hvw hw'v'
   · exact absurd hww' (by simp)
@@ -443,11 +437,10 @@ def sum (X Y : MixedGraphCat S) : MixedGraphCat S where
           | _, _ => False⟩ }
   label := Sum.elim X.label Y.label
 
-@[simp] theorem sum_edges (X Y : MixedGraphCat S) :
-    (sum X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
+@[simp] theorem sum_edges : (sum X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
 
 /-- Copairing out of the bridge-free sum. -/
-def sumDesc {X Y T : MixedGraphCat S} (f : Hom X T) (g : Hom Y T) : Hom (sum X Y) T where
+def sumDesc (f : Hom X Z) (g : Hom Y Z) : Hom (sum X Y) Z where
   toFun := Sum.elim f.toFun g.toFun
   edge_map := by
     rintro (v | v) (w | w) h
@@ -463,8 +456,8 @@ def sumDesc {X Y T : MixedGraphCat S} (f : Hom X T) (g : Hom Y T) : Hom (sum X Y
 /-- **Axiom 2 forces the bridges**: the bridge-free sum of two graphs occupying a
     common tier is never tier-ordered — same-tier vertices from the two factors
     are precedence-unrelated across the seam. -/
-theorem not_isTierOrdered_sum (t : S → ι) {X Y : MixedGraphCat S}
-    (v : X.V) (w : Y.V) (htier : X.tier t v = Y.tier t w) :
+theorem not_isTierOrdered_sum (t : S → ι) (v : X.V) (w : Y.V)
+    (htier : X.tier t v = Y.tier t w) :
     ¬ IsTierOrdered (sum X Y).graph ((sum X Y).tier t) := fun h =>
   (h.total (v := .inl v) (w := .inr w) (by simp) htier).elim (fun hp => hp) fun hp => hp
 
@@ -497,7 +490,7 @@ def inr (X Y : MixedGraphCat S) : Y ⟶ sum X Y :=
   ⟨Sum.inr, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Copairing out of the bridge-free sum. -/
-def desc {X Y T : MixedGraphCat S} (f : X ⟶ T) (g : Y ⟶ T) : sum X Y ⟶ T :=
+def desc (f : X ⟶ Z) (g : Y ⟶ Z) : sum X Y ⟶ Z :=
   sumDesc f g
 
 /-- The bridge-free sum is the categorical coproduct of the broad category

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -15,13 +15,12 @@ import Linglib.Core.Combinatorics.MixedGraph
 /-!
 # Labeled mixed graphs
 
-A labeled mixed graph `⟨V, E, A, ℓ⟩` is the general autosegmental object
-([jardine-2019] §5; [jardine-heinz-2015] §2; [jardine-2016-diss] §4.1): a
-`MixedGraph` — association edges as a `SimpleGraph`, order arcs as a `Digraph` —
-with a vertex labeling, and no further structure. Tiers are not part of the
-object: a tier assignment `t : S → ι` induces the node partition, and the
-dissertation's §4.2 axioms carve the autosegmental representations out of the
-raw graphs relative to it.
+A labeled mixed graph `⟨V, E, A, ℓ⟩` has labeled vertices, undirected
+association edges, and directed order arcs — the autosegmental representation
+of [jardine-2019], with no further structure. Tiers are not part of the object:
+a tier assignment `t : S → ι` on the labels induces the tier partition, and
+well-formedness axioms carve the representations out of the raw graphs
+relative to it.
 
 ## Main definitions
 
@@ -55,8 +54,11 @@ raw graphs relative to it.
 
 ## Implementation notes
 
-The object stores no cross-tier order, and morphisms default to the broad
-precedence-forgetting class, where the coproduct and the OCP repair live.
+The graph components reuse `SimpleGraph` (edges are two-element sets, so
+association is symmetric and loopless) and `Digraph`, bundled in
+`Core/Combinatorics/MixedGraph.lean`; no cross-tier order is stored. Morphisms
+default to the broad precedence-forgetting class, where the coproduct and the
+OCP repair live.
 Subgraph-based notions (`ASL.lean`) are signature-sensitive and do not transfer
 to the order signature for free. Monoid laws hold up to `Iso`; strictness
 belongs to the tiered normal form (`MultiAR.lean`).
@@ -84,7 +86,9 @@ def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.arcs
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
 def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
 
-/-- Tier equality propagates along precedence paths once arcs are tier-internal. -/
+/-- Tier equality propagates along precedence paths once arcs are tier-internal;
+    stated as a lemma because use sites have destructured endpoints, on which
+    `induction` cannot fire. -/
 lemma precPath_tier {t : S → ι} {G : MixedGraph V S}
     (harc : ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) {v w : V}
     (h : G.PrecPath v w) : G.tier t v = G.tier t w := by

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -80,13 +80,8 @@ variable {V S ι : Type*}
 section Axioms
 variable (G : MixedGraph V)
 
-/-- Axioms 1–2 ([jardine-2016-diss] §4.2). Axiom 2's tier partition enters as
-    the coloring `c` — data, not a proposition — and what remains propositional
-    is Axiom 1 relative to it: the arcs are tier-internal and strictly totally
-    order each fiber. This is [jardine-2019]'s reading that `A` represents *the
-    order* on each string; the arcs coincide with their path closure
-    (`IsTierOrdered.precPath_eq`), so no closure operator appears in the
-    axioms. -/
+/-- Axioms 1–2 ([jardine-2016-diss] §4.2): the arcs are tier-internal and
+    strictly totally order each fiber of the coloring `c`. -/
 structure IsTierOrdered (c : V → ι) : Prop where
   /-- Arcs never leave a tier. -/
   tier_eq : ∀ ⦃v w⦄, G.arcs.Adj v w → c v = c w
@@ -252,14 +247,13 @@ variable (t : S → ι)
     each same-tier `Y`-vertex. -/
 def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
   V := X.V ⊕ Y.V
-  graph :=
-    { edges := X.graph.edges ⊕g Y.graph.edges
-      arcs :=
-        ⟨fun
-          | .inl v, .inl w => X.graph.arcs.Adj v w
-          | .inr v, .inr w => Y.graph.arcs.Adj v w
-          | .inl v, .inr w => X.tier t v = Y.tier t w
-          | .inr _, .inl _ => False⟩ }
+  graph.edges := X.graph.edges ⊕g Y.graph.edges
+  graph.arcs :=
+    ⟨fun
+      | .inl v, .inl w => X.graph.arcs.Adj v w
+      | .inr v, .inr w => Y.graph.arcs.Adj v w
+      | .inl v, .inr w => X.tier t v = Y.tier t w
+      | .inr _, .inl _ => False⟩
   label := Sum.elim X.label Y.label
 
 @[simp] theorem concat_label_inl (v : X.V) : (concat t X Y).label (.inl v) = X.label v := rfl
@@ -398,13 +392,12 @@ minimal repair that keeps concatenation inside `Representation`. -/
 /-- The bridge-free blockwise sum. -/
 def sum (X Y : MixedGraphCat S) : MixedGraphCat S where
   V := X.V ⊕ Y.V
-  graph :=
-    { edges := X.graph.edges ⊕g Y.graph.edges
-      arcs :=
-        ⟨fun
-          | .inl v, .inl w => X.graph.arcs.Adj v w
-          | .inr v, .inr w => Y.graph.arcs.Adj v w
-          | _, _ => False⟩ }
+  graph.edges := X.graph.edges ⊕g Y.graph.edges
+  graph.arcs :=
+    ⟨fun
+      | .inl v, .inl w => X.graph.arcs.Adj v w
+      | .inr v, .inr w => Y.graph.arcs.Adj v w
+      | _, _ => False⟩
   label := Sum.elim X.label Y.label
 
 @[simp] theorem sum_edges : (sum X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
@@ -547,6 +540,11 @@ def mkIso {X Y : Representation t} (e : MixedGraphCat.Iso X.obj Y.obj) : X ≅ Y
       MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v),
       MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)⟩
 
+/-- Componentwise extensionality for representation morphisms. -/
+theorem hom_ext {X Y : Representation t} {f g : X ⟶ Y}
+    (h : ∀ v, f.hom.toFun v = g.hom.toFun v) : f = g :=
+  InducedCategory.hom_ext (MixedGraphCat.Hom.ext (funext h))
+
 /-- The tensor on morphisms, as a representation morphism. -/
 def tensorHomAux {X₁ Y₁ X₂ Y₂ : Representation t} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
     tensor X₁ X₂ ⟶ tensor Y₁ Y₂ :=
@@ -580,41 +578,36 @@ def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Repr
     with every proof a componentwise `rfl` over the concrete sum maps. -/
 instance : MonoidalCategory (Representation t) :=
   MonoidalCategory.ofTensorHom
-    (id_tensorHom_id := fun _ _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
+    (id_tensorHom_id := fun _ _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v <;> rfl)
     (id_tensorHom := fun _ _ _ _ => rfl)
     (tensorHom_id := fun _ _ => rfl)
-    (tensorHom_comp_tensorHom := fun _ _ _ _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
-    (associator_naturality := fun _ _ _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by
-        rcases (v : _ ⊕ _) with v | v
+    (tensorHom_comp_tensorHom := fun _ _ _ _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v <;> rfl)
+    (associator_naturality := fun _ _ _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v
+      · rcases (v : _ ⊕ _) with v | v <;> rfl
+      · rfl)
+    (leftUnitor_naturality := fun _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v
+      · exact v.elim
+      · rfl)
+    (rightUnitor_naturality := fun _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v
+      · rfl
+      · exact v.elim)
+    (pentagon := fun _ _ _ _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v
+      · rcases (v : _ ⊕ _) with v | v
         · rcases (v : _ ⊕ _) with v | v <;> rfl
-        · rfl)))
-    (leftUnitor_naturality := fun _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by
-        rcases (v : _ ⊕ _) with v | v
-        · exact v.elim
-        · rfl)))
-    (rightUnitor_naturality := fun _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by
-        rcases (v : _ ⊕ _) with v | v
         · rfl
-        · exact v.elim)))
-    (pentagon := fun _ _ _ _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by
-        rcases (v : _ ⊕ _) with v | v
-        · rcases (v : _ ⊕ _) with v | v
-          · rcases (v : _ ⊕ _) with v | v <;> rfl
-          · rfl
-        · rfl)))
-    (triangle := fun _ _ => InducedCategory.hom_ext
-      (MixedGraphCat.Hom.ext (funext fun v => by
-        rcases (v : _ ⊕ _) with v | v
-        · rcases (v : _ ⊕ _) with v | v
-          · rfl
-          · exact v.elim
-        · rfl)))
+      · rfl)
+    (triangle := fun _ _ => hom_ext fun v => by
+      rcases (v : _ ⊕ _) with v | v
+      · rcases (v : _ ⊕ _) with v | v
+        · rfl
+        · exact v.elim
+      · rfl)
 
 end Representation
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -17,30 +17,30 @@ import Linglib.Core.Combinatorics.MixedGraph
 
 A labeled mixed graph `⟨V, E, A, ℓ⟩` has labeled vertices, undirected
 association edges, and directed order arcs — the autosegmental representation
-of [jardine-2019], with no further structure. Tiers are not part of the object:
-a tier assignment `t : S → ι` on the labels induces the tier partition, and
-well-formedness axioms carve the representations out of the raw graphs
-relative to it.
+of [jardine-2019], with no further structure. The graph is a `MixedGraph` (Core)
+and the labeling a map `ℓ : V → S`; `MixedGraphCat S` bundles the two. Tiers are
+not part of the object: a tier assignment `t : S → ι` on the labels induces a
+vertex coloring `X.tier t`, and well-formedness axioms carve the representations
+out of the raw graphs relative to it.
 
 ## Main definitions
 
-* `Autosegmental.MixedGraph V S`: the labeled mixed graph; `PrecPath` is the
-  transitive closure of its arcs.
 * `IsTierOrdered`, `NoInternalAssoc`, `IsSaturated`, `IsPlanar`, `IsOCPClean`:
   the §4.2 axioms (1–2, 3, 4, 5, 6; [jardine-heinz-2015] numbers the NCC and OCP
-  as 4 and 5 and has no saturation axiom). Saturation is stated but not imposed,
-  as in `AR.lean`; tier-orderedness includes path-closure, [jardine-2019]'s
-  reading that `A` represents the order.
-* `MixedGraph.Hom`: label- and association-preserving maps; `precPreserving`
-  marks the full-structure homomorphisms, `MixedGraph.Iso` the full-structure
+  as 4 and 5 and has no saturation axiom) as predicates on a `MixedGraph` and, for
+  tier-relative axioms, a vertex coloring `c : V → ι`. Saturation is stated but
+  not imposed, as in `AR.lean`; tier-orderedness includes path-closure
+  (`MixedGraph.PrecPath`), [jardine-2019]'s reading that `A` represents the order.
+* `MixedGraphCat S`: the labeled mixed graph ([jardine-2019]'s `GR(Γ)`) and the
+  category thereof, with `HasInitial` and `HasBinaryCoproducts`;
+  `MixedGraphCat.Hom` are label- and association-preserving maps, `precPreserving`
+  marks the full-structure homomorphisms, `MixedGraphCat.Iso` the full-structure
   equivalences.
-* `MixedGraph.concat t`: concatenation — the vertex sum with a same-tier bridge,
-  [jardine-heinz-2015] Definition 2 in the order signature, minus its `R_ID`
-  merge (`OCP.collapse`); `MixedGraph.sum` is the bridge-free coproduct.
-* `MixedGraphCat S`: the category of labeled mixed graphs ([jardine-2019]'s
-  `GR(Γ)`), with `HasInitial` and `HasBinaryCoproducts`; `Representation t` is
-  the category of autosegmental representations — the full subcategory on
-  Axioms 1–3, monoidal under `concat`.
+* `MixedGraphCat.concat t`: concatenation — the vertex sum with a same-tier
+  bridge, [jardine-heinz-2015] Definition 2 in the order signature, minus its
+  `R_ID` merge (`OCP.collapse`); `MixedGraphCat.sum` is the bridge-free coproduct.
+* `Representation t`: the category of autosegmental representations — the full
+  subcategory of labeled mixed graphs on Axioms 1–3, monoidal under `concat`.
 
 ## Main results
 
@@ -60,39 +60,29 @@ relative to it.
 
 namespace Autosegmental
 
-variable {V V₁ V₂ V₃ S ι : Type*}
+universe u v
 
-/-- A labeled mixed graph `⟨V, E, A, ℓ⟩` is a mixed graph with a vertex labeling. -/
-structure MixedGraph (V S : Type*) extends _root_.MixedGraph V where
-  /-- The labeling (`ℓ`). -/
-  label : V → S
-
-namespace MixedGraph
-
-/-- The precedence-path relation: the transitive closure of the arcs. -/
-def PrecPath (G : MixedGraph V S) : V → V → Prop := Relation.TransGen G.arcs.Adj
-
-/-- The tier of a vertex under a tier assignment on the alphabet. -/
-def tier (t : S → ι) (G : MixedGraph V S) (v : V) : ι := t (G.label v)
+variable {V S ι : Type*}
 
 /-! ### The §4.2 axioms -/
 
 section Axioms
-variable (t : S → ι) (G : MixedGraph V S)
+variable (G : _root_.MixedGraph V)
 
-/-- Axioms 1–2 ([jardine-2016-diss] §4.2): the arcs are tier-internal and a
-    fiberwise `IsStrictTotalOrder`, stated as flat conjuncts. This is
-    [jardine-2019]'s reading that `A` represents *the order* on each string; the
-    arcs coincide with their path closure (`IsTierOrdered.precPath_iff`), so no
-    closure operator appears in the axioms. -/
-def IsTierOrdered : Prop :=
-  (∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = G.tier t w) ∧
-    (∀ ⦃v w⦄, v ≠ w → G.tier t v = G.tier t w → G.arcs.Adj v w ∨ G.arcs.Adj w v) ∧
+/-- Axioms 1–2 ([jardine-2016-diss] §4.2), relative to a vertex coloring `c`
+    (the tier partition): the arcs are tier-internal and a fiberwise
+    `IsStrictTotalOrder`, stated as flat conjuncts. This is [jardine-2019]'s
+    reading that `A` represents *the order* on each string; the arcs coincide with
+    their path closure (`IsTierOrdered.precPath_iff`), so no closure operator
+    appears in the axioms. -/
+def IsTierOrdered (c : V → ι) : Prop :=
+  (∀ ⦃v w⦄, G.arcs.Adj v w → c v = c w) ∧
+    (∀ ⦃v w⦄, v ≠ w → c v = c w → G.arcs.Adj v w ∨ G.arcs.Adj w v) ∧
     (∀ v, ¬ G.arcs.Adj v v) ∧
     ∀ ⦃u v w⦄, G.arcs.Adj u v → G.arcs.Adj v w → G.arcs.Adj u w
 
 /-- Axiom 3: association never links precedence-path-related (tier-internal)
-    vertices. Tier-free — stated on paths alone, as in the dissertation. -/
+    vertices. Tier-free — stated on arcs alone, as in the dissertation. -/
 def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.edges.Adj v w → ¬ G.arcs.Adj v w
 
 /-- Axiom 4 (full specification): every vertex participates in an association.
@@ -108,16 +98,16 @@ def IsPlanar : Prop :=
     ¬ G.arcs.Adj w' v'
 
 /-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m` bear
-    distinct labels. -/
-def IsOCPClean (m : ι) : Prop :=
-  ∀ ⦃v w⦄, G.arcs.Adj v w → G.tier t v = m → G.label v ≠ G.label w
+    distinct labels. Needs the labeling `ℓ` and its tier assignment `t`. -/
+def IsOCPClean (ℓ : V → S) (t : S → ι) (m : ι) : Prop :=
+  ∀ ⦃v w⦄, G.arcs.Adj v w → t (ℓ v) = m → ℓ v ≠ ℓ w
 
 end Axioms
 
 /-- On the axiom class, precedence paths coincide with the arcs — the
     dissertation's `≺`. -/
-theorem IsTierOrdered.precPath_iff {t : S → ι} {G : MixedGraph V S}
-    (h : G.IsTierOrdered t) {v w : V} : G.PrecPath v w ↔ G.arcs.Adj v w := by
+theorem IsTierOrdered.precPath_iff {G : _root_.MixedGraph V} {c : V → ι}
+    (h : IsTierOrdered G c) {v w : V} : G.PrecPath v w ↔ G.arcs.Adj v w := by
   constructor
   · intro hp
     induction hp with
@@ -128,15 +118,33 @@ theorem IsTierOrdered.precPath_iff {t : S → ι} {G : MixedGraph V S}
 /-- The named form of the flat axioms: on each tier the arcs are a strict total
     order (`LinearOrder`'s own pattern — flat fields, derived class). Feeds
     `linearOrderOfSTO` for sorting the fibers. -/
-theorem IsTierOrdered.isStrictTotalOrder {t : S → ι} {G : MixedGraph V S}
-    (h : G.IsTierOrdered t) (i : ι) :
-    IsStrictTotalOrder {v // G.tier t v = i} (fun a b => G.arcs.Adj a b) where
+theorem IsTierOrdered.isStrictTotalOrder {G : _root_.MixedGraph V} {c : V → ι}
+    (h : IsTierOrdered G c) (i : ι) :
+    IsStrictTotalOrder {v // c v = i} (fun a b => G.arcs.Adj a b) where
   trichotomous a b hab hba := by
     by_contra hne
     rcases h.2.1 (fun hv => hne (Subtype.ext hv)) (a.2.trans b.2.symm) with hp | hp
     exacts [hab hp, hba hp]
   irrefl a := h.2.2.1 a
   trans _ _ _ hab hbc := h.2.2.2 hab hbc
+
+/-! ### The category of labeled mixed graphs -/
+
+/-- An object of the category of labeled mixed graphs over `S`: a vertex type
+    with a mixed graph `⟨V, E, A⟩` on it and a labeling `ℓ : V → S` — the
+    literature's labeled mixed graph `⟨V, E, A, ℓ⟩` / [jardine-2019]'s `GR(Γ)`. -/
+structure MixedGraphCat (S : Type v) : Type (max (u + 1) v) where
+  /-- The vertex type. -/
+  V : Type u
+  /-- The mixed graph: undirected association edges and directed order arcs. -/
+  graph : _root_.MixedGraph V
+  /-- The labeling (`ℓ`). -/
+  label : V → S
+
+namespace MixedGraphCat
+
+/-- The tier of a vertex under a tier assignment on the alphabet. -/
+def tier (t : S → ι) (X : MixedGraphCat S) : X.V → ι := t ∘ X.label
 
 /-! ### Morphisms -/
 
@@ -146,57 +154,53 @@ theorem IsTierOrdered.isStrictTotalOrder {t : S → ι} {G : MixedGraph V S}
     OCP repair live; the precedence-preserving maps form the wide morphism class
     `precPreserving` (the legacy `AR.Hom` vs `PrecAR` split, at the foundation). -/
 @[ext]
-structure Hom (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) where
+structure Hom (X Y : MixedGraphCat S) where
   /-- The vertex map. -/
-  toFun : V₁ → V₂
+  toFun : X.V → Y.V
   /-- Association edges are preserved. -/
-  edge_map : ∀ ⦃v w⦄, G₁.edges.Adj v w → G₂.edges.Adj (toFun v) (toFun w)
+  edge_map : ∀ ⦃v w⦄, X.graph.edges.Adj v w → Y.graph.edges.Adj (toFun v) (toFun w)
   /-- Labels are preserved. -/
-  label_comp : ∀ v, G₂.label (toFun v) = G₁.label v
+  label_comp : ∀ v, Y.label (toFun v) = X.label v
 
 /-- The edge face of a morphism, a stock graph homomorphism. -/
-def Hom.edgesHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (f : Hom G₁ G₂) :
-    G₁.edges →g G₂.edges :=
+def Hom.edgesHom {X Y : MixedGraphCat S} (f : Hom X Y) : X.graph.edges →g Y.graph.edges :=
   ⟨f.toFun, fun h => f.edge_map h⟩
 
 /-- The identity morphism. -/
-def Hom.id (G : MixedGraph V S) : Hom G G :=
+def Hom.id (X : MixedGraphCat S) : Hom X X :=
   ⟨_root_.id, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Composition of morphisms. -/
-def Hom.comp {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : MixedGraph V₃ S}
-    (f : Hom G₁ G₂) (g : Hom G₂ G₃) : Hom G₁ G₃ :=
+def Hom.comp {X Y Z : MixedGraphCat S} (f : Hom X Y) (g : Hom Y Z) : Hom X Z :=
   ⟨g.toFun ∘ f.toFun, fun _ _ h => g.edge_map (f.edge_map h),
     fun v => (g.label_comp _).trans (f.label_comp v)⟩
 
 /-! ### Isomorphism -/
 
 /-- A label- and relation-preserving equivalence of labeled mixed graphs. -/
-structure Iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) extends V₁ ≃ V₂ where
-  edges_iff : ∀ v w, G₂.edges.Adj (toEquiv v) (toEquiv w) ↔ G₁.edges.Adj v w
-  arcs_iff : ∀ v w, G₂.arcs.Adj (toEquiv v) (toEquiv w) ↔ G₁.arcs.Adj v w
-  label_comp : ∀ v, G₂.label (toEquiv v) = G₁.label v
+structure Iso (X Y : MixedGraphCat S) extends X.V ≃ Y.V where
+  edges_iff : ∀ v w, Y.graph.edges.Adj (toEquiv v) (toEquiv w) ↔ X.graph.edges.Adj v w
+  arcs_iff : ∀ v w, Y.graph.arcs.Adj (toEquiv v) (toEquiv w) ↔ X.graph.arcs.Adj v w
+  label_comp : ∀ v, Y.label (toEquiv v) = X.label v
 
 /-- The edge face of an isomorphism, as a stock `SimpleGraph.Iso`. -/
-def Iso.edgesIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
-    G₁.edges ≃g G₂.edges :=
+def Iso.edgesIso {X Y : MixedGraphCat S} (e : Iso X Y) : X.graph.edges ≃g Y.graph.edges :=
   ⟨e.toEquiv, fun {v w} => e.edges_iff v w⟩
 
 /-- The arc face of an isomorphism, as a stock `RelIso`. -/
-def Iso.arcsIso {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) :
-    G₁.arcs.Adj ≃r G₂.arcs.Adj :=
+def Iso.arcsIso {X Y : MixedGraphCat S} (e : Iso X Y) : X.graph.arcs.Adj ≃r Y.graph.arcs.Adj :=
   ⟨e.toEquiv, fun {v w} => e.arcs_iff v w⟩
 
 /-- An isomorphism as a morphism. -/
-def Iso.toHom {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) : Hom G₁ G₂ :=
+def Iso.toHom {X Y : MixedGraphCat S} (e : Iso X Y) : Hom X Y :=
   ⟨e.toEquiv, fun _ _ h => (e.edges_iff _ _).mpr h, e.label_comp⟩
 
 /-- The identity isomorphism. -/
-def Iso.refl (G : MixedGraph V S) : Iso G G :=
-  ⟨Equiv.refl V, fun _ _ => Iff.rfl, fun _ _ => Iff.rfl, fun _ => rfl⟩
+def Iso.refl (X : MixedGraphCat S) : Iso X X :=
+  ⟨Equiv.refl X.V, fun _ _ => Iff.rfl, fun _ _ => Iff.rfl, fun _ => rfl⟩
 
 /-- Inverse isomorphism. -/
-def Iso.symm {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁ G₂) : Iso G₂ G₁ where
+def Iso.symm {X Y : MixedGraphCat S} (e : Iso X Y) : Iso Y X where
   toEquiv := e.toEquiv.symm
   edges_iff v w := by
     conv_rhs => rw [show v = e.toEquiv (e.toEquiv.symm v) from (e.toEquiv.apply_symm_apply v).symm,
@@ -211,8 +215,7 @@ def Iso.symm {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} (e : Iso G₁
     exact (e.label_comp _).symm
 
 /-- Composition of isomorphisms. -/
-def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : MixedGraph V₃ S}
-    (e : Iso G₁ G₂) (f : Iso G₂ G₃) : Iso G₁ G₃ where
+def Iso.trans {X Y Z : MixedGraphCat S} (e : Iso X Y) (f : Iso Y Z) : Iso X Z where
   toEquiv := e.toEquiv.trans f.toEquiv
   edges_iff v w := (f.edges_iff _ _).trans (e.edges_iff v w)
   arcs_iff v w := (f.arcs_iff _ _).trans (e.arcs_iff v w)
@@ -221,17 +224,17 @@ def Iso.trans {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {G₃ : Mixe
 /-! ### The empty graph -/
 
 /-- The empty labeled mixed graph, on the empty vertex type. -/
-def empty (S : Type*) : MixedGraph PEmpty S := ⟨⟨⊥, ⊥⟩, PEmpty.elim⟩
+def empty (S : Type v) : MixedGraphCat S := ⟨PEmpty, ⟨⊥, ⊥⟩, PEmpty.elim⟩
 
-theorem empty_isTierOrdered (t : S → ι) : (empty S).IsTierOrdered t :=
+theorem empty_isTierOrdered (t : S → ι) : IsTierOrdered (empty S).graph ((empty S).tier t) :=
   ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
 
-theorem empty_noInternalAssoc : (empty S).NoInternalAssoc := fun v => v.elim
+theorem empty_noInternalAssoc : NoInternalAssoc (empty S).graph := fun v => v.elim
 
 /-! ### Tier-bridging concatenation
 
 Per tier class, concatenation is the ordinal sum: blockwise arcs plus a bridging
-arc from every `G₁`-vertex of a class to every same-class `G₂`-vertex. This is
+arc from every `X`-vertex of a class to every same-class `Y`-vertex. This is
 the signature of [jardine-2019]'s own formulation — arcs represent *the order* on
 each string, not its successor steps — under which [jardine-heinz-2015]
 Definition 2's last-to-first successor bridge becomes the complete same-class
@@ -249,43 +252,45 @@ variable (t : S → ι)
 
 /-- Concatenation ([jardine-heinz-2015] Definition 2, minus the `R_ID` melody
     merge, in the precedence signature): stock disjoint sum on edges; on arcs the
-    per-tier ordinal sum — blockwise arcs plus a bridge from each `G₁`-vertex to
-    each same-tier `G₂`-vertex. -/
-def concat (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
-  edges := G₁.edges ⊕g G₂.edges
-  arcs :=
-    ⟨fun v w =>
-      match v, w with
-      | .inl v, .inl w => G₁.arcs.Adj v w
-      | .inr v, .inr w => G₂.arcs.Adj v w
-      | .inl v, .inr w => G₁.tier t v = G₂.tier t w
-      | .inr _, .inl _ => False⟩
-  label := Sum.elim G₁.label G₂.label
+    per-tier ordinal sum — blockwise arcs plus a bridge from each `X`-vertex to
+    each same-tier `Y`-vertex. -/
+def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
+  V := X.V ⊕ Y.V
+  graph :=
+    { edges := X.graph.edges ⊕g Y.graph.edges
+      arcs :=
+        ⟨fun v w =>
+          match v, w with
+          | .inl v, .inl w => X.graph.arcs.Adj v w
+          | .inr v, .inr w => Y.graph.arcs.Adj v w
+          | .inl v, .inr w => X.tier t v = Y.tier t w
+          | .inr _, .inl _ => False⟩ }
+  label := Sum.elim X.label Y.label
 
-@[simp] theorem concat_label_inl (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₁) :
-    (concat t G₁ G₂).label (.inl v) = G₁.label v := rfl
+@[simp] theorem concat_label_inl (X Y : MixedGraphCat S) (v : X.V) :
+    (concat t X Y).label (.inl v) = X.label v := rfl
 
-@[simp] theorem concat_label_inr (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (v : V₂) :
-    (concat t G₁ G₂).label (.inr v) = G₂.label v := rfl
+@[simp] theorem concat_label_inr (X Y : MixedGraphCat S) (v : Y.V) :
+    (concat t X Y).label (.inr v) = Y.label v := rfl
 
-@[simp] theorem concat_edges (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
-    (concat t G₁ G₂).edges = G₁.edges ⊕g G₂.edges := rfl
+@[simp] theorem concat_edges (X Y : MixedGraphCat S) :
+    (concat t X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
 
-@[simp] theorem concat_arcs_inl_inl {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₁} :
-    (concat t G₁ G₂).arcs.Adj (.inl v) (.inl w) ↔ G₁.arcs.Adj v w := Iff.rfl
+@[simp] theorem concat_arcs_inl_inl {X Y : MixedGraphCat S} {v w : X.V} :
+    (concat t X Y).graph.arcs.Adj (.inl v) (.inl w) ↔ X.graph.arcs.Adj v w := Iff.rfl
 
-@[simp] theorem concat_arcs_inr_inr {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {v w : V₂} :
-    (concat t G₁ G₂).arcs.Adj (.inr v) (.inr w) ↔ G₂.arcs.Adj v w := Iff.rfl
+@[simp] theorem concat_arcs_inr_inr {X Y : MixedGraphCat S} {v w : Y.V} :
+    (concat t X Y).graph.arcs.Adj (.inr v) (.inr w) ↔ Y.graph.arcs.Adj v w := Iff.rfl
 
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
 
 /-- Concatenation with the empty graph on the right, up to isomorphism. -/
-def concat_empty_iso (G : MixedGraph V S) : Iso (concat t G (empty S)) G where
-  toEquiv := Equiv.sumEmpty V PEmpty
+def concat_empty_iso (X : MixedGraphCat S) : Iso (concat t X (empty S)) X where
+  toEquiv := Equiv.sumEmpty X.V PEmpty
   edges_iff v w := by
     rcases v with v | v
     · rcases w with w | w
-      · simp [Equiv.sumEmpty]
+      · exact Iff.rfl
       · exact w.elim
     · exact v.elim
   arcs_iff v w := by
@@ -300,14 +305,14 @@ def concat_empty_iso (G : MixedGraph V S) : Iso (concat t G (empty S)) G where
     · exact v.elim
 
 /-- Concatenation with the empty graph on the left, up to isomorphism. -/
-def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
-  toEquiv := Equiv.emptySum PEmpty V
+def empty_concat_iso (X : MixedGraphCat S) : Iso (concat t (empty S) X) X where
+  toEquiv := Equiv.emptySum PEmpty X.V
   edges_iff v w := by
     rcases v with v | v
     · exact v.elim
     · rcases w with w | w
       · exact w.elim
-      · simp [Equiv.emptySum]
+      · exact Iff.rfl
   arcs_iff v w := by
     rcases v with v | v
     · exact v.elim
@@ -323,18 +328,18 @@ def empty_concat_iso (G : MixedGraph V S) : Iso (concat t (empty S) G) G where
 
 /-- Concatenation preserves Axioms 1–2; transitivity through the seam holds
     because arcs are tier-internal. -/
-theorem isTierOrdered_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
-    (h₁ : G₁.IsTierOrdered t) (h₂ : G₂.IsTierOrdered t) :
-    (concat t G₁ G₂).IsTierOrdered t := by
+theorem isTierOrdered_concat {X Y : MixedGraphCat S}
+    (h₁ : IsTierOrdered X.graph (X.tier t)) (h₂ : IsTierOrdered Y.graph (Y.tier t)) :
+    IsTierOrdered (concat t X Y).graph ((concat t X Y).tier t) := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · rintro (v | v) (w | w) h
     exacts [h₁.1 h, h, h.elim, h₂.1 h]
   · rintro (v | v) (w | w) hne htier
-    · rcases h₁.2.1 (by simpa using hne) htier with hp | hp
+    · rcases h₁.2.1 (by rintro rfl; exact hne rfl) htier with hp | hp
       exacts [Or.inl hp, Or.inr hp]
     · exact Or.inl htier
     · exact Or.inr htier.symm
-    · rcases h₂.2.1 (by simpa using hne) htier with hp | hp
+    · rcases h₂.2.1 (by rintro rfl; exact hne rfl) htier with hp | hp
       exacts [Or.inl hp, Or.inr hp]
   · rintro (v | v) h
     exacts [h₁.2.2.1 v h, h₂.2.2.1 v h]
@@ -350,9 +355,9 @@ theorem isTierOrdered_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ 
 
 /-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross
     edges. -/
-theorem noInternalAssoc_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
-    (h₁ : G₁.NoInternalAssoc) (h₂ : G₂.NoInternalAssoc) :
-    (concat t G₁ G₂).NoInternalAssoc := by
+theorem noInternalAssoc_concat {X Y : MixedGraphCat S}
+    (h₁ : NoInternalAssoc X.graph) (h₂ : NoInternalAssoc Y.graph) :
+    NoInternalAssoc (concat t X Y).graph := by
   rintro (v | v) (w | w) hadj harc
   · exact h₁ hadj harc
   · exact absurd hadj (by simp)
@@ -364,9 +369,8 @@ theorem noInternalAssoc_concat {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V�
 /-- Concatenation of morphisms is `Sum.map`: blockwise preservation from the
     factors, and label preservation transports the bridge's tier equality. Domain and codomain
     of each factor may have independent vertex types, as morphisms in `MixedGraphCat S` do. -/
-def Hom.sumMap {V₁' V₂' : Type*} {G₁ : MixedGraph V₁ S} {G₁' : MixedGraph V₁' S}
-    {G₂ : MixedGraph V₂ S} {G₂' : MixedGraph V₂' S}
-    (f : Hom G₁ G₁') (g : Hom G₂ G₂') : Hom (concat t G₁ G₂) (concat t G₁' G₂') where
+def Hom.sumMap {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
+    (f : Hom X₁ Y₁) (g : Hom X₂ Y₂) : Hom (concat t X₁ X₂) (concat t Y₁ Y₂) where
   toFun := Sum.map f.toFun g.toFun
   edge_map := by
     rintro (v | v) (w | w) h
@@ -384,9 +388,9 @@ def Hom.sumMap {V₁' V₂' : Type*} {G₁ : MixedGraph V₁ S} {G₁' : MixedGr
 /-- Concatenation is associative up to isomorphism, over `Equiv.sumAssoc`; the
     edge face is the stock `SimpleGraph.Iso.sumAssoc`, and every arc case holds
     definitionally in the order signature. -/
-def concat_assoc_iso (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) (G₃ : MixedGraph V₃ S) :
-    Iso (concat t (concat t G₁ G₂) G₃) (concat t G₁ (concat t G₂ G₃)) where
-  toEquiv := Equiv.sumAssoc V₁ V₂ V₃
+def concat_assoc_iso (X Y Z : MixedGraphCat S) :
+    Iso (concat t (concat t X Y) Z) (concat t X (concat t Y Z)) where
+  toEquiv := Equiv.sumAssoc X.V Y.V Z.V
   edges_iff v w := SimpleGraph.Iso.sumAssoc.map_rel_iff
   arcs_iff v w := by
     rcases v with (a | b) | c <;> rcases w with (a' | b') | c' <;> exact Iff.rfl
@@ -404,22 +408,23 @@ fails across the seam (`not_isTierOrdered_sum`) — `concat`'s bridges are the
 minimal repair that keeps concatenation inside `Representation`. -/
 
 /-- The bridge-free blockwise sum. -/
-def sum (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) : MixedGraph (V₁ ⊕ V₂) S where
-  edges := G₁.edges ⊕g G₂.edges
-  arcs :=
-    ⟨fun v w =>
-      match v, w with
-      | .inl v, .inl w => G₁.arcs.Adj v w
-      | .inr v, .inr w => G₂.arcs.Adj v w
-      | _, _ => False⟩
-  label := Sum.elim G₁.label G₂.label
+def sum (X Y : MixedGraphCat S) : MixedGraphCat S where
+  V := X.V ⊕ Y.V
+  graph :=
+    { edges := X.graph.edges ⊕g Y.graph.edges
+      arcs :=
+        ⟨fun v w =>
+          match v, w with
+          | .inl v, .inl w => X.graph.arcs.Adj v w
+          | .inr v, .inr w => Y.graph.arcs.Adj v w
+          | _, _ => False⟩ }
+  label := Sum.elim X.label Y.label
 
-@[simp] theorem sum_edges (G₁ : MixedGraph V₁ S) (G₂ : MixedGraph V₂ S) :
-    (G₁.sum G₂).edges = G₁.edges ⊕g G₂.edges := rfl
+@[simp] theorem sum_edges (X Y : MixedGraphCat S) :
+    (sum X Y).graph.edges = X.graph.edges ⊕g Y.graph.edges := rfl
 
 /-- Copairing out of the bridge-free sum. -/
-def sumDesc {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {H : MixedGraph V₃ S}
-    (f : Hom G₁ H) (g : Hom G₂ H) : Hom (G₁.sum G₂) H where
+def sumDesc {X Y T : MixedGraphCat S} (f : Hom X T) (g : Hom Y T) : Hom (sum X Y) T where
   toFun := Sum.elim f.toFun g.toFun
   edge_map := by
     rintro (v | v) (w | w) h
@@ -435,82 +440,62 @@ def sumDesc {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S} {H : MixedGrap
 /-- **Axiom 2 forces the bridges**: the bridge-free sum of two graphs occupying a
     common tier is never tier-ordered — same-tier vertices from the two factors
     are precedence-unrelated across the seam. -/
-theorem not_isTierOrdered_sum (t : S → ι) {G₁ : MixedGraph V₁ S} {G₂ : MixedGraph V₂ S}
-    (v : V₁) (w : V₂) (htier : G₁.tier t v = G₂.tier t w) :
-    ¬ (G₁.sum G₂).IsTierOrdered t := fun h =>
+theorem not_isTierOrdered_sum (t : S → ι) {X Y : MixedGraphCat S}
+    (v : X.V) (w : Y.V) (htier : X.tier t v = Y.tier t w) :
+    ¬ IsTierOrdered (sum X Y).graph ((sum X Y).tier t) := fun h =>
   (h.2.1 (v := .inl v) (w := .inr w) (by simp) htier).elim (fun hp => hp) fun hp => hp
-
-end MixedGraph
 
 /-! ### The category of labeled mixed graphs -/
 
-open CategoryTheory
-
-universe u v
-
-/-- An object of the category of labeled mixed graphs over `S`: a vertex type
-    bundled with a labeled mixed graph on it. -/
-structure MixedGraphCat (S : Type v) : Type (max (u + 1) v) where
-  /-- The vertex type. -/
-  V : Type u
-  /-- The labeled mixed graph. -/
-  graph : MixedGraph V S
-
-namespace MixedGraphCat
+open CategoryTheory Limits
 
 instance : Category (MixedGraphCat S) where
-  Hom X Y := MixedGraph.Hom X.graph Y.graph
-  id X := MixedGraph.Hom.id X.graph
+  Hom X Y := Hom X Y
+  id X := Hom.id X
   comp f g := f.comp g
-  id_comp _ := MixedGraph.Hom.ext rfl
-  comp_id _ := MixedGraph.Hom.ext rfl
-  assoc _ _ _ := MixedGraph.Hom.ext rfl
-
-open Limits
-
-/-- The empty graph object. -/
-def empty (S : Type v) : MixedGraphCat S := ⟨PEmpty, MixedGraph.empty S⟩
+  id_comp _ := Hom.ext rfl
+  comp_id _ := Hom.ext rfl
+  assoc _ _ _ := Hom.ext rfl
 
 instance (Y : MixedGraphCat S) : Subsingleton (empty S ⟶ Y) :=
-  ⟨fun _ _ => MixedGraph.Hom.ext (funext fun v => v.elim)⟩
+  ⟨fun _ _ => Hom.ext (funext fun v => v.elim)⟩
 
 instance (Y : MixedGraphCat S) : Nonempty (empty S ⟶ Y) :=
   ⟨⟨PEmpty.elim, fun v => v.elim, fun v => v.elim⟩⟩
 
 instance : HasInitial (MixedGraphCat S) := hasInitial_of_unique (empty S)
 
-/-- The bridge-free sum object. -/
-def sumObj (X Y : MixedGraphCat S) : MixedGraphCat S := ⟨X.V ⊕ Y.V, X.graph.sum Y.graph⟩
-
 /-- Left coprojection. -/
-def inl (X Y : MixedGraphCat S) : X ⟶ sumObj X Y :=
+def inl (X Y : MixedGraphCat S) : X ⟶ sum X Y :=
   ⟨Sum.inl, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Right coprojection. -/
-def inr (X Y : MixedGraphCat S) : Y ⟶ sumObj X Y :=
+def inr (X Y : MixedGraphCat S) : Y ⟶ sum X Y :=
   ⟨Sum.inr, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Copairing out of the bridge-free sum. -/
-def desc {X Y T : MixedGraphCat S} (f : X ⟶ T) (g : Y ⟶ T) : sumObj X Y ⟶ T :=
-  MixedGraph.sumDesc (f : MixedGraph.Hom _ _) (g : MixedGraph.Hom _ _)
+def desc {X Y T : MixedGraphCat S} (f : X ⟶ T) (g : Y ⟶ T) : sum X Y ⟶ T :=
+  sumDesc f g
 
 /-- The bridge-free sum is the categorical coproduct of the broad category
-    (contrast `MixedGraph.not_isTierOrdered_sum`: it leaves the axiom class,
-    which is why `Representation`'s tensor is the bridged `concat` instead). -/
+    (contrast `not_isTierOrdered_sum`: it leaves the axiom class, which is why
+    `Representation`'s tensor is the bridged `concat` instead). -/
 instance (X Y : MixedGraphCat S) : HasBinaryCoproduct X Y :=
   HasColimit.mk
     { cocone := BinaryCofan.mk (inl X Y) (inr X Y)
       isColimit := BinaryCofan.IsColimit.mk _ (fun f g => desc f g)
-        (fun f g => MixedGraph.Hom.ext rfl)
-        (fun f g => MixedGraph.Hom.ext rfl)
-        (fun f g m h₁ h₂ => MixedGraph.Hom.ext (funext fun v => by
+        (fun f g => Hom.ext rfl)
+        (fun f g => Hom.ext rfl)
+        (fun f g m h₁ h₂ => Hom.ext (funext fun v => by
           rcases v with v | v
-          · exact congrArg (fun φ => MixedGraph.Hom.toFun φ v) h₁
-          · exact congrArg (fun φ => MixedGraph.Hom.toFun φ v) h₂)) }
+          · exact congrArg (fun φ => Hom.toFun φ v) h₁
+          · exact congrArg (fun φ => Hom.toFun φ v) h₂)) }
 
 instance : HasBinaryCoproducts (MixedGraphCat S) := hasBinaryCoproducts_of_hasColimit_pair _
 
 end MixedGraphCat
+
+open CategoryTheory
 
 /-- Precedence preservation as a morphism property: the maps that also preserve
     arcs — the model-theoretic full-structure homomorphisms, the foundation
@@ -529,7 +514,7 @@ variable (t : S → ι)
 /-- The structural axiom class ([jardine-2016-diss] §4.2, Axioms 1–3) as an
     object property of the graph category. -/
 def isRepresentation : ObjectProperty (MixedGraphCat S) := fun X =>
-  X.graph.IsTierOrdered t ∧ X.graph.NoInternalAssoc
+  IsTierOrdered X.graph (X.tier t) ∧ NoInternalAssoc X.graph
 
 /-- The category of autosegmental representations over a tier assignment: the
     full subcategory of labeled mixed graphs satisfying the structural axioms.
@@ -549,22 +534,22 @@ variable {t}
 
 /-- The tensor unit: the empty representation. -/
 def unit : Representation t :=
-  ⟨⟨PEmpty, MixedGraph.empty S⟩, MixedGraph.empty_isTierOrdered t,
-    MixedGraph.empty_noInternalAssoc⟩
+  ⟨MixedGraphCat.empty S, MixedGraphCat.empty_isTierOrdered t,
+    MixedGraphCat.empty_noInternalAssoc⟩
 
 /-- The tensor: morpheme concatenation, staying in the axiom class by
     `isTierOrdered_concat`/`noInternalAssoc_concat`. -/
 def tensor (X Y : Representation t) : Representation t :=
-  ⟨⟨X.obj.V ⊕ Y.obj.V, MixedGraph.concat t X.obj.graph Y.obj.graph⟩,
-    MixedGraph.isTierOrdered_concat t X.property.1 Y.property.1,
-    MixedGraph.noInternalAssoc_concat t X.property.2 Y.property.2⟩
+  ⟨MixedGraphCat.concat t X.obj Y.obj,
+    MixedGraphCat.isTierOrdered_concat t X.property.1 Y.property.1,
+    MixedGraphCat.noInternalAssoc_concat t X.property.2 Y.property.2⟩
 
 /-- Under the structural axioms the tier map properly colors the association
     graph: same-tier vertices are precedence-related (Axioms 1–2) and associated
     vertices never are (Axiom 3), so associated vertices lie on distinct tiers.
     Goldsmith's bipartite two-tier geometry is the two-colorable case. -/
 def tierColoring (X : Representation t) : X.obj.graph.edges.Coloring ι :=
-  SimpleGraph.Coloring.mk (X.obj.graph.tier t) fun {_ _} hadj htier =>
+  SimpleGraph.Coloring.mk (X.obj.tier t) fun {_ _} hadj htier =>
     (X.property.1.2.1 hadj.ne htier).elim (X.property.2 hadj) (X.property.2 hadj.symm)
 
 /-- A representation's association graph is colorable by its tiers: tier arity
@@ -574,29 +559,29 @@ theorem edges_colorable [Fintype ι] (X : Representation t) :
   (tierColoring X).colorable
 
 /-- A graph isomorphism as an isomorphism of representations. -/
-def mkIso {X Y : Representation t} (e : MixedGraph.Iso X.obj.graph Y.obj.graph) : X ≅ Y :=
+def mkIso {X Y : Representation t} (e : MixedGraphCat.Iso X.obj Y.obj) : X ≅ Y :=
   InducedCategory.isoMk
     ⟨e.toHom, e.symm.toHom,
-      MixedGraph.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v),
-      MixedGraph.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)⟩
+      MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v),
+      MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)⟩
 
 /-- The tensor on morphisms, as a representation morphism. -/
 def tensorHomAux {X₁ Y₁ X₂ Y₂ : Representation t} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
     tensor X₁ X₂ ⟶ tensor Y₁ Y₂ :=
-  InducedCategory.homMk (MixedGraph.Hom.sumMap (G₁ := X₁.obj.graph) (G₁' := Y₁.obj.graph)
-    (G₂ := X₂.obj.graph) (G₂' := Y₂.obj.graph) t f.hom g.hom)
+  InducedCategory.homMk (MixedGraphCat.Hom.sumMap (X₁ := X₁.obj) (Y₁ := Y₁.obj)
+    (X₂ := X₂.obj) (Y₂ := Y₂.obj) t f.hom g.hom)
 
 /-- Left whiskering, as a representation morphism. -/
 def whiskerLeftAux (X : Representation t) {Y₁ Y₂ : Representation t} (f : Y₁ ⟶ Y₂) :
     tensor X Y₁ ⟶ tensor X Y₂ :=
-  InducedCategory.homMk (MixedGraph.Hom.sumMap (G₁ := X.obj.graph) (G₁' := X.obj.graph)
-    (G₂ := Y₁.obj.graph) (G₂' := Y₂.obj.graph) t (MixedGraph.Hom.id X.obj.graph) f.hom)
+  InducedCategory.homMk (MixedGraphCat.Hom.sumMap (X₁ := X.obj) (Y₁ := X.obj)
+    (X₂ := Y₁.obj) (Y₂ := Y₂.obj) t (MixedGraphCat.Hom.id X.obj) f.hom)
 
 /-- Right whiskering, as a representation morphism. -/
 def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Representation t) :
     tensor X₁ Y ⟶ tensor X₂ Y :=
-  InducedCategory.homMk (MixedGraph.Hom.sumMap (G₁ := X₁.obj.graph) (G₁' := X₂.obj.graph)
-    (G₂ := Y.obj.graph) (G₂' := Y.obj.graph) t f.hom (MixedGraph.Hom.id Y.obj.graph))
+  InducedCategory.homMk (MixedGraphCat.Hom.sumMap (X₁ := X₁.obj) (Y₁ := X₂.obj)
+    (X₂ := Y.obj) (Y₂ := Y.obj) t f.hom (MixedGraphCat.Hom.id Y.obj))
 
 @[simps] instance instMonoidalStruct : MonoidalCategoryStruct (Representation t) where
   tensorObj := tensor
@@ -604,9 +589,9 @@ def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Repr
   tensorHom := tensorHomAux
   whiskerLeft := whiskerLeftAux
   whiskerRight := whiskerRightAux
-  associator X Y Z := mkIso (MixedGraph.concat_assoc_iso t X.obj.graph Y.obj.graph Z.obj.graph)
-  leftUnitor X := mkIso (MixedGraph.empty_concat_iso t X.obj.graph)
-  rightUnitor X := mkIso (MixedGraph.concat_empty_iso t X.obj.graph)
+  associator X Y Z := mkIso (MixedGraphCat.concat_assoc_iso t X.obj Y.obj Z.obj)
+  leftUnitor X := mkIso (MixedGraphCat.empty_concat_iso t X.obj)
+  rightUnitor X := mkIso (MixedGraphCat.concat_empty_iso t X.obj)
 
 /-- The category of autosegmental representations is monoidal under morpheme
     concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as coherence,
@@ -614,35 +599,35 @@ def whiskerRightAux {X₁ X₂ : Representation t} (f : X₁ ⟶ X₂) (Y : Repr
 instance : MonoidalCategory (Representation t) :=
   MonoidalCategory.ofTensorHom
     (id_tensorHom_id := fun _ _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
+      (MixedGraphCat.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
     (id_tensorHom := fun _ _ _ _ => rfl)
     (tensorHom_id := fun _ _ => rfl)
     (tensorHom_comp_tensorHom := fun _ _ _ _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
+      (MixedGraphCat.Hom.ext (funext fun v => by rcases (v : _ ⊕ _) with v | v <;> rfl)))
     (associator_naturality := fun _ _ _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by
+      (MixedGraphCat.Hom.ext (funext fun v => by
         rcases (v : _ ⊕ _) with v | v
         · rcases (v : _ ⊕ _) with v | v <;> rfl
         · rfl)))
     (leftUnitor_naturality := fun _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by
+      (MixedGraphCat.Hom.ext (funext fun v => by
         rcases (v : _ ⊕ _) with v | v
         · exact v.elim
         · rfl)))
     (rightUnitor_naturality := fun _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by
+      (MixedGraphCat.Hom.ext (funext fun v => by
         rcases (v : _ ⊕ _) with v | v
         · rfl
         · exact v.elim)))
     (pentagon := fun _ _ _ _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by
+      (MixedGraphCat.Hom.ext (funext fun v => by
         rcases (v : _ ⊕ _) with v | v
         · rcases (v : _ ⊕ _) with v | v
           · rcases (v : _ ⊕ _) with v | v <;> rfl
           · rfl
         · rfl)))
     (triangle := fun _ _ => InducedCategory.hom_ext
-      (MixedGraph.Hom.ext (funext fun v => by
+      (MixedGraphCat.Hom.ext (funext fun v => by
         rcases (v : _ ⊕ _) with v | v
         · rcases (v : _ ⊕ _) with v | v
           · rfl

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -125,6 +125,19 @@ theorem IsTierOrdered.precPath_iff {t : S → ι} {G : MixedGraph V S}
     | tail _ hb ih => exact h.2.2.2 ih hb
   · exact .single
 
+/-- The named form of the flat axioms: on each tier the arcs are a strict total
+    order (`LinearOrder`'s own pattern — flat fields, derived class). Feeds
+    `linearOrderOfSTO` for sorting the fibers. -/
+theorem IsTierOrdered.isStrictTotalOrder {t : S → ι} {G : MixedGraph V S}
+    (h : G.IsTierOrdered t) (i : ι) :
+    IsStrictTotalOrder {v // G.tier t v = i} (fun a b => G.arcs.Adj a b) where
+  trichotomous a b hab hba := by
+    by_contra hne
+    rcases h.2.1 (fun hv => hne (Subtype.ext hv)) (a.2.trans b.2.symm) with hp | hp
+    exacts [hab hp, hba hp]
+  irrefl a := h.2.2.1 a
+  trans _ _ _ hab hbc := h.2.2.2 hab hbc
+
 /-! ### Morphisms -/
 
 /-- A label- and association-preserving map of labeled mixed graphs. Precedence

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -62,8 +62,7 @@ namespace Autosegmental
 
 variable {V V₁ V₂ V₃ S ι : Type*}
 
-/-- A labeled mixed graph `⟨V, E, A, ℓ⟩` is a mixed graph with a vertex labeling;
-    the literature's edges are two-element sets, so `SimpleGraph` is exact. -/
+/-- A labeled mixed graph `⟨V, E, A, ℓ⟩` is a mixed graph with a vertex labeling. -/
 structure MixedGraph (V S : Type*) extends _root_.MixedGraph V where
   /-- The labeling (`ℓ`). -/
   label : V → S

--- a/Linglib/Phonology/Autosegmental/MultiAR.lean
+++ b/Linglib/Phonology/Autosegmental/MultiAR.lean
@@ -405,16 +405,17 @@ end MultiAR
 
 /-! ### Interpretation into the labeled mixed graph foundation
 
-The tiered presentation denotes a labeled mixed graph (`MixedGraph.lean`) by
-construction: vertices are per-tier positions, the alphabet is the
-tier-partitioned `Σ i, τ i` with tier assignment `Sigma.fst`, arcs are within-tier
-successors, and edges symmetrize the per-pair links. The structural §4.2 axioms
-hold as properties of the construction (`toMixedGraph_isTierOrdered`,
-`toMixedGraph_noInternalAssoc`), and the foundational path-form No-Crossing
-Constraint agrees with the per-pair `IsPlanar` exactly on orientation-normalized
-presentations (`toMixedGraph_isPlanar_iff`) — links between two tiers must be
-stored in one orientation bucket, since the path form also sees crossings between
-an `(i, j)` link and a `(j, i)` link, which the per-pair check cannot couple. -/
+The tiered presentation denotes a labeled mixed graph (`MixedGraphCat`,
+`MixedGraph.lean`) by construction: vertices are per-tier positions, the alphabet
+is the tier-partitioned `Σ i, τ i` with tier assignment `Sigma.fst`, arcs are
+within-tier successors, and edges symmetrize the per-pair links. The structural
+§4.2 axioms hold as properties of the construction
+(`toMixedGraphCat_isTierOrdered`, `toMixedGraphCat_noInternalAssoc`), and the
+foundational path-form No-Crossing Constraint agrees with the per-pair `IsPlanar`
+exactly on orientation-normalized presentations (`toMixedGraphCat_isPlanar_iff`) —
+links between two tiers must be stored in one orientation bucket, since the path
+form also sees crossings between an `(i, j)` link and a `(j, i)` link, which the
+per-pair check cannot couple. -/
 
 namespace MultiGraph
 
@@ -422,24 +423,27 @@ namespace MultiGraph
     vertices, the within-tier position order as arcs ([jardine-2019]'s reading —
     `A` represents the order, matching `IsTierOrdered`'s path-closure), and
     symmetrized per-pair links as edges. -/
-def toMixedGraph (M : MultiGraph τ) :
-    MixedGraph ((i : ι) × Fin (M.tiers i).len) ((i : ι) × τ i) where
-  edges :=
-    { Adj := fun v w => v ≠ w ∧
-        (((v.2 : ℕ), (w.2 : ℕ)) ∈ M.links v.1 w.1 ∨ ((w.2 : ℕ), (v.2 : ℕ)) ∈ M.links w.1 v.1)
-      symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.symm⟩⟩
-      loopless := ⟨fun _ h => h.1 rfl⟩ }
-  arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩
+def toMixedGraphCat (M : MultiGraph τ) : MixedGraphCat ((i : ι) × τ i) where
+  V := (i : ι) × Fin (M.tiers i).len
+  graph :=
+    { edges :=
+        { Adj := fun v w => v ≠ w ∧
+            (((v.2 : ℕ), (w.2 : ℕ)) ∈ M.links v.1 w.1 ∨
+              ((w.2 : ℕ), (v.2 : ℕ)) ∈ M.links w.1 v.1)
+          symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.symm⟩⟩
+          loopless := ⟨fun _ h => h.1 rfl⟩ }
+      arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩ }
   label v := ⟨v.1, (M.tiers v.1).label v.2⟩
 
 variable {M : MultiGraph τ}
 
-@[simp] theorem toMixedGraph_tier (v : (i : ι) × Fin (M.tiers i).len) :
-    M.toMixedGraph.tier Sigma.fst v = v.1 := rfl
+@[simp] theorem toMixedGraphCat_tier (v : (i : ι) × Fin (M.tiers i).len) :
+    M.toMixedGraphCat.tier Sigma.fst v = v.1 := rfl
 
 /-- Axioms 1–2 hold by construction: the arcs are the tier-internal position
     order, already path-closed. -/
-theorem toMixedGraph_isTierOrdered : M.toMixedGraph.IsTierOrdered Sigma.fst := by
+theorem toMixedGraphCat_isTierOrdered :
+    IsTierOrdered M.toMixedGraphCat.graph (M.toMixedGraphCat.tier Sigma.fst) := by
   refine ⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => ?_,
     fun u v w huv hvw => ⟨huv.1.trans hvw.1, by obtain ⟨-, h1⟩ := huv; obtain ⟨-, h2⟩ := hvw; omega⟩⟩
   · obtain ⟨i, p⟩ := v
@@ -454,8 +458,8 @@ theorem toMixedGraph_isTierOrdered : M.toMixedGraph.IsTierOrdered Sigma.fst := b
 
 /-- Axiom 3 holds by construction on diagonal-free presentations: edges land
     across tier-pairs, paths stay within a tier. -/
-theorem toMixedGraph_noInternalAssoc (hdiag : ∀ i, M.links i i = ∅) :
-    M.toMixedGraph.NoInternalAssoc := by
+theorem toMixedGraphCat_noInternalAssoc (hdiag : ∀ i, M.links i i = ∅) :
+    NoInternalAssoc M.toMixedGraphCat.graph := by
   rintro v w ⟨hne, hmem⟩ harc
   obtain ⟨i, p⟩ := v
   obtain ⟨j, q⟩ := w
@@ -467,9 +471,9 @@ theorem toMixedGraph_noInternalAssoc (hdiag : ∀ i, M.links i i = ∅) :
     two tiers stored in one orientation bucket — which also rules out diagonal
     links). Without normalization the path form is strictly stronger: it couples
     an `(i, j)` link with a `(j, i)` link between the same two tiers. -/
-theorem toMixedGraph_isPlanar_iff (hb : M.InBounds)
+theorem toMixedGraphCat_isPlanar_iff (hb : M.InBounds)
     (hor : ∀ i j, M.links i j ≠ ∅ → M.links j i = ∅) :
-    M.toMixedGraph.IsPlanar ↔ M.IsPlanar := by
+    Autosegmental.IsPlanar M.toMixedGraphCat.graph ↔ M.IsPlanar := by
   have hdiag : ∀ i, M.links i i = ∅ := fun i => by
     by_contra h
     exact h (hor i i h)

--- a/Linglib/Phonology/Autosegmental/MultiAR.lean
+++ b/Linglib/Phonology/Autosegmental/MultiAR.lean
@@ -419,7 +419,9 @@ an `(i, j)` link and a `(j, i)` link, which the per-pair check cannot couple. -/
 namespace MultiGraph
 
 /-- The labeled mixed graph a tiered presentation denotes: per-tier positions as
-    vertices, within-tier successor arcs, symmetrized per-pair links as edges. -/
+    vertices, the within-tier position order as arcs ([jardine-2019]'s reading —
+    `A` represents the order, matching `IsTierOrdered`'s path-closure), and
+    symmetrized per-pair links as edges. -/
 def toMixedGraph (M : MultiGraph τ) :
     MixedGraph ((i : ι) × Fin (M.tiers i).len) ((i : ι) × τ i) where
   edges :=
@@ -427,7 +429,7 @@ def toMixedGraph (M : MultiGraph τ) :
         (((v.2 : ℕ), (w.2 : ℕ)) ∈ M.links v.1 w.1 ∨ ((w.2 : ℕ), (v.2 : ℕ)) ∈ M.links w.1 v.1)
       symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.symm⟩⟩
       loopless := ⟨fun _ h => h.1 rfl⟩ }
-  arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) + 1 = (w.2 : ℕ)⟩
+  arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩
   label v := ⟨v.1, (M.tiers v.1).label v.2⟩
 
 variable {M : MultiGraph τ}
@@ -445,21 +447,14 @@ theorem toMixedGraph_precPath {v w : (i : ι) × Fin (M.tiers i).len} :
     | tail _ h ih =>
         obtain ⟨ih1, ih2⟩ := ih; obtain ⟨h1, h2⟩ := h
         exact ⟨ih1.trans h1, by omega⟩
-  · obtain ⟨i, p⟩ := v
-    obtain ⟨j, q⟩ := w
-    rintro ⟨(rfl : i = j), hlt⟩
-    dsimp only at hlt
-    obtain ⟨d, hd⟩ : ∃ d, (p : ℕ) + d + 1 = (q : ℕ) := ⟨(q : ℕ) - (p : ℕ) - 1, by omega⟩
-    clear hlt
-    induction d generalizing q with
-    | zero => exact .single ⟨rfl, hd⟩
-    | succ d ih =>
-        have hm : (p : ℕ) + d + 1 < (M.tiers i).len := by have := q.isLt; omega
-        exact .tail (ih ⟨(p : ℕ) + d + 1, hm⟩ rfl) ⟨rfl, by omega⟩
+  · rintro ⟨heq, hlt⟩
+    exact .single ⟨heq, hlt⟩
 
-/-- Axioms 1–2 hold by construction: successor arcs are tier-internal chains. -/
+/-- Axioms 1–2 hold by construction: the arcs are the tier-internal position
+    order, already path-closed. -/
 theorem toMixedGraph_isTierOrdered : M.toMixedGraph.IsTierOrdered Sigma.fst := by
-  refine ⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => ?_⟩
+  refine ⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => ?_,
+    fun v w h => toMixedGraph_precPath.mp h⟩
   · obtain ⟨i, p⟩ := v
     obtain ⟨j, q⟩ := w
     obtain rfl : i = j := htier

--- a/Linglib/Phonology/Autosegmental/MultiAR.lean
+++ b/Linglib/Phonology/Autosegmental/MultiAR.lean
@@ -42,11 +42,17 @@ than a defeq view.
 * `MonoidalCategory (MultiAR τ)`: tensor is `concat`, via
   `MonoidalCategory.ofTensorHom` — the dependent tiers add only a `funext i` to
   each of `AR`'s coherence proofs.
+* `isNormal` / `MultiAR.Normal`: the orientation-normal form full subcategory
+  (links only in the ascending-order bucket, relative to `[LinearOrder ι]`).
+* `normalForm`: the functor from `MultiAR.Normal` into the foundational
+  `Representation` category, fully faithful (`normalForm.fullyFaithful`).
 
 ## Main results
 
 * `MultiGraph.isPlanar_concat` / `MultiGraph.inBounds_concat`: concatenation
   preserves planarity (given in-bounds) and in-bounds.
+* `normalForm.fullyFaithful`: the normal-form embedding of the tiered
+  presentation into the labeled-mixed-graph foundation is fully faithful.
 
 ## Implementation notes
 
@@ -71,6 +77,12 @@ autosegmental association equivalent in expressible constraints.
   `ObjectProperty.IsMonoidal` over the per-pair `MultiGraph.IsPlanar`) and the
   coproduct universal property (`inl`/`inr`/`coprodDesc`), making the
   `AR`/`MultiAR` pair fully symmetric — both follow `AR.lean`'s pattern.
+* Essential surjectivity of `normalForm`: every `Representation` object is
+  isomorphic to the image of a `MultiAR.Normal` (choose a per-tier ordering of
+  the fiber and read links off the association graph in the canonical bucket).
+* Strict-monoidal upgrade: `normalForm` respects `concat` up to a definitional
+  isomorphism with `MixedGraphCat.concat`, promoting the fully-faithful
+  embedding to a strict monoidal functor.
 -/
 
 namespace Autosegmental
@@ -506,5 +518,187 @@ theorem toMixedGraphCat_isPlanar_iff (hb : M.InBounds)
     · exact absurd (isNonCrossing_iff.mp (h j i) _ hm₂ _ hm₁ hdb) (by omega)
 
 end MultiGraph
+
+/-! ### The normal-form functor into the labeled-mixed-graph foundation
+
+Given a `LinearOrder` on the tier index, tiered presentations whose links live
+only in the ascending-order bucket per unordered tier-pair embed fully
+faithfully into the foundational representation category — this is the
+**normal form** for `MultiAR τ` relative to the ambient linear order. The
+order canonicalizes an orientation choice `MultiGraph.links` allows and
+`MultiGraph.toMixedGraphCat` symmetrizes away: without a normalization, two
+tiered graphs storing the same physical link in opposite `(i, j)` vs. `(j, i)`
+buckets would carry a foundational identity morphism between their images
+that no `MultiAR.Hom` (which is orientation-tracked in `links_preserve`)
+realizes. The ordering also subsumes diagonal-freeness — `¬ i < i` forces
+`links i i = ∅`, exactly the hypothesis `toMixedGraphCat_noInternalAssoc` needs.
+
+Essential surjectivity and the monoidal upgrade (a strict-monoidal embedding
+into `Representation` compatible with `MixedGraphCat.concat`) are follow-ups. -/
+
+section NormalForm
+
+variable [LinearOrder ι]
+
+/-- Orientation-normal form: link storage restricted to the ascending-order
+    tier-pair bucket. Includes diagonal-freeness as the `i = j` special case
+    (`¬ i < i`), matching `toMixedGraphCat_noInternalAssoc`'s hypothesis. -/
+def isNormal : ObjectProperty (MultiAR τ) := fun M => ∀ i j, ¬ i < j → M.links i j = ∅
+
+namespace MultiAR
+
+lemma lt_of_isNormal {M : MultiAR τ} (h : isNormal M) {i j : ι} {p q : ℕ}
+    (hmem : (p, q) ∈ M.links i j) : i < j := by
+  by_contra hle
+  exact Finset.notMem_empty _ (h i j hle ▸ hmem)
+
+lemma diag_empty_of_isNormal {M : MultiAR τ} (h : isNormal M) (i : ι) :
+    M.links i i = ∅ :=
+  h i i (lt_irrefl i)
+
+/-- The full subcategory of orientation-normalized in-bounds multi-tier graphs
+    — the domain of the normal-form functor into `Representation`. -/
+abbrev Normal : Type _ := (isNormal (τ := τ)).FullSubcategory
+
+end MultiAR
+
+namespace MultiAR
+
+/-- Forward direction: a per-tier `LabeledTuple.Hom` family gives a
+    foundational `MixedGraphCat.Hom` between the images. Source normality
+    disambiguates the edge bucket via `i < j`. -/
+def toMixedGraphCatHom {A B : MultiAR τ} (hn : isNormal A) (f : Hom A B) :
+    MixedGraphCat.Hom A.toMultiGraph.toMixedGraphCat B.toMultiGraph.toMixedGraphCat where
+  toFun v := ⟨v.1, (f.fT v.1).toFun v.2⟩
+  edge_map := by
+    rintro v w ⟨_, hmem⟩
+    have h1 : v.1 ≠ w.1 := by
+      rcases hmem with hij | hji
+      · exact ne_of_lt (lt_of_isNormal hn hij)
+      · exact (ne_of_lt (lt_of_isNormal hn hji)).symm
+    refine ⟨?_, ?_⟩
+    · intro heq
+      exact h1 (congrArg (fun (s : (k : ι) × Fin (B.tiers k).len) => s.1) heq)
+    · rcases hmem with hij | hji
+      · exact Or.inl (f.links_preserve v.1 w.1 v.2.isLt w.2.isLt hij)
+      · exact Or.inr (f.links_preserve w.1 v.1 w.2.isLt v.2.isLt hji)
+  label_comp v := congrArg (Sigma.mk v.1) (congrFun (f.fT v.1).label_comp v.2)
+
+omit [LinearOrder ι] in
+/-- The core existence lemma: label preservation forces `φ` on `⟨i, p⟩` to
+    stay in the `i`-tier, and its second component labels `(A.tiers i).label p`. -/
+private lemma ofMixedGraphCatHom_exists {A B : MultiAR τ}
+    (φ : MixedGraphCat.Hom A.toMultiGraph.toMixedGraphCat B.toMultiGraph.toMixedGraphCat)
+    (i : ι) (p : Fin (A.tiers i).len) :
+    ∃ q : Fin (B.tiers i).len, φ.toFun ⟨i, p⟩ = ⟨i, q⟩ ∧
+      (B.tiers i).label q = (A.tiers i).label p := by
+  have hlbl := φ.label_comp ⟨i, p⟩
+  generalize hv : φ.toFun ⟨i, p⟩ = v at hlbl ⊢
+  obtain ⟨j, q⟩ := v
+  have hj : j = i := congrArg (fun (s : (k : ι) × τ k) => s.1) hlbl
+  subst hj
+  exact ⟨q, rfl, eq_of_heq (Sigma.mk.inj_iff.mp hlbl).2⟩
+
+/-- The per-tier `LabeledTuple.Hom` reconstructed from a foundational morphism. -/
+private noncomputable def ofMixedGraphCatHom_fT {A B : MultiAR τ}
+    (φ : MixedGraphCat.Hom A.toMultiGraph.toMixedGraphCat B.toMultiGraph.toMixedGraphCat)
+    (i : ι) : LabeledTuple.Hom (A.tiers i) (B.tiers i) where
+  toFun p := (ofMixedGraphCatHom_exists φ i p).choose
+  label_comp := funext fun p => (ofMixedGraphCatHom_exists φ i p).choose_spec.2
+
+omit [LinearOrder ι] in
+private lemma ofMixedGraphCatHom_fT_spec {A B : MultiAR τ}
+    (φ : MixedGraphCat.Hom A.toMultiGraph.toMixedGraphCat B.toMultiGraph.toMixedGraphCat)
+    (i : ι) (p : Fin (A.tiers i).len) :
+    φ.toFun ⟨i, p⟩ = ⟨i, (ofMixedGraphCatHom_fT φ i).toFun p⟩ :=
+  (ofMixedGraphCatHom_exists φ i p).choose_spec.1
+
+/-- Backward direction as a `MultiAR.Hom`: both source and target normality —
+    source to build the edge witness at `i < j`, target to disambiguate the
+    image bucket by ruling out the `B.links j i` disjunct. -/
+noncomputable def ofMixedGraphCatHom {A B : MultiAR τ}
+    (hnA : isNormal A) (hnB : isNormal B)
+    (φ : MixedGraphCat.Hom A.toMultiGraph.toMixedGraphCat B.toMultiGraph.toMixedGraphCat) :
+    Hom A B where
+  fT := ofMixedGraphCatHom_fT φ
+  links_preserve i j p q hp hq hmem := by
+    have hij : i < j := lt_of_isNormal hnA hmem
+    have hne : (⟨i, ⟨p, hp⟩⟩ : (k : ι) × Fin (A.tiers k).len) ≠ ⟨j, ⟨q, hq⟩⟩ := by
+      intro heq
+      exact (ne_of_lt hij)
+        (congrArg (fun (s : (k : ι) × Fin (A.tiers k).len) => s.1) heq)
+    have hadj : A.toMultiGraph.toMixedGraphCat.graph.edges.Adj
+        ⟨i, ⟨p, hp⟩⟩ ⟨j, ⟨q, hq⟩⟩ := ⟨hne, Or.inl hmem⟩
+    have himg := φ.edge_map hadj
+    rw [ofMixedGraphCatHom_fT_spec φ i ⟨p, hp⟩,
+        ofMixedGraphCatHom_fT_spec φ j ⟨q, hq⟩] at himg
+    obtain ⟨_, hmem'⟩ := himg
+    rcases hmem' with hij' | hji'
+    · exact hij'
+    · exact absurd hji' (by simp [hnB j i (not_lt.mpr hij.le)])
+
+end MultiAR
+
+/-! ### The functor and its full faithfulness -/
+
+open CategoryTheory
+
+/-- The normal-form functor from `MultiAR.Normal` into the foundational
+    representation category. On objects it takes `X` to `X.toMixedGraphCat`
+    with the §4.2 axioms furnished by `toMixedGraphCat_isTierOrdered` and
+    `toMixedGraphCat_noInternalAssoc`; on morphisms it lifts a per-tier
+    `LabeledTuple.Hom` family through the Sigma vertex encoding. -/
+noncomputable def normalForm :
+    (isNormal (τ := τ)).FullSubcategory ⥤
+      Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+  obj X :=
+    ⟨X.obj.toMultiGraph.toMixedGraphCat,
+      MultiGraph.toMixedGraphCat_isTierOrdered,
+      MultiGraph.toMixedGraphCat_noInternalAssoc (MultiAR.diag_empty_of_isNormal X.property)⟩
+  map {X _} f := ObjectProperty.homMk (MultiAR.toMixedGraphCatHom X.property f.hom)
+  map_id X := by
+    apply ObjectProperty.hom_ext
+    apply MixedGraphCat.Hom.ext
+    funext v
+    rcases v with ⟨i, p⟩
+    rfl
+  map_comp {_ _ _} _ _ := by
+    apply ObjectProperty.hom_ext
+    apply MixedGraphCat.Hom.ext
+    funext v
+    rcases v with ⟨i, p⟩
+    rfl
+
+/-- `normalForm` is fully faithful: label preservation forces tier
+    preservation, so foundational morphisms between image graphs recover
+    per-tier `LabeledTuple.Hom` families, and orientation-normality forces
+    each preimage link to land in its own storage bucket. -/
+noncomputable def normalForm.fullyFaithful : (normalForm (τ := τ)).FullyFaithful where
+  preimage {X Y} φ :=
+    ObjectProperty.homMk (MultiAR.ofMixedGraphCatHom X.property Y.property φ.hom)
+  map_preimage {X Y} φ := by
+    apply ObjectProperty.hom_ext
+    apply MixedGraphCat.Hom.ext
+    funext v
+    rcases v with ⟨i, p⟩
+    exact (MultiAR.ofMixedGraphCatHom_fT_spec φ.hom i p).symm
+  preimage_map {X Y} f := by
+    apply ObjectProperty.hom_ext
+    show MultiAR.ofMixedGraphCatHom X.property Y.property _ = f.hom
+    apply MultiAR.Hom.ext
+    funext i
+    apply LabeledTuple.Hom.ext
+    funext p
+    have hspec := MultiAR.ofMixedGraphCatHom_fT_spec
+      (MultiAR.toMixedGraphCatHom X.property f.hom) i p
+    -- LHS is ⟨i, (f.hom.fT i).toFun p⟩ by rfl; second-components equal via HEq → Eq
+    have hheq := (Sigma.mk.inj_iff.mp hspec).2
+    exact (eq_of_heq hheq).symm
+
+instance : (normalForm (τ := τ)).Faithful := normalForm.fullyFaithful.faithful
+
+instance : (normalForm (τ := τ)).Full := normalForm.fullyFaithful.full
+
+end NormalForm
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/MultiAR.lean
+++ b/Linglib/Phonology/Autosegmental/MultiAR.lean
@@ -437,43 +437,29 @@ variable {M : MultiGraph τ}
 @[simp] theorem toMixedGraph_tier (v : (i : ι) × Fin (M.tiers i).len) :
     M.toMixedGraph.tier Sigma.fst v = v.1 := rfl
 
-/-- Precedence paths in the interpretation are exactly same-tier position order. -/
-theorem toMixedGraph_precPath {v w : (i : ι) × Fin (M.tiers i).len} :
-    M.toMixedGraph.PrecPath v w ↔ v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ) := by
-  constructor
-  · intro h
-    induction h with
-    | single h => obtain ⟨h1, h2⟩ := h; exact ⟨h1, by omega⟩
-    | tail _ h ih =>
-        obtain ⟨ih1, ih2⟩ := ih; obtain ⟨h1, h2⟩ := h
-        exact ⟨ih1.trans h1, by omega⟩
-  · rintro ⟨heq, hlt⟩
-    exact .single ⟨heq, hlt⟩
-
 /-- Axioms 1–2 hold by construction: the arcs are the tier-internal position
     order, already path-closed. -/
 theorem toMixedGraph_isTierOrdered : M.toMixedGraph.IsTierOrdered Sigma.fst := by
   refine ⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => ?_,
-    fun v w h => toMixedGraph_precPath.mp h⟩
+    fun u v w huv hvw => ⟨huv.1.trans hvw.1, by obtain ⟨-, h1⟩ := huv; obtain ⟨-, h2⟩ := hvw; omega⟩⟩
   · obtain ⟨i, p⟩ := v
     obtain ⟨j, q⟩ := w
     obtain rfl : i = j := htier
     rcases Nat.lt_trichotomy (p : ℕ) (q : ℕ) with h | h | h
-    · exact Or.inl (toMixedGraph_precPath.mpr ⟨rfl, h⟩)
+    · exact Or.inl ⟨rfl, h⟩
     · exact absurd (by simp [Fin.ext h]) hne
-    · exact Or.inr (toMixedGraph_precPath.mpr ⟨rfl, h⟩)
-  · rw [toMixedGraph_precPath] at h
+    · exact Or.inr ⟨rfl, h⟩
+  · obtain ⟨-, h2⟩ := h
     omega
 
 /-- Axiom 3 holds by construction on diagonal-free presentations: edges land
     across tier-pairs, paths stay within a tier. -/
 theorem toMixedGraph_noInternalAssoc (hdiag : ∀ i, M.links i i = ∅) :
     M.toMixedGraph.NoInternalAssoc := by
-  rintro v w ⟨hne, hmem⟩ hpath
-  rw [toMixedGraph_precPath] at hpath
+  rintro v w ⟨hne, hmem⟩ harc
   obtain ⟨i, p⟩ := v
   obtain ⟨j, q⟩ := w
-  obtain rfl : i = j := hpath.1
+  obtain rfl : i = j := harc.1
   rcases hmem with hm | hm <;> simp [hdiag i] at hm
 
 /-- The foundational path-form No-Crossing Constraint agrees with the per-pair
@@ -499,18 +485,16 @@ theorem toMixedGraph_isPlanar_iff (hb : M.InBounds)
     obtain ⟨hc, hd⟩ := hb i j _ h₂
     exact h (v := ⟨i, ⟨a, ha⟩⟩) (v' := ⟨j, ⟨b, hb'⟩⟩) (w := ⟨i, ⟨c, hc⟩⟩) (w' := ⟨j, ⟨d, hd⟩⟩)
       ⟨by simp [hij], Or.inl h₁⟩ ⟨by simp [hij], Or.inl h₂⟩
-      (toMixedGraph_precPath.mpr ⟨rfl, hac⟩)
-      (toMixedGraph_precPath.mpr ⟨rfl, not_le.mp hbd⟩)
+      ⟨rfl, hac⟩ ⟨rfl, not_le.mp hbd⟩
   · rintro h v v' w w' ⟨hne₁, hm₁⟩ ⟨hne₂, hm₂⟩ hp hp'
-    rw [toMixedGraph_precPath] at hp hp'
     obtain ⟨i, a⟩ := v
     obtain ⟨j, b⟩ := v'
     obtain ⟨i', c⟩ := w
     obtain ⟨j', d⟩ := w'
-    obtain rfl : i = i' := hp.1
-    obtain rfl : j = j' := hp'.1.symm
-    have hac : (a : ℕ) < (c : ℕ) := hp.2
-    have hdb : (d : ℕ) < (b : ℕ) := hp'.2
+    obtain ⟨heq, hac⟩ := hp
+    obtain ⟨heq', hdb⟩ := hp'
+    obtain rfl : i = i' := heq
+    obtain rfl : j = j' := heq'.symm
     rcases hm₁ with hm₁ | hm₁ <;> rcases hm₂ with hm₂ | hm₂
     · exact absurd (isNonCrossing_iff.mp (h i j) _ hm₁ _ hm₂ hac) (by omega)
     · exact absurd hm₂ (by simp [hor i j (Finset.ne_empty_of_mem hm₁)])


### PR DESCRIPTION
Stage 2 of the end-state blueprint: the foundation's `Hom` becomes the broad, precedence-forgetting class (label + association only — where reassociation analyses and the OCP repair live), with `precPreserving` as the wide morphism class of full-structure homomorphisms (the legacy `AR.Hom`/`PrecAR` split, reconstructed at the foundation).

- `MixedGraph.sum`: the bridge-free blockwise sum, with `HasInitial`/`HasBinaryCoproducts` on `MixedGraphCat` (inl/inr/sumDesc universal property)
- `not_isTierOrdered_sum`: **Axiom 2 forces the bridges** — the coproduct leaves the axiom class whenever the factors share a tier; `concat`'s bridges are the minimal repair. The precise content of [jardine-heinz-2015]'s "modification of the disjoint union".