### PR TITLE
refactor(Phonology/Autosegmental): dissolve MultiAR into normal forms

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1356,6 +1356,7 @@ import Linglib.Phonology.Autosegmental.Melody
 import Linglib.Phonology.Autosegmental.MixedGraph
 import Linglib.Phonology.Autosegmental.MultiAR
 import Linglib.Phonology.Autosegmental.NonCrossing
+import Linglib.Phonology.Autosegmental.NormalForm
 import Linglib.Phonology.Autosegmental.Realization
 import Linglib.Phonology.Autosegmental.Sharing
 import Linglib.Phonology.Constraints.Basic

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Order.CompleteLattice.Finset
 import Linglib.Core.Computability.Variety.Langs
 
 /-!
@@ -96,5 +97,17 @@ theorem IsStarFree.comap {α β : Type*} {L : Language β} (h : L.IsStarFree)
 /-- **The full language is star-free** — recognized by the trivial monoid. -/
 theorem isStarFree_univ : IsStarFree (Set.univ : Language α) :=
   Monoid.aperiodicVariety.langs_univ
+
+/-- Star-free languages are closed under finitely-indexed intersections. -/
+theorem IsStarFree.iInter {ι : Type*} [Finite ι] {f : ι → Language α}
+    (h : ∀ i, (f i).IsStarFree) : IsStarFree (⋂ i, f i) := by
+  haveI := Fintype.ofFinite ι
+  classical
+  rw [show (⋂ i, f i) = ⋂ i ∈ (Finset.univ : Finset ι), f i by simp]
+  induction (Finset.univ : Finset ι) using Finset.induction_on with
+  | empty => simpa using isStarFree_univ
+  | insert a s ha ih =>
+    rw [Finset.set_biInter_insert]
+    exact (h a).inter ih
 
 end Language

--- a/Linglib/Phonology/Autosegmental/ASL.lean
+++ b/Linglib/Phonology/Autosegmental/ASL.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Computability.Language
+import Linglib.Phonology.Autosegmental.NormalForm
 import Linglib.Phonology.Autosegmental.Realization
 import Linglib.Phonology.Autosegmental.Embedding
 
@@ -61,5 +62,29 @@ instance [DecidableEq α] [DecidableEq β] (g₀ : S → AR α β) (B : List (Gr
     grammar present it ([jardine-2019]). -/
 def IsASL (L : Language S) : Prop :=
   ∃ (α β : Type) (g₀ : S → AR α β) (B : List (Graph α β)), L = ASL g₀ B
+
+/-! ### ASL in coordinates -/
+
+section Coordinate
+
+variable {ι : Type*} [Finite ι] {τ : ι → Type*}
+
+/-- **The Autosegmental Strictly Local stringset** on the graph foundation:
+    strings whose realization avoids every forbidden factor — the preimage of
+    the banned-subgraph object property along `realize`, the same shape as
+    `TSL.lang = tierProject ⁻¹' (SL-language)`. -/
+def Representation.ASL (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    [∀ s, Finite (g₀ s).obj.V]
+    (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
+    Language S :=
+  { w | (realize g₀ w).Free B }
+
+@[simp] theorem Representation.mem_ASL
+    {g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [∀ s, Finite (g₀ s).obj.V]
+    {B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}}
+    {w : List S} : w ∈ Representation.ASL g₀ B ↔ (realize g₀ w).Free B := Iff.rfl
+
+end Coordinate
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/ASL.lean
+++ b/Linglib/Phonology/Autosegmental/ASL.lean
@@ -21,11 +21,11 @@ local base condition along a free-monoid homomorphism**.
 
 ```
   TSL  =  tierProject ⁻¹' (SL-language)        -- string→tier-string projection
-  ASL  =  realize g₀  ⁻¹' { A | isFreeOf B A } -- string→AR realization
+  ASL  =  AR.realize g₀  ⁻¹' { A | isFreeOf B A } -- string→AR realization
 ```
 
 `tierProject` (`Core/Computability/Subregular/Language/TierStrictlyLocal.lean`) and
-`realize` (`Realization.lean`) are
+`AR.realize` (`Realization.lean`) are
 both concat-distributing free-monoid homs; the difference is only the codomain — a
 tier string (discarding off-tier material) vs an AR (keeping the association lines).
 That extra structure is why [jardine-2019] finds `ASL` and `TSL` incomparable.
@@ -44,18 +44,18 @@ instance [DecidableEq α] [DecidableEq β] (B : List (Graph α β)) (A : AR α �
 
 /-- **The Autosegmental Strictly Local stringset** of a realization `g₀` and a forbidden
     grammar `B` ([jardine-2019]): the strings whose realization avoids `B`. The preimage
-    of the AR object-property `isFreeOf B` along `realize g₀` — the same shape as
+    of the AR object-property `isFreeOf B` along `AR.realize g₀` — the same shape as
     `TSL.lang = tierProject ⁻¹' (SL-language)`, with the AR realization in place of the
     tier projection. -/
 def ASL (g₀ : S → AR α β) (B : List (Graph α β)) : Language S :=
-  realize g₀ ⁻¹' { A | isFreeOf B A }
+  AR.realize g₀ ⁻¹' { A | isFreeOf B A }
 
 @[simp] theorem mem_ASL (g₀ : S → AR α β) (B : List (Graph α β)) (w : List S) :
-    w ∈ ASL g₀ B ↔ isFreeOf B (realize g₀ w) := Iff.rfl
+    w ∈ ASL g₀ B ↔ isFreeOf B (AR.realize g₀ w) := Iff.rfl
 
 instance [DecidableEq α] [DecidableEq β] (g₀ : S → AR α β) (B : List (Graph α β))
     (w : List S) : Decidable (w ∈ ASL g₀ B) :=
-  inferInstanceAs (Decidable (isFreeOf B (realize g₀ w)))
+  inferInstanceAs (Decidable (isFreeOf B (AR.realize g₀ w)))
 
 /-- A stringset is **autosegmental strictly local** when some realization and forbidden
     grammar present it ([jardine-2019]). -/

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -903,6 +903,82 @@ noncomputable def realizeMerged (g₀ : S → Representation (Sigma.fst : ((i : 
 
 end RealizeMerged
 
+section Axiom6Bridge
+
+omit [DecidableEq ι] [DecidableEq (τ m)]
+
+/-- On a normal form, one position covers another in the arc order iff it is
+    its immediate successor. -/
+theorem Representation.covering_normalize [Finite X.obj.V] {i : ι}
+    {p q : Fin (X.tierLength i)} :
+    ((X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ∧
+        ∀ u, ¬ ((X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ u ∧
+          (X.normalize).obj.graph.arcs.Adj u ⟨i, q⟩)) ↔
+      (q : ℕ) = p + 1 := by
+  constructor
+  · rintro ⟨hpq, hcov⟩
+    rw [Representation.arcs_normalize] at hpq
+    by_contra hne
+    have hmid : (p : ℕ) + 1 < q := by
+      have := Fin.lt_def.mp hpq; omega
+    have hq := q.isLt
+    refine hcov ⟨i, ⟨(p : ℕ) + 1, by omega⟩⟩ ⟨?_, ?_⟩
+    · exact (Representation.arcs_normalize _ _ _).mpr
+        (show (p : ℕ) < (p : ℕ) + 1 by omega)
+    · exact (Representation.arcs_normalize _ _ _).mpr
+        (show (p : ℕ) + 1 < (q : ℕ) from hmid)
+  · intro hsucc
+    refine ⟨(Representation.arcs_normalize _ _ _).mpr
+      (show (p : ℕ) < (q : ℕ) by omega), ?_⟩
+    rintro ⟨j, u⟩ ⟨h1, h2⟩
+    rcases eq_or_ne i j with rfl | hij
+    · rw [Representation.arcs_normalize] at h1 h2
+      have := Fin.lt_def.mp h1
+      have := Fin.lt_def.mp h2
+      omega
+    · exact Representation.arcs_normalize_ne hij p u h1
+
+/-- Cleanliness fails at a successor pair exactly when its labels repeat. -/
+private theorem Representation.label_normalize_succ [Finite X.obj.V]
+    {p : ℕ} (hp1 : p + 1 < X.tierLength m) (hp : p < X.tierLength m) :
+    (X.normalize).obj.label ⟨m, ⟨p, hp⟩⟩ = (X.normalize).obj.label ⟨m, ⟨p + 1, hp1⟩⟩ ↔
+      (X.tierWord m)[p]'(by simp; omega) = (X.tierWord m)[p + 1]'(by simp; omega) := by
+  rw [Representation.label_normalize, Representation.label_normalize,
+    ← Representation.tierWord_getElem (p := ⟨p, hp⟩),
+    ← Representation.tierWord_getElem (p := ⟨p + 1, hp1⟩)]
+  exact ⟨fun h => eq_of_heq (Sigma.mk.inj_iff.mp h).2, fun h => congrArg (Sigma.mk m) h⟩
+
+/-- **The OCP bridge**: tier-word cleanliness is Axiom 6 on the normal form —
+    the coordinate OCP and [jardine-2016-diss]'s §4.2 axiom agree. -/
+theorem Representation.isCleanAt_iff_isOCPClean [Finite X.obj.V] :
+    X.IsCleanAt m ↔
+      IsOCPClean (X.normalize).obj.graph (X.normalize).obj.label Sigma.fst m := by
+  constructor
+  · rintro h ⟨i, p⟩ ⟨j, q⟩ hpq hcov htier heq
+    rcases eq_or_ne i j with rfl | hij
+    · obtain rfl : m = i := by
+        symm; simpa [Representation.label_normalize] using htier
+      have hsucc : (q : ℕ) = (p : ℕ) + 1 := (X.covering_normalize).mp ⟨hpq, hcov⟩
+      have hq1 : (p : ℕ) + 1 < X.tierLength m := hsucc ▸ q.isLt
+      rw [show q = ⟨(p : ℕ) + 1, hq1⟩ from Fin.ext hsucc] at heq
+      have hp' : (p : ℕ) + 1 < (X.tierWord m).length := by
+        simp only [Representation.length_tierWord]
+        omega
+      exact List.isChain_iff_getElem.mp h p hp'
+        ((X.label_normalize_succ m hq1 p.isLt).mp heq)
+    · exact Representation.arcs_normalize_ne hij p q hpq
+  · intro h
+    refine List.isChain_iff_getElem.mpr fun p hp heq => ?_
+    have hlen : p + 1 < X.tierLength m := by
+      simpa only [Representation.length_tierWord] using hp
+    have hplt : p < X.tierLength m := by omega
+    have hcover := (X.covering_normalize
+      (p := ⟨p, hplt⟩) (q := ⟨p + 1, hlen⟩) (i := m)).mpr rfl
+    exact h hcover.1 hcover.2 (by simp [Representation.label_normalize])
+      ((X.label_normalize_succ m hlen hplt).mpr heq)
+
+end Axiom6Bridge
+
 end CoordinateCollapse
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -618,14 +618,6 @@ open scoped MonoidalCategory
 
 variable {ι : Type*} [DecidableEq ι] {τ : ι → Type*}
 variable (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
-
-omit [DecidableEq ι] in
-/-- Links are symmetric in coordinates. -/
-theorem Representation.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
-    (h : X.link i j p q) : X.link j i q p := by
-  obtain ⟨hp, hq, hl⟩ := h
-  exact ⟨hq, hp, hl.symm⟩
-
 variable (m : ι) [DecidableEq (τ m)]
 
 /-- Tier words after collapsing melody tier `m`: destuttered at `m`, untouched
@@ -718,19 +710,6 @@ theorem Representation.collapsedWord_tensor
       Representation.tierWord_tensor, Representation.tierWord_collapse]
     exact OCP.collapse_append _ _
   · simp [Representation.collapsedWord, Function.update_of_ne h]
-
-omit [DecidableEq ι] in
-/-- Same-tier vertices are never linked: they are arc-comparable (Axioms 1–2),
-    and association never follows arcs (Axiom 3). -/
-theorem Representation.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
-    ¬ X.link i i p q := by
-  rintro ⟨hp, hq, hl⟩
-  rw [Representation.linkRel_def] at hl
-  have hlab : X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨p, hp⟩⟩)
-      = X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨q, hq⟩⟩) := by
-    show (X.obj.label _).1 = (X.obj.label _).1
-    rw [Representation.label_vertexEquiv, Representation.label_vertexEquiv]
-  exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
 
 theorem Representation.fiberEnum_collapse [Finite X.obj.V] (i : ι) :
     (X.collapse m).fiberEnum i =

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -786,6 +786,99 @@ theorem Representation.link_collapse [Finite X.obj.V] (i j : ι) (r s : ℕ) :
     subst hij
     exact X.not_link_self_tier i p q hpq
 
+theorem Representation.tierLength_collapse [Finite X.obj.V] (i : ι) :
+    (X.collapse m).tierLength i = (X.collapsedWord m i).length := by
+  rw [← Representation.length_tierWord, Representation.tierWord_collapse]
+
+section Congruence
+variable {Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable [Finite X.obj.V] [Finite Y.obj.V]
+
+/-- Left-block positions commute with the collapse-collapse seam. -/
+theorem Representation.collapseIdx_left (i : ι) {p : ℕ} (hp : p < X.tierLength i) :
+    (X.collapse m ⊗ Y.collapse m).collapseIdx m i (X.collapseIdx m i p)
+      = (X ⊗ Y).collapseIdx m i p := by
+  unfold Representation.collapseIdx
+  split_ifs with h
+  · subst h
+    simp only [Representation.tierWord_tensor, Representation.tierWord_collapse,
+      Representation.collapsedWord, Function.update_self]
+    exact (runIdx_append_collapse_left (xs := X.tierWord i) (ys := Y.tierWord i)
+      (by simpa using hp)).symm
+  · rfl
+
+/-- Right-block positions commute with the collapse-collapse seam. -/
+theorem Representation.collapseIdx_right (i : ι) {p : ℕ} (hp : p < Y.tierLength i) :
+    (X.collapse m ⊗ Y.collapse m).collapseIdx m i
+        ((X.collapse m).tierLength i + Y.collapseIdx m i p)
+      = (X ⊗ Y).collapseIdx m i (X.tierLength i + p) := by
+  unfold Representation.collapseIdx
+  split_ifs with h
+  · subst h
+    simp only [Representation.tierWord_tensor, Representation.tierWord_collapse,
+      Representation.collapsedWord, Function.update_self,
+      ← Representation.length_tierWord]
+    exact (runIdx_append_collapse_right (xs := X.tierWord i) (ys := Y.tierWord i)
+      (by simpa using hp)).symm
+  · simp [Representation.tierLength_collapse, Representation.collapsedWord,
+      Function.update_of_ne h]
+
+/-- The link half of the OCP congruence, in ℕ coordinates. -/
+theorem Representation.link_collapse_tensor (i j : ι) (r s : ℕ) :
+    ((X ⊗ Y).collapse m).link i j r s ↔
+      ((X.collapse m ⊗ Y.collapse m).collapse m).link i j r s := by
+  rw [Representation.link_collapse, Representation.link_collapse]
+  constructor
+  · rintro ⟨p, q, hpq, hr, hs⟩
+    rcases (Representation.link_tensor i j p q).mp hpq with hX | ⟨hpi, hqj, hY⟩
+    · refine ⟨X.collapseIdx m i p, X.collapseIdx m j q,
+        (Representation.link_tensor i j _ _).mpr
+          (Or.inl ((X.link_collapse m i j _ _).mpr ⟨p, q, hX, rfl, rfl⟩)), ?_, ?_⟩
+      · rw [X.collapseIdx_left m i hX.1, hr]
+      · rw [X.collapseIdx_left m j hX.2.1, hs]
+    · refine ⟨(X.collapse m).tierLength i + Y.collapseIdx m i (p - X.tierLength i),
+        (X.collapse m).tierLength j + Y.collapseIdx m j (q - X.tierLength j),
+        (Representation.link_tensor i j _ _).mpr (Or.inr ⟨by omega, by omega, ?_⟩), ?_, ?_⟩
+      · rw [Nat.add_sub_cancel_left, Nat.add_sub_cancel_left]
+        exact (Y.link_collapse m i j _ _).mpr ⟨_, _, hY, rfl, rfl⟩
+      · rw [X.collapseIdx_right m i hY.1, Nat.add_sub_cancel' hpi, hr]
+      · rw [X.collapseIdx_right m j hY.2.1, Nat.add_sub_cancel' hqj, hs]
+  · rintro ⟨p', q', hpq', hr, hs⟩
+    rcases (Representation.link_tensor i j p' q').mp hpq' with hX | ⟨hpi', hqj', hY'⟩
+    · obtain ⟨p, q, hX₀, hcp, hcq⟩ := (X.link_collapse m i j p' q').mp hX
+      refine ⟨p, q, (Representation.link_tensor i j p q).mpr (Or.inl hX₀), ?_, ?_⟩
+      · rw [← X.collapseIdx_left m i hX₀.1, hcp, hr]
+      · rw [← X.collapseIdx_left m j hX₀.2.1, hcq, hs]
+    · obtain ⟨a, b, hY₀, hca, hcb⟩ :=
+        (Y.link_collapse m i j (p' - (X.collapse m).tierLength i)
+          (q' - (X.collapse m).tierLength j)).mp hY'
+      refine ⟨X.tierLength i + a, X.tierLength j + b,
+        (Representation.link_tensor i j _ _).mpr (Or.inr ⟨by omega, by omega, ?_⟩), ?_, ?_⟩
+      · rw [Nat.add_sub_cancel_left, Nat.add_sub_cancel_left]
+        exact hY₀
+      · rw [← X.collapseIdx_right m i hY₀.1, hca, Nat.add_sub_cancel' hpi', hr]
+      · rw [← X.collapseIdx_right m j hY₀.2.1, hcb, Nat.add_sub_cancel' hqj', hs]
+
+/-- **The OCP congruence**: collapsing a concatenation is isomorphic to
+    collapsing the concatenation of the collapses — [jardine-heinz-2015]'s
+    melody-merge law, by the classification theorem. -/
+noncomputable def Representation.collapseTensorIso :
+    (X ⊗ Y).collapse m ≅ (X.collapse m ⊗ Y.collapse m).collapse m :=
+  Representation.isoOfReaderEq
+    (fun i => by
+      rw [Representation.tierWord_collapse, Representation.tierWord_collapse,
+        Representation.collapsedWord_tensor])
+    (fun i j r s => Representation.link_collapse_tensor X m i j r s)
+
+/-- The OCP congruence as an equality of isomorphism classes: `collapse`
+    descends to the skeleton monoid. -/
+theorem Representation.toSkeleton_collapse_tensor :
+    toSkeleton ((X ⊗ Y).collapse m)
+      = toSkeleton ((X.collapse m ⊗ Y.collapse m).collapse m) :=
+  Quotient.sound ⟨Representation.collapseTensorIso X m⟩
+
+end Congruence
+
 end CoordinateCollapse
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -620,12 +620,6 @@ variable {ι : Type*} [DecidableEq ι] {τ : ι → Type*}
 variable (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
 
 omit [DecidableEq ι] in
-/-- The label of a canonical vertex sits on its own tier. -/
-theorem Representation.label_vertexEquiv [Finite X.obj.V] (i : ι)
-    (p : Fin (X.tierLength i)) : (X.obj.label (X.vertexEquiv ⟨i, p⟩)).1 = i :=
-  (X.fiberEnum i p).property
-
-omit [DecidableEq ι] in
 /-- Links are symmetric in coordinates. -/
 theorem Representation.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
     (h : X.link i j p q) : X.link j i q p := by

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -23,7 +23,7 @@ supplies the missing merge as a post-processing retraction on the upper tier:
   `(k, j)` is repointed to `(ρ k, j)`, where `ρ` (`runIdx`) sends an upper position to
   the index of its run in the collapsed tier. The lower tier is untouched, so a merged
   node keeps *all* the morae its run was associated with (multiple association).
-* `realizeMerged := collapseAR ∘ AR.realize` — the OCP-merging realization.
+* `AR.realizeMerged := collapseAR ∘ AR.realize` — the OCP-merging realization.
 
 The upper-tier collapse is exactly `OCP.collapse` (= `List.destutter (· ≠ ·)`); the
 link pushforward is the `SimpleGraph.map`/`Quiver.Push` idiom
@@ -596,13 +596,13 @@ variable {S : Type*}
 
 /-- **The OCP-merging realization** ([jardine-2019]): AR.realize the string via the
     bridge-only `concat`, then fuse adjacent identical upper nodes
-    (`collapseAR ∘ AR.realize`). Unlike `AR.realize`, `realizeMerged g₀ (Hⁿ)` is a single H
+    (`collapseAR ∘ AR.realize`). Unlike `AR.realize`, `AR.realizeMerged g₀ (Hⁿ)` is a single H
     node multiply associated — the merge that renders unbounded tone plateauing a
     *local* AR pattern. -/
-def realizeMerged (g₀ : S → AR α β) (w : List S) : AR α β := collapseAR (AR.realize g₀ w)
+def AR.realizeMerged (g₀ : S → AR α β) (w : List S) : AR α β := collapseAR (AR.realize g₀ w)
 
 @[simp] theorem realizeMerged_def (g₀ : S → AR α β) (w : List S) :
-    realizeMerged g₀ w = collapseAR (AR.realize g₀ w) := rfl
+    AR.realizeMerged g₀ w = collapseAR (AR.realize g₀ w) := rfl
 
 /-! ### The collapse in coordinates
 
@@ -879,6 +879,29 @@ theorem Representation.cls_collapse_tensor :
   Quotient.sound ⟨Representation.fullIsoToWideIso (Representation.collapseTensorFullIso X m)⟩
 
 end Congruence
+
+/-- OCP-cleanliness at melody tier `m`: the tier word has no adjacent
+    repeats. -/
+def Representation.IsCleanAt [Finite X.obj.V] : Prop := IsClean (X.tierWord m)
+
+/-- The collapse is OCP-clean at the collapsed tier. -/
+theorem Representation.isCleanAt_collapse [Finite X.obj.V] :
+    (X.collapse m).IsCleanAt m := by
+  unfold Representation.IsCleanAt
+  rw [Representation.tierWord_collapse]
+  simpa [Representation.collapsedWord] using collapse_clean (X.tierWord m)
+
+section RealizeMerged
+variable {S : Type*}
+
+/-- The OCP-merging realization at melody tier `m` — [jardine-2019]'s merging
+    `g_T`: realize, then merge the melody runs. -/
+noncomputable def realizeMerged (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    [∀ s, Finite (g₀ s).obj.V] (w : List S) :
+    Representation (Sigma.fst : ((i : ι) × τ i) → ι) :=
+  (realize g₀ w).collapse m
+
+end RealizeMerged
 
 end CoordinateCollapse
 

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -725,6 +725,73 @@ theorem Representation.collapsedWord_tensor
     exact OCP.collapse_append _ _
   · simp [Representation.collapsedWord, Function.update_of_ne h]
 
+omit [DecidableEq ι] in
+/-- Same-tier vertices are never linked: they are arc-comparable (Axioms 1–2),
+    and association never follows arcs (Axiom 3). -/
+theorem Representation.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
+    ¬ X.link i i p q := by
+  rintro ⟨hp, hq, hl⟩
+  rw [Representation.linkRel_def] at hl
+  have hlab : X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨p, hp⟩⟩)
+      = X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨q, hq⟩⟩) := by
+    show (X.obj.label _).1 = (X.obj.label _).1
+    rw [Representation.label_vertexEquiv, Representation.label_vertexEquiv]
+  exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
+
+theorem Representation.fiberEnum_collapse [Finite X.obj.V] (i : ι) :
+    (X.collapse m).fiberEnum i =
+      (Fin.castOrderIso (by rw [← Representation.length_tierWord,
+        Representation.tierWord_collapse])).trans (X.collapseFiberEnum m i) :=
+  Subsingleton.elim _ _
+
+theorem Representation.vertexEquiv_collapse [Finite X.obj.V] {i : ι}
+    (r : Fin ((X.collapse m).tierLength i)) :
+    (X.collapse m).vertexEquiv ⟨i, r⟩
+      = ⟨i, Fin.cast (by rw [← Representation.length_tierWord,
+          Representation.tierWord_collapse]) r⟩ := by
+  show ((X.collapse m).fiberEnum i r).val = _
+  rw [Representation.fiberEnum_collapse]
+  rfl
+
+/-- The collapse's links are the image of the original links under the
+    repointing — `edges_normalize`'s analogue for the merge. -/
+theorem Representation.link_collapse [Finite X.obj.V] (i j : ι) (r s : ℕ) :
+    (X.collapse m).link i j r s ↔
+      ∃ p q, X.link i j p q ∧ X.collapseIdx m i p = r ∧ X.collapseIdx m j q = s := by
+  constructor
+  · rintro ⟨hr, hs, hl⟩
+    rw [Representation.linkRel_def, Representation.vertexEquiv_collapse,
+      Representation.vertexEquiv_collapse] at hl
+    obtain ⟨-, p, q, hpq, hp, hq⟩ := hl
+    exact ⟨p, q, hpq, hp, hq⟩
+  · rintro ⟨p, q, hpq, hp, hq⟩
+    have hbr : r < (X.collapse m).tierLength i := by
+      rw [← Representation.length_tierWord, Representation.tierWord_collapse]
+      subst hp
+      unfold Representation.collapseIdx
+      split_ifs with h
+      · subst h
+        simpa [Representation.collapsedWord] using
+          runIdx_lt_collapse_length _ (by simpa using hpq.1)
+      · simpa [Representation.collapsedWord, Function.update_of_ne h] using hpq.1
+    have hbs : s < (X.collapse m).tierLength j := by
+      rw [← Representation.length_tierWord, Representation.tierWord_collapse]
+      subst hq
+      unfold Representation.collapseIdx
+      split_ifs with h
+      · subst h
+        simpa [Representation.collapsedWord] using
+          runIdx_lt_collapse_length _ (by simpa using hpq.2.1)
+      · simpa [Representation.collapsedWord, Function.update_of_ne h] using hpq.2.1
+    refine ⟨hbr, hbs, ?_⟩
+    rw [Representation.linkRel_def, Representation.vertexEquiv_collapse,
+      Representation.vertexEquiv_collapse]
+    refine ⟨?_, p, q, hpq, hp, hq⟩
+    intro heq
+    obtain ⟨hij, -⟩ := Sigma.mk.inj_iff.mp heq
+    subst hij
+    exact X.not_link_self_tier i p q hpq
+
 end CoordinateCollapse
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -876,7 +876,7 @@ noncomputable def Representation.collapseTensorFullIso :
 theorem Representation.cls_collapse_tensor :
     Representation.cls ((X ⊗ Y).collapse m)
       = Representation.cls ((X.collapse m ⊗ Y.collapse m).collapse m) :=
-  Quotient.sound ⟨Representation.collapseTensorFullIso X m⟩
+  Quotient.sound ⟨Representation.fullIsoToWideIso (Representation.collapseTensorFullIso X m)⟩
 
 end Congruence
 

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.FreeMonoid.Destutter
 import Linglib.Phonology.OCP
+import Linglib.Phonology.Autosegmental.NormalForm
 import Linglib.Phonology.Autosegmental.Realization
 
 /-!
@@ -22,7 +23,7 @@ supplies the missing merge as a post-processing retraction on the upper tier:
   `(k, j)` is repointed to `(ρ k, j)`, where `ρ` (`runIdx`) sends an upper position to
   the index of its run in the collapsed tier. The lower tier is untouched, so a merged
   node keeps *all* the morae its run was associated with (multiple association).
-* `realizeMerged := collapseAR ∘ realize` — the OCP-merging realization.
+* `realizeMerged := collapseAR ∘ AR.realize` — the OCP-merging realization.
 
 The upper-tier collapse is exactly `OCP.collapse` (= `List.destutter (· ≠ ·)`); the
 link pushforward is the `SimpleGraph.map`/`Quiver.Push` idiom
@@ -593,14 +594,106 @@ The algebraic form of the spreading/contour asymmetry ([jardine-heinz-2015] §7)
 
 variable {S : Type*}
 
-/-- **The OCP-merging realization** ([jardine-2019]): realize the string via the
+/-- **The OCP-merging realization** ([jardine-2019]): AR.realize the string via the
     bridge-only `concat`, then fuse adjacent identical upper nodes
-    (`collapseAR ∘ realize`). Unlike `realize`, `realizeMerged g₀ (Hⁿ)` is a single H
+    (`collapseAR ∘ AR.realize`). Unlike `AR.realize`, `realizeMerged g₀ (Hⁿ)` is a single H
     node multiply associated — the merge that renders unbounded tone plateauing a
     *local* AR pattern. -/
-def realizeMerged (g₀ : S → AR α β) (w : List S) : AR α β := collapseAR (realize g₀ w)
+def realizeMerged (g₀ : S → AR α β) (w : List S) : AR α β := collapseAR (AR.realize g₀ w)
 
 @[simp] theorem realizeMerged_def (g₀ : S → AR α β) (w : List S) :
-    realizeMerged g₀ w = collapseAR (realize g₀ w) := rfl
+    realizeMerged g₀ w = collapseAR (AR.realize g₀ w) := rfl
+
+/-! ### The collapse in coordinates
+
+The OCP merge on the graph foundation: destutter melody tier `m`'s word and
+repoint its links through `runIdx`. Like `normalize` the result is a
+`Representation` on a sigma-`Fin` carrier, but the merge is not a pullback —
+`runIdx` is monotone, not bijective — so the structural axioms are proved
+directly on the merged carrier. -/
+
+section CoordinateCollapse
+
+variable {ι : Type*} [DecidableEq ι] {τ : ι → Type*}
+variable (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+
+omit [DecidableEq ι] in
+/-- The label of a canonical vertex sits on its own tier. -/
+theorem Representation.label_vertexEquiv [Finite X.obj.V] (i : ι)
+    (p : Fin (X.tierLength i)) : (X.obj.label (X.vertexEquiv ⟨i, p⟩)).1 = i :=
+  (X.fiberEnum i p).property
+
+omit [DecidableEq ι] in
+/-- Links are symmetric in coordinates. -/
+theorem Representation.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
+    (h : X.link i j p q) : X.link j i q p := by
+  obtain ⟨hp, hq, hl⟩ := h
+  exact ⟨hq, hp, hl.symm⟩
+
+variable (m : ι) [DecidableEq (τ m)]
+
+/-- Tier words after collapsing melody tier `m`: destuttered at `m`, untouched
+    elsewhere. -/
+noncomputable def Representation.collapsedWord [Finite X.obj.V] : ∀ i, List (τ i) :=
+  Function.update (fun i => X.tierWord i) m (OCP.collapse (X.tierWord m))
+
+theorem Representation.collapsedWord_length_le [Finite X.obj.V] (i : ι) :
+    (X.collapsedWord m i).length ≤ X.tierLength i := by
+  rcases eq_or_ne i m with rfl | h
+  · simpa [Representation.collapsedWord] using OCP.collapse_length_le (X.tierWord i)
+  · simp [Representation.collapsedWord, Function.update_of_ne h]
+
+/-- Position repointing: `runIdx` on the melody tier, identity elsewhere. -/
+noncomputable def Representation.collapseIdx [Finite X.obj.V] (i : ι) (p : ℕ) : ℕ :=
+  if i = m then runIdx (X.tierWord m) p else p
+
+/-- **The OCP-merging collapse**: melody tier `m` destuttered, links repointed
+    through `runIdx`, other tiers untouched. -/
+noncomputable def Representation.collapse [Finite X.obj.V] :
+    Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+  obj :=
+    { V := (i : ι) × Fin (X.collapsedWord m i).length
+      graph :=
+        { edges :=
+            { Adj := fun v w => v ≠ w ∧ ∃ p q, X.link v.1 w.1 p q ∧
+                X.collapseIdx m v.1 p = v.2 ∧ X.collapseIdx m w.1 q = w.2
+              symm := ⟨fun v w h => ⟨h.1.symm, by
+                obtain ⟨p, q, hl, hp, hq⟩ := h.2
+                exact ⟨q, p, X.link_symm hl, hq, hp⟩⟩⟩
+              loopless := ⟨fun v h => h.1 rfl⟩ }
+          arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩ }
+      label := fun v => ⟨v.1, (X.collapsedWord m v.1)[v.2]⟩ }
+  property := by
+    refine ⟨⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => lt_irrefl _ h.2,
+      fun u v w huv hvw => ⟨huv.1.trans hvw.1, huv.2.trans hvw.2⟩⟩, fun v w hadj harc => ?_⟩
+    · obtain ⟨i, p⟩ := v
+      obtain ⟨j, q⟩ := w
+      obtain rfl : i = j := htier
+      rcases Nat.lt_trichotomy (p : ℕ) (q : ℕ) with h | h | h
+      · exact Or.inl ⟨rfl, h⟩
+      · exact absurd (by rw [Fin.ext h]) hne
+      · exact Or.inr ⟨rfl, h⟩
+    · obtain ⟨hne, p, q, ⟨hp, hq, hl⟩, -, -⟩ := hadj
+      obtain ⟨i, pv⟩ := v
+      obtain ⟨j, qw⟩ := w
+      obtain rfl : i = j := harc.1
+      have hlab : X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨p, hp⟩⟩)
+          = X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨q, hq⟩⟩) := by
+        show (X.obj.label _).1 = (X.obj.label _).1
+        rw [X.label_vertexEquiv, X.label_vertexEquiv]
+      exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
+
+instance [Finite X.obj.V] : Finite (X.collapse m).obj.V :=
+  haveI : Finite ((i : ι) × Fin (X.tierLength i)) := Finite.of_equiv _ X.vertexEquiv.symm
+  Finite.of_injective
+    (fun v : (i : ι) × Fin (X.collapsedWord m i).length =>
+      (⟨v.1, v.2.castLE (X.collapsedWord_length_le m v.1)⟩ : (i : ι) × Fin (X.tierLength i)))
+    fun v w h => by
+      obtain ⟨i, p⟩ := v
+      obtain ⟨j, q⟩ := w
+      obtain ⟨rfl, h2⟩ := Sigma.mk.inj_iff.mp h
+      exact congrArg _ (Fin.castLE_injective _ (eq_of_heq h2))
+
+end CoordinateCollapse
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -862,20 +862,21 @@ theorem Representation.link_collapse_tensor (i j : ι) (r s : ℕ) :
 /-- **The OCP congruence**: collapsing a concatenation is isomorphic to
     collapsing the concatenation of the collapses — [jardine-heinz-2015]'s
     melody-merge law, by the classification theorem. -/
-noncomputable def Representation.collapseTensorIso :
-    (X ⊗ Y).collapse m ≅ (X.collapse m ⊗ Y.collapse m).collapse m :=
-  Representation.isoOfReaderEq
+noncomputable def Representation.collapseTensorFullIso :
+    MixedGraphCat.Iso ((X ⊗ Y).collapse m).obj
+      ((X.collapse m ⊗ Y.collapse m).collapse m).obj :=
+  Representation.fullIsoOfReaderEq
     (fun i => by
       rw [Representation.tierWord_collapse, Representation.tierWord_collapse,
         Representation.collapsedWord_tensor])
     (fun i j r s => Representation.link_collapse_tensor X m i j r s)
 
 /-- The OCP congruence as an equality of isomorphism classes: `collapse`
-    descends to the skeleton monoid. -/
-theorem Representation.toSkeleton_collapse_tensor :
-    toSkeleton ((X ⊗ Y).collapse m)
-      = toSkeleton ((X.collapse m ⊗ Y.collapse m).collapse m) :=
-  Quotient.sound ⟨Representation.collapseTensorIso X m⟩
+    descends to the class monoid. -/
+theorem Representation.cls_collapse_tensor :
+    Representation.cls ((X ⊗ Y).collapse m)
+      = Representation.cls ((X.collapse m ⊗ Y.collapse m).collapse m) :=
+  Quotient.sound ⟨Representation.collapseTensorFullIso X m⟩
 
 end Congruence
 

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -694,6 +694,22 @@ instance [Finite X.obj.V] : Finite (X.collapse m).obj.V :=
       obtain ⟨rfl, h2⟩ := Sigma.mk.inj_iff.mp h
       exact congrArg _ (Fin.castLE_injective _ (eq_of_heq h2))
 
+/-- The collapsed fiber at `i` is enumerated by its position range. -/
+noncomputable def Representation.collapseFiberEnum [Finite X.obj.V] (i : ι) :
+    Fin ((X.collapsedWord m i).length) ≃o (X.collapse m).fiber i := by
+  refine StrictMono.orderIsoOfSurjective (fun p => ⟨⟨i, p⟩, rfl⟩) (fun p q h => ⟨rfl, h⟩)
+    fun v => ?_
+  obtain ⟨⟨j, q⟩, hp⟩ := v
+  obtain rfl : j = i := hp
+  exact ⟨q, rfl⟩
+
+/-- **The collapse does what it says**: its tier words are the collapsed
+    words — destuttered at `m` (`Function.update_self`), untouched elsewhere. -/
+@[simp] theorem Representation.tierWord_collapse [Finite X.obj.V] (i : ι) :
+    (X.collapse m).tierWord i = X.collapsedWord m i := by
+  rw [Representation.tierWord_eq_ofFn (X.collapseFiberEnum m i)]
+  exact List.ofFn_getElem
+
 end CoordinateCollapse
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Collapse.lean
+++ b/Linglib/Phonology/Autosegmental/Collapse.lean
@@ -613,6 +613,8 @@ repoint its links through `runIdx`. Like `normalize` the result is a
 directly on the merged carrier. -/
 
 section CoordinateCollapse
+open CategoryTheory
+open scoped MonoidalCategory
 
 variable {ι : Type*} [DecidableEq ι] {τ : ι → Type*}
 variable (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
@@ -709,6 +711,19 @@ noncomputable def Representation.collapseFiberEnum [Finite X.obj.V] (i : ι) :
     (X.collapse m).tierWord i = X.collapsedWord m i := by
   rw [Representation.tierWord_eq_ofFn (X.collapseFiberEnum m i)]
   exact List.ofFn_getElem
+
+/-- The word half of the OCP congruence: collapsing a tensor computes the same
+    tier words as collapsing the tensor of the collapsed factors —
+    `OCP.collapse_append` lifted through the readers. -/
+theorem Representation.collapsedWord_tensor
+    {Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite X.obj.V] [Finite Y.obj.V] (i : ι) :
+    (X ⊗ Y).collapsedWord m i = (X.collapse m ⊗ Y.collapse m).collapsedWord m i := by
+  rcases eq_or_ne i m with rfl | h
+  · simp only [Representation.collapsedWord, Function.update_self,
+      Representation.tierWord_tensor, Representation.tierWord_collapse]
+    exact OCP.collapse_append _ _
+  · simp [Representation.collapsedWord, Function.update_of_ne h]
 
 end CoordinateCollapse
 

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.AR
+import Linglib.Phonology.Autosegmental.NormalForm
 
 /-!
 # The association hull
@@ -90,5 +91,98 @@ theorem AR.mem_links_hull {A : AR α β} {k j : ℕ} :
     (k, j) ∈ A.hull.links
       ↔ ∃ j₁ j₂, (k, j₁) ∈ A.links ∧ (k, j₂) ∈ A.links ∧ j₁ ≤ j ∧ j ≤ j₂ :=
   Graph.mem_links_hull A.inBounds
+
+/-! ### The hull in coordinates
+
+The interval closure on the graph foundation: tier-`m` nodes' links close to
+their hulls on each other tier; links not involving `m` pass through. -/
+
+section CoordinateHull
+
+variable {ι : Type*} [Finite ι] {τ : ι → Type*}
+variable (m : ι) (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V]
+
+/-- Close each tier-`m` node's association set to its interval hull on each
+    other tier. -/
+noncomputable def Representation.hull :
+    Representation (Sigma.fst : ((i : ι) × τ i) → ι) :=
+  Representation.ofData (fun i => X.tierWord i)
+    (fun i j p q =>
+      (i = m ∧ ∃ q₁ q₂, X.link i j p q₁ ∧ X.link i j p q₂ ∧ q₁ ≤ q ∧ q ≤ q₂) ∨
+        (i ≠ m ∧ j ≠ m ∧ X.link i j p q))
+
+instance : Finite (X.hull m).obj.V :=
+  inferInstanceAs (Finite ((_ : ι) × Fin _))
+
+@[simp] theorem Representation.tierWord_hull (i : ι) :
+    (X.hull m).tierWord i = X.tierWord i :=
+  Representation.tierWord_ofData i
+
+/-- Hull membership at the melody tier: `q` lies between two of `p`'s links. -/
+theorem Representation.link_hull_left {j : ι} (hj : m ≠ j) {p q : ℕ}
+    (hq : q < X.tierLength j) :
+    (X.hull m).link m j p q ↔
+      ∃ q₁ q₂, X.link m j p q₁ ∧ X.link m j p q₂ ∧ q₁ ≤ q ∧ q ≤ q₂ := by
+  unfold Representation.hull
+  rw [Representation.link_ofData]
+  constructor
+  · rintro ⟨-, -, -, (⟨-, hfl⟩ | ⟨hne, -, -⟩) | (⟨rfl, -⟩ | ⟨-, hne, -⟩)⟩
+    · exact hfl
+    · exact absurd rfl hne
+    · exact absurd rfl hj
+    · exact absurd rfl hne
+  · rintro ⟨q₁, q₂, h₁, h₂, hle₁, hle₂⟩
+    obtain ⟨hp, -, -⟩ := id h₁
+    refine ⟨hj, ?_, ?_, Or.inl (Or.inl ⟨rfl, q₁, q₂, h₁, h₂, hle₁, hle₂⟩)⟩
+    · simpa using hp
+    · simpa [Representation.length_tierWord] using hq
+
+/-- Links not involving the melody tier pass through the hull unchanged. -/
+theorem Representation.link_hull_of_ne {i j : ι} (hi : i ≠ m) (hj : j ≠ m) (p q : ℕ) :
+    (X.hull m).link i j p q ↔ X.link i j p q := by
+  unfold Representation.hull
+  rw [Representation.link_ofData]
+  constructor
+  · rintro ⟨-, -, -, (⟨rfl, -⟩ | ⟨-, -, hl⟩) | (⟨rfl, -⟩ | ⟨-, -, hl⟩)⟩
+    · exact absurd rfl hi
+    · exact hl
+    · exact absurd rfl hj
+    · exact X.link_symm hl
+  · intro hl
+    obtain ⟨hp, hq, -⟩ := id hl
+    refine ⟨?_, by simpa using hp, by simpa using hq,
+      Or.inl (Or.inr ⟨hi, hj, hl⟩)⟩
+    rintro rfl
+    exact X.not_link_self_tier i p q hl
+
+/-- Melody links flank themselves: the hull extends the link relation. -/
+theorem Representation.link_subset_hull {i j : ι} {p q : ℕ} (h : X.link i j p q) :
+    (X.hull m).link i j p q := by
+  obtain ⟨hp, hq, -⟩ := id h
+  rcases eq_or_ne m i with rfl | hi
+  · rcases eq_or_ne m j with rfl | hj
+    · exact absurd h (X.not_link_self_tier m p q)
+    · exact (X.link_hull_left m hj hq).mpr ⟨q, q, h, h, le_rfl, le_rfl⟩
+  · rcases eq_or_ne m j with rfl | hj
+    · exact (X.hull m).link_symm ((X.link_hull_left m hi hp).mpr
+        ⟨p, p, X.link_symm h, X.link_symm h, le_rfl, le_rfl⟩)
+    · exact (X.link_hull_of_ne m (Ne.symm hi) (Ne.symm hj) p q).mpr h
+
+/-- Per-node convexity at the melody tier: the defining property of the hull. -/
+theorem Representation.link_hull_convex {j : ι} (hj : m ≠ j) {p q₁ q q₂ : ℕ}
+    (hq : q < X.tierLength j)
+    (h₁ : (X.hull m).link m j p q₁) (h₂ : (X.hull m).link m j p q₂)
+    (hle₁ : q₁ ≤ q) (hle₂ : q ≤ q₂) : (X.hull m).link m j p q := by
+  have hlen : (X.hull m).tierLength j = X.tierLength j := by
+    rw [← Representation.length_tierWord, Representation.tierWord_hull,
+      Representation.length_tierWord]
+  obtain ⟨-, hb₁, -⟩ := id h₁
+  obtain ⟨-, hb₂, -⟩ := id h₂
+  rw [hlen] at hb₁ hb₂
+  obtain ⟨a₁, -, ha₁, -, hle₃, -⟩ := (X.link_hull_left m hj hb₁).mp h₁
+  obtain ⟨-, a₂, -, ha₂, -, hle₄⟩ := (X.link_hull_left m hj hb₂).mp h₂
+  exact (X.link_hull_left m hj hq).mpr ⟨a₁, a₂, ha₁, ha₂, by omega, by omega⟩
+
+end CoordinateHull
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -264,7 +264,7 @@ def Representation.junction (as : List α) (bs : List β) :
 
 instance (as : List α) (bs : List β) :
     Finite (Representation.junction as bs).obj.V :=
-  inferInstanceAs (Finite ((b : Bool) × Fin _))
+  inferInstanceAs (Finite ((_ : Bool) × Fin _))
 
 @[simp] theorem Representation.tierWord_junction_true (as : List α) (bs : List β) :
     (Representation.junction as bs).tierWord true = as :=

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -322,6 +322,43 @@ theorem Representation.isPlanar_junction_iff (as : List α) (bs : List β) :
       have h3 : (pw' : ℕ) < (pv' : ℕ) := hpw'v'
       omega
 
+/-! #### The planar local configurations -/
+
+/-- One-to-one association. -/
+def Representation.single (a : α) (b : β) := Representation.junction [a] [b]
+
+/-- A bare (unassociated) timing slot. -/
+def Representation.bare (b : β) := Representation.junction ([] : List α) [b]
+
+/-- A floating autosegment ([leben-1973]). -/
+def Representation.float (a : α) := Representation.junction [a] ([] : List β)
+
+/-- Several melody nodes on one slot. -/
+def Representation.contour (as : List α) (b : β) := Representation.junction as [b]
+
+/-- One melody node over several slots. -/
+def Representation.spread (a : α) (bs : List β) := Representation.junction [a] bs
+
+theorem Representation.isPlanar_single (a : α) (b : β) :
+    IsPlanar (Representation.single a b).obj.graph :=
+  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+
+theorem Representation.isPlanar_bare (b : β) :
+    IsPlanar (Representation.bare (α := α) b).obj.graph :=
+  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+
+theorem Representation.isPlanar_float (a : α) :
+    IsPlanar (Representation.float (β := β) a).obj.graph :=
+  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+
+theorem Representation.isPlanar_contour (as : List α) (b : β) :
+    IsPlanar (Representation.contour as b).obj.graph :=
+  (Representation.isPlanar_junction_iff _ _).mpr (Or.inr (by simp))
+
+theorem Representation.isPlanar_spread (a : α) (bs : List β) :
+    IsPlanar (Representation.spread a bs).obj.graph :=
+  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+
 end CoordinateJunction
 
 end AR

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -237,6 +237,93 @@ variable [DecidableEq α]
 theorem isCleanAR_contour : IsCleanAR (contour as b) ↔ OCP.IsClean as :=
   isCleanAR_junction
 
+/-! ### The junction in coordinates
+
+The complete association as a two-tier `Representation` (`Bool`-indexed:
+`true` the melody tier, `false` the timing tier), built by `ofData`; the
+No-Crossing keystone in the foundational path form. -/
+
+section CoordinateJunction
+
+universe u
+variable {α β : Type u}
+
+/-- The two-tier alphabet: melody labels over `true`, timing labels over
+    `false`. -/
+abbrev TwoTier (α β : Type u) : Bool → Type u := fun b => bif b then α else β
+
+/-- Complete many-to-many association of a melody onto a slot sequence, in
+    coordinates. -/
+def Representation.junction (as : List α) (bs : List β) :
+    Representation (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool) :=
+  Representation.ofData
+    (fun b => match b with
+      | true => (as : List (TwoTier α β true))
+      | false => (bs : List (TwoTier α β false)))
+    (fun i j p q => i = true ∧ j = false ∧ p < as.length ∧ q < bs.length)
+
+instance (as : List α) (bs : List β) :
+    Finite (Representation.junction as bs).obj.V :=
+  inferInstanceAs (Finite ((b : Bool) × Fin _))
+
+@[simp] theorem Representation.tierWord_junction_true (as : List α) (bs : List β) :
+    (Representation.junction as bs).tierWord true = as :=
+  Representation.tierWord_ofData true
+
+@[simp] theorem Representation.tierWord_junction_false (as : List α) (bs : List β) :
+    (Representation.junction as bs).tierWord false = bs :=
+  Representation.tierWord_ofData false
+
+/-- **The No-Crossing Constraint selects the one-sided junctions**: a complete
+    association is planar iff one side has at most one node — the one-to-many
+    `spread`, many-to-one `contour`, and degenerate cases. -/
+theorem Representation.isPlanar_junction_iff (as : List α) (bs : List β) :
+    IsPlanar (Representation.junction as bs).obj.graph ↔
+      as.length ≤ 1 ∨ bs.length ≤ 1 := by
+  constructor
+  · intro h
+    by_contra hc
+    rw [not_or] at hc
+    obtain ⟨ha, hb⟩ := hc
+    rw [Nat.not_le] at ha hb
+    exact h (v := ⟨true, ⟨0, show 0 < as.length by omega⟩⟩)
+      (v' := ⟨false, ⟨1, show 1 < bs.length by omega⟩⟩)
+      (w := ⟨true, ⟨1, show 1 < as.length by omega⟩⟩)
+      (w' := ⟨false, ⟨0, show 0 < bs.length by omega⟩⟩)
+      ⟨by simp, Or.inl ⟨rfl, rfl, show (0 : ℕ) < as.length by omega,
+        show (1 : ℕ) < bs.length by omega⟩⟩
+      ⟨by simp, Or.inl ⟨rfl, rfl, show (1 : ℕ) < as.length by omega,
+        show (0 : ℕ) < bs.length by omega⟩⟩
+      ⟨rfl, show (0 : ℕ) < 1 by omega⟩ ⟨rfl, show (0 : ℕ) < 1 by omega⟩
+  · rintro h ⟨bv, pv⟩ ⟨bv', pv'⟩ ⟨bw, pw⟩ ⟨bw', pw'⟩ hvv' hww' hvw hw'v'
+    obtain ⟨hbvw, hpvw⟩ := hvw
+    obtain ⟨hbw'v', hpw'v'⟩ := hw'v'
+    cases hbvw
+    cases hbw'v'
+    have hv' : bv' = !bv := by
+      rcases hvv' with ⟨hne, -⟩
+      cases bv <;> cases bv' <;> simp_all
+    subst hv'
+    rcases h with h | h <;> cases bv
+    · have h1 : (pv' : ℕ) < as.length := pv'.isLt
+      have h2 : (pw' : ℕ) < as.length := pw'.isLt
+      have h3 : (pw' : ℕ) < (pv' : ℕ) := hpw'v'
+      omega
+    · have h1 : (pv : ℕ) < as.length := pv.isLt
+      have h2 : (pw : ℕ) < as.length := pw.isLt
+      have h3 : (pv : ℕ) < (pw : ℕ) := hpvw
+      omega
+    · have h1 : (pv : ℕ) < bs.length := pv.isLt
+      have h2 : (pw : ℕ) < bs.length := pw.isLt
+      have h3 : (pv : ℕ) < (pw : ℕ) := hpvw
+      omega
+    · have h1 : (pv' : ℕ) < bs.length := pv'.isLt
+      have h2 : (pw' : ℕ) < bs.length := pw'.isLt
+      have h3 : (pw' : ℕ) < (pv' : ℕ) := hpw'v'
+      omega
+
+end CoordinateJunction
+
 end AR
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -237,6 +237,8 @@ variable [DecidableEq α]
 theorem isCleanAR_contour : IsCleanAR (contour as b) ↔ OCP.IsClean as :=
   isCleanAR_junction
 
+end AR
+
 /-! ### The junction in coordinates
 
 The complete association as a two-tier `Representation` (`Bool`-indexed:
@@ -360,7 +362,5 @@ theorem Representation.isPlanar_spread (a : α) (bs : List β) :
   (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
 end CoordinateJunction
-
-end AR
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -276,6 +276,23 @@ instance (as : List α) (bs : List β) :
     (Representation.junction as bs).tierWord false = bs :=
   Representation.tierWord_ofData false
 
+/-- Junction links are complete: every in-bounds melody–timing pair. -/
+theorem Representation.link_junction (as : List α) (bs : List β) {b b' : Bool}
+    {p q : ℕ} : (Representation.junction as bs).link b b' p q ↔
+      b = true ∧ b' = false ∧ p < as.length ∧ q < bs.length ∨
+        b = false ∧ b' = true ∧ p < bs.length ∧ q < as.length := by
+  unfold Representation.junction
+  rw [Representation.link_ofData]
+  constructor
+  · rintro ⟨hne, hp, hq, (⟨rfl, rfl, h1, h2⟩ | ⟨rfl, rfl, h1, h2⟩)⟩
+    · exact Or.inl ⟨rfl, rfl, h1, h2⟩
+    · exact Or.inr ⟨rfl, rfl, by simpa using hp, by simpa using hq⟩
+  · rintro (⟨rfl, rfl, h1, h2⟩ | ⟨rfl, rfl, h1, h2⟩)
+    · exact ⟨by decide, by simpa using h1, by simpa using h2,
+        Or.inl ⟨rfl, rfl, h1, h2⟩⟩
+    · exact ⟨by decide, by simpa using h1, by simpa using h2,
+        Or.inr ⟨rfl, rfl, h2, h1⟩⟩
+
 /-- **The No-Crossing Constraint selects the one-sided junctions**: a complete
     association is planar iff one side has at most one node — the one-to-many
     `spread`, many-to-one `contour`, and degenerate cases. -/

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -551,10 +551,15 @@ theorem hom_ext {X Y : Representation t} {f g : X ⟶ Y}
     (h : ∀ v, f.hom.toFun v = g.hom.toFun v) : f = g :=
   InducedCategory.hom_ext (MixedGraphCat.Hom.ext (funext h))
 
+universe u₁ u₂ u₃
+
 /-- Monoidal structure: morpheme concatenation as tensor, the empty
     representation as unit; the axiom class is closed under both by
-    `isTierOrdered_concat`/`noInternalAssoc_concat`. -/
-@[simps] instance instMonoidalStruct : MonoidalCategoryStruct (Representation t) where
+    `isTierOrdered_concat`/`noInternalAssoc_concat`. Universes pinned so the
+    unit's vertex type shares the objects' universe — autobinding would split
+    the instance head into an unusable `max`. -/
+@[simps] instance instMonoidalStruct {S : Type u₁} {ι : Type u₂} {t : S → ι} :
+    MonoidalCategoryStruct (Representation.{u₁, u₂, u₃} t) where
   tensorObj X Y :=
     ⟨MixedGraphCat.concat t X.obj Y.obj,
       MixedGraphCat.isTierOrdered_concat t X.property.1 Y.property.1,

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -108,10 +108,13 @@ def IsSaturated : Prop := ∀ v, ∃ w, G.edges.Adj v w
 def IsPlanar : Prop :=
   ∀ ⦃v v' w w'⦄, G.edges.Adj v v' → G.edges.Adj w w' → G.arcs.Adj v w → ¬ G.arcs.Adj w' v'
 
-/-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m` bear
-    distinct labels. Needs the labeling `ℓ` and its tier assignment `t`. -/
+/-- Axiom 6, the OCP on melody tier `m`: precedence-adjacent vertices on `m`
+    bear distinct labels. Adjacency is the covering relation of the arcs — in
+    the order-closed signature bare arcs relate all order-comparable pairs,
+    which would wrongly ban any repeated label anywhere on the tier. -/
 def IsOCPClean (ℓ : V → S) (t : S → ι) (m : ι) : Prop :=
-  ∀ ⦃v w⦄, G.arcs.Adj v w → t (ℓ v) = m → ℓ v ≠ ℓ w
+  ∀ ⦃v w⦄, G.arcs.Adj v w → (∀ u, ¬ (G.arcs.Adj v u ∧ G.arcs.Adj u w)) →
+    t (ℓ v) = m → ℓ v ≠ ℓ w
 
 end Axioms
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
+import Mathlib.CategoryTheory.Monoidal.Widesubcategory
 import Mathlib.CategoryTheory.MorphismProperty.Composition
 import Mathlib.Combinatorics.SimpleGraph.Sum
 import Mathlib.Logic.Relation
@@ -520,6 +521,27 @@ instance : (MixedGraphCat.precPreserving (S := S)).IsMultiplicative where
   id_mem _ := fun _ _ h => h
   comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
 
+/-- A full isomorphism's underlying morphism preserves precedence. -/
+theorem MixedGraphCat.Iso.toHom_precPreserving {X Y : MixedGraphCat S}
+    (e : MixedGraphCat.Iso X Y) : MixedGraphCat.precPreserving e.toHom :=
+  fun _ _ h => (e.arcs_iff _ _).mpr h
+
+/-- Concatenation of precedence-preserving morphisms preserves precedence:
+    blockwise from the factors, the bridge transported by labels. -/
+theorem MixedGraphCat.Hom.concatMap_precPreserving (t : S → ι)
+    {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
+    {f : MixedGraphCat.Hom X₁ Y₁} {g : MixedGraphCat.Hom X₂ Y₂}
+    (hf : MixedGraphCat.precPreserving f) (hg : MixedGraphCat.precPreserving g) :
+    MixedGraphCat.precPreserving (f.concatMap t g) := by
+  rintro (v | v) (w | w) h
+  · exact hf h
+  · show Y₁.tier t (f.toFun v) = Y₂.tier t (g.toFun w)
+    rw [show Y₁.tier t (f.toFun v) = X₁.tier t v from congrArg t (f.label_comp v),
+      show Y₂.tier t (g.toFun w) = X₂.tier t w from congrArg t (g.label_comp w)]
+    exact h
+  · exact h.elim
+  · exact hg h
+
 /-! ### The category of autosegmental representations -/
 
 variable (t : S → ι)
@@ -618,6 +640,27 @@ instance : MonoidalCategory (Representation t) :=
     (triangle := fun _ _ => hom_ext fun v => by
       repeat' rcases (v : _ ⊕ _) with v | v
       all_goals first | rfl | exact v.elim)
+
+/-- Precedence preservation on representations: the classical morphisms of the
+    theory, as a monoidally-stable wide subcategory of the broad category. -/
+def precPreserving : MorphismProperty (Representation t) :=
+  fun _ _ f => MixedGraphCat.precPreserving f.hom
+
+instance : (precPreserving (t := t)).IsMonoidalStable where
+  id_mem _ := fun _ _ h => h
+  comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
+  whiskerLeft X _ _ g hg :=
+    MixedGraphCat.Hom.concatMap_precPreserving t (fun _ _ h => h) hg
+  whiskerRight f hf Y :=
+    MixedGraphCat.Hom.concatMap_precPreserving t hf (fun _ _ h => h)
+  associator_hom_mem A B C :=
+    (MixedGraphCat.concatAssocIso t A.obj B.obj C.obj).toHom_precPreserving
+  associator_inv_mem A B C :=
+    (MixedGraphCat.concatAssocIso t A.obj B.obj C.obj).symm.toHom_precPreserving
+  leftUnitor_hom_mem A := (MixedGraphCat.emptyConcatIso t A.obj).toHom_precPreserving
+  leftUnitor_inv_mem A := (MixedGraphCat.emptyConcatIso t A.obj).symm.toHom_precPreserving
+  rightUnitor_hom_mem A := (MixedGraphCat.concatEmptyIso t A.obj).toHom_precPreserving
+  rightUnitor_inv_mem A := (MixedGraphCat.concatEmptyIso t A.obj).symm.toHom_precPreserving
 
 end Representation
 

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -649,9 +649,9 @@ def precPreserving : MorphismProperty (Representation t) :=
 instance : (precPreserving (t := t)).IsMonoidalStable where
   id_mem _ := fun _ _ h => h
   comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
-  whiskerLeft X _ _ g hg :=
+  whiskerLeft _ _ _ _ hg :=
     MixedGraphCat.Hom.concatMap_precPreserving t (fun _ _ h => h) hg
-  whiskerRight f hf Y :=
+  whiskerRight _ hf _ :=
     MixedGraphCat.Hom.concatMap_precPreserving t hf (fun _ _ h => h)
   associator_hom_mem A B C :=
     (MixedGraphCat.concatAssocIso t A.obj B.obj C.obj).toHom_precPreserving

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -371,6 +371,26 @@ def Hom.concatMap {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
     rintro (v | v)
     exacts [f.label_comp v, g.label_comp v]
 
+/-- Concatenation of isomorphisms: full-structure isos compose blockwise, the
+    bridge transported by label preservation. -/
+def Iso.concatCongr {X₁ Y₁ X₂ Y₂ : MixedGraphCat S} (e₁ : Iso X₁ Y₁) (e₂ : Iso X₂ Y₂) :
+    Iso (concat t X₁ X₂) (concat t Y₁ Y₂) where
+  toEquiv := e₁.toEquiv.sumCongr e₂.toEquiv
+  edges_iff v w := by
+    rcases v with v | v <;> rcases w with w | w
+    exacts [e₁.edges_iff v w, Iff.rfl, Iff.rfl, e₂.edges_iff v w]
+  arcs_iff v w := by
+    rcases v with v | v <;> rcases w with w | w
+    · exact e₁.arcs_iff v w
+    · show Y₁.tier t (e₁.toEquiv v) = Y₂.tier t (e₂.toEquiv w) ↔ X₁.tier t v = X₂.tier t w
+      rw [show Y₁.tier t (e₁.toEquiv v) = X₁.tier t v from congrArg t (e₁.label_comp v),
+        show Y₂.tier t (e₂.toEquiv w) = X₂.tier t w from congrArg t (e₂.label_comp w)]
+    · exact Iff.rfl
+    · exact e₂.arcs_iff v w
+  label_comp v := by
+    rcases v with v | v
+    exacts [e₁.label_comp v, e₂.label_comp v]
+
 /-! #### Associativity up to isomorphism ([jardine-heinz-2015] Theorem 3) -/
 
 /-- Concatenation is associative up to isomorphism, over `Equiv.sumAssoc`; the

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -127,6 +127,11 @@ noncomputable def Representation.linkRel [Finite X.obj.V] (i j : ι)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) : Prop :=
   X.obj.graph.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩)
 
+theorem Representation.linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
+    {q : Fin (X.tierLength j)} :
+    X.linkRel i j p q ↔
+      X.obj.graph.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩) := Iff.rfl
+
 /-- The normal form: `X` reindexed onto the canonical vertex type by pulling
     edges, arcs, and labels back along `vertexEquiv`. A `Representation` — the
     normal form is not a separate kind of object. -/
@@ -335,6 +340,42 @@ theorem Representation.tierWord_eq_ofFn {Z : Representation (Sigma.fst : ((i : �
       (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_natAdd i p)).trans
         (Representation.fiberLabel_symm_inr _))
 
+theorem Representation.fiberEnum_tensor (i : ι) :
+    (X ⊗ Y).fiberEnum i =
+      (Fin.castOrderIso (Representation.tierLength_tensor i)).trans
+        (Representation.tensorEnum i) :=
+  Subsingleton.elim _ _
+
+theorem Representation.vertexEquiv_tensor_of_lt {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
+    (h : (r : ℕ) < X.tierLength i) :
+    (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inl (X.vertexEquiv ⟨i, ⟨r, h⟩⟩) := by
+  show ((X ⊗ Y).fiberEnum i r).val = _
+  rw [Representation.fiberEnum_tensor, OrderIso.trans_apply,
+    show Fin.castOrderIso (Representation.tierLength_tensor (X := X) (Y := Y) i) r
+      = Fin.castAdd (Y.tierLength i) ⟨r, h⟩ from rfl,
+    Representation.tensorEnum_apply_castAdd]
+  rfl
+
+theorem Representation.vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
+    (h : X.tierLength i ≤ (r : ℕ)) :
+    (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inr (Y.vertexEquiv ⟨i,
+      ⟨(r : ℕ) - X.tierLength i, by
+        have h1 := r.isLt
+        have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
+          Representation.tierLength_tensor i
+        omega⟩⟩) := by
+  show ((X ⊗ Y).fiberEnum i r).val = _
+  rw [Representation.fiberEnum_tensor, OrderIso.trans_apply,
+    show Fin.castOrderIso (Representation.tierLength_tensor (X := X) (Y := Y) i) r
+      = Fin.natAdd (X.tierLength i) ⟨(r : ℕ) - X.tierLength i, by
+          have h1 := r.isLt
+          have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
+            Representation.tierLength_tensor i
+          omega⟩ from
+      Fin.ext (by simpa using (Nat.add_sub_cancel' h).symm),
+    Representation.tensorEnum_apply_natAdd]
+  rfl
+
 end TierWordTensor
 
 /-! ### Tier content of realizations -/
@@ -447,6 +488,49 @@ def Representation.Free [Finite X.obj.V]
     (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
     Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
+
+open scoped MonoidalCategory in
+/-- Tensor links are blockwise: within the left factor, or within the right
+    factor shifted by the left factor's tier lengths — no cross-factor links. -/
+theorem Representation.link_tensor {X Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite X.obj.V] [Finite Y.obj.V] (i j : ι) (p q : ℕ) :
+    (X ⊗ Y).link i j p q ↔
+      X.link i j p q ∨ X.tierLength i ≤ p ∧ X.tierLength j ≤ q ∧
+        Y.link i j (p - X.tierLength i) (q - X.tierLength j) := by
+  have h2i : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
+    Representation.tierLength_tensor i
+  have h2j : (X ⊗ Y).tierLength j = X.tierLength j + Y.tierLength j :=
+    Representation.tierLength_tensor j
+  constructor
+  · rintro ⟨hp, hq, hl⟩
+    rw [Representation.linkRel_def] at hl
+    rcases lt_or_ge p (X.tierLength i) with hpi | hpi <;>
+      rcases lt_or_ge q (X.tierLength j) with hqj | hqj
+    · rw [Representation.vertexEquiv_tensor_of_lt (h := hpi),
+        Representation.vertexEquiv_tensor_of_lt (h := hqj)] at hl
+      exact Or.inl ⟨hpi, hqj, by simpa [Representation.linkRel_def] using hl⟩
+    · rw [Representation.vertexEquiv_tensor_of_lt (h := hpi),
+        Representation.vertexEquiv_tensor_of_ge (h := hqj)] at hl
+      simp at hl
+    · rw [Representation.vertexEquiv_tensor_of_ge (h := hpi),
+        Representation.vertexEquiv_tensor_of_lt (h := hqj)] at hl
+      simp at hl
+    · rw [Representation.vertexEquiv_tensor_of_ge (h := hpi),
+        Representation.vertexEquiv_tensor_of_ge (h := hqj)] at hl
+      exact Or.inr ⟨hpi, hqj, by omega, by omega,
+        by simpa [Representation.linkRel_def] using hl⟩
+  · rintro (⟨hp, hq, hl⟩ | ⟨hpi, hqj, hp', hq', hl⟩)
+    · rw [Representation.linkRel_def] at hl
+      refine ⟨by omega, by omega, ?_⟩
+      rw [Representation.linkRel_def, Representation.vertexEquiv_tensor_of_lt (h := hp),
+        Representation.vertexEquiv_tensor_of_lt (h := hq)]
+      simpa using hl
+    · rw [Representation.linkRel_def] at hl
+      refine ⟨by omega, by omega, ?_⟩
+      rw [Representation.linkRel_def,
+        Representation.vertexEquiv_tensor_of_ge (h := by omega),
+        Representation.vertexEquiv_tensor_of_ge (h := by omega)]
+      simpa using hl
 
 end Factors
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -58,6 +58,11 @@ def Representation.fiber (X : Representation (Sigma.fst : ((i : ι) × τ i) →
 
 variable {X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
 
+/-- The `τ i` component of a fiber element, extracted from the labeling by
+    transporting along the fiber's tier-membership witness. -/
+def Representation.fiberLabel {i : ι} (v : X.fiber i) : τ i :=
+  v.property ▸ (X.obj.label v.val).2
+
 instance Representation.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
   Subtype.finite
 
@@ -88,6 +93,12 @@ noncomputable def Representation.vertexEquiv [Finite X.obj.V] :
   (Equiv.sigmaCongrRight
     (fun i : ι => (monoEquivOfFin (X.fiber i) rfl).toEquiv)).trans
     (Equiv.sigmaFiberEquiv (fun v : X.obj.V => (X.obj.label v).1))
+
+/-- The tier-`i` label word: the fiber's labels read off in ascending precedence
+    order — the tier content the normal form canonicalizes. -/
+noncomputable def Representation.tierWord [Finite X.obj.V] (i : ι) : List (τ i) :=
+  letI := Fintype.ofFinite (X.fiber i)
+  List.ofFn fun p : Fin (X.tierLen i) => X.fiberLabel (monoEquivOfFin (X.fiber i) rfl p)
 
 /-- The normal form: `X` reindexed onto the canonical vertex type by pulling
     edges, arcs, and labels back along `vertexEquiv`. A `Representation` — the

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -421,6 +421,15 @@ variable (F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
 def Representation.link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
   ∃ (hp : p < X.tierLength i) (hq : q < X.tierLength j), X.linkRel i j ⟨p, hp⟩ ⟨q, hq⟩
 
+open scoped Classical in
+/-- The two-tier reading of tiers `i` over `j`: each tier-`j` position's label
+    with the tier-`i` labels linked to it, in ascending order — the phonetic
+    interpretation of a melody tier over its backbone. -/
+noncomputable def Representation.linearize [Finite X.obj.V] (i j : ι) :
+    List (τ j × List (τ i)) :=
+  (X.tierWord j).zipIdx.map fun bq =>
+    (bq.1, ((X.tierWord i).zipIdx.filter fun ap => X.link i j ap.2 bq.2).map (·.1))
+
 /-- `F` occurs in `X` at per-tier offsets `o`: each tier word of `F` is the
     window of `X`'s at `o i`, and `F`'s links transport shifted. -/
 def Representation.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Finite.Sum
 import Mathlib.Data.Fintype.Sort
 import Mathlib.Data.Fintype.Sum
 import Mathlib.Logic.Equiv.Fin.Basic
+import Linglib.Core.Data.List.Factors
 import Linglib.Phonology.Autosegmental.MixedGraph
 
 /-!
@@ -547,6 +548,32 @@ def Representation.Free [Finite X.obj.V]
     (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
     Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
+
+/-- For a link-free factor, embedding reduces to independent per-tier infix
+    occurrences ([jardine-2019]'s link-free fragment). -/
+theorem Representation.factorEmbeds_iff_infix_of_link_free
+    {F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite F.obj.V] [Finite X.obj.V]
+    (hF : ∀ i j p q, ¬ F.link i j p q) :
+    F.FactorEmbeds X ↔ ∀ i, F.tierWord i <:+: X.tierWord i := by
+  constructor
+  · rintro ⟨o, hw, -⟩ i
+    rw [List.isInfix_iff_exists_offset]
+    rcases Nat.eq_zero_or_pos (F.tierWord i).length with hzero | hpos
+    · exact ⟨0, Nat.zero_le _, fun p hp => absurd hp (by omega)⟩
+    · have h0 := hw i 0 (by simpa [Representation.length_tierWord] using hpos)
+      refine ⟨o i, ?_, fun p hp => hw i p
+        (by simpa [Representation.length_tierWord] using hp)⟩
+      rcases List.getElem?_eq_some_iff.mp
+        (h0 ▸ (List.getElem?_eq_some_iff.mpr
+          ⟨by simpa [Representation.length_tierWord] using hpos, rfl⟩ :
+            (F.tierWord i)[0]? = some _)) with ⟨hb, -⟩
+      omega
+  · intro h
+    choose o ho using fun i => (List.isInfix_iff_exists_offset _ _).mp (h i)
+    refine ⟨o, fun i p hp => ?_, fun i j p q hl => absurd hl (hF i j p q)⟩
+    obtain ⟨-, hoff⟩ := ho i
+    exact hoff p (by simpa [Representation.length_tierWord] using hp)
 
 open scoped MonoidalCategory in
 /-- Tensor links are blockwise: within the left factor, or within the right

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -261,10 +261,12 @@ theorem Representation.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLen i)) 
         (.inr (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i) p)) := by
   simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_natAdd]
 
+omit [Finite X.obj.V] [Finite Y.obj.V] in
 theorem Representation.fiberLabel_symm_inl {i : ι} (w : X.fiber i) :
     Representation.fiberLabel ((Representation.fiberTensorEquiv (X := X) (Y := Y) i).symm
       (.inl w)) = X.fiberLabel w := rfl
 
+omit [Finite X.obj.V] [Finite Y.obj.V] in
 theorem Representation.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
     Representation.fiberLabel ((Representation.fiberTensorEquiv (X := X) (Y := Y) i).symm
       (.inr w)) = Y.fiberLabel w := rfl

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -44,7 +44,7 @@ namespace Autosegmental
 
 open CategoryTheory
 
-variable {ι : Type*} [LinearOrder ι] {τ : ι → Type*}
+variable {ι : Type*} {τ : ι → Type*}
 
 section NormalForm
 open scoped Classical

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -300,4 +300,49 @@ theorem Representation.tierWord_tensor (i : ι) :
 
 end TierWordTensor
 
+/-! ### Tier content of realizations -/
+
+section RealizeTierWord
+open scoped MonoidalCategory
+
+variable {S : Type*} {ι : Type*} {τ : ι → Type*}
+variable (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+
+instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
+    Finite (realize g₀ w).obj.V := by
+  induction w with
+  | nil => exact inferInstanceAs (Finite PEmpty)
+  | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (realize g₀ w).obj.V))
+
+instance : Finite ((𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).obj.V) :=
+  inferInstanceAs (Finite PEmpty)
+
+theorem Representation.tierWord_unit (i : ι) :
+    (𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).tierWord i = [] := by
+  haveI : IsEmpty ((𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).fiber i) :=
+    ⟨fun v => v.val.elim⟩
+  rw [Representation.tierWord_eq_ofFn (n := 0) ⟨Equiv.equivOfIsEmpty _ _, fun {a} => a.elim0⟩]
+  exact List.ofFn_zero
+
+/-- **Tier content is compositional**: the tier word of a realized string is the
+    concatenation of its symbols' tier words — [jardine-2019]'s tier projection
+    of `g`, and the bridge that places link-free ASL conditions per tier. -/
+theorem Representation.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+    (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
+  induction w with
+  | nil => exact Representation.tierWord_unit i
+  | cons a w ih =>
+    calc (realize g₀ (a :: w)).tierWord i
+        = (g₀ a ⊗ realize g₀ w).tierWord i := rfl
+      _ = (g₀ a).tierWord i ++ (realize g₀ w).tierWord i := Representation.tierWord_tensor i
+      _ = ((a :: w).map fun s => (g₀ s).tierWord i).flatten := by rw [ih]; rfl
+
+/-- The tier-`i` projection of a realization, as a free-monoid homomorphism:
+    each symbol contributes its primitive's tier word. -/
+noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
+    FreeMonoid S →* FreeMonoid (τ i) :=
+  FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
+
+end RealizeTierWord
+
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -74,6 +74,15 @@ variable {X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
 def Representation.fiberLabel {i : ι} (v : X.fiber i) : τ i :=
   v.property ▸ (X.obj.label v.val).2
 
+/-- The label of a fiber element decomposes as tier plus `fiberLabel`. -/
+theorem Representation.label_fiber {i : ι} (v : X.fiber i) :
+    X.obj.label v.val = ⟨i, X.fiberLabel v⟩ := by
+  obtain ⟨u, hu⟩ := v
+  show X.obj.label u = _
+  simp only [Representation.fiberLabel]
+  conv_lhs => rw [← Sigma.eta (X.obj.label u)]
+  exact Sigma.eq hu rfl
+
 instance Representation.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
   Subtype.finite
 
@@ -533,5 +542,87 @@ theorem Representation.link_tensor {X Y : Representation (Sigma.fst : ((i : ι) 
       simpa using hl
 
 end Factors
+
+/-! ### Classification: the readers determine the representation
+
+Two finite representations with the same tier words and the same links are
+isomorphic — `(tierWord, link)` is a complete invariant, [jardine-heinz-2015]'s
+tiered tuples as the classification of finite representations. -/
+
+section Classification
+open scoped MonoidalCategory
+
+variable {ι : Type*} {τ : ι → Type*}
+variable {X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+
+/-- The label of a canonical vertex sits on its own tier. -/
+theorem Representation.label_vertexEquiv [Finite X.obj.V] (i : ι)
+    (p : Fin (X.tierLength i)) : (X.obj.label (X.vertexEquiv ⟨i, p⟩)).1 = i :=
+  (X.fiberEnum i p).property
+
+theorem Representation.linkRel_iff_link [Finite X.obj.V] {i j : ι}
+    {p : Fin (X.tierLength i)} {q : Fin (X.tierLength j)} :
+    X.linkRel i j p q ↔ X.link i j (p : ℕ) (q : ℕ) :=
+  ⟨fun h => ⟨p.isLt, q.isLt, h⟩, fun ⟨_, _, h⟩ => by convert h⟩
+
+theorem Representation.tierWord_getElem [Finite X.obj.V] {i : ι}
+    (p : Fin (X.tierLength i)) :
+    (X.tierWord i)[(p : ℕ)]'(by simp) = X.fiberLabel (X.fiberEnum i p) := by
+  simp [Representation.tierWord]
+
+theorem Representation.label_normalize [Finite X.obj.V] {i : ι}
+    (p : Fin (X.tierLength i)) :
+    (X.normalize).obj.label ⟨i, p⟩ = ⟨i, X.fiberLabel (X.fiberEnum i p)⟩ :=
+  X.label_fiber (X.fiberEnum i p)
+
+theorem Representation.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ j)
+    (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
+    ¬ (X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨j, q⟩ := fun ha => by
+  have h2 := X.property.1.tier_eq ha
+  rw [show MixedGraphCat.tier Sigma.fst X.obj (X.vertexEquiv ⟨i, p⟩) = i from
+      X.label_vertexEquiv i p,
+    show MixedGraphCat.tier Sigma.fst X.obj (X.vertexEquiv ⟨j, q⟩) = j from
+      X.label_vertexEquiv j q] at h2
+  exact h h2
+
+/-- **Classification of finite representations**: equal tier words and equal
+    links give an isomorphism — the tuple reading is a complete invariant. -/
+noncomputable def Representation.isoOfReaderEq
+    {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite A.obj.V] [Finite B.obj.V]
+    (hw : ∀ i, A.tierWord i = B.tierWord i)
+    (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) : A ≅ B := by
+  have hlen : ∀ i, A.tierLength i = B.tierLength i := fun i => by
+    rw [← Representation.length_tierWord, hw, Representation.length_tierWord]
+  refine A.normalizeIso.symm ≪≫ Representation.mkIso ?_ ≪≫ B.normalizeIso
+  refine
+    { toEquiv := Equiv.sigmaCongrRight fun i => finCongr (hlen i)
+      edges_iff := fun v w => ?_
+      arcs_iff := fun v w => ?_
+      label_comp := fun v => ?_ }
+  · obtain ⟨i, p⟩ := v
+    obtain ⟨j, q⟩ := w
+    show B.normalize.obj.graph.edges.Adj ⟨i, Fin.cast (hlen i) p⟩ ⟨j, Fin.cast (hlen j) q⟩
+      ↔ A.normalize.obj.graph.edges.Adj ⟨i, p⟩ ⟨j, q⟩
+    rw [Representation.edges_normalize, Representation.edges_normalize,
+      Representation.linkRel_iff_link, Representation.linkRel_iff_link]
+    exact (hl i j p q).symm
+  · obtain ⟨i, p⟩ := v
+    obtain ⟨j, q⟩ := w
+    show B.normalize.obj.graph.arcs.Adj ⟨i, Fin.cast (hlen i) p⟩ ⟨j, Fin.cast (hlen j) q⟩
+      ↔ A.normalize.obj.graph.arcs.Adj ⟨i, p⟩ ⟨j, q⟩
+    rcases eq_or_ne i j with rfl | h
+    · rw [Representation.arcs_normalize, Representation.arcs_normalize]
+      exact (Fin.castOrderIso (hlen i)).lt_iff_lt
+    · exact iff_of_false (Representation.arcs_normalize_ne h _ _)
+        (Representation.arcs_normalize_ne h _ _)
+  · obtain ⟨i, p⟩ := v
+    show B.normalize.obj.label ⟨i, Fin.cast (hlen i) p⟩ = A.normalize.obj.label ⟨i, p⟩
+    rw [Representation.label_normalize, Representation.label_normalize]
+    congr 1
+    rw [← Representation.tierWord_getElem, ← Representation.tierWord_getElem]
+    simp only [hw, Fin.val_cast]
+
+end Classification
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -698,9 +698,9 @@ variable {ι : Type*} {τ : ι → Type*}
 
 /-- The representation presented by tier words `ws` and cross-tier links `L`
     (positions in ℕ coordinates; same-tier and out-of-bounds pairs are
-    ignored). Arcs are the ascending position order on each tier. -/
-def Representation.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop)
-    (hL : ∀ i p q, ¬ L i i p q) :
+    ignored, and same-tier links are excluded by construction). Arcs are the
+    ascending position order on each tier. -/
+def Representation.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop) :
     Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
   obj :=
     { V := (i : ι) × Fin (ws i).length
@@ -725,14 +725,13 @@ def Representation.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → �
     · exact Or.inr ⟨rfl, h⟩
 
 variable [Finite ι] {ws : ∀ i, List (τ i)} {L : ι → ι → ℕ → ℕ → Prop}
-variable {hL : ∀ i p q, ¬ L i i p q}
 
-instance : Finite (Representation.ofData ws L hL).obj.V :=
+instance : Finite (Representation.ofData ws L).obj.V :=
   inferInstanceAs (Finite ((i : ι) × Fin (ws i).length))
 
 /-- The canonical carrier's fiber at `i` is its position range. -/
 noncomputable def Representation.ofDataFiberEnum (i : ι) :
-    Fin ((ws i).length) ≃o (Representation.ofData ws L hL).fiber i := by
+    Fin ((ws i).length) ≃o (Representation.ofData ws L).fiber i := by
   refine StrictMono.orderIsoOfSurjective (fun p => ⟨⟨i, p⟩, rfl⟩) (fun p q h => ⟨rfl, h⟩)
     fun v => ?_
   obtain ⟨⟨j, q⟩, hp⟩ := v
@@ -740,36 +739,35 @@ noncomputable def Representation.ofDataFiberEnum (i : ι) :
   exact ⟨q, rfl⟩
 
 theorem Representation.tierLength_ofData (i : ι) :
-    (Representation.ofData ws L hL).tierLength i = (ws i).length := by
+    (Representation.ofData ws L).tierLength i = (ws i).length := by
   rw [← Representation.length_tierWord,
     Representation.tierWord_eq_ofFn (Representation.ofDataFiberEnum i), List.length_ofFn]
 
 theorem Representation.fiberEnum_ofData (i : ι) :
-    (Representation.ofData ws L hL).fiberEnum i =
+    (Representation.ofData ws L).fiberEnum i =
       (Fin.castOrderIso (Representation.tierLength_ofData i)).trans
         (Representation.ofDataFiberEnum i) :=
   Subsingleton.elim _ _
 
 theorem Representation.vertexEquiv_ofData {i : ι}
-    (r : Fin ((Representation.ofData ws L hL).tierLength i)) :
-    (Representation.ofData ws L hL).vertexEquiv ⟨i, r⟩ =
+    (r : Fin ((Representation.ofData ws L).tierLength i)) :
+    (Representation.ofData ws L).vertexEquiv ⟨i, r⟩ =
       ⟨i, Fin.cast (Representation.tierLength_ofData i) r⟩ := by
-  show ((Representation.ofData ws L hL).fiberEnum i r).val = _
+  show ((Representation.ofData ws L).fiberEnum i r).val = _
   rw [Representation.fiberEnum_ofData]
   rfl
 
 /-- `ofData` reads back its words. -/
 @[simp] theorem Representation.tierWord_ofData (i : ι) :
-    (Representation.ofData ws L hL).tierWord i = ws i := by
+    (Representation.ofData ws L).tierWord i = ws i := by
   rw [Representation.tierWord_eq_ofFn (Representation.ofDataFiberEnum i)]
   exact List.ofFn_getElem
 
 /-- `ofData` reads back its links, symmetrized, on in-bounds cross-tier
     pairs. -/
 theorem Representation.link_ofData (i j : ι) (p q : ℕ) :
-    (Representation.ofData ws L hL).link i j p q ↔
-      i ≠ j ∧ ∃ (hp : p < (ws i).length) (hq : q < (ws j).length),
-        (L i j p q ∨ L j i q p) := by
+    (Representation.ofData ws L).link i j p q ↔
+      i ≠ j ∧ p < (ws i).length ∧ q < (ws j).length ∧ (L i j p q ∨ L j i q p) := by
   constructor
   · rintro ⟨hp, hq, hl⟩
     rw [Representation.linkRel_def, Representation.vertexEquiv_ofData,
@@ -779,9 +777,9 @@ theorem Representation.link_ofData (i j : ι) (p q : ℕ) :
     have hq' : q < (ws j).length := Representation.tierLength_ofData j ▸ hq
     exact ⟨hne, hp', hq', by simpa using hor⟩
   · rintro ⟨hij, hp, hq, hor⟩
-    have hp' : p < (Representation.ofData ws L hL).tierLength i := by
+    have hp' : p < (Representation.ofData ws L).tierLength i := by
       rw [← Representation.length_tierWord, Representation.tierWord_ofData]; exact hp
-    have hq' : q < (Representation.ofData ws L hL).tierLength j := by
+    have hq' : q < (Representation.ofData ws L).tierLength j := by
       rw [← Representation.length_tierWord, Representation.tierWord_ofData]; exact hq
     refine ⟨hp', hq', ?_⟩
     rw [Representation.linkRel_def, Representation.vertexEquiv_ofData,

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -203,6 +203,8 @@ def Representation.fiberTensorEquiv (i : ι) :
 
 variable [Finite X.obj.V] [Finite Y.obj.V]
 
+attribute [local instance] Fintype.ofFinite
+
 theorem Representation.tierLen_tensor (i : ι) :
     (X ⊗ Y).tierLen i = X.tierLen i + Y.tierLen i := by
   letI := Fintype.ofFinite ((X ⊗ Y).fiber i)
@@ -246,6 +248,53 @@ noncomputable def Representation.tensorEnum (i : ι) :
       rw [finSumFinEquiv_symm_apply_natAdd, finSumFinEquiv_symm_apply_natAdd]
       exact (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i)).strictMono
         (by simp only [Fin.lt_def, Fin.val_natAdd] at hpq ⊢; omega)
+
+theorem Representation.tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLen i)) :
+    Representation.tensorEnum i (Fin.castAdd (Y.tierLen i) p) =
+      (Representation.fiberTensorEquiv i).symm
+        (.inl (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i) p)) := by
+  simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_castAdd]
+
+theorem Representation.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLen i)) :
+    Representation.tensorEnum i (Fin.natAdd (X.tierLen i) p) =
+      (Representation.fiberTensorEquiv (X := X) i).symm
+        (.inr (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i) p)) := by
+  simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_natAdd]
+
+theorem Representation.fiberLabel_symm_inl {i : ι} (w : X.fiber i) :
+    Representation.fiberLabel ((Representation.fiberTensorEquiv (X := X) (Y := Y) i).symm
+      (.inl w)) = X.fiberLabel w := rfl
+
+theorem Representation.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
+    Representation.fiberLabel ((Representation.fiberTensorEquiv (X := X) (Y := Y) i).symm
+      (.inr w)) = Y.fiberLabel w := rfl
+
+/-- Any monotone enumeration computes the tier word. -/
+theorem Representation.tierWord_eq_ofFn {Z : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite Z.obj.V] {i : ι} {n : ℕ} (e : Fin n ≃o Z.fiber i) :
+    Z.tierWord i = List.ofFn fun p => Z.fiberLabel (e p) := by
+  have hn : Z.tierLen i = n := by
+    simpa [Representation.tierLen] using (Fintype.card_congr e.toEquiv).symm
+  subst hn
+  rw [Subsingleton.elim e (monoEquivOfFin (Z.fiber i) rfl)]
+  rfl
+
+/-- **Concatenation appends tier content**: the tier word of a tensor is the
+    factors' tier words in sequence — the tuple presentation of
+    [jardine-heinz-2015]'s Definition 2, recovered as a theorem about normal
+    forms. -/
+theorem Representation.tierWord_tensor (i : ι) :
+    (X ⊗ Y).tierWord i = X.tierWord i ++ Y.tierWord i := by
+  rw [Representation.tierWord_eq_ofFn (Representation.tensorEnum i), List.ofFn_add]
+  congr 1
+  · rw [Representation.tierWord_eq_ofFn (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i))]
+    exact congrArg List.ofFn (funext fun p =>
+      (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_castAdd i p)).trans
+        (Representation.fiberLabel_symm_inl _))
+  · rw [Representation.tierWord_eq_ofFn (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i))]
+    exact congrArg List.ofFn (funext fun p =>
+      (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_natAdd i p)).trans
+        (Representation.fiberLabel_symm_inr _))
 
 end TierWordTensor
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.CategoryTheory.Monoidal.Skeleton
+import Mathlib.Data.Fintype.Sort
+import Linglib.Phonology.Autosegmental.MixedGraph
+
+/-!
+# Normal forms of autosegmental representations
+
+Every finite representation is isomorphic to its **normal form**: the same
+representation reindexed onto the canonical vertex type `(i : ι) × Fin nᵢ`,
+each tier fiber enumerated in ascending precedence order
+(`IsTierOrdered.isStrictTotalOrder` → `linearOrderOfSTO` → `monoEquivOfFin`).
+The normal form is a `Representation` — not a separate carrier — and
+`normalizeIso` is definitional: `normalize` pulls the graph back along the
+enumeration equivalence.
+
+Strictness lives where Mac Lane coherence puts it: on the skeleton. The monoid
+of isomorphism classes `Skeleton (Representation t)` carries concatenation with
+associativity on the nose (`CategoryTheory.Monoidal.Skeleton`), and
+`toSkeleton_normalize` says `normalize` chooses representatives.
+
+## Main definitions
+
+* `Representation.fiber`, `Representation.vertexEquiv`: the tier fibers of a
+  finite representation and the canonical enumeration of its vertex type.
+* `Representation.normalize`: the normal form, a `Representation` on the
+  canonical vertex type.
+
+## Main results
+
+* `Representation.normalizeIso`: `X.normalize ≅ X`.
+* `Representation.arcs_normalize`: on normal forms the arcs are the ascending
+  position order — the classification content, [jardine-heinz-2015]'s tiered
+  presentation recovered as a theorem.
+* `Representation.toSkeleton_normalize`: normal forms represent their
+  isomorphism class in the skeleton monoid.
+-/
+
+namespace Autosegmental
+
+open CategoryTheory
+
+variable {ι : Type*} [LinearOrder ι] {τ : ι → Type*}
+
+section NormalForm
+open scoped Classical
+
+/-- Fiber of the tier coloring at `i`: vertices of `X.obj` labelled to tier `i`.
+    Under `IsTierOrdered` its arcs form a strict total order, and under
+    `Finite X.obj.V` it is finite — the two ingredients `monoEquivOfFin`
+    needs to enumerate the fiber as `Fin _`. -/
+def Representation.fiber (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) (i : ι) :
+    Type _ := {v : X.obj.V // (X.obj.label v).1 = i}
+
+variable {X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+
+instance Representation.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
+  Subtype.finite
+
+/-- The arcs restricted to a tier fiber form a strict total order — the classed
+    form of Axioms 1–2 applied to the tier coloring `Sigma.fst`. -/
+instance Representation.fiber.instIsStrictTotalOrder (i : ι) :
+    IsStrictTotalOrder (X.fiber i) (fun a b => X.obj.graph.arcs.Adj a.val b.val) :=
+  X.property.1.isStrictTotalOrder i
+
+/-- Classical linear order on the fiber, from `IsStrictTotalOrder` via
+    `linearOrderOfSTO`. -/
+noncomputable instance Representation.fiber.instLinearOrder (i : ι) :
+    LinearOrder (X.fiber i) := by
+  classical
+  exact linearOrderOfSTO (fun a b : X.fiber i => X.obj.graph.arcs.Adj a.val b.val)
+
+/-- The number of tier-`i` vertices. -/
+noncomputable def Representation.tierLen (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    [Finite X.obj.V] (i : ι) : ℕ :=
+  letI := Fintype.ofFinite (X.fiber i)
+  Fintype.card (X.fiber i)
+
+/-- The canonical enumeration of a finite representation's vertex type: tier
+    fibers in ascending precedence order, assembled over the tier index. -/
+noncomputable def Representation.vertexEquiv [Finite X.obj.V] :
+    ((i : ι) × Fin (X.tierLen i)) ≃ X.obj.V :=
+  letI : ∀ i : ι, Fintype (X.fiber i) := fun _ => Fintype.ofFinite _
+  (Equiv.sigmaCongrRight
+    (fun i : ι => (monoEquivOfFin (X.fiber i) rfl).toEquiv)).trans
+    (Equiv.sigmaFiberEquiv (fun v : X.obj.V => (X.obj.label v).1))
+
+/-- The normal form: `X` reindexed onto the canonical vertex type by pulling
+    edges, arcs, and labels back along `vertexEquiv`. A `Representation` — the
+    normal form is not a separate kind of object. -/
+noncomputable def Representation.normalize
+    (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V] :
+    Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+  obj :=
+    { V := (i : ι) × Fin (X.tierLen i)
+      graph :=
+        { edges := X.obj.graph.edges.comap X.vertexEquiv
+          arcs := ⟨fun v w => X.obj.graph.arcs.Adj (X.vertexEquiv v) (X.vertexEquiv w)⟩ }
+      label := fun v => X.obj.label (X.vertexEquiv v) }
+  property :=
+    ⟨⟨fun _ _ h => X.property.1.tier_eq h,
+      fun _ _ hne htier => X.property.1.total (fun hv => hne (X.vertexEquiv.injective hv)) htier,
+      fun _ h => X.property.1.irrefl _ h,
+      fun _ _ _ huv hvw => X.property.1.trans huv hvw⟩,
+     fun _ _ hadj harc => X.property.2 hadj harc⟩
+
+/-- The normal form is isomorphic to the original — definitionally, since
+    `normalize` is a pullback along `vertexEquiv`. -/
+noncomputable def Representation.normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
+  Representation.mkIso
+    { toEquiv := X.vertexEquiv
+      edges_iff := fun _ _ => Iff.rfl
+      arcs_iff := fun _ _ => Iff.rfl
+      label_comp := fun _ => rfl }
+
+/-- Normal forms represent their isomorphism class: `normalize` is a section of
+    the quotient onto the skeleton, where the monoid of iso classes carries
+    strictly associative concatenation (`CategoryTheory.Monoidal.Skeleton`). -/
+theorem Representation.toSkeleton_normalize [Finite X.obj.V] :
+    toSkeleton (X.normalize) = toSkeleton X :=
+  Quotient.sound ⟨X.normalizeIso⟩
+
+end NormalForm
+
+end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.CategoryTheory.Monoidal.Skeleton
+import Mathlib.Data.Finite.Sigma
 import Mathlib.Data.Finite.Sum
 import Mathlib.Data.Fintype.Sort
 import Mathlib.Data.Fintype.Sum
@@ -683,5 +684,110 @@ noncomputable def Representation.isoOfReaderEq
   Representation.mkIso (Representation.fullIsoOfReaderEq hw hl)
 
 end Classification
+
+/-! ### Building representations from tuple data
+
+The constructor inverse to the readers: tier words plus a position-coordinate
+link relation determine a representation on the canonical carrier. This is the
+tiered presentation as a *function* — the essential-surjectivity direction of
+the classification. -/
+
+section OfData
+
+variable {ι : Type*} {τ : ι → Type*}
+
+/-- The representation presented by tier words `ws` and cross-tier links `L`
+    (positions in ℕ coordinates; same-tier and out-of-bounds pairs are
+    ignored). Arcs are the ascending position order on each tier. -/
+def Representation.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop)
+    (hL : ∀ i p q, ¬ L i i p q) :
+    Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+  obj :=
+    { V := (i : ι) × Fin (ws i).length
+      graph :=
+        { edges :=
+            { Adj := fun v w => v.1 ≠ w.1 ∧
+                (L v.1 w.1 v.2 w.2 ∨ L w.1 v.1 w.2 v.2)
+              symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.symm⟩⟩
+              loopless := ⟨fun _ h => h.1 rfl⟩ }
+          arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩ }
+      label := fun v => ⟨v.1, (ws v.1)[v.2]⟩ }
+  property := by
+    refine ⟨⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => lt_irrefl _ h.2,
+      fun u v w huv hvw => ⟨huv.1.trans hvw.1, huv.2.trans hvw.2⟩⟩,
+      fun v w hadj harc => hadj.1 harc.1⟩
+    obtain ⟨i, p⟩ := v
+    obtain ⟨j, q⟩ := w
+    obtain rfl : i = j := htier
+    rcases Nat.lt_trichotomy (p : ℕ) (q : ℕ) with h | h | h
+    · exact Or.inl ⟨rfl, h⟩
+    · exact absurd (by rw [Fin.ext h]) hne
+    · exact Or.inr ⟨rfl, h⟩
+
+variable [Finite ι] {ws : ∀ i, List (τ i)} {L : ι → ι → ℕ → ℕ → Prop}
+variable {hL : ∀ i p q, ¬ L i i p q}
+
+instance : Finite (Representation.ofData ws L hL).obj.V :=
+  inferInstanceAs (Finite ((i : ι) × Fin (ws i).length))
+
+/-- The canonical carrier's fiber at `i` is its position range. -/
+noncomputable def Representation.ofDataFiberEnum (i : ι) :
+    Fin ((ws i).length) ≃o (Representation.ofData ws L hL).fiber i := by
+  refine StrictMono.orderIsoOfSurjective (fun p => ⟨⟨i, p⟩, rfl⟩) (fun p q h => ⟨rfl, h⟩)
+    fun v => ?_
+  obtain ⟨⟨j, q⟩, hp⟩ := v
+  obtain rfl : j = i := hp
+  exact ⟨q, rfl⟩
+
+theorem Representation.tierLength_ofData (i : ι) :
+    (Representation.ofData ws L hL).tierLength i = (ws i).length := by
+  rw [← Representation.length_tierWord,
+    Representation.tierWord_eq_ofFn (Representation.ofDataFiberEnum i), List.length_ofFn]
+
+theorem Representation.fiberEnum_ofData (i : ι) :
+    (Representation.ofData ws L hL).fiberEnum i =
+      (Fin.castOrderIso (Representation.tierLength_ofData i)).trans
+        (Representation.ofDataFiberEnum i) :=
+  Subsingleton.elim _ _
+
+theorem Representation.vertexEquiv_ofData {i : ι}
+    (r : Fin ((Representation.ofData ws L hL).tierLength i)) :
+    (Representation.ofData ws L hL).vertexEquiv ⟨i, r⟩ =
+      ⟨i, Fin.cast (Representation.tierLength_ofData i) r⟩ := by
+  show ((Representation.ofData ws L hL).fiberEnum i r).val = _
+  rw [Representation.fiberEnum_ofData]
+  rfl
+
+/-- `ofData` reads back its words. -/
+@[simp] theorem Representation.tierWord_ofData (i : ι) :
+    (Representation.ofData ws L hL).tierWord i = ws i := by
+  rw [Representation.tierWord_eq_ofFn (Representation.ofDataFiberEnum i)]
+  exact List.ofFn_getElem
+
+/-- `ofData` reads back its links, symmetrized, on in-bounds cross-tier
+    pairs. -/
+theorem Representation.link_ofData (i j : ι) (p q : ℕ) :
+    (Representation.ofData ws L hL).link i j p q ↔
+      i ≠ j ∧ ∃ (hp : p < (ws i).length) (hq : q < (ws j).length),
+        (L i j p q ∨ L j i q p) := by
+  constructor
+  · rintro ⟨hp, hq, hl⟩
+    rw [Representation.linkRel_def, Representation.vertexEquiv_ofData,
+      Representation.vertexEquiv_ofData] at hl
+    obtain ⟨hne, hor⟩ := hl
+    have hp' : p < (ws i).length := Representation.tierLength_ofData i ▸ hp
+    have hq' : q < (ws j).length := Representation.tierLength_ofData j ▸ hq
+    exact ⟨hne, hp', hq', by simpa using hor⟩
+  · rintro ⟨hij, hp, hq, hor⟩
+    have hp' : p < (Representation.ofData ws L hL).tierLength i := by
+      rw [← Representation.length_tierWord, Representation.tierWord_ofData]; exact hp
+    have hq' : q < (Representation.ofData ws L hL).tierLength j := by
+      rw [← Representation.length_tierWord, Representation.tierWord_ofData]; exact hq
+    refine ⟨hp', hq', ?_⟩
+    rw [Representation.linkRel_def, Representation.vertexEquiv_ofData,
+      Representation.vertexEquiv_ofData]
+    exact ⟨hij, by simpa using hor⟩
+
+end OfData
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
-import Mathlib.CategoryTheory.Monoidal.Skeleton
 import Mathlib.Data.Finite.Sum
 import Mathlib.Data.Fintype.Sort
 import Mathlib.Data.Fintype.Sum
@@ -22,10 +21,10 @@ The normal form is a `Representation` — not a separate carrier — and
 `normalizeIso` is definitional: `normalize` pulls the graph back along the
 enumeration equivalence.
 
-Strictness lives where Mac Lane coherence puts it: on the skeleton. The monoid
-of isomorphism classes `Skeleton (Representation t)` carries concatenation with
-associativity on the nose (`CategoryTheory.Monoidal.Skeleton`), and
-`toSkeleton_normalize` says `normalize` chooses representatives.
+Strictness lives on isomorphism classes: `Representation.IsoClass` carries
+concatenation with associativity on the nose — full-structure classes, since
+broad categorical isomorphism forgets the arcs and is too coarse to preserve
+tier words. `cls_normalize` says `normalize` chooses representatives.
 
 ## Main definitions
 
@@ -36,7 +35,7 @@ associativity on the nose (`CategoryTheory.Monoidal.Skeleton`), and
 * `Representation.normalize`: the normal form, a `Representation` on the
   canonical vertex type.
 * `realize`, `realizeHom`, `tierProj`: [jardine-2019]'s `g` as iterated tensor,
-  as a free-monoid hom into the skeleton, and its per-tier projections.
+  as a free-monoid hom into the class monoid, and its per-tier projections.
 
 ## Main results
 
@@ -47,8 +46,8 @@ associativity on the nose (`CategoryTheory.Monoidal.Skeleton`), and
 * `Representation.tierWord_tensor`, `Representation.tierWord_realize`:
   concatenation appends tier words; tier content of a realization is
   compositional.
-* `Representation.toSkeleton_normalize`: normal forms represent their
-  isomorphism class in the skeleton monoid.
+* `Representation.IsoClass`, `Representation.cls_normalize`: the concatenation
+  monoid of isomorphism classes; normal forms represent their class.
 -/
 
 namespace Autosegmental
@@ -56,6 +55,55 @@ namespace Autosegmental
 open CategoryTheory
 
 variable {ι : Type*} {τ : ι → Type*}
+
+/-! ### The monoid of representations up to isomorphism
+
+Full-structure isomorphism classes of representations, with strictly
+associative concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as a
+`Monoid`. Full isos, not the broad categorical `≅` (which forgets arcs), are
+the theory's identity criterion: they preserve tier orders, so the tuple
+readers descend to classes. -/
+
+section IsoClasses
+open scoped MonoidalCategory
+
+/-- Full-structure isomorphism as an equivalence of representations. -/
+def Representation.isoSetoid :
+    Setoid (Representation (Sigma.fst : ((i : ι) × τ i) → ι)) where
+  r A B := Nonempty (MixedGraphCat.Iso A.obj B.obj)
+  iseqv := ⟨fun _ => ⟨MixedGraphCat.Iso.refl _⟩, fun ⟨e⟩ => ⟨e.symm⟩,
+    fun ⟨e⟩ ⟨f⟩ => ⟨e.trans f⟩⟩
+
+/-- Isomorphism classes of representations — the carrier of the concatenation
+    monoid of ARs. -/
+def Representation.IsoClass (ι : Type*) (τ : ι → Type*) :=
+  Quotient (Representation.isoSetoid (ι := ι) (τ := τ))
+
+/-- The class of a representation. -/
+def Representation.cls (A : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    Representation.IsoClass ι τ :=
+  Quotient.mk Representation.isoSetoid A
+
+instance : Monoid (Representation.IsoClass ι τ) where
+  mul := Quotient.map₂ (· ⊗ ·)
+    fun _ _ ⟨e₁⟩ _ _ ⟨e₂⟩ => ⟨MixedGraphCat.Iso.concatCongr _ e₁ e₂⟩
+  one := Representation.cls (𝟙_ _)
+  mul_assoc := by
+    rintro ⟨A⟩ ⟨B⟩ ⟨C⟩
+    exact Quotient.sound ⟨MixedGraphCat.concatAssocIso _ A.obj B.obj C.obj⟩
+  one_mul := by
+    rintro ⟨A⟩
+    exact Quotient.sound ⟨MixedGraphCat.emptyConcatIso _ A.obj⟩
+  mul_one := by
+    rintro ⟨A⟩
+    exact Quotient.sound ⟨MixedGraphCat.concatEmptyIso _ A.obj⟩
+
+/-- Concatenation of classes is the class of the tensor. -/
+theorem Representation.cls_tensor
+    (A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    Representation.cls (A ⊗ B) = Representation.cls A * Representation.cls B := rfl
+
+end IsoClasses
 
 section NormalForm
 open scoped Classical
@@ -160,14 +208,18 @@ noncomputable def Representation.normalize
       fun _ _ _ huv hvw => X.property.1.trans huv hvw⟩,
      fun _ _ hadj harc => X.property.2 hadj harc⟩
 
-/-- The normal form is isomorphic to the original — definitionally, since
-    `normalize` is a pullback along `vertexEquiv`. -/
+/-- The normal form is fully isomorphic to the original — definitionally,
+    since `normalize` is a pullback along `vertexEquiv`. -/
+noncomputable def Representation.normalizeFullIso [Finite X.obj.V] :
+    MixedGraphCat.Iso (X.normalize).obj X.obj where
+  toEquiv := X.vertexEquiv
+  edges_iff _ _ := Iff.rfl
+  arcs_iff _ _ := Iff.rfl
+  label_comp _ := rfl
+
+/-- The normal form is isomorphic to the original. -/
 noncomputable def Representation.normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
-  Representation.mkIso
-    { toEquiv := X.vertexEquiv
-      edges_iff := fun _ _ => Iff.rfl
-      arcs_iff := fun _ _ => Iff.rfl
-      label_comp := fun _ => rfl }
+  Representation.mkIso X.normalizeFullIso
 
 /-- On normal forms the edges are exactly `linkRel` — with `arcs_normalize`,
     the complete tuple reading of the normal form. -/
@@ -183,12 +235,11 @@ theorem Representation.arcs_normalize [Finite X.obj.V] (i : ι)
     (X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ↔ p < q :=
   (X.fiberEnum i).lt_iff_lt
 
-/-- Normal forms represent their isomorphism class: `normalize` is a section of
-    the quotient onto the skeleton, where the monoid of iso classes carries
-    strictly associative concatenation (`CategoryTheory.Monoidal.Skeleton`). -/
-theorem Representation.toSkeleton_normalize [Finite X.obj.V] :
-    toSkeleton (X.normalize) = toSkeleton X :=
-  Quotient.sound ⟨X.normalizeIso⟩
+/-- Normal forms represent their isomorphism class: `normalize` is a section
+    of the quotient onto `Representation.IsoClass`. -/
+theorem Representation.cls_normalize [Finite X.obj.V] :
+    Representation.cls (X.normalize) = Representation.cls X :=
+  Quotient.sound ⟨X.normalizeFullIso⟩
 
 end NormalForm
 
@@ -215,13 +266,13 @@ noncomputable def realize (g₀ : S → Representation (Sigma.fst : ((i : ι) ×
 @[simp] theorem realize_cons (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
     (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
 
-/-- The realization as a free-monoid homomorphism into the skeleton monoid —
-    the string→AR monoid hom, with associativity strict on iso classes
-    (`CategoryTheory.Monoidal.Skeleton`). -/
+/-- The realization as a free-monoid homomorphism into the monoid of
+    isomorphism classes — the string→AR monoid hom, with associativity strict
+    on classes. -/
 noncomputable def realizeHom
     (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    FreeMonoid S →* Skeleton (Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :=
-  FreeMonoid.lift (toSkeleton ∘ g₀)
+    FreeMonoid S →* Representation.IsoClass ι τ :=
+  FreeMonoid.lift (Representation.cls ∘ g₀)
 
 end Realize
 
@@ -431,14 +482,14 @@ noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
 
 /-- `realizeHom` packages `realize`: on a word it is the class of the realized
     representation. -/
-theorem realizeHom_ofList [∀ s, Finite (g₀ s).obj.V] (w : List S) :
-    realizeHom g₀ (FreeMonoid.ofList w) = toSkeleton (realize g₀ w) := by
+theorem realizeHom_ofList (w : List S) :
+    realizeHom g₀ (FreeMonoid.ofList w) = Representation.cls (realize g₀ w) := by
   induction w with
   | nil => rfl
   | cons a w ih =>
     rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
-      map_mul, ih, realize_cons]
-    exact (CategoryTheory.Skeleton.toSkeleton_tensorObj _ _).symm
+      map_mul, ih, realize_cons, Representation.cls_tensor]
+    rfl
 
 /-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
 theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
@@ -585,16 +636,17 @@ theorem Representation.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ 
       X.label_vertexEquiv j q] at h2
   exact h h2
 
-/-- **Classification of finite representations**: equal tier words and equal
-    links give an isomorphism — the tuple reading is a complete invariant. -/
-noncomputable def Representation.isoOfReaderEq
+/-- The classification isomorphism, as a full-structure `MixedGraphCat.Iso` —
+    the form that descends to `Representation.IsoClass`. -/
+noncomputable def Representation.fullIsoOfReaderEq
     {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
-    (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) : A ≅ B := by
+    (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) :
+    MixedGraphCat.Iso A.obj B.obj := by
   have hlen : ∀ i, A.tierLength i = B.tierLength i := fun i => by
     rw [← Representation.length_tierWord, hw, Representation.length_tierWord]
-  refine A.normalizeIso.symm ≪≫ Representation.mkIso ?_ ≪≫ B.normalizeIso
+  refine A.normalizeFullIso.symm.trans (MixedGraphCat.Iso.trans ?_ B.normalizeFullIso)
   refine
     { toEquiv := Equiv.sigmaCongrRight fun i => finCongr (hlen i)
       edges_iff := fun v w => ?_
@@ -622,6 +674,15 @@ noncomputable def Representation.isoOfReaderEq
     congr 1
     rw [← Representation.tierWord_getElem, ← Representation.tierWord_getElem]
     simp only [hw, Fin.val_cast]
+
+/-- **Classification of finite representations**: equal tier words and equal
+    links give an isomorphism — the tuple reading is a complete invariant. -/
+noncomputable def Representation.isoOfReaderEq
+    {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite A.obj.V] [Finite B.obj.V]
+    (hw : ∀ i, A.tierWord i = B.tierWord i)
+    (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) : A ≅ B :=
+  Representation.mkIso (Representation.fullIsoOfReaderEq hw hl)
 
 end Classification
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -5,7 +5,10 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.CategoryTheory.Monoidal.Skeleton
+import Mathlib.Data.Finite.Sum
 import Mathlib.Data.Fintype.Sort
+import Mathlib.Data.Fintype.Sum
+import Mathlib.Logic.Equiv.Fin.Basic
 import Linglib.Phonology.Autosegmental.MixedGraph
 
 /-!
@@ -170,5 +173,80 @@ noncomputable def realizeHom
   FreeMonoid.lift (toSkeleton ∘ g₀)
 
 end Realize
+
+/-! ### Tier words of tensors
+
+Concatenation appends tier content: within a tier, the bridge arc puts every
+left-factor vertex before every right-factor vertex, so the tensor's fiber is
+the lexicographic sum of the factors' fibers and its ascending enumeration is
+the two enumerations in sequence (`Subsingleton (Fin n ≃o ·)` — monotone
+enumerations are unique). -/
+
+section TierWordTensor
+open scoped MonoidalCategory
+
+variable {ι : Type*} {τ : ι → Type*}
+variable {X Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+
+instance [Finite X.obj.V] [Finite Y.obj.V] : Finite ((X ⊗ Y).obj.V) :=
+  inferInstanceAs (Finite (X.obj.V ⊕ Y.obj.V))
+
+/-- A tensor's tier fiber splits as the sum of the factors' fibers. -/
+def Representation.fiberTensorEquiv (i : ι) :
+    (X ⊗ Y).fiber i ≃ X.fiber i ⊕ Y.fiber i where
+  toFun v := match v with
+    | ⟨.inl w, h⟩ => .inl ⟨w, h⟩
+    | ⟨.inr w, h⟩ => .inr ⟨w, h⟩
+  invFun := Sum.elim (fun w => ⟨.inl w.val, w.property⟩) (fun w => ⟨.inr w.val, w.property⟩)
+  left_inv := by rintro ⟨w | w, h⟩ <;> rfl
+  right_inv := by rintro (w | w) <;> rfl
+
+variable [Finite X.obj.V] [Finite Y.obj.V]
+
+theorem Representation.tierLen_tensor (i : ι) :
+    (X ⊗ Y).tierLen i = X.tierLen i + Y.tierLen i := by
+  letI := Fintype.ofFinite ((X ⊗ Y).fiber i)
+  letI := Fintype.ofFinite (X.fiber i)
+  letI := Fintype.ofFinite (Y.fiber i)
+  simp only [Representation.tierLen]
+  rw [Fintype.card_congr (Representation.fiberTensorEquiv i), Fintype.card_sum]
+
+open Representation in
+/-- The blockwise enumeration of a tensor's fiber: left factor first, then
+    right — monotone because the bridge arc orders the blocks. -/
+noncomputable def Representation.tensorEnum (i : ι) :
+    Fin (X.tierLen i + Y.tierLen i) ≃o (X ⊗ Y).fiber i := by
+  letI := Fintype.ofFinite (X.fiber i)
+  letI := Fintype.ofFinite (Y.fiber i)
+  refine StrictMono.orderIsoOfSurjective
+    (finSumFinEquiv.symm.trans
+      (((monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i)).toEquiv.sumCongr
+        (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i)).toEquiv).trans
+        (fiberTensorEquiv i).symm))
+    ?_ (Equiv.surjective _)
+  intro p q hpq
+  simp only [Equiv.trans_apply]
+  induction p using Fin.addCases with
+  | left p₁ =>
+    rw [finSumFinEquiv_symm_apply_castAdd]
+    induction q using Fin.addCases with
+    | left q₁ =>
+      rw [finSumFinEquiv_symm_apply_castAdd]
+      exact (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i)).strictMono
+        (by simp only [Fin.lt_def, Fin.val_castAdd] at hpq ⊢; exact hpq)
+    | right q₂ =>
+      rw [finSumFinEquiv_symm_apply_natAdd]
+      exact (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i) p₁).property.trans
+        ((monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i) q₂).property).symm
+  | right p₂ =>
+    induction q using Fin.addCases with
+    | left q₁ =>
+      exact absurd hpq (by simp only [Fin.lt_def, Fin.val_natAdd, Fin.val_castAdd]; omega)
+    | right q₂ =>
+      rw [finSumFinEquiv_symm_apply_natAdd, finSumFinEquiv_symm_apply_natAdd]
+      exact (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i)).strictMono
+        (by simp only [Fin.lt_def, Fin.val_natAdd] at hpq ⊢; omega)
+
+end TierWordTensor
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -29,17 +29,24 @@ associativity on the nose (`CategoryTheory.Monoidal.Skeleton`), and
 
 ## Main definitions
 
-* `Representation.fiber`, `Representation.vertexEquiv`: the tier fibers of a
-  finite representation and the canonical enumeration of its vertex type.
+* `Representation.fiber`, `Representation.fiberEnum`, `Representation.vertexEquiv`:
+  the tier fibers of a finite representation and their canonical enumerations.
+* `Representation.tierLength`, `Representation.tierWord`, `Representation.linkRel`:
+  the tuple reading — per-tier sizes, label words, and position-coordinate links.
 * `Representation.normalize`: the normal form, a `Representation` on the
   canonical vertex type.
+* `realize`, `realizeHom`, `tierProj`: [jardine-2019]'s `g` as iterated tensor,
+  as a free-monoid hom into the skeleton, and its per-tier projections.
 
 ## Main results
 
 * `Representation.normalizeIso`: `X.normalize ≅ X`.
-* `Representation.arcs_normalize`: on normal forms the arcs are the ascending
-  position order — the classification content, [jardine-heinz-2015]'s tiered
-  presentation recovered as a theorem.
+* `Representation.arcs_normalize`, `Representation.edges_normalize`: on normal
+  forms the arcs are the ascending position order and the edges are `linkRel` —
+  [jardine-heinz-2015]'s tiered presentation recovered as a theorem.
+* `Representation.tierWord_tensor`, `Representation.tierWord_realize`:
+  concatenation appends tier words; tier content of a realization is
+  compositional.
 * `Representation.toSkeleton_normalize`: normal forms represent their
   isomorphism class in the skeleton monoid.
 -/

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -635,8 +635,26 @@ theorem Representation.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ 
       X.label_vertexEquiv j q] at h2
   exact h h2
 
+/-- Links are symmetric in coordinates. -/
+theorem Representation.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
+    (h : X.link i j p q) : X.link j i q p := by
+  obtain ⟨hp, hq, hl⟩ := h
+  exact ⟨hq, hp, hl.symm⟩
+
+/-- Same-tier vertices are never linked: they are arc-comparable (Axioms 1–2),
+    and association never follows arcs (Axiom 3). -/
+theorem Representation.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
+    ¬ X.link i i p q := by
+  rintro ⟨hp, hq, hl⟩
+  rw [Representation.linkRel_def] at hl
+  have hlab : X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨p, hp⟩⟩)
+      = X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨q, hq⟩⟩) := by
+    show (X.obj.label _).1 = (X.obj.label _).1
+    rw [Representation.label_vertexEquiv, Representation.label_vertexEquiv]
+  exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
+
 /-- The classification isomorphism, as a full-structure `MixedGraphCat.Iso` —
-    the form that descends to `Representation.IsoClass`. -/
+    the form that descends to the class monoid. -/
 noncomputable def Representation.fullIsoOfReaderEq
     {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite A.obj.V] [Finite B.obj.V]

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -84,31 +84,40 @@ noncomputable instance Representation.fiber.instLinearOrder (i : ι) :
   exact linearOrderOfSTO (fun a b : X.fiber i => X.obj.graph.arcs.Adj a.val b.val)
 
 /-- The number of tier-`i` vertices. -/
-noncomputable def Representation.tierLen (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+noncomputable def Representation.tierLength (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
     [Finite X.obj.V] (i : ι) : ℕ :=
   letI := Fintype.ofFinite (X.fiber i)
   Fintype.card (X.fiber i)
 
+/-- The canonical ascending enumeration of a tier fiber. -/
+noncomputable def Representation.fiberEnum [Finite X.obj.V] (i : ι) :
+    Fin (X.tierLength i) ≃o X.fiber i :=
+  letI := Fintype.ofFinite (X.fiber i)
+  monoEquivOfFin (X.fiber i) rfl
+
 /-- The canonical enumeration of a finite representation's vertex type: tier
     fibers in ascending precedence order, assembled over the tier index. -/
 noncomputable def Representation.vertexEquiv [Finite X.obj.V] :
-    ((i : ι) × Fin (X.tierLen i)) ≃ X.obj.V :=
+    ((i : ι) × Fin (X.tierLength i)) ≃ X.obj.V :=
   letI : ∀ i : ι, Fintype (X.fiber i) := fun _ => Fintype.ofFinite _
-  (Equiv.sigmaCongrRight
-    (fun i : ι => (monoEquivOfFin (X.fiber i) rfl).toEquiv)).trans
+  (Equiv.sigmaCongrRight (fun i : ι => (X.fiberEnum i).toEquiv)).trans
     (Equiv.sigmaFiberEquiv (fun v : X.obj.V => (X.obj.label v).1))
 
 /-- The tier-`i` label word: the fiber's labels read off in ascending precedence
     order — the tier content the normal form canonicalizes. -/
 noncomputable def Representation.tierWord [Finite X.obj.V] (i : ι) : List (τ i) :=
   letI := Fintype.ofFinite (X.fiber i)
-  List.ofFn fun p : Fin (X.tierLen i) => X.fiberLabel (monoEquivOfFin (X.fiber i) rfl p)
+  List.ofFn fun p : Fin (X.tierLength i) => X.fiberLabel (X.fiberEnum i p)
+
+@[simp] theorem Representation.length_tierWord [Finite X.obj.V] (i : ι) :
+    (X.tierWord i).length = X.tierLength i := by
+  simp [Representation.tierWord]
 
 /-- The link relation in position coordinates: tier-`i` position `p` associates
     to tier-`j` position `q`. With `tierWord`, the complete tuple reading of a
     finite representation. -/
 noncomputable def Representation.linkRel [Finite X.obj.V] (i j : ι)
-    (p : Fin (X.tierLen i)) (q : Fin (X.tierLen j)) : Prop :=
+    (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) : Prop :=
   X.obj.graph.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩)
 
 /-- The normal form: `X` reindexed onto the canonical vertex type by pulling
@@ -118,7 +127,7 @@ noncomputable def Representation.normalize
     (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V] :
     Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
   obj :=
-    { V := (i : ι) × Fin (X.tierLen i)
+    { V := (i : ι) × Fin (X.tierLength i)
       graph :=
         { edges := X.obj.graph.edges.comap X.vertexEquiv
           arcs := ⟨fun v w => X.obj.graph.arcs.Adj (X.vertexEquiv v) (X.vertexEquiv w)⟩ }
@@ -138,6 +147,20 @@ noncomputable def Representation.normalizeIso [Finite X.obj.V] : X.normalize ≅
       edges_iff := fun _ _ => Iff.rfl
       arcs_iff := fun _ _ => Iff.rfl
       label_comp := fun _ => rfl }
+
+/-- On normal forms the edges are exactly `linkRel` — with `arcs_normalize`,
+    the complete tuple reading of the normal form. -/
+theorem Representation.edges_normalize [Finite X.obj.V] (i j : ι)
+    (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
+    (X.normalize).obj.graph.edges.Adj ⟨i, p⟩ ⟨j, q⟩ ↔ X.linkRel i j p q := Iff.rfl
+
+/-- On normal forms the arcs are the ascending position order — the
+    classification content: [jardine-heinz-2015]'s tiered presentation
+    recovered as a theorem. -/
+theorem Representation.arcs_normalize [Finite X.obj.V] (i : ι)
+    (p q : Fin (X.tierLength i)) :
+    (X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ↔ p < q :=
+  (X.fiberEnum i).lt_iff_lt
 
 /-- Normal forms represent their isomorphism class: `normalize` is a section of
     the quotient onto the skeleton, where the monoid of iso classes carries
@@ -212,25 +235,25 @@ variable [Finite X.obj.V] [Finite Y.obj.V]
 
 attribute [local instance] Fintype.ofFinite
 
-theorem Representation.tierLen_tensor (i : ι) :
-    (X ⊗ Y).tierLen i = X.tierLen i + Y.tierLen i := by
+@[simp] theorem Representation.tierLength_tensor (i : ι) :
+    (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i := by
   letI := Fintype.ofFinite ((X ⊗ Y).fiber i)
   letI := Fintype.ofFinite (X.fiber i)
   letI := Fintype.ofFinite (Y.fiber i)
-  simp only [Representation.tierLen]
+  simp only [Representation.tierLength]
   rw [Fintype.card_congr (Representation.fiberTensorEquiv i), Fintype.card_sum]
 
 open Representation in
 /-- The blockwise enumeration of a tensor's fiber: left factor first, then
     right — monotone because the bridge arc orders the blocks. -/
 noncomputable def Representation.tensorEnum (i : ι) :
-    Fin (X.tierLen i + Y.tierLen i) ≃o (X ⊗ Y).fiber i := by
+    Fin (X.tierLength i + Y.tierLength i) ≃o (X ⊗ Y).fiber i := by
   letI := Fintype.ofFinite (X.fiber i)
   letI := Fintype.ofFinite (Y.fiber i)
   refine StrictMono.orderIsoOfSurjective
     (finSumFinEquiv.symm.trans
-      (((monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i)).toEquiv.sumCongr
-        (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i)).toEquiv).trans
+      (((X.fiberEnum i).toEquiv.sumCongr
+        (Y.fiberEnum i).toEquiv).trans
         (fiberTensorEquiv i).symm))
     ?_ (Equiv.surjective _)
   intro p q hpq
@@ -241,31 +264,31 @@ noncomputable def Representation.tensorEnum (i : ι) :
     induction q using Fin.addCases with
     | left q₁ =>
       rw [finSumFinEquiv_symm_apply_castAdd]
-      exact (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i)).strictMono
+      exact (X.fiberEnum i).strictMono
         (by simp only [Fin.lt_def, Fin.val_castAdd] at hpq ⊢; exact hpq)
     | right q₂ =>
       rw [finSumFinEquiv_symm_apply_natAdd]
-      exact (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i) p₁).property.trans
-        ((monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i) q₂).property).symm
+      exact (X.fiberEnum i p₁).property.trans
+        ((Y.fiberEnum i q₂).property).symm
   | right p₂ =>
     induction q using Fin.addCases with
     | left q₁ =>
       exact absurd hpq (by simp only [Fin.lt_def, Fin.val_natAdd, Fin.val_castAdd]; omega)
     | right q₂ =>
       rw [finSumFinEquiv_symm_apply_natAdd, finSumFinEquiv_symm_apply_natAdd]
-      exact (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i)).strictMono
+      exact (Y.fiberEnum i).strictMono
         (by simp only [Fin.lt_def, Fin.val_natAdd] at hpq ⊢; omega)
 
-theorem Representation.tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLen i)) :
-    Representation.tensorEnum i (Fin.castAdd (Y.tierLen i) p) =
+theorem Representation.tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLength i)) :
+    Representation.tensorEnum i (Fin.castAdd (Y.tierLength i) p) =
       (Representation.fiberTensorEquiv i).symm
-        (.inl (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i) p)) := by
+        (.inl (X.fiberEnum i p)) := by
   simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_castAdd]
 
-theorem Representation.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLen i)) :
-    Representation.tensorEnum i (Fin.natAdd (X.tierLen i) p) =
+theorem Representation.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLength i)) :
+    Representation.tensorEnum i (Fin.natAdd (X.tierLength i) p) =
       (Representation.fiberTensorEquiv (X := X) i).symm
-        (.inr (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i) p)) := by
+        (.inr (Y.fiberEnum i p)) := by
   simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_natAdd]
 
 omit [Finite X.obj.V] [Finite Y.obj.V] in
@@ -282,25 +305,25 @@ theorem Representation.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
 theorem Representation.tierWord_eq_ofFn {Z : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite Z.obj.V] {i : ι} {n : ℕ} (e : Fin n ≃o Z.fiber i) :
     Z.tierWord i = List.ofFn fun p => Z.fiberLabel (e p) := by
-  have hn : Z.tierLen i = n := by
-    simpa [Representation.tierLen] using (Fintype.card_congr e.toEquiv).symm
+  have hn : Z.tierLength i = n := by
+    simpa [Representation.tierLength] using (Fintype.card_congr e.toEquiv).symm
   subst hn
-  rw [Subsingleton.elim e (monoEquivOfFin (Z.fiber i) rfl)]
+  rw [Subsingleton.elim e (Z.fiberEnum i)]
   rfl
 
 /-- **Concatenation appends tier content**: the tier word of a tensor is the
     factors' tier words in sequence — the tuple presentation of
     [jardine-heinz-2015]'s Definition 2, recovered as a theorem about normal
     forms. -/
-theorem Representation.tierWord_tensor (i : ι) :
+@[simp] theorem Representation.tierWord_tensor (i : ι) :
     (X ⊗ Y).tierWord i = X.tierWord i ++ Y.tierWord i := by
   rw [Representation.tierWord_eq_ofFn (Representation.tensorEnum i), List.ofFn_add]
   congr 1
-  · rw [Representation.tierWord_eq_ofFn (monoEquivOfFin (X.fiber i) (rfl : _ = X.tierLen i))]
+  · rw [Representation.tierWord_eq_ofFn (X.fiberEnum i)]
     exact congrArg List.ofFn (funext fun p =>
       (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_castAdd i p)).trans
         (Representation.fiberLabel_symm_inl _))
-  · rw [Representation.tierWord_eq_ofFn (monoEquivOfFin (Y.fiber i) (rfl : _ = Y.tierLen i))]
+  · rw [Representation.tierWord_eq_ofFn (Y.fiberEnum i)]
     exact congrArg List.ofFn (funext fun p =>
       (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_natAdd i p)).trans
         (Representation.fiberLabel_symm_inr _))
@@ -324,11 +347,11 @@ instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
 instance : Finite ((𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).obj.V) :=
   inferInstanceAs (Finite PEmpty)
 
-theorem Representation.tierWord_unit (i : ι) :
+@[simp] theorem Representation.tierWord_unit (i : ι) :
     (𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).tierWord i = [] := by
   haveI : IsEmpty ((𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).fiber i) :=
     ⟨fun v => v.val.elim⟩
-  rw [Representation.tierWord_eq_ofFn (n := 0) ⟨Equiv.equivOfIsEmpty _ _, fun {a} => a.elim0⟩]
+  rw [Representation.tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
   exact List.ofFn_zero
 
 /-- **Tier content is compositional**: the tier word of a realized string is the
@@ -337,18 +360,40 @@ theorem Representation.tierWord_unit (i : ι) :
 theorem Representation.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
     (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
   induction w with
-  | nil => exact Representation.tierWord_unit i
+  | nil => simp
   | cons a w ih =>
     calc (realize g₀ (a :: w)).tierWord i
         = (g₀ a ⊗ realize g₀ w).tierWord i := rfl
-      _ = (g₀ a).tierWord i ++ (realize g₀ w).tierWord i := Representation.tierWord_tensor i
-      _ = ((a :: w).map fun s => (g₀ s).tierWord i).flatten := by rw [ih]; rfl
+      _ = ((a :: w).map fun s => (g₀ s).tierWord i).flatten := by simp [ih]
 
 /-- The tier-`i` projection of a realization, as a free-monoid homomorphism:
     each symbol contributes its primitive's tier word. -/
 noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
     FreeMonoid S →* FreeMonoid (τ i) :=
   FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
+
+/-- `realizeHom` packages `realize`: on a word it is the class of the realized
+    representation. -/
+theorem realizeHom_ofList [∀ s, Finite (g₀ s).obj.V] (w : List S) :
+    realizeHom g₀ (FreeMonoid.ofList w) = toSkeleton (realize g₀ w) := by
+  induction w with
+  | nil => rfl
+  | cons a w ih =>
+    rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
+      map_mul, ih, realize_cons]
+    exact (CategoryTheory.Skeleton.toSkeleton_tensorObj _ _).symm
+
+/-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
+theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+    tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((realize g₀ w).tierWord i) := by
+  induction w with
+  | nil => simp [realize_nil]
+  | cons a w ih =>
+    rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
+      map_mul, ih]
+    calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((realize g₀ w).tierWord i)
+        = FreeMonoid.ofList ((g₀ a).tierWord i ++ (realize g₀ w).tierWord i) := rfl
+      _ = _ := by rw [← Representation.tierWord_tensor i]; rfl
 
 end RealizeTierWord
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.CategoryTheory.Monoidal.Skeleton
 import Mathlib.Data.Fintype.Sort
 import Linglib.Phonology.Autosegmental.MixedGraph
@@ -136,5 +137,38 @@ theorem Representation.toSkeleton_normalize [Finite X.obj.V] :
   Quotient.sound ⟨X.normalizeIso⟩
 
 end NormalForm
+
+/-! ### Realization of strings
+
+[jardine-2019]'s mapping `g`: each symbol denotes a representation primitive, a
+string denotes their concatenation. The monoid-homomorphism content lives on the
+skeleton, where concatenation is strictly associative. -/
+
+section Realize
+open scoped MonoidalCategory
+
+variable {S : Type*} {ι : Type*} {τ : ι → Type*}
+
+/-- Realize a string as a representation: the iterated tensor of its symbols'
+    primitives ([jardine-2019]'s `g`). -/
+noncomputable def realize (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    (w : List S) : Representation (Sigma.fst : ((i : ι) × τ i) → ι) :=
+  (w.map g₀).foldr (· ⊗ ·) (𝟙_ _)
+
+@[simp] theorem realize_nil (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    realize g₀ [] = 𝟙_ _ := rfl
+
+@[simp] theorem realize_cons (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
+
+/-- The realization as a free-monoid homomorphism into the skeleton monoid —
+    the string→AR monoid hom, with associativity strict on iso classes
+    (`CategoryTheory.Monoidal.Skeleton`). -/
+noncomputable def realizeHom
+    (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    FreeMonoid S →* Skeleton (Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :=
+  FreeMonoid.lift (toSkeleton ∘ g₀)
+
+end Realize
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.CategoryTheory.Monoidal.Skeleton
 import Mathlib.Data.Finite.Sum
 import Mathlib.Data.Fintype.Sort
 import Mathlib.Data.Fintype.Sum
@@ -21,10 +22,10 @@ The normal form is a `Representation` — not a separate carrier — and
 `normalizeIso` is definitional: `normalize` pulls the graph back along the
 enumeration equivalence.
 
-Strictness lives on isomorphism classes: `Representation.IsoClass` carries
-concatenation with associativity on the nose — full-structure classes, since
-broad categorical isomorphism forgets the arcs and is too coarse to preserve
-tier words. `cls_normalize` says `normalize` chooses representatives.
+Strictness lives on isomorphism classes of the precedence-preserving wide
+subcategory (`PrecRepresentation`): full-structure classes, since broad
+categorical isomorphism forgets the arcs and is too coarse to preserve tier
+words. `cls_normalize` says `normalize` chooses representatives.
 
 ## Main definitions
 
@@ -46,8 +47,9 @@ tier words. `cls_normalize` says `normalize` chooses representatives.
 * `Representation.tierWord_tensor`, `Representation.tierWord_realize`:
   concatenation appends tier words; tier content of a realization is
   compositional.
-* `Representation.IsoClass`, `Representation.cls_normalize`: the concatenation
-  monoid of isomorphism classes; normal forms represent their class.
+* `PrecRepresentation`, `Representation.cls_normalize`: the monoid of
+  isomorphism classes of the precedence-preserving category; normal forms
+  represent their class.
 -/
 
 namespace Autosegmental
@@ -58,50 +60,46 @@ variable {ι : Type*} {τ : ι → Type*}
 
 /-! ### The monoid of representations up to isomorphism
 
-Full-structure isomorphism classes of representations, with strictly
-associative concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as a
-`Monoid`. Full isos, not the broad categorical `≅` (which forgets arcs), are
-the theory's identity criterion: they preserve tier orders, so the tuple
-readers descend to classes. -/
+Isomorphism classes in the **precedence-preserving** wide subcategory — the
+theory's identity criterion. The broad categorical `≅` forgets arcs and is too
+coarse (it identifies tier orders); wide-subcategory isos are exactly the
+full-structure isomorphisms, so the tuple readers descend to classes. The
+monoid structure is stock: `precPreserving` is monoidally stable, so
+`WideSubcategory` inherits the monoidal category and `Monoidal.Skeleton` the
+strictly associative monoid. -/
 
 section IsoClasses
 open scoped MonoidalCategory
 
-/-- Full-structure isomorphism as an equivalence of representations. -/
-def Representation.isoSetoid :
-    Setoid (Representation (Sigma.fst : ((i : ι) × τ i) → ι)) where
-  r A B := Nonempty (MixedGraphCat.Iso A.obj B.obj)
-  iseqv := ⟨fun _ => ⟨MixedGraphCat.Iso.refl _⟩, fun ⟨e⟩ => ⟨e.symm⟩,
-    fun ⟨e⟩ ⟨f⟩ => ⟨e.trans f⟩⟩
+/-- Representations with the classical precedence-preserving morphisms. -/
+abbrev PrecRepresentation (ι : Type*) (τ : ι → Type*) :=
+  WideSubcategory (Representation.precPreserving (t := (Sigma.fst : ((i : ι) × τ i) → ι)))
 
-/-- Isomorphism classes of representations — the carrier of the concatenation
-    monoid of ARs. -/
-def Representation.IsoClass (ι : Type*) (τ : ι → Type*) :=
-  Quotient (Representation.isoSetoid (ι := ι) (τ := τ))
+/-- A full isomorphism is an isomorphism of the precedence-preserving
+    category: both directions preserve arcs. -/
+noncomputable def Representation.fullIsoToWideIso
+    {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    (e : MixedGraphCat.Iso A.obj B.obj) :
+    (⟨A⟩ : PrecRepresentation ι τ) ≅ ⟨B⟩ where
+  hom := ⟨InducedCategory.homMk e.toHom, e.toHom_precPreserving⟩
+  inv := ⟨InducedCategory.homMk e.symm.toHom, e.symm.toHom_precPreserving⟩
+  hom_inv_id := InducedWideCategory.Hom.ext (InducedCategory.hom_ext
+    (MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v)))
+  inv_hom_id := InducedWideCategory.Hom.ext (InducedCategory.hom_ext
+    (MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)))
 
-/-- The class of a representation. -/
-def Representation.cls (A : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    Representation.IsoClass ι τ :=
-  Quotient.mk Representation.isoSetoid A
-
-instance : Monoid (Representation.IsoClass ι τ) where
-  mul := Quotient.map₂ (· ⊗ ·)
-    fun _ _ ⟨e₁⟩ _ _ ⟨e₂⟩ => ⟨MixedGraphCat.Iso.concatCongr _ e₁ e₂⟩
-  one := Representation.cls (𝟙_ _)
-  mul_assoc := by
-    rintro ⟨A⟩ ⟨B⟩ ⟨C⟩
-    exact Quotient.sound ⟨MixedGraphCat.concatAssocIso _ A.obj B.obj C.obj⟩
-  one_mul := by
-    rintro ⟨A⟩
-    exact Quotient.sound ⟨MixedGraphCat.emptyConcatIso _ A.obj⟩
-  mul_one := by
-    rintro ⟨A⟩
-    exact Quotient.sound ⟨MixedGraphCat.concatEmptyIso _ A.obj⟩
+/-- The class of a representation: its isomorphism class in the skeleton of the
+    precedence-preserving category — the monoid of ARs. -/
+noncomputable def Representation.cls
+    (A : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    Skeleton (PrecRepresentation ι τ) :=
+  toSkeleton ⟨A⟩
 
 /-- Concatenation of classes is the class of the tensor. -/
 theorem Representation.cls_tensor
     (A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    Representation.cls (A ⊗ B) = Representation.cls A * Representation.cls B := rfl
+    Representation.cls (A ⊗ B) = Representation.cls A * Representation.cls B :=
+  CategoryTheory.Skeleton.toSkeleton_tensorObj (⟨A⟩ : PrecRepresentation ι τ) ⟨B⟩
 
 end IsoClasses
 
@@ -239,7 +237,7 @@ theorem Representation.arcs_normalize [Finite X.obj.V] (i : ι)
     of the quotient onto `Representation.IsoClass`. -/
 theorem Representation.cls_normalize [Finite X.obj.V] :
     Representation.cls (X.normalize) = Representation.cls X :=
-  Quotient.sound ⟨X.normalizeFullIso⟩
+  Quotient.sound ⟨Representation.fullIsoToWideIso X.normalizeFullIso⟩
 
 end NormalForm
 
@@ -271,7 +269,7 @@ noncomputable def realize (g₀ : S → Representation (Sigma.fst : ((i : ι) ×
     on classes. -/
 noncomputable def realizeHom
     (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    FreeMonoid S →* Representation.IsoClass ι τ :=
+    FreeMonoid S →* Skeleton (PrecRepresentation ι τ) :=
   FreeMonoid.lift (Representation.cls ∘ g₀)
 
 end Realize

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -104,6 +104,13 @@ noncomputable def Representation.tierWord [Finite X.obj.V] (i : ι) : List (τ i
   letI := Fintype.ofFinite (X.fiber i)
   List.ofFn fun p : Fin (X.tierLen i) => X.fiberLabel (monoEquivOfFin (X.fiber i) rfl p)
 
+/-- The link relation in position coordinates: tier-`i` position `p` associates
+    to tier-`j` position `q`. With `tierWord`, the complete tuple reading of a
+    finite representation. -/
+noncomputable def Representation.linkRel [Finite X.obj.V] (i j : ι)
+    (p : Fin (X.tierLen i)) (q : Fin (X.tierLen j)) : Prop :=
+  X.obj.graph.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩)
+
 /-- The normal form: `X` reindexed onto the canonical vertex type by pulling
     edges, arcs, and labels back along `vertexEquiv`. A `Representation` — the
     normal form is not a separate kind of object. -/

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -404,4 +404,41 @@ theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
 
 end RealizeTierWord
 
+/-! ### Factors and banned-subgraph grammars
+
+[jardine-2017]'s connected-subgraph embedding in position coordinates: a factor
+occurs at per-tier offsets when its tier words are windows of the host's and its
+links transport shifted. Banned-subgraph grammars ([jardine-2016-diss] Ch. 5)
+are lists of forbidden factors. -/
+
+section Factors
+
+variable {ι : Type*} {τ : ι → Type*}
+variable (F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+
+/-- Tier-`i` position `p` links to tier-`j` position `q`, in ℕ coordinates
+    (out-of-bounds positions link to nothing). -/
+def Representation.link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
+  ∃ (hp : p < X.tierLength i) (hq : q < X.tierLength j), X.linkRel i j ⟨p, hp⟩ ⟨q, hq⟩
+
+/-- `F` occurs in `X` at per-tier offsets `o`: each tier word of `F` is the
+    window of `X`'s at `o i`, and `F`'s links transport shifted. -/
+def Representation.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
+  (∀ i p, p < F.tierLength i → (X.tierWord i)[p + o i]? = (F.tierWord i)[p]?) ∧
+    ∀ i j p q, F.link i j p q → X.link i j (p + o i) (q + o j)
+
+/-- `F` **subgraph-embeds** in `X` when some offsets place it as a factor
+    ([jardine-2017]'s connected-subgraph embedding). -/
+def Representation.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
+  ∃ o : ι → ℕ, F.IsFactorAt X o
+
+/-- `X` avoids every forbidden factor of a banned-subgraph grammar
+    ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
+def Representation.Free [Finite X.obj.V]
+    (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
+    Prop :=
+  ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
+
+end Factors
+
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -360,7 +360,7 @@ theorem Representation.vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tie
     (h : X.tierLength i ≤ (r : ℕ)) :
     (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inr (Y.vertexEquiv ⟨i,
       ⟨(r : ℕ) - X.tierLength i, by
-        have h1 := r.isLt
+        have _h1 := r.isLt
         have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
           Representation.tierLength_tensor i
         omega⟩⟩) := by

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -11,10 +11,10 @@ import Linglib.Phonology.Autosegmental.AR
 # Autosegmental realization of strings
 
 The **realization** of a string maps each symbol to its autosegmental graph primitive
-and concatenates them ([jardine-2019]'s mapping `g`): `realize g₀ w = ∏ (w.map g₀)` in
+and concatenates them ([jardine-2019]'s mapping `g`): `AR.realize g₀ w = ∏ (w.map g₀)` in
 the concatenation monoid `Monoid (AR α β)`.
 
-This is a string→AR **monoid homomorphism** (`realize_append`), the exact analogue —
+This is a string→AR **monoid homomorphism** (`AR.realize_append`), the exact analogue —
 one categorical level up — of the string→tier-string projection
 `TierProjection.apply` (= `List.filterMap`, also concat-distributing): both are
 free-monoid homomorphisms built from a per-symbol map, used to define a subregular
@@ -30,24 +30,24 @@ variable {S : Type*} {α β : Type*}
 
 /-- **Realize** a string as an autosegmental representation: concatenate the graph
     primitives `g₀ a` of its symbols ([jardine-2019]'s `g`). -/
-def realize (g₀ : S → AR α β) (w : List S) : AR α β := (w.map g₀).prod
+def AR.realize (g₀ : S → AR α β) (w : List S) : AR α β := (w.map g₀).prod
 
-@[simp] theorem realize_nil (g₀ : S → AR α β) : realize g₀ [] = AR.empty := rfl
+@[simp] theorem AR.realize_nil (g₀ : S → AR α β) : AR.realize g₀ [] = AR.empty := rfl
 
-@[simp] theorem realize_cons (g₀ : S → AR α β) (a : S) (w : List S) :
-    realize g₀ (a :: w) = (g₀ a).concat (realize g₀ w) := rfl
+@[simp] theorem AR.realize_cons (g₀ : S → AR α β) (a : S) (w : List S) :
+    AR.realize g₀ (a :: w) = (g₀ a).concat (AR.realize g₀ w) := rfl
 
 /-- **The realization is a monoid homomorphism**: it distributes over concatenation —
     the string→AR analogue of `TierProjection.apply_append`. -/
-theorem realize_append (g₀ : S → AR α β) (xs ys : List S) :
-    realize g₀ (xs ++ ys) = (realize g₀ xs).concat (realize g₀ ys) := by
-  simp only [realize, List.map_append, List.prod_append]; rfl
+theorem AR.realize_append (g₀ : S → AR α β) (xs ys : List S) :
+    AR.realize g₀ (xs ++ ys) = (AR.realize g₀ xs).concat (AR.realize g₀ ys) := by
+  simp only [AR.realize, List.map_append, List.prod_append]; rfl
 
 /-! ### Tier projections
 
 The realization composed with a tier accessor is itself a free-monoid hom into that
 tier's free monoid: `upperProj g₀` sends a string to the concatenation of its symbols'
-upper tiers (the underlying list of `realize g₀ w`'s upper tier), and likewise
+upper tiers (the underlying list of `AR.realize g₀ w`'s upper tier), and likewise
 `lowerProj`. These factor the realization's tier content through `FreeMonoid` and are
 the bridge used to place link-free `ASL` sets in `SF` (`Studies.Jardine2019`): a
 per-tier factor constraint on the realization is the `comap` of a factor language along
@@ -70,35 +70,35 @@ def lowerProj (g₀ : S → AR α β) : FreeMonoid S →* FreeMonoid β :=
     lowerProj g₀ (FreeMonoid.of s) = FreeMonoid.ofList (g₀ s).lower.toList :=
   FreeMonoid.lift_eval_of _ _
 
-/-- The upper tier of a realization is its upper projection: `(realize g₀ w).upper`'s
+/-- The upper tier of a realization is its upper projection: `(AR.realize g₀ w).upper`'s
 underlying list is `upperProj g₀ w`. -/
 theorem realize_upper_toList (g₀ : S → AR α β) (w : List S) :
-    (realize g₀ w).upper.toList = upperProj g₀ (FreeMonoid.ofList w) := by
+    (AR.realize g₀ w).upper.toList = upperProj g₀ (FreeMonoid.ofList w) := by
   induction w with
-  | nil => rw [realize_nil, show FreeMonoid.ofList ([] : List S) = 1 from rfl, map_one]; rfl
+  | nil => rw [AR.realize_nil, show FreeMonoid.ofList ([] : List S) = 1 from rfl, map_one]; rfl
   | cons s w ih =>
-    rw [realize_cons, AR.upper_concat, LabeledTuple.toList_concat, ih, FreeMonoid.ofList_cons,
+    rw [AR.realize_cons, AR.upper_concat, LabeledTuple.toList_concat, ih, FreeMonoid.ofList_cons,
       map_mul, upperProj_of]
     rfl
 
 /-- The lower tier of a realization is its lower projection. -/
 theorem realize_lower_toList (g₀ : S → AR α β) (w : List S) :
-    (realize g₀ w).lower.toList = lowerProj g₀ (FreeMonoid.ofList w) := by
+    (AR.realize g₀ w).lower.toList = lowerProj g₀ (FreeMonoid.ofList w) := by
   induction w with
-  | nil => rw [realize_nil, show FreeMonoid.ofList ([] : List S) = 1 from rfl, map_one]; rfl
+  | nil => rw [AR.realize_nil, show FreeMonoid.ofList ([] : List S) = 1 from rfl, map_one]; rfl
   | cons s w ih =>
-    rw [realize_cons, AR.lower_concat, LabeledTuple.toList_concat, ih, FreeMonoid.ofList_cons,
+    rw [AR.realize_cons, AR.lower_concat, LabeledTuple.toList_concat, ih, FreeMonoid.ofList_cons,
       map_mul, lowerProj_of]
     rfl
 
 /-! ### Linearization: the association-state string of an AR
 
-The inverse direction of the bridge. Where `realize` builds an AR from a string,
+The inverse direction of the bridge. Where `AR.realize` builds an AR from a string,
 `linearize` reads the **association-state string** off an AR: per timing-tier position,
 its label together with the labels of the melody nodes linked to it, in tier order. This
 is the linearisation phonologists use implicitly when writing a tonal input as a string of
 TBU symbols — [jardine-2016] §4.4: each string symbol records one timing unit's
-associations, so transducer look-ahead is measured on the timing tier. Like `realize`, it
+associations, so transducer look-ahead is measured on the timing tier. Like `AR.realize`, it
 is a monoid homomorphism into `(List, ++)` (`AR.linearize_concat`), so the linearization
 of a realization is the concatenation of the per-symbol association profiles
 (`linearize_realize`). -/
@@ -249,9 +249,9 @@ theorem AR.linearize_concat (A B : AR α β) :
 /-- The linearization of a realization is the concatenation of the per-symbol
 association profiles ([jardine-2016] (40)). -/
 theorem linearize_realize (g₀ : S → AR α β) (w : List S) :
-    (realize g₀ w).linearize = w.flatMap fun a => (g₀ a).linearize := by
+    (AR.realize g₀ w).linearize = w.flatMap fun a => (g₀ a).linearize := by
   induction w with
   | nil => simp
-  | cons a w ih => rw [realize_cons, AR.linearize_concat, ih, List.flatMap_cons]
+  | cons a w ih => rw [AR.realize_cons, AR.linearize_concat, ih, List.flatMap_cons]
 
 end Autosegmental

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -430,24 +430,31 @@ theorem surfacesWith_plateauAR {w : List TBU} {i : ℕ} :
 def utp : Surfacing TBU where
   hi := .H
   lo := .O
-  Surfaces w i := (plateauAR w).SurfacesWith _root_.Tone.TRN.H i
+  Surfaces w i := .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i
   hi_ne_lo := by decide
   lt_length h := by
-    have h₂ := List.length_pos_of_mem (surfacesWith_plateauAR.mp h).2
+    have h₂ := List.length_pos_of_mem h.2
     rw [List.length_drop] at h₂
     omega
-  surfaces_of_hi h := surfacesWith_plateauAR.mpr
+  surfaces_of_hi h :=
     ⟨List.mem_take_iff.mpr ⟨_, Nat.lt_succ_self _, h⟩, List.mem_drop_iff.mpr ⟨_, le_rfl, h⟩⟩
-  decSurfaces w i := decidable_of_iff _ surfacesWith_plateauAR.symm
+  decSurfaces w i := inferInstanceAs (Decidable (_ ∧ _))
+
+/-- **What surfaces is the representation**: `utp.Surfaces w i` is H-linkedness
+    of timing slot `i` in the coordinate output representation `plateauRep w` —
+    the OCP-merged, hull-closed realization. -/
+theorem utp.surfaces_iff_link_plateauRep {w : List TBU} {i : ℕ} :
+    utp.Surfaces w i ↔ ∃ k, (plateauRep w).link true false k i :=
+  (link_plateauRep w i).symm
 
 @[simp] theorem utp.hi_def : utp.hi = .H := rfl
 
 @[simp] theorem utp.lo_def : utp.lo = .O := rfl
 
-/-- The string-level reading of surfacing: the windowed form, now derived. -/
+/-- The string-level reading of surfacing: the windowed form, definitional. -/
 theorem utp.surfaces_def {w : List TBU} {i : ℕ} :
     utp.Surfaces w i ↔ .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i :=
-  surfacesWith_plateauAR
+  Iff.rfl
 
 variable {w : List TBU} {i j k : ℕ}
 

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -108,6 +108,9 @@ noncomputable def plateauRep (w : List TBU) :
       (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
   ((Autosegmental.realize toRep w).collapse true).hull true
 
+instance (w : List TBU) : Finite (plateauRep w).obj.V :=
+  inferInstanceAs (Finite ((_ : Bool) × Fin _))
+
 section TierWords
 open CategoryTheory
 open scoped MonoidalCategory
@@ -277,6 +280,49 @@ theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
       exact Autosegmental.runIdx_replicate _ _ _
     · unfold Autosegmental.Representation.collapseIdx
       rw [if_neg (by decide)]
+
+/-- **What surfaces is the representation**: slot `j` is H-linked in
+    `plateauRep w` iff some H-toned TBU lies at or before `j` and some at or
+    after it — fusion then spreading, read back as the string window. -/
+theorem link_plateauRep (w : List TBU) (j : ℕ) :
+    (∃ k, (plateauRep w).link true false k j) ↔
+      .H ∈ w.take (j + 1) ∧ .H ∈ w.drop j := by
+  haveI := Autosegmental.realize.instFinite toRep w
+  have hlen : ((Autosegmental.realize toRep w).collapse true).tierLength false
+      = w.length := by
+    rw [← Autosegmental.Representation.length_tierWord,
+      Autosegmental.Representation.tierWord_collapse,
+      show (Autosegmental.realize toRep w).collapsedWord true false
+        = (Autosegmental.realize toRep w).tierWord false from
+        Function.update_of_ne (by decide) _ _,
+      tierWord_realize_toRep_false]
+    exact List.length_replicate
+  rw [List.mem_take_iff, List.mem_drop_iff]
+  constructor
+  · rintro ⟨k, hk⟩
+    obtain ⟨-, hjb, -⟩ := id hk
+    have hlenh : (plateauRep w).tierLength false = w.length := by
+      rw [← Autosegmental.Representation.length_tierWord,
+        show (plateauRep w).tierWord false
+          = ((Autosegmental.realize toRep w).collapse true).tierWord false from
+          Autosegmental.Representation.tierWord_hull true _ false,
+        Autosegmental.Representation.length_tierWord, hlen]
+    have hjw : j < w.length := hlenh ▸ hjb
+    obtain ⟨q₁, q₂, h₁, h₂, hle₁, hle₂⟩ :=
+      (Autosegmental.Representation.link_hull_left true _ (by decide)
+        (by omega : j < ((Autosegmental.realize toRep w).collapse true).tierLength false)).mp hk
+    obtain ⟨-, hq₁⟩ := (link_realizeMerged w k q₁).mp h₁
+    obtain ⟨-, hq₂⟩ := (link_realizeMerged w k q₂).mp h₂
+    exact ⟨⟨q₁, by omega, hq₁⟩, q₂, hle₂, hq₂⟩
+  · rintro ⟨⟨q₁, hq₁b, hq₁⟩, q₂, hq₂b, hq₂⟩
+    have hq₂w : q₂ < w.length := by
+      rcases List.getElem?_eq_some_iff.mp hq₂ with ⟨h, -⟩
+      exact h
+    have hl₁ := (link_realizeMerged w 0 q₁).mpr ⟨rfl, hq₁⟩
+    have hl₂ := (link_realizeMerged w 0 q₂).mpr ⟨rfl, hq₂⟩
+    exact ⟨0, (Autosegmental.Representation.link_hull_left true _ (by decide)
+      (by omega : j < ((Autosegmental.realize toRep w).collapse true).tierLength false)).mpr
+      ⟨q₁, q₂, hl₁, hl₂, by omega, hq₂b⟩⟩
 
 end TierWords
 

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -121,13 +121,13 @@ theorem isLinkedLower_realize_toAR {w : List TBU} {j : ℕ} :
 
 /-- The merged input representation: one fused H, linked to exactly the H-positions. -/
 theorem mem_links_realizeMerged_toAR {w : List TBU} {p : ℕ × ℕ} :
-    p ∈ (realizeMerged toAR w).links ↔ p.1 = 0 ∧ w[p.2]? = some TBU.H := by
+    p ∈ (AR.realizeMerged toAR w).links ↔ p.1 = 0 ∧ w[p.2]? = some TBU.H := by
   rw [realizeMerged_def, mem_links_collapseAR_of_upper_replicate (upper_realize_toAR w),
     isLinkedLower_realize_toAR]
 
 /-- The melodic tier of the merged representation: one fused H if any, else empty. -/
 theorem upper_realizeMerged_toAR (v : List TBU) :
-    (realizeMerged toAR v).upper.toList
+    (AR.realizeMerged toAR v).upper.toList
       = if .H ∈ v then [_root_.Tone.TRN.H] else [] := by
   rw [realizeMerged_def, upper_collapseAR, upper_realize_toAR]
   by_cases hv : .H ∈ v
@@ -139,23 +139,23 @@ theorem upper_realizeMerged_toAR (v : List TBU) :
 
 /-- The timing tier survives merging: the bare tier of the input's length. -/
 theorem lower_realizeMerged_toAR (v : List TBU) :
-    (realizeMerged toAR v).lower.toList = List.replicate v.length () := by
+    (AR.realizeMerged toAR v).lower.toList = List.replicate v.length () := by
   rw [realizeMerged_def, collapseAR_lower, lower_realize_toAR]
 
 /-- With any H present, the fused melody node is the H at index `0`. -/
 theorem upper_get?_realizeMerged_toAR {w : List TBU} (hw : .H ∈ w) :
-    (realizeMerged toAR w).upper.get? 0 = some _root_.Tone.TRN.H := by
+    (AR.realizeMerged toAR w).upper.get? 0 = some _root_.Tone.TRN.H := by
   rw [LabeledTuple.get?_eq_getElem?, upper_realizeMerged_toAR, if_pos hw]
   rfl
 
 /-- The output representation: fuse, then spread — the merged input, hull-closed. -/
-def plateauAR (w : List TBU) : AR _root_.Tone.TRN Unit := (realizeMerged toAR w).hull
+def plateauAR (w : List TBU) : AR _root_.Tone.TRN Unit := (AR.realizeMerged toAR w).hull
 
 @[simp] theorem plateauAR_upper {w : List TBU} :
-    (plateauAR w).upper = (realizeMerged toAR w).upper := rfl
+    (plateauAR w).upper = (AR.realizeMerged toAR w).upper := rfl
 
 @[simp] theorem plateauAR_lower {w : List TBU} :
-    (plateauAR w).lower = (realizeMerged toAR w).lower := rfl
+    (plateauAR w).lower = (AR.realizeMerged toAR w).lower := rfl
 
 /-- A link of the output representation: the fused node, over a flanked position. -/
 theorem mem_links_plateauAR {w : List TBU} {k j : ℕ} :
@@ -416,7 +416,7 @@ definition; the square closes the loop at the level of whole representations. -/
 output representation — fusion-plus-spreading followed by linearization equals `utp.map`
 followed by realization. -/
 theorem realizeMerged_toAR_map (w : List TBU) :
-    realizeMerged toAR (utp.map w) = plateauAR w := by
+    AR.realizeMerged toAR (utp.map w) = plateauAR w := by
   refine AR.ext_toGraph (Graph.ext (LabeledTuple.toList_injective ?_)
     (LabeledTuple.toList_injective ?_) ?_)
   · simp only [plateauAR_upper, upper_realizeMerged_toAR, utp.H_mem_map]

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -87,7 +87,7 @@ def toAR : TBU → AR _root_.Tone.TRN Unit
   | .O => .bare ()
 
 theorem linearize_realize_toAR (w : List TBU) :
-    (realize toAR w).linearize
+    (AR.realize toAR w).linearize
       = w.map fun a => ((), if a = .H then [_root_.Tone.TRN.H] else []) := by
   rw [linearize_realize]
   induction w with
@@ -95,25 +95,25 @@ theorem linearize_realize_toAR (w : List TBU) :
   | cons a w ih => rw [List.flatMap_cons, List.map_cons, ih]; cases a <;> simp [toAR]
 
 theorem upper_realize_toAR (v : List TBU) :
-    (realize toAR v).upper.toList = List.replicate (v.count .H) _root_.Tone.TRN.H := by
+    (AR.realize toAR v).upper.toList = List.replicate (v.count .H) _root_.Tone.TRN.H := by
   induction v with
   | nil => rfl
   | cons a v ih =>
-    rw [realize_cons, AR.upper_concat, LabeledTuple.toList_concat, ih]
+    rw [AR.realize_cons, AR.upper_concat, LabeledTuple.toList_concat, ih]
     cases a <;> simp [toAR, List.replicate_succ]
 
 /-- The lower tier of the realization is the bare timing tier. -/
 theorem lower_realize_toAR (v : List TBU) :
-    (realize toAR v).lower.toList = List.replicate v.length () := by
+    (AR.realize toAR v).lower.toList = List.replicate v.length () := by
   induction v with
   | nil => rfl
   | cons a v ih =>
-    rw [realize_cons, AR.lower_concat, LabeledTuple.toList_concat, ih]
+    rw [AR.realize_cons, AR.lower_concat, LabeledTuple.toList_concat, ih]
     cases a <;> simp [toAR, List.replicate_succ]
 
 /-- A timing node of the input representation is linked iff its TBU is H-toned. -/
 theorem isLinkedLower_realize_toAR {w : List TBU} {j : ℕ} :
-    (realize toAR w).toGraph.IsLinkedLower j ↔ w[j]? = some .H := by
+    (AR.realize toAR w).toGraph.IsLinkedLower j ↔ w[j]? = some .H := by
   rw [AR.isLinkedLower_iff_linearize, linearize_realize_toAR]
   cases hv : w[j]? with
   | none => simp [List.getElem?_map, hv]

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -108,6 +108,55 @@ noncomputable def plateauRep (w : List TBU) :
       (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
   ((Autosegmental.realize toRep w).collapse true).hull true
 
+section TierWords
+open CategoryTheory
+open scoped MonoidalCategory
+
+/-- The melody word of a realized string: one `H` node per H-toned TBU. -/
+theorem tierWord_realize_toRep_true (w : List TBU) :
+    (Autosegmental.realize toRep w).tierWord true
+      = List.replicate (w.count .H) _root_.Tone.TRN.H := by
+  induction w with
+  | nil => simp [Autosegmental.Representation.tierWord_unit]
+  | cons a w ih =>
+    calc (Autosegmental.realize toRep (a :: w)).tierWord true
+        = (toRep a ⊗ Autosegmental.realize toRep w).tierWord true := rfl
+      _ = (toRep a).tierWord true ++ (Autosegmental.realize toRep w).tierWord true :=
+          Autosegmental.Representation.tierWord_tensor true
+      _ = List.replicate ((a :: w).count .H) _root_.Tone.TRN.H := by
+          rw [ih]
+          cases a
+          · rw [show (toRep TBU.H).tierWord true = [_root_.Tone.TRN.H] from
+              Autosegmental.Representation.tierWord_ofData true,
+              List.count_cons_self, List.replicate_succ]
+            rfl
+          · rw [show (toRep TBU.O).tierWord true = [] from
+              Autosegmental.Representation.tierWord_ofData true,
+              List.count_cons_of_ne (by decide)]
+            rfl
+
+/-- The timing word of a realized string: one slot per TBU. -/
+theorem tierWord_realize_toRep_false (w : List TBU) :
+    (Autosegmental.realize toRep w).tierWord false = List.replicate w.length () := by
+  induction w with
+  | nil => simp [Autosegmental.Representation.tierWord_unit]
+  | cons a w ih =>
+    calc (Autosegmental.realize toRep (a :: w)).tierWord false
+        = (toRep a ⊗ Autosegmental.realize toRep w).tierWord false := rfl
+      _ = (toRep a).tierWord false ++ (Autosegmental.realize toRep w).tierWord false :=
+          Autosegmental.Representation.tierWord_tensor false
+      _ = List.replicate (a :: w).length () := by
+          rw [ih, List.length_cons, List.replicate_succ]
+          cases a
+          · rw [show (toRep TBU.H).tierWord false = [()] from
+              Autosegmental.Representation.tierWord_ofData false]
+            rfl
+          · rw [show (toRep TBU.O).tierWord false = [()] from
+              Autosegmental.Representation.tierWord_ofData false]
+            rfl
+
+end TierWords
+
 theorem linearize_realize_toAR (w : List TBU) :
     (AR.realize toAR w).linearize
       = w.map fun a => ((), if a = .H then [_root_.Tone.TRN.H] else []) := by

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -155,6 +155,102 @@ theorem tierWord_realize_toRep_false (w : List TBU) :
               Autosegmental.Representation.tierWord_ofData false]
             rfl
 
+/-- Links of a realized string: slot `j` links to melody node `p` exactly when
+    TBU `j` is H-toned and `p` is its accumulated melody position. -/
+theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
+    (Autosegmental.realize toRep w).link true false p j ↔
+      p = (w.take j).count .H ∧ w[j]? = some .H := by
+  induction w generalizing p j with
+  | nil =>
+    have h0 : (Autosegmental.realize toRep []).tierLength true = 0 := by
+      rw [← Autosegmental.Representation.length_tierWord,
+        show (Autosegmental.realize toRep []).tierWord true = _ from
+          Autosegmental.Representation.tierWord_unit true, List.length_nil]
+    constructor
+    · rintro ⟨hp, -, -⟩
+      omega
+    · rintro ⟨-, h⟩
+      simp at h
+  | cons a w ih =>
+    haveI := Autosegmental.realize.instFinite toRep w
+    rw [show (Autosegmental.realize toRep (a :: w)).link true false p j
+          = (toRep a ⊗ Autosegmental.realize toRep w).link true false p j from rfl,
+      Autosegmental.Representation.link_tensor (X := toRep a)
+        (Y := Autosegmental.realize toRep w) true false p j]
+    cases a
+    · have hta : (toRep TBU.H).tierLength true = 1 := by
+        rw [← Autosegmental.Representation.length_tierWord,
+          show (toRep TBU.H).tierWord true = [_root_.Tone.TRN.H] from
+            Autosegmental.Representation.tierWord_ofData true]
+        rfl
+      have hfa : (toRep TBU.H).tierLength false = 1 := by
+        rw [← Autosegmental.Representation.length_tierWord,
+          show (toRep TBU.H).tierWord false = [()] from
+            Autosegmental.Representation.tierWord_ofData false]
+        rfl
+      have hj : (toRep TBU.H).link true false p j ↔ p = 0 ∧ j = 0 := by
+        refine (Autosegmental.Representation.link_junction
+          [_root_.Tone.TRN.H] [()]).trans ?_
+        constructor
+        · rintro (⟨-, -, h1, h2⟩ | ⟨h, -⟩)
+          · exact ⟨by simpa using h1, by simpa using h2⟩
+          · exact absurd h (by decide)
+        · rintro ⟨rfl, rfl⟩
+          exact Or.inl ⟨rfl, rfl, by simp, by simp⟩
+      rw [hj, hta, hfa, ih]
+      rcases j with _ | j
+      · simp
+      · constructor
+        · rintro (⟨-, h⟩ | ⟨hp1, -, hrec, hj1⟩)
+          · exact absurd h (by omega)
+          · rw [show j + 1 - 1 = j from rfl] at hrec
+            refine ⟨?_, by simpa using hj1⟩
+            rw [List.take_succ_cons, List.count_cons_self]
+            omega
+        · rintro ⟨hp, hj1⟩
+          rw [List.take_succ_cons, List.count_cons_self] at hp
+          refine Or.inr ⟨by omega, by omega, ?_, by simpa using hj1⟩
+          have : j + 1 - 1 = j := by omega
+          rw [this]
+          omega
+    · have hta : (toRep TBU.O).tierLength true = 0 := by
+        rw [← Autosegmental.Representation.length_tierWord,
+          show (toRep TBU.O).tierWord true = [] from
+            Autosegmental.Representation.tierWord_ofData true]
+        rfl
+      have hfa : (toRep TBU.O).tierLength false = 1 := by
+        rw [← Autosegmental.Representation.length_tierWord,
+          show (toRep TBU.O).tierWord false = [()] from
+            Autosegmental.Representation.tierWord_ofData false]
+        rfl
+      have hj : ¬ (toRep TBU.O).link true false p j := by
+        intro h
+        rcases (Autosegmental.Representation.link_junction
+          ([] : List _root_.Tone.TRN) [()]).mp h with ⟨-, -, h1, -⟩ | ⟨h1, -⟩
+        · simp at h1
+        · exact absurd h1 (by decide)
+      rw [hta, hfa, ih]
+      rcases j with _ | j
+      · constructor
+        · rintro (h | ⟨-, h, -⟩)
+          · exact absurd h hj
+          · omega
+        · rintro ⟨-, h⟩
+          simp at h
+      · constructor
+        · rintro (h | ⟨-, -, hrec, hj1⟩)
+          · exact absurd h hj
+          · rw [show j + 1 - 1 = j from rfl] at hrec
+            refine ⟨?_, by simpa using hj1⟩
+            rw [List.take_succ_cons, List.count_cons_of_ne (by decide)]
+            omega
+        · rintro ⟨hp, hj1⟩
+          rw [List.take_succ_cons, List.count_cons_of_ne (by decide)] at hp
+          refine Or.inr ⟨by omega, by omega, ?_, by simpa using hj1⟩
+          have : j + 1 - 1 = j := by omega
+          rw [this]
+          omega
+
 end TierWords
 
 theorem linearize_realize_toAR (w : List TBU) :

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -251,6 +251,33 @@ theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
           rw [this]
           omega
 
+/-- Links of the OCP-merged realization: the single fused `H` node (index `0`)
+    links exactly to the H-toned slots. -/
+theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
+    ((Autosegmental.realize toRep w).collapse true).link true false k j ↔
+      k = 0 ∧ w[j]? = some .H := by
+  haveI := Autosegmental.realize.instFinite toRep w
+  rw [Autosegmental.Representation.link_collapse]
+  constructor
+  · rintro ⟨p, q, hl, hk, hjq⟩
+    obtain ⟨hp, hq⟩ := (link_realize_toRep w p q).mp hl
+    refine ⟨?_, ?_⟩
+    · rw [← hk]
+      unfold Autosegmental.Representation.collapseIdx
+      rw [if_pos rfl, tierWord_realize_toRep_true]
+      exact Autosegmental.runIdx_replicate _ _ _
+    · rw [← hjq]
+      unfold Autosegmental.Representation.collapseIdx
+      rw [if_neg (by decide)]
+      exact hq
+  · rintro ⟨rfl, hj⟩
+    refine ⟨(w.take j).count .H, j, (link_realize_toRep w _ j).mpr ⟨rfl, hj⟩, ?_, ?_⟩
+    · unfold Autosegmental.Representation.collapseIdx
+      rw [if_pos rfl, tierWord_realize_toRep_true]
+      exact Autosegmental.runIdx_replicate _ _ _
+    · unfold Autosegmental.Representation.collapseIdx
+      rw [if_neg (by decide)]
+
 end TierWords
 
 theorem linearize_realize_toAR (w : List TBU) :

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -86,6 +86,28 @@ def toAR : TBU → AR _root_.Tone.TRN Unit
   | .H => .single _root_.Tone.TRN.H ()
   | .O => .bare ()
 
+/-- `toAR` in coordinates: the two-tier representation of one association
+    state (melody over `true`, timing over `false`). -/
+noncomputable def toRep (a : TBU) :
+    Autosegmental.Representation
+      (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
+  match a with
+  | .H => Autosegmental.Representation.single _root_.Tone.TRN.H ()
+  | .O => Autosegmental.Representation.bare ()
+
+instance (a : TBU) : Finite (toRep a).obj.V := by
+  cases a <;> exact inferInstanceAs (Finite ((_ : Bool) × Fin _))
+
+instance : DecidableEq (Autosegmental.TwoTier _root_.Tone.TRN Unit true) :=
+  inferInstanceAs (DecidableEq _root_.Tone.TRN)
+
+/-- The output representation in coordinates: OCP-merge then hull, both at the
+    melody tier. -/
+noncomputable def plateauRep (w : List TBU) :
+    Autosegmental.Representation
+      (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
+  ((Autosegmental.realize toRep w).collapse true).hull true
+
 theorem linearize_realize_toAR (w : List TBU) :
     (AR.realize toAR w).linearize
       = w.map fun a => ((), if a = .H then [_root_.Tone.TRN.H] else []) := by

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -226,7 +226,7 @@ nodes into one, giving [hyman-katamba-2010]'s output representation (7): a singl
 autosegment multiply linked to exactly the `plateau`, over an unchanged timing tier. -/
 
 theorem mem_links_realizeMerged_utp (p : ℕ × ℕ) :
-    p ∈ (realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ utp.Surfaces w p.2 := by
+    p ∈ (AR.realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ utp.Surfaces w p.2 := by
   have hL : ∀ j, (AR.realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ utp.Surfaces w j :=
     fun j => by rw [isLinkedLower_realize_toAR, utp.map_getElem?_H_iff]
   rw [realizeMerged_def,
@@ -235,12 +235,12 @@ theorem mem_links_realizeMerged_utp (p : ℕ × ℕ) :
 /-- Multiple association ((7)): the merged realization links melody node `0` to exactly
 the `plateau`. Unconditional: a toneless word has an empty plateau and no lines. -/
 theorem links_realizeMerged_utp :
-    (realizeMerged toAR (utp.map w)).links = {0} ×ˢ plateau w := by
+    (AR.realizeMerged toAR (utp.map w)).links = {0} ×ˢ plateau w := by
   ext ⟨k, j⟩; rw [mem_links_realizeMerged_utp]; simp [and_comm, eq_comm]
 
 /-- The timing tier survives the merge: one slot per input TBU. -/
 theorem lower_realizeMerged_utp :
-    (realizeMerged toAR (utp.map w)).lower.toList = List.replicate w.length () := by
+    (AR.realizeMerged toAR (utp.map w)).lower.toList = List.replicate w.length () := by
   rw [realizeMerged_def, collapseAR_lower]
   have h := List.eq_replicate_of_mem
     (l := (AR.realize toAR (utp.map w)).lower.toList) (a := ()) fun _ _ => rfl
@@ -250,7 +250,7 @@ theorem lower_realizeMerged_utp :
 /-- The fused plateau ((7)): with at least one H, the merged melody tier is a single H
 autosegment. -/
 theorem upper_realizeMerged_utp (hw : .H ∈ w) :
-    (realizeMerged toAR (utp.map w)).upper.toList = [Tone.TRN.H] := by
+    (AR.realizeMerged toAR (utp.map w)).upper.toList = [Tone.TRN.H] := by
   obtain ⟨m, hm⟩ : ∃ m, ((utp.map w).count .H) = m + 1 := by
     obtain ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     have := List.count_pos_iff.mpr <| List.mem_iff_getElem?.mpr
@@ -260,7 +260,7 @@ theorem upper_realizeMerged_utp (hw : .H ∈ w) :
 
 /-- (7) concretely: `HØØH` fuses to one H linked to all four TBUs. -/
 example :
-    (realizeMerged toAR (utp.map [.H, .O, .O, .H])).links
+    (AR.realizeMerged toAR (utp.map [.H, .O, .O, .H])).links
       = {(0, 0), (0, 1), (0, 2), (0, 3)} := by decide
 
 end AutosegmentalGrounding

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -214,7 +214,7 @@ def readTBU (s : Unit × List Tone.TRN) : TBU := if s.2.isEmpty then .O else .H
 /-- (37a): the TBU string is recoverable from the realized AR, so the complexity results
 transfer to the autosegmental analysis. -/
 theorem readTBU_linearize_realize (w : List TBU) :
-    ((realize toAR w).linearize).map readTBU = w := by
+    ((AR.realize toAR w).linearize).map readTBU = w := by
   rw [linearize_realize_toAR, List.map_map]
   conv_rhs => rw [← List.map_id w]
   exact List.map_congr_left fun a _ => by cases a <;> rfl
@@ -227,7 +227,7 @@ autosegment multiply linked to exactly the `plateau`, over an unchanged timing t
 
 theorem mem_links_realizeMerged_utp (p : ℕ × ℕ) :
     p ∈ (realizeMerged toAR (utp.map w)).links ↔ p.1 = 0 ∧ utp.Surfaces w p.2 := by
-  have hL : ∀ j, (realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ utp.Surfaces w j :=
+  have hL : ∀ j, (AR.realize toAR (utp.map w)).toGraph.IsLinkedLower j ↔ utp.Surfaces w j :=
     fun j => by rw [isLinkedLower_realize_toAR, utp.map_getElem?_H_iff]
   rw [realizeMerged_def,
     mem_links_collapseAR_of_upper_replicate (upper_realize_toAR (utp.map w)), hL]
@@ -243,7 +243,7 @@ theorem lower_realizeMerged_utp :
     (realizeMerged toAR (utp.map w)).lower.toList = List.replicate w.length () := by
   rw [realizeMerged_def, collapseAR_lower]
   have h := List.eq_replicate_of_mem
-    (l := (realize toAR (utp.map w)).lower.toList) (a := ()) fun _ _ => rfl
+    (l := (AR.realize toAR (utp.map w)).lower.toList) (a := ()) fun _ _ => rfl
   rwa [LabeledTuple.toList_length, ← AR.linearize_length, linearize_realize_toAR,
     List.length_map, Tone.Surfacing.map_length] at h
 

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -263,6 +263,31 @@ example :
     (AR.realizeMerged toAR (utp.map [.H, .O, .O, .H])).links
       = {(0, 0), (0, 1), (0, 2), (0, 3)} := by decide
 
+/-! #### The autosegmental grounding in coordinates
+
+The same claims on the graph foundation: the output representation's melody
+fuses to one `H`, linked exactly to the surfacing slots. -/
+
+/-- (7) in coordinates: the merged output's links are the fused `H` node over
+    the surfacing positions. -/
+theorem link_realizeMerged_map {w : List TBU} {k j : ℕ} :
+    ((Autosegmental.realize Tone.Plateauing.toRep (utp.map w)).collapse true).link
+        true false k j ↔ k = 0 ∧ utp.Surfaces w j := by
+  rw [Tone.Plateauing.link_realizeMerged, utp.map_getElem?_H_iff]
+
+/-- (7) concretely: `HØØH` fuses to one H linked to all four TBUs. -/
+example : ∀ j < 4,
+    ((Autosegmental.realize Tone.Plateauing.toRep
+      (utp.map [.H, .O, .O, .H])).collapse true).link true false 0 j := by
+  intro j hj
+  rw [link_realizeMerged_map]
+  refine ⟨rfl, ?_⟩
+  match j, hj with
+  | 0, _ => decide
+  | 1, _ => decide
+  | 2, _ => decide
+  | 3, _ => decide
+
 end AutosegmentalGrounding
 
 /-- Computationally, tone is different (§7): UTP is fully regular — regular but neither

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -26,7 +26,7 @@ Two realizations are checked, against the same forbidden tone melody `*HLH`:
   catches only a *local* `H-L-H` (three adjacent tonal nodes) — `hlh_excluded`.
 * `Autosegmental.realizeMerged` (`Collapse.lean`) is [jardine-2019]'s OCP-*merging*
   `g_T`: `g_T(Hⁿ)` is a *single* `H` node multiply associated. Banning `*HLH` over
-  `realizeMerged` becomes genuinely **non-local** — it forbids `H⁺ L⁺ H⁺` for *any*
+  `AR.realizeMerged` becomes genuinely **non-local** — it forbids `H⁺ L⁺ H⁺` for *any*
   plateau widths, because the plateaus collapse to single nodes before the melody is
   read (`hlhTier_merged_excludes_plateau` vs `hlhTier_unmerged_admits_plateau`).
 
@@ -138,7 +138,7 @@ theorem hhlh_excluded : [ToneSym.H, .H, .L, .H] ∉ ASL gT [hlh] := by decide
 /-! ### The OCP-merging realization: non-local tone plateauing
 
 [jardine-2019]'s `g_T` is OCP-*merging* — an `H`-plateau `Hⁿ` is a single `H` node, not
-`n` of them. `realizeMerged` (`Collapse.lean`) supplies that merge. Against it we ban
+`n` of them. `AR.realizeMerged` (`Collapse.lean`) supplies that merge. Against it we ban
 the *tonal-tier melody* `*HLH` — an `H-L-H` sequence read off the tone tier alone
 (`hlhTier`: upper `[H, L, H]`, no morae pinned), so the constraint is on tonal adjacency
 after merging, not on per-mora docking. This is where merging buys non-local power:
@@ -153,13 +153,13 @@ def hlhTier : Graph ToneSym Mora :=
     AR.float ToneSym.H).toGraph
 
 /-- The merging variant of `ASL`: the same forbidden-subgraph preimage, taken along the
-    OCP-merging realization `realizeMerged` instead of the bridge-only `AR.realize`. -/
+    OCP-merging realization `AR.realizeMerged` instead of the bridge-only `AR.realize`. -/
 def ASL' (g₀ : ToneSym → AR ToneSym Mora) (B : List (Graph ToneSym Mora)) : Language ToneSym :=
-  realizeMerged g₀ ⁻¹' { A | isFreeOf B A }
+  AR.realizeMerged g₀ ⁻¹' { A | isFreeOf B A }
 
 instance (g₀ : ToneSym → AR ToneSym Mora) (B : List (Graph ToneSym Mora))
     (w : List ToneSym) : Decidable (w ∈ ASL' g₀ B) :=
-  inferInstanceAs (Decidable (isFreeOf B (realizeMerged g₀ w)))
+  inferInstanceAs (Decidable (isFreeOf B (AR.realizeMerged g₀ w)))
 
 /-- `LHHLH` is excluded under merging: the `HH`-plateau merges, so the tone tier reads
     `L-H-L-H` and the medial `H-L-H` melody appears ([jardine-2019]'s `*HLH`). -/
@@ -170,7 +170,7 @@ theorem lhhlh_merged_excluded : [ToneSym.L, .H, .H, .L, .H] ∉ ASL' gT [hlhTier
 theorem hhh_merged_included : [ToneSym.H, .H, .H] ∈ ASL' gT [hlhTier] := by decide
 
 /-- **The non-local power merging buys.** An *unbounded* plateau `HH-LL-HH` is excluded
-    under `realizeMerged`: every run collapses, so the tone tier reads `H-L-H` and the
+    under `AR.realizeMerged`: every run collapses, so the tone tier reads `H-L-H` and the
     melody appears — no matter the plateau widths. -/
 theorem hlhTier_merged_excludes_plateau :
     [ToneSym.H, .H, .L, .L, .H, .H] ∉ ASL' gT [hlhTier] := by decide

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -95,6 +95,66 @@ theorem ASL.isStarFree_of_links_empty (g₀ : S → AR α β) (B : List (Graph �
     rw [hset]
     exact (isStarFree_occur_of_links_empty g₀ F hFmem).compl.inter ih'
 
+/-! #### The star-free placement in coordinates -/
+
+section Coordinate
+
+variable {ι : Type*} [Finite ι] {τ : ι → Type*}
+
+/-- For a single link-free forbidden factor, the strings whose realization
+    contains it form a star-free language: the finite intersection of per-tier
+    factor constraints, each the inverse image of a star-free contains-factor
+    language along a tier projection. -/
+theorem Representation.isStarFree_occur_of_link_free
+    (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    [∀ s, Finite (g₀ s).obj.V]
+    (F : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite F.obj.V]
+    (hF : ∀ i j p q, ¬ F.link i j p q) :
+    Language.IsStarFree {w : List S | F.FactorEmbeds (Autosegmental.realize g₀ w)} := by
+  have hset : {w : List S | F.FactorEmbeds (Autosegmental.realize g₀ w)}
+      = ⋂ i, {w : List S | F.tierWord i <:+: tierProj g₀ i (FreeMonoid.ofList w)} := by
+    ext w
+    haveI := Autosegmental.realize.instFinite g₀ w
+    simp only [Set.mem_setOf_eq, Set.mem_iInter,
+      Representation.factorEmbeds_iff_infix_of_link_free hF, tierProj_ofList]
+    exact Iff.rfl
+  rw [hset]
+  exact Language.IsStarFree.iInter fun i =>
+    (Language.isStarFree_containsFactor (F.tierWord i)).comap (tierProj g₀ i)
+
+/-- **Link-free autosegmental SL sets are star-free**, on the graph foundation:
+    when no forbidden factor carries association lines, `Representation.ASL` is
+    a Boolean combination of per-tier factor constraints. -/
+theorem Representation.ASL.isStarFree_of_link_free
+    (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+    [∀ s, Finite (g₀ s).obj.V]
+    (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
+    (hB : ∀ F ∈ B, haveI := F.property; ∀ i j p q, ¬ F.val.link i j p q) :
+    (Representation.ASL g₀ B).IsStarFree := by
+  induction B with
+  | nil =>
+    have : Representation.ASL g₀ ([] :
+        List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
+        = Set.univ :=
+      Set.eq_univ_of_forall fun w F hF => absurd hF (List.not_mem_nil)
+    rw [this]
+    exact Language.isStarFree_univ
+  | cons F B' ih =>
+    have hFl := hB F (List.mem_cons_self ..)
+    have ih' := ih fun F' hF' => hB F' (List.mem_cons_of_mem _ hF')
+    have hset : Representation.ASL g₀ (F :: B') =
+        {w : List S | haveI := F.property
+          F.val.FactorEmbeds (Autosegmental.realize g₀ w)}ᶜ ∩ Representation.ASL g₀ B' := by
+      ext w
+      show (∀ G ∈ F :: B', _) ↔ _
+      rw [List.forall_mem_cons]
+      exact Iff.rfl
+    rw [hset]
+    haveI := F.property
+    exact (Representation.isStarFree_occur_of_link_free g₀ F.val hFl).compl.inter ih'
+
+end Coordinate
+
 end Autosegmental
 
 namespace Jardine2019

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -22,7 +22,7 @@ banned-subgraph constraints over its realizations.
 Two realizations are checked, against the same forbidden tone melody `*HLH`:
 
 * `Autosegmental.realize` uses the project's *bridge-only* `concat` (the coproduct), so
-  an `H`-plateau `Hⁿ` stays `n` separate `H` nodes. Banning `*HLH` over `realize` then
+  an `H`-plateau `Hⁿ` stays `n` separate `H` nodes. Banning `*HLH` over `AR.realize` then
   catches only a *local* `H-L-H` (three adjacent tonal nodes) — `hlh_excluded`.
 * `Autosegmental.realizeMerged` (`Collapse.lean`) is [jardine-2019]'s OCP-*merging*
   `g_T`: `g_T(Hⁿ)` is a *single* `H` node multiply associated. Banning `*HLH` over
@@ -60,13 +60,13 @@ contains `F` form a star-free language: the intersection of two per-tier
 factor-occurrence constraints, each the inverse image (`comap`) of a star-free
 contains-factor language along a tier projection. -/
 theorem isStarFree_occur_of_links_empty (g₀ : S → AR α β) (F : Graph α β) (hF : F.links = ∅) :
-    Language.IsStarFree {w : List S | SubgraphEmbeds F (realize g₀ w).toGraph} := by
-  have hset : {w : List S | SubgraphEmbeds F (realize g₀ w).toGraph}
+    Language.IsStarFree {w : List S | SubgraphEmbeds F (AR.realize g₀ w).toGraph} := by
+  have hset : {w : List S | SubgraphEmbeds F (AR.realize g₀ w).toGraph}
       = {w : List S | F.upper.toList <:+: upperProj g₀ (FreeMonoid.ofList w)}
         ∩ {w : List S | F.lower.toList <:+: lowerProj g₀ (FreeMonoid.ofList w)} := by
     ext w
     simp only [Set.mem_setOf_eq, Set.mem_inter_iff]
-    rw [subgraphEmbeds_iff_infix_of_links_empty F (realize g₀ w).toGraph hF,
+    rw [subgraphEmbeds_iff_infix_of_links_empty F (AR.realize g₀ w).toGraph hF,
       realize_upper_toList, realize_lower_toList]
   rw [hset]
   exact ((Language.isStarFree_containsFactor F.upper.toList).comap (upperProj g₀)).inter
@@ -88,9 +88,9 @@ theorem ASL.isStarFree_of_links_empty (g₀ : S → AR α β) (B : List (Graph �
     have hFmem : F.links = ∅ := hB F (List.mem_cons_self ..)
     have ih' := ih (fun F' hF' => hB F' (List.mem_cons_of_mem _ hF'))
     have hset : ASL g₀ (F :: B') =
-        {w : List S | SubgraphEmbeds F (realize g₀ w).toGraph}ᶜ ∩ ASL g₀ B' := by
+        {w : List S | SubgraphEmbeds F (AR.realize g₀ w).toGraph}ᶜ ∩ ASL g₀ B' := by
       ext w
-      show (∀ G ∈ F :: B', ¬ SubgraphEmbeds G (realize g₀ w).toGraph) ↔ _
+      show (∀ G ∈ F :: B', ¬ SubgraphEmbeds G (AR.realize g₀ w).toGraph) ↔ _
       rw [List.forall_mem_cons]; exact Iff.rfl
     rw [hset]
     exact (isStarFree_occur_of_links_empty g₀ F hFmem).compl.inter ih'
@@ -153,7 +153,7 @@ def hlhTier : Graph ToneSym Mora :=
     AR.float ToneSym.H).toGraph
 
 /-- The merging variant of `ASL`: the same forbidden-subgraph preimage, taken along the
-    OCP-merging realization `realizeMerged` instead of the bridge-only `realize`. -/
+    OCP-merging realization `realizeMerged` instead of the bridge-only `AR.realize`. -/
 def ASL' (g₀ : ToneSym → AR ToneSym Mora) (B : List (Graph ToneSym Mora)) : Language ToneSym :=
   realizeMerged g₀ ⁻¹' { A | isFreeOf B A }
 
@@ -175,7 +175,7 @@ theorem hhh_merged_included : [ToneSym.H, .H, .H] ∈ ASL' gT [hlhTier] := by de
 theorem hlhTier_merged_excludes_plateau :
     [ToneSym.H, .H, .L, .L, .H, .H] ∉ ASL' gT [hlhTier] := by decide
 
-/-- The same string is **admitted** under the non-merging `realize`: with the plateaus
+/-- The same string is **admitted** under the non-merging `AR.realize`: with the plateaus
     kept apart, the tone tier reads `H-H-L-L-H-H`, which has no three *adjacent* `H-L-H`
     nodes. The contrast with `hlhTier_merged_excludes_plateau` is exactly the non-local
     expressivity OCP merging adds — the local `hlh_excluded` constraint cannot see it. -/


### PR DESCRIPTION
The strict carrier stops being a first-order object: NormalForm.lean derives the tuple presentation from the graph foundation (normalize-as-reindexing, tierWord/linkRel readers, tierWord_tensor, realize into the skeleton monoid). In progress: factor layer + consumer migrations, bipartite deletion, Graph/AR renames.