### PR TITLE
refactor(Phonology/Autosegmental): port direct-carrier consumers

### DIFF
--- a/Linglib/Fragments/Poko/Tone.lean
+++ b/Linglib/Fragments/Poko/Tone.lean
@@ -74,7 +74,7 @@ def Syll.morpheme : Syll → Morpheme
 /-- Each stem's lexical melody ([mcpherson-lamont-2026] ex. 3): tones
     over the stem's single TBU, with the lexical pre-linking — the H of
     an `/M^H/` stem is the sole unlinked (floating) element. -/
-def Syll.melody (s : Syll) : Graph (TierSpec TRN) (SegSpec Syll) :=
+def Syll.melody (s : Syll) : FloatingForm Syll TRN :=
   match s with
   | .kak => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
   | .ri  => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
@@ -87,8 +87,8 @@ def Syll.melody (s : Syll) : Graph (TierSpec TRN) (SegSpec Syll) :=
 
 /-- The underlying form of a stem sequence: melodies concatenated
     left-to-right. -/
-def word (ss : List Syll) : Graph (TierSpec TRN) (SegSpec Syll) :=
-  .concatList (ss.map Syll.melody)
+def word (ss : List Syll) : FloatingForm Syll TRN :=
+  .concatInputs (ss.map Syll.melody)
 
 /-- Poko autosegmental forms: syllable backbone, `TRN` tone tier. -/
 abbrev Form := FloatingForm Syll TRN

--- a/Linglib/Fragments/Tangale/Phonology.lean
+++ b/Linglib/Fragments/Tangale/Phonology.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Phonology.Autosegmental.AR
+import Linglib.Phonology.Autosegmental.Junction
 
 /-!
 # Tangale tone processes and the elision cascade
@@ -32,51 +32,54 @@ inductive Tone where
   | H | L
   deriving DecidableEq, Repr
 
-variable {β : Type*}
+open Autosegmental
 
-/-- High Tone Spread ([kidda-1985] (31)): the toneme at `i` — an H
-linked to TBU `j` at a morpheme or word boundary — spreads onto the
-following TBU. The structural description is carried by the
-application theorems. -/
-def hts (g : Graph Tone β) (i j : ℕ) : Graph Tone β := g.link i (j + 1)
+/-- High Tone Spread ([kidda-1985] (31)) on the link presentation: the toneme
+    at `i` — an H linked to TBU `j` at a morpheme or word boundary — spreads
+    onto the following TBU. -/
+def hts (L : Bool → Bool → ℕ → ℕ → Prop) (i j : ℕ) (b b' : Bool) (p q : ℕ) : Prop :=
+  L b b' p q ∨ b = true ∧ b' = false ∧ p = i ∧ q = j + 1
 
-/-- Left Line Delinking ([kidda-1985] (35a)): erase the original
-(left) line after the toneme has spread rightward. -/
-def lld (g : Graph Tone β) (i j : ℕ) : Graph Tone β := g.delink i j
+/-- Left Line Delinking ([kidda-1985] (35a)): erase the original (left) line
+    after the toneme has spread rightward. -/
+def lld (L : Bool → Bool → ℕ → ℕ → Prop) (i j : ℕ) (b b' : Bool) (p q : ℕ) : Prop :=
+  L b b' p q ∧ ¬ (b = true ∧ b' = false ∧ p = i ∧ q = j)
 
-/-- Spread creates the falling contour (§4.6): the docked TBU
-surfaces with H on top of whatever it already bore. -/
-theorem hts_surfacesWith_H {g : Graph Tone β} {i j : ℕ}
-    (hH : g.upper.get? i = some Tone.H) :
-    (hts g i j).SurfacesWith Tone.H (j + 1) :=
-  ⟨i, Finset.mem_insert_self _ _, hH⟩
+variable {ws : ∀ b, List (TwoTier Tone Unit b)} {L : Bool → Bool → ℕ → ℕ → Prop}
 
-/-- Spread followed by Left Line Delinking shifts the H one TBU
-rightward ((34)): the docked TBU keeps the new line and the source
-loses the original. -/
-theorem lld_hts_shift {g : Graph Tone β} {i j : ℕ}
-    (hH : g.upper.get? i = some Tone.H) :
-    (lld (hts g i j) i j).SurfacesWith Tone.H (j + 1) ∧
-    (i, j) ∉ (lld (hts g i j) i j).links := by
-  refine ⟨⟨i, ?_, hH⟩, by simp [lld, hts]⟩
-  simp [lld, hts]
+/-- Spread creates the falling contour (§4.6): the docked TBU surfaces with H
+    on top of whatever it already bore. -/
+theorem hts_surfacesWith_H {i j : ℕ} (hH : (ws true)[i]? = some Tone.H)
+    (hj : j + 1 < (ws false).length) :
+    (Representation.ofData ws (hts L i j)).surfacesWith Tone.H (j + 1) := by
+  rcases List.getElem?_eq_some_iff.mp hH with ⟨hi, -⟩
+  refine ⟨i, (Representation.link_ofData true false i (j + 1)).mpr
+    ⟨by decide, hi, hj, Or.inl (Or.inr ⟨rfl, rfl, rfl, rfl⟩)⟩, ?_⟩
+  rw [Representation.tierWord_ofData]
+  exact hH
 
-/-- Blocking is representationally visible: where the spread line is
-absent, applying HTS changes the graph. -/
-theorem hts_ne_self {g : Graph Tone β} {i j : ℕ}
-    (h : (i, j + 1) ∉ g.links) : hts g i j ≠ g :=
-  fun he => h (he ▸ Finset.mem_insert_self _ _)
-
-/-- 'Horse is good' ([kidda-1985] (29a) *tuužé koŋ*): H on the noun's
-final TBU, L on the predicate. -/
-def horseIsGood : Graph Tone Unit :=
-  ⟨.ofList [Tone.H, Tone.L], .ofList [(), (), ()], {(0, 1), (1, 2)}⟩
-
-/-- After HTS the predicate TBU bears both H and L — the falling
-contour of *tụụzẹ́ kôŋ*, realized as such pause-finally ((29a)). -/
-example :
-    (hts horseIsGood 0 1).SurfacesWith Tone.H 2 ∧
-    (hts horseIsGood 0 1).SurfacesWith Tone.L 2 := by decide
+/-- Spread followed by Left Line Delinking shifts the H one TBU rightward
+    ((34)): the docked TBU keeps the new line and the source loses the
+    original. -/
+theorem lld_hts_shift {i j : ℕ} (hH : (ws true)[i]? = some Tone.H)
+    (hj : j + 1 < (ws false).length) (hne : j + 1 ≠ j)
+    (hor : ∀ p q, ¬ L false true p q) :
+    (Representation.ofData ws (lld (hts L i j) i j)).surfacesWith Tone.H (j + 1) ∧
+      ¬ (Representation.ofData ws (lld (hts L i j) i j)).link true false i j := by
+  rcases List.getElem?_eq_some_iff.mp hH with ⟨hi, -⟩
+  constructor
+  · refine ⟨i, (Representation.link_ofData true false i (j + 1)).mpr
+      ⟨by decide, hi, hj, Or.inl ⟨Or.inr ⟨rfl, rfl, rfl, rfl⟩, ?_⟩⟩, ?_⟩
+    · rintro ⟨-, -, -, h⟩
+      exact hne h
+    · rw [Representation.tierWord_ofData]
+      exact hH
+  · rintro h
+    rcases (Representation.link_ofData true false i j).mp h with
+      ⟨-, -, -, ⟨-, hno⟩ | ⟨hraw | ⟨hfalse, -⟩, -⟩⟩
+    · exact hno ⟨rfl, rfl, rfl, rfl⟩
+    · exact hor _ _ hraw
+    · exact absurd hfalse (by decide)
 
 /-! ### The elision cascade (Ch. 2)
 

--- a/Linglib/Phonology/Autosegmental/Correspondence.lean
+++ b/Linglib/Phonology/Autosegmental/Correspondence.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.Embedding
+import Linglib.Phonology.Autosegmental.Junction
 
 /-!
 # Phonological transformations as correspondence-graph relations
@@ -84,6 +85,67 @@ theorem specifiedBy_append (φ ψ : List (Graph S T)) (G : Graph S T) :
 /-- The empty grammar specifies all of GEN. -/
 @[simp] theorem specifiedBy_nil (G : Graph S T) : specifiedBy [] G ↔ True := by
   simp [specifiedBy, Graph.Free]
+
+/-! ### Correspondence on the graph foundation
+
+The same layer over two-tier representations: input over `true`, output over
+`false`, correspondence arcs the links, banned subgraphs `Representation.Free`. -/
+
+section Coordinate
+
+universe u
+variable {S T : Type u}
+
+/-- A finite two-tier correspondence representation. -/
+abbrev Rep (S T : Type u) :=
+  {G : Representation.{u, 0, u} (Sigma.fst : ((b : Bool) × TwoTier S T b) → Bool) //
+    Finite G.obj.V}
+
+/-- The **input** string: the `true`-tier word. -/
+noncomputable def Rep.input (G : Rep S T) : List S :=
+  haveI := G.property
+  G.val.tierWord true
+
+/-- The **output** string: the `false`-tier word. -/
+noncomputable def Rep.output (G : Rep S T) : List T :=
+  haveI := G.property
+  G.val.tierWord false
+
+/-- **R(CG)** ([jardine-2016-diss] Def. 25) on the foundation: the string
+    relation realized by a set of correspondence representations. -/
+def relRep (CG : Rep S T → Prop) (w : List S) (v : List T) : Prop :=
+  ∃ G, CG G ∧ G.input = w ∧ G.output = v
+
+/-- `R` is monotone: more correspondence graphs realize a larger relation. -/
+theorem relRep_mono {CG CG' : Rep S T → Prop} (h : ∀ G, CG G → CG' G) {w v} :
+    relRep CG w v → relRep CG' w v := by
+  rintro ⟨G, hG, hi, ho⟩
+  exact ⟨G, h G hG, hi, ho⟩
+
+/-- A process **specified by banned subgraphs** `φ` (Jardine's `CG(φ)`): the
+    representations free of every forbidden pattern. -/
+def specifiedByRep (φ : List (Rep S T)) (G : Rep S T) : Prop :=
+  haveI := G.property
+  G.val.Free φ
+
+/-- A string relation is **local** when presented by a finite banned-subgraph
+    grammar over correspondence representations. -/
+def IsLocalRep (R : List S → List T → Prop) : Prop :=
+  ∃ φ : List (Rep S T), R = relRep (specifiedByRep φ)
+
+/-- Banned-subgraph grammars **compose by union**: the `L^NL_G` conjunction of
+    two local constraint sets. -/
+theorem specifiedByRep_append (φ ψ : List (Rep S T)) (G : Rep S T) :
+    specifiedByRep (φ ++ ψ) G ↔ specifiedByRep φ G ∧ specifiedByRep ψ G := by
+  unfold specifiedByRep Representation.Free
+  rw [List.forall_mem_append]
+
+/-- The empty grammar specifies all of GEN. -/
+@[simp] theorem specifiedByRep_nil (G : Rep S T) : specifiedByRep [] G ↔ True := by
+  unfold specifiedByRep Representation.Free
+  simp
+
+end Coordinate
 
 end Correspondence
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Morphology.MorphWord
-import Linglib.Phonology.Autosegmental.AR
+import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple
+import Linglib.Phonology.Autosegmental.NonCrossing
 import Linglib.Phonology.Autosegmental.NonCrossing
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Image
@@ -106,12 +107,16 @@ bookkeeping (`deletedTier`, `surfaceLinks` vs underlying `links`) is
 language-independent.
 -/
 
-/-- An autosegmental form: extends `Graph (TierSpec T) (SegSpec S)`
-    with OT-style surface bookkeeping. The inherited `Graph` is the
-    *underlying* representation; `deletedTier` and `surfaceLinks`
-    track the surface state separately. -/
-structure FloatingForm (S T : Type*)
-    extends Graph (TierSpec T) (SegSpec S) where
+/-- An autosegmental form: an underlying two-tier presentation (tones over
+    segments, with association links) plus OT-style surface bookkeeping —
+    `deletedTier` and `surfaceLinks` track the surface state separately. -/
+structure FloatingForm (S T : Type*) where
+  /-- The tonal tier (underlying). -/
+  upper : LabeledTuple (TierSpec T)
+  /-- The segmental backbone (underlying). -/
+  lower : LabeledTuple (SegSpec S)
+  /-- The underlying association links. -/
+  links : Finset Link
   /-- SURFACE deletion set on the upper tier (current state). -/
   deletedTier : Finset TierIdx
   /-- SURFACE association lines (current state). May differ from
@@ -132,11 +137,9 @@ variable {S T : Type*} [DecidableEq S] [DecidableEq T] (f : FloatingForm S T)
 
 /-! ### Surface graph (derived view) -/
 
-/-- The **surface graph**: same tiers as the underlying graph but with
-    `surfaceLinks` in place of `links`. Makes the underlying/surface
-    duality explicit — both states are `Graph`s sharing tier data. -/
-@[reducible] def surfaceGraph : Graph (TierSpec T) (SegSpec S) :=
-  { f.toGraph with links := f.surfaceLinks }
+/-- The **surface state is planar**: the surface links satisfy the
+    per-pair No-Crossing Constraint. -/
+abbrev SurfaceIsPlanar : Prop := IsNonCrossing f.surfaceLinks
 
 /-! ### Construction -/
 
@@ -195,6 +198,44 @@ abbrev IsInsertedLink (l : Link) : Prop := l ∈ f.surfaceLinks ∧ l ∉ f.link
 /-- An underlying link absent on the surface — deleted by GEN (`MAX` source). -/
 abbrev IsDeletedLink (l : Link) : Prop := l ∈ f.links ∧ l ∉ f.surfaceLinks
 
+/-- The lower-tier slot `i` is linked on the surface. -/
+abbrev SurfaceLinkedLower (i : SegIdx) : Prop := ∃ l ∈ f.surfaceLinks, l.snd = i
+
+/-- The presentation is in bounds: every link's endpoints index into the
+    tiers. -/
+def InBounds : Prop := ∀ p ∈ f.links, p.1 < f.upper.len ∧ p.2 < f.lower.len
+
+instance [DecidableEq S] [DecidableEq T] : Decidable f.InBounds :=
+  inferInstanceAs (Decidable (∀ _ ∈ _, _))
+
+/-! ### Input concatenation -/
+
+/-- Concatenation of underlying input states ([jardine-heinz-2015]): tier
+    juxtaposition with index-shifted links, surface mirroring underlying. -/
+def hconcat (g : FloatingForm S T) : FloatingForm S T :=
+  let ls := f.links ∪ g.links.image (shiftLink f.upper.len f.lower.len)
+  { upper := f.upper.concat g.upper
+    lower := f.lower.concat g.lower
+    links := ls
+    deletedTier := ∅
+    surfaceLinks := ls }
+
+@[simp] theorem hconcat_upper (g : FloatingForm S T) :
+    (f.hconcat g).upper = f.upper.concat g.upper := rfl
+
+@[simp] theorem hconcat_lower (g : FloatingForm S T) :
+    (f.hconcat g).lower = f.lower.concat g.lower := rfl
+
+@[simp] theorem hconcat_links (g : FloatingForm S T) :
+    (f.hconcat g).links = f.links ∪ g.links.image (shiftLink f.upper.len f.lower.len) := rfl
+
+@[simp] theorem hconcat_surfaceLinks (g : FloatingForm S T) :
+    (f.hconcat g).surfaceLinks
+      = f.links ∪ g.links.image (shiftLink f.upper.len f.lower.len) := rfl
+
+@[simp] theorem hconcat_deletedTier (g : FloatingForm S T) :
+    (f.hconcat g).deletedTier = ∅ := rfl
+
 /-! ### Atomic GEN operations -/
 
 /-- Delete the underlying upper-tier element at index `k`. Cascades to remove
@@ -244,8 +285,8 @@ def gen : Finset (FloatingForm S T) :=
     shrink the surface link set (`IsNonCrossing.subset`), and each inserted link
     passed the `¬ Crosses` filter (`IsNonCrossing.insert_of_not_indexCrosses`).
     So `gen` is closed on the structural well-formedness condition. -/
-theorem gen_preserves_isPlanar (h : f.surfaceGraph.IsPlanar) :
-    ∀ g ∈ f.gen, g.surfaceGraph.IsPlanar := by
+theorem gen_preserves_isPlanar (h : f.SurfaceIsPlanar) :
+    ∀ g ∈ f.gen, g.SurfaceIsPlanar := by
   have h' : IsNonCrossing f.surfaceLinks := h
   intro g hg
   show IsNonCrossing g.surfaceLinks
@@ -298,6 +339,14 @@ def countUpper (p : TierIdx → Prop) [DecidablePred p] : ℕ :=
 /-- Count lower-tier (backbone) positions satisfying decidable `p`. -/
 def countLower (p : SegIdx → Prop) [DecidablePred p] : ℕ :=
   (List.range f.lower.len).countP (λ i => decide (p i))
+
+/-- The empty input. -/
+def emptyInput : FloatingForm S T :=
+  { upper := .empty, lower := .empty, links := ∅, deletedTier := ∅, surfaceLinks := ∅ }
+
+/-- Left-to-right concatenation of a list of input states. -/
+def concatInputs (gs : List (FloatingForm S T)) : FloatingForm S T :=
+  gs.foldr hconcat emptyInput
 
 end FloatingForm
 

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -378,6 +378,13 @@ theorem Representation.isPlanar_spread (a : α) (bs : List β) :
     IsPlanar (Representation.spread a bs).obj.graph :=
   (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
+/-- A timing slot **surfaces with** melody label `a`: some `a`-labelled melody
+    node links to it. -/
+def Representation.surfacesWith
+    (X : Representation (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool))
+    [Finite X.obj.V] (a : α) (j : ℕ) : Prop :=
+  ∃ k, X.link true false k j ∧ (X.tierWord true)[k]? = some a
+
 end CoordinateJunction
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -34,17 +34,16 @@ namespace Autosegmental
 
 variable {S T : Type*}
 
-namespace Graph
+namespace FloatingForm
 
 variable (m : Morpheme) (tones : List T) (tbus : List S) (links : Finset Link)
 
 /-- One morpheme's underlying autosegmental contribution ([rolle-2018]
     §2.1 Def 1): `tones` over `tbus`, every element sponsored by `m`,
-    pre-linked by `links` in melody-local coordinates. -/
-def melody : Graph (TierSpec T) (SegSpec S) where
-  upper := .ofList (tones.map fun t => { value := t, morpheme := m })
-  lower := .ofList (tbus.map fun s => { seg := s, morpheme := m })
-  links := links
+    pre-linked by `links` in melody-local coordinates; an input state. -/
+def melody : FloatingForm S T :=
+  mkInput (tbus.map fun s => { seg := s, morpheme := m })
+    (tones.map fun t => { value := t, morpheme := m }) links
 
 @[simp] theorem melody_upper :
     (melody m tones tbus links).upper
@@ -68,17 +67,7 @@ theorem melody_lower_morpheme {j : ℕ} (hj : j < tbus.length) :
   rw [melody_lower, LabeledTuple.ofList_get?]
   simp [hj]
 
-end Graph
-
-/-- Package an underlying graph as a derivation input: nothing deleted,
-    surface links mirror the underlying links. -/
-def FloatingForm.ofGraph (g : Graph (TierSpec T) (SegSpec S)) : FloatingForm S T :=
-  { g with deletedTier := ∅, surfaceLinks := g.links }
-
-/-- `mkInput` is `ofGraph` of the corresponding raw graph. -/
-theorem FloatingForm.mkInput_eq_ofGraph (lower : List (SegSpec S))
-    (upper : List (TierSpec T)) (links : Finset Link) :
-    mkInput lower upper links = ofGraph ⟨.ofList upper, .ofList lower, links⟩ := rfl
+end FloatingForm
 
 /-- **Consistency of Exponence** ([zimmermann-2024] §4): GEN never alters
     morphemic affiliation — every one-step candidate carries its input's

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.Floating
+import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Autosegmental.AR
 import Linglib.Phonology.Autosegmental.Embedding
 
@@ -241,59 +242,33 @@ association lines by the prefix's tier lengths.
 
 /-- The historic-tense exponent: a floating `(d)` melodic segment,
     no skeleton, no associations ([laoide-kemp-2026] Fig. 1). -/
-def historicExponent : Graph (TierSpec Segment) (SegSpec CVKind) where
+def historicExponent : FloatingForm CVKind Segment where
   upper := .ofList [mel .dPrime mHist]
   lower := .empty
   links := ∅
+  deletedTier := ∅
+  surfaceLinks := ∅
 
 /-- The past-tense impersonal exponent: an empty CV unit (`[C, V]`
     skeleton), no melody, no associations ([laoide-kemp-2026] §6.2,
     Fig. 5). -/
-def impersonalExponent : Graph (TierSpec Segment) (SegSpec CVKind) where
+def impersonalExponent : FloatingForm CVKind Segment where
   upper := .empty
   lower := .ofList [slot .C mImpers, slot .V mImpers]
   links := ∅
-
-/-- Wrap a bare association graph as an input `FloatingForm` (surface
-    state = underlying state). -/
-private def ofGraph (g : Graph (TierSpec Segment) (SegSpec CVKind)) :
-    FloatingForm CVKind Segment :=
-  FloatingForm.mkInput g.lower.toList g.upper.toList g.links
-
-/-- Rebuilding a `LabeledTuple` from its underlying list is the identity (up to
-    the length-cast packaged in `LabeledTuple.ext`). The round-trip
-    `mkInput` performs on the tiers is therefore inert. -/
-private theorem ofList_toList {γ : Type*} (a : LabeledTuple γ) :
-    LabeledTuple.ofList a.toList = a := by
-  refine LabeledTuple.ext (by simp) ?_
-  funext i
-  simp only [LabeledTuple.ofList_label, LabeledTuple.toList, List.get_eq_getElem,
-    Function.comp_apply, List.getElem_ofFn]
-  congr 1
-
-/-- `ofGraph` preserves the underlying graph: the `.toList`/`.ofList` round-trip
-    on the tiers cancels (`ofList_toList`) and the links pass through unchanged. -/
-@[simp] private theorem ofGraph_toGraph (g : Graph (TierSpec Segment) (SegSpec CVKind)) :
-    (ofGraph g).toGraph = g := by
-  unfold ofGraph FloatingForm.mkInput
-  cases g with
-  | mk upper lower links =>
-    simp only [Graph.mk.injEq]
-    exact ⟨ofList_toList upper, ofList_toList lower, trivial⟩
-
-@[simp] private theorem ofGraph_surfaceLinks (g : Graph (TierSpec Segment) (SegSpec CVKind)) :
-    (ofGraph g).surfaceLinks = g.links := rfl
+  deletedTier := ∅
+  surfaceLinks := ∅
 
 /-- Prefix the historic-tense exponent onto a stem (Fig. 1): floating
     `(d)` becomes melody index 0; the stem's melody shifts right by one. -/
 def withHist (stem : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
-  ofGraph (historicExponent.concat stem.toGraph)
+  historicExponent.hconcat stem
 
 /-- Prefix the empty-CV impersonal exponent onto a stem (Fig. 5): the
     stem's skeleton shifts right by two, so the left edge is an empty
     `C₀V₀` unit. -/
 def withImpers (stem : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
-  ofGraph (impersonalExponent.concat stem.toGraph)
+  impersonalExponent.hconcat stem
 
 /-! ## §5 Lenition: the `{L}` deletion rule for *f*
 
@@ -357,8 +332,8 @@ instance (f : FloatingForm CVKind Segment) (j : Nat) : Decidable (isVSlot f j) :
     non-empty V-slot. The structural predicate at the heart of the
     paper's analysis ([laoide-kemp-2026] §4.1). -/
 def dDockable (f : FloatingForm CVKind Segment) : Prop :=
-  isCSlot f 0 ∧ ¬ f.surfaceGraph.IsLinkedLower 0 ∧
-    isVSlot f 1 ∧ f.surfaceGraph.IsLinkedLower 1
+  isCSlot f 0 ∧ ¬ f.SurfaceLinkedLower 0 ∧
+    isVSlot f 1 ∧ f.SurfaceLinkedLower 1
 
 instance (f : FloatingForm CVKind Segment) : Decidable (dDockable f) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _))
@@ -464,26 +439,17 @@ dissolved). -/
     ([bermudez-otero-2012]'s strict modularity) — not a non-local
     insertion rule. -/
 theorem withHist_eq_concat (stem : FloatingForm CVKind Segment) :
-    (withHist stem).toGraph = historicExponent.concat stem.toGraph := by
-  rw [withHist, ofGraph_toGraph]
-
-/-- `historicExponent` is in-bounds: it has no links, so the condition
-    is vacuous. -/
-private theorem historicExponent_inBounds : historicExponent.InBounds := by decide
-
-/-- `historicExponent` is planar: `IsPlanar` reads only `.links`, which
-    is `∅` — the same content as `Graph.empty`. -/
-private theorem historicExponent_isPlanar : historicExponent.IsPlanar :=
-  Graph.isPlanar_empty (α := TierSpec Segment) (β := SegSpec CVKind)
+    withHist stem = historicExponent.hconcat stem := rfl
 
 /-- Composing the historic-tense morpheme preserves autosegmental
     well-formedness — a direct consequence of the No-Crossing
-    Constraint being morpheme-modular (`ncc_isMonoidal`). The
-    floating `(d)` is prefixed without ever creating a crossing
-    association line, for any planar stem. -/
+    Constraint being morpheme-modular. The floating `(d)` shifts the
+    stem's links monotonically, never creating a crossing line. -/
 theorem withHist_isPlanar (stem : FloatingForm CVKind Segment)
-    (hP : stem.toGraph.IsPlanar) : (withHist stem).toGraph.IsPlanar :=
-  Graph.isPlanar_concat historicExponent_inBounds historicExponent_isPlanar hP
+    (hP : IsNonCrossing stem.links) : IsNonCrossing (withHist stem).links := by
+  rw [withHist_eq_concat, FloatingForm.hconcat_links]
+  simp only [historicExponent, Finset.empty_union]
+  exact hP.image_monotone (ρ := (· + 1)) fun _ _ h => Nat.add_le_add_right h 1
 
 /-- A concrete suffix used to probe right-insensitivity. -/
 private def someSuffix : FloatingForm CVKind Segment :=
@@ -498,7 +464,7 @@ private def someSuffix : FloatingForm CVKind Segment :=
     *looks* boundary-spanning but is in fact morpheme-local. -/
 theorem dPrime_right_invariant :
     dPrimeSurfaces (withHist ól) ↔
-      dPrimeSurfaces (withHist (ofGraph (ól.toGraph.concat someSuffix.toGraph))) := by
+      dPrimeSurfaces (withHist ((ól.hconcat someSuffix))) := by
   decide
 
 /-! ### The general no-look-ahead theorem
@@ -515,11 +481,9 @@ alone — the formal content of strict modularity (no look-ahead). -/
     reduces to the stem having an underlying link to `j`: the floating
     `(d)` shifts melody indices only, never skeletal ones. -/
 private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment) (j : Nat) :
-    (withHist X).surfaceGraph.IsLinkedLower j ↔ ∃ a, (a, j) ∈ X.toGraph.links := by
-  have hlinks : (withHist X).surfaceGraph.links =
-      X.toGraph.links.image (shiftLink 1 0) := by
-    show (historicExponent.concat X.toGraph).links = _
-    rw [Graph.links_concat]
+    (withHist X).SurfaceLinkedLower j ↔ ∃ a, (a, j) ∈ X.links := by
+  have hlinks : (withHist X).surfaceLinks = X.links.image (shiftLink 1 0) := by
+    rw [withHist_eq_concat, FloatingForm.hconcat_surfaceLinks]
     simp [historicExponent]
   constructor
   · rintro ⟨p, hp, hpj⟩
@@ -532,7 +496,6 @@ private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment) (j : Na
       rw [h2]; exact hpj
     rw [← hqj]; exact hq
   · rintro ⟨a, ha⟩
-    show ∃ p ∈ (withHist X).surfaceGraph.links, p.snd = j
     refine ⟨(a + 1, j), ?_, rfl⟩
     rw [hlinks, Finset.mem_image]
     exact ⟨(a, j), ha, by simp [shiftLink]⟩
@@ -542,9 +505,9 @@ private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment) (j : Na
     `≥ stem.lower.len`, never reaching `j`. -/
 private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment) {j : Nat}
     (hj : j < stem.lower.len) :
-    (∃ a, (a, j) ∈ (stem.toGraph.concat suffix.toGraph).links) ↔
-      ∃ a, (a, j) ∈ stem.toGraph.links := by
-  rw [Graph.links_concat]
+    (∃ a, (a, j) ∈ (stem.hconcat suffix).links) ↔
+      ∃ a, (a, j) ∈ stem.links := by
+  rw [FloatingForm.hconcat_links]
   constructor
   · rintro ⟨a, ha⟩
     rw [Finset.mem_union] at ha
@@ -562,17 +525,15 @@ private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment) {j
 /-- The skeletal (lower) tier of a historic form is the stem's — the
     floating `(d)` contributes no skeletal slot. -/
 private theorem withHist_lower (Y : FloatingForm CVKind Segment) :
-    (withHist Y).lower = Y.toGraph.lower := by
-  rw [show (withHist Y).lower = (withHist Y).toGraph.lower from rfl, withHist_eq_concat,
-    Graph.lower_concat]
-  simp [historicExponent, LabeledTuple.empty_concat]
+    (withHist Y).lower = Y.lower := by
+  rw [withHist_eq_concat, FloatingForm.hconcat_lower]
+  exact LabeledTuple.empty_concat Y.lower
 
 /-- The melodic (upper) tier of a historic form is `(d)` concatenated with the
     stem's — used to compute upper-tier lengths in the locality proofs. -/
 private theorem withHist_upper (Y : FloatingForm CVKind Segment) :
-    (withHist Y).upper = historicExponent.upper.concat Y.toGraph.upper := by
-  rw [show (withHist Y).upper = (withHist Y).toGraph.upper from rfl, withHist_eq_concat,
-    Graph.upper_concat]
+    (withHist Y).upper = historicExponent.upper.concat Y.upper := by
+  rw [withHist_eq_concat, FloatingForm.hconcat_upper]
 
 /-- **The general no-look-ahead theorem.** For *any* suffix, the
     `(d)`-docking configuration of the historic-tense form is determined
@@ -585,20 +546,19 @@ private theorem withHist_upper (Y : FloatingForm CVKind Segment) :
     statement, on which it rests.) -/
 theorem dDockable_withHist_concat_right (stem suffix : FloatingForm CVKind Segment)
     (h2 : 2 ≤ stem.lower.len) :
-    dDockable (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))) ↔
+    dDockable (withHist ((stem.hconcat suffix))) ↔
       dDockable (withHist stem) := by
   have hlow : ∀ j, j < stem.lower.len →
-      (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).lower.get? j =
+      (withHist ((stem.hconcat suffix))).lower.get? j =
         (withHist stem).lower.get? j := by
     intro j hj
-    rw [withHist_lower, withHist_lower, ofGraph_toGraph,
-      Graph.lower_concat, LabeledTuple.get?_concat_left hj]
+    rw [withHist_lower, withHist_lower, FloatingForm.hconcat_lower,
+      LabeledTuple.get?_concat_left hj]
   have hlink : ∀ j, j < stem.lower.len →
-      ((withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).surfaceGraph.IsLinkedLower j ↔
-        (withHist stem).surfaceGraph.IsLinkedLower j) := by
+      ((withHist ((stem.hconcat suffix))).SurfaceLinkedLower j ↔
+        (withHist stem).SurfaceLinkedLower j) := by
     intro j hj
     rw [isLinkedLower_withHist, isLinkedLower_withHist]
-    show (∃ a, (a, j) ∈ (stem.toGraph.concat suffix.toGraph).links) ↔ _
     exact linked_concat_low stem suffix hj
   unfold dDockable isCSlot isVSlot
   rw [hlow 0 (by omega), hlow 1 (by omega), hlink 0 (by omega), hlink 1 (by omega)]
@@ -609,7 +569,7 @@ The configuration-level theorem above is pre-lenition. The full
 `dPrimeSurfaces` version additionally needs `{L}`-docking (`lenite`) to
 be left-local: `lenite` targets the consonant on skeletal slot 0, which
 is the stem's, and deletes the same melody index in both forms. This
-needs the stem **in-bounds** (`stem.toGraph.InBounds`): otherwise a stem
+needs the stem **in-bounds** (`stem.InBounds`): otherwise a stem
 link with an out-of-range melody index would sit outside `withHist
 stem`'s `initialConsonantIdx` search range but inside the longer suffixed
 range, and `lenite` could target different indices. -/
@@ -620,18 +580,18 @@ range, and `lenite` could target different indices. -/
     for `initialConsonantIdx` and after `deleteTierElem`. -/
 private theorem mem_surfaceLinks_concat (stem suffix : FloatingForm CVKind Segment)
     {k j : Nat} (hj : j < stem.lower.len) :
-    (k, j) ∈ (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).surfaceLinks ↔
+    (k, j) ∈ (withHist ((stem.hconcat suffix))).surfaceLinks ↔
       (k, j) ∈ (withHist stem).surfaceLinks := by
-  have hsB : (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).surfaceLinks =
-      (stem.toGraph.concat suffix.toGraph).links.image (shiftLink 1 0) := by
-    show (historicExponent.concat (stem.toGraph.concat suffix.toGraph)).links = _
-    rw [Graph.links_concat]; simp [historicExponent]
+  have hsB : (withHist ((stem.hconcat suffix))).surfaceLinks =
+      (stem.hconcat suffix).links.image (shiftLink 1 0) := by
+    rw [withHist_eq_concat, FloatingForm.hconcat_surfaceLinks]
+    simp [historicExponent]
   have hsA : (withHist stem).surfaceLinks =
-      stem.toGraph.links.image (shiftLink 1 0) := by
-    show (historicExponent.concat stem.toGraph).links = _
-    rw [Graph.links_concat]; simp [historicExponent]
-  rw [hsB, hsA, Graph.links_concat, Finset.image_union, Finset.mem_union]
-  have hfalse : (k, j) ∉ (suffix.toGraph.links.image
+      stem.links.image (shiftLink 1 0) := by
+    rw [withHist_eq_concat, FloatingForm.hconcat_surfaceLinks]
+    simp [historicExponent]
+  rw [hsB, hsA, FloatingForm.hconcat_links, Finset.image_union, Finset.mem_union]
+  have hfalse : (k, j) ∉ (suffix.links.image
       (shiftLink stem.upper.len stem.lower.len)).image (shiftLink 1 0) := by
     rw [Finset.image_image, Finset.mem_image]
     rintro ⟨⟨a, b⟩, _, he⟩
@@ -664,36 +624,37 @@ private theorem find?_range_stable {p : Nat → Bool} {m n : Nat} (hmn : m ≤ n
     by `InBounds`, the stem's slot-0 links sit inside its own melody
     range, so the longer suffixed search finds no extra match. -/
 private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Segment)
-    (h2 : 2 ≤ stem.lower.len) (hib : stem.toGraph.InBounds) :
-    initialConsonantIdx (withHist (ofGraph (stem.toGraph.concat suffix.toGraph)))
+    (h2 : 2 ≤ stem.lower.len) (hib : stem.InBounds) :
+    initialConsonantIdx (withHist ((stem.hconcat suffix)))
       = initialConsonantIdx (withHist stem) := by
   have hpt : (fun k => decide ((k, 0) ∈
-        (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).surfaceLinks)) =
+        (withHist ((stem.hconcat suffix))).surfaceLinks)) =
       (fun k => decide ((k, 0) ∈ (withHist stem).surfaceLinks)) :=
     funext fun k => decide_eq_decide.mpr (mem_surfaceLinks_concat stem suffix (by omega))
-  have eA : (withHist stem).upper.len = stem.toGraph.upper.len + 1 := by
+  have eA : (withHist stem).upper.len = stem.upper.len + 1 := by
     rw [withHist_upper]; simp [historicExponent, Nat.add_comm]
   unfold initialConsonantIdx
   rw [hpt]
   apply find?_range_stable
   · show (withHist stem).upper.len ≤
-      (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).upper.len
-    have eB : (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).upper.len =
-        stem.toGraph.upper.len + suffix.toGraph.upper.len + 1 := by
-      rw [withHist_upper, ofGraph_toGraph, Graph.upper_concat]
+      (withHist ((stem.hconcat suffix))).upper.len
+    have eB : (withHist ((stem.hconcat suffix))).upper.len =
+        stem.upper.len + suffix.upper.len + 1 := by
+      rw [withHist_upper, FloatingForm.hconcat_upper]
       simp [historicExponent, LabeledTuple.concat_len]; omega
     omega
   · intro i hi
     simp only [decide_eq_false_iff_not]
     intro hmem
-    have hsA : (withHist stem).surfaceLinks = stem.toGraph.links.image (shiftLink 1 0) := by
-      show (historicExponent.concat stem.toGraph).links = _
-      rw [Graph.links_concat]; simp [historicExponent]
+    have hsA : (withHist stem).surfaceLinks = stem.links.image (shiftLink 1 0) := by
+      rw [withHist_eq_concat, FloatingForm.hconcat_surfaceLinks]
+      simp [historicExponent]
     rw [hsA, Finset.mem_image] at hmem
     obtain ⟨⟨a, b⟩, hab, he⟩ := hmem
     have hfst := congrArg Prod.fst he
     simp only [shiftLink_apply] at hfst
-    have hin := hib (a, b) hab
+    have hin1 : a < stem.upper.len := (hib (a, b) hab).1
+    rw [eA] at hi
     omega
 
 /-- The docking configuration is right-local even after `lenite` deletes
@@ -701,21 +662,21 @@ private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Se
     leaves the lower tier, so the slot-0/1 agreement survives. -/
 private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKind Segment)
     (h2 : 2 ≤ stem.lower.len) (k : Nat) :
-    dDockable ((withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).deleteTierElem k) ↔
+    dDockable ((withHist ((stem.hconcat suffix))).deleteTierElem k) ↔
       dDockable ((withHist stem).deleteTierElem k) := by
   have hlow : ∀ j, j < stem.lower.len →
-      ((withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).deleteTierElem k).lower.get? j =
+      ((withHist ((stem.hconcat suffix))).deleteTierElem k).lower.get? j =
         ((withHist stem).deleteTierElem k).lower.get? j := by
     intro j hj
-    show (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).lower.get? j =
+    show (withHist ((stem.hconcat suffix))).lower.get? j =
       (withHist stem).lower.get? j
-    rw [withHist_lower, withHist_lower, ofGraph_toGraph,
-      Graph.lower_concat, LabeledTuple.get?_concat_left hj]
+    rw [withHist_lower, withHist_lower, FloatingForm.hconcat_lower,
+      LabeledTuple.get?_concat_left hj]
   have hlink : ∀ j, j < stem.lower.len →
-      (((withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).deleteTierElem k).surfaceGraph.IsLinkedLower j ↔
-        ((withHist stem).deleteTierElem k).surfaceGraph.IsLinkedLower j) := by
+      (((withHist ((stem.hconcat suffix))).deleteTierElem k).SurfaceLinkedLower j ↔
+        ((withHist stem).deleteTierElem k).SurfaceLinkedLower j) := by
     intro j hj
-    show (∃ p ∈ (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).surfaceLinks.filter
+    show (∃ p ∈ (withHist ((stem.hconcat suffix))).surfaceLinks.filter
         (fun l => l.fst ≠ k), p.snd = j) ↔
       (∃ p ∈ (withHist stem).surfaceLinks.filter (fun l => l.fst ≠ k), p.snd = j)
     simp only [Finset.mem_filter]
@@ -740,18 +701,18 @@ private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKi
     the paper's central claim, in full: preverbal *d'* never looks
     rightward past the word it attaches to. -/
 theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind Segment)
-    (h2 : 2 ≤ stem.lower.len) (hib : stem.toGraph.InBounds) :
-    dPrimeSurfaces (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))) ↔
+    (h2 : 2 ≤ stem.lower.len) (hib : stem.InBounds) :
+    dPrimeSurfaces (withHist ((stem.hconcat suffix))) ↔
       dPrimeSurfaces (withHist stem) := by
   have hk : ∀ k, initialConsonantIdx (withHist stem) = some k →
-      (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).upper.get? k =
+      (withHist ((stem.hconcat suffix))).upper.get? k =
         (withHist stem).upper.get? k := by
     intro k hoi
     have hk_lt : k < (withHist stem).upper.len :=
       List.mem_range.mp (List.mem_of_find?_eq_some hoi)
-    have hsplit : (withHist (ofGraph (stem.toGraph.concat suffix.toGraph))).upper =
-        (withHist stem).upper.concat suffix.toGraph.upper := by
-      rw [withHist_upper, ofGraph_toGraph, Graph.upper_concat, withHist_upper,
+    have hsplit : (withHist ((stem.hconcat suffix))).upper =
+        (withHist stem).upper.concat suffix.upper := by
+      rw [withHist_upper, FloatingForm.hconcat_upper, withHist_upper,
         LabeledTuple.concat_assoc]
     rw [hsplit, LabeledTuple.get?_concat_left hk_lt]
   unfold dPrimeSurfaces lenite
@@ -790,11 +751,16 @@ extensional content (no look-ahead) is fully captured by
 `dPrimeSurfaces_withHist_concat_right` above: for any suffix, whether
 `(d)` surfaces depends only on the stem's left edge. -/
 
-open CategoryTheory MonoidalCategory in
-/-- The historic-tense exponent as an object of the monoidal category
-    `WellFormedAR` (well-formed: no links, hence in-bounds and planar). -/
-def historicExponentAR : WellFormedAR (TierSpec Segment) (SegSpec CVKind) :=
-  WellFormedAR.mk ⟨historicExponent, historicExponent_inBounds⟩ historicExponent_isPlanar
+/-- The historic-tense exponent as an object of the monoidal category of
+    representations: one floating `(d)` melody node, no skeleton, no links. -/
+def historicExponentRep :
+    Representation (Sigma.fst :
+      ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) :=
+  Representation.ofData
+    (fun b => match b with
+      | true => ([mel .dPrime mHist] : List (TwoTier (TierSpec Segment) (SegSpec CVKind) true))
+      | false => [])
+    ⊥
 
 open CategoryTheory MonoidalCategory in
 /-- **The historic morpheme is an endofunctor on `WellFormedAR`.** Prefixing `(d)`
@@ -802,17 +768,20 @@ open CategoryTheory MonoidalCategory in
     which exists only because `WellFormedAR` is a `MonoidalCategory`. Left- rather
     than right-tensoring encodes the morpheme's directionality as a
     preverbal particle. -/
-def withHistFunctor : WellFormedAR (TierSpec Segment) (SegSpec CVKind) ⥤
-    WellFormedAR (TierSpec Segment) (SegSpec CVKind) :=
-  tensorLeft historicExponentAR
+def withHistFunctor :
+    Representation (Sigma.fst :
+        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) ⥤
+    Representation (Sigma.fst :
+        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) :=
+  tensorLeft historicExponentRep
 
 open CategoryTheory MonoidalCategory in
-/-- The functor's action on objects *is* morpheme prefixing: it agrees
-    with `withHist` at the level of the underlying graph
-    (`withHist_eq_concat`). -/
-theorem withHistFunctor_obj_toGraph
-    (X : WellFormedAR (TierSpec Segment) (SegSpec CVKind)) :
-    (withHistFunctor.obj X).obj.toGraph = historicExponent.concat X.obj.toGraph := rfl
+/-- The functor's action on objects *is* morpheme prefixing: the tensor of
+    the exponent with the stem. -/
+theorem withHistFunctor_obj
+    (X : Representation (Sigma.fst :
+        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool)) :
+    withHistFunctor.obj X = historicExponentRep ⊗ X := rfl
 
 open CategoryTheory MonoidalCategory in
 /-- **Associativity of prefixation is the associator.** This natural
@@ -821,10 +790,12 @@ open CategoryTheory MonoidalCategory in
     not exist unless the monoidal structure is *coherent* (pentagon +
     triangle). It is the concrete artifact that makes `WellFormedAR`'s coherence
     load-bearing rather than decorative. -/
-noncomputable def prefixAssoc (X : WellFormedAR (TierSpec Segment) (SegSpec CVKind)) :
-    tensorLeft (historicExponentAR ⊗ X) ≅
-      tensorLeft X ⋙ tensorLeft historicExponentAR :=
-  tensorLeftTensor historicExponentAR X
+noncomputable def prefixAssoc
+    (X : Representation (Sigma.fst :
+        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool)) :
+    tensorLeft (historicExponentRep ⊗ X) ≅
+      tensorLeft X ⋙ tensorLeft historicExponentRep :=
+  tensorLeftTensor historicExponentRep X
 
 /-! ## §11.5 The morphism-functor frontier: why lenition is precedence-sensitive
 

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.OCP
-import Linglib.Phonology.Autosegmental.MultiAR
+import Linglib.Phonology.Autosegmental.NormalForm
 import Linglib.Fragments.Laal.Prosody
 
 /-!
@@ -164,46 +164,68 @@ open Autosegmental
 /-- The four Laal tone tiers: `[±upper]` register, `[±raised]`, the TRN, the mora. -/
 abbrev laalTier : Fin 4 → Type := ![Option Bool, Option Bool, Unit, Unit]
 
-/-- A one-TRN M-toned form (`M = [−upper, +raised]`, [lionnet-2022] ex. 51): the
-    register `[−upper]` and `[+raised]` features and the single mora each associate to
-    the one TRN. -/
-def mForm : MultiAR laalTier where
-  tiers := Fin.cons (.ofList [some false]) (Fin.cons (.ofList [some true])
-    (Fin.cons (.ofList [()]) (Fin.cons (.ofList [()]) finZeroElim)))
-  links i j := match i, j with
-    | 0, 2 => {(0, 0)}    -- register ↔ TRN
-    | 1, 2 => {(0, 0)}    -- [raised] ↔ TRN
-    | 2, 3 => {(0, 0)}    -- TRN ↔ mora
-    | _, _ => ∅
-  inBounds := by decide
+/-- The tier words of a one-TRN M-toned form (`M = [−upper, +raised]`,
+    [lionnet-2022] ex. 51). -/
+def laalWords : ∀ i : Fin 4, List (laalTier i) :=
+  Fin.cons [some false] (Fin.cons [some true] (Fin.cons [()] (Fin.cons [()] finZeroElim)))
 
-/-- The form is planar — each spoke's single association is non-crossing (per-pair NCC). -/
-theorem mForm_planar : mForm.IsPlanar := by decide
+/-- The hub-and-spoke links (ex. 52): register, `[raised]`, and mora each
+    associate to the TRN. -/
+def laalSpokes (i j : Fin 4) (p q : ℕ) : Prop :=
+  ((i, j) = (0, 2) ∨ (i, j) = (1, 2) ∨ (i, j) = (2, 3)) ∧ p = 0 ∧ q = 0
 
-/-- The links of `delinkRaised`: the `[raised]`↔TRN pair `(1,2)` emptied. -/
-private def delinkedLinks (G : MultiAR laalTier) (i j : Fin 4) : Finset (ℕ × ℕ) :=
-  if (i, j) = (1, 2) then ∅ else G.links i j
+instance (i j : Fin 4) (p q : ℕ) : Decidable (laalSpokes i j p q) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
-/-- **Partial activity** (§5): delinking the `[−raised]` feature acts on the
-    `[raised]`↔TRN layer (tier-pair `(1,2)`) alone. -/
-def delinkRaised (G : MultiAR laalTier) : MultiAR laalTier where
-  toMultiGraph := { G.toMultiGraph with links := delinkedLinks G }
-  inBounds := by
-    intro i j p hp
-    simp only [delinkedLinks] at hp
-    split_ifs at hp with h
-    · exact absurd hp (by simp)
-    · exact G.inBounds i j p hp
+/-- The M-toned form on the graph foundation. -/
+def mForm : Representation (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :=
+  Representation.ofData laalWords laalSpokes
+
+instance : Fintype mForm.obj.V :=
+  inferInstanceAs (Fintype ((i : Fin 4) × Fin _))
+
+instance (v w : mForm.obj.V) : Decidable (mForm.obj.graph.edges.Adj v w) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+instance (v w : mForm.obj.V) : Decidable (mForm.obj.graph.arcs.Adj v w) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- The form is planar — each spoke's single association is non-crossing, in
+    the foundational path form of the NCC. -/
+theorem mForm_planar : IsPlanar mForm.obj.graph := by
+  unfold IsPlanar
+  decide
+
+/-- **Partial activity** (§5): delinking a feature acts on one tier-pair layer
+    alone — here `[raised]`↔TRN, the pair `(1, 2)`. -/
+def delink (L : Fin 4 → Fin 4 → ℕ → ℕ → Prop) (i₀ j₀ : Fin 4)
+    (i j : Fin 4) (p q : ℕ) : Prop :=
+  ¬ (i = i₀ ∧ j = j₀) ∧ L i j p q
+
+/-- The M form with the subtonal `[−raised]` feature delinked. -/
+def delinkRaised : Representation (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :=
+  Representation.ofData laalWords (delink laalSpokes 1 2)
 
 /-- Delinking the subtonal `[−raised]` feature leaves the **whole-TRN** layer
-    (TRN↔mora, tier-pair `(2,3)`) untouched: partial activity is independent of full
-    activity — the structural content of [lionnet-2022]'s subtonal-feature autonomy,
-    impossible to state on a bundled `TRN`. -/
-theorem partial_indep_of_full (G : MultiAR laalTier) :
-    (delinkRaised G).links 2 3 = G.links 2 3 := by simp [delinkRaised, delinkedLinks]
+    (TRN↔mora, tier-pair `(2, 3)`) untouched: partial activity is independent
+    of full activity — the structural content of [lionnet-2022]'s
+    subtonal-feature autonomy, impossible to state on a bundled `TRN`. -/
+instance : Finite mForm.obj.V := inferInstanceAs (Finite ((i : Fin 4) × Fin _))
+
+instance : Finite delinkRaised.obj.V := inferInstanceAs (Finite ((i : Fin 4) × Fin _))
+
+theorem partial_indep_of_full (p q : ℕ) :
+    delinkRaised.link 2 3 p q ↔ mForm.link 2 3 p q := by
+  unfold delinkRaised mForm
+  rw [Representation.link_ofData, Representation.link_ofData]
+  simp [delink, laalSpokes]
 
 /-- And it does remove the `[raised]`↔TRN association. -/
-theorem delinkRaised_erases (G : MultiAR laalTier) :
-    (delinkRaised G).links 1 2 = ∅ := by simp [delinkRaised, delinkedLinks]
+theorem delinkRaised_erases (p q : ℕ) : ¬ delinkRaised.link 1 2 p q := by
+  unfold delinkRaised
+  rw [Representation.link_ofData]
+  rintro ⟨-, -, -, ⟨hne, -⟩ | ⟨-, h2, -⟩⟩
+  · exact hne ⟨rfl, rfl⟩
+  · rcases h2 with h2 | h2 | h2 <;> simp_all
 
 end Lionnet2022Laal

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -182,7 +182,7 @@ def mForm : Representation (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :
   Representation.ofData laalWords laalSpokes
 
 instance : Fintype mForm.obj.V :=
-  inferInstanceAs (Fintype ((i : Fin 4) × Fin _))
+  inferInstanceAs (Fintype ((_ : Fin 4) × Fin _))
 
 instance (v w : mForm.obj.V) : Decidable (mForm.obj.graph.edges.Adj v w) :=
   inferInstanceAs (Decidable (_ ∧ _))
@@ -210,9 +210,9 @@ def delinkRaised : Representation (Sigma.fst : ((i : Fin 4) × laalTier i) → F
     (TRN↔mora, tier-pair `(2, 3)`) untouched: partial activity is independent
     of full activity — the structural content of [lionnet-2022]'s
     subtonal-feature autonomy, impossible to state on a bundled `TRN`. -/
-instance : Finite mForm.obj.V := inferInstanceAs (Finite ((i : Fin 4) × Fin _))
+instance : Finite mForm.obj.V := inferInstanceAs (Finite ((_ : Fin 4) × Fin _))
 
-instance : Finite delinkRaised.obj.V := inferInstanceAs (Finite ((i : Fin 4) × Fin _))
+instance : Finite delinkRaised.obj.V := inferInstanceAs (Finite ((_ : Fin 4) × Fin _))
 
 theorem partial_indep_of_full (p q : ℕ) :
     delinkRaised.link 2 3 p q ↔ mForm.link 2 3 p q := by

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -192,7 +192,7 @@ def lrDerivation (input : Form) : HSDerivation Form where
 namespace Fig3
 
 /-- Fig. 3 input `/kāk^H + rī^H + dō^H/`: each M linked, each H floating. -/
-def fig3Input : Form := .ofGraph (word [.kak, .ri, .do])
+def fig3Input : Form := word [.kak, .ri, .do]
 
 /-- Directional-LR derivation (`*FLOAT^→`). -/
 def derivationLR : HSDerivation Form := lrDerivation fig3Input
@@ -297,7 +297,7 @@ end Fig3
 namespace Eq24
 
 /-- Eq. (24) input `/nãn + rī^H + nã/`; H-rī is the only floating tone. -/
-def eq24Input : Form := .ofGraph (word [.nan, .ri, .na])
+def eq24Input : Form := word [.nan, .ri, .na]
 
 /-- Directional-LR derivation over `stdRanking`. -/
 def derivationLR : HSDerivation Form := lrDerivation eq24Input
@@ -327,7 +327,7 @@ end Eq24
 namespace Eq21
 
 /-- Eq. (21) input `/nãn + rī^H/` (phrase-final): no rightward landing site. -/
-def eq21Input : Form := .ofGraph (word [.nan, .ri])
+def eq21Input : Form := word [.nan, .ri]
 
 /-- Directional-LR derivation; eq. (20)'s `*FLOAT, *TAUTDOCK ≫ MAX(H)` is a sub-ranking. -/
 def derivationLR : HSDerivation Form := lrDerivation eq21Input
@@ -349,7 +349,7 @@ end Eq21
 namespace Eq27
 
 /-- Eq. (27) input `/kāk^H + kǎ/`; kǎ carries a linked MH contour. -/
-def eq27Input : Form := .ofGraph (word [.kak, .ka])
+def eq27Input : Form := word [.kak, .ka]
 
 /-- Directional-LR derivation over `stdRanking`. -/
 def derivationLR : HSDerivation Form := lrDerivation eq27Input
@@ -371,7 +371,7 @@ end Eq27
 namespace Eq30
 
 /-- Eq. (30) input `/kāk^H + ìlí/`; ìlí carries a linked LH contour (L% omitted). -/
-def eq30Input : Form := .ofGraph (word [.kak, .ili])
+def eq30Input : Form := word [.kak, .ili]
 
 /-- Eq. (30) ranking: `stdRanking` plus `*M◁L` above *TAUTDOCK — the inversion that
     licenses tautomorphemic docking (30c). -/
@@ -402,7 +402,7 @@ end Eq30
 namespace Eq22
 
 /-- Eq. (22a) input `/nãn + rī^H + ne/`; ne is toneless. -/
-def eq22Input : Form := .ofGraph (word [.nan, .ri, .ne])
+def eq22Input : Form := word [.nan, .ri, .ne]
 
 /-- Directional-LR derivation over `stdRanking`. -/
 def derivationLR : HSDerivation Form := lrDerivation eq22Input


### PR DESCRIPTION
Ports every remaining bipartite/MultiAR consumer cluster onto the graph foundation: Lionnet2022Laal register geometry (MultiAR now consumer-free), Tangale tone processes as link-presentation operations, the correspondence layer, and the full Floating cluster — FloatingForm carries its presentation data directly (no Graph inheritance), with LaoideKemp2026's no-look-ahead theorems on the hconcat algebra and its §11 monoidal content (tensorLeft, coherence) restated on the Representation category. decide survives on concrete ofData forms throughout.