### PR TITLE
refactor(Phonology/Autosegmental): decidable factor grammars

### DIFF
--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -378,6 +378,23 @@ theorem Representation.isPlanar_spread (a : α) (bs : List β) :
     IsPlanar (Representation.spread a bs).obj.graph :=
   (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
+/-- Two-tier factor embedding is a search over two bounded offsets. -/
+theorem Representation.factorEmbeds_iff_two_tier
+    {F X : Representation (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool)}
+    [Finite F.obj.V] [Finite X.obj.V] :
+    F.FactorEmbeds X ↔
+      ∃ ot ≤ X.tierLength true, ∃ of ≤ X.tierLength false,
+        F.IsFactorAt X (fun b => bif b then ot else of) := by
+  rw [Representation.factorEmbeds_iff_bounded]
+  constructor
+  · rintro ⟨o, hb, hfa⟩
+    refine ⟨o true, hb true, o false, hb false, ?_⟩
+    have he : (fun b => bif b then o true else o false) = o :=
+      funext fun b => by cases b <;> rfl
+    rwa [he]
+  · rintro ⟨ot, hot, of, hof, hfa⟩
+    exact ⟨_, fun b => by cases b <;> simpa, hfa⟩
+
 /-- A timing slot **surfaces with** melody label `a`: some `a`-labelled melody
     node links to it. -/
 def Representation.surfacesWith

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -395,6 +395,94 @@ theorem Representation.factorEmbeds_iff_two_tier
   · rintro ⟨ot, hot, of, hof, hfa⟩
     exact ⟨_, fun b => by cases b <;> simpa, hfa⟩
 
+/-- The data-level factor check: `wsF`/`LF` occurs in `wsX`/`LX` at some pair
+    of bounded offsets — list windows match and links transport shifted. The
+    decidable face of `FactorEmbeds` for `ofData`-presented forms. -/
+def dataEmbeds (wsF wsX : ∀ b : Bool, List (TwoTier α β b))
+    (LF LX : Bool → Bool → ℕ → ℕ → Prop) : Prop :=
+  ∃ ot ≤ (wsX true).length, ∃ of ≤ (wsX false).length,
+    (∀ p < (wsF true).length, (wsX true)[p + ot]? = (wsF true)[p]?) ∧
+    (∀ p < (wsF false).length, (wsX false)[p + of]? = (wsF false)[p]?) ∧
+    ∀ p < (wsF true).length, ∀ q < (wsF false).length,
+      (LF true false p q ∨ LF false true q p) →
+        (LX true false (p + ot) (q + of) ∨ LX false true (q + of) (p + ot))
+
+instance {wsF wsX : ∀ b : Bool, List (TwoTier α β b)}
+    {LF LX : Bool → Bool → ℕ → ℕ → Prop}
+    [DecidableEq α] [DecidableEq β]
+    [∀ i j p q, Decidable (LF i j p q)] [∀ i j p q, Decidable (LX i j p q)] :
+    Decidable (dataEmbeds wsF wsX LF LX) := by
+  unfold dataEmbeds
+  haveI : DecidableEq (TwoTier α β true) := inferInstanceAs (DecidableEq α)
+  haveI : DecidableEq (TwoTier α β false) := inferInstanceAs (DecidableEq β)
+  infer_instance
+
+/-- **The spec**: on `ofData`-presented two-tier forms, factor embedding is the
+    data-level check — the bridge that turns banned-subgraph verdicts into
+    kernel computations. -/
+theorem Representation.factorEmbeds_ofData_iff
+    {wsF wsX : ∀ b : Bool, List (TwoTier α β b)}
+    {LF LX : Bool → Bool → ℕ → ℕ → Prop} :
+    (Representation.ofData wsF LF).FactorEmbeds (Representation.ofData wsX LX) ↔
+      dataEmbeds wsF wsX LF LX := by
+  rw [Representation.factorEmbeds_iff_two_tier]
+  simp only [Representation.tierLength_ofData]
+  constructor
+  · rintro ⟨ot, hot, of, hof, hw, hl⟩
+    refine ⟨ot, hot, of, hof, ?_, ?_, ?_⟩
+    · intro p hp
+      have := hw true p (by rw [Representation.tierLength_ofData]; exact hp)
+      rwa [Representation.tierWord_ofData, Representation.tierWord_ofData] at this
+    · intro p hp
+      have := hw false p (by rw [Representation.tierLength_ofData]; exact hp)
+      rwa [Representation.tierWord_ofData, Representation.tierWord_ofData] at this
+    · intro p hp q hq hpq
+      have hlk := hl true false p q ((Representation.link_ofData true false p q).mpr
+        ⟨by decide, hp, hq, hpq⟩)
+      rcases (Representation.link_ofData true false (p + ot) (q + of)).mp hlk with
+        ⟨-, -, -, hres⟩
+      exact hres
+  · rintro ⟨ot, hot, of, hof, hwt, hwf, hlk⟩
+    have hbt : ∀ p, p < (wsF true).length → p + ot < (wsX true).length := by
+      intro p hp
+      have h1 : (wsX true)[p + ot]? = some ((wsF true)[p]'hp) :=
+        (hwt p hp).trans (List.getElem?_eq_getElem hp)
+      exact (List.getElem?_eq_some_iff.mp h1).1
+    have hbf : ∀ q, q < (wsF false).length → q + of < (wsX false).length := by
+      intro q hq
+      have h1 : (wsX false)[q + of]? = some ((wsF false)[q]'hq) :=
+        (hwf q hq).trans (List.getElem?_eq_getElem hq)
+      exact (List.getElem?_eq_some_iff.mp h1).1
+    refine ⟨ot, hot, of, hof, ?_, ?_⟩
+    · intro i p hp
+      rw [Representation.tierLength_ofData] at hp
+      cases i
+      · rw [show ((Representation.ofData wsX LX).tierWord false)
+            = wsX false from Representation.tierWord_ofData false,
+          show ((Representation.ofData wsF LF).tierWord false)
+            = wsF false from Representation.tierWord_ofData false]
+        exact hwf p hp
+      · rw [show ((Representation.ofData wsX LX).tierWord true)
+            = wsX true from Representation.tierWord_ofData true,
+          show ((Representation.ofData wsF LF).tierWord true)
+            = wsF true from Representation.tierWord_ofData true]
+        exact hwt p hp
+    · intro i j p q hl
+      rcases (Representation.link_ofData i j p q).mp hl with ⟨hne, hp, hq, hor⟩
+      have hcases : i = true ∧ j = false ∨ i = false ∧ j = true := by
+        cases i <;> cases j <;> simp_all
+      rcases hcases with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
+      · rcases hlk p hp q hq hor with hres | hres
+        · exact (Representation.link_ofData true false _ _).mpr
+            ⟨by decide, hbt p hp, hbf q hq, Or.inl hres⟩
+        · exact (Representation.link_ofData true false _ _).mpr
+            ⟨by decide, hbt p hp, hbf q hq, Or.inr hres⟩
+      · rcases hlk q hq p hp hor.symm with hres | hres
+        · exact (Representation.link_ofData false true _ _).mpr
+            ⟨by decide, hbf p hp, hbt q hq, Or.inr hres⟩
+        · exact (Representation.link_ofData false true _ _).mpr
+            ⟨by decide, hbf p hp, hbt q hq, Or.inl hres⟩
+
 /-- A timing slot **surfaces with** melody label `a`: some `a`-labelled melody
     node links to it. -/
 def Representation.surfacesWith

--- a/Linglib/Phonology/Autosegmental/MixedGraph.lean
+++ b/Linglib/Phonology/Autosegmental/MixedGraph.lean
@@ -545,6 +545,25 @@ theorem MixedGraphCat.Hom.concatMap_precPreserving (t : S → ι)
   · exact h.elim
   · exact hg h
 
+/-- A vertex with no arc-predecessor: the tier-initial position. -/
+def MixedGraphCat.NoPred (X : MixedGraphCat S) (v : X.V) : Prop :=
+  ∀ u, ¬ X.graph.arcs.Adj u v
+
+/-- Erase every association line incident to a tier-`i₀`-initial vertex — the
+    graph model of an initial-position delinking process (e.g. lenition
+    targeting the word-initial slot). Arcs and labels are untouched. -/
+def MixedGraphCat.delinkMin (t : S → ι) (i₀ : ι) (X : MixedGraphCat S) :
+    MixedGraphCat S where
+  V := X.V
+  graph :=
+    { edges :=
+        { Adj := fun v w => X.graph.edges.Adj v w ∧
+            ¬ (X.tier t v = i₀ ∧ X.NoPred v) ∧ ¬ (X.tier t w = i₀ ∧ X.NoPred w)
+          symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.2, h.2.1⟩⟩
+          loopless := ⟨fun v h => X.graph.edges.loopless.irrefl v h.1⟩ }
+      arcs := X.graph.arcs }
+  label := X.label
+
 /-! ### The category of autosegmental representations -/
 
 variable (t : S → ι)
@@ -664,6 +683,50 @@ instance : (precPreserving (t := t)).IsMonoidalStable where
   leftUnitor_inv_mem A := (MixedGraphCat.emptyConcatIso t A.obj).symm.toHom_precPreserving
   rightUnitor_hom_mem A := (MixedGraphCat.concatEmptyIso t A.obj).toHom_precPreserving
   rightUnitor_inv_mem A := (MixedGraphCat.concatEmptyIso t A.obj).symm.toHom_precPreserving
+
+/-- Delinking preserves the structural axioms: arcs are untouched and the
+    edge set shrinks. -/
+def delinkMinRep (i₀ : ι) (X : Representation t) : Representation t :=
+  ⟨MixedGraphCat.delinkMin t i₀ X.obj,
+    ⟨X.property.1.tier_eq, X.property.1.total, X.property.1.irrefl, X.property.1.trans⟩,
+    fun _ _ hadj harc => X.property.2 hadj.1 harc⟩
+
+open CategoryTheory in
+/-- **Initial-position delinking is an endofunctor of the precedence-preserving
+    wide subcategory**: an arc-preserving morphism transports tier-initiality
+    for free (an arc into `v` maps to an arc into `f v`), so the delinked edge
+    conditions carry over. On the broad category the lift fails — a
+    label-preserving reindexing can move a non-initial vertex into initial
+    position (`Studies/LaoideKemp2026`'s counterexample). -/
+def delinkMinFunctor (i₀ : ι) :
+    WideSubcategory (Representation.precPreserving (t := t)) ⥤
+      WideSubcategory (Representation.precPreserving (t := t)) where
+  obj X := ⟨delinkMinRep i₀ X.obj⟩
+  map {X Y} f :=
+    ⟨InducedCategory.homMk
+      { toFun := f.hom.hom.toFun
+        edge_map := by
+          rintro v w ⟨hadj, hv, hw⟩
+          refine ⟨f.hom.hom.edge_map hadj, ?_, ?_⟩
+          · rintro ⟨htier, hmin⟩
+            refine hv ⟨?_, fun u hu => hmin (f.hom.hom.toFun u) (f.property hu)⟩
+            rw [show X.obj.obj.tier t v = Y.obj.obj.tier t (f.hom.hom.toFun v) from
+              (congrArg t (f.hom.hom.label_comp v)).symm]
+            exact htier
+          · rintro ⟨htier, hmin⟩
+            refine hw ⟨?_, fun u hu => hmin (f.hom.hom.toFun u) (f.property hu)⟩
+            rw [show X.obj.obj.tier t w = Y.obj.obj.tier t (f.hom.hom.toFun w) from
+              (congrArg t (f.hom.hom.label_comp w)).symm]
+            exact htier
+        label_comp := f.hom.hom.label_comp }, f.property⟩
+  map_id X := by
+    apply WideSubcategory.hom_ext
+    apply InducedCategory.hom_ext
+    rfl
+  map_comp f g := by
+    apply WideSubcategory.hom_ext
+    apply InducedCategory.hom_ext
+    rfl
 
 end Representation
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -589,6 +589,17 @@ theorem Representation.factorEmbeds_iff_bounded
   · rintro ⟨o, -, hfa⟩
     exact ⟨o, hfa⟩
 
+/-- Link conditions are supported on the factor's tier ranges. -/
+theorem Representation.forall_link_iff_bounded
+    {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι)} [Finite F.obj.V]
+    {C : ι → ι → ℕ → ℕ → Prop} :
+    (∀ i j p q, F.link i j p q → C i j p q) ↔
+      ∀ i j, ∀ p < F.tierLength i, ∀ q < F.tierLength j,
+        F.link i j p q → C i j p q := by
+  refine ⟨fun h i j p _ q _ hl => h i j p q hl, fun h i j p q hl => ?_⟩
+  obtain ⟨hp, hq, -⟩ := id hl
+  exact h i j p hp q hq hl
+
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
     ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
 def Representation.Free [Finite X.obj.V]

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -542,6 +542,53 @@ def Representation.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ)
 def Representation.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
   ∃ o : ι → ℕ, F.IsFactorAt X o
 
+/-- Offsets clamp to the host's tier lengths: `FactorEmbeds` is a bounded
+    search. On tiers where the factor is nonempty the word-window condition
+    already forces the bound; empty factor tiers accept any offset, so `min`
+    clamps them harmlessly. -/
+theorem Representation.factorEmbeds_iff_bounded
+    {F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+    [Finite F.obj.V] [Finite X.obj.V] :
+    F.FactorEmbeds X ↔
+      ∃ o : ι → ℕ, (∀ i, o i ≤ X.tierLength i) ∧ F.IsFactorAt X o := by
+  constructor
+  · rintro ⟨o, hw, hl⟩
+    refine ⟨fun i => min (o i) (X.tierLength i), fun i => min_le_right _ _, fun i p hp => ?_,
+      fun i j p q h => ?_⟩
+    · have horig := hw i p hp
+      show (X.tierWord i)[p + min (o i) (X.tierLength i)]? = (F.tierWord i)[p]?
+      rcases le_or_gt (o i) (X.tierLength i) with hle | hgt
+      · rwa [Nat.min_eq_left hle]
+      · exfalso
+        have hnone : (X.tierWord i)[p + o i]? = none := by
+          rw [List.getElem?_eq_none_iff]
+          simp only [Representation.length_tierWord]
+          omega
+        have hsome : p < (F.tierWord i).length := by
+          simpa [Representation.length_tierWord] using hp
+        rw [hnone, List.getElem?_eq_some_iff.mpr ⟨hsome, rfl⟩] at horig
+        simp at horig
+    · obtain ⟨hpb, hqb, -⟩ := id (hl i j p q h)
+      have h' := hl i j p q h
+      have hoi : min (o i) (X.tierLength i) = o i := by
+        have := hw i p (by obtain ⟨hp', -, -⟩ := id h; omega)
+        rcases le_or_gt (o i) (X.tierLength i) with hle | hgt
+        · exact Nat.min_eq_left hle
+        · exfalso
+          obtain ⟨hpX, -, -⟩ := id h'
+          omega
+      have hoj : min (o j) (X.tierLength j) = o j := by
+        rcases le_or_gt (o j) (X.tierLength j) with hle | hgt
+        · exact Nat.min_eq_left hle
+        · exfalso
+          obtain ⟨-, hqX, -⟩ := id h'
+          omega
+      show X.link i j (p + min (o i) (X.tierLength i)) (q + min (o j) (X.tierLength j))
+      rw [hoi, hoj]
+      exact h'
+  · rintro ⟨o, -, hfa⟩
+    exact ⟨o, hfa⟩
+
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
     ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
 def Representation.Free [Finite X.obj.V]

--- a/Linglib/Studies/Jardine2016.lean
+++ b/Linglib/Studies/Jardine2016.lean
@@ -32,35 +32,137 @@ open Autosegmental Correspondence
 inductive Seg | a | p | b
   deriving DecidableEq, Repr
 
-/-- A correspondence graph over the one alphabet (input and output both `Seg`). -/
-abbrev CGraph := Graph Seg Seg
+open Autosegmental Autosegmental.Correspondence in
+/-- A correspondence representation over the one alphabet. -/
+abbrev CRep := Rep Seg Seg
 
-/-- The faithfulness banned subgraph `*[pⁱ↔p]`: a `p` corresponding to a `p`. Forbidding
-    it forces an intervocalic `p` to change. -/
-def noPP : CGraph := ⟨.ofList [Seg.p], .ofList [Seg.p], {(0, 0)}⟩
+/-- The faithfulness banned subgraph `*[pⁱ↔p]`: a `p` corresponding to a `p`.
+    Forbidding it forces an intervocalic `p` to change. -/
+def noPP : CRep :=
+  ⟨Autosegmental.Representation.ofData
+    (fun b => match b with
+      | true => ([Seg.p] : List (Autosegmental.TwoTier Seg Seg true))
+      | false => [Seg.p])
+    (fun i j p q => i = true ∧ j = false ∧ p = 0 ∧ q = 0),
+    inferInstanceAs (Finite ((_ : Bool) × Fin _))⟩
 
 /-- The voicing correspondence `apa ↔ aba`: identity positions, the medial `p`
     corresponding to a `b`. -/
-def gVoice : CGraph :=
-  ⟨.ofList [Seg.a, .p, .a], .ofList [Seg.a, .b, .a], {(0, 0), (1, 1), (2, 2)}⟩
+def gVoice : CRep :=
+  ⟨Autosegmental.Representation.ofData
+    (fun b => match b with
+      | true => ([Seg.a, .p, .a] : List (Autosegmental.TwoTier Seg Seg true))
+      | false => [Seg.a, .b, .a])
+    (fun i j p q => i = true ∧ j = false ∧ p = q),
+    inferInstanceAs (Finite ((_ : Bool) × Fin _))⟩
 
 /-- The faithful correspondence `apa ↔ apa`: the medial `p` stays `p`. -/
-def gFaithful : CGraph :=
-  ⟨.ofList [Seg.a, .p, .a], .ofList [Seg.a, .p, .a], {(0, 0), (1, 1), (2, 2)}⟩
+def gFaithful : CRep :=
+  ⟨Autosegmental.Representation.ofData
+    (fun b => match b with
+      | true => ([Seg.a, .p, .a] : List (Autosegmental.TwoTier Seg Seg true))
+      | false => [Seg.a, .p, .a])
+    (fun i j p q => i = true ∧ j = false ∧ p = q),
+    inferInstanceAs (Finite ((_ : Bool) × Fin _))⟩
+
+open Autosegmental Autosegmental.Correspondence
+
+instance : Finite (noPP : CRep).val.obj.V :=
+  inferInstanceAs (Finite ((_ : Bool) × Fin _))
+
+instance : Finite (gVoice : CRep).val.obj.V :=
+  inferInstanceAs (Finite ((_ : Bool) × Fin _))
+
+instance : Finite (gFaithful : CRep).val.obj.V :=
+  inferInstanceAs (Finite ((_ : Bool) × Fin _))
 
 /-- `gVoice` reads input `apa`, output `aba`. -/
-theorem gVoice_io : input gVoice = [Seg.a, .p, .a] ∧ output gVoice = [Seg.a, .b, .a] := by
-  decide
+theorem gVoice_io :
+    gVoice.input = [Seg.a, .p, .a] ∧ gVoice.output = [Seg.a, .b, .a] :=
+  ⟨Representation.tierWord_ofData true, Representation.tierWord_ofData false⟩
 
-/-- The voicing correspondence is **admitted** by the `*[p↔p]` grammar (no `p↔p`). -/
-theorem gVoice_specified : specifiedBy [noPP] gVoice := by decide
+/-- The faithful correspondence is **rejected** — it contains a `p↔p`,
+    embedded at position 1 of both tiers. -/
+theorem gFaithful_rejected : ¬ specifiedByRep [noPP] gFaithful := by
+  intro h
+  refine h noPP (List.mem_singleton.mpr rfl) ⟨fun _ => 1, ?_, ?_⟩
+  · intro i p hp
+    have hp' : p < (Representation.ofData
+        (fun b => match b with
+          | true => ([Seg.p] : List (Autosegmental.TwoTier Seg Seg true))
+          | false => [Seg.p])
+        (fun i j p q => i = true ∧ j = false ∧ p = 0 ∧ q = 0)).tierLength i := hp
+    rw [Representation.tierLength_ofData] at hp'
+    have hp0 : p = 0 := by cases i <;> simpa using Nat.lt_one_iff.mp (by simpa using hp')
+    subst hp0
+    show ((gFaithful : CRep).val.tierWord i)[0 + 1]? = ((noPP : CRep).val.tierWord i)[0]?
+    rw [show (gFaithful : CRep).val.tierWord i
+        = _ from Representation.tierWord_ofData i,
+      show (noPP : CRep).val.tierWord i = _ from Representation.tierWord_ofData i]
+    cases i <;> rfl
+  · intro i j p q hl
+    rcases (Representation.link_ofData i j p q).mp hl with
+      ⟨-, -, -, ⟨rfl, rfl, rfl, rfl⟩ | ⟨rfl, rfl, rfl, rfl⟩⟩
+    · exact (Representation.link_ofData true false 1 1).mpr
+        ⟨by decide, by decide, by decide, Or.inl ⟨rfl, rfl, rfl⟩⟩
+    · exact (Representation.link_ofData false true 1 1).mpr
+        ⟨by decide, by decide, by decide, Or.inr ⟨rfl, rfl, rfl⟩⟩
 
-/-- The faithful correspondence is **rejected** — it contains a `p↔p`. -/
-theorem gFaithful_rejected : ¬ specifiedBy [noPP] gFaithful := by decide
+/-- The voicing correspondence is **admitted** by the `*[p↔p]` grammar: the
+    `p↔p` link would have to land on the output `b`. -/
+theorem gVoice_specified : specifiedByRep [noPP] gVoice := by
+  intro F hF
+  rw [List.mem_singleton] at hF
+  subst hF
+  rintro ⟨o, hw, hl⟩
+  have hbt : (0 : ℕ) < (noPP : CRep).val.tierLength true := by
+    rw [show (noPP : CRep).val.tierLength true
+      = _ from Representation.tierLength_ofData true]
+    simp
+  have hbf : (0 : ℕ) < (noPP : CRep).val.tierLength false := by
+    rw [show (noPP : CRep).val.tierLength false
+      = _ from Representation.tierLength_ofData false]
+    simp
+  have hwt := hw true 0 hbt
+  have hwf := hw false 0 hbf
+  rw [show (gVoice : CRep).val.tierWord true
+      = _ from Representation.tierWord_ofData true,
+    show (noPP : CRep).val.tierWord true
+      = _ from Representation.tierWord_ofData true] at hwt
+  rw [show (gVoice : CRep).val.tierWord false
+      = _ from Representation.tierWord_ofData false,
+    show (noPP : CRep).val.tierWord false
+      = _ from Representation.tierWord_ofData false] at hwf
+  have hlink := hl true false 0 0 ((Representation.link_ofData true false 0 0).mpr
+    ⟨by decide, by decide, by decide, Or.inl ⟨rfl, rfl, rfl, rfl⟩⟩)
+  rcases (Representation.link_ofData true false (0 + o true) (0 + o false)).mp hlink with
+    ⟨-, hpb, hqb, ⟨-, -, hpq⟩ | ⟨h1, -⟩⟩
+  · have h3' : o false < 3 := by
+      have := Representation.tierLength_ofData
+        (ws := fun b => match b with
+          | true => ([Seg.a, .p, .a] : List (Autosegmental.TwoTier Seg Seg true))
+          | false => [Seg.a, .b, .a])
+        (L := fun i j p q => i = true ∧ j = false ∧ p = q) false
+      simp only [Nat.zero_add] at hqb
+      omega
+    simp only [Nat.zero_add] at hpq
+    rw [hpq] at hwt
+    match hof : o false, h3' with
+    | 0, _ =>
+      rw [hof] at hwt
+      exact Seg.noConfusion (Option.some.inj hwt)
+    | 1, _ =>
+      rw [hof] at hwf
+      exact Seg.noConfusion (Option.some.inj hwf)
+    | 2, _ =>
+      rw [hof] at hwt
+      exact Seg.noConfusion (Option.some.inj hwt)
+  · exact absurd h1 (by decide)
 
-/-- Hence `apa ↔ aba` lies in the relation presented by the local grammar `*[p↔p]`,
-    witnessed by `gVoice` ([jardine-2016] Def. 25). -/
-theorem voicing_local : rel (specifiedBy [noPP]) [Seg.a, .p, .a] [Seg.a, .b, .a] :=
-  ⟨gVoice, gVoice_specified, by decide, by decide⟩
+/-- Hence `apa ↔ aba` lies in the relation presented by the local grammar
+    `*[p↔p]`, witnessed by `gVoice` ([jardine-2016] Def. 25). -/
+theorem voicing_local :
+    relRep (specifiedByRep [noPP]) [Seg.a, .p, .a] [Seg.a, .b, .a] :=
+  ⟨gVoice, gVoice_specified, gVoice_io.1, gVoice_io.2⟩
 
 end Jardine2016

--- a/Linglib/Studies/Jardine2017.lean
+++ b/Linglib/Studies/Jardine2017.lean
@@ -99,157 +99,154 @@ inductive TBU
   | bdry
   deriving DecidableEq, Repr
 
-/-- An autosegmental representation in Jardine 2017's sense:
-    `Graph Tone TBU`. Upper tier is tones (with implicit precedence
-    by list order); lower tier is TBUs; links are association lines. -/
-abbrev AR := Graph Tone TBU
+/-- An autosegmental representation in Jardine 2017's sense, on the graph
+    foundation: tones over TBUs (with implicit precedence by position),
+    links as association lines. -/
+abbrev ARep := Autosegmental.Representation
+  (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier Tone TBU b) → Bool)
+
+/-- Link presentations from finite pair lists (melody position, TBU position). -/
+def mkL (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) : Prop :=
+  i = true ∧ j = false ∧ (p, q) ∈ links
+
+instance (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) :
+    Decidable (mkL links i j p q) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
+
+/-- Build a representation from a tone melody, a TBU string, and links. -/
+abbrev mk (tones : List Tone) (tbus : List TBU) (links : List (ℕ × ℕ)) : ARep :=
+  Autosegmental.Representation.ofData
+    (fun b => match b with
+      | true => (tones : List (Autosegmental.TwoTier Tone TBU true))
+      | false => tbus)
+    (mkL links)
+
+open Autosegmental in
+/-- Non-embedding verdicts compute: the spec plus kernel evaluation. -/
+theorem mk_embeds_iff {tF tX : List Tone} {bF bX : List TBU}
+    {lF lX : List (ℕ × ℕ)} :
+    (mk tF bF lF).FactorEmbeds (mk tX bX lX) ↔
+      dataEmbeds
+        (fun b => match b with
+          | true => (tF : List (Autosegmental.TwoTier Tone TBU true))
+          | false => bF)
+        (fun b => match b with
+          | true => (tX : List (Autosegmental.TwoTier Tone TBU true))
+          | false => bX)
+        (mkL lF) (mkL lX) :=
+  Representation.factorEmbeds_ofData_iff
 
 /-! ## §2 Mende: right-edge multiple association
 [jardine-2017] §3.1, eq. (5)
 
 In Mende, tonal *plateaus* (a single tone associated to multiple
 syllables) and contour tones (multiple tones on one syllable) are
-restricted to the right word edge. The HLL melody surfacing on a
-trisyllabic word like `félàmà` 'junction' arises from L's right-edge
-spread to syllables 2 and 3.
--/
+restricted to the right word edge. -/
 
 namespace Mende
 
-/-- `mbû` 'owl' (1σ, HL contour). Both H and L associate to the
-    single syllable. Contour at the right edge — the only edge. -/
-def mbû : AR := (Autosegmental.AR.contour [Tone.H, Tone.L] TBU.σ).toGraph
+/-- `mbû` 'owl' (1σ, HL contour). -/
+abbrev mbû : ARep := mk [Tone.H, Tone.L] [TBU.σ] [(0, 0), (1, 0)]
 
 /-- `ngìlà` 'dog' (2σ, HL melody, one tone per syllable). -/
-def ngìlà : AR := (Autosegmental.AR.single Tone.H TBU.σ * Autosegmental.AR.single Tone.L TBU.σ).toGraph
+abbrev ngìlà : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (1, 1)]
 
-/-- `félàmà` 'junction' (3σ, HL melody with L-spread to right two
-    syllables: HLL surface). The diagnostic case for Mende: L
-    spreads at the *right* edge. -/
-def félàmà : AR :=
-  (Autosegmental.AR.single Tone.H TBU.σ * Autosegmental.AR.spread Tone.L [TBU.σ, TBU.σ]).toGraph
+/-- `félàmà` 'junction' (3σ, HL melody with L-spread to the right two
+    syllables: HLL surface). The diagnostic case for Mende. -/
+abbrev félàmà : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ, TBU.σ] [(0, 0), (1, 1), (1, 2)]
 
-/-! ### §2.1 Forbidden subgraphs ([jardine-2017] eq. 21)
+/-- **(21a) non-final H spreading**: an H linked to two consecutive σs with an
+    L following on the tonal tier. -/
+abbrev forbidden_nonfinal_H : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (0, 1)]
 
-The Mende grammar is the conjunction of three forbidden subgraphs.
-Each subgraph captures one structural configuration that doesn't
-appear in any well-formed Mende AR.
--/
+/-- **(21b) non-final L spreading** (mirror). -/
+abbrev forbidden_nonfinal_L : ARep := mk [Tone.L, Tone.H] [TBU.σ, TBU.σ] [(0, 0), (0, 1)]
 
-/-- **(21a) non-final H spreading**: `¬ H→L : σ σ`. An H tone linked
-    to two consecutive σs, with an L tone following on the tonal
-    tier. The L's presence is what makes the H "non-final" — there's
-    another tone to its right. -/
-def forbidden_nonfinal_H : AR :=
-  (Autosegmental.AR.spread Tone.H [TBU.σ, TBU.σ] * Autosegmental.AR.float Tone.L).toGraph
+/-- **(21c) non-final contour**: an HL contour on a σ with another σ
+    following. -/
+abbrev forbidden_nonfinal_contour : ARep :=
+  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (1, 0)]
 
-/-- **(21b) non-final L spreading**: `¬ L→H : σ σ`. An L tone linked
-    to two consecutive σs, with an H tone following. -/
-def forbidden_nonfinal_L : AR :=
-  (Autosegmental.AR.spread Tone.L [TBU.σ, TBU.σ] * Autosegmental.AR.float Tone.H).toGraph
+/-! ### §2.2 Attested forms satisfy the Mende grammar ([jardine-2017] §5.1) -/
 
-/-- **(21c) non-final contour**: `¬ H L : σ→σ`. A contour (H and L
-    both linked to one σ), with another σ following on the TBU tier.
-    The trailing σ makes the contour-bearing σ "non-final". -/
-def forbidden_nonfinal_contour : AR :=
-  (Autosegmental.AR.contour [Tone.H, Tone.L] TBU.σ * Autosegmental.AR.bare TBU.σ).toGraph
+theorem mbû_no_nonfinal_H : ¬ forbidden_nonfinal_H.FactorEmbeds mbû := by
+  rw [mk_embeds_iff]; decide
 
-/-- The Mende grammar's forbidden block patterns ([jardine-2017] (21a–c)): a
-    form is well-formed iff it is `Graph.Free` of all three. -/
-def mendeForbidden : List AR :=
-  [forbidden_nonfinal_H, forbidden_nonfinal_L, forbidden_nonfinal_contour]
+theorem mbû_no_nonfinal_L : ¬ forbidden_nonfinal_L.FactorEmbeds mbû := by
+  rw [mk_embeds_iff]; decide
 
-/-! ### §2.2 Attested forms satisfy the Mende grammar
+theorem mbû_no_nonfinal_contour : ¬ forbidden_nonfinal_contour.FactorEmbeds mbû := by
+  rw [mk_embeds_iff]; decide
 
-Each attested form is well-formed under the Mende grammar iff it
-does not contain any forbidden subgraph. By `SubgraphEmbeds`, this
-is `decide`-checkable.
--/
+theorem ngìlà_no_nonfinal_H : ¬ forbidden_nonfinal_H.FactorEmbeds ngìlà := by
+  rw [mk_embeds_iff]; decide
 
-/-- `mbû` (HL contour on 1σ) — well-formed. -/
-theorem mbû_no_nonfinal_H : ¬ SubgraphEmbeds forbidden_nonfinal_H mbû := by decide
-theorem mbû_no_nonfinal_L : ¬ SubgraphEmbeds forbidden_nonfinal_L mbû := by decide
-theorem mbû_no_nonfinal_contour : ¬ SubgraphEmbeds forbidden_nonfinal_contour mbû := by decide
+theorem ngìlà_no_nonfinal_L : ¬ forbidden_nonfinal_L.FactorEmbeds ngìlà := by
+  rw [mk_embeds_iff]; decide
 
-/-- `ngìlà` (HL on 2σ, one tone per σ) — well-formed. -/
-theorem ngìlà_no_nonfinal_H : ¬ SubgraphEmbeds forbidden_nonfinal_H ngìlà := by decide
-theorem ngìlà_no_nonfinal_L : ¬ SubgraphEmbeds forbidden_nonfinal_L ngìlà := by decide
 theorem ngìlà_no_nonfinal_contour :
-    ¬ SubgraphEmbeds forbidden_nonfinal_contour ngìlà := by decide
+    ¬ forbidden_nonfinal_contour.FactorEmbeds ngìlà := by
+  rw [mk_embeds_iff]; decide
 
-/-- `félàmà` (HLL on 3σ via L-spread to final two σs) — the key
-    well-formedness check. L is multiply associated, but the spread
-    is to the *right edge*; no forbidden subgraph embeds. -/
-theorem félàmà_no_nonfinal_H : ¬ SubgraphEmbeds forbidden_nonfinal_H félàmà := by decide
-theorem félàmà_no_nonfinal_L : ¬ SubgraphEmbeds forbidden_nonfinal_L félàmà := by decide
+theorem félàmà_no_nonfinal_H : ¬ forbidden_nonfinal_H.FactorEmbeds félàmà := by
+  rw [mk_embeds_iff]; decide
+
+theorem félàmà_no_nonfinal_L : ¬ forbidden_nonfinal_L.FactorEmbeds félàmà := by
+  rw [mk_embeds_iff]; decide
+
 theorem félàmà_no_nonfinal_contour :
-    ¬ SubgraphEmbeds forbidden_nonfinal_contour félàmà := by decide
-
-/-- All three Mende attested forms satisfy the full Mende grammar: each is
-    `Graph.Free` of `mendeForbidden` (none of the three forbidden subgraphs
-    embeds into any of them). [jardine-2017] §5.1, the main empirical claim. -/
-theorem mende_grammar_admits_attested :
-    mbû.Free mendeForbidden ∧ ngìlà.Free mendeForbidden ∧ félàmà.Free mendeForbidden := by
-  decide
+    ¬ forbidden_nonfinal_contour.FactorEmbeds félàmà := by
+  rw [mk_embeds_iff]; decide
 
 end Mende
 
-/-! ## §3 Hausa: left-edge multiple association
-[jardine-2017] eq. (7), (22)
-
-Hausa is the *mirror* of Mende: multiple association occurs only at
-the left edge. `háantúnàa` 'noses' has HHL surface — the H spreads
-*leftward* to the first two syllables.
--/
+/-! ## §3 Hausa: left-edge multiple association ([jardine-2017] eq. (7), (22)) -/
 
 namespace Hausa
 
 /-- `fáadi` 'fall' (2σ, HL melody one-to-one). -/
-def fáadi : AR := (Autosegmental.AR.single Tone.H TBU.σ * Autosegmental.AR.single Tone.L TBU.σ).toGraph
+abbrev fáadi : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (1, 1)]
 
-/-- `háantúnàa` 'noses' (3σ, HHL — H spreads at the *left* edge to
-    the first two syllables). The Hausa diagnostic. -/
-def háantúnàa : AR :=
-  (Autosegmental.AR.spread Tone.H [TBU.σ, TBU.σ] * Autosegmental.AR.single Tone.L TBU.σ).toGraph
+/-- `háantúnàa` 'noses' (3σ, HHL — H spreads at the *left* edge). -/
+abbrev háantúnàa : ARep :=
+  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ, TBU.σ] [(0, 0), (0, 1), (1, 2)]
 
-/-! ### §3.1 Forbidden subgraphs ([jardine-2017] eq. 22)
-
-Hausa's grammar is the mirror of Mende's: non-*initial* multiple
-association is forbidden. The first two subgraphs match an L
-preceding an H linked to two σs (non-initial H spreading) and
-mirror; the third forbids a non-initial contour.
--/
-
-/-- **(22a) non-initial H spreading**: `¬ L→H : σ σ`. An L on the
-    tonal tier followed by an H linked to two σs — the H is
-    non-initial (preceded by L). -/
-def forbidden_noninitial_H : AR :=
-  ((Autosegmental.AR.float Tone.L : Autosegmental.AR Tone TBU) * Autosegmental.AR.spread Tone.H [TBU.σ, TBU.σ]).toGraph
+/-- **(22a) non-initial H spreading**: an L preceding an H linked to two σs. -/
+abbrev forbidden_noninitial_H : ARep :=
+  mk [Tone.L, Tone.H] [TBU.σ, TBU.σ] [(1, 0), (1, 1)]
 
 /-- **(22b) non-initial L spreading** (mirror). -/
-def forbidden_noninitial_L : AR :=
-  ((Autosegmental.AR.float Tone.H : Autosegmental.AR Tone TBU) * Autosegmental.AR.spread Tone.L [TBU.σ, TBU.σ]).toGraph
+abbrev forbidden_noninitial_L : ARep :=
+  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(1, 0), (1, 1)]
 
-/-- **(22c) non-initial contour**: a σ preceded by another σ on
-    the TBU tier, with a contour H L linked to the second σ. -/
-def forbidden_noninitial_contour : AR :=
-  ((Autosegmental.AR.bare TBU.σ : Autosegmental.AR Tone TBU) * Autosegmental.AR.contour [Tone.H, Tone.L] TBU.σ).toGraph
+/-- **(22c) non-initial contour**: a σ preceded by another σ, bearing an HL
+    contour. -/
+abbrev forbidden_noninitial_contour : ARep :=
+  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 1), (1, 1)]
 
 /-! ### §3.2 Attested Hausa forms satisfy the Hausa grammar -/
 
-theorem fáadi_no_noninitial_H :
-    ¬ SubgraphEmbeds forbidden_noninitial_H fáadi := by decide
-theorem fáadi_no_noninitial_L :
-    ¬ SubgraphEmbeds forbidden_noninitial_L fáadi := by decide
+theorem fáadi_no_noninitial_H : ¬ forbidden_noninitial_H.FactorEmbeds fáadi := by
+  rw [mk_embeds_iff]; decide
+
+theorem fáadi_no_noninitial_L : ¬ forbidden_noninitial_L.FactorEmbeds fáadi := by
+  rw [mk_embeds_iff]; decide
+
 theorem fáadi_no_noninitial_contour :
-    ¬ SubgraphEmbeds forbidden_noninitial_contour fáadi := by decide
+    ¬ forbidden_noninitial_contour.FactorEmbeds fáadi := by
+  rw [mk_embeds_iff]; decide
 
 theorem háantúnàa_no_noninitial_H :
-    ¬ SubgraphEmbeds forbidden_noninitial_H háantúnàa := by decide
+    ¬ forbidden_noninitial_H.FactorEmbeds háantúnàa := by
+  rw [mk_embeds_iff]; decide
+
 theorem háantúnàa_no_noninitial_L :
-    ¬ SubgraphEmbeds forbidden_noninitial_L háantúnàa := by decide
+    ¬ forbidden_noninitial_L.FactorEmbeds háantúnàa := by
+  rw [mk_embeds_iff]; decide
+
 theorem háantúnàa_no_noninitial_contour :
-    ¬ SubgraphEmbeds forbidden_noninitial_contour háantúnàa := by decide
+    ¬ forbidden_noninitial_contour.FactorEmbeds háantúnàa := by
+  rw [mk_embeds_iff]; decide
 
 end Hausa
 
@@ -272,12 +269,14 @@ prohibition applies.
     forbids: non-final H spreading. This makes Mende and Hausa
     mutually exclusive on their diagnostic forms. -/
 theorem hausa_haantunaa_violates_mende :
-    SubgraphEmbeds Mende.forbidden_nonfinal_H Hausa.háantúnàa := by decide
+    Mende.forbidden_nonfinal_H.FactorEmbeds Hausa.háantúnàa := by
+  rw [mk_embeds_iff]; decide
 
 /-- Symmetrically, Mende's `félàmà` (HLL = L-spread to last 2σ)
     contains Hausa's forbidden non-initial-L pattern. -/
 theorem mende_felama_violates_hausa :
-    SubgraphEmbeds Hausa.forbidden_noninitial_L Mende.félàmà := by decide
+    Hausa.forbidden_noninitial_L.FactorEmbeds Mende.félàmà := by
+  rw [mk_embeds_iff]; decide
 
 /-! ## §5 Future extensions
 

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -424,7 +424,7 @@ theorem laoideKemp_fig1_fig5 :
 /-! ## §10 Modularity: the analysis lives in the monoidal subcategory
 
 [laoide-kemp-2026]'s strict-modularity thesis, formalised against the
-monoidal-subcategory framework (`Autosegmental.WellFormedAR`).
+monoidal category of representations.
 Three theorems, one per modular commitment: the morpheme is *composed*
 by the monoidal product `⊗ = concat` (not inserted by a non-local
 rule); the composition *preserves well-formedness* because the
@@ -732,9 +732,9 @@ theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind 
 
 The deepest categorical content: morpheme *prefixation* is not merely a
 function on representations but an **endofunctor on the monoidal
-category** `WellFormedAR` — mathlib's `tensorLeft`. This consumes the full
-`MonoidalCategory (WellFormedAR α β)` instance (not merely the `concat`
-operation), and the **associativity of prefixation** is `WellFormedAR`'s
+category** of representations — mathlib's `tensorLeft`. This consumes the
+full `MonoidalCategory (Representation t)` instance (not merely the tensor
+operation), and the **associativity of prefixation** is the category's
 associator, exhibited by `tensorLeftTensor` — a natural isomorphism
 that does not exist without coherence (pentagon + triangle).
 
@@ -743,10 +743,10 @@ not right: the categorical encoding of the morpheme's **directionality**
 as a preverbal particle rather than a suffix.
 
 The remaining Layer-2 frontier — modelling *lenition* and *docking*
-themselves as functors `WellFormedAR ⥤ WellFormedAR` (acting on morphisms, not just
+themselves as endofunctors of the representation category (acting on morphisms, not just
 objects) — is left open. The conjecture is that they are functorial
 only over the precedence-preserving `Graph.SubgraphEmbeds`, not over
-all of `AR.Hom`; settling it either way is a genuine result. The
+all broad morphisms; `delinkMinFunctor` settles the lenition case. The
 extensional content (no look-ahead) is fully captured by
 `dPrimeSurfaces_withHist_concat_right` above: for any suffix, whether
 `(d)` surfaces depends only on the stem's left edge. -/
@@ -763,9 +763,9 @@ def historicExponentRep :
     ⊥
 
 open CategoryTheory MonoidalCategory in
-/-- **The historic morpheme is an endofunctor on `WellFormedAR`.** Prefixing `(d)`
+/-- **The historic morpheme is an endofunctor of the representation category.** Prefixing `(d)`
     is left-tensoring by `historicExponentAR` — mathlib's `tensorLeft`,
-    which exists only because `WellFormedAR` is a `MonoidalCategory`. Left- rather
+    which exists only because the category is monoidal. Left- rather
     than right-tensoring encodes the morpheme's directionality as a
     preverbal particle. -/
 def withHistFunctor :
@@ -786,9 +786,9 @@ theorem withHistFunctor_obj
 open CategoryTheory MonoidalCategory in
 /-- **Associativity of prefixation is the associator.** This natural
     isomorphism — prefixing the compound `(d) ⊗ X` equals prefixing `X`
-    then prefixing `(d)` — is built from `WellFormedAR`'s associator, so it does
+    then prefixing `(d)` — is built from the category's associator, so it does
     not exist unless the monoidal structure is *coherent* (pentagon +
-    triangle). It is the concrete artifact that makes `WellFormedAR`'s coherence
+    triangle). It is the concrete artifact that makes the monoidal coherence
     load-bearing rather than decorative. -/
 noncomputable def prefixAssoc
     (X : Representation (Sigma.fst :
@@ -807,9 +807,9 @@ association lines to the leftmost (word-initial) skeletal slot.
 
 The answer is a sharp dichotomy. `delinkInitial` is **not** a functor on
 the full category `AR α β`: a label-preserving reindexing
-(`AR.Hom`) can move a non-initial element into initial position, after
+(a broad `MixedGraphCat.Hom`) can move a non-initial element into initial position, after
 which there is *no* morphism between the delinked images at all
-(`delinkInitial_not_functorial`). But over `PrecAR`, the
+(`delinkInitial_not_functorial`). But over the precedence-preserving wide subcategory, the
 **precedence-preserving wide subcategory** (`Autosegmental/Embedding.lean`:
 order-embedding tier maps; `SubgraphEmbeds` translations are canonical
 instances), it lifts to a genuine endofunctor `delinkInitialFunctor`

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -820,110 +820,85 @@ linguistic fact that lenition targets the *word-initial* consonant: the
 process is functorial over exactly the maps that preserve precedence. -/
 
 section Frontier
-variable {α β : Type*}
 
-/-- The model of `{L}`-lenition: erase the association lines to the
-    leftmost (slot-0) skeletal position. Erasing links preserves
-    in-boundedness, so it is an endomap of `AR`. -/
-def delinkInitial (A : AR α β) : AR α β where
-  toGraph := { A.toGraph with links := A.links.filter (fun p => p.snd ≠ 0) }
-  inBounds p hp := A.inBounds p (Finset.mem_of_mem_filter p hp)
+open Autosegmental
 
-@[simp] theorem delinkInitial_links (A : AR α β) :
-    (delinkInitial A).links = A.links.filter (fun p => p.snd ≠ 0) := rfl
+/-- Lenition's structural model on the foundation: erase the association
+    lines at the word-initial (tier-initial) skeletal position —
+    `MixedGraphCat.delinkMin`. Its functoriality over precedence-preserving
+    morphisms is the substrate theorem `Autosegmental.delinkMinFunctor`;
+    here we exhibit the **negative half**: on the broad category the lift
+    fails, because a label-preserving reindexing can move a non-initial
+    slot into initial position. -/
+private abbrev negA :
+    Representation (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
+  Representation.ofData
+    (fun b => match b with
+      | true => ([()] : List (TwoTier Unit Bool true))
+      | false => [false, true])
+    (fun i j p q => i = true ∧ j = false ∧ p = 0 ∧ q = 1)
 
-/-- **`delinkInitial` is functorial over precedence-preserving morphisms.**
-    An `AR.Hom` that *reflects slot 0* (never maps a non-initial slot to
-    slot 0) lifts to a morphism between the delinked graphs, with the same
-    index maps. Precedence-preserving `SubgraphEmbeds` translations satisfy
-    the hypothesis: a translation sends slot `j` to `j + δ`, which is `0`
-    only when `j = 0`. -/
-def delinkInitial_map {A B : AR α β} (f : AR.Hom A B)
-    (hf : ∀ (j : Fin A.lower.len), (f.fL.toFun j : ℕ) = 0 → (j : ℕ) = 0) :
-    AR.Hom (delinkInitial A) (delinkInitial B) where
-  fU := f.fU
-  fL := f.fL
-  links_preserve {i j} hi hj h := by
-    rw [delinkInitial_links, Finset.mem_filter] at h ⊢
-    obtain ⟨hmem, hne⟩ := h
-    exact ⟨f.links_preserve hi hj hmem, fun h0 => hne (hf ⟨j, hj⟩ h0)⟩
+private abbrev negB :
+    Representation (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
+  Representation.ofData
+    (fun b => match b with
+      | true => ([()] : List (TwoTier Unit Bool true))
+      | false => [true, false])
+    (fun i j p q => i = true ∧ j = false ∧ p = 0 ∧ q = 0)
 
-/-- Functor law: `delinkInitial_map` preserves identities. -/
-theorem delinkInitial_map_id (A : AR α β) :
-    delinkInitial_map (AR.Hom.id A) (fun _ h => h) = AR.Hom.id (delinkInitial A) := by
-  apply AR.Hom.ext <;> rfl
+/-- The label-preserving swap of the two skeletal slots: a broad morphism
+    (it does not preserve precedence). -/
+private def negSwap : MixedGraphCat.Hom negA.obj negB.obj where
+  toFun v := match v with
+    | ⟨true, p⟩ => ⟨true, p⟩
+    | ⟨false, ⟨0, _⟩⟩ => ⟨false, ⟨1, by decide⟩⟩
+    | ⟨false, ⟨1, _⟩⟩ => ⟨false, ⟨0, by decide⟩⟩
+  edge_map := by
+    rintro ⟨bv, p⟩ ⟨bw, q⟩ ⟨hne, hor⟩
+    rcases hor with ⟨rfl, rfl, hp, hq⟩ | ⟨rfl, rfl, hp, hq⟩
+    · obtain rfl : p = ⟨0, by decide⟩ := Fin.ext hp
+      obtain rfl : q = ⟨1, by decide⟩ := Fin.ext hq
+      exact ⟨by decide, Or.inl ⟨rfl, rfl, rfl, rfl⟩⟩
+    · obtain rfl : q = ⟨0, by decide⟩ := Fin.ext hp
+      obtain rfl : p = ⟨1, by decide⟩ := Fin.ext hq
+      exact ⟨by decide, Or.inr ⟨rfl, rfl, rfl, rfl⟩⟩
+  label_comp := by
+    rintro ⟨bv, p⟩
+    cases bv
+    · match p with
+      | ⟨0, _⟩ => rfl
+      | ⟨1, _⟩ => rfl
+    · rfl
 
-/-- Functor law: `delinkInitial_map` preserves composition. -/
-theorem delinkInitial_map_comp {A B C : AR α β} (f : AR.Hom A B) (g : AR.Hom B C)
-    (hf : ∀ (j : Fin A.lower.len), (f.fL.toFun j : ℕ) = 0 → (j : ℕ) = 0)
-    (hg : ∀ (j : Fin B.lower.len), (g.fL.toFun j : ℕ) = 0 → (j : ℕ) = 0)
-    (hfg : ∀ (j : Fin A.lower.len), ((f.comp g).fL.toFun j : ℕ) = 0 → (j : ℕ) = 0) :
-    delinkInitial_map (f.comp g) hfg =
-      (delinkInitial_map f hf).comp (delinkInitial_map g hg) := by
-  apply AR.Hom.ext <;> rfl
-
-open CategoryTheory in
-/-- **`delinkInitial` is an endofunctor of the precedence-preserving subcategory
-    `PrecAR`** (`Autosegmental/Embedding.lean`). Lenition lifts to a morphism
-    exactly when the reindexing preserves precedence — `delinkInitial_not_functorial`
-    shows it fails on the full `AR`. The object endomap is `delinkInitial`, the
-    morphism action `delinkInitial_map`; precedence-preservation transports for free
-    because `delinkInitial_map` keeps the tier maps unchanged. This makes "lenition
-    respects linear adjacency" a typed theorem ([jardine-2017] Ch. 7's process-as-
-    graph-relation view, here in categorical form). -/
-def delinkInitialFunctor : PrecAR α β ⥤ PrecAR α β where
-  obj A := ⟨delinkInitial A.obj⟩
-  map {_ _} f := ⟨delinkInitial_map f.hom (precPreserving.reflects_zero f.property), f.property⟩
-  map_id A := by apply WideSubcategory.hom_ext; exact delinkInitial_map_id A.obj
-  map_comp f g := by
-    apply WideSubcategory.hom_ext
-    exact delinkInitial_map_comp f.hom g.hom
-      (precPreserving.reflects_zero f.property)
-      (precPreserving.reflects_zero g.property)
-      (precPreserving.reflects_zero (precPreserving.comp_mem _ _ f.property g.property))
+/-- **Delinking is not functorial on the broad category**: `negSwap` is a
+    morphism, yet the delinked images admit no morphism at all — the
+    surviving slot-1 link of `negA` lands on `negB`'s initial slot, which
+    delinking erased. The obstruction is precisely failure to preserve
+    precedence (`Autosegmental.delinkMinFunctor` lifts it otherwise). -/
+theorem delinkInitial_not_functorial :
+    IsEmpty (MixedGraphCat.Hom
+      (MixedGraphCat.delinkMin Sigma.fst false negA.obj)
+      (MixedGraphCat.delinkMin Sigma.fst false negB.obj)) := by
+  refine ⟨fun g => ?_⟩
+  let v1 : negA.obj.V := ⟨true, ⟨0, by decide⟩⟩
+  let w1 : negA.obj.V := ⟨false, ⟨1, by decide⟩⟩
+  have hsurv : (MixedGraphCat.delinkMin Sigma.fst false negA.obj).graph.edges.Adj v1 w1 := by
+    refine ⟨⟨by decide, Or.inl ⟨rfl, rfl, rfl, rfl⟩⟩, ?_, ?_⟩
+    · rintro ⟨h, -⟩
+      exact absurd h (by decide)
+    · rintro ⟨-, hmin⟩
+      exact hmin ⟨false, ⟨0, by decide⟩⟩ ⟨rfl, by decide⟩
+  have htw : (g.toFun w1).1 = false := congrArg Sigma.fst (g.label_comp w1)
+  obtain ⟨⟨-, hor⟩, hv, hw⟩ := g.edge_map hsurv
+  rcases hor with ⟨-, -, -, hq⟩ | ⟨ht, -, -, -⟩
+  · -- the image link lands on negB's initial slot: contradiction with delinking
+    refine hw ⟨htw, fun u hu => ?_⟩
+    have h2 : (u.2 : ℕ) < ((g.toFun w1).2 : ℕ) := hu.2
+    omega
+  · -- the symmetric orientation contradicts label preservation
+    exact absurd (htw.symm.trans ht) (by decide)
 
 end Frontier
-
-/-! ### The negative counterexample -/
-
-private def negA : AR ℕ ℕ := ⟨⟨.ofList [0], .ofList [0, 1], {(0, 1)}⟩, by decide⟩
-private def negB : AR ℕ ℕ := ⟨⟨.ofList [0], .ofList [1, 0], {(0, 0)}⟩, by decide⟩
-
-/-- A label-preserving reindexing that **swaps** the two skeletal slots,
-    moving the slot-1 element into initial position. A valid `AR.Hom`
-    that does *not* reflect slot 0 (`fL 1 = 0`). The `Fin`-indexed maps
-    need no canonical-shift bookkeeping. -/
-private def negSwap : AR.Hom negA negB where
-  fU := ⟨_root_.id, by decide⟩
-  fL := ⟨fun j => if (j : ℕ) = 0 then ⟨1, by decide⟩ else ⟨0, by decide⟩, by decide⟩
-  links_preserve := by
-    intro i j hi hj h
-    have hij : (i, j) = (0, 1) := by
-      have : (i, j) ∈ ({(0, 1)} : Finset (ℕ × ℕ)) := h
-      simpa using this
-    obtain ⟨rfl, rfl⟩ := Prod.mk.injEq .. ▸ hij
-    show ((0 : ℕ), (0 : ℕ)) ∈ negB.links
-    decide
-
-/-- **`delinkInitial` is not a functor on the full category.** `negSwap`
-    is a morphism `negA → negB`, yet after delinking there is *no* morphism
-    `delinkInitial negA → delinkInitial negB` at all: the surviving slot-1
-    link of `negA` has been moved onto slot 0 of `negB`, which delinking
-    erases, so link-preservation becomes impossible. A functor would have
-    to supply such a morphism; none exists. The positive
-    `delinkInitial_map` shows the obstruction is exactly the failure to
-    preserve precedence. -/
-theorem delinkInitial_not_functorial :
-    ∃ (A B : AR ℕ ℕ) (_ : AR.Hom A B),
-      IsEmpty (AR.Hom (delinkInitial A) (delinkInitial B)) :=
-  ⟨negA, negB, negSwap, ⟨fun g => by
-    have hp : ((0, 1) : ℕ × ℕ) ∈ (delinkInitial negA).links := by decide
-    have hi : (0 : ℕ) < (delinkInitial negA).upper.len := by decide
-    have hj : (1 : ℕ) < (delinkInitial negA).lower.len := by decide
-    have h := g.links_preserve hi hj hp
-    have hempty : (delinkInitial negB).links = ∅ := by decide
-    rw [hempty] at h
-    simp at h⟩⟩
 
 /-! ## §12 The strict-modularity payoff
 


### PR DESCRIPTION
Decidable banned-subgraph grammars on the foundation: factor embedding as a bounded search, the data-level checker dataEmbeds with its spec factorEmbeds_ofData_iff (verdicts on concrete forms are rw-then-decide), Jardine 2016 + 2017 fully ported (correspondence grammar by witness proofs; Mende/Hausa suites by the checker), the initial-delink endofunctor on the precedence-preserving wide subcategory with the non-functoriality counterexample on the broad category (LaoideKemp §11.5).