### PR TITLE
refactor(Phonology/Autosegmental): end-state names — Graph and AR

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1344,13 +1344,13 @@ import Linglib.Morphology.UsageBased.Network
 import Linglib.Morphology.Word
 import Linglib.Morphology.WugTest
 import Linglib.Phonology.Autosegmental.ASL
-import Linglib.Phonology.Autosegmental.Collapse
+import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Correspondence
 import Linglib.Phonology.Autosegmental.Floating
 import Linglib.Phonology.Autosegmental.Hull
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Autosegmental.Melody
-import Linglib.Phonology.Autosegmental.MixedGraph
+import Linglib.Phonology.Autosegmental.Graph
 import Linglib.Phonology.Autosegmental.NonCrossing
 import Linglib.Phonology.Autosegmental.NormalForm
 import Linglib.Phonology.Autosegmental.Sharing

--- a/Linglib/Fragments/Tangale/Phonology.lean
+++ b/Linglib/Fragments/Tangale/Phonology.lean
@@ -51,11 +51,11 @@ variable {ws : ∀ b, List (TwoTier Tone Unit b)} {L : Bool → Bool → ℕ →
     on top of whatever it already bore. -/
 theorem hts_surfacesWith_H {i j : ℕ} (hH : (ws true)[i]? = some Tone.H)
     (hj : j + 1 < (ws false).length) :
-    (Representation.ofData ws (hts L i j)).surfacesWith Tone.H (j + 1) := by
+    (AR.ofData ws (hts L i j)).surfacesWith Tone.H (j + 1) := by
   rcases List.getElem?_eq_some_iff.mp hH with ⟨hi, -⟩
-  refine ⟨i, (Representation.link_ofData true false i (j + 1)).mpr
+  refine ⟨i, (AR.link_ofData true false i (j + 1)).mpr
     ⟨by decide, hi, hj, Or.inl (Or.inr ⟨rfl, rfl, rfl, rfl⟩)⟩, ?_⟩
-  rw [Representation.tierWord_ofData]
+  rw [AR.tierWord_ofData]
   exact hH
 
 /-- Spread followed by Left Line Delinking shifts the H one TBU rightward
@@ -64,18 +64,18 @@ theorem hts_surfacesWith_H {i j : ℕ} (hH : (ws true)[i]? = some Tone.H)
 theorem lld_hts_shift {i j : ℕ} (hH : (ws true)[i]? = some Tone.H)
     (hj : j + 1 < (ws false).length) (hne : j + 1 ≠ j)
     (hor : ∀ p q, ¬ L false true p q) :
-    (Representation.ofData ws (lld (hts L i j) i j)).surfacesWith Tone.H (j + 1) ∧
-      ¬ (Representation.ofData ws (lld (hts L i j) i j)).link true false i j := by
+    (AR.ofData ws (lld (hts L i j) i j)).surfacesWith Tone.H (j + 1) ∧
+      ¬ (AR.ofData ws (lld (hts L i j) i j)).link true false i j := by
   rcases List.getElem?_eq_some_iff.mp hH with ⟨hi, -⟩
   constructor
-  · refine ⟨i, (Representation.link_ofData true false i (j + 1)).mpr
+  · refine ⟨i, (AR.link_ofData true false i (j + 1)).mpr
       ⟨by decide, hi, hj, Or.inl ⟨Or.inr ⟨rfl, rfl, rfl, rfl⟩, ?_⟩⟩, ?_⟩
     · rintro ⟨-, -, -, h⟩
       exact hne h
-    · rw [Representation.tierWord_ofData]
+    · rw [AR.tierWord_ofData]
       exact hH
   · rintro h
-    rcases (Representation.link_ofData true false i j).mp h with
+    rcases (AR.link_ofData true false i j).mp h with
       ⟨-, -, -, ⟨-, hno⟩ | ⟨hraw | ⟨hfalse, -⟩, -⟩⟩
     · exact hno ⟨rfl, rfl, rfl, rfl⟩
     · exact hor _ _ hraw

--- a/Linglib/Phonology/Autosegmental/ASL.lean
+++ b/Linglib/Phonology/Autosegmental/ASL.lean
@@ -44,17 +44,17 @@ variable {ι : Type*} [Finite ι] {τ : ι → Type*}
     strings whose realization avoids every forbidden factor — the preimage of
     the banned-subgraph object property along `realize`, the same shape as
     `TSL.lang = tierProject ⁻¹' (SL-language)`. -/
-def Representation.ASL (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+def AR.ASL (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     [∀ s, Finite (g₀ s).obj.V]
-    (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
+    (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
     Language S :=
   { w | (realize g₀ w).Free B }
 
-@[simp] theorem Representation.mem_ASL
-    {g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+@[simp] theorem AR.mem_ASL
+    {g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [∀ s, Finite (g₀ s).obj.V]
-    {B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}}
-    {w : List S} : w ∈ Representation.ASL g₀ B ↔ (realize g₀ w).Free B := Iff.rfl
+    {B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}}
+    {w : List S} : w ∈ AR.ASL g₀ B ↔ (realize g₀ w).Free B := Iff.rfl
 
 end Coordinate
 

--- a/Linglib/Phonology/Autosegmental/Correspondence.lean
+++ b/Linglib/Phonology/Autosegmental/Correspondence.lean
@@ -48,7 +48,7 @@ variable {S T : Type*}
 /-! ### Correspondence on the graph foundation
 
 The same layer over two-tier representations: input over `true`, output over
-`false`, correspondence arcs the links, banned subgraphs `Representation.Free`. -/
+`false`, correspondence arcs the links, banned subgraphs `AR.Free`. -/
 
 section Coordinate
 
@@ -57,7 +57,7 @@ variable {S T : Type u}
 
 /-- A finite two-tier correspondence representation. -/
 abbrev Rep (S T : Type u) :=
-  {G : Representation.{u, 0, u} (Sigma.fst : ((b : Bool) × TwoTier S T b) → Bool) //
+  {G : AR.{u, 0, u} (Sigma.fst : ((b : Bool) × TwoTier S T b) → Bool) //
     Finite G.obj.V}
 
 /-- The **input** string: the `true`-tier word. -/
@@ -96,12 +96,12 @@ def IsLocalRep (R : List S → List T → Prop) : Prop :=
     two local constraint sets. -/
 theorem specifiedByRep_append (φ ψ : List (Rep S T)) (G : Rep S T) :
     specifiedByRep (φ ++ ψ) G ↔ specifiedByRep φ G ∧ specifiedByRep ψ G := by
-  unfold specifiedByRep Representation.Free
+  unfold specifiedByRep AR.Free
   rw [List.forall_mem_append]
 
 /-- The empty grammar specifies all of GEN. -/
 @[simp] theorem specifiedByRep_nil (G : Rep S T) : specifiedByRep [] G ↔ True := by
-  unfold specifiedByRep Representation.Free
+  unfold specifiedByRep AR.Free
   simp
 
 end Coordinate

--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -19,7 +19,7 @@ import Linglib.Core.Combinatorics.MixedGraph
 A labeled mixed graph `⟨V, E, A, ℓ⟩` has labeled vertices, undirected
 association edges, and directed order arcs — the autosegmental representation
 of [jardine-2019], with no further structure. The graph is a `MixedGraph` (Core)
-and the labeling a map `ℓ : V → S`; `MixedGraphCat S` bundles the two. Tiers are
+and the labeling a map `ℓ : V → S`; `Graph S` bundles the two. Tiers are
 not part of the object: a tier assignment `t : S → ι` on the labels induces a
 vertex coloring `X.tier t`, and well-formedness axioms carve the representations
 out of the raw graphs relative to it.
@@ -32,15 +32,15 @@ out of the raw graphs relative to it.
   tier-relative axioms, a vertex coloring `c : V → ι`. Saturation is stated but
   not imposed, as in `AR.lean`; tier-orderedness includes path-closure
   (`MixedGraph.PrecPath`), [jardine-2019]'s reading that `A` represents the order.
-* `MixedGraphCat S`: the labeled mixed graph ([jardine-2019]'s `GR(Γ)`) and the
+* `Graph S`: the labeled mixed graph ([jardine-2019]'s `GR(Γ)`) and the
   category thereof, with `HasInitial` and `HasBinaryCoproducts`;
-  `MixedGraphCat.Hom` are label- and association-preserving maps, `precPreserving`
-  marks the full-structure homomorphisms, `MixedGraphCat.Iso` the full-structure
+  `Graph.Hom` are label- and association-preserving maps, `precPreserving`
+  marks the full-structure homomorphisms, `Graph.Iso` the full-structure
   equivalences.
-* `MixedGraphCat.concat t`: concatenation — the vertex sum with a same-tier
+* `Graph.concat t`: concatenation — the vertex sum with a same-tier
   bridge, [jardine-heinz-2015] Definition 2 in the order signature, minus its
-  `R_ID` merge (`OCP.collapse`); `MixedGraphCat.sum` is the bridge-free coproduct.
-* `Representation t`: the category of autosegmental representations — the full
+  `R_ID` merge (`OCP.collapse`); `Graph.sum` is the bridge-free coproduct.
+* `AR t`: the category of autosegmental representations — the full
   subcategory of labeled mixed graphs on Axioms 1–3, monoidal under `concat`.
 
 ## Main results
@@ -51,7 +51,7 @@ out of the raw graphs relative to it.
   order signature; `isPlanar_concat` is [jardine-2019]'s NCC-preservation.
 * `not_isTierOrdered_sum`: the bridge-free coproduct leaves the axiom class
   whenever the factors share a tier — Axiom 2 forces `concat`'s bridges.
-* `Representation.tierColoring`: the tier map properly colors the association
+* `AR.tierColoring`: the tier map properly colors the association
   graph, so tier arity bounds its chromatic number (`edges_colorable`).
 
 ## Implementation notes
@@ -140,7 +140,7 @@ theorem IsTierOrdered.isStrictTotalOrder (h : IsTierOrdered G c) (i : ι) :
 /-- An object of the category of labeled mixed graphs over `S`: a vertex type
     with a mixed graph `⟨V, E, A⟩` on it and a labeling `ℓ : V → S` — the
     literature's labeled mixed graph `⟨V, E, A, ℓ⟩` / [jardine-2019]'s `GR(Γ)`. -/
-structure MixedGraphCat (S : Type*) where
+structure Graph (S : Type*) where
   /-- The vertex type. -/
   V : Type*
   /-- The mixed graph: undirected association edges and directed order arcs. -/
@@ -148,12 +148,12 @@ structure MixedGraphCat (S : Type*) where
   /-- The labeling (`ℓ`). -/
   label : V → S
 
-namespace MixedGraphCat
+namespace Graph
 
-variable {X Y Z : MixedGraphCat S}
+variable {X Y Z : Graph S}
 
 /-- The tier of a vertex under a tier assignment on the alphabet. -/
-def tier (t : S → ι) (X : MixedGraphCat S) : X.V → ι := t ∘ X.label
+def tier (t : S → ι) (X : Graph S) : X.V → ι := t ∘ X.label
 
 /-! ### Morphisms -/
 
@@ -163,7 +163,7 @@ def tier (t : S → ι) (X : MixedGraphCat S) : X.V → ι := t ∘ X.label
     OCP repair live; the precedence-preserving maps form the wide morphism class
     `precPreserving` (the legacy `AR.Hom` vs `PrecAR` split, at the foundation). -/
 @[ext]
-structure Hom (X Y : MixedGraphCat S) where
+structure Hom (X Y : Graph S) where
   /-- The vertex map. -/
   toFun : X.V → Y.V
   /-- Association edges are preserved. -/
@@ -176,7 +176,7 @@ def Hom.edgesHom (f : Hom X Y) : X.graph.edges →g Y.graph.edges :=
   ⟨f.toFun, fun h => f.edge_map h⟩
 
 /-- The identity morphism. -/
-def Hom.id (X : MixedGraphCat S) : Hom X X :=
+def Hom.id (X : Graph S) : Hom X X :=
   ⟨_root_.id, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Composition of morphisms. -/
@@ -187,7 +187,7 @@ def Hom.comp (f : Hom X Y) (g : Hom Y Z) : Hom X Z :=
 /-! ### Isomorphism -/
 
 /-- A label- and relation-preserving equivalence of labeled mixed graphs. -/
-structure Iso (X Y : MixedGraphCat S) extends X.V ≃ Y.V where
+structure Iso (X Y : Graph S) extends X.V ≃ Y.V where
   /-- Association edges correspond. -/
   edges_iff : ∀ v w, Y.graph.edges.Adj (toEquiv v) (toEquiv w) ↔ X.graph.edges.Adj v w
   /-- Order arcs correspond. -/
@@ -208,7 +208,7 @@ def Iso.toHom (e : Iso X Y) : Hom X Y :=
   ⟨e.toEquiv, fun _ _ h => (e.edges_iff _ _).mpr h, e.label_comp⟩
 
 /-- The identity isomorphism. -/
-def Iso.refl (X : MixedGraphCat S) : Iso X X :=
+def Iso.refl (X : Graph S) : Iso X X :=
   ⟨Equiv.refl X.V, fun _ _ => Iff.rfl, fun _ _ => Iff.rfl, fun _ => rfl⟩
 
 /-- Inverse isomorphism. -/
@@ -228,7 +228,7 @@ def Iso.trans (e : Iso X Y) (f : Iso Y Z) : Iso X Z where
 /-! ### The empty graph -/
 
 /-- The empty labeled mixed graph, on the empty vertex type. -/
-def empty (S : Type*) : MixedGraphCat S := ⟨PEmpty, ⟨⊥, ⊥⟩, PEmpty.elim⟩
+def empty (S : Type*) : Graph S := ⟨PEmpty, ⟨⊥, ⊥⟩, PEmpty.elim⟩
 
 theorem isTierOrdered_empty (t : S → ι) : IsTierOrdered (empty S).graph ((empty S).tier t) :=
   ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
@@ -249,7 +249,7 @@ variable (t : S → ι)
     merge, in the precedence signature): stock disjoint sum on edges; on arcs the
     per-tier ordinal sum — blockwise arcs plus a bridge from each `X`-vertex to
     each same-tier `Y`-vertex. -/
-def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
+def concat (X Y : Graph S) : Graph S where
   V := X.V ⊕ Y.V
   graph.edges := X.graph.edges ⊕g Y.graph.edges
   graph.arcs :=
@@ -282,7 +282,7 @@ def concat (X Y : MixedGraphCat S) : MixedGraphCat S where
 /-! ### Unit laws ([jardine-heinz-2015] Theorem 1) -/
 
 /-- Concatenation with the empty graph on the right, up to isomorphism. -/
-def concatEmptyIso (X : MixedGraphCat S) : Iso (concat t X (empty S)) X where
+def concatEmptyIso (X : Graph S) : Iso (concat t X (empty S)) X where
   toEquiv := Equiv.sumEmpty X.V PEmpty
   edges_iff
     | .inl _, .inl _ => Iff.rfl
@@ -297,7 +297,7 @@ def concatEmptyIso (X : MixedGraphCat S) : Iso (concat t X (empty S)) X where
     | .inr v => v.elim
 
 /-- Concatenation with the empty graph on the left, up to isomorphism. -/
-def emptyConcatIso (X : MixedGraphCat S) : Iso (concat t (empty S) X) X where
+def emptyConcatIso (X : Graph S) : Iso (concat t (empty S) X) X where
   toEquiv := Equiv.emptySum PEmpty X.V
   edges_iff
     | .inl v, _ => v.elim
@@ -365,7 +365,7 @@ theorem isPlanar_concat (h₁ : IsPlanar X.graph) (h₂ : IsPlanar Y.graph) :
 
 /-- Concatenation of morphisms is `Sum.map`: blockwise preservation from the
     factors; label preservation transports the bridge's tier equality. -/
-def Hom.concatMap {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
+def Hom.concatMap {X₁ Y₁ X₂ Y₂ : Graph S}
     (f : Hom X₁ Y₁) (g : Hom X₂ Y₂) : Hom (concat t X₁ X₂) (concat t Y₁ Y₂) where
   toFun := Sum.map f.toFun g.toFun
   edge_map := by
@@ -377,7 +377,7 @@ def Hom.concatMap {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
 
 /-- Concatenation of isomorphisms: full-structure isos compose blockwise, the
     bridge transported by label preservation. -/
-def Iso.concatCongr {X₁ Y₁ X₂ Y₂ : MixedGraphCat S} (e₁ : Iso X₁ Y₁) (e₂ : Iso X₂ Y₂) :
+def Iso.concatCongr {X₁ Y₁ X₂ Y₂ : Graph S} (e₁ : Iso X₁ Y₁) (e₂ : Iso X₂ Y₂) :
     Iso (concat t X₁ X₂) (concat t Y₁ Y₂) where
   toEquiv := e₁.toEquiv.sumCongr e₂.toEquiv
   edges_iff v w := by
@@ -400,7 +400,7 @@ def Iso.concatCongr {X₁ Y₁ X₂ Y₂ : MixedGraphCat S} (e₁ : Iso X₁ Y�
 /-- Concatenation is associative up to isomorphism, over `Equiv.sumAssoc`; the
     edge face is the stock `SimpleGraph.Iso.sumAssoc`, and every arc case holds
     definitionally in the order signature. -/
-def concatAssocIso (X Y Z : MixedGraphCat S) :
+def concatAssocIso (X Y Z : Graph S) :
     Iso (concat t (concat t X Y) Z) (concat t X (concat t Y Z)) where
   toEquiv := Equiv.sumAssoc X.V Y.V Z.V
   edges_iff v w := SimpleGraph.Iso.sumAssoc.map_rel_iff
@@ -414,13 +414,13 @@ end Concat
 /-! ### The bridge-free sum, and why the bridges exist
 
 The plain blockwise sum carries no bridging arcs. It is the categorical
-coproduct of the broad category (`MixedGraphCat`), but it does **not** stay in
+coproduct of the broad category (`Graph`), but it does **not** stay in
 the axiom class: whenever both factors occupy a common tier, Axiom 2's totality
 fails across the seam (`not_isTierOrdered_sum`) — `concat`'s bridges are the
-minimal repair that keeps concatenation inside `Representation`. -/
+minimal repair that keeps concatenation inside `AR`. -/
 
 /-- The bridge-free blockwise sum. -/
-def sum (X Y : MixedGraphCat S) : MixedGraphCat S where
+def sum (X Y : Graph S) : Graph S where
   V := X.V ⊕ Y.V
   graph.edges := X.graph.edges ⊕g Y.graph.edges
   graph.arcs :=
@@ -470,7 +470,7 @@ theorem not_isTierOrdered_sum (t : S → ι) (v : X.V) (w : Y.V)
 
 open CategoryTheory Limits
 
-instance : Category (MixedGraphCat S) where
+instance : Category (Graph S) where
   Hom X Y := Hom X Y
   id X := Hom.id X
   comp f g := f.comp g
@@ -478,26 +478,26 @@ instance : Category (MixedGraphCat S) where
   comp_id _ := Hom.ext rfl
   assoc _ _ _ := Hom.ext rfl
 
-instance (Y : MixedGraphCat S) : Subsingleton (empty S ⟶ Y) :=
+instance (Y : Graph S) : Subsingleton (empty S ⟶ Y) :=
   ⟨fun _ _ => Hom.ext (funext fun v => v.elim)⟩
 
-instance (Y : MixedGraphCat S) : Nonempty (empty S ⟶ Y) :=
+instance (Y : Graph S) : Nonempty (empty S ⟶ Y) :=
   ⟨⟨PEmpty.elim, fun v => v.elim, fun v => v.elim⟩⟩
 
-instance : HasInitial (MixedGraphCat S) := hasInitial_of_unique (empty S)
+instance : HasInitial (Graph S) := hasInitial_of_unique (empty S)
 
 /-- Left coprojection. -/
-def inl (X Y : MixedGraphCat S) : X ⟶ sum X Y :=
+def inl (X Y : Graph S) : X ⟶ sum X Y :=
   ⟨Sum.inl, fun _ _ h => h, fun _ => rfl⟩
 
 /-- Right coprojection. -/
-def inr (X Y : MixedGraphCat S) : Y ⟶ sum X Y :=
+def inr (X Y : Graph S) : Y ⟶ sum X Y :=
   ⟨Sum.inr, fun _ _ h => h, fun _ => rfl⟩
 
 /-- The bridge-free sum is the categorical coproduct of the broad category
     (contrast `not_isTierOrdered_sum`: it leaves the axiom class, which is why
-    `Representation`'s tensor is the bridged `concat` instead). -/
-instance (X Y : MixedGraphCat S) : HasBinaryCoproduct X Y :=
+    `AR`'s tensor is the bridged `concat` instead). -/
+instance (X Y : Graph S) : HasBinaryCoproduct X Y :=
   HasColimit.mk
     { cocone := BinaryCofan.mk (inl X Y) (inr X Y)
       isColimit := BinaryCofan.IsColimit.mk _ (fun f g => sumDesc f g)
@@ -508,34 +508,34 @@ instance (X Y : MixedGraphCat S) : HasBinaryCoproduct X Y :=
           · exact congrArg (fun φ => Hom.toFun φ v) h₁
           · exact congrArg (fun φ => Hom.toFun φ v) h₂)) }
 
-instance : HasBinaryCoproducts (MixedGraphCat S) := hasBinaryCoproducts_of_hasColimit_pair _
+instance : HasBinaryCoproducts (Graph S) := hasBinaryCoproducts_of_hasColimit_pair _
 
-end MixedGraphCat
+end Graph
 
 open CategoryTheory
 
 /-- Precedence preservation as a morphism property: the maps that also preserve
     arcs — the model-theoretic full-structure homomorphisms, the foundation
     counterpart of the legacy `PrecAR` wide subcategory. -/
-def MixedGraphCat.precPreserving : MorphismProperty (MixedGraphCat S) := fun X Y f =>
+def Graph.precPreserving : MorphismProperty (Graph S) := fun X Y f =>
   ∀ ⦃v w⦄, X.graph.arcs.Adj v w → Y.graph.arcs.Adj (f.toFun v) (f.toFun w)
 
-instance : (MixedGraphCat.precPreserving (S := S)).IsMultiplicative where
+instance : (Graph.precPreserving (S := S)).IsMultiplicative where
   id_mem _ := fun _ _ h => h
   comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
 
 /-- A full isomorphism's underlying morphism preserves precedence. -/
-theorem MixedGraphCat.Iso.toHom_precPreserving {X Y : MixedGraphCat S}
-    (e : MixedGraphCat.Iso X Y) : MixedGraphCat.precPreserving e.toHom :=
+theorem Graph.Iso.toHom_precPreserving {X Y : Graph S}
+    (e : Graph.Iso X Y) : Graph.precPreserving e.toHom :=
   fun _ _ h => (e.arcs_iff _ _).mpr h
 
 /-- Concatenation of precedence-preserving morphisms preserves precedence:
     blockwise from the factors, the bridge transported by labels. -/
-theorem MixedGraphCat.Hom.concatMap_precPreserving (t : S → ι)
-    {X₁ Y₁ X₂ Y₂ : MixedGraphCat S}
-    {f : MixedGraphCat.Hom X₁ Y₁} {g : MixedGraphCat.Hom X₂ Y₂}
-    (hf : MixedGraphCat.precPreserving f) (hg : MixedGraphCat.precPreserving g) :
-    MixedGraphCat.precPreserving (f.concatMap t g) := by
+theorem Graph.Hom.concatMap_precPreserving (t : S → ι)
+    {X₁ Y₁ X₂ Y₂ : Graph S}
+    {f : Graph.Hom X₁ Y₁} {g : Graph.Hom X₂ Y₂}
+    (hf : Graph.precPreserving f) (hg : Graph.precPreserving g) :
+    Graph.precPreserving (f.concatMap t g) := by
   rintro (v | v) (w | w) h
   · exact hf h
   · show Y₁.tier t (f.toFun v) = Y₂.tier t (g.toFun w)
@@ -546,14 +546,14 @@ theorem MixedGraphCat.Hom.concatMap_precPreserving (t : S → ι)
   · exact hg h
 
 /-- A vertex with no arc-predecessor: the tier-initial position. -/
-def MixedGraphCat.NoPred (X : MixedGraphCat S) (v : X.V) : Prop :=
+def Graph.NoPred (X : Graph S) (v : X.V) : Prop :=
   ∀ u, ¬ X.graph.arcs.Adj u v
 
 /-- Erase every association line incident to a tier-`i₀`-initial vertex — the
     graph model of an initial-position delinking process (e.g. lenition
     targeting the word-initial slot). Arcs and labels are untouched. -/
-def MixedGraphCat.delinkMin (t : S → ι) (i₀ : ι) (X : MixedGraphCat S) :
-    MixedGraphCat S where
+def Graph.delinkMin (t : S → ι) (i₀ : ι) (X : Graph S) :
+    Graph S where
   V := X.V
   graph :=
     { edges :=
@@ -570,20 +570,18 @@ variable (t : S → ι)
 
 /-- The structural axiom class ([jardine-2016-diss] §4.2, Axioms 1–3) as an
     object property of the graph category. -/
-def isRepresentation : ObjectProperty (MixedGraphCat S) := fun X =>
+def isRepresentation : ObjectProperty (Graph S) := fun X =>
   IsTierOrdered X.graph (X.tier t) ∧ NoInternalAssoc X.graph
 
-/-- The category of autosegmental representations over a tier assignment: the
-    full subcategory of labeled mixed graphs satisfying the structural axioms.
-    These are the formal literature's **ARs** — [jardine-2019] and
-    [chandlee-jardine-2019] introduce "autosegmental representation" once and
-    use `AR` as the type-name throughout; this category takes that name once the
-    bipartite strict carrier currently called `AR` is dissolved into it. -/
-abbrev Representation := (isRepresentation t).FullSubcategory
+/-- The category of **autosegmental representations** over a tier assignment:
+    the full subcategory of labeled mixed graphs satisfying the structural
+    axioms — the formal literature's ARs ([jardine-2019],
+    [chandlee-jardine-2019]). -/
+abbrev AR := (isRepresentation t).FullSubcategory
 
 /-! ### The monoidal structure: morpheme concatenation -/
 
-namespace Representation
+namespace AR
 
 open MonoidalCategory
 
@@ -593,27 +591,27 @@ variable {t}
     graph: same-tier vertices are precedence-related (Axioms 1–2) and associated
     vertices never are (Axiom 3), so associated vertices lie on distinct tiers.
     Goldsmith's bipartite two-tier geometry is the two-colorable case. -/
-def tierColoring (X : Representation t) : X.obj.graph.edges.Coloring ι :=
+def tierColoring (X : AR t) : X.obj.graph.edges.Coloring ι :=
   SimpleGraph.Coloring.mk (X.obj.tier t) fun {_ _} hadj htier =>
     (X.property.1.total hadj.ne htier).elim (X.property.2 hadj) (X.property.2 hadj.symm)
 
 /-- A representation's association graph is colorable by its tiers: tier arity
     bounds the chromatic number of the association pattern. -/
-theorem edges_colorable [Fintype ι] (X : Representation t) :
+theorem edges_colorable [Fintype ι] (X : AR t) :
     X.obj.graph.edges.Colorable (Fintype.card ι) :=
   (tierColoring X).colorable
 
 /-- A graph isomorphism as an isomorphism of representations. -/
-def mkIso {X Y : Representation t} (e : MixedGraphCat.Iso X.obj Y.obj) : X ≅ Y :=
+def mkIso {X Y : AR t} (e : Graph.Iso X.obj Y.obj) : X ≅ Y :=
   InducedCategory.isoMk
     ⟨e.toHom, e.symm.toHom,
-      MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v),
-      MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)⟩
+      Graph.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v),
+      Graph.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)⟩
 
 /-- Componentwise extensionality for representation morphisms. -/
-theorem hom_ext {X Y : Representation t} {f g : X ⟶ Y}
+theorem hom_ext {X Y : AR t} {f g : X ⟶ Y}
     (h : ∀ v, f.hom.toFun v = g.hom.toFun v) : f = g :=
-  InducedCategory.hom_ext (MixedGraphCat.Hom.ext (funext h))
+  InducedCategory.hom_ext (Graph.Hom.ext (funext h))
 
 universe u₁ u₂ u₃
 
@@ -623,27 +621,27 @@ universe u₁ u₂ u₃
     unit's vertex type shares the objects' universe — autobinding would split
     the instance head into an unusable `max`. -/
 @[simps] instance instMonoidalStruct {S : Type u₁} {ι : Type u₂} {t : S → ι} :
-    MonoidalCategoryStruct (Representation.{u₁, u₂, u₃} t) where
+    MonoidalCategoryStruct (AR.{u₁, u₂, u₃} t) where
   tensorObj X Y :=
-    ⟨MixedGraphCat.concat t X.obj Y.obj,
-      MixedGraphCat.isTierOrdered_concat t X.property.1 Y.property.1,
-      MixedGraphCat.noInternalAssoc_concat t X.property.2 Y.property.2⟩
+    ⟨Graph.concat t X.obj Y.obj,
+      Graph.isTierOrdered_concat t X.property.1 Y.property.1,
+      Graph.noInternalAssoc_concat t X.property.2 Y.property.2⟩
   tensorUnit :=
-    ⟨MixedGraphCat.empty S, MixedGraphCat.isTierOrdered_empty t,
-      MixedGraphCat.noInternalAssoc_empty⟩
-  tensorHom f g := InducedCategory.homMk (MixedGraphCat.Hom.concatMap t f.hom g.hom)
+    ⟨Graph.empty S, Graph.isTierOrdered_empty t,
+      Graph.noInternalAssoc_empty⟩
+  tensorHom f g := InducedCategory.homMk (Graph.Hom.concatMap t f.hom g.hom)
   whiskerLeft X _ _ f :=
-    InducedCategory.homMk (MixedGraphCat.Hom.concatMap t (MixedGraphCat.Hom.id X.obj) f.hom)
+    InducedCategory.homMk (Graph.Hom.concatMap t (Graph.Hom.id X.obj) f.hom)
   whiskerRight f Y :=
-    InducedCategory.homMk (MixedGraphCat.Hom.concatMap t f.hom (MixedGraphCat.Hom.id Y.obj))
-  associator X Y Z := mkIso (MixedGraphCat.concatAssocIso t X.obj Y.obj Z.obj)
-  leftUnitor X := mkIso (MixedGraphCat.emptyConcatIso t X.obj)
-  rightUnitor X := mkIso (MixedGraphCat.concatEmptyIso t X.obj)
+    InducedCategory.homMk (Graph.Hom.concatMap t f.hom (Graph.Hom.id Y.obj))
+  associator X Y Z := mkIso (Graph.concatAssocIso t X.obj Y.obj Z.obj)
+  leftUnitor X := mkIso (Graph.emptyConcatIso t X.obj)
+  rightUnitor X := mkIso (Graph.concatEmptyIso t X.obj)
 
 /-- The category of autosegmental representations is monoidal under morpheme
     concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as coherence,
     with every proof a componentwise `rfl` over the concrete sum maps. -/
-instance : MonoidalCategory (Representation t) :=
+instance : MonoidalCategory (AR t) :=
   MonoidalCategory.ofTensorHom
     (id_tensorHom_id := fun _ _ => hom_ext (congrFun Sum.map_id_id))
     (id_tensorHom := fun _ _ _ _ => rfl)
@@ -665,29 +663,29 @@ instance : MonoidalCategory (Representation t) :=
 
 /-- Precedence preservation on representations: the classical morphisms of the
     theory, as a monoidally-stable wide subcategory of the broad category. -/
-def precPreserving : MorphismProperty (Representation t) :=
-  fun _ _ f => MixedGraphCat.precPreserving f.hom
+def precPreserving : MorphismProperty (AR t) :=
+  fun _ _ f => Graph.precPreserving f.hom
 
 instance : (precPreserving (t := t)).IsMonoidalStable where
   id_mem _ := fun _ _ h => h
   comp_mem _ _ hf hg := fun _ _ h => hg (hf h)
   whiskerLeft _ _ _ _ hg :=
-    MixedGraphCat.Hom.concatMap_precPreserving t (fun _ _ h => h) hg
+    Graph.Hom.concatMap_precPreserving t (fun _ _ h => h) hg
   whiskerRight _ hf _ :=
-    MixedGraphCat.Hom.concatMap_precPreserving t hf (fun _ _ h => h)
+    Graph.Hom.concatMap_precPreserving t hf (fun _ _ h => h)
   associator_hom_mem A B C :=
-    (MixedGraphCat.concatAssocIso t A.obj B.obj C.obj).toHom_precPreserving
+    (Graph.concatAssocIso t A.obj B.obj C.obj).toHom_precPreserving
   associator_inv_mem A B C :=
-    (MixedGraphCat.concatAssocIso t A.obj B.obj C.obj).symm.toHom_precPreserving
-  leftUnitor_hom_mem A := (MixedGraphCat.emptyConcatIso t A.obj).toHom_precPreserving
-  leftUnitor_inv_mem A := (MixedGraphCat.emptyConcatIso t A.obj).symm.toHom_precPreserving
-  rightUnitor_hom_mem A := (MixedGraphCat.concatEmptyIso t A.obj).toHom_precPreserving
-  rightUnitor_inv_mem A := (MixedGraphCat.concatEmptyIso t A.obj).symm.toHom_precPreserving
+    (Graph.concatAssocIso t A.obj B.obj C.obj).symm.toHom_precPreserving
+  leftUnitor_hom_mem A := (Graph.emptyConcatIso t A.obj).toHom_precPreserving
+  leftUnitor_inv_mem A := (Graph.emptyConcatIso t A.obj).symm.toHom_precPreserving
+  rightUnitor_hom_mem A := (Graph.concatEmptyIso t A.obj).toHom_precPreserving
+  rightUnitor_inv_mem A := (Graph.concatEmptyIso t A.obj).symm.toHom_precPreserving
 
 /-- Delinking preserves the structural axioms: arcs are untouched and the
     edge set shrinks. -/
-def delinkMinRep (i₀ : ι) (X : Representation t) : Representation t :=
-  ⟨MixedGraphCat.delinkMin t i₀ X.obj,
+def delinkMinRep (i₀ : ι) (X : AR t) : AR t :=
+  ⟨Graph.delinkMin t i₀ X.obj,
     ⟨X.property.1.tier_eq, X.property.1.total, X.property.1.irrefl, X.property.1.trans⟩,
     fun _ _ hadj harc => X.property.2 hadj.1 harc⟩
 
@@ -699,8 +697,8 @@ open CategoryTheory in
     label-preserving reindexing can move a non-initial vertex into initial
     position (`Studies/LaoideKemp2026`'s counterexample). -/
 def delinkMinFunctor (i₀ : ι) :
-    WideSubcategory (Representation.precPreserving (t := t)) ⥤
-      WideSubcategory (Representation.precPreserving (t := t)) where
+    WideSubcategory (AR.precPreserving (t := t)) ⥤
+      WideSubcategory (AR.precPreserving (t := t)) where
   obj X := ⟨delinkMinRep i₀ X.obj⟩
   map {X Y} f :=
     ⟨InducedCategory.homMk
@@ -728,6 +726,6 @@ def delinkMinFunctor (i₀ : ι) :
     apply InducedCategory.hom_ext
     rfl
 
-end Representation
+end AR
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -34,13 +34,13 @@ variable {α β : Type*}
 section CoordinateHull
 
 variable {ι : Type*} [Finite ι] {τ : ι → Type*}
-variable (m : ι) (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V]
+variable (m : ι) (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V]
 
 /-- Close each tier-`m` node's association set to its interval hull on each
     other tier. -/
-noncomputable def Representation.hull :
-    Representation (Sigma.fst : ((i : ι) × τ i) → ι) :=
-  Representation.ofData (fun i => X.tierWord i)
+noncomputable def AR.hull :
+    AR (Sigma.fst : ((i : ι) × τ i) → ι) :=
+  AR.ofData (fun i => X.tierWord i)
     (fun i j p q =>
       (i = m ∧ ∃ q₁ q₂, X.link i j p q₁ ∧ X.link i j p q₂ ∧ q₁ ≤ q ∧ q ≤ q₂) ∨
         (i ≠ m ∧ j ≠ m ∧ X.link i j p q))
@@ -48,17 +48,17 @@ noncomputable def Representation.hull :
 instance : Finite (X.hull m).obj.V :=
   inferInstanceAs (Finite ((_ : ι) × Fin _))
 
-@[simp] theorem Representation.tierWord_hull (i : ι) :
+@[simp] theorem AR.tierWord_hull (i : ι) :
     (X.hull m).tierWord i = X.tierWord i :=
-  Representation.tierWord_ofData i
+  AR.tierWord_ofData i
 
 /-- Hull membership at the melody tier: `q` lies between two of `p`'s links. -/
-theorem Representation.link_hull_left {j : ι} (hj : m ≠ j) {p q : ℕ}
+theorem AR.link_hull_left {j : ι} (hj : m ≠ j) {p q : ℕ}
     (hq : q < X.tierLength j) :
     (X.hull m).link m j p q ↔
       ∃ q₁ q₂, X.link m j p q₁ ∧ X.link m j p q₂ ∧ q₁ ≤ q ∧ q ≤ q₂ := by
-  unfold Representation.hull
-  rw [Representation.link_ofData]
+  unfold AR.hull
+  rw [AR.link_ofData]
   constructor
   · rintro ⟨-, -, -, (⟨-, hfl⟩ | ⟨hne, -, -⟩) | (⟨rfl, -⟩ | ⟨-, hne, -⟩)⟩
     · exact hfl
@@ -69,13 +69,13 @@ theorem Representation.link_hull_left {j : ι} (hj : m ≠ j) {p q : ℕ}
     obtain ⟨hp, -, -⟩ := id h₁
     refine ⟨hj, ?_, ?_, Or.inl (Or.inl ⟨rfl, q₁, q₂, h₁, h₂, hle₁, hle₂⟩)⟩
     · simpa using hp
-    · simpa [Representation.length_tierWord] using hq
+    · simpa [AR.length_tierWord] using hq
 
 /-- Links not involving the melody tier pass through the hull unchanged. -/
-theorem Representation.link_hull_of_ne {i j : ι} (hi : i ≠ m) (hj : j ≠ m) (p q : ℕ) :
+theorem AR.link_hull_of_ne {i j : ι} (hi : i ≠ m) (hj : j ≠ m) (p q : ℕ) :
     (X.hull m).link i j p q ↔ X.link i j p q := by
-  unfold Representation.hull
-  rw [Representation.link_ofData]
+  unfold AR.hull
+  rw [AR.link_ofData]
   constructor
   · rintro ⟨-, -, -, (⟨rfl, -⟩ | ⟨-, -, hl⟩) | (⟨rfl, -⟩ | ⟨-, -, hl⟩)⟩
     · exact absurd rfl hi
@@ -90,7 +90,7 @@ theorem Representation.link_hull_of_ne {i j : ι} (hi : i ≠ m) (hj : j ≠ m) 
     exact X.not_link_self_tier i p q hl
 
 /-- Melody links flank themselves: the hull extends the link relation. -/
-theorem Representation.link_subset_hull {i j : ι} {p q : ℕ} (h : X.link i j p q) :
+theorem AR.link_subset_hull {i j : ι} {p q : ℕ} (h : X.link i j p q) :
     (X.hull m).link i j p q := by
   obtain ⟨hp, hq, -⟩ := id h
   rcases eq_or_ne m i with rfl | hi
@@ -103,13 +103,13 @@ theorem Representation.link_subset_hull {i j : ι} {p q : ℕ} (h : X.link i j p
     · exact (X.link_hull_of_ne m (Ne.symm hi) (Ne.symm hj) p q).mpr h
 
 /-- Per-node convexity at the melody tier: the defining property of the hull. -/
-theorem Representation.link_hull_convex {j : ι} (hj : m ≠ j) {p q₁ q q₂ : ℕ}
+theorem AR.link_hull_convex {j : ι} (hj : m ≠ j) {p q₁ q q₂ : ℕ}
     (hq : q < X.tierLength j)
     (h₁ : (X.hull m).link m j p q₁) (h₂ : (X.hull m).link m j p q₂)
     (hle₁ : q₁ ≤ q) (hle₂ : q ≤ q₂) : (X.hull m).link m j p q := by
   have hlen : (X.hull m).tierLength j = X.tierLength j := by
-    rw [← Representation.length_tierWord, Representation.tierWord_hull,
-      Representation.length_tierWord]
+    rw [← AR.length_tierWord, AR.tierWord_hull,
+      AR.length_tierWord]
   obtain ⟨-, hb₁, -⟩ := id h₁
   obtain ⟨-, hb₂, -⟩ := id h₂
   rw [hlen] at hb₁ hb₂

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -57,7 +57,7 @@ variable {α β : Type*} {a : α} {b : β} {as : List α} {bs : List β}
 
 /-! ### The junction in coordinates
 
-The complete association as a two-tier `Representation` (`Bool`-indexed:
+The complete association as a two-tier `AR` (`Bool`-indexed:
 `true` the melody tier, `false` the timing tier), built by `ofData`; the
 No-Crossing keystone in the foundational path form. -/
 
@@ -72,33 +72,33 @@ abbrev TwoTier (α β : Type u) : Bool → Type u := fun b => bif b then α else
 
 /-- Complete many-to-many association of a melody onto a slot sequence, in
     coordinates. -/
-def Representation.junction (as : List α) (bs : List β) :
-    Representation (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool) :=
-  Representation.ofData
+def AR.junction (as : List α) (bs : List β) :
+    AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool) :=
+  AR.ofData
     (fun b => match b with
       | true => (as : List (TwoTier α β true))
       | false => (bs : List (TwoTier α β false)))
     (fun i j p q => i = true ∧ j = false ∧ p < as.length ∧ q < bs.length)
 
 instance (as : List α) (bs : List β) :
-    Finite (Representation.junction as bs).obj.V :=
+    Finite (AR.junction as bs).obj.V :=
   inferInstanceAs (Finite ((_ : Bool) × Fin _))
 
-@[simp] theorem Representation.tierWord_junction_true (as : List α) (bs : List β) :
-    (Representation.junction as bs).tierWord true = as :=
-  Representation.tierWord_ofData true
+@[simp] theorem AR.tierWord_junction_true (as : List α) (bs : List β) :
+    (AR.junction as bs).tierWord true = as :=
+  AR.tierWord_ofData true
 
-@[simp] theorem Representation.tierWord_junction_false (as : List α) (bs : List β) :
-    (Representation.junction as bs).tierWord false = bs :=
-  Representation.tierWord_ofData false
+@[simp] theorem AR.tierWord_junction_false (as : List α) (bs : List β) :
+    (AR.junction as bs).tierWord false = bs :=
+  AR.tierWord_ofData false
 
 /-- Junction links are complete: every in-bounds melody–timing pair. -/
-theorem Representation.link_junction (as : List α) (bs : List β) {b b' : Bool}
-    {p q : ℕ} : (Representation.junction as bs).link b b' p q ↔
+theorem AR.link_junction (as : List α) (bs : List β) {b b' : Bool}
+    {p q : ℕ} : (AR.junction as bs).link b b' p q ↔
       b = true ∧ b' = false ∧ p < as.length ∧ q < bs.length ∨
         b = false ∧ b' = true ∧ p < bs.length ∧ q < as.length := by
-  unfold Representation.junction
-  rw [Representation.link_ofData]
+  unfold AR.junction
+  rw [AR.link_ofData]
   constructor
   · rintro ⟨hne, hp, hq, (⟨rfl, rfl, h1, h2⟩ | ⟨rfl, rfl, h1, h2⟩)⟩
     · exact Or.inl ⟨rfl, rfl, h1, h2⟩
@@ -112,8 +112,8 @@ theorem Representation.link_junction (as : List α) (bs : List β) {b b' : Bool}
 /-- **The No-Crossing Constraint selects the one-sided junctions**: a complete
     association is planar iff one side has at most one node — the one-to-many
     `spread`, many-to-one `contour`, and degenerate cases. -/
-theorem Representation.isPlanar_junction_iff (as : List α) (bs : List β) :
-    IsPlanar (Representation.junction as bs).obj.graph ↔
+theorem AR.isPlanar_junction_iff (as : List α) (bs : List β) :
+    IsPlanar (AR.junction as bs).obj.graph ↔
       as.length ≤ 1 ∨ bs.length ≤ 1 := by
   constructor
   · intro h
@@ -160,48 +160,48 @@ theorem Representation.isPlanar_junction_iff (as : List α) (bs : List β) :
 /-! #### The planar local configurations -/
 
 /-- One-to-one association. -/
-def Representation.single (a : α) (b : β) := Representation.junction [a] [b]
+def AR.single (a : α) (b : β) := AR.junction [a] [b]
 
 /-- A bare (unassociated) timing slot. -/
-def Representation.bare (b : β) := Representation.junction ([] : List α) [b]
+def AR.bare (b : β) := AR.junction ([] : List α) [b]
 
 /-- A floating autosegment ([leben-1973]). -/
-def Representation.float (a : α) := Representation.junction [a] ([] : List β)
+def AR.float (a : α) := AR.junction [a] ([] : List β)
 
 /-- Several melody nodes on one slot. -/
-def Representation.contour (as : List α) (b : β) := Representation.junction as [b]
+def AR.contour (as : List α) (b : β) := AR.junction as [b]
 
 /-- One melody node over several slots. -/
-def Representation.spread (a : α) (bs : List β) := Representation.junction [a] bs
+def AR.spread (a : α) (bs : List β) := AR.junction [a] bs
 
-theorem Representation.isPlanar_single (a : α) (b : β) :
-    IsPlanar (Representation.single a b).obj.graph :=
-  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+theorem AR.isPlanar_single (a : α) (b : β) :
+    IsPlanar (AR.single a b).obj.graph :=
+  (AR.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
-theorem Representation.isPlanar_bare (b : β) :
-    IsPlanar (Representation.bare (α := α) b).obj.graph :=
-  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+theorem AR.isPlanar_bare (b : β) :
+    IsPlanar (AR.bare (α := α) b).obj.graph :=
+  (AR.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
-theorem Representation.isPlanar_float (a : α) :
-    IsPlanar (Representation.float (β := β) a).obj.graph :=
-  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+theorem AR.isPlanar_float (a : α) :
+    IsPlanar (AR.float (β := β) a).obj.graph :=
+  (AR.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
-theorem Representation.isPlanar_contour (as : List α) (b : β) :
-    IsPlanar (Representation.contour as b).obj.graph :=
-  (Representation.isPlanar_junction_iff _ _).mpr (Or.inr (by simp))
+theorem AR.isPlanar_contour (as : List α) (b : β) :
+    IsPlanar (AR.contour as b).obj.graph :=
+  (AR.isPlanar_junction_iff _ _).mpr (Or.inr (by simp))
 
-theorem Representation.isPlanar_spread (a : α) (bs : List β) :
-    IsPlanar (Representation.spread a bs).obj.graph :=
-  (Representation.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
+theorem AR.isPlanar_spread (a : α) (bs : List β) :
+    IsPlanar (AR.spread a bs).obj.graph :=
+  (AR.isPlanar_junction_iff _ _).mpr (Or.inl (by simp))
 
 /-- Two-tier factor embedding is a search over two bounded offsets. -/
-theorem Representation.factorEmbeds_iff_two_tier
-    {F X : Representation (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool)}
+theorem AR.factorEmbeds_iff_two_tier
+    {F X : AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool)}
     [Finite F.obj.V] [Finite X.obj.V] :
     F.FactorEmbeds X ↔
       ∃ ot ≤ X.tierLength true, ∃ of ≤ X.tierLength false,
         F.IsFactorAt X (fun b => bif b then ot else of) := by
-  rw [Representation.factorEmbeds_iff_bounded]
+  rw [AR.factorEmbeds_iff_bounded]
   constructor
   · rintro ⟨o, hb, hfa⟩
     refine ⟨o true, hb true, o false, hb false, ?_⟩
@@ -236,26 +236,26 @@ instance {wsF wsX : ∀ b : Bool, List (TwoTier α β b)}
 /-- **The spec**: on `ofData`-presented two-tier forms, factor embedding is the
     data-level check — the bridge that turns banned-subgraph verdicts into
     kernel computations. -/
-theorem Representation.factorEmbeds_ofData_iff
+theorem AR.factorEmbeds_ofData_iff
     {wsF wsX : ∀ b : Bool, List (TwoTier α β b)}
     {LF LX : Bool → Bool → ℕ → ℕ → Prop} :
-    (Representation.ofData wsF LF).FactorEmbeds (Representation.ofData wsX LX) ↔
+    (AR.ofData wsF LF).FactorEmbeds (AR.ofData wsX LX) ↔
       dataEmbeds wsF wsX LF LX := by
-  rw [Representation.factorEmbeds_iff_two_tier]
-  simp only [Representation.tierLength_ofData]
+  rw [AR.factorEmbeds_iff_two_tier]
+  simp only [AR.tierLength_ofData]
   constructor
   · rintro ⟨ot, hot, of, hof, hw, hl⟩
     refine ⟨ot, hot, of, hof, ?_, ?_, ?_⟩
     · intro p hp
-      have := hw true p (by rw [Representation.tierLength_ofData]; exact hp)
-      rwa [Representation.tierWord_ofData, Representation.tierWord_ofData] at this
+      have := hw true p (by rw [AR.tierLength_ofData]; exact hp)
+      rwa [AR.tierWord_ofData, AR.tierWord_ofData] at this
     · intro p hp
-      have := hw false p (by rw [Representation.tierLength_ofData]; exact hp)
-      rwa [Representation.tierWord_ofData, Representation.tierWord_ofData] at this
+      have := hw false p (by rw [AR.tierLength_ofData]; exact hp)
+      rwa [AR.tierWord_ofData, AR.tierWord_ofData] at this
     · intro p hp q hq hpq
-      have hlk := hl true false p q ((Representation.link_ofData true false p q).mpr
+      have hlk := hl true false p q ((AR.link_ofData true false p q).mpr
         ⟨by decide, hp, hq, hpq⟩)
-      rcases (Representation.link_ofData true false (p + ot) (q + of)).mp hlk with
+      rcases (AR.link_ofData true false (p + ot) (q + of)).mp hlk with
         ⟨-, -, -, hres⟩
       exact hres
   · rintro ⟨ot, hot, of, hof, hwt, hwf, hlk⟩
@@ -271,38 +271,38 @@ theorem Representation.factorEmbeds_ofData_iff
       exact (List.getElem?_eq_some_iff.mp h1).1
     refine ⟨ot, hot, of, hof, ?_, ?_⟩
     · intro i p hp
-      rw [Representation.tierLength_ofData] at hp
+      rw [AR.tierLength_ofData] at hp
       cases i
-      · rw [show ((Representation.ofData wsX LX).tierWord false)
-            = wsX false from Representation.tierWord_ofData false,
-          show ((Representation.ofData wsF LF).tierWord false)
-            = wsF false from Representation.tierWord_ofData false]
+      · rw [show ((AR.ofData wsX LX).tierWord false)
+            = wsX false from AR.tierWord_ofData false,
+          show ((AR.ofData wsF LF).tierWord false)
+            = wsF false from AR.tierWord_ofData false]
         exact hwf p hp
-      · rw [show ((Representation.ofData wsX LX).tierWord true)
-            = wsX true from Representation.tierWord_ofData true,
-          show ((Representation.ofData wsF LF).tierWord true)
-            = wsF true from Representation.tierWord_ofData true]
+      · rw [show ((AR.ofData wsX LX).tierWord true)
+            = wsX true from AR.tierWord_ofData true,
+          show ((AR.ofData wsF LF).tierWord true)
+            = wsF true from AR.tierWord_ofData true]
         exact hwt p hp
     · intro i j p q hl
-      rcases (Representation.link_ofData i j p q).mp hl with ⟨hne, hp, hq, hor⟩
+      rcases (AR.link_ofData i j p q).mp hl with ⟨hne, hp, hq, hor⟩
       have hcases : i = true ∧ j = false ∨ i = false ∧ j = true := by
         cases i <;> cases j <;> simp_all
       rcases hcases with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
       · rcases hlk p hp q hq hor with hres | hres
-        · exact (Representation.link_ofData true false _ _).mpr
+        · exact (AR.link_ofData true false _ _).mpr
             ⟨by decide, hbt p hp, hbf q hq, Or.inl hres⟩
-        · exact (Representation.link_ofData true false _ _).mpr
+        · exact (AR.link_ofData true false _ _).mpr
             ⟨by decide, hbt p hp, hbf q hq, Or.inr hres⟩
       · rcases hlk q hq p hp hor.symm with hres | hres
-        · exact (Representation.link_ofData false true _ _).mpr
+        · exact (AR.link_ofData false true _ _).mpr
             ⟨by decide, hbf p hp, hbt q hq, Or.inr hres⟩
-        · exact (Representation.link_ofData false true _ _).mpr
+        · exact (AR.link_ofData false true _ _).mpr
             ⟨by decide, hbf p hp, hbt q hq, Or.inl hres⟩
 
 /-- A timing slot **surfaces with** melody label `a`: some `a`-labelled melody
     node links to it. -/
-def Representation.surfacesWith
-    (X : Representation (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool))
+def AR.surfacesWith
+    (X : AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool))
     [Finite X.obj.V] (a : α) (j : ℕ) : Prop :=
   ∃ k, X.link true false k j ∧ (X.tierWord true)[k]? = some a
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Fintype.Sort
 import Mathlib.Data.Fintype.Sum
 import Mathlib.Logic.Equiv.Fin.Basic
 import Linglib.Core.Data.List.Factors
-import Linglib.Phonology.Autosegmental.MixedGraph
+import Linglib.Phonology.Autosegmental.Graph
 
 /-!
 # Normal forms of autosegmental representations
@@ -20,36 +20,36 @@ Every finite representation is isomorphic to its **normal form**: the same
 representation reindexed onto the canonical vertex type `(i : ι) × Fin nᵢ`,
 each tier fiber enumerated in ascending precedence order
 (`IsTierOrdered.isStrictTotalOrder` → `linearOrderOfSTO` → `monoEquivOfFin`).
-The normal form is a `Representation` — not a separate carrier — and
+The normal form is a `AR` — not a separate carrier — and
 `normalizeIso` is definitional: `normalize` pulls the graph back along the
 enumeration equivalence.
 
 Strictness lives on isomorphism classes of the precedence-preserving wide
-subcategory (`PrecRepresentation`): full-structure classes, since broad
+subcategory (`PrecAR`): full-structure classes, since broad
 categorical isomorphism forgets the arcs and is too coarse to preserve tier
 words. `cls_normalize` says `normalize` chooses representatives.
 
 ## Main definitions
 
-* `Representation.fiber`, `Representation.fiberEnum`, `Representation.vertexEquiv`:
+* `AR.fiber`, `AR.fiberEnum`, `AR.vertexEquiv`:
   the tier fibers of a finite representation and their canonical enumerations.
-* `Representation.tierLength`, `Representation.tierWord`, `Representation.linkRel`:
+* `AR.tierLength`, `AR.tierWord`, `AR.linkRel`:
   the tuple reading — per-tier sizes, label words, and position-coordinate links.
-* `Representation.normalize`: the normal form, a `Representation` on the
+* `AR.normalize`: the normal form, a `AR` on the
   canonical vertex type.
 * `realize`, `realizeHom`, `tierProj`: [jardine-2019]'s `g` as iterated tensor,
   as a free-monoid hom into the class monoid, and its per-tier projections.
 
 ## Main results
 
-* `Representation.normalizeIso`: `X.normalize ≅ X`.
-* `Representation.arcs_normalize`, `Representation.edges_normalize`: on normal
+* `AR.normalizeIso`: `X.normalize ≅ X`.
+* `AR.arcs_normalize`, `AR.edges_normalize`: on normal
   forms the arcs are the ascending position order and the edges are `linkRel` —
   [jardine-heinz-2015]'s tiered presentation recovered as a theorem.
-* `Representation.tierWord_tensor`, `Representation.tierWord_realize`:
+* `AR.tierWord_tensor`, `AR.tierWord_realize`:
   concatenation appends tier words; tier content of a realization is
   compositional.
-* `PrecRepresentation`, `Representation.cls_normalize`: the monoid of
+* `PrecAR`, `AR.cls_normalize`: the monoid of
   isomorphism classes of the precedence-preserving category; normal forms
   represent their class.
 -/
@@ -74,34 +74,34 @@ section IsoClasses
 open scoped MonoidalCategory
 
 /-- Representations with the classical precedence-preserving morphisms. -/
-abbrev PrecRepresentation (ι : Type*) (τ : ι → Type*) :=
-  WideSubcategory (Representation.precPreserving (t := (Sigma.fst : ((i : ι) × τ i) → ι)))
+abbrev PrecAR (ι : Type*) (τ : ι → Type*) :=
+  WideSubcategory (AR.precPreserving (t := (Sigma.fst : ((i : ι) × τ i) → ι)))
 
 /-- A full isomorphism is an isomorphism of the precedence-preserving
     category: both directions preserve arcs. -/
-noncomputable def Representation.fullIsoToWideIso
-    {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
-    (e : MixedGraphCat.Iso A.obj B.obj) :
-    (⟨A⟩ : PrecRepresentation ι τ) ≅ ⟨B⟩ where
+noncomputable def AR.fullIsoToWideIso
+    {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    (e : Graph.Iso A.obj B.obj) :
+    (⟨A⟩ : PrecAR ι τ) ≅ ⟨B⟩ where
   hom := ⟨InducedCategory.homMk e.toHom, e.toHom_precPreserving⟩
   inv := ⟨InducedCategory.homMk e.symm.toHom, e.symm.toHom_precPreserving⟩
   hom_inv_id := InducedWideCategory.Hom.ext (InducedCategory.hom_ext
-    (MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v)))
+    (Graph.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v)))
   inv_hom_id := InducedWideCategory.Hom.ext (InducedCategory.hom_ext
-    (MixedGraphCat.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)))
+    (Graph.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)))
 
 /-- The class of a representation: its isomorphism class in the skeleton of the
     precedence-preserving category — the monoid of ARs. -/
-noncomputable def Representation.cls
-    (A : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    Skeleton (PrecRepresentation ι τ) :=
+noncomputable def AR.cls
+    (A : AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    Skeleton (PrecAR ι τ) :=
   toSkeleton ⟨A⟩
 
 /-- Concatenation of classes is the class of the tensor. -/
-theorem Representation.cls_tensor
-    (A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    Representation.cls (A ⊗ B) = Representation.cls A * Representation.cls B :=
-  CategoryTheory.Skeleton.toSkeleton_tensorObj (⟨A⟩ : PrecRepresentation ι τ) ⟨B⟩
+theorem AR.cls_tensor
+    (A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    AR.cls (A ⊗ B) = AR.cls A * AR.cls B :=
+  CategoryTheory.Skeleton.toSkeleton_tensorObj (⟨A⟩ : PrecAR ι τ) ⟨B⟩
 
 end IsoClasses
 
@@ -112,56 +112,56 @@ open scoped Classical
     Under `IsTierOrdered` its arcs form a strict total order, and under
     `Finite X.obj.V` it is finite — the two ingredients `monoEquivOfFin`
     needs to enumerate the fiber as `Fin _`. -/
-def Representation.fiber (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) (i : ι) :
+def AR.fiber (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) (i : ι) :
     Type _ := {v : X.obj.V // (X.obj.label v).1 = i}
 
-variable {X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
 
 /-- The `τ i` component of a fiber element, extracted from the labeling by
     transporting along the fiber's tier-membership witness. -/
-def Representation.fiberLabel {i : ι} (v : X.fiber i) : τ i :=
+def AR.fiberLabel {i : ι} (v : X.fiber i) : τ i :=
   v.property ▸ (X.obj.label v.val).2
 
 /-- The label of a fiber element decomposes as tier plus `fiberLabel`. -/
-theorem Representation.label_fiber {i : ι} (v : X.fiber i) :
+theorem AR.label_fiber {i : ι} (v : X.fiber i) :
     X.obj.label v.val = ⟨i, X.fiberLabel v⟩ := by
   obtain ⟨u, hu⟩ := v
   show X.obj.label u = _
-  simp only [Representation.fiberLabel]
+  simp only [AR.fiberLabel]
   conv_lhs => rw [← Sigma.eta (X.obj.label u)]
   exact Sigma.eq hu rfl
 
-instance Representation.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
+instance AR.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
   Subtype.finite
 
 /-- The arcs restricted to a tier fiber form a strict total order — the classed
     form of Axioms 1–2 applied to the tier coloring `Sigma.fst`. -/
-instance Representation.fiber.instIsStrictTotalOrder (i : ι) :
+instance AR.fiber.instIsStrictTotalOrder (i : ι) :
     IsStrictTotalOrder (X.fiber i) (fun a b => X.obj.graph.arcs.Adj a.val b.val) :=
   X.property.1.isStrictTotalOrder i
 
 /-- Classical linear order on the fiber, from `IsStrictTotalOrder` via
     `linearOrderOfSTO`. -/
-noncomputable instance Representation.fiber.instLinearOrder (i : ι) :
+noncomputable instance AR.fiber.instLinearOrder (i : ι) :
     LinearOrder (X.fiber i) := by
   classical
   exact linearOrderOfSTO (fun a b : X.fiber i => X.obj.graph.arcs.Adj a.val b.val)
 
 /-- The number of tier-`i` vertices. -/
-noncomputable def Representation.tierLength (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+noncomputable def AR.tierLength (X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
     [Finite X.obj.V] (i : ι) : ℕ :=
   letI := Fintype.ofFinite (X.fiber i)
   Fintype.card (X.fiber i)
 
 /-- The canonical ascending enumeration of a tier fiber. -/
-noncomputable def Representation.fiberEnum [Finite X.obj.V] (i : ι) :
+noncomputable def AR.fiberEnum [Finite X.obj.V] (i : ι) :
     Fin (X.tierLength i) ≃o X.fiber i :=
   letI := Fintype.ofFinite (X.fiber i)
   monoEquivOfFin (X.fiber i) rfl
 
 /-- The canonical enumeration of a finite representation's vertex type: tier
     fibers in ascending precedence order, assembled over the tier index. -/
-noncomputable def Representation.vertexEquiv [Finite X.obj.V] :
+noncomputable def AR.vertexEquiv [Finite X.obj.V] :
     ((i : ι) × Fin (X.tierLength i)) ≃ X.obj.V :=
   letI : ∀ i : ι, Fintype (X.fiber i) := fun _ => Fintype.ofFinite _
   (Equiv.sigmaCongrRight (fun i : ι => (X.fiberEnum i).toEquiv)).trans
@@ -169,32 +169,32 @@ noncomputable def Representation.vertexEquiv [Finite X.obj.V] :
 
 /-- The tier-`i` label word: the fiber's labels read off in ascending precedence
     order — the tier content the normal form canonicalizes. -/
-noncomputable def Representation.tierWord [Finite X.obj.V] (i : ι) : List (τ i) :=
+noncomputable def AR.tierWord [Finite X.obj.V] (i : ι) : List (τ i) :=
   letI := Fintype.ofFinite (X.fiber i)
   List.ofFn fun p : Fin (X.tierLength i) => X.fiberLabel (X.fiberEnum i p)
 
-@[simp] theorem Representation.length_tierWord [Finite X.obj.V] (i : ι) :
+@[simp] theorem AR.length_tierWord [Finite X.obj.V] (i : ι) :
     (X.tierWord i).length = X.tierLength i := by
-  simp [Representation.tierWord]
+  simp [AR.tierWord]
 
 /-- The link relation in position coordinates: tier-`i` position `p` associates
     to tier-`j` position `q`. With `tierWord`, the complete tuple reading of a
     finite representation. -/
-noncomputable def Representation.linkRel [Finite X.obj.V] (i j : ι)
+noncomputable def AR.linkRel [Finite X.obj.V] (i j : ι)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) : Prop :=
   X.obj.graph.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩)
 
-theorem Representation.linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
+theorem AR.linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
     {q : Fin (X.tierLength j)} :
     X.linkRel i j p q ↔
       X.obj.graph.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩) := Iff.rfl
 
 /-- The normal form: `X` reindexed onto the canonical vertex type by pulling
-    edges, arcs, and labels back along `vertexEquiv`. A `Representation` — the
+    edges, arcs, and labels back along `vertexEquiv`. A `AR` — the
     normal form is not a separate kind of object. -/
-noncomputable def Representation.normalize
-    (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V] :
-    Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+noncomputable def AR.normalize
+    (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V] :
+    AR (Sigma.fst : ((i : ι) × τ i) → ι) where
   obj :=
     { V := (i : ι) × Fin (X.tierLength i)
       graph :=
@@ -210,36 +210,36 @@ noncomputable def Representation.normalize
 
 /-- The normal form is fully isomorphic to the original — definitionally,
     since `normalize` is a pullback along `vertexEquiv`. -/
-noncomputable def Representation.normalizeFullIso [Finite X.obj.V] :
-    MixedGraphCat.Iso (X.normalize).obj X.obj where
+noncomputable def AR.normalizeFullIso [Finite X.obj.V] :
+    Graph.Iso (X.normalize).obj X.obj where
   toEquiv := X.vertexEquiv
   edges_iff _ _ := Iff.rfl
   arcs_iff _ _ := Iff.rfl
   label_comp _ := rfl
 
 /-- The normal form is isomorphic to the original. -/
-noncomputable def Representation.normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
-  Representation.mkIso X.normalizeFullIso
+noncomputable def AR.normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
+  AR.mkIso X.normalizeFullIso
 
 /-- On normal forms the edges are exactly `linkRel` — with `arcs_normalize`,
     the complete tuple reading of the normal form. -/
-theorem Representation.edges_normalize [Finite X.obj.V] (i j : ι)
+theorem AR.edges_normalize [Finite X.obj.V] (i j : ι)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
     (X.normalize).obj.graph.edges.Adj ⟨i, p⟩ ⟨j, q⟩ ↔ X.linkRel i j p q := Iff.rfl
 
 /-- On normal forms the arcs are the ascending position order — the
     classification content: [jardine-heinz-2015]'s tiered presentation
     recovered as a theorem. -/
-theorem Representation.arcs_normalize [Finite X.obj.V] (i : ι)
+theorem AR.arcs_normalize [Finite X.obj.V] (i : ι)
     (p q : Fin (X.tierLength i)) :
     (X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ↔ p < q :=
   (X.fiberEnum i).lt_iff_lt
 
 /-- Normal forms represent their isomorphism class: `normalize` is a section
-    of the quotient onto `Representation.IsoClass`. -/
-theorem Representation.cls_normalize [Finite X.obj.V] :
-    Representation.cls (X.normalize) = Representation.cls X :=
-  Quotient.sound ⟨Representation.fullIsoToWideIso X.normalizeFullIso⟩
+    of the quotient onto `AR.IsoClass`. -/
+theorem AR.cls_normalize [Finite X.obj.V] :
+    AR.cls (X.normalize) = AR.cls X :=
+  Quotient.sound ⟨AR.fullIsoToWideIso X.normalizeFullIso⟩
 
 end NormalForm
 
@@ -256,23 +256,23 @@ variable {S : Type*} {ι : Type*} {τ : ι → Type*}
 
 /-- Realize a string as a representation: the iterated tensor of its symbols'
     primitives ([jardine-2019]'s `g`). -/
-noncomputable def realize (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
-    (w : List S) : Representation (Sigma.fst : ((i : ι) × τ i) → ι) :=
+noncomputable def realize (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
+    (w : List S) : AR (Sigma.fst : ((i : ι) × τ i) → ι) :=
   (w.map g₀).foldr (· ⊗ ·) (𝟙_ _)
 
-@[simp] theorem realize_nil (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
+@[simp] theorem realize_nil (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
     realize g₀ [] = 𝟙_ _ := rfl
 
-@[simp] theorem realize_cons (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+@[simp] theorem realize_cons (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
 
 /-- The realization as a free-monoid homomorphism into the monoid of
     isomorphism classes — the string→AR monoid hom, with associativity strict
     on classes. -/
 noncomputable def realizeHom
-    (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    FreeMonoid S →* Skeleton (PrecRepresentation ι τ) :=
-  FreeMonoid.lift (Representation.cls ∘ g₀)
+    (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    FreeMonoid S →* Skeleton (PrecAR ι τ) :=
+  FreeMonoid.lift (AR.cls ∘ g₀)
 
 end Realize
 
@@ -288,13 +288,13 @@ section TierWordTensor
 open scoped MonoidalCategory
 
 variable {ι : Type*} {τ : ι → Type*}
-variable {X Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {X Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
 
 instance [Finite X.obj.V] [Finite Y.obj.V] : Finite ((X ⊗ Y).obj.V) :=
   inferInstanceAs (Finite (X.obj.V ⊕ Y.obj.V))
 
 /-- A tensor's tier fiber splits as the sum of the factors' fibers. -/
-def Representation.fiberTensorEquiv (i : ι) :
+def AR.fiberTensorEquiv (i : ι) :
     (X ⊗ Y).fiber i ≃ X.fiber i ⊕ Y.fiber i where
   toFun v := match v with
     | ⟨.inl w, h⟩ => .inl ⟨w, h⟩
@@ -307,18 +307,18 @@ variable [Finite X.obj.V] [Finite Y.obj.V]
 
 attribute [local instance] Fintype.ofFinite
 
-@[simp] theorem Representation.tierLength_tensor (i : ι) :
+@[simp] theorem AR.tierLength_tensor (i : ι) :
     (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i := by
   letI := Fintype.ofFinite ((X ⊗ Y).fiber i)
   letI := Fintype.ofFinite (X.fiber i)
   letI := Fintype.ofFinite (Y.fiber i)
-  simp only [Representation.tierLength]
-  rw [Fintype.card_congr (Representation.fiberTensorEquiv i), Fintype.card_sum]
+  simp only [AR.tierLength]
+  rw [Fintype.card_congr (AR.fiberTensorEquiv i), Fintype.card_sum]
 
-open Representation in
+open AR in
 /-- The blockwise enumeration of a tensor's fiber: left factor first, then
     right — monotone because the bridge arc orders the blocks. -/
-noncomputable def Representation.tensorEnum (i : ι) :
+noncomputable def AR.tensorEnum (i : ι) :
     Fin (X.tierLength i + Y.tierLength i) ≃o (X ⊗ Y).fiber i := by
   letI := Fintype.ofFinite (X.fiber i)
   letI := Fintype.ofFinite (Y.fiber i)
@@ -351,34 +351,34 @@ noncomputable def Representation.tensorEnum (i : ι) :
       exact (Y.fiberEnum i).strictMono
         (by simp only [Fin.lt_def, Fin.val_natAdd] at hpq ⊢; omega)
 
-theorem Representation.tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLength i)) :
-    Representation.tensorEnum i (Fin.castAdd (Y.tierLength i) p) =
-      (Representation.fiberTensorEquiv i).symm
+theorem AR.tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLength i)) :
+    AR.tensorEnum i (Fin.castAdd (Y.tierLength i) p) =
+      (AR.fiberTensorEquiv i).symm
         (.inl (X.fiberEnum i p)) := by
-  simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_castAdd]
+  simp [AR.tensorEnum, finSumFinEquiv_symm_apply_castAdd]
 
-theorem Representation.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLength i)) :
-    Representation.tensorEnum i (Fin.natAdd (X.tierLength i) p) =
-      (Representation.fiberTensorEquiv (X := X) i).symm
+theorem AR.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLength i)) :
+    AR.tensorEnum i (Fin.natAdd (X.tierLength i) p) =
+      (AR.fiberTensorEquiv (X := X) i).symm
         (.inr (Y.fiberEnum i p)) := by
-  simp [Representation.tensorEnum, finSumFinEquiv_symm_apply_natAdd]
+  simp [AR.tensorEnum, finSumFinEquiv_symm_apply_natAdd]
 
 omit [Finite X.obj.V] [Finite Y.obj.V] in
-theorem Representation.fiberLabel_symm_inl {i : ι} (w : X.fiber i) :
-    Representation.fiberLabel ((Representation.fiberTensorEquiv (X := X) (Y := Y) i).symm
+theorem AR.fiberLabel_symm_inl {i : ι} (w : X.fiber i) :
+    AR.fiberLabel ((AR.fiberTensorEquiv (X := X) (Y := Y) i).symm
       (.inl w)) = X.fiberLabel w := rfl
 
 omit [Finite X.obj.V] [Finite Y.obj.V] in
-theorem Representation.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
-    Representation.fiberLabel ((Representation.fiberTensorEquiv (X := X) (Y := Y) i).symm
+theorem AR.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
+    AR.fiberLabel ((AR.fiberTensorEquiv (X := X) (Y := Y) i).symm
       (.inr w)) = Y.fiberLabel w := rfl
 
 /-- Any monotone enumeration computes the tier word. -/
-theorem Representation.tierWord_eq_ofFn {Z : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.tierWord_eq_ofFn {Z : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite Z.obj.V] {i : ι} {n : ℕ} (e : Fin n ≃o Z.fiber i) :
     Z.tierWord i = List.ofFn fun p => Z.fiberLabel (e p) := by
   have hn : Z.tierLength i = n := by
-    simpa [Representation.tierLength] using (Fintype.card_congr e.toEquiv).symm
+    simpa [AR.tierLength] using (Fintype.card_congr e.toEquiv).symm
   subst hn
   rw [Subsingleton.elim e (Z.fiberEnum i)]
   rfl
@@ -387,53 +387,53 @@ theorem Representation.tierWord_eq_ofFn {Z : Representation (Sigma.fst : ((i : �
     factors' tier words in sequence — the tuple presentation of
     [jardine-heinz-2015]'s Definition 2, recovered as a theorem about normal
     forms. -/
-@[simp] theorem Representation.tierWord_tensor (i : ι) :
+@[simp] theorem AR.tierWord_tensor (i : ι) :
     (X ⊗ Y).tierWord i = X.tierWord i ++ Y.tierWord i := by
-  rw [Representation.tierWord_eq_ofFn (Representation.tensorEnum i), List.ofFn_add]
+  rw [AR.tierWord_eq_ofFn (AR.tensorEnum i), List.ofFn_add]
   congr 1
-  · rw [Representation.tierWord_eq_ofFn (X.fiberEnum i)]
+  · rw [AR.tierWord_eq_ofFn (X.fiberEnum i)]
     exact congrArg List.ofFn (funext fun p =>
-      (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_castAdd i p)).trans
-        (Representation.fiberLabel_symm_inl _))
-  · rw [Representation.tierWord_eq_ofFn (Y.fiberEnum i)]
+      (congrArg AR.fiberLabel (AR.tensorEnum_apply_castAdd i p)).trans
+        (AR.fiberLabel_symm_inl _))
+  · rw [AR.tierWord_eq_ofFn (Y.fiberEnum i)]
     exact congrArg List.ofFn (funext fun p =>
-      (congrArg Representation.fiberLabel (Representation.tensorEnum_apply_natAdd i p)).trans
-        (Representation.fiberLabel_symm_inr _))
+      (congrArg AR.fiberLabel (AR.tensorEnum_apply_natAdd i p)).trans
+        (AR.fiberLabel_symm_inr _))
 
-theorem Representation.fiberEnum_tensor (i : ι) :
+theorem AR.fiberEnum_tensor (i : ι) :
     (X ⊗ Y).fiberEnum i =
-      (Fin.castOrderIso (Representation.tierLength_tensor i)).trans
-        (Representation.tensorEnum i) :=
+      (Fin.castOrderIso (AR.tierLength_tensor i)).trans
+        (AR.tensorEnum i) :=
   Subsingleton.elim _ _
 
-theorem Representation.vertexEquiv_tensor_of_lt {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
+theorem AR.vertexEquiv_tensor_of_lt {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
     (h : (r : ℕ) < X.tierLength i) :
     (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inl (X.vertexEquiv ⟨i, ⟨r, h⟩⟩) := by
   show ((X ⊗ Y).fiberEnum i r).val = _
-  rw [Representation.fiberEnum_tensor, OrderIso.trans_apply,
-    show Fin.castOrderIso (Representation.tierLength_tensor (X := X) (Y := Y) i) r
+  rw [AR.fiberEnum_tensor, OrderIso.trans_apply,
+    show Fin.castOrderIso (AR.tierLength_tensor (X := X) (Y := Y) i) r
       = Fin.castAdd (Y.tierLength i) ⟨r, h⟩ from rfl,
-    Representation.tensorEnum_apply_castAdd]
+    AR.tensorEnum_apply_castAdd]
   rfl
 
-theorem Representation.vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
+theorem AR.vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
     (h : X.tierLength i ≤ (r : ℕ)) :
     (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inr (Y.vertexEquiv ⟨i,
       ⟨(r : ℕ) - X.tierLength i, by
         have _h1 := r.isLt
         have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
-          Representation.tierLength_tensor i
+          AR.tierLength_tensor i
         omega⟩⟩) := by
   show ((X ⊗ Y).fiberEnum i r).val = _
-  rw [Representation.fiberEnum_tensor, OrderIso.trans_apply,
-    show Fin.castOrderIso (Representation.tierLength_tensor (X := X) (Y := Y) i) r
+  rw [AR.fiberEnum_tensor, OrderIso.trans_apply,
+    show Fin.castOrderIso (AR.tierLength_tensor (X := X) (Y := Y) i) r
       = Fin.natAdd (X.tierLength i) ⟨(r : ℕ) - X.tierLength i, by
           have h1 := r.isLt
           have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
-            Representation.tierLength_tensor i
+            AR.tierLength_tensor i
           omega⟩ from
       Fin.ext (by simpa using (Nat.add_sub_cancel' h).symm),
-    Representation.tensorEnum_apply_natAdd]
+    AR.tensorEnum_apply_natAdd]
   rfl
 
 end TierWordTensor
@@ -444,7 +444,7 @@ section RealizeTierWord
 open scoped MonoidalCategory
 
 variable {S : Type*} {ι : Type*} {τ : ι → Type*}
-variable (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
 
 instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
     Finite (realize g₀ w).obj.V := by
@@ -452,20 +452,20 @@ instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
   | nil => exact inferInstanceAs (Finite PEmpty)
   | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (realize g₀ w).obj.V))
 
-instance : Finite ((𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).obj.V) :=
+instance : Finite ((𝟙_ (AR (Sigma.fst : ((i : ι) × τ i) → ι))).obj.V) :=
   inferInstanceAs (Finite PEmpty)
 
-@[simp] theorem Representation.tierWord_unit (i : ι) :
-    (𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).tierWord i = [] := by
-  haveI : IsEmpty ((𝟙_ (Representation (Sigma.fst : ((i : ι) × τ i) → ι))).fiber i) :=
+@[simp] theorem AR.tierWord_unit (i : ι) :
+    (𝟙_ (AR (Sigma.fst : ((i : ι) × τ i) → ι))).tierWord i = [] := by
+  haveI : IsEmpty ((𝟙_ (AR (Sigma.fst : ((i : ι) × τ i) → ι))).fiber i) :=
     ⟨fun v => v.val.elim⟩
-  rw [Representation.tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
+  rw [AR.tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
   exact List.ofFn_zero
 
 /-- **Tier content is compositional**: the tier word of a realized string is the
     concatenation of its symbols' tier words — [jardine-2019]'s tier projection
     of `g`, and the bridge that places link-free ASL conditions per tier. -/
-theorem Representation.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+theorem AR.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
     (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
   induction w with
   | nil => simp
@@ -483,12 +483,12 @@ noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
 /-- `realizeHom` packages `realize`: on a word it is the class of the realized
     representation. -/
 theorem realizeHom_ofList (w : List S) :
-    realizeHom g₀ (FreeMonoid.ofList w) = Representation.cls (realize g₀ w) := by
+    realizeHom g₀ (FreeMonoid.ofList w) = AR.cls (realize g₀ w) := by
   induction w with
   | nil => rfl
   | cons a w ih =>
     rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
-      map_mul, ih, realize_cons, Representation.cls_tensor]
+      map_mul, ih, realize_cons, AR.cls_tensor]
     rfl
 
 /-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
@@ -501,7 +501,7 @@ theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
       map_mul, ih]
     calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((realize g₀ w).tierWord i)
         = FreeMonoid.ofList ((g₀ a).tierWord i ++ (realize g₀ w).tierWord i) := rfl
-      _ = _ := by rw [← Representation.tierWord_tensor i]; rfl
+      _ = _ := by rw [← AR.tierWord_tensor i]; rfl
 
 end RealizeTierWord
 
@@ -515,39 +515,39 @@ are lists of forbidden factors. -/
 section Factors
 
 variable {ι : Type*} {τ : ι → Type*}
-variable (F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (F X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
 
 /-- Tier-`i` position `p` links to tier-`j` position `q`, in ℕ coordinates
     (out-of-bounds positions link to nothing). -/
-def Representation.link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
+def AR.link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
   ∃ (hp : p < X.tierLength i) (hq : q < X.tierLength j), X.linkRel i j ⟨p, hp⟩ ⟨q, hq⟩
 
 open scoped Classical in
 /-- The two-tier reading of tiers `i` over `j`: each tier-`j` position's label
     with the tier-`i` labels linked to it, in ascending order — the phonetic
     interpretation of a melody tier over its backbone. -/
-noncomputable def Representation.linearize [Finite X.obj.V] (i j : ι) :
+noncomputable def AR.linearize [Finite X.obj.V] (i j : ι) :
     List (τ j × List (τ i)) :=
   (X.tierWord j).zipIdx.map fun bq =>
     (bq.1, ((X.tierWord i).zipIdx.filter fun ap => X.link i j ap.2 bq.2).map (·.1))
 
 /-- `F` occurs in `X` at per-tier offsets `o`: each tier word of `F` is the
     window of `X`'s at `o i`, and `F`'s links transport shifted. -/
-def Representation.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
+def AR.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
   (∀ i p, p < F.tierLength i → (X.tierWord i)[p + o i]? = (F.tierWord i)[p]?) ∧
     ∀ i j p q, F.link i j p q → X.link i j (p + o i) (q + o j)
 
 /-- `F` **subgraph-embeds** in `X` when some offsets place it as a factor
     ([jardine-2017]'s connected-subgraph embedding). -/
-def Representation.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
+def AR.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
   ∃ o : ι → ℕ, F.IsFactorAt X o
 
 /-- Offsets clamp to the host's tier lengths: `FactorEmbeds` is a bounded
     search. On tiers where the factor is nonempty the word-window condition
     already forces the bound; empty factor tiers accept any offset, so `min`
     clamps them harmlessly. -/
-theorem Representation.factorEmbeds_iff_bounded
-    {F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.factorEmbeds_iff_bounded
+    {F X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite F.obj.V] [Finite X.obj.V] :
     F.FactorEmbeds X ↔
       ∃ o : ι → ℕ, (∀ i, o i ≤ X.tierLength i) ∧ F.IsFactorAt X o := by
@@ -562,10 +562,10 @@ theorem Representation.factorEmbeds_iff_bounded
       · exfalso
         have hnone : (X.tierWord i)[p + o i]? = none := by
           rw [List.getElem?_eq_none_iff]
-          simp only [Representation.length_tierWord]
+          simp only [AR.length_tierWord]
           omega
         have hsome : p < (F.tierWord i).length := by
-          simpa [Representation.length_tierWord] using hp
+          simpa [AR.length_tierWord] using hp
         rw [hnone, List.getElem?_eq_some_iff.mpr ⟨hsome, rfl⟩] at horig
         simp at horig
     · obtain ⟨hpb, hqb, -⟩ := id (hl i j p q h)
@@ -590,8 +590,8 @@ theorem Representation.factorEmbeds_iff_bounded
     exact ⟨o, hfa⟩
 
 /-- Link conditions are supported on the factor's tier ranges. -/
-theorem Representation.forall_link_iff_bounded
-    {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι)} [Finite F.obj.V]
+theorem AR.forall_link_iff_bounded
+    {F : AR (Sigma.fst : ((i : ι) × τ i) → ι)} [Finite F.obj.V]
     {C : ι → ι → ℕ → ℕ → Prop} :
     (∀ i j p q, F.link i j p q → C i j p q) ↔
       ∀ i j, ∀ p < F.tierLength i, ∀ q < F.tierLength j,
@@ -602,15 +602,15 @@ theorem Representation.forall_link_iff_bounded
 
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
     ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
-def Representation.Free [Finite X.obj.V]
-    (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
+def AR.Free [Finite X.obj.V]
+    (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
     Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
 
 /-- For a link-free factor, embedding reduces to independent per-tier infix
     occurrences ([jardine-2019]'s link-free fragment). -/
-theorem Representation.factorEmbeds_iff_infix_of_link_free
-    {F X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.factorEmbeds_iff_infix_of_link_free
+    {F X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite F.obj.V] [Finite X.obj.V]
     (hF : ∀ i j p q, ¬ F.link i j p q) :
     F.FactorEmbeds X ↔ ∀ i, F.tierWord i <:+: X.tierWord i := by
@@ -619,61 +619,61 @@ theorem Representation.factorEmbeds_iff_infix_of_link_free
     rw [List.isInfix_iff_exists_offset]
     rcases Nat.eq_zero_or_pos (F.tierWord i).length with hzero | hpos
     · exact ⟨0, Nat.zero_le _, fun p hp => absurd hp (by omega)⟩
-    · have h0 := hw i 0 (by simpa [Representation.length_tierWord] using hpos)
+    · have h0 := hw i 0 (by simpa [AR.length_tierWord] using hpos)
       refine ⟨o i, ?_, fun p hp => hw i p
-        (by simpa [Representation.length_tierWord] using hp)⟩
+        (by simpa [AR.length_tierWord] using hp)⟩
       rcases List.getElem?_eq_some_iff.mp
         (h0 ▸ (List.getElem?_eq_some_iff.mpr
-          ⟨by simpa [Representation.length_tierWord] using hpos, rfl⟩ :
+          ⟨by simpa [AR.length_tierWord] using hpos, rfl⟩ :
             (F.tierWord i)[0]? = some _)) with ⟨hb, -⟩
       omega
   · intro h
     choose o ho using fun i => (List.isInfix_iff_exists_offset _ _).mp (h i)
     refine ⟨o, fun i p hp => ?_, fun i j p q hl => absurd hl (hF i j p q)⟩
     obtain ⟨-, hoff⟩ := ho i
-    exact hoff p (by simpa [Representation.length_tierWord] using hp)
+    exact hoff p (by simpa [AR.length_tierWord] using hp)
 
 open scoped MonoidalCategory in
 /-- Tensor links are blockwise: within the left factor, or within the right
     factor shifted by the left factor's tier lengths — no cross-factor links. -/
-theorem Representation.link_tensor {X Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.link_tensor {X Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite X.obj.V] [Finite Y.obj.V] (i j : ι) (p q : ℕ) :
     (X ⊗ Y).link i j p q ↔
       X.link i j p q ∨ X.tierLength i ≤ p ∧ X.tierLength j ≤ q ∧
         Y.link i j (p - X.tierLength i) (q - X.tierLength j) := by
   have h2i : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
-    Representation.tierLength_tensor i
+    AR.tierLength_tensor i
   have h2j : (X ⊗ Y).tierLength j = X.tierLength j + Y.tierLength j :=
-    Representation.tierLength_tensor j
+    AR.tierLength_tensor j
   constructor
   · rintro ⟨hp, hq, hl⟩
-    rw [Representation.linkRel_def] at hl
+    rw [AR.linkRel_def] at hl
     rcases lt_or_ge p (X.tierLength i) with hpi | hpi <;>
       rcases lt_or_ge q (X.tierLength j) with hqj | hqj
-    · rw [Representation.vertexEquiv_tensor_of_lt (h := hpi),
-        Representation.vertexEquiv_tensor_of_lt (h := hqj)] at hl
-      exact Or.inl ⟨hpi, hqj, by simpa [Representation.linkRel_def] using hl⟩
-    · rw [Representation.vertexEquiv_tensor_of_lt (h := hpi),
-        Representation.vertexEquiv_tensor_of_ge (h := hqj)] at hl
+    · rw [AR.vertexEquiv_tensor_of_lt (h := hpi),
+        AR.vertexEquiv_tensor_of_lt (h := hqj)] at hl
+      exact Or.inl ⟨hpi, hqj, by simpa [AR.linkRel_def] using hl⟩
+    · rw [AR.vertexEquiv_tensor_of_lt (h := hpi),
+        AR.vertexEquiv_tensor_of_ge (h := hqj)] at hl
       simp at hl
-    · rw [Representation.vertexEquiv_tensor_of_ge (h := hpi),
-        Representation.vertexEquiv_tensor_of_lt (h := hqj)] at hl
+    · rw [AR.vertexEquiv_tensor_of_ge (h := hpi),
+        AR.vertexEquiv_tensor_of_lt (h := hqj)] at hl
       simp at hl
-    · rw [Representation.vertexEquiv_tensor_of_ge (h := hpi),
-        Representation.vertexEquiv_tensor_of_ge (h := hqj)] at hl
+    · rw [AR.vertexEquiv_tensor_of_ge (h := hpi),
+        AR.vertexEquiv_tensor_of_ge (h := hqj)] at hl
       exact Or.inr ⟨hpi, hqj, by omega, by omega,
-        by simpa [Representation.linkRel_def] using hl⟩
+        by simpa [AR.linkRel_def] using hl⟩
   · rintro (⟨hp, hq, hl⟩ | ⟨hpi, hqj, hp', hq', hl⟩)
-    · rw [Representation.linkRel_def] at hl
+    · rw [AR.linkRel_def] at hl
       refine ⟨by omega, by omega, ?_⟩
-      rw [Representation.linkRel_def, Representation.vertexEquiv_tensor_of_lt (h := hp),
-        Representation.vertexEquiv_tensor_of_lt (h := hq)]
+      rw [AR.linkRel_def, AR.vertexEquiv_tensor_of_lt (h := hp),
+        AR.vertexEquiv_tensor_of_lt (h := hq)]
       simpa using hl
-    · rw [Representation.linkRel_def] at hl
+    · rw [AR.linkRel_def] at hl
       refine ⟨by omega, by omega, ?_⟩
-      rw [Representation.linkRel_def,
-        Representation.vertexEquiv_tensor_of_ge (h := by omega),
-        Representation.vertexEquiv_tensor_of_ge (h := by omega)]
+      rw [AR.linkRel_def,
+        AR.vertexEquiv_tensor_of_ge (h := by omega),
+        AR.vertexEquiv_tensor_of_ge (h := by omega)]
       simpa using hl
 
 end Factors
@@ -688,67 +688,67 @@ section Classification
 open scoped MonoidalCategory
 
 variable {ι : Type*} {τ : ι → Type*}
-variable {X : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
 
 /-- The label of a canonical vertex sits on its own tier. -/
-theorem Representation.label_vertexEquiv [Finite X.obj.V] (i : ι)
+theorem AR.label_vertexEquiv [Finite X.obj.V] (i : ι)
     (p : Fin (X.tierLength i)) : (X.obj.label (X.vertexEquiv ⟨i, p⟩)).1 = i :=
   (X.fiberEnum i p).property
 
-theorem Representation.linkRel_iff_link [Finite X.obj.V] {i j : ι}
+theorem AR.linkRel_iff_link [Finite X.obj.V] {i j : ι}
     {p : Fin (X.tierLength i)} {q : Fin (X.tierLength j)} :
     X.linkRel i j p q ↔ X.link i j (p : ℕ) (q : ℕ) :=
   ⟨fun h => ⟨p.isLt, q.isLt, h⟩, fun ⟨_, _, h⟩ => by convert h⟩
 
-theorem Representation.tierWord_getElem [Finite X.obj.V] {i : ι}
+theorem AR.tierWord_getElem [Finite X.obj.V] {i : ι}
     (p : Fin (X.tierLength i)) :
     (X.tierWord i)[(p : ℕ)]'(by simp) = X.fiberLabel (X.fiberEnum i p) := by
-  simp [Representation.tierWord]
+  simp [AR.tierWord]
 
-theorem Representation.label_normalize [Finite X.obj.V] {i : ι}
+theorem AR.label_normalize [Finite X.obj.V] {i : ι}
     (p : Fin (X.tierLength i)) :
     (X.normalize).obj.label ⟨i, p⟩ = ⟨i, X.fiberLabel (X.fiberEnum i p)⟩ :=
   X.label_fiber (X.fiberEnum i p)
 
-theorem Representation.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ j)
+theorem AR.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ j)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
     ¬ (X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨j, q⟩ := fun ha => by
   have h2 := X.property.1.tier_eq ha
-  rw [show MixedGraphCat.tier Sigma.fst X.obj (X.vertexEquiv ⟨i, p⟩) = i from
+  rw [show Graph.tier Sigma.fst X.obj (X.vertexEquiv ⟨i, p⟩) = i from
       X.label_vertexEquiv i p,
-    show MixedGraphCat.tier Sigma.fst X.obj (X.vertexEquiv ⟨j, q⟩) = j from
+    show Graph.tier Sigma.fst X.obj (X.vertexEquiv ⟨j, q⟩) = j from
       X.label_vertexEquiv j q] at h2
   exact h h2
 
 /-- Links are symmetric in coordinates. -/
-theorem Representation.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
+theorem AR.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
     (h : X.link i j p q) : X.link j i q p := by
   obtain ⟨hp, hq, hl⟩ := h
   exact ⟨hq, hp, hl.symm⟩
 
 /-- Same-tier vertices are never linked: they are arc-comparable (Axioms 1–2),
     and association never follows arcs (Axiom 3). -/
-theorem Representation.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
+theorem AR.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
     ¬ X.link i i p q := by
   rintro ⟨hp, hq, hl⟩
-  rw [Representation.linkRel_def] at hl
+  rw [AR.linkRel_def] at hl
   have hlab : X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨p, hp⟩⟩)
       = X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨q, hq⟩⟩) := by
     show (X.obj.label _).1 = (X.obj.label _).1
-    rw [Representation.label_vertexEquiv, Representation.label_vertexEquiv]
+    rw [AR.label_vertexEquiv, AR.label_vertexEquiv]
   exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
 
-/-- The classification isomorphism, as a full-structure `MixedGraphCat.Iso` —
+/-- The classification isomorphism, as a full-structure `Graph.Iso` —
     the form that descends to the class monoid. -/
-noncomputable def Representation.fullIsoOfReaderEq
-    {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+noncomputable def AR.fullIsoOfReaderEq
+    {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
     (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) :
-    MixedGraphCat.Iso A.obj B.obj := by
+    Graph.Iso A.obj B.obj := by
   have hlen : ∀ i, A.tierLength i = B.tierLength i := fun i => by
-    rw [← Representation.length_tierWord, hw, Representation.length_tierWord]
-  refine A.normalizeFullIso.symm.trans (MixedGraphCat.Iso.trans ?_ B.normalizeFullIso)
+    rw [← AR.length_tierWord, hw, AR.length_tierWord]
+  refine A.normalizeFullIso.symm.trans (Graph.Iso.trans ?_ B.normalizeFullIso)
   refine
     { toEquiv := Equiv.sigmaCongrRight fun i => finCongr (hlen i)
       edges_iff := fun v w => ?_
@@ -758,33 +758,33 @@ noncomputable def Representation.fullIsoOfReaderEq
     obtain ⟨j, q⟩ := w
     show B.normalize.obj.graph.edges.Adj ⟨i, Fin.cast (hlen i) p⟩ ⟨j, Fin.cast (hlen j) q⟩
       ↔ A.normalize.obj.graph.edges.Adj ⟨i, p⟩ ⟨j, q⟩
-    rw [Representation.edges_normalize, Representation.edges_normalize,
-      Representation.linkRel_iff_link, Representation.linkRel_iff_link]
+    rw [AR.edges_normalize, AR.edges_normalize,
+      AR.linkRel_iff_link, AR.linkRel_iff_link]
     exact (hl i j p q).symm
   · obtain ⟨i, p⟩ := v
     obtain ⟨j, q⟩ := w
     show B.normalize.obj.graph.arcs.Adj ⟨i, Fin.cast (hlen i) p⟩ ⟨j, Fin.cast (hlen j) q⟩
       ↔ A.normalize.obj.graph.arcs.Adj ⟨i, p⟩ ⟨j, q⟩
     rcases eq_or_ne i j with rfl | h
-    · rw [Representation.arcs_normalize, Representation.arcs_normalize]
+    · rw [AR.arcs_normalize, AR.arcs_normalize]
       exact (Fin.castOrderIso (hlen i)).lt_iff_lt
-    · exact iff_of_false (Representation.arcs_normalize_ne h _ _)
-        (Representation.arcs_normalize_ne h _ _)
+    · exact iff_of_false (AR.arcs_normalize_ne h _ _)
+        (AR.arcs_normalize_ne h _ _)
   · obtain ⟨i, p⟩ := v
     show B.normalize.obj.label ⟨i, Fin.cast (hlen i) p⟩ = A.normalize.obj.label ⟨i, p⟩
-    rw [Representation.label_normalize, Representation.label_normalize]
+    rw [AR.label_normalize, AR.label_normalize]
     congr 1
-    rw [← Representation.tierWord_getElem, ← Representation.tierWord_getElem]
+    rw [← AR.tierWord_getElem, ← AR.tierWord_getElem]
     simp only [hw, Fin.val_cast]
 
 /-- **Classification of finite representations**: equal tier words and equal
     links give an isomorphism — the tuple reading is a complete invariant. -/
-noncomputable def Representation.isoOfReaderEq
-    {A B : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+noncomputable def AR.isoOfReaderEq
+    {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
     (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) : A ≅ B :=
-  Representation.mkIso (Representation.fullIsoOfReaderEq hw hl)
+  AR.mkIso (AR.fullIsoOfReaderEq hw hl)
 
 end Classification
 
@@ -803,8 +803,8 @@ variable {ι : Type*} {τ : ι → Type*}
     (positions in ℕ coordinates; same-tier and out-of-bounds pairs are
     ignored, and same-tier links are excluded by construction). Arcs are the
     ascending position order on each tier. -/
-def Representation.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop) :
-    Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+def AR.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop) :
+    AR (Sigma.fst : ((i : ι) × τ i) → ι) where
   obj :=
     { V := (i : ι) × Fin (ws i).length
       graph :=
@@ -829,64 +829,64 @@ def Representation.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → �
 
 variable [Finite ι] {ws : ∀ i, List (τ i)} {L : ι → ι → ℕ → ℕ → Prop}
 
-instance : Finite (Representation.ofData ws L).obj.V :=
+instance : Finite (AR.ofData ws L).obj.V :=
   inferInstanceAs (Finite ((i : ι) × Fin (ws i).length))
 
 /-- The canonical carrier's fiber at `i` is its position range. -/
-noncomputable def Representation.ofDataFiberEnum (i : ι) :
-    Fin ((ws i).length) ≃o (Representation.ofData ws L).fiber i := by
+noncomputable def AR.ofDataFiberEnum (i : ι) :
+    Fin ((ws i).length) ≃o (AR.ofData ws L).fiber i := by
   refine StrictMono.orderIsoOfSurjective (fun p => ⟨⟨i, p⟩, rfl⟩) (fun p q h => ⟨rfl, h⟩)
     fun v => ?_
   obtain ⟨⟨j, q⟩, hp⟩ := v
   obtain rfl : j = i := hp
   exact ⟨q, rfl⟩
 
-theorem Representation.tierLength_ofData (i : ι) :
-    (Representation.ofData ws L).tierLength i = (ws i).length := by
-  rw [← Representation.length_tierWord,
-    Representation.tierWord_eq_ofFn (Representation.ofDataFiberEnum i), List.length_ofFn]
+theorem AR.tierLength_ofData (i : ι) :
+    (AR.ofData ws L).tierLength i = (ws i).length := by
+  rw [← AR.length_tierWord,
+    AR.tierWord_eq_ofFn (AR.ofDataFiberEnum i), List.length_ofFn]
 
-theorem Representation.fiberEnum_ofData (i : ι) :
-    (Representation.ofData ws L).fiberEnum i =
-      (Fin.castOrderIso (Representation.tierLength_ofData i)).trans
-        (Representation.ofDataFiberEnum i) :=
+theorem AR.fiberEnum_ofData (i : ι) :
+    (AR.ofData ws L).fiberEnum i =
+      (Fin.castOrderIso (AR.tierLength_ofData i)).trans
+        (AR.ofDataFiberEnum i) :=
   Subsingleton.elim _ _
 
-theorem Representation.vertexEquiv_ofData {i : ι}
-    (r : Fin ((Representation.ofData ws L).tierLength i)) :
-    (Representation.ofData ws L).vertexEquiv ⟨i, r⟩ =
-      ⟨i, Fin.cast (Representation.tierLength_ofData i) r⟩ := by
-  show ((Representation.ofData ws L).fiberEnum i r).val = _
-  rw [Representation.fiberEnum_ofData]
+theorem AR.vertexEquiv_ofData {i : ι}
+    (r : Fin ((AR.ofData ws L).tierLength i)) :
+    (AR.ofData ws L).vertexEquiv ⟨i, r⟩ =
+      ⟨i, Fin.cast (AR.tierLength_ofData i) r⟩ := by
+  show ((AR.ofData ws L).fiberEnum i r).val = _
+  rw [AR.fiberEnum_ofData]
   rfl
 
 /-- `ofData` reads back its words. -/
-@[simp] theorem Representation.tierWord_ofData (i : ι) :
-    (Representation.ofData ws L).tierWord i = ws i := by
-  rw [Representation.tierWord_eq_ofFn (Representation.ofDataFiberEnum i)]
+@[simp] theorem AR.tierWord_ofData (i : ι) :
+    (AR.ofData ws L).tierWord i = ws i := by
+  rw [AR.tierWord_eq_ofFn (AR.ofDataFiberEnum i)]
   exact List.ofFn_getElem
 
 /-- `ofData` reads back its links, symmetrized, on in-bounds cross-tier
     pairs. -/
-theorem Representation.link_ofData (i j : ι) (p q : ℕ) :
-    (Representation.ofData ws L).link i j p q ↔
+theorem AR.link_ofData (i j : ι) (p q : ℕ) :
+    (AR.ofData ws L).link i j p q ↔
       i ≠ j ∧ p < (ws i).length ∧ q < (ws j).length ∧ (L i j p q ∨ L j i q p) := by
   constructor
   · rintro ⟨hp, hq, hl⟩
-    rw [Representation.linkRel_def, Representation.vertexEquiv_ofData,
-      Representation.vertexEquiv_ofData] at hl
+    rw [AR.linkRel_def, AR.vertexEquiv_ofData,
+      AR.vertexEquiv_ofData] at hl
     obtain ⟨hne, hor⟩ := hl
-    have hp' : p < (ws i).length := Representation.tierLength_ofData i ▸ hp
-    have hq' : q < (ws j).length := Representation.tierLength_ofData j ▸ hq
+    have hp' : p < (ws i).length := AR.tierLength_ofData i ▸ hp
+    have hq' : q < (ws j).length := AR.tierLength_ofData j ▸ hq
     exact ⟨hne, hp', hq', by simpa using hor⟩
   · rintro ⟨hij, hp, hq, hor⟩
-    have hp' : p < (Representation.ofData ws L).tierLength i := by
-      rw [← Representation.length_tierWord, Representation.tierWord_ofData]; exact hp
-    have hq' : q < (Representation.ofData ws L).tierLength j := by
-      rw [← Representation.length_tierWord, Representation.tierWord_ofData]; exact hq
+    have hp' : p < (AR.ofData ws L).tierLength i := by
+      rw [← AR.length_tierWord, AR.tierWord_ofData]; exact hp
+    have hq' : q < (AR.ofData ws L).tierLength j := by
+      rw [← AR.length_tierWord, AR.tierWord_ofData]; exact hq
     refine ⟨hp', hq', ?_⟩
-    rw [Representation.linkRel_def, Representation.vertexEquiv_ofData,
-      Representation.vertexEquiv_ofData]
+    rw [AR.linkRel_def, AR.vertexEquiv_ofData,
+      AR.vertexEquiv_ofData]
     exact ⟨hij, by simpa using hor⟩
 
 end OfData

--- a/Linglib/Phonology/Autosegmental/OCP.lean
+++ b/Linglib/Phonology/Autosegmental/OCP.lean
@@ -62,129 +62,11 @@ open OCP
 
 variable {α β : Type*} [DecidableEq α]
 
-/-! ### The run-index map -/
-
-/-- **Run index** of upper position `k` in `xs`: the index (0-based) of the
-    OCP-run containing `k`, i.e. one less than the number of runs in the prefix
-    `xs[0..k]`. Concretely `(OCP.collapse (xs.take (k+1))).length - 1`. -/
-def runIdx (xs : List α) (k : ℕ) : ℕ := (collapse (xs.take (k + 1))).length - 1
-
-/-- `runIdx` is monotone: later positions sit in later (or the same) runs. -/
-theorem runIdx_monotone (xs : List α) : Monotone (runIdx xs) := by
-  intro a b hab
-  unfold runIdx
-  have hsub : (collapse (xs.take (a + 1))).Sublist (xs.take (b + 1)) :=
-    (collapse_sublist _).trans (List.take_sublist_take_left (by omega))
-  have hlen := List.IsChain.length_le_length_destutter_ne hsub (collapse_clean _)
-  simp only [collapse_eq_destutter] at hlen ⊢
-  omega
-
-/-- `runIdx` lands inside the collapsed tier: an in-bounds position maps to an
-    in-bounds run index. The upper half of `collapseAR`'s in-bounds proof. -/
-theorem runIdx_lt_collapse_length (xs : List α) {k : ℕ} (hk : k < xs.length) :
-    runIdx xs k < (collapse xs).length := by
-  unfold runIdx
-  have hne : xs.take (k + 1) ≠ [] := by
-    intro h
-    have hlen : (xs.take (k + 1)).length = k + 1 := List.length_take_of_le (by omega)
-    rw [h] at hlen; simp at hlen
-  have hsub : (collapse (xs.take (k + 1))).Sublist xs :=
-    (collapse_sublist _).trans (List.take_sublist _ _)
-  have hlen := List.IsChain.length_le_length_destutter_ne hsub (collapse_clean _)
-  simp only [collapse_eq_destutter] at hlen ⊢
-  have hpos : 0 < ((xs.take (k + 1)).destutter (· ≠ ·)).length := by
-    rw [List.length_pos_iff]
-    intro h
-    rw [← collapse_eq_destutter, collapse_eq_nil] at h
-    exact hne h
-  omega
-
-/-- On a constant tier every position lies in the single run: `runIdx` is `0`. -/
-@[simp] theorem runIdx_replicate (n : ℕ) (a : α) (k : ℕ) :
-    runIdx (List.replicate n a) k = 0 := by
-  unfold runIdx
-  rw [List.take_replicate]
-  cases hm : min (k + 1) n with
-  | zero => simp
-  | succ m => rw [collapse_replicate, List.length_singleton]
-
-/-! ### Run-index and concatenation
-
-The defining property of `concat` for the OCP quotient: `runIdx` commutes with the
-collapse-collapse seam (`runIdx_append_collapse_left/right`). On the A-block the prefix
-run-index is untouched (`runIdx_append_left`, plus `runIdx_clean` re-reading a clean tier
-as the identity); on the B-block the seam merges exactly when `collapse xs` ends in the
-element heading `ys` (`runIdx_append_right`, the AR shadow of
-`List.destutter_append_length_clean`). -/
-
-/-- The prefix run-index is unaffected by a right append. -/
-theorem runIdx_append_left {xs ys : List α} {k : ℕ} (h : k < xs.length) :
-    runIdx (xs ++ ys) k = runIdx xs k := by
-  unfold runIdx; rw [List.take_append_of_le_length (by omega)]
-
-/-- On a clean tier `runIdx` is the identity (no runs to merge). -/
-theorem runIdx_clean {xs : List α} (hc : IsClean xs) {k : ℕ} (h : k < xs.length) :
-    runIdx xs k = k := by
-  unfold runIdx
-  rw [collapse_idempotent_on_clean (hc.take (k + 1)), List.length_take_of_le (by omega)]
-  omega
-
-/-- The length of the collapse of a nonempty prefix is its top run-index plus one. -/
-theorem collapse_take_succ_length {xs : List α} {m : ℕ} (hm : m < xs.length) :
-    (collapse (xs.take (m + 1))).length = runIdx xs m + 1 := by
-  unfold runIdx
-  have hpos : 0 < (collapse (xs.take (m + 1))).length := by
-    rw [List.length_pos_iff]
-    refine fun h => ?_
-    have hne : xs.take (m + 1) ≠ [] := by
-      intro h'
-      have : (xs.take (m + 1)).length = m + 1 := List.length_take_of_le (by omega)
-      rw [h'] at this; simp at this
-    exact hne (collapse_eq_nil.mp h)
-  omega
-
-/-- The collapse of a prefix has the same head as the whole tier. -/
-theorem collapse_take_head? {xs : List α} {m : ℕ} :
-    (collapse (xs.take (m + 1))).head? = xs.head? := by
-  rw [collapse, List.destutter_head?]
-  cases xs <;> simp
-
-/-- **The B-part seam identity.** Reading a suffix position through the collapse of an
-append: the run-index is the left collapse's length plus the suffix's own run-index, minus
-one exactly when the seam merges (`List.destutter_append_length_clean`). -/
-theorem runIdx_append_right {xs ys : List α} {a : ℕ} (ha : a < ys.length) :
-    runIdx (xs ++ ys) (xs.length + a) =
-      (collapse xs).length + runIdx ys a -
-        (if (collapse xs).getLast? = ys.head? then 1 else 0) := by
-  unfold runIdx
-  rw [show xs.length + a + 1 = xs.length + (a + 1) by omega, List.take_length_add_append,
-    collapse_append, collapse_eq_destutter,
-    List.destutter_append_length_clean (collapse_clean _) (collapse_clean _),
-    collapse_take_succ_length ha, collapse_take_head?]
-  split_ifs with h
-  · have : 0 < (collapse ys).length := Nat.zero_lt_of_lt (runIdx_lt_collapse_length ys ha)
-    omega
-  · omega
-
-/-- A-block: a prefix index commutes with the collapse-collapse seam. -/
-theorem runIdx_append_collapse_left {xs ys : List α} {k : ℕ} (h : k < xs.length) :
-    runIdx (xs ++ ys) k = runIdx (collapse xs ++ collapse ys) (runIdx xs k) := by
-  rw [runIdx_append_left h, runIdx_append_left (runIdx_lt_collapse_length xs h),
-    runIdx_clean (collapse_clean _) (runIdx_lt_collapse_length xs h)]
-
-/-- B-block: a suffix index commutes with the collapse-collapse seam. -/
-theorem runIdx_append_collapse_right {xs ys : List α} {a : ℕ} (ha : a < ys.length) :
-    runIdx (xs ++ ys) (xs.length + a) =
-      runIdx (collapse xs ++ collapse ys) ((collapse xs).length + runIdx ys a) := by
-  rw [runIdx_append_right ha, runIdx_append_right (runIdx_lt_collapse_length ys ha),
-    collapse_idempotent, runIdx_clean (collapse_clean _) (runIdx_lt_collapse_length ys ha),
-    collapse_eq_destutter ys, List.destutter_head?]
-
 /-! ### The collapse in coordinates
 
 The OCP merge on the graph foundation: destutter melody tier `m`'s word and
 repoint its links through `runIdx`. Like `normalize` the result is a
-`Representation` on a sigma-`Fin` carrier, but the merge is not a pullback —
+`AR` on a sigma-`Fin` carrier, but the merge is not a pullback —
 `runIdx` is monotone, not bijective — so the structural axioms are proved
 directly on the merged carrier. -/
 
@@ -193,28 +75,28 @@ open CategoryTheory
 open scoped MonoidalCategory
 
 variable {ι : Type*} [DecidableEq ι] {τ : ι → Type*}
-variable (X : Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
 variable (m : ι) [DecidableEq (τ m)]
 
 /-- Tier words after collapsing melody tier `m`: destuttered at `m`, untouched
     elsewhere. -/
-noncomputable def Representation.collapsedWord [Finite X.obj.V] : ∀ i, List (τ i) :=
+noncomputable def AR.collapsedWord [Finite X.obj.V] : ∀ i, List (τ i) :=
   Function.update (fun i => X.tierWord i) m (OCP.collapse (X.tierWord m))
 
-theorem Representation.collapsedWord_length_le [Finite X.obj.V] (i : ι) :
+theorem AR.collapsedWord_length_le [Finite X.obj.V] (i : ι) :
     (X.collapsedWord m i).length ≤ X.tierLength i := by
   rcases eq_or_ne i m with rfl | h
-  · simpa [Representation.collapsedWord] using OCP.collapse_length_le (X.tierWord i)
-  · simp [Representation.collapsedWord, Function.update_of_ne h]
+  · simpa [AR.collapsedWord] using OCP.collapse_length_le (X.tierWord i)
+  · simp [AR.collapsedWord, Function.update_of_ne h]
 
 /-- Position repointing: `runIdx` on the melody tier, identity elsewhere. -/
-noncomputable def Representation.collapseIdx [Finite X.obj.V] (i : ι) (p : ℕ) : ℕ :=
+noncomputable def AR.collapseIdx [Finite X.obj.V] (i : ι) (p : ℕ) : ℕ :=
   if i = m then runIdx (X.tierWord m) p else p
 
 /-- **The OCP-merging collapse**: melody tier `m` destuttered, links repointed
     through `runIdx`, other tiers untouched. -/
-noncomputable def Representation.collapse [Finite X.obj.V] :
-    Representation (Sigma.fst : ((i : ι) × τ i) → ι) where
+noncomputable def AR.collapse [Finite X.obj.V] :
+    AR (Sigma.fst : ((i : ι) × τ i) → ι) where
   obj :=
     { V := (i : ι) × Fin (X.collapsedWord m i).length
       graph :=
@@ -259,7 +141,7 @@ instance [Finite X.obj.V] : Finite (X.collapse m).obj.V :=
       exact congrArg _ (Fin.castLE_injective _ (eq_of_heq h2))
 
 /-- The collapsed fiber at `i` is enumerated by its position range. -/
-noncomputable def Representation.collapseFiberEnum [Finite X.obj.V] (i : ι) :
+noncomputable def AR.collapseFiberEnum [Finite X.obj.V] (i : ι) :
     Fin ((X.collapsedWord m i).length) ≃o (X.collapse m).fiber i := by
   refine StrictMono.orderIsoOfSurjective (fun p => ⟨⟨i, p⟩, rfl⟩) (fun p q h => ⟨rfl, h⟩)
     fun v => ?_
@@ -269,146 +151,146 @@ noncomputable def Representation.collapseFiberEnum [Finite X.obj.V] (i : ι) :
 
 /-- **The collapse does what it says**: its tier words are the collapsed
     words — destuttered at `m` (`Function.update_self`), untouched elsewhere. -/
-@[simp] theorem Representation.tierWord_collapse [Finite X.obj.V] (i : ι) :
+@[simp] theorem AR.tierWord_collapse [Finite X.obj.V] (i : ι) :
     (X.collapse m).tierWord i = X.collapsedWord m i := by
-  rw [Representation.tierWord_eq_ofFn (X.collapseFiberEnum m i)]
+  rw [AR.tierWord_eq_ofFn (X.collapseFiberEnum m i)]
   exact List.ofFn_getElem
 
 /-- The word half of the OCP congruence: collapsing a tensor computes the same
     tier words as collapsing the tensor of the collapsed factors —
     `OCP.collapse_append` lifted through the readers. -/
-theorem Representation.collapsedWord_tensor
-    {Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.collapsedWord_tensor
+    {Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite X.obj.V] [Finite Y.obj.V] (i : ι) :
     (X ⊗ Y).collapsedWord m i = (X.collapse m ⊗ Y.collapse m).collapsedWord m i := by
   rcases eq_or_ne i m with rfl | h
-  · simp only [Representation.collapsedWord, Function.update_self,
-      Representation.tierWord_tensor, Representation.tierWord_collapse]
+  · simp only [AR.collapsedWord, Function.update_self,
+      AR.tierWord_tensor, AR.tierWord_collapse]
     exact OCP.collapse_append _ _
-  · simp [Representation.collapsedWord, Function.update_of_ne h]
+  · simp [AR.collapsedWord, Function.update_of_ne h]
 
-theorem Representation.fiberEnum_collapse [Finite X.obj.V] (i : ι) :
+theorem AR.fiberEnum_collapse [Finite X.obj.V] (i : ι) :
     (X.collapse m).fiberEnum i =
-      (Fin.castOrderIso (by rw [← Representation.length_tierWord,
-        Representation.tierWord_collapse])).trans (X.collapseFiberEnum m i) :=
+      (Fin.castOrderIso (by rw [← AR.length_tierWord,
+        AR.tierWord_collapse])).trans (X.collapseFiberEnum m i) :=
   Subsingleton.elim _ _
 
-theorem Representation.vertexEquiv_collapse [Finite X.obj.V] {i : ι}
+theorem AR.vertexEquiv_collapse [Finite X.obj.V] {i : ι}
     (r : Fin ((X.collapse m).tierLength i)) :
     (X.collapse m).vertexEquiv ⟨i, r⟩
-      = ⟨i, Fin.cast (by rw [← Representation.length_tierWord,
-          Representation.tierWord_collapse]) r⟩ := by
+      = ⟨i, Fin.cast (by rw [← AR.length_tierWord,
+          AR.tierWord_collapse]) r⟩ := by
   show ((X.collapse m).fiberEnum i r).val = _
-  rw [Representation.fiberEnum_collapse]
+  rw [AR.fiberEnum_collapse]
   rfl
 
 /-- The collapse's links are the image of the original links under the
     repointing — `edges_normalize`'s analogue for the merge. -/
-theorem Representation.link_collapse [Finite X.obj.V] (i j : ι) (r s : ℕ) :
+theorem AR.link_collapse [Finite X.obj.V] (i j : ι) (r s : ℕ) :
     (X.collapse m).link i j r s ↔
       ∃ p q, X.link i j p q ∧ X.collapseIdx m i p = r ∧ X.collapseIdx m j q = s := by
   constructor
   · rintro ⟨hr, hs, hl⟩
-    rw [Representation.linkRel_def, Representation.vertexEquiv_collapse,
-      Representation.vertexEquiv_collapse] at hl
+    rw [AR.linkRel_def, AR.vertexEquiv_collapse,
+      AR.vertexEquiv_collapse] at hl
     obtain ⟨-, p, q, hpq, hp, hq⟩ := hl
     exact ⟨p, q, hpq, hp, hq⟩
   · rintro ⟨p, q, hpq, hp, hq⟩
     have hbr : r < (X.collapse m).tierLength i := by
-      rw [← Representation.length_tierWord, Representation.tierWord_collapse]
+      rw [← AR.length_tierWord, AR.tierWord_collapse]
       subst hp
-      unfold Representation.collapseIdx
+      unfold AR.collapseIdx
       split_ifs with h
       · subst h
-        simpa [Representation.collapsedWord] using
+        simpa [AR.collapsedWord] using
           runIdx_lt_collapse_length _ (by simpa using hpq.1)
-      · simpa [Representation.collapsedWord, Function.update_of_ne h] using hpq.1
+      · simpa [AR.collapsedWord, Function.update_of_ne h] using hpq.1
     have hbs : s < (X.collapse m).tierLength j := by
-      rw [← Representation.length_tierWord, Representation.tierWord_collapse]
+      rw [← AR.length_tierWord, AR.tierWord_collapse]
       subst hq
-      unfold Representation.collapseIdx
+      unfold AR.collapseIdx
       split_ifs with h
       · subst h
-        simpa [Representation.collapsedWord] using
+        simpa [AR.collapsedWord] using
           runIdx_lt_collapse_length _ (by simpa using hpq.2.1)
-      · simpa [Representation.collapsedWord, Function.update_of_ne h] using hpq.2.1
+      · simpa [AR.collapsedWord, Function.update_of_ne h] using hpq.2.1
     refine ⟨hbr, hbs, ?_⟩
-    rw [Representation.linkRel_def, Representation.vertexEquiv_collapse,
-      Representation.vertexEquiv_collapse]
+    rw [AR.linkRel_def, AR.vertexEquiv_collapse,
+      AR.vertexEquiv_collapse]
     refine ⟨?_, p, q, hpq, hp, hq⟩
     intro heq
     obtain ⟨hij, -⟩ := Sigma.mk.inj_iff.mp heq
     subst hij
     exact X.not_link_self_tier i p q hpq
 
-theorem Representation.tierLength_collapse [Finite X.obj.V] (i : ι) :
+theorem AR.tierLength_collapse [Finite X.obj.V] (i : ι) :
     (X.collapse m).tierLength i = (X.collapsedWord m i).length := by
-  rw [← Representation.length_tierWord, Representation.tierWord_collapse]
+  rw [← AR.length_tierWord, AR.tierWord_collapse]
 
 section Congruence
-variable {Y : Representation (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
 variable [Finite X.obj.V] [Finite Y.obj.V]
 
 /-- Left-block positions commute with the collapse-collapse seam. -/
-theorem Representation.collapseIdx_left (i : ι) {p : ℕ} (hp : p < X.tierLength i) :
+theorem AR.collapseIdx_left (i : ι) {p : ℕ} (hp : p < X.tierLength i) :
     (X.collapse m ⊗ Y.collapse m).collapseIdx m i (X.collapseIdx m i p)
       = (X ⊗ Y).collapseIdx m i p := by
-  unfold Representation.collapseIdx
+  unfold AR.collapseIdx
   split_ifs with h
   · subst h
-    simp only [Representation.tierWord_tensor, Representation.tierWord_collapse,
-      Representation.collapsedWord, Function.update_self]
+    simp only [AR.tierWord_tensor, AR.tierWord_collapse,
+      AR.collapsedWord, Function.update_self]
     exact (runIdx_append_collapse_left (xs := X.tierWord i) (ys := Y.tierWord i)
       (by simpa using hp)).symm
   · rfl
 
 /-- Right-block positions commute with the collapse-collapse seam. -/
-theorem Representation.collapseIdx_right (i : ι) {p : ℕ} (hp : p < Y.tierLength i) :
+theorem AR.collapseIdx_right (i : ι) {p : ℕ} (hp : p < Y.tierLength i) :
     (X.collapse m ⊗ Y.collapse m).collapseIdx m i
         ((X.collapse m).tierLength i + Y.collapseIdx m i p)
       = (X ⊗ Y).collapseIdx m i (X.tierLength i + p) := by
-  unfold Representation.collapseIdx
+  unfold AR.collapseIdx
   split_ifs with h
   · subst h
-    simp only [Representation.tierWord_tensor, Representation.tierWord_collapse,
-      Representation.collapsedWord, Function.update_self,
-      ← Representation.length_tierWord]
+    simp only [AR.tierWord_tensor, AR.tierWord_collapse,
+      AR.collapsedWord, Function.update_self,
+      ← AR.length_tierWord]
     exact (runIdx_append_collapse_right (xs := X.tierWord i) (ys := Y.tierWord i)
       (by simpa using hp)).symm
-  · simp [Representation.tierLength_collapse, Representation.collapsedWord,
+  · simp [AR.tierLength_collapse, AR.collapsedWord,
       Function.update_of_ne h]
 
 /-- The link half of the OCP congruence, in ℕ coordinates. -/
-theorem Representation.link_collapse_tensor (i j : ι) (r s : ℕ) :
+theorem AR.link_collapse_tensor (i j : ι) (r s : ℕ) :
     ((X ⊗ Y).collapse m).link i j r s ↔
       ((X.collapse m ⊗ Y.collapse m).collapse m).link i j r s := by
-  rw [Representation.link_collapse, Representation.link_collapse]
+  rw [AR.link_collapse, AR.link_collapse]
   constructor
   · rintro ⟨p, q, hpq, hr, hs⟩
-    rcases (Representation.link_tensor i j p q).mp hpq with hX | ⟨hpi, hqj, hY⟩
+    rcases (AR.link_tensor i j p q).mp hpq with hX | ⟨hpi, hqj, hY⟩
     · refine ⟨X.collapseIdx m i p, X.collapseIdx m j q,
-        (Representation.link_tensor i j _ _).mpr
+        (AR.link_tensor i j _ _).mpr
           (Or.inl ((X.link_collapse m i j _ _).mpr ⟨p, q, hX, rfl, rfl⟩)), ?_, ?_⟩
       · rw [X.collapseIdx_left m i hX.1, hr]
       · rw [X.collapseIdx_left m j hX.2.1, hs]
     · refine ⟨(X.collapse m).tierLength i + Y.collapseIdx m i (p - X.tierLength i),
         (X.collapse m).tierLength j + Y.collapseIdx m j (q - X.tierLength j),
-        (Representation.link_tensor i j _ _).mpr (Or.inr ⟨by omega, by omega, ?_⟩), ?_, ?_⟩
+        (AR.link_tensor i j _ _).mpr (Or.inr ⟨by omega, by omega, ?_⟩), ?_, ?_⟩
       · rw [Nat.add_sub_cancel_left, Nat.add_sub_cancel_left]
         exact (Y.link_collapse m i j _ _).mpr ⟨_, _, hY, rfl, rfl⟩
       · rw [X.collapseIdx_right m i hY.1, Nat.add_sub_cancel' hpi, hr]
       · rw [X.collapseIdx_right m j hY.2.1, Nat.add_sub_cancel' hqj, hs]
   · rintro ⟨p', q', hpq', hr, hs⟩
-    rcases (Representation.link_tensor i j p' q').mp hpq' with hX | ⟨hpi', hqj', hY'⟩
+    rcases (AR.link_tensor i j p' q').mp hpq' with hX | ⟨hpi', hqj', hY'⟩
     · obtain ⟨p, q, hX₀, hcp, hcq⟩ := (X.link_collapse m i j p' q').mp hX
-      refine ⟨p, q, (Representation.link_tensor i j p q).mpr (Or.inl hX₀), ?_, ?_⟩
+      refine ⟨p, q, (AR.link_tensor i j p q).mpr (Or.inl hX₀), ?_, ?_⟩
       · rw [← X.collapseIdx_left m i hX₀.1, hcp, hr]
       · rw [← X.collapseIdx_left m j hX₀.2.1, hcq, hs]
     · obtain ⟨a, b, hY₀, hca, hcb⟩ :=
         (Y.link_collapse m i j (p' - (X.collapse m).tierLength i)
           (q' - (X.collapse m).tierLength j)).mp hY'
       refine ⟨X.tierLength i + a, X.tierLength j + b,
-        (Representation.link_tensor i j _ _).mpr (Or.inr ⟨by omega, by omega, ?_⟩), ?_, ?_⟩
+        (AR.link_tensor i j _ _).mpr (Or.inr ⟨by omega, by omega, ?_⟩), ?_, ?_⟩
       · rw [Nat.add_sub_cancel_left, Nat.add_sub_cancel_left]
         exact hY₀
       · rw [← X.collapseIdx_right m i hY₀.1, hca, Nat.add_sub_cancel' hpi', hr]
@@ -417,43 +299,43 @@ theorem Representation.link_collapse_tensor (i j : ι) (r s : ℕ) :
 /-- **The OCP congruence**: collapsing a concatenation is isomorphic to
     collapsing the concatenation of the collapses — [jardine-heinz-2015]'s
     melody-merge law, by the classification theorem. -/
-noncomputable def Representation.collapseTensorFullIso :
-    MixedGraphCat.Iso ((X ⊗ Y).collapse m).obj
+noncomputable def AR.collapseTensorFullIso :
+    Graph.Iso ((X ⊗ Y).collapse m).obj
       ((X.collapse m ⊗ Y.collapse m).collapse m).obj :=
-  Representation.fullIsoOfReaderEq
+  AR.fullIsoOfReaderEq
     (fun i => by
-      rw [Representation.tierWord_collapse, Representation.tierWord_collapse,
-        Representation.collapsedWord_tensor])
-    (fun i j r s => Representation.link_collapse_tensor X m i j r s)
+      rw [AR.tierWord_collapse, AR.tierWord_collapse,
+        AR.collapsedWord_tensor])
+    (fun i j r s => AR.link_collapse_tensor X m i j r s)
 
 /-- The OCP congruence as an equality of isomorphism classes: `collapse`
     descends to the class monoid. -/
-theorem Representation.cls_collapse_tensor :
-    Representation.cls ((X ⊗ Y).collapse m)
-      = Representation.cls ((X.collapse m ⊗ Y.collapse m).collapse m) :=
-  Quotient.sound ⟨Representation.fullIsoToWideIso (Representation.collapseTensorFullIso X m)⟩
+theorem AR.cls_collapse_tensor :
+    AR.cls ((X ⊗ Y).collapse m)
+      = AR.cls ((X.collapse m ⊗ Y.collapse m).collapse m) :=
+  Quotient.sound ⟨AR.fullIsoToWideIso (AR.collapseTensorFullIso X m)⟩
 
 end Congruence
 
 /-- OCP-cleanliness at melody tier `m`: the tier word has no adjacent
     repeats. -/
-def Representation.IsCleanAt [Finite X.obj.V] : Prop := IsClean (X.tierWord m)
+def AR.IsCleanAt [Finite X.obj.V] : Prop := IsClean (X.tierWord m)
 
 /-- The collapse is OCP-clean at the collapsed tier. -/
-theorem Representation.isCleanAt_collapse [Finite X.obj.V] :
+theorem AR.isCleanAt_collapse [Finite X.obj.V] :
     (X.collapse m).IsCleanAt m := by
-  unfold Representation.IsCleanAt
-  rw [Representation.tierWord_collapse]
-  simpa [Representation.collapsedWord] using collapse_clean (X.tierWord m)
+  unfold AR.IsCleanAt
+  rw [AR.tierWord_collapse]
+  simpa [AR.collapsedWord] using collapse_clean (X.tierWord m)
 
 section RealizeMerged
 variable {S : Type*}
 
 /-- The OCP-merging realization at melody tier `m` — [jardine-2019]'s merging
     `g_T`: realize, then merge the melody runs. -/
-noncomputable def realizeMerged (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+noncomputable def realizeMerged (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     [∀ s, Finite (g₀ s).obj.V] (w : List S) :
-    Representation (Sigma.fst : ((i : ι) × τ i) → ι) :=
+    AR (Sigma.fst : ((i : ι) × τ i) → ι) :=
   (realize g₀ w).collapse m
 
 end RealizeMerged
@@ -464,7 +346,7 @@ omit [DecidableEq ι] [DecidableEq (τ m)]
 
 /-- On a normal form, one position covers another in the arc order iff it is
     its immediate successor. -/
-theorem Representation.covering_normalize [Finite X.obj.V] {i : ι}
+theorem AR.covering_normalize [Finite X.obj.V] {i : ι}
     {p q : Fin (X.tierLength i)} :
     ((X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ∧
         ∀ u, ¬ ((X.normalize).obj.graph.arcs.Adj ⟨i, p⟩ u ∧
@@ -472,64 +354,64 @@ theorem Representation.covering_normalize [Finite X.obj.V] {i : ι}
       (q : ℕ) = p + 1 := by
   constructor
   · rintro ⟨hpq, hcov⟩
-    rw [Representation.arcs_normalize] at hpq
+    rw [AR.arcs_normalize] at hpq
     by_contra hne
     have hmid : (p : ℕ) + 1 < q := by
       have := Fin.lt_def.mp hpq; omega
     have hq := q.isLt
     refine hcov ⟨i, ⟨(p : ℕ) + 1, by omega⟩⟩ ⟨?_, ?_⟩
-    · exact (Representation.arcs_normalize _ _ _).mpr
+    · exact (AR.arcs_normalize _ _ _).mpr
         (show (p : ℕ) < (p : ℕ) + 1 by omega)
-    · exact (Representation.arcs_normalize _ _ _).mpr
+    · exact (AR.arcs_normalize _ _ _).mpr
         (show (p : ℕ) + 1 < (q : ℕ) from hmid)
   · intro hsucc
-    refine ⟨(Representation.arcs_normalize _ _ _).mpr
+    refine ⟨(AR.arcs_normalize _ _ _).mpr
       (show (p : ℕ) < (q : ℕ) by omega), ?_⟩
     rintro ⟨j, u⟩ ⟨h1, h2⟩
     rcases eq_or_ne i j with rfl | hij
-    · rw [Representation.arcs_normalize] at h1 h2
+    · rw [AR.arcs_normalize] at h1 h2
       have := Fin.lt_def.mp h1
       have := Fin.lt_def.mp h2
       omega
-    · exact Representation.arcs_normalize_ne hij p u h1
+    · exact AR.arcs_normalize_ne hij p u h1
 
 /-- Cleanliness fails at a successor pair exactly when its labels repeat. -/
-private theorem Representation.label_normalize_succ [Finite X.obj.V]
+private theorem AR.label_normalize_succ [Finite X.obj.V]
     {p : ℕ} (hp1 : p + 1 < X.tierLength m) (hp : p < X.tierLength m) :
     (X.normalize).obj.label ⟨m, ⟨p, hp⟩⟩ = (X.normalize).obj.label ⟨m, ⟨p + 1, hp1⟩⟩ ↔
       (X.tierWord m)[p]'(by simp; omega) = (X.tierWord m)[p + 1]'(by simp; omega) := by
-  rw [Representation.label_normalize, Representation.label_normalize,
-    ← Representation.tierWord_getElem (p := ⟨p, hp⟩),
-    ← Representation.tierWord_getElem (p := ⟨p + 1, hp1⟩)]
+  rw [AR.label_normalize, AR.label_normalize,
+    ← AR.tierWord_getElem (p := ⟨p, hp⟩),
+    ← AR.tierWord_getElem (p := ⟨p + 1, hp1⟩)]
   exact ⟨fun h => eq_of_heq (Sigma.mk.inj_iff.mp h).2, fun h => congrArg (Sigma.mk m) h⟩
 
 /-- **The OCP bridge**: tier-word cleanliness is Axiom 6 on the normal form —
     the coordinate OCP and [jardine-2016-diss]'s §4.2 axiom agree. -/
-theorem Representation.isCleanAt_iff_isOCPClean [Finite X.obj.V] :
+theorem AR.isCleanAt_iff_isOCPClean [Finite X.obj.V] :
     X.IsCleanAt m ↔
       IsOCPClean (X.normalize).obj.graph (X.normalize).obj.label Sigma.fst m := by
   constructor
   · rintro h ⟨i, p⟩ ⟨j, q⟩ hpq hcov htier heq
     rcases eq_or_ne i j with rfl | hij
     · obtain rfl : m = i := by
-        symm; simpa [Representation.label_normalize] using htier
+        symm; simpa [AR.label_normalize] using htier
       have hsucc : (q : ℕ) = (p : ℕ) + 1 := (X.covering_normalize).mp ⟨hpq, hcov⟩
       have hq1 : (p : ℕ) + 1 < X.tierLength m := hsucc ▸ q.isLt
       rw [show q = ⟨(p : ℕ) + 1, hq1⟩ from Fin.ext hsucc] at heq
       have hp' : (p : ℕ) + 1 < (X.tierWord m).length := by
-        simp only [Representation.length_tierWord]
+        simp only [AR.length_tierWord]
         omega
       exact List.isChain_iff_getElem.mp h p hp'
         ((X.label_normalize_succ m hq1 p.isLt).mp heq)
-    · exact Representation.arcs_normalize_ne hij p q hpq
+    · exact AR.arcs_normalize_ne hij p q hpq
   · intro h
     refine List.isChain_iff_getElem.mpr fun p hp heq => ?_
     have hlen : p + 1 < X.tierLength m := by
-      simpa only [Representation.length_tierWord] using hp
+      simpa only [AR.length_tierWord] using hp
     have hplt : p < X.tierLength m := by omega
     have hcover := (X.covering_normalize
       (p := ⟨p, hplt⟩) (q := ⟨p + 1, hlen⟩) (i := m)).mpr rfl
-    exact h hcover.1 hcover.2 (by simp [Representation.label_normalize])
+    exact h hcover.1 hcover.2 (by simp [AR.label_normalize])
       ((X.label_normalize_succ m hlen hplt).mpr heq)
 
 end Axiom6Bridge

--- a/Linglib/Phonology/OCP.lean
+++ b/Linglib/Phonology/OCP.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Order.Monotone.Basic
 import Linglib.Core.Data.List.Destutter
 
 /-!
@@ -177,5 +178,128 @@ theorem block_isClean {xs : List α} (hx : IsClean xs) : IsClean (block rule xs)
   unfold block; split <;> assumption
 
 end
+
+/-! ### The run-index map -/
+
+section RunIndex
+variable {α : Type*} [DecidableEq α]
+
+/-- **Run index** of upper position `k` in `xs`: the index (0-based) of the
+    OCP-run containing `k`, i.e. one less than the number of runs in the prefix
+    `xs[0..k]`. Concretely `(OCP.collapse (xs.take (k+1))).length - 1`. -/
+def runIdx (xs : List α) (k : ℕ) : ℕ := (collapse (xs.take (k + 1))).length - 1
+
+/-- `runIdx` is monotone: later positions sit in later (or the same) runs. -/
+theorem runIdx_monotone (xs : List α) : Monotone (runIdx xs) := by
+  intro a b hab
+  unfold runIdx
+  have hsub : (collapse (xs.take (a + 1))).Sublist (xs.take (b + 1)) :=
+    (collapse_sublist _).trans (List.take_sublist_take_left (by omega))
+  have hlen := List.IsChain.length_le_length_destutter_ne hsub (collapse_clean _)
+  simp only [collapse_eq_destutter] at hlen ⊢
+  omega
+
+/-- `runIdx` lands inside the collapsed tier: an in-bounds position maps to an
+    in-bounds run index. The upper half of `collapseAR`'s in-bounds proof. -/
+theorem runIdx_lt_collapse_length (xs : List α) {k : ℕ} (hk : k < xs.length) :
+    runIdx xs k < (collapse xs).length := by
+  unfold runIdx
+  have hne : xs.take (k + 1) ≠ [] := by
+    intro h
+    have hlen : (xs.take (k + 1)).length = k + 1 := List.length_take_of_le (by omega)
+    rw [h] at hlen; simp at hlen
+  have hsub : (collapse (xs.take (k + 1))).Sublist xs :=
+    (collapse_sublist _).trans (List.take_sublist _ _)
+  have hlen := List.IsChain.length_le_length_destutter_ne hsub (collapse_clean _)
+  simp only [collapse_eq_destutter] at hlen ⊢
+  have hpos : 0 < ((xs.take (k + 1)).destutter (· ≠ ·)).length := by
+    rw [List.length_pos_iff]
+    intro h
+    rw [← collapse_eq_destutter, collapse_eq_nil] at h
+    exact hne h
+  omega
+
+/-- On a constant tier every position lies in the single run: `runIdx` is `0`. -/
+@[simp] theorem runIdx_replicate (n : ℕ) (a : α) (k : ℕ) :
+    runIdx (List.replicate n a) k = 0 := by
+  unfold runIdx
+  rw [List.take_replicate]
+  cases hm : min (k + 1) n with
+  | zero => simp
+  | succ m => rw [collapse_replicate, List.length_singleton]
+
+/-! ### Run-index and concatenation
+
+The defining property of `concat` for the OCP quotient: `runIdx` commutes with the
+collapse-collapse seam (`runIdx_append_collapse_left/right`). On the A-block the prefix
+run-index is untouched (`runIdx_append_left`, plus `runIdx_clean` re-reading a clean tier
+as the identity); on the B-block the seam merges exactly when `collapse xs` ends in the
+element heading `ys` (`runIdx_append_right`, the AR shadow of
+`List.destutter_append_length_clean`). -/
+
+/-- The prefix run-index is unaffected by a right append. -/
+theorem runIdx_append_left {xs ys : List α} {k : ℕ} (h : k < xs.length) :
+    runIdx (xs ++ ys) k = runIdx xs k := by
+  unfold runIdx; rw [List.take_append_of_le_length (by omega)]
+
+/-- On a clean tier `runIdx` is the identity (no runs to merge). -/
+theorem runIdx_clean {xs : List α} (hc : IsClean xs) {k : ℕ} (h : k < xs.length) :
+    runIdx xs k = k := by
+  unfold runIdx
+  rw [collapse_idempotent_on_clean (hc.take (k + 1)), List.length_take_of_le (by omega)]
+  omega
+
+/-- The length of the collapse of a nonempty prefix is its top run-index plus one. -/
+theorem collapse_take_succ_length {xs : List α} {m : ℕ} (hm : m < xs.length) :
+    (collapse (xs.take (m + 1))).length = runIdx xs m + 1 := by
+  unfold runIdx
+  have hpos : 0 < (collapse (xs.take (m + 1))).length := by
+    rw [List.length_pos_iff]
+    refine fun h => ?_
+    have hne : xs.take (m + 1) ≠ [] := by
+      intro h'
+      have : (xs.take (m + 1)).length = m + 1 := List.length_take_of_le (by omega)
+      rw [h'] at this; simp at this
+    exact hne (collapse_eq_nil.mp h)
+  omega
+
+/-- The collapse of a prefix has the same head as the whole tier. -/
+theorem collapse_take_head? {xs : List α} {m : ℕ} :
+    (collapse (xs.take (m + 1))).head? = xs.head? := by
+  rw [collapse, List.destutter_head?]
+  cases xs <;> simp
+
+/-- **The B-part seam identity.** Reading a suffix position through the collapse of an
+append: the run-index is the left collapse's length plus the suffix's own run-index, minus
+one exactly when the seam merges (`List.destutter_append_length_clean`). -/
+theorem runIdx_append_right {xs ys : List α} {a : ℕ} (ha : a < ys.length) :
+    runIdx (xs ++ ys) (xs.length + a) =
+      (collapse xs).length + runIdx ys a -
+        (if (collapse xs).getLast? = ys.head? then 1 else 0) := by
+  unfold runIdx
+  rw [show xs.length + a + 1 = xs.length + (a + 1) by omega, List.take_length_add_append,
+    collapse_append, collapse_eq_destutter,
+    List.destutter_append_length_clean (collapse_clean _) (collapse_clean _),
+    collapse_take_succ_length ha, collapse_take_head?]
+  split_ifs with h
+  · have : 0 < (collapse ys).length := Nat.zero_lt_of_lt (runIdx_lt_collapse_length ys ha)
+    omega
+  · omega
+
+/-- A-block: a prefix index commutes with the collapse-collapse seam. -/
+theorem runIdx_append_collapse_left {xs ys : List α} {k : ℕ} (h : k < xs.length) :
+    runIdx (xs ++ ys) k = runIdx (collapse xs ++ collapse ys) (runIdx xs k) := by
+  rw [runIdx_append_left h, runIdx_append_left (runIdx_lt_collapse_length xs h),
+    runIdx_clean (collapse_clean _) (runIdx_lt_collapse_length xs h)]
+
+/-- B-block: a suffix index commutes with the collapse-collapse seam. -/
+theorem runIdx_append_collapse_right {xs ys : List α} {a : ℕ} (ha : a < ys.length) :
+    runIdx (xs ++ ys) (xs.length + a) =
+      runIdx (collapse xs ++ collapse ys) ((collapse xs).length + runIdx ys a) := by
+  rw [runIdx_append_right ha, runIdx_append_right (runIdx_lt_collapse_length ys ha),
+    collapse_idempotent, runIdx_clean (collapse_clean _) (runIdx_lt_collapse_length ys ha),
+    collapse_eq_destutter ys, List.destutter_head?]
+
+end RunIndex
 
 end OCP

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Finset.Max
 import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Data.List.TakeDrop
 import Linglib.Core.Computability.Subregular.Function.Bimachine
-import Linglib.Phonology.Autosegmental.Collapse
+import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Autosegmental.Hull
 import Linglib.Phonology.Tone.Basic
@@ -82,11 +82,11 @@ open Autosegmental
 /-- `toAR` in coordinates: the two-tier representation of one association
     state (melody over `true`, timing over `false`). -/
 noncomputable def toRep (a : TBU) :
-    Autosegmental.Representation
+    Autosegmental.AR
       (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
   match a with
-  | .H => Autosegmental.Representation.single _root_.Tone.TRN.H ()
-  | .O => Autosegmental.Representation.bare ()
+  | .H => Autosegmental.AR.single _root_.Tone.TRN.H ()
+  | .O => Autosegmental.AR.bare ()
 
 instance (a : TBU) : Finite (toRep a).obj.V := by
   cases a <;> exact inferInstanceAs (Finite ((_ : Bool) × Fin _))
@@ -97,7 +97,7 @@ instance : DecidableEq (Autosegmental.TwoTier _root_.Tone.TRN Unit true) :=
 /-- The output representation in coordinates: OCP-merge then hull, both at the
     melody tier. -/
 noncomputable def plateauRep (w : List TBU) :
-    Autosegmental.Representation
+    Autosegmental.AR
       (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
   ((Autosegmental.realize toRep w).collapse true).hull true
 
@@ -113,21 +113,21 @@ theorem tierWord_realize_toRep_true (w : List TBU) :
     (Autosegmental.realize toRep w).tierWord true
       = List.replicate (w.count .H) _root_.Tone.TRN.H := by
   induction w with
-  | nil => simp [Autosegmental.Representation.tierWord_unit]
+  | nil => simp [Autosegmental.AR.tierWord_unit]
   | cons a w ih =>
     calc (Autosegmental.realize toRep (a :: w)).tierWord true
         = (toRep a ⊗ Autosegmental.realize toRep w).tierWord true := rfl
       _ = (toRep a).tierWord true ++ (Autosegmental.realize toRep w).tierWord true :=
-          Autosegmental.Representation.tierWord_tensor true
+          Autosegmental.AR.tierWord_tensor true
       _ = List.replicate ((a :: w).count .H) _root_.Tone.TRN.H := by
           rw [ih]
           cases a
           · rw [show (toRep TBU.H).tierWord true = [_root_.Tone.TRN.H] from
-              Autosegmental.Representation.tierWord_ofData true,
+              Autosegmental.AR.tierWord_ofData true,
               List.count_cons_self, List.replicate_succ]
             rfl
           · rw [show (toRep TBU.O).tierWord true = [] from
-              Autosegmental.Representation.tierWord_ofData true,
+              Autosegmental.AR.tierWord_ofData true,
               List.count_cons_of_ne (by decide)]
             rfl
 
@@ -135,20 +135,20 @@ theorem tierWord_realize_toRep_true (w : List TBU) :
 theorem tierWord_realize_toRep_false (w : List TBU) :
     (Autosegmental.realize toRep w).tierWord false = List.replicate w.length () := by
   induction w with
-  | nil => simp [Autosegmental.Representation.tierWord_unit]
+  | nil => simp [Autosegmental.AR.tierWord_unit]
   | cons a w ih =>
     calc (Autosegmental.realize toRep (a :: w)).tierWord false
         = (toRep a ⊗ Autosegmental.realize toRep w).tierWord false := rfl
       _ = (toRep a).tierWord false ++ (Autosegmental.realize toRep w).tierWord false :=
-          Autosegmental.Representation.tierWord_tensor false
+          Autosegmental.AR.tierWord_tensor false
       _ = List.replicate (a :: w).length () := by
           rw [ih, List.length_cons, List.replicate_succ]
           cases a
           · rw [show (toRep TBU.H).tierWord false = [()] from
-              Autosegmental.Representation.tierWord_ofData false]
+              Autosegmental.AR.tierWord_ofData false]
             rfl
           · rw [show (toRep TBU.O).tierWord false = [()] from
-              Autosegmental.Representation.tierWord_ofData false]
+              Autosegmental.AR.tierWord_ofData false]
             rfl
 
 /-- Links of a realized string: slot `j` links to melody node `p` exactly when
@@ -159,9 +159,9 @@ theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
   induction w generalizing p j with
   | nil =>
     have h0 : (Autosegmental.realize toRep []).tierLength true = 0 := by
-      rw [← Autosegmental.Representation.length_tierWord,
+      rw [← Autosegmental.AR.length_tierWord,
         show (Autosegmental.realize toRep []).tierWord true = _ from
-          Autosegmental.Representation.tierWord_unit true, List.length_nil]
+          Autosegmental.AR.tierWord_unit true, List.length_nil]
     constructor
     · rintro ⟨hp, -, -⟩
       omega
@@ -171,21 +171,21 @@ theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
     haveI := Autosegmental.realize.instFinite toRep w
     rw [show (Autosegmental.realize toRep (a :: w)).link true false p j
           = (toRep a ⊗ Autosegmental.realize toRep w).link true false p j from rfl,
-      Autosegmental.Representation.link_tensor (X := toRep a)
+      Autosegmental.AR.link_tensor (X := toRep a)
         (Y := Autosegmental.realize toRep w) true false p j]
     cases a
     · have hta : (toRep TBU.H).tierLength true = 1 := by
-        rw [← Autosegmental.Representation.length_tierWord,
+        rw [← Autosegmental.AR.length_tierWord,
           show (toRep TBU.H).tierWord true = [_root_.Tone.TRN.H] from
-            Autosegmental.Representation.tierWord_ofData true]
+            Autosegmental.AR.tierWord_ofData true]
         rfl
       have hfa : (toRep TBU.H).tierLength false = 1 := by
-        rw [← Autosegmental.Representation.length_tierWord,
+        rw [← Autosegmental.AR.length_tierWord,
           show (toRep TBU.H).tierWord false = [()] from
-            Autosegmental.Representation.tierWord_ofData false]
+            Autosegmental.AR.tierWord_ofData false]
         rfl
       have hj : (toRep TBU.H).link true false p j ↔ p = 0 ∧ j = 0 := by
-        refine (Autosegmental.Representation.link_junction
+        refine (Autosegmental.AR.link_junction
           [_root_.Tone.TRN.H] [()]).trans ?_
         constructor
         · rintro (⟨-, -, h1, h2⟩ | ⟨h, -⟩)
@@ -210,18 +210,18 @@ theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
           rw [this]
           omega
     · have hta : (toRep TBU.O).tierLength true = 0 := by
-        rw [← Autosegmental.Representation.length_tierWord,
+        rw [← Autosegmental.AR.length_tierWord,
           show (toRep TBU.O).tierWord true = [] from
-            Autosegmental.Representation.tierWord_ofData true]
+            Autosegmental.AR.tierWord_ofData true]
         rfl
       have hfa : (toRep TBU.O).tierLength false = 1 := by
-        rw [← Autosegmental.Representation.length_tierWord,
+        rw [← Autosegmental.AR.length_tierWord,
           show (toRep TBU.O).tierWord false = [()] from
-            Autosegmental.Representation.tierWord_ofData false]
+            Autosegmental.AR.tierWord_ofData false]
         rfl
       have hj : ¬ (toRep TBU.O).link true false p j := by
         intro h
-        rcases (Autosegmental.Representation.link_junction
+        rcases (Autosegmental.AR.link_junction
           ([] : List _root_.Tone.TRN) [()]).mp h with ⟨-, -, h1, -⟩ | ⟨h1, -⟩
         · simp at h1
         · exact absurd h1 (by decide)
@@ -253,25 +253,25 @@ theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
     ((Autosegmental.realize toRep w).collapse true).link true false k j ↔
       k = 0 ∧ w[j]? = some .H := by
   haveI := Autosegmental.realize.instFinite toRep w
-  rw [Autosegmental.Representation.link_collapse]
+  rw [Autosegmental.AR.link_collapse]
   constructor
   · rintro ⟨p, q, hl, hk, hjq⟩
     obtain ⟨hp, hq⟩ := (link_realize_toRep w p q).mp hl
     refine ⟨?_, ?_⟩
     · rw [← hk]
-      unfold Autosegmental.Representation.collapseIdx
+      unfold Autosegmental.AR.collapseIdx
       rw [if_pos rfl, tierWord_realize_toRep_true]
-      exact Autosegmental.runIdx_replicate _ _ _
+      exact OCP.runIdx_replicate _ _ _
     · rw [← hjq]
-      unfold Autosegmental.Representation.collapseIdx
+      unfold Autosegmental.AR.collapseIdx
       rw [if_neg (by decide)]
       exact hq
   · rintro ⟨rfl, hj⟩
     refine ⟨(w.take j).count .H, j, (link_realize_toRep w _ j).mpr ⟨rfl, hj⟩, ?_, ?_⟩
-    · unfold Autosegmental.Representation.collapseIdx
+    · unfold Autosegmental.AR.collapseIdx
       rw [if_pos rfl, tierWord_realize_toRep_true]
-      exact Autosegmental.runIdx_replicate _ _ _
-    · unfold Autosegmental.Representation.collapseIdx
+      exact OCP.runIdx_replicate _ _ _
+    · unfold Autosegmental.AR.collapseIdx
       rw [if_neg (by decide)]
 
 /-- **What surfaces is the representation**: slot `j` is H-linked in
@@ -283,8 +283,8 @@ theorem link_plateauRep (w : List TBU) (j : ℕ) :
   haveI := Autosegmental.realize.instFinite toRep w
   have hlen : ((Autosegmental.realize toRep w).collapse true).tierLength false
       = w.length := by
-    rw [← Autosegmental.Representation.length_tierWord,
-      Autosegmental.Representation.tierWord_collapse,
+    rw [← Autosegmental.AR.length_tierWord,
+      Autosegmental.AR.tierWord_collapse,
       show (Autosegmental.realize toRep w).collapsedWord true false
         = (Autosegmental.realize toRep w).tierWord false from
         Function.update_of_ne (by decide) _ _,
@@ -295,14 +295,14 @@ theorem link_plateauRep (w : List TBU) (j : ℕ) :
   · rintro ⟨k, hk⟩
     obtain ⟨-, hjb, -⟩ := id hk
     have hlenh : (plateauRep w).tierLength false = w.length := by
-      rw [← Autosegmental.Representation.length_tierWord,
+      rw [← Autosegmental.AR.length_tierWord,
         show (plateauRep w).tierWord false
           = ((Autosegmental.realize toRep w).collapse true).tierWord false from
-          Autosegmental.Representation.tierWord_hull true _ false,
-        Autosegmental.Representation.length_tierWord, hlen]
+          Autosegmental.AR.tierWord_hull true _ false,
+        Autosegmental.AR.length_tierWord, hlen]
     have hjw : j < w.length := hlenh ▸ hjb
     obtain ⟨q₁, q₂, h₁, h₂, hle₁, hle₂⟩ :=
-      (Autosegmental.Representation.link_hull_left true _ (by decide)
+      (Autosegmental.AR.link_hull_left true _ (by decide)
         (by omega : j < ((Autosegmental.realize toRep w).collapse true).tierLength false)).mp hk
     obtain ⟨-, hq₁⟩ := (link_realizeMerged w k q₁).mp h₁
     obtain ⟨-, hq₂⟩ := (link_realizeMerged w k q₂).mp h₂
@@ -313,7 +313,7 @@ theorem link_plateauRep (w : List TBU) (j : ℕ) :
       exact h
     have hl₁ := (link_realizeMerged w 0 q₁).mpr ⟨rfl, hq₁⟩
     have hl₂ := (link_realizeMerged w 0 q₂).mpr ⟨rfl, hq₂⟩
-    exact ⟨0, (Autosegmental.Representation.link_hull_left true _ (by decide)
+    exact ⟨0, (Autosegmental.AR.link_hull_left true _ (by decide)
       (by omega : j < ((Autosegmental.realize toRep w).collapse true).tierLength false)).mpr
       ⟨q₁, q₂, hl₁, hl₂, by omega, hq₂b⟩⟩
 

--- a/Linglib/Studies/Jardine2016.lean
+++ b/Linglib/Studies/Jardine2016.lean
@@ -39,7 +39,7 @@ abbrev CRep := Rep Seg Seg
 /-- The faithfulness banned subgraph `*[pⁱ↔p]`: a `p` corresponding to a `p`.
     Forbidding it forces an intervocalic `p` to change. -/
 def noPP : CRep :=
-  ⟨Autosegmental.Representation.ofData
+  ⟨Autosegmental.AR.ofData
     (fun b => match b with
       | true => ([Seg.p] : List (Autosegmental.TwoTier Seg Seg true))
       | false => [Seg.p])
@@ -49,7 +49,7 @@ def noPP : CRep :=
 /-- The voicing correspondence `apa ↔ aba`: identity positions, the medial `p`
     corresponding to a `b`. -/
 def gVoice : CRep :=
-  ⟨Autosegmental.Representation.ofData
+  ⟨Autosegmental.AR.ofData
     (fun b => match b with
       | true => ([Seg.a, .p, .a] : List (Autosegmental.TwoTier Seg Seg true))
       | false => [Seg.a, .b, .a])
@@ -58,7 +58,7 @@ def gVoice : CRep :=
 
 /-- The faithful correspondence `apa ↔ apa`: the medial `p` stays `p`. -/
 def gFaithful : CRep :=
-  ⟨Autosegmental.Representation.ofData
+  ⟨Autosegmental.AR.ofData
     (fun b => match b with
       | true => ([Seg.a, .p, .a] : List (Autosegmental.TwoTier Seg Seg true))
       | false => [Seg.a, .p, .a])
@@ -79,7 +79,7 @@ instance : Finite (gFaithful : CRep).val.obj.V :=
 /-- `gVoice` reads input `apa`, output `aba`. -/
 theorem gVoice_io :
     gVoice.input = [Seg.a, .p, .a] ∧ gVoice.output = [Seg.a, .b, .a] :=
-  ⟨Representation.tierWord_ofData true, Representation.tierWord_ofData false⟩
+  ⟨AR.tierWord_ofData true, AR.tierWord_ofData false⟩
 
 /-- The faithful correspondence is **rejected** — it contains a `p↔p`,
     embedded at position 1 of both tiers. -/
@@ -87,25 +87,25 @@ theorem gFaithful_rejected : ¬ specifiedByRep [noPP] gFaithful := by
   intro h
   refine h noPP (List.mem_singleton.mpr rfl) ⟨fun _ => 1, ?_, ?_⟩
   · intro i p hp
-    have hp' : p < (Representation.ofData
+    have hp' : p < (AR.ofData
         (fun b => match b with
           | true => ([Seg.p] : List (Autosegmental.TwoTier Seg Seg true))
           | false => [Seg.p])
         (fun i j p q => i = true ∧ j = false ∧ p = 0 ∧ q = 0)).tierLength i := hp
-    rw [Representation.tierLength_ofData] at hp'
+    rw [AR.tierLength_ofData] at hp'
     have hp0 : p = 0 := by cases i <;> simpa using Nat.lt_one_iff.mp (by simpa using hp')
     subst hp0
     show ((gFaithful : CRep).val.tierWord i)[0 + 1]? = ((noPP : CRep).val.tierWord i)[0]?
     rw [show (gFaithful : CRep).val.tierWord i
-        = _ from Representation.tierWord_ofData i,
-      show (noPP : CRep).val.tierWord i = _ from Representation.tierWord_ofData i]
+        = _ from AR.tierWord_ofData i,
+      show (noPP : CRep).val.tierWord i = _ from AR.tierWord_ofData i]
     cases i <;> rfl
   · intro i j p q hl
-    rcases (Representation.link_ofData i j p q).mp hl with
+    rcases (AR.link_ofData i j p q).mp hl with
       ⟨-, -, -, ⟨rfl, rfl, rfl, rfl⟩ | ⟨rfl, rfl, rfl, rfl⟩⟩
-    · exact (Representation.link_ofData true false 1 1).mpr
+    · exact (AR.link_ofData true false 1 1).mpr
         ⟨by decide, by decide, by decide, Or.inl ⟨rfl, rfl, rfl⟩⟩
-    · exact (Representation.link_ofData false true 1 1).mpr
+    · exact (AR.link_ofData false true 1 1).mpr
         ⟨by decide, by decide, by decide, Or.inr ⟨rfl, rfl, rfl⟩⟩
 
 /-- The voicing correspondence is **admitted** by the `*[p↔p]` grammar: the
@@ -117,28 +117,28 @@ theorem gVoice_specified : specifiedByRep [noPP] gVoice := by
   rintro ⟨o, hw, hl⟩
   have hbt : (0 : ℕ) < (noPP : CRep).val.tierLength true := by
     rw [show (noPP : CRep).val.tierLength true
-      = _ from Representation.tierLength_ofData true]
+      = _ from AR.tierLength_ofData true]
     simp
   have hbf : (0 : ℕ) < (noPP : CRep).val.tierLength false := by
     rw [show (noPP : CRep).val.tierLength false
-      = _ from Representation.tierLength_ofData false]
+      = _ from AR.tierLength_ofData false]
     simp
   have hwt := hw true 0 hbt
   have hwf := hw false 0 hbf
   rw [show (gVoice : CRep).val.tierWord true
-      = _ from Representation.tierWord_ofData true,
+      = _ from AR.tierWord_ofData true,
     show (noPP : CRep).val.tierWord true
-      = _ from Representation.tierWord_ofData true] at hwt
+      = _ from AR.tierWord_ofData true] at hwt
   rw [show (gVoice : CRep).val.tierWord false
-      = _ from Representation.tierWord_ofData false,
+      = _ from AR.tierWord_ofData false,
     show (noPP : CRep).val.tierWord false
-      = _ from Representation.tierWord_ofData false] at hwf
-  have hlink := hl true false 0 0 ((Representation.link_ofData true false 0 0).mpr
+      = _ from AR.tierWord_ofData false] at hwf
+  have hlink := hl true false 0 0 ((AR.link_ofData true false 0 0).mpr
     ⟨by decide, by decide, by decide, Or.inl ⟨rfl, rfl, rfl, rfl⟩⟩)
-  rcases (Representation.link_ofData true false (0 + o true) (0 + o false)).mp hlink with
+  rcases (AR.link_ofData true false (0 + o true) (0 + o false)).mp hlink with
     ⟨-, hpb, hqb, ⟨-, -, hpq⟩ | ⟨h1, -⟩⟩
   · have h3' : o false < 3 := by
-      have := Representation.tierLength_ofData
+      have := AR.tierLength_ofData
         (ws := fun b => match b with
           | true => ([Seg.a, .p, .a] : List (Autosegmental.TwoTier Seg Seg true))
           | false => [Seg.a, .b, .a])

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -8,7 +8,7 @@ import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.LetterSubsequential
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 import Linglib.Core.Computability.Subregular.Function.Hierarchy
-import Linglib.Phonology.Autosegmental.Collapse
+import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Tone.Plateauing

--- a/Linglib/Studies/Jardine2017.lean
+++ b/Linglib/Studies/Jardine2017.lean
@@ -101,7 +101,7 @@ inductive TBU
 /-- An autosegmental representation in Jardine 2017's sense, on the graph
     foundation: tones over TBUs (with implicit precedence by position),
     links as association lines. -/
-abbrev ARep := Autosegmental.Representation
+abbrev ARep := Autosegmental.AR
   (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier Tone TBU b) → Bool)
 
 /-- Link presentations from finite pair lists (melody position, TBU position). -/
@@ -114,7 +114,7 @@ instance (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) :
 
 /-- Build a representation from a tone melody, a TBU string, and links. -/
 abbrev mk (tones : List Tone) (tbus : List TBU) (links : List (ℕ × ℕ)) : ARep :=
-  Autosegmental.Representation.ofData
+  Autosegmental.AR.ofData
     (fun b => match b with
       | true => (tones : List (Autosegmental.TwoTier Tone TBU true))
       | false => tbus)
@@ -133,7 +133,7 @@ theorem mk_embeds_iff {tF tX : List Tone} {bF bX : List TBU}
           | true => (tX : List (Autosegmental.TwoTier Tone TBU true))
           | false => bX)
         (mkL lF) (mkL lX) :=
-  Representation.factorEmbeds_ofData_iff
+  AR.factorEmbeds_ofData_iff
 
 /-! ## §2 Mende: right-edge multiple association
 [jardine-2017] §3.1, eq. (5)

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.ASL
-import Linglib.Phonology.Autosegmental.Collapse
+import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Core.Computability.Subregular.Language.ContainsFactor
 
@@ -63,10 +63,10 @@ variable {ι : Type*} [Finite ι] {τ : ι → Type*}
     contains it form a star-free language: the finite intersection of per-tier
     factor constraints, each the inverse image of a star-free contains-factor
     language along a tier projection. -/
-theorem Representation.isStarFree_occur_of_link_free
-    (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+theorem AR.isStarFree_occur_of_link_free
+    (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     [∀ s, Finite (g₀ s).obj.V]
-    (F : Representation (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite F.obj.V]
+    (F : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite F.obj.V]
     (hF : ∀ i j p q, ¬ F.link i j p q) :
     Language.IsStarFree {w : List S | F.FactorEmbeds (Autosegmental.realize g₀ w)} := by
   have hset : {w : List S | F.FactorEmbeds (Autosegmental.realize g₀ w)}
@@ -74,25 +74,25 @@ theorem Representation.isStarFree_occur_of_link_free
     ext w
     haveI := Autosegmental.realize.instFinite g₀ w
     simp only [Set.mem_setOf_eq, Set.mem_iInter,
-      Representation.factorEmbeds_iff_infix_of_link_free hF, tierProj_ofList]
+      AR.factorEmbeds_iff_infix_of_link_free hF, tierProj_ofList]
     exact Iff.rfl
   rw [hset]
   exact Language.IsStarFree.iInter fun i =>
     (Language.isStarFree_containsFactor (F.tierWord i)).comap (tierProj g₀ i)
 
 /-- **Link-free autosegmental SL sets are star-free**, on the graph foundation:
-    when no forbidden factor carries association lines, `Representation.ASL` is
+    when no forbidden factor carries association lines, `AR.ASL` is
     a Boolean combination of per-tier factor constraints. -/
-theorem Representation.ASL.isStarFree_of_link_free
-    (g₀ : S → Representation (Sigma.fst : ((i : ι) × τ i) → ι))
+theorem AR.ASL.isStarFree_of_link_free
+    (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     [∀ s, Finite (g₀ s).obj.V]
-    (B : List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
+    (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
     (hB : ∀ F ∈ B, haveI := F.property; ∀ i j p q, ¬ F.val.link i j p q) :
-    (Representation.ASL g₀ B).IsStarFree := by
+    (AR.ASL g₀ B).IsStarFree := by
   induction B with
   | nil =>
-    have : Representation.ASL g₀ ([] :
-        List {F : Representation (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
+    have : AR.ASL g₀ ([] :
+        List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
         = Set.univ :=
       Set.eq_univ_of_forall fun w F hF => absurd hF (List.not_mem_nil)
     rw [this]
@@ -100,16 +100,16 @@ theorem Representation.ASL.isStarFree_of_link_free
   | cons F B' ih =>
     have hFl := hB F (List.mem_cons_self ..)
     have ih' := ih fun F' hF' => hB F' (List.mem_cons_of_mem _ hF')
-    have hset : Representation.ASL g₀ (F :: B') =
+    have hset : AR.ASL g₀ (F :: B') =
         {w : List S | haveI := F.property
-          F.val.FactorEmbeds (Autosegmental.realize g₀ w)}ᶜ ∩ Representation.ASL g₀ B' := by
+          F.val.FactorEmbeds (Autosegmental.realize g₀ w)}ᶜ ∩ AR.ASL g₀ B' := by
       ext w
       show (∀ G ∈ F :: B', _) ↔ _
       rw [List.forall_mem_cons]
       exact Iff.rfl
     rw [hset]
     haveI := F.property
-    exact (Representation.isStarFree_occur_of_link_free g₀ F.val hFl).compl.inter ih'
+    exact (AR.isStarFree_occur_of_link_free g₀ F.val hFl).compl.inter ih'
 
 end Coordinate
 
@@ -128,7 +128,7 @@ inductive Mora | μ
   deriving DecidableEq, Repr
 
 /-- Two-tier tone representations (melody over `true`, morae over `false`). -/
-abbrev TRep := Representation
+abbrev TRep := AR
   (Sigma.fst : ((b : Bool) × TwoTier ToneSym Mora b) → Bool)
 
 /-- Link presentations from finite pair lists. -/
@@ -141,7 +141,7 @@ instance (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) :
 
 /-- Build a representation from a tone melody, morae, and links. -/
 abbrev mk (tones : List ToneSym) (moras : List Mora) (links : List (ℕ × ℕ)) : TRep :=
-  Representation.ofData
+  AR.ofData
     (fun b => match b with
       | true => (tones : List (TwoTier ToneSym Mora true))
       | false => moras)
@@ -158,7 +158,7 @@ theorem mk_embeds_iff {tF tX : List ToneSym} {bF bX : List Mora}
           | true => (tX : List (TwoTier ToneSym Mora true))
           | false => bX)
         (mkL lF) (mkL lX) :=
-  Representation.factorEmbeds_ofData_iff
+  AR.factorEmbeds_ofData_iff
 
 /-- The forbidden subgraph `*HLH` ([jardine-2019] (3)): an `H-L-H` tone
     sequence, three tones each on their own mora. -/
@@ -195,7 +195,7 @@ theorem hhlh_excluded :
 /-! ### The OCP-merging realization: non-local tone plateauing
 
 [jardine-2019]'s `g_T` is OCP-*merging*: an `H`-plateau `Hⁿ` fuses to a single
-`H` node (`Representation.collapse`). Against the merged forms we ban the
+`H` node (`AR.collapse`). Against the merged forms we ban the
 **tonal-tier melody** `*HLH` — adjacent tonal nodes, morae unconstrained —
 which is where merging buys non-local power: `H⁺ L⁺ H⁺` is excluded for *any*
 plateau widths, because the plateaus collapse first. -/
@@ -236,11 +236,11 @@ theorem hlhTier_unmerged_admits_plateau :
 
 /-- **The `*HLH` tonal-tier melody set is star-free**: `hlhTier` carries no
     links, so any grammar built from it falls in the link-free fragment
-    (`Representation.ASL.isStarFree_of_link_free`) — a concrete instance of
+    (`AR.ASL.isStarFree_of_link_free`) — a concrete instance of
     [jardine-2019]'s `ASL ⊊ SF` placement. -/
 theorem hlhTier_link_free : ∀ i j p q, ¬ hlhTier.link i j p q := by
   intro i j p q hl
-  rcases (Representation.link_ofData i j p q).mp hl with
+  rcases (AR.link_ofData i j p q).mp hl with
     ⟨-, -, -, ⟨-, -, h⟩ | ⟨-, -, h⟩⟩ <;> exact absurd h (List.not_mem_nil)
 
 end Jardine2019

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -731,7 +731,7 @@ theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind 
 The deepest categorical content: morpheme *prefixation* is not merely a
 function on representations but an **endofunctor on the monoidal
 category** of representations — mathlib's `tensorLeft`. This consumes the
-full `MonoidalCategory (Representation t)` instance (not merely the tensor
+full `MonoidalCategory (AR t)` instance (not merely the tensor
 operation), and the **associativity of prefixation** is the category's
 associator, exhibited by `tensorLeftTensor` — a natural isomorphism
 that does not exist without coherence (pentagon + triangle).
@@ -752,9 +752,9 @@ extensional content (no look-ahead) is fully captured by
 /-- The historic-tense exponent as an object of the monoidal category of
     representations: one floating `(d)` melody node, no skeleton, no links. -/
 def historicExponentRep :
-    Representation (Sigma.fst :
+    AR (Sigma.fst :
       ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) :=
-  Representation.ofData
+  AR.ofData
     (fun b => match b with
       | true => ([mel .dPrime mHist] : List (TwoTier (TierSpec Segment) (SegSpec CVKind) true))
       | false => [])
@@ -767,9 +767,9 @@ open CategoryTheory MonoidalCategory in
     than right-tensoring encodes the morpheme's directionality as a
     preverbal particle. -/
 def withHistFunctor :
-    Representation (Sigma.fst :
+    AR (Sigma.fst :
         ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) ⥤
-    Representation (Sigma.fst :
+    AR (Sigma.fst :
         ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) :=
   tensorLeft historicExponentRep
 
@@ -777,7 +777,7 @@ open CategoryTheory MonoidalCategory in
 /-- The functor's action on objects *is* morpheme prefixing: the tensor of
     the exponent with the stem. -/
 theorem withHistFunctor_obj
-    (X : Representation (Sigma.fst :
+    (X : AR (Sigma.fst :
         ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool)) :
     withHistFunctor.obj X = historicExponentRep ⊗ X := rfl
 
@@ -789,7 +789,7 @@ open CategoryTheory MonoidalCategory in
     triangle). It is the concrete artifact that makes the monoidal coherence
     load-bearing rather than decorative. -/
 noncomputable def prefixAssoc
-    (X : Representation (Sigma.fst :
+    (X : AR (Sigma.fst :
         ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool)) :
     tensorLeft (historicExponentRep ⊗ X) ≅
       tensorLeft X ⋙ tensorLeft historicExponentRep :=
@@ -805,11 +805,11 @@ association lines to the leftmost (word-initial) skeletal slot.
 
 The answer is a sharp dichotomy. `delinkInitial` is **not** a functor on
 the full category `AR α β`: a label-preserving reindexing
-(a broad `MixedGraphCat.Hom`) can move a non-initial element into initial position, after
+(a broad `Graph.Hom`) can move a non-initial element into initial position, after
 which there is *no* morphism between the delinked images at all
 (`delinkInitial_not_functorial`). But over the precedence-preserving wide subcategory, the
 **precedence-preserving wide subcategory** (the foundation's
-`Representation.precPreserving`), it lifts to a genuine endofunctor `delinkInitialFunctor`
+`AR.precPreserving`), it lifts to a genuine endofunctor `delinkInitialFunctor`
 (built from `delinkInitial_map` / `_id` / `_comp`; precedence-preservation
 discharges the reflects-initial-slot hypothesis via
 `precPreserving.reflects_zero`). This is the categorical content of the
@@ -822,22 +822,22 @@ open Autosegmental
 
 /-- Lenition's structural model on the foundation: erase the association
     lines at the word-initial (tier-initial) skeletal position —
-    `MixedGraphCat.delinkMin`. Its functoriality over precedence-preserving
+    `Graph.delinkMin`. Its functoriality over precedence-preserving
     morphisms is the substrate theorem `Autosegmental.delinkMinFunctor`;
     here we exhibit the **negative half**: on the broad category the lift
     fails, because a label-preserving reindexing can move a non-initial
     slot into initial position. -/
 private abbrev negA :
-    Representation (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
-  Representation.ofData
+    AR (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
+  AR.ofData
     (fun b => match b with
       | true => ([()] : List (TwoTier Unit Bool true))
       | false => [false, true])
     (fun i j p q => i = true ∧ j = false ∧ p = 0 ∧ q = 1)
 
 private abbrev negB :
-    Representation (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
-  Representation.ofData
+    AR (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
+  AR.ofData
     (fun b => match b with
       | true => ([()] : List (TwoTier Unit Bool true))
       | false => [true, false])
@@ -845,7 +845,7 @@ private abbrev negB :
 
 /-- The label-preserving swap of the two skeletal slots: a broad morphism
     (it does not preserve precedence). -/
-private def negSwap : MixedGraphCat.Hom negA.obj negB.obj where
+private def negSwap : Graph.Hom negA.obj negB.obj where
   toFun v := match v with
     | ⟨true, p⟩ => ⟨true, p⟩
     | ⟨false, ⟨0, _⟩⟩ => ⟨false, ⟨1, by decide⟩⟩
@@ -873,13 +873,13 @@ private def negSwap : MixedGraphCat.Hom negA.obj negB.obj where
     delinking erased. The obstruction is precisely failure to preserve
     precedence (`Autosegmental.delinkMinFunctor` lifts it otherwise). -/
 theorem delinkInitial_not_functorial :
-    IsEmpty (MixedGraphCat.Hom
-      (MixedGraphCat.delinkMin Sigma.fst false negA.obj)
-      (MixedGraphCat.delinkMin Sigma.fst false negB.obj)) := by
+    IsEmpty (Graph.Hom
+      (Graph.delinkMin Sigma.fst false negA.obj)
+      (Graph.delinkMin Sigma.fst false negB.obj)) := by
   refine ⟨fun g => ?_⟩
   let v1 : negA.obj.V := ⟨true, ⟨0, by decide⟩⟩
   let w1 : negA.obj.V := ⟨false, ⟨1, by decide⟩⟩
-  have hsurv : (MixedGraphCat.delinkMin Sigma.fst false negA.obj).graph.edges.Adj v1 w1 := by
+  have hsurv : (Graph.delinkMin Sigma.fst false negA.obj).graph.edges.Adj v1 w1 := by
     refine ⟨⟨by decide, Or.inl ⟨rfl, rfl, rfl, rfl⟩⟩, ?_, ?_⟩
     · rintro ⟨h, -⟩
       exact absurd h (by decide)

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -178,8 +178,8 @@ instance (i j : Fin 4) (p q : ℕ) : Decidable (laalSpokes i j p q) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- The M-toned form on the graph foundation. -/
-def mForm : Representation (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :=
-  Representation.ofData laalWords laalSpokes
+def mForm : AR (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :=
+  AR.ofData laalWords laalSpokes
 
 instance : Fintype mForm.obj.V :=
   inferInstanceAs (Fintype ((_ : Fin 4) × Fin _))
@@ -203,8 +203,8 @@ def delink (L : Fin 4 → Fin 4 → ℕ → ℕ → Prop) (i₀ j₀ : Fin 4)
   ¬ (i = i₀ ∧ j = j₀) ∧ L i j p q
 
 /-- The M form with the subtonal `[−raised]` feature delinked. -/
-def delinkRaised : Representation (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :=
-  Representation.ofData laalWords (delink laalSpokes 1 2)
+def delinkRaised : AR (Sigma.fst : ((i : Fin 4) × laalTier i) → Fin 4) :=
+  AR.ofData laalWords (delink laalSpokes 1 2)
 
 /-- Delinking the subtonal `[−raised]` feature leaves the **whole-TRN** layer
     (TRN↔mora, tier-pair `(2, 3)`) untouched: partial activity is independent
@@ -217,13 +217,13 @@ instance : Finite delinkRaised.obj.V := inferInstanceAs (Finite ((_ : Fin 4) × 
 theorem partial_indep_of_full (p q : ℕ) :
     delinkRaised.link 2 3 p q ↔ mForm.link 2 3 p q := by
   unfold delinkRaised mForm
-  rw [Representation.link_ofData, Representation.link_ofData]
+  rw [AR.link_ofData, AR.link_ofData]
   simp [delink, laalSpokes]
 
 /-- And it does remove the `[raised]`↔TRN association. -/
 theorem delinkRaised_erases (p q : ℕ) : ¬ delinkRaised.link 1 2 p q := by
   unfold delinkRaised
-  rw [Representation.link_ofData]
+  rw [AR.link_ofData]
   rintro ⟨-, -, -, ⟨hne, -⟩ | ⟨-, h2, -⟩⟩
   · exact hne ⟨rfl, rfl⟩
   · rcases h2 with h2 | h2 | h2 <;> simp_all


### PR DESCRIPTION
Executes the recorded end-state naming: MixedGraphCat → Autosegmental.Graph (Jardine's GR(Γ), the 'henceforth graph'), Representation → Autosegmental.AR (the literature's type name), MixedGraph.lean → Graph.lean, Collapse.lean → OCP.lean with the runIdx list machinery demoted to Phonology/OCP.lean. Full-library build verified locally.