### PR TITLE
refactor(Phonology/Autosegmental): split Graph/AR + demote delinkMin

### DIFF
--- a/Linglib/Phonology/Autosegmental/Graph.lean
+++ b/Linglib/Phonology/Autosegmental/Graph.lean
@@ -30,7 +30,7 @@ out of the raw graphs relative to it.
   the §4.2 axioms (1–2, 3, 4, 5, 6; [jardine-heinz-2015] numbers the NCC and OCP
   as 4 and 5 and has no saturation axiom) as predicates on a `MixedGraph` and, for
   tier-relative axioms, a vertex coloring `c : V → ι`. Saturation is stated but
-  not imposed, as in `AR.lean`; tier-orderedness includes path-closure
+  not imposed; tier-orderedness includes path-closure
   (`MixedGraph.PrecPath`), [jardine-2019]'s reading that `A` represents the order.
 * `Graph S`: the labeled mixed graph ([jardine-2019]'s `GR(Γ)`) and the
   category thereof, with `HasInitial` and `HasBinaryCoproducts`;
@@ -68,8 +68,10 @@ remark). The choice is not free elsewhere: subgraph-based notions such as
 
 ## TODO
 
-* The normal-form equivalence with the strict tuple presentation, with
-  `IsPlanar` reducing to the per-pair NCC on normal forms.
+* Package `AR.ofData` and `AR.isoOfReaderEq` (`NormalForm.lean`) as a
+  `CategoryTheory.Equivalence` between the strict tuple category and the
+  finite representations, and reduce `IsPlanar` on normal forms to the
+  per-pair `IsNonCrossing` of the link relation.
 -/
 
 namespace Autosegmental
@@ -99,7 +101,7 @@ def NoInternalAssoc : Prop := ∀ ⦃v w⦄, G.edges.Adj v w → ¬ G.arcs.Adj v
 
 /-- Axiom 4 (full specification): every vertex participates in an association.
     [goldsmith-1976]'s original well-formedness condition; stated but deliberately
-    not imposed — floating elements are well-formed, as in `AR.lean`. -/
+    not imposed — floating elements are well-formed. -/
 def IsSaturated : Prop := ∀ v, ∃ w, G.edges.Adj v w
 
 /-- Axiom 5, the No-Crossing Constraint in [jardine-2016-diss]'s general path
@@ -545,25 +547,6 @@ theorem Graph.Hom.concatMap_precPreserving (t : S → ι)
   · exact h.elim
   · exact hg h
 
-/-- A vertex with no arc-predecessor: the tier-initial position. -/
-def Graph.NoPred (X : Graph S) (v : X.V) : Prop :=
-  ∀ u, ¬ X.graph.arcs.Adj u v
-
-/-- Erase every association line incident to a tier-`i₀`-initial vertex — the
-    graph model of an initial-position delinking process (e.g. lenition
-    targeting the word-initial slot). Arcs and labels are untouched. -/
-def Graph.delinkMin (t : S → ι) (i₀ : ι) (X : Graph S) :
-    Graph S where
-  V := X.V
-  graph :=
-    { edges :=
-        { Adj := fun v w => X.graph.edges.Adj v w ∧
-            ¬ (X.tier t v = i₀ ∧ X.NoPred v) ∧ ¬ (X.tier t w = i₀ ∧ X.NoPred w)
-          symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.2, h.2.1⟩⟩
-          loopless := ⟨fun v h => X.graph.edges.loopless.irrefl v h.1⟩ }
-      arcs := X.graph.arcs }
-  label := X.label
-
 /-! ### The category of autosegmental representations -/
 
 variable (t : S → ι)
@@ -681,50 +664,6 @@ instance : (precPreserving (t := t)).IsMonoidalStable where
   leftUnitor_inv_mem A := (Graph.emptyConcatIso t A.obj).symm.toHom_precPreserving
   rightUnitor_hom_mem A := (Graph.concatEmptyIso t A.obj).toHom_precPreserving
   rightUnitor_inv_mem A := (Graph.concatEmptyIso t A.obj).symm.toHom_precPreserving
-
-/-- Delinking preserves the structural axioms: arcs are untouched and the
-    edge set shrinks. -/
-def delinkMinRep (i₀ : ι) (X : AR t) : AR t :=
-  ⟨Graph.delinkMin t i₀ X.obj,
-    ⟨X.property.1.tier_eq, X.property.1.total, X.property.1.irrefl, X.property.1.trans⟩,
-    fun _ _ hadj harc => X.property.2 hadj.1 harc⟩
-
-open CategoryTheory in
-/-- **Initial-position delinking is an endofunctor of the precedence-preserving
-    wide subcategory**: an arc-preserving morphism transports tier-initiality
-    for free (an arc into `v` maps to an arc into `f v`), so the delinked edge
-    conditions carry over. On the broad category the lift fails — a
-    label-preserving reindexing can move a non-initial vertex into initial
-    position (`Studies/LaoideKemp2026`'s counterexample). -/
-def delinkMinFunctor (i₀ : ι) :
-    WideSubcategory (AR.precPreserving (t := t)) ⥤
-      WideSubcategory (AR.precPreserving (t := t)) where
-  obj X := ⟨delinkMinRep i₀ X.obj⟩
-  map {X Y} f :=
-    ⟨InducedCategory.homMk
-      { toFun := f.hom.hom.toFun
-        edge_map := by
-          rintro v w ⟨hadj, hv, hw⟩
-          refine ⟨f.hom.hom.edge_map hadj, ?_, ?_⟩
-          · rintro ⟨htier, hmin⟩
-            refine hv ⟨?_, fun u hu => hmin (f.hom.hom.toFun u) (f.property hu)⟩
-            rw [show X.obj.obj.tier t v = Y.obj.obj.tier t (f.hom.hom.toFun v) from
-              (congrArg t (f.hom.hom.label_comp v)).symm]
-            exact htier
-          · rintro ⟨htier, hmin⟩
-            refine hw ⟨?_, fun u hu => hmin (f.hom.hom.toFun u) (f.property hu)⟩
-            rw [show X.obj.obj.tier t w = Y.obj.obj.tier t (f.hom.hom.toFun w) from
-              (congrArg t (f.hom.hom.label_comp w)).symm]
-            exact htier
-        label_comp := f.hom.hom.label_comp }, f.property⟩
-  map_id X := by
-    apply WideSubcategory.hom_ext
-    apply InducedCategory.hom_ext
-    rfl
-  map_comp f g := by
-    apply WideSubcategory.hom_ext
-    apply InducedCategory.hom_ext
-    rfl
 
 end AR
 

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -743,8 +743,8 @@ as a preverbal particle rather than a suffix.
 The remaining Layer-2 frontier — modelling *lenition* and *docking*
 themselves as endofunctors of the representation category (acting on morphisms, not just
 objects) — is left open. The conjecture is that they are functorial
-only over the precedence-preserving `Graph.SubgraphEmbeds`, not over
-all broad morphisms; `delinkMinFunctor` settles the lenition case. The
+only over precedence-preserving morphisms, not over all broad ones;
+`delinkInitialFunctor` settles the lenition case. The
 extensional content (no look-ahead) is fully captured by
 `dPrimeSurfaces_withHist_concat_right` above: for any suffix, whether
 `(d)` surfaces depends only on the stem's left edge. -/
@@ -804,15 +804,14 @@ objects. At the graph level, lenition is `delinkInitial`: erase the
 association lines to the leftmost (word-initial) skeletal slot.
 
 The answer is a sharp dichotomy. `delinkInitial` is **not** a functor on
-the full category `AR α β`: a label-preserving reindexing
+the broad category: a label-preserving reindexing
 (a broad `Graph.Hom`) can move a non-initial element into initial position, after
 which there is *no* morphism between the delinked images at all
-(`delinkInitial_not_functorial`). But over the precedence-preserving wide subcategory, the
-**precedence-preserving wide subcategory** (the foundation's
-`AR.precPreserving`), it lifts to a genuine endofunctor `delinkInitialFunctor`
-(built from `delinkInitial_map` / `_id` / `_comp`; precedence-preservation
-discharges the reflects-initial-slot hypothesis via
-`precPreserving.reflects_zero`). This is the categorical content of the
+(`delinkInitial_not_functorial`). But over the **precedence-preserving wide
+subcategory** (the foundation's `AR.precPreserving`), it lifts to a genuine
+endofunctor `delinkInitialFunctor`: an arc-preserving morphism transports
+tier-initiality for free — an arc into `v` maps to an arc into `f v` — so the
+delinked edge conditions carry over. This is the categorical content of the
 linguistic fact that lenition targets the *word-initial* consonant: the
 process is functorial over exactly the maps that preserve precedence. -/
 
@@ -820,13 +819,70 @@ section Frontier
 
 open Autosegmental
 
-/-- Lenition's structural model on the foundation: erase the association
-    lines at the word-initial (tier-initial) skeletal position —
-    `Graph.delinkMin`. Its functoriality over precedence-preserving
-    morphisms is the substrate theorem `Autosegmental.delinkMinFunctor`;
-    here we exhibit the **negative half**: on the broad category the lift
-    fails, because a label-preserving reindexing can move a non-initial
-    slot into initial position. -/
+/-- A vertex with no arc-predecessor: the tier-initial position. -/
+def NoPred {S : Type*} (X : Graph S) (v : X.V) : Prop :=
+  ∀ u, ¬ X.graph.arcs.Adj u v
+
+/-- Erase every association line incident to a tier-`i₀`-initial vertex — the
+    graph model of the paper's initial-position delinking (lenition targeting
+    the word-initial slot). Arcs and labels are untouched. -/
+def delinkInitial {S ι : Type*} (t : S → ι) (i₀ : ι) (X : Graph S) : Graph S where
+  V := X.V
+  graph :=
+    { edges :=
+        { Adj := fun v w => X.graph.edges.Adj v w ∧
+            ¬ (X.tier t v = i₀ ∧ NoPred X v) ∧ ¬ (X.tier t w = i₀ ∧ NoPred X w)
+          symm := ⟨fun _ _ h => ⟨h.1.symm, h.2.2, h.2.1⟩⟩
+          loopless := ⟨fun v h => X.graph.edges.loopless.irrefl v h.1⟩ }
+      arcs := X.graph.arcs }
+  label := X.label
+
+/-- Delinking preserves the structural axioms: arcs are untouched and the
+    edge set shrinks. -/
+def delinkInitialRep {S ι : Type*} {t : S → ι} (i₀ : ι) (X : AR t) : AR t :=
+  ⟨delinkInitial t i₀ X.obj,
+    ⟨X.property.1.tier_eq, X.property.1.total, X.property.1.irrefl, X.property.1.trans⟩,
+    fun _ _ hadj harc => X.property.2 hadj.1 harc⟩
+
+open CategoryTheory in
+/-- **Initial-position delinking is an endofunctor of the precedence-preserving
+    wide subcategory**: an arc-preserving morphism transports tier-initiality
+    for free (an arc into `v` maps to an arc into `f v`), so the delinked edge
+    conditions carry over. On the broad category the lift fails
+    (`delinkInitial_not_functorial` below). -/
+def delinkInitialFunctor {S ι : Type*} {t : S → ι} (i₀ : ι) :
+    WideSubcategory (AR.precPreserving (t := t)) ⥤
+      WideSubcategory (AR.precPreserving (t := t)) where
+  obj X := ⟨delinkInitialRep i₀ X.obj⟩
+  map {X Y} f :=
+    ⟨InducedCategory.homMk
+      { toFun := f.hom.hom.toFun
+        edge_map := by
+          rintro v w ⟨hadj, hv, hw⟩
+          refine ⟨f.hom.hom.edge_map hadj, ?_, ?_⟩
+          · rintro ⟨htier, hmin⟩
+            refine hv ⟨?_, fun u hu => hmin (f.hom.hom.toFun u) (f.property hu)⟩
+            rw [show X.obj.obj.tier t v = Y.obj.obj.tier t (f.hom.hom.toFun v) from
+              (congrArg t (f.hom.hom.label_comp v)).symm]
+            exact htier
+          · rintro ⟨htier, hmin⟩
+            refine hw ⟨?_, fun u hu => hmin (f.hom.hom.toFun u) (f.property hu)⟩
+            rw [show X.obj.obj.tier t w = Y.obj.obj.tier t (f.hom.hom.toFun w) from
+              (congrArg t (f.hom.hom.label_comp w)).symm]
+            exact htier
+        label_comp := f.hom.hom.label_comp }, f.property⟩
+  map_id X := by
+    apply WideSubcategory.hom_ext
+    apply InducedCategory.hom_ext
+    rfl
+  map_comp f g := by
+    apply WideSubcategory.hom_ext
+    apply InducedCategory.hom_ext
+    rfl
+
+/-- The **negative half** of the dichotomy needs a witness: on the broad
+    category the lift fails, because a label-preserving reindexing can move a
+    non-initial slot into initial position. -/
 private abbrev negA :
     AR (Sigma.fst : ((b : Bool) × TwoTier Unit Bool b) → Bool) :=
   AR.ofData
@@ -871,15 +927,15 @@ private def negSwap : Graph.Hom negA.obj negB.obj where
     morphism, yet the delinked images admit no morphism at all — the
     surviving slot-1 link of `negA` lands on `negB`'s initial slot, which
     delinking erased. The obstruction is precisely failure to preserve
-    precedence (`Autosegmental.delinkMinFunctor` lifts it otherwise). -/
+    precedence (`delinkInitialFunctor` lifts it otherwise). -/
 theorem delinkInitial_not_functorial :
     IsEmpty (Graph.Hom
-      (Graph.delinkMin Sigma.fst false negA.obj)
-      (Graph.delinkMin Sigma.fst false negB.obj)) := by
+      (delinkInitial Sigma.fst false negA.obj)
+      (delinkInitial Sigma.fst false negB.obj)) := by
   refine ⟨fun g => ?_⟩
   let v1 : negA.obj.V := ⟨true, ⟨0, by decide⟩⟩
   let w1 : negA.obj.V := ⟨false, ⟨1, by decide⟩⟩
-  have hsurv : (Graph.delinkMin Sigma.fst false negA.obj).graph.edges.Adj v1 w1 := by
+  have hsurv : (delinkInitial Sigma.fst false negA.obj).graph.edges.Adj v1 w1 := by
     refine ⟨⟨by decide, Or.inl ⟨rfl, rfl, rfl, rfl⟩⟩, ?_, ?_⟩
     · rintro ⟨h, -⟩
       exact absurd h (by decide)


### PR DESCRIPTION
Post-audit Graph.lean reorganization: the file interleaved two stories (ambient category vs axiom class), stating the §4.2 axioms 450 lines before the object they define.

- New `AR.lean` — one file per first-order object, per the end-state design: §4.2 axioms + accessors, axiom-preservation lemmas, `not_isTierOrdered_sum`, `isRepresentation`/`AR`, monoidal + wide-subcategory tower. `Graph.lean` keeps the ambient story and sheds the Monoidal/FullSubcategory/Widesubcategory imports.
- Single-consumer delinking cluster demoted into `Studies/LaoideKemp2026` §11.5 as `delinkInitial*`, truthing its phantom references; Graph.lean TODO refreshed, dead `AR.lean` cross-refs dropped.
- Post-#1405 rename line-wrap re-flow; Linglib.lean Autosegmental block alphabetized.