### PR TITLE
style(Phonology/Autosegmental): drop redundant axioms header

### DIFF
--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -53,8 +53,6 @@ namespace Autosegmental
 
 variable {V S ι : Type*}
 
-/-! ### The §4.2 axioms -/
-
 section Axioms
 variable (E : SimpleGraph V) (A : Digraph V)
 


### PR DESCRIPTION
The module docstring's opening sentence already introduces exactly this block; the remaining three section headers still delimit the file.