### PR TITLE
refactor(Phonology/Autosegmental): IsTierOrdered extends IsStrictOrder

### DIFF
--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -6,7 +6,6 @@ Authors: Robert Hawkins
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 import Mathlib.CategoryTheory.Monoidal.Widesubcategory
-import Mathlib.Logic.Relation
 import Linglib.Phonology.Autosegmental.Graph
 
 /-!
@@ -61,15 +60,11 @@ section Axioms
 variable (E : SimpleGraph V) (A : Digraph V)
 
 /-- The arcs `A` are tier-internal and strictly totally order each fiber of `c` (Axioms 1–2). -/
-structure IsTierOrdered (c : V → ι) : Prop where
+structure IsTierOrdered (c : V → ι) : Prop extends IsStrictOrder V A.Adj where
   /-- Arcs never leave a tier. -/
   tier_eq : ∀ ⦃v w⦄, A.Adj v w → c v = c w
   /-- Distinct same-tier vertices are arc-comparable. -/
   total : ∀ ⦃v w⦄, v ≠ w → c v = c w → A.Adj v w ∨ A.Adj w v
-  /-- No vertex precedes itself. -/
-  irrefl : ∀ v, ¬ A.Adj v v
-  /-- Arcs compose. -/
-  trans : ∀ ⦃u v w⦄, A.Adj u v → A.Adj v w → A.Adj u w
 
 /-- No association edge links arc-related vertices (Axiom 3). -/
 def NoInternalAssoc : Prop := ∀ ⦃v w⦄, E.Adj v w → ¬ A.Adj v w
@@ -87,24 +82,6 @@ def IsOCPClean (ℓ : V → S) (t : S → ι) (m : ι) : Prop :=
 
 end Axioms
 
-variable {A : Digraph V} {c : V → ι}
-
-/-- On the axiom class, precedence paths — the transitive closure of the
-    arcs — coincide with the arcs: the dissertation's `≺`. -/
-theorem IsTierOrdered.transGen_eq (h : IsTierOrdered A c) :
-    Relation.TransGen A.Adj = A.Adj :=
-  haveI : IsTrans V A.Adj := ⟨h.trans⟩
-  Relation.transGen_eq_self
-
-/-- The classed form of the axioms: on each tier the arcs are a strict total
-    order. Feeds `linearOrderOfSTO` for sorting the fibers. -/
-theorem IsTierOrdered.isStrictTotalOrder (h : IsTierOrdered A c) (i : ι) :
-    IsStrictTotalOrder {v // c v = i} (A.Adj · ·) where
-  trichotomous a b hab hba :=
-    Subtype.ext <| of_not_not fun hne => (h.total hne (a.2.trans b.2.symm)).elim hab hba
-  irrefl a := h.irrefl a
-  trans _ _ _ hab hbc := h.trans hab hbc
-
 /-! ### Axiom preservation under the graph operations -/
 
 namespace Graph
@@ -112,53 +89,40 @@ namespace Graph
 variable {X Y : Graph S}
 
 theorem isTierOrdered_empty (t : S → ι) : IsTierOrdered (empty S).arcs ((empty S).tier t) :=
-  ⟨fun v => v.elim, fun v => v.elim, fun v => v.elim, fun v => v.elim⟩
+  { irrefl := (·.elim), trans := (·.elim), tier_eq := (·.elim), total := (·.elim) }
 
-theorem noInternalAssoc_empty : NoInternalAssoc (empty S).edges (empty S).arcs :=
-  fun v => v.elim
+theorem noInternalAssoc_empty : NoInternalAssoc (empty S).edges (empty S).arcs := (·.elim)
 
 section Concat
 variable (t : S → ι)
 
-/-- Concatenation preserves Axioms 1–2; transitivity through the seam holds
-    because arcs are tier-internal. -/
+/-- Concatenation preserves Axioms 1–2; seam transitivity holds because arcs are
+    tier-internal. -/
 theorem isTierOrdered_concat
     (h₁ : IsTierOrdered X.arcs (X.tier t)) (h₂ : IsTierOrdered Y.arcs (Y.tier t)) :
-    IsTierOrdered (concat t X Y).arcs ((concat t X Y).tier t) := by
-  refine ⟨?_, ?_, ?_, ?_⟩
-  · rintro (v | v) (w | w) h
-    exacts [h₁.tier_eq h, h, h.elim, h₂.tier_eq h]
-  · rintro (v | v) (w | w) hne htier
-    · rcases h₁.total (by rintro rfl; exact hne rfl) htier with hp | hp
-      exacts [Or.inl hp, Or.inr hp]
-    · exact Or.inl htier
-    · exact Or.inr htier.symm
-    · rcases h₂.total (by rintro rfl; exact hne rfl) htier with hp | hp
-      exacts [Or.inl hp, Or.inr hp]
-  · rintro (v | v) h
-    exacts [h₁.irrefl v h, h₂.irrefl v h]
-  · rintro (u | u) (v | v) (w | w) huv hvw <;>
-      first
-        | exact h₁.trans huv hvw
-        | exact h₂.trans huv hvw
-        | exact (h₁.tier_eq huv).trans hvw
-        | exact huv.trans (h₂.tier_eq hvw)
-        | exact (huv : False).elim
-        | exact (hvw : False).elim
+    IsTierOrdered (concat t X Y).arcs ((concat t X Y).tier t) where
+  tier_eq := by rintro (v | v) (w | w) h; exacts [h₁.tier_eq h, h, h.elim, h₂.tier_eq h]
+  total := by
+    rintro (v | v) (w | w) hne htier
+    exacts [h₁.total (Sum.inl_injective.ne_iff.mp hne) htier, Or.inl htier,
+      Or.inr htier.symm, h₂.total (Sum.inr_injective.ne_iff.mp hne) htier]
+  irrefl := by rintro (v | v) h; exacts [h₁.irrefl v h, h₂.irrefl v h]
+  trans := by
+    rintro (u | u) (v | v) (w | w) huv hvw
+    exacts [h₁.trans _ _ _ huv hvw, (h₁.tier_eq huv).trans hvw, (hvw : False).elim,
+      huv.trans (h₂.tier_eq hvw), (huv : False).elim, (huv : False).elim,
+      (hvw : False).elim, h₂.trans _ _ _ huv hvw]
 
-/-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross
-    edges. -/
+/-- Concatenation preserves Axiom 3: the disjoint edge sum adds no cross edges. -/
 theorem noInternalAssoc_concat (h₁ : NoInternalAssoc X.edges X.arcs)
     (h₂ : NoInternalAssoc Y.edges Y.arcs) :
     NoInternalAssoc (concat t X Y).edges (concat t X Y).arcs := by
   rintro (v | v) (w | w) hadj harc
   exacts [h₁ hadj harc, absurd hadj (by simp), absurd hadj (by simp), h₂ hadj harc]
 
-/-- Concatenation preserves the No-Crossing Constraint ([jardine-2019]'s
-    headline [jardine-heinz-2015] result): plain factor planarity suffices.
-    Association edges are blockwise, so a straddle needs both edges in one block —
-    reducing to the factor's `IsPlanar` — or one per block, where the required
-    return arc runs `inr → inl` and does not exist. -/
+/-- Concatenation preserves the No-Crossing Constraint ([jardine-2019]'s headline
+    [jardine-heinz-2015] result): factor planarity suffices — a straddle needs both
+    edges in one block, or a return arc `inr → inl` that does not exist. -/
 theorem isPlanar_concat (h₁ : IsPlanar X.edges X.arcs) (h₂ : IsPlanar Y.edges Y.arcs) :
     IsPlanar (concat t X Y).edges (concat t X Y).arcs := by
   rintro (v | v) (v' | v') (w | w) (w' | w') hvv' hww' hvw hw'v' <;>
@@ -197,7 +161,7 @@ abbrev AR (t : S → ι) :=
 
 namespace AR
 
-open MonoidalCategory
+open Graph MonoidalCategory
 
 variable {t : S → ι}
 
@@ -233,22 +197,20 @@ universe u₁ u₂ u₃
     representation as unit; the axiom class is closed under both by
     `isTierOrdered_concat`/`noInternalAssoc_concat`. Universes pinned so the
     unit's vertex type shares the objects' universe — autobinding would split
-    the instance head into an unusable `max`. -/
+    the instance head into an unusable `max`; `@[simps]` feeds the tensor
+    rewrites in `NormalForm.lean`. -/
 @[simps] instance instMonoidalStruct {S : Type u₁} {ι : Type u₂} {t : S → ι} :
     MonoidalCategoryStruct (AR.{u₁, u₂, u₃} t) where
   tensorObj X Y :=
-    ⟨Graph.concat t X.obj Y.obj,
-      Graph.isTierOrdered_concat t X.property.1 Y.property.1,
-      Graph.noInternalAssoc_concat t X.property.2 Y.property.2⟩
-  tensorUnit :=
-    ⟨Graph.empty S, Graph.isTierOrdered_empty t,
-      Graph.noInternalAssoc_empty⟩
-  tensorHom f g := InducedCategory.homMk (Graph.Hom.concatMap t f.hom g.hom)
-  whiskerLeft X _ _ f := InducedCategory.homMk (Graph.Hom.concatMap t (Graph.Hom.id X.obj) f.hom)
-  whiskerRight f Y := InducedCategory.homMk (Graph.Hom.concatMap t f.hom (Graph.Hom.id Y.obj))
-  associator X Y Z := mkIso (Graph.concatAssocIso t X.obj Y.obj Z.obj)
-  leftUnitor X := mkIso (Graph.emptyConcatIso t X.obj)
-  rightUnitor X := mkIso (Graph.concatEmptyIso t X.obj)
+    ⟨concat t X.obj Y.obj, isTierOrdered_concat t X.property.1 Y.property.1,
+      noInternalAssoc_concat t X.property.2 Y.property.2⟩
+  tensorUnit := ⟨empty S, isTierOrdered_empty t, noInternalAssoc_empty⟩
+  tensorHom f g := InducedCategory.homMk (Hom.concatMap t f.hom g.hom)
+  whiskerLeft X _ _ f := InducedCategory.homMk (Hom.concatMap t (Hom.id X.obj) f.hom)
+  whiskerRight f Y := InducedCategory.homMk (Hom.concatMap t f.hom (Hom.id Y.obj))
+  associator X Y Z := mkIso (concatAssocIso t X.obj Y.obj Z.obj)
+  leftUnitor X := mkIso (emptyConcatIso t X.obj)
+  rightUnitor X := mkIso (concatEmptyIso t X.obj)
 
 /-- The category of autosegmental representations is monoidal under morpheme
     concatenation — [jardine-heinz-2015] Theorems 1 and 3 packaged as coherence,

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -83,8 +83,7 @@ def IsPlanar : Prop :=
 
 /-- Precedence-adjacent vertices on melody tier `m` bear distinct labels (Axiom 6, the OCP). -/
 def IsOCPClean (ℓ : V → S) (t : S → ι) (m : ι) : Prop :=
-  ∀ ⦃v w⦄, A.Adj v w → (∀ u, ¬ (A.Adj v u ∧ A.Adj u w)) →
-    t (ℓ v) = m → ℓ v ≠ ℓ w
+  ∀ ⦃v w⦄, A.Adj v w → (∀ u, ¬ (A.Adj v u ∧ A.Adj u w)) → t (ℓ v) = m → ℓ v ≠ ℓ w
 
 end Axioms
 

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -28,6 +28,10 @@ category of autosegmental representations, monoidal under `Graph.concat`.
   includes path-closure — the arcs are transitively closed, [jardine-2019]'s
   reading that `A` represents the order; the OCP reads adjacency as the covering
   relation of the arcs, since order-closed arcs relate all comparable pairs.
+  Axiom 6's word-level form is `AR.IsCleanAt`, bridged by
+  `AR.isCleanAt_iff_isOCPClean` (`OCP.lean`) through the shared hub
+  `OCP.IsClean`; connecting Axiom 5 to the coordinate `IsNonCrossing`
+  (`NonCrossing.lean`) is the TODO below.
 * `AR t`: the category of autosegmental representations — the full
   subcategory of labeled mixed graphs on Axioms 1–3, monoidal under `concat`.
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -19,7 +19,7 @@ import Linglib.Phonology.Autosegmental.AR
 Every finite representation is isomorphic to its **normal form**: the same
 representation reindexed onto the canonical vertex type `(i : ι) × Fin nᵢ`,
 each tier fiber enumerated in ascending precedence order
-(`IsTierOrdered.isStrictTotalOrder` → `linearOrderOfSTO` → `monoEquivOfFin`).
+(the fiber `IsStrictTotalOrder` instance → `linearOrderOfSTO` → `monoEquivOfFin`).
 The normal form is a `AR` — not a separate carrier — and
 `normalizeIso` is definitional: `normalize` pulls the graph back along the
 enumeration equivalence.
@@ -137,8 +137,11 @@ instance AR.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
 /-- The arcs restricted to a tier fiber form a strict total order — the classed
     form of Axioms 1–2 applied to the tier coloring `Sigma.fst`. -/
 instance AR.fiber.instIsStrictTotalOrder (i : ι) :
-    IsStrictTotalOrder (X.fiber i) (fun a b => X.obj.arcs.Adj a.val b.val) :=
-  X.property.1.isStrictTotalOrder i
+    IsStrictTotalOrder (X.fiber i) (fun a b => X.obj.arcs.Adj a.val b.val) where
+  trichotomous a b hab hba := Subtype.ext <| of_not_not fun hne =>
+    (X.property.1.total hne (a.2.trans b.2.symm)).elim hab hba
+  irrefl a := X.property.1.irrefl a.1
+  trans _ _ _ hab hbc := X.property.1.trans _ _ _ hab hbc
 
 /-- Classical linear order on the fiber, from `IsStrictTotalOrder` via
     `linearOrderOfSTO`. -/
@@ -201,10 +204,11 @@ noncomputable def AR.normalize
       arcs := ⟨fun v w => X.obj.arcs.Adj (X.vertexEquiv v) (X.vertexEquiv w)⟩
       label := fun v => X.obj.label (X.vertexEquiv v) }
   property :=
-    ⟨⟨fun _ _ h => X.property.1.tier_eq h,
-      fun _ _ hne htier => X.property.1.total (fun hv => hne (X.vertexEquiv.injective hv)) htier,
-      fun _ h => X.property.1.irrefl _ h,
-      fun _ _ _ huv hvw => X.property.1.trans huv hvw⟩,
+    ⟨{ irrefl := fun _ h => X.property.1.irrefl _ h,
+       trans := fun _ _ _ huv hvw => X.property.1.trans _ _ _ huv hvw,
+       tier_eq := fun _ _ h => X.property.1.tier_eq h,
+       total := fun _ _ hne htier =>
+         X.property.1.total (fun hv => hne (X.vertexEquiv.injective hv)) htier },
      fun _ _ hadj harc => X.property.2 hadj harc⟩
 
 /-- The normal form is fully isomorphic to the original — definitionally,
@@ -814,8 +818,10 @@ def AR.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop)
       arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩
       label := fun v => ⟨v.1, (ws v.1)[v.2]⟩ }
   property := by
-    refine ⟨⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => lt_irrefl _ h.2,
-      fun u v w huv hvw => ⟨huv.1.trans hvw.1, huv.2.trans hvw.2⟩⟩,
+    refine ⟨{ irrefl := fun v h => lt_irrefl _ h.2,
+              trans := fun u v w huv hvw => ⟨huv.1.trans hvw.1, huv.2.trans hvw.2⟩,
+              tier_eq := fun v w h => h.1,
+              total := fun v w hne htier => ?_ },
       fun v w hadj harc => hadj.1 harc.1⟩
     obtain ⟨i, p⟩ := v
     obtain ⟨j, q⟩ := w

--- a/Linglib/Phonology/Autosegmental/OCP.lean
+++ b/Linglib/Phonology/Autosegmental/OCP.lean
@@ -109,8 +109,11 @@ noncomputable def AR.collapse [Finite X.obj.V] :
       arcs := ⟨fun v w => v.1 = w.1 ∧ (v.2 : ℕ) < (w.2 : ℕ)⟩
       label := fun v => ⟨v.1, (X.collapsedWord m v.1)[v.2]⟩ }
   property := by
-    refine ⟨⟨fun v w h => h.1, fun v w hne htier => ?_, fun v h => lt_irrefl _ h.2,
-      fun u v w huv hvw => ⟨huv.1.trans hvw.1, huv.2.trans hvw.2⟩⟩, fun v w hadj harc => ?_⟩
+    refine ⟨{ irrefl := fun v h => lt_irrefl _ h.2,
+              trans := fun u v w huv hvw => ⟨huv.1.trans hvw.1, huv.2.trans hvw.2⟩,
+              tier_eq := fun v w h => h.1,
+              total := fun v w hne htier => ?_ },
+      fun v w hadj harc => ?_⟩
     · obtain ⟨i, p⟩ := v
       obtain ⟨j, q⟩ := w
       obtain rfl : i = j := htier

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -839,9 +839,7 @@ def delinkInitial {S ι : Type*} (t : S → ι) (i₀ : ι) (X : Graph S) : Grap
 /-- Delinking preserves the structural axioms: arcs are untouched and the
     edge set shrinks. -/
 def delinkInitialRep {S ι : Type*} {t : S → ι} (i₀ : ι) (X : AR t) : AR t :=
-  ⟨delinkInitial t i₀ X.obj,
-    ⟨X.property.1.tier_eq, X.property.1.total, X.property.1.irrefl, X.property.1.trans⟩,
-    fun _ _ hadj harc => X.property.2 hadj.1 harc⟩
+  ⟨delinkInitial t i₀ X.obj, X.property.1, fun _ _ hadj harc => X.property.2 hadj.1 harc⟩
 
 open CategoryTheory in
 /-- **Initial-position delinking is an endofunctor of the precedence-preserving


### PR DESCRIPTION
AR.lean section review (re-lands the batch stranded by #1409's early merge), externally mathlib-reviewed:

- `IsTierOrdered` extends `IsStrictOrder V A.Adj` (the IsStrictTotalOrder pattern); zero-consumer `transGen_eq` deleted, single-consumer fiber STO inlined at its NormalForm consumer; preservation proofs compressed to rintro + positional `exacts` (grind and aesop_cat autoparams verified unable to split sum vertices behind projections).
- Module doc points Axiom 6 at the `OCP.IsClean` hub and Axiom 5 at the `IsNonCrossing` TODO; `IsOCPClean` body one-lined.
- Monoidal block compacted via `open Graph`; `@[simps]` verified load-bearing for NormalForm's tensor rewrites and documented as such.