### PR TITLE
refactor(Phonology/Autosegmental): split review fixes + TieredAR

### DIFF
--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -30,7 +30,7 @@ are lists of forbidden factors.
 namespace Autosegmental
 
 variable {ι : Type*} {τ : ι → Type*}
-variable (F X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (F X : TieredAR ι τ)
 
 /-- `F` occurs in `X` at per-tier offsets `o`: each tier word of `F` is the
     window of `X`'s at `o i`, and `F`'s links transport shifted. -/
@@ -48,7 +48,7 @@ def AR.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
     already forces the bound; empty factor tiers accept any offset, so `min`
     clamps them harmlessly. -/
 theorem AR.factorEmbeds_iff_bounded
-    {F X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    {F X : TieredAR ι τ}
     [Finite F.obj.V] [Finite X.obj.V] :
     F.FactorEmbeds X ↔
       ∃ o : ι → ℕ, (∀ i, o i ≤ X.tierLength i) ∧ F.IsFactorAt X o := by
@@ -93,14 +93,14 @@ theorem AR.factorEmbeds_iff_bounded
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
     ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
 def AR.Free [Finite X.obj.V]
-    (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
+    (B : List {F : TieredAR ι τ // Finite F.obj.V}) :
     Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
 
 /-- For a link-free factor, embedding reduces to independent per-tier infix
     occurrences ([jardine-2019]'s link-free fragment). -/
 theorem AR.factorEmbeds_iff_infix_of_link_free
-    {F X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    {F X : TieredAR ι τ}
     [Finite F.obj.V] [Finite X.obj.V]
     (hF : ∀ i j p q, ¬ F.link i j p q) :
     F.FactorEmbeds X ↔ ∀ i, F.tierWord i <:+: X.tierWord i := by

--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -38,7 +38,7 @@ def AR.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
   (∀ i p, p < F.tierLength i → (X.tierWord i)[p + o i]? = (F.tierWord i)[p]?) ∧
     ∀ i j p q, F.link i j p q → X.link i j (p + o i) (q + o j)
 
-/-- `F` **subgraph-embeds** in `X` when some offsets place it as a factor
+/-- `F` subgraph-embeds in `X` when some offsets place it as a factor
     ([jardine-2017]'s connected-subgraph embedding). -/
 def AR.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
   ∃ o : ι → ℕ, F.IsFactorAt X o

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -34,12 +34,12 @@ variable {α β : Type*}
 section CoordinateHull
 
 variable {ι : Type*} [Finite ι] {τ : ι → Type*}
-variable (m : ι) (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V]
+variable (m : ι) (X : TieredAR ι τ) [Finite X.obj.V]
 
 /-- Close each tier-`m` node's association set to its interval hull on each
     other tier. -/
 noncomputable def AR.hull :
-    AR (Sigma.fst : ((i : ι) × τ i) → ι) :=
+    TieredAR ι τ :=
   AR.ofData (fun i => X.tierWord i)
     (fun i j p q =>
       (i = m ∧ ∃ q₁ q₂, X.link i j p q₁ ∧ X.link i j p q₂ ∧ q₁ ≤ q ∧ q ≤ q₂) ∨

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -48,10 +48,7 @@ variable {ι : Type*} {τ : ι → Type*}
 section NormalForm
 open scoped Classical
 
-/-- Fiber of the tier coloring at `i`: vertices of `X.obj` labelled to tier `i`.
-    Under `IsTierOrdered` its arcs form a strict total order, and under
-    `Finite X.obj.V` it is finite — the two ingredients `monoEquivOfFin`
-    needs to enumerate the fiber as `Fin _`. -/
+/-- The vertices of `X.obj` labelled to tier `i`. -/
 def AR.fiber (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) (i : ι) :
     Type _ := {v : X.obj.V // (X.obj.label v).1 = i}
 
@@ -74,8 +71,7 @@ theorem AR.label_fiber {i : ι} (v : X.fiber i) :
 instance AR.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
   Subtype.finite
 
-/-- The arcs restricted to a tier fiber form a strict total order — the classed
-    form of Axioms 1–2 applied to the tier coloring `Sigma.fst`. -/
+/-- The arcs restricted to a tier fiber form a strict total order. -/
 instance AR.fiber.instIsStrictTotalOrder (i : ι) :
     IsStrictTotalOrder (X.fiber i) (fun a b => X.obj.arcs.Adj a.val b.val) where
   trichotomous a b hab hba := Subtype.ext <| of_not_not fun hne =>
@@ -151,8 +147,7 @@ noncomputable def AR.normalize
          X.property.1.total (fun hv => hne (X.vertexEquiv.injective hv)) htier },
      fun _ _ hadj harc => X.property.2 hadj harc⟩
 
-/-- The normal form is fully isomorphic to the original — definitionally,
-    since `normalize` is a pullback along `vertexEquiv`. -/
+/-- The normal form is fully isomorphic to the original. -/
 noncomputable def AR.normalizeFullIso [Finite X.obj.V] :
     Graph.Iso (X.normalize).obj X.obj where
   toEquiv := X.vertexEquiv
@@ -164,15 +159,12 @@ noncomputable def AR.normalizeFullIso [Finite X.obj.V] :
 noncomputable def AR.normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
   AR.mkIso X.normalizeFullIso
 
-/-- On normal forms the edges are exactly `linkRel` — with `arcs_normalize`,
-    the complete tuple reading of the normal form. -/
+/-- On normal forms the edges are exactly `linkRel`. -/
 theorem AR.edges_normalize [Finite X.obj.V] (i j : ι)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
     (X.normalize).obj.edges.Adj ⟨i, p⟩ ⟨j, q⟩ ↔ X.linkRel i j p q := Iff.rfl
 
-/-- On normal forms the arcs are the ascending position order — the
-    classification content: [jardine-heinz-2015]'s tiered presentation
-    recovered as a theorem. -/
+/-- On normal forms the arcs are the ascending position order. -/
 theorem AR.arcs_normalize [Finite X.obj.V] (i : ι)
     (p q : Fin (X.tierLength i)) :
     (X.normalize).obj.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ↔ p < q :=
@@ -287,10 +279,7 @@ theorem AR.tierWord_eq_ofFn {Z : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
   rw [Subsingleton.elim e (Z.fiberEnum i)]
   rfl
 
-/-- **Concatenation appends tier content**: the tier word of a tensor is the
-    factors' tier words in sequence — the tuple presentation of
-    [jardine-heinz-2015]'s Definition 2, recovered as a theorem about normal
-    forms. -/
+/-- The tier word of a tensor is the concatenation of the factors' tier words. -/
 @[simp] theorem AR.tierWord_tensor (i : ι) :
     (X ⊗ Y).tierWord i = X.tierWord i ++ Y.tierWord i := by
   rw [AR.tierWord_eq_ofFn (AR.tensorEnum i), List.ofFn_add]
@@ -370,8 +359,7 @@ def AR.link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
 
 open scoped Classical in
 /-- The two-tier reading of tiers `i` over `j`: each tier-`j` position's label
-    with the tier-`i` labels linked to it, in ascending order — the phonetic
-    interpretation of a melody tier over its backbone. -/
+    paired with its linked tier-`i` labels in ascending order. -/
 noncomputable def AR.linearize [Finite X.obj.V] (i j : ι) :
     List (τ j × List (τ i)) :=
   (X.tierWord j).zipIdx.map fun bq =>
@@ -481,8 +469,7 @@ theorem AR.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
   obtain ⟨hp, hq, hl⟩ := h
   exact ⟨hq, hp, hl.symm⟩
 
-/-- Same-tier vertices are never linked: they are arc-comparable (Axioms 1–2),
-    and association never follows arcs (Axiom 3). -/
+/-- Same-tier vertices are never linked. -/
 theorem AR.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
     ¬ X.link i i p q := by
   rintro ⟨hp, hq, hl⟩
@@ -493,8 +480,7 @@ theorem AR.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
     rw [AR.label_vertexEquiv, AR.label_vertexEquiv]
   exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
 
-/-- The classification isomorphism, as a full-structure `Graph.Iso` —
-    the form that descends to the class monoid. -/
+/-- The classification isomorphism as a full-structure `Graph.Iso`. -/
 noncomputable def AR.fullIsoOfReaderEq
     {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite A.obj.V] [Finite B.obj.V]
@@ -532,8 +518,8 @@ noncomputable def AR.fullIsoOfReaderEq
     rw [← AR.tierWord_getElem, ← AR.tierWord_getElem]
     simp only [hw, Fin.val_cast]
 
-/-- **Classification of finite representations**: equal tier words and equal
-    links give an isomorphism — the tuple reading is a complete invariant. -/
+/-- Finite representations with equal tier words and equal links are isomorphic;
+    the tuple reading is a complete invariant. -/
 noncomputable def AR.isoOfReaderEq
     {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [Finite A.obj.V] [Finite B.obj.V]

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -45,14 +45,18 @@ open CategoryTheory
 
 variable {ι : Type*} {τ : ι → Type*}
 
+/-- Representations over the sigma alphabet `(i : ι) × τ i` with its native tier
+    projection `Sigma.fst` — the coordinate carrier of the normal-form theory. -/
+abbrev TieredAR (ι : Type*) (τ : ι → Type*) := AR (Sigma.fst : ((i : ι) × τ i) → ι)
+
 section NormalForm
 open scoped Classical
 
 /-- The vertices of `X.obj` labelled to tier `i`. -/
-def AR.fiber (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) (i : ι) :
+def AR.fiber (X : TieredAR ι τ) (i : ι) :
     Type _ := {v : X.obj.V // (X.obj.label v).1 = i}
 
-variable {X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {X : TieredAR ι τ}
 
 /-- The `τ i` component of a fiber element, extracted from the labeling by
     transporting along the fiber's tier-membership witness. -/
@@ -87,7 +91,7 @@ noncomputable instance AR.fiber.instLinearOrder (i : ι) :
   exact linearOrderOfSTO (fun a b : X.fiber i => X.obj.arcs.Adj a.val b.val)
 
 /-- The number of tier-`i` vertices. -/
-noncomputable def AR.tierLength (X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
+noncomputable def AR.tierLength (X : TieredAR ι τ)
     [Finite X.obj.V] (i : ι) : ℕ :=
   letI := Fintype.ofFinite (X.fiber i)
   Fintype.card (X.fiber i)
@@ -132,8 +136,8 @@ theorem AR.linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
     edges, arcs, and labels back along `vertexEquiv`. A `AR` — the
     normal form is not a separate kind of object. -/
 noncomputable def AR.normalize
-    (X : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite X.obj.V] :
-    AR (Sigma.fst : ((i : ι) × τ i) → ι) where
+    (X : TieredAR ι τ) [Finite X.obj.V] :
+    TieredAR ι τ where
   obj :=
     { V := (i : ι) × Fin (X.tierLength i)
       edges := X.obj.edges.comap X.vertexEquiv
@@ -184,7 +188,7 @@ section TierWordTensor
 open scoped MonoidalCategory
 
 variable {ι : Type*} {τ : ι → Type*}
-variable {X Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {X Y : TieredAR ι τ}
 
 instance [Finite X.obj.V] [Finite Y.obj.V] : Finite ((X ⊗ Y).obj.V) :=
   inferInstanceAs (Finite (X.obj.V ⊕ Y.obj.V))
@@ -270,7 +274,7 @@ theorem AR.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
       (.inr w)) = Y.fiberLabel w := rfl
 
 /-- Any monotone enumeration computes the tier word. -/
-theorem AR.tierWord_eq_ofFn {Z : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.tierWord_eq_ofFn {Z : TieredAR ι τ}
     [Finite Z.obj.V] {i : ι} {n : ℕ} (e : Fin n ≃o Z.fiber i) :
     Z.tierWord i = List.ofFn fun p => Z.fiberLabel (e p) := by
   have hn : Z.tierLength i = n := by
@@ -329,12 +333,12 @@ theorem AR.vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
     AR.tensorEnum_apply_natAdd]
   rfl
 
-instance : Finite ((𝟙_ (AR (Sigma.fst : ((i : ι) × τ i) → ι))).obj.V) :=
+instance : Finite ((𝟙_ (TieredAR ι τ)).obj.V) :=
   inferInstanceAs (Finite PEmpty)
 
 @[simp] theorem AR.tierWord_unit (i : ι) :
-    (𝟙_ (AR (Sigma.fst : ((i : ι) × τ i) → ι))).tierWord i = [] := by
-  haveI : IsEmpty ((𝟙_ (AR (Sigma.fst : ((i : ι) × τ i) → ι))).fiber i) :=
+    (𝟙_ (TieredAR ι τ)).tierWord i = [] := by
+  haveI : IsEmpty ((𝟙_ (TieredAR ι τ)).fiber i) :=
     ⟨fun v => v.val.elim⟩
   rw [AR.tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
   exact List.ofFn_zero
@@ -350,7 +354,7 @@ is the blockwise companion of `tierWord_tensor`. -/
 section LinkReader
 
 variable {ι : Type*} {τ : ι → Type*}
-variable (X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (X : TieredAR ι τ)
 
 /-- Tier-`i` position `p` links to tier-`j` position `q`, in ℕ coordinates
     (out-of-bounds positions link to nothing). -/
@@ -367,7 +371,7 @@ noncomputable def AR.linearize [Finite X.obj.V] (i j : ι) :
 
 /-- Link conditions are supported on the factor's tier ranges. -/
 theorem AR.forall_link_iff_bounded
-    {F : AR (Sigma.fst : ((i : ι) × τ i) → ι)} [Finite F.obj.V]
+    {F : TieredAR ι τ} [Finite F.obj.V]
     {C : ι → ι → ℕ → ℕ → Prop} :
     (∀ i j p q, F.link i j p q → C i j p q) ↔
       ∀ i j, ∀ p < F.tierLength i, ∀ q < F.tierLength j,
@@ -379,7 +383,7 @@ theorem AR.forall_link_iff_bounded
 open scoped MonoidalCategory in
 /-- Tensor links are blockwise: within the left factor, or within the right
     factor shifted by the left factor's tier lengths — no cross-factor links. -/
-theorem AR.link_tensor {X Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.link_tensor {X Y : TieredAR ι τ}
     [Finite X.obj.V] [Finite Y.obj.V] (i j : ι) (p q : ℕ) :
     (X ⊗ Y).link i j p q ↔
       X.link i j p q ∨ X.tierLength i ≤ p ∧ X.tierLength j ≤ q ∧
@@ -431,7 +435,7 @@ section Classification
 open scoped MonoidalCategory
 
 variable {ι : Type*} {τ : ι → Type*}
-variable {X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {X : TieredAR ι τ}
 
 /-- The label of a canonical vertex sits on its own tier. -/
 theorem AR.label_vertexEquiv [Finite X.obj.V] (i : ι)
@@ -482,7 +486,7 @@ theorem AR.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
 
 /-- The classification isomorphism as a full-structure `Graph.Iso`. -/
 noncomputable def AR.fullIsoOfReaderEq
-    {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    {A B : TieredAR ι τ}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
     (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) :
@@ -521,7 +525,7 @@ noncomputable def AR.fullIsoOfReaderEq
 /-- Finite representations with equal tier words and equal links are isomorphic;
     the tuple reading is a complete invariant. -/
 noncomputable def AR.isoOfReaderEq
-    {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    {A B : TieredAR ι τ}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
     (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) : A ≅ B :=
@@ -545,7 +549,7 @@ variable {ι : Type*} {τ : ι → Type*}
     ignored, and same-tier links are excluded by construction). Arcs are the
     ascending position order on each tier. -/
 def AR.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop) :
-    AR (Sigma.fst : ((i : ι) × τ i) → ι) where
+    TieredAR ι τ where
   obj :=
     { V := (i : ι) × Fin (ws i).length
       edges :=

--- a/Linglib/Phonology/Autosegmental/OCP.lean
+++ b/Linglib/Phonology/Autosegmental/OCP.lean
@@ -75,7 +75,7 @@ open CategoryTheory
 open scoped MonoidalCategory
 
 variable {ι : Type*} [DecidableEq ι] {τ : ι → Type*}
-variable (X : AR (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (X : TieredAR ι τ)
 variable (m : ι) [DecidableEq (τ m)]
 
 /-- Tier words after collapsing melody tier `m`: destuttered at `m`, untouched
@@ -96,7 +96,7 @@ noncomputable def AR.collapseIdx [Finite X.obj.V] (i : ι) (p : ℕ) : ℕ :=
 /-- **The OCP-merging collapse**: melody tier `m` destuttered, links repointed
     through `runIdx`, other tiers untouched. -/
 noncomputable def AR.collapse [Finite X.obj.V] :
-    AR (Sigma.fst : ((i : ι) × τ i) → ι) where
+    TieredAR ι τ where
   obj :=
     { V := (i : ι) × Fin (X.collapsedWord m i).length
       edges :=
@@ -162,7 +162,7 @@ noncomputable def AR.collapseFiberEnum [Finite X.obj.V] (i : ι) :
     tier words as collapsing the tensor of the collapsed factors —
     `OCP.collapse_append` lifted through the readers. -/
 theorem AR.collapsedWord_tensor
-    {Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    {Y : TieredAR ι τ}
     [Finite X.obj.V] [Finite Y.obj.V] (i : ι) :
     (X ⊗ Y).collapsedWord m i = (X.collapse m ⊗ Y.collapse m).collapsedWord m i := by
   rcases eq_or_ne i m with rfl | h
@@ -230,7 +230,7 @@ theorem AR.tierLength_collapse [Finite X.obj.V] (i : ι) :
   rw [← AR.length_tierWord, AR.tierWord_collapse]
 
 section Congruence
-variable {Y : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+variable {Y : TieredAR ι τ}
 variable [Finite X.obj.V] [Finite Y.obj.V]
 
 /-- Left-block positions commute with the collapse-collapse seam. -/
@@ -335,9 +335,9 @@ variable {S : Type*}
 
 /-- The OCP-merging realization at melody tier `m` — [jardine-2019]'s merging
     `g_T`: realize, then merge the melody runs. -/
-noncomputable def realizeMerged (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
+noncomputable def realizeMerged (g₀ : S → TieredAR ι τ)
     [∀ s, Finite (g₀ s).obj.V] (w : List S) :
-    AR (Sigma.fst : ((i : ι) × τ i) → ι) :=
+    TieredAR ι τ :=
   (realize g₀ w).collapse m
 
 end RealizeMerged

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -46,25 +46,25 @@ abbrev PrecAR (ι : Type*) (τ : ι → Type*) :=
 
 /-- A full isomorphism is an isomorphism of the precedence-preserving category;
     both directions preserve arcs. -/
-noncomputable def AR.fullIsoToWideIso {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+noncomputable def AR.fullIsoToWideIso {A B : TieredAR ι τ}
     (e : Graph.Iso A.obj B.obj) : (⟨A⟩ : PrecAR ι τ) ≅ ⟨B⟩ :=
   CategoryTheory.isoMk (AR.mkIso e) e.toHom_precPreserving e.symm.toHom_precPreserving
 
 /-- The class of a representation, its isomorphism class in the skeleton of the
     precedence-preserving category. -/
 noncomputable def AR.cls
-    (A : AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    (A : TieredAR ι τ) :
     Skeleton (PrecAR ι τ) :=
   toSkeleton ⟨A⟩
 
 /-- Concatenation of classes is the class of the tensor. -/
 theorem AR.cls_tensor
-    (A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
+    (A B : TieredAR ι τ) :
     AR.cls (A ⊗ B) = AR.cls A * AR.cls B :=
   CategoryTheory.Skeleton.toSkeleton_tensorObj (⟨A⟩ : PrecAR ι τ) ⟨B⟩
 
 /-- Normal forms represent their class. -/
-theorem AR.cls_normalize {X : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+theorem AR.cls_normalize {X : TieredAR ι τ}
     [Finite X.obj.V] : AR.cls (X.normalize) = AR.cls X :=
   Quotient.sound ⟨AR.fullIsoToWideIso X.normalizeFullIso⟩
 
@@ -79,14 +79,14 @@ variable {S : Type*}
 
 /-- Realize a string as a representation: the iterated tensor of its symbols'
     primitives ([jardine-2019]'s `g`). -/
-noncomputable def realize (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
-    (w : List S) : AR (Sigma.fst : ((i : ι) × τ i) → ι) :=
+noncomputable def realize (g₀ : S → TieredAR ι τ)
+    (w : List S) : TieredAR ι τ :=
   (w.map g₀).foldr (· ⊗ ·) (𝟙_ _)
 
-@[simp] theorem realize_nil (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
+@[simp] theorem realize_nil (g₀ : S → TieredAR ι τ) :
     realize g₀ [] = 𝟙_ _ := rfl
 
-@[simp] theorem realize_cons (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
+@[simp] theorem realize_cons (g₀ : S → TieredAR ι τ)
     (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
 
 end Realize
@@ -97,7 +97,7 @@ section RealizeTierWord
 open scoped MonoidalCategory
 
 variable {S : Type*}
-variable (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
+variable (g₀ : S → TieredAR ι τ)
 
 instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
     Finite (realize g₀ w).obj.V := by

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -20,8 +20,8 @@ arcs and is too coarse to preserve tier words.
 
 * `PrecAR`, `AR.cls`: representations with the classical precedence-preserving
   morphisms, and the monoid of their isomorphism classes.
-* `realize`, `realizeHom`, `tierProj`: the realization as iterated tensor, as a
-  free-monoid homomorphism into the class monoid, and its per-tier projections.
+* `realize`, `tierProj`: the realization as iterated tensor, and its per-tier
+  projections as free-monoid homomorphisms.
 
 ## Main results
 
@@ -44,21 +44,14 @@ open scoped MonoidalCategory
 abbrev PrecAR (ι : Type*) (τ : ι → Type*) :=
   WideSubcategory (AR.precPreserving (t := (Sigma.fst : ((i : ι) × τ i) → ι)))
 
-/-- A full isomorphism is an isomorphism of the precedence-preserving
-    category: both directions preserve arcs. -/
-noncomputable def AR.fullIsoToWideIso
-    {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
-    (e : Graph.Iso A.obj B.obj) :
-    (⟨A⟩ : PrecAR ι τ) ≅ ⟨B⟩ where
-  hom := ⟨InducedCategory.homMk e.toHom, e.toHom_precPreserving⟩
-  inv := ⟨InducedCategory.homMk e.symm.toHom, e.symm.toHom_precPreserving⟩
-  hom_inv_id := InducedWideCategory.Hom.ext (InducedCategory.hom_ext
-    (Graph.Hom.ext (funext fun v => e.toEquiv.symm_apply_apply v)))
-  inv_hom_id := InducedWideCategory.Hom.ext (InducedCategory.hom_ext
-    (Graph.Hom.ext (funext fun v => e.toEquiv.apply_symm_apply v)))
+/-- A full isomorphism is an isomorphism of the precedence-preserving category;
+    both directions preserve arcs. -/
+noncomputable def AR.fullIsoToWideIso {A B : AR (Sigma.fst : ((i : ι) × τ i) → ι)}
+    (e : Graph.Iso A.obj B.obj) : (⟨A⟩ : PrecAR ι τ) ≅ ⟨B⟩ :=
+  CategoryTheory.isoMk (AR.mkIso e) e.toHom_precPreserving e.symm.toHom_precPreserving
 
-/-- The class of a representation: its isomorphism class in the skeleton of the
-    precedence-preserving category — the monoid of ARs. -/
+/-- The class of a representation, its isomorphism class in the skeleton of the
+    precedence-preserving category. -/
 noncomputable def AR.cls
     (A : AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
     Skeleton (PrecAR ι τ) :=
@@ -96,14 +89,6 @@ noncomputable def realize (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → �
 @[simp] theorem realize_cons (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
 
-/-- The realization as a free-monoid homomorphism into the monoid of
-    isomorphism classes — the string→AR monoid hom, with associativity strict
-    on classes. -/
-noncomputable def realizeHom
-    (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)) :
-    FreeMonoid S →* Skeleton (PrecAR ι τ) :=
-  FreeMonoid.lift (AR.cls ∘ g₀)
-
 end Realize
 
 /-! ### Tier content of realizations -/
@@ -120,9 +105,7 @@ instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
   | nil => exact inferInstanceAs (Finite PEmpty)
   | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (realize g₀ w).obj.V))
 
-/-- **Tier content is compositional**: the tier word of a realized string is the
-    concatenation of its symbols' tier words — [jardine-2019]'s tier projection
-    of `g`, and the bridge that places link-free ASL conditions per tier. -/
+/-- The tier word of a realized string is the concatenation of its symbols' tier words. -/
 theorem AR.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
     (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
   induction w with
@@ -137,17 +120,6 @@ theorem AR.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S)
 noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
     FreeMonoid S →* FreeMonoid (τ i) :=
   FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
-
-/-- `realizeHom` packages `realize`: on a word it is the class of the realized
-    representation. -/
-theorem realizeHom_ofList (w : List S) :
-    realizeHom g₀ (FreeMonoid.ofList w) = AR.cls (realize g₀ w) := by
-  induction w with
-  | nil => rfl
-  | cons a w ih =>
-    rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
-      map_mul, ih, realize_cons, AR.cls_tensor]
-    rfl
 
 /-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
 theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -72,6 +72,7 @@ def AR.ASL (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     Language S :=
   { w | (realize g₀ w).Free B }
 
+omit [Finite ι] in
 @[simp] theorem AR.mem_ASL
     {g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [∀ s, Finite (g₀ s).obj.V]


### PR DESCRIPTION
Applies the mathlib review of the split trio:

- `realizeHom`/`realizeHom_ofList` removed (verified dead; their only consumer chain was the OCP quotient-monoid layer gutted in #1404 — the remaining `cls`/`PrecAR`/Skeleton island is a pending design decision, escalated separately).
- `fullIsoToWideIso` rewritten via mathlib's `CategoryTheory.isoMk` wide-subcategory builder (10 lines → 1).
- Declarative-register sweep across the trio (bold leads, colon labels, proof-commentary tails).
- `TieredAR ι τ` abbrev for the sigma carrier, swept across the five substrate files (39 sites); `omit [Finite ι]` kills the warning #1413 introduced at `mem_ASL`.