### PR TITLE
refactor(Phonology/Autosegmental): AR namespace + IsFactorAt structure

### DIFF
--- a/Linglib/Core/Data/List/Factors.lean
+++ b/Linglib/Core/Data/List/Factors.lean
@@ -36,17 +36,17 @@ lemma take_append_take (n : ℕ) (X Y : List α) :
   rw [take_append, take_append, take_take, min_eq_left (by omega)]
 
 /-- A list is an infix of another iff some shift aligns every position of `S` with
-`A` (`getElem?`-wise): `S <:+: A` exactly when there is an offset `δ ≤ A.length` with
-`A[i + δ]? = S[i]?` for every `i < S.length`. The positional companion of
-`mem_kFactors`. -/
+`A` (`getElem?`-wise): `S <:+: A` exactly when there is an offset `δ` with
+`A[i + δ]? = S[i]?` for every `i < S.length`. The equations force the offset in
+bounds when `S` is nonempty. The positional companion of `mem_kFactors`. -/
 theorem isInfix_iff_exists_offset (S A : List α) :
-    S <:+: A ↔ ∃ δ ≤ A.length, ∀ i < S.length, A[i + δ]? = S[i]? := by
+    S <:+: A ↔ ∃ δ, ∀ i < S.length, A[i + δ]? = S[i]? := by
   constructor
   · rintro ⟨s, t, rfl⟩
-    refine ⟨s.length, by simp, fun i hi => ?_⟩
+    refine ⟨s.length, fun i hi => ?_⟩
     rw [List.append_assoc, List.getElem?_append_right (by omega), Nat.add_sub_cancel,
       List.getElem?_append_left hi]
-  · rintro ⟨δ, hδ, hmatch⟩
+  · rintro ⟨δ, hmatch⟩
     rcases Nat.eq_zero_or_pos S.length with h0 | hpos
     · obtain rfl : S = [] := List.length_eq_zero_iff.mp h0
       exact List.nil_infix

--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -30,81 +30,63 @@ are lists of forbidden factors.
 namespace Autosegmental
 
 variable {ι : Type*} {τ : ι → Type*}
-variable (F X : TieredAR ι τ)
+variable (F X : TieredAR ι τ) [Finite F.obj.V] [Finite X.obj.V]
 
 namespace AR
 
-/-- `F` occurs in `X` at per-tier offsets `o`: each tier word of `F` is the
-    window of `X`'s at `o i`, and `F`'s links transport shifted. -/
-def IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
-  (∀ i p, p < F.tierLength i → (X.tierWord i)[p + o i]? = (F.tierWord i)[p]?) ∧
-    ∀ i j p q, F.link i j p q → X.link i j (p + o i) (q + o j)
+/-- `F` occurs in `X` at per-tier offsets `o`. -/
+structure IsFactorAt (o : ι → ℕ) : Prop where
+  /-- Each tier word of `F` is the window of `X`'s at the tier's offset. -/
+  window : ∀ i p, p < F.tierLength i → (X.tierWord i)[p + o i]? = (F.tierWord i)[p]?
+  /-- Links transport by the offsets. -/
+  link_map : ∀ i j p q, F.link i j p q → X.link i j (p + o i) (q + o j)
 
 /-- `F` subgraph-embeds in `X` when some offsets place it as a factor
     ([jardine-2017]'s connected-subgraph embedding). -/
-def FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
-  ∃ o : ι → ℕ, F.IsFactorAt X o
-
-/-- Offsets clamp to the host's tier lengths: `FactorEmbeds` is a bounded
-    search. On tiers where the factor is nonempty the word-window condition
-    already forces the bound; empty factor tiers accept any offset, so `min`
-    clamps them harmlessly. -/
-theorem factorEmbeds_iff_bounded
-    {F X : TieredAR ι τ}
-    [Finite F.obj.V] [Finite X.obj.V] :
-    F.FactorEmbeds X ↔
-      ∃ o : ι → ℕ, (∀ i, o i ≤ X.tierLength i) ∧ F.IsFactorAt X o := by
-  constructor
-  · rintro ⟨o, hw, hl⟩
-    refine ⟨fun i => min (o i) (X.tierLength i), fun i => min_le_right _ _, fun i p hp => ?_,
-      fun i j p q h => ?_⟩
-    · have horig := hw i p hp
-      show (X.tierWord i)[p + min (o i) (X.tierLength i)]? = (F.tierWord i)[p]?
-      rcases le_or_gt (o i) (X.tierLength i) with hle | hgt
-      · rwa [Nat.min_eq_left hle]
-      · exfalso
-        have hnone : (X.tierWord i)[p + o i]? = none := by
-          rw [List.getElem?_eq_none_iff]
-          simp only [length_tierWord]
-          omega
-        have hsome : p < (F.tierWord i).length := by
-          simpa [length_tierWord] using hp
-        rw [hnone, List.getElem?_eq_some_iff.mpr ⟨hsome, rfl⟩] at horig
-        simp at horig
-    · obtain ⟨hpb, hqb, -⟩ := id (hl i j p q h)
-      have h' := hl i j p q h
-      have hoi : min (o i) (X.tierLength i) = o i := by
-        have := hw i p (by obtain ⟨hp', -, -⟩ := id h; omega)
-        rcases le_or_gt (o i) (X.tierLength i) with hle | hgt
-        · exact Nat.min_eq_left hle
-        · exfalso
-          obtain ⟨hpX, -, -⟩ := id h'
-          omega
-      have hoj : min (o j) (X.tierLength j) = o j := by
-        rcases le_or_gt (o j) (X.tierLength j) with hle | hgt
-        · exact Nat.min_eq_left hle
-        · exfalso
-          obtain ⟨-, hqX, -⟩ := id h'
-          omega
-      show X.link i j (p + min (o i) (X.tierLength i)) (q + min (o j) (X.tierLength j))
-      rw [hoi, hoj]
-      exact h'
-  · rintro ⟨o, -, hfa⟩
-    exact ⟨o, hfa⟩
+def FactorEmbeds : Prop := ∃ o : ι → ℕ, F.IsFactorAt X o
 
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
     ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
-def Free [Finite X.obj.V]
-    (B : List {F : TieredAR ι τ // Finite F.obj.V}) :
-    Prop :=
+def Free (B : List {F : TieredAR ι τ // Finite F.obj.V}) : Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
+
+variable {F X} {o : ι → ℕ}
+
+/-- On a tier where the factor is nonempty, the window equations force the offset
+    in bounds. -/
+theorem IsFactorAt.offset_le (h : F.IsFactorAt X o) {i : ι} (hi : F.tierLength i ≠ 0) :
+    o i ≤ X.tierLength i := by
+  have hb : 0 < (F.tierWord i).length := by simpa using Nat.pos_of_ne_zero hi
+  have h0 := (h.window i 0 (Nat.pos_of_ne_zero hi)).trans
+    (List.getElem?_eq_some_iff.mpr ⟨hb, rfl⟩)
+  have := (List.getElem?_eq_some_iff.mp h0).1
+  simp only [length_tierWord] at this
+  omega
+
+/-- Offsets clamp to the host's tier lengths; the clamp only moves offsets on
+    tiers where the factor is empty. -/
+theorem IsFactorAt.clamp (h : F.IsFactorAt X o) :
+    F.IsFactorAt X fun i => min (o i) (X.tierLength i) where
+  window i p hp := by
+    show (X.tierWord i)[p + min (o i) (X.tierLength i)]? = (F.tierWord i)[p]?
+    rw [Nat.min_eq_left (h.offset_le (i := i) (by omega))]
+    exact h.window i p hp
+  link_map i j p q hl := by
+    obtain ⟨hpF, hqF, -⟩ := id hl
+    show X.link i j (p + min (o i) (X.tierLength i)) (q + min (o j) (X.tierLength j))
+    rw [Nat.min_eq_left (h.offset_le (i := i) (by omega)),
+      Nat.min_eq_left (h.offset_le (i := j) (by omega))]
+    exact h.link_map i j p q hl
+
+/-- `FactorEmbeds` is a bounded search over offsets. -/
+theorem factorEmbeds_iff_bounded :
+    F.FactorEmbeds X ↔
+      ∃ o : ι → ℕ, (∀ i, o i ≤ X.tierLength i) ∧ F.IsFactorAt X o :=
+  ⟨fun ⟨_, h⟩ => ⟨_, fun _ => min_le_right _ _, h.clamp⟩, fun ⟨o, _, h⟩ => ⟨o, h⟩⟩
 
 /-- For a link-free factor, embedding reduces to independent per-tier infix
     occurrences ([jardine-2019]'s link-free fragment). -/
-theorem factorEmbeds_iff_infix_of_link_free
-    {F X : TieredAR ι τ}
-    [Finite F.obj.V] [Finite X.obj.V]
-    (hF : ∀ i j p q, ¬ F.link i j p q) :
+theorem factorEmbeds_iff_infix_of_link_free (hF : ∀ i j p q, ¬ F.link i j p q) :
     F.FactorEmbeds X ↔ ∀ i, F.tierWord i <:+: X.tierWord i := by
   constructor
   · rintro ⟨o, hw, -⟩ i

--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -32,22 +32,24 @@ namespace Autosegmental
 variable {ι : Type*} {τ : ι → Type*}
 variable (F X : TieredAR ι τ)
 
+namespace AR
+
 /-- `F` occurs in `X` at per-tier offsets `o`: each tier word of `F` is the
     window of `X`'s at `o i`, and `F`'s links transport shifted. -/
-def AR.IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
+def IsFactorAt [Finite F.obj.V] [Finite X.obj.V] (o : ι → ℕ) : Prop :=
   (∀ i p, p < F.tierLength i → (X.tierWord i)[p + o i]? = (F.tierWord i)[p]?) ∧
     ∀ i j p q, F.link i j p q → X.link i j (p + o i) (q + o j)
 
 /-- `F` subgraph-embeds in `X` when some offsets place it as a factor
     ([jardine-2017]'s connected-subgraph embedding). -/
-def AR.FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
+def FactorEmbeds [Finite F.obj.V] [Finite X.obj.V] : Prop :=
   ∃ o : ι → ℕ, F.IsFactorAt X o
 
 /-- Offsets clamp to the host's tier lengths: `FactorEmbeds` is a bounded
     search. On tiers where the factor is nonempty the word-window condition
     already forces the bound; empty factor tiers accept any offset, so `min`
     clamps them harmlessly. -/
-theorem AR.factorEmbeds_iff_bounded
+theorem factorEmbeds_iff_bounded
     {F X : TieredAR ι τ}
     [Finite F.obj.V] [Finite X.obj.V] :
     F.FactorEmbeds X ↔
@@ -63,10 +65,10 @@ theorem AR.factorEmbeds_iff_bounded
       · exfalso
         have hnone : (X.tierWord i)[p + o i]? = none := by
           rw [List.getElem?_eq_none_iff]
-          simp only [AR.length_tierWord]
+          simp only [length_tierWord]
           omega
         have hsome : p < (F.tierWord i).length := by
-          simpa [AR.length_tierWord] using hp
+          simpa [length_tierWord] using hp
         rw [hnone, List.getElem?_eq_some_iff.mpr ⟨hsome, rfl⟩] at horig
         simp at horig
     · obtain ⟨hpb, hqb, -⟩ := id (hl i j p q h)
@@ -92,14 +94,14 @@ theorem AR.factorEmbeds_iff_bounded
 
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
     ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
-def AR.Free [Finite X.obj.V]
+def Free [Finite X.obj.V]
     (B : List {F : TieredAR ι τ // Finite F.obj.V}) :
     Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
 
 /-- For a link-free factor, embedding reduces to independent per-tier infix
     occurrences ([jardine-2019]'s link-free fragment). -/
-theorem AR.factorEmbeds_iff_infix_of_link_free
+theorem factorEmbeds_iff_infix_of_link_free
     {F X : TieredAR ι τ}
     [Finite F.obj.V] [Finite X.obj.V]
     (hF : ∀ i j p q, ¬ F.link i j p q) :
@@ -109,18 +111,20 @@ theorem AR.factorEmbeds_iff_infix_of_link_free
     rw [List.isInfix_iff_exists_offset]
     rcases Nat.eq_zero_or_pos (F.tierWord i).length with hzero | hpos
     · exact ⟨0, Nat.zero_le _, fun p hp => absurd hp (by omega)⟩
-    · have h0 := hw i 0 (by simpa [AR.length_tierWord] using hpos)
+    · have h0 := hw i 0 (by simpa [length_tierWord] using hpos)
       refine ⟨o i, ?_, fun p hp => hw i p
-        (by simpa [AR.length_tierWord] using hp)⟩
+        (by simpa [length_tierWord] using hp)⟩
       rcases List.getElem?_eq_some_iff.mp
         (h0 ▸ (List.getElem?_eq_some_iff.mpr
-          ⟨by simpa [AR.length_tierWord] using hpos, rfl⟩ :
+          ⟨by simpa [length_tierWord] using hpos, rfl⟩ :
             (F.tierWord i)[0]? = some _)) with ⟨hb, -⟩
       omega
   · intro h
     choose o ho using fun i => (List.isInfix_iff_exists_offset _ _).mp (h i)
     refine ⟨o, fun i p hp => ?_, fun i j p q hl => absurd hl (hF i j p q)⟩
     obtain ⟨-, hoff⟩ := ho i
-    exact hoff p (by simpa [AR.length_tierWord] using hp)
+    exact hoff p (by simpa [length_tierWord] using hp)
+
+end AR
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -108,22 +108,12 @@ theorem factorEmbeds_iff_infix_of_link_free
     F.FactorEmbeds X ↔ ∀ i, F.tierWord i <:+: X.tierWord i := by
   constructor
   · rintro ⟨o, hw, -⟩ i
-    rw [List.isInfix_iff_exists_offset]
-    rcases Nat.eq_zero_or_pos (F.tierWord i).length with hzero | hpos
-    · exact ⟨0, Nat.zero_le _, fun p hp => absurd hp (by omega)⟩
-    · have h0 := hw i 0 (by simpa [length_tierWord] using hpos)
-      refine ⟨o i, ?_, fun p hp => hw i p
-        (by simpa [length_tierWord] using hp)⟩
-      rcases List.getElem?_eq_some_iff.mp
-        (h0 ▸ (List.getElem?_eq_some_iff.mpr
-          ⟨by simpa [length_tierWord] using hpos, rfl⟩ :
-            (F.tierWord i)[0]? = some _)) with ⟨hb, -⟩
-      omega
+    exact (List.isInfix_iff_exists_offset _ _).mpr
+      ⟨o i, fun p hp => hw i p (by simpa using hp)⟩
   · intro h
     choose o ho using fun i => (List.isInfix_iff_exists_offset _ _).mp (h i)
-    refine ⟨o, fun i p hp => ?_, fun i j p q hl => absurd hl (hF i j p q)⟩
-    obtain ⟨-, hoff⟩ := ho i
-    exact hoff p (by simpa [length_tierWord] using hp)
+    exact ⟨o, fun i p hp => ho i p (by simpa using hp),
+      fun i j p q hl => absurd hl (hF i j p q)⟩
 
 end AR
 

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -49,34 +49,36 @@ variable {ι : Type*} {τ : ι → Type*}
     projection `Sigma.fst` — the coordinate carrier of the normal-form theory. -/
 abbrev TieredAR (ι : Type*) (τ : ι → Type*) := AR (Sigma.fst : ((i : ι) × τ i) → ι)
 
+namespace AR
+
 section NormalForm
 open scoped Classical
 
 /-- The vertices of `X.obj` labelled to tier `i`. -/
-def AR.fiber (X : TieredAR ι τ) (i : ι) :
+def fiber (X : TieredAR ι τ) (i : ι) :
     Type _ := {v : X.obj.V // (X.obj.label v).1 = i}
 
 variable {X : TieredAR ι τ}
 
 /-- The `τ i` component of a fiber element, extracted from the labeling by
     transporting along the fiber's tier-membership witness. -/
-def AR.fiberLabel {i : ι} (v : X.fiber i) : τ i :=
+def fiberLabel {i : ι} (v : X.fiber i) : τ i :=
   v.property ▸ (X.obj.label v.val).2
 
 /-- The label of a fiber element decomposes as tier plus `fiberLabel`. -/
-theorem AR.label_fiber {i : ι} (v : X.fiber i) :
+theorem label_fiber {i : ι} (v : X.fiber i) :
     X.obj.label v.val = ⟨i, X.fiberLabel v⟩ := by
   obtain ⟨u, hu⟩ := v
   show X.obj.label u = _
-  simp only [AR.fiberLabel]
+  simp only [fiberLabel]
   conv_lhs => rw [← Sigma.eta (X.obj.label u)]
   exact Sigma.eq hu rfl
 
-instance AR.fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
+instance fiber.instFinite [Finite X.obj.V] (i : ι) : Finite (X.fiber i) :=
   Subtype.finite
 
 /-- The arcs restricted to a tier fiber form a strict total order. -/
-instance AR.fiber.instIsStrictTotalOrder (i : ι) :
+instance fiber.instIsStrictTotalOrder (i : ι) :
     IsStrictTotalOrder (X.fiber i) (fun a b => X.obj.arcs.Adj a.val b.val) where
   trichotomous a b hab hba := Subtype.ext <| of_not_not fun hne =>
     (X.property.1.total hne (a.2.trans b.2.symm)).elim hab hba
@@ -85,26 +87,26 @@ instance AR.fiber.instIsStrictTotalOrder (i : ι) :
 
 /-- Classical linear order on the fiber, from `IsStrictTotalOrder` via
     `linearOrderOfSTO`. -/
-noncomputable instance AR.fiber.instLinearOrder (i : ι) :
+noncomputable instance fiber.instLinearOrder (i : ι) :
     LinearOrder (X.fiber i) := by
   classical
   exact linearOrderOfSTO (fun a b : X.fiber i => X.obj.arcs.Adj a.val b.val)
 
 /-- The number of tier-`i` vertices. -/
-noncomputable def AR.tierLength (X : TieredAR ι τ)
+noncomputable def tierLength (X : TieredAR ι τ)
     [Finite X.obj.V] (i : ι) : ℕ :=
   letI := Fintype.ofFinite (X.fiber i)
   Fintype.card (X.fiber i)
 
 /-- The canonical ascending enumeration of a tier fiber. -/
-noncomputable def AR.fiberEnum [Finite X.obj.V] (i : ι) :
+noncomputable def fiberEnum [Finite X.obj.V] (i : ι) :
     Fin (X.tierLength i) ≃o X.fiber i :=
   letI := Fintype.ofFinite (X.fiber i)
   monoEquivOfFin (X.fiber i) rfl
 
 /-- The canonical enumeration of a finite representation's vertex type: tier
     fibers in ascending precedence order, assembled over the tier index. -/
-noncomputable def AR.vertexEquiv [Finite X.obj.V] :
+noncomputable def vertexEquiv [Finite X.obj.V] :
     ((i : ι) × Fin (X.tierLength i)) ≃ X.obj.V :=
   letI : ∀ i : ι, Fintype (X.fiber i) := fun _ => Fintype.ofFinite _
   (Equiv.sigmaCongrRight (fun i : ι => (X.fiberEnum i).toEquiv)).trans
@@ -112,22 +114,22 @@ noncomputable def AR.vertexEquiv [Finite X.obj.V] :
 
 /-- The tier-`i` label word: the fiber's labels read off in ascending precedence
     order — the tier content the normal form canonicalizes. -/
-noncomputable def AR.tierWord [Finite X.obj.V] (i : ι) : List (τ i) :=
+noncomputable def tierWord [Finite X.obj.V] (i : ι) : List (τ i) :=
   letI := Fintype.ofFinite (X.fiber i)
   List.ofFn fun p : Fin (X.tierLength i) => X.fiberLabel (X.fiberEnum i p)
 
-@[simp] theorem AR.length_tierWord [Finite X.obj.V] (i : ι) :
+@[simp] theorem length_tierWord [Finite X.obj.V] (i : ι) :
     (X.tierWord i).length = X.tierLength i := by
-  simp [AR.tierWord]
+  simp [tierWord]
 
 /-- The link relation in position coordinates: tier-`i` position `p` associates
     to tier-`j` position `q`. With `tierWord`, the complete tuple reading of a
     finite representation. -/
-noncomputable def AR.linkRel [Finite X.obj.V] (i j : ι)
+noncomputable def linkRel [Finite X.obj.V] (i j : ι)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) : Prop :=
   X.obj.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩)
 
-theorem AR.linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
+theorem linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
     {q : Fin (X.tierLength j)} :
     X.linkRel i j p q ↔
       X.obj.edges.Adj (X.vertexEquiv ⟨i, p⟩) (X.vertexEquiv ⟨j, q⟩) := Iff.rfl
@@ -135,7 +137,7 @@ theorem AR.linkRel_def [Finite X.obj.V] {i j : ι} {p : Fin (X.tierLength i)}
 /-- The normal form: `X` reindexed onto the canonical vertex type by pulling
     edges, arcs, and labels back along `vertexEquiv`. A `AR` — the
     normal form is not a separate kind of object. -/
-noncomputable def AR.normalize
+noncomputable def normalize
     (X : TieredAR ι τ) [Finite X.obj.V] :
     TieredAR ι τ where
   obj :=
@@ -152,7 +154,7 @@ noncomputable def AR.normalize
      fun _ _ hadj harc => X.property.2 hadj harc⟩
 
 /-- The normal form is fully isomorphic to the original. -/
-noncomputable def AR.normalizeFullIso [Finite X.obj.V] :
+noncomputable def normalizeFullIso [Finite X.obj.V] :
     Graph.Iso (X.normalize).obj X.obj where
   toEquiv := X.vertexEquiv
   edges_iff _ _ := Iff.rfl
@@ -160,16 +162,16 @@ noncomputable def AR.normalizeFullIso [Finite X.obj.V] :
   label_comp _ := rfl
 
 /-- The normal form is isomorphic to the original. -/
-noncomputable def AR.normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
-  AR.mkIso X.normalizeFullIso
+noncomputable def normalizeIso [Finite X.obj.V] : X.normalize ≅ X :=
+  mkIso X.normalizeFullIso
 
 /-- On normal forms the edges are exactly `linkRel`. -/
-theorem AR.edges_normalize [Finite X.obj.V] (i j : ι)
+theorem edges_normalize [Finite X.obj.V] (i j : ι)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
     (X.normalize).obj.edges.Adj ⟨i, p⟩ ⟨j, q⟩ ↔ X.linkRel i j p q := Iff.rfl
 
 /-- On normal forms the arcs are the ascending position order. -/
-theorem AR.arcs_normalize [Finite X.obj.V] (i : ι)
+theorem arcs_normalize [Finite X.obj.V] (i : ι)
     (p q : Fin (X.tierLength i)) :
     (X.normalize).obj.arcs.Adj ⟨i, p⟩ ⟨i, q⟩ ↔ p < q :=
   (X.fiberEnum i).lt_iff_lt
@@ -194,7 +196,7 @@ instance [Finite X.obj.V] [Finite Y.obj.V] : Finite ((X ⊗ Y).obj.V) :=
   inferInstanceAs (Finite (X.obj.V ⊕ Y.obj.V))
 
 /-- A tensor's tier fiber splits as the sum of the factors' fibers. -/
-def AR.fiberTensorEquiv (i : ι) :
+def fiberTensorEquiv (i : ι) :
     (X ⊗ Y).fiber i ≃ X.fiber i ⊕ Y.fiber i where
   toFun v := match v with
     | ⟨.inl w, h⟩ => .inl ⟨w, h⟩
@@ -207,18 +209,18 @@ variable [Finite X.obj.V] [Finite Y.obj.V]
 
 attribute [local instance] Fintype.ofFinite
 
-@[simp] theorem AR.tierLength_tensor (i : ι) :
+@[simp] theorem tierLength_tensor (i : ι) :
     (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i := by
   letI := Fintype.ofFinite ((X ⊗ Y).fiber i)
   letI := Fintype.ofFinite (X.fiber i)
   letI := Fintype.ofFinite (Y.fiber i)
-  simp only [AR.tierLength]
-  rw [Fintype.card_congr (AR.fiberTensorEquiv i), Fintype.card_sum]
+  simp only [tierLength]
+  rw [Fintype.card_congr (fiberTensorEquiv i), Fintype.card_sum]
 
 open AR in
 /-- The blockwise enumeration of a tensor's fiber: left factor first, then
     right — monotone because the bridge arc orders the blocks. -/
-noncomputable def AR.tensorEnum (i : ι) :
+noncomputable def tensorEnum (i : ι) :
     Fin (X.tierLength i + Y.tierLength i) ≃o (X ⊗ Y).fiber i := by
   letI := Fintype.ofFinite (X.fiber i)
   letI := Fintype.ofFinite (Y.fiber i)
@@ -251,96 +253,96 @@ noncomputable def AR.tensorEnum (i : ι) :
       exact (Y.fiberEnum i).strictMono
         (by simp only [Fin.lt_def, Fin.val_natAdd] at hpq ⊢; omega)
 
-theorem AR.tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLength i)) :
-    AR.tensorEnum i (Fin.castAdd (Y.tierLength i) p) =
-      (AR.fiberTensorEquiv i).symm
+theorem tensorEnum_apply_castAdd (i : ι) (p : Fin (X.tierLength i)) :
+    tensorEnum i (Fin.castAdd (Y.tierLength i) p) =
+      (fiberTensorEquiv i).symm
         (.inl (X.fiberEnum i p)) := by
-  simp [AR.tensorEnum, finSumFinEquiv_symm_apply_castAdd]
+  simp [tensorEnum, finSumFinEquiv_symm_apply_castAdd]
 
-theorem AR.tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLength i)) :
-    AR.tensorEnum i (Fin.natAdd (X.tierLength i) p) =
-      (AR.fiberTensorEquiv (X := X) i).symm
+theorem tensorEnum_apply_natAdd (i : ι) (p : Fin (Y.tierLength i)) :
+    tensorEnum i (Fin.natAdd (X.tierLength i) p) =
+      (fiberTensorEquiv (X := X) i).symm
         (.inr (Y.fiberEnum i p)) := by
-  simp [AR.tensorEnum, finSumFinEquiv_symm_apply_natAdd]
+  simp [tensorEnum, finSumFinEquiv_symm_apply_natAdd]
 
 omit [Finite X.obj.V] [Finite Y.obj.V] in
-theorem AR.fiberLabel_symm_inl {i : ι} (w : X.fiber i) :
-    AR.fiberLabel ((AR.fiberTensorEquiv (X := X) (Y := Y) i).symm
+theorem fiberLabel_symm_inl {i : ι} (w : X.fiber i) :
+    fiberLabel ((fiberTensorEquiv (X := X) (Y := Y) i).symm
       (.inl w)) = X.fiberLabel w := rfl
 
 omit [Finite X.obj.V] [Finite Y.obj.V] in
-theorem AR.fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
-    AR.fiberLabel ((AR.fiberTensorEquiv (X := X) (Y := Y) i).symm
+theorem fiberLabel_symm_inr {i : ι} (w : Y.fiber i) :
+    fiberLabel ((fiberTensorEquiv (X := X) (Y := Y) i).symm
       (.inr w)) = Y.fiberLabel w := rfl
 
 /-- Any monotone enumeration computes the tier word. -/
-theorem AR.tierWord_eq_ofFn {Z : TieredAR ι τ}
+theorem tierWord_eq_ofFn {Z : TieredAR ι τ}
     [Finite Z.obj.V] {i : ι} {n : ℕ} (e : Fin n ≃o Z.fiber i) :
     Z.tierWord i = List.ofFn fun p => Z.fiberLabel (e p) := by
   have hn : Z.tierLength i = n := by
-    simpa [AR.tierLength] using (Fintype.card_congr e.toEquiv).symm
+    simpa [tierLength] using (Fintype.card_congr e.toEquiv).symm
   subst hn
   rw [Subsingleton.elim e (Z.fiberEnum i)]
   rfl
 
 /-- The tier word of a tensor is the concatenation of the factors' tier words. -/
-@[simp] theorem AR.tierWord_tensor (i : ι) :
+@[simp] theorem tierWord_tensor (i : ι) :
     (X ⊗ Y).tierWord i = X.tierWord i ++ Y.tierWord i := by
-  rw [AR.tierWord_eq_ofFn (AR.tensorEnum i), List.ofFn_add]
+  rw [tierWord_eq_ofFn (tensorEnum i), List.ofFn_add]
   congr 1
-  · rw [AR.tierWord_eq_ofFn (X.fiberEnum i)]
+  · rw [tierWord_eq_ofFn (X.fiberEnum i)]
     exact congrArg List.ofFn (funext fun p =>
-      (congrArg AR.fiberLabel (AR.tensorEnum_apply_castAdd i p)).trans
-        (AR.fiberLabel_symm_inl _))
-  · rw [AR.tierWord_eq_ofFn (Y.fiberEnum i)]
+      (congrArg fiberLabel (tensorEnum_apply_castAdd i p)).trans
+        (fiberLabel_symm_inl _))
+  · rw [tierWord_eq_ofFn (Y.fiberEnum i)]
     exact congrArg List.ofFn (funext fun p =>
-      (congrArg AR.fiberLabel (AR.tensorEnum_apply_natAdd i p)).trans
-        (AR.fiberLabel_symm_inr _))
+      (congrArg fiberLabel (tensorEnum_apply_natAdd i p)).trans
+        (fiberLabel_symm_inr _))
 
-theorem AR.fiberEnum_tensor (i : ι) :
+theorem fiberEnum_tensor (i : ι) :
     (X ⊗ Y).fiberEnum i =
-      (Fin.castOrderIso (AR.tierLength_tensor i)).trans
-        (AR.tensorEnum i) :=
+      (Fin.castOrderIso (tierLength_tensor i)).trans
+        (tensorEnum i) :=
   Subsingleton.elim _ _
 
-theorem AR.vertexEquiv_tensor_of_lt {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
+theorem vertexEquiv_tensor_of_lt {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
     (h : (r : ℕ) < X.tierLength i) :
     (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inl (X.vertexEquiv ⟨i, ⟨r, h⟩⟩) := by
   show ((X ⊗ Y).fiberEnum i r).val = _
-  rw [AR.fiberEnum_tensor, OrderIso.trans_apply,
-    show Fin.castOrderIso (AR.tierLength_tensor (X := X) (Y := Y) i) r
+  rw [fiberEnum_tensor, OrderIso.trans_apply,
+    show Fin.castOrderIso (tierLength_tensor (X := X) (Y := Y) i) r
       = Fin.castAdd (Y.tierLength i) ⟨r, h⟩ from rfl,
-    AR.tensorEnum_apply_castAdd]
+    tensorEnum_apply_castAdd]
   rfl
 
-theorem AR.vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
+theorem vertexEquiv_tensor_of_ge {i : ι} {r : Fin ((X ⊗ Y).tierLength i)}
     (h : X.tierLength i ≤ (r : ℕ)) :
     (X ⊗ Y).vertexEquiv ⟨i, r⟩ = Sum.inr (Y.vertexEquiv ⟨i,
       ⟨(r : ℕ) - X.tierLength i, by
         have _h1 := r.isLt
         have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
-          AR.tierLength_tensor i
+          tierLength_tensor i
         omega⟩⟩) := by
   show ((X ⊗ Y).fiberEnum i r).val = _
-  rw [AR.fiberEnum_tensor, OrderIso.trans_apply,
-    show Fin.castOrderIso (AR.tierLength_tensor (X := X) (Y := Y) i) r
+  rw [fiberEnum_tensor, OrderIso.trans_apply,
+    show Fin.castOrderIso (tierLength_tensor (X := X) (Y := Y) i) r
       = Fin.natAdd (X.tierLength i) ⟨(r : ℕ) - X.tierLength i, by
           have h1 := r.isLt
           have h2 : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
-            AR.tierLength_tensor i
+            tierLength_tensor i
           omega⟩ from
       Fin.ext (by simpa using (Nat.add_sub_cancel' h).symm),
-    AR.tensorEnum_apply_natAdd]
+    tensorEnum_apply_natAdd]
   rfl
 
 instance : Finite ((𝟙_ (TieredAR ι τ)).obj.V) :=
   inferInstanceAs (Finite PEmpty)
 
-@[simp] theorem AR.tierWord_unit (i : ι) :
+@[simp] theorem tierWord_unit (i : ι) :
     (𝟙_ (TieredAR ι τ)).tierWord i = [] := by
   haveI : IsEmpty ((𝟙_ (TieredAR ι τ)).fiber i) :=
     ⟨fun v => v.val.elim⟩
-  rw [AR.tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
+  rw [tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
   exact List.ofFn_zero
 
 end TierWordTensor
@@ -358,19 +360,19 @@ variable (X : TieredAR ι τ)
 
 /-- Tier-`i` position `p` links to tier-`j` position `q`, in ℕ coordinates
     (out-of-bounds positions link to nothing). -/
-def AR.link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
+def link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
   ∃ (hp : p < X.tierLength i) (hq : q < X.tierLength j), X.linkRel i j ⟨p, hp⟩ ⟨q, hq⟩
 
 open scoped Classical in
 /-- The two-tier reading of tiers `i` over `j`: each tier-`j` position's label
     paired with its linked tier-`i` labels in ascending order. -/
-noncomputable def AR.linearize [Finite X.obj.V] (i j : ι) :
+noncomputable def linearize [Finite X.obj.V] (i j : ι) :
     List (τ j × List (τ i)) :=
   (X.tierWord j).zipIdx.map fun bq =>
     (bq.1, ((X.tierWord i).zipIdx.filter fun ap => X.link i j ap.2 bq.2).map (·.1))
 
 /-- Link conditions are supported on the factor's tier ranges. -/
-theorem AR.forall_link_iff_bounded
+theorem forall_link_iff_bounded
     {F : TieredAR ι τ} [Finite F.obj.V]
     {C : ι → ι → ℕ → ℕ → Prop} :
     (∀ i j p q, F.link i j p q → C i j p q) ↔
@@ -383,44 +385,44 @@ theorem AR.forall_link_iff_bounded
 open scoped MonoidalCategory in
 /-- Tensor links are blockwise: within the left factor, or within the right
     factor shifted by the left factor's tier lengths — no cross-factor links. -/
-theorem AR.link_tensor {X Y : TieredAR ι τ}
+theorem link_tensor {X Y : TieredAR ι τ}
     [Finite X.obj.V] [Finite Y.obj.V] (i j : ι) (p q : ℕ) :
     (X ⊗ Y).link i j p q ↔
       X.link i j p q ∨ X.tierLength i ≤ p ∧ X.tierLength j ≤ q ∧
         Y.link i j (p - X.tierLength i) (q - X.tierLength j) := by
   have h2i : (X ⊗ Y).tierLength i = X.tierLength i + Y.tierLength i :=
-    AR.tierLength_tensor i
+    tierLength_tensor i
   have h2j : (X ⊗ Y).tierLength j = X.tierLength j + Y.tierLength j :=
-    AR.tierLength_tensor j
+    tierLength_tensor j
   constructor
   · rintro ⟨hp, hq, hl⟩
-    rw [AR.linkRel_def] at hl
+    rw [linkRel_def] at hl
     rcases lt_or_ge p (X.tierLength i) with hpi | hpi <;>
       rcases lt_or_ge q (X.tierLength j) with hqj | hqj
-    · rw [AR.vertexEquiv_tensor_of_lt (h := hpi),
-        AR.vertexEquiv_tensor_of_lt (h := hqj)] at hl
-      exact Or.inl ⟨hpi, hqj, by simpa [AR.linkRel_def] using hl⟩
-    · rw [AR.vertexEquiv_tensor_of_lt (h := hpi),
-        AR.vertexEquiv_tensor_of_ge (h := hqj)] at hl
+    · rw [vertexEquiv_tensor_of_lt (h := hpi),
+        vertexEquiv_tensor_of_lt (h := hqj)] at hl
+      exact Or.inl ⟨hpi, hqj, by simpa [linkRel_def] using hl⟩
+    · rw [vertexEquiv_tensor_of_lt (h := hpi),
+        vertexEquiv_tensor_of_ge (h := hqj)] at hl
       simp at hl
-    · rw [AR.vertexEquiv_tensor_of_ge (h := hpi),
-        AR.vertexEquiv_tensor_of_lt (h := hqj)] at hl
+    · rw [vertexEquiv_tensor_of_ge (h := hpi),
+        vertexEquiv_tensor_of_lt (h := hqj)] at hl
       simp at hl
-    · rw [AR.vertexEquiv_tensor_of_ge (h := hpi),
-        AR.vertexEquiv_tensor_of_ge (h := hqj)] at hl
+    · rw [vertexEquiv_tensor_of_ge (h := hpi),
+        vertexEquiv_tensor_of_ge (h := hqj)] at hl
       exact Or.inr ⟨hpi, hqj, by omega, by omega,
-        by simpa [AR.linkRel_def] using hl⟩
+        by simpa [linkRel_def] using hl⟩
   · rintro (⟨hp, hq, hl⟩ | ⟨hpi, hqj, hp', hq', hl⟩)
-    · rw [AR.linkRel_def] at hl
+    · rw [linkRel_def] at hl
       refine ⟨by omega, by omega, ?_⟩
-      rw [AR.linkRel_def, AR.vertexEquiv_tensor_of_lt (h := hp),
-        AR.vertexEquiv_tensor_of_lt (h := hq)]
+      rw [linkRel_def, vertexEquiv_tensor_of_lt (h := hp),
+        vertexEquiv_tensor_of_lt (h := hq)]
       simpa using hl
-    · rw [AR.linkRel_def] at hl
+    · rw [linkRel_def] at hl
       refine ⟨by omega, by omega, ?_⟩
-      rw [AR.linkRel_def,
-        AR.vertexEquiv_tensor_of_ge (h := by omega),
-        AR.vertexEquiv_tensor_of_ge (h := by omega)]
+      rw [linkRel_def,
+        vertexEquiv_tensor_of_ge (h := by omega),
+        vertexEquiv_tensor_of_ge (h := by omega)]
       simpa using hl
 
 end LinkReader
@@ -438,26 +440,26 @@ variable {ι : Type*} {τ : ι → Type*}
 variable {X : TieredAR ι τ}
 
 /-- The label of a canonical vertex sits on its own tier. -/
-theorem AR.label_vertexEquiv [Finite X.obj.V] (i : ι)
+theorem label_vertexEquiv [Finite X.obj.V] (i : ι)
     (p : Fin (X.tierLength i)) : (X.obj.label (X.vertexEquiv ⟨i, p⟩)).1 = i :=
   (X.fiberEnum i p).property
 
-theorem AR.linkRel_iff_link [Finite X.obj.V] {i j : ι}
+theorem linkRel_iff_link [Finite X.obj.V] {i j : ι}
     {p : Fin (X.tierLength i)} {q : Fin (X.tierLength j)} :
     X.linkRel i j p q ↔ X.link i j (p : ℕ) (q : ℕ) :=
   ⟨fun h => ⟨p.isLt, q.isLt, h⟩, fun ⟨_, _, h⟩ => by convert h⟩
 
-theorem AR.tierWord_getElem [Finite X.obj.V] {i : ι}
+theorem tierWord_getElem [Finite X.obj.V] {i : ι}
     (p : Fin (X.tierLength i)) :
     (X.tierWord i)[(p : ℕ)]'(by simp) = X.fiberLabel (X.fiberEnum i p) := by
-  simp [AR.tierWord]
+  simp [tierWord]
 
-theorem AR.label_normalize [Finite X.obj.V] {i : ι}
+theorem label_normalize [Finite X.obj.V] {i : ι}
     (p : Fin (X.tierLength i)) :
     (X.normalize).obj.label ⟨i, p⟩ = ⟨i, X.fiberLabel (X.fiberEnum i p)⟩ :=
   X.label_fiber (X.fiberEnum i p)
 
-theorem AR.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ j)
+theorem arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ j)
     (p : Fin (X.tierLength i)) (q : Fin (X.tierLength j)) :
     ¬ (X.normalize).obj.arcs.Adj ⟨i, p⟩ ⟨j, q⟩ := fun ha => by
   have h2 := X.property.1.tier_eq ha
@@ -468,31 +470,31 @@ theorem AR.arcs_normalize_ne [Finite X.obj.V] {i j : ι} (h : i ≠ j)
   exact h h2
 
 /-- Links are symmetric in coordinates. -/
-theorem AR.link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
+theorem link_symm [Finite X.obj.V] {i j : ι} {p q : ℕ}
     (h : X.link i j p q) : X.link j i q p := by
   obtain ⟨hp, hq, hl⟩ := h
   exact ⟨hq, hp, hl.symm⟩
 
 /-- Same-tier vertices are never linked. -/
-theorem AR.not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
+theorem not_link_self_tier [Finite X.obj.V] (i : ι) (p q : ℕ) :
     ¬ X.link i i p q := by
   rintro ⟨hp, hq, hl⟩
-  rw [AR.linkRel_def] at hl
+  rw [linkRel_def] at hl
   have hlab : X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨p, hp⟩⟩)
       = X.obj.tier Sigma.fst (X.vertexEquiv ⟨i, ⟨q, hq⟩⟩) := by
     show (X.obj.label _).1 = (X.obj.label _).1
-    rw [AR.label_vertexEquiv, AR.label_vertexEquiv]
+    rw [label_vertexEquiv, label_vertexEquiv]
   exact (X.property.1.total hl.ne hlab).elim (X.property.2 hl) (X.property.2 hl.symm)
 
 /-- The classification isomorphism as a full-structure `Graph.Iso`. -/
-noncomputable def AR.fullIsoOfReaderEq
+noncomputable def fullIsoOfReaderEq
     {A B : TieredAR ι τ}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
     (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) :
     Graph.Iso A.obj B.obj := by
   have hlen : ∀ i, A.tierLength i = B.tierLength i := fun i => by
-    rw [← AR.length_tierWord, hw, AR.length_tierWord]
+    rw [← length_tierWord, hw, length_tierWord]
   refine A.normalizeFullIso.symm.trans (Graph.Iso.trans ?_ B.normalizeFullIso)
   refine
     { toEquiv := Equiv.sigmaCongrRight fun i => finCongr (hlen i)
@@ -503,33 +505,33 @@ noncomputable def AR.fullIsoOfReaderEq
     obtain ⟨j, q⟩ := w
     show B.normalize.obj.edges.Adj ⟨i, Fin.cast (hlen i) p⟩ ⟨j, Fin.cast (hlen j) q⟩
       ↔ A.normalize.obj.edges.Adj ⟨i, p⟩ ⟨j, q⟩
-    rw [AR.edges_normalize, AR.edges_normalize,
-      AR.linkRel_iff_link, AR.linkRel_iff_link]
+    rw [edges_normalize, edges_normalize,
+      linkRel_iff_link, linkRel_iff_link]
     exact (hl i j p q).symm
   · obtain ⟨i, p⟩ := v
     obtain ⟨j, q⟩ := w
     show B.normalize.obj.arcs.Adj ⟨i, Fin.cast (hlen i) p⟩ ⟨j, Fin.cast (hlen j) q⟩
       ↔ A.normalize.obj.arcs.Adj ⟨i, p⟩ ⟨j, q⟩
     rcases eq_or_ne i j with rfl | h
-    · rw [AR.arcs_normalize, AR.arcs_normalize]
+    · rw [arcs_normalize, arcs_normalize]
       exact (Fin.castOrderIso (hlen i)).lt_iff_lt
-    · exact iff_of_false (AR.arcs_normalize_ne h _ _)
-        (AR.arcs_normalize_ne h _ _)
+    · exact iff_of_false (arcs_normalize_ne h _ _)
+        (arcs_normalize_ne h _ _)
   · obtain ⟨i, p⟩ := v
     show B.normalize.obj.label ⟨i, Fin.cast (hlen i) p⟩ = A.normalize.obj.label ⟨i, p⟩
-    rw [AR.label_normalize, AR.label_normalize]
+    rw [label_normalize, label_normalize]
     congr 1
-    rw [← AR.tierWord_getElem, ← AR.tierWord_getElem]
+    rw [← tierWord_getElem, ← tierWord_getElem]
     simp only [hw, Fin.val_cast]
 
 /-- Finite representations with equal tier words and equal links are isomorphic;
     the tuple reading is a complete invariant. -/
-noncomputable def AR.isoOfReaderEq
+noncomputable def isoOfReaderEq
     {A B : TieredAR ι τ}
     [Finite A.obj.V] [Finite B.obj.V]
     (hw : ∀ i, A.tierWord i = B.tierWord i)
     (hl : ∀ i j p q, A.link i j p q ↔ B.link i j p q) : A ≅ B :=
-  AR.mkIso (AR.fullIsoOfReaderEq hw hl)
+  mkIso (fullIsoOfReaderEq hw hl)
 
 end Classification
 
@@ -548,7 +550,7 @@ variable {ι : Type*} {τ : ι → Type*}
     (positions in ℕ coordinates; same-tier and out-of-bounds pairs are
     ignored, and same-tier links are excluded by construction). Arcs are the
     ascending position order on each tier. -/
-def AR.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop) :
+def ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop) :
     TieredAR ι τ where
   obj :=
     { V := (i : ι) × Fin (ws i).length
@@ -575,66 +577,68 @@ def AR.ofData (ws : ∀ i, List (τ i)) (L : ι → ι → ℕ → ℕ → Prop)
 
 variable [Finite ι] {ws : ∀ i, List (τ i)} {L : ι → ι → ℕ → ℕ → Prop}
 
-instance : Finite (AR.ofData ws L).obj.V :=
+instance : Finite (ofData ws L).obj.V :=
   inferInstanceAs (Finite ((i : ι) × Fin (ws i).length))
 
 /-- The canonical carrier's fiber at `i` is its position range. -/
-noncomputable def AR.ofDataFiberEnum (i : ι) :
-    Fin ((ws i).length) ≃o (AR.ofData ws L).fiber i := by
+noncomputable def ofDataFiberEnum (i : ι) :
+    Fin ((ws i).length) ≃o (ofData ws L).fiber i := by
   refine StrictMono.orderIsoOfSurjective (fun p => ⟨⟨i, p⟩, rfl⟩) (fun p q h => ⟨rfl, h⟩)
     fun v => ?_
   obtain ⟨⟨j, q⟩, hp⟩ := v
   obtain rfl : j = i := hp
   exact ⟨q, rfl⟩
 
-theorem AR.tierLength_ofData (i : ι) :
-    (AR.ofData ws L).tierLength i = (ws i).length := by
-  rw [← AR.length_tierWord,
-    AR.tierWord_eq_ofFn (AR.ofDataFiberEnum i), List.length_ofFn]
+theorem tierLength_ofData (i : ι) :
+    (ofData ws L).tierLength i = (ws i).length := by
+  rw [← length_tierWord,
+    tierWord_eq_ofFn (ofDataFiberEnum i), List.length_ofFn]
 
-theorem AR.fiberEnum_ofData (i : ι) :
-    (AR.ofData ws L).fiberEnum i =
-      (Fin.castOrderIso (AR.tierLength_ofData i)).trans
-        (AR.ofDataFiberEnum i) :=
+theorem fiberEnum_ofData (i : ι) :
+    (ofData ws L).fiberEnum i =
+      (Fin.castOrderIso (tierLength_ofData i)).trans
+        (ofDataFiberEnum i) :=
   Subsingleton.elim _ _
 
-theorem AR.vertexEquiv_ofData {i : ι}
-    (r : Fin ((AR.ofData ws L).tierLength i)) :
-    (AR.ofData ws L).vertexEquiv ⟨i, r⟩ =
-      ⟨i, Fin.cast (AR.tierLength_ofData i) r⟩ := by
-  show ((AR.ofData ws L).fiberEnum i r).val = _
-  rw [AR.fiberEnum_ofData]
+theorem vertexEquiv_ofData {i : ι}
+    (r : Fin ((ofData ws L).tierLength i)) :
+    (ofData ws L).vertexEquiv ⟨i, r⟩ =
+      ⟨i, Fin.cast (tierLength_ofData i) r⟩ := by
+  show ((ofData ws L).fiberEnum i r).val = _
+  rw [fiberEnum_ofData]
   rfl
 
 /-- `ofData` reads back its words. -/
-@[simp] theorem AR.tierWord_ofData (i : ι) :
-    (AR.ofData ws L).tierWord i = ws i := by
-  rw [AR.tierWord_eq_ofFn (AR.ofDataFiberEnum i)]
+@[simp] theorem tierWord_ofData (i : ι) :
+    (ofData ws L).tierWord i = ws i := by
+  rw [tierWord_eq_ofFn (ofDataFiberEnum i)]
   exact List.ofFn_getElem
 
 /-- `ofData` reads back its links, symmetrized, on in-bounds cross-tier
     pairs. -/
-theorem AR.link_ofData (i j : ι) (p q : ℕ) :
-    (AR.ofData ws L).link i j p q ↔
+theorem link_ofData (i j : ι) (p q : ℕ) :
+    (ofData ws L).link i j p q ↔
       i ≠ j ∧ p < (ws i).length ∧ q < (ws j).length ∧ (L i j p q ∨ L j i q p) := by
   constructor
   · rintro ⟨hp, hq, hl⟩
-    rw [AR.linkRel_def, AR.vertexEquiv_ofData,
-      AR.vertexEquiv_ofData] at hl
+    rw [linkRel_def, vertexEquiv_ofData,
+      vertexEquiv_ofData] at hl
     obtain ⟨hne, hor⟩ := hl
-    have hp' : p < (ws i).length := AR.tierLength_ofData i ▸ hp
-    have hq' : q < (ws j).length := AR.tierLength_ofData j ▸ hq
+    have hp' : p < (ws i).length := tierLength_ofData i ▸ hp
+    have hq' : q < (ws j).length := tierLength_ofData j ▸ hq
     exact ⟨hne, hp', hq', by simpa using hor⟩
   · rintro ⟨hij, hp, hq, hor⟩
-    have hp' : p < (AR.ofData ws L).tierLength i := by
-      rw [← AR.length_tierWord, AR.tierWord_ofData]; exact hp
-    have hq' : q < (AR.ofData ws L).tierLength j := by
-      rw [← AR.length_tierWord, AR.tierWord_ofData]; exact hq
+    have hp' : p < (ofData ws L).tierLength i := by
+      rw [← length_tierWord, tierWord_ofData]; exact hp
+    have hq' : q < (ofData ws L).tierLength j := by
+      rw [← length_tierWord, tierWord_ofData]; exact hq
     refine ⟨hp', hq', ?_⟩
-    rw [AR.linkRel_def, AR.vertexEquiv_ofData,
-      AR.vertexEquiv_ofData]
+    rw [linkRel_def, vertexEquiv_ofData,
+      vertexEquiv_ofData]
     exact ⟨hij, by simpa using hor⟩
 
 end OfData
+
+end AR
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/OCP.lean
+++ b/Linglib/Phonology/Autosegmental/OCP.lean
@@ -13,7 +13,7 @@ import Linglib.Phonology.Autosegmental.Realization
 A merging tone realization ([jardine-2019]; the melody-merging naming function of
 [jardine-heinz-2015], Mende example) is **OCP-merging**: a tonal melody `Hⁿ` realizes as a
 *single* H node multiply associated to the `n` morae, not `n` separate H nodes. The
-project's `Autosegmental.realize` (`Realization.lean`) instead uses the bridge-only
+project's `Autosegmental.AR.realize` (`Realization.lean`) instead uses the bridge-only
 `concat` (the categorical coproduct), which keeps the `n` H nodes apart. This file
 supplies the missing merge as a post-processing retraction on the upper tier:
 
@@ -334,11 +334,11 @@ section RealizeMerged
 variable {S : Type*}
 
 /-- The OCP-merging realization at melody tier `m` — [jardine-2019]'s merging
-    `g_T`: realize, then merge the melody runs. -/
+    `g_T`: AR.realize, then merge the melody runs. -/
 noncomputable def realizeMerged (g₀ : S → TieredAR ι τ)
     [∀ s, Finite (g₀ s).obj.V] (w : List S) :
     TieredAR ι τ :=
-  (realize g₀ w).collapse m
+  (AR.realize g₀ w).collapse m
 
 end RealizeMerged
 

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -41,10 +41,11 @@ abbrev PrecAR (ι : Type*) (τ : ι → Type*) :=
 
 namespace AR
 
-/-! ### The monoid of representations up to isomorphism -/
-
-section IsoClasses
 open scoped MonoidalCategory
+
+variable {S : Type*} (g₀ : S → TieredAR ι τ)
+
+/-! ### The monoid of representations up to isomorphism -/
 
 /-- A full isomorphism is an isomorphism of the precedence-preserving category;
     both directions preserve arcs. -/
@@ -54,52 +55,31 @@ noncomputable def fullIsoToWideIso {A B : TieredAR ι τ}
 
 /-- The class of a representation, its isomorphism class in the skeleton of the
     precedence-preserving category. -/
-noncomputable def cls
-    (A : TieredAR ι τ) :
-    Skeleton (PrecAR ι τ) :=
+noncomputable def cls (A : TieredAR ι τ) : Skeleton (PrecAR ι τ) :=
   toSkeleton ⟨A⟩
 
 /-- Concatenation of classes is the class of the tensor. -/
-theorem cls_tensor
-    (A B : TieredAR ι τ) :
-    cls (A ⊗ B) = cls A * cls B :=
+theorem cls_tensor (A B : TieredAR ι τ) : cls (A ⊗ B) = cls A * cls B :=
   CategoryTheory.Skeleton.toSkeleton_tensorObj (⟨A⟩ : PrecAR ι τ) ⟨B⟩
 
 /-- Normal forms represent their class. -/
-theorem cls_normalize {X : TieredAR ι τ}
-    [Finite X.obj.V] : cls (X.normalize) = cls X :=
+theorem cls_normalize {X : TieredAR ι τ} [Finite X.obj.V] :
+    cls (X.normalize) = cls X :=
   Quotient.sound ⟨fullIsoToWideIso X.normalizeFullIso⟩
-
-end IsoClasses
 
 /-! ### Realization of strings -/
 
-section Realize
-open scoped MonoidalCategory
-
-variable {S : Type*}
-
 /-- Realize a string as a representation: the iterated tensor of its symbols'
     primitives ([jardine-2019]'s `g`). -/
-noncomputable def realize (g₀ : S → TieredAR ι τ)
-    (w : List S) : TieredAR ι τ :=
+noncomputable def realize (w : List S) : TieredAR ι τ :=
   (w.map g₀).foldr (· ⊗ ·) (𝟙_ _)
 
-@[simp] theorem realize_nil (g₀ : S → TieredAR ι τ) :
-    realize g₀ [] = 𝟙_ _ := rfl
+@[simp] theorem realize_nil : realize g₀ [] = 𝟙_ _ := rfl
 
-@[simp] theorem realize_cons (g₀ : S → TieredAR ι τ)
-    (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
-
-end Realize
+@[simp] theorem realize_cons (a : S) (w : List S) :
+    realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
 
 /-! ### Tier content of realizations -/
-
-section RealizeTierWord
-open scoped MonoidalCategory
-
-variable {S : Type*}
-variable (g₀ : S → TieredAR ι τ)
 
 instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
     Finite (realize g₀ w).obj.V := by
@@ -112,10 +92,7 @@ theorem tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
     (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
   induction w with
   | nil => simp
-  | cons a w ih =>
-    calc (realize g₀ (a :: w)).tierWord i
-        = (g₀ a ⊗ realize g₀ w).tierWord i := rfl
-      _ = ((a :: w).map fun s => (g₀ s).tierWord i).flatten := by simp [ih]
+  | cons a w ih => simp [ih]
 
 /-- The tier-`i` projection of a realization, as a free-monoid homomorphism:
     each symbol contributes its primitive's tier word. -/
@@ -123,19 +100,15 @@ noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
     FreeMonoid S →* FreeMonoid (τ i) :=
   FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
 
+@[simp] theorem tierProj_of [∀ s, Finite (g₀ s).obj.V] (i : ι) (a : S) :
+    tierProj g₀ i (FreeMonoid.of a) = FreeMonoid.ofList ((g₀ a).tierWord i) := rfl
+
 /-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
 theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
     tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((realize g₀ w).tierWord i) := by
   induction w with
-  | nil => simp [realize_nil]
-  | cons a w ih =>
-    rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
-      map_mul, ih]
-    calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((realize g₀ w).tierWord i)
-        = FreeMonoid.ofList ((g₀ a).tierWord i ++ (realize g₀ w).tierWord i) := rfl
-      _ = _ := by rw [← tierWord_tensor i]; rfl
-
-end RealizeTierWord
+  | nil => simp
+  | cons a w ih => simp [FreeMonoid.ofList_cons, FreeMonoid.ofList_append, ih]
 
 end AR
 

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -35,38 +35,40 @@ open CategoryTheory
 
 variable {ι : Type*} {τ : ι → Type*}
 
+/-- Representations with the classical precedence-preserving morphisms. -/
+abbrev PrecAR (ι : Type*) (τ : ι → Type*) :=
+  WideSubcategory (AR.precPreserving (t := (Sigma.fst : ((i : ι) × τ i) → ι)))
+
+namespace AR
+
 /-! ### The monoid of representations up to isomorphism -/
 
 section IsoClasses
 open scoped MonoidalCategory
 
-/-- Representations with the classical precedence-preserving morphisms. -/
-abbrev PrecAR (ι : Type*) (τ : ι → Type*) :=
-  WideSubcategory (AR.precPreserving (t := (Sigma.fst : ((i : ι) × τ i) → ι)))
-
 /-- A full isomorphism is an isomorphism of the precedence-preserving category;
     both directions preserve arcs. -/
-noncomputable def AR.fullIsoToWideIso {A B : TieredAR ι τ}
+noncomputable def fullIsoToWideIso {A B : TieredAR ι τ}
     (e : Graph.Iso A.obj B.obj) : (⟨A⟩ : PrecAR ι τ) ≅ ⟨B⟩ :=
-  CategoryTheory.isoMk (AR.mkIso e) e.toHom_precPreserving e.symm.toHom_precPreserving
+  CategoryTheory.isoMk (mkIso e) e.toHom_precPreserving e.symm.toHom_precPreserving
 
 /-- The class of a representation, its isomorphism class in the skeleton of the
     precedence-preserving category. -/
-noncomputable def AR.cls
+noncomputable def cls
     (A : TieredAR ι τ) :
     Skeleton (PrecAR ι τ) :=
   toSkeleton ⟨A⟩
 
 /-- Concatenation of classes is the class of the tensor. -/
-theorem AR.cls_tensor
+theorem cls_tensor
     (A B : TieredAR ι τ) :
-    AR.cls (A ⊗ B) = AR.cls A * AR.cls B :=
+    cls (A ⊗ B) = cls A * cls B :=
   CategoryTheory.Skeleton.toSkeleton_tensorObj (⟨A⟩ : PrecAR ι τ) ⟨B⟩
 
 /-- Normal forms represent their class. -/
-theorem AR.cls_normalize {X : TieredAR ι τ}
-    [Finite X.obj.V] : AR.cls (X.normalize) = AR.cls X :=
-  Quotient.sound ⟨AR.fullIsoToWideIso X.normalizeFullIso⟩
+theorem cls_normalize {X : TieredAR ι τ}
+    [Finite X.obj.V] : cls (X.normalize) = cls X :=
+  Quotient.sound ⟨fullIsoToWideIso X.normalizeFullIso⟩
 
 end IsoClasses
 
@@ -79,15 +81,15 @@ variable {S : Type*}
 
 /-- Realize a string as a representation: the iterated tensor of its symbols'
     primitives ([jardine-2019]'s `g`). -/
-noncomputable def AR.realize (g₀ : S → TieredAR ι τ)
+noncomputable def realize (g₀ : S → TieredAR ι τ)
     (w : List S) : TieredAR ι τ :=
   (w.map g₀).foldr (· ⊗ ·) (𝟙_ _)
 
-@[simp] theorem AR.realize_nil (g₀ : S → TieredAR ι τ) :
-    AR.realize g₀ [] = 𝟙_ _ := rfl
+@[simp] theorem realize_nil (g₀ : S → TieredAR ι τ) :
+    realize g₀ [] = 𝟙_ _ := rfl
 
-@[simp] theorem AR.realize_cons (g₀ : S → TieredAR ι τ)
-    (a : S) (w : List S) : AR.realize g₀ (a :: w) = g₀ a ⊗ AR.realize g₀ w := rfl
+@[simp] theorem realize_cons (g₀ : S → TieredAR ι τ)
+    (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
 
 end Realize
 
@@ -99,40 +101,42 @@ open scoped MonoidalCategory
 variable {S : Type*}
 variable (g₀ : S → TieredAR ι τ)
 
-instance AR.realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
-    Finite (AR.realize g₀ w).obj.V := by
+instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
+    Finite (realize g₀ w).obj.V := by
   induction w with
   | nil => exact inferInstanceAs (Finite PEmpty)
-  | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (AR.realize g₀ w).obj.V))
+  | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (realize g₀ w).obj.V))
 
 /-- The tier word of a realized string is the concatenation of its symbols' tier words. -/
-theorem AR.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
-    (AR.realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
+theorem tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+    (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
   induction w with
   | nil => simp
   | cons a w ih =>
-    calc (AR.realize g₀ (a :: w)).tierWord i
-        = (g₀ a ⊗ AR.realize g₀ w).tierWord i := rfl
+    calc (realize g₀ (a :: w)).tierWord i
+        = (g₀ a ⊗ realize g₀ w).tierWord i := rfl
       _ = ((a :: w).map fun s => (g₀ s).tierWord i).flatten := by simp [ih]
 
 /-- The tier-`i` projection of a realization, as a free-monoid homomorphism:
     each symbol contributes its primitive's tier word. -/
-noncomputable def AR.tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
+noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
     FreeMonoid S →* FreeMonoid (τ i) :=
   FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
 
-/-- `AR.tierProj` packages `tierWord`: on a word it is the realized tier word. -/
-theorem AR.tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
-    AR.tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((AR.realize g₀ w).tierWord i) := by
+/-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
+theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+    tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((realize g₀ w).tierWord i) := by
   induction w with
-  | nil => simp [AR.realize_nil]
+  | nil => simp [realize_nil]
   | cons a w ih =>
     rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
       map_mul, ih]
-    calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((AR.realize g₀ w).tierWord i)
-        = FreeMonoid.ofList ((g₀ a).tierWord i ++ (AR.realize g₀ w).tierWord i) := rfl
-      _ = _ := by rw [← AR.tierWord_tensor i]; rfl
+    calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((realize g₀ w).tierWord i)
+        = FreeMonoid.ofList ((g₀ a).tierWord i ++ (realize g₀ w).tierWord i) := rfl
+      _ = _ := by rw [← tierWord_tensor i]; rfl
 
 end RealizeTierWord
+
+end AR
 
 end Autosegmental

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -20,7 +20,7 @@ arcs and is too coarse to preserve tier words.
 
 * `PrecAR`, `AR.cls`: representations with the classical precedence-preserving
   morphisms, and the monoid of their isomorphism classes.
-* `realize`, `tierProj`: the realization as iterated tensor, and its per-tier
+* `AR.realize`, `AR.tierProj`: the realization as iterated tensor, and its per-tier
   projections as free-monoid homomorphisms.
 
 ## Main results
@@ -79,15 +79,15 @@ variable {S : Type*}
 
 /-- Realize a string as a representation: the iterated tensor of its symbols'
     primitives ([jardine-2019]'s `g`). -/
-noncomputable def realize (g₀ : S → TieredAR ι τ)
+noncomputable def AR.realize (g₀ : S → TieredAR ι τ)
     (w : List S) : TieredAR ι τ :=
   (w.map g₀).foldr (· ⊗ ·) (𝟙_ _)
 
-@[simp] theorem realize_nil (g₀ : S → TieredAR ι τ) :
-    realize g₀ [] = 𝟙_ _ := rfl
+@[simp] theorem AR.realize_nil (g₀ : S → TieredAR ι τ) :
+    AR.realize g₀ [] = 𝟙_ _ := rfl
 
-@[simp] theorem realize_cons (g₀ : S → TieredAR ι τ)
-    (a : S) (w : List S) : realize g₀ (a :: w) = g₀ a ⊗ realize g₀ w := rfl
+@[simp] theorem AR.realize_cons (g₀ : S → TieredAR ι τ)
+    (a : S) (w : List S) : AR.realize g₀ (a :: w) = g₀ a ⊗ AR.realize g₀ w := rfl
 
 end Realize
 
@@ -99,38 +99,38 @@ open scoped MonoidalCategory
 variable {S : Type*}
 variable (g₀ : S → TieredAR ι τ)
 
-instance realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
-    Finite (realize g₀ w).obj.V := by
+instance AR.realize.instFinite [∀ s, Finite (g₀ s).obj.V] (w : List S) :
+    Finite (AR.realize g₀ w).obj.V := by
   induction w with
   | nil => exact inferInstanceAs (Finite PEmpty)
-  | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (realize g₀ w).obj.V))
+  | cons a w ih => exact inferInstanceAs (Finite ((g₀ a).obj.V ⊕ (AR.realize g₀ w).obj.V))
 
 /-- The tier word of a realized string is the concatenation of its symbols' tier words. -/
 theorem AR.tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
-    (realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
+    (AR.realize g₀ w).tierWord i = (w.map fun s => (g₀ s).tierWord i).flatten := by
   induction w with
   | nil => simp
   | cons a w ih =>
-    calc (realize g₀ (a :: w)).tierWord i
-        = (g₀ a ⊗ realize g₀ w).tierWord i := rfl
+    calc (AR.realize g₀ (a :: w)).tierWord i
+        = (g₀ a ⊗ AR.realize g₀ w).tierWord i := rfl
       _ = ((a :: w).map fun s => (g₀ s).tierWord i).flatten := by simp [ih]
 
 /-- The tier-`i` projection of a realization, as a free-monoid homomorphism:
     each symbol contributes its primitive's tier word. -/
-noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
+noncomputable def AR.tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
     FreeMonoid S →* FreeMonoid (τ i) :=
   FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
 
-/-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
-theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
-    tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((realize g₀ w).tierWord i) := by
+/-- `AR.tierProj` packages `tierWord`: on a word it is the realized tier word. -/
+theorem AR.tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+    AR.tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((AR.realize g₀ w).tierWord i) := by
   induction w with
-  | nil => simp [realize_nil]
+  | nil => simp [AR.realize_nil]
   | cons a w ih =>
     rw [show FreeMonoid.ofList (a :: w) = FreeMonoid.of a * FreeMonoid.ofList w from rfl,
       map_mul, ih]
-    calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((realize g₀ w).tierWord i)
-        = FreeMonoid.ofList ((g₀ a).tierWord i ++ (realize g₀ w).tierWord i) := rfl
+    calc FreeMonoid.ofList ((g₀ a).tierWord i) * FreeMonoid.ofList ((AR.realize g₀ w).tierWord i)
+        = FreeMonoid.ofList ((g₀ a).tierWord i ++ (AR.realize g₀ w).tierWord i) := rfl
       _ = _ := by rw [← AR.tierWord_tensor i]; rfl
 
 end RealizeTierWord

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -99,7 +99,7 @@ instance : DecidableEq (Autosegmental.TwoTier _root_.Tone.TRN Unit true) :=
 noncomputable def plateauRep (w : List TBU) :
     Autosegmental.AR
       (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
-  ((Autosegmental.realize toRep w).collapse true).hull true
+  ((Autosegmental.AR.realize toRep w).collapse true).hull true
 
 instance (w : List TBU) : Finite (plateauRep w).obj.V :=
   inferInstanceAs (Finite ((_ : Bool) × Fin _))
@@ -110,14 +110,14 @@ open scoped MonoidalCategory
 
 /-- The melody word of a realized string: one `H` node per H-toned TBU. -/
 theorem tierWord_realize_toRep_true (w : List TBU) :
-    (Autosegmental.realize toRep w).tierWord true
+    (Autosegmental.AR.realize toRep w).tierWord true
       = List.replicate (w.count .H) _root_.Tone.TRN.H := by
   induction w with
   | nil => simp [Autosegmental.AR.tierWord_unit]
   | cons a w ih =>
-    calc (Autosegmental.realize toRep (a :: w)).tierWord true
-        = (toRep a ⊗ Autosegmental.realize toRep w).tierWord true := rfl
-      _ = (toRep a).tierWord true ++ (Autosegmental.realize toRep w).tierWord true :=
+    calc (Autosegmental.AR.realize toRep (a :: w)).tierWord true
+        = (toRep a ⊗ Autosegmental.AR.realize toRep w).tierWord true := rfl
+      _ = (toRep a).tierWord true ++ (Autosegmental.AR.realize toRep w).tierWord true :=
           Autosegmental.AR.tierWord_tensor true
       _ = List.replicate ((a :: w).count .H) _root_.Tone.TRN.H := by
           rw [ih]
@@ -133,13 +133,13 @@ theorem tierWord_realize_toRep_true (w : List TBU) :
 
 /-- The timing word of a realized string: one slot per TBU. -/
 theorem tierWord_realize_toRep_false (w : List TBU) :
-    (Autosegmental.realize toRep w).tierWord false = List.replicate w.length () := by
+    (Autosegmental.AR.realize toRep w).tierWord false = List.replicate w.length () := by
   induction w with
   | nil => simp [Autosegmental.AR.tierWord_unit]
   | cons a w ih =>
-    calc (Autosegmental.realize toRep (a :: w)).tierWord false
-        = (toRep a ⊗ Autosegmental.realize toRep w).tierWord false := rfl
-      _ = (toRep a).tierWord false ++ (Autosegmental.realize toRep w).tierWord false :=
+    calc (Autosegmental.AR.realize toRep (a :: w)).tierWord false
+        = (toRep a ⊗ Autosegmental.AR.realize toRep w).tierWord false := rfl
+      _ = (toRep a).tierWord false ++ (Autosegmental.AR.realize toRep w).tierWord false :=
           Autosegmental.AR.tierWord_tensor false
       _ = List.replicate (a :: w).length () := by
           rw [ih, List.length_cons, List.replicate_succ]
@@ -154,13 +154,13 @@ theorem tierWord_realize_toRep_false (w : List TBU) :
 /-- Links of a realized string: slot `j` links to melody node `p` exactly when
     TBU `j` is H-toned and `p` is its accumulated melody position. -/
 theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
-    (Autosegmental.realize toRep w).link true false p j ↔
+    (Autosegmental.AR.realize toRep w).link true false p j ↔
       p = (w.take j).count .H ∧ w[j]? = some .H := by
   induction w generalizing p j with
   | nil =>
-    have h0 : (Autosegmental.realize toRep []).tierLength true = 0 := by
+    have h0 : (Autosegmental.AR.realize toRep []).tierLength true = 0 := by
       rw [← Autosegmental.AR.length_tierWord,
-        show (Autosegmental.realize toRep []).tierWord true = _ from
+        show (Autosegmental.AR.realize toRep []).tierWord true = _ from
           Autosegmental.AR.tierWord_unit true, List.length_nil]
     constructor
     · rintro ⟨hp, -, -⟩
@@ -168,11 +168,11 @@ theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
     · rintro ⟨-, h⟩
       simp at h
   | cons a w ih =>
-    haveI := Autosegmental.realize.instFinite toRep w
-    rw [show (Autosegmental.realize toRep (a :: w)).link true false p j
-          = (toRep a ⊗ Autosegmental.realize toRep w).link true false p j from rfl,
+    haveI := Autosegmental.AR.realize.instFinite toRep w
+    rw [show (Autosegmental.AR.realize toRep (a :: w)).link true false p j
+          = (toRep a ⊗ Autosegmental.AR.realize toRep w).link true false p j from rfl,
       Autosegmental.AR.link_tensor (X := toRep a)
-        (Y := Autosegmental.realize toRep w) true false p j]
+        (Y := Autosegmental.AR.realize toRep w) true false p j]
     cases a
     · have hta : (toRep TBU.H).tierLength true = 1 := by
         rw [← Autosegmental.AR.length_tierWord,
@@ -250,9 +250,9 @@ theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
 /-- Links of the OCP-merged realization: the single fused `H` node (index `0`)
     links exactly to the H-toned slots. -/
 theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
-    ((Autosegmental.realize toRep w).collapse true).link true false k j ↔
+    ((Autosegmental.AR.realize toRep w).collapse true).link true false k j ↔
       k = 0 ∧ w[j]? = some .H := by
-  haveI := Autosegmental.realize.instFinite toRep w
+  haveI := Autosegmental.AR.realize.instFinite toRep w
   rw [Autosegmental.AR.link_collapse]
   constructor
   · rintro ⟨p, q, hl, hk, hjq⟩
@@ -280,13 +280,13 @@ theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
 theorem link_plateauRep (w : List TBU) (j : ℕ) :
     (∃ k, (plateauRep w).link true false k j) ↔
       .H ∈ w.take (j + 1) ∧ .H ∈ w.drop j := by
-  haveI := Autosegmental.realize.instFinite toRep w
-  have hlen : ((Autosegmental.realize toRep w).collapse true).tierLength false
+  haveI := Autosegmental.AR.realize.instFinite toRep w
+  have hlen : ((Autosegmental.AR.realize toRep w).collapse true).tierLength false
       = w.length := by
     rw [← Autosegmental.AR.length_tierWord,
       Autosegmental.AR.tierWord_collapse,
-      show (Autosegmental.realize toRep w).collapsedWord true false
-        = (Autosegmental.realize toRep w).tierWord false from
+      show (Autosegmental.AR.realize toRep w).collapsedWord true false
+        = (Autosegmental.AR.realize toRep w).tierWord false from
         Function.update_of_ne (by decide) _ _,
       tierWord_realize_toRep_false]
     exact List.length_replicate
@@ -297,13 +297,13 @@ theorem link_plateauRep (w : List TBU) (j : ℕ) :
     have hlenh : (plateauRep w).tierLength false = w.length := by
       rw [← Autosegmental.AR.length_tierWord,
         show (plateauRep w).tierWord false
-          = ((Autosegmental.realize toRep w).collapse true).tierWord false from
+          = ((Autosegmental.AR.realize toRep w).collapse true).tierWord false from
           Autosegmental.AR.tierWord_hull true _ false,
         Autosegmental.AR.length_tierWord, hlen]
     have hjw : j < w.length := hlenh ▸ hjb
     obtain ⟨q₁, q₂, h₁, h₂, hle₁, hle₂⟩ :=
       (Autosegmental.AR.link_hull_left true _ (by decide)
-        (by omega : j < ((Autosegmental.realize toRep w).collapse true).tierLength false)).mp hk
+        (by omega : j < ((Autosegmental.AR.realize toRep w).collapse true).tierLength false)).mp hk
     obtain ⟨-, hq₁⟩ := (link_realizeMerged w k q₁).mp h₁
     obtain ⟨-, hq₂⟩ := (link_realizeMerged w k q₂).mp h₂
     exact ⟨⟨q₁, by omega, hq₁⟩, q₂, hle₂, hq₂⟩
@@ -314,7 +314,7 @@ theorem link_plateauRep (w : List TBU) (j : ℕ) :
     have hl₁ := (link_realizeMerged w 0 q₁).mpr ⟨rfl, hq₁⟩
     have hl₂ := (link_realizeMerged w 0 q₂).mpr ⟨rfl, hq₂⟩
     exact ⟨0, (Autosegmental.AR.link_hull_left true _ (by decide)
-      (by omega : j < ((Autosegmental.realize toRep w).collapse true).tierLength false)).mpr
+      (by omega : j < ((Autosegmental.AR.realize toRep w).collapse true).tierLength false)).mpr
       ⟨q₁, q₂, hl₁, hl₂, by omega, hq₂b⟩⟩
 
 end TierWords

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -213,13 +213,13 @@ fuses to one `H`, linked exactly to the surfacing slots. -/
 /-- (7) in coordinates: the merged output's links are the fused `H` node over
     the surfacing positions. -/
 theorem link_realizeMerged_map {w : List TBU} {k j : ℕ} :
-    ((Autosegmental.realize Tone.Plateauing.toRep (utp.map w)).collapse true).link
+    ((Autosegmental.AR.realize Tone.Plateauing.toRep (utp.map w)).collapse true).link
         true false k j ↔ k = 0 ∧ utp.Surfaces w j := by
   rw [Tone.Plateauing.link_realizeMerged, utp.map_getElem?_H_iff]
 
 /-- (7) concretely: `HØØH` fuses to one H linked to all four TBUs. -/
 example : ∀ j < 4,
-    ((Autosegmental.realize Tone.Plateauing.toRep
+    ((Autosegmental.AR.realize Tone.Plateauing.toRep
       (utp.map [.H, .O, .O, .H])).collapse true).link true false 0 j := by
   intro j hj
   rw [link_realizeMerged_map]

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -23,10 +23,10 @@ banned-subgraph constraints over its realizations.
 
 Two realizations are checked, against the same forbidden tone melody `*HLH`:
 
-* `Autosegmental.realize` uses the project's *bridge-only* `concat` (the coproduct), so
+* `Autosegmental.AR.realize` uses the project's *bridge-only* `concat` (the coproduct), so
   an `H`-plateau `Hⁿ` stays `n` separate `H` nodes. Banning `*HLH` over `AR.realize` then
   catches only a *local* `H-L-H` (three adjacent tonal nodes) — `hlh_excluded`.
-* `Autosegmental.realizeMerged` (`OCP.lean`) is [jardine-2019]'s OCP-*merging*
+* `Autosegmental.AR.realizeMerged` (`OCP.lean`) is [jardine-2019]'s OCP-*merging*
   `g_T`: `g_T(Hⁿ)` is a *single* `H` node multiply associated. Banning `*HLH` over
   `AR.realizeMerged` becomes genuinely **non-local** — it forbids `H⁺ L⁺ H⁺` for *any*
   plateau widths, because the plateaus collapse to single nodes before the melody is
@@ -64,20 +64,20 @@ variable {ι : Type*} [Finite ι] {τ : ι → Type*}
 /-- The Autosegmental Strictly Local stringset `ASL^g`: strings whose realization
     avoids every forbidden factor. It is the same construction as the tier-based
     strictly local sets — a preimage of a local condition along a free-monoid
-    homomorphism (`TSL = tierProject ⁻¹' SL`); the association structure `realize`
+    homomorphism (`TSL = tierProject ⁻¹' SL`); the association structure `AR.realize`
     keeps is why [jardine-2019] finds the two classes incomparable. -/
 def AR.ASL (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
     [∀ s, Finite (g₀ s).obj.V]
     (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
     Language S :=
-  { w | (realize g₀ w).Free B }
+  { w | (AR.realize g₀ w).Free B }
 
 omit [Finite ι] in
 @[simp] theorem AR.mem_ASL
     {g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)}
     [∀ s, Finite (g₀ s).obj.V]
     {B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}}
-    {w : List S} : w ∈ AR.ASL g₀ B ↔ (realize g₀ w).Free B := Iff.rfl
+    {w : List S} : w ∈ AR.ASL g₀ B ↔ (AR.realize g₀ w).Free B := Iff.rfl
 
 /-- For a single link-free forbidden factor, the strings whose realization
     contains it form a star-free language: the finite intersection of per-tier
@@ -88,17 +88,17 @@ theorem AR.isStarFree_occur_of_link_free
     [∀ s, Finite (g₀ s).obj.V]
     (F : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite F.obj.V]
     (hF : ∀ i j p q, ¬ F.link i j p q) :
-    Language.IsStarFree {w : List S | F.FactorEmbeds (Autosegmental.realize g₀ w)} := by
-  have hset : {w : List S | F.FactorEmbeds (Autosegmental.realize g₀ w)}
-      = ⋂ i, {w : List S | F.tierWord i <:+: tierProj g₀ i (FreeMonoid.ofList w)} := by
+    Language.IsStarFree {w : List S | F.FactorEmbeds (Autosegmental.AR.realize g₀ w)} := by
+  have hset : {w : List S | F.FactorEmbeds (Autosegmental.AR.realize g₀ w)}
+      = ⋂ i, {w : List S | F.tierWord i <:+: AR.tierProj g₀ i (FreeMonoid.ofList w)} := by
     ext w
-    haveI := Autosegmental.realize.instFinite g₀ w
+    haveI := Autosegmental.AR.realize.instFinite g₀ w
     simp only [Set.mem_setOf_eq, Set.mem_iInter,
-      AR.factorEmbeds_iff_infix_of_link_free hF, tierProj_ofList]
+      AR.factorEmbeds_iff_infix_of_link_free hF, AR.tierProj_ofList]
     exact Iff.rfl
   rw [hset]
   exact Language.IsStarFree.iInter fun i =>
-    (Language.isStarFree_containsFactor (F.tierWord i)).comap (tierProj g₀ i)
+    (Language.isStarFree_containsFactor (F.tierWord i)).comap (AR.tierProj g₀ i)
 
 /-- **Link-free autosegmental SL sets are star-free**, on the graph foundation:
     when no forbidden factor carries association lines, `AR.ASL` is
@@ -122,7 +122,7 @@ theorem AR.ASL.isStarFree_of_link_free
     have ih' := ih fun F' hF' => hB F' (List.mem_cons_of_mem _ hF')
     have hset : AR.ASL g₀ (F :: B') =
         {w : List S | haveI := F.property
-          F.val.FactorEmbeds (Autosegmental.realize g₀ w)}ᶜ ∩ AR.ASL g₀ B' := by
+          F.val.FactorEmbeds (Autosegmental.AR.realize g₀ w)}ᶜ ∩ AR.ASL g₀ B' := by
       ext w
       show (∀ G ∈ F :: B', _) ↔ _
       rw [List.forall_mem_cons]


### PR DESCRIPTION
Namespace-AR blocks across the split trio, IsFactorAt as a two-field Prop structure with offset_le/clamp, sharpened Core isInfix_iff_exists_offset, and Realization binder hoisting with simp-golfed tierProj.