### PR TITLE
refactor(Semantics/Modification): lattice-general classification

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1739,8 +1739,8 @@ import Linglib.Semantics.Modality.Temporal
 import Linglib.Semantics.Modality.TemporalAxes
 import Linglib.Semantics.Modality.TemporalConstraint
 import Linglib.Semantics.Modality.Typology
-import Linglib.Semantics.Modification.Adjective
 import Linglib.Semantics.Modification.Basic
+import Linglib.Semantics.Modification.Classification
 import Linglib.Semantics.Modification.Coercion
 import Linglib.Semantics.Modification.RelativeClause
 import Linglib.Semantics.Mood.Defs

--- a/Linglib/Semantics/Degree/Adjective.lean
+++ b/Linglib/Semantics/Degree/Adjective.lean
@@ -27,7 +27,7 @@ abstract `PolarMeasure`.
 Core degree types (`Degree`, `Threshold`) live in `Core.MeasurementScale`; the
 threshold semantics (`positiveMeaning`, `negativeMeaning`) in `Semantics/Degree/Basic`.
 The intersective/subsective/privative classification lives in
-`Semantics/Modification/Adjective.lean`.
+`Semantics/Modification/Classification.lean`.
 -/
 
 namespace Degree

--- a/Linglib/Semantics/Modification/Adjective.lean
+++ b/Linglib/Semantics/Modification/Adjective.lean
@@ -81,6 +81,12 @@ def isIntersective (adj : AdjMeaning W E) : Prop :=
 def isSubsective (adj : AdjMeaning W E) : Prop :=
   ∀ (N : Property W E) (w : W) (x : E), adj N w x → N w x
 
+/-- Subsectivity is the deflationary condition in the pointwise order:
+    `adj ≤ id`. -/
+theorem isSubsective_iff_le_id {adj : AdjMeaning W E} :
+    isSubsective adj ↔ adj ≤ id :=
+  Iff.rfl
+
 /-- An adjective is **privative** if its extension is always disjoint
     from the noun's extension ([kamp-1975]).
 

--- a/Linglib/Semantics/Modification/Basic.lean
+++ b/Linglib/Semantics/Modification/Basic.lean
@@ -1,4 +1,4 @@
-import Mathlib.Logic.Basic
+import Mathlib.Order.PropInstances
 
 /-!
 # Modifiers
@@ -10,24 +10,22 @@ adverbs, and relative clauses are all modifiers — of *different* `τ` (nominal
 `e ⇒ t`, event `Event → Prop`, …) — unified by *being* this type, not by
 implementing an interface.
 
-The well-behaved special case is **intersective** modification: conjunction with a
-fixed property (`λx. P x ∧ Q x`), on which restrictive relative clauses,
-intersective adjectives, and manner adverbs all converge.
+The [kamp-1975] meaning-postulate classification is order-theoretic and is
+stated here at that generality: over an ordered carrier, **subsective**
+modifiers are deflationary (`m x ≤ x`), **privative** modifiers have output
+disjoint from the modificand, and **intersective** modifiers are
+meet-translations (`m x = q ⊓ x`; at `α → Prop`, pointwise conjunction).
+The intensional hierarchy (`Modification/Classification.lean`) and its
+single-world specializations (`Studies/Kamp1975.lean` § 1) are these
+classes at the carriers `W → E → Prop` and `E → Prop`.
 
 ## Main declarations
 
 * `Modifier` — a modifier of `τ` is an endofunction `τ → τ`.
-* `Modifier.intersective` — the intersective modifier built from a property `P`.
-
-## Implementation notes
-
-`Modifier.intersective` is the canonical intersective-modification operation; the
-concrete reflexes reduce to it (`ArgumentStructure`'s `modify` over events calls
-it; the type-driven interpreter's Predicate Modification step is it at `e ⇒ t`).
-The [kamp-1975] modifier-meaning classification (intersective / subsective /
-privative / extensional) lives at its intensional generality in
-`Modification/Adjective.lean`; `Studies/Kamp1975.lean` § 1 specializes it to a
-single world.
+* `Modifier.intersective` — the intersective modifier built from `q`: meet
+  the modificand with `q`.
+* `Modifier.isIntersective` / `.isSubsective` / `.isPrivative` — the
+  [kamp-1975] classification over an ordered carrier.
 -/
 
 /-- A modifier of `τ` is a function on the modificand's denotation
@@ -39,8 +37,50 @@ namespace Modifier
 
 variable {α : Type*}
 
+/-- A modifier over an ordered carrier is **subsective** if its output lies
+    below the modificand: a skillful surgeon is a surgeon. -/
+def isSubsective [LE α] (m : Modifier α) : Prop :=
+  ∀ x, m x ≤ x
+
+/-- Subsectivity is the deflationary condition in the pointwise order on
+    modifiers. -/
+theorem isSubsective_iff_le_id [LE α] {m : Modifier α} :
+    isSubsective m ↔ m ≤ id :=
+  Iff.rfl
+
+/-- A modifier is **privative** if its output is disjoint from the
+    modificand: a fake gun is not a gun. -/
+def isPrivative [PartialOrder α] [OrderBot α] (m : Modifier α) : Prop :=
+  ∀ x, Disjoint (m x) x
+
+/-- A modifier that is both privative and subsective sends every modificand
+    to `⊥` — the order-theoretic core of "privative is incompatible with
+    subsective". -/
+theorem isPrivative.eq_bot [PartialOrder α] [OrderBot α] {m : Modifier α}
+    (hp : isPrivative m) (hs : isSubsective m) (x : α) : m x = ⊥ :=
+  le_bot_iff.mp (hp x le_rfl (hs x))
+
+section SemilatticeInf
+
+variable [SemilatticeInf α]
+
+/-- A modifier is **intersective** if it is meet with some fixed element. -/
+def isIntersective (m : Modifier α) : Prop :=
+  ∃ q, ∀ x, m x = q ⊓ x
+
+/-- Intersective ⟹ subsective ([kamp-1975]'s implication structure). -/
+theorem isIntersective.isSubsective {m : Modifier α}
+    (h : isIntersective m) : isSubsective m := by
+  obtain ⟨q, hq⟩ := h
+  intro x
+  rw [hq]
+  exact inf_le_right
+
+end SemilatticeInf
+
 /-- The intersective modifier built from a property `P`: combine `P` with the
-    modificand by pointwise conjunction. The well-behaved special case
+    modificand by pointwise conjunction — meet-translation at the carrier
+    `α → Prop` (`intersective_isIntersective`). The well-behaved special case
     (restrictive relative clauses, intersective adjectives, manner adverbs). -/
 def intersective (P : α → Prop) : Modifier (α → Prop) :=
   fun Q x => P x ∧ Q x
@@ -51,5 +91,9 @@ def intersective (P : α → Prop) : Modifier (α → Prop) :=
 /-- Head and modifier intersect symmetrically (conjunction is commutative). -/
 theorem intersective_comm (P Q : α → Prop) : intersective P Q = intersective Q P := by
   funext x; exact propext And.comm
+
+theorem intersective_isIntersective (P : α → Prop) :
+    isIntersective (intersective P) :=
+  ⟨P, fun _ => rfl⟩
 
 end Modifier

--- a/Linglib/Semantics/Modification/Classification.lean
+++ b/Linglib/Semantics/Modification/Classification.lean
@@ -1,12 +1,21 @@
+import Linglib.Semantics.Modification.Basic
+import Mathlib.Order.PropInstances
 import Mathlib.Data.Set.Basic
 import Mathlib.Tactic.Common
 
 /-!
-# Adjective Classification Hierarchy
+# Modifier-Meaning Classification at the Intensional Carrier
 [kamp-1975] [kamp-partee-1995] [parsons-1970]
 
-The standard classification of adjective meanings as functions from
-properties to properties, constrained by meaning postulates.
+The standard classification of adnominal modifier meanings, constrained
+by meaning postulates. The order-theoretic classes
+(`Modifier.isIntersective` / `.isSubsective` / `.isPrivative`) live in
+`Modification/Basic.lean`; this file works at the intensional carrier
+`Modifier (Property W E)` — functions from properties to properties,
+type `⟨⟨s,⟨e,t⟩⟩, ⟨s,⟨e,t⟩⟩⟩` in Montague notation — adding the
+pointwise unfolding lemmas, the one genuinely intensional class
+(`isExtensional`), the implication structure, and [partee-2010]'s
+post-collapse `RevisedClass`.
 
 [parsons-1970] independently introduced the operator approach
 (modifiers as functions on predicates, not conjoinable predicates) and
@@ -34,12 +43,12 @@ Privative is incompatible with subsective (given non-empty extension).
 
 ## Design
 
-The hierarchy is defined over *intensional* adjective meanings
-(`Property W E → Property W E`) parameterized by a world type `W` and
-entity type `E`. This is the most general formulation, from which
-single-world (extensional) specializations follow — see
-`Studies/Kamp1975.lean` § 1 for the single-world specialization
-theorems.
+Single-world (extensional) specializations are the same order-theoretic
+classes at the carrier `E → Prop` — see `Studies/Kamp1975.lean` § 1 for
+the specialization theorems. Whether *adjectives* uniformly denote
+`Modifier (Property W E)` is itself a theoretical claim (see
+`Studies/Elbourne2026.lean`); the carrier is named for the denotation
+type, not the word class.
 
 [partee-2010] argues the privative class should be eliminated
 in favor of subsective + noun coercion; see `Partee2010.lean`. The
@@ -54,89 +63,85 @@ namespace Modification
     predicates over entities. -/
 abbrev Property (W E : Type*) := W → E → Prop
 
-/-- An adjective meaning: a function from noun properties to modified
-    noun-phrase properties (type `⟨⟨s,⟨e,t⟩⟩, ⟨s,⟨e,t⟩⟩⟩` in Montague
-    notation). -/
-abbrev AdjMeaning (W E : Type*) := Property W E → Property W E
-
-/-! ### Class Definitions -/
+/-! ### Pointwise forms of the order-theoretic classes -/
 
 section Hierarchy
 
-variable {W E : Type*}
+open Modifier
 
-/-- An adjective is **intersective** if its extension at each world is the
-    intersection of the noun's extension with some fixed property Q
-    ([kamp-1975]).
+variable {W E : Type*} {adj : Modifier (Property W E)}
+
+/-- Pointwise form of `Modifier.isIntersective` at the intensional
+    carrier: the extension at each world is the intersection of the
+    noun's extension with some fixed property Q ([kamp-1975]).
 
     Examples: "gray", "French", "carnivorous", "four-legged". -/
-def isIntersective (adj : AdjMeaning W E) : Prop :=
-  ∃ (Q : Property W E), ∀ (N : Property W E) (w : W) (x : E),
-    adj N w x ↔ (Q w x ∧ N w x)
+theorem isIntersective_iff :
+    isIntersective adj ↔
+      ∃ (Q : Property W E), ∀ (N : Property W E) (w : W) (x : E),
+        adj N w x ↔ (Q w x ∧ N w x) := by
+  refine ⟨fun ⟨Q, hQ⟩ => ⟨Q, fun N w x => by rw [hQ]; exact Iff.rfl⟩,
+          fun ⟨Q, hQ⟩ => ⟨Q, fun N => ?_⟩⟩
+  funext w x
+  exact propext (hQ N w x)
 
-/-- An adjective is **subsective** if its extension is always a subset
-    of the noun's extension ([kamp-1975]).
+/-- Pointwise form of `Modifier.isSubsective` at the intensional
+    carrier: the extension is always a subset of the noun's extension
+    ([kamp-1975]).
 
     Examples: "skillful", "good", "typical". -/
-def isSubsective (adj : AdjMeaning W E) : Prop :=
-  ∀ (N : Property W E) (w : W) (x : E), adj N w x → N w x
-
-/-- Subsectivity is the deflationary condition in the pointwise order:
-    `adj ≤ id`. -/
-theorem isSubsective_iff_le_id {adj : AdjMeaning W E} :
-    isSubsective adj ↔ adj ≤ id :=
+theorem isSubsective_iff :
+    isSubsective adj ↔
+      ∀ (N : Property W E) (w : W) (x : E), adj N w x → N w x :=
   Iff.rfl
 
-/-- An adjective is **privative** if its extension is always disjoint
-    from the noun's extension ([kamp-1975]).
+/-- Pointwise form of `Modifier.isPrivative` at the intensional carrier:
+    the extension is always disjoint from the noun's extension
+    ([kamp-1975]).
 
     Examples: "fake", "counterfeit".
     [partee-2010] argues this class should be eliminated. -/
-def isPrivative (adj : AdjMeaning W E) : Prop :=
-  ∀ (N : Property W E) (w : W) (x : E), adj N w x → ¬ N w x
+theorem isPrivative_iff :
+    isPrivative adj ↔
+      ∀ (N : Property W E) (w : W) (x : E), adj N w x → ¬ N w x := by
+  simp only [isPrivative, Pi.disjoint_iff, Prop.disjoint_iff, not_and]
 
-/-- An adjective is **extensional** if its extension in world w depends
-    only on the noun's extension in w, not on the noun's intension
-    ([kamp-1975]).
+/-- A modifier meaning is **extensional** if its extension in world w
+    depends only on the noun's extension in w, not on the noun's
+    intension ([kamp-1975]). The one class of the hierarchy that is
+    genuinely intensional — it has no order-theoretic form.
 
     "four-legged" and "gray" are extensional; "skillful" is not (being a
     skillful surgeon depends on what counts as a surgeon across contexts,
     not just who the surgeons are in this world). -/
-def isExtensional (adj : AdjMeaning W E) : Prop :=
+def isExtensional (adj : Modifier (Property W E)) : Prop :=
   ∀ (N₁ N₂ : Property W E) (w : W),
     (∀ x, N₁ w x ↔ N₂ w x) → ∀ x, adj N₁ w x ↔ adj N₂ w x
 
 /-! ### Implication Structure
 
-    Intersective → {extensional, subsective}.
+    Intersective → {extensional, subsective} (the second is
+    `Modifier.isIntersective.isSubsective`, at any carrier).
     Extensional and subsective are independent.
-    Privative is incompatible with subsective (given non-empty extension). -/
+    Privative is incompatible with subsective (given non-empty extension;
+    the order-theoretic core is `Modifier.isPrivative.eq_bot`). -/
 
-/-- Intersective adjectives are extensional: if `F(N)(w)(x) ↔ Q(w)(x) ∧ N(w)(x)`,
-    then the result in w depends only on N(w). -/
-theorem intersective_implies_extensional {adj : AdjMeaning W E}
-    (h : isIntersective adj) : isExtensional adj := by
-  obtain ⟨Q, hQ⟩ := h
+/-- Intersective modifier meanings are extensional: if
+    `F(N)(w)(x) ↔ Q(w)(x) ∧ N(w)(x)`, then the result in w depends only
+    on N(w). -/
+theorem isExtensional_of_isIntersective (h : isIntersective adj) :
+    isExtensional adj := by
+  obtain ⟨Q, hQ⟩ := isIntersective_iff.mp h
   intro N₁ N₂ w hext x
   simp only [hQ, hext]
 
-/-- Intersective adjectives are subsective: if
-    `F(N)(w)(x) ↔ Q(w)(x) ∧ N(w)(x)`, then `F(N)(w)(x) → N(w)(x)`. -/
-theorem intersective_implies_subsective {adj : AdjMeaning W E}
-    (h : isIntersective adj) : isSubsective adj := by
-  obtain ⟨Q, hQ⟩ := h
-  intro N w x hadj
-  exact ((hQ N w x).mp hadj).2
-
-/-- Privative adjectives are not subsective (when the adjective has
+/-- Privative modifier meanings are not subsective (when the modifier has
     non-empty extension for some noun). -/
-theorem privative_not_subsective {adj : AdjMeaning W E}
-    (hp : isPrivative adj)
-    (hne : ∃ N w x, adj N w x) :
-    ¬ isSubsective adj := by
-  intro ha
+theorem not_isSubsective_of_isPrivative (hp : isPrivative adj)
+    (hne : ∃ N w x, adj N w x) : ¬ isSubsective adj := by
+  intro hs
   obtain ⟨N, w, x, hadj⟩ := hne
-  exact hp N w x hadj (ha N w x hadj)
+  exact isPrivative_iff.mp hp N w x hadj (hs N w x hadj)
 
 end Hierarchy
 
@@ -147,17 +152,19 @@ end Hierarchy
 
 section Independence
 
+open Modifier
+
 /-- Witness: extensional but NOT subsective.
-    An adjective that ignores both the noun and intension entirely
+    A modifier that ignores both the noun and intension entirely
     (always returns True) is trivially extensional, but not subsective
     because it holds even when the noun does not. -/
 private inductive W1 | w
 private inductive E1 | a
 
-private def extNotSubAdj : AdjMeaning W1 E1 := fun _N _w _x => True
+private def extNotSubAdj : Modifier (Property W1 E1) := fun _N _w _x => True
 
 theorem extensional_not_implies_subsective :
-    ∃ (adj : AdjMeaning W1 E1), isExtensional adj ∧ ¬ isSubsective adj :=
+    ∃ (adj : Modifier (Property W1 E1)), isExtensional adj ∧ ¬ isSubsective adj :=
   ⟨extNotSubAdj,
    fun _ _ _ _ _ => Iff.rfl,
    fun h => (h (fun _ _ => False) .w .a trivial).elim⟩
@@ -169,13 +176,13 @@ theorem extensional_not_implies_subsective :
 private inductive W2' | w₁ | w₂
 private inductive E2 | a | b
 
-private def subNotExtAdj : AdjMeaning W2' E2 := fun N w x =>
+private def subNotExtAdj : Modifier (Property W2' E2) := fun N w x =>
   N w x ∧ match x with
     | .a => N .w₁ .a
     | _  => False
 
 theorem subsective_not_implies_extensional :
-    ∃ (adj : AdjMeaning W2' E2), isSubsective adj ∧ ¬ isExtensional adj :=
+    ∃ (adj : Modifier (Property W2' E2)), isSubsective adj ∧ ¬ isExtensional adj :=
   ⟨subNotExtAdj,
    fun _ _ _ h => h.1,
    fun hext => by
@@ -218,8 +225,8 @@ inductive RevisedClass where
 
 /-- Predicate-level interpretation of `RevisedClass`. Per the subset
     ordering, `intersective` and `subsective` are not disjoint: every
-    intersective adjective satisfies `isSubsective` (see
-    `intersective_implies_subsective`).
+    intersective modifier meaning satisfies `Modifier.isSubsective`
+    (`Modifier.isIntersective.isSubsective`).
 
     Caveat on `.nonSubsective`: the membership condition `¬ isSubsective
     adj` is necessary but coarse — it also holds of Kamp-privatives,
@@ -227,10 +234,10 @@ inductive RevisedClass where
     natural class. Read `.nonSubsective` as Partee's *intended* "modal"
     class (alleged, potential, putative); the bare predicate
     `¬ isSubsective` over-generates. -/
-def RevisedClass.satisfies : RevisedClass → AdjMeaning W E → Prop
-  | .intersective  => isIntersective
-  | .subsective    => isSubsective
-  | .nonSubsective => fun adj => ¬ isSubsective adj
+def RevisedClass.satisfies : RevisedClass → Modifier (Property W E) → Prop
+  | .intersective  => Modifier.isIntersective
+  | .subsective    => Modifier.isSubsective
+  | .nonSubsective => fun adj => ¬ Modifier.isSubsective adj
 
 end Revised
 

--- a/Linglib/Semantics/Modification/Coercion.lean
+++ b/Linglib/Semantics/Modification/Coercion.lean
@@ -22,7 +22,10 @@ partial setting. Not to be confused with complement coercion
 ## Main definitions
 
 * `isNonVacuous P w d`: NVP at world `w` within local domain `d`.
-* `LicensedCoercion N adj w`: NVP-licensed widening of `N`.
+* `LicensedCoercion N adj w`: NVP-licensed widening of `N`. The `shift`
+  is a full intension even though licensing holds at the single context
+  world `w`: a non-extensional `adj` reads the shift's values at other
+  worlds.
 * `SubsectiveReanalysis adjClassical`: reanalysis as subsective-after-coercion.
 -/
 
@@ -35,27 +38,46 @@ variable {W E : Type*}
 def isNonVacuous (P : Property W E) (w : W) (d : E → Prop) : Prop :=
   (∃ x, d x ∧ P w x) ∧ (∃ x, d x ∧ ¬ P w x)
 
+/-- `isNonVacuous` is monotone in the local domain. -/
+theorem isNonVacuous.mono {P : Property W E} {w : W} {d d' : E → Prop}
+    (h : isNonVacuous P w d) (hdd' : d ≤ d') : isNonVacuous P w d' :=
+  ⟨h.1.imp fun x hx => ⟨hdd' x hx.1, hx.2⟩, h.2.imp fun x hx => ⟨hdd' x hx.1, hx.2⟩⟩
+
+/-- The NVP is self-dual: a predicate and its complement are non-vacuous
+    in the same local domains. -/
+theorem isNonVacuous_compl {P : Property W E} {w : W} {d : E → Prop} :
+    isNonVacuous (fun w x => ¬ P w x) w d ↔ isNonVacuous P w d := by
+  unfold isNonVacuous
+  simp only [not_not]
+  exact and_comm
+
 /-- A wider noun extension `shift ⊇ N` at `w` under which `adj shift`
     is non-vacuous in `shift`'s extension (the HPP local domain). -/
 structure LicensedCoercion (N : Property W E) (adj : AdjMeaning W E) (w : W) where
   shift : Property W E
-  le_shift : ∀ x, N w x → shift w x
+  le_shift : N w ≤ shift w
   satisfies_nvp : isNonVacuous (adj shift) w (shift w)
 
 /-- Reanalysis of `adjClassical` as subsective-after-coercion. The
     coercion is NVP-conditional — [partee-2010]'s coercion-as-last-resort:
-    `shift_inert` requires `nounShift N = N` whenever direct application
-    is already non-vacuous, so the structure does not coerce
-    gratuitously. -/
+    `shift_inert` forbids widening whenever direct application is already
+    non-vacuous (`nounShift_eq_self` derives the identity). -/
 structure SubsectiveReanalysis (adjClassical : AdjMeaning W E) where
   nounShift : Property W E → Property W E
   adjSubsective : AdjMeaning W E
-  le_nounShift : ∀ (N : Property W E) (w : W) (x : E), N w x → nounShift N w x
+  le_nounShift : ∀ N, N ≤ nounShift N
   is_subsective : isSubsective adjSubsective
   shift_inert : ∀ (N : Property W E) (w : W),
-    isNonVacuous (adjClassical N) w (N w) → nounShift N = N
+    isNonVacuous (adjClassical N) w (N w) → nounShift N ≤ N
 
 variable {adjClassical : AdjMeaning W E}
+
+/-- Where direct application is already non-vacuous, the shift is the
+    identity. -/
+theorem SubsectiveReanalysis.nounShift_eq_self (R : SubsectiveReanalysis adjClassical)
+    {N : Property W E} {w : W} (h : isNonVacuous (adjClassical N) w (N w)) :
+    R.nounShift N = N :=
+  le_antisymm (R.shift_inert N w h) (R.le_nounShift N)
 
 /-- A reanalysis licenses a coercion at every world where the shifted
     noun renders the reanalysed meaning non-vacuous — the positive

--- a/Linglib/Semantics/Modification/Coercion.lean
+++ b/Linglib/Semantics/Modification/Coercion.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Modification.Adjective
+import Linglib.Semantics.Modification.Classification
 
 /-!
 # Modification-time noun coercion (NVP + HPP)
@@ -53,7 +53,7 @@ theorem isNonVacuous_compl {P : Property W E} {w : W} {d : E → Prop} :
 
 /-- A wider noun extension `shift ⊇ N` at `w` under which `adj shift`
     is non-vacuous in `shift`'s extension (the HPP local domain). -/
-structure LicensedCoercion (N : Property W E) (adj : AdjMeaning W E) (w : W) where
+structure LicensedCoercion (N : Property W E) (adj : Modifier (Property W E)) (w : W) where
   shift : Property W E
   le_shift : N w ≤ shift w
   satisfies_nvp : isNonVacuous (adj shift) w (shift w)
@@ -62,15 +62,15 @@ structure LicensedCoercion (N : Property W E) (adj : AdjMeaning W E) (w : W) whe
     coercion is NVP-conditional — [partee-2010]'s coercion-as-last-resort:
     `shift_inert` forbids widening whenever direct application is already
     non-vacuous (`nounShift_eq_self` derives the identity). -/
-structure SubsectiveReanalysis (adjClassical : AdjMeaning W E) where
+structure SubsectiveReanalysis (adjClassical : Modifier (Property W E)) where
   nounShift : Property W E → Property W E
-  adjSubsective : AdjMeaning W E
+  adjSubsective : Modifier (Property W E)
   le_nounShift : ∀ N, N ≤ nounShift N
-  is_subsective : isSubsective adjSubsective
+  is_subsective : Modifier.isSubsective adjSubsective
   shift_inert : ∀ (N : Property W E) (w : W),
     isNonVacuous (adjClassical N) w (N w) → nounShift N ≤ N
 
-variable {adjClassical : AdjMeaning W E}
+variable {adjClassical : Modifier (Property W E)}
 
 /-- Where direct application is already non-vacuous, the shift is the
     identity. -/

--- a/Linglib/Studies/DelPinal2015.lean
+++ b/Linglib/Studies/DelPinal2015.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Modification.Adjective
+import Linglib.Semantics.Modification.Classification
 import Linglib.Semantics.Modification.Coercion
 import Linglib.Studies.Kamp1975
 import Linglib.Studies.Partee2010
@@ -24,11 +24,11 @@ it with C-structure).
   eqs. 16, 11, 12); `fakeDelPinal`, `counterfeitDelPinal`: constructive
   witnesses. `artificialDC` is *not* a `DelPinalReanalysis` (it admits
   no look-like-N inference) — see `artificialDC_not_DelPinalReanalysis`.
-* `AdjMeaning.toDCAdjMeaning`: lift a classical `AdjMeaning` to a
+* `toDCAdjMeaning`: lift a classical modifier meaning to a
   `DCAdjMeaning` by inheriting noun qualia.
 * `DelPinalReanalysis.no_LicensedCoercion`: cross-framework divergence
   with [partee-2010] (any DC reanalysis projects to a Kamp-privative
-  `AdjMeaning`, hence admits no NVP-licensed coercion).
+  classical modifier meaning, hence admits no NVP-licensed coercion).
 * `Kamp1975_fakeAdj_lift_not_DelPinalReanalysis`: Kamp's classical typing
   of `fake` is genuinely impoverished — the lift to `DCAdjMeaning` fails
   to satisfy the look-like-N constraint that DC's `fake` enforces.
@@ -61,7 +61,7 @@ satisfies `extension_implies_formal`.
 
 namespace DelPinal2015
 
-open Modification
+open Modification Modifier
 
 /-- Property-valued rendering of the four [pustejovsky-1995] qualia
     roles (`Pustejovsky1995.QualeRole`); the Type-valued original is
@@ -166,37 +166,36 @@ theorem artificialDC_not_DelPinalReanalysis :
 
 /-! ### Cross-framework divergence with [partee-2010] -/
 
-/-- Classical-`AdjMeaning` projection of a DC operator under a
+/-- Classical modifier-meaning projection of a DC operator under a
     per-noun qualia assignment `Q`. -/
-def DelPinalReanalysis.toAdjMeaning (r : DelPinalReanalysis W E)
-    (Q : Property W E → Qualia W E) : AdjMeaning W E :=
+def DelPinalReanalysis.toModifier (r : DelPinalReanalysis W E)
+    (Q : Property W E → Qualia W E) : Modifier (Property W E) :=
   fun N w x => (r.operator ⟨N, Q N⟩).extension w x
 
-theorem DelPinalReanalysis.toAdjMeaning_isPrivative
+theorem DelPinalReanalysis.toModifier_isPrivative
     (r : DelPinalReanalysis W E) (Q : Property W E → Qualia W E) :
-    isPrivative (r.toAdjMeaning Q) :=
-  fun N w x h => r.extension_privative ⟨N, Q N⟩ w x h
+    isPrivative (r.toModifier Q) :=
+  isPrivative_iff.mpr fun N w x h => r.extension_privative ⟨N, Q N⟩ w x h
 
 /-- The classical projection of any DC reanalysis admits no
     `LicensedCoercion`. The two frameworks make incompatible type-level
     commitments about privatives. The comparison is extensional-only:
-    `toAdjMeaning` reads off E-structure, discarding the C-structure
+    `toModifier` reads off E-structure, discarding the C-structure
     where DC relocates the look-like-N content that Partee's coercion
     carries in the widened extension. -/
 theorem DelPinalReanalysis.no_LicensedCoercion
     (r : DelPinalReanalysis W E) (Q : Property W E → Qualia W E)
     (N : Property W E) (w : W) :
-    IsEmpty (LicensedCoercion N (r.toAdjMeaning Q) w) :=
+    IsEmpty (LicensedCoercion N (r.toModifier Q) w) :=
   Partee2010.isPrivative_no_LicensedCoercion
-    (r.toAdjMeaning_isPrivative Q) N w
+    (r.toModifier_isPrivative Q) N w
 
 /-! ### Classical lift; impoverishment of Kamp-typed `fake` -/
 
-/-- Lift a classical `AdjMeaning` to a `DCAdjMeaning` by computing the
-    extension via the classical adj and inheriting the input noun's
+/-- Lift a classical modifier meaning to a `DCAdjMeaning` by computing
+    the extension via the classical adj and inheriting the input noun's
     qualia (the C-structure passes through unchanged). -/
-def _root_.Modification.AdjMeaning.toDCAdjMeaning
-    (adj : AdjMeaning W E) : DCAdjMeaning W E :=
+def toDCAdjMeaning (adj : Modifier (Property W E)) : DCAdjMeaning W E :=
   fun N => { extension := adj N.extension, qualia := N.qualia }
 
 /-- `Kamp1975.fakeAdj` lifted to a `DCAdjMeaning` is *not* a
@@ -207,7 +206,7 @@ def _root_.Modification.AdjMeaning.toDCAdjMeaning
     Pinal's argument that the classical analysis is incomplete. -/
 theorem Kamp1975_fakeAdj_lift_not_DelPinalReanalysis :
     ¬ ∃ (r : DelPinalReanalysis Kamp1975.W2 Kamp1975.E3),
-      r.operator = Kamp1975.fakeAdj.toDCAdjMeaning := by
+      r.operator = toDCAdjMeaning Kamp1975.fakeAdj := by
   rintro ⟨r, hr⟩
   let N : NounMeaning Kamp1975.W2 Kamp1975.E3 :=
     { extension := fun _ _ => False
@@ -231,7 +230,7 @@ theorem Kamp1975_fakeAdj_lift_not_DelPinalReanalysis :
     objects for it. -/
 theorem Kamp1975_fakeAdj_RevisedClass_nonSubsective :
     RevisedClass.nonSubsective.satisfies Kamp1975.fakeAdj :=
-  privative_not_subsective Kamp1975.fake_privative
+  not_isSubsective_of_isPrivative Kamp1975.fake_privative
     ⟨fun _ _ => False, Kamp1975.W2.w₁, Kamp1975.E3.b, trivial, id⟩
 
 /-! ### Output-qualia witness theorems

--- a/Linglib/Studies/Elbourne2026.lean
+++ b/Linglib/Studies/Elbourne2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Modification.Adjective
+import Linglib.Semantics.Modification.Classification
 
 /-!
 # Elbourne (2026): Adjectives without syntactic categories
@@ -14,8 +14,8 @@ eliminating syntactic categories in favor of semantic types
 
 ## Key result
 
-`Modification/Adjective.lean` already defines `AdjMeaning W E = Property W E →
-Property W E`, which IS the ⟨et,et⟩ type. The Kamp hierarchy there
+`Modification/Classification.lean` already provides the carrier
+`Modifier (Property W E)`, which IS the ⟨et,et⟩ type. The Kamp hierarchy there
 (intersective, subsective, privative) classifies adjectives by meaning
 postulates *within* that type — not by assigning different types to
 different classes. The present file makes this explicit and adds
@@ -37,14 +37,14 @@ construction.
 3. FA-sufficiency: FA on ⟨et,et⟩ = PM on ⟨e,t⟩; PM limitation
 4. "Fido was cute" derivation
 5. Connection to Classification hierarchy
-6. Former: non-subsective `AdjMeaning` + PM failure + end-to-end chain
+6. Former: non-subsective modifier meaning + PM failure + end-to-end chain
 7. Compulsory E_R: attributive-only adjectives
 -/
 
 namespace Elbourne2026
 
-open Modification
-  (Property AdjMeaning isIntersective isSubsective)
+open Modification (Property isIntersective_iff)
+open Modifier (isIntersective isSubsective)
 
 /-! ### ⟨et,et⟩ Adjective Denotations -/
 
@@ -61,7 +61,7 @@ def trivialNoun : Property I E := fun _ _ => True
 
     [elbourne-2026] (24b)/(59):
     `/cute/ :: λf⟨e,it⟩.λx.λt. f(x)(t) & cute(x)(t)` -/
-def intersective (Q : Property I E) : AdjMeaning I E :=
+def intersective (Q : Property I E) : Modifier (Property I E) :=
   fun N t x => N t x ∧ Q t x
 
 /-- Applying an intersective adjective to the trivial noun recovers
@@ -86,7 +86,7 @@ variable {I E : Type*}
 
     [elbourne-2026] (8)/(27c):
     `BE :: λR⟨i,it⟩.λG⟨eit,eit⟩.λx.λt. ∃t'(R(t')(t) & G(λy.λt''.⊤)(x)(t'))` -/
-def copulaBE (R : I → I → Prop) (G : AdjMeaning I E)
+def copulaBE (R : I → I → Prop) (G : Modifier (Property I E))
     (x : E) (t : I) : Prop :=
   ∃ t', R t' t ∧ G trivialNoun t' x
 
@@ -121,7 +121,7 @@ theorem fa_eq_pm (Q N : Property I E) :
   funext t x; exact propext And.comm
 
 /-- PM always produces **intersective** results: the composition
-    `λN.λt.λx. A(t)(x) ∧ N(t)(x)` satisfies `Modification.isIntersective`
+    `λN.λt.λx. A(t)(x) ∧ N(t)(x)` satisfies `Modifier.isIntersective`
     with witness `A`. This means PM is too restrictive even for merely
     subsective adjectives like `skillful` — not just non-subsective ones.
 
@@ -131,7 +131,7 @@ theorem fa_eq_pm (Q N : Property I E) :
     merely subsective adjectives." -/
 theorem pm_always_intersective (A : Property I E) :
     isIntersective (fun N t x => A t x ∧ N t x) :=
-  ⟨A, fun _ _ _ => Iff.rfl⟩
+  ⟨A, fun _ => rfl⟩
 
 /-- Corollary: PM always yields subsective results (`A ∧ N` entails
     `N`). Follows from `pm_always_intersective` via the hierarchy
@@ -169,11 +169,11 @@ section HierarchyConnection
 variable {I E : Type*}
 
 /-- Intersective ⟨et,et⟩ adjectives satisfy
-    `Modification.isIntersective`. The witness is the underlying
+    `Modifier.isIntersective`. The witness is the underlying
     property Q. -/
 theorem intersective_is_classified (Q : Property I E) :
     isIntersective (intersective Q) :=
-  ⟨Q, fun _ _ _ => And.comm⟩
+  ⟨Q, fun N => by funext t x; exact propext And.comm⟩
 
 /-- Intersective ⟨et,et⟩ adjectives are subsective:
     `cute N` entails `N`. -/
@@ -227,7 +227,7 @@ private def judge : Property T2 E1
     [elbourne-2026] (44)/(60):
     `λf⟨e,it⟩.λx.λt. ∃t'(< (t')(t) & f(x)(t') & ¬f(x)(t))` -/
 def formerAdj {I E : Type*} (times : List I)
-    (ltb : I → I → Prop) : AdjMeaning I E :=
+    (ltb : I → I → Prop) : Modifier (Property I E) :=
   fun N t x => (∃ t' ∈ times, ltb t' t ∧ N t' x) ∧ ¬ N t x
 
 private def ltb2 : T2 → T2 → Prop
@@ -247,8 +247,8 @@ theorem former_adj_holds :
   · exact id
 
 /-- `formerAdj` is not subsective — connecting directly to
-    `Modification.isSubsective`. This is a genuine `AdjMeaning`,
-    so it integrates with the full classification hierarchy. -/
+    `Modifier.isSubsective`. This is a genuine intensional modifier
+    meaning, so it integrates with the full classification hierarchy. -/
 theorem former_adj_not_subsective :
     ¬ isSubsective (formerAdj (E := E1) allT2 ltb2) := by
   intro h

--- a/Linglib/Studies/HoulihanEtAl2023.lean
+++ b/Linglib/Studies/HoulihanEtAl2023.lean
@@ -3,7 +3,7 @@ import Linglib.Pragmatics.BToM
 import Linglib.Pragmatics.GameTheory
 import Linglib.Core.Probability.Decision.Basic
 import Linglib.Pragmatics.RSA.CombinedUtility
-import Linglib.Semantics.Modification.Adjective
+import Linglib.Semantics.Modification.Classification
 
 /-!
 # [houlihan-kleiman-weiner-hewitt-tenenbaum-saxe-2023] — Emotion Prediction as
@@ -452,27 +452,27 @@ The threshold θ makes them gradable ([kennedy-2007]): "more generous"
 /-- "Generous" as an intersective adjective meaning:
 ⟦generous N⟧(p) = N(p) ∧ ω_AIA(p) > θ. -/
 def generousAdj (θ : ℚ) :
-    Modification.AdjMeaning Unit SocialValueProfile :=
+    Modifier (Modification.Property Unit SocialValueProfile) :=
   fun N _ p => p.ωAIA > θ ∧ N () p
 
 /-- "Fair-minded" as an intersective adjective meaning:
 ⟦fair-minded N⟧(p) = N(p) ∧ ω_DIA(p) > θ. -/
 def fairMindedAdj (θ : ℚ) :
-    Modification.AdjMeaning Unit SocialValueProfile :=
+    Modifier (Modification.Property Unit SocialValueProfile) :=
   fun N _ p => p.ωDIA > θ ∧ N () p
 
-open Modification in
+open Modifier in
 /-- Evaluative adjectives grounded in BToM-inferred preferences are
 intersective: ⟦generous N⟧ = ⟦N⟧ ∩ {x | ω_AIA(x) > θ}. -/
 theorem generous_is_intersective (θ : ℚ) :
     isIntersective (generousAdj θ) :=
-  ⟨fun _ p => p.ωAIA > θ, fun _ _ _ => Iff.rfl⟩
+  ⟨fun _ p => p.ωAIA > θ, fun _ => rfl⟩
 
-open Modification in
+open Modifier in
 /-- Fair-minded is intersective. -/
 theorem fairMinded_is_intersective (θ : ℚ) :
     isIntersective (fairMindedAdj θ) :=
-  ⟨fun _ p => p.ωDIA > θ, fun _ _ _ => Iff.rfl⟩
+  ⟨fun _ p => p.ωDIA > θ, fun _ => rfl⟩
 
 /-- Generous and selfish are contradictory at any threshold:
 generous requires ω_AIA > θ, selfish requires ω_AIA < θ. -/

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Modification.Adjective
+import Linglib.Semantics.Modification.Classification
 import Linglib.Core.Logic.Trivalent
 import Mathlib.Data.Set.Basic
 
@@ -15,7 +15,8 @@ Kamp presents two theories of adjective semantics:
 **Theory 1 (§ 1–2)**: Adjectives as functions from properties to
 properties (type `⟨⟨e,t⟩,⟨e,t⟩⟩`). The classification hierarchy —
 intersective, subsective, privative, extensional — is formalized in
-`Semantics/Modification/Adjective.lean`.
+`Modification/Basic.lean` (order-theoretic core) and
+`Semantics/Modification/Classification.lean` (intensional carrier).
 
 **Theory 2 (§ 3–7)**: Vague/graded models. Kamp introduces *vague
 models* `⟨M, S, F, p⟩` (partial model + completions + σ-field +
@@ -28,7 +29,7 @@ and § 3 formalizes the comparative definitions that descend from it.
 
 ## Structure
 
-- § 1: Single-world specialization of `Adjective.lean`'s hierarchy
+- § 1: Single-world specialization of the `Modifier.is*` hierarchy
 - § 2: Many-valued logic failure (motivation for Theory 2)
 - § 3: Kamp → Klein lineage: `kampAtLeastAs` ↔ `kleinMoreThan`
 - § 4: Concrete witnesses for each hierarchy class
@@ -45,43 +46,38 @@ motivates the move to supervaluation / probability over completions.
 
 namespace Kamp1975
 
-open Modification
+open Modification Modifier
 
 /-! ### Bridge to single-world predicates
 
-`Adjective.lean` defines the general intensional hierarchy:
-`isIntersective`, `isSubsective`, `isPrivative`, `isExtensional` over
-`Property W E = W → E → Prop`. The bridge theorems below show that
-fixing a world reduces the intensional definitions to their single-
-world counterparts. -/
+The classification (`Modifier.isIntersective`, `.isSubsective`, …) is
+one order-theoretic definition instantiated at two carriers: the
+intensional `Property W E = W → E → Prop` and the single-world
+`E → Prop`. The bridge theorems below show that fixing a world sends
+the first instance to the second. -/
 
 section Bridge
 
 variable {W E : Type*}
 
 /-- Single-world specialization: given a fixed world, the intensional
-    hierarchy reduces to the extensional one.
-
-    If `adj` is intersective, then at any fixed world `w`, the function
-    `N ↦ adj N w` is intersective in the extensional sense: there
-    exists a fixed predicate Q(w) such that the result is Q(w) ∩ N(w). -/
-theorem intersective_at_world {adj : AdjMeaning W E}
+    instance of `Modifier.isIntersective` reduces to the `E → Prop`
+    instance on the rigidified single-world view `N ↦ adj (fun _ => N) w`. -/
+theorem intersective_at_world {adj : Modifier (Property W E)}
     (h : isIntersective adj) (w : W) :
-    ∃ (Q_w : E → Prop), ∀ (N : E → Prop) (x : E),
-      adj (fun _ => N) w x ↔ (Q_w x ∧ N x) := by
+    isIntersective (fun N : E → Prop => adj (fun _ => N) w) := by
   obtain ⟨Q, hQ⟩ := h
-  exact ⟨Q w, fun N x => hQ (fun _ => N) w x⟩
+  exact ⟨Q w, fun N => congrFun (hQ fun _ => N) w⟩
 
-/-- Single-world specialization of subsective. -/
-theorem subsective_at_world {adj : AdjMeaning W E}
+/-- Single-world specialization of `Modifier.isSubsective`. -/
+theorem subsective_at_world {adj : Modifier (Property W E)}
     (h : isSubsective adj) (w : W) :
-    ∀ (N : E → Prop) (x : E), adj (fun _ => N) w x → N x := by
-  intro N x hadj
-  exact h (fun _ => N) w x hadj
+    isSubsective (fun N : E → Prop => adj (fun _ => N) w) :=
+  fun N => h (fun _ => N) w
 
 /-! `intersective_at_world` and `subsective_at_world` show that fixing
-    a world reduces the intensional hierarchy to single-world
-    predicates. -/
+    a world sends the intensional instance of the hierarchy to the
+    single-world instance — the same classes, one definition. -/
 
 end Bridge
 
@@ -190,16 +186,17 @@ inductive E3 | a | b | c
     Models [kamp-1975]'s intersective class. Entailment pattern:
     "gray cat" entails both "gray" and "cat"; "gray" + "cat" entails
     "gray cat". -/
-def grayAdj : AdjMeaning W2 E3 := fun N w x =>
+def grayAdj : Modifier (Property W2 E3) := fun N w x =>
   (match x with | .a => True | _ => False) ∧ N w x
 
 theorem gray_intersective : isIntersective grayAdj :=
-  ⟨fun _ x => match x with | .a => True | _ => False,
-   fun N w x => by cases x <;> simp [grayAdj]⟩
+  isIntersective_iff.mpr
+    ⟨fun _ x => match x with | .a => True | _ => False,
+     fun N w x => by cases x <;> simp [grayAdj]⟩
 
 /-- "gray" is therefore also extensional and subsective. -/
-example : isExtensional grayAdj := intersective_implies_extensional gray_intersective
-example : isSubsective grayAdj := intersective_implies_subsective gray_intersective
+example : isExtensional grayAdj := isExtensional_of_isIntersective gray_intersective
+example : isSubsective grayAdj := gray_intersective.isSubsective
 
 /-- **"fake"**: a privative adjective (traditional analysis). "Fake N"
     entities are never N.
@@ -209,12 +206,11 @@ example : isSubsective grayAdj := intersective_implies_subsective gray_intersect
 
     [partee-2010] argues this class should be reanalyzed as
     subsective with noun coercion — see `Partee2010.lean`. -/
-def fakeAdj : AdjMeaning W2 E3 := fun N w x =>
+def fakeAdj : Modifier (Property W2 E3) := fun N w x =>
   (match x with | .b => True | _ => False) ∧ ¬ N w x
 
-theorem fake_privative : isPrivative fakeAdj := by
-  intro N w x h
-  exact h.2
+theorem fake_privative : isPrivative fakeAdj :=
+  isPrivative_iff.mpr fun _ _ _ h => h.2
 
 /-- **"skillful"**: a subsective adjective that is NOT extensional.
     Being a "skillful N" depends on N's intension — what counts as an N
@@ -224,14 +220,13 @@ theorem fake_privative : isPrivative fakeAdj := by
     Entailment pattern: "skillful surgeon" entails "surgeon" (subsective),
     but "skillful surgeon" + "violinist" does not entail "skillful
     violinist" (not intersective, because not extensional). -/
-def skillfulAdj : AdjMeaning W2 E3 := fun N w x =>
+def skillfulAdj : Modifier (Property W2 E3) := fun N w x =>
   N w x ∧ match x with
     | .a => N .w₁ .a  -- a's skill assessment depends on N's intension
     | _  => False
 
-theorem skillful_subsective : isSubsective skillfulAdj := by
-  intro N w x h
-  exact h.1
+theorem skillful_subsective : isSubsective skillfulAdj :=
+  fun _ _ _ h => h.1
 
 theorem skillful_not_extensional : ¬ isExtensional skillfulAdj := by
   intro hext
@@ -253,7 +248,7 @@ theorem skillful_not_extensional : ¬ isExtensional skillfulAdj := by
     "alleged", "potential", "putative" that carry no meaning postulate
     constraining the relationship between the modified and unmodified
     extension. -/
-def allegedAdj : AdjMeaning W2 E3 := fun _N _ x =>
+def allegedAdj : Modifier (Property W2 E3) := fun _N _ x =>
   match x with | .a => True | _ => False
 
 /-- "alleged N" does not entail "N" (not subsective). -/
@@ -264,7 +259,7 @@ theorem alleged_not_subsective : ¬ isSubsective allegedAdj := by
 /-- "alleged N" does not entail "not N" (not privative). -/
 theorem alleged_not_privative : ¬ isPrivative allegedAdj := by
   intro h
-  exact h (fun _ _ => True) .w₁ .a trivial trivial
+  exact isPrivative_iff.mp h (fun _ _ => True) .w₁ .a trivial trivial
 
 end Witnesses
 

--- a/Linglib/Studies/Partee2010.lean
+++ b/Linglib/Studies/Partee2010.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Modification.Adjective
+import Linglib.Semantics.Modification.Classification
 import Linglib.Semantics.Modification.Coercion
 import Linglib.Studies.Kamp1975
 import Linglib.Data.Examples.Schema
@@ -32,7 +32,7 @@ NP-splitting data from [nowak-2000] is the empirical wedge.
 
 namespace Partee2010
 
-open Modification
+open Modification Modifier
 
 variable {W E : Type*}
 
@@ -41,12 +41,12 @@ variable {W E : Type*}
 /-- Kamp-privative adjectives admit no NVP-licensed coercion. For any
     shift, NVP requires a positive witness `x` with `adj shift w x ∧
     shift w x`; privativity forces `adj shift w x → ¬ shift w x`. -/
-theorem isPrivative_no_LicensedCoercion {adj : AdjMeaning W E}
+theorem isPrivative_no_LicensedCoercion {adj : Modifier (Property W E)}
     (hp : isPrivative adj) (N : Property W E) (w : W) :
     IsEmpty (LicensedCoercion N adj w) :=
   ⟨fun lc => by
     obtain ⟨x, hshift, hadj⟩ := lc.satisfies_nvp.1
-    exact hp lc.shift w x hadj hshift⟩
+    exact isPrivative_iff.mp hp lc.shift w x hadj hshift⟩
 
 /-- Specialisation to `Kamp1975.fakeAdj`. -/
 theorem fakeAdj_no_LicensedCoercion (N : Property Kamp1975.W2 Kamp1975.E3)
@@ -68,7 +68,7 @@ def fakeReanalysis : SubsectiveReanalysis Kamp1975.fakeAdj where
   is_subsective _ _ _ h := h.1
   shift_inert N w hne := by
     obtain ⟨x, hN, hadj⟩ := hne.1
-    exact absurd hN (Kamp1975.fake_privative N w x hadj)
+    exact absurd hN (isPrivative_iff.mp Kamp1975.fake_privative N w x hadj)
 
 /-- A toy noun for the fur scenario: `a` is (real) fur. -/
 def furN : Property Kamp1975.W2 Kamp1975.E3 := fun _ x => x = .a

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -3617,7 +3617,7 @@
   role      = {cited},
   doi       = {10.1017/cbo9780511897696.011},
   validated = {true},
-  sources   = {Studies/Kamp1975.lean;Semantics/Modification/Adjective.lean}
+  sources   = {Studies/Kamp1975.lean;Semantics/Modification/Classification.lean}
 }% REF: Huddleston, R. (1976). Some theoretical issues in the description of the English verb. *Lingua* 40:331-383.
 @article{huddleston-1976,
   author    = {Huddleston, Rodney},


### PR DESCRIPTION
Redesigns the modifier-classification API the way mathlib would cut it (follow-up to #1417).

- `Modifier.isSubsective` / `.isPrivative` / `.isIntersective` defined once, order-theoretically, in `Modification/Basic.lean` (deflationary `m x ≤ x`; `Disjoint (m x) x`; meet-translation `m x = q ⊓ x`); `isPrivative.eq_bot` is the general privative-vs-subsective incompatibility
- `AdjMeaning` eliminated: the carrier is `Modifier (Property W E)` (word-class naming presupposed what Elbourne 2026 debates); `Adjective.lean` → `Classification.lean` with pointwise `_iff` bridges and the genuinely intensional `isExtensional`; Kamp1975's at-world theorems now state that fixing a world maps one instance of the classes to another
- first commit: order-language proof fields for the coercion structures (`le_shift`, `le_nounShift`, minimal `shift_inert` + derived `nounShift_eq_self`, `isNonVacuous` mono/compl API)