### PR TITLE
refactor(Semantics): general intersective + Property via Intension

### DIFF
--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Tree.Basic
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Intensional.Variables
+import Linglib.Semantics.Intensional.Algebra
 import Linglib.Semantics.Composition.LexEntry
 import Linglib.Semantics.Modification.Basic
 

--- a/Linglib/Semantics/Modification/Basic.lean
+++ b/Linglib/Semantics/Modification/Basic.lean
@@ -76,24 +76,23 @@ theorem isIntersective.isSubsective {m : Modifier α}
   rw [hq]
   exact inf_le_right
 
-end SemilatticeInf
-
-/-- The intersective modifier built from a property `P`: combine `P` with the
-    modificand by pointwise conjunction — meet-translation at the carrier
-    `α → Prop` (`intersective_isIntersective`). The well-behaved special case
+/-- The intersective modifier built from `q`: meet the modificand with `q`.
+    At `α → Prop` this is pointwise conjunction; at conjoinable `Denot`
+    domains (`Intensional/Algebra.lean` instances) it is Partee-Rooth
+    generalized conjunction with the head. The well-behaved special case
     (restrictive relative clauses, intersective adjectives, manner adverbs). -/
-def intersective (P : α → Prop) : Modifier (α → Prop) :=
-  fun Q x => P x ∧ Q x
+def intersective (q : α) : Modifier α := (q ⊓ ·)
 
-@[simp] theorem intersective_apply (P Q : α → Prop) (x : α) :
+@[simp] theorem intersective_apply {β : Type*} (P Q : β → Prop) (x : β) :
     intersective P Q x = (P x ∧ Q x) := rfl
 
-/-- Head and modifier intersect symmetrically (conjunction is commutative). -/
-theorem intersective_comm (P Q : α → Prop) : intersective P Q = intersective Q P := by
-  funext x; exact propext And.comm
+/-- Modificand and modifier meet symmetrically. -/
+theorem intersective_comm (q r : α) : intersective q r = intersective r q :=
+  inf_comm q r
 
-theorem intersective_isIntersective (P : α → Prop) :
-    isIntersective (intersective P) :=
-  ⟨P, fun _ => rfl⟩
+theorem intersective_isIntersective (q : α) : isIntersective (intersective q) :=
+  ⟨q, fun _ => rfl⟩
+
+end SemilatticeInf
 
 end Modifier

--- a/Linglib/Semantics/Modification/Classification.lean
+++ b/Linglib/Semantics/Modification/Classification.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Modification.Basic
+import Linglib.Semantics.Intensional.Rigidity
 import Mathlib.Order.PropInstances
 import Mathlib.Data.Set.Basic
 import Mathlib.Tactic.Common
@@ -59,9 +60,10 @@ the licensing mechanism (NVP + HPP) lives in
 
 namespace Modification
 
-/-- An intensional property: a function from worlds to characteristic
-    predicates over entities. -/
-abbrev Property (W E : Type*) := W → E → Prop
+/-- An intensional property: an `Intensional.Intension` valued in
+    characteristic predicates over entities (a function from worlds to
+    predicates). -/
+abbrev Property (W E : Type*) := Intensional.Intension W (E → Prop)
 
 /-! ### Pointwise forms of the order-theoretic classes -/
 

--- a/Linglib/Semantics/Modification/RelativeClause.lean
+++ b/Linglib/Semantics/Modification/RelativeClause.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Intensional.Variables
+import Linglib.Semantics.Intensional.Algebra
 import Linglib.Semantics.Modification.Basic
 
 /-!


### PR DESCRIPTION
Finishes the foundations the lattice redesign (#1419) started, using the Denot Boolean-algebra instances `Intensional/Algebra.lean` already provides.

- `Modifier.intersective` generalized to the meet-translation `(q ⊓ ·)` over `[SemilatticeInf α]` (removes #1419's pointwise-∧ compromise); `Intensional.Algebra` wired into the Denot-typed consumers (`Composition/Tree.lean`, `Modification/RelativeClause.lean`) whose missing import forced that compromise
- `Modification.Property` grounded as `Intensional.Intension W (E → Prop)` — derives from the intensional layer instead of restating it (defeq-invisible to consumers)