### PR TITLE
refactor(Semantics/Modification): deep cleanse of Classification

### DIFF
--- a/Linglib/Semantics/Intensional/Rigidity.lean
+++ b/Linglib/Semantics/Intensional/Rigidity.lean
@@ -356,9 +356,9 @@ The operator-side dual of `IsRigid`: an operator on intensions is
 through the argument's extension at `w` (local truth-functionality at
 `β = Prop`). Negation and the other pointwise connectives are extensional
 everywhere; quantifiers over indices (`Core.Logic.Modal.box`) are not.
-`Modification.isExtensional` (Kamp 1975's
-extensional adjective operators) is the entity-indexed `∀ w`-closure of
-this notion. -/
+Kamp-style extensional adjective operators
+(`Semantics/Modification/Classification.lean`) are the
+`α = β = E → Prop` instance of this notion. -/
 
 /-- `O` is extensional at `w`: its value at `w` depends on the argument
 intension only through the argument's extension at `w`. Equivalently,

--- a/Linglib/Semantics/Modification/Basic.lean
+++ b/Linglib/Semantics/Modification/Basic.lean
@@ -5,7 +5,7 @@ import Mathlib.Order.PropInstances
 [parsons-1970] [kamp-1975]
 
 A **modifier** of `τ` is a function on the modificand's denotation
-([parsons-1970]: "modifiers as functions on predicates"). Adjectives,
+([parsons-1970]: modifiers as functions on predicates). Adjectives,
 adverbs, and relative clauses are all modifiers — of *different* `τ` (nominal
 `e ⇒ t`, event `Event → Prop`, …) — unified by *being* this type, not by
 implementing an interface.

--- a/Linglib/Semantics/Modification/Classification.lean
+++ b/Linglib/Semantics/Modification/Classification.lean
@@ -5,57 +5,41 @@ import Mathlib.Data.Set.Basic
 import Mathlib.Tactic.Common
 
 /-!
-# Modifier-Meaning Classification at the Intensional Carrier
-[kamp-1975] [kamp-partee-1995] [parsons-1970]
+# Modifier-meaning classification at the intensional carrier
 
-The standard classification of adnominal modifier meanings, constrained
-by meaning postulates. The order-theoretic classes
-(`Modifier.isIntersective` / `.isSubsective` / `.isPrivative`) live in
-`Modification/Basic.lean`; this file works at the intensional carrier
-`Modifier (Property W E)` — functions from properties to properties,
-type `⟨⟨s,⟨e,t⟩⟩, ⟨s,⟨e,t⟩⟩⟩` in Montague notation — adding the
-pointwise unfolding lemmas, the one genuinely intensional class
-(`isExtensional`), the implication structure, and [partee-2010]'s
-post-collapse `RevisedClass`.
+We instantiate the order-theoretic modifier classes of
+`Modification/Basic.lean` (`Modifier.isIntersective`, `.isSubsective`,
+`.isPrivative`) at intensional properties, providing their pointwise
+unfolding lemmas, the implication structure, and [partee-2010]'s
+post-collapse three-class hierarchy.
 
-[parsons-1970] independently introduced the operator approach
-(modifiers as functions on predicates, not conjoinable predicates) and
-distinguished "predicative" adjectives (analyzable as conjunction =
-intersective) from "non-predicative" (= non-intersective), and
-"standard" modifiers (A N → N = subsective) from "non-standard"
-(= non-subsective). [kamp-1975] refined these binary distinctions
-into the full four-class hierarchy below.
-
-## Hierarchy
-
-1. **Intersective**: `⟦A N⟧ = ⟦A⟧ ∩ ⟦N⟧`
-2. **Subsective**: `⟦A N⟧ ⊆ ⟦N⟧`
-3. **Privative**: `⟦A N⟧ ∩ ⟦N⟧ = ∅`
-4. **Extensional**: depends only on N's extension, not intension
-5. **Non-subsective** (modal): no entailment (alleged, potential)
-
-## Implication Structure
-
-    intersective → {extensional, subsective}
-
-Extensional and subsective are independent: neither implies the other
-(§ 3 provides witnesses for both separations).
-Privative is incompatible with subsective (given non-empty extension).
-
-## Design
-
-Single-world (extensional) specializations are the same order-theoretic
-classes at the carrier `E → Prop` — see `Studies/Kamp1975.lean` § 1 for
-the specialization theorems. Whether *adjectives* uniformly denote
-`Modifier (Property W E)` is itself a theoretical claim (see
-`Studies/Elbourne2026.lean`); the carrier is named for the denotation
+The classification descends from the operator treatment of modifiers
+introduced independently by [parsons-1970] (intersective = his
+"predicative", subsective = his "standard") and [kamp-1975], and was
+consolidated in [kamp-partee-1995]; the class labels are Partee's.
+Extensionality — dependence on the noun's extension at each world — is
+the orthogonal, cross-cutting dimension, not a rung of the entailment
+hierarchy: it is `Intensional.IsExtensional` at this carrier, and
+`Studies/Kamp1975.lean` § 4 witnesses its independence from
+subsectivity. Whether *adjectives* uniformly denote
+`Modifier (Property W E)` is itself a theoretical claim
+(`Studies/Elbourne2026.lean`); the carrier is named for the denotation
 type, not the word class.
 
-[partee-2010] argues the privative class should be eliminated
-in favor of subsective + noun coercion; see `Partee2010.lean`. The
-post-collapse 3-class hierarchy is captured by `RevisedClass` below;
-the licensing mechanism (NVP + HPP) lives in
-`Semantics/Modification/Coercion.lean`.
+## Main definitions
+
+* `Property W E`: intensional properties, `Intensional.Intension W (E → Prop)`.
+* `isIntersective_iff`, `isPrivative_iff`: pointwise forms of the
+  order-theoretic classes at this carrier ("gray"/"French" vs
+  "fake"/"counterfeit"; subsective "skillful" needs no unfolding lemma —
+  `Modifier.isSubsective` is already pointwise here).
+* `isExtensional_of_isIntersective`: intersective modifier meanings are
+  `Intensional.IsExtensional`.
+* `not_isSubsective_of_isPrivative`: privative meanings with non-empty
+  extension are not subsective (intersective → subsective holds at any
+  carrier: `Modifier.isIntersective.isSubsective`).
+* `RevisedClass`: [partee-2010]'s three-class hierarchy after the
+  privative collapse, interpreted by `RevisedClass.satisfies`.
 -/
 
 namespace Modification
@@ -75,31 +59,17 @@ variable {W E : Type*} {adj : Modifier (Property W E)}
 
 /-- Pointwise form of `Modifier.isIntersective` at the intensional
     carrier: the extension at each world is the intersection of the
-    noun's extension with some fixed property Q ([kamp-1975]).
+    noun's extension with some fixed property Q.
 
     Examples: "gray", "French", "carnivorous", "four-legged". -/
 theorem isIntersective_iff :
     isIntersective adj ↔
       ∃ (Q : Property W E), ∀ (N : Property W E) (w : W) (x : E),
         adj N w x ↔ (Q w x ∧ N w x) := by
-  refine ⟨fun ⟨Q, hQ⟩ => ⟨Q, fun N w x => by rw [hQ]; exact Iff.rfl⟩,
-          fun ⟨Q, hQ⟩ => ⟨Q, fun N => ?_⟩⟩
-  funext w x
-  exact propext (hQ N w x)
-
-/-- Pointwise form of `Modifier.isSubsective` at the intensional
-    carrier: the extension is always a subset of the noun's extension
-    ([kamp-1975]).
-
-    Examples: "skillful", "good", "typical". -/
-theorem isSubsective_iff :
-    isSubsective adj ↔
-      ∀ (N : Property W E) (w : W) (x : E), adj N w x → N w x :=
-  Iff.rfl
+  simp only [isIntersective, funext_iff, Pi.inf_apply, inf_Prop_eq, eq_iff_iff]
 
 /-- Pointwise form of `Modifier.isPrivative` at the intensional carrier:
-    the extension is always disjoint from the noun's extension
-    ([kamp-1975]).
+    the extension is always disjoint from the noun's extension.
 
     Examples: "fake", "counterfeit".
     [partee-2010] argues this class should be eliminated. -/
@@ -108,34 +78,20 @@ theorem isPrivative_iff :
       ∀ (N : Property W E) (w : W) (x : E), adj N w x → ¬ N w x := by
   simp only [isPrivative, Pi.disjoint_iff, Prop.disjoint_iff, not_and]
 
-/-- A modifier meaning is **extensional** if its extension in world w
-    depends only on the noun's extension in w, not on the noun's
-    intension ([kamp-1975]). The one class of the hierarchy that is
-    genuinely intensional — it has no order-theoretic form.
+/-! ### Implication structure
 
-    "four-legged" and "gray" are extensional; "skillful" is not (being a
-    skillful surgeon depends on what counts as a surgeon across contexts,
-    not just who the surgeons are in this world). -/
-def isExtensional (adj : Modifier (Property W E)) : Prop :=
-  ∀ (N₁ N₂ : Property W E) (w : W),
-    (∀ x, N₁ w x ↔ N₂ w x) → ∀ x, adj N₁ w x ↔ adj N₂ w x
+    Intersective → subsective holds at any carrier
+    (`Modifier.isIntersective.isSubsective`); intersective → extensional
+    and the privative/subsective incompatibility are stated here. The
+    order-theoretic core of the latter is `Modifier.isPrivative.eq_bot`. -/
 
-/-! ### Implication Structure
-
-    Intersective → {extensional, subsective} (the second is
-    `Modifier.isIntersective.isSubsective`, at any carrier).
-    Extensional and subsective are independent.
-    Privative is incompatible with subsective (given non-empty extension;
-    the order-theoretic core is `Modifier.isPrivative.eq_bot`). -/
-
-/-- Intersective modifier meanings are extensional: if
-    `F(N)(w)(x) ↔ Q(w)(x) ∧ N(w)(x)`, then the result in w depends only
-    on N(w). -/
+/-- Intersective modifier meanings are extensional: meet with a fixed
+    property reads the noun only through its extension at each world. -/
 theorem isExtensional_of_isIntersective (h : isIntersective adj) :
-    isExtensional adj := by
-  obtain ⟨Q, hQ⟩ := isIntersective_iff.mp h
-  intro N₁ N₂ w hext x
-  simp only [hQ, hext]
+    Intensional.IsExtensional adj := by
+  obtain ⟨Q, hQ⟩ := h
+  intro w N₁ N₂ hN
+  simp only [hQ, Pi.inf_apply, hN]
 
 /-- Privative modifier meanings are not subsective (when the modifier has
     non-empty extension for some noun). -/
@@ -147,61 +103,7 @@ theorem not_isSubsective_of_isPrivative (hp : isPrivative adj)
 
 end Hierarchy
 
-/-! ### Independence: Extensional ⊥ Subsective
-
-    Neither extensional → subsective nor subsective → extensional.
-    We construct explicit witnesses for both separations. -/
-
-section Independence
-
-open Modifier
-
-/-- Witness: extensional but NOT subsective.
-    A modifier that ignores both the noun and intension entirely
-    (always returns True) is trivially extensional, but not subsective
-    because it holds even when the noun does not. -/
-private inductive W1 | w
-private inductive E1 | a
-
-private def extNotSubAdj : Modifier (Property W1 E1) := fun _N _w _x => True
-
-theorem extensional_not_implies_subsective :
-    ∃ (adj : Modifier (Property W1 E1)), isExtensional adj ∧ ¬ isSubsective adj :=
-  ⟨extNotSubAdj,
-   fun _ _ _ _ _ => Iff.rfl,
-   fun h => (h (fun _ _ => False) .w .a trivial).elim⟩
-
-/-- Witness: subsective but NOT extensional.
-    "skillful N" depends on N's intension (whether entity a is N in
-    world w₁) to determine the result in world w₂. Subsective because
-    the first conjunct is `N w x`. -/
-private inductive W2' | w₁ | w₂
-private inductive E2 | a | b
-
-private def subNotExtAdj : Modifier (Property W2' E2) := fun N w x =>
-  N w x ∧ match x with
-    | .a => N .w₁ .a
-    | _  => False
-
-theorem subsective_not_implies_extensional :
-    ∃ (adj : Modifier (Property W2' E2)), isSubsective adj ∧ ¬ isExtensional adj :=
-  ⟨subNotExtAdj,
-   fun _ _ _ h => h.1,
-   fun hext => by
-     let N₁ : Property W2' E2 := fun _ _ => True
-     let N₂ : Property W2' E2 := fun w x => match w, x with
-       | .w₁, .a => False
-       | _, _    => True
-     have hagree : ∀ x, N₁ .w₂ x ↔ N₂ .w₂ x := fun x => by
-       cases x <;> simp [N₁, N₂]
-     have h := hext N₁ N₂ .w₂ hagree .a
-     -- LHS: subNotExtAdj N₁ .w₂ .a = True ∧ True; RHS: True ∧ False
-     have hLHS : subNotExtAdj N₁ .w₂ .a := ⟨trivial, trivial⟩
-     exact (h.mp hLHS).2⟩
-
-end Independence
-
-/-! ### Revised Hierarchy ([partee-2010])
+/-! ### Revised hierarchy ([partee-2010])
 
 The post-collapse 3-class hierarchy after eliminating "privative" via
 noun coercion. Per [partee-2010] footnote 1, the hierarchy is
@@ -221,7 +123,8 @@ inductive RevisedClass where
   | intersective
   /-- `⟦A N⟧ ⊆ ⟦N*⟧` — includes former "privatives" via coercion. -/
   | subsective
-  /-- No entailment: alleged, potential, putative (Kamp's non-subsective). -/
+  /-- No entailment: alleged, potential, putative (the plain/modal
+      non-subsective class). -/
   | nonSubsective
   deriving DecidableEq
 

--- a/Linglib/Semantics/Modification/Classification.lean
+++ b/Linglib/Semantics/Modification/Classification.lean
@@ -14,9 +14,11 @@ unfolding lemmas, the implication structure, and [partee-2010]'s
 post-collapse three-class hierarchy.
 
 The classification descends from the operator treatment of modifiers
-introduced independently by [parsons-1970] (intersective = his
-"predicative", subsective = his "standard") and [kamp-1975], and was
-consolidated in [kamp-partee-1995]; the class labels are Partee's.
+introduced independently by [parsons-1970] and [kamp-1975] — Kamp's
+definitions (4)–(7): "predicative" (intersective), "privative",
+"affirmative" (subsective), "extensional"; Parsons's terms were
+"predicative" and "standard" — and was consolidated in
+[kamp-partee-1995]; the modern labels are Partee's.
 Extensionality — dependence on the noun's extension at each world — is
 the orthogonal, cross-cutting dimension, not a rung of the entailment
 hierarchy: it is `Intensional.IsExtensional` at this carrier, and
@@ -59,7 +61,8 @@ variable {W E : Type*} {adj : Modifier (Property W E)}
 
 /-- Pointwise form of `Modifier.isIntersective` at the intensional
     carrier: the extension at each world is the intersection of the
-    noun's extension with some fixed property Q.
+    noun's extension with some fixed property Q ([kamp-1975]
+    definition (4), "predicative").
 
     Examples: "gray", "French", "carnivorous", "four-legged". -/
 theorem isIntersective_iff :
@@ -69,7 +72,8 @@ theorem isIntersective_iff :
   simp only [isIntersective, funext_iff, Pi.inf_apply, inf_Prop_eq, eq_iff_iff]
 
 /-- Pointwise form of `Modifier.isPrivative` at the intensional carrier:
-    the extension is always disjoint from the noun's extension.
+    the extension is always disjoint from the noun's extension
+    ([kamp-1975] definition (5)).
 
     Examples: "fake", "counterfeit".
     [partee-2010] argues this class should be eliminated. -/

--- a/Linglib/Semantics/Modification/Coercion.lean
+++ b/Linglib/Semantics/Modification/Coercion.lean
@@ -7,8 +7,11 @@ import Linglib.Semantics.Modification.Classification
 noun-extension widening under the Non-Vacuity Principle and Head Primacy
 Principle of [kamp-partee-1995] (§ 5.3, p. 161; stated as formulae (18)
 and (20) in [partee-2010] § 4), used by [partee-2010] to reanalyse
-privative adjectives as subsective-after-coercion. Consumed by
-`Studies/Partee2010.lean` and `Studies/DelPinal2015.lean`.
+privative adjectives as subsective-after-coercion. Both principles are
+anticipated in [kamp-1975] § 7: the noun as the central contextual
+factor fixing the adjective's standards, and the requirement that an
+attributive adjective "cut the extension of the noun" nontrivially.
+Consumed by `Studies/Partee2010.lean` and `Studies/DelPinal2015.lean`.
 
 Scope: models the adjective-triggered widening of [partee-2010]'s
 fake-fur case; the constitutive-material case (stone lion) is bracketed

--- a/Linglib/Studies/Elbourne2026.lean
+++ b/Linglib/Studies/Elbourne2026.lean
@@ -43,7 +43,7 @@ construction.
 
 namespace Elbourne2026
 
-open Modification (Property isIntersective_iff)
+open Modification (Property)
 open Modifier (isIntersective isSubsective)
 
 /-! ### ⟨et,et⟩ Adjective Denotations -/

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -120,7 +120,7 @@ theorem kleene_dilemma :
 
 /-! ### Kamp → Klein Lineage -/
 
-/-! [kamp-1975]'s completion-based comparative definition:
+/-! [kamp-1975]'s completion-based comparative, definition (12):
 
     u₁ is at least as A as u₂ iff for every completion M' ∈ S where
     u₂ is in the extension of A, u₁ is also in the extension.
@@ -133,9 +133,11 @@ theorem kleene_dilemma :
     is equivalent to Klein's "¬∃ completion where u₂ ∈ ext ∧ u₁ ∉ ext",
     and Klein's strict comparative adds the asymmetric witness. -/
 
-/-- Kamp's completion-based comparative induces a `Preorder` on
-    entities: `u₁ ≤ u₂` iff every completion in S that puts u₂ in the
-    extension also puts u₁ in the extension.
+/-- Kamp's completion-based comparative (definition (12)) induces a
+    `Preorder` on entities: `u₁ ≤ u₂` iff every completion in S that puts
+    u₂ in the extension also puts u₁ in the extension. Kamp notes (12) is
+    "precisely the proposal … in Lewis (1970), where it is attributed to
+    David Kaplan".
 
     This is the S-restricted analogue of `kleinPreorder` from
     `Delineation.lean`. The extension parameter remains `Bool`-valued
@@ -183,7 +185,8 @@ inductive E3 | a | b | c
     `{x | gray(x)} ∩ {x | N(w)(x)}` — a fixed property independent of
     the noun.
 
-    Models [kamp-1975]'s intersective class. Entailment pattern:
+    Models [kamp-1975] definition (4), his "predicative" class (the
+    modern *intersective*). Entailment pattern:
     "gray cat" entails both "gray" and "cat"; "gray" + "cat" entails
     "gray cat". -/
 def grayAdj : Modifier (Property W2 E3) := fun N w x =>
@@ -202,11 +205,13 @@ example : isSubsective grayAdj := gray_intersective.isSubsective
 /-- **"fake"**: a privative adjective (traditional analysis). "Fake N"
     entities are never N.
 
-    Models [kamp-1975]'s privative class. Entailment pattern:
-    "fake gun" entails "not a gun".
+    Models [kamp-1975] definition (5); *fake* and *false* are Kamp's
+    examples. Entailment pattern: "fake gun" entails "not a gun".
 
-    [partee-2010] argues this class should be reanalyzed as
-    subsective with noun coercion — see `Partee2010.lean`. -/
+    Kamp himself doubts "that there is any English adjective which is
+    privative (in the precise sense here defined) in all of its possible
+    uses" — anticipating [partee-2010]'s reanalysis of the class as
+    subsective with noun coercion; see `Partee2010.lean`. -/
 def fakeAdj : Modifier (Property W2 E3) := fun N w x =>
   (match x with | .b => True | _ => False) ∧ ¬ N w x
 
@@ -217,7 +222,9 @@ theorem fake_privative : isPrivative fakeAdj :=
     Being a "skillful N" depends on N's intension — what counts as an N
     across worlds — not just who the N's are in this world.
 
-    Models [kamp-1975]'s subsective-but-not-extensional case.
+    Models [kamp-1975] definition (6), his "affirmative" class (the
+    modern *subsective*), without definition (7); *skilful* is Kamp's own
+    non-extensional example.
     Entailment pattern: "skillful surgeon" entails "surgeon" (subsective),
     but "skillful surgeon" + "violinist" does not entail "skillful
     violinist" (not intersective, because not extensional). -/
@@ -241,7 +248,8 @@ theorem skillful_not_extensional : ¬ Intensional.IsExtensional skillfulAdj := b
   have hLHS : skillfulAdj N₁ .w₂ .a := ⟨trivial, trivial⟩
   exact (congrFun h .a ▸ hLHS).2
 
-/-- **"alleged"**: a non-subsective (modal) adjective. An "alleged N"
+/-- **"alleged"**: a non-subsective (modal) adjective — [kamp-1975]'s
+    opening example (1), "Every alleged thief is a thief". An "alleged N"
     may or may not be an N — the adjective creates an intensional
     context without entailing or anti-entailing the noun.
 

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -195,7 +195,8 @@ theorem gray_intersective : isIntersective grayAdj :=
      fun N w x => by cases x <;> simp [grayAdj]⟩
 
 /-- "gray" is therefore also extensional and subsective. -/
-example : isExtensional grayAdj := isExtensional_of_isIntersective gray_intersective
+example : Intensional.IsExtensional grayAdj :=
+  isExtensional_of_isIntersective gray_intersective
 example : isSubsective grayAdj := gray_intersective.isSubsective
 
 /-- **"fake"**: a privative adjective (traditional analysis). "Fake N"
@@ -228,17 +229,17 @@ def skillfulAdj : Modifier (Property W2 E3) := fun N w x =>
 theorem skillful_subsective : isSubsective skillfulAdj :=
   fun _ _ _ h => h.1
 
-theorem skillful_not_extensional : ¬ isExtensional skillfulAdj := by
+theorem skillful_not_extensional : ¬ Intensional.IsExtensional skillfulAdj := by
   intro hext
   let N₁ : Property W2 E3 := fun _ _ => True
   let N₂ : Property W2 E3 := fun w x => match w, x with
     | .w₁, .a => False
     | _, _    => True
-  have hagree : ∀ x, N₁ .w₂ x ↔ N₂ .w₂ x := fun x => by
-    cases x <;> simp [N₁, N₂]
-  have h := hext N₁ N₂ .w₂ hagree .a
+  have hagree : N₁ .w₂ = N₂ .w₂ := by
+    funext x; cases x <;> simp [N₁, N₂]
+  have h := hext .w₂ N₁ N₂ hagree
   have hLHS : skillfulAdj N₁ .w₂ .a := ⟨trivial, trivial⟩
-  exact (h.mp hLHS).2
+  exact (congrFun h .a ▸ hLHS).2
 
 /-- **"alleged"**: a non-subsective (modal) adjective. An "alleged N"
     may or may not be an N — the adjective creates an intensional
@@ -250,6 +251,12 @@ theorem skillful_not_extensional : ¬ isExtensional skillfulAdj := by
     extension. -/
 def allegedAdj : Modifier (Property W2 E3) := fun _N _ x =>
   match x with | .a => True | _ => False
+
+/-- "alleged" ignores the noun entirely, so it is trivially extensional —
+    with `skillful_not_extensional` and `skillful_subsective`, this
+    witnesses that extensionality is orthogonal to subsectivity. -/
+theorem alleged_extensional : Intensional.IsExtensional allegedAdj :=
+  fun _ _ _ _ => rfl
 
 /-- "alleged N" does not entail "N" (not subsective). -/
 theorem alleged_not_subsective : ¬ isSubsective allegedAdj := by


### PR DESCRIPTION
Three-agent audit cleanse of `Modification/Classification.lean`; net −90 lines.

- module docstring rewritten to the mathlib register (Order/Closure.lean as exemplar); attribution corrections from primary/secondary-source verification: the four-class hierarchy is the Montague/Parsons/Kamp lineage consolidated in Kamp & Partee 1995 with Partee's labels (not Kamp 1975 alone); extensionality presented as the orthogonal dimension, not hierarchy rung #4; Parsons 1970 "predicative"/"standard" attributions verified correct and kept
- local `isExtensional` deleted — it re-defined `Intensional.IsExtensional` (already imported); `isExtensional_of_isIntersective` now concludes the Rigidity-layer notion, and Rigidity's prose cross-reference is truthful again
- Independence section deleted: `subNotExtAdj` duplicated `Kamp1975.skillfulAdj` definitionally; the orthogonality witnesses now live in `Studies/Kamp1975.lean` via real adjectives (new `alleged_extensional` + existing `skillful_not_extensional`)
- zero-consumer `isSubsective_iff` dropped; `isIntersective_iff` golfed to a one-line `simp only`