### PR TITLE
docs(Semantics): calibrate docstrings to mathlib register

### DIFF
--- a/Linglib/Semantics/Modification/Classification.lean
+++ b/Linglib/Semantics/Modification/Classification.lean
@@ -8,40 +8,29 @@ import Mathlib.Tactic.Common
 # Modifier-meaning classification at the intensional carrier
 
 We instantiate the order-theoretic modifier classes of
-`Modification/Basic.lean` (`Modifier.isIntersective`, `.isSubsective`,
-`.isPrivative`) at intensional properties, providing their pointwise
-unfolding lemmas, the implication structure, and [partee-2010]'s
-post-collapse three-class hierarchy.
-
-The classification descends from the operator treatment of modifiers
-introduced independently by [parsons-1970] and [kamp-1975] — Kamp's
-definitions (4)–(7): "predicative" (intersective), "privative",
-"affirmative" (subsective), "extensional"; Parsons's terms were
-"predicative" and "standard" — and was consolidated in
-[kamp-partee-1995]; the modern labels are Partee's.
-Extensionality — dependence on the noun's extension at each world — is
-the orthogonal, cross-cutting dimension, not a rung of the entailment
-hierarchy: it is `Intensional.IsExtensional` at this carrier, and
-`Studies/Kamp1975.lean` § 4 witnesses its independence from
-subsectivity. Whether *adjectives* uniformly denote
-`Modifier (Property W E)` is itself a theoretical claim
-(`Studies/Elbourne2026.lean`); the carrier is named for the denotation
-type, not the word class.
+`Modification/Basic.lean` at intensional properties. The classification
+goes back to [parsons-1970] and [kamp-1975] (definitions (4)–(7)) and
+was consolidated in [kamp-partee-1995]; the modern labels are Partee's.
 
 ## Main definitions
 
 * `Property W E`: intensional properties, `Intensional.Intension W (E → Prop)`.
 * `isIntersective_iff`, `isPrivative_iff`: pointwise forms of the
-  order-theoretic classes at this carrier ("gray"/"French" vs
-  "fake"/"counterfeit"; subsective "skillful" needs no unfolding lemma —
-  `Modifier.isSubsective` is already pointwise here).
+  order-theoretic classes at this carrier.
 * `isExtensional_of_isIntersective`: intersective modifier meanings are
   `Intensional.IsExtensional`.
 * `not_isSubsective_of_isPrivative`: privative meanings with non-empty
-  extension are not subsective (intersective → subsective holds at any
-  carrier: `Modifier.isIntersective.isSubsective`).
+  extension are not subsective.
 * `RevisedClass`: [partee-2010]'s three-class hierarchy after the
-  privative collapse, interpreted by `RevisedClass.satisfies`.
+  privative collapse.
+
+## Implementation notes
+
+Extensionality is orthogonal to the entailment hierarchy; the
+independence witnesses are in `Studies/Kamp1975.lean`. Whether
+*adjectives* uniformly denote `Modifier (Property W E)` is a
+theoretical claim (`Studies/Elbourne2026.lean`); the carrier is named
+for the denotation type, not the word class.
 -/
 
 namespace Modification

--- a/Linglib/Semantics/Modification/Coercion.lean
+++ b/Linglib/Semantics/Modification/Coercion.lean
@@ -3,33 +3,25 @@ import Linglib.Semantics.Modification.Classification
 /-!
 # Modification-time noun coercion (NVP + HPP)
 
-`LicensedCoercion` and `SubsectiveReanalysis`: type-level architecture for
-noun-extension widening under the Non-Vacuity Principle and Head Primacy
-Principle of [kamp-partee-1995] (§ 5.3, p. 161; stated as formulae (18)
-and (20) in [partee-2010] § 4), used by [partee-2010] to reanalyse
-privative adjectives as subsective-after-coercion. Both principles are
-anticipated in [kamp-1975] § 7: the noun as the central contextual
-factor fixing the adjective's standards, and the requirement that an
-attributive adjective "cut the extension of the noun" nontrivially.
-Consumed by `Studies/Partee2010.lean` and `Studies/DelPinal2015.lean`.
+Noun-extension widening under the Non-Vacuity and Head Primacy
+Principles of [kamp-partee-1995], used by [partee-2010] to reanalyse
+privative adjectives as subsective-after-coercion; both principles are
+anticipated in [kamp-1975] § 7.
 
 ## Main definitions
 
 * `isNonVacuous P w d`: NVP at world `w` within local domain `d`.
-* `LicensedCoercion N adj w`: NVP-licensed widening of `N`. The `shift`
-  is a full intension even though licensing holds at the single context
-  world `w`: a non-extensional `adj` reads the shift's values at other
-  worlds.
-* `SubsectiveReanalysis adjClassical`: reanalysis as subsective-after-coercion.
+* `LicensedCoercion N adj w`: NVP-licensed widening of `N`.
+* `SubsectiveReanalysis adjClassical`: reanalysis as
+  subsective-after-coercion.
 
 ## Implementation notes
 
-This models the adjective-triggered widening of [partee-2010]'s fake-fur
-case; the constitutive-material case (stone lion) is bracketed there and
-not modelled here. `isNonVacuous` states the NVP bivalently (negative
-extension = complement), simplifying [kamp-partee-1995]'s partial
-setting. Not to be confused with complement coercion
-(`Studies/Pustejovsky1995.lean`), NP type-shifting
+This models the fake-fur widening of [partee-2010] § 4 (its formulae
+(18) and (20)); the constitutive-material case (stone lion) is bracketed
+there. `isNonVacuous` states the NVP bivalently, simplifying
+[kamp-partee-1995]'s partial setting. Not to be confused with complement
+coercion (`Studies/Pustejovsky1995.lean`), NP type-shifting
 (`Semantics/Composition/TypeShifting.lean`), or aspectual coercion
 (`Semantics/Aspect/Composition.lean`).
 -/
@@ -57,7 +49,9 @@ theorem isNonVacuous_compl {P : Property W E} {w : W} {d : E → Prop} :
   exact and_comm
 
 /-- A wider noun extension `shift ⊇ N` at `w` under which `adj shift`
-    is non-vacuous in `shift`'s extension (the HPP local domain). -/
+    is non-vacuous in `shift`'s extension (the HPP local domain). The
+    `shift` is a full intension although licensing holds at the single
+    world `w`: a non-extensional `adj` reads its values at other worlds. -/
 structure LicensedCoercion (N : Property W E) (adj : Modifier (Property W E)) (w : W) where
   shift : Property W E
   le_shift : N w ≤ shift w

--- a/Linglib/Semantics/Modification/Coercion.lean
+++ b/Linglib/Semantics/Modification/Coercion.lean
@@ -13,15 +13,6 @@ factor fixing the adjective's standards, and the requirement that an
 attributive adjective "cut the extension of the noun" nontrivially.
 Consumed by `Studies/Partee2010.lean` and `Studies/DelPinal2015.lean`.
 
-Scope: models the adjective-triggered widening of [partee-2010]'s
-fake-fur case; the constitutive-material case (stone lion) is bracketed
-there and not modelled here. `isNonVacuous` states the NVP bivalently
-(negative extension = complement), simplifying [kamp-partee-1995]'s
-partial setting. Not to be confused with complement coercion
-(`Studies/Pustejovsky1995.lean`), NP type-shifting
-(`Semantics/Composition/TypeShifting.lean`), or aspectual coercion
-(`Semantics/Aspect/Composition.lean`).
-
 ## Main definitions
 
 * `isNonVacuous P w d`: NVP at world `w` within local domain `d`.
@@ -30,6 +21,17 @@ partial setting. Not to be confused with complement coercion
   world `w`: a non-extensional `adj` reads the shift's values at other
   worlds.
 * `SubsectiveReanalysis adjClassical`: reanalysis as subsective-after-coercion.
+
+## Implementation notes
+
+This models the adjective-triggered widening of [partee-2010]'s fake-fur
+case; the constitutive-material case (stone lion) is bracketed there and
+not modelled here. `isNonVacuous` states the NVP bivalently (negative
+extension = complement), simplifying [kamp-partee-1995]'s partial
+setting. Not to be confused with complement coercion
+(`Studies/Pustejovsky1995.lean`), NP type-shifting
+(`Semantics/Composition/TypeShifting.lean`), or aspectual coercion
+(`Semantics/Aspect/Composition.lean`).
 -/
 
 namespace Modification

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -85,12 +85,11 @@ end Bridge
 
 /-! ### The many-valued dilemma -/
 
-/-- **Kamp's dilemma** (pp. 130–131): no truth-functional conjunction can
-    both be idempotent at the borderline value and make borderline
-    contradictions false — with `neg indet = indet`, the two demands land
-    on the same input pair. Kamp states the argument for every linearly
-    ordered n-valued logic; `Trivalent` is its minimal (n = 3) witness.
-    Supervaluation escapes by giving up truth-functionality. -/
+/-- No truth-functional conjunction is both idempotent at the borderline
+    value and false on borderline contradictions: with `neg indet = indet`,
+    both demands constrain the same input pair. This is the dilemma of
+    [kamp-1975], pp. 130–131, stated there for every linearly ordered
+    n-valued logic; `Trivalent` is the minimal witness. -/
 theorem kleene_dilemma :
     ¬∃ (meet : Trivalent → Trivalent → Trivalent),
       meet .indet .indet = .indet ∧
@@ -115,14 +114,12 @@ admissible completion that puts u₂ in the extension also puts u₁ in it.
 comparison classes; the bridge is
 `Klein1980.kleinPreorder_eq_kampPreorder`. -/
 
-/-- Kamp's completion-based comparative (definition (12), paper § 4)
-    induces a `Preorder`: `le u₁ u₂` iff every completion in `S` that
-    puts `u₂` in the extension also puts `u₁` in — so `le` reads "u₁ is
-    at least as A as u₂", Kamp's `≥`. Kamp notes (12) is "precisely the
-    proposal … in Lewis (1970), where it is attributed to David Kaplan"
-    (for his one-dimensional *heavy* example).
-
-    The S-restricted analogue of `kleinPreorder` from `Delineation.lean`. -/
+/-- Kamp's completion comparative (definition (12), paper § 4) as a
+    `Preorder`: `le u₁ u₂` iff every completion in `S` that puts `u₂` in
+    the extension also puts `u₁` in — `le` reads "u₁ is at least as A as
+    u₂", Kamp's `≥`. The S-restricted analogue of `kleinPreorder` in
+    `Delineation.lean`. Kamp credits (12) to Lewis (1970), where it is
+    attributed to Kaplan. -/
 @[reducible] def kampPreorder {E C : Type*} (ext : C → E → Prop) (S : Set C) :
     Preorder E where
   le u₁ u₂ := ∀ c ∈ S, ext c u₂ → ext c u₁
@@ -139,9 +136,9 @@ theorem kampPreorder_antitone {E C : Type*} (ext : C → E → Prop) (u₁ u₂ 
 
 Kamp's second candidate, definition (13) (paper § 4), compares the
 *measures* of the completion sets rather than the sets themselves. His
-§ 5 argues (13) is wrong for multi-criteria adjectives — it forces any
-two entities to be comparable — while (12) correctly leaves Smith and
-Jones incomparable in cleverness; for one-dimensional adjectives
+§ 5 argues against (13) for multi-criteria adjectives: it makes any two
+entities comparable, while (12) leaves Smith and Jones incomparable in
+cleverness — for Kamp the right verdict. For one-dimensional adjectives
 (*heavy*, *tall*, *hot*) the two provably coincide. -/
 
 section MeasuredComparative
@@ -158,10 +155,9 @@ variable {E C : Type*} (ext : C → E → Prop) [∀ c e, Decidable (ext c e)]
 def kampMeasureLe (u₁ u₂ : E) : Prop :=
   ∑ c ∈ S with ext c u₂, p c ≤ ∑ c ∈ S with ext c u₁, p c
 
-/-- (13) is total: measures are rationals, hence linearly ordered —
-    Kamp's § 5 objection that (13) "implies that for any objects u₁ and
-    u₂ ... either u₁ is at least as A as u₂ or u₂ is at least as A as
-    u₁". -/
+/-- (13) is total: it makes any two objects comparable. This is Kamp's
+    § 5 objection to (13); (12) does not share the property
+    (`clever_incomparable`). -/
 theorem kampMeasureLe_total (u₁ u₂ : E) :
     kampMeasureLe ext S p u₁ u₂ ∨ kampMeasureLe ext S p u₂ u₁ :=
   le_total _ _
@@ -262,14 +258,9 @@ inductive W2 | w₁ | w₂
 /-- Three entities suffice for all witness constructions. -/
 inductive E3 | a | b | c
 
-/-- **"gray"**: an intersective adjective. The extension of "gray N" is
-    `{x | gray(x)} ∩ {x | N(w)(x)}` — a fixed property independent of
-    the noun.
-
-    Models [kamp-1975] definition (4), his "predicative" class (the
-    modern *intersective*). Entailment pattern:
-    "gray cat" entails both "gray" and "cat"; "gray" + "cat" entails
-    "gray cat". -/
+/-- "gray": an intersective adjective ([kamp-1975] definition (4),
+    "predicative") — a fixed property conjoined with the noun, so
+    "gray cat" entails both "gray" and "cat". -/
 def grayAdj : Modifier (Property W2 E3) := fun N w x =>
   (match x with | .a => True | _ => False) ∧ N w x
 
@@ -283,33 +274,22 @@ example : Intensional.IsExtensional grayAdj :=
   isExtensional_of_isIntersective gray_intersective
 example : isSubsective grayAdj := gray_intersective.isSubsective
 
-/-- **"fake"**: a privative adjective (traditional analysis). "Fake N"
-    entities are never N.
-
-    Models [kamp-1975] definition (5); *fake* and *false* are Kamp's
-    examples. Entailment pattern: "fake gun" entails "not a gun".
-
-    Kamp himself doubts "that there is any English adjective which is
-    privative (in the precise sense here defined) in all of its possible
-    uses" — anticipating [partee-2010]'s reanalysis of the class as
-    subsective with noun coercion; see `Partee2010.lean`. -/
+/-- "fake": a privative adjective ([kamp-1975] definition (5); *fake* and
+    *false* are his examples) — "fake gun" entails "not a gun". Kamp
+    doubts any English adjective is privative "in all of its
+    possible uses", anticipating [partee-2010]'s subsective-plus-coercion
+    reanalysis; see `Partee2010.lean`. -/
 def fakeAdj : Modifier (Property W2 E3) := fun N w x =>
   (match x with | .b => True | _ => False) ∧ ¬ N w x
 
 theorem fake_privative : isPrivative fakeAdj :=
   isPrivative_iff.mpr fun _ _ _ h => h.2
 
-/-- **"skillful"**: a subsective adjective that is NOT extensional.
-    Being a "skillful N" depends on N's intension — what counts as an N
-    across worlds — not just who the N's are in this world.
-
-    Models [kamp-1975] definition (6), his "affirmative" class (the
-    modern *subsective*), without definition (7); *skilful* is his
-    non-extensional example (crediting the cobblers/darts-players case
-    to David Lewis).
-    Entailment pattern: "skillful surgeon" entails "surgeon" (subsective),
-    but "skillful surgeon" + "violinist" does not entail "skillful
-    violinist" (not intersective, because not extensional). -/
+/-- "skillful": subsective ([kamp-1975] definition (6), "affirmative")
+    but not extensional — "skillful surgeon" entails "surgeon", yet skill
+    depends on the noun's intension, not just its current extension
+    (Kamp's example, crediting the cobblers/darts-players case to David
+    Lewis). -/
 def skillfulAdj : Modifier (Property W2 E3) := fun N w x =>
   N w x ∧ match x with
     | .a => N .w₁ .a  -- a's skill assessment depends on N's intension
@@ -330,15 +310,10 @@ theorem skillful_not_extensional : ¬ Intensional.IsExtensional skillfulAdj := b
   have hLHS : skillfulAdj N₁ .w₂ .a := ⟨trivial, trivial⟩
   exact (congrFun h .a ▸ hLHS).2
 
-/-- **"alleged"**: a non-subsective (modal) adjective — [kamp-1975]'s
-    opening example (1), "Every alleged thief is a thief". An "alleged N"
-    may or may not be an N — the adjective creates an intensional
-    context without entailing or anti-entailing the noun.
-
-    This is the complement class in the hierarchy: adjectives like
-    "alleged", "potential", "putative" that carry no meaning postulate
-    constraining the relationship between the modified and unmodified
-    extension. -/
+/-- "alleged": a non-subsective (modal) adjective — [kamp-1975]'s opening
+    example (1), "Every alleged thief is a thief" is no logical truth. No
+    meaning postulate relates the modified and unmodified extensions
+    (likewise "potential", "putative"). -/
 def allegedAdj : Modifier (Property W2 E3) := fun _N _ x =>
   match x with | .a => True | _ => False
 

--- a/Linglib/Studies/Kamp1975.lean
+++ b/Linglib/Studies/Kamp1975.lean
@@ -5,49 +5,28 @@ import Mathlib.Algebra.Order.Ring.Rat
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 
 /-!
-# Kamp (1975): Two Theories about Adjectives [kamp-1975]
+# Kamp (1975): Two Theories about Adjectives
+[kamp-1975]
 
-In E. Keenan (ed.), *Formal Semantics of Natural Language*, 123–155.
-Cambridge University Press.
-
-Kamp presents two theories of adjective semantics. **Theory 1**:
-adjectives as functions from properties to properties, classified by
-meaning postulates — his definitions (4)–(7), "predicative", "privative",
-"affirmative", "extensional" — formalized in `Modification/Basic.lean`
-and `Semantics/Modification/Classification.lean`; § 1 below bridges the
-intensional and single-world carriers. **Theory 2**: vague models
-`⟨M, S, F, p⟩` (partial model, completions, field of subsets,
-probability measure), from which the comparative is derived by
-quantification over completions. The model apparatus itself (partial,
-graded, and context-dependent models) is not formalized — completions
-are abstracted to an opaque carrier — but the theory's comparative core
-is: definitions (12) and (13) (paper § 4), their § 5 comparison, and
-one-dimensionality (condition (18), paper § 6).
-
-Building on [van-fraassen-1969]'s supervaluations, Theory 2 is the
-ancestor of [klein-1980]'s delineation semantics and an independent
-contemporary of [fine-1975] (Kamp met Fine's paper "only after the
-present paper had already been given its final form", fn. 1).
+Theory 1 classifies adjective meanings (functions from properties to
+properties) by meaning postulates — the classification lives in
+`Semantics/Modification/Classification.lean`. Theory 2, building on
+[van-fraassen-1969]'s supervaluations, derives the comparative from
+quantification over completions of a partial model; we formalize its
+comparative core, leaving the model apparatus abstract.
 
 ## Main results
 
-* `intersective_at_world`, `subsective_at_world`: fixing a world sends the
-  intensional instance of the `Modifier.is*` hierarchy to the single-world
-  instance.
-* `kleene_dilemma`: no truth-functional conjunction is both idempotent at
-  the borderline value and falsifies borderline contradictions
-  (pp. 130–131).
-* `kampPreorder`: definition (12), the completion comparative, as a
-  `Preorder`; `Klein1980.kleinPreorder_eq_kampPreorder` is the delineation
-  bridge.
-* `kampMeasureLe`: definition (13), the measure comparative;
-  `kampMeasureLe_total` states the forced totality Kamp objects to, and
-  `clever_incomparable` is his Smith/Jones witness for (12).
-* `kampPreorder_le_iff_kampMeasureLe`: for one-dimensional adjectives with
-  positive weights, (12) and (13) coincide.
-* `grayAdj`, `fakeAdj`, `skillfulAdj`, `allegedAdj`: witnesses inhabiting
-  each class of the definitions-(4)–(7) hierarchy, shared as fixtures by
-  `Partee2010.lean` and `DelPinal2015.lean`.
+* `kleene_dilemma`: no truth-functional conjunction is both idempotent
+  at the borderline value and false on borderline contradictions.
+* `kampPreorder`: the completion comparative, definition (12).
+* `kampMeasureLe`: the measure comparative, definition (13);
+  `kampMeasureLe_total` is Kamp's objection to it and
+  `clever_incomparable` his Smith/Jones witness.
+* `kampPreorder_le_iff_kampMeasureLe`: for one-dimensional adjectives,
+  (12) and (13) coincide.
+* `grayAdj`, `fakeAdj`, `skillfulAdj`, `allegedAdj`: witnesses for the
+  four classes, shared by `Partee2010.lean` and `DelPinal2015.lean`.
 -/
 
 namespace Kamp1975


### PR DESCRIPTION
Docstring calibration against a read of mathlib exemplars (Order/Filter/Defs, Probability/Kernel/Defs, Order/Lattice, Topology/UniformSpace/Defs, SimpleGraph/Basic).

- declaration docstrings trimmed to the mathlib register: object-first copular sentences, teaching voice not advocacy voice (evaluations attributed to Kamp, not asserted — "correctly"/"wrong" removed), source locations in the "This is definition (N) of [ref]" pattern, no verbatim-quote blocks or entailment-pattern enumerations in decl docstrings
- `Coercion.lean`: scope/disambiguation prose moved under `## Implementation notes` (mathlib section order)