### PR TITLE
refactor(Core/Probability/Decision): DecisionProblem namespace + API

### DIFF
--- a/Linglib/Core/Probability/Decision/Basic.lean
+++ b/Linglib/Core/Probability/Decision/Basic.lean
@@ -16,43 +16,50 @@ import Mathlib.Tactic.Ring
 /-!
 # Decision problems and the value of information
 
-Finite decision problems over an arbitrary `LinearOrderedField K` and
-[van-rooy-2003]'s
-decision-theoretic values of propositions and questions: expected utility,
-utility value `UV`, question utility `EUV`, value of sample information
-`VSI`/`EVSI`, and the maximin analogues. Theory-neutral: no question-semantic
-imports, so any module (RSA, causal decision theory, explanation models) can
-use decision problems without pulling in the `Question` cone.
+Finite decision problems over an arbitrary `LinearOrder`ed `Field K` and
+[van-rooy-2003]'s decision-theoretic values of propositions and questions:
+expected utility, utility value `UV`, question utility `EUV`, value of sample
+information `VSI`/`EVSI`, and the maximin analogues. Theory-neutral: no
+question-semantic imports, so any module (RSA, causal decision theory,
+explanation models) can use decision problems without pulling in the
+`Question` cone.
 
 ## Main definitions
 
 * `DecisionProblem`: a utility function `W → A → K` with a prior `W → K`.
   The structure itself is constraint-free; theorems assume
-  `[Field K] [LinearOrder K] [IsStrictOrderedRing K]`. Studies instantiate `K := ℚ` for exact,
-  `decide`-friendly arithmetic; `Core.Probability.Decision.ExperimentDesign`
-  uses `K := ℝ` against `eig`.
-* `expectedUtility`, `dpValue`, `conditionalEU`, `valueAfterLearning`,
-  `utilityValue`: `EU(a)`, `V(D)`, `EU(a ∣ C)`, `V(D ∣ C)`, and
-  `UV(C) = V(D ∣ C) − V(D)`.
-* `questionUtility`: `EUV(Q) = ∑_{q ∈ Q} P(q) · UV(q)`.
-* `valueSampleInfo`, `expectedVSI`: [van-rooy-2003]'s `VSI`/`EVSI` (p. 742).
-* `securityLevel`, `maximinValue`, `maximinUtilityValue`, `questionMaximin`:
-  the maximin (worst-case) analogues.
-* `IsResolved`: [van-rooy-2003]'s resolution of a decision problem (p. 736).
+  `[Field K] [LinearOrder K] [IsStrictOrderedRing K]`. Studies instantiate
+  `K := ℚ` for exact, `decide`-friendly arithmetic;
+  `Core.Probability.Decision.ExperimentDesign` uses `K := ℝ` against `eig`.
+* `DecisionProblem.expectedUtility`, `.value`, `.condExpectedUtility`,
+  `.condValue`, `.utilityValue`: `EU(a)`, `V(D)`, `EU(a ∣ C)`, `V(D ∣ C)`,
+  and `UV(C) = V(D ∣ C) − V(D)`.
+* `DecisionProblem.questionUtility`: `EUV(Q) = ∑_{q ∈ Q} P(q) · UV(q)`.
+* `DecisionProblem.valueSampleInfo`, `.expectedValueSampleInfo`:
+  [van-rooy-2003]'s `VSI`/`EVSI` (p. 742).
+* `DecisionProblem.securityLevel`, `.maximinValue`, `.maximinUtilityValue`,
+  `.questionMaximin`: the maximin (worst-case) analogues.
+* `DecisionProblem.IsResolved`: [van-rooy-2003]'s resolution of a decision
+  problem (p. 736).
 
 ## Main results
 
-* `euv_eq_evsi`: `EUV(Q) = EVSI(Q)` ([van-rooy-2003], p. 742).
-* `questionUtility_mono_of_refines`: `EUV` is monotone under partition
-  refinement — the `⟹` direction of [van-rooy-2003]'s §4.1 Fact (p. 743).
-* `binary_question_value_decomposition`: the yes/no-question instance.
+* `DecisionProblem.questionUtility_eq_expectedValueSampleInfo`:
+  `EUV(Q) = EVSI(Q)` ([van-rooy-2003], p. 742).
+* `DecisionProblem.questionUtility_mono_of_refines`: `EUV` is monotone under
+  partition refinement — the `⟹` direction of [van-rooy-2003]'s §4.1 Fact
+  (p. 743).
+* `DecisionProblem.binary_question_value_decomposition`: the yes/no-question
+  instance.
 
 ## Design: Fintype + Finset
 
 Functions that sum over the full universe use `[Fintype W]` with `∑ w : W`.
 Functions that operate over action sets or world subsets use `Finset`.
-`questionUtility` and `expectedVSI` take `Finset (Finset W)` (cells as sets);
-`questionMaximin` takes a `List (Finset W)` of cells.
+`questionUtility` and `expectedValueSampleInfo` take `Finset (Finset W)`
+(cells as sets); `questionMaximin` takes a `List (Finset W)` of cells.
+Empty action sets get the junk value `0` (the `Real.sSup` convention), with
+`_of_nonempty` characterization lemmas as the working API.
 
 - [van-rooy-2003]. Questioning to Resolve Decision Problems. L&P 26.
 - [blackwell-1953]. Equivalent Comparisons of Experiments.
@@ -61,8 +68,6 @@ Functions that operate over action sets or world subsets use `Finset`.
 namespace Core.DecisionTheory
 
 variable {K W A : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
-
-/-! ### Decision problems -/
 
 /-- A decision problem `D = (W, A, U, π)` with utility and prior. -/
 structure DecisionProblem (K W A : Type*) where
@@ -82,8 +87,6 @@ def withUniformPrior [Fintype W] (utility : W → A → K) : DecisionProblem K W
   utility := utility
   prior := uniformPrior
 
-end DecisionProblem
-
 /-! ### Expected utility -/
 
 variable (dp : DecisionProblem K W A)
@@ -93,27 +96,60 @@ def expectedUtility [Fintype W] (a : A) : K :=
   ∑ w : W, dp.prior w * dp.utility w a
 
 /-- Value of a decision problem: max EU over actions, or `0` if empty. -/
-def dpValue [Fintype W] (actions : Finset A) : K :=
-  if h : actions.Nonempty then actions.sup' h (expectedUtility dp) else 0
+def value [Fintype W] (actions : Finset A) : K :=
+  if h : actions.Nonempty then actions.sup' h dp.expectedUtility else 0
 
-/-- Conditional expected utility of action `a` given cell membership. -/
-def conditionalEU (cell : Finset W) (a : A) : K :=
-  let totalProb := cell.sum dp.prior
-  if totalProb = 0 then 0
-  else cell.sum (λ w => (dp.prior w / totalProb) * dp.utility w a)
+/-- Conditional expected utility of action `a` given cell membership
+    (`0` on zero-mass cells). -/
+def condExpectedUtility (cell : Finset W) (a : A) : K :=
+  if cell.sum dp.prior = 0 then 0
+  else cell.sum (λ w => (dp.prior w / cell.sum dp.prior) * dp.utility w a)
 
 /-- Value of the decision problem after learning `cell`: best conditional EU
     among actions. -/
-def valueAfterLearning (actions : Finset A) (cell : Finset W) : K :=
-  if h : actions.Nonempty then actions.sup' h (conditionalEU dp cell) else 0
+def condValue (actions : Finset A) (cell : Finset W) : K :=
+  if h : actions.Nonempty then actions.sup' h (dp.condExpectedUtility cell) else 0
 
 /-- `UV(C) = V(D ∣ C) − V(D)`, the utility value of learning proposition `C`. -/
 def utilityValue [Fintype W] (actions : Finset A) (cell : Finset W) : K :=
-  valueAfterLearning dp actions cell - dpValue dp actions
+  dp.condValue actions cell - dp.value actions
 
 /-- Probability of a cell of the partition. -/
 def cellProbability (cell : Finset W) : K :=
   cell.sum dp.prior
+
+section CharacterizationApi
+
+variable {dp} {actions : Finset A} {cell : Finset W}
+
+omit [IsStrictOrderedRing K] in
+theorem value_of_nonempty [Fintype W] (h : actions.Nonempty) :
+    dp.value actions = actions.sup' h dp.expectedUtility := dif_pos h
+
+omit [IsStrictOrderedRing K] in
+@[simp] theorem value_empty [Fintype W] : dp.value (∅ : Finset A) = 0 :=
+  dif_neg Finset.not_nonempty_empty
+
+omit [IsStrictOrderedRing K] in
+theorem condValue_of_nonempty (h : actions.Nonempty) :
+    dp.condValue actions cell = actions.sup' h (dp.condExpectedUtility cell) :=
+  dif_pos h
+
+omit [IsStrictOrderedRing K] in
+@[simp] theorem condValue_empty : dp.condValue (∅ : Finset A) cell = 0 :=
+  dif_neg Finset.not_nonempty_empty
+
+omit [IsStrictOrderedRing K] in
+theorem condExpectedUtility_of_ne_zero (h : cell.sum dp.prior ≠ 0) (a : A) :
+    dp.condExpectedUtility cell a
+      = cell.sum (λ w => (dp.prior w / cell.sum dp.prior) * dp.utility w a) :=
+  if_neg h
+
+omit [IsStrictOrderedRing K] in
+@[simp] theorem condExpectedUtility_of_eq_zero (h : cell.sum dp.prior = 0) (a : A) :
+    dp.condExpectedUtility cell a = 0 := if_pos h
+
+end CharacterizationApi
 
 /-! ### Maximin -/
 
@@ -123,23 +159,42 @@ def securityLevel (worlds : Finset W) (a : A) : K :=
 
 /-- `MV = max_a min_w U(w, a)`, the maximin value. -/
 def maximinValue (worlds : Finset W) (actions : Finset A) : K :=
-  if h : actions.Nonempty then actions.sup' h (securityLevel dp worlds) else 0
+  if h : actions.Nonempty then actions.sup' h (dp.securityLevel worlds) else 0
+
+section MaximinApi
+
+variable {dp} {worlds : Finset W} {actions : Finset A} {a : A}
+
+omit [IsStrictOrderedRing K] in
+theorem securityLevel_of_nonempty (h : worlds.Nonempty) :
+    dp.securityLevel worlds a = worlds.inf' h (λ w => dp.utility w a) := dif_pos h
+
+omit [IsStrictOrderedRing K] in
+theorem maximinValue_of_nonempty (h : actions.Nonempty) :
+    dp.maximinValue worlds actions = actions.sup' h (dp.securityLevel worlds) :=
+  dif_pos h
+
+omit [IsStrictOrderedRing K] in
+@[simp] theorem maximinValue_empty :
+    dp.maximinValue worlds (∅ : Finset A) = 0 := dif_neg Finset.not_nonempty_empty
+
+end MaximinApi
 
 section InterCells
 
 variable [DecidableEq W]
 
 /-- Conditional security level: worst case within cell `c`. -/
-def conditionalSecurityLevel (worlds : Finset W) (a : A) (c : Finset W) : K :=
-  securityLevel dp (worlds ∩ c) a
+def condSecurityLevel (worlds : Finset W) (a : A) (c : Finset W) : K :=
+  dp.securityLevel (worlds ∩ c) a
 
 /-- Maximin value after learning `c`. -/
-def maximinAfterLearning (worlds : Finset W) (actions : Finset A) (c : Finset W) : K :=
-  maximinValue dp (worlds ∩ c) actions
+def condMaximinValue (worlds : Finset W) (actions : Finset A) (c : Finset W) : K :=
+  dp.maximinValue (worlds ∩ c) actions
 
 /-- Maximin utility value of learning `c`. -/
 def maximinUtilityValue (worlds : Finset W) (actions : Finset A) (c : Finset W) : K :=
-  maximinAfterLearning dp worlds actions c - maximinValue dp worlds actions
+  dp.condMaximinValue worlds actions c - dp.maximinValue worlds actions
 
 end InterCells
 
@@ -166,7 +221,7 @@ instance IsResolved.instDecidable (dp : DecisionProblem K W A) (acts : Set A) (c
     question `Q`. -/
 def questionUtility [Fintype W] (dp : DecisionProblem K W A) (actions : Finset A)
     (cells : Finset (Finset W)) : K :=
-  cells.sum (λ cell => cellProbability dp cell * utilityValue dp actions cell)
+  cells.sum (λ cell => dp.cellProbability cell * dp.utilityValue actions cell)
 
 /-- `MV(Q) = min_{q ∈ Q} MV(q)`, the maximin question value. -/
 def questionMaximin [DecidableEq W] (dp : DecisionProblem K W A) (worlds : Finset W)
@@ -174,8 +229,8 @@ def questionMaximin [DecidableEq W] (dp : DecisionProblem K W A) (worlds : Finse
   match q with
   | [] => 0
   | c :: cs => cs.foldl (λ m cell =>
-      min m (maximinUtilityValue dp worlds actions cell)
-    ) (maximinUtilityValue dp worlds actions c)
+      min m (dp.maximinUtilityValue worlds actions cell)
+    ) (dp.maximinUtilityValue worlds actions c)
 
 /-! ### Value of sample information -/
 
@@ -186,7 +241,7 @@ def questionMaximin [DecidableEq W] (dp : DecisionProblem K W A) (worlds : Finse
 noncomputable def optimalAction [Fintype W] (dp : DecisionProblem K W A)
     (actions : Finset A) : Option A :=
   if h : actions.Nonempty then
-    some (Finset.exists_max_image actions (expectedUtility dp) h).choose
+    some (Finset.exists_max_image actions dp.expectedUtility h).choose
   else none
 
 /-- `VSI(C) = V(D ∣ C) − EU(a⁰ ∣ C)`: the value of sample information from
@@ -198,29 +253,30 @@ noncomputable def optimalAction [Fintype W] (dp : DecisionProblem K W A)
 noncomputable def valueSampleInfo [Fintype W] (dp : DecisionProblem K W A)
     (actions : Finset A) (cell : Finset W) : K :=
   let currentActionEU := match optimalAction dp actions with
-    | some a => conditionalEU dp cell a
+    | some a => dp.condExpectedUtility cell a
     | none => 0
-  valueAfterLearning dp actions cell - currentActionEU
+  dp.condValue actions cell - currentActionEU
 
 /-- `EVSI(Q) = ∑ P(C) · VSI(C)`: the expected value of sample information
     from asking question `Q` ([van-rooy-2003], p. 742). -/
-noncomputable def expectedVSI [Fintype W] (dp : DecisionProblem K W A)
+noncomputable def expectedValueSampleInfo [Fintype W] (dp : DecisionProblem K W A)
     (actions : Finset A) (cells : Finset (Finset W)) : K :=
-  cells.sum (λ cell => cellProbability dp cell * valueSampleInfo dp actions cell)
+  cells.sum (λ cell => dp.cellProbability cell * valueSampleInfo dp actions cell)
 
 section EuvEvsi
 
 variable [Fintype W]
 
 omit [IsStrictOrderedRing K] in
-private lemma optimalAction_eu_eq_dpValue (dp : DecisionProblem K W A) (actions : Finset A) :
+private lemma optimalAction_expectedUtility_eq_value (dp : DecisionProblem K W A)
+    (actions : Finset A) :
     (match optimalAction dp actions with
-     | some a => expectedUtility dp a
-     | none => (0 : K)) = dpValue dp actions := by
-  unfold optimalAction dpValue
+     | some a => dp.expectedUtility a
+     | none => (0 : K)) = dp.value actions := by
+  unfold optimalAction value
   by_cases hne : actions.Nonempty
   · rw [dif_pos hne, dif_pos hne]; simp only []
-    have hspec := (Finset.exists_max_image actions (expectedUtility dp) hne).choose_spec
+    have hspec := (Finset.exists_max_image actions dp.expectedUtility hne).choose_spec
     exact le_antisymm (Finset.le_sup' _ hspec.1)
       (Finset.sup'_le hne _ λ a ha => hspec.2 a ha)
   · rw [dif_neg hne, dif_neg hne]
@@ -235,22 +291,22 @@ omit [IsStrictOrderedRing K] in
     The two hypotheses are the **law of total expectation**
     (`∑ P(C) · EU(a ∣ C) = EU(a)` for all actions) and **cell probability
     normalization** (`∑ P(C) = 1`). -/
-theorem euv_eq_evsi (dp : DecisionProblem K W A) (actions : Finset A)
-    (cells : Finset (Finset W))
+theorem questionUtility_eq_expectedValueSampleInfo (dp : DecisionProblem K W A)
+    (actions : Finset A) (cells : Finset (Finset W))
     (hLTE : ∀ a, cells.sum (λ cell =>
-      cellProbability dp cell * conditionalEU dp cell a) = expectedUtility dp a)
-    (hSum : cells.sum (λ cell => cellProbability dp cell) = 1) :
-    questionUtility dp actions cells = expectedVSI dp actions cells := by
+      dp.cellProbability cell * dp.condExpectedUtility cell a) = dp.expectedUtility a)
+    (hSum : cells.sum (λ cell => dp.cellProbability cell) = 1) :
+    questionUtility dp actions cells = expectedValueSampleInfo dp actions cells := by
   set S := cells.sum (λ cell =>
-      cellProbability dp cell * valueAfterLearning dp actions cell)
-  have hLHS : questionUtility dp actions cells = S - dpValue dp actions := by
+      dp.cellProbability cell * dp.condValue actions cell)
+  have hLHS : questionUtility dp actions cells = S - dp.value actions := by
     unfold questionUtility; simp only [utilityValue]; simp_rw [mul_sub]
     rw [Finset.sum_sub_distrib]
     congr 1; rw [← Finset.sum_mul, hSum, one_mul]
-  have hRHS : expectedVSI dp actions cells = S - dpValue dp actions := by
-    unfold expectedVSI; dsimp only [valueSampleInfo]; simp_rw [mul_sub]
+  have hRHS : expectedValueSampleInfo dp actions cells = S - dp.value actions := by
+    unfold expectedValueSampleInfo; dsimp only [valueSampleInfo]; simp_rw [mul_sub]
     rw [Finset.sum_sub_distrib]
-    congr 1; rw [← optimalAction_eu_eq_dpValue dp actions]
+    congr 1; rw [← optimalAction_expectedUtility_eq_value dp actions]
     generalize optimalAction dp actions = oa
     cases oa with
     | none => simp
@@ -273,7 +329,7 @@ has lower Bayes risk in every decision problem — is
 expected value of the corresponding deterministic experiment.
 
 The mathematical core is the **unnormalized cell value** `maxₐ ∑_{w∈c} P(w)·U(w,a)`,
-which equals `P(c)·V(D|c)` (`cellProb_mul_valueAfterLearning_eq_uValue`) and is
+which equals `P(c)·V(D|c)` (`cellProbability_mul_condValue_eq_uValue`) and is
 **superadditive** under splitting a cell into disjoint pieces
 (`uValue_union_le`): the max of a sum is at most the sum of the maxes. Summed over a
 partition, this gives `questionUtility (finer) ≥ questionUtility (coarser)`. -/
@@ -283,8 +339,8 @@ section Refinement
 /-- The **unnormalized cell value** of `cell`: the best, over actions, of the
 *unnormalized* expected utility `∑_{w∈cell} P(w)·U(w,a)`. This linearizes the
 probability-weighted conditional value `P(cell)·V(D|cell)` (see
-`cellProb_mul_valueAfterLearning_eq_uValue`), turning Van Rooy's question utility into
-a sum that splitting a cell can only increase. -/
+`cellProbability_mul_condValue_eq_uValue`), turning Van Rooy's question utility
+into a sum that splitting a cell can only increase. -/
 private def uValue (dp : DecisionProblem K W A) (acts : Finset A) (cell : Finset W) : K :=
   if h : acts.Nonempty then
     acts.sup' h (λ a => ∑ w ∈ cell, dp.prior w * dp.utility w a)
@@ -292,45 +348,33 @@ private def uValue (dp : DecisionProblem K W A) (acts : Finset A) (cell : Finset
 
 /-- `P(cell)·V(D|cell) = maxₐ ∑_{w∈cell} P(w)·U(w,a)`: the probability-weighted
 conditional value equals the unnormalized cell value. The normalizing `1/P(cell)` in
-`conditionalEU` cancels against the `P(cell)` weight; when `P(cell) = 0`, a nonnegative
-prior forces every `P(w) = 0` on the cell, so both sides vanish. -/
-private lemma cellProb_mul_valueAfterLearning_eq_uValue (dp : DecisionProblem K W A)
+`condExpectedUtility` cancels against the `P(cell)` weight; when `P(cell) = 0`, a
+nonnegative prior forces every `P(w) = 0` on the cell, so both sides vanish. -/
+private lemma cellProbability_mul_condValue_eq_uValue (dp : DecisionProblem K W A)
     (acts : Finset A) (cell : Finset W) (hprior : ∀ w, 0 ≤ dp.prior w) :
-    cellProbability dp cell * valueAfterLearning dp acts cell = uValue dp acts cell := by
-  unfold uValue valueAfterLearning
+    dp.cellProbability cell * dp.condValue acts cell = uValue dp acts cell := by
+  unfold uValue
   by_cases hne : acts.Nonempty
-  · rw [dif_pos hne, dif_pos hne]
-    have htp_nonneg : 0 ≤ cellProbability dp cell :=
+  · rw [condValue_of_nonempty hne, dif_pos hne]
+    have htp_nonneg : 0 ≤ dp.cellProbability cell :=
       Finset.sum_nonneg (λ w _ => hprior w)
-    by_cases htp : cellProbability dp cell = 0
+    by_cases htp : dp.cellProbability cell = 0
     · rw [htp, zero_mul]
       have hpw : ∀ w ∈ cell, dp.prior w = 0 :=
         (Finset.sum_eq_zero_iff_of_nonneg (λ w _ => hprior w)).mp htp
       have hz : ∀ a ∈ acts, (∑ w ∈ cell, dp.prior w * dp.utility w a) = 0 := by
         intro a _; exact Finset.sum_eq_zero (λ w hw => by rw [hpw w hw, zero_mul])
       rw [Finset.sup'_congr hne rfl hz, Finset.sup'_const]
-    · rw [Finset.mul₀_sup' htp_nonneg (conditionalEU dp cell) acts hne]
+    · have hS : cell.sum dp.prior ≠ 0 := htp
+      rw [Finset.mul₀_sup' htp_nonneg (dp.condExpectedUtility cell) acts hne]
       refine Finset.sup'_congr hne rfl (λ a _ => ?_)
-      have htp' : cell.sum dp.prior ≠ 0 := htp
-      have hcEU : conditionalEU dp cell a
-          = cell.sum (λ w => dp.prior w / cell.sum dp.prior * dp.utility w a) := by
-        show (if cell.sum dp.prior = 0 then (0 : K) else
-              cell.sum (λ w => dp.prior w / cell.sum dp.prior * dp.utility w a)) = _
-        rw [if_neg htp']
-      show cell.sum dp.prior * conditionalEU dp cell a
+      show cell.sum dp.prior * dp.condExpectedUtility cell a
           = ∑ w ∈ cell, dp.prior w * dp.utility w a
-      rw [hcEU, Finset.mul_sum]
+      rw [condExpectedUtility_of_ne_zero hS, Finset.mul_sum]
       refine Finset.sum_congr rfl (λ w _ => ?_)
-      rw [div_mul_eq_mul_div, ← mul_div_assoc, mul_div_cancel_left₀ _ htp']
-  · rw [dif_neg hne, dif_neg hne, mul_zero]
-
-omit [IsStrictOrderedRing K] in
-private lemma uValue_empty (dp : DecisionProblem K W A) (acts : Finset A) :
-    uValue dp acts ∅ = 0 := by
-  unfold uValue
-  by_cases h : acts.Nonempty
-  · rw [dif_pos h]; simp only [Finset.sum_empty, Finset.sup'_const]
-  · rw [dif_neg h]
+      rw [div_mul_eq_mul_div, ← mul_div_assoc, mul_div_cancel_left₀ _ hS]
+  · rw [Finset.not_nonempty_iff_eq_empty.mp hne, condValue_empty, dif_neg
+      Finset.not_nonempty_empty, mul_zero]
 
 variable [DecidableEq W]
 
@@ -352,17 +396,18 @@ private lemma uValue_union_le (dp : DecisionProblem K W A) (acts : Finset A)
 
 /-- **Splitting a cell never decreases its decision value**: for disjoint cells `c₁`, `c₂`
 and a nonnegative prior,
-`P(c₁)·V(D|c₁) + P(c₂)·V(D|c₂) ≥ P(c₁ ∪ c₂)·V(D|c₁ ∪ c₂)`.
+`P(c₁ ∪ c₂)·V(D|c₁ ∪ c₂) ≤ P(c₁)·V(D|c₁) + P(c₂)·V(D|c₂)`.
 This is [blackwell-1953]'s data-processing inequality for a single binary refinement, the
 building block of [van-rooy-2003]'s §4.1 question-utility monotonicity (p. 743). -/
-theorem cellProb_valueAfterLearning_split_ge (dp : DecisionProblem K W A) (acts : Finset A)
-    {c₁ c₂ : Finset W} (hdisj : Disjoint c₁ c₂) (hprior : ∀ w, 0 ≤ dp.prior w) :
-    cellProbability dp (c₁ ∪ c₂) * valueAfterLearning dp acts (c₁ ∪ c₂) ≤
-    cellProbability dp c₁ * valueAfterLearning dp acts c₁ +
-    cellProbability dp c₂ * valueAfterLearning dp acts c₂ := by
-  rw [cellProb_mul_valueAfterLearning_eq_uValue dp acts _ hprior,
-    cellProb_mul_valueAfterLearning_eq_uValue dp acts _ hprior,
-    cellProb_mul_valueAfterLearning_eq_uValue dp acts _ hprior]
+theorem cellProbability_mul_condValue_union_le (dp : DecisionProblem K W A)
+    (acts : Finset A) {c₁ c₂ : Finset W} (hdisj : Disjoint c₁ c₂)
+    (hprior : ∀ w, 0 ≤ dp.prior w) :
+    dp.cellProbability (c₁ ∪ c₂) * dp.condValue acts (c₁ ∪ c₂) ≤
+    dp.cellProbability c₁ * dp.condValue acts c₁ +
+    dp.cellProbability c₂ * dp.condValue acts c₂ := by
+  rw [cellProbability_mul_condValue_eq_uValue dp acts _ hprior,
+    cellProbability_mul_condValue_eq_uValue dp acts _ hprior,
+    cellProbability_mul_condValue_eq_uValue dp acts _ hprior]
   exact uValue_union_le dp acts hdisj
 
 /-- **Question utility rises under refinement (binary split)** — the `⟹` ("only if")
@@ -371,20 +416,20 @@ cell `c₁ ∪ c₂` of a question into the two disjoint cells `c₁`, `c₂` ca
 expected utility value `EUV`. This is the finite-partition instance of [blackwell-1953]'s
 data-processing inequality; any finite refinement of one partition by another is a
 composition of such binary splits, so iterating gives the full §4.1 monotonicity. -/
-theorem questionUtility_split_ge [Fintype W] (dp : DecisionProblem K W A) (acts : Finset A)
-    {c₁ c₂ : Finset W} (rest : Finset (Finset W))
+theorem questionUtility_split_ge [Fintype W] (dp : DecisionProblem K W A)
+    (acts : Finset A) {c₁ c₂ : Finset W} (rest : Finset (Finset W))
     (hdisj : Disjoint c₁ c₂) (hprior : ∀ w, 0 ≤ dp.prior w)
     (hc₁ : c₁ ∉ rest) (hc₂ : c₂ ∉ rest) (hne12 : c₁ ≠ c₂) (hcrest : c₁ ∪ c₂ ∉ rest) :
     questionUtility dp acts (insert (c₁ ∪ c₂) rest) ≤
     questionUtility dp acts (insert c₁ (insert c₂ rest)) := by
   have hc₁' : c₁ ∉ insert c₂ rest := by
     simp only [Finset.mem_insert, not_or]; exact ⟨hne12, hc₁⟩
-  have hcp : cellProbability dp (c₁ ∪ c₂)
-      = cellProbability dp c₁ + cellProbability dp c₂ := Finset.sum_union hdisj
-  have hcpd : cellProbability dp (c₁ ∪ c₂) * dpValue dp acts
-      = cellProbability dp c₁ * dpValue dp acts
-        + cellProbability dp c₂ * dpValue dp acts := by rw [hcp]; ring
-  have hsplit := cellProb_valueAfterLearning_split_ge dp acts hdisj hprior
+  have hcp : dp.cellProbability (c₁ ∪ c₂)
+      = dp.cellProbability c₁ + dp.cellProbability c₂ := Finset.sum_union hdisj
+  have hcpd : dp.cellProbability (c₁ ∪ c₂) * dp.value acts
+      = dp.cellProbability c₁ * dp.value acts
+        + dp.cellProbability c₂ * dp.value acts := by rw [hcp]; ring
+  have hsplit := cellProbability_mul_condValue_union_le dp acts hdisj hprior
   unfold questionUtility
   rw [Finset.sum_insert hcrest, Finset.sum_insert hc₁', Finset.sum_insert hc₂]
   simp only [utilityValue, mul_sub]
@@ -396,6 +441,14 @@ The binary `questionUtility_split_ge` lifts to an arbitrary refinement of one pa
 another, via general superadditivity of `uValue` and a fiberwise regrouping. The refinement
 is presented by a map `assign` sending each finer cell to the coarser cell containing it,
 with each coarser cell the union (`Finset.sup`) of its fiber. -/
+
+omit [DecidableEq W] [IsStrictOrderedRing K] in
+private lemma uValue_empty (dp : DecisionProblem K W A) (acts : Finset A) :
+    uValue dp acts ∅ = 0 := by
+  unfold uValue
+  by_cases h : acts.Nonempty
+  · rw [dif_pos h]; simp only [Finset.sum_empty, Finset.sup'_const]
+  · rw [dif_neg h]
 
 /-- **General superadditivity of `uValue`**: splitting a union of pairwise-disjoint cells
 into its pieces never lowers the best-action value, `uValue (⨆ parts) ≤ ∑ uValue`. The
@@ -423,10 +476,10 @@ private lemma uValue_sup_le (dp : DecisionProblem K W A) (acts : Finset A) :
 
 omit [LinearOrder K] [IsStrictOrderedRing K] in
 /-- Cell probability is additive over a union of pairwise-disjoint cells. -/
-private lemma cellProb_sup (dp : DecisionProblem K W A) :
+private lemma cellProbability_sup (dp : DecisionProblem K W A) :
     ∀ {parts : Finset (Finset W)},
       (∀ p₁ ∈ parts, ∀ p₂ ∈ parts, p₁ ≠ p₂ → Disjoint p₁ p₂) →
-      cellProbability dp (parts.sup id) = ∑ p ∈ parts, cellProbability dp p := by
+      dp.cellProbability (parts.sup id) = ∑ p ∈ parts, dp.cellProbability p := by
   intro parts
   induction parts using Finset.induction with
   | empty => intro _; simp [cellProbability, Finset.sup_empty, Finset.bot_eq_empty]
@@ -446,16 +499,16 @@ omit [DecidableEq W] in
 /-- `questionUtility` in linearized form: total best-action value minus the baseline value
 weighted by total cell mass. Lets refinement monotonicity reduce to `∑ uValue` superadditivity
 once total mass is shown invariant. -/
-private lemma questionUtility_eq [Fintype W] (dp : DecisionProblem K W A) (acts : Finset A)
-    (cells : Finset (Finset W)) (hprior : ∀ w, 0 ≤ dp.prior w) :
+private lemma questionUtility_eq [Fintype W] (dp : DecisionProblem K W A)
+    (acts : Finset A) (cells : Finset (Finset W)) (hprior : ∀ w, 0 ≤ dp.prior w) :
     questionUtility dp acts cells
       = (∑ c ∈ cells, uValue dp acts c)
-        - dpValue dp acts * (∑ c ∈ cells, cellProbability dp c) := by
+        - dp.value acts * (∑ c ∈ cells, dp.cellProbability c) := by
   unfold questionUtility
   rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
   refine Finset.sum_congr rfl (λ c _ => ?_)
   unfold utilityValue
-  rw [mul_sub, cellProb_mul_valueAfterLearning_eq_uValue dp acts c hprior]
+  rw [mul_sub, cellProbability_mul_condValue_eq_uValue dp acts c hprior]
   ring
 
 /-- **Question utility is monotone under partition refinement** — the `⟹` direction of
@@ -474,11 +527,12 @@ theorem questionUtility_mono_of_refines [Fintype W] (dp : DecisionProblem K W A)
       ∀ f₂ ∈ fine.filter (λ f => assign f = c), f₁ ≠ f₂ → Disjoint f₁ f₂ :=
     λ c _ f₁ hf₁ f₂ hf₂ hne =>
       hdisj f₁ (Finset.mem_of_mem_filter _ hf₁) f₂ (Finset.mem_of_mem_filter _ hf₂) hne
-  have hcell : ∑ c ∈ coarse, cellProbability dp c = ∑ f ∈ fine, cellProbability dp f := by
-    rw [← Finset.sum_fiberwise_of_maps_to hmaps (λ f => cellProbability dp f)]
+  have hcell : ∑ c ∈ coarse, dp.cellProbability c
+      = ∑ f ∈ fine, dp.cellProbability f := by
+    rw [← Finset.sum_fiberwise_of_maps_to hmaps (λ f => dp.cellProbability f)]
     refine Finset.sum_congr rfl (λ c hc => ?_)
-    rw [← cellProb_sup dp (hfdisj c hc)]
-    exact congrArg (cellProbability dp) (hcover c hc)
+    rw [← cellProbability_sup dp (hfdisj c hc)]
+    exact congrArg dp.cellProbability (hcover c hc)
   have huv : ∑ c ∈ coarse, uValue dp acts c ≤ ∑ f ∈ fine, uValue dp acts f := by
     calc ∑ c ∈ coarse, uValue dp acts c
         = ∑ c ∈ coarse, uValue dp acts ((fine.filter (λ f => assign f = c)).sup id) :=
@@ -487,7 +541,8 @@ theorem questionUtility_mono_of_refines [Fintype W] (dp : DecisionProblem K W A)
           Finset.sum_le_sum (λ c hc => uValue_sup_le dp acts (hfdisj c hc))
       _ = ∑ f ∈ fine, uValue dp acts f :=
           Finset.sum_fiberwise_of_maps_to hmaps (λ f => uValue dp acts f)
-  rw [questionUtility_eq dp acts coarse hprior, questionUtility_eq dp acts fine hprior, hcell]
+  rw [questionUtility_eq dp acts coarse hprior, questionUtility_eq dp acts fine hprior,
+    hcell]
   linarith [huv]
 
 end Refinement
@@ -501,10 +556,10 @@ section MaximinMono
 
 omit [IsStrictOrderedRing K] in
 /-- The security level is at most the utility of any world in the set. -/
-theorem securityLevel_le_utility (dp : DecisionProblem K W A) (worlds : Finset W) (a : A)
-    {w : W} (hw : w ∈ worlds) :
-    securityLevel dp worlds a ≤ dp.utility w a := by
-  unfold securityLevel; rw [dif_pos ⟨w, hw⟩]
+theorem securityLevel_le_utility (dp : DecisionProblem K W A) (worlds : Finset W)
+    (a : A) {w : W} (hw : w ∈ worlds) :
+    dp.securityLevel worlds a ≤ dp.utility w a := by
+  rw [securityLevel_of_nonempty ⟨w, hw⟩]
   exact Finset.inf'_le _ hw
 
 omit [IsStrictOrderedRing K] in
@@ -512,20 +567,19 @@ omit [IsStrictOrderedRing K] in
     at least the min over more. -/
 theorem securityLevel_anti (dp : DecisionProblem K W A) {S₁ S₂ : Finset W} (a : A)
     (hne : S₁.Nonempty) (hsub : S₁ ⊆ S₂) :
-    securityLevel dp S₂ a ≤ securityLevel dp S₁ a := by
-  unfold securityLevel; rw [dif_pos hne, dif_pos (hne.mono hsub)]
+    dp.securityLevel S₂ a ≤ dp.securityLevel S₁ a := by
+  rw [securityLevel_of_nonempty hne, securityLevel_of_nonempty (hne.mono hsub)]
   exact Finset.inf'_mono _ hsub hne
 
 omit [IsStrictOrderedRing K] in
 /-- The maximin value is antitone in the world set. -/
 theorem maximinValue_anti (dp : DecisionProblem K W A) {S₁ S₂ : Finset W}
     (actions : Finset A) (hne : S₁.Nonempty) (hsub : S₁ ⊆ S₂) :
-    maximinValue dp S₂ actions ≤ maximinValue dp S₁ actions := by
-  unfold maximinValue
+    dp.maximinValue S₂ actions ≤ dp.maximinValue S₁ actions := by
   by_cases ha : actions.Nonempty
-  · rw [dif_pos ha, dif_pos ha]
+  · rw [maximinValue_of_nonempty ha, maximinValue_of_nonempty ha]
     exact Finset.sup'_mono_fun λ a _ => securityLevel_anti dp a hne hsub
-  · rw [dif_neg ha, dif_neg ha]
+  · rw [Finset.not_nonempty_iff_eq_empty.mp ha, maximinValue_empty, maximinValue_empty]
 
 variable [DecidableEq W]
 
@@ -534,9 +588,9 @@ variable [DecidableEq W]
 theorem maximinUtilityValue_anti (dp : DecisionProblem K W A) (worlds : Finset W)
     (actions : Finset A) {c₁ c₂ : Finset W} (hsub : c₁ ⊆ c₂)
     (hne : (worlds ∩ c₁).Nonempty) :
-    maximinUtilityValue dp worlds actions c₂ ≤
-      maximinUtilityValue dp worlds actions c₁ := by
-  unfold maximinUtilityValue maximinAfterLearning
+    dp.maximinUtilityValue worlds actions c₂ ≤
+      dp.maximinUtilityValue worlds actions c₁ := by
+  unfold maximinUtilityValue condMaximinValue
   have hsub' : worlds ∩ c₁ ⊆ worlds ∩ c₂ := Finset.inter_subset_inter_left hsub
   linarith [maximinValue_anti dp actions hne hsub']
 
@@ -544,8 +598,8 @@ theorem maximinUtilityValue_anti (dp : DecisionProblem K W A) (worlds : Finset W
     over `worlds ∩ c ⊆ worlds` considers fewer worst cases. -/
 theorem maximinUtilityValue_nonneg (dp : DecisionProblem K W A) (worlds : Finset W)
     (actions : Finset A) (c : Finset W) (hne : (worlds ∩ c).Nonempty) :
-    0 ≤ maximinUtilityValue dp worlds actions c := by
-  unfold maximinUtilityValue maximinAfterLearning
+    0 ≤ dp.maximinUtilityValue worlds actions c := by
+  unfold maximinUtilityValue condMaximinValue
   linarith [maximinValue_anti dp actions hne Finset.inter_subset_left]
 
 end MaximinMono
@@ -578,11 +632,11 @@ private lemma foldl_min_le_of_mem (f : α → K) (xs : List α) (init : K)
 
 omit [IsStrictOrderedRing K] in
 /-- The question maximin value is at most the MUV of each cell in the question. -/
-theorem questionMaximin_le_muv [DecidableEq W] (dp : DecisionProblem K W A)
-    (worlds : Finset W) (actions : Finset A) (q : List (Finset W)) {cell : Finset W}
-    (hcell : cell ∈ q) :
+theorem questionMaximin_le_maximinUtilityValue [DecidableEq W]
+    (dp : DecisionProblem K W A) (worlds : Finset W) (actions : Finset A)
+    (q : List (Finset W)) {cell : Finset W} (hcell : cell ∈ q) :
     questionMaximin dp worlds actions q ≤
-      maximinUtilityValue dp worlds actions cell := by
+      dp.maximinUtilityValue worlds actions cell := by
   cases q with
   | nil => exact absurd hcell List.not_mem_nil
   | cons c cs =>
@@ -596,17 +650,17 @@ end FoldlMin
 /-! ### Special decision problems -/
 
 /-- An epistemic DP where the agent wants to know the exact world state. -/
-def epistemicDP [DecidableEq W] (target : W) : DecisionProblem K W A where
+def epistemic [DecidableEq W] (target : W) : DecisionProblem K W A where
   utility w _ := if w = target then 1 else 0
   prior _ := 1
 
 /-- A complete-information DP where only exact-state knowledge is useful. -/
-def completeInformationDP [DecidableEq W] : DecisionProblem K W W where
+def completeInformation [DecidableEq W] : DecisionProblem K W W where
   utility w a := if a = w then 1 else 0
   prior _ := 1
 
 /-- A mention-some DP: any satisfier resolves the problem. -/
-def mentionSomeDP (satisfies : W → Prop) [DecidablePred satisfies] :
+def mentionSome (satisfies : W → Prop) [DecidablePred satisfies] :
     DecisionProblem K W Bool where
   utility w a := if a ∧ satisfies w then 1 else 0
   prior _ := 1
@@ -625,10 +679,10 @@ variable [Fintype W] [DecidableEq W]
 omit [LinearOrder K] [IsStrictOrderedRing K] in
 /-- Cell probabilities of a binary partition `{P, ¬P}` sum to `1` when the
     prior is a proper distribution. -/
-theorem binary_cellProb_sum (dp : DecisionProblem K W A) (P : W → Prop) [DecidablePred P]
-    (hPrior : Finset.univ.sum dp.prior = 1) :
-    cellProbability dp (Finset.univ.filter P) +
-      cellProbability dp (Finset.univ.filter (¬ P ·)) = 1 := by
+theorem cellProbability_filter_add_filter_not (dp : DecisionProblem K W A)
+    (P : W → Prop) [DecidablePred P] (hPrior : Finset.univ.sum dp.prior = 1) :
+    dp.cellProbability (Finset.univ.filter P) +
+      dp.cellProbability (Finset.univ.filter (¬ P ·)) = 1 := by
   unfold cellProbability
   rw [← Finset.sum_union (Finset.disjoint_filter_filter_not _ _ P),
     Finset.filter_union_filter_not_eq P Finset.univ, hPrior]
@@ -638,18 +692,18 @@ theorem binary_cellProb_sum (dp : DecisionProblem K W A) (P : W → Prop) [Decid
         `∑ P(cell) · V(D|cell) = EUV({P, ¬P}, D) + V(D)`
 
     where the LHS is the probability-weighted sum of conditional DP values,
-    `EUV` is `questionUtility`, and `V(D)` is `dpValue`. -/
+    `EUV` is `questionUtility`, and `V(D)` is `value`. -/
 theorem binary_question_value_decomposition (dp : DecisionProblem K W A)
     (actions : Finset A) (P : W → Prop) [DecidablePred P]
     (hPrior : Finset.univ.sum dp.prior = 1) :
-    cellProbability dp (Finset.univ.filter P) *
-        valueAfterLearning dp actions (Finset.univ.filter P) +
-      cellProbability dp (Finset.univ.filter (¬ P ·)) *
-        valueAfterLearning dp actions (Finset.univ.filter (¬ P ·)) =
+    dp.cellProbability (Finset.univ.filter P) *
+        dp.condValue actions (Finset.univ.filter P) +
+      dp.cellProbability (Finset.univ.filter (¬ P ·)) *
+        dp.condValue actions (Finset.univ.filter (¬ P ·)) =
     questionUtility dp actions
         {Finset.univ.filter P, Finset.univ.filter (¬ P ·)} +
-      dpValue dp actions := by
-  have hSum := binary_cellProb_sum dp P hPrior
+      dp.value actions := by
+  have hSum := cellProbability_filter_add_filter_not dp P hPrior
   have ⟨w₀⟩ : Nonempty W := by
     by_contra h; rw [not_nonempty_iff] at h; simp [Finset.univ_eq_empty] at hPrior
   have hne : Finset.univ.filter P ≠ Finset.univ.filter (¬ P ·) := by
@@ -660,10 +714,12 @@ theorem binary_question_value_decomposition (dp : DecisionProblem K W A)
     · have : w₀ ∈ Finset.univ.filter (¬ P ·) := by simp [hp]
       rw [← heq] at this; simp [hp] at this
   simp only [questionUtility, utilityValue, Finset.sum_pair hne]
-  linarith [show cellProbability dp (Finset.univ.filter P) * dpValue dp actions +
-      cellProbability dp (Finset.univ.filter (¬ P ·)) * dpValue dp actions
-      = dpValue dp actions from by rw [← add_mul, hSum, one_mul]]
+  linarith [show dp.cellProbability (Finset.univ.filter P) * dp.value actions +
+      dp.cellProbability (Finset.univ.filter (¬ P ·)) * dp.value actions
+      = dp.value actions from by rw [← add_mul, hSum, one_mul]]
 
 end BinaryQuestion
+
+end DecisionProblem
 
 end Core.DecisionTheory

--- a/Linglib/Core/Probability/Decision/Blackwell.lean
+++ b/Linglib/Core/Probability/Decision/Blackwell.lean
@@ -467,7 +467,7 @@ partition of `Θ` into the fibers of `f`, viewed as an error-free observation. C
 partition (post-composing the classifier) is a deterministic garbling, so a finer partition
 Blackwell-dominates every coarsening. This is the kernel-level form of the fact that
 partition-refinement monotonicity of question value ([van-rooy-2003] §4.1, formalized
-ℚ-valued as `Core.DecisionTheory.questionUtility_mono_of_refines`) is a special case of
+ℚ-valued as `Core.DecisionTheory.DecisionProblem.questionUtility_mono_of_refines`) is a special case of
 [blackwell-1953]. -/
 
 /-- A coarsened classifier is a garbling of the classifier it factors through: the

--- a/Linglib/Core/Probability/Decision/ExperimentDesign.lean
+++ b/Linglib/Core/Probability/Decision/ExperimentDesign.lean
@@ -41,7 +41,7 @@ The kernel-level Blackwell order behind both lives in
 | `ObservationModel`           | `Question W` (partition cells)         |
 | `marginalObs`                | `cellProbability`                      |
 | `posterior`                  | conditioning on cell membership        |
-| `dpValueR`                   | `valueAfterLearning` / `dpValue`       |
+| `dpValueR`                   | `condValue` / `DecisionProblem.value`       |
 | `eig`                        | `questionUtility` (EUV)                |
 | `optimalExperiment`          | (no softmax wrapper in DecisionTheory) |
 
@@ -101,7 +101,7 @@ noncomputable def optimalExperiment [Fintype E] (om : ObservationModel W E O)
     is the EU of the optimal action under those beliefs,
     `V(post) = maxₐ ∑_w post(w) · U(w,a)` (`0` if `actions` is empty).
 
-    The exact ℝ analog of `DecisionTheory.dpValue` — same `Finset.sup'` shape,
+    The exact ℝ analog of `DecisionTheory.DecisionProblem.value` — same `Finset.sup'` shape,
     so the deterministic-observation bridge (`eig_deterministicObs_eq_euv`)
     matches definitionally cell by cell. -/
 noncomputable def dpValueR {A : Type*} (utility : W → A → ℝ)
@@ -190,7 +190,7 @@ private lemma marginalObs_mul_dpValueR {A : Type*} [DecidableEq O] [DecidableEq 
 classifier `classify : W → O` whose fibers are all nonempty, the expected information
 gain of the (single) deterministic experiment under the decision-theoretic value
 function equals [van-rooy-2003]'s expected utility value of the corresponding
-partition question — `Core.DecisionTheory.questionUtility`, cast from ℚ to ℝ.
+partition question — `Core.DecisionTheory.DecisionProblem.questionUtility`, cast from ℚ to ℝ.
 
 The fiber-nonemptiness hypothesis keeps the `Finset.image` indexing faithful: empty
 fibers would collapse in the cell set while still contributing (zero) terms to the
@@ -202,7 +202,7 @@ theorem eig_deterministicObs_eq_euv {A : Type*} [DecidableEq O] [DecidableEq W]
     (hfib : ∀ o : O, (Finset.univ.filter (fun w => classify w = o)).Nonempty) :
     eig (deterministicObs classify) (fun w => (dp.prior w : ℝ))
         (dpValueR (fun w a => (dp.utility w a : ℝ)) acts) () =
-    (DecisionTheory.questionUtility dp acts
+    (DecisionTheory.DecisionProblem.questionUtility dp acts
       (Finset.univ.image (fun o : O =>
         Finset.univ.filter (fun w => classify w = o))) : ℚ) := by
   set fiberMap : O → Finset W := fun o => Finset.univ.filter (fun w => classify w = o)
@@ -215,17 +215,17 @@ theorem eig_deterministicObs_eq_euv {A : Type*} [DecidableEq O] [DecidableEq W]
     have hw₂ : w ∈ fiberMap o₂ := heq ▸ hw
     exact hw₁.symm.trans (Finset.mem_filter.mp hw₂).2
   -- Fiber probabilities sum to the total prior mass = 1.
-  have hcellSum : ∑ o : O, DecisionTheory.cellProbability dp (fiberMap o) = 1 := by
-    simp only [DecisionTheory.cellProbability, hfiberMap]
+  have hcellSum : ∑ o : O, DecisionTheory.DecisionProblem.cellProbability dp (fiberMap o) = 1 := by
+    simp only [DecisionTheory.DecisionProblem.cellProbability, hfiberMap]
     rw [Finset.sum_fiberwise_of_maps_to (fun w _ => Finset.mem_univ (classify w))]
     exact hsum
   -- Per-cell decision-theoretic identity (private lemma from Basic re-derived inline):
   -- P(cell) · V(D|cell) = sup'_a ∑_{w∈cell} P(w) · U(w,a).
   have hcell_val : ∀ cell : Finset W,
-      DecisionTheory.cellProbability dp cell * DecisionTheory.valueAfterLearning dp acts cell
+      DecisionTheory.DecisionProblem.cellProbability dp cell * DecisionTheory.DecisionProblem.condValue dp acts cell
         = acts.sup' hacts (fun a => ∑ w ∈ cell, dp.prior w * dp.utility w a) := by
     intro cell
-    unfold DecisionTheory.cellProbability DecisionTheory.valueAfterLearning
+    unfold DecisionTheory.DecisionProblem.cellProbability DecisionTheory.DecisionProblem.condValue
     rw [dif_pos hacts]
     have htp_nonneg : 0 ≤ cell.sum dp.prior :=
       Finset.sum_nonneg (fun w _ => hprior w)
@@ -238,23 +238,23 @@ theorem eig_deterministicObs_eq_euv {A : Type*} [DecidableEq O] [DecidableEq W]
       exact Finset.sum_eq_zero (fun w hw => by rw [hpw w hw, zero_mul])
     · rw [Finset.mul₀_sup' htp_nonneg _ acts hacts]
       refine Finset.sup'_congr hacts rfl (fun a _ => ?_)
-      have hcEU : DecisionTheory.conditionalEU dp cell a
+      have hcEU : DecisionTheory.DecisionProblem.condExpectedUtility dp cell a
           = cell.sum (fun w => dp.prior w / cell.sum dp.prior * dp.utility w a) := by
         show (if cell.sum dp.prior = 0 then (0 : ℚ) else _) = _
         rw [if_neg htp]
       rw [hcEU, Finset.mul_sum]
       refine Finset.sum_congr rfl (fun w _ => ?_)
       rw [div_mul_eq_mul_div, ← mul_div_assoc, mul_div_cancel_left₀ _ htp]
-  -- `dpValueR` on the ℝ-cast prior equals the cast of `dpValue`.
+  -- `dpValueR` on the ℝ-cast prior equals the cast of `DecisionProblem.value`.
   have hdpvR : dpValueR (fun w a => (dp.utility w a : ℝ)) acts (fun w => (dp.prior w : ℝ))
-      = ((DecisionTheory.dpValue dp acts : ℚ) : ℝ) := by
-    simp only [dpValueR, DecisionTheory.dpValue, dif_pos hacts]
+      = ((DecisionTheory.DecisionProblem.value dp acts : ℚ) : ℝ) := by
+    simp only [dpValueR, DecisionTheory.DecisionProblem.value, dif_pos hacts]
     rw [show acts.sup' hacts (fun a => ∑ w : W, (dp.prior w : ℝ) * (dp.utility w a : ℝ))
          = acts.sup' hacts
-             (fun a => ((DecisionTheory.expectedUtility dp a : ℚ) : ℝ)) from ?_]
+             (fun a => ((DecisionTheory.DecisionProblem.expectedUtility dp a : ℚ) : ℝ)) from ?_]
     · exact (Finset.apply_sup'_eq_sup'_comp hacts _ (fun x y => Rat.cast_max x y)).symm
     · refine Finset.sup'_congr hacts rfl (fun a _ => ?_)
-      simp only [DecisionTheory.expectedUtility]; push_cast; rfl
+      simp only [DecisionTheory.DecisionProblem.expectedUtility]; push_cast; rfl
   -- Assemble.
   unfold eig
   rw [hdpvR]
@@ -270,13 +270,13 @@ theorem eig_deterministicObs_eq_euv {A : Type*} [DecidableEq O] [DecidableEq W]
   rw [← Rat.cast_sum, ← Rat.cast_sub]
   -- Cast down: prove the ℚ identity.
   congr 1
-  unfold DecisionTheory.questionUtility
+  unfold DecisionTheory.DecisionProblem.questionUtility
   rw [Finset.sum_image hinj]
-  simp only [DecisionTheory.utilityValue]
+  simp only [DecisionTheory.DecisionProblem.utilityValue]
   simp_rw [mul_sub]
   rw [Finset.sum_sub_distrib]
-  rw [show (∑ o : O, DecisionTheory.cellProbability dp (fiberMap o) *
-        DecisionTheory.valueAfterLearning dp acts (fiberMap o))
+  rw [show (∑ o : O, DecisionTheory.DecisionProblem.cellProbability dp (fiberMap o) *
+        DecisionTheory.DecisionProblem.condValue dp acts (fiberMap o))
         = ∑ o : O, acts.sup' hacts (fun a =>
             ∑ w ∈ fiberMap o, dp.prior w * dp.utility w a) from
       Finset.sum_congr rfl (fun o _ => hcell_val (fiberMap o))]

--- a/Linglib/Pragmatics/DecisionTheoretic/MerinBridge.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/MerinBridge.lean
@@ -47,7 +47,7 @@ Note: UV(E) for a **single cell** E can be negative even when BF > 1
 
 namespace DTS.MerinBridge
 
-open Core.DecisionTheory
+open Core.DecisionTheory Core.DecisionTheory.DecisionProblem
 open DTS
 
 /-! ## Encoding Merin's Question as a Decision Problem
@@ -94,7 +94,7 @@ preferred. A Prop-level reformulation needs decidability for
 arbitrary `e : World4 → Prop`, which constrains the form of any
 finite enumeration argument. The intended proof: posRelevant means
 P(E∧H)·P(¬H) > P(E∧¬H)·P(H), which under uniform prior reduces to
-|E∩H|·|¬H| > |E∩¬H|·|H|; conditionalEU(accept|E) = |E∩H|/|E| while
+|E∩H|·|¬H| > |E∩¬H|·|H|; condExpectedUtility(accept|E) = |E∩H|/|E| while
 expectedUtility(accept) = |H|/|W|, so the shift inequality reduces
 to the same cell-count comparison. -/
 theorem posRelevant_shifts_accept_eu :
@@ -105,7 +105,7 @@ theorem posRelevant_shifts_accept_eu :
     (∃ w, w ∈ ctx.topic) →
     (∃ w, w ∉ ctx.topic) →
     posRelevant ctx e →
-    conditionalEU (truthDP ctx)
+    condExpectedUtility (truthDP ctx)
       (Finset.univ.filter (fun w => w ∈ e)) true >
     expectedUtility (truthDP ctx) true := by
   sorry
@@ -118,8 +118,8 @@ change any conditional EU, so UV(E) = 0.
 
 The key step: BF = 1 under uniform prior means P(E|H) = P(E|¬H),
 which gives |E∩H|/|H| = |E∩¬H|/|¬H|, hence |E∩H|/|E| = |H|/4.
-So conditionalEU(a|E) = expectedUtility(a) for each action a,
-making valueAfterLearning = dpValue.
+So condExpectedUtility(a|E) = expectedUtility(a) for each action a,
+making condValue = DecisionProblem.value.
 
 TODO: Original Bool-based proof used `decide` over the 256-cell
 finite verification. A kernel-checkable structural proof requires

--- a/Linglib/Pragmatics/DecisionTheoretic/PartitionAdjunction.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/PartitionAdjunction.lean
@@ -40,7 +40,7 @@ only trivially dominable DPs.
 
 -/
 
-open Core.DecisionTheory
+open Core.DecisionTheory Core.DecisionTheory.DecisionProblem
 open Core.Categorical
 
 namespace DTS.PartitionAdjunction

--- a/Linglib/Pragmatics/SoftmaxOptimality.lean
+++ b/Linglib/Pragmatics/SoftmaxOptimality.lean
@@ -54,9 +54,9 @@ theorem expectedUtilityR_nonneg {W A : Type*} [Fintype W]
 /-- ℚ-ordering of EU is preserved under the cast to ℝ. -/
 theorem expectedUtilityR_mono {W A : Type*} [Fintype W] [DecidableEq W]
     (dp : DecisionTheory.DecisionProblem ℚ W A) (a₁ a₂ : A)
-    (h : DecisionTheory.expectedUtility dp a₁ ≤ DecisionTheory.expectedUtility dp a₂) :
+    (h : DecisionTheory.DecisionProblem.expectedUtility dp a₁ ≤ DecisionTheory.DecisionProblem.expectedUtility dp a₂) :
     expectedUtilityR dp a₁ ≤ expectedUtilityR dp a₂ := by
-  simp only [expectedUtilityR, DecisionTheory.expectedUtility] at *
+  simp only [expectedUtilityR, DecisionTheory.DecisionProblem.expectedUtility] at *
   exact_mod_cast h
 
 /-- Softmax agent from a decision problem: score(a) = exp(α · EU(a)).

--- a/Linglib/Semantics/Attitudes/Desire.lean
+++ b/Linglib/Semantics/Attitudes/Desire.lean
@@ -1027,7 +1027,7 @@ def wantWithSloman [Fintype W]
 /-! ### §3. Bridge to `Core.Agent.DecisionTheory`
 
 `Lassiter.expectedValue` is the proposition-conditional analog of
-`Core.Agent.DecisionTheory.conditionalEU`. Wrapping the value function
+`Core.Agent.DecisionTheory.DecisionProblem.condExpectedUtility`. Wrapping the value function
 as a unit-action utility makes the bridge explicit. -/
 
 /-- Wrap a Lassiter `(prior, value)` pair as a unit-action

--- a/Linglib/Studies/HoulihanEtAl2023.lean
+++ b/Linglib/Studies/HoulihanEtAl2023.lean
@@ -378,7 +378,7 @@ namespace for dot notation. -/
 
 namespace Pragmatics.GameTheory.SymmetricGame
 
-open Core.DecisionTheory
+open Core.DecisionTheory Core.DecisionTheory.DecisionProblem
 
 /-- A symmetric game with beliefs about the opponent's action yields
 a material-payoff decision problem.

--- a/Linglib/Studies/Merin1999.lean
+++ b/Linglib/Studies/Merin1999.lean
@@ -42,7 +42,7 @@ Merin, not proved there).
 
 namespace Merin1999
 
-open QUD Core.DecisionTheory
+open QUD Core.DecisionTheory Core.DecisionTheory.DecisionProblem
 
 /-! ### FACT 1: complement families -/
 
@@ -210,16 +210,16 @@ conditional EU by the cell's probability
 def partitionEU [Fintype M] [DecidableEq M]
     (dp : DecisionProblem ℚ M A) (q : QUD M) (a : A) : ℚ :=
   (q.toCellsFinset Finset.univ).sum (fun cell =>
-    cell.sum dp.prior * conditionalEU dp cell a)
+    cell.sum dp.prior * condExpectedUtility dp cell a)
 
 /-- Cell probability times conditional EU is the raw weighted sum, for
 non-negative priors. -/
 private theorem cellProb_mul_conditionalEU [DecidableEq M]
     (dp : DecisionProblem ℚ M A) (cell : Finset M) (a : A)
     (hprior : ∀ w, dp.prior w ≥ 0) :
-    cell.sum dp.prior * conditionalEU dp cell a =
+    cell.sum dp.prior * condExpectedUtility dp cell a =
     cell.sum (fun w => dp.prior w * dp.utility w a) := by
-  simp only [conditionalEU]
+  simp only [condExpectedUtility]
   by_cases htot : cell.sum dp.prior = 0
   · simp only [htot, ite_true, mul_zero]
     symm; apply Finset.sum_eq_zero; intro w hw
@@ -265,7 +265,7 @@ theorem partitionEU_coarsening_regroup [Fintype M] [DecidableEq M]
     partitionEU dp q' a =
       (q'.toCellsFinset Finset.univ).sum (fun c' =>
         ((q.toCellsFinset Finset.univ).filter (· ⊆ c')).sum (fun c =>
-          c.sum dp.prior * conditionalEU dp c a)) := by
+          c.sum dp.prior * condExpectedUtility dp c a)) := by
   unfold partitionEU
   refine Finset.sum_congr rfl (fun c' hc' => ?_)
   rw [cellProb_mul_conditionalEU dp c' a hprior]

--- a/Linglib/Studies/TsvilodubEtAl2026.lean
+++ b/Linglib/Studies/TsvilodubEtAl2026.lean
@@ -60,7 +60,7 @@ set_option autoImplicit false
 namespace TsvilodubEtAl2026
 
 open scoped ENNReal NNReal
-open Core.DecisionTheory
+open Core.DecisionTheory Core.DecisionTheory.DecisionProblem
 
 /-! ### Expected value of perfect information
 
@@ -87,7 +87,7 @@ def oracleValue {W A : Type*} [Fintype W] (dp : DecisionProblem ℚ W A)
 
 /-- Expected value of perfect information (EVPI).
 
-    EVPI = oracleValue − dpValue
+    EVPI = oracleValue − DecisionProblem.value
          = Σ_w P(w) · max_a U(w,a) − max_a Σ_w P(w) · U(w,a)
 
     Equivalently, the expected regret of the current best action.
@@ -95,7 +95,7 @@ def oracleValue {W A : Type*} [Fintype W] (dp : DecisionProblem ℚ W A)
     [raiffa-schlaifer-1961] -/
 def evpi {W A : Type*} [Fintype W] [DecidableEq W]
     (dp : DecisionProblem ℚ W A) (actions : Finset A) : ℚ :=
-  oracleValue dp actions - dpValue dp actions
+  oracleValue dp actions - DecisionProblem.value dp actions
 
 /-- EVPI is non-negative: acting with perfect information is at least
     as good as acting without.
@@ -104,15 +104,15 @@ def evpi {W A : Type*} [Fintype W] [DecidableEq W]
     `Σ_w P(w) · U(w,a)`. The oracle value `Σ_w P(w) · max_a' U(w,a')`
     is pointwise ≥ `Σ_w P(w) · U(w,a)` since `max_a' U(w,a') ≥ U(w,a)`.
     Therefore `oracleValue ≥ EU(a)` for every `a`, hence
-    `oracleValue ≥ max_a EU(a) = dpValue`. -/
+    `oracleValue ≥ max_a EU(a) = DecisionProblem.value`. -/
 theorem evpi_nonneg {W A : Type*} [Fintype W] [DecidableEq W]
     (dp : DecisionProblem ℚ W A) (actions : Finset A)
     (hprior : ∀ w, 0 ≤ dp.prior w) (hne : actions.Nonempty) :
     0 ≤ evpi dp actions := by
   unfold evpi
-  suffices h : dpValue dp actions ≤ oracleValue dp actions by linarith
-  -- dpValue = sup' of expectedUtility; show each EU(a) ≤ oracleValue
-  unfold dpValue oracleValue
+  suffices h : DecisionProblem.value dp actions ≤ oracleValue dp actions by linarith
+  -- DecisionProblem.value = sup' of expectedUtility; show each EU(a) ≤ oracleValue
+  unfold DecisionProblem.value oracleValue
   rw [dif_pos hne]
   apply Finset.sup'_le
   intro a ha
@@ -226,8 +226,8 @@ private theorem oracleValue_eq_one {ε δ : ℚ} (hδ0 : 0 ≤ δ) :
   ring
 
 private theorem dpValue_eq {ε δ : ℚ} (hε : ε ≤ 1/2) :
-    dpValue (dp ε δ) Finset.univ = 1 - min ε δ := by
-  rw [dpValue, dif_pos Finset.univ_nonempty]
+    DecisionProblem.value (dp ε δ) Finset.univ = 1 - min ε δ := by
+  rw [DecisionProblem.value, dif_pos Finset.univ_nonempty]
   refine le_antisymm (Finset.sup'_le _ _ fun r _ => ?_) ?_
   · have h₁ := min_le_left ε δ
     have h₂ := min_le_right ε δ

--- a/Linglib/Studies/VanRooy2003.lean
+++ b/Linglib/Studies/VanRooy2003.lean
@@ -21,22 +21,22 @@ notation maps to the substrate as:
 
 | [van-rooy-2003]                             | substrate                                  |
 |--------------------------------------------------|--------------------------------------------|
-| `EU(a) = ∑_w P(w) · U(a, w)` (p. 733)            | `Core.DecisionTheory.expectedUtility`      |
-| `UV(Choose now) = max_a EU(a)` (p. 734)          | `Core.DecisionTheory.dpValue`              |
-| `EU(a, C) = ∑_w P_C(w) · U(a, w)` (p. 735)       | `Core.DecisionTheory.conditionalEU`        |
-| `UV(Learn C, choose later) = max_a EU(a, C)`     | `Core.DecisionTheory.valueAfterLearning`   |
-| `UV(C) = UV(L C, c later) − UV(C now)` (p. 735)  | `Core.DecisionTheory.utilityValue`         |
-| `UV*(C) = VSI(C)` ≥ 0 (p. 735)                   | `Core.DecisionTheory.valueSampleInfo`      |
-| `EUV(Q) = ∑_q P(q) · UV(q)` (p. 742)             | `Core.DecisionTheory.questionUtility`      |
+| `EU(a) = ∑_w P(w) · U(a, w)` (p. 733)            | `Core.DecisionTheory.DecisionProblem.expectedUtility`      |
+| `UV(Choose now) = max_a EU(a)` (p. 734)          | `Core.DecisionTheory.DecisionProblem.value`              |
+| `EU(a, C) = ∑_w P_C(w) · U(a, w)` (p. 735)       | `Core.DecisionTheory.DecisionProblem.condExpectedUtility`        |
+| `UV(Learn C, choose later) = max_a EU(a, C)`     | `Core.DecisionTheory.DecisionProblem.condValue`   |
+| `UV(C) = UV(L C, c later) − UV(C now)` (p. 735)  | `Core.DecisionTheory.DecisionProblem.utilityValue`         |
+| `UV*(C) = VSI(C)` ≥ 0 (p. 735)                   | `Core.DecisionTheory.DecisionProblem.valueSampleInfo`      |
+| `EUV(Q) = ∑_q P(q) · UV(q)` (p. 742)             | `Core.DecisionTheory.DecisionProblem.questionUtility`      |
 | `Q ⊑ Q'`  (every Q-alt ⊆ some Q'-alt) (p. 741)   | `Question.Entails`                 |
-| `C resolves DP` (p. 736)                         | `Core.DecisionTheory.IsResolved`           |
+| `C resolves DP` (p. 736)                         | `Core.DecisionTheory.DecisionProblem.IsResolved`           |
 
 ## What this file proves
 
 * **§3.1 Action-induced partition `A*`** (p. 736-737):
   `optimalityCell dp acts a` and `actionPartition`.
 * **§3.1 *C* resolves DP** (p. 736): the substrate's
-  `Core.DecisionTheory.IsResolved dp acts C` — some action weakly
+  `Core.DecisionTheory.DecisionProblem.IsResolved dp acts C` — some action weakly
   dominates every other on every world in C.
 * **§3.1/§4.1 decision-relevance** (`IsDecisionRelevant`): the
   qualitative, prior-free core of van Rooy's relevance — a question is
@@ -50,7 +50,7 @@ notation maps to the substrate as:
   direction — a finer partition weakly dominates a coarser one for every decision
   problem — is the data-processing inequality `blackwell_euv_fact_forward`
   (deriving the substrate refinement map from `⊑` and applying
-  `Core.DecisionTheory.questionUtility_mono_of_refines`). The `⟸` direction is the
+  `Core.DecisionTheory.DecisionProblem.questionUtility_mono_of_refines`). The `⟸` direction is the
   [blackwell-1953] *converse*, `ProbabilityTheory.isGarblingOf_of_blackwellDominates`
   (finite, kernel-level — now proved; the partition-cell bridge to `questionUtility`
   is the remaining Layer-2 work, so this direction is still `sorry`).
@@ -82,7 +82,7 @@ bar). The reusable substrate it relied on stays one layer down:
 
 namespace VanRooy2003
 
-open Core Core.DecisionTheory Question
+open Core Core.DecisionTheory Core.DecisionTheory.DecisionProblem Question
 
 variable {W A : Type*}
 
@@ -132,7 +132,7 @@ theorem optimalityCell_pairwise_disjoint
 > actions, i.e., if in each resulting world no action has a higher
 > utility than this one."
 
-This is exactly `Core.DecisionTheory.IsResolved dp acts C`. We do not
+This is exactly `Core.DecisionTheory.DecisionProblem.IsResolved dp acts C`. We do not
 introduce a paper-vocabulary alias — consumers should use the
 substrate predicate directly. -/
 
@@ -248,7 +248,7 @@ def CoversAltsOf (Q Q' : Question W) : Prop :=
     theorem (p. 743, "a special case of [blackwell-1953]") is the
     quantitative *iff* `Q.Entails Q' ↔ ∀ dp, EUV(Q) ≥ EUV(Q')`
     over the expected utility value `EUV` (= substrate `questionUtility`,
-    with `EUV = EVSI` available as `euv_eq_evsi`). The result here is a
+    with `EUV = EVSI` available as `questionUtility_eq_expectedValueSampleInfo`). The result here is a
     one-directional, prior-free Prop transfer over the *dual* condition
     `CoversAltsOf`: on a general inquisitive (non-partition) `Question W`,
     `Entails` (P-alts ⊆ Q-alts) does not transfer the qualitative
@@ -256,7 +256,7 @@ def CoversAltsOf (Q Q' : Question W) : Prop :=
     recovering [van-rooy-2003]'s partition-based argument.
 
     For the *quantitative* §4.1 Fact (p. 743), the EUV-monotonicity ("only if")
-    direction is now `Core.DecisionTheory.questionUtility_split_ge` (a finer
+    direction is now `Core.DecisionTheory.DecisionProblem.questionUtility_split_ge` (a finer
     partition has `EUV ≥` the coarser one, for every decision problem). The
     remaining gap to the full `Entails`-level *iff* is (i) a
     `Question W → Finset (Finset W)` finite-alternatives partition-cell adapter, and
@@ -278,7 +278,7 @@ theorem decisionRelevance_preserved_under_cover
 
 [van-rooy-2003] p. 743 states that `Q ⊑ Q' ↔ ∀ DP, EUV(Q) ≥ EUV(Q')` is "a special case
 of [blackwell-1953]". We state it over [groenendijk-stokhof-1984] partition cells — the
-`Finset (Finset W)` that `Core.DecisionTheory.questionUtility` consumes. There, van Rooy's
+`Finset (Finset W)` that `Core.DecisionTheory.DecisionProblem.questionUtility` consumes. There, van Rooy's
 `Q ⊑ Q'` (p. 741: "∀ q ∈ Q : ∃ q' ∈ Q' : q ⊆ q'") is the cell-level refinement
 `∀ f ∈ fine, ∃ c ∈ coarse, f ⊆ c`, and the value side ranges over every decision problem
 with a proper prior.
@@ -291,7 +291,7 @@ discharging `Entails` against this cell refinement.) -/
 is weakly better than a coarser one for *every* decision problem (the data-processing
 inequality). Van Rooy's refinement `fine ⊑ coarse` (each fine cell `⊆` some coarse cell,
 p. 741) plus the partition structure furnish the substrate refinement map — each fine cell's
-containing coarse cell — and `Core.DecisionTheory.questionUtility_mono_of_refines` concludes.
+containing coarse cell — and `Core.DecisionTheory.DecisionProblem.questionUtility_mono_of_refines` concludes.
 
 `hfine_cover` and the disjointness hypotheses encode that `fine`, `coarse` are genuine
 [groenendijk-stokhof-1984] partitions of the world set. -/


### PR DESCRIPTION
Follow-up to #1428: moves the Decision operations into the `DecisionProblem` namespace (dot notation throughout), spells out acronym names (`dpValue` → `value`, `conditionalEU` → `condExpectedUtility`, `valueAfterLearning` → `condValue`, `expectedVSI` → `expectedValueSampleInfo`, `euv_eq_evsi` → `questionUtility_eq_expectedValueSampleInfo`), and adds the `_of_nonempty`/`_empty` characterization-lemma layer (`@[simp]` on the unconditional cases) with proofs re-golfed onto it in place of `unfold` + `dif_pos` ceremony.