### PR TITLE
refactor(Semantics/Dynamic/DRS): spine ops, simp API, K&R attributions

### DIFF
--- a/Linglib/Core/Logic/CylindricAlgebra.lean
+++ b/Linglib/Core/Logic/CylindricAlgebra.lean
@@ -23,20 +23,19 @@ algebraic source.
 
 ## Connections across the library
 
-### Proved bridges (`Core/Logic/CylindricAlgebra/`)
+### Proved bridges
 
-The bridge modules in `Core/Logic/CylindricAlgebra/` prove algebraic identities
-(not analogies) between framework-specific operations and cylindric ops.
+Paper-anchored study files prove algebraic identities (not analogies) between
+framework-specific operations and cylindric ops.
 
 | Framework | Operation | = Cylindric | Bridge |
 |---|---|---|---|
-| CDRT ([muskens-1996]) | `closure (new n ;; φ)` | `cylindrify n (closure φ)` | `DynamicSemantics.lean` |
-| CDRT | `eq' (dref n) (dref m)` | `diagonal n m` | `DynamicSemantics.lean` |
-| Charlow ([charlow-2019]) | `staticExists x body` | `cylindrify x body` | `DynamicSemantics.lean` |
-| Charlow | `dynamicExists x body` | `cylindrify x body` | `DynamicSemantics.lean` |
-| Update/Accessibility | `closure (introReg n ;; D)` | `cylindrify n (closure D)` | `Accessibility.lean` |
-| DPL ([groenendijk-stokhof-1991]) | `closure (DPLRel.exists_ x φ)` | `cylindrify x (closure φ)` | `DynamicSemantics.lean` |
-| DPL | `closure (atom (g(x) = g(y)))` | `diagonal x y` | `DynamicSemantics.lean` |
+| CDRT ([muskens-1996]) | `closure (new n ;; φ)` | `cylindrify n (closure φ)` | `Studies/Muskens1996.lean` |
+| CDRT | `eq' (dref n) (dref m)` | `diagonal n m` | `Studies/Muskens1996.lean` |
+| Charlow ([charlow-2019]) | `staticExists x body` | `cylindrify x body` | `Studies/Charlow2019.lean` |
+| Charlow | `dynamicExists x body` | `cylindrify x body` | `Studies/Charlow2019.lean` |
+| DPL ([groenendijk-stokhof-1991]) | `closure (DPLRel.exists_ x φ)` | `cylindrify x (closure φ)` | `Studies/GroenendijkStokhof1991.lean` |
+| DPL | `closure (atom (g(x) = g(y)))` | `diagonal x y` | `Studies/GroenendijkStokhof1991.lean` |
 
 ### Unproved connections (same algebra, bridges not yet formalized)
 

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -9,9 +9,14 @@ Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
 
 * `DRS.map` / `Condition.map` — functorial renaming of discourse referents along
   `f : V → W`. When `f` is a bijection this is Kamp & Reyle's *alphabetic
-  variant* (Def. 1.4.7); `map_id` makes "renaming to the identity is the
-  identity" a free corollary.
+  variant* (the prose preceding Def. 1.4.8); `map_id` makes "renaming to the
+  identity is the identity" a free corollary.
 * `merge` algebra — identity (`empty`) and associativity.
+* `DRS.Bound` / `DRS.IsProper` — properness (no free discourse referent,
+  Def. 1.4.2–1.4.3).
+* `Condition.occ` / `DRS.occ` — occurring referents, as a decidable `Finset`.
+* `DRS.accessibleFrom` / `DRS.Accessible` — decidable, host-relative
+  accessibility (Def. 1.4.11).
 -/
 
 open FirstOrder
@@ -189,8 +194,10 @@ def Condition.accScopeL (s : Finset V) : List (Condition L V) → V → Option (
       | none => Condition.accScopeL s cs x
 end
 
-/-- The referents accessible from `u`'s introduction in `T` ([kamp-reyle-1993],
-Def. 1.4.11), as a decidable `Finset`; `∅` if `u` is not introduced in `T`. -/
+/-- The referents accessible from `u`'s introduction in `T`, as a decidable
+`Finset`; `∅` if `u` is not introduced in `T`. ([kamp-reyle-1993] Def. 1.4.11
+defines accessibility of a referent from a *condition*; this is the derived
+referent-to-referent relation of the surrounding prose.) -/
 def DRS.accessibleFrom (T : DRS L V) (u : V) : Finset V := (DRS.accScope ∅ T u).getD ∅
 
 /-- `v` is accessible from `u`'s position in `T`. Decidable (Finset membership). -/

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -14,8 +14,10 @@ A faithful Lean model of the canonical DRS data type, built on mathlib's
 A DRS is a pair `⟨referents, conditions⟩` (Def. 1.4.1): `referents` is the
 *universe* `U` — a finite set of discourse referents — and `conditions` a
 collection of DRS-conditions. Conditions are **atomic** (`rel`, `eq`) or
-**complex** (`neg`, `imp`, `dis`); sub-DRSs occur *only* inside complex
-conditions. Relation symbols come arity-indexed from a `FirstOrder.Language`.
+**complex**; sub-DRSs occur *only* inside complex conditions. Def. 1.4.1's only
+complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
+(conditionals and disjunction). Relation symbols come arity-indexed from a
+`FirstOrder.Language`.
 
 ## Main declarations
 
@@ -49,8 +51,9 @@ mutual
 set of discourse referents); `conditions` the DRS-conditions. -/
 inductive DRS (L : Language.{u, v}) (V : Type w) where
   | mk (referents : Finset V) (conditions : List (Condition L V))
-/-- A DRS-condition ([kamp-reyle-1993], Def. 1.4.1): atomic (`rel`, `eq`) or
-complex (`neg`, `imp`, `dis`). Sub-DRSs occur only inside complex conditions. -/
+/-- A DRS-condition ([kamp-reyle-1993]): atomic (`rel`, `eq`) or complex —
+`neg` per Def. 1.4.1, `imp`/`dis` per its Chapter 2 extension. Sub-DRSs occur
+only inside complex conditions. -/
 inductive Condition (L : Language.{u, v}) (V : Type w) where
   /-- Atomic condition: `n`-ary relation symbol `R` applied to referents `args`. -/
   | rel {n : ℕ} (R : L.Relations n) (args : Fin n → V)

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -1,8 +1,6 @@
 import Linglib.Semantics.Dynamic.DRS.Basic
 import Linglib.Semantics.Dynamic.DRS.Reduction
 import Linglib.Semantics.Dynamic.Update
-import Mathlib.Data.Fin.VecNotation
-import Mathlib.Tactic.FinCases
 
 /-!
 # Relational (dynamic) semantics of DRSs, and its equivalence with verifying embeddings
@@ -51,26 +49,6 @@ open Semantics.Dynamic.Core.DynProp (Update dneg dimpl ddisj closure dseq)
 namespace DRT
 
 universe u v w x
-
-/-! ### Reindexing concrete atomic arguments
-
-A concrete DRS atom `.rel R ![k₁, …]` interprets (via `holds`/`Realize`) to
-`RelMap R (fun i => v (![k₁, …] i))`. These `@[simp]` lemmas reindex that to
-`![v k₁, …]`, so truth-condition proofs over concrete DRSs work with the atom's
-assigned values directly. (No general mathlib form exists — Loogle finds only a
-buried `comp_fin3` in the elliptic-curve files.) -/
-section Reindex
-variable {α β : Type*}
-
-@[simp] theorem vecArg₁ (v : α → β) (k : α) : (fun i => v (![k] i)) = ![v k] := by
-  funext i; fin_cases i; rfl
-@[simp] theorem vecArg₂ (v : α → β) (j k : α) : (fun i => v (![j, k] i)) = ![v j, v k] := by
-  funext i; fin_cases i <;> rfl
-@[simp] theorem vecArg₃ (v : α → β) (j k l : α) :
-    (fun i => v (![j, k, l] i)) = ![v j, v k, v l] := by
-  funext i; fin_cases i <;> rfl
-
-end Reindex
 
 variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
 
@@ -152,8 +130,8 @@ theorem DRS.toRel_iff_realize (K : DRS L V) (a a' : V → M) :
 theorem Condition.holds_iff_realize (c : Condition L V) (a : V → M) :
     Condition.holds c a ↔ Condition.Realize a c := by
   match c with
-  | .rel R args => simp only [Condition.holds, Condition.Realize]
-  | .eq u v => simp only [Condition.holds, Condition.Realize]
+  | .rel R args => exact Iff.rfl
+  | .eq u v => exact Iff.rfl
   | .neg K =>
     simp only [Condition.holds_neg, Condition.Realize]
     exact not_congr (exists_congr (fun a' => DRS.toRel_iff_realize K a a'))
@@ -171,7 +149,7 @@ theorem Condition.holds_iff_realize (c : Condition L V) (a : V → M) :
 theorem Condition.holdsAll_iff_realizeAll (cs : List (Condition L V)) (a : V → M) :
     Condition.holdsAll cs a ↔ Condition.RealizeAll a cs := by
   match cs with
-  | [] => simp only [Condition.holdsAll, Condition.RealizeAll]
+  | [] => exact Iff.rfl
   | c :: cs =>
     simp only [Condition.holdsAll, Condition.RealizeAll]
     exact and_congr (Condition.holds_iff_realize c a) (Condition.holdsAll_iff_realizeAll cs a)
@@ -193,7 +171,6 @@ embedding's values at its occurring referents. Proved by surgery on the output
 witness, the load-bearing case being the `imp` clause of `Condition.holds_congr`. -/
 theorem DRS.trueRel_congr [DecidableEq V] (K : DRS L V) (a₁ a₂ : V → M)
     (h : Set.EqOn a₁ a₂ ↑(DRS.occ K)) : DRS.trueRel K a₁ ↔ DRS.trueRel K a₂ := by
-  classical
   match K with
   | .mk U conds =>
     simp only [DRS.trueRel_iff, DRS.toRel_mk]
@@ -201,22 +178,21 @@ theorem DRS.trueRel_congr [DecidableEq V] (K : DRS L V) (a₁ a₂ : V → M)
         (∃ a', (∀ x, x ∉ U → a' x = b₁ x) ∧ Condition.holdsAll conds a') →
         (∃ a', (∀ x, x ∉ U → a' x = b₂ x) ∧ Condition.holdsAll conds a') := by
       rintro b₁ b₂ hb ⟨a', hag, hh⟩
-      refine ⟨(↑(Condition.occL conds) : Set V).piecewise a' b₂, ?_, ?_⟩
+      refine ⟨(Condition.occL conds).piecewise a' b₂, ?_, ?_⟩
       · intro x hx
-        by_cases hxc : x ∈ (↑(Condition.occL conds) : Set V)
-        · rw [Set.piecewise_eq_of_mem _ _ _ hxc, hag x hx]
+        by_cases hxc : x ∈ Condition.occL conds
+        · rw [Finset.piecewise_eq_of_mem _ _ _ hxc, hag x hx]
           refine hb ?_
           simp only [DRS.occ, Finset.coe_union]
-          exact Or.inr hxc
-        · rw [Set.piecewise_eq_of_notMem _ _ _ hxc]
+          exact Or.inr (Finset.mem_coe.mpr hxc)
+        · rw [Finset.piecewise_eq_of_notMem _ _ _ hxc]
       · refine (Condition.holdsAll_congr conds _ a' ?_).mpr hh
         intro x hx
-        exact Set.piecewise_eq_of_mem _ _ _ hx
+        exact Finset.piecewise_eq_of_mem _ _ _ (Finset.mem_coe.mp hx)
     exact ⟨key a₁ a₂ h, key a₂ a₁ h.symm⟩
 /-- A condition's set denotation depends only on its occurring referents. -/
 theorem Condition.holds_congr [DecidableEq V] (c : Condition L V) (a₁ a₂ : V → M)
     (h : Set.EqOn a₁ a₂ ↑(Condition.occ c)) : Condition.holds c a₁ ↔ Condition.holds c a₂ := by
-  classical
   match c with
   | .rel R args =>
     simp only [Condition.holds]
@@ -241,25 +217,28 @@ theorem Condition.holds_congr [DecidableEq V] (c : Condition L V) (a₁ a₂ : V
       cases ante with
       | mk Ua condsa =>
         obtain ⟨hag, hh⟩ := ha'
-        have hset : (↑(DRS.occ (DRS.mk Ua condsa)) ∪ ↑(DRS.occ cons) : Set V) =
-            ↑(Condition.occ (Condition.imp (DRS.mk Ua condsa) cons)) := by
-          simp [Condition.occ, Finset.coe_union]
+        have hset : DRS.occ (DRS.mk Ua condsa) ∪ DRS.occ cons =
+            Condition.occ (Condition.imp (DRS.mk Ua condsa) cons) := by
+          simp [Condition.occ]
         have hagree : Set.EqOn
-            ((↑(DRS.occ (DRS.mk Ua condsa)) ∪ ↑(DRS.occ cons) : Set V).piecewise a' b₁) a'
+            ((DRS.occ (DRS.mk Ua condsa) ∪ DRS.occ cons).piecewise a' b₁) a'
             ↑(DRS.occ cons) := by
-          intro x hx; exact Set.piecewise_eq_of_mem _ _ _ (Or.inr hx)
+          intro x hx
+          exact Finset.piecewise_eq_of_mem _ _ _
+            (Finset.mem_union_right _ (Finset.mem_coe.mp hx))
         have hr₁ : DRS.toRel (DRS.mk Ua condsa) b₁
-            ((↑(DRS.occ (DRS.mk Ua condsa)) ∪ ↑(DRS.occ cons) : Set V).piecewise a' b₁) := by
+            ((DRS.occ (DRS.mk Ua condsa) ∪ DRS.occ cons).piecewise a' b₁) := by
           refine ⟨?_, ?_⟩
           · intro x hx
-            by_cases hxS : x ∈ (↑(DRS.occ (DRS.mk Ua condsa)) ∪ ↑(DRS.occ cons) : Set V)
-            · rw [Set.piecewise_eq_of_mem _ _ _ hxS, hag x hx]
-              exact (hb (hset ▸ hxS)).symm
-            · rw [Set.piecewise_eq_of_notMem _ _ _ hxS]
+            by_cases hxS : x ∈ DRS.occ (DRS.mk Ua condsa) ∪ DRS.occ cons
+            · rw [Finset.piecewise_eq_of_mem _ _ _ hxS, hag x hx]
+              exact (hb (Finset.mem_coe.mpr (hset ▸ hxS))).symm
+            · rw [Finset.piecewise_eq_of_notMem _ _ _ hxS]
           · refine (Condition.holdsAll_congr condsa _ a' ?_).mpr hh
             intro x hx
-            refine Set.piecewise_eq_of_mem _ _ _ (Or.inl ?_)
-            simp only [DRS.occ, Finset.coe_union]; exact Or.inr hx
+            refine Finset.piecewise_eq_of_mem _ _ _ (Finset.mem_union_left _ ?_)
+            simp only [DRS.occ]
+            exact Finset.mem_union_right _ (Finset.mem_coe.mp hx)
         obtain ⟨a₄, ha₄⟩ := hL _ hr₁
         have hcc := DRS.trueRel_congr cons _ a' hagree
         simp only [DRS.trueRel_iff] at hcc
@@ -280,9 +259,9 @@ theorem Condition.holdsAll_congr [DecidableEq V] (cs : List (Condition L V)) (a�
     (h : Set.EqOn a₁ a₂ ↑(Condition.occL cs)) :
     Condition.holdsAll cs a₁ ↔ Condition.holdsAll cs a₂ := by
   match cs with
-  | [] => simp only [Condition.holdsAll]
+  | [] => exact Iff.rfl
   | c :: cs =>
-    simp only [Condition.holdsAll]
+    simp only [Condition.holdsAll_cons]
     have hsub : ↑(Condition.occ c) ⊆ ↑(Condition.occL (c :: cs)) :=
       Finset.coe_subset.mpr Finset.subset_union_left
     have hsubr : ↑(Condition.occL cs) ⊆ ↑(Condition.occL (c :: cs)) :=
@@ -294,7 +273,7 @@ end
 /-! ### The merging lemma: sequencing is merge, under freshness -/
 
 /-- The conjunction of conditions distributes over list append. -/
-theorem Condition.holdsAll_append (cs ds : List (Condition L V)) (a : V → M) :
+@[simp] theorem Condition.holdsAll_append (cs ds : List (Condition L V)) (a : V → M) :
     Condition.holdsAll (cs ++ ds) a ↔ Condition.holdsAll cs a ∧ Condition.holdsAll ds a := by
   induction cs with
   | nil => simp [Condition.holdsAll]
@@ -307,7 +286,6 @@ This is what gives `merge` its dynamic meaning. -/
 theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
     (hfresh : ∀ x ∈ K₂.referents, x ∉ Condition.occL K₁.conditions) :
     (DRS.toRel (K₁.merge K₂) : Update (V → M)) = DRS.toRel K₁ ⨟ DRS.toRel K₂ := by
-  classical
   obtain ⟨U₁, conds₁⟩ := K₁
   obtain ⟨U₂, conds₂⟩ := K₂
   simp only [DRS.referents_mk, DRS.conditions_mk] at hfresh
@@ -317,20 +295,20 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
     Condition.holdsAll_append, dseq, Relation.Comp]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩
-    refine ⟨(↑U₂ : Set V).piecewise a a', ⟨?_, ?_⟩, ?_, ?_⟩
+    refine ⟨U₂.piecewise a a', ⟨?_, ?_⟩, ?_, ?_⟩
     · intro x hx
-      by_cases hxU2 : x ∈ (↑U₂ : Set V)
-      · rw [Set.piecewise_eq_of_mem _ _ _ hxU2]
-      · rw [Set.piecewise_eq_of_notMem _ _ _ hxU2]
+      by_cases hxU2 : x ∈ U₂
+      · rw [Finset.piecewise_eq_of_mem _ _ _ hxU2]
+      · rw [Finset.piecewise_eq_of_notMem _ _ _ hxU2]
         refine hag x ?_
         rw [Finset.mem_union, not_or]
-        exact ⟨hx, fun h => hxU2 (Finset.mem_coe.mpr h)⟩
+        exact ⟨hx, hxU2⟩
     · refine (Condition.holdsAll_congr conds₁ _ a' ?_).mpr hh₁
       intro x hx
-      exact Set.piecewise_eq_of_notMem _ _ _
-        (fun h => hfresh x (Finset.mem_coe.mp h) (Finset.mem_coe.mp hx))
+      exact Finset.piecewise_eq_of_notMem _ _ _
+        (fun h => hfresh x h (Finset.mem_coe.mp hx))
     · intro x hx
-      exact (Set.piecewise_eq_of_notMem _ _ _ (fun h => hx (Finset.mem_coe.mp h))).symm
+      exact (Finset.piecewise_eq_of_notMem _ _ _ hx).symm
     · exact hh₂
   · rintro ⟨a'', ⟨hag1, hh1⟩, hag2, hh2⟩
     refine ⟨?_, ?_, hh2⟩

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Dynamic.DRS.Basic
 import Linglib.Semantics.Dynamic.DRS.Reduction
+import Linglib.Semantics.Dynamic.Update
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
 
@@ -37,10 +38,15 @@ identification:
 * `DRS.trueRel_congr` — the coincidence lemma: denotation depends only on the
   occurring referents (`DRS.occ`, from `DRS/Basic.lean`).
 * `DRS.toRel_merge` — the Merging Lemma: under freshness, `merge` denotes the
-  sequencing (relational composition) of the two box relations.
+  spine sequencing `⨟` (relational composition) of the two box relations.
+
+Naming: the dynamic face (`toRel`, `holds`, `trueRel`) follows the spine's
+lowerCamel operation names (`dneg`, `dseq`, `closure`); the static face
+(`DRS.Realize`, `DRS/Semantics.lean`) follows mathlib's `Formula.Realize`.
 -/
 
 open FirstOrder FirstOrder.Language
+open Semantics.Dynamic.Core.DynProp (Update dneg dimpl ddisj closure dseq)
 
 namespace DRT
 
@@ -74,17 +80,17 @@ mutual
 /-- The relational (dynamic) denotation of a DRS ([muskens-1996], SEM3): the
 input-output relation `⟨a, a'⟩` where `a'` differs from `a` at most on the
 universe and verifies every condition. -/
-def DRS.toRel : DRS L V → (V → M) → (V → M) → Prop
+def DRS.toRel : DRS L V → Update (V → M)
   | .mk U conds => fun a a' => (∀ x, x ∉ U → a' x = a x) ∧ Condition.holdsAll conds a'
 /-- The set denotation of a condition ([muskens-1996], SEM1/2): the set of
-embeddings at which it holds. Complex conditions reference the box relation
-`DRS.toRel` of their sub-DRSs. -/
+embeddings at which it holds. Complex conditions apply the spine connectives
+`dneg`/`dimpl`/`ddisj` to the box relations of their sub-DRSs. -/
 def Condition.holds : Condition L V → (V → M) → Prop
   | .rel R args => fun a => Structure.RelMap R (fun i => a (args i))
   | .eq u v => fun a => a u = a v
-  | .neg K => fun a => ¬ ∃ a', DRS.toRel K a a'
-  | .imp ante cons => fun a => ∀ a', DRS.toRel ante a a' → ∃ a'', DRS.toRel cons a' a''
-  | .dis l r => fun a => ∃ a', DRS.toRel l a a' ∨ DRS.toRel r a a'
+  | .neg K => dneg (DRS.toRel K)
+  | .imp ante cons => dimpl (DRS.toRel ante) (DRS.toRel cons)
+  | .dis l r => ddisj (DRS.toRel l) (DRS.toRel r)
 /-- Every condition in the list holds at `a`. A `List` helper — the higher-order
 form fails the nested-inductive structural-recursion checker. -/
 def Condition.holdsAll : List (Condition L V) → (V → M) → Prop
@@ -93,8 +99,41 @@ def Condition.holdsAll : List (Condition L V) → (V → M) → Prop
 end
 
 /-- A DRS is *true* under an input embedding `a` iff some output embedding is
-related to it ([muskens-1996], p. 148). -/
-def DRS.trueRel (K : DRS L V) (a : V → M) : Prop := ∃ a', DRS.toRel K a a'
+related to it ([muskens-1996], p. 148) — the spine's anaphoric `closure`. -/
+def DRS.trueRel (K : DRS L V) (a : V → M) : Prop := closure (DRS.toRel K) a
+
+/-! ### Structural simp API -/
+
+@[simp] theorem DRS.toRel_mk (U : Finset V) (conds : List (Condition L V)) (a a' : V → M) :
+    DRS.toRel (.mk U conds) a a' ↔
+      (∀ x, x ∉ U → a' x = a x) ∧ Condition.holdsAll conds a' := Iff.rfl
+
+@[simp] theorem Condition.holds_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) (a : V → M) :
+    (Condition.rel R args).holds a ↔ Structure.RelMap R (fun i => a (args i)) := Iff.rfl
+
+@[simp] theorem Condition.holds_eq (u v : V) (a : V → M) :
+    (Condition.eq u v : Condition L V).holds a ↔ a u = a v := Iff.rfl
+
+@[simp] theorem Condition.holds_neg (K : DRS L V) (a : V → M) :
+    (Condition.neg K).holds a ↔ ¬ ∃ a', DRS.toRel K a a' := Iff.rfl
+
+@[simp] theorem Condition.holds_imp (ante cons : DRS L V) (a : V → M) :
+    (Condition.imp ante cons).holds a ↔
+      ∀ a', DRS.toRel ante a a' → ∃ a'', DRS.toRel cons a' a'' := Iff.rfl
+
+@[simp] theorem Condition.holds_dis (l r : DRS L V) (a : V → M) :
+    (Condition.dis l r).holds a ↔ ∃ a', DRS.toRel l a a' ∨ DRS.toRel r a a' := Iff.rfl
+
+@[simp] theorem Condition.holdsAll_nil (a : V → M) :
+    Condition.holdsAll ([] : List (Condition L V)) a := trivial
+
+@[simp] theorem Condition.holdsAll_cons (c : Condition L V) (cs : List (Condition L V))
+    (a : V → M) :
+    Condition.holdsAll (c :: cs) a ↔ Condition.holds c a ∧ Condition.holdsAll cs a := Iff.rfl
+
+/-- `trueRel` unfolded: some output embedding is related to the input. -/
+theorem DRS.trueRel_iff (K : DRS L V) (a : V → M) :
+    DRS.trueRel K a ↔ ∃ a', DRS.toRel K a a' := Iff.rfl
 
 /-! ### Equivalence with the verifying-embedding semantics -/
 
@@ -116,16 +155,16 @@ theorem Condition.holds_iff_realize (c : Condition L V) (a : V → M) :
   | .rel R args => simp only [Condition.holds, Condition.Realize]
   | .eq u v => simp only [Condition.holds, Condition.Realize]
   | .neg K =>
-    simp only [Condition.holds, Condition.Realize]
+    simp only [Condition.holds_neg, Condition.Realize]
     exact not_congr (exists_congr (fun a' => DRS.toRel_iff_realize K a a'))
   | .imp ante cons =>
-    simp only [Condition.holds, Condition.Realize]
+    simp only [Condition.holds_imp, Condition.Realize]
     refine forall_congr' (fun a' => ?_)
     rw [DRS.toRel_iff_realize ante a a', and_imp]
     refine imp_congr_right (fun _ => imp_congr_right (fun _ => ?_))
     exact exists_congr (fun a'' => DRS.toRel_iff_realize cons a' a'')
   | .dis l r =>
-    simp only [Condition.holds, Condition.Realize, exists_or]
+    simp only [Condition.holds_dis, Condition.Realize, exists_or]
     exact or_congr (exists_congr (fun a' => DRS.toRel_iff_realize l a a'))
       (exists_congr (fun a' => DRS.toRel_iff_realize r a a'))
 /-- The list analogue of `Condition.holds_iff_realize`. -/
@@ -143,7 +182,7 @@ end
 `Realize`/`toFormula`/`toRel` triangle. -/
 theorem DRS.trueRel_iff_realize_toFormula [DecidableEq V] (K : DRS L V) (a : V → M) :
     DRS.trueRel K a ↔ (K.toFormula).Realize a := by
-  rw [DRS.trueRel, DRS.realize_toFormula K a]
+  rw [DRS.trueRel_iff, DRS.realize_toFormula K a]
   exact exists_congr (fun a' => DRS.toRel_iff_realize K a a')
 
 /-! ### The coincidence lemma -/
@@ -157,7 +196,7 @@ theorem DRS.trueRel_congr [DecidableEq V] (K : DRS L V) (a₁ a₂ : V → M)
   classical
   match K with
   | .mk U conds =>
-    simp only [DRS.trueRel, DRS.toRel]
+    simp only [DRS.trueRel_iff, DRS.toRel_mk]
     have key : ∀ (b₁ b₂ : V → M), Set.EqOn b₁ b₂ ↑(DRS.occ (DRS.mk U conds)) →
         (∃ a', (∀ x, x ∉ U → a' x = b₁ x) ∧ Condition.holdsAll conds a') →
         (∃ a', (∀ x, x ∉ U → a' x = b₂ x) ∧ Condition.holdsAll conds a') := by
@@ -189,12 +228,12 @@ theorem Condition.holds_congr [DecidableEq V] (c : Condition L V) (a₁ a₂ : V
     rw [h (show u ∈ ↑(Condition.occ (Condition.eq u v)) by simp [Condition.occ]),
       h (show v ∈ ↑(Condition.occ (Condition.eq u v)) by simp [Condition.occ])]
   | .neg K =>
-    simp only [Condition.holds]
+    simp only [Condition.holds_neg]
     have hk := DRS.trueRel_congr K a₁ a₂ h
-    simp only [DRS.trueRel] at hk
+    simp only [DRS.trueRel_iff] at hk
     rw [hk]
   | .imp ante cons =>
-    simp only [Condition.holds]
+    simp only [Condition.holds_imp]
     have hante : ∀ (b₁ b₂ : V → M), Set.EqOn b₁ b₂ ↑(Condition.occ (Condition.imp ante cons)) →
         (∀ a', DRS.toRel ante b₁ a' → ∃ a'', DRS.toRel cons a' a'') →
         (∀ a', DRS.toRel ante b₂ a' → ∃ a'', DRS.toRel cons a' a'') := by
@@ -223,18 +262,18 @@ theorem Condition.holds_congr [DecidableEq V] (c : Condition L V) (a₁ a₂ : V
             simp only [DRS.occ, Finset.coe_union]; exact Or.inr hx
         obtain ⟨a₄, ha₄⟩ := hL _ hr₁
         have hcc := DRS.trueRel_congr cons _ a' hagree
-        simp only [DRS.trueRel] at hcc
+        simp only [DRS.trueRel_iff] at hcc
         exact hcc.mp ⟨a₄, ha₄⟩
     exact ⟨hante a₁ a₂ h, hante a₂ a₁ h.symm⟩
   | .dis l r =>
-    simp only [Condition.holds, exists_or]
+    simp only [Condition.holds_dis, exists_or]
     have hsub : ↑(DRS.occ l) ⊆ ↑(Condition.occ (Condition.dis l r)) :=
       Finset.coe_subset.mpr Finset.subset_union_left
     have hsubr : ↑(DRS.occ r) ⊆ ↑(Condition.occ (Condition.dis l r)) :=
       Finset.coe_subset.mpr Finset.subset_union_right
     have hl := DRS.trueRel_congr l a₁ a₂ (h.mono hsub)
     have hr := DRS.trueRel_congr r a₁ a₂ (h.mono hsubr)
-    simp only [DRS.trueRel] at hl hr
+    simp only [DRS.trueRel_iff] at hl hr
     rw [hl, hr]
 /-- The list analogue of `Condition.holds_congr`. -/
 theorem Condition.holdsAll_congr [DecidableEq V] (cs : List (Condition L V)) (a₁ a₂ : V → M)
@@ -262,18 +301,20 @@ theorem Condition.holdsAll_append (cs ds : List (Condition L V)) (a : V → M) :
   | cons c cs ih => simp only [List.cons_append, Condition.holdsAll, ih, and_assoc]
 
 /-- **Merging Lemma** ([muskens-1996], §II.2): when `K₂`'s universe is fresh
-for `K₁`'s conditions, the relation denoted by the merge `K₁ ⊕ K₂` is the
-relational composition (sequencing `K₁ ; K₂`) of the two box relations —
-`‖K₁ ⊕ K₂‖ = ‖K₁‖ ∘ ‖K₂‖`. This is what gives `merge` its dynamic meaning. -/
+for `K₁`'s conditions, the merge `K₁ ⊕ K₂` denotes the spine sequencing
+(relational composition) of the two box relations — `‖K₁ ⊕ K₂‖ = ‖K₁‖ ⨟ ‖K₂‖`.
+This is what gives `merge` its dynamic meaning. -/
 theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
-    (hfresh : ∀ x ∈ K₂.referents, x ∉ Condition.occL K₁.conditions) (a a' : V → M) :
-    DRS.toRel (K₁.merge K₂) a a' ↔ ∃ a'', DRS.toRel K₁ a a'' ∧ DRS.toRel K₂ a'' a' := by
+    (hfresh : ∀ x ∈ K₂.referents, x ∉ Condition.occL K₁.conditions) :
+    (DRS.toRel (K₁.merge K₂) : Update (V → M)) = DRS.toRel K₁ ⨟ DRS.toRel K₂ := by
   classical
   obtain ⟨U₁, conds₁⟩ := K₁
   obtain ⟨U₂, conds₂⟩ := K₂
   simp only [DRS.referents_mk, DRS.conditions_mk] at hfresh
+  funext a a'
+  apply propext
   simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRel,
-    Condition.holdsAll_append]
+    Condition.holdsAll_append, dseq, Relation.Comp]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩
     refine ⟨(↑U₂ : Set V).piecewise a a', ⟨?_, ?_⟩, ?_, ?_⟩

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -8,14 +8,18 @@ import Mathlib.Tactic.FinCases
 [muskens-1996]
 
 Muskens's reformulation of DRT. Conditions denote *sets* of embeddings (SEM1/2);
-boxes denote *binary relations* between embeddings (SEM3, input → output); a box
-is true under an input embedding `a` iff some output `a'` is related to it
-(p. 148). This is the dynamic / CCP face of DRT, dual to the static
-verifying-embedding semantics `DRS.Realize` ([kamp-reyle-1993], Def. 1.4.4).
+boxes denote *binary relations* between embeddings (SEM3, input → output, the
+format of [groenendijk-stokhof-1991]); a box is true under an input embedding
+`a` iff some output `a'` is related to it (p. 148). This is the dynamic / CCP
+face of DRT, dual to the static verifying-embedding semantics `DRS.Realize` —
+the total-assignment rendering of [kamp-reyle-1993]'s verification (see the
+deviation note in `DRS/Semantics.lean`).
 
 The two semantics are *defined independently* and proved equivalent — Muskens's
-remark that the relational interpretation "is in fact equivalent" to Kamp &
-Reyle's. The equivalence is a theorem, not a definitional identification:
+remark that the relational interpretation "is in fact equivalent" to the
+verifying-embedding one (his fn. 4 scopes the remark: both sides here are the
+total-assignment variant). The equivalence is a theorem, not a definitional
+identification:
 
 * `DRS.toRel_iff_realize` — the relation `toRel K a a'` holds iff `a'` extends `a`
   over `K`'s universe and verifies `K` (the keystone bridge).
@@ -30,8 +34,8 @@ Reyle's. The equivalence is a theorem, not a definitional identification:
 * `DRS.trueRel` — relational truth: some output embedding is related to the input.
 * `DRS.toRel_iff_realize` / `Condition.holds_iff_realize` — equivalence with the
   static `DRS.Realize` semantics.
-* `DRS.occ` / `DRS.trueRel_congr` — occurring referents and the coincidence lemma
-  (denotation depends only on them).
+* `DRS.trueRel_congr` — the coincidence lemma: denotation depends only on the
+  occurring referents (`DRS.occ`, from `DRS/Basic.lean`).
 * `DRS.toRel_merge` — the Merging Lemma: under freshness, `merge` denotes the
   sequencing (relational composition) of the two box relations.
 -/
@@ -95,9 +99,10 @@ def DRS.trueRel (K : DRS L V) (a : V → M) : Prop := ∃ a', DRS.toRel K a a'
 /-! ### Equivalence with the verifying-embedding semantics -/
 
 mutual
-/-- **Muskens ≡ Kamp & Reyle** ([muskens-1996]): the relational denotation
+/-- **SEM3 ≡ verification semantics** ([muskens-1996]): the relational denotation
 agrees with the static verifying-embedding semantics — `toRel K a a'` holds iff
-the output `a'` extends the input `a` over `K`'s universe and verifies `K`. -/
+the output `a'` extends the input `a` over `K`'s universe and verifies `K`.
+(Both sides are the total-assignment variant; see `DRS/Semantics.lean`.) -/
 theorem DRS.toRel_iff_realize (K : DRS L V) (a a' : V → M) :
     DRS.toRel K a a' ↔ (∀ x, x ∉ K.referents → a' x = a x) ∧ DRS.Realize a' K := by
   match K with

--- a/Linglib/Semantics/Dynamic/DRS/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Semantics.lean
@@ -6,11 +6,18 @@ import Mathlib.ModelTheory.Semantics
 [kamp-reyle-1993]
 
 DRS truth via *verifying embeddings* into a mathlib `FirstOrder.Language.Structure`
-— exactly Kamp & Reyle's Def. 1.4.4–1.4.5. An embedding is an assignment
-`v : V → M` of discourse referents to the model domain; the discourse referents
-introduced by a sub-DRS are existentially (re)assigned when that sub-DRS is
-entered, which is what `(∀ x ∉ K.referents, v' x = v x)` expresses (`v'` extends
-`v` on `K`'s universe).
+— Kamp & Reyle's Def. 1.4.4–1.4.5 in the *total-assignment* rendering. An
+embedding is an assignment `v : V → M` of discourse referents to the model
+domain; the discourse referents introduced by a sub-DRS are existentially
+(re)assigned when that sub-DRS is entered, which is what
+`(∀ x ∉ K.referents, v' x = v x)` expresses (`v'` extends `v` on `K`'s universe).
+
+**Deviation** ([muskens-1996], fn. 4): K&R's embeddings are *partial* functions
+that sub-DRSs strictly *extend*, so a re-declared referent keeps its value; here
+embeddings are total and a re-declared referent is freely reassigned. The two
+agree on DRSs that declare each referent once — the construction algorithm never
+re-declares — but diverge on re-declaration: `[ | [x | man x] ⇒ [x | mortal x]]`
+says "every man is mortal" for K&R, "if there is a man there is a mortal" here.
 
 ## Main declarations
 
@@ -32,11 +39,13 @@ mutual
 holds under the assignment `v`. -/
 def DRS.Realize (v : V → M) : DRS L V → Prop
   | .mk _ conds => Condition.RealizeAll v conds
-/-- `v` verifies a condition (Def. 1.4.4(ii)). A sub-DRS `K` is entered by
-existentially (re)assigning the referents of its universe (`v'` agrees with `v`
-off `K.referents`). For `imp`, the consequent witness `v''` extends the
-*antecedent* assignment `v'` (not the host `v`): antecedent referents are visible
-in the consequent — the `⇒` accessibility asymmetry. -/
+/-- `v` verifies a condition — Def. 1.4.4(ii) for the atomic and `¬` clauses;
+the `⇒`/`∨` clauses are K&R's Chapter 2 conditional and disjunction semantics.
+A sub-DRS `K` is entered by existentially (re)assigning the referents of its
+universe (`v'` agrees with `v` off `K.referents`). For `imp`, the consequent
+witness `v''` extends the *antecedent* assignment `v'` (not the host `v`):
+antecedent referents are visible in the consequent — the `⇒` accessibility
+asymmetry. -/
 def Condition.Realize (v : V → M) : Condition L V → Prop
   | .rel R args => Structure.RelMap R (fun i => v (args i))
   | .eq a b => v a = v b

--- a/Linglib/Studies/KampReyle1993.lean
+++ b/Linglib/Studies/KampReyle1993.lean
@@ -16,10 +16,11 @@ not a local re-implementation.
 1. **Existential persistence**: "A man walked in. He sat down." The indefinite's
    discourse referent persists across sentences — `∃ e, man e ∧ walked-in e ∧
    sat-down e` (`persistence_tc`).
-2. **Donkey anaphora**: "If a farmer owns a donkey, he beats it." The implication
-   clause (K&R Def. 1.4.4) yields the **universal** reading — `∀ farmer-donkey
-   owning pairs, beats` (`donkey_universal_reading`). The antecedent's referents
-   are universally bound and remain accessible in the consequent.
+2. **Donkey anaphora**: "If a farmer owns a donkey, he beats it." The `⇒`
+   verification clause (K&R's Chapter 2 conditional semantics) yields the
+   **universal** reading — `∀ farmer-donkey owning pairs, beats`
+   (`donkey_universal_reading`). The antecedent's referents are universally
+   bound and remain accessible in the consequent.
 3. **Negation blocks anaphora**: "A man didn't walk in. *He…" — a referent
    introduced under negation is inaccessible (`negation_tc`).
 4. **Subordination/accessibility** (Def. 1.4.10/1.4.11): the antecedent and
@@ -88,10 +89,10 @@ def donkeyCons : DRS krLang ℕ := .mk ∅ [.rel .beats (![1, 2])]
 /-- "If a¹ farmer owns a² donkey, he₁ beats it₂." — `[ | donkeyAnte ⇒ donkeyCons]`. -/
 def donkey : DRS krLang ℕ := .mk ∅ [.imp donkeyAnte donkeyCons]
 
-/-- The donkey universal reading: the implication clause (K&R Def. 1.4.4) makes the
-antecedent's existentials universal — every owning farmer-donkey pair satisfies
-`beats`. The empty-universe consequent reuses the antecedent's values (the
-anaphora). -/
+/-- The donkey universal reading: the `⇒` verification clause (K&R's Chapter 2
+conditional semantics) makes the antecedent's existentials universal — every
+owning farmer-donkey pair satisfies `beats`. The empty-universe consequent
+reuses the antecedent's values (the anaphora). -/
 theorem donkey_universal_reading (a : ℕ → M) :
     DRS.trueRel donkey a ↔
     ∀ e₁ e₂ : M, (rm .farmer ![e₁] ∧ rm .donkey ![e₂] ∧ rm .owns ![e₁, e₂]) →

--- a/Linglib/Studies/KampReyle1993.lean
+++ b/Linglib/Studies/KampReyle1993.lean
@@ -1,6 +1,5 @@
 import Linglib.Semantics.Dynamic.DRS.Dynamics
 import Mathlib.Data.Fin.VecNotation
-import Mathlib.Tactic.FinCases
 
 /-!
 # Kamp & Reyle (1993): From Discourse to Logic
@@ -58,6 +57,22 @@ variable {M : Type*} [krLang.Structure M]
 `L`). Lets truth-conditions read as `rm .farmer ![e]`. -/
 abbrev rm {n} (R : krLang.Relations n) (x : Fin n → M) : Prop := Structure.RelMap R x
 
+/-- Reindex a composed vector argument componentwise: with `comp_vecEmpty`, folds
+`fun i => v (![k₁, …] i)` to `![v k₁, …]`, so truth-condition proofs work with the
+atoms' assigned values directly. Point-ful because `Condition.holds_rel` produces
+the eta-expanded form, which the point-free mathlib lemmas (`Fin.comp_cons`,
+`FinVec.map_eq`) do not match. -/
+private theorem comp_vecCons {α β : Type*} (v : α → β) (k : α) {n : ℕ} (t : Fin n → α) :
+    (fun i => v (Matrix.vecCons k t i)) = Matrix.vecCons (v k) (fun i => v (t i)) := by
+  funext i
+  cases i using Fin.cases <;> rfl
+
+/-- Base case of `comp_vecCons`. -/
+private theorem comp_vecEmpty {α β : Type*} (v : α → β) :
+    (fun i => v (Matrix.vecEmpty i)) = (![] : Fin 0 → β) := by
+  funext i
+  exact i.elim0
+
 /-! ### Existential persistence -/
 
 /-- "A¹ man walked in. He₁ sat down." — `[u₁ | man u₁, walked-in u₁, sat-down u₁]`. -/
@@ -69,7 +84,7 @@ that is a man, walked in, and sat down. -/
 theorem persistence_tc (a : ℕ → M) :
     DRS.trueRel persistence a ↔ ∃ e : M, rm .man ![e] ∧ rm .walkedIn ![e] ∧ rm .satDown ![e] := by
   simp only [DRS.trueRel_iff, persistence, DRS.toRel_mk, Condition.holdsAll_cons,
-    Condition.holdsAll_nil, Condition.holds_rel, vecArg₁, and_true]
+    Condition.holdsAll_nil, Condition.holds_rel, comp_vecCons, comp_vecEmpty, and_true]
   constructor
   · rintro ⟨a', _, hm, hw, hs⟩; exact ⟨a' 1, hm, hw, hs⟩
   · rintro ⟨e, hm, hw, hs⟩
@@ -99,7 +114,7 @@ theorem donkey_universal_reading (a : ℕ → M) :
       rm .beats ![e₁, e₂] := by
   simp only [DRS.trueRel_iff, donkey, donkeyAnte, donkeyCons, DRS.toRel_mk,
     Condition.holdsAll_cons, Condition.holdsAll_nil, Condition.holds_imp, Condition.holds_rel,
-    vecArg₁, vecArg₂, and_true]
+    comp_vecCons, comp_vecEmpty, and_true]
   constructor
   · rintro ⟨a', _, himp⟩ e₁ e₂ ⟨hf, hd, ho⟩
     set v' := Function.update (Function.update a' 1 e₁) 2 e₂ with hv'
@@ -125,7 +140,8 @@ is bound inside the negation and inaccessible to any continuation. -/
 theorem negation_tc (a : ℕ → M) :
     DRS.trueRel negation a ↔ ¬ ∃ e : M, rm .man ![e] ∧ rm .walkedIn ![e] := by
   simp only [DRS.trueRel_iff, negation, negInner, DRS.toRel_mk, Condition.holdsAll_cons,
-    Condition.holdsAll_nil, Condition.holds_neg, Condition.holds_rel, vecArg₁, and_true]
+    Condition.holdsAll_nil, Condition.holds_neg, Condition.holds_rel, comp_vecCons,
+    comp_vecEmpty, and_true]
   constructor
   · rintro ⟨a', _, hneg⟩ ⟨e, hm, hw⟩
     exact hneg ⟨Function.update a' 1 e, fun x hx => by

--- a/Linglib/Studies/KampReyle1993.lean
+++ b/Linglib/Studies/KampReyle1993.lean
@@ -68,8 +68,8 @@ def persistence : DRS krLang ℕ :=
 that is a man, walked in, and sat down. -/
 theorem persistence_tc (a : ℕ → M) :
     DRS.trueRel persistence a ↔ ∃ e : M, rm .man ![e] ∧ rm .walkedIn ![e] ∧ rm .satDown ![e] := by
-  simp only [DRS.trueRel, persistence, DRS.toRel, Condition.holdsAll, Condition.holds, vecArg₁,
-    and_true]
+  simp only [DRS.trueRel_iff, persistence, DRS.toRel_mk, Condition.holdsAll_cons,
+    Condition.holdsAll_nil, Condition.holds_rel, vecArg₁, and_true]
   constructor
   · rintro ⟨a', _, hm, hw, hs⟩; exact ⟨a' 1, hm, hw, hs⟩
   · rintro ⟨e, hm, hw, hs⟩
@@ -97,8 +97,9 @@ theorem donkey_universal_reading (a : ℕ → M) :
     DRS.trueRel donkey a ↔
     ∀ e₁ e₂ : M, (rm .farmer ![e₁] ∧ rm .donkey ![e₂] ∧ rm .owns ![e₁, e₂]) →
       rm .beats ![e₁, e₂] := by
-  simp only [DRS.trueRel, donkey, donkeyAnte, donkeyCons, DRS.toRel, Condition.holdsAll,
-    Condition.holds, vecArg₁, vecArg₂, and_true]
+  simp only [DRS.trueRel_iff, donkey, donkeyAnte, donkeyCons, DRS.toRel_mk,
+    Condition.holdsAll_cons, Condition.holdsAll_nil, Condition.holds_imp, Condition.holds_rel,
+    vecArg₁, vecArg₂, and_true]
   constructor
   · rintro ⟨a', _, himp⟩ e₁ e₂ ⟨hf, hd, ho⟩
     set v' := Function.update (Function.update a' 1 e₁) 2 e₂ with hv'
@@ -123,8 +124,8 @@ def negation : DRS krLang ℕ := .mk ∅ [.neg negInner]
 is bound inside the negation and inaccessible to any continuation. -/
 theorem negation_tc (a : ℕ → M) :
     DRS.trueRel negation a ↔ ¬ ∃ e : M, rm .man ![e] ∧ rm .walkedIn ![e] := by
-  simp only [DRS.trueRel, negation, negInner, DRS.toRel, Condition.holdsAll, Condition.holds,
-    vecArg₁, and_true]
+  simp only [DRS.trueRel_iff, negation, negInner, DRS.toRel_mk, Condition.holdsAll_cons,
+    Condition.holdsAll_nil, Condition.holds_neg, Condition.holds_rel, vecArg₁, and_true]
   constructor
   · rintro ⟨a', _, hneg⟩ ⟨e, hm, hw⟩
     exact hneg ⟨Function.update a' 1 e, fun x hx => by


### PR DESCRIPTION
Deep-audit fixes for `DRS/Dynamics.lean` (Muskens 1996 relational semantics; verified against the paper and K&R 1993):
- route `toRel`/`holds`/`trueRel` through the `DynProp` spine (`dneg`/`dimpl`/`ddisj`/`closure`); Merging Lemma restated as `toRel (K₁.merge K₂) = toRel K₁ ⨟ toRel K₂`; add the structural `@[simp]` API (`toRel_mk`, `holds_*`, `holdsAll_*`)
- replace the lambda-headed `vecArg` `@[simp]` family (simp.otherHead warnings) with a general private reindex lemma in its sole consumer; drop `classical` via `Finset.piecewise`
- correct K&R over-attributions: `Realize` documented as the total-assignment rendering (Muskens fn. 4), ⇒/∨ clauses credited to Ch. 2 rather than Def. 1.4.4/1.4.1, alphabetic-variant and stale bridge-table pointers fixed