### PR TITLE
feat(Semantics/Dynamic): based state and transition foundation

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1642,6 +1642,7 @@ import Linglib.Semantics.Dynamic.DRS.Dynamics
 import Linglib.Semantics.Dynamic.DRS.Reduction
 import Linglib.Semantics.Dynamic.DRS.Semantics
 import Linglib.Semantics.Dynamic.DiscourseRef
+import Linglib.Semantics.Dynamic.InfoState
 import Linglib.Semantics.Dynamic.Intensional
 import Linglib.Semantics.Dynamic.PLA.Basic
 import Linglib.Semantics.Dynamic.PLA.Epistemic

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1642,7 +1642,8 @@ import Linglib.Semantics.Dynamic.DRS.Dynamics
 import Linglib.Semantics.Dynamic.DRS.Reduction
 import Linglib.Semantics.Dynamic.DRS.Semantics
 import Linglib.Semantics.Dynamic.DiscourseRef
-import Linglib.Semantics.Dynamic.InfoState
+import Linglib.Semantics.Dynamic.State
+import Linglib.Semantics.Dynamic.Transition
 import Linglib.Semantics.Dynamic.Intensional
 import Linglib.Semantics.Dynamic.PLA.Basic
 import Linglib.Semantics.Dynamic.PLA.Epistemic

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -12,8 +12,8 @@ Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
   variant* (the prose preceding Def. 1.4.8); `map_id` makes "renaming to the
   identity is the identity" a free corollary.
 * `merge` algebra — identity (`empty`) and associativity.
-* `DRS.Bound` / `DRS.IsProper` — properness (no free discourse referent,
-  Def. 1.4.2–1.4.3).
+* `DRS.fv` / `DRS.IsProper` — free discourse referents (as a `Finset`) and
+  properness (`fv K = ∅`, Def. 1.4.2–1.4.3).
 * `Condition.occ` / `DRS.occ` — occurring referents, as a decidable `Finset`.
 * `DRS.accessibleFrom` / `DRS.Accessible` — decidable, host-relative
   accessibility (Def. 1.4.11).
@@ -95,39 +95,6 @@ theorem merge_assoc (K₁ K₂ K₃ : DRS L V) :
 
 end DRS
 
-/-! ### Properness (no free discourse referent) -/
-
-section Proper
-variable [DecidableEq V]
-
-mutual
-/-- `Bound b K`: every discourse referent occurring in `K` is bound — present in
-`b` or introduced by `K`'s universe or by an ancestor reachable "left and up"
-(the antecedent of a `⇒` threads its referents into the consequent). -/
-def DRS.Bound (b : Finset V) : DRS L V → Prop
-  | .mk U conds => Condition.BoundAll (b ∪ U) conds
-/-- `b`-boundedness of a condition. -/
-def Condition.Bound (b : Finset V) : Condition L V → Prop
-  | .rel _ args => ∀ i, args i ∈ b
-  | .eq u v => u ∈ b ∧ v ∈ b
-  | .neg K => DRS.Bound b K
-  | .imp a c => DRS.Bound b a ∧ DRS.Bound (b ∪ a.referents) c
-  | .dis l r => DRS.Bound b l ∧ DRS.Bound b r
-/-- `b`-boundedness of a list of conditions. A `List` helper (not
-`List.Forall (Condition.Bound b)`) — the higher-order form fails the
-nested-inductive structural-recursion checker. -/
-def Condition.BoundAll (b : Finset V) : List (Condition L V) → Prop
-  | [] => True
-  | c :: cs => Condition.Bound b c ∧ Condition.BoundAll b cs
-end
-
-/-- A DRS is *proper* iff it has no free discourse referent
-([kamp-reyle-1993], Def. 1.4.2–1.4.3): every occurring referent is bound at
-its position. -/
-def DRS.IsProper (K : DRS L V) : Prop := DRS.Bound ∅ K
-
-end Proper
-
 /-! ### Occurring referents -/
 
 section Occ
@@ -153,6 +120,86 @@ def Condition.occL : List (Condition L V) → Finset V
 end
 
 end Occ
+
+/-! ### Free discourse referents and properness -/
+
+section Fv
+variable [DecidableEq V]
+
+mutual
+/-- The free discourse referents of a DRS: referents occurring in its
+conditions and not bound by its universe or by an ancestor reachable "left
+and up" (the antecedent of a `⇒` threads its referents into the consequent).
+`K.fv ⊆ b` says every referent of `K` is bound in context `b`. -/
+def DRS.fv : DRS L V → Finset V
+  | .mk U conds => Condition.fvL conds \ U
+/-- The free discourse referents of a condition. -/
+def Condition.fv : Condition L V → Finset V
+  | .rel _ args => Finset.image args Finset.univ
+  | .eq u v => {u, v}
+  | .neg K => DRS.fv K
+  | .imp a c => DRS.fv a ∪ (DRS.fv c \ a.referents)
+  | .dis l r => DRS.fv l ∪ DRS.fv r
+/-- Free referents of a list of conditions. A `List` helper — the
+higher-order form fails the nested-inductive structural-recursion checker. -/
+def Condition.fvL : List (Condition L V) → Finset V
+  | [] => ∅
+  | c :: cs => Condition.fv c ∪ Condition.fvL cs
+end
+
+@[simp] theorem DRS.fv_mk (U : Finset V) (conds : List (Condition L V)) :
+    (DRS.mk U conds).fv = Condition.fvL conds \ U := rfl
+@[simp] theorem Condition.fv_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (Condition.rel R args).fv = Finset.image args Finset.univ := rfl
+@[simp] theorem Condition.fv_eq (u v : V) :
+    (Condition.eq u v : Condition L V).fv = {u, v} := rfl
+@[simp] theorem Condition.fv_neg (K : DRS L V) : (Condition.neg K).fv = K.fv := rfl
+@[simp] theorem Condition.fv_imp (a c : DRS L V) :
+    (Condition.imp a c).fv = a.fv ∪ (c.fv \ a.referents) := rfl
+@[simp] theorem Condition.fv_dis (l r : DRS L V) :
+    (Condition.dis l r).fv = l.fv ∪ r.fv := rfl
+@[simp] theorem Condition.fvL_nil : Condition.fvL ([] : List (Condition L V)) = ∅ := rfl
+@[simp] theorem Condition.fvL_cons (c : Condition L V) (cs : List (Condition L V)) :
+    Condition.fvL (c :: cs) = c.fv ∪ Condition.fvL cs := rfl
+
+mutual
+/-- Free referents occur. -/
+theorem DRS.fv_subset_occ (K : DRS L V) : K.fv ⊆ K.occ := by
+  match K with
+  | .mk U conds =>
+    simp only [DRS.fv_mk, DRS.occ]
+    exact (Finset.sdiff_subset).trans (Condition.fvL_subset_occL conds) |>.trans
+      Finset.subset_union_right
+/-- Free referents of a condition occur. -/
+theorem Condition.fv_subset_occ (c : Condition L V) : c.fv ⊆ c.occ := by
+  match c with
+  | .rel R args => simp [Condition.occ]
+  | .eq u v => simp [Condition.occ]
+  | .neg K => simpa [Condition.occ] using DRS.fv_subset_occ K
+  | .imp a c =>
+    simp only [Condition.fv_imp, Condition.occ]
+    exact Finset.union_subset_union (DRS.fv_subset_occ a)
+      ((Finset.sdiff_subset).trans (DRS.fv_subset_occ c))
+  | .dis l r =>
+    simp only [Condition.fv_dis, Condition.occ]
+    exact Finset.union_subset_union (DRS.fv_subset_occ l) (DRS.fv_subset_occ r)
+/-- The list analogue of `Condition.fv_subset_occ`. -/
+theorem Condition.fvL_subset_occL (cs : List (Condition L V)) :
+    Condition.fvL cs ⊆ Condition.occL cs := by
+  match cs with
+  | [] => simp
+  | c :: cs =>
+    simp only [Condition.fvL_cons, Condition.occL]
+    exact Finset.union_subset_union (Condition.fv_subset_occ c)
+      (Condition.fvL_subset_occL cs)
+end
+
+/-- A DRS is *proper* iff it has no free discourse referent
+([kamp-reyle-1993], Def. 1.4.2–1.4.3). -/
+def DRS.IsProper (K : DRS L V) : Prop := K.fv = ∅
+
+end Fv
+
 
 /-! ### Accessibility (decidable, host-relative)
 

--- a/Linglib/Semantics/Dynamic/InfoState.lean
+++ b/Linglib/Semantics/Dynamic/InfoState.lean
@@ -1,0 +1,217 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Set.Function
+import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Order.Lattice
+
+/-!
+# Based information states
+[kamp-vangenabith-reyle-2011] (Defs. 22–26), [heim-1982]
+
+An information state relative to a *base* `X` — a finite set of discourse
+referents — is a set of world–assignment pairs whose membership depends on
+assignments only through their values at `X`. The base is the "context as
+storage" dimension of dynamic meaning: finer than a proposition (it records
+which referents are live for anaphora — [kamp-vangenabith-reyle-2011]'s
+Partee marbles argument), coarser than syntax, and framework-neutral.
+
+Total-assignment rendering: the chapter's partial embeddings with domain `X`
+become total assignments with `X`-supported membership (`BaseSupported`).
+Under it the chapter's definitions collapse to order theory:
+
+* Def. 25's informativeness order is componentwise — the base grows and the
+  carrier shrinks (`le_def`; the chapter's projection form is
+  `le_iff_projection`).
+* Def. 26's consistent merge is carrier intersection at the union base, and
+  it is the *join* of the informativeness order (`SemilatticeSup`;
+  `mem_sup_iff` recovers the chapter's choice-function form).
+* Def. 23(iv)'s minimal information state Λ (empty base, no information)
+  is `⊥`.
+
+`InfoStateOf P` (`ContextChange.lean`) is the unbased, level-0 notion — a
+bare set of possibilities; `InfoState` adds the base. The based update
+relations acting on these states live in `BasedUpdate.lean`.
+
+## Main declarations
+
+* `BaseSupported` — membership depends only on assignment values at `X`.
+* `InfoState` — a base together with a supported carrier.
+* `InfoState.prop` — the proposition determined by a state (Def. 23(v)).
+* `InfoState.restrict` — the best approximation supported on a smaller base
+  (presheaf restriction along base inclusion).
+-/
+
+namespace Semantics.Dynamic.Core
+
+variable {W V M : Type*}
+
+/-- A set of world–assignment pairs is *supported* on `X` when membership
+depends on the assignment only through its values at `X`. -/
+def BaseSupported (X : Finset V) (S : Set (W × (V → M))) : Prop :=
+  ∀ ⦃w : W⦄ ⦃f g : V → M⦄, Set.EqOn f g ↑X → ((w, f) ∈ S ↔ (w, g) ∈ S)
+
+theorem BaseSupported.mono {X Y : Finset V} {S : Set (W × (V → M))}
+    (h : BaseSupported X S) (hXY : X ⊆ Y) : BaseSupported Y S :=
+  fun _ _ _ hfg => h (hfg.mono (Finset.coe_subset.mpr hXY))
+
+theorem BaseSupported.inter {X : Finset V} {S T : Set (W × (V → M))}
+    (hS : BaseSupported X S) (hT : BaseSupported X T) : BaseSupported X (S ∩ T) :=
+  fun _ _ _ hfg => and_congr (hS hfg) (hT hfg)
+
+/-- An information state ([kamp-vangenabith-reyle-2011], Defs. 22–23): a base
+`X` of live discourse referents together with an `X`-supported set of
+world–assignment pairs. -/
+@[ext] structure InfoState (W : Type*) (V : Type*) (M : Type*) where
+  /-- The live discourse referents (the chapter's base `X`). -/
+  base : Finset V
+  /-- The world–assignment pairs compatible with the information. -/
+  carrier : Set (W × (V → M))
+  /-- Membership depends on assignments only through their values at `base`. -/
+  supported : BaseSupported base carrier
+
+namespace InfoState
+
+instance : Membership (W × (V → M)) (InfoState W V M) :=
+  ⟨fun I p => p ∈ I.carrier⟩
+
+@[simp] theorem mem_carrier {I : InfoState W V M} {p : W × (V → M)} :
+    p ∈ I.carrier ↔ p ∈ I := Iff.rfl
+
+/-! ### The informativeness order -/
+
+/-- Informativeness ([kamp-vangenabith-reyle-2011], Def. 25): `I ≤ I'` iff
+`I'` carries at least as much information — the base grows and the carrier
+shrinks. -/
+instance : PartialOrder (InfoState W V M) where
+  le I I' := I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier
+  le_refl _ := ⟨subset_rfl, subset_rfl⟩
+  le_trans _ _ _ h h' := ⟨h.1.trans h'.1, h'.2.trans h.2⟩
+  le_antisymm _ _ h h' :=
+    InfoState.ext (Finset.Subset.antisymm h.1 h'.1) (Set.Subset.antisymm h'.2 h.2)
+
+theorem le_def {I I' : InfoState W V M} :
+    I ≤ I' ↔ I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier := Iff.rfl
+
+/-- The chapter's projection form of Def. 25 — every pair of the stronger
+state restricts to one of the weaker — coincides with `≤`: support makes the
+projected witness the pair itself. -/
+theorem le_iff_projection {I I' : InfoState W V M} :
+    I ≤ I' ↔ I.base ⊆ I'.base ∧
+      ∀ ⦃w g⦄, (w, g) ∈ I' → ∃ f, (w, f) ∈ I ∧ Set.EqOn f g ↑I.base := by
+  constructor
+  · rintro ⟨hb, hc⟩
+    exact ⟨hb, fun w g hg => ⟨g, hc hg, Set.eqOn_refl g _⟩⟩
+  · rintro ⟨hb, hproj⟩
+    refine ⟨hb, fun p hp => ?_⟩
+    obtain ⟨w, g⟩ := p
+    obtain ⟨f, hf, hfg⟩ := hproj hp
+    exact (I.supported hfg).mp hf
+
+/-- The minimal information state Λ ([kamp-vangenabith-reyle-2011],
+Def. 23(iv)): empty base, no information. -/
+instance : OrderBot (InfoState W V M) where
+  bot := ⟨∅, Set.univ, fun _ _ _ _ => Iff.rfl⟩
+  bot_le _ := ⟨Finset.empty_subset _, Set.subset_univ _⟩
+
+@[simp] theorem base_bot : (⊥ : InfoState W V M).base = ∅ := rfl
+@[simp] theorem carrier_bot : (⊥ : InfoState W V M).carrier = Set.univ := rfl
+
+/-! ### Consistent merge is the join -/
+
+section Merge
+variable [DecidableEq V]
+
+/-- Consistent merge ([kamp-vangenabith-reyle-2011], Def. 26) is the join of
+the informativeness order: union the bases, intersect the carriers. -/
+instance : SemilatticeSup (InfoState W V M) where
+  sup I I' :=
+    ⟨I.base ∪ I'.base, I.carrier ∩ I'.carrier,
+      (I.supported.mono Finset.subset_union_left).inter
+        (I'.supported.mono Finset.subset_union_right)⟩
+  le_sup_left _ _ := ⟨Finset.subset_union_left, Set.inter_subset_left⟩
+  le_sup_right _ _ := ⟨Finset.subset_union_right, Set.inter_subset_right⟩
+  sup_le _ _ _ h h' :=
+    ⟨Finset.union_subset h.1 h'.1, Set.subset_inter h.2 h'.2⟩
+
+@[simp] theorem base_sup (I I' : InfoState W V M) :
+    (I ⊔ I').base = I.base ∪ I'.base := rfl
+@[simp] theorem carrier_sup (I I' : InfoState W V M) :
+    (I ⊔ I').carrier = I.carrier ∩ I'.carrier := rfl
+
+/-- The chapter's choice-function form of Def. 26: a pair belongs to the
+merge iff it restricts into each component — support makes the choice
+functions the pair itself. -/
+theorem mem_sup_iff {I I' : InfoState W V M} {w : W} {h : V → M} :
+    (w, h) ∈ I ⊔ I' ↔
+      (∃ f, (w, f) ∈ I ∧ Set.EqOn f h ↑I.base) ∧
+      (∃ g, (w, g) ∈ I' ∧ Set.EqOn g h ↑I'.base) := by
+  constructor
+  · rintro ⟨hI, hI'⟩
+    exact ⟨⟨h, hI, Set.eqOn_refl h _⟩, ⟨h, hI', Set.eqOn_refl h _⟩⟩
+  · rintro ⟨⟨f, hf, hfh⟩, ⟨g, hg, hgh⟩⟩
+    exact ⟨(I.supported hfh).mp hf, (I'.supported hgh).mp hg⟩
+
+end Merge
+
+/-! ### The proposition determined by a state -/
+
+/-- The proposition a state determines ([kamp-vangenabith-reyle-2011],
+Def. 23(v)): the worlds compatible with some assignment. -/
+def prop (I : InfoState W V M) : Set W := Prod.fst '' I.carrier
+
+theorem mem_prop {I : InfoState W V M} {w : W} :
+    w ∈ I.prop ↔ ∃ f, (w, f) ∈ I := by
+  simp [prop, Prod.exists]
+
+/-- Stronger states determine stronger propositions. -/
+theorem prop_anti {I I' : InfoState W V M} (h : I ≤ I') : I'.prop ⊆ I.prop :=
+  Set.image_mono h.2
+
+@[simp] theorem prop_bot [Nonempty M] : (⊥ : InfoState W V M).prop = Set.univ := by
+  ext w
+  exact ⟨fun _ => trivial, fun _ => ⟨(w, fun _ => Classical.arbitrary M), trivial, rfl⟩⟩
+
+/-! ### Restriction to a smaller base -/
+
+/-- Restrict a state to base `Y`: the best `Y`-supported approximation — a
+pair survives iff some carrier member agrees with it on `Y`. -/
+def restrict (I : InfoState W V M) (Y : Finset V) : InfoState W V M where
+  base := Y
+  carrier := {p | ∃ f, (p.1, f) ∈ I.carrier ∧ Set.EqOn f p.2 ↑Y}
+  supported := fun _ _ _ hgg' =>
+    exists_congr fun _ => and_congr_right fun _ =>
+      ⟨fun h => h.trans hgg', fun h => h.trans hgg'.symm⟩
+
+@[simp] theorem base_restrict (I : InfoState W V M) (Y : Finset V) :
+    (I.restrict Y).base = Y := rfl
+
+theorem mem_restrict {I : InfoState W V M} {Y : Finset V} {w : W} {g : V → M} :
+    (w, g) ∈ I.restrict Y ↔ ∃ f, (w, f) ∈ I ∧ Set.EqOn f g ↑Y := Iff.rfl
+
+/-- Restricting to the state's own base is the identity. -/
+@[simp] theorem restrict_base (I : InfoState W V M) : I.restrict I.base = I := by
+  ext1
+  · rfl
+  · ext ⟨w, g⟩
+    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported hfg).mp hf,
+      fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
+
+/-- Restriction is transitive along shrinking bases. -/
+theorem restrict_restrict (I : InfoState W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
+    (I.restrict Y).restrict Z = I.restrict Z := by
+  ext1
+  · rfl
+  · ext ⟨w, g⟩
+    constructor
+    · rintro ⟨f, ⟨f', hf', hf'f⟩, hfg⟩
+      exact ⟨f', hf', (hf'f.mono (Finset.coe_subset.mpr hZY)).trans hfg⟩
+    · rintro ⟨f, hf, hfg⟩
+      exact ⟨f, ⟨f, hf, Set.eqOn_refl f _⟩, hfg⟩
+
+/-- Restriction to a sub-base weakens the state. -/
+theorem restrict_le {I : InfoState W V M} {Y : Finset V} (h : Y ⊆ I.base) :
+    I.restrict Y ≤ I :=
+  ⟨h, fun p hp => ⟨p.2, hp, Set.eqOn_refl p.2 _⟩⟩
+
+end InfoState
+
+end Semantics.Dynamic.Core

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -28,19 +28,23 @@ Under it the chapter's definitions collapse to order theory:
   is `⊥`.
 
 `InfoStateOf P` (`ContextChange.lean`) is the unbased, level-0 notion — a
-bare set of possibilities; `InfoState` adds the base. The based update
-relations acting on these states live in `BasedUpdate.lean`.
+bare set of possibilities; `State` adds the base. The based update
+relations acting on these states live in `Transition.lean`.
+
+The namespace is `Semantics.Dynamic` (not the legacy `Semantics.Dynamic.Core`
+of the pre-2026-07 spine): the based layer starts the clean namespace the
+rest of the spine migrates into.
 
 ## Main declarations
 
 * `BaseSupported` — membership depends only on assignment values at `X`.
-* `InfoState` — a base together with a supported carrier.
-* `InfoState.prop` — the proposition determined by a state (Def. 23(v)).
-* `InfoState.restrict` — the best approximation supported on a smaller base
+* `State` — a base together with a supported carrier.
+* `State.prop` — the proposition determined by a state (Def. 23(v)).
+* `State.restrict` — the best approximation supported on a smaller base
   (presheaf restriction along base inclusion).
 -/
 
-namespace Semantics.Dynamic.Core
+namespace Semantics.Dynamic
 
 variable {W V M : Type*}
 
@@ -60,7 +64,7 @@ theorem BaseSupported.inter {X : Finset V} {S T : Set (W × (V → M))}
 /-- An information state ([kamp-vangenabith-reyle-2011], Defs. 22–23): a base
 `X` of live discourse referents together with an `X`-supported set of
 world–assignment pairs. -/
-@[ext] structure InfoState (W : Type*) (V : Type*) (M : Type*) where
+@[ext] structure State (W : Type*) (V : Type*) (M : Type*) where
   /-- The live discourse referents (the chapter's base `X`). -/
   base : Finset V
   /-- The world–assignment pairs compatible with the information. -/
@@ -68,12 +72,12 @@ world–assignment pairs. -/
   /-- Membership depends on assignments only through their values at `base`. -/
   supported : BaseSupported base carrier
 
-namespace InfoState
+namespace State
 
-instance : Membership (W × (V → M)) (InfoState W V M) :=
+instance : Membership (W × (V → M)) (State W V M) :=
   ⟨fun I p => p ∈ I.carrier⟩
 
-@[simp] theorem mem_carrier {I : InfoState W V M} {p : W × (V → M)} :
+@[simp] theorem mem_carrier {I : State W V M} {p : W × (V → M)} :
     p ∈ I.carrier ↔ p ∈ I := Iff.rfl
 
 /-! ### The informativeness order -/
@@ -81,20 +85,20 @@ instance : Membership (W × (V → M)) (InfoState W V M) :=
 /-- Informativeness ([kamp-vangenabith-reyle-2011], Def. 25): `I ≤ I'` iff
 `I'` carries at least as much information — the base grows and the carrier
 shrinks. -/
-instance : PartialOrder (InfoState W V M) where
+instance : PartialOrder (State W V M) where
   le I I' := I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier
   le_refl _ := ⟨subset_rfl, subset_rfl⟩
   le_trans _ _ _ h h' := ⟨h.1.trans h'.1, h'.2.trans h.2⟩
   le_antisymm _ _ h h' :=
-    InfoState.ext (Finset.Subset.antisymm h.1 h'.1) (Set.Subset.antisymm h'.2 h.2)
+    State.ext (Finset.Subset.antisymm h.1 h'.1) (Set.Subset.antisymm h'.2 h.2)
 
-theorem le_def {I I' : InfoState W V M} :
+theorem le_def {I I' : State W V M} :
     I ≤ I' ↔ I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier := Iff.rfl
 
 /-- The chapter's projection form of Def. 25 — every pair of the stronger
 state restricts to one of the weaker — coincides with `≤`: support makes the
 projected witness the pair itself. -/
-theorem le_iff_projection {I I' : InfoState W V M} :
+theorem le_iff_projection {I I' : State W V M} :
     I ≤ I' ↔ I.base ⊆ I'.base ∧
       ∀ ⦃w g⦄, (w, g) ∈ I' → ∃ f, (w, f) ∈ I ∧ Set.EqOn f g ↑I.base := by
   constructor
@@ -108,12 +112,12 @@ theorem le_iff_projection {I I' : InfoState W V M} :
 
 /-- The minimal information state Λ ([kamp-vangenabith-reyle-2011],
 Def. 23(iv)): empty base, no information. -/
-instance : OrderBot (InfoState W V M) where
+instance : OrderBot (State W V M) where
   bot := ⟨∅, Set.univ, fun _ _ _ _ => Iff.rfl⟩
   bot_le _ := ⟨Finset.empty_subset _, Set.subset_univ _⟩
 
-@[simp] theorem base_bot : (⊥ : InfoState W V M).base = ∅ := rfl
-@[simp] theorem carrier_bot : (⊥ : InfoState W V M).carrier = Set.univ := rfl
+@[simp] theorem base_bot : (⊥ : State W V M).base = ∅ := rfl
+@[simp] theorem carrier_bot : (⊥ : State W V M).carrier = Set.univ := rfl
 
 /-! ### Consistent merge is the join -/
 
@@ -122,7 +126,7 @@ variable [DecidableEq V]
 
 /-- Consistent merge ([kamp-vangenabith-reyle-2011], Def. 26) is the join of
 the informativeness order: union the bases, intersect the carriers. -/
-instance : SemilatticeSup (InfoState W V M) where
+instance : SemilatticeSup (State W V M) where
   sup I I' :=
     ⟨I.base ∪ I'.base, I.carrier ∩ I'.carrier,
       (I.supported.mono Finset.subset_union_left).inter
@@ -132,15 +136,15 @@ instance : SemilatticeSup (InfoState W V M) where
   sup_le _ _ _ h h' :=
     ⟨Finset.union_subset h.1 h'.1, Set.subset_inter h.2 h'.2⟩
 
-@[simp] theorem base_sup (I I' : InfoState W V M) :
+@[simp] theorem base_sup (I I' : State W V M) :
     (I ⊔ I').base = I.base ∪ I'.base := rfl
-@[simp] theorem carrier_sup (I I' : InfoState W V M) :
+@[simp] theorem carrier_sup (I I' : State W V M) :
     (I ⊔ I').carrier = I.carrier ∩ I'.carrier := rfl
 
 /-- The chapter's choice-function form of Def. 26: a pair belongs to the
 merge iff it restricts into each component — support makes the choice
 functions the pair itself. -/
-theorem mem_sup_iff {I I' : InfoState W V M} {w : W} {h : V → M} :
+theorem mem_sup_iff {I I' : State W V M} {w : W} {h : V → M} :
     (w, h) ∈ I ⊔ I' ↔
       (∃ f, (w, f) ∈ I ∧ Set.EqOn f h ↑I.base) ∧
       (∃ g, (w, g) ∈ I' ∧ Set.EqOn g h ↑I'.base) := by
@@ -156,17 +160,17 @@ end Merge
 
 /-- The proposition a state determines ([kamp-vangenabith-reyle-2011],
 Def. 23(v)): the worlds compatible with some assignment. -/
-def prop (I : InfoState W V M) : Set W := Prod.fst '' I.carrier
+def prop (I : State W V M) : Set W := Prod.fst '' I.carrier
 
-theorem mem_prop {I : InfoState W V M} {w : W} :
+theorem mem_prop {I : State W V M} {w : W} :
     w ∈ I.prop ↔ ∃ f, (w, f) ∈ I := by
   simp [prop, Prod.exists]
 
 /-- Stronger states determine stronger propositions. -/
-theorem prop_anti {I I' : InfoState W V M} (h : I ≤ I') : I'.prop ⊆ I.prop :=
+theorem prop_anti {I I' : State W V M} (h : I ≤ I') : I'.prop ⊆ I.prop :=
   Set.image_mono h.2
 
-@[simp] theorem prop_bot [Nonempty M] : (⊥ : InfoState W V M).prop = Set.univ := by
+@[simp] theorem prop_bot [Nonempty M] : (⊥ : State W V M).prop = Set.univ := by
   ext w
   exact ⟨fun _ => trivial, fun _ => ⟨(w, fun _ => Classical.arbitrary M), trivial, rfl⟩⟩
 
@@ -174,21 +178,21 @@ theorem prop_anti {I I' : InfoState W V M} (h : I ≤ I') : I'.prop ⊆ I.prop :
 
 /-- Restrict a state to base `Y`: the best `Y`-supported approximation — a
 pair survives iff some carrier member agrees with it on `Y`. -/
-def restrict (I : InfoState W V M) (Y : Finset V) : InfoState W V M where
+def restrict (I : State W V M) (Y : Finset V) : State W V M where
   base := Y
   carrier := {p | ∃ f, (p.1, f) ∈ I.carrier ∧ Set.EqOn f p.2 ↑Y}
   supported := fun _ _ _ hgg' =>
     exists_congr fun _ => and_congr_right fun _ =>
       ⟨fun h => h.trans hgg', fun h => h.trans hgg'.symm⟩
 
-@[simp] theorem base_restrict (I : InfoState W V M) (Y : Finset V) :
+@[simp] theorem base_restrict (I : State W V M) (Y : Finset V) :
     (I.restrict Y).base = Y := rfl
 
-theorem mem_restrict {I : InfoState W V M} {Y : Finset V} {w : W} {g : V → M} :
+theorem mem_restrict {I : State W V M} {Y : Finset V} {w : W} {g : V → M} :
     (w, g) ∈ I.restrict Y ↔ ∃ f, (w, f) ∈ I ∧ Set.EqOn f g ↑Y := Iff.rfl
 
 /-- Restricting to the state's own base is the identity. -/
-@[simp] theorem restrict_base (I : InfoState W V M) : I.restrict I.base = I := by
+@[simp] theorem restrict_base (I : State W V M) : I.restrict I.base = I := by
   ext1
   · rfl
   · ext ⟨w, g⟩
@@ -196,7 +200,7 @@ theorem mem_restrict {I : InfoState W V M} {Y : Finset V} {w : W} {g : V → M} 
       fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
 
 /-- Restriction is transitive along shrinking bases. -/
-theorem restrict_restrict (I : InfoState W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
+theorem restrict_restrict (I : State W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
     (I.restrict Y).restrict Z = I.restrict Z := by
   ext1
   · rfl
@@ -208,10 +212,10 @@ theorem restrict_restrict (I : InfoState W V M) {Y Z : Finset V} (hZY : Z ⊆ Y)
       exact ⟨f, ⟨f, hf, Set.eqOn_refl f _⟩, hfg⟩
 
 /-- Restriction to a sub-base weakens the state. -/
-theorem restrict_le {I : InfoState W V M} {Y : Finset V} (h : Y ⊆ I.base) :
+theorem restrict_le {I : State W V M} {Y : Finset V} (h : Y ⊆ I.base) :
     I.restrict Y ≤ I :=
   ⟨h, fun p hp => ⟨p.2, hp, Set.eqOn_refl p.2 _⟩⟩
 
-end InfoState
+end State
 
-end Semantics.Dynamic.Core
+end Semantics.Dynamic

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -1,0 +1,173 @@
+import Linglib.Semantics.Dynamic.State
+import Linglib.Semantics.Dynamic.ContextChange
+
+/-!
+# Transitions between based information states
+[kamp-vangenabith-reyle-2011] (Defs. 24, 27)
+
+The hom type of based dynamic semantics: a `Transition W M X Y` is a
+world-indexed relation between assignments that reads its input only at the
+source base `X` and writes its output only at the target base `Y ⊇ X`.
+Objects are bases (finite sets of discourse referents); a DRS denotes an
+arrow `X ⟶ X ∪ U`; sequencing is world-pointwise relational composition.
+
+Applying a transition to a `State` (Def. 24) is the level-0 `lift` of
+`ContextChange.lean` at the forgotten relation (`toUpdate`) — level 1 rides
+level 0 by construction. The chapter's regularity conditions (Def. 27)
+become theorems: the base of the output is `I.base ∪ Y` (`apply_base`), and
+applying an extension at its source base only adds information
+(`le_apply`). In the unbased, one-object collapse these facts degrade into
+side conditions (the Merging Lemma's freshness hypothesis); here the typing
+carries them.
+
+## Main declarations
+
+* `Transition` — the based relation; `id`, `comp` and their laws.
+* `Transition.toUpdate` — forget the bases (the collapse to level 0).
+* `Transition.apply` — Def. 24's context change, via `lift`.
+* `Transition.IsExtension` / `le_apply` — Def. 27(ii): information growth.
+-/
+
+namespace Semantics.Dynamic
+
+open Semantics.Dynamic.Core (lift)
+
+variable {W V M : Type*} {X Y Z : Finset V}
+
+/-- A transition: a world-indexed relation between assignments reading
+inputs at `X` and writing outputs at `Y`. The `grow` field makes arrows
+context-extending — bases never shrink. -/
+@[ext] structure Transition (W M : Type*) {V : Type*} (X Y : Finset V) where
+  /-- The world-indexed relation between input and output assignments. -/
+  rel : W → (V → M) → (V → M) → Prop
+  /-- Bases only grow along an update. -/
+  grow : X ⊆ Y
+  /-- Inputs are read only at the source base. -/
+  supported_left : ∀ ⦃w f f' g⦄, Set.EqOn f f' ↑X → (rel w f g ↔ rel w f' g)
+  /-- Outputs are constrained only at the target base. -/
+  supported_right : ∀ ⦃w f g g'⦄, Set.EqOn g g' ↑Y → (rel w f g ↔ rel w f g')
+
+namespace Transition
+
+/-- The identity transition at `X`: the test that changes nothing. -/
+def id (X : Finset V) : Transition W M X X where
+  rel _ f g := Set.EqOn f g ↑X
+  grow := subset_rfl
+  supported_left _ _ _ _ hff' := ⟨hff'.symm.trans, hff'.trans⟩
+  supported_right _ _ _ _ hgg' := ⟨(·.trans hgg'), (·.trans hgg'.symm)⟩
+
+/-- Sequencing: world-pointwise relational composition. -/
+def comp (u : Transition W M X Y) (v : Transition W M Y Z) :
+    Transition W M X Z where
+  rel w := Relation.Comp (u.rel w) (v.rel w)
+  grow := u.grow.trans v.grow
+  supported_left _ _ _ _ hff' :=
+    exists_congr fun _ => and_congr_left fun _ => u.supported_left hff'
+  supported_right _ _ _ _ hgg' :=
+    exists_congr fun _ => and_congr_right fun _ => v.supported_right hgg'
+
+@[simp] theorem id_comp (u : Transition W M X Y) : (id X).comp u = u := by
+  ext w f g
+  exact ⟨fun ⟨k, hfk, hk⟩ => (u.supported_left hfk).mpr hk,
+    fun h => ⟨f, Set.eqOn_refl f _, h⟩⟩
+
+@[simp] theorem comp_id (u : Transition W M X Y) : u.comp (id Y) = u := by
+  ext w f g
+  exact ⟨fun ⟨k, hk, hkg⟩ => (u.supported_right hkg).mp hk,
+    fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
+
+theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
+    {Z' : Finset V} (t : Transition W M Z Z') :
+    (u.comp v).comp t = u.comp (v.comp t) := by
+  ext w f g
+  exact ⟨fun ⟨k, ⟨j, hj, hjk⟩, hk⟩ => ⟨j, hj, k, hjk, hk⟩,
+    fun ⟨j, hj, k, hjk, hk⟩ => ⟨k, ⟨j, hj, hjk⟩, hk⟩⟩
+
+/-! ### Application to information states -/
+
+section Apply
+variable [DecidableEq V]
+
+/-- Forget the bases: the level-0 relation on world–assignment pairs (the
+world is preserved). -/
+def toUpdate (u : Transition W M X Y) :
+    Core.DynProp.Update (W × (V → M)) :=
+  fun p q => p.1 = q.1 ∧ u.rel p.1 p.2 q.2
+
+/-- Context change ([kamp-vangenabith-reyle-2011], Def. 24): the carrier is
+the level-0 `lift` of the forgotten relation; the base grows to
+`I.base ∪ Y` (Def. 27(ii)). -/
+def apply (u : Transition W M X Y) (I : State W V M) : State W V M where
+  base := I.base ∪ Y
+  carrier := lift u.toUpdate I.carrier
+  supported := by
+    intro w g g' hgg'
+    exact exists_congr fun p => and_congr_right fun _ => and_congr_right fun _ =>
+      u.supported_right (hgg'.mono (by simp))
+
+@[simp] theorem apply_base (u : Transition W M X Y) (I : State W V M) :
+    (u.apply I).base = I.base ∪ Y := rfl
+
+theorem mem_apply {u : Transition W M X Y} {I : State W V M} {w : W}
+    {g : V → M} : (w, g) ∈ u.apply I ↔ ∃ f, (w, f) ∈ I ∧ u.rel w f g := by
+  constructor
+  · rintro ⟨⟨w', f⟩, hf, rfl, hr⟩
+    exact ⟨f, hf, hr⟩
+  · rintro ⟨f, hf, hr⟩
+    exact ⟨(w, f), hf, rfl, hr⟩
+
+/-- Applying the identity transition is the identity, at the identity. -/
+@[simp] theorem apply_id (I : State W V M) (h : I.base = X) :
+    (id X).apply I = I := by
+  ext1
+  · simp [h]
+  · ext ⟨w, g⟩
+    rw [State.mem_carrier, mem_apply]
+    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported (h ▸ hfg)).mp hf,
+      fun hg => ⟨g, hg, Set.eqOn_refl g _⟩⟩
+
+/-- `apply` is functorial: sequencing then applying is applying twice. -/
+theorem apply_comp (u : Transition W M X Y) (v : Transition W M Y Z)
+    (I : State W V M) : (u.comp v).apply I = v.apply (u.apply I) := by
+  ext1
+  · simp only [apply_base, Finset.union_assoc, Finset.union_eq_right.mpr v.grow]
+  · ext ⟨w, h⟩
+    rw [State.mem_carrier, mem_apply, State.mem_carrier, mem_apply]
+    constructor
+    · rintro ⟨f, hf, k, hfk, hkh⟩
+      exact ⟨k, mem_apply.mpr ⟨f, hf, hfk⟩, hkh⟩
+    · rintro ⟨k, hk, hkh⟩
+      obtain ⟨f, hf, hfk⟩ := mem_apply.mp hk
+      exact ⟨f, hf, k, hfk, hkh⟩
+
+end Apply
+
+/-! ### Information growth (Def. 27) -/
+
+/-- A transition is an *extension* when outputs agree with inputs on the source
+base: established referents persist, only new ones are assigned. -/
+def IsExtension (u : Transition W M X Y) : Prop :=
+  ∀ ⦃w f g⦄, u.rel w f g → Set.EqOn g f ↑X
+
+/-- The identity is an extension. -/
+theorem isExtension_id : (id X : Transition W M X X).IsExtension :=
+  fun _ _ _ h => h.symm
+
+/-- Extensions compose. -/
+theorem IsExtension.comp {u : Transition W M X Y} {v : Transition W M Y Z}
+    (hu : u.IsExtension) (hv : v.IsExtension) : (u.comp v).IsExtension := by
+  rintro w f g ⟨k, hfk, hkg⟩
+  exact ((hv hkg).mono (Finset.coe_subset.mpr u.grow)).trans (hu hfk)
+
+/-- Def. 27(ii): applying an extension at its source base only adds
+information — the informativeness order grows along updates. -/
+theorem le_apply [DecidableEq V] (u : Transition W M X Y) (hu : u.IsExtension)
+    (I : State W V M) (hbase : I.base = X) : I ≤ u.apply I := by
+  refine ⟨hbase ▸ Finset.subset_union_left, ?_⟩
+  rintro ⟨w, g⟩ hg
+  obtain ⟨f, hf, hr⟩ := mem_apply.mp hg
+  exact (I.supported ((hu hr).symm.mono (by rw [hbase]))).mp hf
+
+end Transition
+
+end Semantics.Dynamic

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4587,6 +4587,21 @@
   role      = {cited},
   validated = {true},
   sources   = {Studies/KampReyle1993.lean}
+}% REF: Kamp, van Genabith & Reyle (2011). Discourse Representation Theory. HPL 15, 125-394.
+@incollection{kamp-vangenabith-reyle-2011,
+  author    = {Kamp, Hans and van Genabith, Josef and Reyle, Uwe},
+  year      = {2011},
+  title     = {Discourse Representation Theory},
+  booktitle = {Handbook of Philosophical Logic},
+  volume    = {15},
+  editor    = {Gabbay, Dov M. and Guenthner, Franz},
+  pages     = {125--394},
+  doi       = {10.1007/978-94-007-0485-5_3},
+  publisher = {Springer},
+  subfield  = {semantics/dynamic},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Semantics/Dynamic/InfoState.lean}
 }% REF: Dixon, R. M. W. (1994). *Ergativity*. Cambridge University Press.
 @book{dixon-1994,
   author    = {Dixon, R. M. W.},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4601,7 +4601,7 @@
   subfield  = {semantics/dynamic},
   role      = {formalized},
   validated = {true},
-  sources   = {Semantics/Dynamic/InfoState.lean}
+  sources   = {Semantics/Dynamic/State.lean}
 }% REF: Dixon, R. M. W. (1994). *Ergativity*. Cambridge University Press.
 @book{dixon-1994,
   author    = {Dixon, R. M. W.},


### PR DESCRIPTION
First batch of the based-dynamics foundation (spec: Kamp–van Genabith–Reyle HPL ch. 3, Defs. 22–27): `State` (base + base-supported carrier; the informativeness order is componentwise, consistent merge is its join, Λ is ⊥) and `Transition` (base-indexed world-relative relations; `apply` derived through `ContextChange.lift`, growth laws as theorems). Also replaces the recursive `DRS.Bound` with a `DRS.fv` Finset (`IsProper := fv = ∅`).
- new namespace `Semantics.Dynamic` (not legacy `.Core`) — the clean namespace the spine migrates into
- adds verified bib entry `kamp-vangenabith-reyle-2011`