### PR TITLE
feat(Semantics/Dynamic): Possibility carrier; based DRS semantics

### DIFF
--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,18 +1,21 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Function
+import Mathlib.Logic.Function.DependsOn
 import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Lattice
 
 /-!
-# Based information states
+# Possibilities and based information states
 [kamp-vangenabith-reyle-2011] (Defs. 22–26), [heim-1982]
 
-An information state relative to a *base* `X` — a finite set of discourse
-referents — is a set of world–assignment pairs whose membership depends on
-assignments only through their values at `X`. The base is the "context as
-storage" dimension of dynamic meaning: finer than a proposition (it records
-which referents are live for anaphora — [kamp-vangenabith-reyle-2011]'s
-Partee marbles argument), coarser than syntax, and framework-neutral.
+A *possibility* is a world paired with an assignment of discourse referents —
+the point type of dynamic semantics. An *information state* relative to a
+*base* `X` — a finite set of discourse referents — is a set of possibilities
+whose membership depends on assignments only through their values at `X`
+(mathlib's `DependsOn`, per world). The base is the "context as storage"
+dimension of dynamic meaning: finer than a proposition (it records which
+referents are live for anaphora — [kamp-vangenabith-reyle-2011]'s Partee
+marbles argument), coarser than syntax, and framework-neutral.
 
 Total-assignment rendering: the chapter's partial embeddings with domain `X`
 become total assignments with `X`-supported membership (`BaseSupported`).
@@ -28,8 +31,8 @@ Under it the chapter's definitions collapse to order theory:
   is `⊥`.
 
 `InfoStateOf P` (`ContextChange.lean`) is the unbased, level-0 notion — a
-bare set of possibilities; `State` adds the base. The based update
-relations acting on these states live in `Transition.lean`.
+bare set of possibilities; `State` adds the base. The transitions acting on
+these states live in `Transition.lean`.
 
 The namespace is `Semantics.Dynamic` (not the legacy `Semantics.Dynamic.Core`
 of the pre-2026-07 spine): the based layer starts the clean namespace the
@@ -37,8 +40,10 @@ rest of the spine migrates into.
 
 ## Main declarations
 
-* `BaseSupported` — membership depends only on assignment values at `X`.
-* `State` — a base together with a supported carrier.
+* `Possibility` — a world paired with an assignment of discourse referents.
+* `BaseSupported` — membership depends only on assignment values at `X`
+  (`DependsOn`, per world).
+* `State` — a base together with a supported carrier of possibilities.
 * `State.prop` — the proposition determined by a state (Def. 23(v)).
 * `State.restrict` — the best approximation supported on a smaller base
   (presheaf restriction along base inclusion).
@@ -48,36 +53,65 @@ namespace Semantics.Dynamic
 
 variable {W V M : Type*}
 
-/-- A set of world–assignment pairs is *supported* on `X` when membership
-depends on the assignment only through its values at `X`. -/
-def BaseSupported (X : Finset V) (S : Set (W × (V → M))) : Prop :=
-  ∀ ⦃w : W⦄ ⦃f g : V → M⦄, Set.EqOn f g ↑X → ((w, f) ∈ S ↔ (w, g) ∈ S)
+/-! ### Possibilities -/
 
-theorem BaseSupported.mono {X Y : Finset V} {S : Set (W × (V → M))}
+/-- A possibility: a world paired with an assignment of discourse referents
+to individuals — the point type of dynamic semantics. -/
+@[ext] structure Possibility (W V M : Type*) where
+  /-- The world coordinate. -/
+  world : W
+  /-- The assignment of discourse referents. -/
+  assignment : V → M
+
+/-! ### Base-supported sets -/
+
+/-- A set of possibilities is *supported* on `X` when membership depends on
+the assignment only through its values at `X`: for each world, the
+membership predicate `DependsOn` the coordinates in `X`. -/
+def BaseSupported (X : Finset V) (S : Set (Possibility W V M)) : Prop :=
+  ∀ w : W, DependsOn (fun f => (⟨w, f⟩ : Possibility W V M) ∈ S) ↑X
+
+/-- Introduction form: supply the membership-invariance iff. -/
+theorem baseSupported_of_iff {X : Finset V} {S : Set (Possibility W V M)}
+    (h : ∀ ⦃w : W⦄ ⦃f g : V → M⦄, Set.EqOn f g ↑X →
+      ((⟨w, f⟩ : Possibility W V M) ∈ S ↔ ⟨w, g⟩ ∈ S)) :
+    BaseSupported X S :=
+  fun _ _ _ hfg => propext (h hfg)
+
+/-- Elimination form: membership is invariant under agreement on the base. -/
+theorem BaseSupported.mem_iff {X : Finset V} {S : Set (Possibility W V M)}
+    (h : BaseSupported X S) {w : W} {f g : V → M} (hfg : Set.EqOn f g ↑X) :
+    (⟨w, f⟩ : Possibility W V M) ∈ S ↔ ⟨w, g⟩ ∈ S :=
+  iff_of_eq (h w hfg)
+
+theorem BaseSupported.mono {X Y : Finset V} {S : Set (Possibility W V M)}
     (h : BaseSupported X S) (hXY : X ⊆ Y) : BaseSupported Y S :=
-  fun _ _ _ hfg => h (hfg.mono (Finset.coe_subset.mpr hXY))
+  fun w => (h w).mono (Finset.coe_subset.mpr hXY)
 
-theorem BaseSupported.inter {X : Finset V} {S T : Set (W × (V → M))}
+theorem BaseSupported.inter {X : Finset V} {S T : Set (Possibility W V M)}
     (hS : BaseSupported X S) (hT : BaseSupported X T) : BaseSupported X (S ∩ T) :=
-  fun _ _ _ hfg => and_congr (hS hfg) (hT hfg)
+  baseSupported_of_iff fun _ _ _ hfg =>
+    and_congr (hS.mem_iff hfg) (hT.mem_iff hfg)
+
+/-! ### Information states -/
 
 /-- An information state ([kamp-vangenabith-reyle-2011], Defs. 22–23): a base
 `X` of live discourse referents together with an `X`-supported set of
-world–assignment pairs. -/
-@[ext] structure State (W : Type*) (V : Type*) (M : Type*) where
+possibilities. -/
+@[ext] structure State (W V M : Type*) where
   /-- The live discourse referents (the chapter's base `X`). -/
   base : Finset V
-  /-- The world–assignment pairs compatible with the information. -/
-  carrier : Set (W × (V → M))
+  /-- The possibilities compatible with the information. -/
+  carrier : Set (Possibility W V M)
   /-- Membership depends on assignments only through their values at `base`. -/
   supported : BaseSupported base carrier
 
 namespace State
 
-instance : Membership (W × (V → M)) (State W V M) :=
+instance : Membership (Possibility W V M) (State W V M) :=
   ⟨fun I p => p ∈ I.carrier⟩
 
-@[simp] theorem mem_carrier {I : State W V M} {p : W × (V → M)} :
+@[simp] theorem mem_carrier {I : State W V M} {p : Possibility W V M} :
     p ∈ I.carrier ↔ p ∈ I := Iff.rfl
 
 /-! ### The informativeness order -/
@@ -95,12 +129,13 @@ instance : PartialOrder (State W V M) where
 theorem le_def {I I' : State W V M} :
     I ≤ I' ↔ I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier := Iff.rfl
 
-/-- The chapter's projection form of Def. 25 — every pair of the stronger
-state restricts to one of the weaker — coincides with `≤`: support makes the
-projected witness the pair itself. -/
+/-- The chapter's projection form of Def. 25 — every possibility of the
+stronger state restricts to one of the weaker — coincides with `≤`: support
+makes the projected witness the possibility itself. -/
 theorem le_iff_projection {I I' : State W V M} :
     I ≤ I' ↔ I.base ⊆ I'.base ∧
-      ∀ ⦃w g⦄, (w, g) ∈ I' → ∃ f, (w, f) ∈ I ∧ Set.EqOn f g ↑I.base := by
+      ∀ ⦃w g⦄, (⟨w, g⟩ : Possibility W V M) ∈ I' →
+        ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑I.base := by
   constructor
   · rintro ⟨hb, hc⟩
     exact ⟨hb, fun w g hg => ⟨g, hc hg, Set.eqOn_refl g _⟩⟩
@@ -108,12 +143,12 @@ theorem le_iff_projection {I I' : State W V M} :
     refine ⟨hb, fun p hp => ?_⟩
     obtain ⟨w, g⟩ := p
     obtain ⟨f, hf, hfg⟩ := hproj hp
-    exact (I.supported hfg).mp hf
+    exact (I.supported.mem_iff hfg).mp hf
 
 /-- The minimal information state Λ ([kamp-vangenabith-reyle-2011],
 Def. 23(iv)): empty base, no information. -/
 instance : OrderBot (State W V M) where
-  bot := ⟨∅, Set.univ, fun _ _ _ _ => Iff.rfl⟩
+  bot := ⟨∅, Set.univ, fun _ _ _ _ => rfl⟩
   bot_le _ := ⟨Finset.empty_subset _, Set.subset_univ _⟩
 
 @[simp] theorem base_bot : (⊥ : State W V M).base = ∅ := rfl
@@ -141,18 +176,18 @@ instance : SemilatticeSup (State W V M) where
 @[simp] theorem carrier_sup (I I' : State W V M) :
     (I ⊔ I').carrier = I.carrier ∩ I'.carrier := rfl
 
-/-- The chapter's choice-function form of Def. 26: a pair belongs to the
-merge iff it restricts into each component — support makes the choice
-functions the pair itself. -/
+/-- The chapter's choice-function form of Def. 26: a possibility belongs to
+the merge iff it restricts into each component — support makes the choice
+functions the possibility itself. -/
 theorem mem_sup_iff {I I' : State W V M} {w : W} {h : V → M} :
-    (w, h) ∈ I ⊔ I' ↔
-      (∃ f, (w, f) ∈ I ∧ Set.EqOn f h ↑I.base) ∧
-      (∃ g, (w, g) ∈ I' ∧ Set.EqOn g h ↑I'.base) := by
+    (⟨w, h⟩ : Possibility W V M) ∈ I ⊔ I' ↔
+      (∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f h ↑I.base) ∧
+      (∃ g, (⟨w, g⟩ : Possibility W V M) ∈ I' ∧ Set.EqOn g h ↑I'.base) := by
   constructor
   · rintro ⟨hI, hI'⟩
     exact ⟨⟨h, hI, Set.eqOn_refl h _⟩, ⟨h, hI', Set.eqOn_refl h _⟩⟩
   · rintro ⟨⟨f, hf, hfh⟩, ⟨g, hg, hgh⟩⟩
-    exact ⟨(I.supported hfh).mp hf, (I'.supported hgh).mp hg⟩
+    exact ⟨(I.supported.mem_iff hfh).mp hf, (I'.supported.mem_iff hgh).mp hg⟩
 
 end Merge
 
@@ -160,43 +195,52 @@ end Merge
 
 /-- The proposition a state determines ([kamp-vangenabith-reyle-2011],
 Def. 23(v)): the worlds compatible with some assignment. -/
-def prop (I : State W V M) : Set W := Prod.fst '' I.carrier
+def prop (I : State W V M) : Set W := Possibility.world '' I.carrier
 
 theorem mem_prop {I : State W V M} {w : W} :
-    w ∈ I.prop ↔ ∃ f, (w, f) ∈ I := by
-  simp [prop, Prod.exists]
+    w ∈ I.prop ↔ ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I := by
+  constructor
+  · rintro ⟨⟨w', f⟩, hp, rfl⟩
+    exact ⟨f, hp⟩
+  · rintro ⟨f, hf⟩
+    exact ⟨⟨w, f⟩, hf, rfl⟩
 
 /-- Stronger states determine stronger propositions. -/
-theorem prop_anti {I I' : State W V M} (h : I ≤ I') : I'.prop ⊆ I.prop :=
-  Set.image_mono h.2
+theorem prop_anti : Antitone (prop : State W V M → Set W) :=
+  fun _ _ h => Set.image_mono h.2
 
 @[simp] theorem prop_bot [Nonempty M] : (⊥ : State W V M).prop = Set.univ := by
   ext w
-  exact ⟨fun _ => trivial, fun _ => ⟨(w, fun _ => Classical.arbitrary M), trivial, rfl⟩⟩
+  exact ⟨fun _ => trivial,
+    fun _ => ⟨⟨w, fun _ => Classical.arbitrary M⟩, trivial, rfl⟩⟩
 
 /-! ### Restriction to a smaller base -/
 
 /-- Restrict a state to base `Y`: the best `Y`-supported approximation — a
-pair survives iff some carrier member agrees with it on `Y`. -/
+possibility survives iff some carrier member agrees with it on `Y`. -/
 def restrict (I : State W V M) (Y : Finset V) : State W V M where
   base := Y
-  carrier := {p | ∃ f, (p.1, f) ∈ I.carrier ∧ Set.EqOn f p.2 ↑Y}
-  supported := fun _ _ _ hgg' =>
+  carrier :=
+    {p | ∃ f, (⟨p.world, f⟩ : Possibility W V M) ∈ I.carrier ∧
+      Set.EqOn f p.assignment ↑Y}
+  supported := baseSupported_of_iff fun _ _ _ hgg' =>
     exists_congr fun _ => and_congr_right fun _ =>
       ⟨fun h => h.trans hgg', fun h => h.trans hgg'.symm⟩
 
 @[simp] theorem base_restrict (I : State W V M) (Y : Finset V) :
     (I.restrict Y).base = Y := rfl
 
-theorem mem_restrict {I : State W V M} {Y : Finset V} {w : W} {g : V → M} :
-    (w, g) ∈ I.restrict Y ↔ ∃ f, (w, f) ∈ I ∧ Set.EqOn f g ↑Y := Iff.rfl
+@[simp] theorem mem_restrict {I : State W V M} {Y : Finset V} {w : W}
+    {g : V → M} :
+    (⟨w, g⟩ : Possibility W V M) ∈ I.restrict Y ↔
+      ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑Y := Iff.rfl
 
 /-- Restricting to the state's own base is the identity. -/
 @[simp] theorem restrict_base (I : State W V M) : I.restrict I.base = I := by
   ext1
   · rfl
   · ext ⟨w, g⟩
-    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported hfg).mp hf,
+    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported.mem_iff hfg).mp hf,
       fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
 
 /-- Restriction is transitive along shrinking bases. -/
@@ -214,7 +258,7 @@ theorem restrict_restrict (I : State W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
 /-- Restriction to a sub-base weakens the state. -/
 theorem restrict_le {I : State W V M} {Y : Finset V} (h : Y ⊆ I.base) :
     I.restrict Y ≤ I :=
-  ⟨h, fun p hp => ⟨p.2, hp, Set.eqOn_refl p.2 _⟩⟩
+  ⟨h, fun p hp => ⟨p.assignment, hp, Set.eqOn_refl p.assignment _⟩⟩
 
 end State
 

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -88,11 +88,11 @@ theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
 section Apply
 variable [DecidableEq V]
 
-/-- Forget the bases: the level-0 relation on world–assignment pairs (the
-world is preserved). -/
+/-- Forget the bases: the level-0 relation on possibilities (the world is
+preserved). -/
 def toUpdate (u : Transition W M X Y) :
-    Core.DynProp.Update (W × (V → M)) :=
-  fun p q => p.1 = q.1 ∧ u.rel p.1 p.2 q.2
+    Core.DynProp.Update (Possibility W V M) :=
+  fun p q => p.world = q.world ∧ u.rel p.world p.assignment q.assignment
 
 /-- Context change ([kamp-vangenabith-reyle-2011], Def. 24): the carrier is
 the level-0 `lift` of the forgotten relation; the base grows to
@@ -100,21 +100,22 @@ the level-0 `lift` of the forgotten relation; the base grows to
 def apply (u : Transition W M X Y) (I : State W V M) : State W V M where
   base := I.base ∪ Y
   carrier := lift u.toUpdate I.carrier
-  supported := by
-    intro w g g' hgg'
-    exact exists_congr fun p => and_congr_right fun _ => and_congr_right fun _ =>
+  supported := baseSupported_of_iff fun _ _ _ hgg' =>
+    exists_congr fun _ => and_congr_right fun _ => and_congr_right fun _ =>
       u.supported_right (hgg'.mono (by simp))
 
 @[simp] theorem apply_base (u : Transition W M X Y) (I : State W V M) :
     (u.apply I).base = I.base ∪ Y := rfl
 
 theorem mem_apply {u : Transition W M X Y} {I : State W V M} {w : W}
-    {g : V → M} : (w, g) ∈ u.apply I ↔ ∃ f, (w, f) ∈ I ∧ u.rel w f g := by
+    {g : V → M} :
+    (⟨w, g⟩ : Possibility W V M) ∈ u.apply I ↔
+      ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ u.rel w f g := by
   constructor
   · rintro ⟨⟨w', f⟩, hf, rfl, hr⟩
     exact ⟨f, hf, hr⟩
   · rintro ⟨f, hf, hr⟩
-    exact ⟨(w, f), hf, rfl, hr⟩
+    exact ⟨⟨w, f⟩, hf, rfl, hr⟩
 
 /-- Applying the identity transition is the identity, at the identity. -/
 @[simp] theorem apply_id (I : State W V M) (h : I.base = X) :
@@ -123,7 +124,7 @@ theorem mem_apply {u : Transition W M X Y} {I : State W V M} {w : W}
   · simp [h]
   · ext ⟨w, g⟩
     rw [State.mem_carrier, mem_apply]
-    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported (h ▸ hfg)).mp hf,
+    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported.mem_iff (h ▸ hfg)).mp hf,
       fun hg => ⟨g, hg, Set.eqOn_refl g _⟩⟩
 
 /-- `apply` is functorial: sequencing then applying is applying twice. -/
@@ -166,7 +167,7 @@ theorem le_apply [DecidableEq V] (u : Transition W M X Y) (hu : u.IsExtension)
   refine ⟨hbase ▸ Finset.subset_union_left, ?_⟩
   rintro ⟨w, g⟩ hg
   obtain ⟨f, hf, hr⟩ := mem_apply.mp hg
-  exact (I.supported ((hu hr).symm.mono (by rw [hbase]))).mp hf
+  exact (I.supported.mem_iff ((hu hr).symm.mono (by rw [hbase]))).mp hf
 
 end Transition
 


### PR DESCRIPTION
Adopts the architect RFC's carrier dissent and lands B3 stage 1:
- `State.carrier : Set (Possibility W V M)` with a named-fields `Possibility` point structure; `BaseSupported` derived from mathlib's `DependsOn`; `mem_prop` made definitional (`Filter.mem_map` pattern)
- `DRS/Based.lean`: base-threaded `toRelAt` (K&R persistence semantics — read-support is one line, no witness surgery; write-support needs exactly the referential presupposition `fv ⊆ X`), `DRS.transition : Transition X (X ∪ U)`, `DRS.state` via action on `⊥`