### PR TITLE
feat(Semantics/Dynamic/DRS): based semantics; DRS as spine transition

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1636,6 +1636,7 @@ import Linglib.Semantics.Dynamic.CDRT
 import Linglib.Semantics.Dynamic.ContextChange
 import Linglib.Semantics.Dynamic.ContextFilter
 import Linglib.Semantics.Dynamic.DPL
+import Linglib.Semantics.Dynamic.DRS.Based
 import Linglib.Semantics.Dynamic.DRS.Basic
 import Linglib.Semantics.Dynamic.DRS.Defs
 import Linglib.Semantics.Dynamic.DRS.Dynamics

--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -1,0 +1,199 @@
+import Linglib.Semantics.Dynamic.DRS.Basic
+import Linglib.Semantics.Dynamic.Transition
+
+/-!
+# Based relational semantics of DRSs
+[kamp-vangenabith-reyle-2011] (Defs. 19, 22, 24), [kamp-reyle-1993]
+
+The base-threaded verification semantics: `toRelAt X K f g` holds when the
+output `g` agrees with the input `f` *on the context base* `X` and verifies
+`K`'s conditions, sub-boxes entered at the grown base. This is the
+total-assignment rendering of K&R's partial-embedding semantics
+(Def. 19): values at established referents *persist* — contrast the flat
+`DRS.toRel` (`DRS/Dynamics.lean`), whose agree-off-universe clause freely
+reassigns re-declared referents (Muskens's fn. 4 divergence).
+
+Persistence is what makes the based semantics well-typed: `toRelAt X K` is
+read only at `X` (`toRelAt_congr_left` — one line, no witness surgery) and
+written only at `X ∪ U` (`toRelAt_congr_right`, given the *referential
+presupposition* `K.fv ⊆ X`), so a well-formed DRS denotes a spine
+`Transition X (X ∪ U)` (`DRS.transition`), and a proper DRS expresses an
+information state by acting on `⊥` (`DRS.state`, Def. 22).
+
+The Merging Lemma and the action equation for this semantics
+(`toRelAt_merge`, `state_merge`) are stated with the familiar freshness
+hypothesis; the based setting needs strictly less — only *capture* by
+sub-box universes is fatal, re-declaration is harmless — and the TODOs
+record the sharp side condition.
+
+## Main declarations
+
+* `DRS.toRelAt` / `Condition.holdsAt` — the base-threaded semantics.
+* `DRS.toRelAt_congr_left` / `toRelAt_congr_right` — read/write support.
+* `DRS.transition` — a DRS as a spine transition `X ⟶ X ∪ U`.
+* `DRS.state` — the information state a proper DRS expresses.
+-/
+
+open FirstOrder FirstOrder.Language
+open Semantics.Dynamic (Possibility State Transition baseSupported_of_iff)
+
+namespace DRT
+
+universe u v w x
+
+variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
+variable [DecidableEq V]
+
+/-! ### The base-threaded semantics -/
+
+mutual
+/-- Base-threaded relational semantics ([kamp-vangenabith-reyle-2011],
+Def. 19 in total-assignment form): the output agrees with the input *on the
+base* — established referents persist — and verifies the conditions, with
+sub-boxes entered at the grown base. -/
+def DRS.toRelAt (X : Finset V) : DRS L V → (V → M) → (V → M) → Prop
+  | .mk U conds => fun f g => Set.EqOn g f ↑X ∧ Condition.holdsAllAt (X ∪ U) conds g
+/-- A condition holds at a base under an assignment; sub-DRSs are entered as
+context extensions of the current base. -/
+def Condition.holdsAt (X : Finset V) : Condition L V → (V → M) → Prop
+  | .rel R args => fun g => Structure.RelMap R (fun i => g (args i))
+  | .eq u v => fun g => g u = g v
+  | .neg K => fun g => ¬ ∃ g', DRS.toRelAt X K g g'
+  | .imp a c => fun g => ∀ g', DRS.toRelAt X a g g' →
+      ∃ g'', DRS.toRelAt (X ∪ a.referents) c g' g''
+  | .dis l r => fun g => ∃ g', DRS.toRelAt X l g g' ∨ DRS.toRelAt X r g g'
+/-- Every condition in the list holds at the base. A `List` helper — the
+higher-order form fails the nested-inductive structural-recursion checker. -/
+def Condition.holdsAllAt (X : Finset V) : List (Condition L V) → (V → M) → Prop
+  | [] => fun _ => True
+  | c :: cs => fun g => Condition.holdsAt X c g ∧ Condition.holdsAllAt X cs g
+end
+
+/-! ### Structural simp API -/
+
+@[simp] theorem DRS.toRelAt_mk (X U : Finset V) (conds : List (Condition L V))
+    (f g : V → M) :
+    DRS.toRelAt X (.mk U conds) f g ↔
+      Set.EqOn g f ↑X ∧ Condition.holdsAllAt (X ∪ U) conds g := Iff.rfl
+
+@[simp] theorem Condition.holdsAt_rel (X : Finset V) {n : ℕ} (R : L.Relations n)
+    (args : Fin n → V) (g : V → M) :
+    (Condition.rel R args).holdsAt X g ↔
+      Structure.RelMap R (fun i => g (args i)) := Iff.rfl
+
+@[simp] theorem Condition.holdsAt_eq (X : Finset V) (u v : V) (g : V → M) :
+    (Condition.eq u v : Condition L V).holdsAt X g ↔ g u = g v := Iff.rfl
+
+@[simp] theorem Condition.holdsAt_neg (X : Finset V) (K : DRS L V) (g : V → M) :
+    (Condition.neg K).holdsAt X g ↔ ¬ ∃ g', DRS.toRelAt X K g g' := Iff.rfl
+
+@[simp] theorem Condition.holdsAt_imp (X : Finset V) (a c : DRS L V) (g : V → M) :
+    (Condition.imp a c).holdsAt X g ↔
+      ∀ g', DRS.toRelAt X a g g' →
+        ∃ g'', DRS.toRelAt (X ∪ a.referents) c g' g'' := Iff.rfl
+
+@[simp] theorem Condition.holdsAt_dis (X : Finset V) (l r : DRS L V) (g : V → M) :
+    (Condition.dis l r).holdsAt X g ↔
+      ∃ g', DRS.toRelAt X l g g' ∨ DRS.toRelAt X r g g' := Iff.rfl
+
+@[simp] theorem Condition.holdsAllAt_nil (X : Finset V) (g : V → M) :
+    Condition.holdsAllAt X ([] : List (Condition L V)) g := trivial
+
+@[simp] theorem Condition.holdsAllAt_cons (X : Finset V) (c : Condition L V)
+    (cs : List (Condition L V)) (g : V → M) :
+    Condition.holdsAllAt X (c :: cs) g ↔
+      Condition.holdsAt X c g ∧ Condition.holdsAllAt X cs g := Iff.rfl
+
+/-! ### Read and write support
+
+The based clauses only mention the input through the agreement conjunct, so
+read-support is one line — the flat semantics' piecewise witness surgery
+disappears. Write-support needs the referential presupposition `fv ⊆ X`
+only at the atomic clauses. -/
+
+/-- `toRelAt X K` reads its input only at `X`. -/
+theorem DRS.toRelAt_congr_left (X : Finset V) (K : DRS L V) {f f' g : V → M}
+    (h : Set.EqOn f f' ↑X) : DRS.toRelAt X K f g ↔ DRS.toRelAt X K f' g := by
+  obtain ⟨U, conds⟩ := K
+  simp only [DRS.toRelAt_mk]
+  exact and_congr_left fun _ => ⟨fun he => he.trans h, fun he => he.trans h.symm⟩
+
+/-- A condition with free referents in `X` depends on the assignment only at
+`X`. -/
+theorem Condition.holdsAt_congr {X : Finset V} (c : Condition L V)
+    (hfv : c.fv ⊆ X) {g g' : V → M} (hgg' : Set.EqOn g g' ↑X) :
+    Condition.holdsAt X c g ↔ Condition.holdsAt X c g' := by
+  match c with
+  | .rel R args =>
+    simp only [Condition.holdsAt_rel]
+    have : (fun i => g (args i)) = fun i => g' (args i) := by
+      funext i
+      exact hgg' (Finset.mem_coe.mpr (hfv (by simp)))
+    rw [this]
+  | .eq u v =>
+    simp only [Condition.holdsAt_eq]
+    rw [hgg' (Finset.mem_coe.mpr (hfv (by simp [Condition.fv_eq]))),
+      hgg' (Finset.mem_coe.mpr (hfv (by simp [Condition.fv_eq])))]
+  | .neg K =>
+    simp only [Condition.holdsAt_neg]
+    exact not_congr (exists_congr fun k => DRS.toRelAt_congr_left X K hgg')
+  | .imp a c =>
+    simp only [Condition.holdsAt_imp]
+    exact forall_congr' fun g₁ =>
+      imp_congr (DRS.toRelAt_congr_left X a hgg') Iff.rfl
+  | .dis l r =>
+    simp only [Condition.holdsAt_dis]
+    exact exists_congr fun k =>
+      or_congr (DRS.toRelAt_congr_left X l hgg') (DRS.toRelAt_congr_left X r hgg')
+
+/-- The list analogue of `Condition.holdsAt_congr`. -/
+theorem Condition.holdsAllAt_congr {X : Finset V} (cs : List (Condition L V))
+    (hfv : Condition.fvL cs ⊆ X) {g g' : V → M} (hgg' : Set.EqOn g g' ↑X) :
+    Condition.holdsAllAt X cs g ↔ Condition.holdsAllAt X cs g' := by
+  induction cs with
+  | nil => exact Iff.rfl
+  | cons c cs ih =>
+    rw [Condition.fvL_cons, Finset.union_subset_iff] at hfv
+    simp only [Condition.holdsAllAt_cons]
+    exact and_congr (Condition.holdsAt_congr c hfv.1 hgg') (ih hfv.2)
+
+/-- `toRelAt X K` writes its output only at `X ∪ U`, given the referential
+presupposition `K.fv ⊆ X`. -/
+theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.fv ⊆ X)
+    {f g g' : V → M} (hgg' : Set.EqOn g g' ↑(X ∪ K.referents)) :
+    DRS.toRelAt X K f g ↔ DRS.toRelAt X K f g' := by
+  obtain ⟨U, conds⟩ := K
+  rw [DRS.fv_mk, sdiff_le_iff] at hfv
+  rw [DRS.referents_mk] at hgg'
+  have hX : Set.EqOn g g' ↑X := hgg'.mono (by simp)
+  simp only [DRS.toRelAt_mk]
+  exact and_congr
+    ⟨fun he => hX.symm.trans he, fun he => hX.trans he⟩
+    (Condition.holdsAllAt_congr conds
+      (by rwa [sup_comm, Finset.sup_eq_union] at hfv) hgg')
+
+/-! ### A DRS as a spine transition -/
+
+/-- A well-formed DRS denotes a transition from its context base to the
+base grown by its universe — `K.fv ⊆ X` is the *referential presupposition*
+([kamp-vangenabith-reyle-2011], Def. 27(i)). -/
+def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V) (hK : K.fv ⊆ X) :
+    Transition W M X (X ∪ K.referents) where
+  rel _ f g := DRS.toRelAt X K f g
+  grow := Finset.subset_union_left
+  supported_left _ _ _ _ h := DRS.toRelAt_congr_left X K h
+  supported_right _ _ _ _ h := DRS.toRelAt_congr_right K hK h
+
+/-- Established referents persist along a DRS transition. -/
+theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
+    (hK : K.fv ⊆ X) : (K.transition (M := M) W X hK).IsExtension := by
+  intro w f g h
+  obtain ⟨U, conds⟩ := K
+  exact h.1
+
+/-- The information state a proper DRS expresses
+([kamp-vangenabith-reyle-2011], Def. 22): act on the minimal state. -/
+def DRS.state (W : Type*) (K : DRS L V) (hK : K.IsProper) : State W V M :=
+  (K.transition W ∅ (Finset.subset_empty.mpr hK)).apply ⊥
+
+end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -196,4 +196,233 @@ theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
 def DRS.state (W : Type*) (K : DRS L V) (hK : K.IsProper) : State W V M :=
   (K.transition W ∅ (Finset.subset_empty.mpr hK)).apply ⊥
 
+/-! ### Base invariance
+
+A fresh extension of the base is invisible to a well-formed condition. The
+only fatal interference is *capture* — a fresh referent colliding with a
+sub-box universe would freeze a previously local existential — so the
+hypothesis is disjointness from the occurring referents. Re-declaration of
+base referents needs no exclusion: persistence makes it inert. -/
+
+@[simp] theorem Condition.holdsAllAt_append (X : Finset V)
+    (cs ds : List (Condition L V)) (g : V → M) :
+    Condition.holdsAllAt X (cs ++ ds) g ↔
+      Condition.holdsAllAt X cs g ∧ Condition.holdsAllAt X ds g := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih => simp [ih, and_assoc]
+
+/-- Surgery: overriding a `toRelAt`-output with the input's values on a
+fresh `Δ` yields an output at the grown base, agreeing with the original on
+the working base. -/
+private theorem DRS.toRelAt_adjust {X Δ U : Finset V} {conds : List (Condition L V)}
+    (hΔU : Disjoint Δ U) (hfvc : Condition.fvL conds ⊆ X ∪ U)
+    (hIH : ∀ k : V → M, Condition.holdsAllAt ((X ∪ U) ∪ Δ) conds k ↔
+      Condition.holdsAllAt (X ∪ U) conds k)
+    {g k : V → M} (hk : DRS.toRelAt X (.mk U conds) g k) :
+    DRS.toRelAt (X ∪ Δ) (.mk U conds) g (fun x => if x ∈ Δ then g x else k x) ∧
+      Set.EqOn (fun x => if x ∈ Δ then g x else k x) k ↑(X ∪ U) := by
+  obtain ⟨hag, hh⟩ := hk
+  have hkk' : Set.EqOn (fun x => if x ∈ Δ then g x else k x) k ↑(X ∪ U) := by
+    intro x hx
+    by_cases hxΔ : x ∈ Δ
+    · have hxU : x ∉ U := Finset.disjoint_left.mp hΔU hxΔ
+      have hxX : x ∈ X := by
+        rcases Finset.mem_union.mp (Finset.mem_coe.mp hx) with h | h
+        · exact h
+        · exact absurd h hxU
+      simp only [if_pos hxΔ]
+      exact (hag (Finset.mem_coe.mpr hxX)).symm
+    · simp only [if_neg hxΔ]
+  refine ⟨⟨?_, ?_⟩, hkk'⟩
+  · intro x hx
+    by_cases hxΔ : x ∈ Δ
+    · simp only [if_pos hxΔ]
+    · have hxX : x ∈ X := by
+        rcases Finset.mem_union.mp (Finset.mem_coe.mp hx) with h | h
+        · exact h
+        · exact absurd h hxΔ
+      simp only [if_neg hxΔ]
+      exact hag (Finset.mem_coe.mpr hxX)
+  · rw [Finset.union_right_comm]
+    exact (hIH _).mpr ((Condition.holdsAllAt_congr conds hfvc hkk'.symm).mp hh)
+
+/-- Fresh base extensions discard: an output at the grown base is an output
+at the working base. -/
+private theorem DRS.toRelAt_down {X Δ U : Finset V} {conds : List (Condition L V)}
+    (hIH : ∀ k : V → M, Condition.holdsAllAt ((X ∪ U) ∪ Δ) conds k ↔
+      Condition.holdsAllAt (X ∪ U) conds k)
+    {g k : V → M} (hk : DRS.toRelAt (X ∪ Δ) (.mk U conds) g k) :
+    DRS.toRelAt X (.mk U conds) g k := by
+  obtain ⟨hag, hh⟩ := hk
+  refine ⟨hag.mono (Finset.coe_subset.mpr Finset.subset_union_left), ?_⟩
+  rw [Finset.union_right_comm] at hh
+  exact (hIH k).mp hh
+
+mutual
+/-- **Base invariance**: a fresh base extension is invisible to a well-formed
+condition. -/
+theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
+    (hocc : Disjoint Δ c.occ) (hfv : c.fv ⊆ X) (g : V → M) :
+    Condition.holdsAt (X ∪ Δ) c g ↔ Condition.holdsAt X c g := by
+  match c with
+  | .rel R args => exact Iff.rfl
+  | .eq u v => exact Iff.rfl
+  | .neg K =>
+    obtain ⟨U, conds⟩ := K
+    simp only [Condition.occ, DRS.occ] at hocc
+    rw [Condition.fv_neg, DRS.fv_mk, sdiff_le_iff] at hfv
+    obtain ⟨hΔU, hΔc⟩ := Finset.disjoint_union_right.mp hocc
+    have hfvc : Condition.fvL conds ⊆ X ∪ U := by
+      rwa [sup_comm, Finset.sup_eq_union] at hfv
+    have hIH : ∀ k : V → M, Condition.holdsAllAt ((X ∪ U) ∪ Δ) conds k ↔
+        Condition.holdsAllAt (X ∪ U) conds k :=
+      fun k => Condition.holdsAllAt_union_fresh conds hΔc hfvc k
+    simp only [Condition.holdsAt_neg]
+    exact not_congr ⟨fun ⟨k, hk⟩ => ⟨k, DRS.toRelAt_down hIH hk⟩,
+      fun ⟨k, hk⟩ => ⟨_, (DRS.toRelAt_adjust hΔU hfvc hIH hk).1⟩⟩
+  | .imp a c' =>
+    obtain ⟨Ua, ca⟩ := a
+    obtain ⟨Uc, cc⟩ := c'
+    simp only [Condition.occ, DRS.occ] at hocc
+    obtain ⟨ha, hc⟩ := Finset.disjoint_union_right.mp hocc
+    obtain ⟨hΔUa, hΔca⟩ := Finset.disjoint_union_right.mp ha
+    obtain ⟨hΔUc, hΔcc⟩ := Finset.disjoint_union_right.mp hc
+    rw [Condition.fv_imp, Finset.union_subset_iff] at hfv
+    obtain ⟨hfva, hfvc'⟩ := hfv
+    rw [DRS.fv_mk, sdiff_le_iff] at hfva
+    have hfvca : Condition.fvL ca ⊆ X ∪ Ua := by
+      rwa [sup_comm, Finset.sup_eq_union] at hfva
+    have hfvcc : Condition.fvL cc ⊆ (X ∪ Ua) ∪ Uc := by
+      intro x hx
+      by_cases hxUc : x ∈ Uc
+      · exact Finset.mem_union_right _ hxUc
+      · by_cases hxUa : x ∈ Ua
+        · exact Finset.mem_union_left _ (Finset.mem_union_right _ hxUa)
+        · refine Finset.mem_union_left _ (Finset.mem_union_left _ (hfvc' ?_))
+          rw [DRS.fv_mk, DRS.referents_mk, Finset.mem_sdiff, Finset.mem_sdiff]
+          exact ⟨⟨hx, hxUc⟩, hxUa⟩
+    have hIHa : ∀ k : V → M, Condition.holdsAllAt ((X ∪ Ua) ∪ Δ) ca k ↔
+        Condition.holdsAllAt (X ∪ Ua) ca k :=
+      fun k => Condition.holdsAllAt_union_fresh ca hΔca hfvca k
+    have hIHc : ∀ k : V → M, Condition.holdsAllAt (((X ∪ Ua) ∪ Uc) ∪ Δ) cc k ↔
+        Condition.holdsAllAt ((X ∪ Ua) ∪ Uc) cc k :=
+      fun k => Condition.holdsAllAt_union_fresh cc hΔcc hfvcc k
+    simp only [Condition.holdsAt_imp, DRS.referents_mk]
+    constructor
+    · intro hL g₁ hg₁
+      obtain ⟨hadj, heq⟩ := DRS.toRelAt_adjust hΔUa hfvca hIHa hg₁
+      obtain ⟨g₂, hg₂⟩ := hL _ hadj
+      rw [Finset.union_right_comm] at hg₂
+      refine ⟨g₂, (DRS.toRelAt_congr_left (X ∪ Ua) _ heq).mp ?_⟩
+      exact DRS.toRelAt_down hIHc hg₂
+    · intro hR g₁ hg₁
+      obtain ⟨g₂, hg₂⟩ := hR g₁ (DRS.toRelAt_down hIHa hg₁)
+      have hadj := (DRS.toRelAt_adjust hΔUc hfvcc hIHc hg₂).1
+      rw [Finset.union_right_comm] at hadj
+      exact ⟨_, hadj⟩
+  | .dis l r =>
+    obtain ⟨Ul, cl⟩ := l
+    obtain ⟨Ur, cr⟩ := r
+    simp only [Condition.occ, DRS.occ] at hocc
+    obtain ⟨hl, hr⟩ := Finset.disjoint_union_right.mp hocc
+    obtain ⟨hΔUl, hΔcl⟩ := Finset.disjoint_union_right.mp hl
+    obtain ⟨hΔUr, hΔcr⟩ := Finset.disjoint_union_right.mp hr
+    rw [Condition.fv_dis, Finset.union_subset_iff] at hfv
+    obtain ⟨hfvl, hfvr⟩ := hfv
+    rw [DRS.fv_mk, sdiff_le_iff] at hfvl hfvr
+    have hfvcl : Condition.fvL cl ⊆ X ∪ Ul := by
+      rwa [sup_comm, Finset.sup_eq_union] at hfvl
+    have hfvcr : Condition.fvL cr ⊆ X ∪ Ur := by
+      rwa [sup_comm, Finset.sup_eq_union] at hfvr
+    have hIHl : ∀ k : V → M, Condition.holdsAllAt ((X ∪ Ul) ∪ Δ) cl k ↔
+        Condition.holdsAllAt (X ∪ Ul) cl k :=
+      fun k => Condition.holdsAllAt_union_fresh cl hΔcl hfvcl k
+    have hIHr : ∀ k : V → M, Condition.holdsAllAt ((X ∪ Ur) ∪ Δ) cr k ↔
+        Condition.holdsAllAt (X ∪ Ur) cr k :=
+      fun k => Condition.holdsAllAt_union_fresh cr hΔcr hfvcr k
+    simp only [Condition.holdsAt_dis]
+    constructor
+    · rintro ⟨k, hk | hk⟩
+      · exact ⟨k, Or.inl (DRS.toRelAt_down hIHl hk)⟩
+      · exact ⟨k, Or.inr (DRS.toRelAt_down hIHr hk)⟩
+    · rintro ⟨k, hk | hk⟩
+      · exact ⟨_, Or.inl (DRS.toRelAt_adjust hΔUl hfvcl hIHl hk).1⟩
+      · exact ⟨_, Or.inr (DRS.toRelAt_adjust hΔUr hfvcr hIHr hk).1⟩
+/-- The list analogue of `Condition.holdsAt_union_fresh`. -/
+theorem Condition.holdsAllAt_union_fresh {X Δ : Finset V}
+    (cs : List (Condition L V)) (hocc : Disjoint Δ (Condition.occL cs))
+    (hfv : Condition.fvL cs ⊆ X) (g : V → M) :
+    Condition.holdsAllAt (X ∪ Δ) cs g ↔ Condition.holdsAllAt X cs g := by
+  match cs with
+  | [] => exact Iff.rfl
+  | c :: cs =>
+    simp only [Condition.occL] at hocc
+    obtain ⟨hc, hcs⟩ := Finset.disjoint_union_right.mp hocc
+    rw [Condition.fvL_cons, Finset.union_subset_iff] at hfv
+    simp only [Condition.holdsAllAt_cons]
+    exact and_congr (Condition.holdsAt_union_fresh c hc hfv.1 g)
+      (Condition.holdsAllAt_union_fresh cs hcs hfv.2 g)
+end
+
+/-! ### The Merging Lemma and the action equation -/
+
+/-- **Based Merging Lemma**: merge is sequencing. The side condition asks
+only that `K₂`'s universe not occur in `K₁`'s conditions (no *capture*);
+re-declaration of context or `K₁`-universe referents is allowed — persistence
+makes it inert. Contrast the flat lemma (`DRS.toRel_merge`), whose freshness
+hypothesis also had to forbid re-declaration. -/
+theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv ⊆ X)
+    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions))
+    (f g : V → M) :
+    DRS.toRelAt X (K₁.merge K₂) f g ↔
+      ∃ h, DRS.toRelAt X K₁ f h ∧ DRS.toRelAt (X ∪ K₁.referents) K₂ h g := by
+  obtain ⟨U₁, c₁⟩ := K₁
+  obtain ⟨U₂, c₂⟩ := K₂
+  rw [DRS.fv_mk, sdiff_le_iff] at h₁
+  have hfvc₁ : Condition.fvL c₁ ⊆ X ∪ U₁ := by
+    rwa [sup_comm, Finset.sup_eq_union] at h₁
+  simp only [DRS.referents_mk, DRS.conditions_mk] at hfresh
+  simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRelAt_mk,
+    Condition.holdsAllAt_append]
+  constructor
+  · rintro ⟨hag, hh₁, hh₂⟩
+    refine ⟨g, ⟨hag, ?_⟩, Set.eqOn_refl g _, ?_⟩
+    · rw [← Finset.union_assoc] at hh₁
+      exact (Condition.holdsAllAt_union_fresh c₁ hfresh hfvc₁ g).mp hh₁
+    · rwa [← Finset.union_assoc] at hh₂
+  · rintro ⟨h, ⟨hhf, hh₁⟩, hgh, hh₂⟩
+    refine ⟨fun x hx =>
+      (hgh ((Finset.coe_subset.mpr Finset.subset_union_left) hx)).trans (hhf hx),
+      ?_, ?_⟩
+    · rw [← Finset.union_assoc]
+      exact (Condition.holdsAllAt_union_fresh c₁ hfresh hfvc₁ g).mpr
+        ((Condition.holdsAllAt_congr c₁ hfvc₁ hgh).mpr hh₁)
+    · rwa [← Finset.union_assoc]
+
+/-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
+DRS's transition to the state a proper context DRS expresses yields the
+state of the merge. -/
+theorem DRS.state_merge (W : Type*) (K₁ K₂ : DRS L V) (h₁ : K₁.IsProper)
+    (h₂ : K₂.fv ⊆ K₁.referents)
+    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
+    (K₂.transition (M := M) W K₁.referents h₂).apply (K₁.state W h₁) =
+      (K₁.merge K₂).state W (DRS.isProper_merge h₁ h₂) := by
+  have hmerge := fun (e g : V → M) => DRS.toRelAt_merge (X := (∅ : Finset V)) K₁ K₂
+    (Finset.subset_empty.mpr h₁) hfresh e g
+  ext1
+  · ext x
+    simp [DRS.state, DRS.merge, Finset.mem_union]
+  · ext ⟨w, g⟩
+    simp only [State.mem_carrier, DRS.state, Transition.mem_apply]
+    constructor
+    · rintro ⟨f, ⟨e, -, he⟩, hr⟩
+      have hr' : DRS.toRelAt (∅ ∪ K₁.referents) K₂ f g := by
+        rw [Finset.empty_union]; exact hr
+      exact ⟨e, Set.mem_univ _, (hmerge e g).mpr ⟨f, he, hr'⟩⟩
+    · rintro ⟨e, -, he⟩
+      obtain ⟨f, hef, hfg⟩ := (hmerge e g).mp he
+      rw [Finset.empty_union] at hfg
+      exact ⟨f, ⟨e, Set.mem_univ _, hef⟩, hfg⟩
+
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -194,9 +194,30 @@ theorem Condition.fvL_subset_occL (cs : List (Condition L V)) :
       (Condition.fvL_subset_occL cs)
 end
 
+@[simp] theorem Condition.fvL_append (cs ds : List (Condition L V)) :
+    Condition.fvL (cs ++ ds) = Condition.fvL cs ∪ Condition.fvL ds := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih => simp [ih, Finset.union_assoc]
+
 /-- A DRS is *proper* iff it has no free discourse referent
 ([kamp-reyle-1993], Def. 1.4.2–1.4.3). -/
 def DRS.IsProper (K : DRS L V) : Prop := K.fv = ∅
+
+/-- Merging preserves properness when the increment's free referents are
+supplied by the context DRS's universe. -/
+theorem DRS.isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
+    (h₂ : K₂.fv ⊆ K₁.referents) : (K₁.merge K₂).IsProper := by
+  obtain ⟨U₁, c₁⟩ := K₁
+  obtain ⟨U₂, c₂⟩ := K₂
+  rw [DRS.IsProper, DRS.fv_mk, Finset.sdiff_eq_empty_iff_subset] at h₁
+  rw [DRS.fv_mk, DRS.referents_mk] at h₂
+  rw [DRS.merge, DRS.conditions_mk, DRS.referents_mk, DRS.IsProper, DRS.fv_mk,
+    Condition.fvL_append, Finset.sdiff_eq_empty_iff_subset]
+  refine Finset.union_subset (h₁.trans Finset.subset_union_left) fun x hx => ?_
+  by_cases hxU₂ : x ∈ U₂
+  · exact Finset.mem_union_right _ hxU₂
+  · exact Finset.mem_union_left _ (h₂ (Finset.mem_sdiff.mpr ⟨hx, hxU₂⟩))
 
 end Fv
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -195,24 +195,21 @@ end Merge
 
 /-- The proposition a state determines ([kamp-vangenabith-reyle-2011],
 Def. 23(v)): the worlds compatible with some assignment. -/
-def prop (I : State W V M) : Set W := Possibility.world '' I.carrier
+def prop (I : State W V M) : Set W := {w | ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I}
 
-theorem mem_prop {I : State W V M} {w : W} :
-    w ∈ I.prop ↔ ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I := by
-  constructor
-  · rintro ⟨⟨w', f⟩, hp, rfl⟩
-    exact ⟨f, hp⟩
-  · rintro ⟨f, hf⟩
-    exact ⟨⟨w, f⟩, hf, rfl⟩
+@[simp] theorem mem_prop {I : State W V M} {w : W} :
+    w ∈ I.prop ↔ ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I := Iff.rfl
+
+theorem prop_eq_image (I : State W V M) : I.prop = Possibility.world '' I.carrier :=
+  Set.ext fun _ => ⟨fun ⟨f, hf⟩ => ⟨⟨_, f⟩, hf, rfl⟩, fun ⟨⟨_, f⟩, hp, hw⟩ => ⟨f, hw ▸ hp⟩⟩
 
 /-- Stronger states determine stronger propositions. -/
 theorem prop_anti : Antitone (prop : State W V M → Set W) :=
-  fun _ _ h => Set.image_mono h.2
+  fun _ _ h _ ⟨f, hf⟩ => ⟨f, h.2 hf⟩
 
 @[simp] theorem prop_bot [Nonempty M] : (⊥ : State W V M).prop = Set.univ := by
   ext w
-  exact ⟨fun _ => trivial,
-    fun _ => ⟨⟨w, fun _ => Classical.arbitrary M⟩, trivial, rfl⟩⟩
+  exact ⟨fun _ => trivial, fun _ => ⟨fun _ => Classical.arbitrary M, trivial⟩⟩
 
 /-! ### Restriction to a smaller base -/
 


### PR DESCRIPTION
Recovers the commit stranded when #1437 merged mid-push, plus B3 stage 2 — the based-dynamics keystones:
- `DRS/Based.lean`: base-threaded `toRelAt` (K&R persistence), one-line read-support, write-support = referential presupposition; `DRS.transition`, `DRS.state`
- base-invariance mutual induction (`holdsAt_union_fresh`): fresh base extensions are invisible to well-formed conditions
- **based Merging Lemma** (`toRelAt_merge`): side condition is capture-only (`Disjoint K₂.referents (occL K₁.conditions)`) — re-declaration is allowed, strictly weaker than the flat lemma's freshness
- **action equation** (`state_merge`, KvGR p. 159): ⟦K⟧ᵈ(⟦Kᵢ⟧ˢ) = ⟦Kᵢ ⊎ K⟧ˢ
- `DRS.fv` API: `fvL_append`, `isProper_merge`; `State.prop` set-builder golf