### PR TITLE
feat(Semantics/Dynamic): Transition.copy; merging lemma on the spine

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -20,11 +20,11 @@ presupposition* `K.fv ⊆ X`), so a well-formed DRS denotes a spine
 `Transition X (X ∪ U)` (`DRS.transition`), and a proper DRS expresses an
 information state by acting on `⊥` (`DRS.state`, Def. 22).
 
-The Merging Lemma and the action equation for this semantics
-(`toRelAt_merge`, `state_merge`) are stated with the familiar freshness
-hypothesis; the based setting needs strictly less — only *capture* by
-sub-box universes is fatal, re-declaration is harmless — and the TODOs
-record the sharp side condition.
+The Merging Lemma for this semantics (`toRelAt_merge`) needs strictly less
+than the flat freshness hypothesis — only *capture* by sub-box universes is
+fatal, re-declaration is harmless — and lifts to the spine
+(`transition_merge`), where the action equation (`state_merge`) becomes an
+instance of functoriality (`Transition.apply_comp`).
 
 ## Main declarations
 
@@ -32,6 +32,8 @@ record the sharp side condition.
 * `DRS.toRelAt_congr_left` / `toRelAt_congr_right` — read/write support.
 * `DRS.transition` — a DRS as a spine transition `X ⟶ X ∪ U`.
 * `DRS.state` — the information state a proper DRS expresses.
+* `DRS.transition_merge` / `DRS.state_merge` — the Merging Lemma on the
+  spine and the action equation.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -188,6 +190,13 @@ theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
   intro w f g h
   obtain ⟨U, conds⟩ := K
   exact h.1
+
+/-- Repackaging a DRS transition along an equality of context bases is the
+transition at the new base. -/
+theorem DRS.transition_copy (W : Type*) {X X' : Finset V} (K : DRS L V)
+    (hX : X = X') (hK : K.fv ⊆ X) (hK' : K.fv ⊆ X') :
+    (K.transition (M := M) W X hK).copy hX (by rw [hX]) = K.transition W X' hK' := by
+  subst hX; rfl
 
 /-- The information state a proper DRS expresses
 ([kamp-vangenabith-reyle-2011], Def. 22): act on the minimal state. -/
@@ -398,27 +407,33 @@ theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv �
       (Condition.holdsAllAt_union_fresh c₁ hfresh hfvc₁ g).mpr
         ((Condition.holdsAllAt_congr c₁ hfvc₁ hgh).mpr hh₁), hh₂⟩
 
+/-- **Transition-level Merging Lemma**: sequencing the transitions is the
+merge's transition, repackaged along associativity of the grown bases. -/
+theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
+    (h₁ : K₁.fv ⊆ X) (h₂ : K₂.fv ⊆ X ∪ K₁.referents)
+    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
+    (K₁.transition (M := M) W X h₁).comp (K₂.transition W (X ∪ K₁.referents) h₂) =
+      ((K₁.merge K₂).transition W X (DRS.fv_merge_subset h₁ h₂)).copy rfl
+        (by rw [DRS.merge_referents, ← Finset.union_assoc]) := by
+  ext w f g
+  simp only [Transition.rel_copy, Transition.comp, DRS.transition,
+    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, Semantics.Dynamic.Core.DynProp.dseq]
+
 /-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
 DRS's transition to the state a proper context DRS expresses yields the
-state of the merge. -/
+state of the merge — an instance of `Transition.apply_comp` through the
+transition-level Merging Lemma. -/
 theorem DRS.state_merge (W : Type*) (K₁ K₂ : DRS L V) (h₁ : K₁.IsProper)
     (h₂ : K₂.fv ⊆ K₁.referents)
     (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
     (K₂.transition (M := M) W K₁.referents h₂).apply (K₁.state W h₁) =
       (K₁.merge K₂).state W (DRS.isProper_merge h₁ h₂) := by
-  have hmerge := DRS.toRelAt_merge (X := (∅ : Finset V)) (M := M) K₁ K₂
-    (Finset.subset_empty.mpr h₁) hfresh
-  ext1
-  · ext x
-    simp [DRS.merge, Finset.mem_union]
-  · ext ⟨w, g⟩
-    simp only [State.mem_carrier, Transition.mem_apply, DRS.mem_state, hmerge,
-      DRS.transition, Semantics.Dynamic.Core.DynProp.dseq, Relation.Comp,
-      Finset.empty_union]
-    constructor
-    · rintro ⟨f, ⟨e, he⟩, hr⟩
-      exact ⟨e, f, he, hr⟩
-    · rintro ⟨e, f, he, hr⟩
-      exact ⟨f, ⟨e, he⟩, hr⟩
+  simp only [DRS.state]
+  rw [← DRS.transition_copy (M := M) W K₂ (Finset.empty_union _)
+      (h₂.trans Finset.subset_union_right) h₂,
+    Transition.apply_copy, ← Transition.apply_comp,
+    DRS.transition_merge (M := M) W K₁ K₂ (Finset.subset_empty.mpr h₁)
+      (h₂.trans Finset.subset_union_right) hfresh,
+    Transition.apply_copy]
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -207,6 +207,18 @@ end
   | nil => simp
   | cons c cs ih => simp [ih, Finset.union_assoc]
 
+/-- Merging preserves boundedness: the merge's free referents are supplied by
+`X` when the context's are and the increment's are supplied by the grown base. -/
+theorem DRS.fv_merge_subset {X : Finset V} {K₁ K₂ : DRS L V} (h₁ : K₁.fv ⊆ X)
+    (h₂ : K₂.fv ⊆ X ∪ K₁.referents) : (K₁.merge K₂).fv ⊆ X := by
+  obtain ⟨U₁, c₁⟩ := K₁
+  obtain ⟨U₂, c₂⟩ := K₂
+  rw [DRS.referents_mk] at h₂
+  rw [DRS.fv_subset_iff] at h₁ h₂
+  rw [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.fv_subset_iff,
+    Condition.fvL_append, ← Finset.union_assoc]
+  exact Finset.union_subset (h₁.trans Finset.subset_union_left) h₂
+
 /-- A DRS is *proper* iff it has no free discourse referent
 ([kamp-reyle-1993], Def. 1.4.2–1.4.3). -/
 def DRS.IsProper (K : DRS L V) : Prop := K.fv = ∅
@@ -214,17 +226,9 @@ def DRS.IsProper (K : DRS L V) : Prop := K.fv = ∅
 /-- Merging preserves properness when the increment's free referents are
 supplied by the context DRS's universe. -/
 theorem DRS.isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
-    (h₂ : K₂.fv ⊆ K₁.referents) : (K₁.merge K₂).IsProper := by
-  obtain ⟨U₁, c₁⟩ := K₁
-  obtain ⟨U₂, c₂⟩ := K₂
-  rw [DRS.IsProper, DRS.fv_mk, Finset.sdiff_eq_empty_iff_subset] at h₁
-  rw [DRS.fv_mk, DRS.referents_mk] at h₂
-  rw [DRS.merge, DRS.conditions_mk, DRS.referents_mk, DRS.IsProper, DRS.fv_mk,
-    Condition.fvL_append, Finset.sdiff_eq_empty_iff_subset]
-  refine Finset.union_subset (h₁.trans Finset.subset_union_left) fun x hx => ?_
-  by_cases hxU₂ : x ∈ U₂
-  · exact Finset.mem_union_right _ hxU₂
-  · exact Finset.mem_union_left _ (h₂ (Finset.mem_sdiff.mpr ⟨hx, hxU₂⟩))
+    (h₂ : K₂.fv ⊆ K₁.referents) : (K₁.merge K₂).IsProper :=
+  Finset.subset_empty.mp (DRS.fv_merge_subset (Finset.subset_empty.mpr h₁)
+    (h₂.trans Finset.subset_union_right))
 
 end Fv
 

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -143,6 +143,30 @@ theorem apply_comp (u : Transition W M X Y) (v : Transition W M Y Z)
 
 end Apply
 
+/-! ### Repackaging along base equalities
+
+The substrate-safe form of `eqToHom` conjugation (mathlib's `Filter.copy`
+pattern): composites whose indices differ by `Finset` identities — e.g.
+`(X ∪ U₁) ∪ U₂` against `X ∪ (U₁ ∪ U₂)` — are equated through `copy`, keeping
+cast-free statements everywhere below the category layer. -/
+
+/-- Repackage a transition along equalities of its bases. -/
+def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') :
+    Transition W M X' Y' :=
+  hX ▸ hY ▸ u
+
+@[simp] theorem rel_copy (u : Transition W M X Y) {X' Y' : Finset V}
+    (hX : X = X') (hY : Y = Y') : (u.copy hX hY).rel = u.rel := by
+  subst hX hY; rfl
+
+@[simp] theorem copy_rfl (u : Transition W M X Y) : u.copy rfl rfl = u := rfl
+
+/-- Application is invariant under repackaging. -/
+@[simp] theorem apply_copy [DecidableEq V] (u : Transition W M X Y)
+    {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') (I : State W V M) :
+    (u.copy hX hY).apply I = u.apply I := by
+  subst hX hY; rfl
+
 /-! ### Information growth (Def. 27) -/
 
 /-- A transition is an *extension* when outputs agree with inputs on the source


### PR DESCRIPTION
Filter.copy-pattern repackaging along base equalities, and its payoff: the Merging Lemma lifted to `Transition` (`DRS.transition_merge`), with the action equation `DRS.state_merge` re-derived as an `apply_comp` corollary. `DRS.fv_merge_subset` generalizes `isProper_merge`, which becomes a two-line corollary.