### PR TITLE
refactor(Semantics/Dynamic): home BUS at UpdateSemantics/Bilateral

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1631,7 +1631,7 @@ import Linglib.Semantics.Degree.Noun
 import Linglib.Semantics.Degree.Predicate
 import Linglib.Semantics.Degree.Quantifier
 import Linglib.Semantics.Dynamic.Lookup
-import Linglib.Semantics.Dynamic.Bilateral
+import Linglib.Semantics.Dynamic.UpdateSemantics.Bilateral
 import Linglib.Semantics.Dynamic.CDRT
 import Linglib.Semantics.Dynamic.ContextChange
 import Linglib.Semantics.Dynamic.Situation

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -58,7 +58,7 @@ incompatible ways:
 
 | Framework | DNE mechanism | File |
 |-----------|---------------|------|
-| Bilateral (BUS, [krahmer-muskens-1995], [elliott-sudo-2025]) | Two update channels (positive/negative); negation = swap | `Dynamic/Bilateral.lean`, `Studies/ElliottSudo2025.lean` |
+| Bilateral (BUS, [krahmer-muskens-1995], [elliott-sudo-2025]) | Two update channels (positive/negative); negation = swap | `Dynamic/UpdateSemantics/Bilateral.lean`, `Studies/ElliottSudo2025.lean` |
 | ICDRT ([hofmann-2025]) | Propositional drefs + complementation under flat update | `Studies/Hofmann2025.lean` |
 | TTR ([cooper-2023]) | Classical metalanguage reduction; negation is static | `Semantics/TypeTheoretic/` |
 

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -3,12 +3,16 @@ import Linglib.Core.Logic.Bilateral.Defs
 import Mathlib.Algebra.Group.Defs
 
 /-!
-# Bilateral Denotations
+# Bilateral Update Semantics
+[elliott-sudo-2025], [krahmer-muskens-1995]
 
-
-The bilateral denotation structure for dynamic semantics. Bilateral semantics
-tracks both positive and negative update dimensions, enabling Double Negation
-Elimination (DNE) and proper treatment of cross-disjunct anaphora.
+Bilateral Update Semantics (BUS, [elliott-sudo-2025]'s formulation, with
+[krahmer-muskens-1995]'s bilateral DRT as ancestor): update semantics where
+each sentence carries both a positive and a negative update dimension,
+enabling Double Negation Elimination (DNE) and cross-disjunct anaphora.
+Unlike the Veltman states of `UpdateSemantics/Basic.lean` (bare `Set W`),
+BUS states are possibility sets (`InfoState W E`) — they carry assignments,
+since anaphora is the target phenomenon.
 
 ## Insight
 

--- a/Linglib/Semantics/Truthmaker/Basic.lean
+++ b/Linglib/Semantics/Truthmaker/Basic.lean
@@ -329,7 +329,7 @@ variable {S : Type*}
 theorem neg_involutive : Function.Involutive (@neg S) := neg_neg
 
 /-- `BilProp S` carries an `InvolutiveNeg` structure — the same mathlib
-    abstraction satisfied by `Semantics/Dynamic/Bilateral.lean`'s
+    abstraction satisfied by `Semantics/Dynamic/UpdateSemantics/Bilateral.lean`'s
     `BilateralDen`. The two bilateral frameworks (state-based truthmaker,
     update-based dynamic) are unified at the swap-pair level by being
     instances of `InvolutiveNeg`. -/

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -342,7 +342,7 @@ how many negations wrap it.
 
 This is the architectural difference: CDRT uses *state* for binding;
 TTR uses *structure*. The bilateral DNE strategy
-(`Semantics/Dynamic/Bilateral.lean`) is a third
+(`Semantics/Dynamic/UpdateSemantics/Bilateral.lean`) is a third
 approach — bilateral DNE is structural at the *state* level (swap is
 involutive), distinct from TTR's structural-at-the-*type* level. The
 three are surveyed in `Dynamic/Update.lean`'s "three

--- a/Linglib/Studies/Dekker2012.lean
+++ b/Linglib/Studies/Dekker2012.lean
@@ -9,7 +9,7 @@ PLA (`Semantics/Dynamic/PLA/`, originating in [dekker-1994]) is the
 foundational system for dynamic semantics with explicit pronoun indices.
 This study verifies the formalized PLA's behavior on the canonical anaphora
 puzzles and contrasts it with Bilateral Update Semantics (BUS,
-`Bilateral.lean` and `Studies/ElliottSudo2025.lean`), which solves
+`UpdateSemantics/Bilateral.lean` and `Studies/ElliottSudo2025.lean`), which solves
 anaphora cases that PLA structurally cannot.
 
 **Caveat on the formalization**: the PLA substrate as formalized is
@@ -146,7 +146,7 @@ theorem bathroom_pla_has_domain :
 -- § 2. PLA vs BUS: architectural divergence
 -- ════════════════════════════════════════════════════════════════
 
-/-! BUS's bilateral substrate lives in `Semantics/Dynamic/Bilateral.lean`
+/-! BUS's bilateral substrate lives in `Semantics/Dynamic/UpdateSemantics/Bilateral.lean`
 with the type
 
 ```
@@ -157,7 +157,7 @@ structure BilateralDen (W E : Type*) where
 
 and negation as `def neg φ := { positive := φ.negative, negative := φ.positive }`.
 The DNE law `neg (neg φ) = φ` then holds by `rfl`
-(`BilateralDen.neg_neg` in `Bilateral.lean`).
+(`BilateralDen.neg_neg` in `UpdateSemantics/Bilateral.lean`).
 
 PLA and BUS use different `InfoState` parametrizations, so a single
 file cannot import both side-by-side. The BUS-side facts are stated

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.Bilateral
+import Linglib.Semantics.Dynamic.UpdateSemantics.Bilateral
 import Linglib.Semantics.Dynamic.DPL
 import Linglib.Data.Examples.ElliottSudo2025
 

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -4,7 +4,7 @@ import Linglib.Studies.Sauerland2003
 import Linglib.Semantics.Presupposition.PhiFeatures
 import Linglib.Semantics.Presupposition.MaximizePresupposition
 import Linglib.Semantics.Exhaustification.Presuppositional
-import Linglib.Semantics.Dynamic.Bilateral
+import Linglib.Semantics.Dynamic.UpdateSemantics.Bilateral
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.FinCases


### PR DESCRIPTION
Bilateral Update Semantics self-classifies as update semantics ([elliott-sudo-2025]: "Elliott's (2022, 2024) specific formulation of Bilateral Update Semantics"), so the file joins the framework family at `UpdateSemantics/Bilateral.lean` — freeing the bare `Bilateral` name, which collides with `Core/Logic/Bilateral` and BSML. The module docstring gains its missing citation line and states the carrier contrast with Veltman states (`InfoState W E` vs bare `Set W`: BUS carries assignments because anaphora is the target).