### PR TITLE
refactor(Semantics/Dynamic): unify namespaces into DynamicSemantics

### DIFF
--- a/Linglib/Discourse/Roles.lean
+++ b/Linglib/Discourse/Roles.lean
@@ -19,7 +19,7 @@ namespace Discourse
 open Semantics.Context
 
 /-- The two fundamental discourse participants. `.addressee` matches
-    `KContext.addressee` (not `.listener` as in `Semantics.Dynamic`). -/
+    `KContext.addressee` (not `.listener` as in `DynamicSemantics`). -/
 inductive DiscourseRole where
   | speaker
   | addressee

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -115,7 +115,7 @@ The key insight: this classification is DERIVED from the `PartialProp` produced 
 field of the PartialProp determines the classification.
 
 Postsuppositions (yǐwéi's ◇¬p) are output-context constraints, formalized
-separately in `Semantics.Dynamic.Postsupposition`.
+separately in `PPCDRT`.
 -/
 
 /--
@@ -353,7 +353,7 @@ their projective content is fundamentally different:
 
 1. **Not a presupposition**: [glass-2025] argues yǐwéi's falsity inference
    is a postsupposition (about output context) not presupposition (input).
-   Postsuppositions are formalized in `Semantics.Dynamic.Postsupposition`.
+   Postsuppositions are formalized in `PPCDRT`.
 
 2. **Different requirement**: yǐwéi requires CommonGround ◇ ¬p (CommonGround compatible with ¬p),
    not CommonGround ⊨ ¬p (CommonGround entails ¬p)

--- a/Linglib/Semantics/Dynamic/CDRT.lean
+++ b/Linglib/Semantics/Dynamic/CDRT.lean
@@ -21,9 +21,9 @@ the paper's derivations) and the weakest-precondition calculus live in
 `Studies/Muskens1996.lean`.
 -/
 
-namespace Semantics.Dynamic.CDRT
+namespace CDRT
 
-open Semantics.Dynamic.Core.DynProp
+open DynamicSemantics.DynProp
 
 /-- CDRT state: Muskens's type `s`, concretely an assignment `Nat → E`.
 His *registers* are the maps from states (see `dref`), not the states —
@@ -35,7 +35,7 @@ abbrev State (E : Type*) := Core.Assignment E
 
 /-- Register lookup as a Dynamic Ty2 dref: Muskens's type `se`,
 picking out the value stored at position `n`. -/
-def dref {E : Type*} (n : Nat) : Semantics.Dynamic.Core.Dref (State E) E :=
+def dref {E : Type*} (n : Nat) : DynamicSemantics.Dref (State E) E :=
   λ r => r n
 
 /-- Dynamic proposition (box, type `s(st)`): the relational `Update`
@@ -68,7 +68,7 @@ abbrev DProp.impl {E : Type*} (φ ψ : DProp E) : DProp E := test (dimpl φ ψ)
 /-- Dynamic disjunction as a test (SEM2, [muskens-1996] p. 148): the
 spine's `ddisj` via `test`. -/
 abbrev DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
-  test (Semantics.Dynamic.Core.DynProp.ddisj φ ψ)
+  test (DynamicSemantics.DynProp.ddisj φ ψ)
 
 /-- Truth at a state: the spine's `closure`. -/
 abbrev DProp.true_at {E : Type*} (φ : DProp E) (i : State E) : Prop :=
@@ -97,4 +97,4 @@ theorem DProp.ofStatic_true_at {E : Type*} (p : SProp E) (i : State E) :
   simp only [DProp.true_at, closure, DProp.ofStatic, test]
   exact ⟨λ ⟨_, rfl, h⟩ => h, λ h => ⟨i, rfl, h⟩⟩
 
-end Semantics.Dynamic.CDRT
+end CDRT

--- a/Linglib/Semantics/Dynamic/ContextChange.lean
+++ b/Linglib/Semantics/Dynamic/ContextChange.lean
@@ -21,7 +21,7 @@ operations (`CCP.negTest`, `CCP.might`, `CCP.must`) test the *whole*
 input state rather than filtering per-element.
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 open _root_.Core (Assignment)
 
@@ -70,7 +70,7 @@ theorem seq_id (u : CCP P) : u ;; id = u := rfl
 /-- CCPs form a monoid under sequential composition. Scoped because
 `CCP P` is an abbreviation for `Set P → Set P`: a global instance would
 attach `*`/`1` to a bare function type for every importer. Activate with
-`open scoped Semantics.Dynamic.Core.CCP`. -/
+`open scoped DynamicSemantics.CCP`. -/
 scoped instance : Monoid (CCP P) where
   mul := seq
   one := id
@@ -571,4 +571,4 @@ theorem updateFromSat_eq_lift_test {P φ : Type*} (sat : P → φ → Prop) (ψ 
 
 end RelationalBridge
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/DPL.lean
+++ b/Linglib/Semantics/Dynamic/DPL.lean
@@ -29,9 +29,9 @@ In DPL:
 3. DNE failure: ¬¬φ ≠ φ for anaphora (negation is a test)
 -/
 
-namespace Semantics.Dynamic.DPL
+namespace DPL
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 -- Placeholder: Full implementation TODO
 
@@ -430,4 +430,4 @@ theorem trueAt_eq_closure {E : Type*} (φ : DPLRel E) (g : Assignment E) :
 
 export DPLRel (atom conj exists_ neg impl disj forall_ close)
 
-end Semantics.Dynamic.DPL
+end DPL

--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -40,7 +40,7 @@ instance of functoriality (`Transition.apply_comp`).
 -/
 
 open FirstOrder FirstOrder.Language
-open Semantics.Dynamic (Possibility State Transition baseSupported_of_iff)
+open DynamicSemantics (Possibility State Transition baseSupported_of_iff)
 
 namespace DRT
 
@@ -399,7 +399,7 @@ theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv �
   funext f g
   apply propext
   simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRelAt_mk,
-    Condition.holdsAllAt_append, Semantics.Dynamic.Core.DynProp.dseq, Relation.Comp]
+    Condition.holdsAllAt_append, DynamicSemantics.DynProp.dseq, Relation.Comp]
   rw [← Finset.union_assoc]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩
@@ -420,7 +420,7 @@ theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
         (by rw [DRS.merge_referents, ← Finset.union_assoc]) := by
   ext w f g
   simp only [Transition.rel_copy, Transition.comp, DRS.transition,
-    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, Semantics.Dynamic.Core.DynProp.dseq]
+    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.DynProp.dseq]
 
 /-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
 DRS's transition to the state a proper context DRS expresses yields the

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -44,7 +44,7 @@ lowerCamel operation names (`dneg`, `dseq`, `closure`); the static face
 -/
 
 open FirstOrder FirstOrder.Language
-open Semantics.Dynamic.Core.DynProp (Update dneg dimpl ddisj closure dseq)
+open DynamicSemantics.DynProp (Update dneg dimpl ddisj closure dseq)
 
 namespace DRT
 

--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -48,10 +48,10 @@ distributive — unlike test-based dynamic negation that inspects whole
 states.
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 open Core (Assignment)
-open Core.DynProp
+open DynProp
 
 variable {W E : Type*}
 
@@ -668,8 +668,8 @@ theorem toDynProp_id_algebraic (c : IContext W E) :
 /-- ICDRT contexts expose the shared lookup interface at `M = Entity`
 (`Dynamic/Lookup.lean`), making ICDRT lookups comparable with the
 extensional (`M = Id`) and [charlow-2019] (`M = Set`) families. -/
-instance : Semantics.Dynamic.Context.HasFiberedLookup Entity
+instance : DynamicSemantics.HasFiberedLookup Entity
     (ICDRTAssignment W E) IVar W E where
   iLookup i v w := i.indiv v w
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/ICDRT/Defs.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Defs.lean
@@ -20,7 +20,7 @@ apparatus in `Studies/Hofmann2025.lean`. (The concept drefs of
 [krifka-2026] live with their consumer in `Studies/Krifka2026.lean`.)
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 /--
 Entities extended with the universal falsifier ⋆ ([brasoveanu-2006]; adopted
@@ -155,4 +155,4 @@ def updateProp (g : ICDRTAssignment W E) (p : PVar) (s : Set W) : ICDRTAssignmen
 
 end ICDRTAssignment
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Lookup.lean
+++ b/Linglib/Semantics/Dynamic/Lookup.lean
@@ -19,7 +19,7 @@ the family's file; the comparisons live in the studies that draw them
 (`Studies/Hofmann2025.lean`, `Studies/Charlow2019.lean`).
 -/
 
-namespace Semantics.Dynamic.Context
+namespace DynamicSemantics
 
 open _root_.Core (Assignment)
 
@@ -44,4 +44,4 @@ instance instAssignmentHasFiberedLookup (E : Type u) :
     HasFiberedLookup Id (Assignment E) Nat PUnit.{u + 1} E where
   iLookup g v _ := g v
 
-end Semantics.Dynamic.Context
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/PLA/Basic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Basic.lean
@@ -33,7 +33,7 @@ This distinction prevents variable clash and enables clean compositional semanti
 Uses `Finset.biUnion` instead of `List.foldl` for cleaner proofs.
 -/
 
-namespace Semantics.Dynamic.PLA
+namespace PLA
 
 open Classical
 
@@ -214,4 +214,4 @@ theorem Formula.resolve_no_pronouns (φ : Formula) (ρ : Resolution) :
   | conj φ ψ ih1 ih2 => simp [Formula.resolve, Formula.range, ih1, ih2]
   | exists_ i φ ih => exact ih
 
-end Semantics.Dynamic.PLA
+end PLA

--- a/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
@@ -24,10 +24,10 @@ For de re/de dicto distinctions:
 - A concept is an intensional way of identifying entities
 -/
 
-namespace Semantics.Dynamic.PLA
+namespace PLA
 
 open Classical
-open Semantics.Dynamic.Core.CCP
+open DynamicSemantics.CCP
 
 
 variable {E : Type*} [Nonempty E]
@@ -330,4 +330,4 @@ See `Semantics.Modality.Kratzer` for the full Kratzer framework with:
 - Galois connection (extension/intension duality)
 -/
 
-end Semantics.Dynamic.PLA
+end PLA

--- a/Linglib/Semantics/Dynamic/PLA/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Semantics.lean
@@ -25,10 +25,10 @@ M ⊨ φ means φ is true in M: for all assignments g, there exists a witness
 sequence ê such that M, g, ê ⊨ φ.
 -/
 
-namespace Semantics.Dynamic.PLA
+namespace PLA
 
 open Classical
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 
 /-- An assignment maps variable indices to entities -/
@@ -484,4 +484,4 @@ theorem formulaToDRS_correct (M : Model E) (φ : Formula) (g h : MergedAssignmen
 
 end Embedding
 
-end Semantics.Dynamic.PLA
+end PLA

--- a/Linglib/Semantics/Dynamic/PLA/Translation.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Translation.lean
@@ -12,7 +12,7 @@ PLA uses:
   `Poss E = Assignment E × Assignment E` (no worlds, explicit pronouns)
 
 Core uses:
-  `Possibility W E = { world : W, assignment : Assignment E }` (worlds, no pronouns)
+  `Possibility W ℕ E = { world : W, assignment : Assignment E }` (worlds, no pronouns)
 
 ## The Solution
 
@@ -20,7 +20,7 @@ Core uses:
 2. Core to PLA: split assignment, use trivial world
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 open _root_.Core (Assignment)
 
@@ -41,7 +41,7 @@ Embed PLA possibility into Core possibility.
 Uses Unit world and combines assignment/witnesses into single assignment.
 Pronouns are offset by a large constant to avoid collision.
 -/
-def PLAPoss.toCore {E : Type*} (p : PLAPoss E) : Possibility Unit E where
+def PLAPoss.toCore {E : Type*} (p : PLAPoss E) : Possibility Unit ℕ E where
   world := ()
   assignment := λ n =>
     if n < 1000 then p.assignment n  -- Variables: indices < 1000
@@ -57,7 +57,7 @@ Project Core possibility to PLA possibility.
 
 Discards world, splits assignment into variable/pronoun parts.
 -/
-def Possibility.toPLA {W E : Type*} (p : Possibility W E) : PLAPoss E where
+def Possibility.toPLA {W E : Type*} (p : Possibility W ℕ E) : PLAPoss E where
   assignment := λ n => p.assignment n
   witnesses := λ n => p.assignment (n + 1000)
 
@@ -105,13 +105,13 @@ def PLACCP (E : Type*) := PLAInfoState E → PLAInfoState E
 /--
 Lift PLA CCP to Core CCP.
 -/
-def PLACCP.toCoreCCP {E : Type*} (φ : PLACCP E) : CCP (Possibility Unit E) :=
+def PLACCP.toCoreCCP {E : Type*} (φ : PLACCP E) : CCP (Possibility Unit ℕ E) :=
   λ s => (φ (InfoState.toPLA s)).toCore
 
 /--
 Project Core CCP to PLA CCP (for Unit world).
 -/
-def CCP.toPLACCP {E : Type*} (φ : CCP (Possibility Unit E)) : PLACCP E :=
+def CCP.toPLACCP {E : Type*} (φ : CCP (Possibility Unit ℕ E)) : PLACCP E :=
   λ s => InfoState.toPLA (φ s.toCore)
 
 
@@ -146,4 +146,4 @@ Both PLA and Core can have bilateral variants.
 -/
 
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/PLA/Update.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Update.lean
@@ -21,12 +21,12 @@ import Linglib.Semantics.Dynamic.ContextChange
 - Dynamic conjunction: non-commutative, non-idempotent
 -/
 
-namespace Semantics.Dynamic.PLA
+namespace PLA
 
--- We use Core.CCP infrastructure directly via qualified names
+-- We use DynamicSemantics.CCP infrastructure directly via qualified names
 
 open Classical
-open Semantics.Dynamic.Core.CCP
+open DynamicSemantics.CCP
 
 
 /--
@@ -89,15 +89,15 @@ theorem Formula.content_conj {E : Type*} [Nonempty E] (M : Model E) (φ ψ : For
 /--
 PLA Possibility type: (assignment, witness sequence) pairs.
 
-This instantiates the generic Core.CCP framework for PLA.
+This instantiates the generic DynamicSemantics.CCP framework for PLA.
 -/
 abbrev Poss (E : Type*) := Assignment E × WitnessSeq E
 
 /--
 PLA satisfaction relation: possibility satisfies formula.
 
-This bridges PLA to the Core.CCP infrastructure, matching the signature
-`P → φ → Prop` expected by Core.updateFromSat.
+This bridges PLA to the DynamicSemantics.CCP infrastructure, matching the signature
+`P → φ → Prop` expected by DynamicSemantics.updateFromSat.
 -/
 def satisfiesPLA {E : Type*} [Nonempty E] (M : Model E) :
     Poss E → Formula → Prop :=
@@ -114,28 +114,28 @@ def Formula.satPoss {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
 /--
 An update is a Context Change Potential over PLA possibilities.
 
-We inherit the Monoid structure from `Core.CCP`:
-- Identity: `Core.CCP.id` (leaves state unchanged)
-- Composition: `Core.CCP.seq` (do u, then v), notation `;`
+We inherit the Monoid structure from `DynamicSemantics.CCP`:
+- Identity: `DynamicSemantics.CCP.id` (leaves state unchanged)
+- Composition: `DynamicSemantics.CCP.seq` (do u, then v), notation `;`
 - Associativity: guaranteed by the Monoid laws
 -/
-abbrev Update (E : Type*) := Core.CCP (Poss E)
+abbrev Update (E : Type*) := DynamicSemantics.CCP (Poss E)
 
 namespace Update
 
 variable {E : Type*}
 
-/-- Identity update: leaves state unchanged (from Core.CCP) -/
-abbrev id : Update E := Core.CCP.id
+/-- Identity update: leaves state unchanged (from DynamicSemantics.CCP) -/
+abbrev id : Update E := DynamicSemantics.CCP.id
 
-/-- Absurd update: always yields empty state (from Core.CCP) -/
-abbrev absurd : Update E := Core.CCP.absurd
+/-- Absurd update: always yields empty state (from DynamicSemantics.CCP) -/
+abbrev absurd : Update E := DynamicSemantics.CCP.absurd
 
--- Sequential composition notation comes from Core.CCP
--- infixl:70 " ;; " => Core.CCP.seq
+-- Sequential composition notation comes from DynamicSemantics.CCP
+-- infixl:70 " ;; " => DynamicSemantics.CCP.seq
 
-/-- Absurd before anything yields absurd output (from Core.CCP) -/
-theorem seq_absurd (u : Update E) : Core.CCP.seq u absurd = absurd := Core.CCP.seq_absurd u
+/-- Absurd before anything yields absurd output (from DynamicSemantics.CCP) -/
+theorem seq_absurd (u : Update E) : DynamicSemantics.CCP.seq u absurd = absurd := DynamicSemantics.CCP.seq_absurd u
 
 end Update
 
@@ -249,7 +249,7 @@ theorem Formula.dynConj_eq {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formu
 theorem Formula.mem_dynConj {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formula)
     (s : InfoState E) (g : Assignment E) (ê : WitnessSeq E) :
     (g, ê) ∈ (φ.dynConj M ψ) s ↔ (g, ê) ∈ s ∧ φ.sat M g ê ∧ ψ.sat M g ê := by
-  simp only [Formula.dynConj, Core.CCP.seq, Formula.mem_update]
+  simp only [Formula.dynConj, DynamicSemantics.CCP.seq, Formula.mem_update]
   tauto
 
 /--
@@ -261,7 +261,7 @@ theorem dynConj_static {E : Type*} [Nonempty E] (M : Model E)
     (_hφ : φ.domain = ∅) (_hψ : ψ.domain = ∅) :
     (φ.dynConj M ψ) s = (φ ⋀ ψ).update M s := by
   ext ⟨g, ê⟩
-  simp only [Formula.dynConj, Core.CCP.seq, Formula.mem_update, Formula.sat]
+  simp only [Formula.dynConj, DynamicSemantics.CCP.seq, Formula.mem_update, Formula.sat]
   tauto
 
 
@@ -313,11 +313,11 @@ theorem update_elim {E : Type*} [Nonempty E] (M : Model E) (s : InfoState E)
 
 
 /--
-PLA formula update equals Core.updateFromSat via satPoss.
+PLA formula update equals DynamicSemantics.updateFromSat via satPoss.
 -/
 theorem update_eq_updateFromSat {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
     (s : InfoState E) :
-    φ.update M s = Core.updateFromSat (satisfiesPLA M) φ s := rfl
+    φ.update M s = DynamicSemantics.updateFromSat (satisfiesPLA M) φ s := rfl
 
 /--
 Eliminativity: updates never add possibilities, only remove them.
@@ -325,29 +325,29 @@ Eliminativity: updates never add possibilities, only remove them.
 This is the fundamental property of dynamic semantics: information only grows.
 Every update is a subset of the input state.
 
-This follows from `Core.updateFromSat_eliminative`.
+This follows from `DynamicSemantics.updateFromSat_eliminative`.
 -/
 theorem update_eliminative {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
     (s : InfoState E) : φ.update M s ⊆ s :=
-  Core.updateFromSat_eliminative (satisfiesPLA M) φ s
+  DynamicSemantics.updateFromSat_eliminative (satisfiesPLA M) φ s
 
 /--
 PLA's formula update is eliminative in the Core sense.
 -/
 theorem update_isEliminative {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
-    Core.IsEliminative (φ.update M : Update E) :=
-  Core.updateFromSat_eliminative (satisfiesPLA M) φ
+    DynamicSemantics.IsEliminative (φ.update M : Update E) :=
+  DynamicSemantics.updateFromSat_eliminative (satisfiesPLA M) φ
 
 /--
 Monotonicity of update: larger input states yield larger output states.
 
 If s ⊆ t, then φ.update(s) ⊆ φ.update(t).
 
-This follows from `Core.updateFromSat_monotone`.
+This follows from `DynamicSemantics.updateFromSat_monotone`.
 -/
 theorem update_monotone {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
     (s t : InfoState E) (h : s ⊆ t) : φ.update M s ⊆ φ.update M t :=
-  Core.updateFromSat_monotone (satisfiesPLA M) φ h
+  DynamicSemantics.updateFromSat_monotone (satisfiesPLA M) φ h
 
 /--
 Support is downward closed: if t ⊆ s and s supports φ, then t supports φ.
@@ -415,7 +415,7 @@ theorem static_seq_is_intersection {E : Type*} [Nonempty E] (M : Model E)
     (φ ψ : Formula) (s : InfoState E)
     (_hφ : φ.domain = ∅) (_hψ : ψ.domain = ∅) :
     (φ.update M ;; ψ.update M) s = s ∩ φ.content M ∩ ψ.content M := by
-  simp only [Core.CCP.seq, contents_updates_equiv, Set.inter_assoc]
+  simp only [DynamicSemantics.CCP.seq, contents_updates_equiv, Set.inter_assoc]
 
 /-- Only ∃ introduces discourse referents. -/
 theorem dynamicity_source_exists (x : VarIdx) (φ : Formula) :
@@ -590,7 +590,7 @@ figure in the *membership condition*, not in the surviving possibilities. -/
 
 section UpdateAPI
 
-open Semantics.Dynamic.Core.CCP
+open DynamicSemantics.CCP
 
 variable {E : Type*} [Nonempty E]
 
@@ -623,7 +623,7 @@ theorem exists_domain_nonempty (x : VarIdx) (φ : Formula) :
 theorem seq_update_mem (M : Model E) (φ ψ : Formula) (s : InfoState E) (p : Poss E) :
     p ∈ (φ.update M ;; ψ.update M) s ↔
     p ∈ s ∧ φ.sat M p.1 p.2 ∧ ψ.sat M p.1 p.2 := by
-  simp only [Core.CCP.seq, Formula.update, InfoState.restrict, Set.mem_setOf_eq]
+  simp only [DynamicSemantics.CCP.seq, Formula.update, InfoState.restrict, Set.mem_setOf_eq]
   tauto
 
 /-- Sequential update as set comprehension. -/
@@ -663,4 +663,4 @@ theorem static_existential_local_scope (x : VarIdx) (φ ψ : Formula) :
 
 end UpdateAPI
 
-end Semantics.Dynamic.PLA
+end PLA

--- a/Linglib/Semantics/Dynamic/PPCDRT/Anaphora.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Anaphora.lean
@@ -42,7 +42,7 @@ the multi-reciprocal pairwise prediction, the Tracy/Matty/Chris case) live
 in `Studies/HaugDalrymple2020.lean`.
 -/
 
-namespace Semantics.Dynamic.PPCDRT
+namespace PPCDRT
 
 open Core
 
@@ -218,4 +218,4 @@ theorem maximizeAnaphora_implies_relation (φ : Nat → Nat → PPDRSCond E)
     (h : maximizeAnaphora φ uAnaph uAnt S Δ) :
     φ uAnaph uAnt S Δ := h.1
 
-end Semantics.Dynamic.PPCDRT
+end PPCDRT

--- a/Linglib/Semantics/Dynamic/PPCDRT/Cumulativity.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Cumulativity.lean
@@ -22,7 +22,7 @@ the structural identity that the original `Reference/Reciprocals.lean`
 docstring asserted as prose.
 -/
 
-namespace Semantics.Dynamic.PPCDRT
+namespace PPCDRT
 
 open Core
 open Semantics.Plurality.Cumulativity
@@ -99,4 +99,4 @@ theorem groupIdentityCond_iff_cumulative_eq [DecidableEq E]
     intro d
     rw [← hxa d, ← hxb d, h]
 
-end Semantics.Dynamic.PPCDRT
+end PPCDRT

--- a/Linglib/Semantics/Dynamic/PPCDRT/Defs.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Defs.lean
@@ -61,7 +61,7 @@ them into PPCDRT. Initial linglib consumer:
 single current consumer).
 -/
 
-namespace Semantics.Dynamic.PPCDRT
+namespace PPCDRT
 
 open Core
 
@@ -80,4 +80,4 @@ variable {E : Type u}
     without changing this signature. -/
 abbrev PPDRSCond (E : Type u) := PluralAssign E → Set Nat → Prop
 
-end Semantics.Dynamic.PPCDRT
+end PPCDRT

--- a/Linglib/Semantics/Dynamic/PartialTransformer.lean
+++ b/Linglib/Semantics/Dynamic/PartialTransformer.lean
@@ -36,7 +36,7 @@ dynamic conjunction, conditional, and disjunction
   `admits_pdisj_ofPartialProp` — the filtering connectives, derived
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 open Semantics.Presupposition
 
@@ -193,4 +193,4 @@ theorem admits_pneg_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :
 
 end PartialCCP
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Dynamic.ContextChange
 A *possibility* is a world paired with an assignment of discourse referents —
 the point type of dynamic semantics. This file holds the point object and its
 small coupled constructions: the pointwise API (`extend`, `agreeOn`,
-`sameWorld`), the register-form instances of the legacy `Core` spine
+`sameWorld`), the register-form instances
 (`Nat`-keyed assignments), the unbased set-of-possibilities vocabulary
 (`InfoState.definedAt`, `novelAt`, `worlds`, `subsistsIn`, `supports`), and
 the possibility-specific CCP constructors (`InfoState.update`,
@@ -17,7 +17,7 @@ The based information states built over possibilities live in `State.lean`;
 the generic level-0 CCP algebra in `ContextChange.lean`.
 -/
 
-namespace Semantics.Dynamic
+namespace DynamicSemantics
 
 /-! ### The point object -/
 
@@ -57,26 +57,18 @@ def extend [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
 
 end Possibility
 
-end Semantics.Dynamic
-
-namespace Semantics.Dynamic.Core
-
 open _root_.Core (Assignment)
 
-/-! ### Register-form instances (legacy `Core` spine)
+/-! ### Register-form information states
 
-The pre-2026-07 spine keys assignments by `Nat` registers
-(`Assignment E := Nat → E`); these abbrevs instantiate the general point
-object at `V := ℕ`. -/
-
-/-- A possibility with a register-form assignment. -/
-abbrev Possibility (W E : Type*) := Semantics.Dynamic.Possibility W ℕ E
+Register-keyed dynamic semantics (`Assignment E := Nat → E`) instantiates
+the point object at `V := ℕ`. -/
 
 /-- Information state: set of possibilities.
 
-This is `InfoStateOf (Possibility W E)` — a specialization of the
+This is `InfoStateOf (Possibility W ℕ E)` — a specialization of the
 generic `InfoStateOf` to world-assignment possibilities. -/
-abbrev InfoState (W : Type*) (E : Type*) := Set (Possibility W E)
+abbrev InfoState (W : Type*) (E : Type*) := Set (Possibility W ℕ E)
 
 namespace InfoState
 
@@ -86,7 +78,7 @@ variable {W E : Type*}
 def univ : InfoState W E := Set.univ
 
 /-- The absurd state: no possibilities. -/
-def empty : InfoState W E := (∅ : Set (Possibility W E))
+def empty : InfoState W E := (∅ : Set (Possibility W ℕ E))
 
 /-- State is consistent (non-empty). -/
 def consistent (s : InfoState W E) : Prop := s.Nonempty
@@ -96,7 +88,7 @@ def trivial (s : InfoState W E) : Prop := s = Set.univ
 
 /-- Variable x is defined in state s iff all possibilities agree on x's value. -/
 def definedAt (s : InfoState W E) (x : Nat) : Prop :=
-  ∀ p q : Possibility W E, p ∈ s → q ∈ s → p.assignment x = q.assignment x
+  ∀ p q : Possibility W ℕ E, p ∈ s → q ∈ s → p.assignment x = q.assignment x
 
 /-- The set of defined variables in a state. -/
 def definedVars (s : InfoState W E) : Set Nat :=
@@ -107,7 +99,7 @@ def novelAt (s : InfoState W E) (x : Nat) : Prop := ¬s.definedAt x
 
 /-- In a consistent state, novel means assignments actually disagree. -/
 theorem novelAt_iff_disagree (s : InfoState W E) (x : Nat) (hs : s.consistent) :
-    s.novelAt x ↔ ∃ p q : Possibility W E, p ∈ s ∧ q ∈ s ∧ p.assignment x ≠ q.assignment x := by
+    s.novelAt x ↔ ∃ p q : Possibility W ℕ E, p ∈ s ∧ q ∈ s ∧ p.assignment x ≠ q.assignment x := by
   constructor
   · intro h
     simp only [novelAt, definedAt] at h
@@ -269,31 +261,31 @@ end InfoState
 
 /-- Existential CCP: ∃x.φ introduces x then updates with φ. -/
 def CCP.exists_ {W E : Type*} (x : Nat) (domain : Set E)
-    (φ : CCP (Possibility W E)) : CCP (Possibility W E) :=
+    (φ : CCP (Possibility W ℕ E)) : CCP (Possibility W ℕ E) :=
   λ (s : InfoState W E) => φ (s.randomAssign x domain)
 
 /-- Existential with full domain -/
 def CCP.existsFull {W E : Type*} (x : Nat)
-    (φ : CCP (Possibility W E)) : CCP (Possibility W E) :=
+    (φ : CCP (Possibility W ℕ E)) : CCP (Possibility W ℕ E) :=
   λ (s : InfoState W E) => φ (s.randomAssignFull x)
 
 /--
 Lift a classical proposition to a CCP.
 -/
-def CCP.ofProp {W E : Type*} (φ : W → Prop) : CCP (Possibility W E) :=
+def CCP.ofProp {W E : Type*} (φ : W → Prop) : CCP (Possibility W ℕ E) :=
   λ (s : InfoState W E) => s⟦φ⟧
 
 /--
 Lift a predicate on entities (via variable lookup).
 -/
-def CCP.ofPred1 {W E : Type*} (p : E → W → Prop) (x : Nat) : CCP (Possibility W E) :=
+def CCP.ofPred1 {W E : Type*} (p : E → W → Prop) (x : Nat) : CCP (Possibility W ℕ E) :=
   λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) poss.world }
 
 /--
 Lift a binary predicate.
 -/
-def CCP.ofPred2 {W E : Type*} (p : E → E → W → Prop) (x y : Nat) : CCP (Possibility W E) :=
+def CCP.ofPred2 {W E : Type*} (p : E → E → W → Prop) (x y : Nat) : CCP (Possibility W ℕ E) :=
   λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) (poss.assignment y) poss.world }
 
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Situation.lean
+++ b/Linglib/Semantics/Dynamic/Situation.lean
@@ -19,7 +19,7 @@ eliminative-vs-generative dichotomy of [groenendijk-stokhof-veltman-1996]
   a Kleisli arrow (`Mood.dynSUBJ`).
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 open _root_.Core (Assignment)
 open _root_.Intensional (WorldTimeIndex)
@@ -258,4 +258,4 @@ theorem dynIntroduce_current_in_gen {W Time : Type*}
   obtain ⟨g, s, s', hc, h_gen, _, h_eq⟩ := h
   exact ⟨s, ⟨g, hc⟩, h_eq ▸ h_gen⟩
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -35,10 +35,6 @@ Under it the chapter's definitions collapse to order theory:
 bare set of possibilities; `State` adds the base. The transitions acting on
 these states live in `Transition.lean`.
 
-The namespace is `Semantics.Dynamic` (not the legacy `Semantics.Dynamic.Core`
-of the pre-2026-07 spine): the based layer starts the clean namespace the
-rest of the spine migrates into.
-
 ## Main declarations
 
 * `BaseSupported` — membership depends only on assignment values at `X`
@@ -49,7 +45,7 @@ rest of the spine migrates into.
   (presheaf restriction along base inclusion).
 -/
 
-namespace Semantics.Dynamic
+namespace DynamicSemantics
 
 variable {W V M : Type*}
 
@@ -249,4 +245,4 @@ theorem restrict_le {I : State W V M} {Y : Finset V} (h : Y ⊆ I.base) :
 
 end State
 
-end Semantics.Dynamic
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -28,9 +28,9 @@ carries them.
 * `Transition.IsExtension` / `le_apply` — Def. 27(ii): information growth.
 -/
 
-namespace Semantics.Dynamic
+namespace DynamicSemantics
 
-open Semantics.Dynamic.Core (lift)
+open DynamicSemantics (lift)
 
 variable {W V M : Type*} {X Y Z : Finset V}
 
@@ -91,7 +91,7 @@ variable [DecidableEq V]
 /-- Forget the bases: the level-0 relation on possibilities (the world is
 preserved). -/
 def toUpdate (u : Transition W M X Y) :
-    Core.DynProp.Update (Possibility W V M) :=
+    DynProp.Update (Possibility W V M) :=
   fun p q => p.world = q.world ∧ u.rel p.world p.assignment q.assignment
 
 /-- Context change ([kamp-vangenabith-reyle-2011], Def. 24): the carrier is
@@ -195,4 +195,4 @@ theorem le_apply [DecidableEq V] (u : Transition W M X Y) (hu : u.IsExtension)
 
 end Transition
 
-end Semantics.Dynamic
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Ty2.lean
+++ b/Linglib/Semantics/Dynamic/Ty2.lean
@@ -34,10 +34,10 @@ dref's as functions taking info states as arguments.
 - BUS: Dynamic Ty2 + bilateral (pos/neg) structure
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 -- Re-export the Update algebra so downstream code that opens
--- Semantics.Dynamic.Core continues to see Update, Condition, dseq, test, etc.
+-- DynamicSemantics continues to see Update, Condition, dseq, test, etc.
 export DynProp (Update Condition
   dseq test dneg dimpl ddisj closure
   valid entails
@@ -193,4 +193,4 @@ theorem specificDref_extend_invariant {S E : Type*} [AssignmentStructure S E]
   exact AssignmentStructure.extend_other i u (specificDref e) d h.symm
 
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -80,7 +80,7 @@ dynamic frameworks should declare which DNE strategy they adopt and
 link to one of these comparisons.
 -/
 
-namespace Semantics.Dynamic.Core.DynProp
+namespace DynamicSemantics.DynProp
 
 /-! ### Core types -/
 
@@ -226,7 +226,7 @@ theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
 test as unit (`dseq_assoc`, `test_dseq`, `dseq_test`). Scoped because
 `Update S` is an abbreviation for `S → S → Prop`: a global instance would
 attach `*`/`1` to the bare function type. Activate with
-`open scoped Semantics.Dynamic.Core.DynProp`; mathlib's
+`open scoped DynamicSemantics.DynProp`; mathlib's
 `WriterT (Update S) Id` then gets `Monad`/`LawfulMonad` for free. -/
 scoped instance : Monoid (Update S) where
   mul := dseq
@@ -280,4 +280,4 @@ theorem dseq_closure (D₁ D₂ : Update S) :
 
 end Theorems
 
-end Semantics.Dynamic.Core.DynProp
+end DynamicSemantics.DynProp

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
@@ -15,7 +15,7 @@ In Update Semantics:
 
 -/
 
-namespace Semantics.Dynamic.UpdateSemantics
+namespace UpdateSemantics
 
 open Classical
 
@@ -30,7 +30,7 @@ abbrev State (W : Type*) := Set W
 Update function: how a sentence modifies a state. This is the spine's
 `CCP W` (set-transformer context change potential) under Veltman's name.
 -/
-abbrev Update (W : Type*) := Core.CCP W
+abbrev Update (W : Type*) := DynamicSemantics.CCP W
 
 /--
 Propositional update: eliminate worlds where φ fails.
@@ -45,41 +45,41 @@ Conjunction: sequential update.
 
 ⟦φ ∧ ψ⟧ = ⟦ψ⟧ ∘ ⟦φ⟧
 
-Delegates to `Core.CCP.seq`.
+Delegates to `DynamicSemantics.CCP.seq`.
 -/
 def Update.conj {W : Type*} (φ ψ : Update W) : Update W :=
-  Core.CCP.seq φ ψ
+  DynamicSemantics.CCP.seq φ ψ
 
 /--
 Negation: complement within the input state.
 
 ⟦¬φ⟧(s) = s \ ⟦φ⟧(s)   ([veltman-1996])
 
-Delegates to `Core.CCP.neg`. The whole-state consistency test is
-`Core.CCP.negTest`.
+Delegates to `DynamicSemantics.CCP.neg`. The whole-state consistency test is
+`DynamicSemantics.CCP.negTest`.
 -/
 def Update.neg {W : Type*} (φ : Update W) : Update W :=
-  Core.CCP.neg φ
+  DynamicSemantics.CCP.neg φ
 
 /--
 Epistemic "might": compatibility test.
 
 ⟦might φ⟧(s) = s if ⟦φ⟧(s) ≠ ∅, else ∅
 
-Delegates to `Core.CCP.might`.
+Delegates to `DynamicSemantics.CCP.might`.
 -/
 noncomputable def Update.might {W : Type*} (φ : Update W) : Update W :=
-  Core.CCP.might φ
+  DynamicSemantics.CCP.might φ
 
 /--
 Epistemic "must": universal test.
 
 ⟦must φ⟧(s) = s if ⟦φ⟧(s) = s, else ∅
 
-Delegates to `Core.CCP.must`.
+Delegates to `DynamicSemantics.CCP.must`.
 -/
 noncomputable def Update.must {W : Type*} (φ : Update W) : Update W :=
-  Core.CCP.must φ
+  DynamicSemantics.CCP.must φ
 
 /--
 Might is a TEST: it doesn't change the state (if it passes).
@@ -87,7 +87,7 @@ Might is a TEST: it doesn't change the state (if it passes).
 theorem might_is_test {W : Type*} (φ : Update W) (s : State W)
     (h : (φ s).Nonempty) :
     Update.might φ s = s := by
-  simp [Update.might, Core.CCP.might, Core.CCP.guard, h]
+  simp [Update.might, DynamicSemantics.CCP.might, DynamicSemantics.CCP.guard, h]
 
 /--
 Order matters for epistemic might.
@@ -106,15 +106,15 @@ theorem might_order_matters {W : Type*} [DecidableEq W] [Nontrivial W] :
   obtain ⟨w₁, w₂, hne⟩ := exists_pair_ne W
   refine ⟨fun w => w = w₁, inferInstance, {w₁, w₂}, ?_, ?_⟩
   · -- "p and might(not p)" fails: after learning p, only w₁ remains, and ¬p w₁ is false
-    simp only [Update.conj, Core.CCP.seq, Update.prop, Update.might, Core.CCP.might,
-      Core.CCP.guard]
+    simp only [Update.conj, DynamicSemantics.CCP.seq, Update.prop, Update.might, DynamicSemantics.CCP.might,
+      DynamicSemantics.CCP.guard]
     have h_not_nonempty :
         ¬({w ∈ {w ∈ ({w₁, w₂} : Set W) | w = w₁} | ¬w = w₁}).Nonempty := by
       rintro ⟨w, ⟨_, hw_p⟩, hw_np⟩; exact hw_np hw_p
     simp only [h_not_nonempty, ↓reduceIte]
   · -- "might(not p) and p" succeeds: might test passes on {w₁, w₂}, then p keeps w₁
-    simp only [Update.conj, Core.CCP.seq, Update.prop, Update.might, Core.CCP.might,
-      Core.CCP.guard]
+    simp only [Update.conj, DynamicSemantics.CCP.seq, Update.prop, Update.might, DynamicSemantics.CCP.might,
+      DynamicSemantics.CCP.guard]
     have h_nonempty : ({w ∈ ({w₁, w₂} : Set W) | ¬w = w₁}).Nonempty :=
       ⟨w₂, Or.inr rfl, hne.symm⟩
     simp only [h_nonempty, ↓reduceIte]
@@ -206,14 +206,14 @@ noncomputable def PUpdate.presup {W : Type*} (p φ : W → Prop) : PState W → 
       none
 
 /-- `PUpdate.presup` is the `Option`-valued shadow of
-    `Core.PartialCCP.ofPartialProp`: defined (≠ `none`) at `some s` exactly
+    `DynamicSemantics.PartialCCP.ofPartialProp`: defined (≠ `none`) at `some s` exactly
     when `s` admits the corresponding partial update. `PartialCCP` is the
     canonical `Part`-based form; this clause survives for the
     [yagi-2025] disjunction machinery below. -/
 theorem PUpdate.presup_ne_none_iff_admits {W : Type*} (p φ : W → Prop)
     (s : State W) :
     PUpdate.presup p φ (some s) ≠ none ↔
-      (Core.PartialCCP.ofPartialProp ⟨p, φ⟩).admits s := by
+      (DynamicSemantics.PartialCCP.ofPartialProp ⟨p, φ⟩).admits s := by
   simp only [PUpdate.presup]
   split_ifs with h
   · refine ⟨fun _ w hw => ?_, fun _ => Option.some_ne_none _⟩
@@ -342,4 +342,4 @@ theorem presup_disj_uninformative_when_supported {W : Type*}
     · exact Set.mem_union_left _ ⟨hw, hφ⟩
     · exact Set.mem_union_right _ ⟨⟨hw, fun h => hφ h.2⟩, hψ_sub w ⟨hw, fun h => hφ h.2⟩⟩
 
-end Semantics.Dynamic.UpdateSemantics
+end UpdateSemantics

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -49,7 +49,7 @@ against PLA (which lacks DNE for anaphora and fails on the bathroom
 sentence) is in `Studies/Dekker2012.lean`.
 -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 
 /--
@@ -124,12 +124,12 @@ theorem atom_negative_monotone (pred : W → Prop) :
 
 /-- Atomic positive update is eliminative. -/
 theorem atom_positive_eliminative (pred : W → Prop) :
-    IsEliminative (atom pred).positive (P := Possibility W E) :=
+    IsEliminative (atom pred).positive (P := Possibility W ℕ E) :=
   sep_eliminative _
 
 /-- Atomic negative update is eliminative. -/
 theorem atom_negative_eliminative (pred : W → Prop) :
-    IsEliminative (atom pred).negative (P := Possibility W E) :=
+    IsEliminative (atom pred).negative (P := Possibility W ℕ E) :=
   sep_eliminative _
 
 
@@ -392,12 +392,12 @@ theorem pred1_negative_monotone (p : E → W → Prop) [∀ e w, Decidable (p e 
 
 /-- pred1 positive update is eliminative. -/
 theorem pred1_positive_eliminative (p : E → W → Prop) [∀ e w, Decidable (p e w)] (t : Nat) :
-    IsEliminative (pred1 p t).positive (P := Possibility W E) :=
+    IsEliminative (pred1 p t).positive (P := Possibility W ℕ E) :=
   sep_eliminative _
 
 /-- pred1 negative update is eliminative. -/
 theorem pred1_negative_eliminative (p : E → W → Prop) [∀ e w, Decidable (p e w)] (t : Nat) :
-    IsEliminative (pred1 p t).negative (P := Possibility W E) :=
+    IsEliminative (pred1 p t).negative (P := Possibility W ℕ E) :=
   sep_eliminative _
 
 /-- pred2 positive update is monotone. -/
@@ -415,13 +415,13 @@ theorem pred2_negative_monotone (p : E → E → W → Prop) [∀ e₁ e₂ w, D
 /-- pred2 positive update is eliminative. -/
 theorem pred2_positive_eliminative (p : E → E → W → Prop) [∀ e₁ e₂ w, Decidable (p e₁ e₂ w)]
     (t₁ t₂ : Nat) :
-    IsEliminative (pred2 p t₁ t₂).positive (P := Possibility W E) :=
+    IsEliminative (pred2 p t₁ t₂).positive (P := Possibility W ℕ E) :=
   sep_eliminative _
 
 /-- pred2 negative update is eliminative. -/
 theorem pred2_negative_eliminative (p : E → E → W → Prop) [∀ e₁ e₂ w, Decidable (p e₁ e₂ w)]
     (t₁ t₂ : Nat) :
-    IsEliminative (pred2 p t₁ t₂).negative (P := Possibility W E) :=
+    IsEliminative (pred2 p t₁ t₂).negative (P := Possibility W ℕ E) :=
   sep_eliminative _
 
 
@@ -508,4 +508,4 @@ theorem neg_le_neg_iff (φ ψ : BilateralDen W E) : ~φ ≤ ~ψ ↔ φ ≤ ψ :=
 end BilateralDen
 
 
-end Semantics.Dynamic.Core
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
@@ -56,7 +56,7 @@ formalized in `Frames.lean` alongside this module.
 
 -/
 
-namespace Semantics.Dynamic.Default
+namespace UpdateSemantics.Default
 
 open Core.Order
 
@@ -412,4 +412,4 @@ theorem compatible_defaults_optimal (φ ψ : W → Prop) (d : Set W)
   exact hnφw ((Normality.refine_le.mp (hopt hvd hle)).2 hφv)
 
 
-end Semantics.Dynamic.Default
+end UpdateSemantics.Default

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Necessity.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Necessity.lean
@@ -67,7 +67,7 @@ maximal-element-induced world preorder
 instantiating them.
 -/
 
-namespace Semantics.Dynamic.Default.ExpState
+namespace UpdateSemantics.Default.ExpState
 
 open Core.Order
 
@@ -139,9 +139,9 @@ theorem boxLe_of_respects (σ : ExpState W) (p : W → Prop)
     (Normality.optimal_of_respects_connected σ.order p σ.info hresp hconn hex
       hw).2
 
-end Semantics.Dynamic.Default.ExpState
+end UpdateSemantics.Default.ExpState
 
-namespace Semantics.Dynamic.Default
+namespace UpdateSemantics.Default
 
 variable {W : Type*}
 
@@ -173,4 +173,4 @@ instance (σ : ExpState W) : NormalModality W σ.boxLe where
   necessitation := fun _ _ => trivial
   K _ _ hpq hp w hopt := hpq w hopt (hp w hopt)
 
-end Semantics.Dynamic.Default
+end UpdateSemantics.Default

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -45,7 +45,7 @@ namespace Mood
 
 open Core (Assignment)
 open Intensional (WorldTimeIndex)
-open HistoricalAlternatives Semantics.Dynamic.Core
+open HistoricalAlternatives DynamicSemantics
 
 variable {W Time : Type*} [LE Time] (history : HistoricalAlternatives W Time)
   (v : SVar) (c : SitContext W Time)

--- a/Linglib/Semantics/Mood/SpeechEvent.lean
+++ b/Linglib/Semantics/Mood/SpeechEvent.lean
@@ -46,7 +46,7 @@ so the inquisitive route induces the initial state. Binding height
 
 namespace Mood
 
-open Semantics.Dynamic.Default
+open UpdateSemantics.Default
 open Semantics.Modality (ModalFlavor)
 open HasTarget (target)
 open Semantics.Modality.EventRelativity (EventProjection)

--- a/Linglib/Semantics/Mood/State.lean
+++ b/Linglib/Semantics/Mood/State.lean
@@ -60,7 +60,7 @@ embedding.
 
 namespace Mood
 
-open Semantics.Dynamic.Default
+open UpdateSemantics.Default
 
 /-- The mood state: an `ExpState` enriched with an inquiry partition
 recording the open question (`⊤` is "no question"). -/

--- a/Linglib/Semantics/Mood/Verbal.lean
+++ b/Linglib/Semantics/Mood/Verbal.lean
@@ -42,7 +42,7 @@ complementation.
 
 namespace Mood
 
-open Semantics.Dynamic.Default
+open UpdateSemantics.Default
 open HasTarget (target)
 
 variable {W : Type*}

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -46,7 +46,7 @@ points. References: [heim-1983], [schlenker-2009], [von-fintel-1999],
 ## Implementation notes
 
 `PartialProp W` is parametric over the evaluation point. Common instantiations:
-`PartialProp World` (classical possible worlds), `PartialProp (Possibility W E)`
+`PartialProp World` (classical possible worlds), `PartialProp (Possibility W ℕ E)`
 (dynamic world-assignment pairs).
 
 The choice of connective system (how gaps behave under ∧/∨) is orthogonal

--- a/Linglib/Semantics/Reference/Almog2014.lean
+++ b/Linglib/Semantics/Reference/Almog2014.lean
@@ -288,7 +288,7 @@ theorem properName_deJure {C W E : Type*} (e : E) :
 
 /-! ## Bridge: PLA and the Frege Puzzle
 
-[dekker-2012]'s cover-relative belief framework (`Semantics.Dynamic.PLA`) gives a
+[dekker-2012]'s cover-relative belief framework (`PLA`) gives a
 formal mechanism for Frege puzzles: two concepts can co-refer at the actual
 world but diverge in belief-accessible worlds. This is exactly the scenario
 where proper names have the same referent but different cognitive significance.

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -37,7 +37,7 @@ intrinsic presupposition is layered on separately in `toPartialProp`.
 The unification this core was built toward is realized by the seam lemma
 `PronounDenotation.interpPronoun_eq_iLookup`: the pronoun's static
 `interpPronoun` selector *is* the `M = Id` extensional-baseline instance of
-`Semantics.Dynamic.Context.HasFiberedLookup.iLookup`, modulo the `Option`
+`DynamicSemantics.HasFiberedLookup.iLookup`, modulo the `Option`
 partiality layer this signature adds. Static reference and dynamic
 (`Set`/`PMF`) anaphora therefore meet at one lookup interface on the static
 fiber, and bound pronouns share that selector with binding supplied externally

--- a/Linglib/Semantics/Reference/PluralityLicensing.lean
+++ b/Linglib/Semantics/Reference/PluralityLicensing.lean
@@ -38,7 +38,7 @@ substrate that defines `bindingCond`, `reciprocityCond`,
 
 namespace Semantics.Reference.PluralityLicensing
 
-open Semantics.Dynamic.PPCDRT
+open PPCDRT
 open Core
 
 universe u

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -93,7 +93,7 @@ higher-blast-radius stage makes `selector` itself functor-valued and *be*
 theorem interpPronoun_eq_iLookup {E W : Type} (i : ℕ) (g : Assignment E)
     (w : PUnit) :
     interpPronoun (E := E) (W := W) i g
-      = Semantics.Dynamic.Context.HasFiberedLookup.iLookup (M := Id) g i w :=
+      = DynamicSemantics.HasFiberedLookup.iLookup (M := Id) g i w :=
   rfl
 
 /-! ### Featural definedness tests -/

--- a/Linglib/Semantics/Reference/Reciprocals.lean
+++ b/Linglib/Semantics/Reference/Reciprocals.lean
@@ -65,7 +65,7 @@ distributive operators (§5) and logophoric antecedents (§6) — see
 
 namespace Semantics.Reference.Reciprocals
 
-open Semantics.Dynamic.PPCDRT
+open PPCDRT
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1: Anaphoric Relations ([higginbotham-1985], [williams-1991])

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -71,7 +71,7 @@ namespace Tense
 
 open _root_.Core (Assignment)
 open _root_.Intensional (WorldTimeIndex)
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 /--
 Dynamic PAST: lifts the static `precedes` relation to an eliminative

--- a/Linglib/Semantics/TypeTheoretic/Discourse.lean
+++ b/Linglib/Semantics/TypeTheoretic/Discourse.lean
@@ -176,15 +176,15 @@ theorem integrate_comm_eq_cg_add {W SignT : Type}
     (utt : SignT) (p : Set W) :
     (s.integrate utt (p :: s.commitments)).toCG = s.toCG.add p := rfl
 
-/-! ## Bridge to Semantics.Dynamic.Core.InfoState -/
+/-! ## Bridge to DynamicSemantics.InfoState -/
 
 /-- TTR's InfoState tracks discourse state via agenda/commitments.
-Semantics.Dynamic.Core.InfoState tracks possibilities (world + assignment).
+DynamicSemantics.InfoState tracks possibilities (world + assignment).
 Bridge: a TTR InfoState with `Set W` commitments induces a Core InfoState
 by filtering possibilities that satisfy all commitments. -/
 def InfoState.toCoreInfoState {W E SignT : Type}
     (s : InfoState SignT (List (Set W))) :
-    Set (_root_.Semantics.Dynamic.Core.Possibility W E) :=
+    Set (_root_.DynamicSemantics.Possibility W ℕ E) :=
   { p | s.commitments.Forall (p.world ∈ ·) }
 
 -- ============================================================================

--- a/Linglib/Studies/Abusch1997.lean
+++ b/Linglib/Studies/Abusch1997.lean
@@ -204,7 +204,7 @@ available "ways of thinking about" entities. -/
 section
 
 open Classical
-open _root_.Semantics.Dynamic.PLA
+open _root_.PLA
 
 variable {E : Type*} [Nonempty E]
 
@@ -838,7 +838,7 @@ theorem abusch_derives_temporal_de_re_full_metaphysical
 theorem pla_isAcquaintedWith_unifies_with_polymorphic
     {E : Type*} (individual : E)
     (C : Cover E)
-    (p : Semantics.Dynamic.PLA.Poss E) :
+    (p : PLA.Poss E) :
     isAcquaintedWith individual C p ↔
     Semantics.Reference.Acquaintance.isAcquaintedWith individual C p :=
   Iff.rfl

--- a/Linglib/Studies/Beaver2001/ABLE.lean
+++ b/Linglib/Studies/Beaver2001/ABLE.lean
@@ -52,10 +52,10 @@ since we don't model discourse markers.
 - **D45/MP5**: Entailment — equivalent to `CCP.entails` (eliminativity makes guard redundant)
 -/
 
-namespace Semantics.Dynamic.ABLE
+namespace Beaver2001.ABLE
 
 open Classical
-open Semantics.Dynamic.Core (CCP InfoStateOf IsEliminative IsTest
+open DynamicSemantics (CCP InfoStateOf IsEliminative IsTest
   updateFromSat eliminative_seq test_eliminative)
 
 variable {P : Type*}
@@ -496,4 +496,4 @@ theorem satisfies_of_entails (φ ψ : Formula P) (σ : InfoStateOf P)
 
 end Formula
 
-end Semantics.Dynamic.ABLE
+end Beaver2001.ABLE

--- a/Linglib/Studies/Beaver2001/Basic.lean
+++ b/Linglib/Studies/Beaver2001/Basic.lean
@@ -57,7 +57,7 @@ function output.
 ## Formalization Coverage
 
 This file formalizes key results from Chs. 2-7. The ABLE fragment (Ch. 7)
-is formalized in `Semantics.Dynamic.ABLE.Basic` and demonstrated
+is formalized in `Beaver2001.ABLE.Basic` and demonstrated
 here via worked examples (§8). Quantifier projection (Ch. 8) and ABLE
 accommodation (Ch. 9) are not yet formalized. Quantifier projection is
 partially addressed by the `QuantifierProjection` type in
@@ -372,7 +372,7 @@ context updates. The core operations map to `ContextSet` operations:
 - **Conditional** σ[φ → ψ] = σ \ (σ[φ] \ σ[φ][ψ]) (residual)
 
 PUL conjunction is exactly CCP sequential composition
-(`CCP.seq` from `Semantics.Dynamic.Core.CCP`).
+(`CCP.seq` from `DynamicSemantics.CCP`).
 PUL negation differs from CCP's test-based negation:
 PUL computes the complement within the input state, while CCP
 negation passes or fails the entire state.
@@ -448,7 +448,7 @@ theorem pulImpl_atomic (p q : Set W) (σ : ContextSet W) (w : W) :
 
 /-! ### ABLE Fragment Demonstrations
 
-The ABLE formalization in `Semantics.Dynamic.ABLE.Basic` provides
+The ABLE formalization in `Beaver2001.ABLE.Basic` provides
 the `Formula` type and its evaluation semantics. Here we instantiate it
 with the Spaceman Spiff scenario from §6 to demonstrate projection through
 negation and conditionals.
@@ -468,7 +468,7 @@ This is why presupposition projection is asymmetric for conjunction:
 in `φ AND ψ`, σ must admit φ, and σ[φ] must admit ψ — so ψ's presupposition
 can be "filtered" by φ's content. -/
 
-open Semantics.Dynamic.ABLE (Formula)
+open Beaver2001.ABLE (Formula)
 
 section ABLEExamples
 

--- a/Linglib/Studies/Beck2001.lean
+++ b/Linglib/Studies/Beck2001.lean
@@ -83,7 +83,7 @@ namespace Beck2001
 
 open Semantics.Plurality.Cumulativity
 open Semantics.Plurality.Reciprocal
-open Semantics.Dynamic.PPCDRT
+open PPCDRT
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1: Four Basic Reciprocal Readings (paper §2)

--- a/Linglib/Studies/Caie2023.lean
+++ b/Linglib/Studies/Caie2023.lean
@@ -345,7 +345,7 @@ The compositional context determines how context-sensitive expressions
 (indexicals, gradable adjectives, configurational predicates) are
 interpreted; the world determines matters of fact.
 
-Structurally analogous to `Possibility W E` in `Dynamic/Possibility.lean`
+Structurally analogous to `Possibility W V M` in `Dynamic/Possibility.lean`
 (⟨world, assignment⟩ pairs in dynamic semantics), but the non-world
 parameter is a compositional context rather than a variable assignment. -/
 structure ContextFragment (C W : Type*) where

--- a/Linglib/Studies/Charlow2014.lean
+++ b/Linglib/Studies/Charlow2014.lean
@@ -53,7 +53,7 @@ the dichotomy. Each of DPL, DRT, CDRT supplies one stateful framework.
 
 namespace Charlow2014
 
-open Semantics.Dynamic.CDRT (DProp State)
+open CDRT (DProp State)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. The dichotomy

--- a/Linglib/Studies/Charlow2019.lean
+++ b/Linglib/Studies/Charlow2019.lean
@@ -14,10 +14,10 @@ reduces to a single operator ↑ determining whether modified assignments
 are retained.
 -/
 
-namespace Semantics.Dynamic.Charlow2019
+namespace Charlow2019
 
 open DPL
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 /-- Truth at an assignment: K True at g ⟺ ∃h. K g h (Charlow's (7)). -/
 def trueAt {E : Type*} (K : DPLRel E) (g : Assignment E) : Prop :=
@@ -116,7 +116,7 @@ theorem antisymmetry_fails {E : Type*} [Nontrivial E] :
 abbrev State (W E : Type*) := Set (W × Assignment E)
 
 /-- Context change potential over Charlow's contexts. -/
-abbrev State.CCP (W E : Type*) := Semantics.Dynamic.Core.CCP (W × Assignment E)
+abbrev State.CCP (W E : Type*) := DynamicSemantics.CCP (W × Assignment E)
 
 /-- Non-distributive negation (28): removes from s points that survive φ. -/
 def stateNeg {W E : Type*} (φ : State.CCP W E) : State.CCP W E :=
@@ -271,7 +271,7 @@ fibered projection is lossy — the native joint state records which worlds
 pair with which assignments beyond what a single `(v, w)` query reveals;
 the `supportCollapse` bridge below collapses genuinely-uncertain states. -/
 instance instCharlowHasFiberedLookup (W E : Type) :
-    Semantics.Dynamic.Context.HasFiberedLookup Set (State W E) Nat W E where
+    DynamicSemantics.HasFiberedLookup Set (State W E) Nat W E where
   iLookup s v w := { e | ∃ g : Assignment E, (w, g) ∈ s ∧ g v = e }
 
 -- ════════════════════════════════════════════════════════════════
@@ -402,7 +402,7 @@ empty-set falsifier makes downstream lookup empty. -/
 section CylindricAlgebraBridges
 
 open Core.CylindricAlgebra
-open Semantics.Dynamic.DPL
+open DPL
 
 /-- Static existential truth = cylindrification.
 
@@ -423,4 +423,4 @@ theorem charlow_dynamic_eq_cylindrify {E : Type*}
 
 end CylindricAlgebraBridges
 
-end Semantics.Dynamic.Charlow2019
+end Charlow2019

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -67,9 +67,9 @@ Appendix B as a Writer monad.
 
 namespace Charlow2021
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 open Semantics.Composition.Continuation
-open scoped Semantics.Dynamic.Core.DynProp
+open scoped DynamicSemantics.DynProp
 
 /-! ### Witness models: the cumulative-reading puzzle
 
@@ -358,7 +358,7 @@ def reify (p : PostSupp S (Update S)) : Update S := dseq p.val p.postsup
 /-- Truth of a bi-dimensional meaning at an assignment (eq. 56): the reified
 update is true at `i` in the substrate sense. -/
 def trueAt (p : PostSupp S (Update S)) (i : S) : Prop :=
-  Semantics.Dynamic.Core.closure p.reify i
+  DynamicSemantics.closure p.reify i
 
 end PostSupp
 
@@ -406,7 +406,7 @@ variable {W E : Type*}
 abbrev State (W E : Type*) := Set (W × Core.Assignment E)
 
 /-- Context change potential over Charlow's contexts. -/
-abbrev State.CCP (W E : Type*) := Semantics.Dynamic.Core.CCP (W × Core.Assignment E)
+abbrev State.CCP (W E : Type*) := DynamicSemantics.CCP (W × Core.Assignment E)
 
 /-- Existential dref introduction at the state level (eq. 74): for each
 world–assignment pair in the context, non-deterministically extend the
@@ -589,7 +589,7 @@ every state-level CCP is distributive. Witness: the constant CCP
 yields `∅`. -/
 theorem dependent_indefinites_need_extra {W E : Type*} [Nonempty W] [Nonempty E] :
     ¬ ∀ (depIndef : State.CCP W E),
-      Semantics.Dynamic.Core.IsDistributive depIndef := by
+      DynamicSemantics.IsDistributive depIndef := by
   intro h
   have h0 := h (fun _ => Set.univ) ∅
   simp only [Set.mem_empty_iff_false, false_and, exists_false, Set.setOf_false] at h0

--- a/Linglib/Studies/Charlow2025.lean
+++ b/Linglib/Studies/Charlow2025.lean
@@ -397,7 +397,7 @@ class DynamicTruth (δ : Type u) (i : outParam (Type v))
 -- § 9. Substrate instance: the canonical DPL substrate
 -- ════════════════════════════════════════════════════════════════
 
-open Semantics.Dynamic.DPL
+open DPL
 
 /-- The DPL relational meaning type (`DPLRel E := (Nat → E) → (Nat → E) → Prop`)
 is a `DynamicSubstrate` via its native conjunction and negation. -/

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -178,8 +178,8 @@ the second is type-dependency (witnesses as structure). Both reduce
 to the same classical truth conditions.
 -/
 
-open Semantics.Dynamic.CDRT (DProp State SProp)
-open Semantics.Dynamic.Core.DynProp (closure dseq test dneg dimpl)
+open CDRT (DProp State SProp)
+open DynamicSemantics.DynProp (closure dseq test dneg dimpl)
 open Semantics.TypeTheoretic (Ppty PPpty Parametric IsTrue IsFalse propT)
 open Cooper2023Ch7 (purify purifyUniv)
 
@@ -198,7 +198,7 @@ def ttr_exists (P : E → Prop) : Type := (x : E) × propT (P x)
 the same truth conditions. Both reduce to `∃ x, P x`. -/
 theorem exists_equiv (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (cdrt_exists n P) i ↔ Nonempty (ttr_exists P) := by
-  simp only [DProp.true_at, Semantics.Dynamic.Core.DynProp.closure, cdrt_exists, DProp.seq, dseq, Relation.Comp, DProp.new,
+  simp only [DProp.true_at, DynamicSemantics.DynProp.closure, cdrt_exists, DProp.seq, dseq, Relation.Comp, DProp.new,
     DProp.ofStatic, test, ttr_exists]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, rfl, hp⟩
@@ -228,7 +228,7 @@ def ttr_donkey (P Q : E → Prop) : Type :=
 the same truth conditions. Both reduce to `∀ x, P x → Q x`. -/
 theorem donkey_equiv (n : Nat) (P Q : E → Prop) (i : State E) :
     DProp.true_at (cdrt_donkey n P Q) i ↔ Nonempty (ttr_donkey P Q) := by
-  simp only [DProp.true_at, Semantics.Dynamic.Core.DynProp.closure, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq, Relation.Comp,
+  simp only [DProp.true_at, DynamicSemantics.DynProp.closure, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq, Relation.Comp,
     DProp.new, DProp.ofStatic, test, ttr_donkey]
   constructor
   · rintro ⟨o, rfl, hall⟩
@@ -361,7 +361,7 @@ the *input* register (no binding). -/
 theorem dne_same_truth (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (DProp.neg (DProp.neg (cdrt_exists n P))) i ↔
     DProp.true_at (cdrt_exists n P) i := by
-  simp only [DProp.true_at, Semantics.Dynamic.Core.DynProp.closure, DProp.neg, test, dneg]
+  simp only [DProp.true_at, DynamicSemantics.DynProp.closure, DProp.neg, test, dneg]
   constructor
   · rintro ⟨_, rfl, h⟩
     exact Classical.byContradiction (λ hno => h ⟨i, rfl, hno⟩)

--- a/Linglib/Studies/DalrympleHaug2024.lean
+++ b/Linglib/Studies/DalrympleHaug2024.lean
@@ -48,7 +48,7 @@ cases, while the quantificational analysis fails for distributive operators
 namespace DalrympleHaug2024
 
 open Semantics.Reference.Reciprocals
-open Semantics.Dynamic.PPCDRT
+open PPCDRT
 open Core
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Dekker2012.lean
+++ b/Linglib/Studies/Dekker2012.lean
@@ -50,8 +50,8 @@ cannot be co-imported.
 
 namespace Dekker2012
 
-open Semantics.Dynamic.PLA
-open Semantics.Dynamic.Core.CCP
+open PLA
+open DynamicSemantics.CCP
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. PLA-side facts: domain vs witness asymmetry
@@ -88,7 +88,7 @@ theorem pla_seq_certifies_both {E : Type*} [Nonempty E] (M : Model E)
     (x : VarIdx) (φ ψ : Formula) (s : InfoState E) (p : Poss E)
     (hp : p ∈ ((Formula.exists_ x φ).update M ;; ψ.update M) s) :
     p ∈ (Formula.exists_ x φ).update M s ∧ ψ.sat M p.1 p.2 := by
-  simp only [Semantics.Dynamic.Core.CCP.seq] at hp
+  simp only [DynamicSemantics.CCP.seq] at hp
   constructor
   · exact update_eliminative M ψ _ hp
   · simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -45,8 +45,8 @@ Under these simplification conditions, the general FC preconditions
 
 namespace ElliottSudo2025
 
-open Semantics.Dynamic.Core
-open Semantics.Dynamic
+open DynamicSemantics
+open DynamicSemantics
 open Classical
 
 variable {W E : Type*}
@@ -132,7 +132,7 @@ prefix:max "□ᵇ" => box
 
 /-- Diamond positive is a test (returns s or ∅). -/
 theorem diamond_positive_isTest (φ : BUSDen W E) :
-    IsTest (◇ᵇφ).positive (P := Core.Possibility W E) := by
+    IsTest (◇ᵇφ).positive (P := Possibility W ℕ E) := by
   intro s
   show (if (φ.positive s).consistent then s else ∅) = s ∨
        (if (φ.positive s).consistent then s else ∅) = ∅
@@ -142,7 +142,7 @@ theorem diamond_positive_isTest (φ : BUSDen W E) :
 
 /-- Diamond negative is a test (returns s or ∅). -/
 theorem diamond_negative_isTest (φ : BUSDen W E) :
-    IsTest (◇ᵇφ).negative (P := Core.Possibility W E) := by
+    IsTest (◇ᵇφ).negative (P := Possibility W ℕ E) := by
   intro s
   show (if s ⪯ φ.negative s then s else ∅) = s ∨
        (if s ⪯ φ.negative s then s else ∅) = ∅
@@ -152,7 +152,7 @@ theorem diamond_negative_isTest (φ : BUSDen W E) :
 
 /-- Diamond positive is eliminative (from IsTest). -/
 theorem diamond_positive_eliminative (φ : BUSDen W E) :
-    IsEliminative (◇ᵇφ).positive (P := Core.Possibility W E) :=
+    IsEliminative (◇ᵇφ).positive (P := Possibility W ℕ E) :=
   test_eliminative _ (diamond_positive_isTest φ)
 
 /-- Diamond positive subset (convenience form). -/
@@ -162,7 +162,7 @@ theorem diamond_positive_subset (φ : BUSDen W E) (s : InfoState W E) :
 
 /-- Diamond negative is eliminative (from IsTest). -/
 theorem diamond_negative_eliminative (φ : BUSDen W E) :
-    IsEliminative (◇ᵇφ).negative (P := Core.Possibility W E) :=
+    IsEliminative (◇ᵇφ).negative (P := Possibility W ℕ E) :=
   test_eliminative _ (diamond_negative_isTest φ)
 
 /-- Diamond negative subset (convenience form). -/
@@ -172,12 +172,12 @@ theorem diamond_negative_subset (φ : BUSDen W E) (s : InfoState W E) :
 
 /-- Box positive is eliminative (□φ = ¬◇¬φ, so positive = diamond negative of ¬φ). -/
 theorem box_positive_eliminative (φ : BUSDen W E) :
-    IsEliminative (□ᵇφ).positive (P := Core.Possibility W E) :=
+    IsEliminative (□ᵇφ).positive (P := Possibility W ℕ E) :=
   diamond_negative_eliminative (BilateralDen.neg φ)
 
 /-- Box negative is eliminative. -/
 theorem box_negative_eliminative (φ : BUSDen W E) :
-    IsEliminative (□ᵇφ).negative (P := Core.Possibility W E) :=
+    IsEliminative (□ᵇφ).negative (P := Possibility W ℕ E) :=
   diamond_positive_eliminative (BilateralDen.neg φ)
 
 end BUSDen
@@ -349,9 +349,9 @@ because `¬¬φ = φ` (`dne_preserves_binding`), whereas in DPL negation is
 a test, so `¬¬∃xφ ≠ ∃xφ` and the discourse referent never escapes. -/
 theorem dpl_diverges_on_double_negation [Nontrivial E] :
     Examples.double_negation.judgment = .acceptable ∧
-    ∃ (x : Nat) (φ : Semantics.Dynamic.DPL.DPLRel E),
-      Semantics.Dynamic.DPL.DPLRel.neg (.neg (.exists_ x φ)) ≠ .exists_ x φ :=
-  ⟨rfl, Semantics.Dynamic.DPL.dpl_dne_fails_anaphora⟩
+    ∃ (x : Nat) (φ : DPL.DPLRel E),
+      DPL.DPLRel.neg (.neg (.exists_ x φ)) ≠ .exists_ x φ :=
+  ⟨rfl, DPL.dpl_dne_fails_anaphora⟩
 
 /-- Egli's theorem (positive): `(∃x.φ) ∧ ψ ⊆ ∃x(φ ∧ ψ)` for positive
 updates. The positive direction holds because conjunction sequences

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -718,8 +718,8 @@ existential introduction but the output state is a subset of the input.
 
 section BilateralBridge
 
-open Semantics.Dynamic.Core (BilateralDen Possibility InfoState)
-open Semantics.Dynamic.Core.BilateralDen (neg exists_ atom)
+open DynamicSemantics (BilateralDen Possibility InfoState)
+open DynamicSemantics.BilateralDen (neg exists_ atom)
 
 variable {W E : Type*}
 
@@ -737,7 +737,7 @@ structure NumberedDRef where
     possibilities from `s` where no domain element witnesses `φ`. -/
 theorem exists_negative_characterization
     (x : Nat) (domain : Set E) (φ : BilateralDen W E)
-    (s : InfoState W E) (p : Possibility W E) :
+    (s : InfoState W E) (p : Possibility W ℕ E) :
     p ∈ (exists_ x domain φ).negative s ↔
     p ∈ s ∧ ∀ e ∈ domain, (p.extend x e) ∉
       φ.positive (s.randomAssign x domain) := by
@@ -748,7 +748,7 @@ theorem exists_negative_characterization
     This is the bilateral analog of universal falsification. -/
 theorem neg_exists_positive
     (x : Nat) (domain : Set E) (φ : BilateralDen W E)
-    (s : InfoState W E) (p : Possibility W E) :
+    (s : InfoState W E) (p : Possibility W ℕ E) :
     p ∈ (neg (exists_ x domain φ)).positive s ↔
     p ∈ s ∧ ∀ e ∈ domain, (p.extend x e) ∉
       φ.positive (s.randomAssign x domain) := by

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -27,7 +27,7 @@ Dynamic Predicate Logic. *Linguistics and Philosophy* 14(1): 39-100.
 
 namespace GroenendijkStokhof1991
 
-open Semantics.Dynamic.DPL
+open DPL
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Cross-Sentential Anaphora (§2.1, §2.3)
@@ -179,7 +179,7 @@ section CylindricAlgebra
 
 open Core.CylindricAlgebra
 open Core (Assignment)
-open Semantics.Dynamic.Core.DynProp (closure)
+open DynamicSemantics.DynProp (closure)
 
 /-- **DPL existential = cylindrification.**
 

--- a/Linglib/Studies/HaugDalrymple2020.lean
+++ b/Linglib/Studies/HaugDalrymple2020.lean
@@ -68,7 +68,7 @@ docstrings here follow that attribution.
 namespace HaugDalrymple2020
 
 open Semantics.Reference.Reciprocals
-open Semantics.Dynamic.PPCDRT
+open PPCDRT
 open Core
 open Trivalent (dist metaAssert)
 open Semantics.Plurality.Cumulativity

--- a/Linglib/Studies/Heim1982/Basic.lean
+++ b/Linglib/Studies/Heim1982/Basic.lean
@@ -37,8 +37,8 @@ example rows in `Heim1982.Examples`.
 
 namespace Heim1982
 
-open Semantics.Dynamic.FileChangeSemantics
-open Semantics.Dynamic.Core
+open FileChangeSemantics
+open DynamicSemantics
 
 -- ════════════════════════════════════════════════════
 -- § 1. Model Setup
@@ -253,7 +253,7 @@ inductive ExEntity : Type where
 
 open ExWorld ExEntity
 
-instance : Nonempty (Possibility ExWorld ExEntity) :=
+instance : Nonempty (Possibility ExWorld ℕ ExEntity) :=
   ⟨⟨w₀, λ _ => john⟩⟩
 
 /-- Starting file: no discourse referents, all possibilities. -/

--- a/Linglib/Studies/Heim1982/FileChangeSemantics.lean
+++ b/Linglib/Studies/Heim1982/FileChangeSemantics.lean
@@ -50,7 +50,7 @@ existential quantification into the notion of truth itself.
 
 ## Relation to Core Infrastructure
 
-| This Module | `Semantics.Dynamic.Core` |
+| This Module | `DynamicSemantics` |
 |-------------|------------------------|
 | `HeimFile` | `InfoState W E` (enriched with a domain) |
 | `FCP` (partial) | `CCP` (total) |
@@ -58,9 +58,9 @@ existential quantification into the notion of truth itself.
 | familiarity guard | `InfoState.definedAt` |
 -/
 
-namespace Semantics.Dynamic.FileChangeSemantics
+namespace FileChangeSemantics
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 open Classical
 
 -- ════════════════════════════════════════════════════
@@ -163,7 +163,7 @@ updates also expand the domain: Dom(F + φ) = Dom(F) ∪ {i₁,...,iₙ}.
 We follow the modern convention where domain expansion is handled
 by `indef` only. This is equivalent in practice because every variable
 in an atomic predicate has been previously introduced. -/
-def atom (pred : Core.Possibility W E → Prop) : FCP W E :=
+def atom (pred : Possibility W ℕ E → Prop) : FCP W E :=
   λ F => some { dom := F.dom, sat := { p ∈ F.sat | pred p } }
 
 /-- Atomic predicate on world only. -/
@@ -333,7 +333,7 @@ theorem seq_id (φ : FCP W E) : FCP.seq φ FCP.id = φ := by
   cases φ F <;> rfl
 
 /-- Atomic updates preserve the domain. -/
-theorem atom_preserves_dom (pred : Core.Possibility W E → Prop) (F : HeimFile W E) :
+theorem atom_preserves_dom (pred : Possibility W ℕ E → Prop) (F : HeimFile W E) :
     (FCP.atom pred F).map (·.dom) = some F.dom := by
   simp [FCP.atom]
 
@@ -371,7 +371,7 @@ theorem cond_eq (φ ψ : FCP W E) :
 
 This is Principle (A): information only grows
 (possibilities only decrease). -/
-theorem atom_eliminative (pred : Core.Possibility W E → Prop)
+theorem atom_eliminative (pred : Possibility W ℕ E → Prop)
     (F : HeimFile W E) (F' : HeimFile W E)
     (h : FCP.atom pred F = some F') :
     F'.sat ⊆ F.sat := by
@@ -438,17 +438,17 @@ section Bridge
 variable {W E : Type*}
 
 /-- Lift a total CCP to a (total) FCP that preserves domain. -/
-def liftCCP (u : CCP (Core.Possibility W E)) : FCP W E :=
+def liftCCP (u : CCP (Possibility W ℕ E)) : FCP W E :=
   λ F => some { dom := F.dom, sat := u F.sat }
 
 /-- Lift preserves sequential composition. -/
-theorem liftCCP_seq (u v : CCP (Core.Possibility W E)) :
+theorem liftCCP_seq (u v : CCP (Possibility W ℕ E)) :
     liftCCP (CCP.seq u v) = FCP.seq (liftCCP u) (liftCCP v) := by
   funext F
   simp [liftCCP, FCP.seq, CCP.seq]
 
 /-- Lifted CCPs are always defined (total). -/
-theorem liftCCP_definedOn (u : CCP (Core.Possibility W E)) (F : HeimFile W E) :
+theorem liftCCP_definedOn (u : CCP (Possibility W ℕ E)) (F : HeimFile W E) :
     definedOn F (liftCCP u) :=
   ⟨{ dom := F.dom, sat := u F.sat }, rfl⟩
 
@@ -461,9 +461,9 @@ def resultSat (φ : FCP W E) (F : HeimFile W E) : Option (InfoState W E) :=
 /-- Lift an Update (relational meaning) to an FCP via the relational image.
 
 This connects FCPs to the relational algebra
-in `Core.DynProp`. The resulting FCP preserves domain and is always
+in `DynamicSemantics.DynProp`. The resulting FCP preserves domain and is always
 defined (total). -/
-def liftDRS (R : DynProp.Update (Core.Possibility W E)) : FCP W E :=
+def liftDRS (R : DynProp.Update (Possibility W ℕ E)) : FCP W E :=
   liftCCP (lift R)
 
 /-- `liftDRS` preserves sequential composition: lifting a relational
@@ -471,7 +471,7 @@ sequence equals sequencing lifted FCPs.
 
 This shows the FCS algebra homomorphically embeds the DynProp
 algebra — the unification underlying [muskens-1996]. -/
-theorem liftDRS_seq (R₁ R₂ : DynProp.Update (Core.Possibility W E)) :
+theorem liftDRS_seq (R₁ R₂ : DynProp.Update (Possibility W ℕ E)) :
     liftDRS (DynProp.dseq R₁ R₂) = FCP.seq (liftDRS R₁) (liftDRS R₂) := by
   simp only [liftDRS]
   rw [lift_dseq]
@@ -483,7 +483,7 @@ set_option linter.unusedSimpArgs false in
 FCS's `atom pred` = lifting `DynProp.test (λ p => pred p)`. This
 shows atomic FCPs are exactly the relational tests, connecting
 Principle (A) to the DynProp algebra. -/
-theorem atom_eq_liftDRS_test (pred : Core.Possibility W E → Prop) :
+theorem atom_eq_liftDRS_test (pred : Possibility W ℕ E → Prop) :
     FCP.atom pred = liftDRS (DynProp.test pred) := by
   funext F
   simp only [FCP.atom, liftDRS, liftCCP, lift, DynProp.test]
@@ -496,4 +496,4 @@ theorem atom_eq_liftDRS_test (pred : Core.Possibility W E → Prop) :
 
 end Bridge
 
-end Semantics.Dynamic.FileChangeSemantics
+end FileChangeSemantics

--- a/Linglib/Studies/Heim1983.lean
+++ b/Linglib/Studies/Heim1983.lean
@@ -160,14 +160,14 @@ theorem filtering_removes_trigger :
 /-! ### Filtering derived from partial CCPs
 
 [heim-1983]'s actual machinery: sentences denote *partial* context change
-potentials (`Semantics.Dynamic.Core.PartialCCP`), and admittance does the
+potentials (`DynamicSemantics.PartialCCP`), and admittance does the
 projection work. The conditional's CCP is admitted by every context — the
 antecedent's update satisfies the consequent's king-presupposition — while
 the bare consequent's CCP is not admitted by the full context. The
 filtering recorded in the trigger tables above is a theorem, not a table
 entry. -/
 
-open Semantics.Dynamic.Core in
+open DynamicSemantics in
 /-- Every context admits ⟦if the king exists, the king is bald⟧: the
     antecedent's update filters the consequent's presupposition
     ([heim-1983]'s conditional CCP). -/
@@ -180,7 +180,7 @@ theorem conditional_admitted_everywhere (c : Set KingWorld) :
   · trivial
   · exact ha
 
-open Semantics.Dynamic.Core in
+open DynamicSemantics in
 /-- The bare consequent ⟦the king is bald⟧ is NOT admitted by the full
     context: the `noKing` world fails the presupposition, which therefore
     projects. -/

--- a/Linglib/Studies/Hofmann2025.lean
+++ b/Linglib/Studies/Hofmann2025.lean
@@ -63,7 +63,7 @@ empirical applications.
 
 namespace Hofmann2025
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Empirical Data

--- a/Linglib/Studies/HollidayMandelkern2024.lean
+++ b/Linglib/Studies/HollidayMandelkern2024.lean
@@ -780,7 +780,7 @@ theorem hm_predicts_disjSyll_failure :
     semantics.
 
     Veltman 1996's update semantics predicts the opposite: order MATTERS.
-    `Semantics.Dynamic.UpdateSemantics.Basic.might_order_matters`
+    `UpdateSemantics.Basic.might_order_matters`
     proves that `p ∧ might ¬p` collapses to ∅ but `might ¬p ∧ p` does not,
     on any state with `Nontrivial W`.
 
@@ -814,15 +814,15 @@ theorem hm_veltman_disagree_on_wittgenstein_symmetry :
               (diamond epistemicScale (orthoNeg pathFrame propP)) x)) ∧
     -- Veltman side: some Bool state distinguishes the two orderings.
     (∃ p : Bool → Prop, ∃ _ : DecidablePred p,
-       ∃ s : Semantics.Dynamic.UpdateSemantics.State Bool,
-       Semantics.Dynamic.UpdateSemantics.Update.conj
-         (Semantics.Dynamic.UpdateSemantics.Update.prop p)
-         (Semantics.Dynamic.UpdateSemantics.Update.might
-           (Semantics.Dynamic.UpdateSemantics.Update.prop (fun w => ¬ p w))) s = ∅ ∧
-       (Semantics.Dynamic.UpdateSemantics.Update.conj
-         (Semantics.Dynamic.UpdateSemantics.Update.might
-           (Semantics.Dynamic.UpdateSemantics.Update.prop (fun w => ¬ p w)))
-         (Semantics.Dynamic.UpdateSemantics.Update.prop p) s).Nonempty) :=
-  ⟨hm_wittgenstein_symmetric, Semantics.Dynamic.UpdateSemantics.might_order_matters⟩
+       ∃ s : UpdateSemantics.State Bool,
+       UpdateSemantics.Update.conj
+         (UpdateSemantics.Update.prop p)
+         (UpdateSemantics.Update.might
+           (UpdateSemantics.Update.prop (fun w => ¬ p w))) s = ∅ ∧
+       (UpdateSemantics.Update.conj
+         (UpdateSemantics.Update.might
+           (UpdateSemantics.Update.prop (fun w => ¬ p w)))
+         (UpdateSemantics.Update.prop p) s).Nonempty) :=
+  ⟨hm_wittgenstein_symmetric, UpdateSemantics.might_order_matters⟩
 
 end HollidayMandelkern2024

--- a/Linglib/Studies/KampVanGenabithReyle2011.lean
+++ b/Linglib/Studies/KampVanGenabithReyle2011.lean
@@ -19,7 +19,7 @@ run against the based substrate (`Semantics/Dynamic/State.lean`,
 -/
 
 open FirstOrder FirstOrder.Language DRT
-open Semantics.Dynamic (Possibility State baseSupported_of_iff)
+open DynamicSemantics (Possibility State baseSupported_of_iff)
 
 namespace KampVanGenabithReyle2011
 

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -57,13 +57,13 @@ The abstract `AssignmentStructure` (`Dynamic/Ty2.lean`) takes drefs `S → E`,
 but only projection drefs `fun g => g n` make sense for concrete `Assignment E`.
 
 The DPL comparison below (`dpl_dne_fails_anaphora`) consumes these; they stay in
-`Semantics.Dynamic.Core` so they read as substrate names, awaiting promotion to
+`DynamicSemantics` so they read as substrate names, awaiting promotion to
 `Studies/GroenendijkStokhof1991.lean`. -/
 
-namespace Semantics.Dynamic.Core
+namespace DynamicSemantics
 
 open _root_.Core (Assignment)
-open Semantics.Dynamic.Core.DynProp
+open DynamicSemantics.DynProp
 
 variable {E : Type*}
 
@@ -118,13 +118,13 @@ def closeAt (φ : Update (Assignment E)) : Update (Assignment E) :=
 @[simp] theorem closeAt_eq (φ : Update (Assignment E)) :
     closeAt φ = test (closure φ) := rfl
 
-end Semantics.Dynamic.Core
+end DynamicSemantics
 
 
 namespace KeshetAbney2024
 
 open KeshetAbney2024.PIP
-open Semantics.Dynamic.Core (IVar ICDRTAssignment Entity IContext)
+open DynamicSemantics (IVar ICDRTAssignment Entity IContext)
 open Core.Logic.Modal (AccessRel)
 
 
@@ -1068,8 +1068,8 @@ theorem pip_quantifier_blocking :
 
 section DPLComparison
 
-open Semantics.Dynamic.Core (existsAt existsAt_iff)
-open Semantics.Dynamic.Core.DynProp (Update dneg test)
+open DynamicSemantics (existsAt existsAt_iff)
+open DynamicSemantics.DynProp (Update dneg test)
 open _root_.Core (Assignment)
 
 /-!

--- a/Linglib/Studies/KeshetAbney2024/Basic.lean
+++ b/Linglib/Studies/KeshetAbney2024/Basic.lean
@@ -47,7 +47,7 @@ external/local variable distinction) are faithfully preserved.
 
 namespace KeshetAbney2024.PIP
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 
 -- ============================================================

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -41,7 +41,7 @@ formalized here.
 namespace KeshetAbney2024.PIP.Bridges
 
 open KeshetAbney2024.PIP
-open Semantics.Dynamic.Core (IVar ICDRTAssignment Entity IContext)
+open DynamicSemantics (IVar ICDRTAssignment Entity IContext)
 open Core.Logic.Modal (AccessRel box diamond)
 open Core.Logic.Modal.Logic (frameConditions)
 

--- a/Linglib/Studies/KeshetAbney2024/Connectives.lean
+++ b/Linglib/Studies/KeshetAbney2024/Connectives.lean
@@ -33,7 +33,7 @@ produces the same truth conditions as `Intensional.box`.
 
 namespace KeshetAbney2024.PIP
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 open Core.Logic.Modal (AccessRel box diamond box_T)
 
 variable {W E : Type*}

--- a/Linglib/Studies/Krifka2026.lean
+++ b/Linglib/Studies/Krifka2026.lean
@@ -42,8 +42,8 @@ namespace Krifka2026
 
 open Semantics.Kinds.NMP (Property Kind IsMass
   kindAnaphorMass kindAnaphorCount kindAnaphorCount_mass)
-open Semantics.Dynamic.Core.DynProp (Update Condition test dneg eq_of_test)
-open scoped Semantics.Dynamic.Core.DynProp
+open DynamicSemantics.DynProp (Update Condition test dneg eq_of_test)
+open scoped DynamicSemantics.DynProp
 
 /-! ### Concept drefs and heterogeneous dref values ([krifka-2026] §4)
 

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -40,7 +40,7 @@ namespace Mendes2025
 open Core (Assignment)
 open Intensional (WorldTimeIndex)
 open HistoricalAlternatives
-open Semantics.Dynamic.Core
+open DynamicSemantics
 open Tense
 open Mood
 

--- a/Linglib/Studies/Muskens1996.lean
+++ b/Linglib/Studies/Muskens1996.lean
@@ -9,7 +9,7 @@ import Mathlib.Data.Fin.VecNotation
 
 [muskens-1996] shows that DRT embeds in classical type theory once states are
 atomic and discourse referents are functions from states — the Dynamic Ty2
-substrate at `Semantics.Dynamic.Core`. This study covers the paper's two
+substrate at `DynamicSemantics`. This study covers the paper's two
 worked developments over that substrate:
 
 * **The compositional fragment** (§III.4, §IV): lexical translations T₀ for a
@@ -35,7 +35,7 @@ application, `dseq`, and λ-abstraction.
 
 namespace Muskens1996
 
-open Semantics.Dynamic.Core
+open DynamicSemantics
 
 variable {S E : Type*}
 
@@ -301,7 +301,7 @@ the correspondence whose DPL face lives in
 section CylindricAlgebra
 
 open Core.CylindricAlgebra
-open Semantics.Dynamic.CDRT
+open CDRT
 
 /-- Discourse referent introduction under closure = cylindrification.
 

--- a/Linglib/Studies/Rakosi2019.lean
+++ b/Linglib/Studies/Rakosi2019.lean
@@ -53,7 +53,7 @@ namespace Rakosi2019
 
 open Semantics.Reference.Reciprocals
 open Semantics.Reference.PluralityLicensing
-open Semantics.Dynamic.PPCDRT
+open PPCDRT
 open Core
 open Hungarian.Reciprocals
 

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -322,7 +322,7 @@ def directionUpdate (K : Scoreboard W) (p : W → Prop)
 /-! ### POSW substrate bridge
 
 The scoreboard's CommonGround and G components project jointly into a
-the POSW substrate (`Semantics.Dynamic.Default.ExpState` under its
+the POSW substrate (`UpdateSemantics.Default.ExpState` under its
 `Semantics/Dynamic/UpdateSemantics/Necessity.lean` modal reading): CommonGround via
 `contextSet`, G via the goal-induced preference ordering. Assertion ↔
 `assert`, direction ↔ `promote`. -/
@@ -377,7 +377,7 @@ lemma mem_directionUpdate_goalContents (K : Scoreboard W) (p : W → Prop)
 
 /-- Project the scoreboard into a POSW-style expectation state: `info`
     from CommonGround, `order` from goal-induced preference. -/
-def toExpState (K : Scoreboard W) : Semantics.Dynamic.Default.ExpState W where
+def toExpState (K : Scoreboard W) : UpdateSemantics.Default.ExpState W where
   info := K.contextSet
   order := Preorder.ofLE (fun w v => ∀ p ∈ K.goalContents, p v → p w)
     (fun _ _ _ hp => hp)
@@ -414,7 +414,7 @@ theorem toExpState_direction_eq_promote (K : Scoreboard W) (p : W → Prop)
     (s t pr : Nat) (hin : t < K.goals.length) (w v : W) :
     (K.directionUpdate p s t pr).toExpState.order.le w v ↔
       (K.toExpState.promote p).order.le w v := by
-  simp only [toExpState_le, Semantics.Dynamic.Default.ExpState.promote_order,
+  simp only [toExpState_le, UpdateSemantics.Default.ExpState.promote_order,
     Core.Order.Normality.refine_le, toExpState_le]
   constructor
   · intro h
@@ -498,7 +498,7 @@ open Intensional (WorldTimeIndex)
 open Discourse (forceLinkingPrinciple defaultSemanticType Scoreboard)
 open Mood.Illocutionary (sincerityCondition)
 open Mood (State Component Illocutionary HasTarget)
-open Semantics.Dynamic.Default (ExpState)
+open UpdateSemantics.Default (ExpState)
 open HistoricalAlternatives
 open Semantics.Modality.Kratzer
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -47,7 +47,7 @@ the normalcy predicate in the GEN operator for generic sentences.
 namespace Veltman1996
 
 open Core.Logic.TweetyNixon
-open Semantics.Dynamic.Default
+open UpdateSemantics.Default
 open Core.Order
 open Classical
 

--- a/Linglib/Studies/Yagi2025.lean
+++ b/Linglib/Studies/Yagi2025.lean
@@ -233,14 +233,14 @@ theorem kp_presup_entails_assertion :
 
 /-! ## Failure 3: Update semantics ([yagi-2025] §2.3)
 
-Bridges to `Semantics.Dynamic.UpdateSemantics.Basic`, which
+Bridges to `UpdateSemantics.Basic`, which
 collapses the [heim-1982]/[veltman-1996]/[beaver-2001]
 treatments of presuppositional disjunction into a single `PUpdate.disjPresup`
 operator. -/
 
 section UpdateSemantics
 
-open Semantics.Dynamic.UpdateSemantics
+open UpdateSemantics
 
 /-- The ideal input state for (1c): all worlds with a head of state. The
 `noHeadOfState` world is excluded — Yagi's discussion presupposes a context


### PR DESCRIPTION
RFC step 7, the last reorg step: the legacy `Semantics.Dynamic.Core` and `Semantics.Dynamic.Context` namespaces and the transitional `Semantics.Dynamic` spine unify into the single area namespace `DynamicSemantics` (the MeasureTheory-pattern: one segment, the field's literature name, one `open` at the top of a consumer file). Framework namespaces flatten to root per the DRT/RSA precedent (`PLA`, `UpdateSemantics`, `DPL`, `CDRT`, `PPCDRT`), and two nonconforming study namespaces drop to the short paper-name convention (`Charlow2019`, `FileChangeSemantics`; `ABLE` joins `Beaver2001`). The 2-arg register-form `Possibility` abbrev dies (collision with the 3-arg point object); its sites spell `Possibility W ℕ E`. File paths unchanged.