### PR TITLE
feat(Semantics/Dynamic): the category of contexts and its collapse

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1633,6 +1633,8 @@ import Linglib.Semantics.Degree.Quantifier
 import Linglib.Semantics.Dynamic.Lookup
 import Linglib.Semantics.Dynamic.UpdateSemantics.Bilateral
 import Linglib.Semantics.Dynamic.CDRT
+import Linglib.Semantics.Dynamic.Category
+import Linglib.Semantics.Dynamic.Collapse
 import Linglib.Semantics.Dynamic.ContextChange
 import Linglib.Semantics.Dynamic.Situation
 import Linglib.Semantics.Dynamic.DPL

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -1,0 +1,98 @@
+import Linglib.Semantics.Dynamic.Transition
+import Mathlib.CategoryTheory.Category.Preorder
+import Mathlib.CategoryTheory.Types.Basic
+
+/-!
+# The category of contexts
+[kamp-vangenabith-reyle-2011], [groenendijk-stokhof-1991], [muskens-1996]
+
+Based dynamic semantics is a category: objects are contexts (bases of live
+discourse referents), morphisms are `Transition`s, composition is
+world-pointwise relational composition. The identity and associativity laws
+are `Transition.lean`'s `id_comp`/`comp_id`/`comp_assoc`.
+
+Two structures make the levels of the spine mathematically precise:
+
+* `State.presheaf` — information states form a presheaf on the poset of
+  bases: the fiber over `X` is the states based at `X`, restriction along
+  `Y ⊆ X` is `State.restrict`.
+* `Ctx.collapse` — the *one-object collapse* to level 0 is a functor to
+  mathlib's `RelCat` sending a context to its possibilities *up to
+  agreement on the base* and a transition to its `toUpdate` relation.
+  The quotient is forced: `toUpdate` sends `𝟙 X` to agreement-on-`X`, not
+  to equality, so the collapse is only lawful on base-agreement classes —
+  `supported_left`/`supported_right` are exactly the congruence
+  conditions. The collapse is faithful (`Ctx.collapse_faithful`): a
+  transition loses nothing under it; what the collapse forgets is the
+  base-indexing of the objects.
+
+## Main declarations
+
+* `Ctx` — bundled contexts; `Category (Ctx W M V)` with `Transition` homs.
+* `State.presheaf` — the fibered states, contravariant along `⊆`.
+* `Ctx.agreeSetoid` / `Ctx.collapse` — the collapse functor to `RelCat`.
+-/
+
+namespace DynamicSemantics
+
+open CategoryTheory
+
+/-- A context: a base of live discourse referents, bundled as an object of
+the category whose morphisms are `Transition W M X Y`. -/
+@[ext] structure Ctx (W M : Type*) (V : Type*) where
+  /-- The live discourse referents. -/
+  base : Finset V
+
+namespace Ctx
+
+variable {W M V : Type*}
+
+/-- Morphisms of contexts: transitions between the bases. -/
+@[ext] structure Hom (X Y : Ctx W M V) where
+  /-- The underlying transition. -/
+  t : Transition W M X.base Y.base
+
+instance : Category (Ctx W M V) where
+  Hom := Hom
+  id X := ⟨Transition.id X.base⟩
+  comp u v := ⟨u.t.comp v.t⟩
+  id_comp u := Hom.ext (Transition.id_comp u.t)
+  comp_id u := Hom.ext (Transition.comp_id u.t)
+  assoc u v w := Hom.ext (Transition.comp_assoc u.t v.t w.t)
+
+@[simp] theorem t_id (X : Ctx W M V) : Hom.t (𝟙 X) = Transition.id X.base := rfl
+
+@[simp] theorem t_comp {X Y Z : Ctx W M V} (u : X ⟶ Y) (v : Y ⟶ Z) :
+    (u ≫ v).t = u.t.comp v.t := rfl
+
+end Ctx
+
+/-! ### The state presheaf -/
+
+universe u v w
+
+/-- The states based at `X`: the fiber of the presheaf of states. -/
+abbrev State.fiber (W M : Type*) {V : Type*} (X : (Finset V)ᵒᵖ) : Type _ :=
+  {I : State W V M // I.base = X.unop}
+
+/-- Information states form a presheaf on the poset of bases: the fiber
+over `X` is the states based at `X`, and restriction along `Y ⊆ X` is
+`State.restrict` — the presheaf laws are `restrict_base` and
+`restrict_restrict`. -/
+def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
+    (Finset V)ᵒᵖ ⥤ Type (max u v w) where
+  obj := State.fiber W M
+  map {X Y} f := TypeCat.ofHom
+    fun I => ⟨I.val.restrict Y.unop, State.base_restrict I.val Y.unop⟩
+  map_id X := by
+    ext I : 3
+    apply Subtype.ext
+    obtain ⟨J, hJ⟩ := I
+    show J.restrict X.unop = J
+    rw [← hJ]
+    exact J.restrict_base
+  map_comp {X Y Z} h k := by
+    ext I : 3
+    exact Subtype.ext (I.val.restrict_restrict (leOfHom k.unop)).symm
+
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -1,0 +1,137 @@
+import Linglib.Semantics.Dynamic.Category
+import Mathlib.CategoryTheory.Category.RelCat
+
+/-!
+# The one-object collapse
+[muskens-1996], [groenendijk-stokhof-1991]
+
+The collapse of based dynamic semantics to level 0: a functor from the
+category of contexts to mathlib's `RelCat`, sending a context to its
+possibilities *up to agreement on the base* and a transition to its
+`toUpdate` relation. The quotient is forced: `toUpdate` sends `𝟙 X` to
+agreement-on-`X`, not to equality, so the collapse is only lawful on
+base-agreement classes — `supported_left`/`supported_right` are exactly the
+congruence conditions. The collapse is faithful (`Ctx.collapse_faithful`):
+a transition loses nothing under it; what the collapse forgets is the
+base-indexing of the objects.
+
+This lives apart from `Category.lean` because importing `RelCat` (a type
+synonym for `Type u` carrying the relations category) interferes with
+instance resolution for the functions category on `Type u`, which the
+state presheaf needs.
+
+## Main declarations
+
+* `Ctx.agreeSetoid` — possibilities up to agreement on the base.
+* `Ctx.collapse` — the collapse functor to `RelCat`; faithful.
+-/
+
+namespace DynamicSemantics
+
+open CategoryTheory
+
+
+
+namespace Ctx
+
+variable {W M V : Type*}
+
+/-- Possibilities up to agreement on the base: same world, same assignment
+at every live referent. The collapse functor sends a context to the
+quotient by this relation. -/
+def agreeSetoid (X : Ctx W M V) : Setoid (Possibility W V M) where
+  r p q := p.world = q.world ∧ Set.EqOn p.assignment q.assignment ↑X.base
+  iseqv :=
+    ⟨fun _ => ⟨rfl, Set.eqOn_refl _ _⟩,
+     fun h => ⟨h.1.symm, h.2.symm⟩,
+     fun h h' => ⟨h.1.trans h'.1, h.2.trans h'.2⟩⟩
+
+/-- `toUpdate` descends to base-agreement classes: `supported_left` and
+`supported_right` are precisely the congruence conditions. -/
+def collapseRel {X Y : Ctx W M V} (u : X ⟶ Y) :
+    Quotient X.agreeSetoid → Quotient Y.agreeSetoid → Prop :=
+  Quotient.lift₂ (fun p q => u.t.toUpdate p q)
+    fun p₁ q₁ p₂ q₂ hp hq => propext <| by
+      simp only [Transition.toUpdate]
+      rw [hp.1, hq.1]
+      exact and_congr Iff.rfl
+        ((u.t.supported_left hp.2).trans (u.t.supported_right hq.2))
+
+@[simp] theorem collapseRel_mk {X Y : Ctx W M V} (u : X ⟶ Y)
+    (p q : Possibility W V M) :
+    collapseRel u (⟦p⟧) (⟦q⟧) ↔ u.t.toUpdate p q := Iff.rfl
+
+/-- On base-agreement classes the identity transition collapses to
+equality — the unitality the raw `toUpdate` lacks. -/
+theorem collapseRel_id (X : Ctx W M V) (p q : Quotient X.agreeSetoid) :
+    collapseRel (𝟙 X) p q ↔ p = q := by
+  induction p using Quotient.ind
+  induction q using Quotient.ind
+  rename_i p q
+  constructor
+  · rintro ⟨hw, ha⟩
+    exact Quotient.sound ⟨hw, ha⟩
+  · intro h
+    obtain ⟨hw, ha⟩ := Quotient.exact h
+    exact ⟨hw, ha⟩
+
+/-- On base-agreement classes sequencing collapses to relational
+composition. -/
+theorem collapseRel_comp {X Y Z : Ctx W M V} (u : X ⟶ Y) (v : Y ⟶ Z)
+    (p : Quotient X.agreeSetoid) (r : Quotient Z.agreeSetoid) :
+    collapseRel (u ≫ v) p r ↔
+      ∃ q, collapseRel u p q ∧ collapseRel v q r := by
+  induction p using Quotient.ind
+  induction r using Quotient.ind
+  rename_i p r
+  constructor
+  · intro h
+    have h' : (u.t.toUpdate ⨟ v.t.toUpdate) p r := by
+      rw [← Transition.toUpdate_comp, ← t_comp]
+      exact h
+    obtain ⟨k, hk₁, hk₂⟩ := h'
+    exact ⟨(⟦k⟧), hk₁, hk₂⟩
+  · rintro ⟨q, hq₁, hq₂⟩
+    induction q using Quotient.ind
+    rename_i k
+    show (u ≫ v).t.toUpdate p r
+    rw [t_comp, Transition.toUpdate_comp]
+    exact ⟨k, hq₁, hq₂⟩
+
+/-- **The one-object collapse**: forget the bases, keeping possibilities up
+to base-agreement. Functoriality on composition is `toUpdate_comp`; on
+identities it is `Quotient.sound`/`exact` — which is why the quotient is
+forced: on raw possibilities `toUpdate (𝟙 X)` is agreement-on-`X`, not
+equality. -/
+def collapse (W M V : Type*) : Ctx W M V ⥤ RelCat where
+  obj X := Quotient X.agreeSetoid
+  map u := .ofRel {pq | collapseRel u pq.1 pq.2}
+  map_id X := by
+    apply RelCat.Hom.ext
+    ext ⟨p, q⟩
+    rw [Set.mem_setOf_eq, RelCat.Hom.rel_id]
+    exact (collapseRel_id X p q).trans SetRel.mem_id.symm
+  map_comp {X Y Z} u v := by
+    apply RelCat.Hom.ext
+    ext ⟨p, r⟩
+    rw [Set.mem_setOf_eq, RelCat.Hom.rel_comp, collapseRel_comp]
+    constructor
+    · rintro ⟨q, h₁, h₂⟩
+      exact SetRel.prodMk_mem_comp h₁ h₂
+    · rintro ⟨q, h₁, h₂⟩
+      exact ⟨q, h₁, h₂⟩
+
+/-- The collapse is faithful: a transition is recoverable from its relation
+on base-agreement classes. What the collapse forgets is only the
+base-indexing of the objects. -/
+instance collapse_faithful : (collapse W M V).Faithful where
+  map_injective {X Y} {u v} h := by
+    have hs : ∀ p q : Possibility W V M, u.t.toUpdate p q ↔ v.t.toUpdate p q :=
+      fun p q => Set.ext_iff.mp (congrArg RelCat.Hom.rel h) (⟦p⟧, ⟦q⟧)
+    refine Hom.ext (Transition.ext ?_)
+    funext w f g
+    exact propext (by simpa [Transition.toUpdate] using hs ⟨w, f⟩ ⟨w, g⟩)
+
+end Ctx
+
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -83,16 +83,34 @@ theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
   exact ⟨fun ⟨k, ⟨j, hj, hjk⟩, hk⟩ => ⟨j, hj, k, hjk, hk⟩,
     fun ⟨j, hj, k, hjk, hk⟩ => ⟨k, ⟨j, hj, hjk⟩, hk⟩⟩
 
-/-! ### Application to information states -/
-
-section Apply
-variable [DecidableEq V]
+/-! ### The forgotten relation -/
 
 /-- Forget the bases: the level-0 relation on possibilities (the world is
 preserved). -/
 def toUpdate (u : Transition W M X Y) :
     DynProp.Update (Possibility W V M) :=
   fun p q => p.world = q.world ∧ u.rel p.world p.assignment q.assignment
+
+/-- Forgetting bases sends sequencing to relational composition — the
+one-object collapse is functorial on composition. (It is not unital:
+`toUpdate (id X)` is agreement on `X`, not equality — see the quotient
+collapse in `Category.lean`.) -/
+theorem toUpdate_comp (u : Transition W M X Y) (v : Transition W M Y Z) :
+    (u.comp v).toUpdate = u.toUpdate ⨟ v.toUpdate := by
+  funext p q
+  simp only [toUpdate, comp, DynProp.dseq, Relation.Comp, eq_iff_iff]
+  constructor
+  · rintro ⟨hw, k, huk, hkv⟩
+    exact ⟨⟨p.world, k⟩, ⟨rfl, huk⟩, hw, hkv⟩
+  · rintro ⟨k, ⟨hwk, huk⟩, hkw, hkv⟩
+    refine ⟨hwk.trans hkw, k.assignment, huk, ?_⟩
+    rw [hwk]
+    exact hkv
+
+/-! ### Application to information states -/
+
+section Apply
+variable [DecidableEq V]
 
 /-- Context change ([kamp-vangenabith-reyle-2011], Def. 24): the carrier is
 the level-0 `lift` of the forgotten relation; the base grows to


### PR DESCRIPTION
B4 phase 1, on the unified namespace: `Ctx W M V` is a category (objects = bases, homs = `Transition`s; laws were already proven in Transition.lean), `State.presheaf` makes restriction a presheaf on the poset of bases, and `Ctx.collapse` is the one-object collapse to mathlib's `RelCat` — on possibilities *up to base-agreement*, since `toUpdate` sends identities to agreement-on-`X`, not equality; `supported_left`/`supported_right` are exactly the descent conditions, and the collapse is faithful. `Collapse.lean` is split from `Category.lean` because importing `RelCat` interferes with instance resolution for the functions category on `Type u`. Next: the DRS syntactic category and the DPL/US functor instantiations in their study files.