### PR TITLE
docs(Semantics/Dynamic): anchor two-level architecture in MBV 2011

### DIFF
--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -4,7 +4,8 @@ import Mathlib.CategoryTheory.Types.Basic
 
 /-!
 # The category of contexts
-[kamp-vangenabith-reyle-2011], [groenendijk-stokhof-1991], [muskens-1996]
+[kamp-vangenabith-reyle-2011], [muskens-van-benthem-visser-2011],
+[groenendijk-stokhof-1991], [muskens-1996]
 
 Based dynamic semantics is a category: objects are contexts (bases of live
 discourse referents), morphisms are `Transition`s, composition is

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -3,12 +3,15 @@ import Mathlib.CategoryTheory.Category.RelCat
 
 /-!
 # The one-object collapse
-[muskens-1996], [groenendijk-stokhof-1991]
+[muskens-van-benthem-visser-2011], [muskens-1996], [groenendijk-stokhof-1991]
 
-The collapse of based dynamic semantics to level 0: a functor from the
-category of contexts to mathlib's `RelCat`, sending a context to its
-possibilities *up to agreement on the base* and a transition to its
-`toUpdate` relation. The quotient is forced: `toUpdate` sends `𝟙 X` to
+The collapse of based dynamic semantics to level 0 — the relational
+algebra of procedures over a single state space, with composition,
+converse, and the diagonal ([muskens-van-benthem-visser-2011]'s "Dynamic
+Constants as Operators in Relational Algebra"; mathlib's `RelCat`). The
+collapse is a functor from the category of contexts to `RelCat`, sending a
+context to its possibilities *up to agreement on the base* and a
+transition to its `toUpdate` relation. The quotient is forced: `toUpdate` sends `𝟙 X` to
 agreement-on-`X`, not to equality, so the collapse is only lawful on
 base-agreement classes — `supported_left`/`supported_right` are exactly the
 congruence conditions. The collapse is faithful (`Ctx.collapse_faithful`):

--- a/Linglib/Semantics/Dynamic/ContextChange.lean
+++ b/Linglib/Semantics/Dynamic/ContextChange.lean
@@ -553,6 +553,19 @@ theorem lift_lower (φ : CCP S) (hd : IsDistributive φ) :
   rw [hd σ]
   simp only [Set.mem_setOf_eq]
 
+/-- `lift` is the strongest-postcondition operator `SP(A, R) = R[A]` of
+[muskens-van-benthem-visser-2011], and it reflects the pointwise order:
+update inclusion at every input state is relational inclusion — the
+SP-characterization of update-update consequence. -/
+theorem lift_le_lift_iff {R R' : Update S} : lift R ≤ lift R' ↔ R ≤ R' := by
+  constructor
+  · intro h i j hR
+    obtain ⟨i', hi', hR'⟩ := h {i} ⟨i, rfl, hR⟩
+    cases hi'
+    exact hR'
+  · rintro h σ j ⟨i, hi, hR⟩
+    exact ⟨i, hi, h i j hR⟩
+
 /-- `lift (test C)` is eliminative: it only removes elements. -/
 theorem lift_test_isEliminative (C : Condition S) :
     IsEliminative (lift (DynProp.test C)) := by

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4588,6 +4588,22 @@
   validated = {true},
   sources   = {Studies/KampReyle1993.lean}
 }% REF: Kamp, van Genabith & Reyle (2011). Discourse Representation Theory. HPL 15, 125-394.
+@incollection{muskens-van-benthem-visser-2011,
+  author    = {Muskens, Reinhard and van Benthem, Johan and Visser, Albert},
+  year      = {2011},
+  title     = {Dynamics},
+  booktitle = {Handbook of Logic and Language},
+  edition   = {2},
+  editor    = {van Benthem, Johan and ter Meulen, Alice},
+  pages     = {607--669},
+  doi       = {10.1016/B978-0-444-53726-3.00012-8},
+  publisher = {Elsevier},
+  subfield  = {semantics/dynamic},
+  role      = {formalized},
+  validated = {true},
+  sources   = {publisher PDF in hand},
+}
+
 @incollection{kamp-vangenabith-reyle-2011,
   author    = {Kamp, Hans and van Genabith, Josef and Reyle, Uwe},
   year      = {2011},


### PR DESCRIPTION
Adds the verified `muskens-van-benthem-visser-2011` entry (Handbook of Logic and Language ch. 12, DOI checked against the publisher PDF) and cites it where it is the actual source: the collapse's target — the relational algebra of procedures over one state space — and the two-level modes/projections picture the category file formalizes. Also `lift_le_lift_iff`: `lift` is the chapter's strongest-postcondition operator `SP(A, R) = R[A]` and reflects the pointwise order — the SP-characterization of update-update consequence.