### PR TITLE
refactor(Semantics/Dynamic): states at a base as collapsed propositions

### DIFF
--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -72,17 +72,13 @@ end Ctx
 
 universe u v w
 
-/-- The states based at `X`: the fiber of the presheaf of states. -/
-abbrev State.fiber (W M : Type*) {V : Type*} (X : (Finset V)ᵒᵖ) : Type _ :=
-  {I : State W V M // I.base = X.unop}
-
 /-- Information states form a presheaf on the poset of bases: the fiber
 over `X` is the states based at `X`, and restriction along `Y ⊆ X` is
 `State.restrict` — the presheaf laws are `restrict_base` and
 `restrict_restrict`. -/
 def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
     (Finset V)ᵒᵖ ⥤ Type (max u v w) where
-  obj := State.fiber W M
+  obj X := State.fiber W M X.unop
   map {X Y} f := TypeCat.ofHom
     fun I => ⟨I.val.restrict Y.unop, State.base_restrict I.val Y.unop⟩
   map_id X := by

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -25,7 +25,7 @@ state presheaf needs.
 
 ## Main declarations
 
-* `Ctx.agreeSetoid` — possibilities up to agreement on the base.
+* `Ctx.agreeSetoid` — `Possibility.agreeSetoid` at the context's base.
 * `Ctx.collapse` — the collapse functor to `RelCat`; faithful.
 -/
 
@@ -39,15 +39,9 @@ namespace Ctx
 
 variable {W M V : Type*}
 
-/-- Possibilities up to agreement on the base: same world, same assignment
-at every live referent. The collapse functor sends a context to the
-quotient by this relation. -/
-def agreeSetoid (X : Ctx W M V) : Setoid (Possibility W V M) where
-  r p q := p.world = q.world ∧ Set.EqOn p.assignment q.assignment ↑X.base
-  iseqv :=
-    ⟨fun _ => ⟨rfl, Set.eqOn_refl _ _⟩,
-     fun h => ⟨h.1.symm, h.2.symm⟩,
-     fun h h' => ⟨h.1.trans h'.1, h.2.trans h'.2⟩⟩
+/-- Agreement on the context's base: `Possibility.agreeSetoid` at `↑X.base`. -/
+abbrev agreeSetoid (X : Ctx W M V) : Setoid (Possibility W V M) :=
+  Possibility.agreeSetoid ↑X.base
 
 /-- `toUpdate` descends to base-agreement classes: `supported_left` and
 `supported_right` are precisely the congruence conditions. -/

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,4 +1,6 @@
 import Linglib.Semantics.Dynamic.ContextChange
+import Mathlib.Data.Set.Function
+import Mathlib.Data.Setoid.Basic
 
 /-!
 # Possibilities
@@ -6,8 +8,8 @@ import Linglib.Semantics.Dynamic.ContextChange
 
 A *possibility* is a world paired with an assignment of discourse referents —
 the point type of dynamic semantics. This file holds the point object and its
-small coupled constructions: the pointwise API (`extend`, `agreeOn`,
-`sameWorld`), the register-form instances
+small coupled constructions: the pointwise API (`extend`, `agreeSetoid`),
+the register-form instances
 (`Nat`-keyed assignments), the unbased set-of-possibilities vocabulary
 (`InfoState.definedAt`, `novelAt`, `worlds`, `subsistsIn`, `supports`), and
 the possibility-specific CCP constructors (`InfoState.update`,
@@ -33,12 +35,18 @@ namespace Possibility
 
 variable {W V M : Type*}
 
-/-- Two possibilities agree on the referents in `vars`. -/
-def agreeOn (p q : Possibility W V M) (vars : Set V) : Prop :=
-  ∀ x ∈ vars, p.assignment x = q.assignment x
+/-- Possibilities up to agreement on `X`: equal worlds, assignments agreeing
+on `X`. Quotienting by this setoid is the state space at granularity `X` —
+the collapse of `Collapse.lean`, and the target of `State.fiberEquiv`. -/
+def agreeSetoid (X : Set V) : Setoid (Possibility W V M) where
+  r p q := p.world = q.world ∧ Set.EqOn p.assignment q.assignment X
+  iseqv :=
+    ⟨fun _ => ⟨rfl, Set.eqOn_refl _ _⟩, fun h => ⟨h.1.symm, h.2.symm⟩,
+      fun h h' => ⟨h.1.trans h'.1, h.2.trans h'.2⟩⟩
 
-/-- Same world, possibly different assignment. -/
-def sameWorld (p q : Possibility W V M) : Prop := p.world = q.world
+/-- Coarser bases identify more possibilities. -/
+theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
+  fun _ _ hXY _ _ h => ⟨h.1, h.2.mono hXY⟩
 
 /-- Extend the assignment at a single referent, via `Function.update`. -/
 def extend [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -27,7 +27,7 @@ Under it the chapter's definitions collapse to order theory:
   `le_iff_projection`).
 * Def. 26's consistent merge is carrier intersection at the union base, and
   it is the *join* of the informativeness order (`SemilatticeSup`;
-  `mem_sup_iff` recovers the chapter's choice-function form).
+  `mem_sup_iff_projection` recovers the chapter's choice-function form).
 * Def. 23(iv)'s minimal information state Λ (empty base, no information)
   is `⊥`.
 
@@ -35,14 +35,29 @@ Under it the chapter's definitions collapse to order theory:
 bare set of possibilities; `State` adds the base. The transitions acting on
 these states live in `Transition.lean`.
 
+Support is *saturation*: a carrier is supported on `X` iff it is a union of
+`Possibility.agreeSetoid ↑X` classes (`baseSupported_iff`), so a state
+based at `X` is exactly a proposition over the `X`-collapsed state space
+(`fiberEquiv`) — [muskens-van-benthem-visser-2011]'s propositions-over-a-
+state-space picture at granularity `X`. The projection ladder carrier →
+agreement classes (`fiberEquiv`) → worlds (`prop`) forgets in two
+documented steps; the marbles argument lives in the second.
+
+`State` gets a `Membership` instance rather than `SetLike`: the coe to
+carriers is not injective (`Set.univ` is supported at every base — same
+carrier, different base), and `Filter` is the precedent.
+
 ## Main declarations
 
 * `BaseSupported` — membership depends only on assignment values at `X`
-  (`DependsOn`, per world).
+  (`DependsOn`, per world); equivalently, saturation for the agreement
+  setoid (`baseSupported_iff`).
 * `State` — a base together with a supported carrier of possibilities.
 * `State.prop` — the proposition determined by a state (Def. 23(v)).
 * `State.restrict` — the best approximation supported on a smaller base
-  (presheaf restriction along base inclusion).
+  (presheaf restriction along base inclusion; `le_restrict_iff`).
+* `State.fiberEquiv` / `fiberOrderIso` — the states based at `X` are the
+  propositions over the `X`-collapsed state space, reversing the order.
 -/
 
 namespace DynamicSemantics
@@ -78,6 +93,32 @@ theorem BaseSupported.inter {X : Finset V} {S T : Set (Possibility W V M)}
     (hS : BaseSupported X S) (hT : BaseSupported X T) : BaseSupported X (S ∩ T) :=
   baseSupported_of_iff fun _ _ _ hfg =>
     and_congr (hS.mem_iff hfg) (hT.mem_iff hfg)
+
+/-- A set is supported on `X` iff membership is invariant under agreement on
+`X`: `BaseSupported X` is saturation for `Possibility.agreeSetoid ↑X`. -/
+theorem baseSupported_iff {X : Finset V} {S : Set (Possibility W V M)} :
+    BaseSupported X S ↔
+      ∀ ⦃p q⦄, Possibility.agreeSetoid (↑X : Set V) p q → (p ∈ S ↔ q ∈ S) := by
+  constructor
+  · rintro h ⟨w, f⟩ ⟨w', g⟩ ⟨rfl, hfg⟩
+    exact h.mem_iff hfg
+  · intro h
+    exact baseSupported_of_iff fun _ _ _ hfg => h ⟨rfl, hfg⟩
+
+/-- Point form of `BaseSupported.mem_iff`: membership is invariant on
+agreement classes. -/
+theorem BaseSupported.mem_congr {X : Finset V} {S : Set (Possibility W V M)}
+    (h : BaseSupported X S) {p q : Possibility W V M}
+    (hpq : Possibility.agreeSetoid (↑X : Set V) p q) : p ∈ S ↔ q ∈ S :=
+  baseSupported_iff.mp h hpq
+
+/-- The saturation round trip: a supported set is the preimage of its image
+in the collapsed state space. -/
+theorem BaseSupported.preimage_image_mk {X : Finset V} {S : Set (Possibility W V M)}
+    (h : BaseSupported X S) :
+    Quotient.mk (Possibility.agreeSetoid ↑X) ⁻¹' (Quotient.mk _ '' S) = S :=
+  Set.Subset.antisymm (fun _ ⟨_, hq, hqp⟩ => (h.mem_congr (Quotient.exact hqp)).mp hq)
+    (Set.subset_preimage_image _ _)
 
 /-! ### Information states -/
 
@@ -140,6 +181,8 @@ instance : OrderBot (State W V M) where
 @[simp] theorem base_bot : (⊥ : State W V M).base = ∅ := rfl
 @[simp] theorem carrier_bot : (⊥ : State W V M).carrier = Set.univ := rfl
 
+@[simp] theorem mem_bot {p : Possibility W V M} : p ∈ (⊥ : State W V M) := trivial
+
 /-! ### Consistent merge is the join -/
 
 section Merge
@@ -162,18 +205,21 @@ instance : SemilatticeSup (State W V M) where
 @[simp] theorem carrier_sup (I I' : State W V M) :
     (I ⊔ I').carrier = I.carrier ∩ I'.carrier := rfl
 
+@[simp] theorem mem_sup {I I' : State W V M} {p : Possibility W V M} :
+    p ∈ I ⊔ I' ↔ p ∈ I ∧ p ∈ I' := Iff.rfl
+
 /-- The chapter's choice-function form of Def. 26: a possibility belongs to
 the merge iff it restricts into each component — support makes the choice
 functions the possibility itself. -/
-theorem mem_sup_iff {I I' : State W V M} {w : W} {h : V → M} :
-    (⟨w, h⟩ : Possibility W V M) ∈ I ⊔ I' ↔
-      (∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f h ↑I.base) ∧
-      (∃ g, (⟨w, g⟩ : Possibility W V M) ∈ I' ∧ Set.EqOn g h ↑I'.base) := by
+theorem mem_sup_iff_projection {I I' : State W V M} {w : W} {k : V → M} :
+    (⟨w, k⟩ : Possibility W V M) ∈ I ⊔ I' ↔
+      (∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f k ↑I.base) ∧
+      (∃ g, (⟨w, g⟩ : Possibility W V M) ∈ I' ∧ Set.EqOn g k ↑I'.base) := by
   constructor
   · rintro ⟨hI, hI'⟩
-    exact ⟨⟨h, hI, Set.eqOn_refl h _⟩, ⟨h, hI', Set.eqOn_refl h _⟩⟩
-  · rintro ⟨⟨f, hf, hfh⟩, ⟨g, hg, hgh⟩⟩
-    exact ⟨(I.supported.mem_iff hfh).mp hf, (I'.supported.mem_iff hgh).mp hg⟩
+    exact ⟨⟨k, hI, Set.eqOn_refl k _⟩, ⟨k, hI', Set.eqOn_refl k _⟩⟩
+  · rintro ⟨⟨f, hf, hfk⟩, ⟨g, hg, hgk⟩⟩
+    exact ⟨(I.supported.mem_iff hfk).mp hf, (I'.supported.mem_iff hgk).mp hg⟩
 
 end Merge
 
@@ -193,9 +239,8 @@ theorem prop_eq_image (I : State W V M) : I.prop = Possibility.world '' I.carrie
 theorem prop_anti : Antitone (prop : State W V M → Set W) :=
   fun _ _ h _ ⟨f, hf⟩ => ⟨f, h.2 hf⟩
 
-@[simp] theorem prop_bot [Nonempty M] : (⊥ : State W V M).prop = Set.univ := by
-  ext w
-  exact ⟨fun _ => trivial, fun _ => ⟨fun _ => Classical.arbitrary M, trivial⟩⟩
+@[simp] theorem prop_bot [Nonempty M] : (⊥ : State W V M).prop = Set.univ :=
+  Set.eq_univ_of_forall fun _ => ⟨fun _ => Classical.arbitrary M, trivial⟩
 
 /-! ### Restriction to a smaller base -/
 
@@ -242,6 +287,82 @@ theorem restrict_restrict (I : State W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
 theorem restrict_le {I : State W V M} {Y : Finset V} (h : Y ⊆ I.base) :
     I.restrict Y ≤ I :=
   ⟨h, fun p hp => ⟨p.assignment, hp, Set.eqOn_refl p.assignment _⟩⟩
+
+/-- Restriction is the *best* `Y`-supported approximation: for states based
+below `Y`, lying below `I.restrict Y` is lying below `I`. -/
+theorem le_restrict_iff {I J : State W V M} {Y : Finset V}
+    (hJ : J.base ⊆ Y) (hY : Y ⊆ I.base) : J ≤ I.restrict Y ↔ J ≤ I := by
+  constructor
+  · exact fun h => h.trans (restrict_le hY)
+  · rintro ⟨hb, hc⟩
+    refine ⟨hJ, fun p hp => ?_⟩
+    obtain ⟨w, g⟩ := p
+    obtain ⟨f, hf, hfg⟩ := hp
+    exact (J.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hJ))).mp (hc hf)
+
+/-- Restriction never changes the proposition — only anaphoric potential. -/
+@[simp] theorem prop_restrict (I : State W V M) (Y : Finset V) :
+    (I.restrict Y).prop = I.prop :=
+  Set.ext fun _ =>
+    ⟨fun ⟨_, f, hf, _⟩ => ⟨f, hf⟩, fun ⟨f, hf⟩ => ⟨f, f, hf, Set.eqOn_refl f _⟩⟩
+
+/-! ### States at a base as collapsed propositions -/
+
+/-- The states based at `X`. -/
+abbrev fiber (W M : Type*) {V : Type*} (X : Finset V) : Type _ :=
+  {I : State W V M // I.base = X}
+
+theorem fiber_supported {X : Finset V} (I : fiber W M X) :
+    BaseSupported X I.1.carrier :=
+  (congrArg (fun b => BaseSupported b I.1.carrier) I.2).mp I.1.supported
+
+/-- A state based at `X` is a proposition over the `X`-collapsed state
+space ([muskens-van-benthem-visser-2011]'s picture at granularity `X`):
+support is saturation, so carriers and sets of agreement classes are in
+bijection. -/
+def fiberEquiv (X : Finset V) :
+    fiber W M X ≃ Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V))) where
+  toFun I := {q | q.liftOn (· ∈ I.1) fun _ _ h => propext ((fiber_supported I).mem_congr h)}
+  invFun T :=
+    ⟨⟨X, Quotient.mk _ ⁻¹' T, baseSupported_iff.mpr fun _ _ h => by
+        rw [Set.mem_preimage, Set.mem_preimage, Quotient.sound h]⟩, rfl⟩
+  left_inv I := Subtype.ext (State.ext I.2.symm rfl)
+  right_inv T := by
+    ext q
+    induction q using Quotient.ind
+    exact Iff.rfl
+
+@[simp] theorem mem_fiberEquiv {X : Finset V} {I : fiber W M X} {p : Possibility W V M} :
+    Quotient.mk _ p ∈ fiberEquiv X I ↔ p ∈ I.1 := Iff.rfl
+
+@[simp] theorem mem_fiberEquiv_symm {X : Finset V} {p : Possibility W V M}
+    {T : Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V)))} :
+    p ∈ ((fiberEquiv X).symm T).1 ↔ Quotient.mk _ p ∈ T := Iff.rfl
+
+/-- The equivalence is the image of the carrier in the collapsed space —
+the sibling of `prop_eq_image`, one rung up the ladder. -/
+theorem fiberEquiv_eq_image {X : Finset V} (I : fiber W M X) :
+    fiberEquiv X I = Quotient.mk _ '' I.1.carrier := by
+  have h := (fiber_supported I).preimage_image_mk
+  ext q
+  induction q using Quotient.ind
+  rw [mem_fiberEquiv, ← State.mem_carrier, ← Set.mem_preimage, h]
+
+/-- Informativeness at a fixed base is reverse inclusion of collapsed
+propositions. -/
+def fiberOrderIso (X : Finset V) :
+    fiber W M X ≃o (Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V))))ᵒᵈ where
+  toEquiv := (fiberEquiv X).trans OrderDual.toDual
+  map_rel_iff' {I I'} := by
+    show OrderDual.toDual (fiberEquiv X I) ≤ OrderDual.toDual (fiberEquiv X I') ↔ I ≤ I'
+    rw [OrderDual.toDual_le_toDual]
+    constructor
+    · intro h
+      refine ⟨by rw [I.2, I'.2], fun p hp => ?_⟩
+      exact mem_fiberEquiv.mp (h (mem_fiberEquiv.mpr hp))
+    · rintro ⟨-, hc⟩ q hq
+      induction q using Quotient.ind
+      exact mem_fiberEquiv.mpr (hc (mem_fiberEquiv.mp hq))
 
 end State
 


### PR DESCRIPTION
Mathlib-reviewer pass on State.lean plus the MBV-motivated characterizations. `Possibility.agreeSetoid` becomes the point-level primitive (subsuming the consumerless `agreeOn`/`sameWorld`); support is characterized as saturation (`baseSupported_iff`, `BaseSupported.preimage_image_mk`, statement shape after `QuotientGroup.preimage_image_mk`); and `State.fiberEquiv`/`fiberOrderIso` prove a state based at `X` is exactly a proposition over the `X`-collapsed state space, reversing the informativeness order. Review fixes in passing: `mem_bot`/`mem_sup` complete the Filter-pattern lattice API (`mem_sup_iff` → `mem_sup_iff_projection`), `prop_restrict` (restriction never changes truth conditions), `le_restrict_iff` (restrict is the universal `Y`-supported approximation), and a Membership-not-SetLike implementation note. `Collapse.lean`'s setoid dedupes onto the point-level one.