### PR TITLE
refactor(Semantics/Dynamic): mathlib docstrings; split out InfoState.lean

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1658,6 +1658,7 @@ import Linglib.Semantics.Dynamic.PPCDRT.Cumulativity
 import Linglib.Semantics.Dynamic.PPCDRT.Defs
 import Linglib.Semantics.Dynamic.PartialTransformer
 import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 import Linglib.Semantics.Dynamic.Ty2
 import Linglib.Semantics.Dynamic.Update
 import Linglib.Semantics.Dynamic.UpdateSemantics.Basic

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -4,34 +4,33 @@ import Mathlib.CategoryTheory.Types.Basic
 
 /-!
 # The category of contexts
-[kamp-vangenabith-reyle-2011], [muskens-van-benthem-visser-2011],
-[groenendijk-stokhof-1991], [muskens-1996]
 
-Based dynamic semantics is a category: objects are contexts (bases of live
-discourse referents), morphisms are `Transition`s, composition is
-world-pointwise relational composition. The identity and associativity laws
-are `Transition.lean`'s `id_comp`/`comp_id`/`comp_assoc`.
+Based dynamic semantics is a category: objects are contexts (bases of
+live discourse referents), morphisms are `Transition`s, composition is
+world-pointwise relational composition. The identity and associativity
+laws are `Transition.lean`'s `id_comp`/`comp_id`/`comp_assoc`.
 
-Two structures make the levels of the spine mathematically precise:
+## Main definitions
 
-* `State.presheaf` — information states form a presheaf on the poset of
-  bases: the fiber over `X` is the states based at `X`, restriction along
-  `Y ⊆ X` is `State.restrict`.
-* `Ctx.collapse` — the *one-object collapse* to level 0 is a functor to
-  mathlib's `RelCat` sending a context to its possibilities *up to
-  agreement on the base* and a transition to its `toUpdate` relation.
-  The quotient is forced: `toUpdate` sends `𝟙 X` to agreement-on-`X`, not
-  to equality, so the collapse is only lawful on base-agreement classes —
-  `supported_left`/`supported_right` are exactly the congruence
-  conditions. The collapse is faithful (`Ctx.collapse_faithful`): a
-  transition loses nothing under it; what the collapse forgets is the
-  base-indexing of the objects.
+- `Ctx W M V`: bundled contexts, with a `Category` instance whose
+  morphisms are `Transition`s between the bases.
+- `State.presheaf`: information states as a presheaf on the poset of
+  bases — the fiber over `X` is the states based at `X`, restriction is
+  `State.restrict`.
 
-## Main declarations
+## Implementation notes
 
-* `Ctx` — bundled contexts; `Category (Ctx W M V)` with `Transition` homs.
-* `State.presheaf` — the fibered states, contravariant along `⊆`.
-* `Ctx.agreeSetoid` / `Ctx.collapse` — the collapse functor to `RelCat`.
+Morphisms are a one-field structure wrapping `Transition` (the
+`RelCat.Hom` pattern): an unbundled `Hom` field breaks dot-notation on
+morphisms. The collapse functor to `RelCat` lives in `Collapse.lean`,
+because importing `RelCat` interferes with instance resolution for the
+functions category on `Type u`, which `State.presheaf` needs.
+
+## References
+
+- [kamp-vangenabith-reyle-2011]
+- [muskens-van-benthem-visser-2011]
+- [groenendijk-stokhof-1991], [muskens-1996]
 -/
 
 namespace DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -3,30 +3,39 @@ import Mathlib.CategoryTheory.Category.RelCat
 
 /-!
 # The one-object collapse
-[muskens-van-benthem-visser-2011], [muskens-1996], [groenendijk-stokhof-1991]
 
 The collapse of based dynamic semantics to level 0 — the relational
 algebra of procedures over a single state space, with composition,
 converse, and the diagonal ([muskens-van-benthem-visser-2011]'s "Dynamic
-Constants as Operators in Relational Algebra"; mathlib's `RelCat`). The
-collapse is a functor from the category of contexts to `RelCat`, sending a
-context to its possibilities *up to agreement on the base* and a
-transition to its `toUpdate` relation. The quotient is forced: `toUpdate` sends `𝟙 X` to
-agreement-on-`X`, not to equality, so the collapse is only lawful on
-base-agreement classes — `supported_left`/`supported_right` are exactly the
-congruence conditions. The collapse is faithful (`Ctx.collapse_faithful`):
-a transition loses nothing under it; what the collapse forgets is the
-base-indexing of the objects.
+Constants as Operators in Relational Algebra"; mathlib's `RelCat`).
 
-This lives apart from `Category.lean` because importing `RelCat` (a type
-synonym for `Type u` carrying the relations category) interferes with
-instance resolution for the functions category on `Type u`, which the
-state presheaf needs.
+## Main definitions
 
-## Main declarations
+- `Ctx.agreeSetoid`: `Possibility.agreeSetoid` at the context's base.
+- `Ctx.collapse`: the functor `Ctx W M V ⥤ RelCat` sending a context to
+  its possibilities up to base-agreement and a transition to its
+  `toUpdate` relation.
 
-* `Ctx.agreeSetoid` — `Possibility.agreeSetoid` at the context's base.
-* `Ctx.collapse` — the collapse functor to `RelCat`; faithful.
+## Main results
+
+- `Ctx.collapseRel_id`, `Ctx.collapseRel_comp`: identity and sequencing
+  collapse to equality and relational composition on agreement classes.
+- `Ctx.collapse_faithful`: a transition is recoverable from its collapsed
+  relation; what the collapse forgets is the base-indexing of objects.
+
+## Implementation notes
+
+The quotient is forced: `toUpdate` sends `𝟙 X` to agreement-on-`X`, not
+to equality, so the collapse is lawful only on base-agreement classes —
+`supported_left`/`supported_right` are exactly the congruence conditions.
+This file is separate from `Category.lean` because importing `RelCat` (a
+type synonym for `Type u` carrying the relations category) interferes
+with instance resolution for the functions category on `Type u`.
+
+## References
+
+- [muskens-van-benthem-visser-2011]
+- [muskens-1996], [groenendijk-stokhof-1991]
 -/
 
 namespace DynamicSemantics
@@ -37,7 +46,7 @@ open CategoryTheory
 
 namespace Ctx
 
-variable {W M V : Type*}
+variable {W M V : Type*} {X Y Z : Ctx W M V}
 
 /-- Agreement on the context's base: `Possibility.agreeSetoid` at `↑X.base`. -/
 abbrev agreeSetoid (X : Ctx W M V) : Setoid (Possibility W V M) :=
@@ -45,7 +54,7 @@ abbrev agreeSetoid (X : Ctx W M V) : Setoid (Possibility W V M) :=
 
 /-- `toUpdate` descends to base-agreement classes: `supported_left` and
 `supported_right` are precisely the congruence conditions. -/
-def collapseRel {X Y : Ctx W M V} (u : X ⟶ Y) :
+def collapseRel (u : X ⟶ Y) :
     Quotient X.agreeSetoid → Quotient Y.agreeSetoid → Prop :=
   Quotient.lift₂ (fun p q => u.t.toUpdate p q)
     fun p₁ q₁ p₂ q₂ hp hq => propext <| by
@@ -54,7 +63,7 @@ def collapseRel {X Y : Ctx W M V} (u : X ⟶ Y) :
       exact and_congr Iff.rfl
         ((u.t.supported_left hp.2).trans (u.t.supported_right hq.2))
 
-@[simp] theorem collapseRel_mk {X Y : Ctx W M V} (u : X ⟶ Y)
+@[simp] theorem collapseRel_mk (u : X ⟶ Y)
     (p q : Possibility W V M) :
     collapseRel u (⟦p⟧) (⟦q⟧) ↔ u.t.toUpdate p q := Iff.rfl
 
@@ -74,7 +83,7 @@ theorem collapseRel_id (X : Ctx W M V) (p q : Quotient X.agreeSetoid) :
 
 /-- On base-agreement classes sequencing collapses to relational
 composition. -/
-theorem collapseRel_comp {X Y Z : Ctx W M V} (u : X ⟶ Y) (v : Y ⟶ Z)
+theorem collapseRel_comp (u : X ⟶ Y) (v : Y ⟶ Z)
     (p : Quotient X.agreeSetoid) (r : Quotient Z.agreeSetoid) :
     collapseRel (u ≫ v) p r ↔
       ∃ q, collapseRel u p q ∧ collapseRel v q r := by

--- a/Linglib/Semantics/Dynamic/DPL.lean
+++ b/Linglib/Semantics/Dynamic/DPL.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 import Linglib.Semantics.Dynamic.Ty2
 
 /-!

--- a/Linglib/Semantics/Dynamic/InfoState.lean
+++ b/Linglib/Semantics/Dynamic/InfoState.lean
@@ -1,0 +1,261 @@
+import Linglib.Semantics.Dynamic.ContextChange
+import Linglib.Semantics.Dynamic.Possibility
+
+/-!
+# Register-form information states
+
+Unbased information states over register-keyed possibilities
+(`Assignment E := Nat → E`, i.e. the point object at `V := ℕ`) — the
+state notion of the pre-based dynamic frameworks (PLA, BUS, file change
+semantics). The based refinement lives in `State.lean`.
+
+## Main definitions
+
+- `InfoState W E`: sets of register-form possibilities.
+- `InfoState.definedAt`, `novelAt`, `worlds`, `subsistsIn`, `supports`:
+  the unbased state vocabulary.
+- `InfoState.update`, `randomAssign`, `CCP.exists_`, `CCP.ofProp`,
+  `CCP.ofPred1`, `CCP.ofPred2`: the possibility-specific CCP
+  constructors.
+
+## References
+
+- [kamp-vangenabith-reyle-2011]
+- [heim-1982]
+-/
+
+namespace DynamicSemantics
+
+open _root_.Core (Assignment)
+
+
+/-! ### Register-form information states
+
+Register-keyed dynamic semantics (`Assignment E := Nat → E`) instantiates
+the point object at `V := ℕ`. -/
+
+/-- Information state: set of possibilities.
+
+This is `InfoStateOf (Possibility W ℕ E)` — a specialization of the
+generic `InfoStateOf` to world-assignment possibilities. -/
+abbrev InfoState (W : Type*) (E : Type*) := Set (Possibility W ℕ E)
+
+namespace InfoState
+
+variable {W E : Type*}
+
+/-- The trivial state: all possibilities. -/
+def univ : InfoState W E := Set.univ
+
+/-- The absurd state: no possibilities. -/
+def empty : InfoState W E := (∅ : Set (Possibility W ℕ E))
+
+/-- State is consistent (non-empty). -/
+def consistent (s : InfoState W E) : Prop := s.Nonempty
+
+/-- State is trivial (all possibilities). -/
+def trivial (s : InfoState W E) : Prop := s = Set.univ
+
+/-- Variable x is defined in state s iff all possibilities agree on x's value. -/
+def definedAt (s : InfoState W E) (x : Nat) : Prop :=
+  ∀ p q : Possibility W ℕ E, p ∈ s → q ∈ s → p.assignment x = q.assignment x
+
+/-- The set of defined variables in a state. -/
+def definedVars (s : InfoState W E) : Set Nat :=
+  { x | s.definedAt x }
+
+/-- Variable x is novel in state s iff x is not defined. -/
+def novelAt (s : InfoState W E) (x : Nat) : Prop := ¬s.definedAt x
+
+/-- In a consistent state, novel means assignments actually disagree. -/
+theorem novelAt_iff_disagree (s : InfoState W E) (x : Nat) (hs : s.consistent) :
+    s.novelAt x ↔ ∃ p q : Possibility W ℕ E, p ∈ s ∧ q ∈ s ∧ p.assignment x ≠ q.assignment x := by
+  constructor
+  · intro h
+    simp only [novelAt, definedAt] at h
+    push Not at h
+    exact h
+  · intro ⟨p, q, hp, hq, hne⟩
+    simp only [novelAt, definedAt]
+    push Not
+    exact ⟨p, q, hp, hq, hne⟩
+
+/-- Project to the set of worlds in the state. -/
+def worlds (s : InfoState W E) : Set W :=
+  { w | ∃ p ∈ s, p.world = w }
+
+end InfoState
+
+/-- State subsistence: s subsists in s' iff every possibility in s has a descendant in s'. -/
+def InfoState.subsistsIn {W E : Type*} (s s' : InfoState W E) : Prop :=
+  ∀ p ∈ s, ∃ p' ∈ s', p.world = p'.world ∧
+    ∀ x, s.definedAt x → p.assignment x = p'.assignment x
+
+scoped notation:50 s " ⪯ " s' => InfoState.subsistsIn s s'
+
+namespace InfoState
+
+variable {W E : Type*}
+
+/-- Subsistence is reflexive. -/
+theorem subsistsIn_refl (s : InfoState W E) : s ⪯ s := by
+  intro p hp
+  exact ⟨p, hp, rfl, λ _ _ => rfl⟩
+
+/-- Subset implies subsistence. -/
+theorem subset_subsistsIn {s s' : InfoState W E} (h : s ⊆ s') : s ⪯ s' := by
+  intro p hp
+  exact ⟨p, h hp, rfl, λ _ _ => rfl⟩
+
+/-- State s supports proposition φ iff φ holds at all worlds in s:
+`supportOf` at the world-evaluation satisfaction relation. -/
+def supports (s : InfoState W E) (φ : W → Prop) : Prop :=
+  supportOf (λ p ψ => ψ p.world) s φ
+
+scoped notation:50 s " ⊫ " φ => InfoState.supports s φ
+
+/-- Support is preserved by subset. -/
+theorem supports_mono {s s' : InfoState W E} (h : s ⊆ s')
+    (φ : W → Prop) (hsupp : s' ⊫ φ) : s ⊫ φ :=
+  support_mono _ s' s φ h hsupp
+
+end InfoState
+
+/-! ### Context change over possibilities -/
+
+/-- Update state with proposition: keep only possibilities where φ holds. -/
+def InfoState.update {W E : Type*} (s : InfoState W E) (φ : W → Prop) : InfoState W E :=
+  { p ∈ s | φ p.world }
+
+notation:max s "⟦" φ "⟧" => InfoState.update s φ
+
+namespace InfoState
+
+variable {W E : Type*}
+
+/-- Propositional update is monotone in the state argument. -/
+theorem update_monotone (φ : W → Prop) : Monotone (· ⟦φ⟧ : InfoState W E → InfoState W E) :=
+  sep_monotone _
+
+/-- Update is monotonic: larger states give larger results -/
+theorem update_mono {s s' : InfoState W E} (h : s ⊆ s') (φ : W → Prop) :
+    s⟦φ⟧ ⊆ s'⟦φ⟧ :=
+  update_monotone φ h
+
+/-- Update is idempotent -/
+theorem update_update (s : InfoState W E) (φ : W → Prop) :
+    s⟦φ⟧⟦φ⟧ = s⟦φ⟧ := by
+  ext p
+  simp only [update, Set.mem_setOf_eq]
+  constructor
+  · intro ⟨⟨hs, _⟩, hφ⟩; exact ⟨hs, hφ⟩
+  · intro ⟨hs, hφ⟩; exact ⟨⟨hs, hφ⟩, hφ⟩
+
+/-- Sequential update = conjunction -/
+theorem update_seq (s : InfoState W E) (φ ψ : W → Prop) :
+    s⟦φ⟧⟦ψ⟧ = s⟦λ w => φ w ∧ ψ w⟧ := by
+  ext p
+  simp only [update, Set.mem_setOf_eq]
+  constructor
+  · intro ⟨⟨hs, hφ⟩, hψ⟩; exact ⟨hs, hφ, hψ⟩
+  · intro ⟨hs, hφ, hψ⟩; exact ⟨⟨hs, hφ⟩, hψ⟩
+
+/-- Update preserves definedness -/
+theorem update_preserves_defined (s : InfoState W E) (φ : W → Prop) (x : Nat)
+    (h : s.definedAt x) : s⟦φ⟧.definedAt x := by
+  intro p q hp hq
+  exact h p q hp.1 hq.1
+
+/-- s[φ] ⊫ φ -/
+theorem update_supports (s : InfoState W E) (φ : W → Prop) : s⟦φ⟧ ⊫ φ := by
+  intro p ⟨_, hφ⟩
+  exact hφ
+
+/-- Dynamic entailment for propositions. -/
+def dynamicEntails (φ ψ : W → Prop) : Prop :=
+  ∀ s : InfoState W E, (s⟦φ⟧).consistent → s⟦φ⟧ ⊫ ψ
+
+/-- Any proposition dynamically entails itself -/
+theorem dynamicEntails_refl (φ : W → Prop) : dynamicEntails (W := W) (E := E) φ φ := by
+  intro s _
+  exact update_supports s φ
+
+/-- φ dynamically entails φ ∧ ψ when φ entails ψ -/
+theorem dynamicEntails_conj (φ ψ : W → Prop)
+    (h : dynamicEntails (W := W) (E := E) φ ψ) :
+    dynamicEntails (W := W) (E := E) φ (λ w => φ w ∧ ψ w) := by
+  intro s hcons p hp
+  constructor
+  · exact update_supports s φ p hp
+  · exact h s hcons p hp
+
+end InfoState
+
+/-- Random assignment: introduce new discourse referent at variable x. -/
+def InfoState.randomAssign {W E : Type*} (s : InfoState W E) (x : Nat)
+    (domain : Set E) : InfoState W E :=
+  { p' | ∃ p ∈ s, ∃ e ∈ domain, p' = p.extend x e }
+
+/-- Random assignment with full domain -/
+def InfoState.randomAssignFull {W E : Type*} (s : InfoState W E) (x : Nat) : InfoState W E :=
+  { p' | ∃ p ∈ s, ∃ e : E, p' = p.extend x e }
+
+namespace InfoState
+
+variable {W E : Type*}
+
+/-- Random assignment makes x novel (when domain has multiple elements) -/
+theorem randomAssign_makes_novel (s : InfoState W E) (x : Nat) (domain : Set E)
+    (hs : s.consistent) (hdom : ∃ e₁ e₂ : E, e₁ ∈ domain ∧ e₂ ∈ domain ∧ e₁ ≠ e₂) :
+    (s.randomAssign x domain).novelAt x := by
+  obtain ⟨p, hp⟩ := hs
+  obtain ⟨e₁, e₂, he₁, he₂, hne⟩ := hdom
+  simp only [novelAt, definedAt]
+  push Not
+  refine ⟨p.extend x e₁, p.extend x e₂, ?_, ?_, ?_⟩
+  · exact ⟨p, hp, e₁, he₁, rfl⟩
+  · exact ⟨p, hp, e₂, he₂, rfl⟩
+  · simp [Possibility.extend, hne]
+
+/-- Random assignment preserves other defined variables -/
+theorem randomAssign_preserves_defined (s : InfoState W E) (x y : Nat) (domain : Set E)
+    (h : s.definedAt y) (hne : y ≠ x) : (s.randomAssign x domain).definedAt y := by
+  intro p q hp hq
+  obtain ⟨p', hp', _, _, rfl⟩ := hp
+  obtain ⟨q', hq', _, _, rfl⟩ := hq
+  simp only [Possibility.extend]
+  simp [hne]
+  exact h p' q' hp' hq'
+
+end InfoState
+
+/-- Existential CCP: ∃x.φ introduces x then updates with φ. -/
+def CCP.exists_ {W E : Type*} (x : Nat) (domain : Set E)
+    (φ : CCP (Possibility W ℕ E)) : CCP (Possibility W ℕ E) :=
+  λ (s : InfoState W E) => φ (s.randomAssign x domain)
+
+/-- Existential with full domain -/
+def CCP.existsFull {W E : Type*} (x : Nat)
+    (φ : CCP (Possibility W ℕ E)) : CCP (Possibility W ℕ E) :=
+  λ (s : InfoState W E) => φ (s.randomAssignFull x)
+
+/--
+Lift a classical proposition to a CCP.
+-/
+def CCP.ofProp {W E : Type*} (φ : W → Prop) : CCP (Possibility W ℕ E) :=
+  λ (s : InfoState W E) => s⟦φ⟧
+
+/--
+Lift a predicate on entities (via variable lookup).
+-/
+def CCP.ofPred1 {W E : Type*} (p : E → W → Prop) (x : Nat) : CCP (Possibility W ℕ E) :=
+  λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) poss.world }
+
+/--
+Lift a binary predicate.
+-/
+def CCP.ofPred2 {W E : Type*} (p : E → E → W → Prop) (x y : Nat) : CCP (Possibility W ℕ E) :=
+  λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) (poss.assignment y) poss.world }
+
+
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/PLA/Translation.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Translation.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 import Linglib.Core.Logic.Assignment
 
 /-!

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,22 +1,25 @@
-import Linglib.Semantics.Dynamic.ContextChange
 import Mathlib.Data.Set.Function
 import Mathlib.Data.Setoid.Basic
 
 /-!
 # Possibilities
-[kamp-vangenabith-reyle-2011] (Def. 22), [heim-1982]
 
-A *possibility* is a world paired with an assignment of discourse referents —
-the point type of dynamic semantics. This file holds the point object and its
-small coupled constructions: the pointwise API (`extend`, `agreeSetoid`),
-the register-form instances
-(`Nat`-keyed assignments), the unbased set-of-possibilities vocabulary
-(`InfoState.definedAt`, `novelAt`, `worlds`, `subsistsIn`, `supports`), and
-the possibility-specific CCP constructors (`InfoState.update`,
-`randomAssign`, `CCP.exists_`, `CCP.ofProp`).
+A *possibility* is a world paired with an assignment of discourse
+referents — the point type of dynamic semantics. Based information
+states over possibilities live in `State.lean`, the unbased register-form
+states in `InfoState.lean`, and the generic level-0 CCP algebra in
+`ContextChange.lean`.
 
-The based information states built over possibilities live in `State.lean`;
-the generic level-0 CCP algebra in `ContextChange.lean`.
+## Main definitions
+
+- `Possibility W V M`: the point object.
+- `Possibility.agreeSetoid X`: possibilities up to agreement on `X` — the
+  state space at granularity `X` (`Collapse.lean`, `State.fiberEquiv`).
+
+## References
+
+- [kamp-vangenabith-reyle-2011], Def. 22
+- [heim-1982]
 -/
 
 namespace DynamicSemantics
@@ -64,236 +67,5 @@ def extend [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
     (p.extend x e).world = p.world := rfl
 
 end Possibility
-
-open _root_.Core (Assignment)
-
-/-! ### Register-form information states
-
-Register-keyed dynamic semantics (`Assignment E := Nat → E`) instantiates
-the point object at `V := ℕ`. -/
-
-/-- Information state: set of possibilities.
-
-This is `InfoStateOf (Possibility W ℕ E)` — a specialization of the
-generic `InfoStateOf` to world-assignment possibilities. -/
-abbrev InfoState (W : Type*) (E : Type*) := Set (Possibility W ℕ E)
-
-namespace InfoState
-
-variable {W E : Type*}
-
-/-- The trivial state: all possibilities. -/
-def univ : InfoState W E := Set.univ
-
-/-- The absurd state: no possibilities. -/
-def empty : InfoState W E := (∅ : Set (Possibility W ℕ E))
-
-/-- State is consistent (non-empty). -/
-def consistent (s : InfoState W E) : Prop := s.Nonempty
-
-/-- State is trivial (all possibilities). -/
-def trivial (s : InfoState W E) : Prop := s = Set.univ
-
-/-- Variable x is defined in state s iff all possibilities agree on x's value. -/
-def definedAt (s : InfoState W E) (x : Nat) : Prop :=
-  ∀ p q : Possibility W ℕ E, p ∈ s → q ∈ s → p.assignment x = q.assignment x
-
-/-- The set of defined variables in a state. -/
-def definedVars (s : InfoState W E) : Set Nat :=
-  { x | s.definedAt x }
-
-/-- Variable x is novel in state s iff x is not defined. -/
-def novelAt (s : InfoState W E) (x : Nat) : Prop := ¬s.definedAt x
-
-/-- In a consistent state, novel means assignments actually disagree. -/
-theorem novelAt_iff_disagree (s : InfoState W E) (x : Nat) (hs : s.consistent) :
-    s.novelAt x ↔ ∃ p q : Possibility W ℕ E, p ∈ s ∧ q ∈ s ∧ p.assignment x ≠ q.assignment x := by
-  constructor
-  · intro h
-    simp only [novelAt, definedAt] at h
-    push Not at h
-    exact h
-  · intro ⟨p, q, hp, hq, hne⟩
-    simp only [novelAt, definedAt]
-    push Not
-    exact ⟨p, q, hp, hq, hne⟩
-
-/-- Project to the set of worlds in the state. -/
-def worlds (s : InfoState W E) : Set W :=
-  { w | ∃ p ∈ s, p.world = w }
-
-end InfoState
-
-/-- State subsistence: s subsists in s' iff every possibility in s has a descendant in s'. -/
-def InfoState.subsistsIn {W E : Type*} (s s' : InfoState W E) : Prop :=
-  ∀ p ∈ s, ∃ p' ∈ s', p.world = p'.world ∧
-    ∀ x, s.definedAt x → p.assignment x = p'.assignment x
-
-scoped notation:50 s " ⪯ " s' => InfoState.subsistsIn s s'
-
-namespace InfoState
-
-variable {W E : Type*}
-
-/-- Subsistence is reflexive. -/
-theorem subsistsIn_refl (s : InfoState W E) : s ⪯ s := by
-  intro p hp
-  exact ⟨p, hp, rfl, λ _ _ => rfl⟩
-
-/-- Subset implies subsistence. -/
-theorem subset_subsistsIn {s s' : InfoState W E} (h : s ⊆ s') : s ⪯ s' := by
-  intro p hp
-  exact ⟨p, h hp, rfl, λ _ _ => rfl⟩
-
-/-- State s supports proposition φ iff φ holds at all worlds in s:
-`supportOf` at the world-evaluation satisfaction relation. -/
-def supports (s : InfoState W E) (φ : W → Prop) : Prop :=
-  supportOf (λ p ψ => ψ p.world) s φ
-
-scoped notation:50 s " ⊫ " φ => InfoState.supports s φ
-
-/-- Support is preserved by subset. -/
-theorem supports_mono {s s' : InfoState W E} (h : s ⊆ s')
-    (φ : W → Prop) (hsupp : s' ⊫ φ) : s ⊫ φ :=
-  support_mono _ s' s φ h hsupp
-
-end InfoState
-
-/-! ### Context change over possibilities -/
-
-/-- Update state with proposition: keep only possibilities where φ holds. -/
-def InfoState.update {W E : Type*} (s : InfoState W E) (φ : W → Prop) : InfoState W E :=
-  { p ∈ s | φ p.world }
-
-notation:max s "⟦" φ "⟧" => InfoState.update s φ
-
-namespace InfoState
-
-variable {W E : Type*}
-
-/-- Propositional update is monotone in the state argument. -/
-theorem update_monotone (φ : W → Prop) : Monotone (· ⟦φ⟧ : InfoState W E → InfoState W E) :=
-  sep_monotone _
-
-/-- Update is monotonic: larger states give larger results -/
-theorem update_mono {s s' : InfoState W E} (h : s ⊆ s') (φ : W → Prop) :
-    s⟦φ⟧ ⊆ s'⟦φ⟧ :=
-  update_monotone φ h
-
-/-- Update is idempotent -/
-theorem update_update (s : InfoState W E) (φ : W → Prop) :
-    s⟦φ⟧⟦φ⟧ = s⟦φ⟧ := by
-  ext p
-  simp only [update, Set.mem_setOf_eq]
-  constructor
-  · intro ⟨⟨hs, _⟩, hφ⟩; exact ⟨hs, hφ⟩
-  · intro ⟨hs, hφ⟩; exact ⟨⟨hs, hφ⟩, hφ⟩
-
-/-- Sequential update = conjunction -/
-theorem update_seq (s : InfoState W E) (φ ψ : W → Prop) :
-    s⟦φ⟧⟦ψ⟧ = s⟦λ w => φ w ∧ ψ w⟧ := by
-  ext p
-  simp only [update, Set.mem_setOf_eq]
-  constructor
-  · intro ⟨⟨hs, hφ⟩, hψ⟩; exact ⟨hs, hφ, hψ⟩
-  · intro ⟨hs, hφ, hψ⟩; exact ⟨⟨hs, hφ⟩, hψ⟩
-
-/-- Update preserves definedness -/
-theorem update_preserves_defined (s : InfoState W E) (φ : W → Prop) (x : Nat)
-    (h : s.definedAt x) : s⟦φ⟧.definedAt x := by
-  intro p q hp hq
-  exact h p q hp.1 hq.1
-
-/-- s[φ] ⊫ φ -/
-theorem update_supports (s : InfoState W E) (φ : W → Prop) : s⟦φ⟧ ⊫ φ := by
-  intro p ⟨_, hφ⟩
-  exact hφ
-
-/-- Dynamic entailment for propositions. -/
-def dynamicEntails (φ ψ : W → Prop) : Prop :=
-  ∀ s : InfoState W E, (s⟦φ⟧).consistent → s⟦φ⟧ ⊫ ψ
-
-/-- Any proposition dynamically entails itself -/
-theorem dynamicEntails_refl (φ : W → Prop) : dynamicEntails (W := W) (E := E) φ φ := by
-  intro s _
-  exact update_supports s φ
-
-/-- φ dynamically entails φ ∧ ψ when φ entails ψ -/
-theorem dynamicEntails_conj (φ ψ : W → Prop)
-    (h : dynamicEntails (W := W) (E := E) φ ψ) :
-    dynamicEntails (W := W) (E := E) φ (λ w => φ w ∧ ψ w) := by
-  intro s hcons p hp
-  constructor
-  · exact update_supports s φ p hp
-  · exact h s hcons p hp
-
-end InfoState
-
-/-- Random assignment: introduce new discourse referent at variable x. -/
-def InfoState.randomAssign {W E : Type*} (s : InfoState W E) (x : Nat)
-    (domain : Set E) : InfoState W E :=
-  { p' | ∃ p ∈ s, ∃ e ∈ domain, p' = p.extend x e }
-
-/-- Random assignment with full domain -/
-def InfoState.randomAssignFull {W E : Type*} (s : InfoState W E) (x : Nat) : InfoState W E :=
-  { p' | ∃ p ∈ s, ∃ e : E, p' = p.extend x e }
-
-namespace InfoState
-
-variable {W E : Type*}
-
-/-- Random assignment makes x novel (when domain has multiple elements) -/
-theorem randomAssign_makes_novel (s : InfoState W E) (x : Nat) (domain : Set E)
-    (hs : s.consistent) (hdom : ∃ e₁ e₂ : E, e₁ ∈ domain ∧ e₂ ∈ domain ∧ e₁ ≠ e₂) :
-    (s.randomAssign x domain).novelAt x := by
-  obtain ⟨p, hp⟩ := hs
-  obtain ⟨e₁, e₂, he₁, he₂, hne⟩ := hdom
-  simp only [novelAt, definedAt]
-  push Not
-  refine ⟨p.extend x e₁, p.extend x e₂, ?_, ?_, ?_⟩
-  · exact ⟨p, hp, e₁, he₁, rfl⟩
-  · exact ⟨p, hp, e₂, he₂, rfl⟩
-  · simp [Possibility.extend, hne]
-
-/-- Random assignment preserves other defined variables -/
-theorem randomAssign_preserves_defined (s : InfoState W E) (x y : Nat) (domain : Set E)
-    (h : s.definedAt y) (hne : y ≠ x) : (s.randomAssign x domain).definedAt y := by
-  intro p q hp hq
-  obtain ⟨p', hp', _, _, rfl⟩ := hp
-  obtain ⟨q', hq', _, _, rfl⟩ := hq
-  simp only [Possibility.extend]
-  simp [hne]
-  exact h p' q' hp' hq'
-
-end InfoState
-
-/-- Existential CCP: ∃x.φ introduces x then updates with φ. -/
-def CCP.exists_ {W E : Type*} (x : Nat) (domain : Set E)
-    (φ : CCP (Possibility W ℕ E)) : CCP (Possibility W ℕ E) :=
-  λ (s : InfoState W E) => φ (s.randomAssign x domain)
-
-/-- Existential with full domain -/
-def CCP.existsFull {W E : Type*} (x : Nat)
-    (φ : CCP (Possibility W ℕ E)) : CCP (Possibility W ℕ E) :=
-  λ (s : InfoState W E) => φ (s.randomAssignFull x)
-
-/--
-Lift a classical proposition to a CCP.
--/
-def CCP.ofProp {W E : Type*} (φ : W → Prop) : CCP (Possibility W ℕ E) :=
-  λ (s : InfoState W E) => s⟦φ⟧
-
-/--
-Lift a predicate on entities (via variable lookup).
--/
-def CCP.ofPred1 {W E : Type*} (p : E → W → Prop) (x : Nat) : CCP (Possibility W ℕ E) :=
-  λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) poss.world }
-
-/--
-Lift a binary predicate.
--/
-def CCP.ofPred2 {W E : Type*} (p : E → E → W → Prop) (x y : Nat) : CCP (Possibility W ℕ E) :=
-  λ (s : InfoState W E) => { poss ∈ s | p (poss.assignment x) (poss.assignment y) poss.world }
-
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -6,63 +6,63 @@ import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Lattice
 
 /-!
-# Possibilities and based information states
-[kamp-vangenabith-reyle-2011] (Defs. 22–26), [heim-1982]
+# Based information states
 
-A *possibility* is a world paired with an assignment of discourse referents —
-the point type of dynamic semantics. An *information state* relative to a
-*base* `X` — a finite set of discourse referents — is a set of possibilities
-whose membership depends on assignments only through their values at `X`
-(mathlib's `DependsOn`, per world). The base is the "context as storage"
-dimension of dynamic meaning: finer than a proposition (it records which
-referents are live for anaphora — [kamp-vangenabith-reyle-2011]'s Partee
-marbles argument), coarser than syntax, and framework-neutral.
+A *possibility* is a world paired with a total assignment of discourse
+referents; an *information state* relative to a *base* `X` — a finite set
+of live discourse referents — is an `X`-supported set of possibilities.
+The base is the "context as storage" dimension of dynamic meaning: finer
+than a proposition, coarser than syntax ([kamp-vangenabith-reyle-2011]'s
+Partee-marbles argument). `InfoStateOf P` (`ContextChange.lean`) is the
+unbased level-0 notion; the transitions acting on states live in
+`Transition.lean`.
 
-Total-assignment rendering: the chapter's partial embeddings with domain `X`
-become total assignments with `X`-supported membership (`BaseSupported`).
-Under it the chapter's definitions collapse to order theory:
+## Main definitions
 
-* Def. 25's informativeness order is componentwise — the base grows and the
-  carrier shrinks (`le_def`; the chapter's projection form is
-  `le_iff_projection`).
-* Def. 26's consistent merge is carrier intersection at the union base, and
-  it is the *join* of the informativeness order (`SemilatticeSup`;
-  `mem_sup_iff_projection` recovers the chapter's choice-function form).
-* Def. 23(iv)'s minimal information state Λ (empty base, no information)
-  is `⊥`.
+- `BaseSupported X S`: membership in `S` depends on assignments only
+  through their values at `X` (mathlib's `DependsOn`, per world).
+- `State W V M`: a base with an `X`-supported carrier, ordered by
+  informativeness, with the minimal state Λ as `⊥` and consistent merge
+  as `⊔`.
+- `State.prop`: the proposition a state determines.
+- `State.restrict`: the best approximation supported on a smaller base.
+- `State.fiberEquiv`, `State.fiberOrderIso`: the states based at `X`, as
+  propositions over the `X`-collapsed state space.
 
-`InfoStateOf P` (`ContextChange.lean`) is the unbased, level-0 notion — a
-bare set of possibilities; `State` adds the base. The transitions acting on
-these states live in `Transition.lean`.
+## Main results
 
-Support is *saturation*: a carrier is supported on `X` iff it is a union of
-`Possibility.agreeSetoid ↑X` classes (`baseSupported_iff`), so a state
-based at `X` is exactly a proposition over the `X`-collapsed state space
-(`fiberEquiv`) — [muskens-van-benthem-visser-2011]'s propositions-over-a-
-state-space picture at granularity `X`. The projection ladder carrier →
-agreement classes (`fiberEquiv`) → worlds (`prop`) forgets in two
-documented steps; the marbles argument lives in the second.
+- `le_iff_projection`, `mem_sup_iff_projection`: the chapter's projection
+  and choice-function forms of order and merge coincide with the
+  componentwise ones — support supplies the witnesses.
+- `baseSupported_iff`, `BaseSupported.preimage_image_mk`: support is
+  *saturation* for `Possibility.agreeSetoid ↑X`.
+- `prop_restrict`, `le_restrict_iff`: restriction never changes the
+  proposition, and is the universal `Y`-supported approximation.
+
+## Implementation notes
+
+The chapter's partial embeddings with domain `X` are rendered as total
+assignments with `X`-supported membership; Def. 25's informativeness
+order, Def. 26's consistent merge, and Def. 23(iv)'s minimal state then
+collapse to order theory (`PartialOrder`, `SemilatticeSup`, `OrderBot`).
 
 `State` gets a `Membership` instance rather than `SetLike`: the coe to
-carriers is not injective (`Set.univ` is supported at every base — same
-carrier, different base), and `Filter` is the precedent.
+carriers is not injective (`Set.univ` is supported at every base), and
+`Filter` is the precedent. The projection ladder carrier → agreement
+classes (`fiberEquiv`) → worlds (`prop`) forgets in two documented steps;
+[muskens-van-benthem-visser-2011]'s propositions-over-a-state-space
+picture is the middle rung, at granularity `X`.
 
-## Main declarations
+## References
 
-* `BaseSupported` — membership depends only on assignment values at `X`
-  (`DependsOn`, per world); equivalently, saturation for the agreement
-  setoid (`baseSupported_iff`).
-* `State` — a base together with a supported carrier of possibilities.
-* `State.prop` — the proposition determined by a state (Def. 23(v)).
-* `State.restrict` — the best approximation supported on a smaller base
-  (presheaf restriction along base inclusion; `le_restrict_iff`).
-* `State.fiberEquiv` / `fiberOrderIso` — the states based at `X` are the
-  propositions over the `X`-collapsed state space, reversing the order.
+- [kamp-vangenabith-reyle-2011], Defs. 22–26
+- [heim-1982]
+- [muskens-van-benthem-visser-2011]
 -/
 
 namespace DynamicSemantics
 
-variable {W V M : Type*}
+variable {W V M : Type*} {X Y : Finset V} {S T : Set (Possibility W V M)}
 
 /-! ### Base-supported sets -/
 
@@ -73,30 +73,27 @@ def BaseSupported (X : Finset V) (S : Set (Possibility W V M)) : Prop :=
   ∀ w : W, DependsOn (fun f => (⟨w, f⟩ : Possibility W V M) ∈ S) ↑X
 
 /-- Introduction form: supply the membership-invariance iff. -/
-theorem baseSupported_of_iff {X : Finset V} {S : Set (Possibility W V M)}
+theorem baseSupported_of_iff
     (h : ∀ ⦃w : W⦄ ⦃f g : V → M⦄, Set.EqOn f g ↑X →
       ((⟨w, f⟩ : Possibility W V M) ∈ S ↔ ⟨w, g⟩ ∈ S)) :
     BaseSupported X S :=
   fun _ _ _ hfg => propext (h hfg)
 
 /-- Elimination form: membership is invariant under agreement on the base. -/
-theorem BaseSupported.mem_iff {X : Finset V} {S : Set (Possibility W V M)}
-    (h : BaseSupported X S) {w : W} {f g : V → M} (hfg : Set.EqOn f g ↑X) :
+theorem BaseSupported.mem_iff (h : BaseSupported X S) {w : W} {f g : V → M} (hfg : Set.EqOn f g ↑X) :
     (⟨w, f⟩ : Possibility W V M) ∈ S ↔ ⟨w, g⟩ ∈ S :=
   iff_of_eq (h w hfg)
 
-theorem BaseSupported.mono {X Y : Finset V} {S : Set (Possibility W V M)}
-    (h : BaseSupported X S) (hXY : X ⊆ Y) : BaseSupported Y S :=
+theorem BaseSupported.mono (h : BaseSupported X S) (hXY : X ⊆ Y) : BaseSupported Y S :=
   fun w => (h w).mono (Finset.coe_subset.mpr hXY)
 
-theorem BaseSupported.inter {X : Finset V} {S T : Set (Possibility W V M)}
-    (hS : BaseSupported X S) (hT : BaseSupported X T) : BaseSupported X (S ∩ T) :=
+theorem BaseSupported.inter (hS : BaseSupported X S) (hT : BaseSupported X T) : BaseSupported X (S ∩ T) :=
   baseSupported_of_iff fun _ _ _ hfg =>
     and_congr (hS.mem_iff hfg) (hT.mem_iff hfg)
 
 /-- A set is supported on `X` iff membership is invariant under agreement on
 `X`: `BaseSupported X` is saturation for `Possibility.agreeSetoid ↑X`. -/
-theorem baseSupported_iff {X : Finset V} {S : Set (Possibility W V M)} :
+theorem baseSupported_iff :
     BaseSupported X S ↔
       ∀ ⦃p q⦄, Possibility.agreeSetoid (↑X : Set V) p q → (p ∈ S ↔ q ∈ S) := by
   constructor
@@ -107,15 +104,13 @@ theorem baseSupported_iff {X : Finset V} {S : Set (Possibility W V M)} :
 
 /-- Point form of `BaseSupported.mem_iff`: membership is invariant on
 agreement classes. -/
-theorem BaseSupported.mem_congr {X : Finset V} {S : Set (Possibility W V M)}
-    (h : BaseSupported X S) {p q : Possibility W V M}
+theorem BaseSupported.mem_congr (h : BaseSupported X S) {p q : Possibility W V M}
     (hpq : Possibility.agreeSetoid (↑X : Set V) p q) : p ∈ S ↔ q ∈ S :=
   baseSupported_iff.mp h hpq
 
 /-- The saturation round trip: a supported set is the preimage of its image
 in the collapsed state space. -/
-theorem BaseSupported.preimage_image_mk {X : Finset V} {S : Set (Possibility W V M)}
-    (h : BaseSupported X S) :
+theorem BaseSupported.preimage_image_mk (h : BaseSupported X S) :
     Quotient.mk (Possibility.agreeSetoid ↑X) ⁻¹' (Quotient.mk _ '' S) = S :=
   Set.Subset.antisymm (fun _ ⟨_, hq, hqp⟩ => (h.mem_congr (Quotient.exact hqp)).mp hq)
     (Set.subset_preimage_image _ _)
@@ -135,10 +130,12 @@ possibilities. -/
 
 namespace State
 
+variable {I I' J : State W V M} {p : Possibility W V M}
+
 instance : Membership (Possibility W V M) (State W V M) :=
   ⟨fun I p => p ∈ I.carrier⟩
 
-@[simp] theorem mem_carrier {I : State W V M} {p : Possibility W V M} :
+@[simp] theorem mem_carrier :
     p ∈ I.carrier ↔ p ∈ I := Iff.rfl
 
 /-! ### The informativeness order -/
@@ -153,13 +150,13 @@ instance : PartialOrder (State W V M) where
   le_antisymm _ _ h h' :=
     State.ext (Finset.Subset.antisymm h.1 h'.1) (Set.Subset.antisymm h'.2 h.2)
 
-theorem le_def {I I' : State W V M} :
+theorem le_def :
     I ≤ I' ↔ I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier := Iff.rfl
 
 /-- The chapter's projection form of Def. 25 — every possibility of the
 stronger state restricts to one of the weaker — coincides with `≤`: support
 makes the projected witness the possibility itself. -/
-theorem le_iff_projection {I I' : State W V M} :
+theorem le_iff_projection :
     I ≤ I' ↔ I.base ⊆ I'.base ∧
       ∀ ⦃w g⦄, (⟨w, g⟩ : Possibility W V M) ∈ I' →
         ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑I.base := by
@@ -181,7 +178,7 @@ instance : OrderBot (State W V M) where
 @[simp] theorem base_bot : (⊥ : State W V M).base = ∅ := rfl
 @[simp] theorem carrier_bot : (⊥ : State W V M).carrier = Set.univ := rfl
 
-@[simp] theorem mem_bot {p : Possibility W V M} : p ∈ (⊥ : State W V M) := trivial
+@[simp] theorem mem_bot : p ∈ (⊥ : State W V M) := trivial
 
 /-! ### Consistent merge is the join -/
 
@@ -205,13 +202,13 @@ instance : SemilatticeSup (State W V M) where
 @[simp] theorem carrier_sup (I I' : State W V M) :
     (I ⊔ I').carrier = I.carrier ∩ I'.carrier := rfl
 
-@[simp] theorem mem_sup {I I' : State W V M} {p : Possibility W V M} :
+@[simp] theorem mem_sup :
     p ∈ I ⊔ I' ↔ p ∈ I ∧ p ∈ I' := Iff.rfl
 
 /-- The chapter's choice-function form of Def. 26: a possibility belongs to
 the merge iff it restricts into each component — support makes the choice
 functions the possibility itself. -/
-theorem mem_sup_iff_projection {I I' : State W V M} {w : W} {k : V → M} :
+theorem mem_sup_iff_projection {w : W} {k : V → M} :
     (⟨w, k⟩ : Possibility W V M) ∈ I ⊔ I' ↔
       (∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f k ↑I.base) ∧
       (∃ g, (⟨w, g⟩ : Possibility W V M) ∈ I' ∧ Set.EqOn g k ↑I'.base) := by
@@ -229,7 +226,7 @@ end Merge
 Def. 23(v)): the worlds compatible with some assignment. -/
 def prop (I : State W V M) : Set W := {w | ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I}
 
-@[simp] theorem mem_prop {I : State W V M} {w : W} :
+@[simp] theorem mem_prop {w : W} :
     w ∈ I.prop ↔ ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I := Iff.rfl
 
 theorem prop_eq_image (I : State W V M) : I.prop = Possibility.world '' I.carrier :=
@@ -258,8 +255,7 @@ def restrict (I : State W V M) (Y : Finset V) : State W V M where
 @[simp] theorem base_restrict (I : State W V M) (Y : Finset V) :
     (I.restrict Y).base = Y := rfl
 
-@[simp] theorem mem_restrict {I : State W V M} {Y : Finset V} {w : W}
-    {g : V → M} :
+@[simp] theorem mem_restrict {w : W} {g : V → M} :
     (⟨w, g⟩ : Possibility W V M) ∈ I.restrict Y ↔
       ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑Y := Iff.rfl
 
@@ -272,7 +268,7 @@ def restrict (I : State W V M) (Y : Finset V) : State W V M where
       fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
 
 /-- Restriction is transitive along shrinking bases. -/
-theorem restrict_restrict (I : State W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
+theorem restrict_restrict (I : State W V M) {Z : Finset V} (hZY : Z ⊆ Y) :
     (I.restrict Y).restrict Z = I.restrict Z := by
   ext1
   · rfl
@@ -284,14 +280,13 @@ theorem restrict_restrict (I : State W V M) {Y Z : Finset V} (hZY : Z ⊆ Y) :
       exact ⟨f, ⟨f, hf, Set.eqOn_refl f _⟩, hfg⟩
 
 /-- Restriction to a sub-base weakens the state. -/
-theorem restrict_le {I : State W V M} {Y : Finset V} (h : Y ⊆ I.base) :
+theorem restrict_le (h : Y ⊆ I.base) :
     I.restrict Y ≤ I :=
   ⟨h, fun p hp => ⟨p.assignment, hp, Set.eqOn_refl p.assignment _⟩⟩
 
 /-- Restriction is the *best* `Y`-supported approximation: for states based
 below `Y`, lying below `I.restrict Y` is lying below `I`. -/
-theorem le_restrict_iff {I J : State W V M} {Y : Finset V}
-    (hJ : J.base ⊆ Y) (hY : Y ⊆ I.base) : J ≤ I.restrict Y ↔ J ≤ I := by
+theorem le_restrict_iff (hJ : J.base ⊆ Y) (hY : Y ⊆ I.base) : J ≤ I.restrict Y ↔ J ≤ I := by
   constructor
   · exact fun h => h.trans (restrict_le hY)
   · rintro ⟨hb, hc⟩
@@ -312,7 +307,7 @@ theorem le_restrict_iff {I J : State W V M} {Y : Finset V}
 abbrev fiber (W M : Type*) {V : Type*} (X : Finset V) : Type _ :=
   {I : State W V M // I.base = X}
 
-theorem fiber_supported {X : Finset V} (I : fiber W M X) :
+theorem fiber_supported (I : fiber W M X) :
     BaseSupported X I.1.carrier :=
   (congrArg (fun b => BaseSupported b I.1.carrier) I.2).mp I.1.supported
 
@@ -332,16 +327,16 @@ def fiberEquiv (X : Finset V) :
     induction q using Quotient.ind
     exact Iff.rfl
 
-@[simp] theorem mem_fiberEquiv {X : Finset V} {I : fiber W M X} {p : Possibility W V M} :
+@[simp] theorem mem_fiberEquiv {I : fiber W M X} :
     Quotient.mk _ p ∈ fiberEquiv X I ↔ p ∈ I.1 := Iff.rfl
 
-@[simp] theorem mem_fiberEquiv_symm {X : Finset V} {p : Possibility W V M}
+@[simp] theorem mem_fiberEquiv_symm
     {T : Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V)))} :
     p ∈ ((fiberEquiv X).symm T).1 ↔ Quotient.mk _ p ∈ T := Iff.rfl
 
 /-- The equivalence is the image of the carrier in the collapsed space —
 the sibling of `prop_eq_image`, one rung up the ladder. -/
-theorem fiberEquiv_eq_image {X : Finset V} (I : fiber W M X) :
+theorem fiberEquiv_eq_image (I : fiber W M X) :
     fiberEquiv X I = Quotient.mk _ '' I.1.carrier := by
   have h := (fiber_supported I).preimage_image_mk
   ext q

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 import Linglib.Core.Logic.Bilateral.Defs
 import Mathlib.Algebra.Group.Defs
 

--- a/Linglib/Semantics/TypeTheoretic/Discourse.lean
+++ b/Linglib/Semantics/TypeTheoretic/Discourse.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.TypeTheoretic.Basic
-import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 import Linglib.Semantics.Mood.Defs
 import Linglib.Features.ClauseForm
 

--- a/Linglib/Studies/Dekker2012.lean
+++ b/Linglib/Studies/Dekker2012.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Dynamic.PLA.Update
-import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 
 /-!
 # Dekker (2012): Predicate Logic with Anaphora vs Bilateral Update Semantics

--- a/Linglib/Studies/Heim1982/FileChangeSemantics.lean
+++ b/Linglib/Studies/Heim1982/FileChangeSemantics.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.Possibility
+import Linglib.Semantics.Dynamic.InfoState
 
 /-!
 # File Change Semantics


### PR DESCRIPTION
Module docstrings across the based spine restructured to mathlib's convention (intro, `## Main definitions`, `## Main results`, `## Implementation notes`, `## References` — after `Order/Filter/Defs` and `GroupTheory/Complement`), and recurring binders lifted to `variable` blocks (`{X Y : Finset V} {S T : Set (Possibility W V M)}`, `{I I' J : State W V M}`). Also resolves the Possibility/State division-of-labor muddle: the register-form layer (`InfoState`, its unbased vocabulary, the CCP constructors) moves to its own `InfoState.lean`, leaving `Possibility.lean` as the pure point-object file with Mathlib-leaf imports. Five register-layer consumers repoint; `State.lean`'s import cone drops the level-0 pull-through.