### PR TITLE
feat(Semantics/Dynamic/DRS): DRT's category of contexts

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1640,6 +1640,7 @@ import Linglib.Semantics.Dynamic.Situation
 import Linglib.Semantics.Dynamic.DPL
 import Linglib.Semantics.Dynamic.DRS.Based
 import Linglib.Semantics.Dynamic.DRS.Basic
+import Linglib.Semantics.Dynamic.DRS.Category
 import Linglib.Semantics.Dynamic.DRS.Defs
 import Linglib.Semantics.Dynamic.DRS.Dynamics
 import Linglib.Semantics.Dynamic.DRS.Reduction

--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -187,6 +187,17 @@ def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V) (hK : K.fv ⊆ X) :
   supported_left _ _ _ _ h := DRS.toRelAt_congr_left X K h
   supported_right _ _ _ _ h := DRS.toRelAt_congr_right K hK h
 
+/-- The empty DRS denotes the identity transition. -/
+theorem DRS.transition_empty (W : Type*) (X : Finset V)
+    (h : (DRS.empty : DRS L V).fv ⊆ X) :
+    DRS.empty.transition (M := M) W X h =
+      (Transition.id X).copy rfl (Finset.union_empty X).symm := by
+  apply Transition.ext
+  funext w f g
+  rw [Transition.rel_copy]
+  show (Set.EqOn g f ↑X ∧ _) = _
+  simp [Transition.id, Set.eqOn_comm]
+
 /-- Established referents persist along a DRS transition. -/
 theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
     (hK : K.fv ⊆ X) : (K.transition (M := M) W X hK).IsExtension := by

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -119,6 +119,12 @@ def Condition.occL : List (Condition L V) → Finset V
   | c :: cs => Condition.occ c ∪ Condition.occL cs
 end
 
+@[simp] theorem Condition.occL_append (cs ds : List (Condition L V)) :
+    Condition.occL (cs ++ ds) = Condition.occL cs ∪ Condition.occL ds := by
+  induction cs with
+  | nil => simp [Condition.occL]
+  | cons c cs ih => simp [Condition.occL, ih, Finset.union_assoc]
+
 end Occ
 
 /-! ### Free discourse referents and properness -/

--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -1,0 +1,139 @@
+import Linglib.Semantics.Dynamic.DRS.Based
+import Linglib.Semantics.Dynamic.Category
+
+/-!
+# DRT's category of contexts
+
+Well-formed DRSs are the morphisms of a category whose objects are
+contexts (bases of discourse referents): a morphism `X ⟶ Y` is a DRS
+whose free referents are supplied by `X` (the referential
+presupposition), whose occurring referents are *visible* — declared in
+the context or introduced by the DRS itself — and whose introductions
+are fresh for the context, growing `X` to `Y`. Composition is `merge`;
+identity is the empty DRS.
+
+The visibility invariant is what makes composition unconditional: it
+*derives* the Merging Lemma's capture-freshness side condition, so
+`merge` needs no hypotheses here. Interpretation (`Ctx.sem`) is then an
+identity-on-objects functor into the semantic category of contexts
+`DynamicSemantics.Ctx`, and its functoriality on composition *is* the
+Merging Lemma (`DRS.transition_merge`).
+
+"Category of contexts" is the field's name for this structure: it is a
+syntactic category in the sense of categorical logic (objects are
+contexts, arrows are syntax), and the diachronic information ordering
+of [visser-vermeulen-1996]'s bracketing approach, in which contexts
+under merge form a category ([muskens-van-benthem-visser-2011]'s
+m-categories). `DRT.Ctx` and `DynamicSemantics.Ctx` are owner-relative
+names: DRT's contexts compose by merging representations, dynamic
+semantics' by relational composition of transitions.
+
+## Main definitions
+
+- `DRT.Ctx L V`: contexts, with well-formed DRSs as morphisms and
+  `merge` as composition.
+- `DRT.Ctx.sem`: interpretation as a functor into
+  `DynamicSemantics.Ctx W M V`, given a model of the language.
+
+## References
+
+- [visser-vermeulen-1996], [muskens-1996] (the merge algebra)
+- [kamp-vangenabith-reyle-2011], [kamp-reyle-1993]
+-/
+
+namespace DRT
+
+open CategoryTheory DynamicSemantics FirstOrder
+
+universe u v w
+
+variable {L : Language.{u, v}} {V : Type w} [DecidableEq V]
+
+/-- An object of DRT's category of contexts: a base of discourse
+referents available in the context. -/
+@[ext] structure Ctx (L : Language.{u, v}) (V : Type w) where
+  /-- The available discourse referents. -/
+  base : Finset V
+
+namespace Ctx
+
+/-- A morphism `X ⟶ Y`: a DRS whose free referents are supplied by `X`,
+whose occurring referents are visible, and whose fresh introductions grow
+`X` to `Y`. -/
+@[ext] structure Hom (X Y : Ctx L V) where
+  /-- The underlying DRS. -/
+  drs : DRS L V
+  /-- The referential presupposition: free referents are supplied by the
+  context. -/
+  presup : drs.fv ⊆ X.base
+  /-- Visibility: every occurring referent is contextual or introduced. -/
+  occ_le : Condition.occL drs.conditions ⊆ X.base ∪ drs.referents
+  /-- Introductions are fresh for the context. -/
+  fresh : Disjoint X.base drs.referents
+  /-- The context grows by the introduced referents. -/
+  target : X.base ∪ drs.referents = Y.base
+
+instance : Category (Ctx L V) where
+  Hom := Hom
+  id X :=
+    ⟨DRS.empty, by simp [DRS.empty], by simp [DRS.empty, Condition.occL],
+      by simp [DRS.empty], by simp [DRS.empty]⟩
+  comp {X Y Z} u v :=
+    { drs := u.drs.merge v.drs
+      presup := DRS.fv_merge_subset u.presup (by rw [u.target]; exact v.presup)
+      occ_le := by
+        rw [DRS.merge_conditions, Condition.occL_append, DRS.merge_referents,
+          ← Finset.union_assoc]
+        exact Finset.union_subset
+          (u.occ_le.trans Finset.subset_union_left)
+          (by rw [u.target]; exact v.occ_le)
+      fresh := by
+        rw [DRS.merge_referents, Finset.disjoint_union_right]
+        refine ⟨u.fresh, ?_⟩
+        have : Disjoint Y.base v.drs.referents := v.fresh
+        rw [← u.target] at this
+        exact this.mono_left Finset.subset_union_left
+      target := by
+        rw [DRS.merge_referents, ← Finset.union_assoc, u.target, v.target] }
+  id_comp u := Hom.ext (DRS.empty_merge u.drs)
+  comp_id u := Hom.ext (DRS.merge_empty u.drs)
+  assoc u v w := Hom.ext (DRS.merge_assoc u.drs v.drs w.drs)
+
+@[simp] theorem drs_id (X : Ctx L V) : Hom.drs (𝟙 X) = DRS.empty := rfl
+
+@[simp] theorem drs_comp {X Y Z : Ctx L V} (u : X ⟶ Y) (v : Y ⟶ Z) :
+    (u ≫ v).drs = u.drs.merge v.drs := rfl
+
+/-- **Interpretation is a functor**: a model of `L` sends DRT's category
+of contexts to the semantic one, identically on objects and a DRS to its
+transition — and functoriality on composition is the Merging Lemma, its
+capture-freshness side condition derived from the visibility invariant. -/
+def sem (W M : Type*) [L.Structure M] :
+    Ctx L V ⥤ DynamicSemantics.Ctx W M V where
+  obj X := ⟨X.base⟩
+  map {X Y} u := ⟨(u.drs.transition W X.base u.presup).copy rfl u.target⟩
+  map_id X := by
+    apply DynamicSemantics.Ctx.Hom.ext
+    show ((DRS.empty.transition W X.base _).copy rfl _) = Transition.id X.base
+    rw [DRS.transition_empty]
+    exact (Transition.copy_copy _ _ _ _ _).trans (Transition.copy_rfl _)
+  map_comp {X Y Z} u v := by
+    apply DynamicSemantics.Ctx.Hom.ext
+    have hocc : Condition.occL u.drs.conditions ⊆ Y.base := by
+      rw [← u.target]; exact u.occ_le
+    have hfresh : Disjoint v.drs.referents (Condition.occL u.drs.conditions) :=
+      v.fresh.symm.mono_right hocc
+    have hv : v.drs.fv ⊆ X.base ∪ u.drs.referents := by
+      rw [u.target]; exact v.presup
+    show ((u ≫ v).drs.transition W X.base (u ≫ v).presup).copy rfl (u ≫ v).target =
+      ((u.drs.transition W X.base u.presup).copy rfl u.target).comp
+        ((v.drs.transition W Y.base v.presup).copy rfl v.target)
+    rw [← DRS.transition_copy (M := M) W v.drs u.target hv v.presup,
+      Transition.copy_copy, Transition.copy_comp_copy,
+      DRS.transition_merge (M := M) W u.drs v.drs u.presup hv hfresh,
+      Transition.copy_copy]
+    rfl
+
+end Ctx
+
+end DRT

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -179,6 +179,19 @@ def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X') (hY : Y = Y')
 
 @[simp] theorem copy_rfl (u : Transition W M X Y) : u.copy rfl rfl = u := rfl
 
+@[simp] theorem copy_copy (u : Transition W M X Y) {X' Y' X'' Y'' : Finset V}
+    (hX : X = X') (hY : Y = Y') (hX' : X' = X'') (hY' : Y' = Y'') :
+    (u.copy hX hY).copy hX' hY' = u.copy (hX.trans hX') (hY.trans hY') := by
+  subst hX hY hX' hY'
+  rfl
+
+/-- Repackaged transitions compose to the repackaged composite. -/
+theorem copy_comp_copy (u : Transition W M X Y) (v : Transition W M Y Z)
+    {X' Y' Z' : Finset V} (hX : X = X') (hY : Y = Y') (hZ : Z = Z') :
+    (u.copy hX hY).comp (v.copy hY hZ) = (u.comp v).copy hX hZ := by
+  subst hX hY hZ
+  rfl
+
 /-- Application is invariant under repackaging. -/
 @[simp] theorem apply_copy [DecidableEq V] (u : Transition W M X Y)
     {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') (I : State W V M) :

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4588,6 +4588,20 @@
   validated = {true},
   sources   = {Studies/KampReyle1993.lean}
 }% REF: Kamp, van Genabith & Reyle (2011). Discourse Representation Theory. HPL 15, 125-394.
+@article{visser-vermeulen-1996,
+  author    = {Visser, Albert and Vermeulen, Kees},
+  year      = {1996},
+  title     = {Dynamic Bracketing and Discourse Representation},
+  journal   = {Notre Dame Journal of Formal Logic},
+  volume    = {37},
+  number    = {2},
+  pages     = {321--365},
+  doi       = {10.1305/ndjfl/1040046091},
+  subfield  = {semantics/dynamic},
+  role      = {cited},
+  validated = {true},
+  sources   = {Project Euclid},
+}% REF: Visser & Vermeulen (1996). Dynamic Bracketing and Discourse Representation. NDJFL 37(2), 321-365.
 @incollection{muskens-van-benthem-visser-2011,
   author    = {Muskens, Reinhard and van Benthem, Johan and Visser, Albert},
   year      = {2011},


### PR DESCRIPTION
B4 phase 2: `DRT.Ctx L V` — **the category of contexts**, the field's name for this structure (a syntactic category in the categorical-logic sense; the diachronic ordering of Visser & Vermeulen 1996's bracketing approach, cf. the m-categories of MBV 2011). Objects are contexts (bases); a morphism `X ⟶ Y` is a DRS with the referential presupposition, a *visibility* invariant (`occL conds ⊆ X ∪ referents`), context-freshness, and `X ∪ referents = Y`; composition is `merge` with **no side conditions**, because visibility derives the Merging Lemma's capture-freshness. Owner-relative naming: `DRT.Ctx` (compose by merging representations) vs `DynamicSemantics.Ctx` (compose transitions relationally); `Ctx.sem` interprets the former into the latter identically on objects, and its `map_comp` *is* the Merging Lemma (`transition_merge`), with the copy algebra (`copy_copy`, new `copy_comp_copy`) confining base-index bookkeeping. Support lemmas: `Condition.occL_append`, `DRS.transition_empty`; verified bib entry `visser-vermeulen-1996`.