### PR TITLE
docs(Semantics/Dynamic/DRS): clarify Ctx levels; cite visser-1998

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -21,12 +21,16 @@ Merging Lemma (`DRS.transition_merge`).
 
 "Category of contexts" is the field's name for this structure: it is a
 syntactic category in the sense of categorical logic (objects are
-contexts, arrows are syntax), and the diachronic information ordering
-of [visser-vermeulen-1996]'s bracketing approach, in which contexts
-under merge form a category ([muskens-van-benthem-visser-2011]'s
-m-categories). `DRT.Ctx` and `DynamicSemantics.Ctx` are owner-relative
-names: DRT's contexts compose by merging representations, dynamic
-semantics' by relational composition of transitions.
+contexts — declarations of variables, type theory's *bases*, cf.
+[visser-1998] — and arrows are syntax), and the diachronic information
+ordering of [visser-vermeulen-1996]'s bracketing approach, in which
+contexts under merge form a category
+([muskens-van-benthem-visser-2011]'s m-categories). `DRT.Ctx` and
+`DynamicSemantics.Ctx` name the two levels of DRT's architecture, not
+rival theories: DRT's distinctive *representation* level, where contexts
+compose by merging boxes, and the framework-neutral semantic level,
+where they compose transitions relationally — the level other dynamic
+frameworks interpret into as well.
 
 ## Main definitions
 
@@ -37,7 +41,8 @@ semantics' by relational composition of transitions.
 
 ## References
 
-- [visser-vermeulen-1996], [muskens-1996] (the merge algebra)
+- [visser-vermeulen-1996], [visser-1998], [muskens-1996] (the merge
+  algebra and context typing)
 - [kamp-vangenabith-reyle-2011], [kamp-reyle-1993]
 -/
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4588,6 +4588,19 @@
   validated = {true},
   sources   = {Studies/KampReyle1993.lean}
 }% REF: Kamp, van Genabith & Reyle (2011). Discourse Representation Theory. HPL 15, 125-394.
+@article{visser-1998,
+  author    = {Visser, Albert},
+  year      = {1998},
+  title     = {Contexts in Dynamic Predicate Logic},
+  journal   = {Journal of Logic, Language, and Information},
+  volume    = {7},
+  pages     = {21--52},
+  doi       = {10.1023/A:1008206916207},
+  subfield  = {semantics/dynamic},
+  role      = {cited},
+  validated = {true},
+  sources   = {publisher PDF in hand},
+}% REF: Visser (1998). Contexts in Dynamic Predicate Logic. JoLLI 7, 21-52.
 @article{visser-vermeulen-1996,
   author    = {Visser, Albert and Vermeulen, Kees},
   year      = {1996},


### PR DESCRIPTION
Follow-up to #1454: the two `Ctx`'s are the two levels of DRT's architecture (representation level vs framework-neutral semantic level), not a syntax-theory/semantics-theory split — DRT is itself a dynamic-semantics theory. Cites [visser-1998] (JoLLI 7, verified) for context = declaration of variables / basis.