### PR TITLE
refactor(Semantics/Dynamic/DPL): cleanse; based reading in GS1991 study

### DIFF
--- a/Linglib/Semantics/Dynamic/DPL.lean
+++ b/Linglib/Semantics/Dynamic/DPL.lean
@@ -5,28 +5,24 @@ import Linglib.Semantics.Dynamic.Ty2
 # Dynamic Predicate Logic
 [groenendijk-stokhof-1991]
 
-Stub for Dynamic Predicate Logic (DPL), the foundational dynamic semantic
-theory that treats meanings as relations between assignments.
+The DPL substrate: meanings are relations between total assignments
+(`DPLRel`, the paper's Definition 2), truth is having an output
+(Definition 3), and `♦` closes a meaning to its test (Definition 17).
+Conjunction is relational composition and the existential is random
+reassignment — the two externally dynamic constants; negation,
+implication, disjunction, and the universal are tests. The paper's
+results about the system (scope extension, donkey equivalence, the
+restricted double-negation laws, interdefinability) are proved in
+`Studies/GroenendijkStokhof1991.lean`.
 
-## Key Ideas
+## Main definitions
 
-In DPL:
-- Sentences denote relations between input and output assignments
-- Existential quantification introduces new discourse referents
-- Conjunction is relation composition (dynamic!)
-- Negation is a test (doesn't change assignment)
-
-## Semantic Type
-
-⟦φ⟧ : Assignment → Assignment → Prop
-
-(A sentence maps input assignment to output assignment)
-
-## Key Properties
-
-1. Scope extension: ∃x(φ ∧ ψ) ≡ (∃xφ) ∧ ψ if x not free in ψ
-2. Anaphora: variables persist across conjunction
-3. DNE failure: ¬¬φ ≠ φ for anaphora (negation is a test)
+- `DPLRel` with Definition 2's clauses: `atom`, `conj`, `exists_`,
+  `neg`, `impl`, `disj`, `forall_`; `close` (Definition 17).
+- `trueAt`, `satisfactionSet`, `productionSet` (Definitions 3, 6, 9).
+- `toDRS`/`ofDRS`: a DPL relation is an `Update` over assignments — DPL
+  embeds in dynamic Ty2 at `S = Assignment E`, each connective matching
+  its `DynProp` combinator (`conj_eq_dseq`, `neg_eq_test_dneg`, ...).
 -/
 
 namespace DPL
@@ -34,363 +30,118 @@ namespace DPL
 open DynamicSemantics
 open _root_.Core (Assignment)
 
--- Placeholder: Full implementation TODO
+variable {E : Type*}
 
-/--
-DPL semantic type: relation between assignments.
+/-- DPL semantic type (Definition 2): `⟦φ⟧ g h` means that starting from
+input assignment `g`, the formula `φ` can update to output `h`. -/
+def DPLRel (E : Type*) := (ℕ → E) → (ℕ → E) → Prop
 
-⟦φ⟧(g, h) means: starting from assignment g, the formula φ can
-update to assignment h.
--/
-def DPLRel (E : Type*) := (Nat → E) → (Nat → E) → Prop
-
-/--
-Atomic predicate in DPL: tests without changing assignment.
--/
-def DPLRel.atom {E : Type*} (p : (Nat → E) → Prop) : DPLRel E :=
+/-- Atomic predicate (clauses 1–2): test the input without changing it. -/
+def DPLRel.atom (p : (ℕ → E) → Prop) : DPLRel E :=
   λ g h => g = h ∧ p g
 
-/--
-DPL conjunction: relation composition.
-
-⟦φ ∧ ψ⟧(g, h) iff ∃k. ⟦φ⟧(g, k) ∧ ⟦ψ⟧(k, h)
--/
-def DPLRel.conj {E : Type*} (φ ψ : DPLRel E) : DPLRel E :=
+/-- Conjunction (clause 4): relation composition —
+`⟦φ ∧ ψ⟧ g h` iff `∃k, ⟦φ⟧ g k ∧ ⟦ψ⟧ k h`. -/
+def DPLRel.conj (φ ψ : DPLRel E) : DPLRel E :=
   λ g h => ∃ k, φ g k ∧ ψ k h
 
-/--
-DPL existential: random assignment then scope.
-
-⟦∃x.φ⟧(g, h) iff ∃d. ⟦φ⟧(g[x↦d], h)
--/
-def DPLRel.exists_ {E : Type*} (x : Nat) (φ : DPLRel E) : DPLRel E :=
+/-- Existential quantification (clause 7): random assignment at `x`,
+then the scope — `⟦∃x φ⟧ g h` iff `∃d, ⟦φ⟧ g[x↦d] h`. -/
+def DPLRel.exists_ (x : ℕ) (φ : DPLRel E) : DPLRel E :=
   λ g h => ∃ d : E, φ (λ n => if n = x then d else g n) h
 
-/--
-DPL negation: test without changing assignment.
-
-⟦¬φ⟧(g, h) iff g = h ∧ ¬∃k. ⟦φ⟧(g, k)
-
-Note: this does not validate DNE.
--/
-def DPLRel.neg {E : Type*} (φ : DPLRel E) : DPLRel E :=
+/-- Negation (clause 3): the test that no output is reachable —
+`⟦¬φ⟧ g h` iff `g = h ∧ ¬∃k, ⟦φ⟧ g k`. Not DNE-valid: see
+`Studies/GroenendijkStokhof1991.lean`. -/
+def DPLRel.neg (φ : DPLRel E) : DPLRel E :=
   λ g h => g = h ∧ ¬∃ k, φ g k
 
--- Key Theorems (TODO: Prove)
-
-/--
-DPL does not validate DNE for anaphora.
-
-¬¬∃x.φ is not equivalent to ∃x.φ because negation resets the output assignment:
-`neg(neg(exists_ x φ)) g h` forces `g = h` (it's a test), while `exists_ x φ`
-can change the assignment to export a witness.
-
-Requires `Nontrivial E` (at least 2 elements): for `Unit`, all assignments are
-identical and DNE holds vacuously.
--/
-theorem dpl_dne_fails_anaphora {E : Type*} [Nontrivial E] :
-    ∃ (x : Nat) (φ : DPLRel E),
-      DPLRel.neg (DPLRel.neg (DPLRel.exists_ x φ)) ≠ DPLRel.exists_ x φ := by
-  obtain ⟨e₁, e₂, hne⟩ := exists_pair_ne E
-  refine ⟨0, λ g h => g = h, ?_⟩
-  intro heq
-  -- exists_ 0 (=) at (λ _ => e₁, λ n => if n=0 then e₂ else e₁) is true (d = e₂)
-  -- neg(neg(exists_ 0 (=))) at same args requires g = h, which fails (e₁ ≠ e₂)
-  have hrhs : (DPLRel.exists_ 0 (λ (g h : Nat → E) => g = h))
-              (λ _ => e₁) (λ n => if n = 0 then e₂ else e₁) :=
-    ⟨e₂, rfl⟩
-  rw [← heq] at hrhs
-  have h_eq := congr_fun hrhs.1 0
-  simp at h_eq
-  exact hne h_eq
-
-/--
-Scope extension theorem: ∃x(φ ∧ ψ) ≡ (∃xφ) ∧ ψ when x not free in ψ.
-
-"Not free in ψ" means ψ is invariant under reassigning x in both input and output
-assignments. Under this condition, the existential can scope out past conjunction.
-
-TODO: Prove by extensionality and reordering existential quantifiers.
--/
-theorem scope_extension {E : Type*} (x : Nat) (φ ψ : DPLRel E)
-    (_hfree : ∀ (g h : Nat → E) (d : E),
-      ψ g h ↔ ψ (λ n => if n = x then d else g n) (λ n => if n = x then d else h n)) :
-    DPLRel.exists_ x (DPLRel.conj φ ψ) = DPLRel.conj (DPLRel.exists_ x φ) ψ := by
-  funext g h
-  simp only [DPLRel.exists_, DPLRel.conj, eq_iff_iff]
-  constructor
-  · rintro ⟨d, k, hφ, hψ⟩
-    exact ⟨k, ⟨d, hφ⟩, hψ⟩
-  · rintro ⟨k, ⟨d, hφ⟩, hψ⟩
-    exact ⟨d, k, hφ, hψ⟩
-
--- ════════════════════════════════════════════════════════════════
--- § Definition 2: Remaining Connectives (clauses 5, 6, 8)
--- ════════════════════════════════════════════════════════════════
-
-/--
-DPL implication: internally dynamic, externally static.
-
-⟦φ → ψ⟧(g, h) iff g = h and every output of φ from g can be
-extended by ψ. Implication passes on bindings from its antecedent
-to its consequent (internally dynamic), but the implication as a
-whole is a test (externally static). This gives existential
-quantifiers in the antecedent *universal* force — the key to
-donkey sentences.
--/
-def DPLRel.impl {E : Type*} (φ ψ : DPLRel E) : DPLRel E :=
+/-- Implication (clause 6): internally dynamic, externally static —
+every output of the antecedent can be extended by the consequent. The
+antecedent passes bindings to the consequent, giving its existentials
+universal force (donkey sentences). -/
+def DPLRel.impl (φ ψ : DPLRel E) : DPLRel E :=
   λ g h => g = h ∧ ∀ k, φ g k → ∃ j, ψ k j
 
-/--
-DPL disjunction: externally and internally static.
-
-⟦φ ∨ ψ⟧(g, h) iff g = h and at least one disjunct can be
-successfully processed from g. No anaphoric relations are
-possible between or across disjuncts.
--/
-def DPLRel.disj {E : Type*} (φ ψ : DPLRel E) : DPLRel E :=
+/-- Disjunction (clause 5): externally and internally static — no
+anaphoric relations across or out of the disjuncts. -/
+def DPLRel.disj (φ ψ : DPLRel E) : DPLRel E :=
   λ g h => g = h ∧ ∃ k, φ g k ∨ ψ g k
 
-/--
-DPL universal quantification: a test.
-
-⟦∀x.φ⟧(g, h) iff g = h and for every value d at position x,
-φ can be successfully processed. Like negation, implication,
-and disjunction, the universal quantifier is externally static.
--/
-def DPLRel.forall_ {E : Type*} (x : Nat) (φ : DPLRel E) : DPLRel E :=
+/-- Universal quantification (clause 8): a test — for every value at
+`x`, the scope can be processed. Externally static. -/
+def DPLRel.forall_ (x : ℕ) (φ : DPLRel E) : DPLRel E :=
   λ g h => g = h ∧ ∀ d : E, ∃ m, φ (λ n => if n = x then d else g n) m
 
-/--
-DPL closure (the ◇ operator, Definition 17).
-
-⟦◇φ⟧(g, h) iff g = h and φ can be successfully processed from g.
-Closure turns any formula into a test with the same truth conditions.
--/
-def DPLRel.close {E : Type*} (φ : DPLRel E) : DPLRel E :=
+/-- Closure (Definition 17): `⟦♦φ⟧ g h` iff `g = h` and `φ` can be
+successfully processed — the test with `φ`'s truth conditions. -/
+def DPLRel.close (φ : DPLRel E) : DPLRel E :=
   λ g h => g = h ∧ ∃ k, φ g k
 
--- ════════════════════════════════════════════════════════════════
--- § Semantic Notions (Definitions 3, 6, 9)
--- ════════════════════════════════════════════════════════════════
+/-! ### Semantic notions (Definitions 3, 6, 9) -/
 
-/-- Truth (Definition 3): φ is true w.r.t. g iff it has an output. -/
-def DPLRel.trueAt {E : Type*} (φ : DPLRel E) (g : Nat → E) : Prop :=
+/-- Truth (Definition 3): `φ` is true w.r.t. `g` iff it has an output. -/
+def DPLRel.trueAt (φ : DPLRel E) (g : ℕ → E) : Prop :=
   ∃ h, φ g h
 
-/-- Satisfaction set (Definition 6): inputs from which φ succeeds. -/
-def DPLRel.satisfactionSet {E : Type*} (φ : DPLRel E) : Set (Nat → E) :=
+/-- Satisfaction set (Definition 6): inputs from which `φ` succeeds. -/
+def DPLRel.satisfactionSet (φ : DPLRel E) : Set (ℕ → E) :=
   { g | ∃ h, φ g h }
 
-/-- Production set (Definition 9): possible outputs of φ. -/
-def DPLRel.productionSet {E : Type*} (φ : DPLRel E) : Set (Nat → E) :=
+/-- Production set (Definition 9): possible outputs of `φ`. -/
+def DPLRel.productionSet (φ : DPLRel E) : Set (ℕ → E) :=
   { h | ∃ g, φ g h }
 
--- ════════════════════════════════════════════════════════════════
--- § Interdefinability of Connectives (§3.4)
--- ════════════════════════════════════════════════════════════════
+/-! ### DPL as dynamic Ty2
 
-/-! The connectives `→`, `∨`, `∀x` are interdefinable from `¬`, `∧`, `∃x`.
-This is the standard classical interdefinability — but crucially, the
-*reverse* does not hold in DPL: `∧` and `∃x` cannot be defined from
-`→`, `∨`, `∀x` because the latter are all externally static. -/
+DPL embeds directly into dynamic Ty2 at `S = Assignment E`: DPL
+assignments are Ty2 states, DPL relations are `Update` meanings, and
+each connective matches its `DynProp` combinator. -/
 
-/-- `φ → ψ ≈ ¬(φ ∧ ¬ψ)` — implication from conjunction and negation. -/
-theorem impl_interdefinable {E : Type*} (φ ψ : DPLRel E) :
-    DPLRel.impl φ ψ = DPLRel.neg (DPLRel.conj φ (DPLRel.neg ψ)) := by
-  funext g h
-  simp only [DPLRel.impl, DPLRel.neg, DPLRel.conj, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, hall⟩
-    refine ⟨rfl, fun ⟨k, m, hφ, hmk, hnψ⟩ => ?_⟩
-    subst hmk; exact hnψ (hall m hφ)
-  · rintro ⟨rfl, hneg⟩
-    exact ⟨rfl, fun k hφ => by_contra fun hne => hneg ⟨k, k, hφ, rfl, hne⟩⟩
-
-/-- `φ ∨ ψ ≈ ¬(¬φ ∧ ¬ψ)` — disjunction from conjunction and negation. -/
-theorem disj_interdefinable {E : Type*} (φ ψ : DPLRel E) :
-    DPLRel.disj φ ψ = DPLRel.neg (DPLRel.conj (DPLRel.neg φ) (DPLRel.neg ψ)) := by
-  funext g h
-  simp only [DPLRel.disj, DPLRel.neg, DPLRel.conj, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, k, hφψ⟩
-    refine ⟨rfl, ?_⟩
-    rintro ⟨_, m, ⟨rfl, hnφ⟩, rfl, hnψ⟩
-    cases hφψ with
-    | inl hφ => exact hnφ ⟨k, hφ⟩
-    | inr hψ => exact hnψ ⟨k, hψ⟩
-  · rintro ⟨rfl, hneg⟩
-    refine ⟨rfl, by_contra fun hne => ?_⟩
-    push_neg at hne
-    exact hneg ⟨g, g, ⟨rfl, fun ⟨j, hφ⟩ => (hne j).1 hφ⟩,
-      rfl, fun ⟨j, hψ⟩ => (hne j).2 hψ⟩
-
-/-- `∀x.φ ≈ ¬∃x.¬φ` — universal from existential and negation. -/
-theorem forall_interdefinable {E : Type*} (x : Nat) (φ : DPLRel E) :
-    DPLRel.forall_ x φ = DPLRel.neg (DPLRel.exists_ x (DPLRel.neg φ)) := by
-  funext g h
-  simp only [DPLRel.forall_, DPLRel.neg, DPLRel.exists_, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, hall⟩
-    refine ⟨rfl, ?_⟩
-    rintro ⟨k, d, rfl, hneg⟩
-    exact hneg (hall d)
-  · rintro ⟨rfl, hneg⟩
-    refine ⟨rfl, fun d => by_contra fun hne => hneg ⟨_, d, rfl, hne⟩⟩
-
--- ════════════════════════════════════════════════════════════════
--- § Key Equivalences
--- ════════════════════════════════════════════════════════════════
-
-/--
-**¬∃xφ ≈ ∀x¬φ** — negation commutes with quantifier switch.
-
-This follows from the fact that negation turns anything into a test.
--/
-theorem neg_exists_eq_forall_neg {E : Type*} (x : Nat) (φ : DPLRel E) :
-    DPLRel.neg (DPLRel.exists_ x φ) = DPLRel.forall_ x (DPLRel.neg φ) := by
-  funext g h
-  simp only [DPLRel.neg, DPLRel.exists_, DPLRel.forall_, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, hneg⟩
-    refine ⟨rfl, fun d => ⟨_, rfl, fun ⟨k, hφ⟩ => hneg ⟨k, d, hφ⟩⟩⟩
-  · rintro ⟨rfl, hall⟩
-    refine ⟨rfl, ?_⟩
-    rintro ⟨k, d, hφ⟩
-    obtain ⟨m, rfl, hneg⟩ := hall d
-    exact hneg ⟨k, hφ⟩
-
-/--
-**The donkey equivalence: ∃xφ → ψ ≈ ∀x[φ → ψ]**
-
-The central theorem of [groenendijk-stokhof-1991]: an existential
-quantifier in the antecedent of an implication has *universal* force.
-This is what makes donkey sentences compositional — "if a farmer owns
-a donkey, he beats it" gets the universal reading from the dynamic
-semantics of implication alone, without stipulating wide-scope ∀.
--/
-theorem donkey_equivalence {E : Type*} (x : Nat) (φ ψ : DPLRel E) :
-    DPLRel.impl (DPLRel.exists_ x φ) ψ =
-    DPLRel.forall_ x (DPLRel.impl φ ψ) := by
-  funext g h
-  simp only [DPLRel.impl, DPLRel.exists_, DPLRel.forall_, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, hall⟩
-    refine ⟨rfl, fun d => ⟨_, rfl, fun k hφ => hall k ⟨d, hφ⟩⟩⟩
-  · rintro ⟨rfl, hall⟩
-    refine ⟨rfl, fun k ⟨d, hφ⟩ => ?_⟩
-    obtain ⟨m, rfl, himpl⟩ := hall d
-    exact himpl k hφ
-
-/--
-**Conjunction is not commutative in DPL.**
-
-`∃xPx ∧ Qx` and `Qx ∧ ∃xPx` differ because in the first,
-∃x binds x in Qx (left-to-right binding), while in the second,
-Qx uses x's current value before ∃x reassigns it.
-
-Requires `Nontrivial E` so that reassignment can change the value.
--/
-theorem conj_not_comm {E : Type*} [Nontrivial E] :
-    ∃ (φ ψ : DPLRel E), DPLRel.conj φ ψ ≠ DPLRel.conj ψ φ := by
-  obtain ⟨e₁, e₂, hne⟩ := exists_pair_ne E
-  -- φ = ∃₀(identity): random reassignment at variable 0
-  let φ : DPLRel E := DPLRel.exists_ 0 (λ g h => g = h)
-  -- ψ = test that variable 0 equals e₁
-  let ψ : DPLRel E := DPLRel.atom (λ g => g 0 = e₁)
-  refine ⟨φ, ψ, ?_⟩
-  intro heq
-  -- conj φ ψ accepts input (λ _ => e₂) by setting var 0 to e₁
-  have hfwd : (DPLRel.conj φ ψ) (λ _ => e₂)
-      (λ n => if n = 0 then e₁ else e₂) := by
-    refine ⟨λ n => if n = 0 then e₁ else e₂, ⟨e₁, ?_⟩, rfl, ?_⟩
-    · funext n; simp
-    · simp
-  -- conj ψ φ rejects input (λ _ => e₂) because ψ tests g(0) = e₁ first
-  rw [heq] at hfwd
-  obtain ⟨k, ⟨rfl, hk0⟩, _⟩ := hfwd
-  simp at hk0
-  exact hne hk0.symm
-
--- ════════════════════════════════════════════════════════════════
--- § Closure Properties (Definition 17)
--- ════════════════════════════════════════════════════════════════
-
-/-- ◇φ ≈ ¬¬φ — closure is double negation (s-equivalence). -/
-theorem close_eq_neg_neg {E : Type*} (φ : DPLRel E) :
-    DPLRel.close φ = DPLRel.neg (DPLRel.neg φ) := by
-  funext g h
-  simp only [DPLRel.close, DPLRel.neg, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, k, hφ⟩
-    exact ⟨rfl, fun ⟨_, rfl, hneg⟩ => hneg ⟨k, hφ⟩⟩
-  · rintro ⟨rfl, hneg⟩
-    exact ⟨rfl, by_contra fun hne => hneg ⟨g, rfl, hne⟩⟩
-
-/-- Implication is a test: ⟦φ → ψ⟧(g, h) implies g = h. -/
-theorem impl_isTest {E : Type*} (φ ψ : DPLRel E) (g h : Nat → E)
-    (h_impl : DPLRel.impl φ ψ g h) : g = h := h_impl.1
-
-/-- Disjunction is a test. -/
-theorem disj_isTest {E : Type*} (φ ψ : DPLRel E) (g h : Nat → E)
-    (h_disj : DPLRel.disj φ ψ g h) : g = h := h_disj.1
-
-/-- Universal quantification is a test. -/
-theorem forall_isTest {E : Type*} (x : Nat) (φ : DPLRel E) (g h : Nat → E)
-    (h_fa : DPLRel.forall_ x φ g h) : g = h := h_fa.1
-
-/-! ## DPL-as-Dynamic-Ty2
-
-DPL embeds directly into Dynamic Ty2 with `S = Assignment E = Nat → E`.
-DPL assignments ARE Dynamic Ty2 assignments; DPL relations ARE Update meanings.
-The cylindric algebra bridges (`closure(∃) = cylindrify`, `closure(=) = diagonal`)
-live in `Studies/GroenendijkStokhof1991.lean` (DPL) and `Studies/Muskens1996.lean` (CDRT).
--/
-
-/-- DPL dref: projection function for variable n. -/
-def dref {E : Type*} (n : Nat) : Dref (Assignment E) E := λ g => g n
+/-- DPL dref: projection function for variable `n`. -/
+def dref (n : ℕ) : Dref (Assignment E) E := λ g => g n
 
 /-- DPL extend is `Function.update`. -/
-abbrev extend {E : Type*} (g : Assignment E) (n : Nat) (e : E) : Assignment E :=
+abbrev extend (g : Assignment E) (n : ℕ) (e : E) : Assignment E :=
   Function.update g n e
 
-theorem extend_at {E : Type*} (g : Assignment E) (n : Nat) (e : E) :
+theorem extend_at (g : Assignment E) (n : ℕ) (e : E) :
     dref n (extend g n e) = e := by simp [dref, extend]
 
-theorem extend_other {E : Type*} (g : Assignment E) (n m : Nat) (e : E) (h : n ≠ m) :
+theorem extend_other (g : Assignment E) (n m : ℕ) (e : E) (h : n ≠ m) :
     dref m (extend g n e) = dref m g := by simp [dref, extend, h.symm]
 
-/-- DPL relation IS an Update over `Assignment E`. -/
-def toDRS {E : Type*} (φ : DPLRel E) : Update (Assignment E) := φ
+/-- A DPL relation is an `Update` over `Assignment E`. -/
+def toDRS (φ : DPLRel E) : Update (Assignment E) := φ
 
-/-- Update IS a DPL relation. -/
-def ofDRS {E : Type*} (D : Update (Assignment E)) : DPLRel E := D
+/-- An `Update` is a DPL relation. -/
+def ofDRS (D : Update (Assignment E)) : DPLRel E := D
 
-@[simp] theorem toDRS_ofDRS {E : Type*} (φ : DPLRel E) : ofDRS (toDRS φ) = φ := rfl
-@[simp] theorem ofDRS_toDRS {E : Type*} (D : Update (Assignment E)) : toDRS (ofDRS D) = D := rfl
+@[simp] theorem toDRS_ofDRS (φ : DPLRel E) : ofDRS (toDRS φ) = φ := rfl
+@[simp] theorem ofDRS_toDRS (D : Update (Assignment E)) : toDRS (ofDRS D) = D := rfl
 
-theorem atom_eq_test {E : Type*} (p : Assignment E → Prop) :
+theorem atom_eq_test (p : Assignment E → Prop) :
     toDRS (DPLRel.atom p) = test (λ g => p g) := by
   ext g h
-  simp only [toDRS, DPLRel.atom, test, eq_iff_iff]
+  simp only [toDRS, DPLRel.atom, test]
   constructor
   · intro ⟨heq, hp⟩; exact ⟨heq, by rw [← heq]; exact hp⟩
   · intro ⟨heq, hp⟩; exact ⟨heq, by rw [heq]; exact hp⟩
 
-theorem conj_eq_dseq {E : Type*} (φ ψ : DPLRel E) :
+theorem conj_eq_dseq (φ ψ : DPLRel E) :
     toDRS (DPLRel.conj φ ψ) = dseq (toDRS φ) (toDRS ψ) := by
   ext g h
   simp only [toDRS, DPLRel.conj, dseq, Relation.Comp]
 
-theorem neg_eq_test_dneg {E : Type*} (φ : DPLRel E) :
+theorem neg_eq_test_dneg (φ : DPLRel E) :
     toDRS (DPLRel.neg φ) = test (dneg (toDRS φ)) := by
   ext g h
-  simp only [toDRS, DPLRel.neg, test, dneg, eq_iff_iff]
+  simp only [toDRS, DPLRel.neg, test, dneg]
   constructor
   · intro ⟨heq, hnex⟩; exact ⟨heq, by rw [← heq]; exact hnex⟩
   · intro ⟨heq, hnex⟩; exact ⟨heq, by rw [heq]; exact hnex⟩
 
-theorem exists_eq {E : Type*} (x : Nat) (φ : DPLRel E) :
+theorem exists_eq (x : ℕ) (φ : DPLRel E) :
     toDRS (DPLRel.exists_ x φ) = λ g h => ∃ d : E, toDRS φ (extend g x d) h := by
   have hup : ∀ (g : Assignment E) (d : E),
       (fun n => if n = x then d else g n) = Function.update g x d := fun g d => by
@@ -398,37 +149,35 @@ theorem exists_eq {E : Type*} (x : Nat) (φ : DPLRel E) :
   funext g h
   exact propext (exists_congr fun d => by rw [hup g d]; exact Iff.rfl)
 
-/-- **DPL implication = test of dynamic implication.** -/
-theorem impl_eq_test_dimpl {E : Type*} (φ ψ : DPLRel E) :
+/-- DPL implication is the test of dynamic implication. -/
+theorem impl_eq_test_dimpl (φ ψ : DPLRel E) :
     toDRS (DPLRel.impl φ ψ) = test (dimpl (toDRS φ) (toDRS ψ)) := by
   ext g h
-  simp only [toDRS, DPLRel.impl, test, dimpl, eq_iff_iff]
+  simp only [toDRS, DPLRel.impl, test, dimpl]
   constructor
   · intro ⟨heq, hall⟩; exact ⟨heq, by rw [← heq]; exact hall⟩
   · intro ⟨heq, hall⟩; exact ⟨heq, by rw [heq]; exact hall⟩
 
-/-- **DPL disjunction = test of dynamic disjunction.** -/
-theorem disj_eq_test_ddisj {E : Type*} (φ ψ : DPLRel E) :
+/-- DPL disjunction is the test of dynamic disjunction. -/
+theorem disj_eq_test_ddisj (φ ψ : DPLRel E) :
     toDRS (DPLRel.disj φ ψ) = test (ddisj (toDRS φ) (toDRS ψ)) := by
   ext g h
-  simp only [toDRS, DPLRel.disj, test, ddisj, eq_iff_iff]
+  simp only [toDRS, DPLRel.disj, test, ddisj]
   constructor
   · intro ⟨heq, hd⟩; exact ⟨heq, by rw [← heq]; exact hd⟩
   · intro ⟨heq, hd⟩; exact ⟨heq, by rw [heq]; exact hd⟩
 
-/-- **DPL closure = test of existential closure.** -/
-theorem close_eq_test_closure {E : Type*} (φ : DPLRel E) :
+/-- DPL closure is the test of existential closure. -/
+theorem close_eq_test_closure (φ : DPLRel E) :
     toDRS (DPLRel.close φ) = test (closure (toDRS φ)) := by
   ext g h
-  simp only [toDRS, DPLRel.close, test, closure, eq_iff_iff]
+  simp only [toDRS, DPLRel.close, test, closure]
   constructor
   · intro ⟨heq, hc⟩; exact ⟨heq, by rw [← heq]; exact hc⟩
   · intro ⟨heq, hc⟩; exact ⟨heq, by rw [heq]; exact hc⟩
 
-/-- **DPL truth = existential closure.** -/
-theorem trueAt_eq_closure {E : Type*} (φ : DPLRel E) (g : Assignment E) :
+/-- DPL truth is existential closure. -/
+theorem trueAt_eq_closure (φ : DPLRel E) (g : Assignment E) :
     DPLRel.trueAt φ g ↔ closure (toDRS φ) g := Iff.rfl
-
-export DPLRel (atom conj exists_ neg impl disj forall_ close)
 
 end DPL

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -161,6 +161,43 @@ theorem apply_comp (u : Transition W M X Y) (v : Transition W M Y Z)
 
 end Apply
 
+/-! ### Random assignment -/
+
+section RandomAssign
+variable [DecidableEq V]
+
+/-- The random-assignment transition ([groenendijk-stokhof-1991]'s random
+reset `k[x]g`, [heim-1982]'s indefinite widening): read the input off `x`,
+leave the output free at `x` — the generating arrow `X ⟶ insert x X` of
+context extension. -/
+def randomAssign (X : Finset V) (x : V) : Transition W M X (insert x X) where
+  rel _ f h := Set.EqOn f h ↑(X.erase x)
+  grow := Finset.subset_insert x X
+  supported_left _ _ _ _ hff' :=
+    have hsub : (↑(X.erase x) : Set V) ⊆ ↑X :=
+      Finset.coe_subset.mpr (Finset.erase_subset ..)
+    ⟨((hff'.mono hsub).symm.trans ·), ((hff'.mono hsub).trans ·)⟩
+  supported_right _ _ _ _ hgg' :=
+    have hsub : (↑(X.erase x) : Set V) ⊆ ↑(insert x X) :=
+      Finset.coe_subset.mpr ((Finset.erase_subset ..).trans (Finset.subset_insert ..))
+    ⟨(·.trans (hgg'.mono hsub)), (·.trans (hgg'.symm.mono hsub))⟩
+
+@[simp] theorem rel_randomAssign {x : V} {w : W} {f h : V → M} :
+    (randomAssign (M := M) X x).rel w f h ↔ Set.EqOn f h ↑(X.erase x) :=
+  Iff.rfl
+
+/-- Applying the random-assignment transition at a state's own base is the
+state-level random assignment of `State.lean`. -/
+theorem randomAssign_apply (I : State W V M) (x : V) :
+    (randomAssign I.base x).apply I = I.randomAssign x := by
+  ext1
+  · exact Finset.union_eq_right.mpr (Finset.subset_insert ..)
+  · ext ⟨w, g⟩
+    rw [State.mem_carrier, mem_apply]
+    exact Iff.rfl
+
+end RandomAssign
+
 /-! ### Repackaging along base equalities
 
 The substrate-safe form of `eqToHom` conjugation (mathlib's `Filter.copy`

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Dynamic.UpdateSemantics.Bilateral
 import Linglib.Semantics.Dynamic.DPL
+import Linglib.Studies.GroenendijkStokhof1991
 import Linglib.Data.Examples.ElliottSudo2025
 
 /-!
@@ -338,7 +339,7 @@ theorem dpl_diverges_on_double_negation [Nontrivial E] :
     Examples.double_negation.judgment = .acceptable ∧
     ∃ (x : Nat) (φ : DPL.DPLRel E),
       DPL.DPLRel.neg (.neg (.exists_ x φ)) ≠ .exists_ x φ :=
-  ⟨rfl, DPL.dpl_dne_fails_anaphora⟩
+  ⟨rfl, GroenendijkStokhof1991.dne_fails_anaphora⟩
 
 /-! ### Bathroom configuration -/
 

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -1,192 +1,279 @@
 import Linglib.Core.Logic.CylindricAlgebra
 import Linglib.Semantics.Dynamic.DPL
+import Linglib.Semantics.Dynamic.Transition
 
 /-!
 # Groenendijk & Stokhof (1991): Dynamic Predicate Logic
 [groenendijk-stokhof-1991]
 
-Dynamic Predicate Logic. *Linguistics and Philosophy* 14(1): 39-100.
+Dynamic Predicate Logic. *Linguistics and Philosophy* 14(1): 39–100.
+The DPL substrate (`DPLRel`, Definition 2) lives in
+`Semantics/Dynamic/DPL.lean`; this file proves the paper's claims about
+it.
 
-## Key Claims Verified
+## Main results
 
-1. **Cross-sentential anaphora** (§2.1): Existential quantifiers bind
-   variables across conjunction (`scope_extension`).
-
-2. **Donkey sentences** (§2.4): Existential quantifiers in the antecedent
-   of an implication have universal force (`donkey_equivalence`).
-
-3. **Blocking** (§2.5): Universal quantifiers, negation, implication, and
-   disjunction are externally static — they do not export bindings.
-
-4. **DNE failure** (§3.4): Double negation elimination fails for anaphora
-   (`dpl_dne_fails_anaphora`), because negation resets the output assignment.
-
-5. **Interdefinability** (§3.4): `→`, `∨`, `∀` are definable from `¬`, `∧`, `∃`,
-   but not vice versa — the DPL asymmetry.
+- `scope_extension`, `donkey_equivalence`: the two central equivalences —
+  existentials bind across conjunction (`∃xφ ∧ ψ ≃ ∃x[φ ∧ ψ]`), and get
+  universal force in conditional antecedents (`∃xφ → ψ ≃ ∀x[φ → ψ]`),
+  both unconditional (they are the normal-binding-form equivalences of
+  Fact 17, §3.6).
+- Blocking (§2.5): `neg`, `impl`, `disj`, `forall_` are tests — no
+  binding escapes.
+- §3.4's logical facts: `conj_assoc`, `conj_not_comm`,
+  `close_eq_neg_neg` (`♦φ ≃ ¬¬φ`), the restricted double-negation law
+  `neg_neg_eq_self_iff_isTest` (`¬¬φ ≃ φ` iff `φ` is a test), its
+  anaphoric consequence `dne_fails_anaphora`, and the
+  interdefinability of `→`, `∨`, `∀` from `¬`, `∧`, `∃`.
+- `closure_exists_eq_cylindrify` and friends: the satisfaction-set
+  computations from Fact 19's proof (§3.6), in cylindric-algebra
+  vocabulary.
+- The based reading: DPL's generators as context-extension arrows
+  (`testTransition`, `Transition.randomAssign`), with clause 4 as
+  transition composition and clause 7 factoring through the
+  random-assignment arrow.
 -/
 
 namespace GroenendijkStokhof1991
 
 open DPL
 
--- ════════════════════════════════════════════════════════════════
--- § 1. Cross-Sentential Anaphora (§2.1, §2.3)
--- ════════════════════════════════════════════════════════════════
+/-! ### Scope extension (§2.1, §2.3) -/
 
 /-! "A man walks in the park. He whistles."
 
-DPL translation: ∃x[man(x) ∧ walk_in_park(x)] ∧ whistle(x)
+DPL translation: `∃x[man(x) ∧ walk(x)] ∧ whistle(x)`. Scope extension
+makes this equal to `∃x[man(x) ∧ walk(x) ∧ whistle(x)]`: the
+existential binds across conjunction, unconditionally — a later conjunct
+with free `x` is simply captured. This accounts for
+`Heim1982.Examples.indefinite_persists`. -/
 
-The scope extension theorem shows this equals ∃x[man(x) ∧ walk_in_park(x) ∧ whistle(x)]:
-the existential quantifier's binding power extends across conjunction.
+variable {E : Type*}
 
-This accounts for `Heim1982.Examples.indefinite_persists`. -/
+/-- Scope extension: `∃xφ ∧ ψ ≃ ∃x[φ ∧ ψ]` — one of the four
+normal-binding-form equivalences in Fact 17's proof (§3.6), and the
+formal content of cross-sentential anaphora (§2.1). -/
+theorem scope_extension (x : ℕ) (φ ψ : DPLRel E) :
+    DPLRel.exists_ x (DPLRel.conj φ ψ) = DPLRel.conj (DPLRel.exists_ x φ) ψ := by
+  funext g h
+  simp only [DPLRel.exists_, DPLRel.conj, eq_iff_iff]
+  exact ⟨fun ⟨d, k, hφ, hψ⟩ => ⟨k, ⟨d, hφ⟩, hψ⟩,
+    fun ⟨k, ⟨d, hφ⟩, hψ⟩ => ⟨d, k, hφ, hψ⟩⟩
 
-/-- DPL correctly predicts indefinite persistence: scope extension
-ensures ∃x in the first sentence binds x in the second. -/
-theorem indefinite_persistence_predicted :
-    ∀ {E : Type*} (x : Nat) (P Q R : DPLRel E)
-      (hfree : ∀ (g h : Nat → E) (d : E),
-        R g h ↔ R (λ n => if n = x then d else g n)
-                    (λ n => if n = x then d else h n)),
-    DPLRel.exists_ x (DPLRel.conj (DPLRel.conj P Q) R) =
-    DPLRel.conj (DPLRel.exists_ x (DPLRel.conj P Q)) R :=
-  fun x P Q R hfree => scope_extension x (DPLRel.conj P Q) R hfree
-
--- ════════════════════════════════════════════════════════════════
--- § 2. Donkey Sentences (§2.4)
--- ════════════════════════════════════════════════════════════════
+/-! ### Donkey sentences (§2.4) -/
 
 /-! "If a farmer owns a donkey, he beats it."
 
-DPL translation: ∃x[farmer(x) ∧ ∃y[donkey(y) ∧ own(x,y)]] → beat(x,y)
-
-By `donkey_equivalence`, this is equivalent to:
-  ∀x[farmer(x) ∧ ∃y[donkey(y) ∧ own(x,y)] → beat(x,y)]
-
-And applying it again for y:
-  ∀x∀y[farmer(x) ∧ donkey(y) ∧ own(x,y) → beat(x,y)]
-
-This gives the universal "strong" reading recorded for
-`Geach1962.Examples.donkey_classic` and
+DPL translation: `∃x[farmer(x) ∧ ∃y[donkey(y) ∧ own(x,y)]] → beat(x,y)`.
+By `donkey_equivalence` (twice), this equals
+`∀x∀y[farmer(x) ∧ donkey(y) ∧ own(x,y) → beat(x,y)]` — the universal
+"strong" reading recorded for `Geach1962.Examples.donkey_classic` and
 `Heim1982.Examples.conditional_donkey`. -/
 
-/-- The donkey equivalence gives universal force to indefinites in
-conditional antecedents, matching the strong/universal reading of
-`Heim1982.Examples.conditional_donkey`. -/
-theorem donkey_universal_force :
-    ∀ {E : Type*} (x : Nat) (φ ψ : DPLRel E),
+/-- The donkey equivalence: `∃xφ → ψ ≃ ∀x[φ → ψ]`. An existential in the
+antecedent of an implication has universal force — donkey sentences are
+compositional without stipulating wide-scope `∀`. -/
+theorem donkey_equivalence (x : ℕ) (φ ψ : DPLRel E) :
     DPLRel.impl (DPLRel.exists_ x φ) ψ =
-    DPLRel.forall_ x (DPLRel.impl φ ψ) :=
-  fun x φ ψ => donkey_equivalence x φ ψ
+    DPLRel.forall_ x (DPLRel.impl φ ψ) := by
+  funext g h
+  simp only [DPLRel.impl, DPLRel.exists_, DPLRel.forall_, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, hall⟩
+    refine ⟨rfl, fun d => ⟨_, rfl, fun k hφ => hall k ⟨d, hφ⟩⟩⟩
+  · rintro ⟨rfl, hall⟩
+    refine ⟨rfl, fun k ⟨d, hφ⟩ => ?_⟩
+    obtain ⟨m, rfl, himpl⟩ := hall d
+    exact himpl k hφ
 
--- ════════════════════════════════════════════════════════════════
--- § 3. Blocking: Universal Quantifiers are Tests (§2.5)
--- ════════════════════════════════════════════════════════════════
+/-- `¬∃xφ ≃ ∀x¬φ`: negation commutes with the quantifier switch, since
+negation turns anything into a test. -/
+theorem neg_exists_eq_forall_neg (x : ℕ) (φ : DPLRel E) :
+    DPLRel.neg (DPLRel.exists_ x φ) = DPLRel.forall_ x (DPLRel.neg φ) := by
+  funext g h
+  simp only [DPLRel.neg, DPLRel.exists_, DPLRel.forall_, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, hneg⟩
+    refine ⟨rfl, fun d => ⟨_, rfl, fun ⟨k, hφ⟩ => hneg ⟨k, d, hφ⟩⟩⟩
+  · rintro ⟨rfl, hall⟩
+    refine ⟨rfl, ?_⟩
+    rintro ⟨k, d, hφ⟩
+    obtain ⟨m, rfl, hneg⟩ := hall d
+    exact hneg ⟨k, hφ⟩
 
-/-! "Every man walked in. *He sat down."
+/-! ### Blocking: the externally static constants (§2.5) -/
 
-The universal quantifier is a test: ⟦∀xφ⟧(g,h) forces g = h.
-This means no new bindings are created — the pronoun "he" has
-no accessible antecedent.
+/-! "Every man walked in. *He sat down." / "John didn't see a bird.
+*It was singing."
 
-This accounts for `Heim1982.Examples.universal_blocks`. -/
+Negation, implication, disjunction, and the universal are *tests*: they
+force output = input, so no binding escapes them. This accounts for
+`Heim1982.Examples.universal_blocks`, `standard_negation_blocks`, and
+`conditional_antecedent`. -/
 
-/-- Universal quantification is externally static: it cannot
-introduce discourse referents. Any formula following ∀xφ sees
-the same assignment as before. -/
-theorem universal_blocks_anaphora {E : Type*} (x : Nat) (φ : DPLRel E)
-    (g h : Nat → E) (hfa : DPLRel.forall_ x φ g h) : g = h :=
-  forall_isTest x φ g h hfa
+/-- Negation is a test. -/
+theorem neg_isTest (φ : DPLRel E) (g h : ℕ → E)
+    (hn : DPLRel.neg φ g h) : g = h := hn.1
 
-/-- Negation is externally static: it blocks anaphora.
-Accounts for `Heim1982.Examples.standard_negation_blocks`. -/
-theorem negation_blocks_anaphora {E : Type*} (φ : DPLRel E)
-    (g h : Nat → E) (hn : DPLRel.neg φ g h) : g = h := hn.1
+/-- Implication is a test: antecedent bindings do not escape. -/
+theorem impl_isTest (φ ψ : DPLRel E) (g h : ℕ → E)
+    (hi : DPLRel.impl φ ψ g h) : g = h := hi.1
 
-/-- Implication is externally static: bindings in the antecedent
-or consequent don't escape. Accounts for
-`Heim1982.Examples.conditional_antecedent`. -/
-theorem implication_blocks_anaphora {E : Type*} (φ ψ : DPLRel E)
-    (g h : Nat → E) (hi : DPLRel.impl φ ψ g h) : g = h := hi.1
+/-- Disjunction is a test: no anaphora across or out of disjuncts. -/
+theorem disj_isTest (φ ψ : DPLRel E) (g h : ℕ → E)
+    (hd : DPLRel.disj φ ψ g h) : g = h := hd.1
 
--- ════════════════════════════════════════════════════════════════
--- § 4. DNE Failure (§3.4)
--- ════════════════════════════════════════════════════════════════
+/-- The universal quantifier is a test: it introduces no referents. -/
+theorem forall_isTest (x : ℕ) (φ : DPLRel E) (g h : ℕ → E)
+    (hfa : DPLRel.forall_ x φ g h) : g = h := hfa.1
 
-/-! "It is not the case that nobody walked in. *He sat down."
+/-! ### Logical facts (§3.4) -/
 
-Double negation ¬¬∃xφ is a test (g = h), so it cannot export the
-witness introduced by ∃x. This contrasts with ∃xφ itself, which
-does export. Hence ¬¬∃xφ ≠ ∃xφ.
+/-- Conjunction is associative — despite the increased binding power of
+the existential (§3.4). -/
+theorem conj_assoc (φ ψ χ : DPLRel E) :
+    DPLRel.conj (DPLRel.conj φ ψ) χ = DPLRel.conj φ (DPLRel.conj ψ χ) := by
+  funext g h
+  simp only [DPLRel.conj, eq_iff_iff]
+  exact ⟨fun ⟨k, ⟨j, hj, hjk⟩, hk⟩ => ⟨j, hj, k, hjk, hk⟩,
+    fun ⟨j, hj, k, hjk, hk⟩ => ⟨k, ⟨j, hj, hjk⟩, hk⟩⟩
 
-A known limitation of DPL: doubly negated indefinites do in fact
-license anaphora (`ElliottSudo2025.Examples.double_negation` is judged
-acceptable), so DPL underpredicts here. The divergence is stated as a
-theorem in `Studies/ElliottSudo2025.lean`
-(`dpl_diverges_on_double_negation`), where the later, comparing paper
-lives. -/
+/-- Conjunction is not commutative: binding is left-to-right (§3.4). -/
+theorem conj_not_comm [Nontrivial E] :
+    ∃ (φ ψ : DPLRel E), DPLRel.conj φ ψ ≠ DPLRel.conj ψ φ := by
+  obtain ⟨e₁, e₂, hne⟩ := exists_pair_ne E
+  refine ⟨DPLRel.exists_ 0 (fun g h => g = h),
+    DPLRel.atom (fun g => g 0 = e₁), fun heq => ?_⟩
+  have hfwd : (DPLRel.conj (DPLRel.exists_ 0 (fun g h => g = h))
+      (DPLRel.atom (fun g => g 0 = e₁))) (fun _ => e₂)
+      (fun n => if n = 0 then e₁ else e₂) := by
+    refine ⟨fun n => if n = 0 then e₁ else e₂, ⟨e₁, ?_⟩, rfl, ?_⟩
+    · funext n; simp
+    · simp
+  rw [heq] at hfwd
+  obtain ⟨k, ⟨rfl, hk0⟩, -⟩ := hfwd
+  simp at hk0
+  exact hne hk0.symm
 
-/-- DPL predicts double negation blocks anaphora, contra the empirical
-judgment in `ElliottSudo2025.Examples.double_negation`. This is the
-well-known DPL limitation that [elliott-sudo-2025] and bilateral
-update semantics address. -/
-theorem dne_blocks_anaphora_dpl_prediction {E : Type*} [Nontrivial E] :
-    ∃ (x : Nat) (φ : DPLRel E),
-      DPLRel.neg (DPLRel.neg (DPLRel.exists_ x φ)) ≠
-      DPLRel.exists_ x φ :=
-  dpl_dne_fails_anaphora
+/-- `♦φ ≃ ¬¬φ`: closure is double negation (§3.4). -/
+theorem close_eq_neg_neg (φ : DPLRel E) :
+    DPLRel.close φ = DPLRel.neg (DPLRel.neg φ) := by
+  funext g h
+  simp only [DPLRel.close, DPLRel.neg, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, k, hφ⟩
+    exact ⟨rfl, fun ⟨_, rfl, hneg⟩ => hneg ⟨k, hφ⟩⟩
+  · rintro ⟨rfl, hneg⟩
+    exact ⟨rfl, by_contra fun hne => hneg ⟨g, rfl, hne⟩⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 5. The DPL Asymmetry (§3.4)
--- ════════════════════════════════════════════════════════════════
+/-- Closure fixes exactly the tests: `♦φ ≃ φ` iff `φ` is a test (§3.4). -/
+theorem close_eq_self_iff_isTest (φ : DPLRel E) :
+    DPLRel.close φ = φ ↔ ∀ g h, φ g h → g = h := by
+  constructor
+  · intro h g k hφ
+    rw [← h] at hφ
+    exact hφ.1
+  · intro htest
+    funext g h
+    simp only [DPLRel.close, eq_iff_iff]
+    constructor
+    · rintro ⟨rfl, k, hk⟩
+      obtain rfl := htest g k hk
+      exact hk
+    · exact fun hφ => ⟨htest g h hφ, h, hφ⟩
 
-/-! In standard PL, any pair from {¬, ∧, ∨, →} plus quantifiers
-suffices to define the others. In DPL, only {¬, ∧, ∃} works as
-a basis — {¬, →, ∀} and {¬, ∨, ∀} cannot define conjunction or
-existential quantification, because ∧ and ∃ are the only connectives
-that are externally dynamic. -/
+/-- The paper's restricted double-negation law (§3.4): `¬¬φ ≃ φ` exactly
+when `φ` is a test. -/
+theorem neg_neg_eq_self_iff_isTest (φ : DPLRel E) :
+    DPLRel.neg (DPLRel.neg φ) = φ ↔ ∀ g h, φ g h → g = h :=
+  close_eq_neg_neg φ ▸ close_eq_self_iff_isTest φ
 
-/-- ¬, ∧, ∃ suffice: implication is definable. -/
-theorem impl_from_conj_neg {E : Type*} (φ ψ : DPLRel E) :
-    DPLRel.impl φ ψ = DPLRel.neg (DPLRel.conj φ (DPLRel.neg ψ)) :=
-  impl_interdefinable φ ψ
+/-- DNE fails for anaphora: `¬¬∃xφ ≠ ∃xφ`, since the existential is not
+a test. The anaphoric consequence — doubly negated indefinites should
+not license anaphora — underpredicts
+(`ElliottSudo2025.Examples.double_negation` is acceptable); the
+divergence theorem lives with the comparing paper, in
+`Studies/ElliottSudo2025.lean`. -/
+theorem dne_fails_anaphora [Nontrivial E] :
+    ∃ (x : ℕ) (φ : DPLRel E),
+      DPLRel.neg (DPLRel.neg (DPLRel.exists_ x φ)) ≠ DPLRel.exists_ x φ := by
+  obtain ⟨e₁, e₂, hne⟩ := exists_pair_ne E
+  refine ⟨0, fun g h => g = h, fun heq => ?_⟩
+  have hrhs : (DPLRel.exists_ 0 (fun (g h : ℕ → E) => g = h))
+      (fun _ => e₁) (fun n => if n = 0 then e₂ else e₁) :=
+    ⟨e₂, rfl⟩
+  rw [← heq] at hrhs
+  have h_eq := congr_fun hrhs.1 0
+  simp at h_eq
+  exact hne h_eq
 
-/-- ¬, ∧, ∃ suffice: disjunction is definable. -/
-theorem disj_from_conj_neg {E : Type*} (φ ψ : DPLRel E) :
-    DPLRel.disj φ ψ = DPLRel.neg (DPLRel.conj (DPLRel.neg φ) (DPLRel.neg ψ)) :=
-  disj_interdefinable φ ψ
+/-! ### Interdefinability (§3.4)
 
-/-- ¬, ∧, ∃ suffice: universal is definable. -/
-theorem forall_from_exists_neg {E : Type*} (x : Nat) (φ : DPLRel E) :
-    DPLRel.forall_ x φ = DPLRel.neg (DPLRel.exists_ x (DPLRel.neg φ)) :=
-  forall_interdefinable x φ
+`→`, `∨`, `∀` are definable from `¬`, `∧`, `∃` — but not conversely:
+the latter contains the only externally dynamic constants
+(`conj_not_comm` separates `∧` from any test). -/
 
-/-- The reverse fails: conjunction is NOT definable from →, ∨, ∀, ¬ alone,
-because conjunction is the only binary connective that is externally dynamic. -/
-theorem conj_not_from_static_ops {E : Type*} [Nontrivial E] :
-    ∃ (φ ψ : DPLRel E), DPLRel.conj φ ψ ≠ DPLRel.conj ψ φ :=
-  conj_not_comm
+/-- `φ → ψ ≃ ¬[φ ∧ ¬ψ]`. -/
+theorem impl_interdefinable (φ ψ : DPLRel E) :
+    DPLRel.impl φ ψ = DPLRel.neg (DPLRel.conj φ (DPLRel.neg ψ)) := by
+  funext g h
+  simp only [DPLRel.impl, DPLRel.neg, DPLRel.conj, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, hall⟩
+    refine ⟨rfl, fun ⟨k, m, hφ, hmk, hnψ⟩ => ?_⟩
+    subst hmk; exact hnψ (hall m hφ)
+  · rintro ⟨rfl, hneg⟩
+    exact ⟨rfl, fun k hφ => by_contra fun hne => hneg ⟨k, k, hφ, rfl, hne⟩⟩
 
-/-! ### Cylindric-algebra bridges
+/-- `φ ∨ ψ ≃ ¬[¬φ ∧ ¬ψ]`. -/
+theorem disj_interdefinable (φ ψ : DPLRel E) :
+    DPLRel.disj φ ψ = DPLRel.neg (DPLRel.conj (DPLRel.neg φ) (DPLRel.neg ψ)) := by
+  funext g h
+  simp only [DPLRel.disj, DPLRel.neg, DPLRel.conj, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, k, hφψ⟩
+    refine ⟨rfl, ?_⟩
+    rintro ⟨_, m, ⟨rfl, hnφ⟩, rfl, hnψ⟩
+    cases hφψ with
+    | inl hφ => exact hnφ ⟨k, hφ⟩
+    | inr hψ => exact hnψ ⟨k, hψ⟩
+  · rintro ⟨rfl, hneg⟩
+    refine ⟨rfl, by_contra fun hne => ?_⟩
+    push Not at hne
+    exact hneg ⟨g, g, ⟨rfl, fun ⟨j, hφ⟩ => (hne j).1 hφ⟩,
+      rfl, fun ⟨j, hψ⟩ => (hne j).2 hψ⟩
 
-DPL's existential and identity test are cylindric-algebra operations under
-`closure` — the defining correspondence between DPL and cylindric set
-algebra ([henkin-monk-tarski-1971]). These are algebraic identities, not
-analogies. -/
+/-- `∀xφ ≃ ¬∃x¬φ`. -/
+theorem forall_interdefinable (x : ℕ) (φ : DPLRel E) :
+    DPLRel.forall_ x φ = DPLRel.neg (DPLRel.exists_ x (DPLRel.neg φ)) := by
+  funext g h
+  simp only [DPLRel.forall_, DPLRel.neg, DPLRel.exists_, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, hall⟩
+    refine ⟨rfl, ?_⟩
+    rintro ⟨k, d, rfl, hneg⟩
+    exact hneg (hall d)
+  · rintro ⟨rfl, hneg⟩
+    refine ⟨rfl, fun d => by_contra fun hne => hneg ⟨_, d, rfl, hne⟩⟩
 
-section CylindricAlgebra
+/-! ### Satisfaction sets and PL (§3.6) -/
+
+/-! Fact 19 (§3.6) relates DPL to PL through satisfaction sets: for
+formulas in normal binding form, `\φ\` is the PL meaning. Its proof
+computes `\∃xψ\ = {g | ∃k: k[x]g ∧ k ∈ \ψ\}` — cylindrification of the
+satisfaction set. Under `closure` (`= satisfactionSet`, Definition 6)
+these computations are algebraic identities in the cylindric set algebra
+([henkin-monk-tarski-1971]). -/
+
+section SatisfactionSets
 
 open Core.CylindricAlgebra
 open Core (Assignment)
 open DynamicSemantics.DynProp (closure)
 
-/-- **DPL existential = cylindrification.**
-
-`closure(∃x.φ) = cₓ(closure(φ))`: the truth-conditional content of
-DPL's existential quantifier at variable `x` is exactly cylindrification
-at register `x`. -/
-theorem dpl_closure_exists_eq_cylindrify {E : Type*} (x : Nat) (φ : DPLRel E) :
+/-- **DPL existential = cylindrification**: `\∃xφ\ = cₓ\φ\` — the
+existential case of Fact 19's computation. -/
+theorem closure_exists_eq_cylindrify (x : ℕ) (φ : DPLRel E) :
     closure (toDRS (DPLRel.exists_ x φ)) =
     cylindrify x (closure (toDRS φ)) := by
   have hup : ∀ (g : Assignment E) (d : E),
@@ -196,25 +283,97 @@ theorem dpl_closure_exists_eq_cylindrify {E : Type*} (x : Nat) (φ : DPLRel E) :
   exact ⟨fun ⟨h, d, hφ⟩ => ⟨d, h, hup g d ▸ hφ⟩,
          fun ⟨d, h, hφ⟩ => ⟨h, d, (hup g d).symm ▸ hφ⟩⟩
 
-/-- **DPL identity test = diagonal element.**
-
-`closure(atom(g(x) = g(y))) = Dxy`: the truth condition of the DPL
-atomic formula `x = y` is the diagonal element `Dxy` from cylindric
-algebra. -/
-theorem dpl_closure_identity_eq_diagonal {E : Type*} (x y : Nat) :
+/-- **DPL identity test = diagonal element**: `\x = y\ = Dxy`. -/
+theorem closure_identity_eq_diagonal (x y : Nat) :
     closure (toDRS (DPLRel.atom (fun g : Assignment E => g x = g y))) =
     @diagonal E x y := by
   ext g; simp only [closure, toDRS, DPLRel.atom, diagonal]
   exact ⟨fun ⟨_, rfl, h⟩ => h, fun h => ⟨g, rfl, h⟩⟩
 
-/-- DPL negation under closure is a test for non-cylindrifiability:
-`closure(¬φ)(g)` iff no assignment update satisfies φ. -/
-theorem dpl_closure_neg_eq {E : Type*} (φ : DPLRel E) :
+/-- DPL negation complements the satisfaction set: `\¬φ\ = ∁\φ\`. -/
+theorem closure_neg_eq (φ : DPLRel E) :
     closure (toDRS (DPLRel.neg φ)) =
     fun g => ¬ closure (toDRS φ) g := by
   ext g; simp only [closure, toDRS, DPLRel.neg]
   exact ⟨fun ⟨_, rfl, h⟩ => h, fun h => ⟨g, rfl, h⟩⟩
 
-end CylindricAlgebra
+end SatisfactionSets
+
+/-! ### The based reading: DPL generators as context extension -/
+
+/-! DPL meanings are relations on total assignments (Definition 2); the
+based substrate (`Transition.lean`) types them by the contexts they read
+and write. The two generators land as arrows: tests (clauses 1–3, 5, 6, 8
+are all of this shape) become `testTransition`s `X ⟶ X`, and the random
+reset of clause 7 is `Transition.randomAssign : X ⟶ insert x X`.
+Sequencing is clause 4 (`rel_comp_iff_conj`), and the existential factors
+as random assignment composed with its scope
+(`rel_randomAssign_comp_iff_exists`) — so a DPL formula's based meaning is
+a composite of the generating arrows of `DynamicSemantics.Ctx`. -/
+
+section BasedReading
+
+open DynamicSemantics
+
+variable {W : Type*} {X Y : Finset ℕ}
+
+/-- A DPL test as a transition: a condition supported on the context,
+checked without changing the assignment. Clauses 1–3, 5, 6, and 8 of
+Definition 2 are all of this form. -/
+def testTransition (X : Finset ℕ) (C : (ℕ → E) → Prop)
+    (hC : DependsOn C ↑X) : Transition W E X X where
+  rel _ f h := Set.EqOn f h ↑X ∧ C f
+  grow := subset_rfl
+  supported_left _ _ _ _ hff' :=
+    and_congr ⟨(hff'.symm.trans ·), (hff'.trans ·)⟩ (iff_of_eq (hC hff'))
+  supported_right _ _ _ _ hgg' :=
+    and_congr ⟨(·.trans hgg'), (·.trans hgg'.symm)⟩ Iff.rfl
+
+/-- Applying a test at a state based below its context filters the
+carrier — the based form of Definition 2's test clauses. -/
+theorem mem_testTransition_apply {C : (ℕ → E) → Prop} {hC : DependsOn C ↑X}
+    {I : State W ℕ E} (hbase : I.base ⊆ X) {w : W} {g : ℕ → E} :
+    (⟨w, g⟩ : Possibility W ℕ E) ∈ (testTransition X C hC).apply I ↔
+      (⟨w, g⟩ : Possibility W ℕ E) ∈ I ∧ C g := by
+  rw [Transition.mem_apply]
+  constructor
+  · rintro ⟨f, hf, hfg, hCf⟩
+    exact ⟨(I.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hbase))).mp hf,
+      (hC hfg) ▸ hCf⟩
+  · rintro ⟨hg, hCg⟩
+    exact ⟨g, hg, Set.eqOn_refl g _, hCg⟩
+
+/-- Clause 4 is transition composition: if `u` and `v` realize `φ` and
+`ψ` world-pointwise, their composite realizes `φ ∧ ψ`. -/
+theorem rel_comp_iff_conj {Z : Finset ℕ} {u : Transition W E X Y}
+    {v : Transition W E Y Z} {φ ψ : DPLRel E}
+    (hu : ∀ w f h, u.rel w f h ↔ φ f h) (hv : ∀ w f h, v.rel w f h ↔ ψ f h)
+    (w : W) (f h : ℕ → E) :
+    (u.comp v).rel w f h ↔ DPLRel.conj φ ψ f h :=
+  exists_congr fun k => and_congr (hu w f k) (hv w k h)
+
+/-- Clause 7 factors through the category: the existential is the
+random-assignment arrow composed with its scope. The scope's transition
+reads only `insert x X`, which is what lets the reset's underspecification
+off `x` collapse to Definition 2's `∃d`. -/
+theorem rel_randomAssign_comp_iff_exists {x : ℕ}
+    {u : Transition W E (insert x X) Y} {φ : DPLRel E}
+    (hu : ∀ w f h, u.rel w f h ↔ φ f h) (w : W) (f h : ℕ → E) :
+    ((Transition.randomAssign X x).comp u).rel w f h ↔
+      DPLRel.exists_ x φ f h := by
+  constructor
+  · rintro ⟨k, hfk, huk⟩
+    refine ⟨k x, (hu ..).mp ((u.supported_left fun y hy => ?_).mp huk)⟩
+    rcases Finset.mem_insert.mp hy with rfl | hyX
+    · simp
+    · rcases eq_or_ne y x with rfl | hyx
+      · simp
+      · exact (hfk (Finset.mem_coe.mpr (Finset.mem_erase.mpr ⟨hyx, hyX⟩))).symm.trans
+          (if_neg hyx).symm
+  · rintro ⟨d, hφ⟩
+    refine ⟨fun n => if n = x then d else f n, fun y hy => ?_, (hu ..).mpr hφ⟩
+    exact (if_neg (Finset.mem_erase.mp hy).1).symm
+
+end BasedReading
 
 end GroenendijkStokhof1991


### PR DESCRIPTION
Deep cleanse of the DPL pair against the paper (PDF in hand), plus B4 phase 3's first piece.
- `DPL.lean` slims to substrate (Definition 2 clauses, Definitions 3/6/9/17 notions, the Ty2 embedding); the paper's *results* move to `Studies/GroenendijkStokhof1991.lean` where they belong: scope extension and donkey equivalence (now **unconditional**, per Fact 17's normal-binding-form equivalences — the old `_hfree` hypothesis was vestigial), blocking, §3.4's logical facts incl. the newly added restricted DNE law `¬¬φ ≃ φ ↔ φ is a test` and `conj_assoc`, interdefinability, and the satisfaction-set/cylindrification identities reframed as Fact 19's §3.6 computations (the paper's own PL-correspondence, not an editorial bridge). Style: banners and § ordinals → mathlib headers, `variable` blocks, `ℕ`, no redundant `dpl_` prefixes, `export` dropped, `push Not`.
- **Based reading** (new study section + `Transition.randomAssign` in substrate): tests and the random-assignment arrow `X ⟶ insert x X` are the generators; clause 4 is transition composition, clause 7 factors as random assignment ∘ scope, and `randomAssign_apply` reconciles with `State.randomAssign`.
Verified against the two sources handed today; GSV96 Def 2.8/2.9 also confirms `Possibility.Descendant` as shipped.