### PR TITLE
feat(Semantics/Dynamic): classify the fibers; Veltman as the ∅-fiber

### DIFF
--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -51,6 +51,27 @@ def agreeSetoid (X : Set V) : Setoid (Possibility W V M) where
 theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
   fun _ _ hXY _ _ h => ⟨h.1, h.2.mono hXY⟩
 
+open scoped Classical in
+/-- The state space at granularity `X`, classified: a possibility up to
+agreement on `X` is a world together with an assignment of the
+`X`-referents. -/
+noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
+    Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) where
+  toFun := Quotient.lift (fun p => (p.world, X.restrict p.assignment))
+    fun _ _ h => Prod.ext h.1 (funext fun x => h.2 x.2)
+  invFun wf :=
+    Quotient.mk _
+      ⟨wf.1, fun v => if h : v ∈ X then wf.2 ⟨v, h⟩ else Classical.arbitrary M⟩
+  left_inv := by
+    rintro ⟨p⟩
+    exact Quotient.sound ⟨rfl, fun v hv => dif_pos hv⟩
+  right_inv wf := Prod.ext rfl (funext fun x => dif_pos x.2)
+
+@[simp] theorem agreeQuotientEquiv_mk (X : Set V) [Nonempty M]
+    (p : Possibility W V M) :
+    agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
+  rfl
+
 /-- Extend the assignment at a single referent, via `Function.update`. -/
 def extend [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
     Possibility W V M :=

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -3,6 +3,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Function
 import Mathlib.Logic.Function.DependsOn
 import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Order.Hom.CompleteLattice
 import Mathlib.Order.Lattice
 
 /-!
@@ -37,6 +38,10 @@ acting on states live in `Transition.lean`.
   *saturation* for `Possibility.agreeSetoid ↑X`.
 - `prop_restrict`, `le_restrict_iff`: restriction never changes the
   proposition, and is the universal `Y`-supported approximation.
+- `fiberOrderIsoProd`, `fiberEmptyOrderIso`: the fiber at `X` classified
+  as propositions over world–`X`-assignment pairs ([heim-1982]'s
+  satisfaction sets), degenerating at `X = ∅` to bare propositions
+  ([veltman-1996]'s update-semantics states).
 
 ## Implementation notes
 
@@ -390,6 +395,61 @@ def fiberOrderIso (X : Finset V) :
     · rintro ⟨-, hc⟩ q hq
       induction q using Quotient.ind
       exact mem_fiberEquiv.mpr (hc (mem_fiberEquiv.mp hq))
+
+section Classified
+variable [Nonempty M]
+
+/-- The fiber at `X`, classified: a based state is a proposition over
+world–`X`-assignment pairs, reversed by informativeness — [heim-1982]'s
+satisfaction sets of domain-`X` sequences, as a theorem rather than a
+gloss. -/
+noncomputable def fiberOrderIsoProd (X : Finset V) :
+    fiber W M X ≃o (Set (W × ((↑X : Set V) → M)))ᵒᵈ :=
+  (fiberOrderIso X).trans
+    (Possibility.agreeQuotientEquiv (↑X : Set V)).toOrderIsoSet.dual
+
+/-- Membership form of the classification: a pair lies in the classified
+state iff the corresponding possibility does. -/
+theorem mem_fiberOrderIsoProd {I : fiber W M X} {w : W} {g : V → M} :
+    (w, (↑X : Set V).restrict g) ∈
+        OrderDual.ofDual (fiberOrderIsoProd X I) ↔
+      (⟨w, g⟩ : Possibility W V M) ∈ I.1 := by
+  show (w, (↑X : Set V).restrict g) ∈
+    Possibility.agreeQuotientEquiv (↑X : Set V) '' fiberEquiv X I ↔ _
+  constructor
+  · rintro ⟨q, hq, heq⟩
+    obtain ⟨p⟩ := q
+    obtain ⟨h1, h2⟩ := Prod.ext_iff.mp heq
+    exact ((fiber_supported I).mem_congr
+      ⟨h1, fun v hv => congrFun h2 ⟨v, hv⟩⟩).mp (mem_fiberEquiv.mp hq)
+  · intro hg
+    exact ⟨Quotient.mk _ ⟨w, g⟩, mem_fiberEquiv.mpr hg, rfl⟩
+
+/-- At the empty context the fiber degenerates to bare propositions:
+[veltman-1996]'s update-semantics states are the referent-free fiber. -/
+noncomputable def fiberEmptyOrderIso :
+    fiber W M (∅ : Finset V) ≃o (Set W)ᵒᵈ :=
+  haveI : IsEmpty ((↑(∅ : Finset V) : Set V) : Type _) :=
+    ⟨fun x => by simpa using x.2⟩
+  (fiberOrderIsoProd ∅).trans (Equiv.prodUnique W _).toOrderIsoSet.dual
+
+/-- Membership form: at the empty context, membership is a fact about the
+world alone. -/
+theorem mem_fiberEmptyOrderIso {I : fiber W M (∅ : Finset V)} {w : W}
+    {g : V → M} :
+    w ∈ OrderDual.ofDual (fiberEmptyOrderIso I) ↔
+      (⟨w, g⟩ : Possibility W V M) ∈ I.1 := by
+  haveI : IsEmpty ((↑(∅ : Finset V) : Set V) : Type _) :=
+    ⟨fun x => by simpa using x.2⟩
+  rw [← mem_fiberOrderIsoProd (g := g)]
+  show w ∈ Equiv.prodUnique W _ '' OrderDual.ofDual (fiberOrderIsoProd ∅ I) ↔ _
+  constructor
+  · rintro ⟨⟨w', f⟩, hf, rfl⟩
+    rwa [Subsingleton.elim ((↑(∅ : Finset V) : Set V).restrict g) f]
+  · intro h
+    exact ⟨(w, _), h, rfl⟩
+
+end Classified
 
 end State
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -1,6 +1,8 @@
 import Linglib.Core.Logic.TweetyNixon
 import Linglib.Core.Order.Normality
+import Linglib.Semantics.Dynamic.UpdateSemantics.Basic
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
+import Linglib.Semantics.Dynamic.State
 
 /-!
 # [veltman-1996] — Full Study
@@ -862,5 +864,56 @@ theorem optimal_as_normalcy (no : Preorder W) (d : Set W)
 
 end GenericsBridge
 
+/-! ### Update-semantics states as the referent-free fiber
+
+Veltman's information states are bare sets of worlds. In the based
+substrate they are exactly the states at the empty context: `toBasedState`
+embeds them, the embedding is an order-reversal onto the `∅`-fiber
+(`State.fiberEmptyOrderIso`), and propositional update transports to
+carrier filtering. -/
+
+section BasedFiber
+
+open DynamicSemantics UpdateSemantics
+
+variable {W V M : Type*} {s t : Set W}
+
+/-- A Veltman state as a based state at the empty context. -/
+def toBasedState (V M : Type*) (s : Set W) : DynamicSemantics.State W V M where
+  base := ∅
+  carrier := {p | p.world ∈ s}
+  supported := baseSupported_of_iff fun _ _ _ _ => Iff.rfl
+
+@[simp] theorem mem_toBasedState {p : Possibility W V M} :
+    p ∈ toBasedState V M s ↔ p.world ∈ s := Iff.rfl
+
+/-- The embedding reverses the orders: eliminating worlds is gaining
+information. -/
+theorem toBasedState_le_iff [Nonempty M] :
+    toBasedState V M s ≤ toBasedState V M t ↔ t ⊆ s := by
+  constructor
+  · intro h w hw
+    exact h.2 (show (⟨w, fun _ => Classical.arbitrary M⟩ : Possibility W V M) ∈ _ from hw)
+  · exact fun h => ⟨subset_rfl, fun p hp => h hp⟩
+
+/-- Propositional update ([veltman-1996]'s elimination) transports to
+carrier filtering on based states. -/
+theorem toBasedState_update_prop (φ : W → Prop) :
+    (toBasedState V M (UpdateSemantics.Update.prop φ s)).carrier =
+      {p ∈ (toBasedState V M s).carrier | φ p.world} := rfl
+
+/-- The embedding inverts the fiber classification: a Veltman state is
+precisely a state of the `∅`-fiber, read through
+`State.fiberEmptyOrderIso`. -/
+theorem fiberEmptyOrderIso_toBasedState [Nonempty M] (s : Set W) :
+    State.fiberEmptyOrderIso (M := M) ⟨toBasedState V M s, rfl⟩ =
+      OrderDual.toDual s := by
+  have h : ∀ w : W,
+      w ∈ OrderDual.ofDual
+        (State.fiberEmptyOrderIso (M := M) ⟨toBasedState V M s, rfl⟩) ↔ w ∈ s :=
+    fun w => State.mem_fiberEmptyOrderIso (g := fun _ => Classical.arbitrary M)
+  exact Set.ext h
+
+end BasedFiber
 
 end Veltman1996


### PR DESCRIPTION
B4 phase 3, first functor-side piece: the collapsed state space at granularity `X` is classified — `Possibility.agreeQuotientEquiv : Quotient (agreeSetoid X) ≃ W × (X → M)` (the reviewer's `Setoid.ker`-style follow-up), whence `State.fiberOrderIsoProd : fiber W M X ≃o (Set (W × (↑X → M)))ᵒᵈ` — a based state at context `X` *is* a set of world-assignment pairs with domain `X`, [heim-1982]'s satisfaction sets as a theorem rather than a gloss. At `X = ∅` this degenerates to `fiberEmptyOrderIso : fiber W M ∅ ≃o (Set W)ᵒᵈ`, and `Studies/Veltman1996.lean` wires it up: `toBasedState` embeds update-semantics states as the referent-free fiber (order-reversing, `toBasedState_le_iff`), propositional update transports to carrier filtering (`rfl`), and the embedding inverts the classification (`fiberEmptyOrderIso_toBasedState`). Third framework placed in the based tower, after DRT (#1454) and the DPL generators (#1458).