### PR TITLE
refactor(Semantics/Dynamic): dissolve DynProp namespace; spine cleanse

### DIFF
--- a/Linglib/Semantics/Dynamic/CDRT.lean
+++ b/Linglib/Semantics/Dynamic/CDRT.lean
@@ -38,7 +38,6 @@ the paper's derivations) and the weakest-precondition calculus live in
 
 namespace DynamicSemantics
 
-open DynProp
 
 /-- Discourse referent (Muskens' type `se`): a function from states to
 individuals. Constant drefs (`Function.const`, AX4's names) are drefs
@@ -110,7 +109,7 @@ end DynamicSemantics
 
 namespace CDRT
 
-open DynamicSemantics DynamicSemantics.DynProp
+open DynamicSemantics
 
 /-- CDRT state: Muskens' type `s`, concretely an assignment `Nat → E`.
 His *registers* are register indices `n : ℕ` with values read by `dref`
@@ -162,7 +161,7 @@ abbrev DProp.impl {E : Type*} (φ ψ : DProp E) : DProp E := test (dimpl φ ψ)
 /-- Dynamic disjunction as a test (SEM2, [muskens-1996] p. 148): the
 spine's `ddisj` via `test`. -/
 abbrev DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
-  test (DynamicSemantics.DynProp.ddisj φ ψ)
+  test (DynamicSemantics.ddisj φ ψ)
 
 /-- Truth at a state: the spine's `closure`. -/
 abbrev DProp.true_at {E : Type*} (φ : DProp E) (i : State E) : Prop :=

--- a/Linglib/Semantics/Dynamic/ContextChange.lean
+++ b/Linglib/Semantics/Dynamic/ContextChange.lean
@@ -1,30 +1,46 @@
 import Linglib.Semantics.Dynamic.Update
-import Linglib.Core.Logic.Assignment
 import Mathlib.Data.Set.Basic
 import Mathlib.Algebra.Group.Defs
 
 /-!
-# Core Dynamic Semantics Infrastructure
+# Context change potentials
 
-`InfoStateOf P` (sets of possibilities) and `CCP P` (context change
-potentials, the set-transformer view of dynamic meaning), shared by the
-PLA, DRT, DPL, and CDRT formalizations.
+The set-transformer view of dynamic meaning ([heim-1983],
+[veltman-1996]): a `CCP P` acts on information states `InfoStateOf P`
+(sets of possibilities) as a whole. It is the global counterpart of the
+relational `Update S` of `Update.lean`: `lift` (the relational image,
+[muskens-van-benthem-visser-2011]'s strongest postcondition) and `lower`
+form a round trip — `lower_lift` everywhere, `lift_lower` exactly on the
+`IsDistributive` CCPs, which process elements independently. What the
+set-transformer view genuinely adds is the non-distributive tests
+(`CCP.guard`, `might`, `must`, `negTest`) that inspect the whole state.
 
-The relational `Update S` ([groenendijk-stokhof-1991], [muskens-1996]) of
-`Update.lean` is the primary dynamic type; `CCP` connects to it
-via `lift R σ = { j | ∃ i ∈ σ, R i j }` and `lower φ i j = j ∈ φ {i}`,
-which form a round-trip pair: `lower ∘ lift = id` everywhere
-(`lower_lift`), and `lift ∘ lower = id` exactly on the distributive CCPs
-(`lift_lower`). The `IsDistributive` CCPs — those that process elements
-independently — are exactly the image of `lift`; non-distributive
-operations (`CCP.negTest`, `CCP.might`, `CCP.must`) test the *whole*
-input state rather than filtering per-element.
+## Main definitions
+
+- `InfoStateOf P`, `CCP P`: states as sets, meanings as set
+  transformers, a monoid under `CCP.seq`.
+- `CCP.neg`, `disj`: Heim/Veltman negation and its derived disjunction;
+  `CCP.guard` and the whole-state tests `might`, `must`, `negTest`.
+- `IsEliminative`, `IsExpansive`, `IsTest`, `IsDistributive`: the basic
+  classification of CCPs. N.B. `IsTest` (pass-or-`∅`, Veltman's test) is
+  *not* the counterpart of the relational `Update.IsTest` (stay-put,
+  DPL's test): `lift` of a relational test is an eliminative filter, not
+  a pass-or-`∅` test.
+- `supportOf`, `contentOf`, `updateFromSat`: satisfaction-based updates
+  and the support relation.
+- `lift`, `lower`: the bridge to the relational algebra.
+
+## Main results
+
+- `lower_lift`, `lift_lower`, `lift_isDistributive`: distributive CCPs
+  are exactly the relational images.
+- `lift_le_lift_iff`: `lift` reflects the pointwise order — the
+  SP-characterization of update-update consequence.
+- `might_not_isDistributive`: whole-state tests are genuinely beyond the
+  relational fragment.
 -/
 
 namespace DynamicSemantics
-
-open _root_.Core (Assignment)
-
 
 /--
 An InfoState is a set of possibilities.
@@ -35,10 +51,6 @@ Different theories instantiate `P` differently:
 - Intensional: World × Assignment
 -/
 abbrev InfoStateOf (P : Type*) := Set P
-
--- InfoState is just Set, so we get:
--- ⊤ = Set.univ, ⊥ = ∅, ⊔ = ∪, ⊓ = ∩
-
 
 /--
 A Context Change Potential (CCP) is a function from states to states.
@@ -62,7 +74,6 @@ def seq (u v : CCP P) : CCP P := λ s => v (u s)
 
 scoped infixl:70 " ;; " => seq
 
--- Monoid laws
 theorem seq_assoc (u v w : CCP P) : (u ;; v) ;; w = u ;; (v ;; w) := rfl
 theorem id_seq (u : CCP P) : id ;; u = u := rfl
 theorem seq_id (u : CCP P) : u ;; id = u := rfl
@@ -156,6 +167,7 @@ theorem entails_id (φ : CCP P) : entails φ id := by
 
 end CCP
 
+variable {P : Type*}
 
 /--
 An update is eliminative if it never adds possibilities.
@@ -163,15 +175,15 @@ An update is eliminative if it never adds possibilities.
 This is the fundamental property of dynamic semantics:
 information only grows (possibilities only decrease).
 -/
-def IsEliminative {P : Type*} (u : CCP P) : Prop :=
+def IsEliminative (u : CCP P) : Prop :=
   ∀ s, u s ⊆ s
 
 /-- Identity is eliminative -/
-theorem eliminative_id {P : Type*} : IsEliminative (CCP.id : CCP P) :=
+theorem eliminative_id : IsEliminative (CCP.id : CCP P) :=
   λ _ => Set.Subset.rfl
 
 /-- Sequential composition preserves eliminativity -/
-theorem eliminative_seq {P : Type*} (u v : CCP P)
+theorem eliminative_seq (u v : CCP P)
     (hu : IsEliminative u) (hv : IsEliminative v) :
     IsEliminative (u.seq v) := λ s _ hp =>
   hu s (hv (u s) hp)
@@ -185,86 +197,67 @@ modal horizon expansion ([kirkpatrick-2024]), and accommodation.
 These are the dual of eliminative operations: where eliminative updates
 can only shrink the state, expansive updates can only grow it.
 -/
-def IsExpansive {P : Type*} (u : CCP P) : Prop :=
+def IsExpansive (u : CCP P) : Prop :=
   ∀ s, s ⊆ u s
 
 /-- Identity is expansive -/
-theorem expansive_id {P : Type*} : IsExpansive (CCP.id : CCP P) :=
+theorem expansive_id : IsExpansive (CCP.id : CCP P) :=
   λ _ => Set.Subset.rfl
 
 /-- Sequential composition preserves expansiveness -/
-theorem expansive_seq {P : Type*} (u v : CCP P)
+theorem expansive_seq (u v : CCP P)
     (hu : IsExpansive u) (hv : IsExpansive v) :
     IsExpansive (u.seq v) := λ s _ hp =>
   hv (u s) (hu s hp)
 
 /-- A CCP that is both eliminative and expansive is the identity on every input. -/
-theorem eliminative_expansive_id {P : Type*} (u : CCP P)
+theorem eliminative_expansive_id (u : CCP P)
     (he : IsEliminative u) (hx : IsExpansive u) :
     ∀ s, u s = s :=
   λ s => Set.Subset.antisymm (he s) (hx s)
 
-/-- Eliminative ↔ antitone on the identity: u s ≤ s for all s. -/
-theorem isEliminative_iff_le_id {P : Type*} (u : CCP P) :
-    IsEliminative u ↔ ∀ s, u s ≤ s := Iff.rfl
-
-/-- Expansive ↔ identity below: s ≤ u s for all s. -/
-theorem isExpansive_iff_id_le {P : Type*} (u : CCP P) :
-    IsExpansive u ↔ ∀ s, s ≤ u s := Iff.rfl
-
-/-- Eliminative updates are antitone at the identity: u ≤ id in the pointwise order. -/
-theorem IsEliminative.le_id {P : Type*} {u : CCP P} (h : IsEliminative u) (s : InfoStateOf P) :
-    u s ≤ s := h s
-
-/-- Expansive updates satisfy id ≤ u in the pointwise order. -/
-theorem IsExpansive.id_le {P : Type*} {u : CCP P} (h : IsExpansive u) (s : InfoStateOf P) :
-    s ≤ u s := h s
-
-
-/--
-A test is a CCP that either passes (returns input) or fails (returns ∅).
-
-Tests don't change information - they check compatibility.
-Examples: might, must, presupposition triggers.
--/
-def IsTest {P : Type*} (u : CCP P) : Prop :=
+/-- A test either passes (returns its input) or fails (returns `∅`) —
+[veltman-1996]'s tests: `might`, `must`, presupposition checks. Not the
+counterpart of the relational `Update.IsTest`: lifting a relational
+test gives an eliminative filter, not a pass-or-`∅` test. -/
+def IsTest (u : CCP P) : Prop :=
   ∀ s, u s = s ∨ u s = ∅
 
 /-- Tests are eliminative -/
-theorem test_eliminative {P : Type*} (u : CCP P) (h : IsTest u) :
+theorem test_eliminative (u : CCP P) (h : IsTest u) :
     IsEliminative u := λ s p hp => by
   cases h s with
   | inl heq => rw [heq] at hp; exact hp
   | inr hemp => rw [hemp] at hp; exact False.elim hp
 
 open Classical in
-theorem CCP.guard_isTest {P : Type*} (C : Set P → Prop) : IsTest (CCP.guard C) := by
+theorem CCP.guard_isTest (C : Set P → Prop) : IsTest (CCP.guard C) := by
   intro s; simp only [CCP.guard]; split <;> simp
 
-theorem CCP.negTest_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.negTest φ) :=
+theorem CCP.negTest_isTest (φ : CCP P) : IsTest (CCP.negTest φ) :=
   CCP.guard_isTest _
 
-theorem CCP.might_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.might φ) :=
+theorem CCP.might_isTest (φ : CCP P) : IsTest (CCP.might φ) :=
   CCP.guard_isTest _
 
-theorem CCP.must_isTest {P : Type*} (φ : CCP P) : IsTest (CCP.must φ) :=
+theorem CCP.must_isTest (φ : CCP P) : IsTest (CCP.must φ) :=
   CCP.guard_isTest _
 
-theorem CCP.impl_isTest {P : Type*} (φ ψ : CCP P) : IsTest (CCP.impl φ ψ) :=
+theorem CCP.impl_isTest (φ ψ : CCP P) : IsTest (CCP.impl φ ψ) :=
   CCP.guard_isTest _
 
 open Classical in
 /-- Duality for the test pair: might φ = must-not (must-not φ). The
 analogous identity fails for set-difference `neg` (DNE holds instead
 on eliminative updates). -/
-theorem CCP.might_eq_negTest_negTest {P : Type*} (φ : CCP P) :
+theorem CCP.might_eq_negTest_negTest (φ : CCP P) :
     CCP.might φ = CCP.negTest (CCP.negTest φ) := by
   funext s
   by_cases h : (φ s).Nonempty
   · simp [CCP.might, CCP.negTest, CCP.guard, h]
   · by_cases hs : s.Nonempty
     · simp [CCP.might, CCP.negTest, CCP.guard, h, hs]
-    · simp [CCP.might, CCP.negTest, CCP.guard, h, hs,
+    · simp [CCP.might, CCP.negTest, CCP.guard,
         Set.not_nonempty_iff_eq_empty.mp hs]
 
 
@@ -327,12 +320,12 @@ end GaloisContent
 
 /-- Filtering a set by a predicate is monotone. This is the shared foundation
     for monotonicity of `updateFromSat`, `atom`, `pred1`, `pred2`, etc. -/
-theorem sep_monotone {P : Type*} (pred : P → Prop) :
+theorem sep_monotone (pred : P → Prop) :
     Monotone (λ s : Set P => { p ∈ s | pred p }) :=
   λ _ _ h _ hp => ⟨h hp.1, hp.2⟩
 
 /-- Filtering a set by a predicate is eliminative. -/
-theorem sep_eliminative {P : Type*} (pred : P → Prop) :
+theorem sep_eliminative (pred : P → Prop) :
     IsEliminative (λ s : Set P => { p ∈ s | pred p }) :=
   λ _ _ hp => hp.1
 
@@ -393,16 +386,8 @@ theorem dynamicEntails_refl {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
 /-- Dynamic entailment is transitive -/
 theorem dynamicEntails_trans {P φ : Type*} (sat : P → φ → Prop)
     (ψ₁ ψ₂ ψ₃ : φ) (h1 : dynamicEntailsOf sat ψ₁ ψ₂) (h2 : dynamicEntailsOf sat ψ₂ ψ₃) :
-    dynamicEntailsOf sat ψ₁ ψ₃ := λ s p hp => by
-  -- p ∈ updateFromSat sat ψ₁ s means p ∈ s and sat p ψ₁
-  have hp_sat1 : sat p ψ₁ := hp.2
-  have hp_in_s : p ∈ s := hp.1
-  -- By h1, updateFromSat sat ψ₁ s supports ψ₂, so sat p ψ₂
-  have hp_sat2 : sat p ψ₂ := h1 s p hp
-  -- p ∈ updateFromSat sat ψ₂ s
-  have hp_in_2 : p ∈ updateFromSat sat ψ₂ s := ⟨hp_in_s, hp_sat2⟩
-  -- By h2, updateFromSat sat ψ₂ s supports ψ₃
-  exact h2 s p hp_in_2
+    dynamicEntailsOf sat ψ₁ ψ₃ :=
+  fun s p hp => h2 s p ⟨hp.1, h1 s p hp⟩
 
 
 /--
@@ -415,15 +400,11 @@ theorem updateFromSat_monotone {P φ : Type*} (sat : P → φ → Prop) (ψ : φ
   sep_monotone _
 
 
--- Re-export the Assignment type so downstream code can write `Assignment E`
--- (updates are mathlib's `Function.update`).
-export _root_.Core (Assignment)
-
--- ═══ Distributivity ═══
+/-! ### Distributivity -/
 
 /-- A CCP is distributive when it processes each element of the input independently:
     φ(s) = ⋃_{i∈s} φ({i}). -/
-def IsDistributive {P : Type*} (φ : CCP P) : Prop :=
+def IsDistributive (φ : CCP P) : Prop :=
   ∀ s, φ s = {p | ∃ i ∈ s, p ∈ φ {i}}
 
 /-- `updateFromSat` is always distributive: it filters per-element. -/
@@ -475,7 +456,7 @@ theorem might_not_isDistributive :
       exact absurd hx_val (by decide)
   · exact hmem_i
 
--- ═══ Relational ↔ CCP Correspondence ═══
+/-! ### The relational bridge -/
 
 /-! The relational type `Update S = S → S → Prop` from `DynProp` is the
 primary dynamic semantic type. Every `Update` gives rise to a distributive
@@ -489,7 +470,6 @@ genuine additions of the set-transformer perspective. -/
 
 section RelationalBridge
 
-open DynProp
 
 variable {S : Type*}
 
@@ -522,8 +502,8 @@ theorem lift_dseq (R₁ R₂ : Update S) :
 /-- Lifting a test produces a per-element filter:
 `lift (test C) σ = { i ∈ σ | C i }`. -/
 theorem lift_test (C : Condition S) :
-    lift (DynProp.test C) = λ σ => { i ∈ σ | C i } := by
-  funext σ; ext j; simp only [lift, DynProp.test, Set.mem_setOf_eq]
+    lift (test C) = λ σ => { i ∈ σ | C i } := by
+  funext σ; ext j; simp only [lift, test, Set.mem_setOf_eq]
   constructor
   · rintro ⟨i, hi, rfl, hC⟩; exact ⟨hi, hC⟩
   · rintro ⟨hj, hC⟩; exact ⟨j, hj, rfl, hC⟩
@@ -568,16 +548,16 @@ theorem lift_le_lift_iff {R R' : Update S} : lift R ≤ lift R' ↔ R ≤ R' := 
 
 /-- `lift (test C)` is eliminative: it only removes elements. -/
 theorem lift_test_isEliminative (C : Condition S) :
-    IsEliminative (lift (DynProp.test C)) := by
+    IsEliminative (lift (test C)) := by
   rw [lift_test]; intro σ j ⟨hj, _⟩; exact hj
 
 /-- `updateFromSat` is the lifting of `test` applied to a satisfaction
 relation. This connects the CCP-native `updateFromSat` to the
 primary relational algebra. -/
 theorem updateFromSat_eq_lift_test {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
-    updateFromSat sat ψ = lift (DynProp.test (λ p => sat p ψ)) := by
+    updateFromSat sat ψ = lift (test (λ p => sat p ψ)) := by
   funext σ; ext p
-  simp only [updateFromSat, lift, DynProp.test, Set.mem_setOf_eq]
+  simp only [updateFromSat, lift, test, Set.mem_setOf_eq]
   constructor
   · rintro ⟨hp, hsat⟩; exact ⟨p, hp, rfl, hsat⟩
   · rintro ⟨i, hi, rfl, hsat⟩; exact ⟨hi, hsat⟩

--- a/Linglib/Semantics/Dynamic/ContextChange.lean
+++ b/Linglib/Semantics/Dynamic/ContextChange.lean
@@ -110,6 +110,14 @@ non-distributive tests that inspect the entire input state. -/
 noncomputable def guard (C : InfoStateOf P → Prop) : CCP P :=
   λ s => if C s then s else ∅
 
+/-- A guard whose condition holds passes the state through. -/
+@[simp] theorem guard_pos {C : InfoStateOf P → Prop} {s} (h : C s) : guard C s = s :=
+  if_pos h
+
+/-- A guard whose condition fails crashes to `∅`. -/
+@[simp] theorem guard_neg {C : InfoStateOf P → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
+  if_neg h
+
 /--
 Test-based negation: passes (returns input) iff φ yields ∅.
 

--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -428,7 +428,7 @@ theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
     (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
     (K₁.transition (M := M) W X h₁).comp (K₂.transition W (X ∪ K₁.referents) h₂) =
       ((K₁.merge K₂).transition W X (DRS.fv_merge_subset h₁ h₂)).copy rfl
-        (by rw [DRS.merge_referents, ← Finset.union_assoc]) := by
+        (by rw [DRS.referents_merge, ← Finset.union_assoc]) := by
   ext w f g
   simp only [Transition.rel_copy, Transition.comp, DRS.transition,
     DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.dseq]

--- a/Linglib/Semantics/Dynamic/DRS/Based.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Based.lean
@@ -410,7 +410,7 @@ theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv �
   funext f g
   apply propext
   simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRelAt_mk,
-    Condition.holdsAllAt_append, DynamicSemantics.DynProp.dseq, Relation.Comp]
+    Condition.holdsAllAt_append, DynamicSemantics.dseq, Relation.Comp]
   rw [← Finset.union_assoc]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩
@@ -431,7 +431,7 @@ theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
         (by rw [DRS.merge_referents, ← Finset.union_assoc]) := by
   ext w f g
   simp only [Transition.rel_copy, Transition.comp, DRS.transition,
-    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.DynProp.dseq]
+    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.dseq]
 
 /-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
 DRS's transition to the state a proper context DRS expresses yields the

--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -87,19 +87,19 @@ instance : Category (Ctx L V) where
     { drs := u.drs.merge v.drs
       presup := DRS.fv_merge_subset u.presup (by rw [u.target]; exact v.presup)
       occ_le := by
-        rw [DRS.merge_conditions, Condition.occL_append, DRS.merge_referents,
+        rw [DRS.conditions_merge, Condition.occL_append, DRS.referents_merge,
           ← Finset.union_assoc]
         exact Finset.union_subset
           (u.occ_le.trans Finset.subset_union_left)
           (by rw [u.target]; exact v.occ_le)
       fresh := by
-        rw [DRS.merge_referents, Finset.disjoint_union_right]
+        rw [DRS.referents_merge, Finset.disjoint_union_right]
         refine ⟨u.fresh, ?_⟩
         have : Disjoint Y.base v.drs.referents := v.fresh
         rw [← u.target] at this
         exact this.mono_left Finset.subset_union_left
       target := by
-        rw [DRS.merge_referents, ← Finset.union_assoc, u.target, v.target] }
+        rw [DRS.referents_merge, ← Finset.union_assoc, u.target, v.target] }
   id_comp u := Hom.ext (DRS.empty_merge u.drs)
   comp_id u := Hom.ext (DRS.merge_empty u.drs)
   assoc u v w := Hom.ext (DRS.merge_assoc u.drs v.drs w.drs)

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -45,6 +45,8 @@ namespace DRT
 
 universe u v w
 
+variable {L : Language.{u, v}} {V : Type w}
+
 mutual
 /-- A discourse representation structure: the pair `⟨referents, conditions⟩`
 ([kamp-reyle-1993], Def. 1.4.1). `referents` is the universe `U` (a finite
@@ -68,8 +70,6 @@ inductive Condition (L : Language.{u, v}) (V : Type w) where
 end
 
 namespace DRS
-
-variable {L : Language.{u, v}} {V : Type w}
 
 /-- The referents (universe `U`) of a DRS — the discourse referents it introduces. -/
 def referents : DRS L V → Finset V
@@ -95,10 +95,10 @@ symmetric binary `⊕`. An operation, not a syntactic constructor. -/
 def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
   .mk (K₁.referents ∪ K₂.referents) (K₁.conditions ++ K₂.conditions)
 
-@[simp] theorem merge_referents [DecidableEq V] (K₁ K₂ : DRS L V) :
+@[simp] theorem referents_merge [DecidableEq V] (K₁ K₂ : DRS L V) :
     (K₁.merge K₂).referents = K₁.referents ∪ K₂.referents := rfl
 
-@[simp] theorem merge_conditions [DecidableEq V] (K₁ K₂ : DRS L V) :
+@[simp] theorem conditions_merge [DecidableEq V] (K₁ K₂ : DRS L V) :
     (K₁.merge K₂).conditions = K₁.conditions ++ K₂.conditions := rfl
 
 end DRS
@@ -114,8 +114,7 @@ extension:
 * the consequent of a `⇒` is subordinate to its *antecedent* (the ⇒ asymmetry:
   antecedent referents are accessible in the consequent, not conversely);
 * each disjunct of a `∨` is subordinate to the containing DRS. -/
-inductive DirectlySubordinate {L : Language.{u, v}} {V : Type w} :
-    DRS L V → DRS L V → Prop where
+inductive DirectlySubordinate : DRS L V → DRS L V → Prop where
   | neg {D K : DRS L V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D
   | impAnte {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate a D
   | impCons {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate c a
@@ -123,13 +122,16 @@ inductive DirectlySubordinate {L : Language.{u, v}} {V : Type w} :
   | disR {D l r : DRS L V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate r D
 
 /-- `K₁ < K₂`: subordinate — transitive closure of `DirectlySubordinate`
-([kamp-reyle-1993], Def. 1.4.10(ii)). -/
-abbrev Subordinate {L : Language.{u, v}} {V : Type w} : DRS L V → DRS L V → Prop :=
+([kamp-reyle-1993], Def. 1.4.10(ii)). Anchors Def. 1.4.10(ii) only:
+accessibility (`accessibleFrom`, `DRS/Basic.lean`) does not build on this
+closure. -/
+abbrev Subordinate : DRS L V → DRS L V → Prop :=
   Relation.TransGen DirectlySubordinate
 
 /-- `K₁ ≤ K₂`: weakly subordinate — reflexive-transitive closure
-([kamp-reyle-1993]; the `≤` of Def. 1.4.10). -/
-abbrev WeakSubordinate {L : Language.{u, v}} {V : Type w} : DRS L V → DRS L V → Prop :=
+([kamp-reyle-1993]; the `≤` of Def. 1.4.10). Anchors Def. 1.4.10(ii) only:
+accessibility does not build on this closure. -/
+abbrev WeakSubordinate : DRS L V → DRS L V → Prop :=
   Relation.ReflTransGen DirectlySubordinate
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -38,6 +38,8 @@ identification:
 * `DRS.toRel_merge` — the Merging Lemma: under freshness, `merge` denotes the
   spine sequencing `⨟` (relational composition) of the two box relations.
 
+## Implementation notes
+
 Naming: the dynamic face (`toRel`, `holds`, `trueRel`) follows the spine's
 lowerCamel operation names (`dneg`, `dseq`, `closure`); the static face
 (`DRS.Realize`, `DRS/Semantics.lean`) follows mathlib's `Formula.Realize`.
@@ -284,11 +286,11 @@ for `K₁`'s conditions, the merge `K₁ ⊕ K₂` denotes the spine sequencing
 (relational composition) of the two box relations — `‖K₁ ⊕ K₂‖ = ‖K₁‖ ⨟ ‖K₂‖`.
 This is what gives `merge` its dynamic meaning. -/
 theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
-    (hfresh : ∀ x ∈ K₂.referents, x ∉ Condition.occL K₁.conditions) :
+    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
     (DRS.toRel (K₁.merge K₂) : Update (V → M)) = DRS.toRel K₁ ⨟ DRS.toRel K₂ := by
   obtain ⟨U₁, conds₁⟩ := K₁
   obtain ⟨U₂, conds₂⟩ := K₂
-  simp only [DRS.referents_mk, DRS.conditions_mk] at hfresh
+  simp only [DRS.referents_mk, DRS.conditions_mk, Finset.disjoint_left] at hfresh
   funext a a'
   apply propext
   simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRel,
@@ -306,7 +308,7 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
     · refine (Condition.holdsAll_congr conds₁ _ a' ?_).mpr hh₁
       intro x hx
       exact Finset.piecewise_eq_of_notMem _ _ _
-        (fun h => hfresh x h (Finset.mem_coe.mp hx))
+        (fun h => hfresh h (Finset.mem_coe.mp hx))
     · intro x hx
       exact (Finset.piecewise_eq_of_notMem _ _ _ hx).symm
     · exact hh₂
@@ -316,6 +318,6 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
       rw [Finset.mem_union, not_or] at hx
       rw [hag2 x hx.2, hag1 x hx.1]
     · exact (Condition.holdsAll_congr conds₁ a' a''
-        (fun x hx => hag2 x (fun hu => hfresh x hu (Finset.mem_coe.mp hx)))).mpr hh1
+        (fun x hx => hag2 x (fun hu => hfresh hu (Finset.mem_coe.mp hx)))).mpr hh1
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -44,7 +44,7 @@ lowerCamel operation names (`dneg`, `dseq`, `closure`); the static face
 -/
 
 open FirstOrder FirstOrder.Language
-open DynamicSemantics.DynProp (Update dneg dimpl ddisj closure dseq)
+open DynamicSemantics (Update dneg dimpl ddisj closure dseq)
 
 namespace DRT
 

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -5,8 +5,8 @@ import Mathlib.ModelTheory.Syntax
 # From DRT to predicate logic: the DRS → first-order reduction
 [kamp-reyle-1993] (§1.5), [muskens-1996]
 
-The "surprise" theorem of the whole development: the bespoke DRS box language is
-*equivalent to ordinary first-order logic*. We translate each DRS into a mathlib
+The bespoke DRS box language is *equivalent to ordinary first-order
+logic*. We translate each DRS into a mathlib
 `FirstOrder.Language.Formula` and prove its `Realize` coincides with the bespoke
 `DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and Muskens's
 "DRSs are already present in classical logic", now a Lean theorem
@@ -54,7 +54,9 @@ over the conjunction of the (translated) conditions ([kamp-reyle-1993] §1.5). -
 noncomputable def DRS.toFormula [DecidableEq V] : DRS L V → L.Formula V
   | .mk U conds => closeExists U (Condition.toFormulaAll conds)
 /-- The conjunction of a DRS's conditions, *without* closing its universe (used
-as the antecedent body of a `⇒`). -/
+as the antecedent body of a `⇒`). A mutual sibling — the composite
+`Condition.toFormulaAll ∘ conditions` fails the nested-inductive
+structural-recursion checker. -/
 noncomputable def DRS.bodyFormula [DecidableEq V] : DRS L V → L.Formula V
   | .mk _ conds => Condition.toFormulaAll conds
 /-- Translate a single DRS-condition to a formula. -/
@@ -150,13 +152,14 @@ theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
   | .mk U conds =>
     rw [DRS.toFormula, realize_closeExists]
     simp only [DRS.referents_mk, DRS.Realize]
-    exact exists_congr (fun v' => and_congr_right (fun _ => realize_toFormulaAll conds v'))
+    exact exists_congr fun v' =>
+      and_congr_right fun _ => Condition.realize_toFormulaAll conds v'
 /-- The open body of a DRS (its conditions, no universe closure) realizes as
 `DRS.Realize` (used for the antecedent of `⇒`). -/
 theorem DRS.realize_bodyFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
     (DRS.bodyFormula K).Realize v ↔ DRS.Realize v K := by
   match K with
-  | .mk _ conds => exact realize_toFormulaAll conds v
+  | .mk _ conds => exact Condition.realize_toFormulaAll conds v
 /-- A single condition's translation realizes as `Condition.Realize`. -/
 theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : V → M) :
     (Condition.toFormula c).Realize v ↔ Condition.Realize v c := by
@@ -178,13 +181,13 @@ theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : V �
     simp only [Condition.toFormula, Condition.Realize, Formula.realize_sup]
     rw [DRS.realize_toFormula l v, DRS.realize_toFormula r v]
 /-- A list of conditions' conjoined translation realizes as `RealizeAll`. -/
-theorem realize_toFormulaAll [DecidableEq V] (cs : List (Condition L V)) (v : V → M) :
+theorem Condition.realize_toFormulaAll [DecidableEq V] (cs : List (Condition L V)) (v : V → M) :
     (Condition.toFormulaAll cs).Realize v ↔ Condition.RealizeAll v cs := by
   match cs with
   | [] => simp [Condition.toFormulaAll, Condition.RealizeAll, Formula.realize_top]
   | c :: cs =>
     rw [Condition.toFormulaAll, Condition.RealizeAll, Formula.realize_inf,
-      Condition.realize_toFormula c v, realize_toFormulaAll cs v]
+      Condition.realize_toFormula c v, Condition.realize_toFormulaAll cs v]
 end
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Semantics.lean
@@ -6,7 +6,7 @@ import Mathlib.ModelTheory.Semantics
 [kamp-reyle-1993]
 
 DRS truth via *verifying embeddings* into a mathlib `FirstOrder.Language.Structure`
-— Kamp & Reyle's Def. 1.4.4–1.4.5 in the *total-assignment* rendering. An
+— Kamp & Reyle's Def. 1.4.4 in the *total-assignment* rendering. An
 embedding is an assignment `v : V → M` of discourse referents to the model
 domain; the discourse referents introduced by a sub-DRS are existentially
 (re)assigned when that sub-DRS is entered, which is what
@@ -23,7 +23,6 @@ says "every man is mortal" for K&R, "if there is a man there is a mortal" here.
 
 * `DRS.Realize` / `Condition.Realize` — the verifying-embedding relation
   (Def. 1.4.4), reusing mathlib's `Structure.RelMap` for atomic conditions.
-* `DRS.trueIn` — `K` is true in `M` iff some embedding verifies it (Def. 1.4.5).
 -/
 
 open FirstOrder FirstOrder.Language
@@ -63,10 +62,5 @@ def Condition.RealizeAll (v : V → M) : List (Condition L V) → Prop
   | [] => True
   | c :: cs => Condition.Realize v c ∧ Condition.RealizeAll v cs
 end
-
-/-- `K` is *true* in `M` iff some embedding verifies it ([kamp-reyle-1993],
-Def. 1.4.5). -/
-def DRS.trueIn (M : Type x) [L.Structure M] (K : DRS L V) : Prop :=
-  ∃ v : V → M, K.Realize v
 
 end DRT

--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -20,12 +20,12 @@ carrier types) and below paper-specific theories such as [hofmann-2025]
 | Layer | Names |
 |-------|-------|
 | Information state | `IContext` (set of assignment-world pairs), `DynProp` (context transformer) |
-| Update relations | `ICDRTUpdate`, `ICDRTUpdate.{seq, idUp, toDynProp}` |
+| Update relations | `ICDRTUpdate`, `ICDRTUpdate.{seq, idUp, toUpdate}` |
 | Variable updates | `propVarUp`, `indivVarUp`, `multiVarUp`, `relVarUp` |
 | Dynamic conditions | `dynInclusion`, `dynIdentity`, `dynComplement`, `isComplement`, `dynUnion` |
 | Predication | `dynPred`, `localEntailment` |
 | Veridicality typology | `veridicalIndiv/Prop`, `counterfactualIndiv/Prop`, `hypotheticalIndiv/Prop`, `accessible`, `subsetReq` |
-| Static-to-dynamic bridge | `fiberDRS`, `toDynProp_eq_lift_fiberDRS` |
+| Static-to-dynamic bridge | `fiberDRS`, `toUpdate_eq_lift_fiberDRS` |
 
 ## Architecture
 
@@ -37,11 +37,11 @@ ICDRTUpdate W E ──fiberDRS──→ Update (ICDRTAssignment W E × W) ──
     seq = dseq              dseq (fiber level)                    CCP.seq
 ```
 
-The factorization `toDynProp = lift ∘ fiberDRS` separates two concerns:
+The factorization `toUpdate = lift ∘ fiberDRS` separates two concerns:
 - `fiberDRS`: embed assignment-only relations into pair relations (passive worlds)
 - `lift`: convert relational meanings to set-transformer meanings
 
-`toDynProp` is always distributive (corollary of `lift_isDistributive`).
+`toUpdate` is always distributive (corollary of `lift_isDistributive`).
 This is the algebraic content of [hofmann-2025]'s observation that
 ICDRT-style negation via propositional dref complementation stays
 distributive — unlike test-based dynamic negation that inspects whole
@@ -51,7 +51,6 @@ states.
 namespace DynamicSemantics
 
 open Core (Assignment)
-open DynProp
 
 variable {W E : Type*}
 
@@ -130,7 +129,7 @@ end DynProp
 Following [muskens-1996]'s Compositional DRT, dynamic updates are
 relations between assignments rather than operations on sets of
 assignment-world pairs. The lift to context transformers is done by
-`toDynProp` below. -/
+`toUpdate` below. -/
 def ICDRTUpdate (W : Type*) (E : Type*) :=
   ICDRTAssignment W E → ICDRTAssignment W E → Prop
 
@@ -151,18 +150,18 @@ def successful (D : ICDRTUpdate W E) (i : ICDRTAssignment W E) : Prop :=
   ∃ j, D i j
 
 /-- Lift a static update relation to a context update on information states. -/
-def toDynProp (D : ICDRTUpdate W E) : DynProp W E :=
+def toUpdate (D : ICDRTUpdate W E) : DynProp W E :=
   λ c => { p | ∃ i, (i, p.2) ∈ c ∧ D i p.1 }
 
 /-- Identity update lifts to identity on contexts. -/
-theorem idUp_toDynProp (c : IContext W E) :
-    ICDRTUpdate.idUp.toDynProp c = c :=
+theorem idUp_toUpdate (c : IContext W E) :
+    ICDRTUpdate.idUp.toUpdate c = c :=
   Set.ext (λ ⟨j, _⟩ =>
     ⟨λ ⟨_, hic, rfl⟩ => hic, λ hjc => ⟨j, hjc, rfl⟩⟩)
 
 /-- Sequential composition lifts to function composition on contexts. -/
-theorem seq_toDynProp (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
-    (seq D₁ D₂).toDynProp c = D₂.toDynProp (D₁.toDynProp c) :=
+theorem seq_toUpdate (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
+    (seq D₁ D₂).toUpdate c = D₂.toUpdate (D₁.toUpdate c) :=
   Set.ext (λ ⟨_, _⟩ =>
     ⟨λ ⟨i, hic, k, h1, h2⟩ => ⟨k, ⟨i, hic, h1⟩, h2⟩,
      λ ⟨k, ⟨i, hic, h1⟩, h2⟩ => ⟨i, hic, k, h1, h2⟩⟩)
@@ -563,13 +562,13 @@ ICDRT updates operate on assignments only and worlds are inert fibers.
 def fiberDRS (D : ICDRTUpdate W E) : Update (ICDRTAssignment W E × W) :=
   λ ⟨i, w⟩ ⟨j, w'⟩ => w = w' ∧ D i j
 
-/-- `toDynProp = lift ∘ fiberDRS`: the static-to-dynamic bridge factors
+/-- `toUpdate = lift ∘ fiberDRS`: the static-to-dynamic bridge factors
 through fiberwise embedding followed by relational image. -/
-theorem toDynProp_eq_lift_fiberDRS (D : ICDRTUpdate W E) :
-    D.toDynProp = lift (fiberDRS D) := by
+theorem toUpdate_eq_lift_fiberDRS (D : ICDRTUpdate W E) :
+    D.toUpdate = lift (fiberDRS D) := by
   funext σ
   apply Set.ext; intro ⟨j, w⟩
-  simp only [ICDRTUpdate.toDynProp, lift, fiberDRS, Set.mem_setOf_eq]
+  simp only [ICDRTUpdate.toUpdate, lift, fiberDRS, Set.mem_setOf_eq]
   constructor
   · rintro ⟨i, hic, hD⟩
     exact ⟨⟨i, w⟩, hic, rfl, hD⟩
@@ -606,54 +605,54 @@ theorem fiberDRS_homomorphism :
 -- § 11. Distributivity, Test Eliminativity, and Round-Trip
 -- ════════════════════════════════════════════════════════════════
 
-/-- `toDynProp D` is always distributive: it processes each
+/-- `toUpdate D` is always distributive: it processes each
 assignment-world pair independently. Corollary of `lift_isDistributive`. -/
-theorem toDynProp_isDistributive (D : ICDRTUpdate W E) :
-    IsDistributive (D.toDynProp) := by
-  rw [toDynProp_eq_lift_fiberDRS]
+theorem toUpdate_isDistributive (D : ICDRTUpdate W E) :
+    IsDistributive (D.toUpdate) := by
+  rw [toUpdate_eq_lift_fiberDRS]
   exact lift_isDistributive (fiberDRS D)
 
 /-- A test update — one that preserves the assignment — lifts to an
 eliminative CCP: it can only shrink the context, never grow it. -/
-theorem toDynProp_test_eliminative (C : ICDRTAssignment W E → Prop) :
-    IsEliminative (ICDRTUpdate.toDynProp (λ i j => i = j ∧ C j)) := by
+theorem toUpdate_test_eliminative (C : ICDRTAssignment W E → Prop) :
+    IsEliminative (ICDRTUpdate.toUpdate (λ i j => i = j ∧ C j)) := by
   intro _ ⟨_, _⟩ hjw
   obtain ⟨_, hiw, rfl, _⟩ := hjw
   exact hiw
 
 /-- The DEC condition lifts to an eliminative CCP: assertion narrows the
 context (removes worlds from the commitment set). -/
-theorem toDynProp_dec_eliminative (φ_DC φ : PVar) :
-    IsEliminative (ICDRTUpdate.toDynProp
+theorem toUpdate_dec_eliminative (φ_DC φ : PVar) :
+    IsEliminative (ICDRTUpdate.toUpdate
       (λ i j : ICDRTAssignment W E => i = j ∧ decCondition φ_DC φ j)) :=
-  toDynProp_test_eliminative _
+  toUpdate_test_eliminative _
 
 /-- ICDRT-style negation via complementation stays distributive — unlike
 test-based dynamic negation that inspects the whole input state. -/
 theorem complement_update_distributive (φ_outer φ_inner : PVar) :
-    IsDistributive (ICDRTUpdate.toDynProp
+    IsDistributive (ICDRTUpdate.toUpdate
       (λ i j : ICDRTAssignment W E =>
         i = j ∧ isComplement φ_outer φ_inner j)) :=
-  toDynProp_isDistributive _
+  toUpdate_isDistributive _
 
 /-- Round-trip: lowering the CCP back to a relation recovers the fiberwise
 embedding. Combined with `lower_lift`, this shows no information is lost
 in the `fiberDRS`/`lift` factorization. -/
-theorem lower_toDynProp (D : ICDRTUpdate W E) :
-    lower (D.toDynProp) = fiberDRS D := by
-  rw [toDynProp_eq_lift_fiberDRS, lower_lift]
+theorem lower_toUpdate (D : ICDRTUpdate W E) :
+    lower (D.toUpdate) = fiberDRS D := by
+  rw [toUpdate_eq_lift_fiberDRS, lower_lift]
 
-/-- `toDynProp` preserves sequential composition — algebraic derivation via
+/-- `toUpdate` preserves sequential composition — algebraic derivation via
 `fiberDRS_seq` + `lift_dseq`. -/
-theorem toDynProp_seq_algebraic (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
-    (ICDRTUpdate.seq D₁ D₂).toDynProp c = CCP.seq D₁.toDynProp D₂.toDynProp c := by
-  conv_lhs => rw [toDynProp_eq_lift_fiberDRS, fiberDRS_seq, lift_dseq]
-  conv_rhs => rw [toDynProp_eq_lift_fiberDRS D₁, toDynProp_eq_lift_fiberDRS D₂]
+theorem toUpdate_seq_algebraic (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
+    (ICDRTUpdate.seq D₁ D₂).toUpdate c = CCP.seq D₁.toUpdate D₂.toUpdate c := by
+  conv_lhs => rw [toUpdate_eq_lift_fiberDRS, fiberDRS_seq, lift_dseq]
+  conv_rhs => rw [toUpdate_eq_lift_fiberDRS D₁, toUpdate_eq_lift_fiberDRS D₂]
 
-/-- `toDynProp` preserves identity — algebraic derivation via `fiberDRS_idUp`. -/
-theorem toDynProp_id_algebraic (c : IContext W E) :
-    ICDRTUpdate.idUp.toDynProp c = CCP.id c := by
-  rw [toDynProp_eq_lift_fiberDRS, fiberDRS_idUp]
+/-- `toUpdate` preserves identity — algebraic derivation via `fiberDRS_idUp`. -/
+theorem toUpdate_id_algebraic (c : IContext W E) :
+    ICDRTUpdate.idUp.toUpdate c = CCP.id c := by
+  rw [toUpdate_eq_lift_fiberDRS, fiberDRS_idUp]
   apply Set.ext; intro ⟨j, w⟩
   simp only [lift, CCP.id, Set.mem_setOf_eq]
   constructor

--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -17,35 +17,26 @@ carrier types) and below paper-specific theories such as [hofmann-2025]
 
 ## Main definitions
 
-| Layer | Names |
-|-------|-------|
-| Information state | `IContext` (set of assignment-world pairs), `DynProp` (context transformer) |
-| Update relations | `ICDRTUpdate`, `ICDRTUpdate.{seq, idUp, toUpdate}` |
-| Variable updates | `propVarUp`, `indivVarUp`, `multiVarUp`, `relVarUp` |
-| Dynamic conditions | `dynInclusion`, `dynIdentity`, `dynComplement`, `isComplement`, `dynUnion` |
-| Predication | `dynPred`, `localEntailment` |
-| Veridicality typology | `veridicalIndiv/Prop`, `counterfactualIndiv/Prop`, `hypotheticalIndiv/Prop`, `accessible`, `subsetReq` |
-| Static-to-dynamic bridge | `fiberDRS`, `toUpdate_eq_lift_fiberDRS` |
-
-## Architecture
-
-```
-ICDRTUpdate W E ──fiberDRS──→ Update (ICDRTAssignment W E × W) ──lift──→ CCP (... × W)
-       ‖                              ‖                                    ‖
-   Update (Assign)              Update (Assign × World)                 DynProp W E
-       │                              │                                    │
-    seq = dseq              dseq (fiber level)                    CCP.seq
-```
+- `IContext`, `DynProp`: information states (sets of assignment-world
+  pairs) and context transformers over them (the spine's `CCP` at ICDRT
+  possibilities).
+- `ICDRTUpdate`, with `seq`, `idUp`, and the lift `toUpdate`: static
+  update relations between assignments, after [muskens-1996].
+- `propVarUp`, `indivVarUp`, `multiVarUp`, `relVarUp`: variable updates.
+- `dynInclusion`, `isComplement`: dynamic conditions on propositional drefs.
+- `dynPred`, `localEntailment`: predication and local contextual entailment.
+- `veridicalIndiv`, `counterfactualIndiv`, `hypotheticalIndiv`,
+  `counterfactualProp`, `accessible`, `subsetReq`: the veridicality typology.
+- `fiberDRS`, `toUpdate_eq_lift_fiberDRS`: the static-to-dynamic bridge.
 
 The factorization `toUpdate = lift ∘ fiberDRS` separates two concerns:
-- `fiberDRS`: embed assignment-only relations into pair relations (passive worlds)
-- `lift`: convert relational meanings to set-transformer meanings
-
-`toUpdate` is always distributive (corollary of `lift_isDistributive`).
-This is the algebraic content of [hofmann-2025]'s observation that
-ICDRT-style negation via propositional dref complementation stays
-distributive — unlike test-based dynamic negation that inspects whole
-states.
+`fiberDRS` embeds assignment-only relations into pair relations (passive
+worlds), and `lift` converts relational meanings to set-transformer
+meanings. Consequently `toUpdate` is always distributive (corollary of
+`lift_isDistributive`) — the algebraic content of [hofmann-2025]'s
+observation that ICDRT-style negation via propositional dref
+complementation stays distributive, unlike test-based dynamic negation
+that inspects whole states.
 -/
 
 namespace DynamicSemantics
@@ -53,21 +44,10 @@ namespace DynamicSemantics
 open Core (Assignment)
 
 variable {W E : Type*}
+variable (φ φ₁ φ₂ φ₃ φ_DC φ_anaphor φ_antecedent : PVar) (v : IVar)
+variable (i j : ICDRTAssignment W E)
 
-
--- ════════════════════════════════════════════════════════════════
--- § 1. Information States and Context Transformers
--- ════════════════════════════════════════════════════════════════
-
-namespace ICDRTAssignment
-
-/-- Notation for individual variable lookup -/
-notation g "⟦" v "⟧ᵢ" => ICDRTAssignment.indiv g v
-
-/-- Notation for propositional variable lookup -/
-notation g "⟦" p "⟧ₚ" => ICDRTAssignment.prop g p
-
-end ICDRTAssignment
+/-! ### Information states and context transformers -/
 
 /-- Set of assignment-world pairs (information state in flat update).
 
@@ -81,24 +61,9 @@ namespace IContext
 /-- The trivial context (all possibilities) -/
 def univ : IContext W E := Set.univ
 
-/-- The absurd context (no possibilities) -/
-def empty : IContext W E := ∅
-
-/-- Context is consistent (non-empty) -/
-def consistent (c : IContext W E) : Prop := c.Nonempty
-
-/-- Worlds in the context (projection) -/
-def worlds (c : IContext W E) : Set W := { w | ∃ g, (g, w) ∈ c }
-
 /-- Update with a world-predicate -/
 def update (c : IContext W E) (p : W → Prop) : IContext W E :=
   { gw ∈ c | p gw.2 }
-
-/-- Update with an assignment-world predicate -/
-def updateFull (c : IContext W E) (p : ICDRTAssignment W E → W → Prop) : IContext W E :=
-  { gw ∈ c | p gw.1 gw.2 }
-
-notation:max c "⟦" p "⟧" => IContext.update c p
 
 end IContext
 
@@ -114,15 +79,9 @@ abbrev id : DynProp W E := CCP.id
 /-- Absurd (contradiction): the spine's `CCP.absurd`. -/
 abbrev absurd : DynProp W E := CCP.absurd
 
-/-- Lift a classical proposition to a context filter. -/
-def ofProp (p : W → Prop) : DynProp W E := λ c => IContext.update c p
-
 end DynProp
 
-
--- ════════════════════════════════════════════════════════════════
--- § 2. Updates as Static Relations (after [muskens-1996])
--- ════════════════════════════════════════════════════════════════
+/-! ### Updates as static relations -/
 
 /-- Static update relation between input and output assignments.
 
@@ -135,9 +94,11 @@ def ICDRTUpdate (W : Type*) (E : Type*) :=
 
 namespace ICDRTUpdate
 
+variable (D D₁ D₂ : ICDRTUpdate W E) (c : IContext W E)
+
 /-- Sequencing (`;`): relational composition.
     `(D₁ ; D₂)(i)(j) ↔ ∃k, D₁(i)(k) ∧ D₂(k)(j)` -/
-def seq (D₁ D₂ : ICDRTUpdate W E) : ICDRTUpdate W E :=
+def seq : ICDRTUpdate W E :=
   λ i j => ∃ k, D₁ i k ∧ D₂ k j
 
 infixl:60 " ⨟ " => seq
@@ -145,33 +106,24 @@ infixl:60 " ⨟ " => seq
 /-- Identity update: output equals input. -/
 def idUp : ICDRTUpdate W E := λ i j => i = j
 
-/-- An update is successful from `i` if some output `j` exists. -/
-def successful (D : ICDRTUpdate W E) (i : ICDRTAssignment W E) : Prop :=
-  ∃ j, D i j
-
 /-- Lift a static update relation to a context update on information states. -/
-def toUpdate (D : ICDRTUpdate W E) : DynProp W E :=
+def toUpdate : DynProp W E :=
   λ c => { p | ∃ i, (i, p.2) ∈ c ∧ D i p.1 }
 
 /-- Identity update lifts to identity on contexts. -/
-theorem idUp_toUpdate (c : IContext W E) :
-    ICDRTUpdate.idUp.toUpdate c = c :=
+theorem idUp_toUpdate : ICDRTUpdate.idUp.toUpdate c = c :=
   Set.ext (λ ⟨j, _⟩ =>
     ⟨λ ⟨_, hic, rfl⟩ => hic, λ hjc => ⟨j, hjc, rfl⟩⟩)
 
 /-- Sequential composition lifts to function composition on contexts. -/
-theorem seq_toUpdate (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
-    (seq D₁ D₂).toUpdate c = D₂.toUpdate (D₁.toUpdate c) :=
+theorem seq_toUpdate : (seq D₁ D₂).toUpdate c = D₂.toUpdate (D₁.toUpdate c) :=
   Set.ext (λ ⟨_, _⟩ =>
     ⟨λ ⟨i, hic, k, h1, h2⟩ => ⟨k, ⟨i, hic, h1⟩, h2⟩,
      λ ⟨k, ⟨i, hic, h1⟩, h2⟩ => ⟨i, hic, k, h1, h2⟩⟩)
 
 end ICDRTUpdate
 
-
--- ════════════════════════════════════════════════════════════════
--- § 3. Variable Updates
--- ════════════════════════════════════════════════════════════════
+/-! ### Variable updates -/
 
 /-- Propositional variable update: `j` differs from `i` at most in the value of `p`.
 `i[p]j` -/
@@ -181,7 +133,7 @@ def propVarUp (p : PVar) (i j : ICDRTAssignment W E) : Prop :=
 
 /-- Individual variable update: `j` differs from `i` at most in the value of `v`.
 `i[v]j` -/
-def indivVarUp (v : IVar) (i j : ICDRTAssignment W E) : Prop :=
+def indivVarUp : Prop :=
   (∀ p : PVar, j.prop p = i.prop p) ∧
   (∀ u : IVar, u ≠ v → j.indiv u = i.indiv u)
 
@@ -200,42 +152,22 @@ The biconditional (not just implication) is crucial: it ensures that
 `v` has a referent in all and only the φ-worlds, preventing drefs under
 negation from having global referents. Following [hofmann-2025]
 Definition 25. -/
-def relVarUp (φ : PVar) (v : IVar) (i j : ICDRTAssignment W E) : Prop :=
+def relVarUp : Prop :=
   indivVarUp v i j ∧
   (∀ w : W, w ∈ j.prop φ ↔ j.indiv v w ≠ .star)
 
-
--- ════════════════════════════════════════════════════════════════
--- § 4. Dynamic Conditions on Propositional Drefs
--- ════════════════════════════════════════════════════════════════
+/-! ### Dynamic conditions on propositional drefs -/
 
 /-- Dynamic inclusion: `φ₁(i) ⊆ φ₂(i)`. -/
-def dynInclusion (φ₁ φ₂ : PVar) (i : ICDRTAssignment W E) : Prop :=
+def dynInclusion : Prop :=
   i.prop φ₁ ⊆ i.prop φ₂
-
-notation:50 φ₁ " ∈ₚ " φ₂ " at " i => dynInclusion φ₁ φ₂ i
-
-/-- Dynamic identity: `α(i) = β(i)`. -/
-def dynIdentity (α β : PVar) (i : ICDRTAssignment W E) : Prop :=
-  i.prop α = i.prop β
-
-/-- Dynamic complementation: set-theoretic complement of a propositional dref. -/
-def dynComplement (φ : PVar) (i : ICDRTAssignment W E) : Set W :=
-  (i.prop φ)ᶜ
 
 /-- Condition: `φ₁` is the complement of `φ₂` at state `i`.
 The negation condition `φ₁ ≡ φ̄₂`. -/
-def isComplement (φ₁ φ₂ : PVar) (i : ICDRTAssignment W E) : Prop :=
+def isComplement : Prop :=
   i.prop φ₁ = (i.prop φ₂)ᶜ
 
-/-- Dynamic union: `φ₁(i) ∪ φ₂(i)`. -/
-def dynUnion (φ₁ φ₂ : PVar) (i : ICDRTAssignment W E) : Set W :=
-  i.prop φ₁ ∪ i.prop φ₂
-
-
--- ════════════════════════════════════════════════════════════════
--- § 5. Predication and Local Entailment
--- ════════════════════════════════════════════════════════════════
+/-! ### Predication and local entailment -/
 
 /-- Dynamic predication: `R_φ(v)`.
 
@@ -259,51 +191,26 @@ def dynPred (R : E → W → Prop) (φ : PVar) (v : IVar)
 `∀w.(φ(i)(w) → v(i)(w) ≠ ⋆_e)`
 
 A precondition for anaphora to `v` resolved in local context `φ`. -/
-def localEntailment (φ : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) : Prop :=
+def localEntailment : Prop :=
   ∀ w ∈ i.prop φ, i.indiv v w ≠ .star
 
-/-- Predication entails existence: a successful predication of `R` to `v`
-implies `v(i)(w) ≠ ⋆`. -/
-theorem pred_entails_existence (v : IVar) (i : ICDRTAssignment W E)
-    (w : W) (e : E) (hv : i.indiv v w = .some e) :
-    i.indiv v w ≠ .star := by
-  rw [hv]; exact fun h => nomatch h
+/-! ### Veridicality typology -/
 
-
--- ════════════════════════════════════════════════════════════════
--- § 6. Veridicality Typology
--- ════════════════════════════════════════════════════════════════
-
-/-- Veridical individual dref: `v` has a referent in all `φ_DC`-worlds. -/
-def veridicalIndiv (φ_DC : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) : Prop :=
-  ∀ w ∈ i.prop φ_DC, i.indiv v w ≠ .star
-
-/-- Veridical propositional dref: `φ_DC(i) ⊆ δ(i)`. -/
-def veridicalProp (φ_DC : PVar) (δ : PVar)
-    (i : ICDRTAssignment W E) : Prop :=
-  i.prop φ_DC ⊆ i.prop δ
+/-- Veridical individual dref: `v` has a referent in all `φ_DC`-worlds —
+`localEntailment` read at the commitment set. -/
+abbrev veridicalIndiv : Prop := localEntailment φ_DC v i
 
 /-- Counterfactual individual dref: `v` maps to `⋆` in all `φ_DC`-worlds. -/
-def counterfactualIndiv (φ_DC : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) : Prop :=
+def counterfactualIndiv : Prop :=
   ∀ w ∈ i.prop φ_DC, i.indiv v w = .star
 
 /-- Counterfactual propositional dref: `φ_DC(i) ∩ δ(i) = ∅`. -/
-def counterfactualProp (φ_DC : PVar) (δ : PVar)
-    (i : ICDRTAssignment W E) : Prop :=
+def counterfactualProp (φ_DC δ : PVar) (i : ICDRTAssignment W E) : Prop :=
   i.prop φ_DC ∩ i.prop δ = ∅
 
 /-- Hypothetical individual dref: neither veridical nor counterfactual. -/
-def hypotheticalIndiv (φ_DC : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) : Prop :=
+def hypotheticalIndiv : Prop :=
   ¬veridicalIndiv φ_DC v i ∧ ¬counterfactualIndiv φ_DC v i
-
-/-- Hypothetical propositional dref: neither veridical nor counterfactual. -/
-def hypotheticalProp (φ_DC : PVar) (δ : PVar)
-    (i : ICDRTAssignment W E) : Prop :=
-  ¬veridicalProp φ_DC δ i ∧ ¬counterfactualProp φ_DC δ i
 
 /-- Accessibility: `v` is accessible at the anaphor site `φ_anaphor` iff
 it is locally entailed there and the discourse is consistent. -/
@@ -312,24 +219,17 @@ def accessible (φ_anaphor : PVar) (v : IVar)
   localEntailment φ_anaphor v i ∧ (i.prop φ_DC).Nonempty
 
 /-- Subset requirement: indefinite at `φ_antecedent` can antecede pronoun at
-`φ_anaphor` only when `φ_anaphor(i) ⊆ φ_antecedent(i)`. -/
-def subsetReq (φ_anaphor φ_antecedent : PVar)
-    (i : ICDRTAssignment W E) : Prop :=
-  i.prop φ_anaphor ⊆ i.prop φ_antecedent
+`φ_anaphor` only when `φ_anaphor(i) ⊆ φ_antecedent(i)` — `dynInclusion` at
+the anaphor site. -/
+abbrev subsetReq : Prop := dynInclusion φ_anaphor φ_antecedent i
 
+/-! ### Multi-agent discourse contexts -/
 
--- ════════════════════════════════════════════════════════════════
--- § 7. Multi-Agent Discourse Contexts
--- ════════════════════════════════════════════════════════════════
-
-/-- Generic declarative-assertion subset condition: `φ_DC(j) ⊆ φ(j)`.
-
-Definitionally identical to `dynInclusion φ_DC φ j`; kept as a
-separate name because the speech-act literature reads it as
-"the speaker's commitment set is updated to a subset of the
-asserted content". -/
-def decCondition (φ_DC : PVar) (φ : PVar) (j : ICDRTAssignment W E) : Prop :=
-  j.prop φ_DC ⊆ j.prop φ
+/-- Generic declarative-assertion subset condition: `φ_DC(j) ⊆ φ(j)` —
+`dynInclusion` under the speech-act reading "the speaker's commitment set
+is updated to a subset of the asserted content". -/
+abbrev decCondition (φ_DC φ : PVar) (j : ICDRTAssignment W E) : Prop :=
+  dynInclusion φ_DC φ j
 
 /-- **Counterfactual antecedent blocks veridical anaphor**
 ([hofmann-2025]'s bathroom-sentence theorem: "There isn't a bathroom.
@@ -375,18 +275,6 @@ namespace DiscContext
 def consistent {Speaker : Type*} (c : DiscContext W E Speaker) : Prop :=
   ∀ x : Speaker, (c.state.prop (c.dcVar x)).Nonempty
 
-/-- An update `D` is *successful* in context `C` iff some output assignment
-exists. -/
-def updateSuccessful {Speaker : Type*} (c : DiscContext W E Speaker)
-    (D : ICDRTUpdate W E) : Prop :=
-  ∃ j, D c.state j
-
-/-- An update is *acceptable* iff it is successful AND leaves all commitment
-sets nonempty (preserves discourse consistency). -/
-def updateAcceptable {Speaker : Type*} (c : DiscContext W E Speaker)
-    (D : ICDRTUpdate W E) : Prop :=
-  ∃ j, D c.state j ∧ ∀ x : Speaker, (j.prop (c.dcVar x)).Nonempty
-
 /-- Null assignment: every propositional dref maps to all worlds; every
 individual dref maps to ⋆ in every world. The "no information yet" state. -/
 def nullAssignment : ICDRTAssignment W E where
@@ -403,15 +291,12 @@ def initialContext {Speaker : Type*} (dcVar : Speaker → PVar) :
 /-- The initial context is always consistent. -/
 theorem initialContext_consistent [Nonempty W]
     {Speaker : Type*} {dcVar : Speaker → PVar} :
-    (initialContext dcVar : DiscContext W E Speaker).consistent := by
-  intro _; exact Set.univ_nonempty
+    (initialContext dcVar : DiscContext W E Speaker).consistent :=
+  λ _ => Set.univ_nonempty
 
 end DiscContext
 
-
--- ════════════════════════════════════════════════════════════════
--- § 8. Pragmatic and Propositional Maximization
--- ════════════════════════════════════════════════════════════════
+/-! ### Pragmatic and propositional maximization -/
 
 /-- Pragmatic maximization for commitment sets.
 
@@ -449,22 +334,17 @@ def believeCondition (φ_belief : PVar) (dox : ICDRTAssignment W E → Set W)
     (j : ICDRTAssignment W E) : Prop :=
   dox j ⊆ j.prop φ_belief
 
-
--- ════════════════════════════════════════════════════════════════
--- § 9. Structural Theorems
--- ════════════════════════════════════════════════════════════════
+/-! ### Structural theorems -/
 
 /-- Local entailment follows from relative variable update. The biconditional
 in `relVarUp` (Definition 25ii) directly yields local contextual entailment
 at the output assignment. -/
-theorem relVarUp_implies_localEntailment (φ : PVar) (v : IVar)
-    (i j : ICDRTAssignment W E) (h : relVarUp φ v i j) :
+theorem relVarUp_implies_localEntailment (h : relVarUp φ v i j) :
     localEntailment φ v j :=
   λ w hw => (h.2 w).mp hw
 
 /-- Veridical dref + DC-subsumed anaphor context + consistency → accessibility. -/
-theorem veridical_implies_accessible (φ_DC φ_anaphor : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+theorem veridical_implies_accessible
     (h_veridical : veridicalIndiv φ_DC v i)
     (h_subset : i.prop φ_anaphor ⊆ i.prop φ_DC)
     (h_consistent : (i.prop φ_DC).Nonempty) :
@@ -472,8 +352,7 @@ theorem veridical_implies_accessible (φ_DC φ_anaphor : PVar) (v : IVar)
   ⟨λ w hw => h_veridical w (h_subset hw), h_consistent⟩
 
 /-- Counterfactual dref in veridical anaphor context → inaccessibility. -/
-theorem counterfactual_veridical_fails (φ_DC φ_anaphor φ_antecedent : PVar)
-    (v : IVar) (i : ICDRTAssignment W E)
+theorem counterfactual_veridical_fails
     (h_cf : counterfactualIndiv φ_DC v i)
     (h_dc_veridical : i.prop φ_DC ⊆ i.prop φ_anaphor)
     (h_subset : subsetReq φ_anaphor φ_antecedent i)
@@ -487,7 +366,7 @@ theorem counterfactual_veridical_fails (φ_DC φ_anaphor φ_antecedent : PVar)
   exact h_ne_star (h_cf w hw)
 
 /-- Double complementation collapses: `φ₁ ≡ φ̄₂` and `φ₃ ≡ φ̄₁` give `φ₃ = φ₂`. -/
-theorem double_complement_eq (φ₁ φ₂ φ₃ : PVar) (i : ICDRTAssignment W E)
+theorem double_complement_eq
     (h1 : isComplement φ₁ φ₂ i)
     (h2 : isComplement φ₃ φ₁ i) :
     i.prop φ₃ = i.prop φ₂ := by
@@ -506,18 +385,12 @@ theorem disjunction_enables_anaphora (φ₃ φ_a : PVar) (v : IVar)
 
 /-- Veridicality trichotomy: every individual dref is veridical, counterfactual,
 or hypothetical relative to any speaker. -/
-theorem veridicality_trichotomy (φ_DC : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) :
+theorem veridicality_trichotomy :
     veridicalIndiv φ_DC v i ∨ counterfactualIndiv φ_DC v i ∨ hypotheticalIndiv φ_DC v i := by
-  by_cases hv : veridicalIndiv φ_DC v i
-  · exact Or.inl hv
-  · by_cases hc : counterfactualIndiv φ_DC v i
-    · exact Or.inr (Or.inl hc)
-    · exact Or.inr (Or.inr ⟨hv, hc⟩)
+  tauto
 
 /-- Veridical and counterfactual are incompatible given a nonempty DC. -/
-theorem veridical_counterfactual_exclusive (φ_DC : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+theorem veridical_counterfactual_exclusive
     (hv : veridicalIndiv φ_DC v i) (hc : counterfactualIndiv φ_DC v i) :
     ¬(i.prop φ_DC).Nonempty :=
   λ ⟨w, hw⟩ => absurd (hc w hw) (hv w hw)
@@ -547,10 +420,9 @@ theorem dec_complement_counterfactual (φ_DC φ_outer φ_inner : PVar)
   rintro ⟨hw_dc, hw_inner⟩
   exact h_dec hw_dc hw_inner
 
+/-! ### Fiberwise lift to CCP -/
 
--- ════════════════════════════════════════════════════════════════
--- § 10. Fiberwise Lift to CCP
--- ════════════════════════════════════════════════════════════════
+variable (D D₁ D₂ : ICDRTUpdate W E)
 
 /-- Embed an assignment-only relation into a pair relation with passive worlds.
 
@@ -559,13 +431,12 @@ theorem dec_complement_counterfactual (φ_DC φ_outer φ_inner : PVar)
 ICDRT updates operate on assignments only and worlds are inert fibers.
 `fiberDRS` makes this structure explicit at the type level of
 `Update (ICDRTAssignment W E × W)`. -/
-def fiberDRS (D : ICDRTUpdate W E) : Update (ICDRTAssignment W E × W) :=
+def fiberDRS : Update (ICDRTAssignment W E × W) :=
   λ ⟨i, w⟩ ⟨j, w'⟩ => w = w' ∧ D i j
 
 /-- `toUpdate = lift ∘ fiberDRS`: the static-to-dynamic bridge factors
 through fiberwise embedding followed by relational image. -/
-theorem toUpdate_eq_lift_fiberDRS (D : ICDRTUpdate W E) :
-    D.toUpdate = lift (fiberDRS D) := by
+theorem toUpdate_eq_lift_fiberDRS : D.toUpdate = lift (fiberDRS D) := by
   funext σ
   apply Set.ext; intro ⟨j, w⟩
   simp only [ICDRTUpdate.toUpdate, lift, fiberDRS, Set.mem_setOf_eq]
@@ -576,7 +447,7 @@ theorem toUpdate_eq_lift_fiberDRS (D : ICDRTUpdate W E) :
     exact ⟨i, hiw, hD⟩
 
 /-- `fiberDRS` preserves sequential composition. -/
-theorem fiberDRS_seq (D₁ D₂ : ICDRTUpdate W E) :
+theorem fiberDRS_seq :
     fiberDRS (ICDRTUpdate.seq D₁ D₂) = dseq (fiberDRS D₁) (fiberDRS D₂) := by
   funext p q; cases p; cases q
   simp only [fiberDRS, ICDRTUpdate.seq, dseq, Relation.Comp, eq_iff_iff]
@@ -593,22 +464,11 @@ theorem fiberDRS_idUp :
   simp only [fiberDRS, ICDRTUpdate.idUp, eq_iff_iff, Prod.mk.injEq]
   exact ⟨λ ⟨h1, h2⟩ => ⟨h2, h1⟩, λ ⟨h1, h2⟩ => ⟨h2, h1⟩⟩
 
-/-- `fiberDRS` is a monoid homomorphism `(ICDRTUpdate, seq, idUp) → (Update, dseq, id)`. -/
-theorem fiberDRS_homomorphism :
-    (∀ (D₁ D₂ : ICDRTUpdate W E),
-      fiberDRS (ICDRTUpdate.seq D₁ D₂) = dseq (fiberDRS D₁) (fiberDRS D₂)) ∧
-    fiberDRS (ICDRTUpdate.idUp : ICDRTUpdate W E) = λ p q => p = q :=
-  ⟨fiberDRS_seq, fiberDRS_idUp⟩
-
-
--- ════════════════════════════════════════════════════════════════
--- § 11. Distributivity, Test Eliminativity, and Round-Trip
--- ════════════════════════════════════════════════════════════════
+/-! ### Distributivity and test eliminativity -/
 
 /-- `toUpdate D` is always distributive: it processes each
 assignment-world pair independently. Corollary of `lift_isDistributive`. -/
-theorem toUpdate_isDistributive (D : ICDRTUpdate W E) :
-    IsDistributive (D.toUpdate) := by
+theorem toUpdate_isDistributive : IsDistributive (D.toUpdate) := by
   rw [toUpdate_eq_lift_fiberDRS]
   exact lift_isDistributive (fiberDRS D)
 
@@ -620,49 +480,7 @@ theorem toUpdate_test_eliminative (C : ICDRTAssignment W E → Prop) :
   obtain ⟨_, hiw, rfl, _⟩ := hjw
   exact hiw
 
-/-- The DEC condition lifts to an eliminative CCP: assertion narrows the
-context (removes worlds from the commitment set). -/
-theorem toUpdate_dec_eliminative (φ_DC φ : PVar) :
-    IsEliminative (ICDRTUpdate.toUpdate
-      (λ i j : ICDRTAssignment W E => i = j ∧ decCondition φ_DC φ j)) :=
-  toUpdate_test_eliminative _
-
-/-- ICDRT-style negation via complementation stays distributive — unlike
-test-based dynamic negation that inspects the whole input state. -/
-theorem complement_update_distributive (φ_outer φ_inner : PVar) :
-    IsDistributive (ICDRTUpdate.toUpdate
-      (λ i j : ICDRTAssignment W E =>
-        i = j ∧ isComplement φ_outer φ_inner j)) :=
-  toUpdate_isDistributive _
-
-/-- Round-trip: lowering the CCP back to a relation recovers the fiberwise
-embedding. Combined with `lower_lift`, this shows no information is lost
-in the `fiberDRS`/`lift` factorization. -/
-theorem lower_toUpdate (D : ICDRTUpdate W E) :
-    lower (D.toUpdate) = fiberDRS D := by
-  rw [toUpdate_eq_lift_fiberDRS, lower_lift]
-
-/-- `toUpdate` preserves sequential composition — algebraic derivation via
-`fiberDRS_seq` + `lift_dseq`. -/
-theorem toUpdate_seq_algebraic (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
-    (ICDRTUpdate.seq D₁ D₂).toUpdate c = CCP.seq D₁.toUpdate D₂.toUpdate c := by
-  conv_lhs => rw [toUpdate_eq_lift_fiberDRS, fiberDRS_seq, lift_dseq]
-  conv_rhs => rw [toUpdate_eq_lift_fiberDRS D₁, toUpdate_eq_lift_fiberDRS D₂]
-
-/-- `toUpdate` preserves identity — algebraic derivation via `fiberDRS_idUp`. -/
-theorem toUpdate_id_algebraic (c : IContext W E) :
-    ICDRTUpdate.idUp.toUpdate c = CCP.id c := by
-  rw [toUpdate_eq_lift_fiberDRS, fiberDRS_idUp]
-  apply Set.ext; intro ⟨j, w⟩
-  simp only [lift, CCP.id, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨p, hp, rfl⟩; exact hp
-  · intro hjw; exact ⟨⟨j, w⟩, hjw, rfl⟩
-
-
--- ════════════════════════════════════════════════════════════════
--- § Fibered lookup instance
--- ════════════════════════════════════════════════════════════════
+/-! ### Fibered lookup instance -/
 
 /-- ICDRT contexts expose the shared lookup interface at `M = Entity`
 (`Dynamic/Lookup.lean`), making ICDRT lookups comparable with the

--- a/Linglib/Semantics/Dynamic/ICDRT/Defs.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Defs.lean
@@ -26,8 +26,7 @@ namespace DynamicSemantics
 Entities extended with the universal falsifier ⋆ ([brasoveanu-2006]; adopted
 by [hofmann-2025]): individual drefs map to ⋆ in worlds where the referent
 does not exist — in "There's no bathroom", the bathroom variable maps to ⋆
-in all worlds. Lexical relations are axiomatically false of ⋆
-(`star_falsifies`).
+in all worlds. Lexical relations are axiomatically false of ⋆.
 -/
 inductive Entity (E : Type*) where
   | some : E → Entity E
@@ -38,35 +37,12 @@ namespace Entity
 
 variable {E : Type*}
 
-/-- Lift a predicate to handle ⋆ (false for ⋆) -/
-def liftPred (p : E → Bool) : Entity E → Bool
-  | .some e => p e
-  | .star => false
-
-/-- Lift a binary predicate (false if either is ⋆) -/
-def liftPred₂ (p : E → E → Bool) : Entity E → Entity E → Bool
-  | .some e₁, .some e₂ => p e₁ e₂
-  | _, _ => false
-
 /-- Is this a real entity (not ⋆)? -/
 def isSome : Entity E → Prop
   | .some _ => True
   | .star => False
 
 instance : DecidablePred (@isSome E) := fun e => by unfold isSome; cases e <;> infer_instance
-
-/-- ⋆ is the universal falsifier: any lifted predicate yields false for ⋆ —
-[hofmann-2025]'s axiom that lexical relations are false of ⋆. -/
-@[simp] theorem star_falsifies (p : E → Bool) :
-    Entity.liftPred p (.star : Entity E) = false := rfl
-
-/-- ⋆ falsifies binary predicates from the left. -/
-@[simp] theorem star_falsifies₂_left (p : E → E → Bool) (e : Entity E) :
-    Entity.liftPred₂ p (.star : Entity E) e = false := by cases e <;> rfl
-
-/-- ⋆ falsifies binary predicates from the right. -/
-@[simp] theorem star_falsifies₂_right (p : E → E → Bool) (e : Entity E) :
-    Entity.liftPred₂ p e (.star : Entity E) = false := by cases e <;> rfl
 
 instance [Inhabited E] : Inhabited (Entity E) where
   default := .star
@@ -86,13 +62,6 @@ instance [Fintype E] : Fintype (Entity E) where
   complete := λ x => by cases x <;> simp [Finset.mem_cons]
 
 end Entity
-
-/--
-Variable indices for discourse referents.
-
-We use natural numbers but provide type wrappers for clarity.
--/
-abbrev Var := Nat
 
 /--
 A propositional variable (names a propositional dref).

--- a/Linglib/Semantics/Dynamic/PLA/Basic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Basic.lean
@@ -6,36 +6,28 @@ import Mathlib.Data.List.Basic
 import Mathlib.Data.Fintype.Basic
 
 /-!
-# Predicate Logic with Anaphora (PLA)
-[dekker-1994] [dekker-2012]
+# Predicate Logic with Anaphora: syntax
 
-The foundational system for dynamic semantics with explicit pronoun
-indices, originating in [dekker-1994] and consolidated in [dekker-2012].
+Syntax for Predicate Logic with Anaphora (PLA), the dynamic system originating
+in [dekker-1994] and consolidated in [dekker-2012]. PLA distinguishes variables
+`x_i`, bound by quantifiers, from pronouns `p_i`, anaphoric expressions resolved
+from discourse context; the distinction prevents variable clash and keeps
+composition clean.
 
-## Innovation
+## Main definitions
 
-PLA distinguishes variables (x_i) from pronouns (p_i):
-- Variables are bound by quantifiers (∃x_i)
-- Pronouns are anaphoric expressions resolved from discourse context
+- `PLA.Term`, `PLA.Formula`: terms (variables or pronouns) and formulas
+- `PLA.Formula.domain`: the variables existentially bound in a formula, `n(φ)`
+- `PLA.Formula.range`: the pronouns occurring in a formula, `r(φ)`
+- `PLA.Resolution`, `PLA.Formula.resolve`: replacing pronouns with variables, `φ^ρ`
 
-This distinction prevents variable clash and enables clean compositional semantics.
+## Main results
 
-## Core Definitions ([dekker-2012] Ch. 2)
-
-| Concept | Notation | Description |
-|---------|----------|-------------|
-| Domain | n(φ) | Variables existentially bound in φ |
-| Range | r(φ) | Pronouns occurring in φ |
-| Resolution | φ^ρ | Replace pronouns with variables |
-
-## Implementation Notes
-
-Uses `Finset.biUnion` instead of `List.foldl` for cleaner proofs.
+- `PLA.Formula.resolve_preserves_domain`: resolution preserves the domain
+- `PLA.Formula.resolve_no_pronouns`: resolution eliminates all pronouns
 -/
 
 namespace PLA
-
-open Classical
 
 
 /-- Variable index: identifies a variable x_i -/
@@ -63,16 +55,6 @@ def vars : Term → Finset VarIdx
   | .var i => {i}
   | .pron _ => ∅
 
-/-- Is this a pronoun? -/
-def isPron : Term → Prop
-  | .var _ => False
-  | .pron _ => True
-
-instance : DecidablePred isPron := fun t => by unfold isPron; cases t <;> infer_instance
-
-theorem pronouns_var (i : VarIdx) : (Term.var i).pronouns = ∅ := rfl
-theorem pronouns_pron (i : PronIdx) : (Term.pron i).pronouns = {i} := rfl
-
 end Term
 
 
@@ -83,9 +65,6 @@ def termsPronouns (ts : List Term) : Finset PronIdx :=
 theorem mem_termsPronouns (ts : List Term) (i : PronIdx) :
     i ∈ termsPronouns ts ↔ ∃ t ∈ ts, i ∈ t.pronouns := by
   simp only [termsPronouns, Finset.mem_biUnion, List.mem_toFinset]
-
-theorem termsPronouns_nil : termsPronouns [] = ∅ := by
-  simp [termsPronouns]
 
 
 /-- PLA Formula -/
@@ -106,7 +85,7 @@ def disj (φ ψ : Formula) : Formula := neg (conj (neg φ) (neg ψ))
 infixr:30 " ⋁ " => disj
 
 def impl (φ ψ : Formula) : Formula := neg (conj φ (neg ψ))
-infixr:25 " ⟶ " => impl
+scoped infixr:25 " ⟶ " => impl
 
 def forall_ (i : VarIdx) (φ : Formula) : Formula := neg (exists_ i (neg φ))
 

--- a/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
@@ -2,26 +2,28 @@ import Linglib.Semantics.Dynamic.PLA.Update
 import Linglib.Semantics.Intensional.Rigidity
 
 /-!
-# PLA Epistemic Operators
+# PLA epistemic operators
 
-[dekker-2012] Chapter 4: Quantification and Modality (§4.3: Alethic and Epistemic Modality).
+Epistemic modals for PLA, from [dekker-2012]'s chapter on quantification and
+modality. Unlike assertoric updates, `might` and `must` are tests in the sense
+of [veltman-1996]: `might φ` passes an information state iff `φ` is consistent
+with it, `must φ` iff the state supports `φ`; neither eliminates possibilities.
+For de re vs de dicto distinctions, `PLA.Concept` instantiates
+`Intensional.Intension` at PLA possibilities: a way of identifying entities
+across assignment-witness pairs.
 
-## Key Concepts
+## Main definitions
 
-### Epistemic Modality
-- Might φ: φ is compatible with current information
-- Must φ: φ follows from current information
+- `PLA.Formula.might`, `PLA.Formula.must`: epistemic tests on information
+  states
+- `PLA.Concept`, `PLA.Concept.isRigid`: concepts over PLA possibilities
 
-### The Test Semantics
-Unlike assertoric updates that eliminate possibilities, epistemic modals
-TEST the information state:
-- might φ passes if some (g, ê) satisfies φ
-- must φ passes if all (g, ê) satisfy φ
+## Main results
 
-### Conceptual Covers ([dekker-2012] §3.2/§4.2)
-For de re/de dicto distinctions:
-- A peg is an extensional reference to an entity
-- A concept is an intensional way of identifying entities
+- `PLA.might_iff_consistent`, `PLA.must_iff_supports`: test characterizations
+- `PLA.might_idempotent`, `PLA.must_idempotent`: testing twice is testing once
+- `PLA.might_iff_not_must_neg`: the dynamic version of the modal duality
+  ◇φ ↔ ¬□¬φ
 -/
 
 namespace PLA
@@ -29,8 +31,7 @@ namespace PLA
 open Classical
 open DynamicSemantics.CCP
 
-
-variable {E : Type*} [Nonempty E]
+variable {E : Type*} (M : Model E)
 
 /--
 Might φ: φ is consistent with the information state.
@@ -39,7 +40,7 @@ Might φ: φ is consistent with the information state.
 
 This is a TEST: it doesn't eliminate possibilities, it checks if φ is possible.
 -/
-def Formula.might (M : Model E) (φ : Formula) : Update E :=
+def Formula.might (φ : Formula) : Update E :=
   λ s => if (φ.update M s).Nonempty then s else ∅
 
 /--
@@ -49,14 +50,14 @@ Must φ: φ is supported by the information state.
 
 This is also a TEST: it passes only if φ is certain.
 -/
-def Formula.must (M : Model E) (φ : Formula) : Update E :=
+def Formula.must (φ : Formula) : Update E :=
   λ s => if s ⊫[M] φ then s else ∅
 
 
 /--
 Might as consistency test: might φ passes iff some possibility satisfies φ.
 -/
-theorem might_iff_consistent (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem might_iff_consistent (φ : Formula) (s : InfoState E) :
     φ.might M s = s ↔ (φ.update M s).Nonempty ∨ s = ∅ := by
   simp only [Formula.might]
   constructor
@@ -75,7 +76,7 @@ theorem might_iff_consistent (M : Model E) (φ : Formula) (s : InfoState E) :
 /--
 Must as support test: must φ passes iff the state supports φ.
 -/
-theorem must_iff_supports (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem must_iff_supports (φ : Formula) (s : InfoState E) :
     φ.must M s = s ↔ (s ⊫[M] φ) ∨ s = ∅ := by
   simp only [Formula.must]
   constructor
@@ -93,27 +94,26 @@ theorem must_iff_supports (M : Model E) (φ : Formula) (s : InfoState E) :
 /--
 Testing doesn't change information (when it passes).
 -/
-theorem might_preserves_info (M : Model E) (φ : Formula) (s : InfoState E)
+theorem might_preserves_info (φ : Formula) (s : InfoState E)
     (h : (φ.update M s).Nonempty) :
     φ.might M s = s := by
   simp only [Formula.might, if_pos h]
 
-theorem must_preserves_info (M : Model E) (φ : Formula) (s : InfoState E)
-    (h : s ⊫[M] φ) :
+theorem must_preserves_info (φ : Formula) (s : InfoState E) (h : s ⊫[M] φ) :
     φ.must M s = s := by
   simp only [Formula.must, if_pos h]
 
 /--
 [veltman-1996]: Tests never add possibilities.
 -/
-theorem might_subset (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem might_subset (φ : Formula) (s : InfoState E) :
     φ.might M s ⊆ s := by
   simp only [Formula.might]
   split_ifs
   · exact Set.Subset.rfl
   · exact Set.empty_subset s
 
-theorem must_subset (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem must_subset (φ : Formula) (s : InfoState E) :
     φ.must M s ⊆ s := by
   simp only [Formula.must]
   split_ifs
@@ -124,13 +124,13 @@ theorem must_subset (M : Model E) (φ : Formula) (s : InfoState E) :
 /--
 Asserting then testing: φ; might ψ passes iff φ-update leaves room for ψ.
 -/
-theorem update_then_might (M : Model E) (φ ψ : Formula) (s : InfoState E) :
+theorem update_then_might (φ ψ : Formula) (s : InfoState E) :
     (φ.update M ;; ψ.might M) s = ψ.might M (φ.update M s) := rfl
 
 /--
 Asserting then requiring: φ; must ψ passes iff φ-update supports ψ.
 -/
-theorem update_then_must (M : Model E) (φ ψ : Formula) (s : InfoState E) :
+theorem update_then_must (φ ψ : Formula) (s : InfoState E) :
     (φ.update M ;; ψ.must M) s = ψ.must M (φ.update M s) := rfl
 
 
@@ -139,7 +139,7 @@ Must idempotence: must (must φ) ≡ must φ
 
 Once we've verified certainty, re-checking doesn't change anything.
 -/
-theorem must_idempotent (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem must_idempotent (φ : Formula) (s : InfoState E) :
     φ.must M (φ.must M s) = φ.must M s := by
   simp only [Formula.must]
   by_cases hsup : s ⊫[M] φ
@@ -151,7 +151,7 @@ Might idempotence: might (might φ) ≡ might φ
 
 Testing for consistency twice is the same as testing once.
 -/
-theorem might_idempotent (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem might_idempotent (φ : Formula) (s : InfoState E) :
     φ.might M (φ.might M s) = φ.might M s := by
   simp only [Formula.might]
   by_cases hne : (φ.update M s).Nonempty
@@ -164,7 +164,7 @@ theorem might_idempotent (M : Model E) (φ : Formula) (s : InfoState E) :
 /--
 If s supports φ, then might φ passes.
 -/
-theorem supports_implies_might (M : Model E) (φ : Formula) (s : InfoState E)
+theorem supports_implies_might (φ : Formula) (s : InfoState E)
     (hs : s.Nonempty) (hsup : s ⊫[M] φ) :
     φ.might M s = s := by
   simp only [Formula.might]
@@ -175,14 +175,6 @@ theorem supports_implies_might (M : Model E) (φ : Formula) (s : InfoState E)
     exact ⟨hp, hsup p hp⟩
   simp only [if_pos hne]
 
-/--
-If s supports φ, then must φ passes.
--/
-theorem supports_implies_must (M : Model E) (φ : Formula) (s : InfoState E)
-    (hsup : s ⊫[M] φ) :
-    φ.must M s = s := by
-  simp only [Formula.must, if_pos hsup]
-
 
 /--
 Modal duality: might φ passes iff must ¬φ fails (on nonempty states).
@@ -190,45 +182,18 @@ Modal duality: might φ passes iff must ¬φ fails (on nonempty states).
 `might φ` passes on s ↔ `must ¬φ` fails on s (i.e., s does not support ¬φ).
 This is the dynamic version of the classical duality ◇φ ↔ ¬□¬φ.
 -/
-theorem might_iff_not_must_neg (M : Model E) (φ : Formula) (s : InfoState E)
-    (hs : s.Nonempty) :
+theorem might_iff_not_must_neg (φ : Formula) (s : InfoState E) (hs : s.Nonempty) :
     φ.might M s = s ↔ (∼φ).must M s ≠ s := by
+  rw [ne_eq, might_iff_consistent, must_iff_supports]
+  simp only [Set.nonempty_iff_ne_empty.mp hs, or_false]
   constructor
-  · -- (→) might φ passes → must ¬φ fails
-    intro hmight hmust
-    -- might passed, so φ.update M s is nonempty
-    have hne : (φ.update M s).Nonempty := by
-      simp only [Formula.might] at hmight
-      split_ifs at hmight with h
-      · exact h
-      · exact absurd hmight.symm (Set.nonempty_iff_ne_empty.mp hs)
-    -- must ¬φ passed, so s supports ¬φ
-    have hsup : s ⊫[M] (∼φ) := by
-      simp only [Formula.must] at hmust
-      split_ifs at hmust with h
-      · exact h
-      · exact absurd hmust.symm (Set.nonempty_iff_ne_empty.mp hs)
-    -- Contradiction: some p ∈ s satisfies φ, but all p ∈ s satisfy ¬φ
-    obtain ⟨p, hp⟩ := hne
-    simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp
-    have := hsup p hp.1
-    simp only [Formula.sat] at this
-    exact this hp.2
-  · -- (←) must ¬φ fails → might φ passes
-    intro h
-    -- s does not support ¬φ
-    have hnsup : ¬(s ⊫[M] (∼φ)) := by
-      intro hsup
-      apply h
-      simp only [Formula.must, if_pos hsup]
-    -- So some p ∈ s does not satisfy ¬φ, i.e., satisfies φ
-    simp only [InfoState.supports, Formula.sat, not_forall, Classical.not_not] at hnsup
-    obtain ⟨p, hp, hsat⟩ := hnsup
-    have hne : (φ.update M s).Nonempty := by
-      use p
-      simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq]
-      exact ⟨hp, hsat⟩
-    simp only [Formula.might, if_pos hne]
+  · rintro ⟨⟨g, ê⟩, hp⟩ hsup
+    rw [Formula.mem_update] at hp
+    exact hsup _ hp.1 hp.2
+  · intro h
+    simp only [InfoState.supports, Formula.sat, not_forall, Classical.not_not] at h
+    obtain ⟨p, hp, hsat⟩ := h
+    exact ⟨p, (Formula.mem_update M φ s p.1 p.2).mpr ⟨hp, hsat⟩⟩
 
 
 /--
@@ -260,7 +225,6 @@ Alias for `Intensional.Intension.rigid` at the PLA index.
 -/
 abbrev Concept.const (e : E) : Concept E := Intensional.Intension.rigid e
 
-omit [Nonempty E] in
 theorem const_is_rigid (e : E) : (Concept.const e).isRigid :=
   Intensional.Intension.rigid_isRigid e
 

--- a/Linglib/Semantics/Dynamic/PLA/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Semantics.lean
@@ -3,26 +3,27 @@ import Linglib.Semantics.Dynamic.CDRT
 import Linglib.Semantics.Dynamic.PLA.Translation
 
 /-!
-# PLA Semantics
-[dekker-2012]
+# PLA satisfaction and truth
 
-Satisfaction and truth for Predicate Logic with Anaphora.
+Satisfaction and truth for Predicate Logic with Anaphora [dekker-2012].
+Variables are interpreted by an assignment `g`; pronouns get their values from
+outside the formula through a witness sequence `ê`. Satisfaction `M, g, ê ⊨ φ`
+is relative to both; truth existentially quantifies the witness sequence.
 
-## Key Concepts
+## Main definitions
 
-### Witness Sequences
-Pronouns are interpreted via witness sequences ê = (e₁,..., eₙ).
-Unlike variables (interpreted by assignments), pronouns get their values
-from outside the formula through the witness sequence.
+- `PLA.Assignment`, `PLA.WitnessSeq`, `PLA.Model`, `PLA.Term.eval`
+- `PLA.Formula.sat`, `PLA.Formula.trueIn`: satisfaction and truth
+- `PLA.formulaToDRS`: embedding into Dynamic Ty2 [muskens-1996]
 
-### Satisfaction
-M, g, ê ⊨ φ means formula φ is satisfied in model M relative to:
-- Assignment g (for variables)
-- Witness sequence ê (for pronouns)
+## Main results
 
-### Truth
-M ⊨ φ means φ is true in M: for all assignments g, there exists a witness
-sequence ê such that M, g, ê ⊨ φ.
+- `PLA.Formula.sat_resolve`: resolution correctness (Observation 7 of
+  [dekker-2012])
+- `PLA.obs4_pla_pl_equivalence`: PLA conservatively extends predicate logic
+- `PLA.obs5_relevance`: satisfaction depends only on occurring free variables
+  and pronouns
+- `PLA.formulaToDRS_correct`: the Dynamic Ty2 embedding preserves satisfaction
 -/
 
 namespace PLA
@@ -37,14 +38,19 @@ abbrev Assignment (E : Type*) := VarIdx → E
 /-- A witness sequence maps pronoun indices to entities -/
 abbrev WitnessSeq (E : Type*) := PronIdx → E
 
-/-- Assignment-update notation `g[i ↦ e]` for mathlib's `Function.update`. -/
-notation g "[" i " ↦ " e "]" => Function.update g i e
+/-- Assignment-update notation `g[i ↦ e]` for mathlib's `Function.update`.
+
+Unlike `Semantics/Intensional/Variables.lean`'s `notation:max`, this stays at the
+default precedence: at `max` the trailing `[` would capture the list-literal
+arguments of `Formula.atom`. -/
+scoped notation g "[" i " ↦ " e "]" => Function.update g i e
 
 /-- A model provides predicate interpretations -/
 structure Model (E : Type*) where
   /-- Interpretation: predicate name → argument tuple → truth value -/
   interp : String → List E → Bool
 
+variable {E : Type*}
 
 /--
 Evaluate a term given assignment g and witness sequence ê.
@@ -54,18 +60,42 @@ Evaluate a term given assignment g and witness sequence ê.
 
 Variables and pronouns have different interpretation sources.
 -/
-def Term.eval {E : Type*} (g : Assignment E) (ê : WitnessSeq E) : Term → E
+def Term.eval (g : Assignment E) (ê : WitnessSeq E) : Term → E
   | .var i => g i
   | .pron i => ê i
 
 @[simp]
-theorem Term.eval_var {E : Type*} (g : Assignment E) (ê : WitnessSeq E) (i : VarIdx) :
+theorem Term.eval_var (g : Assignment E) (ê : WitnessSeq E) (i : VarIdx) :
     (Term.var i).eval g ê = g i := rfl
 
 @[simp]
-theorem Term.eval_pron {E : Type*} (g : Assignment E) (ê : WitnessSeq E) (i : PronIdx) :
+theorem Term.eval_pron (g : Assignment E) (ê : WitnessSeq E) (i : PronIdx) :
     (Term.pron i).eval g ê = ê i := rfl
 
+/--
+Term evaluation under resolution: when ê(i) = g(ρ(i)), evaluation is preserved.
+-/
+theorem Term.eval_resolve (g : Assignment E) (ê : WitnessSeq E) (ρ : Resolution)
+    (t : Term) (h : ∀ i, t = .pron i → ê i = g (ρ i)) :
+    t.eval g ê = (t.resolve ρ).eval g ê := by
+  cases t with
+  | var i => rfl
+  | pron i =>
+    simp only [eval, resolve]
+    exact h i rfl
+
+/-- For pronoun-free terms, evaluation doesn't depend on the witness sequence. -/
+theorem Term.eval_witness_irrelevant (t : Term) (ht : t.pronouns = ∅)
+    (g : Assignment E) (ê₁ ê₂ : WitnessSeq E) :
+    t.eval g ê₁ = t.eval g ê₂ := by
+  cases t with
+  | var _ => rfl
+  | pron i => simp [Term.pronouns] at ht
+
+
+section Satisfaction
+
+variable (M : Model E)
 
 /--
 PLA Satisfaction: M, g, ê ⊨ φ
@@ -77,58 +107,41 @@ PLA Satisfaction: M, g, ê ⊨ φ
 - Conjunction: both conjuncts satisfied
 - Existential: witness exists in domain
 -/
-def Formula.sat {E : Type*} [Nonempty E] (M : Model E) (g : Assignment E) (ê : WitnessSeq E) :
-    Formula → Prop
+def Formula.sat (g : Assignment E) (ê : WitnessSeq E) : Formula → Prop
   | .atom name ts => M.interp name (ts.map (Term.eval g ê))
-  | .neg φ => ¬φ.sat M g ê
-  | .conj φ ψ => φ.sat M g ê ∧ ψ.sat M g ê
-  | .exists_ i φ => ∃ e : E, φ.sat M (g[i ↦ e]) ê
+  | .neg φ => ¬φ.sat g ê
+  | .conj φ ψ => φ.sat g ê ∧ ψ.sat g ê
+  | .exists_ i φ => ∃ e : E, φ.sat (g[i ↦ e]) ê
 
 /-- Truth in a model: M ⊨ φ iff for all g, ∃ê such that M, g, ê ⊨ φ -/
-def Formula.trueIn {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) : Prop :=
+def Formula.trueIn (φ : Formula) : Prop :=
   ∀ g : Assignment E, ∃ ê : WitnessSeq E, φ.sat M g ê
 
 
 /-- Double negation elimination -/
-theorem Formula.sat_neg_neg {E : Type*} [Nonempty E] (M : Model E) (g : Assignment E)
-    (ê : WitnessSeq E) (φ : Formula) :
+theorem Formula.sat_neg_neg (g : Assignment E) (ê : WitnessSeq E) (φ : Formula) :
     (∼(∼φ)).sat M g ê ↔ φ.sat M g ê := by
   simp only [Formula.sat]
   exact Classical.not_not
 
 /-- Conjunction elimination (left) -/
-theorem Formula.sat_conj_left {E : Type*} [Nonempty E] (M : Model E) (g : Assignment E)
-    (ê : WitnessSeq E) (φ ψ : Formula) :
+theorem Formula.sat_conj_left (g : Assignment E) (ê : WitnessSeq E) (φ ψ : Formula) :
     (φ ⋀ ψ).sat M g ê → φ.sat M g ê := And.left
 
 /-- Conjunction elimination (right) -/
-theorem Formula.sat_conj_right {E : Type*} [Nonempty E] (M : Model E) (g : Assignment E)
-    (ê : WitnessSeq E) (φ ψ : Formula) :
+theorem Formula.sat_conj_right (g : Assignment E) (ê : WitnessSeq E) (φ ψ : Formula) :
     (φ ⋀ ψ).sat M g ê → ψ.sat M g ê := And.right
 
 /-- Conjunction introduction -/
-theorem Formula.sat_conj_intro {E : Type*} [Nonempty E] (M : Model E) (g : Assignment E)
-    (ê : WitnessSeq E) (φ ψ : Formula) :
+theorem Formula.sat_conj_intro (g : Assignment E) (ê : WitnessSeq E) (φ ψ : Formula) :
     φ.sat M g ê → ψ.sat M g ê → (φ ⋀ ψ).sat M g ê := And.intro
 
 /-- Existential introduction -/
-theorem Formula.sat_exists_intro {E : Type*} [Nonempty E] (M : Model E) (g : Assignment E)
-    (ê : WitnessSeq E) (i : VarIdx) (φ : Formula) (e : E) :
+theorem Formula.sat_exists_intro (g : Assignment E) (ê : WitnessSeq E) (i : VarIdx)
+    (φ : Formula) (e : E) :
     φ.sat M (g[i ↦ e]) ê → (Formula.exists_ i φ).sat M g ê :=
   λ h => ⟨e, h⟩
 
-
-/--
-Term evaluation under resolution: when ê(i) = g(ρ(i)), evaluation is preserved.
--/
-theorem Term.eval_resolve {E : Type*} (g : Assignment E) (ê : WitnessSeq E) (ρ : Resolution)
-    (t : Term) (h : ∀ i, t = .pron i → ê i = g (ρ i)) :
-    t.eval g ê = (t.resolve ρ).eval g ê := by
-  cases t with
-  | var i => rfl
-  | pron i =>
-    simp only [eval, resolve]
-    exact h i rfl
 
 /--
 Resolution Correctness ([dekker-2012] Observation 7, §2.2, p.30).
@@ -138,8 +151,7 @@ and no pronoun resolves to a bound variable, then satisfaction is preserved:
 
   M, g, ê ⊨ φ ↔ M, g, ê ⊨ φ^ρ
 -/
-theorem Formula.sat_resolve {E : Type*} [Nonempty E]
-    (M : Model E) (g : Assignment E) (ê : WitnessSeq E) (ρ : Resolution)
+theorem Formula.sat_resolve (g : Assignment E) (ê : WitnessSeq E) (ρ : Resolution)
     (φ : Formula)
     (hcompat : ∀ i ∈ φ.range, ê i = g (ρ i))
     (hnoCapture : ∀ i ∈ φ.range, ρ i ∉ φ.domain) :
@@ -214,22 +226,12 @@ example : (exManWalkedIn.resolve exResolution).range = ∅ :=
 end Examples
 
 
-/-- For pronoun-free terms, evaluation doesn't depend on the witness sequence. -/
-theorem Term.eval_witness_irrelevant {E : Type*} (t : Term) (ht : t.pronouns = ∅)
-    (g : Assignment E) (ê₁ ê₂ : WitnessSeq E) :
-    t.eval g ê₁ = t.eval g ê₂ := by
-  cases t with
-  | var _ => rfl
-  | pron i => simp [Term.pronouns] at ht
-
-
 /-- Observation 4 ([dekker-2012] §2.2, p.25): PLA and PL equivalence.
 
 For pronoun-free formulas, satisfaction is independent of the witness sequence.
 This shows PLA conservatively extends PL: standard predicate logic formulas have
 the same truth conditions in PLA as in PL. -/
-theorem obs4_pla_pl_equivalence {E : Type*} [Nonempty E] (M : Model E)
-    (φ : Formula) (hfree : φ.range = ∅)
+theorem obs4_pla_pl_equivalence (φ : Formula) (hfree : φ.range = ∅)
     (g : Assignment E) (ê₁ ê₂ : WitnessSeq E) :
     φ.sat M g ê₁ ↔ φ.sat M g ê₂ := by
   induction φ generalizing g with
@@ -273,8 +275,7 @@ Satisfaction depends only on the values of free variables and pronouns
 that actually occur in the formula. Assignments that agree on freeVars
 and witness sequences that agree on range yield the same satisfaction.
 -/
-theorem obs5_relevance {E : Type*} [Nonempty E] (M : Model E)
-    (φ : Formula) (g₁ g₂ : Assignment E) (ê₁ ê₂ : WitnessSeq E)
+theorem obs5_relevance (φ : Formula) (g₁ g₂ : Assignment E) (ê₁ ê₂ : WitnessSeq E)
     (hg : ∀ x ∈ φ.freeVars, g₁ x = g₂ x)
     (hê : ∀ i ∈ φ.range, ê₁ i = ê₂ i) :
     φ.sat M g₁ ê₁ ↔ φ.sat M g₂ ê₂ := by
@@ -325,14 +326,14 @@ theorem obs5_relevance {E : Type*} [Nonempty E] (M : Model E)
     · intro i hi
       exact hê i hi
 
+end Satisfaction
 
--- ════════════════════════════════════════════════════════════════
--- § Embedding into Dynamic Ty2 [muskens-1996]
--- ════════════════════════════════════════════════════════════════
 
-/-! PLA distinguishes variables (`VarIdx`) from pronouns (`PronIdx`);
-Dynamic Ty2 has a single dref type `S → E`. The embedding uses the
-sum type `(VarIdx ⊕ PronIdx) → E` as the `S` parameter, providing
+/-! ### Embedding into Dynamic Ty2
+
+PLA distinguishes variables (`VarIdx`) from pronouns (`PronIdx`);
+Dynamic Ty2 ([muskens-1996]) has a single dref type `S → E`. The embedding
+uses the sum type `(VarIdx ⊕ PronIdx) → E` as the `S` parameter, providing
 type-safe separation without magic numbers. Because PLA updates are
 eliminative (filter, never extend), every PLA formula translates to
 a `test` in Dynamic Ty2. -/
@@ -342,33 +343,33 @@ a `test` in Dynamic Ty2. -/
 abbrev MergedAssignment (E : Type*) := (VarIdx ⊕ PronIdx) → E
 
 /-- Variable dref: projection at `.inl i`. -/
-def varDref {E : Type*} (i : VarIdx) : Dref (MergedAssignment E) E :=
+def varDref (i : VarIdx) : Dref (MergedAssignment E) E :=
   λ g => g (.inl i)
 
 /-- Pronoun dref: projection at `.inr i`. -/
-def pronDref {E : Type*} (i : PronIdx) : Dref (MergedAssignment E) E :=
+def pronDref (i : PronIdx) : Dref (MergedAssignment E) E :=
   λ g => g (.inr i)
 
 /-- Interpret a PLA term as a Dynamic Ty2 dref. -/
-def termToDref {E : Type*} : Term → Dref (MergedAssignment E) E
+def termToDref : Term → Dref (MergedAssignment E) E
   | .var i => varDref i
   | .pron i => pronDref i
 
 /-- Convert `PLAPoss` to merged assignment. -/
-def plaPossToMerged {E : Type*} (p : PLAPoss E) : MergedAssignment E
+def plaPossToMerged (p : PLAPoss E) : MergedAssignment E
   | .inl i => p.assignment i
   | .inr i => p.witnesses i
 
 /-- Convert merged assignment to `PLAPoss`. -/
-def mergedToPLAPoss {E : Type*} (g : MergedAssignment E) : PLAPoss E :=
+def mergedToPLAPoss (g : MergedAssignment E) : PLAPoss E :=
   { assignment := λ i => g (.inl i)
   , witnesses := λ i => g (.inr i) }
 
-theorem plaPoss_roundtrip {E : Type*} (p : PLAPoss E) :
+theorem plaPoss_roundtrip (p : PLAPoss E) :
     mergedToPLAPoss (plaPossToMerged p) = p := by
   simp only [mergedToPLAPoss, plaPossToMerged]
 
-theorem merged_roundtrip {E : Type*} (g : MergedAssignment E) :
+theorem merged_roundtrip (g : MergedAssignment E) :
     plaPossToMerged (mergedToPLAPoss g) = g := by
   funext x
   cases x <;> rfl
@@ -376,7 +377,7 @@ theorem merged_roundtrip {E : Type*} (g : MergedAssignment E) :
 
 section Embedding
 
-variable {E : Type*} [Nonempty E]
+variable (M : Model E)
 
 /-- Functional update for merged assignments (only affects variables). -/
 def extend (g : MergedAssignment E) (i : VarIdx) (e : E) : MergedAssignment E :=
@@ -388,36 +389,6 @@ def extend (g : MergedAssignment E) (i : VarIdx) (e : E) : MergedAssignment E :=
 def evalTerm (g : MergedAssignment E) : Term → E
   | .var i => g (.inl i)
   | .pron i => g (.inr i)
-
-/-- Translate a PLA formula to a Dynamic Ty2 condition.
-
-PLA existentials check for *existence* of a witness but don't extend the
-assignment (eliminative semantics). -/
-def formulaToCondition (M : Model E) : Formula → Condition (MergedAssignment E)
-  | .atom name ts => λ g => M.interp name (ts.map (evalTerm g))
-  | .neg φ => λ g => ¬(formulaToCondition M φ g)
-  | .conj φ ψ => λ g => formulaToCondition M φ g ∧ formulaToCondition M ψ g
-  | .exists_ x φ => λ g => ∃ e : E, formulaToCondition M φ (extend g x e)
-
-/-- Translate a PLA formula to a Dynamic Ty2 Update. PLA's eliminative
-updates mean every formula translates to a `test`. -/
-def formulaToDRS (M : Model E) (φ : Formula) : Update (MergedAssignment E) :=
-  test (formulaToCondition M φ)
-
-theorem formulaToDRS_atom (M : Model E) (name : String) (ts : List Term) :
-    formulaToDRS M (.atom name ts) =
-      test (λ g => M.interp name (ts.map (evalTerm g))) := rfl
-
-theorem formulaToDRS_neg (M : Model E) (φ : Formula) :
-    formulaToDRS M (∼φ) = test (λ g => ¬formulaToCondition M φ g) := rfl
-
-theorem formulaToDRS_conj (M : Model E) (φ ψ : Formula) :
-    formulaToDRS M (φ ⋀ ψ) =
-      test (λ g => formulaToCondition M φ g ∧ formulaToCondition M ψ g) := rfl
-
-theorem formulaToDRS_exists (M : Model E) (x : VarIdx) (φ : Formula) :
-    formulaToDRS M (.exists_ x φ) =
-      test (λ g => ∃ e : E, formulaToCondition M φ (extend g x e)) := rfl
 
 /-- Split a merged assignment into variable and witness components. -/
 def splitAssignment (g : MergedAssignment E) : Assignment E × WitnessSeq E :=
@@ -439,7 +410,37 @@ theorem extend_snd_eq (g : MergedAssignment E) (x : VarIdx) (e : E) :
   ext n
   simp only [splitAssignment, extend]
 
-theorem formulaToCondition_eq_sat (M : Model E) (φ : Formula) (g : MergedAssignment E) :
+/-- Translate a PLA formula to a Dynamic Ty2 condition.
+
+PLA existentials check for *existence* of a witness but don't extend the
+assignment (eliminative semantics). -/
+def formulaToCondition : Formula → Condition (MergedAssignment E)
+  | .atom name ts => λ g => M.interp name (ts.map (evalTerm g))
+  | .neg φ => λ g => ¬(formulaToCondition φ g)
+  | .conj φ ψ => λ g => formulaToCondition φ g ∧ formulaToCondition ψ g
+  | .exists_ x φ => λ g => ∃ e : E, formulaToCondition φ (extend g x e)
+
+/-- Translate a PLA formula to a Dynamic Ty2 Update. PLA's eliminative
+updates mean every formula translates to a `test`. -/
+def formulaToDRS (φ : Formula) : Update (MergedAssignment E) :=
+  test (formulaToCondition M φ)
+
+theorem formulaToDRS_atom (name : String) (ts : List Term) :
+    formulaToDRS M (.atom name ts) =
+      test (λ g => M.interp name (ts.map (evalTerm g))) := rfl
+
+theorem formulaToDRS_neg (φ : Formula) :
+    formulaToDRS M (∼φ) = test (λ g => ¬formulaToCondition M φ g) := rfl
+
+theorem formulaToDRS_conj (φ ψ : Formula) :
+    formulaToDRS M (φ ⋀ ψ) =
+      test (λ g => formulaToCondition M φ g ∧ formulaToCondition M ψ g) := rfl
+
+theorem formulaToDRS_exists (x : VarIdx) (φ : Formula) :
+    formulaToDRS M (.exists_ x φ) =
+      test (λ g => ∃ e : E, formulaToCondition M φ (extend g x e)) := rfl
+
+theorem formulaToCondition_eq_sat (φ : Formula) (g : MergedAssignment E) :
     formulaToCondition M φ g ↔ φ.sat M (splitAssignment g).1 (splitAssignment g).2 := by
   induction φ generalizing g with
   | atom name ts =>
@@ -471,7 +472,7 @@ theorem formulaToCondition_eq_sat (M : Model E) (φ : Formula) (g : MergedAssign
 
 /-- A merged assignment satisfies the embedded Update iff the split
 assignment satisfies the original PLA formula. -/
-theorem formulaToDRS_correct (M : Model E) (φ : Formula) (g h : MergedAssignment E) :
+theorem formulaToDRS_correct (φ : Formula) (g h : MergedAssignment E) :
     formulaToDRS M φ g h ↔ (g = h ∧ φ.sat M (splitAssignment g).1 (splitAssignment g).2) := by
   simp only [formulaToDRS, test]
   constructor

--- a/Linglib/Semantics/Dynamic/PLA/Update.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Update.lean
@@ -2,32 +2,42 @@ import Linglib.Semantics.Dynamic.PLA.Semantics
 import Linglib.Semantics.Dynamic.ContextChange
 
 /-!
-# PLA Dynamic Update Semantics
+# PLA dynamic update semantics
 
-[dekker-2012] Chapter 3: Information Update and Support.
+Information update and support for PLA, after [dekker-2012]: three equivalent
+perspectives on dynamic meaning — *contents* (sets of assignment-witness
+pairs), *updates* (context change potentials over PLA possibilities,
+instantiating `DynamicSemantics.CCP`), and *support* (a state supports a
+formula when the formula holds throughout it).
 
-## Three Equivalent Views
+## Main definitions
 
-[dekker-2012] shows three equivalent perspectives on dynamic meaning:
+- `PLA.InfoState`, `PLA.Formula.content`, `PLA.Formula.update`,
+  `PLA.InfoState.supports`
+- `PLA.Formula.dynConj`: sequential update
+- `PLA.dynamicEntails`: dynamic entailment, scoped notation `φ ⊨[M]_dyn ψ`
 
-1. Contents: sets of world-assignment pairs (what information is conveyed)
-2. Updates: functions from input states to output states (how information changes)
-3. Support: when a state supports a formula (evidential perspective)
+## Main results
 
-## Key Results
-
-- Observation 16 (Proper Update): contents-to-updates equivalence
-- Observation 17 (Proper Support): updates-to-support equivalence
-- Dynamic conjunction: non-commutative, non-idempotent
+- `PLA.contents_updates_equiv` (Observation 16): update is intersection with
+  content
+- `PLA.updates_support_equiv` (Observation 17): support means update is the
+  identity
+- `PLA.update_eliminative`: updates only filter the input state; consequently
+  dynamic conjunction here is commutative and static-reducible
+  (`PLA.dynConj_static`) — [dekker-2012]'s non-commutativity claims concern
+  witness-sequence dynamics this formalization does not render
+- `PLA.obs10_dynamic_eq_classical_entailment`: dynamic entailment is
+  conservative over classical entailment
 -/
 
 namespace PLA
 
--- We use DynamicSemantics.CCP infrastructure directly via qualified names
-
 open Classical
 open DynamicSemantics.CCP
+open scoped Formula
 
+variable {E : Type*}
 
 /--
 An information state is a set of (assignment, witness) pairs.
@@ -41,8 +51,6 @@ abbrev InfoState (E : Type*) := Set (Assignment E × WitnessSeq E)
 
 namespace InfoState
 
-variable {E : Type*}
-
 /-- The trivial state: all possibilities -/
 def univ : InfoState E := Set.univ
 
@@ -53,37 +61,10 @@ def empty : InfoState E := ∅
 def consistent (s : InfoState E) : Prop := s.Nonempty
 
 /-- Restrict state to pairs where formula is satisfied -/
-def restrict [Nonempty E] (s : InfoState E) (M : Model E) (φ : Formula) : InfoState E :=
+def restrict (s : InfoState E) (M : Model E) (φ : Formula) : InfoState E :=
   { p ∈ s | φ.sat M p.1 p.2 }
 
 end InfoState
-
-
-/--
-The content of a formula: set of (g, ê) pairs where φ is satisfied.
-
-⟦φ⟧^M = { (g, ê) | M, g, ê ⊨ φ }
-
-This is the "static" meaning - what information φ conveys.
--/
-def Formula.content {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) : InfoState E :=
-  { p | φ.sat M p.1 p.2 }
-
-theorem Formula.mem_content {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (g : Assignment E) (ê : WitnessSeq E) :
-    (g, ê) ∈ φ.content M ↔ φ.sat M g ê := Iff.rfl
-
-/-- Content of negation is complement -/
-theorem Formula.content_neg {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
-    (∼φ).content M = (φ.content M)ᶜ := by
-  ext ⟨g, ê⟩
-  simp [content, sat]
-
-/-- Content of conjunction is intersection -/
-theorem Formula.content_conj {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formula) :
-    (φ ⋀ ψ).content M = φ.content M ∩ ψ.content M := by
-  ext ⟨g, ê⟩
-  simp [content, sat]
 
 
 /--
@@ -92,24 +73,6 @@ PLA Possibility type: (assignment, witness sequence) pairs.
 This instantiates the generic DynamicSemantics.CCP framework for PLA.
 -/
 abbrev Poss (E : Type*) := Assignment E × WitnessSeq E
-
-/--
-PLA satisfaction relation: possibility satisfies formula.
-
-This bridges PLA to the DynamicSemantics.CCP infrastructure, matching the signature
-`P → φ → Prop` expected by DynamicSemantics.updateFromSat.
--/
-def satisfiesPLA {E : Type*} [Nonempty E] (M : Model E) :
-    Poss E → Formula → Prop :=
-  λ p φ => φ.sat M p.1 p.2
-
-/--
-PLA satisfaction as a predicate on possibilities (curried version).
--/
-def Formula.satPoss {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
-    Poss E → Prop :=
-  λ p => satisfiesPLA M p φ
-
 
 /--
 An update is a Context Change Potential over PLA possibilities.
@@ -123,21 +86,56 @@ abbrev Update (E : Type*) := DynamicSemantics.CCP (Poss E)
 
 namespace Update
 
-variable {E : Type*}
-
 /-- Identity update: leaves state unchanged (from DynamicSemantics.CCP) -/
 abbrev id : Update E := DynamicSemantics.CCP.id
 
 /-- Absurd update: always yields empty state (from DynamicSemantics.CCP) -/
 abbrev absurd : Update E := DynamicSemantics.CCP.absurd
 
--- Sequential composition notation comes from DynamicSemantics.CCP
--- infixl:70 " ;; " => DynamicSemantics.CCP.seq
-
 /-- Absurd before anything yields absurd output (from DynamicSemantics.CCP) -/
-theorem seq_absurd (u : Update E) : DynamicSemantics.CCP.seq u absurd = absurd := DynamicSemantics.CCP.seq_absurd u
+theorem seq_absurd (u : Update E) : DynamicSemantics.CCP.seq u absurd = absurd :=
+  DynamicSemantics.CCP.seq_absurd u
 
 end Update
+
+
+section
+variable (M : Model E)
+
+/--
+The content of a formula: set of (g, ê) pairs where φ is satisfied.
+
+⟦φ⟧^M = { (g, ê) | M, g, ê ⊨ φ }
+
+This is the "static" meaning - what information φ conveys.
+-/
+def Formula.content (φ : Formula) : InfoState E :=
+  { p | φ.sat M p.1 p.2 }
+
+theorem Formula.mem_content (φ : Formula) (g : Assignment E) (ê : WitnessSeq E) :
+    (g, ê) ∈ φ.content M ↔ φ.sat M g ê := Iff.rfl
+
+/-- Content of negation is complement -/
+theorem Formula.content_neg (φ : Formula) :
+    (∼φ).content M = (φ.content M)ᶜ := by
+  ext ⟨g, ê⟩
+  simp [content, sat]
+
+/-- Content of conjunction is intersection -/
+theorem Formula.content_conj (φ ψ : Formula) :
+    (φ ⋀ ψ).content M = φ.content M ∩ ψ.content M := by
+  ext ⟨g, ê⟩
+  simp [content, sat]
+
+
+/--
+PLA satisfaction relation: possibility satisfies formula.
+
+This bridges PLA to the DynamicSemantics.CCP infrastructure, matching the signature
+`P → φ → Prop` expected by DynamicSemantics.updateFromSat.
+-/
+def satisfiesPLA : Poss E → Formula → Prop :=
+  λ p φ => φ.sat M p.1 p.2
 
 /--
 The update of a formula: filter state to satisfying pairs.
@@ -145,11 +143,11 @@ The update of a formula: filter state to satisfying pairs.
 ⟦φ⟧ : InfoState → InfoState
 ⟦φ⟧(s) = { (g, ê) ∈ s | M, g, ê ⊨ φ }
 -/
-def Formula.update {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) : Update E :=
+def Formula.update (φ : Formula) : Update E :=
   λ s => InfoState.restrict s M φ
 
-theorem Formula.mem_update {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s : InfoState E) (g : Assignment E) (ê : WitnessSeq E) :
+theorem Formula.mem_update (φ : Formula) (s : InfoState E) (g : Assignment E)
+    (ê : WitnessSeq E) :
     (g, ê) ∈ φ.update M s ↔ (g, ê) ∈ s ∧ φ.sat M g ê := by
   simp [update, InfoState.restrict]
 
@@ -163,8 +161,7 @@ The update of φ is intersection with the content of φ:
 
 This shows Contents and Updates are equivalent perspectives.
 -/
-theorem contents_updates_equiv {E : Type*} [Nonempty E]
-    (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem contents_updates_equiv (φ : Formula) (s : InfoState E) :
     φ.update M s = s ∩ φ.content M := by
   ext ⟨g, ê⟩
   simp [Formula.update, Formula.content, InfoState.restrict]
@@ -177,26 +174,29 @@ s ⊨ φ iff ∀(g, ê) ∈ s, M, g, ê ⊨ φ
 
 This is the evidential perspective: the speaker's evidence supports φ.
 -/
-def InfoState.supports {E : Type*} [Nonempty E] (s : InfoState E) (M : Model E)
-    (φ : Formula) : Prop :=
+def InfoState.supports (s : InfoState E) (φ : Formula) : Prop :=
   ∀ p ∈ s, φ.sat M p.1 p.2
 
-notation:50 s " ⊫[" M "] " φ => InfoState.supports s M φ
+end
+
+scoped notation:50 s " ⊫[" M "] " φ => InfoState.supports M s φ
+
+section
+variable (M : Model E)
 
 /-- Empty state supports everything (vacuously) -/
-theorem InfoState.empty_supports {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
+theorem InfoState.empty_supports (φ : Formula) :
     (∅ : InfoState E) ⊫[M] φ := by
   intro p hp
   exact False.elim hp
 
 /-- Support is monotonic: if s ⊆ t and t supports φ, then s supports φ -/
-theorem InfoState.supports_mono {E : Type*} [Nonempty E] (s t : InfoState E) (M : Model E)
-    (φ : Formula) (h : s ⊆ t) (ht : t ⊫[M] φ) :
+theorem InfoState.supports_mono (s t : InfoState E) (φ : Formula) (h : s ⊆ t)
+    (ht : t ⊫[M] φ) :
     s ⊫[M] φ := λ p hp => ht p (h hp)
 
 /-- Support and conjunction -/
-theorem InfoState.supports_conj {E : Type*} [Nonempty E] (s : InfoState E) (M : Model E)
-    (φ ψ : Formula) :
+theorem InfoState.supports_conj (s : InfoState E) (φ ψ : Formula) :
     (s ⊫[M] (φ ⋀ ψ)) ↔ (s ⊫[M] φ) ∧ (s ⊫[M] ψ) := by
   constructor
   · intro h
@@ -216,8 +216,7 @@ A state supports φ iff updating with φ leaves it unchanged:
 
 This shows Updates and Support are equivalent perspectives.
 -/
-theorem updates_support_equiv {E : Type*} [Nonempty E]
-    (M : Model E) (φ : Formula) (s : InfoState E) :
+theorem updates_support_equiv (φ : Formula) (s : InfoState E) :
     (s ⊫[M] φ) ↔ φ.update M s = s := by
   constructor
   · intro h
@@ -234,31 +233,33 @@ theorem updates_support_equiv {E : Type*} [Nonempty E]
 /--
 Dynamic conjunction: sequential update, φ then ψ.
 
-Non-commutative: "A man came. He sat down." ≠ "He sat down. A man came."
-Non-idempotent: ∃x.φ; ∃x.φ ≠ ∃x.φ (may introduce different witnesses).
-(Non-commutativity and non-idempotence are Observation 9, [dekker-2012] §2.2, p.32.)
+In this eliminative formalization both conjuncts act as filters, so dynamic
+conjunction is commutative and reduces to static conjunction
+(`dynConj_static`). [dekker-2012]'s non-commutativity and non-idempotence
+claims (Observation 9, §2.2, p.32) concern the witness-sequence dynamics,
+which this formalization does not render: existentials certify witnesses in
+the membership condition without exporting them to output states.
 -/
-def Formula.dynConj {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formula) : Update E :=
+def Formula.dynConj (φ ψ : Formula) : Update E :=
   φ.update M ;; ψ.update M
 
 /-- Dynamic conjunction update rule -/
-theorem Formula.dynConj_eq {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formula) (s : InfoState E) :
+theorem Formula.dynConj_eq (φ ψ : Formula) (s : InfoState E) :
     (φ.dynConj M ψ) s = ψ.update M (φ.update M s) := rfl
 
 /-- Dynamic conjunction membership -/
-theorem Formula.mem_dynConj {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formula)
-    (s : InfoState E) (g : Assignment E) (ê : WitnessSeq E) :
+theorem Formula.mem_dynConj (φ ψ : Formula) (s : InfoState E) (g : Assignment E)
+    (ê : WitnessSeq E) :
     (g, ê) ∈ (φ.dynConj M ψ) s ↔ (g, ê) ∈ s ∧ φ.sat M g ê ∧ ψ.sat M g ê := by
   simp only [Formula.dynConj, DynamicSemantics.CCP.seq, Formula.mem_update]
   tauto
 
 /--
-For static formulas (no new drefs), dynamic conjunction
-equals static conjunction.
+Dynamic conjunction reduces to static conjunction. [dekker-2012] restricts
+this to dref-free formulas; here updates are eliminative, so it holds
+unconditionally.
 -/
-theorem dynConj_static {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) (s : InfoState E)
-    (_hφ : φ.domain = ∅) (_hψ : ψ.domain = ∅) :
+theorem dynConj_static (φ ψ : Formula) (s : InfoState E) :
     (φ.dynConj M ψ) s = (φ ⋀ ψ).update M s := by
   ext ⟨g, ê⟩
   simp only [Formula.dynConj, DynamicSemantics.CCP.seq, Formula.mem_update, Formula.sat]
@@ -292,31 +293,27 @@ theorem dne_syntactic (φ : Formula) :
 
 
 /-- Updating with a tautology leaves state unchanged -/
-theorem update_taut {E : Type*} [Nonempty E] (M : Model E) (s : InfoState E)
-    (φ : Formula) (htaut : ∀ g ê, φ.sat M g ê) :
+theorem update_taut (s : InfoState E) (φ : Formula) (htaut : ∀ g ê, φ.sat M g ê) :
     φ.update M s = s := by
   ext ⟨g, ê⟩
   simp [Formula.update, InfoState.restrict, htaut]
 
 /-- Updating with a contradiction yields empty state -/
-theorem update_contra {E : Type*} [Nonempty E] (M : Model E) (s : InfoState E)
-    (φ : Formula) (hcontra : ∀ g ê, ¬φ.sat M g ê) :
+theorem update_contra (s : InfoState E) (φ : Formula) (hcontra : ∀ g ê, ¬φ.sat M g ê) :
     φ.update M s = ∅ := by
   ext ⟨g, ê⟩
   simp [Formula.update, InfoState.restrict, hcontra]
 
 /-- Update elimination: if s already supports φ, update is identity -/
-theorem update_elim {E : Type*} [Nonempty E] (M : Model E) (s : InfoState E)
-    (φ : Formula) (h : s ⊫[M] φ) :
+theorem update_elim (s : InfoState E) (φ : Formula) (h : s ⊫[M] φ) :
     φ.update M s = s :=
   (updates_support_equiv M φ s).mp h
 
 
 /--
-PLA formula update equals DynamicSemantics.updateFromSat via satPoss.
+PLA formula update equals DynamicSemantics.updateFromSat via satisfiesPLA.
 -/
-theorem update_eq_updateFromSat {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s : InfoState E) :
+theorem update_eq_updateFromSat (φ : Formula) (s : InfoState E) :
     φ.update M s = DynamicSemantics.updateFromSat (satisfiesPLA M) φ s := rfl
 
 /--
@@ -327,14 +324,13 @@ Every update is a subset of the input state.
 
 This follows from `DynamicSemantics.updateFromSat_eliminative`.
 -/
-theorem update_eliminative {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s : InfoState E) : φ.update M s ⊆ s :=
+theorem update_eliminative (φ : Formula) (s : InfoState E) : φ.update M s ⊆ s :=
   DynamicSemantics.updateFromSat_eliminative (satisfiesPLA M) φ s
 
 /--
 PLA's formula update is eliminative in the Core sense.
 -/
-theorem update_isEliminative {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
+theorem update_isEliminative (φ : Formula) :
     DynamicSemantics.IsEliminative (φ.update M : Update E) :=
   DynamicSemantics.updateFromSat_eliminative (satisfiesPLA M) φ
 
@@ -345,8 +341,8 @@ If s ⊆ t, then φ.update(s) ⊆ φ.update(t).
 
 This follows from `DynamicSemantics.updateFromSat_monotone`.
 -/
-theorem update_monotone {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s t : InfoState E) (h : s ⊆ t) : φ.update M s ⊆ φ.update M t :=
+theorem update_monotone (φ : Formula) (s t : InfoState E) (h : s ⊆ t) :
+    φ.update M s ⊆ φ.update M t :=
   DynamicSemantics.updateFromSat_monotone (satisfiesPLA M) φ h
 
 /--
@@ -354,23 +350,23 @@ Support is downward closed: if t ⊆ s and s supports φ, then t supports φ.
 
 Smaller states have "more information" (fewer possibilities = more certainty).
 -/
-theorem support_downward_closed {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s t : InfoState E) (h : t ⊆ s) (hs : s ⊫[M] φ) : t ⊫[M] φ :=
+theorem support_downward_closed (φ : Formula) (s t : InfoState E) (h : t ⊆ s)
+    (hs : s ⊫[M] φ) : t ⊫[M] φ :=
   λ p hp => hs p (h hp)
 
 /--
 Intersection preserves support: if s and t both support φ, so does s ∩ t.
 -/
-theorem support_inter {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s t : InfoState E) (hs : s ⊫[M] φ) (_ht : t ⊫[M] φ) : (s ∩ t) ⊫[M] φ := by
+theorem support_inter (φ : Formula) (s t : InfoState E) (hs : s ⊫[M] φ)
+    (_ht : t ⊫[M] φ) : (s ∩ t) ⊫[M] φ := by
   intro p hp
   exact hs p hp.1
 
 /--
 Union and support: s ∪ t supports φ iff both s and t support φ.
 -/
-theorem support_union_iff {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s t : InfoState E) : ((s ∪ t) ⊫[M] φ) ↔ (s ⊫[M] φ) ∧ (t ⊫[M] φ) := by
+theorem support_union_iff (φ : Formula) (s t : InfoState E) :
+    ((s ∪ t) ⊫[M] φ) ↔ (s ⊫[M] φ) ∧ (t ⊫[M] φ) := by
   constructor
   · intro h
     exact ⟨λ p hp => h p (Set.mem_union_left t hp),
@@ -383,8 +379,8 @@ theorem support_union_iff {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
 /--
 Update distributes over intersection: φ.update(s ∩ t) = φ.update(s) ∩ φ.update(t)
 -/
-theorem update_inter {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s t : InfoState E) : φ.update M (s ∩ t) = φ.update M s ∩ φ.update M t := by
+theorem update_inter (φ : Formula) (s t : InfoState E) :
+    φ.update M (s ∩ t) = φ.update M s ∩ φ.update M t := by
   ext p
   simp only [Formula.update, InfoState.restrict, Set.mem_inter_iff, Set.mem_setOf_eq]
   tauto
@@ -394,8 +390,7 @@ Sequential composition with intersection: (φ; ψ)(s) ⊆ φ(s) ∩ ψ(s)
 
 Note: this is not equality in general due to the dynamic nature of sequencing.
 -/
-theorem dynConj_subset_inter {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) (s : InfoState E) :
+theorem dynConj_subset_inter (φ ψ : Formula) (s : InfoState E) :
     (φ.dynConj M ψ) s ⊆ φ.update M s ∩ ψ.update M s := by
   intro p hp
   rw [Formula.mem_dynConj] at hp
@@ -404,16 +399,8 @@ theorem dynConj_subset_inter {E : Type*} [Nonempty E] (M : Model E)
   exact ⟨⟨hp.1, hp.2.1⟩, ⟨hp.1, hp.2.2⟩⟩
 
 
-/-- CCP Reducibility: updates = intersection with content. -/
-theorem ccp_reducibility {E : Type*} [Nonempty E] (M : Model E)
-    (φ : Formula) (s : InfoState E) :
-    φ.update M s = s ∩ φ.content M :=
-  contents_updates_equiv M φ s
-
-/-- Sequential composition = nested intersection of contents. -/
-theorem static_seq_is_intersection {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) (s : InfoState E)
-    (_hφ : φ.domain = ∅) (_hψ : ψ.domain = ∅) :
+/-- Sequential composition is nested intersection of contents. -/
+theorem static_seq_is_intersection (φ ψ : Formula) (s : InfoState E) :
     (φ.update M ;; ψ.update M) s = s ∩ φ.content M ∩ ψ.content M := by
   simp only [DynamicSemantics.CCP.seq, contents_updates_equiv, Set.inter_assoc]
 
@@ -438,34 +425,11 @@ theorem domain_empty_iff_no_exists : ∀ φ : Formula, φ.domain = ∅ ↔
   intro φ
   rw [Finset.eq_empty_iff_forall_notMem]
 
-/-- CCP reducibility: for dref-free formulas, φ; ψ = φ ∧ ψ. -/
-theorem ccp_reduces_to_static {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) (s : InfoState E)
-    (hφ : φ.domain = ∅) (hψ : ψ.domain = ∅) :
-    (φ.update M ;; ψ.update M) s = (φ ⋀ ψ).update M s := by
-  have h := dynConj_static M φ ψ s hφ hψ
-  simp only [Formula.dynConj] at h
-  exact h
-
-/-- Updates are eliminative: they only filter, never add. -/
-theorem updates_are_tests {E : Type*} [Nonempty E] (M : Model E)
-    (φ : Formula) (s : InfoState E) :
-    φ.update M s ⊆ s :=
-  update_eliminative M φ s
-
 /-- Same content implies same update. -/
-theorem same_content_same_update {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) (hcontent : φ.content M = ψ.content M) (s : InfoState E) :
+theorem same_content_same_update (φ ψ : Formula) (hcontent : φ.content M = ψ.content M)
+    (s : InfoState E) :
     φ.update M s = ψ.update M s := by
   rw [contents_updates_equiv, contents_updates_equiv, hcontent]
-
-/-- Updates are intersection with content: φ.update s = { p ∈ s | p ∈ φ.content }. -/
-theorem dekker_minimalism {E : Type*} [Nonempty E] (M : Model E) (φ : Formula)
-    (s : InfoState E) :
-    φ.update M s = { p ∈ s | p ∈ φ.content M } := by
-  rw [contents_updates_equiv]
-  ext p
-  simp only [Set.mem_inter_iff, Set.mem_setOf_eq]
 
 
 /--
@@ -474,54 +438,41 @@ yields a state that supports ψ.
 
 This is the fundamental semantic consequence relation for dynamic semantics.
 -/
-def dynamicEntails {E : Type*} [Nonempty E] (M : Model E) (φ ψ : Formula) : Prop :=
+def dynamicEntails (φ ψ : Formula) : Prop :=
   ∀ s : InfoState E, (φ.update M s) ⊫[M] ψ
 
-notation:50 φ " ⊨[" M "]_dyn " ψ => dynamicEntails M φ ψ
+end
+
+scoped notation:50 φ " ⊨[" M "]_dyn " ψ => dynamicEntails M φ ψ
+
+section
+variable (M : Model E)
 
 /--
 Reflexivity of dynamic entailment: φ ⊨_dyn φ.
 
 Updating with φ yields a state that supports φ.
 -/
-theorem dynamicEntails_refl {E : Type*} [Nonempty E] (M : Model E) (φ : Formula) :
+theorem dynamicEntails_refl (φ : Formula) :
     φ ⊨[M]_dyn φ := by
   intro s p hp
   simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp
   exact hp.2
 
 /--
-Chaining dynamic entailment: if φ ⊨_dyn ψ and ψ ⊨_dyn χ, then φ ⊨_dyn χ.
-
-Note: This holds because update is eliminative - if φ entails ψ,
-then updating with φ produces a state that supports ψ, and since
-that state is a subset of the original, it also supports χ if ψ ⊨_dyn χ.
+Transitivity of dynamic entailment; holds because update is eliminative.
 -/
-theorem dynamicEntails_trans {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ χ : Formula) (h1 : φ ⊨[M]_dyn ψ) (h2 : ψ ⊨[M]_dyn χ) :
+theorem dynamicEntails_trans (φ ψ χ : Formula) (h1 : φ ⊨[M]_dyn ψ) (h2 : ψ ⊨[M]_dyn χ) :
     φ ⊨[M]_dyn χ := by
   intro s p hp
-  -- p ∈ φ.update M s, so p ∈ s and φ.sat M p
-  have hp_in_s : p ∈ s := update_eliminative M φ s hp
-  -- φ.update M s supports ψ by h1
-  have hψ : (φ.update M s) ⊫[M] ψ := h1 s
-  -- So ψ.sat M p since p ∈ φ.update M s
-  have hψ_sat : ψ.sat M p.1 p.2 := hψ p hp
-  -- Now consider ψ.update M s
-  -- We need to show χ.sat M p
-  -- ψ.update M s supports χ by h2
-  have hχ : (ψ.update M s) ⊫[M] χ := h2 s
-  -- p ∈ ψ.update M s since p ∈ s and ψ.sat M p
-  have hp_in_ψ : p ∈ ψ.update M s := by
-    rw [Formula.mem_update]
-    exact ⟨hp_in_s, hψ_sat⟩
-  exact hχ p hp_in_ψ
+  exact h2 s p ((Formula.mem_update M ψ s p.1 p.2).mpr
+    ⟨update_eliminative M φ s hp, h1 s p hp⟩)
 
 /--
 Weakening: if s supports φ and φ ⊨_dyn ψ, then φ.update(s) supports ψ.
 -/
-theorem dynamicEntails_weakening {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) (s : InfoState E) (hent : φ ⊨[M]_dyn ψ) :
+theorem dynamicEntails_weakening (φ ψ : Formula) (s : InfoState E)
+    (hent : φ ⊨[M]_dyn ψ) :
     (φ.update M s) ⊫[M] ψ :=
   hent s
 
@@ -534,8 +485,7 @@ Dynamic entailment coincides with classical pointwise entailment:
 
 This shows that PLA's dynamic consequence relation is conservative
 over classical PL consequence. -/
-theorem obs10_dynamic_eq_classical_entailment {E : Type*} [Nonempty E] (M : Model E)
-    (φ ψ : Formula) :
+theorem obs10_dynamic_eq_classical_entailment (φ ψ : Formula) :
     (φ ⊨[M]_dyn ψ) ↔ (∀ (g : Assignment E) (ê : WitnessSeq E), φ.sat M g ê → ψ.sat M g ê) := by
   constructor
   · -- Dynamic → Classical: use s = Set.univ
@@ -555,8 +505,7 @@ Observation 11 ([dekker-2012] §2.3, p.34): Deduction Theorem.
 φ ∧ χ ⊨_dyn ψ  ↔  φ ⊨_dyn χ → ψ
 
 The classical deduction theorem holds in PLA's dynamic system. -/
-theorem obs11_deduction_theorem {E : Type*} [Nonempty E] (M : Model E)
-    (φ χ ψ : Formula) :
+theorem obs11_deduction_theorem (φ χ ψ : Formula) :
     ((φ ⋀ χ) ⊨[M]_dyn ψ) ↔ (φ ⊨[M]_dyn (χ ⟶ ψ)) := by
   constructor
   · -- (→) If φ∧χ ⊨ ψ, then φ ⊨ χ→ψ
@@ -588,24 +537,12 @@ Note the eliminative character these make explicit: updates only filter
 the input state (`update_eliminative`), so an existential's witness values
 figure in the *membership condition*, not in the surviving possibilities. -/
 
-section UpdateAPI
-
-open DynamicSemantics.CCP
-
-variable {E : Type*} [Nonempty E]
-
 /-- Existential update output characterization. -/
-theorem exists_update_characterization (M : Model E) (x : VarIdx) (φ : Formula)
-    (s : InfoState E) :
+theorem exists_update_characterization (x : VarIdx) (φ : Formula) (s : InfoState E) :
     (Formula.exists_ x φ).update M s =
     { p ∈ s | ∃ e : E, φ.sat M (p.1[x ↦ e]) p.2 } := by
   ext p
   simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq, Formula.sat]
-
-/-- Domain passes through negation. -/
-theorem neg_domain (φ : Formula) :
-    (∼φ).domain = φ.domain := by
-  simp only [Formula.domain]
 
 /-- Double negation preserves range. -/
 theorem dne_range_same (φ : Formula) :
@@ -619,37 +556,21 @@ theorem exists_domain_nonempty (x : VarIdx) (φ : Formula) :
   simp only [Formula.domain]
   exact Finset.mem_insert_self x _
 
-/-- Sequential update composition membership. -/
-theorem seq_update_mem (M : Model E) (φ ψ : Formula) (s : InfoState E) (p : Poss E) :
-    p ∈ (φ.update M ;; ψ.update M) s ↔
-    p ∈ s ∧ φ.sat M p.1 p.2 ∧ ψ.sat M p.1 p.2 := by
-  simp only [DynamicSemantics.CCP.seq, Formula.update, InfoState.restrict, Set.mem_setOf_eq]
-  tauto
-
 /-- Sequential update as set comprehension. -/
-theorem seq_update_eq (M : Model E) (φ ψ : Formula) (s : InfoState E) :
+theorem seq_update_eq (φ ψ : Formula) (s : InfoState E) :
     (φ.update M ;; ψ.update M) s =
     { p ∈ s | φ.sat M p.1 p.2 ∧ ψ.sat M p.1 p.2 } := by
-  ext p
-  rw [seq_update_mem]
-  simp only [Set.mem_setOf_eq]
+  ext ⟨g, ê⟩
+  exact Formula.mem_dynConj M φ ψ s g ê
 
-/-- Dref-free formulas have commutative conjunction. -/
-theorem static_conjunction_commutes (M : Model E) (φ ψ : Formula) (s : InfoState E)
-    (_hφ : φ.domain = ∅) (_hψ : ψ.domain = ∅) :
+/-- Sequential update commutes: eliminative updates are filters, so order is
+irrelevant. ([dekker-2012] restricts this to dref-free formulas.) -/
+theorem static_conjunction_commutes (φ ψ : Formula) (s : InfoState E) :
     (φ.update M ;; ψ.update M) s = (ψ.update M ;; φ.update M) s := by
   rw [seq_update_eq, seq_update_eq]
   ext p
   simp only [Set.mem_setOf_eq]
   tauto
-
-/-- Dynamic conjunction equals static for dref-free formulas. -/
-theorem dyn_eq_static_when_no_drefs (M : Model E) (φ ψ : Formula) (s : InfoState E)
-    (_hφ : φ.domain = ∅) (_hψ : ψ.domain = ∅) :
-    (φ.update M ;; ψ.update M) s = (φ ⋀ ψ).update M s := by
-  rw [seq_update_eq]
-  ext p
-  simp only [Set.mem_setOf_eq, Formula.update, InfoState.restrict, Formula.sat]
 
 /-- The existential marks its variable in the domain; conjunction unions
     domains, leaving the second conjunct's domain unaffected. -/
@@ -661,6 +582,6 @@ theorem static_existential_local_scope (x : VarIdx) (φ ψ : Formula) :
     exact Finset.mem_insert_self x _
   · simp only [Formula.domain]
 
-end UpdateAPI
+end
 
 end PLA

--- a/Linglib/Semantics/Dynamic/PPCDRT/Anaphora.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Anaphora.lean
@@ -1,12 +1,12 @@
 import Linglib.Semantics.Dynamic.PPCDRT.Defs
 
 /-!
-# PPCDRT — Anaphoric Relations and Maximize Anaphora
+# PPCDRT — Anaphoric Relations
 [haug-dalrymple-2020] [dotlacil-2013] [murray-2008]
 [langendoen-1978]
 
 The anaphoric-relation conditions on top of the PPCDRT substrate, plus
-the `R_u` set construction and the Maximize Anaphora principle.
+the `R_u` set construction.
 
 Three relations distinguished by [higginbotham-1985], [williams-1991]
 and formalized in [haug-dalrymple-2020]:
@@ -30,29 +30,24 @@ and formalized in [haug-dalrymple-2020]:
 
 The reciprocity-as-cumulativity link asserted by [langendoen-1978]
 shows up as a structural theorem in `Cumulativity.lean`: `groupIdentityCond`
-is the bidirectional-coverage shape that `Plurality.Cumulativity.cumulativeOp`
+is the bidirectional-coverage shape that `Plurality.Cumulativity.Cumulative`
 expresses for plural arguments.
 
-§6 of [haug-dalrymple-2020] adds the **Maximize Anaphora** principle
-(eq 128): when interpreting a discourse referent introduced by a reciprocal
-with antecedent and relation φ, maximize the set `R_u` of pairs in the
-relation, subject to consistency with world knowledge. The substrate-level
-statement is given here; the §6.1/§6.2/§6.3 applications (the SMH contrast,
-the multi-reciprocal pairwise prediction, the Tracy/Matty/Chris case) live
-in `Studies/HaugDalrymple2020.lean`.
+§6 of [haug-dalrymple-2020] builds its Maximize Anaphora principle
+(eq 128) over the set `R_u` of anaphor-antecedent value pairs (eq 127),
+defined here; the §6.1/§6.2/§6.3 applications (the SMH contrast, the
+multi-reciprocal pairwise prediction, the Tracy/Matty/Chris case) live in
+`Studies/HaugDalrymple2020.lean`.
 -/
 
 namespace PPCDRT
 
 open Core
 
-universe u
+variable {E : Type*}
+variable (uAnaph uAnt : Nat) (S : PluralAssign E) (Δ : Set Nat)
 
-variable {E : Type u}
-
--- ════════════════════════════════════════════════════════════════
--- § 1: Binding (=) — [haug-dalrymple-2020] eq 30
--- ════════════════════════════════════════════════════════════════
+/-! ### Binding -/
 
 /-- Binding (`u_anaph = u_ant`): pointwise dref equality across the plural
     state. The two drefs hold the same `Option E` value at every state —
@@ -64,85 +59,43 @@ variable {E : Type u}
     state. Stronger than the *coreference* presupposition (the eq-29 `→`
     abbreviation), which only requires defined-and-equal where both are
     defined. -/
-def bindingCond (uAnaph uAnt : Nat) : PPDRSCond E := λ S _Δ =>
+def bindingCond : PPDRSCond E := λ S _Δ =>
   ∀ s ∈ S, s uAnaph = s uAnt
 
--- ════════════════════════════════════════════════════════════════
--- § 2: Group Identity (∪) — [haug-dalrymple-2020] §2.3
--- ════════════════════════════════════════════════════════════════
-
-/-- One-direction sum-dref coverage: every value `uAnaph` takes across
-    the plural state is also a value `uAnt` takes.
-
-    *Note*: this is NOT [haug-dalrymple-2020] eq 29 (the asymmetric
-    `→`). Paper eq 29 is `λS.λΔ.∀s ∈ S. u_anaph(s,[s]_Δ) = u_ant(s,S)` —
-    an *equation* between two evaluations, not a subset relation. At
-    Δ = ∅ paper eq 29 reduces to pointwise `bindingCond`, not to
-    `coverCond`. The closer paper match is the SUM-dref equality of
-    eq 37 (p. 16), but eq 37 is also bidirectional.
-
-    `coverCond` is a derived auxiliary used solely by the bidirectional
-    bridge `groupIdentityCond_iff_bidir_coverCond` below — it spells
-    out one direction of the value-set equality so consumers can reason
-    about it directly. It is not itself paper-stipulated. -/
-def coverCond (uAnaph uAnt : Nat) : PPDRSCond E := λ S _Δ =>
-  Core.PluralAssign.sumDref S uAnaph ⊆ Core.PluralAssign.sumDref S uAnt
+/-! ### Group identity -/
 
 /-- Group identity (`∪u_anaph = ∪u_ant`): the value-sets of the two
     drefs across the plural state are equal.
 
     [haug-dalrymple-2020] eq 41 stipulates `∂(∪u = ∪𝒜(u))` for *each
-    other* — exactly this symmetric equality on sum-drefs. Bidirectional
-    `coverCond` is an alternative formulation provable via
-    `groupIdentityCond_iff_bidir_coverCond` below. -/
-def groupIdentityCond (uAnaph uAnt : Nat) : PPDRSCond E := λ S _Δ =>
+    other* — exactly this symmetric equality on sum-drefs. -/
+def groupIdentityCond : PPDRSCond E := λ S _Δ =>
   Core.PluralAssign.sumDref S uAnaph = Core.PluralAssign.sumDref S uAnt
 
-/-- Group identity is the bidirectional version of `coverCond`. -/
-theorem groupIdentityCond_iff_bidir_coverCond (uAnaph uAnt : Nat)
-    (S : PluralAssign E) (Δ : Set Nat) :
-    groupIdentityCond uAnaph uAnt S Δ ↔
-    coverCond uAnaph uAnt S Δ ∧ coverCond uAnt uAnaph S Δ := by
-  unfold groupIdentityCond coverCond
-  exact ⟨fun h => ⟨h.le, h.ge⟩, fun ⟨h₁, h₂⟩ => Set.Subset.antisymm h₁ h₂⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 3: Reciprocity (R) — [haug-dalrymple-2020] eq 41
--- ════════════════════════════════════════════════════════════════
+/-! ### Reciprocity -/
 
 /-- Reciprocity (`∂(∪u = ∪u') ∧ ∂(u ≠ u')`): group identity plus
     per-state distinctness. The presupposition wrappers are realized
     semantically when consumers project to `Truth`. -/
-def reciprocityCond (uAnaph uAnt : Nat) : PPDRSCond E := λ S Δ =>
+def reciprocityCond : PPDRSCond E := λ S Δ =>
   groupIdentityCond uAnaph uAnt S Δ ∧
   ∀ s ∈ S, ∀ d_a d_b, s uAnaph = some d_a → s uAnt = some d_b → d_a ≠ d_b
 
--- ════════════════════════════════════════════════════════════════
--- § 4: Underspecified — [haug-dalrymple-2020] §4.2 + [murray-2008]
--- ════════════════════════════════════════════════════════════════
+/-! ### Underspecified reflexive/reciprocal -/
 
 /-- Underspecified reflexive/reciprocal: group identity with no
     distinctness. Permits reflexive, reciprocal, and mixed readings.
     [murray-2008] (Cheyenne), [cable-2014] (German *sich*). -/
-def underspecifiedCond (uAnaph uAnt : Nat) : PPDRSCond E :=
+def underspecifiedCond : PPDRSCond E :=
   groupIdentityCond uAnaph uAnt
 
--- ════════════════════════════════════════════════════════════════
--- § 5: Implication Lattice — derives the cumulativity / underspec / etc.
--- relationships from the substrate definitions
--- ════════════════════════════════════════════════════════════════
+/-! ### Implication lattice -/
 
 /-- Binding implies group identity: pointwise `Option` equality of dref
     values yields equality of value-sets. [haug-dalrymple-2020] fig 1. -/
-theorem binding_implies_groupIdentity (uAnaph uAnt : Nat) (S : PluralAssign E) (Δ : Set Nat)
-    (h : bindingCond uAnaph uAnt S Δ) : groupIdentityCond uAnaph uAnt S Δ := by
-  unfold groupIdentityCond
-  ext d
-  constructor
-  · rintro ⟨g, hgS, hgu⟩
-    exact ⟨g, hgS, by rw [← h g hgS]; exact hgu⟩
-  · rintro ⟨g, hgS, hgu⟩
-    exact ⟨g, hgS, by rw [h g hgS]; exact hgu⟩
+theorem binding_implies_groupIdentity (h : bindingCond uAnaph uAnt S Δ) :
+    groupIdentityCond uAnaph uAnt S Δ :=
+  Set.ext λ _ => exists_congr λ g => and_congr_right λ hgS => by rw [h g hgS]
 
 /-- Reciprocity excludes binding *when there is some state where both
     drefs are defined*: per-state distinctness then contradicts pointwise
@@ -150,8 +103,7 @@ theorem binding_implies_groupIdentity (uAnaph uAnt : Nat) (S : PluralAssign E) (
     both drefs to be undefined at a state, in which case binding (Option
     `none = none`) and reciprocity (vacuous distinctness) trivially
     co-exist. -/
-theorem reciprocity_excludes_binding (uAnaph uAnt : Nat)
-    (S : PluralAssign E) (Δ : Set Nat)
+theorem reciprocity_excludes_binding
     (hdef : ∃ s ∈ S, ∃ d, s uAnaph = some d)
     (h : reciprocityCond uAnaph uAnt S Δ) :
     ¬ bindingCond uAnaph uAnt S Δ := by
@@ -165,57 +117,23 @@ theorem reciprocity_excludes_binding (uAnaph uAnt : Nat)
 
 /-- Reciprocity strengthens underspecified: reciprocity = underspecified
     + per-state distinctness, so reciprocity implies underspecified. -/
-theorem reciprocity_strengthens_underspecified (uAnaph uAnt : Nat)
-    (S : PluralAssign E) (Δ : Set Nat)
+theorem reciprocity_strengthens_underspecified
     (h : reciprocityCond uAnaph uAnt S Δ) :
     underspecifiedCond uAnaph uAnt S Δ := h.1
 
--- ════════════════════════════════════════════════════════════════
--- § 6: R_u ([haug-dalrymple-2020] eq 127)
--- ════════════════════════════════════════════════════════════════
+/-! ### The relation set `R_u` -/
 
 /-- The set of (anaphor-value, antecedent-value) pairs across the plural
     state. [haug-dalrymple-2020] eq 127:
     `R_u = {⟨v(s)(u_anaph), v(s)(u_ant)⟩ : s ∈ S}`. -/
-def R_u (uAnaph uAnt : Nat) (S : PluralAssign E) : Set (E × E) :=
+def R_u : Set (E × E) :=
   { p | ∃ s ∈ S, s uAnaph = some p.1 ∧ s uAnt = some p.2 }
 
 /-- A bigger plural state yields a (weakly) bigger R_u. -/
-theorem R_u_mono (uAnaph uAnt : Nat) {S₁ S₂ : PluralAssign E}
+theorem R_u_mono {S₁ S₂ : PluralAssign E}
     (h : ∀ g, g ∈ S₁ → g ∈ S₂) :
     R_u uAnaph uAnt S₁ ⊆ R_u uAnaph uAnt S₂ := by
   rintro ⟨a, b⟩ ⟨g, hg, hAnaph, hAnt⟩
   exact ⟨g, h g hg, hAnaph, hAnt⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 7: Maximize Anaphora ([haug-dalrymple-2020] eq 128)
--- ════════════════════════════════════════════════════════════════
-
-/-- **Maximize Anaphora** ([haug-dalrymple-2020] eq 128). In
-    interpreting a DRS containing a discourse referent `u` introduced by
-    a reciprocal with antecedent `u'` and relation `φ`, maximize the set
-    `R_u` of pairs standing in `φ`, subject to the constraint that `φ`
-    holds in the local DRS given world knowledge.
-
-    The substrate-level statement: for the chosen plural state `S`, no
-    proper extension of `S` (in the lifted-Set sense on `R_u`) also
-    satisfies `φ`. Per [haug-dalrymple-2020] §6, this is a
-    *generation principle*, not a decidable predicate — concrete examples
-    supply per-instance `decide`-checks.
-
-    Note: the principle replaces the Strongest Meaning Hypothesis of
-    [dalrymple-et-al-1998]; §6.1 of [haug-dalrymple-2020]
-    discusses the empirical contrast (paper eq 132–133). -/
-def maximizeAnaphora (φ : Nat → Nat → PPDRSCond E) (uAnaph uAnt : Nat)
-    (S : PluralAssign E) (Δ : Set Nat) : Prop :=
-  φ uAnaph uAnt S Δ ∧
-  ∀ S', φ uAnaph uAnt S' Δ →
-    R_u uAnaph uAnt S' ⊆ R_u uAnaph uAnt S
-
-/-- Maximize Anaphora implies the chosen state satisfies the relation. -/
-theorem maximizeAnaphora_implies_relation (φ : Nat → Nat → PPDRSCond E)
-    (uAnaph uAnt : Nat) (S : PluralAssign E) (Δ : Set Nat)
-    (h : maximizeAnaphora φ uAnaph uAnt S Δ) :
-    φ uAnaph uAnt S Δ := h.1
 
 end PPCDRT

--- a/Linglib/Semantics/Dynamic/PPCDRT/Cumulativity.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Cumulativity.lean
@@ -9,15 +9,13 @@ import Linglib.Semantics.Plurality.Cumulativity
 cumulativity: in *the women pointed at each other*, every woman points at
 some other woman and every woman is pointed at by some other woman.
 [haug-dalrymple-2020] §1 reaffirms this. The link is structural: the
-PPCDRT condition `groupIdentityCond u_anaph u_ant`
-(`Plurality.Cumulativity` is the bidirectional-coverage version of equality
-on the value-sets `∪u_anaph(S) = ∪u_ant(S)`) collapses to
-`Cumulative (· = ·)` on the Finset of value pairs.
+PPCDRT condition `groupIdentityCond u_anaph u_ant` — equality of the
+value-sets `∪u_anaph(S)` and `∪u_ant(S)` across the plural state —
+collapses to `Cumulative (· = ·)` on the Finsets of values.
 
 The `Plurality/Cumulativity.lean` substrate is `Prop`-valued over
-`Finset × Finset` (with a `Decidable` instance), while PPCDRT is also
-`Prop`-valued over `PluralAssign`. The bridge theorem under
-`[DecidableEq E]` and finiteness assumptions on the value-sets establishes
+`Finset × Finset`, while PPCDRT is `Prop`-valued over `PluralAssign`. The
+bridge theorem, under finiteness assumptions on the value-sets, establishes
 the structural identity that the original `Reference/Reciprocals.lean`
 docstring asserted as prose.
 -/
@@ -27,14 +25,9 @@ namespace PPCDRT
 open Core
 open Semantics.Plurality.Cumulativity
 
--- Note: monomorphic `Type` (universe 0) here — `Plurality.Cumulativity.Cumulative`
--- now lives at `Type*` so this could be lifted; lifted as needed by future
--- consumers.
-variable {E : Type}
+variable {E : Type*}
 
--- ════════════════════════════════════════════════════════════════
--- § 1: Cumulative Operator Reduces to Set Equality on Equality
--- ════════════════════════════════════════════════════════════════
+/-! ### The cumulative operator on equality -/
 
 /-- The cumulative operator `**` of [krifka-1989]/Beck-Sauerland on
     the equality relation reduces to `Finset` equality.
@@ -46,7 +39,7 @@ variable {E : Type}
     ⊆ direction: if `Cumulative (· = ·) x y`, then for every `a ∈ x`
     there is `b ∈ y` with `a = b`, so `a ∈ y`; and symmetrically.
     ⊇ direction: if `x = y`, every element witnesses itself. -/
-theorem cumulative_eq_iff_finset_eq [DecidableEq E] (x y : Finset E) :
+theorem cumulative_eq_iff_finset_eq (x y : Finset E) :
     Cumulative (fun a b : E => a = b) x y ↔ x = y := by
   constructor
   · rintro ⟨hLR, hRL⟩
@@ -64,24 +57,21 @@ theorem cumulative_eq_iff_finset_eq [DecidableEq E] (x y : Finset E) :
     · intro b hby
       exact ⟨b, h ▸ hby, rfl⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 2: Bridge: groupIdentityCond ↔ Cumulative
--- (resolves audit finding: prose claim → theorem)
--- ════════════════════════════════════════════════════════════════
+/-! ### Bridge: `groupIdentityCond` ↔ `Cumulative` -/
 
 /-- Bridge: when the value-sets of the two drefs across the plural state
     are *given* as Finsets matching `sumDref`, group identity holds iff
-    those Finsets are equal — iff `Cumulative (· = ·)` returns `true`.
+    those Finsets are equal — iff `Cumulative (· = ·)` holds.
 
     The hypothesis is stated as `Set` membership on `sumDref` because
     `Set E → Finset E` requires `Set.Finite`, which is downstream of the
-    consumer's choice of value domain. Concrete H&D examples (Phase 4)
-    instantiate this with `[Fintype]` toy domains where the value-sets are
+    consumer's choice of value domain. Concrete H&D examples instantiate
+    this with `[Fintype]` toy domains where the value-sets are
     automatically finite.
 
     This theorem is the formal realisation of [langendoen-1978]'s
     reciprocity-as-cumulativity claim within PPCDRT. -/
-theorem groupIdentityCond_iff_cumulative_eq [DecidableEq E]
+theorem groupIdentityCond_iff_cumulative_eq
     (uAnaph uAnt : Nat) (S : PluralAssign E) (xa xb : Finset E)
     (hxa : ∀ d, d ∈ xa ↔ d ∈ Core.PluralAssign.sumDref S uAnaph)
     (hxb : ∀ d, d ∈ xb ↔ d ∈ Core.PluralAssign.sumDref S uAnt) :

--- a/Linglib/Semantics/Dynamic/PPCDRT/Defs.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Defs.lean
@@ -13,43 +13,14 @@ Partial CDRT [haug-2014] adds *partial* assignments so a discourse
 referent can be introduced without forcing eager pragmatic resolution: the
 unresolved condition `u_anaph → u_ant` is interpreted as a presupposition.
 
-This file defines the **condition** type used by `Anaphora.lean` for the
-`bindingCond` / `groupIdentityCond` / `reciprocityCond` predicates and by
-`Cumulativity.lean` for the bridge to `Plurality.Cumulativity.cumulativeOp`.
-
-## What lives here
-
-```
-PPDRSCond E := PluralAssign E → Set Nat → Prop      -- condition shape
-                                                      (paper eq 27)
-```
-
-A PPDRS condition takes the (output) plural state plus the distribution
-context `Δ` (the set of drefs being distributed over). The Δ argument is
-used by future distribution machinery (`δ_u`, paper eq 14) but not by the
-present binding/group-identity/reciprocity conditions, all of which ignore
-it — see `Anaphora.lean`.
-
-## What does NOT live here (yet)
-
-The full PPCDRT operator set from [haug-dalrymple-2020] eq 25 — the
-Δ-relativized DRS as a 3-place relation `λΔ.λI.λO.…`, the sequencing
-operator `⨟`, the distribution operator `δ_u`, the presupposition wrapper
-`∂`, the `max^u` maximizing operator, the dref-introduction `[u₁ … uₙ]` —
-was prototyped but trimmed because **no current consumer exercises any of
-them**. Per [haug-dalrymple-2020]'s presentation those operators
-*are* the substrate's expressive interest; their absence here is honest
-about the substrate-façade flag from the second-pass audit. They will land
-when:
-
-- A Brasoveanu 2007 / Dotlačil 2013 / Haug 2014 study file consumes them, OR
-- The H&D study file extends to §3.1 intensionality (currently the
-  narrow-vs-wide contrast is at the value-set level, not at the level of
-  `δ_w`-distributed doxastic alternatives).
-
-The `Anaphora.lean` and `Cumulativity.lean` files in this directory only
-need `PPDRSCond` plus the `Core.PluralAssign` primitives (`singularAt`,
-`sumDref`, `singleton`, `restrict`, `defined`, `null`, `ofPred`).
+This file defines the **condition** type `PPDRSCond` used by
+`Anaphora.lean` for the `bindingCond` / `groupIdentityCond` /
+`reciprocityCond` predicates and by `Cumulativity.lean` for the bridge to
+`Plurality.Cumulativity.Cumulative`. A PPDRS condition takes the (output)
+plural state plus the distribution context `Δ` (the set of drefs being
+distributed over); the Δ argument is used by distribution machinery
+(`δ_u`, paper eq 14) but ignored by the present
+binding/group-identity/reciprocity conditions — see `Anaphora.lean`.
 
 ## Anchoring
 
@@ -57,17 +28,13 @@ Framework substrate. PPCDRT originates with [brasoveanu-2007] (PCDRT)
 and [haug-2014] (Partial CDRT); [haug-dalrymple-2020] composes
 them into PPCDRT. Initial linglib consumer:
 `Studies/HaugDalrymple2020.lean`. Mirrors
-`Semantics/Dynamic/Intensional.lean` (ICDRT substrate, also
-single current consumer).
+`Semantics/Dynamic/ICDRT/Defs.lean` (ICDRT substrate, also single
+current consumer).
 -/
 
 namespace PPCDRT
 
 open Core
-
-universe u
-
-variable {E : Type u}
 
 /-- A PPDRS condition: takes the (output) plural state and the
     distribution context `Δ`. [haug-dalrymple-2020] eq 27.
@@ -78,6 +45,6 @@ variable {E : Type u}
     Δ = ∅). It is preserved in the type so consumers that DO need
     distribution (e.g. a future Dotlačil 2013 study file) can plug in
     without changing this signature. -/
-abbrev PPDRSCond (E : Type u) := PluralAssign E → Set Nat → Prop
+abbrev PPDRSCond (E : Type*) := PluralAssign E → Set Nat → Prop
 
 end PPCDRT

--- a/Linglib/Semantics/Dynamic/PartialTransformer.lean
+++ b/Linglib/Semantics/Dynamic/PartialTransformer.lean
@@ -4,7 +4,6 @@ import Linglib.Semantics.Presupposition.Context
 
 /-!
 # Partial Context Change Potentials
-[karttunen-1974] [heim-1983]
 
 Heim's context change potentials are *partial* functions on contexts: the
 domain condition IS the presupposition ([heim-1983]'s "c admits φ",
@@ -30,8 +29,7 @@ dynamic conjunction, conditional, and disjunction
   ([heim-1983] gives CCPs for *not/and/if*; the disjunction clause with
   ¬φ local context follows [beaver-2001])
 - `admits_pseq` — the Karttunen satisfaction law, by construction
-- `admits_ofPartialProp_iff_presupSatisfied` — admittance is
-  `Context.presupSatisfied`
+- `admits_ofPartialProp` — admittance is `Context.presupSatisfied`
 - `admits_pseq_ofPartialProp`, `admits_pcond_ofPartialProp`,
   `admits_pdisj_ofPartialProp` — the filtering connectives, derived
 -/
@@ -59,16 +57,17 @@ def ofCCP (φ : CCP P) : PartialCCP P := λ s => Part.some (φ s)
 @[simp] theorem admits_ofCCP (φ : CCP P) (s : InfoStateOf P) :
     (ofCCP φ).admits s := trivial
 
-/-- The Heimian update of a static partial proposition: defined iff every
-    world of the input satisfies the presupposition, updating by
-    intersecting with the assertion.
+/-- The Heimian update of a static partial proposition: defined iff the
+    context globally satisfies the presupposition
+    (`Context.presupSatisfied`), updating by intersecting with the
+    assertion.
 
     The whole-state domain condition is what separates admittance from
     per-world filtering (`updateFromSat`): a context containing a single
     presupposition-failing world admits nothing, rather than silently
     discarding the world. -/
 def ofPartialProp (p : PartialProp W) : PartialCCP W :=
-  λ s => ⟨∀ w ∈ s, p.presup w, λ _ => { w ∈ s | p.assertion w }⟩
+  λ s => ⟨Context.presupSatisfied s p, λ _ => { w ∈ s | p.assertion w }⟩
 
 @[simp] theorem ofPartialProp_get (p : PartialProp W) (s : InfoStateOf W)
     (h : ((ofPartialProp p) s).Dom) :
@@ -131,17 +130,12 @@ theorem admits_pdisj (φ ψ : PartialCCP P) (s : InfoStateOf P) :
 
 /-! ### The Stalnaker bridge -/
 
-/-- Admittance of an atomic update is global presupposition satisfaction. -/
+/-- Admittance of an atomic update is the static layer's
+    `Context.presupSatisfied`, by construction: the dynamic definedness
+    condition and the satisfaction-theoretic context condition are one
+    notion. -/
 theorem admits_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :
-    (ofPartialProp p).admits s ↔ ∀ w ∈ s, p.presup w :=
-  Iff.rfl
-
-/-- Admittance is the static layer's `Context.presupSatisfied`: the dynamic
-    definedness condition and the satisfaction-theoretic context condition
-    are one notion. -/
-theorem admits_ofPartialProp_iff_presupSatisfied (p : PartialProp W)
-    (c : CommonGround.ContextSet W) :
-    (ofPartialProp p).admits c ↔ Context.presupSatisfied c p :=
+    (ofPartialProp p).admits s ↔ Context.presupSatisfied s p :=
   Iff.rfl
 
 /-! ### Filtering connectives, derived
@@ -155,36 +149,26 @@ composition law of partial updates, not a stipulation. -/
     presupposition pointwise. -/
 theorem admits_pseq_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
     (pseq (ofPartialProp p) (ofPartialProp q)).admits s ↔
-      ∀ w ∈ s, (PartialProp.andFilter p q).presup w := by
-  constructor
-  · rintro ⟨hp, hq⟩ w hw
-    exact ⟨hp w hw, λ ha => hq w ⟨hw, ha⟩⟩
-  · intro h
-    exact ⟨λ w hw => (h w hw).1, λ w hw => (h w hw.1).2 hw.2⟩
+      ∀ w ∈ s, (PartialProp.andFilter p q).presup w :=
+  ⟨λ ⟨hp, hq⟩ _ hw => ⟨hp hw, λ ha => hq ⟨hw, ha⟩⟩,
+   λ h => ⟨λ w hw => (h w hw).1, λ w hw => (h w hw.1).2 hw.2⟩⟩
 
 /-- Dynamic conditional admits `s` iff `s` satisfies `impFilter`'s
     presupposition pointwise. -/
 theorem admits_pcond_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
     (pcond (ofPartialProp p) (ofPartialProp q)).admits s ↔
-      ∀ w ∈ s, (PartialProp.impFilter p q).presup w := by
-  constructor
-  · rintro ⟨hp, hq⟩ w hw
-    exact ⟨hp w hw, λ ha => hq w ⟨hw, ha⟩⟩
-  · intro h
-    exact ⟨λ w hw => (h w hw).1, λ w hw => (h w hw.1).2 hw.2⟩
+      ∀ w ∈ s, (PartialProp.impFilter p q).presup w :=
+  admits_pseq_ofPartialProp p q s
 
 /-- Dynamic disjunction admits `s` iff `s` satisfies `orFilter`'s
     presupposition pointwise: the ¬φ local context is Karttunen's
     negative-antecedent filtering. -/
 theorem admits_pdisj_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
     (pdisj (ofPartialProp p) (ofPartialProp q)).admits s ↔
-      ∀ w ∈ s, (PartialProp.orFilter p q).presup w := by
-  constructor
-  · rintro ⟨hp, hq⟩ w hw
-    exact ⟨hp w hw, λ hna => hq w ⟨hw, λ hc => hna hc.2⟩⟩
-  · intro h
-    exact ⟨λ w hw => (h w hw).1,
-           λ w hw => (h w hw.1).2 (λ ha => hw.2 ⟨hw.1, ha⟩)⟩
+      ∀ w ∈ s, (PartialProp.orFilter p q).presup w :=
+  ⟨λ ⟨hp, hq⟩ _ hw => ⟨hp hw, λ hna => hq ⟨hw, λ hc => hna hc.2⟩⟩,
+   λ h => ⟨λ w hw => (h w hw).1,
+     λ w hw => (h w hw.1).2 (λ ha => hw.2 ⟨hw.1, ha⟩)⟩⟩
 
 /-- Negation projects the atomic presupposition unchanged. -/
 theorem admits_pneg_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :

--- a/Linglib/Semantics/Dynamic/Situation.lean
+++ b/Linglib/Semantics/Dynamic/Situation.lean
@@ -25,26 +25,25 @@ open _root_.Core (Assignment)
 open _root_.Intensional (WorldTimeIndex)
 
 /--
-A situation-variable dynamic context.
+An entry of a situation-variable context: a pair `(g, s)` where
+`g : Nat → WorldTimeIndex W Time` is a Tarski-style assignment of situation
+variables (the shared `Core.Assignment` substrate) and `s` is the current
+evaluation situation. Unlike [mendes-2025]'s assignments, which also carry
+individual and propositional drefs, entries hold only the situation
+component — situation-variable semantics is independent of the
+individual-dref machinery.
+-/
+abbrev SitEntry (W Time : Type*) :=
+  Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time
 
-Each entry is a pair `(g, s)` where `g : Nat → WorldTimeIndex W Time`
-is a Tarski-style assignment of situation variables (using the shared
-`Core.Assignment` substrate) and `s : WorldTimeIndex W Time` is the
-current evaluation situation.
-
-The original Mendes-style formalization bundled this with an
-`ICDRTAssignment W E` for individual and propositional drefs
-(`structure SitAssignment`), but no consumer of `SitContext` actually
-accesses entity drefs — situation-variable semantics is independent of
-the individual-dref machinery. Co-locating with `Core.Assignment`
-keeps the carrier flat and removes the `E` parameter.
+/--
+A situation-variable dynamic context: a set of `SitEntry`s.
 
 Kept as `abbrev` so it inherits `Set α`'s `Membership`,
 `EmptyCollection`, `HasSubset`, `Union`, `Inter`, and `Singleton`
 instances directly.
 -/
-abbrev SitContext (W Time : Type*) :=
-  Set (Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+abbrev SitContext (W Time : Type*) := Set (SitEntry W Time)
 
 /--
 A situation variable (names a situation dref).
@@ -55,6 +54,9 @@ retrieved by `Mood.dynIND` and the `Tense.dynPAST`/`dynPRES`/`dynFUT`
 constraints (see `Semantics/{Tense,Mood}/Dynamic.lean`).
 -/
 abbrev SVar := Nat
+
+variable {W Time : Type*} (proj₁ proj₂ : SitEntry W Time → WorldTimeIndex W Time)
+  (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
 
 /--
 Filter a context by a binary relation between two projections of each entry.
@@ -70,48 +72,25 @@ common specializations are:
 
 Mathlib precedent: `Set.image2` over `Set.image`.
 -/
-def dynRelationOn {W Time : Type*}
-    (proj₁ proj₂ :
-      Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time
-        → WorldTimeIndex W Time)
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
-    (c : SitContext W Time) : SitContext W Time :=
+def dynRelationOn (c : SitContext W Time) : SitContext W Time :=
   { gs ∈ c | R (proj₁ gs) (proj₂ gs) }
 
-theorem dynRelationOn_isEliminative {W Time : Type*}
-    (proj₁ proj₂ :
-      Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time
-        → WorldTimeIndex W Time)
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop) :
-    IsEliminative (P := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
-      (dynRelationOn proj₁ proj₂ R) :=
+theorem dynRelationOn_isEliminative :
+    IsEliminative (P := SitEntry W Time) (dynRelationOn proj₁ proj₂ R) :=
   fun _ _ h => h.1
 
 /-- Idempotence of any `dynRelationOn` filter. -/
-theorem dynRelationOn_idempotent {W Time : Type*}
-    (proj₁ proj₂ :
-      Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time
-        → WorldTimeIndex W Time)
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
-    (c : SitContext W Time) :
+theorem dynRelationOn_idempotent (c : SitContext W Time) :
     dynRelationOn proj₁ proj₂ R (dynRelationOn proj₁ proj₂ R c) =
-      dynRelationOn proj₁ proj₂ R c := by
-  apply Set.ext; intro gs
-  unfold dynRelationOn
-  exact ⟨fun ⟨⟨hc, _⟩, hR⟩ => ⟨hc, hR⟩, fun ⟨hc, hR⟩ => ⟨⟨hc, hR⟩, hR⟩⟩
+      dynRelationOn proj₁ proj₂ R c :=
+  Set.ext fun _ => ⟨fun ⟨⟨hc, _⟩, hR⟩ => ⟨hc, hR⟩, fun ⟨hc, hR⟩ => ⟨⟨hc, hR⟩, hR⟩⟩
 
 /-- Two contradictory `dynRelationOn` filters compose to the empty context. -/
-theorem dynRelationOn_contradictory {W Time : Type*}
-    (proj₁ proj₂ :
-      Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time
-        → WorldTimeIndex W Time)
+theorem dynRelationOn_contradictory
     (R₁ R₂ : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
-    (h : ∀ s₁ s₂, R₁ s₁ s₂ → R₂ s₁ s₂ → False)
-    (c : SitContext W Time) :
-    dynRelationOn proj₁ proj₂ R₁ (dynRelationOn proj₁ proj₂ R₂ c) = ∅ := by
-  apply Set.ext; intro gs
-  unfold dynRelationOn
-  refine ⟨fun ⟨⟨_, hR₂⟩, hR₁⟩ => absurd hR₁ (fun hR₁ => h _ _ hR₁ hR₂), False.elim⟩
+    (h : ∀ s₁ s₂, R₁ s₁ s₂ → R₂ s₁ s₂ → False) (c : SitContext W Time) :
+    dynRelationOn proj₁ proj₂ R₁ (dynRelationOn proj₁ proj₂ R₂ c) = ∅ :=
+  Set.ext fun _ => ⟨fun ⟨⟨_, hR₂⟩, hR₁⟩ => h _ _ hR₁ hR₂, False.elim⟩
 
 /--
 Filter a context by a binary relation on two situation-variable lookups.
@@ -120,53 +99,22 @@ The "two bound variables" specialization of `dynRelationOn`. All temporal
 constraints (`Tense.dynPAST`, `dynPRES`, `dynFUT`) are instances
 of `dynRelation` with the appropriate ordering on `.time`.
 -/
-def dynRelation {W Time : Type*}
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
-    (v₁ v₂ : SVar) (c : SitContext W Time) : SitContext W Time :=
-  { gs ∈ c | R (gs.1 v₁) (gs.1 v₂) }
-
-/-- `dynRelation` is the `dynRelationOn` specialization with both
-projections looking up bound variables. -/
-theorem dynRelation_eq_dynRelationOn {W Time : Type*}
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
-    (v₁ v₂ : SVar) (c : SitContext W Time) :
-    dynRelation R v₁ v₂ c =
-      dynRelationOn (fun gs => gs.1 v₁) (fun gs => gs.1 v₂) R c := rfl
-
-theorem dynRelation_isEliminative {W Time : Type*}
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop) (v₁ v₂ : SVar) :
-    IsEliminative (P := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
-      (dynRelation R v₁ v₂) :=
-  fun _ _ h => h.1
-
-/-- Applying the same relation filter twice is the same as applying it once. -/
-theorem dynRelation_idempotent {W Time : Type*}
-    (R : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
-    (v₁ v₂ : SVar) (c : SitContext W Time) :
-    dynRelation R v₁ v₂ (dynRelation R v₁ v₂ c) = dynRelation R v₁ v₂ c := by
-  apply Set.ext; intro gs
-  unfold dynRelation
-  exact ⟨fun ⟨⟨hc, _⟩, hR⟩ => ⟨hc, hR⟩, fun ⟨hc, hR⟩ => ⟨⟨hc, hR⟩, hR⟩⟩
+def dynRelation (v₁ v₂ : SVar) (c : SitContext W Time) : SitContext W Time :=
+  dynRelationOn (fun gs => gs.1 v₁) (fun gs => gs.1 v₂) R c
 
 /-- Contradictory relation filters compose to the empty context. -/
-theorem dynRelation_contradictory {W Time : Type*}
+theorem dynRelation_contradictory
     (R₁ R₂ : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
     (h : ∀ s₁ s₂, R₁ s₁ s₂ → R₂ s₁ s₂ → False)
     (v₁ v₂ : SVar) (c : SitContext W Time) :
-    dynRelation R₁ v₁ v₂ (dynRelation R₂ v₁ v₂ c) = ∅ := by
-  apply Set.ext; intro gs
-  unfold dynRelation
-  constructor
-  · rintro ⟨⟨_, hR₂⟩, hR₁⟩
-    exact absurd hR₁ (fun hR₁ => h _ _ hR₁ hR₂)
-  · exact False.elim
+    dynRelation R₁ v₁ v₂ (dynRelation R₂ v₁ v₂ c) = ∅ :=
+  dynRelationOn_contradictory _ _ R₁ R₂ h c
 
 /-- Transitive relations chain across three situation variables. -/
-theorem dynRelation_transitive {W Time : Type*}
+theorem dynRelation_transitive
     (R₁ R₂ R₃ : WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
     (hTrans : ∀ a b c, R₁ a b → R₂ b c → R₃ a c)
-    (v₁ v₂ v₃ : SVar) (c : SitContext W Time)
-    (gs : Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+    (v₁ v₂ v₃ : SVar) (c : SitContext W Time) (gs : SitEntry W Time)
     (h : gs ∈ dynRelation R₂ v₂ v₃ (dynRelation R₁ v₁ v₂ c)) :
     R₃ (gs.1 v₁) (gs.1 v₃) :=
   hTrans _ _ _ h.1.2 h.2
@@ -179,14 +127,13 @@ comparison operators (<, =, >) form a complete partition of any context.
 The temporal partition (`PAST ∪ PRES ∪ FUT = c`) is the special case
 where `f = WorldTimeIndex.time`.
 -/
-theorem dynRelation_trichotomy {W Time α : Type*} [LinearOrder α]
-    (f : WorldTimeIndex W Time → α)
-    (v₁ v₂ : SVar) (c : SitContext W Time) :
+theorem dynRelation_trichotomy {α : Type*} [LinearOrder α]
+    (f : WorldTimeIndex W Time → α) (v₁ v₂ : SVar) (c : SitContext W Time) :
     dynRelation (fun s₁ s₂ => f s₁ < f s₂) v₁ v₂ c ∪
     dynRelation (fun s₁ s₂ => f s₁ = f s₂) v₁ v₂ c ∪
     dynRelation (fun s₁ s₂ => f s₁ > f s₂) v₁ v₂ c = c := by
   apply Set.ext; intro gs
-  unfold dynRelation
+  unfold dynRelation dynRelationOn
   constructor
   · rintro ((⟨hc, _⟩ | ⟨hc, _⟩) | ⟨hc, _⟩) <;> exact hc
   · intro hc
@@ -195,11 +142,8 @@ theorem dynRelation_trichotomy {W Time α : Type*} [LinearOrder α]
     · exact Or.inl (Or.inr ⟨hc, h⟩)
     · exact Or.inr ⟨hc, h⟩
 
--- ════════════════════════════════════════════════════════════════
--- § Generative updates: Kleisli composition for the powerset monad
--- ════════════════════════════════════════════════════════════════
+/-! ### Generative updates: Kleisli composition for the powerset monad
 
-/-!
 The eliminative-vs-generative dichotomy from [groenendijk-stokhof-veltman-1996]
 is exactly the `Set.filter` vs `Set.bind` dichotomy of the powerset monad.
 `dynRelationOn`/`dynRelation` cover the eliminative side
@@ -223,8 +167,7 @@ for the powerset monad.
 Unlike `dynRelationOn`/`dynRelation`, this is *not* eliminative
 — it can produce entries that did not appear in the input context.
 -/
-def dynIntroduce {W Time : Type*}
-    (gen : WorldTimeIndex W Time → Set (WorldTimeIndex W Time))
+def dynIntroduce (gen : WorldTimeIndex W Time → Set (WorldTimeIndex W Time))
     (v : SVar) (c : SitContext W Time) : SitContext W Time :=
   { gs' |
     ∃ g s s',
@@ -236,22 +179,20 @@ def dynIntroduce {W Time : Type*}
 /-- After `dynIntroduce gen v`, looking up `v` in the assignment always
 returns the new current situation. This is the structural property that
 makes a same-variable filter (e.g. `dynIND v ∘ dynIntroduce gen v`) vacuous. -/
-theorem dynIntroduce_binds_current {W Time : Type*}
+theorem dynIntroduce_binds_current
     (gen : WorldTimeIndex W Time → Set (WorldTimeIndex W Time))
-    (v : SVar) (c : SitContext W Time)
-    (gs : Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+    (v : SVar) (c : SitContext W Time) (gs : SitEntry W Time)
     (h : gs ∈ dynIntroduce gen v c) :
     gs.1 v = gs.2 := by
   unfold dynIntroduce at h
   obtain ⟨g, _, s', _, _, h_upd, h_eq⟩ := h
-  rw [h_upd, h_eq]; simp only [Function.update_self]
+  rw [h_upd, h_eq, Function.update_self]
 
 /-- Every output entry of `dynIntroduce` has its current situation drawn
 from `gen` applied to some input situation. -/
-theorem dynIntroduce_current_in_gen {W Time : Type*}
+theorem dynIntroduce_current_in_gen
     (gen : WorldTimeIndex W Time → Set (WorldTimeIndex W Time))
-    (v : SVar) (c : SitContext W Time)
-    (gs : Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+    (v : SVar) (c : SitContext W Time) (gs : SitEntry W Time)
     (h : gs ∈ dynIntroduce gen v c) :
     ∃ s, (∃ g, (g, s) ∈ c) ∧ gs.2 ∈ gen s := by
   unfold dynIntroduce at h

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -88,7 +88,7 @@ theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
 /-- Forget the bases: the level-0 relation on possibilities (the world is
 preserved). -/
 def toUpdate (u : Transition W M X Y) :
-    DynProp.Update (Possibility W V M) :=
+    Update (Possibility W V M) :=
   fun p q => p.world = q.world ∧ u.rel p.world p.assignment q.assignment
 
 /-- Forgetting bases sends sequencing to relational composition — the
@@ -98,7 +98,7 @@ collapse in `Category.lean`.) -/
 theorem toUpdate_comp (u : Transition W M X Y) (v : Transition W M Y Z) :
     (u.comp v).toUpdate = u.toUpdate ⨟ v.toUpdate := by
   funext p q
-  simp only [toUpdate, comp, DynProp.dseq, Relation.Comp, eq_iff_iff]
+  simp only [toUpdate, comp, dseq, Relation.Comp, eq_iff_iff]
   constructor
   · rintro ⟨hw, k, huk, hkv⟩
     exact ⟨⟨p.world, k⟩, ⟨rfl, huk⟩, hw, hkv⟩

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -5,82 +5,46 @@ import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.Use
 
 /-!
-# Dynamic Propositions: The Semantic Algebra
+# The relational update algebra
 [heim-1982] [groenendijk-stokhof-1991] [kamp-reyle-1993]
 
-The relational type `Update S = S → S → Prop` and its core operations
-form the semantic algebra shared by all dynamic semantic systems:
-DRT, DPL, File Change Semantics, PLA, CDRT, BUS, and others.
+`Update S = S → S → Prop` and its operations: the semantic algebra that
+DRT, DPL, File Change Semantics, PLA, CDRT, and BUS instantiate.
+[heim-1982]'s file change potentials, [kamp-reyle-1993]'s verification
+clauses (Def. 1.4.4), and [groenendijk-stokhof-1991]'s DPL relations all
+arrive at this structure; [muskens-1996] parametrizes it over the state
+type. The set-transformer face, and the bridge identifying this algebra
+with its distributive fragment, live in `ContextChange.lean`.
 
-## Intellectual Origins
+## Main definitions
 
-Three independent but converging lines of work arrive at essentially
-the same algebraic structure:
+- `Update S`, `Condition S`: relations on states, properties of states.
+- `dseq` (`⨟`), `test`, `dneg`, `dimpl`, `ddisj`, `closure`: the
+  connectives; a `Monoid` under `⨟` (scoped instance).
+- `Update.IsTest`: DPL's tests — updates that never change the state.
+- `valid`, `entails` (`⊨`), `sEntails` (`⊨ₛ`): truth and
+  [groenendijk-stokhof-1991] §3.5's two entailment notions.
 
-- **[heim-1982]**: Sentence meanings are *file change potentials* —
-  functions from files to files. Her principle (A),
-  `SAT(F + φ) = SAT(F) ∩ {a : a SAT φ}`, decomposes update into
-  the operations formalized here as `test` (intersection) and `dseq`
-  (successive file change).
+## Main results
 
-- **[kamp-reyle-1993]**: Update verification clauses (Def 1.4.4)
-  define when an embedding can be extended to satisfy each connective.
-  These clauses correspond exactly to `test`, `dseq`, `dneg`, `dimpl`,
-  and `ddisj`.
+- `Update.IsTest.eq_test_closure`: a test is the test of its own truth
+  conditions — the semantic content of [groenendijk-stokhof-1991]'s
+  Fact 6.
+- `entails_iff_valid_test_dimpl` (the deduction theorem, Fact 11),
+  `sEntails_iff_test_closure_entails` (Fact 12), `sEntails_of_subset`
+  (Fact 10).
 
-- **[groenendijk-stokhof-1991]**: Dynamic Predicate Logic makes
-  the relational type explicit: meanings ARE binary relations on
-  assignments. Their DPL conjunction = relational composition (`dseq`),
-  DPL negation = universal non-existence (`dneg`), etc.
+## Implementation notes
 
-[muskens-1996] unified these by parametrizing over the state
-type `S`, showing all systems embed into this algebra.
-
-## Operations
-
-| Operation | Type | Origin |
-|-----------|------|--------|
-| `Update S` | `S → S → Prop` | G&S 1991, implicit in Heim 1982 |
-| `dseq` | `Update S → Update S → Update S` | relational composition |
-| `test` | `Condition S → Update S` | identity + check |
-| `dneg` | `Update S → Condition S` | universal non-existence |
-| `dimpl` | `Update S → Update S → Condition S` | K&R verification for ⇒ |
-| `ddisj` | `Update S → Update S → Condition S` | K&R verification for ∨ |
-| `closure` | `Update S → Condition S` | existential closure (Heim's truth) |
-
-## Cross-cutting smell: three incompatible DNE solutions
-
-`dneg` (above) gives the standard relational negation `¬D i ⟺ ¬∃k, D i k`,
-which fails double-negation elimination — `dneg (dneg D) ≢ D` because
-positive update information is destroyed when negation collapses to a
-state predicate. Three downstream frameworks repair DNE in mutually
-incompatible ways:
-
-| Framework | DNE mechanism | File |
-|-----------|---------------|------|
-| Bilateral (BUS, [krahmer-muskens-1995], [elliott-sudo-2025]) | Two update channels (positive/negative); negation = swap | `Dynamic/UpdateSemantics/Bilateral.lean`, `Studies/ElliottSudo2025.lean` |
-| ICDRT ([hofmann-2025]) | Propositional drefs + complementation under flat update | `Studies/Hofmann2025.lean` |
-| TTR ([cooper-2023]) | Classical metalanguage reduction; negation is static | `Semantics/TypeTheoretic/` |
-
-These are not mere notational variants. Bilateral DNE is structural
-(swap is involutive by definition); ICDRT DNE is derived (complementation
-of a propositional dref); TTR DNE is inherited (the metalanguage is
-classical so `¬¬p ↔ p` holds at the static layer). Each repair pays
-for itself with different downstream costs — bilateral cannot
-distinguish speaker-vs-hearer commitments; ICDRT requires intensional
-contexts; TTR loses dynamic state-threading at the negation site.
-
-The cross-framework comparisons are formalized at the phenomenon level:
-`Studies/Hofmann2025.lean §7` (bilateral vs ICDRT on
-the bathroom sentence), `Studies/Cooper2023.lean §§ 4-5`
-(CDRT ↔ TTR truth-conditional equivalence + dynamic divergence under
-negation), and `Studies/Dekker2012.lean` (PLA vs BUS
-on the bathroom sentence: eliminative test vs structural swap). New
-dynamic frameworks should declare which DNE strategy they adopt and
-link to one of these comparisons.
+`dneg` fails double-negation elimination: negation collapses positive
+update information to a state predicate. The repairs are
+framework-specific and mutually incompatible — bilateral swap
+(`UpdateSemantics/Bilateral.lean`), propositional drefs (ICDRT,
+`Studies/Hofmann2025.lean`), classical metalanguage (TTR,
+`Studies/Cooper2023.lean`) — and the comparisons live in those studies.
 -/
 
-namespace DynamicSemantics.DynProp
+namespace DynamicSemantics
 
 /-! ### Core types -/
 
@@ -130,10 +94,14 @@ theorem eq_of_test {C : Condition S} {i j : S} (h : test C i j) : i = j :=
   h.1
 
 /-- An update is a *test* when it never changes the state
-([groenendijk-stokhof-1991], Definition 11). -/
-def IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
+([groenendijk-stokhof-1991], Definition 11) — DPL's tests. The CCP-level
+`IsTest` of `ContextChange.lean` (pass-or-`∅`, Veltman's tests) is a
+different notion: `lift` of a relational test is a filter, not a
+pass-or-`∅` test. -/
+def Update.IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
 
-theorem isTest_test (C : Condition S) : IsTest (test C) := fun _ _ h => h.1
+theorem Update.isTest_test (C : Condition S) : Update.IsTest (test C) :=
+  fun _ _ h => h.1
 
 /-- Dynamic conjunction (sequencing): `D₁ ; D₂`.
 
@@ -192,7 +160,7 @@ scoped notation D₁ " ⊨ " D₂ => entails D₁ D₂
 /-- A test is the test of its own closure — the semantic content of
 [groenendijk-stokhof-1991]'s Fact 6: up to contradictions, tests are
 exactly the conditions. -/
-theorem IsTest.eq_test_closure {D : Update S} (h : IsTest D) :
+theorem Update.IsTest.eq_test_closure {D : Update S} (h : Update.IsTest D) :
     D = test (closure D) := by
   funext i j
   simp only [test, closure, eq_iff_iff]
@@ -278,7 +246,7 @@ theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
 test as unit (`dseq_assoc`, `test_dseq`, `dseq_test`). Scoped because
 `Update S` is an abbreviation for `S → S → Prop`: a global instance would
 attach `*`/`1` to the bare function type. Activate with
-`open scoped DynamicSemantics.DynProp`; mathlib's
+`open scoped DynamicSemantics`; mathlib's
 `WriterT (Update S) Id` then gets `Monad`/`LawfulMonad` for free. -/
 scoped instance : Monoid (Update S) where
   mul := dseq
@@ -331,16 +299,5 @@ theorem dseq_closure (D₁ D₂ : Update S) :
     exact ⟨j, h, hD₁, hD₂⟩
 
 end Theorems
-
-end DynamicSemantics.DynProp
-
-namespace DynamicSemantics
-
--- Surface the level-0 algebra: downstream files open `DynamicSemantics`
--- and use these unqualified.
-export DynProp (Update Condition
-  dseq test dneg dimpl ddisj closure
-  valid entails
-  dseq_assoc test_dseq dseq_test dneg_dneg_test closure_closure dseq_closure)
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Basic.lean
@@ -17,7 +17,7 @@ In Update Semantics:
 
 namespace UpdateSemantics
 
-open Classical
+variable {W : Type*}
 
 /--
 Update Semantics state: a set of possible worlds.
@@ -37,7 +37,7 @@ Propositional update: eliminate worlds where φ fails.
 
 ⟦φ⟧(s) = { w ∈ s | φ(w) }
 -/
-def Update.prop {W : Type*} (φ : W → Prop) : Update W :=
+def Update.prop (φ : W → Prop) : Update W :=
   λ s => { w ∈ s | φ w }
 
 /--
@@ -47,7 +47,7 @@ Conjunction: sequential update.
 
 Delegates to `DynamicSemantics.CCP.seq`.
 -/
-def Update.conj {W : Type*} (φ ψ : Update W) : Update W :=
+abbrev Update.conj (φ ψ : Update W) : Update W :=
   DynamicSemantics.CCP.seq φ ψ
 
 /--
@@ -58,7 +58,7 @@ Negation: complement within the input state.
 Delegates to `DynamicSemantics.CCP.neg`. The whole-state consistency test is
 `DynamicSemantics.CCP.negTest`.
 -/
-def Update.neg {W : Type*} (φ : Update W) : Update W :=
+abbrev Update.neg (φ : Update W) : Update W :=
   DynamicSemantics.CCP.neg φ
 
 /--
@@ -68,7 +68,7 @@ Epistemic "might": compatibility test.
 
 Delegates to `DynamicSemantics.CCP.might`.
 -/
-noncomputable def Update.might {W : Type*} (φ : Update W) : Update W :=
+noncomputable abbrev Update.might (φ : Update W) : Update W :=
   DynamicSemantics.CCP.might φ
 
 /--
@@ -78,16 +78,15 @@ Epistemic "must": universal test.
 
 Delegates to `DynamicSemantics.CCP.must`.
 -/
-noncomputable def Update.must {W : Type*} (φ : Update W) : Update W :=
+noncomputable abbrev Update.must (φ : Update W) : Update W :=
   DynamicSemantics.CCP.must φ
 
 /--
 Might is a TEST: it doesn't change the state (if it passes).
 -/
-theorem might_is_test {W : Type*} (φ : Update W) (s : State W)
-    (h : (φ s).Nonempty) :
-    Update.might φ s = s := by
-  simp [Update.might, DynamicSemantics.CCP.might, DynamicSemantics.CCP.guard, h]
+theorem Update.might_eq_self_of_nonempty (φ : Update W) (s : State W)
+    (h : (φ s).Nonempty) : Update.might φ s = s :=
+  DynamicSemantics.CCP.guard_pos h
 
 /--
 Order matters for epistemic might.
@@ -99,33 +98,28 @@ the might test passes on the initial state, then learning eliminates ¬rain worl
 
 Requires `Nontrivial W`: for empty or singleton W, no state has both
 p-worlds and ¬p-worlds, making the second conjunct unsatisfiable. -/
-theorem might_order_matters {W : Type*} [DecidableEq W] [Nontrivial W] :
+theorem might_order_matters [Nontrivial W] :
     ∃ (p : W → Prop) (_ : DecidablePred p) (s : State W),
       Update.conj (Update.prop p) (Update.might (Update.prop fun w => ¬p w)) s = ∅ ∧
       (Update.conj (Update.might (Update.prop fun w => ¬p w)) (Update.prop p) s).Nonempty := by
   obtain ⟨w₁, w₂, hne⟩ := exists_pair_ne W
-  refine ⟨fun w => w = w₁, inferInstance, {w₁, w₂}, ?_, ?_⟩
+  refine ⟨fun w => w = w₁, Classical.decPred _, {w₁, w₂}, ?_, ?_⟩
   · -- "p and might(not p)" fails: after learning p, only w₁ remains, and ¬p w₁ is false
-    simp only [Update.conj, DynamicSemantics.CCP.seq, Update.prop, Update.might, DynamicSemantics.CCP.might,
-      DynamicSemantics.CCP.guard]
-    have h_not_nonempty :
-        ¬({w ∈ {w ∈ ({w₁, w₂} : Set W) | w = w₁} | ¬w = w₁}).Nonempty := by
-      rintro ⟨w, ⟨_, hw_p⟩, hw_np⟩; exact hw_np hw_p
-    simp only [h_not_nonempty, ↓reduceIte]
+    simp only [Update.conj, DynamicSemantics.CCP.seq, DynamicSemantics.CCP.might]
+    refine DynamicSemantics.CCP.guard_neg ?_
+    rintro ⟨w, ⟨_, hw_p⟩, hw_np⟩; exact hw_np hw_p
   · -- "might(not p) and p" succeeds: might test passes on {w₁, w₂}, then p keeps w₁
-    simp only [Update.conj, DynamicSemantics.CCP.seq, Update.prop, Update.might, DynamicSemantics.CCP.might,
-      DynamicSemantics.CCP.guard]
-    have h_nonempty : ({w ∈ ({w₁, w₂} : Set W) | ¬w = w₁}).Nonempty :=
-      ⟨w₂, Or.inr rfl, hne.symm⟩
-    simp only [h_nonempty, ↓reduceIte]
-    exact ⟨w₁, ⟨Or.inl rfl, rfl⟩⟩
+    have h : Update.might (Update.prop fun w => ¬w = w₁) ({w₁, w₂} : State W) = {w₁, w₂} :=
+      DynamicSemantics.CCP.guard_pos ⟨w₂, Or.inr rfl, hne.symm⟩
+    simp only [Update.conj, DynamicSemantics.CCP.seq, h]
+    exact ⟨w₁, Or.inl rfl, rfl⟩
 
 /--
 State s supports φ iff updating with φ doesn't change s.
 
 s ⊨ φ iff ⟦φ⟧(s) = s
 -/
-def supports {W : Type*} (s : State W) (φ : Update W) : Prop :=
+def supports (s : State W) (φ : Update W) : Prop :=
   φ s = s
 
 /--
@@ -133,11 +127,10 @@ State s accepts φ iff updating with φ yields a non-empty state.
 
 s accepts φ iff ⟦φ⟧(s) ≠ ∅
 -/
-def accepts {W : Type*} (s : State W) (φ : Update W) : Prop :=
+def accepts (s : State W) (φ : Update W) : Prop :=
   (φ s).Nonempty
 
-
--- ═══ Three Notions of Validity (§1.2) ═══
+/-! ### Three notions of validity -/
 
 /-- **Validity₁**: updating the minimal state **0** with the premises
     in order yields a state that supports the conclusion.
@@ -147,28 +140,27 @@ def accepts {W : Type*} (s : State W) (φ : Update W) : Prop :=
     [veltman-1996], §1.2. This is the notion Veltman concentrates on:
     it captures the fact that default conclusions depend on exactly what
     information is available. -/
-def valid₁ {W : Type*} (premises : List (Update W)) (conclusion : Update W) : Prop :=
+def valid₁ (premises : List (Update W)) (conclusion : Update W) : Prop :=
   supports (premises.foldl (fun s u => u s) Set.univ) conclusion
 
 /-- **Validity₂**: for *every* state σ, updating with the premises
     in order yields a state that supports the conclusion.
 
     ψ₁,...,ψₙ ⊩₂ φ  iff  ∀σ, σ[ψ₁]⋯[ψₙ] ⊨ φ -/
-def valid₂ {W : Type*} (premises : List (Update W)) (conclusion : Update W) : Prop :=
+def valid₂ (premises : List (Update W)) (conclusion : Update W) : Prop :=
   ∀ σ : State W, supports (premises.foldl (fun s u => u s) σ) conclusion
 
 /-- **Validity₃**: one cannot accept all premises without accepting
     the conclusion. Closest to the classical notion.
 
     ψ₁,...,ψₙ ⊩₃ φ  iff  ∀σ, (σ ⊨ ψ₁ ∧ ... ∧ σ ⊨ ψₙ) → σ ⊨ φ -/
-def valid₃ {W : Type*} (premises : List (Update W)) (conclusion : Update W) : Prop :=
+def valid₃ (premises : List (Update W)) (conclusion : Update W) : Prop :=
   ∀ σ : State W, (∀ p ∈ premises, supports σ p) → supports σ conclusion
 
 /-- Validity₂ implies validity₁: specializing σ = **0**.
 
     [veltman-1996], Proposition 1.3 (one direction, unconditional). -/
-theorem valid₂_imp_valid₁ {W : Type*}
-    (premises : List (Update W)) (conclusion : Update W) :
+theorem valid₂_imp_valid₁ (premises : List (Update W)) (conclusion : Update W) :
     valid₂ premises conclusion → valid₁ premises conclusion :=
   fun h => h Set.univ
 
@@ -176,12 +168,11 @@ theorem valid₂_imp_valid₁ {W : Type*}
 
     [veltman-1996], §1.2: validity₃ is the only notion that is
     both left and right monotonic. -/
-theorem valid₃_monotone {W : Type*}
-    (premises extra : List (Update W)) (conclusion : Update W) :
+theorem valid₃_monotone (premises extra : List (Update W)) (conclusion : Update W) :
     valid₃ premises conclusion → valid₃ (premises ++ extra) conclusion :=
   fun h σ hsup => h σ (fun p hp => hsup p (List.mem_append_left extra hp))
 
--- ═══ Presuppositional Updates (§2.3 of [yagi-2025]) ═══
+/-! ### Presuppositional updates -/
 
 /-- The designated undefined state: update failure.
 
@@ -189,6 +180,7 @@ theorem valid₃_monotone {W : Type*}
     the update yields ∗. We model ∗ as `none` via `Option (State W)`. -/
 abbrev PState (W : Type*) := Option (State W)
 
+open Classical in
 /-- Presuppositional update: update by φ_p is defined only when the
     presupposition p is supported (i.e. `s[p] = s`).
 
@@ -197,7 +189,7 @@ abbrev PState (W : Type*) := Option (State W)
              = s[φ]  otherwise
 
     [heim-1982] [beaver-2001] [veltman-1996] -/
-noncomputable def PUpdate.presup {W : Type*} (p φ : W → Prop) : PState W → PState W
+noncomputable def PUpdate.presup (p φ : W → Prop) : PState W → PState W
   | none => none
   | some s =>
     if Update.prop p s = s then
@@ -210,8 +202,7 @@ noncomputable def PUpdate.presup {W : Type*} (p φ : W → Prop) : PState W → 
     when `s` admits the corresponding partial update. `PartialCCP` is the
     canonical `Part`-based form; this clause survives for the
     [yagi-2025] disjunction machinery below. -/
-theorem PUpdate.presup_ne_none_iff_admits {W : Type*} (p φ : W → Prop)
-    (s : State W) :
+theorem PUpdate.presup_ne_none_iff_admits (p φ : W → Prop) (s : State W) :
     PUpdate.presup p φ (some s) ≠ none ↔
       (DynamicSemantics.PartialCCP.ofPartialProp ⟨p, φ⟩).admits s := by
   simp only [PUpdate.presup]
@@ -226,7 +217,7 @@ theorem PUpdate.presup_ne_none_iff_admits {W : Type*} (p φ : W → Prop)
 /-- Negation extended to PState: s[¬φ] = s/s[φ].
 
     [yagi-2025] Definition 4: s[¬φ] = s \ s[φ]. -/
-noncomputable def PUpdate.neg {W : Type*} (φ : W → Prop) : PState W → PState W
+def PUpdate.neg (φ : W → Prop) : PState W → PState W
   | none => none
   | some s => some (s \ Update.prop φ s)
 
@@ -234,8 +225,7 @@ noncomputable def PUpdate.neg {W : Type*} (φ : W → Prop) : PState W → PStat
 
     [yagi-2025] Definition 4, [heim-1982].
     Extended with ∗ ∪ s = s ∪ ∗ = ∗. -/
-noncomputable def PUpdate.disj {W : Type*} (φ ψ : W → Prop) :
-    PState W → PState W
+def PUpdate.disj (φ ψ : W → Prop) : PState W → PState W
   | none => none
   | some s =>
     let left := Update.prop φ s
@@ -251,7 +241,7 @@ noncomputable def PUpdate.disj {W : Type*} (φ ψ : W → Prop) :
 
     Both presuppositional updates must be defined for the result to be
     defined: s[φ_p] requires s ⊨ p, and s[¬φ_p][ψ_q] requires s[¬φ_p] ⊨ q. -/
-noncomputable def PUpdate.disjPresup {W : Type*} (p φ q ψ : W → Prop) :
+noncomputable def PUpdate.disjPresup (p φ q ψ : W → Prop) :
     PState W → PState W
   | none => none
   | some s =>
@@ -278,8 +268,7 @@ noncomputable def PUpdate.disjPresup {W : Type*} (p φ q ψ : W → Prop) :
     By default χ = ω = ⊤ (both tautological), but when the default
     violates genuineness ([zimmermann-2000]), the split becomes
     non-trivial: χ = ¬q and ω = ¬p for conflicting presuppositions. -/
-noncomputable def PUpdate.disjFlex {W : Type*}
-    (χ φ_presup φ ω ψ_presup ψ : W → Prop)
+noncomputable def PUpdate.disjFlex (χ φ_presup φ ω ψ_presup ψ : W → Prop)
     (_h_split : ∀ s : State W, Update.prop χ s ∪ Update.prop ω s = s) :
     PState W → PState W
   | none => none
@@ -292,8 +281,7 @@ noncomputable def PUpdate.disjFlex {W : Type*}
     | some l, some r => some (l ∪ r)
     | _, _ => none  -- ∗ poisons: if either side is undefined, result is ∗
 
-
--- ═══ Yagi's Core Observations (Dynamic) ═══
+/-! ### Yagi's core observations -/
 
 /-- Presuppositional disjunction update is uninformative when both
     presuppositions are already supported: if s ⊨ p and s ⊨ q and the
@@ -305,8 +293,7 @@ noncomputable def PUpdate.disjFlex {W : Type*}
     (unless s = ∅). For the conflicting case, see
     `update_yields_undefined` in the Yagi2025 study, which shows the
     update is undefined (∗) rather than uninformative. -/
-theorem presup_disj_uninformative_when_supported {W : Type*}
-    (p φ q ψ : W → Prop) (s : State W)
+theorem presup_disj_uninformative_when_supported (p φ q ψ : W → Prop) (s : State W)
     (hp : Update.prop p s = s) (hq : Update.prop q s = s)
     (h_or : ∀ w, w ∈ s → (φ w ∨ ψ w)) :
     PUpdate.disjPresup p φ q ψ (some s) = some s := by

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Default.lean
@@ -36,7 +36,7 @@ Key patterns are verified as regression tests in
 `Studies/Veltman1996.lean`.
 
 §4 (expectation frames, conditional defaults, specificity) is
-formalized in `Frames.lean` alongside this module.
+formalized in `Studies/Veltman1996.lean`.
 
 ## Connection to existing infrastructure
 
@@ -62,8 +62,7 @@ open Core.Order
 
 variable {W : Type*}
 
-
--- ═══ Expectation States ═══
+/-! ### Expectation states -/
 
 /-- An **expectation state**: an information state paired with a
     normality ordering on worlds.
@@ -92,14 +91,13 @@ def ExpState.init : ExpState W where
 def ExpState.optimal (σ : ExpState W) : Set W :=
   Normality.optimal σ.order σ.info
 
-
--- ═══ Update Operations ═══
+/-! ### Update operations -/
 
 /-- **Assertion update** (Veltman's factual update): eliminate
     non-φ-worlds, preserve the pattern. Information grows; expectations
     are unchanged. This is [portner-2018]'s `+`-update on the context
-    set, and the standard eliminative update from CCP.lean lifted to
-    expectation states. -/
+    set, and the standard eliminative update from ContextChange.lean
+    lifted to expectation states. -/
 def ExpState.assert (σ : ExpState W) (φ : W → Prop) : ExpState W :=
   ⟨{ w ∈ σ.info | φ w }, σ.order⟩
 
@@ -133,8 +131,7 @@ noncomputable def mightTest (φ : W → Prop) (σ : ExpState W) : ExpState W :=
 
 end Classical
 
-
--- ═══ Basic Properties ═══
+/-! ### Basic properties -/
 
 namespace ExpState
 
@@ -196,7 +193,7 @@ theorem mem_foldl_assert_info (ps : List (W → Prop)) (σ : ExpState W) (v : W)
   | nil => simp
   | cons p ps ih =>
     rw [List.foldl_cons, ih]
-    simp only [assert_info, Set.mem_setOf_eq, List.mem_cons, Set.mem_sep_iff]
+    simp only [assert_info, Set.mem_setOf_eq, List.mem_cons]
     constructor
     · rintro ⟨⟨hv, hp⟩, hps⟩
       exact ⟨hv, fun q hq => hq.elim (fun h => h ▸ hp) (hps q)⟩
@@ -212,7 +209,7 @@ theorem foldl_promote_order_le (ps : List (W → Prop)) (σ : ExpState W) (w v :
   | nil => exact ⟨fun h => ⟨h, by simp⟩, And.left⟩
   | cons p ps ih =>
     rw [List.foldl_cons, ih]
-    simp only [promote_order, Core.Order.Normality.refine_le, List.mem_cons]
+    simp only [List.mem_cons]
     constructor
     · rintro ⟨⟨hle, hp⟩, hps⟩
       exact ⟨hle, fun q hq => hq.elim (fun h => h ▸ hp) (hps q)⟩
@@ -231,7 +228,7 @@ theorem foldl_promote_order_le (ps : List (W → Prop)) (σ : ExpState W) (w v :
     information state. -/
 theorem le_assert_iff (σ : ExpState W) (φ : W → Prop) :
     σ ≤ σ.assert φ ↔ ∀ w ∈ σ.info, φ w :=
-  ⟨fun h w hw => (h.1 hw).2, fun h => ⟨fun _ hw => ⟨hw, h _ hw⟩, le_refl _⟩⟩
+  ⟨fun h _ hw => (h.1 hw).2, fun h => ⟨fun _ hw => ⟨hw, h _ hw⟩, le_refl _⟩⟩
 
 /-- **Acceptance fixpoint for promotion** ([veltman-1996]: `e` is a
     *default* in `ε` iff `ε ∘ e = ε`, his Def 4.2): the input refines
@@ -267,8 +264,7 @@ theorem presumablyTest_preserves_order (φ : W → Prop) (σ : ExpState W) :
     (presumablyTest φ σ).order = σ.order := by
   unfold presumablyTest; split <;> rfl
 
-
--- ═══ Key Theorem — "Normally p; Presumably p" Succeeds ═══
+/-! ### "Normally p; presumably p" succeeds -/
 
 /-- **General presumably**: if the ordering is connected, respects φ,
     and the info state has φ-worlds, then "presumably φ" passes.
@@ -302,12 +298,11 @@ theorem normally_presumably_succeeds (φ : W → Prop) (d : Set W)
   rw [Normality.refine_total_optimal φ d hex] at hw
   exact hw.2
 
+/-! ### Persistence -/
 
--- ═══ Persistence ═══
-
-/-- **Persistence under assertion**: if the ordering respects p
-    (i.e., the state has accepted "normally p"), then asserting any
-    q preserves this. Learning new facts does not undo expectations.
+/-- **Persistence under assertion**: asserting any `ψ` preserves respect
+    for `φ` — learning new facts does not undo expectations. Immediate,
+    since `assert` leaves the ordering untouched (`assert_order`).
 
     [veltman-1996], Proposition 3.6(iv). -/
 theorem persistence_assert (σ : ExpState W) (φ ψ : W → Prop)
@@ -330,8 +325,7 @@ theorem normally_creates_respect (σ : ExpState W) (φ : W → Prop) :
     Normality.respects (σ.promote φ).order φ :=
   Normality.refine_respects σ.order φ
 
-
--- ═══ Idempotency and Commutativity ═══
+/-! ### Idempotency and commutativity -/
 
 /-- **Idempotency**: if the state already accepts "normally φ" (the
     ordering respects φ), then processing "normally φ" again is a no-op.
@@ -352,14 +346,10 @@ theorem promote_promote_self (σ : ExpState W) (φ : W → Prop) :
 /-- **Commutativity**: the order of defaults doesn't matter.
     "Normally φ; normally ψ" = "normally ψ; normally φ". -/
 theorem promote_comm (σ : ExpState W) (φ ψ : W → Prop) :
-    (σ.promote φ).promote ψ = (σ.promote ψ).promote φ := by
-  show ExpState.mk σ.info (Normality.refine (Normality.refine σ.order φ) ψ) =
-       ExpState.mk σ.info (Normality.refine (Normality.refine σ.order ψ) φ)
-  congr 1
-  exact Normality.refine_comm σ.order φ ψ
+    (σ.promote φ).promote ψ = (σ.promote ψ).promote φ :=
+  congrArg (ExpState.mk σ.info) (Normality.refine_comm σ.order φ ψ)
 
-
--- ═══ Conflicting Defaults ═══
+/-! ### Conflicting defaults -/
 
 /-- **Conflicting defaults produce agnosticism.** After processing both
     "normally p" and "normally ¬p", the ordering relates worlds only
@@ -378,8 +368,7 @@ theorem conflicting_defaults_le (φ : W → Prop) (w v : W) :
 
 /-- The conflicting-default ordering is equivalent to p-agreement:
     w is at most as normal as v iff they agree on p. -/
-theorem conflicting_defaults_iff_agree (φ : W → Prop) [DecidablePred φ]
-    (w v : W) :
+theorem conflicting_defaults_iff_agree (φ : W → Prop) (w v : W) :
     (Normality.refine (Normality.refine Normality.total φ) (fun x => ¬φ x)).le w v ↔
     (φ w ↔ φ v) := by
   rw [conflicting_defaults_le]
@@ -389,8 +378,7 @@ theorem conflicting_defaults_iff_agree (φ : W → Prop) [DecidablePred φ]
   · intro ⟨h1, h2⟩
     exact ⟨h2, fun hv hw => hv (h1 hw)⟩
 
-
--- ═══ Compatible Defaults ═══
+/-! ### Compatible defaults -/
 
 /-- When two defaults are compatible (p implies q), processing both in
     sequence makes p-worlds optimal: the expectations reinforce rather

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Necessity.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Necessity.lean
@@ -8,63 +8,39 @@ import Linglib.Semantics.Dynamic.UpdateSemantics.Default
 /-!
 # Necessity modals over expectation states
 
-[portner-2018]'s **partially ordered set of worlds** (posw) — the pair
-`⟨cs, ≤⟩` of a context set and an ordering that his mood unification has
-verbal mood, sentence mood, and modal flavor operate on — is
-[veltman-1996]'s expectation state `ExpState` read at the discourse
-level, a lineage Portner makes explicit by crediting Veltman's update
-logic for his update operations and writing the promotion update via
-Veltman's `∘` refinement. `info` is the Stalnakerian context set
+[portner-2018]'s partially ordered set of worlds — the pair `⟨cs, ≤⟩`
+his mood unification operates on — is [veltman-1996]'s `ExpState` read
+at the discourse level: `info` is the Stalnakerian context set
 ([stalnaker-1978]), `order` the Kratzerian ordering source
-([kratzer-1981]), `ExpState.assert` Portner's assertive update, and
-`ExpState.promote` his ordering-refinement update ([portner-2004]'s
-To-Do-List update). Portner's central architectural insight — belief vs.
-desire is `□_cs` vs. `□_≤` over the same agent's state, assertion vs.
-directive is the informational vs. the preferential update over the
-discourse state — becomes: the two updates touch disjoint components
-(`ExpState.assert_order`, `ExpState.promote_info`), and the two modals
-quantify over them.
+([kratzer-1981]). This file adds the modal half of that API: the
+necessity modals over the two components, and the comparison of each
+with its update's acceptance fixpoint ([veltman-1996]'s `σ ⊩ φ` iff
+`σ[φ] = σ`, reformulated by [portner-2018] for *believe* and *want*
+following [farkas-2003]).
 
-This file adds the *modal* half of that API: the necessity modals
-`□_cs` (`boxCs`) and `□_≤` (`boxLe`), the `best` worlds the latter
-quantifies over, their normality in the modal-logic sense
-(`NormalModality`), and the support/necessity comparison relating
-each modal to its update's acceptance fixpoint.
+## Main definitions
 
-## Support vs necessity
+- `ExpState.boxCs`: informational necessity `□_cs` — truth throughout
+  the information state (Portner's *believe*).
+- `ExpState.boxLe`: preferential necessity `□_≤` — truth at all optimal
+  worlds (Portner's *want*, Kratzerian deontic/bouletic modals
+  ([condoravdi-lauer-2012]), and the test condition of [veltman-1996]'s
+  *presumably*).
+- `NormalModality`: necessitation plus the K-axiom.
 
-[veltman-1996]'s acceptance (`σ ⊩ φ` iff `σ[φ] = σ`) gives each
-update a *support* condition (`ExpState.le_assert_iff`,
-`ExpState.le_promote_iff`). Comparing support with necessity:
+## Main results
 
-- **informational**: support of `assert` *is* `boxCs`
-  (`le_assert_iff_boxCs`) — the fixpoint [farkas-2003] uses to
-  characterize indicative-licensing (assertive) contexts.
-- **preferential**: support of `promote` is `Normality.respects`
-  ("φ is already on the To-Do List"), which is *not* equivalent to
-  `boxLe` and implies it only on connected orders with a φ-witness
-  (`boxLe_of_respects` — [veltman-1996]'s *normally φ ⊩ presumably
-  φ*). Connectedness can be destroyed by `promote` itself; Veltman's
-  ambiguous states are exactly the disconnected ones.
+- `le_assert_iff_boxCs`: support of `assert` *is* `boxCs` — the fixpoint
+  [farkas-2003] uses to characterize indicative-licensing contexts.
+- `boxLe_of_respects`: support of `promote` (`Normality.respects`)
+  implies `boxLe` on connected orders with a witness — [veltman-1996]'s
+  *normally φ ⊩ presumably φ*. The converse fails, and disconnected
+  orders (Veltman's ambiguous states) break this direction too.
 
-The support conditions are linguistically load-bearing:
-[portner-2018] reformulates the attitudes as update fixpoints —
-*believe* as `m + φ = m` and *want* as `m ⋆ φ = m`, extending
-[farkas-2003]'s Heim-style assertive fixpoint to the preferential
-side — so his fixpoint clauses are exactly `ExpState.le_assert_iff` /
-`ExpState.le_promote_iff`, and `boxLe_of_respects` is the formal
-relation between his two semantics for *want* (modal vs. fixpoint).
-That the informational component is the one where support and
-necessity coincide is the type-level face of assertion's special
-status among the updates.
-
-**Caveat** on the preferential side: [condoravdi-lauer-2012]'s
-*preference structures* are strict partial orders on **propositions**,
-one type level above the world ordering here; see
-`Core.Order.PreferenceStructure`. POSW-style states consume the
-maximal-element-induced world preorder
-(`Core.Order.PreferenceStructure.maxInducedLe`) rather than
-instantiating them.
+[condoravdi-lauer-2012]'s preference structures order *propositions*,
+one type level above the world ordering here; POSW-style states consume
+`Core.Order.PreferenceStructure.maxInducedLe` rather than instantiating
+them.
 -/
 
 namespace UpdateSemantics.Default.ExpState
@@ -147,18 +123,14 @@ variable {W : Type*}
 
 /-! ### Normal modality structure
 
-`boxCs` and `boxLe` are both **normal modalities** in the modal-logic
-sense: each satisfies necessitation (`□⊤`) and the K-axiom
-(`□(p→q) → □p → □q`) — one shape of the inf-preservation pattern that
-`∀` over any subset enjoys. The third State modal `boxAns` is *not*
-normal (see `Semantics/Mood/State.lean`); it has its own closure
-structure under boolean operations instead. -/
+`boxCs` and `boxLe` are both normal modalities — one shape of the
+inf-preservation pattern that `∀` over any subset enjoys. The third
+State modal `boxAns` is *not* normal (see `Semantics/Mood/State.lean`);
+it has its own closure structure under boolean operations instead. -/
 
-/-- A **normal modality** in the sense of basic modal logic:
-    quantifies a unary box over `W → Prop` predicates, satisfying
-    necessitation (`box ⊤`) and the K-axiom (`box (p → q) → box p
-    → box q`). The two universal modals `ExpState.boxCs` and
-    `ExpState.boxLe` are normal; `State.boxAns` is not. -/
+/-- A **normal modality** in the sense of basic modal logic: a unary box
+    over `W → Prop` predicates satisfying necessitation (`box ⊤`) and
+    the K-axiom (`box (p → q) → box p → box q`). -/
 class NormalModality (W : Type*) (box : (W → Prop) → Prop) : Prop where
   /-- Necessitation: the box always holds for `⊤`. -/
   necessitation : box (fun _ => True)

--- a/Linglib/Studies/Abusch1997.lean
+++ b/Linglib/Studies/Abusch1997.lean
@@ -206,7 +206,7 @@ section
 open Classical
 open _root_.PLA
 
-variable {E : Type*} [Nonempty E]
+variable {E : Type*}
 
 /--
 Doxastic accessibility relation: what worlds/possibilities agent a

--- a/Linglib/Studies/Charlow2019.lean
+++ b/Linglib/Studies/Charlow2019.lean
@@ -18,6 +18,7 @@ namespace Charlow2019
 
 open DPL
 open DynamicSemantics
+open _root_.Core (Assignment)
 
 /-- Truth at an assignment: K True at g ⟺ ∃h. K g h (Charlow's (7)). -/
 def trueAt {E : Type*} (K : DPLRel E) (g : Assignment E) : Prop :=

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -69,7 +69,7 @@ namespace Charlow2021
 
 open DynamicSemantics
 open Semantics.Composition.Continuation
-open scoped DynamicSemantics.DynProp
+open scoped DynamicSemantics
 
 /-! ### Witness models: the cumulative-reading puzzle
 

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -179,7 +179,7 @@ to the same classical truth conditions.
 -/
 
 open CDRT (DProp State SProp)
-open DynamicSemantics.DynProp (closure dseq test dneg dimpl)
+open DynamicSemantics (closure dseq test dneg dimpl)
 open Semantics.TypeTheoretic (Ppty PPpty Parametric IsTrue IsFalse propT)
 open Cooper2023Ch7 (purify purifyUniv)
 
@@ -198,7 +198,7 @@ def ttr_exists (P : E → Prop) : Type := (x : E) × propT (P x)
 the same truth conditions. Both reduce to `∃ x, P x`. -/
 theorem exists_equiv (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (cdrt_exists n P) i ↔ Nonempty (ttr_exists P) := by
-  simp only [DProp.true_at, DynamicSemantics.DynProp.closure, cdrt_exists, DProp.seq, dseq, Relation.Comp, DProp.new,
+  simp only [DProp.true_at, DynamicSemantics.closure, cdrt_exists, DProp.seq, dseq, Relation.Comp, DProp.new,
     DProp.ofStatic, test, ttr_exists]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, rfl, hp⟩
@@ -228,7 +228,7 @@ def ttr_donkey (P Q : E → Prop) : Type :=
 the same truth conditions. Both reduce to `∀ x, P x → Q x`. -/
 theorem donkey_equiv (n : Nat) (P Q : E → Prop) (i : State E) :
     DProp.true_at (cdrt_donkey n P Q) i ↔ Nonempty (ttr_donkey P Q) := by
-  simp only [DProp.true_at, DynamicSemantics.DynProp.closure, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq, Relation.Comp,
+  simp only [DProp.true_at, DynamicSemantics.closure, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq, Relation.Comp,
     DProp.new, DProp.ofStatic, test, ttr_donkey]
   constructor
   · rintro ⟨o, rfl, hall⟩
@@ -361,7 +361,7 @@ the *input* register (no binding). -/
 theorem dne_same_truth (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (DProp.neg (DProp.neg (cdrt_exists n P))) i ↔
     DProp.true_at (cdrt_exists n P) i := by
-  simp only [DProp.true_at, DynamicSemantics.DynProp.closure, DProp.neg, test, dneg]
+  simp only [DProp.true_at, DynamicSemantics.closure, DProp.neg, test, dneg]
   constructor
   · rintro ⟨_, rfl, h⟩
     exact Classical.byContradiction (λ hno => h ⟨i, rfl, hno⟩)

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -111,24 +111,24 @@ force output = input, so no binding escapes them. This accounts for
 `Heim1982.Examples.universal_blocks`, `standard_negation_blocks`, and
 `conditional_antecedent`. -/
 
-open DynamicSemantics.DynProp (IsTest) in
+open DynamicSemantics (IsTest) in
 /-- Negation is a test. -/
-theorem neg_isTest (φ : DPLRel E) : IsTest (toDRS (DPLRel.neg φ)) :=
+theorem neg_isTest (φ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.neg φ)) :=
   fun _ _ hn => hn.1
 
-open DynamicSemantics.DynProp (IsTest) in
+open DynamicSemantics (IsTest) in
 /-- Implication is a test: antecedent bindings do not escape. -/
-theorem impl_isTest (φ ψ : DPLRel E) : IsTest (toDRS (DPLRel.impl φ ψ)) :=
+theorem impl_isTest (φ ψ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.impl φ ψ)) :=
   fun _ _ hi => hi.1
 
-open DynamicSemantics.DynProp (IsTest) in
+open DynamicSemantics (IsTest) in
 /-- Disjunction is a test: no anaphora across or out of disjuncts. -/
-theorem disj_isTest (φ ψ : DPLRel E) : IsTest (toDRS (DPLRel.disj φ ψ)) :=
+theorem disj_isTest (φ ψ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.disj φ ψ)) :=
   fun _ _ hd => hd.1
 
-open DynamicSemantics.DynProp (IsTest) in
+open DynamicSemantics (IsTest) in
 /-- The universal quantifier is a test: it introduces no referents. -/
-theorem forall_isTest (x : ℕ) (φ : DPLRel E) : IsTest (toDRS (DPLRel.forall_ x φ)) :=
+theorem forall_isTest (x : ℕ) (φ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.forall_ x φ)) :=
   fun _ _ hfa => hfa.1
 
 /-! ### Logical facts (§3.4) -/
@@ -264,7 +264,7 @@ theorem forall_interdefinable (x : ℕ) (φ : DPLRel E) :
 
 section Metatheory
 
-open DynamicSemantics.DynProp
+open DynamicSemantics
 
 /-- s-equivalence (Definition 7) at a fixed model: same satisfaction
 set. The paper quantifies over models; `DPLRel` fixes one. -/
@@ -297,15 +297,15 @@ theorem sEquiv_pEquiv_ne [Nontrivial E] :
 /-- Definition 12's semantic core, clause 2: a conjunction of tests is a
 test. With the static constants (`neg_isTest`, ..., Fact 5) this closes
 the conditions under the semantics. -/
-theorem conj_isTest {φ ψ : DPLRel E} (hφ : IsTest (toDRS φ))
-    (hψ : IsTest (toDRS ψ)) : IsTest (toDRS (DPLRel.conj φ ψ)) :=
+theorem conj_isTest {φ ψ : DPLRel E} (hφ : DynamicSemantics.Update.IsTest (toDRS φ))
+    (hψ : DynamicSemantics.Update.IsTest (toDRS ψ)) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.conj φ ψ)) :=
   fun _ _ ⟨_, h1, h2⟩ => (hφ h1).trans (hψ h2)
 
 /-- Fact 4: for tests, s-equivalence coincides with equivalence — a test
 is determined by its truth conditions (`IsTest.eq_test_closure`, the
 semantic form of Fact 6). -/
 theorem sEquiv_iff_eq_of_isTest {φ ψ : DPLRel E}
-    (hφ : IsTest (toDRS φ)) (hψ : IsTest (toDRS ψ)) :
+    (hφ : DynamicSemantics.Update.IsTest (toDRS φ)) (hψ : DynamicSemantics.Update.IsTest (toDRS ψ)) :
     sEquiv φ ψ ↔ φ = ψ := by
   refine ⟨fun h => ?_, sEquiv_of_eq⟩
   have hc : closure (toDRS φ) = closure (toDRS ψ) :=
@@ -317,7 +317,7 @@ theorem sEquiv_iff_eq_of_isTest {φ ψ : DPLRel E}
 /-! ### Entailment (§3.5)
 
 Dynamic entailment (Definition 20) is the generic
-`DynamicSemantics.DynProp.entails`; s-entailment (Definition 18) is
+`DynamicSemantics.entails`; s-entailment (Definition 18) is
 `sEntails`, and meaning inclusion implies it (`sEntails_of_subset`,
 Fact 10). Facts 13–16 — the restricted reflexivity and transitivity
 laws — carry syntactic `AQV/FV` side conditions and await the syntax
@@ -387,7 +387,7 @@ section SatisfactionSets
 
 open Core.CylindricAlgebra
 open Core (Assignment)
-open DynamicSemantics.DynProp (closure)
+open DynamicSemantics (closure)
 
 /-- **DPL existential = cylindrification**: `\∃xφ\ = cₓ\φ\` — the
 existential case of Fact 19's computation. -/

--- a/Linglib/Studies/HaugDalrymple2020.lean
+++ b/Linglib/Studies/HaugDalrymple2020.lean
@@ -33,7 +33,7 @@ the PPCDRT substrate (`Semantics/Dynamic/PPCDRT/`):
 | §4.5    | Subgroup readings (forks, gravity)     | Weak-vs-strong contrast    |
 | §4.6    | Collective antecedents                 | Distinctness neutralization |
 | §5      | Quantified antecedents + truth-value gap | `Trivalent` via `removeGap` |
-| §6      | Maximize Anaphora as a principle       | `R_u` + `maximizeAnaphora` |
+| §6      | Maximize Anaphora as a principle       | `R_u` |
 | §6.2    | Multi-reciprocal pairwise prediction   | `R_u` over two reciprocals |
 | §6.3    | MA interacting with scope              | Tracy/Matty/Chris case     |
 

--- a/Linglib/Studies/Heim1983.lean
+++ b/Linglib/Studies/Heim1983.lean
@@ -187,6 +187,6 @@ open DynamicSemantics in
 theorem bare_consequent_not_admitted :
     ¬ (PartialCCP.ofPartialProp kingBald).admits Set.univ := by
   intro h
-  exact h .noKing trivial
+  exact h (Set.mem_univ .noKing)
 
 end Heim1983

--- a/Linglib/Studies/Hofmann2025.lean
+++ b/Linglib/Studies/Hofmann2025.lean
@@ -745,7 +745,7 @@ Type-driven compositional semantics for ICDRT. Each lexical entry is a
 higher-order function over dynamic meta-types; composition is function
 application + sequential update. The resulting `ICDRTUpdate` values lift
 to distributive CCPs via `Core/Intensional.lean`'s
-`toDynProp_isDistributive`.
+`toUpdate_isDistributive`.
 
 ### Meta-types (Definition 13)
 
@@ -922,18 +922,18 @@ theorem double_neg_complement (φ' φ'' : PVar) (φ : PVar)
 
 /-- Every compositional derivation lifts to a distributive CCP. -/
 theorem comp_isDistributive (D : ICDRTUpdate W E) :
-    IsDistributive D.toDynProp :=
-  toDynProp_isDistributive D
+    IsDistributive D.toUpdate :=
+  toUpdate_isDistributive D
 
 /-- Every compositional derivation factors through `fiberDRS`. -/
 theorem comp_factorizes (D : ICDRTUpdate W E) :
-    D.toDynProp = lift (fiberDRS D) :=
-  toDynProp_eq_lift_fiberDRS D
+    D.toUpdate = lift (fiberDRS D) :=
+  toUpdate_eq_lift_fiberDRS D
 
 /-- Sequential composition in the fragment lifts to CCP composition. -/
 theorem comp_seq_lifts (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
-    (ICDRTUpdate.seq D₁ D₂).toDynProp c = D₂.toDynProp (D₁.toDynProp c) :=
-  ICDRTUpdate.seq_toDynProp D₁ D₂ c
+    (ICDRTUpdate.seq D₁ D₂).toUpdate c = D₂.toUpdate (D₁.toUpdate c) :=
+  ICDRTUpdate.seq_toUpdate D₁ D₂ c
 
 -- § 6.4 Compositional derivations applied to Model M₁
 
@@ -987,15 +987,15 @@ def modalSub_comp : ICDRTUpdate BWorld BEnt :=
 
 /-- Every compositional derivation lifts to a distributive CCP. -/
 theorem veridical_comp_distributive :
-    IsDistributive veridical_comp.toDynProp :=
-  toDynProp_isDistributive _
+    IsDistributive veridical_comp.toUpdate :=
+  toUpdate_isDistributive _
 
 /-- Sequential composition lifts correctly. -/
 theorem veridical_comp_factors (c : IContext BWorld BEnt) :
-    veridical_comp.toDynProp c =
-    (semDEC pDC_S p3 itIsUpstairs).toDynProp
-      ((semDEC pDC_S p1 thereIsABathroom).toDynProp c) :=
-  ICDRTUpdate.seq_toDynProp _ _ c
+    veridical_comp.toUpdate c =
+    (semDEC pDC_S p3 itIsUpstairs).toUpdate
+      ((semDEC pDC_S p1 thereIsABathroom).toUpdate c) :=
+  ICDRTUpdate.seq_toUpdate _ _ c
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -63,7 +63,7 @@ The DPL comparison below (`dpl_dne_fails_anaphora`) consumes these; they stay in
 namespace DynamicSemantics
 
 open _root_.Core (Assignment)
-open DynamicSemantics.DynProp
+open DynamicSemantics
 
 variable {E : Type*}
 
@@ -1069,7 +1069,7 @@ theorem pip_quantifier_blocking :
 section DPLComparison
 
 open DynamicSemantics (existsAt existsAt_iff)
-open DynamicSemantics.DynProp (Update dneg test)
+open DynamicSemantics (Update dneg test)
 open _root_.Core (Assignment)
 
 /-!

--- a/Linglib/Studies/Krifka2026.lean
+++ b/Linglib/Studies/Krifka2026.lean
@@ -42,8 +42,8 @@ namespace Krifka2026
 
 open Semantics.Kinds.NMP (Property Kind IsMass
   kindAnaphorMass kindAnaphorCount kindAnaphorCount_mass)
-open DynamicSemantics.DynProp (Update Condition test dneg eq_of_test)
-open scoped DynamicSemantics.DynProp
+open DynamicSemantics (Update Condition test dneg eq_of_test)
+open scoped DynamicSemantics
 
 /-! ### Concept drefs and heterogeneous dref values ([krifka-2026] §4)
 


### PR DESCRIPTION
First tranche of the mathlib-reviewer pass over `Semantics/Dynamic/`, covering the level-0 spine.
- `DynProp` namespace dissolved into `DynamicSemantics` — it existed only to be re-exported (the shim is gone), and the file/namespace mismatch with it; the relational test predicate becomes `Update.IsTest` (owner-relative, resolving the collision with the CCP-level `IsTest`, which is a *different* notion — both docstrings now state the trap: lifting a relational test is a filter, not a pass-or-∅ test). ICDRT's `toDynProp` → `toUpdate`.
- `Update.lean`: module docstring to mathlib register (the DNE-repair essay compressed to Implementation notes).
- `ContextChange.lean`: honest title and mathlib-layout docstring stating the lift/lower architecture; `variable` block; banners → `/-! ### -/`; four consumerless wrapper lemmas cut; the vestigial `Assignment` import/re-export removed (consumers now import it themselves); the long-standing `unusedSimpArgs` warnings fixed; `dynamicEntails_trans` golfed.
Files vs namespaces: kept `Update.lean`/`ContextChange.lean` as two files — the relational and set-transformer carriers have distinct ergonomic profiles (two `Monoid` instances, disjoint consumer families), per the general-plus-specialization house pattern.