### PR TITLE
feat(Semantics/Dynamic): the update algebra as the Kleisli construction

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1649,6 +1649,7 @@ import Linglib.Semantics.Dynamic.ICDRT.Defs
 import Linglib.Semantics.Dynamic.State
 import Linglib.Semantics.Dynamic.Transition
 import Linglib.Semantics.Dynamic.ICDRT.Basic
+import Linglib.Semantics.Dynamic.Kleisli
 import Linglib.Semantics.Dynamic.PLA.Basic
 import Linglib.Semantics.Dynamic.PLA.Epistemic
 import Linglib.Semantics.Dynamic.PLA.Semantics

--- a/Linglib/Semantics/Dynamic/ContextChange.lean
+++ b/Linglib/Semantics/Dynamic/ContextChange.lean
@@ -14,6 +14,8 @@ form a round trip — `lower_lift` everywhere, `lift_lower` exactly on the
 `IsDistributive` CCPs, which process elements independently. What the
 set-transformer view genuinely adds is the non-distributive tests
 (`CCP.guard`, `might`, `must`, `negTest`) that inspect the whole state.
+`Kleisli.lean` certifies this picture: `lift` is the powerset monad's
+`bind`, an equivalence onto the completely-join-preserving transformers.
 
 ## Main definitions
 

--- a/Linglib/Semantics/Dynamic/Kleisli.lean
+++ b/Linglib/Semantics/Dynamic/Kleisli.lean
@@ -1,0 +1,190 @@
+import Linglib.Semantics.Dynamic.ContextChange
+import Mathlib.Data.Set.Functor
+import Mathlib.CategoryTheory.Category.KleisliCat
+import Mathlib.CategoryTheory.Category.RelCat
+import Mathlib.Order.Hom.CompleteLattice
+
+/-!
+# The update algebra is the Kleisli construction
+[charlow-2014] [muskens-van-benthem-visser-2011]
+
+The relational/set-transformer pair of `Update.lean` and
+`ContextChange.lean` is canonical, not a design choice. An update
+`S → S → Prop` is a Kleisli arrow `S → Set S` of the powerset monad —
+definitionally — and under that reading sequencing is Kleisli
+composition, the trivial test is `pure`, and `lift` is `bind`:
+[charlow-2014]'s monadic view of dynamic semantics, as theorems. `lift`
+is then an equivalence onto the completely-join-preserving transformers
+(`sSupHom`), so the transformer algebra is the suplattice completion of
+the relational one and the non-distributive tests (`might`, `must`) are
+exactly the residue. Categorically, `RelCat ≌ KleisliCat Set`; with
+`Ctx.collapse` landing in `RelCat`, the based tower reads
+`Ctx ⥤ RelCat ≌ KleisliCat Set ↪ suplattice endomaps`, every arrow
+canonical.
+
+## Main results
+
+- `dseq_eq_kleisliComp`, `test_top_eq_pure`, `lift_eq_bind`: the monadic
+  reading of the update algebra.
+- `isDistributive_iff_map_sSup`, `liftEquiv`, `liftEquiv_dseq`:
+  distributive CCPs are exactly the completely-join-preserving maps, and
+  `lift`/`lower` is an equivalence onto them, sending sequencing to
+  composition.
+- `relCatEquivKleisli`: `RelCat ≌ KleisliCat Set`. [UPSTREAM] candidate —
+  pure category theory, absent from mathlib.
+-/
+
+namespace DynamicSemantics
+
+attribute [local instance] Set.monad
+
+universe u
+
+variable {S : Type*}
+
+/-! ### The Set-monad reading -/
+
+/-- Sequencing is Kleisli composition for the powerset monad: an update
+is a Kleisli arrow `S → Set S`, definitionally. -/
+theorem dseq_eq_kleisliComp (D₁ D₂ : S → Set S) :
+    ((D₁ ⨟ D₂ : Update S) : S → Set S) = D₁ >=> D₂ := by
+  funext i
+  ext j
+  show (∃ k, D₁ i k ∧ D₂ k j) ↔ j ∈ D₁ i >>= D₂
+  simp only [Set.bind_def, Set.mem_iUnion, exists_prop]
+  rfl
+
+/-- The trivial test is `pure`. -/
+theorem test_top_eq_pure :
+    (test (fun _ => True) : Update S) = fun i => (pure i : Set S) := by
+  funext i j
+  show (i = j ∧ True) = (j ∈ ({i} : Set S))
+  simp [eq_comm]
+
+/-- `lift` is `bind`: the relational image is the monad's extension
+operator. -/
+theorem lift_eq_bind (R : Update S) (σ : Set S) :
+    lift R σ = σ >>= (R : S → Set S) := by
+  ext j
+  simp only [lift, Set.bind_def, Set.mem_iUnion, Set.mem_setOf_eq, exists_prop]
+  rfl
+
+/-! ### Distributivity is complete join preservation -/
+
+/-- A CCP is distributive iff it preserves arbitrary joins of states. -/
+theorem isDistributive_iff_map_sSup (φ : CCP S) :
+    IsDistributive φ ↔ ∀ T : Set (Set S), φ (sSup T) = sSup (φ '' T) := by
+  simp only [Set.sSup_eq_sUnion]
+  constructor
+  · intro h T
+    ext j
+    constructor
+    · intro hj
+      rw [h] at hj
+      obtain ⟨i, ⟨t, ht, hit⟩, hji⟩ := hj
+      refine ⟨φ t, ⟨t, ht, rfl⟩, ?_⟩
+      rw [h t]
+      exact ⟨i, hit, hji⟩
+    · rintro ⟨_, ⟨t, ht, rfl⟩, hjt⟩
+      rw [h t] at hjt
+      obtain ⟨i, hit, hji⟩ := hjt
+      rw [h]
+      exact ⟨i, ⟨t, ht, hit⟩, hji⟩
+  · intro h s
+    have hs : s = ⋃₀ ((fun i => ({i} : Set S)) '' s) := by
+      ext i
+      simp
+    ext j
+    constructor
+    · intro hj
+      rw [hs, h] at hj
+      obtain ⟨_, ⟨_, ⟨i, hi, rfl⟩, rfl⟩, hji⟩ := hj
+      exact ⟨i, hi, hji⟩
+    · rintro ⟨i, hi, hji⟩
+      rw [hs, h]
+      exact ⟨φ {i}, ⟨{i}, ⟨i, hi, rfl⟩, rfl⟩, hji⟩
+
+/-- The relational algebra is exactly the completely-join-preserving
+fragment of the transformer algebra: `lift`/`lower` as an equivalence
+onto `sSupHom`. -/
+def liftEquiv : Update S ≃ sSupHom (Set S) (Set S) where
+  toFun R := ⟨lift R, (isDistributive_iff_map_sSup _).mp (lift_isDistributive R)⟩
+  invFun f := lower f
+  left_inv := lower_lift
+  right_inv f := sSupHom.ext fun σ =>
+    congrFun (lift_lower _ ((isDistributive_iff_map_sSup _).mpr f.map_sSup')) σ
+
+/-- The equivalence sends sequencing to composition (diagrammatic order):
+the transformer monoid restricts to the relational one. -/
+theorem liftEquiv_dseq (D₁ D₂ : Update S) :
+    (liftEquiv (D₁ ⨟ D₂) : Set S → Set S) =
+      (liftEquiv D₂ : Set S → Set S) ∘ (liftEquiv D₁ : Set S → Set S) :=
+  lift_dseq D₁ D₂
+
+/-! ### `RelCat ≌ KleisliCat Set` -/
+
+open CategoryTheory
+
+/-- [UPSTREAM] Relations to Kleisli arrows of the powerset monad: curry. -/
+def relCatToKleisli : RelCat.{u} ⥤ KleisliCat Set where
+  obj X := X
+  map f := fun x => {y | (x, y) ∈ f.rel}
+  map_id X := funext fun x => by
+    ext y
+    show (x, y) ∈ SetRel.id ↔ y ∈ ({x} : Set X)
+    simp [SetRel.id, eq_comm]
+  map_comp {X Y Z} f g := funext fun x => by
+    ext z
+    show (x, z) ∈ SetRel.comp f.rel g.rel ↔ _
+    simp only [SetRel.comp, KleisliCat.comp_def,
+      Set.bind_def, Set.mem_iUnion, Set.mem_setOf_eq, exists_prop]
+
+/-- [UPSTREAM] Kleisli arrows of the powerset monad to relations:
+uncurry. -/
+def kleisliToRelCat : KleisliCat Set ⥤ RelCat.{u} where
+  obj X := X
+  map f := .ofRel {p | p.2 ∈ f p.1}
+  map_id X := by
+    apply RelCat.Hom.ext
+    ext ⟨x, y⟩
+    show y ∈ ({x} : Set X) ↔ (x, y) ∈ SetRel.id
+    simp [SetRel.id, eq_comm]
+  map_comp {X Y Z} f g := by
+    apply RelCat.Hom.ext
+    ext ⟨x, z⟩
+    simp only [KleisliCat.comp_def, Set.bind_def, Set.mem_iUnion,
+      Set.mem_setOf_eq, exists_prop]
+    rfl
+
+/-- [UPSTREAM] The category of relations is the Kleisli category of the
+powerset monad. -/
+def relCatEquivKleisli : RelCat.{u} ≌ KleisliCat Set :=
+  CategoryTheory.Equivalence.mk relCatToKleisli kleisliToRelCat
+  (NatIso.ofComponents (fun X => Iso.refl X) (by
+    intro X Y f
+    apply RelCat.Hom.ext
+    ext ⟨x, y⟩
+    simp only [relCatToKleisli, kleisliToRelCat, Functor.id_map,
+      Functor.comp_map, Iso.refl_hom, RelCat.Hom.rel_comp, RelCat.Hom.rel_id]
+    constructor
+    · rintro ⟨b, hb, he⟩
+      obtain rfl : b = y := he
+      exact ⟨x, rfl, hb⟩
+    · rintro ⟨b, he, hb⟩
+      obtain rfl : x = b := he
+      exact ⟨y, hb, rfl⟩))
+  (NatIso.ofComponents (fun X => Iso.refl X) (by
+    intro X Y f
+    funext x
+    ext y
+    simp only [relCatToKleisli, kleisliToRelCat, Functor.id_map,
+      Functor.comp_map, Iso.refl_hom, KleisliCat.comp_def, KleisliCat.id_def,
+      Set.bind_def, Set.mem_iUnion, Set.mem_setOf_eq, exists_prop]
+    constructor
+    · rintro ⟨i, hi, rfl⟩
+      exact ⟨x, rfl, hi⟩
+    · rintro ⟨i, hi, hyf⟩
+      obtain rfl : i = x := hi
+      exact ⟨y, hyf, rfl⟩))
+
+end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -14,7 +14,9 @@ DRT, DPL, File Change Semantics, PLA, CDRT, and BUS instantiate.
 clauses (Def. 1.4.4), and [groenendijk-stokhof-1991]'s DPL relations all
 arrive at this structure; [muskens-1996] parametrizes it over the state
 type. The set-transformer face, and the bridge identifying this algebra
-with its distributive fragment, live in `ContextChange.lean`.
+with its distributive fragment, live in `ContextChange.lean`; the
+canonical account of the pair — Kleisli arrows of the powerset monad
+inside their suplattice completion — is certified in `Kleisli.lean`.
 
 ## Main definitions
 


### PR DESCRIPTION
Canonicalizes the relational/set-transformer pair (per discussion: the pair stays, the bespoke bridge vocabulary goes). New `Kleisli.lean`:
- `dseq_eq_kleisliComp`, `test_top_eq_pure`, `lift_eq_bind`: an update is a Kleisli arrow of the powerset monad, sequencing is Kleisli composition, `lift` is `bind` — [charlow-2014]'s monadic reading as theorems (T10).
- `isDistributive_iff_map_sSup` + `liftEquiv : Update S ≃ sSupHom (Set S) (Set S)`: the relational algebra is exactly the completely-join-preserving fragment of the transformer algebra, with `liftEquiv_dseq` sending sequencing to composition — `IsDistributive`/`lower` become mathlib vocabulary.
- `relCatEquivKleisli : RelCat ≌ KleisliCat Set` (T9) — [UPSTREAM] candidate, absent from mathlib. With `Ctx.collapse` landing in `RelCat`, the based tower now reads `Ctx ⥤ RelCat ≌ KleisliCat Set ↪ suplattice endomaps`, every arrow canonical.
Cross-reference pointers added to `Update.lean`/`ContextChange.lean`.