### PR TITLE
refactor(Semantics/Dynamic): cull the InfoStateOf alias

### DIFF
--- a/Linglib/Semantics/Dynamic/PartialTransformer.lean
+++ b/Linglib/Semantics/Dynamic/PartialTransformer.lean
@@ -8,7 +8,7 @@ import Linglib.Semantics.Presupposition.Context
 Heim's context change potentials are *partial* functions on contexts: the
 domain condition IS the presupposition ([heim-1983]'s "c admits φ",
 [karttunen-1974]'s "c satisfies-the-presuppositions-of φ").
-`PartialCCP P := InfoStateOf P →. InfoStateOf P` grounds this in mathlib's
+`PartialCCP P := Set P →. Set P` grounds this in mathlib's
 `PFun`: `Part.Dom` is admittance, and the satisfaction law for conjunction —
 "c admits φ∧ψ iff c admits φ and c[φ] admits ψ" — is the domain condition
 of partial-function composition, true by construction (`admits_pseq`).
@@ -41,7 +41,7 @@ open Semantics.Presupposition
 /-- A partial context change potential: a partial function on information
     states. The domain condition is the presupposition; `Part.Dom` is
     [heim-1983]'s admittance. -/
-abbrev PartialCCP (P : Type*) := InfoStateOf P →. InfoStateOf P
+abbrev PartialCCP (P : Type*) := Set P →. Set P
 
 namespace PartialCCP
 
@@ -49,12 +49,12 @@ variable {P W : Type*}
 
 /-- `u.admits s`: the update is defined at `s` ([heim-1983]'s "s admits u",
     [karttunen-1974]'s satisfaction). This is `Part.Dom`. -/
-def admits (u : PartialCCP P) (s : InfoStateOf P) : Prop := (u s).Dom
+def admits (u : PartialCCP P) (s : Set P) : Prop := (u s).Dom
 
 /-- Total CCPs are partial CCPs with trivial presupposition. -/
 def ofCCP (φ : CCP P) : PartialCCP P := λ s => Part.some (φ s)
 
-@[simp] theorem admits_ofCCP (φ : CCP P) (s : InfoStateOf P) :
+@[simp] theorem admits_ofCCP (φ : CCP P) (s : Set P) :
     (ofCCP φ).admits s := trivial
 
 /-- The Heimian update of a static partial proposition: defined iff the
@@ -69,7 +69,7 @@ def ofCCP (φ : CCP P) : PartialCCP P := λ s => Part.some (φ s)
 def ofPartialProp (p : PartialProp W) : PartialCCP W :=
   λ s => ⟨Context.presupSatisfied s p, λ _ => { w ∈ s | p.assertion w }⟩
 
-@[simp] theorem ofPartialProp_get (p : PartialProp W) (s : InfoStateOf W)
+@[simp] theorem ofPartialProp_get (p : PartialProp W) (s : Set W)
     (h : ((ofPartialProp p) s).Dom) :
     ((ofPartialProp p) s).get h = { w ∈ s | p.assertion w } := rfl
 
@@ -99,31 +99,31 @@ def pdisj (φ ψ : PartialCCP P) : PartialCCP P :=
 /-- **The Karttunen satisfaction law** ([karttunen-1974]), by construction:
     `s` admits `φ ∧ ψ` iff `s` admits `φ` and `s[φ]` admits `ψ`. The
     statement is the domain condition of `Part.bind`. -/
-theorem admits_pseq (φ ψ : PartialCCP P) (s : InfoStateOf P) :
+theorem admits_pseq (φ ψ : PartialCCP P) (s : Set P) :
     (pseq φ ψ).admits s ↔ ∃ h : φ.admits s, ψ.admits ((φ s).get h) :=
   Iff.rfl
 
 /-- The satisfaction law, with admittance of the first conjunct given. -/
-theorem admits_pseq_iff (φ ψ : PartialCCP P) (s : InfoStateOf P)
+theorem admits_pseq_iff (φ ψ : PartialCCP P) (s : Set P)
     (h : φ.admits s) :
     (pseq φ ψ).admits s ↔ ψ.admits ((φ s).get h) :=
   ⟨λ ⟨_, hb⟩ => hb, λ hb => ⟨h, hb⟩⟩
 
 /-- Negation projects: `s` admits `¬φ` iff `s` admits `φ`. -/
-@[simp] theorem admits_pneg (φ : PartialCCP P) (s : InfoStateOf P) :
+@[simp] theorem admits_pneg (φ : PartialCCP P) (s : Set P) :
     (pneg φ).admits s ↔ φ.admits s :=
   Iff.rfl
 
 /-- Conditional admittance: `s` admits `if φ, ψ` iff `s` admits `φ` and
     `s[φ]` admits `ψ` — the same condition as conjunction
     ([karttunen-1974]). -/
-theorem admits_pcond (φ ψ : PartialCCP P) (s : InfoStateOf P) :
+theorem admits_pcond (φ ψ : PartialCCP P) (s : Set P) :
     (pcond φ ψ).admits s ↔ ∃ h : φ.admits s, ψ.admits ((φ s).get h) :=
   Iff.rfl
 
 /-- Disjunction admittance: `s` admits `φ ∨ ψ` iff `s` admits `φ` and the
     ¬φ local context `s \ s[φ]` admits `ψ`. -/
-theorem admits_pdisj (φ ψ : PartialCCP P) (s : InfoStateOf P) :
+theorem admits_pdisj (φ ψ : PartialCCP P) (s : Set P) :
     (pdisj φ ψ).admits s ↔
       ∃ h : φ.admits s, ψ.admits (s \ (φ s).get h) :=
   Iff.rfl
@@ -134,7 +134,7 @@ theorem admits_pdisj (φ ψ : PartialCCP P) (s : InfoStateOf P) :
     `Context.presupSatisfied`, by construction: the dynamic definedness
     condition and the satisfaction-theoretic context condition are one
     notion. -/
-theorem admits_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :
+theorem admits_ofPartialProp (p : PartialProp W) (s : Set W) :
     (ofPartialProp p).admits s ↔ Context.presupSatisfied s p :=
   Iff.rfl
 
@@ -147,7 +147,7 @@ composition law of partial updates, not a stipulation. -/
 
 /-- Dynamic conjunction admits `s` iff `s` satisfies `andFilter`'s
     presupposition pointwise. -/
-theorem admits_pseq_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
+theorem admits_pseq_ofPartialProp (p q : PartialProp W) (s : Set W) :
     (pseq (ofPartialProp p) (ofPartialProp q)).admits s ↔
       ∀ w ∈ s, (PartialProp.andFilter p q).presup w :=
   ⟨λ ⟨hp, hq⟩ _ hw => ⟨hp hw, λ ha => hq ⟨hw, ha⟩⟩,
@@ -155,7 +155,7 @@ theorem admits_pseq_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
 
 /-- Dynamic conditional admits `s` iff `s` satisfies `impFilter`'s
     presupposition pointwise. -/
-theorem admits_pcond_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
+theorem admits_pcond_ofPartialProp (p q : PartialProp W) (s : Set W) :
     (pcond (ofPartialProp p) (ofPartialProp q)).admits s ↔
       ∀ w ∈ s, (PartialProp.impFilter p q).presup w :=
   admits_pseq_ofPartialProp p q s
@@ -163,7 +163,7 @@ theorem admits_pcond_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
 /-- Dynamic disjunction admits `s` iff `s` satisfies `orFilter`'s
     presupposition pointwise: the ¬φ local context is Karttunen's
     negative-antecedent filtering. -/
-theorem admits_pdisj_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
+theorem admits_pdisj_ofPartialProp (p q : PartialProp W) (s : Set W) :
     (pdisj (ofPartialProp p) (ofPartialProp q)).admits s ↔
       ∀ w ∈ s, (PartialProp.orFilter p q).presup w :=
   ⟨λ ⟨hp, hq⟩ _ hw => ⟨hp hw, λ hna => hq ⟨hw, λ hc => hna hc.2⟩⟩,
@@ -171,7 +171,7 @@ theorem admits_pdisj_ofPartialProp (p q : PartialProp W) (s : InfoStateOf W) :
      λ w hw => (h w hw.1).2 (λ ha => hw.2 ⟨hw.1, ha⟩)⟩⟩
 
 /-- Negation projects the atomic presupposition unchanged. -/
-theorem admits_pneg_ofPartialProp (p : PartialProp W) (s : InfoStateOf W) :
+theorem admits_pneg_ofPartialProp (p : PartialProp W) (s : Set W) :
     (pneg (ofPartialProp p)).admits s ↔ ∀ w ∈ s, p.presup w :=
   Iff.rfl
 

--- a/Linglib/Semantics/Dynamic/Situation.lean
+++ b/Linglib/Semantics/Dynamic/Situation.lean
@@ -76,7 +76,7 @@ def dynRelationOn (c : SitContext W Time) : SitContext W Time :=
   { gs ∈ c | R (proj₁ gs) (proj₂ gs) }
 
 theorem dynRelationOn_isEliminative :
-    IsEliminative (P := SitEntry W Time) (dynRelationOn proj₁ proj₂ R) :=
+    IsEliminative (S := SitEntry W Time) (dynRelationOn proj₁ proj₂ R) :=
   fun _ _ h => h.1
 
 /-- Idempotence of any `dynRelationOn` filter. -/

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -13,8 +13,8 @@ An *information state* relative to a *base* `X` — a finite set of live
 discourse referents — is an `X`-supported set of possibilities
 (`Possibility.lean`). The base is the "context as storage" dimension of
 dynamic meaning: finer than a proposition, coarser than syntax
-([kamp-vangenabith-reyle-2011]'s Partee-marbles argument). The unbased
-level-0 notion is `InfoStateOf P` (`Update.lean`); the transitions
+([kamp-vangenabith-reyle-2011]'s Partee-marbles argument). Unbased level-0 states
+are plain sets of possibilities (`Update.lean`); the transitions
 acting on states live in `Transition.lean`.
 
 ## Main definitions

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -32,8 +32,8 @@ powerset monad, transformers their suplattice completion.
 - `Update.IsTest`: DPL's tests — updates that never change the state.
 - `valid`, `entails` (`⊨`), `sEntails` (`⊨ₛ`): truth and
   [groenendijk-stokhof-1991] §3.5's two entailment notions.
-- `InfoStateOf P`, `CCP P`: states as sets, meanings as set
-  transformers, a monoid under `CCP.seq`; `CCP.neg`, `disj`,
+- `CCP P`: meanings as transformers of information states (plain
+  `Set P`), a monoid under `CCP.seq`; `CCP.neg`, `disj`,
   `CCP.guard` and the whole-state tests `might`, `must`, `negTest`.
 - `IsEliminative`, `IsExpansive`, `IsTest`, `IsDistributive`: the
   classification of CCPs. N.B. the CCP-level `IsTest` (pass-or-`∅`,
@@ -328,21 +328,11 @@ end Theorems
 
 
 /--
-An InfoState is a set of possibilities.
-
-Different theories instantiate `P` differently:
-- PLA: Assignment × WitnessSeq
-- DRT: Assignment
-- Intensional: World × Assignment
--/
-abbrev InfoStateOf (P : Type*) := Set P
-
-/--
 A Context Change Potential (CCP) is a function from states to states.
 
 This is the semantic type for dynamic meanings.
 -/
-abbrev CCP (P : Type*) := InfoStateOf P → InfoStateOf P
+abbrev CCP (P : Type*) := Set P → Set P
 
 namespace CCP
 
@@ -392,15 +382,15 @@ open Classical in
 /-- Whole-state test: pass the state through iff it satisfies `C` — the
 shared shape of `negTest`, `might`, `must`, and `impl`, the
 non-distributive tests that inspect the entire input state. -/
-noncomputable def guard (C : InfoStateOf P → Prop) : CCP P :=
+noncomputable def guard (C : Set P → Prop) : CCP P :=
   λ s => if C s then s else ∅
 
 /-- A guard whose condition holds passes the state through. -/
-@[simp] theorem guard_pos {C : InfoStateOf P → Prop} {s} (h : C s) : guard C s = s :=
+@[simp] theorem guard_pos {C : Set P → Prop} {s} (h : C s) : guard C s = s :=
   if_pos h
 
 /-- A guard whose condition fails crashes to `∅`. -/
-@[simp] theorem guard_neg {C : InfoStateOf P → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
+@[simp] theorem guard_neg {C : Set P → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
   if_neg h
 
 /--
@@ -452,7 +442,7 @@ def disj (φ ψ : CCP P) : CCP P := neg (seq (neg φ) (neg ψ))
 
 /-- Dynamic entailment: φ entails ψ iff ψ adds no information after φ. -/
 def entails (φ ψ : CCP P) : Prop :=
-  ∀ s : InfoStateOf P, (φ s).Nonempty → ψ (φ s) = φ s
+  ∀ s : Set P, (φ s).Nonempty → ψ (φ s) = φ s
 
 /-- Entailment is reflexive -/
 theorem entails_id (φ : CCP P) : entails φ id := by
@@ -563,13 +553,13 @@ Support relation: s supports ψ if all possibilities in s satisfy ψ.
 
 This is the fundamental entailment relation of dynamic semantics.
 -/
-def supportOf (sat : P → φ → Prop) (s : InfoStateOf P) (ψ : φ) : Prop :=
+def supportOf (sat : P → φ → Prop) (s : Set P) (ψ : φ) : Prop :=
   ∀ p ∈ s, sat p ψ
 
 /--
 Content of a formula: all possibilities satisfying it.
 -/
-def contentOf (sat : P → φ → Prop) (ψ : φ) : InfoStateOf P :=
+def contentOf (sat : P → φ → Prop) (ψ : φ) : Set P :=
   { p | sat p ψ }
 
 /--
@@ -577,7 +567,7 @@ Galois connection: s ⊆ content ψ ↔ s supports ψ
 
 This is the fundamental duality of dynamic semantics.
 -/
-theorem support_iff_subset_content (sat : P → φ → Prop) (s : InfoStateOf P) (ψ : φ) :
+theorem support_iff_subset_content (sat : P → φ → Prop) (s : Set P) (ψ : φ) :
     supportOf sat s ψ ↔ s ⊆ contentOf sat ψ := by
   constructor
   · intro h p hp
@@ -588,7 +578,7 @@ theorem support_iff_subset_content (sat : P → φ → Prop) (s : InfoStateOf P)
 /--
 Support is downward closed: smaller states support more.
 -/
-theorem support_mono (sat : P → φ → Prop) (s t : InfoStateOf P) (ψ : φ)
+theorem support_mono (sat : P → φ → Prop) (s t : Set P) (ψ : φ)
     (h : t ⊆ s) (hs : supportOf sat s ψ) : supportOf sat t ψ :=
   λ p hp => hs p (h hp)
 
@@ -638,19 +628,19 @@ theorem updateFromSat_eliminative {P φ : Type*} (sat : P → φ → Prop) (ψ :
 
 /-- Standard update membership -/
 theorem mem_updateFromSat {P φ : Type*} (sat : P → φ → Prop) (ψ : φ)
-    (s : InfoStateOf P) (p : P) :
+    (s : Set P) (p : P) :
     p ∈ updateFromSat sat ψ s ↔ p ∈ s ∧ sat p ψ := Iff.rfl
 
 /-- Update equals intersection with content -/
 theorem updateFromSat_eq_inter_content {P φ : Type*} (sat : P → φ → Prop)
-    (ψ : φ) (s : InfoStateOf P) :
+    (ψ : φ) (s : Set P) :
     updateFromSat sat ψ s = s ∩ contentOf sat ψ := by
   ext p
   simp only [mem_updateFromSat, contentOf, Set.mem_inter_iff, Set.mem_setOf_eq]
 
 /-- Support-Update equivalence -/
 theorem support_iff_update_eq {P φ : Type*} (sat : P → φ → Prop)
-    (ψ : φ) (s : InfoStateOf P) :
+    (ψ : φ) (s : Set P) :
     supportOf sat s ψ ↔ updateFromSat sat ψ s = s := by
   constructor
   · intro h
@@ -669,7 +659,7 @@ Dynamic entailment: φ dynamically entails ψ if updating with φ
 always yields a state that supports ψ.
 -/
 def dynamicEntailsOf {P φ : Type*} (sat : P → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
-  ∀ s : InfoStateOf P, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
+  ∀ s : Set P, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
 
 /-- Dynamic entailment is reflexive -/
 theorem dynamicEntails_refl {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -14,8 +14,11 @@ Dynamic meanings in their two canonical faces. The *relational* face
 [heim-1982]'s file change potentials, [kamp-reyle-1993]'s verification
 clauses, parametrized over the state type by [muskens-1996]): meanings
 relate input states to output states pointwise. The *set-transformer*
-face (`CCP P = Set P → Set P`, [heim-1983], [veltman-1996]): meanings
-act on information states as wholes. `lift` (the relational image,
+face (`CCP S = Set S → Set S`, [heim-1983], [veltman-1996]): meanings
+act on information states — plain sets — as wholes. The literature says
+"state" at both levels: DPL's states are the points `S`, Veltman's are
+the sets `Set S`, and `lift` identifies the relational face's states
+with the transformer face's points — one carrier, two vocabularies. `lift` (the relational image,
 [muskens-van-benthem-visser-2011]'s strongest postcondition) and `lower`
 identify the relational algebra with the *distributive* transformers —
 those that process elements independently — and what the transformer
@@ -32,8 +35,8 @@ powerset monad, transformers their suplattice completion.
 - `Update.IsTest`: DPL's tests — updates that never change the state.
 - `valid`, `entails` (`⊨`), `sEntails` (`⊨ₛ`): truth and
   [groenendijk-stokhof-1991] §3.5's two entailment notions.
-- `CCP P`: meanings as transformers of information states (plain
-  `Set P`), a monoid under `CCP.seq`; `CCP.neg`, `disj`,
+- `CCP S`: meanings as transformers of information states (plain
+  `Set S`), a monoid under `CCP.seq`; `CCP.neg`, `disj`,
   `CCP.guard` and the whole-state tests `might`, `must`, `negTest`.
 - `IsEliminative`, `IsExpansive`, `IsTest`, `IsDistributive`: the
   classification of CCPs. N.B. the CCP-level `IsTest` (pass-or-`∅`,
@@ -332,32 +335,32 @@ A Context Change Potential (CCP) is a function from states to states.
 
 This is the semantic type for dynamic meanings.
 -/
-abbrev CCP (P : Type*) := Set P → Set P
+abbrev CCP (S : Type*) := Set S → Set S
 
 namespace CCP
 
-variable {P : Type*}
+variable {S : Type*}
 
 /-- Identity CCP: leaves state unchanged -/
-def id : CCP P := λ s => s
+def id : CCP S := λ s => s
 
 /-- Absurd CCP: yields empty state -/
-def absurd : CCP P := λ _ => ∅
+def absurd : CCP S := λ _ => ∅
 
 /-- Sequential composition of CCPs -/
-def seq (u v : CCP P) : CCP P := λ s => v (u s)
+def seq (u v : CCP S) : CCP S := λ s => v (u s)
 
 scoped infixl:70 " ;; " => seq
 
-theorem seq_assoc (u v w : CCP P) : (u ;; v) ;; w = u ;; (v ;; w) := rfl
-theorem id_seq (u : CCP P) : id ;; u = u := rfl
-theorem seq_id (u : CCP P) : u ;; id = u := rfl
+theorem seq_assoc (u v w : CCP S) : (u ;; v) ;; w = u ;; (v ;; w) := rfl
+theorem id_seq (u : CCP S) : id ;; u = u := rfl
+theorem seq_id (u : CCP S) : u ;; id = u := rfl
 
 /-- CCPs form a monoid under sequential composition. Scoped because
-`CCP P` is an abbreviation for `Set P → Set P`: a global instance would
+`CCP S` is an abbreviation for `Set S → Set S`: a global instance would
 attach `*`/`1` to a bare function type for every importer. Activate with
 `open scoped DynamicSemantics.CCP`. -/
-scoped instance : Monoid (CCP P) where
+scoped instance : Monoid (CCP S) where
   mul := seq
   one := id
   mul_assoc _ _ _ := rfl
@@ -365,7 +368,7 @@ scoped instance : Monoid (CCP P) where
   mul_one _ := rfl
 
 /-- seq_absurd: anything followed by absurd is absurd -/
-theorem seq_absurd (u : CCP P) : u ;; absurd = absurd := rfl
+theorem seq_absurd (u : CCP S) : u ;; absurd = absurd := rfl
 
 /--
 Dynamic negation: complement within the input state.
@@ -375,22 +378,22 @@ This is the standard dynamic negation of [heim-1982], [veltman-1996]:
 Does not validate DNE on non-eliminative updates. For the whole-state
 consistency test (must-not), see `negTest`.
 -/
-def neg (φ : CCP P) : CCP P :=
+def neg (φ : CCP S) : CCP S :=
   λ s => s \ φ s
 
 open Classical in
 /-- Whole-state test: pass the state through iff it satisfies `C` — the
 shared shape of `negTest`, `might`, `must`, and `impl`, the
 non-distributive tests that inspect the entire input state. -/
-noncomputable def guard (C : Set P → Prop) : CCP P :=
+noncomputable def guard (C : Set S → Prop) : CCP S :=
   λ s => if C s then s else ∅
 
 /-- A guard whose condition holds passes the state through. -/
-@[simp] theorem guard_pos {C : Set P → Prop} {s} (h : C s) : guard C s = s :=
+@[simp] theorem guard_pos {C : Set S → Prop} {s} (h : C s) : guard C s = s :=
   if_pos h
 
 /-- A guard whose condition fails crashes to `∅`. -/
-@[simp] theorem guard_neg {C : Set P → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
+@[simp] theorem guard_neg {C : Set S → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
   if_neg h
 
 /--
@@ -401,7 +404,7 @@ A whole-state consistency test ("must-not"), NOT [heim-1982]'s or
 coincide only when `φ s = ∅` or `φ s = s` — see
 `Studies/Beaver2001/ABLE.lean` for the proven divergence.
 -/
-noncomputable def negTest (φ : CCP P) : CCP P :=
+noncomputable def negTest (φ : CCP S) : CCP S :=
   guard (λ s => ¬ (φ s).Nonempty)
 
 /--
@@ -409,7 +412,7 @@ Compatibility test ("might"): passes iff φ yields a nonempty result.
 
 might(φ)(s) = s if φ(s) ≠ ∅, else ∅
 -/
-noncomputable def might (φ : CCP P) : CCP P :=
+noncomputable def might (φ : CCP S) : CCP S :=
   guard (λ s => (φ s).Nonempty)
 
 open Classical in
@@ -418,7 +421,7 @@ Full support test ("must"): passes iff φ returns input unchanged.
 
 must(φ)(s) = s if φ(s) = s, else ∅
 -/
-noncomputable def must (φ : CCP P) : CCP P :=
+noncomputable def must (φ : CCP S) : CCP S :=
   guard (λ s => φ s = s)
 
 open Classical in
@@ -427,7 +430,7 @@ Dynamic implication test: passes iff output of φ is preserved by ψ.
 
 impl(φ,ψ)(s) = s if φ(s) ⊆ ψ(φ(s)), else ∅
 -/
-noncomputable def impl (φ ψ : CCP P) : CCP P :=
+noncomputable def impl (φ ψ : CCP S) : CCP S :=
   guard (λ s => φ s ⊆ ψ (φ s))
 
 /--
@@ -438,19 +441,19 @@ disjunct is evaluated in the input updated with the negation of the
 first — the local-context clause of the satisfaction literature
 ([beaver-2001]; [heim-1983] itself gives CCPs only for *not/and/if*).
 -/
-def disj (φ ψ : CCP P) : CCP P := neg (seq (neg φ) (neg ψ))
+def disj (φ ψ : CCP S) : CCP S := neg (seq (neg φ) (neg ψ))
 
 /-- Dynamic entailment: φ entails ψ iff ψ adds no information after φ. -/
-def entails (φ ψ : CCP P) : Prop :=
-  ∀ s : Set P, (φ s).Nonempty → ψ (φ s) = φ s
+def entails (φ ψ : CCP S) : Prop :=
+  ∀ s : Set S, (φ s).Nonempty → ψ (φ s) = φ s
 
 /-- Entailment is reflexive -/
-theorem entails_id (φ : CCP P) : entails φ id := by
+theorem entails_id (φ : CCP S) : entails φ id := by
   intro s _; rfl
 
 end CCP
 
-variable {P : Type*}
+variable {S : Type*}
 
 /--
 An update is eliminative if it never adds possibilities.
@@ -458,15 +461,15 @@ An update is eliminative if it never adds possibilities.
 This is the fundamental property of dynamic semantics:
 information only grows (possibilities only decrease).
 -/
-def IsEliminative (u : CCP P) : Prop :=
+def IsEliminative (u : CCP S) : Prop :=
   ∀ s, u s ⊆ s
 
 /-- Identity is eliminative -/
-theorem eliminative_id : IsEliminative (CCP.id : CCP P) :=
+theorem eliminative_id : IsEliminative (CCP.id : CCP S) :=
   λ _ => Set.Subset.rfl
 
 /-- Sequential composition preserves eliminativity -/
-theorem eliminative_seq (u v : CCP P)
+theorem eliminative_seq (u v : CCP S)
     (hu : IsEliminative u) (hv : IsEliminative v) :
     IsEliminative (u.seq v) := λ s _ hp =>
   hu s (hv (u s) hp)
@@ -480,21 +483,21 @@ modal horizon expansion ([kirkpatrick-2024]), and accommodation.
 These are the dual of eliminative operations: where eliminative updates
 can only shrink the state, expansive updates can only grow it.
 -/
-def IsExpansive (u : CCP P) : Prop :=
+def IsExpansive (u : CCP S) : Prop :=
   ∀ s, s ⊆ u s
 
 /-- Identity is expansive -/
-theorem expansive_id : IsExpansive (CCP.id : CCP P) :=
+theorem expansive_id : IsExpansive (CCP.id : CCP S) :=
   λ _ => Set.Subset.rfl
 
 /-- Sequential composition preserves expansiveness -/
-theorem expansive_seq (u v : CCP P)
+theorem expansive_seq (u v : CCP S)
     (hu : IsExpansive u) (hv : IsExpansive v) :
     IsExpansive (u.seq v) := λ s _ hp =>
   hv (u s) (hu s hp)
 
 /-- A CCP that is both eliminative and expansive is the identity on every input. -/
-theorem eliminative_expansive_id (u : CCP P)
+theorem eliminative_expansive_id (u : CCP S)
     (he : IsEliminative u) (hx : IsExpansive u) :
     ∀ s, u s = s :=
   λ s => Set.Subset.antisymm (he s) (hx s)
@@ -503,37 +506,37 @@ theorem eliminative_expansive_id (u : CCP P)
 [veltman-1996]'s tests: `might`, `must`, presupposition checks. Not the
 counterpart of the relational `Update.IsTest`: lifting a relational
 test gives an eliminative filter, not a pass-or-`∅` test. -/
-def IsTest (u : CCP P) : Prop :=
+def IsTest (u : CCP S) : Prop :=
   ∀ s, u s = s ∨ u s = ∅
 
 /-- Tests are eliminative -/
-theorem test_eliminative (u : CCP P) (h : IsTest u) :
+theorem test_eliminative (u : CCP S) (h : IsTest u) :
     IsEliminative u := λ s p hp => by
   cases h s with
   | inl heq => rw [heq] at hp; exact hp
   | inr hemp => rw [hemp] at hp; exact False.elim hp
 
 open Classical in
-theorem CCP.guard_isTest (C : Set P → Prop) : IsTest (CCP.guard C) := by
+theorem CCP.guard_isTest (C : Set S → Prop) : IsTest (CCP.guard C) := by
   intro s; simp only [CCP.guard]; split <;> simp
 
-theorem CCP.negTest_isTest (φ : CCP P) : IsTest (CCP.negTest φ) :=
+theorem CCP.negTest_isTest (φ : CCP S) : IsTest (CCP.negTest φ) :=
   CCP.guard_isTest _
 
-theorem CCP.might_isTest (φ : CCP P) : IsTest (CCP.might φ) :=
+theorem CCP.might_isTest (φ : CCP S) : IsTest (CCP.might φ) :=
   CCP.guard_isTest _
 
-theorem CCP.must_isTest (φ : CCP P) : IsTest (CCP.must φ) :=
+theorem CCP.must_isTest (φ : CCP S) : IsTest (CCP.must φ) :=
   CCP.guard_isTest _
 
-theorem CCP.impl_isTest (φ ψ : CCP P) : IsTest (CCP.impl φ ψ) :=
+theorem CCP.impl_isTest (φ ψ : CCP S) : IsTest (CCP.impl φ ψ) :=
   CCP.guard_isTest _
 
 open Classical in
 /-- Duality for the test pair: might φ = must-not (must-not φ). The
 analogous identity fails for set-difference `neg` (DNE holds instead
 on eliminative updates). -/
-theorem CCP.might_eq_negTest_negTest (φ : CCP P) :
+theorem CCP.might_eq_negTest_negTest (φ : CCP S) :
     CCP.might φ = CCP.negTest (CCP.negTest φ) := by
   funext s
   by_cases h : (φ s).Nonempty
@@ -546,20 +549,20 @@ theorem CCP.might_eq_negTest_negTest (φ : CCP P) :
 
 section GaloisContent
 
-variable {P φ : Type*}
+variable {S φ : Type*}
 
 /--
 Support relation: s supports ψ if all possibilities in s satisfy ψ.
 
 This is the fundamental entailment relation of dynamic semantics.
 -/
-def supportOf (sat : P → φ → Prop) (s : Set P) (ψ : φ) : Prop :=
+def supportOf (sat : S → φ → Prop) (s : Set S) (ψ : φ) : Prop :=
   ∀ p ∈ s, sat p ψ
 
 /--
 Content of a formula: all possibilities satisfying it.
 -/
-def contentOf (sat : P → φ → Prop) (ψ : φ) : Set P :=
+def contentOf (sat : S → φ → Prop) (ψ : φ) : Set S :=
   { p | sat p ψ }
 
 /--
@@ -567,7 +570,7 @@ Galois connection: s ⊆ content ψ ↔ s supports ψ
 
 This is the fundamental duality of dynamic semantics.
 -/
-theorem support_iff_subset_content (sat : P → φ → Prop) (s : Set P) (ψ : φ) :
+theorem support_iff_subset_content (sat : S → φ → Prop) (s : Set S) (ψ : φ) :
     supportOf sat s ψ ↔ s ⊆ contentOf sat ψ := by
   constructor
   · intro h p hp
@@ -578,20 +581,20 @@ theorem support_iff_subset_content (sat : P → φ → Prop) (s : Set P) (ψ : �
 /--
 Support is downward closed: smaller states support more.
 -/
-theorem support_mono (sat : P → φ → Prop) (s t : Set P) (ψ : φ)
+theorem support_mono (sat : S → φ → Prop) (s t : Set S) (ψ : φ)
     (h : t ⊆ s) (hs : supportOf sat s ψ) : supportOf sat t ψ :=
   λ p hp => hs p (h hp)
 
 /--
 Empty state supports everything (vacuously).
 -/
-theorem empty_supports (sat : P → φ → Prop) (ψ : φ) :
+theorem empty_supports (sat : S → φ → Prop) (ψ : φ) :
     supportOf sat ∅ ψ := λ _ hp => False.elim hp
 
 /--
 Content is antitone in entailment.
 -/
-theorem content_mono (sat : P → φ → Prop) (ψ₁ ψ₂ : φ)
+theorem content_mono (sat : S → φ → Prop) (ψ₁ ψ₂ : φ)
     (h : ∀ p, sat p ψ₁ → sat p ψ₂) :
     contentOf sat ψ₁ ⊆ contentOf sat ψ₂ :=
   λ _ hp => h _ hp
@@ -603,13 +606,13 @@ end GaloisContent
 
 /-- Filtering a set by a predicate is monotone. This is the shared foundation
     for monotonicity of `updateFromSat`, `atom`, `pred1`, `pred2`, etc. -/
-theorem sep_monotone (pred : P → Prop) :
-    Monotone (λ s : Set P => { p ∈ s | pred p }) :=
+theorem sep_monotone (pred : S → Prop) :
+    Monotone (λ s : Set S => { p ∈ s | pred p }) :=
   λ _ _ h _ hp => ⟨h hp.1, hp.2⟩
 
 /-- Filtering a set by a predicate is eliminative. -/
-theorem sep_eliminative (pred : P → Prop) :
-    IsEliminative (λ s : Set P => { p ∈ s | pred p }) :=
+theorem sep_eliminative (pred : S → Prop) :
+    IsEliminative (λ s : Set S => { p ∈ s | pred p }) :=
   λ _ _ hp => hp.1
 
 
@@ -618,29 +621,29 @@ The standard update construction: filter by satisfaction.
 
 This is how PLA, DRT, DPL all define updates.
 -/
-def updateFromSat {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) : CCP P :=
+def updateFromSat {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) : CCP S :=
   λ s => { p ∈ s | sat p ψ }
 
 /-- Standard updates are eliminative -/
-theorem updateFromSat_eliminative {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
+theorem updateFromSat_eliminative {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
     IsEliminative (updateFromSat sat ψ) :=
   sep_eliminative _
 
 /-- Standard update membership -/
-theorem mem_updateFromSat {P φ : Type*} (sat : P → φ → Prop) (ψ : φ)
-    (s : Set P) (p : P) :
+theorem mem_updateFromSat {S φ : Type*} (sat : S → φ → Prop) (ψ : φ)
+    (s : Set S) (p : S) :
     p ∈ updateFromSat sat ψ s ↔ p ∈ s ∧ sat p ψ := Iff.rfl
 
 /-- Update equals intersection with content -/
-theorem updateFromSat_eq_inter_content {P φ : Type*} (sat : P → φ → Prop)
-    (ψ : φ) (s : Set P) :
+theorem updateFromSat_eq_inter_content {S φ : Type*} (sat : S → φ → Prop)
+    (ψ : φ) (s : Set S) :
     updateFromSat sat ψ s = s ∩ contentOf sat ψ := by
   ext p
   simp only [mem_updateFromSat, contentOf, Set.mem_inter_iff, Set.mem_setOf_eq]
 
 /-- Support-Update equivalence -/
-theorem support_iff_update_eq {P φ : Type*} (sat : P → φ → Prop)
-    (ψ : φ) (s : Set P) :
+theorem support_iff_update_eq {S φ : Type*} (sat : S → φ → Prop)
+    (ψ : φ) (s : Set S) :
     supportOf sat s ψ ↔ updateFromSat sat ψ s = s := by
   constructor
   · intro h
@@ -658,16 +661,16 @@ theorem support_iff_update_eq {P φ : Type*} (sat : P → φ → Prop)
 Dynamic entailment: φ dynamically entails ψ if updating with φ
 always yields a state that supports ψ.
 -/
-def dynamicEntailsOf {P φ : Type*} (sat : P → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
-  ∀ s : Set P, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
+def dynamicEntailsOf {S φ : Type*} (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
+  ∀ s : Set S, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
 
 /-- Dynamic entailment is reflexive -/
-theorem dynamicEntails_refl {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
+theorem dynamicEntails_refl {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
     dynamicEntailsOf sat ψ ψ :=
   λ _ _ hp => hp.2
 
 /-- Dynamic entailment is transitive -/
-theorem dynamicEntails_trans {P φ : Type*} (sat : P → φ → Prop)
+theorem dynamicEntails_trans {S φ : Type*} (sat : S → φ → Prop)
     (ψ₁ ψ₂ ψ₃ : φ) (h1 : dynamicEntailsOf sat ψ₁ ψ₂) (h2 : dynamicEntailsOf sat ψ₂ ψ₃) :
     dynamicEntailsOf sat ψ₁ ψ₃ :=
   fun s p hp => h2 s p ⟨hp.1, h1 s p hp⟩
@@ -678,7 +681,7 @@ theorem dynamicEntails_trans {P φ : Type*} (sat : P → φ → Prop)
 larger output states. Uses mathlib's `Monotone` (i.e., `s ≤ t → f s ≤ f t`
 where `≤` on `Set` is `⊆`).
 -/
-theorem updateFromSat_monotone {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
+theorem updateFromSat_monotone {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
     Monotone (updateFromSat sat ψ) :=
   sep_monotone _
 
@@ -687,11 +690,11 @@ theorem updateFromSat_monotone {P φ : Type*} (sat : P → φ → Prop) (ψ : φ
 
 /-- A CCP is distributive when it processes each element of the input independently:
     φ(s) = ⋃_{i∈s} φ({i}). -/
-def IsDistributive (φ : CCP P) : Prop :=
+def IsDistributive (φ : CCP S) : Prop :=
   ∀ s, φ s = {p | ∃ i ∈ s, p ∈ φ {i}}
 
 /-- `updateFromSat` is always distributive: it filters per-element. -/
-theorem updateFromSat_isDistributive {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
+theorem updateFromSat_isDistributive {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
     IsDistributive (updateFromSat sat ψ) := by
   intro s; ext p; simp only [updateFromSat, Set.mem_setOf_eq]
   constructor
@@ -701,12 +704,12 @@ theorem updateFromSat_isDistributive {P φ : Type*} (sat : P → φ → Prop) (�
 /-- `CCP.might` is not distributive: the whole-context test can pass while
     individual-element tests fail.
 
-    Witness: P = Bool, φ keeps only `true`.
+    Witness: S = Bool, φ keeps only `true`.
     `might φ {true, false} = {true, false}` (whole-context test passes),
     but per-singleton: `might φ {false} = ∅` (test fails on false-only context).
     So `false` is in the whole-context result but not the distributive union. -/
 theorem might_not_isDistributive :
-    ∃ (P : Type) (φ : CCP P), ¬IsDistributive (CCP.might φ) := by
+    ∃ (S : Type) (φ : CCP S), ¬IsDistributive (CCP.might φ) := by
   use Bool
   let φ : CCP Bool := λ s => {p ∈ s | p = true}
   use φ
@@ -837,7 +840,7 @@ theorem lift_test_isEliminative (C : Condition S) :
 /-- `updateFromSat` is the lifting of `test` applied to a satisfaction
 relation. This connects the CCP-native `updateFromSat` to the
 primary relational algebra. -/
-theorem updateFromSat_eq_lift_test {P φ : Type*} (sat : P → φ → Prop) (ψ : φ) :
+theorem updateFromSat_eq_lift_test {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
     updateFromSat sat ψ = lift (test (λ p => sat p ψ)) := by
   funext σ; ext p
   simp only [updateFromSat, lift, test, Set.mem_setOf_eq]

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -66,7 +66,7 @@ def dynSUBJ : SitContext W Time → SitContext W Time :=
 
 /-- `dynIND` is a context filter. -/
 theorem dynIND_isEliminative :
-    IsEliminative (P := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+    IsEliminative (S := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
       (dynIND v) :=
   dynRelationOn_isEliminative _ _ _
 
@@ -150,7 +150,7 @@ def Grammatical.dynOp :
 
 /-- Indicative's dynamic operator is eliminative: a context filter. -/
 theorem dynOp_indicative_isEliminative :
-    IsEliminative (P := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
+    IsEliminative (S := Assignment (WorldTimeIndex W Time) × WorldTimeIndex W Time)
       (Grammatical.indicative.dynOp history v) :=
   dynIND_isEliminative v
 

--- a/Linglib/Studies/Beaver2001/ABLE.lean
+++ b/Linglib/Studies/Beaver2001/ABLE.lean
@@ -55,7 +55,7 @@ since we don't model discourse markers.
 namespace Beaver2001.ABLE
 
 open Classical
-open DynamicSemantics (CCP InfoStateOf IsEliminative IsTest
+open DynamicSemantics (CCP IsEliminative IsTest
   updateFromSat eliminative_seq test_eliminative)
 
 variable {P : Type*}
@@ -130,7 +130,7 @@ A state σ *admits* φ iff:
 - For `might φ`: σ admits φ
 - For `∂ φ`: σ already entails φ (i.e., σ[φ] = σ)
 -/
-noncomputable def pulAdmits : Formula P → InfoStateOf P → Prop
+noncomputable def pulAdmits : Formula P → Set P → Prop
   | .pred _     => λ _ => True
   | .not φ      => λ σ => φ.pulAdmits σ
   | .and φ ψ    => λ σ => φ.pulAdmits σ ∧ ψ.pulAdmits (φ.eval σ)
@@ -151,7 +151,7 @@ theorem presup_eliminative (φ : Formula P) : IsEliminative φ.presup.eval := by
   exact test_eliminative _ (presup_isTest φ)
 
 /-- Admittance of ∂φ is equivalent to σ[φ] = σ. -/
-theorem presup_admits_iff (φ : Formula P) (σ : InfoStateOf P) :
+theorem presup_admits_iff (φ : Formula P) (σ : Set P) :
     (Formula.presup φ).pulAdmits σ ↔ φ.eval σ = σ := by
   simp only [pulAdmits]
 
@@ -164,28 +164,28 @@ theorem presup_admits_iff (φ : Formula P) (σ : InfoStateOf P) :
 If φ presupposes ψ (i.e., φ = ∂ψ AND χ), then NOT φ also
 presupposes ψ. Here we prove the component: admitting NOT φ
 requires admitting φ. -/
-theorem admits_not (φ : Formula P) (σ : InfoStateOf P) :
+theorem admits_not (φ : Formula P) (σ : Set P) :
     (Formula.not φ).pulAdmits σ ↔ φ.pulAdmits σ := by
   simp only [pulAdmits]
 
 /-- **Fact 8.1 (ii)**: Left presupposition projects through AND.
 
 Admitting AND φ ψ requires admitting φ (among other things). -/
-theorem admits_and_left (φ ψ : Formula P) (σ : InfoStateOf P) :
+theorem admits_and_left (φ ψ : Formula P) (σ : Set P) :
     (Formula.and φ ψ).pulAdmits σ → φ.pulAdmits σ := by
   intro ⟨h, _⟩; exact h
 
 /-- Admitting AND φ ψ requires that the intermediate context σ[φ]
 admits ψ. This is the structural basis for conditional presupposition
 projection (used in the proof of Fact 8.3). -/
-theorem admits_and_right (φ ψ : Formula P) (σ : InfoStateOf P) :
+theorem admits_and_right (φ ψ : Formula P) (σ : Set P) :
     (Formula.and φ ψ).pulAdmits σ → ψ.pulAdmits (φ.eval σ) := by
   intro ⟨_, h⟩; exact h
 
 /-- **Fact 8.1 (iii)**: Presupposition projects through IF...THEN.
 
 Admitting IF φ THEN ψ (= NOT(φ AND NOT ψ)) requires admitting φ. -/
-theorem admits_impl_left (φ ψ : Formula P) (σ : InfoStateOf P) :
+theorem admits_impl_left (φ ψ : Formula P) (σ : Set P) :
     (Formula.impl φ ψ).pulAdmits σ → φ.pulAdmits σ := by
   intro h; exact h.1
 
@@ -204,13 +204,13 @@ theorem might_eliminative (φ : Formula P) : IsEliminative (Formula.might φ).ev
 /-- **Fact 8.8 (1)**: Presupposition projects through MIGHT.
 
 Admitting MIGHT φ requires admitting φ. -/
-theorem admits_might (φ : Formula P) (σ : InfoStateOf P) :
+theorem admits_might (φ : Formula P) (σ : Set P) :
     (Formula.might φ).pulAdmits σ ↔ φ.pulAdmits σ := by
   simp only [pulAdmits]
 
 /-- **Fact 8.8 (2)**: MUST φ = NOT(MIGHT(NOT φ)) projects presuppositions
 of φ. Admitting MUST φ requires admitting φ. -/
-theorem admits_must (φ : Formula P) (σ : InfoStateOf P) :
+theorem admits_must (φ : Formula P) (σ : Set P) :
     (Formula.must φ).pulAdmits σ ↔ φ.pulAdmits σ := by
   simp only [Formula.must, pulAdmits]
 
@@ -250,7 +250,7 @@ while CCP.negTest is a test (pass/fail on the whole context).
 They coincide only when φ is eliminative AND σ[φ] = ∅ or σ[φ] = σ.
 -/
 theorem not_neq_ccpNegTest :
-    ∃ (P : Type) (φ : Formula P) (σ : InfoStateOf P),
+    ∃ (P : Type) (φ : Formula P) (σ : Set P),
       (Formula.not φ).eval σ ≠ CCP.negTest φ.eval σ := by
   -- Witness: P = Bool, φ = pred (· = true), σ = {true, false}
   -- NOT φ gives σ \ {true} = {false} (nonempty)
@@ -306,13 +306,13 @@ theorem eval_eliminative (φ : Formula P) : IsEliminative φ.eval := by
 /-- A state σ **satisfies** φ iff σ[φ] = σ (updating adds no information).
 [beaver-2001] D29 / MP4 (closure-based; we use the set-based equivalent:
 φ is satisfied when the update is a fixed point). -/
-noncomputable def satisfies (φ : Formula P) (σ : InfoStateOf P) : Prop :=
+noncomputable def satisfies (φ : Formula P) (σ : Set P) : Prop :=
   φ.eval σ = σ
 
 /-- A formula φ **presupposes** ψ iff every state that admits φ
 also satisfies ψ. [beaver-2001] D46, MP6. -/
 def presupposes (φ ψ : Formula P) : Prop :=
-  ∀ σ : InfoStateOf P, φ.pulAdmits σ → ψ.satisfies σ
+  ∀ σ : Set P, φ.pulAdmits σ → ψ.satisfies σ
 
 -- ════════════════════════════════════════════════════════════════
 -- § 9b. Satisfaction–Consistency Bridge (Lemma 8.6, Fact 8.7)
@@ -326,7 +326,7 @@ def presupposes (φ ψ : Formula P) : Prop :=
 The proof uses eliminativity: since φ.eval σ ⊆ σ (all ABLE formulas
 are eliminative), the fixed-point condition φ.eval σ = σ reduces to
 checking that σ \ φ.eval σ is empty. -/
-theorem lemma_8_6 (φ : Formula P) (σ : InfoStateOf P) :
+theorem lemma_8_6 (φ : Formula P) (σ : Set P) :
     φ.satisfies σ ↔ ¬((Formula.not φ).eval σ).Nonempty := by
   simp only [satisfies, eval]
   constructor
@@ -354,7 +354,7 @@ theorem must_eliminative (φ : Formula P) : IsEliminative (Formula.must φ).eval
 The proof chains through Lemma 8.6: satisfaction ↔ ¬consistent-with-NOT
 ↔ MIGHT(NOT φ) fails ↔ NOT(MIGHT(NOT φ)) passes.
 [beaver-2001] Ch. 8 §8.3. -/
-theorem fact_8_7 (φ : Formula P) (σ : InfoStateOf P) :
+theorem fact_8_7 (φ : Formula P) (σ : Set P) :
     (Formula.must φ).satisfies σ ↔ φ.satisfies σ := by
   constructor
   · intro h
@@ -458,7 +458,7 @@ from updating with φ satisfies ψ.
 In our set-based formulation (without discourse markers), this reduces
 to: for all σ, ψ.eval(φ.eval σ) = φ.eval σ. -/
 noncomputable def entails (φ ψ : Formula P) : Prop :=
-  ∀ σ : InfoStateOf P, ψ.eval (φ.eval σ) = φ.eval σ
+  ∀ σ : Set P, ψ.eval (φ.eval σ) = φ.eval σ
 
 /-- **ABLE entailment ↔ CCP entailment**.
 
@@ -486,7 +486,7 @@ theorem entails_trans (φ ψ χ : Formula P)
 
 /-- Entailment preserves satisfaction: if φ ⊨ ψ and σ satisfies φ,
 then σ satisfies ψ. -/
-theorem satisfies_of_entails (φ ψ : Formula P) (σ : InfoStateOf P)
+theorem satisfies_of_entails (φ ψ : Formula P) (σ : Set P)
     (hent : φ.entails ψ) (hsat : φ.satisfies σ) :
     ψ.satisfies σ := by
   unfold satisfies at hsat ⊢

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -141,7 +141,7 @@ theorem diamond_negative_eq (φ : BUSDen W E) (s) :
 
 /-- Diamond positive is a test (returns s or ∅). -/
 theorem diamond_positive_isTest (φ : BUSDen W E) :
-    IsTest (◇ᵇφ).positive (P := Possibility W ℕ (Option E)) := by
+    IsTest (◇ᵇφ).positive (S := Possibility W ℕ (Option E)) := by
   intro s
   rw [diamond_positive_eq]
   split
@@ -150,7 +150,7 @@ theorem diamond_positive_isTest (φ : BUSDen W E) :
 
 /-- Diamond negative is a test (returns s or ∅). -/
 theorem diamond_negative_isTest (φ : BUSDen W E) :
-    IsTest (◇ᵇφ).negative (P := Possibility W ℕ (Option E)) := by
+    IsTest (◇ᵇφ).negative (S := Possibility W ℕ (Option E)) := by
   intro s
   rw [diamond_negative_eq]
   split
@@ -159,7 +159,7 @@ theorem diamond_negative_isTest (φ : BUSDen W E) :
 
 /-- Diamond positive is eliminative (from IsTest). -/
 theorem diamond_positive_eliminative (φ : BUSDen W E) :
-    IsEliminative (◇ᵇφ).positive (P := Possibility W ℕ (Option E)) :=
+    IsEliminative (◇ᵇφ).positive (S := Possibility W ℕ (Option E)) :=
   test_eliminative _ (diamond_positive_isTest φ)
 
 /-- Diamond positive subset (convenience form). -/
@@ -169,7 +169,7 @@ theorem diamond_positive_subset (φ : BUSDen W E) (s) :
 
 /-- Diamond negative is eliminative (from IsTest). -/
 theorem diamond_negative_eliminative (φ : BUSDen W E) :
-    IsEliminative (◇ᵇφ).negative (P := Possibility W ℕ (Option E)) :=
+    IsEliminative (◇ᵇφ).negative (S := Possibility W ℕ (Option E)) :=
   test_eliminative _ (diamond_negative_isTest φ)
 
 /-- Diamond negative subset (convenience form). -/
@@ -179,12 +179,12 @@ theorem diamond_negative_subset (φ : BUSDen W E) (s) :
 
 /-- Box positive is eliminative (□φ = ¬◇¬φ, so positive = diamond negative of ¬φ). -/
 theorem box_positive_eliminative (φ : BUSDen W E) :
-    IsEliminative (□ᵇφ).positive (P := Possibility W ℕ (Option E)) :=
+    IsEliminative (□ᵇφ).positive (S := Possibility W ℕ (Option E)) :=
   diamond_negative_eliminative (BilateralDen.neg φ)
 
 /-- Box negative is eliminative. -/
 theorem box_negative_eliminative (φ : BUSDen W E) :
-    IsEliminative (□ᵇφ).negative (P := Possibility W ℕ (Option E)) :=
+    IsEliminative (□ᵇφ).negative (S := Possibility W ℕ (Option E)) :=
   diamond_positive_eliminative (BilateralDen.neg φ)
 
 end BUSDen


### PR DESCRIPTION
Follow-up to the InfoState retirement (#1457) and the file merge (#1464): `InfoStateOf P` was a bare synonym for `Set P` whose docstring still advertised instantiations that no longer exist (PLA witness-pairs, register-form DRT states). Level-0 states are plain `Set P` everywhere now — 4 files swept, docstring prose adjusted.