### PR TITLE
refactor(Semantics/Dynamic/ICDRT): delta-only substrate under ICDRT namespace

### DIFF
--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -9,125 +9,137 @@ import Mathlib.Data.Set.Basic
 [muskens-1996] [stone-1999] [brasoveanu-2006] [hofmann-2025]
 
 ICDRT ([hofmann-2025]'s intensional extension of [muskens-1996]'s
-Compositional DRT): dynamic semantics built over `ICDRTAssignment`
+Compositional DRT): dynamic semantics built over `ICDRT.Assignment`
 (individual drefs as `IVar → W → Entity E` plus propositional drefs as
 `PVar → Set W`). This is a layer above `ICDRT/Defs.lean` (which owns the
 carrier types) and below paper-specific theories such as [hofmann-2025]
 (whose paper apparatus lives in `Studies/Hofmann2025.lean`).
 
+ICDRT's *delta* over the level-0 spine is exactly its carrier and its
+conditions: `ICDRT.Update` is the spine's relational `Update` at ICDRT
+assignments, sequencing is the spine's `dseq`, and the static-to-dynamic
+bridge `toUpdate` is `lift ∘ fiberDRS` — by definition, not by theorem.
+`fiberDRS` embeds assignment-only relations into pair relations (passive
+worlds); `lift` is the spine's relational image. Consequently `toUpdate`
+is always distributive (`lift_isDistributive`) — the algebraic content
+of [hofmann-2025]'s observation that ICDRT-style negation via
+propositional dref complementation stays distributive, unlike test-based
+dynamic negation that inspects whole states.
+
 ## Main definitions
 
-- `IContext`, `DynProp`: information states (sets of assignment-world
-  pairs) and context transformers over them (the spine's `CCP` at ICDRT
-  possibilities).
-- `ICDRTUpdate`, with `seq`, `idUp`, and the lift `toUpdate`: static
-  update relations between assignments, after [muskens-1996].
+- `ICDRT.Context`: information states — sets of assignment-world pairs.
+- `ICDRT.Update` (the spine's `Update` at ICDRT assignments), `idUp`,
+  `fiberDRS`, and `toUpdate := lift ∘ fiberDRS`.
 - `propVarUp`, `indivVarUp`, `multiVarUp`, `relVarUp`: variable updates.
 - `dynInclusion`, `isComplement`: dynamic conditions on propositional drefs.
 - `dynPred`, `localEntailment`: predication and local contextual entailment.
 - `veridicalIndiv`, `counterfactualIndiv`, `hypotheticalIndiv`,
   `counterfactualProp`, `accessible`, `subsetReq`: the veridicality typology.
-- `fiberDRS`, `toUpdate_eq_lift_fiberDRS`: the static-to-dynamic bridge.
-
-The factorization `toUpdate = lift ∘ fiberDRS` separates two concerns:
-`fiberDRS` embeds assignment-only relations into pair relations (passive
-worlds), and `lift` converts relational meanings to set-transformer
-meanings. Consequently `toUpdate` is always distributive (corollary of
-`lift_isDistributive`) — the algebraic content of [hofmann-2025]'s
-observation that ICDRT-style negation via propositional dref
-complementation stays distributive, unlike test-based dynamic negation
-that inspects whole states.
 -/
 
-namespace DynamicSemantics
-
-open Core (Assignment)
+namespace DynamicSemantics.ICDRT
 
 variable {W E : Type*}
 variable (φ φ₁ φ₂ φ₃ φ_DC φ_anaphor φ_antecedent : PVar) (v : IVar)
-variable (i j : ICDRTAssignment W E)
+variable (i j : Assignment W E)
 
-/-! ### Information states and context transformers -/
+/-! ### Information states -/
 
 /-- Set of assignment-world pairs (information state in flat update).
 
 Kept as `abbrev` so it inherits `Set α`'s `Membership`,
 `EmptyCollection`, `HasSubset`, `Union`, `Inter`, and `Singleton`
 instances (and the corresponding `Set` API) directly. -/
-abbrev IContext (W : Type*) (E : Type*) := Set (ICDRTAssignment W E × W)
-
-namespace IContext
+abbrev Context (W : Type*) (E : Type*) := Set (Assignment W E × W)
 
 /-- The trivial context (all possibilities) -/
-def univ : IContext W E := Set.univ
-
-/-- Update with a world-predicate -/
-def update (c : IContext W E) (p : W → Prop) : IContext W E :=
-  { gw ∈ c | p gw.2 }
-
-end IContext
-
-/-- Context-to-context transformer (sentence denotation): the spine's
-`CCP` at ICDRT possibilities. -/
-abbrev DynProp (W : Type*) (E : Type*) := CCP (ICDRTAssignment W E × W)
-
-namespace DynProp
-
-/-- Identity (says nothing): the spine's `CCP.id`. -/
-abbrev id : DynProp W E := CCP.id
-
-/-- Absurd (contradiction): the spine's `CCP.absurd`. -/
-abbrev absurd : DynProp W E := CCP.absurd
-
-end DynProp
+def Context.univ : Context W E := Set.univ
 
 /-! ### Updates as static relations -/
 
-/-- Static update relation between input and output assignments.
-
-Following [muskens-1996]'s Compositional DRT, dynamic updates are
-relations between assignments rather than operations on sets of
-assignment-world pairs. The lift to context transformers is done by
-`toUpdate` below. -/
-def ICDRTUpdate (W : Type*) (E : Type*) :=
-  ICDRTAssignment W E → ICDRTAssignment W E → Prop
-
-namespace ICDRTUpdate
-
-variable (D D₁ D₂ : ICDRTUpdate W E) (c : IContext W E)
-
-/-- Sequencing (`;`): relational composition.
-    `(D₁ ; D₂)(i)(j) ↔ ∃k, D₁(i)(k) ∧ D₂(k)(j)` -/
-def seq : ICDRTUpdate W E :=
-  λ i j => ∃ k, D₁ i k ∧ D₂ k j
-
-infixl:60 " ⨟ " => seq
+/-- Static update relation between input and output assignments: the
+spine's relational `Update` at ICDRT assignments. Following
+[muskens-1996]'s Compositional DRT, dynamic updates are relations between
+assignments; sequencing is the spine's `dseq` and the lift to context
+transformers is `toUpdate` below. -/
+abbrev Update (W : Type*) (E : Type*) :=
+  DynamicSemantics.Update (Assignment W E)
 
 /-- Identity update: output equals input. -/
-def idUp : ICDRTUpdate W E := λ i j => i = j
+def idUp : Update W E := Eq
 
-/-- Lift a static update relation to a context update on information states. -/
-def toUpdate : DynProp W E :=
-  λ c => { p | ∃ i, (i, p.2) ∈ c ∧ D i p.1 }
+section Bridge
+
+variable (D D₁ D₂ : Update W E) (c : Context W E)
+
+/-- Embed an assignment-only relation into a pair relation with passive worlds.
+
+`fiberDRS D (i, w) (j, w') ↔ w = w' ∧ D i j`
+
+ICDRT updates operate on assignments only and worlds are inert fibers.
+`fiberDRS` makes this structure explicit at the type level of
+`Update (Assignment W E × W)`. -/
+def fiberDRS : DynamicSemantics.Update (Assignment W E × W) :=
+  λ ⟨i, w⟩ ⟨j, w'⟩ => w = w' ∧ D i j
+
+/-- Lift a static update relation to a context transformer: the fiberwise
+embedding followed by the spine's relational image. -/
+def toUpdate : CCP (Assignment W E × W) :=
+  lift (fiberDRS D)
+
+/-- Membership in the lifted update. -/
+theorem mem_toUpdate {p : Assignment W E × W} :
+    p ∈ toUpdate D c ↔ ∃ i, (i, p.2) ∈ c ∧ D i p.1 := by
+  obtain ⟨j, w⟩ := p
+  constructor
+  · rintro ⟨⟨i, w'⟩, hic, rfl, hD⟩
+    exact ⟨i, hic, hD⟩
+  · rintro ⟨i, hic, hD⟩
+    exact ⟨(i, w), hic, rfl, hD⟩
 
 /-- Identity update lifts to identity on contexts. -/
-theorem idUp_toUpdate : ICDRTUpdate.idUp.toUpdate c = c :=
-  Set.ext (λ ⟨j, _⟩ =>
-    ⟨λ ⟨_, hic, rfl⟩ => hic, λ hjc => ⟨j, hjc, rfl⟩⟩)
+theorem idUp_toUpdate : toUpdate (idUp : Update W E) c = c :=
+  Set.ext λ ⟨j, w⟩ =>
+    ⟨λ ⟨⟨_, _⟩, hic, hw, hij⟩ => by obtain rfl := hw; obtain rfl := hij; exact hic,
+     λ hjc => ⟨(j, w), hjc, rfl, rfl⟩⟩
+
+/-- `fiberDRS` preserves sequential composition. -/
+theorem fiberDRS_dseq :
+    fiberDRS (D₁ ⨟ D₂) = dseq (fiberDRS D₁) (fiberDRS D₂) := by
+  funext p q; cases p; cases q
+  simp only [fiberDRS, dseq, Relation.Comp, eq_iff_iff]
+  constructor
+  · rintro ⟨rfl, k, h1, h2⟩
+    exact ⟨⟨k, _⟩, ⟨rfl, h1⟩, ⟨rfl, h2⟩⟩
+  · rintro ⟨⟨k, _⟩, ⟨rfl, h1⟩, ⟨rfl, h2⟩⟩
+    exact ⟨rfl, k, h1, h2⟩
 
 /-- Sequential composition lifts to function composition on contexts. -/
-theorem seq_toUpdate : (seq D₁ D₂).toUpdate c = D₂.toUpdate (D₁.toUpdate c) :=
-  Set.ext (λ ⟨_, _⟩ =>
-    ⟨λ ⟨i, hic, k, h1, h2⟩ => ⟨k, ⟨i, hic, h1⟩, h2⟩,
-     λ ⟨k, ⟨i, hic, h1⟩, h2⟩ => ⟨i, hic, k, h1, h2⟩⟩)
+theorem dseq_toUpdate : toUpdate (D₁ ⨟ D₂) c = toUpdate D₂ (toUpdate D₁ c) := by
+  rw [toUpdate, fiberDRS_dseq, lift_dseq]
+  rfl
 
-end ICDRTUpdate
+/-- `toUpdate D` is always distributive: it processes each
+assignment-world pair independently. Corollary of `lift_isDistributive`. -/
+theorem toUpdate_isDistributive : IsDistributive (toUpdate D) :=
+  lift_isDistributive (fiberDRS D)
+
+/-- A test update — one that preserves the assignment — lifts to an
+eliminative CCP: it can only shrink the context, never grow it. -/
+theorem toUpdate_test_eliminative (C : Assignment W E → Prop) :
+    IsEliminative (toUpdate (λ i j => i = j ∧ C j)) := by
+  intro _ ⟨_, _⟩ hjw
+  obtain ⟨⟨_, _⟩, hiw, rfl, rfl, _⟩ := hjw
+  exact hiw
+
+end Bridge
 
 /-! ### Variable updates -/
 
 /-- Propositional variable update: `j` differs from `i` at most in the value of `p`.
 `i[p]j` -/
-def propVarUp (p : PVar) (i j : ICDRTAssignment W E) : Prop :=
+def propVarUp (p : PVar) (i j : Assignment W E) : Prop :=
   (∀ q : PVar, q ≠ p → j.prop q = i.prop q) ∧
   (∀ v : IVar, j.indiv v = i.indiv v)
 
@@ -139,7 +151,7 @@ def indivVarUp : Prop :=
 
 /-- Multi-variable update: `j` differs from `i` at most in the listed prop/indiv vars. -/
 def multiVarUp (ps : List PVar) (vs : List IVar)
-    (i j : ICDRTAssignment W E) : Prop :=
+    (i j : Assignment W E) : Prop :=
   (∀ p : PVar, p ∉ ps → j.prop p = i.prop p) ∧
   (∀ v : IVar, v ∉ vs → j.indiv v = i.indiv v)
 
@@ -180,7 +192,7 @@ Holds when the predicate `R` applies to `v`'s referent in every world
 of the local context `φ`. The universal falsifier ⋆ never satisfies
 `R`, so a `⋆`-valued referent in any φ-world makes `dynPred` fail. -/
 def dynPred (R : E → W → Prop) (φ : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) : Prop :=
+    (i : Assignment W E) : Prop :=
   ∀ w ∈ i.prop φ,
     match i.indiv v w with
     | .some e => R e w
@@ -205,7 +217,7 @@ def counterfactualIndiv : Prop :=
   ∀ w ∈ i.prop φ_DC, i.indiv v w = .star
 
 /-- Counterfactual propositional dref: `φ_DC(i) ∩ δ(i) = ∅`. -/
-def counterfactualProp (φ_DC δ : PVar) (i : ICDRTAssignment W E) : Prop :=
+def counterfactualProp (φ_DC δ : PVar) (i : Assignment W E) : Prop :=
   i.prop φ_DC ∩ i.prop δ = ∅
 
 /-- Hypothetical individual dref: neither veridical nor counterfactual. -/
@@ -215,7 +227,7 @@ def hypotheticalIndiv : Prop :=
 /-- Accessibility: `v` is accessible at the anaphor site `φ_anaphor` iff
 it is locally entailed there and the discourse is consistent. -/
 def accessible (φ_anaphor : PVar) (v : IVar)
-    (φ_DC : PVar) (i : ICDRTAssignment W E) : Prop :=
+    (φ_DC : PVar) (i : Assignment W E) : Prop :=
   localEntailment φ_anaphor v i ∧ (i.prop φ_DC).Nonempty
 
 /-- Subset requirement: indefinite at `φ_antecedent` can antecede pronoun at
@@ -228,7 +240,7 @@ abbrev subsetReq : Prop := dynInclusion φ_anaphor φ_antecedent i
 /-- Generic declarative-assertion subset condition: `φ_DC(j) ⊆ φ(j)` —
 `dynInclusion` under the speech-act reading "the speaker's commitment set
 is updated to a subset of the asserted content". -/
-abbrev decCondition (φ_DC φ : PVar) (j : ICDRTAssignment W E) : Prop :=
+abbrev decCondition (φ_DC φ : PVar) (j : Assignment W E) : Prop :=
   dynInclusion φ_DC φ j
 
 /-- **Counterfactual antecedent blocks veridical anaphor**
@@ -241,7 +253,7 @@ the anaphor's subset requirement, then the discourse is inconsistent.
 Frameworks without propositional-dref structure have no analogue —
 [charlow-2019]'s `State W E` handles the same phenomenon by
 alternative-set filtering (`Studies/Charlow2019.lean`). -/
-theorem counterfactual_blocks_veridical (i j : ICDRTAssignment W E)
+theorem counterfactual_blocks_veridical (i j : Assignment W E)
     (φ_DC φ_anaphor φ_neg : PVar)
     (h_extends_DC : j.prop φ_DC = i.prop φ_DC)
     (h_extends_neg : j.prop φ_neg = i.prop φ_neg)
@@ -264,7 +276,7 @@ distinct interlocutors can carry contradictory commitments simultaneously
 without making the discourse inconsistent. -/
 structure DiscContext (W : Type*) (E : Type*) (Speaker : Type*) where
   /-- Current discourse state -/
-  state : ICDRTAssignment W E
+  state : Assignment W E
   /-- Map from interlocutors to their commitment-set propositional variables -/
   dcVar : Speaker → PVar
 
@@ -277,7 +289,7 @@ def consistent {Speaker : Type*} (c : DiscContext W E Speaker) : Prop :=
 
 /-- Null assignment: every propositional dref maps to all worlds; every
 individual dref maps to ⋆ in every world. The "no information yet" state. -/
-def nullAssignment : ICDRTAssignment W E where
+def nullAssignment : Assignment W E where
   prop := λ _ => Set.univ
   indiv := λ _ _ => .star
 
@@ -307,8 +319,8 @@ assigns a proper superset to any interlocutor's commitment-set dref:
 
 A formal articulation of the Gricean Quantity maxim: speakers commit to
 the strongest claim supported by the evidence. -/
-def pragMaxDC {Speaker : Type*} (dcVar : Speaker → PVar) (D : ICDRTUpdate W E)
-    (i j : ICDRTAssignment W E) : Prop :=
+def pragMaxDC {Speaker : Type*} (dcVar : Speaker → PVar) (D : Update W E)
+    (i j : Assignment W E) : Prop :=
   D i j ∧ ∀ h, D i h → ∀ x : Speaker, ¬(j.prop (dcVar x) ⊂ h.prop (dcVar x))
 
 /-- Propositional maximization: `max_φ(D)`.
@@ -320,8 +332,8 @@ other successful output `k` assigns a proper superset to `φ`:
 
 Used to ensure local contexts are as wide as the truth conditions allow,
 e.g. for the inner content of a negated existential. -/
-def propMaxOp (φ : PVar) (D : ICDRTUpdate W E)
-    (i j : ICDRTAssignment W E) : Prop :=
+def propMaxOp (φ : PVar) (D : Update W E)
+    (i j : Assignment W E) : Prop :=
   D i j ∧ ∀ k, D i k → ¬(j.prop φ ⊂ k.prop φ)
 
 /-- Doxastic accessibility condition for an attitude verb's local context.
@@ -330,8 +342,8 @@ def propMaxOp (φ : PVar) (D : ICDRTUpdate W E)
 
 `dox j` returns the set of worlds compatible with the agent's beliefs
 at assignment `j`; the condition asserts that `φ'` contains them. -/
-def believeCondition (φ_belief : PVar) (dox : ICDRTAssignment W E → Set W)
-    (j : ICDRTAssignment W E) : Prop :=
+def believeCondition (φ_belief : PVar) (dox : Assignment W E → Set W)
+    (j : Assignment W E) : Prop :=
   dox j ⊆ j.prop φ_belief
 
 /-! ### Structural theorems -/
@@ -377,7 +389,7 @@ theorem double_complement_eq
 `φ₃`-worlds and the anaphor's local context is contained in `φ₃`, then `v`
 is locally entailed at the anaphor site. -/
 theorem disjunction_enables_anaphora (φ₃ φ_a : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+    (i : Assignment W E)
     (h_sub : i.prop φ_a ⊆ i.prop φ₃)
     (h_rel : ∀ w, w ∈ i.prop φ₃ → i.indiv v w ≠ .star) :
     localEntailment φ_a v i :=
@@ -398,7 +410,7 @@ theorem veridical_counterfactual_exclusive
 /-- The universal falsifier blocks dynamic predication: if `v` maps to `⋆` at
 some `w ∈ φ`, then `R_φ(v)` fails. -/
 theorem star_blocks_dynPred (R : E → W → Prop) (φ : PVar) (v : IVar)
-    (i : ICDRTAssignment W E) (w : W)
+    (i : Assignment W E) (w : W)
     (hw : w ∈ i.prop φ) (hstar : i.indiv v w = .star)
     (hpred : dynPred R φ v i) : False := by
   have := hpred w hw; rw [hstar] at this; exact this
@@ -409,7 +421,7 @@ is the core algebraic move that turns negation into commitment-set
 counterfactuality (the recipe used by [hofmann-2025]'s analysis of
 "there isn't a bathroom"). -/
 theorem dec_complement_counterfactual (φ_DC φ_outer φ_inner : PVar)
-    (i : ICDRTAssignment W E)
+    (i : Assignment W E)
     (h_comp : isComplement φ_outer φ_inner i)
     (h_dec : dynInclusion φ_DC φ_outer i) :
     counterfactualProp φ_DC φ_inner i := by
@@ -420,73 +432,13 @@ theorem dec_complement_counterfactual (φ_DC φ_outer φ_inner : PVar)
   rintro ⟨hw_dc, hw_inner⟩
   exact h_dec hw_dc hw_inner
 
-/-! ### Fiberwise lift to CCP -/
-
-variable (D D₁ D₂ : ICDRTUpdate W E)
-
-/-- Embed an assignment-only relation into a pair relation with passive worlds.
-
-`fiberDRS D (i, w) (j, w') ↔ w = w' ∧ D i j`
-
-ICDRT updates operate on assignments only and worlds are inert fibers.
-`fiberDRS` makes this structure explicit at the type level of
-`Update (ICDRTAssignment W E × W)`. -/
-def fiberDRS : Update (ICDRTAssignment W E × W) :=
-  λ ⟨i, w⟩ ⟨j, w'⟩ => w = w' ∧ D i j
-
-/-- `toUpdate = lift ∘ fiberDRS`: the static-to-dynamic bridge factors
-through fiberwise embedding followed by relational image. -/
-theorem toUpdate_eq_lift_fiberDRS : D.toUpdate = lift (fiberDRS D) := by
-  funext σ
-  apply Set.ext; intro ⟨j, w⟩
-  simp only [ICDRTUpdate.toUpdate, lift, fiberDRS, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hic, hD⟩
-    exact ⟨⟨i, w⟩, hic, rfl, hD⟩
-  · rintro ⟨⟨i, _⟩, hiw, rfl, hD⟩
-    exact ⟨i, hiw, hD⟩
-
-/-- `fiberDRS` preserves sequential composition. -/
-theorem fiberDRS_seq :
-    fiberDRS (ICDRTUpdate.seq D₁ D₂) = dseq (fiberDRS D₁) (fiberDRS D₂) := by
-  funext p q; cases p; cases q
-  simp only [fiberDRS, ICDRTUpdate.seq, dseq, Relation.Comp, eq_iff_iff]
-  constructor
-  · rintro ⟨rfl, k, h1, h2⟩
-    exact ⟨⟨k, _⟩, ⟨rfl, h1⟩, ⟨rfl, h2⟩⟩
-  · rintro ⟨⟨k, _⟩, ⟨rfl, h1⟩, ⟨rfl, h2⟩⟩
-    exact ⟨rfl, k, h1, h2⟩
-
-/-- `fiberDRS` preserves identity. -/
-theorem fiberDRS_idUp :
-    fiberDRS (ICDRTUpdate.idUp : ICDRTUpdate W E) = λ p q => p = q := by
-  funext p q; cases p; cases q
-  simp only [fiberDRS, ICDRTUpdate.idUp, eq_iff_iff, Prod.mk.injEq]
-  exact ⟨λ ⟨h1, h2⟩ => ⟨h2, h1⟩, λ ⟨h1, h2⟩ => ⟨h2, h1⟩⟩
-
-/-! ### Distributivity and test eliminativity -/
-
-/-- `toUpdate D` is always distributive: it processes each
-assignment-world pair independently. Corollary of `lift_isDistributive`. -/
-theorem toUpdate_isDistributive : IsDistributive (D.toUpdate) := by
-  rw [toUpdate_eq_lift_fiberDRS]
-  exact lift_isDistributive (fiberDRS D)
-
-/-- A test update — one that preserves the assignment — lifts to an
-eliminative CCP: it can only shrink the context, never grow it. -/
-theorem toUpdate_test_eliminative (C : ICDRTAssignment W E → Prop) :
-    IsEliminative (ICDRTUpdate.toUpdate (λ i j => i = j ∧ C j)) := by
-  intro _ ⟨_, _⟩ hjw
-  obtain ⟨_, hiw, rfl, _⟩ := hjw
-  exact hiw
-
 /-! ### Fibered lookup instance -/
 
 /-- ICDRT contexts expose the shared lookup interface at `M = Entity`
 (`Dynamic/Lookup.lean`), making ICDRT lookups comparable with the
 extensional (`M = Id`) and [charlow-2019] (`M = Set`) families. -/
 instance : DynamicSemantics.HasFiberedLookup Entity
-    (ICDRTAssignment W E) IVar W E where
+    (Assignment W E) IVar W E where
   iLookup i v w := i.indiv v w
 
-end DynamicSemantics
+end DynamicSemantics.ICDRT

--- a/Linglib/Semantics/Dynamic/ICDRT/Defs.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Defs.lean
@@ -11,8 +11,8 @@ Dynamic Ty2): entities extended with the universal falsifier ⋆
 (`Entity`, [brasoveanu-2006]'s dummy value for referent-less worlds), the
 two variable sorts (`IVar` for individuals, `PVar` for the propositional
 drefs that store local contexts), and the two-sorted assignment
-(`ICDRTAssignment` — individual drefs as individual concepts `W → Entity E`,
-propositional drefs as `Set W`).
+(`ICDRT.Assignment` — individual drefs as individual concepts
+`W → Entity E`, propositional drefs as `Set W`).
 
 The system built over these types — updates, dynamic conditions, the
 veridicality typology — lives in `ICDRT/Basic.lean`; the paper-specific
@@ -20,13 +20,16 @@ apparatus in `Studies/Hofmann2025.lean`. (The concept drefs of
 [krifka-2026] live with their consumer in `Studies/Krifka2026.lean`.)
 -/
 
-namespace DynamicSemantics
+namespace DynamicSemantics.ICDRT
 
 /--
 Entities extended with the universal falsifier ⋆ ([brasoveanu-2006]; adopted
 by [hofmann-2025]): individual drefs map to ⋆ in worlds where the referent
 does not exist — in "There's no bathroom", the bathroom variable maps to ⋆
 in all worlds. Lexical relations are axiomatically false of ⋆.
+
+`Option E` under a renaming, kept as its own inductive for the paper's ⋆
+vocabulary and constructor-level pattern matching in consumers.
 -/
 inductive Entity (E : Type*) where
   | some : E → Entity E
@@ -90,7 +93,7 @@ In ICDRT, we need to track two kinds of assignments:
 This is used by the ICDRT system (`ICDRT/Basic.lean`); simpler theories
 can use Nat → E.
 -/
-structure ICDRTAssignment (W : Type*) (E : Type*) where
+structure Assignment (W : Type*) (E : Type*) where
   /-- Individual variable assignment: intensional individual drefs (individual
       concepts). Each variable maps worlds to entities, possibly ⋆.
       In [hofmann-2025]'s notation: type s(we), i.e., for each variable v,
@@ -100,28 +103,29 @@ structure ICDRTAssignment (W : Type*) (E : Type*) where
   /-- Propositional variable assignment -/
   prop : PVar → Set W
 
-namespace ICDRTAssignment
+namespace Assignment
 
 variable {W E : Type*}
 
 /-- Empty assignment (all variables map to ⋆ / empty set) -/
-def empty : ICDRTAssignment W E where
+def empty : Assignment W E where
   indiv := λ _ _ => .star
   prop := λ _ => ∅
 
-/-- Update individual variable with an individual concept (world-dependent). -/
-def updateIndiv (g : ICDRTAssignment W E) (v : IVar) (e : W → Entity E) : ICDRTAssignment W E :=
-  { g with indiv := λ v' => if v' == v then e else g.indiv v' }
+/-- Update individual variable with an individual concept (world-dependent):
+mathlib's `Function.update` at the `indiv` field. -/
+def updateIndiv (g : Assignment W E) (v : IVar) (e : W → Entity E) : Assignment W E :=
+  { g with indiv := Function.update g.indiv v e }
 
 /-- Update individual variable with a constant entity (world-invariant).
     Convenience for cases where the entity is the same in all worlds. -/
-def updateIndivConst (g : ICDRTAssignment W E) (v : IVar) (e : Entity E) : ICDRTAssignment W E :=
+def updateIndivConst (g : Assignment W E) (v : IVar) (e : Entity E) : Assignment W E :=
   g.updateIndiv v (λ _ => e)
 
-/-- Update propositional variable -/
-def updateProp (g : ICDRTAssignment W E) (p : PVar) (s : Set W) : ICDRTAssignment W E :=
-  { g with prop := λ p' => if p' == p then s else g.prop p' }
+/-- Update propositional variable: `Function.update` at the `prop` field. -/
+def updateProp (g : Assignment W E) (p : PVar) (s : Set W) : Assignment W E :=
+  { g with prop := Function.update g.prop p s }
 
-end ICDRTAssignment
+end Assignment
 
-end DynamicSemantics
+end DynamicSemantics.ICDRT

--- a/Linglib/Studies/Charlow2019.lean
+++ b/Linglib/Studies/Charlow2019.lean
@@ -18,6 +18,7 @@ namespace Charlow2019
 
 open DPL
 open DynamicSemantics
+open DynamicSemantics.ICDRT
 open _root_.Core (Assignment)
 
 /-- Truth at an assignment: K True at g ⟺ ∃h. K g h (Charlow's (7)). -/
@@ -279,14 +280,14 @@ instance instCharlowHasFiberedLookup (W E : Type) :
 -- Bridge natural transformations — Hofmann ⇄ Charlow
 -- ════════════════════════════════════════════════════════════════
 
-/-- **Hofmann ↪ Charlow**: lift an `ICDRTAssignment` to a Charlow state on
+/-- **Hofmann ↪ Charlow**: lift an `ICDRT.Assignment` to a Charlow state on
 the worlds where every `vars`-listed variable has a non-`⋆` referent.
 At such worlds the resulting state has exactly one alternative — the
 assignment forced by Hofmann's values on `vars` (free elsewhere).
 At ⋆-worlds for any `vars`-listed variable, the world contributes no
 alternatives. -/
 def singletonLift {W E : Type} [Inhabited E]
-    (worlds : Set W) (vars : Finset Nat) (i : ICDRTAssignment W E) :
+    (worlds : Set W) (vars : Finset Nat) (i : ICDRT.Assignment W E) :
     State W E :=
   { p | p.1 ∈ worlds ∧
         (∀ v ∈ vars, i.indiv ⟨v⟩ p.1 ≠ Entity.star) ∧
@@ -302,7 +303,7 @@ drefs are dropped (Charlow has no propositional-dref structure to
 preserve). The reverse-image `singletonLift` ∘ `supportCollapse` loses
 information whenever the Charlow state has genuine uncertainty. -/
 noncomputable def supportCollapse {W E : Type}
-    (s : State W E) : ICDRTAssignment W E where
+    (s : State W E) : ICDRT.Assignment W E where
   prop _ := ∅
   indiv v w :=
     open Classical in
@@ -324,7 +325,7 @@ reverse direction (`singletonLift ∘ supportCollapse`) is *not* the
 identity — collapsing genuine Charlow uncertainty to `⋆` and then
 re-singleton-lifting forgets which alternatives were possible. -/
 theorem supportCollapse_singletonLift {W E : Type} [Inhabited E]
-    (worlds : Set W) (vars : Finset Nat) (i : ICDRTAssignment W E)
+    (worlds : Set W) (vars : Finset Nat) (i : ICDRT.Assignment W E)
     (v : IVar) (w : W) (hw : w ∈ worlds) (hv : v.idx ∈ vars)
     (hall : ∀ u ∈ vars, i.indiv ⟨u⟩ w ≠ Entity.star) :
     (supportCollapse (singletonLift worlds vars i)).indiv v w =

--- a/Linglib/Studies/Hofmann2025.lean
+++ b/Linglib/Studies/Hofmann2025.lean
@@ -64,6 +64,7 @@ empirical applications.
 namespace Hofmann2025
 
 open DynamicSemantics
+open DynamicSemantics.ICDRT
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Empirical Data
@@ -338,7 +339,7 @@ After (19a) + (30):
 -/
 
 /-- Output assignment after "There is a bathroom. It is upstairs." (Figure 6) -/
-def j_veridical : ICDRTAssignment BWorld BEnt where
+def j_veridical : ICDRT.Assignment BWorld BEnt where
   prop | ⟨10⟩ => {w_bu, w_b}  -- pDC_S
        | ⟨0⟩  => {w_bu, w_b}  -- p1
        | ⟨2⟩  => {w_bu}        -- p3
@@ -346,14 +347,14 @@ def j_veridical : ICDRTAssignment BWorld BEnt where
   indiv := indivBathroom
 
 /-- The update (19a): `[φ₁, φ₁ : v | φ_{DC_S} ∈ φ₁, bathroom_{φ₁}(v)]` -/
-def update_19a : ICDRTUpdate BWorld BEnt := λ i j =>
+def update_19a : ICDRT.Update BWorld BEnt := λ i j =>
   multiVarUp [p1] [v1] i j ∧
   (∀ w, w ∈ j.prop p1 ↔ j.indiv v1 w ≠ .star) ∧
   decCondition pDC_S p1 j ∧
   dynPred isBathroom p1 v1 j
 
 /-- The update (30): `[φ₃ | φ_{DC_S} ∈ φ₃, upstairs_{φ₃}(v)]` -/
-def update_30 : ICDRTUpdate BWorld BEnt := λ i j =>
+def update_30 : ICDRT.Update BWorld BEnt := λ i j =>
   multiVarUp [p3] [] i j ∧
   decCondition pDC_S p3 j ∧
   dynPred isUpstairs p3 v1 j
@@ -396,7 +397,7 @@ Attempting (30) requires φ₃ ⊆ φ₂ (subset requirement) AND
 -/
 
 /-- Output assignment after "There isn't a bathroom" (Figure 7). -/
-def j_counterfactual : ICDRTAssignment BWorld BEnt where
+def j_counterfactual : ICDRT.Assignment BWorld BEnt where
   prop | ⟨10⟩ => {w_u, w_0}     -- pDC_S
        | ⟨0⟩  => {w_u, w_0}     -- p1
        | ⟨1⟩  => {w_bu, w_b}    -- p2
@@ -424,7 +425,7 @@ theorem counterfactual_complement :
     `counterfactual_blocks_veridical` (`ICDRT/Basic.lean`): the only
     paper-specific work is the disjointness witness `h_disjoint`. -/
 theorem counterfactual_veridical_impossible
-    (j : ICDRTAssignment BWorld BEnt)
+    (j : ICDRT.Assignment BWorld BEnt)
     (h_extends : ∀ p, p ≠ p3 → j.prop p = j_counterfactual.prop p)
     (_h_indiv : j.indiv = j_counterfactual.indiv)
     (h_dec : decCondition pDC_S p3 j)
@@ -454,7 +455,7 @@ Since φ_{DC_S} ⊆ φ₁ = φ₃, v is veridical.
 -/
 
 /-- Output after double negation (Figure 8). -/
-def j_double_neg : ICDRTAssignment BWorld BEnt where
+def j_double_neg : ICDRT.Assignment BWorld BEnt where
   prop | ⟨10⟩ => {w_bu, w_b}    -- pDC_S
        | ⟨0⟩  => {w_bu, w_b}    -- p1
        | ⟨1⟩  => {w_u, w_0}     -- p2
@@ -497,7 +498,7 @@ being disjoint from φ₃.
 -/
 
 /-- Output after bathroom disjunction (Figure 9). -/
-def j_bathroom_disj : ICDRTAssignment BWorld BEnt where
+def j_bathroom_disj : ICDRT.Assignment BWorld BEnt where
   prop | ⟨10⟩ => {w_bu, w_u, w_0}  -- pDC_S
        | ⟨0⟩  => {w_bu, w_u, w_0}  -- p1
        | ⟨1⟩  => {w_u, w_0}        -- p2
@@ -540,7 +541,7 @@ Both commitment sets nonempty → discourse consistent despite contradiction.
 -/
 
 /-- Output after disagreement (Figure 10). -/
-def j_disagreement : ICDRTAssignment BWorld BEnt where
+def j_disagreement : ICDRT.Assignment BWorld BEnt where
   prop | ⟨11⟩ => {w_u, w_0}     -- pDC_A
        | ⟨12⟩ => {w_bu}          -- pDC_B
        | ⟨0⟩  => {w_u, w_0}     -- p1
@@ -602,7 +603,7 @@ deriving φ₄ from `DOX(sue, φ₃)`.
 def p4_modal : PVar := ⟨4⟩
 
 /-- Output after "There isn't a bathroom. Sue believes it's upstairs." -/
-def j_modal_sub : ICDRTAssignment BWorld BEnt where
+def j_modal_sub : ICDRT.Assignment BWorld BEnt where
   prop | ⟨10⟩ => {w_u, w_0}     -- pDC_S
        | ⟨0⟩  => {w_u, w_0}     -- p1
        | ⟨1⟩  => {w_bu, w_b}    -- p2
@@ -743,7 +744,7 @@ theorem all_data_correct :
 
 Type-driven compositional semantics for ICDRT. Each lexical entry is a
 higher-order function over dynamic meta-types; composition is function
-application + sequential update. The resulting `ICDRTUpdate` values lift
+application + sequential update. The resulting `ICDRT.Update` values lift
 to distributive CCPs via `Core/Intensional.lean`'s
 `toUpdate_isDistributive`.
 
@@ -753,23 +754,23 @@ to distributive CCPs via `Core/Intensional.lean`'s
 |-------|------|----------------|
 | **e** | `IVar` | Individual dref name |
 | **w** | `PVar` | Propositional dref name |
-| **t** | `ICDRTUpdate W E` | Static update relation |
+| **t** | `ICDRT.Update W E` | Static update relation |
 
 Compositional types are functions between these: `e(wt)` = VP type,
 `wt` = sentence type, etc.
 -/
 
 /-- VP / predicate type: `e(wt)` — takes individual dref and local context. -/
-abbrev SemE (W E : Type*) := IVar → PVar → ICDRTUpdate W E
+abbrev SemE (W E : Type*) := IVar → PVar → ICDRT.Update W E
 
 /-- Sentence / clause type: `wt` — takes local context, returns update. -/
-abbrev SemW (W E : Type*) := PVar → ICDRTUpdate W E
+abbrev SemW (W E : Type*) := PVar → ICDRT.Update W E
 
 variable {W E : Type*}
 
 /-- Vacuous VP scope: identity predicate `λv.λφ.idUp`. Used when a
 sentence has no VP beyond the NP (e.g., "there is a bathroom"). -/
-def vacuousScope : SemE W E := λ _ _ => ICDRTUpdate.idUp
+def vacuousScope : SemE W E := λ _ _ => ICDRT.idUp
 
 /-- (15) Common noun: `bathroom ⟿ λv_e.λφ_w.[bathroom_φ(v)]`.
 A test update: assignment unchanged, but `R_φ(v)` must hold at the output. -/
@@ -783,18 +784,18 @@ abbrev intransVP (R : E → W → Prop) : SemE W E := commonNoun R
 
 The biconditional in `relVarUp` ensures `v` has a referent exactly in
 the φ-worlds, preventing scope leakage. -/
-def indefinite (v : IVar) (P P' : SemE W E) (φ : PVar) : ICDRTUpdate W E :=
-  ICDRTUpdate.seq (ICDRTUpdate.seq (λ i j => relVarUp φ v i j) (P v φ)) (P' v φ)
+def indefinite (v : IVar) (P P' : SemE W E) (φ : PVar) : ICDRT.Update W E :=
+  dseq (dseq (λ i j => relVarUp φ v i j) (P v φ)) (P' v φ)
 
 /-- (17) Pronoun: `it_v ⟿ λP.λφ.P(v)(φ)`. The pronoun contributes no
 update — it simply passes its index `v` to the predicate. -/
-def pronoun (v : IVar) (P : SemE W E) (φ : PVar) : ICDRTUpdate W E :=
+def pronoun (v : IVar) (P : SemE W E) (φ : PVar) : ICDRT.Update W E :=
   P v φ
 
 /-- (14) Proper name: `Mary ⟿ λP.λφ.[v | v ≡ Mary_e]; P(v)(φ)`. -/
 def properName (name : E) (v : IVar) (P : SemE W E) (φ : PVar) :
-    ICDRTUpdate W E :=
-  ICDRTUpdate.seq
+    ICDRT.Update W E :=
+  dseq
     (λ i j => indivVarUp v i j ∧ ∀ w : W, j.indiv v w = .some name)
     (P v φ)
 
@@ -802,8 +803,8 @@ def properName (name : E) (v : IVar) (P : SemE W E) (φ : PVar) :
 
 Static complementation over propositional drefs, NOT bilateral swap —
 the algebraic content of [hofmann-2025]'s key insight (§5.1.1). -/
-def semNOT (φ' : PVar) (Sc : SemW W E) (φ : PVar) : ICDRTUpdate W E :=
-  ICDRTUpdate.seq
+def semNOT (φ' : PVar) (Sc : SemW W E) (φ : PVar) : ICDRT.Update W E :=
+  dseq
     (λ i j => propVarUp φ' i j ∧ isComplement φ φ' j)
     (propMaxOp φ' (Sc φ'))
 
@@ -813,9 +814,9 @@ max_{φ'}(Sc'(φ')); max_{φ''}(Sc''(φ''))`.
 The disjuncts' local contexts need NOT overlap — this is how bathroom
 disjunctions enable cross-disjunct anaphora. -/
 def semOR (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
-    ICDRTUpdate W E :=
-  ICDRTUpdate.seq
-    (ICDRTUpdate.seq
+    ICDRT.Update W E :=
+  dseq
+    (dseq
       (λ i j => multiVarUp [φ', φ''] [] i j ∧
         j.prop φ = j.prop φ' ∪ j.prop φ'')
       (propMaxOp φ' (Sc' φ')))
@@ -824,9 +825,9 @@ def semOR (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
 /-- (18c) Conditional: `IF^{φ',φ''} ⟿ λSc'.λSc''.λφ.[φ',φ'' | φ ≡ φ̄'⊎φ''];
 max_{φ'}(Sc'(φ')); max_{φ''}(Sc''(φ''))`. -/
 def semIF (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
-    ICDRTUpdate W E :=
-  ICDRTUpdate.seq
-    (ICDRTUpdate.seq
+    ICDRT.Update W E :=
+  dseq
+    (dseq
       (λ i j => multiVarUp [φ', φ''] [] i j ∧
         j.prop φ = (j.prop φ')ᶜ ∪ j.prop φ'')
       (propMaxOp φ' (Sc' φ')))
@@ -835,26 +836,26 @@ def semIF (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
 /-- (18d) Conjunction: `AND^{φ',φ''} ⟿ λSc'.λSc''.λφ.
 [φ' | φ'⊑φ]; max_{φ'}(Sc'(φ')); [φ'' | φ''⊑φ']; max_{φ''}(Sc''(φ''))`. -/
 def semAND (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
-    ICDRTUpdate W E :=
-  ICDRTUpdate.seq
-    (ICDRTUpdate.seq
-      (ICDRTUpdate.seq
+    ICDRT.Update W E :=
+  dseq
+    (dseq
+      (dseq
         (λ i j => propVarUp φ' i j ∧ dynInclusion φ' φ j)
         (propMaxOp φ' (Sc' φ')))
       (λ i j => propVarUp φ'' i j ∧ dynInclusion φ'' φ' j))
     (propMaxOp φ'' (Sc'' φ''))
 
 /-- (18e) Attitude verb: `believed ⟿ λv.λSc.λφ.[φ' | believe_φ(v,φ')]; max_{φ'}(Sc(φ'))`. -/
-def semBelieved (φ' : PVar) (dox : ICDRTAssignment W E → Set W)
-    (Sc : SemW W E) (_φ : PVar) : ICDRTUpdate W E :=
-  ICDRTUpdate.seq
+def semBelieved (φ' : PVar) (dox : ICDRT.Assignment W E → Set W)
+    (Sc : SemW W E) (_φ : PVar) : ICDRT.Update W E :=
+  dseq
     (λ i j => propVarUp φ' i j ∧ believeCondition φ' dox j)
     (propMaxOp φ' (Sc φ'))
 
 /-- (19) Declarative assertion: `DEC_S^φ ⟿ λSc.[φ | φ_{DC_S}⊑φ]; max_φ(Sc(φ))`. -/
 def semDEC (φ_DC : PVar) (φ : PVar) (Sc : SemW W E) :
-    ICDRTUpdate W E :=
-  ICDRTUpdate.seq
+    ICDRT.Update W E :=
+  dseq
     (λ i j => propVarUp φ i j ∧ decCondition φ_DC φ j)
     (propMaxOp φ (Sc φ))
 
@@ -862,11 +863,11 @@ def semDEC (φ_DC : PVar) (φ : PVar) (Sc : SemW W E) :
 
 /-- A common noun is a test: it preserves the assignment. -/
 theorem commonNoun_is_test (R : E → W → Prop) (v : IVar) (φ : PVar)
-    (i j : ICDRTAssignment W E) (h : commonNoun R v φ i j) : i = j := h.1
+    (i j : ICDRT.Assignment W E) (h : commonNoun R v φ i j) : i = j := h.1
 
 /-- `vacuousScope` is a test (identity). -/
 theorem vacuousScope_is_test (v : IVar) (φ : PVar)
-    (i j : ICDRTAssignment W E) (h : vacuousScope v φ i j) : i = j := h
+    (i j : ICDRT.Assignment W E) (h : vacuousScope v φ i j) : i = j := h
 
 /-- `pronoun v P φ` is just `P v φ` — the pronoun is transparent. -/
 theorem pronoun_transparent (v : IVar) (P : SemE W E) (φ : PVar) :
@@ -878,7 +879,7 @@ between composition and accessibility. -/
 theorem indefinite_test_entails (v : IVar) (P P' : SemE W E) (φ : PVar)
     (hP : ∀ a b, P v φ a b → a = b)
     (hP' : ∀ a b, P' v φ a b → a = b)
-    (i j : ICDRTAssignment W E)
+    (i j : ICDRT.Assignment W E)
     (h : indefinite v P P' φ i j) :
     localEntailment φ v j := by
   obtain ⟨l, ⟨m, hrel, hPml⟩, hP'lj⟩ := h
@@ -890,7 +891,7 @@ theorem indefinite_test_entails (v : IVar) (P P' : SemE W E) (φ : PVar)
 
 /-- DEC introduces the inclusion condition. -/
 theorem semDEC_inclusion (φ_DC φ : PVar) (Sc : SemW W E)
-    (i j : ICDRTAssignment W E) (h : semDEC φ_DC φ Sc i j) :
+    (i j : ICDRT.Assignment W E) (h : semDEC φ_DC φ Sc i j) :
     ∃ k, propVarUp φ i k ∧ decCondition φ_DC φ k ∧
       propMaxOp φ (Sc φ) k j := by
   obtain ⟨k, hk, hmax⟩ := h
@@ -898,7 +899,7 @@ theorem semDEC_inclusion (φ_DC φ : PVar) (Sc : SemW W E)
 
 /-- NOT introduces the complement condition on the intermediate assignment. -/
 theorem semNOT_introduces_complement (φ' : PVar) (Sc : SemW W E) (φ : PVar)
-    (i j : ICDRTAssignment W E) (h : semNOT φ' Sc φ i j) :
+    (i j : ICDRT.Assignment W E) (h : semNOT φ' Sc φ i j) :
     ∃ k, propVarUp φ' i k ∧ isComplement φ φ' k ∧
       propMaxOp φ' (Sc φ') k j := by
   obtain ⟨k, hk, hmax⟩ := h
@@ -907,7 +908,7 @@ theorem semNOT_introduces_complement (φ' : PVar) (Sc : SemW W E) (φ : PVar)
 /-- Double negation restores the original local context via double
 complementation. -/
 theorem double_neg_complement (φ' φ'' : PVar) (φ : PVar)
-    (k j : ICDRTAssignment W E)
+    (k j : ICDRT.Assignment W E)
     (h_outer : isComplement φ φ' k)
     (h_inner : isComplement φ' φ'' j)
     (h_prop_pres : j.prop φ = k.prop φ)
@@ -921,19 +922,20 @@ theorem double_neg_complement (φ' φ'' : PVar) (φ : PVar)
 -- § 6.3 Bridge to CCP
 
 /-- Every compositional derivation lifts to a distributive CCP. -/
-theorem comp_isDistributive (D : ICDRTUpdate W E) :
-    IsDistributive D.toUpdate :=
+theorem comp_isDistributive (D : ICDRT.Update W E) :
+    IsDistributive (ICDRT.toUpdate D) :=
   toUpdate_isDistributive D
 
-/-- Every compositional derivation factors through `fiberDRS`. -/
-theorem comp_factorizes (D : ICDRTUpdate W E) :
-    D.toUpdate = lift (fiberDRS D) :=
-  toUpdate_eq_lift_fiberDRS D
+/-- Every compositional derivation factors through `fiberDRS`:
+`toUpdate` is `lift ∘ fiberDRS` by definition. -/
+theorem comp_factorizes (D : ICDRT.Update W E) :
+    ICDRT.toUpdate D = lift (fiberDRS D) :=
+  rfl
 
 /-- Sequential composition in the fragment lifts to CCP composition. -/
-theorem comp_seq_lifts (D₁ D₂ : ICDRTUpdate W E) (c : IContext W E) :
-    (ICDRTUpdate.seq D₁ D₂).toUpdate c = D₂.toUpdate (D₁.toUpdate c) :=
-  ICDRTUpdate.seq_toUpdate D₁ D₂ c
+theorem comp_seq_lifts (D₁ D₂ : ICDRT.Update W E) (c : ICDRT.Context W E) :
+    ICDRT.toUpdate (D₁ ⨟ D₂) c = ICDRT.toUpdate D₂ (ICDRT.toUpdate D₁ c) :=
+  dseq_toUpdate D₁ D₂ c
 
 -- § 6.4 Compositional derivations applied to Model M₁
 
@@ -948,21 +950,21 @@ def itIsUpstairs : SemW BWorld BEnt :=
   pronoun v1 (intransVP isUpstairs)
 
 /-- **Veridical**: "There is a bathroom. It is upstairs." -/
-def veridical_comp : ICDRTUpdate BWorld BEnt :=
-  ICDRTUpdate.seq
+def veridical_comp : ICDRT.Update BWorld BEnt :=
+  dseq
     (semDEC pDC_S p1 thereIsABathroom)
     (semDEC pDC_S p3 itIsUpstairs)
 
 /-- **Negated**: "There isn't a bathroom." -/
-def negated_comp : ICDRTUpdate BWorld BEnt :=
+def negated_comp : ICDRT.Update BWorld BEnt :=
   semDEC pDC_S p1 (semNOT p2 thereIsABathroom)
 
 /-- **Double negation**: "It's not the case that there isn't a bathroom." -/
-def doubleNeg_comp : ICDRTUpdate BWorld BEnt :=
+def doubleNeg_comp : ICDRT.Update BWorld BEnt :=
   semDEC pDC_S p1 (semNOT p2 (semNOT p3 thereIsABathroom))
 
 /-- **Bathroom disjunction**: "Either there isn't a bathroom, or it's upstairs." -/
-def bathDisj_comp : ICDRTUpdate BWorld BEnt :=
+def bathDisj_comp : ICDRT.Update BWorld BEnt :=
   semDEC pDC_S p1
     (semOR p2 p3
       (semNOT p4 thereIsABathroom)
@@ -971,14 +973,14 @@ def bathDisj_comp : ICDRTUpdate BWorld BEnt :=
 /-- **Disagreement**: A: "There isn't a bathroom." B: "It is upstairs."
 Different speakers have different commitment sets — what bilateral
 accounts CANNOT handle (§5.1.1). -/
-def disagree_comp : ICDRTUpdate BWorld BEnt :=
-  ICDRTUpdate.seq
+def disagree_comp : ICDRT.Update BWorld BEnt :=
+  dseq
     (semDEC pDC_A p1 (semNOT p2 thereIsABathroom))
     (semDEC pDC_B p3 itIsUpstairs)
 
 /-- **Modal subordination**: "There isn't a bathroom. Sue believes it's upstairs." -/
-def modalSub_comp : ICDRTUpdate BWorld BEnt :=
-  ICDRTUpdate.seq
+def modalSub_comp : ICDRT.Update BWorld BEnt :=
+  dseq
     (semDEC pDC_S p1 (semNOT p2 thereIsABathroom))
     (semDEC pDC_S p3
       (semBelieved p4_modal
@@ -987,15 +989,15 @@ def modalSub_comp : ICDRTUpdate BWorld BEnt :=
 
 /-- Every compositional derivation lifts to a distributive CCP. -/
 theorem veridical_comp_distributive :
-    IsDistributive veridical_comp.toUpdate :=
+    IsDistributive (ICDRT.toUpdate veridical_comp) :=
   toUpdate_isDistributive _
 
 /-- Sequential composition lifts correctly. -/
-theorem veridical_comp_factors (c : IContext BWorld BEnt) :
-    veridical_comp.toUpdate c =
-    (semDEC pDC_S p3 itIsUpstairs).toUpdate
-      ((semDEC pDC_S p1 thereIsABathroom).toUpdate c) :=
-  ICDRTUpdate.seq_toUpdate _ _ c
+theorem veridical_comp_factors (c : ICDRT.Context BWorld BEnt) :
+    ICDRT.toUpdate veridical_comp c =
+    ICDRT.toUpdate (semDEC pDC_S p3 itIsUpstairs)
+      (ICDRT.toUpdate (semDEC pDC_S p1 thereIsABathroom) c) :=
+  dseq_toUpdate _ _ c
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -1024,7 +1026,7 @@ no per-speaker structure.
 | Modal subordination | `counterfactualIndiv` + modal shift | ✗ |
 | Veridicality | Three-way | ✗ |
 | Truth conditions | `dec_complement_counterfactual` | ✗ (no DC) |
-| State type | `ICDRTAssignment` | `InfoState` |
+| State type | `ICDRT.Assignment` | `InfoState` |
 
 The root cause: BUS is a **single-agent** system; ICDRT is
 **multi-agent** by construction.
@@ -1035,7 +1037,7 @@ If the second disjunct's context grants `v` a referent, and the anaphor's
 context is within it, the pronoun is resolved. -/
 theorem icdrt_bathroom_anaphora
     (φ_disj2 φ_anaphor : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+    (i : ICDRT.Assignment W E)
     (h_sub : i.prop φ_anaphor ⊆ i.prop φ_disj2)
     (h_ref : ∀ w, w ∈ i.prop φ_disj2 → i.indiv v w ≠ .star) :
     localEntailment φ_anaphor v i :=
@@ -1045,7 +1047,7 @@ theorem icdrt_bathroom_anaphora
 `v` is counterfactual for A but veridical for B, simultaneously. -/
 theorem icdrt_disagreement_possible
     (φ_DC_A φ_DC_B : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+    (i : ICDRT.Assignment W E)
     (h_cf_A : counterfactualIndiv φ_DC_A v i)
     (h_ver_B : veridicalIndiv φ_DC_B v i) :
     (∀ w ∈ i.prop φ_DC_A, i.indiv v w = .star) ∧
@@ -1070,8 +1072,8 @@ upstairs", `pragMaxDC` updates each speaker's commitment set
 independently — A's stays excluding bathroom-worlds, B's expands to
 include them. The same dref `v` has different veridicality per speaker. -/
 theorem icdrt_disagreement_via_pragMaxDC {Speaker : Type*}
-    (dcVar : Speaker → PVar) (D : ICDRTUpdate W E)
-    (i j : ICDRTAssignment W E) (v : IVar)
+    (dcVar : Speaker → PVar) (D : ICDRT.Update W E)
+    (i j : ICDRT.Assignment W E) (v : IVar)
     (A B : Speaker)
     (_h_max : pragMaxDC dcVar D i j)
     (h_cf_A : counterfactualIndiv (dcVar A) v j)
@@ -1085,7 +1087,7 @@ hypothetical context: `v` maps to ⋆ in DC worlds but has referents in
 the modal context's worlds. -/
 theorem icdrt_modal_subordination
     (φ_DC φ_modal : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+    (i : ICDRT.Assignment W E)
     (h_cf : counterfactualIndiv φ_DC v i)
     (h_ent : localEntailment φ_modal v i)
     (_h_disjoint : i.prop φ_modal ∩ i.prop φ_DC = ∅) :
@@ -1097,7 +1099,7 @@ theorem icdrt_modal_subordination
 hypothetical worlds where the antecedent's binding holds. -/
 theorem icdrt_modal_subset_satisfied
     (_φ_DC φ_antecedent φ_modal : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+    (i : ICDRT.Assignment W E)
     (h_sub : subsetReq φ_modal φ_antecedent i)
     (h_rel : ∀ w, w ∈ i.prop φ_antecedent ↔ i.indiv v w ≠ .star) :
     localEntailment φ_modal v i :=
@@ -1105,14 +1107,14 @@ theorem icdrt_modal_subset_satisfied
 
 /-- The three veridicality categories are exhaustive. -/
 theorem icdrt_veridicality_exhaustive
-    (φ_DC : PVar) (v : IVar) (i : ICDRTAssignment W E) :
+    (φ_DC : PVar) (v : IVar) (i : ICDRT.Assignment W E) :
     veridicalIndiv φ_DC v i ∨ counterfactualIndiv φ_DC v i ∨ hypotheticalIndiv φ_DC v i :=
   veridicality_trichotomy φ_DC v i
 
 /-- ICDRT double negation: complementing twice recovers the original
 proposition. The static analog of BUS's definitional DNE. -/
 theorem icdrt_dne
-    (φ₁ φ₂ φ₃ : PVar) (i : ICDRTAssignment W E)
+    (φ₁ φ₂ φ₃ : PVar) (i : ICDRT.Assignment W E)
     (h1 : isComplement φ₁ φ₂ i) (h2 : isComplement φ₃ φ₁ i) :
     i.prop φ₃ = i.prop φ₂ :=
   double_complement_eq φ₁ φ₂ φ₃ i h1 h2
@@ -1122,7 +1124,7 @@ state — it just maps to ⋆ in the speaker's DC worlds. This persistence
 is what enables disagreement and modal subordination. -/
 theorem icdrt_negated_dref_persists
     (φ_inner φ_outer : PVar) (v : IVar)
-    (i : ICDRTAssignment W E)
+    (i : ICDRT.Assignment W E)
     (_h_not : isComplement φ_outer φ_inner i)
     (h_ent : localEntailment φ_inner v i) :
     ∀ w ∈ i.prop φ_inner, i.indiv v w ≠ .star :=
@@ -1134,7 +1136,7 @@ together imply the inner content is counterfactual relative to the
 speaker. -/
 theorem icdrt_neg_existential_truth
     (φ_DC φ_outer φ_inner : PVar)
-    (i : ICDRTAssignment W E)
+    (i : ICDRT.Assignment W E)
     (h_comp : isComplement φ_outer φ_inner i)
     (h_dec : dynInclusion φ_DC φ_outer i) :
     counterfactualProp φ_DC φ_inner i :=

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -124,7 +124,7 @@ end DynamicSemantics
 namespace KeshetAbney2024
 
 open KeshetAbney2024.PIP
-open DynamicSemantics (IVar ICDRTAssignment Entity IContext)
+open DynamicSemantics.ICDRT (IVar Assignment Entity Context idUp)
 open Core.Logic.Modal (AccessRel)
 
 
@@ -160,10 +160,10 @@ def sAccess : AccessRel SWorld
   | .actual, .noWolf => True
   | _, _ => False
 
-def isWolf (g : ICDRTAssignment SWorld SEntity) (w : SWorld) : Prop :=
+def isWolf (g : Assignment SWorld SEntity) (w : SWorld) : Prop :=
   g.indiv vWolf w = .some .wolf
 
-def comesIn (g : ICDRTAssignment SWorld SEntity) (w : SWorld) : Prop :=
+def comesIn (g : Assignment SWorld SEntity) (w : SWorld) : Prop :=
   g.indiv vWolf w = .some .wolf ∧ w = .wolfIn
 
 /--
@@ -210,10 +210,10 @@ theorem stone_discourse_label_available (d : Discourse SWorld SEntity) :
              LabelStore.register, LabelStore.lookup, αWolf, vWolf, isWolf]
   rfl
 
-private def g₀_stone : ICDRTAssignment SWorld SEntity :=
+private def g₀_stone : Assignment SWorld SEntity :=
   { indiv := λ _ _w => .star, prop := λ _ => ∅ }
 
-private def g_wolf : ICDRTAssignment SWorld SEntity :=
+private def g_wolf : Assignment SWorld SEntity :=
   g₀_stone.updateIndivConst vWolf (.some .wolf)
 
 private def stone_d₀ : Discourse SWorld SEntity :=
@@ -299,10 +299,10 @@ inductive BEntity where
 def αBath : FLabel := ⟨1⟩
 def vBath : IVar := ⟨1⟩
 
-def isBathroom (g : ICDRTAssignment BWorld BEntity) (w : BWorld) : Prop :=
+def isBathroom (g : Assignment BWorld BEntity) (w : BWorld) : Prop :=
   g.indiv vBath w = .some .bathroom
 
-def isUpstairs (g : ICDRTAssignment BWorld BEntity) (w : BWorld) : Prop :=
+def isUpstairs (g : Assignment BWorld BEntity) (w : BWorld) : Prop :=
   g.indiv vBath w = .some .bathroom ∧ w = .bath
 
 /--
@@ -334,7 +334,7 @@ theorem bathroom_label_survives_negation (d : Discourse BWorld BEntity) :
              αBath]
   rfl
 
-private def g₀ : ICDRTAssignment BWorld BEntity :=
+private def g₀ : Assignment BWorld BEntity :=
   { indiv := λ _ _w => .star, prop := λ _ => ∅ }
 
 private def bath_d₀ : Discourse BWorld BEntity :=
@@ -349,7 +349,7 @@ theorem bathroom_sentence_consistent :
   intro ⟨_, hpred⟩
   simp [isBathroom, g₀, vBath] at hpred
 
-private def g_bath : ICDRTAssignment BWorld BEntity :=
+private def g_bath : Assignment BWorld BEntity :=
   g₀.updateIndivConst vBath (.some .bathroom)
 
 /-- Negative test: bathroom at noBath world is rejected. -/
@@ -403,7 +403,7 @@ inductive PWorld where
   deriving DecidableEq, Repr, Inhabited
 
 /-- Relational paycheck predicate: depends on both paycheck and possessor. -/
-def isPaycheckOf (g : ICDRTAssignment PWorld PEntity) (w : PWorld) : Prop :=
+def isPaycheckOf (g : Assignment PWorld PEntity) (w : PWorld) : Prop :=
   match g.indiv vPaycheck w, g.indiv vPossessor w with
   | .some .johnsPaycheck, .some .john => True
   | .some .billsPaycheck, .some .bill => True
@@ -411,7 +411,7 @@ def isPaycheckOf (g : ICDRTAssignment PWorld PEntity) (w : PWorld) : Prop :=
 
 /-- Re-evaluation yields Bill's paycheck when possessor = Bill. -/
 theorem paycheck_needs_descriptions :
-    let g : ICDRTAssignment PWorld PEntity :=
+    let g : Assignment PWorld PEntity :=
       { indiv := λ v _w =>
           if v == vPaycheck then .some .billsPaycheck
           else if v == vPossessor then .some .bill
@@ -625,7 +625,7 @@ def ibAccess : AccessRel IBWorld
   | _, _ => False
 
 /-- World-dependent predicate: burger exists only at burgerW. -/
-def isBurgerAt (g : ICDRTAssignment IBWorld IBEntity) (w : IBWorld) : Prop :=
+def isBurgerAt (g : Assignment IBWorld IBEntity) (w : IBWorld) : Prop :=
   g.indiv vBurger w = .some .burger ∧ w = .burgerW
 
 def burgerSentence : PUpdate IBWorld IBEntity :=
@@ -642,7 +642,7 @@ theorem burger_label_registered (d : Discourse IBWorld IBEntity) :
 
 /-- The burger description fails at actual — presupposition failure. -/
 theorem burger_desc_fails_at_actual :
-    ∀ g : ICDRTAssignment IBWorld IBEntity,
+    ∀ g : Assignment IBWorld IBEntity,
     ¬ isBurgerAt g .actual := by
   intro g h; exact absurd h.2 (by decide)
 
@@ -706,7 +706,7 @@ def iaAccess : AccessRel IAWorld
   | _, _ => False
 
 /-- World-INdependent predicate: holds at ALL worlds. -/
-def isAnimalInShed (g : ICDRTAssignment IAWorld IAEntity) (w : IAWorld) : Prop :=
+def isAnimalInShed (g : Assignment IAWorld IAEntity) (w : IAWorld) : Prop :=
   g.indiv vAnimal w = .some .animal
 
 def animalSentence : PUpdate IAWorld IAEntity :=
@@ -722,7 +722,7 @@ theorem animal_label_registered (d : Discourse IAWorld IAEntity) :
   rfl
 
 theorem animal_desc_succeeds :
-    ∀ (g : ICDRTAssignment IAWorld IAEntity) (w : IAWorld),
+    ∀ (g : Assignment IAWorld IAEntity) (w : IAWorld),
     g.indiv vAnimal w = .some .animal → isAnimalInShed g w := by
   intro g w h; exact h
 
@@ -786,7 +786,7 @@ def maAccess : AccessRel MAWorld
   | _, _ => False
 
 /-- World-dependent predicate: different animal in each world. -/
-def isAnimalInShedMA (g : ICDRTAssignment MAWorld MAEntity) (w : MAWorld) : Prop :=
+def isAnimalInShedMA (g : Assignment MAWorld MAEntity) (w : MAWorld) : Prop :=
   match g.indiv vMA w, w with
   | .some .cat, .actual => True
   | .some .dog, .shedW1 => True
@@ -794,7 +794,7 @@ def isAnimalInShedMA (g : ICDRTAssignment MAWorld MAEntity) (w : MAWorld) : Prop
   | _, _ => False
 
 /-- At the actual world, only one entity satisfies the description. -/
-private def maG (e : MAEntity) : ICDRTAssignment MAWorld MAEntity :=
+private def maG (e : MAEntity) : Assignment MAWorld MAEntity :=
   { indiv := λ v _w => if v == vMA then .some e else .star
     prop := λ _ => ∅ }
 
@@ -869,7 +869,7 @@ def pcAccess : AccessRel PCWorld
   | _, _ => False
 
 /-- World-dependent predicate: winner only at resolution worlds. -/
-def isWinner (g : ICDRTAssignment PCWorld PCEntity) (w : PCWorld) : Prop :=
+def isWinner (g : Assignment PCWorld PCEntity) (w : PCWorld) : Prop :=
   match g.indiv vWinner w, w with
   | .some .alice, .aliceWins => True
   | .some .bob, .bobWins => True
@@ -883,7 +883,7 @@ def candidateSentence : PUpdate PCWorld PCEntity :=
 
 /-- The winner description is empty at the actual world — no winner declared yet. -/
 theorem winner_desc_empty_at_actual :
-    ∀ g : ICDRTAssignment PCWorld PCEntity,
+    ∀ g : Assignment PCWorld PCEntity,
     ¬ isWinner g .actual := by
   intro g; simp [isWinner]
 
@@ -895,7 +895,7 @@ DESCRIPTION yields nothing at actual → infelicitous.
 -/
 theorem candidates_exist_but_description_fails :
     ({.alice, .bob} : Set PCEntity).Nonempty ∧
-    (∀ g : ICDRTAssignment PCWorld PCEntity, ¬ isWinner g .actual) :=
+    (∀ g : Assignment PCWorld PCEntity, ¬ isWinner g .actual) :=
   ⟨⟨.alice, Set.mem_insert _ _⟩, winner_desc_empty_at_actual⟩
 
 /-- The label is registered (the mechanism works), but the description
@@ -925,8 +925,8 @@ Since the pronoun's existential presupposition (paper item 9) requires
 the description to hold at the evaluation world, might fails and must succeeds.
 -/
 theorem pip_intensional_anaphora_contrast :
-    (∀ g : ICDRTAssignment IBWorld IBEntity, ¬ isBurgerAt g .actual) ∧
-    (∀ (g : ICDRTAssignment IAWorld IAEntity) (w : IAWorld),
+    (∀ g : Assignment IBWorld IBEntity, ¬ isBurgerAt g .actual) ∧
+    (∀ (g : Assignment IAWorld IAEntity) (w : IAWorld),
      g.indiv vAnimal w = .some .animal → isAnimalInShed g w) :=
   ⟨burger_desc_fails_at_actual, animal_desc_succeeds⟩
 
@@ -1016,7 +1016,7 @@ theorem intensional_anaphora_is_T_axiom :
     -- Might's accessibility is ALSO reflexive at actual
     ibAccess .actual .actual ∧
     -- But the burger description fails at actual (world-dependent)
-    (∀ g : ICDRTAssignment IBWorld IBEntity, ¬ isBurgerAt g .actual) :=
+    (∀ g : Assignment IBWorld IBEntity, ¬ isBurgerAt g .actual) :=
   ⟨animal_must_realistic, trivial, burger_desc_fails_at_actual⟩
 
 
@@ -1220,25 +1220,25 @@ def αDonkey : FLabel := ⟨30⟩
 def vFarmer : IVar := ⟨30⟩
 def vDonkey : IVar := ⟨31⟩
 
-def isFarmer (g : ICDRTAssignment DWorld DEntity) (w : DWorld) : Prop :=
+def isFarmer (g : Assignment DWorld DEntity) (w : DWorld) : Prop :=
   match g.indiv vFarmer w with
   | .some .farmer1 | .some .farmer2 => True
   | _ => False
 
-def isDonkey (g : ICDRTAssignment DWorld DEntity) (w : DWorld) : Prop :=
+def isDonkey (g : Assignment DWorld DEntity) (w : DWorld) : Prop :=
   match g.indiv vDonkey w with
   | .some .donkey1 | .some .donkey2 => True
   | _ => False
 
 /-- Ownership: farmer1 owns donkey1, farmer2 owns donkey2. -/
-def owns (g : ICDRTAssignment DWorld DEntity) (w : DWorld) : Prop :=
+def owns (g : Assignment DWorld DEntity) (w : DWorld) : Prop :=
   match g.indiv vFarmer w, g.indiv vDonkey w with
   | .some .farmer1, .some .donkey1 => True
   | .some .farmer2, .some .donkey2 => True
   | _, _ => False
 
 /-- Beating: every farmer who owns a donkey beats it. -/
-def beats (g : ICDRTAssignment DWorld DEntity) (w : DWorld) : Prop :=
+def beats (g : Assignment DWorld DEntity) (w : DWorld) : Prop :=
   match g.indiv vFarmer w, g.indiv vDonkey w with
   | .some .farmer1, .some .donkey1 => True
   | .some .farmer2, .some .donkey2 => True
@@ -1325,7 +1325,7 @@ def nobAccess : AccessRel HNWorld
   | .actual, .nobWonder => True
   | _, _ => False
 
-def isWitch (g : ICDRTAssignment HNWorld HNEntity) (w : HNWorld) : Prop :=
+def isWitch (g : Assignment HNWorld HNEntity) (w : HNWorld) : Prop :=
   g.indiv vWitch w = .some .witch
 
 /-- Hob's belief: "a witch blighted his mare" -/

--- a/Linglib/Studies/KeshetAbney2024/Basic.lean
+++ b/Linglib/Studies/KeshetAbney2024/Basic.lean
@@ -20,7 +20,7 @@ evaluation world.
 PIP is natively a **static, truth-conditional** system: formulas denote
 truth values relative to a model, plural assignment set G, and evaluation
 world w*. Our formalization encodes PIP as a dynamic update system over
-the generic intensional context type `IContext W E` (in
+the generic intensional context type `ICDRT.Context W E` (in
 `Dynamic/Intensional.lean`), which is a legitimate approach:
 [brasoveanu-2010] shows the equivalence between plural predicate calculi
 and dynamic plural logics. The key properties (label monotonicity,
@@ -48,6 +48,7 @@ external/local variable distinction) are faithfully preserved.
 namespace KeshetAbney2024.PIP
 
 open DynamicSemantics
+open DynamicSemantics.ICDRT
 
 
 -- ============================================================
@@ -77,7 +78,7 @@ structure Description (W : Type*) (E : Type*) where
   /-- The variable being described -/
   var : IVar
   /-- The constraining predicate (per assignment and world) -/
-  predicate : ICDRTAssignment W E → W → Prop
+  predicate : ICDRT.Assignment W E → W → Prop
 
 
 -- ============================================================
@@ -137,7 +138,7 @@ cross-boundary anaphora.
 -/
 structure Discourse (W : Type*) (E : Type*) where
   /-- The information state (set of assignment-world pairs) -/
-  info : IContext W E
+  info : ICDRT.Context W E
   /-- The label registry (monotonically accumulated) -/
   labels : LabelStore W E
 
@@ -147,7 +148,7 @@ variable {W E : Type*}
 
 /-- Initial discourse: all possibilities, no labels. -/
 def initial : Discourse W E where
-  info := IContext.univ
+  info := ICDRT.Context.univ
   labels := LabelStore.empty
 
 /-- Empty discourse: contradiction. -/
@@ -159,7 +160,7 @@ def empty : Discourse W E where
 def consistent (d : Discourse W E) : Prop := d.info.Nonempty
 
 /-- Update only the info state, preserving labels. -/
-def mapInfo (d : Discourse W E) (f : IContext W E → IContext W E) : Discourse W E :=
+def mapInfo (d : Discourse W E) (f : ICDRT.Context W E → ICDRT.Context W E) : Discourse W E :=
   { d with info := f d.info }
 
 /-- Register a new label, preserving info state. -/
@@ -200,7 +201,7 @@ In PIP, presuppositions are used for:
 2. Pronominal anaphora (presupposes antecedent is accessible)
 -/
 def presuppose {W E : Type*}
-    (pred : ICDRTAssignment W E → W → Prop) : PUpdate W E :=
+    (pred : ICDRT.Assignment W E → W → Prop) : PUpdate W E :=
   λ d => d.mapInfo (λ c => { gw ∈ c | pred gw.1 gw.2 })
 
 
@@ -245,7 +246,7 @@ assignments may bind different entities to the same variable, and
 truth requires the predicate to hold across all of them.
 -/
 def pluralTruth {W E : Type*}
-    (c : IContext W E) (w : W) (pred : ICDRTAssignment W E → W → Prop) : Prop :=
+    (c : ICDRT.Context W E) (w : W) (pred : ICDRT.Assignment W E → W → Prop) : Prop :=
   ∀ g, (g, w) ∈ c → pred g w
 
 
@@ -296,24 +297,24 @@ For "Every farmer bought a donkey. They paid a lot for them.",
 This is a core PIP operation (paper items 25–27), not study-specific.
 GQ arguments in PIP take two summation terms: restrictor and scope.
 -/
-def summationFiltered {W E : Type*} (c : IContext W E) (v : IVar)
-    (φ : ICDRTAssignment W E → W → Prop) : Set (Entity E) :=
+def summationFiltered {W E : Type*} (c : ICDRT.Context W E) (v : IVar)
+    (φ : ICDRT.Assignment W E → W → Prop) : Set (Entity E) :=
   { e | ∃ g w, (g, w) ∈ c ∧ φ g w ∧ g.indiv v w = e }
 
 /-- Summation without filtering: collects all values of variable v. -/
-def summationValues {W E : Type*} (c : IContext W E) (v : IVar) : Set (Entity E) :=
+def summationValues {W E : Type*} (c : ICDRT.Context W E) (v : IVar) : Set (Entity E) :=
   { e | ∃ g w, (g, w) ∈ c ∧ g.indiv v w = e }
 
 /-- Unfiltered summation equals trivially filtered summation. -/
 theorem summationValues_eq_trivial_filter {W E : Type*}
-    (c : IContext W E) (v : IVar) :
+    (c : ICDRT.Context W E) (v : IVar) :
     summationValues c v = summationFiltered c v (λ _ _ => True) := by
   ext e; simp [summationValues, summationFiltered]
 
 /-- Any assignment in a non-empty context contributes to summation. -/
 theorem summation_nonempty {W E : Type*}
-    (c : IContext W E) (v : IVar)
-    (gw : ICDRTAssignment W E × W)
+    (c : ICDRT.Context W E) (v : IVar)
+    (gw : ICDRT.Assignment W E × W)
     (h : gw ∈ c) :
     gw.1.indiv v gw.2 ∈ summationValues c v :=
   ⟨gw.1, gw.2, h, rfl⟩

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -41,7 +41,7 @@ formalized here.
 namespace KeshetAbney2024.PIP.Bridges
 
 open KeshetAbney2024.PIP
-open DynamicSemantics (IVar ICDRTAssignment Entity IContext)
+open DynamicSemantics.ICDRT (IVar Assignment Entity Context)
 open Core.Logic.Modal (AccessRel box diamond)
 open Core.Logic.Modal.Logic (frameConditions)
 
@@ -332,7 +332,7 @@ theorem mustBase_agrees_box {W D : Type*}
 
 PIP is natively a static, truth-conditional system. Our formalization
 in `Basic.lean` / `Connectives.lean` encodes PIP as a dynamic update
-system over `IContext W E`. [brasoveanu-2010] shows the equivalence
+system over `Context W E`. [brasoveanu-2010] shows the equivalence
 between plural predicate calculi and dynamic plural logics.
 
 The following theorems prove that the static system (`PIPExprF.truth`)
@@ -352,10 +352,10 @@ and `atom p` filters the info state to pairs where `p g w`.
 When the info state is a singleton, the dynamic update is non-empty
 iff the static truth value is true.
 
-TODO: Full proof requires reasoning about `Set.sep` over singleton IContext.
+TODO: Full proof requires reasoning about `Set.sep` over singleton Context.
 -/
 theorem static_atom_agrees_dynamic {W E : Type*}
-    (p : ICDRTAssignment W E → W → Prop) (g : ICDRTAssignment W E) (w : W)
+    (p : Assignment W E → W → Prop) (g : Assignment W E) (w : W)
     (d : Discourse W E) (hd : (g, w) ∈ d.info) :
     (g, w) ∈ (atom p d).info ↔ p g w := by
   unfold atom Discourse.mapInfo
@@ -368,7 +368,7 @@ Negation in both systems complements the truth value / info state.
 The dynamic system keeps pairs from the input that did NOT survive φ.
 -/
 theorem static_neg_agrees_dynamic {W E : Type*}
-    (φ : PUpdate W E) (g : ICDRTAssignment W E) (w : W)
+    (φ : PUpdate W E) (g : Assignment W E) (w : W)
     (d : Discourse W E) (hd : (g, w) ∈ d.info) :
     (g, w) ∈ (negation φ d).info ↔ (g, w) ∉ (φ d).info := by
   unfold negation

--- a/Linglib/Studies/KeshetAbney2024/Composition.lean
+++ b/Linglib/Studies/KeshetAbney2024/Composition.lean
@@ -46,7 +46,7 @@ fundamental bridge between PIP's formula language and its set-based
 compositional interface.
 
 This is the *static* analogue of `PIP.Basic.summationFiltered`, which
-performs the same collection on the dynamic `IContext` level. Agreement
+performs the same collection on the dynamic `ICDRT.Context` level. Agreement
 between the two is part of the static↔dynamic correspondence.
 -/
 def sigmaEval (body : D → PIPExprF W D) (w : W) : Set D :=

--- a/Linglib/Studies/KeshetAbney2024/Connectives.lean
+++ b/Linglib/Studies/KeshetAbney2024/Connectives.lean
@@ -34,6 +34,7 @@ produces the same truth conditions as `Intensional.box`.
 namespace KeshetAbney2024.PIP
 
 open DynamicSemantics
+open DynamicSemantics.ICDRT
 open Core.Logic.Modal (AccessRel box diamond box_T)
 
 variable {W E : Type*}
@@ -47,7 +48,7 @@ variable {W E : Type*}
 Atomic predicate: filters the info state to pairs satisfying the predicate.
 Labels are preserved.
 -/
-def atom (pred : ICDRTAssignment W E → W → Prop) : PUpdate W E :=
+def atom (pred : ICDRT.Assignment W E → W → Prop) : PUpdate W E :=
   λ d => d.mapInfo (λ c => { gw ∈ c | pred gw.1 gw.2 })
 
 /--
@@ -116,10 +117,10 @@ negation and modal operators. This is what enables:
 - Paycheck pronouns: "John spent his paycheck. Bill saved it."
 -/
 def existsLabeled (α : FLabel) (v : IVar) (domain : Set E)
-    (bodyPred : ICDRTAssignment W E → W → Prop)
+    (bodyPred : ICDRT.Assignment W E → W → Prop)
     (body : PUpdate W E) : PUpdate W E :=
   λ d =>
-    let extended : IContext W E :=
+    let extended : ICDRT.Context W E :=
       { gw | ∃ g₀ e, (g₀, gw.2) ∈ d.info ∧
                       e ∈ domain ∧
                       gw.1 = g₀.updateIndivConst v (.some e) }
@@ -133,7 +134,7 @@ Unlabeled existential: standard ∃x. φ without descriptive tracking.
 def exists_ (v : IVar) (domain : Set E)
     (body : PUpdate W E) : PUpdate W E :=
   λ d =>
-    let extended : IContext W E :=
+    let extended : ICDRT.Context W E :=
       { gw | ∃ g₀ e, (g₀, gw.2) ∈ d.info ∧
                       e ∈ domain ∧
                       gw.1 = g₀.updateIndivConst v (.some e) }
@@ -164,17 +165,17 @@ would produce no accessible-world pairs for universal modals to check,
 making must/would vacuously satisfied and losing the modal subordination
 mechanism.
 -/
-def modalExpand (c : IContext W E) (access : AccessRel W) : IContext W E :=
+def modalExpand (c : ICDRT.Context W E) (access : AccessRel W) : ICDRT.Context W E :=
   c ∪ { gw | ∃ w₀, (gw.1, w₀) ∈ c ∧ access w₀ gw.2 }
 
 /-- Modal expansion includes all original pairs. -/
-theorem modalExpand_superset (c : IContext W E) (access : AccessRel W) :
+theorem modalExpand_superset (c : ICDRT.Context W E) (access : AccessRel W) :
     c ⊆ modalExpand c access := by
   intro x hx; left; exact hx
 
 /-- Modal expansion adds accessible-world pairs. -/
-theorem modalExpand_adds_accessible (c : IContext W E) (access : AccessRel W)
-    (g : ICDRTAssignment W E) (w₀ w₁ : W)
+theorem modalExpand_adds_accessible (c : ICDRT.Context W E) (access : AccessRel W)
+    (g : ICDRT.Assignment W E) (w₀ w₁ : W)
     (hc : (g, w₀) ∈ c) (hacc : access w₀ w₁) :
     (g, w₁) ∈ modalExpand c access := by
   right; exact ⟨w₀, hc, hacc⟩
@@ -202,7 +203,7 @@ def must (access : AccessRel W) (allWorlds : List W)
     (body : PUpdate W E) : PUpdate W E :=
   λ d =>
     let bodyResult := body { d with info := modalExpand d.info access }
-    let result : IContext W E :=
+    let result : ICDRT.Context W E :=
       { gw ∈ d.info |
         ∀ w₁ ∈ allWorlds, access gw.2 w₁ → (gw.1, w₁) ∈ bodyResult.info }
     -- Labels from the body propagate outward
@@ -221,7 +222,7 @@ def might (access : AccessRel W) (allWorlds : List W)
     (body : PUpdate W E) : PUpdate W E :=
   λ d =>
     let bodyResult := body { d with info := modalExpand d.info access }
-    let result : IContext W E :=
+    let result : ICDRT.Context W E :=
       { gw ∈ d.info |
         ∃ w₁ ∈ allWorlds, access gw.2 w₁ ∧ (gw.1, w₁) ∈ bodyResult.info }
     { info := result, labels := bodyResult.labels }
@@ -291,8 +292,8 @@ used throughout `Semantics/Modality/`. Since accessibility is now the
 project-canonical Prop-valued `AccessRel`, the identity is direct — no lift.
 -/
 theorem must_truth_agrees_box [Fintype W]
-    (R : AccessRel W) (p : ICDRTAssignment W E → W → Prop)
-    (d : Discourse W E) (g : ICDRTAssignment W E) (w₀ : W)
+    (R : AccessRel W) (p : ICDRT.Assignment W E → W → Prop)
+    (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hd : (g, w₀) ∈ d.info) :
     ((g, w₀) ∈ (must R (Finset.univ : Finset W).toList (atom p) d).info) ↔
     box R (p g) w₀ := by
@@ -311,8 +312,8 @@ theorem must_truth_agrees_box [Fintype W]
 PIP's `might` agrees with `diamond`.
 -/
 theorem might_truth_agrees_diamond [Fintype W]
-    (R : AccessRel W) (p : ICDRTAssignment W E → W → Prop)
-    (d : Discourse W E) (g : ICDRTAssignment W E) (w₀ : W)
+    (R : AccessRel W) (p : ICDRT.Assignment W E → W → Prop)
+    (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hd : (g, w₀) ∈ d.info) :
     ((g, w₀) ∈ (might R (Finset.univ : Finset W).toList (atom p) d).info) ↔
     diamond R (p g) w₀ := by
@@ -335,8 +336,8 @@ modal base guarantees the description holds at the evaluation world — from
 -/
 theorem must_realistic_of_refl [Fintype W]
     (R : AccessRel W) [Std.Refl R]
-    (p : ICDRTAssignment W E → W → Prop)
-    (d : Discourse W E) (g : ICDRTAssignment W E) (w₀ : W)
+    (p : ICDRT.Assignment W E → W → Prop)
+    (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hd : (g, w₀) ∈ d.info)
     (hmust : (g, w₀) ∈ (must R (Finset.univ : Finset W).toList (atom p) d).info) :
     p g w₀ :=
@@ -351,8 +352,8 @@ This is the version that applies to non-globally-reflexive relations
 [kratzer-1991]'s realistic modal base without requiring global reflexivity.
 -/
 theorem must_realistic_at [Fintype W]
-    (R : AccessRel W) (p : ICDRTAssignment W E → W → Prop)
-    (d : Discourse W E) (g : ICDRTAssignment W E) (w₀ : W)
+    (R : AccessRel W) (p : ICDRT.Assignment W E → W → Prop)
+    (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hRefl_at : R w₀ w₀)
     (hmust : (g, w₀) ∈ (must R (Finset.univ : Finset W).toList (atom p) d).info) :
     p g w₀ := by


### PR DESCRIPTION
The last spoke re-stipulating level 0, refactored to contribute only its delta (review findings H1/H2/H4 + M2/M3):
- `ICDRTUpdate` → `ICDRT.Update`, an **abbrev of the spine's `Update`** at ICDRT assignments: its hand-rolled `seq` (with a `⨟` at clashing precedence 60) dies in favor of `dseq`/spine-`⨟`, and `toUpdate` is now **`lift ∘ fiberDRS` by definition** — the old `toUpdate_eq_lift_fiberDRS` theorem is `rfl` (kept in Hofmann2025 as `comp_factorizes := rfl`), `toUpdate_isDistributive` a one-liner, `dseq_toUpdate` derived through `fiberDRS_dseq` + `lift_dseq`; new `mem_toUpdate` characterization.
- Everything ICDRT-specific moves under **`DynamicSemantics.ICDRT`** (owner-relative: `ICDRT.Assignment` replaces the stuttering `ICDRTAssignment`, `ICDRT.Context` replaces `IContext`); the name-squatting `DynProp` abbrev and its `id`/`absurd` re-abbrevs die (consumerless), as does `Context.update`.
- `updateIndiv`/`updateProp` via `Function.update` instead of hand-rolled `==`-matches; `Entity` stays an inductive with the rationale documented (paper's ⋆ vocabulary, constructor matching in consumers).
Consumers migrated: Hofmann2025, the KeshetAbney2024 cluster, Charlow2019.