### PR TITLE
refactor(Semantics/Dynamic): Update.lean audit and unity keystones

### DIFF
--- a/Linglib/Core/Logic/CylindricAlgebra.lean
+++ b/Linglib/Core/Logic/CylindricAlgebra.lean
@@ -30,7 +30,7 @@ framework-specific operations and cylindric ops.
 
 | Framework | Operation | = Cylindric | Bridge |
 |---|---|---|---|
-| CDRT ([muskens-1996]) | `closure (new n ;; φ)` | `cylindrify n (closure φ)` | `Studies/Muskens1996.lean` |
+| CDRT ([muskens-1996]) | `closure (new n * φ)` | `cylindrify n (closure φ)` | `Studies/Muskens1996.lean` |
 | CDRT | `eq' (dref n) (dref m)` | `diagonal n m` | `Studies/Muskens1996.lean` |
 | Charlow ([charlow-2019]) | `staticExists x body` | `cylindrify x body` | `Studies/Charlow2019.lean` |
 | Charlow | `dynamicExists x body` | `cylindrify x body` | `Studies/Charlow2019.lean` |
@@ -52,7 +52,7 @@ same argument — the bridge theorems just haven't been written yet.
 | PIP ([keshet-abney-2024]) | `exists_ v domain body` | `cylindrify v (domain ∩ body)` |
 | File Change ([heim-1982]) | indefinite extends Dom, widens Sat | `cylindrify n (⟦φ⟧)` |
 | Kamp & Reyle Update ([kamp-reyle-1993]) | `box [n] [conds]` | `cylindrify n (interp conds)` |
-| IntensionalCDRT ([hofmann-2025]) | intensional `new n ;; φ` | `cylindrify n (closure φ)` |
+| IntensionalCDRT ([hofmann-2025]) | intensional `new n * φ` | `cylindrify n (closure φ)` |
 
 ### Same algebra, different base type
 

--- a/Linglib/Semantics/Composition/WriterMonad.lean
+++ b/Linglib/Semantics/Composition/WriterMonad.lean
@@ -31,7 +31,7 @@ content can flow into side-issue computations, but side-issue content cannot
 leak back into at-issue computation.
 
 See `Studies/Charlow2021.lean` (`PostSupp`) for the same pattern applied to
-dynamic GQs, with the log monoid `(Update S, dseq, test ⊤)` in place of
+dynamic GQs, with the log monoid `(Update S, Update.seq, test ⊤)` in place of
 `List P`.
 -/
 

--- a/Linglib/Semantics/Dynamic/CDRT.lean
+++ b/Linglib/Semantics/Dynamic/CDRT.lean
@@ -166,10 +166,6 @@ abbrev DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
 abbrev DProp.true_at {E : Type*} (φ : DProp E) (i : State E) : Prop :=
   closure φ i
 
-/-- Dynamic entailment: every output of `φ` can be extended by `ψ`. -/
-def DProp.entails {E : Type*} (φ ψ : DProp E) : Prop :=
-  ∀ i o, φ i o → ψ.true_at o
-
 /-! ### Reduction lemmas -/
 
 /-- The output of a negated `DProp` always equals the input state. -/

--- a/Linglib/Semantics/Dynamic/CDRT.lean
+++ b/Linglib/Semantics/Dynamic/CDRT.lean
@@ -37,6 +37,7 @@ the paper's derivations) and the weakest-precondition calculus live in
 
 namespace DynamicSemantics
 
+open Update
 
 /-- Discourse referent (Muskens' type `se`): a function from states to
 individuals. Constant drefs (`Function.const`, AX4's names) are drefs
@@ -78,11 +79,11 @@ def randomAssign (r : R) : Update S :=
 
 /-- Existential update: `∃r(D) = [r]; D`. -/
 def dexists (r : R) (D : Update S) : Update S :=
-  dseq (randomAssign r) D
+  seq (randomAssign r) D
 
 /-- Universal condition: `∀r(D) = ¬∃r(¬D)`. -/
 def dforall (r : R) (D : Update S) : Condition S :=
-  dneg (dexists r (test (dneg D)))
+  neg (dexists r (test (neg D)))
 
 end RegisterStructure
 
@@ -108,7 +109,7 @@ end DynamicSemantics
 
 namespace CDRT
 
-open DynamicSemantics
+open DynamicSemantics DynamicSemantics.Update
 
 /-- CDRT state: Muskens' type `s`, concretely an assignment `Nat → E`.
 His *registers* are register indices `n : ℕ` with values read by `dref`
@@ -130,8 +131,8 @@ abbrev SProp (E : Type*) := Condition (State E)
 /-- Embed a static proposition as a dynamic one: the spine's `test`. -/
 abbrev DProp.ofStatic {E : Type*} (p : SProp E) : DProp E := test p
 
-/-- Dynamic conjunction: the spine's relational composition `dseq`. -/
-abbrev DProp.seq {E : Type*} (φ ψ : DProp E) : DProp E := dseq φ ψ
+/-- Dynamic conjunction: the spine's relational composition `seq`. -/
+abbrev DProp.seq {E : Type*} (φ ψ : DProp E) : DProp E := Update.seq φ ψ
 
 @[inherit_doc] infixl:65 " ;; " => DProp.seq
 
@@ -150,17 +151,17 @@ theorem DProp.new_eq_randomAssign {E : Type*} (n : Nat) :
     constructor <;> (rintro rfl; funext m; simp [RegisterStructure.extend,
       Function.update_apply])
 
-/-- Dynamic negation: the spine's `dneg`, re-entering the update algebra
+/-- Dynamic negation: the spine's `neg`, re-entering the update algebra
 via `test`. -/
-abbrev DProp.neg {E : Type*} (φ : DProp E) : DProp E := test (dneg φ)
+abbrev DProp.neg {E : Type*} (φ : DProp E) : DProp E := test (Update.neg φ)
 
-/-- Dynamic implication: the spine's `dimpl` via `test`. -/
-abbrev DProp.impl {E : Type*} (φ ψ : DProp E) : DProp E := test (dimpl φ ψ)
+/-- Dynamic implication: the spine's `impl` via `test`. -/
+abbrev DProp.impl {E : Type*} (φ ψ : DProp E) : DProp E := test (Update.impl φ ψ)
 
 /-- Dynamic disjunction as a test (SEM2, [muskens-1996] p. 148): the
-spine's `ddisj` via `test`. -/
-abbrev DProp.ddisj {E : Type*} (φ ψ : DProp E) : DProp E :=
-  test (DynamicSemantics.ddisj φ ψ)
+spine's `disj` via `test`. -/
+abbrev DProp.disj {E : Type*} (φ ψ : DProp E) : DProp E :=
+  test (Update.disj φ ψ)
 
 /-- Truth at a state: the spine's `closure`. -/
 abbrev DProp.true_at {E : Type*} (φ : DProp E) (i : State E) : Prop :=
@@ -176,7 +177,7 @@ theorem DProp.neg_output {E : Type*} {φ : DProp E} {i o : State E}
 the consequent. -/
 theorem DProp.impl_true_at {E : Type*} (φ ψ : DProp E) (i : State E) :
     DProp.true_at (DProp.impl φ ψ) i ↔ ∀ k, φ i k → DProp.true_at ψ k := by
-  simp only [DProp.true_at, closure, DProp.impl, test, dimpl]
+  simp only [DProp.true_at, closure, DProp.impl, test, Update.impl]
   exact ⟨fun ⟨_, rfl, h⟩ => h, fun h => ⟨i, rfl, h⟩⟩
 
 /-- A static `DProp` is true at `i` iff its static content holds. -/

--- a/Linglib/Semantics/Dynamic/CDRT.lean
+++ b/Linglib/Semantics/Dynamic/CDRT.lean
@@ -134,8 +134,6 @@ abbrev DProp.ofStatic {E : Type*} (p : SProp E) : DProp E := test p
 /-- Dynamic conjunction: the spine's relational composition `seq`. -/
 abbrev DProp.seq {E : Type*} (φ ψ : DProp E) : DProp E := Update.seq φ ψ
 
-@[inherit_doc] infixl:65 " ;; " => DProp.seq
-
 /-- New discourse referent: `[new n]` extends the state at position `n`
 with an arbitrary value. -/
 def DProp.new {E : Type*} (n : Nat) : DProp E :=

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -92,7 +92,7 @@ theorem collapseRel_comp (u : X ⟶ Y) (v : Y ⟶ Z)
   rename_i p r
   constructor
   · intro h
-    have h' : (u.t.toUpdate ⨟ v.t.toUpdate) p r := by
+    have h' : Update.seq u.t.toUpdate v.t.toUpdate p r := by
       rw [← Transition.toUpdate_comp, ← t_comp]
       exact h
     obtain ⟨k, hk₁, hk₂⟩ := h'

--- a/Linglib/Semantics/Dynamic/DPL.lean
+++ b/Linglib/Semantics/Dynamic/DPL.lean
@@ -28,6 +28,7 @@ restricted double-negation laws, interdefinability) are proved in
 namespace DPL
 
 open DynamicSemantics
+open DynamicSemantics.Update
 open _root_.Core (Assignment)
 
 variable {E : Type*}
@@ -129,14 +130,14 @@ theorem atom_eq_test (p : Assignment E → Prop) :
   · intro ⟨heq, hp⟩; exact ⟨heq, by rw [heq]; exact hp⟩
 
 theorem conj_eq_dseq (φ ψ : DPLRel E) :
-    toDRS (DPLRel.conj φ ψ) = dseq (toDRS φ) (toDRS ψ) := by
+    toDRS (DPLRel.conj φ ψ) = seq (toDRS φ) (toDRS ψ) := by
   ext g h
-  simp only [toDRS, DPLRel.conj, dseq, Relation.Comp]
+  simp only [toDRS, DPLRel.conj, seq, Relation.Comp]
 
 theorem neg_eq_test_dneg (φ : DPLRel E) :
-    toDRS (DPLRel.neg φ) = test (dneg (toDRS φ)) := by
+    toDRS (DPLRel.neg φ) = test (neg (toDRS φ)) := by
   ext g h
-  simp only [toDRS, DPLRel.neg, test, dneg]
+  simp only [toDRS, DPLRel.neg, test, neg]
   constructor
   · intro ⟨heq, hnex⟩; exact ⟨heq, by rw [← heq]; exact hnex⟩
   · intro ⟨heq, hnex⟩; exact ⟨heq, by rw [heq]; exact hnex⟩
@@ -151,18 +152,18 @@ theorem exists_eq (x : ℕ) (φ : DPLRel E) :
 
 /-- DPL implication is the test of dynamic implication. -/
 theorem impl_eq_test_dimpl (φ ψ : DPLRel E) :
-    toDRS (DPLRel.impl φ ψ) = test (dimpl (toDRS φ) (toDRS ψ)) := by
+    toDRS (DPLRel.impl φ ψ) = test (impl (toDRS φ) (toDRS ψ)) := by
   ext g h
-  simp only [toDRS, DPLRel.impl, test, dimpl]
+  simp only [toDRS, DPLRel.impl, test, impl]
   constructor
   · intro ⟨heq, hall⟩; exact ⟨heq, by rw [← heq]; exact hall⟩
   · intro ⟨heq, hall⟩; exact ⟨heq, by rw [heq]; exact hall⟩
 
 /-- DPL disjunction is the test of dynamic disjunction. -/
 theorem disj_eq_test_ddisj (φ ψ : DPLRel E) :
-    toDRS (DPLRel.disj φ ψ) = test (ddisj (toDRS φ) (toDRS ψ)) := by
+    toDRS (DPLRel.disj φ ψ) = test (disj (toDRS φ) (toDRS ψ)) := by
   ext g h
-  simp only [toDRS, DPLRel.disj, test, ddisj]
+  simp only [toDRS, DPLRel.disj, test, disj]
   constructor
   · intro ⟨heq, hd⟩; exact ⟨heq, by rw [← heq]; exact hd⟩
   · intro ⟨heq, hd⟩; exact ⟨heq, by rw [heq]; exact hd⟩

--- a/Linglib/Semantics/Dynamic/DPL.lean
+++ b/Linglib/Semantics/Dynamic/DPL.lean
@@ -22,7 +22,7 @@ restricted double-negation laws, interdefinability) are proved in
 - `trueAt`, `satisfactionSet`, `productionSet` (Definitions 3, 6, 9).
 - `toDRS`/`ofDRS`: a DPL relation is an `Update` over assignments — DPL
   embeds in dynamic Ty2 at `S = Assignment E`, each connective matching
-  its `DynProp` combinator (`conj_eq_dseq`, `neg_eq_test_dneg`, ...).
+  its spine combinator (`conj_eq_dseq`, `neg_eq_test_dneg`, ...).
 -/
 
 namespace DPL
@@ -96,7 +96,7 @@ def DPLRel.productionSet (φ : DPLRel E) : Set (ℕ → E) :=
 
 DPL embeds directly into dynamic Ty2 at `S = Assignment E`: DPL
 assignments are Ty2 states, DPL relations are `Update` meanings, and
-each connective matches its `DynProp` combinator. -/
+each connective matches its spine combinator. -/
 
 /-- DPL dref: projection function for variable `n`. -/
 def dref (n : ℕ) : Dref (Assignment E) E := λ g => g n

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -41,12 +41,13 @@ identification:
 ## Implementation notes
 
 Naming: the dynamic face (`toRel`, `holds`, `trueRel`) follows the spine's
-lowerCamel operation names (`dneg`, `dseq`, `closure`); the static face
+lowerCamel operation names (`neg`, `seq`, `closure`); the static face
 (`DRS.Realize`, `DRS/Semantics.lean`) follows mathlib's `Formula.Realize`.
 -/
 
 open FirstOrder FirstOrder.Language
-open DynamicSemantics (Update dneg dimpl ddisj closure dseq)
+open DynamicSemantics (Update)
+open DynamicSemantics.Update (neg impl disj closure seq)
 
 namespace DRT
 
@@ -64,13 +65,13 @@ def DRS.toRel : DRS L V → Update (V → M)
   | .mk U conds => fun a a' => (∀ x, x ∉ U → a' x = a x) ∧ Condition.holdsAll conds a'
 /-- The set denotation of a condition ([muskens-1996], SEM1/2): the set of
 embeddings at which it holds. Complex conditions apply the spine connectives
-`dneg`/`dimpl`/`ddisj` to the box relations of their sub-DRSs. -/
+`neg`/`impl`/`disj` to the box relations of their sub-DRSs. -/
 def Condition.holds : Condition L V → (V → M) → Prop
   | .rel R args => fun a => Structure.RelMap R (fun i => a (args i))
   | .eq u v => fun a => a u = a v
-  | .neg K => dneg (DRS.toRel K)
-  | .imp ante cons => dimpl (DRS.toRel ante) (DRS.toRel cons)
-  | .dis l r => ddisj (DRS.toRel l) (DRS.toRel r)
+  | .neg K => neg (DRS.toRel K)
+  | .imp ante cons => impl (DRS.toRel ante) (DRS.toRel cons)
+  | .dis l r => disj (DRS.toRel l) (DRS.toRel r)
 /-- Every condition in the list holds at `a`. A `List` helper — the higher-order
 form fails the nested-inductive structural-recursion checker. -/
 def Condition.holdsAll : List (Condition L V) → (V → M) → Prop
@@ -294,7 +295,7 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
   funext a a'
   apply propext
   simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRel,
-    Condition.holdsAll_append, dseq, Relation.Comp]
+    Condition.holdsAll_append, seq, Relation.Comp]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩
     refine ⟨U₂.piecewise a a', ⟨?_, ?_⟩, ?_, ?_⟩

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -36,7 +36,7 @@ identification:
 * `DRS.trueRel_congr` — the coincidence lemma: denotation depends only on the
   occurring referents (`DRS.occ`, from `DRS/Basic.lean`).
 * `DRS.toRel_merge` — the Merging Lemma: under freshness, `merge` denotes the
-  spine sequencing `⨟` (relational composition) of the two box relations.
+  spine sequencing `Update.seq` (relational composition) of the two box relations.
 
 ## Implementation notes
 
@@ -284,11 +284,11 @@ end
 
 /-- **Merging Lemma** ([muskens-1996], §II.2): when `K₂`'s universe is fresh
 for `K₁`'s conditions, the merge `K₁ ⊕ K₂` denotes the spine sequencing
-(relational composition) of the two box relations — `‖K₁ ⊕ K₂‖ = ‖K₁‖ ⨟ ‖K₂‖`.
+(relational composition) of the two box relations — `‖K₁ ⊕ K₂‖ = seq ‖K₁‖ ‖K₂‖`.
 This is what gives `merge` its dynamic meaning. -/
 theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
     (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
-    (DRS.toRel (K₁.merge K₂) : Update (V → M)) = DRS.toRel K₁ ⨟ DRS.toRel K₂ := by
+    (DRS.toRel (K₁.merge K₂) : Update (V → M)) = seq (DRS.toRel K₁) (DRS.toRel K₂) := by
   obtain ⟨U₁, conds₁⟩ := K₁
   obtain ⟨U₂, conds₂⟩ := K₂
   simp only [DRS.referents_mk, DRS.conditions_mk, Finset.disjoint_left] at hfresh

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -410,7 +410,7 @@ theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv �
   funext f g
   apply propext
   simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRelAt_mk,
-    Condition.holdsAllAt_append, DynamicSemantics.dseq, Relation.Comp]
+    Condition.holdsAllAt_append, DynamicSemantics.Update.seq, Relation.Comp]
   rw [← Finset.union_assoc]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩
@@ -431,7 +431,7 @@ theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
         (by rw [DRS.referents_merge, ← Finset.union_assoc]) := by
   ext w f g
   simp only [Transition.rel_copy, Transition.comp, DRS.transition,
-    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.dseq]
+    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.Update.seq]
 
 /-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
 DRS's transition to the state a proper context DRS expresses yields the

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -402,7 +402,8 @@ hypothesis also had to forbid re-declaration. -/
 theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv ⊆ X)
     (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
     (DRS.toRelAt X (K₁.merge K₂) : (V → M) → (V → M) → Prop) =
-      DRS.toRelAt X K₁ ⨟ DRS.toRelAt (X ∪ K₁.referents) K₂ := by
+      DynamicSemantics.Update.seq (DRS.toRelAt X K₁)
+        (DRS.toRelAt (X ∪ K₁.referents) K₂) := by
   obtain ⟨U₁, c₁⟩ := K₁
   obtain ⟨U₂, c₂⟩ := K₂
   have hfvc₁ := DRS.fv_subset_iff.mp h₁

--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -17,7 +17,7 @@ carrier types) and below paper-specific theories such as [hofmann-2025]
 
 ICDRT's *delta* over the level-0 spine is exactly its carrier and its
 conditions: `ICDRT.Update` is the spine's relational `Update` at ICDRT
-assignments, sequencing is the spine's `dseq`, and the static-to-dynamic
+assignments, sequencing is the spine's `seq`, and the static-to-dynamic
 bridge `toUpdate` is `lift ∘ fiberDRS` — by definition, not by theorem.
 `fiberDRS` embeds assignment-only relations into pair relations (passive
 worlds); `lift` is the spine's relational image. Consequently `toUpdate`
@@ -40,6 +40,8 @@ dynamic negation that inspects whole states.
 
 namespace DynamicSemantics.ICDRT
 
+open Update
+
 variable {W E : Type*}
 variable (φ φ₁ φ₂ φ₃ φ_DC φ_anaphor φ_antecedent : PVar) (v : IVar)
 variable (i j : Assignment W E)
@@ -61,7 +63,7 @@ def Context.univ : Context W E := Set.univ
 /-- Static update relation between input and output assignments: the
 spine's relational `Update` at ICDRT assignments. Following
 [muskens-1996]'s Compositional DRT, dynamic updates are relations between
-assignments; sequencing is the spine's `dseq` and the lift to context
+assignments; sequencing is the spine's `seq` and the lift to context
 transformers is `toUpdate` below. -/
 abbrev Update (W : Type*) (E : Type*) :=
   DynamicSemantics.Update (Assignment W E)
@@ -105,10 +107,10 @@ theorem idUp_toUpdate : toUpdate (idUp : Update W E) c = c :=
      λ hjc => ⟨(j, w), hjc, rfl, rfl⟩⟩
 
 /-- `fiberDRS` preserves sequential composition. -/
-theorem fiberDRS_dseq :
-    fiberDRS (D₁ ⨟ D₂) = dseq (fiberDRS D₁) (fiberDRS D₂) := by
+theorem fiberDRS_seq :
+    fiberDRS (D₁ ⨟ D₂) = seq (fiberDRS D₁) (fiberDRS D₂) := by
   funext p q; cases p; cases q
-  simp only [fiberDRS, dseq, Relation.Comp, eq_iff_iff]
+  simp only [fiberDRS, seq, Relation.Comp, eq_iff_iff]
   constructor
   · rintro ⟨rfl, k, h1, h2⟩
     exact ⟨⟨k, _⟩, ⟨rfl, h1⟩, ⟨rfl, h2⟩⟩
@@ -116,8 +118,8 @@ theorem fiberDRS_dseq :
     exact ⟨rfl, k, h1, h2⟩
 
 /-- Sequential composition lifts to function composition on contexts. -/
-theorem dseq_toUpdate : toUpdate (D₁ ⨟ D₂) c = toUpdate D₂ (toUpdate D₁ c) := by
-  rw [toUpdate, fiberDRS_dseq, lift_dseq]
+theorem seq_toUpdate : toUpdate (D₁ ⨟ D₂) c = toUpdate D₂ (toUpdate D₁ c) := by
+  rw [toUpdate, fiberDRS_seq, lift_seq]
   rfl
 
 /-- `toUpdate D` is always distributive: it processes each

--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -108,7 +108,7 @@ theorem idUp_toUpdate : toUpdate (idUp : Update W E) c = c :=
 
 /-- `fiberDRS` preserves sequential composition. -/
 theorem fiberDRS_seq :
-    fiberDRS (D₁ ⨟ D₂) = seq (fiberDRS D₁) (fiberDRS D₂) := by
+    fiberDRS (Update.seq D₁ D₂) = seq (fiberDRS D₁) (fiberDRS D₂) := by
   funext p q; cases p; cases q
   simp only [fiberDRS, seq, Relation.Comp, eq_iff_iff]
   constructor
@@ -118,7 +118,7 @@ theorem fiberDRS_seq :
     exact ⟨rfl, k, h1, h2⟩
 
 /-- Sequential composition lifts to function composition on contexts. -/
-theorem seq_toUpdate : toUpdate (D₁ ⨟ D₂) c = toUpdate D₂ (toUpdate D₁ c) := by
+theorem seq_toUpdate : toUpdate (Update.seq D₁ D₂) c = toUpdate D₂ (toUpdate D₁ c) := by
   rw [toUpdate, fiberDRS_seq, lift_seq]
   rfl
 

--- a/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
+++ b/Linglib/Semantics/Dynamic/ICDRT/Basic.lean
@@ -122,13 +122,13 @@ theorem dseq_toUpdate : toUpdate (D₁ ⨟ D₂) c = toUpdate D₂ (toUpdate D�
 
 /-- `toUpdate D` is always distributive: it processes each
 assignment-world pair independently. Corollary of `lift_isDistributive`. -/
-theorem toUpdate_isDistributive : IsDistributive (toUpdate D) :=
+theorem toUpdate_isDistributive : CCP.IsDistributive (toUpdate D) :=
   lift_isDistributive (fiberDRS D)
 
 /-- A test update — one that preserves the assignment — lifts to an
 eliminative CCP: it can only shrink the context, never grow it. -/
 theorem toUpdate_test_eliminative (C : Assignment W E → Prop) :
-    IsEliminative (toUpdate (λ i j => i = j ∧ C j)) := by
+    CCP.IsEliminative (toUpdate (λ i j => i = j ∧ C j)) := by
   intro _ ⟨_, _⟩ hjw
   obtain ⟨⟨_, _⟩, hiw, rfl, rfl, _⟩ := hjw
   exact hiw

--- a/Linglib/Semantics/Dynamic/Kleisli.lean
+++ b/Linglib/Semantics/Dynamic/Kleisli.lean
@@ -24,9 +24,9 @@ canonical.
 
 ## Main results
 
-- `dseq_eq_kleisliComp`, `test_top_eq_pure`, `lift_eq_bind`: the monadic
+- `seq_eq_kleisliComp`, `test_top_eq_pure`, `lift_eq_bind`: the monadic
   reading of the update algebra.
-- `isDistributive_iff_map_sSup`, `liftEquiv`, `liftEquiv_dseq`:
+- `isDistributive_iff_map_sSup`, `liftEquiv`, `liftEquiv_seq`:
   distributive CCPs are exactly the completely-join-preserving maps, and
   `lift`/`lower` is an equivalence onto them, sending sequencing to
   composition.
@@ -35,6 +35,8 @@ canonical.
 -/
 
 namespace DynamicSemantics
+
+open Update
 
 attribute [local instance] Set.monad
 
@@ -46,8 +48,8 @@ variable {S : Type*}
 
 /-- Sequencing is Kleisli composition for the powerset monad: an update
 is a Kleisli arrow `S → Set S`, definitionally. -/
-theorem dseq_eq_kleisliComp (D₁ D₂ : S → Set S) :
-    (dseq D₁ D₂ : S → Set S) = D₁ >=> D₂ :=
+theorem seq_eq_kleisliComp (D₁ D₂ : S → Set S) :
+    (seq D₁ D₂ : S → Set S) = D₁ >=> D₂ :=
   funext fun i => Set.ext fun j => by
     rw [Bind.kleisliRight, Set.bind_def, Set.mem_iUnion₂]
     exact exists_congr fun k => exists_prop.symm
@@ -112,14 +114,14 @@ def liftEquiv : Update S ≃ sSupHom (Set S) (Set S) where
 
 /-- The equivalence sends sequencing to composition (diagrammatic order):
 the transformer monoid restricts to the relational one. -/
-theorem liftEquiv_dseq (D₁ D₂ : Update S) :
+theorem liftEquiv_seq (D₁ D₂ : Update S) :
     (liftEquiv (D₁ ⨟ D₂) : Set S → Set S) =
       (liftEquiv D₂ : Set S → Set S) ∘ (liftEquiv D₁ : Set S → Set S) :=
-  lift_dseq D₁ D₂
+  lift_seq D₁ D₂
 
 /-! ### `RelCat ≌ KleisliCat Set` -/
 
-open CategoryTheory
+open CategoryTheory Update
 
 /-- [UPSTREAM] Relations to Kleisli arrows of the powerset monad: curry. -/
 def relCatToKleisli : RelCat.{u} ⥤ KleisliCat Set where

--- a/Linglib/Semantics/Dynamic/Kleisli.lean
+++ b/Linglib/Semantics/Dynamic/Kleisli.lean
@@ -69,7 +69,7 @@ theorem lift_eq_bind (R : Update S) (σ : Set S) :
 
 /-- A CCP is distributive iff it preserves arbitrary joins of states. -/
 theorem isDistributive_iff_map_sSup (φ : CCP S) :
-    IsDistributive φ ↔ ∀ T : Set (Set S), φ (sSup T) = sSup (φ '' T) := by
+    CCP.IsDistributive φ ↔ ∀ T : Set (Set S), φ (sSup T) = sSup (φ '' T) := by
   simp only [Set.sSup_eq_sUnion]
   constructor
   · intro h T

--- a/Linglib/Semantics/Dynamic/Kleisli.lean
+++ b/Linglib/Semantics/Dynamic/Kleisli.lean
@@ -115,7 +115,7 @@ def liftEquiv : Update S ≃ sSupHom (Set S) (Set S) where
 /-- The equivalence sends sequencing to composition (diagrammatic order):
 the transformer monoid restricts to the relational one. -/
 theorem liftEquiv_seq (D₁ D₂ : Update S) :
-    (liftEquiv (D₁ ⨟ D₂) : Set S → Set S) =
+    (liftEquiv (seq D₁ D₂) : Set S → Set S) =
       (liftEquiv D₂ : Set S → Set S) ∘ (liftEquiv D₁ : Set S → Set S) :=
   lift_seq D₁ D₂
 

--- a/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
@@ -191,7 +191,8 @@ theorem might_iff_not_must_neg (φ : Formula) (s : InfoState E) (hs : s.Nonempty
     rw [Formula.mem_update] at hp
     exact hsup _ hp.1 hp.2
   · intro h
-    simp only [InfoState.supports, Formula.sat, not_forall, Classical.not_not] at h
+    simp only [InfoState.supports, DynamicSemantics.supportOf, satisfiesPLA,
+      Formula.sat, not_forall, Classical.not_not] at h
     obtain ⟨p, hp, hsat⟩ := h
     exact ⟨p, (Formula.mem_update M φ s p.1 p.2).mpr ⟨hp, hsat⟩⟩
 

--- a/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
@@ -125,13 +125,13 @@ theorem must_subset (φ : Formula) (s : InfoState E) :
 Asserting then testing: φ; might ψ passes iff φ-update leaves room for ψ.
 -/
 theorem update_then_might (φ ψ : Formula) (s : InfoState E) :
-    (φ.update M ;; ψ.might M) s = ψ.might M (φ.update M s) := rfl
+    seq (φ.update M) (ψ.might M) s = ψ.might M (φ.update M s) := rfl
 
 /--
 Asserting then requiring: φ; must ψ passes iff φ-update supports ψ.
 -/
 theorem update_then_must (φ ψ : Formula) (s : InfoState E) :
-    (φ.update M ;; ψ.must M) s = ψ.must M (φ.update M s) := rfl
+    seq (φ.update M) (ψ.must M) s = ψ.must M (φ.update M s) := rfl
 
 
 /--

--- a/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Epistemic.lean
@@ -172,7 +172,7 @@ theorem supports_implies_might (φ : Formula) (s : InfoState E)
     obtain ⟨p, hp⟩ := hs
     use p
     simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq]
-    exact ⟨hp, hsup p hp⟩
+    exact ⟨hp, hsup hp⟩
   simp only [if_pos hne]
 
 
@@ -189,10 +189,11 @@ theorem might_iff_not_must_neg (φ : Formula) (s : InfoState E) (hs : s.Nonempty
   constructor
   · rintro ⟨⟨g, ê⟩, hp⟩ hsup
     rw [Formula.mem_update] at hp
-    exact hsup _ hp.1 hp.2
+    exact hsup hp.1 hp.2
   · intro h
-    simp only [InfoState.supports, DynamicSemantics.supportOf, satisfiesPLA,
-      Formula.sat, not_forall, Classical.not_not] at h
+    simp only [InfoState.supports, DynamicSemantics.supportOf, Set.subset_def,
+      DynamicSemantics.contentOf, Set.mem_setOf_eq, satisfiesPLA, Formula.sat,
+      not_forall, Classical.not_not] at h
     obtain ⟨p, hp, hsat⟩ := h
     exact ⟨p, (Formula.mem_update M φ s p.1 p.2).mpr ⟨hp, hsat⟩⟩
 

--- a/Linglib/Semantics/Dynamic/PLA/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Semantics.lean
@@ -29,6 +29,7 @@ namespace PLA
 
 open Classical
 open DynamicSemantics
+open DynamicSemantics.Update (test)
 
 
 /-- An assignment maps variable indices to entities -/

--- a/Linglib/Semantics/Dynamic/PLA/Update.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Update.lean
@@ -239,7 +239,7 @@ which this formalization does not render: existentials certify witnesses in
 the membership condition without exporting them to output states.
 -/
 def Formula.dynConj (φ ψ : Formula) : Update E :=
-  φ.update M ;; ψ.update M
+  seq (φ.update M) (ψ.update M)
 
 /-- Dynamic conjunction update rule -/
 theorem Formula.dynConj_eq (φ ψ : Formula) (s : InfoState E) :
@@ -391,7 +391,7 @@ theorem dynConj_subset_inter (φ ψ : Formula) (s : InfoState E) :
 
 /-- Sequential composition is nested intersection of contents. -/
 theorem static_seq_is_intersection (φ ψ : Formula) (s : InfoState E) :
-    (φ.update M ;; ψ.update M) s = s ∩ φ.content M ∩ ψ.content M := by
+    seq (φ.update M) (ψ.update M) s = s ∩ φ.content M ∩ ψ.content M := by
   simp only [DynamicSemantics.CCP.seq, contents_updates_equiv, Set.inter_assoc]
 
 /-- Only ∃ introduces discourse referents. -/
@@ -543,7 +543,7 @@ theorem exists_domain_nonempty (x : VarIdx) (φ : Formula) :
 
 /-- Sequential update as set comprehension. -/
 theorem seq_update_eq (φ ψ : Formula) (s : InfoState E) :
-    (φ.update M ;; ψ.update M) s =
+    seq (φ.update M) (ψ.update M) s =
     { p ∈ s | φ.sat M p.1 p.2 ∧ ψ.sat M p.1 p.2 } := by
   ext ⟨g, ê⟩
   exact Formula.mem_dynConj M φ ψ s g ê
@@ -551,7 +551,7 @@ theorem seq_update_eq (φ ψ : Formula) (s : InfoState E) :
 /-- Sequential update commutes: eliminative updates are filters, so order is
 irrelevant. ([dekker-2012] restricts this to dref-free formulas.) -/
 theorem static_conjunction_commutes (φ ψ : Formula) (s : InfoState E) :
-    (φ.update M ;; ψ.update M) s = (ψ.update M ;; φ.update M) s := by
+    seq (φ.update M) (ψ.update M) s = seq (ψ.update M) (φ.update M) s := by
   rw [seq_update_eq, seq_update_eq]
   ext p
   simp only [Set.mem_setOf_eq]

--- a/Linglib/Semantics/Dynamic/PLA/Update.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Update.lean
@@ -208,10 +208,10 @@ theorem InfoState.supports_conj (s : InfoState E) (φ ψ : Formula) :
   constructor
   · intro h
     constructor
-    · intro p hp; exact (h p hp).1
-    · intro p hp; exact (h p hp).2
+    · intro p hp; exact (h hp).1
+    · intro p hp; exact (h hp).2
   · intro ⟨hφ, hψ⟩ p hp
-    exact ⟨hφ p hp, hψ p hp⟩
+    exact ⟨hφ hp, hψ hp⟩
 
 
 /--
@@ -350,29 +350,21 @@ Smaller states have "more information" (fewer possibilities = more certainty).
 -/
 theorem support_downward_closed (φ : Formula) (s t : InfoState E) (h : t ⊆ s)
     (hs : s ⊫[M] φ) : t ⊫[M] φ :=
-  λ p hp => hs p (h hp)
+  h.trans hs
 
 /--
 Intersection preserves support: if s and t both support φ, so does s ∩ t.
 -/
 theorem support_inter (φ : Formula) (s t : InfoState E) (hs : s ⊫[M] φ)
-    (_ht : t ⊫[M] φ) : (s ∩ t) ⊫[M] φ := by
-  intro p hp
-  exact hs p hp.1
+    (_ht : t ⊫[M] φ) : (s ∩ t) ⊫[M] φ :=
+  Set.inter_subset_left.trans hs
 
 /--
 Union and support: s ∪ t supports φ iff both s and t support φ.
 -/
 theorem support_union_iff (φ : Formula) (s t : InfoState E) :
-    ((s ∪ t) ⊫[M] φ) ↔ (s ⊫[M] φ) ∧ (t ⊫[M] φ) := by
-  constructor
-  · intro h
-    exact ⟨λ p hp => h p (Set.mem_union_left t hp),
-           λ p hp => h p (Set.mem_union_right s hp)⟩
-  · intro ⟨hs, ht⟩ p hp
-    cases hp with
-    | inl hps => exact hs p hps
-    | inr hpt => exact ht p hpt
+    ((s ∪ t) ⊫[M] φ) ↔ (s ⊫[M] φ) ∧ (t ⊫[M] φ) :=
+  Set.union_subset_iff
 
 /--
 Update distributes over intersection: φ.update(s ∩ t) = φ.update(s) ∩ φ.update(t)
@@ -486,7 +478,7 @@ theorem obs10_dynamic_eq_classical_entailment (φ ψ : Formula) :
     have hmem : (g, ê) ∈ φ.update M Set.univ := by
       simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq, Set.mem_univ, true_and]
       exact hsat
-    exact hdyn Set.univ (g, ê) hmem
+    exact hdyn Set.univ hmem
   · -- Classical → Dynamic: unfold update membership
     intro hclass s p hp
     simp only [DynamicSemantics.mem_updateFromSat, satisfiesPLA] at hp
@@ -510,14 +502,14 @@ theorem obs11_deduction_theorem (φ χ ψ : Formula) :
     have hmem : p ∈ (φ ⋀ χ).update M s := by
       simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq, Formula.sat]
       exact ⟨hp.1, hp.2, hχ⟩
-    exact hnψ (h s p hmem)
+    exact hnψ (h s hmem)
   · -- (←) If φ ⊨ χ→ψ, then φ∧χ ⊨ ψ
     intro h s p hp
     simp only [DynamicSemantics.mem_updateFromSat, satisfiesPLA, Formula.sat] at hp
     have hp_φ : p ∈ φ.update M s := by
       simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq]
       exact ⟨hp.1, hp.2.1⟩
-    have himpl := h s p hp_φ
+    have himpl := h s hp_φ
     simp only [Formula.impl] at himpl
     by_contra hnψ
     exact himpl ⟨hp.2.2, hnψ⟩

--- a/Linglib/Semantics/Dynamic/PLA/Update.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Update.lean
@@ -80,30 +80,8 @@ equivalence, componentwise. -/
 def possEquivMerged {E : Type*} : Poss E ≃ MergedAssignment E :=
   (Equiv.sumArrowEquivProdArrow _ _ E).symm
 
-/--
-An update is a Context Change Potential over PLA possibilities.
-
-We inherit the Monoid structure from `DynamicSemantics.CCP`:
-- Identity: `DynamicSemantics.CCP.id` (leaves state unchanged)
-- Composition: `DynamicSemantics.CCP.seq` (do u, then v), notation `;`
-- Associativity: guaranteed by the Monoid laws
--/
+/-- An update is a context change potential over PLA possibilities. -/
 abbrev Update (E : Type*) := DynamicSemantics.CCP (Poss E)
-
-namespace Update
-
-/-- Identity update: leaves state unchanged (from DynamicSemantics.CCP) -/
-abbrev id : Update E := DynamicSemantics.CCP.id
-
-/-- Absurd update: always yields empty state (from DynamicSemantics.CCP) -/
-abbrev absurd : Update E := DynamicSemantics.CCP.absurd
-
-/-- Absurd before anything yields absurd output (from DynamicSemantics.CCP) -/
-theorem seq_absurd (u : Update E) : DynamicSemantics.CCP.seq u absurd = absurd :=
-  DynamicSemantics.CCP.seq_absurd u
-
-end Update
-
 
 section
 variable (M : Model E)

--- a/Linglib/Semantics/Dynamic/PLA/Update.lean
+++ b/Linglib/Semantics/Dynamic/PLA/Update.lean
@@ -109,14 +109,24 @@ section
 variable (M : Model E)
 
 /--
-The content of a formula: set of (g, ê) pairs where φ is satisfied.
+PLA satisfaction relation: possibility satisfies formula.
+
+This bridges PLA to the DynamicSemantics.CCP infrastructure, matching the signature
+`P → φ → Prop` expected by DynamicSemantics.updateFromSat.
+-/
+def satisfiesPLA : Poss E → Formula → Prop :=
+  λ p φ => φ.sat M p.1 p.2
+
+/--
+The content of a formula: set of (g, ê) pairs where φ is satisfied —
+the spine's `contentOf` at `satisfiesPLA`.
 
 ⟦φ⟧^M = { (g, ê) | M, g, ê ⊨ φ }
 
 This is the "static" meaning - what information φ conveys.
 -/
 def Formula.content (φ : Formula) : InfoState E :=
-  { p | φ.sat M p.1 p.2 }
+  DynamicSemantics.contentOf (satisfiesPLA M) φ
 
 theorem Formula.mem_content (φ : Formula) (g : Assignment E) (ê : WitnessSeq E) :
     (g, ê) ∈ φ.content M ↔ φ.sat M g ê := Iff.rfl
@@ -125,23 +135,14 @@ theorem Formula.mem_content (φ : Formula) (g : Assignment E) (ê : WitnessSeq E
 theorem Formula.content_neg (φ : Formula) :
     (∼φ).content M = (φ.content M)ᶜ := by
   ext ⟨g, ê⟩
-  simp [content, sat]
+  simp [content, DynamicSemantics.contentOf, satisfiesPLA, sat]
 
 /-- Content of conjunction is intersection -/
 theorem Formula.content_conj (φ ψ : Formula) :
     (φ ⋀ ψ).content M = φ.content M ∩ ψ.content M := by
   ext ⟨g, ê⟩
-  simp [content, sat]
+  simp [content, DynamicSemantics.contentOf, satisfiesPLA, sat]
 
-
-/--
-PLA satisfaction relation: possibility satisfies formula.
-
-This bridges PLA to the DynamicSemantics.CCP infrastructure, matching the signature
-`P → φ → Prop` expected by DynamicSemantics.updateFromSat.
--/
-def satisfiesPLA : Poss E → Formula → Prop :=
-  λ p φ => φ.sat M p.1 p.2
 
 /--
 The update of a formula: filter state to satisfying pairs.
@@ -168,20 +169,20 @@ The update of φ is intersection with the content of φ:
 This shows Contents and Updates are equivalent perspectives.
 -/
 theorem contents_updates_equiv (φ : Formula) (s : InfoState E) :
-    φ.update M s = s ∩ φ.content M := by
-  ext ⟨g, ê⟩
-  simp [Formula.update, Formula.content, InfoState.restrict]
+    φ.update M s = s ∩ φ.content M :=
+  DynamicSemantics.updateFromSat_eq_inter_content (satisfiesPLA M) φ s
 
 
 /--
-A state supports a formula iff the formula is satisfied throughout the state.
+A state supports a formula iff the formula is satisfied throughout the
+state — the spine's `supportOf` at `satisfiesPLA`.
 
 s ⊨ φ iff ∀(g, ê) ∈ s, M, g, ê ⊨ φ
 
 This is the evidential perspective: the speaker's evidence supports φ.
 -/
 def InfoState.supports (s : InfoState E) (φ : Formula) : Prop :=
-  ∀ p ∈ s, φ.sat M p.1 p.2
+  DynamicSemantics.supportOf (satisfiesPLA M) s φ
 
 end
 
@@ -192,14 +193,14 @@ variable (M : Model E)
 
 /-- Empty state supports everything (vacuously) -/
 theorem InfoState.empty_supports (φ : Formula) :
-    (∅ : InfoState E) ⊫[M] φ := by
-  intro p hp
-  exact False.elim hp
+    (∅ : InfoState E) ⊫[M] φ :=
+  DynamicSemantics.empty_supports (satisfiesPLA M) φ
 
 /-- Support is monotonic: if s ⊆ t and t supports φ, then s supports φ -/
 theorem InfoState.supports_mono (s t : InfoState E) (φ : Formula) (h : s ⊆ t)
     (ht : t ⊫[M] φ) :
-    s ⊫[M] φ := λ p hp => ht p (h hp)
+    s ⊫[M] φ :=
+  DynamicSemantics.support_mono (satisfiesPLA M) t s φ h ht
 
 /-- Support and conjunction -/
 theorem InfoState.supports_conj (s : InfoState E) (φ ψ : Formula) :
@@ -223,17 +224,8 @@ A state supports φ iff updating with φ leaves it unchanged:
 This shows Updates and Support are equivalent perspectives.
 -/
 theorem updates_support_equiv (φ : Formula) (s : InfoState E) :
-    (s ⊫[M] φ) ↔ φ.update M s = s := by
-  constructor
-  · intro h
-    ext ⟨g, ê⟩
-    simp [Formula.update, InfoState.restrict]
-    intro hs
-    exact h (g, ê) hs
-  · intro h p hp
-    have : p ∈ φ.update M s := by rw [h]; exact hp
-    simp [Formula.update, InfoState.restrict] at this
-    exact this.2
+    (s ⊫[M] φ) ↔ φ.update M s = s :=
+  DynamicSemantics.support_iff_update_eq (satisfiesPLA M) φ s
 
 
 /--
@@ -337,7 +329,7 @@ theorem update_eliminative (φ : Formula) (s : InfoState E) : φ.update M s ⊆ 
 PLA's formula update is eliminative in the Core sense.
 -/
 theorem update_isEliminative (φ : Formula) :
-    DynamicSemantics.IsEliminative (φ.update M : Update E) :=
+    DynamicSemantics.CCP.IsEliminative (φ.update M : Update E) :=
   DynamicSemantics.updateFromSat_eliminative (satisfiesPLA M) φ
 
 /--
@@ -440,12 +432,11 @@ theorem same_content_same_update (φ ψ : Formula) (hcontent : φ.content M = ψ
 
 /--
 Dynamic entailment: φ dynamically entails ψ if updating with φ always
-yields a state that supports ψ.
-
-This is the fundamental semantic consequence relation for dynamic semantics.
+yields a state that supports ψ — the spine's `dynamicEntailsOf` at
+`satisfiesPLA`.
 -/
 def dynamicEntails (φ ψ : Formula) : Prop :=
-  ∀ s : InfoState E, (φ.update M s) ⊫[M] ψ
+  DynamicSemantics.dynamicEntailsOf (satisfiesPLA M) φ ψ
 
 end
 
@@ -460,19 +451,15 @@ Reflexivity of dynamic entailment: φ ⊨_dyn φ.
 Updating with φ yields a state that supports φ.
 -/
 theorem dynamicEntails_refl (φ : Formula) :
-    φ ⊨[M]_dyn φ := by
-  intro s p hp
-  simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp
-  exact hp.2
+    φ ⊨[M]_dyn φ :=
+  DynamicSemantics.dynamicEntails_refl (satisfiesPLA M) φ
 
 /--
 Transitivity of dynamic entailment; holds because update is eliminative.
 -/
 theorem dynamicEntails_trans (φ ψ χ : Formula) (h1 : φ ⊨[M]_dyn ψ) (h2 : ψ ⊨[M]_dyn χ) :
-    φ ⊨[M]_dyn χ := by
-  intro s p hp
-  exact h2 s p ((Formula.mem_update M ψ s p.1 p.2).mpr
-    ⟨update_eliminative M φ s hp, h1 s p hp⟩)
+    φ ⊨[M]_dyn χ :=
+  DynamicSemantics.dynamicEntails_trans (satisfiesPLA M) φ ψ χ h1 h2
 
 /--
 Weakening: if s supports φ and φ ⊨_dyn ψ, then φ.update(s) supports ψ.
@@ -502,7 +489,7 @@ theorem obs10_dynamic_eq_classical_entailment (φ ψ : Formula) :
     exact hdyn Set.univ (g, ê) hmem
   · -- Classical → Dynamic: unfold update membership
     intro hclass s p hp
-    simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp
+    simp only [DynamicSemantics.mem_updateFromSat, satisfiesPLA] at hp
     exact hclass p.1 p.2 hp.2
 
 /--
@@ -516,7 +503,7 @@ theorem obs11_deduction_theorem (φ χ ψ : Formula) :
   constructor
   · -- (→) If φ∧χ ⊨ ψ, then φ ⊨ χ→ψ
     intro h s p hp
-    simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp
+    simp only [DynamicSemantics.mem_updateFromSat, satisfiesPLA] at hp
     show (χ ⟶ ψ).sat M p.1 p.2
     simp only [Formula.impl, Formula.sat]
     intro ⟨hχ, hnψ⟩
@@ -526,12 +513,12 @@ theorem obs11_deduction_theorem (φ χ ψ : Formula) :
     exact hnψ (h s p hmem)
   · -- (←) If φ ⊨ χ→ψ, then φ∧χ ⊨ ψ
     intro h s p hp
-    simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq, Formula.sat] at hp
+    simp only [DynamicSemantics.mem_updateFromSat, satisfiesPLA, Formula.sat] at hp
     have hp_φ : p ∈ φ.update M s := by
       simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq]
       exact ⟨hp.1, hp.2.1⟩
     have himpl := h s p hp_φ
-    simp only [Formula.impl, Formula.sat] at himpl
+    simp only [Formula.impl] at himpl
     by_contra hnψ
     exact himpl ⟨hp.2.2, hnψ⟩
 

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -31,6 +31,7 @@ carries them.
 namespace DynamicSemantics
 
 open DynamicSemantics (lift)
+open Update
 
 variable {W V M : Type*} {X Y Z : Finset V}
 
@@ -98,7 +99,7 @@ collapse in `Category.lean`.) -/
 theorem toUpdate_comp (u : Transition W M X Y) (v : Transition W M Y Z) :
     (u.comp v).toUpdate = u.toUpdate ⨟ v.toUpdate := by
   funext p q
-  simp only [toUpdate, comp, dseq, Relation.Comp, eq_iff_iff]
+  simp only [toUpdate, comp, seq, Relation.Comp, eq_iff_iff]
   constructor
   · rintro ⟨hw, k, huk, hkv⟩
     exact ⟨⟨p.world, k⟩, ⟨rfl, huk⟩, hw, hkv⟩

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -97,7 +97,7 @@ one-object collapse is functorial on composition. (It is not unital:
 `toUpdate (id X)` is agreement on `X`, not equality — see the quotient
 collapse in `Category.lean`.) -/
 theorem toUpdate_comp (u : Transition W M X Y) (v : Transition W M Y Z) :
-    (u.comp v).toUpdate = u.toUpdate ⨟ v.toUpdate := by
+    (u.comp v).toUpdate = seq u.toUpdate v.toUpdate := by
   funext p q
   simp only [toUpdate, comp, seq, Relation.Comp, eq_iff_iff]
   constructor

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -157,13 +157,7 @@ abbrev CCP (S : Type*) := Set S → Set S
 
 namespace CCP
 
-variable {S : Type*} {u v φ ψ : CCP S}
-
-/-- The identity CCP. -/
-def id : CCP S := λ s => s
-
-/-- The absurd CCP: crash to the empty state. -/
-def absurd : CCP S := λ _ => ∅
+variable {S : Type*} {u v : CCP S}
 
 /-- Sequential composition of CCPs, in diagrammatic order. -/
 def seq (u v : CCP S) : CCP S := λ s => v (u s)
@@ -176,36 +170,32 @@ scoped instance : Monoid (CCP S) where
   one_mul _ := rfl
   mul_one _ := rfl
 
-/-- The absurd CCP absorbs on the right. -/
-theorem seq_absurd (u : CCP S) : seq u absurd = absurd := rfl
-
 /-- Dynamic negation by set difference: the states that do not survive `φ`
 ([heim-1982]; [veltman-1996]). -/
 def neg (φ : CCP S) : CCP S := λ s => s \ φ s
 
 /-! ### Whole-state tests -/
 
-open Classical in
 /-- `guard C` passes a state through iff it satisfies `C`, else crashes to `∅`. -/
-noncomputable def guard (C : Set S → Prop) : CCP S := λ s => if C s then s else ∅
+def guard (C : Set S → Prop) : CCP S := λ s => { p ∈ s | C s }
 
 /-- A guard whose condition holds passes the state through. -/
 @[simp] theorem guard_pos {C : Set S → Prop} {s} (h : C s) : guard C s = s :=
-  if_pos h
+  Set.ext λ _ => and_iff_left h
 
 /-- A guard whose condition fails crashes to `∅`. -/
 @[simp] theorem guard_neg {C : Set S → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
-  if_neg h
+  Set.eq_empty_of_forall_notMem λ _ hp => h hp.2
 
 /-- `negTest φ` passes iff `φ` crashes — a whole-state consistency test, not
 the set-difference `neg` (see the implementation notes). -/
-noncomputable def negTest (φ : CCP S) : CCP S := guard (λ s => ¬ (φ s).Nonempty)
+def negTest (φ : CCP S) : CCP S := guard (λ s => ¬ (φ s).Nonempty)
 
 /-- `might φ` passes iff `φ` yields a nonempty result ([veltman-1996]). -/
-noncomputable def might (φ : CCP S) : CCP S := guard (λ s => (φ s).Nonempty)
+def might (φ : CCP S) : CCP S := guard (λ s => (φ s).Nonempty)
 
 /-- `must φ` passes iff `φ` returns its input unchanged ([veltman-1996]). -/
-noncomputable def must (φ : CCP S) : CCP S := guard (λ s => φ s = s)
+def must (φ : CCP S) : CCP S := guard (λ s => φ s = s)
 
 /-- Acceptance consequence: every `φ`-output is a fixed point of `ψ`
 ([veltman-1996]'s acceptance validity; [beaver-2001]'s D45). -/
@@ -213,18 +203,16 @@ def entails (φ ψ : CCP S) : Prop := ∀ s : Set S, ψ (φ s) = φ s
 
 /-! ### Classification -/
 
-/-- A transformer is *eliminative* if it never adds possibilities: `u ≤ id`
-pointwise. -/
-def IsEliminative (u : CCP S) : Prop := ∀ s, u s ⊆ s
+/-- A transformer is *eliminative* if it never adds possibilities. -/
+def IsEliminative (u : CCP S) : Prop := u ≤ id
 
 /-- The identity is eliminative. -/
-theorem isEliminative_id : IsEliminative (id : CCP S) :=
-  λ _ => Set.Subset.rfl
+theorem isEliminative_id : IsEliminative (id : CCP S) := le_rfl
 
 /-- Sequencing preserves eliminativity. -/
 theorem IsEliminative.seq (hu : IsEliminative u) (hv : IsEliminative v) :
-    IsEliminative (u.seq v) := λ s _ hp =>
-  hu s (hv (u s) hp)
+    IsEliminative (u.seq v) :=
+  λ s => (hv (u s)).trans (hu s)
 
 /-- A transformer is a *test* if it passes its input through or crashes to
 `∅` — [veltman-1996]'s tests, `Update.IsTest` one carrier up. -/

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -102,8 +102,6 @@ namespace DynamicSemantics
 
 /-! ## The relational face -/
 
-section Relational
-
 /-- A dynamic meaning as a binary relation between input and output states. -/
 abbrev Update (S : Type*) := S → S → Prop
 
@@ -185,8 +183,6 @@ theorem IsTest.eq_test_closure (h : IsTest D) :
   exact propext (by grind [test, closure, IsTest])
 
 end Update
-
-end Relational
 
 /-! ## The transformer face -/
 

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -187,6 +187,9 @@ def guard (C : Set S → Prop) : CCP S := λ s => { p ∈ s | C s }
 @[simp] theorem guard_neg {C : Set S → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
   Set.eq_empty_of_forall_notMem λ _ hp => h hp.2
 
+@[simp] theorem mem_guard {C : Set S → Prop} {s : Set S} {p : S} :
+    p ∈ guard C s ↔ p ∈ s ∧ C s := Iff.rfl
+
 /-- `negTest φ` passes iff `φ` crashes — a whole-state consistency test, not
 the set-difference `neg` (see the implementation notes). -/
 def negTest (φ : CCP S) : CCP S := guard (λ s => ¬ (φ s).Nonempty)
@@ -228,12 +231,11 @@ theorem guard_isTest (C : Set S → Prop) : IsTest (guard C) :=
 
 /-- A test is the guard of its own acceptance condition — the mirror of
 `Update.IsTest.eq_test_closure`. -/
-theorem IsTest.eq_guard (h : IsTest u) : u = guard fun s => u s = s := by
-  funext s
-  by_cases hs : u s = s
-  · rw [guard_pos (C := fun t => u t = t) hs, hs]
-  · rw [guard_neg (C := fun t => u t = t) hs]
-    exact (h s).resolve_left hs
+theorem IsTest.eq_guard (h : IsTest u) : u = guard fun s => u s = s :=
+  funext λ s => Set.ext λ p =>
+    ⟨λ hp => (h s).elim (λ hs => ⟨hs ▸ hp, hs⟩)
+      (λ h₀ => absurd (h₀ ▸ hp) (Set.notMem_empty p)),
+     λ ⟨hp, hs⟩ => hs.symm ▸ hp⟩
 
 /-- The tests are exactly the guards. -/
 theorem isTest_iff_exists_guard : IsTest u ↔ ∃ C, u = guard C :=
@@ -251,17 +253,14 @@ theorem might_not_isDistributive :
     ∃ (S : Type) (φ : CCP S), ¬IsDistributive (might φ) := by
   refine ⟨Bool, (fun s => {p ∈ s | p = true}), fun hD => ?_⟩
   have hfalse :
-      false ∈ might (fun s : Set Bool => {p ∈ s | p = true}) {true, false} := by
-    rw [might, guard_pos ⟨true, Or.inl rfl, rfl⟩]
-    exact Or.inr rfl
+      false ∈ might (fun s : Set Bool => {p ∈ s | p = true}) {true, false} :=
+    ⟨Or.inr rfl, true, Or.inl rfl, rfl⟩
   rw [hD] at hfalse
   obtain ⟨i, hi, hmem⟩ := hfalse
   rcases hi with rfl | rfl
-  · rw [might, guard_pos ⟨true, rfl, rfl⟩] at hmem
-    exact Bool.false_ne_true hmem
-  · rw [might, guard_neg (fun ⟨x, hx, hx'⟩ => Bool.false_ne_true (hx ▸ hx'))]
-      at hmem
-    exact hmem
+  · exact Bool.false_ne_true hmem.1
+  · obtain ⟨x, hx, hx'⟩ := hmem.2
+    exact Bool.false_ne_true (hx ▸ hx')
 
 end CCP
 

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -36,8 +36,9 @@ iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
 ## Main definitions
 
 * `Update S`, `Condition S`: relations on states and properties of states.
-* `test`, `dneg`, `dseq`, `dimpl`, `ddisj`, `closure`: the relational
-  connectives; `Update S` is a scoped `Monoid` and `IsQuantale`.
+* `Update.test`, `Update.neg`, `Update.seq` (`⨟`), `Update.impl`,
+  `Update.disj`, `Update.closure`: the relational connectives; `Update S` is
+  a scoped `Monoid` and `IsQuantale`.
 * `Update.IsTest`: updates that never change the state.
 * `CCP S`: transformers of information states, a scoped `Monoid` under
   `CCP.seq`, with `CCP.neg`, the whole-state tests `CCP.guard`, `might`,
@@ -66,17 +67,17 @@ iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
 
 ## Notation
 
-* `D₁ ⨟ D₂` for `dseq D₁ D₂`.
+* `D₁ ⨟ D₂` for `Update.seq D₁ D₂`.
 * `u ;; v` for `CCP.seq u v`, scoped to `DynamicSemantics.CCP`.
 
 ## Implementation notes
 
 The algebraic instances are scoped: `Update S` and `CCP S` abbreviate
 function types, so global instances would attach `*` and `1` to bare function
-types for every importer. `open scoped DynamicSemantics` also makes mathlib's
+types for every importer. `open scoped DynamicSemantics.Update` also makes mathlib's
 `WriterT (Update S) Id` a lawful monad.
 
-`dneg` does not validate double-negation elimination: negation collapses
+`Update.neg` does not validate double-negation elimination: negation collapses
 update information to a state predicate. The repairs are framework-specific —
 bilateral swap (`UpdateSemantics/Bilateral.lean`), propositional discourse
 referents (`Studies/Hofmann2025.lean`), classical metalanguage
@@ -109,6 +110,8 @@ abbrev Update (S : Type*) := S → S → Prop
 /-- A static property of a single state; `test` embeds conditions into updates. -/
 abbrev Condition (S : Type*) := S → Prop
 
+namespace Update
+
 variable {S : Type*} {C : Condition S} {D : Update S} {i j : S}
 
 /-! ### The connectives -/
@@ -116,22 +119,19 @@ variable {S : Type*} {C : Condition S} {D : Update S} {i j : S}
 /-- `test C` checks `C` without changing the state. -/
 def test (C : Condition S) : Update S := λ i j => i = j ∧ C j
 
-/-- A test relates a state only to itself. -/
-theorem eq_of_test (h : test C i j) : i = j := h.1
-
-/-- `dneg D` holds at `i` iff no output `k` satisfies `D`. -/
-def dneg (D : Update S) : Condition S := λ i => ¬∃ k, D i k
+/-- `neg D` holds at `i` iff no output `k` satisfies `D`. -/
+def neg (D : Update S) : Condition S := λ i => ¬∃ k, D i k
 
 /-- `D₁ ⨟ D₂` relates `i` to `k` iff some intermediate `j` has `D₁ i j` and `D₂ j k`. -/
-def dseq (D₁ D₂ : Update S) : Update S := Relation.Comp D₁ D₂
+def seq (D₁ D₂ : Update S) : Update S := Relation.Comp D₁ D₂
 
-infixl:65 " ⨟ " => dseq
+infixl:65 " ⨟ " => Update.seq
 
-/-- `dimpl D₁ D₂` holds at `i` iff every `D₁`-output from `i` has a `D₂`-output. -/
-def dimpl (D₁ D₂ : Update S) : Condition S := λ i => ∀ h, D₁ i h → ∃ k, D₂ h k
+/-- `impl D₁ D₂` holds at `i` iff every `D₁`-output from `i` has a `D₂`-output. -/
+def impl (D₁ D₂ : Update S) : Condition S := λ i => ∀ h, D₁ i h → ∃ k, D₂ h k
 
-/-- `ddisj D₁ D₂` holds at `i` iff some disjunct has an output from `i`. -/
-def ddisj (D₁ D₂ : Update S) : Condition S := λ i => ∃ k, D₁ i k ∨ D₂ i k
+/-- `disj D₁ D₂` holds at `i` iff some disjunct has an output from `i`. -/
+def disj (D₁ D₂ : Update S) : Condition S := λ i => ∃ k, D₁ i k ∨ D₂ i k
 
 /-- `closure D` holds at `i` iff `D` has an output from `i` — [heim-1982]'s truth definition. -/
 def closure (D : Update S) : Condition S := λ i => ∃ k, D i k
@@ -141,7 +141,7 @@ def closure (D : Update S) : Condition S := λ i => ∃ k, D i k
 /-- `Update S` is a monoid under `⨟` with the trivial test as unit (scoped;
 see the implementation notes). -/
 scoped instance : Monoid (Update S) where
-  mul := dseq
+  mul := seq
   one := test (λ _ => True)
   mul_assoc _ _ _ := Relation.comp_assoc
   one_mul D := funext₂ λ i _ => propext ⟨λ ⟨_, ⟨h, _⟩, d⟩ => h ▸ d, λ d => ⟨i, ⟨rfl, ⟨⟩⟩, d⟩⟩
@@ -153,13 +153,13 @@ scoped instance : IsQuantale (Update S) where
   mul_sSup_distrib D s := by
     funext i k
     show (D ⨟ sSup s) i k = (⨆ E ∈ s, D ⨟ E) i k
-    simp only [dseq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
+    simp only [seq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
     exact propext ⟨fun ⟨b, hD, ⟨E, hE⟩, hbk⟩ => ⟨E, hE, b, hD, hbk⟩,
       fun ⟨E, hE, b, hD, hbk⟩ => ⟨b, hD, ⟨E, hE⟩, hbk⟩⟩
   sSup_mul_distrib s D := by
     funext i k
     show (sSup s ⨟ D) i k = (⨆ E ∈ s, E ⨟ D) i k
-    simp only [dseq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
+    simp only [seq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
     exact propext ⟨fun ⟨b, ⟨⟨E, hE⟩, hib⟩, hbk⟩ => ⟨E, hE, b, hib, hbk⟩,
       fun ⟨E, hE, b, hib, hbk⟩ => ⟨b, ⟨⟨E, hE⟩, hib⟩, hbk⟩⟩
 
@@ -167,22 +167,24 @@ scoped instance : IsQuantale (Update S) where
 
 /-- An update is a *test* if it never changes the state
 ([groenendijk-stokhof-1991], Definition 11). -/
-def Update.IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
+def IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
 
 /-- `test C` is a test. -/
-theorem Update.isTest_test (C : Condition S) : Update.IsTest (test C) :=
+theorem isTest_test (C : Condition S) : IsTest (test C) :=
   fun _ _ h => h.1
 
 /-- Tests are the subidentities of the update monoid: the coreflexives `D ≤ 1`. -/
-theorem Update.isTest_iff_le_one : D.IsTest ↔ D ≤ 1 :=
+theorem isTest_iff_le_one : D.IsTest ↔ D ≤ 1 :=
   ⟨fun h _ _ hij => ⟨h hij, trivial⟩, fun h _ _ hij => (h _ _ hij).1⟩
 
 /-- A test is the test of its own closure ([groenendijk-stokhof-1991]'s
 Fact 6); the transformer-face mirror is `CCP.IsTest.eq_guard`. -/
-theorem Update.IsTest.eq_test_closure (h : Update.IsTest D) :
+theorem IsTest.eq_test_closure (h : IsTest D) :
     D = test (closure D) := by
   funext i j
-  exact propext (by grind [test, closure, Update.IsTest])
+  exact propext (by grind [test, closure, IsTest])
+
+end Update
 
 end Relational
 
@@ -321,6 +323,8 @@ section RelationalBridge
 
 variable {S : Type*} {R R' : Update S} {C : Condition S} {σ : Set S} {i j : S}
 
+open Update
+
 /-- The relational image: `lift R σ` collects the `R`-outputs of the elements
 of `σ` — the strongest postcondition of [muskens-van-benthem-visser-2011]. -/
 def lift (R : Update S) : CCP S := λ σ => { j | ∃ i ∈ σ, R i j }
@@ -331,8 +335,8 @@ def lower (φ : CCP S) : Update S := λ i j => j ∈ φ {i}
 theorem mem_lift : j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
 
 /-- `lift` sends sequencing to composition. -/
-theorem lift_dseq (R₁ R₂ : Update S) :
-    lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) :=
+theorem lift_seq (R₁ R₂ : Update S) :
+    lift (R₁ ⨟ R₂) = CCP.seq (lift R₁) (lift R₂) :=
   funext λ _ => Set.ext λ _ => ⟨λ ⟨i, m, j, a, b⟩ => ⟨j, ⟨i, m, a⟩, b⟩,
     λ ⟨j, ⟨i, m, a⟩, b⟩ => ⟨i, m, j, a, b⟩⟩
 
@@ -438,6 +442,8 @@ in content, and dynamic entailment is content inclusion
 section Satisfaction
 
 variable {S φ : Type*}
+
+open Update (test)
 
 /-- The content of a formula: all possibilities satisfying it. -/
 def contentOf (sat : S → φ → Prop) (ψ : φ) : Set S := { p | sat p ψ }

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -138,29 +138,16 @@ def closure (D : Update S) : Condition S := λ i => ∃ k, D i k
 
 /-! ### The update quantale -/
 
-/-- Sequencing is associative. -/
-theorem dseq_assoc (D₁ D₂ D₃ : Update S) :
-    (D₁ ⨟ D₂) ⨟ D₃ = D₁ ⨟ (D₂ ⨟ D₃) :=
-  Relation.comp_assoc
-
-/-- An everywhere-true test is a left identity for sequencing. -/
-theorem test_dseq (C : Condition S) (D : Update S) (hC : ∀ i, C i) :
-    test C ⨟ D = D := by
-  funext i j; simp [dseq, Relation.Comp, test, hC]
-
-/-- An everywhere-true test is a right identity for sequencing. -/
-theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
-    D ⨟ test C = D := by
-  funext i j; simp [dseq, Relation.Comp, test, hC]
-
 /-- `Update S` is a monoid under `⨟` with the trivial test as unit (scoped;
 see the implementation notes). -/
 scoped instance : Monoid (Update S) where
   mul := dseq
   one := test (λ _ => True)
-  mul_assoc := dseq_assoc
-  one_mul D := test_dseq _ D (λ _ => trivial)
-  mul_one D := dseq_test D _ (λ _ => trivial)
+  mul_assoc _ _ _ := Relation.comp_assoc
+  one_mul D := funext₂ λ i j => propext
+    ⟨λ ⟨_, ⟨hik, _⟩, hD⟩ => hik ▸ hD, λ hD => ⟨i, ⟨rfl, trivial⟩, hD⟩⟩
+  mul_one D := funext₂ λ i j => propext
+    ⟨λ ⟨_, hD, hkj, _⟩ => hkj ▸ hD, λ hD => ⟨j, hD, rfl, trivial⟩⟩
 
 /-- `Update S` is a quantale: sequencing distributes over arbitrary unions of
 updates, so mathlib's residuation vocabulary applies (scoped). -/

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -65,10 +65,6 @@ iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
   fixed point of the update, and the satisfaction layer's consequence is
   acceptance consequence.
 
-## Notation
-
-* `u ;; v` for `CCP.seq u v`, scoped to `DynamicSemantics.CCP`.
-
 ## Implementation notes
 
 The algebraic instances are scoped: `Update S` and `CCP S` abbreviate
@@ -199,8 +195,6 @@ def absurd : CCP S := λ _ => ∅
 /-- Sequential composition of CCPs, in diagrammatic order. -/
 def seq (u v : CCP S) : CCP S := λ s => v (u s)
 
-scoped infixl:70 " ;; " => seq
-
 /-- `CCP S` is a monoid under `seq` (scoped; see the implementation notes). -/
 scoped instance : Monoid (CCP S) where
   mul := seq
@@ -210,7 +204,7 @@ scoped instance : Monoid (CCP S) where
   mul_one _ := rfl
 
 /-- The absurd CCP absorbs on the right. -/
-theorem seq_absurd (u : CCP S) : u ;; absurd = absurd := rfl
+theorem seq_absurd (u : CCP S) : seq u absurd = absurd := rfl
 
 /-- Dynamic negation by set difference: the states that do not survive `φ`
 ([heim-1982]; [veltman-1996]). -/

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -36,7 +36,7 @@ iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
 ## Main definitions
 
 * `Update S`, `Condition S`: relations on states and properties of states.
-* `Update.test`, `Update.neg`, `Update.seq` (`⨟`), `Update.impl`,
+* `Update.test`, `Update.neg`, `Update.seq`, `Update.impl`,
   `Update.disj`, `Update.closure`: the relational connectives; `Update S` is
   a scoped `Monoid` and `IsQuantale`.
 * `Update.IsTest`: updates that never change the state.
@@ -67,7 +67,6 @@ iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
 
 ## Notation
 
-* `D₁ ⨟ D₂` for `Update.seq D₁ D₂`.
 * `u ;; v` for `CCP.seq u v`, scoped to `DynamicSemantics.CCP`.
 
 ## Implementation notes
@@ -120,10 +119,8 @@ def test (C : Condition S) : Update S := λ i j => i = j ∧ C j
 /-- `neg D` holds at `i` iff no output `k` satisfies `D`. -/
 def neg (D : Update S) : Condition S := λ i => ¬∃ k, D i k
 
-/-- `D₁ ⨟ D₂` relates `i` to `k` iff some intermediate `j` has `D₁ i j` and `D₂ j k`. -/
+/-- `seq D₁ D₂` relates `i` to `k` iff some intermediate `j` has `D₁ i j` and `D₂ j k`. -/
 def seq (D₁ D₂ : Update S) : Update S := Relation.Comp D₁ D₂
-
-infixl:65 " ⨟ " => Update.seq
 
 /-- `impl D₁ D₂` holds at `i` iff every `D₁`-output from `i` has a `D₂`-output. -/
 def impl (D₁ D₂ : Update S) : Condition S := λ i => ∀ h, D₁ i h → ∃ k, D₂ h k
@@ -136,7 +133,7 @@ def closure (D : Update S) : Condition S := λ i => ∃ k, D i k
 
 /-! ### The update quantale -/
 
-/-- `Update S` is a monoid under `⨟` with the trivial test as unit (scoped;
+/-- `Update S` is a monoid under `seq` with the trivial test as unit (scoped;
 see the implementation notes). -/
 scoped instance : Monoid (Update S) where
   mul := seq
@@ -150,13 +147,13 @@ updates, so mathlib's residuation vocabulary applies (scoped). -/
 scoped instance : IsQuantale (Update S) where
   mul_sSup_distrib D s := by
     funext i k
-    show (D ⨟ sSup s) i k = (⨆ E ∈ s, D ⨟ E) i k
+    show seq D (sSup s) i k = (⨆ E ∈ s, seq D E) i k
     simp only [seq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
     exact propext ⟨fun ⟨b, hD, ⟨E, hE⟩, hbk⟩ => ⟨E, hE, b, hD, hbk⟩,
       fun ⟨E, hE, b, hD, hbk⟩ => ⟨b, hD, ⟨E, hE⟩, hbk⟩⟩
   sSup_mul_distrib s D := by
     funext i k
-    show (sSup s ⨟ D) i k = (⨆ E ∈ s, E ⨟ D) i k
+    show seq (sSup s) D i k = (⨆ E ∈ s, seq E D) i k
     simp only [seq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
     exact propext ⟨fun ⟨b, ⟨⟨E, hE⟩, hib⟩, hbk⟩ => ⟨E, hE, b, hib, hbk⟩,
       fun ⟨E, hE, b, hib, hbk⟩ => ⟨b, ⟨⟨E, hE⟩, hib⟩, hbk⟩⟩
@@ -332,7 +329,7 @@ theorem mem_lift : j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
 
 /-- `lift` sends sequencing to composition. -/
 theorem lift_seq (R₁ R₂ : Update S) :
-    lift (R₁ ⨟ R₂) = CCP.seq (lift R₁) (lift R₂) :=
+    lift (seq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) :=
   funext λ _ => Set.ext λ _ => ⟨λ ⟨i, m, j, a, b⟩ => ⟨j, ⟨i, m, a⟩, b⟩,
     λ ⟨j, ⟨i, m, a⟩, b⟩ => ⟨i, m, j, a, b⟩⟩
 

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -11,64 +11,82 @@ import Mathlib.Tactic.Use
 
 Dynamic meanings in their two canonical faces. The *relational* face
 (`Update S = S → S → Prop`, [groenendijk-stokhof-1991]'s DPL relations,
-[heim-1982]'s file change potentials, [kamp-reyle-1993]'s verification
-clauses, parametrized over the state type by [muskens-1996]): meanings
-relate input states to output states pointwise. The *set-transformer*
-face (`CCP S = Set S → Set S`, [heim-1983], [veltman-1996]): meanings
-act on information states — plain sets — as wholes. The literature says
-"state" at both levels: DPL's states are the points `S`, Veltman's are
-the sets `Set S`, and `lift` identifies the relational face's states
-with the transformer face's points — one carrier, two vocabularies. `lift` (the relational image,
-[muskens-van-benthem-visser-2011]'s strongest postcondition) and `lower`
-identify the relational algebra with the *distributive* transformers —
-those that process elements independently — and what the transformer
-face genuinely adds is the non-distributive tests (`CCP.guard`, `might`,
-`must`, `negTest`) that inspect the whole state. `Kleisli.lean`
-certifies the pair as canonical: updates are the Kleisli arrows of the
-powerset monad, transformers their suplattice completion.
+[kamp-reyle-1993]'s verification clauses, parametrized over the state
+type by [muskens-1996]): meanings relate input states to output states
+pointwise. The *set-transformer* face (`CCP S = Set S → Set S`,
+[heim-1982]'s file change potentials, [heim-1983]'s and
+[veltman-1996]'s context change): meanings act on information states —
+plain sets — as wholes. The literature says "state" at both levels:
+DPL's states are the points `S`, Veltman's are the sets `Set S`, and
+`lift` identifies the relational face's states with the transformer
+face's points — one carrier, two vocabularies. `lift` (the relational
+image, [muskens-van-benthem-visser-2011]'s strongest postcondition) and
+`lower` identify the relational algebra with the *distributive*
+transformers — those that process elements independently — and what the
+transformer face genuinely adds is the non-distributive tests
+(`CCP.guard`, `might`, `must`) that inspect the whole state.
+`Kleisli.lean` certifies the pair as canonical: updates are the Kleisli
+arrows of the powerset monad, transformers endomaps of its free
+algebra, and `lift` the comparison between the two — so the two faces
+are the Kleisli and Eilenberg–Moore presentations of one monad.
+
+The algebra is the same at both levels. Meanings compose as a monoid
+(`⨟` relational, `;;` transformer); *tests* are the subidentities —
+`Update.IsTest` is `D ≤ 1` (`isTest_iff_le_one`) — and each level
+normalizes its tests against its own carrier: a relational test is the
+`test` of its truth condition (`Update.IsTest.eq_test_closure`), a
+transformer test is the `guard` of its acceptance condition
+(`CCP.IsTest.eq_guard`). The two notions are one concept at adjacent
+carriers, which is why `lift` does *not* intertwine them: `lift [C]` is
+the kernel operator `σ ↦ σ ∩ C` (eliminative, per-point), not a
+pass-or-`∅` guard.
 
 ## Main definitions
 
 - `Update S`, `Condition S`: relations on states, properties of states;
   `dseq` (`⨟`), `test`, `dneg`, `dimpl`, `ddisj`, `closure`; a `Monoid`
   under `⨟` (scoped instance).
-- `Update.IsTest`: DPL's tests — updates that never change the state.
-- `valid`, `entails` (`⊨`), `sEntails` (`⊨ₛ`): truth and
-  [groenendijk-stokhof-1991] §3.5's two entailment notions.
+- `Update.IsTest`: DPL's tests — the subidentities of the update
+  monoid.
 - `CCP S`: meanings as transformers of information states (plain
-  `Set S`), a monoid under `CCP.seq`; `CCP.neg`, `disj`,
-  `CCP.guard` and the whole-state tests `might`, `must`, `negTest`.
-- `IsEliminative`, `IsExpansive`, `IsTest`, `IsDistributive`: the
-  classification of CCPs. N.B. the CCP-level `IsTest` (pass-or-`∅`,
-  Veltman's test) is *not* the counterpart of the relational
-  `Update.IsTest` (stay-put, DPL's test): `lift` of a relational test
-  is an eliminative filter, not a pass-or-`∅` test.
-- `supportOf`, `contentOf`, `updateFromSat`: satisfaction-based updates
-  and the support relation.
+  `Set S`), a monoid under `CCP.seq`; `CCP.neg`, `CCP.guard` and the
+  whole-state tests `might`, `must`, `negTest`; `CCP.entails`
+  (acceptance-based consequence).
+- `CCP.IsEliminative`, `CCP.IsTest`, `CCP.IsDistributive`: the
+  classification of CCPs.
+- `supportOf`, `contentOf`, `updateFromSat`, `dynamicEntailsOf`: the
+  satisfaction-parameterized layer instantiated by PLA, DRT, DPL.
 - `lift`, `lower`: the bridge between the faces.
 
 ## Main results
 
-- `Update.IsTest.eq_test_closure`: a test is the test of its own truth
-  conditions ([groenendijk-stokhof-1991]'s Fact 6).
-- `entails_iff_valid_test_dimpl` (the deduction theorem, Fact 11),
-  `sEntails_iff_test_closure_entails` (Fact 12), `sEntails_of_subset`
-  (Fact 10).
+- `Update.IsTest.eq_test_closure` ([groenendijk-stokhof-1991]'s
+  Fact 6) and `CCP.IsTest.eq_guard`: the mirror normal forms for tests
+  at the two levels.
 - `lower_lift`, `lift_lower`, `lift_isDistributive`: distributive CCPs
   are exactly the relational images.
 - `lift_le_lift_iff`: `lift` reflects the pointwise order — the
   SP-characterization of update-update consequence.
-- `might_not_isDistributive`: whole-state tests are genuinely beyond
-  the relational fragment.
+- `exists_eq_lift_test_iff`: the static fragment is exactly
+  eliminative ∧ distributive — van Benthem's additivity
+  ([van-benthem-1986]; [rothschild-yalcin-2016]; [gillies-2022]) — and
+  `CCP.might_not_isDistributive` witnesses that whole-state tests are
+  genuinely beyond it.
+- `support_iff_update_eq`: support is being a fixed point of the
+  update — the hinge between the satisfaction layer and `CCP.entails`.
 
 ## Implementation notes
+
+[groenendijk-stokhof-1991] §3.5's entailment notions (`⊨`, `⊨ₛ`, the
+deduction theorem, Facts 10–12) live with their paper in
+`Studies/GroenendijkStokhof1991.lean`.
 
 `dneg` fails double-negation elimination: negation collapses positive
 update information to a state predicate. The repairs are
 framework-specific and mutually incompatible — bilateral swap
 (`UpdateSemantics/Bilateral.lean`), propositional drefs (ICDRT,
 `Studies/Hofmann2025.lean`), classical metalanguage (TTR,
-`Studies/Cooper2023.lean`) — and the comparisons live in those studies.
+`Studies/Cooper2023/`) — and the comparisons live in those studies.
 -/
 
 namespace DynamicSemantics
@@ -97,8 +115,8 @@ variable {S : Type*}
 
 /-- Dynamic negation: `¬D` holds at `i` iff no output `k` satisfies `D`.
 
-Corresponds to [kamp-reyle-1993] Def 1.4.4 (negation verification)
-and [groenendijk-stokhof-1991] DPL negation. -/
+[kamp-reyle-1993]'s verifying-embedding clause for negation and
+[groenendijk-stokhof-1991]'s DPL negation. -/
 def dneg (D : Update S) : Condition S :=
   λ i => ¬∃ k, D i k
 
@@ -106,8 +124,8 @@ scoped notation "∼" D => dneg D
 
 /-- Test: lift a condition to an Update that checks `C` without changing state.
 
-Corresponds to [heim-1982]'s intersection with the satisfaction
-set: `SAT(F') = SAT(F) ∩ {a : C(a)}`. -/
+Under `lift` this is [heim-1982]'s intersection with the satisfaction
+set, `SAT(F') = SAT(F) ∩ {a : C(a)}` (`lift_test`). -/
 def test (C : Condition S) : Update S :=
   λ i j => i = j ∧ C j
 
@@ -121,10 +139,10 @@ theorem eq_of_test {C : Condition S} {i j : S} (h : test C i j) : i = j :=
   h.1
 
 /-- An update is a *test* when it never changes the state
-([groenendijk-stokhof-1991], Definition 11) — DPL's tests. The CCP-level
-CCP-level `IsTest` below (pass-or-`∅`, Veltman's tests) is a
-different notion: `lift` of a relational test is a filter, not a
-pass-or-`∅` test. -/
+([groenendijk-stokhof-1991], Definition 11) — DPL's tests, the
+subidentities of the update monoid (`isTest_iff_le_one`). `CCP.IsTest`
+(pass-or-`∅`, Veltman's tests) is the same concept one carrier up:
+`lift` of a relational test is a filter, not a pass-or-`∅` guard. -/
 def Update.IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
 
 theorem Update.isTest_test (C : Condition S) : Update.IsTest (test C) :=
@@ -134,8 +152,8 @@ theorem Update.isTest_test (C : Condition S) : Update.IsTest (test C) :=
 
 Mathlib's relational composition `Relation.Comp` at endorelations: there
 exists an intermediate state witnessing both transitions. This is
-[heim-1982]'s successive file change, [kamp-reyle-1993]'s Update
-sequencing, and [groenendijk-stokhof-1991]'s DPL conjunction. -/
+[heim-1982]'s successive file change, [kamp-reyle-1993]'s DRS merge,
+and [groenendijk-stokhof-1991]'s DPL conjunction. -/
 def dseq (D₁ D₂ : Update S) : Update S :=
   Relation.Comp D₁ D₂
 
@@ -143,17 +161,16 @@ infixl:65 " ⨟ " => dseq
 
 /-- Dynamic implication: `D₁ → D₂`.
 
-Every way of satisfying the antecedent can be extended to satisfy
-the consequent. Corresponds to [kamp-reyle-1993] Def 1.4.4
-(implication verification): for all `h`, if `D₁ i h` then
-`∃ k, D₂ h k`. -/
+Every way of satisfying the antecedent can be extended to satisfy the
+consequent — [kamp-reyle-1993]'s verifying-embedding clause for the
+conditional. -/
 def dimpl (D₁ D₂ : Update S) : Condition S :=
   λ i => ∀ h, D₁ i h → ∃ k, D₂ h k
 
 /-- Dynamic disjunction: `D₁ ∨ D₂`.
 
-Corresponds to [kamp-reyle-1993] Def 1.4.4 (disjunction
-verification): there exists an output via either disjunct. -/
+There exists an output via either disjunct — [kamp-reyle-1993]'s
+verifying-embedding clause for disjunction. -/
 def ddisj (D₁ D₂ : Update S) : Condition S :=
   λ i => ∃ k, D₁ i k ∨ D₂ i k
 
@@ -167,70 +184,6 @@ def closure (D : Update S) : Condition S :=
 scoped notation "!" D => closure D
 
 end Operations
-
-/-! ### Truth and entailment -/
-
-section Truth
-
-variable {S : Type*}
-
-/-- An `Update` is valid iff satisfiable (`closure`) at every input. -/
-def valid (D : Update S) : Prop := ∀ i, closure D i
-
-/-- Dynamic entailment: `D₁ ⊨ D₂` iff every output of `D₁` can be
-extended by `D₂`. -/
-def entails (D₁ D₂ : Update S) : Prop :=
-  ∀ i j, D₁ i j → closure D₂ j
-
-scoped notation D₁ " ⊨ " D₂ => entails D₁ D₂
-
-/-- A test is the test of its own closure — the semantic content of
-[groenendijk-stokhof-1991]'s Fact 6: up to contradictions, tests are
-exactly the conditions. -/
-theorem Update.IsTest.eq_test_closure {D : Update S} (h : Update.IsTest D) :
-    D = test (closure D) := by
-  funext i j
-  simp only [test, closure, eq_iff_iff]
-  constructor
-  · intro hij
-    obtain rfl := h hij
-    exact ⟨rfl, i, hij⟩
-  · rintro ⟨rfl, k, hk⟩
-    obtain rfl := h hk
-    exact hk
-
-/-- s-entailment ([groenendijk-stokhof-1991], Definition 18): truth is
-preserved from premiss to conclusion. Unlike `⊨`, it sees no binding
-between them. -/
-def sEntails (D₁ D₂ : Update S) : Prop :=
-  ∀ i, closure D₁ i → closure D₂ i
-
-scoped notation D₁ " ⊨ₛ " D₂ => sEntails D₁ D₂
-
-/-- Meaning inclusion implies s-entailment ([groenendijk-stokhof-1991],
-Fact 10); the converse fails. -/
-theorem sEntails_of_subset {D₁ D₂ : Update S}
-    (h : ∀ ⦃i j⦄, D₁ i j → D₂ i j) : D₁ ⊨ₛ D₂ :=
-  fun _ ⟨j, hj⟩ => ⟨j, h hj⟩
-
-/-- The deduction theorem ([groenendijk-stokhof-1991], Fact 11):
-entailment is validity of the implication test. -/
-theorem entails_iff_valid_test_dimpl (D₁ D₂ : Update S) :
-    (D₁ ⊨ D₂) ↔ valid (test (dimpl D₁ D₂)) := by
-  constructor
-  · intro h i
-    exact ⟨i, rfl, h i⟩
-  · rintro h i j hij
-    obtain ⟨k, rfl, hd⟩ := h i
-    exact hd j hij
-
-/-- [groenendijk-stokhof-1991]'s Fact 12, in closure form: s-entailment
-is entailment from the closed premiss. -/
-theorem sEntails_iff_test_closure_entails (D₁ D₂ : Update S) :
-    (D₁ ⊨ₛ D₂) ↔ (test (closure D₁) ⊨ D₂) :=
-  ⟨fun h _ j ⟨_, hc⟩ => h j hc, fun h i hc => h i i ⟨rfl, hc⟩⟩
-
-end Truth
 
 /-! ### Algebraic properties -/
 
@@ -247,13 +200,7 @@ theorem dseq_assoc (D₁ D₂ D₃ : Update S) :
 theorem test_dseq (C : Condition S) (D : Update S) (hC : ∀ i, C i) :
     test C ⨟ D = D := by
   funext i j
-  simp only [dseq, Relation.Comp, test, eq_iff_iff]
-  constructor
-  · intro ⟨h, ⟨hih, _⟩, hD⟩
-    subst hih
-    exact hD
-  · intro hD
-    exact ⟨i, ⟨rfl, hC i⟩, hD⟩
+  simp [dseq, Relation.Comp, test, hC]
 
 /-- Test is right identity for sequencing (when condition holds everywhere).
 Together with `test_dseq` and `dseq_assoc`, this makes `(Update S, ⨟, test ⊤)`
@@ -261,13 +208,7 @@ a monoid. -/
 theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
     D ⨟ test C = D := by
   funext i j
-  simp only [dseq, Relation.Comp, test, eq_iff_iff]
-  constructor
-  · intro ⟨h, hD, hhj, _⟩
-    subst hhj
-    exact hD
-  · intro hD
-    exact ⟨j, hD, rfl, hC j⟩
+  simp [dseq, Relation.Comp, test, hC]
 
 /-- `Update S` is a monoid under dynamic conjunction `⨟` with the trivial
 test as unit (`dseq_assoc`, `test_dseq`, `dseq_test`). Scoped because
@@ -282,79 +223,48 @@ scoped instance : Monoid (Update S) where
   one_mul D := test_dseq _ D (λ _ => trivial)
   mul_one D := dseq_test D _ (λ _ => trivial)
 
-/-- Double negation for tests. -/
-theorem dneg_dneg_test (C : Condition S) :
-    dneg (test (dneg (test C))) = C := by
-  funext i
-  simp only [dneg, test, eq_iff_iff]
-  constructor
-  · intro h
-    by_contra hC
-    apply h
-    use i
-    constructor
-    · rfl
-    · intro ⟨k, hik, hCk⟩
-      subst hik
-      exact hC hCk
-  · intro hC ⟨j, hji, hNeg⟩
-    apply hNeg
-    use i
-    exact ⟨hji.symm, hC⟩
+/-! ### Tests are the subidentities -/
 
-/-- Closure is idempotent. -/
-theorem closure_closure (D : Update S) :
-    closure (test (closure D)) = closure D := by
-  funext i
-  simp only [closure, test, eq_iff_iff]
-  constructor
-  · intro ⟨j, hij, k, hD⟩
-    subst hij
-    exact ⟨k, hD⟩
-  · intro ⟨k, hD⟩
-    exact ⟨i, rfl, k, hD⟩
+/-- Tests are the subidentities of the update monoid: `D` is a test iff
+`D ≤ 1` in the pointwise order — the coreflexive relations. -/
+theorem Update.isTest_iff_le_one {D : Update S} :
+    D.IsTest ↔ D ≤ 1 :=
+  ⟨fun h _ _ hij => ⟨h hij, trivial⟩, fun h _ _ hij => (h _ _ hij).1⟩
 
-/-- Sequencing distributes over closure. -/
-theorem dseq_closure (D₁ D₂ : Update S) :
-    closure (D₁ ⨟ D₂) = λ i => ∃ h, D₁ i h ∧ closure D₂ h := by
-  funext i
-  simp only [closure, dseq, Relation.Comp, eq_iff_iff]
-  constructor
-  · intro ⟨j, h, hD₁, hD₂⟩
-    exact ⟨h, hD₁, j, hD₂⟩
-  · intro ⟨h, hD₁, j, hD₂⟩
-    exact ⟨j, h, hD₁, hD₂⟩
+/-- A test is the test of its own closure — the semantic content of
+[groenendijk-stokhof-1991]'s Fact 6: up to contradictions, tests are
+exactly the conditions. The transformer-face mirror is
+`CCP.IsTest.eq_guard`. -/
+theorem Update.IsTest.eq_test_closure {D : Update S} (h : Update.IsTest D) :
+    D = test (closure D) := by
+  funext i j
+  exact propext (by grind [test, closure, Update.IsTest])
 
 end Theorems
 
 /-! ## The set-transformer face -/
 
 
-/--
-A Context Change Potential (CCP) is a function from states to states.
-
-This is the semantic type for dynamic meanings.
--/
+/-- A Context Change Potential: meanings as transformers of whole
+information states, [heim-1983]'s and [veltman-1996]'s semantic type.
+The distributive CCPs are exactly the `lift`s of relational `Update`s;
+the rest — the whole-state tests below — are what this face adds. -/
 abbrev CCP (S : Type*) := Set S → Set S
 
 namespace CCP
 
 variable {S : Type*}
 
-/-- Identity CCP: leaves state unchanged -/
+/-- The identity CCP. -/
 def id : CCP S := λ s => s
 
-/-- Absurd CCP: yields empty state -/
+/-- The absurd CCP: crash to the empty state. -/
 def absurd : CCP S := λ _ => ∅
 
-/-- Sequential composition of CCPs -/
+/-- Sequential composition of CCPs, in diagrammatic order. -/
 def seq (u v : CCP S) : CCP S := λ s => v (u s)
 
 scoped infixl:70 " ;; " => seq
-
-theorem seq_assoc (u v w : CCP S) : (u ;; v) ;; w = u ;; (v ;; w) := rfl
-theorem id_seq (u : CCP S) : id ;; u = u := rfl
-theorem seq_id (u : CCP S) : u ;; id = u := rfl
 
 /-- CCPs form a monoid under sequential composition. Scoped because
 `CCP S` is an abbreviation for `Set S → Set S`: a global instance would
@@ -367,7 +277,7 @@ scoped instance : Monoid (CCP S) where
   one_mul _ := rfl
   mul_one _ := rfl
 
-/-- seq_absurd: anything followed by absurd is absurd -/
+/-- The absurd CCP absorbs on the right. -/
 theorem seq_absurd (u : CCP S) : u ;; absurd = absurd := rfl
 
 /--
@@ -383,8 +293,9 @@ def neg (φ : CCP S) : CCP S :=
 
 open Classical in
 /-- Whole-state test: pass the state through iff it satisfies `C` — the
-shared shape of `negTest`, `might`, `must`, and `impl`, the
-non-distributive tests that inspect the entire input state. -/
+shared shape of `negTest`, `might`, and `must`, the non-distributive
+tests that inspect the entire input state. Every pass-or-`∅` CCP is a
+guard (`IsTest.eq_guard`). -/
 noncomputable def guard (C : Set S → Prop) : CCP S :=
   λ s => if C s then s else ∅
 
@@ -415,7 +326,6 @@ might(φ)(s) = s if φ(s) ≠ ∅, else ∅
 noncomputable def might (φ : CCP S) : CCP S :=
   guard (λ s => (φ s).Nonempty)
 
-open Classical in
 /--
 Full support test ("must"): passes iff φ returns input unchanged.
 
@@ -424,338 +334,246 @@ must(φ)(s) = s if φ(s) = s, else ∅
 noncomputable def must (φ : CCP S) : CCP S :=
   guard (λ s => φ s = s)
 
-open Classical in
-/--
-Dynamic implication test: passes iff output of φ is preserved by ψ.
-
-impl(φ,ψ)(s) = s if φ(s) ⊆ ψ(φ(s)), else ∅
--/
-noncomputable def impl (φ ψ : CCP S) : CCP S :=
-  guard (λ s => φ s ⊆ ψ (φ s))
-
-/--
-Dynamic disjunction via De Morgan: φ ∨ ψ = ¬(¬φ ; ¬ψ).
-
-For eliminative updates this unfolds to φ(s) ∪ ψ(s \ φ(s)): the second
-disjunct is evaluated in the input updated with the negation of the
-first — the local-context clause of the satisfaction literature
-([beaver-2001]; [heim-1983] itself gives CCPs only for *not/and/if*).
--/
-def disj (φ ψ : CCP S) : CCP S := neg (seq (neg φ) (neg ψ))
-
-/-- Dynamic entailment: φ entails ψ iff ψ adds no information after φ. -/
+/-- Acceptance-based consequence: every output of `φ` is a fixed point
+of `ψ` — updating with the conclusion after the premiss changes nothing
+([veltman-1996]'s acceptance validity; [beaver-2001]'s D45 entailment,
+`Studies/Beaver2001/ABLE.lean`). `support_iff_update_eq` connects the
+fixed-point reading to the satisfaction layer's `supportOf`. -/
 def entails (φ ψ : CCP S) : Prop :=
-  ∀ s : Set S, (φ s).Nonempty → ψ (φ s) = φ s
-
-/-- Entailment is reflexive -/
-theorem entails_id (φ : CCP S) : entails φ id := by
-  intro s _; rfl
+  ∀ s : Set S, ψ (φ s) = φ s
 
 end CCP
 
+/-! ### The classification of CCPs -/
+
+namespace CCP
+
 variable {S : Type*}
 
-/--
-An update is eliminative if it never adds possibilities.
-
-This is the fundamental property of dynamic semantics:
-information only grows (possibilities only decrease).
--/
+/-- An update is *eliminative* when it never adds possibilities —
+information only grows. Equivalently, `u ≤ id` in the pointwise order:
+the deflationary transformers. -/
 def IsEliminative (u : CCP S) : Prop :=
   ∀ s, u s ⊆ s
 
-/-- Identity is eliminative -/
-theorem eliminative_id : IsEliminative (CCP.id : CCP S) :=
+/-- The identity is eliminative. -/
+theorem isEliminative_id : IsEliminative (id : CCP S) :=
   λ _ => Set.Subset.rfl
 
-/-- Sequential composition preserves eliminativity -/
-theorem eliminative_seq (u v : CCP S)
+/-- Sequencing preserves eliminativity. -/
+theorem IsEliminative.seq {u v : CCP S}
     (hu : IsEliminative u) (hv : IsEliminative v) :
     IsEliminative (u.seq v) := λ s _ hp =>
   hu s (hv (u s) hp)
 
-
-/--
-An update is expansive if it never removes possibilities.
-
-Expansive operations include discourse referent introduction (DRT/DPL),
-modal horizon expansion ([kirkpatrick-2024]), and accommodation.
-These are the dual of eliminative operations: where eliminative updates
-can only shrink the state, expansive updates can only grow it.
--/
-def IsExpansive (u : CCP S) : Prop :=
-  ∀ s, s ⊆ u s
-
-/-- Identity is expansive -/
-theorem expansive_id : IsExpansive (CCP.id : CCP S) :=
-  λ _ => Set.Subset.rfl
-
-/-- Sequential composition preserves expansiveness -/
-theorem expansive_seq (u v : CCP S)
-    (hu : IsExpansive u) (hv : IsExpansive v) :
-    IsExpansive (u.seq v) := λ s _ hp =>
-  hv (u s) (hu s hp)
-
-/-- A CCP that is both eliminative and expansive is the identity on every input. -/
-theorem eliminative_expansive_id (u : CCP S)
-    (he : IsEliminative u) (hx : IsExpansive u) :
-    ∀ s, u s = s :=
-  λ s => Set.Subset.antisymm (he s) (hx s)
-
 /-- A test either passes (returns its input) or fails (returns `∅`) —
-[veltman-1996]'s tests: `might`, `must`, presupposition checks. Not the
-counterpart of the relational `Update.IsTest`: lifting a relational
-test gives an eliminative filter, not a pass-or-`∅` test. -/
+[veltman-1996]'s tests: `might`, `must`, presupposition checks. The
+same subidentity concept as the relational `Update.IsTest`, one carrier
+up — which is why `lift` does not intertwine the two: lifting a
+relational test gives an eliminative filter, not a pass-or-`∅` guard. -/
 def IsTest (u : CCP S) : Prop :=
   ∀ s, u s = s ∨ u s = ∅
 
-/-- Tests are eliminative -/
-theorem test_eliminative (u : CCP S) (h : IsTest u) :
+/-- Tests are eliminative. -/
+theorem IsTest.isEliminative {u : CCP S} (h : IsTest u) :
     IsEliminative u := λ s p hp => by
   cases h s with
   | inl heq => rw [heq] at hp; exact hp
   | inr hemp => rw [hemp] at hp; exact False.elim hp
 
-open Classical in
-theorem CCP.guard_isTest (C : Set S → Prop) : IsTest (CCP.guard C) := by
-  intro s; simp only [CCP.guard]; split <;> simp
+theorem guard_isTest (C : Set S → Prop) : IsTest (guard C) := by
+  intro s; simp only [guard]; split <;> simp
 
-theorem CCP.negTest_isTest (φ : CCP S) : IsTest (CCP.negTest φ) :=
-  CCP.guard_isTest _
-
-theorem CCP.might_isTest (φ : CCP S) : IsTest (CCP.might φ) :=
-  CCP.guard_isTest _
-
-theorem CCP.must_isTest (φ : CCP S) : IsTest (CCP.must φ) :=
-  CCP.guard_isTest _
-
-theorem CCP.impl_isTest (φ ψ : CCP S) : IsTest (CCP.impl φ ψ) :=
-  CCP.guard_isTest _
-
-open Classical in
-/-- Duality for the test pair: might φ = must-not (must-not φ). The
-analogous identity fails for set-difference `neg` (DNE holds instead
-on eliminative updates). -/
-theorem CCP.might_eq_negTest_negTest (φ : CCP S) :
-    CCP.might φ = CCP.negTest (CCP.negTest φ) := by
+/-- A test is the guard of its own acceptance condition — the
+transformer-face mirror of `Update.IsTest.eq_test_closure`. -/
+theorem IsTest.eq_guard {u : CCP S} (h : IsTest u) :
+    u = guard fun s => u s = s := by
   funext s
-  by_cases h : (φ s).Nonempty
-  · simp [CCP.might, CCP.negTest, CCP.guard, h]
-  · by_cases hs : s.Nonempty
-    · simp [CCP.might, CCP.negTest, CCP.guard, h, hs]
-    · simp [CCP.might, CCP.negTest, CCP.guard,
-        Set.not_nonempty_iff_eq_empty.mp hs]
+  by_cases hs : u s = s
+  · rw [guard_pos (C := fun t => u t = t) hs, hs]
+  · rw [guard_neg (C := fun t => u t = t) hs]
+    exact (h s).resolve_left hs
+
+/-- The tests are exactly the guards. -/
+theorem isTest_iff_exists_guard {u : CCP S} :
+    IsTest u ↔ ∃ C, u = guard C :=
+  ⟨fun h => ⟨_, h.eq_guard⟩, fun ⟨C, hC⟩ => hC ▸ guard_isTest C⟩
+
+end CCP
 
 
-section GaloisContent
+/-! ### The satisfaction layer
+
+A satisfaction relation `sat : S → φ → Prop` induces the standard
+eliminative fragment: per-formula contents, filter updates, the support
+relation, and acceptance-based entailment. PLA, DRT, and DPL define
+their updates by instantiating `sat`. -/
+
+section Satisfaction
 
 variable {S φ : Type*}
 
-/--
-Support relation: s supports ψ if all possibilities in s satisfy ψ.
-
-This is the fundamental entailment relation of dynamic semantics.
--/
+/-- `s` supports `ψ` when every possibility in `s` satisfies `ψ`. -/
 def supportOf (sat : S → φ → Prop) (s : Set S) (ψ : φ) : Prop :=
   ∀ p ∈ s, sat p ψ
 
-/--
-Content of a formula: all possibilities satisfying it.
--/
+/-- The content of a formula: all possibilities satisfying it. -/
 def contentOf (sat : S → φ → Prop) (ψ : φ) : Set S :=
   { p | sat p ψ }
 
-/--
-Galois connection: s ⊆ content ψ ↔ s supports ψ
-
-This is the fundamental duality of dynamic semantics.
--/
+/-- Support is inclusion in content. -/
 theorem support_iff_subset_content (sat : S → φ → Prop) (s : Set S) (ψ : φ) :
-    supportOf sat s ψ ↔ s ⊆ contentOf sat ψ := by
-  constructor
-  · intro h p hp
-    exact h p hp
-  · intro h p hp
-    exact h hp
+    supportOf sat s ψ ↔ s ⊆ contentOf sat ψ :=
+  Iff.rfl
 
-/--
-Support is downward closed: smaller states support more.
--/
+/-- Support is downward closed: smaller states support more. -/
 theorem support_mono (sat : S → φ → Prop) (s t : Set S) (ψ : φ)
     (h : t ⊆ s) (hs : supportOf sat s ψ) : supportOf sat t ψ :=
   λ p hp => hs p (h hp)
 
-/--
-Empty state supports everything (vacuously).
--/
+/-- The empty state supports everything (vacuously). -/
 theorem empty_supports (sat : S → φ → Prop) (ψ : φ) :
     supportOf sat ∅ ψ := λ _ hp => False.elim hp
 
-/--
-Content is antitone in entailment.
--/
+/-- Content is monotone in pointwise entailment. -/
 theorem content_mono (sat : S → φ → Prop) (ψ₁ ψ₂ : φ)
     (h : ∀ p, sat p ψ₁ → sat p ψ₂) :
     contentOf sat ψ₁ ⊆ contentOf sat ψ₂ :=
   λ _ hp => h _ hp
 
-end GaloisContent
-
-
-/-! ### Separation (filtering) infrastructure -/
-
-/-- Filtering a set by a predicate is monotone. This is the shared foundation
-    for monotonicity of `updateFromSat`, `atom`, `pred1`, `pred2`, etc. -/
+/-- Filtering a set by a predicate is monotone — the shared foundation
+for `updateFromSat_monotone` and its per-predicate instances. -/
 theorem sep_monotone (pred : S → Prop) :
     Monotone (λ s : Set S => { p ∈ s | pred p }) :=
   λ _ _ h _ hp => ⟨h hp.1, hp.2⟩
 
 /-- Filtering a set by a predicate is eliminative. -/
 theorem sep_eliminative (pred : S → Prop) :
-    IsEliminative (λ s : Set S => { p ∈ s | pred p }) :=
-  λ _ _ hp => hp.1
+    CCP.IsEliminative (λ s : Set S => { p ∈ s | pred p }) :=
+  λ s => Set.sep_subset s pred
 
-
-/--
-The standard update construction: filter by satisfaction.
-
-This is how PLA, DRT, DPL all define updates.
--/
-def updateFromSat {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) : CCP S :=
+/-- The standard update construction: filter by satisfaction — how PLA,
+DRT, and DPL all define updates. Kept as the literal filter (rather
+than `lift (test _)`, see `updateFromSat_eq_lift_test`) so instantiating
+frameworks connect by `rfl`. -/
+def updateFromSat (sat : S → φ → Prop) (ψ : φ) : CCP S :=
   λ s => { p ∈ s | sat p ψ }
 
-/-- Standard updates are eliminative -/
-theorem updateFromSat_eliminative {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
-    IsEliminative (updateFromSat sat ψ) :=
+/-- Standard updates are eliminative. -/
+theorem updateFromSat_eliminative (sat : S → φ → Prop) (ψ : φ) :
+    CCP.IsEliminative (updateFromSat sat ψ) :=
   sep_eliminative _
 
-/-- Standard update membership -/
-theorem mem_updateFromSat {S φ : Type*} (sat : S → φ → Prop) (ψ : φ)
-    (s : Set S) (p : S) :
+@[simp] theorem mem_updateFromSat {sat : S → φ → Prop} {ψ : φ}
+    {s : Set S} {p : S} :
     p ∈ updateFromSat sat ψ s ↔ p ∈ s ∧ sat p ψ := Iff.rfl
 
-/-- Update equals intersection with content -/
-theorem updateFromSat_eq_inter_content {S φ : Type*} (sat : S → φ → Prop)
+/-- Updating is intersecting with the content. -/
+theorem updateFromSat_eq_inter_content (sat : S → φ → Prop)
     (ψ : φ) (s : Set S) :
-    updateFromSat sat ψ s = s ∩ contentOf sat ψ := by
-  ext p
-  simp only [mem_updateFromSat, contentOf, Set.mem_inter_iff, Set.mem_setOf_eq]
+    updateFromSat sat ψ s = s ∩ contentOf sat ψ :=
+  rfl
 
-/-- Support-Update equivalence -/
-theorem support_iff_update_eq {S φ : Type*} (sat : S → φ → Prop)
+/-- Support is being a fixed point of the update ([dekker-2012]'s
+Proper Support) — the hinge between the satisfaction layer and the
+acceptance-based `CCP.entails`. -/
+theorem support_iff_update_eq (sat : S → φ → Prop)
     (ψ : φ) (s : Set S) :
     supportOf sat s ψ ↔ updateFromSat sat ψ s = s := by
   constructor
   · intro h
     ext p
-    simp only [mem_updateFromSat]
-    constructor
-    · intro ⟨hp, _⟩; exact hp
-    · intro hp; exact ⟨hp, h p hp⟩
+    exact ⟨fun hp => hp.1, fun hp => ⟨hp, h p hp⟩⟩
   · intro h p hp
     have : p ∈ updateFromSat sat ψ s := by rw [h]; exact hp
     exact this.2
 
-
-/--
-Dynamic entailment: φ dynamically entails ψ if updating with φ
-always yields a state that supports ψ.
--/
-def dynamicEntailsOf {S φ : Type*} (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
+/-- Dynamic entailment: updating with `ψ₁` always yields a state
+supporting `ψ₂`. -/
+def dynamicEntailsOf (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
   ∀ s : Set S, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
 
-/-- Dynamic entailment is reflexive -/
-theorem dynamicEntails_refl {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
+/-- Dynamic entailment is `CCP.entails` of the induced updates: the
+satisfaction layer's consequence is the acceptance-based one. -/
+theorem dynamicEntailsOf_iff_entails (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) :
+    dynamicEntailsOf sat ψ₁ ψ₂ ↔
+      CCP.entails (updateFromSat sat ψ₁) (updateFromSat sat ψ₂) :=
+  forall_congr' fun s => support_iff_update_eq sat ψ₂ (updateFromSat sat ψ₁ s)
+
+/-- Dynamic entailment is reflexive. -/
+theorem dynamicEntails_refl (sat : S → φ → Prop) (ψ : φ) :
     dynamicEntailsOf sat ψ ψ :=
   λ _ _ hp => hp.2
 
-/-- Dynamic entailment is transitive -/
-theorem dynamicEntails_trans {S φ : Type*} (sat : S → φ → Prop)
-    (ψ₁ ψ₂ ψ₃ : φ) (h1 : dynamicEntailsOf sat ψ₁ ψ₂) (h2 : dynamicEntailsOf sat ψ₂ ψ₃) :
+/-- Dynamic entailment is transitive. -/
+theorem dynamicEntails_trans (sat : S → φ → Prop) (ψ₁ ψ₂ ψ₃ : φ)
+    (h1 : dynamicEntailsOf sat ψ₁ ψ₂) (h2 : dynamicEntailsOf sat ψ₂ ψ₃) :
     dynamicEntailsOf sat ψ₁ ψ₃ :=
   fun s p hp => h2 s p ⟨hp.1, h1 s p hp⟩
 
-
-/--
-`updateFromSat` is monotone in the state argument: larger input states yield
-larger output states. Uses mathlib's `Monotone` (i.e., `s ≤ t → f s ≤ f t`
-where `≤` on `Set` is `⊆`).
--/
-theorem updateFromSat_monotone {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
+/-- `updateFromSat` is monotone in the state argument. -/
+theorem updateFromSat_monotone (sat : S → φ → Prop) (ψ : φ) :
     Monotone (updateFromSat sat ψ) :=
   sep_monotone _
+
+end Satisfaction
 
 
 /-! ### Distributivity -/
 
-/-- A CCP is distributive when it processes each element of the input independently:
-    φ(s) = ⋃_{i∈s} φ({i}). -/
+namespace CCP
+
+variable {S : Type*}
+
+/-- A CCP is distributive when it processes each element of the input
+independently: `φ(s) = ⋃_{i ∈ s} φ({i})` — equivalently, it preserves
+arbitrary joins of states (`Kleisli.lean`'s
+`isDistributive_iff_map_sSup`). -/
 def IsDistributive (φ : CCP S) : Prop :=
   ∀ s, φ s = {p | ∃ i ∈ s, p ∈ φ {i}}
 
+/-- `might` is not distributive: the whole-context test can pass while
+every individual-element test fails. Witness: `S = Bool`, `φ` keeps only
+`true`; then `false` survives `might φ` on `{true, false}` but lies in
+no per-singleton output. -/
+theorem might_not_isDistributive :
+    ∃ (S : Type) (φ : CCP S), ¬IsDistributive (might φ) := by
+  refine ⟨Bool, (fun s => {p ∈ s | p = true}), fun hD => ?_⟩
+  have hfalse :
+      false ∈ might (fun s : Set Bool => {p ∈ s | p = true}) {true, false} := by
+    rw [might, guard_pos ⟨true, Or.inl rfl, rfl⟩]
+    exact Or.inr rfl
+  rw [hD] at hfalse
+  obtain ⟨i, hi, hmem⟩ := hfalse
+  rcases hi with rfl | rfl
+  · rw [might, guard_pos ⟨true, rfl, rfl⟩] at hmem
+    exact Bool.false_ne_true hmem
+  · rw [might, guard_neg (fun ⟨x, hx, hx'⟩ => Bool.false_ne_true (hx ▸ hx'))]
+      at hmem
+    exact hmem
+
+end CCP
+
 /-- `updateFromSat` is always distributive: it filters per-element. -/
 theorem updateFromSat_isDistributive {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
-    IsDistributive (updateFromSat sat ψ) := by
+    CCP.IsDistributive (updateFromSat sat ψ) := by
   intro s; ext p; simp only [updateFromSat, Set.mem_setOf_eq]
   constructor
   · intro ⟨hp, hsat⟩; exact ⟨p, hp, ⟨rfl, hsat⟩⟩
   · rintro ⟨i, hi, hpi, hsat⟩; cases hpi; exact ⟨hi, hsat⟩
 
-/-- `CCP.might` is not distributive: the whole-context test can pass while
-    individual-element tests fail.
+/-! ### The relational bridge
 
-    Witness: S = Bool, φ keeps only `true`.
-    `might φ {true, false} = {true, false}` (whole-context test passes),
-    but per-singleton: `might φ {false} = ∅` (test fails on false-only context).
-    So `false` is in the whole-context result but not the distributive union. -/
-theorem might_not_isDistributive :
-    ∃ (S : Type) (φ : CCP S), ¬IsDistributive (CCP.might φ) := by
-  use Bool
-  let φ : CCP Bool := λ s => {p ∈ s | p = true}
-  use φ
-  intro hD
-  let s : Set Bool := {true, false}
-  have hφ_nonempty : (φ s).Nonempty := by
-    refine ⟨true, ?_, rfl⟩
-    show true ∈ s
-    exact Or.inl rfl
-  have hmem : false ∈ CCP.might φ s := by
-    simp only [CCP.might, CCP.guard, hφ_nonempty, ↓reduceIte]
-    show false ∈ s
-    exact Or.inr rfl
-  rw [hD s] at hmem
-  obtain ⟨i, hi, hmem_i⟩ := hmem
-  simp only [CCP.might, CCP.guard] at hmem_i
-  split at hmem_i
-  · next hne =>
-    cases hi with
-    | inl h =>
-      subst h
-      have : false ∈ ({true} : Set Bool) := hmem_i
-      change false = true at this
-      exact absurd this (by decide)
-    | inr h =>
-      subst h
-      obtain ⟨x, hx_mem, hx_val⟩ := hne
-      change x = false at hx_mem
-      subst hx_mem
-      exact absurd hx_val (by decide)
-  · exact hmem_i
-
-/-! ### The relational bridge -/
-
-/-! The relational type `Update S = S → S → Prop` from `DynProp` is the
-primary dynamic semantic type. Every `Update` gives rise to a distributive
-`CCP` via the relational image (`lift`), and every distributive CCP
-arises this way (`lower`). The round-trip is the identity in both
-directions (for distributive CCPs).
+The relational type `Update S = S → S → Prop` is the primary dynamic
+semantic type. Every `Update` gives rise to a distributive `CCP` via
+the relational image (`lift`), and every distributive CCP arises this
+way (`lower`); the round-trip is the identity in both directions.
 
 Non-distributive CCP operations (`negTest`, `might`, `must`) test the
 *whole* input state and have no direct `Update` counterpart — they are
 genuine additions of the set-transformer perspective. -/
 
 section RelationalBridge
-
 
 variable {S : Type*}
 
@@ -773,6 +591,9 @@ def lift (R : Update S) : CCP S :=
 This is the inverse of `lift` for distributive CCPs. -/
 def lower (φ : CCP S) : Update S :=
   λ i j => j ∈ φ {i}
+
+theorem mem_lift {R : Update S} {σ : Set S} {j : S} :
+    j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
 
 /-- Lifting preserves sequential composition:
 `lift (R₁ ⨟ R₂) = lift R₁ ;; lift R₂`. -/
@@ -795,7 +616,7 @@ theorem lift_test (C : Condition S) :
   · rintro ⟨hj, hC⟩; exact ⟨j, hj, rfl, hC⟩
 
 /-- Lifted CCPs are always distributive. -/
-theorem lift_isDistributive (R : Update S) : IsDistributive (lift R) := by
+theorem lift_isDistributive (R : Update S) : CCP.IsDistributive (lift R) := by
   intro σ; ext j; simp only [lift, Set.mem_setOf_eq]
   constructor
   · rintro ⟨i, hi, hR⟩
@@ -813,7 +634,7 @@ theorem lower_lift (R : Update S) : lower (lift R) = R := by
 
 /-- Round-trip: `lift (lower φ) = φ` for distributive CCPs.
 Distributive CCPs are exactly the relational images. -/
-theorem lift_lower (φ : CCP S) (hd : IsDistributive φ) :
+theorem lift_lower (φ : CCP S) (hd : CCP.IsDistributive φ) :
     lift (lower φ) = φ := by
   funext σ; ext j; simp only [lift, lower, Set.mem_setOf_eq]
   rw [hd σ]
@@ -834,8 +655,30 @@ theorem lift_le_lift_iff {R R' : Update S} : lift R ≤ lift R' ↔ R ≤ R' := 
 
 /-- `lift (test C)` is eliminative: it only removes elements. -/
 theorem lift_test_isEliminative (C : Condition S) :
-    IsEliminative (lift (test C)) := by
+    CCP.IsEliminative (lift (test C)) := by
   rw [lift_test]; intro σ j ⟨hj, _⟩; exact hj
+
+/-- The static fragment characterized: a CCP is a lifted test filter iff
+it is both eliminative and distributive — van Benthem's *additivity*
+([van-benthem-1986]; [rothschild-yalcin-2016]; [gillies-2022]). The two
+canonical dynamic systems drop exactly one conjunct each, in
+complementary directions: update semantics keeps eliminativity but its
+whole-state tests break distributivity
+(`CCP.might_not_isDistributive`), while DPL's random reassignment keeps
+distributivity but breaks eliminativity. -/
+theorem exists_eq_lift_test_iff {φ : CCP S} :
+    (∃ C : Condition S, φ = lift (test C)) ↔
+      CCP.IsEliminative φ ∧ CCP.IsDistributive φ := by
+  constructor
+  · rintro ⟨C, rfl⟩
+    exact ⟨lift_test_isEliminative C, lift_isDistributive _⟩
+  · rintro ⟨he, hd⟩
+    refine ⟨fun i => i ∈ φ {i}, ?_⟩
+    funext s
+    rw [hd s, lift_test]
+    ext p
+    exact ⟨fun ⟨i, hi, hpi⟩ => by obtain rfl : p = i := he {i} hpi; exact ⟨hi, hpi⟩,
+      fun ⟨hp, hC⟩ => ⟨p, hp, hC⟩⟩
 
 @[simp] theorem mem_lift_test {C : Condition S} {σ : Set S} {i : S} :
     i ∈ lift (test C) σ ↔ i ∈ σ ∧ C i := by

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -144,10 +144,8 @@ scoped instance : Monoid (Update S) where
   mul := dseq
   one := test (λ _ => True)
   mul_assoc _ _ _ := Relation.comp_assoc
-  one_mul D := funext₂ λ i j => propext
-    ⟨λ ⟨_, ⟨hik, _⟩, hD⟩ => hik ▸ hD, λ hD => ⟨i, ⟨rfl, trivial⟩, hD⟩⟩
-  mul_one D := funext₂ λ i j => propext
-    ⟨λ ⟨_, hD, hkj, _⟩ => hkj ▸ hD, λ hD => ⟨j, hD, rfl, trivial⟩⟩
+  one_mul D := funext₂ λ i _ => propext ⟨λ ⟨_, ⟨h, _⟩, d⟩ => h ▸ d, λ d => ⟨i, ⟨rfl, ⟨⟩⟩, d⟩⟩
+  mul_one D := funext₂ λ _ j => propext ⟨λ ⟨_, d, h, _⟩ => h ▸ d, λ d => ⟨j, d, rfl, ⟨⟩⟩⟩
 
 /-- `Update S` is a quantale: sequencing distributes over arbitrary unions of
 updates, so mathlib's residuation vocabulary applies (scoped). -/

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -66,8 +66,7 @@ iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
 
 ## Notation
 
-* `D₁ ⨟ D₂` for `dseq D₁ D₂`; scoped `∼ D` for `dneg D`, `[ C ]` for
-  `test C`, `! D` for `closure D`.
+* `D₁ ⨟ D₂` for `dseq D₁ D₂`.
 * `u ;; v` for `CCP.seq u v`, scoped to `DynamicSemantics.CCP`.
 
 ## Implementation notes
@@ -117,15 +116,11 @@ variable {S : Type*} {C : Condition S} {D : Update S} {i j : S}
 /-- `test C` checks `C` without changing the state. -/
 def test (C : Condition S) : Update S := λ i j => i = j ∧ C j
 
-scoped notation "[" C "]" => test C
-
 /-- A test relates a state only to itself. -/
 theorem eq_of_test (h : test C i j) : i = j := h.1
 
-/-- `∼D` holds at `i` iff no output `k` satisfies `D`. -/
+/-- `dneg D` holds at `i` iff no output `k` satisfies `D`. -/
 def dneg (D : Update S) : Condition S := λ i => ¬∃ k, D i k
-
-scoped notation "∼" D => dneg D
 
 /-- `D₁ ⨟ D₂` relates `i` to `k` iff some intermediate `j` has `D₁ i j` and `D₂ j k`. -/
 def dseq (D₁ D₂ : Update S) : Update S := Relation.Comp D₁ D₂
@@ -138,10 +133,8 @@ def dimpl (D₁ D₂ : Update S) : Condition S := λ i => ∀ h, D₁ i h → �
 /-- `ddisj D₁ D₂` holds at `i` iff some disjunct has an output from `i`. -/
 def ddisj (D₁ D₂ : Update S) : Condition S := λ i => ∃ k, D₁ i k ∨ D₂ i k
 
-/-- `!D` holds at `i` iff `D` has an output from `i` — [heim-1982]'s truth definition. -/
+/-- `closure D` holds at `i` iff `D` has an output from `i` — [heim-1982]'s truth definition. -/
 def closure (D : Update S) : Condition S := λ i => ∃ k, D i k
-
-scoped notation "!" D => closure D
 
 /-! ### The update quantale -/
 
@@ -153,14 +146,12 @@ theorem dseq_assoc (D₁ D₂ D₃ : Update S) :
 /-- An everywhere-true test is a left identity for sequencing. -/
 theorem test_dseq (C : Condition S) (D : Update S) (hC : ∀ i, C i) :
     test C ⨟ D = D := by
-  funext i j
-  simp [dseq, Relation.Comp, test, hC]
+  funext i j; simp [dseq, Relation.Comp, test, hC]
 
 /-- An everywhere-true test is a right identity for sequencing. -/
 theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
     D ⨟ test C = D := by
-  funext i j
-  simp [dseq, Relation.Comp, test, hC]
+  funext i j; simp [dseq, Relation.Comp, test, hC]
 
 /-- `Update S` is a monoid under `⨟` with the trivial test as unit (scoped;
 see the implementation notes). -/
@@ -293,15 +284,12 @@ theorem IsEliminative.seq (hu : IsEliminative u) (hv : IsEliminative v) :
 def IsTest (u : CCP S) : Prop := ∀ s, u s = s ∨ u s = ∅
 
 /-- Tests are eliminative. -/
-theorem IsTest.isEliminative (h : IsTest u) :
-    IsEliminative u := λ s p hp => by
-  cases h s with
-  | inl heq => rw [heq] at hp; exact hp
-  | inr hemp => rw [hemp] at hp; exact False.elim hp
+theorem IsTest.isEliminative (h : IsTest u) : IsEliminative u :=
+  λ s p hp => (h s).elim (· ▸ hp) (λ hemp => (Set.notMem_empty p (hemp ▸ hp)).elim)
 
 /-- Guards are tests. -/
-theorem guard_isTest (C : Set S → Prop) : IsTest (guard C) := by
-  intro s; simp only [guard]; split <;> simp
+theorem guard_isTest (C : Set S → Prop) : IsTest (guard C) :=
+  λ s => (Classical.em (C s)).elim (λ h => .inl (guard_pos h)) (λ h => .inr (guard_neg h))
 
 /-- A test is the guard of its own acceptance condition — the mirror of
 `Update.IsTest.eq_test_closure`. -/
@@ -359,37 +347,27 @@ theorem mem_lift : j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
 
 /-- `lift` sends sequencing to composition. -/
 theorem lift_dseq (R₁ R₂ : Update S) :
-    lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) := by
-  funext σ; ext k; simp only [lift, CCP.seq, dseq, Relation.Comp, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hi, j, hR₁, hR₂⟩
-    exact ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩
-  · rintro ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩
-    exact ⟨i, hi, j, hR₁, hR₂⟩
+    lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) :=
+  funext λ _ => Set.ext λ _ =>
+    ⟨λ ⟨i, hi, j, hR₁, hR₂⟩ => ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩,
+     λ ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩ => ⟨i, hi, j, hR₁, hR₂⟩⟩
 
 /-- `lift (test C)` is the filter by `C`. -/
 theorem lift_test (C : Condition S) :
-    lift (test C) = λ σ => { i ∈ σ | C i } := by
-  funext σ; ext j; simp only [lift, test, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hi, rfl, hC⟩; exact ⟨hi, hC⟩
-  · rintro ⟨hj, hC⟩; exact ⟨j, hj, rfl, hC⟩
+    lift (test C) = λ σ => { i ∈ σ | C i } :=
+  funext λ _ => Set.ext λ j =>
+    ⟨λ ⟨_, hi, hij, hC⟩ => ⟨hij ▸ hi, hC⟩, λ ⟨hj, hC⟩ => ⟨j, hj, rfl, hC⟩⟩
 
 /-- Lifted transformers are distributive. -/
-theorem lift_isDistributive (R : Update S) : CCP.IsDistributive (lift R) := by
-  intro σ; ext j; simp only [lift, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hi, hR⟩
-    refine ⟨i, hi, i, ?_, hR⟩; exact rfl
-  · rintro ⟨i, hi, i', hi', hR⟩
-    refine ⟨i, hi, ?_⟩; rwa [hi'] at hR
+theorem lift_isDistributive (R : Update S) : CCP.IsDistributive (lift R) :=
+  λ _ => Set.ext λ _ =>
+    ⟨λ ⟨i, hi, hR⟩ => ⟨i, hi, i, rfl, hR⟩,
+     λ ⟨i, hi, _, hi', hR⟩ => ⟨i, hi, hi' ▸ hR⟩⟩
 
 /-- `lower` is a left inverse of `lift`: the relational face loses nothing. -/
-theorem lower_lift (R : Update S) : lower (lift R) = R := by
-  funext i j; simp only [lower, lift, Set.mem_setOf_eq, eq_iff_iff]
-  constructor
-  · rintro ⟨i', hi', hR⟩; rwa [hi'] at hR
-  · intro hR; exact ⟨i, rfl, hR⟩
+theorem lower_lift (R : Update S) : lower (lift R) = R :=
+  funext₂ λ i _ => propext
+    ⟨λ ⟨_, hi', hR⟩ => hi' ▸ hR, λ hR => ⟨i, rfl, hR⟩⟩
 
 /-- `lift` is a right inverse of `lower` on distributive transformers. -/
 theorem lift_lower (φ : CCP S) (hd : CCP.IsDistributive φ) :
@@ -551,12 +529,9 @@ theorem updateFromSat_eq_inter_content (sat : S → φ → Prop)
 
 /-- The induced update is the lift of the satisfaction test. -/
 theorem updateFromSat_eq_lift_test (sat : S → φ → Prop) (ψ : φ) :
-    updateFromSat sat ψ = lift (test (λ p => sat p ψ)) := by
-  funext σ; ext p
-  simp only [updateFromSat, lift, test, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨hp, hsat⟩; exact ⟨p, hp, rfl, hsat⟩
-  · rintro ⟨i, hi, rfl, hsat⟩; exact ⟨hi, hsat⟩
+    updateFromSat sat ψ = lift (test (λ p => sat p ψ)) :=
+  funext λ _ => Set.ext λ p =>
+    ⟨λ ⟨hp, hs⟩ => ⟨p, hp, rfl, hs⟩, λ ⟨_, hi, hip, hs⟩ => ⟨hip ▸ hi, hs⟩⟩
 
 /-- Induced updates are distributive. -/
 theorem updateFromSat_isDistributive (sat : S → φ → Prop) (ψ : φ) :
@@ -568,14 +543,9 @@ theorem updateFromSat_isDistributive (sat : S → φ → Prop) (ψ : φ) :
 Support). -/
 theorem support_iff_update_eq (sat : S → φ → Prop)
     (ψ : φ) (s : Set S) :
-    supportOf sat s ψ ↔ updateFromSat sat ψ s = s := by
-  constructor
-  · intro h
-    ext p
-    exact ⟨fun hp => hp.1, fun hp => ⟨hp, h p hp⟩⟩
-  · intro h p hp
-    have : p ∈ updateFromSat sat ψ s := by rw [h]; exact hp
-    exact this.2
+    supportOf sat s ψ ↔ updateFromSat sat ψ s = s :=
+  ⟨λ h => Set.ext λ p => ⟨λ hp => hp.1, λ hp => ⟨hp, h p hp⟩⟩,
+   λ h p hp => by rw [← h] at hp; exact hp.2⟩
 
 /-- Dynamic entailment: updating with `ψ₁` always yields a state supporting
 `ψ₂`. -/

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Order.Quantale
 import Mathlib.Data.Set.Basic
 import Mathlib.Logic.Relation
 import Mathlib.Tactic.TypeStar
@@ -7,215 +8,162 @@ import Mathlib.Tactic.Use
 
 /-!
 # The update algebra
-[heim-1982] [groenendijk-stokhof-1991] [kamp-reyle-1993] [veltman-1996]
 
-Dynamic meanings in their two canonical faces. The *relational* face
-(`Update S = S → S → Prop`, [groenendijk-stokhof-1991]'s DPL relations,
-[kamp-reyle-1993]'s verification clauses, parametrized over the state
-type by [muskens-1996]): meanings relate input states to output states
-pointwise. The *set-transformer* face (`CCP S = Set S → Set S`,
-[heim-1982]'s file change potentials, [heim-1983]'s and
-[veltman-1996]'s context change): meanings act on information states —
-plain sets — as wholes. The literature says "state" at both levels:
-DPL's states are the points `S`, Veltman's are the sets `Set S`, and
-`lift` identifies the relational face's states with the transformer
-face's points — one carrier, two vocabularies. `lift` (the relational
-image, [muskens-van-benthem-visser-2011]'s strongest postcondition) and
-`lower` identify the relational algebra with the *distributive*
-transformers — those that process elements independently — and what the
-transformer face genuinely adds is the non-distributive tests
-(`CCP.guard`, `might`, `must`) that inspect the whole state.
-`Kleisli.lean` certifies the pair as canonical: updates are the Kleisli
-arrows of the powerset monad, transformers endomaps of its free
-algebra, and `lift` the comparison between the two — so the two faces
-are the Kleisli and Eilenberg–Moore presentations of one monad.
+This file defines dynamic meanings in their two canonical forms and the bridge
+between them. A relational update (`Update S`) relates input states to output
+states pointwise — [groenendijk-stokhof-1991]'s DPL relations and
+[kamp-reyle-1993]'s verifying embeddings, parametrized over the state type
+following [muskens-1996]. A context change potential (`CCP S`) transforms
+information states — sets of states — as wholes: the file change potentials of
+[heim-1982] and [heim-1983] and the updates of [veltman-1996]. `lift` sends a
+relation to its image transformer ([muskens-van-benthem-visser-2011]'s
+strongest postcondition), `lower` recovers a relation from behaviour on
+singletons, and the image of `lift` is exactly the distributive transformers.
+`Kleisli.lean` upgrades the pair to the Kleisli and Eilenberg–Moore
+presentations of the powerset monad.
 
-The algebra is the same at both levels. Meanings compose as a monoid
-(`⨟` relational, `;;` transformer); *tests* are the subidentities —
-`Update.IsTest` is `D ≤ 1` (`isTest_iff_le_one`) — and each level
-normalizes its tests against its own carrier: a relational test is the
-`test` of its truth condition (`Update.IsTest.eq_test_closure`), a
-transformer test is the `guard` of its acceptance condition
-(`CCP.IsTest.eq_guard`). The two notions are one concept at adjacent
-carriers, which is why `lift` does *not* intertwine them: `lift [C]` is
-the kernel operator `σ ↦ σ ∩ C` (eliminative, per-point), not a
-pass-or-`∅` guard.
+Both faces carry the same algebra. Updates form a monoid under sequencing —
+indeed a quantale, since sequencing distributes over arbitrary unions — and
+tests are its subidentities (`Update.isTest_iff_le_one`), with a normal form
+at each face: a relational test is the `test` of its truth condition
+(`Update.IsTest.eq_test_closure`), a transformer test is the `guard` of its
+acceptance condition (`CCP.IsTest.eq_guard`). The two test notions are one
+concept at adjacent carriers, so `lift` does not interchange them: `lift` of
+a relational test is an eliminative filter, not a pass-or-`∅` guard. The
+static fragment is their common ground: a transformer is a lifted test filter
+iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
 
 ## Main definitions
 
-- `Update S`, `Condition S`: relations on states, properties of states;
-  `dseq` (`⨟`), `test`, `dneg`, `dimpl`, `ddisj`, `closure`; a `Monoid`
-  under `⨟` (scoped instance).
-- `Update.IsTest`: DPL's tests — the subidentities of the update
-  monoid.
-- `CCP S`: meanings as transformers of information states (plain
-  `Set S`), a monoid under `CCP.seq`; `CCP.neg`, `CCP.guard` and the
-  whole-state tests `might`, `must`, `negTest`; `CCP.entails`
-  (acceptance-based consequence).
-- `CCP.IsEliminative`, `CCP.IsTest`, `CCP.IsDistributive`: the
-  classification of CCPs.
-- `supportOf`, `contentOf`, `updateFromSat`, `dynamicEntailsOf`: the
-  satisfaction-parameterized layer instantiated by PLA, DRT, DPL.
-- `lift`, `lower`: the bridge between the faces.
+* `Update S`, `Condition S`: relations on states and properties of states.
+* `test`, `dneg`, `dseq`, `dimpl`, `ddisj`, `closure`: the relational
+  connectives; `Update S` is a scoped `Monoid` and `IsQuantale`.
+* `Update.IsTest`: updates that never change the state.
+* `CCP S`: transformers of information states, a scoped `Monoid` under
+  `CCP.seq`, with `CCP.neg`, the whole-state tests `CCP.guard`, `might`,
+  `must`, `negTest`, and acceptance consequence `CCP.entails`.
+* `CCP.IsEliminative`, `CCP.IsTest`, `CCP.IsDistributive`: the classification
+  of transformers.
+* `lift`, `lower`: the bridge between the two faces.
+* `supportOf`, `contentOf`, `updateFromSat`, `dynamicEntailsOf`: the layer a
+  satisfaction relation induces; PLA, DRT, and DPL instantiate it.
 
 ## Main results
 
-- `Update.IsTest.eq_test_closure` ([groenendijk-stokhof-1991]'s
-  Fact 6) and `CCP.IsTest.eq_guard`: the mirror normal forms for tests
-  at the two levels.
-- `lower_lift`, `lift_lower`, `lift_isDistributive`: distributive CCPs
-  are exactly the relational images.
-- `lift_le_lift_iff`: `lift` reflects the pointwise order — the
-  SP-characterization of update-update consequence.
-- `exists_eq_lift_test_iff`: the static fragment is exactly
-  eliminative ∧ distributive — van Benthem's additivity
-  ([van-benthem-1986]; [rothschild-yalcin-2016]; [gillies-2022]) — and
-  `CCP.might_not_isDistributive` witnesses that whole-state tests are
-  genuinely beyond it.
-- `support_iff_update_eq`: support is being a fixed point of the
-  update — the hinge between the satisfaction layer and `CCP.entails`.
+* `Update.isTest_iff_le_one`, `Update.IsTest.eq_test_closure`
+  ([groenendijk-stokhof-1991]'s Fact 6), `CCP.IsTest.eq_guard`: tests are the
+  subidentities, with a normal form at each face.
+* `lower_lift`, `lift_lower`, `lift_isDistributive`: the distributive
+  transformers are exactly the relational images.
+* `lift_le_lift_iff`: `lift` reflects the pointwise order.
+* `exists_eq_lift_test_iff`: a transformer is a lifted test filter iff it is
+  eliminative and distributive — [van-benthem-1986]'s additivity, per
+  [rothschild-yalcin-2016] and [gillies-2022]. `CCP.might_not_isDistributive`
+  witnesses that whole-state tests lie outside this fragment.
+* `support_iff_update_eq`, `dynamicEntailsOf_iff_entails`: support is being a
+  fixed point of the update, and the satisfaction layer's consequence is
+  acceptance consequence.
+
+## Notation
+
+* `D₁ ⨟ D₂` for `dseq D₁ D₂`; scoped `∼ D` for `dneg D`, `[ C ]` for
+  `test C`, `! D` for `closure D`.
+* `u ;; v` for `CCP.seq u v`, scoped to `DynamicSemantics.CCP`.
 
 ## Implementation notes
 
-[groenendijk-stokhof-1991] §3.5's entailment notions (`⊨`, `⊨ₛ`, the
-deduction theorem, Facts 10–12) live with their paper in
+The algebraic instances are scoped: `Update S` and `CCP S` abbreviate
+function types, so global instances would attach `*` and `1` to bare function
+types for every importer. `open scoped DynamicSemantics` also makes mathlib's
+`WriterT (Update S) Id` a lawful monad.
+
+`dneg` does not validate double-negation elimination: negation collapses
+update information to a state predicate. The repairs are framework-specific —
+bilateral swap (`UpdateSemantics/Bilateral.lean`), propositional discourse
+referents (`Studies/Hofmann2025.lean`), classical metalanguage
+(`Studies/Cooper2023/`). Similarly `CCP.negTest` is not `CCP.neg`: the two
+coincide only on fixed or crashed inputs (`Studies/Beaver2001/ABLE.lean`).
+
+`updateFromSat` is kept as the literal filter rather than defined as
+`lift (test _)` (see `updateFromSat_eq_lift_test`) so that instantiating
+frameworks connect to it by `rfl`. [groenendijk-stokhof-1991]'s entailment
+notions and Facts 10–12 live with their paper in
 `Studies/GroenendijkStokhof1991.lean`.
 
-`dneg` fails double-negation elimination: negation collapses positive
-update information to a state predicate. The repairs are
-framework-specific and mutually incompatible — bilateral swap
-(`UpdateSemantics/Bilateral.lean`), propositional drefs (ICDRT,
-`Studies/Hofmann2025.lean`), classical metalanguage (TTR,
-`Studies/Cooper2023/`) — and the comparisons live in those studies.
+## References
+
+* [groenendijk-stokhof-1991], [kamp-reyle-1993], [muskens-1996]
+* [heim-1982], [heim-1983], [veltman-1996]
+* [muskens-van-benthem-visser-2011]
+* [van-benthem-1986], [rothschild-yalcin-2016], [gillies-2022]
 -/
 
 namespace DynamicSemantics
 
-/-! ### Core types -/
+/-! ## The relational face -/
 
-/-- Update meaning: type `s(st)` — binary relation on states.
+section Relational
 
-A proposition in dynamic semantics is a relation between an input
-state and an output state. This is the type that [heim-1982]'s
-file change potentials, [kamp-reyle-1993]'s Update verification,
-and [groenendijk-stokhof-1991]'s DPL meanings all instantiate. -/
+/-- A dynamic meaning as a binary relation between input and output states. -/
 abbrev Update (S : Type*) := S → S → Prop
 
-/-- Condition: type `st` — property of a single state.
-
-Static conditions that do not change the state. Conditions are
-lifted to Update meanings via `test`. -/
+/-- A static property of a single state; `test` embeds conditions into updates. -/
 abbrev Condition (S : Type*) := S → Prop
 
-/-! ### Operations -/
+variable {S : Type*} {C : Condition S} {D : Update S} {i j : S}
 
-section Operations
+/-! ### The connectives -/
 
-variable {S : Type*}
-
-/-- Dynamic negation: `¬D` holds at `i` iff no output `k` satisfies `D`.
-
-[kamp-reyle-1993]'s verifying-embedding clause for negation and
-[groenendijk-stokhof-1991]'s DPL negation. -/
-def dneg (D : Update S) : Condition S :=
-  λ i => ¬∃ k, D i k
-
-scoped notation "∼" D => dneg D
-
-/-- Test: lift a condition to an Update that checks `C` without changing state.
-
-Under `lift` this is [heim-1982]'s intersection with the satisfaction
-set, `SAT(F') = SAT(F) ∩ {a : C(a)}` (`lift_test`). -/
-def test (C : Condition S) : Update S :=
-  λ i j => i = j ∧ C j
+/-- `test C` checks `C` without changing the state. -/
+def test (C : Condition S) : Update S := λ i j => i = j ∧ C j
 
 scoped notation "[" C "]" => test C
 
-/-- A test relates a state only to itself. Operators that return a
-`Condition` (`dneg`, `dimpl`, `ddisj`) re-enter the update algebra via
-`test`, so updates factoring through `test` cannot modify the state —
-the algebraic core of anaphoric-island facts. -/
-theorem eq_of_test {C : Condition S} {i j : S} (h : test C i j) : i = j :=
-  h.1
+/-- A test relates a state only to itself. -/
+theorem eq_of_test (h : test C i j) : i = j := h.1
 
-/-- An update is a *test* when it never changes the state
-([groenendijk-stokhof-1991], Definition 11) — DPL's tests, the
-subidentities of the update monoid (`isTest_iff_le_one`). `CCP.IsTest`
-(pass-or-`∅`, Veltman's tests) is the same concept one carrier up:
-`lift` of a relational test is a filter, not a pass-or-`∅` guard. -/
-def Update.IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
+/-- `∼D` holds at `i` iff no output `k` satisfies `D`. -/
+def dneg (D : Update S) : Condition S := λ i => ¬∃ k, D i k
 
-theorem Update.isTest_test (C : Condition S) : Update.IsTest (test C) :=
-  fun _ _ h => h.1
+scoped notation "∼" D => dneg D
 
-/-- Dynamic conjunction (sequencing): `D₁ ; D₂`.
-
-Mathlib's relational composition `Relation.Comp` at endorelations: there
-exists an intermediate state witnessing both transitions. This is
-[heim-1982]'s successive file change, [kamp-reyle-1993]'s DRS merge,
-and [groenendijk-stokhof-1991]'s DPL conjunction. -/
-def dseq (D₁ D₂ : Update S) : Update S :=
-  Relation.Comp D₁ D₂
+/-- `D₁ ⨟ D₂` relates `i` to `k` iff some intermediate `j` has `D₁ i j` and `D₂ j k`. -/
+def dseq (D₁ D₂ : Update S) : Update S := Relation.Comp D₁ D₂
 
 infixl:65 " ⨟ " => dseq
 
-/-- Dynamic implication: `D₁ → D₂`.
+/-- `dimpl D₁ D₂` holds at `i` iff every `D₁`-output from `i` has a `D₂`-output. -/
+def dimpl (D₁ D₂ : Update S) : Condition S := λ i => ∀ h, D₁ i h → ∃ k, D₂ h k
 
-Every way of satisfying the antecedent can be extended to satisfy the
-consequent — [kamp-reyle-1993]'s verifying-embedding clause for the
-conditional. -/
-def dimpl (D₁ D₂ : Update S) : Condition S :=
-  λ i => ∀ h, D₁ i h → ∃ k, D₂ h k
+/-- `ddisj D₁ D₂` holds at `i` iff some disjunct has an output from `i`. -/
+def ddisj (D₁ D₂ : Update S) : Condition S := λ i => ∃ k, D₁ i k ∨ D₂ i k
 
-/-- Dynamic disjunction: `D₁ ∨ D₂`.
-
-There exists an output via either disjunct — [kamp-reyle-1993]'s
-verifying-embedding clause for disjunction. -/
-def ddisj (D₁ D₂ : Update S) : Condition S :=
-  λ i => ∃ k, D₁ i k ∨ D₂ i k
-
-/-- Anaphoric closure: `∃ output state`.
-
-[heim-1982]'s truth definition: a file is true iff its
-satisfaction set is non-empty, i.e., some assignment satisfies it. -/
-def closure (D : Update S) : Condition S :=
-  λ i => ∃ k, D i k
+/-- `!D` holds at `i` iff `D` has an output from `i` — [heim-1982]'s truth definition. -/
+def closure (D : Update S) : Condition S := λ i => ∃ k, D i k
 
 scoped notation "!" D => closure D
 
-end Operations
+/-! ### The update quantale -/
 
-/-! ### Algebraic properties -/
-
-section Theorems
-
-variable {S : Type*}
-
-/-- Sequencing is associative: mathlib's `Relation.comp_assoc`. -/
+/-- Sequencing is associative. -/
 theorem dseq_assoc (D₁ D₂ D₃ : Update S) :
     (D₁ ⨟ D₂) ⨟ D₃ = D₁ ⨟ (D₂ ⨟ D₃) :=
   Relation.comp_assoc
 
-/-- Test is left identity for sequencing (when condition holds everywhere). -/
+/-- An everywhere-true test is a left identity for sequencing. -/
 theorem test_dseq (C : Condition S) (D : Update S) (hC : ∀ i, C i) :
     test C ⨟ D = D := by
   funext i j
   simp [dseq, Relation.Comp, test, hC]
 
-/-- Test is right identity for sequencing (when condition holds everywhere).
-Together with `test_dseq` and `dseq_assoc`, this makes `(Update S, ⨟, test ⊤)`
-a monoid. -/
+/-- An everywhere-true test is a right identity for sequencing. -/
 theorem dseq_test (D : Update S) (C : Condition S) (hC : ∀ i, C i) :
     D ⨟ test C = D := by
   funext i j
   simp [dseq, Relation.Comp, test, hC]
 
-/-- `Update S` is a monoid under dynamic conjunction `⨟` with the trivial
-test as unit (`dseq_assoc`, `test_dseq`, `dseq_test`). Scoped because
-`Update S` is an abbreviation for `S → S → Prop`: a global instance would
-attach `*`/`1` to the bare function type. Activate with
-`open scoped DynamicSemantics`; mathlib's
-`WriterT (Update S) Id` then gets `Monad`/`LawfulMonad` for free. -/
+/-- `Update S` is a monoid under `⨟` with the trivial test as unit (scoped;
+see the implementation notes). -/
 scoped instance : Monoid (Update S) where
   mul := dseq
   one := test (λ _ => True)
@@ -223,37 +171,53 @@ scoped instance : Monoid (Update S) where
   one_mul D := test_dseq _ D (λ _ => trivial)
   mul_one D := dseq_test D _ (λ _ => trivial)
 
+/-- `Update S` is a quantale: sequencing distributes over arbitrary unions of
+updates, so mathlib's residuation vocabulary applies (scoped). -/
+scoped instance : IsQuantale (Update S) where
+  mul_sSup_distrib D s := by
+    funext i k
+    show (D ⨟ sSup s) i k = (⨆ E ∈ s, D ⨟ E) i k
+    simp only [dseq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
+    exact propext ⟨fun ⟨b, hD, ⟨E, hE⟩, hbk⟩ => ⟨E, hE, b, hD, hbk⟩,
+      fun ⟨E, hE, b, hD, hbk⟩ => ⟨b, hD, ⟨E, hE⟩, hbk⟩⟩
+  sSup_mul_distrib s D := by
+    funext i k
+    show (sSup s ⨟ D) i k = (⨆ E ∈ s, E ⨟ D) i k
+    simp only [dseq, Relation.Comp, sSup_apply, iSup_apply, iSup_Prop_eq]
+    exact propext ⟨fun ⟨b, ⟨⟨E, hE⟩, hib⟩, hbk⟩ => ⟨E, hE, b, hib, hbk⟩,
+      fun ⟨E, hE, b, hib, hbk⟩ => ⟨b, ⟨⟨E, hE⟩, hib⟩, hbk⟩⟩
+
 /-! ### Tests are the subidentities -/
 
-/-- Tests are the subidentities of the update monoid: `D` is a test iff
-`D ≤ 1` in the pointwise order — the coreflexive relations. -/
-theorem Update.isTest_iff_le_one {D : Update S} :
-    D.IsTest ↔ D ≤ 1 :=
+/-- An update is a *test* if it never changes the state
+([groenendijk-stokhof-1991], Definition 11). -/
+def Update.IsTest (D : Update S) : Prop := ∀ ⦃i j⦄, D i j → i = j
+
+/-- `test C` is a test. -/
+theorem Update.isTest_test (C : Condition S) : Update.IsTest (test C) :=
+  fun _ _ h => h.1
+
+/-- Tests are the subidentities of the update monoid: the coreflexives `D ≤ 1`. -/
+theorem Update.isTest_iff_le_one : D.IsTest ↔ D ≤ 1 :=
   ⟨fun h _ _ hij => ⟨h hij, trivial⟩, fun h _ _ hij => (h _ _ hij).1⟩
 
-/-- A test is the test of its own closure — the semantic content of
-[groenendijk-stokhof-1991]'s Fact 6: up to contradictions, tests are
-exactly the conditions. The transformer-face mirror is
-`CCP.IsTest.eq_guard`. -/
-theorem Update.IsTest.eq_test_closure {D : Update S} (h : Update.IsTest D) :
+/-- A test is the test of its own closure ([groenendijk-stokhof-1991]'s
+Fact 6); the transformer-face mirror is `CCP.IsTest.eq_guard`. -/
+theorem Update.IsTest.eq_test_closure (h : Update.IsTest D) :
     D = test (closure D) := by
   funext i j
   exact propext (by grind [test, closure, Update.IsTest])
 
-end Theorems
+end Relational
 
-/-! ## The set-transformer face -/
+/-! ## The transformer face -/
 
-
-/-- A Context Change Potential: meanings as transformers of whole
-information states, [heim-1983]'s and [veltman-1996]'s semantic type.
-The distributive CCPs are exactly the `lift`s of relational `Update`s;
-the rest — the whole-state tests below — are what this face adds. -/
+/-- A context change potential: a transformer of whole information states. -/
 abbrev CCP (S : Type*) := Set S → Set S
 
 namespace CCP
 
-variable {S : Type*}
+variable {S : Type*} {u v φ ψ : CCP S}
 
 /-- The identity CCP. -/
 def id : CCP S := λ s => s
@@ -266,10 +230,7 @@ def seq (u v : CCP S) : CCP S := λ s => v (u s)
 
 scoped infixl:70 " ;; " => seq
 
-/-- CCPs form a monoid under sequential composition. Scoped because
-`CCP S` is an abbreviation for `Set S → Set S`: a global instance would
-attach `*`/`1` to a bare function type for every importer. Activate with
-`open scoped DynamicSemantics.CCP`. -/
+/-- `CCP S` is a monoid under `seq` (scoped; see the implementation notes). -/
 scoped instance : Monoid (CCP S) where
   mul := seq
   one := id
@@ -280,24 +241,15 @@ scoped instance : Monoid (CCP S) where
 /-- The absurd CCP absorbs on the right. -/
 theorem seq_absurd (u : CCP S) : u ;; absurd = absurd := rfl
 
-/--
-Dynamic negation: complement within the input state.
+/-- Dynamic negation by set difference: the states that do not survive `φ`
+([heim-1982]; [veltman-1996]). -/
+def neg (φ : CCP S) : CCP S := λ s => s \ φ s
 
-This is the standard dynamic negation of [heim-1982], [veltman-1996]:
-¬φ(s) = s \ φ(s). Worlds survive iff they do not survive φ.
-Does not validate DNE on non-eliminative updates. For the whole-state
-consistency test (must-not), see `negTest`.
--/
-def neg (φ : CCP S) : CCP S :=
-  λ s => s \ φ s
+/-! ### Whole-state tests -/
 
 open Classical in
-/-- Whole-state test: pass the state through iff it satisfies `C` — the
-shared shape of `negTest`, `might`, and `must`, the non-distributive
-tests that inspect the entire input state. Every pass-or-`∅` CCP is a
-guard (`IsTest.eq_guard`). -/
-noncomputable def guard (C : Set S → Prop) : CCP S :=
-  λ s => if C s then s else ∅
+/-- `guard C` passes a state through iff it satisfies `C`, else crashes to `∅`. -/
+noncomputable def guard (C : Set S → Prop) : CCP S := λ s => if C s then s else ∅
 
 /-- A guard whose condition holds passes the state through. -/
 @[simp] theorem guard_pos {C : Set S → Prop} {s} (h : C s) : guard C s = s :=
@@ -307,87 +259,53 @@ noncomputable def guard (C : Set S → Prop) : CCP S :=
 @[simp] theorem guard_neg {C : Set S → Prop} {s} (h : ¬C s) : guard C s = ∅ :=
   if_neg h
 
-/--
-Test-indexed negation: passes (returns input) iff φ yields ∅.
+/-- `negTest φ` passes iff `φ` crashes — a whole-state consistency test, not
+the set-difference `neg` (see the implementation notes). -/
+noncomputable def negTest (φ : CCP S) : CCP S := guard (λ s => ¬ (φ s).Nonempty)
 
-A whole-state consistency test ("must-not"), NOT [heim-1982]'s or
-[veltman-1996]'s negation (that is `neg`, set difference). The two
-coincide only when `φ s = ∅` or `φ s = s` — see
-`Studies/Beaver2001/ABLE.lean` for the proven divergence.
--/
-noncomputable def negTest (φ : CCP S) : CCP S :=
-  guard (λ s => ¬ (φ s).Nonempty)
+/-- `might φ` passes iff `φ` yields a nonempty result ([veltman-1996]). -/
+noncomputable def might (φ : CCP S) : CCP S := guard (λ s => (φ s).Nonempty)
 
-/--
-Compatibility test ("might"): passes iff φ yields a nonempty result.
+/-- `must φ` passes iff `φ` returns its input unchanged ([veltman-1996]). -/
+noncomputable def must (φ : CCP S) : CCP S := guard (λ s => φ s = s)
 
-might(φ)(s) = s if φ(s) ≠ ∅, else ∅
--/
-noncomputable def might (φ : CCP S) : CCP S :=
-  guard (λ s => (φ s).Nonempty)
+/-- Acceptance consequence: every `φ`-output is a fixed point of `ψ`
+([veltman-1996]'s acceptance validity; [beaver-2001]'s D45). -/
+def entails (φ ψ : CCP S) : Prop := ∀ s : Set S, ψ (φ s) = φ s
 
-/--
-Full support test ("must"): passes iff φ returns input unchanged.
+/-! ### Classification -/
 
-must(φ)(s) = s if φ(s) = s, else ∅
--/
-noncomputable def must (φ : CCP S) : CCP S :=
-  guard (λ s => φ s = s)
-
-/-- Acceptance-based consequence: every output of `φ` is a fixed point
-of `ψ` — updating with the conclusion after the premiss changes nothing
-([veltman-1996]'s acceptance validity; [beaver-2001]'s D45 entailment,
-`Studies/Beaver2001/ABLE.lean`). `support_iff_update_eq` connects the
-fixed-point reading to the satisfaction layer's `supportOf`. -/
-def entails (φ ψ : CCP S) : Prop :=
-  ∀ s : Set S, ψ (φ s) = φ s
-
-end CCP
-
-/-! ### The classification of CCPs -/
-
-namespace CCP
-
-variable {S : Type*}
-
-/-- An update is *eliminative* when it never adds possibilities —
-information only grows. Equivalently, `u ≤ id` in the pointwise order:
-the deflationary transformers. -/
-def IsEliminative (u : CCP S) : Prop :=
-  ∀ s, u s ⊆ s
+/-- A transformer is *eliminative* if it never adds possibilities: `u ≤ id`
+pointwise. -/
+def IsEliminative (u : CCP S) : Prop := ∀ s, u s ⊆ s
 
 /-- The identity is eliminative. -/
 theorem isEliminative_id : IsEliminative (id : CCP S) :=
   λ _ => Set.Subset.rfl
 
 /-- Sequencing preserves eliminativity. -/
-theorem IsEliminative.seq {u v : CCP S}
-    (hu : IsEliminative u) (hv : IsEliminative v) :
+theorem IsEliminative.seq (hu : IsEliminative u) (hv : IsEliminative v) :
     IsEliminative (u.seq v) := λ s _ hp =>
   hu s (hv (u s) hp)
 
-/-- A test either passes (returns its input) or fails (returns `∅`) —
-[veltman-1996]'s tests: `might`, `must`, presupposition checks. The
-same subidentity concept as the relational `Update.IsTest`, one carrier
-up — which is why `lift` does not intertwine the two: lifting a
-relational test gives an eliminative filter, not a pass-or-`∅` guard. -/
-def IsTest (u : CCP S) : Prop :=
-  ∀ s, u s = s ∨ u s = ∅
+/-- A transformer is a *test* if it passes its input through or crashes to
+`∅` — [veltman-1996]'s tests, `Update.IsTest` one carrier up. -/
+def IsTest (u : CCP S) : Prop := ∀ s, u s = s ∨ u s = ∅
 
 /-- Tests are eliminative. -/
-theorem IsTest.isEliminative {u : CCP S} (h : IsTest u) :
+theorem IsTest.isEliminative (h : IsTest u) :
     IsEliminative u := λ s p hp => by
   cases h s with
   | inl heq => rw [heq] at hp; exact hp
   | inr hemp => rw [hemp] at hp; exact False.elim hp
 
+/-- Guards are tests. -/
 theorem guard_isTest (C : Set S → Prop) : IsTest (guard C) := by
   intro s; simp only [guard]; split <;> simp
 
-/-- A test is the guard of its own acceptance condition — the
-transformer-face mirror of `Update.IsTest.eq_test_closure`. -/
-theorem IsTest.eq_guard {u : CCP S} (h : IsTest u) :
-    u = guard fun s => u s = s := by
+/-- A test is the guard of its own acceptance condition — the mirror of
+`Update.IsTest.eq_test_closure`. -/
+theorem IsTest.eq_guard (h : IsTest u) : u = guard fun s => u s = s := by
   funext s
   by_cases hs : u s = s
   · rw [guard_pos (C := fun t => u t = t) hs, hs]
@@ -395,19 +313,174 @@ theorem IsTest.eq_guard {u : CCP S} (h : IsTest u) :
     exact (h s).resolve_left hs
 
 /-- The tests are exactly the guards. -/
-theorem isTest_iff_exists_guard {u : CCP S} :
-    IsTest u ↔ ∃ C, u = guard C :=
+theorem isTest_iff_exists_guard : IsTest u ↔ ∃ C, u = guard C :=
   ⟨fun h => ⟨_, h.eq_guard⟩, fun ⟨C, hC⟩ => hC ▸ guard_isTest C⟩
+
+/-- A transformer is *distributive* if it acts per-element:
+`φ s = ⋃ i ∈ s, φ {i}` — equivalently, it preserves arbitrary joins
+(`Kleisli.lean`'s `isDistributive_iff_map_sSup`). -/
+def IsDistributive (φ : CCP S) : Prop :=
+  ∀ s, φ s = {p | ∃ i ∈ s, p ∈ φ {i}}
+
+/-- `might` is not distributive: a whole-state test can pass where every
+per-singleton test fails. -/
+theorem might_not_isDistributive :
+    ∃ (S : Type) (φ : CCP S), ¬IsDistributive (might φ) := by
+  refine ⟨Bool, (fun s => {p ∈ s | p = true}), fun hD => ?_⟩
+  have hfalse :
+      false ∈ might (fun s : Set Bool => {p ∈ s | p = true}) {true, false} := by
+    rw [might, guard_pos ⟨true, Or.inl rfl, rfl⟩]
+    exact Or.inr rfl
+  rw [hD] at hfalse
+  obtain ⟨i, hi, hmem⟩ := hfalse
+  rcases hi with rfl | rfl
+  · rw [might, guard_pos ⟨true, rfl, rfl⟩] at hmem
+    exact Bool.false_ne_true hmem
+  · rw [might, guard_neg (fun ⟨x, hx, hx'⟩ => Bool.false_ne_true (hx ▸ hx'))]
+      at hmem
+    exact hmem
 
 end CCP
 
+/-! ## The bridge -/
 
-/-! ### The satisfaction layer
+section RelationalBridge
 
-A satisfaction relation `sat : S → φ → Prop` induces the standard
-eliminative fragment: per-formula contents, filter updates, the support
-relation, and acceptance-based entailment. PLA, DRT, and DPL define
-their updates by instantiating `sat`. -/
+variable {S : Type*} {R R' : Update S} {C : Condition S} {σ : Set S} {i j : S}
+
+/-- The relational image: `lift R σ` collects the `R`-outputs of the elements
+of `σ` — the strongest postcondition of [muskens-van-benthem-visser-2011]. -/
+def lift (R : Update S) : CCP S := λ σ => { j | ∃ i ∈ σ, R i j }
+
+/-- `lower φ i j` holds iff `j` is an output of `φ` on the singleton `{i}`. -/
+def lower (φ : CCP S) : Update S := λ i j => j ∈ φ {i}
+
+theorem mem_lift : j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
+
+/-- `lift` sends sequencing to composition. -/
+theorem lift_dseq (R₁ R₂ : Update S) :
+    lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) := by
+  funext σ; ext k; simp only [lift, CCP.seq, dseq, Relation.Comp, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨i, hi, j, hR₁, hR₂⟩
+    exact ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩
+  · rintro ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩
+    exact ⟨i, hi, j, hR₁, hR₂⟩
+
+/-- `lift (test C)` is the filter by `C`. -/
+theorem lift_test (C : Condition S) :
+    lift (test C) = λ σ => { i ∈ σ | C i } := by
+  funext σ; ext j; simp only [lift, test, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨i, hi, rfl, hC⟩; exact ⟨hi, hC⟩
+  · rintro ⟨hj, hC⟩; exact ⟨j, hj, rfl, hC⟩
+
+/-- Lifted transformers are distributive. -/
+theorem lift_isDistributive (R : Update S) : CCP.IsDistributive (lift R) := by
+  intro σ; ext j; simp only [lift, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨i, hi, hR⟩
+    refine ⟨i, hi, i, ?_, hR⟩; exact rfl
+  · rintro ⟨i, hi, i', hi', hR⟩
+    refine ⟨i, hi, ?_⟩; rwa [hi'] at hR
+
+/-- `lower` is a left inverse of `lift`: the relational face loses nothing. -/
+theorem lower_lift (R : Update S) : lower (lift R) = R := by
+  funext i j; simp only [lower, lift, Set.mem_setOf_eq, eq_iff_iff]
+  constructor
+  · rintro ⟨i', hi', hR⟩; rwa [hi'] at hR
+  · intro hR; exact ⟨i, rfl, hR⟩
+
+/-- `lift` is a right inverse of `lower` on distributive transformers. -/
+theorem lift_lower (φ : CCP S) (hd : CCP.IsDistributive φ) :
+    lift (lower φ) = φ := by
+  funext σ; ext j; simp only [lift, lower, Set.mem_setOf_eq]
+  rw [hd σ]
+  simp only [Set.mem_setOf_eq]
+
+/-- `lift` reflects (and preserves) the pointwise order. -/
+theorem lift_le_lift_iff : lift R ≤ lift R' ↔ R ≤ R' := by
+  constructor
+  · intro h i j hR
+    obtain ⟨i', hi', hR'⟩ := h {i} ⟨i, rfl, hR⟩
+    cases hi'
+    exact hR'
+  · rintro h σ j ⟨i, hi, hR⟩
+    exact ⟨i, hi, h i j hR⟩
+
+/-! ### Test filters -/
+
+@[simp] theorem mem_lift_test : i ∈ lift (test C) σ ↔ i ∈ σ ∧ C i := by
+  rw [lift_test]; exact Iff.rfl
+
+/-- `lift (test C)` is eliminative: it only removes elements. -/
+theorem lift_test_isEliminative (C : Condition S) :
+    CCP.IsEliminative (lift (test C)) := by
+  rw [lift_test]; intro σ j ⟨hj, _⟩; exact hj
+
+/-- Composing test filters conjoins the conditions. -/
+theorem lift_test_lift_test (C₁ C₂ : Condition S) (σ : Set S) :
+    lift (test C₂) (lift (test C₁) σ) = lift (test fun i => C₁ i ∧ C₂ i) σ :=
+  Set.ext fun i => by
+    simp only [mem_lift_test]
+    exact and_assoc
+
+/-- Test filters are idempotent. -/
+theorem lift_test_idem (C : Condition S) (σ : Set S) :
+    lift (test C) (lift (test C) σ) = lift (test C) σ := by
+  rw [lift_test_lift_test]
+  exact Set.ext fun i => by simp only [mem_lift_test, and_self]
+
+/-- Contradictory test filters compose to the empty state. -/
+theorem lift_test_disjoint (C₁ C₂ : Condition S)
+    (h : ∀ i, C₁ i → C₂ i → False) (σ : Set S) :
+    lift (test C₂) (lift (test C₁) σ) = ∅ := by
+  rw [lift_test_lift_test]
+  exact Set.eq_empty_of_forall_notMem fun i hi =>
+    h i (mem_lift_test.mp hi).2.1 (mem_lift_test.mp hi).2.2
+
+/-- Covering test filters partition the state. -/
+theorem lift_test_cover₃ (C₁ C₂ C₃ : Condition S)
+    (h : ∀ i, C₁ i ∨ C₂ i ∨ C₃ i) (σ : Set S) :
+    lift (test C₁) σ ∪ lift (test C₂) σ ∪ lift (test C₃) σ = σ :=
+  Set.ext fun i => by
+    simp only [Set.mem_union, mem_lift_test]
+    refine ⟨fun hi => ?_, fun hi => ?_⟩
+    · rcases hi with (⟨h', -⟩ | ⟨h', -⟩) | ⟨h', -⟩ <;> exact h'
+    · rcases h i with h' | h' | h'
+      · exact Or.inl (Or.inl ⟨hi, h'⟩)
+      · exact Or.inl (Or.inr ⟨hi, h'⟩)
+      · exact Or.inr ⟨hi, h'⟩
+
+/-! ### The static fragment -/
+
+/-- A transformer is a lifted test filter iff it is eliminative and
+distributive — [van-benthem-1986]'s additivity ([rothschild-yalcin-2016];
+[gillies-2022]). Update semantics keeps eliminativity but its whole-state
+tests break distributivity; DPL's random reassignment keeps distributivity
+but breaks eliminativity. -/
+theorem exists_eq_lift_test_iff {φ : CCP S} :
+    (∃ C : Condition S, φ = lift (test C)) ↔
+      CCP.IsEliminative φ ∧ CCP.IsDistributive φ := by
+  constructor
+  · rintro ⟨C, rfl⟩
+    exact ⟨lift_test_isEliminative C, lift_isDistributive _⟩
+  · rintro ⟨he, hd⟩
+    refine ⟨fun i => i ∈ φ {i}, ?_⟩
+    funext s
+    rw [hd s, lift_test]
+    ext p
+    exact ⟨fun ⟨i, hi, hpi⟩ => by obtain rfl : p = i := he {i} hpi; exact ⟨hi, hpi⟩,
+      fun ⟨hp, hC⟩ => ⟨p, hp, hC⟩⟩
+
+end RelationalBridge
+
+/-! ## The satisfaction layer
+
+A satisfaction relation `sat : S → φ → Prop` induces the standard eliminative
+fragment: per-formula contents, filter updates, the support relation, and
+dynamic entailment. PLA, DRT, and DPL define their updates by instantiating
+`sat`. -/
 
 section Satisfaction
 
@@ -441,8 +514,7 @@ theorem content_mono (sat : S → φ → Prop) (ψ₁ ψ₂ : φ)
     contentOf sat ψ₁ ⊆ contentOf sat ψ₂ :=
   λ _ hp => h _ hp
 
-/-- Filtering a set by a predicate is monotone — the shared foundation
-for `updateFromSat_monotone` and its per-predicate instances. -/
+/-- Filtering a set by a predicate is monotone. -/
 theorem sep_monotone (pred : S → Prop) :
     Monotone (λ s : Set S => { p ∈ s | pred p }) :=
   λ _ _ h _ hp => ⟨h hp.1, hp.2⟩
@@ -452,21 +524,24 @@ theorem sep_eliminative (pred : S → Prop) :
     CCP.IsEliminative (λ s : Set S => { p ∈ s | pred p }) :=
   λ s => Set.sep_subset s pred
 
-/-- The standard update construction: filter by satisfaction — how PLA,
-DRT, and DPL all define updates. Kept as the literal filter (rather
-than `lift (test _)`, see `updateFromSat_eq_lift_test`) so instantiating
-frameworks connect by `rfl`. -/
+/-- The update a satisfaction relation induces: filter to the satisfying
+possibilities (see the implementation notes on the choice of body). -/
 def updateFromSat (sat : S → φ → Prop) (ψ : φ) : CCP S :=
   λ s => { p ∈ s | sat p ψ }
-
-/-- Standard updates are eliminative. -/
-theorem updateFromSat_eliminative (sat : S → φ → Prop) (ψ : φ) :
-    CCP.IsEliminative (updateFromSat sat ψ) :=
-  sep_eliminative _
 
 @[simp] theorem mem_updateFromSat {sat : S → φ → Prop} {ψ : φ}
     {s : Set S} {p : S} :
     p ∈ updateFromSat sat ψ s ↔ p ∈ s ∧ sat p ψ := Iff.rfl
+
+/-- Induced updates are eliminative. -/
+theorem updateFromSat_eliminative (sat : S → φ → Prop) (ψ : φ) :
+    CCP.IsEliminative (updateFromSat sat ψ) :=
+  sep_eliminative _
+
+/-- `updateFromSat` is monotone in the state argument. -/
+theorem updateFromSat_monotone (sat : S → φ → Prop) (ψ : φ) :
+    Monotone (updateFromSat sat ψ) :=
+  sep_monotone _
 
 /-- Updating is intersecting with the content. -/
 theorem updateFromSat_eq_inter_content (sat : S → φ → Prop)
@@ -474,9 +549,23 @@ theorem updateFromSat_eq_inter_content (sat : S → φ → Prop)
     updateFromSat sat ψ s = s ∩ contentOf sat ψ :=
   rfl
 
-/-- Support is being a fixed point of the update ([dekker-2012]'s
-Proper Support) — the hinge between the satisfaction layer and the
-acceptance-based `CCP.entails`. -/
+/-- The induced update is the lift of the satisfaction test. -/
+theorem updateFromSat_eq_lift_test (sat : S → φ → Prop) (ψ : φ) :
+    updateFromSat sat ψ = lift (test (λ p => sat p ψ)) := by
+  funext σ; ext p
+  simp only [updateFromSat, lift, test, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨hp, hsat⟩; exact ⟨p, hp, rfl, hsat⟩
+  · rintro ⟨i, hi, rfl, hsat⟩; exact ⟨hi, hsat⟩
+
+/-- Induced updates are distributive. -/
+theorem updateFromSat_isDistributive (sat : S → φ → Prop) (ψ : φ) :
+    CCP.IsDistributive (updateFromSat sat ψ) := by
+  rw [updateFromSat_eq_lift_test]
+  exact lift_isDistributive _
+
+/-- Support is being a fixed point of the update ([dekker-2012]'s Proper
+Support). -/
 theorem support_iff_update_eq (sat : S → φ → Prop)
     (ψ : φ) (s : Set S) :
     supportOf sat s ψ ↔ updateFromSat sat ψ s = s := by
@@ -488,13 +577,12 @@ theorem support_iff_update_eq (sat : S → φ → Prop)
     have : p ∈ updateFromSat sat ψ s := by rw [h]; exact hp
     exact this.2
 
-/-- Dynamic entailment: updating with `ψ₁` always yields a state
-supporting `ψ₂`. -/
+/-- Dynamic entailment: updating with `ψ₁` always yields a state supporting
+`ψ₂`. -/
 def dynamicEntailsOf (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
   ∀ s : Set S, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
 
-/-- Dynamic entailment is `CCP.entails` of the induced updates: the
-satisfaction layer's consequence is the acceptance-based one. -/
+/-- Dynamic entailment is acceptance consequence of the induced updates. -/
 theorem dynamicEntailsOf_iff_entails (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) :
     dynamicEntailsOf sat ψ₁ ψ₂ ↔
       CCP.entails (updateFromSat sat ψ₁) (updateFromSat sat ψ₂) :=
@@ -511,225 +599,6 @@ theorem dynamicEntails_trans (sat : S → φ → Prop) (ψ₁ ψ₂ ψ₃ : φ)
     dynamicEntailsOf sat ψ₁ ψ₃ :=
   fun s p hp => h2 s p ⟨hp.1, h1 s p hp⟩
 
-/-- `updateFromSat` is monotone in the state argument. -/
-theorem updateFromSat_monotone (sat : S → φ → Prop) (ψ : φ) :
-    Monotone (updateFromSat sat ψ) :=
-  sep_monotone _
-
 end Satisfaction
-
-
-/-! ### Distributivity -/
-
-namespace CCP
-
-variable {S : Type*}
-
-/-- A CCP is distributive when it processes each element of the input
-independently: `φ(s) = ⋃_{i ∈ s} φ({i})` — equivalently, it preserves
-arbitrary joins of states (`Kleisli.lean`'s
-`isDistributive_iff_map_sSup`). -/
-def IsDistributive (φ : CCP S) : Prop :=
-  ∀ s, φ s = {p | ∃ i ∈ s, p ∈ φ {i}}
-
-/-- `might` is not distributive: the whole-context test can pass while
-every individual-element test fails. Witness: `S = Bool`, `φ` keeps only
-`true`; then `false` survives `might φ` on `{true, false}` but lies in
-no per-singleton output. -/
-theorem might_not_isDistributive :
-    ∃ (S : Type) (φ : CCP S), ¬IsDistributive (might φ) := by
-  refine ⟨Bool, (fun s => {p ∈ s | p = true}), fun hD => ?_⟩
-  have hfalse :
-      false ∈ might (fun s : Set Bool => {p ∈ s | p = true}) {true, false} := by
-    rw [might, guard_pos ⟨true, Or.inl rfl, rfl⟩]
-    exact Or.inr rfl
-  rw [hD] at hfalse
-  obtain ⟨i, hi, hmem⟩ := hfalse
-  rcases hi with rfl | rfl
-  · rw [might, guard_pos ⟨true, rfl, rfl⟩] at hmem
-    exact Bool.false_ne_true hmem
-  · rw [might, guard_neg (fun ⟨x, hx, hx'⟩ => Bool.false_ne_true (hx ▸ hx'))]
-      at hmem
-    exact hmem
-
-end CCP
-
-/-- `updateFromSat` is always distributive: it filters per-element. -/
-theorem updateFromSat_isDistributive {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
-    CCP.IsDistributive (updateFromSat sat ψ) := by
-  intro s; ext p; simp only [updateFromSat, Set.mem_setOf_eq]
-  constructor
-  · intro ⟨hp, hsat⟩; exact ⟨p, hp, ⟨rfl, hsat⟩⟩
-  · rintro ⟨i, hi, hpi, hsat⟩; cases hpi; exact ⟨hi, hsat⟩
-
-/-! ### The relational bridge
-
-The relational type `Update S = S → S → Prop` is the primary dynamic
-semantic type. Every `Update` gives rise to a distributive `CCP` via
-the relational image (`lift`), and every distributive CCP arises this
-way (`lower`); the round-trip is the identity in both directions.
-
-Non-distributive CCP operations (`negTest`, `might`, `must`) test the
-*whole* input state and have no direct `Update` counterpart — they are
-genuine additions of the set-transformer perspective. -/
-
-section RelationalBridge
-
-variable {S : Type*}
-
-/-- Lift a relational Update meaning to a CCP (set transformer).
-
-This is the relational image: given input state `σ`, collect all
-outputs reachable from any element of `σ`. The resulting CCP is
-always distributive (`lift_isDistributive`). -/
-def lift (R : Update S) : CCP S :=
-  λ σ => { j | ∃ i ∈ σ, R i j }
-
-/-- Lower a CCP to a relational Update meaning.
-
-`lower φ i j` holds iff `j` is in the output of the singleton `{i}`.
-This is the inverse of `lift` for distributive CCPs. -/
-def lower (φ : CCP S) : Update S :=
-  λ i j => j ∈ φ {i}
-
-theorem mem_lift {R : Update S} {σ : Set S} {j : S} :
-    j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
-
-/-- Lifting preserves sequential composition:
-`lift (R₁ ⨟ R₂) = lift R₁ ;; lift R₂`. -/
-theorem lift_dseq (R₁ R₂ : Update S) :
-    lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) := by
-  funext σ; ext k; simp only [lift, CCP.seq, dseq, Relation.Comp, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hi, j, hR₁, hR₂⟩
-    exact ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩
-  · rintro ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩
-    exact ⟨i, hi, j, hR₁, hR₂⟩
-
-/-- Lifting a test produces a per-element filter:
-`lift (test C) σ = { i ∈ σ | C i }`. -/
-theorem lift_test (C : Condition S) :
-    lift (test C) = λ σ => { i ∈ σ | C i } := by
-  funext σ; ext j; simp only [lift, test, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hi, rfl, hC⟩; exact ⟨hi, hC⟩
-  · rintro ⟨hj, hC⟩; exact ⟨j, hj, rfl, hC⟩
-
-/-- Lifted CCPs are always distributive. -/
-theorem lift_isDistributive (R : Update S) : CCP.IsDistributive (lift R) := by
-  intro σ; ext j; simp only [lift, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨i, hi, hR⟩
-    refine ⟨i, hi, i, ?_, hR⟩; exact rfl
-  · rintro ⟨i, hi, i', hi', hR⟩
-    refine ⟨i, hi, ?_⟩; rwa [hi'] at hR
-
-/-- Round-trip: `lower (lift R) = R`. The relational type loses no
-information when lifted and lowered. -/
-theorem lower_lift (R : Update S) : lower (lift R) = R := by
-  funext i j; simp only [lower, lift, Set.mem_setOf_eq, eq_iff_iff]
-  constructor
-  · rintro ⟨i', hi', hR⟩; rwa [hi'] at hR
-  · intro hR; exact ⟨i, rfl, hR⟩
-
-/-- Round-trip: `lift (lower φ) = φ` for distributive CCPs.
-Distributive CCPs are exactly the relational images. -/
-theorem lift_lower (φ : CCP S) (hd : CCP.IsDistributive φ) :
-    lift (lower φ) = φ := by
-  funext σ; ext j; simp only [lift, lower, Set.mem_setOf_eq]
-  rw [hd σ]
-  simp only [Set.mem_setOf_eq]
-
-/-- `lift` is the strongest-postcondition operator `SP(A, R) = R[A]` of
-[muskens-van-benthem-visser-2011], and it reflects the pointwise order:
-update inclusion at every input state is relational inclusion — the
-SP-characterization of update-update consequence. -/
-theorem lift_le_lift_iff {R R' : Update S} : lift R ≤ lift R' ↔ R ≤ R' := by
-  constructor
-  · intro h i j hR
-    obtain ⟨i', hi', hR'⟩ := h {i} ⟨i, rfl, hR⟩
-    cases hi'
-    exact hR'
-  · rintro h σ j ⟨i, hi, hR⟩
-    exact ⟨i, hi, h i j hR⟩
-
-/-- `lift (test C)` is eliminative: it only removes elements. -/
-theorem lift_test_isEliminative (C : Condition S) :
-    CCP.IsEliminative (lift (test C)) := by
-  rw [lift_test]; intro σ j ⟨hj, _⟩; exact hj
-
-/-- The static fragment characterized: a CCP is a lifted test filter iff
-it is both eliminative and distributive — van Benthem's *additivity*
-([van-benthem-1986]; [rothschild-yalcin-2016]; [gillies-2022]). The two
-canonical dynamic systems drop exactly one conjunct each, in
-complementary directions: update semantics keeps eliminativity but its
-whole-state tests break distributivity
-(`CCP.might_not_isDistributive`), while DPL's random reassignment keeps
-distributivity but breaks eliminativity. -/
-theorem exists_eq_lift_test_iff {φ : CCP S} :
-    (∃ C : Condition S, φ = lift (test C)) ↔
-      CCP.IsEliminative φ ∧ CCP.IsDistributive φ := by
-  constructor
-  · rintro ⟨C, rfl⟩
-    exact ⟨lift_test_isEliminative C, lift_isDistributive _⟩
-  · rintro ⟨he, hd⟩
-    refine ⟨fun i => i ∈ φ {i}, ?_⟩
-    funext s
-    rw [hd s, lift_test]
-    ext p
-    exact ⟨fun ⟨i, hi, hpi⟩ => by obtain rfl : p = i := he {i} hpi; exact ⟨hi, hpi⟩,
-      fun ⟨hp, hC⟩ => ⟨p, hp, hC⟩⟩
-
-@[simp] theorem mem_lift_test {C : Condition S} {σ : Set S} {i : S} :
-    i ∈ lift (test C) σ ↔ i ∈ σ ∧ C i := by
-  rw [lift_test]; exact Iff.rfl
-
-/-- Composing test filters conjoins the conditions. -/
-theorem lift_test_lift_test (C₁ C₂ : Condition S) (σ : Set S) :
-    lift (test C₂) (lift (test C₁) σ) = lift (test fun i => C₁ i ∧ C₂ i) σ :=
-  Set.ext fun i => by
-    simp only [mem_lift_test]
-    exact and_assoc
-
-/-- Test filters are idempotent. -/
-theorem lift_test_idem (C : Condition S) (σ : Set S) :
-    lift (test C) (lift (test C) σ) = lift (test C) σ := by
-  rw [lift_test_lift_test]
-  exact Set.ext fun i => by simp only [mem_lift_test, and_self]
-
-/-- Contradictory test filters compose to the empty state. -/
-theorem lift_test_disjoint (C₁ C₂ : Condition S)
-    (h : ∀ i, C₁ i → C₂ i → False) (σ : Set S) :
-    lift (test C₂) (lift (test C₁) σ) = ∅ := by
-  rw [lift_test_lift_test]
-  exact Set.eq_empty_of_forall_notMem fun i hi =>
-    h i (mem_lift_test.mp hi).2.1 (mem_lift_test.mp hi).2.2
-
-/-- Covering test filters partition the state: if the conditions cover,
-the union of the filters is the identity. -/
-theorem lift_test_cover₃ (C₁ C₂ C₃ : Condition S)
-    (h : ∀ i, C₁ i ∨ C₂ i ∨ C₃ i) (σ : Set S) :
-    lift (test C₁) σ ∪ lift (test C₂) σ ∪ lift (test C₃) σ = σ :=
-  Set.ext fun i => by
-    simp only [Set.mem_union, mem_lift_test]
-    refine ⟨fun hi => ?_, fun hi => ?_⟩
-    · rcases hi with (⟨h', -⟩ | ⟨h', -⟩) | ⟨h', -⟩ <;> exact h'
-    · rcases h i with h' | h' | h'
-      · exact Or.inl (Or.inl ⟨hi, h'⟩)
-      · exact Or.inl (Or.inr ⟨hi, h'⟩)
-      · exact Or.inr ⟨hi, h'⟩
-
-/-- `updateFromSat` is the lifting of `test` applied to a satisfaction
-relation. This connects the CCP-native `updateFromSat` to the
-primary relational algebra. -/
-theorem updateFromSat_eq_lift_test {S φ : Type*} (sat : S → φ → Prop) (ψ : φ) :
-    updateFromSat sat ψ = lift (test (λ p => sat p ψ)) := by
-  funext σ; ext p
-  simp only [updateFromSat, lift, test, Set.mem_setOf_eq]
-  constructor
-  · rintro ⟨hp, hsat⟩; exact ⟨p, hp, rfl, hsat⟩
-  · rintro ⟨i, hi, rfl, hsat⟩; exact ⟨hi, hsat⟩
-
-end RelationalBridge
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -429,46 +429,44 @@ end RelationalBridge
 /-! ## The satisfaction layer
 
 A satisfaction relation `sat : S → φ → Prop` induces the standard eliminative
-fragment: per-formula contents, filter updates, the support relation, and
-dynamic entailment. PLA, DRT, and DPL define their updates by instantiating
+fragment, and the layer reduces to mathlib's intersection–subset API: the
+induced update intersects with content (definitionally), support is inclusion
+in content, and dynamic entailment is content inclusion
+(`dynamicEntailsOf_iff_content_subset`). PLA, DRT, and DPL instantiate
 `sat`. -/
 
 section Satisfaction
 
 variable {S φ : Type*}
 
-/-- `s` supports `ψ` when every possibility in `s` satisfies `ψ`. -/
-def supportOf (sat : S → φ → Prop) (s : Set S) (ψ : φ) : Prop :=
-  ∀ p ∈ s, sat p ψ
-
 /-- The content of a formula: all possibilities satisfying it. -/
-def contentOf (sat : S → φ → Prop) (ψ : φ) : Set S :=
-  { p | sat p ψ }
+def contentOf (sat : S → φ → Prop) (ψ : φ) : Set S := { p | sat p ψ }
 
-/-- Support is inclusion in content. -/
-theorem support_iff_subset_content (sat : S → φ → Prop) (s : Set S) (ψ : φ) :
-    supportOf sat s ψ ↔ s ⊆ contentOf sat ψ :=
-  Iff.rfl
+/-- `s` supports `ψ` when every possibility in `s` satisfies `ψ`: inclusion
+in content. -/
+def supportOf (sat : S → φ → Prop) (s : Set S) (ψ : φ) : Prop :=
+  s ⊆ contentOf sat ψ
 
 /-- Support is downward closed: smaller states support more. -/
 theorem support_mono (sat : S → φ → Prop) (s t : Set S) (ψ : φ)
     (h : t ⊆ s) (hs : supportOf sat s ψ) : supportOf sat t ψ :=
-  λ p hp => hs p (h hp)
+  h.trans hs
 
 /-- The empty state supports everything (vacuously). -/
 theorem empty_supports (sat : S → φ → Prop) (ψ : φ) :
-    supportOf sat ∅ ψ := λ _ hp => False.elim hp
+    supportOf sat ∅ ψ :=
+  Set.empty_subset _
 
 /-- Content is monotone in pointwise entailment. -/
 theorem content_mono (sat : S → φ → Prop) (ψ₁ ψ₂ : φ)
     (h : ∀ p, sat p ψ₁ → sat p ψ₂) :
     contentOf sat ψ₁ ⊆ contentOf sat ψ₂ :=
-  λ _ hp => h _ hp
+  Set.setOf_subset_setOf.mpr h
 
 /-- Filtering a set by a predicate is monotone. -/
 theorem sep_monotone (pred : S → Prop) :
     Monotone (λ s : Set S => { p ∈ s | pred p }) :=
-  λ _ _ h _ hp => ⟨h hp.1, hp.2⟩
+  λ _ _ h => Set.inter_subset_inter_left _ h
 
 /-- Filtering a set by a predicate is eliminative. -/
 theorem sep_eliminative (pred : S → Prop) :
@@ -487,12 +485,12 @@ def updateFromSat (sat : S → φ → Prop) (ψ : φ) : CCP S :=
 /-- Induced updates are eliminative. -/
 theorem updateFromSat_eliminative (sat : S → φ → Prop) (ψ : φ) :
     CCP.IsEliminative (updateFromSat sat ψ) :=
-  sep_eliminative _
+  λ _ => Set.inter_subset_left
 
 /-- `updateFromSat` is monotone in the state argument. -/
 theorem updateFromSat_monotone (sat : S → φ → Prop) (ψ : φ) :
     Monotone (updateFromSat sat ψ) :=
-  sep_monotone _
+  λ _ _ h => Set.inter_subset_inter_left _ h
 
 /-- Updating is intersecting with the content. -/
 theorem updateFromSat_eq_inter_content (sat : S → φ → Prop)
@@ -508,22 +506,26 @@ theorem updateFromSat_eq_lift_test (sat : S → φ → Prop) (ψ : φ) :
 
 /-- Induced updates are distributive. -/
 theorem updateFromSat_isDistributive (sat : S → φ → Prop) (ψ : φ) :
-    CCP.IsDistributive (updateFromSat sat ψ) := by
-  rw [updateFromSat_eq_lift_test]
-  exact lift_isDistributive _
+    CCP.IsDistributive (updateFromSat sat ψ) :=
+  updateFromSat_eq_lift_test sat ψ ▸ lift_isDistributive _
 
 /-- Support is being a fixed point of the update ([dekker-2012]'s Proper
 Support). -/
 theorem support_iff_update_eq (sat : S → φ → Prop)
     (ψ : φ) (s : Set S) :
     supportOf sat s ψ ↔ updateFromSat sat ψ s = s :=
-  ⟨λ h => Set.ext λ p => ⟨λ hp => hp.1, λ hp => ⟨hp, h p hp⟩⟩,
-   λ h p hp => by rw [← h] at hp; exact hp.2⟩
+  Set.inter_eq_left.symm
 
 /-- Dynamic entailment: updating with `ψ₁` always yields a state supporting
 `ψ₂`. -/
 def dynamicEntailsOf (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) : Prop :=
   ∀ s : Set S, supportOf sat (updateFromSat sat ψ₁ s) ψ₂
+
+/-- Dynamic entailment is content inclusion — the layer's consequence
+relation is classical entailment on contents. -/
+theorem dynamicEntailsOf_iff_content_subset (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) :
+    dynamicEntailsOf sat ψ₁ ψ₂ ↔ contentOf sat ψ₁ ⊆ contentOf sat ψ₂ :=
+  ⟨λ h _ hp => h Set.univ ⟨trivial, hp⟩, λ h _ => Set.inter_subset_right.trans h⟩
 
 /-- Dynamic entailment is acceptance consequence of the induced updates. -/
 theorem dynamicEntailsOf_iff_entails (sat : S → φ → Prop) (ψ₁ ψ₂ : φ) :
@@ -534,13 +536,13 @@ theorem dynamicEntailsOf_iff_entails (sat : S → φ → Prop) (ψ₁ ψ₂ : φ
 /-- Dynamic entailment is reflexive. -/
 theorem dynamicEntails_refl (sat : S → φ → Prop) (ψ : φ) :
     dynamicEntailsOf sat ψ ψ :=
-  λ _ _ hp => hp.2
+  λ _ => Set.inter_subset_right
 
 /-- Dynamic entailment is transitive. -/
 theorem dynamicEntails_trans (sat : S → φ → Prop) (ψ₁ ψ₂ ψ₃ : φ)
     (h1 : dynamicEntailsOf sat ψ₁ ψ₂) (h2 : dynamicEntailsOf sat ψ₂ ψ₃) :
     dynamicEntailsOf sat ψ₁ ψ₃ :=
-  fun s p hp => h2 s p ⟨hp.1, h1 s p hp⟩
+  λ s => Set.Subset.trans (h1 s) ((dynamicEntailsOf_iff_content_subset sat ψ₂ ψ₃).mp h2)
 
 end Satisfaction
 

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -9,88 +9,61 @@ import Mathlib.Tactic.Use
 /-!
 # The update algebra
 
-This file defines dynamic meanings in their two canonical forms and the bridge
-between them. A relational update (`Update S`) relates input states to output
-states pointwise — [groenendijk-stokhof-1991]'s DPL relations and
-[kamp-reyle-1993]'s verifying embeddings, parametrized over the state type
-following [muskens-1996]. A context change potential (`CCP S`) transforms
-information states — sets of states — as wholes: the file change potentials of
-[heim-1982] and [heim-1983] and the updates of [veltman-1996]. `lift` sends a
-relation to its image transformer ([muskens-van-benthem-visser-2011]'s
-strongest postcondition), `lower` recovers a relation from behaviour on
-singletons, and the image of `lift` is exactly the distributive transformers.
-`Kleisli.lean` upgrades the pair to the Kleisli and Eilenberg–Moore
-presentations of the powerset monad.
-
-Both faces carry the same algebra. Updates form a monoid under sequencing —
-indeed a quantale, since sequencing distributes over arbitrary unions — and
-tests are its subidentities (`Update.isTest_iff_le_one`), with a normal form
-at each face: a relational test is the `test` of its truth condition
-(`Update.IsTest.eq_test_closure`), a transformer test is the `guard` of its
-acceptance condition (`CCP.IsTest.eq_guard`). The two test notions are one
-concept at adjacent carriers, so `lift` does not interchange them: `lift` of
-a relational test is an eliminative filter, not a pass-or-`∅` guard. The
-static fragment is their common ground: a transformer is a lifted test filter
-iff it is eliminative and distributive (`exists_eq_lift_test_iff`).
+Dynamic meanings come in two forms: a relational update `Update S` relates
+input states to output states, and a context change potential `CCP S`
+transforms sets of states as wholes. `lift` sends an update to its image
+transformer, `lower` recovers it, and the distributive transformers are
+exactly the relational images. A satisfaction relation induces the standard
+eliminative fragment (`updateFromSat`), which PLA, DRT, and DPL instantiate.
+The monadic reading of the pair is in `Kleisli.lean`.
 
 ## Main definitions
 
-* `Update S`, `Condition S`: relations on states and properties of states.
-* `Update.test`, `Update.neg`, `Update.seq`, `Update.impl`,
-  `Update.disj`, `Update.closure`: the relational connectives; `Update S` is
-  a scoped `Monoid` and `IsQuantale`.
+* `Update S`, `Condition S`: relations on states, properties of states.
+* `Update.test`, `Update.neg`, `Update.seq`, `Update.impl`, `Update.disj`,
+  `Update.closure`: the relational connectives.
 * `Update.IsTest`: updates that never change the state.
-* `CCP S`: transformers of information states, a scoped `Monoid` under
-  `CCP.seq`, with `CCP.neg`, the whole-state tests `CCP.guard`, `might`,
-  `must`, `negTest`, and acceptance consequence `CCP.entails`.
-* `CCP.IsEliminative`, `CCP.IsTest`, `CCP.IsDistributive`: the classification
-  of transformers.
-* `lift`, `lower`: the bridge between the two faces.
+* `CCP.guard`, `CCP.might`, `CCP.must`, `CCP.negTest`: whole-state tests.
+* `CCP.IsEliminative`, `CCP.IsTest`, `CCP.IsDistributive`: the
+  classification of transformers.
+* `lift`, `lower`: the bridge between the two forms.
 * `supportOf`, `contentOf`, `updateFromSat`, `dynamicEntailsOf`: the layer a
-  satisfaction relation induces; PLA, DRT, and DPL instantiate it.
+  satisfaction relation induces.
 
 ## Main results
 
-* `Update.isTest_iff_le_one`, `Update.IsTest.eq_test_closure`
-  ([groenendijk-stokhof-1991]'s Fact 6), `CCP.IsTest.eq_guard`: tests are the
-  subidentities, with a normal form at each face.
-* `lower_lift`, `lift_lower`, `lift_isDistributive`: the distributive
-  transformers are exactly the relational images.
-* `lift_le_lift_iff`: `lift` reflects the pointwise order.
+* `Update S` is a `Monoid` and an `IsQuantale` under sequencing (scoped);
+  tests are its subidentities (`Update.isTest_iff_le_one`).
+* `Update.IsTest.eq_test_closure`, `CCP.IsTest.eq_guard`: a test is the test
+  of its truth condition, a guard of its acceptance condition.
+* `lower_lift`, `lift_lower`: `lift` and `lower` are mutually inverse on
+  distributive transformers.
 * `exists_eq_lift_test_iff`: a transformer is a lifted test filter iff it is
-  eliminative and distributive — [van-benthem-1986]'s additivity, per
-  [rothschild-yalcin-2016] and [gillies-2022]. `CCP.might_not_isDistributive`
-  witnesses that whole-state tests lie outside this fragment.
-* `support_iff_update_eq`, `dynamicEntailsOf_iff_entails`: support is being a
-  fixed point of the update, and the satisfaction layer's consequence is
-  acceptance consequence.
+  eliminative and distributive; `CCP.might_not_isDistributive` separates.
+* `support_iff_update_eq`: support is being a fixed point of the update.
 
 ## Implementation notes
 
 The algebraic instances are scoped: `Update S` and `CCP S` abbreviate
-function types, so global instances would attach `*` and `1` to bare function
-types for every importer. `open scoped DynamicSemantics.Update` also makes mathlib's
-`WriterT (Update S) Id` a lawful monad.
-
-`Update.neg` does not validate double-negation elimination: negation collapses
-update information to a state predicate. The repairs are framework-specific —
-bilateral swap (`UpdateSemantics/Bilateral.lean`), propositional discourse
-referents (`Studies/Hofmann2025.lean`), classical metalanguage
-(`Studies/Cooper2023/`). Similarly `CCP.negTest` is not `CCP.neg`: the two
-coincide only on fixed or crashed inputs (`Studies/Beaver2001/ABLE.lean`).
-
-`updateFromSat` is kept as the literal filter rather than defined as
-`lift (test _)` (see `updateFromSat_eq_lift_test`) so that instantiating
-frameworks connect to it by `rfl`. [groenendijk-stokhof-1991]'s entailment
-notions and Facts 10–12 live with their paper in
+function types. `updateFromSat` is the literal filter rather than
+`lift (test _)` so that instantiating frameworks connect to it by `rfl`.
+`Update.neg` does not validate double-negation elimination and `CCP.negTest`
+is not `CCP.neg`; the framework-specific repairs and comparisons live in the
+studies. [groenendijk-stokhof-1991]'s entailment notions live in
 `Studies/GroenendijkStokhof1991.lean`.
 
 ## References
 
-* [groenendijk-stokhof-1991], [kamp-reyle-1993], [muskens-1996]
-* [heim-1982], [heim-1983], [veltman-1996]
-* [muskens-van-benthem-visser-2011]
-* [van-benthem-1986], [rothschild-yalcin-2016], [gillies-2022]
+* [J. Groenendijk and M. Stokhof, *Dynamic Predicate Logic*][groenendijk-stokhof-1991]
+* [H. Kamp and U. Reyle, *From Discourse to Logic*][kamp-reyle-1993]
+* [R. Muskens, *Combining Montague Semantics and Discourse Representation*][muskens-1996]
+* [I. Heim, *The Semantics of Definite and Indefinite Noun Phrases*][heim-1982]
+* [I. Heim, *On the Projection Problem for Presuppositions*][heim-1983]
+* [F. Veltman, *Defaults in Update Semantics*][veltman-1996]
+* [R. Muskens, J. van Benthem, and A. Visser, *Dynamics*][muskens-van-benthem-visser-2011]
+* [J. van Benthem, *Essays in Logical Semantics*][van-benthem-1986]
+* [D. Rothschild and S. Yalcin, *Three Notions of Dynamicness in Language*][rothschild-yalcin-2016]
+* [A. Gillies, *On Groenendijk and Stokhof's "Dynamic Predicate Logic"*][gillies-2022]
 -/
 
 namespace DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Update.lean
+++ b/Linglib/Semantics/Dynamic/Update.lean
@@ -333,43 +333,31 @@ theorem mem_lift : j ∈ lift R σ ↔ ∃ i ∈ σ, R i j := Iff.rfl
 /-- `lift` sends sequencing to composition. -/
 theorem lift_dseq (R₁ R₂ : Update S) :
     lift (dseq R₁ R₂) = CCP.seq (lift R₁) (lift R₂) :=
-  funext λ _ => Set.ext λ _ =>
-    ⟨λ ⟨i, hi, j, hR₁, hR₂⟩ => ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩,
-     λ ⟨j, ⟨i, hi, hR₁⟩, hR₂⟩ => ⟨i, hi, j, hR₁, hR₂⟩⟩
+  funext λ _ => Set.ext λ _ => ⟨λ ⟨i, m, j, a, b⟩ => ⟨j, ⟨i, m, a⟩, b⟩,
+    λ ⟨j, ⟨i, m, a⟩, b⟩ => ⟨i, m, j, a, b⟩⟩
 
 /-- `lift (test C)` is the filter by `C`. -/
 theorem lift_test (C : Condition S) :
     lift (test C) = λ σ => { i ∈ σ | C i } :=
-  funext λ _ => Set.ext λ j =>
-    ⟨λ ⟨_, hi, hij, hC⟩ => ⟨hij ▸ hi, hC⟩, λ ⟨hj, hC⟩ => ⟨j, hj, rfl, hC⟩⟩
+  funext λ _ => Set.ext λ j => ⟨λ ⟨_, m, e, c⟩ => ⟨e ▸ m, c⟩, λ ⟨m, c⟩ => ⟨j, m, rfl, c⟩⟩
 
 /-- Lifted transformers are distributive. -/
 theorem lift_isDistributive (R : Update S) : CCP.IsDistributive (lift R) :=
-  λ _ => Set.ext λ _ =>
-    ⟨λ ⟨i, hi, hR⟩ => ⟨i, hi, i, rfl, hR⟩,
-     λ ⟨i, hi, _, hi', hR⟩ => ⟨i, hi, hi' ▸ hR⟩⟩
+  λ _ => Set.ext λ _ => ⟨λ ⟨i, m, r⟩ => ⟨i, m, i, rfl, r⟩, λ ⟨i, m, _, e, r⟩ => ⟨i, m, e ▸ r⟩⟩
 
 /-- `lower` is a left inverse of `lift`: the relational face loses nothing. -/
 theorem lower_lift (R : Update S) : lower (lift R) = R :=
-  funext₂ λ i _ => propext
-    ⟨λ ⟨_, hi', hR⟩ => hi' ▸ hR, λ hR => ⟨i, rfl, hR⟩⟩
+  funext₂ λ i _ => propext ⟨λ ⟨_, e, r⟩ => e ▸ r, λ r => ⟨i, rfl, r⟩⟩
 
 /-- `lift` is a right inverse of `lower` on distributive transformers. -/
 theorem lift_lower (φ : CCP S) (hd : CCP.IsDistributive φ) :
-    lift (lower φ) = φ := by
-  funext σ; ext j; simp only [lift, lower, Set.mem_setOf_eq]
-  rw [hd σ]
-  simp only [Set.mem_setOf_eq]
+    lift (lower φ) = φ :=
+  funext λ σ => (hd σ).symm
 
 /-- `lift` reflects (and preserves) the pointwise order. -/
-theorem lift_le_lift_iff : lift R ≤ lift R' ↔ R ≤ R' := by
-  constructor
-  · intro h i j hR
-    obtain ⟨i', hi', hR'⟩ := h {i} ⟨i, rfl, hR⟩
-    cases hi'
-    exact hR'
-  · rintro h σ j ⟨i, hi, hR⟩
-    exact ⟨i, hi, h i j hR⟩
+theorem lift_le_lift_iff : lift R ≤ lift R' ↔ R ≤ R' :=
+  ⟨λ h i _ r => match h {i} ⟨i, rfl, r⟩ with | ⟨_, e, r'⟩ => e ▸ r',
+   λ h _ j ⟨i, m, r⟩ => ⟨i, m, h i j r⟩⟩
 
 /-! ### Test filters -/
 

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -352,11 +352,11 @@ theorem atom_negative_monotone (pred : W → Prop) :
   sep_monotone _
 
 theorem atom_positive_eliminative (pred : W → Prop) :
-    IsEliminative (atom pred (V := V) (E := E)).positive :=
+    CCP.IsEliminative (atom pred (V := V) (E := E)).positive :=
   sep_eliminative _
 
 theorem atom_negative_eliminative (pred : W → Prop) :
-    IsEliminative (atom pred (V := V) (E := E)).negative :=
+    CCP.IsEliminative (atom pred (V := V) (E := E)).negative :=
   sep_eliminative _
 
 theorem pred1_positive_monotone (P : E → W → Prop) (t : V) :
@@ -368,19 +368,19 @@ theorem pred1_negative_monotone (P : E → W → Prop) (t : V) :
   sep_monotone _
 
 theorem pred1_positive_eliminative (P : E → W → Prop) (t : V) :
-    IsEliminative (pred1 P t (W := W)).positive :=
+    CCP.IsEliminative (pred1 P t (W := W)).positive :=
   sep_eliminative _
 
 theorem pred1_negative_eliminative (P : E → W → Prop) (t : V) :
-    IsEliminative (pred1 P t (W := W)).negative :=
+    CCP.IsEliminative (pred1 P t (W := W)).negative :=
   sep_eliminative _
 
 theorem pred2_positive_eliminative (P : E → E → W → Prop) (t₁ t₂ : V) :
-    IsEliminative (pred2 P t₁ t₂ (W := W)).positive :=
+    CCP.IsEliminative (pred2 P t₁ t₂ (W := W)).positive :=
   sep_eliminative _
 
 theorem pred2_negative_eliminative (P : E → E → W → Prop) (t₁ t₂ : V) :
-    IsEliminative (pred2 P t₁ t₂ (W := W)).negative :=
+    CCP.IsEliminative (pred2 P t₁ t₂ (W := W)).negative :=
   sep_eliminative _
 
 /-! ### The bilateral algebra -/

--- a/Linglib/Semantics/Genericity/Dynamic.lean
+++ b/Linglib/Semantics/Genericity/Dynamic.lean
@@ -303,7 +303,7 @@ But it fails the third axiom:
    `horizonStep g h₁ ⊄ horizonStep g h₂`
 
 This is structurally interesting: eliminative updates (assertion, test) ARE
-monotone (`updateFromSat_monotone` in `Core/CCP.lean`), so they form closure
+monotone (`DynamicSemantics.updateFromSat_monotone`), so they form closure
 operators on the dual lattice. Expansive generic updates fail monotonicity
 precisely because a LARGER input can BLOCK expansion that a smaller input
 would trigger — a phenomenon impossible in eliminative semantics. -/
@@ -356,7 +356,7 @@ omit [DecidableEq E] in
     horizonStep g []` but `false ∉ horizonStep g [true]`.
 
     This contrasts with eliminative updates, which ARE monotone
-    (`updateFromSat_monotone` in `Core/CCP.lean`): for eliminative
+    (`DynamicSemantics.updateFromSat_monotone`): for eliminative
     semantics, `s ⊆ t → u(s) ⊆ u(t)`. The failure of monotonicity
     for expansive updates is what prevents `horizonStep` from being
     a closure operator (`Order.ClosureOperator` in Mathlib), despite

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -55,6 +55,7 @@ namespace Mood
 open Intensional (WorldTimeIndex)
 open HistoricalAlternatives DynamicSemantics
 open DynamicSemantics.CCP (IsEliminative)
+open DynamicSemantics.Update (test closure)
 
 variable {W Time : Type*}
 

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -54,6 +54,7 @@ namespace Mood
 
 open Intensional (WorldTimeIndex)
 open HistoricalAlternatives DynamicSemantics
+open DynamicSemantics.CCP (IsEliminative)
 
 variable {W Time : Type*}
 

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -26,7 +26,7 @@ world coordinate is the current evaluation index, drefs are indices.
   intersection with the satisfaction set — is the prototype "static
   condition lifts to context filter"; [veltman-1996] formalizes it as
   the *test*, and [groenendijk-stokhof-veltman-1996] generalize to
-  eliminative updates (`IsEliminative`).
+  eliminative updates (`CCP.IsEliminative`).
 - [de-groote-2006] recovers static readings from dynamic ones by the
   trivial continuation; [charlow-2021] recasts the lift monadically.
   The `dynPAST = lift (test (precedes · ·))` factoring below is the

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -50,6 +50,7 @@ namespace Tense
 
 open _root_.Intensional (WorldTimeIndex)
 open DynamicSemantics
+open DynamicSemantics.Update (test closure)
 
 variable {W Time : Type*}
 

--- a/Linglib/Studies/Beaver2001/ABLE.lean
+++ b/Linglib/Studies/Beaver2001/ABLE.lean
@@ -49,14 +49,14 @@ since we don't model discourse markers.
 - **Lemma 8.6**: Satisfaction ↔ inconsistency with NOT (eliminativity bridge)
 - **Fact 8.7**: MUST is a test for satisfaction
 - **Facts 8.5, 8.8**: MIGHT and MUST are tests; presupposition projects through them
-- **D45/MP5**: Entailment — equivalent to `CCP.entails` (eliminativity makes guard redundant)
+- **D45/MP5**: Entailment — the spine's `CCP.entails`, by definition
 -/
 
 namespace Beaver2001.ABLE
 
 open Classical
-open DynamicSemantics (CCP IsEliminative IsTest
-  updateFromSat eliminative_seq test_eliminative)
+open DynamicSemantics (CCP updateFromSat)
+open DynamicSemantics.CCP (IsEliminative IsTest)
 
 variable {P : Type*}
 
@@ -148,7 +148,7 @@ theorem presup_isTest (φ : Formula P) : IsTest φ.presup.eval := by
 
 /-- ∂ is eliminative. -/
 theorem presup_eliminative (φ : Formula P) : IsEliminative φ.presup.eval := by
-  exact test_eliminative _ (presup_isTest φ)
+  exact (presup_isTest φ).isEliminative
 
 /-- Admittance of ∂φ is equivalent to σ[φ] = σ. -/
 theorem presup_admits_iff (φ : Formula P) (σ : Set P) :
@@ -199,7 +199,7 @@ theorem might_isTest (φ : Formula P) : IsTest (Formula.might φ).eval := by
 
 /-- MIGHT is eliminative. -/
 theorem might_eliminative (φ : Formula P) : IsEliminative (Formula.might φ).eval :=
-  test_eliminative _ (might_isTest φ)
+  (might_isTest φ).isEliminative
 
 /-- **Fact 8.8 (1)**: Presupposition projects through MIGHT.
 
@@ -286,7 +286,7 @@ theorem not_eliminative (φ : Formula P) :
 theorem and_eliminative (φ ψ : Formula P)
     (hφ : IsEliminative φ.eval) (hψ : IsEliminative ψ.eval) :
     IsEliminative (Formula.and φ ψ).eval :=
-  eliminative_seq φ.eval ψ.eval hφ hψ
+  hφ.seq hψ
 
 /-- All ABLE formulas are eliminative (output ⊆ input).
 This is the inductive closure of the per-constructor eliminativity
@@ -345,7 +345,7 @@ theorem must_isTest (φ : Formula P) : IsTest (Formula.must φ).eval := by
 
 /-- MUST is eliminative. -/
 theorem must_eliminative (φ : Formula P) : IsEliminative (Formula.must φ).eval :=
-  test_eliminative _ (must_isTest φ)
+  (must_isTest φ).isEliminative
 
 /-- **Fact 8.7 (2–3)**: MUST φ is a test for satisfaction of φ.
 
@@ -450,30 +450,16 @@ theorem eval_empty (φ : Formula P) : φ.eval ∅ = ∅ :=
   Set.subset_empty_iff.mp (eval_eliminative φ ∅)
 
 /-- **Entailment in ABLE (D45)**: φ entails ψ iff every state resulting
-from updating with φ satisfies ψ.
+from updating with φ satisfies ψ — the spine's acceptance-based
+`CCP.entails`.
 
 [beaver-2001] Ch. 7 §7.2, Meaning Postulate MP5:
 `entails = λF λF' [∀I∀J, I{F}J → J satisfies F']`
 
-In our set-based formulation (without discourse markers), this reduces
+In the set-based formulation (without discourse markers), this reduces
 to: for all σ, ψ.eval(φ.eval σ) = φ.eval σ. -/
 noncomputable def entails (φ ψ : Formula P) : Prop :=
-  ∀ σ : Set P, ψ.eval (φ.eval σ) = φ.eval σ
-
-/-- **ABLE entailment ↔ CCP entailment**.
-
-The nonemptiness guard in `CCP.entails` is redundant for ABLE formulas
-because all ABLE formulas are eliminative: ψ.eval ∅ = ∅.
-[beaver-2001] D45 = `CCP.entails` modulo this vacuous case. -/
-theorem entails_iff_ccp_entails (φ ψ : Formula P) :
-    φ.entails ψ ↔ CCP.entails φ.eval ψ.eval := by
-  constructor
-  · intro h s _; exact h s
-  · intro h s
-    by_cases hne : (φ.eval s).Nonempty
-    · exact h s hne
-    · simp only [Set.not_nonempty_iff_eq_empty] at hne
-      rw [hne, eval_empty]
+  CCP.entails φ.eval ψ.eval
 
 /-- ABLE entailment is transitive. -/
 theorem entails_trans (φ ψ χ : Formula P)

--- a/Linglib/Studies/Beaver2001/ABLE.lean
+++ b/Linglib/Studies/Beaver2001/ABLE.lean
@@ -224,11 +224,19 @@ theorem eval_and_eq_seq (φ ψ : Formula P) :
 
 /-- ABLE MIGHT = CCP.might. -/
 theorem eval_might_eq_ccpMight (φ : Formula P) :
-    (Formula.might φ).eval = CCP.might φ.eval := rfl
+    (Formula.might φ).eval = CCP.might φ.eval := by
+  funext σ
+  by_cases h : (φ.eval σ).Nonempty
+  · rw [CCP.might, CCP.guard_pos (C := λ s => (φ.eval s).Nonempty) h]; simp only [eval, if_pos h]
+  · rw [CCP.might, CCP.guard_neg (C := λ s => (φ.eval s).Nonempty) h]; simp only [eval, if_neg h]
 
 /-- ABLE ∂ = CCP.must. -/
 theorem eval_presup_eq_ccpMust (φ : Formula P) :
-    (Formula.presup φ).eval = CCP.must φ.eval := rfl
+    (Formula.presup φ).eval = CCP.must φ.eval := by
+  funext σ
+  by_cases h : φ.eval σ = σ
+  · rw [CCP.must, CCP.guard_pos (C := λ s => φ.eval s = s) h]; simp only [eval, if_pos h]
+  · rw [CCP.must, CCP.guard_neg (C := λ s => φ.eval s = s) h]; simp only [eval, if_neg h]
 
 /-- ABLE pred = updateFromSat (via identity).
 
@@ -262,10 +270,10 @@ theorem not_neq_ccpNegTest :
     refine Set.mem_diff_of_mem (Or.inr rfl) ?_
     intro ⟨_, hf⟩; exact Bool.noConfusion hf
   rw [h] at this
-  simp only [eval, CCP.negTest, CCP.guard] at this
-  have hne : ({ p : Bool | p ∈ ({true, false} : Set Bool) ∧ p = true}).Nonempty :=
+  have hne : ((Formula.pred (· = true)).eval ({true, false} : Set Bool)).Nonempty :=
     ⟨true, Or.inl rfl, rfl⟩
-  simp only [hne, not_true, ↓reduceIte] at this
+  rw [CCP.negTest, CCP.guard_neg (C := λ s => ¬((Formula.pred (· = true)).eval s).Nonempty)
+    (not_not_intro hne)] at this
   exact this
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Charlow2014.lean
+++ b/Linglib/Studies/Charlow2014.lean
@@ -163,9 +163,8 @@ def dpl : AnaphoraFramework farmer donkey owns beats where
 /-! ### CDRT (Muskens 1996)
 
 Donkey encoding: `cdrt_full_donkey` (`Cooper2023.lean §4`):
-`DProp.impl (DProp.new 0 ;; ofStatic (farmer ∘ ·0) ;;
-              DProp.new 1 ;; ofStatic (donkey ∘ ·1 ∧ owns ·0 ·1))
-            (ofStatic (beats ·0 ·1))`.
+`DProp.impl (DProp.new 0 * ofStatic (farmer ∘ ·0) * DProp.new 1 *
+              ofStatic (donkey ∘ ·1 ∧ owns ·0 ·1)) (ofStatic (beats ·0 ·1))`.
 Truth equivalence: `full_donkey_equiv` (Cooper2023 §4) + Π-type
 classical reduction.
 Negation: `DProp.neg φ := test (Update.neg φ)` — a test. Output

--- a/Linglib/Studies/Charlow2014.lean
+++ b/Linglib/Studies/Charlow2014.lean
@@ -168,7 +168,7 @@ Donkey encoding: `cdrt_full_donkey` (`Cooper2023.lean §4`):
             (ofStatic (beats ·0 ·1))`.
 Truth equivalence: `full_donkey_equiv` (Cooper2023 §4) + Π-type
 classical reduction.
-Negation: `DProp.neg φ := test (dneg φ)` — a test. Output
+Negation: `DProp.neg φ := test (Update.neg φ)` — a test. Output
 register equals input; drefs from inside negation are dropped
 (`neg_destroys_dref`, `dne_same_truth` in Cooper2023 §5). -/
 def cdrt : AnaphoraFramework farmer donkey owns beats where

--- a/Linglib/Studies/Charlow2019.lean
+++ b/Linglib/Studies/Charlow2019.lean
@@ -18,6 +18,7 @@ namespace Charlow2019
 
 open DPL
 open DynamicSemantics
+open DynamicSemantics.CCP (IsDistributive)
 open DynamicSemantics.ICDRT
 open _root_.Core (Assignment)
 

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -68,6 +68,7 @@ Appendix B as a Writer monad.
 namespace Charlow2021
 
 open DynamicSemantics
+open DynamicSemantics.CCP (IsDistributive)
 open Semantics.Composition.Continuation
 open scoped DynamicSemantics
 
@@ -589,7 +590,7 @@ every state-level CCP is distributive. Witness: the constant CCP
 yields `∅`. -/
 theorem dependent_indefinites_need_extra {W E : Type*} [Nonempty W] [Nonempty E] :
     ¬ ∀ (depIndef : State.CCP W E),
-      DynamicSemantics.IsDistributive depIndef := by
+      DynamicSemantics.CCP.IsDistributive depIndef := by
   intro h
   have h0 := h (fun _ => Set.univ) ∅
   simp only [Set.mem_empty_iff_false, false_and, exists_false, Set.setOf_false] at h0

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -68,9 +68,10 @@ Appendix B as a Writer monad.
 namespace Charlow2021
 
 open DynamicSemantics
+open DynamicSemantics.Update (test seq closure neg)
 open DynamicSemantics.CCP (IsDistributive)
 open Semantics.Composition.Continuation
-open scoped DynamicSemantics
+open scoped DynamicSemantics.Update
 
 /-! ### Witness models: the cumulative-reading puzzle
 
@@ -184,15 +185,15 @@ def sawDRS (u v : R) (rel : E → E → Prop) : Update S :=
 `E^v P ; M_v(E^v P) ; n_v` (the flat counterpart of the scope-taking
 dynamic-GQ entry, eq. 3). -/
 def exactlyN_pw (v : R) (P : E → Prop) (n : ℕ) : Update S :=
-  dseq (dseq (Evar v P) (Mvar v (Evar v P))) (CardTest v n)
+  seq (seq (Evar v P) (Mvar v (Evar v P))) (CardTest v n)
 
 /-- The pseudo-cumulative LF (5): the object's cardinality test is trapped
 inside the subject's maximization. -/
 def pseudoCumulative (v u : R) (boys movies : E → Prop)
     (saw' : E → E → Prop) : Update S :=
-  dseq
-    (Mvar v (dseq
-      (dseq (Evar v boys) (Mvar u (dseq (Evar u movies) (sawDRS u v saw'))))
+  seq
+    (Mvar v (seq
+      (seq (Evar v boys) (Mvar u (seq (Evar u movies) (sawDRS u v saw'))))
       (CardTest u 5)))
     (CardTest v 3)
 
@@ -200,8 +201,8 @@ def pseudoCumulative (v u : R) (boys movies : E → Prop)
 maximizations. -/
 def cumulative (v u : R) (boys movies : E → Prop)
     (saw' : E → E → Prop) : Update S :=
-  dseq (dseq
-    (Mvar v (dseq (Evar v boys) (Mvar u (dseq (Evar u movies) (sawDRS u v saw')))))
+  seq (seq
+    (Mvar v (seq (Evar v boys) (Mvar u (seq (Evar u movies) (sawDRS u v saw')))))
     (CardTest u 5))
     (CardTest v 3)
 
@@ -230,7 +231,7 @@ abbrev TowerGQ (S : Type*) := Cont (Update S) (Update S → Update S)
 `Update S → Update S`. The cardinality test is evaluated after the
 higher-order scope argument `c` — the key that unlocks cumulative readings. -/
 def exactlyN_tower (v : R) (P : E → Prop) (n : ℕ) : TowerGQ S :=
-  λ k => dseq (k (λ body => Mvar v (dseq (Evar v P) body))) (CardTest v n)
+  λ k => seq (k (λ body => Mvar v (seq (Evar v P) body))) (CardTest v n)
 
 /-- Higher-order derivation of "exactly 3 boys saw exactly 5 movies"
 (eq. 27, derived in §3.3 by β-reduction of the linearized terms; §3.4's
@@ -304,7 +305,7 @@ compositional packaging: a bi-dimensional meaning pairs an at-issue value
 with post-suppositional content — an `Update` accumulated via dynamic
 conjunction and discharged at the discourse level after scope-taking
 (§5.1) — implemented in Appendix B as a Writer monad over the monoid
-`(Update S, dseq, test ⊤)`. -/
+`(Update S, seq, test ⊤)`. -/
 
 section PostSuppositional
 
@@ -315,7 +316,7 @@ post-suppositional content — mathlib's Writer monad `WriterT (Update S) Id`
 over the monoid `(Update S, ⨟, test ⊤)`. The `Monad`/`LawfulMonad` instances
 come from mathlib via the scoped `Monoid (Update S)` instance, and agree with
 the paper's `pure`/`bind` (Appendix B, eqs. 120–121): `pure` carries the
-trivial post-supposition; `bind` accumulates post-suppositions via `dseq`. -/
+trivial post-supposition; `bind` accumulates post-suppositions via `seq`. -/
 abbrev PostSupp (S A : Type u) : Type u := WriterT (Update S) Id A
 
 namespace PostSupp
@@ -346,11 +347,11 @@ def postsup (p : PostSupp S A) : Update S := p.run.2
     (m >>= f).val = (f m.val).val := rfl
 
 @[simp] theorem postsup_bind (m : PostSupp S A) (f : A → PostSupp S B) :
-    (m >>= f).postsup = dseq m.postsup (f m.val).postsup := rfl
+    (m >>= f).postsup = seq m.postsup (f m.val).postsup := rfl
 
 /-- Reification (the bullet operator, eq. 58): sequence the at-issue update
 with its accumulated post-supposition. -/
-def reify (p : PostSupp S (Update S)) : Update S := dseq p.val p.postsup
+def reify (p : PostSupp S (Update S)) : Update S := seq p.val p.postsup
 
 @[simp] theorem reify_pure (D : Update S) :
     (pure D : PostSupp S (Update S)).reify = D :=
@@ -359,7 +360,7 @@ def reify (p : PostSupp S (Update S)) : Update S := dseq p.val p.postsup
 /-- Truth of a bi-dimensional meaning at an assignment (eq. 56): the reified
 update is true at `i` in the substrate sense. -/
 def trueAt (p : PostSupp S (Update S)) (i : S) : Prop :=
-  DynamicSemantics.closure p.reify i
+  DynamicSemantics.Update.closure p.reify i
 
 end PostSupp
 
@@ -374,12 +375,12 @@ def exactlyN_postsup (v : R) (P : E → Prop) (n : ℕ) :
 /-- Bi-dimensional derivation of "exactly 3 boys saw exactly 5 movies":
 nested maximizations at issue; both cardinality tests accumulate
 post-suppositionally (under `bind`, tests from different quantifiers simply
-`dseq`-accumulate, independent of scope). -/
+`seq`-accumulate, independent of scope). -/
 def cumulativePostsup (v u : R) (boys movies : E → Prop)
     (saw' : E → E → Prop) : PostSupp S (Update S) :=
   PostSupp.mk
-    (Mvar v (dseq (Evar v boys) (Mvar u (dseq (Evar u movies) (sawDRS u v saw')))))
-    (dseq (CardTest u 5) (CardTest v 3))
+    (Mvar v (seq (Evar v boys) (Mvar u (seq (Evar u movies) (sawDRS u v saw')))))
+    (seq (CardTest u 5) (CardTest v 3))
 
 /-- Reifying the bi-dimensional derivation recovers exactly the cumulative
 LF (6): deferring cardinality tests as post-suppositions yields the

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -313,7 +313,7 @@ universe u
 
 /-- Bi-dimensional meaning (§5.1): an at-issue value paired with accumulated
 post-suppositional content — mathlib's Writer monad `WriterT (Update S) Id`
-over the monoid `(Update S, ⨟, test ⊤)`. The `Monad`/`LawfulMonad` instances
+over the monoid `(Update S, Update.seq, test ⊤)`. The `Monad`/`LawfulMonad` instances
 come from mathlib via the scoped `Monoid (Update S)` instance, and agree with
 the paper's `pure`/`bind` (Appendix B, eqs. 120–121): `pure` carries the
 trivial post-supposition; `bind` accumulates post-suppositions via `seq`. -/

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -354,7 +354,7 @@ def reify (p : PostSupp S (Update S)) : Update S := dseq p.val p.postsup
 
 @[simp] theorem reify_pure (D : Update S) :
     (pure D : PostSupp S (Update S)).reify = D :=
-  dseq_test D _ (λ _ => trivial)
+  mul_one D
 
 /-- Truth of a bi-dimensional meaning at an assignment (eq. 56): the reified
 update is true at `i` in the substrate sense. -/
@@ -388,7 +388,7 @@ theorem reify_cumulativePostsup (v u : R) (boys movies : E → Prop)
     (saw' : E → E → Prop) :
     (cumulativePostsup (S := S) v u boys movies saw').reify =
       cumulative v u boys movies saw' :=
-  (dseq_assoc _ _ _).symm
+  (mul_assoc _ _ _).symm
 
 end PostSuppositional
 

--- a/Linglib/Studies/Charlow2025.lean
+++ b/Linglib/Studies/Charlow2025.lean
@@ -196,7 +196,7 @@ inductive NegFree {Atom : Type v} : DynForm Atom → Prop where
 
 /-- A formula is **double-negation-free** if no subformula has the shape
 `¬¬ψ`. The constructors enumerate the allowed `¬`-prefixed shapes (atom,
-exi, conj of dneg-frees), excluding `.neg (.neg ψ)`. -/
+exi, conj of neg-frees), excluding `.neg (.neg ψ)`. -/
 inductive DNegFree {Atom : Type v} : DynForm Atom → Prop where
   | atom (a : Atom) : DNegFree (.atom a)
   | exi (n : Nat) : DNegFree (.exi n)

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -180,6 +180,7 @@ to the same classical truth conditions.
 
 open CDRT (DProp State SProp)
 open DynamicSemantics.Update (closure seq test neg impl)
+open scoped DynamicSemantics.Update
 open Semantics.TypeTheoretic (Ppty PPpty Parametric IsTrue IsFalse propT)
 open Cooper2023Ch7 (purify purifyUniv)
 
@@ -187,7 +188,7 @@ variable {E : Type}
 
 /-- CDRT existential: introduce dref n, test P on r(n). -/
 def cdrt_exists (n : Nat) (P : E → Prop) : DProp E :=
-  DProp.new n ;; DProp.ofStatic (λ r => P (r n))
+  DProp.new n * DProp.ofStatic (λ r => P (r n))
 
 /-- TTR existential: Σ-type with entity witness. This is `purify` applied
 to a parametric property with background `E`; the result doesn't depend
@@ -215,7 +216,7 @@ theorem exists_classical (P : E → Prop) :
 extending the register with a P-entity at n, Q holds of that entity." -/
 def cdrt_donkey (n : Nat) (P Q : E → Prop) : DProp E :=
   DProp.impl
-    (DProp.new n ;; DProp.ofStatic (λ r => P (r n)))
+    (DProp.new n * DProp.ofStatic (λ r => P (r n)))
     (DProp.ofStatic (λ r => Q (r n)))
 
 /-- TTR donkey: Π-type over witnesses. "For every P-witness, Q holds."
@@ -255,8 +256,8 @@ theorem donkey_classical (P Q : E → Prop) :
 def cdrt_full_donkey (farmer donkey_ : E → Prop) (owns beats : E → E → Prop) :
     DProp E :=
   DProp.impl
-    (DProp.new 0 ;; DProp.ofStatic (λ r => farmer (r 0)) ;;
-     DProp.new 1 ;; DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1)))
+    (DProp.new 0 * DProp.ofStatic (λ r => farmer (r 0)) *
+     DProp.new 1 * DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1)))
     (DProp.ofStatic (λ r => beats (r 0) (r 1)))
 
 def ttr_full_donkey (farmer donkey_ : E → Prop) (owns beats : E → E → Prop) :
@@ -265,10 +266,12 @@ def ttr_full_donkey (farmer donkey_ : E → Prop) (owns beats : E → E → Prop
 
 private theorem donkey_antecedent_iff
     (farmer donkey_ : E → Prop) (owns : E → E → Prop) (i k : State E) :
-    (DProp.new 0 ;; DProp.ofStatic (λ r => farmer (r 0)) ;;
-     DProp.new 1 ;; DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1))) i k ↔
+    (DProp.new 0 * DProp.ofStatic (λ r => farmer (r 0)) *
+     DProp.new 1 * DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1))
+       : DProp E) i k ↔
     ∃ x y, k = (λ m => if m = 1 then y else if m = 0 then x else i m) ∧
       farmer x ∧ donkey_ y ∧ owns x y := by
+  show DProp.seq (DProp.seq (DProp.seq _ _) _) _ i k ↔ _
   simp only [DProp.seq, seq, Relation.Comp, DProp.new, DProp.ofStatic, test]
   constructor
   · rintro ⟨k₃, ⟨k₂, ⟨k₁, ⟨e₀, rfl⟩, rfl, hf⟩, ⟨e₁, rfl⟩⟩, rfl, hd, ho⟩

--- a/Linglib/Studies/Cooper2023/Basic.lean
+++ b/Linglib/Studies/Cooper2023/Basic.lean
@@ -179,7 +179,7 @@ to the same classical truth conditions.
 -/
 
 open CDRT (DProp State SProp)
-open DynamicSemantics (closure dseq test dneg dimpl)
+open DynamicSemantics.Update (closure seq test neg impl)
 open Semantics.TypeTheoretic (Ppty PPpty Parametric IsTrue IsFalse propT)
 open Cooper2023Ch7 (purify purifyUniv)
 
@@ -198,7 +198,7 @@ def ttr_exists (P : E → Prop) : Type := (x : E) × propT (P x)
 the same truth conditions. Both reduce to `∃ x, P x`. -/
 theorem exists_equiv (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (cdrt_exists n P) i ↔ Nonempty (ttr_exists P) := by
-  simp only [DProp.true_at, DynamicSemantics.closure, cdrt_exists, DProp.seq, dseq, Relation.Comp, DProp.new,
+  simp only [DProp.true_at, DynamicSemantics.Update.closure, cdrt_exists, DProp.seq, seq, Relation.Comp, DProp.new,
     DProp.ofStatic, test, ttr_exists]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, rfl, hp⟩
@@ -228,7 +228,7 @@ def ttr_donkey (P Q : E → Prop) : Type :=
 the same truth conditions. Both reduce to `∀ x, P x → Q x`. -/
 theorem donkey_equiv (n : Nat) (P Q : E → Prop) (i : State E) :
     DProp.true_at (cdrt_donkey n P Q) i ↔ Nonempty (ttr_donkey P Q) := by
-  simp only [DProp.true_at, DynamicSemantics.closure, cdrt_donkey, DProp.impl, dimpl, DProp.seq, dseq, Relation.Comp,
+  simp only [DProp.true_at, DynamicSemantics.Update.closure, cdrt_donkey, DProp.impl, impl, DProp.seq, seq, Relation.Comp,
     DProp.new, DProp.ofStatic, test, ttr_donkey]
   constructor
   · rintro ⟨o, rfl, hall⟩
@@ -269,7 +269,7 @@ private theorem donkey_antecedent_iff
      DProp.new 1 ;; DProp.ofStatic (λ r => donkey_ (r 1) ∧ owns (r 0) (r 1))) i k ↔
     ∃ x y, k = (λ m => if m = 1 then y else if m = 0 then x else i m) ∧
       farmer x ∧ donkey_ y ∧ owns x y := by
-  simp only [DProp.seq, dseq, Relation.Comp, DProp.new, DProp.ofStatic, test]
+  simp only [DProp.seq, seq, Relation.Comp, DProp.new, DProp.ofStatic, test]
   constructor
   · rintro ⟨k₃, ⟨k₂, ⟨k₁, ⟨e₀, rfl⟩, rfl, hf⟩, ⟨e₁, rfl⟩⟩, rfl, hd, ho⟩
     exact ⟨e₀, e₁, rfl, by simpa, by simpa, by simpa⟩
@@ -361,7 +361,7 @@ the *input* register (no binding). -/
 theorem dne_same_truth (n : Nat) (P : E → Prop) (i : State E) :
     DProp.true_at (DProp.neg (DProp.neg (cdrt_exists n P))) i ↔
     DProp.true_at (cdrt_exists n P) i := by
-  simp only [DProp.true_at, DynamicSemantics.closure, DProp.neg, test, dneg]
+  simp only [DProp.true_at, DynamicSemantics.Update.closure, DProp.neg, test, neg]
   constructor
   · rintro ⟨_, rfl, h⟩
     exact Classical.byContradiction (λ hno => h ⟨i, rfl, hno⟩)

--- a/Linglib/Studies/Dekker2012.lean
+++ b/Linglib/Studies/Dekker2012.lean
@@ -77,7 +77,7 @@ theorem pla_exists_certifies_witness {E : Type*} [Nonempty E] (M : Model E)
   simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq, Formula.sat] at hp
   exact hp.2
 
-/-- Surviving a sequenced update `(∃x.φ) ;; ψ` means surviving the
+/-- Surviving a sequenced update `∃x.φ` then `ψ` means surviving the
 existential update *and* satisfying `ψ` — the possibility is filtered by
 both conjuncts. Since the state is only filtered, this records
 satisfiability of both conjuncts at `p`; it does not link `ψ`'s pronouns
@@ -85,7 +85,7 @@ to the existential's witness (that would require witness export, which
 the eliminative formalization lacks). -/
 theorem pla_seq_certifies_both {E : Type*} [Nonempty E] (M : Model E)
     (x : VarIdx) (φ ψ : Formula) (s : InfoState E) (p : Poss E)
-    (hp : p ∈ ((Formula.exists_ x φ).update M ;; ψ.update M) s) :
+    (hp : p ∈ (seq ((Formula.exists_ x φ).update M) (ψ.update M)) s) :
     p ∈ (Formula.exists_ x φ).update M s ∧ ψ.sat M p.1 p.2 := by
   simp only [DynamicSemantics.CCP.seq] at hp
   constructor
@@ -93,11 +93,11 @@ theorem pla_seq_certifies_both {E : Type*} [Nonempty E] (M : Model E)
   · simp only [Formula.update, InfoState.restrict, Set.mem_setOf_eq] at hp
     exact hp.2
 
-/-- Combining the two: a possibility surviving `(∃x.φ) ;; ψ` certifies a
+/-- Combining the two: a possibility surviving `∃x.φ` then `ψ` certifies a
 witness for `φ` and satisfies `ψ`. -/
 theorem pla_seq_certifies_witness {E : Type*} [Nonempty E] (M : Model E)
     (x : VarIdx) (φ ψ : Formula) (s : InfoState E) (p : Poss E)
-    (hp : p ∈ ((Formula.exists_ x φ).update M ;; ψ.update M) s) :
+    (hp : p ∈ (seq ((Formula.exists_ x φ).update M) (ψ.update M)) s) :
     (∃ e : E, φ.sat M (p.1[x ↦ e]) p.2) ∧ ψ.sat M p.1 p.2 :=
   ⟨pla_exists_certifies_witness M x φ s p (pla_seq_certifies_both M x φ ψ s p hp).1,
    (pla_seq_certifies_both M x φ ψ s p hp).2⟩

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -48,6 +48,7 @@ Under these simplification conditions, the general FC preconditions
 namespace ElliottSudo2025
 
 open DynamicSemantics
+open DynamicSemantics.CCP (IsTest IsEliminative)
 open Classical
 
 variable {W E : Type*}
@@ -160,7 +161,7 @@ theorem diamond_negative_isTest (φ : BUSDen W E) :
 /-- Diamond positive is eliminative (from IsTest). -/
 theorem diamond_positive_eliminative (φ : BUSDen W E) :
     IsEliminative (◇ᵇφ).positive (S := Possibility W ℕ (Option E)) :=
-  test_eliminative _ (diamond_positive_isTest φ)
+  (diamond_positive_isTest φ).isEliminative
 
 /-- Diamond positive subset (convenience form). -/
 theorem diamond_positive_subset (φ : BUSDen W E) (s) :
@@ -170,7 +171,7 @@ theorem diamond_positive_subset (φ : BUSDen W E) (s) :
 /-- Diamond negative is eliminative (from IsTest). -/
 theorem diamond_negative_eliminative (φ : BUSDen W E) :
     IsEliminative (◇ᵇφ).negative (S := Possibility W ℕ (Option E)) :=
-  test_eliminative _ (diamond_negative_isTest φ)
+  (diamond_negative_isTest φ).isEliminative
 
 /-- Diamond negative subset (convenience form). -/
 theorem diamond_negative_subset (φ : BUSDen W E) (s) :

--- a/Linglib/Studies/GiorgoloAsudeh2012.lean
+++ b/Linglib/Studies/GiorgoloAsudeh2012.lean
@@ -346,7 +346,7 @@ end Bridge
 
 `PostSupp S A` ([charlow-2021]) is structurally identical to a single
 Writer monad: a value paired with accumulated side-effect content, composed
-via `pure`/`bind` with log sequencing via `dseq`. The Writer monad for CIs
+via `pure`/`bind` with log sequencing via `Update.seq`. The Writer monad for CIs
 and Charlow's `PostSupp` for modified numerals are the same pattern applied
 to different side-effects (CI propositions vs cardinality tests), confirming
 [shan-2001]'s insight that monads capture recurring compositional

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -261,7 +261,7 @@ theorem forall_interdefinable (x : ℕ) (φ : DPLRel E) :
 
 section Metatheory
 
-open DynamicSemantics
+open DynamicSemantics DynamicSemantics.Update
 
 /-- s-equivalence (Definition 7) at a fixed model: same satisfaction
 set. The paper quantifies over models; `DPLRel` fixes one. -/
@@ -347,8 +347,8 @@ theorem sEntails_of_subset {D₁ D₂ : Update S}
 
 /-- The deduction theorem (Fact 11) in spine vocabulary: entailment is
 validity of the implication test. -/
-theorem entails_iff_valid_test_dimpl (D₁ D₂ : Update S) :
-    (D₁ ⊨ D₂) ↔ valid (test (dimpl D₁ D₂)) := by
+theorem entails_iff_valid_test_impl (D₁ D₂ : Update S) :
+    (D₁ ⊨ D₂) ↔ valid (test (impl D₁ D₂)) := by
   constructor
   · intro h i
     exact ⟨i, rfl, h i⟩
@@ -370,7 +370,7 @@ deduction theorem read through the Ty2 embedding. -/
 theorem deduction (φ ψ : DPLRel E) :
     (toDRS φ ⊨ toDRS ψ) ↔ valid (toDRS (DPLRel.impl φ ψ)) := by
   rw [impl_eq_test_dimpl]
-  exact entails_iff_valid_test_dimpl (toDRS φ) (toDRS ψ)
+  exact entails_iff_valid_test_impl (toDRS φ) (toDRS ψ)
 
 /-- Fact 12: s-entailment is dynamic entailment from the closed premiss
 `♦φ`. -/
@@ -428,7 +428,7 @@ section SatisfactionSets
 
 open Core.CylindricAlgebra
 open Core (Assignment)
-open DynamicSemantics (closure)
+open DynamicSemantics.Update (closure)
 
 /-- **DPL existential = cylindrification**: `\∃xφ\ = cₓ\φ\` — the
 existential case of Fact 19's computation. -/
@@ -472,7 +472,7 @@ a composite of the generating arrows of `DynamicSemantics.Ctx`. -/
 
 section IndexedReading
 
-open DynamicSemantics
+open DynamicSemantics DynamicSemantics.Update
 
 variable {W : Type*} {X Y : Finset ℕ}
 

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -37,6 +37,7 @@ it.
 namespace GroenendijkStokhof1991
 
 open DPL
+open DynamicSemantics (Update)
 
 /-! ### Scope extension (§2.1, §2.3) -/
 
@@ -111,24 +112,20 @@ force output = input, so no binding escapes them. This accounts for
 `Heim1982.Examples.universal_blocks`, `standard_negation_blocks`, and
 `conditional_antecedent`. -/
 
-open DynamicSemantics (IsTest) in
 /-- Negation is a test. -/
-theorem neg_isTest (φ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.neg φ)) :=
+theorem neg_isTest (φ : DPLRel E) : Update.IsTest (toDRS (DPLRel.neg φ)) :=
   fun _ _ hn => hn.1
 
-open DynamicSemantics (IsTest) in
 /-- Implication is a test: antecedent bindings do not escape. -/
-theorem impl_isTest (φ ψ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.impl φ ψ)) :=
+theorem impl_isTest (φ ψ : DPLRel E) : Update.IsTest (toDRS (DPLRel.impl φ ψ)) :=
   fun _ _ hi => hi.1
 
-open DynamicSemantics (IsTest) in
 /-- Disjunction is a test: no anaphora across or out of disjuncts. -/
-theorem disj_isTest (φ ψ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.disj φ ψ)) :=
+theorem disj_isTest (φ ψ : DPLRel E) : Update.IsTest (toDRS (DPLRel.disj φ ψ)) :=
   fun _ _ hd => hd.1
 
-open DynamicSemantics (IsTest) in
 /-- The universal quantifier is a test: it introduces no referents. -/
-theorem forall_isTest (x : ℕ) (φ : DPLRel E) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.forall_ x φ)) :=
+theorem forall_isTest (x : ℕ) (φ : DPLRel E) : Update.IsTest (toDRS (DPLRel.forall_ x φ)) :=
   fun _ _ hfa => hfa.1
 
 /-! ### Logical facts (§3.4) -/
@@ -297,15 +294,15 @@ theorem sEquiv_pEquiv_ne [Nontrivial E] :
 /-- Definition 12's semantic core, clause 2: a conjunction of tests is a
 test. With the static constants (`neg_isTest`, ..., Fact 5) this closes
 the conditions under the semantics. -/
-theorem conj_isTest {φ ψ : DPLRel E} (hφ : DynamicSemantics.Update.IsTest (toDRS φ))
-    (hψ : DynamicSemantics.Update.IsTest (toDRS ψ)) : DynamicSemantics.Update.IsTest (toDRS (DPLRel.conj φ ψ)) :=
+theorem conj_isTest {φ ψ : DPLRel E} (hφ : Update.IsTest (toDRS φ))
+    (hψ : Update.IsTest (toDRS ψ)) : Update.IsTest (toDRS (DPLRel.conj φ ψ)) :=
   fun _ _ ⟨_, h1, h2⟩ => (hφ h1).trans (hψ h2)
 
 /-- Fact 4: for tests, s-equivalence coincides with equivalence — a test
 is determined by its truth conditions (`IsTest.eq_test_closure`, the
 semantic form of Fact 6). -/
 theorem sEquiv_iff_eq_of_isTest {φ ψ : DPLRel E}
-    (hφ : DynamicSemantics.Update.IsTest (toDRS φ)) (hψ : DynamicSemantics.Update.IsTest (toDRS ψ)) :
+    (hφ : Update.IsTest (toDRS φ)) (hψ : Update.IsTest (toDRS ψ)) :
     sEquiv φ ψ ↔ φ = ψ := by
   refine ⟨fun h => ?_, sEquiv_of_eq⟩
   have hc : closure (toDRS φ) = closure (toDRS ψ) :=
@@ -316,12 +313,56 @@ theorem sEquiv_iff_eq_of_isTest {φ ψ : DPLRel E}
 
 /-! ### Entailment (§3.5)
 
-Dynamic entailment (Definition 20) is the generic
-`DynamicSemantics.entails`; s-entailment (Definition 18) is
-`sEntails`, and meaning inclusion implies it (`sEntails_of_subset`,
-Fact 10). Facts 13–16 — the restricted reflexivity and transitivity
-laws — carry syntactic `AQV/FV` side conditions and await the syntax
-stratum. -/
+The paper's two entailment notions, stated over the spine's carrier
+(`Update S`) at full generality. Facts 13–16 — the restricted
+reflexivity and transitivity laws — carry syntactic `AQV/FV` side
+conditions and await the syntax stratum. -/
+
+section Entailment
+
+variable {S : Type*}
+
+/-- An `Update` is valid iff satisfiable (`closure`) at every input. -/
+def valid (D : Update S) : Prop := ∀ i, closure D i
+
+/-- Dynamic entailment (Definition 20): every output of `D₁` can be
+extended by `D₂`. -/
+def entails (D₁ D₂ : Update S) : Prop :=
+  ∀ i j, D₁ i j → closure D₂ j
+
+scoped notation D₁ " ⊨ " D₂ => entails D₁ D₂
+
+/-- s-entailment (Definition 18): truth is preserved from premiss to
+conclusion. Unlike `⊨`, it sees no binding between them. -/
+def sEntails (D₁ D₂ : Update S) : Prop :=
+  ∀ i, closure D₁ i → closure D₂ i
+
+scoped notation D₁ " ⊨ₛ " D₂ => sEntails D₁ D₂
+
+/-- Meaning inclusion implies s-entailment (Fact 10); the converse
+fails. -/
+theorem sEntails_of_subset {D₁ D₂ : Update S}
+    (h : ∀ ⦃i j⦄, D₁ i j → D₂ i j) : D₁ ⊨ₛ D₂ :=
+  fun _ ⟨j, hj⟩ => ⟨j, h hj⟩
+
+/-- The deduction theorem (Fact 11) in spine vocabulary: entailment is
+validity of the implication test. -/
+theorem entails_iff_valid_test_dimpl (D₁ D₂ : Update S) :
+    (D₁ ⊨ D₂) ↔ valid (test (dimpl D₁ D₂)) := by
+  constructor
+  · intro h i
+    exact ⟨i, rfl, h i⟩
+  · rintro h i j hij
+    obtain ⟨k, rfl, hd⟩ := h i
+    exact hd j hij
+
+/-- Fact 12, in closure form: s-entailment is entailment from the
+closed premiss. -/
+theorem sEntails_iff_test_closure_entails (D₁ D₂ : Update S) :
+    (D₁ ⊨ₛ D₂) ↔ (test (closure D₁) ⊨ D₂) :=
+  ⟨fun h _ j ⟨_, hc⟩ => h j hc, fun h i hc => h i i ⟨rfl, hc⟩⟩
+
+end Entailment
 
 /-- The deduction theorem (Fact 11): `φ ⊨ ψ` iff `⊨ φ → ψ` — DPL
 implication is the test of dynamic implication, so this is the generic

--- a/Linglib/Studies/HaugDalrymple2020.lean
+++ b/Linglib/Studies/HaugDalrymple2020.lean
@@ -40,7 +40,7 @@ the PPCDRT substrate (`Semantics/Dynamic/PPCDRT/`):
 Sections paper-acknowledged but not formalised (out of scope for a
 study-file size budget): the full §2.3 Δ-relativised distribution
 machinery (deferred — the substrate-trimming pass removed the prototyped
-`delta`/`⨟`/`∂`/`max^u` operators since no consumer exercised them; they
+`delta`/`seq`/`∂`/`max^u` operators since no consumer exercised them; they
 will return alongside a Brasoveanu 2007 / Dotlačil 2013 study file);
 the §5.2 empirical-fit table; the §7 typological excursus.
 

--- a/Linglib/Studies/Hofmann2025.lean
+++ b/Linglib/Studies/Hofmann2025.lean
@@ -64,6 +64,7 @@ empirical applications.
 namespace Hofmann2025
 
 open DynamicSemantics
+open DynamicSemantics.CCP (IsDistributive)
 open DynamicSemantics.ICDRT
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Hofmann2025.lean
+++ b/Linglib/Studies/Hofmann2025.lean
@@ -936,7 +936,7 @@ theorem comp_factorizes (D : ICDRT.Update W E) :
 
 /-- Sequential composition in the fragment lifts to CCP composition. -/
 theorem comp_seq_lifts (D₁ D₂ : ICDRT.Update W E) (c : ICDRT.Context W E) :
-    ICDRT.toUpdate (D₁ ⨟ D₂) c = ICDRT.toUpdate D₂ (ICDRT.toUpdate D₁ c) :=
+    ICDRT.toUpdate (seq D₁ D₂) c = ICDRT.toUpdate D₂ (ICDRT.toUpdate D₁ c) :=
   seq_toUpdate D₁ D₂ c
 
 -- § 6.4 Compositional derivations applied to Model M₁

--- a/Linglib/Studies/Hofmann2025.lean
+++ b/Linglib/Studies/Hofmann2025.lean
@@ -64,6 +64,7 @@ empirical applications.
 namespace Hofmann2025
 
 open DynamicSemantics
+open DynamicSemantics.Update (seq test closure)
 open DynamicSemantics.CCP (IsDistributive)
 open DynamicSemantics.ICDRT
 
@@ -786,7 +787,7 @@ abbrev intransVP (R : E → W → Prop) : SemE W E := commonNoun R
 The biconditional in `relVarUp` ensures `v` has a referent exactly in
 the φ-worlds, preventing scope leakage. -/
 def indefinite (v : IVar) (P P' : SemE W E) (φ : PVar) : ICDRT.Update W E :=
-  dseq (dseq (λ i j => relVarUp φ v i j) (P v φ)) (P' v φ)
+  seq (seq (λ i j => relVarUp φ v i j) (P v φ)) (P' v φ)
 
 /-- (17) Pronoun: `it_v ⟿ λP.λφ.P(v)(φ)`. The pronoun contributes no
 update — it simply passes its index `v` to the predicate. -/
@@ -796,7 +797,7 @@ def pronoun (v : IVar) (P : SemE W E) (φ : PVar) : ICDRT.Update W E :=
 /-- (14) Proper name: `Mary ⟿ λP.λφ.[v | v ≡ Mary_e]; P(v)(φ)`. -/
 def properName (name : E) (v : IVar) (P : SemE W E) (φ : PVar) :
     ICDRT.Update W E :=
-  dseq
+  seq
     (λ i j => indivVarUp v i j ∧ ∀ w : W, j.indiv v w = .some name)
     (P v φ)
 
@@ -805,7 +806,7 @@ def properName (name : E) (v : IVar) (P : SemE W E) (φ : PVar) :
 Static complementation over propositional drefs, NOT bilateral swap —
 the algebraic content of [hofmann-2025]'s key insight (§5.1.1). -/
 def semNOT (φ' : PVar) (Sc : SemW W E) (φ : PVar) : ICDRT.Update W E :=
-  dseq
+  seq
     (λ i j => propVarUp φ' i j ∧ isComplement φ φ' j)
     (propMaxOp φ' (Sc φ'))
 
@@ -816,8 +817,8 @@ The disjuncts' local contexts need NOT overlap — this is how bathroom
 disjunctions enable cross-disjunct anaphora. -/
 def semOR (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
     ICDRT.Update W E :=
-  dseq
-    (dseq
+  seq
+    (seq
       (λ i j => multiVarUp [φ', φ''] [] i j ∧
         j.prop φ = j.prop φ' ∪ j.prop φ'')
       (propMaxOp φ' (Sc' φ')))
@@ -827,8 +828,8 @@ def semOR (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
 max_{φ'}(Sc'(φ')); max_{φ''}(Sc''(φ''))`. -/
 def semIF (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
     ICDRT.Update W E :=
-  dseq
-    (dseq
+  seq
+    (seq
       (λ i j => multiVarUp [φ', φ''] [] i j ∧
         j.prop φ = (j.prop φ')ᶜ ∪ j.prop φ'')
       (propMaxOp φ' (Sc' φ')))
@@ -838,9 +839,9 @@ def semIF (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
 [φ' | φ'⊑φ]; max_{φ'}(Sc'(φ')); [φ'' | φ''⊑φ']; max_{φ''}(Sc''(φ''))`. -/
 def semAND (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
     ICDRT.Update W E :=
-  dseq
-    (dseq
-      (dseq
+  seq
+    (seq
+      (seq
         (λ i j => propVarUp φ' i j ∧ dynInclusion φ' φ j)
         (propMaxOp φ' (Sc' φ')))
       (λ i j => propVarUp φ'' i j ∧ dynInclusion φ'' φ' j))
@@ -849,14 +850,14 @@ def semAND (φ' φ'' : PVar) (Sc' Sc'' : SemW W E) (φ : PVar) :
 /-- (18e) Attitude verb: `believed ⟿ λv.λSc.λφ.[φ' | believe_φ(v,φ')]; max_{φ'}(Sc(φ'))`. -/
 def semBelieved (φ' : PVar) (dox : ICDRT.Assignment W E → Set W)
     (Sc : SemW W E) (_φ : PVar) : ICDRT.Update W E :=
-  dseq
+  seq
     (λ i j => propVarUp φ' i j ∧ believeCondition φ' dox j)
     (propMaxOp φ' (Sc φ'))
 
 /-- (19) Declarative assertion: `DEC_S^φ ⟿ λSc.[φ | φ_{DC_S}⊑φ]; max_φ(Sc(φ))`. -/
 def semDEC (φ_DC : PVar) (φ : PVar) (Sc : SemW W E) :
     ICDRT.Update W E :=
-  dseq
+  seq
     (λ i j => propVarUp φ i j ∧ decCondition φ_DC φ j)
     (propMaxOp φ (Sc φ))
 
@@ -936,7 +937,7 @@ theorem comp_factorizes (D : ICDRT.Update W E) :
 /-- Sequential composition in the fragment lifts to CCP composition. -/
 theorem comp_seq_lifts (D₁ D₂ : ICDRT.Update W E) (c : ICDRT.Context W E) :
     ICDRT.toUpdate (D₁ ⨟ D₂) c = ICDRT.toUpdate D₂ (ICDRT.toUpdate D₁ c) :=
-  dseq_toUpdate D₁ D₂ c
+  seq_toUpdate D₁ D₂ c
 
 -- § 6.4 Compositional derivations applied to Model M₁
 
@@ -952,7 +953,7 @@ def itIsUpstairs : SemW BWorld BEnt :=
 
 /-- **Veridical**: "There is a bathroom. It is upstairs." -/
 def veridical_comp : ICDRT.Update BWorld BEnt :=
-  dseq
+  seq
     (semDEC pDC_S p1 thereIsABathroom)
     (semDEC pDC_S p3 itIsUpstairs)
 
@@ -975,13 +976,13 @@ def bathDisj_comp : ICDRT.Update BWorld BEnt :=
 Different speakers have different commitment sets — what bilateral
 accounts CANNOT handle (§5.1.1). -/
 def disagree_comp : ICDRT.Update BWorld BEnt :=
-  dseq
+  seq
     (semDEC pDC_A p1 (semNOT p2 thereIsABathroom))
     (semDEC pDC_B p3 itIsUpstairs)
 
 /-- **Modal subordination**: "There isn't a bathroom. Sue believes it's upstairs." -/
 def modalSub_comp : ICDRT.Update BWorld BEnt :=
-  dseq
+  seq
     (semDEC pDC_S p1 (semNOT p2 thereIsABathroom))
     (semDEC pDC_S p3
       (semBelieved p4_modal
@@ -998,7 +999,7 @@ theorem veridical_comp_factors (c : ICDRT.Context BWorld BEnt) :
     ICDRT.toUpdate veridical_comp c =
     ICDRT.toUpdate (semDEC pDC_S p3 itIsUpstairs)
       (ICDRT.toUpdate (semDEC pDC_S p1 thereIsABathroom) c) :=
-  dseq_toUpdate _ _ c
+  seq_toUpdate _ _ c
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -52,7 +52,7 @@ finite models.
 `Nat`-indexed dynamic operators on the Tarski-style state `Assignment E := Nat → E`
 (`Core.Assignment`), generic over `E`: `randomAssignAt n` (DPL `[x_n]`), `existsAt n φ`
 (DPL `∃x_n.φ`, CDRT `[u_n]; φ`), `forallAt n φ` (DPL `∀x_n.φ`), `closeAt φ` (DPL `◇φ`).
-`existsAt n` is `dseq` after `randomAssignAt n`; `forallAt n` is `¬∃¬` via `test`/`dneg`.
+`existsAt n` is `seq` after `randomAssignAt n`; `forallAt n` is `¬∃¬` via `test`/`neg`.
 `RegisterStructure` (`Dynamic/CDRT.lean`) abstracts these: its canonical
 instance at `Nat → E` has register indices `n` with projection values.
 
@@ -64,6 +64,7 @@ namespace DynamicSemantics
 
 open _root_.Core (Assignment)
 open DynamicSemantics
+open DynamicSemantics.Update (test seq neg closure)
 
 variable {E : Type*}
 
@@ -71,33 +72,33 @@ variable {E : Type*}
 def randomAssignAt (n : Nat) : Update (Assignment E) :=
   fun g h => ∃ d : E, h = Function.update g n d
 
-/-- `existsAt n φ` is `dseq (randomAssignAt n) φ`. Holds at `(g, h)` iff
+/-- `existsAt n φ` is `seq (randomAssignAt n) φ`. Holds at `(g, h)` iff
 some witness `d : E` makes `φ` accept the input `g[n↦d]` and produce `h`. -/
 def existsAt (n : Nat) (φ : Update (Assignment E)) : Update (Assignment E) :=
-  dseq (randomAssignAt n) φ
+  seq (randomAssignAt n) φ
 
-/-- The decomposition: `existsAt = dseq ∘ randomAssignAt`. -/
+/-- The decomposition: `existsAt = seq ∘ randomAssignAt`. -/
 @[simp] theorem existsAt_eq_dseq (n : Nat) (φ : Update (Assignment E)) :
-    existsAt n φ = dseq (randomAssignAt n) φ := rfl
+    existsAt n φ = seq (randomAssignAt n) φ := rfl
 
 /-- Direct unfolding: `existsAt n φ g h ↔ ∃ d : E, φ (Function.update g n d) h`. -/
 theorem existsAt_iff (n : Nat) (φ : Update (Assignment E)) (g h : Assignment E) :
     existsAt n φ g h ↔ ∃ d : E, φ (Function.update g n d) h := by
-  simp only [existsAt, dseq, Relation.Comp, randomAssignAt]
+  simp only [existsAt, seq, Relation.Comp, randomAssignAt]
   constructor
   · rintro ⟨k, ⟨d, rfl⟩, hφ⟩; exact ⟨d, hφ⟩
   · rintro ⟨d, hφ⟩; exact ⟨Function.update g n d, ⟨d, rfl⟩, hφ⟩
 
 /-- `forallAt n φ`: a test that requires `φ` to succeed for every value at `n`.
-Definitionally `test (dneg (existsAt n (test (dneg φ))))` — the standard
+Definitionally `test (neg (existsAt n (test (neg φ))))` — the standard
 DPL/Muskens reduction `∀ ≈ ¬∃¬`. -/
 def forallAt (n : Nat) (φ : Update (Assignment E)) : Update (Assignment E) :=
-  test (dneg (existsAt n (test (dneg φ))))
+  test (neg (existsAt n (test (neg φ))))
 
 /-- Direct truth condition: `forallAt n φ g h ↔ g = h ∧ ∀ d, ∃ k, φ (Function.update g n d) k`. -/
 theorem forallAt_iff (n : Nat) (φ : Update (Assignment E)) (g h : Assignment E) :
     forallAt n φ g h ↔ g = h ∧ ∀ d : E, ∃ k, φ (Function.update g n d) k := by
-  simp only [forallAt, test, dneg, existsAt, dseq, Relation.Comp, randomAssignAt]
+  simp only [forallAt, test, neg, existsAt, seq, Relation.Comp, randomAssignAt]
   constructor
   · rintro ⟨rfl, hneg⟩
     refine ⟨rfl, fun d => ?_⟩
@@ -1069,7 +1070,8 @@ theorem pip_quantifier_blocking :
 section DPLComparison
 
 open DynamicSemantics (existsAt existsAt_iff)
-open DynamicSemantics (Update dneg test)
+open DynamicSemantics (Update)
+open DynamicSemantics.Update (neg test)
 open _root_.Core (Assignment)
 
 /-!
@@ -1089,19 +1091,19 @@ The following theorems make this architectural difference explicit.
 
 **Substrate names**: DPL relations are `Update (Assignment E)` from
 `Semantics/Dynamic/`. The DPL operator aliases are
-substrate operations: `DPLRel.neg φ` is `test (dneg φ)`,
+substrate operations: `DPLRel.neg φ` is `test (neg φ)`,
 `DPLRel.exists_ x φ` is `existsAt x φ`. -/
 
 /--
 DPL negation resets the output assignment — it cannot export bindings.
 
 This is the key structural property of DPL that blocks cross-negation
-anaphora: after `¬φ` (`test (dneg φ)`), the output assignment equals the
+anaphora: after `¬φ` (`test (neg φ)`), the output assignment equals the
 input, so any variables bound inside φ are inaccessible.
 -/
 theorem dpl_neg_is_test :
     ∀ (E : Type*) (φ : Update (Assignment E)) (g h : Assignment E),
-    test (dneg φ) g h → g = h :=
+    test (neg φ) g h → g = h :=
   λ _ _ _ _ h => h.1
 
 /--
@@ -1123,7 +1125,7 @@ theorem pip_neg_preserves_labels :
 DPL double negation does not recover anaphora.
 
 For `Nontrivial E`, there exist `x : Nat` and `φ : Update (Assignment E)` such
-that `test (dneg (test (dneg (existsAt x φ))))` ≠ `existsAt x φ`. The
+that `test (neg (test (neg (existsAt x φ))))` ≠ `existsAt x φ`. The
 substrate-name restatement of [groenendijk-stokhof-1991]'s observation
 that DPL negation collapses positive update information.
 
@@ -1132,7 +1134,7 @@ that DPL negation collapses positive update information.
 for DPL theorems in substrate form. -/
 private theorem dpl_dne_fails_anaphora {E : Type*} [Nontrivial E] :
     ∃ (x : Nat) (φ : Update (Assignment E)),
-      test (dneg (test (dneg (existsAt x φ)))) ≠ existsAt x φ := by
+      test (neg (test (neg (existsAt x φ)))) ≠ existsAt x φ := by
   obtain ⟨e₁, e₂, hne⟩ := exists_pair_ne E
   refine ⟨0, fun g h => g = h, fun heq => hne ?_⟩
   let g₀ : Assignment E := fun _ => e₁
@@ -1158,7 +1160,7 @@ Concretely:
 theorem pip_solves_dpl_negation_problem :
     -- DPL: ¬¬∃xφ ≠ ∃xφ (double negation fails for anaphora)
     (∃ (x : Nat) (φ : Update (Assignment Nat)),
-      test (dneg (test (dneg (existsAt x φ)))) ≠ existsAt x φ) ∧
+      test (neg (test (neg (existsAt x φ)))) ≠ existsAt x φ) ∧
     -- PIP: labels survive negation (bathroom sentences work)
     (∀ d : Discourse BWorld BEntity,
       (negation

--- a/Linglib/Studies/Krifka2026.lean
+++ b/Linglib/Studies/Krifka2026.lean
@@ -18,7 +18,7 @@ and derive kind individuals via [chierchia-1998]'s ∩ from
 substrate `Update`/`test`/`dneg` algebra of `Semantics/Dynamic/Connectives`
 at heterogeneous assignments over `DRefVal`.
 
-Negation here is the paper's VP negation ⟦doesn't⟧ (44b), `test (∼φ)`; the
+Negation here is the paper's VP negation ⟦doesn't⟧ (44b), `test (dneg φ)`; the
 sentential ⟦NEG⟧ (34) additionally restricts the negated existential to
 extensions g≤k, and both carry a world-time index — differences orthogonal to
 projection, which needs only that negation is a test. The paper derives the
@@ -252,7 +252,7 @@ theorem entity_trapped_by_test {n : Nat}
     h n = .undef :=
   (test_apply_eq hTest n).trans hNovel
 
-/-- The concept/entity asymmetry under negation `test (∼φ)` ((44e)): the
+/-- The concept/entity asymmetry under negation `test (dneg φ)` ((44e)): the
     concept dref persists, the entity dref does not. Both conjuncts are
     instances of `test_apply_eq` — the asymmetry is carried entirely by where
     the hypotheses place the two conditions (input presupposition vs input
@@ -260,7 +260,7 @@ theorem entity_trapped_by_test {n : Nat}
 theorem concept_entity_asymmetry {nC nE : Nat} {c : ConceptDRef W E}
     {φ : Update (HAssign W E)} {g h : HAssign W E}
     (hPresup : g nC = .concept c) (hNovel : g nE = .undef)
-    (hNeg : test (∼φ) g h) :
+    (hNeg : test (dneg φ) g h) :
     h nC = .concept c ∧ h nE = .undef :=
   ⟨concept_survives_test hPresup hNeg, entity_trapped_by_test hNovel hNeg⟩
 
@@ -279,7 +279,7 @@ theorem dog_concept_survives_negation
     {g h : HAssign W E}
     (hDog : g 2 = .concept dogConcept)
     (hNovel : g 3 = .undef)
-    (hNeg : test (∼φ) g h) :
+    (hNeg : test (dneg φ) g h) :
     h 2 = .concept dogConcept ∧ h 3 = .undef :=
   concept_entity_asymmetry hDog hNovel hNeg
 
@@ -321,7 +321,7 @@ def ownADog : Update (HAssign Wld Ent) := entityIntro 3 (λ g h =>
 
 /-- "John₁ doesn't own [DP a₃ [NP dog]₂]": the paper's VP negation
     ⟦doesn't⟧ (44b) is the substrate test of dynamic negation. -/
-def doesntOwnADog : Update (HAssign Wld Ent) := test (∼ownADog)
+def doesntOwnADog : Update (HAssign Wld Ent) := test (dneg ownADog)
 
 /-- The negation is satisfiable in this model (no dogs exist).
     Output: g₀ = h (test), confirming no entity dref was introduced. -/

--- a/Linglib/Studies/Krifka2026.lean
+++ b/Linglib/Studies/Krifka2026.lean
@@ -15,10 +15,10 @@ by indefinites under negation are trapped. Kind anaphors pick up concept drefs
 and derive kind individuals via [chierchia-1998]'s ∩ from
 `Semantics/Genericity/NominalMappingParameter`: ⟦it⟧ = λP[MASS] λi.∩P(i),
 ⟦they⟧ = λP[COUNT] λi.∩⊔P(i) (17a,b). The dynamic layer instantiates the
-substrate `Update`/`test`/`dneg` algebra of `Semantics/Dynamic/Connectives`
+substrate `Update`/`test`/`neg` algebra of `Semantics/Dynamic/Connectives`
 at heterogeneous assignments over `DRefVal`.
 
-Negation here is the paper's VP negation ⟦doesn't⟧ (44b), `test (dneg φ)`; the
+Negation here is the paper's VP negation ⟦doesn't⟧ (44b), `test (neg φ)`; the
 sentential ⟦NEG⟧ (34) additionally restricts the negated existential to
 extensions g≤k, and both carry a world-time index — differences orthogonal to
 projection, which needs only that negation is a test. The paper derives the
@@ -42,7 +42,8 @@ namespace Krifka2026
 
 open Semantics.Kinds.NMP (Property Kind IsMass
   kindAnaphorMass kindAnaphorCount kindAnaphorCount_mass)
-open DynamicSemantics (Update Condition test dneg eq_of_test)
+open DynamicSemantics (Update Condition)
+open DynamicSemantics.Update (test neg)
 open scoped DynamicSemantics
 
 /-! ### Concept drefs and heterogeneous dref values ([krifka-2026] §4)
@@ -231,7 +232,7 @@ def entityIntro (n : Nat) (body : Update (HAssign W E)) : Update (HAssign W E) :
     fact covers [krifka-2026]'s whole island list at once. -/
 theorem test_apply_eq {C : Condition (HAssign W E)} {g h : HAssign W E}
     (hTest : test C g h) (n : Nat) : h n = g n :=
-  congrFun (eq_of_test hTest).symm n
+  congrFun hTest.1.symm n
 
 /-- **Concept drefs survive islands** ((5a), (25), (44–45)): a concept dref
     presupposed in the input is still anchored in the output of any test.
@@ -252,7 +253,7 @@ theorem entity_trapped_by_test {n : Nat}
     h n = .undef :=
   (test_apply_eq hTest n).trans hNovel
 
-/-- The concept/entity asymmetry under negation `test (dneg φ)` ((44e)): the
+/-- The concept/entity asymmetry under negation `test (neg φ)` ((44e)): the
     concept dref persists, the entity dref does not. Both conjuncts are
     instances of `test_apply_eq` — the asymmetry is carried entirely by where
     the hypotheses place the two conditions (input presupposition vs input
@@ -260,7 +261,7 @@ theorem entity_trapped_by_test {n : Nat}
 theorem concept_entity_asymmetry {nC nE : Nat} {c : ConceptDRef W E}
     {φ : Update (HAssign W E)} {g h : HAssign W E}
     (hPresup : g nC = .concept c) (hNovel : g nE = .undef)
-    (hNeg : test (dneg φ) g h) :
+    (hNeg : test (neg φ) g h) :
     h nC = .concept c ∧ h nE = .undef :=
   ⟨concept_survives_test hPresup hNeg, entity_trapped_by_test hNovel hNeg⟩
 
@@ -279,7 +280,7 @@ theorem dog_concept_survives_negation
     {g h : HAssign W E}
     (hDog : g 2 = .concept dogConcept)
     (hNovel : g 3 = .undef)
-    (hNeg : test (dneg φ) g h) :
+    (hNeg : test (neg φ) g h) :
     h 2 = .concept dogConcept ∧ h 3 = .undef :=
   concept_entity_asymmetry hDog hNovel hNeg
 
@@ -321,7 +322,7 @@ def ownADog : Update (HAssign Wld Ent) := entityIntro 3 (λ g h =>
 
 /-- "John₁ doesn't own [DP a₃ [NP dog]₂]": the paper's VP negation
     ⟦doesn't⟧ (44b) is the substrate test of dynamic negation. -/
-def doesntOwnADog : Update (HAssign Wld Ent) := test (dneg ownADog)
+def doesntOwnADog : Update (HAssign Wld Ent) := test (neg ownADog)
 
 /-- The negation is satisfiable in this model (no dogs exist).
     Output: g₀ = h (test), confirming no entity dref was introduced. -/

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -41,6 +41,7 @@ open Core (Assignment)
 open Intensional (WorldTimeIndex)
 open HistoricalAlternatives
 open DynamicSemantics
+open DynamicSemantics.CCP (IsEliminative)
 open Tense
 open Mood
 

--- a/Linglib/Studies/Muskens1996.lean
+++ b/Linglib/Studies/Muskens1996.lean
@@ -29,12 +29,12 @@ worked developments over that substrate:
 | `[[π]]` | `DynPred S E → Update S` | dynamic quantifier (`DynQuant`) |
 
 Composition rules T₁–T₅ need no special formalization: they are function
-application, `dseq`, and λ-abstraction.
+application, `seq`, and λ-abstraction.
 -/
 
 namespace Muskens1996
 
-open DynamicSemantics
+open DynamicSemantics DynamicSemantics.Update
 
 variable {R S E : Type*}
 
@@ -64,21 +64,21 @@ def tv (R : E → E → Prop) : DynQuant S E → DynPred S E :=
 /-- Indefinite determiner: `aⁿ ↝ λP'λP([uₙ]; P'(uₙ); P(uₙ))`.
 Type `[π] → [[π]]`; introduces discourse referent `u`. -/
 def detA [RegisterStructure R S E] (u : R) : DynPred S E → DynQuant S E :=
-  λ noun vp => dseq (RegisterStructure.randomAssign u)
-    (dseq (noun (RegisterStructure.val u)) (vp (RegisterStructure.val u)))
+  λ noun vp => seq (RegisterStructure.randomAssign u)
+    (seq (noun (RegisterStructure.val u)) (vp (RegisterStructure.val u)))
 
 /-- Universal determiner: `everyⁿ ↝ λP'λP(([uₙ]; P'(uₙ)) ⇒ P(uₙ))`.
 Dynamic implication gives universal force. -/
 def detEvery [RegisterStructure R S E] (u : R) : DynPred S E → DynQuant S E :=
   λ noun vp =>
-    test (dimpl (dseq (RegisterStructure.randomAssign u) (noun (RegisterStructure.val u)))
+    test (impl (seq (RegisterStructure.randomAssign u) (noun (RegisterStructure.val u)))
       (vp (RegisterStructure.val u)))
 
 /-- Negative determiner: `noⁿ ↝ λP'λP[|not([uₙ]; P'(uₙ); P(uₙ))]`. -/
 def detNo [RegisterStructure R S E] (u : R) : DynPred S E → DynQuant S E :=
   λ noun vp =>
-    test (dneg (dseq (RegisterStructure.randomAssign u)
-      (dseq (noun (RegisterStructure.val u)) (vp (RegisterStructure.val u)))))
+    test (neg (seq (RegisterStructure.randomAssign u)
+      (seq (noun (RegisterStructure.val u)) (vp (RegisterStructure.val u)))))
 
 /-- Proper name NP: `Maryⁿ ↝ λP.P(Mary)`. Type `[[π]]`. -/
 def properNP (name : Dref S E) : DynQuant S E :=
@@ -90,12 +90,12 @@ def pro (u : Dref S E) : DynQuant S E :=
 
 /-- Conditional: `if ↝ λpq[|p ⇒ q]`. -/
 def cond : Update S → Update S → Update S :=
-  λ p q => test (dimpl p q)
+  λ p q => test (impl p q)
 
 /-- Auxiliary negation: `doesn't ↝ λPλQ[|not Q(P)]` — takes VP (P) then
 subject NP (Q), matching [muskens-1996]'s argument order. -/
 def auxNeg : DynPred S E → DynQuant S E → Update S :=
-  λ P Q => test (dneg (Q P))
+  λ P Q => test (neg (Q P))
 
 /-! ### Generalized coordination (§IV)
 
@@ -103,27 +103,27 @@ def auxNeg : DynPred S E → DynQuant S E → Update S :=
 pointwise. The same schema works at every syntactic category. -/
 
 /-- Sentence-level `and`: `K₁ and K₂ = K₁; K₂`. -/
-def andS : Update S → Update S → Update S := dseq
+def andS : Update S → Update S → Update S := seq
 
 /-- Sentence-level `or`: `K₁ or K₂ = [K₁ or K₂]` (disjunction test). -/
 def orS : Update S → Update S → Update S :=
-  λ D₁ D₂ => test (ddisj D₁ D₂)
+  λ D₁ D₂ => test (disj D₁ D₂)
 
 /-- VP-level `and`: `λv(P₁(v); P₂(v))`. -/
 def andVP : DynPred S E → DynPred S E → DynPred S E :=
-  λ P₁ P₂ u => dseq (P₁ u) (P₂ u)
+  λ P₁ P₂ u => seq (P₁ u) (P₂ u)
 
 /-- VP-level `or`: `λv[P₁(v) or P₂(v)]`. -/
 def orVP : DynPred S E → DynPred S E → DynPred S E :=
-  λ P₁ P₂ u => test (ddisj (P₁ u) (P₂ u))
+  λ P₁ P₂ u => test (disj (P₁ u) (P₂ u))
 
 /-- NP-level `and`: `λP(Q₁(P); Q₂(P))`. -/
 def andNP : DynQuant S E → DynQuant S E → DynQuant S E :=
-  λ Q₁ Q₂ P => dseq (Q₁ P) (Q₂ P)
+  λ Q₁ Q₂ P => seq (Q₁ P) (Q₂ P)
 
 /-- NP-level `or`: `λP[Q₁(P) or Q₂(P)]`. -/
 def orNP : DynQuant S E → DynQuant S E → DynQuant S E :=
-  λ Q₁ Q₂ P => test (ddisj (Q₁ P) (Q₂ P))
+  λ Q₁ Q₂ P => test (disj (Q₁ P) (Q₂ P))
 
 /-! ### The paper's derivations -/
 
@@ -139,7 +139,7 @@ abhors box is the worked example Muskens runs the wp calculus on (p. 173),
 with truth conditions `∃x₁ x₂ (man x₁ ∧ woman x₂ ∧ adores x₁ x₂ ∧
 abhors x₂ x₁)`. -/
 def exampleText (man woman : E → Prop) (adores abhors : E → E → Prop) : Update S :=
-  dseq
+  seq
     (detA u₁ (cn man) (tv adores (detA u₂ (cn woman))))
     (pro (RegisterStructure.val u₂) (tv abhors (pro (RegisterStructure.val u₁))))
 
@@ -149,7 +149,7 @@ def exampleText (man woman : E → Prop) (adores abhors : E → E → Prop) : Up
 def donkeySentence
     (farmer donkey_ : E → Prop) (owns beats : E → E → Prop) : Update S :=
   detEvery u₁
-    (λ v => dseq (cn farmer v) (detA u₂ (cn donkey_) (λ w => test (atom2 owns v w))))
+    (λ v => seq (cn farmer v) (detA u₂ (cn donkey_) (λ w => test (atom2 owns v w))))
     (tv beats (pro (RegisterStructure.val u₂)))
 
 /-- "A² cat catches a¹ fish and eats it₁." — the paper's (52), decorated as
@@ -185,9 +185,9 @@ theorem wp_test (C : Condition S) (χ : Condition S) :
 
 /-- WP of sequencing (WP_{;}): the postcondition threads through. -/
 theorem wp_seq (D₁ D₂ : Update S) (χ : Condition S) :
-    wp (dseq D₁ D₂) χ = wp D₁ (wp D₂ χ) := by
+    wp (seq D₁ D₂) χ = wp D₁ (wp D₂ χ) := by
   ext i
-  simp only [wp, dseq, Relation.Comp]
+  simp only [wp, seq, Relation.Comp]
   constructor
   · rintro ⟨j, ⟨h, hD₁, hD₂⟩, hχ⟩
     exact ⟨h, hD₁, j, hD₂, hχ⟩
@@ -238,22 +238,22 @@ def dplEntails (D₁ D₂ : Update S) : Prop :=
 /-- Corollary to Proposition 3: DPL entailment = validity of dynamic
 implication. -/
 theorem dpl_entailment_eq_dimpl_valid (D₁ D₂ : Update S) :
-    dplEntails D₁ D₂ ↔ ∀ i, dimpl D₁ D₂ i := by
-  simp only [dplEntails, dimpl]
+    dplEntails D₁ D₂ ↔ ∀ i, impl D₁ D₂ i := by
+  simp only [dplEntails, impl]
 
 /-! ### Truth-condition extraction rules -/
 
 /-- TR of negation: `tr(not K) = ¬wp(K, ⊤)`. -/
 theorem tr_neg_eq (D : Update S) :
-    dneg D = λ i => ¬ wp D (λ _ => True) i := by
+    neg D = λ i => ¬ wp D (λ _ => True) i := by
   simp only [wp_true_eq_closure]; rfl
 
 /-- TR of disjunction: `tr(K₁ or K₂) = wp(K₁, ⊤) ∨ wp(K₂, ⊤)` — the
 existential distributes over disjunction. -/
 theorem tr_disj_eq (D₁ D₂ : Update S) :
-    ddisj D₁ D₂ = λ i => wp D₁ (λ _ => True) i ∨ wp D₂ (λ _ => True) i := by
+    disj D₁ D₂ = λ i => wp D₁ (λ _ => True) i ∨ wp D₂ (λ _ => True) i := by
   ext i
-  simp only [ddisj, wp, and_true]
+  simp only [disj, wp, and_true]
   constructor
   · rintro ⟨k, hk⟩
     cases hk with
@@ -266,9 +266,9 @@ theorem tr_disj_eq (D₁ D₂ : Update S) :
 /-- TR of implication: `tr(K₁ ⇒ K₂) = ¬wp(K₁, ¬wp(K₂, ⊤))` — no way to
 satisfy the antecedent without satisfying the consequent. -/
 theorem tr_impl_eq (D₁ D₂ : Update S) :
-    dimpl D₁ D₂ = λ i => ¬ wp D₁ (λ j => ¬ wp D₂ (λ _ => True) j) i := by
+    impl D₁ D₂ = λ i => ¬ wp D₁ (λ j => ¬ wp D₂ (λ _ => True) j) i := by
   ext i
-  simp only [dimpl, wp, and_true]
+  simp only [impl, wp, and_true]
   constructor
   · intro h ⟨j, hD₁, hNot⟩
     exact hNot (h j hD₁)
@@ -312,7 +312,7 @@ then continuing with `φ` equals cylindrifying `φ` at `n`. -/
 theorem cdrt_new_seq_eq_cylindrify {E : Type*} (n : Nat) (φ : DProp E) :
     closure (DProp.new n ;; φ) =
     cylindrify n (closure φ) := by
-  ext g; simp only [closure, DProp.seq, dseq, Relation.Comp, DProp.new, cylindrify]
+  ext g; simp only [closure, DProp.seq, seq, Relation.Comp, DProp.new, cylindrify]
   constructor
   · rintro ⟨o, k, ⟨e, rfl⟩, hφ⟩
     exact ⟨e, o, by convert hφ using 2; simp [Function.update_apply]⟩

--- a/Linglib/Studies/Muskens1996.lean
+++ b/Linglib/Studies/Muskens1996.lean
@@ -307,10 +307,10 @@ open CDRT
 
 /-- Discourse referent introduction under closure = cylindrification.
 
-`closure(new n ;; φ) = cₙ(closure(φ))`: introducing dref `n`
+`closure(new n * φ) = cₙ(closure(φ))`: introducing dref `n`
 then continuing with `φ` equals cylindrifying `φ` at `n`. -/
 theorem cdrt_new_seq_eq_cylindrify {E : Type*} (n : Nat) (φ : DProp E) :
-    closure (DProp.new n ;; φ) =
+    closure (DProp.new n * φ) =
     cylindrify n (closure φ) := by
   ext g; simp only [closure, DProp.seq, seq, Relation.Comp, DProp.new, cylindrify]
   constructor

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -14331,6 +14331,38 @@
   role      = {foundational},
   sources   = {Studies/GroenendijkStokhof1991.lean}
 }
+@incollection{gillies-2022,
+  author    = {Gillies, Anthony S.},
+  year      = {2022},
+  title     = {On {G}roenendijk and {S}tokhof's ``{D}ynamic {P}redicate {L}ogic''},
+  booktitle = {A Reader's Guide to Classic Papers in Formal Semantics},
+  editor    = {McNally, Louise and Szab{\'o}, Zolt{\'a}n Gendler},
+  series    = {Studies in Linguistics and Philosophy},
+  volume    = {100},
+  pages     = {121--153},
+  publisher = {Springer},
+  doi       = {10.1007/978-3-030-85308-2_8},
+  subfield  = {semantics/dynamic},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Dynamic/Update.lean}
+}
+
+@article{rothschild-yalcin-2016,
+  author    = {Rothschild, Daniel and Yalcin, Seth},
+  year      = {2016},
+  title     = {Three Notions of Dynamicness in Language},
+  journal   = {Linguistics and Philosophy},
+  volume    = {39},
+  number    = {4},
+  pages     = {333--355},
+  doi       = {10.1007/s10988-016-9188-1},
+  subfield  = {semantics/dynamic},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Dynamic/Update.lean}
+}
+
 @article{veltman-1996,
   author    = {Veltman, Frank},
   year      = {1996},


### PR DESCRIPTION
Executes the 2026-07-16 deep audit of the Update.lean spine (punchlist: scratch/update-audit-2026-07-16.md).
- CCP-owned classification (`CCP.IsTest`/`IsEliminative`/`IsDistributive`, dot-notation lemmas; kills the `IsTest` collision), dead-cluster culls, compiler-verified golfs, stale-pointer fixes.
- GS1991-only entailment section demoted into its study; PLA satisfaction layer grounded in the spine; `CCP.entails` drops its nonstandard guard (ABLE's D45 is the spine notion by definition).
- New keystones: subidentity/guard normal forms for tests at both faces, and the static-fragment characterization eliminative ∧ distributive ↔ lifted test filter (van Benthem 1986; Rothschild & Yalcin 2016; Gillies 2022 — new verified bib entries).