### PR TITLE
refactor(Semantics/Dynamic): base-free states as sets of possibilities

### DIFF
--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -11,48 +11,26 @@ live discourse referents), morphisms are `Transition`s, composition is
 world-pointwise relational composition. The identity and associativity
 laws are `Transition.lean`'s `id_comp`/`comp_id`/`comp_assoc`.
 
-The category locates the module's inhabitants. States over a context are
-not an independent structure: `State.presheaf` is the powerset functor
-applied fiberwise to the presheaf of environments
-(`presheafIsoEnvironments`), so level 1 is the `Set` effect read over
-the category of contexts, exactly as `Collapse.lean`'s level 0 is the
-same effect read over a point — and `Partial.lean`'s partial CCPs are
-the `Part` column. Under the identification, `State.restrict` is direct
-image along environment projections (`fiberOrderIsoProd_restrict`), the
-left adjoint of mathlib's `Set.image_preimage`/`Set.preimage_kernImage`
-triple: [lawvere-1969]'s quantifiers as adjoints, in [jacobs-1999]'s
-fibrational reading of contexts — the "indexed" picture `State.lean`
-cites via [visser-1998]. Syntax categories interpret into `Ctx`
-(`DRS/Category.lean`'s `sem`); the degenerate fiber at `∅` is
-[veltman-1996]'s update semantics (`State.fiberEmptyOrderIso`).
+The presheaf of state fibers is the composite of the environments
+presheaf with the powerset functor — definitionally, in this
+formulation: the predecessor proved the isomorphism
+(`presheafIsoEnvironments`); typing states at their environments makes
+it the definition (`State.presheaf`). Restriction is `Set.image` along
+environment weakening, the ∃-leg of mathlib's
+`Set.image_preimage`/`Set.preimage_kernImage` triple ([lawvere-1969]'s
+quantifiers as adjoints to weakening, as retold by [jacobs-1999]).
+Syntax categories interpret into `Ctx` (`DRS/Category.lean`); the fiber
+at `∅` is [veltman-1996]'s update semantics.
 
 ## Main definitions
 
 - `Ctx W M V`: bundled contexts, with a `Category` instance whose
   morphisms are `Transition`s between the bases.
-- `State.presheaf`: information states as a presheaf on the poset of
-  bases — the fiber over `X` is the states indexed at `X`, restriction is
-  `State.restrict`. Precedent: [abramsky-sadrzadeh-2014]'s presheaf of
-  basic DRSs over vocabulary–variable contexts, whose base category
-  additionally has relabelling morphisms; ours is the inclusions-only
-  fragment with model-theoretic fibers.
 - `environments`: the presheaf of world–assignment pairs at each
-  granularity — a model read over the category of contexts.
-- `State.presheafIsoEnvironments`: `State.presheaf` is the composite of
-  `environments` with the powerset functor.
-
-## Main results
-
-- `State.fiberOrderIsoProd_restrict`: under the fiber classification,
-  restriction is direct image along the environment projection.
-
-## Implementation notes
-
-Morphisms are a one-field structure wrapping `Transition` (the
-`RelCat.Hom` pattern): an unbundled `Hom` field breaks dot-notation on
-morphisms. The collapse functor to `RelCat` lives in `Collapse.lean`,
-because importing `RelCat` interferes with instance resolution for the
-functions category on `Type u`, which `State.presheaf` needs.
+  granularity — a set-valued indexed category in [jacobs-1999]'s sense,
+  its maps the semantic face of *weakening*. Precedent for the
+  states-as-presheaf reading: [abramsky-sadrzadeh-2014].
+- `State.presheaf`: the state fibers — `environments ⋙ Set`.
 
 ## References
 
@@ -96,31 +74,9 @@ instance : Category (Ctx W M V) where
 
 end Ctx
 
-/-! ### The state presheaf -/
+/-! ### The environments presheaf and the state fibers -/
 
 universe u v w
-
-/-- Information states form a presheaf on the poset of bases: the fiber
-over `X` is the states indexed at `X`, and restriction along `Y ⊆ X` is
-`State.restrict` — the presheaf laws are `restrict_base` and
-`restrict_restrict`. -/
-def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
-    (Finset V)ᵒᵖ ⥤ Type (max u v w) where
-  obj X := State.fiber W M X.unop
-  map {X Y} f := TypeCat.ofHom
-    fun I => ⟨I.val.restrict Y.unop, State.base_restrict I.val Y.unop⟩
-  map_id X := by
-    ext I : 3
-    apply Subtype.ext
-    obtain ⟨J, hJ⟩ := I
-    show J.restrict X.unop = J
-    rw [← hJ]
-    exact J.restrict_base
-  map_comp {X Y Z} h k := by
-    ext I : 3
-    exact Subtype.ext (I.val.restrict_restrict (leOfHom k.unop)).symm
-
-/-! ### The presheaf is a composite -/
 
 /-- The presheaf of environments: over `X`, world–assignment pairs at
 granularity `X`; restriction precomposes with the inclusion. A model read
@@ -134,74 +90,12 @@ def environments (W : Type u) (M : Type v) (V : Type w) :
   map {X Y} f := TypeCat.ofHom fun p =>
     ⟨p.1, fun v => p.2 ⟨v.1, leOfHom f.unop v.2⟩⟩
 
-section Classified
-variable {W : Type u} {M : Type v} {V : Type w} [Nonempty M]
-
-open scoped Classical in
-/-- Under the fiber classification, restriction is direct image along the
-environment projection (weakening) — the left adjoint of mathlib's
-`Set.image_preimage`/`Set.preimage_kernImage` triple: [lawvere-1969]'s
-quantifiers as left and right adjoints to weakening, as retold by
-[jacobs-1999]. -/
-theorem State.fiberOrderIsoProd_restrict {X Y : Finset V} (hYX : Y ⊆ X)
-    (I : State.fiber W M X) :
-    OrderDual.ofDual (State.fiberOrderIsoProd Y
-        ⟨I.val.restrict Y, State.base_restrict I.val Y⟩) =
-      (fun p : W × ((↑X : Set V) → M) =>
-        (p.1, fun v : (↑Y : Set V) => p.2 ⟨v.1, hYX v.2⟩)) ''
-        OrderDual.ofDual (State.fiberOrderIsoProd X I) := by
-  ext ⟨w, h⟩
-  constructor
-  · intro hmem
-    have hg : (↑Y : Set V).restrict (fun v => if hv : v ∈ (↑Y : Set V) then
-        h ⟨v, hv⟩ else Classical.arbitrary M) = h :=
-      funext fun v => dif_pos v.2
-    rw [← hg] at hmem
-    obtain ⟨k, hk, hkg⟩ := State.mem_restrict.mp
-      (State.mem_fiberOrderIsoProd.mp hmem)
-    refine ⟨(w, (↑X : Set V).restrict k),
-      State.mem_fiberOrderIsoProd.mpr hk, ?_⟩
-    refine Prod.ext rfl ?_
-    rw [← hg]
-    funext v
-    exact hkg v.2
-  · rintro ⟨⟨w', e⟩, hmem, heq⟩
-    obtain ⟨rfl, rfl⟩ := Prod.mk.injEq .. |>.mp heq
-    have hk : (↑X : Set V).restrict (fun v => if hv : v ∈ (↑X : Set V) then
-        e ⟨v, hv⟩ else Classical.arbitrary M) = e :=
-      funext fun v => dif_pos v.2
-    rw [← hk] at hmem
-    have hYk : (↑Y : Set V).restrict (fun v => if hv : v ∈ (↑X : Set V) then
-        e ⟨v, hv⟩ else Classical.arbitrary M) =
-        fun v : (↑Y : Set V) => e ⟨v.1, hYX v.2⟩ :=
-      funext fun v => dif_pos (hYX v.2)
-    rw [← hYk]
-    exact State.mem_fiberOrderIsoProd.mpr
-      (State.mem_restrict.mpr
-        ⟨_, State.mem_fiberOrderIsoProd.mp hmem, Set.eqOn_refl _ _⟩)
-
-/-- `State.presheaf` is not primitive: it is the composite of the
-environments presheaf with the powerset functor — the fiber
-classification `State.fiberOrderIsoProd`, naturally in the base. The
-`Set` here is the same monad whose Kleisli category is level 0
-(`Collapse.lean`): the presheaf face and the monadic face of dynamic
-semantics are one structure. -/
-noncomputable def State.presheafIsoEnvironments
-    (W : Type u) (M : Type v) (V : Type w) [Nonempty M] :
-    State.presheaf W M V ≅ environments W M V ⋙ ofTypeFunctor Set :=
-  NatIso.ofComponents
-    (fun X => ((State.fiberOrderIsoProd X.unop).toEquiv.trans
-      OrderDual.ofDual).toIso)
-    (by
-      intro X Y f
-      ext I : 3
-      show OrderDual.ofDual (State.fiberOrderIsoProd Y.unop
-          ⟨I.val.restrict Y.unop, State.base_restrict I.val Y.unop⟩) = _
-      rw [State.fiberOrderIsoProd_restrict (leOfHom f.unop) I]
-      show _ = Functor.map _ (OrderDual.ofDual (State.fiberOrderIsoProd X.unop I))
-      rw [Set.fmap_eq_image]
-      rfl)
-
-end Classified
+/-- The state fibers as a presheaf on the poset of bases: the powerset
+functor applied fiberwise to the environments — by definition, in this
+formulation. The fiber over `X` is `Set (W × (↑X → M))`; restriction is
+direct image along environment weakening. -/
+def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
+    (Finset V)ᵒᵖ ⥤ Type (max u v w) :=
+  environments W M V ⋙ ofTypeFunctor Set
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Dynamic.Category
+import Linglib.Semantics.Dynamic.Update
 import Mathlib.Data.Set.Functor
 import Mathlib.CategoryTheory.Category.KleisliCat
 import Mathlib.CategoryTheory.Category.RelCat
@@ -30,18 +31,14 @@ continuation-based systems choose further effects.
 
 ## Main definitions
 
-- `Ctx.agreeSetoid`: `Possibility.agreeSetoid` at the context's base.
 - `Ctx.collapse`: the functor `Ctx W M V ⥤ RelCat` sending a context to
-  its possibilities up to base-agreement and a transition to its
-  `toUpdate` relation.
+  its environment space and a transition to its world-threaded relation.
 - `liftEquiv`: `Update S ≃ sSupHom (Set S) (Set S)`.
 - `relCatEquivKleisli`: `RelCat ≌ KleisliCat Set`. [UPSTREAM] candidate —
   pure category theory, absent from mathlib.
 
 ## Main results
 
-- `Ctx.collapseRel_id`, `Ctx.collapseRel_comp`: identity and sequencing
-  collapse to equality and relational composition on agreement classes.
 - `Ctx.collapse_faithful`: a transition is recoverable from its collapsed
   relation; what the collapse forgets is the base-indexing of objects.
 - `seq_eq_kleisliComp`, `test_top_eq_pure`, `lift_eq_bind`: the monadic
@@ -52,12 +49,10 @@ continuation-based systems choose further effects.
 
 ## Implementation notes
 
-The quotient is forced: `toUpdate` sends `𝟙 X` to agreement-on-`X`, not
-to equality, so the collapse is lawful only on base-agreement classes —
-`supported_left`/`supported_right` are exactly the congruence conditions.
-This file is separate from `Category.lean` because importing `RelCat` (a
-type synonym for `Type u` carrying the relations category) interferes
-with instance resolution for the functions category on `Type u`.
+The predecessor collapsed through base-agreement classes of total
+assignments — the quotient was forced because the untyped `toUpdate` sent
+identities to agreement-on-`X` rather than equality. Typed transitions
+are unital, so the collapse lands in `RelCat` directly, with no setoid.
 
 ## References
 
@@ -76,95 +71,47 @@ namespace Ctx
 
 variable {W M V : Type*} {X Y Z : Ctx W M V}
 
-/-- Agreement on the context's base: `Possibility.agreeSetoid` at `↑X.base`. -/
-abbrev agreeSetoid (X : Ctx W M V) : Setoid (Possibility W V M) :=
-  Possibility.agreeSetoid ↑X.base
-
-/-- `toUpdate` descends to base-agreement classes: `supported_left` and
-`supported_right` are precisely the congruence conditions. -/
-def collapseRel (u : X ⟶ Y) :
-    Quotient X.agreeSetoid → Quotient Y.agreeSetoid → Prop :=
-  Quotient.lift₂ (fun p q => u.t.toUpdate p q)
-    fun p₁ q₁ p₂ q₂ hp hq => propext <| by
-      simp only [Transition.toUpdate]
-      rw [hp.1, hq.1]
-      exact and_congr Iff.rfl
-        ((u.t.supported_left hp.2).trans (u.t.supported_right hq.2))
-
-@[simp] theorem collapseRel_mk (u : X ⟶ Y)
-    (p q : Possibility W V M) :
-    collapseRel u (⟦p⟧) (⟦q⟧) ↔ u.t.toUpdate p q := Iff.rfl
-
-/-- On base-agreement classes the identity transition collapses to
-equality — the unitality the raw `toUpdate` lacks. -/
-theorem collapseRel_id (X : Ctx W M V) (p q : Quotient X.agreeSetoid) :
-    collapseRel (𝟙 X) p q ↔ p = q := by
-  induction p using Quotient.ind
-  induction q using Quotient.ind
-  rename_i p q
-  constructor
-  · rintro ⟨hw, ha⟩
-    exact Quotient.sound ⟨hw, ha⟩
-  · intro h
-    obtain ⟨hw, ha⟩ := Quotient.exact h
-    exact ⟨hw, ha⟩
-
-/-- On base-agreement classes sequencing collapses to relational
-composition. -/
-theorem collapseRel_comp (u : X ⟶ Y) (v : Y ⟶ Z)
-    (p : Quotient X.agreeSetoid) (r : Quotient Z.agreeSetoid) :
-    collapseRel (u ≫ v) p r ↔
-      ∃ q, collapseRel u p q ∧ collapseRel v q r := by
-  induction p using Quotient.ind
-  induction r using Quotient.ind
-  rename_i p r
-  constructor
-  · intro h
-    have h' : Update.seq u.t.toUpdate v.t.toUpdate p r := by
-      rw [← Transition.toUpdate_comp, ← t_comp]
-      exact h
-    obtain ⟨k, hk₁, hk₂⟩ := h'
-    exact ⟨(⟦k⟧), hk₁, hk₂⟩
-  · rintro ⟨q, hq₁, hq₂⟩
-    induction q using Quotient.ind
-    rename_i k
-    show (u ≫ v).t.toUpdate p r
-    rw [t_comp, Transition.toUpdate_comp]
-    exact ⟨k, hq₁, hq₂⟩
-
-/-- **The one-object collapse**: forget the bases, keeping possibilities up
-to base-agreement. Functoriality on composition is `toUpdate_comp`; on
-identities it is `Quotient.sound`/`exact` — which is why the quotient is
-forced: on raw possibilities `toUpdate (𝟙 X)` is agreement-on-`X`, not
-equality. -/
+/-- **The one-object collapse**: forget the base-indexing, sending a
+context to its environment space and a transition to its world-threaded
+relation. Unital by typing — no quotient needed. -/
 def collapse (W M V : Type*) : Ctx W M V ⥤ RelCat where
-  obj X := Quotient X.agreeSetoid
-  map u := .ofRel {pq | collapseRel u pq.1 pq.2}
+  obj X := W × ((↑X.base : Set V) → M)
+  map {X Y} u := .ofRel {p | p.1.1 = p.2.1 ∧ u.t.rel p.1.1 p.1.2 p.2.2}
   map_id X := by
     apply RelCat.Hom.ext
-    ext ⟨p, q⟩
-    rw [Set.mem_setOf_eq, RelCat.Hom.rel_id]
-    exact (collapseRel_id X p q).trans SetRel.mem_id.symm
+    ext ⟨⟨w, e⟩, ⟨w', e'⟩⟩
+    show (w = w' ∧ e = e') ↔ _
+    constructor
+    · rintro ⟨rfl, rfl⟩
+      exact SetRel.mem_id.mpr rfl
+    · intro h
+      exact Prod.ext_iff.mp (SetRel.mem_id.mp h)
   map_comp {X Y Z} u v := by
     apply RelCat.Hom.ext
-    ext ⟨p, r⟩
-    rw [Set.mem_setOf_eq, RelCat.Hom.rel_comp, collapseRel_comp]
+    ext ⟨⟨w, e⟩, ⟨w'', e''⟩⟩
     constructor
-    · rintro ⟨q, h₁, h₂⟩
-      exact SetRel.prodMk_mem_comp h₁ h₂
-    · rintro ⟨q, h₁, h₂⟩
-      exact ⟨q, h₁, h₂⟩
+    · rintro ⟨hw, k, huk, hkv⟩
+      exact SetRel.prodMk_mem_comp
+        (show ((w, e), (w, k)) ∈ _ from ⟨rfl, huk⟩)
+        (show ((w, k), (w'', e'')) ∈ _ from ⟨hw, hkv⟩)
+    · rintro ⟨⟨w', k⟩, ⟨hw1, huk⟩, hw2, hkv⟩
+      refine ⟨hw1.trans hw2, k, huk, ?_⟩
+      rw [hw1]
+      exact hkv
 
-/-- The collapse is faithful: a transition is recoverable from its relation
-on base-agreement classes. What the collapse forgets is only the
+/-- The collapse is faithful: a transition is recoverable from its
+world-threaded relation. What the collapse forgets is only the
 base-indexing of the objects. -/
 instance collapse_faithful : (collapse W M V).Faithful where
   map_injective {X Y} {u v} h := by
-    have hs : ∀ p q : Possibility W V M, u.t.toUpdate p q ↔ v.t.toUpdate p q :=
-      fun p q => Set.ext_iff.mp (congrArg RelCat.Hom.rel h) (⟦p⟧, ⟦q⟧)
+    have hs : ∀ (w : W) e e', u.t.rel w e e' ↔ v.t.rel w e e' := by
+      intro w e e'
+      have h2 : (w = w ∧ u.t.rel w e e') ↔ (w = w ∧ v.t.rel w e e') :=
+        Set.ext_iff.mp (congrArg RelCat.Hom.rel h) ((w, e), (w, e'))
+      exact ⟨fun hr => (h2.mp ⟨rfl, hr⟩).2, fun hr => (h2.mpr ⟨rfl, hr⟩).2⟩
     refine Hom.ext (Transition.ext ?_)
-    funext w f g
-    exact propext (by simpa [Transition.toUpdate] using hs ⟨w, f⟩ ⟨w, g⟩)
+    funext w e e'
+    exact propext (hs w e e')
 
 end Ctx
 

--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -113,15 +113,13 @@ instance : Category (Ctx L V) where
 of contexts to the semantic one, identically on objects and a DRS to its
 transition — and functoriality on composition is the Merging Lemma, its
 capture-freshness side condition derived from the visibility invariant. -/
-def sem (W M : Type*) [L.Structure M] :
+def sem (W M : Type*) [L.Structure M] [Nonempty M] :
     Ctx L V ⥤ DynamicSemantics.Ctx W M V where
   obj X := ⟨X.base⟩
   map {X Y} u := ⟨(u.drs.transition W X.base u.presup).copy rfl u.target⟩
   map_id X := by
     apply DynamicSemantics.Ctx.Hom.ext
-    show ((DRS.empty.transition W X.base _).copy rfl _) = Transition.id X.base
-    rw [DRS.transition_empty]
-    exact (Transition.copy_copy _ _ _ _ _).trans (Transition.copy_rfl _)
+    exact DRS.transition_empty W X.base _ _
   map_comp {X Y Z} u v := by
     apply DynamicSemantics.Ctx.Hom.ext
     have hocc : Condition.occL u.drs.conditions ⊆ Y.base := by

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -40,7 +40,7 @@ instance of functoriality (`Transition.apply_comp`).
 -/
 
 open FirstOrder FirstOrder.Language
-open DynamicSemantics (Possibility State Transition baseSupported_of_iff)
+open DynamicSemantics (Possibility State Transition)
 
 namespace DRT
 
@@ -180,30 +180,31 @@ theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.fv ⊆ X)
 /-- A well-formed DRS denotes a transition from its context base to the
 base grown by its universe — `K.fv ⊆ X` is the *referential presupposition*
 ([kamp-vangenabith-reyle-2011], Def. 27(i)). -/
-def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V) (hK : K.fv ⊆ X) :
-    Transition W M X (X ∪ K.referents) where
-  rel _ f g := DRS.toRelAt X K f g
-  grow := Finset.subset_union_left
-  supported_left _ _ _ _ h := DRS.toRelAt_congr_left X K h
-  supported_right _ _ _ _ h := DRS.toRelAt_congr_right K hK h
+theorem DRS.readsAt_toRelAt {W : Type*} (X : Finset V) (K : DRS L V) :
+    Transition.ReadsAt (W := W) X fun _ => DRS.toRelAt (M := M) X K :=
+  fun _ _ _ _ h => DRS.toRelAt_congr_left X K h
 
-/-- The empty DRS denotes the identity transition. -/
-theorem DRS.transition_empty (W : Type*) (X : Finset V)
-    (h : (DRS.empty : DRS L V).fv ⊆ X) :
-    DRS.empty.transition (M := M) W X h =
-      (Transition.id X).copy rfl (Finset.union_empty X).symm := by
-  apply Transition.ext
-  funext w f g
-  rw [Transition.rel_copy]
-  show (Set.EqOn g f ↑X ∧ _) = _
-  simp [Transition.id, Set.eqOn_comm]
+theorem DRS.writesAt_toRelAt {W : Type*} {X : Finset V} (K : DRS L V)
+    (hK : K.fv ⊆ X) :
+    Transition.WritesAt (W := W) (X ∪ K.referents)
+      fun _ => DRS.toRelAt (M := M) X K :=
+  fun _ _ _ _ h => DRS.toRelAt_congr_right K hK h
+
+/-- A well-formed DRS as a transition, via the total–typed bridge: read
+at `X`, write at `X ∪ U`. The referential presupposition documents
+Def. 24's domain condition; the congruence lemmas above are the bridge's
+support hypotheses. -/
+def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V)
+    (_hK : K.fv ⊆ X) : Transition W M X (X ∪ K.referents) :=
+  Transition.ofTotal Finset.subset_union_left fun _ => DRS.toRelAt X K
 
 /-- Established referents persist along a DRS transition. -/
 theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
     (hK : K.fv ⊆ X) : (K.transition (M := M) W X hK).IsExtension := by
-  intro w f g h
+  rintro w e e' ⟨f, g, rfl, rfl, hrel⟩
   obtain ⟨U, conds⟩ := K
-  exact h.1
+  funext v
+  exact (hrel.1 v.2).symm
 
 /-- Repackaging a DRS transition along an equality of context bases is the
 transition at the new base. -/
@@ -213,21 +214,36 @@ theorem DRS.transition_copy (W : Type*) {X X' : Finset V} (K : DRS L V)
   subst hX; rfl
 
 /-- The information state a proper DRS expresses
-([kamp-vangenabith-reyle-2011], Def. 22): act on the minimal state. -/
+([kamp-vangenabith-reyle-2011], Def. 22): act on the initial state. -/
 def DRS.state (W : Type*) (K : DRS L V) (hK : K.IsProper) : State W V M :=
-  (K.transition W ∅ (Finset.subset_empty.mpr hK)).apply ⊥
+  (K.transition W ∅ (Finset.subset_empty.mpr hK)).applyState State.initial
 
-@[simp] theorem DRS.state_base (W : Type*) (K : DRS L V) (hK : K.IsProper) :
-    (K.state (M := M) W hK).base = K.referents := by
-  simp [DRS.state]
+/-- The state a DRS expresses lives in its referents' stratum. -/
+theorem DRS.uniformAt_state (W : Type*) (K : DRS L V) (hK : K.IsProper) :
+    State.UniformAt K.referents (K.state (M := M) W hK) := by
+  rw [← Finset.empty_union K.referents]
+  exact Transition.uniformAt_applyState
+    (K.transition W ∅ (Finset.subset_empty.mpr hK)) State.initial
 
-/-- The characteristic membership form: a possibility survives in `⟦K⟧ˢ` iff
-some input reaches its assignment. -/
-@[simp] theorem DRS.mem_state {W : Type*} {K : DRS L V} {hK : K.IsProper}
-    {w : W} {g : V → M} :
-    (⟨w, g⟩ : Possibility W V M) ∈ K.state W hK ↔ ∃ e, DRS.toRelAt ∅ K e g := by
-  simp only [DRS.state, Transition.mem_apply]
-  exact ⟨fun ⟨e, _, he⟩ => ⟨e, he⟩, fun ⟨e, he⟩ => ⟨e, Set.mem_univ _, he⟩⟩
+/-- The characteristic membership form: a point survives in `⟦K⟧ˢ` iff it
+lives on the referents and its values are reached from some input. -/
+theorem DRS.mem_state {W : Type*} {K : DRS L V} {hK : K.IsProper}
+    {q : Possibility W V (Option M)} :
+    q ∈ K.state W hK ↔ q.dom = (↑(∅ ∪ K.referents) : Set V) ∧
+      ∃ f g : V → M, DRS.toRelAt ∅ K f g ∧
+        ∀ v : (↑(∅ ∪ K.referents) : Set V), q.assignment v.1 = some (g v.1) := by
+  constructor
+  · rintro ⟨hq, p, hpI, hp, hw, e, e', he, he', f, g, hf, hg, hrel⟩
+    refine ⟨hq, f, g, hrel, fun v => ?_⟩
+    rw [he' v]
+    exact congrArg some (congrFun hg v).symm
+  · rintro ⟨hq, f, g, hrel, hvals⟩
+    refine ⟨hq, ⟨q.world, fun _ => none⟩, fun _ => rfl, ?_, rfl,
+      (↑(∅ : Finset V) : Set V).restrict f,
+      (↑(∅ ∪ K.referents) : Set V).restrict g,
+      fun v => absurd v.2 (by simp), fun v => hvals v, f, g, rfl, rfl, hrel⟩
+    ext v
+    simp [Possibility.dom]
 
 /-! ### Base invariance
 
@@ -430,9 +446,11 @@ theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
     (K₁.transition (M := M) W X h₁).comp (K₂.transition W (X ∪ K₁.referents) h₂) =
       ((K₁.merge K₂).transition W X (DRS.fv_merge_subset h₁ h₂)).copy rfl
         (by rw [DRS.referents_merge, ← Finset.union_assoc]) := by
-  ext w f g
-  simp only [Transition.rel_copy, Transition.comp, DRS.transition,
-    DRS.toRelAt_merge K₁ K₂ h₁ hfresh, DynamicSemantics.Update.seq]
+  unfold DRS.transition
+  rw [Transition.ofTotal_comp (DRS.readsAt_toRelAt (X ∪ K₁.referents) K₂),
+    Transition.ofTotal_copy]
+  exact Transition.ofTotal_congr _ _
+    (funext fun _ => (DRS.toRelAt_merge K₁ K₂ h₁ hfresh).symm)
 
 /-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
 DRS's transition to the state a proper context DRS expresses yields the
@@ -441,15 +459,15 @@ transition-level Merging Lemma. -/
 theorem DRS.state_merge (W : Type*) (K₁ K₂ : DRS L V) (h₁ : K₁.IsProper)
     (h₂ : K₂.fv ⊆ K₁.referents)
     (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
-    (K₂.transition (M := M) W K₁.referents h₂).apply (K₁.state W h₁) =
+    (K₂.transition (M := M) W K₁.referents h₂).applyState (K₁.state W h₁) =
       (K₁.merge K₂).state W (DRS.isProper_merge h₁ h₂) := by
   simp only [DRS.state]
   rw [← DRS.transition_copy (M := M) W K₂ (Finset.empty_union _)
       (h₂.trans Finset.subset_union_right) h₂,
-    Transition.apply_copy, ← Transition.apply_comp,
+    Transition.applyState_copy, ← Transition.applyState_comp,
     DRS.transition_merge (M := M) W K₁ K₂ (Finset.subset_empty.mpr h₁)
       (h₂.trans Finset.subset_union_right) hfresh,
-    Transition.apply_copy]
+    Transition.applyState_copy]
 
 /-! ### Reconciliation with the flat semantics
 

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -198,6 +198,29 @@ def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V)
     (_hK : K.fv ⊆ X) : Transition W M X (X ∪ K.referents) :=
   Transition.ofTotal Finset.subset_union_left fun _ => DRS.toRelAt X K
 
+/-- The empty DRS denotes the identity transition, repackaged to its
+source: interpretation sends DRT's unit to the semantic unit. Nonempty
+entities are needed — under extension-typing an empty domain separates
+the empty box from the identity. -/
+theorem DRS.transition_empty [Nonempty M] (W : Type*) (X : Finset V)
+    (h : (DRS.empty : DRS L V).fv ⊆ X)
+    (he : X ∪ (DRS.empty : DRS L V).referents = X) :
+    (DRS.empty.transition (M := M) W X h).copy rfl he =
+      Transition.id X := by
+  unfold DRS.transition
+  rw [Transition.ofTotal_copy]
+  apply Transition.ext
+  funext w e e'
+  apply propext
+  constructor
+  · rintro ⟨f, g, rfl, rfl, hfg, -⟩
+    exact funext fun v => (hfg v.2).symm
+  · rintro rfl
+    refine ⟨fun v => if hv : v ∈ (↑X : Set V) then e ⟨v, hv⟩
+      else Classical.arbitrary M, fun v => if hv : v ∈ (↑X : Set V) then e ⟨v, hv⟩
+      else Classical.arbitrary M, funext fun v => dif_pos v.2,
+      funext fun v => dif_pos v.2, fun v _ => rfl, trivial⟩
+
 /-- Established referents persist along a DRS transition. -/
 theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
     (hK : K.fv ⊆ X) : (K.transition (M := M) W X hK).IsExtension := by

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -58,9 +58,9 @@ stratum they reduce to `⊇` and `⊆` respectively
 
 `State` is an abbreviation, so `Set`'s complete lattice is available and
 `⊑`/`⪯` are scoped relations rather than instances. Neither is
-antisymmetric on raw sets (adding an ancestor of an existing point is
-invisible to both); antisymmetry holds on each uniform stratum, where
-they coincide with `⊇`/`⊆`. The predecessor of this file classified its
+antisymmetric on raw sets (adding a comparable point is invisible — an
+ancestor for `⪯`, a descendant for `⊑`); antisymmetry holds on each
+uniform stratum, where they coincide with `⊇`/`⊆`. The predecessor of this file classified its
 fibers as `(Set (W × (↑X → M)))ᵒᵈ` — the dual lands here because its
 order was Def. 25's, matching `⊑`, not `⪯`.
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,724 +1,239 @@
 import Linglib.Semantics.Dynamic.Possibility
 import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Finset.Lattice.Lemmas
-import Mathlib.Data.Finset.Piecewise
 import Mathlib.Data.Set.Function
-import Mathlib.Order.BoundedOrder.Basic
-import Mathlib.Order.Hom.CompleteLattice
-import Mathlib.Order.Lattice
 
 /-!
-# Indexed information states
+# Information states
 
-An *information state* relative to a *base* `X` — a finite set of live
-discourse referents — is an `X`-supported set of possibilities
-(`Possibility.lean`). The base is the "context as storage" dimension of
-dynamic meaning: finer than a proposition, coarser than syntax
-([kamp-vangenabith-reyle-2011]'s Partee-marbles argument). Level-0 states are plain,
-unindexed sets of possibilities (`Update.lean`); the transitions
-acting on states live in `Transition.lean`.
+An *information state* is a set of world–assignment pairs, with the
+assignments partial — [kamp-vangenabith-reyle-2011]'s Def. 23 (sets of
+pairs of a world and an embedding), the form the field standardly
+assumes: the absurd state is `∅`, the initial state is `W × {g_⊤}`
+(`initial`), and the lattice of states is `Set`'s. Partiality is by
+`Option` ([elliott-sudo-2025]'s Def. 3.1: total functions into
+`D ∪ {∗}`), so no component of a state carries a proof obligation.
+
+There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
+(`UniformAt`), and a base is the index of a fiber, not part of the data.
+Points with domain `X` are world–`X`-environment pairs, constructively
+(`Possibility.domEquiv` — the total-assignment rendering needed choice
+and an inhabitant of `M` to recover this). Informativeness
+([kamp-vangenabith-reyle-2011] Def. 25) is *subsistence*: every point of
+the weaker state has a descendant in the stronger — the order of
+[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9 and
+[elliott-sudo-2025] Def. 3.3, promoted here from the bilateral system to
+the root.
 
 ## Main definitions
 
-- `BaseSupported X S`: `S` is a cylinder at granularity `X` — a preimage
-  along `Possibility.proj`, so membership depends on assignments only
-  through their values at `X`.
-- `State W V M`: a base with an `X`-supported carrier, ordered by
-  informativeness, with the minimal state Λ as `⊥` and consistent merge
-  as `⊔`.
-- `State.prop`: the proposition a state determines.
-- `State.restrict`, `State.weaken`, `State.kernRestrict`: the transports
-  along base inclusion — [lawvere-1969]'s quantifier triple.
-- `State.fiberEquiv`, `State.fiberOrderIso`: the states indexed at `X`, as
-  propositions over the `X`-collapsed state space.
+- `Possibility.dom`, `Possibility.Descendant`: the defined referents of
+  a partial point, and same-world graph-extension.
+- `State W V M`: information states; `initial`, with `∅` the absurd
+  state.
+- `Subsists` (`≺`), `subsistsIn` (`⪯`): the informativeness order.
+- `worlds`, `Familiar`: worldly content and familiarity.
+- `State.UniformAt`, `Possibility.domEquiv`: the indexed stratum and its
+  constructive classification.
+- `Possibility.restrict`, `State.restrict`, `State.randomAssign`:
+  domain restriction (pointwise, by direct image) and random assignment.
 
 ## Main results
 
-- `le_iff_projection`, `mem_sup_iff_projection`: the chapter's projection
-  and choice-function forms of order and merge coincide with the
-  componentwise ones — support supplies the witnesses.
-- `baseSupported_iff`, `BaseSupported.preimage_image_mk`: support is
-  *saturation* for `Possibility.agreeSetoid ↑X`.
-- `prop_restrict`, `le_restrict_iff`: restriction never changes the
-  proposition, and is the universal `Y`-supported approximation.
-- `Compatible.restrict_sup_left`, `sup_le_of_restrict_eq`: consistent
-  merge is sheaf gluing for the presheaf of states
-  ([abramsky-sadrzadeh-2014]'s semantic unification), and the least one;
-  `exists_ne_of_restrict_eq`: the gluing is not unique — restriction
-  forgets cross-referent correlation.
-- `weaken_le_iff`, `kernRestrict_le_iff`, `restrict_weaken`,
-  `restrict_sup_weaken`: the adjunctions `kernRestrict ⊣ weaken ⊣
-  restrict`, Beck–Chevalley, and Frobenius — the fibers form a
-  hyperdoctrine over the category of contexts ([jacobs-1999]).
-- `fiberOrderIsoProd`, `fiberEmptyOrderIso`: the fiber at `X` classified
-  as propositions over world–`X`-assignment pairs ([heim-1982]'s
-  satisfaction sets), degenerating at `X = ∅` to bare propositions
-  ([veltman-1996]'s update-semantics states).
-
-## Implementation notes
-
-*Indexed* is Jacobs' term, via [visser-1998]'s "indexed" treatment of
-predicate-logic semantics: meanings carry their variable declaration —
-the pair ⟨base, carrier⟩ — rather than living over one global assignment
-space. The chapter calls the declaration a *base*; type theory calls it
-a basis.
-
-The chapter's partial embeddings with domain `X` are rendered as total
-assignments with `X`-supported membership; Def. 25's informativeness
-order, Def. 26's consistent merge, and Def. 23(iv)'s minimal state then
-collapse to order theory (`PartialOrder`, `SemilatticeSup`, `OrderBot`).
-
-`State` gets a `Membership` instance rather than `SetLike`: the coe to
-carriers is not injective (`Set.univ` is supported at every base), and
-`Filter` is the precedent. The projection ladder carrier → agreement
-classes (`fiberEquiv`) → worlds (`prop`) forgets in two documented steps;
-[muskens-van-benthem-visser-2011]'s propositions-over-a-state-space
-picture is the middle rung, at granularity `X`.
+- `subsistsIn_restrict`: restriction only forgets — the restricted state
+  subsists in the original.
+- `uniformAt_initial`: the initial state is the empty-base fiber.
 
 ## References
 
-- [kamp-vangenabith-reyle-2011], Defs. 22–26
+- [kamp-vangenabith-reyle-2011], Defs. 23, 25
+- [groenendijk-stokhof-veltman-1996], [elliott-sudo-2025]
 - [heim-1982]
-- [muskens-van-benthem-visser-2011], [abramsky-sadrzadeh-2014]
-- [lawvere-1969], [jacobs-1999]
 -/
 
 namespace DynamicSemantics
 
-variable {W V M : Type*} {X Y : Finset V} {S T : Set (Possibility W V M)}
+variable {W V M : Type*}
 
-/-! ### Base-supported sets -/
+/-! ### Partial points -/
 
-/-- A set of possibilities is *supported* on `X` when it is a *cylinder*
-at granularity `X`: a preimage along `Possibility.proj`. Membership then
-depends on the assignment only through its values at `X`
-(`BaseSupported.mem_iff`). -/
-def BaseSupported (X : Finset V) (S : Set (Possibility W V M)) : Prop :=
-  S ∈ Set.range (Set.preimage (Possibility.proj (↑X : Set V)))
+namespace Possibility
 
-/-- Introduction form: supply the membership-invariance iff. -/
-theorem baseSupported_of_iff
-    (h : ∀ ⦃w : W⦄ ⦃f g : V → M⦄, Set.EqOn f g ↑X →
-      ((⟨w, f⟩ : Possibility W V M) ∈ S ↔ ⟨w, g⟩ ∈ S)) :
-    BaseSupported X S := by
-  refine ⟨Possibility.proj (↑X : Set V) '' S, ?_⟩
-  refine Set.Subset.antisymm ?_ (Set.subset_preimage_image _ _)
-  rintro ⟨w, g⟩ ⟨⟨w', f⟩, hf, heq⟩
-  obtain ⟨rfl, h2⟩ := Prod.ext_iff.mp heq
-  exact (h (Set.restrict_eq_restrict_iff.mp h2)).mp hf
+/-- The referents a partial point defines — Def. 23's `Dom(f)`. -/
+def dom (p : Possibility W V (Option M)) : Set V :=
+  {v | (p.assignment v).isSome}
 
-/-- Elimination form: membership is invariant under agreement on the base. -/
-theorem BaseSupported.mem_iff (h : BaseSupported X S) {w : W} {f g : V → M}
-    (hfg : Set.EqOn f g ↑X) :
-    (⟨w, f⟩ : Possibility W V M) ∈ S ↔ ⟨w, g⟩ ∈ S := by
-  obtain ⟨T, rfl⟩ := h
-  exact iff_of_eq (congrArg (· ∈ T) (Possibility.proj_eq_proj_iff.mpr ⟨rfl, hfg⟩))
+@[simp] theorem mem_dom {p : Possibility W V (Option M)} {v : V} :
+    v ∈ p.dom ↔ (p.assignment v).isSome := Iff.rfl
 
-/-- Cylinders coarsen: precompose with the restriction of environments. -/
-theorem BaseSupported.mono (h : BaseSupported X S) (hXY : X ⊆ Y) :
-    BaseSupported Y S := by
-  obtain ⟨T, rfl⟩ := h
-  exact ⟨(fun e : W × ((↑Y : Set V) → M) =>
-    (e.1, fun v : (↑X : Set V) => e.2 ⟨v.1, hXY v.2⟩)) ⁻¹' T, rfl⟩
+/-- `q` is a *descendant* of `p` ([elliott-sudo-2025], Def. 3.3): same
+world, and `q`'s assignment extends `p`'s wherever the latter is defined
+([groenendijk-stokhof-veltman-1996]'s graph-extension). -/
+def Descendant (p q : Possibility W V (Option M)) : Prop :=
+  p.world = q.world ∧ ∀ x e, p.assignment x = some e → q.assignment x = some e
 
-/-- Preimages intersect: cylinders are closed under intersection. -/
-theorem BaseSupported.inter (hS : BaseSupported X S) (hT : BaseSupported X T) :
-    BaseSupported X (S ∩ T) := by
-  obtain ⟨A, rfl⟩ := hS
-  obtain ⟨B, rfl⟩ := hT
-  exact ⟨A ∩ B, rfl⟩
+theorem Descendant.refl (p : Possibility W V (Option M)) :
+    p.Descendant p :=
+  ⟨rfl, fun _ _ h => h⟩
 
-/-- A set is supported on `X` iff membership is invariant under agreement on
-`X`: `BaseSupported X` is saturation for `Possibility.agreeSetoid ↑X`. -/
-theorem baseSupported_iff :
-    BaseSupported X S ↔
-      ∀ ⦃p q⦄, Possibility.agreeSetoid (↑X : Set V) p q → (p ∈ S ↔ q ∈ S) := by
-  constructor
-  · rintro h ⟨w, f⟩ ⟨w', g⟩ ⟨rfl, hfg⟩
-    exact h.mem_iff hfg
-  · intro h
-    exact baseSupported_of_iff fun _ _ _ hfg => h ⟨rfl, hfg⟩
+theorem Descendant.trans {p q r : Possibility W V (Option M)}
+    (hpq : p.Descendant q) (hqr : q.Descendant r) : p.Descendant r :=
+  ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
 
-/-- Point form of `BaseSupported.mem_iff`: membership is invariant on
-agreement classes. -/
-theorem BaseSupported.mem_congr (h : BaseSupported X S) {p q : Possibility W V M}
-    (hpq : Possibility.agreeSetoid (↑X : Set V) p q) : p ∈ S ↔ q ∈ S :=
-  baseSupported_iff.mp h hpq
+/-- Descendance grows the domain. -/
+theorem Descendant.dom_subset {p q : Possibility W V (Option M)}
+    (h : p.Descendant q) : p.dom ⊆ q.dom := fun v hv => by
+  obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
+  exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
 
-/-- The saturation round trip: a supported set is the preimage of its image
-in the collapsed state space. -/
-theorem BaseSupported.preimage_image_mk (h : BaseSupported X S) :
-    Quotient.mk (Possibility.agreeSetoid ↑X) ⁻¹' (Quotient.mk _ '' S) = S :=
-  Set.Subset.antisymm (fun _ ⟨_, hq, hqp⟩ => (h.mem_congr (Quotient.exact hqp)).mp hq)
-    (Set.subset_preimage_image _ _)
+end Possibility
 
 /-! ### Information states -/
 
-/-- An information state ([kamp-vangenabith-reyle-2011], Defs. 22–23): a base
-`X` of live discourse referents together with an `X`-supported set of
-possibilities. -/
-@[ext] structure State (W V M : Type*) where
-  /-- The live discourse referents (the chapter's base `X`). -/
-  base : Finset V
-  /-- The possibilities compatible with the information. -/
-  carrier : Set (Possibility W V M)
-  /-- Membership depends on assignments only through their values at `base`. -/
-  supported : BaseSupported base carrier
+/-- An information state: a set of world–assignment pairs, the
+assignments partial (Def. 23). The absurd state is `∅`; the lattice of
+states is `Set`'s. -/
+abbrev State (W V M : Type*) := Set (Possibility W V (Option M))
+
+/-- The initial information state `W × {g_⊤}`: every world live, no
+referent defined. -/
+def State.initial : State W V M := {p | ∀ v, p.assignment v = none}
+
+/-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it has a
+descendant in `s`. -/
+def Subsists (p : Possibility W V (Option M)) (s : State W V M) : Prop :=
+  ∃ q ∈ s, p.Descendant q
+
+@[inherit_doc] scoped notation:50 p " ≺ " s => Subsists p s
+
+theorem Subsists.of_mem {p : Possibility W V (Option M)} {s : State W V M}
+    (h : p ∈ s) : p ≺ s :=
+  ⟨p, h, Possibility.Descendant.refl p⟩
+
+/-- `s` subsists in `s'`: the informativeness order, Def. 25's
+projection form — every point of the weaker state has a descendant in
+the stronger. -/
+def subsistsIn (s s' : State W V M) : Prop :=
+  ∀ p ∈ s, p ≺ s'
+
+@[inherit_doc] scoped notation:50 s " ⪯ " s' => subsistsIn s s'
+
+theorem subsistsIn_refl (s : State W V M) : s ⪯ s :=
+  fun _ hp => Subsists.of_mem hp
+
+theorem subsistsIn_trans {s t u : State W V M} (hst : s ⪯ t)
+    (htu : t ⪯ u) : s ⪯ u := fun p hp => by
+  obtain ⟨q, hq, hpq⟩ := hst p hp
+  obtain ⟨r, hr, hqr⟩ := htu q hq
+  exact ⟨r, hr, hpq.trans hqr⟩
+
+/-- The worldly content of a state ([elliott-sudo-2025] Def. 3.1's 𝒲). -/
+def worlds (s : State W V M) : Set W :=
+  Possibility.world '' s
+
+@[simp] theorem mem_worlds {s : State W V M} {w : W} :
+    w ∈ worlds s ↔ ∃ p ∈ s, Possibility.world p = w := Iff.rfl
+
+/-- A referent is *familiar* at a state ([elliott-sudo-2025], Def. 3.2;
+[heim-1982]'s files): defined at every point. -/
+def Familiar (s : State W V M) (x : V) : Prop :=
+  ∀ p ∈ s, p.assignment x ≠ none
+
+/-! ### Restriction and random assignment -/
+
+namespace Possibility
+
+variable [DecidableEq V]
+
+/-- Restrict a partial point to the referents in `X`. -/
+def restrict (X : Finset V) (p : Possibility W V (Option M)) :
+    Possibility W V (Option M) :=
+  ⟨p.world, fun v => if v ∈ X then p.assignment v else none⟩
+
+@[simp] theorem restrict_world (X : Finset V)
+    (p : Possibility W V (Option M)) :
+    (p.restrict X).world = p.world := rfl
+
+/-- Restriction is an ancestor. -/
+theorem restrict_descendant (X : Finset V)
+    (p : Possibility W V (Option M)) : (p.restrict X).Descendant p :=
+  ⟨rfl, fun x e h => by
+    by_cases hx : x ∈ X
+    · simpa [restrict, hx] using h
+    · simp [restrict, hx] at h⟩
+
+end Possibility
 
 namespace State
 
-variable {I I' J : State W V M} {p : Possibility W V M}
+/-! ### The uniform stratum -/
 
-instance : Membership (Possibility W V M) (State W V M) :=
-  ⟨fun I p => p ∈ I.carrier⟩
+/-- The state is uniform at `X`: every point defines exactly the
+referents in `X` — Def. 23's "Dom(f) = X", as a stratum rather than a
+component. -/
+def UniformAt (X : Finset V) (I : State W V M) : Prop :=
+  ∀ p ∈ I, Possibility.dom p = (↑X : Set V)
 
-@[simp] theorem mem_carrier :
-    p ∈ I.carrier ↔ p ∈ I := Iff.rfl
+/-- The initial state is uniform at the empty base. -/
+theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
+  fun p hp => by
+    ext v
+    simp [Possibility.dom, hp v]
 
-/-! ### The informativeness order -/
-
-/-- Informativeness ([kamp-vangenabith-reyle-2011], Def. 25): `I ≤ I'` iff
-`I'` carries at least as much information — the base grows and the carrier
-shrinks. -/
-instance : PartialOrder (State W V M) where
-  le I I' := I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier
-  le_refl _ := ⟨subset_rfl, subset_rfl⟩
-  le_trans _ _ _ h h' := ⟨h.1.trans h'.1, h'.2.trans h.2⟩
-  le_antisymm _ _ h h' :=
-    State.ext (Finset.Subset.antisymm h.1 h'.1) (Set.Subset.antisymm h'.2 h.2)
-
-theorem le_def :
-    I ≤ I' ↔ I.base ⊆ I'.base ∧ I'.carrier ⊆ I.carrier := Iff.rfl
-
-/-- The chapter's projection form of Def. 25 — every possibility of the
-stronger state restricts to one of the weaker — coincides with `≤`: support
-makes the projected witness the possibility itself. -/
-theorem le_iff_projection :
-    I ≤ I' ↔ I.base ⊆ I'.base ∧
-      ∀ ⦃w g⦄, (⟨w, g⟩ : Possibility W V M) ∈ I' →
-        ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑I.base := by
-  constructor
-  · rintro ⟨hb, hc⟩
-    exact ⟨hb, fun w g hg => ⟨g, hc hg, Set.eqOn_refl g _⟩⟩
-  · rintro ⟨hb, hproj⟩
-    refine ⟨hb, fun p hp => ?_⟩
-    obtain ⟨w, g⟩ := p
-    obtain ⟨f, hf, hfg⟩ := hproj hp
-    exact (I.supported.mem_iff hfg).mp hf
-
-/-- The minimal information state Λ ([kamp-vangenabith-reyle-2011],
-Def. 23(iv)): empty base, no information. -/
-instance : OrderBot (State W V M) where
-  bot := ⟨∅, Set.univ, ⟨Set.univ, rfl⟩⟩
-  bot_le _ := ⟨Finset.empty_subset _, Set.subset_univ _⟩
-
-@[simp] theorem base_bot : (⊥ : State W V M).base = ∅ := rfl
-@[simp] theorem carrier_bot : (⊥ : State W V M).carrier = Set.univ := rfl
-
-@[simp] theorem mem_bot : p ∈ (⊥ : State W V M) := trivial
-
-/-! ### Consistent merge is the join -/
-
-section Merge
 variable [DecidableEq V]
 
-/-- Consistent merge ([kamp-vangenabith-reyle-2011], Def. 26) is the join of
-the informativeness order: union the bases, intersect the carriers. -/
-instance : SemilatticeSup (State W V M) where
-  sup I I' :=
-    ⟨I.base ∪ I'.base, I.carrier ∩ I'.carrier,
-      (I.supported.mono Finset.subset_union_left).inter
-        (I'.supported.mono Finset.subset_union_right)⟩
-  le_sup_left _ _ := ⟨Finset.subset_union_left, Set.inter_subset_left⟩
-  le_sup_right _ _ := ⟨Finset.subset_union_right, Set.inter_subset_right⟩
-  sup_le _ _ _ h h' :=
-    ⟨Finset.union_subset h.1 h'.1, Set.subset_inter h.2 h'.2⟩
-
-@[simp] theorem base_sup (I I' : State W V M) :
-    (I ⊔ I').base = I.base ∪ I'.base := rfl
-@[simp] theorem carrier_sup (I I' : State W V M) :
-    (I ⊔ I').carrier = I.carrier ∩ I'.carrier := rfl
-
-@[simp] theorem mem_sup :
-    p ∈ I ⊔ I' ↔ p ∈ I ∧ p ∈ I' := Iff.rfl
-
-/-- The chapter's choice-function form of Def. 26: a possibility belongs to
-the merge iff it restricts into each component — support makes the choice
-functions the possibility itself. -/
-theorem mem_sup_iff_projection {w : W} {k : V → M} :
-    (⟨w, k⟩ : Possibility W V M) ∈ I ⊔ I' ↔
-      (∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f k ↑I.base) ∧
-      (∃ g, (⟨w, g⟩ : Possibility W V M) ∈ I' ∧ Set.EqOn g k ↑I'.base) := by
-  constructor
-  · rintro ⟨hI, hI'⟩
-    exact ⟨⟨k, hI, Set.eqOn_refl k _⟩, ⟨k, hI', Set.eqOn_refl k _⟩⟩
-  · rintro ⟨⟨f, hf, hfk⟩, ⟨g, hg, hgk⟩⟩
-    exact ⟨(I.supported.mem_iff hfk).mp hf, (I'.supported.mem_iff hgk).mp hg⟩
-
-end Merge
-
-/-! ### The proposition determined by a state -/
-
-/-- The proposition a state determines ([kamp-vangenabith-reyle-2011],
-Def. 23(v)): the worlds compatible with some assignment. -/
-def prop (I : State W V M) : Set W := {w | ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I}
-
-@[simp] theorem mem_prop {w : W} :
-    w ∈ I.prop ↔ ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I := Iff.rfl
-
-theorem prop_eq_image (I : State W V M) : I.prop = Possibility.world '' I.carrier :=
-  Set.ext fun _ => ⟨fun ⟨f, hf⟩ => ⟨⟨_, f⟩, hf, rfl⟩, fun ⟨⟨_, f⟩, hp, hw⟩ => ⟨f, hw ▸ hp⟩⟩
-
-/-- Stronger states determine stronger propositions. -/
-theorem prop_anti : Antitone (prop : State W V M → Set W) :=
-  fun _ _ h _ ⟨f, hf⟩ => ⟨f, h.2 hf⟩
-
-@[simp] theorem prop_bot [Nonempty M] : (⊥ : State W V M).prop = Set.univ :=
-  Set.eq_univ_of_forall fun _ => ⟨fun _ => Classical.arbitrary M, trivial⟩
-
-/-! ### Restriction to a smaller base -/
-
-/-- Restrict a state to base `Y`: the best `Y`-supported approximation — a
-possibility survives iff some carrier member agrees with it on `Y`. -/
-def restrict (I : State W V M) (Y : Finset V) : State W V M where
-  base := Y
-  carrier :=
-    {p | ∃ f, (⟨p.world, f⟩ : Possibility W V M) ∈ I.carrier ∧
-      Set.EqOn f p.assignment ↑Y}
-  supported := baseSupported_of_iff fun _ _ _ hgg' =>
-    exists_congr fun _ => and_congr_right fun _ =>
-      ⟨fun h => h.trans hgg', fun h => h.trans hgg'.symm⟩
-
-@[simp] theorem base_restrict (I : State W V M) (Y : Finset V) :
-    (I.restrict Y).base = Y := rfl
-
-@[simp] theorem mem_restrict {w : W} {g : V → M} :
-    (⟨w, g⟩ : Possibility W V M) ∈ I.restrict Y ↔
-      ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑Y := Iff.rfl
-
-/-- Restricting to the state's own base is the identity. -/
-@[simp] theorem restrict_base (I : State W V M) : I.restrict I.base = I := by
-  ext1
-  · rfl
-  · ext ⟨w, g⟩
-    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported.mem_iff hfg).mp hf,
-      fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
-
-/-- Restriction is transitive along shrinking bases. -/
-theorem restrict_restrict (I : State W V M) {Z : Finset V} (hZY : Z ⊆ Y) :
-    (I.restrict Y).restrict Z = I.restrict Z := by
-  ext1
-  · rfl
-  · ext ⟨w, g⟩
-    constructor
-    · rintro ⟨f, ⟨f', hf', hf'f⟩, hfg⟩
-      exact ⟨f', hf', (hf'f.mono (Finset.coe_subset.mpr hZY)).trans hfg⟩
-    · rintro ⟨f, hf, hfg⟩
-      exact ⟨f, ⟨f, hf, Set.eqOn_refl f _⟩, hfg⟩
-
-/-- Restriction to a sub-base weakens the state. -/
-theorem restrict_le (h : Y ⊆ I.base) :
-    I.restrict Y ≤ I :=
-  ⟨h, fun p hp => ⟨p.assignment, hp, Set.eqOn_refl p.assignment _⟩⟩
-
-/-- Restriction is the *best* `Y`-supported approximation: for states indexed
-below `Y`, lying below `I.restrict Y` is lying below `I`. -/
-theorem le_restrict_iff (hJ : J.base ⊆ Y) (hY : Y ⊆ I.base) : J ≤ I.restrict Y ↔ J ≤ I := by
-  constructor
-  · exact fun h => h.trans (restrict_le hY)
-  · rintro ⟨hb, hc⟩
-    refine ⟨hJ, fun p hp => ?_⟩
-    obtain ⟨w, g⟩ := p
-    obtain ⟨f, hf, hfg⟩ := hp
-    exact (J.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hJ))).mp (hc hf)
-
-/-- Restriction never changes the proposition — only anaphoric potential. -/
-@[simp] theorem prop_restrict (I : State W V M) (Y : Finset V) :
-    (I.restrict Y).prop = I.prop :=
-  Set.ext fun _ =>
-    ⟨fun ⟨_, f, hf, _⟩ => ⟨f, hf⟩, fun ⟨f, hf⟩ => ⟨f, f, hf, Set.eqOn_refl f _⟩⟩
-
-/-! ### Weakening and the quantifier adjoints
-
-The three transports along a base inclusion — `kernRestrict`, `weaken`,
-`restrict` — are [lawvere-1969]'s quantifier triple `∀ ⊣ w* ⊣ ∃`
-(mathlib's `Set.kernImage`, `Set.preimage`, `Set.image` along environment
-projections; `Category.lean`'s `fiberOrderIsoProd_restrict` computes the
-`restrict` leg). The informativeness order reverses inclusion, so here
-the ∃-leg is the *right* adjoint: `kernRestrict ⊣ weaken ⊣ restrict`.
-Beck–Chevalley (`restrict_weaken`) commutes the adjoints across the
-poset's pullback squares: the fibers form a hyperdoctrine over the
-category of contexts ([jacobs-1999]). -/
-
-/-- Weakening: grow the base, keep the carrier — supported carriers are
-already cylindric off the base. Semantically vacuous, anaphorically not:
-the new referents are live. [jacobs-1999]'s weakening. -/
-def weaken (I : State W V M) (h : I.base ⊆ Y) : State W V M where
-  base := Y
-  carrier := I.carrier
-  supported := I.supported.mono h
-
-@[simp] theorem base_weaken (h : I.base ⊆ Y) : (I.weaken h).base = Y := rfl
-
-@[simp] theorem carrier_weaken (h : I.base ⊆ Y) :
-    (I.weaken h).carrier = I.carrier := rfl
-
-@[simp] theorem weaken_self (I : State W V M) : I.weaken subset_rfl = I := rfl
-
-theorem weaken_weaken {Z : Finset V} (h : I.base ⊆ Y) (h' : Y ⊆ Z) :
-    (I.weaken h).weaken h' = I.weaken (h.trans h') := rfl
-
-/-- The universal counterpart of restriction: a possibility survives iff
-*every* variant agreeing with it on `Y` is in the carrier. The ∀-leg of
-the quantifier triple (`Set.kernImage` where `restrict` is `Set.image`),
-and the transport for universal quantification and the DRS conditional. -/
-def kernRestrict (I : State W V M) (Y : Finset V) : State W V M where
-  base := Y
-  carrier := {p | ∀ f, Set.EqOn f p.assignment ↑Y →
-    (⟨p.world, f⟩ : Possibility W V M) ∈ I.carrier}
-  supported := baseSupported_of_iff fun _ _ _ hfg =>
-    forall_congr' fun _ =>
-      imp_congr_left ⟨fun h => h.trans hfg, fun h => h.trans hfg.symm⟩
-
-@[simp] theorem base_kernRestrict : (I.kernRestrict Y).base = Y := rfl
-
-@[simp] theorem mem_kernRestrict {w : W} {g : V → M} :
-    (⟨w, g⟩ : Possibility W V M) ∈ I.kernRestrict Y ↔
-      ∀ f, Set.EqOn f g ↑Y → (⟨w, f⟩ : Possibility W V M) ∈ I := Iff.rfl
-
-/-- The universal approximation is at least as informative as the
-existential one. -/
-theorem restrict_le_kernRestrict (I : State W V M) (Y : Finset V) :
-    I.restrict Y ≤ I.kernRestrict Y :=
-  ⟨subset_rfl, fun p hp =>
-    ⟨p.assignment, hp p.assignment (Set.eqOn_refl _ _), Set.eqOn_refl _ _⟩⟩
-
-/-- Weakening is left adjoint to restriction — `Set.image_preimage` in the
-fibers, the informativeness order making the ∃-leg the right adjoint.
-`le_restrict_iff` is this connection with the weakening left implicit. -/
-theorem weaken_le_iff (hJ : J.base ⊆ Y) (hY : Y ⊆ I.base) :
-    J.weaken hJ ≤ I ↔ J ≤ I.restrict Y := by
-  constructor
-  · rintro ⟨-, hc⟩
-    refine ⟨hJ, fun p hp => ?_⟩
-    obtain ⟨w, g⟩ := p
-    obtain ⟨f, hf, hfg⟩ := hp
-    exact (J.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hJ))).mp (hc hf)
-  · rintro ⟨-, hc⟩
-    exact ⟨hY, fun p hp => hc ⟨p.assignment, hp, Set.eqOn_refl _ _⟩⟩
-
-/-- `kernRestrict` is left adjoint to weakening — `Set.preimage_kernImage`
-in the fibers: `I.kernRestrict J.base` is the strongest `J.base`-supported
-consequence of `I`. -/
-theorem kernRestrict_le_iff (h : J.base ⊆ I.base) :
-    I.kernRestrict J.base ≤ J ↔ I ≤ J.weaken h := by
-  constructor
-  · rintro ⟨-, hc⟩
-    exact ⟨subset_rfl, fun p hp => hc hp p.assignment (Set.eqOn_refl _ _)⟩
-  · rintro ⟨-, hc⟩
-    refine ⟨subset_rfl, fun p hp => ?_⟩
-    obtain ⟨w, g⟩ := p
-    intro f hfg
-    exact hc ((J.supported.mem_iff hfg).mpr hp)
-
-section BeckChevalley
-variable [DecidableEq V]
-
-/-- Beck–Chevalley: weakening then restricting is restricting to the
-intersection then weakening — the quantifier adjoints commute across the
-poset's pullback squares. -/
-theorem restrict_weaken (I : State W V M) (Z : Finset V) :
-    (I.weaken (Finset.subset_union_left : I.base ⊆ I.base ∪ Z)).restrict Z =
-      (I.restrict (I.base ∩ Z)).weaken Finset.inter_subset_right := by
-  refine State.ext rfl (Set.ext fun p => ?_)
-  obtain ⟨w, g⟩ := p
-  constructor
-  · rintro ⟨f, hf, hfg⟩
-    exact ⟨f, hf, hfg.mono (by rw [Finset.coe_inter]; exact Set.inter_subset_right)⟩
-  · rintro ⟨f, hf, hfg⟩
-    refine ⟨I.base.piecewise f g,
-      (I.supported.mem_iff fun x hx => I.base.piecewise_eq_of_mem f g hx).mpr hf,
-      fun z hz => ?_⟩
-    by_cases hzB : z ∈ I.base
-    · rw [Finset.piecewise_eq_of_mem _ _ _ hzB]
-      exact hfg (by rw [Finset.coe_inter]; exact ⟨hzB, hz⟩)
-    · rw [Finset.piecewise_eq_of_notMem _ _ _ hzB]
-
-end BeckChevalley
-
-/-! ### Merge is gluing -/
-
-section Gluing
-variable [DecidableEq V]
-
-/-- Two states are *compatible* when they agree under restriction to their
-common base ([abramsky-sadrzadeh-2014]'s compatible families, for pairs). -/
-def Compatible (I J : State W V M) : Prop :=
-  I.restrict (I.base ∩ J.base) = J.restrict (I.base ∩ J.base)
-
-@[simp] theorem compatible_refl (I : State W V M) : I.Compatible I := by
-  show I.restrict _ = I.restrict _
-  rw [Finset.inter_self]
-
-theorem Compatible.symm (h : I.Compatible J) : J.Compatible I := by
-  show J.restrict _ = I.restrict _
-  rw [Finset.inter_comm]
-  exact Eq.symm h
-
-/-- Disjoint-base states determining the same proposition are compatible —
-[kamp-vangenabith-reyle-2011] Def. 26's "of particular importance" case. -/
-theorem compatible_of_disjoint (hd : Disjoint I.base J.base)
-    (hw : I.prop = J.prop) : I.Compatible J := by
-  show I.restrict _ = J.restrict _
-  rw [Finset.disjoint_iff_inter_eq_empty.mp hd]
-  refine State.ext rfl (Set.ext fun p => ?_)
-  constructor
-  · rintro ⟨f, hf, -⟩
-    obtain ⟨g, hg⟩ : p.world ∈ J.prop := hw ▸ ⟨f, hf⟩
-    exact ⟨g, hg, fun x hx => absurd hx (by simp)⟩
-  · rintro ⟨f, hf, -⟩
-    obtain ⟨g, hg⟩ : p.world ∈ I.prop := hw.symm ▸ ⟨f, hf⟩
-    exact ⟨g, hg, fun x hx => absurd hx (by simp)⟩
-
-/-- **Merge is gluing**: the join of compatible states restricts back onto
-the left component — [abramsky-sadrzadeh-2014]'s semantic unification,
-with no disjointness hypothesis. The carrier witness is repaired on
-`J.base` only, which support tolerates. -/
-theorem Compatible.restrict_sup_left (h : I.Compatible J) :
-    (I ⊔ J).restrict I.base = I := by
-  refine State.ext rfl (Set.ext fun p => ?_)
-  obtain ⟨w, g⟩ := p
-  constructor
-  · rintro ⟨f, hf, hfg⟩
-    exact (I.supported.mem_iff hfg).mp (mem_sup.mp hf).1
-  · intro hg
-    have hD : (⟨w, g⟩ : Possibility W V M) ∈ I.restrict (I.base ∩ J.base) :=
-      ⟨g, hg, Set.eqOn_refl _ _⟩
-    rw [show I.restrict (I.base ∩ J.base) = J.restrict (I.base ∩ J.base)
-      from h] at hD
-    obtain ⟨f, hfJ, hfg⟩ := hD
-    have hpw : Set.EqOn (J.base.piecewise f g) g ↑I.base := fun x hx => by
-      by_cases hxJ : x ∈ J.base
-      · rw [Finset.piecewise_eq_of_mem _ _ _ hxJ]
-        exact hfg (by rw [Finset.coe_inter]; exact ⟨hx, hxJ⟩)
-      · rw [Finset.piecewise_eq_of_notMem _ _ _ hxJ]
-    refine ⟨J.base.piecewise f g, mem_sup.mpr ⟨?_, ?_⟩, hpw⟩
-    · exact (I.supported.mem_iff hpw).mpr hg
-    · exact (J.supported.mem_iff
-        (fun x hx => J.base.piecewise_eq_of_mem f g hx)).mpr hfJ
-
-/-- Merge is gluing, right component. -/
-theorem Compatible.restrict_sup_right (h : I.Compatible J) :
-    (I ⊔ J).restrict J.base = J := by
-  rw [sup_comm]
-  exact h.symm.restrict_sup_left
-
-/-- Frobenius reciprocity: restriction distributes over merge with a
-weakened state, unconditionally — where the gluing law needs
-compatibility, the weakened component needs nothing. -/
-theorem restrict_sup_weaken (hJ : J.base ⊆ Y) (hY : Y ⊆ I.base) :
-    (I ⊔ J.weaken (hJ.trans hY)).restrict Y = I.restrict Y ⊔ J := by
-  refine State.ext (Finset.union_eq_left.mpr hJ).symm (Set.ext fun p => ?_)
-  obtain ⟨w, g⟩ := p
-  constructor
-  · rintro ⟨f, hf, hfg⟩
-    obtain ⟨hfI, hfJ⟩ := mem_sup.mp hf
-    exact mem_sup.mpr ⟨⟨f, hfI, hfg⟩,
-      (J.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hJ))).mp hfJ⟩
-  · intro hp
-    obtain ⟨⟨f, hfI, hfg⟩, hpJ⟩ := mem_sup.mp hp
-    exact ⟨f, mem_sup.mpr ⟨hfI,
-      (J.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hJ))).mpr hpJ⟩, hfg⟩
-
-/-- The merge is the *least* gluing: any state that restricts onto both
-components over the union base lies above it. -/
-theorem sup_le_of_restrict_eq {S : State W V M} (hb : S.base = I.base ∪ J.base)
-    (hI : S.restrict I.base = I) (hJ : S.restrict J.base = J) : I ⊔ J ≤ S :=
-  ⟨le_of_eq hb.symm, fun p hp => mem_sup.mpr
-    ⟨by rw [← hI]; exact ⟨p.assignment, hp, Set.eqOn_refl _ _⟩,
-     by rw [← hJ]; exact ⟨p.assignment, hp, Set.eqOn_refl _ _⟩⟩⟩
-
-end Gluing
-
-/-- The diagonal state: two referents, correlated. -/
-private def diag : State Unit Bool Bool where
-  base := {false, true}
-  carrier := {p | p.assignment false = p.assignment true}
-  supported := baseSupported_of_iff fun _ f g hfg => by
-    show f false = f true ↔ g false = g true
-    rw [hfg (by simp), hfg (by simp)]
-
-/-- The full state: two referents, unconstrained. -/
-private def square : State Unit Bool Bool where
-  base := {false, true}
-  carrier := Set.univ
-  supported := baseSupported_of_iff fun _ _ _ _ => Iff.rfl
-
-/-- **The gluing is not unique**: the diagonal and the full square agree on
-every singleton restriction yet differ. Restriction forgets cross-referent
-correlation, so a state is not determined by its per-referent
-projections — the marbles argument, one referent up. -/
-theorem exists_ne_of_restrict_eq :
-    ∃ I J : State Unit Bool Bool, I.base = J.base ∧ I ≠ J ∧
-      ∀ x, I.restrict {x} = J.restrict {x} := by
-  refine ⟨diag, square, rfl, fun h => ?_, fun x => ?_⟩
-  · have : (⟨(), id⟩ : Possibility Unit Bool Bool) ∈ diag := by
-      rw [h]; trivial
-    exact Bool.false_ne_true this
-  · refine State.ext rfl (Set.ext fun p => ?_)
-    constructor
-    · rintro ⟨f, -, hfg⟩
-      exact ⟨f, trivial, hfg⟩
-    · rintro ⟨f, -, -⟩
-      refine ⟨fun _ => p.assignment x, rfl, fun y hy => ?_⟩
-      obtain rfl : y = x := by simpa using hy
-      rfl
-
-/-! ### Random assignment -/
-
-/-- Random assignment: introduce the discourse referent `x` — the base
-grows, and any constraint at `x` is dropped ([heim-1982]'s indefinite
-widening, [groenendijk-stokhof-1991]'s random reset). For a novel `x` the
-carrier is unchanged (`randomAssign_of_notMem`) — supported carriers are
-already cylindric off the base, so introduction is pure base growth; for a
-live `x` the update is destructive. -/
-def randomAssign [DecidableEq V] (I : State W V M) (x : V) : State W V M :=
-  (I.restrict (I.base.erase x)).weaken
-    (show I.base.erase x ⊆ insert x I.base from
-      (Finset.erase_subset ..).trans (Finset.subset_insert ..))
-
-section RandomAssign
-variable [DecidableEq V] {x : V}
-
-@[simp] theorem base_randomAssign (I : State W V M) (x : V) :
-    (I.randomAssign x).base = insert x I.base := rfl
-
-theorem mem_randomAssign {w : W} {g : V → M} :
-    (⟨w, g⟩ : Possibility W V M) ∈ I.randomAssign x ↔
-      ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ Set.EqOn f g ↑(I.base.erase x) :=
-  Iff.rfl
-
-/-- Introducing a novel referent only grows the base. -/
-theorem randomAssign_of_notMem (hx : x ∉ I.base) :
-    (I.randomAssign x).carrier = I.carrier := by
-  show (I.restrict (I.base.erase x)).carrier = I.carrier
-  rw [Finset.erase_eq_of_notMem hx, restrict_base]
-
-end RandomAssign
-
-/-! ### States at a base as collapsed propositions -/
-
-/-- The states indexed at `X`. -/
-abbrev fiber (W M : Type*) {V : Type*} (X : Finset V) : Type _ :=
-  {I : State W V M // I.base = X}
-
-theorem fiber_supported (I : fiber W M X) :
-    BaseSupported X I.1.carrier :=
-  (congrArg (fun b => BaseSupported b I.1.carrier) I.2).mp I.1.supported
-
-/-- A state indexed at `X` is a proposition over the `X`-collapsed state
-space ([muskens-van-benthem-visser-2011]'s picture at granularity `X`):
-support is saturation, so carriers and sets of agreement classes are in
-bijection. -/
-def fiberEquiv (X : Finset V) :
-    fiber W M X ≃ Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V))) where
-  toFun I := {q | q.liftOn (· ∈ I.1) fun _ _ h => propext ((fiber_supported I).mem_congr h)}
-  invFun T :=
-    ⟨⟨X, Quotient.mk _ ⁻¹' T, baseSupported_iff.mpr fun _ _ h => by
-        rw [Set.mem_preimage, Set.mem_preimage, Quotient.sound h]⟩, rfl⟩
-  left_inv I := Subtype.ext (State.ext I.2.symm rfl)
-  right_inv T := by
-    ext q
-    induction q using Quotient.ind
-    exact Iff.rfl
-
-@[simp] theorem mem_fiberEquiv {I : fiber W M X} :
-    Quotient.mk _ p ∈ fiberEquiv X I ↔ p ∈ I.1 := Iff.rfl
-
-@[simp] theorem mem_fiberEquiv_symm
-    {T : Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V)))} :
-    p ∈ ((fiberEquiv X).symm T).1 ↔ Quotient.mk _ p ∈ T := Iff.rfl
-
-/-- The equivalence is the image of the carrier in the collapsed space —
-the sibling of `prop_eq_image`, one rung up the ladder. -/
-theorem fiberEquiv_eq_image (I : fiber W M X) :
-    fiberEquiv X I = Quotient.mk _ '' I.1.carrier := by
-  have h := (fiber_supported I).preimage_image_mk
-  ext q
-  induction q using Quotient.ind
-  rw [mem_fiberEquiv, ← State.mem_carrier, ← Set.mem_preimage, h]
-
-/-- Informativeness at a fixed base is reverse inclusion of collapsed
-propositions. -/
-def fiberOrderIso (X : Finset V) :
-    fiber W M X ≃o (Set (Quotient (Possibility.agreeSetoid (W := W) (M := M) (↑X : Set V))))ᵒᵈ where
-  toEquiv := (fiberEquiv X).trans OrderDual.toDual
-  map_rel_iff' {I I'} := by
-    show OrderDual.toDual (fiberEquiv X I) ≤ OrderDual.toDual (fiberEquiv X I') ↔ I ≤ I'
-    rw [OrderDual.toDual_le_toDual]
-    constructor
-    · intro h
-      refine ⟨by rw [I.2, I'.2], fun p hp => ?_⟩
-      exact mem_fiberEquiv.mp (h (mem_fiberEquiv.mpr hp))
-    · rintro ⟨-, hc⟩ q hq
-      induction q using Quotient.ind
-      exact mem_fiberEquiv.mpr (hc (mem_fiberEquiv.mp hq))
-
-section Classified
-variable [Nonempty M]
-
-/-- The fiber at `X`, classified: a indexed state is a proposition over
-world–`X`-assignment pairs, reversed by informativeness — [heim-1982]'s
-satisfaction sets of domain-`X` sequences, as a theorem rather than a
-gloss. -/
-noncomputable def fiberOrderIsoProd (X : Finset V) :
-    fiber W M X ≃o (Set (W × ((↑X : Set V) → M)))ᵒᵈ :=
-  (fiberOrderIso X).trans
-    (Possibility.agreeQuotientEquiv (↑X : Set V)).toOrderIsoSet.dual
-
-/-- Membership form of the classification: a pair lies in the classified
-state iff the corresponding possibility does. -/
-theorem mem_fiberOrderIsoProd {I : fiber W M X} {w : W} {g : V → M} :
-    (w, (↑X : Set V).restrict g) ∈
-        OrderDual.ofDual (fiberOrderIsoProd X I) ↔
-      (⟨w, g⟩ : Possibility W V M) ∈ I.1 := by
-  show (w, (↑X : Set V).restrict g) ∈
-    Possibility.agreeQuotientEquiv (↑X : Set V) '' fiberEquiv X I ↔ _
-  constructor
-  · rintro ⟨q, hq, heq⟩
-    obtain ⟨p⟩ := q
-    obtain ⟨h1, h2⟩ := Prod.ext_iff.mp heq
-    exact ((fiber_supported I).mem_congr
-      ⟨h1, fun v hv => congrFun h2 ⟨v, hv⟩⟩).mp (mem_fiberEquiv.mp hq)
-  · intro hg
-    exact ⟨Quotient.mk _ ⟨w, g⟩, mem_fiberEquiv.mpr hg, rfl⟩
-
-/-- At the empty context the fiber degenerates to bare propositions:
-[veltman-1996]'s update-semantics states are the referent-free fiber. -/
-noncomputable def fiberEmptyOrderIso :
-    fiber W M (∅ : Finset V) ≃o (Set W)ᵒᵈ :=
-  haveI : IsEmpty ((↑(∅ : Finset V) : Set V) : Type _) :=
-    ⟨fun x => by simpa using x.2⟩
-  (fiberOrderIsoProd ∅).trans (Equiv.prodUnique W _).toOrderIsoSet.dual
-
-/-- Membership form: at the empty context, membership is a fact about the
-world alone. -/
-theorem mem_fiberEmptyOrderIso {I : fiber W M (∅ : Finset V)} {w : W}
-    {g : V → M} :
-    w ∈ OrderDual.ofDual (fiberEmptyOrderIso I) ↔
-      (⟨w, g⟩ : Possibility W V M) ∈ I.1 := by
-  haveI : IsEmpty ((↑(∅ : Finset V) : Set V) : Type _) :=
-    ⟨fun x => by simpa using x.2⟩
-  rw [← mem_fiberOrderIsoProd (g := g)]
-  show w ∈ Equiv.prodUnique W _ '' OrderDual.ofDual (fiberOrderIsoProd ∅ I) ↔ _
-  constructor
-  · rintro ⟨⟨w', f⟩, hf, rfl⟩
-    rwa [Subsingleton.elim ((↑(∅ : Finset V) : Set V).restrict g) f]
-  · intro h
-    exact ⟨(w, _), h, rfl⟩
-
-end Classified
+/-- Restriction of a state: pointwise, by direct image. -/
+def restrict (X : Finset V) (I : State W V M) : State W V M :=
+  Possibility.restrict X '' I
+
+/-- Restriction only forgets: the restricted state subsists in the
+original. -/
+theorem subsistsIn_restrict (X : Finset V) (I : State W V M) :
+    I.restrict X ⪯ I := by
+  rintro p ⟨q, hq, rfl⟩
+  exact ⟨q, hq, Possibility.restrict_descendant X q⟩
+
+/-- Random assignment ([elliott-sudo-2025], (43);
+[groenendijk-stokhof-1991]'s `x := random`): indeterministically extend
+each point to a defined value at `x`. -/
+def randomAssign (I : State W V M) (x : V) : State W V M :=
+  {p | ∃ q ∈ I, ∃ m : M,
+    p = ⟨q.world, Function.update q.assignment x (some m)⟩}
 
 end State
+
+/-! ### The indexed classification -/
+
+namespace Possibility
+
+variable [DecidableEq V]
+
+/-- Partial points with domain `X` are world–`X`-environment pairs —
+constructively: the classification that the total-assignment rendering
+recovered only with choice and an inhabitant of `M`. -/
+def domEquiv (X : Finset V) :
+    {p : Possibility W V (Option M) // p.dom = (↑X : Set V)} ≃
+      W × ((↑X : Set V) → M) where
+  toFun p :=
+    (p.1.world, fun v => (p.1.assignment v.1).get
+      ((Set.ext_iff.mp p.2 v.1).mpr v.2))
+  invFun e :=
+    ⟨⟨e.1, fun v => if h : v ∈ (↑X : Set V) then some (e.2 ⟨v, h⟩)
+      else none⟩, by
+      ext v
+      by_cases h : v ∈ (↑X : Set V) <;> simp [dom, h]⟩
+  left_inv p := by
+    obtain ⟨⟨w, g⟩, hp⟩ := p
+    refine Subtype.ext (Possibility.ext rfl (funext fun v => ?_))
+    by_cases h : v ∈ (↑X : Set V)
+    · simp only [dif_pos h, Option.some_get]
+    · have hnone : g v = none := Option.not_isSome_iff_eq_none.mp
+        fun hs => h ((Set.ext_iff.mp hp v).mp hs)
+      simp only [dif_neg h]
+      exact hnone.symm
+  right_inv e := by
+    refine Prod.ext rfl (funext fun v => ?_)
+    simp
+
+end Possibility
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -119,6 +119,72 @@ theorem Descendant.eq_of_dom_eq {p q : Possibility W V (Option M)}
       exact absurd this (by simp)
   · exact (h.2 v e hp).symm ▸ rfl
 
+/-- Two partial points are *compatible*: same world, agreeing wherever
+both are defined — [kamp-vangenabith-reyle-2011] Def. 26's condition
+that the union of chosen points be a function. -/
+def Compatible (p q : Possibility W V (Option M)) : Prop :=
+  p.world = q.world ∧
+    ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e'
+
+/-- The union of two points: defined wherever either is, the left
+taking precedence (agreement makes the choice immaterial). -/
+def union (p q : Possibility W V (Option M)) :
+    Possibility W V (Option M) :=
+  ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
+
+theorem left_descendant_union (p q : Possibility W V (Option M)) :
+    p.Descendant (p.union q) :=
+  ⟨rfl, fun v e h => by simp [union, h]⟩
+
+theorem Compatible.right_descendant_union
+    {p q : Possibility W V (Option M)} (h : p.Compatible q) :
+    q.Descendant (p.union q) :=
+  ⟨h.1.symm, fun v e hq => by
+    rcases hp : p.assignment v with _ | e'
+    · simp [union, hp, hq]
+    · simp [union, hp, h.2 v e' e hp hq]⟩
+
+/-- On a shared domain, compatibility is equality. -/
+theorem Compatible.eq_of_dom_eq {p q : Possibility W V (Option M)}
+    (h : p.Compatible q) (hdom : p.dom = q.dom) : p = q := by
+  refine Possibility.ext h.1 (funext fun v => ?_)
+  rcases hp : p.assignment v with _ | e
+  · rcases hq : q.assignment v with _ | e
+    · rfl
+    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
+      rw [Possibility.mem_dom, hp] at this
+      exact absurd this (by simp)
+  · rcases hq : q.assignment v with _ | e'
+    · have : v ∈ q.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hp⟩
+      rw [Possibility.mem_dom, hq] at this
+      exact absurd this (by simp)
+    · exact congrArg some (h.2 v e e' hp hq)
+
+/-- Union of points unites domains. -/
+theorem dom_union (p q : Possibility W V (Option M)) :
+    (p.union q).dom = p.dom ∪ q.dom := by
+  ext v
+  rcases hp : p.assignment v with _ | e <;> simp [union, dom, hp]
+
+/-- Common ancestors are compatible. -/
+theorem Descendant.compatible {p q u : Possibility W V (Option M)}
+    (hp : p.Descendant u) (hq : q.Descendant u) : p.Compatible q :=
+  ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
+    have h1 := hp.2 v e he
+    have h2 := hq.2 v e' he'
+    rw [h1] at h2
+    exact (Option.some.injEq .. ▸ h2 :)⟩
+
+/-- The union of two ancestors is an ancestor. -/
+theorem Descendant.union_descendant {p q u : Possibility W V (Option M)}
+    (hp : p.Descendant u) (hq : q.Descendant u) :
+    (p.union q).Descendant u :=
+  ⟨hp.1, fun v e h => by
+    rcases hpv : p.assignment v with _ | e'
+    · exact hq.2 v e (by simpa [union, hpv] using h)
+    · have : e' = e := by simpa [union, hpv] using h
+      exact this ▸ hp.2 v e' hpv⟩
+
 end Possibility
 
 /-! ### Information states -/
@@ -181,6 +247,35 @@ theorem infoLe_trans {s t u : State W V M} (hst : s ⊑ t) (htu : t ⊑ u) :
 /-- The absurd state is maximally informative. -/
 theorem infoLe_empty (s : State W V M) : s ⊑ (∅ : State W V M) :=
   fun q hq => absurd hq (Set.notMem_empty q)
+
+/-! ### Consistent merge -/
+
+/-- Consistent merge ([kamp-vangenabith-reyle-2011] Def. 26, binary):
+the points assembled from compatible pairs. Across strata this is the
+descendant-mediated join — plain intersection of point-sets is empty
+between distinct strata. -/
+def State.merge (s s' : State W V M) : State W V M :=
+  {r | ∃ p ∈ s, ∃ q ∈ s', p.Compatible q ∧ r = p.union q}
+
+/-- The merge is above the left component in informativeness. -/
+theorem infoLe_merge_left (s s' : State W V M) : s ⊑ s.merge s' := by
+  rintro r ⟨p, hp, q, hq, hpq, rfl⟩
+  exact ⟨p, hp, Possibility.left_descendant_union p q⟩
+
+/-- The merge is above the right component in informativeness. -/
+theorem infoLe_merge_right (s s' : State W V M) : s' ⊑ s.merge s' := by
+  rintro r ⟨p, hp, q, hq, hpq, rfl⟩
+  exact ⟨q, hq, hpq.right_descendant_union⟩
+
+/-- **The merge is the least upper bound** (Def. 26's universal
+property, in the informativeness preorder): anything above both
+components is above their merge. -/
+theorem merge_infoLe {s s' t : State W V M} (hs : s ⊑ t)
+    (hs' : s' ⊑ t) : s.merge s' ⊑ t := fun u hu => by
+  obtain ⟨p, hp, hpu⟩ := hs u hu
+  obtain ⟨q, hq, hqu⟩ := hs' u hu
+  exact ⟨p.union q, ⟨p, hp, q, hq, hpu.compatible hqu, rfl⟩,
+    hpu.union_descendant hqu⟩
 
 /-- The worldly content of a state ([elliott-sudo-2025] Def. 3.1's 𝒲). -/
 def worlds (s : State W V M) : Set W :=
@@ -294,8 +389,34 @@ theorem infoLe_iff_superset {X : Finset V} {s s' : State W V M}
     rwa [← hpq.eq_of_dom_eq ((hs p hp).trans (hs' q hq).symm)]
   · exact fun h q hq => ⟨q, h hq, Possibility.Descendant.refl q⟩
 
+/-- Within one stratum, merge is intersection: compatibility on a shared
+domain forces equality. -/
+theorem merge_eq_inter_of_uniform {X : Finset V} {s s' : State W V M}
+    (hs : UniformAt X s) (hs' : UniformAt X s') :
+    s.merge s' = s ∩ s' := by
+  have hself : ∀ r : Possibility W V (Option M), r.union r = r := fun r =>
+    Possibility.ext rfl (funext fun v => by
+      rcases h : r.assignment v with _ | e <;> simp [Possibility.union, h])
+  ext r
+  constructor
+  · rintro ⟨p, hp, q, hq, hpq, rfl⟩
+    obtain rfl := hpq.eq_of_dom_eq ((hs p hp).trans (hs' q hq).symm)
+    rw [hself p]
+    exact ⟨hp, hq⟩
+  · rintro ⟨hr, hr'⟩
+    refine ⟨r, hr, r, hr', ⟨rfl, fun v e e' he he' => ?_⟩, (hself r).symm⟩
+    rw [he] at he'
+    exact (Option.some.injEq .. ▸ he' :)
+
 section Fibred
 variable [DecidableEq V]
+
+/-- Merge unites strata. -/
+theorem uniformAt_merge {X Y : Finset V} {s s' : State W V M}
+    (hs : UniformAt X s) (hs' : UniformAt Y s') :
+    UniformAt (X ∪ Y) (s.merge s') := by
+  rintro r ⟨p, hp, q, hq, -, rfl⟩
+  rw [Possibility.dom_union, hs p hp, hs' q hq, Finset.coe_union]
 
 /-- Subsistence out of a stratum factors through reindexing: the weaker
 state includes into the restricted image of the stronger — the fibred

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -481,6 +481,12 @@ each point to a defined value at `x`. -/
 def randomAssign (I : State W V M) (x : V) : State W V M :=
   {p | ∃ q ∈ I, ∃ m : M, p = q.extend x (some m)}
 
+/-- Random assignment makes its referent familiar. -/
+theorem familiar_randomAssign (I : State W V M) (x : V) :
+    Familiar (I.randomAssign x) x := by
+  rintro p ⟨q, -, m, rfl⟩
+  simp
+
 end State
 
 /-! ### The indexed classification -/

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -17,12 +17,17 @@ There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
 (`UniformAt`), and a base is the index of a fiber, not part of the data.
 Points with domain `X` are world–`X`-environment pairs, constructively
 (`Possibility.domEquiv` — the total-assignment rendering needed choice
-and an inhabitant of `M` to recover this). Informativeness
-([kamp-vangenabith-reyle-2011] Def. 25) is *subsistence*: every point of
-the weaker state has a descendant in the stronger — the order of
-[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9 and
-[elliott-sudo-2025] Def. 3.3, promoted here from the bilateral system to
-the root.
+and an inhabitant of `M` to recover this). Two preorders run through states, and they are
+dual on shared strata. *Informativeness* (`⊑`,
+[kamp-vangenabith-reyle-2011] Def. 25) quantifies over the stronger
+state: every point of the stronger has an ancestor in the weaker — the
+absurd state `∅` is maximally informative, the eliminative direction.
+*Subsistence* (`⪯`, [elliott-sudo-2025] Def. 3.3, after
+[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) quantifies over the
+weaker: every point survives, extended, into the stronger — the
+anaphoric-support direction, with `∅` at the bottom. On a uniform
+stratum they reduce to `⊇` and `⊆` respectively
+(`infoLe_iff_superset`, `subsistsIn_iff_subset`).
 
 ## Main definitions
 
@@ -30,7 +35,8 @@ the root.
   a partial point, and same-world graph-extension.
 - `State W V M`: information states; `initial`, with `∅` the absurd
   state.
-- `Subsists` (`≺`), `subsistsIn` (`⪯`): the informativeness order.
+- `infoLe` (`⊑`): informativeness (Def. 25); `Subsists` (`≺`),
+  `subsistsIn` (`⪯`): subsistence.
 - `worlds`, `Familiar`: worldly content and familiarity.
 - `State.UniformAt`, `Possibility.domEquiv`: the indexed stratum and its
   constructive classification.
@@ -39,9 +45,24 @@ the root.
 
 ## Main results
 
+- `Possibility.Descendant.eq_of_dom_eq`: on a shared domain, descendance
+  is equality — so both preorders are partial orders on each uniform
+  stratum (`infoLe_iff_superset`, `subsistsIn_iff_subset`).
 - `subsistsIn_restrict`: restriction only forgets — the restricted state
   subsists in the original.
+- `uniformAt_restrict`, `restrict_restrict`: restriction meets the
+  stratification.
 - `uniformAt_initial`: the initial state is the empty-base fiber.
+
+## Implementation notes
+
+`State` is an abbreviation, so `Set`'s complete lattice is available and
+`⊑`/`⪯` are scoped relations rather than instances. Neither is
+antisymmetric on raw sets (adding an ancestor of an existing point is
+invisible to both); antisymmetry holds on each uniform stratum, where
+they coincide with `⊇`/`⊆`. The predecessor of this file classified its
+fibers as `(Set (W × (↑X → M)))ᵒᵈ` — the dual lands here because its
+order was Def. 25's, matching `⊑`, not `⪯`.
 
 ## References
 
@@ -85,6 +106,19 @@ theorem Descendant.dom_subset {p q : Possibility W V (Option M)}
   obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
   exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
 
+/-- On a shared domain, descendance is equality: there is no room to
+grow. -/
+theorem Descendant.eq_of_dom_eq {p q : Possibility W V (Option M)}
+    (h : p.Descendant q) (hdom : p.dom = q.dom) : p = q := by
+  refine Possibility.ext h.1 (funext fun v => ?_)
+  rcases hp : p.assignment v with _ | e
+  · rcases hq : q.assignment v with _ | e
+    · rfl
+    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
+      rw [Possibility.mem_dom, hp] at this
+      exact absurd this (by simp)
+  · exact (h.2 v e hp).symm ▸ rfl
+
 end Possibility
 
 /-! ### Information states -/
@@ -126,6 +160,28 @@ theorem subsistsIn_trans {s t u : State W V M} (hst : s ⪯ t)
   obtain ⟨r, hr, hqr⟩ := htu q hq
   exact ⟨r, hr, hpq.trans hqr⟩
 
+/-- Informativeness ([kamp-vangenabith-reyle-2011] Def. 25): `s'` carries
+at least as much information as `s` — every point of the stronger state
+has an ancestor in the weaker. The absurd state is maximally
+informative; the eliminative direction, dual to `⪯` on shared strata. -/
+def infoLe (s s' : State W V M) : Prop :=
+  ∀ q ∈ s', ∃ p ∈ s, p.Descendant q
+
+@[inherit_doc] scoped notation:50 s " ⊑ " s' => infoLe s s'
+
+theorem infoLe_refl (s : State W V M) : s ⊑ s :=
+  fun q hq => ⟨q, hq, Possibility.Descendant.refl q⟩
+
+theorem infoLe_trans {s t u : State W V M} (hst : s ⊑ t) (htu : t ⊑ u) :
+    s ⊑ u := fun r hr => by
+  obtain ⟨q, hq, hqr⟩ := htu r hr
+  obtain ⟨p, hp, hpq⟩ := hst q hq
+  exact ⟨p, hp, hpq.trans hqr⟩
+
+/-- The absurd state is maximally informative. -/
+theorem infoLe_empty (s : State W V M) : s ⊑ (∅ : State W V M) :=
+  fun q hq => absurd hq (Set.notMem_empty q)
+
 /-- The worldly content of a state ([elliott-sudo-2025] Def. 3.1's 𝒲). -/
 def worlds (s : State W V M) : Set W :=
   Possibility.world '' s
@@ -161,6 +217,44 @@ theorem restrict_descendant (X : Finset V)
     · simpa [restrict, hx] using h
     · simp [restrict, hx] at h⟩
 
+/-- Restriction intersects the domain. -/
+theorem dom_restrict (X : Finset V) (p : Possibility W V (Option M)) :
+    (p.restrict X).dom = ↑X ∩ p.dom := by
+  ext v
+  by_cases hv : v ∈ X <;> simp [restrict, dom, hv]
+
+/-- Descendance out of a stratum is *being the restriction*: for `p` at
+`X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
+hom-characterization of the fibred order. -/
+theorem descendant_iff_eq_restrict {X : Finset V}
+    {p q : Possibility W V (Option M)} (hp : p.dom = (↑X : Set V)) :
+    p.Descendant q ↔ p = q.restrict X := by
+  constructor
+  · intro h
+    refine Possibility.ext h.1 (funext fun v => ?_)
+    by_cases hv : v ∈ X
+    · have hsome : (p.assignment v).isSome :=
+        (Set.ext_iff.mp hp v).mpr hv
+      obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hsome
+      rw [he]
+      simp only [restrict, if_pos hv]
+      exact (h.2 v e he).symm
+    · have hnone : p.assignment v = none :=
+        Option.not_isSome_iff_eq_none.mp
+          fun hs => hv ((Set.ext_iff.mp hp v).mp hs)
+      rw [hnone]
+      simp [restrict, hv]
+  · rintro rfl
+    exact restrict_descendant X q
+
+/-- Restriction is pointwise idempotent along intersections. -/
+theorem restrict_restrict (X Y : Finset V)
+    (p : Possibility W V (Option M)) :
+    (p.restrict Y).restrict X = p.restrict (X ∩ Y) := by
+  refine Possibility.ext rfl (funext fun v => ?_)
+  by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;>
+    simp [restrict, hx, hy]
+
 end Possibility
 
 namespace State
@@ -179,6 +273,61 @@ theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
     ext v
     simp [Possibility.dom, hp v]
 
+/-- On a uniform stratum, subsistence is inclusion. -/
+theorem subsistsIn_iff_subset {X : Finset V} {s s' : State W V M}
+    (hs : UniformAt X s) (hs' : UniformAt X s') :
+    (s ⪯ s') ↔ s ⊆ s' := by
+  constructor
+  · intro h p hp
+    obtain ⟨q, hq, hpq⟩ := h p hp
+    rwa [hpq.eq_of_dom_eq ((hs p hp).trans (hs' q hq).symm)]
+  · exact fun h p hp => Subsists.of_mem (h hp)
+
+/-- On a uniform stratum, informativeness is reverse inclusion — the
+eliminative direction. -/
+theorem infoLe_iff_superset {X : Finset V} {s s' : State W V M}
+    (hs : UniformAt X s) (hs' : UniformAt X s') :
+    (s ⊑ s') ↔ s' ⊆ s := by
+  constructor
+  · intro h q hq
+    obtain ⟨p, hp, hpq⟩ := h q hq
+    rwa [← hpq.eq_of_dom_eq ((hs p hp).trans (hs' q hq).symm)]
+  · exact fun h q hq => ⟨q, h hq, Possibility.Descendant.refl q⟩
+
+section Fibred
+variable [DecidableEq V]
+
+/-- Subsistence out of a stratum factors through reindexing: the weaker
+state includes into the restricted image of the stronger — the fibred
+order, glued from within-stratum `⊆` along `restrict`. -/
+theorem subsistsIn_iff_subset_restrict {X : Finset V}
+    {s s' : State W V M} (hs : UniformAt X s) :
+    (s ⪯ s') ↔ s ⊆ Possibility.restrict X '' s' := by
+  constructor
+  · intro h p hp
+    obtain ⟨q, hq, hpq⟩ := h p hp
+    exact ⟨q, hq,
+      ((Possibility.descendant_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
+  · rintro h p hp
+    obtain ⟨q, hq, rfl⟩ := h hp
+    exact ⟨q, hq, Possibility.restrict_descendant X q⟩
+
+/-- Informativeness out of a stratum factors through reindexing: the
+restricted image of the stronger is included in the weaker — the
+eliminative direction of the fibred order. -/
+theorem infoLe_iff_restrict_subset {X : Finset V}
+    {s s' : State W V M} (hs : UniformAt X s) :
+    (s ⊑ s') ↔ Possibility.restrict X '' s' ⊆ s := by
+  constructor
+  · rintro h r ⟨q, hq, rfl⟩
+    obtain ⟨p, hp, hpq⟩ := h q hq
+    rwa [← (Possibility.descendant_iff_eq_restrict (hs p hp)).mp hpq]
+  · intro h q hq
+    exact ⟨q.restrict X, h ⟨q, hq, rfl⟩,
+      Possibility.restrict_descendant X q⟩
+
+end Fibred
+
 variable [DecidableEq V]
 
 /-- Restriction of a state: pointwise, by direct image. -/
@@ -192,12 +341,24 @@ theorem subsistsIn_restrict (X : Finset V) (I : State W V M) :
   rintro p ⟨q, hq, rfl⟩
   exact ⟨q, hq, Possibility.restrict_descendant X q⟩
 
+/-- Restriction meets the stratification. -/
+theorem uniformAt_restrict {X Y : Finset V} {I : State W V M}
+    (h : UniformAt Y I) : UniformAt (X ∩ Y) (I.restrict X) := by
+  rintro p ⟨q, hq, rfl⟩
+  rw [Possibility.dom_restrict, h q hq, Finset.coe_inter]
+
+/-- Restriction composes along intersections. -/
+theorem restrict_restrict (X Y : Finset V) (I : State W V M) :
+    (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
+  unfold restrict
+  rw [← Set.image_comp]
+  exact congrFun (congrArg _ (funext (Possibility.restrict_restrict X Y))) I
+
 /-- Random assignment ([elliott-sudo-2025], (43);
 [groenendijk-stokhof-1991]'s `x := random`): indeterministically extend
 each point to a defined value at `x`. -/
 def randomAssign (I : State W V M) (x : V) : State W V M :=
-  {p | ∃ q ∈ I, ∃ m : M,
-    p = ⟨q.world, Function.update q.assignment x (some m)⟩}
+  {p | ∃ q ∈ I, ∃ m : M, p = q.extend x (some m)}
 
 end State
 

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -105,6 +105,65 @@ theorem apply_comp (u : Transition W M X Y) (v : Transition W M Y Z)
   · rintro ⟨k, ⟨e, he, hek⟩, hkh⟩
     exact ⟨e, he, k, hek, hkh⟩
 
+/-! ### Application to root states -/
+
+section ApplyState
+
+/-- Context change on root states ([kamp-vangenabith-reyle-2011],
+Def. 24 — the regular CCP): points of the `X`-stratum step to points of
+the `Y`-stratum through the transition, worlds preserved. Index-free:
+both sides are plain states. -/
+def applyState (u : Transition W M X Y) (I : State W V M) :
+    State W V M :=
+  {q | q.dom = (↑Y : Set V) ∧ ∃ p ∈ I, p.dom = (↑X : Set V) ∧
+    p.world = q.world ∧
+    ∃ (e : (↑X : Set V) → M) (e' : (↑Y : Set V) → M),
+      (∀ v : (↑X : Set V), p.assignment v.1 = some (e v)) ∧
+      (∀ v : (↑Y : Set V), q.assignment v.1 = some (e' v)) ∧
+      u.rel q.world e e'}
+
+/-- Application lands in the target stratum. -/
+theorem uniformAt_applyState (u : Transition W M X Y) (I : State W V M) :
+    State.UniformAt Y (u.applyState I) := fun _ hq => hq.1
+
+variable [DecidableEq V]
+
+/-- The point of the `Y`-stratum carrying a given world and environment. -/
+private def ptOf (Y : Finset V) (w : W) (e : (↑Y : Set V) → M) :
+    Possibility W V (Option M) :=
+  ⟨w, fun v => if hv : v ∈ (↑Y : Set V) then some (e ⟨v, hv⟩) else none⟩
+
+private theorem dom_ptOf (Y : Finset V) (w : W) (e : (↑Y : Set V) → M) :
+    (ptOf Y w e).dom = (↑Y : Set V) := by
+  ext v
+  by_cases hv : v ∈ (↑Y : Set V) <;> simp [ptOf, Possibility.dom, hv]
+
+/-- Root application is functorial. -/
+theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
+    (I : State W V M) :
+    (u.comp v).applyState I = v.applyState (u.applyState I) := by
+  ext q
+  constructor
+  · rintro ⟨hq, p, hpI, hp, hw, e, e'', he, he'', k, huk, hkv⟩
+    refine ⟨hq, ptOf Y q.world k, ⟨dom_ptOf .., p, hpI, hp, hw, e, k, he,
+      fun x => ?_, huk⟩, dom_ptOf .., rfl, k, e'', fun x => ?_, he'', hkv⟩
+    · simp [ptOf]
+    · simp [ptOf]
+  · rintro ⟨hq, m, ⟨hm, p, hpI, hp, hw, e, k, he, hk, huk⟩, -, hmw, k', e'',
+      hk', he'', hvk⟩
+    have hkk' : k = k' := funext fun x => by
+      have h1 := hk x
+      have h2 := hk' x
+      rw [h1] at h2
+      exact (Option.some.injEq .. ▸ h2 :)
+    refine ⟨hq, p, hpI, hp, hw.trans hmw, e, e'', he, he'', k, ?_, ?_⟩
+    · rw [← hmw]
+      exact huk
+    · rw [hkk']
+      exact hvk
+
+end ApplyState
+
 /-! ### Random assignment -/
 
 /-- The random-assignment transition ([groenendijk-stokhof-1991]'s random
@@ -197,6 +256,13 @@ def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X')
     (hX' : X' = X'') (hY' : Y' = Y'') :
     (u.copy hX hY).copy hX' hY' = u.copy (hX.trans hX') (hY.trans hY') := by
   subst hX hY hX' hY'
+  rfl
+
+/-- Typed relations repackage by re-proving the growth. -/
+theorem ofTotal_copy {R : W → (V → M) → (V → M) → Prop} {h : X ⊆ Y}
+    {Y' : Finset V} (hY : Y = Y') :
+    (ofTotal h R).copy rfl hY = ofTotal (hY ▸ h) R := by
+  subst hY
   rfl
 
 /-- Repackaged transitions compose to the repackaged composite. -/

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -117,6 +117,67 @@ def randomAssign [DecidableEq V] (X : Finset V) (x : V) :
     e ⟨v, hv⟩ = e' ⟨v, Finset.mem_insert_of_mem hv⟩
   grow := Finset.subset_insert x X
 
+/-! ### Typing total-assignment relations
+
+Frameworks state their clauses on total assignments (DPL's Definition 2,
+DRT's verification). `ofTotal` types such a relation at contexts by
+existential extension; the predecessor's `supported_left`/
+`supported_right` fields return as *hypotheses* — `ReadsAt`/`WritesAt` —
+carried by the framework's own congruence lemmas, and under them the
+typing is faithful (`ofTotal_rel_restrict`) and functorial
+(`ofTotal_comp`). -/
+
+section OfTotal
+
+variable {R S : W → (V → M) → (V → M) → Prop}
+
+/-- The relation reads its input only at `X`. -/
+def ReadsAt (X : Finset V) (R : W → (V → M) → (V → M) → Prop) : Prop :=
+  ∀ ⦃w f f' g⦄, Set.EqOn f f' (↑X : Set V) → (R w f g ↔ R w f' g)
+
+/-- The relation constrains its output only at `Y`. -/
+def WritesAt (Y : Finset V) (R : W → (V → M) → (V → M) → Prop) : Prop :=
+  ∀ ⦃w f g g'⦄, Set.EqOn g g' (↑Y : Set V) → (R w f g ↔ R w f g')
+
+/-- Type a total-assignment relation at contexts, by existential
+extension of the environments. -/
+def ofTotal (h : X ⊆ Y) (R : W → (V → M) → (V → M) → Prop) :
+    Transition W M X Y where
+  rel w e e' := ∃ f g : V → M, (↑X : Set V).restrict f = e ∧
+    (↑Y : Set V).restrict g = e' ∧ R w f g
+  grow := h
+
+/-- Under the support hypotheses, the typing is faithful: related
+environments are exactly the restrictions of related assignments. -/
+theorem ofTotal_rel_restrict {h : X ⊆ Y} (hR : ReadsAt X R)
+    (hW : WritesAt Y R) {w : W} {f g : V → M} :
+    (ofTotal h R).rel w ((↑X : Set V).restrict f)
+      ((↑Y : Set V).restrict g) ↔ R w f g := by
+  constructor
+  · rintro ⟨f', g', hf', hg', hR'⟩
+    rw [hR (Set.restrict_eq_restrict_iff.mp hf'),
+      hW (Set.restrict_eq_restrict_iff.mp hg')] at hR'
+    exact hR'
+  · intro hfg
+    exact ⟨f, g, rfl, rfl, hfg⟩
+
+/-- Typing is functorial on composition, given read-support of the second
+relation: the mid-assignments stitch. -/
+theorem ofTotal_comp {h₁ : X ⊆ Y} {h₂ : Y ⊆ Z} (hS : ReadsAt Y S) :
+    (ofTotal h₁ R).comp (ofTotal h₂ S) =
+      ofTotal (h₁.trans h₂) (fun w => Relation.Comp (R w) (S w)) := by
+  ext w e e''
+  constructor
+  · rintro ⟨e', ⟨f, g₁, hf, hg₁, hR⟩, f₂, g, hf₂, hg, hS'⟩
+    refine ⟨f, g, hf, hg, g₁, hR, ?_⟩
+    rw [← hf₂] at hg₁
+    exact (hS (Set.restrict_eq_restrict_iff.mp hg₁)).mpr hS'
+  · rintro ⟨f, g, hf, hg, k, hR, hS'⟩
+    exact ⟨(↑Y : Set V).restrict k, ⟨f, k, hf, rfl, hR⟩,
+      ⟨k, g, rfl, hg, hS'⟩⟩
+
+end OfTotal
+
 /-! ### Repackaging along base equalities
 
 The substrate-safe form of `eqToHom` conjugation (mathlib's `Filter.copy`

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -258,6 +258,12 @@ def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X')
   subst hX hY hX' hY'
   rfl
 
+/-- Typing respects relation equality; the growth proof is irrelevant. -/
+theorem ofTotal_congr {R R' : W → (V → M) → (V → M) → Prop}
+    (h h' : X ⊆ Y) (hR : R = R') : ofTotal h R = ofTotal h' R' := by
+  subst hR
+  rfl
+
 /-- Typed relations repackage by re-proving the growth. -/
 theorem ofTotal_copy {R : W → (V → M) → (V → M) → Prop} {h : X ⊆ Y}
     {Y' : Finset V} (hY : Y = Y') :
@@ -276,6 +282,13 @@ theorem copy_comp_copy (u : Transition W M X Y) (v : Transition W M Y Z)
 @[simp] theorem apply_copy (u : Transition W M X Y) {X' Y' : Finset V}
     (hX : X = X') (hY : Y = Y') (T : Set (W × ((↑X' : Set V) → M))) :
     (u.copy hX hY).apply T = (by subst hX hY; exact u.apply T) := by
+  subst hX hY
+  rfl
+
+/-- Root application is invariant under repackaging. -/
+@[simp] theorem applyState_copy [DecidableEq V] (u : Transition W M X Y)
+    {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') (I : State W V M) :
+    (u.copy hX hY).applyState I = u.applyState I := by
   subst hX hY
   rfl
 

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -1,229 +1,139 @@
 import Linglib.Semantics.Dynamic.State
-import Linglib.Semantics.Dynamic.Update
 
 /-!
-# Transitions between indexed information states
+# Transitions between context fibers
 [kamp-vangenabith-reyle-2011] (Defs. 24, 27)
 
 The hom type of indexed dynamic semantics: a `Transition W M X Y` is a
-world-indexed relation between assignments that reads its input only at the
-source base `X` and writes its output only at the target base `Y ⊇ X`.
-Objects are bases (finite sets of discourse referents); a DRS denotes an
-arrow `X ⟶ X ∪ U`; sequencing is world-pointwise relational composition.
+world-indexed relation between an `X`-environment and a `Y`-environment,
+`Y ⊇ X`. Objects are bases; a DRS denotes an arrow `X ⟶ X ∪ U`;
+sequencing is world-pointwise relational composition. The predecessor of
+this file stated transitions on total assignments and carried
+`supported_left`/`supported_right` invariants; typing the relation at the
+environments dissolves both, and the identity transition becomes plain
+equality rather than agreement-on-`X`.
 
-Applying a transition to a `State` (Def. 24) is the level-0 `lift` of
-`Update.lean` at the forgotten relation (`toUpdate`) — level 1 rides
-level 0 by construction. The chapter's regularity conditions (Def. 27)
-become theorems: the base of the output is `I.base ∪ Y` (`apply_base`), and
-applying an extension at its source base only adds information
-(`le_apply`). In the unindexed, one-object collapse these facts degrade into
-side conditions (the Merging Lemma's freshness hypothesis); here the typing
-carries them.
-
-The chapter's own name for the induced map on information states is the
-(regular) *Context Change Potential* (Def. 24); *transition* names the
-underlying world-indexed relation, after the transition-system reading of
-dynamic semantics ([fernando-1992], cited there).
+Applying a transition acts fiberwise on sets of environments — the
+presheaf fibers of `Category.lean` — functorially (`apply_comp`). The
+chapter's own name for the induced map is the (regular) *Context Change
+Potential* (Def. 24); *transition* names the underlying relation, after
+the transition-system reading of dynamic semantics ([fernando-1992],
+cited there).
 
 ## Main declarations
 
-* `Transition` — the indexed relation; `id`, `comp` and their laws.
-* `Transition.toUpdate` — forget the bases (the collapse to level 0).
-* `Transition.apply` — Def. 24's context change, via `lift`.
-* `Transition.IsExtension` / `le_apply` — Def. 27(ii): information growth.
+* `Transition` — the typed relation; `id`, `comp` and their laws.
+* `Transition.apply` — Def. 24's context change, on fibers.
+* `Transition.copy` — repackaging along base equalities (the
+  `Filter.copy` pattern; the cast point, kept out of every statement).
+* `Transition.IsExtension` — Def. 27(ii): established referents persist.
+* `Transition.randomAssign` — the generating arrow `X ⟶ insert x X`.
 -/
 
 namespace DynamicSemantics
 
-open DynamicSemantics (lift)
-open Update
-
 variable {W V M : Type*} {X Y Z : Finset V}
 
-/-- A transition: a world-indexed relation between assignments reading
-inputs at `X` and writing outputs at `Y`. The `grow` field makes arrows
-context-extending — bases never shrink. -/
+/-- A transition: a world-indexed relation from `X`-environments to
+`Y`-environments. The `grow` field makes arrows context-extending —
+bases never shrink. -/
 @[ext] structure Transition (W M : Type*) {V : Type*} (X Y : Finset V) where
-  /-- The world-indexed relation between input and output assignments. -/
-  rel : W → (V → M) → (V → M) → Prop
+  /-- The world-indexed relation between input and output environments. -/
+  rel : W → ((↑X : Set V) → M) → ((↑Y : Set V) → M) → Prop
   /-- Bases only grow along an update. -/
   grow : X ⊆ Y
-  /-- Inputs are read only at the source base. -/
-  supported_left : ∀ ⦃w f f' g⦄, Set.EqOn f f' ↑X → (rel w f g ↔ rel w f' g)
-  /-- Outputs are constrained only at the target base. -/
-  supported_right : ∀ ⦃w f g g'⦄, Set.EqOn g g' ↑Y → (rel w f g ↔ rel w f g')
 
 namespace Transition
 
-/-- The identity transition at `X`: the test that changes nothing. -/
+/-- The identity transition at `X`: equality of environments. -/
 def id (X : Finset V) : Transition W M X X where
-  rel _ f g := Set.EqOn f g ↑X
+  rel _ e e' := e = e'
   grow := subset_rfl
-  supported_left _ _ _ _ hff' := ⟨hff'.symm.trans, hff'.trans⟩
-  supported_right _ _ _ _ hgg' := ⟨(·.trans hgg'), (·.trans hgg'.symm)⟩
+
+@[simp] theorem rel_id {w : W} {e e' : (↑X : Set V) → M} :
+    (id X : Transition W M X X).rel w e e' ↔ e = e' := Iff.rfl
 
 /-- Sequencing: world-pointwise relational composition. -/
 def comp (u : Transition W M X Y) (v : Transition W M Y Z) :
     Transition W M X Z where
   rel w := Relation.Comp (u.rel w) (v.rel w)
   grow := u.grow.trans v.grow
-  supported_left _ _ _ _ hff' :=
-    exists_congr fun _ => and_congr_left fun _ => u.supported_left hff'
-  supported_right _ _ _ _ hgg' :=
-    exists_congr fun _ => and_congr_right fun _ => v.supported_right hgg'
 
 @[simp] theorem id_comp (u : Transition W M X Y) : (id X).comp u = u := by
-  ext w f g
-  exact ⟨fun ⟨k, hfk, hk⟩ => (u.supported_left hfk).mpr hk,
-    fun h => ⟨f, Set.eqOn_refl f _, h⟩⟩
+  ext w e e'
+  exact ⟨fun ⟨k, hek, hk⟩ => hek ▸ hk, fun h => ⟨e, rfl, h⟩⟩
 
 @[simp] theorem comp_id (u : Transition W M X Y) : u.comp (id Y) = u := by
-  ext w f g
-  exact ⟨fun ⟨k, hk, hkg⟩ => (u.supported_right hkg).mp hk,
-    fun h => ⟨g, h, Set.eqOn_refl g _⟩⟩
+  ext w e e'
+  exact ⟨fun ⟨k, hk, hke⟩ => hke ▸ hk, fun h => ⟨e', h, rfl⟩⟩
 
 theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
     {Z' : Finset V} (t : Transition W M Z Z') :
     (u.comp v).comp t = u.comp (v.comp t) := by
-  ext w f g
+  ext w e e'
   exact ⟨fun ⟨k, ⟨j, hj, hjk⟩, hk⟩ => ⟨j, hj, k, hjk, hk⟩,
     fun ⟨j, hj, k, hjk, hk⟩ => ⟨k, ⟨j, hj, hjk⟩, hk⟩⟩
 
-/-! ### The forgotten relation -/
+/-! ### Application to fibers -/
 
-/-- Forget the bases: the level-0 relation on possibilities (the world is
-preserved). -/
-def toUpdate (u : Transition W M X Y) :
-    Update (Possibility W V M) :=
-  fun p q => p.world = q.world ∧ u.rel p.world p.assignment q.assignment
+/-- Context change ([kamp-vangenabith-reyle-2011], Def. 24), on the
+presheaf fibers: relate environments through the transition, worlds
+preserved. -/
+def apply (u : Transition W M X Y)
+    (T : Set (W × ((↑X : Set V) → M))) :
+    Set (W × ((↑Y : Set V) → M)) :=
+  {e' | ∃ e, (e'.1, e) ∈ T ∧ u.rel e'.1 e e'.2}
 
-/-- Forgetting bases sends sequencing to relational composition — the
-one-object collapse is functorial on composition. (It is not unital:
-`toUpdate (id X)` is agreement on `X`, not equality — see the quotient
-collapse in `Category.lean`.) -/
-theorem toUpdate_comp (u : Transition W M X Y) (v : Transition W M Y Z) :
-    (u.comp v).toUpdate = seq u.toUpdate v.toUpdate := by
-  funext p q
-  simp only [toUpdate, comp, seq, Relation.Comp, eq_iff_iff]
-  constructor
-  · rintro ⟨hw, k, huk, hkv⟩
-    exact ⟨⟨p.world, k⟩, ⟨rfl, huk⟩, hw, hkv⟩
-  · rintro ⟨k, ⟨hwk, huk⟩, hkw, hkv⟩
-    refine ⟨hwk.trans hkw, k.assignment, huk, ?_⟩
-    rw [hwk]
-    exact hkv
+theorem mem_apply {u : Transition W M X Y}
+    {T : Set (W × ((↑X : Set V) → M))} {w : W} {g : (↑Y : Set V) → M} :
+    (w, g) ∈ u.apply T ↔ ∃ e, (w, e) ∈ T ∧ u.rel w e g := Iff.rfl
 
-/-! ### Application to information states -/
-
-section Apply
-variable [DecidableEq V]
-
-/-- Context change ([kamp-vangenabith-reyle-2011], Def. 24): the carrier is
-the level-0 `lift` of the forgotten relation; the base grows to
-`I.base ∪ Y` (Def. 27(ii)). -/
-def apply (u : Transition W M X Y) (I : State W V M) : State W V M where
-  base := I.base ∪ Y
-  carrier := lift u.toUpdate I.carrier
-  supported := baseSupported_of_iff fun _ _ _ hgg' =>
-    exists_congr fun _ => and_congr_right fun _ => and_congr_right fun _ =>
-      u.supported_right (hgg'.mono (by simp))
-
-@[simp] theorem apply_base (u : Transition W M X Y) (I : State W V M) :
-    (u.apply I).base = I.base ∪ Y := rfl
-
-theorem mem_apply {u : Transition W M X Y} {I : State W V M} {w : W}
-    {g : V → M} :
-    (⟨w, g⟩ : Possibility W V M) ∈ u.apply I ↔
-      ∃ f, (⟨w, f⟩ : Possibility W V M) ∈ I ∧ u.rel w f g := by
-  constructor
-  · rintro ⟨⟨w', f⟩, hf, rfl, hr⟩
-    exact ⟨f, hf, hr⟩
-  · rintro ⟨f, hf, hr⟩
-    exact ⟨⟨w, f⟩, hf, rfl, hr⟩
-
-/-- Applying the identity transition is the identity, at the identity. -/
-@[simp] theorem apply_id (I : State W V M) (h : I.base = X) :
-    (id X).apply I = I := by
-  ext1
-  · simp [h]
-  · ext ⟨w, g⟩
-    rw [State.mem_carrier, mem_apply]
-    exact ⟨fun ⟨f, hf, hfg⟩ => (I.supported.mem_iff (h ▸ hfg)).mp hf,
-      fun hg => ⟨g, hg, Set.eqOn_refl g _⟩⟩
+/-- Applying the identity transition is the identity. -/
+@[simp] theorem apply_id (T : Set (W × ((↑X : Set V) → M))) :
+    (id X).apply T = T := by
+  ext ⟨w, e⟩
+  exact ⟨fun ⟨k, hk, hke⟩ => (show k = e from hke) ▸ hk, fun h => ⟨e, h, rfl⟩⟩
 
 /-- `apply` is functorial: sequencing then applying is applying twice. -/
 theorem apply_comp (u : Transition W M X Y) (v : Transition W M Y Z)
-    (I : State W V M) : (u.comp v).apply I = v.apply (u.apply I) := by
-  ext1
-  · simp only [apply_base, Finset.union_assoc, Finset.union_eq_right.mpr v.grow]
-  · ext ⟨w, h⟩
-    rw [State.mem_carrier, mem_apply, State.mem_carrier, mem_apply]
-    constructor
-    · rintro ⟨f, hf, k, hfk, hkh⟩
-      exact ⟨k, mem_apply.mpr ⟨f, hf, hfk⟩, hkh⟩
-    · rintro ⟨k, hk, hkh⟩
-      obtain ⟨f, hf, hfk⟩ := mem_apply.mp hk
-      exact ⟨f, hf, k, hfk, hkh⟩
-
-end Apply
+    (T : Set (W × ((↑X : Set V) → M))) :
+    (u.comp v).apply T = v.apply (u.apply T) := by
+  ext ⟨w, h⟩
+  constructor
+  · rintro ⟨e, he, k, hek, hkh⟩
+    exact ⟨k, ⟨e, he, hek⟩, hkh⟩
+  · rintro ⟨k, ⟨e, he, hek⟩, hkh⟩
+    exact ⟨e, he, k, hek, hkh⟩
 
 /-! ### Random assignment -/
 
-section RandomAssign
-variable [DecidableEq V]
-
 /-- The random-assignment transition ([groenendijk-stokhof-1991]'s random
-reset `k[x]g`, [heim-1982]'s indefinite widening): read the input off `x`,
-leave the output free at `x` — the generating arrow `X ⟶ insert x X` of
-context extension. -/
-def randomAssign (X : Finset V) (x : V) : Transition W M X (insert x X) where
-  rel _ f h := Set.EqOn f h ↑(X.erase x)
+reset `k[x]g`, [heim-1982]'s indefinite widening): preserve the input off
+`x`, leave the output free at `x` — the generating arrow
+`X ⟶ insert x X` of context extension. -/
+def randomAssign [DecidableEq V] (X : Finset V) (x : V) :
+    Transition W M X (insert x X) where
+  rel _ e e' := ∀ (v : V) (hv : v ∈ X), v ≠ x →
+    e ⟨v, hv⟩ = e' ⟨v, Finset.mem_insert_of_mem hv⟩
   grow := Finset.subset_insert x X
-  supported_left _ _ _ _ hff' :=
-    have hsub : (↑(X.erase x) : Set V) ⊆ ↑X :=
-      Finset.coe_subset.mpr (Finset.erase_subset ..)
-    ⟨((hff'.mono hsub).symm.trans ·), ((hff'.mono hsub).trans ·)⟩
-  supported_right _ _ _ _ hgg' :=
-    have hsub : (↑(X.erase x) : Set V) ⊆ ↑(insert x X) :=
-      Finset.coe_subset.mpr ((Finset.erase_subset ..).trans (Finset.subset_insert ..))
-    ⟨(·.trans (hgg'.mono hsub)), (·.trans (hgg'.symm.mono hsub))⟩
-
-@[simp] theorem rel_randomAssign {x : V} {w : W} {f h : V → M} :
-    (randomAssign (M := M) X x).rel w f h ↔ Set.EqOn f h ↑(X.erase x) :=
-  Iff.rfl
-
-/-- Applying the random-assignment transition at a state's own base is the
-state-level random assignment of `State.lean`. -/
-theorem randomAssign_apply (I : State W V M) (x : V) :
-    (randomAssign I.base x).apply I = I.randomAssign x := by
-  ext1
-  · exact Finset.union_eq_right.mpr (Finset.subset_insert ..)
-  · ext ⟨w, g⟩
-    rw [State.mem_carrier, mem_apply]
-    exact Iff.rfl
-
-end RandomAssign
 
 /-! ### Repackaging along base equalities
 
 The substrate-safe form of `eqToHom` conjugation (mathlib's `Filter.copy`
 pattern): composites whose indices differ by `Finset` identities — e.g.
-`(X ∪ U₁) ∪ U₂` against `X ∪ (U₁ ∪ U₂)` — are equated through `copy`, keeping
-cast-free statements everywhere below the category layer. -/
+`(X ∪ U₁) ∪ U₂` against `X ∪ (U₁ ∪ U₂)` — are equated through `copy`,
+keeping cast-free statements everywhere below the category layer. -/
 
 /-- Repackage a transition along equalities of its bases. -/
-def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') :
-    Transition W M X' Y' :=
+def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X')
+    (hY : Y = Y') : Transition W M X' Y' :=
   hX ▸ hY ▸ u
-
-@[simp] theorem rel_copy (u : Transition W M X Y) {X' Y' : Finset V}
-    (hX : X = X') (hY : Y = Y') : (u.copy hX hY).rel = u.rel := by
-  subst hX hY; rfl
 
 @[simp] theorem copy_rfl (u : Transition W M X Y) : u.copy rfl rfl = u := rfl
 
-@[simp] theorem copy_copy (u : Transition W M X Y) {X' Y' X'' Y'' : Finset V}
-    (hX : X = X') (hY : Y = Y') (hX' : X' = X'') (hY' : Y' = Y'') :
+@[simp] theorem copy_copy (u : Transition W M X Y)
+    {X' Y' X'' Y'' : Finset V} (hX : X = X') (hY : Y = Y')
+    (hX' : X' = X'') (hY' : Y' = Y'') :
     (u.copy hX hY).copy hX' hY' = u.copy (hX.trans hX') (hY.trans hY') := by
   subst hX hY hX' hY'
   rfl
@@ -236,36 +146,28 @@ theorem copy_comp_copy (u : Transition W M X Y) (v : Transition W M Y Z)
   rfl
 
 /-- Application is invariant under repackaging. -/
-@[simp] theorem apply_copy [DecidableEq V] (u : Transition W M X Y)
-    {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') (I : State W V M) :
-    (u.copy hX hY).apply I = u.apply I := by
-  subst hX hY; rfl
+@[simp] theorem apply_copy (u : Transition W M X Y) {X' Y' : Finset V}
+    (hX : X = X') (hY : Y = Y') (T : Set (W × ((↑X' : Set V) → M))) :
+    (u.copy hX hY).apply T = (by subst hX hY; exact u.apply T) := by
+  subst hX hY
+  rfl
 
 /-! ### Information growth (Def. 27) -/
 
-/-- A transition is an *extension* when outputs agree with inputs on the source
-base: established referents persist, only new ones are assigned. -/
+/-- A transition is an *extension* when outputs restrict to their inputs:
+established referents persist, only new ones are assigned. -/
 def IsExtension (u : Transition W M X Y) : Prop :=
-  ∀ ⦃w f g⦄, u.rel w f g → Set.EqOn g f ↑X
+  ∀ ⦃w e e'⦄, u.rel w e e' → e = fun v => e' ⟨v.1, u.grow v.2⟩
 
 /-- The identity is an extension. -/
 theorem isExtension_id : (id X : Transition W M X X).IsExtension :=
-  fun _ _ _ h => h.symm
+  fun _ _ _ h => h
 
 /-- Extensions compose. -/
 theorem IsExtension.comp {u : Transition W M X Y} {v : Transition W M Y Z}
     (hu : u.IsExtension) (hv : v.IsExtension) : (u.comp v).IsExtension := by
-  rintro w f g ⟨k, hfk, hkg⟩
-  exact ((hv hkg).mono (Finset.coe_subset.mpr u.grow)).trans (hu hfk)
-
-/-- Def. 27(ii): applying an extension at its source base only adds
-information — the informativeness order grows along updates. -/
-theorem le_apply [DecidableEq V] (u : Transition W M X Y) (hu : u.IsExtension)
-    (I : State W V M) (hbase : I.base = X) : I ≤ u.apply I := by
-  refine ⟨hbase ▸ Finset.subset_union_left, ?_⟩
-  rintro ⟨w, g⟩ hg
-  obtain ⟨f, hf, hr⟩ := mem_apply.mp hg
-  exact (I.supported.mem_iff ((hu hr).symm.mono (by rw [hbase]))).mp hf
+  rintro w e e' ⟨k, hek, hke⟩
+  rw [hu hek, hv hke]
 
 end Transition
 

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -1,5 +1,5 @@
+import Linglib.Semantics.Dynamic.State
 import Linglib.Semantics.Dynamic.Update
-import Linglib.Semantics.Dynamic.Possibility
 import Linglib.Core.Logic.Bilateral.Defs
 import Mathlib.Algebra.Group.Defs
 
@@ -39,7 +39,9 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 - `partition`, `partition_assertable`: every possibility subsists
   positively, subsists negatively, or is unknown.
 - `de_morgan_disj`, `de_morgan_conj`: de Morgan's laws, unlike in
-  standard dynamic semantics.
+  standard dynamic semantics. (Descendance, subsistence, `worlds`,
+  `Familiar`, and random assignment now live at the root, in
+  `State.lean` — this file's vocabulary became the module's.)
 - `egli`: Egli's theorem for the positive dimension, definitionally.
 - `isBilateral`: the update algebra is a bilateral logic in the sense of
   `Core.Logic.Bilateral`.
@@ -59,64 +61,6 @@ The empirical comparison against full ICDRT is in
 namespace DynamicSemantics
 
 variable {W V E : Type*}
-
-/-! ### Partiality, descendance, subsistence -/
-
-/-- `q` is a *descendant* of `p` ([elliott-sudo-2025], Def. 3.3): same
-world, and `q`'s assignment extends `p`'s wherever the latter is defined
-([groenendijk-stokhof-veltman-1996]'s form — see the module docstring). -/
-def Possibility.Descendant (p q : Possibility W V (Option E)) : Prop :=
-  p.world = q.world ∧ ∀ x e, p.assignment x = some e → q.assignment x = some e
-
-theorem Possibility.Descendant.refl (p : Possibility W V (Option E)) :
-    p.Descendant p :=
-  ⟨rfl, fun _ _ h => h⟩
-
-theorem Possibility.Descendant.trans {p q r : Possibility W V (Option E)}
-    (hpq : p.Descendant q) (hqr : q.Descendant r) : p.Descendant r :=
-  ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
-
-/-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it has a
-descendant in `s`. -/
-def Subsists (p : Possibility W V (Option E))
-    (s : Set (Possibility W V (Option E))) : Prop :=
-  ∃ q ∈ s, p.Descendant q
-
-@[inherit_doc] scoped notation:50 p " ≺ " s => Subsists p s
-
-theorem Subsists.of_mem {p : Possibility W V (Option E)}
-    {s : Set (Possibility W V (Option E))} (h : p ∈ s) : p ≺ s :=
-  ⟨p, h, Possibility.Descendant.refl p⟩
-
-/-- A state subsists in another when each of its possibilities does — the
-state-level reading of the paper's overloaded `≺`. -/
-def subsistsIn (s s' : Set (Possibility W V (Option E))) : Prop :=
-  ∀ p ∈ s, p ≺ s'
-
-@[inherit_doc] scoped notation:50 s " ⪯ " s' => subsistsIn s s'
-
-/-! ### Worldly information, familiarity, random assignment -/
-
-/-- The *worldly information* of a state ([elliott-sudo-2025], Def. 3.1's
-𝒲): its image in the worlds. -/
-def worlds {M : Type*} (s : Set (Possibility W V M)) : Set W :=
-  Possibility.world '' s
-
-@[simp] theorem mem_worlds {M : Type*} {s : Set (Possibility W V M)} {w : W} :
-    w ∈ worlds s ↔ ∃ p ∈ s, Possibility.world p = w := Iff.rfl
-
-/-- A variable is *familiar* at a state ([elliott-sudo-2025], Def. 3.2)
-when it is defined at every possibility; its values may still differ
-across possibilities. -/
-def Familiar (s : Set (Possibility W V (Option E))) (x : V) : Prop :=
-  ∀ p ∈ s, p.assignment x ≠ none
-
-/-- Random assignment ([elliott-sudo-2025], (43)): indeterministically
-extend each possibility to a defined value at `x`. Novelty is not encoded
-— updates may be destructive, per the paper. -/
-def randomAssign [DecidableEq V] (s : Set (Possibility W V (Option E)))
-    (x : V) : Set (Possibility W V (Option E)) :=
-  {q | ∃ p ∈ s, ∃ e : E, q = p.extend x (some e)}
 
 /-! ### Bilateral denotations -/
 
@@ -292,10 +236,10 @@ the scope; the negative update merely removes possibilities — it retains
 those of `s` whose world falsifies the existential classically, and
 introduces no anaphoric information. -/
 def exists_ (x : V) (φ : BilateralDen W V E) : BilateralDen W V E where
-  positive s := φ.positive (randomAssign s x)
+  positive s := φ.positive (State.randomAssign s x)
   negative s :=
-    {p ∈ s | p.world ∉ worlds (φ.positive (randomAssign s x)) ∧
-      p.world ∈ worlds (φ.negative (randomAssign s x))}
+    {p ∈ s | p.world ∉ worlds (φ.positive (State.randomAssign s x)) ∧
+      p.world ∈ worlds (φ.negative (State.randomAssign s x))}
 
 /-- Universal quantification, by de Morgan duality: `∀x φ = ¬∃x ¬φ`. -/
 def forall_ (x : V) (φ : BilateralDen W V E) : BilateralDen W V E :=

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -323,98 +323,116 @@ theorem noGluing_merged : ¬ ∃ s, IsGluing mergedCover mergedFamily s := by
 
 open DynamicSemantics
 
-/-- The anticorrelation state on two referents. -/
-private def anti (i j : Fin 3) : State Unit (Fin 3) Bool where
-  base := {i, j}
-  carrier := {p | p.assignment i ≠ p.assignment j}
-  supported := baseSupported_of_iff fun _ f g hfg => by
-    show f i ≠ f j ↔ g i ≠ g j
-    rw [hfg (by simp), hfg (by simp)]
+/-- The anticorrelation state on two referents: points defining exactly
+`{i, j}`, with distinct values. -/
+private def anti (i j : Fin 3) : State Unit (Fin 3) Bool :=
+  {p | p.dom = (↑({i, j} : Finset (Fin 3)) : Set (Fin 3)) ∧
+    p.assignment i ≠ p.assignment j}
 
-/-- Anticorrelation restricted to a singleton is no information: flip
-the other coordinate to witness any value. -/
-private theorem mem_anti_restrict {i j k : Fin 3} (hij : i ≠ j)
-    (hk : i = k ∨ j = k) (p : Possibility Unit (Fin 3) Bool) :
-    p ∈ (anti i j).restrict {k} := by
-  obtain ⟨w, g⟩ := p
-  rcases hk with rfl | rfl
-  · refine ⟨Function.update (fun _ => !(g i)) i (g i), ?_, fun y hy => ?_⟩
-    · show Function.update (fun _ => !(g i)) i (g i) i ≠
-        Function.update (fun _ => !(g i)) i (g i) j
-      rw [Function.update_self, Function.update_of_ne (Ne.symm hij)]
-      exact fun h => Bool.not_ne_self _ h.symm
-    · obtain rfl : y = i := by simpa using hy
-      exact Function.update_self ..
-  · refine ⟨Function.update (fun _ => !(g j)) j (g j), ?_, fun y hy => ?_⟩
-    · show Function.update (fun _ => !(g j)) j (g j) i ≠
-        Function.update (fun _ => !(g j)) j (g j) j
-      rw [Function.update_self, Function.update_of_ne hij]
-      exact Bool.not_ne_self _
-    · obtain rfl : y = j := by simpa using hy
-      exact Function.update_self ..
+/-- A two-referent point. -/
+private def pt2 (i j : Fin 3) (a b : Bool) :
+    Possibility Unit (Fin 3) (Option Bool) :=
+  ⟨(), fun v => if v = i then some a else if v = j then some b else none⟩
 
-private theorem anti_restrict_eq {i j k i' j' : Fin 3} (hij : i ≠ j)
-    (hij' : i' ≠ j') (hk : i = k ∨ j = k) (hk' : i' = k ∨ j' = k) :
-    (anti i j).restrict {k} = (anti i' j').restrict {k} :=
-  State.ext rfl (Set.ext fun p =>
-    iff_of_true (mem_anti_restrict hij hk p) (mem_anti_restrict hij' hk' p))
+private theorem pt2_mem_anti {i j : Fin 3} (hij : i ≠ j) (a b : Bool)
+    (hab : a ≠ b) : pt2 i j a b ∈ anti i j := by
+  refine ⟨?_, ?_⟩
+  · ext v
+    by_cases hvi : v = i
+    · simp [pt2, Possibility.dom, hvi]
+    · by_cases hvj : v = j <;>
+        simp [pt2, Possibility.dom, hvi, hvj, hij.symm]
+  · simp only [pt2, if_pos rfl, if_neg hij.symm]
+    exact fun h => hab (Option.some.injEq .. ▸ h :)
 
-/-- The three anticorrelation states are pairwise compatible. -/
-theorem anti_pairwise_compatible :
-    ((anti 0 1).Compatible (anti 1 2)) ∧
-    ((anti 1 2).Compatible (anti 0 2)) ∧
-    ((anti 0 1).Compatible (anti 0 2)) := by
-  refine ⟨?_, ?_, ?_⟩
-  · show (anti 0 1).restrict _ = (anti 1 2).restrict _
-    rw [show ((anti 0 1).base ∩ (anti 1 2).base : Finset (Fin 3)) = {1}
-      from by decide]
-    exact anti_restrict_eq (by decide) (by decide) (Or.inr rfl) (Or.inl rfl)
-  · show (anti 1 2).restrict _ = (anti 0 2).restrict _
-    rw [show ((anti 1 2).base ∩ (anti 0 2).base : Finset (Fin 3)) = {2}
-      from by decide]
-    exact anti_restrict_eq (by decide) (by decide) (Or.inr rfl) (Or.inr rfl)
-  · show (anti 0 1).restrict _ = (anti 0 2).restrict _
-    rw [show ((anti 0 1).base ∩ (anti 0 2).base : Finset (Fin 3)) = {0}
-      from by decide]
-    exact anti_restrict_eq (by decide) (by decide) (Or.inl rfl) (Or.inl rfl)
+/-- Adjacent anticorrelation states are consistent: their Def. 26 merge
+is inhabited — the pair glues. -/
+private theorem merge_anti_nonempty {i j k : Fin 3} (hij : i ≠ j)
+    (hjk : j ≠ k) (hik : i ≠ k) :
+    ((anti i j).merge (anti j k)).Nonempty := by
+  refine ⟨(pt2 i j false true).union (pt2 j k true false),
+    pt2 i j false true, pt2_mem_anti hij false true (by simp),
+    pt2 j k true false, pt2_mem_anti hjk true false (by simp), ?_, rfl⟩
+  refine ⟨rfl, fun v e e' he he' => ?_⟩
+  simp only [pt2] at he he'
+  split at he
+  · rename_i hvi
+    subst hvi
+    rw [if_neg hij, if_neg hik] at he'
+    exact absurd he' (by simp)
+  · split at he
+    · rename_i hvi hvj
+      subst hvj
+      rw [if_pos rfl] at he'
+      have h1 : e = true := by
+        have := he.symm
+        simpa using this
+      have h2 : e' = true := by
+        have := he'.symm
+        simpa using this
+      rw [h1, h2]
+    · exact absurd he (by simp)
 
-/-- **Contextuality in the `State` fibers**: no state restricts onto all
-three anticorrelation constraints — Boolean anticorrelation cannot hold
-on three referents at once. Pairwise-compatible local information with
-no global section, the paper's contextuality, model-theoretically. -/
+/-- **Contextuality in the states** ([abramsky-sadrzadeh-2014]'s frame,
+model-theoretically): the three anticorrelation constraints are pairwise
+consistent — each pair merges (`merge_anti_nonempty`) — but no state
+restricts onto all three: Boolean anticorrelation cannot hold on three
+referents at once. Local consistency without a global section. -/
 theorem no_gluing_triangle :
     ¬ ∃ S : State Unit (Fin 3) Bool,
       S.restrict {0, 1} = anti 0 1 ∧ S.restrict {1, 2} = anti 1 2 ∧
       S.restrict {0, 2} = anti 0 2 := by
   rintro ⟨S, h01, h12, h02⟩
-  have hsub : ∀ {Y : Finset (Fin 3)} {p : Possibility Unit (Fin 3) Bool},
-      p ∈ S → p ∈ S.restrict Y :=
-    fun hp => ⟨_, hp, Set.eqOn_refl _ _⟩
-  have hempty : S.carrier = ∅ := by
-    refine Set.eq_empty_iff_forall_notMem.mpr fun p hp => ?_
-    have hp01 : p.assignment 0 ≠ p.assignment 1 := by
-      have h := hsub (Y := ({0, 1} : Finset (Fin 3))) hp
-      rw [h01] at h
-      exact h
-    have hp12 : p.assignment 1 ≠ p.assignment 2 := by
-      have h := hsub (Y := ({1, 2} : Finset (Fin 3))) hp
-      rw [h12] at h
-      exact h
-    have hp02 : p.assignment 0 ≠ p.assignment 2 := by
-      have h := hsub (Y := ({0, 2} : Finset (Fin 3))) hp
-      rw [h02] at h
-      exact h
-    cases hb0 : p.assignment 0 <;> cases hb1 : p.assignment 1 <;>
-      cases hb2 : p.assignment 2 <;> simp_all
-  have h2 : (anti 0 1).prop = ∅ := by
-    rw [← h01, State.prop_restrict]
-    refine Set.eq_empty_iff_forall_notMem.mpr fun w hw => ?_
-    obtain ⟨f, hf⟩ := hw
-    exact Set.eq_empty_iff_forall_notMem.mp hempty _ hf
-  have hwit : (() : Unit) ∈ (anti 0 1).prop :=
-    ⟨fun k => decide (k = 1),
-      show decide ((0 : Fin 3) = 1) ≠ decide ((1 : Fin 3) = 1) by decide⟩
-  rw [h2] at hwit
-  exact hwit
+  -- the target states are inhabited, so S is
+  have hne : S.Nonempty := by
+    rcases Set.eq_empty_or_nonempty S with rfl | h
+    · have : (∅ : State Unit (Fin 3) Bool) = anti 0 1 := by
+        simpa [State.restrict] using h01
+      exact absurd (this ▸ pt2_mem_anti (by decide) false true (by simp) :
+        pt2 0 1 false true ∈ (∅ : State Unit (Fin 3) Bool)) (by simp)
+    · exact h
+  obtain ⟨r, hr⟩ := hne
+  -- r's restrictions land in each anticorrelation state
+  have key : ∀ (i j : Fin 3), S.restrict {i, j} = anti i j →
+      ∃ a b : Bool, r.assignment i = some a ∧ r.assignment j = some b ∧
+        a ≠ b := by
+    intro i j hS
+    have hmem : r.restrict {i, j} ∈ anti i j := by
+      rw [← hS]
+      exact ⟨r, hr, rfl⟩
+    obtain ⟨hdom, hne⟩ := hmem
+    rw [Possibility.dom_restrict] at hdom
+    have hi : (r.assignment i).isSome := by
+      have : i ∈ (↑({i, j} : Finset (Fin 3)) : Set (Fin 3)) ∩
+          Possibility.dom r := by
+        rw [hdom]
+        simp
+      exact this.2
+    have hj : (r.assignment j).isSome := by
+      have : j ∈ (↑({i, j} : Finset (Fin 3)) : Set (Fin 3)) ∩
+          Possibility.dom r := by
+        rw [hdom]
+        simp
+      exact this.2
+    obtain ⟨a, ha⟩ := Option.isSome_iff_exists.mp hi
+    obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp hj
+    refine ⟨a, b, ha, hb, fun hab => ?_⟩
+    subst hab
+    apply hne
+    have hri : (r.restrict {i, j}).assignment i = some a := by
+      simpa [Possibility.restrict] using ha
+    have hrj : (r.restrict {i, j}).assignment j = some a := by
+      simpa [Possibility.restrict] using hb
+    rw [hri, hrj]
+  obtain ⟨a, b, ha, hb, hab⟩ := key 0 1 h01
+  obtain ⟨b', c, hb', hc, hbc⟩ := key 1 2 h12
+  obtain ⟨a', c', ha', hc', hac⟩ := key 0 2 h02
+  rw [hb] at hb'
+  rw [ha] at ha'
+  rw [hc] at hc'
+  obtain rfl := (Option.some.injEq .. ▸ hb' :)
+  obtain rfl := (Option.some.injEq .. ▸ ha' :)
+  obtain rfl := (Option.some.injEq .. ▸ hc' :)
+  cases a <;> cases b <;> cases c <;> simp_all
 
 end AbramskySadrzadeh2014

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -342,7 +342,7 @@ private theorem pt2_mem_anti {i j : Fin 3} (hij : i ≠ j) (a b : Bool)
     · simp [pt2, Possibility.dom, hvi]
     · by_cases hvj : v = j <;>
         simp [pt2, Possibility.dom, hvi, hvj, hij.symm]
-  · simp only [pt2, if_pos rfl, if_neg hij.symm]
+  · simp only [pt2, if_neg hij.symm]
     exact fun h => hab (Option.some.injEq .. ▸ h :)
 
 /-- Adjacent anticorrelation states are consistent: their Def. 26 merge

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -674,8 +674,7 @@ theorem constant_presup_satisfied_iff_satisfiable
   · intro hsat
     obtain ⟨w, hw⟩ := hne
     exact ⟨w, hw, hsat hw⟩
-  · intro ⟨_, _, hdef⟩
-    intro _ _
+  · intro ⟨_, _, hdef⟩ _ _
     exact hdef
 
 -- ============================================================================
@@ -718,7 +717,8 @@ existential introduction but the output state is a subset of the input.
 
 section BilateralBridge
 
-open DynamicSemantics (BilateralDen Possibility worlds randomAssign)
+open DynamicSemantics (BilateralDen Possibility worlds)
+open DynamicSemantics.State (randomAssign)
 open DynamicSemantics.BilateralDen (neg exists_ atom)
 
 variable {W E : Type*}

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -1,7 +1,6 @@
 import Linglib.Core.Logic.CylindricAlgebra
 import Linglib.Semantics.Dynamic.DPL
 import Linglib.Semantics.Dynamic.Transition
-import Mathlib.Logic.Function.DependsOn
 
 /-!
 # Groenendijk & Stokhof (1991): Dynamic Predicate Logic
@@ -462,13 +461,14 @@ end SatisfactionSets
 /-! ### The indexed reading: DPL generators as context extension -/
 
 /-! DPL meanings are relations on total assignments (Definition 2); the
-indexed substrate (`Transition.lean`) types them by the contexts they read
-and write. The two generators land as arrows: tests (clauses 1–3, 5, 6, 8
-are all of this shape) become `testTransition`s `X ⟶ X`, and the random
-reset of clause 7 is `Transition.randomAssign : X ⟶ insert x X`.
-Sequencing is clause 4 (`rel_comp_iff_conj`), and the existential factors
-as random assignment composed with its scope
-(`rel_randomAssign_comp_iff_exists`) — so a DPL formula's indexed meaning is
+indexed substrate (`Transition.lean`) types them by the contexts they
+read and write, via the total–typed bridge `Transition.ofTotal`. Tests
+(clauses 1–3, 5, 6, 8 are all of this shape) become `testTransition`s
+`X ⟶ X` — the predecessor's `DependsOn` guard dissolved with the
+typing — and the random reset of clause 7 is `Transition.randomAssign :
+X ⟶ insert x X`. Sequencing is clause 4 (`toTransition_comp`), and the
+existential factors through the category *unconditionally*
+(`randomAssign_comp_toTransition`) — a DPL formula's indexed meaning is
 a composite of the generating arrows of `DynamicSemantics.Ctx`. -/
 
 section IndexedReading
@@ -477,62 +477,95 @@ open DynamicSemantics DynamicSemantics.Update
 
 variable {W : Type*} {X Y : Finset ℕ}
 
-/-- A DPL test as a transition: a condition supported on the context,
-checked without changing the assignment. Clauses 1–3, 5, 6, and 8 of
+/-- A DPL relation as a transition at contexts, worlds inert, via the
+substrate's total–typed bridge. -/
+def toTransition (h : X ⊆ Y) (φ : DPLRel E) : Transition W E X Y :=
+  Transition.ofTotal h fun _ => φ
+
+/-- A DPL test as a transition: a condition on the context, checked
+without changing the environment. Clauses 1–3, 5, 6, and 8 of
 Definition 2 are all of this form. -/
-def testTransition (X : Finset ℕ) (C : (ℕ → E) → Prop)
-    (hC : DependsOn C ↑X) : Transition W E X X where
-  rel _ f h := Set.EqOn f h ↑X ∧ C f
+def testTransition (X : Finset ℕ) (C : ((↑X : Set ℕ) → E) → Prop) :
+    Transition W E X X where
+  rel _ e e' := e = e' ∧ C e
   grow := subset_rfl
-  supported_left _ _ _ _ hff' :=
-    and_congr ⟨(hff'.symm.trans ·), (hff'.trans ·)⟩ (iff_of_eq (hC hff'))
-  supported_right _ _ _ _ hgg' :=
-    and_congr ⟨(·.trans hgg'), (·.trans hgg'.symm)⟩ Iff.rfl
 
-/-- Applying a test at a state indexed below its context filters the
-carrier — the indexed form of Definition 2's test clauses. -/
-theorem mem_testTransition_apply {C : (ℕ → E) → Prop} {hC : DependsOn C ↑X}
-    {I : State W ℕ E} (hbase : I.base ⊆ X) {w : W} {g : ℕ → E} :
-    (⟨w, g⟩ : Possibility W ℕ E) ∈ (testTransition X C hC).apply I ↔
-      (⟨w, g⟩ : Possibility W ℕ E) ∈ I ∧ C g := by
-  rw [Transition.mem_apply]
+/-- Applying a test filters the fiber — the indexed form of
+Definition 2's test clauses. -/
+theorem testTransition_apply {C : ((↑X : Set ℕ) → E) → Prop}
+    (T : Set (W × ((↑X : Set ℕ) → E))) :
+    (testTransition X C).apply T = {e ∈ T | C e.2} := by
+  ext ⟨w, e⟩
   constructor
-  · rintro ⟨f, hf, hfg, hCf⟩
-    exact ⟨(I.supported.mem_iff (hfg.mono (Finset.coe_subset.mpr hbase))).mp hf,
-      (hC hfg) ▸ hCf⟩
-  · rintro ⟨hg, hCg⟩
-    exact ⟨g, hg, Set.eqOn_refl g _, hCg⟩
+  · rintro ⟨e₀, he₀, heq, hC⟩
+    cases heq
+    exact ⟨he₀, hC⟩
+  · rintro ⟨hT, hC⟩
+    exact ⟨e, hT, rfl, hC⟩
 
-/-- Clause 4 is transition composition: if `u` and `v` realize `φ` and
-`ψ` world-pointwise, their composite realizes `φ ∧ ψ`. -/
-theorem rel_comp_iff_conj {Z : Finset ℕ} {u : Transition W E X Y}
-    {v : Transition W E Y Z} {φ ψ : DPLRel E}
-    (hu : ∀ w f h, u.rel w f h ↔ φ f h) (hv : ∀ w f h, v.rel w f h ↔ ψ f h)
-    (w : W) (f h : ℕ → E) :
-    (u.comp v).rel w f h ↔ DPLRel.conj φ ψ f h :=
-  exists_congr fun k => and_congr (hu w f k) (hv w k h)
+/-- Clause 4 is transition composition: with the second conjunct reading
+within its context, typed sequencing is DPL conjunction. -/
+theorem toTransition_comp {Z : Finset ℕ} (h₁ : X ⊆ Y) (h₂ : Y ⊆ Z)
+    {φ ψ : DPLRel E}
+    (hψ : Transition.ReadsAt (W := W) Y fun _ => ψ) :
+    (toTransition (W := W) h₁ φ).comp (toTransition h₂ ψ) =
+      toTransition (h₁.trans h₂) (φ.conj ψ) :=
+  Transition.ofTotal_comp hψ
 
-/-- Clause 7 factors through the category: the existential is the
-random-assignment arrow composed with its scope. The scope's transition
-reads only `insert x X`, which is what lets the reset's underspecification
-off `x` collapse to Definition 2's `∃d`. -/
-theorem rel_randomAssign_comp_iff_exists {x : ℕ}
-    {u : Transition W E (insert x X) Y} {φ : DPLRel E}
-    (hu : ∀ w f h, u.rel w f h ↔ φ f h) (w : W) (f h : ℕ → E) :
-    ((Transition.randomAssign X x).comp u).rel w f h ↔
-      DPLRel.exists_ x φ f h := by
+/-- Clause 7 factors through the category, unconditionally: composing the
+random-assignment arrow with a typed scope is the existential. The
+scope's transition reads only `insert x X`, which is what lets the
+reset's underspecification off `x` collapse to Definition 2's `∃d`. -/
+theorem randomAssign_comp_toTransition {x : ℕ} (h : insert x X ⊆ Y)
+    (φ : DPLRel E) :
+    (Transition.randomAssign X x).comp (toTransition (W := W) h φ) =
+      toTransition ((Finset.subset_insert x X).trans h)
+        (DPLRel.exists_ x φ) := by
+  ext w e e''
   constructor
-  · rintro ⟨k, hfk, huk⟩
-    refine ⟨k x, (hu ..).mp ((u.supported_left fun y hy => ?_).mp huk)⟩
-    rcases Finset.mem_insert.mp hy with rfl | hyX
-    · simp
-    · rcases eq_or_ne y x with rfl | hyx
-      · simp
-      · exact (hfk (Finset.mem_coe.mpr (Finset.mem_erase.mpr ⟨hyx, hyX⟩))).symm.trans
-          (if_neg hyx).symm
-  · rintro ⟨d, hφ⟩
-    refine ⟨fun n => if n = x then d else f n, fun y hy => ?_, (hu ..).mpr hφ⟩
-    exact (if_neg (Finset.mem_erase.mp hy).1).symm
+  · rintro ⟨e', hmid, f, g, hf, hg, hφ⟩
+    by_cases hx : x ∈ X
+    · refine ⟨Function.update f x (e ⟨x, hx⟩), g, funext fun v => ?_, hg,
+        f x, ?_⟩
+      · rcases eq_or_ne v.1 x with hvx | hvx
+        · show Function.update f x (e ⟨x, hx⟩) v.1 = e v
+          rw [show v = ⟨x, hx⟩ from Subtype.ext hvx]
+          exact Function.update_self ..
+        · show Function.update f x (e ⟨x, hx⟩) v.1 = e v
+          rw [Function.update_of_ne hvx]
+          have h1 : f v.1 = e' ⟨v.1, Finset.mem_insert_of_mem v.2⟩ :=
+            congrFun hf ⟨v.1, Finset.mem_insert_of_mem v.2⟩
+          rw [h1]
+          exact (hmid v.1 v.2 hvx).symm
+      · have hff : (fun n => if n = x then f x
+            else Function.update f x (e ⟨x, hx⟩) n) = f := funext fun n => by
+          rcases eq_or_ne n x with rfl | hn
+          · simp
+          · simp [Function.update_of_ne hn, if_neg hn]
+        show φ _ g
+        rw [hff]
+        exact hφ
+    · refine ⟨f, g, funext fun v => ?_, hg, f x, ?_⟩
+      · show f v.1 = e v
+        have h1 : f v.1 = e' ⟨v.1, Finset.mem_insert_of_mem v.2⟩ :=
+          congrFun hf ⟨v.1, Finset.mem_insert_of_mem v.2⟩
+        rw [h1]
+        exact (hmid v.1 v.2 fun hvx => hx (hvx ▸ v.2)).symm
+      · have hff : (fun n => if n = x then f x else f n) = f :=
+          funext fun n => by
+            rcases eq_or_ne n x with rfl | hn
+            · simp
+            · simp [if_neg hn]
+        show φ _ g
+        rw [hff]
+        exact hφ
+  · rintro ⟨F, g, hF, hg, d, hφ⟩
+    refine ⟨(↑(insert x X) : Set ℕ).restrict fun n => if n = x then d else F n,
+      fun v hv hvx => ?_, (fun n => if n = x then d else F n), g,
+      rfl, hg, hφ⟩
+    show e ⟨v, hv⟩ = if v = x then d else F v
+    rw [if_neg hvx]
+    exact (congrFun hF ⟨v, hv⟩).symm
 
 end IndexedReading
 

--- a/Linglib/Studies/Heim1982/Basic.lean
+++ b/Linglib/Studies/Heim1982/Basic.lean
@@ -7,7 +7,7 @@ import Linglib.Data.Examples.Heim1982
 
 Formal analysis of cross-sentential anaphora using [heim-1982]'s
 File Change Semantics. This study file connects the FCS theory
-(`Semantics/Dynamic/FileChange/Basic.lean`) to the example rows
+(`Studies/Heim1982/FileChangeSemantics.lean`) to the example rows
 in `Data/Examples/Heim1982.json` (`Heim1982.Examples`).
 
 ## Key Claims Formalized
@@ -27,7 +27,9 @@ in `Data/Examples/Heim1982.json` (`Heim1982.Examples`).
 
 5. **Truth criterion (C)**: φ is true w.r.t. F iff Sat(F + φ) is
    nonempty ([heim-1982], Ch III §3.2). This builds existential
-   quantification into the notion of truth.
+   quantification into the notion of truth — see `trueIn`,
+   `supports_trueIn`, `supports_idempotent`, and the eliminativity
+   family (Principle (A)) in `FileChangeSemantics.lean`.
 
 ## Connection to Empirical Data
 
@@ -68,39 +70,39 @@ where ∃x₁ extends Dom(F) to include x₁.
 
 /-- The indefinite "a man walked in" as an FCP:
 ∃x. man(x) ∧ walkedIn(x). -/
-def aManWalkedIn (man walkedIn : E → Prop) (x : Nat) : FCP W E :=
+def aManWalkedIn (man walkedIn : E → Prop) (x : ℕ) : FCP W E :=
   FCP.indef x (FCP.seq (FCP.atomVar man x) (FCP.atomVar walkedIn x))
 
 /-- "He sat down" as an FCP: satDown(x). -/
-def heSatDown (satDown : E → Prop) (x : Nat) : FCP W E :=
+def heSatDown (satDown : E → Prop) (x : ℕ) : FCP W E :=
   FCP.atomVar satDown x
 
 /-- The full discourse "A man walked in. He sat down." -/
-def indefinitePersistsDiscourse (man walkedIn satDown : E → Prop) (x : Nat) :
+def indefinitePersistsDiscourse (man walkedIn satDown : E → Prop) (x : ℕ) :
     FCP W E :=
   FCP.seq (aManWalkedIn man walkedIn x) (heSatDown satDown x)
 
 /-- When x is novel, the indefinite FCP is defined
-(not a presupposition failure) — provided the body is total. -/
-theorem indef_defined_when_novel (x : Nat) (F : State W ℕ E)
-    (hnovel : x ∉ F.base) (body : FCP W E)
-    (hbody : ∀ G, ∃ G', body G = some G') :
-    ∃ F', FCP.indef x body F = some F' := by
-  simp only [FCP.indef, if_neg hnovel]
-  exact hbody _
+(not a presupposition failure) — provided the body is defined on the
+randomly assigned file. -/
+theorem indef_defined_when_novel (x : ℕ) (F : State W ℕ E)
+    (hnovel : ∀ p ∈ F, p.assignment x = none) (body : FCP W E)
+    (hbody : (body (F.randomAssign x)).Dom) :
+    definedOn F (FCP.indef x body) :=
+  ⟨hnovel, hbody⟩
 
-/-- After the indefinite, x is in the domain — provided the body
-preserves domain membership.
+/-- After the indefinite, x is familiar — provided the body preserves
+familiarity.
 
 This is the formal content of "indefinites introduce discourse
 referents" — the defining claim of [heim-1982]. -/
-theorem indef_adds_to_dom (x : Nat) (body : FCP W E)
-    (F F' : State W ℕ E) (hnovel : x ∉ F.base)
-    (hres : FCP.indef x body F = some F')
-    (hbody_dom : ∀ G G', body G = some G' → x ∈ G.base → x ∈ G'.base) :
-    x ∈ F'.base := by
-  simp only [FCP.indef, if_neg hnovel] at hres
-  exact hbody_dom _ F' hres (by simp)
+theorem indef_adds_to_dom (x : ℕ) (body : FCP W E)
+    (F : State W ℕ E) {F' : State W ℕ E}
+    (hres : F' ∈ FCP.indef x body F)
+    (hbody : ∀ G, Familiar G x → ∀ G' ∈ body G, Familiar G' x) :
+    Familiar F' x := by
+  obtain ⟨-, hmem⟩ := Part.mem_assert_iff.mp hres
+  exact hbody _ (State.familiar_randomAssign F x) F' hmem
 
 -- ════════════════════════════════════════════════════
 -- § 3. Negation Blocks Dref Export
@@ -110,21 +112,19 @@ theorem indef_adds_to_dom (x : Nat) (body : FCP W E)
 
 This accounts for `Examples.standard_negation_blocks`.
 The FCS analysis: negation closes the scope of the indefinite's dref.
-After F + [¬(∃x. bird(x) ∧ saw(j,x))], x is NOT in Dom — the
-negation's domain matches the input domain, not the extended one.
--/
+After F + [¬(∃x. bird(x) ∧ saw(j,x))], x is NOT familiar — negation
+keeps points of the input file, where x was never assigned. -/
 
-/-- A variable introduced inside negation is NOT in the output domain.
+/-- A variable introduced inside negation stays novel in the output.
 
-Negation preserves the input domain (`neg_preserves_dom`), so a
-novel variable stays novel after negation — the dref is trapped
+Negation is eliminative over the *input* file (`neg_eliminative`), so
+a novel variable stays novel after negation — the dref is trapped
 inside the scope of ¬. -/
-theorem neg_blocks_dref (x : Nat) (φ : FCP W E)
-    (F : State W ℕ E) (hnovel : x ∉ F.base)
-    (F' : State W ℕ E) (h : FCP.neg (FCP.indef x φ) F = some F') :
-    x ∉ F'.base := by
-  rw [neg_preserves_base (FCP.indef x φ) F F' h]
-  exact hnovel
+theorem neg_blocks_dref (x : ℕ) (φ : FCP W E) {F F' : State W ℕ E}
+    (hnovel : ∀ p ∈ F, p.assignment x = none)
+    (h : F' ∈ FCP.neg φ F) :
+    ∀ p ∈ F', p.assignment x = none :=
+  fun p hp => hnovel p (neg_eliminative φ h hp)
 
 -- ════════════════════════════════════════════════════
 -- § 4. Novelty-Familiarity Condition
@@ -137,98 +137,40 @@ p. 202):
 - Definites REQUIRE familiarity (x ∈ Dom(F))
 
 Violations cause undefinedness (presupposition failure), not
-falsehood. This is modeled by FCPs returning `none`. -/
+falsehood. This is modeled by FCPs being `Part`-undefined. -/
 
 /-- An indefinite with a familiar index causes presupposition failure.
 
 This accounts for why "*A man₁ walked in. A man₁ sat down." is
 infelicitous when the second indefinite reuses index 1. -/
-theorem novelty_violation (x : Nat) (body : FCP W E)
-    (F : State W ℕ E) (h : x ∈ F.base) :
-    FCP.indef x body F = none :=
-  indef_familiar_none x body F h
+theorem novelty_violation (x : ℕ) (body : FCP W E)
+    (F : State W ℕ E) (hne : F.Nonempty) (h : Familiar F x) :
+    ¬ definedOn F (FCP.indef x body) :=
+  indef_not_novel_not_definedOn x body F fun hall => by
+    obtain ⟨p, hp⟩ := hne
+    exact h p hp (hall p hp)
 
 /-- A definite with a novel index causes presupposition failure.
 
 This accounts for why "#He₁ sat down." is infelicitous at the start
 of a discourse (when no index 1 dref has been established). -/
-theorem familiarity_violation (x : Nat) (body : FCP W E)
-    (F : State W ℕ E) (h : x ∉ F.base) :
-    FCP.def_ x body F = none :=
-  def_novel_none x body F h
+theorem familiarity_violation (x : ℕ) (body : FCP W E)
+    (F : State W ℕ E) (h : ¬ Familiar F x) :
+    ¬ definedOn F (FCP.def_ x body) :=
+  def_not_familiar_not_definedOn x body F h
 
-/-- An indefinite followed by a definite with the same index is
-well-defined: the indefinite makes x familiar for the definite.
+/-- On a file where x is familiar, the definite applies transparently.
 
-"A man₁ walked in. He₁ sat down." — after the indefinite introduces
-dref 1, the definite "he₁" finds it familiar. -/
-theorem indef_then_def_defined (x : Nat)
-    (bodyIndef bodyDef : FCP W E)
-    (F : State W ℕ E) (_hnovel : x ∉ F.base)
-    (F₁ : State W ℕ E)
-    (_hstep1 : FCP.indef x bodyIndef F = some F₁)
-    (hfam : x ∈ F₁.base) :
-    FCP.def_ x bodyDef F₁ = bodyDef F₁ :=
-  if_pos hfam
+With `indef_adds_to_dom`, this derives "A man₁ walked in. He₁ sat
+down.": the indefinite makes index 1 familiar, so the definite "he₁"
+is no presupposition failure. -/
+theorem def_familiar (x : ℕ) (body : FCP W E)
+    (F : State W ℕ E) (hfam : Familiar F x) :
+    FCP.def_ x body F = body F :=
+  Part.assert_pos hfam
 
 -- ════════════════════════════════════════════════════
--- § 5. Truth Criterion (C)
--- ════════════════════════════════════════════════════
-
-/-! [heim-1982]'s truth definition (Ch III §3.2, p. 214):
-
-> (C) A formula φ is true w.r.t. a file F if F + φ is true,
->     and false w.r.t. F if F + φ is false.
-
-A file is true iff Sat(F) ≠ ∅. So truth of φ w.r.t. F amounts to
-Sat(F + φ) being nonempty. Crucially, this builds existential
-quantification into the notion of truth, making Existential Closure
-dispensable (Ch III §3.1). -/
-
-/-- Truth unfolds to: F + φ is defined and has nonempty Sat. -/
-theorem trueIn_iff (F : State W ℕ E) (φ : FCP W E) :
-    trueIn F φ ↔ ∃ F', φ F = some F' ∧ F'.carrier.Nonempty :=
-  Iff.rfl
-
-/-- Falsity unfolds to: F + φ is defined but has empty Sat. -/
-theorem falseIn_iff (F : State W ℕ E) (φ : FCP W E) :
-    falseIn F φ ↔ ∃ F', φ F = some F' ∧ ¬F'.carrier.Nonempty :=
-  Iff.rfl
-
-/-- Support (idempotency) implies truth for consistent files. -/
-theorem support_implies_truth (F : State W ℕ E) (φ : FCP W E)
-    (hsup : supports F φ) (hcons : F.carrier.Nonempty) : trueIn F φ :=
-  supports_trueIn F φ hsup hcons
-
-/-- Support is idempotent: if F supports φ, then updating twice
-equals updating once. -/
-theorem support_double_update (F : State W ℕ E) (φ : FCP W E)
-    (h : supports F φ) : FCP.seq φ φ F = φ F :=
-  supports_idempotent F φ h
-
--- ════════════════════════════════════════════════════
--- § 6. Eliminativity (Principle A)
--- ════════════════════════════════════════════════════
-
-/-! [heim-1982]'s Principle (A): file change only eliminates
-possibilities, never adds them. This holds for atomic updates,
-negation, and their compositions. -/
-
-/-- Negation is eliminative: Sat(F + ¬φ) ⊆ Sat(F). -/
-theorem neg_is_eliminative (φ : FCP W E) (F F' : State W ℕ E)
-    (h : FCP.neg φ F = some F') : F'.carrier ⊆ F.carrier :=
-  neg_eliminative φ F F' h
-
-/-- Sequential composition preserves eliminativity. -/
-theorem seq_is_eliminative (φ ψ : FCP W E)
-    (hφ : ∀ F F', φ F = some F' → F'.carrier ⊆ F.carrier)
-    (hψ : ∀ F F', ψ F = some F' → F'.carrier ⊆ F.carrier)
-    (F F' : State W ℕ E) (h : FCP.seq φ ψ F = some F') :
-    F'.carrier ⊆ F.carrier :=
-  seq_eliminative φ ψ hφ hψ F F' h
-
--- ════════════════════════════════════════════════════
--- § 7. Concrete Examples
+-- § 5. Concrete Examples
 -- ════════════════════════════════════════════════════
 
 /-! We instantiate the FCS framework with a concrete finite model
@@ -249,24 +191,21 @@ inductive ExEntity : Type where
 
 open ExWorld ExEntity
 
-instance : Nonempty (Possibility ExWorld ℕ ExEntity) :=
-  ⟨⟨w₀, λ _ => john⟩⟩
-
-/-- Starting file: no discourse referents, all possibilities — the
-minimal state `Λ`. -/
-def startFile : State ExWorld ℕ ExEntity := ⊥
+/-- Starting file: no discourse referents, all worlds open — the
+minimal state. -/
+def startFile : State ExWorld ℕ ExEntity := State.initial
 
 /-- Index 1 is novel in the start file (no drefs yet). -/
-example : 1 ∉ startFile.base := by
-  simp [startFile]
+example : ∀ p ∈ startFile, p.assignment 1 = none :=
+  fun _ hp => hp 1
 
-/-- The start file is consistent (Sat = Set.univ is nonempty). -/
-example : startFile.carrier.Nonempty := Set.univ_nonempty
+/-- The start file is consistent (nonempty). -/
+example : startFile.Nonempty := ⟨⟨w₀, λ _ => none⟩, λ _ => rfl⟩
 
 end ConcreteExamples
 
 -- ════════════════════════════════════════════════════
--- § 8. Connection to Empirical Data
+-- § 6. Connection to Empirical Data
 -- ════════════════════════════════════════════════════
 
 /-! Each row in `Heim1982.Examples` corresponds to a structural property
@@ -274,12 +213,13 @@ of FCS. The per-row theorems below check the row's recorded judgment
 against the FCS prediction derived above. -/
 
 /-- Indefinite persistence is judged acceptable; FCS predicts this via
-`indef_adds_to_dom` (the indefinite extends Dom and nothing closes it). -/
+`indef_adds_to_dom` (the indefinite makes its index familiar and nothing
+closes it). -/
 theorem datum_indefinitePersists :
     Examples.indefinite_persists.judgment = .acceptable := rfl
 
 /-- Single negation blocks; FCS predicts this via `neg_blocks_dref`
-(negation preserves the input domain). -/
+(negation keeps only input-file points). -/
 theorem datum_standardNegationBlocks :
     Examples.standard_negation_blocks.judgment = .unacceptable := rfl
 
@@ -292,7 +232,7 @@ theorem datum_negativeBlocks :
     Examples.negative_blocks.judgment = .unacceptable := rfl
 
 /-- Definite reference is acceptable; FCS predicts this via
-`indef_then_def_defined` (the established dref satisfies familiarity). -/
+`def_familiar` (the established dref satisfies familiarity). -/
 theorem datum_definiteReference :
     Examples.definite_reference.judgment = .acceptable := rfl
 

--- a/Linglib/Studies/Heim1982/FileChangeSemantics.lean
+++ b/Linglib/Studies/Heim1982/FileChangeSemantics.lean
@@ -1,53 +1,43 @@
 import Linglib.Semantics.Dynamic.State
+import Mathlib.Data.PFun
 
 /-!
 # File Change Semantics
 [heim-1982] [heim-1983]
 
 Heim's File Change Semantics: sentence meanings are *file change
-potentials* (FCPs), partial functions from files to files. A file
-`⟨Dom(F), Sat(F)⟩` *is* a based information state: `Dom(F)` is
-`State.base` (the open file cards) and `Sat(F)` is `State.carrier`, whose
-support invariant renders the partiality of Heim's satisfaction sequences
-— they carry information exactly at the file's cards. Partiality of FCPs
-(`Option`) models presupposition as definedness: the Novelty Condition for
-indefinites, the Familiarity Condition for definites.
+potentials* (FCPs), partial functions from files to files. A file *is* an
+information state (`Semantics/Dynamic/State.lean`): its cards are the
+defined referents of its points, `Dom(F)` the shared domain of a uniform
+file, `Sat(F)` the state itself. Partiality of FCPs models
+presupposition as definedness — and since the Novelty and Familiarity
+Conditions are genuinely propositional over base-free states, the
+partiality is `Part`'s, the module's own partial column
+(`Dynamic/Partial.lean`): `(φ F).Dom` is Heim's "F admits φ".
+
+Heim's clauses land on the root vocabulary: familiarity is `Familiar`,
+negation keeps the points of `F` that do *not subsist* (`≺`) in the
+scope's update — the no-verifying-extension clause is non-subsistence,
+the same repair [groenendijk-stokhof-veltman-1996] Def. 3.1 makes.
 
 ## Main definitions
 
-- `FCP`: partial functions `State W ℕ E → Option (State W ℕ E)`.
-- `FCP.atomW`, `atomVar`, `atomVar2`: atomic updates (filter the carrier).
-- `FCP.seq`, `neg`, `cond`: conjunction as sequencing, negation as the
-  no-verifying-extension test, conditionals as `¬(φ ∧ ¬ψ)`.
+- `FCP`: partial functions `State W ℕ E →. State W ℕ E`.
+- `FCP.atomW`, `atomVar`, `atomVar2`: atomic updates (filter the points).
+- `FCP.seq`, `neg`, `cond`: conjunction as sequencing, negation as
+  non-subsistence, conditionals as `¬(φ ∧ ¬ψ)`.
 - `FCP.indef`, `def_`: novelty-guarded introduction (via
   `State.randomAssign`) and familiarity-guarded definite update.
 - `trueIn`, `falseIn` (truth criterion (C), Ch III §3.2), `supports`,
-  `fcpEntails`.
+  `fcpEntails`, `definedOn`.
 
 ## Main results
 
-- `atomVar_definedOn_iff`: familiarity of the variable is exactly
-  definedness of the atomic update.
-- `neg_preserves_base`, `neg_blocks_dref` (in `Basic.lean`): negation
-  traps discourse referents.
-- `atomW_eliminative`, `neg_eliminative`, `seq_eliminative`:
-  Principle (A) — file change only eliminates possibilities.
-
-## Implementation notes
-
-Negation keeps the possibilities of `F` with *no verifying extension* in
-the scope's update (the negation clause familiar from DRT,
-[kamp-reyle-1993]): membership in the update restricted back to `F.base`
-(`State.restrict`) says exactly "some extension survives". A raw
-non-membership clause over total assignments would let a possibility
-survive `¬∃x φ` whenever its own irrelevant `x`-value fails `φ`.
-
-[heim-1982]'s rule (i'') lets atomic updates expand the domain by the
-mentioned variables. We follow the modern convention (shared by DRT and
-DPL) where domain growth is the indefinite's job — and the support
-discipline turns the convention's proviso ("every variable mentioned has
-already been introduced") into a genuine definedness condition on
-`atomVar`/`atomVar2`.
+- `atomVar_definedOn_iff`: Heim's Familiarity Condition is exactly
+  definedness of the atomic update — stated with `Familiar` itself.
+- `atomW_eliminative`, `atomVar_eliminative`, `neg_eliminative`,
+  `seq_eliminative`: Principle (A) — file change only eliminates points.
+- `seq_assoc`, `id_seq`, `seq_id`: the FCP monoid.
 -/
 
 namespace FileChangeSemantics
@@ -57,71 +47,48 @@ open DynamicSemantics
 variable {W E : Type*}
 
 /-- A File Change Potential: a partial function from files to files.
-Partiality (`Option`) captures presupposition-as-definedness: when a
-novelty or familiarity precondition fails, the FCP returns `none` rather
-than an empty file. -/
-def FCP (W : Type*) (E : Type*) := State W ℕ E → Option (State W ℕ E)
+`Part`-partiality captures presupposition-as-definedness: when a novelty
+or familiarity precondition fails, the FCP is undefined rather than
+absurd. -/
+def FCP (W : Type*) (E : Type*) := State W ℕ E →. State W ℕ E
 
-/-- Card `i` in `F` refers to entity `x` iff every satisfying possibility
-assigns `x` to position `i` (Ch III §2.3, p. 207). -/
+/-- Card `i` in `F` refers to entity `x` iff every point assigns `x` to
+position `i` (Ch III §2.3). -/
 def refersTo (F : State W ℕ E) (i : ℕ) (x : E) : Prop :=
-  ∀ p ∈ F.carrier, p.assignment i = x
+  ∀ p ∈ F, p.assignment i = some x
 
 namespace FCP
 
-/-- Atomic predicate on the world: filter the carrier, keep the base. -/
+/-- Atomic predicate on the world: filter the points. -/
 def atomW (pred : W → Prop) : FCP W E :=
-  λ F => some
-    { base := F.base
-      carrier := {p ∈ F.carrier | pred p.world}
-      supported := baseSupported_of_iff fun _ _ _ hfg =>
-        and_congr (F.supported.mem_iff hfg) Iff.rfl }
+  fun F => Part.some {p ∈ F | pred p.world}
 
-/-- Atomic predicate on the variable `x`: filter the carrier by the value
-at `x`. Defined only if `x` is familiar — the support discipline makes
-"every variable mentioned has been introduced" a definedness condition. -/
+/-- Atomic predicate on the variable `x`: filter the points by the value
+at `x`. Defined only if `x` is familiar — Heim's "every variable
+mentioned has been introduced", as a genuine definedness condition. -/
 def atomVar (pred : E → Prop) (x : ℕ) : FCP W E :=
-  λ F => if hx : x ∈ F.base then
-    some
-      { base := F.base
-        carrier := {p ∈ F.carrier | pred (p.assignment x)}
-        supported := baseSupported_of_iff fun _ f g hfg =>
-          and_congr (F.supported.mem_iff hfg)
-            (by show pred (f x) ↔ pred (g x)
-                rw [hfg (Finset.mem_coe.mpr hx)]) }
-  else none
+  fun F => Part.assert (Familiar F x) fun _ =>
+    Part.some {p ∈ F | ∃ e, p.assignment x = some e ∧ pred e}
 
 /-- Binary atomic predicate on `x` and `y`; both must be familiar. -/
 def atomVar2 (pred : E → E → Prop) (x y : ℕ) : FCP W E :=
-  λ F => if hxy : x ∈ F.base ∧ y ∈ F.base then
-    some
-      { base := F.base
-        carrier := {p ∈ F.carrier | pred (p.assignment x) (p.assignment y)}
-        supported := baseSupported_of_iff fun _ f g hfg =>
-          and_congr (F.supported.mem_iff hfg)
-            (by show pred (f x) (f y) ↔ pred (g x) (g y)
-                rw [hfg (Finset.mem_coe.mpr hxy.1),
-                  hfg (Finset.mem_coe.mpr hxy.2)]) }
-  else none
+  fun F => Part.assert (Familiar F x ∧ Familiar F y) fun _ =>
+    Part.some {p ∈ F | ∃ e e', p.assignment x = some e ∧
+      p.assignment y = some e' ∧ pred e e'}
 
 /-- Sequential composition (conjunction): `F + [φ ∧ ψ] = (F + φ) + ψ`.
 If either step is undefined (presupposition failure), the whole is. -/
 def seq (φ ψ : FCP W E) : FCP W E :=
-  λ F => (φ F).bind ψ
+  fun F => (φ F).bind ψ
 
 @[inherit_doc] infixl:70 " +> " => seq
 
-/-- Negation: keep the possibilities of `F` with no verifying extension in
-the scope's update — membership in the update restricted back to `F.base`
-says "some extension survives". The base is preserved: negation traps
-discourse referents. Undefined when the scope is. -/
+/-- Negation: keep the points of `F` that do not subsist in the scope's
+update — the no-verifying-extension clause, as non-subsistence.
+Referents introduced inside the scope are trapped. Undefined when the
+scope is. -/
 def neg (φ : FCP W E) : FCP W E :=
-  λ F => (φ F).map fun F' =>
-    { base := F.base
-      carrier := {p ∈ F.carrier | p ∉ F'.restrict F.base}
-      supported := baseSupported_of_iff fun _ _ _ hfg =>
-        and_congr (F.supported.mem_iff hfg)
-          (not_congr ((F'.restrict F.base).supported.mem_iff hfg)) }
+  fun F => (φ F).map fun F' => {p ∈ F | ¬ p ≺ F'}
 
 /-- Conditional: `F + [if φ then ψ] = F + [¬(φ ∧ ¬ψ)]` — Heim's analysis
 of conditionals as negated conjunctions. -/
@@ -129,41 +96,43 @@ def cond (φ ψ : FCP W E) : FCP W E :=
   neg (seq φ (neg ψ))
 
 /-- Indefinite introduction: defined only if `x` is novel (the Novelty
-Condition); then introduce `x` by random assignment and update with the
-body. Indefinites don't quantify — they open a new file card. -/
-def indef (x : ℕ) (body : FCP W E) : FCP W E :=
-  λ F => if x ∈ F.base then none else body (F.randomAssign x)
+Condition — no point defines it); then introduce `x` by random
+assignment and update with the body. Indefinites don't quantify — they
+open a new file card. -/
+def indef [DecidableEq ℕ] (x : ℕ) (body : FCP W E) : FCP W E :=
+  fun F => Part.assert (∀ p ∈ F, p.assignment x = none) fun _ =>
+    body (F.randomAssign x)
 
 /-- Definite reference: defined only if `x` is familiar (the Familiarity
-Condition); the dref is already established, so the file structure is
-untouched before the body applies. -/
+Condition); the dref is already established, so the file is untouched
+before the body applies. -/
 def def_ (x : ℕ) (body : FCP W E) : FCP W E :=
-  λ F => if x ∈ F.base then body F else none
+  fun F => Part.assert (Familiar F x) fun _ => body F
 
 /-- Identity FCP: no change. -/
-def id : FCP W E := λ F => some F
+def id : FCP W E := fun F => Part.some F
 
 /-- Absurd FCP: always undefined (total presupposition failure). -/
-def fail : FCP W E := λ _ => none
+def fail : FCP W E := fun _ => Part.none
 
 end FCP
 
 /-! ### Truth and entailment (Ch III §3) -/
 
-/-- Truth criterion (C) (Ch III §3.2, p. 214): `φ` is true w.r.t. `F` iff
-`F + φ` is defined and consistent. Existential quantification is built
-into truth itself — indefinites need no existential closure. -/
+/-- Truth criterion (C) (Ch III §3.2): `φ` is true w.r.t. `F` iff `F + φ`
+is defined and consistent. Existential quantification is built into
+truth itself — indefinites need no existential closure. -/
 def trueIn (F : State W ℕ E) (φ : FCP W E) : Prop :=
-  ∃ F', φ F = some F' ∧ F'.carrier.Nonempty
+  ∃ F' ∈ φ F, F'.Nonempty
 
 /-- `φ` is false w.r.t. `F` iff `F + φ` is defined but absurd. -/
 def falseIn (F : State W ℕ E) (φ : FCP W E) : Prop :=
-  ∃ F', φ F = some F' ∧ ¬F'.carrier.Nonempty
+  ∃ F' ∈ φ F, ¬F'.Nonempty
 
 /-- `F` supports `φ` iff updating changes nothing — the dynamic notion of
 entailment/support, stronger than `trueIn`. -/
 def supports (F : State W ℕ E) (φ : FCP W E) : Prop :=
-  φ F = some F
+  φ F = Part.some F
 
 /-- `F` entails `φ` iff `F` supports it. -/
 def fileEntails (F : State W ℕ E) (φ : FCP W E) : Prop :=
@@ -172,21 +141,23 @@ def fileEntails (F : State W ℕ E) (φ : FCP W E) : Prop :=
 /-- `φ` semantically entails `ψ` iff every defined update with `φ`
 supports `ψ`. -/
 def fcpEntails (φ ψ : FCP W E) : Prop :=
-  ∀ F F' : State W ℕ E, φ F = some F' → supports F' ψ
+  ∀ F : State W ℕ E, ∀ F' ∈ φ F, supports F' ψ
 
-/-- `φ` is defined on `F` (no presupposition failure). -/
+/-- `φ` is defined on `F` — Heim's "F admits φ", `Part.Dom` as in
+`Dynamic/Partial.lean`. -/
 def definedOn (F : State W ℕ E) (φ : FCP W E) : Prop :=
-  ∃ F', φ F = some F'
+  (φ F).Dom
 
 /-- Truth implies definedness. -/
 theorem trueIn_definedOn (F : State W ℕ E) (φ : FCP W E)
-    (h : trueIn F φ) : definedOn F φ :=
-  ⟨h.choose, h.choose_spec.1⟩
+    (h : trueIn F φ) : definedOn F φ := by
+  obtain ⟨F', hF', -⟩ := h
+  exact Part.dom_iff_mem.mpr ⟨F', hF'⟩
 
 /-- Support implies truth for consistent files. -/
 theorem supports_trueIn (F : State W ℕ E) (φ : FCP W E)
-    (hsup : supports F φ) (hcons : F.carrier.Nonempty) : trueIn F φ :=
-  ⟨F, hsup, hcons⟩
+    (hsup : supports F φ) (hcons : F.Nonempty) : trueIn F φ :=
+  ⟨F, by rw [hsup]; exact Part.mem_some F, hcons⟩
 
 /-! ### Theorems -/
 
@@ -196,103 +167,74 @@ section Theorems
 theorem seq_assoc (φ ψ χ : FCP W E) :
     FCP.seq (FCP.seq φ ψ) χ = FCP.seq φ (FCP.seq ψ χ) := by
   funext F
-  simp only [FCP.seq]
-  cases φ F <;> rfl
+  exact Part.bind_assoc ..
 
 /-- Identity is left unit for sequential composition. -/
 theorem id_seq (φ : FCP W E) : FCP.seq FCP.id φ = φ := by
-  funext F; simp [FCP.seq, FCP.id, Option.bind]
+  funext F
+  exact Part.bind_some ..
 
 /-- Identity is right unit for sequential composition. -/
 theorem seq_id (φ : FCP W E) : FCP.seq φ FCP.id = φ := by
-  funext F; simp [FCP.seq]
-  cases φ F <;> rfl
+  funext F
+  exact Part.bind_some_right _
 
-/-- Familiarity is exactly definedness for variable atoms. -/
+/-- **The Familiarity Condition is definedness**: variable atoms are
+defined exactly on files where the variable is familiar. -/
 theorem atomVar_definedOn_iff (pred : E → Prop) (x : ℕ) (F : State W ℕ E) :
-    definedOn F (FCP.atomVar pred x) ↔ x ∈ F.base := by
-  simp only [definedOn, FCP.atomVar]
-  split
-  · exact iff_of_true ⟨_, rfl⟩ ‹_›
-  · exact iff_of_false (by simp) ‹_›
+    definedOn F (FCP.atomVar pred x) ↔ Familiar F x :=
+  ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, trivial⟩⟩
 
-/-- World atoms preserve the base. -/
-theorem atomW_preserves_base (pred : W → Prop) (F : State W ℕ E) :
-    (FCP.atomW pred F).map (·.base) = some F.base := rfl
-
-/-- Negation preserves the base. -/
-theorem neg_preserves_base (φ : FCP W E) (F F' : State W ℕ E)
-    (h : FCP.neg φ F = some F') : F'.base = F.base := by
-  simp only [FCP.neg, Option.map_eq_some_iff] at h
-  obtain ⟨G, -, rfl⟩ := h
-  rfl
-
-/-- Indefinite is undefined when the variable is familiar (not novel). -/
-theorem indef_familiar_none (x : ℕ) (body : FCP W E) (F : State W ℕ E)
-    (h : x ∈ F.base) : FCP.indef x body F = none :=
-  if_pos h
-
-/-- Definite is undefined when the variable is novel (not familiar). -/
-theorem def_novel_none (x : ℕ) (body : FCP W E) (F : State W ℕ E)
-    (h : x ∉ F.base) : FCP.def_ x body F = none :=
-  if_neg h
-
-/-- World atoms are eliminative: Sat(F + P) ⊆ Sat(F) — Principle (A):
-information only grows. -/
-theorem atomW_eliminative (pred : W → Prop) (F F' : State W ℕ E)
-    (h : FCP.atomW pred F = some F') : F'.carrier ⊆ F.carrier := by
-  obtain rfl : _ = F' := Option.some.inj h
+/-- World atoms are eliminative: `Sat(F + P) ⊆ Sat(F)` — Principle (A):
+file change only eliminates. -/
+theorem atomW_eliminative (pred : W → Prop) {F F' : State W ℕ E}
+    (h : F' ∈ FCP.atomW pred F) : F' ⊆ F := by
+  obtain rfl := Part.mem_some_iff.mp h
   exact fun p hp => hp.1
 
 /-- Variable atoms are eliminative. -/
-theorem atomVar_eliminative (pred : E → Prop) (x : ℕ) (F F' : State W ℕ E)
-    (h : FCP.atomVar pred x F = some F') : F'.carrier ⊆ F.carrier := by
-  simp only [FCP.atomVar] at h
-  split at h
-  · obtain rfl : _ = F' := Option.some.inj h
-    exact fun p hp => hp.1
-  · exact absurd h (by simp)
+theorem atomVar_eliminative (pred : E → Prop) (x : ℕ) {F F' : State W ℕ E}
+    (h : F' ∈ FCP.atomVar pred x F) : F' ⊆ F := by
+  obtain ⟨hdom, hval⟩ := Part.mem_assert_iff.mp h
+  obtain rfl := Part.mem_some_iff.mp hval
+  exact fun p hp => hp.1
 
-/-- Negation is eliminative: Sat(F + ¬φ) ⊆ Sat(F). -/
-theorem neg_eliminative (φ : FCP W E) (F F' : State W ℕ E)
-    (h : FCP.neg φ F = some F') : F'.carrier ⊆ F.carrier := by
-  simp only [FCP.neg, Option.map_eq_some_iff] at h
-  obtain ⟨G, -, rfl⟩ := h
+/-- Negation is eliminative: `Sat(F + ¬φ) ⊆ Sat(F)`. -/
+theorem neg_eliminative (φ : FCP W E) {F F' : State W ℕ E}
+    (h : F' ∈ FCP.neg φ F) : F' ⊆ F := by
+  obtain ⟨G, -, rfl⟩ := (Part.mem_map_iff _).mp h
   exact fun p hp => hp.1
 
 /-- Sequential composition of eliminative FCPs is eliminative. -/
 theorem seq_eliminative (φ ψ : FCP W E)
-    (hφ : ∀ F F', φ F = some F' → F'.carrier ⊆ F.carrier)
-    (hψ : ∀ F F', ψ F = some F' → F'.carrier ⊆ F.carrier)
-    (F F' : State W ℕ E) (h : FCP.seq φ ψ F = some F') :
-    F'.carrier ⊆ F.carrier := by
-  simp only [FCP.seq, Option.bind] at h
-  cases hφF : φ F with
-  | none => rw [hφF] at h; exact absurd h (by simp)
-  | some F₁ =>
-    rw [hφF] at h
-    simp at h
-    intro p hp
-    exact hφ F F₁ hφF (hψ F₁ F' h hp)
+    (hφ : ∀ F : State W ℕ E, ∀ F' ∈ φ F, F' ⊆ F)
+    (hψ : ∀ F : State W ℕ E, ∀ F' ∈ ψ F, F' ⊆ F)
+    {F F' : State W ℕ E} (h : F' ∈ FCP.seq φ ψ F) : F' ⊆ F := by
+  obtain ⟨F₁, hF₁, hF'⟩ := Part.mem_bind_iff.mp h
+  exact (hψ F₁ F' hF').trans (hφ F F₁ hF₁)
 
-/-- Base monotonicity for definite updates: when the body preserves the
-base, so does the definite FCP. -/
-theorem def_preserves_base (x : ℕ) (body : FCP W E)
-    (hbody : ∀ G G', body G = some G' → G'.base = G.base)
-    (F F' : State W ℕ E) (h : FCP.def_ x body F = some F') :
-    F'.base = F.base := by
-  simp only [FCP.def_] at h
-  split at h
-  · exact hbody F F' h
-  · exact absurd h (by simp)
+/-- Indefinite is undefined when the variable is not novel. -/
+theorem indef_not_novel_not_definedOn (x : ℕ) (body : FCP W E)
+    (F : State W ℕ E) (h : ¬ ∀ p ∈ F, p.assignment x = none) :
+    ¬ definedOn F (FCP.indef x body) := by
+  simp only [definedOn, FCP.indef, Part.assert]
+  rintro ⟨hnovel, -⟩
+  exact h hnovel
+
+/-- Definite is undefined when the variable is unfamiliar. -/
+theorem def_not_familiar_not_definedOn (x : ℕ) (body : FCP W E)
+    (F : State W ℕ E) (h : ¬ Familiar F x) :
+    ¬ definedOn F (FCP.def_ x body) := by
+  simp only [definedOn, FCP.def_, Part.assert]
+  rintro ⟨hfam, -⟩
+  exact h hfam
 
 /-- Support is idempotent: if `F` supports `φ`, updating twice is the same
 as once. -/
 theorem supports_idempotent (F : State W ℕ E) (φ : FCP W E)
     (h : supports F φ) : FCP.seq φ φ F = φ F := by
   simp only [FCP.seq, supports] at *
-  rw [h]
-  simp [h]
+  rw [h, Part.bind_some, h]
 
 end Theorems
 

--- a/Linglib/Studies/KampVanGenabithReyle2011.lean
+++ b/Linglib/Studies/KampVanGenabithReyle2011.lean
@@ -12,14 +12,14 @@ run against the indexed substrate (`Semantics/Dynamic/State.lean`,
 * **Partee's marbles** ((42), the argument for Def. 22): two information
   states that determine the *same proposition* but differ — anaphoric
   potential lives strictly below truth conditions, so propositions cannot be
-  the objects of context change (`marble_prop_eq_coin`, `marble_ne_coin`).
+  the objects of context change (`marble_worlds_eq_coin`, `marble_ne_coin`).
 * **The action equation on a discourse** (p. 159): "A¹ man walked in. He₁
   sat down." — applying the second sentence's transition to the state the
   first expresses is the state of the merge (`persistence_action`).
 -/
 
 open FirstOrder FirstOrder.Language DRT
-open DynamicSemantics (Possibility State baseSupported_of_iff)
+open DynamicSemantics (Possibility State worlds mem_worlds)
 
 namespace KampVanGenabithReyle2011
 
@@ -31,41 +31,38 @@ missing" and "a coin is missing" express the same proposition — true in
 exactly world `true` — but the states record different witnesses for the
 referent, so anaphora can distinguish them. -/
 
-/-- "A marble is missing": the referent is the marble `0`, in world `true`. -/
-def marbleState : State Bool Unit (Fin 2) where
-  base := {()}
-  carrier := {p | p.world = true ∧ p.assignment () = 0}
-  supported := baseSupported_of_iff fun w f g h => by
-    have hfg : f () = g () := h (by simp)
-    simp [Set.mem_setOf_eq, hfg]
+/-- "A marble is missing": the referent carries the marble `0`, in world
+`true`. -/
+def marbleState : State Bool Unit (Fin 2) :=
+  {p | p.world = true ∧ p.assignment () = some 0}
 
-/-- "A coin is missing": the referent is the coin `1`, in world `true`. -/
-def coinState : State Bool Unit (Fin 2) where
-  base := {()}
-  carrier := {p | p.world = true ∧ p.assignment () = 1}
-  supported := baseSupported_of_iff fun w f g h => by
-    have hfg : f () = g () := h (by simp)
-    simp [Set.mem_setOf_eq, hfg]
+/-- "A coin is missing": the referent carries the coin `1`, in world
+`true`. -/
+def coinState : State Bool Unit (Fin 2) :=
+  {p | p.world = true ∧ p.assignment () = some 1}
 
-/-- The two states determine the same proposition. -/
-theorem marble_prop_eq_coin : marbleState.prop = coinState.prop := by
+/-- The two states determine the same worldly content (Def. 23(v)'s
+proposition). -/
+theorem marble_worlds_eq_coin : worlds marbleState = worlds coinState := by
   ext w
-  simp only [State.mem_prop]
+  simp only [mem_worlds]
   constructor
-  · rintro ⟨f, hw, -⟩
-    exact ⟨fun _ => 1, hw, rfl⟩
-  · rintro ⟨f, hw, -⟩
-    exact ⟨fun _ => 0, hw, rfl⟩
+  · rintro ⟨p, ⟨hw, -⟩, rfl⟩
+    exact ⟨⟨p.world, fun _ => some 1⟩, ⟨hw, rfl⟩, rfl⟩
+  · rintro ⟨p, ⟨hw, -⟩, rfl⟩
+    exact ⟨⟨p.world, fun _ => some 0⟩, ⟨hw, rfl⟩, rfl⟩
 
 /-- But the states differ: the marble witness is not a coin witness. The
-proposition collapse (`marble_prop_eq_coin`) plus this separation is Partee's
+worldly collapse (`marble_worlds_eq_coin`) plus this separation is Partee's
 argument that context change operates on information states, not
 propositions. -/
 theorem marble_ne_coin : marbleState ≠ coinState := by
   intro h
-  have : (⟨true, fun _ => 0⟩ : Possibility Bool Unit (Fin 2)) ∈ coinState.carrier := by
-    rw [← h]; exact ⟨rfl, rfl⟩
-  exact absurd this.2 (by decide)
+  have hmem : (⟨true, fun _ => some 0⟩ : Possibility Bool Unit (Option (Fin 2))) ∈
+      coinState := by
+    rw [← h]
+    exact ⟨rfl, rfl⟩
+  exact absurd hmem.2 (by simp)
 
 /-! ### The action equation on a two-sentence discourse (p. 159) -/
 
@@ -99,7 +96,7 @@ theorem sentence₂_fresh :
 /-- The action equation for the discourse: interpreting sentence two against
 the context sentence one expresses is interpreting their merge from scratch. -/
 theorem persistence_action {M : Type} [dLang.Structure M] :
-    (sentence₂.transition (M := M) Bool sentence₁.referents sentence₂_bound).apply
+    (sentence₂.transition (M := M) Bool sentence₁.referents sentence₂_bound).applyState
         (sentence₁.state Bool sentence₁_proper) =
       (sentence₁.merge sentence₂).state Bool
         (DRS.isProper_merge sentence₁_proper sentence₂_bound) :=

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -923,7 +923,7 @@ theorem toIndexedState_update_prop (φ : W → Prop) :
     toIndexedState V M (UpdateSemantics.Update.prop φ s) =
       {p ∈ toIndexedState V M s | φ p.world} :=
   Set.ext fun p => by
-    simp only [mem_toIndexedState, Set.mem_sep_iff, Set.mem_setOf_eq,
+    simp only [mem_toIndexedState, Set.mem_setOf_eq,
       UpdateSemantics.Update.prop]
     tauto
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -864,13 +864,14 @@ theorem optimal_as_normalcy (no : Preorder W) (d : Set W)
 
 end GenericsBridge
 
-/-! ### Update-semantics states as the referent-free fiber
+/-! ### Update-semantics states as the referent-free stratum
 
-Veltman's information states are bare sets of worlds. In the indexed
-substrate they are exactly the states at the empty context: `toIndexedState`
-embeds them, the embedding is an order-reversal onto the `∅`-fiber
-(`State.fiberEmptyOrderIso`), and propositional update transports to
-carrier filtering. -/
+Veltman's information states are bare sets of worlds. In the substrate
+they are exactly the uniform states at the empty context:
+`toIndexedState` embeds them constructively — no choice, no inhabitant
+of `M`, unlike under the total-assignment rendering — the embedding
+reverses into the informativeness order `⊑`, and propositional update
+transports to point filtering. -/
 
 section IndexedFiber
 
@@ -878,41 +879,53 @@ open DynamicSemantics UpdateSemantics
 
 variable {W V M : Type*} {s t : Set W}
 
-/-- A Veltman state as a indexed state at the empty context. -/
-def toIndexedState (V M : Type*) (s : Set W) : DynamicSemantics.State W V M where
-  base := ∅
-  carrier := {p | p.world ∈ s}
-  supported := baseSupported_of_iff fun _ _ _ _ => Iff.rfl
+/-- A Veltman state as the referent-free state: its worlds, with nothing
+yet introduced. -/
+def toIndexedState (V M : Type*) (s : Set W) :
+    DynamicSemantics.State W V M :=
+  {p | p.world ∈ s ∧ ∀ v, p.assignment v = none}
 
-@[simp] theorem mem_toIndexedState {p : Possibility W V M} :
-    p ∈ toIndexedState V M s ↔ p.world ∈ s := Iff.rfl
+@[simp] theorem mem_toIndexedState {p : Possibility W V (Option M)} :
+    p ∈ toIndexedState V M s ↔
+      p.world ∈ s ∧ ∀ v, p.assignment v = none := Iff.rfl
 
-/-- The embedding reverses the orders: eliminating worlds is gaining
-information. -/
-theorem toIndexedState_le_iff [Nonempty M] :
-    toIndexedState V M s ≤ toIndexedState V M t ↔ t ⊆ s := by
+/-- The embedding lands in the empty stratum. -/
+theorem uniformAt_toIndexedState :
+    State.UniformAt ∅ (toIndexedState V M s) := fun p hp => by
+  ext v
+  simp [Possibility.dom, hp.2 v]
+
+/-- The embedding is faithful on worldly content. -/
+@[simp] theorem worlds_toIndexedState :
+    worlds (toIndexedState V M s) = s := by
+  ext w
+  constructor
+  · rintro ⟨p, hp, rfl⟩
+    exact hp.1
+  · intro hw
+    exact ⟨⟨w, fun _ => none⟩, ⟨hw, fun _ => rfl⟩, rfl⟩
+
+/-- Eliminating worlds is gaining information: the embedding reverses
+into `⊑`. -/
+theorem toIndexedState_infoLe_iff :
+    (toIndexedState V M s ⊑ toIndexedState V M t) ↔ t ⊆ s := by
   constructor
   · intro h w hw
-    exact h.2 (show (⟨w, fun _ => Classical.arbitrary M⟩ : Possibility W V M) ∈ _ from hw)
-  · exact fun h => ⟨subset_rfl, fun p hp => h hp⟩
+    obtain ⟨p, hp, hpq⟩ := h ⟨w, fun _ => none⟩ ⟨hw, fun _ => rfl⟩
+    have hs := hp.1
+    rwa [hpq.1] at hs
+  · rintro h q ⟨hq, hnone⟩
+    exact ⟨q, ⟨h hq, hnone⟩, Possibility.Descendant.refl q⟩
 
 /-- Propositional update ([veltman-1996]'s elimination) transports to
-carrier filtering on indexed states. -/
+point filtering. -/
 theorem toIndexedState_update_prop (φ : W → Prop) :
-    (toIndexedState V M (UpdateSemantics.Update.prop φ s)).carrier =
-      {p ∈ (toIndexedState V M s).carrier | φ p.world} := rfl
-
-/-- The embedding inverts the fiber classification: a Veltman state is
-precisely a state of the `∅`-fiber, read through
-`State.fiberEmptyOrderIso`. -/
-theorem fiberEmptyOrderIso_toIndexedState [Nonempty M] (s : Set W) :
-    State.fiberEmptyOrderIso (M := M) ⟨toIndexedState V M s, rfl⟩ =
-      OrderDual.toDual s := by
-  have h : ∀ w : W,
-      w ∈ OrderDual.ofDual
-        (State.fiberEmptyOrderIso (M := M) ⟨toIndexedState V M s, rfl⟩) ↔ w ∈ s :=
-    fun w => State.mem_fiberEmptyOrderIso (g := fun _ => Classical.arbitrary M)
-  exact Set.ext h
+    toIndexedState V M (UpdateSemantics.Update.prop φ s) =
+      {p ∈ toIndexedState V M s | φ p.world} :=
+  Set.ext fun p => by
+    simp only [mem_toIndexedState, Set.mem_sep_iff, Set.mem_setOf_eq,
+      UpdateSemantics.Update.prop]
+    tauto
 
 end IndexedFiber
 


### PR DESCRIPTION
State v2: `State W V M := Set (Possibility W V (Option M))` — the literature's own type (KvGR 2011 Def. 23, Elliott's information states, Elliott–Sudo 2025's BUS carrier) replaces the base+carrier+supported cylinder rendering.

- Dual root orders: informativeness `⊑` (KvGR Def. 25) and subsistence `⪯` (ES2025 Def. 3.3); the Def. 26 merge is the `⊑`-least upper bound; KvGR-indexed states are the dom-uniform strata, classified constructively (no `Classical`, no `Nonempty M`).
- Transitions fully typed (`rel : W → (↑X → M) → (↑Y → M) → Prop`) with a total↔typed bridge (`ofTotal`, `ReadsAt`/`WritesAt`); `BaseSupported` and the support fields dissolve; `Collapse` is quotient-free; `State.presheaf` is definitional.
- Consumers migrated: BUS, DRS (indexed + category), GS1991, Veltman, KvGR, A&S, Enguehard, and Heim's FCS (now `Part`-based: presupposition = definedness, negation = non-subsistence).