### PR TITLE
feat(Semantics/Dynamic): uniform classification; environments glue/BC

### DIFF
--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -31,6 +31,9 @@ at `∅` is [veltman-1996]'s update semantics.
   its maps the semantic face of *weakening*. Precedent for the
   states-as-presheaf reading: [abramsky-sadrzadeh-2014].
 - `State.presheaf`: the state fibers — `environments ⋙ Set`.
+- `environments_glue`, `environments_beck_chevalley`: the context-lattice
+  square is a pullback of environments, so quantification commutes with
+  weakening — the fibers are a hyperdoctrine.
 
 ## References
 
@@ -97,5 +100,81 @@ direct image along environment weakening. -/
 def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
     (Finset V)ᵒᵖ ⥤ Type (max u v w) :=
   environments W M V ⋙ ofTypeFunctor Set
+
+/-! ### Gluing and Beck–Chevalley
+
+`environments` sends each square of the context lattice to a pullback
+(`environments_glue`), so quantification and weakening cohere: the
+existential legs (`Set.image`, which is `State.presheaf`'s own action)
+commute with reindexing (`Set.preimage`) across the square
+(`environments_beck_chevalley`). Together with mathlib's
+`Set.image_subset_iff` (`∃ ⊣ weakening`), `Set.preimage_kernImage`
+(`weakening ⊣ ∀`), and `Set.image_inter_preimage` (Frobenius), the
+fibers form a hyperdoctrine over the context lattice ([lawvere-1969],
+[jacobs-1999]). -/
+
+section Gluing
+
+open Opposite
+
+variable {W M V : Type*} {X Y : Finset V}
+
+/-- The action of `environments` on a lattice inequality, elementwise. -/
+@[simp] theorem environments_map_apply (h : X ≤ Y)
+    (p : (environments W M V).obj (op Y)) :
+    (environments W M V).map (homOfLE h).op p =
+      (p.1, fun v => p.2 ⟨v.1, h v.2⟩) := rfl
+
+variable [DecidableEq V]
+
+/-- Environments glue: a pair of environments over `X` and `Y` whose
+weakenings to `X ⊓ Y` agree is jointly the weakening of a unique
+environment over `X ⊔ Y` — `environments` sends the lattice square to a
+pullback of types. The piecewise witness is the environment face of
+`Possibility.union`. -/
+theorem environments_glue
+    (a : (environments W M V).obj (op X)) (b : (environments W M V).obj (op Y))
+    (hab : (environments W M V).map (homOfLE inf_le_left).op a =
+      (environments W M V).map (homOfLE inf_le_right).op b) :
+    ∃! c : (environments W M V).obj (op (X ⊔ Y)),
+      (environments W M V).map (homOfLE le_sup_left).op c = a ∧
+        (environments W M V).map (homOfLE le_sup_right).op c = b := by
+  simp only [environments_map_apply] at hab ⊢
+  have hw : a.1 = b.1 := congrArg Prod.fst hab
+  have hagree : ∀ (v : V) (hX : v ∈ X) (hY : v ∈ Y),
+      a.2 ⟨v, hX⟩ = b.2 ⟨v, hY⟩ := fun v hX hY =>
+    congrFun (congrArg Prod.snd hab) ⟨v, Finset.mem_inter.mpr ⟨hX, hY⟩⟩
+  refine ⟨(a.1, fun v => if h : v.1 ∈ X then a.2 ⟨v.1, h⟩
+      else b.2 ⟨v.1, (Finset.mem_union.mp v.2).resolve_left h⟩),
+    ⟨Prod.ext rfl (funext fun v => dif_pos v.2),
+      Prod.ext hw (funext fun v => ?_)⟩, fun c' hc' => ?_⟩
+  · by_cases h : v.1 ∈ X
+    · exact (dif_pos h).trans (hagree v.1 h v.2)
+    · exact dif_neg h
+  · obtain ⟨rfl, rfl⟩ := hc'
+    exact Prod.ext rfl (funext fun v => by by_cases h : v.1 ∈ X <;> simp [h])
+
+/-- Beck–Chevalley for the context-lattice square: existential image
+along `X ⊓ Y ≤ X` then weakening to `Y` is weakening to `X ⊔ Y` then
+existential image along `Y ≤ X ⊔ Y` — quantifying and reindexing
+commute. The image legs are `State.presheaf`'s own action on the
+square's arrows. -/
+theorem environments_beck_chevalley (X Y : Finset V)
+    (S : Set ((environments W M V).obj (op X))) :
+    (environments W M V).map (homOfLE (inf_le_right : X ⊓ Y ≤ Y)).op ⁻¹'
+      ((environments W M V).map (homOfLE (inf_le_left : X ⊓ Y ≤ X)).op '' S) =
+    (environments W M V).map (homOfLE (le_sup_right : Y ≤ X ⊔ Y)).op ''
+      ((environments W M V).map (homOfLE (le_sup_left : X ≤ X ⊔ Y)).op ⁻¹' S) := by
+  ext b
+  constructor
+  · rintro ⟨a, ha, hab⟩
+    obtain ⟨c, ⟨hcX, hcY⟩, -⟩ := environments_glue a b hab
+    exact ⟨c, show _ ∈ S by rw [hcX]; exact ha, hcY⟩
+  · rintro ⟨c, hc, rfl⟩
+    refine ⟨(environments W M V).map (homOfLE le_sup_left).op c, hc, ?_⟩
+    rw [← Functor.map_comp_apply, ← Functor.map_comp_apply,
+      ← op_comp, ← op_comp, homOfLE_comp, homOfLE_comp]
+
+end Gluing
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Function
 import Mathlib.Data.Setoid.Basic
 
@@ -22,6 +23,12 @@ points *indices* ([charlow-2025-staged-updates]).
 - `Possibility W V M`: the point object.
 - `Possibility.agreeSetoid X`: possibilities up to agreement on `X` — the
   state space at granularity `X` (`Collapse.lean`, `State.fiberEquiv`).
+- `Possibility.dom`, `Possibility.Descendant`, `Possibility.Compatible`,
+  `Possibility.union`: partial points (`Option`-valued assignments) —
+  their defined referents, growth order, and consistent union.
+- `Possibility.restrict`, `Possibility.domEquiv`: domain restriction and
+  the constructive classification of the domain-`X` points as
+  world–`X`-environment pairs.
 
 ## References
 
@@ -105,6 +112,206 @@ def extend [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
 
 @[simp] theorem extend_world [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
     (p.extend x e).world = p.world := rfl
+
+/-! ### Partial points -/
+
+/-- The referents a partial point defines —
+[kamp-vangenabith-reyle-2011] Def. 23's `Dom(f)`. -/
+def dom (p : Possibility W V (Option M)) : Set V :=
+  {v | (p.assignment v).isSome}
+
+@[simp] theorem mem_dom {p : Possibility W V (Option M)} {v : V} :
+    v ∈ p.dom ↔ (p.assignment v).isSome := Iff.rfl
+
+/-- `q` is a *descendant* of `p` ([elliott-sudo-2025], Def. 3.3): same
+world, and `q`'s assignment extends `p`'s wherever the latter is defined
+([groenendijk-stokhof-veltman-1996]'s graph-extension — pointwise, the
+information order mathlib gives `Part`). -/
+def Descendant (p q : Possibility W V (Option M)) : Prop :=
+  p.world = q.world ∧ ∀ x e, p.assignment x = some e → q.assignment x = some e
+
+theorem Descendant.refl (p : Possibility W V (Option M)) :
+    p.Descendant p :=
+  ⟨rfl, fun _ _ h => h⟩
+
+theorem Descendant.trans {p q r : Possibility W V (Option M)}
+    (hpq : p.Descendant q) (hqr : q.Descendant r) : p.Descendant r :=
+  ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
+
+/-- Descendance grows the domain. -/
+theorem Descendant.dom_subset {p q : Possibility W V (Option M)}
+    (h : p.Descendant q) : p.dom ⊆ q.dom := fun v hv => by
+  obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
+  exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
+
+/-- On a shared domain, descendance is equality: there is no room to
+grow. -/
+theorem Descendant.eq_of_dom_eq {p q : Possibility W V (Option M)}
+    (h : p.Descendant q) (hdom : p.dom = q.dom) : p = q := by
+  refine Possibility.ext h.1 (funext fun v => ?_)
+  rcases hp : p.assignment v with _ | e
+  · rcases hq : q.assignment v with _ | e
+    · rfl
+    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
+      rw [Possibility.mem_dom, hp] at this
+      exact absurd this (by simp)
+  · exact (h.2 v e hp).symm ▸ rfl
+
+/-- Two partial points are *compatible*: same world, agreeing wherever
+both are defined — [kamp-vangenabith-reyle-2011] Def. 26's condition
+that the union of chosen points be a function. -/
+def Compatible (p q : Possibility W V (Option M)) : Prop :=
+  p.world = q.world ∧
+    ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e'
+
+/-- The union of two points: defined wherever either is, the left
+taking precedence (agreement makes the choice immaterial). -/
+def union (p q : Possibility W V (Option M)) :
+    Possibility W V (Option M) :=
+  ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
+
+theorem left_descendant_union (p q : Possibility W V (Option M)) :
+    p.Descendant (p.union q) :=
+  ⟨rfl, fun v e h => by simp [union, h]⟩
+
+theorem Compatible.right_descendant_union
+    {p q : Possibility W V (Option M)} (h : p.Compatible q) :
+    q.Descendant (p.union q) :=
+  ⟨h.1.symm, fun v e hq => by
+    rcases hp : p.assignment v with _ | e'
+    · simp [union, hp, hq]
+    · simp [union, hp, h.2 v e' e hp hq]⟩
+
+/-- On a shared domain, compatibility is equality. -/
+theorem Compatible.eq_of_dom_eq {p q : Possibility W V (Option M)}
+    (h : p.Compatible q) (hdom : p.dom = q.dom) : p = q := by
+  refine Possibility.ext h.1 (funext fun v => ?_)
+  rcases hp : p.assignment v with _ | e
+  · rcases hq : q.assignment v with _ | e
+    · rfl
+    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
+      rw [Possibility.mem_dom, hp] at this
+      exact absurd this (by simp)
+  · rcases hq : q.assignment v with _ | e'
+    · have : v ∈ q.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hp⟩
+      rw [Possibility.mem_dom, hq] at this
+      exact absurd this (by simp)
+    · exact congrArg some (h.2 v e e' hp hq)
+
+/-- Union of points unites domains. -/
+theorem dom_union (p q : Possibility W V (Option M)) :
+    (p.union q).dom = p.dom ∪ q.dom := by
+  ext v
+  rcases hp : p.assignment v with _ | e <;> simp [union, dom, hp]
+
+/-- Common ancestors are compatible. -/
+theorem Descendant.compatible {p q u : Possibility W V (Option M)}
+    (hp : p.Descendant u) (hq : q.Descendant u) : p.Compatible q :=
+  ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
+    have h1 := hp.2 v e he
+    have h2 := hq.2 v e' he'
+    rw [h1] at h2
+    exact (Option.some.injEq .. ▸ h2 :)⟩
+
+/-- The union of two ancestors is an ancestor. -/
+theorem Descendant.union_descendant {p q u : Possibility W V (Option M)}
+    (hp : p.Descendant u) (hq : q.Descendant u) :
+    (p.union q).Descendant u :=
+  ⟨hp.1, fun v e h => by
+    rcases hpv : p.assignment v with _ | e'
+    · exact hq.2 v e (by simpa [union, hpv] using h)
+    · have : e' = e := by simpa [union, hpv] using h
+      exact this ▸ hp.2 v e' hpv⟩
+
+/-! ### Restriction and the indexed classification -/
+
+section Restrict
+
+variable [DecidableEq V]
+
+/-- Restrict a partial point to the referents in `X`. -/
+def restrict (X : Finset V) (p : Possibility W V (Option M)) :
+    Possibility W V (Option M) :=
+  ⟨p.world, fun v => if v ∈ X then p.assignment v else none⟩
+
+@[simp] theorem restrict_world (X : Finset V)
+    (p : Possibility W V (Option M)) :
+    (p.restrict X).world = p.world := rfl
+
+/-- Restriction is an ancestor. -/
+theorem restrict_descendant (X : Finset V)
+    (p : Possibility W V (Option M)) : (p.restrict X).Descendant p :=
+  ⟨rfl, fun x e h => by
+    by_cases hx : x ∈ X
+    · simpa [restrict, hx] using h
+    · simp [restrict, hx] at h⟩
+
+/-- Restriction intersects the domain. -/
+theorem dom_restrict (X : Finset V) (p : Possibility W V (Option M)) :
+    (p.restrict X).dom = ↑X ∩ p.dom := by
+  ext v
+  by_cases hv : v ∈ X <;> simp [restrict, dom, hv]
+
+/-- Descendance out of a stratum is *being the restriction*: for `p` at
+`X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
+hom-characterization of the fibred order. -/
+theorem descendant_iff_eq_restrict {X : Finset V}
+    {p q : Possibility W V (Option M)} (hp : p.dom = (↑X : Set V)) :
+    p.Descendant q ↔ p = q.restrict X := by
+  constructor
+  · intro h
+    refine Possibility.ext h.1 (funext fun v => ?_)
+    by_cases hv : v ∈ X
+    · have hsome : (p.assignment v).isSome :=
+        (Set.ext_iff.mp hp v).mpr hv
+      obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hsome
+      rw [he]
+      simp only [restrict, if_pos hv]
+      exact (h.2 v e he).symm
+    · have hnone : p.assignment v = none :=
+        Option.not_isSome_iff_eq_none.mp
+          fun hs => hv ((Set.ext_iff.mp hp v).mp hs)
+      rw [hnone]
+      simp [restrict, hv]
+  · rintro rfl
+    exact restrict_descendant X q
+
+/-- Restriction is pointwise idempotent along intersections. -/
+theorem restrict_restrict (X Y : Finset V)
+    (p : Possibility W V (Option M)) :
+    (p.restrict Y).restrict X = p.restrict (X ∩ Y) := by
+  refine Possibility.ext rfl (funext fun v => ?_)
+  by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;>
+    simp [restrict, hx, hy]
+
+/-- Partial points with domain `X` are world–`X`-environment pairs —
+constructively: the classification that the total-assignment rendering
+recovered only with choice and an inhabitant of `M`. -/
+def domEquiv (X : Finset V) :
+    {p : Possibility W V (Option M) // p.dom = (↑X : Set V)} ≃
+      W × ((↑X : Set V) → M) where
+  toFun p :=
+    (p.1.world, fun v => (p.1.assignment v.1).get
+      ((Set.ext_iff.mp p.2 v.1).mpr v.2))
+  invFun e :=
+    ⟨⟨e.1, fun v => if h : v ∈ (↑X : Set V) then some (e.2 ⟨v, h⟩)
+      else none⟩, by
+      ext v
+      by_cases h : v ∈ (↑X : Set V) <;> simp [dom, h]⟩
+  left_inv p := by
+    obtain ⟨⟨w, g⟩, hp⟩ := p
+    refine Subtype.ext (Possibility.ext rfl (funext fun v => ?_))
+    by_cases h : v ∈ (↑X : Set V)
+    · simp only [dif_pos h, Option.some_get]
+    · have hnone : g v = none := Option.not_isSome_iff_eq_none.mp
+        fun hs => h ((Set.ext_iff.mp hp v).mp hs)
+      simp only [dif_neg h]
+      exact hnone.symm
+  right_inv e := by
+    refine Prod.ext rfl (funext fun v => ?_)
+    simp
+
+end Restrict
 
 end Possibility
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -31,23 +31,22 @@ stratum they reduce to `⊇` and `⊆` respectively
 
 ## Main definitions
 
-- `Possibility.dom`, `Possibility.Descendant`: the defined referents of
-  a partial point, and same-world graph-extension.
 - `State W V M`: information states; `initial`, with `∅` the absurd
   state.
 - `infoLe` (`⊑`): informativeness (Def. 25); `Subsists` (`≺`),
   `subsistsIn` (`⪯`): subsistence.
+- `State.merge`: Def. 26's consistent merge.
 - `worlds`, `Familiar`: worldly content and familiarity.
-- `State.UniformAt`, `Possibility.domEquiv`: the indexed stratum and its
-  constructive classification.
-- `Possibility.restrict`, `State.restrict`, `State.randomAssign`:
-  domain restriction (pointwise, by direct image) and random assignment.
+- `State.UniformAt`: the indexed stratum (Def. 23's `Dom(f) = X`).
+- `State.restrict`, `State.randomAssign`: domain restriction (by direct
+  image of `Possibility.restrict`) and random assignment.
 
 ## Main results
 
-- `Possibility.Descendant.eq_of_dom_eq`: on a shared domain, descendance
-  is equality — so both preorders are partial orders on each uniform
-  stratum (`infoLe_iff_superset`, `subsistsIn_iff_subset`).
+- `merge_infoLe`: the merge is the `⊑`-least upper bound.
+- `infoLe_iff_superset`, `subsistsIn_iff_subset`: on a uniform stratum
+  both preorders are partial orders, coinciding with `⊇`/`⊆` (via
+  `Possibility.Descendant.eq_of_dom_eq`).
 - `subsistsIn_restrict`: restriction only forgets — the restricted state
   subsists in the original.
 - `uniformAt_restrict`, `restrict_restrict`: restriction meets the
@@ -74,118 +73,6 @@ order was Def. 25's, matching `⊑`, not `⪯`.
 namespace DynamicSemantics
 
 variable {W V M : Type*}
-
-/-! ### Partial points -/
-
-namespace Possibility
-
-/-- The referents a partial point defines — Def. 23's `Dom(f)`. -/
-def dom (p : Possibility W V (Option M)) : Set V :=
-  {v | (p.assignment v).isSome}
-
-@[simp] theorem mem_dom {p : Possibility W V (Option M)} {v : V} :
-    v ∈ p.dom ↔ (p.assignment v).isSome := Iff.rfl
-
-/-- `q` is a *descendant* of `p` ([elliott-sudo-2025], Def. 3.3): same
-world, and `q`'s assignment extends `p`'s wherever the latter is defined
-([groenendijk-stokhof-veltman-1996]'s graph-extension). -/
-def Descendant (p q : Possibility W V (Option M)) : Prop :=
-  p.world = q.world ∧ ∀ x e, p.assignment x = some e → q.assignment x = some e
-
-theorem Descendant.refl (p : Possibility W V (Option M)) :
-    p.Descendant p :=
-  ⟨rfl, fun _ _ h => h⟩
-
-theorem Descendant.trans {p q r : Possibility W V (Option M)}
-    (hpq : p.Descendant q) (hqr : q.Descendant r) : p.Descendant r :=
-  ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
-
-/-- Descendance grows the domain. -/
-theorem Descendant.dom_subset {p q : Possibility W V (Option M)}
-    (h : p.Descendant q) : p.dom ⊆ q.dom := fun v hv => by
-  obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
-  exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
-
-/-- On a shared domain, descendance is equality: there is no room to
-grow. -/
-theorem Descendant.eq_of_dom_eq {p q : Possibility W V (Option M)}
-    (h : p.Descendant q) (hdom : p.dom = q.dom) : p = q := by
-  refine Possibility.ext h.1 (funext fun v => ?_)
-  rcases hp : p.assignment v with _ | e
-  · rcases hq : q.assignment v with _ | e
-    · rfl
-    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
-      rw [Possibility.mem_dom, hp] at this
-      exact absurd this (by simp)
-  · exact (h.2 v e hp).symm ▸ rfl
-
-/-- Two partial points are *compatible*: same world, agreeing wherever
-both are defined — [kamp-vangenabith-reyle-2011] Def. 26's condition
-that the union of chosen points be a function. -/
-def Compatible (p q : Possibility W V (Option M)) : Prop :=
-  p.world = q.world ∧
-    ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e'
-
-/-- The union of two points: defined wherever either is, the left
-taking precedence (agreement makes the choice immaterial). -/
-def union (p q : Possibility W V (Option M)) :
-    Possibility W V (Option M) :=
-  ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
-
-theorem left_descendant_union (p q : Possibility W V (Option M)) :
-    p.Descendant (p.union q) :=
-  ⟨rfl, fun v e h => by simp [union, h]⟩
-
-theorem Compatible.right_descendant_union
-    {p q : Possibility W V (Option M)} (h : p.Compatible q) :
-    q.Descendant (p.union q) :=
-  ⟨h.1.symm, fun v e hq => by
-    rcases hp : p.assignment v with _ | e'
-    · simp [union, hp, hq]
-    · simp [union, hp, h.2 v e' e hp hq]⟩
-
-/-- On a shared domain, compatibility is equality. -/
-theorem Compatible.eq_of_dom_eq {p q : Possibility W V (Option M)}
-    (h : p.Compatible q) (hdom : p.dom = q.dom) : p = q := by
-  refine Possibility.ext h.1 (funext fun v => ?_)
-  rcases hp : p.assignment v with _ | e
-  · rcases hq : q.assignment v with _ | e
-    · rfl
-    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
-      rw [Possibility.mem_dom, hp] at this
-      exact absurd this (by simp)
-  · rcases hq : q.assignment v with _ | e'
-    · have : v ∈ q.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hp⟩
-      rw [Possibility.mem_dom, hq] at this
-      exact absurd this (by simp)
-    · exact congrArg some (h.2 v e e' hp hq)
-
-/-- Union of points unites domains. -/
-theorem dom_union (p q : Possibility W V (Option M)) :
-    (p.union q).dom = p.dom ∪ q.dom := by
-  ext v
-  rcases hp : p.assignment v with _ | e <;> simp [union, dom, hp]
-
-/-- Common ancestors are compatible. -/
-theorem Descendant.compatible {p q u : Possibility W V (Option M)}
-    (hp : p.Descendant u) (hq : q.Descendant u) : p.Compatible q :=
-  ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
-    have h1 := hp.2 v e he
-    have h2 := hq.2 v e' he'
-    rw [h1] at h2
-    exact (Option.some.injEq .. ▸ h2 :)⟩
-
-/-- The union of two ancestors is an ancestor. -/
-theorem Descendant.union_descendant {p q u : Possibility W V (Option M)}
-    (hp : p.Descendant u) (hq : q.Descendant u) :
-    (p.union q).Descendant u :=
-  ⟨hp.1, fun v e h => by
-    rcases hpv : p.assignment v with _ | e'
-    · exact hq.2 v e (by simpa [union, hpv] using h)
-    · have : e' = e := by simpa [union, hpv] using h
-      exact this ▸ hp.2 v e' hpv⟩
-
-end Possibility
 
 /-! ### Information states -/
 
@@ -288,69 +175,6 @@ def worlds (s : State W V M) : Set W :=
 [heim-1982]'s files): defined at every point. -/
 def Familiar (s : State W V M) (x : V) : Prop :=
   ∀ p ∈ s, p.assignment x ≠ none
-
-/-! ### Restriction and random assignment -/
-
-namespace Possibility
-
-variable [DecidableEq V]
-
-/-- Restrict a partial point to the referents in `X`. -/
-def restrict (X : Finset V) (p : Possibility W V (Option M)) :
-    Possibility W V (Option M) :=
-  ⟨p.world, fun v => if v ∈ X then p.assignment v else none⟩
-
-@[simp] theorem restrict_world (X : Finset V)
-    (p : Possibility W V (Option M)) :
-    (p.restrict X).world = p.world := rfl
-
-/-- Restriction is an ancestor. -/
-theorem restrict_descendant (X : Finset V)
-    (p : Possibility W V (Option M)) : (p.restrict X).Descendant p :=
-  ⟨rfl, fun x e h => by
-    by_cases hx : x ∈ X
-    · simpa [restrict, hx] using h
-    · simp [restrict, hx] at h⟩
-
-/-- Restriction intersects the domain. -/
-theorem dom_restrict (X : Finset V) (p : Possibility W V (Option M)) :
-    (p.restrict X).dom = ↑X ∩ p.dom := by
-  ext v
-  by_cases hv : v ∈ X <;> simp [restrict, dom, hv]
-
-/-- Descendance out of a stratum is *being the restriction*: for `p` at
-`X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
-hom-characterization of the fibred order. -/
-theorem descendant_iff_eq_restrict {X : Finset V}
-    {p q : Possibility W V (Option M)} (hp : p.dom = (↑X : Set V)) :
-    p.Descendant q ↔ p = q.restrict X := by
-  constructor
-  · intro h
-    refine Possibility.ext h.1 (funext fun v => ?_)
-    by_cases hv : v ∈ X
-    · have hsome : (p.assignment v).isSome :=
-        (Set.ext_iff.mp hp v).mpr hv
-      obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hsome
-      rw [he]
-      simp only [restrict, if_pos hv]
-      exact (h.2 v e he).symm
-    · have hnone : p.assignment v = none :=
-        Option.not_isSome_iff_eq_none.mp
-          fun hs => hv ((Set.ext_iff.mp hp v).mp hs)
-      rw [hnone]
-      simp [restrict, hv]
-  · rintro rfl
-    exact restrict_descendant X q
-
-/-- Restriction is pointwise idempotent along intersections. -/
-theorem restrict_restrict (X Y : Finset V)
-    (p : Possibility W V (Option M)) :
-    (p.restrict Y).restrict X = p.restrict (X ∩ Y) := by
-  refine Possibility.ext rfl (funext fun v => ?_)
-  by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;>
-    simp [restrict, hx, hy]
-
-end Possibility
 
 namespace State
 
@@ -488,40 +312,5 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
   simp
 
 end State
-
-/-! ### The indexed classification -/
-
-namespace Possibility
-
-variable [DecidableEq V]
-
-/-- Partial points with domain `X` are world–`X`-environment pairs —
-constructively: the classification that the total-assignment rendering
-recovered only with choice and an inhabitant of `M`. -/
-def domEquiv (X : Finset V) :
-    {p : Possibility W V (Option M) // p.dom = (↑X : Set V)} ≃
-      W × ((↑X : Set V) → M) where
-  toFun p :=
-    (p.1.world, fun v => (p.1.assignment v.1).get
-      ((Set.ext_iff.mp p.2 v.1).mpr v.2))
-  invFun e :=
-    ⟨⟨e.1, fun v => if h : v ∈ (↑X : Set V) then some (e.2 ⟨v, h⟩)
-      else none⟩, by
-      ext v
-      by_cases h : v ∈ (↑X : Set V) <;> simp [dom, h]⟩
-  left_inv p := by
-    obtain ⟨⟨w, g⟩, hp⟩ := p
-    refine Subtype.ext (Possibility.ext rfl (funext fun v => ?_))
-    by_cases h : v ∈ (↑X : Set V)
-    · simp only [dif_pos h, Option.some_get]
-    · have hnone : g v = none := Option.not_isSome_iff_eq_none.mp
-        fun hs => h ((Set.ext_iff.mp hp v).mp hs)
-      simp only [dif_neg h]
-      exact hnone.symm
-  right_inv e := by
-    refine Prod.ext rfl (funext fun v => ?_)
-    simp
-
-end Possibility
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Dynamic.Possibility
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Function
+import Mathlib.Order.Hom.Basic
 
 /-!
 # Information states
@@ -310,6 +311,39 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
     Familiar (I.randomAssign x) x := by
   rintro p ⟨q, -, m, rfl⟩
   simp
+
+/-! ### The uniform classification -/
+
+/-- Uniform states at `X` are sets of world–`X`-environment pairs — the
+state-level face of `Possibility.domEquiv`, and the comparison to the
+predecessor's fibers: an order isomorphism for `⊆` (which is `⪯` on the
+stratum, `subsistsIn_iff_subset`), hence an anti-isomorphism for `⊑`
+(`infoLe_iff_superset`). -/
+def uniformEquiv (X : Finset V) :
+    {I : State W V M // UniformAt X I} ≃o Set (W × ((↑X : Set V) → M)) where
+  toFun I := {e | ((Possibility.domEquiv X).symm e).1 ∈ I.1}
+  invFun S :=
+    ⟨{p | ∃ h : p.dom = (↑X : Set V), Possibility.domEquiv X ⟨p, h⟩ ∈ S},
+      fun _ ⟨h, _⟩ => h⟩
+  left_inv I := by
+    refine Subtype.ext (Set.ext fun p => ?_)
+    constructor
+    · rintro ⟨h, hmem⟩
+      simpa using hmem
+    · intro hp
+      exact ⟨I.2 p hp, by simpa using hp⟩
+  right_inv S := Set.ext fun e => by
+    constructor
+    · rintro ⟨h, hmem⟩
+      simpa using hmem
+    · intro he
+      exact ⟨((Possibility.domEquiv X).symm e).2, by simpa using he⟩
+  map_rel_iff' {I J} := by
+    constructor
+    · intro h p hp
+      simpa using h (a := Possibility.domEquiv X ⟨p, I.2 p hp⟩)
+        (by simpa using hp)
+    · exact fun h _ he => h he
 
 end State
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -536,7 +536,7 @@ theorem ExpFrame.const_normal_of_connected (no : Preorder W)
     (d : Set W) (hconn : Normality.connected no) :
     (ExpFrame.const no).normal d = Normality.optimal no d := by
   ext w
-  simp only [normal, const, Set.mem_setOf_eq, Normality.optimal]
+  simp only [normal, Set.mem_setOf_eq, Normality.optimal]
   constructor
   · -- normal → optimal: weaker condition
     intro ⟨hwd, hsub⟩
@@ -580,16 +580,16 @@ def birdDomain : Set TweetyWorld := { w | isBird w }
 def penguinDomain : Set TweetyWorld := { w | isPenguin w }
 
 /-- Ordering for the bird domain: promotes flying. -/
-private def birdOrd : Preorder TweetyWorld :=
+@[reducible] private def birdOrd : Preorder TweetyWorld :=
   Preorder.ofLE (fun w v => flies v → flies w) (fun _ => id)
     (fun _ _ _ huv hvw h => huv (hvw h))
 
 /-- Ordering for the penguin domain: promotes ¬flying. -/
-private def penguinOrd : Preorder TweetyWorld :=
+@[reducible] private def penguinOrd : Preorder TweetyWorld :=
   Preorder.ofLE (fun w v => ¬flies v → ¬flies w) (fun _ => id)
     (fun _ _ _ huv hvw h => huv (hvw h))
 
-private noncomputable def tweetyPattern (d : Set TweetyWorld) :
+@[reducible] private noncomputable def tweetyPattern (d : Set TweetyWorld) :
     Preorder TweetyWorld :=
   if d = penguinDomain then penguinOrd
   else if d = birdDomain then birdOrd
@@ -670,15 +670,15 @@ open NixonWorld
 def quakerDomain : Set NixonWorld := { w | isQuaker w }
 def repDomain : Set NixonWorld := { w | isRepublican w }
 
-private def quakerOrd : Preorder NixonWorld :=
+@[reducible] private def quakerOrd : Preorder NixonWorld :=
   Preorder.ofLE (fun w v => isPacifist v → isPacifist w) (fun _ => id)
     (fun _ _ _ huv hvw h => huv (hvw h))
 
-private def repOrd : Preorder NixonWorld :=
+@[reducible] private def repOrd : Preorder NixonWorld :=
   Preorder.ofLE (fun w v => ¬isPacifist v → ¬isPacifist w) (fun _ => id)
     (fun _ _ _ huv hvw h => huv (hvw h))
 
-private noncomputable def nixonPattern (d : Set NixonWorld) :
+@[reducible] private noncomputable def nixonPattern (d : Set NixonWorld) :
     Preorder NixonWorld :=
   if d = quakerDomain then quakerOrd
   else if d = repDomain then repOrd


### PR DESCRIPTION
Phase 2 of the base-free state picture (follow-up to #1482).

- Pointwise partial-point API (`dom`, `Descendant`, `Compatible`, `union`, `restrict`, `domEquiv`) moves from `State.lean` to its object file `Possibility.lean`; `Descendant` docstring notes it is pointwise `Part`'s information order.
- `State.uniformEquiv`: uniform states at `X` are order-isomorphic to `Set (W × (↑X → M))` — the constructive classification, and the comparison to the predecessor's fibers (order iso for `⪯`/`⊆`, anti for `⊑`).
- `environments_glue` (the context-lattice square is a pullback of types) and `environments_beck_chevalley` (existential image commutes with weakening); with mathlib's `Set.image_subset_iff`/`Set.preimage_kernImage`/`Set.image_inter_preimage` the fibers form a hyperdoctrine — those three are cited, not wrapped. Plus a Veltman1996 zero-warning polish.