### PR TITLE
feat(Semantics/Dynamic): merge-based assertive update; rule-13/18 regimes

### DIFF
--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -15,6 +15,15 @@ Presupposition is `Part`-definedness (`CCP.Partial.admits`, Heim's
 definedness conditions; sequencing and its monoid laws are `PFun.comp`'s
 (`PFun.comp_assoc`, `PFun.id_comp`, `PFun.comp_id`).
 
+The assertive update is *consistent merge* (`State.merge`,
+[kamp-vangenabith-reyle-2011] Def. 26): [heim-1983]'s revised atomic
+rule (18), which filters where the input already defines the atom's
+cards (rule (13), `atomVar_eq_of_familiar`) and extends where it does
+not (`atomVar_eq_of_novel`) — per point, so atoms are total and
+appropriateness ((15)) lives on `indef`/`def_`, as in the paper.
+Principle (A) in its general form is ascent in informativeness
+(`infoLe_ofState`); set-shrinking eliminativity is its familiar face.
+
 Negation keeps the points of `F` that do not *subsist* (`≺`) in the
 scope's update — the no-verifying-extension clause, generalizing
 [heim-1983]'s world-only `s \ s[φ]` (`CCP.Partial.neg`): on a uniform
@@ -25,8 +34,9 @@ the referent-free shadow of the 1982 ones.
 
 - `FCP`: file change potentials —
   `CCP.Partial (Possibility W V (Option M))`.
-- `FCP.atomW`, `FCP.atomVar`, `FCP.atomVar2`: atomic updates,
-  familiarity-guarded.
+- `FCP.ofState`: assertive update as consistent merge; `FCP.atomW`,
+  `FCP.atomVar`, `FCP.atomVar2` are its instances at proposition
+  states.
 - `FCP.neg`, `FCP.cond`: negation as non-subsistence; *if* as `¬(φ ∧ ¬ψ)`.
 - `FCP.indef`, `FCP.def_`: the Novelty and Familiarity Conditions as
   `Part.assert` guards on `State.randomAssign` and identity.
@@ -35,12 +45,14 @@ the referent-free shadow of the 1982 ones.
 
 ## Main results
 
-- `admits_atomVar`: the Familiarity Condition is exactly definedness.
+- `admits_def_`, `admits_indef`: the Familiarity and Novelty Conditions
+  are exactly definedness.
+- `infoLe_ofState`: Principle (A) — updates only add information.
+- `atomW_eq`, `atomVar_eq_of_familiar`, `atomVar_eq_of_novel`: the
+  filtering and extending regimes of the merge-based atom (rules (13)
+  and (18)).
 - `neg_eq_partial_neg`: on a uniform stratum, non-subsistence negation
   is [heim-1983]'s set-difference negation.
-- `atomW_eliminative`, `atomVar_eliminative`, `neg_eliminative`:
-  Principle (A) — file change only eliminates (closure under sequencing
-  is `CCP.Partial.seq_eliminative`).
 -/
 
 namespace DynamicSemantics
@@ -60,22 +72,40 @@ variable {W V M : Type*}
 def refersTo (F : State W V M) (x : V) (m : M) : Prop :=
   ∀ p ∈ F, p.assignment x = some m
 
-/-- Atomic predicate on the world: filter the points. -/
+/-- Assertive update by a state: consistent merge ([heim-1983]'s revised
+atomic rule (18), which is [kamp-vangenabith-reyle-2011] Def. 26's
+`State.merge`) — each input point pairs with every compatible point of
+`A`, filtering where their domains overlap and extending where `A`
+defines more. Total: appropriateness ((15), the Novelty/Familiarity
+Condition) lives on `indef`/`def_`, as in the paper. -/
+def ofState (A : State W V M) : FCP W V M :=
+  fun F => Part.some (State.merge F A)
+
+/-- Principle (A), general form: assertive update ascends in
+informativeness — `merge_infoLe`'s left leg. Set-shrinking
+eliminativity is its familiar-regime shadow (`atomVar_eq_of_familiar`);
+on novel referents the update extends rather than shrinks. -/
+theorem infoLe_ofState (A : State W V M) {F F' : State W V M}
+    (h : F' ∈ ofState A F) : F ⊑ F' := by
+  obtain rfl := Part.mem_some_iff.mp h
+  exact infoLe_merge_left F A
+
+/-- Atomic predicate on the world: merge with the empty-domain
+proposition state. -/
 def atomW (pred : W → Prop) : FCP W V M :=
-  fun F => Part.some {p ∈ F | pred p.world}
+  ofState {q | q.dom = ∅ ∧ pred q.world}
 
-/-- Atomic predicate at card `x`: filter the points by the value at `x`.
-Defined only if `x` is familiar — Heim's "every variable mentioned has
-been introduced", as a genuine definedness condition. -/
+/-- Atomic predicate at card `x`: merge with the `{x}`-domain
+proposition state. Familiar `x` filters (rule (13)); novel `x` extends
+(rule (18)) — per point, so partially familiar files update
+pointwise. -/
 def atomVar (pred : M → Prop) (x : V) : FCP W V M :=
-  fun F => Part.assert (Familiar F x) fun _ =>
-    Part.some {p ∈ F | ∃ m, p.assignment x = some m ∧ pred m}
+  ofState {q | q.dom = {x} ∧ ∃ m, q.assignment x = some m ∧ pred m}
 
-/-- Binary atomic predicate at `x` and `y`; both must be familiar. -/
+/-- Binary atomic predicate at `x` and `y`. -/
 def atomVar2 (pred : M → M → Prop) (x y : V) : FCP W V M :=
-  fun F => Part.assert (Familiar F x ∧ Familiar F y) fun _ =>
-    Part.some {p ∈ F | ∃ m m', p.assignment x = some m ∧
-      p.assignment y = some m' ∧ pred m m'}
+  ofState {q | q.dom = {x, y} ∧ ∃ m m', q.assignment x = some m ∧
+    q.assignment y = some m' ∧ pred m m'}
 
 /-- Negation: keep the points of `F` that do not subsist in the scope's
 update — the no-verifying-extension clause, as non-subsistence.
@@ -145,12 +175,6 @@ theorem supports_idempotent {F : State W V M} {φ : FCP W V M}
 
 /-! ### Admittance -/
 
-/-- **The Familiarity Condition is definedness**: variable atoms are
-defined exactly on files where the variable is familiar. -/
-theorem admits_atomVar (pred : M → Prop) (x : V) (F : State W V M) :
-    (atomVar pred x).admits F ↔ Familiar F x :=
-  ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, trivial⟩⟩
-
 /-- The Novelty Condition is definedness: an indefinite is defined iff
 its card is novel and the body is defined on the extended file. -/
 theorem admits_indef [DecidableEq V] (x : V) (body : FCP W V M)
@@ -160,25 +184,132 @@ theorem admits_indef [DecidableEq V] (x : V) (body : FCP W V M)
         (body (F.randomAssign x)).Dom := by
   exact Iff.rfl
 
-/-- A definite is defined iff its card is familiar and the body is
-defined. -/
+/-- **The Familiarity Condition is definedness** ((15)): a definite is
+defined iff its card is familiar (and the body is defined). -/
 theorem admits_def_ (x : V) (body : FCP W V M) (F : State W V M) :
     (def_ x body).admits F ↔ ∃ _ : Familiar F x, (body F).Dom := by
   exact Iff.rfl
 
-/-! ### Eliminativity (Principle (A)) -/
+/-! ### The two regimes: filtering and extension
 
-/-- World atoms are eliminative: file change only eliminates points. -/
+The merge-based atom has rule (13) as its familiar face and rule (18)'s
+domain extension as its novel face, per point; `⊆`-eliminativity holds
+exactly on the familiar face, while Principle (A) in general is
+`infoLe_ofState`. -/
+
+/-- World atoms filter, unconditionally: merging with an empty-domain
+proposition state eliminates the points at incompatible worlds. -/
+theorem atomW_eq (pred : W → Prop) (F : State W V M) :
+    atomW pred F = Part.some {p ∈ F | pred p.world} := by
+  refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
+  · rintro ⟨p, hp, q, ⟨hqdom, hqpred⟩, hpq, rfl⟩
+    have hqnone : ∀ v, q.assignment v = none := fun v =>
+      Option.not_isSome_iff_eq_none.mp fun hs =>
+        Set.eq_empty_iff_forall_notMem.mp hqdom v hs
+    have huq : p.union q = p :=
+      Possibility.ext rfl (funext fun v => by
+        simp [Possibility.union, hqnone v])
+    rw [huq]
+    exact ⟨hp, hpq.1.symm ▸ hqpred⟩
+  · rintro ⟨hr, hpred⟩
+    refine ⟨r, hr, ⟨r.world, fun _ => none⟩,
+      ⟨Set.ext fun v => by simp [Possibility.dom], hpred⟩,
+      ⟨rfl, fun _ _ _ _ h => by simp at h⟩, ?_⟩
+    exact Possibility.ext rfl (funext fun v => by simp [Possibility.union])
+
+/-- Rule (13), the familiar regime: at a familiar card the atom
+filters — and in particular is eliminative. -/
+theorem atomVar_eq_of_familiar [DecidableEq V] (pred : M → Prop) (x : V)
+    {F : State W V M} (hfam : Familiar F x) :
+    atomVar pred x F =
+      Part.some {p ∈ F | ∃ m, p.assignment x = some m ∧ pred m} := by
+  refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
+  · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
+    have hqnone : ∀ v, v ≠ x → q.assignment v = none := fun v hv =>
+      Option.not_isSome_iff_eq_none.mp fun hs => hv (by
+        have : v ∈ q.dom := hs
+        rwa [hqdom] at this)
+    obtain ⟨m₀, hpx⟩ := Option.ne_none_iff_exists'.mp (hfam p hp)
+    have huq : p.union q = p :=
+      Possibility.ext rfl (funext fun v => by
+        by_cases hv : v = x
+        · subst hv; simp [Possibility.union, hpx]
+        · simp [Possibility.union, hqnone v hv])
+    rw [huq]
+    exact ⟨hp, m₀, hpx, by rw [hpq.2 x m₀ m hpx hqx]; exact hpred⟩
+  · rintro ⟨hr, m, hrx, hpred⟩
+    refine ⟨r, hr, ⟨r.world, fun v => if v = x then some m else none⟩,
+      ⟨Set.ext fun v => by by_cases hv : v = x <;>
+        simp [Possibility.dom, hv], m, by simp, hpred⟩,
+      ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
+    · have he2 : (if v = x then some m else none) = some e' := he'
+      by_cases hv : v = x
+      · rw [if_pos hv] at he2
+        rw [hv, hrx] at he
+        exact (Option.some_inj.mp he).symm.trans (Option.some_inj.mp he2)
+      · rw [if_neg hv] at he2
+        simp at he2
+    · refine Possibility.ext rfl (funext fun v => ?_)
+      by_cases hv : v = x
+      · subst hv; simp [Possibility.union, hrx]
+      · simp [Possibility.union, hv]
+
+/-- Rule (18), the novel regime: at a novel card the atom extends each
+point with every witness — random assignment then filtering, in one
+step. The indefinite needs no extra content clause; `indef` adds only
+the Novelty guard. -/
+theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
+    {F : State W V M} (hnov : ∀ p ∈ F, p.assignment x = none) :
+    atomVar pred x F = Part.some
+      {p ∈ State.randomAssign F x |
+        ∃ m, p.assignment x = some m ∧ pred m} := by
+  refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
+  · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
+    have hqnone : ∀ v, v ≠ x → q.assignment v = none := fun v hv =>
+      Option.not_isSome_iff_eq_none.mp fun hs => hv (by
+        have : v ∈ q.dom := hs
+        rwa [hqdom] at this)
+    have huq : p.union q = p.extend x (some m) :=
+      Possibility.ext rfl (funext fun v => by
+        by_cases hv : v = x
+        · subst hv; simp [Possibility.union, Possibility.extend,
+            hnov p hp, hqx]
+        · simp [Possibility.union, Possibility.extend, hqnone v hv, hv])
+    rw [huq]
+    exact ⟨⟨p, hp, m, rfl⟩, m, Possibility.extend_at .., hpred⟩
+  · rintro ⟨hmem, m, hrx, hpred⟩
+    obtain ⟨p, hp, m', rfl⟩ := hmem
+    rw [Possibility.extend_at] at hrx
+    obtain rfl := (Option.some_inj.mp hrx).symm
+    refine ⟨p, hp, ⟨p.world, fun v => if v = x then some m else none⟩,
+      ⟨Set.ext fun v => by by_cases hv : v = x <;>
+        simp [Possibility.dom, hv], m, by simp, hpred⟩,
+      ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
+    · have he2 : (if v = x then some m else none) = some e' := he'
+      by_cases hv : v = x
+      · rw [hv, hnov p hp] at he
+        simp at he
+      · rw [if_neg hv] at he2
+        simp at he2
+    · refine Possibility.ext (by simp [Possibility.union]) (funext fun v => ?_)
+      by_cases hv : v = x
+      · rw [hv]
+        simp [Possibility.union, Possibility.extend, hnov p hp]
+      · simp [Possibility.union, Possibility.extend, hv]
+
+/-- World atoms are eliminative (the familiar face of Principle (A)). -/
 theorem atomW_eliminative (pred : W → Prop) {F F' : State W V M}
     (h : F' ∈ atomW pred F) : F' ⊆ F := by
+  rw [atomW_eq] at h
   obtain rfl := Part.mem_some_iff.mp h
   exact fun p hp => hp.1
 
-/-- Variable atoms are eliminative. -/
-theorem atomVar_eliminative (pred : M → Prop) (x : V) {F F' : State W V M}
-    (h : F' ∈ atomVar pred x F) : F' ⊆ F := by
-  obtain ⟨hdom, hval⟩ := Part.mem_assert_iff.mp h
-  obtain rfl := Part.mem_some_iff.mp hval
+/-- Variable atoms are eliminative at familiar cards. -/
+theorem atomVar_eliminative [DecidableEq V] (pred : M → Prop) (x : V)
+    {F F' : State W V M}
+    (hfam : Familiar F x) (h : F' ∈ atomVar pred x F) : F' ⊆ F := by
+  rw [atomVar_eq_of_familiar pred x hfam] at h
+  obtain rfl := Part.mem_some_iff.mp h
   exact fun p hp => hp.1
 
 /-- Negation is eliminative. -/


### PR DESCRIPTION
Adopts Heim 1983's revised atomic rule (18) as canonical: `FCP.ofState A F = F.merge A` — assertive update is KvGR Def. 26 consistent merge with the atom's proposition state, so atoms are total and the Novelty/Familiarity Condition (15) lives only on `indef`/`def_`, as in the paper.

- `atomW`/`atomVar`/`atomVar2` redefined through `ofState`; regime theorems `atomW_eq`, `atomVar_eq_of_familiar` (rule (13): filtering, eliminative), `atomVar_eq_of_novel` (rule (18): random assignment + filtering in one step).
- Principle (A) in general form: `infoLe_ofState` — updates ascend in informativeness; ⊆-eliminativity is its familiar face.