### PR TITLE
refactor(Semantics/Dynamic): ground agreement in Setoid.ker; extend to update

### DIFF
--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Dynamic.Transition
 import Mathlib.CategoryTheory.Category.Preorder
+import Mathlib.CategoryTheory.Elements
 import Mathlib.CategoryTheory.Types.Basic
 import Mathlib.Data.Set.Functor
 
@@ -11,12 +12,12 @@ live discourse referents), morphisms are `Transition`s, composition is
 world-pointwise relational composition. The identity and associativity
 laws are `Transition.lean`'s `id_comp`/`comp_id`/`comp_assoc`.
 
-The presheaf of state fibers is the composite of the environments
+The presheaf of state fibers is the composite of the possibilities
 presheaf with the powerset functor — definitionally, in this
 formulation: the predecessor proved the isomorphism
-(`presheafIsoEnvironments`); typing states at their environments makes
+typing states at the possibilities makes
 it the definition (`State.presheaf`). Restriction is `Set.image` along
-environment weakening, the ∃-leg of mathlib's
+weakening, the ∃-leg of mathlib's
 `Set.image_preimage`/`Set.preimage_kernImage` triple ([lawvere-1969]'s
 quantifiers as adjoints to weakening, as retold by [jacobs-1999]).
 Syntax categories interpret into `Ctx` (`DRS/Category.lean`); the fiber
@@ -26,14 +27,17 @@ at `∅` is [veltman-1996]'s update semantics.
 
 - `Ctx W M V`: bundled contexts, with a `Category` instance whose
   morphisms are `Transition`s between the bases.
-- `environments`: the presheaf of world–assignment pairs at each
+- `possibilities`: the presheaf of world–assignment pairs at each
   granularity — a set-valued indexed category in [jacobs-1999]'s sense,
   its maps the semantic face of *weakening*. Precedent for the
   states-as-presheaf reading: [abramsky-sadrzadeh-2014].
-- `State.presheaf`: the state fibers — `environments ⋙ Set`.
-- `environments_glue`, `environments_beck_chevalley`: the context-lattice
-  square is a pullback of environments, so quantification commutes with
+- `State.presheaf`: the state fibers — `possibilities ⋙ Set`.
+- `possibilities_glue`, `possibilities_beck_chevalley`: the context-lattice
+  square is a pullback of possibilities, so quantification commutes with
   weakening — the fibers are a hyperdoctrine.
+- `elementsEquivBased`: the Grothendieck total of the family is the point
+  type — the category of elements is the descent preorder on
+  `Possibility.Based`, opposed.
 
 ## References
 
@@ -77,37 +81,37 @@ instance : Category (Ctx W M V) where
 
 end Ctx
 
-/-! ### The environments presheaf and the state fibers -/
+/-! ### The possibilities presheaf and the state fibers -/
 
 universe u v w
 
-/-- The presheaf of environments: over `X`, world–assignment pairs at
+/-- The presheaf of possibilities: over `X`, world–assignment pairs at
 granularity `X`; restriction precomposes with the inclusion. A model read
 over the category of contexts — a set-valued *indexed category* in
 [jacobs-1999]'s sense, whose maps are the semantic face of *weakening*
 (the functor "which adds an extra dummy" variable, in the book's own
 gloss). -/
-def environments (W : Type u) (M : Type v) (V : Type w) :
+def possibilities (W : Type u) (M : Type v) (V : Type w) :
     (Finset V)ᵒᵖ ⥤ Type (max u v w) where
   obj X := W × ((↑X.unop : Set V) → M)
   map {X Y} f := TypeCat.ofHom fun p =>
     ⟨p.1, fun v => p.2 ⟨v.1, leOfHom f.unop v.2⟩⟩
 
 /-- The state fibers as a presheaf on the poset of bases: the powerset
-functor applied fiberwise to the environments — by definition, in this
+functor applied fiberwise to the possibilities — by definition, in this
 formulation. The fiber over `X` is `Set (W × (↑X → M))`; restriction is
-direct image along environment weakening. -/
+direct image along weakening. -/
 def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
     (Finset V)ᵒᵖ ⥤ Type (max u v w) :=
-  environments W M V ⋙ ofTypeFunctor Set
+  possibilities W M V ⋙ ofTypeFunctor Set
 
 /-! ### Gluing and Beck–Chevalley
 
-`environments` sends each square of the context lattice to a pullback
-(`environments_glue`), so quantification and weakening cohere: the
+`possibilities` sends each square of the context lattice to a pullback
+(`possibilities_glue`), so quantification and weakening cohere: the
 existential legs (`Set.image`, which is `State.presheaf`'s own action)
 commute with reindexing (`Set.preimage`) across the square
-(`environments_beck_chevalley`). Together with mathlib's
+(`possibilities_beck_chevalley`). Together with mathlib's
 `Set.image_subset_iff` (`∃ ⊣ weakening`), `Set.preimage_kernImage`
 (`weakening ⊣ ∀`), and `Set.image_inter_preimage` (Frobenius), the
 fibers form a hyperdoctrine over the context lattice ([lawvere-1969],
@@ -119,27 +123,27 @@ open Opposite
 
 variable {W M V : Type*} {X Y : Finset V}
 
-/-- The action of `environments` on a lattice inequality, elementwise. -/
-@[simp] theorem environments_map_apply (h : X ≤ Y)
-    (p : (environments W M V).obj (op Y)) :
-    (environments W M V).map (homOfLE h).op p =
+/-- The action of `possibilities` on a lattice inequality, elementwise. -/
+@[simp] theorem possibilities_map_apply (h : X ≤ Y)
+    (p : (possibilities W M V).obj (op Y)) :
+    (possibilities W M V).map (homOfLE h).op p =
       (p.1, fun v => p.2 ⟨v.1, h v.2⟩) := rfl
 
 variable [DecidableEq V]
 
-/-- Environments glue: a pair of environments over `X` and `Y` whose
+/-- Possibilities glue: a pair of possibilities over `X` and `Y` whose
 weakenings to `X ⊓ Y` agree is jointly the weakening of a unique
-environment over `X ⊔ Y` — `environments` sends the lattice square to a
-pullback of types. The piecewise witness is the environment face of
-`Possibility.union`. -/
-theorem environments_glue
-    (a : (environments W M V).obj (op X)) (b : (environments W M V).obj (op Y))
-    (hab : (environments W M V).map (homOfLE inf_le_left).op a =
-      (environments W M V).map (homOfLE inf_le_right).op b) :
-    ∃! c : (environments W M V).obj (op (X ⊔ Y)),
-      (environments W M V).map (homOfLE le_sup_left).op c = a ∧
-        (environments W M V).map (homOfLE le_sup_right).op c = b := by
-  simp only [environments_map_apply] at hab ⊢
+possibility over `X ⊔ Y` — `possibilities` sends the lattice square to a
+pullback of types. The piecewise witness is `Possibility.union` in the charts of
+`Possibility.domEquiv`. -/
+theorem possibilities_glue
+    (a : (possibilities W M V).obj (op X)) (b : (possibilities W M V).obj (op Y))
+    (hab : (possibilities W M V).map (homOfLE inf_le_left).op a =
+      (possibilities W M V).map (homOfLE inf_le_right).op b) :
+    ∃! c : (possibilities W M V).obj (op (X ⊔ Y)),
+      (possibilities W M V).map (homOfLE le_sup_left).op c = a ∧
+        (possibilities W M V).map (homOfLE le_sup_right).op c = b := by
+  simp only [possibilities_map_apply] at hab ⊢
   have hw : a.1 = b.1 := congrArg Prod.fst hab
   have hagree : ∀ (v : V) (hX : v ∈ X) (hY : v ∈ Y),
       a.2 ⟨v, hX⟩ = b.2 ⟨v, hY⟩ := fun v hX hY =>
@@ -159,22 +163,89 @@ along `X ⊓ Y ≤ X` then weakening to `Y` is weakening to `X ⊔ Y` then
 existential image along `Y ≤ X ⊔ Y` — quantifying and reindexing
 commute. The image legs are `State.presheaf`'s own action on the
 square's arrows. -/
-theorem environments_beck_chevalley (X Y : Finset V)
-    (S : Set ((environments W M V).obj (op X))) :
-    (environments W M V).map (homOfLE (inf_le_right : X ⊓ Y ≤ Y)).op ⁻¹'
-      ((environments W M V).map (homOfLE (inf_le_left : X ⊓ Y ≤ X)).op '' S) =
-    (environments W M V).map (homOfLE (le_sup_right : Y ≤ X ⊔ Y)).op ''
-      ((environments W M V).map (homOfLE (le_sup_left : X ≤ X ⊔ Y)).op ⁻¹' S) := by
+theorem possibilities_beck_chevalley (X Y : Finset V)
+    (S : Set ((possibilities W M V).obj (op X))) :
+    (possibilities W M V).map (homOfLE (inf_le_right : X ⊓ Y ≤ Y)).op ⁻¹'
+      ((possibilities W M V).map (homOfLE (inf_le_left : X ⊓ Y ≤ X)).op '' S) =
+    (possibilities W M V).map (homOfLE (le_sup_right : Y ≤ X ⊔ Y)).op ''
+      ((possibilities W M V).map (homOfLE (le_sup_left : X ≤ X ⊔ Y)).op ⁻¹' S) := by
   ext b
   constructor
   · rintro ⟨a, ha, hab⟩
-    obtain ⟨c, ⟨hcX, hcY⟩, -⟩ := environments_glue a b hab
+    obtain ⟨c, ⟨hcX, hcY⟩, -⟩ := possibilities_glue a b hab
     exact ⟨c, show _ ∈ S by rw [hcX]; exact ha, hcY⟩
   · rintro ⟨c, hc, rfl⟩
-    refine ⟨(environments W M V).map (homOfLE le_sup_left).op c, hc, ?_⟩
+    refine ⟨(possibilities W M V).map (homOfLE le_sup_left).op c, hc, ?_⟩
     rw [← Functor.map_comp_apply, ← Functor.map_comp_apply,
       ← op_comp, ← op_comp, homOfLE_comp, homOfLE_comp]
 
 end Gluing
+
+/-! ### The Grothendieck total -/
+
+section Total
+
+open Opposite
+
+variable {W M V : Type*} [DecidableEq V]
+
+/-- Classify each element of the possibilities family as a based point:
+on objects this is `Possibility.domEquiv`; arrows become descents, by
+`Possibility.descendant_iff_eq_restrict`. -/
+noncomputable def elementsToBased :
+    (possibilities W M V).Elements ⥤ (Possibility.Based W V M)ᵒᵖ where
+  obj x := op ⟨((Possibility.domEquiv x.1.unop).symm x.2).1, by
+    rw [((Possibility.domEquiv x.1.unop).symm x.2).2]
+    exact x.1.unop.finite_toSet⟩
+  map {x y} f := (homOfLE (show
+      ((Possibility.domEquiv y.1.unop).symm y.2).1.Descendant
+        ((Possibility.domEquiv x.1.unop).symm x.2).1 by
+    have hb : y.1.unop ≤ x.1.unop := leOfHom f.1.unop
+    have hmap : (possibilities W M V).map f.1 x.2 = y.2 := f.2
+    rw [Subsingleton.elim f.1 (homOfLE hb).op, possibilities_map_apply]
+      at hmap
+    rw [← hmap, ← Possibility.restrict_domEquiv_symm hb]
+    exact Possibility.restrict_descendant _ _)).op
+  map_id _ := Subsingleton.elim _ _
+  map_comp _ _ := Subsingleton.elim _ _
+
+instance : (elementsToBased (W := W) (M := M) (V := V)).Faithful where
+  map_injective _ := Subtype.ext (Subsingleton.elim _ _)
+
+instance : (elementsToBased (W := W) (M := M) (V := V)).Full where
+  map_surjective {x y} f := by
+    have hd : ((Possibility.domEquiv y.1.unop).symm y.2).1.Descendant
+        ((Possibility.domEquiv x.1.unop).symm x.2).1 := leOfHom f.unop
+    have hb : y.1.unop ≤ x.1.unop := Finset.coe_subset.mp
+      (((Possibility.domEquiv y.1.unop).symm y.2).2 ▸
+        ((Possibility.domEquiv x.1.unop).symm x.2).2 ▸ hd.dom_subset)
+    refine ⟨⟨(homOfLE hb).op, ?_⟩, Subsingleton.elim _ _⟩
+    refine (Possibility.domEquiv y.1.unop).symm.injective (Subtype.ext ?_)
+    rw [possibilities_map_apply, ← Possibility.restrict_domEquiv_symm hb]
+    exact ((Possibility.descendant_iff_eq_restrict
+      ((Possibility.domEquiv y.1.unop).symm y.2).2).mp hd).symm
+
+instance : (elementsToBased (W := W) (M := M) (V := V)).EssSurj where
+  mem_essImage y :=
+    ⟨⟨op y.unop.2.toFinset,
+        Possibility.domEquiv _ ⟨y.unop.1, y.unop.2.coe_toFinset.symm⟩⟩,
+      ⟨eqToIso (by
+        apply Opposite.unop_injective
+        apply Subtype.ext
+        have hval := congrArg Subtype.val
+          ((Possibility.domEquiv y.unop.2.toFinset).symm_apply_apply
+            ⟨y.unop.1, y.unop.2.coe_toFinset.symm⟩)
+        exact hval)⟩⟩
+
+instance : (elementsToBased (W := W) (M := M) (V := V)).IsEquivalence := {}
+
+/-- **The Grothendieck total of the possibilities family is the point
+type**: the category of elements is equivalent to the opposite of the
+descent preorder on based points. -/
+noncomputable def elementsEquivBased :
+    (possibilities W M V).Elements ≌ (Possibility.Based W V M)ᵒᵖ :=
+  elementsToBased.asEquivalence
+
+end Total
 
 end DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -37,7 +37,7 @@ continuation-based systems choose further effects.
 ## Main definitions
 
 - `Ctx.collapse`: the functor `Ctx W M V ⥤ RelCat` sending a context to
-  its environment space and a transition to its world-threaded relation.
+  its possibility space and a transition to its world-threaded relation.
 - `liftEquiv`: `Update S ≃ sSupHom (Set S) (Set S)`.
 - `relCatEquivKleisli`: `RelCat ≌ KleisliCat Set`. [UPSTREAM] candidate —
   pure category theory, absent from mathlib.
@@ -77,7 +77,7 @@ namespace Ctx
 variable {W M V : Type*} {X Y Z : Ctx W M V}
 
 /-- **The one-object collapse**: forget the base-indexing, sending a
-context to its environment space and a transition to its world-threaded
+context to its possibility space and a transition to its world-threaded
 relation. Unital by typing — no quotient needed. -/
 def collapse (W M V : Type*) : Ctx W M V ⥤ RelCat where
   obj X := W × ((↑X.base : Set V) → M)

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -21,7 +21,12 @@ algebra is the suplattice completion of the relational one and the
 non-distributive tests (`might`, `must`) are exactly the residue.
 Categorically, `RelCat ≌ KleisliCat Set`, and the indexed tower reads
 `Ctx ⥤ RelCat ≌ KleisliCat Set ↪ suplattice endomaps`, every arrow
-canonical.
+canonical. The collapsed state space at `X` is the `X`-stratum of root
+states, classified by `Possibility.domEquiv`/`State.uniformEquiv`, and
+the relational action computes the root-state CCP through that
+classification (`Transition.uniformEquiv_applyState`) — the extraction
+of a relational meaning from a DRT-style one, as a morphism
+([visser-vermeulen-1996]).
 
 The powerset monad is one column of the effect view of dynamic semantics
 ([moggi-1991], [shan-2001], [bumford-charlow-2024]): a framework's update

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -122,7 +122,9 @@ def cond (φ ψ : FCP W V M) : FCP W V M :=
 /-- Indefinite introduction: defined only if `x` is novel (the Novelty
 Condition — no point defines it); then introduce `x` by random
 assignment and update with the body. Indefinites don't quantify — they
-open a new file card. -/
+open a new file card. [heim-1991] later derives novelty from Maximize
+Presupposition rather than stipulating it; the guard here is the
+original (15). -/
 def indef [DecidableEq V] (x : V) (body : FCP W V M) : FCP W V M :=
   fun F => Part.assert (∀ p ∈ F, p.assignment x = none) fun _ =>
     body (State.randomAssign F x)

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -269,17 +269,17 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
       Option.not_isSome_iff_eq_none.mp fun hs => hv (by
         have : v ∈ q.dom := hs
         rwa [hqdom] at this)
-    have huq : p.union q = p.extend x (some m) :=
+    have huq : p.union q = p.update x (some m) :=
       Possibility.ext rfl (funext fun v => by
         by_cases hv : v = x
-        · subst hv; simp [Possibility.union, Possibility.extend,
+        · subst hv; simp [Possibility.union, Possibility.update,
             hnov p hp, hqx]
-        · simp [Possibility.union, Possibility.extend, hqnone v hv, hv])
+        · simp [Possibility.union, Possibility.update, hqnone v hv, hv])
     rw [huq]
-    exact ⟨⟨p, hp, m, rfl⟩, m, Possibility.extend_at .., hpred⟩
+    exact ⟨⟨p, hp, m, rfl⟩, m, Possibility.update_self .., hpred⟩
   · rintro ⟨hmem, m, hrx, hpred⟩
     obtain ⟨p, hp, m', rfl⟩ := hmem
-    rw [Possibility.extend_at] at hrx
+    rw [Possibility.update_self] at hrx
     obtain rfl := (Option.some_inj.mp hrx).symm
     refine ⟨p, hp, ⟨p.world, fun v => if v = x then some m else none⟩,
       ⟨Set.ext fun v => by by_cases hv : v = x <;>
@@ -294,8 +294,8 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     · refine Possibility.ext (by simp [Possibility.union]) (funext fun v => ?_)
       by_cases hv : v = x
       · rw [hv]
-        simp [Possibility.union, Possibility.extend, hnov p hp]
-      · simp [Possibility.union, Possibility.extend, hv]
+        simp [Possibility.union, Possibility.update, hnov p hp]
+      · simp [Possibility.union, Possibility.update, hv]
 
 /-- World atoms are eliminative (the familiar face of Principle (A)). -/
 theorem atomW_eliminative (pred : W → Prop) {F F' : State W V M}

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Set.Function
 
 /-!
@@ -28,7 +29,7 @@ universe across worlds — and the monadic tradition calls the same points
   their defined referents, growth order, and consistent union.
 - `Possibility.restrict`, `Possibility.domEquiv`: domain restriction and
   the constructive classification of the domain-`X` points as
-  world–`X`-environment pairs.
+  world–`X`-assignment pairs.
 
 ## References
 
@@ -281,7 +282,7 @@ theorem restrict_restrict (X Y : Finset V)
   by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;>
     simp [restrict, hx, hy]
 
-/-- Partial points with domain `X` are world–`X`-environment pairs —
+/-- Partial points with domain `X` are world–`X`-assignment pairs —
 constructively: the classification that the total-assignment rendering
 recovered only with choice and an inhabitant of `M`. -/
 def domEquiv (X : Finset V) :
@@ -308,7 +309,40 @@ def domEquiv (X : Finset V) :
     refine Prod.ext rfl (funext fun v => ?_)
     simp
 
+@[simp] theorem domEquiv_symm_val (X : Finset V)
+    (e : W × ((↑X : Set V) → M)) :
+    ((domEquiv X).symm e).1 =
+      ⟨e.1, fun v => if h : v ∈ (↑X : Set V) then some (e.2 ⟨v, h⟩)
+        else none⟩ :=
+  rfl
+
+/-- The charts commute with restriction: restricting a classified point
+is weakening its chart. -/
+theorem restrict_domEquiv_symm {Y X : Finset V} (h : Y ≤ X)
+    (e : W × ((↑X : Set V) → M)) :
+    ((domEquiv X).symm e).1.restrict Y =
+      ((domEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 := by
+  rw [domEquiv_symm_val, domEquiv_symm_val]
+  refine Possibility.ext rfl (funext fun v => ?_)
+  by_cases hv : v ∈ Y
+  · have hvX : v ∈ X := h hv
+    simp [restrict, hv, hvX]
+  · simp [restrict, hv]
+
 end Restrict
+
+/-! ### Based points -/
+
+/-- A *based* point: a possibility whose domain is finite —
+[kamp-vangenabith-reyle-2011] Def. 23 calls the domain the *base*.
+Under descent, based points form the total space of `Category.lean`'s
+possibilities family. -/
+def Based (W V M : Type*) := {p : Possibility W V (Option M) // p.dom.Finite}
+
+instance : Preorder (Based W V M) where
+  le p q := p.1.Descendant q.1
+  le_refl p := Descendant.refl p.1
+  le_trans _ _ _ := Descendant.trans
 
 end Possibility
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -53,12 +53,11 @@ referents to individuals. -/
 
 namespace Possibility
 
-variable {W V M : Type*} (X : Set V)
+variable {W V M : Type*} (X : Set V) (p : Possibility W V M)
 
 /-- The projection of a possibility to granularity `X` is its world
 together with its assignment of the `X`-referents. -/
-def proj (p : Possibility W V M) : W × (X → M) :=
-  (p.world, X.restrict p.assignment)
+def proj : W × (X → M) := (p.world, X.restrict p.assignment)
 
 /-- Two possibilities agree at granularity `X` when their projections to
 `X` coincide. -/
@@ -82,27 +81,24 @@ noncomputable def agreeQuotientEquiv [Nonempty M] :
       exact Subtype.val_injective.extend_apply wf.2
         (fun _ => Classical.arbitrary M) x)
 
-@[simp] theorem agreeQuotientEquiv_mk [Nonempty M]
-    (p : Possibility W V M) :
+@[simp] theorem agreeQuotientEquiv_mk [Nonempty M] :
     agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
   rfl
 
 /-- Update the assignment at a single referent. -/
-def update [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
-    Possibility W V M :=
+def update [DecidableEq V] (x : V) (e : M) : Possibility W V M :=
   { p with assignment := Function.update p.assignment x e }
 
-@[simp] theorem update_self [DecidableEq V] (p : Possibility W V M)
-    (x : V) (e : M) : (p.update x e).assignment x = e :=
+@[simp] theorem update_self [DecidableEq V] (x : V) (e : M) :
+    (p.update x e).assignment x = e :=
   Function.update_self ..
 
-@[simp] theorem update_of_ne [DecidableEq V] (p : Possibility W V M)
-    {x y : V} (e : M) (h : y ≠ x) :
-    (p.update x e).assignment y = p.assignment y :=
+@[simp] theorem update_of_ne [DecidableEq V] {x y : V} (e : M)
+    (h : y ≠ x) : (p.update x e).assignment y = p.assignment y :=
   Function.update_of_ne h ..
 
-@[simp] theorem update_world [DecidableEq V] (p : Possibility W V M)
-    (x : V) (e : M) : (p.update x e).world = p.world := rfl
+@[simp] theorem update_world [DecidableEq V] (x : V) (e : M) :
+    (p.update x e).world = p.world := rfl
 
 /-! ### Partial points -/
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -15,14 +15,18 @@ sets of possibilities, with the generic level-0 CCP algebra in
 [groenendijk-stokhof-veltman-1996]'s possibilities are triples carrying a
 referent system ([vermeulen-1995]) we do not; [elliott-sudo-2025]'s are
 world–assignment pairs like ours. [kamp-vangenabith-reyle-2011] leaves the
-pairs of its Def. 22 unnamed, and the monadic tradition calls the same
-points *indices* ([charlow-2025-staged-updates]).
+pairs of its Def. 22 unnamed — DRT's word for the assignment is
+*(verifying) embedding*, a partial function on referents with one
+universe across worlds — and the monadic tradition calls the same points
+*indices* ([charlow-2025-staged-updates]).
 
 ## Main definitions
 
-- `Possibility W V M`: the point object.
-- `Possibility.agreeSetoid X`: possibilities up to agreement on `X` — the
-  state space at granularity `X` (`Collapse.lean`, `State.fiberEquiv`).
+- `Possibility W V M`: the point object; `Possibility.update` rewrites
+  one referent.
+- `Possibility.agreeSetoid X`: agreement at granularity `X`, as the
+  kernel of the projection `Possibility.proj X`; quotienting by it is
+  the state space at granularity `X` (`Collapse.lean`).
 - `Possibility.dom`, `Possibility.Descendant`, `Possibility.Compatible`,
   `Possibility.union`: partial points (`Option`-valued assignments) —
   their defined referents, growth order, and consistent union.
@@ -39,10 +43,8 @@ points *indices* ([charlow-2025-staged-updates]).
 
 namespace DynamicSemantics
 
-/-! ### The point object -/
-
-/-- A possibility: a world paired with an assignment of discourse referents
-to individuals — the point type of dynamic semantics. -/
+/-- A possibility is a world paired with an assignment of discourse
+referents to individuals. -/
 @[ext] structure Possibility (W V M : Type*) where
   /-- The world coordinate. -/
   world : W
@@ -53,65 +55,62 @@ namespace Possibility
 
 variable {W V M : Type*}
 
-/-- The projection of a possibility to granularity `A`: its world together
-with its assignment of the `A`-referents — the pointwise face of
-`Category.lean`'s `environments`. -/
+/-- The projection of a possibility to granularity `A` is its world
+together with its assignment of the `A`-referents. -/
 def proj (A : Set V) (p : Possibility W V M) : W × (A → M) :=
   (p.world, A.restrict p.assignment)
 
-/-- Possibilities up to agreement on `X`: equal worlds, assignments agreeing
-on `X`. Quotienting by this setoid is the state space at granularity `X` —
-the collapse of `Collapse.lean`, and the target of `State.fiberEquiv`. -/
-def agreeSetoid (X : Set V) : Setoid (Possibility W V M) where
-  r p q := p.world = q.world ∧ Set.EqOn p.assignment q.assignment X
-  iseqv :=
-    ⟨fun _ => ⟨rfl, Set.eqOn_refl _ _⟩, fun h => ⟨h.1.symm, h.2.symm⟩,
-      fun h h' => ⟨h.1.trans h'.1, h.2.trans h'.2⟩⟩
+/-- Two possibilities agree at granularity `X` when their projections to
+`X` coincide. -/
+def agreeSetoid (X : Set V) : Setoid (Possibility W V M) :=
+  Setoid.ker (proj X)
 
-/-- Projections agree exactly on agreement classes: `proj A` is the
-effective quotient map for `agreeSetoid A`. -/
-theorem proj_eq_proj_iff {A : Set V} {p q : Possibility W V M} :
-    proj A p = proj A q ↔ agreeSetoid A p q :=
+/-- Possibilities agree at `X` exactly when they share their world and
+their assignments agree on `X`. -/
+theorem agreeSetoid_iff {X : Set V} {p q : Possibility W V M} :
+    agreeSetoid X p q ↔
+      p.world = q.world ∧ Set.EqOn p.assignment q.assignment X :=
   Prod.ext_iff.trans (and_congr Iff.rfl Set.restrict_eq_restrict_iff)
 
-/-- Coarser bases identify more possibilities. -/
-theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
-  fun _ _ hXY _ _ h => ⟨h.1, h.2.mono hXY⟩
+/-- Coarser granularities identify more possibilities. -/
+theorem agreeSetoid_anti :
+    Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
+  fun _ _ hXY _ _ h =>
+    have h' := agreeSetoid_iff.mp h
+    agreeSetoid_iff.mpr ⟨h'.1, h'.2.mono hXY⟩
 
-open scoped Classical in
-/-- The state space at granularity `X`, classified: a possibility up to
-agreement on `X` is a world together with an assignment of the
-`X`-referents. -/
+/-- A possibility up to agreement at `X` is a world together with an
+assignment of the `X`-referents. -/
 noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
-    Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) where
-  toFun := Quotient.lift (proj X) fun _ _ h => proj_eq_proj_iff.mpr h
-  invFun wf :=
-    Quotient.mk _
-      ⟨wf.1, fun v => if h : v ∈ X then wf.2 ⟨v, h⟩ else Classical.arbitrary M⟩
-  left_inv := by
-    rintro ⟨p⟩
-    exact Quotient.sound ⟨rfl, fun v hv => dif_pos hv⟩
-  right_inv wf := Prod.ext rfl (funext fun x => dif_pos x.2)
+    Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) :=
+  Setoid.quotientKerEquivOfRightInverse (proj X)
+    (fun wf => ⟨wf.1,
+      Function.extend Subtype.val wf.2 fun _ => Classical.arbitrary M⟩)
+    fun wf => Prod.ext rfl (funext fun x => by
+      exact Subtype.val_injective.extend_apply wf.2
+        (fun _ => Classical.arbitrary M) x)
 
 @[simp] theorem agreeQuotientEquiv_mk (X : Set V) [Nonempty M]
     (p : Possibility W V M) :
     agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
   rfl
 
-/-- Extend the assignment at a single referent, via `Function.update`. -/
-def extend [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
+/-- Update the assignment at a single referent. -/
+def update [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
     Possibility W V M :=
   { p with assignment := Function.update p.assignment x e }
 
-@[simp] theorem extend_at [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
-    (p.extend x e).assignment x = e := by simp [extend]
+@[simp] theorem update_self [DecidableEq V] (p : Possibility W V M)
+    (x : V) (e : M) : (p.update x e).assignment x = e :=
+  Function.update_self ..
 
-@[simp] theorem extend_other [DecidableEq V] (p : Possibility W V M) (x y : V)
-    (e : M) (h : y ≠ x) : (p.extend x e).assignment y = p.assignment y := by
-  simp [extend, h]
+@[simp] theorem update_of_ne [DecidableEq V] (p : Possibility W V M)
+    {x y : V} (e : M) (h : y ≠ x) :
+    (p.update x e).assignment y = p.assignment y :=
+  Function.update_of_ne h ..
 
-@[simp] theorem extend_world [DecidableEq V] (p : Possibility W V M) (x : V) (e : M) :
-    (p.extend x e).world = p.world := rfl
+@[simp] theorem update_world [DecidableEq V] (p : Possibility W V M)
+    (x : V) (e : M) : (p.update x e).world = p.world := rfl
 
 /-! ### Partial points -/
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -53,21 +53,22 @@ referents to individuals. -/
 
 namespace Possibility
 
-variable {W V M : Type*}
+variable {W V M : Type*} (X : Set V)
 
-/-- The projection of a possibility to granularity `A` is its world
-together with its assignment of the `A`-referents. -/
-def proj (A : Set V) (p : Possibility W V M) : W × (A → M) :=
-  (p.world, A.restrict p.assignment)
+/-- The projection of a possibility to granularity `X` is its world
+together with its assignment of the `X`-referents. -/
+def proj (p : Possibility W V M) : W × (X → M) :=
+  (p.world, X.restrict p.assignment)
 
 /-- Two possibilities agree at granularity `X` when their projections to
 `X` coincide. -/
-def agreeSetoid (X : Set V) : Setoid (Possibility W V M) :=
+def agreeSetoid : Setoid (Possibility W V M) :=
   Setoid.ker (proj X)
 
+variable {X} in
 /-- Possibilities agree at `X` exactly when they share their world and
 their assignments agree on `X`. -/
-theorem agreeSetoid_iff {X : Set V} {p q : Possibility W V M} :
+theorem agreeSetoid_iff {p q : Possibility W V M} :
     agreeSetoid X p q ↔
       p.world = q.world ∧ Set.EqOn p.assignment q.assignment X :=
   Prod.ext_iff.trans (and_congr Iff.rfl Set.restrict_eq_restrict_iff)
@@ -81,7 +82,7 @@ theorem agreeSetoid_anti :
 
 /-- A possibility up to agreement at `X` is a world together with an
 assignment of the `X`-referents. -/
-noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
+noncomputable def agreeQuotientEquiv [Nonempty M] :
     Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) :=
   Setoid.quotientKerEquivOfRightInverse (proj X)
     (fun wf => ⟨wf.1,
@@ -90,7 +91,7 @@ noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
       exact Subtype.val_injective.extend_apply wf.2
         (fun _ => Classical.arbitrary M) x)
 
-@[simp] theorem agreeQuotientEquiv_mk (X : Set V) [Nonempty M]
+@[simp] theorem agreeQuotientEquiv_mk [Nonempty M]
     (p : Possibility W V M) :
     agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
   rfl
@@ -221,6 +222,50 @@ theorem Descendant.union_descendant {p q u : Possibility W V (Option M)}
     · exact hq.2 v e (by simpa [union, hpv] using h)
     · have : e' = e := by simpa [union, hpv] using h
       exact this ▸ hp.2 v e' hpv⟩
+
+theorem Compatible.symm {p q : Possibility W V (Option M)}
+    (h : p.Compatible q) : q.Compatible p :=
+  ⟨h.1.symm, fun v e e' hq hp => (h.2 v e' e hp hq).symm⟩
+
+/-- Union of points is associative. -/
+theorem union_assoc (p q v : Possibility W V (Option M)) :
+    (p.union q).union v = p.union (q.union v) :=
+  Possibility.ext rfl (funext fun _ => Option.or_assoc ..)
+
+/-- On compatible points the left precedence of `union` is
+immaterial. -/
+theorem Compatible.union_comm {p q : Possibility W V (Option M)}
+    (h : p.Compatible q) : p.union q = q.union p :=
+  Possibility.ext h.1 (funext fun v => by
+    rcases hp : p.assignment v with _ | e <;>
+      rcases hq : q.assignment v with _ | e' <;> simp [union, hp, hq]
+    exact h.2 v e e' hp hq)
+
+/-- A union is compatible with whatever both components are compatible
+with. -/
+theorem Compatible.union_left {p q v : Possibility W V (Option M)}
+    (hpv : p.Compatible v) (hqv : q.Compatible v) :
+    (p.union q).Compatible v :=
+  ⟨hpv.1, fun x e e' he he' => by
+    rcases hp : p.assignment x with _ | c
+    · exact hqv.2 x e e' (by simpa [union, hp] using he) he'
+    · have hce : c = e := by simpa [union, hp] using he
+      exact hce ▸ hpv.2 x c e' hp he'⟩
+
+/-- The left component of a compatible union is compatible. -/
+theorem Compatible.left_of_union {p q v : Possibility W V (Option M)}
+    (h : (p.union q).Compatible v) : p.Compatible v :=
+  ⟨h.1, fun x e e' hp hv => h.2 x e e' (by simp [union, hp]) hv⟩
+
+/-- The right component of a compatible union is compatible, given the
+components agree. -/
+theorem Compatible.right_of_union {p q v : Possibility W V (Option M)}
+    (hpq : p.Compatible q) (h : (p.union q).Compatible v) :
+    q.Compatible v :=
+  ⟨hpq.1.symm.trans h.1, fun x e e' hq hv => by
+    rcases hp : p.assignment x with _ | c
+    · exact h.2 x e e' (by simp [union, hp, hq]) hv
+    · exact hpq.2 x c e hp hq ▸ h.2 x c e' (by simp [union, hp]) hv⟩
 
 /-! ### Restriction and the indexed classification -/
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -69,16 +69,22 @@ theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility
     congrArg (fun wf : W × (Y → M) =>
       ((wf.1, fun v => wf.2 ⟨v.1, hXY v.2⟩) : W × (X → M))) h
 
+/-- The possibility over a world–`X`-environment pair, junk-valued off
+`X`. -/
+noncomputable def ofEnv [Nonempty M] (wf : W × (X → M)) : Possibility W V M :=
+  ⟨wf.1, Function.extend Subtype.val wf.2 fun _ => Classical.arbitrary M⟩
+
+/-- `proj X` retracts `ofEnv X`. -/
+@[simp] theorem proj_ofEnv [Nonempty M] (wf : W × (X → M)) :
+    proj X (ofEnv X wf) = wf :=
+  Prod.ext rfl (funext fun x => by
+    exact Subtype.val_injective.extend_apply wf.2 (fun _ => Classical.arbitrary M) x)
+
 /-- A possibility up to agreement at `X` is a world together with an
 assignment of the `X`-referents. -/
 noncomputable def agreeQuotientEquiv [Nonempty M] :
-    Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) :=
-  Setoid.quotientKerEquivOfRightInverse (proj X)
-    (fun wf => ⟨wf.1,
-      Function.extend Subtype.val wf.2 fun _ => Classical.arbitrary M⟩)
-    fun wf => Prod.ext rfl (funext fun x => by
-      exact Subtype.val_injective.extend_apply wf.2
-        (fun _ => Classical.arbitrary M) x)
+    Quotient (agreeSetoid X : Setoid (Possibility W V M)) ≃ W × (X → M) :=
+  Setoid.quotientKerEquivOfRightInverse (proj X) (ofEnv X) (proj_ofEnv X)
 
 @[simp] theorem agreeQuotientEquiv_mk [Nonempty M] :
     agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -64,8 +64,7 @@ def proj : W × (X → M) := (p.world, X.restrict p.assignment)
 def agreeSetoid : Setoid (Possibility W V M) := Setoid.ker (proj X)
 
 /-- Coarser granularities identify more possibilities. -/
-theorem agreeSetoid_anti :
-    Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
+theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
   fun X Y hXY _ _ h =>
     congrArg (fun wf : W × (Y → M) =>
       ((wf.1, fun v => wf.2 ⟨v.1, hXY v.2⟩) : W × (X → M))) h

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -69,8 +69,8 @@ theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility
     congrArg (fun wf : W × (Y → M) =>
       ((wf.1, fun v => wf.2 ⟨v.1, hXY v.2⟩) : W × (X → M))) h
 
-/-- The possibility over a world–`X`-environment pair, junk-valued off
-`X`. -/
+/-- Extend a world–`X`-environment pair to a possibility, taking
+arbitrary values outside `X`. -/
 noncomputable def ofEnv [Nonempty M] (wf : W × (X → M)) : Possibility W V M :=
   ⟨wf.1, Function.extend Subtype.val wf.2 fun _ => Classical.arbitrary M⟩
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -65,19 +65,12 @@ def proj (X : Set V) (p : Possibility W V M) : W × (X → M) :=
 def agreeSetoid (X : Set V) : Setoid (Possibility W V M) :=
   Setoid.ker (proj X)
 
-/-- Possibilities agree at `X` exactly when they share their world and
-their assignments agree on `X`. -/
-theorem agreeSetoid_iff {X : Set V} {p q : Possibility W V M} :
-    agreeSetoid X p q ↔
-      p.world = q.world ∧ Set.EqOn p.assignment q.assignment X :=
-  Prod.ext_iff.trans (and_congr Iff.rfl Set.restrict_eq_restrict_iff)
-
 /-- Coarser granularities identify more possibilities. -/
 theorem agreeSetoid_anti :
     Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
-  fun _ _ hXY _ _ h =>
-    have h' := agreeSetoid_iff.mp h
-    agreeSetoid_iff.mpr ⟨h'.1, h'.2.mono hXY⟩
+  fun X Y hXY _ _ h =>
+    congrArg (fun wf : W × (Y → M) =>
+      ((wf.1, fun v => wf.2 ⟨v.1, hXY v.2⟩) : W × (X → M))) h
 
 /-- A possibility up to agreement at `X` is a world together with an
 assignment of the `X`-referents. -/

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,6 +1,5 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Function
-import Mathlib.Data.Setoid.Basic
 
 /-!
 # Possibilities
@@ -24,9 +23,6 @@ universe across worlds — and the monadic tradition calls the same points
 
 - `Possibility W V M`: the point object; `Possibility.update` rewrites
   one referent.
-- `Possibility.agreeSetoid X`: agreement at granularity `X`, as the
-  kernel of the projection `Possibility.proj X`; quotienting by it is
-  the state space at granularity `X` (`Collapse.lean`).
 - `Possibility.dom`, `Possibility.Descendant`, `Possibility.Compatible`,
   `Possibility.union`: partial points (`Option`-valued assignments) —
   their defined referents, growth order, and consistent union.
@@ -53,42 +49,7 @@ referents to individuals. -/
 
 namespace Possibility
 
-variable {W V M : Type*} (X : Set V) (p : Possibility W V M)
-
-/-- The projection of a possibility to granularity `X` is its world
-together with its assignment of the `X`-referents. -/
-def proj : W × (X → M) := (p.world, X.restrict p.assignment)
-
-/-- Two possibilities agree at granularity `X` when their projections to
-`X` coincide. -/
-def agreeSetoid : Setoid (Possibility W V M) := Setoid.ker (proj X)
-
-/-- Coarser granularities identify more possibilities. -/
-theorem agreeSetoid_anti : Antitone (agreeSetoid : Set V → Setoid (Possibility W V M)) :=
-  fun X Y hXY _ _ h =>
-    congrArg (fun wf : W × (Y → M) =>
-      ((wf.1, fun v => wf.2 ⟨v.1, hXY v.2⟩) : W × (X → M))) h
-
-/-- Extend a world–`X`-environment pair to a possibility, taking
-arbitrary values outside `X`. -/
-noncomputable def ofEnv [Nonempty M] (wf : W × (X → M)) : Possibility W V M :=
-  ⟨wf.1, Function.extend Subtype.val wf.2 fun _ => Classical.arbitrary M⟩
-
-/-- `proj X` retracts `ofEnv X`. -/
-@[simp] theorem proj_ofEnv [Nonempty M] (wf : W × (X → M)) :
-    proj X (ofEnv X wf) = wf :=
-  Prod.ext rfl (funext fun x => by
-    exact Subtype.val_injective.extend_apply wf.2 (fun _ => Classical.arbitrary M) x)
-
-/-- A possibility up to agreement at `X` is a world together with an
-assignment of the `X`-referents. -/
-noncomputable def agreeQuotientEquiv [Nonempty M] :
-    Quotient (agreeSetoid X : Setoid (Possibility W V M)) ≃ W × (X → M) :=
-  Setoid.quotientKerEquivOfRightInverse (proj X) (ofEnv X) (proj_ofEnv X)
-
-@[simp] theorem agreeQuotientEquiv_mk [Nonempty M] :
-    agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
-  rfl
+variable {W V M : Type*} (p : Possibility W V M)
 
 /-- Update the assignment at a single referent. -/
 def update [DecidableEq V] (x : V) (e : M) : Possibility W V M :=

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -53,22 +53,21 @@ referents to individuals. -/
 
 namespace Possibility
 
-variable {W V M : Type*} (X : Set V)
+variable {W V M : Type*}
 
 /-- The projection of a possibility to granularity `X` is its world
 together with its assignment of the `X`-referents. -/
-def proj (p : Possibility W V M) : W × (X → M) :=
+def proj (X : Set V) (p : Possibility W V M) : W × (X → M) :=
   (p.world, X.restrict p.assignment)
 
 /-- Two possibilities agree at granularity `X` when their projections to
 `X` coincide. -/
-def agreeSetoid : Setoid (Possibility W V M) :=
+def agreeSetoid (X : Set V) : Setoid (Possibility W V M) :=
   Setoid.ker (proj X)
 
-variable {X} in
 /-- Possibilities agree at `X` exactly when they share their world and
 their assignments agree on `X`. -/
-theorem agreeSetoid_iff {p q : Possibility W V M} :
+theorem agreeSetoid_iff {X : Set V} {p q : Possibility W V M} :
     agreeSetoid X p q ↔
       p.world = q.world ∧ Set.EqOn p.assignment q.assignment X :=
   Prod.ext_iff.trans (and_congr Iff.rfl Set.restrict_eq_restrict_iff)
@@ -82,7 +81,7 @@ theorem agreeSetoid_anti :
 
 /-- A possibility up to agreement at `X` is a world together with an
 assignment of the `X`-referents. -/
-noncomputable def agreeQuotientEquiv [Nonempty M] :
+noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
     Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) :=
   Setoid.quotientKerEquivOfRightInverse (proj X)
     (fun wf => ⟨wf.1,
@@ -91,7 +90,7 @@ noncomputable def agreeQuotientEquiv [Nonempty M] :
       exact Subtype.val_injective.extend_apply wf.2
         (fun _ => Classical.arbitrary M) x)
 
-@[simp] theorem agreeQuotientEquiv_mk [Nonempty M]
+@[simp] theorem agreeQuotientEquiv_mk (X : Set V) [Nonempty M]
     (p : Possibility W V M) :
     agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
   rfl

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -53,17 +53,16 @@ referents to individuals. -/
 
 namespace Possibility
 
-variable {W V M : Type*}
+variable {W V M : Type*} (X : Set V)
 
 /-- The projection of a possibility to granularity `X` is its world
 together with its assignment of the `X`-referents. -/
-def proj (X : Set V) (p : Possibility W V M) : W × (X → M) :=
+def proj (p : Possibility W V M) : W × (X → M) :=
   (p.world, X.restrict p.assignment)
 
 /-- Two possibilities agree at granularity `X` when their projections to
 `X` coincide. -/
-def agreeSetoid (X : Set V) : Setoid (Possibility W V M) :=
-  Setoid.ker (proj X)
+def agreeSetoid : Setoid (Possibility W V M) := Setoid.ker (proj X)
 
 /-- Coarser granularities identify more possibilities. -/
 theorem agreeSetoid_anti :
@@ -74,7 +73,7 @@ theorem agreeSetoid_anti :
 
 /-- A possibility up to agreement at `X` is a world together with an
 assignment of the `X`-referents. -/
-noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
+noncomputable def agreeQuotientEquiv [Nonempty M] :
     Quotient (agreeSetoid (W := W) (M := M) X) ≃ W × (X → M) :=
   Setoid.quotientKerEquivOfRightInverse (proj X)
     (fun wf => ⟨wf.1,
@@ -83,7 +82,7 @@ noncomputable def agreeQuotientEquiv (X : Set V) [Nonempty M] :
       exact Subtype.val_injective.extend_apply wf.2
         (fun _ => Classical.arbitrary M) x)
 
-@[simp] theorem agreeQuotientEquiv_mk (X : Set V) [Nonempty M]
+@[simp] theorem agreeQuotientEquiv_mk [Nonempty M]
     (p : Possibility W V M) :
     agreeQuotientEquiv X (Quotient.mk _ p) = (p.world, X.restrict p.assignment) :=
   rfl

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -333,10 +333,10 @@ end Restrict
 
 /-! ### Based points -/
 
-/-- A *based* point: a possibility whose domain is finite —
-[kamp-vangenabith-reyle-2011] Def. 23 calls the domain the *base*.
-Under descent, based points form the total space of `Category.lean`'s
-possibilities family. -/
+/-- A possibility is *based* when its domain is a base — realizable as
+some `X : Finset V`, [kamp-vangenabith-reyle-2011] Def. 23's word —
+which is exactly finiteness. Under descent, based points form the total
+space of `Category.lean`'s possibilities family. -/
 def Based (W V M : Type*) := {p : Possibility W V (Option M) // p.dom.Finite}
 
 instance : Preorder (Based W V M) where

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -45,6 +45,9 @@ stratum they reduce to `⊇` and `⊆` respectively
 ## Main results
 
 - `merge_infoLe`: the merge is the `⊑`-least upper bound.
+- `merge_assoc`, `merge_comm`, `merge_initial`: states form a
+  commutative monoid under consistent merge — the content half of
+  [visser-vermeulen-1996]'s monoidal processing.
 - `infoLe_iff_superset`, `subsistsIn_iff_subset`: on a uniform stratum
   both preorders are partial orders, coinciding with `⊇`/`⊆` (via
   `Possibility.Descendant.eq_of_dom_eq`).
@@ -164,6 +167,49 @@ theorem merge_infoLe {s s' t : State W V M} (hs : s ⊑ t)
   obtain ⟨q, hq, hqu⟩ := hs' u hu
   exact ⟨p.union q, ⟨p, hp, q, hq, hpu.compatible hqu, rfl⟩,
     hpu.union_descendant hqu⟩
+
+/-- Consistent merge is commutative. -/
+theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s := by
+  ext r
+  constructor <;> rintro ⟨p, hp, q, hq, h, rfl⟩ <;>
+    exact ⟨q, hq, p, hp, h.symm, h.union_comm⟩
+
+/-- Consistent merge is associative. -/
+theorem merge_assoc (s t u : State W V M) :
+    (s.merge t).merge u = s.merge (t.merge u) := by
+  ext r
+  constructor
+  · rintro ⟨a, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv, hav, rfl⟩
+    have hpv := hav.left_of_union
+    have hqv := hpq.right_of_union hav
+    exact ⟨p, hp, q.union v, ⟨q, hq, v, hv, hqv, rfl⟩,
+      (Possibility.Compatible.union_left hpq.symm hpv.symm).symm,
+      Possibility.union_assoc p q v⟩
+  · rintro ⟨p, hp, a, ⟨q, hq, v, hv, hqv, rfl⟩, hpa, rfl⟩
+    have hpq := hpa.symm.left_of_union.symm
+    have hpv := (hqv.right_of_union hpa.symm).symm
+    exact ⟨p.union q, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv,
+      Possibility.Compatible.union_left hpv hqv,
+      (Possibility.union_assoc p q v).symm⟩
+
+/-- The initial state is a unit for consistent merge: with `merge_comm`,
+`merge_assoc`, and `merge_infoLe`, updating is joining in a commutative
+monoid of information — the content half of
+[visser-vermeulen-1996]'s monoidal processing. -/
+@[simp] theorem merge_initial (s : State W V M) : s.merge State.initial = s := by
+  ext r
+  constructor
+  · rintro ⟨p, hp, q, hq, -, rfl⟩
+    have hq' : p.union q = p :=
+      Possibility.ext rfl (funext fun v => by simp [Possibility.union, hq v])
+    rwa [hq']
+  · intro hr
+    exact ⟨r, hr, ⟨r.world, fun _ => none⟩, fun _ => rfl,
+      ⟨rfl, fun _ _ _ _ h => by simp at h⟩,
+      Possibility.ext rfl (funext fun v => by simp [Possibility.union])⟩
+
+@[simp] theorem initial_merge (s : State W V M) : State.merge State.initial s = s := by
+  rw [merge_comm, merge_initial]
 
 /-- The worldly content of a state ([elliott-sudo-2025] Def. 3.1's 𝒲). -/
 def worlds (s : State W V M) : Set W :=

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -309,7 +309,7 @@ theorem restrict_restrict (X Y : Finset V) (I : State W V M) :
 [groenendijk-stokhof-1991]'s `x := random`): indeterministically extend
 each point to a defined value at `x`. -/
 def randomAssign (I : State W V M) (x : V) : State W V M :=
-  {p | ∃ q ∈ I, ∃ m : M, p = q.extend x (some m)}
+  {p | ∃ q ∈ I, ∃ m : M, p = q.update x (some m)}
 
 /-- Random assignment makes its referent familiar. -/
 theorem familiar_randomAssign (I : State W V M) (x : V) :

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -16,7 +16,7 @@ assumes: the absurd state is `∅`, the initial state is `W × {g_⊤}`
 
 There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
 (`UniformAt`), and a base is the index of a fiber, not part of the data.
-Points with domain `X` are world–`X`-environment pairs, constructively
+Points with domain `X` are world–`X`-assignment pairs, constructively
 (`Possibility.domEquiv` — the total-assignment rendering needed choice
 and an inhabitant of `M` to recover this). Two preorders run through states, and they are
 dual on shared strata. *Informativeness* (`⊑`,
@@ -365,7 +365,7 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
 
 /-! ### The uniform classification -/
 
-/-- Uniform states at `X` are sets of world–`X`-environment pairs — the
+/-- Uniform states at `X` are sets of world–`X`-assignment pairs — the
 state-level face of `Possibility.domEquiv`, and the comparison to the
 predecessor's fibers: an order isomorphism for `⊆` (which is `⪯` on the
 stratum, `subsistsIn_iff_subset`), hence an anti-isomorphism for `⊑`

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -162,6 +162,38 @@ theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
     · rw [hkk']
       exact hvk
 
+/-- Root and fiber semantics agree under the classification: on the
+`X`-stratum, the regular CCP `applyState` is `apply`, transported along
+`State.uniformEquiv` — the relational collapse computes the root-state
+update. -/
+theorem uniformEquiv_applyState (u : Transition W M X Y)
+    {I : State W V M} (hI : State.UniformAt X I) :
+    State.uniformEquiv Y ⟨u.applyState I, uniformAt_applyState u I⟩ =
+      u.apply (State.uniformEquiv X ⟨I, hI⟩) := by
+  ext f
+  constructor
+  · intro hf
+    obtain ⟨-, p, hp, hpX, hw, e, f', hpe, hqf, hrel⟩ :
+        ptOf Y f.1 f.2 ∈ u.applyState I := hf
+    have hf' : f' = f.2 := funext fun v =>
+      Option.some_inj.mp ((hqf v).symm.trans (dif_pos v.2))
+    subst hf'
+    refine ⟨e, ?_, by exact hrel⟩
+    show ptOf X f.1 e ∈ I
+    have hpeq : ptOf X f.1 e = p := by
+      refine Possibility.ext (by exact hw.symm) (funext fun v => ?_)
+      by_cases hv : v ∈ (↑X : Set V)
+      · exact (dif_pos hv).trans (hpe ⟨v, hv⟩).symm
+      · exact (dif_neg hv).trans
+          (Option.not_isSome_iff_eq_none.mp fun hs => hv (hpX ▸ hs)).symm
+    rw [hpeq]; exact hp
+  · rintro ⟨e, hmem, hrel⟩
+    have hpI : ptOf X f.1 e ∈ I := hmem
+    show ptOf Y f.1 f.2 ∈ u.applyState I
+    exact ⟨dom_ptOf .., ptOf X f.1 e, hpI, dom_ptOf .., by simp [ptOf], e,
+      f.2, fun v => by simp [ptOf], fun v => by simp [ptOf],
+      by exact hrel⟩
+
 end ApplyState
 
 /-! ### Random assignment -/

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -5,15 +5,15 @@ import Linglib.Semantics.Dynamic.State
 [kamp-vangenabith-reyle-2011] (Defs. 24, 27)
 
 The hom type of indexed dynamic semantics: a `Transition W M X Y` is a
-world-indexed relation between an `X`-environment and a `Y`-environment,
+world-indexed relation between an `X`-assignment and a `Y`-assignment,
 `Y ⊇ X`. Objects are bases; a DRS denotes an arrow `X ⟶ X ∪ U`;
 sequencing is world-pointwise relational composition. The predecessor of
 this file stated transitions on total assignments and carried
 `supported_left`/`supported_right` invariants; typing the relation at the
-environments dissolves both, and the identity transition becomes plain
+assignments dissolves both, and the identity transition becomes plain
 equality rather than agreement-on-`X`.
 
-Applying a transition acts fiberwise on sets of environments — the
+Applying a transition acts fiberwise on sets of possibilities — the
 presheaf fibers of `Category.lean` — functorially (`apply_comp`). The
 chapter's own name for the induced map is the (regular) *Context Change
 Potential* (Def. 24); *transition* names the underlying relation, after
@@ -34,18 +34,18 @@ namespace DynamicSemantics
 
 variable {W V M : Type*} {X Y Z : Finset V}
 
-/-- A transition: a world-indexed relation from `X`-environments to
-`Y`-environments. The `grow` field makes arrows context-extending —
+/-- A transition: a world-indexed relation from `X`-assignments to
+`Y`-assignments. The `grow` field makes arrows context-extending —
 bases never shrink. -/
 @[ext] structure Transition (W M : Type*) {V : Type*} (X Y : Finset V) where
-  /-- The world-indexed relation between input and output environments. -/
+  /-- The world-indexed relation between input and output assignments. -/
   rel : W → ((↑X : Set V) → M) → ((↑Y : Set V) → M) → Prop
   /-- Bases only grow along an update. -/
   grow : X ⊆ Y
 
 namespace Transition
 
-/-- The identity transition at `X`: equality of environments. -/
+/-- The identity transition at `X`: equality of assignments. -/
 def id (X : Finset V) : Transition W M X X where
   rel _ e e' := e = e'
   grow := subset_rfl
@@ -77,7 +77,7 @@ theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
 /-! ### Application to fibers -/
 
 /-- Context change ([kamp-vangenabith-reyle-2011], Def. 24), on the
-presheaf fibers: relate environments through the transition, worlds
+presheaf fibers: relate assignments through the transition, worlds
 preserved. -/
 def apply (u : Transition W M X Y)
     (T : Set (W × ((↑X : Set V) → M))) :
@@ -128,7 +128,7 @@ theorem uniformAt_applyState (u : Transition W M X Y) (I : State W V M) :
 
 variable [DecidableEq V]
 
-/-- The point of the `Y`-stratum carrying a given world and environment. -/
+/-- The point of the `Y`-stratum carrying a given world and assignment. -/
 private def ptOf (Y : Finset V) (w : W) (e : (↑Y : Set V) → M) :
     Possibility W V (Option M) :=
   ⟨w, fun v => if hv : v ∈ (↑Y : Set V) then some (e ⟨v, hv⟩) else none⟩
@@ -231,7 +231,7 @@ def WritesAt (Y : Finset V) (R : W → (V → M) → (V → M) → Prop) : Prop 
   ∀ ⦃w f g g'⦄, Set.EqOn g g' (↑Y : Set V) → (R w f g ↔ R w f g')
 
 /-- Type a total-assignment relation at contexts, by existential
-extension of the environments. -/
+extension of the assignments. -/
 def ofTotal (h : X ⊆ Y) (R : W → (V → M) → (V → M) → Prop) :
     Transition W M X Y where
   rel w e e' := ∃ f g : V → M, (↑X : Set V).restrict f = e ∧
@@ -239,7 +239,7 @@ def ofTotal (h : X ⊆ Y) (R : W → (V → M) → (V → M) → Prop) :
   grow := h
 
 /-- Under the support hypotheses, the typing is faithful: related
-environments are exactly the restrictions of related assignments. -/
+assignments are exactly the restrictions of related assignments. -/
 theorem ofTotal_rel_restrict {h : X ⊆ Y} (hR : ReadsAt X R)
     (hW : WritesAt Y R) {w : W} {f g : V → M} :
     (ofTotal h R).rel w ((↑X : Set V).restrict f)


### PR DESCRIPTION
Mathlib-alignment audit of `Possibility.lean` against KvGR 2011 (Defs 0.19/0.22–0.23 verified in the chapter: embeddings partial with a constant universe; "base" is their word).

- `agreeSetoid X := Setoid.ker (proj X)`; the old conjunction survives as `agreeSetoid_iff`; `agreeQuotientEquiv` via `Setoid.quotientKerEquivOfRightInverse` with `Function.extend Subtype.val` as the section — no dite, no `open scoped Classical`.
- `Possibility.extend` → `Possibility.update` (it is `Function.update`; the old name collided with `Function.extend`); lemmas follow mathlib naming (`update_self`/`update_of_ne`), proved as terms.
- Declaration docstrings in mathlib sentence register; stale `State.fiberEquiv` pointer fixed.