### PR TITLE
refactor(Semantics/Dynamic): granularities as sets; descent as the point order

### DIFF
--- a/Linglib/Core/Order/Flat.lean
+++ b/Linglib/Core/Order/Flat.lean
@@ -77,9 +77,10 @@ relation out of the `Option` namespace (`Option.FlatLE → Flat.LE`).
 
 /-- The flat information order on an atomic feature slot: every
 committed value persists upward, so `none` is below everything and
-distinct atoms are incomparable. -/
+distinct atoms are incomparable. This is `Part`'s partial order,
+carried on `Option` for computability (`flatLE_iff_ofOption_le`). -/
 def Option.FlatLE {α : Type*} (a b : Option α) : Prop :=
-  ∀ x : α, a = some x → b = some x
+  ∀ x ∈ a, x ∈ b
 
 namespace Option.FlatLE
 
@@ -101,6 +102,19 @@ protected theorem antisymm (h1 : a.FlatLE b) (h2 : b.FlatLE a) : a = b := by
     cases b with
     | none => rfl
     | some y => exact absurd (h2 y rfl) (by simp)
+
+/-- Flat order with no definedness gain is equality. -/
+theorem eq_of_isSome (h : a.FlatLE b) (hb : b.isSome → a.isSome) : a = b :=
+  h.antisymm fun x hx => by
+    obtain ⟨y, hy⟩ := Option.isSome_iff_exists.mp
+      (hb (Option.isSome_iff_exists.mpr ⟨x, hx⟩))
+    rwa [← Option.some_inj.mp ((h y hy).symm.trans hx)]
+
+/-- The flat order is `Part`'s order, along `Part.ofOption`. -/
+theorem flatLE_iff_ofOption_le {a b : Option α} :
+    a.FlatLE b ↔ Part.ofOption a ≤ Part.ofOption b :=
+  ⟨fun h x hx => Part.mem_ofOption.mpr (h x (Part.mem_ofOption.mp hx)),
+    fun h x hx => Part.mem_ofOption.mp (h x (Part.mem_ofOption.mpr hx))⟩
 
 theorem none_le (b : Option α) : Option.FlatLE none b := λ _ h => nomatch h
 
@@ -216,14 +230,16 @@ private theorem ωSupImpl_isLUB (c : Chain (Flat α)) :
     split
     · next h =>
       intro a ha
-      have hj : (c j).isSome := by rw [ha]; rfl
+      have ha' : c j = some a := ha
+      show c (Nat.find h) = some a
+      have hj : (c j).isSome := by rw [ha']; rfl
       have hmono : c (Nat.find h) ≤ c j := (OrderHomClass.mono c) (Nat.find_min' h hj)
       obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp (Nat.find_spec h)
       have hjb : c j = some b := hmono b hb
-      rw [hb, Option.some.inj (ha.symm.trans hjb)]
+      rw [hb, Option.some.inj (ha'.symm.trans hjb)]
     · next h =>
       intro a ha
-      exact absurd ⟨j, by rw [ha]; rfl⟩ h
+      exact absurd ⟨j, by rw [show c j = some a from ha]; rfl⟩ h
   · intro u hu
     unfold ωSupImpl
     split

--- a/Linglib/Core/Order/Flat.lean
+++ b/Linglib/Core/Order/Flat.lean
@@ -87,6 +87,10 @@ variable {α : Type*} {a b c : Option α}
 
 protected theorem refl (a : Option α) : a.FlatLE a := λ _ h => h
 
+/-- Flat order preserves definedness. -/
+theorem isSome_mono (h : a.FlatLE b) : a.isSome → b.isSome := fun ha =>
+  Option.isSome_iff_exists.mpr ((Option.isSome_iff_exists.mp ha).imp h)
+
 protected theorem trans (h1 : a.FlatLE b) (h2 : b.FlatLE c) : a.FlatLE c :=
   λ x hx => h2 x (h1 x hx)
 

--- a/Linglib/Morphology/Unification.lean
+++ b/Linglib/Morphology/Unification.lean
@@ -360,7 +360,7 @@ private theorem clause_of_flatLE {α : Type _} [BEq α] [LawfulBEq α] {a b u : 
     | some y =>
       have hx := ha x rfl
       have hy := hb y rfl
-      simp [beq_iff_eq, Option.some.inj (hx.symm.trans hy)]
+      simp [Option.some.inj (hx.symm.trans hy)]
 
 /-- Bounded above implies the executable check passes. -/
 theorem compatible_of_le {f g u : MorphFeatures} (hf : f ≤ u) (hg : g ≤ u) :

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -193,19 +193,19 @@ variable {W M V : Type*}
 
 /-- Classify each element of the possibilities family as a point: on
 objects this is `Possibility.domEquiv`; arrows become descents, by
-`Possibility.descendant_iff_eq_restrict`. -/
+`Possibility.le_iff_eq_restrict`. -/
 noncomputable def elementsToPoints :
     (possibilities W M V).Elements ⥤ (Possibility W V (Option M))ᵒᵖ where
   obj x := op ((Possibility.domEquiv x.1.unop).symm x.2).1
   map {x y} f := (homOfLE (show
-      ((Possibility.domEquiv y.1.unop).symm y.2).1.Descendant
+      ((Possibility.domEquiv y.1.unop).symm y.2).1 ≤
         ((Possibility.domEquiv x.1.unop).symm x.2).1 by
     have hb : y.1.unop ≤ x.1.unop := leOfHom f.1.unop
     have hmap : (possibilities W M V).map f.1 x.2 = y.2 := f.2
     rw [Subsingleton.elim f.1 (homOfLE hb).op, possibilities_map_apply]
       at hmap
     rw [← hmap, ← Possibility.restrict_domEquiv_symm hb]
-    exact Possibility.restrict_descendant _ _)).op
+    exact Possibility.restrict_le _ _)).op
   map_id _ := Subsingleton.elim _ _
   map_comp _ _ := Subsingleton.elim _ _
 
@@ -214,16 +214,16 @@ instance : (elementsToPoints (W := W) (M := M) (V := V)).Faithful where
 
 instance : (elementsToPoints (W := W) (M := M) (V := V)).Full where
   map_surjective {x y} f := by
-    have hd : ((Possibility.domEquiv y.1.unop).symm y.2).1.Descendant
+    have hd : ((Possibility.domEquiv y.1.unop).symm y.2).1 ≤
         ((Possibility.domEquiv x.1.unop).symm x.2).1 := leOfHom f.unop
     have hb : y.1.unop ≤ x.1.unop := by
-      have hsub := hd.dom_subset
+      have hsub := Possibility.dom_mono hd
       rwa [((Possibility.domEquiv y.1.unop).symm y.2).2,
         ((Possibility.domEquiv x.1.unop).symm x.2).2] at hsub
     refine ⟨⟨(homOfLE hb).op, ?_⟩, Subsingleton.elim _ _⟩
     refine (Possibility.domEquiv y.1.unop).symm.injective (Subtype.ext ?_)
     rw [possibilities_map_apply, ← Possibility.restrict_domEquiv_symm hb]
-    exact ((Possibility.descendant_iff_eq_restrict
+    exact ((Possibility.le_iff_eq_restrict
       ((Possibility.domEquiv y.1.unop).symm y.2).2).mp hd).symm
 
 instance : (elementsToPoints (W := W) (M := M) (V := V)).EssSurj where

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -135,7 +135,7 @@ variable [∀ v, Decidable (v ∈ X)]
 weakenings to `X ⊓ Y` agree is jointly the weakening of a unique
 possibility over `X ⊔ Y` — `possibilities` sends the lattice square to a
 pullback of types. The piecewise witness is `Possibility.union` in the charts of
-`Possibility.domEquiv`. -/
+`Possibility.domainEquiv`. -/
 theorem possibilities_glue
     (a : (possibilities W M V).obj (op X)) (b : (possibilities W M V).obj (op Y))
     (hab : (possibilities W M V).map (homOfLE inf_le_left).op a =
@@ -192,19 +192,19 @@ open scoped Classical
 variable {W M V : Type*}
 
 /-- Classify each element of the possibilities family as a point: on
-objects this is `Possibility.domEquiv`; arrows become descents, by
+objects this is `Possibility.domainEquiv`; arrows become descents, by
 `Possibility.le_iff_eq_restrict`. -/
 noncomputable def elementsToPoints :
     (possibilities W M V).Elements ⥤ (Possibility W V (Option M))ᵒᵖ where
-  obj x := op ((Possibility.domEquiv x.1.unop).symm x.2).1
+  obj x := op ((Possibility.domainEquiv x.1.unop).symm x.2).1
   map {x y} f := (homOfLE (show
-      ((Possibility.domEquiv y.1.unop).symm y.2).1 ≤
-        ((Possibility.domEquiv x.1.unop).symm x.2).1 by
+      ((Possibility.domainEquiv y.1.unop).symm y.2).1 ≤
+        ((Possibility.domainEquiv x.1.unop).symm x.2).1 by
     have hb : y.1.unop ≤ x.1.unop := leOfHom f.1.unop
     have hmap : (possibilities W M V).map f.1 x.2 = y.2 := f.2
     rw [Subsingleton.elim f.1 (homOfLE hb).op, possibilities_map_apply]
       at hmap
-    rw [← hmap, ← Possibility.restrict_domEquiv_symm hb]
+    rw [← hmap, ← Possibility.restrict_domainEquiv_symm hb]
     exact Possibility.restrict_le _ _)).op
   map_id _ := Subsingleton.elim _ _
   map_comp _ _ := Subsingleton.elim _ _
@@ -214,25 +214,25 @@ instance : (elementsToPoints (W := W) (M := M) (V := V)).Faithful where
 
 instance : (elementsToPoints (W := W) (M := M) (V := V)).Full where
   map_surjective {x y} f := by
-    have hd : ((Possibility.domEquiv y.1.unop).symm y.2).1 ≤
-        ((Possibility.domEquiv x.1.unop).symm x.2).1 := leOfHom f.unop
+    have hd : ((Possibility.domainEquiv y.1.unop).symm y.2).1 ≤
+        ((Possibility.domainEquiv x.1.unop).symm x.2).1 := leOfHom f.unop
     have hb : y.1.unop ≤ x.1.unop := by
-      have hsub := Possibility.dom_mono hd
-      rwa [((Possibility.domEquiv y.1.unop).symm y.2).2,
-        ((Possibility.domEquiv x.1.unop).symm x.2).2] at hsub
+      have hsub := Possibility.domain_mono hd
+      rwa [((Possibility.domainEquiv y.1.unop).symm y.2).2,
+        ((Possibility.domainEquiv x.1.unop).symm x.2).2] at hsub
     refine ⟨⟨(homOfLE hb).op, ?_⟩, Subsingleton.elim _ _⟩
-    refine (Possibility.domEquiv y.1.unop).symm.injective (Subtype.ext ?_)
-    rw [possibilities_map_apply, ← Possibility.restrict_domEquiv_symm hb]
+    refine (Possibility.domainEquiv y.1.unop).symm.injective (Subtype.ext ?_)
+    rw [possibilities_map_apply, ← Possibility.restrict_domainEquiv_symm hb]
     exact ((Possibility.le_iff_eq_restrict
-      ((Possibility.domEquiv y.1.unop).symm y.2).2).mp hd).symm
+      ((Possibility.domainEquiv y.1.unop).symm y.2).2).mp hd).symm
 
 instance : (elementsToPoints (W := W) (M := M) (V := V)).EssSurj where
   mem_essImage y :=
-    ⟨⟨op y.unop.dom, Possibility.domEquiv _ ⟨y.unop, rfl⟩⟩,
+    ⟨⟨op y.unop.domain, Possibility.domainEquiv _ ⟨y.unop, rfl⟩⟩,
       ⟨eqToIso (by
         apply Opposite.unop_injective
         have hval := congrArg Subtype.val
-          ((Possibility.domEquiv y.unop.dom).symm_apply_apply ⟨y.unop, rfl⟩)
+          ((Possibility.domainEquiv y.unop.domain).symm_apply_apply ⟨y.unop, rfl⟩)
         exact hval)⟩⟩
 
 instance : (elementsToPoints (W := W) (M := M) (V := V)).IsEquivalence := {}

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -35,9 +35,9 @@ at `∅` is [veltman-1996]'s update semantics.
 - `possibilities_glue`, `possibilities_beck_chevalley`: the context-lattice
   square is a pullback of possibilities, so quantification commutes with
   weakening — the fibers are a hyperdoctrine.
-- `elementsEquivBased`: the Grothendieck total of the family is the point
-  type — the category of elements is the descent preorder on
-  `Possibility.Based`, opposed.
+- `elementsEquivPoints`: the Grothendieck total of the family is the
+  point type — the category of elements is the descent preorder on the
+  points, opposed.
 
 ## References
 
@@ -55,7 +55,7 @@ open CategoryTheory
 the category whose morphisms are `Transition W M X Y`. -/
 @[ext] structure Ctx (W M : Type*) (V : Type*) where
   /-- The live discourse referents. -/
-  base : Finset V
+  base : Set V
 
 namespace Ctx
 
@@ -92,8 +92,8 @@ over the category of contexts — a set-valued *indexed category* in
 (the functor "which adds an extra dummy" variable, in the book's own
 gloss). -/
 def possibilities (W : Type u) (M : Type v) (V : Type w) :
-    (Finset V)ᵒᵖ ⥤ Type (max u v w) where
-  obj X := W × ((↑X.unop : Set V) → M)
+    (Set V)ᵒᵖ ⥤ Type (max u v w) where
+  obj X := W × (X.unop → M)
   map {X Y} f := TypeCat.ofHom fun p =>
     ⟨p.1, fun v => p.2 ⟨v.1, leOfHom f.unop v.2⟩⟩
 
@@ -102,7 +102,7 @@ functor applied fiberwise to the possibilities — by definition, in this
 formulation. The fiber over `X` is `Set (W × (↑X → M))`; restriction is
 direct image along weakening. -/
 def State.presheaf (W : Type u) (M : Type v) (V : Type w) :
-    (Finset V)ᵒᵖ ⥤ Type (max u v w) :=
+    (Set V)ᵒᵖ ⥤ Type (max u v w) :=
   possibilities W M V ⋙ ofTypeFunctor Set
 
 /-! ### Gluing and Beck–Chevalley
@@ -121,7 +121,7 @@ section Gluing
 
 open Opposite
 
-variable {W M V : Type*} {X Y : Finset V}
+variable {W M V : Type*} {X Y : Set V}
 
 /-- The action of `possibilities` on a lattice inequality, elementwise. -/
 @[simp] theorem possibilities_map_apply (h : X ≤ Y)
@@ -129,7 +129,7 @@ variable {W M V : Type*} {X Y : Finset V}
     (possibilities W M V).map (homOfLE h).op p =
       (p.1, fun v => p.2 ⟨v.1, h v.2⟩) := rfl
 
-variable [DecidableEq V]
+variable [∀ v, Decidable (v ∈ X)]
 
 /-- Possibilities glue: a pair of possibilities over `X` and `Y` whose
 weakenings to `X ⊓ Y` agree is jointly the weakening of a unique
@@ -147,9 +147,9 @@ theorem possibilities_glue
   have hw : a.1 = b.1 := congrArg Prod.fst hab
   have hagree : ∀ (v : V) (hX : v ∈ X) (hY : v ∈ Y),
       a.2 ⟨v, hX⟩ = b.2 ⟨v, hY⟩ := fun v hX hY =>
-    congrFun (congrArg Prod.snd hab) ⟨v, Finset.mem_inter.mpr ⟨hX, hY⟩⟩
+    congrFun (congrArg Prod.snd hab) ⟨v, hX, hY⟩
   refine ⟨(a.1, fun v => if h : v.1 ∈ X then a.2 ⟨v.1, h⟩
-      else b.2 ⟨v.1, (Finset.mem_union.mp v.2).resolve_left h⟩),
+      else b.2 ⟨v.1, v.2.resolve_left h⟩),
     ⟨Prod.ext rfl (funext fun v => dif_pos v.2),
       Prod.ext hw (funext fun v => ?_)⟩, fun c' hc' => ?_⟩
   · by_cases h : v.1 ∈ X
@@ -163,7 +163,7 @@ along `X ⊓ Y ≤ X` then weakening to `Y` is weakening to `X ⊔ Y` then
 existential image along `Y ≤ X ⊔ Y` — quantifying and reindexing
 commute. The image legs are `State.presheaf`'s own action on the
 square's arrows. -/
-theorem possibilities_beck_chevalley (X Y : Finset V)
+theorem possibilities_beck_chevalley
     (S : Set ((possibilities W M V).obj (op X))) :
     (possibilities W M V).map (homOfLE (inf_le_right : X ⊓ Y ≤ Y)).op ⁻¹'
       ((possibilities W M V).map (homOfLE (inf_le_left : X ⊓ Y ≤ X)).op '' S) =
@@ -187,16 +187,16 @@ section Total
 
 open Opposite
 
-variable {W M V : Type*} [DecidableEq V]
+open scoped Classical
 
-/-- Classify each element of the possibilities family as a based point:
-on objects this is `Possibility.domEquiv`; arrows become descents, by
+variable {W M V : Type*}
+
+/-- Classify each element of the possibilities family as a point: on
+objects this is `Possibility.domEquiv`; arrows become descents, by
 `Possibility.descendant_iff_eq_restrict`. -/
-noncomputable def elementsToBased :
-    (possibilities W M V).Elements ⥤ (Possibility.Based W V M)ᵒᵖ where
-  obj x := op ⟨((Possibility.domEquiv x.1.unop).symm x.2).1, by
-    rw [((Possibility.domEquiv x.1.unop).symm x.2).2]
-    exact x.1.unop.finite_toSet⟩
+noncomputable def elementsToPoints :
+    (possibilities W M V).Elements ⥤ (Possibility W V (Option M))ᵒᵖ where
+  obj x := op ((Possibility.domEquiv x.1.unop).symm x.2).1
   map {x y} f := (homOfLE (show
       ((Possibility.domEquiv y.1.unop).symm y.2).1.Descendant
         ((Possibility.domEquiv x.1.unop).symm x.2).1 by
@@ -209,42 +209,40 @@ noncomputable def elementsToBased :
   map_id _ := Subsingleton.elim _ _
   map_comp _ _ := Subsingleton.elim _ _
 
-instance : (elementsToBased (W := W) (M := M) (V := V)).Faithful where
+instance : (elementsToPoints (W := W) (M := M) (V := V)).Faithful where
   map_injective _ := Subtype.ext (Subsingleton.elim _ _)
 
-instance : (elementsToBased (W := W) (M := M) (V := V)).Full where
+instance : (elementsToPoints (W := W) (M := M) (V := V)).Full where
   map_surjective {x y} f := by
     have hd : ((Possibility.domEquiv y.1.unop).symm y.2).1.Descendant
         ((Possibility.domEquiv x.1.unop).symm x.2).1 := leOfHom f.unop
-    have hb : y.1.unop ≤ x.1.unop := Finset.coe_subset.mp
-      (((Possibility.domEquiv y.1.unop).symm y.2).2 ▸
-        ((Possibility.domEquiv x.1.unop).symm x.2).2 ▸ hd.dom_subset)
+    have hb : y.1.unop ≤ x.1.unop := by
+      have hsub := hd.dom_subset
+      rwa [((Possibility.domEquiv y.1.unop).symm y.2).2,
+        ((Possibility.domEquiv x.1.unop).symm x.2).2] at hsub
     refine ⟨⟨(homOfLE hb).op, ?_⟩, Subsingleton.elim _ _⟩
     refine (Possibility.domEquiv y.1.unop).symm.injective (Subtype.ext ?_)
     rw [possibilities_map_apply, ← Possibility.restrict_domEquiv_symm hb]
     exact ((Possibility.descendant_iff_eq_restrict
       ((Possibility.domEquiv y.1.unop).symm y.2).2).mp hd).symm
 
-instance : (elementsToBased (W := W) (M := M) (V := V)).EssSurj where
+instance : (elementsToPoints (W := W) (M := M) (V := V)).EssSurj where
   mem_essImage y :=
-    ⟨⟨op y.unop.2.toFinset,
-        Possibility.domEquiv _ ⟨y.unop.1, y.unop.2.coe_toFinset.symm⟩⟩,
+    ⟨⟨op y.unop.dom, Possibility.domEquiv _ ⟨y.unop, rfl⟩⟩,
       ⟨eqToIso (by
         apply Opposite.unop_injective
-        apply Subtype.ext
         have hval := congrArg Subtype.val
-          ((Possibility.domEquiv y.unop.2.toFinset).symm_apply_apply
-            ⟨y.unop.1, y.unop.2.coe_toFinset.symm⟩)
+          ((Possibility.domEquiv y.unop.dom).symm_apply_apply ⟨y.unop, rfl⟩)
         exact hval)⟩⟩
 
-instance : (elementsToBased (W := W) (M := M) (V := V)).IsEquivalence := {}
+instance : (elementsToPoints (W := W) (M := M) (V := V)).IsEquivalence := {}
 
 /-- **The Grothendieck total of the possibilities family is the point
 type**: the category of elements is equivalent to the opposite of the
-descent preorder on based points. -/
-noncomputable def elementsEquivBased :
-    (possibilities W M V).Elements ≌ (Possibility.Based W V M)ᵒᵖ :=
-  elementsToBased.asEquivalence
+descent preorder on points — every point lies over its own domain. -/
+noncomputable def elementsEquivPoints :
+    (possibilities W M V).Elements ≌ (Possibility W V (Option M))ᵒᵖ :=
+  elementsToPoints.asEquivalence
 
 end Total
 

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -22,7 +22,7 @@ non-distributive tests (`might`, `must`) are exactly the residue.
 Categorically, `RelCat ≌ KleisliCat Set`, and the indexed tower reads
 `Ctx ⥤ RelCat ≌ KleisliCat Set ↪ suplattice endomaps`, every arrow
 canonical. The collapsed state space at `X` is the `X`-stratum of root
-states, classified by `Possibility.domEquiv`/`State.uniformEquiv`, and
+states, classified by `Possibility.domainEquiv`/`State.uniformEquiv`, and
 the relational action computes the root-state CCP through that
 classification (`Transition.uniformEquiv_applyState`) — the extraction
 of a relational meaning from a DRT-style one, as a morphism

--- a/Linglib/Semantics/Dynamic/Collapse.lean
+++ b/Linglib/Semantics/Dynamic/Collapse.lean
@@ -80,7 +80,7 @@ variable {W M V : Type*} {X Y Z : Ctx W M V}
 context to its possibility space and a transition to its world-threaded
 relation. Unital by typing — no quotient needed. -/
 def collapse (W M V : Type*) : Ctx W M V ⥤ RelCat where
-  obj X := W × ((↑X.base : Set V) → M)
+  obj X := W × (X.base → M)
   map {X Y} u := .ofRel {p | p.1.1 = p.2.1 ∧ u.t.rel p.1.1 p.1.2 p.2.2}
   map_id X := by
     apply RelCat.Hom.ext

--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -115,11 +115,12 @@ transition — and functoriality on composition is the Merging Lemma, its
 capture-freshness side condition derived from the visibility invariant. -/
 def sem (W M : Type*) [L.Structure M] [Nonempty M] :
     Ctx L V ⥤ DynamicSemantics.Ctx W M V where
-  obj X := ⟨X.base⟩
-  map {X Y} u := ⟨(u.drs.transition W X.base u.presup).copy rfl u.target⟩
+  obj X := ⟨↑X.base⟩
+  map {X Y} u := ⟨(u.drs.transition W X.base u.presup).copy rfl
+    (Finset.coe_inj.mpr u.target)⟩
   map_id X := by
     apply DynamicSemantics.Ctx.Hom.ext
-    exact DRS.transition_empty W X.base _ _
+    exact DRS.transition_empty W X.base (by simp [DRS.empty]) (by simp [DRS.empty])
   map_comp {X Y Z} u v := by
     apply DynamicSemantics.Ctx.Hom.ext
     have hocc : Condition.occL u.drs.conditions ⊆ Y.base := by
@@ -128,9 +129,12 @@ def sem (W M : Type*) [L.Structure M] [Nonempty M] :
       v.fresh.symm.mono_right hocc
     have hv : v.drs.fv ⊆ X.base ∪ u.drs.referents := by
       rw [u.target]; exact v.presup
-    show ((u ≫ v).drs.transition W X.base (u ≫ v).presup).copy rfl (u ≫ v).target =
-      ((u.drs.transition W X.base u.presup).copy rfl u.target).comp
-        ((v.drs.transition W Y.base v.presup).copy rfl v.target)
+    show ((u ≫ v).drs.transition W X.base (u ≫ v).presup).copy rfl
+        (Finset.coe_inj.mpr (u ≫ v).target) =
+      ((u.drs.transition W X.base u.presup).copy rfl
+        (Finset.coe_inj.mpr u.target)).comp
+        ((v.drs.transition W Y.base v.presup).copy rfl
+          (Finset.coe_inj.mpr v.target))
     rw [← DRS.transition_copy (M := M) W v.drs u.target hv v.presup,
       Transition.copy_copy, Transition.copy_comp_copy,
       DRS.transition_merge (M := M) W u.drs v.drs u.presup hv hfresh,

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -255,7 +255,7 @@ theorem DRS.uniformAt_state (W : Type*) (K : DRS L V) (hK : K.IsProper) :
 lives on the referents and its values are reached from some input. -/
 theorem DRS.mem_state {W : Type*} {K : DRS L V} {hK : K.IsProper}
     {q : Possibility W V (Option M)} :
-    q ∈ K.state W hK ↔ q.dom = (↑(∅ ∪ K.referents) : Set V) ∧
+    q ∈ K.state W hK ↔ q.domain = (↑(∅ ∪ K.referents) : Set V) ∧
       ∃ f g : V → M, DRS.toRelAt ∅ K f g ∧
         ∀ v : (↑(∅ ∪ K.referents) : Set V), q.assignment v.1 = some (g v.1) := by
   constructor
@@ -269,7 +269,7 @@ theorem DRS.mem_state {W : Type*} {K : DRS L V} {hK : K.IsProper}
       (↑(∅ ∪ K.referents) : Set V).restrict g,
       fun v => absurd v.2 (by simp), fun v => hvals v, f, g, rfl, rfl, hrel⟩
     ext v
-    simp [Possibility.dom]
+    simp [Possibility.domain]
 
 /-! ### Base invariance
 

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -181,12 +181,12 @@ theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.fv ⊆ X)
 base grown by its universe — `K.fv ⊆ X` is the *referential presupposition*
 ([kamp-vangenabith-reyle-2011], Def. 27(i)). -/
 theorem DRS.readsAt_toRelAt {W : Type*} (X : Finset V) (K : DRS L V) :
-    Transition.ReadsAt (W := W) X fun _ => DRS.toRelAt (M := M) X K :=
+    Transition.ReadsAt (W := W) ↑X fun _ => DRS.toRelAt (M := M) X K :=
   fun _ _ _ _ h => DRS.toRelAt_congr_left X K h
 
 theorem DRS.writesAt_toRelAt {W : Type*} {X : Finset V} (K : DRS L V)
     (hK : K.fv ⊆ X) :
-    Transition.WritesAt (W := W) (X ∪ K.referents)
+    Transition.WritesAt (W := W) ↑(X ∪ K.referents)
       fun _ => DRS.toRelAt (M := M) X K :=
   fun _ _ _ _ h => DRS.toRelAt_congr_right K hK h
 
@@ -195,8 +195,10 @@ at `X`, write at `X ∪ U`. The referential presupposition documents
 Def. 24's domain condition; the congruence lemmas above are the bridge's
 support hypotheses. -/
 def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V)
-    (_hK : K.fv ⊆ X) : Transition W M X (X ∪ K.referents) :=
-  Transition.ofTotal Finset.subset_union_left fun _ => DRS.toRelAt X K
+    (_hK : K.fv ⊆ X) :
+    Transition W M (↑X : Set V) (↑(X ∪ K.referents) : Set V) :=
+  Transition.ofTotal (Finset.coe_subset.mpr Finset.subset_union_left)
+    fun _ => DRS.toRelAt X K
 
 /-- The empty DRS denotes the identity transition, repackaged to its
 source: interpretation sends DRT's unit to the semantic unit. Nonempty
@@ -205,8 +207,8 @@ the empty box from the identity. -/
 theorem DRS.transition_empty [Nonempty M] (W : Type*) (X : Finset V)
     (h : (DRS.empty : DRS L V).fv ⊆ X)
     (he : X ∪ (DRS.empty : DRS L V).referents = X) :
-    (DRS.empty.transition (M := M) W X h).copy rfl he =
-      Transition.id X := by
+    (DRS.empty.transition (M := M) W X h).copy rfl (Finset.coe_inj.mpr he) =
+      Transition.id (↑X : Set V) := by
   unfold DRS.transition
   rw [Transition.ofTotal_copy]
   apply Transition.ext
@@ -233,7 +235,8 @@ theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
 transition at the new base. -/
 theorem DRS.transition_copy (W : Type*) {X X' : Finset V} (K : DRS L V)
     (hX : X = X') (hK : K.fv ⊆ X) (hK' : K.fv ⊆ X') :
-    (K.transition (M := M) W X hK).copy hX (by rw [hX]) = K.transition W X' hK' := by
+    (K.transition (M := M) W X hK).copy (Finset.coe_inj.mpr hX) (by rw [hX]) =
+      K.transition W X' hK' := by
   subst hX; rfl
 
 /-- The information state a proper DRS expresses
@@ -243,10 +246,10 @@ def DRS.state (W : Type*) (K : DRS L V) (hK : K.IsProper) : State W V M :=
 
 /-- The state a DRS expresses lives in its referents' stratum. -/
 theorem DRS.uniformAt_state (W : Type*) (K : DRS L V) (hK : K.IsProper) :
-    State.UniformAt K.referents (K.state (M := M) W hK) := by
-  rw [← Finset.empty_union K.referents]
-  exact Transition.uniformAt_applyState
-    (K.transition W ∅ (Finset.subset_empty.mpr hK)) State.initial
+    State.UniformAt ↑K.referents (K.state (M := M) W hK) := by
+  have h := Transition.uniformAt_applyState
+    (K.transition (M := M) W ∅ (Finset.subset_empty.mpr hK)) State.initial
+  simpa [DRS.state] using h
 
 /-- The characteristic membership form: a point survives in `⟦K⟧ˢ` iff it
 lives on the referents and its values are reached from some input. -/

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -278,10 +278,10 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
             hnov p hp, hqx]
         · simp [Possibility.union, Possibility.update, hqnone v hv, hv])
     rw [huq]
-    exact ⟨⟨p, hp, m, rfl⟩, m, Possibility.update_self .., hpred⟩
+    exact ⟨⟨p, hp, m, rfl⟩, m, by simp, hpred⟩
   · rintro ⟨hmem, m, hrx, hpred⟩
     obtain ⟨p, hp, m', rfl⟩ := hmem
-    rw [Possibility.update_self] at hrx
+    simp only [Possibility.update_assignment, Function.update_self] at hrx
     obtain rfl := (Option.some_inj.mp hrx).symm
     refine ⟨p, hp, ⟨p.world, fun v => if v = x then some m else none⟩,
       ⟨Set.ext fun v => by by_cases hv : v = x <;>

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -93,18 +93,18 @@ theorem infoLe_ofState (A : State W V M) {F F' : State W V M}
 /-- Atomic predicate on the world: merge with the empty-domain
 proposition state. -/
 def atomW (pred : W → Prop) : FCP W V M :=
-  ofState {q | q.dom = ∅ ∧ pred q.world}
+  ofState {q | q.domain = ∅ ∧ pred q.world}
 
 /-- Atomic predicate at card `x`: merge with the `{x}`-domain
 proposition state. Familiar `x` filters (rule (13)); novel `x` extends
 (rule (18)) — per point, so partially familiar files update
 pointwise. -/
 def atomVar (pred : M → Prop) (x : V) : FCP W V M :=
-  ofState {q | q.dom = {x} ∧ ∃ m, q.assignment x = some m ∧ pred m}
+  ofState {q | q.domain = {x} ∧ ∃ m, q.assignment x = some m ∧ pred m}
 
 /-- Binary atomic predicate at `x` and `y`. -/
 def atomVar2 (pred : M → M → Prop) (x y : V) : FCP W V M :=
-  ofState {q | q.dom = {x, y} ∧ ∃ m m', q.assignment x = some m ∧
+  ofState {q | q.domain = {x, y} ∧ ∃ m m', q.assignment x = some m ∧
     q.assignment y = some m' ∧ pred m m'}
 
 /-- Negation: keep the points of `F` that do not subsist in the scope's
@@ -215,7 +215,7 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
     exact ⟨hp, hpq.1.symm ▸ hqpred⟩
   · rintro ⟨hr, hpred⟩
     refine ⟨r, hr, ⟨r.world, fun _ => none⟩,
-      ⟨Set.ext fun v => by simp [Possibility.dom], hpred⟩,
+      ⟨Set.ext fun v => by simp [Possibility.domain], hpred⟩,
       ⟨rfl, fun _ _ _ _ h => by simp at h⟩, ?_⟩
     exact Possibility.ext rfl (funext fun v => by simp [Possibility.union])
 
@@ -229,7 +229,7 @@ theorem atomVar_eq_of_familiar [DecidableEq V] (pred : M → Prop) (x : V)
   · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
     have hqnone : ∀ v, v ≠ x → q.assignment v = none := fun v hv =>
       Option.not_isSome_iff_eq_none.mp fun hs => hv (by
-        have : v ∈ q.dom := hs
+        have : v ∈ q.domain := hs
         rwa [hqdom] at this)
     obtain ⟨m₀, hpx⟩ := Option.ne_none_iff_exists'.mp (hfam p hp)
     have huq : p.union q = p :=
@@ -242,7 +242,7 @@ theorem atomVar_eq_of_familiar [DecidableEq V] (pred : M → Prop) (x : V)
   · rintro ⟨hr, m, hrx, hpred⟩
     refine ⟨r, hr, ⟨r.world, fun v => if v = x then some m else none⟩,
       ⟨Set.ext fun v => by by_cases hv : v = x <;>
-        simp [Possibility.dom, hv], m, by simp, hpred⟩,
+        simp [Possibility.domain, hv], m, by simp, hpred⟩,
       ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · have he2 : (if v = x then some m else none) = some e' := he'
       by_cases hv : v = x
@@ -269,7 +269,7 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
   · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
     have hqnone : ∀ v, v ≠ x → q.assignment v = none := fun v hv =>
       Option.not_isSome_iff_eq_none.mp fun hs => hv (by
-        have : v ∈ q.dom := hs
+        have : v ∈ q.domain := hs
         rwa [hqdom] at this)
     have huq : p.union q = p.update x (some m) :=
       Possibility.ext rfl (funext fun v => by
@@ -285,7 +285,7 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     obtain rfl := (Option.some_inj.mp hrx).symm
     refine ⟨p, hp, ⟨p.world, fun v => if v = x then some m else none⟩,
       ⟨Set.ext fun v => by by_cases hv : v = x <;>
-        simp [Possibility.dom, hv], m, by simp, hpred⟩,
+        simp [Possibility.domain, hv], m, by simp, hpred⟩,
       ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · have he2 : (if v = x then some m else none) = some e' := he'
       by_cases hv : v = x

--- a/Linglib/Semantics/Dynamic/Partial.lean
+++ b/Linglib/Semantics/Dynamic/Partial.lean
@@ -15,7 +15,7 @@ of partial-function composition, true by construction (`admits_seq`).
 
 This is partiality of the *arrow*, and it is orthogonal to the partiality
 of the *points*: DRT's embeddings are partial assignments of discourse
-referents (`Possibility.dom`, `Option`-valued — `Dynamic/State.lean`),
+referents (`Possibility.domain`, `Option`-valued — `Dynamic/State.lean`),
 which encodes referential growth, not presupposition. The two compose in
 `Dynamic/FileChange.lean`, where `FCP` is `CCP.Partial` at partial-point
 states. ([haug-2014]'s "partial dynamic semantics" is the *point* sense.)

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -50,12 +50,8 @@ end Update
 
 variable {p q u : Possibility W V (Option M)}
 
-/-- Descent is the canonical order on partial points ([elliott-sudo-2025]
-Def. 3.3's descendance, [groenendijk-stokhof-veltman-1996]'s
-graph-extension — pointwise, the information order mathlib gives
-`Part`): same world, and the larger assignment defined wherever the
-smaller is. Every point lies over its own domain, so under descent the
-points form the total space of `Category.lean`'s possibilities family. -/
+/-- Descent orders partial points: same world, and the larger assignment
+defined wherever the smaller is ([elliott-sudo-2025], Def. 3.3). -/
 instance : Preorder (Possibility W V (Option M)) where
   le p q := p.world = q.world ∧
     ∀ x e, p.assignment x = some e → q.assignment x = some e

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -62,26 +62,24 @@ theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, (p.assignment x).FlatL
   Iff.rfl
 
 /-- The domain of a partial point is the set of referents it defines. -/
-def dom (p : Possibility W V (Option M)) : Set V :=
+def domain (p : Possibility W V (Option M)) : Set V :=
   {v | (p.assignment v).isSome}
 
-@[simp] theorem mem_dom {v : V} :
-    v ∈ p.dom ↔ (p.assignment v).isSome := Iff.rfl
+@[simp] theorem mem_domain {v : V} :
+    v ∈ p.domain ↔ (p.assignment v).isSome := Iff.rfl
 
 /-- Descent grows the domain. -/
-theorem dom_mono (h : p ≤ q) : p.dom ⊆ q.dom := fun v hv => by
-  obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
-  exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
+theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v => (h.2 v).isSome_mono
 
 /-- On a shared domain, descent is equality: there is no room to
 grow. -/
-theorem eq_of_le_of_dom_eq (h : p ≤ q) (hdom : p.dom = q.dom) : p = q := by
+theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q := by
   refine Possibility.ext h.1 (funext fun v => ?_)
   rcases hp : p.assignment v with _ | e
   · rcases hq : q.assignment v with _ | e
     · rfl
-    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
-      rw [Possibility.mem_dom, hp] at this
+    · have : v ∈ p.domain := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
+      rw [Possibility.mem_domain, hp] at this
       exact absurd this (by simp)
   · exact (h.2 v e hp).symm ▸ rfl
 
@@ -110,25 +108,25 @@ theorem Compatible.le_union_right (h : p.Compatible q) :
     · simp [union, hp, h.2 v e' e hp hq]⟩
 
 /-- On a shared domain, compatibility is equality. -/
-theorem Compatible.eq_of_dom_eq (h : p.Compatible q) (hdom : p.dom = q.dom) : p = q := by
+theorem Compatible.eq_of_domain_eq (h : p.Compatible q) (hdom : p.domain = q.domain) : p = q := by
   refine Possibility.ext h.1 (funext fun v => ?_)
   rcases hp : p.assignment v with _ | e
   · rcases hq : q.assignment v with _ | e
     · rfl
-    · have : v ∈ p.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
-      rw [Possibility.mem_dom, hp] at this
+    · have : v ∈ p.domain := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
+      rw [Possibility.mem_domain, hp] at this
       exact absurd this (by simp)
   · rcases hq : q.assignment v with _ | e'
-    · have : v ∈ q.dom := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hp⟩
-      rw [Possibility.mem_dom, hq] at this
+    · have : v ∈ q.domain := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hp⟩
+      rw [Possibility.mem_domain, hq] at this
       exact absurd this (by simp)
     · exact congrArg some (h.2 v e e' hp hq)
 
 /-- Union of points unites domains. -/
-theorem dom_union (p q : Possibility W V (Option M)) :
-    (p.union q).dom = p.dom ∪ q.dom := by
+theorem domain_union (p q : Possibility W V (Option M)) :
+    (p.union q).domain = p.domain ∪ q.domain := by
   ext v
-  rcases hp : p.assignment v with _ | e <;> simp [union, dom, hp]
+  rcases hp : p.assignment v with _ | e <;> simp [union, domain, hp]
 
 /-- Points below a common point are compatible. -/
 theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
@@ -210,17 +208,17 @@ theorem restrict_le (X : Set V) [∀ v, Decidable (v ∈ X)]
     · simp [restrict, hx] at h⟩
 
 /-- Restriction intersects the domain. -/
-theorem dom_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
+theorem domain_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
     (p : Possibility W V (Option M)) :
-    (p.restrict X).dom = X ∩ p.dom := by
+    (p.restrict X).domain = X ∩ p.domain := by
   ext v
-  by_cases hv : v ∈ X <;> simp [restrict, dom, hv]
+  by_cases hv : v ∈ X <;> simp [restrict, domain, hv]
 
 /-- Descent out of a stratum is *being the restriction*: for `p` at
 `X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
 hom-characterization of the fibred order. -/
 theorem le_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
-    (hp : p.dom = X) :
+    (hp : p.domain = X) :
     p ≤ q ↔ p = q.restrict X := by
   constructor
   · intro h
@@ -251,8 +249,8 @@ theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
 /-- Partial points with domain `X` are world–`X`-assignment pairs —
 constructively: the classification that the total-assignment rendering
 recovered only with choice and an inhabitant of `M`. -/
-def domEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
-    {p : Possibility W V (Option M) // p.dom = X} ≃ W × (X → M) where
+def domainEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
+    {p : Possibility W V (Option M) // p.domain = X} ≃ W × (X → M) where
   toFun p :=
     (p.1.world, fun v => (p.1.assignment v.1).get
       ((Set.ext_iff.mp p.2 v.1).mpr v.2))
@@ -260,7 +258,7 @@ def domEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
     ⟨⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩)
       else none⟩, by
       ext v
-      by_cases h : v ∈ X <;> simp [dom, h]⟩
+      by_cases h : v ∈ X <;> simp [domain, h]⟩
   left_inv p := by
     obtain ⟨⟨w, g⟩, hp⟩ := p
     refine Subtype.ext (Possibility.ext rfl (funext fun v => ?_))
@@ -274,20 +272,20 @@ def domEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
     refine Prod.ext rfl (funext fun v => ?_)
     simp
 
-theorem domEquiv_symm_val (X : Set V) [∀ v, Decidable (v ∈ X)]
+theorem domainEquiv_symm_val (X : Set V) [∀ v, Decidable (v ∈ X)]
     (e : W × (X → M)) :
-    ((domEquiv X).symm e).1 =
+    ((domainEquiv X).symm e).1 =
       ⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩)
         else none⟩ :=
   rfl
 
 /-- The charts commute with restriction: restricting a classified point
 is weakening its chart. -/
-theorem restrict_domEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
+theorem restrict_domainEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
     [∀ v, Decidable (v ∈ Y)] (h : Y ⊆ X) (e : W × (X → M)) :
-    ((domEquiv X).symm e).1.restrict Y =
-      ((domEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 := by
-  rw [domEquiv_symm_val, domEquiv_symm_val]
+    ((domainEquiv X).symm e).1.restrict Y =
+      ((domainEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 := by
+  rw [domainEquiv_symm_val, domainEquiv_symm_val]
   refine Possibility.ext rfl (funext fun v => ?_)
   by_cases hv : v ∈ Y
   · have hvX : v ∈ X := h hv

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -73,15 +73,9 @@ theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v => (h.2 v).is
 
 /-- On a shared domain, descent is equality: there is no room to
 grow. -/
-theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q := by
-  refine Possibility.ext h.1 (funext fun v => ?_)
-  rcases hp : p.assignment v with _ | e
-  · rcases hq : q.assignment v with _ | e
-    · rfl
-    · have : v ∈ p.domain := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
-      rw [Possibility.mem_domain, hp] at this
-      exact absurd this (by simp)
-  · exact (h.2 v e hp).symm ▸ rfl
+theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q :=
+  Possibility.ext h.1 (funext fun v =>
+    (h.2 v).eq_of_isSome fun hv => (Set.ext_iff.mp hdom v).mpr hv)
 
 /-- Two partial points are *compatible*: same world, agreeing wherever
 both are defined — [kamp-vangenabith-reyle-2011] Def. 26's condition
@@ -98,29 +92,25 @@ def union (p q : Possibility W V (Option M)) :
 
 theorem le_union_left (p q : Possibility W V (Option M)) :
     p ≤ p.union q :=
-  ⟨rfl, fun v e h => by simp [union, h]⟩
+  ⟨rfl, fun v e h => by simp [union, show p.assignment v = some e from h]⟩
 
 theorem Compatible.le_union_right (h : p.Compatible q) :
     q ≤ p.union q :=
   ⟨h.1.symm, fun v e hq => by
+    have hq' : q.assignment v = some e := hq
     rcases hp : p.assignment v with _ | e'
-    · simp [union, hp, hq]
-    · simp [union, hp, h.2 v e' e hp hq]⟩
+    · simp [union, hp, hq']
+    · simp [union, hp, h.2 v e' e hp hq']⟩
 
 /-- On a shared domain, compatibility is equality. -/
-theorem Compatible.eq_of_domain_eq (h : p.Compatible q) (hdom : p.domain = q.domain) : p = q := by
-  refine Possibility.ext h.1 (funext fun v => ?_)
-  rcases hp : p.assignment v with _ | e
-  · rcases hq : q.assignment v with _ | e
-    · rfl
-    · have : v ∈ p.domain := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hq⟩
-      rw [Possibility.mem_domain, hp] at this
-      exact absurd this (by simp)
-  · rcases hq : q.assignment v with _ | e'
-    · have : v ∈ q.domain := hdom ▸ Option.isSome_iff_exists.mpr ⟨e, hp⟩
-      rw [Possibility.mem_domain, hq] at this
-      exact absurd this (by simp)
-    · exact congrArg some (h.2 v e e' hp hq)
+theorem Compatible.eq_of_domain_eq (h : p.Compatible q)
+    (hdom : p.domain = q.domain) : p = q :=
+  eq_of_le_of_domain_eq
+    ⟨h.1, fun v e hv => by
+      obtain ⟨e', he'⟩ := Option.isSome_iff_exists.mp
+        ((Set.ext_iff.mp hdom v).mp (Option.isSome_iff_exists.mpr ⟨e, hv⟩))
+      exact he'.trans (congrArg some (h.2 v e e' hv he').symm)⟩
+    hdom
 
 /-- Union of points unites domains. -/
 theorem domain_union (p q : Possibility W V (Option M)) :
@@ -131,8 +121,8 @@ theorem domain_union (p q : Possibility W V (Option M)) :
 /-- Points below a common point are compatible. -/
 theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
   ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
-    have h1 := hp.2 v e he
-    have h2 := hq.2 v e' he'
+    have h1 : u.assignment v = some e := hp.2 v e he
+    have h2 : u.assignment v = some e' := hq.2 v e' he'
     rw [h1] at h2
     exact (Option.some.injEq .. ▸ h2 :)⟩
 
@@ -140,9 +130,10 @@ theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
 theorem union_le (hp : p ≤ u) (hq : q ≤ u) :
     p.union q ≤ u :=
   ⟨hp.1, fun v e h => by
+    have h' : (p.union q).assignment v = some e := h
     rcases hpv : p.assignment v with _ | e'
-    · exact hq.2 v e (by simpa [union, hpv] using h)
-    · have : e' = e := by simpa [union, hpv] using h
+    · exact hq.2 v e (by simpa [union, hpv] using h')
+    · have : e' = e := by simpa [union, hpv] using h'
       exact this ▸ hp.2 v e' hpv⟩
 
 theorem Compatible.symm (h : p.Compatible q) : q.Compatible p :=

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -10,18 +10,6 @@ of discourse referents — and the structure of its partial points: the
 descent order, compatibility and union, restriction, and the
 classification of each stratum as world–assignment pairs.
 
-## Main definitions
-
-- `Possibility W V M`: the point object; `Possibility.update` rewrites
-  one referent.
-- `Possibility.dom`, the `Preorder` instance (descent),
-  `Possibility.Compatible`, `Possibility.union`: partial points
-  (`Option`-valued assignments) — their defined referents, information
-  order, and consistent union.
-- `Possibility.restrict`, `Possibility.domEquiv`: domain restriction and
-  the constructive classification of the domain-`X` points as
-  world–`X`-assignment pairs.
-
 ## References
 
 - [groenendijk-stokhof-veltman-1996], [elliott-sudo-2025]

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -70,6 +70,8 @@ end Update
 
 /-! ### Partial points -/
 
+variable {p q u : Possibility W V (Option M)}
+
 /-- Descent is the canonical order on partial points ([elliott-sudo-2025]
 Def. 3.3's descendance, [groenendijk-stokhof-veltman-1996]'s
 graph-extension — pointwise, the information order mathlib gives
@@ -83,7 +85,7 @@ instance : Preorder (Possibility W V (Option M)) where
   le_trans _ _ _ hpq hqr :=
     ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
 
-theorem le_def {p q : Possibility W V (Option M)} :
+theorem le_def :
     p ≤ q ↔ p.world = q.world ∧
       ∀ x e, p.assignment x = some e → q.assignment x = some e := Iff.rfl
 
@@ -91,19 +93,17 @@ theorem le_def {p q : Possibility W V (Option M)} :
 def dom (p : Possibility W V (Option M)) : Set V :=
   {v | (p.assignment v).isSome}
 
-@[simp] theorem mem_dom {p : Possibility W V (Option M)} {v : V} :
+@[simp] theorem mem_dom {v : V} :
     v ∈ p.dom ↔ (p.assignment v).isSome := Iff.rfl
 
 /-- Descent grows the domain. -/
-theorem dom_mono {p q : Possibility W V (Option M)}
-    (h : p ≤ q) : p.dom ⊆ q.dom := fun v hv => by
+theorem dom_mono (h : p ≤ q) : p.dom ⊆ q.dom := fun v hv => by
   obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
   exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
 
 /-- On a shared domain, descent is equality: there is no room to
 grow. -/
-theorem eq_of_le_of_dom_eq {p q : Possibility W V (Option M)}
-    (h : p ≤ q) (hdom : p.dom = q.dom) : p = q := by
+theorem eq_of_le_of_dom_eq (h : p ≤ q) (hdom : p.dom = q.dom) : p = q := by
   refine Possibility.ext h.1 (funext fun v => ?_)
   rcases hp : p.assignment v with _ | e
   · rcases hq : q.assignment v with _ | e
@@ -130,8 +130,7 @@ theorem le_union_left (p q : Possibility W V (Option M)) :
     p ≤ p.union q :=
   ⟨rfl, fun v e h => by simp [union, h]⟩
 
-theorem Compatible.le_union_right
-    {p q : Possibility W V (Option M)} (h : p.Compatible q) :
+theorem Compatible.le_union_right (h : p.Compatible q) :
     q ≤ p.union q :=
   ⟨h.1.symm, fun v e hq => by
     rcases hp : p.assignment v with _ | e'
@@ -139,8 +138,7 @@ theorem Compatible.le_union_right
     · simp [union, hp, h.2 v e' e hp hq]⟩
 
 /-- On a shared domain, compatibility is equality. -/
-theorem Compatible.eq_of_dom_eq {p q : Possibility W V (Option M)}
-    (h : p.Compatible q) (hdom : p.dom = q.dom) : p = q := by
+theorem Compatible.eq_of_dom_eq (h : p.Compatible q) (hdom : p.dom = q.dom) : p = q := by
   refine Possibility.ext h.1 (funext fun v => ?_)
   rcases hp : p.assignment v with _ | e
   · rcases hq : q.assignment v with _ | e
@@ -161,8 +159,7 @@ theorem dom_union (p q : Possibility W V (Option M)) :
   rcases hp : p.assignment v with _ | e <;> simp [union, dom, hp]
 
 /-- Points below a common point are compatible. -/
-theorem compatible_of_le_of_le {p q u : Possibility W V (Option M)}
-    (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
+theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
   ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
     have h1 := hp.2 v e he
     have h2 := hq.2 v e' he'
@@ -170,8 +167,7 @@ theorem compatible_of_le_of_le {p q u : Possibility W V (Option M)}
     exact (Option.some.injEq .. ▸ h2 :)⟩
 
 /-- The union of two lower bounds is a lower bound. -/
-theorem union_le {p q u : Possibility W V (Option M)}
-    (hp : p ≤ u) (hq : q ≤ u) :
+theorem union_le (hp : p ≤ u) (hq : q ≤ u) :
     p.union q ≤ u :=
   ⟨hp.1, fun v e h => by
     rcases hpv : p.assignment v with _ | e'
@@ -179,8 +175,7 @@ theorem union_le {p q u : Possibility W V (Option M)}
     · have : e' = e := by simpa [union, hpv] using h
       exact this ▸ hp.2 v e' hpv⟩
 
-theorem Compatible.symm {p q : Possibility W V (Option M)}
-    (h : p.Compatible q) : q.Compatible p :=
+theorem Compatible.symm (h : p.Compatible q) : q.Compatible p :=
   ⟨h.1.symm, fun v e e' hq hp => (h.2 v e' e hp hq).symm⟩
 
 /-- Union of points is associative. -/
@@ -190,8 +185,7 @@ theorem union_assoc (p q v : Possibility W V (Option M)) :
 
 /-- On compatible points the left precedence of `union` is
 immaterial. -/
-theorem Compatible.union_comm {p q : Possibility W V (Option M)}
-    (h : p.Compatible q) : p.union q = q.union p :=
+theorem Compatible.union_comm (h : p.Compatible q) : p.union q = q.union p :=
   Possibility.ext h.1 (funext fun v => by
     rcases hp : p.assignment v with _ | e <;>
       rcases hq : q.assignment v with _ | e' <;> simp [union, hp, hq]
@@ -199,25 +193,24 @@ theorem Compatible.union_comm {p q : Possibility W V (Option M)}
 
 /-- A union is compatible with whatever both components are compatible
 with. -/
-theorem Compatible.union_left {p q v : Possibility W V (Option M)}
-    (hpv : p.Compatible v) (hqv : q.Compatible v) :
-    (p.union q).Compatible v :=
-  ⟨hpv.1, fun x e e' he he' => by
+theorem Compatible.union_left (hpu : p.Compatible u) (hqu : q.Compatible u) :
+    (p.union q).Compatible u :=
+  ⟨hpu.1, fun x e e' he he' => by
     rcases hp : p.assignment x with _ | c
-    · exact hqv.2 x e e' (by simpa [union, hp] using he) he'
+    · exact hqu.2 x e e' (by simpa [union, hp] using he) he'
     · have hce : c = e := by simpa [union, hp] using he
-      exact hce ▸ hpv.2 x c e' hp he'⟩
+      exact hce ▸ hpu.2 x c e' hp he'⟩
 
 /-- The left component of a compatible union is compatible. -/
-theorem Compatible.left_of_union {p q v : Possibility W V (Option M)}
-    (h : (p.union q).Compatible v) : p.Compatible v :=
+theorem Compatible.left_of_union
+    (h : (p.union q).Compatible u) : p.Compatible u :=
   ⟨h.1, fun x e e' hp hv => h.2 x e e' (by simp [union, hp]) hv⟩
 
 /-- The right component of a compatible union is compatible, given the
 components agree. -/
-theorem Compatible.right_of_union {p q v : Possibility W V (Option M)}
-    (hpq : p.Compatible q) (h : (p.union q).Compatible v) :
-    q.Compatible v :=
+theorem Compatible.right_of_union
+    (hpq : p.Compatible q) (h : (p.union q).Compatible u) :
+    q.Compatible u :=
   ⟨hpq.1.symm.trans h.1, fun x e e' hq hv => by
     rcases hp : p.assignment x with _ | c
     · exact h.2 x e e' (by simp [union, hp, hq]) hv
@@ -255,7 +248,7 @@ theorem dom_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
 `X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
 hom-characterization of the fibred order. -/
 theorem le_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
-    {p q : Possibility W V (Option M)} (hp : p.dom = X) :
+    (hp : p.dom = X) :
     p ≤ q ↔ p = q.restrict X := by
   constructor
   · intro h

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -225,19 +225,17 @@ theorem Compatible.right_of_union {p q v : Possibility W V (Option M)}
 
 section Restrict
 
-variable [DecidableEq V]
-
 /-- Restrict a partial point to the referents in `X`. -/
-def restrict (X : Finset V) (p : Possibility W V (Option M)) :
-    Possibility W V (Option M) :=
+def restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
+    (p : Possibility W V (Option M)) : Possibility W V (Option M) :=
   ⟨p.world, fun v => if v ∈ X then p.assignment v else none⟩
 
-@[simp] theorem restrict_world (X : Finset V)
+@[simp] theorem restrict_world (X : Set V) [∀ v, Decidable (v ∈ X)]
     (p : Possibility W V (Option M)) :
     (p.restrict X).world = p.world := rfl
 
 /-- Restriction is an ancestor. -/
-theorem restrict_descendant (X : Finset V)
+theorem restrict_descendant (X : Set V) [∀ v, Decidable (v ∈ X)]
     (p : Possibility W V (Option M)) : (p.restrict X).Descendant p :=
   ⟨rfl, fun x e h => by
     by_cases hx : x ∈ X
@@ -245,16 +243,17 @@ theorem restrict_descendant (X : Finset V)
     · simp [restrict, hx] at h⟩
 
 /-- Restriction intersects the domain. -/
-theorem dom_restrict (X : Finset V) (p : Possibility W V (Option M)) :
-    (p.restrict X).dom = ↑X ∩ p.dom := by
+theorem dom_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
+    (p : Possibility W V (Option M)) :
+    (p.restrict X).dom = X ∩ p.dom := by
   ext v
   by_cases hv : v ∈ X <;> simp [restrict, dom, hv]
 
 /-- Descendance out of a stratum is *being the restriction*: for `p` at
 `X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
 hom-characterization of the fibred order. -/
-theorem descendant_iff_eq_restrict {X : Finset V}
-    {p q : Possibility W V (Option M)} (hp : p.dom = (↑X : Set V)) :
+theorem descendant_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
+    {p q : Possibility W V (Option M)} (hp : p.dom = X) :
     p.Descendant q ↔ p = q.restrict X := by
   constructor
   · intro h
@@ -275,8 +274,8 @@ theorem descendant_iff_eq_restrict {X : Finset V}
     exact restrict_descendant X q
 
 /-- Restriction is pointwise idempotent along intersections. -/
-theorem restrict_restrict (X Y : Finset V)
-    (p : Possibility W V (Option M)) :
+theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
+    [∀ v, Decidable (v ∈ Y)] (p : Possibility W V (Option M)) :
     (p.restrict Y).restrict X = p.restrict (X ∩ Y) := by
   refine Possibility.ext rfl (funext fun v => ?_)
   by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;>
@@ -285,21 +284,20 @@ theorem restrict_restrict (X Y : Finset V)
 /-- Partial points with domain `X` are world–`X`-assignment pairs —
 constructively: the classification that the total-assignment rendering
 recovered only with choice and an inhabitant of `M`. -/
-def domEquiv (X : Finset V) :
-    {p : Possibility W V (Option M) // p.dom = (↑X : Set V)} ≃
-      W × ((↑X : Set V) → M) where
+def domEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
+    {p : Possibility W V (Option M) // p.dom = X} ≃ W × (X → M) where
   toFun p :=
     (p.1.world, fun v => (p.1.assignment v.1).get
       ((Set.ext_iff.mp p.2 v.1).mpr v.2))
   invFun e :=
-    ⟨⟨e.1, fun v => if h : v ∈ (↑X : Set V) then some (e.2 ⟨v, h⟩)
+    ⟨⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩)
       else none⟩, by
       ext v
-      by_cases h : v ∈ (↑X : Set V) <;> simp [dom, h]⟩
+      by_cases h : v ∈ X <;> simp [dom, h]⟩
   left_inv p := by
     obtain ⟨⟨w, g⟩, hp⟩ := p
     refine Subtype.ext (Possibility.ext rfl (funext fun v => ?_))
-    by_cases h : v ∈ (↑X : Set V)
+    by_cases h : v ∈ X
     · simp only [dif_pos h, Option.some_get]
     · have hnone : g v = none := Option.not_isSome_iff_eq_none.mp
         fun hs => h ((Set.ext_iff.mp hp v).mp hs)
@@ -309,17 +307,17 @@ def domEquiv (X : Finset V) :
     refine Prod.ext rfl (funext fun v => ?_)
     simp
 
-@[simp] theorem domEquiv_symm_val (X : Finset V)
-    (e : W × ((↑X : Set V) → M)) :
+theorem domEquiv_symm_val (X : Set V) [∀ v, Decidable (v ∈ X)]
+    (e : W × (X → M)) :
     ((domEquiv X).symm e).1 =
-      ⟨e.1, fun v => if h : v ∈ (↑X : Set V) then some (e.2 ⟨v, h⟩)
+      ⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩)
         else none⟩ :=
   rfl
 
 /-- The charts commute with restriction: restricting a classified point
 is weakening its chart. -/
-theorem restrict_domEquiv_symm {Y X : Finset V} (h : Y ≤ X)
-    (e : W × ((↑X : Set V) → M)) :
+theorem restrict_domEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
+    [∀ v, Decidable (v ∈ Y)] (h : Y ⊆ X) (e : W × (X → M)) :
     ((domEquiv X).symm e).1.restrict Y =
       ((domEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 := by
   rw [domEquiv_symm_val, domEquiv_symm_val]
@@ -343,6 +341,30 @@ instance : Preorder (Based W V M) where
   le p q := p.1.Descendant q.1
   le_refl p := Descendant.refl p.1
   le_trans _ _ _ := Descendant.trans
+
+/-! ### Instantiations
+
+Update systems share one form — states are sets of points, updates act
+on states — and differ in the point. The parameters select the system:
+worlds only gives propositional update semantics ([veltman-1996]; the
+`∅`-fiber), assignments only gives lifted DPL, and the general form is
+FCS/DRT's pairs. Propositional inquisitive semantics instead *iterates*
+the construction — its points are sets of worlds — a level shift, not a
+parameter choice. -/
+
+/-- Worlds-only points: propositional update semantics. -/
+def worldEquiv (W M : Type*) : Possibility W Empty M ≃ W where
+  toFun p := p.world
+  invFun w := ⟨w, Empty.elim⟩
+  left_inv _ := Possibility.ext rfl (funext fun v => v.elim)
+  right_inv _ := rfl
+
+/-- Assignments-only points: lifted DPL. -/
+def assignmentEquiv (V M : Type*) : Possibility Unit V M ≃ (V → M) where
+  toFun p := p.assignment
+  invFun g := ⟨(), g⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
 
 end Possibility
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -329,18 +329,16 @@ theorem restrict_domEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
 
 end Restrict
 
-/-! ### Based points -/
-
-/-- A possibility is *based* when its domain is a base — realizable as
-some `X : Finset V`, [kamp-vangenabith-reyle-2011] Def. 23's word —
-which is exactly finiteness. Under descent, based points form the total
+/-- Descent is the canonical order on partial points: every point lies
+over its own domain, and under this order the points form the total
 space of `Category.lean`'s possibilities family. -/
-def Based (W V M : Type*) := {p : Possibility W V (Option M) // p.dom.Finite}
-
-instance : Preorder (Based W V M) where
-  le p q := p.1.Descendant q.1
-  le_refl p := Descendant.refl p.1
+instance : Preorder (Possibility W V (Option M)) where
+  le := Descendant
+  le_refl := Descendant.refl
   le_trans _ _ _ := Descendant.trans
+
+@[simp] theorem le_def {p q : Possibility W V (Option M)} :
+    p ≤ q ↔ p.Descendant q := Iff.rfl
 
 /-! ### Instantiations
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -5,20 +5,10 @@ import Mathlib.Data.Set.Function
 /-!
 # Possibilities
 
-A *possibility* is a world paired with an assignment of discourse
-referents — the point type of dynamic semantics. Indexed information
-states over possibilities live in `State.lean`; unindexed states are plain
-sets of possibilities, with the generic level-0 CCP algebra in
-`Update.lean`.
-
-*Possibility* is the update-semantics tradition's word:
-[groenendijk-stokhof-veltman-1996]'s possibilities are triples carrying a
-referent system ([vermeulen-1995]) we do not; [elliott-sudo-2025]'s are
-world–assignment pairs like ours. [kamp-vangenabith-reyle-2011] leaves the
-pairs of its Def. 22 unnamed — DRT's word for the assignment is
-*(verifying) embedding*, a partial function on referents with one
-universe across worlds — and the monadic tradition calls the same points
-*indices* ([charlow-2025-staged-updates]).
+This file defines a *possibility* — a world paired with an assignment
+of discourse referents — and the structure of its partial points: the
+descent order, compatibility and union, restriction, and the
+classification of each stratum as world–assignment pairs.
 
 ## Main definitions
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -54,15 +54,12 @@ variable {p q u : Possibility W V (Option M)}
 /-- Descent orders partial points: same world, assignments pointwise in
 the flat information order ([elliott-sudo-2025], Def. 3.3). -/
 instance : Preorder (Possibility W V (Option M)) where
-  le p q := p.world = q.world ∧
-    ∀ x, (p.assignment x).FlatLE (q.assignment x)
+  le p q := p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x)
   le_refl _ := ⟨rfl, fun x => Option.FlatLE.refl _⟩
-  le_trans _ _ _ hpq hqr :=
-    ⟨hpq.1.trans hqr.1, fun x => (hpq.2 x).trans (hqr.2 x)⟩
+  le_trans _ _ _ hpq hqr := ⟨hpq.1.trans hqr.1, fun x => (hpq.2 x).trans (hqr.2 x)⟩
 
-theorem le_def :
-    p ≤ q ↔ p.world = q.world ∧
-      ∀ x, (p.assignment x).FlatLE (q.assignment x) := Iff.rfl
+theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x) :=
+  Iff.rfl
 
 /-- The domain of a partial point is the set of referents it defines. -/
 def dom (p : Possibility W V (Option M)) : Set V :=

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -53,20 +53,20 @@ namespace Possibility
 
 variable {W V M : Type*} (p : Possibility W V M)
 
+section Update
+
+variable [DecidableEq V] (x : V) (e : M)
+
 /-- Update the assignment at a single referent. -/
-def update [DecidableEq V] (x : V) (e : M) : Possibility W V M :=
+def update : Possibility W V M :=
   { p with assignment := Function.update p.assignment x e }
 
-@[simp] theorem update_self [DecidableEq V] (x : V) (e : M) :
-    (p.update x e).assignment x = e :=
-  Function.update_self ..
+@[simp] theorem update_world : (p.update x e).world = p.world := rfl
 
-@[simp] theorem update_of_ne [DecidableEq V] {x y : V} (e : M)
-    (h : y ≠ x) : (p.update x e).assignment y = p.assignment y :=
-  Function.update_of_ne h ..
+@[simp] theorem update_assignment :
+    (p.update x e).assignment = Function.update p.assignment x e := rfl
 
-@[simp] theorem update_world [DecidableEq V] (x : V) (e : M) :
-    (p.update x e).world = p.world := rfl
+end Update
 
 /-! ### Partial points -/
 
@@ -87,8 +87,7 @@ theorem le_def {p q : Possibility W V (Option M)} :
     p ≤ q ↔ p.world = q.world ∧
       ∀ x e, p.assignment x = some e → q.assignment x = some e := Iff.rfl
 
-/-- The referents a partial point defines —
-[kamp-vangenabith-reyle-2011] Def. 23's `Dom(f)`. -/
+/-- The domain of a partial point is the set of referents it defines. -/
 def dom (p : Possibility W V (Option M)) : Set V :=
   {v | (p.assignment v).isSome}
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -24,9 +24,10 @@ universe across worlds — and the monadic tradition calls the same points
 
 - `Possibility W V M`: the point object; `Possibility.update` rewrites
   one referent.
-- `Possibility.dom`, `Possibility.Descendant`, `Possibility.Compatible`,
-  `Possibility.union`: partial points (`Option`-valued assignments) —
-  their defined referents, growth order, and consistent union.
+- `Possibility.dom`, the `Preorder` instance (descent),
+  `Possibility.Compatible`, `Possibility.union`: partial points
+  (`Option`-valued assignments) — their defined referents, information
+  order, and consistent union.
 - `Possibility.restrict`, `Possibility.domEquiv`: domain restriction and
   the constructive classification of the domain-`X` points as
   world–`X`-assignment pairs.
@@ -69,6 +70,23 @@ def update [DecidableEq V] (x : V) (e : M) : Possibility W V M :=
 
 /-! ### Partial points -/
 
+/-- Descent is the canonical order on partial points ([elliott-sudo-2025]
+Def. 3.3's descendance, [groenendijk-stokhof-veltman-1996]'s
+graph-extension — pointwise, the information order mathlib gives
+`Part`): same world, and the larger assignment defined wherever the
+smaller is. Every point lies over its own domain, so under descent the
+points form the total space of `Category.lean`'s possibilities family. -/
+instance : Preorder (Possibility W V (Option M)) where
+  le p q := p.world = q.world ∧
+    ∀ x e, p.assignment x = some e → q.assignment x = some e
+  le_refl _ := ⟨rfl, fun _ _ h => h⟩
+  le_trans _ _ _ hpq hqr :=
+    ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
+
+theorem le_def {p q : Possibility W V (Option M)} :
+    p ≤ q ↔ p.world = q.world ∧
+      ∀ x e, p.assignment x = some e → q.assignment x = some e := Iff.rfl
+
 /-- The referents a partial point defines —
 [kamp-vangenabith-reyle-2011] Def. 23's `Dom(f)`. -/
 def dom (p : Possibility W V (Option M)) : Set V :=
@@ -77,31 +95,16 @@ def dom (p : Possibility W V (Option M)) : Set V :=
 @[simp] theorem mem_dom {p : Possibility W V (Option M)} {v : V} :
     v ∈ p.dom ↔ (p.assignment v).isSome := Iff.rfl
 
-/-- `q` is a *descendant* of `p` ([elliott-sudo-2025], Def. 3.3): same
-world, and `q`'s assignment extends `p`'s wherever the latter is defined
-([groenendijk-stokhof-veltman-1996]'s graph-extension — pointwise, the
-information order mathlib gives `Part`). -/
-def Descendant (p q : Possibility W V (Option M)) : Prop :=
-  p.world = q.world ∧ ∀ x e, p.assignment x = some e → q.assignment x = some e
-
-theorem Descendant.refl (p : Possibility W V (Option M)) :
-    p.Descendant p :=
-  ⟨rfl, fun _ _ h => h⟩
-
-theorem Descendant.trans {p q r : Possibility W V (Option M)}
-    (hpq : p.Descendant q) (hqr : q.Descendant r) : p.Descendant r :=
-  ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
-
-/-- Descendance grows the domain. -/
-theorem Descendant.dom_subset {p q : Possibility W V (Option M)}
-    (h : p.Descendant q) : p.dom ⊆ q.dom := fun v hv => by
+/-- Descent grows the domain. -/
+theorem dom_mono {p q : Possibility W V (Option M)}
+    (h : p ≤ q) : p.dom ⊆ q.dom := fun v hv => by
   obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hv
   exact Option.isSome_iff_exists.mpr ⟨e, h.2 v e he⟩
 
-/-- On a shared domain, descendance is equality: there is no room to
+/-- On a shared domain, descent is equality: there is no room to
 grow. -/
-theorem Descendant.eq_of_dom_eq {p q : Possibility W V (Option M)}
-    (h : p.Descendant q) (hdom : p.dom = q.dom) : p = q := by
+theorem eq_of_le_of_dom_eq {p q : Possibility W V (Option M)}
+    (h : p ≤ q) (hdom : p.dom = q.dom) : p = q := by
   refine Possibility.ext h.1 (funext fun v => ?_)
   rcases hp : p.assignment v with _ | e
   · rcases hq : q.assignment v with _ | e
@@ -124,13 +127,13 @@ def union (p q : Possibility W V (Option M)) :
     Possibility W V (Option M) :=
   ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
 
-theorem left_descendant_union (p q : Possibility W V (Option M)) :
-    p.Descendant (p.union q) :=
+theorem le_union_left (p q : Possibility W V (Option M)) :
+    p ≤ p.union q :=
   ⟨rfl, fun v e h => by simp [union, h]⟩
 
-theorem Compatible.right_descendant_union
+theorem Compatible.le_union_right
     {p q : Possibility W V (Option M)} (h : p.Compatible q) :
-    q.Descendant (p.union q) :=
+    q ≤ p.union q :=
   ⟨h.1.symm, fun v e hq => by
     rcases hp : p.assignment v with _ | e'
     · simp [union, hp, hq]
@@ -158,19 +161,19 @@ theorem dom_union (p q : Possibility W V (Option M)) :
   ext v
   rcases hp : p.assignment v with _ | e <;> simp [union, dom, hp]
 
-/-- Common ancestors are compatible. -/
-theorem Descendant.compatible {p q u : Possibility W V (Option M)}
-    (hp : p.Descendant u) (hq : q.Descendant u) : p.Compatible q :=
+/-- Points below a common point are compatible. -/
+theorem compatible_of_le_of_le {p q u : Possibility W V (Option M)}
+    (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
   ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
     have h1 := hp.2 v e he
     have h2 := hq.2 v e' he'
     rw [h1] at h2
     exact (Option.some.injEq .. ▸ h2 :)⟩
 
-/-- The union of two ancestors is an ancestor. -/
-theorem Descendant.union_descendant {p q u : Possibility W V (Option M)}
-    (hp : p.Descendant u) (hq : q.Descendant u) :
-    (p.union q).Descendant u :=
+/-- The union of two lower bounds is a lower bound. -/
+theorem union_le {p q u : Possibility W V (Option M)}
+    (hp : p ≤ u) (hq : q ≤ u) :
+    p.union q ≤ u :=
   ⟨hp.1, fun v e h => by
     rcases hpv : p.assignment v with _ | e'
     · exact hq.2 v e (by simpa [union, hpv] using h)
@@ -234,9 +237,9 @@ def restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
     (p : Possibility W V (Option M)) :
     (p.restrict X).world = p.world := rfl
 
-/-- Restriction is an ancestor. -/
-theorem restrict_descendant (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (p : Possibility W V (Option M)) : (p.restrict X).Descendant p :=
+/-- Restriction descends. -/
+theorem restrict_le (X : Set V) [∀ v, Decidable (v ∈ X)]
+    (p : Possibility W V (Option M)) : p.restrict X ≤ p :=
   ⟨rfl, fun x e h => by
     by_cases hx : x ∈ X
     · simpa [restrict, hx] using h
@@ -249,12 +252,12 @@ theorem dom_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
   ext v
   by_cases hv : v ∈ X <;> simp [restrict, dom, hv]
 
-/-- Descendance out of a stratum is *being the restriction*: for `p` at
+/-- Descent out of a stratum is *being the restriction*: for `p` at
 `X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
 hom-characterization of the fibred order. -/
-theorem descendant_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
+theorem le_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
     {p q : Possibility W V (Option M)} (hp : p.dom = X) :
-    p.Descendant q ↔ p = q.restrict X := by
+    p ≤ q ↔ p = q.restrict X := by
   constructor
   · intro h
     refine Possibility.ext h.1 (funext fun v => ?_)
@@ -271,7 +274,7 @@ theorem descendant_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
       rw [hnone]
       simp [restrict, hv]
   · rintro rfl
-    exact restrict_descendant X q
+    exact restrict_le X q
 
 /-- Restriction is pointwise idempotent along intersections. -/
 theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
@@ -328,17 +331,6 @@ theorem restrict_domEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
   · simp [restrict, hv]
 
 end Restrict
-
-/-- Descent is the canonical order on partial points: every point lies
-over its own domain, and under this order the points form the total
-space of `Category.lean`'s possibilities family. -/
-instance : Preorder (Possibility W V (Option M)) where
-  le := Descendant
-  le_refl := Descendant.refl
-  le_trans _ _ _ := Descendant.trans
-
-@[simp] theorem le_def {p q : Possibility W V (Option M)} :
-    p ≤ q ↔ p.Descendant q := Iff.rfl
 
 /-! ### Instantiations
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Order.Flat
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Set.Function
@@ -50,18 +51,18 @@ end Update
 
 variable {p q u : Possibility W V (Option M)}
 
-/-- Descent orders partial points: same world, and the larger assignment
-defined wherever the smaller is ([elliott-sudo-2025], Def. 3.3). -/
+/-- Descent orders partial points: same world, assignments pointwise in
+the flat information order ([elliott-sudo-2025], Def. 3.3). -/
 instance : Preorder (Possibility W V (Option M)) where
   le p q := p.world = q.world ∧
-    ∀ x e, p.assignment x = some e → q.assignment x = some e
-  le_refl _ := ⟨rfl, fun _ _ h => h⟩
+    ∀ x, (p.assignment x).FlatLE (q.assignment x)
+  le_refl _ := ⟨rfl, fun x => Option.FlatLE.refl _⟩
   le_trans _ _ _ hpq hqr :=
-    ⟨hpq.1.trans hqr.1, fun x e h => hqr.2 x e (hpq.2 x e h)⟩
+    ⟨hpq.1.trans hqr.1, fun x => (hpq.2 x).trans (hqr.2 x)⟩
 
 theorem le_def :
     p ≤ q ↔ p.world = q.world ∧
-      ∀ x e, p.assignment x = some e → q.assignment x = some e := Iff.rfl
+      ∀ x, (p.assignment x).FlatLE (q.assignment x) := Iff.rfl
 
 /-- The domain of a partial point is the set of referents it defines. -/
 def dom (p : Possibility W V (Option M)) : Set V :=

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -17,7 +17,7 @@ assumes: the absurd state is `∅`, the initial state is `W × {g_⊤}`
 There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
 (`UniformAt`), and a base is the index of a fiber, not part of the data.
 Points with domain `X` are world–`X`-assignment pairs, constructively
-(`Possibility.domEquiv` — the total-assignment rendering needed choice
+(`Possibility.domainEquiv` — the total-assignment rendering needed choice
 and an inhabitant of `M` to recover this). Two preorders run through states, and they are
 dual on shared strata. *Informativeness* (`⊑`,
 [kamp-vangenabith-reyle-2011] Def. 25) quantifies over the stronger
@@ -50,7 +50,7 @@ stratum they reduce to `⊇` and `⊆` respectively
   [visser-vermeulen-1996]'s monoidal processing.
 - `infoLe_iff_superset`, `subsistsIn_iff_subset`: on a uniform stratum
   both preorders are partial orders, coinciding with `⊇`/`⊆` (via
-  `Possibility.eq_of_le_of_dom_eq`).
+  `Possibility.eq_of_le_of_domain_eq`).
 - `subsistsIn_restrict`: restriction only forgets — the restricted state
   subsists in the original.
 - `uniformAt_restrict`, `restrict_restrict`: restriction meets the
@@ -231,21 +231,21 @@ namespace State
 referents in `X` — Def. 23's "Dom(f) = X", as a stratum rather than a
 component. -/
 def UniformAt (X : Set V) (I : State W V M) : Prop :=
-  ∀ p ∈ I, Possibility.dom p = X
+  ∀ p ∈ I, Possibility.domain p = X
 
 /-- The initial state is uniform at the empty base. -/
 theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
   fun p hp => by
     ext v
-    simp [Possibility.dom, hp v]
+    simp [Possibility.domain, hp v]
 
 /-- Into a uniform stratum, subsistence is membership: a point already
 at the stratum's domain has no room to grow. -/
 theorem subsists_iff_mem {X : Set V} {s : State W V M}
     (hs : UniformAt X s) {p : Possibility W V (Option M)}
-    (hp : p.dom = X) : (p ≺ s) ↔ p ∈ s :=
+    (hp : p.domain = X) : (p ≺ s) ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
-    (Possibility.eq_of_le_of_dom_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
+    (Possibility.eq_of_le_of_domain_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
     Subsists.of_mem⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
@@ -262,7 +262,7 @@ theorem infoLe_iff_superset {X : Set V} {s s' : State W V M}
   constructor
   · intro h q hq
     obtain ⟨p, hp, hpq⟩ := h q hq
-    rwa [← Possibility.eq_of_le_of_dom_eq hpq ((hs p hp).trans (hs' q hq).symm)]
+    rwa [← Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)]
   · exact fun h q hq => ⟨q, h hq, le_refl q⟩
 
 /-- Within one stratum, merge is intersection: compatibility on a shared
@@ -276,7 +276,7 @@ theorem merge_eq_inter_of_uniform {X : Set V} {s s' : State W V M}
   ext r
   constructor
   · rintro ⟨p, hp, q, hq, hpq, rfl⟩
-    obtain rfl := hpq.eq_of_dom_eq ((hs p hp).trans (hs' q hq).symm)
+    obtain rfl := hpq.eq_of_domain_eq ((hs p hp).trans (hs' q hq).symm)
     rw [hself p]
     exact ⟨hp, hq⟩
   · rintro ⟨hr, hr'⟩
@@ -291,7 +291,7 @@ theorem uniformAt_merge {X Y : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt Y s') :
     UniformAt (X ∪ Y) (s.merge s') := by
   rintro r ⟨p, hp, q, hq, -, rfl⟩
-  rw [Possibility.dom_union, hs p hp, hs' q hq]
+  rw [Possibility.domain_union, hs p hp, hs' q hq]
 
 /-- Subsistence out of a stratum factors through reindexing: the weaker
 state includes into the restricted image of the stronger — the fibred
@@ -343,7 +343,7 @@ theorem uniformAt_restrict {X Y : Set V} [∀ v, Decidable (v ∈ X)]
     {I : State W V M}
     (h : UniformAt Y I) : UniformAt (X ∩ Y) (I.restrict X) := by
   rintro p ⟨q, hq, rfl⟩
-  rw [Possibility.dom_restrict, h q hq]
+  rw [Possibility.domain_restrict, h q hq]
 
 /-- Restriction composes along intersections. -/
 theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
@@ -370,15 +370,15 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
 /-! ### The uniform classification -/
 
 /-- Uniform states at `X` are sets of world–`X`-assignment pairs — the
-state-level face of `Possibility.domEquiv`, and the comparison to the
+state-level face of `Possibility.domainEquiv`, and the comparison to the
 predecessor's fibers: an order isomorphism for `⊆` (which is `⪯` on the
 stratum, `subsistsIn_iff_subset`), hence an anti-isomorphism for `⊑`
 (`infoLe_iff_superset`). -/
 def uniformEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
     {I : State W V M // UniformAt X I} ≃o Set (W × (X → M)) where
-  toFun I := {e | ((Possibility.domEquiv X).symm e).1 ∈ I.1}
+  toFun I := {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
   invFun S :=
-    ⟨{p | ∃ h : p.dom = X, Possibility.domEquiv X ⟨p, h⟩ ∈ S},
+    ⟨{p | ∃ h : p.domain = X, Possibility.domainEquiv X ⟨p, h⟩ ∈ S},
       fun _ ⟨h, _⟩ => h⟩
   left_inv I := by
     refine Subtype.ext (Set.ext fun p => ?_)
@@ -392,11 +392,11 @@ def uniformEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
     · rintro ⟨h, hmem⟩
       simpa using hmem
     · intro he
-      exact ⟨((Possibility.domEquiv X).symm e).2, by simpa using he⟩
+      exact ⟨((Possibility.domainEquiv X).symm e).2, by simpa using he⟩
   map_rel_iff' {I J} := by
     constructor
     · intro h p hp
-      simpa using h (a := Possibility.domEquiv X ⟨p, I.2 p hp⟩)
+      simpa using h (a := Possibility.domainEquiv X ⟨p, I.2 p hp⟩)
         (by simpa using hp)
     · exact fun h _ he => h he
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -230,8 +230,8 @@ namespace State
 /-- The state is uniform at `X`: every point defines exactly the
 referents in `X` — Def. 23's "Dom(f) = X", as a stratum rather than a
 component. -/
-def UniformAt (X : Finset V) (I : State W V M) : Prop :=
-  ∀ p ∈ I, Possibility.dom p = (↑X : Set V)
+def UniformAt (X : Set V) (I : State W V M) : Prop :=
+  ∀ p ∈ I, Possibility.dom p = X
 
 /-- The initial state is uniform at the empty base. -/
 theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
@@ -241,22 +241,22 @@ theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
 
 /-- Into a uniform stratum, subsistence is membership: a point already
 at the stratum's domain has no room to grow. -/
-theorem subsists_iff_mem {X : Finset V} {s : State W V M}
+theorem subsists_iff_mem {X : Set V} {s : State W V M}
     (hs : UniformAt X s) {p : Possibility W V (Option M)}
-    (hp : p.dom = (↑X : Set V)) : (p ≺ s) ↔ p ∈ s :=
+    (hp : p.dom = X) : (p ≺ s) ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
     (hpq.eq_of_dom_eq (hp.trans (hs q hq).symm)).symm ▸ hq,
     Subsists.of_mem⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
-theorem subsistsIn_iff_subset {X : Finset V} {s s' : State W V M}
+theorem subsistsIn_iff_subset {X : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt X s') :
     (s ⪯ s') ↔ s ⊆ s' :=
   forall₂_congr fun p hp => subsists_iff_mem hs' (hs p hp)
 
 /-- On a uniform stratum, informativeness is reverse inclusion — the
 eliminative direction. -/
-theorem infoLe_iff_superset {X : Finset V} {s s' : State W V M}
+theorem infoLe_iff_superset {X : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt X s') :
     (s ⊑ s') ↔ s' ⊆ s := by
   constructor
@@ -267,7 +267,7 @@ theorem infoLe_iff_superset {X : Finset V} {s s' : State W V M}
 
 /-- Within one stratum, merge is intersection: compatibility on a shared
 domain forces equality. -/
-theorem merge_eq_inter_of_uniform {X : Finset V} {s s' : State W V M}
+theorem merge_eq_inter_of_uniform {X : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt X s') :
     s.merge s' = s ∩ s' := by
   have hself : ∀ r : Possibility W V (Option M), r.union r = r := fun r =>
@@ -285,19 +285,19 @@ theorem merge_eq_inter_of_uniform {X : Finset V} {s s' : State W V M}
     exact (Option.some.injEq .. ▸ he' :)
 
 section Fibred
-variable [DecidableEq V]
 
 /-- Merge unites strata. -/
-theorem uniformAt_merge {X Y : Finset V} {s s' : State W V M}
+theorem uniformAt_merge {X Y : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt Y s') :
     UniformAt (X ∪ Y) (s.merge s') := by
   rintro r ⟨p, hp, q, hq, -, rfl⟩
-  rw [Possibility.dom_union, hs p hp, hs' q hq, Finset.coe_union]
+  rw [Possibility.dom_union, hs p hp, hs' q hq]
 
 /-- Subsistence out of a stratum factors through reindexing: the weaker
 state includes into the restricted image of the stronger — the fibred
 order, glued from within-stratum `⊆` along `restrict`. -/
-theorem subsistsIn_iff_subset_restrict {X : Finset V}
+theorem subsistsIn_iff_subset_restrict {X : Set V}
+    [∀ v, Decidable (v ∈ X)]
     {s s' : State W V M} (hs : UniformAt X s) :
     (s ⪯ s') ↔ s ⊆ Possibility.restrict X '' s' := by
   constructor
@@ -312,7 +312,8 @@ theorem subsistsIn_iff_subset_restrict {X : Finset V}
 /-- Informativeness out of a stratum factors through reindexing: the
 restricted image of the stronger is included in the weaker — the
 eliminative direction of the fibred order. -/
-theorem infoLe_iff_restrict_subset {X : Finset V}
+theorem infoLe_iff_restrict_subset {X : Set V}
+    [∀ v, Decidable (v ∈ X)]
     {s s' : State W V M} (hs : UniformAt X s) :
     (s ⊑ s') ↔ Possibility.restrict X '' s' ⊆ s := by
   constructor
@@ -325,31 +326,34 @@ theorem infoLe_iff_restrict_subset {X : Finset V}
 
 end Fibred
 
-variable [DecidableEq V]
-
 /-- Restriction of a state: pointwise, by direct image. -/
-def restrict (X : Finset V) (I : State W V M) : State W V M :=
+def restrict (X : Set V) [∀ v, Decidable (v ∈ X)] (I : State W V M) :
+    State W V M :=
   Possibility.restrict X '' I
 
 /-- Restriction only forgets: the restricted state subsists in the
 original. -/
-theorem subsistsIn_restrict (X : Finset V) (I : State W V M) :
-    I.restrict X ⪯ I := by
+theorem subsistsIn_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
+    (I : State W V M) : I.restrict X ⪯ I := by
   rintro p ⟨q, hq, rfl⟩
   exact ⟨q, hq, Possibility.restrict_descendant X q⟩
 
 /-- Restriction meets the stratification. -/
-theorem uniformAt_restrict {X Y : Finset V} {I : State W V M}
+theorem uniformAt_restrict {X Y : Set V} [∀ v, Decidable (v ∈ X)]
+    {I : State W V M}
     (h : UniformAt Y I) : UniformAt (X ∩ Y) (I.restrict X) := by
   rintro p ⟨q, hq, rfl⟩
-  rw [Possibility.dom_restrict, h q hq, Finset.coe_inter]
+  rw [Possibility.dom_restrict, h q hq]
 
 /-- Restriction composes along intersections. -/
-theorem restrict_restrict (X Y : Finset V) (I : State W V M) :
+theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
+    [∀ v, Decidable (v ∈ Y)] (I : State W V M) :
     (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
   unfold restrict
   rw [← Set.image_comp]
   exact congrFun (congrArg _ (funext (Possibility.restrict_restrict X Y))) I
+
+variable [DecidableEq V]
 
 /-- Random assignment ([elliott-sudo-2025], (43);
 [groenendijk-stokhof-1991]'s `x := random`): indeterministically extend
@@ -370,11 +374,11 @@ state-level face of `Possibility.domEquiv`, and the comparison to the
 predecessor's fibers: an order isomorphism for `⊆` (which is `⪯` on the
 stratum, `subsistsIn_iff_subset`), hence an anti-isomorphism for `⊑`
 (`infoLe_iff_superset`). -/
-def uniformEquiv (X : Finset V) :
-    {I : State W V M // UniformAt X I} ≃o Set (W × ((↑X : Set V) → M)) where
+def uniformEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
+    {I : State W V M // UniformAt X I} ≃o Set (W × (X → M)) where
   toFun I := {e | ((Possibility.domEquiv X).symm e).1 ∈ I.1}
   invFun S :=
-    ⟨{p | ∃ h : p.dom = (↑X : Set V), Possibility.domEquiv X ⟨p, h⟩ ∈ S},
+    ⟨{p | ∃ h : p.dom = X, Possibility.domEquiv X ⟨p, h⟩ ∈ S},
       fun _ ⟨h, _⟩ => h⟩
   left_inv I := by
     refine Subtype.ext (Set.ext fun p => ?_)

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -21,7 +21,7 @@ Points with domain `X` are world–`X`-assignment pairs, constructively
 and an inhabitant of `M` to recover this). Two preorders run through states, and they are
 dual on shared strata. *Informativeness* (`⊑`,
 [kamp-vangenabith-reyle-2011] Def. 25) quantifies over the stronger
-state: every point of the stronger has an ancestor in the weaker — the
+state: every point of the stronger lies above a point of the weaker — the
 absurd state `∅` is maximally informative, the eliminative direction.
 *Subsistence* (`⪯`, [elliott-sudo-2025] Def. 3.3, after
 [groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) quantifies over the
@@ -50,7 +50,7 @@ stratum they reduce to `⊇` and `⊆` respectively
   [visser-vermeulen-1996]'s monoidal processing.
 - `infoLe_iff_superset`, `subsistsIn_iff_subset`: on a uniform stratum
   both preorders are partial orders, coinciding with `⊇`/`⊆` (via
-  `Possibility.Descendant.eq_of_dom_eq`).
+  `Possibility.eq_of_le_of_dom_eq`).
 - `subsistsIn_restrict`: restriction only forgets — the restricted state
   subsists in the original.
 - `uniformAt_restrict`, `restrict_restrict`: restriction meets the
@@ -61,8 +61,8 @@ stratum they reduce to `⊇` and `⊆` respectively
 
 `State` is an abbreviation, so `Set`'s complete lattice is available and
 `⊑`/`⪯` are scoped relations rather than instances. Neither is
-antisymmetric on raw sets (adding a comparable point is invisible — an
-ancestor for `⪯`, a descendant for `⊑`); antisymmetry holds on each
+antisymmetric on raw sets (adding a comparable point is invisible —
+below for `⪯`, above for `⊑`); antisymmetry holds on each
 uniform stratum, where they coincide with `⊇`/`⊆`. The predecessor of this file classified its
 fibers as `(Set (W × (↑X → M)))ᵒᵈ` — the dual lands here because its
 order was Def. 25's, matching `⊑`, not `⪯`.
@@ -90,15 +90,15 @@ referent defined. -/
 def State.initial : State W V M := {p | ∀ v, p.assignment v = none}
 
 /-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it has a
-descendant in `s`. -/
+point above it in `s`. -/
 def Subsists (p : Possibility W V (Option M)) (s : State W V M) : Prop :=
-  ∃ q ∈ s, p.Descendant q
+  ∃ q ∈ s, p ≤ q
 
 @[inherit_doc] scoped notation:50 p " ≺ " s => Subsists p s
 
 theorem Subsists.of_mem {p : Possibility W V (Option M)} {s : State W V M}
     (h : p ∈ s) : p ≺ s :=
-  ⟨p, h, Possibility.Descendant.refl p⟩
+  ⟨p, h, le_refl p⟩
 
 /-- `s` subsists in `s'`: the informativeness order, Def. 25's
 projection form — every point of the weaker state has a descendant in
@@ -119,15 +119,15 @@ theorem subsistsIn_trans {s t u : State W V M} (hst : s ⪯ t)
 
 /-- Informativeness ([kamp-vangenabith-reyle-2011] Def. 25): `s'` carries
 at least as much information as `s` — every point of the stronger state
-has an ancestor in the weaker. The absurd state is maximally
+lies above a point of the weaker. The absurd state is maximally
 informative; the eliminative direction, dual to `⪯` on shared strata. -/
 def infoLe (s s' : State W V M) : Prop :=
-  ∀ q ∈ s', ∃ p ∈ s, p.Descendant q
+  ∀ q ∈ s', ∃ p ∈ s, p ≤ q
 
 @[inherit_doc] scoped notation:50 s " ⊑ " s' => infoLe s s'
 
 theorem infoLe_refl (s : State W V M) : s ⊑ s :=
-  fun q hq => ⟨q, hq, Possibility.Descendant.refl q⟩
+  fun q hq => ⟨q, hq, le_refl q⟩
 
 theorem infoLe_trans {s t u : State W V M} (hst : s ⊑ t) (htu : t ⊑ u) :
     s ⊑ u := fun r hr => by
@@ -151,12 +151,12 @@ def State.merge (s s' : State W V M) : State W V M :=
 /-- The merge is above the left component in informativeness. -/
 theorem infoLe_merge_left (s s' : State W V M) : s ⊑ s.merge s' := by
   rintro r ⟨p, hp, q, hq, hpq, rfl⟩
-  exact ⟨p, hp, Possibility.left_descendant_union p q⟩
+  exact ⟨p, hp, Possibility.le_union_left p q⟩
 
 /-- The merge is above the right component in informativeness. -/
 theorem infoLe_merge_right (s s' : State W V M) : s' ⊑ s.merge s' := by
   rintro r ⟨p, hp, q, hq, hpq, rfl⟩
-  exact ⟨q, hq, hpq.right_descendant_union⟩
+  exact ⟨q, hq, hpq.le_union_right⟩
 
 /-- **The merge is the least upper bound** (Def. 26's universal
 property, in the informativeness preorder): anything above both
@@ -165,8 +165,8 @@ theorem merge_infoLe {s s' t : State W V M} (hs : s ⊑ t)
     (hs' : s' ⊑ t) : s.merge s' ⊑ t := fun u hu => by
   obtain ⟨p, hp, hpu⟩ := hs u hu
   obtain ⟨q, hq, hqu⟩ := hs' u hu
-  exact ⟨p.union q, ⟨p, hp, q, hq, hpu.compatible hqu, rfl⟩,
-    hpu.union_descendant hqu⟩
+  exact ⟨p.union q, ⟨p, hp, q, hq, Possibility.compatible_of_le_of_le hpu hqu, rfl⟩,
+    Possibility.union_le hpu hqu⟩
 
 /-- Consistent merge is commutative. -/
 theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s := by
@@ -245,7 +245,7 @@ theorem subsists_iff_mem {X : Set V} {s : State W V M}
     (hs : UniformAt X s) {p : Possibility W V (Option M)}
     (hp : p.dom = X) : (p ≺ s) ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
-    (hpq.eq_of_dom_eq (hp.trans (hs q hq).symm)).symm ▸ hq,
+    (Possibility.eq_of_le_of_dom_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
     Subsists.of_mem⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
@@ -262,8 +262,8 @@ theorem infoLe_iff_superset {X : Set V} {s s' : State W V M}
   constructor
   · intro h q hq
     obtain ⟨p, hp, hpq⟩ := h q hq
-    rwa [← hpq.eq_of_dom_eq ((hs p hp).trans (hs' q hq).symm)]
-  · exact fun h q hq => ⟨q, h hq, Possibility.Descendant.refl q⟩
+    rwa [← Possibility.eq_of_le_of_dom_eq hpq ((hs p hp).trans (hs' q hq).symm)]
+  · exact fun h q hq => ⟨q, h hq, le_refl q⟩
 
 /-- Within one stratum, merge is intersection: compatibility on a shared
 domain forces equality. -/
@@ -304,10 +304,10 @@ theorem subsistsIn_iff_subset_restrict {X : Set V}
   · intro h p hp
     obtain ⟨q, hq, hpq⟩ := h p hp
     exact ⟨q, hq,
-      ((Possibility.descendant_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
+      ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
   · rintro h p hp
     obtain ⟨q, hq, rfl⟩ := h hp
-    exact ⟨q, hq, Possibility.restrict_descendant X q⟩
+    exact ⟨q, hq, Possibility.restrict_le X q⟩
 
 /-- Informativeness out of a stratum factors through reindexing: the
 restricted image of the stronger is included in the weaker — the
@@ -319,10 +319,10 @@ theorem infoLe_iff_restrict_subset {X : Set V}
   constructor
   · rintro h r ⟨q, hq, rfl⟩
     obtain ⟨p, hp, hpq⟩ := h q hq
-    rwa [← (Possibility.descendant_iff_eq_restrict (hs p hp)).mp hpq]
+    rwa [← (Possibility.le_iff_eq_restrict (hs p hp)).mp hpq]
   · intro h q hq
     exact ⟨q.restrict X, h ⟨q, hq, rfl⟩,
-      Possibility.restrict_descendant X q⟩
+      Possibility.restrict_le X q⟩
 
 end Fibred
 
@@ -336,7 +336,7 @@ original. -/
 theorem subsistsIn_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
     (I : State W V M) : I.restrict X ⪯ I := by
   rintro p ⟨q, hq, rfl⟩
-  exact ⟨q, hq, Possibility.restrict_descendant X q⟩
+  exact ⟨q, hq, Possibility.restrict_le X q⟩
 
 /-- Restriction meets the stratification. -/
 theorem uniformAt_restrict {X Y : Set V} [∀ v, Decidable (v ∈ X)]

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -115,7 +115,7 @@ the `Y`-stratum through the transition, worlds preserved. Index-free:
 both sides are plain states. -/
 def applyState (u : Transition W M X Y) (I : State W V M) :
     State W V M :=
-  {q | q.dom = Y ∧ ∃ p ∈ I, p.dom = X ∧
+  {q | q.domain = Y ∧ ∃ p ∈ I, p.domain = X ∧
     p.world = q.world ∧
     ∃ (e : X → M) (e' : Y → M),
       (∀ v : X, p.assignment v.1 = some (e v)) ∧
@@ -133,10 +133,10 @@ private def ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) 
     Possibility W V (Option M) :=
   ⟨w, fun v => if hv : v ∈ Y then some (e ⟨v, hv⟩) else none⟩
 
-private theorem dom_ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) :
-    (ptOf Y w e).dom = Y := by
+private theorem domain_ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) :
+    (ptOf Y w e).domain = Y := by
   ext v
-  by_cases hv : v ∈ Y <;> simp [ptOf, Possibility.dom, hv]
+  by_cases hv : v ∈ Y <;> simp [ptOf, Possibility.domain, hv]
 
 /-- Root application is functorial. -/
 theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
@@ -145,8 +145,8 @@ theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
   ext q
   constructor
   · rintro ⟨hq, p, hpI, hp, hw, e, e'', he, he'', k, huk, hkv⟩
-    refine ⟨hq, ptOf Y q.world k, ⟨dom_ptOf .., p, hpI, hp, hw, e, k, he,
-      fun x => ?_, huk⟩, dom_ptOf .., rfl, k, e'', fun x => ?_, he'', hkv⟩
+    refine ⟨hq, ptOf Y q.world k, ⟨domain_ptOf .., p, hpI, hp, hw, e, k, he,
+      fun x => ?_, huk⟩, domain_ptOf .., rfl, k, e'', fun x => ?_, he'', hkv⟩
     · simp [ptOf]
     · simp [ptOf]
   · rintro ⟨hq, m, ⟨hm, p, hpI, hp, hw, e, k, he, hk, huk⟩, -, hmw, k', e'',
@@ -190,7 +190,7 @@ theorem uniformEquiv_applyState [∀ v, Decidable (v ∈ X)] (u : Transition W M
   · rintro ⟨e, hmem, hrel⟩
     have hpI : ptOf X f.1 e ∈ I := hmem
     show ptOf Y f.1 f.2 ∈ u.applyState I
-    exact ⟨dom_ptOf .., ptOf X f.1 e, hpI, dom_ptOf .., by simp [ptOf], e,
+    exact ⟨domain_ptOf .., ptOf X f.1 e, hpI, domain_ptOf .., by simp [ptOf], e,
       f.2, fun v => by simp [ptOf], fun v => by simp [ptOf],
       by exact hrel⟩
 

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -32,25 +32,25 @@ cited there).
 
 namespace DynamicSemantics
 
-variable {W V M : Type*} {X Y Z : Finset V}
+variable {W V M : Type*} {X Y Z : Set V}
 
 /-- A transition: a world-indexed relation from `X`-assignments to
 `Y`-assignments. The `grow` field makes arrows context-extending —
 bases never shrink. -/
-@[ext] structure Transition (W M : Type*) {V : Type*} (X Y : Finset V) where
+@[ext] structure Transition (W M : Type*) {V : Type*} (X Y : Set V) where
   /-- The world-indexed relation between input and output assignments. -/
-  rel : W → ((↑X : Set V) → M) → ((↑Y : Set V) → M) → Prop
+  rel : W → (X → M) → (Y → M) → Prop
   /-- Bases only grow along an update. -/
   grow : X ⊆ Y
 
 namespace Transition
 
 /-- The identity transition at `X`: equality of assignments. -/
-def id (X : Finset V) : Transition W M X X where
+def id (X : Set V) : Transition W M X X where
   rel _ e e' := e = e'
   grow := subset_rfl
 
-@[simp] theorem rel_id {w : W} {e e' : (↑X : Set V) → M} :
+@[simp] theorem rel_id {w : W} {e e' : X → M} :
     (id X : Transition W M X X).rel w e e' ↔ e = e' := Iff.rfl
 
 /-- Sequencing: world-pointwise relational composition. -/
@@ -68,7 +68,7 @@ def comp (u : Transition W M X Y) (v : Transition W M Y Z) :
   exact ⟨fun ⟨k, hk, hke⟩ => hke ▸ hk, fun h => ⟨e', h, rfl⟩⟩
 
 theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
-    {Z' : Finset V} (t : Transition W M Z Z') :
+    {Z' : Set V} (t : Transition W M Z Z') :
     (u.comp v).comp t = u.comp (v.comp t) := by
   ext w e e'
   exact ⟨fun ⟨k, ⟨j, hj, hjk⟩, hk⟩ => ⟨j, hj, k, hjk, hk⟩,
@@ -80,23 +80,23 @@ theorem comp_assoc (u : Transition W M X Y) (v : Transition W M Y Z)
 presheaf fibers: relate assignments through the transition, worlds
 preserved. -/
 def apply (u : Transition W M X Y)
-    (T : Set (W × ((↑X : Set V) → M))) :
-    Set (W × ((↑Y : Set V) → M)) :=
+    (T : Set (W × (X → M))) :
+    Set (W × (Y → M)) :=
   {e' | ∃ e, (e'.1, e) ∈ T ∧ u.rel e'.1 e e'.2}
 
 theorem mem_apply {u : Transition W M X Y}
-    {T : Set (W × ((↑X : Set V) → M))} {w : W} {g : (↑Y : Set V) → M} :
+    {T : Set (W × (X → M))} {w : W} {g : Y → M} :
     (w, g) ∈ u.apply T ↔ ∃ e, (w, e) ∈ T ∧ u.rel w e g := Iff.rfl
 
 /-- Applying the identity transition is the identity. -/
-@[simp] theorem apply_id (T : Set (W × ((↑X : Set V) → M))) :
+@[simp] theorem apply_id (T : Set (W × (X → M))) :
     (id X).apply T = T := by
   ext ⟨w, e⟩
   exact ⟨fun ⟨k, hk, hke⟩ => (show k = e from hke) ▸ hk, fun h => ⟨e, h, rfl⟩⟩
 
 /-- `apply` is functorial: sequencing then applying is applying twice. -/
 theorem apply_comp (u : Transition W M X Y) (v : Transition W M Y Z)
-    (T : Set (W × ((↑X : Set V) → M))) :
+    (T : Set (W × (X → M))) :
     (u.comp v).apply T = v.apply (u.apply T) := by
   ext ⟨w, h⟩
   constructor
@@ -115,28 +115,28 @@ the `Y`-stratum through the transition, worlds preserved. Index-free:
 both sides are plain states. -/
 def applyState (u : Transition W M X Y) (I : State W V M) :
     State W V M :=
-  {q | q.dom = (↑Y : Set V) ∧ ∃ p ∈ I, p.dom = (↑X : Set V) ∧
+  {q | q.dom = Y ∧ ∃ p ∈ I, p.dom = X ∧
     p.world = q.world ∧
-    ∃ (e : (↑X : Set V) → M) (e' : (↑Y : Set V) → M),
-      (∀ v : (↑X : Set V), p.assignment v.1 = some (e v)) ∧
-      (∀ v : (↑Y : Set V), q.assignment v.1 = some (e' v)) ∧
+    ∃ (e : X → M) (e' : Y → M),
+      (∀ v : X, p.assignment v.1 = some (e v)) ∧
+      (∀ v : Y, q.assignment v.1 = some (e' v)) ∧
       u.rel q.world e e'}
 
 /-- Application lands in the target stratum. -/
 theorem uniformAt_applyState (u : Transition W M X Y) (I : State W V M) :
     State.UniformAt Y (u.applyState I) := fun _ hq => hq.1
 
-variable [DecidableEq V]
+variable [∀ v, Decidable (v ∈ Y)]
 
 /-- The point of the `Y`-stratum carrying a given world and assignment. -/
-private def ptOf (Y : Finset V) (w : W) (e : (↑Y : Set V) → M) :
+private def ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) :
     Possibility W V (Option M) :=
-  ⟨w, fun v => if hv : v ∈ (↑Y : Set V) then some (e ⟨v, hv⟩) else none⟩
+  ⟨w, fun v => if hv : v ∈ Y then some (e ⟨v, hv⟩) else none⟩
 
-private theorem dom_ptOf (Y : Finset V) (w : W) (e : (↑Y : Set V) → M) :
-    (ptOf Y w e).dom = (↑Y : Set V) := by
+private theorem dom_ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) :
+    (ptOf Y w e).dom = Y := by
   ext v
-  by_cases hv : v ∈ (↑Y : Set V) <;> simp [ptOf, Possibility.dom, hv]
+  by_cases hv : v ∈ Y <;> simp [ptOf, Possibility.dom, hv]
 
 /-- Root application is functorial. -/
 theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
@@ -166,7 +166,7 @@ theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
 `X`-stratum, the regular CCP `applyState` is `apply`, transported along
 `State.uniformEquiv` — the relational collapse computes the root-state
 update. -/
-theorem uniformEquiv_applyState (u : Transition W M X Y)
+theorem uniformEquiv_applyState [∀ v, Decidable (v ∈ X)] (u : Transition W M X Y)
     {I : State W V M} (hI : State.UniformAt X I) :
     State.uniformEquiv Y ⟨u.applyState I, uniformAt_applyState u I⟩ =
       u.apply (State.uniformEquiv X ⟨I, hI⟩) := by
@@ -182,7 +182,7 @@ theorem uniformEquiv_applyState (u : Transition W M X Y)
     show ptOf X f.1 e ∈ I
     have hpeq : ptOf X f.1 e = p := by
       refine Possibility.ext (by exact hw.symm) (funext fun v => ?_)
-      by_cases hv : v ∈ (↑X : Set V)
+      by_cases hv : v ∈ X
       · exact (dif_pos hv).trans (hpe ⟨v, hv⟩).symm
       · exact (dif_neg hv).trans
           (Option.not_isSome_iff_eq_none.mp fun hs => hv (hpX ▸ hs)).symm
@@ -202,11 +202,11 @@ end ApplyState
 reset `k[x]g`, [heim-1982]'s indefinite widening): preserve the input off
 `x`, leave the output free at `x` — the generating arrow
 `X ⟶ insert x X` of context extension. -/
-def randomAssign [DecidableEq V] (X : Finset V) (x : V) :
+def randomAssign (X : Set V) (x : V) :
     Transition W M X (insert x X) where
   rel _ e e' := ∀ (v : V) (hv : v ∈ X), v ≠ x →
-    e ⟨v, hv⟩ = e' ⟨v, Finset.mem_insert_of_mem hv⟩
-  grow := Finset.subset_insert x X
+    e ⟨v, hv⟩ = e' ⟨v, Set.mem_insert_of_mem x hv⟩
+  grow := Set.subset_insert x X
 
 /-! ### Typing total-assignment relations
 
@@ -223,27 +223,27 @@ section OfTotal
 variable {R S : W → (V → M) → (V → M) → Prop}
 
 /-- The relation reads its input only at `X`. -/
-def ReadsAt (X : Finset V) (R : W → (V → M) → (V → M) → Prop) : Prop :=
-  ∀ ⦃w f f' g⦄, Set.EqOn f f' (↑X : Set V) → (R w f g ↔ R w f' g)
+def ReadsAt (X : Set V) (R : W → (V → M) → (V → M) → Prop) : Prop :=
+  ∀ ⦃w f f' g⦄, Set.EqOn f f' X → (R w f g ↔ R w f' g)
 
 /-- The relation constrains its output only at `Y`. -/
-def WritesAt (Y : Finset V) (R : W → (V → M) → (V → M) → Prop) : Prop :=
-  ∀ ⦃w f g g'⦄, Set.EqOn g g' (↑Y : Set V) → (R w f g ↔ R w f g')
+def WritesAt (Y : Set V) (R : W → (V → M) → (V → M) → Prop) : Prop :=
+  ∀ ⦃w f g g'⦄, Set.EqOn g g' Y → (R w f g ↔ R w f g')
 
 /-- Type a total-assignment relation at contexts, by existential
 extension of the assignments. -/
 def ofTotal (h : X ⊆ Y) (R : W → (V → M) → (V → M) → Prop) :
     Transition W M X Y where
-  rel w e e' := ∃ f g : V → M, (↑X : Set V).restrict f = e ∧
-    (↑Y : Set V).restrict g = e' ∧ R w f g
+  rel w e e' := ∃ f g : V → M, X.restrict f = e ∧
+    Y.restrict g = e' ∧ R w f g
   grow := h
 
 /-- Under the support hypotheses, the typing is faithful: related
 assignments are exactly the restrictions of related assignments. -/
 theorem ofTotal_rel_restrict {h : X ⊆ Y} (hR : ReadsAt X R)
     (hW : WritesAt Y R) {w : W} {f g : V → M} :
-    (ofTotal h R).rel w ((↑X : Set V).restrict f)
-      ((↑Y : Set V).restrict g) ↔ R w f g := by
+    (ofTotal h R).rel w (X.restrict f)
+      (Y.restrict g) ↔ R w f g := by
   constructor
   · rintro ⟨f', g', hf', hg', hR'⟩
     rw [hR (Set.restrict_eq_restrict_iff.mp hf'),
@@ -264,7 +264,7 @@ theorem ofTotal_comp {h₁ : X ⊆ Y} {h₂ : Y ⊆ Z} (hS : ReadsAt Y S) :
     rw [← hf₂] at hg₁
     exact (hS (Set.restrict_eq_restrict_iff.mp hg₁)).mpr hS'
   · rintro ⟨f, g, hf, hg, k, hR, hS'⟩
-    exact ⟨(↑Y : Set V).restrict k, ⟨f, k, hf, rfl, hR⟩,
+    exact ⟨Y.restrict k, ⟨f, k, hf, rfl, hR⟩,
       ⟨k, g, rfl, hg, hS'⟩⟩
 
 end OfTotal
@@ -272,19 +272,19 @@ end OfTotal
 /-! ### Repackaging along base equalities
 
 The substrate-safe form of `eqToHom` conjugation (mathlib's `Filter.copy`
-pattern): composites whose indices differ by `Finset` identities — e.g.
+pattern): composites whose indices differ by base identities — e.g.
 `(X ∪ U₁) ∪ U₂` against `X ∪ (U₁ ∪ U₂)` — are equated through `copy`,
 keeping cast-free statements everywhere below the category layer. -/
 
 /-- Repackage a transition along equalities of its bases. -/
-def copy (u : Transition W M X Y) {X' Y' : Finset V} (hX : X = X')
+def copy (u : Transition W M X Y) {X' Y' : Set V} (hX : X = X')
     (hY : Y = Y') : Transition W M X' Y' :=
   hX ▸ hY ▸ u
 
 @[simp] theorem copy_rfl (u : Transition W M X Y) : u.copy rfl rfl = u := rfl
 
 @[simp] theorem copy_copy (u : Transition W M X Y)
-    {X' Y' X'' Y'' : Finset V} (hX : X = X') (hY : Y = Y')
+    {X' Y' X'' Y'' : Set V} (hX : X = X') (hY : Y = Y')
     (hX' : X' = X'') (hY' : Y' = Y'') :
     (u.copy hX hY).copy hX' hY' = u.copy (hX.trans hX') (hY.trans hY') := by
   subst hX hY hX' hY'
@@ -298,20 +298,20 @@ theorem ofTotal_congr {R R' : W → (V → M) → (V → M) → Prop}
 
 /-- Typed relations repackage by re-proving the growth. -/
 theorem ofTotal_copy {R : W → (V → M) → (V → M) → Prop} {h : X ⊆ Y}
-    {Y' : Finset V} (hY : Y = Y') :
+    {Y' : Set V} (hY : Y = Y') :
     (ofTotal h R).copy rfl hY = ofTotal (hY ▸ h) R := by
   subst hY
   rfl
 
 /-- Repackaged transitions compose to the repackaged composite. -/
 theorem copy_comp_copy (u : Transition W M X Y) (v : Transition W M Y Z)
-    {X' Y' Z' : Finset V} (hX : X = X') (hY : Y = Y') (hZ : Z = Z') :
+    {X' Y' Z' : Set V} (hX : X = X') (hY : Y = Y') (hZ : Z = Z') :
     (u.copy hX hY).comp (v.copy hY hZ) = (u.comp v).copy hX hZ := by
   subst hX hY hZ
   rfl
 
 /-- Application is invariant under repackaging. -/
-@[simp] theorem apply_copy (u : Transition W M X Y) {X' Y' : Finset V}
+@[simp] theorem apply_copy (u : Transition W M X Y) {X' Y' : Set V}
     (hX : X = X') (hY : Y = Y') (T : Set (W × ((↑X' : Set V) → M))) :
     (u.copy hX hY).apply T = (by subst hX hY; exact u.apply T) := by
   subst hX hY
@@ -319,7 +319,7 @@ theorem copy_comp_copy (u : Transition W M X Y) (v : Transition W M Y Z)
 
 /-- Root application is invariant under repackaging. -/
 @[simp] theorem applyState_copy [DecidableEq V] (u : Transition W M X Y)
-    {X' Y' : Finset V} (hX : X = X') (hY : Y = Y') (I : State W V M) :
+    {X' Y' : Set V} (hX : X = X') (hY : Y = Y') (I : State W V M) :
     (u.copy hX hY).applyState I = u.applyState I := by
   subst hX hY
   rfl

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -22,7 +22,7 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 
 ## Main definitions
 
-- `Possibility.Descendant`, `Subsists` (`≺`), `subsistsIn` (`⪯`):
+- the descent order, `Subsists` (`≺`), `subsistsIn` (`⪯`):
   descendance and subsistence (Def. 3.3, after
   [groenendijk-stokhof-veltman-1996]).
 - `worlds`, `Familiar`: worldly information (Def. 3.1's 𝒲) and
@@ -48,7 +48,7 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 
 ## Implementation notes
 
-Descendance requires the descendant to *extend* the assignment, per
+Descent requires the larger point to *extend* the assignment, per
 [groenendijk-stokhof-veltman-1996]; [elliott-sudo-2025]'s Def. 3.3
 phrases the clause as domain inclusion, and their examples do not
 discriminate. The paper overloads `≺` for possibility-in-state and

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -326,7 +326,7 @@ open DynamicSemantics
 /-- The anticorrelation state on two referents: points defining exactly
 `{i, j}`, with distinct values. -/
 private def anti (i j : Fin 3) : State Unit (Fin 3) Bool :=
-  {p | p.dom = (↑({i, j} : Finset (Fin 3)) : Set (Fin 3)) ∧
+  {p | p.dom = ({i, j} : Set (Fin 3)) ∧
     p.assignment i ≠ p.assignment j}
 
 /-- A two-referent point. -/
@@ -403,13 +403,13 @@ theorem no_gluing_triangle :
     obtain ⟨hdom, hne⟩ := hmem
     rw [Possibility.dom_restrict] at hdom
     have hi : (r.assignment i).isSome := by
-      have : i ∈ (↑({i, j} : Finset (Fin 3)) : Set (Fin 3)) ∩
+      have : i ∈ ({i, j} : Set (Fin 3)) ∩
           Possibility.dom r := by
         rw [hdom]
         simp
       exact this.2
     have hj : (r.assignment j).isSome := by
-      have : j ∈ (↑({i, j} : Finset (Fin 3)) : Set (Fin 3)) ∩
+      have : j ∈ ({i, j} : Set (Fin 3)) ∩
           Possibility.dom r := by
         rw [hdom]
         simp

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -326,7 +326,7 @@ open DynamicSemantics
 /-- The anticorrelation state on two referents: points defining exactly
 `{i, j}`, with distinct values. -/
 private def anti (i j : Fin 3) : State Unit (Fin 3) Bool :=
-  {p | p.dom = ({i, j} : Set (Fin 3)) ∧
+  {p | p.domain = ({i, j} : Set (Fin 3)) ∧
     p.assignment i ≠ p.assignment j}
 
 /-- A two-referent point. -/
@@ -339,9 +339,9 @@ private theorem pt2_mem_anti {i j : Fin 3} (hij : i ≠ j) (a b : Bool)
   refine ⟨?_, ?_⟩
   · ext v
     by_cases hvi : v = i
-    · simp [pt2, Possibility.dom, hvi]
+    · simp [pt2, Possibility.domain, hvi]
     · by_cases hvj : v = j <;>
-        simp [pt2, Possibility.dom, hvi, hvj, hij.symm]
+        simp [pt2, Possibility.domain, hvi, hvj, hij.symm]
   · simp only [pt2, if_neg hij.symm]
     exact fun h => hab (Option.some.injEq .. ▸ h :)
 
@@ -401,16 +401,16 @@ theorem no_gluing_triangle :
       rw [← hS]
       exact ⟨r, hr, rfl⟩
     obtain ⟨hdom, hne⟩ := hmem
-    rw [Possibility.dom_restrict] at hdom
+    rw [Possibility.domain_restrict] at hdom
     have hi : (r.assignment i).isSome := by
       have : i ∈ ({i, j} : Set (Fin 3)) ∩
-          Possibility.dom r := by
+          Possibility.domain r := by
         rw [hdom]
         simp
       exact this.2
     have hj : (r.assignment j).isSome := by
       have : j ∈ ({i, j} : Set (Fin 3)) ∩
-          Possibility.dom r := by
+          Possibility.domain r := by
         rw [hdom]
         simp
       exact this.2

--- a/Linglib/Studies/GroenendijkStokhof1991.lean
+++ b/Linglib/Studies/GroenendijkStokhof1991.lean
@@ -475,7 +475,7 @@ section IndexedReading
 
 open DynamicSemantics DynamicSemantics.Update
 
-variable {W : Type*} {X Y : Finset ℕ}
+variable {W : Type*} {X Y : Set ℕ}
 
 /-- A DPL relation as a transition at contexts, worlds inert, via the
 substrate's total–typed bridge. -/
@@ -485,15 +485,15 @@ def toTransition (h : X ⊆ Y) (φ : DPLRel E) : Transition W E X Y :=
 /-- A DPL test as a transition: a condition on the context, checked
 without changing the environment. Clauses 1–3, 5, 6, and 8 of
 Definition 2 are all of this form. -/
-def testTransition (X : Finset ℕ) (C : ((↑X : Set ℕ) → E) → Prop) :
+def testTransition (X : Set ℕ) (C : (X → E) → Prop) :
     Transition W E X X where
   rel _ e e' := e = e' ∧ C e
   grow := subset_rfl
 
 /-- Applying a test filters the fiber — the indexed form of
 Definition 2's test clauses. -/
-theorem testTransition_apply {C : ((↑X : Set ℕ) → E) → Prop}
-    (T : Set (W × ((↑X : Set ℕ) → E))) :
+theorem testTransition_apply {C : (X → E) → Prop}
+    (T : Set (W × (X → E))) :
     (testTransition X C).apply T = {e ∈ T | C e.2} := by
   ext ⟨w, e⟩
   constructor
@@ -505,7 +505,7 @@ theorem testTransition_apply {C : ((↑X : Set ℕ) → E) → Prop}
 
 /-- Clause 4 is transition composition: with the second conjunct reading
 within its context, typed sequencing is DPL conjunction. -/
-theorem toTransition_comp {Z : Finset ℕ} (h₁ : X ⊆ Y) (h₂ : Y ⊆ Z)
+theorem toTransition_comp {Z : Set ℕ} (h₁ : X ⊆ Y) (h₂ : Y ⊆ Z)
     {φ ψ : DPLRel E}
     (hψ : Transition.ReadsAt (W := W) Y fun _ => ψ) :
     (toTransition (W := W) h₁ φ).comp (toTransition h₂ ψ) =
@@ -519,7 +519,7 @@ reset's underspecification off `x` collapse to Definition 2's `∃d`. -/
 theorem randomAssign_comp_toTransition {x : ℕ} (h : insert x X ⊆ Y)
     (φ : DPLRel E) :
     (Transition.randomAssign X x).comp (toTransition (W := W) h φ) =
-      toTransition ((Finset.subset_insert x X).trans h)
+      toTransition ((Set.subset_insert x X).trans h)
         (DPLRel.exists_ x φ) := by
   ext w e e''
   constructor
@@ -533,8 +533,8 @@ theorem randomAssign_comp_toTransition {x : ℕ} (h : insert x X ⊆ Y)
           exact Function.update_self ..
         · show Function.update f x (e ⟨x, hx⟩) v.1 = e v
           rw [Function.update_of_ne hvx]
-          have h1 : f v.1 = e' ⟨v.1, Finset.mem_insert_of_mem v.2⟩ :=
-            congrFun hf ⟨v.1, Finset.mem_insert_of_mem v.2⟩
+          have h1 : f v.1 = e' ⟨v.1, Set.mem_insert_of_mem x v.2⟩ :=
+            congrFun hf ⟨v.1, Set.mem_insert_of_mem x v.2⟩
           rw [h1]
           exact (hmid v.1 v.2 hvx).symm
       · have hff : (fun n => if n = x then f x
@@ -547,8 +547,8 @@ theorem randomAssign_comp_toTransition {x : ℕ} (h : insert x X ⊆ Y)
         exact hφ
     · refine ⟨f, g, funext fun v => ?_, hg, f x, ?_⟩
       · show f v.1 = e v
-        have h1 : f v.1 = e' ⟨v.1, Finset.mem_insert_of_mem v.2⟩ :=
-          congrFun hf ⟨v.1, Finset.mem_insert_of_mem v.2⟩
+        have h1 : f v.1 = e' ⟨v.1, Set.mem_insert_of_mem x v.2⟩ :=
+          congrFun hf ⟨v.1, Set.mem_insert_of_mem x v.2⟩
         rw [h1]
         exact (hmid v.1 v.2 fun hvx => hx (hvx ▸ v.2)).symm
       · have hff : (fun n => if n = x then f x else f n) = f :=

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -893,7 +893,7 @@ def toIndexedState (V M : Type*) (s : Set W) :
 theorem uniformAt_toIndexedState :
     State.UniformAt ∅ (toIndexedState V M s) := fun p hp => by
   ext v
-  simp [Possibility.dom, hp.2 v]
+  simp [Possibility.domain, hp.2 v]
 
 /-- The embedding is faithful on worldly content. -/
 @[simp] theorem worlds_toIndexedState :

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -915,7 +915,7 @@ theorem toIndexedState_infoLe_iff :
     have hs := hp.1
     rwa [hpq.1] at hs
   · rintro h q ⟨hq, hnone⟩
-    exact ⟨q, ⟨h hq, hnone⟩, Possibility.Descendant.refl q⟩
+    exact ⟨q, ⟨h hq, hnone⟩, le_refl q⟩
 
 /-- Propositional update ([veltman-1996]'s elimination) transports to
 point filtering. -/


### PR DESCRIPTION
Generalizes the dynamic-semantics substrate from `Finset V` to `Set V` granularities, keeping `Finset` only where syntax demands it (DRS universes, interpreted through the coercion). Matches KvGR — states are relative to arbitrary sets of referents; finiteness comes from finite texts — and uses the `Set.piecewise` pattern (`[∀ v, Decidable (v ∈ X)]` instance arguments) so the substrate stays constructive and Finset call-sites discharge instances automatically.

- Descent is inlined as the canonical `Preorder` on partial points (sup-style names: `le_union_left`, `union_le`, …); `Based` dissolves — the Grothendieck total (`elementsEquivPoints`) is now over *all* points, every point lying over its own domain.
- Instantiation equivalences for the update-semantics varieties: `worldEquiv` (propositional update semantics), `assignmentEquiv` (lifted DPL); the inquisitive variety is the powerset level-shift, documented.
- `Possibility.update` refactored to projection lemmas (`update_assignment`/`update_world`), letting `Function.update`'s simp set do the case work; module docstring cut to mathlib register.