### PR TITLE
refactor(Semantics/Dynamic): possibilities on Part; Flat in WithBot mold

### DIFF
--- a/Linglib/Core/Logic/Trivalent.lean
+++ b/Linglib/Core/Logic/Trivalent.lean
@@ -569,7 +569,7 @@ def equivFlatBool : Trivalent ≃ Flat Bool where
   toFun := toFlat
   invFun := ofFlat
   left_inv a := by cases a <;> rfl
-  right_inv x := by cases x with | none => rfl | some b => cases b <;> rfl
+  right_inv x := by cases x with | bot => rfl | coe b => cases b <;> rfl
 
 /-- The truth order and the knowledge order genuinely differ: in the truth order
 `false ≤ indet`, but in the knowledge order the committed value `false` is not below

--- a/Linglib/Core/Order/Flat.lean
+++ b/Linglib/Core/Order/Flat.lean
@@ -2,46 +2,36 @@ import Mathlib.Order.OmegaCompletePartialOrder
 import Linglib.Core.Order.PartialUnify
 
 /-!
-# The flat domain
+# The flat order
 
-`Flat α` is `Option α` carrying the *flat* order: `⊥` (`none`, no information)
-below everything, distinct values incomparable. An order-carrying alias in the
-`WithBot` mold, but the underlying order is *discrete*, not lifted — committed
-values are an antichain.
+`Flat α` is `Option α` with the flat order: `⊥` below everything, distinct
+values incomparable. It is the lift of the discrete order on `α` — the order
+of partial values under extension — and is mathlib's order on `Part α`
+carried on its decidable twin `Option` (`le_iff_ofOption_le`), where it
+supports `DecidableEq`, `DecidableLE`, `#eval`, and constructor
+pattern-matching. "Flat domain" is the domain-theory name for this poset
+([winskel-1993]; the `flat` class of Isabelle/HOLCF).
 
-This is the **free (Scott) domain on a set**: the lift of the discrete order,
-`Flat = lift ∘ discrete`, equivalently `1 + α` as an object. Two facts make it
-the canonical small domain rather than an ad-hoc gadget:
+The flat order is bounded-complete but not a lattice: meets are total
+(`SemilatticeInf`), joins partial (`PartialUnify`). It is ω-complete
+(`OmegaCompletePartialOrder`), every chain being eventually constant.
+Linguistically it is one atomic feature slot, ordered by [shieber-1986]'s and
+[carpenter-1992]'s subsumption; `Flat Bool` is the knowledge order of Kleene
+three-valued logic. Feature bundles arise via the `Pi` `PartialUnify`
+instance, with `Compat` as consistency.
 
-* it is **bounded-complete but not a lattice** — meets are total
-  (`SemilatticeInf`, agreement or `⊥`) while joins are *partial*
-  (`PartialUnify`: `⊥` is identity, equal commitments merge, distinct
-  commitments have no upper bound). Bounded-completeness *is* the join being
-  partial-yet-unique-when-defined;
-* it is **ω-complete** (`OmegaCompletePartialOrder`) — chains are eventually
-  constant, so they have suprema. `Flat` is the generator of domain theory and
-  the order side of the lifting/partiality monad (`Option`), whose Kleisli
-  arrows `α → Flat β` are partial functions — `PartialUnify.unify` among them.
-
-Linguistically it is one atomic feature slot: the order is [shieber-1986]'s and
-[carpenter-1992]'s subsumption order (an *information* order — `⊥` = unmarked,
-a wildcard for agreement), and `Flat Bool` is the knowledge order of Kleene
-three-valued logic. Feature bundles are built from it by the `Pi` `PartialUnify`
-instance; `Compat` is consistency.
-
-The order skeleton (`Option.FlatLE`, `Flat`, the `PartialOrder`/`OrderBot`/
-`SemilatticeInf`/`OmegaCompletePartialOrder` instances) is an `[UPSTREAM]`
-candidate for `Mathlib/Order/Flat.lean` — root-level `Flat` as with `WithBot`,
-coexisting with the existing namespaced `Module.Flat` and `ConvexCone.Flat`
-(write `_root_.Flat` under `open Module`). The `PartialUnify` instance and
-`compat_iff` stay here: `PartialUnify` is linglib's, not mathlib's.
+The order skeleton follows the `WithBot` mold (`Mathlib/Order/TypeTags.lean`,
+`Mathlib/Order/WithBot.lean`) and is an `[UPSTREAM]` candidate for
+`Mathlib/Order/Flat.lean`, coexisting with the namespaced `Module.Flat` and
+`ConvexCone.Flat`. The `PartialUnify` instance and `compat_iff` stay here.
 
 ## Main declarations
 
-* `Option.FlatLE` — the flat order as a relation on `Option α`
-* `Flat` — the order-carrying alias, with `PartialOrder`, `OrderBot`,
-  `SemilatticeInf`, `OmegaCompletePartialOrder`, and `PartialUnify` instances
+* `Flat` — the order-carrying alias, with coercion `↑ : α → Flat α`, and
+  `PartialOrder`, `OrderBot`, `SemilatticeInf`, `OmegaCompletePartialOrder`,
+  and `PartialUnify` instances
 * `Flat.coe_le_coe`, `Flat.not_coe_le_bot` — the order, characterized
+* `Flat.or` — left-biased total merge, with `le_or_left`/`or_le`
 * `Flat.ωSup_mem_range` — chains attain their supremum (the domain has height ≤ 2)
 * `Flat.ωScottContinuous_of_monotone` — monotone maps out of `Flat` are continuous
 * `Flat.liftEquiv` — the free-domain universal property: functions `α → D` are
@@ -69,73 +59,30 @@ The free-domain universal property is now `liftEquiv` (with its enabling lemma
 * **Three-valued logic.** `Flat Bool` is the knowledge order of Kleene
   three-valued logic; the strong-Kleene connectives are exactly its continuous
   maps. Connects this substrate to the trivalence/presupposition layer.
-
-Ergonomics, separately: add a coercion `↑ : α → Flat α` (as `WithBot.some`) so
-`coe_le_coe`/`not_coe_le_bot` need no explicit `@LE.le`, and move the order
-relation out of the `Option` namespace (`Option.FlatLE → Flat.LE`).
+* An inductive `Flat.LT` in the `WithBot.LT` mold, for upstreaming.
 -/
 
-/-- The flat information order on an atomic feature slot: every
-committed value persists upward, so `none` is below everything and
-distinct atoms are incomparable. This is `Part`'s partial order,
-carried on `Option` for computability (`flatLE_iff_ofOption_le`). -/
-def Option.FlatLE {α : Type*} (a b : Option α) : Prop :=
-  ∀ x ∈ a, x ∈ b
-
-namespace Option.FlatLE
-
-variable {α : Type*} {a b c : Option α}
-
-protected theorem refl (a : Option α) : a.FlatLE a := λ _ h => h
-
-/-- Flat order preserves definedness. -/
-theorem isSome_mono (h : a.FlatLE b) : a.isSome → b.isSome := fun ha =>
-  Option.isSome_iff_exists.mpr ((Option.isSome_iff_exists.mp ha).imp h)
-
-protected theorem trans (h1 : a.FlatLE b) (h2 : b.FlatLE c) : a.FlatLE c :=
-  λ x hx => h2 x (h1 x hx)
-
-protected theorem antisymm (h1 : a.FlatLE b) (h2 : b.FlatLE a) : a = b := by
-  cases a with
-  | some x => exact (h1 x rfl).symm
-  | none =>
-    cases b with
-    | none => rfl
-    | some y => exact absurd (h2 y rfl) (by simp)
-
-/-- Flat order with no definedness gain is equality. -/
-theorem eq_of_isSome (h : a.FlatLE b) (hb : b.isSome → a.isSome) : a = b :=
-  h.antisymm fun x hx => by
-    obtain ⟨y, hy⟩ := Option.isSome_iff_exists.mp
-      (hb (Option.isSome_iff_exists.mpr ⟨x, hx⟩))
-    rwa [← Option.some_inj.mp ((h y hy).symm.trans hx)]
-
-/-- The flat order is `Part`'s order, along `Part.ofOption`. -/
-theorem flatLE_iff_ofOption_le {a b : Option α} :
-    a.FlatLE b ↔ Part.ofOption a ≤ Part.ofOption b :=
-  ⟨fun h x hx => Part.mem_ofOption.mpr (h x (Part.mem_ofOption.mp hx)),
-    fun h x hx => Part.mem_ofOption.mp (h x (Part.mem_ofOption.mpr hx))⟩
-
-theorem none_le (b : Option α) : Option.FlatLE none b := λ _ h => nomatch h
-
-instance [DecidableEq α] : Decidable (a.FlatLE b) :=
-  match a, b with
-  | none, _ => .isTrue (λ _ h => nomatch h)
-  | some x, some y =>
-    if h : x = y then .isTrue (λ _ hx => by simpa [h] using hx)
-    else .isFalse (λ hle => h (Option.some.inj (hle x rfl)).symm)
-  | some x, none => .isFalse (λ hle => nomatch hle x rfl)
-
-end Option.FlatLE
-
-/-- An atomic feature slot: `Option α` carrying the flat information
-order as its `≤`. A `def`, not an `abbrev`, so the order instances do
-not leak onto bare `Option`. -/
+/-- `Flat α` is `Option α` carrying the flat information order: `⊥` below
+everything, distinct values incomparable. A `def`, not an `abbrev`, so the
+order instances do not leak onto bare `Option`. -/
 def Flat (α : Type*) := Option α
 
 namespace Flat
 
-variable {α : Type*}
+variable {α : Type*} {a b : α} {x y z : Flat α}
+
+/-- The canonical map from `α` into `Flat α`. -/
+@[coe, match_pattern] def some : α → Flat α :=
+  Option.some
+
+instance coe : Coe α (Flat α) :=
+  ⟨some⟩
+
+instance bot : Bot (Flat α) :=
+  ⟨none⟩
+
+instance inhabited : Inhabited (Flat α) :=
+  ⟨⊥⟩
 
 instance [DecidableEq α] : DecidableEq (Flat α) :=
   inferInstanceAs (DecidableEq (Option α))
@@ -147,62 +94,160 @@ instance [BEq α] [LawfulBEq α] : LawfulBEq (Flat α) :=
   inferInstanceAs (LawfulBEq (Option α))
 
 instance [Repr α] : Repr (Flat α) :=
-  inferInstanceAs (Repr (Option α))
+  ⟨fun o _ =>
+    match o with
+    | none => "⊥"
+    | Option.some a => "↑" ++ repr a⟩
 
-instance : Inhabited (Flat α) :=
-  ⟨(none : Option α)⟩
+theorem coe_injective : Function.Injective ((↑) : α → Flat α) :=
+  Option.some_injective _
 
-instance : PartialOrder (Flat α) where
-  le a b := Option.FlatLE a b
-  le_refl := Option.FlatLE.refl
-  le_trans _ _ _ := Option.FlatLE.trans
-  le_antisymm _ _ := Option.FlatLE.antisymm
-
-instance : OrderBot (Flat α) where
-  bot := (none : Option α)
-  bot_le := Option.FlatLE.none_le
-
-instance [DecidableEq α] (a b : Flat α) : Decidable (a ≤ b) :=
-  inferInstanceAs (Decidable (Option.FlatLE a b))
-
-theorem le_def {a b : Flat α} : a ≤ b ↔ Option.FlatLE a b := Iff.rfl
+@[simp, norm_cast] theorem coe_inj : (a : Flat α) = b ↔ a = b :=
+  Option.some_inj
 
 theorem none_eq_bot : (none : Flat α) = (⊥ : Flat α) := rfl
 
-@[simp] theorem coe_le_coe {a b : α} :
-    @LE.le (Flat α) _ (some a) (some b) ↔ a = b := by
-  rw [le_def]
-  refine ⟨λ h => (Option.some.inj (h a rfl)).symm, ?_⟩
-  rintro rfl x hx
-  exact hx
+theorem some_eq_coe (a : α) : (Option.some a : Flat α) = (↑a : Flat α) := rfl
 
-@[simp] theorem not_coe_le_bot (a : α) : ¬ @LE.le (Flat α) _ (some a) ⊥ := by
-  rw [le_def]
-  exact λ h => (Option.some_ne_none a).symm (h a rfl)
+@[simp] theorem bot_ne_coe : ⊥ ≠ (a : Flat α) := nofun
 
-/-- The meet of two slots: their agreement, or nothing. -/
-protected def inf [DecidableEq α] (a b : Flat α) : Flat α :=
-  if (a : Option α) = (b : Option α) then a else (none : Option α)
+@[simp] theorem coe_ne_bot : (a : Flat α) ≠ ⊥ := nofun
+
+/-- Recursor for `Flat` using the preferred forms `⊥` and `↑a`. -/
+@[elab_as_elim, induction_eliminator, cases_eliminator]
+def recBotCoe {C : Flat α → Sort*} (bot : C ⊥) (coe : ∀ a : α, C a) : ∀ x : Flat α, C x
+  | ⊥ => bot
+  | (a : α) => coe a
+
+@[simp] theorem recBotCoe_bot {C : Flat α → Sort*} (d : C ⊥) (f : ∀ a : α, C a) :
+    @recBotCoe _ C d f ⊥ = d := rfl
+
+@[simp] theorem recBotCoe_coe {C : Flat α → Sort*} (d : C ⊥) (f : ∀ a : α, C a) (x : α) :
+    @recBotCoe _ C d f ↑x = f x := rfl
+
+theorem ne_bot_iff_exists : x ≠ ⊥ ↔ ∃ a : α, x = ↑a := by
+  cases x <;> simp
+
+/-! ### The flat order -/
+
+/-- Auxiliary definition for the order on `Flat`. -/
+@[mk_iff le_def_aux]
+protected inductive LE : Flat α → Flat α → Prop
+  | protected bot_le (x : Flat α) : Flat.LE ⊥ x
+  | protected refl (a : α) : Flat.LE ↑a ↑a
+
+/-- The flat order on `Flat α`, defined by `⊥ ≤ x` and `↑a ≤ ↑a`. The
+definition as an inductive predicate follows `WithBot.LE`; it cannot be
+accidentally unfolded too far. -/
+instance (priority := 10) instLE : LE (Flat α) where le := Flat.LE
+
+lemma le_def : x ≤ y ↔ x = ⊥ ∨ ∃ a : α, x = ↑a ∧ y = ↑a := by
+  rw [show (x ≤ y) = Flat.LE x y from rfl, le_def_aux]
+
+@[simp, norm_cast] theorem coe_le_coe : (a : Flat α) ≤ b ↔ a = b :=
+  ⟨fun h => by cases h; rfl, fun h => h ▸ .refl a⟩
+
+@[simp] theorem not_coe_le_bot (a : α) : ¬(a : Flat α) ≤ ⊥ :=
+  fun h => by cases h
+
+instance : OrderBot (Flat α) where
+  bot_le := Flat.LE.bot_le
+
+instance : PartialOrder (Flat α) where
+  le_refl x := by cases x with
+    | bot => exact .bot_le _
+    | coe a => exact .refl a
+  le_trans x y z hxy hyz := by
+    cases hxy with
+    | bot_le => exact .bot_le _
+    | refl => exact hyz
+  le_antisymm x y hxy hyx := by
+    cases hxy with
+    | bot_le => cases hyx with | bot_le => rfl
+    | refl => rfl
+
+@[simp] theorem le_bot_iff : x ≤ ⊥ ↔ x = ⊥ := by
+  cases x <;> simp
+
+theorem coe_le_iff : (a : Flat α) ≤ y ↔ y = ↑a :=
+  ⟨fun h => by cases h; rfl, fun h => h ▸ .refl a⟩
+
+theorem le_coe_iff : x ≤ (b : Flat α) ↔ x = ⊥ ∨ x = ↑b := by
+  cases x <;> simp
+
+instance [DecidableEq α] : DecidableLE (Flat α)
+  | ⊥, _ => isTrue (.bot_le _)
+  | (a : α), ⊥ => isFalse (not_coe_le_bot a)
+  | (a : α), (b : α) => decidable_of_iff' _ coe_le_coe
+
+/-- Definedness persists up the flat order. -/
+theorem ne_bot_of_le (h : x ≤ y) (hx : x ≠ ⊥) : y ≠ ⊥ :=
+  fun hy => hx (le_bot_iff.mp (hy ▸ h))
+
+/-- A flat inequality with no definedness gain is an equality. -/
+theorem eq_of_le (h : x ≤ y) (hyx : y ≠ ⊥ → x ≠ ⊥) : x = y := by
+  cases h with
+  | bot_le y =>
+    cases y with
+    | bot => rfl
+    | coe a => exact absurd (hyx coe_ne_bot) (by simp)
+  | refl => rfl
+
+/-- The flat order is `Part`'s order, along `Part.ofOption`. -/
+theorem le_iff_ofOption_le :
+    x ≤ y ↔ Part.ofOption (x : Option α) ≤ Part.ofOption (y : Option α) := by
+  constructor
+  · rintro (_ | _)
+    · exact fun i hi => absurd (Part.mem_ofOption.mp hi) nofun
+    · exact le_rfl
+  · intro h
+    cases x with
+    | bot => exact bot_le
+    | coe a =>
+      obtain rfl : y = ↑a :=
+        Part.mem_ofOption.mp (h a (Part.mem_ofOption.mpr rfl))
+      exact le_rfl
+
+/-! ### Left-biased merge -/
+
+/-- The left-biased total merge of two slots, keeping the first committed
+value; the total companion of the partial join `Flat.unify`. -/
+protected def or (x y : Flat α) : Flat α :=
+  Option.or x y
+
+@[simp] theorem bot_or (y : Flat α) : (⊥ : Flat α).or y = y := rfl
+
+@[simp] theorem coe_or (a : α) (y : Flat α) : (↑a : Flat α).or y = ↑a := rfl
+
+@[simp] theorem or_bot (x : Flat α) : x.or ⊥ = x := by cases x <;> rfl
+
+theorem or_assoc (x y z : Flat α) : (x.or y).or z = x.or (y.or z) :=
+  Option.or_assoc ..
+
+theorem le_or_left (x y : Flat α) : x ≤ x.or y := by
+  cases x <;> simp
+
+theorem or_le (hx : x ≤ z) (hy : y ≤ z) : x.or y ≤ z := by
+  cases x with
+  | bot => exact hy
+  | coe a => exact hx
+
+/-! ### Meets -/
+
+/-- The meet of two slots is their agreement, or `⊥`. -/
+protected def inf [DecidableEq α] (x y : Flat α) : Flat α :=
+  if x = y then x else ⊥
 
 instance [DecidableEq α] : SemilatticeInf (Flat α) where
   inf := Flat.inf
-  inf_le_left a b := by
-    unfold Flat.inf
-    split
-    · exact Option.FlatLE.refl a
-    · exact Option.FlatLE.none_le a
-  inf_le_right a b := by
-    unfold Flat.inf
-    split
-    · next h => exact h ▸ Option.FlatLE.refl a
-    · exact Option.FlatLE.none_le b
-  le_inf c a b hca hcb := by
-    intro x hx
-    have ha := hca x hx
-    have hb := hcb x hx
-    unfold Flat.inf
-    rw [ha, hb]
-    exact if_pos rfl
+  inf_le_left x y := by unfold Flat.inf; split <;> simp
+  inf_le_right x y := by unfold Flat.inf; split <;> simp_all
+  le_inf x y z hxy hxz := by
+    cases hxy with
+    | bot_le => exact bot_le
+    | refl a =>
+      obtain rfl : z = ↑a := by cases hxz; rfl
+      simp [Flat.inf]
 
 /-! ### The flat domain is ω-complete
 
@@ -214,37 +259,37 @@ supremum. This is the *flat domain*, the canonical nontrivial example of an
 section OmegaCPO
 open OmegaCompletePartialOrder
   (Chain ωScottContinuous ContinuousHom ωSup le_ωSup isLUB_range_ωSup)
+open Classical
 
-open Classical in
 /-- The supremum of a chain in the flat order: the committed value if the chain
 ever leaves `⊥`, and `⊥` otherwise. The implementation behind the `ωSup`
 projection (cf. `Prod.ωSupImpl`); state results about `ωSup`. -/
 private noncomputable def ωSupImpl (c : Chain (Flat α)) : Flat α :=
-  if h : ∃ i, (c i).isSome then c (Nat.find h) else none
+  if h : ∃ i, c i ≠ ⊥ then c (Nat.find h) else ⊥
 
 private theorem ωSupImpl_isLUB (c : Chain (Flat α)) :
     IsLUB (Set.range c) (ωSupImpl c) := by
-  refine ⟨?_, ?_⟩
+  constructor
   · rintro _ ⟨j, rfl⟩
     unfold ωSupImpl
     split
     · next h =>
-      intro a ha
-      have ha' : c j = some a := ha
-      show c (Nat.find h) = some a
-      have hj : (c j).isSome := by rw [ha']; rfl
-      have hmono : c (Nat.find h) ≤ c j := (OrderHomClass.mono c) (Nat.find_min' h hj)
-      obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp (Nat.find_spec h)
-      have hjb : c j = some b := hmono b hb
-      rw [hb, Option.some.inj (ha'.symm.trans hjb)]
+      cases hj : c j with
+      | bot => exact bot_le
+      | coe a =>
+        obtain ⟨b, hb⟩ := ne_bot_iff_exists.mp (Nat.find_spec h)
+        have hmono : c (Nat.find h) ≤ c j :=
+          (OrderHomClass.mono c) (Nat.find_min' h (by simp [hj]))
+        rw [hj, hb, coe_le_coe] at hmono
+        rw [hb, hmono]
     · next h =>
-      intro a ha
-      exact absurd ⟨j, by rw [show c j = some a from ha]; rfl⟩ h
+      push Not at h
+      exact (h j).le
   · intro u hu
     unfold ωSupImpl
     split
     · next h => exact hu (Set.mem_range_self (Nat.find h))
-    · exact Option.FlatLE.none_le u
+    · exact bot_le
 
 /-- The flat domain is an `OmegaCompletePartialOrder`: chains are eventually
 constant, so their suprema are the eventual value (or `⊥`). -/
@@ -261,12 +306,8 @@ theorem ωSup_mem_range (c : Chain (Flat α)) : ωSup c ∈ Set.range c := by
   split
   · next h => exact ⟨Nat.find h, rfl⟩
   · next h =>
-    refine ⟨0, ?_⟩
-    by_contra hne
-    refine h ⟨0, ?_⟩
-    cases hc : c 0 with
-    | none => exact absurd hc hne
-    | some a => rfl
+    push Not at h
+    exact ⟨0, h 0⟩
 
 /-- Every monotone map out of the flat domain is `ωScottContinuous`: chains
 attain their suprema (`ωSup_mem_range`), so continuity is automatic. This is
@@ -283,110 +324,103 @@ theorem ωScottContinuous_of_monotone {D : Type*} [OmegaCompletePartialOrder D]
     exact hu ⟨k, rfl⟩
 
 /-- The extension of `g : α → D` to the flat domain by `⊥ ↦ ⊥`. -/
-private def liftFun {D : Type*} [Bot D] (g : α → D) : Flat α → D
-  | none => ⊥
-  | some a => g a
+private def liftFun {D : Type*} [Bot D] (g : α → D) : Flat α → D :=
+  recBotCoe ⊥ g
 
 private theorem liftFun_monotone {D : Type*} [Preorder D] [OrderBot D]
     (g : α → D) : Monotone (liftFun g) := by
   intro x y hxy
-  cases x with
-  | none => exact bot_le
-  | some a =>
-    obtain rfl : y = some a := le_def.mp hxy a rfl
-    exact le_refl _
+  cases hxy with
+  | bot_le => exact bot_le
+  | refl => exact le_rfl
 
-/-- **The flat domain is free.** Strict continuous maps out of `Flat α` into a
-pointed domain `D` are exactly functions `α → D` — the universal property of
-the free domain. The forward map precomposes with `some`; the inverse extends
-by `⊥ ↦ ⊥`, continuous by `ωScottContinuous_of_monotone`. -/
+/-- The flat domain is free: functions `α → D` into a pointed domain are
+exactly the strict continuous maps `Flat α →𝒄 D`. The forward map extends by
+`⊥ ↦ ⊥`, continuous by `ωScottContinuous_of_monotone`; the inverse
+precomposes with `↑`. -/
 noncomputable def liftEquiv {D : Type*} [OmegaCompletePartialOrder D] [OrderBot D] :
     (α → D) ≃ {f : Flat α →𝒄 D // f ⊥ = ⊥} where
   toFun g := ⟨ContinuousHom.ofFun (liftFun g)
     (ωScottContinuous_of_monotone (liftFun_monotone g)), rfl⟩
-  invFun f a := f.1 (some a)
+  invFun f a := f.1 ↑a
   left_inv g := by funext a; rfl
   right_inv := by
     rintro ⟨f, hf⟩
     refine Subtype.ext (DFunLike.ext _ _ ?_)
     intro x
     cases x with
-    | none => exact hf.symm
-    | some a => rfl
+    | bot => exact hf.symm
+    | coe a => rfl
 
 end OmegaCPO
 
-/-- Unify two slots: `none` is identity, equal commitments merge,
-distinct commitments clash. -/
-protected def unify [DecidableEq α] (a b : Flat α) : Option (Flat α) :=
-  match (a : Option α), (b : Option α) with
-  | none, b => some b
-  | some x, none => some (some x)
-  | some x, some y => if x = y then some (some x) else none
+/-! ### Unification -/
 
-private theorem unify_some_some [DecidableEq α] (x y : α) :
-    Flat.unify (some x : Flat α) (some y) = if x = y then some (some x) else none :=
+/-- Unification of two slots merges equal commitments, treats `⊥` as
+identity, and fails on distinct commitments. -/
+protected def unify [DecidableEq α] (x y : Flat α) : Option (Flat α) :=
+  match x, y with
+  | ⊥, y => Option.some y
+  | (a : α), ⊥ => Option.some ↑a
+  | (a : α), (b : α) => if a = b then Option.some ↑a else Option.none
+
+private theorem unify_coe_coe [DecidableEq α] (a b : α) :
+    Flat.unify (↑a : Flat α) ↑b = if a = b then Option.some ↑a else Option.none :=
   rfl
 
 instance [DecidableEq α] : PartialUnify (Flat α) where
   unify := Flat.unify
   isLUB_of_unify_eq_some := by
-    intro a b c h
-    match a, b with
-    | none, b =>
-      obtain rfl : b = c := Option.some.inj h
-      exact ⟨PartialUnify.mem_upperBounds_pair.mpr
-          ⟨Option.FlatLE.none_le _, le_rfl⟩,
-        λ u hu => (PartialUnify.mem_upperBounds_pair.mp hu).2⟩
-    | some x, none =>
-      obtain rfl : (some x : Flat α) = c := Option.some.inj h
-      exact ⟨PartialUnify.mem_upperBounds_pair.mpr
-          ⟨le_rfl, Option.FlatLE.none_le _⟩,
-        λ u hu => (PartialUnify.mem_upperBounds_pair.mp hu).1⟩
-    | some x, some y =>
-      rw [unify_some_some] at h
+    intro x y z h
+    match x, y with
+    | ⊥, y =>
+      obtain rfl : y = z := Option.some.inj h
+      exact ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨bot_le, le_rfl⟩,
+        fun u hu => (PartialUnify.mem_upperBounds_pair.mp hu).2⟩
+    | (a : α), ⊥ =>
+      obtain rfl : (↑a : Flat α) = z := Option.some.inj h
+      exact ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨le_rfl, bot_le⟩,
+        fun u hu => (PartialUnify.mem_upperBounds_pair.mp hu).1⟩
+    | (a : α), (b : α) =>
+      rw [unify_coe_coe] at h
       split at h
-      · next hxy =>
-        subst hxy
-        obtain rfl : (some x : Flat α) = c := Option.some.inj h
+      · next hab =>
+        subst hab
+        obtain rfl : (↑a : Flat α) = z := Option.some.inj h
         rw [Set.pair_eq_singleton]
         exact isLUB_singleton
-      · exact absurd h.symm (Option.some_ne_none c)
+      · exact absurd h.symm (Option.some_ne_none z)
   isSome_unify_of_bddAbove := by
-    intro a b hbdd
+    intro x y hbdd
     obtain ⟨u, hu⟩ := hbdd
-    obtain ⟨hau, hbu⟩ := PartialUnify.mem_upperBounds_pair.mp hu
-    match a, b with
-    | none, b => exact rfl
-    | some x, none => exact rfl
-    | some x, some y =>
-      have hx : (u : Option α) = some x := hau x rfl
-      have hy : (u : Option α) = some y := hbu y rfl
-      have hxy : x = y := Option.some.inj (hx.symm.trans hy)
-      show (Flat.unify (some x : Option α) (some y : Option α)).isSome
-      rw [unify_some_some, if_pos hxy]
+    obtain ⟨hxu, hyu⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+    match x, y with
+    | ⊥, y => exact rfl
+    | (a : α), ⊥ => exact rfl
+    | (a : α), (b : α) =>
+      obtain rfl : u = ↑a := coe_le_iff.mp hxu
+      obtain rfl : a = b := coe_inj.mp (coe_le_iff.mp hyu)
+      show (Flat.unify (↑a : Flat α) ↑a).isSome
+      rw [unify_coe_coe, if_pos rfl]
       rfl
 
-/-- Slot compatibility, characterized: committed values must coincide;
-    an uncommitted slot is a wildcard. -/
-theorem compat_iff [DecidableEq α] {a b : Flat α} :
-    Compat a b ↔ ∀ x : α, a = some x → ∀ y : α, b = some y → x = y := by
+/-- Two slots are compatible exactly when their committed values coincide;
+an uncommitted slot is a wildcard. -/
+theorem compat_iff [DecidableEq α] :
+    Compat x y ↔ ∀ a : α, x = ↑a → ∀ b : α, y = ↑b → a = b := by
   rw [compat_iff_isSome_unify]
-  show (Flat.unify a b).isSome = true ↔ _
-  match a, b with
-  | none, b =>
-    exact iff_of_true rfl (λ x hx => nomatch hx)
-  | some x, none =>
-    exact iff_of_true rfl (λ x' _ y hy => nomatch hy)
-  | some x, some y =>
-    rw [unify_some_some]
-    by_cases hxy : x = y
-    · subst hxy
+  show (Flat.unify x y).isSome = true ↔ _
+  match x, y with
+  | ⊥, y => exact iff_of_true rfl (fun a ha => absurd ha bot_ne_coe)
+  | (a : α), ⊥ => exact iff_of_true rfl (fun _ _ b hb => absurd hb bot_ne_coe)
+  | (a : α), (b : α) =>
+    rw [unify_coe_coe]
+    by_cases hab : a = b
+    · subst hab
       exact iff_of_true (by rw [if_pos rfl]; rfl)
-        (λ x' hx' y' hy' =>
-          (Option.some.inj hx').symm.trans (Option.some.inj hy'))
-    · rw [if_neg hxy]
-      exact iff_of_false nofun (λ h => hxy (h x rfl y rfl))
+        (fun a' ha' b' hb' => (coe_inj.mp ha').symm.trans (coe_inj.mp hb'))
+    · rw [if_neg hab]
+      exact iff_of_false nofun (fun h => hab (h a rfl b rfl))
 
 /-! ### Non-distributivity
 
@@ -397,9 +431,9 @@ partial join (`PartialUnify`), so the distributive law cannot even be
 *stated* on it directly; `unify_distinct_eq_none` is the witness — distinct
 atoms have no upper bound, so the join the law would require is undefined. -/
 
-theorem unify_distinct_eq_none [DecidableEq α] {a b : α} (h : a ≠ b) :
-    Flat.unify (some a : Flat α) (some b) = none := by
-  show (if a = b then some (some a : Flat α) else none) = none
+theorem unify_distinct_eq_none [DecidableEq α] (h : a ≠ b) :
+    Flat.unify (↑a : Flat α) ↑b = Option.none := by
+  rw [unify_coe_coe]
   exact if_neg h
 
 end Flat

--- a/Linglib/Core/Order/PartialUnify.lean
+++ b/Linglib/Core/Order/PartialUnify.lean
@@ -232,6 +232,13 @@ theorem Compat.symm [Preorder α] {a b : α} (h : Compat a b) : Compat b a := by
   obtain ⟨ha, hb⟩ := PartialUnify.mem_upperBounds_pair.mp hu
   exact Compat.of_le hb ha
 
+/-- Compatibility persists downward. -/
+theorem Compat.mono [Preorder α] {a b c d : α} (h₁ : a ≤ b) (h₂ : c ≤ d)
+    (h : Compat b d) : Compat a c := by
+  obtain ⟨u, hu⟩ := h
+  obtain ⟨hb, hd⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+  exact Compat.of_le (h₁.trans hb) (h₂.trans hd)
+
 theorem compat_self [Preorder α] (a : α) : Compat a a :=
   Compat.of_le le_rfl le_rfl
 

--- a/Linglib/Data/UD/Basic.lean
+++ b/Linglib/Data/UD/Basic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
+import Linglib.Core.Order.Flat
 
 /-!
 # Universal Dependencies Types
@@ -23,8 +24,9 @@ substrate every other layer builds on: `Features/` aliases the feature types
 (e.g. `Number.fromUD`/`Number.toUD`, …) and `Morphology/Word.lean` builds the
 ms-word token over the vocabulary.
 The bare `UD` namespace (no `Data.` prefix) is intentional — UD is its own
-external project. Subsumption-order theory over `MorphFeatures` lives in
-`Morphology/Unification.lean` (mathlib-importing); this file stays mathlib-light.
+external project. Feature slots are `Flat`-valued (`Core/Order/Flat.lean`);
+subsumption-order theory over `MorphFeatures` lives in
+`Morphology/Unification.lean`.
 -/
 
 namespace UD
@@ -289,25 +291,25 @@ inductive Polarity where
 -- Feature Bundle
 
 /-- A morphological feature bundle (partial assignment).
-    Uses Option to represent unspecified features. -/
+    Slots are `Flat`-valued: `⊥` = unspecified. -/
 structure MorphFeatures where
-  number   : Option Number   := none
-  gender   : Option Gender   := none
-  case_    : Option Case     := none
-  definite : Option Definite := none
-  degree   : Option Degree   := none
-  pronType : Option PronType := none
+  number   : Flat Number   := ⊥
+  gender   : Flat Gender   := ⊥
+  case_    : Flat Case     := ⊥
+  definite : Flat Definite := ⊥
+  degree   : Flat Degree   := ⊥
+  pronType : Flat PronType := ⊥
   /-- Reflexive (UD `Reflex=Yes`); `false` = feature absent. Distinguishes a reflexive
       anaphor from a plain personal pronoun; not an agreement feature, so not consulted
       by `compatible`. -/
-  reflex   : Bool            := false
-  person   : Option Person   := none
-  verbForm : Option VerbForm := none
-  tense    : Option Tense    := none
-  aspect   : Option Aspect   := none
-  mood     : Option Mood     := none
-  voice    : Option Voice    := none
-  polarity : Option Polarity := none
+  reflex   : Bool          := false
+  person   : Flat Person   := ⊥
+  verbForm : Flat VerbForm := ⊥
+  tense    : Flat Tense    := ⊥
+  aspect   : Flat Aspect   := ⊥
+  mood     : Flat Mood     := ⊥
+  voice    : Flat Voice    := ⊥
+  polarity : Flat Polarity := ⊥
   deriving DecidableEq, Repr, Inhabited
 
 /-- Empty feature bundle -/
@@ -319,7 +321,7 @@ def MorphFeatures.isWh (f : MorphFeatures) : Bool :=
   f.pronType == some .Int || f.pronType == some .Rel
 
 /-- Are two feature bundles compatible — bounded above in the subsumption order
-    ([shieber-1986] §3.2.3)? Total over *all* option-valued fields: a conflict in any
+    ([shieber-1986] §3.2.3)? Total over *all* `Flat`-valued fields: a conflict in any
     committed feature makes unification fail. (`reflex` needs no clause — a `Bool` slot
     with `false` = absent is always joinable by `||`.) The order-theoretic
     characterization is proved in `Morphology/Unification.lean`. -/
@@ -345,9 +347,16 @@ def MorphFeatures.compatible (f1 f2 : MorphFeatures) : Bool :=
   simp only [MorphFeatures.compatible, beq_self_eq_true, Bool.or_true, Bool.and_true]
 
 private theorem MorphFeatures.compatible_clause_comm {α : Type _} [BEq α] [LawfulBEq α]
-    (a b : Option α) :
+    (a b : Flat α) :
     (a.isNone || b.isNone || a == b) = (b.isNone || a.isNone || b == a) := by
-  cases a <;> cases b <;> simp [eq_comm]
+  cases a with
+  | bot => cases b <;> rfl
+  | coe v =>
+    cases b with
+    | bot => rfl
+    | coe x =>
+      show (v == x) = (x == v)
+      simp [eq_comm]
 
 /-- Feature compatibility is symmetric. -/
 theorem MorphFeatures.compatible_comm (f1 f2 : MorphFeatures) :
@@ -398,20 +407,20 @@ theorem MorphFeatures.compatible_person {f1 f2 : MorphFeatures}
     (left-biased per field, which on `compatible` inputs is symmetric since doubly
     committed fields agree). Only meaningful under `compatible`; `unify` adds the guard. -/
 def MorphFeatures.merge (f1 f2 : MorphFeatures) : MorphFeatures where
-  number   := f1.number   <|> f2.number
-  gender   := f1.gender   <|> f2.gender
-  case_    := f1.case_    <|> f2.case_
-  definite := f1.definite <|> f2.definite
-  degree   := f1.degree   <|> f2.degree
-  pronType := f1.pronType <|> f2.pronType
-  reflex   := f1.reflex   || f2.reflex
-  person   := f1.person   <|> f2.person
-  verbForm := f1.verbForm <|> f2.verbForm
-  tense    := f1.tense    <|> f2.tense
-  aspect   := f1.aspect   <|> f2.aspect
-  mood     := f1.mood     <|> f2.mood
-  voice    := f1.voice    <|> f2.voice
-  polarity := f1.polarity <|> f2.polarity
+  number   := f1.number.or f2.number
+  gender   := f1.gender.or f2.gender
+  case_    := f1.case_.or f2.case_
+  definite := f1.definite.or f2.definite
+  degree   := f1.degree.or f2.degree
+  pronType := f1.pronType.or f2.pronType
+  reflex   := f1.reflex || f2.reflex
+  person   := f1.person.or f2.person
+  verbForm := f1.verbForm.or f2.verbForm
+  tense    := f1.tense.or f2.tense
+  aspect   := f1.aspect.or f2.aspect
+  mood     := f1.mood.or f2.mood
+  voice    := f1.voice.or f2.voice
+  polarity := f1.polarity.or f2.polarity
 
 /-- Unify two feature bundles ([shieber-1986] §3.2.3): the least upper bound in the
     subsumption order when the bundles are compatible (`Morphology/Unification.lean` proves

--- a/Linglib/Features/Basic.lean
+++ b/Linglib/Features/Basic.lean
@@ -139,7 +139,7 @@ variable [∀ t, PartialOrder (S t)]
 
 /-- Subsumption: pointwise ≤ on slots — `b₂` is at least as specified as
 `b₁` ([shieber-1986] §3.2.2; [carpenter-1992] Definition 2.1). For flat
-slots this is `Option.FlatLE`; for set-valued slots it is the
+slots this is `≤` on `Flat`; for set-valued slots it is the
 indeterminacy order ([dalrymple-kaplan-2000]: superset = less
 determinate). -/
 def Subsumes (b₁ b₂ : B) : Prop :=

--- a/Linglib/Morphology/Unification.lean
+++ b/Linglib/Morphology/Unification.lean
@@ -1,5 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.Basic
+import Linglib.Core.Order.Flat
 import Linglib.Core.Order.PartialUnify
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.BoundedOrder.Basic
@@ -26,7 +27,6 @@ Unification (§3.2.3) is "the most general feature structure `D` such that `D′
 
 ## Main declarations
 
-* `Option.FlatLE` — the flat information order on one atomic feature slot.
 * `instance : PartialOrder UD.MorphFeatures` — subsumption ("only a partial order",
   §3.2.3), with decidable `≤`.
 * `instance : OrderBot UD.MorphFeatures` — the empty bundle is bottom.
@@ -71,7 +71,7 @@ pays for `Mathlib.Order` — and it is the canonical home for order instances on
 `UD.MorphFeatures`.
 
 The non-distributivity of the subsumption lattice is a documented
-obstruction (`MorphFeatures.not_distrib_witness`): any ≥3-value slot
+obstruction (`Flat.unify_distinct_eq_none`): any ≥3-value slot
 (here, `Case`) makes the per-slot lattice the diamond Mₙ, modular but
 *not* distributive ([carpenter-1992] p. 15, eq. (4), notes this
 explicitly: "our partial orders are *not* required to be distributive
@@ -84,14 +84,11 @@ set_option autoImplicit false
 
 /-! ### The flat order on one feature slot
 
-`Option.FlatLE` is the slot-level subsumption relation ([shieber-1986]
-§3.2.2: `none` below everything, distinct atoms incomparable). The
-definition and its `refl`/`trans`/`antisymm`/`none_le` API live in
-`Linglib/Core/Order/Flat.lean`, where they also carry the bundled
-`PartialOrder`/`OrderBot`/`SemilatticeInf`/`PartialUnify` instances on
-the order-carrying alias `Flat α`. Re-exported here under their
-original names for backward compatibility with this file's own proofs
-and consumers.
+The slot-level subsumption relation ([shieber-1986] §3.2.2: `⊥` below
+everything, distinct atoms incomparable) is the order of `Flat`
+(`Linglib/Core/Order/Flat.lean`), whose
+`PartialOrder`/`OrderBot`/`SemilatticeInf`/`PartialUnify` instances
+supply the per-slot steps of the bundle-level proofs below.
 -/
 
 namespace UD
@@ -151,12 +148,12 @@ namespace UD.MorphFeatures
 /-- Subsumption ([shieber-1986] §3.2.2): `f` carries a subset of `g`'s information —
 field-wise flat order on the option slots, implication on the `reflex` flag. -/
 def Subsumes (f g : MorphFeatures) : Prop :=
-  f.number.FlatLE g.number ∧ f.gender.FlatLE g.gender ∧ f.case_.FlatLE g.case_ ∧
-  f.definite.FlatLE g.definite ∧ f.degree.FlatLE g.degree ∧
-  f.pronType.FlatLE g.pronType ∧ (f.reflex = true → g.reflex = true) ∧
-  f.person.FlatLE g.person ∧ f.verbForm.FlatLE g.verbForm ∧ f.tense.FlatLE g.tense ∧
-  f.aspect.FlatLE g.aspect ∧ f.mood.FlatLE g.mood ∧ f.voice.FlatLE g.voice ∧
-  f.polarity.FlatLE g.polarity
+  f.number ≤ g.number ∧ f.gender ≤ g.gender ∧ f.case_ ≤ g.case_ ∧
+  f.definite ≤ g.definite ∧ f.degree ≤ g.degree ∧
+  f.pronType ≤ g.pronType ∧ (f.reflex = true → g.reflex = true) ∧
+  f.person ≤ g.person ∧ f.verbForm ≤ g.verbForm ∧ f.tense ≤ g.tense ∧
+  f.aspect ≤ g.aspect ∧ f.mood ≤ g.mood ∧ f.voice ≤ g.voice ∧
+  f.polarity ≤ g.polarity
 
 /-! ### `MorphFeatures` as a feature bundle, and the derived order
 
@@ -179,7 +176,7 @@ def val (f : MorphFeatures) :
   | .definite => f.definite
   | .degree   => f.degree
   | .pronType => f.pronType
-  | .reflex   => if f.reflex then some () else none
+  | .reflex   => if f.reflex then (↑() : Flat Unit) else ⊥
   | .person   => f.person
   | .verbForm => f.verbForm
   | .tense    => f.tense
@@ -193,7 +190,7 @@ instance : BundleLike MorphFeatures MorphFeatureType
   val := MorphFeatures.val
 
 private theorem reflex_eq_of_val_reflex_eq {b1 b2 : Bool}
-    (h : (if b1 then some () else none) = (if b2 then some () else none)) :
+    (h : (if b1 then (↑() : Flat Unit) else ⊥) = if b2 then ↑() else ⊥) :
     b1 = b2 := by
   cases b1 <;> cases b2 <;> simp_all
 
@@ -223,9 +220,9 @@ instance : LawfulBundleLike MorphFeatures :=
   ⟨val_injective⟩
 
 private theorem reflex_val_le_iff {b1 b2 : Bool} :
-    Option.FlatLE (if b1 then some () else none) (if b2 then some () else none)
+    (if b1 then (↑() : Flat Unit) else ⊥) ≤ (if b2 then ↑() else ⊥)
       ↔ (b1 = true → b2 = true) := by
-  cases b1 <;> cases b2 <;> simp [Option.FlatLE]
+  cases b1 <;> cases b2 <;> simp
 
 /-- Subsumption is exactly the bundle order: the field-wise 14-conjunct form
 coincides with the per-slot `Flat` order on the valuation `val`. -/
@@ -275,7 +272,7 @@ other feature structures … they contain no information at all" (§3.2.2). -/
 instance : OrderBot MorphFeatures where
   bot := {}
   bot_le f := (subsumes_iff_val_le {} f).mpr (by
-    intro t; cases t <;> exact Option.FlatLE.none_le _)
+    intro t; cases t <;> exact bot_le)
 
 /-! ### Compatibility is boundedness above; unification is the least upper bound -/
 
@@ -285,31 +282,24 @@ the executable `compatible` check via `compatible_iff_bddAbove`, which also make
 it decidable. -/
 def Compatible (f g : MorphFeatures) : Prop := BddAbove ({f, g} : Set MorphFeatures)
 
-private theorem clause_of_some_some {α : Type _} [BEq α] [LawfulBEq α] {x y : α}
-    (h : ((some x : Option α).isNone || (some y : Option α).isNone
-          || (some x : Option α) == some y) = true) : x = y := by
-  simpa [Option.isNone] using h
-
-private theorem some_flatLE_orElse {α : Type _} (a b : Option α) {x : α}
-    (hx : a = some x) : (a <|> b) = some x := by
-  subst hx; rfl
-
 /-- The left input subsumes the merge. -/
 theorem le_merge_left (f g : MorphFeatures) : f ≤ f.merge g := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
     first
-      | exact fun x hx => some_flatLE_orElse _ _ hx
+      | exact Flat.le_or_left _ _
       | exact fun hr => by simp [merge, hr]
 
-private theorem flatLE_merge_right {α : Type _} [BEq α] [LawfulBEq α] (a b : Option α)
-    (hcl : (a.isNone || b.isNone || a == b) = true) : b.FlatLE (a <|> b) := by
-  intro x hx
+private theorem le_or_of_clause {α : Type _} [BEq α] [LawfulBEq α] {a b : Flat α}
+    (hcl : (a.isNone || b.isNone || a == b) = true) : b ≤ a.or b := by
   cases a with
-  | none => simpa using hx
-  | some v =>
-    subst hx
-    have : v = x := clause_of_some_some hcl
-    simp [this]
+  | bot => exact le_rfl
+  | coe v =>
+    cases b with
+    | bot => exact bot_le
+    | coe x =>
+      obtain rfl : v = x :=
+        Flat.coe_inj.mp (eq_of_beq (show ((v : Flat α) == ↑x) = true from hcl))
+      exact le_rfl
 
 /-- The right input subsumes the merge — *given compatibility* (the doubly committed
 slots agree, so the left bias is harmless). -/
@@ -317,21 +307,14 @@ theorem le_merge_right {f g : MorphFeatures} (h : f.compatible g = true) :
     g ≤ f.merge g := by
   simp only [compatible, Bool.and_eq_true] at h
   obtain ⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨h1, h2⟩, h3⟩, h4⟩, h5⟩, h6⟩, h7⟩, h8⟩, h9⟩, h10⟩, h11⟩, h12⟩, h13⟩ := h
-  exact ⟨flatLE_merge_right _ _ h1, flatLE_merge_right _ _ h2,
-         flatLE_merge_right _ _ h3, flatLE_merge_right _ _ h4,
-         flatLE_merge_right _ _ h5, flatLE_merge_right _ _ h6,
+  exact ⟨le_or_of_clause h1, le_or_of_clause h2,
+         le_or_of_clause h3, le_or_of_clause h4,
+         le_or_of_clause h5, le_or_of_clause h6,
          fun hr => by simp [merge, hr],
-         flatLE_merge_right _ _ h7, flatLE_merge_right _ _ h8,
-         flatLE_merge_right _ _ h9, flatLE_merge_right _ _ h10,
-         flatLE_merge_right _ _ h11, flatLE_merge_right _ _ h12,
-         flatLE_merge_right _ _ h13⟩
-
-private theorem orElse_flatLE {α : Type _} {a b u : Option α}
-    (ha : a.FlatLE u) (hb : b.FlatLE u) : (a <|> b).FlatLE u := by
-  intro x hx
-  cases a with
-  | none => exact hb x (by simpa using hx)
-  | some v => exact ha x (by simpa using hx)
+         le_or_of_clause h7, le_or_of_clause h8,
+         le_or_of_clause h9, le_or_of_clause h10,
+         le_or_of_clause h11, le_or_of_clause h12,
+         le_or_of_clause h13⟩
 
 /-- The merge is below every common upper bound — minimality ("the *most general*
 feature structure", §3.2.3). -/
@@ -339,28 +322,27 @@ theorem merge_le {f g u : MorphFeatures} (hf : f ≤ u) (hg : g ≤ u) :
     f.merge g ≤ u := by
   obtain ⟨a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14⟩ := hf
   obtain ⟨b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14⟩ := hg
-  refine ⟨orElse_flatLE a1 b1, orElse_flatLE a2 b2, orElse_flatLE a3 b3,
-          orElse_flatLE a4 b4, orElse_flatLE a5 b5, orElse_flatLE a6 b6, ?_,
-          orElse_flatLE a8 b8, orElse_flatLE a9 b9, orElse_flatLE a10 b10,
-          orElse_flatLE a11 b11, orElse_flatLE a12 b12, orElse_flatLE a13 b13,
-          orElse_flatLE a14 b14⟩
+  refine ⟨Flat.or_le a1 b1, Flat.or_le a2 b2, Flat.or_le a3 b3,
+          Flat.or_le a4 b4, Flat.or_le a5 b5, Flat.or_le a6 b6, ?_,
+          Flat.or_le a8 b8, Flat.or_le a9 b9, Flat.or_le a10 b10,
+          Flat.or_le a11 b11, Flat.or_le a12 b12, Flat.or_le a13 b13,
+          Flat.or_le a14 b14⟩
   intro hr
   rcases Bool.or_eq_true_iff.mp (by simpa [merge] using hr) with h | h
   · exact a7 h
   · exact b7 h
 
-private theorem clause_of_flatLE {α : Type _} [BEq α] [LawfulBEq α] {a b u : Option α}
-    (ha : a.FlatLE u) (hb : b.FlatLE u) :
-    (a.isNone || b.isNone || a == b) = true := by
+private theorem clause_of_le {α : Type _} [BEq α] [LawfulBEq α] {a b u : Flat α}
+    (ha : a ≤ u) (hb : b ≤ u) : (a.isNone || b.isNone || a == b) = true := by
   cases a with
-  | none => simp
-  | some x =>
+  | bot => rfl
+  | coe x =>
     cases b with
-    | none => simp
-    | some y =>
-      have hx := ha x rfl
-      have hy := hb y rfl
-      simp [Option.some.inj (hx.symm.trans hy)]
+    | bot => rfl
+    | coe y =>
+      obtain rfl : u = ↑x := Flat.coe_le_iff.mp ha
+      obtain rfl : y = x := Flat.coe_le_coe.mp hb
+      exact beq_self_eq_true _
 
 /-- Bounded above implies the executable check passes. -/
 theorem compatible_of_le {f g u : MorphFeatures} (hf : f ≤ u) (hg : g ≤ u) :
@@ -368,11 +350,11 @@ theorem compatible_of_le {f g u : MorphFeatures} (hf : f ≤ u) (hg : g ≤ u) :
   obtain ⟨a1, a2, a3, a4, a5, a6, _, a8, a9, a10, a11, a12, a13, a14⟩ := hf
   obtain ⟨b1, b2, b3, b4, b5, b6, _, b8, b9, b10, b11, b12, b13, b14⟩ := hg
   simp only [compatible, Bool.and_eq_true]
-  exact ⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨clause_of_flatLE a1 b1, clause_of_flatLE a2 b2⟩,
-    clause_of_flatLE a3 b3⟩, clause_of_flatLE a4 b4⟩, clause_of_flatLE a5 b5⟩,
-    clause_of_flatLE a6 b6⟩, clause_of_flatLE a8 b8⟩, clause_of_flatLE a9 b9⟩,
-    clause_of_flatLE a10 b10⟩, clause_of_flatLE a11 b11⟩, clause_of_flatLE a12 b12⟩,
-    clause_of_flatLE a13 b13⟩, clause_of_flatLE a14 b14⟩
+  exact ⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨clause_of_le a1 b1, clause_of_le a2 b2⟩,
+    clause_of_le a3 b3⟩, clause_of_le a4 b4⟩, clause_of_le a5 b5⟩,
+    clause_of_le a6 b6⟩, clause_of_le a8 b8⟩, clause_of_le a9 b9⟩,
+    clause_of_le a10 b10⟩, clause_of_le a11 b11⟩, clause_of_le a12 b12⟩,
+    clause_of_le a13 b13⟩, clause_of_le a14 b14⟩
 
 /-- The `Bool` check is exactly boundedness above in the subsumption order: the
 order-theoretic identity of "compatible". -/
@@ -422,46 +404,22 @@ Shieber's *generalization* (anti-unification): the most specific bundle subsumed
 both inputs. Unlike unification it is total — the meet always exists — so
 `MorphFeatures` is a genuine `SemilatticeInf` with `⊥`. -/
 
-private def slotInf {α : Type _} [DecidableEq α] (a b : Option α) : Option α :=
-  if a = b then a else none
-
-private theorem slotInf_flatLE_left {α : Type _} [DecidableEq α] (a b : Option α) :
-    (slotInf a b).FlatLE a := by
-  unfold slotInf; split
-  · exact .refl _
-  · exact .none_le _
-
-private theorem slotInf_flatLE_right {α : Type _} [DecidableEq α] (a b : Option α) :
-    (slotInf a b).FlatLE b := by
-  unfold slotInf; split
-  · next h => subst h; exact .refl _
-  · exact .none_le _
-
-private theorem flatLE_slotInf {α : Type _} [DecidableEq α] {a b c : Option α}
-    (h1 : c.FlatLE a) (h2 : c.FlatLE b) : c.FlatLE (slotInf a b) := by
-  intro x hx
-  have ha := h1 x hx
-  have hb := h2 x hx
-  unfold slotInf
-  rw [ha, hb]
-  simp
-
 instance : Min MorphFeatures where
   min f g :=
-    { number   := slotInf f.number g.number
-      gender   := slotInf f.gender g.gender
-      case_    := slotInf f.case_ g.case_
-      definite := slotInf f.definite g.definite
-      degree   := slotInf f.degree g.degree
-      pronType := slotInf f.pronType g.pronType
+    { number   := f.number ⊓ g.number
+      gender   := f.gender ⊓ g.gender
+      case_    := f.case_ ⊓ g.case_
+      definite := f.definite ⊓ g.definite
+      degree   := f.degree ⊓ g.degree
+      pronType := f.pronType ⊓ g.pronType
       reflex   := f.reflex && g.reflex
-      person   := slotInf f.person g.person
-      verbForm := slotInf f.verbForm g.verbForm
-      tense    := slotInf f.tense g.tense
-      aspect   := slotInf f.aspect g.aspect
-      mood     := slotInf f.mood g.mood
-      voice    := slotInf f.voice g.voice
-      polarity := slotInf f.polarity g.polarity }
+      person   := f.person ⊓ g.person
+      verbForm := f.verbForm ⊓ g.verbForm
+      tense    := f.tense ⊓ g.tense
+      aspect   := f.aspect ⊓ g.aspect
+      mood     := f.mood ⊓ g.mood
+      voice    := f.voice ⊓ g.voice
+      polarity := f.polarity ⊓ g.polarity }
 
 private theorem band_true_left {x y : Bool} (h : (x && y) = true) : x = true := by
   cases x <;> simp_all
@@ -477,28 +435,24 @@ instance : SemilatticeInf MorphFeatures :=
     (inferInstance : Min MorphFeatures) with
     inf := min
     inf_le_left := fun f g => show Subsumes (min f g) f from
-      ⟨slotInf_flatLE_left _ _, slotInf_flatLE_left _ _, slotInf_flatLE_left _ _,
-       slotInf_flatLE_left _ _, slotInf_flatLE_left _ _, slotInf_flatLE_left _ _,
+      ⟨inf_le_left, inf_le_left, inf_le_left, inf_le_left, inf_le_left, inf_le_left,
        fun hr => band_true_left hr,
-       slotInf_flatLE_left _ _, slotInf_flatLE_left _ _, slotInf_flatLE_left _ _,
-       slotInf_flatLE_left _ _, slotInf_flatLE_left _ _, slotInf_flatLE_left _ _,
-       slotInf_flatLE_left _ _⟩
+       inf_le_left, inf_le_left, inf_le_left, inf_le_left, inf_le_left, inf_le_left,
+       inf_le_left⟩
     inf_le_right := fun f g => show Subsumes (min f g) g from
-      ⟨slotInf_flatLE_right _ _, slotInf_flatLE_right _ _, slotInf_flatLE_right _ _,
-       slotInf_flatLE_right _ _, slotInf_flatLE_right _ _, slotInf_flatLE_right _ _,
+      ⟨inf_le_right, inf_le_right, inf_le_right, inf_le_right, inf_le_right, inf_le_right,
        fun hr => band_true_right hr,
-       slotInf_flatLE_right _ _, slotInf_flatLE_right _ _, slotInf_flatLE_right _ _,
-       slotInf_flatLE_right _ _, slotInf_flatLE_right _ _, slotInf_flatLE_right _ _,
-       slotInf_flatLE_right _ _⟩
+       inf_le_right, inf_le_right, inf_le_right, inf_le_right, inf_le_right, inf_le_right,
+       inf_le_right⟩
     le_inf := fun c f g hcf hcg => by
       obtain ⟨a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14⟩ := hcf
       obtain ⟨b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14⟩ := hcg
-      exact ⟨flatLE_slotInf a1 b1, flatLE_slotInf a2 b2, flatLE_slotInf a3 b3,
-             flatLE_slotInf a4 b4, flatLE_slotInf a5 b5, flatLE_slotInf a6 b6,
+      exact ⟨le_inf a1 b1, le_inf a2 b2, le_inf a3 b3,
+             le_inf a4 b4, le_inf a5 b5, le_inf a6 b6,
              fun hr => band_true_intro (a7 hr) (b7 hr),
-             flatLE_slotInf a8 b8, flatLE_slotInf a9 b9, flatLE_slotInf a10 b10,
-             flatLE_slotInf a11 b11, flatLE_slotInf a12 b12, flatLE_slotInf a13 b13,
-             flatLE_slotInf a14 b14⟩ }
+             le_inf a8 b8, le_inf a9 b9, le_inf a10 b10,
+             le_inf a11 b11, le_inf a12 b12, le_inf a13 b13,
+             le_inf a14 b14⟩ }
 
 /-! ### Unification computes least upper bounds — further laws -/
 

--- a/Linglib/Phonology/Segmental/ElementTheory.lean
+++ b/Linglib/Phonology/Segmental/ElementTheory.lean
@@ -120,10 +120,10 @@ end Element
 structure MR where
   /-- The numeration — Breit's complement-position `C`: every element present. -/
   elements : Finset Element
-  /-- The optional head (SOHC: at most one). -/
-  head : Option Element
+  /-- The optional head (SOHC: at most one), a `Flat` slot: `⊥` = unheaded. -/
+  head : Flat Element
   /-- The head, if any, is among the elements (Breit: `H ⊆ C`). -/
-  head_mem : ∀ e ∈ head, e ∈ elements
+  head_mem : ∀ e : Element, head = ↑e → e ∈ elements
   deriving DecidableEq
 
 namespace MR
@@ -133,19 +133,19 @@ variable (m : MR) (e : Element)
 /-! ### Set-merge constructors -/
 
 /-- The empty MR | |: the empty representation (usually [ə]). -/
-def empty : MR := ⟨∅, none, by simp⟩
+def empty : MR := ⟨∅, ⊥, by simp⟩
 
 /-- The **unheaded simplex** |e|: a single bare element. -/
-def simplex : MR := ⟨{e}, none, by simp⟩
+def simplex : MR := ⟨{e}, ⊥, by simp⟩
 
 /-- The **headed simplex** |e̲|: a single element that is also its own head. -/
-def headedSimplex : MR := ⟨{e}, some e, by simp⟩
+def headedSimplex : MR := ⟨{e}, ↑e, by simp⟩
 
 /-- |h̲ op|: a head `h` with one operator `op`. -/
-def headPlusOp (h op : Element) : MR := ⟨{h, op}, some h, by simp⟩
+def headPlusOp (h op : Element) : MR := ⟨{h, op}, ↑h, by simp⟩
 
 /-- An **unheaded numeration**: a bare set of elements with no head. -/
-def numeration (es : Finset Element) : MR := ⟨es, none, by simp⟩
+def numeration (es : Finset Element) : MR := ⟨es, ⊥, by simp⟩
 
 /-! ### Head, complement, operators -/
 
@@ -155,18 +155,18 @@ def HasElement : Prop := e ∈ m.elements
 instance : Decidable (m.HasElement e) := inferInstanceAs (Decidable (e ∈ m.elements))
 
 /-- `e` is the head of the MR. -/
-def IsHead : Prop := m.head = some e
+def IsHead : Prop := m.head = ↑e
 
-instance : Decidable (m.IsHead e) := inferInstanceAs (Decidable (m.head = some e))
+instance : Decidable (m.IsHead e) := inferInstanceAs (Decidable (m.head = ↑e))
 
 /-- The MR has a head. -/
-def IsHeaded : Prop := m.head ≠ none
+def IsHeaded : Prop := m.head ≠ ⊥
 
 /-- The **operators** (dependents): all but the head ([kaye-lowenstamm-vergnaud-1985]). -/
 def ops : Finset Element :=
   match m.head with
-  | none => m.elements
-  | some h => m.elements.erase h
+  | ⊥ => m.elements
+  | (h : Element) => m.elements.erase h
 
 /-! ### Antagonism -/
 
@@ -199,42 +199,52 @@ def compose : MR where
 /-- Remove element `e`, demoting it from head if present (complement-decomposition). -/
 def decompose : MR where
   elements := m.elements.erase e
-  head := if m.head = some e then none else m.head
-  head_mem := by grind [MR.head_mem, Option.mem_def]
+  head := if m.head = ↑e then ⊥ else m.head
+  head_mem := by
+    intro x hx
+    split at hx
+    · exact absurd hx Flat.bot_ne_coe
+    · next h => exact Finset.mem_erase.mpr ⟨fun hxe => h (hxe ▸ hx), m.head_mem x hx⟩
 
 /-- Promote `e` to head, adding it if absent (head-composition). -/
 def headCompose : MR where
   elements := insert e m.elements
-  head := some e
-  head_mem := by grind [Finset.mem_insert_self, Option.mem_def]
+  head := ↑e
+  head_mem := by simp
 
 /-- Remove the head, leaving the elements bare (head-decomposition). -/
-def headDecompose : MR := ⟨m.elements, none, by simp⟩
+def headDecompose : MR := ⟨m.elements, ⊥, by simp⟩
 
 /-- Union `host` and `floater`, the floater's head overriding (non-monotone, so
     not the order-join). -/
 def dock (host floater : MR) : MR where
   elements := host.elements ∪ floater.elements
-  head := match floater.head with
-    | some f => some f
-    | none   => host.head
-  head_mem := by grind [MR.head_mem, Option.mem_def]
+  head := floater.head.or host.head
+  head_mem := by
+    intro x hx
+    cases hf : floater.head with
+    | bot =>
+      rw [hf, Flat.bot_or] at hx
+      exact Finset.mem_union_left _ (host.head_mem x hx)
+    | coe f =>
+      rw [hf, Flat.coe_or] at hx
+      exact Finset.mem_union_right _ (floater.head_mem x (hf.trans hx))
 
 /-! ### Elemental refinement order -/
 
-/-- Refinement: inclusion on elements, flat order (`Option.FlatLE`) on the head
+/-- Refinement: inclusion on elements, flat order (`≤` on `Flat`) on the head
     ([cavirani-vandenwyngaerd-2026]). -/
 def Refines (m₁ m₂ : MR) : Prop :=
-  m₁.elements ⊆ m₂.elements ∧ Option.FlatLE m₁.head m₂.head
+  m₁.elements ⊆ m₂.elements ∧ m₁.head ≤ m₂.head
 
 instance (m₁ m₂ : MR) : Decidable (Refines m₁ m₂) := inferInstanceAs (Decidable (_ ∧ _))
 
 instance : PartialOrder MR where
   le := Refines
-  le_refl _ := ⟨Finset.Subset.refl _, Option.FlatLE.refl _⟩
+  le_refl _ := ⟨Finset.Subset.refl _, le_rfl⟩
   le_trans _ _ _ h₁ h₂ := ⟨h₁.1.trans h₂.1, h₁.2.trans h₂.2⟩
   le_antisymm _ _ h₁ h₂ :=
-    MR.ext (Finset.Subset.antisymm h₁.1 h₂.1) (Option.FlatLE.antisymm h₁.2 h₂.2)
+    MR.ext (Finset.Subset.antisymm h₁.1 h₂.1) (h₁.2.antisymm h₂.2)
 
 instance (m₁ m₂ : MR) : Decidable (m₁ ≤ m₂) := inferInstanceAs (Decidable (Refines m₁ m₂))
 

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -187,15 +187,13 @@ section Total
 
 open Opposite
 
-open scoped Classical
-
 variable {W M V : Type*}
 
 /-- Classify each element of the possibilities family as a point: on
 objects this is `Possibility.domainEquiv`; arrows become descents, by
 `Possibility.le_iff_eq_restrict`. -/
-noncomputable def elementsToPoints :
-    (possibilities W M V).Elements ⥤ (Possibility W V (Option M))ᵒᵖ where
+def elementsToPoints :
+    (possibilities W M V).Elements ⥤ (Possibility W V (Part M))ᵒᵖ where
   obj x := op ((Possibility.domainEquiv x.1.unop).symm x.2).1
   map {x y} f := (homOfLE (show
       ((Possibility.domainEquiv y.1.unop).symm y.2).1 ≤
@@ -241,7 +239,7 @@ instance : (elementsToPoints (W := W) (M := M) (V := V)).IsEquivalence := {}
 type**: the category of elements is equivalent to the opposite of the
 descent preorder on points — every point lies over its own domain. -/
 noncomputable def elementsEquivPoints :
-    (possibilities W M V).Elements ≌ (Possibility W V (Option M))ᵒᵖ :=
+    (possibilities W M V).Elements ≌ (Possibility W V (Part M))ᵒᵖ :=
   elementsToPoints.asEquivalence
 
 end Total

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -254,22 +254,23 @@ theorem DRS.uniformAt_state (W : Type*) (K : DRS L V) (hK : K.IsProper) :
 /-- The characteristic membership form: a point survives in `⟦K⟧ˢ` iff it
 lives on the referents and its values are reached from some input. -/
 theorem DRS.mem_state {W : Type*} {K : DRS L V} {hK : K.IsProper}
-    {q : Possibility W V (Option M)} :
+    {q : Possibility W V (Part M)} :
     q ∈ K.state W hK ↔ q.domain = (↑(∅ ∪ K.referents) : Set V) ∧
       ∃ f g : V → M, DRS.toRelAt ∅ K f g ∧
-        ∀ v : (↑(∅ ∪ K.referents) : Set V), q.assignment v.1 = some (g v.1) := by
+        ∀ v : (↑(∅ ∪ K.referents) : Set V), g v.1 ∈ q.assignment v.1 := by
   constructor
   · rintro ⟨hq, p, hpI, hp, hw, e, e', he, he', f, g, hf, hg, hrel⟩
     refine ⟨hq, f, g, hrel, fun v => ?_⟩
-    rw [he' v]
-    exact congrArg some (congrFun hg v).symm
+    have hv := he' v
+    rw [← hg] at hv
+    exact hv
   · rintro ⟨hq, f, g, hrel, hvals⟩
-    refine ⟨hq, ⟨q.world, fun _ => none⟩, fun _ => rfl, ?_, rfl,
+    refine ⟨hq, ⟨q.world, fun _ => ⊥⟩, fun _ => rfl, ?_, rfl,
       (↑(∅ : Finset V) : Set V).restrict f,
       (↑(∅ ∪ K.referents) : Set V).restrict g,
       fun v => absurd v.2 (by simp), fun v => hvals v, f, g, rfl, rfl, hrel⟩
     ext v
-    simp [Possibility.domain]
+    exact iff_of_false (fun h => h) (by simp)
 
 /-! ### Base invariance
 

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -212,11 +212,11 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
       Possibility.ext rfl (funext fun v => by
         simp [Possibility.union, hqnone v])
     rw [huq]
-    exact ⟨hp, hpq.1.symm ▸ hqpred⟩
+    exact ⟨hp, (Possibility.compat_iff.mp hpq).1.symm ▸ hqpred⟩
   · rintro ⟨hr, hpred⟩
     refine ⟨r, hr, ⟨r.world, fun _ => none⟩,
       ⟨Set.ext fun v => by simp [Possibility.domain], hpred⟩,
-      ⟨rfl, fun _ _ _ _ h => by simp at h⟩, ?_⟩
+      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => by simp at h⟩, ?_⟩
     exact Possibility.ext rfl (funext fun v => by simp [Possibility.union])
 
 /-- Rule (13), the familiar regime: at a familiar card the atom
@@ -238,12 +238,12 @@ theorem atomVar_eq_of_familiar [DecidableEq V] (pred : M → Prop) (x : V)
         · subst hv; simp [Possibility.union, hpx]
         · simp [Possibility.union, hqnone v hv])
     rw [huq]
-    exact ⟨hp, m₀, hpx, by rw [hpq.2 x m₀ m hpx hqx]; exact hpred⟩
+    exact ⟨hp, m₀, hpx, by rw [(Possibility.compat_iff.mp hpq).2 x m₀ m hpx hqx]; exact hpred⟩
   · rintro ⟨hr, m, hrx, hpred⟩
     refine ⟨r, hr, ⟨r.world, fun v => if v = x then some m else none⟩,
       ⟨Set.ext fun v => by by_cases hv : v = x <;>
         simp [Possibility.domain, hv], m, by simp, hpred⟩,
-      ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
+      Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · have he2 : (if v = x then some m else none) = some e' := he'
       by_cases hv : v = x
       · rw [if_pos hv] at he2
@@ -286,7 +286,7 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     refine ⟨p, hp, ⟨p.world, fun v => if v = x then some m else none⟩,
       ⟨Set.ext fun v => by by_cases hv : v = x <;>
         simp [Possibility.domain, hv], m, by simp, hpred⟩,
-      ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
+      Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · have he2 : (if v = x then some m else none) = some e' := he'
       by_cases hv : v = x
       · rw [hv, hnov p hp] at he

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -33,7 +33,7 @@ the referent-free shadow of the 1982 ones.
 ## Main definitions
 
 - `FCP`: file change potentials —
-  `CCP.Partial (Possibility W V (Option M))`.
+  `CCP.Partial (Possibility W V (Part M))`.
 - `FCP.ofState`: assertive update as consistent merge; `FCP.atomW`,
   `FCP.atomVar`, `FCP.atomVar2` are its instances at proposition
   states.
@@ -61,7 +61,7 @@ namespace DynamicSemantics
 referential information states — `CCP.Partial` at the possibility type.
 Partiality is presupposition (`CCP.Partial.admits`); Heim's files number
 their cards, `V := ℕ`. -/
-abbrev FCP (W V M : Type*) := CCP.Partial (Possibility W V (Option M))
+abbrev FCP (W V M : Type*) := CCP.Partial (Possibility W V (Part M))
 
 namespace FCP
 
@@ -70,7 +70,7 @@ variable {W V M : Type*}
 /-- Card `x` in `F` refers to `m`: every point assigns `m` to `x`
 (Ch. III §2.3). -/
 def refersTo (F : State W V M) (x : V) (m : M) : Prop :=
-  ∀ p ∈ F, p.assignment x = some m
+  ∀ p ∈ F, m ∈ p.assignment x
 
 /-- Assertive update by a state: consistent merge ([heim-1983]'s revised
 atomic rule (18), which is [kamp-vangenabith-reyle-2011] Def. 26's
@@ -100,12 +100,12 @@ proposition state. Familiar `x` filters (rule (13)); novel `x` extends
 (rule (18)) — per point, so partially familiar files update
 pointwise. -/
 def atomVar (pred : M → Prop) (x : V) : FCP W V M :=
-  ofState {q | q.domain = {x} ∧ ∃ m, q.assignment x = some m ∧ pred m}
+  ofState {q | q.domain = {x} ∧ ∃ m ∈ q.assignment x, pred m}
 
 /-- Binary atomic predicate at `x` and `y`. -/
 def atomVar2 (pred : M → M → Prop) (x y : V) : FCP W V M :=
-  ofState {q | q.domain = {x, y} ∧ ∃ m m', q.assignment x = some m ∧
-    q.assignment y = some m' ∧ pred m m'}
+  ofState {q | q.domain = {x, y} ∧ ∃ m ∈ q.assignment x,
+    ∃ m' ∈ q.assignment y, pred m m'}
 
 /-- Negation: keep the points of `F` that do not subsist in the scope's
 update — the no-verifying-extension clause, as non-subsistence.
@@ -126,7 +126,7 @@ open a new file card. [heim-1991] later derives novelty from Maximize
 Presupposition rather than stipulating it; the guard here is the
 original (15). -/
 def indef [DecidableEq V] (x : V) (body : FCP W V M) : FCP W V M :=
-  fun F => Part.assert (∀ p ∈ F, p.assignment x = none) fun _ =>
+  fun F => Part.assert (∀ p ∈ F, ¬(p.assignment x).Dom) fun _ =>
     body (State.randomAssign F x)
 
 /-- Definite reference: defined only if `x` is familiar (the Familiarity
@@ -182,7 +182,7 @@ its card is novel and the body is defined on the extended file. -/
 theorem admits_indef [DecidableEq V] (x : V) (body : FCP W V M)
     (F : State W V M) :
     (indef x body).admits F ↔
-      ∃ _ : ∀ p ∈ F, p.assignment x = none,
+      ∃ _ : ∀ p ∈ F, ¬(p.assignment x).Dom,
         (body (F.randomAssign x)).Dom := by
   exact Iff.rfl
 
@@ -205,99 +205,98 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
     atomW pred F = Part.some {p ∈ F | pred p.world} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
   · rintro ⟨p, hp, q, ⟨hqdom, hqpred⟩, hpq, rfl⟩
-    have hqnone : ∀ v, q.assignment v = none := fun v =>
-      Option.not_isSome_iff_eq_none.mp fun hs =>
-        Set.eq_empty_iff_forall_notMem.mp hqdom v hs
-    have huq : p.union q = p :=
-      Possibility.ext rfl (funext fun v => by
-        simp [Possibility.union, hqnone v])
-    rw [huq]
+    have hqle : q ≤ p := ⟨(Possibility.compat_iff.mp hpq).1.symm, fun v e he =>
+      absurd (Part.dom_iff_mem.mpr ⟨e, he⟩)
+        (Set.eq_empty_iff_forall_notMem.mp hqdom v)⟩
+    rw [le_antisymm (Possibility.union_le le_rfl hqle) (Possibility.le_union_left p q)]
     exact ⟨hp, (Possibility.compat_iff.mp hpq).1.symm ▸ hqpred⟩
   · rintro ⟨hr, hpred⟩
-    refine ⟨r, hr, ⟨r.world, fun _ => none⟩,
-      ⟨Set.ext fun v => by simp [Possibility.domain], hpred⟩,
-      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => by simp at h⟩, ?_⟩
-    exact Possibility.ext rfl (funext fun v => by simp [Possibility.union])
+    have hqle : (⟨r.world, fun _ => ⊥⟩ : Possibility W V (Part M)) ≤ r :=
+      ⟨rfl, fun _ => bot_le⟩
+    refine ⟨r, hr, ⟨r.world, fun _ => ⊥⟩,
+      ⟨Set.eq_empty_iff_forall_notMem.mpr fun _ hv => hv, hpred⟩,
+      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => absurd h (Part.notMem_none _)⟩, ?_⟩
+    exact (le_antisymm (Possibility.union_le le_rfl hqle)
+      (Possibility.le_union_left ..)).symm
 
 /-- Rule (13), the familiar regime: at a familiar card the atom
 filters — and in particular is eliminative. -/
-theorem atomVar_eq_of_familiar [DecidableEq V] (pred : M → Prop) (x : V)
+theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
     {F : State W V M} (hfam : Familiar F x) :
     atomVar pred x F =
-      Part.some {p ∈ F | ∃ m, p.assignment x = some m ∧ pred m} := by
+      Part.some {p ∈ F | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
   · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
-    have hqnone : ∀ v, v ≠ x → q.assignment v = none := fun v hv =>
-      Option.not_isSome_iff_eq_none.mp fun hs => hv (by
-        have : v ∈ q.domain := hs
-        rwa [hqdom] at this)
-    obtain ⟨m₀, hpx⟩ := Option.ne_none_iff_exists'.mp (hfam p hp)
-    have huq : p.union q = p :=
-      Possibility.ext rfl (funext fun v => by
-        by_cases hv : v = x
-        · subst hv; simp [Possibility.union, hpx]
-        · simp [Possibility.union, hqnone v hv])
-    rw [huq]
-    exact ⟨hp, m₀, hpx, by rw [(Possibility.compat_iff.mp hpq).2 x m₀ m hpx hqx]; exact hpred⟩
+    obtain ⟨hw, hag⟩ := Possibility.compat_iff.mp hpq
+    obtain ⟨m₀, hpx⟩ := Part.dom_iff_mem.mp (hfam p hp)
+    have hqle : q ≤ p := ⟨hw.symm, fun v e he => by
+      have hveq : v = x := hqdom.subset (Part.dom_iff_mem.mpr ⟨e, he⟩)
+      subst hveq
+      exact (Part.mem_unique he hqx).trans (hag v m₀ m hpx hqx).symm ▸ hpx⟩
+    rw [le_antisymm (Possibility.union_le le_rfl hqle) (Possibility.le_union_left p q)]
+    exact ⟨hp, m₀, hpx, hag x m₀ m hpx hqx ▸ hpred⟩
   · rintro ⟨hr, m, hrx, hpred⟩
-    refine ⟨r, hr, ⟨r.world, fun v => if v = x then some m else none⟩,
-      ⟨Set.ext fun v => by by_cases hv : v = x <;>
-        simp [Possibility.domain, hv], m, by simp, hpred⟩,
+    have hqle : (⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩ : Possibility W V (Part M)) ≤ r :=
+      ⟨rfl, fun v e he => by obtain ⟨rfl, rfl⟩ := he; exact hrx⟩
+    refine ⟨r, hr, ⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩,
+      ⟨Set.ext fun v => Iff.rfl, m, ⟨rfl, rfl⟩, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
-    · have he2 : (if v = x then some m else none) = some e' := he'
-      by_cases hv : v = x
-      · rw [if_pos hv] at he2
-        rw [hv, hrx] at he
-        exact (Option.some_inj.mp he).symm.trans (Option.some_inj.mp he2)
-      · rw [if_neg hv] at he2
-        simp at he2
-    · refine Possibility.ext rfl (funext fun v => ?_)
-      by_cases hv : v = x
-      · subst hv; simp [Possibility.union, hrx]
-      · simp [Possibility.union, hv]
+    · obtain ⟨rfl, rfl⟩ := he'
+      exact Part.mem_unique he hrx
+    · exact (le_antisymm (Possibility.union_le le_rfl hqle)
+        (Possibility.le_union_left ..)).symm
 
 /-- Rule (18), the novel regime: at a novel card the atom extends each
 point with every witness — random assignment then filtering, in one
 step. The indefinite needs no extra content clause; `indef` adds only
 the Novelty guard. -/
 theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
-    {F : State W V M} (hnov : ∀ p ∈ F, p.assignment x = none) :
+    {F : State W V M} (hnov : ∀ p ∈ F, ¬(p.assignment x).Dom) :
     atomVar pred x F = Part.some
-      {p ∈ State.randomAssign F x |
-        ∃ m, p.assignment x = some m ∧ pred m} := by
+      {p ∈ State.randomAssign F x | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
   · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
-    have hqnone : ∀ v, v ≠ x → q.assignment v = none := fun v hv =>
-      Option.not_isSome_iff_eq_none.mp fun hs => hv (by
-        have : v ∈ q.domain := hs
-        rwa [hqdom] at this)
-    have huq : p.union q = p.update x (some m) :=
+    have huq : p.union q = p.update x (Part.some m) :=
       Possibility.ext rfl (funext fun v => by
         by_cases hv : v = x
-        · subst hv; simp [Possibility.union, Possibility.update,
-            hnov p hp, hqx]
-        · simp [Possibility.union, Possibility.update, hqnone v hv, hv])
+        · subst hv
+          simp only [Possibility.union, Possibility.update_assignment,
+            Function.update_self]
+          rw [if_neg (hnov p hp)]
+          exact Part.eq_some_iff.mpr hqx
+        · have hqv : q.assignment v = ⊥ :=
+            Part.eq_none_iff'.mpr fun hd => hv (hqdom.subset hd)
+          by_cases hdp : (p.assignment v).Dom
+          · simp [Possibility.union, Possibility.update, hdp, Function.update_of_ne hv]
+          · have hpv : p.assignment v = ⊥ := Part.eq_none_iff'.mpr hdp
+            simp [Possibility.union, Possibility.update, hqv, hpv,
+              Function.update_of_ne hv])
     rw [huq]
-    exact ⟨⟨p, hp, m, rfl⟩, m, by simp, hpred⟩
+    exact ⟨⟨p, hp, m, rfl⟩, m, by simp [Possibility.update], hpred⟩
   · rintro ⟨hmem, m, hrx, hpred⟩
     obtain ⟨p, hp, m', rfl⟩ := hmem
-    simp only [Possibility.update_assignment, Function.update_self] at hrx
-    obtain rfl := (Option.some_inj.mp hrx).symm
-    refine ⟨p, hp, ⟨p.world, fun v => if v = x then some m else none⟩,
-      ⟨Set.ext fun v => by by_cases hv : v = x <;>
-        simp [Possibility.domain, hv], m, by simp, hpred⟩,
+    obtain rfl : m = m' := by
+      simpa [Possibility.update] using hrx
+    refine ⟨p, hp, ⟨p.world, fun v => ⟨v = x, fun _ => m⟩⟩,
+      ⟨Set.ext fun v => Iff.rfl, m, ⟨rfl, rfl⟩, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
-    · have he2 : (if v = x then some m else none) = some e' := he'
+    · obtain ⟨rfl, rfl⟩ := he'
+      exact absurd (Part.dom_iff_mem.mpr ⟨e, he⟩) (hnov p hp)
+    · refine Possibility.ext rfl (funext fun v => ?_)
       by_cases hv : v = x
-      · rw [hv, hnov p hp] at he
-        simp at he
-      · rw [if_neg hv] at he2
-        simp at he2
-    · refine Possibility.ext (by simp [Possibility.union]) (funext fun v => ?_)
-      by_cases hv : v = x
-      · rw [hv]
-        simp [Possibility.union, Possibility.update, hnov p hp]
-      · simp [Possibility.union, Possibility.update, hv]
+      · subst hv
+        simp only [Possibility.union, Possibility.update_assignment,
+          Function.update_self]
+        rw [if_neg (hnov p hp)]
+        symm
+        exact Part.eq_some_iff.mpr ⟨rfl, rfl⟩
+      · have hqv : (⟨v = x, fun _ => m⟩ : Part M) = ⊥ :=
+          Part.eq_none_iff'.mpr fun hd => hv hd
+        by_cases hdp : (p.assignment v).Dom
+        · simp [Possibility.union, Possibility.update, hdp, Function.update_of_ne hv]
+        · have hpv : p.assignment v = ⊥ := Part.eq_none_iff'.mpr hdp
+          simp [Possibility.union, Possibility.update, hqv, hpv,
+            Function.update_of_ne hv]
 
 /-- World atoms are eliminative (the familiar face of Principle (A)). -/
 theorem atomW_eliminative (pred : W → Prop) {F F' : State W V M}
@@ -307,7 +306,7 @@ theorem atomW_eliminative (pred : W → Prop) {F F' : State W V M}
   exact fun p hp => hp.1
 
 /-- Variable atoms are eliminative at familiar cards. -/
-theorem atomVar_eliminative [DecidableEq V] (pred : M → Prop) (x : V)
+theorem atomVar_eliminative (pred : M → Prop) (x : V)
     {F F' : State W V M}
     (hfam : Familiar F x) (h : F' ∈ atomVar pred x F) : F' ⊆ F := by
   rw [atomVar_eq_of_familiar pred x hfam] at h

--- a/Linglib/Semantics/Dynamic/Partial.lean
+++ b/Linglib/Semantics/Dynamic/Partial.lean
@@ -15,7 +15,7 @@ of partial-function composition, true by construction (`admits_seq`).
 
 This is partiality of the *arrow*, and it is orthogonal to the partiality
 of the *points*: DRT's embeddings are partial assignments of discourse
-referents (`Possibility.domain`, `Option`-valued — `Dynamic/State.lean`),
+referents (`Possibility.domain`, `Part`-valued — `Dynamic/State.lean`),
 which encodes referential growth, not presupposition. The two compose in
 `Dynamic/FileChange.lean`, where `FCP` is `CCP.Partial` at partial-point
 states. ([haug-2014]'s "partial dynamic semantics" is the *point* sense.)

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,6 +1,4 @@
 import Linglib.Core.Order.Flat
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Set.Function
 
 /-!
@@ -14,7 +12,7 @@ classification of each stratum as world–assignment pairs.
 ## References
 
 - [groenendijk-stokhof-veltman-1996], [elliott-sudo-2025]
-- [kamp-vangenabith-reyle-2011], Def. 22
+- [kamp-vangenabith-reyle-2011], Def. 0.22
 - [heim-1982]
 -/
 
@@ -51,12 +49,15 @@ end Update
 
 variable {p q u : Possibility W V (Option M)}
 
-/-- Descent orders partial points: same world, assignments pointwise in
-the flat information order ([elliott-sudo-2025], Def. 3.3). -/
-instance : Preorder (Possibility W V (Option M)) where
+/-- A partial point lies below another in the *descent* order when they
+share their world and the assignments grow pointwise in the flat
+information order ([elliott-sudo-2025], Def. 3.3). -/
+instance : PartialOrder (Possibility W V (Option M)) where
   le p q := p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x)
-  le_refl _ := ⟨rfl, fun x => Option.FlatLE.refl _⟩
+  le_refl _ := ⟨rfl, fun _ => .refl _⟩
   le_trans _ _ _ hpq hqr := ⟨hpq.1.trans hqr.1, fun x => (hpq.2 x).trans (hqr.2 x)⟩
+  le_antisymm _ _ hpq hqp :=
+    Possibility.ext hpq.1 (funext fun x => (hpq.2 x).antisymm (hqp.2 x))
 
 theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x) :=
   Iff.rfl
@@ -71,36 +72,63 @@ def domain (p : Possibility W V (Option M)) : Set V :=
 /-- Descent grows the domain. -/
 theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v => (h.2 v).isSome_mono
 
-/-- On a shared domain, descent is equality: there is no room to
-grow. -/
+/-- On a shared domain, descent is equality — there is no room to grow. -/
 theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q :=
-  Possibility.ext h.1 (funext fun v =>
-    (h.2 v).eq_of_isSome fun hv => (Set.ext_iff.mp hdom v).mpr hv)
+  Possibility.ext h.1 <| funext fun v => (h.2 v).eq_of_isSome fun hv => hdom.superset hv
 
-/-- Two partial points are *compatible*: same world, agreeing wherever
-both are defined — [kamp-vangenabith-reyle-2011] Def. 26's condition
-that the union of chosen points be a function. -/
+/-- Two partial points are *compatible* if they share their world and
+agree wherever both are defined — the requirement in
+[kamp-vangenabith-reyle-2011], Def. 0.26, that the union of chosen
+points be a function. Equivalently, the pair is bounded above in the
+descent order (`compatible_iff_bddAbove`). -/
 def Compatible (p q : Possibility W V (Option M)) : Prop :=
   p.world = q.world ∧
     ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e'
 
-/-- The union of two points: defined wherever either is, the left
-taking precedence (agreement makes the choice immaterial). -/
-def union (p q : Possibility W V (Option M)) :
-    Possibility W V (Option M) :=
+theorem Compatible.symm (h : p.Compatible q) : q.Compatible p :=
+  ⟨h.1.symm, fun v e e' hq hp => (h.2 v e' e hp hq).symm⟩
+
+/-- The union of two points, defined wherever either is, with the left
+taking precedence; on compatible points the precedence is immaterial
+(`Compatible.union_comm`). -/
+def union (p q : Possibility W V (Option M)) : Possibility W V (Option M) :=
   ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
 
-theorem le_union_left (p q : Possibility W V (Option M)) :
-    p ≤ p.union q :=
-  ⟨rfl, fun v e h => by simp [union, show p.assignment v = some e from h]⟩
+theorem le_union_left (p q : Possibility W V (Option M)) : p ≤ p.union q :=
+  ⟨rfl, fun v e h => by simp [union, Option.mem_def.mp h]⟩
 
-theorem Compatible.le_union_right (h : p.Compatible q) :
-    q ≤ p.union q :=
+theorem Compatible.le_union_right (h : p.Compatible q) : q ≤ p.union q :=
   ⟨h.1.symm, fun v e hq => by
-    have hq' : q.assignment v = some e := hq
     rcases hp : p.assignment v with _ | e'
-    · simp [union, hp, hq']
-    · simp [union, hp, h.2 v e' e hp hq']⟩
+    · simpa [union, hp] using hq
+    · simpa [union, hp] using h.2 v e' e hp (Option.mem_def.mp hq)⟩
+
+theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
+  ⟨hp.1, fun v e h => by
+    rcases hpv : p.assignment v with _ | e'
+    · exact hq.2 v e (by simpa [union, hpv] using h)
+    · obtain rfl : e' = e := by simpa [union, hpv] using h
+      exact hp.2 v e' hpv⟩
+
+/-- Points below a common point are compatible. -/
+theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
+  ⟨hp.1.trans hq.1.symm, fun v e e' he he' =>
+    Option.some_injective M ((Option.mem_def.mp (hp.2 v e he)).symm.trans
+      (Option.mem_def.mp (hq.2 v e' he')))⟩
+
+/-- The union of compatible points is their least upper bound. -/
+theorem Compatible.isLUB_union (h : p.Compatible q) : IsLUB {p, q} (p.union q) :=
+  ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨le_union_left p q, h.le_union_right⟩,
+    fun _ hu =>
+      have h := PartialUnify.mem_upperBounds_pair.mp hu
+      union_le h.1 h.2⟩
+
+/-- Compatibility is boundedness above in the descent order — the
+consistency relation `Compat` of the unification substrate. -/
+theorem compatible_iff_bddAbove : p.Compatible q ↔ BddAbove {p, q} :=
+  ⟨fun h => ⟨p.union q, h.isLUB_union.1⟩, fun ⟨_, hu⟩ =>
+    have h := PartialUnify.mem_upperBounds_pair.mp hu
+    compatible_of_le_of_le h.1 h.2⟩
 
 /-- On a shared domain, compatibility is equality. -/
 theorem Compatible.eq_of_domain_eq (h : p.Compatible q)
@@ -108,49 +136,26 @@ theorem Compatible.eq_of_domain_eq (h : p.Compatible q)
   eq_of_le_of_domain_eq
     ⟨h.1, fun v e hv => by
       obtain ⟨e', he'⟩ := Option.isSome_iff_exists.mp
-        ((Set.ext_iff.mp hdom v).mp (Option.isSome_iff_exists.mpr ⟨e, hv⟩))
-      exact he'.trans (congrArg some (h.2 v e e' hv he').symm)⟩
+        (hdom.subset (Option.isSome_iff_exists.mpr ⟨e, hv⟩))
+      exact (h.2 v e e' hv he').symm ▸ he'⟩
     hdom
 
-/-- Union of points unites domains. -/
+/-- The union of two points defines the union of their domains. -/
 theorem domain_union (p q : Possibility W V (Option M)) :
     (p.union q).domain = p.domain ∪ q.domain := by
   ext v
   rcases hp : p.assignment v with _ | e <;> simp [union, domain, hp]
 
-/-- Points below a common point are compatible. -/
-theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
-  ⟨hp.1.trans hq.1.symm, fun v e e' he he' => by
-    have h1 : u.assignment v = some e := hp.2 v e he
-    have h2 : u.assignment v = some e' := hq.2 v e' he'
-    rw [h1] at h2
-    exact (Option.some.injEq .. ▸ h2 :)⟩
-
-/-- The union of two lower bounds is a lower bound. -/
-theorem union_le (hp : p ≤ u) (hq : q ≤ u) :
-    p.union q ≤ u :=
-  ⟨hp.1, fun v e h => by
-    have h' : (p.union q).assignment v = some e := h
-    rcases hpv : p.assignment v with _ | e'
-    · exact hq.2 v e (by simpa [union, hpv] using h')
-    · have : e' = e := by simpa [union, hpv] using h'
-      exact this ▸ hp.2 v e' hpv⟩
-
-theorem Compatible.symm (h : p.Compatible q) : q.Compatible p :=
-  ⟨h.1.symm, fun v e e' hq hp => (h.2 v e' e hp hq).symm⟩
-
-/-- Union of points is associative. -/
 theorem union_assoc (p q v : Possibility W V (Option M)) :
     (p.union q).union v = p.union (q.union v) :=
   Possibility.ext rfl (funext fun _ => Option.or_assoc ..)
 
-/-- On compatible points the left precedence of `union` is
-immaterial. -/
+/-- On compatible points the left precedence of `union` is immaterial. -/
 theorem Compatible.union_comm (h : p.Compatible q) : p.union q = q.union p :=
-  Possibility.ext h.1 (funext fun v => by
-    rcases hp : p.assignment v with _ | e <;>
-      rcases hq : q.assignment v with _ | e' <;> simp [union, hp, hq]
-    exact h.2 v e e' hp hq)
+  Possibility.ext h.1 <| funext fun v => by
+    rcases hp : p.assignment v with _ | e <;> rcases hq : q.assignment v with _ | e' <;>
+      simp [union, hp, hq]
+    exact h.2 v e e' hp hq
 
 /-- A union is compatible with whatever both components are compatible
 with. -/
@@ -159,23 +164,23 @@ theorem Compatible.union_left (hpu : p.Compatible u) (hqu : q.Compatible u) :
   ⟨hpu.1, fun x e e' he he' => by
     rcases hp : p.assignment x with _ | c
     · exact hqu.2 x e e' (by simpa [union, hp] using he) he'
-    · have hce : c = e := by simpa [union, hp] using he
-      exact hce ▸ hpu.2 x c e' hp he'⟩
+    · obtain rfl : c = e := by simpa [union, hp] using he
+      exact hpu.2 x c e' hp he'⟩
 
 /-- The left component of a compatible union is compatible. -/
 theorem Compatible.left_of_union
     (h : (p.union q).Compatible u) : p.Compatible u :=
-  ⟨h.1, fun x e e' hp hv => h.2 x e e' (by simp [union, hp]) hv⟩
+  ⟨h.1, fun x e e' hp hu => h.2 x e e' (by simp [union, hp]) hu⟩
 
 /-- The right component of a compatible union is compatible, given the
 components agree. -/
 theorem Compatible.right_of_union
     (hpq : p.Compatible q) (h : (p.union q).Compatible u) :
     q.Compatible u :=
-  ⟨hpq.1.symm.trans h.1, fun x e e' hq hv => by
+  ⟨hpq.1.symm.trans h.1, fun x e e' hq hu => by
     rcases hp : p.assignment x with _ | c
-    · exact h.2 x e e' (by simp [union, hp, hq]) hv
-    · exact hpq.2 x c e hp hq ▸ h.2 x c e' (by simp [union, hp]) hv⟩
+    · exact h.2 x e e' (by simp [union, hp, hq]) hu
+    · exact hpq.2 x c e hp hq ▸ h.2 x c e' (by simp [union, hp]) hu⟩
 
 /-! ### Restriction and the indexed classification -/
 
@@ -205,73 +210,49 @@ theorem domain_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
   ext v
   by_cases hv : v ∈ X <;> simp [restrict, domain, hv]
 
-/-- Descent out of a stratum is *being the restriction*: for `p` at
-`X`, `p` grows into `q` exactly when `p` is `q` cut to `X`. The
-hom-characterization of the fibred order. -/
+/-- A point with domain `X` descends into `q` exactly when it is `q`
+restricted to `X`. -/
 theorem le_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
     (hp : p.domain = X) :
     p ≤ q ↔ p = q.restrict X := by
-  constructor
-  · intro h
-    refine Possibility.ext h.1 (funext fun v => ?_)
-    by_cases hv : v ∈ X
-    · have hsome : (p.assignment v).isSome :=
-        (Set.ext_iff.mp hp v).mpr hv
-      obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp hsome
-      rw [he]
-      simp only [restrict, if_pos hv]
-      exact (h.2 v e he).symm
-    · have hnone : p.assignment v = none :=
-        Option.not_isSome_iff_eq_none.mp
-          fun hs => hv ((Set.ext_iff.mp hp v).mp hs)
-      rw [hnone]
-      simp [restrict, hv]
-  · rintro rfl
-    exact restrict_le X q
+  refine ⟨fun h => Possibility.ext h.1 (funext fun v => ?_), fun h => h ▸ restrict_le X q⟩
+  by_cases hv : v ∈ X
+  · obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp (hp.superset hv)
+    simp only [restrict, if_pos hv]
+    exact he.trans (Option.mem_def.mp (h.2 v e he)).symm
+  · rw [Option.not_isSome_iff_eq_none.mp fun hs => hv (hp.subset hs)]
+    simp [restrict, hv]
 
-/-- Restriction is pointwise idempotent along intersections. -/
+/-- Consecutive restrictions restrict to the intersection. -/
 theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
     [∀ v, Decidable (v ∈ Y)] (p : Possibility W V (Option M)) :
-    (p.restrict Y).restrict X = p.restrict (X ∩ Y) := by
-  refine Possibility.ext rfl (funext fun v => ?_)
-  by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;>
-    simp [restrict, hx, hy]
+    (p.restrict Y).restrict X = p.restrict (X ∩ Y) :=
+  Possibility.ext rfl <| funext fun v => by
+    by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;> simp [restrict, hx, hy]
 
-/-- Partial points with domain `X` are world–`X`-assignment pairs —
-constructively: the classification that the total-assignment rendering
-recovered only with choice and an inhabitant of `M`. -/
+/-- Partial points with domain `X` are exactly world–`X`-assignment
+pairs. -/
 def domainEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
     {p : Possibility W V (Option M) // p.domain = X} ≃ W × (X → M) where
-  toFun p :=
-    (p.1.world, fun v => (p.1.assignment v.1).get
-      ((Set.ext_iff.mp p.2 v.1).mpr v.2))
+  toFun p := (p.1.world, fun v => (p.1.assignment v.1).get (p.2.superset v.2))
   invFun e :=
-    ⟨⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩)
-      else none⟩, by
+    ⟨⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩) else none⟩, by
       ext v
       by_cases h : v ∈ X <;> simp [domain, h]⟩
-  left_inv p := by
-    obtain ⟨⟨w, g⟩, hp⟩ := p
-    refine Subtype.ext (Possibility.ext rfl (funext fun v => ?_))
+  left_inv p := Subtype.ext <| Possibility.ext rfl <| funext fun v => by
     by_cases h : v ∈ X
     · simp only [dif_pos h, Option.some_get]
-    · have hnone : g v = none := Option.not_isSome_iff_eq_none.mp
-        fun hs => h ((Set.ext_iff.mp hp v).mp hs)
-      simp only [dif_neg h]
-      exact hnone.symm
-  right_inv e := by
-    refine Prod.ext rfl (funext fun v => ?_)
-    simp
+    · exact (dif_neg h).trans
+        (Option.not_isSome_iff_eq_none.mp fun hs => h (p.2.subset hs)).symm
+  right_inv e := Prod.ext rfl (funext fun v => by simp)
 
 theorem domainEquiv_symm_val (X : Set V) [∀ v, Decidable (v ∈ X)]
     (e : W × (X → M)) :
     ((domainEquiv X).symm e).1 =
-      ⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩)
-        else none⟩ :=
+      ⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩) else none⟩ :=
   rfl
 
-/-- The charts commute with restriction: restricting a classified point
-is weakening its chart. -/
+/-- Restricting a classified point restricts its chart. -/
 theorem restrict_domainEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
     [∀ v, Decidable (v ∈ Y)] (h : Y ⊆ X) (e : W × (X → M)) :
     ((domainEquiv X).symm e).1.restrict Y =
@@ -279,8 +260,7 @@ theorem restrict_domainEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
   rw [domainEquiv_symm_val, domainEquiv_symm_val]
   refine Possibility.ext rfl (funext fun v => ?_)
   by_cases hv : v ∈ Y
-  · have hvX : v ∈ X := h hv
-    simp [restrict, hv, hvX]
+  · simp [restrict, hv, h hv]
   · simp [restrict, hv]
 
 end Restrict
@@ -295,14 +275,16 @@ FCS/DRT's pairs. Propositional inquisitive semantics instead *iterates*
 the construction — its points are sets of worlds — a level shift, not a
 parameter choice. -/
 
-/-- Worlds-only points: propositional update semantics. -/
+/-- Worlds-only points are bare worlds — the points of propositional
+update semantics. -/
 def worldEquiv (W M : Type*) : Possibility W Empty M ≃ W where
   toFun p := p.world
   invFun w := ⟨w, Empty.elim⟩
   left_inv _ := Possibility.ext rfl (funext fun v => v.elim)
   right_inv _ := rfl
 
-/-- Assignments-only points: lifted DPL. -/
+/-- Assignment-only points are bare assignments — the points of lifted
+DPL. -/
 def assignmentEquiv (V M : Type*) : Possibility Unit V M ≃ (V → M) where
   toFun p := p.assignment
   invFun g := ⟨(), g⟩

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -50,10 +50,8 @@ end Update
 
 variable {p q u : Possibility W V (Option M)}
 
-/-- A partial point lies below another in the *descent* order when they
-share their world and the assignments grow pointwise in the flat
-information order ([elliott-sudo-2025], Def. 3.3); cf.
-`orderIsoSigmaFlat`. -/
+/-- `p ≤ q` iff `p` and `q` share their world and the assignments grow
+pointwise in the flat information order. -/
 instance : PartialOrder (Possibility W V (Option M)) where
   le p q := p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x)
   le_refl _ := ⟨rfl, fun _ => .refl _⟩

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Order.Flat
 import Mathlib.Data.Set.Function
+import Mathlib.Data.Sigma.Order
 
 /-!
 # Possibilities
@@ -51,7 +52,8 @@ variable {p q u : Possibility W V (Option M)}
 
 /-- A partial point lies below another in the *descent* order when they
 share their world and the assignments grow pointwise in the flat
-information order ([elliott-sudo-2025], Def. 3.3). -/
+information order ([elliott-sudo-2025], Def. 3.3); cf.
+`orderIsoSigmaFlat`. -/
 instance : PartialOrder (Possibility W V (Option M)) where
   le p q := p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x)
   le_refl _ := ⟨rfl, fun _ => .refl _⟩
@@ -61,6 +63,25 @@ instance : PartialOrder (Possibility W V (Option M)) where
 
 theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x) :=
   Iff.rfl
+
+/-- The descent order is assembled from library orders, not hand-rolled:
+partial points are order-isomorphic to `Σ _ : W, (V → Flat M)` — the
+disjoint sum, over worlds, of the pointwise flat orders. -/
+def orderIsoSigmaFlat :
+    Possibility W V (Option M) ≃o Σ _ : W, (V → Flat M) where
+  toFun p := ⟨p.world, p.assignment⟩
+  invFun x := ⟨x.1, x.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_rel_iff' {p q} := by
+    obtain ⟨pw, pa⟩ := p
+    obtain ⟨qw, qa⟩ := q
+    constructor
+    · intro h
+      cases h with
+      | fiber _ _ _ hab => exact ⟨rfl, hab⟩
+    · rintro ⟨rfl, hle⟩
+      exact Sigma.LE.fiber _ _ _ hle
 
 /-- The domain of a partial point is the set of referents it defines. -/
 def domain (p : Possibility W V (Option M)) : Set V :=
@@ -76,32 +97,22 @@ theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v => (h.2 v).is
 theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q :=
   Possibility.ext h.1 <| funext fun v => (h.2 v).eq_of_isSome fun hv => hdom.superset hv
 
-/-- Two partial points are *compatible* if they share their world and
-agree wherever both are defined — the requirement in
-[kamp-vangenabith-reyle-2011], Def. 0.26, that the union of chosen
-points be a function. Equivalently, the pair is bounded above in the
-descent order (`compatible_iff_bddAbove`). -/
-def Compatible (p q : Possibility W V (Option M)) : Prop :=
-  p.world = q.world ∧
-    ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e'
-
-theorem Compatible.symm (h : p.Compatible q) : q.Compatible p :=
-  ⟨h.1.symm, fun v e e' hq hp => (h.2 v e' e hp hq).symm⟩
-
 /-- The union of two points, defined wherever either is, with the left
 taking precedence; on compatible points the precedence is immaterial
-(`Compatible.union_comm`). -/
+(`union_comm`). -/
 def union (p q : Possibility W V (Option M)) : Possibility W V (Option M) :=
   ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
 
 theorem le_union_left (p q : Possibility W V (Option M)) : p ≤ p.union q :=
   ⟨rfl, fun v e h => by simp [union, Option.mem_def.mp h]⟩
 
-theorem Compatible.le_union_right (h : p.Compatible q) : q ≤ p.union q :=
-  ⟨h.1.symm, fun v e hq => by
+private theorem le_union_right_of_agree (hw : p.world = q.world)
+    (hag : ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e') :
+    q ≤ p.union q :=
+  ⟨hw.symm, fun v e hq => by
     rcases hp : p.assignment v with _ | e'
     · simpa [union, hp] using hq
-    · simpa [union, hp] using h.2 v e' e hp (Option.mem_def.mp hq)⟩
+    · simpa [union, hp] using hag v e' e hp (Option.mem_def.mp hq)⟩
 
 theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
   ⟨hp.1, fun v e h => by
@@ -110,35 +121,33 @@ theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
     · obtain rfl : e' = e := by simpa [union, hpv] using h
       exact hp.2 v e' hpv⟩
 
-/-- Points below a common point are compatible. -/
-theorem compatible_of_le_of_le (hp : p ≤ u) (hq : q ≤ u) : p.Compatible q :=
-  ⟨hp.1.trans hq.1.symm, fun v e e' he he' =>
-    Option.some_injective M ((Option.mem_def.mp (hp.2 v e he)).symm.trans
-      (Option.mem_def.mp (hq.2 v e' he')))⟩
+/-- Two partial points are compatible (`Compat`: bounded above in the
+descent order) exactly when they share their world and agree wherever
+both are defined — the requirement in [kamp-vangenabith-reyle-2011],
+Def. 0.26, that the union of chosen points be a function. -/
+theorem compat_iff : Compat p q ↔
+    p.world = q.world ∧
+      ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e' := by
+  constructor
+  · rintro ⟨u, hu⟩
+    obtain ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+    exact ⟨hp.1.trans hq.1.symm, fun v e e' he he' =>
+      Option.some_injective M ((Option.mem_def.mp (hp.2 v e he)).symm.trans
+        (Option.mem_def.mp (hq.2 v e' he')))⟩
+  · rintro ⟨hw, hag⟩
+    exact ⟨p.union q, PartialUnify.mem_upperBounds_pair.mpr
+      ⟨le_union_left p q, le_union_right_of_agree hw hag⟩⟩
+
+theorem le_union_right (h : Compat p q) : q ≤ p.union q :=
+  have h' := compat_iff.mp h
+  le_union_right_of_agree h'.1 h'.2
 
 /-- The union of compatible points is their least upper bound. -/
-theorem Compatible.isLUB_union (h : p.Compatible q) : IsLUB {p, q} (p.union q) :=
-  ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨le_union_left p q, h.le_union_right⟩,
+theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
+  ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨le_union_left p q, le_union_right h⟩,
     fun _ hu =>
       have h := PartialUnify.mem_upperBounds_pair.mp hu
       union_le h.1 h.2⟩
-
-/-- Compatibility is boundedness above in the descent order — the
-consistency relation `Compat` of the unification substrate. -/
-theorem compatible_iff_bddAbove : p.Compatible q ↔ BddAbove {p, q} :=
-  ⟨fun h => ⟨p.union q, h.isLUB_union.1⟩, fun ⟨_, hu⟩ =>
-    have h := PartialUnify.mem_upperBounds_pair.mp hu
-    compatible_of_le_of_le h.1 h.2⟩
-
-/-- On a shared domain, compatibility is equality. -/
-theorem Compatible.eq_of_domain_eq (h : p.Compatible q)
-    (hdom : p.domain = q.domain) : p = q :=
-  eq_of_le_of_domain_eq
-    ⟨h.1, fun v e hv => by
-      obtain ⟨e', he'⟩ := Option.isSome_iff_exists.mp
-        (hdom.subset (Option.isSome_iff_exists.mpr ⟨e, hv⟩))
-      exact (h.2 v e e' hv he').symm ▸ he'⟩
-    hdom
 
 /-- The union of two points defines the union of their domains. -/
 theorem domain_union (p q : Possibility W V (Option M)) :
@@ -146,41 +155,42 @@ theorem domain_union (p q : Possibility W V (Option M)) :
   ext v
   rcases hp : p.assignment v with _ | e <;> simp [union, domain, hp]
 
+/-- On a shared domain, compatibility is equality. -/
+theorem eq_of_compat_of_domain_eq (h : Compat p q) (hdom : p.domain = q.domain) :
+    p = q :=
+  have hu : (p.union q).domain = p.domain := by rw [domain_union, ← hdom, Set.union_self]
+  (eq_of_le_of_domain_eq (le_union_left p q) hu.symm).trans
+    (eq_of_le_of_domain_eq (le_union_right h) (hdom.symm.trans hu.symm)).symm
+
 theorem union_assoc (p q v : Possibility W V (Option M)) :
     (p.union q).union v = p.union (q.union v) :=
   Possibility.ext rfl (funext fun _ => Option.or_assoc ..)
 
 /-- On compatible points the left precedence of `union` is immaterial. -/
-theorem Compatible.union_comm (h : p.Compatible q) : p.union q = q.union p :=
-  Possibility.ext h.1 <| funext fun v => by
-    rcases hp : p.assignment v with _ | e <;> rcases hq : q.assignment v with _ | e' <;>
-      simp [union, hp, hq]
-    exact h.2 v e e' hp hq
+theorem union_comm (h : Compat p q) : p.union q = q.union p :=
+  (isLUB_union h).unique (Set.pair_comm p q ▸ isLUB_union h.symm)
 
 /-- A union is compatible with whatever both components are compatible
 with. -/
-theorem Compatible.union_left (hpu : p.Compatible u) (hqu : q.Compatible u) :
-    (p.union q).Compatible u :=
-  ⟨hpu.1, fun x e e' he he' => by
-    rcases hp : p.assignment x with _ | c
-    · exact hqu.2 x e e' (by simpa [union, hp] using he) he'
-    · obtain rfl : c = e := by simpa [union, hp] using he
-      exact hpu.2 x c e' hp he'⟩
+theorem compat_union_left (hpu : Compat p u) (hqu : Compat q u) :
+    Compat (p.union q) u := by
+  obtain ⟨hpw, hpa⟩ := compat_iff.mp hpu
+  obtain ⟨hqw, hqa⟩ := compat_iff.mp hqu
+  refine compat_iff.mpr ⟨hpw, fun x e e' he he' => ?_⟩
+  rcases hp : p.assignment x with _ | c
+  · exact hqa x e e' (by simpa [union, hp] using he) he'
+  · obtain rfl : c = e := by simpa [union, hp] using he
+    exact hpa x c e' hp he'
 
 /-- The left component of a compatible union is compatible. -/
-theorem Compatible.left_of_union
-    (h : (p.union q).Compatible u) : p.Compatible u :=
-  ⟨h.1, fun x e e' hp hu => h.2 x e e' (by simp [union, hp]) hu⟩
+theorem compat_of_union_left (h : Compat (p.union q) u) : Compat p u :=
+  h.mono (le_union_left p q) le_rfl
 
 /-- The right component of a compatible union is compatible, given the
 components agree. -/
-theorem Compatible.right_of_union
-    (hpq : p.Compatible q) (h : (p.union q).Compatible u) :
-    q.Compatible u :=
-  ⟨hpq.1.symm.trans h.1, fun x e e' hq hu => by
-    rcases hp : p.assignment x with _ | c
-    · exact h.2 x e e' (by simp [union, hp, hq]) hu
-    · exact hpq.2 x c e hp hq ▸ h.2 x c e' (by simp [union, hp]) hu⟩
+theorem compat_of_union_right (hpq : Compat p q) (h : Compat (p.union q) u) :
+    Compat q u :=
+  h.mono (le_union_right hpq) le_rfl
 
 /-! ### Restriction and the indexed classification -/
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,14 +1,15 @@
-import Linglib.Core.Order.Flat
+import Linglib.Core.Order.PartialUnify
+import Mathlib.Data.Part
 import Mathlib.Data.Set.Function
-import Mathlib.Data.Sigma.Order
 
 /-!
 # Possibilities
 
 This file defines a *possibility* — a world paired with an assignment
-of discourse referents — and the structure of its partial points: the
-descent order, compatibility and union, restriction, and the
-classification of each stratum as world–assignment pairs.
+of discourse referents — and the structure of its partial points, with
+`Part`-valued assignments: the descent order, compatibility and union,
+restriction, and the classification of each stratum as
+world–assignment pairs.
 
 ## References
 
@@ -48,76 +49,67 @@ end Update
 
 /-! ### Partial points -/
 
-variable {p q u : Possibility W V (Option M)}
+variable {p q u : Possibility W V (Part M)}
 
 /-- `p ≤ q` iff `p` and `q` share their world and the assignments grow
-pointwise in the flat information order. -/
-instance : PartialOrder (Possibility W V (Option M)) where
-  le p q := p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x)
-  le_refl _ := ⟨rfl, fun _ => .refl _⟩
+pointwise in the order of partial values. -/
+instance : PartialOrder (Possibility W V (Part M)) where
+  le p q := p.world = q.world ∧ ∀ x, p.assignment x ≤ q.assignment x
+  le_refl _ := ⟨rfl, fun _ => le_rfl⟩
   le_trans _ _ _ hpq hqr := ⟨hpq.1.trans hqr.1, fun x => (hpq.2 x).trans (hqr.2 x)⟩
   le_antisymm _ _ hpq hqp :=
     Possibility.ext hpq.1 (funext fun x => (hpq.2 x).antisymm (hqp.2 x))
 
-theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, (p.assignment x).FlatLE (q.assignment x) :=
+theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, p.assignment x ≤ q.assignment x :=
   Iff.rfl
 
-/-- The descent order is assembled from library orders, not hand-rolled:
-partial points are order-isomorphic to `Σ _ : W, (V → Flat M)` — the
-disjoint sum, over worlds, of the pointwise flat orders. -/
-def orderIsoSigmaFlat :
-    Possibility W V (Option M) ≃o Σ _ : W, (V → Flat M) where
-  toFun p := ⟨p.world, p.assignment⟩
-  invFun x := ⟨x.1, x.2⟩
-  left_inv _ := rfl
-  right_inv _ := rfl
-  map_rel_iff' {p q} := by
-    obtain ⟨pw, pa⟩ := p
-    obtain ⟨qw, qa⟩ := q
-    constructor
-    · intro h
-      cases h with
-      | fiber _ _ _ hab => exact ⟨rfl, hab⟩
-    · rintro ⟨rfl, hle⟩
-      exact Sigma.LE.fiber _ _ _ hle
-
 /-- The domain of a partial point is the set of referents it defines. -/
-def domain (p : Possibility W V (Option M)) : Set V :=
-  {v | (p.assignment v).isSome}
+def domain (p : Possibility W V (Part M)) : Set V :=
+  {v | (p.assignment v).Dom}
 
 @[simp] theorem mem_domain {v : V} :
-    v ∈ p.domain ↔ (p.assignment v).isSome := Iff.rfl
+    v ∈ p.domain ↔ (p.assignment v).Dom := Iff.rfl
 
 /-- Descent grows the domain. -/
-theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v => (h.2 v).isSome_mono
+theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v hd =>
+  Part.dom_iff_mem.mpr ⟨_, h.2 v _ (Part.get_mem hd)⟩
 
 /-- On a shared domain, descent is equality — there is no room to grow. -/
 theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q :=
-  Possibility.ext h.1 <| funext fun v => (h.2 v).eq_of_isSome fun hv => hdom.superset hv
+  Possibility.ext h.1 <| funext fun v => le_antisymm (h.2 v) fun e he => by
+    have hd : (p.assignment v).Dom := hdom.superset (Part.dom_iff_mem.mpr ⟨e, he⟩)
+    obtain rfl := Part.mem_unique (h.2 v _ (Part.get_mem hd)) he
+    exact Part.get_mem hd
 
+open Classical in
 /-- The union of two points, defined wherever either is, with the left
 taking precedence; on compatible points the precedence is immaterial
 (`union_comm`). -/
-def union (p q : Possibility W V (Option M)) : Possibility W V (Option M) :=
-  ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
+noncomputable def union (p q : Possibility W V (Part M)) : Possibility W V (Part M) :=
+  ⟨p.world, fun v => if (p.assignment v).Dom then p.assignment v else q.assignment v⟩
 
-theorem le_union_left (p q : Possibility W V (Option M)) : p ≤ p.union q :=
-  ⟨rfl, fun v e h => by simp [union, Option.mem_def.mp h]⟩
+theorem le_union_left (p q : Possibility W V (Part M)) : p ≤ p.union q :=
+  ⟨rfl, fun v e he => by
+    simp only [union]
+    split
+    · exact he
+    · next h => exact absurd (Part.dom_iff_mem.mpr ⟨e, he⟩) h⟩
 
 private theorem le_union_right_of_agree (hw : p.world = q.world)
-    (hag : ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e') :
+    (hag : ∀ v e e', e ∈ p.assignment v → e' ∈ q.assignment v → e = e') :
     q ≤ p.union q :=
-  ⟨hw.symm, fun v e hq => by
-    rcases hp : p.assignment v with _ | e'
-    · simpa [union, hp] using hq
-    · simpa [union, hp] using hag v e' e hp (Option.mem_def.mp hq)⟩
+  ⟨hw.symm, fun v e he => by
+    simp only [union]
+    split
+    · next hd => exact hag v _ e (Part.get_mem hd) he ▸ Part.get_mem hd
+    · exact he⟩
 
 theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
-  ⟨hp.1, fun v e h => by
-    rcases hpv : p.assignment v with _ | e'
-    · exact hq.2 v e (by simpa [union, hpv] using h)
-    · obtain rfl : e' = e := by simpa [union, hpv] using h
-      exact hp.2 v e' hpv⟩
+  ⟨hp.1, fun v e he => by
+    simp only [union] at he
+    split at he
+    · exact hp.2 v e he
+    · exact hq.2 v e he⟩
 
 /-- Two partial points are compatible (`Compat`: bounded above in the
 descent order) exactly when they share their world and agree wherever
@@ -125,13 +117,12 @@ both are defined — the requirement in [kamp-vangenabith-reyle-2011],
 Def. 0.26, that the union of chosen points be a function. -/
 theorem compat_iff : Compat p q ↔
     p.world = q.world ∧
-      ∀ v e e', p.assignment v = some e → q.assignment v = some e' → e = e' := by
+      ∀ v e e', e ∈ p.assignment v → e' ∈ q.assignment v → e = e' := by
   constructor
   · rintro ⟨u, hu⟩
     obtain ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
-    exact ⟨hp.1.trans hq.1.symm, fun v e e' he he' =>
-      Option.some_injective M ((Option.mem_def.mp (hp.2 v e he)).symm.trans
-        (Option.mem_def.mp (hq.2 v e' he')))⟩
+    exact ⟨hp.1.trans hq.1.symm,
+      fun v e e' he he' => Part.mem_unique (hp.2 v e he) (hq.2 v e' he')⟩
   · rintro ⟨hw, hag⟩
     exact ⟨p.union q, PartialUnify.mem_upperBounds_pair.mpr
       ⟨le_union_left p q, le_union_right_of_agree hw hag⟩⟩
@@ -148,10 +139,10 @@ theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
       union_le h.1 h.2⟩
 
 /-- The union of two points defines the union of their domains. -/
-theorem domain_union (p q : Possibility W V (Option M)) :
+theorem domain_union (p q : Possibility W V (Part M)) :
     (p.union q).domain = p.domain ∪ q.domain := by
   ext v
-  rcases hp : p.assignment v with _ | e <;> simp [union, domain, hp]
+  by_cases h : (p.assignment v).Dom <;> simp [union, domain, h]
 
 /-- On a shared domain, compatibility is equality. -/
 theorem eq_of_compat_of_domain_eq (h : Compat p q) (hdom : p.domain = q.domain) :
@@ -160,9 +151,11 @@ theorem eq_of_compat_of_domain_eq (h : Compat p q) (hdom : p.domain = q.domain) 
   (eq_of_le_of_domain_eq (le_union_left p q) hu.symm).trans
     (eq_of_le_of_domain_eq (le_union_right h) (hdom.symm.trans hu.symm)).symm
 
-theorem union_assoc (p q v : Possibility W V (Option M)) :
+theorem union_assoc (p q v : Possibility W V (Part M)) :
     (p.union q).union v = p.union (q.union v) :=
-  Possibility.ext rfl (funext fun _ => Option.or_assoc ..)
+  Possibility.ext rfl <| funext fun x => by
+    by_cases hp : (p.assignment x).Dom <;> by_cases hq : (q.assignment x).Dom <;>
+      simp [union, hp, hq]
 
 /-- On compatible points the left precedence of `union` is immaterial. -/
 theorem union_comm (h : Compat p q) : p.union q = q.union p :=
@@ -175,10 +168,10 @@ theorem compat_union_left (hpu : Compat p u) (hqu : Compat q u) :
   obtain ⟨hpw, hpa⟩ := compat_iff.mp hpu
   obtain ⟨hqw, hqa⟩ := compat_iff.mp hqu
   refine compat_iff.mpr ⟨hpw, fun x e e' he he' => ?_⟩
-  rcases hp : p.assignment x with _ | c
-  · exact hqa x e e' (by simpa [union, hp] using he) he'
-  · obtain rfl : c = e := by simpa [union, hp] using he
-    exact hpa x c e' hp he'
+  simp only [union] at he
+  split at he
+  · exact hpa x e e' he he'
+  · exact hqa x e e' he he'
 
 /-- The left component of a compatible union is compatible. -/
 theorem compat_of_union_left (h : Compat (p.union q) u) : Compat p u :=
@@ -195,81 +188,59 @@ theorem compat_of_union_right (hpq : Compat p q) (h : Compat (p.union q) u) :
 section Restrict
 
 /-- Restrict a partial point to the referents in `X`. -/
-def restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (p : Possibility W V (Option M)) : Possibility W V (Option M) :=
-  ⟨p.world, fun v => if v ∈ X then p.assignment v else none⟩
+def restrict (X : Set V) (p : Possibility W V (Part M)) : Possibility W V (Part M) :=
+  ⟨p.world, fun v => ⟨v ∈ X ∧ (p.assignment v).Dom, fun h => (p.assignment v).get h.2⟩⟩
 
-@[simp] theorem restrict_world (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (p : Possibility W V (Option M)) :
+@[simp] theorem restrict_world (X : Set V) (p : Possibility W V (Part M)) :
     (p.restrict X).world = p.world := rfl
 
 /-- Restriction descends. -/
-theorem restrict_le (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (p : Possibility W V (Option M)) : p.restrict X ≤ p :=
-  ⟨rfl, fun x e h => by
-    by_cases hx : x ∈ X
-    · simpa [restrict, hx] using h
-    · simp [restrict, hx] at h⟩
+theorem restrict_le (X : Set V) (p : Possibility W V (Part M)) : p.restrict X ≤ p :=
+  ⟨rfl, fun v e he => by
+    obtain ⟨⟨-, hd⟩, rfl⟩ := he
+    exact Part.get_mem hd⟩
 
 /-- Restriction intersects the domain. -/
-theorem domain_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (p : Possibility W V (Option M)) :
-    (p.restrict X).domain = X ∩ p.domain := by
-  ext v
-  by_cases hv : v ∈ X <;> simp [restrict, domain, hv]
+theorem domain_restrict (X : Set V) (p : Possibility W V (Part M)) :
+    (p.restrict X).domain = X ∩ p.domain :=
+  rfl
 
 /-- A point with domain `X` descends into `q` exactly when it is `q`
 restricted to `X`. -/
-theorem le_iff_eq_restrict {X : Set V} [∀ v, Decidable (v ∈ X)]
-    (hp : p.domain = X) :
+theorem le_iff_eq_restrict {X : Set V} (hp : p.domain = X) :
     p ≤ q ↔ p = q.restrict X := by
   refine ⟨fun h => Possibility.ext h.1 (funext fun v => ?_), fun h => h ▸ restrict_le X q⟩
-  by_cases hv : v ∈ X
-  · obtain ⟨e, he⟩ := Option.isSome_iff_exists.mp (hp.superset hv)
-    simp only [restrict, if_pos hv]
-    exact he.trans (Option.mem_def.mp (h.2 v e he)).symm
-  · rw [Option.not_isSome_iff_eq_none.mp fun hs => hv (hp.subset hs)]
-    simp [restrict, hv]
+  refine Part.ext' ⟨fun hd => ⟨hp.subset hd, domain_mono h hd⟩, fun hd => hp.superset hd.1⟩
+    fun hd hd' => ?_
+  exact Part.mem_unique (h.2 v _ (Part.get_mem hd)) (Part.get_mem hd'.2)
 
 /-- Consecutive restrictions restrict to the intersection. -/
-theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
-    [∀ v, Decidable (v ∈ Y)] (p : Possibility W V (Option M)) :
+theorem restrict_restrict (X Y : Set V) (p : Possibility W V (Part M)) :
     (p.restrict Y).restrict X = p.restrict (X ∩ Y) :=
-  Possibility.ext rfl <| funext fun v => by
-    by_cases hx : v ∈ X <;> by_cases hy : v ∈ Y <;> simp [restrict, hx, hy]
+  Possibility.ext rfl <| funext fun v =>
+    Part.ext' (by simp [restrict, Set.mem_inter_iff, and_assoc]) fun _ _ => rfl
 
 /-- Partial points with domain `X` are exactly world–`X`-assignment
 pairs. -/
-def domainEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
-    {p : Possibility W V (Option M) // p.domain = X} ≃ W × (X → M) where
+def domainEquiv (X : Set V) :
+    {p : Possibility W V (Part M) // p.domain = X} ≃ W × (X → M) where
   toFun p := (p.1.world, fun v => (p.1.assignment v.1).get (p.2.superset v.2))
-  invFun e :=
-    ⟨⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩) else none⟩, by
-      ext v
-      by_cases h : v ∈ X <;> simp [domain, h]⟩
-  left_inv p := Subtype.ext <| Possibility.ext rfl <| funext fun v => by
-    by_cases h : v ∈ X
-    · simp only [dif_pos h, Option.some_get]
-    · exact (dif_neg h).trans
-        (Option.not_isSome_iff_eq_none.mp fun hs => h (p.2.subset hs)).symm
-  right_inv e := Prod.ext rfl (funext fun v => by simp)
+  invFun e := ⟨⟨e.1, fun v => ⟨v ∈ X, fun h => e.2 ⟨v, h⟩⟩⟩, rfl⟩
+  left_inv p := Subtype.ext <| Possibility.ext rfl <| funext fun _ =>
+    Part.ext' ⟨fun hx => p.2.superset hx, fun hd => p.2.subset hd⟩ fun _ _ => rfl
+  right_inv _ := rfl
 
-theorem domainEquiv_symm_val (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (e : W × (X → M)) :
-    ((domainEquiv X).symm e).1 =
-      ⟨e.1, fun v => if h : v ∈ X then some (e.2 ⟨v, h⟩) else none⟩ :=
+theorem domainEquiv_symm_val (X : Set V) (e : W × (X → M)) :
+    ((domainEquiv X).symm e).1 = ⟨e.1, fun v => ⟨v ∈ X, fun h => e.2 ⟨v, h⟩⟩⟩ :=
   rfl
 
 /-- Restricting a classified point restricts its chart. -/
-theorem restrict_domainEquiv_symm {Y X : Set V} [∀ v, Decidable (v ∈ X)]
-    [∀ v, Decidable (v ∈ Y)] (h : Y ⊆ X) (e : W × (X → M)) :
+theorem restrict_domainEquiv_symm {Y X : Set V} (h : Y ⊆ X) (e : W × (X → M)) :
     ((domainEquiv X).symm e).1.restrict Y =
-      ((domainEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 := by
-  rw [domainEquiv_symm_val, domainEquiv_symm_val]
-  refine Possibility.ext rfl (funext fun v => ?_)
-  by_cases hv : v ∈ Y
-  · simp [restrict, hv, h hv]
-  · simp [restrict, hv]
+      ((domainEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 :=
+  Possibility.ext rfl <| funext fun _ =>
+    Part.ext' ⟨fun hd => hd.1, fun hy => ⟨hy, h hy⟩⟩ fun _ _ =>
+      congrArg e.2 (Subtype.ext rfl)
 
 end Restrict
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -141,12 +141,12 @@ theorem infoLe_empty (s : State W V M) : s ⊑ (∅ : State W V M) :=
 
 /-! ### Consistent merge -/
 
-/-- Consistent merge ([kamp-vangenabith-reyle-2011] Def. 26, binary):
+/-- Consistent merge ([kamp-vangenabith-reyle-2011] Def. 0.26, binary):
 the points assembled from compatible pairs. Across strata this is the
 descendant-mediated join — plain intersection of point-sets is empty
 between distinct strata. -/
 def State.merge (s s' : State W V M) : State W V M :=
-  {r | ∃ p ∈ s, ∃ q ∈ s', p.Compatible q ∧ r = p.union q}
+  {r | ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q}
 
 /-- The merge is above the left component in informativeness. -/
 theorem infoLe_merge_left (s s' : State W V M) : s ⊑ s.merge s' := by
@@ -156,23 +156,23 @@ theorem infoLe_merge_left (s s' : State W V M) : s ⊑ s.merge s' := by
 /-- The merge is above the right component in informativeness. -/
 theorem infoLe_merge_right (s s' : State W V M) : s' ⊑ s.merge s' := by
   rintro r ⟨p, hp, q, hq, hpq, rfl⟩
-  exact ⟨q, hq, hpq.le_union_right⟩
+  exact ⟨q, hq, Possibility.le_union_right hpq⟩
 
-/-- **The merge is the least upper bound** (Def. 26's universal
+/-- **The merge is the least upper bound** (Def. 0.26's universal
 property, in the informativeness preorder): anything above both
 components is above their merge. -/
 theorem merge_infoLe {s s' t : State W V M} (hs : s ⊑ t)
     (hs' : s' ⊑ t) : s.merge s' ⊑ t := fun u hu => by
   obtain ⟨p, hp, hpu⟩ := hs u hu
   obtain ⟨q, hq, hqu⟩ := hs' u hu
-  exact ⟨p.union q, ⟨p, hp, q, hq, Possibility.compatible_of_le_of_le hpu hqu, rfl⟩,
+  exact ⟨p.union q, ⟨p, hp, q, hq, Compat.of_le hpu hqu, rfl⟩,
     Possibility.union_le hpu hqu⟩
 
 /-- Consistent merge is commutative. -/
 theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s := by
   ext r
   constructor <;> rintro ⟨p, hp, q, hq, h, rfl⟩ <;>
-    exact ⟨q, hq, p, hp, h.symm, h.union_comm⟩
+    exact ⟨q, hq, p, hp, h.symm, Possibility.union_comm h⟩
 
 /-- Consistent merge is associative. -/
 theorem merge_assoc (s t u : State W V M) :
@@ -180,16 +180,16 @@ theorem merge_assoc (s t u : State W V M) :
   ext r
   constructor
   · rintro ⟨a, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv, hav, rfl⟩
-    have hpv := hav.left_of_union
-    have hqv := hpq.right_of_union hav
+    have hpv := Possibility.compat_of_union_left hav
+    have hqv := Possibility.compat_of_union_right hpq hav
     exact ⟨p, hp, q.union v, ⟨q, hq, v, hv, hqv, rfl⟩,
-      (Possibility.Compatible.union_left hpq.symm hpv.symm).symm,
+      (Possibility.compat_union_left hpq.symm hpv.symm).symm,
       Possibility.union_assoc p q v⟩
   · rintro ⟨p, hp, a, ⟨q, hq, v, hv, hqv, rfl⟩, hpa, rfl⟩
-    have hpq := hpa.symm.left_of_union.symm
-    have hpv := (hqv.right_of_union hpa.symm).symm
+    have hpq := (Possibility.compat_of_union_left hpa.symm).symm
+    have hpv := (Possibility.compat_of_union_right hqv hpa.symm).symm
     exact ⟨p.union q, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv,
-      Possibility.Compatible.union_left hpv hqv,
+      Possibility.compat_union_left hpv hqv,
       (Possibility.union_assoc p q v).symm⟩
 
 /-- The initial state is a unit for consistent merge: with `merge_comm`,
@@ -205,7 +205,7 @@ monoid of information — the content half of
     rwa [hq']
   · intro hr
     exact ⟨r, hr, ⟨r.world, fun _ => none⟩, fun _ => rfl,
-      ⟨rfl, fun _ _ _ _ h => by simp at h⟩,
+      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => by simp at h⟩,
       Possibility.ext rfl (funext fun v => by simp [Possibility.union])⟩
 
 @[simp] theorem initial_merge (s : State W V M) : State.merge State.initial s = s := by
@@ -276,13 +276,11 @@ theorem merge_eq_inter_of_uniform {X : Set V} {s s' : State W V M}
   ext r
   constructor
   · rintro ⟨p, hp, q, hq, hpq, rfl⟩
-    obtain rfl := hpq.eq_of_domain_eq ((hs p hp).trans (hs' q hq).symm)
+    obtain rfl := Possibility.eq_of_compat_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)
     rw [hself p]
     exact ⟨hp, hq⟩
   · rintro ⟨hr, hr'⟩
-    refine ⟨r, hr, r, hr', ⟨rfl, fun v e e' he he' => ?_⟩, (hself r).symm⟩
-    rw [he] at he'
-    exact (Option.some.injEq .. ▸ he' :)
+    exact ⟨r, hr, r, hr', compat_self r, (hself r).symm⟩
 
 section Fibred
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -11,8 +11,9 @@ assignments partial — [kamp-vangenabith-reyle-2011]'s Def. 23 (sets of
 pairs of a world and an embedding), the form the field standardly
 assumes: the absurd state is `∅`, the initial state is `W × {g_⊤}`
 (`initial`), and the lattice of states is `Set`'s. Partiality is by
-`Option` ([elliott-sudo-2025]'s Def. 3.1: total functions into
-`D ∪ {∗}`), so no component of a state carries a proof obligation.
+`Part` ([elliott-sudo-2025]'s Def. 3.1 renders it as total functions
+into `D ∪ {∗}`), so no component of a state carries data beyond the
+world–assignment pair.
 
 There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
 (`UniformAt`), and a base is the index of a fiber, not part of the data.
@@ -83,20 +84,20 @@ variable {W V M : Type*}
 /-- An information state: a set of world–assignment pairs, the
 assignments partial (Def. 23). The absurd state is `∅`; the lattice of
 states is `Set`'s. -/
-abbrev State (W V M : Type*) := Set (Possibility W V (Option M))
+abbrev State (W V M : Type*) := Set (Possibility W V (Part M))
 
 /-- The initial information state `W × {g_⊤}`: every world live, no
 referent defined. -/
-def State.initial : State W V M := {p | ∀ v, p.assignment v = none}
+def State.initial : State W V M := {p | ∀ v, p.assignment v = ⊥}
 
 /-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it has a
 point above it in `s`. -/
-def Subsists (p : Possibility W V (Option M)) (s : State W V M) : Prop :=
+def Subsists (p : Possibility W V (Part M)) (s : State W V M) : Prop :=
   ∃ q ∈ s, p ≤ q
 
 @[inherit_doc] scoped notation:50 p " ≺ " s => Subsists p s
 
-theorem Subsists.of_mem {p : Possibility W V (Option M)} {s : State W V M}
+theorem Subsists.of_mem {p : Possibility W V (Part M)} {s : State W V M}
     (h : p ∈ s) : p ≺ s :=
   ⟨p, h, le_refl p⟩
 
@@ -201,12 +202,20 @@ monoid of information — the content half of
   constructor
   · rintro ⟨p, hp, q, hq, -, rfl⟩
     have hq' : p.union q = p :=
-      Possibility.ext rfl (funext fun v => by simp [Possibility.union, hq v])
+      Possibility.ext rfl (funext fun v => by
+        by_cases h : (p.assignment v).Dom
+        · simp [Possibility.union, h]
+        · have h' : p.assignment v = ⊥ := Part.eq_none_iff'.mpr h
+          simp [Possibility.union, hq v, h'])
     rwa [hq']
   · intro hr
-    exact ⟨r, hr, ⟨r.world, fun _ => none⟩, fun _ => rfl,
-      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => by simp at h⟩,
-      Possibility.ext rfl (funext fun v => by simp [Possibility.union])⟩
+    exact ⟨r, hr, ⟨r.world, fun _ => ⊥⟩, fun _ => rfl,
+      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => absurd h (Part.notMem_none _)⟩,
+      Possibility.ext rfl (funext fun v => by
+        by_cases h : (r.assignment v).Dom
+        · simp [Possibility.union, h]
+        · have h' : r.assignment v = ⊥ := Part.eq_none_iff'.mpr h
+          simp [Possibility.union, h'])⟩
 
 @[simp] theorem initial_merge (s : State W V M) : State.merge State.initial s = s := by
   rw [merge_comm, merge_initial]
@@ -221,7 +230,7 @@ def worlds (s : State W V M) : Set W :=
 /-- A referent is *familiar* at a state ([elliott-sudo-2025], Def. 3.2;
 [heim-1982]'s files): defined at every point. -/
 def Familiar (s : State W V M) (x : V) : Prop :=
-  ∀ p ∈ s, p.assignment x ≠ none
+  ∀ p ∈ s, (p.assignment x).Dom
 
 namespace State
 
@@ -237,12 +246,13 @@ def UniformAt (X : Set V) (I : State W V M) : Prop :=
 theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
   fun p hp => by
     ext v
-    simp [Possibility.domain, hp v]
+    simp only [Possibility.mem_domain, hp v, Set.mem_empty_iff_false, iff_false]
+    exact Part.not_none_dom
 
 /-- Into a uniform stratum, subsistence is membership: a point already
 at the stratum's domain has no room to grow. -/
 theorem subsists_iff_mem {X : Set V} {s : State W V M}
-    (hs : UniformAt X s) {p : Possibility W V (Option M)}
+    (hs : UniformAt X s) {p : Possibility W V (Part M)}
     (hp : p.domain = X) : (p ≺ s) ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
     (Possibility.eq_of_le_of_domain_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
@@ -270,9 +280,8 @@ domain forces equality. -/
 theorem merge_eq_inter_of_uniform {X : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt X s') :
     s.merge s' = s ∩ s' := by
-  have hself : ∀ r : Possibility W V (Option M), r.union r = r := fun r =>
-    Possibility.ext rfl (funext fun v => by
-      rcases h : r.assignment v with _ | e <;> simp [Possibility.union, h])
+  have hself : ∀ r : Possibility W V (Part M), r.union r = r := fun r =>
+    Possibility.ext rfl (funext fun v => by simp [Possibility.union])
   ext r
   constructor
   · rintro ⟨p, hp, q, hq, hpq, rfl⟩
@@ -295,7 +304,6 @@ theorem uniformAt_merge {X Y : Set V} {s s' : State W V M}
 state includes into the restricted image of the stronger — the fibred
 order, glued from within-stratum `⊆` along `restrict`. -/
 theorem subsistsIn_iff_subset_restrict {X : Set V}
-    [∀ v, Decidable (v ∈ X)]
     {s s' : State W V M} (hs : UniformAt X s) :
     (s ⪯ s') ↔ s ⊆ Possibility.restrict X '' s' := by
   constructor
@@ -311,7 +319,6 @@ theorem subsistsIn_iff_subset_restrict {X : Set V}
 restricted image of the stronger is included in the weaker — the
 eliminative direction of the fibred order. -/
 theorem infoLe_iff_restrict_subset {X : Set V}
-    [∀ v, Decidable (v ∈ X)]
     {s s' : State W V M} (hs : UniformAt X s) :
     (s ⊑ s') ↔ Possibility.restrict X '' s' ⊆ s := by
   constructor
@@ -325,27 +332,23 @@ theorem infoLe_iff_restrict_subset {X : Set V}
 end Fibred
 
 /-- Restriction of a state: pointwise, by direct image. -/
-def restrict (X : Set V) [∀ v, Decidable (v ∈ X)] (I : State W V M) :
-    State W V M :=
+def restrict (X : Set V) (I : State W V M) : State W V M :=
   Possibility.restrict X '' I
 
 /-- Restriction only forgets: the restricted state subsists in the
 original. -/
-theorem subsistsIn_restrict (X : Set V) [∀ v, Decidable (v ∈ X)]
-    (I : State W V M) : I.restrict X ⪯ I := by
+theorem subsistsIn_restrict (X : Set V) (I : State W V M) : I.restrict X ⪯ I := by
   rintro p ⟨q, hq, rfl⟩
   exact ⟨q, hq, Possibility.restrict_le X q⟩
 
 /-- Restriction meets the stratification. -/
-theorem uniformAt_restrict {X Y : Set V} [∀ v, Decidable (v ∈ X)]
-    {I : State W V M}
+theorem uniformAt_restrict {X Y : Set V} {I : State W V M}
     (h : UniformAt Y I) : UniformAt (X ∩ Y) (I.restrict X) := by
   rintro p ⟨q, hq, rfl⟩
   rw [Possibility.domain_restrict, h q hq]
 
 /-- Restriction composes along intersections. -/
-theorem restrict_restrict (X Y : Set V) [∀ v, Decidable (v ∈ X)]
-    [∀ v, Decidable (v ∈ Y)] (I : State W V M) :
+theorem restrict_restrict (X Y : Set V) (I : State W V M) :
     (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
   unfold restrict
   rw [← Set.image_comp]
@@ -357,7 +360,7 @@ variable [DecidableEq V]
 [groenendijk-stokhof-1991]'s `x := random`): indeterministically extend
 each point to a defined value at `x`. -/
 def randomAssign (I : State W V M) (x : V) : State W V M :=
-  {p | ∃ q ∈ I, ∃ m : M, p = q.update x (some m)}
+  {p | ∃ q ∈ I, ∃ m : M, p = q.update x (Part.some m)}
 
 /-- Random assignment makes its referent familiar. -/
 theorem familiar_randomAssign (I : State W V M) (x : V) :
@@ -372,7 +375,7 @@ state-level face of `Possibility.domainEquiv`, and the comparison to the
 predecessor's fibers: an order isomorphism for `⊆` (which is `⪯` on the
 stratum, `subsistsIn_iff_subset`), hence an anti-isomorphism for `⊑`
 (`infoLe_iff_superset`). -/
-def uniformEquiv (X : Set V) [∀ v, Decidable (v ∈ X)] :
+def uniformEquiv (X : Set V) :
     {I : State W V M // UniformAt X I} ≃o Set (W × (X → M)) where
   toFun I := {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
   invFun S :=

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -118,25 +118,21 @@ def applyState (u : Transition W M X Y) (I : State W V M) :
   {q | q.domain = Y ∧ ∃ p ∈ I, p.domain = X ∧
     p.world = q.world ∧
     ∃ (e : X → M) (e' : Y → M),
-      (∀ v : X, p.assignment v.1 = some (e v)) ∧
-      (∀ v : Y, q.assignment v.1 = some (e' v)) ∧
+      (∀ v : X, e v ∈ p.assignment v.1) ∧
+      (∀ v : Y, e' v ∈ q.assignment v.1) ∧
       u.rel q.world e e'}
 
 /-- Application lands in the target stratum. -/
 theorem uniformAt_applyState (u : Transition W M X Y) (I : State W V M) :
     State.UniformAt Y (u.applyState I) := fun _ hq => hq.1
 
-variable [∀ v, Decidable (v ∈ Y)]
-
 /-- The point of the `Y`-stratum carrying a given world and assignment. -/
-private def ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) :
-    Possibility W V (Option M) :=
-  ⟨w, fun v => if hv : v ∈ Y then some (e ⟨v, hv⟩) else none⟩
+private def ptOf (Y : Set V) (w : W) (e : Y → M) :
+    Possibility W V (Part M) :=
+  ⟨w, fun v => ⟨v ∈ Y, fun hv => e ⟨v, hv⟩⟩⟩
 
-private theorem domain_ptOf (Y : Set V) [∀ v, Decidable (v ∈ Y)] (w : W) (e : Y → M) :
-    (ptOf Y w e).domain = Y := by
-  ext v
-  by_cases hv : v ∈ Y <;> simp [ptOf, Possibility.domain, hv]
+private theorem domain_ptOf (Y : Set V) (w : W) (e : Y → M) :
+    (ptOf Y w e).domain = Y := rfl
 
 /-- Root application is functorial. -/
 theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
@@ -145,17 +141,12 @@ theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
   ext q
   constructor
   · rintro ⟨hq, p, hpI, hp, hw, e, e'', he, he'', k, huk, hkv⟩
-    refine ⟨hq, ptOf Y q.world k, ⟨domain_ptOf .., p, hpI, hp, hw, e, k, he,
-      fun x => ?_, huk⟩, domain_ptOf .., rfl, k, e'', fun x => ?_, he'', hkv⟩
-    · simp [ptOf]
-    · simp [ptOf]
+    exact ⟨hq, ptOf Y q.world k, ⟨domain_ptOf .., p, hpI, hp, hw, e, k, he,
+      fun x => ⟨x.2, rfl⟩, huk⟩, domain_ptOf .., rfl, k, e'',
+      fun x => ⟨x.2, rfl⟩, he'', hkv⟩
   · rintro ⟨hq, m, ⟨hm, p, hpI, hp, hw, e, k, he, hk, huk⟩, -, hmw, k', e'',
       hk', he'', hvk⟩
-    have hkk' : k = k' := funext fun x => by
-      have h1 := hk x
-      have h2 := hk' x
-      rw [h1] at h2
-      exact (Option.some.injEq .. ▸ h2 :)
+    have hkk' : k = k' := funext fun x => Part.mem_unique (hk x) (hk' x)
     refine ⟨hq, p, hpI, hp, hw.trans hmw, e, e'', he, he'', k, ?_, ?_⟩
     · rw [← hmw]
       exact huk
@@ -166,7 +157,7 @@ theorem applyState_comp (u : Transition W M X Y) (v : Transition W M Y Z)
 `X`-stratum, the regular CCP `applyState` is `apply`, transported along
 `State.uniformEquiv` — the relational collapse computes the root-state
 update. -/
-theorem uniformEquiv_applyState [∀ v, Decidable (v ∈ X)] (u : Transition W M X Y)
+theorem uniformEquiv_applyState (u : Transition W M X Y)
     {I : State W V M} (hI : State.UniformAt X I) :
     State.uniformEquiv Y ⟨u.applyState I, uniformAt_applyState u I⟩ =
       u.apply (State.uniformEquiv X ⟨I, hI⟩) := by
@@ -175,24 +166,22 @@ theorem uniformEquiv_applyState [∀ v, Decidable (v ∈ X)] (u : Transition W M
   · intro hf
     obtain ⟨-, p, hp, hpX, hw, e, f', hpe, hqf, hrel⟩ :
         ptOf Y f.1 f.2 ∈ u.applyState I := hf
-    have hf' : f' = f.2 := funext fun v =>
-      Option.some_inj.mp ((hqf v).symm.trans (dif_pos v.2))
+    have hf' : f' = f.2 := funext fun v => by
+      obtain ⟨hv, hval⟩ := hqf v
+      exact hval.symm
     subst hf'
     refine ⟨e, ?_, by exact hrel⟩
     show ptOf X f.1 e ∈ I
-    have hpeq : ptOf X f.1 e = p := by
-      refine Possibility.ext (by exact hw.symm) (funext fun v => ?_)
-      by_cases hv : v ∈ X
-      · exact (dif_pos hv).trans (hpe ⟨v, hv⟩).symm
-      · exact (dif_neg hv).trans
-          (Option.not_isSome_iff_eq_none.mp fun hs => hv (hpX ▸ hs)).symm
+    have hpeq : ptOf X f.1 e = p :=
+      Possibility.ext hw.symm <| funext fun v =>
+        Part.ext' ⟨fun hv => hpX.superset hv, fun hd => hpX.subset hd⟩
+          fun hv hd => Part.mem_unique (hpe ⟨v, hv⟩) (Part.get_mem hd)
     rw [hpeq]; exact hp
   · rintro ⟨e, hmem, hrel⟩
     have hpI : ptOf X f.1 e ∈ I := hmem
     show ptOf Y f.1 f.2 ∈ u.applyState I
-    exact ⟨domain_ptOf .., ptOf X f.1 e, hpI, domain_ptOf .., by simp [ptOf], e,
-      f.2, fun v => by simp [ptOf], fun v => by simp [ptOf],
-      by exact hrel⟩
+    exact ⟨domain_ptOf .., ptOf X f.1 e, hpI, domain_ptOf .., rfl, e,
+      f.2, fun v => ⟨v.2, rfl⟩, fun v => ⟨v.2, rfl⟩, by exact hrel⟩
 
 end ApplyState
 
@@ -318,7 +307,7 @@ theorem copy_comp_copy (u : Transition W M X Y) (v : Transition W M Y Z)
   rfl
 
 /-- Root application is invariant under repackaging. -/
-@[simp] theorem applyState_copy [DecidableEq V] (u : Transition W M X Y)
+@[simp] theorem applyState_copy (u : Transition W M X Y)
     {X' Y' : Set V} (hX : X = X') (hY : Y = Y') (I : State W V M) :
     (u.copy hX hY).applyState I = u.applyState I := by
   subst hX hY

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -14,8 +14,8 @@ validating Double Negation Elimination (negation swaps the dimensions)
 and cross-disjunct anaphora.
 
 States are Heimian (the paper's Def. 3.1): sets of world-assignment
-pairs whose assignments are total functions into `Option E` — `none` is
-the paper's `∗`, so definedness is per-possibility and non-uniform.
+pairs whose assignments are `Part E`-valued — `⊥` is the paper's `∗`,
+so definedness is per-possibility and non-uniform.
 This is strictly more expressive than the indexed `State` of `State.lean`:
 a uniform base cannot represent partially familiar states, on which the
 paper's separation of assertability (54) from Heimian familiarity rests.
@@ -70,14 +70,14 @@ Standard dynamic semantics has only the former; the latter is what makes
 DNE and cross-disjunct anaphora work. -/
 @[ext] structure BilateralDen (W V E : Type*) where
   /-- Positive update: the result of asserting the sentence. -/
-  positive : Set (Possibility W V (Option E)) → Set (Possibility W V (Option E))
+  positive : Set (Possibility W V (Part E)) → Set (Possibility W V (Part E))
   /-- Negative update: the result of denying the sentence. -/
-  negative : Set (Possibility W V (Option E)) → Set (Possibility W V (Option E))
+  negative : Set (Possibility W V (Part E)) → Set (Possibility W V (Part E))
 
 namespace BilateralDen
 
-variable {φ ψ : BilateralDen W V E} {s : Set (Possibility W V (Option E))}
-  {p : Possibility W V (Option E)}
+variable {φ ψ : BilateralDen W V E} {s : Set (Possibility W V (Part E))}
+  {p : Possibility W V (Part E)}
 
 /-- Worldly atom: keep the possibilities where the proposition holds
 (positively) or fails (negatively). -/
@@ -89,15 +89,15 @@ def atom (pred : W → Prop) : BilateralDen W V E where
 where `t` is undefined survives in neither dimension
 ([elliott-sudo-2025]'s definedness clause for atomic sentences). -/
 def pred1 (P : E → W → Prop) (t : V) : BilateralDen W V E where
-  positive s := {p ∈ s | ∃ e, p.assignment t = some e ∧ P e p.world}
-  negative s := {p ∈ s | ∃ e, p.assignment t = some e ∧ ¬ P e p.world}
+  positive s := {p ∈ s | ∃ e ∈ p.assignment t, P e p.world}
+  negative s := {p ∈ s | ∃ e ∈ p.assignment t, ¬ P e p.world}
 
 /-- Binary atomic predication at `t₁`, `t₂`; partial like `pred1`. -/
 def pred2 (P : E → E → W → Prop) (t₁ t₂ : V) : BilateralDen W V E where
-  positive s := {p ∈ s | ∃ e₁ e₂, p.assignment t₁ = some e₁ ∧
-    p.assignment t₂ = some e₂ ∧ P e₁ e₂ p.world}
-  negative s := {p ∈ s | ∃ e₁ e₂, p.assignment t₁ = some e₁ ∧
-    p.assignment t₂ = some e₂ ∧ ¬ P e₁ e₂ p.world}
+  positive s := {p ∈ s | ∃ e₁ ∈ p.assignment t₁,
+    ∃ e₂ ∈ p.assignment t₂, P e₁ e₂ p.world}
+  negative s := {p ∈ s | ∃ e₁ ∈ p.assignment t₁,
+    ∃ e₂ ∈ p.assignment t₂, ¬ P e₁ e₂ p.world}
 
 /-- Negation swaps the dimensions: `s[¬φ]⁺ = s[φ]⁻` and `s[¬φ]⁻ = s[φ]⁺`.
 Negation does not "push in" — this is the key insight of bilateralism. -/
@@ -126,14 +126,14 @@ theorem neg_involutive :
 possibilities of `s` that subsist in neither dimension — the dynamic
 analogue of the third Strong Kleene truth value. -/
 def unknownUpdate (φ : BilateralDen W V E)
-    (s : Set (Possibility W V (Option E))) : Set (Possibility W V (Option E)) :=
+    (s : Set (Possibility W V (Part E))) : Set (Possibility W V (Part E)) :=
   {p ∈ s | ¬(p ≺ φ.positive s) ∧ ¬(p ≺ φ.negative s)}
 
 /-- Assertability ([elliott-sudo-2025], (54)): the unknown update is
 empty — every possibility is accounted for by one of the dimensions.
 Strictly weaker than Heimian familiarity. -/
 def assertable (φ : BilateralDen W V E)
-    (c : Set (Possibility W V (Option E))) : Prop :=
+    (c : Set (Possibility W V (Part E))) : Prop :=
   φ.unknownUpdate c = ∅
 
 /-- The unknown update is invariant under negation. -/
@@ -257,21 +257,21 @@ end Quantifiers
 
 /-- Bilateral support: the positive update is consistent and the state
 subsists in it. -/
-def supports (s : Set (Possibility W V (Option E)))
+def supports (s : Set (Possibility W V (Part E)))
     (φ : BilateralDen W V E) : Prop :=
   (φ.positive s).Nonempty ∧ s ⪯ φ.positive s
 
 /-- Bilateral entailment: every consistent positive update of `φ`
 supports `ψ`. -/
 def entails (φ ψ : BilateralDen W V E) : Prop :=
-  ∀ s : Set (Possibility W V (Option E)),
+  ∀ s : Set (Possibility W V (Part E)),
     (φ.positive s).Nonempty → supports (φ.positive s) ψ
 
 @[inherit_doc] notation:50 φ " ⊨ᵇ " ψ => entails φ ψ
 
 /-! ### Structural lemmas -/
 
-theorem atom_complementary (pred : W → Prop) (s : Set (Possibility W V (Option E))) :
+theorem atom_complementary (pred : W → Prop) (s : Set (Possibility W V (Part E))) :
     (atom pred (E := E)).positive s ∪ (atom pred).negative s = s := by
   ext p
   simp only [atom, Set.mem_union, Set.mem_setOf_eq]
@@ -282,7 +282,7 @@ theorem atom_complementary (pred : W → Prop) (s : Set (Possibility W V (Option
     · exact Or.inl ⟨h, hp⟩
     · exact Or.inr ⟨h, hp⟩
 
-theorem atom_disjoint (pred : W → Prop) (s : Set (Possibility W V (Option E))) :
+theorem atom_disjoint (pred : W → Prop) (s : Set (Possibility W V (Part E))) :
     (atom pred (E := E)).positive s ∩ (atom pred).negative s = ∅ := by
   ext p
   exact ⟨fun ⟨⟨_, hp⟩, ⟨_, hnp⟩⟩ => absurd hp hnp, False.elim⟩
@@ -334,8 +334,8 @@ def toPair (φ : BilateralDen W V E) :=
   (φ.positive, φ.negative)
 
 /-- Construct a bilateral denotation from a pair of updates. -/
-def ofPair (u : (Set (Possibility W V (Option E)) → Set (Possibility W V (Option E))) ×
-    (Set (Possibility W V (Option E)) → Set (Possibility W V (Option E)))) :
+def ofPair (u : (Set (Possibility W V (Part E)) → Set (Possibility W V (Part E))) ×
+    (Set (Possibility W V (Part E)) → Set (Possibility W V (Part E)))) :
     BilateralDen W V E where
   positive := u.1
   negative := u.2
@@ -358,7 +358,7 @@ swaps them by definition. -/
 theorem isBilateral :
     Core.Logic.Bilateral.IsBilateral
       (Form := BilateralDen W V E)
-      (Result := Set (Possibility W V (Option E)) → Set (Possibility W V (Option E)))
+      (Result := Set (Possibility W V (Part E)) → Set (Possibility W V (Part E)))
       (·.positive) (·.negative) neg where
   positive_negate _ := rfl
   negative_negate _ := rfl

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -331,19 +331,22 @@ private def anti (i j : Fin 3) : State Unit (Fin 3) Bool :=
 
 /-- A two-referent point. -/
 private def pt2 (i j : Fin 3) (a b : Bool) :
-    Possibility Unit (Fin 3) (Option Bool) :=
-  ⟨(), fun v => if v = i then some a else if v = j then some b else none⟩
+    Possibility Unit (Fin 3) (Part Bool) :=
+  ⟨(), fun v => if v = i then Part.some a else if v = j then Part.some b else ⊥⟩
 
 private theorem pt2_mem_anti {i j : Fin 3} (hij : i ≠ j) (a b : Bool)
     (hab : a ≠ b) : pt2 i j a b ∈ anti i j := by
   refine ⟨?_, ?_⟩
   · ext v
+    simp only [Possibility.mem_domain, pt2]
     by_cases hvi : v = i
-    · simp [pt2, Possibility.domain, hvi]
-    · by_cases hvj : v = j <;>
-        simp [pt2, Possibility.domain, hvi, hvj, hij.symm]
+    · simp [hvi, Part.some_dom]
+    · by_cases hvj : v = j
+      · simp [hvj, hij.symm, Part.some_dom]
+      · simp only [if_neg hvi, if_neg hvj]
+        exact iff_of_false (fun h => h) (by simp [hvi, hvj])
   · simp only [pt2, if_neg hij.symm]
-    exact fun h => hab (Option.some.injEq .. ▸ h :)
+    exact fun h => hab (Part.some_inj.mp (by simpa using h))
 
 /-- Adjacent anticorrelation states are consistent: their Def. 26 merge
 is inhabited — the pair glues. -/
@@ -359,19 +362,15 @@ private theorem merge_anti_nonempty {i j k : Fin 3} (hij : i ≠ j)
   · rename_i hvi
     subst hvi
     rw [if_neg hij, if_neg hik] at he'
-    exact absurd he' (by simp)
+    exact absurd he' (Part.notMem_none e')
   · split at he
     · rename_i hvi hvj
       subst hvj
       rw [if_pos rfl] at he'
-      have h1 : e = true := by
-        have := he.symm
-        simpa using this
-      have h2 : e' = true := by
-        have := he'.symm
-        simpa using this
-      rw [h1, h2]
-    · exact absurd he (by simp)
+      obtain rfl := Part.mem_some_iff.mp he
+      obtain rfl := Part.mem_some_iff.mp he'
+      rfl
+    · exact absurd he (Part.notMem_none e)
 
 /-- **Contextuality in the states** ([abramsky-sadrzadeh-2014]'s frame,
 model-theoretically): the three anticorrelation constraints are pairwise
@@ -394,7 +393,7 @@ theorem no_gluing_triangle :
   obtain ⟨r, hr⟩ := hne
   -- r's restrictions land in each anticorrelation state
   have key : ∀ (i j : Fin 3), S.restrict {i, j} = anti i j →
-      ∃ a b : Bool, r.assignment i = some a ∧ r.assignment j = some b ∧
+      ∃ a b : Bool, a ∈ r.assignment i ∧ b ∈ r.assignment j ∧
         a ≠ b := by
     intro i j hS
     have hmem : r.restrict {i, j} ∈ anti i j := by
@@ -402,37 +401,34 @@ theorem no_gluing_triangle :
       exact ⟨r, hr, rfl⟩
     obtain ⟨hdom, hne⟩ := hmem
     rw [Possibility.domain_restrict] at hdom
-    have hi : (r.assignment i).isSome := by
+    have hi : (r.assignment i).Dom := by
       have : i ∈ ({i, j} : Set (Fin 3)) ∩
           Possibility.domain r := by
         rw [hdom]
         simp
       exact this.2
-    have hj : (r.assignment j).isSome := by
+    have hj : (r.assignment j).Dom := by
       have : j ∈ ({i, j} : Set (Fin 3)) ∩
           Possibility.domain r := by
         rw [hdom]
         simp
       exact this.2
-    obtain ⟨a, ha⟩ := Option.isSome_iff_exists.mp hi
-    obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp hj
+    obtain ⟨a, ha⟩ := Part.dom_iff_mem.mp hi
+    obtain ⟨b, hb⟩ := Part.dom_iff_mem.mp hj
     refine ⟨a, b, ha, hb, fun hab => ?_⟩
     subst hab
     apply hne
-    have hri : (r.restrict {i, j}).assignment i = some a := by
-      simpa [Possibility.restrict] using ha
-    have hrj : (r.restrict {i, j}).assignment j = some a := by
-      simpa [Possibility.restrict] using hb
+    have hri : (r.restrict {i, j}).assignment i = Part.some a :=
+      Part.eq_some_iff.mpr ⟨⟨by simp, hi⟩, Part.get_eq_of_mem ha _⟩
+    have hrj : (r.restrict {i, j}).assignment j = Part.some a :=
+      Part.eq_some_iff.mpr ⟨⟨by simp, hj⟩, Part.get_eq_of_mem hb _⟩
     rw [hri, hrj]
   obtain ⟨a, b, ha, hb, hab⟩ := key 0 1 h01
   obtain ⟨b', c, hb', hc, hbc⟩ := key 1 2 h12
   obtain ⟨a', c', ha', hc', hac⟩ := key 0 2 h02
-  rw [hb] at hb'
-  rw [ha] at ha'
-  rw [hc] at hc'
-  obtain rfl := (Option.some.injEq .. ▸ hb' :)
-  obtain rfl := (Option.some.injEq .. ▸ ha' :)
-  obtain rfl := (Option.some.injEq .. ▸ hc' :)
+  obtain rfl := Part.mem_unique hb hb'
+  obtain rfl := Part.mem_unique ha ha'
+  obtain rfl := Part.mem_unique hc hc'
   cases a <;> cases b <;> cases c <;> simp_all
 
 end AbramskySadrzadeh2014

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -353,7 +353,7 @@ private theorem merge_anti_nonempty {i j k : Fin 3} (hij : i ≠ j)
   refine ⟨(pt2 i j false true).union (pt2 j k true false),
     pt2 i j false true, pt2_mem_anti hij false true (by simp),
     pt2 j k true false, pt2_mem_anti hjk true false (by simp), ?_, rfl⟩
-  refine ⟨rfl, fun v e e' he he' => ?_⟩
+  refine Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩
   simp only [pt2] at he he'
   split at he
   · rename_i hvi

--- a/Linglib/Studies/DalrympleKaplan2000.lean
+++ b/Linglib/Studies/DalrympleKaplan2000.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Order.Flat
 import Linglib.Morphology.Unification
 import Linglib.Features.Case.Basic
 import Linglib.Features.Person.Decomposition
@@ -35,7 +36,7 @@ This is the flagship counterexample to treating the flat information order
 (`Morphology/Unification.lean`) as linguistically definitional: indeterminate
 agreement is an *annotation-level* phenomenon demanding non-flat (set-valued) slots.
 `toIndet` below certifies the relationship — the flat order embeds into the
-(superset-ordered) indeterminacy lattice as the determinate fragment, with `none`
+(superset-ordered) indeterminacy lattice as the determinate fragment, with `⊥`
 (no information) mapping to the universal set.
 
 Formal highlights replicated as theorems: the German/Polish contrast set
@@ -129,17 +130,16 @@ theorem kaufen_rnr :
 /-! ### The refinement certificate: the flat order is the determinate fragment
 
 `Morphology/Unification.lean`'s flat slot order embeds into the indeterminacy
-lattice: a determinate commitment `some x` is the singleton `{x}`, and *no
-information* is the universal set (any realization possible). Information increases
-as sets *shrink*, so the embedding is order-reversing into `⊆` — i.e. an embedding
-into the superset order. Set-valued slots are a refinement of the flat layer, not a
-rival to it. -/
+lattice: a determinate commitment `↑x` is the singleton `{x}`, and *no
+information* (`⊥`) is the universal set (any realization possible). Information
+increases as sets *shrink*, so the embedding is order-reversing into `⊆` — i.e. an
+embedding into the superset order. Set-valued slots are a refinement of the flat
+layer, not a rival to it. -/
 
-/-- A flat slot as an indeterminate value: `none` = no commitment = anything goes. -/
-def toIndet (a : Option Case) : IndetVal Case :=
-  match a with
-  | none => Finset.univ
-  | some x => {x}
+/-- A flat slot as an indeterminate value: `⊥` = no commitment = anything goes. -/
+def toIndet : Flat Case → IndetVal Case
+  | ⊥ => Finset.univ
+  | (x : Case) => {x}
 
 private theorem univ_ne_singleton (y : Case) : (Finset.univ : Finset Case) ≠ {y} := by
   intro h
@@ -150,40 +150,26 @@ private theorem univ_ne_singleton (y : Case) : (Finset.univ : Finset Case) ≠ {
 theorem toIndet_injective : Function.Injective toIndet := by
   intro a b h
   match a, b with
-  | none, none => rfl
-  | none, some y => exact absurd h (univ_ne_singleton y)
-  | some x, none => exact absurd h.symm (univ_ne_singleton x)
-  | some x, some y =>
+  | ⊥, ⊥ => rfl
+  | ⊥, (y : Case) => exact absurd h (univ_ne_singleton y)
+  | (x : Case), ⊥ => exact absurd h.symm (univ_ne_singleton x)
+  | (x : Case), (y : Case) =>
     simp only [toIndet, Finset.singleton_inj] at h
-    exact congrArg some h
+    exact Flat.coe_inj.mpr h
 
 /-- The embedding certificate: flat subsumption is superset inclusion of realization
-    sets. More committed = smaller set; `none` sits below everything because `univ`
+    sets. More committed = smaller set; `⊥` sits below everything because `univ`
     contains everything. -/
-theorem flatLE_iff_toIndet_superset (a b : Option Case) :
-    a.FlatLE b ↔ toIndet b ⊆ toIndet a := by
-  match a, b with
-  | none, b =>
-    simp only [toIndet]
-    exact ⟨fun _ => Finset.subset_univ _, fun _ => Option.FlatLE.none_le _⟩
-  | some x, none =>
-    constructor
-    · intro h
-      exact absurd (h x rfl) (by simp)
-    · intro h
-      exact absurd (Finset.Subset.antisymm (Finset.subset_univ _) h).symm
-        (univ_ne_singleton x)
-  | some x, some z =>
-    constructor
-    · intro h
-      have := Option.some.inj (h x rfl)
-      simp [toIndet, this]
-    · intro h y hy
-      have hxy : x = y := Option.some.inj hy
-      subst hxy
-      have hz : z ∈ ({x} : Finset Case) := h (by simp [toIndet])
-      rw [Finset.mem_singleton] at hz
-      exact congrArg some hz
+theorem le_iff_toIndet_superset (a b : Flat Case) :
+    a ≤ b ↔ toIndet b ⊆ toIndet a := by
+  cases a with
+  | bot => exact iff_of_true bot_le (Finset.subset_univ _)
+  | coe x =>
+    cases b with
+    | bot =>
+      refine iff_of_false (Flat.not_coe_le_bot x) fun h => ?_
+      exact univ_ne_singleton x (Finset.Subset.antisymm h (Finset.subset_univ _))
+    | coe z => simp [toIndet, eq_comm]
 
 /-! ### §§5–6: feature resolution — person as marker sets, resolution as union -/
 

--- a/Linglib/Studies/Dekker2012.lean
+++ b/Linglib/Studies/Dekker2012.lean
@@ -151,14 +151,14 @@ with the type
 ```
 structure BilateralDen (W V E : Type*) where
   positive negative :
-    Set (Possibility W V (Option E)) → Set (Possibility W V (Option E))
+    Set (Possibility W V (Part E)) → Set (Possibility W V (Part E))
 ```
 
 and negation as `def neg φ := { positive := φ.negative, negative := φ.positive }`.
 The DNE law `neg (neg φ) = φ` then holds by `rfl`
 (`BilateralDen.neg_neg` in `UpdateSemantics/Bilateral.lean`).
 
-PLA states (assignment-witness pairs) and BUS states (Option-partial
+PLA states (assignment-witness pairs) and BUS states (`Part`-partial
 possibility sets) are different carriers, so a single file cannot state
 both side-by-side. The BUS-side facts are stated
 abstractly here and verified in their home file.

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -67,14 +67,14 @@ abbrev BUSDen (W : Type*) (E : Type*) := BilateralDen W ℕ E
 
 namespace BUSDen
 
-variable {s : Set (Possibility W ℕ (Option E))}
+variable {s : Set (Possibility W ℕ (Part E))}
 
 /-- Truth-value gap: presupposition failure. -/
-def hasGap (φ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) : Prop :=
+def hasGap (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
   φ.positive s ∪ φ.negative s ⊂ s
 
 /-- Sentence is defined (no presupposition failure). -/
-def defined (φ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) : Prop :=
+def defined (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
   φ.positive s ∪ φ.negative s = s
 
 /-- Strong Kleene conjunction. -/
@@ -89,14 +89,14 @@ def pConj (φ ψ : BUSDen W E) : BUSDen W E where
 
 /-- Strawson entailment: φ entails ψ when φ is defined and true. -/
 def strawsonEntails (φ ψ : BUSDen W E) : Prop :=
-  ∀ s : Set (Possibility W ℕ (Option E)),
+  ∀ s : Set (Possibility W ℕ (Part E)),
     defined φ s →
     (φ.positive s).Nonempty →
     (φ.positive s) ⊆ ψ.positive (φ.positive s)
 
 /-- Strong entailment: φ entails ψ with no presupposition failure. -/
 def strongEntails (φ ψ : BUSDen W E) : Prop :=
-  ∀ s : Set (Possibility W ℕ (Option E)),
+  ∀ s : Set (Possibility W ℕ (Part E)),
     (φ.positive s).Nonempty →
     defined ψ (φ.positive s) ∧
     (φ.positive s) ⊆ ψ.positive (φ.positive s)
@@ -142,7 +142,7 @@ theorem diamond_negative_eq (φ : BUSDen W E) (s) :
 
 /-- Diamond positive is a test (returns s or ∅). -/
 theorem diamond_positive_isTest (φ : BUSDen W E) :
-    IsTest (◇ᵇφ).positive (S := Possibility W ℕ (Option E)) := by
+    IsTest (◇ᵇφ).positive (S := Possibility W ℕ (Part E)) := by
   intro s
   rw [diamond_positive_eq]
   split
@@ -151,7 +151,7 @@ theorem diamond_positive_isTest (φ : BUSDen W E) :
 
 /-- Diamond negative is a test (returns s or ∅). -/
 theorem diamond_negative_isTest (φ : BUSDen W E) :
-    IsTest (◇ᵇφ).negative (S := Possibility W ℕ (Option E)) := by
+    IsTest (◇ᵇφ).negative (S := Possibility W ℕ (Part E)) := by
   intro s
   rw [diamond_negative_eq]
   split
@@ -160,7 +160,7 @@ theorem diamond_negative_isTest (φ : BUSDen W E) :
 
 /-- Diamond positive is eliminative (from IsTest). -/
 theorem diamond_positive_eliminative (φ : BUSDen W E) :
-    IsEliminative (◇ᵇφ).positive (S := Possibility W ℕ (Option E)) :=
+    IsEliminative (◇ᵇφ).positive (S := Possibility W ℕ (Part E)) :=
   (diamond_positive_isTest φ).isEliminative
 
 /-- Diamond positive subset (convenience form). -/
@@ -170,7 +170,7 @@ theorem diamond_positive_subset (φ : BUSDen W E) (s) :
 
 /-- Diamond negative is eliminative (from IsTest). -/
 theorem diamond_negative_eliminative (φ : BUSDen W E) :
-    IsEliminative (◇ᵇφ).negative (S := Possibility W ℕ (Option E)) :=
+    IsEliminative (◇ᵇφ).negative (S := Possibility W ℕ (Part E)) :=
   (diamond_negative_isTest φ).isEliminative
 
 /-- Diamond negative subset (convenience form). -/
@@ -180,30 +180,30 @@ theorem diamond_negative_subset (φ : BUSDen W E) (s) :
 
 /-- Box positive is eliminative (□φ = ¬◇¬φ, so positive = diamond negative of ¬φ). -/
 theorem box_positive_eliminative (φ : BUSDen W E) :
-    IsEliminative (□ᵇφ).positive (S := Possibility W ℕ (Option E)) :=
+    IsEliminative (□ᵇφ).positive (S := Possibility W ℕ (Part E)) :=
   diamond_negative_eliminative (BilateralDen.neg φ)
 
 /-- Box negative is eliminative. -/
 theorem box_negative_eliminative (φ : BUSDen W E) :
-    IsEliminative (□ᵇφ).negative (S := Possibility W ℕ (Option E)) :=
+    IsEliminative (□ᵇφ).negative (S := Possibility W ℕ (Part E)) :=
   diamond_positive_eliminative (BilateralDen.neg φ)
 
 end BUSDen
 
 /-! ### Modality concepts -/
 
-variable {s : Set (Possibility W ℕ (Option E))}
+variable {s : Set (Possibility W ℕ (Part E))}
 
 /-- Possibility: state s makes ◇φ true iff s[φ]⁺ is consistent. -/
-def possible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) : Prop :=
+def possible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
   (φ.positive s).Nonempty
 
 /-- Necessity: state s makes □φ true iff s subsists in s[φ]⁺. -/
-def necessary (φ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) : Prop :=
+def necessary (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
   s ⪯ φ.positive s
 
 /-- Impossibility: ¬◇φ iff s[φ]⁺ is empty. -/
-def impossible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) : Prop :=
+def impossible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
   ¬(φ.positive s).Nonempty
 
 theorem impossible_iff_empty (φ : BUSDen W E) :
@@ -224,8 +224,8 @@ disjunct is responsible for: the (1,*) row of the Strong Kleene truth table.
 
 Every possibility in `s[φ]⁺` is verified by φ, and then classified by ψ
 into one of three truth values. (eq. 92a) -/
-def disjPos1 (φ ψ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) :
-    Set (Possibility W ℕ (Option E)) :=
+def disjPos1 (φ ψ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) :
+    Set (Possibility W ℕ (Part E)) :=
   ψ.positive (φ.positive s)
   ∪ ψ.negative (φ.positive s)
   ∪ ψ.unknownUpdate (φ.positive s)
@@ -239,8 +239,8 @@ table.
 The key term for cross-disjunct anaphora is `s[φ]⁻[ψ]⁺`: when
 `φ = ¬∃x.P(x)`, `s[φ]⁻ = s[∃x.P(x)]⁺` by DNE, introducing the
 discourse referent for binding across disjuncts. (eq. 92b) -/
-def disjPos2 (φ ψ : BUSDen W E) (s : Set (Possibility W ℕ (Option E))) :
-    Set (Possibility W ℕ (Option E)) :=
+def disjPos2 (φ ψ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) :
+    Set (Possibility W ℕ (Part E)) :=
   ψ.positive (φ.positive s)
   ∪ ψ.positive (φ.negative s)
   ∪ ψ.positive (φ.unknownUpdate s)
@@ -378,7 +378,7 @@ The hypotheses `h_dp1` and `h_dp2` encode these simplifications: the
 general forms are contained in the simplified forms, so nonemptiness
 of the general forms transfers to the simplified forms. -/
 theorem fc_with_anaphora (cfg : BathroomConfig W E)
-    (s : Set (Possibility W ℕ (Option E)))
+    (s : Set (Possibility W ℕ (Part E)))
     (h_poss : possible (bathroomSentence cfg) s)
     (h_dp1 : disjPos1 (BilateralDen.neg cfg.bathroom) cfg.funnyPlace s ⊆
              cfg.bathroom.negative s)
@@ -414,32 +414,35 @@ def pHolds : PEntity → PWorld → Prop
   | _, _ => False
 
 /-- The paper's `[x → e]`: register 0 defined, all else `∗`. -/
-def xTo (e : PEntity) : ℕ → Option PEntity :=
-  fun n => if n = 0 then some e else none
+def xTo (e : PEntity) : ℕ → Part PEntity :=
+  fun n => if n = 0 then Part.some e else ⊥
 
 /-- The paper's `[]`: everything `∗`. -/
-def blank : ℕ → Option PEntity := fun _ => none
+def blank : ℕ → Part PEntity := fun _ => ⊥
 
 open PWorld in
 /-- The state of (56). -/
-def s56 : Set (Possibility PWorld ℕ (Option PEntity)) :=
+def s56 : Set (Possibility PWorld ℕ (Part PEntity)) :=
   {⟨wa, xTo .a⟩, ⟨wa, xTo .b⟩, ⟨wb, xTo .a⟩, ⟨wb, xTo .b⟩, ⟨w0, blank⟩}
 
 /-- Positive consistency: `(wa, [x → a])` survives assertion (56a). -/
 theorem mem_positive_s56 :
-    (⟨.wa, xTo .a⟩ : Possibility PWorld ℕ (Option PEntity)) ∈
+    (⟨.wa, xTo .a⟩ : Possibility PWorld ℕ (Part PEntity)) ∈
       (BilateralDen.pred1 pHolds 0).positive s56 :=
-  ⟨by simp [s56], .a, rfl, trivial⟩
+  ⟨by simp [s56], .a, Part.mem_some _, trivial⟩
 
 /-- The gap: `(w∅, [])` subsists in neither dimension, so it is in the
 unknown update (56c). -/
 theorem gap_mem_unknownUpdate_s56 :
-    (⟨.w0, blank⟩ : Possibility PWorld ℕ (Option PEntity)) ∈
+    (⟨.w0, blank⟩ : Possibility PWorld ℕ (Part PEntity)) ∈
       (BilateralDen.pred1 pHolds 0).unknownUpdate s56 := by
   refine ⟨by simp [s56], ?_, ?_⟩ <;>
   · rintro ⟨q, ⟨hq, e, he, -⟩, hw, -⟩
     rcases (by simpa [s56] using hq : q = _ ∨ q = _ ∨ q = _ ∨ q = _ ∨ q = _)
-      with rfl | rfl | rfl | rfl | rfl <;> simp_all [blank]
+      with rfl | rfl | rfl | rfl | rfl <;>
+      first
+        | exact absurd he (Part.notMem_none e)
+        | simp_all
 
 /-- (56)'s upshot: `P(x)` is not assertable at the partially familiar
 state. -/
@@ -451,7 +454,7 @@ theorem not_assertable_s56 :
 `not_assertable_s56` so does assertability; the paper's point is that the
 converse can fail (assertability is strictly weaker). -/
 theorem not_familiar_s56 : ¬Familiar s56 0 := fun h =>
-  h ⟨.w0, blank⟩ (by simp [s56]) rfl
+  h ⟨.w0, blank⟩ (by simp [s56])
 
 end PartialFamiliarity
 

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -739,7 +739,7 @@ structure NumberedDRef where
     of the negative continuation. -/
 theorem exists_negative_characterization
     (x : Nat) (φ : BilateralDen W ℕ E)
-    (s : Set (Possibility W ℕ (Option E))) (p : Possibility W ℕ (Option E)) :
+    (s : Set (Possibility W ℕ (Part E))) (p : Possibility W ℕ (Part E)) :
     p ∈ (exists_ x φ).negative s ↔
     p ∈ s ∧ p.world ∉ worlds (φ.positive (randomAssign s x)) ∧
       p.world ∈ worlds (φ.negative (randomAssign s x)) := by
@@ -750,7 +750,7 @@ theorem exists_negative_characterization
     This is the bilateral analog of universal falsification. -/
 theorem neg_exists_positive
     (x : Nat) (φ : BilateralDen W ℕ E)
-    (s : Set (Possibility W ℕ (Option E))) (p : Possibility W ℕ (Option E)) :
+    (s : Set (Possibility W ℕ (Part E))) (p : Possibility W ℕ (Part E)) :
     p ∈ (neg (exists_ x φ)).positive s ↔
     p ∈ s ∧ p.world ∉ worlds (φ.positive (randomAssign s x)) ∧
       p.world ∈ worlds (φ.negative (randomAssign s x)) := by
@@ -764,7 +764,7 @@ theorem neg_exists_positive
     extension). -/
 theorem neg_exists_eliminative
     (x : Nat) (φ : BilateralDen W ℕ E)
-    (s : Set (Possibility W ℕ (Option E))) :
+    (s : Set (Possibility W ℕ (Part E))) :
     (neg (exists_ x φ)).positive s ⊆ s := by
   intro p hp
   rw [neg_exists_positive] at hp
@@ -775,7 +775,7 @@ theorem neg_exists_eliminative
     semantics — `neg` swaps, so two swaps restore the original. -/
 theorem neg_neg_exists
     (x : Nat) (φ : BilateralDen W ℕ E)
-    (s : Set (Possibility W ℕ (Option E))) :
+    (s : Set (Possibility W ℕ (Part E))) :
     (neg (neg
       (exists_ x φ))).positive s =
     (exists_ x φ).positive s := rfl

--- a/Linglib/Studies/Heim1982/Basic.lean
+++ b/Linglib/Studies/Heim1982/Basic.lean
@@ -87,7 +87,7 @@ def indefinitePersistsDiscourse (man walkedIn satDown : E → Prop) (x : ℕ) :
 (not a presupposition failure) — provided the body is defined on the
 randomly assigned file. -/
 theorem indef_defined_when_novel (x : ℕ) (F : State W ℕ E)
-    (hnovel : ∀ p ∈ F, p.assignment x = none) (body : FCP W ℕ E)
+    (hnovel : ∀ p ∈ F, ¬(p.assignment x).Dom) (body : FCP W ℕ E)
     (hbody : (body (F.randomAssign x)).Dom) :
     (FCP.indef x body).admits F :=
   ⟨hnovel, hbody⟩
@@ -122,9 +122,9 @@ Negation is eliminative over the *input* file (`FCP.neg_eliminative`),
 so a novel variable stays novel after negation — the dref is trapped
 inside the scope of ¬. -/
 theorem neg_blocks_dref (x : ℕ) (φ : FCP W ℕ E) {F F' : State W ℕ E}
-    (hnovel : ∀ p ∈ F, p.assignment x = none)
+    (hnovel : ∀ p ∈ F, ¬(p.assignment x).Dom)
     (h : F' ∈ FCP.neg φ F) :
-    ∀ p ∈ F', p.assignment x = none :=
+    ∀ p ∈ F', ¬(p.assignment x).Dom :=
   fun p hp => hnovel p (FCP.neg_eliminative φ h hp)
 
 -- ════════════════════════════════════════════════════
@@ -149,7 +149,7 @@ theorem novelty_violation (x : ℕ) (body : FCP W ℕ E)
     ¬ (FCP.indef x body).admits F := by
   rintro ⟨hall, -⟩
   obtain ⟨p, hp⟩ := hne
-  exact h p hp (hall p hp)
+  exact hall p hp (h p hp)
 
 /-- A definite with a novel index causes presupposition failure.
 
@@ -198,11 +198,11 @@ minimal state. -/
 def startFile : State ExWorld ℕ ExEntity := State.initial
 
 /-- Index 1 is novel in the start file (no drefs yet). -/
-example : ∀ p ∈ startFile, p.assignment 1 = none :=
+example : ∀ p ∈ startFile, p.assignment 1 = ⊥ :=
   fun _ hp => hp 1
 
 /-- The start file is consistent (nonempty). -/
-example : startFile.Nonempty := ⟨⟨w₀, λ _ => none⟩, λ _ => rfl⟩
+example : startFile.Nonempty := ⟨⟨w₀, λ _ => ⊥⟩, λ _ => rfl⟩
 
 end ConcreteExamples
 

--- a/Linglib/Studies/KampVanGenabithReyle2011.lean
+++ b/Linglib/Studies/KampVanGenabithReyle2011.lean
@@ -34,12 +34,12 @@ referent, so anaphora can distinguish them. -/
 /-- "A marble is missing": the referent carries the marble `0`, in world
 `true`. -/
 def marbleState : State Bool Unit (Fin 2) :=
-  {p | p.world = true ∧ p.assignment () = some 0}
+  {p | p.world = true ∧ p.assignment () = Part.some 0}
 
 /-- "A coin is missing": the referent carries the coin `1`, in world
 `true`. -/
 def coinState : State Bool Unit (Fin 2) :=
-  {p | p.world = true ∧ p.assignment () = some 1}
+  {p | p.world = true ∧ p.assignment () = Part.some 1}
 
 /-- The two states determine the same worldly content (Def. 23(v)'s
 proposition). -/
@@ -48,9 +48,9 @@ theorem marble_worlds_eq_coin : worlds marbleState = worlds coinState := by
   simp only [mem_worlds]
   constructor
   · rintro ⟨p, ⟨hw, -⟩, rfl⟩
-    exact ⟨⟨p.world, fun _ => some 1⟩, ⟨hw, rfl⟩, rfl⟩
+    exact ⟨⟨p.world, fun _ => Part.some 1⟩, ⟨hw, rfl⟩, rfl⟩
   · rintro ⟨p, ⟨hw, -⟩, rfl⟩
-    exact ⟨⟨p.world, fun _ => some 0⟩, ⟨hw, rfl⟩, rfl⟩
+    exact ⟨⟨p.world, fun _ => Part.some 0⟩, ⟨hw, rfl⟩, rfl⟩
 
 /-- But the states differ: the marble witness is not a coin witness. The
 worldly collapse (`marble_worlds_eq_coin`) plus this separation is Partee's
@@ -58,11 +58,11 @@ argument that context change operates on information states, not
 propositions. -/
 theorem marble_ne_coin : marbleState ≠ coinState := by
   intro h
-  have hmem : (⟨true, fun _ => some 0⟩ : Possibility Bool Unit (Option (Fin 2))) ∈
+  have hmem : (⟨true, fun _ => Part.some 0⟩ : Possibility Bool Unit (Part (Fin 2))) ∈
       coinState := by
     rw [← h]
     exact ⟨rfl, rfl⟩
-  exact absurd hmem.2 (by simp)
+  exact absurd (Part.some_inj.mp hmem.2) (by simp)
 
 /-! ### The action equation on a two-sentence discourse (p. 159) -/
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -883,17 +883,18 @@ variable {W V M : Type*} {s t : Set W}
 yet introduced. -/
 def toIndexedState (V M : Type*) (s : Set W) :
     DynamicSemantics.State W V M :=
-  {p | p.world ∈ s ∧ ∀ v, p.assignment v = none}
+  {p | p.world ∈ s ∧ ∀ v, p.assignment v = ⊥}
 
-@[simp] theorem mem_toIndexedState {p : Possibility W V (Option M)} :
+@[simp] theorem mem_toIndexedState {p : Possibility W V (Part M)} :
     p ∈ toIndexedState V M s ↔
-      p.world ∈ s ∧ ∀ v, p.assignment v = none := Iff.rfl
+      p.world ∈ s ∧ ∀ v, p.assignment v = ⊥ := Iff.rfl
 
 /-- The embedding lands in the empty stratum. -/
 theorem uniformAt_toIndexedState :
     State.UniformAt ∅ (toIndexedState V M s) := fun p hp => by
   ext v
-  simp [Possibility.domain, hp.2 v]
+  simp only [Possibility.mem_domain, hp.2 v, Set.mem_empty_iff_false, iff_false]
+  exact Part.not_none_dom
 
 /-- The embedding is faithful on worldly content. -/
 @[simp] theorem worlds_toIndexedState :
@@ -903,7 +904,7 @@ theorem uniformAt_toIndexedState :
   · rintro ⟨p, hp, rfl⟩
     exact hp.1
   · intro hw
-    exact ⟨⟨w, fun _ => none⟩, ⟨hw, fun _ => rfl⟩, rfl⟩
+    exact ⟨⟨w, fun _ => ⊥⟩, ⟨hw, fun _ => rfl⟩, rfl⟩
 
 /-- Eliminating worlds is gaining information: the embedding reverses
 into `⊑`. -/
@@ -911,7 +912,7 @@ theorem toIndexedState_infoLe_iff :
     (toIndexedState V M s ⊑ toIndexedState V M t) ↔ t ⊆ s := by
   constructor
   · intro h w hw
-    obtain ⟨p, hp, hpq⟩ := h ⟨w, fun _ => none⟩ ⟨hw, fun _ => rfl⟩
+    obtain ⟨p, hp, hpq⟩ := h ⟨w, fun _ => ⊥⟩ ⟨hw, fun _ => rfl⟩
     have hs := hp.1
     rwa [hpq.1] at hs
   · rintro h q ⟨hq, hnone⟩

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17243,6 +17243,19 @@
   validated = {true},
   sources   = {Morphology/Unification.lean;Features/Basic.lean}
 }% REF: Shieber (1985) "Evidence against the Context-Freeness of Natural Language"
+@book{winskel-1993,
+  author    = {Winskel, Glynn},
+  year      = {1993},
+  title     = {The Formal Semantics of Programming Languages: An Introduction},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA},
+  isbn      = {0-262-23169-7},
+  subfield  = {semantics},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Order/Flat.lean}
+}
+
 @book{carpenter-1992,
   author    = {Carpenter, Bob},
   year      = {1992},


### PR DESCRIPTION
Ground the dynamic-semantics partial-point substrate in mathlib.

- `Possibility W V (Part M)`: partial points carry mathlib's `Part` — descent is `p.world = q.world ∧ ∀ x, p.assignment x ≤ q.assignment x` in `Part`'s order; `domain = {v | (p.assignment v).Dom}`; `Possibility.Compatible` dissolved into Core's `Compat` (= `BddAbove {p, q}`) with mem-based `compat_iff`; `restrict`/`domainEquiv` lose their `Decidable` instances (`Part` carries `v ∈ X` as `Dom`)
- `Flat` reshaped in the `WithBot` mold (coercion `↑`, `⊥`, inductive `LE`, `recBotCoe`, `DecidableLE`) toward upstreaming; `Option.FlatLE` deleted, consumers (UD bundle, Morphology unification, ElementTheory, DK2000) migrated to `≤`/`Flat.or`, deduplicating their local orElse/inf lemmas
- KVR definition numbers verified against the chapter (0.22/0.26); `winskel-1993` added for the flat-domain term