### PR TITLE
feat(Core/Data): Part.or; Possibility.union as its pointwise lift

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -119,6 +119,7 @@ import Linglib.Core.Data.List.TakeDrop
 import Linglib.Core.Data.Multiset.Antidiagonal
 import Linglib.Core.Data.Multiset.Powerset
 import Linglib.Core.Data.Multiset.Rel
+import Linglib.Core.Data.Part
 import Linglib.Core.Data.RoseTree.Basic
 import Linglib.Core.Data.RoseTree.Count
 import Linglib.Core.Data.RoseTree.DecEq

--- a/Linglib/Core/Data/Part.lean
+++ b/Linglib/Core/Data/Part.lean
@@ -1,0 +1,59 @@
+import Mathlib.Data.Part
+
+/-!
+# Left-biased choice of partial values
+
+`Part.or` is the `Part` analogue of `Option.or`: `p.or q` is defined
+wherever either argument is, with the left taking precedence.
+Noncomputable, since it decides `p.Dom`; `Flat.or` is its computable
+twin on `Option`-carried partial values. An `[UPSTREAM]` candidate for
+`Mathlib/Data/Part.lean`.
+-/
+
+namespace Part
+
+variable {α : Type*} {p q r : Part α} {a : α}
+
+open Classical in
+/-- The left-biased choice of two partial values: defined wherever
+either is, with the left taking precedence. -/
+protected noncomputable def or (p q : Part α) : Part α :=
+  if p.Dom then p else q
+
+@[simp] theorem or_dom : (p.or q).Dom ↔ p.Dom ∨ q.Dom := by
+  by_cases h : p.Dom <;> simp [Part.or, h]
+
+theorem mem_or_iff : a ∈ p.or q ↔ a ∈ p ∨ ¬p.Dom ∧ a ∈ q := by
+  by_cases h : p.Dom
+  · simp [Part.or, h]
+  · simp [Part.or, eq_none_iff'.mpr h]
+
+@[simp] theorem none_or (q : Part α) : Part.none.or q = q :=
+  if_neg not_none_dom
+
+@[simp] theorem or_none (p : Part α) : p.or none = p := by
+  by_cases h : p.Dom
+  · simp [Part.or, h]
+  · simp [Part.or, eq_none_iff'.mpr h]
+
+@[simp] theorem some_or (a : α) (q : Part α) : (Part.some a).or q = Part.some a :=
+  if_pos trivial
+
+@[simp] theorem bot_or (q : Part α) : (⊥ : Part α).or q = q :=
+  none_or q
+
+@[simp] theorem or_bot (p : Part α) : p.or ⊥ = p :=
+  or_none p
+
+@[simp] theorem or_self (p : Part α) : p.or p = p :=
+  ite_self p
+
+theorem or_assoc (p q r : Part α) : (p.or q).or r = p.or (q.or r) := by
+  by_cases hp : p.Dom <;> by_cases hq : q.Dom <;> simp [Part.or, hp, hq]
+
+theorem le_or_left : p ≤ p.or q := fun _ ha => mem_or_iff.mpr (.inl ha)
+
+theorem or_le (hp : p ≤ r) (hq : q ≤ r) : p.or q ≤ r := fun a ha =>
+  (mem_or_iff.mp ha).elim (hp a) fun h => hq a h.2
+
+end Part

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -208,7 +208,7 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
     have hqle : q ≤ p := ⟨(Possibility.compat_iff.mp hpq).1.symm, fun v e he =>
       absurd (Part.dom_iff_mem.mpr ⟨e, he⟩)
         (Set.eq_empty_iff_forall_notMem.mp hqdom v)⟩
-    rw [le_antisymm (Possibility.union_le le_rfl hqle) (Possibility.le_union_left p q)]
+    rw [le_antisymm (Possibility.union_le le_rfl hqle) Possibility.le_union_left]
     exact ⟨hp, (Possibility.compat_iff.mp hpq).1.symm ▸ hqpred⟩
   · rintro ⟨hr, hpred⟩
     have hqle : (⟨r.world, fun _ => ⊥⟩ : Possibility W V (Part M)) ≤ r :=
@@ -217,7 +217,7 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
       ⟨Set.eq_empty_iff_forall_notMem.mpr fun _ hv => hv, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => absurd h (Part.notMem_none _)⟩, ?_⟩
     exact (le_antisymm (Possibility.union_le le_rfl hqle)
-      (Possibility.le_union_left ..)).symm
+      Possibility.le_union_left).symm
 
 /-- Rule (13), the familiar regime: at a familiar card the atom
 filters — and in particular is eliminative. -/
@@ -233,7 +233,7 @@ theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
       have hveq : v = x := hqdom.subset (Part.dom_iff_mem.mpr ⟨e, he⟩)
       subst hveq
       exact (Part.mem_unique he hqx).trans (hag v m₀ m hpx hqx).symm ▸ hpx⟩
-    rw [le_antisymm (Possibility.union_le le_rfl hqle) (Possibility.le_union_left p q)]
+    rw [le_antisymm (Possibility.union_le le_rfl hqle) Possibility.le_union_left]
     exact ⟨hp, m₀, hpx, hag x m₀ m hpx hqx ▸ hpred⟩
   · rintro ⟨hr, m, hrx, hpred⟩
     have hqle : (⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩ : Possibility W V (Part M)) ≤ r :=
@@ -244,7 +244,7 @@ theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
     · obtain ⟨rfl, rfl⟩ := he'
       exact Part.mem_unique he hrx
     · exact (le_antisymm (Possibility.union_le le_rfl hqle)
-        (Possibility.le_union_left ..)).symm
+        Possibility.le_union_left).symm
 
 /-- Rule (18), the novel regime: at a novel card the atom extends each
 point with every witness — random assignment then filtering, in one
@@ -260,17 +260,10 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
       Possibility.ext rfl (funext fun v => by
         by_cases hv : v = x
         · subst hv
-          simp only [Possibility.union, Possibility.update_assignment,
-            Function.update_self]
-          rw [if_neg (hnov p hp)]
-          exact Part.eq_some_iff.mpr hqx
+          simp [Part.eq_none_iff'.mpr (hnov p hp), Part.eq_some_iff.mpr hqx]
         · have hqv : q.assignment v = ⊥ :=
             Part.eq_none_iff'.mpr fun hd => hv (hqdom.subset hd)
-          by_cases hdp : (p.assignment v).Dom
-          · simp [Possibility.union, Possibility.update, hdp, Function.update_of_ne hv]
-          · have hpv : p.assignment v = ⊥ := Part.eq_none_iff'.mpr hdp
-            simp [Possibility.union, Possibility.update, hqv, hpv,
-              Function.update_of_ne hv])
+          simp [hqv, Function.update_of_ne hv])
     rw [huq]
     exact ⟨⟨p, hp, m, rfl⟩, m, by simp [Possibility.update], hpred⟩
   · rintro ⟨hmem, m, hrx, hpred⟩
@@ -285,18 +278,12 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     · refine Possibility.ext rfl (funext fun v => ?_)
       by_cases hv : v = x
       · subst hv
-        simp only [Possibility.union, Possibility.update_assignment,
-          Function.update_self]
-        rw [if_neg (hnov p hp)]
-        symm
-        exact Part.eq_some_iff.mpr ⟨rfl, rfl⟩
+        have hqx : (⟨v = v, fun _ => m⟩ : Part M) = Part.some m :=
+          Part.eq_some_iff.mpr ⟨rfl, rfl⟩
+        simp [Part.eq_none_iff'.mpr (hnov p hp), hqx]
       · have hqv : (⟨v = x, fun _ => m⟩ : Part M) = ⊥ :=
           Part.eq_none_iff'.mpr fun hd => hv hd
-        by_cases hdp : (p.assignment v).Dom
-        · simp [Possibility.union, Possibility.update, hdp, Function.update_of_ne hv]
-        · have hpv : p.assignment v = ⊥ := Part.eq_none_iff'.mpr hdp
-          simp [Possibility.union, Possibility.update, hqv, hpv,
-            Function.update_of_ne hv]
+        simp [hqv, Function.update_of_ne hv]
 
 /-- World atoms are eliminative (the familiar face of Principle (A)). -/
 theorem atomW_eliminative (pred : W → Prop) {F F' : State W V M}

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,15 +1,16 @@
+import Linglib.Core.Data.Part
 import Linglib.Core.Order.PartialUnify
-import Mathlib.Data.Part
-import Mathlib.Data.Set.Function
+import Mathlib.Data.PFun
+import Mathlib.Logic.Function.Basic
 
 /-!
 # Possibilities
 
 This file defines a *possibility* — a world paired with an assignment
 of discourse referents — and the structure of its partial points, with
-`Part`-valued assignments: the descent order, compatibility and union,
-restriction, and the classification of each stratum as
-world–assignment pairs.
+`Part`-valued assignments (partial functions `V →. M`): the descent
+order, compatibility and union, restriction, and the classification of
+each stratum as world–assignment pairs.
 
 ## References
 
@@ -65,7 +66,7 @@ theorem le_def : p ≤ q ↔ p.world = q.world ∧ ∀ x, p.assignment x ≤ q.a
 
 /-- The domain of a partial point is the set of referents it defines. -/
 def domain (p : Possibility W V (Part M)) : Set V :=
-  {v | (p.assignment v).Dom}
+  PFun.Dom p.assignment
 
 @[simp] theorem mem_domain {v : V} :
     v ∈ p.domain ↔ (p.assignment v).Dom := Iff.rfl
@@ -81,35 +82,35 @@ theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q
     obtain rfl := Part.mem_unique (h.2 v _ (Part.get_mem hd)) he
     exact Part.get_mem hd
 
-open Classical in
 /-- The union of two points, defined wherever either is, with the left
 taking precedence; on compatible points the precedence is immaterial
 (`union_comm`). -/
 noncomputable def union (p q : Possibility W V (Part M)) : Possibility W V (Part M) :=
-  ⟨p.world, fun v => if (p.assignment v).Dom then p.assignment v else q.assignment v⟩
+  ⟨p.world, fun v => (p.assignment v).or (q.assignment v)⟩
 
-theorem le_union_left (p q : Possibility W V (Part M)) : p ≤ p.union q :=
-  ⟨rfl, fun v e he => by
-    simp only [union]
-    split
-    · exact he
-    · next h => exact absurd (Part.dom_iff_mem.mpr ⟨e, he⟩) h⟩
+@[simp] theorem union_world : (p.union q).world = p.world := rfl
+
+@[simp] theorem union_assignment (v : V) :
+    (p.union q).assignment v = (p.assignment v).or (q.assignment v) := rfl
+
+/-- A union assignment holds the left component's values, and the
+right's outside the left's domain. -/
+theorem mem_assignment_union {v : V} {e : M} :
+    e ∈ (p.union q).assignment v ↔
+      e ∈ p.assignment v ∨ v ∉ p.domain ∧ e ∈ q.assignment v :=
+  Part.mem_or_iff
+
+theorem le_union_left : p ≤ p.union q :=
+  ⟨rfl, fun _ => Part.le_or_left⟩
 
 private theorem le_union_right_of_agree (hw : p.world = q.world)
     (hag : ∀ v e e', e ∈ p.assignment v → e' ∈ q.assignment v → e = e') :
     q ≤ p.union q :=
-  ⟨hw.symm, fun v e he => by
-    simp only [union]
-    split
-    · next hd => exact hag v _ e (Part.get_mem hd) he ▸ Part.get_mem hd
-    · exact he⟩
+  ⟨hw.symm, fun v e he => mem_assignment_union.mpr <| or_iff_not_imp_left.mpr
+    fun hp => ⟨fun hd => hp (hag v _ e (Part.get_mem hd) he ▸ Part.get_mem hd), he⟩⟩
 
 theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
-  ⟨hp.1, fun v e he => by
-    simp only [union] at he
-    split at he
-    · exact hp.2 v e he
-    · exact hq.2 v e he⟩
+  ⟨hp.1, fun v => Part.or_le (hp.2 v) (hq.2 v)⟩
 
 /-- Two partial points are compatible (`Compat`: bounded above in the
 descent order) exactly when they share their world and agree wherever
@@ -125,7 +126,7 @@ theorem compat_iff : Compat p q ↔
       fun v e e' he he' => Part.mem_unique (hp.2 v e he) (hq.2 v e' he')⟩
   · rintro ⟨hw, hag⟩
     exact ⟨p.union q, PartialUnify.mem_upperBounds_pair.mpr
-      ⟨le_union_left p q, le_union_right_of_agree hw hag⟩⟩
+      ⟨le_union_left, le_union_right_of_agree hw hag⟩⟩
 
 theorem le_union_right (h : Compat p q) : q ≤ p.union q :=
   have h' := compat_iff.mp h
@@ -133,7 +134,7 @@ theorem le_union_right (h : Compat p q) : q ≤ p.union q :=
 
 /-- The union of compatible points is their least upper bound. -/
 theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
-  ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨le_union_left p q, le_union_right h⟩,
+  ⟨PartialUnify.mem_upperBounds_pair.mpr ⟨le_union_left, le_union_right h⟩,
     fun _ hu =>
       have h := PartialUnify.mem_upperBounds_pair.mp hu
       union_le h.1 h.2⟩
@@ -141,21 +142,18 @@ theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
 /-- The union of two points defines the union of their domains. -/
 theorem domain_union (p q : Possibility W V (Part M)) :
     (p.union q).domain = p.domain ∪ q.domain := by
-  ext v
-  by_cases h : (p.assignment v).Dom <;> simp [union, domain, h]
+  ext v; simp
 
 /-- On a shared domain, compatibility is equality. -/
 theorem eq_of_compat_of_domain_eq (h : Compat p q) (hdom : p.domain = q.domain) :
     p = q :=
   have hu : (p.union q).domain = p.domain := by rw [domain_union, ← hdom, Set.union_self]
-  (eq_of_le_of_domain_eq (le_union_left p q) hu.symm).trans
+  (eq_of_le_of_domain_eq le_union_left hu.symm).trans
     (eq_of_le_of_domain_eq (le_union_right h) (hdom.symm.trans hu.symm)).symm
 
-theorem union_assoc (p q v : Possibility W V (Part M)) :
-    (p.union q).union v = p.union (q.union v) :=
-  Possibility.ext rfl <| funext fun x => by
-    by_cases hp : (p.assignment x).Dom <;> by_cases hq : (q.assignment x).Dom <;>
-      simp [union, hp, hq]
+theorem union_assoc (p q r : Possibility W V (Part M)) :
+    (p.union q).union r = p.union (q.union r) :=
+  Possibility.ext rfl <| funext fun _ => Part.or_assoc ..
 
 /-- On compatible points the left precedence of `union` is immaterial. -/
 theorem union_comm (h : Compat p q) : p.union q = q.union p :=
@@ -166,16 +164,14 @@ with. -/
 theorem compat_union_left (hpu : Compat p u) (hqu : Compat q u) :
     Compat (p.union q) u := by
   obtain ⟨hpw, hpa⟩ := compat_iff.mp hpu
-  obtain ⟨hqw, hqa⟩ := compat_iff.mp hqu
-  refine compat_iff.mpr ⟨hpw, fun x e e' he he' => ?_⟩
-  simp only [union] at he
-  split at he
-  · exact hpa x e e' he he'
-  · exact hqa x e e' he he'
+  obtain ⟨-, hqa⟩ := compat_iff.mp hqu
+  exact compat_iff.mpr ⟨hpw, fun v e e' he he' =>
+    (mem_assignment_union.mp he).elim (fun h => hpa v e e' h he') fun h =>
+      hqa v e e' h.2 he'⟩
 
 /-- The left component of a compatible union is compatible. -/
 theorem compat_of_union_left (h : Compat (p.union q) u) : Compat p u :=
-  h.mono (le_union_left p q) le_rfl
+  h.mono le_union_left le_rfl
 
 /-- The right component of a compatible union is compatible, given the
 components agree. -/

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -152,7 +152,7 @@ def State.merge (s s' : State W V M) : State W V M :=
 /-- The merge is above the left component in informativeness. -/
 theorem infoLe_merge_left (s s' : State W V M) : s ⊑ s.merge s' := by
   rintro r ⟨p, hp, q, hq, hpq, rfl⟩
-  exact ⟨p, hp, Possibility.le_union_left p q⟩
+  exact ⟨p, hp, Possibility.le_union_left⟩
 
 /-- The merge is above the right component in informativeness. -/
 theorem infoLe_merge_right (s s' : State W V M) : s' ⊑ s.merge s' := by
@@ -202,20 +202,12 @@ monoid of information — the content half of
   constructor
   · rintro ⟨p, hp, q, hq, -, rfl⟩
     have hq' : p.union q = p :=
-      Possibility.ext rfl (funext fun v => by
-        by_cases h : (p.assignment v).Dom
-        · simp [Possibility.union, h]
-        · have h' : p.assignment v = ⊥ := Part.eq_none_iff'.mpr h
-          simp [Possibility.union, hq v, h'])
+      Possibility.ext rfl (funext fun v => by simp [hq v])
     rwa [hq']
   · intro hr
     exact ⟨r, hr, ⟨r.world, fun _ => ⊥⟩, fun _ => rfl,
       Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => absurd h (Part.notMem_none _)⟩,
-      Possibility.ext rfl (funext fun v => by
-        by_cases h : (r.assignment v).Dom
-        · simp [Possibility.union, h]
-        · have h' : r.assignment v = ⊥ := Part.eq_none_iff'.mpr h
-          simp [Possibility.union, h'])⟩
+      Possibility.ext rfl (funext fun v => by simp)⟩
 
 @[simp] theorem initial_merge (s : State W V M) : State.merge State.initial s = s := by
   rw [merge_comm, merge_initial]


### PR DESCRIPTION
Factors the left-biased choice of partial values out of `Possibility.union` into `Part.or` (`Core/Data/Part.lean`, an `[UPSTREAM]` candidate for `Mathlib/Data/Part.lean`): the `Part` analogue of `Option.or` and the classical twin of `Flat.or`.

- `Possibility.lean` loses its `open Classical`, the inline `if`, and every union case split (`union_assoc` is pointwise `Part.or_assoc`; `domain_union` is `ext; simp`); `domain` now derives from `PFun.Dom`.
- `mem_assignment_union` characterizes union membership in the `Finmap.mem_lookup_union` mold; `le_union_left` args go implicit (`le_sup_left` mold), simplifying State/FileChange call sites.