### PR TITLE
refactor(Semantics/Dynamic): inherit merge and compat from Core order API

### DIFF
--- a/Linglib/Core/Data/Part.lean
+++ b/Linglib/Core/Data/Part.lean
@@ -33,27 +33,27 @@ theorem mem_or_iff : a ∈ p.or q ↔ a ∈ p ∨ ¬p.Dom ∧ a ∈ q := by
   · simp [Part.or, h]
   · simp [Part.or, eq_none_iff'.mpr h]
 
-@[simp] theorem none_or (q : Part α) : Part.none.or q = q :=
+@[simp] theorem none_or : Part.none.or q = q :=
   if_neg not_none_dom
 
-@[simp] theorem or_none (p : Part α) : p.or none = p := by
+@[simp] theorem or_none : p.or none = p := by
   by_cases h : p.Dom
   · simp [Part.or, h]
   · simp [Part.or, eq_none_iff'.mpr h]
 
-@[simp] theorem some_or (a : α) (q : Part α) : (Part.some a).or q = Part.some a :=
+@[simp] theorem some_or : (Part.some a).or q = Part.some a :=
   if_pos trivial
 
-@[simp] theorem bot_or (q : Part α) : (⊥ : Part α).or q = q :=
-  none_or q
+@[simp] theorem bot_or : (⊥ : Part α).or q = q :=
+  none_or
 
-@[simp] theorem or_bot (p : Part α) : p.or ⊥ = p :=
-  or_none p
+@[simp] theorem or_bot : p.or ⊥ = p :=
+  or_none
 
-@[simp] theorem or_self (p : Part α) : p.or p = p :=
+@[simp] theorem or_self : p.or p = p :=
   ite_self p
 
-theorem or_assoc (p q r : Part α) : (p.or q).or r = p.or (q.or r) := by
+theorem or_assoc : (p.or q).or r = p.or (q.or r) := by
   by_cases hp : p.Dom <;> by_cases hq : q.Dom <;> simp [Part.or, hp, hq]
 
 theorem le_or_left : p ≤ p.or q := fun _ ha => mem_or_iff.mpr (.inl ha)
@@ -82,5 +82,12 @@ theorem compat_iff : Compat p q ↔ ∀ a b, a ∈ p → b ∈ q → a = b := by
     exact fun a b ha hb => mem_unique (hp a ha) (hq b hb)
   · exact fun hag => ⟨p.or q, PartialUnify.mem_upperBounds_pair.mpr
       ⟨le_or_left, le_or_right_of_agree hag⟩⟩
+
+theorem le_or_right (h : Compat p q) : q ≤ p.or q :=
+  le_or_right_of_agree (compat_iff.mp h)
+
+theorem compat_or_left (hp : Compat p r) (hq : Compat q r) : Compat (p.or q) r :=
+  compat_iff.mpr fun a b ha hb => (mem_or_iff.mp ha).elim
+    (fun h => compat_iff.mp hp a b h hb) fun h => compat_iff.mp hq a b h.2 hb
 
 end Part

--- a/Linglib/Core/Data/Part.lean
+++ b/Linglib/Core/Data/Part.lean
@@ -86,8 +86,4 @@ theorem compat_iff : Compat p q ↔ ∀ a b, a ∈ p → b ∈ q → a = b := by
 theorem le_or_right (h : Compat p q) : q ≤ p.or q :=
   le_or_right_of_agree (compat_iff.mp h)
 
-theorem compat_or_left (hp : Compat p r) (hq : Compat q r) : Compat (p.or q) r :=
-  compat_iff.mpr fun a b ha hb => (mem_or_iff.mp ha).elim
-    (fun h => compat_iff.mp hp a b h hb) fun h => compat_iff.mp hq a b h.2 hb
-
 end Part

--- a/Linglib/Core/Data/Part.lean
+++ b/Linglib/Core/Data/Part.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Order.PartialUnify
 import Mathlib.Data.Part
 
 /-!
@@ -6,10 +7,12 @@ import Mathlib.Data.Part
 `Part.or` is the `Part` analogue of `Option.or`: `p.or q` is defined
 wherever either argument is, with the left taking precedence.
 Noncomputable, since it decides `p.Dom`; `Flat.or` is its computable
-twin on `Option`-carried partial values. Also two lemmas on the order:
-definedness is monotone (`dom_mono`), and descent without domain
-growth is equality (`eq_of_le_of_dom`). `[UPSTREAM]` candidates for
-`Mathlib/Data/Part.lean`.
+twin on `Option`-carried partial values. Also the order facts of the
+flat domain: definedness is monotone (`dom_mono`), descent without
+domain growth is equality (`eq_of_le_of_dom`), and two partial values
+are bounded above exactly when they agree wherever both are defined
+(`compat_iff`), with `p.or q` the witnessing bound. `[UPSTREAM]`
+candidates for `Mathlib/Data/Part.lean`.
 -/
 
 namespace Part
@@ -65,5 +68,19 @@ theorem eq_of_le_of_dom (h : p ≤ q) (hd : q.Dom → p.Dom) : p = q :=
   Part.ext fun a => ⟨h a, fun ha =>
     have hp := hd (dom_iff_mem.mpr ⟨a, ha⟩)
     mem_unique (h _ (get_mem hp)) ha ▸ get_mem hp⟩
+
+theorem le_or_right_of_agree (hag : ∀ a b, a ∈ p → b ∈ q → a = b) :
+    q ≤ p.or q := fun b hb => mem_or_iff.mpr <| or_iff_not_imp_left.mpr
+  fun hp => ⟨fun hd => hp (hag _ b (get_mem hd) hb ▸ get_mem hd), hb⟩
+
+/-- Two partial values are compatible — bounded above in the flat
+order — exactly when they agree wherever both are defined. -/
+theorem compat_iff : Compat p q ↔ ∀ a b, a ∈ p → b ∈ q → a = b := by
+  constructor
+  · rintro ⟨u, hu⟩
+    obtain ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+    exact fun a b ha hb => mem_unique (hp a ha) (hq b hb)
+  · exact fun hag => ⟨p.or q, PartialUnify.mem_upperBounds_pair.mpr
+      ⟨le_or_left, le_or_right_of_agree hag⟩⟩
 
 end Part

--- a/Linglib/Core/Data/Part.lean
+++ b/Linglib/Core/Data/Part.lean
@@ -6,7 +6,9 @@ import Mathlib.Data.Part
 `Part.or` is the `Part` analogue of `Option.or`: `p.or q` is defined
 wherever either argument is, with the left taking precedence.
 Noncomputable, since it decides `p.Dom`; `Flat.or` is its computable
-twin on `Option`-carried partial values. An `[UPSTREAM]` candidate for
+twin on `Option`-carried partial values. Also two lemmas on the order:
+definedness is monotone (`dom_mono`), and descent without domain
+growth is equality (`eq_of_le_of_dom`). `[UPSTREAM]` candidates for
 `Mathlib/Data/Part.lean`.
 -/
 
@@ -55,5 +57,13 @@ theorem le_or_left : p ≤ p.or q := fun _ ha => mem_or_iff.mpr (.inl ha)
 
 theorem or_le (hp : p ≤ r) (hq : q ≤ r) : p.or q ≤ r := fun a ha =>
   (mem_or_iff.mp ha).elim (hp a) fun h => hq a h.2
+
+theorem dom_mono (h : p ≤ q) (hd : p.Dom) : q.Dom :=
+  dom_iff_mem.mpr ⟨_, h _ (get_mem hd)⟩
+
+theorem eq_of_le_of_dom (h : p ≤ q) (hd : q.Dom → p.Dom) : p = q :=
+  Part.ext fun a => ⟨h a, fun ha =>
+    have hp := hd (dom_iff_mem.mpr ⟨a, ha⟩)
+    mem_unique (h _ (get_mem hp)) ha ▸ get_mem hp⟩
 
 end Part

--- a/Linglib/Core/Order/PartialUnify.lean
+++ b/Linglib/Core/Order/PartialUnify.lean
@@ -265,3 +265,52 @@ instance [PartialOrder α] [PartialUnify α] (a b : α) : Decidable (Compat a b)
   decidable_of_iff _ PartialUnify.isSome_unify_iff_bddAbove
 
 end Compat
+
+/-! ### Joining point sets -/
+
+namespace Set
+
+variable {α : Type*} [PartialOrder α] {s t : Set α} {c : α}
+
+/-- The least upper bounds of pairs drawn from two sets — the
+partial-join analogue of `Set.sups`, keeping exactly the bounded pairs:
+unification of description sets in [carpenter-1992]'s setting. -/
+def lubs (s t : Set α) : Set α :=
+  {c | ∃ a ∈ s, ∃ b ∈ t, IsLUB {a, b} c}
+
+@[simp] theorem mem_lubs : c ∈ s.lubs t ↔ ∃ a ∈ s, ∃ b ∈ t, IsLUB {a, b} c :=
+  Iff.rfl
+
+theorem lubs_comm (s t : Set α) : s.lubs t = t.lubs s := by
+  ext c
+  constructor <;> rintro ⟨a, ha, b, hb, h⟩ <;>
+    exact ⟨b, hb, a, ha, pair_comm a b ▸ h⟩
+
+private theorem mem_lubs_left_iff
+    (H : ∀ a b : α, Compat a b → ∃ c, IsLUB ({a, b} : Set α) c) :
+    ∀ (s t u : Set α) (c : α),
+      c ∈ (s.lubs t).lubs u ↔ ∃ a ∈ s, ∃ b ∈ t, ∃ w ∈ u, IsLUB {a, b, w} c := by
+  intro s t u c
+  constructor
+  · rintro ⟨v, ⟨a, ha, b, hb, hab⟩, w, hw, hvw⟩
+    exact ⟨a, ha, b, hb, w, hw, (PartialUnify.isLUB_pair_step hab).mp hvw⟩
+  · rintro ⟨a, ha, b, hb, w, hw, h⟩
+    obtain ⟨v, hv⟩ := H a b (Compat.of_le (h.1 (mem_insert _ _))
+      (h.1 (mem_insert_of_mem _ (mem_insert _ _))))
+    exact ⟨v, ⟨a, ha, b, hb, hv⟩, w, hw, (PartialUnify.isLUB_pair_step hv).mpr h⟩
+
+/-- Under pairwise bounded completeness — every bounded pair has a join —
+joining point sets is associative. -/
+theorem lubs_assoc (H : ∀ a b : α, Compat a b → ∃ c, IsLUB ({a, b} : Set α) c)
+    (s t u : Set α) : (s.lubs t).lubs u = s.lubs (t.lubs u) := by
+  have hset : ∀ b w a : α, ({b, w, a} : Set α) = {a, b, w} := by
+    intro b w a; ext x; simp [mem_insert_iff]; tauto
+  ext c
+  rw [mem_lubs_left_iff H, lubs_comm s (t.lubs u), mem_lubs_left_iff H]
+  constructor
+  · rintro ⟨a, ha, b, hb, w, hw, h⟩
+    exact ⟨b, hb, w, hw, a, ha, (hset b w a).symm ▸ h⟩
+  · rintro ⟨b, hb, w, hw, a, ha, h⟩
+    exact ⟨a, ha, b, hb, w, hw, hset b w a ▸ h⟩
+
+end Set

--- a/Linglib/Semantics/Dynamic/Category.lean
+++ b/Linglib/Semantics/Dynamic/Category.lean
@@ -203,7 +203,7 @@ def elementsToPoints :
     rw [Subsingleton.elim f.1 (homOfLE hb).op, possibilities_map_apply]
       at hmap
     rw [← hmap, ← Possibility.restrict_domainEquiv_symm hb]
-    exact Possibility.restrict_le _ _)).op
+    exact Possibility.restrict_le)).op
   map_id _ := Subsingleton.elim _ _
   map_comp _ _ := Subsingleton.elim _ _
 

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -265,7 +265,7 @@ theorem DRS.mem_state {W : Type*} {K : DRS L V} {hK : K.IsProper}
     rw [← hg] at hv
     exact hv
   · rintro ⟨hq, f, g, hrel, hvals⟩
-    refine ⟨hq, ⟨q.world, fun _ => ⊥⟩, fun _ => rfl, ?_, rfl,
+    refine ⟨hq, ⟨q.world, fun _ => ⊥⟩, ⟨q.world, rfl⟩, ?_, rfl,
       (↑(∅ : Finset V) : Set V).restrict f,
       (↑(∅ ∪ K.referents) : Set V).restrict g,
       fun v => absurd v.2 (by simp), fun v => hvals v, f, g, rfl, rfl, hrel⟩

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -88,7 +88,7 @@ on novel referents the update extends rather than shrinks. -/
 theorem infoLe_ofState (A : State W V M) {F F' : State W V M}
     (h : F' ∈ ofState A F) : F ⊑ F' := by
   obtain rfl := Part.mem_some_iff.mp h
-  exact infoLe_merge_left F A
+  exact infoLe_merge_left
 
 /-- Atomic predicate on the world: merge with the empty-domain
 proposition state. -/
@@ -204,20 +204,17 @@ proposition state eliminates the points at incompatible worlds. -/
 theorem atomW_eq (pred : W → Prop) (F : State W V M) :
     atomW pred F = Part.some {p ∈ F | pred p.world} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
-  · rintro ⟨p, hp, q, ⟨hqdom, hqpred⟩, hpq, rfl⟩
+  · intro hr
+    obtain ⟨p, hp, q, ⟨hqdom, hqpred⟩, hpq, rfl⟩ := State.mem_merge.mp hr
     have hqle : q ≤ p := ⟨(Possibility.compat_iff.mp hpq).1.symm, fun v e he =>
       absurd (Part.dom_iff_mem.mpr ⟨e, he⟩)
         (Set.eq_empty_iff_forall_notMem.mp hqdom v)⟩
     rw [le_antisymm (Possibility.union_le le_rfl hqle) Possibility.le_union_left]
     exact ⟨hp, (Possibility.compat_iff.mp hpq).1.symm ▸ hqpred⟩
   · rintro ⟨hr, hpred⟩
-    have hqle : (⟨r.world, fun _ => ⊥⟩ : Possibility W V (Part M)) ≤ r :=
-      ⟨rfl, fun _ => bot_le⟩
-    refine ⟨r, hr, ⟨r.world, fun _ => ⊥⟩,
-      ⟨Set.eq_empty_iff_forall_notMem.mpr fun _ hv => hv, hpred⟩,
-      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => absurd h (Part.notMem_none _)⟩, ?_⟩
-    exact (le_antisymm (Possibility.union_le le_rfl hqle)
-      Possibility.le_union_left).symm
+    exact State.mem_merge.mpr ⟨r, hr, Possibility.bot r.world,
+      ⟨Possibility.domain_bot, hpred⟩, .of_le le_rfl Possibility.bot_le,
+      Possibility.union_bot.symm⟩
 
 /-- Rule (13), the familiar regime: at a familiar card the atom
 filters — and in particular is eliminative. -/
@@ -226,7 +223,8 @@ theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
     atomVar pred x F =
       Part.some {p ∈ F | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
-  · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
+  · intro hmem
+    obtain ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩ := State.mem_merge.mp hmem
     obtain ⟨hw, hag⟩ := Possibility.compat_iff.mp hpq
     obtain ⟨m₀, hpx⟩ := Part.dom_iff_mem.mp (hfam p hp)
     have hqle : q ≤ p := ⟨hw.symm, fun v e he => by
@@ -238,7 +236,7 @@ theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
   · rintro ⟨hr, m, hrx, hpred⟩
     have hqle : (⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩ : Possibility W V (Part M)) ≤ r :=
       ⟨rfl, fun v e he => by obtain ⟨rfl, rfl⟩ := he; exact hrx⟩
-    refine ⟨r, hr, ⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩,
+    refine State.mem_merge.mpr ⟨r, hr, ⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩,
       ⟨Set.ext fun v => Iff.rfl, m, ⟨rfl, rfl⟩, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · obtain ⟨rfl, rfl⟩ := he'
@@ -255,7 +253,8 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     atomVar pred x F = Part.some
       {p ∈ State.randomAssign F x | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
-  · rintro ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩
+  · intro hmem
+    obtain ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩ := State.mem_merge.mp hmem
     have huq : p.union q = p.update x (Part.some m) :=
       Possibility.ext rfl (funext fun v => by
         by_cases hv : v = x
@@ -270,7 +269,7 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     obtain ⟨p, hp, m', rfl⟩ := hmem
     obtain rfl : m = m' := by
       simpa [Possibility.update] using hrx
-    refine ⟨p, hp, ⟨p.world, fun v => ⟨v = x, fun _ => m⟩⟩,
+    refine State.mem_merge.mpr ⟨p, hp, ⟨p.world, fun v => ⟨v = x, fun _ => m⟩⟩,
       ⟨Set.ext fun v => Iff.rfl, m, ⟨rfl, rfl⟩, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · obtain ⟨rfl, rfl⟩ := he'

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -80,6 +80,12 @@ theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q
   Possibility.ext h.1 <| funext fun v =>
     Part.eq_of_le_of_dom (h.2 v) fun hd => hdom.superset hd
 
+/-- A point defines no referent exactly when its assignment is nowhere
+defined. -/
+theorem domain_eq_empty_iff : p.domain = ∅ ↔ ∀ v, p.assignment v = ⊥ := by
+  simp only [Set.eq_empty_iff_forall_notMem, mem_domain]
+  exact forall_congr' fun v => Part.eq_none_iff'.symm
+
 /-- The union of two points, defined wherever either is, with the left
 taking precedence; on compatible points the precedence is immaterial
 (`union_comm`). -/
@@ -100,7 +106,7 @@ theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
 /-- Compatibility of partial points is worldwise and pointwise. -/
 theorem compat_iff_forall : Compat p q ↔
     p.world = q.world ∧ ∀ v, Compat (p.assignment v) (q.assignment v) :=
-  ⟨fun ⟨u, hu⟩ =>
+  ⟨fun ⟨_, hu⟩ =>
     have ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
     ⟨hp.1.trans hq.1.symm, fun v => .of_le (hp.2 v) (hq.2 v)⟩,
    fun ⟨hw, hc⟩ => .of_le le_union_left
@@ -126,6 +132,14 @@ theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
       have h := PartialUnify.mem_upperBounds_pair.mp hu
       union_le h.1 h.2⟩
 
+/-- The joins of pairs of points: `u` bounds `{p, q}` least exactly when
+the pair is compatible and `u` is its union. -/
+theorem isLUB_pair_iff : IsLUB {p, q} u ↔ Compat p q ∧ u = p.union q :=
+  ⟨fun h =>
+    have hc : Compat p q := ⟨u, h.1⟩
+    ⟨hc, ((isLUB_union hc).unique h).symm⟩,
+   fun ⟨hc, hu⟩ => hu ▸ isLUB_union hc⟩
+
 /-- The union of two points defines the union of their domains. -/
 theorem domain_union : (p.union q).domain = p.domain ∪ q.domain := by
   ext v; simp
@@ -140,27 +154,27 @@ theorem eq_of_compat_of_domain_eq (h : Compat p q) (hdom : p.domain = q.domain) 
 theorem union_assoc : (p.union q).union r = p.union (q.union r) :=
   Possibility.ext rfl <| funext fun _ => Part.or_assoc
 
+@[simp] theorem union_self : p.union p = p :=
+  Possibility.ext rfl <| funext fun _ => Part.or_self
+
 /-- On compatible points the left precedence of `union` is immaterial. -/
 theorem union_comm (h : Compat p q) : p.union q = q.union p :=
   (isLUB_union h).unique (Set.pair_comm p q ▸ isLUB_union h.symm)
 
-/-- A union is compatible with whatever both components are compatible
-with. -/
-theorem compat_union_left (hpu : Compat p u) (hqu : Compat q u) :
-    Compat (p.union q) u :=
-  have ⟨hpw, hpc⟩ := compat_iff_forall.mp hpu
-  have ⟨_, hqc⟩ := compat_iff_forall.mp hqu
-  compat_iff_forall.mpr ⟨hpw, fun v => Part.compat_or_left (hpc v) (hqc v)⟩
+/-! ### The empty point -/
 
-/-- The left component of a compatible union is compatible. -/
-theorem compat_of_union_left (h : Compat (p.union q) u) : Compat p u :=
-  h.mono le_union_left le_rfl
+/-- The empty point at a world: no referent defined. -/
+def bot (w : W) : Possibility W V (Part M) :=
+  ⟨w, fun _ => ⊥⟩
 
-/-- The right component of a compatible union is compatible, given the
-components agree. -/
-theorem compat_of_union_right (hpq : Compat p q) (h : Compat (p.union q) u) :
-    Compat q u :=
-  h.mono (le_union_right hpq) le_rfl
+theorem bot_le : bot p.world ≤ p :=
+  ⟨rfl, fun _ => _root_.bot_le⟩
+
+@[simp] theorem union_bot {w : W} : p.union (bot w) = p :=
+  Possibility.ext rfl <| funext fun _ => Part.or_bot
+
+@[simp] theorem domain_bot {w : W} : (bot w : Possibility W V (Part M)).domain = ∅ :=
+  domain_eq_empty_iff.mpr fun _ => rfl
 
 /-! ### Restriction and the indexed classification -/
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -72,15 +72,13 @@ def domain (p : Possibility W V (Part M)) : Set V :=
     v ∈ p.domain ↔ (p.assignment v).Dom := Iff.rfl
 
 /-- Descent grows the domain. -/
-theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v hd =>
-  Part.dom_iff_mem.mpr ⟨_, h.2 v _ (Part.get_mem hd)⟩
+theorem domain_mono (h : p ≤ q) : p.domain ⊆ q.domain := fun v =>
+  Part.dom_mono (h.2 v)
 
 /-- On a shared domain, descent is equality — there is no room to grow. -/
 theorem eq_of_le_of_domain_eq (h : p ≤ q) (hdom : p.domain = q.domain) : p = q :=
-  Possibility.ext h.1 <| funext fun v => le_antisymm (h.2 v) fun e he => by
-    have hd : (p.assignment v).Dom := hdom.superset (Part.dom_iff_mem.mpr ⟨e, he⟩)
-    obtain rfl := Part.mem_unique (h.2 v _ (Part.get_mem hd)) he
-    exact Part.get_mem hd
+  Possibility.ext h.1 <| funext fun v =>
+    Part.eq_of_le_of_dom (h.2 v) fun hd => hdom.superset hd
 
 /-- The union of two points, defined wherever either is, with the left
 taking precedence; on compatible points the precedence is immaterial

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -101,12 +101,6 @@ theorem mem_assignment_union {v : V} {e : M} :
 theorem le_union_left : p ≤ p.union q :=
   ⟨rfl, fun _ => Part.le_or_left⟩
 
-private theorem le_union_right_of_agree (hw : p.world = q.world)
-    (hag : ∀ v e e', e ∈ p.assignment v → e' ∈ q.assignment v → e = e') :
-    q ≤ p.union q :=
-  ⟨hw.symm, fun v e he => mem_assignment_union.mpr <| or_iff_not_imp_left.mpr
-    fun hp => ⟨fun hd => hp (hag v _ e (Part.get_mem hd) he ▸ Part.get_mem hd), he⟩⟩
-
 theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
   ⟨hp.1, fun v => Part.or_le (hp.2 v) (hq.2 v)⟩
 
@@ -121,14 +115,14 @@ theorem compat_iff : Compat p q ↔
   · rintro ⟨u, hu⟩
     obtain ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
     exact ⟨hp.1.trans hq.1.symm,
-      fun v e e' he he' => Part.mem_unique (hp.2 v e he) (hq.2 v e' he')⟩
+      fun v => Part.compat_iff.mp (Compat.of_le (hp.2 v) (hq.2 v))⟩
   · rintro ⟨hw, hag⟩
     exact ⟨p.union q, PartialUnify.mem_upperBounds_pair.mpr
-      ⟨le_union_left, le_union_right_of_agree hw hag⟩⟩
+      ⟨le_union_left, hw.symm, fun v => Part.le_or_right_of_agree (hag v)⟩⟩
 
 theorem le_union_right (h : Compat p q) : q ≤ p.union q :=
   have h' := compat_iff.mp h
-  le_union_right_of_agree h'.1 h'.2
+  ⟨h'.1.symm, fun v => Part.le_or_right_of_agree (h'.2 v)⟩
 
 /-- The union of compatible points is their least upper bound. -/
 theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -50,7 +50,7 @@ end Update
 
 /-! ### Partial points -/
 
-variable {p q u : Possibility W V (Part M)}
+variable {p q r u : Possibility W V (Part M)}
 
 /-- `p ≤ q` iff `p` and `q` share their world and the assignments grow
 pointwise in the order of partial values. -/
@@ -91,18 +91,20 @@ noncomputable def union (p q : Possibility W V (Part M)) : Possibility W V (Part
 @[simp] theorem union_assignment (v : V) :
     (p.union q).assignment v = (p.assignment v).or (q.assignment v) := rfl
 
-/-- A union assignment holds the left component's values, and the
-right's outside the left's domain. -/
-theorem mem_assignment_union {v : V} {e : M} :
-    e ∈ (p.union q).assignment v ↔
-      e ∈ p.assignment v ∨ v ∉ p.domain ∧ e ∈ q.assignment v :=
-  Part.mem_or_iff
-
 theorem le_union_left : p ≤ p.union q :=
   ⟨rfl, fun _ => Part.le_or_left⟩
 
 theorem union_le (hp : p ≤ u) (hq : q ≤ u) : p.union q ≤ u :=
   ⟨hp.1, fun v => Part.or_le (hp.2 v) (hq.2 v)⟩
+
+/-- Compatibility of partial points is worldwise and pointwise. -/
+theorem compat_iff_forall : Compat p q ↔
+    p.world = q.world ∧ ∀ v, Compat (p.assignment v) (q.assignment v) :=
+  ⟨fun ⟨u, hu⟩ =>
+    have ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+    ⟨hp.1.trans hq.1.symm, fun v => .of_le (hp.2 v) (hq.2 v)⟩,
+   fun ⟨hw, hc⟩ => .of_le le_union_left
+    ⟨hw.symm, fun v => Part.le_or_right (hc v)⟩⟩
 
 /-- Two partial points are compatible (`Compat`: bounded above in the
 descent order) exactly when they share their world and agree wherever
@@ -111,18 +113,11 @@ Def. 0.26, that the union of chosen points be a function. -/
 theorem compat_iff : Compat p q ↔
     p.world = q.world ∧
       ∀ v e e', e ∈ p.assignment v → e' ∈ q.assignment v → e = e' := by
-  constructor
-  · rintro ⟨u, hu⟩
-    obtain ⟨hp, hq⟩ := PartialUnify.mem_upperBounds_pair.mp hu
-    exact ⟨hp.1.trans hq.1.symm,
-      fun v => Part.compat_iff.mp (Compat.of_le (hp.2 v) (hq.2 v))⟩
-  · rintro ⟨hw, hag⟩
-    exact ⟨p.union q, PartialUnify.mem_upperBounds_pair.mpr
-      ⟨le_union_left, hw.symm, fun v => Part.le_or_right_of_agree (hag v)⟩⟩
+  simp only [compat_iff_forall, Part.compat_iff]
 
 theorem le_union_right (h : Compat p q) : q ≤ p.union q :=
-  have h' := compat_iff.mp h
-  ⟨h'.1.symm, fun v => Part.le_or_right_of_agree (h'.2 v)⟩
+  have h' := compat_iff_forall.mp h
+  ⟨h'.1.symm, fun v => Part.le_or_right (h'.2 v)⟩
 
 /-- The union of compatible points is their least upper bound. -/
 theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
@@ -132,8 +127,7 @@ theorem isLUB_union (h : Compat p q) : IsLUB {p, q} (p.union q) :=
       union_le h.1 h.2⟩
 
 /-- The union of two points defines the union of their domains. -/
-theorem domain_union (p q : Possibility W V (Part M)) :
-    (p.union q).domain = p.domain ∪ q.domain := by
+theorem domain_union : (p.union q).domain = p.domain ∪ q.domain := by
   ext v; simp
 
 /-- On a shared domain, compatibility is equality. -/
@@ -143,9 +137,8 @@ theorem eq_of_compat_of_domain_eq (h : Compat p q) (hdom : p.domain = q.domain) 
   (eq_of_le_of_domain_eq le_union_left hu.symm).trans
     (eq_of_le_of_domain_eq (le_union_right h) (hdom.symm.trans hu.symm)).symm
 
-theorem union_assoc (p q r : Possibility W V (Part M)) :
-    (p.union q).union r = p.union (q.union r) :=
-  Possibility.ext rfl <| funext fun _ => Part.or_assoc ..
+theorem union_assoc : (p.union q).union r = p.union (q.union r) :=
+  Possibility.ext rfl <| funext fun _ => Part.or_assoc
 
 /-- On compatible points the left precedence of `union` is immaterial. -/
 theorem union_comm (h : Compat p q) : p.union q = q.union p :=
@@ -154,12 +147,10 @@ theorem union_comm (h : Compat p q) : p.union q = q.union p :=
 /-- A union is compatible with whatever both components are compatible
 with. -/
 theorem compat_union_left (hpu : Compat p u) (hqu : Compat q u) :
-    Compat (p.union q) u := by
-  obtain ⟨hpw, hpa⟩ := compat_iff.mp hpu
-  obtain ⟨-, hqa⟩ := compat_iff.mp hqu
-  exact compat_iff.mpr ⟨hpw, fun v e e' he he' =>
-    (mem_assignment_union.mp he).elim (fun h => hpa v e e' h he') fun h =>
-      hqa v e e' h.2 he'⟩
+    Compat (p.union q) u :=
+  have ⟨hpw, hpc⟩ := compat_iff_forall.mp hpu
+  have ⟨_, hqc⟩ := compat_iff_forall.mp hqu
+  compat_iff_forall.mpr ⟨hpw, fun v => Part.compat_or_left (hpc v) (hqc v)⟩
 
 /-- The left component of a compatible union is compatible. -/
 theorem compat_of_union_left (h : Compat (p.union q) u) : Compat p u :=
@@ -175,36 +166,35 @@ theorem compat_of_union_right (hpq : Compat p q) (h : Compat (p.union q) u) :
 
 section Restrict
 
+variable {X Y : Set V}
+
 /-- Restrict a partial point to the referents in `X`. -/
 def restrict (X : Set V) (p : Possibility W V (Part M)) : Possibility W V (Part M) :=
   ⟨p.world, fun v => ⟨v ∈ X ∧ (p.assignment v).Dom, fun h => (p.assignment v).get h.2⟩⟩
 
-@[simp] theorem restrict_world (X : Set V) (p : Possibility W V (Part M)) :
-    (p.restrict X).world = p.world := rfl
+@[simp] theorem restrict_world : (p.restrict X).world = p.world := rfl
 
 /-- Restriction descends. -/
-theorem restrict_le (X : Set V) (p : Possibility W V (Part M)) : p.restrict X ≤ p :=
+theorem restrict_le : p.restrict X ≤ p :=
   ⟨rfl, fun v e he => by
     obtain ⟨⟨-, hd⟩, rfl⟩ := he
     exact Part.get_mem hd⟩
 
 /-- Restriction intersects the domain. -/
-theorem domain_restrict (X : Set V) (p : Possibility W V (Part M)) :
-    (p.restrict X).domain = X ∩ p.domain :=
+theorem domain_restrict : (p.restrict X).domain = X ∩ p.domain :=
   rfl
 
 /-- A point with domain `X` descends into `q` exactly when it is `q`
 restricted to `X`. -/
-theorem le_iff_eq_restrict {X : Set V} (hp : p.domain = X) :
+theorem le_iff_eq_restrict (hp : p.domain = X) :
     p ≤ q ↔ p = q.restrict X := by
-  refine ⟨fun h => Possibility.ext h.1 (funext fun v => ?_), fun h => h ▸ restrict_le X q⟩
+  refine ⟨fun h => Possibility.ext h.1 (funext fun v => ?_), fun h => h ▸ restrict_le⟩
   refine Part.ext' ⟨fun hd => ⟨hp.subset hd, domain_mono h hd⟩, fun hd => hp.superset hd.1⟩
     fun hd hd' => ?_
   exact Part.mem_unique (h.2 v _ (Part.get_mem hd)) (Part.get_mem hd'.2)
 
 /-- Consecutive restrictions restrict to the intersection. -/
-theorem restrict_restrict (X Y : Set V) (p : Possibility W V (Part M)) :
-    (p.restrict Y).restrict X = p.restrict (X ∩ Y) :=
+theorem restrict_restrict : (p.restrict Y).restrict X = p.restrict (X ∩ Y) :=
   Possibility.ext rfl <| funext fun v =>
     Part.ext' (by simp [restrict, Set.mem_inter_iff, and_assoc]) fun _ _ => rfl
 
@@ -218,12 +208,8 @@ def domainEquiv (X : Set V) :
     Part.ext' ⟨fun hx => p.2.superset hx, fun hd => p.2.subset hd⟩ fun _ _ => rfl
   right_inv _ := rfl
 
-theorem domainEquiv_symm_val (X : Set V) (e : W × (X → M)) :
-    ((domainEquiv X).symm e).1 = ⟨e.1, fun v => ⟨v ∈ X, fun h => e.2 ⟨v, h⟩⟩⟩ :=
-  rfl
-
 /-- Restricting a classified point restricts its chart. -/
-theorem restrict_domainEquiv_symm {Y X : Set V} (h : Y ⊆ X) (e : W × (X → M)) :
+theorem restrict_domainEquiv_symm (h : Y ⊆ X) (e : W × (X → M)) :
     ((domainEquiv X).symm e).1.restrict Y =
       ((domainEquiv Y).symm (e.1, fun v => e.2 ⟨v.1, h v.2⟩)).1 :=
   Possibility.ext rfl <| funext fun _ =>

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -185,13 +185,13 @@ theorem merge_assoc (s t u : State W V M) :
     have hqv := Possibility.compat_of_union_right hpq hav
     exact ⟨p, hp, q.union v, ⟨q, hq, v, hv, hqv, rfl⟩,
       (Possibility.compat_union_left hpq.symm hpv.symm).symm,
-      Possibility.union_assoc p q v⟩
+      Possibility.union_assoc⟩
   · rintro ⟨p, hp, a, ⟨q, hq, v, hv, hqv, rfl⟩, hpa, rfl⟩
     have hpq := (Possibility.compat_of_union_left hpa.symm).symm
     have hpv := (Possibility.compat_of_union_right hqv hpa.symm).symm
     exact ⟨p.union q, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv,
       Possibility.compat_union_left hpv hqv,
-      (Possibility.union_assoc p q v).symm⟩
+      (Possibility.union_assoc).symm⟩
 
 /-- The initial state is a unit for consistent merge: with `merge_comm`,
 `merge_assoc`, and `merge_infoLe`, updating is joining in a commutative
@@ -305,7 +305,7 @@ theorem subsistsIn_iff_subset_restrict {X : Set V}
       ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
   · rintro h p hp
     obtain ⟨q, hq, rfl⟩ := h hp
-    exact ⟨q, hq, Possibility.restrict_le X q⟩
+    exact ⟨q, hq, Possibility.restrict_le⟩
 
 /-- Informativeness out of a stratum factors through reindexing: the
 restricted image of the stronger is included in the weaker — the
@@ -319,7 +319,7 @@ theorem infoLe_iff_restrict_subset {X : Set V}
     rwa [← (Possibility.le_iff_eq_restrict (hs p hp)).mp hpq]
   · intro h q hq
     exact ⟨q.restrict X, h ⟨q, hq, rfl⟩,
-      Possibility.restrict_le X q⟩
+      Possibility.restrict_le⟩
 
 end Fibred
 
@@ -331,7 +331,7 @@ def restrict (X : Set V) (I : State W V M) : State W V M :=
 original. -/
 theorem subsistsIn_restrict (X : Set V) (I : State W V M) : I.restrict X ⪯ I := by
   rintro p ⟨q, hq, rfl⟩
-  exact ⟨q, hq, Possibility.restrict_le X q⟩
+  exact ⟨q, hq, Possibility.restrict_le⟩
 
 /-- Restriction meets the stratification. -/
 theorem uniformAt_restrict {X Y : Set V} {I : State W V M}
@@ -344,7 +344,7 @@ theorem restrict_restrict (X Y : Set V) (I : State W V M) :
     (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
   unfold restrict
   rw [← Set.image_comp]
-  exact congrFun (congrArg _ (funext (Possibility.restrict_restrict X Y))) I
+  exact congrFun (congrArg _ (funext fun _ => Possibility.restrict_restrict)) I
 
 variable [DecidableEq V]
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,6 +1,5 @@
 import Linglib.Semantics.Dynamic.Possibility
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Set.Function
+import Mathlib.Data.Set.Image
 import Mathlib.Order.Hom.Basic
 
 /-!
@@ -18,9 +17,8 @@ world–assignment pair.
 There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
 (`UniformAt`), and a base is the index of a fiber, not part of the data.
 Points with domain `X` are world–`X`-assignment pairs, constructively
-(`Possibility.domainEquiv` — the total-assignment rendering needed choice
-and an inhabitant of `M` to recover this). Two preorders run through states, and they are
-dual on shared strata. *Informativeness* (`⊑`,
+(`Possibility.domainEquiv`). Two preorders run through states, and they
+are dual on shared strata. *Informativeness* (`⊑`,
 [kamp-vangenabith-reyle-2011] Def. 25) quantifies over the stronger
 state: every point of the stronger lies above a point of the weaker — the
 absurd state `∅` is maximally informative, the eliminative direction.
@@ -64,9 +62,9 @@ stratum they reduce to `⊇` and `⊆` respectively
 `⊑`/`⪯` are scoped relations rather than instances. Neither is
 antisymmetric on raw sets (adding a comparable point is invisible —
 below for `⪯`, above for `⊑`); antisymmetry holds on each
-uniform stratum, where they coincide with `⊇`/`⊆`. The predecessor of this file classified its
-fibers as `(Set (W × (↑X → M)))ᵒᵈ` — the dual lands here because its
-order was Def. 25's, matching `⊑`, not `⪯`.
+uniform stratum, where they coincide with `⊇`/`⊆`. `Subsists` is
+membership in `lowerClosure`, so `⪯` and `⊑` are the containments
+`s ⊆ ↑(lowerClosure s')` and `s' ⊆ ↑(upperClosure s)`.
 
 ## References
 
@@ -87,8 +85,15 @@ states is `Set`'s. -/
 abbrev State (W V M : Type*) := Set (Possibility W V (Part M))
 
 /-- The initial information state `W × {g_⊤}`: every world live, no
-referent defined. -/
-def State.initial : State W V M := {p | ∀ v, p.assignment v = ⊥}
+referent defined — the range of the empty points. -/
+def State.initial : State W V M :=
+  Set.range Possibility.bot
+
+/-- Membership in the initial state: no referent defined. -/
+theorem State.mem_initial {p : Possibility W V (Part M)} :
+    p ∈ (State.initial : State W V M) ↔ ∀ v, p.assignment v = ⊥ :=
+  ⟨fun ⟨_, hw⟩ _ => hw ▸ rfl, fun h =>
+    ⟨p.world, Possibility.ext rfl (funext fun v => (h v).symm)⟩⟩
 
 /-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it has a
 point above it in `s`. -/
@@ -99,7 +104,7 @@ def Subsists (p : Possibility W V (Part M)) (s : State W V M) : Prop :=
 
 theorem Subsists.of_mem {p : Possibility W V (Part M)} {s : State W V M}
     (h : p ∈ s) : p ≺ s :=
-  ⟨p, h, le_refl p⟩
+  ⟨p, h, le_rfl⟩
 
 /-- `s` subsists in `s'`: the informativeness order, Def. 25's
 projection form — every point of the weaker state has a descendant in
@@ -128,7 +133,7 @@ def infoLe (s s' : State W V M) : Prop :=
 @[inherit_doc] scoped notation:50 s " ⊑ " s' => infoLe s s'
 
 theorem infoLe_refl (s : State W V M) : s ⊑ s :=
-  fun q hq => ⟨q, hq, le_refl q⟩
+  fun q hq => ⟨q, hq, le_rfl⟩
 
 theorem infoLe_trans {s t u : State W V M} (hst : s ⊑ t) (htu : t ⊑ u) :
     s ⊑ u := fun r hr => by
@@ -138,60 +143,51 @@ theorem infoLe_trans {s t u : State W V M} (hst : s ⊑ t) (htu : t ⊑ u) :
 
 /-- The absurd state is maximally informative. -/
 theorem infoLe_empty (s : State W V M) : s ⊑ (∅ : State W V M) :=
-  fun q hq => absurd hq (Set.notMem_empty q)
+  fun _ hq => hq.elim
 
 /-! ### Consistent merge -/
 
+variable {s s' t : State W V M} {r : Possibility W V (Part M)}
+
 /-- Consistent merge ([kamp-vangenabith-reyle-2011] Def. 0.26, binary):
-the points assembled from compatible pairs. Across strata this is the
-descendant-mediated join — plain intersection of point-sets is empty
-between distinct strata. -/
+the joins of pairs of points, one from each state (`Set.lubs`). Across
+strata this is the descendant-mediated join — plain intersection of
+point-sets is empty between distinct strata. -/
 def State.merge (s s' : State W V M) : State W V M :=
-  {r | ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q}
+  s.lubs s'
+
+/-- Membership in a merge, in union form. -/
+theorem State.mem_merge :
+    r ∈ s.merge s' ↔ ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q := by
+  simp only [State.merge, Set.mem_lubs, Possibility.isLUB_pair_iff]
 
 /-- The merge is above the left component in informativeness. -/
-theorem infoLe_merge_left (s s' : State W V M) : s ⊑ s.merge s' := by
-  rintro r ⟨p, hp, q, hq, hpq, rfl⟩
-  exact ⟨p, hp, Possibility.le_union_left⟩
+theorem infoLe_merge_left : s ⊑ s.merge s' := by
+  rintro r ⟨p, hp, q, hq, hlub⟩
+  exact ⟨p, hp, hlub.1 (Set.mem_insert _ _)⟩
 
 /-- The merge is above the right component in informativeness. -/
-theorem infoLe_merge_right (s s' : State W V M) : s' ⊑ s.merge s' := by
-  rintro r ⟨p, hp, q, hq, hpq, rfl⟩
-  exact ⟨q, hq, Possibility.le_union_right hpq⟩
+theorem infoLe_merge_right : s' ⊑ s.merge s' := by
+  rintro r ⟨p, hp, q, hq, hlub⟩
+  exact ⟨q, hq, hlub.1 (Set.mem_insert_of_mem _ rfl)⟩
 
 /-- **The merge is the least upper bound** (Def. 0.26's universal
 property, in the informativeness preorder): anything above both
 components is above their merge. -/
-theorem merge_infoLe {s s' t : State W V M} (hs : s ⊑ t)
-    (hs' : s' ⊑ t) : s.merge s' ⊑ t := fun u hu => by
+theorem merge_infoLe (hs : s ⊑ t) (hs' : s' ⊑ t) : s.merge s' ⊑ t := fun u hu => by
   obtain ⟨p, hp, hpu⟩ := hs u hu
   obtain ⟨q, hq, hqu⟩ := hs' u hu
-  exact ⟨p.union q, ⟨p, hp, q, hq, Compat.of_le hpu hqu, rfl⟩,
+  exact ⟨p.union q, ⟨p, hp, q, hq, Possibility.isLUB_union (Compat.of_le hpu hqu)⟩,
     Possibility.union_le hpu hqu⟩
 
 /-- Consistent merge is commutative. -/
-theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s := by
-  ext r
-  constructor <;> rintro ⟨p, hp, q, hq, h, rfl⟩ <;>
-    exact ⟨q, hq, p, hp, h.symm, Possibility.union_comm h⟩
+theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s :=
+  Set.lubs_comm s s'
 
 /-- Consistent merge is associative. -/
 theorem merge_assoc (s t u : State W V M) :
-    (s.merge t).merge u = s.merge (t.merge u) := by
-  ext r
-  constructor
-  · rintro ⟨a, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv, hav, rfl⟩
-    have hpv := Possibility.compat_of_union_left hav
-    have hqv := Possibility.compat_of_union_right hpq hav
-    exact ⟨p, hp, q.union v, ⟨q, hq, v, hv, hqv, rfl⟩,
-      (Possibility.compat_union_left hpq.symm hpv.symm).symm,
-      Possibility.union_assoc⟩
-  · rintro ⟨p, hp, a, ⟨q, hq, v, hv, hqv, rfl⟩, hpa, rfl⟩
-    have hpq := (Possibility.compat_of_union_left hpa.symm).symm
-    have hpv := (Possibility.compat_of_union_right hqv hpa.symm).symm
-    exact ⟨p.union q, ⟨p, hp, q, hq, hpq, rfl⟩, v, hv,
-      Possibility.compat_union_left hpv hqv,
-      (Possibility.union_assoc).symm⟩
+    (s.merge t).merge u = s.merge (t.merge u) :=
+  Set.lubs_assoc (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) s t u
 
 /-- The initial state is a unit for consistent merge: with `merge_comm`,
 `merge_assoc`, and `merge_infoLe`, updating is joining in a commutative
@@ -200,14 +196,13 @@ monoid of information — the content half of
 @[simp] theorem merge_initial (s : State W V M) : s.merge State.initial = s := by
   ext r
   constructor
-  · rintro ⟨p, hp, q, hq, -, rfl⟩
-    have hq' : p.union q = p :=
-      Possibility.ext rfl (funext fun v => by simp [hq v])
-    rwa [hq']
+  · rintro ⟨p, hp, q, ⟨w, rfl⟩, hlub⟩
+    obtain ⟨-, rfl⟩ := Possibility.isLUB_pair_iff.mp hlub
+    rwa [Possibility.union_bot]
   · intro hr
-    exact ⟨r, hr, ⟨r.world, fun _ => ⊥⟩, fun _ => rfl,
-      Possibility.compat_iff.mpr ⟨rfl, fun _ _ _ _ h => absurd h (Part.notMem_none _)⟩,
-      Possibility.ext rfl (funext fun v => by simp)⟩
+    exact ⟨r, hr, Possibility.bot r.world, ⟨r.world, rfl⟩,
+      Possibility.isLUB_pair_iff.mpr
+        ⟨.of_le le_rfl Possibility.bot_le, Possibility.union_bot.symm⟩⟩
 
 @[simp] theorem initial_merge (s : State W V M) : State.merge State.initial s = s := by
   rw [merge_comm, merge_initial]
@@ -235,11 +230,8 @@ def UniformAt (X : Set V) (I : State W V M) : Prop :=
   ∀ p ∈ I, Possibility.domain p = X
 
 /-- The initial state is uniform at the empty base. -/
-theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) :=
-  fun p hp => by
-    ext v
-    simp only [Possibility.mem_domain, hp v, Set.mem_empty_iff_false, iff_false]
-    exact Part.not_none_dom
+theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) := fun _ hp =>
+  Possibility.domain_eq_empty_iff.mpr (mem_initial.mp hp)
 
 /-- Into a uniform stratum, subsistence is membership: a point already
 at the stratum's domain has no room to grow. -/
@@ -265,23 +257,31 @@ theorem infoLe_iff_superset {X : Set V} {s s' : State W V M}
   · intro h q hq
     obtain ⟨p, hp, hpq⟩ := h q hq
     rwa [← Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)]
-  · exact fun h q hq => ⟨q, h hq, le_refl q⟩
+  · exact fun h q hq => ⟨q, h hq, le_rfl⟩
 
 /-- Within one stratum, merge is intersection: compatibility on a shared
 domain forces equality. -/
 theorem merge_eq_inter_of_uniform {X : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt X s') :
     s.merge s' = s ∩ s' := by
-  have hself : ∀ r : Possibility W V (Part M), r.union r = r := fun r =>
-    Possibility.ext rfl (funext fun v => by simp [Possibility.union])
   ext r
+  rw [mem_merge]
   constructor
   · rintro ⟨p, hp, q, hq, hpq, rfl⟩
     obtain rfl := Possibility.eq_of_compat_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)
-    rw [hself p]
+    rw [Possibility.union_self]
     exact ⟨hp, hq⟩
   · rintro ⟨hr, hr'⟩
-    exact ⟨r, hr, r, hr', compat_self r, (hself r).symm⟩
+    exact ⟨r, hr, r, hr', compat_self r, Possibility.union_self.symm⟩
+
+/-- Restriction of a state: pointwise, by direct image. -/
+def restrict (X : Set V) (I : State W V M) : State W V M :=
+  Possibility.restrict X '' I
+
+/-- Membership in a restriction. -/
+theorem mem_restrict {X : Set V} {I : State W V M} {p : Possibility W V (Part M)} :
+    p ∈ I.restrict X ↔ ∃ q ∈ I, q.restrict X = p :=
+  Iff.rfl
 
 section Fibred
 
@@ -289,7 +289,8 @@ section Fibred
 theorem uniformAt_merge {X Y : Set V} {s s' : State W V M}
     (hs : UniformAt X s) (hs' : UniformAt Y s') :
     UniformAt (X ∪ Y) (s.merge s') := by
-  rintro r ⟨p, hp, q, hq, -, rfl⟩
+  intro r hr
+  obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_merge.mp hr
   rw [Possibility.domain_union, hs p hp, hs' q hq]
 
 /-- Subsistence out of a stratum factors through reindexing: the weaker
@@ -297,13 +298,13 @@ state includes into the restricted image of the stronger — the fibred
 order, glued from within-stratum `⊆` along `restrict`. -/
 theorem subsistsIn_iff_subset_restrict {X : Set V}
     {s s' : State W V M} (hs : UniformAt X s) :
-    (s ⪯ s') ↔ s ⊆ Possibility.restrict X '' s' := by
+    (s ⪯ s') ↔ s ⊆ s'.restrict X := by
   constructor
   · intro h p hp
     obtain ⟨q, hq, hpq⟩ := h p hp
     exact ⟨q, hq,
       ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
-  · rintro h p hp
+  · intro h p hp
     obtain ⟨q, hq, rfl⟩ := h hp
     exact ⟨q, hq, Possibility.restrict_le⟩
 
@@ -312,7 +313,7 @@ restricted image of the stronger is included in the weaker — the
 eliminative direction of the fibred order. -/
 theorem infoLe_iff_restrict_subset {X : Set V}
     {s s' : State W V M} (hs : UniformAt X s) :
-    (s ⊑ s') ↔ Possibility.restrict X '' s' ⊆ s := by
+    (s ⊑ s') ↔ s'.restrict X ⊆ s := by
   constructor
   · rintro h r ⟨q, hq, rfl⟩
     obtain ⟨p, hp, hpq⟩ := h q hq
@@ -322,10 +323,6 @@ theorem infoLe_iff_restrict_subset {X : Set V}
       Possibility.restrict_le⟩
 
 end Fibred
-
-/-- Restriction of a state: pointwise, by direct image. -/
-def restrict (X : Set V) (I : State W V M) : State W V M :=
-  Possibility.restrict X '' I
 
 /-- Restriction only forgets: the restricted state subsists in the
 original. -/
@@ -342,9 +339,7 @@ theorem uniformAt_restrict {X Y : Set V} {I : State W V M}
 /-- Restriction composes along intersections. -/
 theorem restrict_restrict (X Y : Set V) (I : State W V M) :
     (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
-  unfold restrict
-  rw [← Set.image_comp]
-  exact congrFun (congrArg _ (funext fun _ => Possibility.restrict_restrict)) I
+  simp only [restrict, Set.image_image, Possibility.restrict_restrict]
 
 variable [DecidableEq V]
 
@@ -363,10 +358,9 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
 /-! ### The uniform classification -/
 
 /-- Uniform states at `X` are sets of world–`X`-assignment pairs — the
-state-level face of `Possibility.domainEquiv`, and the comparison to the
-predecessor's fibers: an order isomorphism for `⊆` (which is `⪯` on the
-stratum, `subsistsIn_iff_subset`), hence an anti-isomorphism for `⊑`
-(`infoLe_iff_superset`). -/
+state-level face of `Possibility.domainEquiv`: an order isomorphism for
+`⊆` (which is `⪯` on the stratum, `subsistsIn_iff_subset`), hence an
+anti-isomorphism for `⊑` (`infoLe_iff_superset`). -/
 def uniformEquiv (X : Set V) :
     {I : State W V M // UniformAt X I} ≃o Set (W × (X → M)) where
   toFun I := {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -353,9 +353,9 @@ is inhabited — the pair glues. -/
 private theorem merge_anti_nonempty {i j k : Fin 3} (hij : i ≠ j)
     (hjk : j ≠ k) (hik : i ≠ k) :
     ((anti i j).merge (anti j k)).Nonempty := by
-  refine ⟨(pt2 i j false true).union (pt2 j k true false),
-    pt2 i j false true, pt2_mem_anti hij false true (by simp),
-    pt2 j k true false, pt2_mem_anti hjk true false (by simp), ?_, rfl⟩
+  refine ⟨(pt2 i j false true).union (pt2 j k true false), State.mem_merge.mpr
+    ⟨pt2 i j false true, pt2_mem_anti hij false true (by simp),
+      pt2 j k true false, pt2_mem_anti hjk true false (by simp), ?_, rfl⟩⟩
   refine Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩
   simp only [pt2] at he he'
   split at he

--- a/Linglib/Studies/Heim1982/Basic.lean
+++ b/Linglib/Studies/Heim1982/Basic.lean
@@ -199,10 +199,10 @@ def startFile : State ExWorld ℕ ExEntity := State.initial
 
 /-- Index 1 is novel in the start file (no drefs yet). -/
 example : ∀ p ∈ startFile, p.assignment 1 = ⊥ :=
-  fun _ hp => hp 1
+  fun _ hp => State.mem_initial.mp hp 1
 
 /-- The start file is consistent (nonempty). -/
-example : startFile.Nonempty := ⟨⟨w₀, λ _ => ⊥⟩, λ _ => rfl⟩
+example : startFile.Nonempty := ⟨Possibility.bot w₀, w₀, rfl⟩
 
 end ConcreteExamples
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -891,10 +891,8 @@ def toIndexedState (V M : Type*) (s : Set W) :
 
 /-- The embedding lands in the empty stratum. -/
 theorem uniformAt_toIndexedState :
-    State.UniformAt ∅ (toIndexedState V M s) := fun p hp => by
-  ext v
-  simp only [Possibility.mem_domain, hp.2 v, Set.mem_empty_iff_false, iff_false]
-  exact Part.not_none_dom
+    State.UniformAt ∅ (toIndexedState V M s) := fun _ hp =>
+  Possibility.domain_eq_empty_iff.mpr hp.2
 
 /-- The embedding is faithful on worldly content. -/
 @[simp] theorem worlds_toIndexedState :


### PR DESCRIPTION
Routes the Dynamic spine's order content through Core, per the State.lean audit.

- `Set.lubs` (Core/Order/PartialUnify): the partial-join lift of point sets, with `mem_lubs`/`lubs_comm`/`lubs_assoc` proved once under pairwise bounded completeness; `State.merge := Set.lubs`, so `merge_comm`/`merge_assoc` are one-line instantiations.
- Part order/compat kit (`dom_mono`, `eq_of_le_of_dom`, `compat_iff`, `le_or_right`); `Possibility` compat lemmas route through one `compat_iff_forall` decomposition, plus `isLUB_pair_iff`, `union_self`, and the per-world `bot` (`initial := Set.range bot`).
- Membership characterizations (`mem_merge`, `mem_initial`, `mem_restrict`) replace downstream defeq-unfolding; `restrict_restrict` via `Set.image_image`; fibred lemmas restated through `State.restrict`.
- Pruned consumer-less API (`mem_assignment_union`, `le_union_right_of_agree`, `domainEquiv_symm_val`, `compat_union_left`/`compat_of_union_left`/`compat_of_union_right`, `compat_or_left`); variables lifted; dead imports dropped.