### PR TITLE
refactor(Semantics/Dynamic): informativeness as the State preorder

### DIFF
--- a/Linglib/Core/Order/PartialUnify.lean
+++ b/Linglib/Core/Order/PartialUnify.lean
@@ -288,6 +288,23 @@ theorem lubs_comm (s t : Set α) : s.lubs t = t.lubs s := by
   constructor <;> rintro ⟨a, ha, b, hb, h⟩ <;>
     exact ⟨b, hb, a, ha, pair_comm a b ▸ h⟩
 
+/-- A set of local units is a right identity for `lubs`: every element
+dominates a member of `t`, and members of `t` sit below anything they
+are compatible with — the set-level face of `⊥` as identity. -/
+theorem lubs_eq_left (h₁ : ∀ a : α, ∃ b ∈ t, b ≤ a)
+    (h₂ : ∀ a : α, ∀ b ∈ t, Compat a b → b ≤ a) : s.lubs t = s := by
+  ext c
+  constructor
+  · rintro ⟨a, ha, b, hb, hub, hleast⟩
+    have hca : c = a := le_antisymm
+      (hleast (PartialUnify.mem_upperBounds_pair.mpr ⟨le_rfl, h₂ a b hb ⟨c, hub⟩⟩))
+      (hub (mem_insert _ _))
+    exact hca ▸ ha
+  · intro hc
+    obtain ⟨b, hb, hbc⟩ := h₁ c
+    exact ⟨c, hc, b, hb, PartialUnify.mem_upperBounds_pair.mpr ⟨le_rfl, hbc⟩,
+      fun _ hu => hu (mem_insert _ _)⟩
+
 /-- Under pairwise bounded completeness, upper closure sends `lubs` to
 the join: a point bounds a pairwise join iff it bounds a point of each
 set. -/

--- a/Linglib/Core/Order/PartialUnify.lean
+++ b/Linglib/Core/Order/PartialUnify.lean
@@ -1,5 +1,7 @@
 import Mathlib.Order.Bounds.Image
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Order.UpperLower.Closure
+import Mathlib.Order.UpperLower.CompleteLattice
 
 /-!
 # Partial unification: computable pairwise least upper bounds
@@ -285,6 +287,23 @@ theorem lubs_comm (s t : Set α) : s.lubs t = t.lubs s := by
   ext c
   constructor <;> rintro ⟨a, ha, b, hb, h⟩ <;>
     exact ⟨b, hb, a, ha, pair_comm a b ▸ h⟩
+
+/-- Under pairwise bounded completeness, upper closure sends `lubs` to
+the join: a point bounds a pairwise join iff it bounds a point of each
+set. -/
+theorem upperClosure_lubs
+    (H : ∀ a b : α, Compat a b → ∃ c, IsLUB ({a, b} : Set α) c) (s t : Set α) :
+    upperClosure (s.lubs t) = upperClosure s ⊔ upperClosure t := by
+  ext x
+  simp only [SetLike.mem_coe, UpperSet.mem_sup_iff, mem_upperClosure, mem_lubs]
+  constructor
+  · rintro ⟨c, ⟨a, ha, b, hb, hab⟩, hcx⟩
+    obtain ⟨hac, hbc⟩ := PartialUnify.mem_upperBounds_pair.mp hab.1
+    exact ⟨⟨a, ha, hac.trans hcx⟩, b, hb, hbc.trans hcx⟩
+  · rintro ⟨⟨a, ha, hax⟩, b, hb, hbx⟩
+    obtain ⟨c, hc⟩ := H a b ⟨x, PartialUnify.mem_upperBounds_pair.mpr ⟨hax, hbx⟩⟩
+    exact ⟨c, ⟨a, ha, b, hb, hc⟩,
+      hc.2 (PartialUnify.mem_upperBounds_pair.mpr ⟨hax, hbx⟩)⟩
 
 private theorem mem_lubs_left_iff
     (H : ∀ a b : α, Compat a b → ∃ c, IsLUB ({a, b} : Set α) c) :

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -242,13 +242,13 @@ theorem DRS.transition_copy (W : Type*) {X X' : Finset V} (K : DRS L V)
 /-- The information state a proper DRS expresses
 ([kamp-vangenabith-reyle-2011], Def. 22): act on the initial state. -/
 def DRS.state (W : Type*) (K : DRS L V) (hK : K.IsProper) : State W V M :=
-  (K.transition W ∅ (Finset.subset_empty.mpr hK)).applyState State.initial
+  (K.transition W ∅ (Finset.subset_empty.mpr hK)).applyState ⊥
 
 /-- The state a DRS expresses lives in its referents' stratum. -/
 theorem DRS.uniformAt_state (W : Type*) (K : DRS L V) (hK : K.IsProper) :
     State.UniformAt ↑K.referents (K.state (M := M) W hK) := by
   have h := Transition.uniformAt_applyState
-    (K.transition (M := M) W ∅ (Finset.subset_empty.mpr hK)) State.initial
+    (K.transition (M := M) W ∅ (Finset.subset_empty.mpr hK)) ⊥
   simpa [DRS.state] using h
 
 /-- The characteristic membership form: a point survives in `⟦K⟧ˢ` iff it

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -22,7 +22,7 @@ cards (rule (13), `atomVar_eq_of_familiar`) and extends where it does
 not (`atomVar_eq_of_novel`) — per point, so atoms are total and
 appropriateness ((15)) lives on `indef`/`def_`, as in the paper.
 Principle (A) in its general form is ascent in informativeness
-(`infoLe_ofState`); set-shrinking eliminativity is its familiar face.
+(`le_ofState`); set-shrinking eliminativity is its familiar face.
 
 Negation keeps the points of `F` that do not *subsist* (`≺`) in the
 scope's update — the no-verifying-extension clause, generalizing
@@ -47,7 +47,7 @@ the referent-free shadow of the 1982 ones.
 
 - `admits_def_`, `admits_indef`: the Familiarity and Novelty Conditions
   are exactly definedness.
-- `infoLe_ofState`: Principle (A) — updates only add information.
+- `le_ofState`: Principle (A) — updates only add information.
 - `atomW_eq`, `atomVar_eq_of_familiar`, `atomVar_eq_of_novel`: the
   filtering and extending regimes of the merge-based atom (rules (13)
   and (18)).
@@ -82,13 +82,13 @@ def ofState (A : State W V M) : FCP W V M :=
   fun F => Part.some (State.merge F A)
 
 /-- Principle (A), general form: assertive update ascends in
-informativeness — `merge_infoLe`'s left leg. Set-shrinking
-eliminativity is its familiar-regime shadow (`atomVar_eq_of_familiar`);
-on novel referents the update extends rather than shrinks. -/
-theorem infoLe_ofState (A : State W V M) {F F' : State W V M}
-    (h : F' ∈ ofState A F) : F ⊑ F' := by
+informativeness — `State.le_merge_left`. Set-shrinking eliminativity is
+its familiar-regime shadow (`atomVar_eq_of_familiar`); on novel
+referents the update extends rather than shrinks. -/
+theorem le_ofState (A : State W V M) {F F' : State W V M}
+    (h : F' ∈ ofState A F) : F ≤ F' := by
   obtain rfl := Part.mem_some_iff.mp h
-  exact infoLe_merge_left
+  exact State.le_merge_left
 
 /-- Atomic predicate on the world: merge with the empty-domain
 proposition state. -/
@@ -173,7 +173,8 @@ same as once. -/
 theorem supports_idempotent {F : State W V M} {φ : FCP W V M}
     (h : supports F φ) : φ.seq φ F = φ F := by
   show (φ F).bind φ = φ F
-  rw [h, Part.bind_some, h]
+  rw [h]
+  exact (Part.bind_some _ _).trans h
 
 /-! ### Admittance -/
 
@@ -197,7 +198,7 @@ theorem admits_def_ (x : V) (body : FCP W V M) (F : State W V M) :
 The merge-based atom has rule (13) as its familiar face and rule (18)'s
 domain extension as its novel face, per point; `⊆`-eliminativity holds
 exactly on the familiar face, while Principle (A) in general is
-`infoLe_ofState`. -/
+`le_ofState`. -/
 
 /-- World atoms filter, unconditionally: merging with an empty-domain
 proposition state eliminates the points at incompatible worlds. -/
@@ -316,9 +317,9 @@ theorem neg_eq_partial_neg [DecidableEq V] {X : Finset V}
     (hφ : ∀ F' ∈ φ F, State.UniformAt X F') :
     neg φ F = CCP.Partial.neg φ F := by
   refine Part.ext' Iff.rfl fun h₁ h₂ => ?_
-  show {p ∈ F | ¬ p ≺ (φ F).get h₁} = F \ (φ F).get h₁
+  show ({p ∈ (F : Set (Possibility W V (Part M))) | ¬ p ≺ (φ F).get h₁} : Set _) =
+    (F : Set (Possibility W V (Part M))) \ (φ F).get h₁
   ext p
-  simp only [Set.mem_sep_iff, Set.mem_sdiff]
   exact and_congr_right fun hp => not_congr
     (State.subsists_iff_mem (hφ _ (Part.get_mem _)) (hF p hp))
 

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -80,7 +80,7 @@ with every compatible point of
 defines more. Total: appropriateness ((15), the Novelty/Familiarity
 Condition) lives on `indef`/`def_`, as in the paper. -/
 def ofState (A : State W V M) : FCP W V M :=
-  fun F => Part.some (F.toState * A)
+  fun F => Part.some (Set.lubs F A)
 
 /-- Principle (A), general form: assertive update ascends in
 informativeness — `State.left_le_mul`. Set-shrinking eliminativity is

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -15,7 +15,7 @@ Presupposition is `Part`-definedness (`CCP.Partial.admits`, Heim's
 definedness conditions; sequencing and its monoid laws are `PFun.comp`'s
 (`PFun.comp_assoc`, `PFun.id_comp`, `PFun.comp_id`).
 
-The assertive update is *consistent merge* (`State.merge`,
+The assertive update is *consistent merge* (the `State` monoid's `*`,
 [kamp-vangenabith-reyle-2011] Def. 26): [heim-1983]'s revised atomic
 rule (18), which filters where the input already defines the atom's
 cards (rule (13), `atomVar_eq_of_familiar`) and extends where it does
@@ -74,21 +74,22 @@ def refersTo (F : State W V M) (x : V) (m : M) : Prop :=
 
 /-- Assertive update by a state: consistent merge ([heim-1983]'s revised
 atomic rule (18), which is [kamp-vangenabith-reyle-2011] Def. 26's
-`State.merge`) — each input point pairs with every compatible point of
+consistent merge, the `State` monoid's `*`) — each input point pairs
+with every compatible point of
 `A`, filtering where their domains overlap and extending where `A`
 defines more. Total: appropriateness ((15), the Novelty/Familiarity
 Condition) lives on `indef`/`def_`, as in the paper. -/
 def ofState (A : State W V M) : FCP W V M :=
-  fun F => Part.some (State.merge F A)
+  fun F => Part.some (F.toState * A)
 
 /-- Principle (A), general form: assertive update ascends in
-informativeness — `State.le_merge_left`. Set-shrinking eliminativity is
+informativeness — `State.left_le_mul`. Set-shrinking eliminativity is
 its familiar-regime shadow (`atomVar_eq_of_familiar`); on novel
 referents the update extends rather than shrinks. -/
 theorem le_ofState (A : State W V M) {F F' : State W V M}
     (h : F' ∈ ofState A F) : F ≤ F' := by
   obtain rfl := Part.mem_some_iff.mp h
-  exact State.le_merge_left
+  exact State.left_le_mul
 
 /-- Atomic predicate on the world: merge with the empty-domain
 proposition state. -/
@@ -206,14 +207,14 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
     atomW pred F = Part.some {p ∈ F | pred p.world} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
   · intro hr
-    obtain ⟨p, hp, q, ⟨hqdom, hqpred⟩, hpq, rfl⟩ := State.mem_merge.mp hr
+    obtain ⟨p, hp, q, ⟨hqdom, hqpred⟩, hpq, rfl⟩ := State.mem_mul.mp hr
     have hqle : q ≤ p := ⟨(Possibility.compat_iff.mp hpq).1.symm, fun v e he =>
       absurd (Part.dom_iff_mem.mpr ⟨e, he⟩)
         (Set.eq_empty_iff_forall_notMem.mp hqdom v)⟩
     rw [le_antisymm (Possibility.union_le le_rfl hqle) Possibility.le_union_left]
     exact ⟨hp, (Possibility.compat_iff.mp hpq).1.symm ▸ hqpred⟩
   · rintro ⟨hr, hpred⟩
-    exact State.mem_merge.mpr ⟨r, hr, Possibility.bot r.world,
+    exact State.mem_mul.mpr ⟨r, hr, Possibility.bot r.world,
       ⟨Possibility.domain_bot, hpred⟩, .of_le le_rfl Possibility.bot_le,
       Possibility.union_bot.symm⟩
 
@@ -225,7 +226,7 @@ theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
       Part.some {p ∈ F | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
   · intro hmem
-    obtain ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩ := State.mem_merge.mp hmem
+    obtain ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩ := State.mem_mul.mp hmem
     obtain ⟨hw, hag⟩ := Possibility.compat_iff.mp hpq
     obtain ⟨m₀, hpx⟩ := Part.dom_iff_mem.mp (hfam p hp)
     have hqle : q ≤ p := ⟨hw.symm, fun v e he => by
@@ -237,7 +238,7 @@ theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
   · rintro ⟨hr, m, hrx, hpred⟩
     have hqle : (⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩ : Possibility W V (Part M)) ≤ r :=
       ⟨rfl, fun v e he => by obtain ⟨rfl, rfl⟩ := he; exact hrx⟩
-    refine State.mem_merge.mpr ⟨r, hr, ⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩,
+    refine State.mem_mul.mpr ⟨r, hr, ⟨r.world, fun v => ⟨v = x, fun _ => m⟩⟩,
       ⟨Set.ext fun v => Iff.rfl, m, ⟨rfl, rfl⟩, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · obtain ⟨rfl, rfl⟩ := he'
@@ -255,7 +256,7 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
       {p ∈ State.randomAssign F x | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
   · intro hmem
-    obtain ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩ := State.mem_merge.mp hmem
+    obtain ⟨p, hp, q, ⟨hqdom, m, hqx, hpred⟩, hpq, rfl⟩ := State.mem_mul.mp hmem
     have huq : p.union q = p.update x (Part.some m) :=
       Possibility.ext rfl (funext fun v => by
         by_cases hv : v = x
@@ -270,7 +271,7 @@ theorem atomVar_eq_of_novel [DecidableEq V] (pred : M → Prop) (x : V)
     obtain ⟨p, hp, m', rfl⟩ := hmem
     obtain rfl : m = m' := by
       simpa [Possibility.update] using hrx
-    refine State.mem_merge.mpr ⟨p, hp, ⟨p.world, fun v => ⟨v = x, fun _ => m⟩⟩,
+    refine State.mem_mul.mpr ⟨p, hp, ⟨p.world, fun v => ⟨v = x, fun _ => m⟩⟩,
       ⟨Set.ext fun v => Iff.rfl, m, ⟨rfl, rfl⟩, hpred⟩,
       Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩, ?_⟩
     · obtain ⟨rfl, rfl⟩ := he'

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -134,7 +134,7 @@ def indef [DecidableEq V] (x : V) (body : FCP W V M) : FCP W V M :=
 Condition); the card is already established, so the file passes through
 to the body. -/
 def def_ (x : V) (body : FCP W V M) : FCP W V M :=
-  fun F => Part.assert (Familiar F x) fun _ => body F
+  fun F => Part.assert (State.Familiar F x) fun _ => body F
 
 /-! ### Truth and entailment (Ch. III §3) -/
 
@@ -191,7 +191,7 @@ theorem admits_indef [DecidableEq V] (x : V) (body : FCP W V M)
 /-- **The Familiarity Condition is definedness** ((15)): a definite is
 defined iff its card is familiar (and the body is defined). -/
 theorem admits_def_ (x : V) (body : FCP W V M) (F : State W V M) :
-    (def_ x body).admits F ↔ ∃ _ : Familiar F x, (body F).Dom := by
+    (def_ x body).admits F ↔ ∃ _ : State.Familiar F x, (body F).Dom := by
   exact Iff.rfl
 
 /-! ### The two regimes: filtering and extension
@@ -221,7 +221,7 @@ theorem atomW_eq (pred : W → Prop) (F : State W V M) :
 /-- Rule (13), the familiar regime: at a familiar card the atom
 filters — and in particular is eliminative. -/
 theorem atomVar_eq_of_familiar (pred : M → Prop) (x : V)
-    {F : State W V M} (hfam : Familiar F x) :
+    {F : State W V M} (hfam : State.Familiar F x) :
     atomVar pred x F =
       Part.some {p ∈ F | ∃ m ∈ p.assignment x, pred m} := by
   refine congrArg Part.some (Set.ext fun r => ⟨?_, ?_⟩)
@@ -296,7 +296,7 @@ theorem atomW_eliminative (pred : W → Prop) {F F' : State W V M}
 /-- Variable atoms are eliminative at familiar cards. -/
 theorem atomVar_eliminative (pred : M → Prop) (x : V)
     {F F' : State W V M}
-    (hfam : Familiar F x) (h : F' ∈ atomVar pred x F) : F' ⊆ F := by
+    (hfam : State.Familiar F x) (h : F' ∈ atomVar pred x F) : F' ⊆ F := by
   rw [atomVar_eq_of_familiar pred x hfam] at h
   obtain rfl := Part.mem_some_iff.mp h
   exact fun p hp => hp.1
@@ -322,7 +322,7 @@ theorem neg_eq_partial_neg [DecidableEq V] {X : Finset V}
     (F : Set (Possibility W V (Part M))) \ (φ F).get h₁
   ext p
   exact and_congr_right fun hp => not_congr
-    (State.mem_lowerClosure_iff (hφ _ (Part.get_mem _)) (hF p hp))
+    ((hφ _ (Part.get_mem _)).mem_lowerClosure (hF p hp))
 
 end FCP
 

--- a/Linglib/Semantics/Dynamic/FileChange.lean
+++ b/Linglib/Semantics/Dynamic/FileChange.lean
@@ -24,7 +24,7 @@ appropriateness ((15)) lives on `indef`/`def_`, as in the paper.
 Principle (A) in its general form is ascent in informativeness
 (`le_ofState`); set-shrinking eliminativity is its familiar face.
 
-Negation keeps the points of `F` that do not *subsist* (`≺`) in the
+Negation keeps the points of `F` that do not *subsist* in the
 scope's update — the no-verifying-extension clause, generalizing
 [heim-1983]'s world-only `s \ s[φ]` (`CCP.Partial.neg`): on a uniform
 stratum the two coincide (`neg_eq_partial_neg`), so the 1983 clauses are
@@ -112,7 +112,7 @@ update — the no-verifying-extension clause, as non-subsistence.
 Referents introduced inside the scope are trapped. Undefined when the
 scope is. -/
 def neg (φ : FCP W V M) : FCP W V M :=
-  fun F => (φ F).map fun F' => {p ∈ F | ¬ p ≺ F'}
+  fun F => (φ F).map fun F' => {p ∈ F | p ∉ lowerClosure F'}
 
 /-- Conditional: `F + [if φ then ψ] = F + [¬(φ ∧ ¬ψ)]` — Heim's analysis
 of conditionals as negated conjunctions. -/
@@ -317,11 +317,11 @@ theorem neg_eq_partial_neg [DecidableEq V] {X : Finset V}
     (hφ : ∀ F' ∈ φ F, State.UniformAt X F') :
     neg φ F = CCP.Partial.neg φ F := by
   refine Part.ext' Iff.rfl fun h₁ h₂ => ?_
-  show ({p ∈ (F : Set (Possibility W V (Part M))) | ¬ p ≺ (φ F).get h₁} : Set _) =
+  show ({p ∈ (F : Set (Possibility W V (Part M))) | p ∉ lowerClosure ((φ F).get h₁)} : Set _) =
     (F : Set (Possibility W V (Part M))) \ (φ F).get h₁
   ext p
   exact and_congr_right fun hp => not_congr
-    (State.subsists_iff_mem (hφ _ (Part.get_mem _)) (hF p hp))
+    (State.mem_lowerClosure_iff (hφ _ (Part.get_mem _)) (hF p hp))
 
 end FCP
 

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -215,6 +215,10 @@ theorem le_iff_eq_restrict (hp : p.domain = X) :
     fun hd hd' => ?_
   exact Part.mem_unique (h.2 v _ (Part.get_mem hd)) (Part.get_mem hd'.2)
 
+/-- A point at its own domain is fixed by restriction. -/
+theorem restrict_eq_self (hp : p.domain = X) : p.restrict X = p :=
+  ((le_iff_eq_restrict hp).mp le_rfl).symm
+
 /-- Consecutive restrictions restrict to the intersection. -/
 theorem restrict_restrict : (p.restrict Y).restrict X = p.restrict (X ∩ Y) :=
   Possibility.ext rfl <| funext fun v =>

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -170,6 +170,14 @@ def bot (w : W) : Possibility W V (Part M) :=
 theorem bot_le : bot p.world ≤ p :=
   ⟨rfl, fun _ => _root_.bot_le⟩
 
+/-- An empty point compatible with `p` shares its world, hence sits
+below it. -/
+theorem bot_le_of_compat {w : W} (h : Compat p (bot w)) : bot w ≤ p := by
+  obtain ⟨u, hu⟩ := h
+  obtain ⟨hpu, hbu⟩ := PartialUnify.mem_upperBounds_pair.mp hu
+  rw [show w = p.world from hbu.1.trans hpu.1.symm]
+  exact bot_le
+
 @[simp] theorem union_bot {w : W} : p.union (bot w) = p :=
   Possibility.ext rfl <| funext fun _ => Part.or_bot
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Dynamic.Possibility
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
+import Mathlib.Order.Antisymmetrization
 import Mathlib.Order.UpperLower.CompleteLattice
 import Mathlib.Order.Hom.Basic
 
@@ -47,6 +48,8 @@ are partial orders, coinciding with `⊇` and `⊆`.
 - `State.le_iff_superset`, `State.lowerClosure_le_iff`,
   `State.mul_eq_inter_of_uniform`: on a uniform stratum the orders
   are `⊇`/`⊆` and merge is intersection.
+- `State.antisymmetrizationOrderIso`: up to informational equivalence,
+  states are the complete lattice of upper sets of possibilities.
 - `State.uniformEquiv`: uniform states at `X` are `Set (W × (X → M))`.
 
 ## Implementation notes
@@ -273,6 +276,35 @@ theorem isGLB_union : IsGLB {s, s'} (s ∪ s') :=
   ⟨by rintro x (rfl | rfl); exacts [union_le_left, union_le_right],
    fun _ hu => le_union (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
 
+/-! ### States up to informational equivalence -/
+
+/-- Up to informational equivalence, states are exactly the upper sets
+of possibilities: `upperClosure` descends to an order isomorphism on
+the antisymmetrization — the Smyth kernel is full. `UpperSet`'s
+complete lattice is the algebra of states up to equivalence; there,
+Def. 0.26's unrestricted (arbitrary-family) merge is `sSup`. -/
+def antisymmetrizationOrderIso :
+    Antisymmetrization (State W V M) (· ≤ ·) ≃o
+      UpperSet (Possibility W V (Part M)) where
+  toFun := Quotient.lift
+    (fun s : State W V M => upperClosure (s : Set (Possibility W V (Part M))))
+    fun _ _ h => le_antisymm (α := UpperSet _) h.1 h.2
+  invFun U := toAntisymmetrization (· ≤ ·)
+    (↑U : Set (Possibility W V (Part M))).toState
+  left_inv := by
+    refine Quotient.ind fun s => Quotient.sound ?_
+    have key : upperClosure
+          ((upperClosure (s : Set (Possibility W V (Part M))) : UpperSet _) :
+            Set (Possibility W V (Part M))) =
+        upperClosure (s : Set (Possibility W V (Part M))) :=
+      SetLike.coe_injective (upperClosure _).upper'.upperClosure
+    exact ⟨le_of_eq (α := UpperSet _) key, le_of_eq (α := UpperSet _) key.symm⟩
+  right_inv U := SetLike.coe_injective U.upper'.upperClosure
+  map_rel_iff' {a b} := by
+    induction a using Quotient.ind
+    induction b using Quotient.ind
+    exact Iff.rfl
+
 end State
 
 /-! ### Familiarity
@@ -424,14 +456,14 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
 /-! ### The uniform classification -/
 
 /-- Uniform states at `X` are sets of world–`X`-assignment pairs — the
-state-level face of `Possibility.domainEquiv`. Informativeness on the
-stratum is reverse inclusion (`le_iff_superset`), so the isomorphism
-lands in the dual order. -/
+state-level face of `Possibility.domainEquiv`. The stratum's order
+faces are `le_iff_superset` and `lowerClosure_le_iff`: informativeness
+is reverse inclusion, subsistence inclusion. -/
 def uniformEquiv (X : Set V) :
-    {I : State W V M // UniformAt X I} ≃o (Set (W × (X → M)))ᵒᵈ where
-  toFun I := OrderDual.toDual {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
+    {I : State W V M // UniformAt X I} ≃ Set (W × (X → M)) where
+  toFun I := {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
   invFun S :=
-    ⟨{p | ∃ h : p.domain = X, Possibility.domainEquiv X ⟨p, h⟩ ∈ OrderDual.ofDual S},
+    ⟨{p | ∃ h : p.domain = X, Possibility.domainEquiv X ⟨p, h⟩ ∈ S},
       fun _ ⟨h, _⟩ => h⟩
   left_inv I := by
     refine Subtype.ext (State.ext fun p => ?_)
@@ -440,21 +472,12 @@ def uniformEquiv (X : Set V) :
       simpa using hmem
     · intro hp
       exact ⟨I.2 p hp, by simpa using hp⟩
-  right_inv S := OrderDual.ofDual.injective <| Set.ext fun e => by
+  right_inv S := Set.ext fun e => by
     constructor
     · rintro ⟨h, hmem⟩
       simpa using hmem
     · intro he
       exact ⟨((Possibility.domainEquiv X).symm e).2, by simpa using he⟩
-  map_rel_iff' {I J} := by
-    rw [← Subtype.coe_le_coe, le_iff_superset I.2 J.2]
-    show ({e | ((Possibility.domainEquiv X).symm e).1 ∈ J.1} : Set (W × (X → M))) ⊆
-        {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1} ↔ _
-    constructor
-    · intro h p hp
-      simpa using h (show Possibility.domainEquiv X ⟨p, J.2 p hp⟩ ∈
-        {e | ((Possibility.domainEquiv X).symm e).1 ∈ J.1} by simpa using hp)
-    · exact fun h _ he => h he
 
 end State
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -9,17 +9,14 @@ import Mathlib.Order.Hom.Basic
 # Information states
 
 This file defines an *information state* — a set of possibilities with
-partial assignments ([kamp-vangenabith-reyle-2011], Def. 0.23) — and
-its order and algebra: informativeness (Def. 0.25) as the preorder
-lifted along `upperClosure`, with initial state `⊥` and absurd state
-`⊤ = ∅`; consistent merge (Def. 0.26) as the monoid `*` and least
-upper bound, dually union as greatest lower bound
-([visser-vermeulen-1996]'s monoidal processing); subsistence
-([elliott-sudo-2025], Def. 3.3) as the dual `lowerClosure` kernel; the
-uniform strata, where both kernels collapse to inclusion; and the
-classifications of a stratum as world–assignment pairs
-(`State.uniformEquiv`) and of states up to informational equivalence
-as the complete lattice of upper sets
+partial assignments — and its order and algebra: informativeness as
+the preorder lifted along `upperClosure`, with initial state `⊥` and
+absurd state `⊤ = ∅`; consistent merge as the monoid `*` and least
+upper bound, dually union as greatest lower bound; subsistence as the
+dual `lowerClosure` kernel; the uniform strata, where both kernels
+collapse to inclusion; and the classifications of a stratum as
+world–assignment pairs (`State.uniformEquiv`) and of states up to
+informational equivalence as the complete lattice of upper sets
 (`State.antisymmetrizationOrderIso`).
 
 `State` is a type synonym in the `OrderDual` mold: `≤` is
@@ -28,9 +25,11 @@ kernel is antisymmetric, `State` is a `Preorder` only.
 
 ## References
 
-- [kamp-vangenabith-reyle-2011], Defs. 0.23–0.26
-- [elliott-sudo-2025], [groenendijk-stokhof-veltman-1996],
-  [heim-1982]
+- [kamp-vangenabith-reyle-2011], Defs. 0.23 (information states),
+  0.25 (informativeness), 0.26 (consistent merge)
+- [elliott-sudo-2025], Def. 3.3 (subsistence);
+  [groenendijk-stokhof-veltman-1996]
+- [visser-vermeulen-1996] (monoidal processing); [heim-1982]
 -/
 
 namespace DynamicSemantics

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -84,8 +84,6 @@ variable {s s' t : State W V M} {r : Possibility W V (Part M)}
 @[reducible] instance : Membership (Possibility W V (Part M)) (State W V M) :=
   inferInstanceAs (Membership _ (Set _))
 
-/-- Point-set inclusion, coinciding with the order only stratum-wise
-(`le_iff_superset`). -/
 instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p ∈ s'⟩
 
 @[reducible] instance : EmptyCollection (State W V M) :=
@@ -97,11 +95,7 @@ instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p 
 
 @[reducible] instance : SDiff (State W V M) := inferInstanceAs (SDiff (Set _))
 
-/-- Interpret a point set as an information state, in the
-`OrderDual.toDual` mold. -/
-def _root_.Set.toState (s : Set (Possibility W V (Part M))) : State W V M := s
-
-@[ext] theorem ext {s s' : State W V M} (h : ∀ p, p ∈ s ↔ p ∈ s') : s = s' :=
+@[ext] theorem ext (h : ∀ p, p ∈ s ↔ p ∈ s') : s = s' :=
   Set.ext h
 
 /-- `s ≤ s'` iff `s'` carries at least as much information as `s`. -/
@@ -118,10 +112,9 @@ instance : OrderBot (State W V M) where
   bot_le _ := le_def.mpr fun q _ => ⟨.bot q.world, ⟨q.world, rfl⟩, Possibility.bot_le⟩
 
 /-- Membership in the initial state: no referent defined. -/
-theorem mem_bot {p : Possibility W V (Part M)} :
-    p ∈ (⊥ : State W V M) ↔ ∀ v, p.assignment v = ⊥ :=
+theorem mem_bot : r ∈ (⊥ : State W V M) ↔ ∀ v, r.assignment v = ⊥ :=
   ⟨fun ⟨_, hw⟩ _ => hw ▸ rfl, fun h =>
-    ⟨p.world, Possibility.ext rfl (funext fun v => (h v).symm)⟩⟩
+    ⟨r.world, Possibility.ext rfl (funext fun v => (h v).symm)⟩⟩
 
 /-- The absurd state `⊤ = ∅` is maximally informative. -/
 instance : OrderTop (State W V M) where
@@ -251,7 +244,7 @@ def antisymmetrizationOrderIso :
     (fun s : State W V M => upperClosure (s : Set (Possibility W V (Part M))))
     fun _ _ h => le_antisymm (α := UpperSet _) h.1 h.2
   invFun U := toAntisymmetrization (· ≤ ·)
-    (↑U : Set (Possibility W V (Part M))).toState
+    (↑U : Set (Possibility W V (Part M)))
   left_inv := by
     refine Quotient.ind fun s => Quotient.sound ?_
     have key : upperClosure

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -74,18 +74,17 @@ variable {W V M : Type*}
 
 /-! ### Information states -/
 
-/-- An information state: a set of world–assignment pairs, the
-assignments partial ([kamp-vangenabith-reyle-2011], Def. 0.23), ordered
-by informativeness rather than inclusion. -/
+/-- An information state is a set of world–assignment pairs. -/
 def State (W V M : Type*) := Set (Possibility W V (Part M))
 
 namespace State
 
+variable {s s' t : State W V M} {r : Possibility W V (Part M)}
+
 @[reducible] instance : Membership (Possibility W V (Part M)) (State W V M) :=
   inferInstanceAs (Membership _ (Set _))
 
-/-- Point-set inclusion between states. Deliberately `HasSubset`, not the
-order: `≤` is informativeness, and the two coincide only stratum-wise
+/-- Point-set inclusion, coinciding with the order only stratum-wise
 (`le_iff_superset`). -/
 instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p ∈ s'⟩
 
@@ -98,28 +97,22 @@ instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p 
 
 @[reducible] instance : SDiff (State W V M) := inferInstanceAs (SDiff (Set _))
 
-/-- Interpret a point set as an information state — the type-synonym
-retyping (`OrderDual.toDual`'s analogue), for positions whose binder is
-`Set`-typed. -/
+/-- Interpret a point set as an information state, in the
+`OrderDual.toDual` mold. -/
 def _root_.Set.toState (s : Set (Possibility W V (Part M))) : State W V M := s
 
 @[ext] theorem ext {s s' : State W V M} (h : ∀ p, p ∈ s ↔ p ∈ s') : s = s' :=
   Set.ext h
 
-/-- Informativeness ([kamp-vangenabith-reyle-2011], Def. 0.25): `s ≤ s'`
-iff `s'` carries at least as much information as `s` — the preorder
-lifted along the upper closure of the point set. -/
+/-- `s ≤ s'` iff `s'` carries at least as much information as `s`. -/
 instance : Preorder (State W V M) :=
   .lift fun s => upperClosure (s : Set (Possibility W V (Part M)))
 
-/-- Def. 0.25 in projection form: every point of the stronger state lies
-above a point of the weaker. -/
-theorem le_def {s s' : State W V M} : s ≤ s' ↔ ∀ q ∈ s', ∃ p ∈ s, p ≤ q :=
+/-- Every point of the stronger state lies above a point of the weaker. -/
+theorem le_def : s ≤ s' ↔ ∀ q ∈ s', ∃ p ∈ s, p ≤ q :=
   le_upperClosure
 
-/-- The initial information state `⊥ = W × {g_⊤}` (Def. 0.23's Λ):
-every world live, no referent defined — the range of the empty points,
-the bottom of the informativeness order. -/
+/-- The initial information state `⊥ = W × {g_⊤}`. -/
 instance : OrderBot (State W V M) where
   bot := Set.range Possibility.bot
   bot_le _ := le_def.mpr fun q _ => ⟨.bot q.world, ⟨q.world, rfl⟩, Possibility.bot_le⟩
@@ -130,14 +123,12 @@ theorem mem_bot {p : Possibility W V (Part M)} :
   ⟨fun ⟨_, hw⟩ _ => hw ▸ rfl, fun h =>
     ⟨p.world, Possibility.ext rfl (funext fun v => (h v).symm)⟩⟩
 
-/-- The absurd state is maximally informative: no live point. -/
+/-- The absurd state `⊤ = ∅` is maximally informative. -/
 instance : OrderTop (State W V M) where
   top := ∅
   le_top _ := le_def.mpr fun _ hq => hq.elim
 
 @[simp] theorem top_eq_empty : (⊤ : State W V M) = ∅ := rfl
-
-end State
 
 /-! ### Subsistence
 
@@ -151,10 +142,6 @@ bottom. -/
 
 /-! ### Consistent merge as multiplication -/
 
-namespace State
-
-variable {s s' t : State W V M} {r : Possibility W V (Part M)}
-
 private theorem lubs_bot (s : State W V M) :
     (Set.lubs s (⊥ : State W V M) : State W V M) = s := by
   ext r
@@ -167,12 +154,8 @@ private theorem lubs_bot (s : State W V M) :
       Possibility.isLUB_pair_iff.mpr
         ⟨.of_le le_rfl Possibility.bot_le, Possibility.union_bot.symm⟩⟩
 
-/-- States form a commutative monoid: `*` is consistent merge
-([kamp-vangenabith-reyle-2011] Def. 0.26, binary) — the joins of pairs
-of points, one from each state (`Set.lubs`) — and `1` is the initial
-state `⊥`. Updating is joining in a commutative monoid of information
-([visser-vermeulen-1996]'s monoidal processing); `Multiset.prod` is
-Def. 0.26's finite n-ary merge. -/
+/-- `s * s'` is consistent merge — the joins of pairs of points, one
+from each state — and `1 = ⊥`. -/
 instance : CommMonoid (State W V M) where
   mul s s' := Set.lubs s s'
   mul_assoc := Set.lubs_assoc fun _ _ h => ⟨_, Possibility.isLUB_union h⟩
@@ -205,19 +188,16 @@ theorem left_le_mul : s ≤ s * s' :=
 theorem right_le_mul : s' ≤ s * s' :=
   le_sup_right.trans_eq upperClosure_mul.symm
 
-/-- Def. 0.26's universal property: anything above both factors is
-above their merge. -/
+/-- Anything above both factors is above their merge. -/
 theorem mul_le (h : s ≤ t) (h' : s' ≤ t) : s * s' ≤ t :=
   upperClosure_mul.trans_le (sup_le h h')
 
-/-- **The merge is the least upper bound** of its factors in the
-informativeness preorder. -/
+/-- The merge is the least upper bound of its factors. -/
 theorem isLUB_mul : IsLUB {s, s'} (s * s') :=
   ⟨by rintro x (rfl | rfl); exacts [left_le_mul, right_le_mul],
    fun _ hu => mul_le (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
 
-/-- Merge is monotone: the ordered-monoid law, [kamp-vangenabith-reyle-2011]
-Def. 0.27's ascent composes across updates. -/
+/-- Merge is monotone in the informativeness order. -/
 instance : CovariantClass (State W V M) (State W V M) (· * ·) (· ≤ ·) :=
   ⟨fun _ _ _ h => mul_le left_le_mul (h.trans right_le_mul)⟩
 
@@ -251,19 +231,19 @@ theorem union_le_right : s ∪ s' ≤ s' :=
 theorem le_union (h : t ≤ s) (h' : t ≤ s') : t ≤ s ∪ s' :=
   (le_inf h h').trans_eq upperClosure_union.symm
 
-/-- **The union is the greatest lower bound** of its components in the
-informativeness preorder — the meet dual to `isLUB_mul`. -/
+/-- The union is the greatest lower bound of its components. -/
 theorem isGLB_union : IsGLB {s, s'} (s ∪ s') :=
   ⟨by rintro x (rfl | rfl); exacts [union_le_left, union_le_right],
    fun _ hu => le_union (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
 
-/-! ### States up to informational equivalence -/
+/-! ### States up to informational equivalence
+
+The Smyth kernel is full: `UpperSet`'s complete lattice is the algebra
+of states up to equivalence, and Def. 0.26's unrestricted
+(arbitrary-family) merge is `sSup` there. -/
 
 /-- Up to informational equivalence, states are exactly the upper sets
-of possibilities: `upperClosure` descends to an order isomorphism on
-the antisymmetrization — the Smyth kernel is full. `UpperSet`'s
-complete lattice is the algebra of states up to equivalence; there,
-Def. 0.26's unrestricted (arbitrary-family) merge is `sSup`. -/
+of possibilities. -/
 def antisymmetrizationOrderIso :
     Antisymmetrization (State W V M) (· ≤ ·) ≃o
       UpperSet (Possibility W V (Part M)) where
@@ -293,8 +273,7 @@ end State
 The worldly content of a state — Def. 0.23(v)'s proposition,
 [elliott-sudo-2025] Def. 3.1's 𝒲 — is the image `Possibility.world '' s`. -/
 
-/-- A referent is *familiar* at a state ([elliott-sudo-2025], Def. 3.2;
-[heim-1982]'s files): defined at every point. -/
+/-- A referent is *familiar* at a state: defined at every point. -/
 def Familiar (s : State W V M) (x : V) : Prop :=
   ∀ p ∈ s, (p.assignment x).Dom
 
@@ -305,8 +284,7 @@ namespace State
 variable {s s' : State W V M}
 
 /-- The state is uniform at `X`: every point defines exactly the
-referents in `X` — Def. 0.23's "Dom(f) = X", as a stratum rather than a
-component. -/
+referents in `X`. -/
 def UniformAt (X : Set V) (I : State W V M) : Prop :=
   ∀ p ∈ I, Possibility.domain p = X
 
@@ -314,8 +292,7 @@ def UniformAt (X : Set V) (I : State W V M) : Prop :=
 theorem uniformAt_bot : UniformAt ∅ (⊥ : State W V M) := fun _ hp =>
   Possibility.domain_eq_empty_iff.mpr (mem_bot.mp hp)
 
-/-- Into a uniform stratum, subsistence is membership: a point already
-at the stratum's domain has no room to grow. -/
+/-- Into a uniform stratum, subsistence is membership. -/
 theorem mem_lowerClosure_iff {X : Set V} (hs : UniformAt X s)
     {p : Possibility W V (Part M)} (hp : p.domain = X) :
     p ∈ lowerClosure s ↔ p ∈ s :=
@@ -329,8 +306,7 @@ theorem lowerClosure_le_iff {X : Set V} (hs : UniformAt X s)
     lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s' :=
   lowerClosure_le.trans (forall₂_congr fun p hp => mem_lowerClosure_iff hs' (hs p hp))
 
-/-- On a uniform stratum, informativeness is reverse inclusion — the
-eliminative direction. -/
+/-- On a uniform stratum, informativeness is reverse inclusion. -/
 theorem le_iff_superset {X : Set V} (hs : UniformAt X s) (hs' : UniformAt X s') :
     s ≤ s' ↔ s' ⊆ s := by
   rw [le_def]
@@ -340,8 +316,7 @@ theorem le_iff_superset {X : Set V} (hs : UniformAt X s) (hs' : UniformAt X s') 
     rwa [← Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)]
   · exact fun h q hq => ⟨q, h hq, le_rfl⟩
 
-/-- Within one stratum, merge is intersection: compatibility on a shared
-domain forces equality. -/
+/-- Within one stratum, merge is intersection. -/
 theorem mul_eq_inter_of_uniform {X : Set V} (hs : UniformAt X s)
     (hs' : UniformAt X s') : s * s' = s ∩ s' := by
   ext r
@@ -372,9 +347,7 @@ theorem uniformAt_mul {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') 
   obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_mul.mp hr
   rw [Possibility.domain_union, hs p hp, hs' q hq]
 
-/-- Subsistence out of a stratum factors through reindexing: the weaker
-state includes into the restricted image of the stronger — the fibred
-order, glued from within-stratum `⊆` along `restrict`. -/
+/-- Subsistence out of a stratum is inclusion into the restricted image. -/
 theorem lowerClosure_le_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
     lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s'.restrict X := by
   rw [lowerClosure_le]
@@ -386,9 +359,8 @@ theorem lowerClosure_le_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
     obtain ⟨q, hq, rfl⟩ := h hp
     exact ⟨q, hq, Possibility.restrict_le⟩
 
-/-- Informativeness out of a stratum factors through reindexing: the
-restricted image of the stronger is included in the weaker — the
-eliminative direction of the fibred order. -/
+/-- Informativeness out of a stratum is reverse inclusion of the
+restricted image. -/
 theorem le_iff_restrict_subset {X : Set V} (hs : UniformAt X s) :
     s ≤ s' ↔ s'.restrict X ⊆ s := by
   rw [le_def]
@@ -435,9 +407,8 @@ def uniformEquiv (X : Set V) :
 
 variable [DecidableEq V]
 
-/-- Random assignment ([elliott-sudo-2025], (43);
-[groenendijk-stokhof-1991]'s `x := random`): indeterministically extend
-each point to a defined value at `x`. -/
+/-- Random assignment: indeterministically extend each point to a
+defined value at `x`. -/
 def randomAssign (I : State W V M) (x : V) : State W V M :=
   {p | ∃ q ∈ I, ∃ m : M, p = q.update x (Part.some m)}
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,4 +1,6 @@
 import Linglib.Semantics.Dynamic.Possibility
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 import Mathlib.Order.UpperLower.CompleteLattice
 import Mathlib.Order.Hom.Basic
 
@@ -12,7 +14,7 @@ carries *informativeness* (Def. 0.25) as its preorder, lifted along the
 upper closure of the point set: `s ≤ s'` iff every point of the
 stronger state lies above a point of the weaker. The initial state is
 `⊥`, the absurd state is `⊤ = ∅`, and consistent merge (Def. 0.26) is
-the least upper bound.
+the monoid multiplication and the least upper bound.
 
 Def. 0.23's base `X` is not a component: `State.UniformAt X` carves it
 out as a stratum, whose states are sets of world–`X`-assignment pairs
@@ -27,7 +29,9 @@ are partial orders, coinciding with `⊇` and `⊆`.
 
 - `State`: information states, preordered by informativeness; `⊥` is
   the initial state (Def. 0.23's Λ), `⊤ = ∅` the absurd state.
-- `State.merge`: consistent merge (Def. 0.26, binary), as `Set.lubs`.
+- the `CommMonoid` instance: `*` is consistent merge (Def. 0.26,
+  binary, as `Set.lubs`) and `1 = ⊥`, so `Multiset.prod` is the finite
+  n-ary merge.
 - `State.UniformAt`, `State.restrict`: the base-`X` stratum; domain
   restriction.
 - `Familiar`, `State.randomAssign`: familiarity and random assignment
@@ -36,12 +40,12 @@ are partial orders, coinciding with `⊇` and `⊆`.
 
 ## Main results
 
-- `State.isLUB_merge`, `State.isGLB_union`: merge is the least upper
-  bound and union the greatest lower bound — with `merge_comm`,
-  `merge_assoc`, `merge_bot`, the content half of
+- `State.isLUB_mul`, `State.isGLB_union`: merge is the least upper
+  bound and union the greatest lower bound — with the `CommMonoid` and
+  `CovariantClass` instances, the content half of
   [visser-vermeulen-1996]'s monoidal processing.
 - `State.le_iff_superset`, `State.lowerClosure_le_iff`,
-  `State.merge_eq_inter_of_uniform`: on a uniform stratum the orders
+  `State.mul_eq_inter_of_uniform`: on a uniform stratum the orders
   are `⊇`/`⊆` and merge is intersection.
 - `State.uniformEquiv`: uniform states at `X` are `Set (W × (X → M))`.
 
@@ -90,6 +94,11 @@ instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p 
 @[reducible] instance : Inter (State W V M) := inferInstanceAs (Inter (Set _))
 
 @[reducible] instance : SDiff (State W V M) := inferInstanceAs (SDiff (Set _))
+
+/-- Interpret a point set as an information state — the type-synonym
+retyping (`OrderDual.toDual`'s analogue), for positions whose binder is
+`Set`-typed. -/
+def _root_.Set.toState (s : Set (Possibility W V (Part M))) : State W V M := s
 
 @[ext] theorem ext {s s' : State W V M} (h : ∀ p, p ∈ s ↔ p ∈ s') : s = s' :=
   Set.ext h
@@ -144,72 +153,14 @@ it), and a state subsists in another iff `lowerClosure s ≤
 lowerClosure s'` — the closure kernel dual to `≤`, with `⊤ = ∅` at the
 bottom. -/
 
-/-! ### Consistent merge -/
+/-! ### Consistent merge as multiplication -/
 
 namespace State
 
 variable {s s' t : State W V M} {r : Possibility W V (Part M)}
 
-/-- Consistent merge ([kamp-vangenabith-reyle-2011] Def. 0.26, binary):
-the joins of pairs of points, one from each state (`Set.lubs`). Across
-strata this is the descendant-mediated join — plain intersection of
-point-sets is empty between distinct strata. -/
-def merge (s s' : State W V M) : State W V M :=
-  Set.lubs s s'
-
-/-- Membership in a merge, in union form. -/
-theorem mem_merge :
-    r ∈ s.merge s' ↔ ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q := by
-  show r ∈ Set.lubs (s : Set (Possibility W V (Part M))) s' ↔ _
-  simp only [Set.mem_lubs, Possibility.isLUB_pair_iff]
-  rfl
-
-/-- The Smyth face of the merge: upper closures compose by join. -/
-theorem upperClosure_merge :
-    upperClosure (s.merge s' : Set (Possibility W V (Part M))) =
-      upperClosure (s : Set (Possibility W V (Part M))) ⊔
-        upperClosure (s' : Set (Possibility W V (Part M))) :=
-  Set.upperClosure_lubs (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) _ _
-
-/-- The merge is above the left component. -/
-theorem le_merge_left : s ≤ s.merge s' := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_merge]
-  exact le_sup_left
-
-/-- The merge is above the right component. -/
-theorem le_merge_right : s' ≤ s.merge s' := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_merge]
-  exact le_sup_right
-
-/-- Def. 0.26's universal property: anything above both components is
-above their merge. -/
-theorem merge_le (h : s ≤ t) (h' : s' ≤ t) : s.merge s' ≤ t := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_merge]
-  exact sup_le h h'
-
-/-- **The merge is the least upper bound** of its components in the
-informativeness preorder. -/
-theorem isLUB_merge : IsLUB {s, s'} (s.merge s') :=
-  ⟨by rintro x (rfl | rfl); exacts [le_merge_left, le_merge_right],
-   fun _ hu => merge_le (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
-
-/-- Consistent merge is commutative. -/
-theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s :=
-  Set.lubs_comm s s'
-
-/-- Consistent merge is associative. -/
-theorem merge_assoc (s t u : State W V M) :
-    (s.merge t).merge u = s.merge (t.merge u) :=
-  Set.lubs_assoc (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) s t u
-
-/-- The initial state is a unit for consistent merge: with `merge_comm`,
-`merge_assoc`, and `isLUB_merge`, updating is joining in a commutative
-monoid of information — the content half of [visser-vermeulen-1996]'s
-monoidal processing. -/
-@[simp] theorem merge_bot (s : State W V M) : s.merge ⊥ = s := by
+private theorem lubs_bot (s : State W V M) :
+    (Set.lubs s (⊥ : State W V M) : State W V M) = s := by
   ext r
   constructor
   · rintro ⟨p, hp, q, ⟨w, rfl⟩, hlub⟩
@@ -220,15 +171,76 @@ monoidal processing. -/
       Possibility.isLUB_pair_iff.mpr
         ⟨.of_le le_rfl Possibility.bot_le, Possibility.union_bot.symm⟩⟩
 
-@[simp] theorem bot_merge (s : State W V M) : merge ⊥ s = s := by
-  rw [merge_comm, merge_bot]
+/-- States form a commutative monoid: `*` is consistent merge
+([kamp-vangenabith-reyle-2011] Def. 0.26, binary) — the joins of pairs
+of points, one from each state (`Set.lubs`) — and `1` is the initial
+state `⊥`. Updating is joining in a commutative monoid of information
+([visser-vermeulen-1996]'s monoidal processing); `Multiset.prod` is
+Def. 0.26's finite n-ary merge. -/
+instance : CommMonoid (State W V M) where
+  mul s s' := Set.lubs s s'
+  mul_assoc := Set.lubs_assoc fun _ _ h => ⟨_, Possibility.isLUB_union h⟩
+  one := ⊥
+  one_mul s := (Set.lubs_comm _ _).trans (lubs_bot s)
+  mul_one := lubs_bot
+  mul_comm := Set.lubs_comm
+
+theorem one_eq_bot : (1 : State W V M) = ⊥ := rfl
+
+/-- Membership in the merge, in union form. -/
+theorem mem_mul :
+    r ∈ s * s' ↔ ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q := by
+  show r ∈ Set.lubs (s : Set (Possibility W V (Part M))) s' ↔ _
+  simp only [Set.mem_lubs, Possibility.isLUB_pair_iff]
+  rfl
+
+/-- The Smyth face of the merge: upper closures compose by join. -/
+theorem upperClosure_mul :
+    upperClosure ((s * s' : State W V M) : Set (Possibility W V (Part M))) =
+      upperClosure (s : Set (Possibility W V (Part M))) ⊔
+        upperClosure (s' : Set (Possibility W V (Part M))) :=
+  Set.upperClosure_lubs (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) _ _
+
+/-- The merge is above the left factor. -/
+theorem left_le_mul : s ≤ s * s' := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_mul]
+  exact le_sup_left
+
+/-- The merge is above the right factor. -/
+theorem right_le_mul : s' ≤ s * s' := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_mul]
+  exact le_sup_right
+
+/-- Def. 0.26's universal property: anything above both factors is
+above their merge. -/
+theorem mul_le (h : s ≤ t) (h' : s' ≤ t) : s * s' ≤ t := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_mul]
+  exact sup_le h h'
+
+/-- **The merge is the least upper bound** of its factors in the
+informativeness preorder. -/
+theorem isLUB_mul : IsLUB {s, s'} (s * s') :=
+  ⟨by rintro x (rfl | rfl); exacts [left_le_mul, right_le_mul],
+   fun _ hu => mul_le (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
+
+/-- Merge is monotone: the ordered-monoid law, [kamp-vangenabith-reyle-2011]
+Def. 0.27's ascent composes across updates. -/
+instance : CovariantClass (State W V M) (State W V M) (· * ·) (· ≤ ·) :=
+  ⟨fun _ _ _ h => mul_le left_le_mul (h.trans right_le_mul)⟩
+
+instance : CovariantClass (State W V M) (State W V M)
+    (Function.swap (· * ·)) (· ≤ ·) :=
+  ⟨fun _ _ _ h => mul_le (h.trans left_le_mul) right_le_mul⟩
 
 /-! ### Union is the meet
 
 Merge is the join of the informativeness order; plain union is its
 meet — pooling two states keeps exactly their common information. `∪`
 is **not** merge: within a stratum merge is intersection
-(`merge_eq_inter_of_uniform`), the eliminative regime. -/
+(`mul_eq_inter_of_uniform`), the eliminative regime. -/
 
 /-- The Smyth face of the union: upper closures compose by meet. -/
 theorem upperClosure_union :
@@ -256,7 +268,7 @@ theorem le_union (h : t ≤ s) (h' : t ≤ s') : t ≤ s ∪ s' := by
   exact le_inf h h'
 
 /-- **The union is the greatest lower bound** of its components in the
-informativeness preorder — the meet dual to `isLUB_merge`. -/
+informativeness preorder — the meet dual to `isLUB_mul`. -/
 theorem isGLB_union : IsGLB {s, s'} (s ∪ s') :=
   ⟨by rintro x (rfl | rfl); exacts [union_le_left, union_le_right],
    fun _ hu => le_union (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
@@ -317,10 +329,10 @@ theorem le_iff_superset {X : Set V} (hs : UniformAt X s) (hs' : UniformAt X s') 
 
 /-- Within one stratum, merge is intersection: compatibility on a shared
 domain forces equality. -/
-theorem merge_eq_inter_of_uniform {X : Set V} (hs : UniformAt X s)
-    (hs' : UniformAt X s') : s.merge s' = s ∩ s' := by
+theorem mul_eq_inter_of_uniform {X : Set V} (hs : UniformAt X s)
+    (hs' : UniformAt X s') : s * s' = s ∩ s' := by
   ext r
-  rw [mem_merge]
+  rw [mem_mul]
   constructor
   · rintro ⟨p, hp, q, hq, hpq, rfl⟩
     obtain rfl := Possibility.eq_of_compat_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)
@@ -341,10 +353,10 @@ theorem mem_restrict {X : Set V} {I : State W V M} {p : Possibility W V (Part M)
 section Fibred
 
 /-- Merge unites strata. -/
-theorem uniformAt_merge {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') :
-    UniformAt (X ∪ Y) (s.merge s') := by
+theorem uniformAt_mul {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') :
+    UniformAt (X ∪ Y) (s * s') := by
   intro r hr
-  obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_merge.mp hr
+  obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_mul.mp hr
   rw [Possibility.domain_union, hs p hp, hs' q hq]
 
 /-- Subsistence out of a stratum factors through reindexing: the weaker

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -45,9 +45,9 @@ are partial orders, coinciding with `⊇` and `⊆`.
   bound and union the greatest lower bound — with the `CommMonoid` and
   `CovariantClass` instances, the content half of
   [visser-vermeulen-1996]'s monoidal processing.
-- `State.le_iff_superset`, `State.lowerClosure_le_iff`,
-  `State.mul_eq_inter_of_uniform`: on a uniform stratum the orders
-  are `⊇`/`⊆` and merge is intersection.
+- `State.UniformAt.le_iff_superset`, `State.UniformAt.lowerClosure_le_iff`,
+  `State.UniformAt.mul_eq_inter`: on a uniform stratum the orders are
+  `⊇`/`⊆` and merge is intersection.
 - `State.antisymmetrizationOrderIso`: up to informational equivalence,
   states are the complete lattice of upper sets of possibilities.
 - `State.uniformEquiv`: uniform states at `X` are `Set (W × (X → M))`.
@@ -240,8 +240,6 @@ def antisymmetrizationOrderIso :
     induction b using Quotient.ind
     exact Iff.rfl
 
-end State
-
 /-! ### Familiarity
 
 The worldly content of a state — Def. 0.23(v)'s proposition,
@@ -251,11 +249,7 @@ The worldly content of a state — Def. 0.23(v)'s proposition,
 def Familiar (s : State W V M) (x : V) : Prop :=
   ∀ p ∈ s, (p.assignment x).Dom
 
-namespace State
-
 /-! ### The uniform stratum -/
-
-variable {s s' : State W V M}
 
 /-- The state is uniform at `X`: every point defines exactly the
 referents in `X`. -/
@@ -266,8 +260,15 @@ def UniformAt (X : Set V) (I : State W V M) : Prop :=
 theorem uniformAt_bot : UniformAt ∅ (⊥ : State W V M) := fun _ hp =>
   Possibility.domain_eq_empty_iff.mpr (mem_bot.mp hp)
 
+/-- A uniform stratum is an antichain: comparable points with one
+domain are equal. -/
+theorem UniformAt.isAntichain {X : Set V} (hs : UniformAt X s) :
+    IsAntichain (· ≤ ·) (s : Set (Possibility W V (Part M))) :=
+  fun p hp q hq hne hpq =>
+    hne (Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs q hq).symm))
+
 /-- Into a uniform stratum, subsistence is membership. -/
-theorem mem_lowerClosure_iff {X : Set V} (hs : UniformAt X s)
+theorem UniformAt.mem_lowerClosure {X : Set V} (hs : UniformAt X s)
     {p : Possibility W V (Part M)} (hp : p.domain = X) :
     p ∈ lowerClosure s ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
@@ -275,23 +276,26 @@ theorem mem_lowerClosure_iff {X : Set V} (hs : UniformAt X s)
     fun h => subset_lowerClosure h⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
-theorem lowerClosure_le_iff {X : Set V} (hs : UniformAt X s)
+theorem UniformAt.lowerClosure_le_iff {X : Set V} (hs : UniformAt X s)
     (hs' : UniformAt X s') :
     lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s' :=
-  lowerClosure_le.trans (forall₂_congr fun p hp => mem_lowerClosure_iff hs' (hs p hp))
+  lowerClosure_le.trans (forall₂_congr fun p hp => hs'.mem_lowerClosure (hs p hp))
+
+/-- Into a uniform stratum, domination is membership. -/
+theorem UniformAt.mem_upperClosure {X : Set V} (hs : UniformAt X s)
+    {q : Possibility W V (Part M)} (hq : q.domain = X) :
+    q ∈ upperClosure s ↔ q ∈ s :=
+  ⟨fun ⟨p, hp, hpq⟩ =>
+    Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans hq.symm) ▸ hp,
+    fun h => subset_upperClosure h⟩
 
 /-- On a uniform stratum, informativeness is reverse inclusion. -/
-theorem le_iff_superset {X : Set V} (hs : UniformAt X s) (hs' : UniformAt X s') :
-    s ≤ s' ↔ s' ⊆ s := by
-  rw [le_def]
-  constructor
-  · intro h q hq
-    obtain ⟨p, hp, hpq⟩ := h q hq
-    rwa [← Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs' q hq).symm)]
-  · exact fun h q hq => ⟨q, h hq, le_rfl⟩
+theorem UniformAt.le_iff_superset {X : Set V} (hs : UniformAt X s)
+    (hs' : UniformAt X s') : s ≤ s' ↔ s' ⊆ s :=
+  le_def.trans (forall₂_congr fun q hq => hs.mem_upperClosure (hs' q hq))
 
 /-- Within one stratum, merge is intersection. -/
-theorem mul_eq_inter_of_uniform {X : Set V} (hs : UniformAt X s)
+theorem UniformAt.mul_eq_inter {X : Set V} (hs : UniformAt X s)
     (hs' : UniformAt X s') : s * s' = s ∩ s' := by
   ext r
   rw [mem_mul]
@@ -315,14 +319,14 @@ theorem mem_restrict {X : Set V} {I : State W V M} {p : Possibility W V (Part M)
 section Fibred
 
 /-- Merge unites strata. -/
-theorem uniformAt_mul {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') :
+theorem UniformAt.mul {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') :
     UniformAt (X ∪ Y) (s * s') := by
   intro r hr
   obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_mul.mp hr
   rw [Possibility.domain_union, hs p hp, hs' q hq]
 
 /-- Subsistence out of a stratum is inclusion into the restricted image. -/
-theorem lowerClosure_le_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
+theorem UniformAt.lowerClosure_le_iff_restrict {X : Set V} (hs : UniformAt X s) :
     lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s'.restrict X := by
   rw [lowerClosure_le]
   constructor
@@ -335,7 +339,7 @@ theorem lowerClosure_le_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
 
 /-- Informativeness out of a stratum is reverse inclusion of the
 restricted image. -/
-theorem le_iff_restrict_subset {X : Set V} (hs : UniformAt X s) :
+theorem UniformAt.le_iff_restrict_subset {X : Set V} (hs : UniformAt X s) :
     s ≤ s' ↔ s'.restrict X ⊆ s := by
   rw [le_def]
   constructor
@@ -356,7 +360,7 @@ theorem lowerClosure_restrict_le (X : Set V) (I : State W V M) :
   exact ⟨q, hq, Possibility.restrict_le⟩
 
 /-- Restriction meets the stratification. -/
-theorem uniformAt_restrict {X Y : Set V} {I : State W V M}
+theorem UniformAt.restrict {X Y : Set V} {I : State W V M}
     (h : UniformAt Y I) : UniformAt (X ∩ Y) (I.restrict X) := by
   rintro p ⟨q, hq, rfl⟩
   rw [Possibility.domain_restrict, h q hq]

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -16,17 +16,17 @@ the least upper bound.
 
 Def. 0.23's base `X` is not a component: `State.UniformAt X` carves it
 out as a stratum, whose states are sets of world–`X`-assignment pairs
-(`State.uniformEquiv`). *Subsistence* (`subsistsIn`,
-[elliott-sudo-2025], Def. 3.3, after
-[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) is the dual closure
-kernel, lifted along the lower closure. On a uniform stratum both
-orders are partial orders, coinciding with `⊇` and `⊆`.
+(`State.uniformEquiv`). *Subsistence* ([elliott-sudo-2025], Def. 3.3,
+after [groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) is not a new
+relation: a point subsists in a state iff it lies in `lowerClosure` of
+its point set, a state subsists in another iff the lower closures are
+ordered — the dual closure kernel. On a uniform stratum both kernels
+are partial orders, coinciding with `⊇` and `⊆`.
 
 ## Main definitions
 
 - `State`: information states, preordered by informativeness; `⊥` is
   the initial state (Def. 0.23's Λ), `⊤ = ∅` the absurd state.
-- `Subsists` (`≺`), `subsistsIn`: point- and state-level subsistence.
 - `State.merge`: consistent merge (Def. 0.26, binary), as `Set.lubs`.
 - `State.UniformAt`, `State.restrict`: the base-`X` stratum; domain
   restriction.
@@ -35,10 +35,11 @@ orders are partial orders, coinciding with `⊇` and `⊆`.
 
 ## Main results
 
-- `State.isLUB_merge`: merge is the least upper bound — with
-  `merge_comm`, `merge_assoc`, `merge_bot`, the content half of
+- `State.isLUB_merge`, `State.isGLB_union`: merge is the least upper
+  bound and union the greatest lower bound — with `merge_comm`,
+  `merge_assoc`, `merge_bot`, the content half of
   [visser-vermeulen-1996]'s monoidal processing.
-- `State.le_iff_superset`, `State.subsistsIn_iff_subset`,
+- `State.le_iff_superset`, `State.lowerClosure_le_iff`,
   `State.merge_eq_inter_of_uniform`: on a uniform stratum the orders
   are `⊇`/`⊆` and merge is intersection.
 - `State.uniformEquiv`: uniform states at `X` are `Set (W × (X → M))`.
@@ -132,37 +133,15 @@ instance : OrderTop (State W V M) where
 
 end State
 
-/-! ### Subsistence -/
+/-! ### Subsistence
 
-/-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it survives,
-possibly extended, into `s` — membership in the lower closure of the
-point set. -/
-def Subsists (p : Possibility W V (Part M)) (s : State W V M) : Prop :=
-  p ∈ lowerClosure (s : Set (Possibility W V (Part M)))
-
-@[inherit_doc] scoped notation:50 p " ≺ " s => Subsists p s
-
-/-- Subsistence unfolded: a point of `s` lies above `p`. -/
-theorem subsists_iff {p : Possibility W V (Part M)} {s : State W V M} :
-    (p ≺ s) ↔ ∃ q ∈ s, p ≤ q :=
-  Iff.rfl
-
-theorem Subsists.of_mem {p : Possibility W V (Part M)} {s : State W V M}
-    (h : p ∈ s) : p ≺ s :=
-  ⟨p, h, le_rfl⟩
-
-/-- `s` subsists in `s'` ([elliott-sudo-2025], Def. 3.3, state-level;
-[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9): every point survives,
-extended, into `s'` — the preorder lifted along the lower closure, dual
-to `≤` on shared strata, with `⊤ = ∅` at the bottom. -/
-def subsistsIn (s s' : State W V M) : Prop :=
-  lowerClosure (s : Set (Possibility W V (Part M))) ≤
-    lowerClosure (s' : Set (Possibility W V (Part M)))
-
-/-- Subsistence in projection form: every point subsists. -/
-theorem subsistsIn_iff {s s' : State W V M} :
-    subsistsIn s s' ↔ ∀ p ∈ s, p ≺ s' :=
-  lowerClosure_le
+*Subsistence* ([elliott-sudo-2025], Def. 3.3, after
+[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) is not a new
+relation: a point subsists in a state iff it lies in the lower closure
+of its point set (`mem_lowerClosure`: some point of the state extends
+it), and a state subsists in another iff `lowerClosure s ≤
+lowerClosure s'` — the closure kernel dual to `≤`, with `⊤ = ∅` at the
+bottom. -/
 
 /-! ### Consistent merge -/
 
@@ -243,6 +222,44 @@ monoidal processing. -/
 @[simp] theorem bot_merge (s : State W V M) : merge ⊥ s = s := by
   rw [merge_comm, merge_bot]
 
+/-! ### Union is the meet
+
+Merge is the join of the informativeness order; plain union is its
+meet — pooling two states keeps exactly their common information. `∪`
+is **not** merge: within a stratum merge is intersection
+(`merge_eq_inter_of_uniform`), the eliminative regime. -/
+
+/-- The Smyth face of the union: upper closures compose by meet. -/
+theorem upperClosure_union :
+    upperClosure ((s ∪ s' : State W V M) : Set (Possibility W V (Part M))) =
+      upperClosure (s : Set (Possibility W V (Part M))) ⊓
+        upperClosure (s' : Set (Possibility W V (Part M))) :=
+  _root_.upperClosure_union _ _
+
+/-- The union is below the left component. -/
+theorem union_le_left : s ∪ s' ≤ s := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_union]
+  exact inf_le_left
+
+/-- The union is below the right component. -/
+theorem union_le_right : s ∪ s' ≤ s' := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_union]
+  exact inf_le_right
+
+/-- Anything below both components is below their union. -/
+theorem le_union (h : t ≤ s) (h' : t ≤ s') : t ≤ s ∪ s' := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_union]
+  exact le_inf h h'
+
+/-- **The union is the greatest lower bound** of its components in the
+informativeness preorder — the meet dual to `isLUB_merge`. -/
+theorem isGLB_union : IsGLB {s, s'} (s ∪ s') :=
+  ⟨by rintro x (rfl | rfl); exacts [union_le_left, union_le_right],
+   fun _ hu => le_union (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
+
 end State
 
 /-! ### Worldly content and familiarity -/
@@ -277,16 +294,18 @@ theorem uniformAt_bot : UniformAt ∅ (⊥ : State W V M) := fun _ hp =>
 
 /-- Into a uniform stratum, subsistence is membership: a point already
 at the stratum's domain has no room to grow. -/
-theorem subsists_iff_mem {X : Set V} (hs : UniformAt X s)
-    {p : Possibility W V (Part M)} (hp : p.domain = X) : (p ≺ s) ↔ p ∈ s :=
+theorem mem_lowerClosure_iff {X : Set V} (hs : UniformAt X s)
+    {p : Possibility W V (Part M)} (hp : p.domain = X) :
+    p ∈ lowerClosure s ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
     (Possibility.eq_of_le_of_domain_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
-    Subsists.of_mem⟩
+    fun h => subset_lowerClosure h⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
-theorem subsistsIn_iff_subset {X : Set V} (hs : UniformAt X s)
-    (hs' : UniformAt X s') : subsistsIn s s' ↔ s ⊆ s' :=
-  subsistsIn_iff.trans (forall₂_congr fun p hp => subsists_iff_mem hs' (hs p hp))
+theorem lowerClosure_le_iff {X : Set V} (hs : UniformAt X s)
+    (hs' : UniformAt X s') :
+    lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s' :=
+  lowerClosure_le.trans (forall₂_congr fun p hp => mem_lowerClosure_iff hs' (hs p hp))
 
 /-- On a uniform stratum, informativeness is reverse inclusion — the
 eliminative direction. -/
@@ -334,12 +353,12 @@ theorem uniformAt_merge {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s'
 /-- Subsistence out of a stratum factors through reindexing: the weaker
 state includes into the restricted image of the stronger — the fibred
 order, glued from within-stratum `⊆` along `restrict`. -/
-theorem subsistsIn_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
-    subsistsIn s s' ↔ s ⊆ s'.restrict X := by
-  rw [subsistsIn_iff]
+theorem lowerClosure_le_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
+    lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s'.restrict X := by
+  rw [lowerClosure_le]
   constructor
   · intro h p hp
-    obtain ⟨q, hq, hpq⟩ := h p hp
+    obtain ⟨q, hq, hpq⟩ := h hp
     exact ⟨q, hq, ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
   · intro h p hp
     obtain ⟨q, hq, rfl⟩ := h hp
@@ -362,9 +381,9 @@ end Fibred
 
 /-- Restriction only forgets: the restricted state subsists in the
 original. -/
-theorem subsistsIn_restrict (X : Set V) (I : State W V M) :
-    subsistsIn (I.restrict X) I := by
-  rw [subsistsIn_iff]
+theorem lowerClosure_restrict_le (X : Set V) (I : State W V M) :
+    lowerClosure (I.restrict X) ≤ lowerClosure I := by
+  rw [lowerClosure_le]
   rintro p ⟨q, hq, rfl⟩
   exact ⟨q, hq, Possibility.restrict_le⟩
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -267,30 +267,6 @@ theorem UniformAt.isAntichain (hs : UniformAt X s) :
   fun p hp q hq hne hpq =>
     hne (Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs q hq).symm))
 
-/-- Into a uniform stratum, subsistence is membership. -/
-theorem UniformAt.mem_lowerClosure (hs : UniformAt X s) (hp : p.domain = X) :
-    p ∈ lowerClosure s ↔ p ∈ s :=
-  ⟨fun ⟨q, hq, hpq⟩ =>
-    (Possibility.eq_of_le_of_domain_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
-    fun h => subset_lowerClosure h⟩
-
-/-- On a uniform stratum, subsistence is inclusion. -/
-theorem UniformAt.lowerClosure_le_iff (hs : UniformAt X s) (hs' : UniformAt X s') :
-    lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s' :=
-  lowerClosure_le.trans (forall₂_congr fun p hp => hs'.mem_lowerClosure (hs p hp))
-
-/-- Into a uniform stratum, domination is membership. -/
-theorem UniformAt.mem_upperClosure (hs : UniformAt X s) (hq : q.domain = X) :
-    q ∈ upperClosure s ↔ q ∈ s :=
-  ⟨fun ⟨p, hp, hpq⟩ =>
-    Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans hq.symm) ▸ hp,
-    fun h => subset_upperClosure h⟩
-
-/-- On a uniform stratum, informativeness is reverse inclusion. -/
-theorem UniformAt.le_iff_superset (hs : UniformAt X s) (hs' : UniformAt X s') :
-    s ≤ s' ↔ s' ⊆ s :=
-  le_def.trans (forall₂_congr fun q hq => hs.mem_upperClosure (hs' q hq))
-
 /-- Within one stratum, merge is intersection. -/
 theorem UniformAt.mul_eq_inter (hs : UniformAt X s) (hs' : UniformAt X s') :
     s * s' = s ∩ s' := by
@@ -312,6 +288,12 @@ def restrict (X : Set V) (s : State W V M) : State W V M :=
 theorem mem_restrict : p ∈ s.restrict X ↔ ∃ q ∈ s, q.restrict X = p :=
   Iff.rfl
 
+/-- Restriction fixes its stratum. -/
+theorem UniformAt.restrict_eq (hs : UniformAt X s) : s.restrict X = s :=
+  ext fun p =>
+    ⟨fun ⟨q, hq, hqp⟩ => (hqp.symm.trans (Possibility.restrict_eq_self (hs q hq))) ▸ hq,
+     fun hp => ⟨p, hp, Possibility.restrict_eq_self (hs p hp)⟩⟩
+
 /-- A point at the stratum's domain lies below `s` iff it lies in the
 restriction of `s`. -/
 theorem mem_lowerClosure_iff_mem_restrict (hp : p.domain = X) :
@@ -325,6 +307,26 @@ theorem UniformAt.mem_upperClosure_iff_restrict_mem (hs : UniformAt X s) :
     q ∈ upperClosure s ↔ q.restrict X ∈ s :=
   ⟨fun ⟨p, hp, hpq⟩ => (Possibility.le_iff_eq_restrict (hs p hp)).mp hpq ▸ hp,
    fun h => ⟨q.restrict X, h, Possibility.restrict_le⟩⟩
+
+/-- Into a uniform stratum, subsistence is membership. -/
+theorem UniformAt.mem_lowerClosure (hs : UniformAt X s) (hp : p.domain = X) :
+    p ∈ lowerClosure s ↔ p ∈ s :=
+  (mem_lowerClosure_iff_mem_restrict hp).trans (by rw [hs.restrict_eq])
+
+/-- On a uniform stratum, subsistence is inclusion. -/
+theorem UniformAt.lowerClosure_le_iff (hs : UniformAt X s) (hs' : UniformAt X s') :
+    lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s' :=
+  lowerClosure_le.trans (forall₂_congr fun p hp => hs'.mem_lowerClosure (hs p hp))
+
+/-- Into a uniform stratum, domination is membership. -/
+theorem UniformAt.mem_upperClosure (hs : UniformAt X s) (hq : q.domain = X) :
+    q ∈ upperClosure s ↔ q ∈ s :=
+  hs.mem_upperClosure_iff_restrict_mem.trans (by rw [Possibility.restrict_eq_self hq])
+
+/-- On a uniform stratum, informativeness is reverse inclusion. -/
+theorem UniformAt.le_iff_superset (hs : UniformAt X s) (hs' : UniformAt X s') :
+    s ≤ s' ↔ s' ⊆ s :=
+  le_def.trans (forall₂_congr fun q hq => hs.mem_upperClosure (hs' q hq))
 
 section Fibred
 
@@ -386,12 +388,12 @@ variable [DecidableEq V]
 
 /-- Random assignment: indeterministically extend each point to a
 defined value at `x`. -/
-def randomAssign (I : State W V M) (x : V) : State W V M :=
-  {p | ∃ q ∈ I, ∃ m : M, p = q.update x (Part.some m)}
+def randomAssign (s : State W V M) (x : V) : State W V M :=
+  {p | ∃ q ∈ s, ∃ m : M, p = q.update x (Part.some m)}
 
 /-- Random assignment makes its referent familiar. -/
-theorem familiar_randomAssign (I : State W V M) (x : V) :
-    Familiar (I.randomAssign x) x := by
+theorem familiar_randomAssign (s : State W V M) (x : V) :
+    Familiar (s.randomAssign x) x := by
   rintro p ⟨q, -, m, rfl⟩
   simp
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -439,6 +439,19 @@ theorem restrict_restrict (X Y : Set V) (I : State W V M) :
     (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
   simp only [restrict, Set.image_image, Possibility.restrict_restrict]
 
+/-! ### The uniform classification -/
+
+/-- Uniform states at `X` are sets of world–`X`-assignment pairs. -/
+def uniformEquiv (X : Set V) :
+    {I : State W V M // UniformAt X I} ≃ Set (W × (X → M)) :=
+  (Equiv.Set.powerset {p : Possibility W V (Part M) | p.domain = X}).trans
+    (Equiv.Set.congr (Possibility.domainEquiv X))
+
+@[simp] theorem mem_uniformEquiv {X : Set V}
+    {I : {I : State W V M // UniformAt X I}} {e : W × (X → M)} :
+    e ∈ uniformEquiv X I ↔ ((Possibility.domainEquiv X).symm e).1 ∈ I.1 :=
+  Set.mem_image_equiv
+
 variable [DecidableEq V]
 
 /-- Random assignment ([elliott-sudo-2025], (43);
@@ -452,32 +465,6 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
     Familiar (I.randomAssign x) x := by
   rintro p ⟨q, -, m, rfl⟩
   simp
-
-/-! ### The uniform classification -/
-
-/-- Uniform states at `X` are sets of world–`X`-assignment pairs — the
-state-level face of `Possibility.domainEquiv`. The stratum's order
-faces are `le_iff_superset` and `lowerClosure_le_iff`: informativeness
-is reverse inclusion, subsistence inclusion. -/
-def uniformEquiv (X : Set V) :
-    {I : State W V M // UniformAt X I} ≃ Set (W × (X → M)) where
-  toFun I := {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
-  invFun S :=
-    ⟨{p | ∃ h : p.domain = X, Possibility.domainEquiv X ⟨p, h⟩ ∈ S},
-      fun _ ⟨h, _⟩ => h⟩
-  left_inv I := by
-    refine Subtype.ext (State.ext fun p => ?_)
-    constructor
-    · rintro ⟨h, hmem⟩
-      simpa using hmem
-    · intro hp
-      exact ⟨I.2 p hp, by simpa using hp⟩
-  right_inv S := Set.ext fun e => by
-    constructor
-    · rintro ⟨h, hmem⟩
-      simpa using hmem
-    · intro he
-      exact ⟨((Possibility.domainEquiv X).symm e).2, by simpa using he⟩
 
 end State
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -136,16 +136,9 @@ bottom. -/
 /-! ### Consistent merge as multiplication -/
 
 private theorem lubs_bot (s : State W V M) :
-    (Set.lubs s (⊥ : State W V M) : State W V M) = s := by
-  ext r
-  constructor
-  · rintro ⟨p, hp, q, ⟨w, rfl⟩, hlub⟩
-    obtain ⟨-, rfl⟩ := Possibility.isLUB_pair_iff.mp hlub
-    rwa [Possibility.union_bot]
-  · intro hr
-    exact ⟨r, hr, Possibility.bot r.world, ⟨r.world, rfl⟩,
-      Possibility.isLUB_pair_iff.mpr
-        ⟨.of_le le_rfl Possibility.bot_le, Possibility.union_bot.symm⟩⟩
+    (Set.lubs s (⊥ : State W V M) : State W V M) = s :=
+  Set.lubs_eq_left (fun p => ⟨.bot p.world, ⟨p.world, rfl⟩, Possibility.bot_le⟩)
+    fun _ _ ⟨_, hw⟩ h => hw ▸ Possibility.bot_le_of_compat (hw ▸ h)
 
 /-- `s * s'` is consistent merge — the joins of pairs of points, one
 from each state — and `1 = ⊥`. -/

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -79,7 +79,7 @@ def State (W V M : Type*) := Set (Possibility W V (Part M))
 
 namespace State
 
-variable {s s' t : State W V M} {r : Possibility W V (Part M)}
+variable {s s' t : State W V M} {p q r : Possibility W V (Part M)} {X Y : Set V}
 
 @[reducible] instance : Membership (Possibility W V (Part M)) (State W V M) :=
   inferInstanceAs (Membership _ (Set _))
@@ -253,8 +253,8 @@ def Familiar (s : State W V M) (x : V) : Prop :=
 
 /-- The state is uniform at `X`: every point defines exactly the
 referents in `X`. -/
-def UniformAt (X : Set V) (I : State W V M) : Prop :=
-  ∀ p ∈ I, Possibility.domain p = X
+def UniformAt (X : Set V) (s : State W V M) : Prop :=
+  ∀ p ∈ s, Possibility.domain p = X
 
 /-- The initial state is uniform at the empty base. -/
 theorem uniformAt_bot : UniformAt ∅ (⊥ : State W V M) := fun _ hp =>
@@ -262,41 +262,38 @@ theorem uniformAt_bot : UniformAt ∅ (⊥ : State W V M) := fun _ hp =>
 
 /-- A uniform stratum is an antichain: comparable points with one
 domain are equal. -/
-theorem UniformAt.isAntichain {X : Set V} (hs : UniformAt X s) :
+theorem UniformAt.isAntichain (hs : UniformAt X s) :
     IsAntichain (· ≤ ·) (s : Set (Possibility W V (Part M))) :=
   fun p hp q hq hne hpq =>
     hne (Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans (hs q hq).symm))
 
 /-- Into a uniform stratum, subsistence is membership. -/
-theorem UniformAt.mem_lowerClosure {X : Set V} (hs : UniformAt X s)
-    {p : Possibility W V (Part M)} (hp : p.domain = X) :
+theorem UniformAt.mem_lowerClosure (hs : UniformAt X s) (hp : p.domain = X) :
     p ∈ lowerClosure s ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
     (Possibility.eq_of_le_of_domain_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
     fun h => subset_lowerClosure h⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
-theorem UniformAt.lowerClosure_le_iff {X : Set V} (hs : UniformAt X s)
-    (hs' : UniformAt X s') :
+theorem UniformAt.lowerClosure_le_iff (hs : UniformAt X s) (hs' : UniformAt X s') :
     lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s' :=
   lowerClosure_le.trans (forall₂_congr fun p hp => hs'.mem_lowerClosure (hs p hp))
 
 /-- Into a uniform stratum, domination is membership. -/
-theorem UniformAt.mem_upperClosure {X : Set V} (hs : UniformAt X s)
-    {q : Possibility W V (Part M)} (hq : q.domain = X) :
+theorem UniformAt.mem_upperClosure (hs : UniformAt X s) (hq : q.domain = X) :
     q ∈ upperClosure s ↔ q ∈ s :=
   ⟨fun ⟨p, hp, hpq⟩ =>
     Possibility.eq_of_le_of_domain_eq hpq ((hs p hp).trans hq.symm) ▸ hp,
     fun h => subset_upperClosure h⟩
 
 /-- On a uniform stratum, informativeness is reverse inclusion. -/
-theorem UniformAt.le_iff_superset {X : Set V} (hs : UniformAt X s)
-    (hs' : UniformAt X s') : s ≤ s' ↔ s' ⊆ s :=
+theorem UniformAt.le_iff_superset (hs : UniformAt X s) (hs' : UniformAt X s') :
+    s ≤ s' ↔ s' ⊆ s :=
   le_def.trans (forall₂_congr fun q hq => hs.mem_upperClosure (hs' q hq))
 
 /-- Within one stratum, merge is intersection. -/
-theorem UniformAt.mul_eq_inter {X : Set V} (hs : UniformAt X s)
-    (hs' : UniformAt X s') : s * s' = s ∩ s' := by
+theorem UniformAt.mul_eq_inter (hs : UniformAt X s) (hs' : UniformAt X s') :
+    s * s' = s ∩ s' := by
   ext r
   rw [mem_mul]
   constructor
@@ -308,66 +305,68 @@ theorem UniformAt.mul_eq_inter {X : Set V} (hs : UniformAt X s)
     exact ⟨r, hr, r, hr', compat_self r, Possibility.union_self.symm⟩
 
 /-- Restriction of a state: pointwise, by direct image. -/
-def restrict (X : Set V) (I : State W V M) : State W V M :=
-  Possibility.restrict X '' I
+def restrict (X : Set V) (s : State W V M) : State W V M :=
+  Possibility.restrict X '' s
 
 /-- Membership in a restriction. -/
-theorem mem_restrict {X : Set V} {I : State W V M} {p : Possibility W V (Part M)} :
-    p ∈ I.restrict X ↔ ∃ q ∈ I, q.restrict X = p :=
+theorem mem_restrict : p ∈ s.restrict X ↔ ∃ q ∈ s, q.restrict X = p :=
   Iff.rfl
+
+/-- A point at the stratum's domain lies below `s` iff it lies in the
+restriction of `s`. -/
+theorem mem_lowerClosure_iff_mem_restrict (hp : p.domain = X) :
+    p ∈ lowerClosure s ↔ p ∈ s.restrict X :=
+  ⟨fun ⟨q, hq, hpq⟩ => ⟨q, hq, ((Possibility.le_iff_eq_restrict hp).mp hpq).symm⟩,
+   fun ⟨q, hq, hqp⟩ => ⟨q, hq, hqp ▸ Possibility.restrict_le⟩⟩
+
+/-- A point lies above a uniform `s` iff its restriction is a point
+of `s`. -/
+theorem UniformAt.mem_upperClosure_iff_restrict_mem (hs : UniformAt X s) :
+    q ∈ upperClosure s ↔ q.restrict X ∈ s :=
+  ⟨fun ⟨p, hp, hpq⟩ => (Possibility.le_iff_eq_restrict (hs p hp)).mp hpq ▸ hp,
+   fun h => ⟨q.restrict X, h, Possibility.restrict_le⟩⟩
 
 section Fibred
 
 /-- Merge unites strata. -/
-theorem UniformAt.mul {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') :
+theorem UniformAt.mul (hs : UniformAt X s) (hs' : UniformAt Y s') :
     UniformAt (X ∪ Y) (s * s') := by
   intro r hr
   obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_mul.mp hr
   rw [Possibility.domain_union, hs p hp, hs' q hq]
 
 /-- Subsistence out of a stratum is inclusion into the restricted image. -/
-theorem UniformAt.lowerClosure_le_iff_restrict {X : Set V} (hs : UniformAt X s) :
-    lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s'.restrict X := by
-  rw [lowerClosure_le]
-  constructor
-  · intro h p hp
-    obtain ⟨q, hq, hpq⟩ := h hp
-    exact ⟨q, hq, ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
-  · intro h p hp
-    obtain ⟨q, hq, rfl⟩ := h hp
-    exact ⟨q, hq, Possibility.restrict_le⟩
+theorem UniformAt.lowerClosure_le_iff_restrict (hs : UniformAt X s) :
+    lowerClosure s ≤ lowerClosure s' ↔ s ⊆ s'.restrict X :=
+  lowerClosure_le.trans
+    (forall₂_congr fun p hp => mem_lowerClosure_iff_mem_restrict (hs p hp))
 
 /-- Informativeness out of a stratum is reverse inclusion of the
 restricted image. -/
-theorem UniformAt.le_iff_restrict_subset {X : Set V} (hs : UniformAt X s) :
-    s ≤ s' ↔ s'.restrict X ⊆ s := by
-  rw [le_def]
-  constructor
-  · rintro h r ⟨q, hq, rfl⟩
-    obtain ⟨p, hp, hpq⟩ := h q hq
-    rwa [← (Possibility.le_iff_eq_restrict (hs p hp)).mp hpq]
-  · intro h q hq
-    exact ⟨q.restrict X, h ⟨q, hq, rfl⟩, Possibility.restrict_le⟩
+theorem UniformAt.le_iff_restrict_subset (hs : UniformAt X s) :
+    s ≤ s' ↔ s'.restrict X ⊆ s :=
+  le_def.trans <|
+    (forall₂_congr fun _ _ => hs.mem_upperClosure_iff_restrict_mem).trans
+      Set.forall_mem_image.symm
 
 end Fibred
 
 /-- Restriction only forgets: the restricted state subsists in the
 original. -/
-theorem lowerClosure_restrict_le (X : Set V) (I : State W V M) :
-    lowerClosure (I.restrict X) ≤ lowerClosure I := by
-  rw [lowerClosure_le]
-  rintro p ⟨q, hq, rfl⟩
-  exact ⟨q, hq, Possibility.restrict_le⟩
+theorem lowerClosure_restrict_le :
+    lowerClosure (s.restrict X) ≤ lowerClosure s :=
+  lowerClosure_le.mpr <|
+    Set.forall_mem_image.mpr fun q hq => ⟨q, hq, Possibility.restrict_le⟩
 
 /-- Restriction meets the stratification. -/
-theorem UniformAt.restrict {X Y : Set V} {I : State W V M}
-    (h : UniformAt Y I) : UniformAt (X ∩ Y) (I.restrict X) := by
+theorem UniformAt.restrict (hs : UniformAt Y s) :
+    UniformAt (X ∩ Y) (s.restrict X) := by
   rintro p ⟨q, hq, rfl⟩
-  rw [Possibility.domain_restrict, h q hq]
+  rw [Possibility.domain_restrict, hs q hq]
 
 /-- Restriction composes along intersections. -/
-theorem restrict_restrict (X Y : Set V) (I : State W V M) :
-    (I.restrict Y).restrict X = I.restrict (X ∩ Y) := by
+theorem restrict_restrict :
+    (s.restrict Y).restrict X = s.restrict (X ∩ Y) := by
   simp only [restrict, Set.image_image, Possibility.restrict_restrict]
 
 /-! ### The uniform classification -/
@@ -378,8 +377,8 @@ def uniformEquiv (X : Set V) :
   (Equiv.Set.powerset {p : Possibility W V (Part M) | p.domain = X}).trans
     (Equiv.Set.congr (Possibility.domainEquiv X))
 
-@[simp] theorem mem_uniformEquiv {X : Set V}
-    {I : {I : State W V M // UniformAt X I}} {e : W × (X → M)} :
+@[simp] theorem mem_uniformEquiv {I : {I : State W V M // UniformAt X I}}
+    {e : W × (X → M)} :
     e ∈ uniformEquiv X I ↔ ((Possibility.domainEquiv X).symm e).1 ∈ I.1 :=
   Set.mem_image_equiv
 

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -100,7 +100,7 @@ instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p 
 
 /-- `s ≤ s'` iff `s'` carries at least as much information as `s`. -/
 instance : Preorder (State W V M) :=
-  .lift fun s => upperClosure (s : Set (Possibility W V (Part M)))
+  .lift upperClosure
 
 /-- Every point of the stronger state lies above a point of the weaker. -/
 theorem le_def : s ≤ s' ↔ ∀ q ∈ s', ∃ p ∈ s, p ≤ q :=
@@ -135,19 +135,18 @@ bottom. -/
 
 /-! ### Consistent merge as multiplication -/
 
-private theorem lubs_bot (s : State W V M) :
-    (Set.lubs s (⊥ : State W V M) : State W V M) = s :=
-  Set.lubs_eq_left (fun p => ⟨.bot p.world, ⟨p.world, rfl⟩, Possibility.bot_le⟩)
-    fun _ _ ⟨_, hw⟩ h => hw ▸ Possibility.bot_le_of_compat (hw ▸ h)
-
 /-- `s * s'` is consistent merge — the joins of pairs of points, one
 from each state — and `1 = ⊥`. -/
 instance : CommMonoid (State W V M) where
-  mul s s' := Set.lubs s s'
+  mul := Set.lubs
   mul_assoc := Set.lubs_assoc fun _ _ h => ⟨_, Possibility.isLUB_union h⟩
   one := ⊥
-  one_mul s := (Set.lubs_comm _ _).trans (lubs_bot s)
-  mul_one := lubs_bot
+  one_mul _ := (Set.lubs_comm _ _).trans <| Set.lubs_eq_left
+    (fun p => ⟨.bot p.world, ⟨p.world, rfl⟩, Possibility.bot_le⟩)
+    fun _ _ ⟨_, hw⟩ h => hw ▸ Possibility.bot_le_of_compat (hw ▸ h)
+  mul_one _ := Set.lubs_eq_left
+    (fun p => ⟨.bot p.world, ⟨p.world, rfl⟩, Possibility.bot_le⟩)
+    fun _ _ ⟨_, hw⟩ h => hw ▸ Possibility.bot_le_of_compat (hw ▸ h)
   mul_comm := Set.lubs_comm
 
 theorem one_eq_bot : (1 : State W V M) = ⊥ := rfl
@@ -155,15 +154,13 @@ theorem one_eq_bot : (1 : State W V M) = ⊥ := rfl
 /-- Membership in the merge, in union form. -/
 theorem mem_mul :
     r ∈ s * s' ↔ ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q := by
-  show r ∈ Set.lubs (s : Set (Possibility W V (Part M))) s' ↔ _
+  show r ∈ Set.lubs s s' ↔ _
   simp only [Set.mem_lubs, Possibility.isLUB_pair_iff]
   rfl
 
 /-- The Smyth face of the merge: upper closures compose by join. -/
 theorem upperClosure_mul :
-    upperClosure ((s * s' : State W V M) : Set (Possibility W V (Part M))) =
-      upperClosure (s : Set (Possibility W V (Part M))) ⊔
-        upperClosure (s' : Set (Possibility W V (Part M))) :=
+    upperClosure (s * s') = upperClosure s ⊔ upperClosure s' :=
   Set.upperClosure_lubs (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) _ _
 
 /-- The merge is above the left factor. -/
@@ -187,10 +184,6 @@ theorem isLUB_mul : IsLUB {s, s'} (s * s') :=
 instance : CovariantClass (State W V M) (State W V M) (· * ·) (· ≤ ·) :=
   ⟨fun _ _ _ h => mul_le left_le_mul (h.trans right_le_mul)⟩
 
-instance : CovariantClass (State W V M) (State W V M)
-    (Function.swap (· * ·)) (· ≤ ·) :=
-  ⟨fun _ _ _ h => mul_le (h.trans left_le_mul) right_le_mul⟩
-
 /-! ### Union is the meet
 
 Merge is the join of the informativeness order; plain union is its
@@ -200,9 +193,7 @@ is **not** merge: within a stratum merge is intersection
 
 /-- The Smyth face of the union: upper closures compose by meet. -/
 theorem upperClosure_union :
-    upperClosure ((s ∪ s' : State W V M) : Set (Possibility W V (Part M))) =
-      upperClosure (s : Set (Possibility W V (Part M))) ⊓
-        upperClosure (s' : Set (Possibility W V (Part M))) :=
+    upperClosure (s ∪ s') = upperClosure s ⊓ upperClosure s' :=
   _root_.upperClosure_union _ _
 
 /-- The union is below the left component. -/
@@ -233,16 +224,13 @@ of possibilities. -/
 def antisymmetrizationOrderIso :
     Antisymmetrization (State W V M) (· ≤ ·) ≃o
       UpperSet (Possibility W V (Part M)) where
-  toFun := Quotient.lift
-    (fun s : State W V M => upperClosure (s : Set (Possibility W V (Part M))))
+  toFun := Quotient.lift (fun s : State W V M => upperClosure s)
     fun _ _ h => le_antisymm (α := UpperSet _) h.1 h.2
   invFun U := toAntisymmetrization (· ≤ ·)
     (↑U : Set (Possibility W V (Part M)))
   left_inv := by
     refine Quotient.ind fun s => Quotient.sound ?_
-    have key : upperClosure
-          ((upperClosure (s : Set (Possibility W V (Part M))) : UpperSet _) :
-            Set (Possibility W V (Part M))) =
+    have key : upperClosure ↑(upperClosure (s : Set (Possibility W V (Part M)))) =
         upperClosure (s : Set (Possibility W V (Part M))) :=
       SetLike.coe_injective (upperClosure _).upper'.upperClosure
     exact ⟨le_of_eq (α := UpperSet _) key, le_of_eq (α := UpperSet _) key.symm⟩

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -1,76 +1,62 @@
 import Linglib.Semantics.Dynamic.Possibility
-import Mathlib.Data.Set.Image
+import Mathlib.Order.UpperLower.CompleteLattice
 import Mathlib.Order.Hom.Basic
 
 /-!
 # Information states
 
-An *information state* is a set of world–assignment pairs, with the
-assignments partial — [kamp-vangenabith-reyle-2011]'s Def. 23 (sets of
-pairs of a world and an embedding), the form the field standardly
-assumes: the absurd state is `∅`, the initial state is `W × {g_⊤}`
-(`initial`), and the lattice of states is `Set`'s. Partiality is by
-`Part` ([elliott-sudo-2025]'s Def. 3.1 renders it as total functions
-into `D ∪ {∗}`), so no component of a state carries data beyond the
-world–assignment pair.
+An *information state* is a set of world–assignment pairs with the
+assignments partial ([kamp-vangenabith-reyle-2011], Def. 0.23;
+partiality by `Part`, after [elliott-sudo-2025], Def. 3.1). `State`
+carries *informativeness* (Def. 0.25) as its preorder, lifted along the
+upper closure of the point set: `s ≤ s'` iff every point of the
+stronger state lies above a point of the weaker. The initial state is
+`⊥`, the absurd state is `⊤ = ∅`, and consistent merge (Def. 0.26) is
+the least upper bound.
 
-There is no base field: Def. 23's "Dom(f) = X" is the *uniform* stratum
-(`UniformAt`), and a base is the index of a fiber, not part of the data.
-Points with domain `X` are world–`X`-assignment pairs, constructively
-(`Possibility.domainEquiv`). Two preorders run through states, and they
-are dual on shared strata. *Informativeness* (`⊑`,
-[kamp-vangenabith-reyle-2011] Def. 25) quantifies over the stronger
-state: every point of the stronger lies above a point of the weaker — the
-absurd state `∅` is maximally informative, the eliminative direction.
-*Subsistence* (`⪯`, [elliott-sudo-2025] Def. 3.3, after
-[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) quantifies over the
-weaker: every point survives, extended, into the stronger — the
-anaphoric-support direction, with `∅` at the bottom. On a uniform
-stratum they reduce to `⊇` and `⊆` respectively
-(`infoLe_iff_superset`, `subsistsIn_iff_subset`).
+Def. 0.23's base `X` is not a component: `State.UniformAt X` carves it
+out as a stratum, whose states are sets of world–`X`-assignment pairs
+(`State.uniformEquiv`). *Subsistence* (`subsistsIn`,
+[elliott-sudo-2025], Def. 3.3, after
+[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) is the dual closure
+kernel, lifted along the lower closure. On a uniform stratum both
+orders are partial orders, coinciding with `⊇` and `⊆`.
 
 ## Main definitions
 
-- `State W V M`: information states; `initial`, with `∅` the absurd
-  state.
-- `infoLe` (`⊑`): informativeness (Def. 25); `Subsists` (`≺`),
-  `subsistsIn` (`⪯`): subsistence.
-- `State.merge`: Def. 26's consistent merge.
-- `worlds`, `Familiar`: worldly content and familiarity.
-- `State.UniformAt`: the indexed stratum (Def. 23's `Dom(f) = X`).
-- `State.restrict`, `State.randomAssign`: domain restriction (by direct
-  image of `Possibility.restrict`) and random assignment.
+- `State`: information states, preordered by informativeness; `⊥` is
+  the initial state (Def. 0.23's Λ), `⊤ = ∅` the absurd state.
+- `Subsists` (`≺`), `subsistsIn`: point- and state-level subsistence.
+- `State.merge`: consistent merge (Def. 0.26, binary), as `Set.lubs`.
+- `State.UniformAt`, `State.restrict`: the base-`X` stratum; domain
+  restriction.
+- `worlds`, `Familiar`, `State.randomAssign`: worldly content,
+  familiarity, random assignment ([elliott-sudo-2025]).
 
 ## Main results
 
-- `merge_infoLe`: the merge is the `⊑`-least upper bound.
-- `merge_assoc`, `merge_comm`, `merge_initial`: states form a
-  commutative monoid under consistent merge — the content half of
+- `State.isLUB_merge`: merge is the least upper bound — with
+  `merge_comm`, `merge_assoc`, `merge_bot`, the content half of
   [visser-vermeulen-1996]'s monoidal processing.
-- `infoLe_iff_superset`, `subsistsIn_iff_subset`: on a uniform stratum
-  both preorders are partial orders, coinciding with `⊇`/`⊆` (via
-  `Possibility.eq_of_le_of_domain_eq`).
-- `subsistsIn_restrict`: restriction only forgets — the restricted state
-  subsists in the original.
-- `uniformAt_restrict`, `restrict_restrict`: restriction meets the
-  stratification.
-- `uniformAt_initial`: the initial state is the empty-base fiber.
+- `State.le_iff_superset`, `State.subsistsIn_iff_subset`,
+  `State.merge_eq_inter_of_uniform`: on a uniform stratum the orders
+  are `⊇`/`⊆` and merge is intersection.
+- `State.uniformEquiv`: uniform states at `X` are `Set (W × (X → M))`.
 
 ## Implementation notes
 
-`State` is an abbreviation, so `Set`'s complete lattice is available and
-`⊑`/`⪯` are scoped relations rather than instances. Neither is
-antisymmetric on raw sets (adding a comparable point is invisible —
-below for `⪯`, above for `⊑`); antisymmetry holds on each
-uniform stratum, where they coincide with `⊇`/`⊆`. `Subsists` is
-membership in `lowerClosure`, so `⪯` and `⊑` are the containments
-`s ⊆ ↑(lowerClosure s')` and `s' ⊆ ↑(upperClosure s)`.
+`State` is a type synonym for the point-set, in the `Lex`/`OrderDual`
+mold: membership and the set operations are re-exposed, while `≤` is
+informativeness — the kernel of `upperClosure` — rather than `⊆`, which
+remains available with its literal meaning. Neither closure kernel is
+antisymmetric on point sets (adding a comparable point is invisible),
+so `State` is a `Preorder` only; antisymmetry holds on each uniform
+stratum.
 
 ## References
 
-- [kamp-vangenabith-reyle-2011], Defs. 23, 25
-- [groenendijk-stokhof-veltman-1996], [elliott-sudo-2025]
-- [heim-1982]
+- [kamp-vangenabith-reyle-2011], Defs. 0.23–0.26
+- [elliott-sudo-2025], [groenendijk-stokhof-veltman-1996], [heim-1982]
 -/
 
 namespace DynamicSemantics
@@ -80,72 +66,107 @@ variable {W V M : Type*}
 /-! ### Information states -/
 
 /-- An information state: a set of world–assignment pairs, the
-assignments partial (Def. 23). The absurd state is `∅`; the lattice of
-states is `Set`'s. -/
-abbrev State (W V M : Type*) := Set (Possibility W V (Part M))
+assignments partial ([kamp-vangenabith-reyle-2011], Def. 0.23), ordered
+by informativeness rather than inclusion. -/
+def State (W V M : Type*) := Set (Possibility W V (Part M))
 
-/-- The initial information state `W × {g_⊤}`: every world live, no
-referent defined — the range of the empty points. -/
-def State.initial : State W V M :=
-  Set.range Possibility.bot
+namespace State
+
+@[reducible] instance : Membership (Possibility W V (Part M)) (State W V M) :=
+  inferInstanceAs (Membership _ (Set _))
+
+/-- Point-set inclusion between states. Deliberately `HasSubset`, not the
+order: `≤` is informativeness, and the two coincide only stratum-wise
+(`le_iff_superset`). -/
+instance : HasSubset (State W V M) := ⟨fun s s' => ∀ ⦃p⦄, p ∈ s → p ∈ s'⟩
+
+@[reducible] instance : EmptyCollection (State W V M) :=
+  inferInstanceAs (EmptyCollection (Set _))
+
+@[reducible] instance : Union (State W V M) := inferInstanceAs (Union (Set _))
+
+@[reducible] instance : Inter (State W V M) := inferInstanceAs (Inter (Set _))
+
+@[reducible] instance : SDiff (State W V M) := inferInstanceAs (SDiff (Set _))
+
+@[ext] theorem ext {s s' : State W V M} (h : ∀ p, p ∈ s ↔ p ∈ s') : s = s' :=
+  Set.ext h
+
+/-- Informativeness ([kamp-vangenabith-reyle-2011], Def. 0.25): `s ≤ s'`
+iff `s'` carries at least as much information as `s` — the preorder
+lifted along the upper closure of the point set. -/
+instance : Preorder (State W V M) :=
+  .lift fun s => upperClosure (s : Set (Possibility W V (Part M)))
+
+/-- Def. 0.25 in projection form: every point of the stronger state lies
+above a point of the weaker. -/
+theorem le_def {s s' : State W V M} : s ≤ s' ↔ ∀ q ∈ s', ∃ p ∈ s, p ≤ q := by
+  change upperClosure _ ≤ upperClosure _ ↔ _
+  rw [← UpperSet.coe_subset_coe]
+  constructor
+  · intro h q hq
+    exact h (subset_upperClosure hq)
+  · rintro h x ⟨q, hq, hqx⟩
+    obtain ⟨p, hp, hpq⟩ := h q hq
+    exact ⟨p, hp, hpq.trans hqx⟩
+
+/-- The initial information state `⊥ = W × {g_⊤}` (Def. 0.23's Λ):
+every world live, no referent defined — the range of the empty points,
+the bottom of the informativeness order. -/
+instance : OrderBot (State W V M) where
+  bot := Set.range Possibility.bot
+  bot_le _ := le_def.mpr fun q _ => ⟨.bot q.world, ⟨q.world, rfl⟩, Possibility.bot_le⟩
 
 /-- Membership in the initial state: no referent defined. -/
-theorem State.mem_initial {p : Possibility W V (Part M)} :
-    p ∈ (State.initial : State W V M) ↔ ∀ v, p.assignment v = ⊥ :=
+theorem mem_bot {p : Possibility W V (Part M)} :
+    p ∈ (⊥ : State W V M) ↔ ∀ v, p.assignment v = ⊥ :=
   ⟨fun ⟨_, hw⟩ _ => hw ▸ rfl, fun h =>
     ⟨p.world, Possibility.ext rfl (funext fun v => (h v).symm)⟩⟩
 
-/-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it has a
-point above it in `s`. -/
+/-- The absurd state is maximally informative: no live point. -/
+instance : OrderTop (State W V M) where
+  top := ∅
+  le_top _ := le_def.mpr fun _ hq => hq.elim
+
+@[simp] theorem top_eq_empty : (⊤ : State W V M) = ∅ := rfl
+
+end State
+
+/-! ### Subsistence -/
+
+/-- `p` *subsists* in `s` ([elliott-sudo-2025], Def. 3.3): it survives,
+possibly extended, into `s` — membership in the lower closure of the
+point set. -/
 def Subsists (p : Possibility W V (Part M)) (s : State W V M) : Prop :=
-  ∃ q ∈ s, p ≤ q
+  p ∈ lowerClosure (s : Set (Possibility W V (Part M)))
 
 @[inherit_doc] scoped notation:50 p " ≺ " s => Subsists p s
+
+/-- Subsistence unfolded: a point of `s` lies above `p`. -/
+theorem subsists_iff {p : Possibility W V (Part M)} {s : State W V M} :
+    (p ≺ s) ↔ ∃ q ∈ s, p ≤ q :=
+  Iff.rfl
 
 theorem Subsists.of_mem {p : Possibility W V (Part M)} {s : State W V M}
     (h : p ∈ s) : p ≺ s :=
   ⟨p, h, le_rfl⟩
 
-/-- `s` subsists in `s'`: the informativeness order, Def. 25's
-projection form — every point of the weaker state has a descendant in
-the stronger. -/
+/-- `s` subsists in `s'` ([elliott-sudo-2025], Def. 3.3, state-level;
+[groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9): every point survives,
+extended, into `s'` — the preorder lifted along the lower closure, dual
+to `≤` on shared strata, with `⊤ = ∅` at the bottom. -/
 def subsistsIn (s s' : State W V M) : Prop :=
-  ∀ p ∈ s, p ≺ s'
+  lowerClosure (s : Set (Possibility W V (Part M))) ≤
+    lowerClosure (s' : Set (Possibility W V (Part M)))
 
-@[inherit_doc] scoped notation:50 s " ⪯ " s' => subsistsIn s s'
-
-theorem subsistsIn_refl (s : State W V M) : s ⪯ s :=
-  fun _ hp => Subsists.of_mem hp
-
-theorem subsistsIn_trans {s t u : State W V M} (hst : s ⪯ t)
-    (htu : t ⪯ u) : s ⪯ u := fun p hp => by
-  obtain ⟨q, hq, hpq⟩ := hst p hp
-  obtain ⟨r, hr, hqr⟩ := htu q hq
-  exact ⟨r, hr, hpq.trans hqr⟩
-
-/-- Informativeness ([kamp-vangenabith-reyle-2011] Def. 25): `s'` carries
-at least as much information as `s` — every point of the stronger state
-lies above a point of the weaker. The absurd state is maximally
-informative; the eliminative direction, dual to `⪯` on shared strata. -/
-def infoLe (s s' : State W V M) : Prop :=
-  ∀ q ∈ s', ∃ p ∈ s, p ≤ q
-
-@[inherit_doc] scoped notation:50 s " ⊑ " s' => infoLe s s'
-
-theorem infoLe_refl (s : State W V M) : s ⊑ s :=
-  fun q hq => ⟨q, hq, le_rfl⟩
-
-theorem infoLe_trans {s t u : State W V M} (hst : s ⊑ t) (htu : t ⊑ u) :
-    s ⊑ u := fun r hr => by
-  obtain ⟨q, hq, hqr⟩ := htu r hr
-  obtain ⟨p, hp, hpq⟩ := hst q hq
-  exact ⟨p, hp, hpq.trans hqr⟩
-
-/-- The absurd state is maximally informative. -/
-theorem infoLe_empty (s : State W V M) : s ⊑ (∅ : State W V M) :=
-  fun _ hq => hq.elim
+/-- Subsistence in projection form: every point subsists. -/
+theorem subsistsIn_iff {s s' : State W V M} :
+    subsistsIn s s' ↔ ∀ p ∈ s, p ≺ s' :=
+  lowerClosure_le
 
 /-! ### Consistent merge -/
+
+namespace State
 
 variable {s s' t : State W V M} {r : Possibility W V (Part M)}
 
@@ -153,32 +174,47 @@ variable {s s' t : State W V M} {r : Possibility W V (Part M)}
 the joins of pairs of points, one from each state (`Set.lubs`). Across
 strata this is the descendant-mediated join — plain intersection of
 point-sets is empty between distinct strata. -/
-def State.merge (s s' : State W V M) : State W V M :=
-  s.lubs s'
+def merge (s s' : State W V M) : State W V M :=
+  Set.lubs s s'
 
 /-- Membership in a merge, in union form. -/
-theorem State.mem_merge :
+theorem mem_merge :
     r ∈ s.merge s' ↔ ∃ p ∈ s, ∃ q ∈ s', Compat p q ∧ r = p.union q := by
-  simp only [State.merge, Set.mem_lubs, Possibility.isLUB_pair_iff]
+  show r ∈ Set.lubs (s : Set (Possibility W V (Part M))) s' ↔ _
+  simp only [Set.mem_lubs, Possibility.isLUB_pair_iff]
+  rfl
 
-/-- The merge is above the left component in informativeness. -/
-theorem infoLe_merge_left : s ⊑ s.merge s' := by
-  rintro r ⟨p, hp, q, hq, hlub⟩
-  exact ⟨p, hp, hlub.1 (Set.mem_insert _ _)⟩
+/-- The Smyth face of the merge: upper closures compose by join. -/
+theorem upperClosure_merge :
+    upperClosure (s.merge s' : Set (Possibility W V (Part M))) =
+      upperClosure (s : Set (Possibility W V (Part M))) ⊔
+        upperClosure (s' : Set (Possibility W V (Part M))) :=
+  Set.upperClosure_lubs (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) _ _
 
-/-- The merge is above the right component in informativeness. -/
-theorem infoLe_merge_right : s' ⊑ s.merge s' := by
-  rintro r ⟨p, hp, q, hq, hlub⟩
-  exact ⟨q, hq, hlub.1 (Set.mem_insert_of_mem _ rfl)⟩
+/-- The merge is above the left component. -/
+theorem le_merge_left : s ≤ s.merge s' := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_merge]
+  exact le_sup_left
 
-/-- **The merge is the least upper bound** (Def. 0.26's universal
-property, in the informativeness preorder): anything above both
-components is above their merge. -/
-theorem merge_infoLe (hs : s ⊑ t) (hs' : s' ⊑ t) : s.merge s' ⊑ t := fun u hu => by
-  obtain ⟨p, hp, hpu⟩ := hs u hu
-  obtain ⟨q, hq, hqu⟩ := hs' u hu
-  exact ⟨p.union q, ⟨p, hp, q, hq, Possibility.isLUB_union (Compat.of_le hpu hqu)⟩,
-    Possibility.union_le hpu hqu⟩
+/-- The merge is above the right component. -/
+theorem le_merge_right : s' ≤ s.merge s' := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_merge]
+  exact le_sup_right
+
+/-- Def. 0.26's universal property: anything above both components is
+above their merge. -/
+theorem merge_le (h : s ≤ t) (h' : s' ≤ t) : s.merge s' ≤ t := by
+  change upperClosure _ ≤ upperClosure _
+  rw [upperClosure_merge]
+  exact sup_le h h'
+
+/-- **The merge is the least upper bound** of its components in the
+informativeness preorder. -/
+theorem isLUB_merge : IsLUB {s, s'} (s.merge s') :=
+  ⟨by rintro x (rfl | rfl); exacts [le_merge_left, le_merge_right],
+   fun _ hu => merge_le (hu (Set.mem_insert _ _)) (hu (Set.mem_insert_of_mem _ rfl))⟩
 
 /-- Consistent merge is commutative. -/
 theorem merge_comm (s s' : State W V M) : s.merge s' = s'.merge s :=
@@ -190,10 +226,10 @@ theorem merge_assoc (s t u : State W V M) :
   Set.lubs_assoc (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) s t u
 
 /-- The initial state is a unit for consistent merge: with `merge_comm`,
-`merge_assoc`, and `merge_infoLe`, updating is joining in a commutative
-monoid of information — the content half of
-[visser-vermeulen-1996]'s monoidal processing. -/
-@[simp] theorem merge_initial (s : State W V M) : s.merge State.initial = s := by
+`merge_assoc`, and `isLUB_merge`, updating is joining in a commutative
+monoid of information — the content half of [visser-vermeulen-1996]'s
+monoidal processing. -/
+@[simp] theorem merge_bot (s : State W V M) : s.merge ⊥ = s := by
   ext r
   constructor
   · rintro ⟨p, hp, q, ⟨w, rfl⟩, hlub⟩
@@ -204,8 +240,12 @@ monoid of information — the content half of
       Possibility.isLUB_pair_iff.mpr
         ⟨.of_le le_rfl Possibility.bot_le, Possibility.union_bot.symm⟩⟩
 
-@[simp] theorem initial_merge (s : State W V M) : State.merge State.initial s = s := by
-  rw [merge_comm, merge_initial]
+@[simp] theorem bot_merge (s : State W V M) : merge ⊥ s = s := by
+  rw [merge_comm, merge_bot]
+
+end State
+
+/-! ### Worldly content and familiarity -/
 
 /-- The worldly content of a state ([elliott-sudo-2025] Def. 3.1's 𝒲). -/
 def worlds (s : State W V M) : Set W :=
@@ -223,36 +263,36 @@ namespace State
 
 /-! ### The uniform stratum -/
 
+variable {s s' : State W V M}
+
 /-- The state is uniform at `X`: every point defines exactly the
-referents in `X` — Def. 23's "Dom(f) = X", as a stratum rather than a
+referents in `X` — Def. 0.23's "Dom(f) = X", as a stratum rather than a
 component. -/
 def UniformAt (X : Set V) (I : State W V M) : Prop :=
   ∀ p ∈ I, Possibility.domain p = X
 
 /-- The initial state is uniform at the empty base. -/
-theorem uniformAt_initial : UniformAt ∅ (initial : State W V M) := fun _ hp =>
-  Possibility.domain_eq_empty_iff.mpr (mem_initial.mp hp)
+theorem uniformAt_bot : UniformAt ∅ (⊥ : State W V M) := fun _ hp =>
+  Possibility.domain_eq_empty_iff.mpr (mem_bot.mp hp)
 
 /-- Into a uniform stratum, subsistence is membership: a point already
 at the stratum's domain has no room to grow. -/
-theorem subsists_iff_mem {X : Set V} {s : State W V M}
-    (hs : UniformAt X s) {p : Possibility W V (Part M)}
-    (hp : p.domain = X) : (p ≺ s) ↔ p ∈ s :=
+theorem subsists_iff_mem {X : Set V} (hs : UniformAt X s)
+    {p : Possibility W V (Part M)} (hp : p.domain = X) : (p ≺ s) ↔ p ∈ s :=
   ⟨fun ⟨q, hq, hpq⟩ =>
     (Possibility.eq_of_le_of_domain_eq hpq (hp.trans (hs q hq).symm)).symm ▸ hq,
     Subsists.of_mem⟩
 
 /-- On a uniform stratum, subsistence is inclusion. -/
-theorem subsistsIn_iff_subset {X : Set V} {s s' : State W V M}
-    (hs : UniformAt X s) (hs' : UniformAt X s') :
-    (s ⪯ s') ↔ s ⊆ s' :=
-  forall₂_congr fun p hp => subsists_iff_mem hs' (hs p hp)
+theorem subsistsIn_iff_subset {X : Set V} (hs : UniformAt X s)
+    (hs' : UniformAt X s') : subsistsIn s s' ↔ s ⊆ s' :=
+  subsistsIn_iff.trans (forall₂_congr fun p hp => subsists_iff_mem hs' (hs p hp))
 
 /-- On a uniform stratum, informativeness is reverse inclusion — the
 eliminative direction. -/
-theorem infoLe_iff_superset {X : Set V} {s s' : State W V M}
-    (hs : UniformAt X s) (hs' : UniformAt X s') :
-    (s ⊑ s') ↔ s' ⊆ s := by
+theorem le_iff_superset {X : Set V} (hs : UniformAt X s) (hs' : UniformAt X s') :
+    s ≤ s' ↔ s' ⊆ s := by
+  rw [le_def]
   constructor
   · intro h q hq
     obtain ⟨p, hp, hpq⟩ := h q hq
@@ -261,9 +301,8 @@ theorem infoLe_iff_superset {X : Set V} {s s' : State W V M}
 
 /-- Within one stratum, merge is intersection: compatibility on a shared
 domain forces equality. -/
-theorem merge_eq_inter_of_uniform {X : Set V} {s s' : State W V M}
-    (hs : UniformAt X s) (hs' : UniformAt X s') :
-    s.merge s' = s ∩ s' := by
+theorem merge_eq_inter_of_uniform {X : Set V} (hs : UniformAt X s)
+    (hs' : UniformAt X s') : s.merge s' = s ∩ s' := by
   ext r
   rw [mem_merge]
   constructor
@@ -286,8 +325,7 @@ theorem mem_restrict {X : Set V} {I : State W V M} {p : Possibility W V (Part M)
 section Fibred
 
 /-- Merge unites strata. -/
-theorem uniformAt_merge {X Y : Set V} {s s' : State W V M}
-    (hs : UniformAt X s) (hs' : UniformAt Y s') :
+theorem uniformAt_merge {X Y : Set V} (hs : UniformAt X s) (hs' : UniformAt Y s') :
     UniformAt (X ∪ Y) (s.merge s') := by
   intro r hr
   obtain ⟨p, hp, q, hq, -, rfl⟩ := mem_merge.mp hr
@@ -296,14 +334,13 @@ theorem uniformAt_merge {X Y : Set V} {s s' : State W V M}
 /-- Subsistence out of a stratum factors through reindexing: the weaker
 state includes into the restricted image of the stronger — the fibred
 order, glued from within-stratum `⊆` along `restrict`. -/
-theorem subsistsIn_iff_subset_restrict {X : Set V}
-    {s s' : State W V M} (hs : UniformAt X s) :
-    (s ⪯ s') ↔ s ⊆ s'.restrict X := by
+theorem subsistsIn_iff_subset_restrict {X : Set V} (hs : UniformAt X s) :
+    subsistsIn s s' ↔ s ⊆ s'.restrict X := by
+  rw [subsistsIn_iff]
   constructor
   · intro h p hp
     obtain ⟨q, hq, hpq⟩ := h p hp
-    exact ⟨q, hq,
-      ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
+    exact ⟨q, hq, ((Possibility.le_iff_eq_restrict (hs p hp)).mp hpq).symm⟩
   · intro h p hp
     obtain ⟨q, hq, rfl⟩ := h hp
     exact ⟨q, hq, Possibility.restrict_le⟩
@@ -311,22 +348,23 @@ theorem subsistsIn_iff_subset_restrict {X : Set V}
 /-- Informativeness out of a stratum factors through reindexing: the
 restricted image of the stronger is included in the weaker — the
 eliminative direction of the fibred order. -/
-theorem infoLe_iff_restrict_subset {X : Set V}
-    {s s' : State W V M} (hs : UniformAt X s) :
-    (s ⊑ s') ↔ s'.restrict X ⊆ s := by
+theorem le_iff_restrict_subset {X : Set V} (hs : UniformAt X s) :
+    s ≤ s' ↔ s'.restrict X ⊆ s := by
+  rw [le_def]
   constructor
   · rintro h r ⟨q, hq, rfl⟩
     obtain ⟨p, hp, hpq⟩ := h q hq
     rwa [← (Possibility.le_iff_eq_restrict (hs p hp)).mp hpq]
   · intro h q hq
-    exact ⟨q.restrict X, h ⟨q, hq, rfl⟩,
-      Possibility.restrict_le⟩
+    exact ⟨q.restrict X, h ⟨q, hq, rfl⟩, Possibility.restrict_le⟩
 
 end Fibred
 
 /-- Restriction only forgets: the restricted state subsists in the
 original. -/
-theorem subsistsIn_restrict (X : Set V) (I : State W V M) : I.restrict X ⪯ I := by
+theorem subsistsIn_restrict (X : Set V) (I : State W V M) :
+    subsistsIn (I.restrict X) I := by
+  rw [subsistsIn_iff]
   rintro p ⟨q, hq, rfl⟩
   exact ⟨q, hq, Possibility.restrict_le⟩
 
@@ -358,33 +396,36 @@ theorem familiar_randomAssign (I : State W V M) (x : V) :
 /-! ### The uniform classification -/
 
 /-- Uniform states at `X` are sets of world–`X`-assignment pairs — the
-state-level face of `Possibility.domainEquiv`: an order isomorphism for
-`⊆` (which is `⪯` on the stratum, `subsistsIn_iff_subset`), hence an
-anti-isomorphism for `⊑` (`infoLe_iff_superset`). -/
+state-level face of `Possibility.domainEquiv`. Informativeness on the
+stratum is reverse inclusion (`le_iff_superset`), so the isomorphism
+lands in the dual order. -/
 def uniformEquiv (X : Set V) :
-    {I : State W V M // UniformAt X I} ≃o Set (W × (X → M)) where
-  toFun I := {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
+    {I : State W V M // UniformAt X I} ≃o (Set (W × (X → M)))ᵒᵈ where
+  toFun I := OrderDual.toDual {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1}
   invFun S :=
-    ⟨{p | ∃ h : p.domain = X, Possibility.domainEquiv X ⟨p, h⟩ ∈ S},
+    ⟨{p | ∃ h : p.domain = X, Possibility.domainEquiv X ⟨p, h⟩ ∈ OrderDual.ofDual S},
       fun _ ⟨h, _⟩ => h⟩
   left_inv I := by
-    refine Subtype.ext (Set.ext fun p => ?_)
+    refine Subtype.ext (State.ext fun p => ?_)
     constructor
     · rintro ⟨h, hmem⟩
       simpa using hmem
     · intro hp
       exact ⟨I.2 p hp, by simpa using hp⟩
-  right_inv S := Set.ext fun e => by
+  right_inv S := OrderDual.ofDual.injective <| Set.ext fun e => by
     constructor
     · rintro ⟨h, hmem⟩
       simpa using hmem
     · intro he
       exact ⟨((Possibility.domainEquiv X).symm e).2, by simpa using he⟩
   map_rel_iff' {I J} := by
+    rw [← Subtype.coe_le_coe, le_iff_superset I.2 J.2]
+    show ({e | ((Possibility.domainEquiv X).symm e).1 ∈ J.1} : Set (W × (X → M))) ⊆
+        {e | ((Possibility.domainEquiv X).symm e).1 ∈ I.1} ↔ _
     constructor
     · intro h p hp
-      simpa using h (a := Possibility.domainEquiv X ⟨p, I.2 p hp⟩)
-        (by simpa using hp)
+      simpa using h (show Possibility.domainEquiv X ⟨p, J.2 p hp⟩ ∈
+        {e | ((Possibility.domainEquiv X).symm e).1 ∈ J.1} by simpa using hp)
     · exact fun h _ he => h he
 
 end State

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -114,15 +114,8 @@ instance : Preorder (State W V M) :=
 
 /-- Def. 0.25 in projection form: every point of the stronger state lies
 above a point of the weaker. -/
-theorem le_def {s s' : State W V M} : s ≤ s' ↔ ∀ q ∈ s', ∃ p ∈ s, p ≤ q := by
-  change upperClosure _ ≤ upperClosure _ ↔ _
-  rw [← UpperSet.coe_subset_coe]
-  constructor
-  · intro h q hq
-    exact h (subset_upperClosure hq)
-  · rintro h x ⟨q, hq, hqx⟩
-    obtain ⟨p, hp, hpq⟩ := h q hq
-    exact ⟨p, hp, hpq.trans hqx⟩
+theorem le_def {s s' : State W V M} : s ≤ s' ↔ ∀ q ∈ s', ∃ p ∈ s, p ≤ q :=
+  le_upperClosure
 
 /-- The initial information state `⊥ = W × {g_⊤}` (Def. 0.23's Λ):
 every world live, no referent defined — the range of the empty points,
@@ -205,23 +198,17 @@ theorem upperClosure_mul :
   Set.upperClosure_lubs (fun _ _ h => ⟨_, Possibility.isLUB_union h⟩) _ _
 
 /-- The merge is above the left factor. -/
-theorem left_le_mul : s ≤ s * s' := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_mul]
-  exact le_sup_left
+theorem left_le_mul : s ≤ s * s' :=
+  le_sup_left.trans_eq upperClosure_mul.symm
 
 /-- The merge is above the right factor. -/
-theorem right_le_mul : s' ≤ s * s' := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_mul]
-  exact le_sup_right
+theorem right_le_mul : s' ≤ s * s' :=
+  le_sup_right.trans_eq upperClosure_mul.symm
 
 /-- Def. 0.26's universal property: anything above both factors is
 above their merge. -/
-theorem mul_le (h : s ≤ t) (h' : s' ≤ t) : s * s' ≤ t := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_mul]
-  exact sup_le h h'
+theorem mul_le (h : s ≤ t) (h' : s' ≤ t) : s * s' ≤ t :=
+  upperClosure_mul.trans_le (sup_le h h')
 
 /-- **The merge is the least upper bound** of its factors in the
 informativeness preorder. -/
@@ -253,22 +240,16 @@ theorem upperClosure_union :
   _root_.upperClosure_union _ _
 
 /-- The union is below the left component. -/
-theorem union_le_left : s ∪ s' ≤ s := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_union]
-  exact inf_le_left
+theorem union_le_left : s ∪ s' ≤ s :=
+  upperClosure_union.trans_le inf_le_left
 
 /-- The union is below the right component. -/
-theorem union_le_right : s ∪ s' ≤ s' := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_union]
-  exact inf_le_right
+theorem union_le_right : s ∪ s' ≤ s' :=
+  upperClosure_union.trans_le inf_le_right
 
 /-- Anything below both components is below their union. -/
-theorem le_union (h : t ≤ s) (h' : t ≤ s') : t ≤ s ∪ s' := by
-  change upperClosure _ ≤ upperClosure _
-  rw [upperClosure_union]
-  exact le_inf h h'
+theorem le_union (h : t ≤ s) (h' : t ≤ s') : t ≤ s ∪ s' :=
+  (le_inf h h').trans_eq upperClosure_union.symm
 
 /-- **The union is the greatest lower bound** of its components in the
 informativeness preorder — the meet dual to `isLUB_mul`. -/

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -30,8 +30,9 @@ are partial orders, coinciding with `⊇` and `⊆`.
 - `State.merge`: consistent merge (Def. 0.26, binary), as `Set.lubs`.
 - `State.UniformAt`, `State.restrict`: the base-`X` stratum; domain
   restriction.
-- `worlds`, `Familiar`, `State.randomAssign`: worldly content,
-  familiarity, random assignment ([elliott-sudo-2025]).
+- `Familiar`, `State.randomAssign`: familiarity and random assignment
+  ([elliott-sudo-2025]); worldly content (Def. 0.23(v)'s proposition,
+  [elliott-sudo-2025]'s 𝒲) is the image `Possibility.world '' s`.
 
 ## Main results
 
@@ -262,14 +263,10 @@ theorem isGLB_union : IsGLB {s, s'} (s ∪ s') :=
 
 end State
 
-/-! ### Worldly content and familiarity -/
+/-! ### Familiarity
 
-/-- The worldly content of a state ([elliott-sudo-2025] Def. 3.1's 𝒲). -/
-def worlds (s : State W V M) : Set W :=
-  Possibility.world '' s
-
-@[simp] theorem mem_worlds {s : State W V M} {w : W} :
-    w ∈ worlds s ↔ ∃ p ∈ s, Possibility.world p = w := Iff.rfl
+The worldly content of a state — Def. 0.23(v)'s proposition,
+[elliott-sudo-2025] Def. 3.1's 𝒲 — is the image `Possibility.world '' s`. -/
 
 /-- A referent is *familiar* at a state ([elliott-sudo-2025], Def. 3.2;
 [heim-1982]'s files): defined at every point. -/

--- a/Linglib/Semantics/Dynamic/State.lean
+++ b/Linglib/Semantics/Dynamic/State.lean
@@ -8,64 +8,29 @@ import Mathlib.Order.Hom.Basic
 /-!
 # Information states
 
-An *information state* is a set of world–assignment pairs with the
-assignments partial ([kamp-vangenabith-reyle-2011], Def. 0.23;
-partiality by `Part`, after [elliott-sudo-2025], Def. 3.1). `State`
-carries *informativeness* (Def. 0.25) as its preorder, lifted along the
-upper closure of the point set: `s ≤ s'` iff every point of the
-stronger state lies above a point of the weaker. The initial state is
-`⊥`, the absurd state is `⊤ = ∅`, and consistent merge (Def. 0.26) is
-the monoid multiplication and the least upper bound.
+This file defines an *information state* — a set of possibilities with
+partial assignments ([kamp-vangenabith-reyle-2011], Def. 0.23) — and
+its order and algebra: informativeness (Def. 0.25) as the preorder
+lifted along `upperClosure`, with initial state `⊥` and absurd state
+`⊤ = ∅`; consistent merge (Def. 0.26) as the monoid `*` and least
+upper bound, dually union as greatest lower bound
+([visser-vermeulen-1996]'s monoidal processing); subsistence
+([elliott-sudo-2025], Def. 3.3) as the dual `lowerClosure` kernel; the
+uniform strata, where both kernels collapse to inclusion; and the
+classifications of a stratum as world–assignment pairs
+(`State.uniformEquiv`) and of states up to informational equivalence
+as the complete lattice of upper sets
+(`State.antisymmetrizationOrderIso`).
 
-Def. 0.23's base `X` is not a component: `State.UniformAt X` carves it
-out as a stratum, whose states are sets of world–`X`-assignment pairs
-(`State.uniformEquiv`). *Subsistence* ([elliott-sudo-2025], Def. 3.3,
-after [groenendijk-stokhof-veltman-1996] Defs. 2.8–2.9) is not a new
-relation: a point subsists in a state iff it lies in `lowerClosure` of
-its point set, a state subsists in another iff the lower closures are
-ordered — the dual closure kernel. On a uniform stratum both kernels
-are partial orders, coinciding with `⊇` and `⊆`.
-
-## Main definitions
-
-- `State`: information states, preordered by informativeness; `⊥` is
-  the initial state (Def. 0.23's Λ), `⊤ = ∅` the absurd state.
-- the `CommMonoid` instance: `*` is consistent merge (Def. 0.26,
-  binary, as `Set.lubs`) and `1 = ⊥`, so `Multiset.prod` is the finite
-  n-ary merge.
-- `State.UniformAt`, `State.restrict`: the base-`X` stratum; domain
-  restriction.
-- `Familiar`, `State.randomAssign`: familiarity and random assignment
-  ([elliott-sudo-2025]); worldly content (Def. 0.23(v)'s proposition,
-  [elliott-sudo-2025]'s 𝒲) is the image `Possibility.world '' s`.
-
-## Main results
-
-- `State.isLUB_mul`, `State.isGLB_union`: merge is the least upper
-  bound and union the greatest lower bound — with the `CommMonoid` and
-  `CovariantClass` instances, the content half of
-  [visser-vermeulen-1996]'s monoidal processing.
-- `State.UniformAt.le_iff_superset`, `State.UniformAt.lowerClosure_le_iff`,
-  `State.UniformAt.mul_eq_inter`: on a uniform stratum the orders are
-  `⊇`/`⊆` and merge is intersection.
-- `State.antisymmetrizationOrderIso`: up to informational equivalence,
-  states are the complete lattice of upper sets of possibilities.
-- `State.uniformEquiv`: uniform states at `X` are `Set (W × (X → M))`.
-
-## Implementation notes
-
-`State` is a type synonym for the point-set, in the `Lex`/`OrderDual`
-mold: membership and the set operations are re-exposed, while `≤` is
-informativeness — the kernel of `upperClosure` — rather than `⊆`, which
-remains available with its literal meaning. Neither closure kernel is
-antisymmetric on point sets (adding a comparable point is invisible),
-so `State` is a `Preorder` only; antisymmetry holds on each uniform
-stratum.
+`State` is a type synonym in the `OrderDual` mold: `≤` is
+informativeness while `⊆` keeps its literal meaning, and since neither
+kernel is antisymmetric, `State` is a `Preorder` only.
 
 ## References
 
 - [kamp-vangenabith-reyle-2011], Defs. 0.23–0.26
-- [elliott-sudo-2025], [groenendijk-stokhof-veltman-1996], [heim-1982]
+- [elliott-sudo-2025], [groenendijk-stokhof-veltman-1996],
+  [heim-1982]
 -/
 
 namespace DynamicSemantics

--- a/Linglib/Semantics/Dynamic/Transition.lean
+++ b/Linglib/Semantics/Dynamic/Transition.lean
@@ -165,12 +165,12 @@ theorem uniformEquiv_applyState (u : Transition W M X Y)
   constructor
   · intro hf
     obtain ⟨-, p, hp, hpX, hw, e, f', hpe, hqf, hrel⟩ :
-        ptOf Y f.1 f.2 ∈ u.applyState I := hf
+        ptOf Y f.1 f.2 ∈ u.applyState I := State.mem_uniformEquiv.mp hf
     have hf' : f' = f.2 := funext fun v => by
       obtain ⟨hv, hval⟩ := hqf v
       exact hval.symm
     subst hf'
-    refine ⟨e, ?_, by exact hrel⟩
+    refine ⟨e, State.mem_uniformEquiv.mpr ?_, by exact hrel⟩
     show ptOf X f.1 e ∈ I
     have hpeq : ptOf X f.1 e = p :=
       Possibility.ext hw.symm <| funext fun v =>
@@ -178,7 +178,8 @@ theorem uniformEquiv_applyState (u : Transition W M X Y)
           fun hv hd => Part.mem_unique (hpe ⟨v, hv⟩) (Part.get_mem hd)
     rw [hpeq]; exact hp
   · rintro ⟨e, hmem, hrel⟩
-    have hpI : ptOf X f.1 e ∈ I := hmem
+    have hpI : ptOf X f.1 e ∈ I := State.mem_uniformEquiv.mp hmem
+    refine State.mem_uniformEquiv.mpr ?_
     show ptOf Y f.1 f.2 ∈ u.applyState I
     exact ⟨domain_ptOf .., ptOf X f.1 e, hpI, domain_ptOf .., rfl, e,
       f.2, fun v => ⟨v.2, rfl⟩, fun v => ⟨v.2, rfl⟩, by exact hrel⟩

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -22,7 +22,7 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 
 ## Main definitions
 
-- the descent order, `Subsists` (`≺`), `subsistsIn` (`⪯`):
+- the descent order, `Subsists` (`≺`), `subsistsIn`:
   descendance and subsistence (Def. 3.3, after
   [groenendijk-stokhof-veltman-1996]).
 - `worlds`, `Familiar`: worldly information (Def. 3.1's 𝒲) and
@@ -52,7 +52,7 @@ Descent requires the larger point to *extend* the assignment, per
 [groenendijk-stokhof-veltman-1996]; [elliott-sudo-2025]'s Def. 3.3
 phrases the clause as domain inclusion, and their examples do not
 discriminate. The paper overloads `≺` for possibility-in-state and
-state-in-state subsistence (their fn. on (73)); here the latter is `⪯`.
+state-in-state subsistence (their fn. on (73)); here the latter is `subsistsIn`.
 
 The empirical comparison against full ICDRT is in
 `Studies/Hofmann2025.lean`; against PLA in `Studies/Dekker2012.lean`.
@@ -259,7 +259,7 @@ end Quantifiers
 subsists in it. -/
 def supports (s : Set (Possibility W V (Part E)))
     (φ : BilateralDen W V E) : Prop :=
-  (φ.positive s).Nonempty ∧ s ⪯ φ.positive s
+  (φ.positive s).Nonempty ∧ subsistsIn s (φ.positive s)
 
 /-- Bilateral entailment: every consistent positive update of `φ`
 supports `ψ`. -/

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -25,8 +25,9 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 - subsistence (Def. 3.3, after [groenendijk-stokhof-veltman-1996]),
   rendered as the lower closure: membership for points, `≤` of
   closures for states.
-- `worlds`, `Familiar`: worldly information (Def. 3.1's 𝒲) and
-  familiarity (Def. 3.2) — defined at every possibility, values free.
+- `Familiar`: familiarity (Def. 3.2) — defined at every possibility,
+  values free; worldly information (Def. 3.1's 𝒲) is the image
+  `Possibility.world '' s`.
 - `randomAssign`: the paper's `s[εₓ]` (43); novelty is not encoded.
 - `BilateralDen` with `atom`, `pred1`, `pred2`, `neg` (`~`), `conj`
   (`⊙`, (61)), `disj` (`⊕`, (64)), `exists_` ((44)–(45)), `forall_`.
@@ -39,9 +40,9 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 - `partition`, `partition_assertable`: every possibility subsists
   positively, subsists negatively, or is unknown.
 - `de_morgan_disj`, `de_morgan_conj`: de Morgan's laws, unlike in
-  standard dynamic semantics. (Descendance, subsistence, `worlds`,
-  `Familiar`, and random assignment now live at the root, in
-  `State.lean` — this file's vocabulary became the module's.)
+  standard dynamic semantics. (Descendance, subsistence, `Familiar`,
+  and random assignment now live at the root, in `State.lean` — this
+  file's vocabulary became the module's.)
 - `egli`: Egli's theorem for the positive dimension, definitionally.
 - `isBilateral`: the update algebra is a bilateral logic in the sense of
   `Core.Logic.Bilateral`.
@@ -239,8 +240,8 @@ introduces no anaphoric information. -/
 def exists_ (x : V) (φ : BilateralDen W V E) : BilateralDen W V E where
   positive s := φ.positive (State.randomAssign s x)
   negative s :=
-    {p ∈ s | p.world ∉ worlds (φ.positive (State.randomAssign s x)) ∧
-      p.world ∈ worlds (φ.negative (State.randomAssign s x))}
+    {p ∈ s | p.world ∉ Possibility.world '' φ.positive (State.randomAssign s x) ∧
+      p.world ∈ Possibility.world '' φ.negative (State.randomAssign s x)}
 
 /-- Universal quantification, by de Morgan duality: `∀x φ = ¬∃x ¬φ`. -/
 def forall_ (x : V) (φ : BilateralDen W V E) : BilateralDen W V E :=

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -25,7 +25,7 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 - subsistence (Def. 3.3, after [groenendijk-stokhof-veltman-1996]),
   rendered as the lower closure: membership for points, `≤` of
   closures for states.
-- `Familiar`: familiarity (Def. 3.2) — defined at every possibility,
+- `State.Familiar`: familiarity (Def. 3.2) — defined at every possibility,
   values free; worldly information (Def. 3.1's 𝒲) is the image
   `Possibility.world '' s`.
 - `randomAssign`: the paper's `s[εₓ]` (43); novelty is not encoded.
@@ -40,7 +40,7 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 - `partition`, `partition_assertable`: every possibility subsists
   positively, subsists negatively, or is unknown.
 - `de_morgan_disj`, `de_morgan_conj`: de Morgan's laws, unlike in
-  standard dynamic semantics. (Descendance, subsistence, `Familiar`,
+  standard dynamic semantics. (Descendance, subsistence, `State.Familiar`,
   and random assignment now live at the root, in `State.lean` — this
   file's vocabulary became the module's.)
 - `egli`: Egli's theorem for the positive dimension, definitionally.

--- a/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
+++ b/Linglib/Semantics/Dynamic/UpdateSemantics/Bilateral.lean
@@ -22,9 +22,9 @@ paper's separation of assertability (54) from Heimian familiarity rests.
 
 ## Main definitions
 
-- the descent order, `Subsists` (`≺`), `subsistsIn`:
-  descendance and subsistence (Def. 3.3, after
-  [groenendijk-stokhof-veltman-1996]).
+- subsistence (Def. 3.3, after [groenendijk-stokhof-veltman-1996]),
+  rendered as the lower closure: membership for points, `≤` of
+  closures for states.
 - `worlds`, `Familiar`: worldly information (Def. 3.1's 𝒲) and
   familiarity (Def. 3.2) — defined at every possibility, values free.
 - `randomAssign`: the paper's `s[εₓ]` (43); novelty is not encoded.
@@ -52,7 +52,8 @@ Descent requires the larger point to *extend* the assignment, per
 [groenendijk-stokhof-veltman-1996]; [elliott-sudo-2025]'s Def. 3.3
 phrases the clause as domain inclusion, and their examples do not
 discriminate. The paper overloads `≺` for possibility-in-state and
-state-in-state subsistence (their fn. on (73)); here the latter is `subsistsIn`.
+state-in-state subsistence (their fn. on (73)); here both are the
+lower closure — membership for points, `≤` of closures for states.
 
 The empirical comparison against full ICDRT is in
 `Studies/Hofmann2025.lean`; against PLA in `Studies/Dekker2012.lean`.
@@ -127,7 +128,7 @@ possibilities of `s` that subsist in neither dimension — the dynamic
 analogue of the third Strong Kleene truth value. -/
 def unknownUpdate (φ : BilateralDen W V E)
     (s : Set (Possibility W V (Part E))) : Set (Possibility W V (Part E)) :=
-  {p ∈ s | ¬(p ≺ φ.positive s) ∧ ¬(p ≺ φ.negative s)}
+  {p ∈ s | p ∉ lowerClosure (φ.positive s) ∧ p ∉ lowerClosure (φ.negative s)}
 
 /-- Assertability ([elliott-sudo-2025], (54)): the unknown update is
 empty — every possibility is accounted for by one of the dimensions.
@@ -141,7 +142,7 @@ theorem unknownUpdate_neg (φ : BilateralDen W V E) (s) :
     (~φ).unknownUpdate s = φ.unknownUpdate s := by
   ext p
   simp only [unknownUpdate, neg, Set.mem_setOf_eq,
-    and_comm (a := ¬(p ≺ φ.negative s))]
+    and_comm (a := p ∉ lowerClosure (φ.negative s))]
 
 /-- Worldly atoms never gap. -/
 theorem unknownUpdate_atom (pred : W → Prop) (s) :
@@ -151,23 +152,23 @@ theorem unknownUpdate_atom (pred : W → Prop) (s) :
     iff_false, not_and]
   intro hp hpos hneg
   by_cases h : pred p.world
-  · exact hpos (Subsists.of_mem ⟨hp, h⟩)
-  · exact hneg (Subsists.of_mem ⟨hp, h⟩)
+  · exact hpos (subset_lowerClosure ⟨hp, h⟩)
+  · exact hneg (subset_lowerClosure ⟨hp, h⟩)
 
 /-- Every possibility subsists positively, subsists negatively, or is
 unknown. -/
 theorem partition (φ : BilateralDen W V E) (hp : p ∈ s) :
-    (p ≺ φ.positive s) ∨ (p ≺ φ.negative s) ∨ p ∈ φ.unknownUpdate s := by
-  by_cases h1 : p ≺ φ.positive s
+    p ∈ lowerClosure (φ.positive s) ∨ p ∈ lowerClosure (φ.negative s) ∨ p ∈ φ.unknownUpdate s := by
+  by_cases h1 : p ∈ lowerClosure (φ.positive s)
   · exact Or.inl h1
-  · by_cases h2 : p ≺ φ.negative s
+  · by_cases h2 : p ∈ lowerClosure (φ.negative s)
     · exact Or.inr (Or.inl h2)
     · exact Or.inr (Or.inr ⟨hp, h1, h2⟩)
 
 /-- Under assertability, every possibility subsists in one of the
 dimensions. -/
 theorem partition_assertable (h : φ.assertable s) (hp : p ∈ s) :
-    (p ≺ φ.positive s) ∨ (p ≺ φ.negative s) := by
+    p ∈ lowerClosure (φ.positive s) ∨ p ∈ lowerClosure (φ.negative s) := by
   rcases partition φ hp with h1 | h2 | h3
   · exact Or.inl h1
   · exact Or.inr h2
@@ -259,7 +260,7 @@ end Quantifiers
 subsists in it. -/
 def supports (s : Set (Possibility W V (Part E)))
     (φ : BilateralDen W V E) : Prop :=
-  (φ.positive s).Nonempty ∧ subsistsIn s (φ.positive s)
+  (φ.positive s).Nonempty ∧ lowerClosure s ≤ lowerClosure (φ.positive s)
 
 /-- Bilateral entailment: every consistent positive update of `φ`
 supports `ψ`. -/

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -352,8 +352,8 @@ private theorem pt2_mem_anti {i j : Fin 3} (hij : i ≠ j) (a b : Bool)
 is inhabited — the pair glues. -/
 private theorem merge_anti_nonempty {i j k : Fin 3} (hij : i ≠ j)
     (hjk : j ≠ k) (hik : i ≠ k) :
-    ((anti i j).merge (anti j k)).Nonempty := by
-  refine ⟨(pt2 i j false true).union (pt2 j k true false), State.mem_merge.mpr
+    (anti i j * anti j k).Nonempty := by
+  refine ⟨(pt2 i j false true).union (pt2 j k true false), State.mem_mul.mpr
     ⟨pt2 i j false true, pt2_mem_anti hij false true (by simp),
       pt2 j k true false, pt2_mem_anti hjk true false (by simp), ?_, rfl⟩⟩
   refine Possibility.compat_iff.mpr ⟨rfl, fun v e e' he he' => ?_⟩

--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -385,10 +385,11 @@ theorem no_gluing_triangle :
   -- the target states are inhabited, so S is
   have hne : S.Nonempty := by
     rcases Set.eq_empty_or_nonempty S with rfl | h
-    · have : (∅ : State Unit (Fin 3) Bool) = anti 0 1 := by
-        simpa [State.restrict] using h01
-      exact absurd (this ▸ pt2_mem_anti (by decide) false true (by simp) :
-        pt2 0 1 false true ∈ (∅ : State Unit (Fin 3) Bool)) (by simp)
+    · have hpt : pt2 0 1 false true ∈ anti 0 1 :=
+        pt2_mem_anti (by decide) false true (by simp)
+      rw [← h01] at hpt
+      obtain ⟨q, hq, -⟩ := hpt
+      exact hq.elim
     · exact h
   obtain ⟨r, hr⟩ := hne
   -- r's restrictions land in each anticorrelation state

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -457,7 +457,7 @@ theorem not_assertable_s56 :
 /-- `x` is not familiar at (56)'s state — familiarity fails, and by
 `not_assertable_s56` so does assertability; the paper's point is that the
 converse can fail (assertability is strictly weaker). -/
-theorem not_familiar_s56 : ¬Familiar s56 0 := fun h =>
+theorem not_familiar_s56 : ¬State.Familiar s56 0 := fun h =>
   h ⟨.w0, blank⟩ (show ⟨PWorld.w0, blank⟩ ∈ s56 by simp [s56])
 
 end PartialFamiliarity

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -118,7 +118,7 @@ modulo introduced anaphoric information — state-level subsistence.
 -/
 def diamond (φ : BUSDen W E) : BUSDen W E where
   positive s := {_i ∈ s | (φ.positive s).Nonempty}
-  negative s := {_i ∈ s | subsistsIn s (φ.negative s)}
+  negative s := {_i ∈ s | lowerClosure s ≤ lowerClosure (φ.negative s)}
 
 /--
 Epistemic necessity ([elliott-sudo-2025], (77)): the dual, □φ = ¬◇¬φ.
@@ -137,8 +137,12 @@ theorem diamond_positive_eq (φ : BUSDen W E) (s) :
 
 /-- The diamond's negative update as a conditional. -/
 theorem diamond_negative_eq (φ : BUSDen W E) (s) :
-    (◇ᵇφ).negative s = if subsistsIn s (φ.negative s) then s else ∅ := by
-  by_cases h : subsistsIn s (φ.negative s) <;> simp [diamond, h]
+    (◇ᵇφ).negative s = if lowerClosure s ≤ lowerClosure (φ.negative s) then s else ∅ := by
+  by_cases h : lowerClosure s ≤ lowerClosure (φ.negative s)
+  · simp only [diamond, if_pos h]
+    exact Set.sep_eq_self_iff_mem_true.mpr fun _ _ => h
+  · simp only [diamond, if_neg h]
+    exact Set.sep_eq_empty_iff_mem_false.mpr fun _ _ => h
 
 /-- Diamond positive is a test (returns s or ∅). -/
 theorem diamond_positive_isTest (φ : BUSDen W E) :
@@ -200,7 +204,7 @@ def possible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
 
 /-- Necessity: state s makes □φ true iff s subsists in s[φ]⁺. -/
 def necessary (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
-  subsistsIn s (φ.positive s)
+  lowerClosure s ≤ lowerClosure (φ.positive s)
 
 /-- Impossibility: ¬◇φ iff s[φ]⁺ is empty. -/
 def impossible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=

--- a/Linglib/Studies/ElliottSudo2025.lean
+++ b/Linglib/Studies/ElliottSudo2025.lean
@@ -118,7 +118,7 @@ modulo introduced anaphoric information — state-level subsistence.
 -/
 def diamond (φ : BUSDen W E) : BUSDen W E where
   positive s := {_i ∈ s | (φ.positive s).Nonempty}
-  negative s := {_i ∈ s | s ⪯ φ.negative s}
+  negative s := {_i ∈ s | subsistsIn s (φ.negative s)}
 
 /--
 Epistemic necessity ([elliott-sudo-2025], (77)): the dual, □φ = ¬◇¬φ.
@@ -137,8 +137,8 @@ theorem diamond_positive_eq (φ : BUSDen W E) (s) :
 
 /-- The diamond's negative update as a conditional. -/
 theorem diamond_negative_eq (φ : BUSDen W E) (s) :
-    (◇ᵇφ).negative s = if s ⪯ φ.negative s then s else ∅ := by
-  by_cases h : s ⪯ φ.negative s <;> simp [diamond, h]
+    (◇ᵇφ).negative s = if subsistsIn s (φ.negative s) then s else ∅ := by
+  by_cases h : subsistsIn s (φ.negative s) <;> simp [diamond, h]
 
 /-- Diamond positive is a test (returns s or ∅). -/
 theorem diamond_positive_isTest (φ : BUSDen W E) :
@@ -200,7 +200,7 @@ def possible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
 
 /-- Necessity: state s makes □φ true iff s subsists in s[φ]⁺. -/
 def necessary (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
-  s ⪯ φ.positive s
+  subsistsIn s (φ.positive s)
 
 /-- Impossibility: ¬◇φ iff s[φ]⁺ is empty. -/
 def impossible (φ : BUSDen W E) (s : Set (Possibility W ℕ (Part E))) : Prop :=
@@ -454,7 +454,7 @@ theorem not_assertable_s56 :
 `not_assertable_s56` so does assertability; the paper's point is that the
 converse can fail (assertability is strictly weaker). -/
 theorem not_familiar_s56 : ¬Familiar s56 0 := fun h =>
-  h ⟨.w0, blank⟩ (by simp [s56])
+  h ⟨.w0, blank⟩ (show ⟨PWorld.w0, blank⟩ ∈ s56 by simp [s56])
 
 end PartialFamiliarity
 

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -717,7 +717,7 @@ existential introduction but the output state is a subset of the input.
 
 section BilateralBridge
 
-open DynamicSemantics (BilateralDen Possibility worlds)
+open DynamicSemantics (BilateralDen Possibility)
 open DynamicSemantics.State (randomAssign)
 open DynamicSemantics.BilateralDen (neg exists_ atom)
 
@@ -741,8 +741,8 @@ theorem exists_negative_characterization
     (x : Nat) (φ : BilateralDen W ℕ E)
     (s : Set (Possibility W ℕ (Part E))) (p : Possibility W ℕ (Part E)) :
     p ∈ (exists_ x φ).negative s ↔
-    p ∈ s ∧ p.world ∉ worlds (φ.positive (randomAssign s x)) ∧
-      p.world ∈ worlds (φ.negative (randomAssign s x)) := by
+    p ∈ s ∧ p.world ∉ Possibility.world '' φ.positive (randomAssign s x) ∧
+      p.world ∈ Possibility.world '' φ.negative (randomAssign s x) := by
   simp only [exists_, Set.mem_setOf_eq]
 
 /-- Negating an existential: the positive update of `¬∃x.φ` collects
@@ -752,8 +752,8 @@ theorem neg_exists_positive
     (x : Nat) (φ : BilateralDen W ℕ E)
     (s : Set (Possibility W ℕ (Part E))) (p : Possibility W ℕ (Part E)) :
     p ∈ (neg (exists_ x φ)).positive s ↔
-    p ∈ s ∧ p.world ∉ worlds (φ.positive (randomAssign s x)) ∧
-      p.world ∈ worlds (φ.negative (randomAssign s x)) := by
+    p ∈ s ∧ p.world ∉ Possibility.world '' φ.positive (randomAssign s x) ∧
+      p.world ∈ Possibility.world '' φ.negative (randomAssign s x) := by
   simp only [neg, exists_negative_characterization]
 
 /-- The output of `¬∃x.φ` is a subset of the input state — negated

--- a/Linglib/Studies/Heim1982/Basic.lean
+++ b/Linglib/Studies/Heim1982/Basic.lean
@@ -100,8 +100,8 @@ referents" — the defining claim of [heim-1982]. -/
 theorem indef_adds_to_dom (x : ℕ) (body : FCP W ℕ E)
     (F : State W ℕ E) {F' : State W ℕ E}
     (hres : F' ∈ FCP.indef x body F)
-    (hbody : ∀ G, Familiar G x → ∀ G' ∈ body G, Familiar G' x) :
-    Familiar F' x := by
+    (hbody : ∀ G, State.Familiar G x → ∀ G' ∈ body G, State.Familiar G' x) :
+    State.Familiar F' x := by
   obtain ⟨-, hmem⟩ := Part.mem_assert_iff.mp hres
   exact hbody _ (State.familiar_randomAssign F x) F' hmem
 
@@ -145,7 +145,7 @@ falsehood. This is modeled by FCPs being `Part`-undefined. -/
 This accounts for why "*A man₁ walked in. A man₁ sat down." is
 infelicitous when the second indefinite reuses index 1. -/
 theorem novelty_violation (x : ℕ) (body : FCP W ℕ E)
-    (F : State W ℕ E) (hne : F.Nonempty) (h : Familiar F x) :
+    (F : State W ℕ E) (hne : F.Nonempty) (h : State.Familiar F x) :
     ¬ (FCP.indef x body).admits F := by
   rintro ⟨hall, -⟩
   obtain ⟨p, hp⟩ := hne
@@ -156,7 +156,7 @@ theorem novelty_violation (x : ℕ) (body : FCP W ℕ E)
 This accounts for why "#He₁ sat down." is infelicitous at the start
 of a discourse (when no index 1 dref has been established). -/
 theorem familiarity_violation (x : ℕ) (body : FCP W ℕ E)
-    (F : State W ℕ E) (h : ¬ Familiar F x) :
+    (F : State W ℕ E) (h : ¬ State.Familiar F x) :
     ¬ (FCP.def_ x body).admits F := by
   rintro ⟨hfam, -⟩
   exact h hfam
@@ -167,7 +167,7 @@ With `indef_adds_to_dom`, this derives "A man₁ walked in. He₁ sat
 down.": the indefinite makes index 1 familiar, so the definite "he₁"
 is no presupposition failure. -/
 theorem def_familiar (x : ℕ) (body : FCP W ℕ E)
-    (F : State W ℕ E) (hfam : Familiar F x) :
+    (F : State W ℕ E) (hfam : State.Familiar F x) :
     FCP.def_ x body F = body F :=
   Part.assert_pos hfam
 

--- a/Linglib/Studies/Heim1982/Basic.lean
+++ b/Linglib/Studies/Heim1982/Basic.lean
@@ -195,11 +195,11 @@ open ExWorld ExEntity
 
 /-- Starting file: no discourse referents, all worlds open — the
 minimal state. -/
-def startFile : State ExWorld ℕ ExEntity := State.initial
+def startFile : State ExWorld ℕ ExEntity := ⊥
 
 /-- Index 1 is novel in the start file (no drefs yet). -/
 example : ∀ p ∈ startFile, p.assignment 1 = ⊥ :=
-  fun _ hp => State.mem_initial.mp hp 1
+  fun _ hp => State.mem_bot.mp hp 1
 
 /-- The start file is consistent (nonempty). -/
 example : startFile.Nonempty := ⟨Possibility.bot w₀, w₀, rfl⟩

--- a/Linglib/Studies/KampVanGenabithReyle2011.lean
+++ b/Linglib/Studies/KampVanGenabithReyle2011.lean
@@ -19,7 +19,7 @@ run against the indexed substrate (`Semantics/Dynamic/State.lean`,
 -/
 
 open FirstOrder FirstOrder.Language DRT
-open DynamicSemantics (Possibility State worlds mem_worlds)
+open DynamicSemantics (Possibility State)
 
 namespace KampVanGenabithReyle2011
 
@@ -43,9 +43,10 @@ def coinState : State Bool Unit (Fin 2) :=
 
 /-- The two states determine the same worldly content (Def. 23(v)'s
 proposition). -/
-theorem marble_worlds_eq_coin : worlds marbleState = worlds coinState := by
+theorem marble_worlds_eq_coin :
+    Possibility.world '' marbleState = Possibility.world '' coinState := by
   ext w
-  simp only [mem_worlds]
+  simp only [Set.mem_image]
   constructor
   · rintro ⟨p, ⟨hw, -⟩, rfl⟩
     exact ⟨⟨p.world, fun _ => Part.some 1⟩, ⟨hw, rfl⟩, rfl⟩

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -895,8 +895,8 @@ theorem uniformAt_toIndexedState :
   Possibility.domain_eq_empty_iff.mpr hp.2
 
 /-- The embedding is faithful on worldly content. -/
-@[simp] theorem worlds_toIndexedState :
-    worlds (toIndexedState V M s) = s := by
+@[simp] theorem world_image_toIndexedState :
+    Possibility.world '' toIndexedState V M s = s := by
   ext w
   constructor
   · rintro ⟨p, hp, rfl⟩

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -870,7 +870,7 @@ Veltman's information states are bare sets of worlds. In the substrate
 they are exactly the uniform states at the empty context:
 `toIndexedState` embeds them constructively — no choice, no inhabitant
 of `M`, unlike under the total-assignment rendering — the embedding
-reverses into the informativeness order `⊑`, and propositional update
+reverses into the informativeness order `≤`, and propositional update
 transports to point filtering. -/
 
 section IndexedFiber
@@ -905,9 +905,10 @@ theorem uniformAt_toIndexedState :
     exact ⟨⟨w, fun _ => ⊥⟩, ⟨hw, fun _ => rfl⟩, rfl⟩
 
 /-- Eliminating worlds is gaining information: the embedding reverses
-into `⊑`. -/
-theorem toIndexedState_infoLe_iff :
-    (toIndexedState V M s ⊑ toIndexedState V M t) ↔ t ⊆ s := by
+into `≤`. -/
+theorem toIndexedState_le_iff :
+    toIndexedState V M s ≤ toIndexedState V M t ↔ t ⊆ s := by
+  rw [State.le_def]
   constructor
   · intro h w hw
     obtain ⟨p, hp, hpq⟩ := h ⟨w, fun _ => ⊥⟩ ⟨hw, fun _ => rfl⟩
@@ -922,9 +923,11 @@ theorem toIndexedState_update_prop (φ : W → Prop) :
     toIndexedState V M (UpdateSemantics.Update.prop φ s) =
       {p ∈ toIndexedState V M s | φ p.world} :=
   Set.ext fun p => by
-    simp only [mem_toIndexedState, Set.mem_setOf_eq,
-      UpdateSemantics.Update.prop]
-    tauto
+    constructor
+    · rintro ⟨⟨hw, hφ⟩, hnone⟩
+      exact ⟨⟨hw, hnone⟩, hφ⟩
+    · rintro ⟨⟨hw, hnone⟩, hφ⟩
+      exact ⟨⟨hw, hφ⟩, hnone⟩
 
 end IndexedFiber
 


### PR DESCRIPTION
Makes `State` a type synonym (`OrderDual`/`Lex` mold) carrying the algebra KvGR give information states, as instances: `Preorder` (Def. 0.25 informativeness, lifted along `upperClosure`), `OrderBot`/`OrderTop` (`⊥` initial, `⊤ = ∅` absurd), and `CommMonoid` with `CovariantClass` — `*` is Def. 0.26's consistent merge (`Set.lubs`, via a new `Set.upperClosure_lubs` keystone), `1 = ⊥`, so `mul_comm/assoc/one` and `Multiset.prod` (finite n-ary merge) come from mathlib. Merge is the order's join (`isLUB_mul`), union its meet (`isGLB_union`). Subsistence needs no relation of its own: `∈ lowerClosure` / `lowerClosure _ ≤ lowerClosure _`; worldly content is `Possibility.world '' s`. The `merge`/`Subsists`/`subsistsIn`/`worlds` defs and `≺`/`⪯`/`⊑` notations are all gone.