### PR TITLE
feat(Pragmatics/NeoGricean): consistency-gated Sauerland derivation

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2633,6 +2633,7 @@ import Linglib.Studies.Santorio2018
 import Linglib.Studies.SarvasyAikhenvald2025
 import Linglib.Studies.Sassoon2013
 import Linglib.Studies.Sauerland2003
+import Linglib.Studies.Sauerland2004
 import Linglib.Studies.SauerlandStateva2011
 import Linglib.Studies.Schlenker2003
 import Linglib.Studies.Schlenker2004

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
 import Linglib.Semantics.Entailment.AsymStronger
 import Linglib.Core.Logic.Modal.Defs
 
@@ -20,12 +21,12 @@ The epistemic modalization ¬Kψ goes back to [soames-1982] and
 secondaries is formalized by [sauerland-2004], [vanrooij-schulz-2004],
 and [spector-2006]; [geurts-2010] is the textbook presentation.
 
-This file provides the modal substrate and the recipe over the
-classification it induces. The full Sauerland derivation — computing the
-secondary implicatures jointly consistent with the assertion and the
-primary set — is TODO; `secondary_blocked_if_possible` and
-`primary_possibility` are instances of K/P duality, not that consistency
-check.
+This file provides the modal substrate, the consistency-gated
+derivation (`SatisfiesPrimaries`, `SecondaryLicensed`), and the recipe
+over the belief-state classification. `secondary_blocked_if_possible`
+and `primary_possibility` are instances of K/P duality; the flagship
+multi-alternative blocking case is exercised in
+`Studies/Sauerland2004.lean`.
 
 The asymmetric-entailment primitive characterizing primary-implicature
 alternatives is `asymStrongerOn` in `Semantics/Entailment/AsymStronger.lean`;
@@ -119,6 +120,54 @@ theorem primary_possibility (e : EpistemicState W) (ψ : W → Prop) :
   simp only [knows, not_forall] at h
   obtain ⟨w, hw⟩ := h
   exact ⟨w, hw.1, hw.2⟩
+
+/-! ### The Sauerland derivation
+
+Asserting φ against scalar alternatives `alts` commits the speaker to
+Kφ plus, for each alternative, the primary implicature ¬Kψ
+([sauerland-2004] (42), verified p. 383). A secondary implicature K¬ψ
+arises exactly when it is *consistent* with that commitment set
+([sauerland-2004] (43)): here, when some epistemic state realizes the
+commitments together with K¬ψ. `secondaryLicensed_iff_reinforceable`
+identifies the single-alternative case with the reinforceability
+diagnostic; the flagship multi-alternative blocking case (K¬A blocked
+for a disjunction because it forces KB) is `Studies/Sauerland2004.lean`. -/
+
+/-- The speaker commitment after asserting φ against `alts`: the
+assertion is known (Kφ) and every primary implicature holds (¬Kψ for
+each alternative). -/
+def SatisfiesPrimaries (e : EpistemicState W) (φ : W → Prop)
+    (alts : List (W → Prop)) : Prop :=
+  knows e φ ∧ ∀ ψ ∈ alts, ¬ knows e ψ
+
+/-- Sauerland's consistency condition: the secondary implicature K¬ψ is
+licensed iff some epistemic state realizes the assertion, all primary
+implicatures, and K¬ψ jointly. -/
+def SecondaryLicensed (φ : W → Prop) (alts : List (W → Prop))
+    (ψ : W → Prop) : Prop :=
+  ∃ e : EpistemicState W, SatisfiesPrimaries e φ alts ∧ hasSecondaryImplicature e ψ
+
+/-- For a lone alternative, Sauerland licensing reduces to consistency
+of the strengthened meaning: K¬ψ is compatible with the commitments
+Kφ ∧ ¬Kψ exactly when φ ∧ ¬ψ is realizable at some world — the same
+condition under which the content ¬ψ is a non-redundant strengthening
+of φ (`Implicature.IsReinforceable φ ψ` in the diagnostics' pair
+form). -/
+theorem secondaryLicensed_iff_strengthening_consistent [Fintype W]
+    (φ ψ : W → Prop) [DecidablePred φ] [DecidablePred ψ] :
+    SecondaryLicensed φ [ψ] ψ ↔ ∃ w, φ w ∧ ¬ ψ w := by
+  constructor
+  · rintro ⟨e, ⟨hφ, _⟩, hψ⟩
+    obtain ⟨w, hw⟩ := e.nonempty
+    exact ⟨w, hφ w hw, hψ w hw⟩
+  · rintro ⟨w, hφw, hψw⟩
+    have hmem : w ∈ Finset.univ.filter (fun v => φ v ∧ ¬ ψ v) :=
+      Finset.mem_filter.2 ⟨Finset.mem_univ w, hφw, hψw⟩
+    refine ⟨⟨Finset.univ.filter (fun v => φ v ∧ ¬ ψ v), ⟨w, hmem⟩⟩, ⟨?_, ?_⟩, ?_⟩
+    · exact fun v hv => ((Finset.mem_filter.1 hv).2).1
+    · simp only [List.mem_singleton, forall_eq]
+      exact fun hk => hψw (hk w hmem)
+    · exact fun v hv => ((Finset.mem_filter.1 hv).2).2
 
 /-! ### The three-way belief-state classification
 

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -135,7 +135,9 @@ for a disjunction because it forces KB) is `Studies/Sauerland2004.lean`. -/
 
 /-- The speaker commitment after asserting φ against `alts`: the
 assertion is known (Kφ) and every primary implicature holds (¬Kψ for
-each alternative). -/
+each alternative). Per [sauerland-2004] (42), the caller supplies only
+the asymmetrically-stronger alternatives (ψ ⇒ φ but not φ ⇒ ψ, e.g. via
+`asymStrongerOn`); the definition itself does not enforce the filter. -/
 def SatisfiesPrimaries (e : EpistemicState W) (φ : W → Prop)
     (alts : List (W → Prop)) : Prop :=
   knows e φ ∧ ∀ ψ ∈ alts, ¬ knows e ψ

--- a/Linglib/Studies/Sauerland2004.lean
+++ b/Linglib/Studies/Sauerland2004.lean
@@ -1,0 +1,123 @@
+import Linglib.Pragmatics.NeoGricean.Basic
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# [sauerland-2004] — Scalar Implicatures in Complex Sentences
+[sauerland-2004]
+
+Sauerland, U. (2004). Scalar implicatures in complex sentences.
+*Linguistics and Philosophy* 27(3): 367–391.
+
+The paper's derivation for disjunction, run through the consistency-gated
+algorithm in `Pragmatics/NeoGricean/Basic.lean` (`SecondaryLicensed`,
+implementing the paper's (42)/(43), verified p. 383): asserting *A or B*
+against the alternatives {A, B, A∧B} yields the primary implicatures
+¬KA, ¬KB, ¬K(A∧B). Of the candidate secondary implicatures, K¬(A∧B)
+is consistent with the commitments and licensed
+(`conj_secondary_licensed`), while K¬A is **blocked**
+(`disjunct_secondary_blocked`): K¬A together with K(A∨B) forces KB,
+contradicting the primary ¬KB. This asymmetry — "not both" arises but
+"not A" does not — is the paper's signature prediction for disjunction,
+unavailable to accounts that negate all stronger alternatives
+indiscriminately.
+
+The four-world model `DisjWorld` distinguishes worlds by which
+disjuncts hold; the assertion *A or B* excludes only `neither`.
+-/
+
+namespace Sauerland2004
+
+open NeoGricean
+
+/-- Worlds distinguished by which of the two disjuncts hold. -/
+inductive DisjWorld where
+  | neither
+  | onlyA
+  | onlyB
+  | both
+  deriving DecidableEq, Repr, Fintype
+
+namespace DisjWorld
+
+/-- The first disjunct A. -/
+def propA : DisjWorld → Prop
+  | .onlyA => True
+  | .both => True
+  | _ => False
+
+/-- The second disjunct B. -/
+def propB : DisjWorld → Prop
+  | .onlyB => True
+  | .both => True
+  | _ => False
+
+/-- The assertion *A or B*. -/
+def disj : DisjWorld → Prop
+  | .neither => False
+  | _ => True
+
+/-- The conjunctive alternative *A and B*. -/
+def conj : DisjWorld → Prop
+  | .both => True
+  | _ => False
+
+instance : DecidablePred propA
+  | .onlyA | .both => isTrue trivial
+  | .neither | .onlyB => isFalse not_false
+
+instance : DecidablePred propB
+  | .onlyB | .both => isTrue trivial
+  | .neither | .onlyA => isFalse not_false
+
+instance : DecidablePred disj
+  | .neither => isFalse not_false
+  | .onlyA | .onlyB | .both => isTrue trivial
+
+instance : DecidablePred conj
+  | .both => isTrue trivial
+  | .neither | .onlyA | .onlyB => isFalse not_false
+
+end DisjWorld
+
+open DisjWorld
+
+/-- The scalar alternatives to *A or B*: each disjunct and the
+conjunction. -/
+def orAlts : List (DisjWorld → Prop) := [propA, propB, conj]
+
+/-- **The licensed secondary implicature**: K¬(A∧B) is consistent with
+the assertion and all primary implicatures — witnessed by the state
+considering exactly `onlyA` and `onlyB` possible. This is the "not
+both" inference of *A or B*. -/
+theorem conj_secondary_licensed : SecondaryLicensed disj orAlts conj := by
+  refine ⟨⟨{.onlyA, .onlyB}, ⟨.onlyA, by decide⟩⟩, ⟨by decide, ?_⟩, by decide⟩
+  intro ψ hψ
+  simp only [orAlts, List.mem_cons, List.not_mem_nil, or_false] at hψ
+  rcases hψ with rfl | rfl | rfl <;> decide
+
+/-- **The blocked secondary implicature**: K¬A is inconsistent with the
+commitments. From K(A∨B) and K¬A every possible world satisfies B, so
+KB holds — contradicting the primary implicature ¬KB. The disjuncts
+therefore yield only ignorance inferences, never "not A". -/
+theorem disjunct_secondary_blocked : ¬ SecondaryLicensed disj orAlts propA := by
+  rintro ⟨e, ⟨hφ, hprim⟩, hsec⟩
+  refine hprim propB (by simp [orAlts]) (fun w hw => ?_)
+  have hd := hφ w hw
+  have hna := hsec w hw
+  cases w <;> simp_all [disj, propA, propB]
+
+/-- By the A↔B symmetry of the model, K¬B is blocked identically. -/
+theorem disjunct_secondary_blocked' : ¬ SecondaryLicensed disj orAlts propB := by
+  rintro ⟨e, ⟨hφ, hprim⟩, hsec⟩
+  refine hprim propA (by simp [orAlts]) (fun w hw => ?_)
+  have hd := hφ w hw
+  have hnb := hsec w hw
+  cases w <;> simp_all [disj, propA, propB]
+
+/-- The strengthened reading of *A or B* the algorithm predicts:
+assertion plus the licensed "not both", realizable at exactly the
+one-disjunct worlds. -/
+theorem strengthened_or_realizable :
+    ∃ w, disj w ∧ ¬ conj w := ⟨.onlyA, trivial, not_false⟩
+
+end Sauerland2004

--- a/Linglib/Studies/Sauerland2004.lean
+++ b/Linglib/Studies/Sauerland2004.lean
@@ -16,7 +16,9 @@ against the alternatives {A, B, A∧B} yields the primary implicatures
 is consistent with the commitments and licensed
 (`conj_secondary_licensed`), while K¬A is **blocked**
 (`disjunct_secondary_blocked`): K¬A together with K(A∨B) forces KB,
-contradicting the primary ¬KB. This asymmetry — "not both" arises but
+contradicting the primary ¬KB. (The paper frames the same block dually:
+K¬A contradicts the possibility implicature PA entailed by the
+assertion plus ¬KB.) This asymmetry — "not both" arises but
 "not A" does not — is the paper's signature prediction for disjunction,
 unavailable to accounts that negate all stronger alternatives
 indiscriminately.


### PR DESCRIPTION
Formalizes the Sauerland 2004 derivation the audit found missing: `SatisfiesPrimaries` (Kφ + the primary ¬Kψ commitments) and `SecondaryLicensed` (K¬ψ licensed iff consistent with the commitment set), with `secondaryLicensed_iff_strengthening_consistent` reducing the single-alternative case to realizability of φ ∧ ¬ψ.

New `Studies/Sauerland2004.lean` exercises the flagship disjunction asymmetry: K¬(A∧B) licensed, K¬A/K¬B blocked (each forces knowledge of the other disjunct, contradicting a primary).