### PR TITLE
refactor(Syntax/Agreement): partial hierarchy order on Agreement.Target

### DIFF
--- a/Linglib/Studies/Corbett1991.lean
+++ b/Linglib/Studies/Corbett1991.lean
@@ -49,7 +49,7 @@ set_option autoImplicit false
 
 namespace Corbett1991
 
-open Agreement (AgreementTarget)
+open Agreement (Target)
 open Data.WALS
 
 /-! ### Substrate: semantic bases and per-language profiles -/
@@ -84,7 +84,7 @@ structure Profile where
   /-- Targets where gender agreement surfaces. An *inventory*, not the
       Agreement Hierarchy itself (which is a monotonicity claim about
       hybrid nouns; not yet formalized). -/
-  agreementTargets : List AgreementTarget := []
+  agreementTargets : List Target := []
   /-- Semantic dimensions organising the system. -/
   semanticBases : List SemanticBasis := []
   /-- Comparative-label bridge for systems the

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -271,13 +271,13 @@ theorem constraint_iii_holds :
 
 /-! ### The Agreement Hierarchy (Ch 6, §6.2) -/
 
-open Agreement (AgreementTarget)
+open Agreement (Target)
 
 /-- Whether agreement is determined by morphological form (syntactic)
     or by referential meaning (semantic).
 
-    Distinct from `Agreement.AgreementType` (grammatical vs. pronominal,
-    [bickel-nichols-2001]), which is about whether the agreement
+    Distinct from the grammatical-vs-pronominal split
+    ([bickel-nichols-2001]), which is about whether the agreement
     marker has referential autonomy. This type is about what *controls*
     agreement — the formal features of the controller or its semantic
     content. -/
@@ -292,19 +292,19 @@ structure AgreementProfile where
   /-- Controller description -/
   controller : String
   /-- Targets where semantic (meaning-driven) agreement is possible. -/
-  semanticTargets : List AgreementTarget
+  semanticTargets : List Target
 
 /-- The four positions of [corbett-1991]'s Agreement Hierarchy (`verb`
-    is not one of them — see `Agreement.AgreementTarget`). -/
-private def hierarchyPositions : List AgreementTarget :=
+    is not one of them — see `Agreement.Target`). -/
+private def hierarchyPositions : List Target :=
   [.attributive, .predicate, .relativePronoun, .personalPronoun]
 
 /-- The Agreement Hierarchy monotonicity constraint: once semantic agreement
     becomes possible at a target, it remains possible at all targets further
-    right (= lower `Agreement.AgreementTarget.rank`) on the hierarchy. -/
+    right (= lower in the `Agreement.Target` order) on the hierarchy. -/
 def AgreementProfile.RespectsHierarchy (p : AgreementProfile) : Prop :=
   ∀ t1 ∈ hierarchyPositions, ∀ t2 ∈ hierarchyPositions,
-    t1.rank ≤ t2.rank ∨ t1 ∉ p.semanticTargets ∨ t2 ∈ p.semanticTargets
+    t1 ≤ t2 ∨ t1 ∉ p.semanticTargets ∨ t2 ∈ p.semanticTargets
 
 instance (p : AgreementProfile) : Decidable p.RespectsHierarchy := by
   unfold AgreementProfile.RespectsHierarchy; infer_instance
@@ -799,7 +799,32 @@ theorem japanese_count_mass_uniform :
 
 /-! ### Predicate Hierarchy Bridge -/
 
-open Agreement (PredicateTarget)
+/-- The Predicate Hierarchy ([comrie-1975], systematized in [corbett-2000]
+    ch. 6) decomposes the predicate position of the Agreement Hierarchy into
+    a sub-hierarchy: verb < participle < adjective < noun, with semantic
+    agreement increasing monotonically toward the noun end (the finite verb
+    is the most-syntactic sub-position). Sub-positions of
+    `Agreement.Target.predicate`, at finer resolution — `verb` here is the
+    finite verb *as predicate*, distinct from the bare `Agreement.Target.verb`
+    label. -/
+inductive PredicateTarget where
+  /-- Finite verb agreement. -/
+  | verb
+  /-- Participial agreement. -/
+  | participle
+  /-- Predicate adjective (e.g. Russian *kniga interesna*). -/
+  | adjective
+  /-- Predicate noun ("she is a doctor"). -/
+  | noun
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Rank in the Predicate Hierarchy: higher = more likely to show
+    semantic agreement. verb (0) < participle (1) < adjective (2) < noun (3). -/
+def PredicateTarget.rank : PredicateTarget → ℕ
+  | .verb       => 0
+  | .participle => 1
+  | .adjective  => 2
+  | .noun       => 3
 
 /-- A predicate-hierarchy profile records the sub-positions (verb, participle,
     adjective, noun) where semantic agreement is possible for a controller —

--- a/Linglib/Studies/WechslerZlatic2000.lean
+++ b/Linglib/Studies/WechslerZlatic2000.lean
@@ -34,7 +34,7 @@ the seven a-priori possibilities, all attested (their §9, n. 3).
 * `no_single_phi_bundle_for_deca` — the §3.3 single-bundle "illusion" as
   a refutation against `Word.Agree`
 * `indexReaders_lowerSet` — the Agreement Hierarchy skeleton over
-  `Agreement.AgreementTarget`, robust to the open predicate position
+  `Agreement.Target`, robust to the open predicate position
 
 Coordinate resolution (their fn. 18) is handled in
 `Studies/DalrympleKaplan2000.lean`, to which the paper defers; the HPSG
@@ -472,20 +472,20 @@ theorem no_single_phi_bundle_for_deca :
 
 /-! ### The Agreement Hierarchy, derived (their §8)
 
-Corbett's hierarchy lives as `Agreement.AgreementTarget`; W&Z's
+Corbett's hierarchy lives as `Agreement.Target`; W&Z's
 contribution is `readsIndex`, the bundle-access derivation of it.
 Attributives lack referential indices (read only CONCORD); pronouns and
 verbs read INDEX, which alone connects to the semantics. The predicate
 position is open in the paper (§7.3): secondary predication points to
 concord (ex. 50), coordination to index (exs. 51–53). -/
 
-open _root_.Agreement (AgreementTarget)
+open _root_.Agreement (Target)
 
 /-- Whether a target reads the INDEX bundle — the precondition for
     semantic agreement (their §8). `predReadsIndex` is the open predicate
     position (§7.3, "left for future research"); the hierarchy's
     monotonicity (`indexReaders_lowerSet`) holds for either value. -/
-def readsIndex (predReadsIndex : Bool) : AgreementTarget → Prop
+def readsIndex (predReadsIndex : Bool) : Target → Prop
   | .attributive => False
   | .predicate => predReadsIndex
   | .relativePronoun => True
@@ -496,15 +496,21 @@ instance (p : Bool) : DecidablePred (readsIndex p) := fun t => by
   cases t <;> simp only [readsIndex] <;> infer_instance
 
 /-- **The hierarchy skeleton**: the index readers form a lower set in the
-    `AgreementTarget` rank (higher rank = more syntactic), so semantic
+    `Agreement.Target` order (higher = more syntactic), so semantic
     agreement can surface only at more-semantic targets — and this holds
     whichever way the open predicate position resolves. This is the
     *categorical* claim W&Z derive (their §8, "concord elements should
     never show semantic agreement unless the pronouns do"); it explains
     but does not reproduce Corbett's gradient, corpus-level likelihood
-    law ([corbett-1998]; their fn. 21). -/
-theorem indexReaders_lowerSet (p : Bool) (t u : AgreementTarget)
-    (h : u.rank ≤ t.rank) : readsIndex p t → readsIndex p u := by
+    law ([corbett-1998]; their fn. 21). W&Z rank no INDEX-reader above
+    another, and none is needed: `verb`, off the hierarchy, reads INDEX
+    outright (`readsIndex_verb`). -/
+theorem indexReaders_lowerSet (p : Bool) (t u : Target)
+    (h : u ≤ t) : readsIndex p t → readsIndex p u := by
   cases p <;> revert t u <;> decide
+
+/-- Verbs read INDEX unconditionally (they agree in person, which only
+    INDEX carries) — no hierarchy position needed. -/
+theorem readsIndex_verb (p : Bool) : readsIndex p .verb := trivial
 
 end WechslerZlatic2000

--- a/Linglib/Syntax/Agreement/Basic.lean
+++ b/Linglib/Syntax/Agreement/Basic.lean
@@ -2,30 +2,32 @@ import Mathlib.Order.Nat
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Agreement targets [corbett-1979]
+# Agreement targets
 
-`Agreement.Target` enumerates the morphosyntactic positions where agreement
-surfaces: the four positions of the Agreement Hierarchy ([corbett-1979];
-[corbett-1991] ch. 8; [corbett-2006]) — attributive > predicate > relative
-pronoun > personal pronoun, along which the likelihood of *semantic* (rather
-than syntactic) agreement increases monotonically from left to right — plus
-`verb` for languages with verbal gender/number agreement.
+This file defines the morphosyntactic positions where agreement surfaces,
+ordered by Corbett's Agreement Hierarchy ([corbett-1979]; [corbett-1991]
+ch. 8; [corbett-2006]): attributive > predicate > relative pronoun >
+personal pronoun, with semantic (rather than syntactic) agreement
+increasingly likely from left to right.
 
-`verb` is a label only: it is not a fifth position of Corbett's hierarchy,
-and the literature licenses no ranking for it. [wechsler-zlatic-2000]
-classify verbs with the pronouns as INDEX-readers but do not rank the
-INDEX-readers among themselves (`WechslerZlatic2000.indexReaders_lowerSet`
-needs no such ranking), while [comrie-1975]'s Predicate Hierarchy grades
-semantic-agreement *likelihood* within the predicate position (finite verb
-least likely; `Corbett2000.PredicateTarget`). Reading INDEX and showing
-semantic agreement are orthogonal axes — INDEX features can be lexically
-fixed — so the two classifications are not rival rankings of `verb`, and
-neither is encoded here. Accordingly the order on `Target` is partial:
-`hierarchyRank` places the four canonical positions on a chain (higher =
-more syntactic) and leaves `verb` comparable only to itself.
+## Main declarations
 
-This type is shared by gender typology (`Studies/Corbett1991.lean`) and
-number agreement (`Studies/Corbett2000.lean`).
+* `Agreement.Target`: the four hierarchy positions, plus `verb` for
+  languages with verbal gender/number agreement.
+* `Agreement.Target.hierarchyRank`: position on the hierarchy (higher =
+  more syntactic); `none` for `verb`.
+* The `PartialOrder` instance: the four positions form a chain; `verb` is
+  comparable only to itself.
+
+## Implementation notes
+
+`verb` is not a position of Corbett's hierarchy, and no ranking of it is
+encoded. [wechsler-zlatic-2000] classify verbs with the pronouns as
+INDEX-readers without ranking the INDEX-readers among themselves
+(`WechslerZlatic2000.indexReaders_lowerSet`), and [comrie-1975]'s Predicate
+Hierarchy grades semantic-agreement likelihood among predicate
+sub-positions (`Corbett2000.PredicateTarget`); the two classifications are
+orthogonal. Hence the order is partial rather than linear.
 -/
 
 namespace Agreement

--- a/Linglib/Syntax/Agreement/Basic.lean
+++ b/Linglib/Syntax/Agreement/Basic.lean
@@ -2,27 +2,27 @@ import Mathlib.Order.Nat
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Agreement Target Hierarchy [corbett-1979]
+# Agreement targets [corbett-1979]
 
-The Agreement Hierarchy ([corbett-1979]; [corbett-1991] ch. 8) has four
-positions — attributive > predicate > relative pronoun > personal pronoun —
-along which the likelihood of *semantic* (rather than syntactic) agreement
-increases monotonically from left to right.
+`Agreement.Target` enumerates the morphosyntactic positions where agreement
+surfaces: the four positions of the Agreement Hierarchy ([corbett-1979];
+[corbett-1991] ch. 8; [corbett-2006]) — attributive > predicate > relative
+pronoun > personal pronoun, along which the likelihood of *semantic* (rather
+than syntactic) agreement increases monotonically from left to right — plus
+`verb` for languages with verbal gender/number agreement.
 
-The `AgreementTarget` enum below additionally carries a `verb` target for
-languages with verbal gender/number agreement. `verb` is a linglib
-refinement, not a fifth position of Corbett's hierarchy, and its placement
-is theory-laden: it is ranked below personal pronoun (the semantic end),
-following [wechsler-zlatic-2000]'s classification of verbal agreement as
-INDEX-reading (see `WechslerZlatic2000.indexReaders_lowerSet`, which
-depends on this placement). Corbett instead subsumes verbal agreement
-under the *predicate* position, where his Predicate Hierarchy
-([comrie-1975]) makes the finite verb the most-syntactic sub-position —
-the opposite end. That view is formalized separately as
-`PredicateTarget` below; the two codings are a genuine cross-framework
-disagreement, kept visible rather than merged. Theorems about the
-four-position hierarchy proper should quantify over the four canonical
-positions only (as `Corbett2000.hierarchyPositions` does).
+`verb` is a label only: it is not a fifth position of Corbett's hierarchy,
+and the literature licenses no ranking for it. [wechsler-zlatic-2000]
+classify verbs with the pronouns as INDEX-readers but do not rank the
+INDEX-readers among themselves (`WechslerZlatic2000.indexReaders_lowerSet`
+needs no such ranking), while [comrie-1975]'s Predicate Hierarchy grades
+semantic-agreement *likelihood* within the predicate position (finite verb
+least likely; `Corbett2000.PredicateTarget`). Reading INDEX and showing
+semantic agreement are orthogonal axes — INDEX features can be lexically
+fixed — so the two classifications are not rival rankings of `verb`, and
+neither is encoded here. Accordingly the order on `Target` is partial:
+`hierarchyRank` places the four canonical positions on a chain (higher =
+more syntactic) and leaves `verb` comparable only to itself.
 
 This type is shared by gender typology (`Studies/Corbett1991.lean`) and
 number agreement (`Studies/Corbett2000.lean`).
@@ -30,143 +30,57 @@ number agreement (`Studies/Corbett2000.lean`).
 
 namespace Agreement
 
-/-- Morphosyntactic targets where agreement can surface, ranked by the
-    Agreement Hierarchy ([corbett-1979]). `verb` is a linglib refinement
-    placed at the semantic end per [wechsler-zlatic-2000] — NOT a
-    position of Corbett's hierarchy; see the module docstring for the
-    competing Corbett/Comrie placement (`PredicateTarget`).
-
-    Higher rank = closer to the controller, agreement more syntactic.
-    Lower rank = further from the controller, agreement more semantic. -/
-inductive AgreementTarget where
-  | attributive       -- attributive adjective (e.g. French *un bon livre*)
-  | predicate         -- predicate adjective/verb (e.g. Russian *kniga interesnaja*)
-  | relativePronoun   -- relative pronoun (e.g. German *der/die/das*)
-  | personalPronoun   -- personal pronoun (e.g. English *he/she/it*)
-  | verb              -- verb (e.g. Hindi *laRkaa aayaa / laRkii aayii*)
+/-- A morphosyntactic target where agreement can surface: the four positions
+    of the Agreement Hierarchy ([corbett-1979]), plus `verb` for verbal
+    gender/number agreement (off the hierarchy — see the module docstring). -/
+inductive Target where
+  /-- Attributive adjective (e.g. French *un bon livre*). -/
+  | attributive
+  /-- Predicate adjective/verb (e.g. Russian *kniga interesna*). -/
+  | predicate
+  /-- Relative pronoun (e.g. German *der/die/das*). -/
+  | relativePronoun
+  /-- Personal pronoun (e.g. English *he/she/it*). -/
+  | personalPronoun
+  /-- Verb (e.g. Hindi *laRkaa aayaa* vs *laRkii aayii*). A label only,
+      not a fifth hierarchy position: `hierarchyRank` is `none`. -/
+  | verb
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- Numeric rank in the Agreement Hierarchy: higher = more likely to show
-    agreement (more syntactic); lower = less likely (more semantic). -/
-def AgreementTarget.rank : AgreementTarget → Nat
-  | .attributive     => 4
-  | .predicate       => 3
-  | .relativePronoun => 2
-  | .personalPronoun => 1
-  | .verb            => 0
+namespace Target
 
-/-- The Agreement Hierarchy is a `LinearOrder` lifted from the rank.
-    Provides `≤`, `<`, `min`, `max`, `Finset.sort`, etc. for free. -/
-instance : LinearOrder AgreementTarget :=
-  LinearOrder.lift' AgreementTarget.rank
-    (fun a b h => by cases a <;> cases b <;> simp_all [AgreementTarget.rank])
+/-- Position on the four-point Agreement Hierarchy, higher = more syntactic
+    (more likely to show syntactic agreement); `none` for `verb`, which is
+    off the hierarchy. -/
+def hierarchyRank : Target → Option ℕ
+  | .attributive     => some 3
+  | .predicate       => some 2
+  | .relativePronoun => some 1
+  | .personalPronoun => some 0
+  | .verb            => none
 
-/-- The hierarchy rank is injective — derivable from the `LinearOrder`
-    instance, restated here as a named lemma for direct invocation. -/
-theorem AgreementTarget.rank_injective :
-    Function.Injective AgreementTarget.rank :=
-  fun a b h => by cases a <;> cases b <;> simp_all [AgreementTarget.rank]
+private def HierarchyLE (t u : Target) : Prop :=
+  match t.hierarchyRank, u.hierarchyRank with
+  | some rt, some ru => rt ≤ ru
+  | none, none => True
+  | _, _ => False
 
--- ============================================================================
--- § 2: Predicate Hierarchy ([comrie-1975]; [corbett-2000] Ch 6)
--- ============================================================================
+private instance : DecidableRel HierarchyLE := fun t u => by
+  cases t <;> cases u <;> simp only [HierarchyLE, hierarchyRank] <;> infer_instance
 
-/-- The Predicate Hierarchy ([comrie-1975], systematised by
-    [corbett-2000]) decomposes the predicate position on the Agreement
-    Hierarchy into a sub-hierarchy:
-    verb < participle < adjective < noun.
+/-- The Agreement Hierarchy as a partial order: `t ≤ u` iff both occupy
+    hierarchy positions and `t`'s is at most as syntactic as `u`'s (so
+    `personalPronoun ≤ attributive`); `verb`, off the hierarchy, is
+    comparable only to itself. -/
+instance : PartialOrder Target where
+  le := HierarchyLE
+  le_refl := by decide
+  le_trans := by decide
+  le_antisymm := by decide
 
-    Semantic agreement increases monotonically along this sub-hierarchy:
-    if semantic agreement is possible on a verb, it is possible on a
-    participle; if on a participle, then on an adjective; etc.
+instance : DecidableRel ((· ≤ ·) : Target → Target → Prop) :=
+  fun t u => inferInstanceAs (Decidable (HierarchyLE t u))
 
-    This is orthogonal to `AgreementTarget`, which treats `.predicate` and
-    `.verb` as two positions on the main hierarchy. The Predicate Hierarchy
-    provides finer resolution *within* the predicate position. -/
-inductive PredicateTarget where
-  | verb         -- finite verb agreement (= AgreementTarget.verb)
-  | participle   -- participial agreement
-  | adjective    -- predicate adjective (= AgreementTarget.predicate)
-  | noun         -- predicate noun ("she is a doctor")
-  deriving DecidableEq, Repr, Inhabited
-
-/-- Rank in the Predicate Hierarchy: higher = more likely to show
-    semantic agreement. verb (0) < participle (1) < adjective (2) < noun (3). -/
-def PredicateTarget.rank : PredicateTarget → Nat
-  | .verb       => 0
-  | .participle => 1
-  | .adjective  => 2
-  | .noun       => 3
-
-/-- The Predicate Hierarchy is a `LinearOrder` lifted from the rank. -/
-instance : LinearOrder PredicateTarget :=
-  LinearOrder.lift' PredicateTarget.rank
-    (fun a b h => by cases a <;> cases b <;> simp_all [PredicateTarget.rank])
-
-/-- The Predicate Hierarchy rank is injective. -/
-theorem PredicateTarget.rank_injective :
-    Function.Injective PredicateTarget.rank :=
-  fun a b h => by cases a <;> cases b <;> simp_all [PredicateTarget.rank]
-
-/-- Map a `PredicateTarget` to the corresponding `AgreementTarget`.
-    Verb maps to `.verb`; participle/adjective/noun all map to
-    `.predicate`. Many-to-one, monotone (preserves the `≤` order
-    once you account for rank collapsing inside `.predicate`). -/
-def PredicateTarget.toAgreementTarget : PredicateTarget → AgreementTarget
-  | .verb       => .verb
-  | .participle => .predicate
-  | .adjective  => .predicate
-  | .noun       => .predicate
-
--- ============================================================================
--- § 3: Agreement Type ([bickel-nichols-2001])
--- ============================================================================
-
-/-- Whether agreement markers have referential autonomy.
-    [bickel-nichols-2001]
-
-    - **grammatical**: pure agreement — the marker cannot stand alone as
-      an argument; an independent NP is required (English *she walk-s*,
-      the *-s* cannot replace *she*)
-    - **pronominal**: cross-referencing — the marker can function as the
-      sole expression of the argument; an independent NP is optional
-      (Swahili *a-li-ki-soma (kitabu)* — the prefixes suffice without
-      the noun)
-
-    This distinction is orthogonal to the Agreement Hierarchy: a language
-    can have pronominal agreement on verbs but grammatical agreement on
-    adjectives, or vice versa. -/
-inductive AgreementType where
-  | grammatical   -- pure agreement (cannot stand alone as argument)
-  | pronominal    -- cross-referencing (can be sole argument expression)
-  deriving DecidableEq, Repr, Inhabited
-
--- ============================================================================
--- § 4: Agreement Direction ([bickel-nichols-2001])
--- ============================================================================
-
-/-- Direction of agreement: which element originates ("drives") the features.
-    [bickel-nichols-2001] §9
-
-    - **headDriven**: the phrasal head provides features that percolate to
-      its dependents — dependents carry the agreement morphology.
-      (German/Watam NP concord: noun's gender/number → adjective, det;
-      = dependent marking in the sense of §3.)
-    - **dependentDriven**: a dependent provides features that the head
-      matches — the head carries the agreement morphology.
-      (Belhare/Swahili verb agreement: subject's person/number → verb;
-      = head marking in the sense of §3.)
-
-    Related to but distinct from `Morphology.LocusOfMarking`: locus
-    is a language-level WALS typological parameter classifying where *all*
-    grammatical relations are marked (head, dependent, double, zero).
-    `AgreementDirection` is phenomenon-specific — a language can be
-    overall head-marking (`LocusOfMarking.headMarking`) yet have specific
-    head-driven agreement (e.g., NP concord in an otherwise head-marking
-    language). -/
-inductive AgreementDirection where
-  | headDriven       -- head drives features → dependents carry morphology (NP concord)
-  | dependentDriven  -- dependent drives features → head carries morphology (verb agreement)
-  deriving DecidableEq, Repr, Inhabited
+end Target
 
 end Agreement

--- a/Linglib/Syntax/Agreement/Basic.lean
+++ b/Linglib/Syntax/Agreement/Basic.lean
@@ -5,10 +5,9 @@ import Mathlib.Tactic.DeriveFintype
 # Agreement targets
 
 This file defines the morphosyntactic positions where agreement surfaces,
-ordered by Corbett's Agreement Hierarchy ([corbett-1979]; [corbett-1991]
-ch. 8; [corbett-2006]): attributive > predicate > relative pronoun >
-personal pronoun, with semantic (rather than syntactic) agreement
-increasingly likely from left to right.
+ordered by Corbett's Agreement Hierarchy: attributive > predicate >
+relative pronoun > personal pronoun, with semantic (rather than syntactic)
+agreement increasingly likely from left to right.
 
 ## Main declarations
 
@@ -28,6 +27,12 @@ INDEX-readers without ranking the INDEX-readers among themselves
 Hierarchy grades semantic-agreement likelihood among predicate
 sub-positions (`Corbett2000.PredicateTarget`); the two classifications are
 orthogonal. Hence the order is partial rather than linear.
+
+## References
+
+* [corbett-1979] — the Agreement Hierarchy
+* [corbett-1991], ch. 8 — the hierarchy applied to gender
+* [corbett-2006] — the standard monograph on agreement
 -/
 
 namespace Agreement

--- a/Linglib/Syntax/Agreement/Controller.lean
+++ b/Linglib/Syntax/Agreement/Controller.lean
@@ -6,8 +6,8 @@ While `Syntax/Agreement/Basic.lean` enumerates WHERE agreement morphology
 surfaces (Corbett 1991 Agreement Hierarchy), this file enumerates WHICH
 GRAMMATICAL ROLE the controlling NP plays. The two axes are orthogonal:
 a language can have subject-controlled verb agreement
-(`Controller.subj` × `AgreementTarget.verb`) and possessor-controlled
-attributive agreement (`Controller.poss` × `AgreementTarget.attributive`).
+(`Controller.subj` × `Target.verb`) and possessor-controlled
+attributive agreement (`Controller.poss` × `Target.attributive`).
 
 ## Typological labels
 

--- a/Linglib/Syntax/Agreement/Profile.lean
+++ b/Linglib/Syntax/Agreement/Profile.lean
@@ -44,6 +44,6 @@ inductive Dimension where
     the dimensions in which that target's form covaries. `∅` = invariant
     (bare) forms. Conditioned splits (e.g. Russian verbs: person/number in
     nonpast, gender/number in past) are unioned, not modeled. -/
-abbrev Profile := AgreementTarget → Finset Dimension
+abbrev Profile := Target → Finset Dimension
 
 end Agreement


### PR DESCRIPTION
Deep-audit follow-up on `Syntax/Agreement/Basic.lean`: rename `AgreementTarget` → `Agreement.Target` (stutter rule) and replace the total `LinearOrder` — whose `verb < personalPronoun` placement no cited framework endorses (W&Z's INDEX-readers are unranked among themselves; Comrie grades likelihood, not access) — with the consensus four-position partial order (`hierarchyRank : Option ℕ`, `verb` off-hierarchy by construction).

- Consumers now use `≤` on the type (`Corbett2000.RespectsHierarchy`, `WechslerZlatic2000.indexReaders_lowerSet`, new `readsIndex_verb`) instead of comparing rank numerals.
- Delete dead substrate (`AgreementType`, `AgreementDirection`, `toAgreementTarget`, unused `rank_injective`/orders); demote single-consumer `PredicateTarget` into `Studies/Corbett2000.lean`.