### PR TITLE
feat(Morphology/Exponence): complete the VI engine square

### DIFF
--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -569,7 +569,7 @@ inductive ImpoverishmentContext where
 
     [adamson-2024] ex. 63: Jarawara [MASC] → ∅ in the context of
     [PL] or [PARTICIPANT]. -/
-structure ImpoverishmentRule where
+structure GenderImpoverishmentRule where
   /-- The feature to be deleted. -/
   targetGender : GenderVal
   /-- The conditioning context (feature that triggers deletion). -/
@@ -577,7 +577,7 @@ structure ImpoverishmentRule where
   deriving DecidableEq, Repr
 
 /-- Apply impoverishment: if the rule matches, delete the gender feature. -/
-def ImpoverishmentRule.apply (rule : ImpoverishmentRule)
+def GenderImpoverishmentRule.apply (rule : GenderImpoverishmentRule)
     (phi : PhiBundle) (contextActive : Bool) : PhiBundle :=
   if contextActive then
     match phi.gender with

--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Minimalist.Agree.Basic
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Exponence.Rule
+import Linglib.Morphology.DM.VocabularyInsertion
 import Mathlib.Data.List.MinMax
 
 /-!
@@ -169,6 +170,75 @@ theorem VocabEntry.toRule_moreSpecific_of_superset {e e' : VocabEntry}
     · rcases hctx with h2 | h2
       · exact Or.inl (h.trans h2)
       · exact Or.inr (h.trans h2)
+
+/-- Every entry matches its own feature bundle. -/
+theorem VocabEntry.matchesFeatures_self (e : VocabEntry) :
+    e.MatchesFeatures e.features := by
+  rw [VocabEntry.MatchesFeatures, List.all_eq_true]
+  intro ef hef
+  exact List.any_eq_true.mpr ⟨ef, hef, beq_self_eq_true ef⟩
+
+/-- Derived specificity, characterized: `e` is at least as specific as
+`e'` in the shared core iff `e'`'s features are a subset of `e`'s and
+`e'`'s context restriction is compatible. Upgrades
+`toRule_moreSpecific_of_superset` to an iff — over feature bundles the
+intensional superset order IS the derived order, with no faithfulness
+assumption (contrast `Morphology.DM.VI.SpecificityFaithful`, which the
+opaque-predicate engine must stipulate). -/
+theorem VocabEntry.toRule_moreSpecific_iff {e e' : VocabEntry} :
+    e.toRule.MoreSpecific e'.toRule ↔
+      (∀ f ∈ FeatureBundle.toGramFeatures e'.features,
+        f ∈ FeatureBundle.toGramFeatures e.features) ∧
+      (e'.context = none ∨ e'.context = e.context) := by
+  constructor
+  · intro h
+    obtain ⟨hm', hctx'⟩ :=
+      h (c := (e.features, e.context)) ⟨e.matchesFeatures_self, Or.inr rfl⟩
+    refine ⟨?_, hctx'⟩
+    rw [VocabEntry.MatchesFeatures, List.all_eq_true] at hm'
+    intro f hf
+    obtain ⟨tf, htf, hbeq⟩ := List.any_eq_true.mp (hm' f hf)
+    exact (beq_iff_eq.mp hbeq) ▸ htf
+  · exact λ ⟨hf, hc⟩ => toRule_moreSpecific_of_superset hf hc
+
+/-! #### Bridge to the opaque-predicate engine -/
+
+/-- Embed a vocabulary entry into the opaque-predicate engine
+(`Morphology.DM.VI.VocabItem`): the context check is feature matching,
+the root check is the category restriction, and the stipulated rank is
+the feature count. -/
+def VocabEntry.toVocabItem (e : VocabEntry) :
+    Morphology.DM.VI.VocabItem FeatureBundle (Option Cat) where
+  exponent := e.exponent
+  contextMatch := λ t => decide (e.MatchesFeatures t)
+  rootMatch := some (λ c => decide (e.context = none ∨ e.context = c))
+  specificity := (FeatureBundle.toGramFeatures e.features).length
+
+/-- The embedding tracks applicability: the opaque engine's `matches`
+agrees with `Matches`. -/
+theorem VocabEntry.toVocabItem_matches (e : VocabEntry)
+    (t : FeatureBundle) (c : Option Cat) :
+    e.toVocabItem.matches t c = true ↔ e.Matches t c := by
+  simp [Morphology.DM.VI.VocabItem.matches, VocabEntry.toVocabItem,
+    VocabEntry.Matches]
+
+/-- The two engines' shared-core views agree: the embedded item's rule
+applies exactly where the entry's rule does. -/
+theorem VocabEntry.toVocabItem_toRule_applies (e : VocabEntry)
+    (tc : FeatureBundle × Option Cat) :
+    e.toVocabItem.toRule.Applies tc ↔ e.toRule.Applies tc :=
+  e.toVocabItem_matches tc.1 tc.2
+
+/-- Derived specificity transfers along the embedding — the cross-engine
+translation is faithful to the shared core's order. -/
+theorem VocabEntry.toVocabItem_toRule_moreSpecific {e f : VocabEntry} :
+    e.toVocabItem.toRule.MoreSpecific f.toVocabItem.toRule ↔
+      e.toRule.MoreSpecific f.toRule := by
+  constructor <;> intro h c hc
+  · exact (f.toVocabItem_toRule_applies c).mp
+      (h ((e.toVocabItem_toRule_applies c).mpr hc))
+  · exact (f.toVocabItem_toRule_applies c).mpr
+      (h ((e.toVocabItem_toRule_applies c).mp hc))
 
 /-- Under a specificity stipulation faithful to the derived order on
 the matching entries, `bestMatch` returns an Elsewhere winner of the

--- a/Linglib/Morphology/Exponence/Rule.lean
+++ b/Linglib/Morphology/Exponence/Rule.lean
@@ -15,17 +15,30 @@ applicable rule.
 Framework engines specialize the context type and expose *intensional*
 context specifications from which the derived order is computable:
 
-* `Morphology.Containment.ExponenceRule` — contexts are the grades of a
-  containment hierarchy; specificity is threshold comparison
-  (`Containment.ExponenceRule.moreSpecific_iff_threshold_le`).
+* `Morphology.Containment.ExponenceRule`
+  (`Morphology/Exponence/Hierarchy.lean`) — contexts are the grades of
+  a containment hierarchy; specificity is threshold comparison
+  (`moreSpecific_iff_threshold_le`). The same carrier's **Superset**
+  reading (`Morphology/Nanosyntax/Superset.lean`, `toSupersetRule`)
+  carries the dual order — span comparison — and over context-free
+  vocabularies the two orders are exact mirrors
+  (`toRule_moreSpecific_iff_toSupersetRule`).
 * `Minimalist.VocabEntry` (`Morphology/DM/VocabSimple.lean`) — contexts
-  are feature bundles; feature-superset entries are at least as
-  specific.
+  are feature bundles; the feature-superset order is exactly the
+  derived order (`VocabEntry.toRule_moreSpecific_iff`), and the entry
+  embeds into the opaque-predicate engine specificity-faithfully
+  (`VocabEntry.toVocabItem`).
 * `Morphology.DM.VI.VocabItem` — contexts are opaque predicates, so the
   derived order is not computable and the engine stipulates a
   `specificity` rank; `SpecificityFaithful` states that the stipulation
   refines the derived order, and under it the engine's selection is an
   Elsewhere winner.
+* `Morphology.Nanosyntax.TreeLexEntry`
+  (`Morphology/Nanosyntax/TreeSpellout.lean`) — contexts are syntactic
+  trees; specificity is reverse tree containment
+  (`toRule_moreSpecific_iff`), and smallest-tree selection is an
+  Elsewhere winner with no side conditions
+  (`treeSelect_isElsewhereWinner`).
 
 ## Main declarations
 

--- a/Linglib/Morphology/MorphProfile.lean
+++ b/Linglib/Morphology/MorphProfile.lean
@@ -72,7 +72,7 @@ inductive Flexivity where
     Distinct from `ExponenceScope` (B&N's broader cumulative/separative
     parameter which applies to all morphological categories, not just case).
     [bickel-nichols-2001] -/
-inductive Exponence where
+inductive CaseExponence where
   | monoexponential
   | polyexponential
   | noCase
@@ -239,7 +239,7 @@ structure MorphProfile where
   /-- Ch 20: Fusion type -/
   fusion : Fusion
   /-- Ch 21: Exponence type -/
-  exponence : Exponence
+  exponence : CaseExponence
   /-- Ch 22: Inflectional synthesis of the verb -/
   verbSynthesis : VerbSynthesis
   /-- Locus of marking (derived from Ch 23 clause-level; fallback for absent languages) -/
@@ -297,7 +297,7 @@ def fromWALS20A : Data.WALS.F20A.FusionType → Option Fusion
 
 /-- Convert WALS 21A exponence type to the local `Exponence` classification.
     Returns `none` for `noCase` (no information about overall exponence). -/
-def fromWALS21A : Data.WALS.F21A.ExponenceType → Option Exponence
+def fromWALS21A : Data.WALS.F21A.ExponenceType → Option CaseExponence
   | .monoexponentialCase  => some .monoexponential
   | .caseNumber           => some .polyexponential
   | .caseReferentiality   => some .polyexponential
@@ -431,7 +431,7 @@ def locusClauseToLocus : LocusClause → LocusOfMarking
 def walsFusion (iso : String) : Option Fusion :=
   (Data.WALS.F20A.lookupISO iso).bind (fromWALS20A ·.value)
 
-def walsExponence (iso : String) : Option Exponence :=
+def walsExponence (iso : String) : Option CaseExponence :=
   (Data.WALS.F21A.lookupISO iso).bind (fromWALS21A ·.value)
 
 def walsVerbSynthesis (iso : String) : Option VerbSynthesis :=
@@ -501,7 +501,7 @@ def walsVerbalNumber (iso : String) : Option VerbalNumber :=
 def MorphProfile.fromWALS
     (language iso : String)
     (fusionFb : Fusion)
-    (exponenceFb : Exponence)
+    (exponenceFb : CaseExponence)
     (verbSynthesisFb : VerbSynthesis)
     (locusFb : LocusOfMarking)
     (prefixSuffixFb : PrefixSuffix)

--- a/Linglib/Morphology/Nanosyntax/Superset.lean
+++ b/Linglib/Morphology/Nanosyntax/Superset.lean
@@ -425,4 +425,66 @@ example :
     spellout homophonous 1 = some "B" ∧
     spellout homophonous 2 = some "A" := by decide
 
+/-! ### The shared exponence core
+
+One carrier, two `Rule` views: the Subset reading
+(`ExponenceRule.toRule`, `Morphology/Exponence/Hierarchy.lean`) and the
+Superset reading below instantiate the shared core with dual
+applicability conditions and opposite derived-specificity orders. -/
+
+section ExponenceCore
+
+open Morphology.Exponence
+
+/-- View an entry under the **Superset** reading as a rule of the
+shared exponence core: applicability is `Matches` (the stored
+constituent contains the structure), dually to `ExponenceRule.toRule`'s
+Subset reading. -/
+def ExponenceRule.toSupersetRule (it : ExponenceRule n F) :
+    Exponence.Rule (Fin n) F :=
+  ⟨it.exponent, it.Matches⟩
+
+/-- Minimize Junk is the derived specificity of the shared core under
+the Superset reading: smaller span = more specific. -/
+theorem ExponenceRule.toSupersetRule_moreSpecific_iff
+    {it jt : ExponenceRule n F} :
+    it.toSupersetRule.MoreSpecific jt.toSupersetRule ↔ it.spans ≤ jt.spans :=
+  ExponenceRule.matches_imp_iff_spans_le
+
+/-- **Subset/Superset duality** over context-free vocabularies (the
+nanosyntax idealization): DM-style Subset specificity of `it` over `jt`
+is Superset specificity of `jt` over `it`. With contextual restrictions
+the Subset order compares thresholds, not spans, and the duality is
+only one-directional. -/
+theorem ExponenceRule.toRule_moreSpecific_iff_toSupersetRule
+    {it jt : ExponenceRule n F}
+    (hit : it.context = none) (hjt : jt.context = none) :
+    it.toRule.MoreSpecific jt.toRule ↔
+      jt.toSupersetRule.MoreSpecific it.toSupersetRule := by
+  rw [ExponenceRule.toRule_moreSpecific_iff,
+    ExponenceRule.moreSpecific_iff_threshold_le,
+    ExponenceRule.toSupersetRule_moreSpecific_iff]
+  unfold ExponenceRule.threshold
+  rw [hit, hjt]
+  simp
+
+/-- Minimize-Junk selection is an Elsewhere winner of the shared core
+under the Superset reading — with no side conditions: over a linear
+hierarchy the span order is total, so the least-span match is maximally
+specific. -/
+theorem spelloutWinner_isElsewhereWinner {v : List (ExponenceRule n F)}
+    {g : Fin n} {it : ExponenceRule n F}
+    (h : spelloutWinner v g = some it) :
+    Exponence.IsElsewhereWinner (v.map ExponenceRule.toSupersetRule) g
+      it.toSupersetRule := by
+  obtain ⟨hmem, hms⟩ := spelloutWinner_spec h
+  obtain ⟨-, -, -, hle⟩ := exists_of_minSpan_eq_coe hms
+  refine ⟨List.mem_map_of_mem hmem, hle, ?_⟩
+  rintro s hs hsapp -
+  obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hs
+  rw [ExponenceRule.toSupersetRule_moreSpecific_iff]
+  exact le_spans_of_minSpan_eq_coe hms hjt hsapp
+
+end ExponenceCore
+
 end Morphology.Containment

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -1,4 +1,6 @@
 import Linglib.Core.Order.Branching
+import Linglib.Morphology.Exponence.Rule
+import Mathlib.Data.List.MinMax
 
 /-!
 # Nanosyntax: Tree-Based Spellout
@@ -22,7 +24,11 @@ uses containment as the simpler equivalent formulation.
 
 - `NanoTree`: feature trees; `NanoTree.Contains`: sub-constituency
 - `TreeLexEntry`: a stored tree paired with an exponent; `TreeLexEntry.Matches`
-- `treeSpellout`: Superset Principle + Elsewhere Condition
+- `treeSelect`, `treeSpellout`: Superset Principle + Elsewhere Condition
+- `TreeLexEntry.toRule`, `treeSelect_isElsewhereWinner`: the engine as an
+  instance of the shared exponence core — derived specificity is reverse
+  tree containment (`toRule_moreSpecific_iff`), and smallest-tree
+  selection is an Elsewhere winner with no side conditions
 - `FootConditionMet`: [taraldsen-et-al-2018]'s constraint on backtracking
 - `chain_contains_iff_le`: for right-branching chains, tree containment
   reduces to rank comparison — tree-based spellout generalizes (not
@@ -173,6 +179,50 @@ where
 instance [DecidableEq F] (s t : NanoTree F) : Decidable (Contains s t) :=
   NanoTree.decContains s t
 
+theorem Contains.trans {a b c : NanoTree F} (h₁ : Contains a b)
+    (h₂ : Contains b c) : Contains a c := by
+  induction h₁ with
+  | refl => exact h₂
+  | child hmem _ ih => exact .child hmem (ih h₂)
+
+instance : Trans (Contains (F := F)) Contains Contains := ⟨Contains.trans⟩
+
+/-- Each daughter's size is bounded by the daughters' total size. -/
+theorem le_sizeList_of_mem {cs : List (NanoTree F)} {c : NanoTree F}
+    (h : c ∈ cs) : c.size ≤ size.sizeList cs := by
+  induction cs with
+  | nil => cases h
+  | cons d ds ih =>
+    rcases List.mem_cons.mp h with rfl | h
+    · simp only [size.sizeList]; omega
+    · have := ih h; simp only [size.sizeList]; omega
+
+theorem size_lt_of_mem {f : F} {cs : List (NanoTree F)} {c : NanoTree F}
+    (h : c ∈ cs) : c.size < (NanoTree.node f cs).size := by
+  have := le_sizeList_of_mem h
+  simp only [size]; omega
+
+/-- Containment is size-monotone: a contained tree is no larger. -/
+theorem Contains.size_le {s t : NanoTree F} (h : Contains s t) :
+    t.size ≤ s.size := by
+  induction h with
+  | refl => exact Nat.le_refl _
+  | child hmem _ ih => exact ih.trans (Nat.le_of_lt (size_lt_of_mem hmem))
+
+/-- Containment is size-strict off the diagonal: a contained tree of no
+smaller size is the tree itself. -/
+theorem Contains.eq_of_size_le {s t : NanoTree F} (h : Contains s t)
+    (hs : s.size ≤ t.size) : s = t := by
+  cases h with
+  | refl => rfl
+  | child hmem hc =>
+    exact absurd hs
+      (Nat.not_le.mpr (Nat.lt_of_le_of_lt hc.size_le (size_lt_of_mem hmem)))
+
+theorem Contains.antisymm {s t : NanoTree F} (h₁ : Contains s t)
+    (h₂ : Contains t s) : s = t :=
+  h₁.eq_of_size_le h₂.size_le
+
 /-! ### Foot -/
 
 /-- The foot of a tree: the feature at the bottom of the leftmost
@@ -217,6 +267,12 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
 
 /-! ### Tree spellout (Elsewhere Condition) -/
 
+/-- The matching entry with the smallest stored tree (first-listed on
+    ties): Minimize Junk over tree-generalized Superset matching. -/
+def treeSelect [DecidableEq F] (entries : List (TreeLexEntry F α))
+    (target : NanoTree F) : Option (TreeLexEntry F α) :=
+  (entries.filter fun e => decide (e.Matches target)).argmin (·.tree.size)
+
 /-- Phrasal spellout via the tree-generalized Superset Principle:
     among entries whose tree contains the target, select the one
     with the smallest tree (most specific match).
@@ -226,14 +282,61 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
     specificity metric is tree size instead of rank. -/
 def treeSpellout [DecidableEq F] (entries : List (TreeLexEntry F α))
     (target : NanoTree F) : Option α :=
-  let matching := entries.filter fun e => decide (e.Matches target)
-  (matching.foldl (init := none) fun acc entry =>
-    match acc with
-    | none => some entry
-    | some prev =>
-      if entry.tree.size < prev.tree.size then some entry
-      else some prev
-  ).map (·.exponent)
+  (treeSelect entries target).map (·.exponent)
+
+/-! ### The shared exponence core -/
+
+section ExponenceCore
+
+open Morphology.Exponence
+
+/-- View a tree lexical entry as a rule of the shared exponence core
+(`Morphology.Exponence.Rule`): contexts are syntactic targets,
+applicability is Superset-Principle matching. -/
+def TreeLexEntry.toRule (e : TreeLexEntry F α) : Rule (NanoTree F) α :=
+  ⟨e.exponent, e.Matches⟩
+
+/-- Derived specificity is reverse containment of the stored trees:
+`a` is at least as specific as `b` exactly when `b`'s tree contains
+`a`'s. Tree size is therefore a faithful specificity measure
+(`Contains.size_le`), which is what licenses smallest-tree selection. -/
+theorem TreeLexEntry.toRule_moreSpecific_iff {a b : TreeLexEntry F α} :
+    a.toRule.MoreSpecific b.toRule ↔ b.tree.Contains a.tree :=
+  ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
+
+/-- Smallest-tree selection is an Elsewhere winner of the shared core,
+with no side conditions: containment is size-antisymmetric
+(`Contains.eq_of_size_le`), so a size-minimal matching entry is
+maximally specific among the matching entries. -/
+theorem treeSelect_isElsewhereWinner [DecidableEq F]
+    {entries : List (TreeLexEntry F α)} {target : NanoTree F}
+    {e : TreeLexEntry F α} (h : treeSelect entries target = some e) :
+    IsElsewhereWinner (entries.map TreeLexEntry.toRule) target e.toRule := by
+  have hmem := List.argmin_mem h
+  rw [List.mem_filter] at hmem
+  obtain ⟨hev, hem⟩ := hmem
+  have hematch : e.Matches target := of_decide_eq_true hem
+  refine ⟨List.mem_map_of_mem hev, hematch, ?_⟩
+  rintro s hs happ hspec
+  obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
+  rw [TreeLexEntry.toRule_moreSpecific_iff] at hspec ⊢
+  have hble : ¬ b.tree.size < e.tree.size :=
+    List.not_lt_of_mem_argmin (f := λ e : TreeLexEntry F α => e.tree.size)
+      (List.mem_filter.mpr
+        ⟨hb, decide_eq_true (show b.Matches target from happ)⟩) h
+  exact hspec.eq_of_size_le (Nat.le_of_not_lt hble) ▸ .refl _
+
+/-- The spelled-out exponent is an Elsewhere winner's exponent. -/
+theorem treeSpellout_isElsewhereWinner [DecidableEq F]
+    {entries : List (TreeLexEntry F α)} {target : NanoTree F} {x : α}
+    (h : treeSpellout entries target = some x) :
+    ∃ e ∈ entries, e.exponent = x ∧
+      IsElsewhereWinner (entries.map TreeLexEntry.toRule) target e.toRule := by
+  obtain ⟨e, he, rfl⟩ := Option.map_eq_some_iff.mp h
+  exact ⟨e, (List.mem_filter.mp (List.argmin_mem he)).1, rfl,
+    treeSelect_isElsewhereWinner he⟩
+
+end ExponenceCore
 
 /-! ### Foot Condition -/
 

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -259,17 +259,17 @@ Two separate impoverishment rules delete [MASC] in different contexts:
 -/
 
 /-- Impoverishment rule 1: [MASC] → ∅ / [PL]. -/
-def jarawaraImpoverishPL : ImpoverishmentRule where
+def jarawaraImpoverishPL : GenderImpoverishmentRule where
   targetGender := ⟨.masc, .pos⟩
   context := .plural
 
 /-- Impoverishment rule 2: [MASC] → ∅ / [PARTICIPANT]. -/
-def jarawaraImpoverishParticipant : ImpoverishmentRule where
+def jarawaraImpoverishParticipant : GenderImpoverishmentRule where
   targetGender := ⟨.masc, .pos⟩
   context := .participant
 
 /-- Both rules from ex. 63. -/
-def jarawaraImpoverishmentRules : List ImpoverishmentRule :=
+def jarawaraImpoverishmentRules : List GenderImpoverishmentRule :=
   [jarawaraImpoverishPL, jarawaraImpoverishParticipant]
 
 /-- Impoverishment deletes [MASC] when [PL] is active. -/


### PR DESCRIPTION
Wave 1 of the morphology objects-and-homs plan (`scratch/morphology-objects-homs-plan.md`), on top of #1501's Containment dissolution.

- Nanosyntax joins the shared exponence core: `TreeLexEntry.toRule` with derived specificity = reverse tree containment (full iff), and `treeSelect_isElsewhereWinner` with no side conditions (containment is size-antisymmetric); `Contains` gains `trans`/`size_le`/`antisymm`; `treeSpellout` refactored through `treeSelect` via `List.argmin`
- Superset reading gets its core view: `toSupersetRule` (Minimize Junk = derived specificity), assumption-free `spelloutWinner_isElsewhereWinner`, and the Subset/Superset duality theorem, exact over `ContextFree` vocabularies
- VocabSimple's one-sided specificity lemma upgraded to a full iff (no faithfulness assumption); cross-engine bridge `VocabEntry.toVocabItem` with applicability-agreement and specificity-transfer lemmas
- name hygiene: `Morphology.Exponence` inductive → `CaseExponence`; Categorizer's colliding `ImpoverishmentRule` → `GenderImpoverishmentRule`