### PR TITLE
feat(Morphology): Morph/Exponent form carrier + Mayan migration

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1326,6 +1326,7 @@ import Linglib.Morphology.FragmentGrammars.FragmentLambda
 import Linglib.Morphology.FragmentGrammars.MultinomialPCFG
 import Linglib.Morphology.Grammaticalization
 import Linglib.Morphology.InflectionRules
+import Linglib.Morphology.Morph
 import Linglib.Morphology.MorphProfile
 import Linglib.Morphology.MorphRule
 import Linglib.Morphology.MorphWord

--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -165,37 +165,42 @@ def absIntranSInNonFinite : Bool := false
 
 /-! ### Person-number paradigm ([vazquez-alvarez-2011] Tables 9-10) -/
 
-/-- Set A (ergative/possessive/genitive) markers: pre-consonantal allomorphs
-    ([vazquez-alvarez-2011] Table 10, p. 83). Note the morphophonemic
-    rule k- → j- /_k (1sg before a /k/ root, e.g., `tyi j-kajpelo`
-    'in my coffee field' p. 76). Plural forms use the inclusive clitic
-    `=la` for 1pl (the unmarked plural form per VA §4.2); the exclusive
-    paradigm with `=l(oj)oñ` is a per-language refinement not exposed
-    by the canonical φ-cell `Agreement.Cell` substrate. -/
-def setAExponentPreC : ExponentTable :=
-  [(.pn .first .Sing, "k-"), (.pn .second .Sing, "a-"), (.pn .third .Sing, "i-"),
-   (.pn .first .Plur, "k-…=la"), (.pn .second .Plur, "a-…=la"), (.pn .third .Plur, "i-…-ob")]
-
-/-- Set A markers: pre-vocalic allomorphs ([vazquez-alvarez-2011]
-    Table 10, p. 83). 1sg `k-` is identical pre-C and pre-V; 2sg surfaces
-    as `aw-`, 3sg as `(i)y-` (some speakers omit the initial vowel —
-    [vazquez-alvarez-2011] examples (12)-(13) p. 76-77). -/
-def setAExponentPreV : ExponentTable :=
-  [(.pn .first .Sing, "k-"), (.pn .second .Sing, "aw-"), (.pn .third .Sing, "(i)y-"),
-   (.pn .first .Plur, "k-…=la"), (.pn .second .Plur, "aw-…=la"), (.pn .third .Plur, "(i)y-…-ob")]
-
-/-- Canonical Set A exponent table for cross-Mayan typology. The
-    pre-consonantal allomorph is the citation form (matching Q'anjob'al's
-    convention); per-context realization uses `setAExponentPreV` before
-    vowel-initial roots. -/
-abbrev setAExponent : ExponentTable := setAExponentPreC
+/-- Set A (ergative/possessive/genitive) markers by following-segment
+    environment ([vazquez-alvarez-2011] Table 10, p. 83). 1sg `k-` is
+    identical in both environments; 2sg surfaces pre-vocalically as
+    `aw-`, 3sg as `iy-` (with speaker-variable omission of the initial
+    vowel, i.e. a variant `y-` — [vazquez-alvarez-2011] examples
+    (12)-(13) p. 76-77). Note the morphophonemic rule k- → j- /_k (1sg
+    before a /k/ root, e.g., `tyi j-kajpelo` 'in my coffee field'
+    p. 76). Plural cells are discontinuous: person prefix plus the
+    inclusive enclitic `=la` for 1pl/2pl (the unmarked plural form per
+    VA §4.2; the exclusive paradigm with `=l(oj)oñ` is a per-language
+    refinement not exposed by the canonical φ-cell substrate) and the
+    suffix `-ob` for 3pl. -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "k"]), (.pn .second .Sing, [.pref "a"]),
+     (.pn .third .Sing, [.pref "i"]),
+     (.pn .first .Plur, [.pref "k", .encl "la"]),
+     (.pn .second .Plur, [.pref "a", .encl "la"]),
+     (.pn .third .Plur, [.pref "i", .suff "ob"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "k"]), (.pn .second .Sing, [.pref "aw"]),
+     (.pn .third .Sing, [.pref "iy"]),
+     (.pn .first .Plur, [.pref "k", .encl "la"]),
+     (.pn .second .Plur, [.pref "aw", .encl "la"]),
+     (.pn .third .Plur, [.pref "iy", .suff "ob"])]
 
 /-- Set B (absolutive) markers: suffixes ([vazquez-alvarez-2011]
-    Table 10, p. 83). 3rd person is null (`-∅`). Plurals use the
-    inclusive `=la` clitic for 1pl per the convention above. -/
+    Table 10, p. 83). 3rd singular has zero exponence; 3pl is the plural
+    suffix alone; 1pl/2pl are discontinuous with the inclusive `=la`
+    enclitic per the convention above. -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "-oñ"), (.pn .second .Sing, "-ety"), (.pn .third .Sing, "-∅"),
-   (.pn .first .Plur, "-oñ=la"), (.pn .second .Plur, "-ety=la"), (.pn .third .Plur, "-∅-ob")]
+  [(.pn .first .Sing, [.suff "oñ"]), (.pn .second .Sing, [.suff "ety"]),
+   (.pn .third .Sing, []),
+   (.pn .first .Plur, [.suff "oñ", .encl "la"]),
+   (.pn .second .Plur, [.suff "ety", .encl "la"]),
+   (.pn .third .Plur, [.suff "ob"])]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches (Cholan, Q'anjob'alan, Tseltalan, K'ichean) per
@@ -204,16 +209,16 @@ def setBExponent : ExponentTable :=
     ([scott-2023]), and `Mayan.isStandard` excludes Mam from the
     cross-Mayan theorem
     (`CoonMateoPedroPreminger2014.mayan_p3sg_abs_null`). -/
-theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
 /-- 3rd person Set A allomorphy: pre-consonantal `i-` vs pre-vocalic
-    `(i)y-`. Distinct from Q'anjob'al's `s-` vs `y-` (the proto-Mayan
+    `iy-`. Distinct from Q'anjob'al's `s-` vs `y-` (the proto-Mayan
     `*s-` ~ `*y-` allomorphy was leveled to `*r` → `y` in proto-Tseltalan,
     and Chol inherited the leveled form per [kaufman-norman-1984]
     p. 91). -/
 theorem p3sg_erg_allomorphy :
-    setAExponentPreC.realize (.pn .third .Sing) = some "i-" ∧
-    setAExponentPreV.realize (.pn .third .Sing) = some "(i)y-" :=
+    (setAExponent .consonant).realize (.pn .third .Sing) = some [.pref "i"] ∧
+    (setAExponent .vowel).realize (.pn .third .Sing) = some [.pref "iy"] :=
   ⟨rfl, rfl⟩
 
 end Chol

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -59,18 +59,31 @@ def absPosition : Mayan.ABSPosition := .high
 
 /-! ### Set A (ERG) exponents -/
 
-/-- Set A (ERG) markers ([preminger-2014] table (29)). -/
-def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, "n/w-"), (.pn .second .Sing, "a(w)-"), (.pn .third .Sing, "r(u)/u-"),
-   (.pn .first .Plur, "q(a)-"), (.pn .second .Plur, "i(w)-"), (.pn .third .Plur, "k(i)-")]
+/-- Set A (ERG) markers ([preminger-2014] ex. (29)) by
+    following-segment environment. Preminger's table glosses its
+    parenthesized segments only as "dropped in certain phonological
+    contexts"; the pre-consonantal vs pre-vocalic assignment below is
+    the standard K'ichean reading (cognate with the verified K'iche'
+    paradigm, [mondloch-2017]). 3sg pre-consonantal *ru-* has a
+    dialectal variant *u-* (Preminger's "r(u)/u-"). -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "n"]), (.pn .second .Sing, [.pref "a"]),
+     (.pn .third .Sing, [.pref "ru"]), (.pn .first .Plur, [.pref "qa"]),
+     (.pn .second .Plur, [.pref "i"]), (.pn .third .Plur, [.pref "ki"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "w"]), (.pn .second .Sing, [.pref "aw"]),
+     (.pn .third .Sing, [.pref "r"]), (.pn .first .Plur, [.pref "q"]),
+     (.pn .second .Plur, [.pref "iw"]), (.pn .third .Plur, [.pref "k"])]
 
 /-! ### Set B (ABS) exponents -/
 
 /-- Set B (ABS) markers; ∅ 3SG doubles as the Elsewhere default
     ([preminger-2014] table (29), Ch. 5). -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "in-"), (.pn .second .Sing, "at-"), (.pn .third .Sing, "∅"),
-   (.pn .first .Plur, "oj-"), (.pn .second .Plur, "ix-"), (.pn .third .Plur, "e-")]
+  [(.pn .first .Sing, [.pref "in"]), (.pn .second .Sing, [.pref "at"]),
+   (.pn .third .Sing, []), (.pn .first .Plur, [.pref "oj"]),
+   (.pn .second .Plur, [.pref "ix"]), (.pn .third .Plur, [.pref "e"])]
 
 /-! ### Argument positions -/
 

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -81,22 +81,22 @@ abbrev phi (p : Person) (n : Number) : PhiFeatures :=
     These are verbal prefixes (or postverbal particles for formal forms)
     that cross-reference S (intransitive subject) and P (transitive
     object). [mondloch-2017] Lessons 9, 15. -/
-def setBMarker : PhiFeatures → String
-  | ⟨.first,  .singular, .informal⟩ => "in-"
-  | ⟨.second, .singular, .informal⟩ => "at-"
-  | ⟨.third,  .singular, .informal⟩ => "∅"
-  | ⟨.first,  .plural, .informal⟩ => "oj-"
-  | ⟨.second, .plural, .informal⟩ => "ix-"
-  | ⟨.third,  .plural, .informal⟩ => "ee-"
-  | ⟨.second, .singular, .formal⟩   => "la"
-  | ⟨.second, .plural, .formal⟩   => "alaq"
+def setBMarker : PhiFeatures → Morphology.Exponent
+  | ⟨.first,  .singular, .informal⟩ => [.pref "in"]
+  | ⟨.second, .singular, .informal⟩ => [.pref "at"]
+  | ⟨.third,  .singular, .informal⟩ => []
+  | ⟨.first,  .plural, .informal⟩ => [.pref "oj"]
+  | ⟨.second, .plural, .informal⟩ => [.pref "ix"]
+  | ⟨.third,  .plural, .informal⟩ => [.pref "ee"]
+  | ⟨.second, .singular, .formal⟩   => [.free "la"]
+  | ⟨.second, .plural, .formal⟩   => [.free "alaq"]
   -- Non-binary number falls through to plural; formal non-2nd is Ø
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
-  | ⟨.firstExclusive, _, .informal⟩ => "oj-"
-  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
-  | ⟨.second, _, .informal⟩   => "ix-"
-  | ⟨.third,  _, .informal⟩   => "ee-"
-  | ⟨_, _, .formal⟩            => "Ø"
+  | ⟨.firstExclusive, _, .informal⟩ => [.pref "oj"]
+  | ⟨.zero, _, .informal⟩ => []  -- no zero-person cell in the paradigm
+  | ⟨.second, _, .informal⟩   => [.pref "ix"]
+  | ⟨.third,  _, .informal⟩   => [.pref "ee"]
+  | ⟨_, _, .formal⟩            => []
 
 /-! ### Set A (ergative) markers -/
 
@@ -104,39 +104,39 @@ def setBMarker : PhiFeatures → String
     These cross-reference A (transitive subject) and are identical to
     possessive pronouns before consonant-initial nouns.
     [mondloch-2017] Lessons 7, 15. -/
-def setAPreC : PhiFeatures → String
-  | ⟨.first,  .singular, .informal⟩ => "nu-/in-"
-  | ⟨.second, .singular, .informal⟩ => "a-"
-  | ⟨.third,  .singular, .informal⟩ => "u-"
-  | ⟨.first,  .plural, .informal⟩ => "qa-"
-  | ⟨.second, .plural, .informal⟩ => "i-"
-  | ⟨.third,  .plural, .informal⟩ => "ki-"
-  | ⟨.second, .singular, .formal⟩   => "la"
-  | ⟨.second, .plural, .formal⟩   => "alaq"
+def setAPreC : PhiFeatures → Morphology.Exponent
+  | ⟨.first,  .singular, .informal⟩ => [.pref "nu"]
+  | ⟨.second, .singular, .informal⟩ => [.pref "a"]
+  | ⟨.third,  .singular, .informal⟩ => [.pref "u"]
+  | ⟨.first,  .plural, .informal⟩ => [.pref "qa"]
+  | ⟨.second, .plural, .informal⟩ => [.pref "i"]
+  | ⟨.third,  .plural, .informal⟩ => [.pref "ki"]
+  | ⟨.second, .singular, .formal⟩   => [.free "la"]
+  | ⟨.second, .plural, .formal⟩   => [.free "alaq"]
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
-  | ⟨.firstExclusive, _, .informal⟩ => "qa-"
-  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
-  | ⟨.second, _, .informal⟩   => "i-"
-  | ⟨.third,  _, .informal⟩   => "ki-"
-  | ⟨_, _, .formal⟩            => "Ø"
+  | ⟨.firstExclusive, _, .informal⟩ => [.pref "qa"]
+  | ⟨.zero, _, .informal⟩ => []  -- no zero-person cell in the paradigm
+  | ⟨.second, _, .informal⟩   => [.pref "i"]
+  | ⟨.third,  _, .informal⟩   => [.pref "ki"]
+  | ⟨_, _, .formal⟩            => []
 
 /-- Set A (ergative) markers before vowel-initial roots.
     [mondloch-2017] Lesson 8. -/
-def setAPreV : PhiFeatures → String
-  | ⟨.first,  .singular, .informal⟩ => "w-"
-  | ⟨.second, .singular, .informal⟩ => "aw-"
-  | ⟨.third,  .singular, .informal⟩ => "r-"
-  | ⟨.first,  .plural, .informal⟩ => "q-"
-  | ⟨.second, .plural, .informal⟩ => "iw-"
-  | ⟨.third,  .plural, .informal⟩ => "k-"
-  | ⟨.second, .singular, .formal⟩   => "la"
-  | ⟨.second, .plural, .formal⟩   => "alaq"
+def setAPreV : PhiFeatures → Morphology.Exponent
+  | ⟨.first,  .singular, .informal⟩ => [.pref "w"]
+  | ⟨.second, .singular, .informal⟩ => [.pref "aw"]
+  | ⟨.third,  .singular, .informal⟩ => [.pref "r"]
+  | ⟨.first,  .plural, .informal⟩ => [.pref "q"]
+  | ⟨.second, .plural, .informal⟩ => [.pref "iw"]
+  | ⟨.third,  .plural, .informal⟩ => [.pref "k"]
+  | ⟨.second, .singular, .formal⟩   => [.free "la"]
+  | ⟨.second, .plural, .formal⟩   => [.free "alaq"]
   | ⟨.first,  _, .informal⟩ | ⟨.firstInclusive, _, .informal⟩
-  | ⟨.firstExclusive, _, .informal⟩ => "q-"
-  | ⟨.zero, _, .informal⟩ => "∅"  -- no zero-person cell in the paradigm
-  | ⟨.second, _, .informal⟩   => "iw-"
-  | ⟨.third,  _, .informal⟩   => "k-"
-  | ⟨_, _, .formal⟩            => "Ø"
+  | ⟨.firstExclusive, _, .informal⟩ => [.pref "q"]
+  | ⟨.zero, _, .informal⟩ => []  -- no zero-person cell in the paradigm
+  | ⟨.second, _, .informal⟩   => [.pref "iw"]
+  | ⟨.third,  _, .informal⟩   => [.pref "k"]
+  | ⟨_, _, .formal⟩            => []
 
 /-! ### Morphological positions -/
 
@@ -212,43 +212,45 @@ theorem kiche_not_tripartite :
 /-! ### Set B per-cell verification -/
 
 /-- 1SG absolutive: in- -/
-theorem setB_1sg : setBMarker (phi .first .singular) = "in-" := rfl
+theorem setB_1sg : setBMarker (phi .first .singular) = [.pref "in"] := rfl
 /-- 2SG absolutive: at- -/
-theorem setB_2sg : setBMarker (phi .second .singular) = "at-" := rfl
+theorem setB_2sg : setBMarker (phi .second .singular) = [.pref "at"] := rfl
 /-- 3SG absolutive: ∅ (null morpheme) -/
-theorem setB_3sg : setBMarker (phi .third .singular) = "∅" := rfl
+theorem setB_3sg : setBMarker (phi .third .singular) = [] := rfl
 /-- 1PL absolutive: oj- -/
-theorem setB_1pl : setBMarker (phi .first .plural) = "oj-" := rfl
+theorem setB_1pl : setBMarker (phi .first .plural) = [.pref "oj"] := rfl
 /-- 2PL absolutive: ix- -/
-theorem setB_2pl : setBMarker (phi .second .plural) = "ix-" := rfl
+theorem setB_2pl : setBMarker (phi .second .plural) = [.pref "ix"] := rfl
 /-- 3PL absolutive: ee- -/
-theorem setB_3pl : setBMarker (phi .third .plural) = "ee-" := rfl
+theorem setB_3pl : setBMarker (phi .third .plural) = [.pref "ee"] := rfl
 /-- 2SG.FORM: la (postverbal) -/
-theorem setB_2sg_form : setBMarker ⟨.second, .singular, .formal⟩ = "la" := rfl
+theorem setB_2sg_form : setBMarker ⟨.second, .singular, .formal⟩ = [.free "la"] := rfl
 /-- 2PL.FORM: alaq (postverbal) -/
-theorem setB_2pl_form : setBMarker ⟨.second, .plural, .formal⟩ = "alaq" := rfl
+theorem setB_2pl_form : setBMarker ⟨.second, .plural, .formal⟩ = [.free "alaq"] := rfl
 
 /-! ### Set A per-cell verification -/
 
-/-- 1SG ergative (preC): nu‑ or in‑ -/
-theorem setA_1sg : setAPreC (phi .first .singular) = "nu-/in-" := rfl
+/-- 1SG ergative (preC): nu- (possessive citation form; in- as transitive
+    subject per [mondloch-2017] Lesson 15 — both pre-consonantal, with w-
+    pre-vocalic for both constructions) -/
+theorem setA_1sg : setAPreC (phi .first .singular) = [.pref "nu"] := rfl
 /-- 2SG ergative (preC): a- -/
-theorem setA_2sg : setAPreC (phi .second .singular) = "a-" := rfl
+theorem setA_2sg : setAPreC (phi .second .singular) = [.pref "a"] := rfl
 /-- 3SG ergative (preC): u- -/
-theorem setA_3sg : setAPreC (phi .third .singular) = "u-" := rfl
+theorem setA_3sg : setAPreC (phi .third .singular) = [.pref "u"] := rfl
 /-- 1PL ergative (preC): qa- -/
-theorem setA_1pl : setAPreC (phi .first .plural) = "qa-" := rfl
+theorem setA_1pl : setAPreC (phi .first .plural) = [.pref "qa"] := rfl
 /-- 2PL ergative (preC): i- -/
-theorem setA_2pl : setAPreC (phi .second .plural) = "i-" := rfl
+theorem setA_2pl : setAPreC (phi .second .plural) = [.pref "i"] := rfl
 /-- 3PL ergative (preC): ki- -/
-theorem setA_3pl : setAPreC (phi .third .plural) = "ki-" := rfl
+theorem setA_3pl : setAPreC (phi .third .plural) = [.pref "ki"] := rfl
 
 /-- 1SG ergative (preV): w- -/
-theorem setA_preV_1sg : setAPreV (phi .first .singular) = "w-" := rfl
+theorem setA_preV_1sg : setAPreV (phi .first .singular) = [.pref "w"] := rfl
 /-- 2SG ergative (preV): aw- -/
-theorem setA_preV_2sg : setAPreV (phi .second .singular) = "aw-" := rfl
+theorem setA_preV_2sg : setAPreV (phi .second .singular) = [.pref "aw"] := rfl
 /-- 3SG ergative (preV): r- -/
-theorem setA_preV_3sg : setAPreV (phi .third .singular) = "r-" := rfl
+theorem setA_preV_3sg : setAPreV (phi .third .singular) = [.pref "r"] := rfl
 
 /-! ### Possessives equal Set A -/
 
@@ -259,10 +261,10 @@ theorem setA_preV_3sg : setAPreV (phi .third .singular) = "r-" := rfl
     morphological paradigm. [mondloch-2017] Lesson 15 explicitly
     notes this identity. -/
 theorem possessives_equal_setA :
-    setAPreC (phi .first .plural) = "qa-" ∧
-    setAPreC (phi .second .singular) = "a-" ∧
-    setAPreC (phi .third .singular) = "u-" ∧
-    setAPreC (phi .third .plural) = "ki-" :=
+    setAPreC (phi .first .plural) = [.pref "qa"] ∧
+    setAPreC (phi .second .singular) = [.pref "a"] ∧
+    setAPreC (phi .third .singular) = [.pref "u"] ∧
+    setAPreC (phi .third .plural) = [.pref "ki"] :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-! ### Formal markers are postverbal -/
@@ -329,15 +331,24 @@ def setALinearity : MarkerLinearity := .prefixal
 /-- Set B linearity: prefixal (HIGH-ABS K'ichean morphology). -/
 def setBLinearity : MarkerLinearity := .prefixal
 
-/-- Canonical Set A exponent table (pre-consonantal allomorph; informal),
-    keyed on the canonical φ-cell `Agreement.Cell` for cross-Mayan consumption. -/
-def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, setAPreC (phi .first  .singular)),
-   (.pn .second .Sing, setAPreC (phi .second .singular)),
-   (.pn .third .Sing, setAPreC (phi .third  .singular)),
-   (.pn .first .Plur, setAPreC (phi .first  .plural)),
-   (.pn .second .Plur, setAPreC (phi .second .plural)),
-   (.pn .third .Plur, setAPreC (phi .third  .plural))]
+/-- Canonical Set A exponent table (informal) by following-segment
+    environment, keyed on the canonical φ-cell `Agreement.Cell` for
+    cross-Mayan consumption. -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, setAPreC (phi .first  .singular)),
+     (.pn .second .Sing, setAPreC (phi .second .singular)),
+     (.pn .third .Sing, setAPreC (phi .third  .singular)),
+     (.pn .first .Plur, setAPreC (phi .first  .plural)),
+     (.pn .second .Plur, setAPreC (phi .second .plural)),
+     (.pn .third .Plur, setAPreC (phi .third  .plural))]
+  | .vowel =>
+    [(.pn .first .Sing, setAPreV (phi .first  .singular)),
+     (.pn .second .Sing, setAPreV (phi .second .singular)),
+     (.pn .third .Sing, setAPreV (phi .third  .singular)),
+     (.pn .first .Plur, setAPreV (phi .first  .plural)),
+     (.pn .second .Plur, setAPreV (phi .second .plural)),
+     (.pn .third .Plur, setAPreV (phi .third  .plural))]
 
 /-- Canonical Set B exponent table (informal) keyed on the canonical φ-cell
     `Agreement.Cell`. -/
@@ -352,6 +363,6 @@ def setBExponent : ExponentTable :=
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
     pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
-theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
 end Kiche

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -73,10 +73,19 @@ open Features.Prominence (ArgumentRole)
 /-! ### Agreement marker paradigms -/
 
 /-- Set A (ERG) markers cross-referencing the transitive agent
-    ([scott-2023] Table 2.8); t- is syncretic for 2/3SG, ky- for 2/3PL. -/
-def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, "n-/w-"), (.pn .second .Sing, "t-"), (.pn .third .Sing, "t-"),
-   (.pn .first .Plur, "q-"), (.pn .second .Plur, "ky-"), (.pn .third .Plur, "ky-")]
+    ([scott-2023] Table 2.8) by following-segment environment; t- is
+    syncretic for 2/3SG, ky- for 2/3PL. Scott: 1SG is the sole Set A
+    allomorphy — pre-consonantal `n-`, pre-vocalic `w-` (exx. (28)-(29));
+    the other markers do not alternate. -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "n"]), (.pn .second .Sing, [.pref "t"]),
+     (.pn .third .Sing, [.pref "t"]), (.pn .first .Plur, [.pref "q"]),
+     (.pn .second .Plur, [.pref "ky"]), (.pn .third .Plur, [.pref "ky"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "w"]), (.pn .second .Sing, [.pref "t"]),
+     (.pn .third .Sing, [.pref "t"]), (.pn .first .Plur, [.pref "q"]),
+     (.pn .second .Plur, [.pref "ky"]), (.pn .third .Plur, [.pref "ky"])]
 
 /-- Set B (ABS) markers ([scott-2023] Table 3.5). The 2/3SG form tz'= is
     the Elsewhere default: it realizes both real 2/3SG intransitive-S
@@ -85,8 +94,9 @@ def setAExponent : ExponentTable :=
     specific Vocabulary Items but surface via Elsewhere fallback (see
     `setBSpecificCells`). -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "chin"), (.pn .second .Sing, "tz'="), (.pn .third .Sing, "tz'="),
-   (.pn .first .Plur, "qo"), (.pn .second .Plur, "chi"), (.pn .third .Plur, "chi")]
+  [(.pn .first .Sing, [.free "chin"]), (.pn .second .Sing, [.procl "tz'"]),
+   (.pn .third .Sing, [.procl "tz'"]), (.pn .first .Plur, [.free "qo"]),
+   (.pn .second .Plur, [.free "chi"]), (.pn .third .Plur, [.free "chi"])]
 
 /-- The four Set B cells with specific Vocabulary Items ([scott-2023]);
     2SG and 3SG fall through to the Elsewhere entry. -/
@@ -95,7 +105,7 @@ def setBSpecificCells : List Cell :=
 
 /-- The Elsewhere Set B marker, surfacing in transitives when Infl's
     probe is blocked and for 2/3SG intransitive S. -/
-def defaultSetB : String := "tz'="
+def defaultSetB : Morphology.Exponent := [.procl "tz'"]
 
 /-! ### Argument positions and agreement status -/
 
@@ -299,16 +309,19 @@ def setBLinearity : MarkerLinearity := .prefixal
 
 /-! ### Marker verification -/
 
-/-- Set A 1SG marker. -/
-theorem setA_1sg : setAExponent.realize (.pn .first .Sing) = some "n-/w-" := rfl
+/-- Set A 1SG marker: pre-consonantal `n-`, pre-vocalic `w-`. -/
+theorem setA_1sg :
+    (setAExponent .consonant).realize (.pn .first .Sing) = some [.pref "n"] ∧
+    (setAExponent .vowel).realize (.pn .first .Sing) = some [.pref "w"] := ⟨rfl, rfl⟩
 
-/-- Set A 3SG marker is "t-" (the default singular Set A — syncretic with 2SG). -/
-theorem setA_3sg : setAExponent.realize (.pn .third .Sing) = some "t-" := rfl
+/-- Set A 3SG marker is `t-` (the default singular Set A — syncretic with 2SG). -/
+theorem setA_3sg :
+    (setAExponent .consonant).realize (.pn .third .Sing) = some [.pref "t"] := rfl
 
-/-- Set B 1SG marker is "chin". -/
-theorem setB_1sg : setBExponent.realize (.pn .first .Sing) = some "chin" := rfl
+/-- Set B 1SG marker is *chin*. -/
+theorem setB_1sg : setBExponent.realize (.pn .first .Sing) = some [.free "chin"] := rfl
 
-/-- Set B 3SG marker is the default "tz'=". -/
+/-- Set B 3SG marker is the default `tz'=`. -/
 theorem setB_3sg : setBExponent.realize (.pn .third .Sing) = some defaultSetB := rfl
 
 /-- A controller's φ-features index the agreement paradigm directly: the
@@ -317,8 +330,9 @@ theorem setB_3sg : setBExponent.realize (.pn .third .Sing) = some defaultSetB :=
     ([corbett-1998]; [scott-2023] Ch. 2). The realizational account
     (impoverishment, Elsewhere; [scott-2023] Ch. 4) stays in the study. -/
 theorem erg_1sg_from_phi :
-    setAExponent.realizeFor
-      { form :="", cat := .PRON, features := { person := some .first, number := some .Sing }} = some "n-/w-" := by
+    (setAExponent .consonant).realizeFor
+      { form :="", cat := .PRON, features := { person := some .first, number := some .Sing }} =
+      some [.pref "n"] := by
   rfl
 
 end Mam

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -3,6 +3,7 @@ import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Agreement.Paradigm
+import Linglib.Morphology.Morph
 import Linglib.Morphology.Word
 
 /-!
@@ -346,31 +347,25 @@ def VerbForm.agreementSlots (f : VerbForm) : Nat :=
 /-! ### Exponent tables -/
 
 /-- An exponent table: a descriptive agreement paradigm over canonical φ-cells
-    (`Agreement.Cell`), mapping each person/number cell to its surface string.
+    (`Agreement.Cell`), mapping each person/number cell to its
+    `Morphology.Exponent` — a possibly empty sequence of `Morphology.Morph`s.
+    Zero exponence is `[]`; a discontinuous realization (person marker plus a
+    separate plural word, e.g. Q'anjob'al *s-…heb'*) is a two-morph exponent.
     Per-language `setAExponent`/`setBExponent` populate this; cross-Mayan
-    typology theorems quantify over it. Discontinuous exponents (person
-    marker plus a separate plural word) are notated with `…` between the
-    parts, e.g. Q'anjob'al `"s-…heb'"`; null exponents use the `∅`
-    notations documented at `ExponentTable.IsThirdSgZero`. -/
-abbrev ExponentTable := Agreement.Paradigm String
+    typology theorems quantify over it. Tables with pre-consonantal vs
+    pre-vocalic variant shapes are `Morphology.Following → ExponentTable`
+    functions, with `.consonant` the citation point. -/
+abbrev ExponentTable := Agreement.Paradigm Morphology.Exponent
 
-/-- Decidable predicate: the third-person singular Set B slot is
-    morphologically null. An invariant of the standard Mayan branches per
+/-- Decidable predicate: the third-person singular Set B slot has zero
+    exponence. An invariant of the standard Mayan branches per
     [kaufman-norman-1984] Table 8 (reconstructing to proto-Cholan and
     proto-Mayan), but not strictly pan-Mayan — SJA Mam's default Set B
     `tz'=` surfaces in the 3sg slot per [scott-2023] §3.3.2, so
     `CoonMateoPedroPreminger2014.mayan_p3sg_abs_null` quantifies only
-    over `isStandard = true`. The
-    predicate is notation-agnostic: `"-∅"` (suffix-notated Set B: Cholan,
-    Q'anjob'alan, Tseltal, and Tsotsil — whose system also has a prefixal
-    subset, see `Tsotsil.setBLinearity`), `"∅"` (prefixal Set B: Kaqchikel
-    and other K'ichean HIGH-ABS), and `"∅-"` all encode "no overt 3sg
-    exponent". The disjunction form is kernel-decidable, unlike a
-    `String.replace` normalization. -/
+    over `isStandard = true`. -/
 def ExponentTable.IsThirdSgZero (e : ExponentTable) : Prop :=
-  e.realize (.pn .third .Sing) = some "-∅" ∨
-  e.realize (.pn .third .Sing) = some "∅" ∨
-  e.realize (.pn .third .Sing) = some "∅-"
+  e.realize (.pn .third .Sing) = some []
 
 instance (e : ExponentTable) : Decidable e.IsThirdSgZero := by
   unfold ExponentTable.IsThirdSgZero; exact inferInstance

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -16,9 +16,9 @@ England 1992:21, Kaufman 1974) — alongside the Cholan-Tzeltalan branch
 
 ## Main declarations
 
-* `Qanjobal.setAExponentPreC`, `Qanjobal.setAExponentPreV`,
-  `Qanjobal.setBExponent`: Set A pre-consonantal and pre-vocalic
-  ergative allomorphs and the Set B absolutive suffixes
+* `Qanjobal.setAExponent`, `Qanjobal.setBExponent`: Set A ergative
+  markers by following-segment environment (pre-consonantal vs
+  pre-vocalic variant shapes) and the Set B absolutive suffixes
   ([coon-mateo-pedro-preminger-2014] table (13)).
 * `Qanjobal.ArgPosition` with `.case`, `.accCase`: argument positions
   and their canonical-ergative and split (extended-ergative) case,
@@ -83,38 +83,37 @@ def absPosition : Mayan.ABSPosition := .high
 
 /-! ### Person-number paradigm -/
 
-/-- Set A (ergative/possessive) markers: pre-consonantal allomorphs
-    ([coon-mateo-pedro-preminger-2014] table (13)). -/
-def setAExponentPreC : ExponentTable :=
-  [(.pn .first .Sing, "hin-"), (.pn .second .Sing, "ha-"), (.pn .third .Sing, "s-"),
-   (.pn .first .Plur, "ko-"), (.pn .second .Plur, "he-"), (.pn .third .Plur, "s-…heb'")]
-
-/-- Set A (ergative/possessive) markers: pre-vocalic allomorphs
-    ([coon-mateo-pedro-preminger-2014] table (13)). -/
-def setAExponentPreV : ExponentTable :=
-  [(.pn .first .Sing, "w-"), (.pn .second .Sing, "h-"), (.pn .third .Sing, "y-"),
-   (.pn .first .Plur, "j-"), (.pn .second .Plur, "hey-"), (.pn .third .Plur, "y-…heb'")]
-
-/-- Canonical Set A exponent table for cross-Mayan typology. The
-    pre-consonantal allomorph is the citation form; per-context
-    realization uses `setAExponentPreV` before vowels. -/
-abbrev setAExponent : ExponentTable := setAExponentPreC
+/-- Set A (ergative/possessive) markers by following-segment
+    environment ([coon-mateo-pedro-preminger-2014] table (13)). The 3pl
+    cells are discontinuous exponents: person prefix plus the free
+    plural word *heb'*. -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "hin"]), (.pn .second .Sing, [.pref "ha"]),
+     (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "ko"]),
+     (.pn .second .Plur, [.pref "he"]),
+     (.pn .third .Plur, [.pref "s", .free "heb'"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "w"]), (.pn .second .Sing, [.pref "h"]),
+     (.pn .third .Sing, [.pref "y"]), (.pn .first .Plur, [.pref "j"]),
+     (.pn .second .Plur, [.pref "hey"]),
+     (.pn .third .Plur, [.pref "y", .free "heb'"])]
 
 /-- Set B (absolutive) markers: suffixes
-    ([coon-mateo-pedro-preminger-2014] table (13)). The 3pl cell *heb'*
-    is an independent plural word (null person exponent plus the plural
-    particle), quoted as in the source table; 1pl *-on* is the table's
-    ASCII for *-on̈* [-oŋ]. -/
+    ([coon-mateo-pedro-preminger-2014] table (13)). The 3pl cell is the
+    free plural word *heb'* alone (zero person exponence plus the
+    plural particle); 1pl *-on* is the table's ASCII for *-on̈* [-oŋ]. -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "-in"), (.pn .second .Sing, "-ach"), (.pn .third .Sing, "-∅"),
-   (.pn .first .Plur, "-on"), (.pn .second .Plur, "-ex"), (.pn .third .Plur, "heb'")]
+  [(.pn .first .Sing, [.suff "in"]), (.pn .second .Sing, [.suff "ach"]),
+   (.pn .third .Sing, []), (.pn .first .Plur, [.suff "on"]),
+   (.pn .second .Plur, [.suff "ex"]), (.pn .third .Plur, [.free "heb'"])]
 
-/-- 3rd person absolutive is null (∅). -/
-theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
+/-- 3rd person absolutive has zero exponence. -/
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
-/-- 3rd person ergative (pre-vocalic) is *y-*, pre-consonantal is *s-*. -/
+/-- 3rd person ergative is *s-* pre-consonantally, *y-* pre-vocalically. -/
 theorem p3sg_erg_allomorphy :
-    setAExponentPreC.realize (.pn .third .Sing) = some "s-" ∧
-    setAExponentPreV.realize (.pn .third .Sing) = some "y-" := ⟨rfl, rfl⟩
+    (setAExponent .consonant).realize (.pn .third .Sing) = some [.pref "s"] ∧
+    (setAExponent .vowel).realize (.pn .third .Sing) = some [.pref "y"] := ⟨rfl, rfl⟩
 
 end Qanjobal

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -83,22 +83,32 @@ def setBLinearity : MarkerLinearity := .suffixal
 
 /-! ### Set A/B exponents (Oxchuc Tseltal) -/
 
-/-- Set A (ERG/GEN) exponents for Oxchuc Tseltal ([polian-2013]): prefixes
-    on the verb or possessed noun, shown as `pre-C/pre-V` allomorph pairs. -/
-def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, "j-/k-"), (.pn .second .Sing, "a-/aw-"), (.pn .third .Sing, "s-/y-"),
-   (.pn .first .Plur, "j-/k-"), (.pn .second .Plur, "a-/aw-"), (.pn .third .Plur, "s-/y-")]
+/-- Set A (ERG/GEN) exponents for Oxchuc Tseltal by following-segment
+    environment ([polian-2013]): prefixes on the verb or possessed noun,
+    `j-`/`a-`/`s-` pre-consonantally, `k-`/`aw-`/`y-` pre-vocalically
+    (person is not distinguished by number in Set A; plural is marked
+    by separate suffixes not part of the person marker). -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "j"]), (.pn .second .Sing, [.pref "a"]),
+     (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "j"]),
+     (.pn .second .Plur, [.pref "a"]), (.pn .third .Plur, [.pref "s"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "k"]), (.pn .second .Sing, [.pref "aw"]),
+     (.pn .third .Sing, [.pref "y"]), (.pn .first .Plur, [.pref "k"]),
+     (.pn .second .Plur, [.pref "aw"]), (.pn .third .Plur, [.pref "y"])]
 
 /-- Set B (ABS) exponents for Oxchuc Tseltal ([polian-2013]): suffixes on
-    the verb stem; 3rd person singular is null (`-∅`). -/
+    the verb stem; 3rd person singular has zero exponence. -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "-on"), (.pn .second .Sing, "-at"), (.pn .third .Sing, "-∅"),
-   (.pn .first .Plur, "-otik"), (.pn .second .Plur, "-ex"), (.pn .third .Plur, "-ik")]
+  [(.pn .first .Sing, [.suff "on"]), (.pn .second .Sing, [.suff "at"]),
+   (.pn .third .Sing, []), (.pn .first .Plur, [.suff "otik"]),
+   (.pn .second .Plur, [.suff "ex"]), (.pn .third .Plur, [.suff "ik"])]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
     pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
-theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
 /-- Tseltal Set B differs from Tsotsil in linearity (suffixal vs
     prefixal-or-suffixal); the marker set assignment is identical. -/

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -82,24 +82,37 @@ def setBLinearity : MarkerLinearity := .either
 
 /-! ### Set A/B exponents (Zinacantec Tsotsil) -/
 
-/-- Set A (ERG/GEN) exponents for Zinacantec Tsotsil ([polian-2013]):
-    prefixes on the verb (ERG) or possessed noun (GEN), varying by following
-    segment, shown as `pre-C/pre-V` allomorph pairs. -/
-def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, "k-/j-"), (.pn .second .Sing, "a-/av-"), (.pn .third .Sing, "s-/y-"),
-   (.pn .first .Plur, "k-/j-"), (.pn .second .Plur, "a-/av-"), (.pn .third .Plur, "s-/y-")]
+/-- Set A (ERG/GEN) exponents for Zinacantec Tsotsil ([polian-2013]) by
+    following-segment environment: prefixes on the verb (ERG) or
+    possessed noun (GEN) — `j-`/`a-`/`s-` pre-consonantally,
+    `k-`/`av-`/`y-` pre-vocalically (same orientation as Tseltal; an
+    earlier revision reversed the 1st-person pair). -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "j"]), (.pn .second .Sing, [.pref "a"]),
+     (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "j"]),
+     (.pn .second .Plur, [.pref "a"]), (.pn .third .Plur, [.pref "s"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "k"]), (.pn .second .Sing, [.pref "av"]),
+     (.pn .third .Sing, [.pref "y"]), (.pn .first .Plur, [.pref "k"]),
+     (.pn .second .Plur, [.pref "av"]), (.pn .third .Plur, [.pref "y"])]
 
-/-- Set B (ABS) exponents for Zinacantec Tsotsil ([polian-2013]): 3rd person
-    singular has no overt exponent (`-∅`); some forms alternate by suffix
-    harmony. -/
+/-- Set B (ABS) exponents for Zinacantec Tsotsil ([polian-2013]): 3rd
+    person singular has zero exponence. The default `-o-` series is
+    listed; harmonic variants (`-un`, `-at`, `-utik`, conditioned by the
+    preceding stem vowel per Aissen/Haviland course materials — the
+    cited Table 1 itself was not accessible for verification) are morph
+    variants of the same suffixes, recorded here rather than as a
+    second table. -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "-on/-un"), (.pn .second .Sing, "-ot/-at"), (.pn .third .Sing, "-∅"),
-   (.pn .first .Plur, "-otik/-utik"), (.pn .second .Plur, "-oxuk"), (.pn .third .Plur, "-ik")]
+  [(.pn .first .Sing, [.suff "on"]), (.pn .second .Sing, [.suff "ot"]),
+   (.pn .third .Sing, []), (.pn .first .Plur, [.suff "otik"]),
+   (.pn .second .Plur, [.suff "oxuk"]), (.pn .third .Plur, [.suff "ik"])]
 
 /-- 3rd person absolutive is null — invariant across the standard
     Mayan branches per [kaufman-norman-1984] Table 8. **Not**
     pan-Mayan: see Mam exception via `Mayan.isStandard`. -/
-theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
 /-! ### Extraction marking -/
 

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -48,22 +48,33 @@ def absPosition : Mayan.ABSPosition := .low
 
 /-! ### Set A exponents -/
 
-/-- Set A markers ([hofling-2017] Table 24.8). -/
-def setAExponent : ExponentTable :=
-  [(.pn .first .Sing, "in(w)-"), (.pn .second .Sing, "a(w)-"), (.pn .third .Sing, "u(y)-"),
-   (.pn .first .Plur, "k-"), (.pn .second .Plur, "a(w)-…-e'ex"),
-   (.pn .third .Plur, "u(y)-…-o'ob'")]
+/-- Set A markers by following-segment environment ([hofling-2017]
+    Table 24.8, where the pre-vocalic glide is parenthesized:
+    *in(w)-*, *a(w)-*, *u(y)-*). 2pl/3pl are discontinuous: person
+    prefix plus the plural suffixes *-e'ex*/*-o'ob'*. -/
+def setAExponent : Morphology.Following → ExponentTable
+  | .consonant =>
+    [(.pn .first .Sing, [.pref "in"]), (.pn .second .Sing, [.pref "a"]),
+     (.pn .third .Sing, [.pref "u"]), (.pn .first .Plur, [.pref "k"]),
+     (.pn .second .Plur, [.pref "a", .suff "e'ex"]),
+     (.pn .third .Plur, [.pref "u", .suff "o'ob'"])]
+  | .vowel =>
+    [(.pn .first .Sing, [.pref "inw"]), (.pn .second .Sing, [.pref "aw"]),
+     (.pn .third .Sing, [.pref "uy"]), (.pn .first .Plur, [.pref "k"]),
+     (.pn .second .Plur, [.pref "aw", .suff "e'ex"]),
+     (.pn .third .Plur, [.pref "uy", .suff "o'ob'"])]
 
 /-! ### Set B exponents -/
 
-/-- Set B markers; ∅ 3SG ([hofling-2017] Table 24.12). -/
+/-- Set B markers; zero-exponence 3SG ([hofling-2017] Table 24.12). -/
 def setBExponent : ExponentTable :=
-  [(.pn .first .Sing, "-en"), (.pn .second .Sing, "-ech"), (.pn .third .Sing, "-∅"),
-   (.pn .first .Plur, "-o'on"), (.pn .second .Plur, "-e'ex"), (.pn .third .Plur, "-o'ob'")]
+  [(.pn .first .Sing, [.suff "en"]), (.pn .second .Sing, [.suff "ech"]),
+   (.pn .third .Sing, []), (.pn .first .Plur, [.suff "o'on"]),
+   (.pn .second .Plur, [.suff "e'ex"]), (.pn .third .Plur, [.suff "o'ob'"])]
 
 /-- 3rd person absolutive is null, as across the standard Mayan
     branches ([kaufman-norman-1984] Table 8). -/
-theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some "-∅" := rfl
+theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
 /-! ### Argument positions -/
 

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -1,0 +1,119 @@
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# The morph: minimal segmental form
+[haspelmath-2020]
+
+The form-side carrier of the morphology layer, following
+[haspelmath-2020]'s proposal: a **morph** is a minimal linguistic form —
+a minimal pairing of syntacticosemantic content with a continuous string
+of phonological segments. Morphs are never zero and never discontinuous
+(a "circumfix" is a construction containing a prefix and a suffix, not a
+single morph); zero and discontinuity live one level up, in the
+**exponent** — a possibly empty sequence of morphs. Nonconcatenative
+exponence (apophony, reduplication, tone) is a process, not a form, and
+is out of this carrier's scope (`Morphology/MorphWord.lean` and the
+autosegmental machinery cover it).
+
+`Morph.Kind` records the attachment classification that descriptive
+notation itself encodes — `X-` prefix, `-X` suffix, `X=` proclitic,
+`=X` enclitic, bare free form — plus `root`.
+`Morph.toString`/`Exponent.toString` reproduce that notation, so the
+display convention is derived, not data.
+
+## Main declarations
+
+* `Morph` with `Morph.Kind` — a segmental form with its attachment kind
+* `Exponent` — a sequence of morphs; `[]` is zero exponence
+* `Morph.toString`, `Exponent.toString` — descriptive-notation display
+* `Following` — following-segment environment for pre-consonantal vs
+  pre-vocalic variant selection
+-/
+
+namespace Morphology
+
+/-- The attachment kind of a morph, as descriptive notation encodes it:
+`X-` prefix, `-X` suffix, `X=` proclitic, `=X` enclitic, bare form.
+`root` follows [haspelmath-2020]'s definitional criterion (a morph
+denoting a thing, an action, or a property); `free` covers free
+non-root morphs (particles, plural words, auxiliaries) — the class
+[haspelmath-2020] notes has no established general name. -/
+inductive Morph.Kind where
+  | root | pref | suff | procl | encl | free
+  deriving DecidableEq, Repr, Fintype
+
+/-- A **morph**: a minimal segmental form with its attachment kind,
+following [haspelmath-2020]'s proposal. `form` is the bare segmental
+material as sources print it, with no boundary notation — hyphens and
+clitic signs are display, produced by `Morph.toString`. -/
+structure Morph where
+  /-- Attachment kind, per the source's notation. -/
+  kind : Morph.Kind
+  /-- Bare segmental material, boundary-notation-free. -/
+  form : String
+  deriving DecidableEq, Repr
+
+/-- An **exponent**: the possibly empty sequence of morphs realizing a
+paradigm cell. `[]` is zero exponence — a form cannot be zero, so there
+is no zero morph; a discontinuous realization (Q'anjob'al *s-…heb'*) is
+a two-morph exponent, [haspelmath-2020]'s "construction containing both
+a prefix and a suffix". Segmental exponence only. -/
+abbrev Exponent := List Morph
+
+namespace Morph
+
+/-- A prefix morph. -/
+def pref (s : String) : Morph := ⟨.pref, s⟩
+
+/-- A suffix morph. -/
+def suff (s : String) : Morph := ⟨.suff, s⟩
+
+/-- A proclitic morph. -/
+def procl (s : String) : Morph := ⟨.procl, s⟩
+
+/-- An enclitic morph. -/
+def encl (s : String) : Morph := ⟨.encl, s⟩
+
+/-- A free non-root morph. -/
+def free (s : String) : Morph := ⟨.free, s⟩
+
+/-- A root morph. -/
+def root (s : String) : Morph := ⟨.root, s⟩
+
+/-- Prefixes and suffixes are affixes. -/
+def IsAffix (m : Morph) : Prop := m.kind = .pref ∨ m.kind = .suff
+
+instance (m : Morph) : Decidable m.IsAffix :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+/-- Proclitics and enclitics are clitics. -/
+def IsClitic (m : Morph) : Prop := m.kind = .procl ∨ m.kind = .encl
+
+instance (m : Morph) : Decidable m.IsClitic :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+/-- Display in descriptive notation: `X-`, `-X`, `X=`, `=X`, bare. -/
+def toString : Morph → String
+  | ⟨.pref, s⟩ => s ++ "-"
+  | ⟨.suff, s⟩ => "-" ++ s
+  | ⟨.procl, s⟩ => s ++ "="
+  | ⟨.encl, s⟩ => "=" ++ s
+  | ⟨.root, s⟩ | ⟨.free, s⟩ => s
+
+end Morph
+
+/-- Display an exponent in descriptive notation: `∅` for zero
+exponence, `…` linking the parts of a discontinuous realization. -/
+def Exponent.toString : Exponent → String
+  | [] => "∅"
+  | ms => String.intercalate "…" (ms.map Morph.toString)
+
+/-- The class of the following segment — the commonest conditioning
+environment for selecting among a morph's variant shapes
+(pre-consonantal vs pre-vocalic allomorph pairs; the phonological
+conditioning of [haspelmath-2020] §7). -/
+inductive Following where
+  | consonant | vowel
+  deriving DecidableEq, Repr, Fintype
+
+end Morphology

--- a/Linglib/Studies/Aissen2003Agreement.lean
+++ b/Linglib/Studies/Aissen2003Agreement.lean
@@ -643,8 +643,10 @@ theorem kaqchikel_A_and_P_indexed :
     distinct: every person-number combination gets a unique marker in
     each set (except 3SG which is ∅ in Set B). -/
 theorem kaqchikel_dual_paradigms :
-    setAExponent.realize (.pn .first .Sing) ≠ setBExponent.realize (.pn .first .Sing) ∧
-    setAExponent.realize (.pn .second .Sing) ≠ setBExponent.realize (.pn .second .Sing) := by
+    (setAExponent .consonant).realize (.pn .first .Sing) ≠
+      setBExponent.realize (.pn .first .Sing) ∧
+    (setAExponent .consonant).realize (.pn .second .Sing) ≠
+      setBExponent.realize (.pn .second .Sing) := by
   decide
 
 -- ============================================================================

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -163,7 +163,8 @@ private def cellBundle (c : Agreement.Cell) : FeatureBundle :=
     All six cells have overt exponents. -/
 def setAVocab : Vocabulary :=
   makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
-    (fun c => (setAExponent.realize c).getD "") (some .v)
+    (fun c => (((setAExponent .consonant).realize c).map
+      Morphology.Exponent.toString).getD "") (some .v)
 
 /-- Set B as DM Vocabulary entries, contextualized to Infl/T: specific
     entries for the five overt cells, plus the Elsewhere ∅ entry
@@ -172,7 +173,8 @@ def setAVocab : Vocabulary :=
 def setBVocab : Vocabulary :=
   makePersonVocab (Agreement.Cell.pnCells.filter (· != .pn .third .Sing))
     Agreement.Cell.toPhiFeatures
-    (fun c => (setBExponent.realize c).getD "") (some .T) ++
+    (fun c => ((setBExponent.realize c).map
+      Morphology.Exponent.toString).getD "") (some .T) ++
   [{ features := ⊥, exponent := "∅", context := some .T }]
 
 /-- Vocabulary insertion recovers the fragment's paradigms: spelling
@@ -181,8 +183,10 @@ def setBVocab : Vocabulary :=
     specific entries. -/
 theorem spellout_matches_paradigm :
     ∀ c ∈ Agreement.Cell.pnCells,
-      spellout setAVocab (cellBundle c) (some .v) = setAExponent.realize c ∧
-      spellout setBVocab (cellBundle c) (some .T) = setBExponent.realize c := by
+      spellout setAVocab (cellBundle c) (some .v) =
+        ((setAExponent .consonant).realize c).map Morphology.Exponent.toString ∧
+      spellout setBVocab (cellBundle c) (some .T) =
+        (setBExponent.realize c).map Morphology.Exponent.toString := by
   decide
 
 /-! ### Two-probe relativized probing ([bejar-rezac-2003], applied per §4.4) -/
@@ -272,7 +276,8 @@ def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
     person restriction is violated: `personRestrictionOk_iff_plc`). -/
 def afMarker (subj obj : Agreement.Cell) : Option String :=
   if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgPosition × Agreement.Cell)) then
-    ((afAgreementTarget subj obj).bind setBExponent.realize) <|>
+    ((afAgreementTarget subj obj).bind
+      (fun t => (setBExponent.realize t).map Morphology.Exponent.toString)) <|>
       spellout setBVocab ⊥ (some .T)
   else none
 

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -182,7 +182,8 @@ open Agreement
     All six cells have specific entries. -/
 def setAVocab : Vocabulary :=
   makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
-    (fun c => (setAExponent.realize c).getD "") (some .v)
+    (fun c => (((setAExponent .consonant).realize c).map
+      Morphology.Exponent.toString).getD "") (some .v)
 
 /-- Set B (ABS) vocabulary entries: φ-features on Infl (.T)
     yield the morphological exponent ([scott-2023] Table 3.5).
@@ -192,8 +193,9 @@ def setAVocab : Vocabulary :=
     matches — also catching the blocked-Infl-probe case in transitives. -/
 def setBVocab : Vocabulary :=
   makePersonVocab setBSpecificCells Agreement.Cell.toPhiFeatures
-    (fun c => (setBExponent.realize c).getD "") (some .T) ++
-    [{ features := ⊥, exponent := defaultSetB, context := some .T }]
+    (fun c => ((setBExponent.realize c).map
+      Morphology.Exponent.toString).getD "") (some .T) ++
+    [{ features := ⊥, exponent := Morphology.Exponent.toString defaultSetB, context := some .T }]
 
 /-- Which Minimalist head φ-Agrees with each argument position.
     Ditransitive R/T default to none (not modeled). -/
@@ -268,11 +270,13 @@ theorem setA_spellout_3sg :
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" := by
   native_decide
 
-/-- Set A spellout for 1SG: Voice with [Person:1, Number:sg] yields A1SG marker. -/
+/-- Set A spellout for 1SG: Voice with [Person:1, Number:sg] yields the
+    A1SG marker (pre-consonantal citation form `n-`; the pre-vocalic
+    variant `w-` lives in the fragment's `.vowel` table). -/
 theorem setA_spellout_1sg :
     let v1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-    spellout setAVocab v1sg (some .v) = some "n-/w-" := by
+    spellout setAVocab v1sg (some .v) = some "n-" := by
   native_decide
 
 -- ============================================================================


### PR DESCRIPTION
Wave 3 of the objects-and-homs plan: the form-side carrier, following [haspelmath-2020]'s proposal (bib entry landed in #1505), with the Mayan cluster as its consumer wave. Full-library build green (6695 jobs).

- `Morphology/Morph.lean`: `Morph` (kind × form; kinds = the sources' own notation conventions), `Exponent := List Morph` (`[]` = zero exponence, length ≥ 2 = discontinuous construction), `toString` reproducing descriptive notation, `Following` conditioning index
- `Mayan.ExponentTable := Agreement.Paradigm Exponent`; `IsThirdSgZero` collapses to `= some []`; all 8 fragments' tables structured, Set A allomorphy unified as `Following → ExponentTable` (replacing two-table / slash-glued / parens / function+table encodings)
- data verified against primary fulltexts (Preminger ex. (29), Scott T2.8, Mondloch, Vázquez Álvarez): fixes Tsotsil's reversed 1sg pair, documents Kaqchikel's convention-based preC/preV decode and Kiche's construction-conditioned nu-/in-
- DM-spellout bridges (Preminger2014, Scott2023) route through `Exponent.toString`; Scott2023's 1SG pin corrected from the glued "n-/w-" to "n-"