### PR TITLE
feat(Morphology/Paradigm): Stump linkage + implicative structure

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1336,6 +1336,7 @@ import Linglib.Morphology.Number
 import Linglib.Morphology.Paradigm.Basic
 import Linglib.Morphology.Paradigm.Complexity
 import Linglib.Morphology.Paradigm.Contiguity
+import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.RootFamily
 import Linglib.Morphology.TenseAspect
 import Linglib.Morphology.TheorySpace
@@ -2697,6 +2698,7 @@ import Linglib.Studies.Stojkovic2026
 import Linglib.Studies.Storme2026
 import Linglib.Studies.Storment2026
 import Linglib.Studies.Sudo2016
+import Linglib.Studies.Stump2016
 import Linglib.Studies.SumersEtAl2023
 import Linglib.Studies.SuttonFilip2021
 import Linglib.Studies.TaraldsenEtAl2018

--- a/Linglib/Morphology/Paradigm/Complexity.lean
+++ b/Linglib/Morphology/Paradigm/Complexity.lean
@@ -2,18 +2,27 @@ import Linglib.Morphology.Paradigm.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
 
 /-!
-# Paradigm complexity: entropy over cell distributions
-[ackerman-malouf-2013] [rathi-hahn-futrell-2026]
+# Paradigm complexity: entropy and implicative structure over cells
+[ackerman-malouf-2013] [bonami-beniamine-2016] [rathi-hahn-futrell-2026]
 
-Entropy-based measures over `ParadigmSystem` cell distributions:
-Shannon entropy of a cell, conditional entropy between cells (the
-integrand of [ackerman-malouf-2013]'s i-complexity), and the derived
-implicative-structure predicates.
+Two views of the Paradigm Cell Filling Problem over a `ParadigmSystem`.
+The **quantitative** layer measures cell distributions: Shannon entropy
+of a cell, conditional entropy between cells (the integrand of
+[ackerman-malouf-2013]'s i-complexity), and the derived
+implicative-structure predicates. The **qualitative** layer is the
+zero-entropy (categorical) case: a set of cells `Predicts` another when
+the forms filling it determine the form filling the target across every
+inflection class — the implicative relation [bonami-beniamine-2016]
+quantify with conditional entropy, here as a plain relation over the
+system's rows. Entropy quantification stays prose-level per repo
+discipline; `Predicts` is its zero-entropy extreme.
 
 ## Main declarations
 
 * `ParadigmSystem.cellEntropy`, `ParadigmSystem.conditionalCellEntropy`
 * `ParadigmSystem.isImplicative`, `ParadigmSystem.isTransparent`
+* `ParadigmSystem.Predicts`, `ParadigmSystem.IsPrincipalPartSet` — the
+  categorical implicative relation and principal-part sets
 
 `iComplexity` (the paper-specific average conditional entropy) and
 `LCECHolds` (the LCEC threshold predicate) live in
@@ -69,5 +78,44 @@ def ParadigmSystem.isImplicative {n : ℕ} {Form : Type*} [DecidableEq Form]
 def ParadigmSystem.isTransparent {n : ℕ} {Form : Type*} [DecidableEq Form]
     (ps : ParadigmSystem n Form) : Prop :=
   ∀ (ci cj : Fin n), ci ≠ cj → ps.isImplicative ci cj
+
+/-! ### Qualitative implicative structure
+
+The categorical (zero-entropy) face of the Paradigm Cell Filling
+Problem [bonami-beniamine-2016]: which sets of known cells determine an
+unknown cell across the inflection classes. -/
+
+/-- A set of cells `S` **predicts** cell `j` when the forms filling `S`
+determine the form filling `j` across the system: any two inflection
+classes agreeing on every cell of `S` also agree at `j`. The
+zero-conditional-entropy case of the implicative relation
+[bonami-beniamine-2016] measure. -/
+def ParadigmSystem.Predicts {n : ℕ} {Form : Type*}
+    (ps : ParadigmSystem n Form) (S : Finset (Fin n)) (j : Fin n) : Prop :=
+  ∀ p ∈ ps.entries, ∀ q ∈ ps.entries,
+    (∀ c ∈ S, p.1 c = q.1 c) → p.1 j = q.1 j
+
+/-- A set of cells is a **principal-part set** when it predicts every cell
+of the system: knowing those forms determines the whole paradigm. -/
+def ParadigmSystem.IsPrincipalPartSet {n : ℕ} {Form : Type*}
+    (ps : ParadigmSystem n Form) (S : Finset (Fin n)) : Prop :=
+  ∀ j, ps.Predicts S j
+
+/-- Prediction is **monotone** in the known cells: enlarging the predictor
+set never destroys a prediction. -/
+theorem ParadigmSystem.Predicts.mono {n : ℕ} {Form : Type*}
+    {ps : ParadigmSystem n Form} {S T : Finset (Fin n)} {j : Fin n}
+    (hST : S ⊆ T) (h : ps.Predicts S j) : ps.Predicts T j :=
+  fun p hp q hq hag => h p hp q hq fun c hc => hag c (hST hc)
+
+/-- A worked case: a two-class system whose first cell is diagnostic. The
+classes differ at cell `0`, so it is a principal-part set — its form
+determines cell `1`. -/
+private def demoSystem : ParadigmSystem 2 String :=
+  { entries := [(![("a"), ("x")], 1 / 2), (![("b"), ("y")], 1 / 2)] }
+
+private theorem demoSystem_principalPart :
+    demoSystem.IsPrincipalPartSet {0} := by
+  intro j; fin_cases j <;> (unfold ParadigmSystem.Predicts; decide)
 
 end Morphology

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -1,0 +1,115 @@
+import Mathlib.Logic.Function.Basic
+
+/-!
+# Paradigm linkage: content paradigms, form paradigms, and correspondence
+[stump-2016]
+
+The paradigm-linkage hypothesis ([stump-2016] Ch. 7) splits a lexeme's
+realizations into three corresponding paradigms:
+
+* the **content paradigm** — cells `⟨L, σ⟩` pairing a lexeme `L` with a
+  morphosyntactic property set `σ`; the interface with syntax and semantics;
+* the **form paradigm** — cells `⟨Z, τ⟩` pairing a stem `Z` from `L`'s stem
+  set with a property set `τ` for which `Z` inflects; the basis for inflection;
+* the **realized paradigm** — cells `⟨w, τ⟩` pairing a word form `w` with the
+  property set it realizes.
+
+Each content cell is realized by being linked to a **form correspondent** — a
+form cell whose realization it shares. The correspondence function `Corr`
+decomposes (§7.2) as a **stem selection** and a **property mapping** `pm`:
+`Corr(⟨L, σ⟩) = ⟨Stem(⟨L, σ⟩), pm(σ)⟩`, and the paradigm function factors as
+`PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`. Canonically `pm` is the identity and each
+lexeme has a single stem, so content and form paradigms are isomorphic; the
+book's later chapters catalogue the deviation modes — morphomic properties
+(Ch. 8), defectiveness/overabundance (Ch. 9), syncretism as many-to-one `Corr`
+(Ch. 10), suppletion/heteroclisis (Ch. 11), deponency as a voice-flipping `pm`
+(Ch. 12, formalized in `Studies/Stump2016.lean`), and polyfunctionality
+(Ch. 13).
+
+## Main declarations
+
+* `Linkage L Z P` — a lexeme-level linkage: stem selection `Stem` plus
+  property mapping `pm`
+* `Linkage.corr` — the form-correspondence function `Corr = ⟨Stem, pm⟩`
+* `Linkage.realize` — the realized paradigm `PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`
+* `Linkage.IsCanonical` — cell-level canonical linkage: property-set
+  preservation (`pm = id`, §7.1 (2a)) and stem invariance (§7.1 (2b))
+* `Linkage.canonical` / `canonical_isCanonical` — the canonical one-stem linkage
+* `Linkage.realize_eq_of_corr_eq` — a many-to-one `Corr` forces content-side
+  syncretism (the Ch. 10 deviation mode)
+-/
+
+namespace Morphology
+
+/-- A **paradigm linkage** ([stump-2016] §7.2), presented from the vantage of a
+single lexeme: the two components of the form-correspondence function `Corr`.
+`stem` is the stem selection `Stem(⟨L, σ⟩)` picking the stem that realizes a
+content cell; `pm` is the property mapping `σ ↦ τ`. Canonically `pm` is the
+identity and `stem` is constant in the property set (one stem per lexeme). -/
+structure Linkage (L Z P : Type*) where
+  /-- Stem selection `Stem(⟨L, σ⟩)`: the stem realizing the content cell. -/
+  stem : L → P → Z
+  /-- The property mapping `pm : σ ↦ τ` carrying a content cell's property set
+  to its form correspondent's. -/
+  pm : P → P
+
+namespace Linkage
+
+variable {L Z P W : Type*} (ℓ : Linkage L Z P)
+
+/-- The **form-correspondence function** `Corr(⟨L, σ⟩) = ⟨Stem(⟨L, σ⟩), pm(σ)⟩`
+([stump-2016] §7.2): the form cell realizing content cell `⟨l, σ⟩`. -/
+def corr (l : L) (σ : P) : Z × P := (ℓ.stem l σ, ℓ.pm σ)
+
+/-- The **realized paradigm** on content cells: `PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`.
+Given the form-cell realization `realizeForm` (the rules of exponence, `PF` on
+form cells), the content cell `⟨l, σ⟩` realizes as `⟨w, τ⟩` where `⟨Z, τ⟩` is
+its form correspondent and `w` is `Z`'s realization at `τ`. -/
+def realize (realizeForm : Z → P → W) (l : L) (σ : P) : W × P :=
+  (realizeForm (ℓ.corr l σ).1 (ℓ.corr l σ).2, (ℓ.corr l σ).2)
+
+/-- **Property-set preservation** ([stump-2016] §7.1, canonical characteristic
+(2a)): the property mapping is the identity, so a content cell and its form
+correspondent share a property set. -/
+def IsPropertyPreserving : Prop := ∀ σ, ℓ.pm σ = σ
+
+/-- **Stem invariance** ([stump-2016] §7.1, canonical characteristic (2b)): each
+lexeme has a single stem realizing all of its cells. -/
+def IsStemInvariant : Prop := ∀ l, ∃ z, ∀ σ, ℓ.stem l σ = z
+
+/-- **Canonical paradigm linkage** at the cell level ([stump-2016] §7.1):
+property-set preservation together with stem invariance. The remaining
+canonical characteristics — unambiguity and isomorphism within/across syntactic
+categories (2c–e) — quantify over sets of paradigms, not a single linkage. -/
+def IsCanonical : Prop := ℓ.IsPropertyPreserving ∧ ℓ.IsStemInvariant
+
+/-- Under property-set preservation, each content cell's form correspondent
+carries the content cell's own property set — the canonical, mismatch-free
+alignment of content and form. -/
+theorem corr_snd_eq_of_propertyPreserving (h : ℓ.IsPropertyPreserving)
+    (l : L) (σ : P) : (ℓ.corr l σ).2 = σ := h σ
+
+/-- **A many-to-one `Corr` forces content-side syncretism**: content cells with
+a common form correspondent share their realization ([stump-2016] Ch. 10's
+syncretism deviation mode). -/
+theorem realize_eq_of_corr_eq (realizeForm : Z → P → W) {l : L} {σ₁ σ₂ : P}
+    (h : ℓ.corr l σ₁ = ℓ.corr l σ₂) :
+    ℓ.realize realizeForm l σ₁ = ℓ.realize realizeForm l σ₂ := by
+  simp only [realize, h]
+
+/-- The **canonical one-stem linkage**: the identity property mapping together
+with a designated stem `st l` for each lexeme. -/
+def canonical (st : L → Z) : Linkage L Z P where
+  stem := fun l _ => st l
+  pm := id
+
+@[simp] theorem canonical_pm (st : L → Z) (σ : P) :
+    (canonical (P := P) st).pm σ = σ := rfl
+
+theorem canonical_isCanonical (st : L → Z) :
+    (canonical (P := P) st).IsCanonical :=
+  ⟨fun _ => rfl, fun l => ⟨st l, fun _ => rfl⟩⟩
+
+end Linkage
+
+end Morphology

--- a/Linglib/Studies/KalinBjorkmanEtAl2026.lean
+++ b/Linglib/Studies/KalinBjorkmanEtAl2026.lean
@@ -2,6 +2,7 @@ import Linglib.Morphology.TheorySpace
 import Linglib.Morphology.MorphRule
 import Linglib.Studies.ZwickyPullum1983
 import Linglib.Morphology.Nanosyntax.Superset
+import Linglib.Morphology.Paradigm.Linkage
 
 -- ============================================================================
 -- § 0b: PFM Substrate (was Morphology/PFM/Core.lean,
@@ -87,6 +88,28 @@ def derive {Feature : Type} [BEq Feature]
   match referrals.findSome? (·.apply pf σ lex) with
   | some form => form
   | none => pf.apply σ lex
+
+/-- PFM's paradigm function is the word form of the [stump-2016] realized
+paradigm under the **canonical** linkage: taking each lexeme as its own single
+stem and the identity property mapping, `PF(⟨lex, σ⟩) = PF(Corr(⟨lex, σ⟩))`
+recovers `pf.apply σ lex`. PFM's realization is thus the mismatch-free case —
+deponency or heteroclisis would require a non-identity `pm` or multiple stems
+(`Morphology/Paradigm/Linkage.lean`, `Studies/Stump2016.lean`). -/
+theorem ParadigmFunction.apply_eq_linkage_realize {Feature : Type} [BEq Feature]
+    (pf : ParadigmFunction Feature) (lex : Lexeme)
+    (σ : MorphPropertySet Feature) :
+    pf.apply σ lex
+      = ((Morphology.Linkage.canonical (Z := Lexeme)
+            (P := MorphPropertySet Feature) id).realize
+          (fun l τ => pf.apply τ l) lex σ).1 :=
+  rfl
+
+/-- The linkage PFM instantiates is canonical ([stump-2016] §7.1): identity
+property mapping and one stem per lexeme. -/
+theorem paradigmFunction_linkage_isCanonical {Feature : Type} :
+    (Morphology.Linkage.canonical (L := Lexeme) (Z := Lexeme)
+      (P := MorphPropertySet Feature) id).IsCanonical :=
+  Morphology.Linkage.canonical_isCanonical _
 
 end Morphology.PFM
 

--- a/Linglib/Studies/Stump2016.lean
+++ b/Linglib/Studies/Stump2016.lean
@@ -1,0 +1,136 @@
+import Linglib.Morphology.Paradigm.Linkage
+
+/-!
+# Stump 2016: Latin deponency as a voice-flipping paradigm linkage
+[stump-2016]
+
+Latin deponent verbs are [stump-2016]'s central argument for the
+paradigm-linkage hypothesis (Ch. 12): their active forms "inflect by means of
+the morphology that ordinarily serves to express a verb's passive forms"
+(§12.1). Deponent *cōnārī* 'try' realizes its active content cells —
+*cōnor, cōnāris, cōnātur, cōnāmur, cōnāminī, cōnantur* (imperfective present
+indicative, Table 12.2) — with the passive personal endings
+(-or, -ris, -tur, -mur, -minī, -ntur) that a regular verb like *parāre*
+'prepare' uses only for its passive (*paror, parāris, parātur, …*, Table 12.1);
+*cōnārī* lacks passive-meaning forms entirely.
+
+In the paradigm-linkage architecture (`Morphology/Paradigm/Linkage.lean`) this
+is a property mapping that crosses the voice axis. A regular verb is subject to
+the canonical `pmc(σ) = σ ∪ {c}` (property-set preserving on the contentful
+features); a deponent is subject to `pm2c(σ:{active}) = σ[active/passive] ∪ {c}`
+(§12.1), replacing active with passive. Abstracting away the inflection-class
+index `c` (which is orthogonal to the voice mismatch), the deponent linkage's
+property mapping flips voice while the regular verb's preserves it. The
+theorems below show *cōnārī*'s linkage deviates from `IsCanonical` on every
+active cell — its form correspondents are all passive — while sharing the
+content-cell space with the regular verb.
+
+## Main declarations
+
+* `conariLinkage`, `parareLinkage` — the deponent and regular linkages
+* `parareLinkage_isCanonical` — the regular verb's voice-preserving linkage is
+  canonical
+* `conari_deviates_on_every_active_cell` — the deponent `pm` moves every active
+  content cell off its own property set
+* `conari_active_realized_by_passive_form` — every active content cell's form
+  correspondent is passive (the deponency claim)
+* `depon_vs_regular` — same active content cell: regular → active form,
+  deponent → passive form
+-/
+
+namespace Stump2016
+
+open Morphology
+
+/-- Voice: the axis Latin deponency crosses ([stump-2016] §12.1). -/
+inductive Voice where
+  | active
+  | passive
+  deriving DecidableEq, Repr
+
+/-- Person–number agreement: the six cells of the imperfective present
+indicative ([stump-2016] Tables 12.1–12.2). -/
+inductive Agr where
+  | s1 | s2 | s3 | p1 | p2 | p3
+  deriving DecidableEq, Repr
+
+/-- A morphosyntactic property set, abstracted to the voice axis and the
+agreement features relevant to Latin deponency (the inflection-class index and
+tense/aspect/mood, held constant across the paradigm below, are elided). -/
+structure Cell where
+  agr : Agr
+  voice : Voice
+  deriving DecidableEq, Repr
+
+/-- The two Latin lexemes contrasted: the deponent *cōnārī* and the regular
+*parāre*. -/
+inductive LatinVerb where
+  | conari
+  | parare
+  deriving DecidableEq, Repr
+
+/-- Their stems. -/
+inductive LatinStem where
+  | cona
+  | para
+  deriving DecidableEq, Repr
+
+/-- The **deponent linkage** of *cōnārī*: a single stem and the voice-flipping
+property mapping `pm2c` ([stump-2016] §12.1), which sends an active content cell
+to a passive form cell. -/
+def conariLinkage : Linkage LatinVerb LatinStem Cell where
+  stem := fun _ _ => .cona
+  pm := fun σ => { σ with voice := .passive }
+
+/-- The **regular linkage** of *parāre*: a single stem and the identity property
+mapping, canonical on the voice axis ([stump-2016] §7.1). -/
+def parareLinkage : Linkage LatinVerb LatinStem Cell where
+  stem := fun _ _ => .para
+  pm := id
+
+/-- *cōnārī*'s six active content cells ([stump-2016] Table 12.2). -/
+def conariContentCells : List Cell :=
+  [⟨.s1, .active⟩, ⟨.s2, .active⟩, ⟨.s3, .active⟩,
+   ⟨.p1, .active⟩, ⟨.p2, .active⟩, ⟨.p3, .active⟩]
+
+/-- The regular verb's linkage is canonical: property-set preserving (`pm = id`)
+and stem invariant ([stump-2016] §7.1, characteristics (2a)–(2b)). -/
+theorem parareLinkage_isCanonical : parareLinkage.IsCanonical :=
+  ⟨fun _ => rfl, fun _ => ⟨.para, fun _ => rfl⟩⟩
+
+/-- The deponent property mapping flips voice on every active cell. -/
+theorem conari_pm_flips_voice (σ : Cell) :
+    (conariLinkage.pm σ).voice = .passive := rfl
+
+/-- The deponent linkage deviates from the canonical isomorphism on every active
+content cell: its property mapping moves the cell off its own property set. -/
+theorem conari_deviates_on_every_active_cell (σ : Cell) (h : σ.voice = .active) :
+    conariLinkage.pm σ ≠ σ := by
+  intro heq
+  have : Voice.passive = Voice.active := h ▸ congrArg Cell.voice heq
+  exact absurd this (by decide)
+
+/-- Hence the deponent linkage is not property-preserving, so not canonical. -/
+theorem conariLinkage_not_canonical : ¬ conariLinkage.IsCanonical := by
+  rintro ⟨hpp, -⟩
+  exact conari_deviates_on_every_active_cell ⟨.s1, .active⟩ rfl (hpp _)
+
+/-- **The deponency claim**: every active content cell of *cōnārī* has a
+*passive* form correspondent — active content realized by passive morphology
+([stump-2016] §12.1). -/
+theorem conari_active_realized_by_passive_form (l : LatinVerb) (σ : Cell) :
+    (conariLinkage.corr l σ).2.voice = .passive := rfl
+
+/-- Every one of *cōnārī*'s six active content cells crosses the voice axis. -/
+theorem conari_all_cells_cross_voice :
+    ∀ σ ∈ conariContentCells, conariLinkage.pm σ ≠ σ := by decide
+
+/-- The crisp contrast: on the *same* active content cell, the regular verb's
+form correspondent stays active while the deponent's becomes passive — deviation
+without any difference in the content-cell space. -/
+theorem depon_vs_regular (σ : Cell) (h : σ.voice = .active) :
+    (parareLinkage.corr .parare σ).2.voice = .active ∧
+      (conariLinkage.corr .conari σ).2.voice = .passive :=
+  ⟨h, rfl⟩
+
+end Stump2016

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19705,6 +19705,20 @@
   role      = {formalized},
   sources   = {Studies/AckermanMalouf2013.lean}
 }
+@article{bonami-beniamine-2016,
+  author    = {Bonami, Olivier and Beniamine, Sacha},
+  year      = {2016},
+  title     = {Joint Predictiveness in Inflectional Paradigms},
+  journal   = {Word Structure},
+  volume    = {9},
+  number    = {2},
+  pages     = {156--182},
+  doi       = {10.3366/word.2016.0092},
+  subfield  = {morphology},
+  validated = {true},
+  role      = {cited},
+  sources   = {Morphology/Paradigm/Complexity.lean}
+}
 @phdthesis{goldsmith-1976,
   author    = {Goldsmith, John A.},
   year      = {1976},
@@ -26284,6 +26298,20 @@
   role      = {cited},
   validated = {true},
   sources   = {Morphology/TheorySpace.lean;Studies/KalinBjorkmanEtAl2026.lean;Morphology/Containment/Vocabulary.lean}
+}
+@book{stump-2016,
+  author    = {Stump, Gregory T.},
+  year      = {2016},
+  title     = {Inflectional Paradigms: Content and Form at the Syntax-Morphology Interface},
+  series    = {Cambridge Studies in Linguistics},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  isbn      = {9781107088832},
+  doi       = {10.1017/CBO9781316105290},
+  subfield  = {morphology},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Morphology/Paradigm/Linkage.lean;Studies/Stump2016.lean;Studies/KalinBjorkmanEtAl2026.lean}
 }
 @article{embick-noyer-2001,
   author    = {Embick, David and Noyer, Rolf},


### PR DESCRIPTION
Wave 4 of the objects-and-homs plan: the paradigm-linkage hom, built true to the book (Stump 2016 chapter PDFs in hand; Ch. 7 read in full). Full-library build green (6697 jobs).

- `Paradigm/Linkage.lean`: Stump's three-paradigm architecture with the Corr decomposition (stem selection × property mapping), `IsCanonical` from his §7.1 characteristics, syncretism as many-to-one Corr; unread deviation chapters get docstring pointers, not invented predicates
- `Studies/Stump2016.lean` (new): Latin deponent *cōnārī* vs regular *parāre* — the voice-flipping property mapping proved non-canonical on every active cell, with every active content cell realized by a passive form correspondent (Table 12.2, §12.1); forms cited, not fabricated
- KalinBjorkmanEtAl2026: `ParadigmFunction` proved to be Stump's realized-paradigm map under the canonical linkage (rfl) — the PFM↔linkage cross-framework hom
- `Complexity.lean`: qualitative implicative layer (`Predicts`, `IsPrincipalPartSet`, monotonicity) as the zero-conditional-entropy case of [bonami-beniamine-2016]'s measure; no entropy numbers
- Elsewhere-study migrations investigated and honestly skipped (none of the four candidates is Elsewhere-shaped)
- verified bib entries `stump-2016`, `bonami-beniamine-2016`