### PR TITLE
refactor(Morphology): parameterize AffixTemplate; absorb Mayan template

### DIFF
--- a/Linglib/Fragments/Japanese/Morph.lean
+++ b/Linglib/Fragments/Japanese/Morph.lean
@@ -45,7 +45,7 @@ example : morphProfile.IsAgglutinating := by decide
 
 /-- Japanese verb suffix template, stem-outward ([kaiser-yamamoto-2013], UD
 segmentation). Japanese is strongly suffixing, so there are no prefix slots. -/
-def verbAffixTemplate : AffixTemplate where
+def verbAffixTemplate : AffixTemplate MorphCategory where
   suffixSlots :=
     [ .derivation       -- 1. -su (suru)
     , .valence          -- 2. -(s)ase (causative)

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -5,6 +5,7 @@ import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Morph
 import Linglib.Morphology.Word
+import Linglib.Morphology.AffixTemplate
 
 /-!
 # Shared Mayan Fragment Infrastructure
@@ -426,32 +427,35 @@ def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
 
 /-- A position class in the Mayan verbal complex, in the traditional
     Mayanist categories (so Set A and Set B stay distinct — a cut
-    `Morphology.MorphCategory` cannot draw). -/
+    `Morphology.MorphCategory` cannot draw). The verb stem is not a slot:
+    a morpheme's position relative to it is the template's prefix/suffix
+    split (`Morphology.AffixTemplate`). -/
 inductive VerbSlot where
   | aspect
   | setB
   | setA
-  | root
   | status
   deriving DecidableEq, Repr
 
-/-- The verbal-complex template, stem-inclusive and left-to-right, in
-    canonical transitive citation form. Per-language morpheme orders as
-    documented in each fragment ([preminger-2014] (12) for the K'ichean
-    shape, [vazquez-alvarez-2011] §3.4 for Chol, [polian-2017] for
-    Tseltalan and the Mam status-suffix loss); Tsotsil's prefixal Set B
-    subset is recorded at `Tsotsil.setBLinearity`. -/
-def template : Mayan → List VerbSlot
-  | .Kaqchikel | .Kiche | .Qanjobal => [.aspect, .setB, .setA, .root, .status]
-  | .Mam => [.aspect, .setB, .setA, .root]
-  | .Chol | .Yukatek => [.aspect, .setA, .root, .status, .setB]
-  | .Tseltal | .Tsotsil => [.aspect, .setA, .root, .setB]
+/-- The verbal-complex template in canonical transitive citation form,
+    with `prefixSlots` running to the verb stem and `suffixSlots` running
+    stem-outward — so a slot's side of the split records its position
+    relative to the root. Per-language morpheme orders as documented in
+    each fragment ([preminger-2014] (12) for the K'ichean shape,
+    [vazquez-alvarez-2011] §3.4 for Chol, [polian-2017] for Tseltalan and
+    the Mam status-suffix loss); Tsotsil's prefixal Set B subset is
+    recorded at `Tsotsil.setBLinearity`. -/
+def template : Mayan → Morphology.AffixTemplate VerbSlot
+  | .Kaqchikel | .Kiche | .Qanjobal => ⟨[.aspect, .setB, .setA], [.status]⟩
+  | .Mam => ⟨[.aspect, .setB, .setA], []⟩
+  | .Chol | .Yukatek => ⟨[.aspect, .setA], [.status, .setB]⟩
+  | .Tseltal | .Tsotsil => ⟨[.aspect, .setA], [.setB]⟩
 
 /-- The absolutive-position classifier derived from the template: HIGH
-    iff Set B precedes the root. `absPosition_matches_template` in
-    `Studies/CoonMateoPedroPreminger2014.lean` checks it against the
+    iff Set B is a pre-stem (prefix) slot. `absPosition_matches_template`
+    in `Studies/CoonMateoPedroPreminger2014.lean` checks it against the
     fragments' analytical `absPosition` values. -/
 def templateABSPosition (l : Mayan) : ABSPosition :=
-  if .setB ∈ (template l).takeWhile (· ≠ .root) then .high else .low
+  if .setB ∈ (template l).prefixSlots then .high else .low
 
 end Mayan

--- a/Linglib/Fragments/Sesotho/Morph.lean
+++ b/Linglib/Fragments/Sesotho/Morph.lean
@@ -22,7 +22,7 @@ open Morphology
 
 /-- Sesotho verb affix template ([demuth-1992], [doke-mofokeng-1967]). The
 suffix slots run stem-outward; the prefix slots run word-edge inward. -/
-def verbAffixTemplate : AffixTemplate where
+def verbAffixTemplate : AffixTemplate MorphCategory where
   suffixSlots :=
     [ .valence    -- 1. reversive
     , .valence    -- 2. causative

--- a/Linglib/Morphology/AffixTemplate.lean
+++ b/Linglib/Morphology/AffixTemplate.lean
@@ -3,37 +3,40 @@ import Linglib.Morphology.MorphRule
 /-!
 # Affix position-class templates
 
-A language's verb (or word) affix template: the ordered morpheme-category slots
-of its prefix and suffix strings. This is the per-language, Fragment-importable
-substrate that `RespectsRelevanceHierarchy` (in `Morphology/MorphRule.lean`)
-tests against [bybee-1985]'s relevance hierarchy — so a language's slot order
-lives once, as Fragment data, and study files derive their checks from it rather
-than re-typing the template.
+A word's affix template: the ordered position-class slots of its prefix and
+suffix strings, parameterized by the slot type `Slot`. Instantiating at
+`MorphCategory` gives a language's slot order as Fragment-importable substrate
+that `RespectsRelevanceHierarchy` (in `Morphology/MorphRule.lean`) tests against
+[bybee-1985]'s relevance hierarchy — so the order lives once, as Fragment data,
+and study files derive their checks from it rather than re-typing the template.
+Instantiating at a language-specific slot type carries finer position classes:
+`Mayan.template` uses `Mayan.VerbSlot`, with the prefix/suffix split encoding a
+morpheme's position relative to the verb stem.
 
 ## Main definitions
 
-* `Morphology.AffixTemplate` — a language's prefix/suffix slots as `MorphCategory` lists.
-* `Morphology.AffixTemplate.suffixRespectsRelevance` — the suffix slots are sorted by relevance.
+* `Morphology.AffixTemplate` — a word's prefix/suffix slots over an arbitrary slot type.
+* `Morphology.AffixTemplate.suffixRespectsRelevance` — the `MorphCategory` suffix slots are sorted by relevance.
 -/
 
 namespace Morphology
 
-/-- A language's affix position-class template. `suffixSlots` runs stem-outward
+/-- A word's affix position-class template. `suffixSlots` runs stem-outward
 (innermost suffix first); `prefixSlots` is listed as the source grammar writes
-it, word-edge inward. Slots are `MorphCategory` tags, not exponents — the actual
+it, word-edge inward. Slots are `Slot` tags, not exponents — the actual
 morphemes live in the citing grammar. -/
-structure AffixTemplate where
-  /-- Suffix slots, ordered stem-outward (innermost suffix first). -/
-  suffixSlots : List MorphCategory := []
+structure AffixTemplate (Slot : Type*) where
   /-- Prefix slots, ordered word-edge inward (outermost prefix first). -/
-  prefixSlots : List MorphCategory := []
+  prefixSlots : List Slot := []
+  /-- Suffix slots, ordered stem-outward (innermost suffix first). -/
+  suffixSlots : List Slot := []
   deriving Repr, DecidableEq
 
 /-- The template's suffix order respects [bybee-1985]'s relevance hierarchy. -/
-def AffixTemplate.suffixRespectsRelevance (t : AffixTemplate) : Prop :=
+def AffixTemplate.suffixRespectsRelevance (t : AffixTemplate MorphCategory) : Prop :=
   RespectsRelevanceHierarchy t.suffixSlots
 
-instance (t : AffixTemplate) : Decidable t.suffixRespectsRelevance :=
+instance (t : AffixTemplate MorphCategory) : Decidable t.suffixRespectsRelevance :=
   inferInstanceAs (Decidable (RespectsRelevanceHierarchy _))
 
 end Morphology


### PR DESCRIPTION
The one-template-carrier unification from the objects-and-homs side-queue. Full-library build green (6695 jobs).

- `AffixTemplate (Slot : Type*)` — position classes over any slot vocabulary; Bybee relevance predicate becomes the `MorphCategory` specialization, untouched semantically
- `Mayan.template` re-expressed as `AffixTemplate VerbSlot`: the prefix/suffix split carries root-relative position structurally, so the `.root` sentinel constructor and the `takeWhile` surgery in `templateABSPosition` dissolve — HIGH-ABS is now literally `setB ∈ prefixSlots`
- `absPosition_matches_template` closes unchanged against the new definition (the refactor is provably value-preserving); no consumer beyond type ascriptions needed edits