### PR TITLE
refactor(Morphology/Exponence): put the specificity order on Rule

### DIFF
--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -143,13 +143,14 @@ def VocabEntry.toRule (e : VocabEntry) : Rule (FeatureBundle × Option Cat) Stri
   ⟨e.exponent, λ tc => e.Matches tc.1 tc.2⟩
 
 /-- Syntactic refinement: a feature-superset entry (with compatible
-context restriction) is at least as specific in the derived order of
-the shared core. -/
-theorem VocabEntry.toRule_moreSpecific_of_superset {e e' : VocabEntry}
+context restriction) is at least as specific in the shared core's
+order. -/
+theorem VocabEntry.toRule_le_of_superset {e e' : VocabEntry}
     (hf : ∀ f ∈ FeatureBundle.toGramFeatures e'.features,
       f ∈ FeatureBundle.toGramFeatures e.features)
     (hc : e'.context = none ∨ e'.context = e.context) :
-    e.toRule.MoreSpecific e'.toRule := by
+    e.toRule ≤ e'.toRule := by
+  rw [Rule.le_iff]
   rintro ⟨t, c⟩ ⟨hm, hctx⟩
   refine ⟨?_, ?_⟩
   · rw [VocabEntry.MatchesFeatures, List.all_eq_true] at hm ⊢
@@ -167,28 +168,29 @@ theorem VocabEntry.matchesFeatures_self (e : VocabEntry) :
   intro ef hef
   exact List.any_eq_true.mpr ⟨ef, hef, beq_self_eq_true ef⟩
 
-/-- Derived specificity, characterized: `e` is at least as specific as
-`e'` in the shared core iff `e'`'s features are a subset of `e`'s and
-`e'`'s context restriction is compatible. Upgrades
-`toRule_moreSpecific_of_superset` to an iff — over feature bundles the
-intensional superset order IS the derived order, with no faithfulness
-assumption (contrast `Morphology.DM.VI.SpecificityFaithful`, which the
-opaque-predicate engine must stipulate). -/
-theorem VocabEntry.toRule_moreSpecific_iff {e e' : VocabEntry} :
-    e.toRule.MoreSpecific e'.toRule ↔
+/-- The shared core's specificity order, characterized: `e ≤ e'` iff
+`e'`'s features are a subset of `e`'s and `e'`'s context restriction is
+compatible. Upgrades `toRule_le_of_superset` to an iff — over feature
+bundles the intensional superset order IS the specificity order, with
+no faithfulness assumption (contrast
+`Morphology.DM.VI.SpecificityFaithful`, which the opaque-predicate
+engine must stipulate). -/
+theorem VocabEntry.toRule_le_iff {e e' : VocabEntry} :
+    e.toRule ≤ e'.toRule ↔
       (∀ f ∈ FeatureBundle.toGramFeatures e'.features,
         f ∈ FeatureBundle.toGramFeatures e.features) ∧
       (e'.context = none ∨ e'.context = e.context) := by
   constructor
   · intro h
     obtain ⟨hm', hctx'⟩ :=
-      h (c := (e.features, e.context)) ⟨e.matchesFeatures_self, Or.inr rfl⟩
+      Rule.le_iff.mp h (c := (e.features, e.context))
+        ⟨e.matchesFeatures_self, Or.inr rfl⟩
     refine ⟨?_, hctx'⟩
     rw [VocabEntry.MatchesFeatures, List.all_eq_true] at hm'
     intro f hf
     obtain ⟨tf, htf, hbeq⟩ := List.any_eq_true.mp (hm' f hf)
     exact (beq_iff_eq.mp hbeq) ▸ htf
-  · exact λ ⟨hf, hc⟩ => toRule_moreSpecific_of_superset hf hc
+  · exact λ ⟨hf, hc⟩ => toRule_le_of_superset hf hc
 
 /-! #### Bridge to the opaque-predicate engine -/
 
@@ -218,11 +220,12 @@ theorem VocabEntry.toVocabItem_toRule_applies (e : VocabEntry)
     e.toVocabItem.toRule.Applies tc ↔ e.toRule.Applies tc :=
   e.toVocabItem_matches tc.1 tc.2
 
-/-- Derived specificity transfers along the embedding — the cross-engine
+/-- Specificity transfers along the embedding — the cross-engine
 translation is faithful to the shared core's order. -/
-theorem VocabEntry.toVocabItem_toRule_moreSpecific {e f : VocabEntry} :
-    e.toVocabItem.toRule.MoreSpecific f.toVocabItem.toRule ↔
-      e.toRule.MoreSpecific f.toRule := by
+theorem VocabEntry.toVocabItem_toRule_le_iff {e f : VocabEntry} :
+    e.toVocabItem.toRule ≤ f.toVocabItem.toRule ↔
+      e.toRule ≤ f.toRule := by
+  simp only [Rule.le_iff]
   constructor <;> intro h c hc
   · exact (f.toVocabItem_toRule_applies c).mp
       (h ((e.toVocabItem_toRule_applies c).mpr hc))
@@ -237,15 +240,15 @@ theorem bestMatch_isElsewhereWinner {vocab : Vocabulary} {target : FeatureBundle
     {ctx : Option Cat} {e : VocabEntry}
     (h : bestMatch vocab target ctx = some e)
     (hfaith : ∀ a ∈ vocab, ∀ b ∈ vocab, a.Matches target ctx →
-      b.Matches target ctx → a.toRule.MoreSpecific b.toRule →
-      ¬ b.toRule.MoreSpecific a.toRule → b.specificity < a.specificity) :
+      b.Matches target ctx → a.toRule ≤ b.toRule →
+      ¬ b.toRule ≤ a.toRule → b.specificity < a.specificity) :
     IsElsewhereWinner (vocab.map VocabEntry.toRule) (target, ctx) e.toRule := by
   have hmem := List.argmax_mem h
   rw [List.mem_filter] at hmem
   obtain ⟨hev, hem⟩ := hmem
   have hematch : e.Matches target ctx := of_decide_eq_true hem
-  refine ⟨List.mem_map_of_mem hev, hematch, ?_⟩
-  rintro s hs happ hspec
+  refine ⟨⟨List.mem_map_of_mem hev, hematch⟩, ?_⟩
+  rintro s ⟨hs, happ⟩ hspec
   obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
   by_contra hns
   have hlt : e.specificity < b.specificity :=

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -169,8 +169,8 @@ order is not computable, so this engine must stipulate a rank — this
 Prop is the obligation the stipulation incurs, and
 `vocabularyInsert_isElsewhereWinner` is what discharging it buys. -/
 def SpecificityFaithful (rules : List (VocabItem Ctx Root)) : Prop :=
-  ∀ a ∈ rules, ∀ b ∈ rules, a.toRule.MoreSpecific b.toRule →
-    ¬ b.toRule.MoreSpecific a.toRule → b.specificity < a.specificity
+  ∀ a ∈ rules, ∀ b ∈ rules, a.toRule ≤ b.toRule →
+    ¬ b.toRule ≤ a.toRule → b.specificity < a.specificity
 
 private theorem findSome?_pairwise_max {l : List (VocabItem Ctx Root)}
     (hs : l.Pairwise (λ a b => b.specificity ≤ a.specificity))
@@ -219,8 +219,8 @@ theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
     exact this.imp (λ hab => by simpa using hab)
   obtain ⟨vi, hvi, hvm, hve, hmax⟩ := findSome?_pairwise_max hsort h
   rw [List.mem_mergeSort] at hvi
-  refine ⟨vi, hvi, hve, List.mem_map_of_mem hvi, hvm, ?_⟩
-  rintro s hs happ hspec
+  refine ⟨vi, hvi, hve, ⟨List.mem_map_of_mem hvi, hvm⟩, ?_⟩
+  rintro s ⟨hs, happ⟩ hspec
   obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
   by_contra hns
   have hlt : vi.specificity < b.specificity := hf b hb vi hvi hspec hns

--- a/Linglib/Morphology/Exponence/Hierarchy.lean
+++ b/Linglib/Morphology/Exponence/Hierarchy.lean
@@ -598,10 +598,10 @@ core: contexts are grades, applicability is `AppliesAt`. -/
 def ExponenceRule.toRule (it : ExponenceRule n F) : Exponence.Rule (Fin n) F :=
   ⟨it.exponent, it.AppliesAt⟩
 
-/-- Containment specificity is definitionally the derived specificity
-of the shared core. -/
-theorem ExponenceRule.toRule_moreSpecific_iff {it jt : ExponenceRule n F} :
-    it.toRule.MoreSpecific jt.toRule ↔ it.MoreSpecific jt :=
+/-- Containment specificity is definitionally the shared core's
+specificity order. -/
+theorem ExponenceRule.toRule_le_iff {it jt : ExponenceRule n F} :
+    it.toRule ≤ jt.toRule ↔ it.MoreSpecific jt :=
   Iff.rfl
 
 /-- The containment engine's Elsewhere winner is an Elsewhere winner of
@@ -611,10 +611,10 @@ theorem isElsewhereWinner_toRule {v : List (ExponenceRule n F)} {g : Fin n}
     Exponence.IsElsewhereWinner (v.map ExponenceRule.toRule) g it.toRule := by
   obtain ⟨hmem, hmt⟩ := winner_spec h
   obtain ⟨-, -, -, hle⟩ := exists_of_maxThreshold_eq_coe hmt
-  refine ⟨List.mem_map_of_mem hmem, hle, ?_⟩
-  rintro s hs hsapp -
+  refine ⟨⟨List.mem_map_of_mem hmem, hle⟩, ?_⟩
+  rintro s ⟨hs, hsapp⟩ -
   obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hs
-  rw [ExponenceRule.toRule_moreSpecific_iff,
+  rw [ExponenceRule.toRule_le_iff,
     ExponenceRule.moreSpecific_iff_threshold_le]
   exact threshold_le_of_maxThreshold_eq_coe hmt hjt hsapp
 

--- a/Linglib/Morphology/Exponence/Rule.lean
+++ b/Linglib/Morphology/Exponence/Rule.lean
@@ -1,51 +1,26 @@
-import Mathlib.Order.Defs.PartialOrder
-import Mathlib.Data.List.Basic
+import Mathlib.Order.Basic
+import Mathlib.Data.Set.Basic
 
 /-!
-# Rules of exponence: derived specificity and Elsewhere selection
+# Rules of exponence
 [kiparsky-1973] [halle-marantz-1993] [stump-2001]
 
-The shared realization core of the morphology formalisms. A rule of
-exponence pairs an exponent with an applicability condition on
-contexts; Pāṇinian specificity is *derived* as applicability-set
-inclusion ([kiparsky-1973]'s Elsewhere Condition compares rule domains,
-not stipulated ranks); an Elsewhere winner is a maximally specific
-applicable rule.
+A **rule of exponence** pairs an exponent with an applicability
+condition on contexts. Rules are preordered by applicability-set
+inclusion ([kiparsky-1973]'s Elsewhere Condition), and Elsewhere
+selection is minimality in this order: the most specific applicable
+rule is the one with the smallest domain.
 
-Framework engines specialize the context type and expose *intensional*
-context specifications from which the derived order is computable:
-
-* `Morphology.Containment.ExponenceRule`
-  (`Morphology/Exponence/Hierarchy.lean`) — contexts are the grades of
-  a containment hierarchy; specificity is threshold comparison
-  (`moreSpecific_iff_threshold_le`). The same carrier's **Superset**
-  reading (`Morphology/Nanosyntax/Superset.lean`, `toSupersetRule`)
-  carries the dual order — span comparison — and over context-free
-  vocabularies the two orders are exact mirrors
-  (`toRule_moreSpecific_iff_toSupersetRule`).
-* `Minimalist.VocabEntry` (`Morphology/DM/VocabSimple.lean`) — contexts
-  are feature bundles; the feature-superset order is exactly the
-  derived order (`VocabEntry.toRule_moreSpecific_iff`), and the entry
-  embeds into the opaque-predicate engine specificity-faithfully
-  (`VocabEntry.toVocabItem`).
-* `Morphology.DM.VI.VocabItem` — contexts are opaque predicates, so the
-  derived order is not computable and the engine stipulates a
-  `specificity` rank; `SpecificityFaithful` states that the stipulation
-  refines the derived order, and under it the engine's selection is an
-  Elsewhere winner.
-* `Morphology.Nanosyntax.TreeLexEntry`
-  (`Morphology/Nanosyntax/TreeSpellout.lean`) — contexts are syntactic
-  trees; specificity is reverse tree containment
-  (`toRule_moreSpecific_iff`), and smallest-tree selection is an
-  Elsewhere winner with no side conditions
-  (`treeSelect_isElsewhereWinner`).
+Framework engines (the containment hierarchy, DM vocabulary items,
+nanosyntax spellout) specialize `Ctx` and connect to this core through
+`toRule` maps and winner theorems in their own files.
 
 ## Main declarations
 
-* `Rule Ctx F` — exponent plus applicability condition
-* `Rule.MoreSpecific` — derived Pāṇinian specificity
-* `IsElsewhereWinner` — maximally specific applicable rule in a
-  vocabulary
+* `Rule` — an exponent with its applicability condition
+* `Rule.applySet` — a rule's applicability set; `r ≤ s` iff
+  `r.applySet ⊆ s.applySet`
+* `IsElsewhereWinner` — a `≤`-minimal applicable rule in a vocabulary
 -/
 
 namespace Morphology.Exponence
@@ -53,10 +28,9 @@ namespace Morphology.Exponence
 variable {Ctx F : Type*}
 
 /-- A **rule of exponence**: an exponent paired with the condition on
-contexts under which the rule applies. The realizational core shared by
-vocabulary-insertion engines; framework engines specialize `Ctx` and
-recover applicability from intensional specifications (thresholds,
-feature bundles). -/
+contexts under which the rule applies. Framework engines specialize
+`Ctx` and recover applicability from intensional specifications
+(thresholds, feature bundles, stored trees). -/
 structure Rule (Ctx : Type*) (F : Type*) where
   /-- The exponent the rule inserts. -/
   exponent : F
@@ -65,37 +39,41 @@ structure Rule (Ctx : Type*) (F : Type*) where
 
 namespace Rule
 
-/-- Derived Pāṇinian specificity: `r` is at least as specific as `s`
-when `r` applies in a subset of the contexts `s` applies in. -/
-def MoreSpecific (r s : Rule Ctx F) : Prop :=
-  ∀ ⦃c : Ctx⦄, r.Applies c → s.Applies c
+/-- The set of contexts a rule applies in. -/
+def applySet (r : Rule Ctx F) : Set Ctx := {c | r.Applies c}
 
-@[refl] theorem MoreSpecific.refl (r : Rule Ctx F) : r.MoreSpecific r :=
-  λ _ h => h
+@[simp] theorem mem_applySet {r : Rule Ctx F} {c : Ctx} :
+    c ∈ r.applySet ↔ r.Applies c :=
+  Iff.rfl
 
-theorem MoreSpecific.trans {r s t : Rule Ctx F}
-    (hrs : r.MoreSpecific s) (hst : s.MoreSpecific t) : r.MoreSpecific t :=
-  λ _ h => hst (hrs h)
+/-- Rules are preordered by applicability-set inclusion: `r ≤ s` when
+`r` applies in a subset of the contexts `s` applies in, i.e. `r` is at
+least as specific as `s`. Only a preorder — rules with the same
+applicability but different exponents are equivalent, not equal. -/
+instance : Preorder (Rule Ctx F) := .lift applySet
 
-instance : Trans (MoreSpecific (Ctx := Ctx) (F := F)) MoreSpecific MoreSpecific :=
-  ⟨MoreSpecific.trans⟩
+theorem le_def {r s : Rule Ctx F} : r ≤ s ↔ r.applySet ⊆ s.applySet :=
+  Iff.rfl
+
+/-- Derived Pāṇinian specificity, unfolded: `r ≤ s` iff `s` applies
+wherever `r` does. -/
+theorem le_iff {r s : Rule Ctx F} :
+    r ≤ s ↔ ∀ ⦃c⦄, r.Applies c → s.Applies c :=
+  Iff.rfl
 
 end Rule
 
-/-- `r` is an **Elsewhere winner** for vocabulary `v` at context `c`:
-`r` is an applicable member of `v`, and no applicable member is
-strictly more specific — any applicable rival at least as specific as
-`r` is exactly as specific. -/
+/-- An **Elsewhere winner** for vocabulary `v` at context `c`: a
+`≤`-minimal applicable member of `v` — no applicable rule in `v` is
+strictly more specific. -/
 def IsElsewhereWinner (v : List (Rule Ctx F)) (c : Ctx) (r : Rule Ctx F) : Prop :=
-  r ∈ v ∧ r.Applies c ∧
-    ∀ s ∈ v, s.Applies c → s.MoreSpecific r → r.MoreSpecific s
+  Minimal (fun s => s ∈ v ∧ s.Applies c) r
 
-/-- Two Elsewhere winners at the same context are mutually specific
-whenever their specificities are comparable. -/
-theorem IsElsewhereWinner.mutual {v : List (Rule Ctx F)} {c : Ctx}
-    {r s : Rule Ctx F} (hr : IsElsewhereWinner v c r)
-    (hs : IsElsewhereWinner v c s) (h : s.MoreSpecific r) :
-    r.MoreSpecific s :=
-  hr.2.2 s hs.1 hs.2.1 h
+/-- A winner is at least as specific as any applicable member of the
+vocabulary that is at least as specific as it. -/
+theorem IsElsewhereWinner.le_of_le {v : List (Rule Ctx F)} {c : Ctx}
+    {r s : Rule Ctx F} (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
+    (happ : s.Applies c) (h : s ≤ r) : r ≤ s :=
+  Minimal.le_of_le hr ⟨hs, happ⟩ h
 
 end Morphology.Exponence

--- a/Linglib/Morphology/Nanosyntax/Superset.lean
+++ b/Linglib/Morphology/Nanosyntax/Superset.lean
@@ -444,26 +444,26 @@ def ExponenceRule.toSupersetRule (it : ExponenceRule n F) :
     Exponence.Rule (Fin n) F :=
   ⟨it.exponent, it.Matches⟩
 
-/-- Minimize Junk is the derived specificity of the shared core under
-the Superset reading: smaller span = more specific. -/
-theorem ExponenceRule.toSupersetRule_moreSpecific_iff
+/-- Minimize Junk is the shared core's specificity order under the
+Superset reading: smaller span = more specific. -/
+theorem ExponenceRule.toSupersetRule_le_iff
     {it jt : ExponenceRule n F} :
-    it.toSupersetRule.MoreSpecific jt.toSupersetRule ↔ it.spans ≤ jt.spans :=
-  ExponenceRule.matches_imp_iff_spans_le
+    it.toSupersetRule ≤ jt.toSupersetRule ↔ it.spans ≤ jt.spans :=
+  Exponence.Rule.le_iff.trans ExponenceRule.matches_imp_iff_spans_le
 
 /-- **Subset/Superset duality** over context-free vocabularies (the
 nanosyntax idealization): DM-style Subset specificity of `it` over `jt`
 is Superset specificity of `jt` over `it`. With contextual restrictions
 the Subset order compares thresholds, not spans, and the duality is
 only one-directional. -/
-theorem ExponenceRule.toRule_moreSpecific_iff_toSupersetRule
+theorem ExponenceRule.toRule_le_iff_toSupersetRule_le
     {it jt : ExponenceRule n F}
     (hit : it.context = none) (hjt : jt.context = none) :
-    it.toRule.MoreSpecific jt.toRule ↔
-      jt.toSupersetRule.MoreSpecific it.toSupersetRule := by
-  rw [ExponenceRule.toRule_moreSpecific_iff,
+    it.toRule ≤ jt.toRule ↔
+      jt.toSupersetRule ≤ it.toSupersetRule := by
+  rw [ExponenceRule.toRule_le_iff,
     ExponenceRule.moreSpecific_iff_threshold_le,
-    ExponenceRule.toSupersetRule_moreSpecific_iff]
+    ExponenceRule.toSupersetRule_le_iff]
   unfold ExponenceRule.threshold
   rw [hit, hjt]
   simp
@@ -479,10 +479,10 @@ theorem spelloutWinner_isElsewhereWinner {v : List (ExponenceRule n F)}
       it.toSupersetRule := by
   obtain ⟨hmem, hms⟩ := spelloutWinner_spec h
   obtain ⟨-, -, -, hle⟩ := exists_of_minSpan_eq_coe hms
-  refine ⟨List.mem_map_of_mem hmem, hle, ?_⟩
-  rintro s hs hsapp -
+  refine ⟨⟨List.mem_map_of_mem hmem, hle⟩, ?_⟩
+  rintro s ⟨hs, hsapp⟩ -
   obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hs
-  rw [ExponenceRule.toSupersetRule_moreSpecific_iff]
+  rw [ExponenceRule.toSupersetRule_le_iff]
   exact le_spans_of_minSpan_eq_coe hms hjt hsapp
 
 end ExponenceCore

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -27,7 +27,7 @@ uses containment as the simpler equivalent formulation.
 - `treeSelect`, `treeSpellout`: Superset Principle + Elsewhere Condition
 - `TreeLexEntry.toRule`, `treeSelect_isElsewhereWinner`: the engine as an
   instance of the shared exponence core — derived specificity is reverse
-  tree containment (`toRule_moreSpecific_iff`), and smallest-tree
+  tree containment (`toRule_le_iff`), and smallest-tree
   selection is an Elsewhere winner with no side conditions
 - `FootConditionMet`: [taraldsen-et-al-2018]'s constraint on backtracking
 - `chain_contains_iff_le`: for right-branching chains, tree containment
@@ -296,13 +296,13 @@ applicability is Superset-Principle matching. -/
 def TreeLexEntry.toRule (e : TreeLexEntry F α) : Rule (NanoTree F) α :=
   ⟨e.exponent, e.Matches⟩
 
-/-- Derived specificity is reverse containment of the stored trees:
+/-- The specificity order is reverse containment of the stored trees:
 `a` is at least as specific as `b` exactly when `b`'s tree contains
 `a`'s. Tree size is therefore a faithful specificity measure
 (`Contains.size_le`), which is what licenses smallest-tree selection. -/
-theorem TreeLexEntry.toRule_moreSpecific_iff {a b : TreeLexEntry F α} :
-    a.toRule.MoreSpecific b.toRule ↔ b.tree.Contains a.tree :=
-  ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
+theorem TreeLexEntry.toRule_le_iff {a b : TreeLexEntry F α} :
+    a.toRule ≤ b.toRule ↔ b.tree.Contains a.tree :=
+  Rule.le_iff.trans ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
 
 /-- Smallest-tree selection is an Elsewhere winner of the shared core,
 with no side conditions: containment is size-antisymmetric
@@ -316,10 +316,10 @@ theorem treeSelect_isElsewhereWinner [DecidableEq F]
   rw [List.mem_filter] at hmem
   obtain ⟨hev, hem⟩ := hmem
   have hematch : e.Matches target := of_decide_eq_true hem
-  refine ⟨List.mem_map_of_mem hev, hematch, ?_⟩
-  rintro s hs happ hspec
+  refine ⟨⟨List.mem_map_of_mem hev, hematch⟩, ?_⟩
+  rintro s ⟨hs, happ⟩ hspec
   obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
-  rw [TreeLexEntry.toRule_moreSpecific_iff] at hspec ⊢
+  rw [TreeLexEntry.toRule_le_iff] at hspec ⊢
   have hble : ¬ b.tree.size < e.tree.size :=
     List.not_lt_of_mem_argmin (f := λ e : TreeLexEntry F α => e.tree.size)
       (List.mem_filter.mpr


### PR DESCRIPTION
Deep audit of the exponence keystone, per review: if there's a clean mathlib reuse, reuse it — the order goes on the object.

- `Rule` gains `applySet` and a `Preorder` instance via `Preorder.lift`: `r ≤ s ↔ r.applySet ⊆ s.applySet` — hand-rolled `MoreSpecific`/refl/trans/`Trans` deleted, all order structure inherited
- `IsElsewhereWinner` is now mathlib's `Minimal` over the applicable sub-vocabulary; `.mutual` collapses to `Minimal.le_of_le` (with its over-strong second-winner hypothesis weakened to membership + applicability)
- module docstring reduced to mathlib register (the four-engine catalog moved out; each engine documents its own connection)
- all five engines migrated to `≤` with `*_le_iff` lemma names; both core `Iff.rfl` characterizations hold definitionally through the lifted order
- the file now contributes exactly what morphology owns: the carrier and the interpretation (domain inclusion = Pāṇinian specificity; minimality = Elsewhere selection)