### PR TITLE
feat(Morphology/Exponence): winner existence, coherence, uniqueness

### DIFF
--- a/Linglib/Morphology/Exponence/Rule.lean
+++ b/Linglib/Morphology/Exponence/Rule.lean
@@ -1,5 +1,8 @@
 import Mathlib.Order.Basic
 import Mathlib.Data.Set.Basic
+import Mathlib.Order.Antisymmetrization
+import Mathlib.Order.Preorder.Finite
+import Mathlib.Data.Set.Finite.Basic
 
 /-!
 # Rules of exponence
@@ -21,6 +24,10 @@ nanosyntax spellout) specialize `Ctx` and connect to this core through
 * `Rule.applySet` — a rule's applicability set; `r ≤ s` iff
   `r.applySet ⊆ s.applySet`
 * `IsElsewhereWinner` — a `≤`-minimal applicable rule in a vocabulary
+* `Coherent` — equivalent rules share an exponent; with
+  `IsElsewhereWinner.exponent_eq`, comparable winners then select one
+  exponent, and `exists_isElsewhereWinner` provides a winner whenever
+  some rule applies
 -/
 
 namespace Morphology.Exponence
@@ -75,5 +82,36 @@ theorem IsElsewhereWinner.le_of_le {v : List (Rule Ctx F)} {c : Ctx}
     {r s : Rule Ctx F} (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
     (happ : s.Applies c) (h : s ≤ r) : r ≤ s :=
   Minimal.le_of_le hr ⟨hs, happ⟩ h
+
+/-! ### Selection: existence, coherence, uniqueness -/
+
+/-- Comparable Elsewhere winners at the same context are equivalent. -/
+theorem IsElsewhereWinner.antisymmRel {v : List (Rule Ctx F)} {c : Ctx}
+    {r s : Rule Ctx F} (hr : IsElsewhereWinner v c r)
+    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
+    AntisymmRel (· ≤ ·) r s := by
+  rcases h with h | h
+  · exact ⟨hr.le_of_le hs.1.1 hs.1.2 h, h⟩
+  · exact ⟨h, hs.le_of_le hr.1.1 hr.1.2 h⟩
+
+/-- A **coherent** vocabulary assigns equivalent rules the same
+exponent, so the exponent descends to the antisymmetrization of the
+specificity preorder ([caha-2009]-style antihomophony, stated
+order-theoretically). -/
+def Coherent (v : List (Rule Ctx F)) : Prop :=
+  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s → r.exponent = s.exponent
+
+/-- Over a coherent vocabulary, comparable winners select the same
+exponent: Elsewhere selection is well defined up to incomparability. -/
+theorem IsElsewhereWinner.exponent_eq {v : List (Rule Ctx F)} {c : Ctx}
+    {r s : Rule Ctx F} (hv : Coherent v) (hr : IsElsewhereWinner v c r)
+    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
+    r.exponent = s.exponent :=
+  hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
+
+/-- A vocabulary with an applicable rule has an Elsewhere winner. -/
+theorem exists_isElsewhereWinner {v : List (Rule Ctx F)} {c : Ctx}
+    (h : ∃ r ∈ v, r.Applies c) : ∃ r, IsElsewhereWinner v c r :=
+  (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
 
 end Morphology.Exponence


### PR DESCRIPTION
The selection theory the order-on-object refactor (#1512) makes possible — all inherited from mathlib. Full-library build green (6698 jobs).

- `exists_isElsewhereWinner`: a vocabulary with an applicable rule has a winner (`Set.Finite.exists_minimal` over the applicable set)
- `Coherent`: equivalent rules share an exponent — antihomophony stated order-theoretically, the condition for `exponent` to descend to the antisymmetrization
- `IsElsewhereWinner.antisymmRel` / `.exponent_eq`: comparable winners are equivalent and, under coherence, select one exponent — Elsewhere selection is well defined up to incomparability