### PR TITLE
refactor(Morphology/Exponence): RuleLike interface; Hierarchy register cleanse

### DIFF
--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -136,21 +136,30 @@ section ExponenceCore
 
 open Morphology.Exponence
 
-/-- View a vocabulary entry as a rule of the shared exponence core
-(`Morphology.Exponence.Rule`): contexts are (target bundle, syntactic
-context) pairs, applicability is `Matches`. -/
-def VocabEntry.toRule (e : VocabEntry) : Rule (FeatureBundle × Option Cat) String :=
-  ⟨e.exponent, λ tc => e.Matches tc.1 tc.2⟩
+/-- A vocabulary entry exposes the shared exponence core interface
+(`Morphology.Exponence.RuleLike`): contexts are (target bundle,
+syntactic context) pairs, applicability is `Matches`. -/
+instance : RuleLike VocabEntry (FeatureBundle × Option Cat) String :=
+  ⟨VocabEntry.exponent, fun e => {tc | e.Matches tc.1 tc.2}⟩
+
+instance : Preorder VocabEntry := RuleLike.toPreorder
+
+/-- Derived specificity, unfolded: `e ≤ e'` iff `e'` matches wherever
+`e` does. -/
+theorem VocabEntry.le_iff_matches {e e' : VocabEntry} :
+    e ≤ e' ↔ ∀ ⦃tc : FeatureBundle × Option Cat⦄,
+      e.Matches tc.1 tc.2 → e'.Matches tc.1 tc.2 :=
+  Iff.rfl
 
 /-- Syntactic refinement: a feature-superset entry (with compatible
 context restriction) is at least as specific in the shared core's
 order. -/
-theorem VocabEntry.toRule_le_of_superset {e e' : VocabEntry}
+theorem VocabEntry.le_of_superset {e e' : VocabEntry}
     (hf : ∀ f ∈ FeatureBundle.toGramFeatures e'.features,
       f ∈ FeatureBundle.toGramFeatures e.features)
     (hc : e'.context = none ∨ e'.context = e.context) :
-    e.toRule ≤ e'.toRule := by
-  rw [Rule.le_iff]
+    e ≤ e' := by
+  rw [VocabEntry.le_iff_matches]
   rintro ⟨t, c⟩ ⟨hm, hctx⟩
   refine ⟨?_, ?_⟩
   · rw [VocabEntry.MatchesFeatures, List.all_eq_true] at hm ⊢
@@ -170,27 +179,26 @@ theorem VocabEntry.matchesFeatures_self (e : VocabEntry) :
 
 /-- The shared core's specificity order, characterized: `e ≤ e'` iff
 `e'`'s features are a subset of `e`'s and `e'`'s context restriction is
-compatible. Upgrades `toRule_le_of_superset` to an iff — over feature
-bundles the intensional superset order IS the specificity order, with
-no faithfulness assumption (contrast
-`Morphology.DM.VI.SpecificityFaithful`, which the opaque-predicate
-engine must stipulate). -/
-theorem VocabEntry.toRule_le_iff {e e' : VocabEntry} :
-    e.toRule ≤ e'.toRule ↔
+compatible. Upgrades `le_of_superset` to an iff — over feature bundles
+the intensional superset order IS the specificity order, with no
+faithfulness assumption (contrast `Morphology.DM.VI.SpecificityFaithful`,
+which the opaque-predicate engine must stipulate). -/
+theorem VocabEntry.le_iff {e e' : VocabEntry} :
+    e ≤ e' ↔
       (∀ f ∈ FeatureBundle.toGramFeatures e'.features,
         f ∈ FeatureBundle.toGramFeatures e.features) ∧
       (e'.context = none ∨ e'.context = e.context) := by
   constructor
   · intro h
     obtain ⟨hm', hctx'⟩ :=
-      Rule.le_iff.mp h (c := (e.features, e.context))
+      VocabEntry.le_iff_matches.mp h (tc := (e.features, e.context))
         ⟨e.matchesFeatures_self, Or.inr rfl⟩
     refine ⟨?_, hctx'⟩
     rw [VocabEntry.MatchesFeatures, List.all_eq_true] at hm'
     intro f hf
     obtain ⟨tf, htf, hbeq⟩ := List.any_eq_true.mp (hm' f hf)
     exact (beq_iff_eq.mp hbeq) ▸ htf
-  · exact λ ⟨hf, hc⟩ => toRule_le_of_superset hf hc
+  · exact λ ⟨hf, hc⟩ => le_of_superset hf hc
 
 /-! #### Bridge to the opaque-predicate engine -/
 
@@ -213,24 +221,20 @@ theorem VocabEntry.toVocabItem_matches (e : VocabEntry)
   simp [Morphology.DM.VI.VocabItem.matches, VocabEntry.toVocabItem,
     VocabEntry.Matches]
 
-/-- The two engines' shared-core views agree: the embedded item's rule
-applies exactly where the entry's rule does. -/
-theorem VocabEntry.toVocabItem_toRule_applies (e : VocabEntry)
+/-- The two engines' interfaces agree: the embedded item applies exactly
+where the entry does. -/
+theorem VocabEntry.toVocabItem_applies (e : VocabEntry)
     (tc : FeatureBundle × Option Cat) :
-    e.toVocabItem.toRule.Applies tc ↔ e.toRule.Applies tc :=
+    RuleLike.Applies e.toVocabItem tc ↔ RuleLike.Applies e tc :=
   e.toVocabItem_matches tc.1 tc.2
 
 /-- Specificity transfers along the embedding — the cross-engine
 translation is faithful to the shared core's order. -/
-theorem VocabEntry.toVocabItem_toRule_le_iff {e f : VocabEntry} :
-    e.toVocabItem.toRule ≤ f.toVocabItem.toRule ↔
-      e.toRule ≤ f.toRule := by
-  simp only [Rule.le_iff]
+theorem VocabEntry.toVocabItem_le_iff {e f : VocabEntry} :
+    e.toVocabItem ≤ f.toVocabItem ↔ e ≤ f := by
   constructor <;> intro h c hc
-  · exact (f.toVocabItem_toRule_applies c).mp
-      (h ((e.toVocabItem_toRule_applies c).mpr hc))
-  · exact (f.toVocabItem_toRule_applies c).mpr
-      (h ((e.toVocabItem_toRule_applies c).mp hc))
+  · exact (f.toVocabItem_applies c).mp (h ((e.toVocabItem_applies c).mpr hc))
+  · exact (f.toVocabItem_applies c).mpr (h ((e.toVocabItem_applies c).mp hc))
 
 /-- Under a specificity stipulation faithful to the derived order on
 the matching entries, `bestMatch` returns an Elsewhere winner of the
@@ -240,23 +244,22 @@ theorem bestMatch_isElsewhereWinner {vocab : Vocabulary} {target : FeatureBundle
     {ctx : Option Cat} {e : VocabEntry}
     (h : bestMatch vocab target ctx = some e)
     (hfaith : ∀ a ∈ vocab, ∀ b ∈ vocab, a.Matches target ctx →
-      b.Matches target ctx → a.toRule ≤ b.toRule →
-      ¬ b.toRule ≤ a.toRule → b.specificity < a.specificity) :
-    IsElsewhereWinner (vocab.map VocabEntry.toRule) (target, ctx) e.toRule := by
+      b.Matches target ctx → a ≤ b →
+      ¬ b ≤ a → b.specificity < a.specificity) :
+    IsElsewhereWinner vocab (target, ctx) e := by
   have hmem := List.argmax_mem h
   rw [List.mem_filter] at hmem
   obtain ⟨hev, hem⟩ := hmem
   have hematch : e.Matches target ctx := of_decide_eq_true hem
-  refine ⟨⟨List.mem_map_of_mem hev, hematch⟩, ?_⟩
+  refine ⟨⟨hev, hematch⟩, ?_⟩
   rintro s ⟨hs, happ⟩ hspec
-  obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
   by_contra hns
-  have hlt : e.specificity < b.specificity :=
-    hfaith b hb e hev happ hematch hspec hns
-  have hble : ¬ e.specificity < b.specificity :=
+  have hlt : e.specificity < s.specificity :=
+    hfaith s hs e hev happ hematch hspec hns
+  have hble : ¬ e.specificity < s.specificity :=
     List.not_lt_of_mem_argmax
       (List.mem_filter.mpr
-        ⟨hb, decide_eq_true (show b.Matches target ctx from happ)⟩) h
+        ⟨hs, decide_eq_true (show s.Matches target ctx from happ)⟩) h
   exact hble hlt
 
 end ExponenceCore

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -156,11 +156,13 @@ open Morphology.Exponence
 
 variable {Ctx Root : Type*}
 
-/-- View a Vocabulary Item as a rule of the shared exponence core
-(`Morphology.Exponence.Rule`): contexts are (feature-context, root)
+/-- A Vocabulary Item exposes the shared exponence core interface
+(`Morphology.Exponence.RuleLike`): contexts are (feature-context, root)
 pairs, applicability is `matches`. -/
-def VocabItem.toRule (vi : VocabItem Ctx Root) : Rule (Ctx × Root) String :=
-  ⟨vi.exponent, λ cr => vi.matches cr.1 cr.2 = true⟩
+instance : RuleLike (VocabItem Ctx Root) (Ctx × Root) String :=
+  ⟨VocabItem.exponent, fun vi => {cr | vi.matches cr.1 cr.2 = true}⟩
+
+instance : Preorder (VocabItem Ctx Root) := RuleLike.toPreorder
 
 /-- The stipulated `specificity` rank is **faithful** when it refines
 the derived specificity of the shared core: a strictly more specific
@@ -169,8 +171,7 @@ order is not computable, so this engine must stipulate a rank — this
 Prop is the obligation the stipulation incurs, and
 `vocabularyInsert_isElsewhereWinner` is what discharging it buys. -/
 def SpecificityFaithful (rules : List (VocabItem Ctx Root)) : Prop :=
-  ∀ a ∈ rules, ∀ b ∈ rules, a.toRule ≤ b.toRule →
-    ¬ b.toRule ≤ a.toRule → b.specificity < a.specificity
+  ∀ a ∈ rules, ∀ b ∈ rules, a ≤ b → ¬ b ≤ a → b.specificity < a.specificity
 
 private theorem findSome?_pairwise_max {l : List (VocabItem Ctx Root)}
     (hs : l.Pairwise (λ a b => b.specificity ≤ a.specificity))
@@ -206,7 +207,7 @@ theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
     (h : vocabularyInsert rules ctx root = some e)
     (hf : SpecificityFaithful rules) :
     ∃ vi ∈ rules, vi.exponent = e ∧
-      IsElsewhereWinner (rules.map VocabItem.toRule) (ctx, root) vi.toRule := by
+      IsElsewhereWinner rules (ctx, root) vi := by
   unfold vocabularyInsert at h
   have hsort : (rules.mergeSort (λ a b => a.specificity ≥ b.specificity)).Pairwise
       (λ a b => b.specificity ≤ a.specificity) := by
@@ -219,13 +220,12 @@ theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
     exact this.imp (λ hab => by simpa using hab)
   obtain ⟨vi, hvi, hvm, hve, hmax⟩ := findSome?_pairwise_max hsort h
   rw [List.mem_mergeSort] at hvi
-  refine ⟨vi, hvi, hve, ⟨List.mem_map_of_mem hvi, hvm⟩, ?_⟩
+  refine ⟨vi, hvi, hve, ⟨hvi, hvm⟩, ?_⟩
   rintro s ⟨hs, happ⟩ hspec
-  obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
   by_contra hns
-  have hlt : vi.specificity < b.specificity := hf b hb vi hvi hspec hns
-  have hble : b.specificity ≤ vi.specificity :=
-    hmax b (List.mem_mergeSort.mpr hb) happ
+  have hlt : vi.specificity < s.specificity := hf s hs vi hvi hspec hns
+  have hble : s.specificity ≤ vi.specificity :=
+    hmax s (List.mem_mergeSort.mpr hs) happ
   omega
 
 end ExponenceCore

--- a/Linglib/Morphology/DegreeContainment.lean
+++ b/Linglib/Morphology/DegreeContainment.lean
@@ -135,8 +135,8 @@ def abc : DegreePattern := ⟨0, 1, 2⟩
 def aba : DegreePattern := ⟨0, 1, 0⟩
 
 /-- *AAB: contiguous, but unattested — excluded by the vocabulary-level
-conditions of `Morphology/Exponence/Hierarchy.lean` (`csg2`), not by
-contiguity. -/
+conditions of `Morphology/Exponence/Hierarchy.lean`
+(`realize_const_of_grounded`), not by contiguity. -/
 def aab : DegreePattern := ⟨0, 0, 1⟩
 
 /-! Smoke tests confirming each named pattern resolves correctly. -/

--- a/Linglib/Morphology/Exponence/Hierarchy.lean
+++ b/Linglib/Morphology/Exponence/Hierarchy.lean
@@ -521,34 +521,32 @@ theorem exists_portmanteau_of_ne {v : List (ExponenceRule 3 F)} (hA : Adjacent v
 
 /-! ### The shared exponence core
 
-The containment engine instantiates `Morphology.Exponence.Rule`:
-applicability is threshold containment, derived specificity is
-threshold comparison, and the Elsewhere winner is a winner of the
-shared core. -/
+The containment engine implements `Morphology.Exponence.RuleLike`
+directly: applicability is threshold containment (the upper set
+`Set.Ici threshold`) and derived specificity is threshold comparison,
+so the Elsewhere winner is an Elsewhere winner of the shared core over
+the native carrier. -/
 
-/-- View a containment-hierarchy rule as a rule of the shared exponence
-core: contexts are grades, applicability is `AppliesAt`. -/
-def ExponenceRule.toRule (it : ExponenceRule n F) : Exponence.Rule (Fin n) F :=
-  ⟨it.exponent, it.AppliesAt⟩
+instance : Exponence.RuleLike (ExponenceRule n F) (Fin n) F :=
+  ⟨ExponenceRule.exponent, fun it => Set.Ici it.threshold⟩
 
-/-- Containment specificity is definitionally the shared core's
-specificity order. -/
-theorem ExponenceRule.toRule_le_iff {it jt : ExponenceRule n F} :
-    it.toRule ≤ jt.toRule ↔ it.MoreSpecific jt :=
+instance : Preorder (ExponenceRule n F) := Exponence.RuleLike.toPreorder
+
+/-- Containment specificity is the shared core's specificity order. -/
+theorem ExponenceRule.le_iff {it jt : ExponenceRule n F} :
+    it ≤ jt ↔ it.MoreSpecific jt :=
   Iff.rfl
 
 /-- The containment engine's Elsewhere winner is an Elsewhere winner of
 the shared core. -/
-theorem isElsewhereWinner_toRule {v : List (ExponenceRule n F)} {g : Fin n}
+theorem winner_isElsewhereWinner {v : List (ExponenceRule n F)} {g : Fin n}
     {it : ExponenceRule n F} (h : winner v g = some it) :
-    Exponence.IsElsewhereWinner (v.map ExponenceRule.toRule) g it.toRule := by
+    Exponence.IsElsewhereWinner v g it := by
   obtain ⟨hmem, hmt⟩ := winner_spec h
   obtain ⟨-, -, -, hle⟩ := exists_of_maxThreshold_eq_coe hmt
-  refine ⟨⟨List.mem_map_of_mem hmem, hle⟩, ?_⟩
+  refine ⟨⟨hmem, hle⟩, ?_⟩
   rintro s ⟨hs, hsapp⟩ -
-  obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hs
-  rw [ExponenceRule.toRule_le_iff,
-    ExponenceRule.moreSpecific_iff_threshold_le]
-  exact threshold_le_of_maxThreshold_eq_coe hmt hjt hsapp
+  rw [ExponenceRule.le_iff, ExponenceRule.moreSpecific_iff_threshold_le]
+  exact threshold_le_of_maxThreshold_eq_coe hmt hs hsapp
 
 end Morphology.Containment

--- a/Linglib/Morphology/Exponence/Hierarchy.lean
+++ b/Linglib/Morphology/Exponence/Hierarchy.lean
@@ -8,61 +8,25 @@ import Mathlib.Data.Finset.Max
 [bobaljik-2012] [halle-marantz-1993] [kiparsky-1973]
 
 The realizational engine behind [bobaljik-2012]'s comparative-suppletion
-generalizations, stated over an arbitrary `n`-grade containment
-hierarchy. An `ExponenceRule` realizes the initial span `[0, spans]` of
-the hierarchy (the root, possibly fused with the first `spans` heads —
-the portmanteau exponence of [bobaljik-2012]'s ch. 5, via Fusion (196)
-or Radkevich's Vocabulary Insertion Principle (197)), optionally
-conditioned on the presence of a higher head. Selection at each grade
-is by the Elsewhere Condition ([kiparsky-1973]): the most specific
-applicable rule wins, where Pāṇinian specificity is *derived* as
-applicability-set inclusion
-(`ExponenceRule.moreSpecific_iff_threshold_le`) — over a linear
-hierarchy applicability sets are nested upward sets, so the Elsewhere
-ordering is total.
-
-Each of [bobaljik-2012]'s generalizations is a theorem with its own
-hypothesis set, mirroring the book's cost accounting:
-
-* CSG1 / *ABA (`isContiguous_realize`): Antihomophony alone — the
-  book's ch. 2 derivation from containment + Elsewhere + the
-  antihomophony assumption (44). The homophony loophole is real: a
-  non-antihomophonous vocabulary generating surface ABA is exhibited in
-  `Studies/Bobaljik2012.lean`.
-* Completeness (`isContiguous_iff_generable`): generable = contiguous
-  over terminal antihomophonous vocabularies.
-* The plateau (`realize_const_of_terminal_adjacent`): terminal rules +
-  adjacent contexts generate only `{AAA, ABB}` — the
-  Bobaljik-minus-portmanteaux fragment, which over-excludes the
-  attested ABC (Latin *bon- ~ mel- ~ opt-*); portmanteau rules repair it.
-* CSG2 / *AAB (`csg2`): Antihomophony + `Grounded` (the book's
-  markedness condition (202)). The book blocks the two AAB routes by
-  two mechanisms — adjacency for root-rules conditioned across an
-  intervening head (190a), condition (202) for context-sensitive
-  portmanteaux (201); under the threshold encoding both reduce to
-  downward closure of the threshold set, so one hypothesis suffices.
-* ABC requires a portmanteau (`exists_portmanteau_of_ne`;
-  [bobaljik-2012] §5.3.1, the degree-domain consequence generalized
-  there as (199)): under adjacency, superlative-grade root allomorphy
-  distinct from the comparative grade arises only via a portmanteau
-  rule.
+generalizations, over an arbitrary `n`-grade containment hierarchy. An
+`ExponenceRule` realizes the initial span `[0, spans]` of the hierarchy,
+optionally conditioned on a higher head; the Elsewhere Condition
+([kiparsky-1973]) selects the most specific applicable rule. Over a linear
+hierarchy, specificity is applicability-set inclusion, so the Elsewhere
+ordering is threshold comparison (`moreSpecific_iff_threshold_le`).
 
 ## Main declarations
 
-* `ExponenceRule n F` — rule of exponence: exponent, exponed span
-  `[0, spans]`, optional conditioning head
-* `Terminal`, `Adjacent`, `Antihomophonous`, `Grounded` — the axiom
-  Props on vocabularies, à la carte
+* `ExponenceRule n F` — exponent, exponed span `[0, spans]`, optional
+  conditioning head
+* `Terminal`, `Adjacent`, `Antihomophonous`, `Grounded` — well-formedness
+  conditions on vocabularies
 * `winner`, `realize` — Elsewhere selection and the realized pattern
-* `isContiguous_realize`, `isContiguous_iff_generable`,
-  `realize_const_of_terminal_adjacent`, `csg2`,
-  `exists_portmanteau_of_ne`
-
-The dual Superset engine lives in
-`Morphology/Nanosyntax/Superset.lean`; synthetic/analytic structure
-(Merger) in `Morphology/DM/Merger.lean`; the n = 3 degree
-instantiations with the book's worked vocabularies in
-`Studies/Bobaljik2012.lean`.
+* `isContiguous_realize`, `isContiguous_iff_generable` — *ABA (CSG1) and
+  generable = contiguous
+* `realize_const_of_terminal_adjacent`, `realize_const_of_grounded`,
+  `exists_portmanteau_of_ne` — the plateau, *AAB (CSG2), and the ABC
+  portmanteau prediction
 -/
 
 namespace Morphology.Containment
@@ -71,18 +35,11 @@ variable {n : ℕ} {F : Type*}
 
 /-! ### Rules of exponence and derived specificity -/
 
-/-- A **rule of exponence** ([bobaljik-2012]'s term — Matthews's
-*exponence*, used in the realizational sense of [stump-2001]) over an
-`n`-grade containment hierarchy. The rule realizes the initial span
-`[0, spans]` — the root when `spans = 0`, a root+heads portmanteau
-when `spans > 0` — and applies only when the (optional) conditioning
-head `context` is present in the structure. DM vocabulary items are
-the `Terminal`-restricted special case; nanosyntax lexical entries
-share the context-free span format but pair it with Superset-based
-selection (`Morphology/Nanosyntax/Superset.lean`) rather than this
-file's containment-directed `AppliesAt`, so the insertion semantics
-differs.
-Latin ([bobaljik-2012] (204)): `bon` is `⟨bon, 0, none⟩`, `mel-` is
+/-- A **rule of exponence** ([bobaljik-2012]) over an `n`-grade containment
+hierarchy. The rule realizes the initial span `[0, spans]` — the bare root
+when `spans = 0`, a root+heads portmanteau when `spans > 0` — and applies
+only when its optional conditioning head `context` is present. Latin
+([bobaljik-2012] (204)): `bon` is `⟨bon, 0, none⟩`, `mel-` is
 `⟨mel, 0, some 1⟩`, the portmanteau `opt-` is `⟨opt, 1, some 2⟩`. -/
 structure ExponenceRule (n : ℕ) (F : Type*) where
   /-- The phonological exponent inserted for the span. -/
@@ -109,22 +66,14 @@ def AppliesAt (it : ExponenceRule n F) (g : Fin n) : Prop :=
 instance (it : ExponenceRule n F) (g : Fin n) : Decidable (it.AppliesAt g) :=
   inferInstanceAs (Decidable (_ ≤ _))
 
-theorem appliesAt_iff {it : ExponenceRule n F} {g : Fin n} :
-    it.AppliesAt g ↔ it.spans ≤ g ∧ ∀ c : Fin n, it.context = some c → c ≤ g := by
-  unfold AppliesAt threshold
-  cases hc : it.context with
-  | none => simp
-  | some c => simp
-
-/-- Pāṇinian specificity: `it` is at least as specific as `jt` when it
-applies in a subset of the structures `jt` applies in. -/
+/-- A rule `it` is at least as specific as `jt` when it applies in a
+subset of the contexts `jt` applies in (Pāṇinian specificity). -/
 def MoreSpecific (it jt : ExponenceRule n F) : Prop :=
   ∀ ⦃g : Fin n⦄, it.AppliesAt g → jt.AppliesAt g
 
 /-- Over a linear containment hierarchy, applicability sets are nested
 upward sets, so derived specificity is threshold comparison — the
-Elsewhere ordering ([kiparsky-1973]) is total and needs no stipulated
-specificity ranking. -/
+Elsewhere ordering ([kiparsky-1973]) is total. -/
 theorem moreSpecific_iff_threshold_le {it jt : ExponenceRule n F} :
     it.MoreSpecific jt ↔ jt.threshold ≤ it.threshold :=
   ⟨λ h => h (le_refl it.threshold), λ h _ hg => le_trans h hg⟩
@@ -138,7 +87,7 @@ needs; vocabularies violating a condition witness the corresponding
 unattested pattern (see the worked examples in
 `Studies/Bobaljik2012.lean`). -/
 
-/-- No portmanteaux: every rule expones the bare root. -/
+/-- Every rule expones the bare root (no portmanteaux). -/
 def Terminal (v : List (ExponenceRule n F)) : Prop :=
   ∀ it ∈ v, (it.spans : ℕ) = 0
 
@@ -154,28 +103,19 @@ def Adjacent (v : List (ExponenceRule n F)) : Prop :=
 instance (v : List (ExponenceRule n F)) : Decidable (Adjacent v) := by
   unfold Adjacent; infer_instance
 
-/-- Distinct rules carry distinct exponents — [bobaljik-2012]'s
-Antihomophony assumption (44), closing the loophole of a surface-ABA
-pattern that is really an ABC with accidental A ≡ C homophony. Stated
-as pairwise antihomophony, a mild strengthening of the book's
-default-vs-contextual formulation; all worked vocabularies satisfy
-it. -/
+/-- Distinct rules carry distinct exponents — [bobaljik-2012]'s Antihomophony
+assumption (44), closing the loophole where a surface-ABA pattern is really an
+ABC with accidental A ≡ C homophony. -/
 def Antihomophonous (v : List (ExponenceRule n F)) : Prop :=
   ∀ it ∈ v, ∀ jt ∈ v, it.exponent = jt.exponent → it = jt
 
 instance [DecidableEq F] (v : List (ExponenceRule n F)) : Decidable (Antihomophonous v) := by
   unfold Antihomophonous; infer_instance
 
-/-- [bobaljik-2012]'s markedness condition (202): a context-sensitive
-rule of exponence involving a node requires a context-free rule
-involving that node. A rule is context-free *for* the node `[0, k]`
-when nothing it mentions extends beyond `k` — i.e. its threshold is
-`k` (the book's fn. 15 rewrites Latin `mel- / __]CMPR]` as the
-node-level context-free `GOOD, CMPR → mel-CMPR`) — so (202) says the
-vocabulary's threshold set is downward closed. On `Adjacent`
-vocabularies this is exactly the book's condition; on non-adjacent
-ones it is a mild strengthening (it also covers the skipped-head items
-the book independently excludes by adjacency). -/
+/-- [bobaljik-2012]'s markedness condition (202): a context-sensitive rule of
+exponence involving a node requires a context-free rule involving that node.
+Under the threshold encoding, this is downward closure of the vocabulary's
+threshold set. -/
 def Grounded (v : List (ExponenceRule n F)) : Prop :=
   ∀ it ∈ v, ∀ k : Fin n, k < it.threshold → ∃ jt ∈ v, jt.threshold = k
 
@@ -224,9 +164,8 @@ theorem maxThreshold_eq_coe_intro {v : List (ExponenceRule n F)} {g : Fin n}
   obtain ⟨hjv, hjle⟩ := mem_applicable.mp hjt
   exact hub jt hjv hjle
 
-/-- The key transfer lemma: a winning threshold persists downward as
-long as it stays applicable. With monotone applicability this is what
-makes Elsewhere selection plateau between grades. -/
+/-- A winning threshold persists downward as long as it stays applicable,
+which is what makes Elsewhere selection plateau between grades. -/
 theorem maxThreshold_eq_coe_of_between {v : List (ExponenceRule n F)} {g g' m : Fin n}
     (h : maxThreshold v g' = ↑m) (hm : m ≤ g) (hg : g ≤ g') :
     maxThreshold v g = ↑m := by
@@ -244,9 +183,7 @@ theorem maxThreshold_eq_bot_of_le {v : List (ExponenceRule n F)} {g g' : Fin n}
   exact h it (mem_applicable.mpr ⟨hv, le_trans hle hg⟩)
 
 /-- The Elsewhere winner at grade `g`: the first rule attaining the
-greatest applicable threshold. By
-`ExponenceRule.moreSpecific_iff_threshold_le`, this is the most specific
-applicable rule. -/
+greatest applicable threshold — the most specific applicable rule. -/
 def winner (v : List (ExponenceRule n F)) (g : Fin n) : Option (ExponenceRule n F) :=
   (maxThreshold v g).recBotCoe none (λ m => v.find? (λ it => it.threshold == m))
 
@@ -518,16 +455,12 @@ theorem isContiguous_iff_generable (p : Paradigm n F) :
 
 /-! ### Three-grade hierarchies: *AAB and the portmanteau prediction -/
 
-/-- **CSG2 / *AAB exclusion** ([bobaljik-2012] ch. 5). Over the
-three-grade degree hierarchy, if the positive and comparative cells
-agree and the superlative cell is realized, all three agree:
-`good – gooder – *best` is not generable. Hypotheses: antihomophony
-plus `Grounded` (the book's markedness condition (202)); the
-threshold-set downward closure makes both of the book's AAB routes —
-the skipped-head root rule (190a) and the context-sensitive
-portmanteau (201) — fail for the same reason, a threshold gap at the
-comparative grade. -/
-theorem csg2 {v : List (ExponenceRule 3 F)} (hAH : Antihomophonous v) (hG : Grounded v)
+/-- **CSG2 / *AAB exclusion** ([bobaljik-2012] ch. 5). Over the three-grade
+degree hierarchy, if the positive and comparative cells agree and the
+superlative cell is realized, all three agree — `good – gooder – *best` is not
+generable — given antihomophony and `Grounded` (the book's condition (202)). -/
+theorem realize_const_of_grounded {v : List (ExponenceRule 3 F)}
+    (hAH : Antihomophonous v) (hG : Grounded v)
     (h01 : realize v 0 = realize v 1) (h2 : (realize v 2).isSome) :
     realize v 1 = realize v 2 := by
   obtain ⟨w2, hw2⟩ : ∃ w, winner v 2 = some w := by
@@ -591,7 +524,7 @@ theorem exists_portmanteau_of_ne {v : List (ExponenceRule 3 F)} (hA : Adjacent v
 The containment engine instantiates `Morphology.Exponence.Rule`:
 applicability is threshold containment, derived specificity is
 threshold comparison, and the Elsewhere winner is a winner of the
-shared core — all true by construction. -/
+shared core. -/
 
 /-- View a containment-hierarchy rule as a rule of the shared exponence
 core: contexts are grades, applicability is `AppliesAt`. -/

--- a/Linglib/Morphology/Exponence/Rule.lean
+++ b/Linglib/Morphology/Exponence/Rule.lean
@@ -9,20 +9,24 @@ import Mathlib.Data.Set.Finite.Basic
 [kiparsky-1973] [halle-marantz-1993] [stump-2001]
 
 A **rule of exponence** pairs an exponent with an applicability
-condition on contexts. Rules are preordered by applicability-set
-inclusion ([kiparsky-1973]'s Elsewhere Condition), and Elsewhere
-selection is minimality in this order: the most specific applicable
-rule is the one with the smallest domain.
+condition on contexts. `RuleLike` is the interface every framework
+engine's carrier implements: an exponent projection and an
+applicability set, ordered by set inclusion ([kiparsky-1973]'s
+Elsewhere Condition). Elsewhere selection is minimality in this order —
+the most specific applicable rule has the smallest domain.
 
-Framework engines (the containment hierarchy, DM vocabulary items,
-nanosyntax spellout) specialize `Ctx` and connect to this core through
-`toRule` maps and winner theorems in their own files.
+`Rule Ctx F` is the free carrier. Framework engines (the containment
+hierarchy, DM vocabulary items, nanosyntax spellout) implement
+`RuleLike` on their own intensional carriers (thresholds, feature
+bundles, stored trees) and install `RuleLike.toPreorder` as the
+carrier's order, so the selection theorems apply to the native type
+with no wrapper.
 
 ## Main declarations
 
 * `Rule` — an exponent with its applicability condition
-* `Rule.applySet` — a rule's applicability set; `r ≤ s` iff
-  `r.applySet ⊆ s.applySet`
+* `RuleLike` — the exponent-plus-applicability interface;
+  `RuleLike.toPreorder` lifts applicability-set inclusion to a preorder
 * `IsElsewhereWinner` — a `≤`-minimal applicable rule in a vocabulary
 * `Coherent` — equivalent rules share an exponent; with
   `IsElsewhereWinner.exponent_eq`, comparable winners then select one
@@ -70,26 +74,58 @@ theorem le_iff {r s : Rule Ctx F} :
 
 end Rule
 
+/-- Carriers whose values expone: an exponent projection and an
+applicability set, à la `SetLike` minus injectivity. Distinct rules may
+share an applicability set while carrying different exponents, so there
+is no `coe_injective` and the induced order is only a preorder
+(`toPreorder`), never a partial order. Framework engines instantiate
+this on their intensional carriers and derive Elsewhere selection over
+the native type. -/
+class RuleLike (R : Type*) (Ctx F : outParam Type*) where
+  /-- The exponent a rule inserts. -/
+  exponent : R → F
+  /-- The set of contexts a rule applies in. -/
+  applySet : R → Set Ctx
+
+namespace RuleLike
+
+variable {R : Type*} [RuleLike R Ctx F]
+
+/-- A rule applies at a context when the context is in its
+applicability set. -/
+def Applies (r : R) (c : Ctx) : Prop := c ∈ applySet (F := F) r
+
+/-- The preorder a carrier opts into: applicability-set inclusion. Not a
+global instance — each engine installs it (or a defeq order) on its own
+carrier. -/
+@[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (F := F))
+
+end RuleLike
+
+/-- The free carrier exposes its fields as the interface. -/
+instance : RuleLike (Rule Ctx F) Ctx F := ⟨Rule.exponent, Rule.applySet⟩
+
+variable {R : Type*} [Preorder R] [RuleLike R Ctx F]
+
 /-- An **Elsewhere winner** for vocabulary `v` at context `c`: a
 `≤`-minimal applicable member of `v` — no applicable rule in `v` is
 strictly more specific. -/
-def IsElsewhereWinner (v : List (Rule Ctx F)) (c : Ctx) (r : Rule Ctx F) : Prop :=
-  Minimal (fun s => s ∈ v ∧ s.Applies c) r
+def IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
+  Minimal (fun s => s ∈ v ∧ RuleLike.Applies (F := F) s c) r
 
 /-- A winner is at least as specific as any applicable member of the
 vocabulary that is at least as specific as it. -/
-theorem IsElsewhereWinner.le_of_le {v : List (Rule Ctx F)} {c : Ctx}
-    {r s : Rule Ctx F} (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
-    (happ : s.Applies c) (h : s ≤ r) : r ≤ s :=
+theorem IsElsewhereWinner.le_of_le {v : List R} {c : Ctx} {r s : R}
+    (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
+    (happ : RuleLike.Applies (F := F) s c) (h : s ≤ r) : r ≤ s :=
   Minimal.le_of_le hr ⟨hs, happ⟩ h
 
 /-! ### Selection: existence, coherence, uniqueness -/
 
 /-- Comparable Elsewhere winners at the same context are equivalent. -/
-theorem IsElsewhereWinner.antisymmRel {v : List (Rule Ctx F)} {c : Ctx}
-    {r s : Rule Ctx F} (hr : IsElsewhereWinner v c r)
-    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
-    AntisymmRel (· ≤ ·) r s := by
+theorem IsElsewhereWinner.antisymmRel {v : List R} {c : Ctx} {r s : R}
+    (hr : IsElsewhereWinner v c r) (hs : IsElsewhereWinner v c s)
+    (h : s ≤ r ∨ r ≤ s) : AntisymmRel (· ≤ ·) r s := by
   rcases h with h | h
   · exact ⟨hr.le_of_le hs.1.1 hs.1.2 h, h⟩
   · exact ⟨h, hs.le_of_le hr.1.1 hr.1.2 h⟩
@@ -98,20 +134,21 @@ theorem IsElsewhereWinner.antisymmRel {v : List (Rule Ctx F)} {c : Ctx}
 exponent, so the exponent descends to the antisymmetrization of the
 specificity preorder ([caha-2009]-style antihomophony, stated
 order-theoretically). -/
-def Coherent (v : List (Rule Ctx F)) : Prop :=
-  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s → r.exponent = s.exponent
+def Coherent (v : List R) : Prop :=
+  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
+    RuleLike.exponent (F := F) r = RuleLike.exponent (F := F) s
 
 /-- Over a coherent vocabulary, comparable winners select the same
 exponent: Elsewhere selection is well defined up to incomparability. -/
-theorem IsElsewhereWinner.exponent_eq {v : List (Rule Ctx F)} {c : Ctx}
-    {r s : Rule Ctx F} (hv : Coherent v) (hr : IsElsewhereWinner v c r)
+theorem IsElsewhereWinner.exponent_eq {v : List R} {c : Ctx} {r s : R}
+    (hv : Coherent v) (hr : IsElsewhereWinner v c r)
     (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
-    r.exponent = s.exponent :=
+    RuleLike.exponent (F := F) r = RuleLike.exponent (F := F) s :=
   hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
 
 /-- A vocabulary with an applicable rule has an Elsewhere winner. -/
-theorem exists_isElsewhereWinner {v : List (Rule Ctx F)} {c : Ctx}
-    (h : ∃ r ∈ v, r.Applies c) : ∃ r, IsElsewhereWinner v c r :=
+theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
+    (h : ∃ r ∈ v, RuleLike.Applies (F := F) r c) : ∃ r, IsElsewhereWinner v c r :=
   (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
 
 end Morphology.Exponence

--- a/Linglib/Morphology/Nanosyntax/Superset.lean
+++ b/Linglib/Morphology/Nanosyntax/Superset.lean
@@ -131,7 +131,7 @@ theorem minSpan_eq_coe_intro {v : List (ExponenceRule n F)} {g : Fin n}
   obtain ⟨hjv, hjle⟩ := mem_matching.mp hjt
   exact hlb jt hjv hjle
 
-/-- The key transfer lemma, dual to `maxThreshold_eq_coe_of_le`: a
+/-- The key transfer lemma, dual to `maxThreshold_eq_coe_of_between`: a
 winning span persists upward as long as the grade stays inside it. -/
 theorem minSpan_eq_coe_of_between {v : List (ExponenceRule n F)} {g g' m : Fin n}
     (h : minSpan v g = ↑m) (hg : g ≤ g') (hm : g' ≤ m) : minSpan v g' = ↑m := by

--- a/Linglib/Morphology/Nanosyntax/Superset.lean
+++ b/Linglib/Morphology/Nanosyntax/Superset.lean
@@ -427,44 +427,48 @@ example :
 
 /-! ### The shared exponence core
 
-One carrier, two `Rule` views: the Subset reading
-(`ExponenceRule.toRule`, `Morphology/Exponence/Hierarchy.lean`) and the
-Superset reading below instantiate the shared core with dual
-applicability conditions and opposite derived-specificity orders. -/
+One carrier, two `RuleLike` views: the Subset reading on
+`ExponenceRule` (`Morphology/Exponence/Hierarchy.lean`) and the Superset
+reading on the `SupersetRule` synonym below install the shared core with
+dual applicability conditions and opposite derived-specificity orders, à
+la `OrderDual`. -/
 
 section ExponenceCore
 
 open Morphology.Exponence
 
-/-- View an entry under the **Superset** reading as a rule of the
-shared exponence core: applicability is `Matches` (the stored
-constituent contains the structure), dually to `ExponenceRule.toRule`'s
-Subset reading. -/
-def ExponenceRule.toSupersetRule (it : ExponenceRule n F) :
-    Exponence.Rule (Fin n) F :=
-  ⟨it.exponent, it.Matches⟩
+/-- The **Superset** reading of an exponence rule: an entry spells out
+grade `g` when its stored constituent contains `g` (the down-set
+`Set.Iic spans`), dually to the Subset reading of `ExponenceRule`. A
+distinct type synonym so the two readings can carry different `RuleLike`
+instances on one carrier, mirroring `OrderDual`. -/
+def SupersetRule (n : ℕ) (F : Type*) := ExponenceRule n F
 
-/-- Minimize Junk is the shared core's specificity order under the
-Superset reading: smaller span = more specific. -/
-theorem ExponenceRule.toSupersetRule_le_iff
-    {it jt : ExponenceRule n F} :
-    it.toSupersetRule ≤ jt.toSupersetRule ↔ it.spans ≤ jt.spans :=
-  Exponence.Rule.le_iff.trans ExponenceRule.matches_imp_iff_spans_le
+instance : RuleLike (SupersetRule n F) (Fin n) F :=
+  ⟨ExponenceRule.exponent, fun it => Set.Iic (ExponenceRule.spans it)⟩
+
+instance : Preorder (SupersetRule n F) := RuleLike.toPreorder
+
+/-- Read an exponence rule under the Superset reading. -/
+def ExponenceRule.superset (it : ExponenceRule n F) : SupersetRule n F := it
+
+/-- Minimize Junk is the Superset reading's specificity order: smaller
+span = more specific. -/
+theorem SupersetRule.le_iff {it jt : SupersetRule n F} :
+    it ≤ jt ↔ ExponenceRule.spans it ≤ ExponenceRule.spans jt :=
+  Set.Iic_subset_Iic
 
 /-- **Subset/Superset duality** over context-free vocabularies (the
 nanosyntax idealization): DM-style Subset specificity of `it` over `jt`
 is Superset specificity of `jt` over `it`. With contextual restrictions
 the Subset order compares thresholds, not spans, and the duality is
 only one-directional. -/
-theorem ExponenceRule.toRule_le_iff_toSupersetRule_le
-    {it jt : ExponenceRule n F}
+theorem ExponenceRule.subset_le_iff_superset_le {it jt : ExponenceRule n F}
     (hit : it.context = none) (hjt : jt.context = none) :
-    it.toRule ≤ jt.toRule ↔
-      jt.toSupersetRule ≤ it.toSupersetRule := by
-  rw [ExponenceRule.toRule_le_iff,
-    ExponenceRule.moreSpecific_iff_threshold_le,
-    ExponenceRule.toSupersetRule_le_iff]
-  unfold ExponenceRule.threshold
+    it ≤ jt ↔ jt.superset ≤ it.superset := by
+  rw [ExponenceRule.le_iff, ExponenceRule.moreSpecific_iff_threshold_le,
+    SupersetRule.le_iff]
+  unfold ExponenceRule.threshold ExponenceRule.superset
   rw [hit, hjt]
   simp
 
@@ -475,14 +479,13 @@ specific. -/
 theorem spelloutWinner_isElsewhereWinner {v : List (ExponenceRule n F)}
     {g : Fin n} {it : ExponenceRule n F}
     (h : spelloutWinner v g = some it) :
-    Exponence.IsElsewhereWinner (v.map ExponenceRule.toSupersetRule) g
-      it.toSupersetRule := by
+    Exponence.IsElsewhereWinner (v.map ExponenceRule.superset) g it.superset := by
   obtain ⟨hmem, hms⟩ := spelloutWinner_spec h
   obtain ⟨-, -, -, hle⟩ := exists_of_minSpan_eq_coe hms
   refine ⟨⟨List.mem_map_of_mem hmem, hle⟩, ?_⟩
   rintro s ⟨hs, hsapp⟩ -
   obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hs
-  rw [ExponenceRule.toSupersetRule_le_iff]
+  rw [SupersetRule.le_iff]
   exact le_spans_of_minSpan_eq_coe hms hjt hsapp
 
 end ExponenceCore

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -25,10 +25,10 @@ uses containment as the simpler equivalent formulation.
 - `NanoTree`: feature trees; `NanoTree.Contains`: sub-constituency
 - `TreeLexEntry`: a stored tree paired with an exponent; `TreeLexEntry.Matches`
 - `treeSelect`, `treeSpellout`: Superset Principle + Elsewhere Condition
-- `TreeLexEntry.toRule`, `treeSelect_isElsewhereWinner`: the engine as an
-  instance of the shared exponence core — derived specificity is reverse
-  tree containment (`toRule_le_iff`), and smallest-tree
-  selection is an Elsewhere winner with no side conditions
+- `treeSelect_isElsewhereWinner`: the engine as an instance of the shared
+  exponence core (`RuleLike`) — derived specificity is reverse tree
+  containment (`TreeLexEntry.le_iff`), and smallest-tree selection is an
+  Elsewhere winner with no side conditions
 - `FootConditionMet`: [taraldsen-et-al-2018]'s constraint on backtracking
 - `chain_contains_iff_le`: for right-branching chains, tree containment
   reduces to rank comparison — tree-based spellout generalizes (not
@@ -290,19 +290,21 @@ section ExponenceCore
 
 open Morphology.Exponence
 
-/-- View a tree lexical entry as a rule of the shared exponence core
-(`Morphology.Exponence.Rule`): contexts are syntactic targets,
+/-- A tree lexical entry exposes the shared exponence core interface
+(`Morphology.Exponence.RuleLike`): contexts are syntactic targets,
 applicability is Superset-Principle matching. -/
-def TreeLexEntry.toRule (e : TreeLexEntry F α) : Rule (NanoTree F) α :=
-  ⟨e.exponent, e.Matches⟩
+instance : RuleLike (TreeLexEntry F α) (NanoTree F) α :=
+  ⟨TreeLexEntry.exponent, fun e => {t | e.Matches t}⟩
+
+instance : Preorder (TreeLexEntry F α) := RuleLike.toPreorder
 
 /-- The specificity order is reverse containment of the stored trees:
 `a` is at least as specific as `b` exactly when `b`'s tree contains
 `a`'s. Tree size is therefore a faithful specificity measure
 (`Contains.size_le`), which is what licenses smallest-tree selection. -/
-theorem TreeLexEntry.toRule_le_iff {a b : TreeLexEntry F α} :
-    a.toRule ≤ b.toRule ↔ b.tree.Contains a.tree :=
-  Rule.le_iff.trans ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
+theorem TreeLexEntry.le_iff {a b : TreeLexEntry F α} :
+    a ≤ b ↔ b.tree.Contains a.tree :=
+  ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
 
 /-- Smallest-tree selection is an Elsewhere winner of the shared core,
 with no side conditions: containment is size-antisymmetric
@@ -311,19 +313,18 @@ maximally specific among the matching entries. -/
 theorem treeSelect_isElsewhereWinner [DecidableEq F]
     {entries : List (TreeLexEntry F α)} {target : NanoTree F}
     {e : TreeLexEntry F α} (h : treeSelect entries target = some e) :
-    IsElsewhereWinner (entries.map TreeLexEntry.toRule) target e.toRule := by
+    IsElsewhereWinner entries target e := by
   have hmem := List.argmin_mem h
   rw [List.mem_filter] at hmem
   obtain ⟨hev, hem⟩ := hmem
   have hematch : e.Matches target := of_decide_eq_true hem
-  refine ⟨⟨List.mem_map_of_mem hev, hematch⟩, ?_⟩
+  refine ⟨⟨hev, hematch⟩, ?_⟩
   rintro s ⟨hs, happ⟩ hspec
-  obtain ⟨b, hb, rfl⟩ := List.mem_map.mp hs
-  rw [TreeLexEntry.toRule_le_iff] at hspec ⊢
-  have hble : ¬ b.tree.size < e.tree.size :=
+  rw [TreeLexEntry.le_iff] at hspec ⊢
+  have hble : ¬ s.tree.size < e.tree.size :=
     List.not_lt_of_mem_argmin (f := λ e : TreeLexEntry F α => e.tree.size)
       (List.mem_filter.mpr
-        ⟨hb, decide_eq_true (show b.Matches target from happ)⟩) h
+        ⟨hs, decide_eq_true (show s.Matches target from happ)⟩) h
   exact hspec.eq_of_size_le (Nat.le_of_not_lt hble) ▸ .refl _
 
 /-- The spelled-out exponent is an Elsewhere winner's exponent. -/
@@ -331,7 +332,7 @@ theorem treeSpellout_isElsewhereWinner [DecidableEq F]
     {entries : List (TreeLexEntry F α)} {target : NanoTree F} {x : α}
     (h : treeSpellout entries target = some x) :
     ∃ e ∈ entries, e.exponent = x ∧
-      IsElsewhereWinner (entries.map TreeLexEntry.toRule) target e.toRule := by
+      IsElsewhereWinner entries target e := by
   obtain ⟨e, he, rfl⟩ := Option.map_eq_some_iff.mp h
   exact ⟨e, (List.mem_filter.mp (List.argmin_mem he)).1, rfl,
     treeSelect_isElsewhereWinner he⟩

--- a/Linglib/Studies/Bobaljik2012.lean
+++ b/Linglib/Studies/Bobaljik2012.lean
@@ -139,7 +139,7 @@ theorem bad_csg : bad.suppletion.SprlSuppletive :=
 
 /-- CSG Part II on the English data: if the superlative is suppletive,
     the comparative is too. Data-level check; the engine derivation
-    (`Morphology.Containment.csg2`) is instantiated at
+    (`Morphology.Containment.realize_const_of_grounded`) is instantiated at
     `welshAAB_blocked` below. -/
 theorem good_csg_part2 : good.suppletion.CmprSuppletive := by decide
 theorem bad_csg_part2 : bad.suppletion.CmprSuppletive := by decide
@@ -268,8 +268,9 @@ theorem latin_all_three_patterns :
 vocabularies [bobaljik-2012] actually writes down. `ExponenceRule`s record
 exponent, exponed span, and conditioning context; `realize` runs
 Elsewhere insertion; `degreeShape` reads the root-suppletion class off
-the realized cells. The hypotheses of the engine's theorems (`csg2`,
-`exists_portmanteau_of_ne`) are `decide`-checked on each vocabulary,
+the realized cells. The hypotheses of the engine's theorems
+(`realize_const_of_grounded`, `exists_portmanteau_of_ne`) are
+`decide`-checked on each vocabulary,
 and the two unattested shapes are exhibited as violations of exactly
 one condition each: AAB violates `Grounded` ((202)), surface ABA
 violates `Antihomophonous` ((44)). -/
@@ -386,11 +387,12 @@ theorem welshAAB_realizes_aab : degreeShape (realize welshAAB) = aab := by decid
     skips the comparative grade, violating `Grounded` ((202)). -/
 theorem welshAAB_not_grounded : ¬ Grounded welshAAB := by decide
 
-/-- The engine theorem `csg2` applied: no vocabulary realizing the AAB
-    cells can satisfy both Antihomophony and `Grounded` — the AAB
-    realization itself refutes the conjunction. -/
+/-- The engine theorem `realize_const_of_grounded` applied: no vocabulary
+    realizing the AAB cells can satisfy both Antihomophony and `Grounded` —
+    the AAB realization itself refutes the conjunction. -/
 theorem welshAAB_blocked : ¬ (Antihomophonous welshAAB ∧ Grounded welshAAB) :=
-  λ ⟨hAH, hG⟩ => absurd (csg2 hAH hG (by decide) (by decide)) (by decide)
+  λ ⟨hAH, hG⟩ =>
+    absurd (realize_const_of_grounded hAH hG (by decide) (by decide)) (by decide)
 
 /-- The homophonous-ABC loophole ([bobaljik-2012] (44) discussion):
     without Antihomophony, surface ABA is generable — a superlative

--- a/Linglib/Studies/Graf2019.lean
+++ b/Linglib/Studies/Graf2019.lean
@@ -140,7 +140,8 @@ in terms of syntactic containment (his suggestion). The pair below
 states the division precisely: AAB is feasibly monotonic, and its
 gradation-side exclusion is carried by realization-level conditions
 ([bobaljik-2012]'s markedness condition (202), via
-`Morphology.Containment.csg2`) — which the person attestation shows
+`Morphology.Containment.realize_const_of_grounded`) — which the person
+attestation shows
 are not category-general, the same point the pronominal case/number
 data make in `Studies/SmithMoskalEtAl2019.lean`. -/
 
@@ -159,7 +160,7 @@ theorem aab_not_groundedly_realizable {v : List (ExponenceRule 3 ℕ)}
   intro h
   have h01 : realize v 0 = realize v 1 := by simp [h]
   have h2 : (realize v 2).isSome := by simp [h]
-  have h12 := csg2 hAH hG h01 h2
+  have h12 := realize_const_of_grounded hAH hG h01 h2
   rw [h] at h12
   exact hab (by simpa using h12)
 

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -476,10 +476,12 @@ structure FinRule (Ctx F : Type*) where
   /-- The forms the rule generates. -/
   supp : Finset Ctx
 
-/-- View a finitely supported rule in the shared exponence core:
-applicability is support membership. -/
-def FinRule.toRule (r : FinRule Ctx F) : Rule Ctx F :=
-  ⟨r.exponent, (· ∈ r.supp)⟩
+/-- A finitely supported rule exposes the shared exponence core interface
+(`Morphology.Exponence.RuleLike`): applicability is support membership. -/
+instance : RuleLike (FinRule Ctx F) Ctx F :=
+  ⟨FinRule.exponent, fun r => {c | c ∈ r.supp}⟩
+
+instance : Preorder (FinRule Ctx F) := RuleLike.toPreorder
 
 /-- **Elsewhere selection is maximum-likelihood inference**
 ([odonnell-2015] §5.5.3): a rule maximizing uniform generation
@@ -488,12 +490,11 @@ winner of the corresponding vocabulary. -/
 theorem maxGenProb_isElsewhereWinner {v : List (FinRule Ctx F)} {c : Ctx}
     {r : FinRule Ctx F} (hrv : r ∈ v) (hrc : c ∈ r.supp)
     (hmax : ∀ s ∈ v, c ∈ s.supp → genProb s.supp c ≤ genProb r.supp c) :
-    IsElsewhereWinner (v.map FinRule.toRule) c r.toRule := by
-  refine ⟨⟨List.mem_map_of_mem hrv, hrc⟩, ?_⟩
-  rintro t ⟨ht, htc⟩ hle
-  obtain ⟨s, hsv, rfl⟩ := List.mem_map.mp ht
+    IsElsewhereWinner v c r := by
+  refine ⟨⟨hrv, hrc⟩, ?_⟩
+  rintro s ⟨hsv, htc⟩ hle
   have htc' : c ∈ s.supp := htc
-  have hsub : s.supp ⊆ r.supp := fun x hx => Rule.le_iff.mp hle hx
+  have hsub : s.supp ⊆ r.supp := fun x hx => hle hx
   have hcard : r.supp.card ≤ s.supp.card := by
     have hp := hmax s hsv htc'
     simp only [genProb] at hp
@@ -504,7 +505,7 @@ theorem maxGenProb_isElsewhereWinner {v : List (FinRule Ctx F)} {c : Ctx}
       exact_mod_cast Finset.card_pos.mpr ⟨c, hrc⟩
     exact_mod_cast (inv_le_inv₀ hs₀ hr₀).mp hp
   have heq : s.supp = r.supp := Finset.eq_of_subset_of_card_le hsub hcard
-  exact Rule.le_iff.mpr fun x hx => show x ∈ s.supp from heq ▸ hx
+  exact fun x hx => show x ∈ s.supp from heq ▸ hx
 
 end ProbabilisticElsewhere
 


### PR DESCRIPTION
Unifies the six per-engine `toRule` bridges into a `RuleLike` class (SetLike minus injectivity, plus an exponent projection; opt-in `toPreorder` per mathlib's `PartialOrder.ofSetLike` pattern) — the containment hierarchy, DM VocabItem/VocabEntry, nanosyntax TreeSpellout, and ODonnell2015's FinRule become instances, with a `SupersetRule` synonym carrying nanosyntax's dual reading OrderDual-style.

- `Hierarchy.lean` docstring register cleanse; `csg2` → `realize_const_of_grounded` (no paper acronyms)
- winner theorems restated on native carriers; dead `appliesAt_iff` deleted