### PR TITLE
refactor(Morphology): rename ExponenceRule to SpanRule

### DIFF
--- a/Linglib/Morphology/DM/DomainLocality.lean
+++ b/Linglib/Morphology/DM/DomainLocality.lean
@@ -43,7 +43,7 @@ grade, which locality unit it belongs to. The AD theory itself is
 *trigger-relative* — a bound on which heads may condition root
 suppletion, formalized at rule level as
 `SmithMoskalEtAl2019.DomainLocal` on
-`Morphology.Containment.ExponenceRule` vocabularies. The substrate is
+`Morphology.Containment.SpanRule` vocabularies. The substrate is
 theory-neutral about how the partition is computed:
 [moskal-2015a-dissertation]'s AD is one source, [embick-2010]'s linear
 adjacency another (every grade its own one-cell domain),

--- a/Linglib/Morphology/DM/Merger.lean
+++ b/Linglib/Morphology/DM/Merger.lean
@@ -181,11 +181,11 @@ condition (90) applied through Merger). Models the
 comparative-embedding periphrasis type (Greek, the book's (107a–b));
 the positive-embedding type (Russian, (107c–d)) needs a per-grade
 embedding choice rather than a single `wordTop`. -/
-def realizeIn (s : Synthesis n) (v : List (ExponenceRule n F)) : Paradigm n (Option F) :=
+def realizeIn (s : Synthesis n) (v : List (SpanRule n F)) : Paradigm n (Option F) :=
   λ g => realize v (min g s.wordTop)
 
 /-- At a synthetic grade, word-internal realization is realization. -/
-theorem realizeIn_eq_realize_of_le {s : Synthesis n} {v : List (ExponenceRule n F)}
+theorem realizeIn_eq_realize_of_le {s : Synthesis n} {v : List (SpanRule n F)}
     {g : Fin n} (h : g ≤ s.wordTop) : realizeIn s v g = realize v g := by
   unfold realizeIn
   rw [min_eq_left h]
@@ -193,21 +193,21 @@ theorem realizeIn_eq_realize_of_le {s : Synthesis n} {v : List (ExponenceRule n 
 /-- At a periphrastic grade, the root word realizes as at `wordTop` —
 the highest grade whose structure is word-internal. -/
 theorem realizeIn_eq_realize_wordTop_of_le {s : Synthesis n}
-    {v : List (ExponenceRule n F)} {g : Fin n} (h : s.wordTop ≤ g) :
+    {v : List (SpanRule n F)} {g : Fin n} (h : s.wordTop ≤ g) :
     realizeIn s v g = realize v s.wordTop := by
   unfold realizeIn
   rw [min_eq_right h]
 
 /-- Word-internal realization is still contiguous: `realizeIn` is
 `realize` precomposed with the monotone regrading `min · wordTop`. -/
-theorem isContiguous_realizeIn {s : Synthesis n} {v : List (ExponenceRule n F)}
+theorem isContiguous_realizeIn {s : Synthesis n} {v : List (SpanRule n F)}
     (hAH : Antihomophonous v) : IsContiguous (realizeIn s v) :=
   (isContiguous_realize hAH).comp_monotone (λ _ _ h => min_le_min_right _ h)
 
 /-- A lexeme with no Merger at all (`wordTop = 0`, fully periphrastic
 paradigm) realizes the same root form at every grade. -/
 theorem realizeIn_const_of_wordTop_eq_zero {s : Synthesis n}
-    {v : List (ExponenceRule n F)} (h : (s.wordTop : ℕ) = 0) (g g' : Fin n) :
+    {v : List (SpanRule n F)} (h : (s.wordTop : ℕ) = 0) (g g' : Fin n) :
     realizeIn s v g = realizeIn s v g' := by
   have hle : ∀ x : Fin n, s.wordTop ≤ x := λ x => by
     rw [Fin.le_def, h]; exact Nat.zero_le _
@@ -220,7 +220,7 @@ a grade requires that grade's word to be synthetic. Contrapositively:
 above `wordTop` the word realizes constantly (`
 realizeIn_eq_realize_wordTop_of_le`). -/
 theorem min_lt_wordTop_of_realizeIn_ne {s : Synthesis n}
-    {v : List (ExponenceRule n F)} {g g' : Fin n}
+    {v : List (SpanRule n F)} {g g' : Fin n}
     (h : realizeIn s v g ≠ realizeIn s v g') : min g g' < s.wordTop := by
   by_contra hle
   push Not at hle
@@ -232,7 +232,7 @@ theorem min_lt_wordTop_of_realizeIn_ne {s : Synthesis n}
 synthetic comparatives — a lexeme showing distinct root forms at two
 grades has undergone Merger at least once, so its comparative is
 synthetic. Excludes `*good – more bett`. -/
-theorem rsg {s : Synthesis 3} {v : List (ExponenceRule 3 F)} {g g' : Fin 3}
+theorem rsg {s : Synthesis 3} {v : List (SpanRule 3 F)} {g g' : Fin 3}
     (h : realizeIn s v g ≠ realizeIn s v g') : s.SyntheticAt 1 := by
   have hlt := min_lt_wordTop_of_realizeIn_ne h
   rw [Fin.lt_def] at hlt

--- a/Linglib/Morphology/Exponence/Hierarchy.lean
+++ b/Linglib/Morphology/Exponence/Hierarchy.lean
@@ -9,7 +9,7 @@ import Mathlib.Data.Finset.Max
 
 The realizational engine behind [bobaljik-2012]'s comparative-suppletion
 generalizations, over an arbitrary `n`-grade containment hierarchy. An
-`ExponenceRule` realizes the initial span `[0, spans]` of the hierarchy,
+`SpanRule` realizes the initial span `[0, spans]` of the hierarchy,
 optionally conditioned on a higher head; the Elsewhere Condition
 ([kiparsky-1973]) selects the most specific applicable rule. Over a linear
 hierarchy, specificity is applicability-set inclusion, so the Elsewhere
@@ -17,7 +17,7 @@ ordering is threshold comparison (`moreSpecific_iff_threshold_le`).
 
 ## Main declarations
 
-* `ExponenceRule n F` — exponent, exponed span `[0, spans]`, optional
+* `SpanRule n F` — exponent, exponed span `[0, spans]`, optional
   conditioning head
 * `Terminal`, `Adjacent`, `Antihomophonous`, `Grounded` — well-formedness
   conditions on vocabularies
@@ -41,7 +41,7 @@ when `spans = 0`, a root+heads portmanteau when `spans > 0` — and applies
 only when its optional conditioning head `context` is present. Latin
 ([bobaljik-2012] (204)): `bon` is `⟨bon, 0, none⟩`, `mel-` is
 `⟨mel, 0, some 1⟩`, the portmanteau `opt-` is `⟨opt, 1, some 2⟩`. -/
-structure ExponenceRule (n : ℕ) (F : Type*) where
+structure SpanRule (n : ℕ) (F : Type*) where
   /-- The phonological exponent inserted for the span. -/
   exponent : F
   /-- Upper end of the exponed initial span `[0, spans]`. -/
@@ -50,35 +50,35 @@ structure ExponenceRule (n : ℕ) (F : Type*) where
   context : Option (Fin n)
   deriving DecidableEq, Repr
 
-namespace ExponenceRule
+namespace SpanRule
 
 /-- The least grade at which the rule is applicable: everything the
 rule mentions — exponed span and conditioning context — must be
 contained in the structure. -/
-def threshold (it : ExponenceRule n F) : Fin n :=
+def threshold (it : SpanRule n F) : Fin n :=
   max it.spans (it.context.getD it.spans)
 
 /-- A rule applies at grade `g` when grade `g`'s structure contains
 everything the rule mentions. -/
-def AppliesAt (it : ExponenceRule n F) (g : Fin n) : Prop :=
+def AppliesAt (it : SpanRule n F) (g : Fin n) : Prop :=
   it.threshold ≤ g
 
-instance (it : ExponenceRule n F) (g : Fin n) : Decidable (it.AppliesAt g) :=
+instance (it : SpanRule n F) (g : Fin n) : Decidable (it.AppliesAt g) :=
   inferInstanceAs (Decidable (_ ≤ _))
 
 /-- A rule `it` is at least as specific as `jt` when it applies in a
 subset of the contexts `jt` applies in (Pāṇinian specificity). -/
-def MoreSpecific (it jt : ExponenceRule n F) : Prop :=
+def MoreSpecific (it jt : SpanRule n F) : Prop :=
   ∀ ⦃g : Fin n⦄, it.AppliesAt g → jt.AppliesAt g
 
 /-- Over a linear containment hierarchy, applicability sets are nested
 upward sets, so derived specificity is threshold comparison — the
 Elsewhere ordering ([kiparsky-1973]) is total. -/
-theorem moreSpecific_iff_threshold_le {it jt : ExponenceRule n F} :
+theorem moreSpecific_iff_threshold_le {it jt : SpanRule n F} :
     it.MoreSpecific jt ↔ jt.threshold ≤ it.threshold :=
   ⟨λ h => h (le_refl it.threshold), λ h _ hg => le_trans h hg⟩
 
-end ExponenceRule
+end SpanRule
 
 /-! ### Well-formedness conditions on vocabularies
 
@@ -88,74 +88,74 @@ unattested pattern (see the worked examples in
 `Studies/Bobaljik2012.lean`). -/
 
 /-- Every rule expones the bare root (no portmanteaux). -/
-def Terminal (v : List (ExponenceRule n F)) : Prop :=
+def Terminal (v : List (SpanRule n F)) : Prop :=
   ∀ it ∈ v, (it.spans : ℕ) = 0
 
-instance (v : List (ExponenceRule n F)) : Decidable (Terminal v) := by
+instance (v : List (SpanRule n F)) : Decidable (Terminal v) := by
   unfold Terminal; infer_instance
 
 /-- Conditioning heads are adjacent to the exponed span —
 [bobaljik-2012]'s (tentatively adopted) adjacency condition on
 contextual allomorphy. -/
-def Adjacent (v : List (ExponenceRule n F)) : Prop :=
+def Adjacent (v : List (SpanRule n F)) : Prop :=
   ∀ it ∈ v, ∀ c : Fin n, it.context = some c → (c : ℕ) = (it.spans : ℕ) + 1
 
-instance (v : List (ExponenceRule n F)) : Decidable (Adjacent v) := by
+instance (v : List (SpanRule n F)) : Decidable (Adjacent v) := by
   unfold Adjacent; infer_instance
 
 /-- Distinct rules carry distinct exponents — [bobaljik-2012]'s Antihomophony
 assumption (44), closing the loophole where a surface-ABA pattern is really an
 ABC with accidental A ≡ C homophony. -/
-def Antihomophonous (v : List (ExponenceRule n F)) : Prop :=
+def Antihomophonous (v : List (SpanRule n F)) : Prop :=
   ∀ it ∈ v, ∀ jt ∈ v, it.exponent = jt.exponent → it = jt
 
-instance [DecidableEq F] (v : List (ExponenceRule n F)) : Decidable (Antihomophonous v) := by
+instance [DecidableEq F] (v : List (SpanRule n F)) : Decidable (Antihomophonous v) := by
   unfold Antihomophonous; infer_instance
 
 /-- [bobaljik-2012]'s markedness condition (202): a context-sensitive rule of
 exponence involving a node requires a context-free rule involving that node.
 Under the threshold encoding, this is downward closure of the vocabulary's
 threshold set. -/
-def Grounded (v : List (ExponenceRule n F)) : Prop :=
+def Grounded (v : List (SpanRule n F)) : Prop :=
   ∀ it ∈ v, ∀ k : Fin n, k < it.threshold → ∃ jt ∈ v, jt.threshold = k
 
-instance (v : List (ExponenceRule n F)) : Decidable (Grounded v) := by
+instance (v : List (SpanRule n F)) : Decidable (Grounded v) := by
   unfold Grounded; infer_instance
 
 /-! ### Elsewhere selection -/
 
 /-- The rules applicable at grade `g`, in vocabulary order. -/
-def applicable (v : List (ExponenceRule n F)) (g : Fin n) : List (ExponenceRule n F) :=
+def applicable (v : List (SpanRule n F)) (g : Fin n) : List (SpanRule n F) :=
   v.filter (λ it => it.threshold ≤ g)
 
-@[simp] theorem mem_applicable {v : List (ExponenceRule n F)} {g : Fin n} {it : ExponenceRule n F} :
+@[simp] theorem mem_applicable {v : List (SpanRule n F)} {g : Fin n} {it : SpanRule n F} :
     it ∈ applicable v g ↔ it ∈ v ∧ it.threshold ≤ g := by
   simp [applicable]
 
 /-- The greatest applicable threshold at grade `g` — the specificity
 level of the Elsewhere winner, `⊥` when nothing applies. -/
-def maxThreshold (v : List (ExponenceRule n F)) (g : Fin n) : WithBot (Fin n) :=
-  ((applicable v g).map ExponenceRule.threshold).maximum
+def maxThreshold (v : List (SpanRule n F)) (g : Fin n) : WithBot (Fin n) :=
+  ((applicable v g).map SpanRule.threshold).maximum
 
-theorem maxThreshold_eq_bot_iff {v : List (ExponenceRule n F)} {g : Fin n} :
+theorem maxThreshold_eq_bot_iff {v : List (SpanRule n F)} {g : Fin n} :
     maxThreshold v g = ⊥ ↔ applicable v g = [] := by
   rw [maxThreshold, List.maximum_eq_bot, List.map_eq_nil_iff]
 
-theorem exists_of_maxThreshold_eq_coe {v : List (ExponenceRule n F)} {g m : Fin n}
+theorem exists_of_maxThreshold_eq_coe {v : List (SpanRule n F)} {g m : Fin n}
     (h : maxThreshold v g = ↑m) : ∃ it ∈ v, it.threshold = m ∧ m ≤ g := by
   obtain ⟨hmem, -⟩ := List.maximum_eq_coe_iff.mp h
   obtain ⟨it, hit, hτ⟩ := List.mem_map.mp hmem
   obtain ⟨hitv, hle⟩ := mem_applicable.mp hit
   exact ⟨it, hitv, hτ, hτ ▸ hle⟩
 
-theorem threshold_le_of_maxThreshold_eq_coe {v : List (ExponenceRule n F)} {g m : Fin n}
-    (h : maxThreshold v g = ↑m) {it : ExponenceRule n F} (hitv : it ∈ v)
+theorem threshold_le_of_maxThreshold_eq_coe {v : List (SpanRule n F)} {g m : Fin n}
+    (h : maxThreshold v g = ↑m) {it : SpanRule n F} (hitv : it ∈ v)
     (hle : it.threshold ≤ g) : it.threshold ≤ m :=
   (List.maximum_eq_coe_iff.mp h).2 _
     (List.mem_map_of_mem (mem_applicable.mpr ⟨hitv, hle⟩))
 
-theorem maxThreshold_eq_coe_intro {v : List (ExponenceRule n F)} {g : Fin n}
-    {it : ExponenceRule n F} (hitv : it ∈ v) (hle : it.threshold ≤ g)
+theorem maxThreshold_eq_coe_intro {v : List (SpanRule n F)} {g : Fin n}
+    {it : SpanRule n F} (hitv : it ∈ v) (hle : it.threshold ≤ g)
     (hub : ∀ jt ∈ v, jt.threshold ≤ g → jt.threshold ≤ it.threshold) :
     maxThreshold v g = ↑it.threshold := by
   rw [maxThreshold, List.maximum_eq_coe_iff]
@@ -166,7 +166,7 @@ theorem maxThreshold_eq_coe_intro {v : List (ExponenceRule n F)} {g : Fin n}
 
 /-- A winning threshold persists downward as long as it stays applicable,
 which is what makes Elsewhere selection plateau between grades. -/
-theorem maxThreshold_eq_coe_of_between {v : List (ExponenceRule n F)} {g g' m : Fin n}
+theorem maxThreshold_eq_coe_of_between {v : List (SpanRule n F)} {g g' m : Fin n}
     (h : maxThreshold v g' = ↑m) (hm : m ≤ g) (hg : g ≤ g') :
     maxThreshold v g = ↑m := by
   obtain ⟨it, hitv, hτ, -⟩ := exists_of_maxThreshold_eq_coe h
@@ -174,7 +174,7 @@ theorem maxThreshold_eq_coe_of_between {v : List (ExponenceRule n F)} {g g' m : 
   exact maxThreshold_eq_coe_intro hitv hm
     (λ jt hjv hjle => threshold_le_of_maxThreshold_eq_coe h hjv (le_trans hjle hg))
 
-theorem maxThreshold_eq_bot_of_le {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem maxThreshold_eq_bot_of_le {v : List (SpanRule n F)} {g g' : Fin n}
     (h : maxThreshold v g' = ⊥) (hg : g ≤ g') : maxThreshold v g = ⊥ := by
   rw [maxThreshold_eq_bot_iff] at h ⊢
   rw [List.eq_nil_iff_forall_not_mem] at h ⊢
@@ -184,19 +184,19 @@ theorem maxThreshold_eq_bot_of_le {v : List (ExponenceRule n F)} {g g' : Fin n}
 
 /-- The Elsewhere winner at grade `g`: the first rule attaining the
 greatest applicable threshold — the most specific applicable rule. -/
-def winner (v : List (ExponenceRule n F)) (g : Fin n) : Option (ExponenceRule n F) :=
+def winner (v : List (SpanRule n F)) (g : Fin n) : Option (SpanRule n F) :=
   (maxThreshold v g).recBotCoe none (λ m => v.find? (λ it => it.threshold == m))
 
-theorem winner_eq_none_of_bot {v : List (ExponenceRule n F)} {g : Fin n}
+theorem winner_eq_none_of_bot {v : List (SpanRule n F)} {g : Fin n}
     (h : maxThreshold v g = ⊥) : winner v g = none := by
   rw [winner, h]; rfl
 
-theorem winner_of_coe {v : List (ExponenceRule n F)} {g m : Fin n}
+theorem winner_of_coe {v : List (SpanRule n F)} {g m : Fin n}
     (h : maxThreshold v g = ↑m) :
     winner v g = v.find? (λ it => it.threshold == m) := by
   rw [winner, h]; rfl
 
-theorem winner_spec {v : List (ExponenceRule n F)} {g : Fin n} {it : ExponenceRule n F}
+theorem winner_spec {v : List (SpanRule n F)} {g : Fin n} {it : SpanRule n F}
     (h : winner v g = some it) :
     it ∈ v ∧ maxThreshold v g = ↑it.threshold := by
   cases hmt : maxThreshold v g with
@@ -206,7 +206,7 @@ theorem winner_spec {v : List (ExponenceRule n F)} {g : Fin n} {it : ExponenceRu
     have hτ : it.threshold = m := by simpa using List.find?_some h
     exact ⟨List.mem_of_find?_eq_some h, by rw [hτ]⟩
 
-theorem exists_winner_of_coe {v : List (ExponenceRule n F)} {g m : Fin n}
+theorem exists_winner_of_coe {v : List (SpanRule n F)} {g m : Fin n}
     (h : maxThreshold v g = ↑m) : ∃ it, winner v g = some it := by
   rw [winner_of_coe h]
   obtain ⟨it, hitv, hτ, -⟩ := exists_of_maxThreshold_eq_coe h
@@ -216,7 +216,7 @@ theorem exists_winner_of_coe {v : List (ExponenceRule n F)} {g m : Fin n}
     rw [List.find?_eq_none] at hf
     exact absurd (by simp [hτ] : (it.threshold == m) = true) (by simpa using hf it hitv)
 
-theorem winner_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
+theorem winner_eq_none_iff {v : List (SpanRule n F)} {g : Fin n} :
     winner v g = none ↔ maxThreshold v g = ⊥ := by
   refine ⟨λ h => ?_, winner_eq_none_of_bot⟩
   cases hmt : maxThreshold v g with
@@ -226,21 +226,21 @@ theorem winner_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
     rw [hit] at h
     exact absurd h (by simp)
 
-theorem winner_congr {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem winner_congr {v : List (SpanRule n F)} {g g' : Fin n}
     (h : maxThreshold v g = maxThreshold v g') : winner v g = winner v g' := by
   rw [winner, winner, h]
 
 /-- The realized pattern: at each grade, the Elsewhere winner's
 exponent (`none` when no rule applies — a paradigm gap). -/
-def realize (v : List (ExponenceRule n F)) : Paradigm n (Option F) :=
-  λ g => (winner v g).map ExponenceRule.exponent
+def realize (v : List (SpanRule n F)) : Paradigm n (Option F) :=
+  λ g => (winner v g).map SpanRule.exponent
 
-theorem realize_congr {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem realize_congr {v : List (SpanRule n F)} {g g' : Fin n}
     (h : maxThreshold v g = maxThreshold v g') : realize v g = realize v g' := by
   show (winner v g).map _ = (winner v g').map _
   rw [winner_congr h]
 
-theorem realize_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
+theorem realize_eq_none_iff {v : List (SpanRule n F)} {g : Fin n} :
     realize v g = none ↔ maxThreshold v g = ⊥ := by
   rw [← winner_eq_none_iff]
   unfold realize
@@ -257,7 +257,7 @@ makes exponents injective in the winner — so realization factors as
 monotone-then-injective and `Basic.lean`'s composition principle
 applies (here inlined as the sandwich argument). -/
 
-theorem isContiguous_realize {v : List (ExponenceRule n F)} (hAH : Antihomophonous v) :
+theorem isContiguous_realize {v : List (SpanRule n F)} (hAH : Antihomophonous v) :
     IsContiguous (realize v) := by
   intro i j k hij hjk heq
   cases hwi : winner v i with
@@ -293,7 +293,7 @@ comparative and superlative cells to coincide and so *over-excludes*
 the attested ABC patterns (Latin *bon- ~ mel- ~ opt-*). Portmanteau items
 (`0 < spans`) are what license ABC; see `exists_portmanteau_of_ne`. -/
 
-theorem applicable_eq_of_cap {v : List (ExponenceRule n F)} {m g g' : Fin n}
+theorem applicable_eq_of_cap {v : List (SpanRule n F)} {m g g' : Fin n}
     (hcap : ∀ it ∈ v, it.threshold ≤ m) (hg : m ≤ g) (hg' : m ≤ g') :
     applicable v g = applicable v g' := by
   unfold applicable
@@ -301,17 +301,17 @@ theorem applicable_eq_of_cap {v : List (ExponenceRule n F)} {m g g' : Fin n}
   simp only [decide_eq_decide]
   exact iff_of_true (le_trans (hcap it hit) hg) (le_trans (hcap it hit) hg')
 
-theorem realize_const_of_cap {v : List (ExponenceRule n F)} {m g g' : Fin n}
+theorem realize_const_of_cap {v : List (SpanRule n F)} {m g g' : Fin n}
     (hcap : ∀ it ∈ v, it.threshold ≤ m) (hg : m ≤ g) (hg' : m ≤ g') :
     realize v g = realize v g' :=
   realize_congr (by unfold maxThreshold; rw [applicable_eq_of_cap hcap hg hg'])
 
-private theorem threshold_le_one {it : ExponenceRule 3 F}
+private theorem threshold_le_one {it : SpanRule 3 F}
     (h0 : (it.spans : ℕ) = 0)
     (hc : ∀ c : Fin 3, it.context = some c → (c : ℕ) = (it.spans : ℕ) + 1) :
     it.threshold ≤ (1 : Fin 3) := by
   have h1 : it.spans ≤ (1 : Fin 3) := by rw [Fin.le_def]; simp [h0]
-  unfold ExponenceRule.threshold
+  unfold SpanRule.threshold
   cases hcx : it.context with
   | none => simpa using h1
   | some c =>
@@ -321,7 +321,7 @@ private theorem threshold_le_one {it : ExponenceRule 3 F}
 /-- Terminal rules with adjacent contexts have thresholds at most the
 first head, so the comparative and superlative cells coincide: only
 AAA and ABB root patterns are generable. -/
-theorem realize_const_of_terminal_adjacent {v : List (ExponenceRule 3 F)}
+theorem realize_const_of_terminal_adjacent {v : List (SpanRule 3 F)}
     (hT : Terminal v) (hA : Adjacent v) : realize v 1 = realize v 2 :=
   realize_const_of_cap (m := (1 : Fin 3))
     (λ it hit => threshold_le_one (hT it hit) (hA it hit)) le_rfl (by decide)
@@ -354,11 +354,11 @@ theorem firstOcc_congr {p : Paradigm n F} {g g' : Fin n} (h : p g = p g') :
 
 /-- The canonical vocabulary of a pattern: one rule per form,
 introduced at the form's first grade and conditioned on it. -/
-def ofPattern (p : Paradigm n F) : List (ExponenceRule n F) :=
+def ofPattern (p : Paradigm n F) : List (SpanRule n F) :=
   (List.finRange n).filterMap (λ s =>
     if firstOcc p s = s then some ⟨p s, ⟨0, s.pos⟩, some s⟩ else none)
 
-theorem mem_ofPattern {p : Paradigm n F} {it : ExponenceRule n F} :
+theorem mem_ofPattern {p : Paradigm n F} {it : SpanRule n F} :
     it ∈ ofPattern p ↔
       ∃ s : Fin n, firstOcc p s = s ∧ it = ⟨p s, ⟨0, s.pos⟩, some s⟩ := by
   simp only [ofPattern, List.mem_filterMap, List.mem_finRange, true_and]
@@ -372,8 +372,8 @@ theorem mem_ofPattern {p : Paradigm n F} {it : ExponenceRule n F} :
 
 omit [DecidableEq F] in
 theorem threshold_ofPattern {p : Paradigm n F} {s : Fin n} :
-    (⟨p s, ⟨0, s.pos⟩, some s⟩ : ExponenceRule n F).threshold = s := by
-  unfold ExponenceRule.threshold
+    (⟨p s, ⟨0, s.pos⟩, some s⟩ : SpanRule n F).threshold = s := by
+  unfold SpanRule.threshold
   simp only [Option.getD_some]
   exact max_eq_right (by rw [Fin.le_def]; exact Nat.zero_le _)
 
@@ -397,11 +397,11 @@ theorem realize_ofPattern {p : Paradigm n F} (hp : IsContiguous p) (g : Fin n) :
   have hff : firstOcc p (firstOcc p g) = firstOcc p g :=
     firstOcc_congr (apply_firstOcc p g)
   have hitem : (⟨p (firstOcc p g), ⟨0, (firstOcc p g).pos⟩, some (firstOcc p g)⟩ :
-      ExponenceRule n F) ∈ ofPattern p :=
+      SpanRule n F) ∈ ofPattern p :=
     mem_ofPattern.mpr ⟨firstOcc p g, hff, rfl⟩
   have hub : ∀ jt ∈ ofPattern p, jt.threshold ≤ g →
       jt.threshold ≤ (⟨p (firstOcc p g), ⟨0, (firstOcc p g).pos⟩,
-        some (firstOcc p g)⟩ : ExponenceRule n F).threshold := by
+        some (firstOcc p g)⟩ : SpanRule n F).threshold := by
     intro jt hjv hjle
     obtain ⟨t, htfo, rfl⟩ := mem_ofPattern.mp hjv
     rw [threshold_ofPattern] at hjle ⊢
@@ -423,7 +423,7 @@ theorem realize_ofPattern {p : Paradigm n F} (hp : IsContiguous p) (g : Fin n) :
   obtain ⟨t, htfo, rfl⟩ := mem_ofPattern.mp hwv
   rw [threshold_ofPattern] at hwτ
   subst hwτ
-  show (winner (ofPattern p) g).map ExponenceRule.exponent = some (p g)
+  show (winner (ofPattern p) g).map SpanRule.exponent = some (p g)
   rw [hw, Option.map_some]
   exact congrArg some (apply_firstOcc p g)
 
@@ -432,7 +432,7 @@ end Completeness
 /-- A pattern is **Elsewhere-generable**: some terminal antihomophonous
 vocabulary realizes it in full. -/
 def ElsewhereGenerable (p : Paradigm n F) : Prop :=
-  ∃ v : List (ExponenceRule n F), Terminal v ∧ Antihomophonous v ∧
+  ∃ v : List (SpanRule n F), Terminal v ∧ Antihomophonous v ∧
     ∀ g, realize v g = some (p g)
 
 /-- **Generable = contiguous.** A fully realized pattern arises from
@@ -459,7 +459,7 @@ theorem isContiguous_iff_generable (p : Paradigm n F) :
 degree hierarchy, if the positive and comparative cells agree and the
 superlative cell is realized, all three agree — `good – gooder – *best` is not
 generable — given antihomophony and `Grounded` (the book's condition (202)). -/
-theorem realize_const_of_grounded {v : List (ExponenceRule 3 F)}
+theorem realize_const_of_grounded {v : List (SpanRule 3 F)}
     (hAH : Antihomophonous v) (hG : Grounded v)
     (h01 : realize v 0 = realize v 1) (h2 : (realize v 2).isSome) :
     realize v 1 = realize v 2 := by
@@ -500,7 +500,7 @@ degree-domain consequence generalized there as (199)): under
 adjacency, root allomorphy at the superlative grade distinct from the
 comparative grade arises only via a portmanteau — the winning rule
 must expone more than the bare root (Latin `opt-`, Welsh `gor-`). -/
-theorem exists_portmanteau_of_ne {v : List (ExponenceRule 3 F)} (hA : Adjacent v)
+theorem exists_portmanteau_of_ne {v : List (SpanRule 3 F)} (hA : Adjacent v)
     (h12 : realize v 1 ≠ realize v 2) :
     ∃ it ∈ v, winner v 2 = some it ∧ 0 < (it.spans : ℕ) := by
   obtain ⟨w2, hw2⟩ : ∃ w, winner v 2 = some w := by
@@ -527,26 +527,26 @@ directly: applicability is threshold containment (the upper set
 so the Elsewhere winner is an Elsewhere winner of the shared core over
 the native carrier. -/
 
-instance : Exponence.RuleLike (ExponenceRule n F) (Fin n) F :=
-  ⟨ExponenceRule.exponent, fun it => Set.Ici it.threshold⟩
+instance : Exponence.RuleLike (SpanRule n F) (Fin n) F :=
+  ⟨SpanRule.exponent, fun it => Set.Ici it.threshold⟩
 
-instance : Preorder (ExponenceRule n F) := Exponence.RuleLike.toPreorder
+instance : Preorder (SpanRule n F) := Exponence.RuleLike.toPreorder
 
 /-- Containment specificity is the shared core's specificity order. -/
-theorem ExponenceRule.le_iff {it jt : ExponenceRule n F} :
+theorem SpanRule.le_iff {it jt : SpanRule n F} :
     it ≤ jt ↔ it.MoreSpecific jt :=
   Iff.rfl
 
 /-- The containment engine's Elsewhere winner is an Elsewhere winner of
 the shared core. -/
-theorem winner_isElsewhereWinner {v : List (ExponenceRule n F)} {g : Fin n}
-    {it : ExponenceRule n F} (h : winner v g = some it) :
+theorem winner_isElsewhereWinner {v : List (SpanRule n F)} {g : Fin n}
+    {it : SpanRule n F} (h : winner v g = some it) :
     Exponence.IsElsewhereWinner v g it := by
   obtain ⟨hmem, hmt⟩ := winner_spec h
   obtain ⟨-, -, -, hle⟩ := exists_of_maxThreshold_eq_coe hmt
   refine ⟨⟨hmem, hle⟩, ?_⟩
   rintro s ⟨hs, hsapp⟩ -
-  rw [ExponenceRule.le_iff, ExponenceRule.moreSpecific_iff_threshold_le]
+  rw [SpanRule.le_iff, SpanRule.moreSpecific_iff_threshold_le]
   exact threshold_le_of_maxThreshold_eq_coe hmt hs hsapp
 
 end Morphology.Containment

--- a/Linglib/Morphology/Nanosyntax/Superset.lean
+++ b/Linglib/Morphology/Nanosyntax/Superset.lean
@@ -5,7 +5,7 @@ import Linglib.Morphology.Exponence.Hierarchy
 [starke-2009] [caha-2009] [bobaljik-2012]
 
 The static core of the nanosyntax selection rule (no cyclic override
-or spellout-driven movement), stated over the same `ExponenceRule`
+or spellout-driven movement), stated over the same `SpanRule`
 vocabularies as the Elsewhere engine of
 `Morphology/Exponence/Hierarchy.lean`. A nanosyntax lexical entry
 stores a constituent and carries no contextual restriction
@@ -35,7 +35,7 @@ degree case) — where DM needs the context-restricted portmanteau of
 
 ## Main declarations
 
-* `ExponenceRule.Matches` — the Superset Principle: entry contains the
+* `SpanRule.Matches` — the Superset Principle: entry contains the
   target structure
 * `ContextFree` — the nanosyntax restriction on vocabularies
 * `minSpan`, `spelloutWinner`, `spellout` — Minimize-Junk competition
@@ -59,70 +59,70 @@ variable {n : ℕ} {F : Type*}
 /-- The **Superset Principle** ([starke-2009]): an entry can spell out
 grade `g` when the constituent it stores contains grade `g`'s
 structure. Anti-monotone in `g`, dually to `AppliesAt`. -/
-def ExponenceRule.Matches (it : ExponenceRule n F) (g : Fin n) : Prop :=
+def SpanRule.Matches (it : SpanRule n F) (g : Fin n) : Prop :=
   g ≤ it.spans
 
-instance (it : ExponenceRule n F) (g : Fin n) : Decidable (it.Matches g) :=
+instance (it : SpanRule n F) (g : Fin n) : Decidable (it.Matches g) :=
   inferInstanceAs (Decidable (_ ≤ _))
 
-theorem ExponenceRule.Matches.anti {it : ExponenceRule n F} {g g' : Fin n}
+theorem SpanRule.Matches.anti {it : SpanRule n F} {g g' : Fin n}
     (h : it.Matches g') (hg : g ≤ g') : it.Matches g :=
   le_trans hg h
 
 /-- Minimize Junk derived, dually to
-`ExponenceRule.moreSpecific_iff_threshold_le`: an entry matches in a
+`SpanRule.moreSpecific_iff_threshold_le`: an entry matches in a
 subset of the structures another matches in iff it stores the smaller
 constituent — smallest-match selection is Pāṇinian specificity under
 superset matching. -/
-theorem ExponenceRule.matches_imp_iff_spans_le {it jt : ExponenceRule n F} :
+theorem SpanRule.matches_imp_iff_spans_le {it jt : SpanRule n F} :
     (∀ ⦃g : Fin n⦄, it.Matches g → jt.Matches g) ↔ it.spans ≤ jt.spans :=
   ⟨λ h => h (le_refl it.spans), λ h _ hg => le_trans hg h⟩
 
 /-- The nanosyntax restriction, in the pointer-free idealization of
 [caha-2009]: entries store bare constituents, with no DM-style
 contextual environment. -/
-def ContextFree (v : List (ExponenceRule n F)) : Prop :=
+def ContextFree (v : List (SpanRule n F)) : Prop :=
   ∀ it ∈ v, it.context = none
 
-instance (v : List (ExponenceRule n F)) : Decidable (ContextFree v) := by
+instance (v : List (SpanRule n F)) : Decidable (ContextFree v) := by
   unfold ContextFree; infer_instance
 
 /-! ### Minimize-Junk competition -/
 
 /-- The entries matching at grade `g`, in vocabulary order. -/
-def matching (v : List (ExponenceRule n F)) (g : Fin n) : List (ExponenceRule n F) :=
+def matching (v : List (SpanRule n F)) (g : Fin n) : List (SpanRule n F) :=
   v.filter (λ it => it.Matches g)
 
-@[simp] theorem mem_matching {v : List (ExponenceRule n F)} {g : Fin n}
-    {it : ExponenceRule n F} :
+@[simp] theorem mem_matching {v : List (SpanRule n F)} {g : Fin n}
+    {it : SpanRule n F} :
     it ∈ matching v g ↔ it ∈ v ∧ g ≤ it.spans := by
-  simp [matching, ExponenceRule.Matches]
+  simp [matching, SpanRule.Matches]
 
 /-- The least matching span at grade `g` — Minimize Junk: the winning
 entry stores as little unrealized structure as possible. `⊤` when no
 entry matches. -/
-def minSpan (v : List (ExponenceRule n F)) (g : Fin n) : WithTop (Fin n) :=
-  ((matching v g).map ExponenceRule.spans).minimum
+def minSpan (v : List (SpanRule n F)) (g : Fin n) : WithTop (Fin n) :=
+  ((matching v g).map SpanRule.spans).minimum
 
-theorem minSpan_eq_top_iff {v : List (ExponenceRule n F)} {g : Fin n} :
+theorem minSpan_eq_top_iff {v : List (SpanRule n F)} {g : Fin n} :
     minSpan v g = ⊤ ↔ matching v g = [] := by
   rw [minSpan, List.minimum_eq_top, List.map_eq_nil_iff]
 
-theorem exists_of_minSpan_eq_coe {v : List (ExponenceRule n F)} {g m : Fin n}
+theorem exists_of_minSpan_eq_coe {v : List (SpanRule n F)} {g m : Fin n}
     (h : minSpan v g = ↑m) : ∃ it ∈ v, it.spans = m ∧ g ≤ m := by
   obtain ⟨hmem, -⟩ := List.minimum_eq_coe_iff.mp h
   obtain ⟨it, hit, hsp⟩ := List.mem_map.mp hmem
   obtain ⟨hitv, hle⟩ := mem_matching.mp hit
   exact ⟨it, hitv, hsp, hsp ▸ hle⟩
 
-theorem le_spans_of_minSpan_eq_coe {v : List (ExponenceRule n F)} {g m : Fin n}
-    (h : minSpan v g = ↑m) {it : ExponenceRule n F} (hitv : it ∈ v)
+theorem le_spans_of_minSpan_eq_coe {v : List (SpanRule n F)} {g m : Fin n}
+    (h : minSpan v g = ↑m) {it : SpanRule n F} (hitv : it ∈ v)
     (hle : g ≤ it.spans) : m ≤ it.spans :=
   (List.minimum_eq_coe_iff.mp h).2 _
     (List.mem_map_of_mem (mem_matching.mpr ⟨hitv, hle⟩))
 
-theorem minSpan_eq_coe_intro {v : List (ExponenceRule n F)} {g : Fin n}
-    {it : ExponenceRule n F} (hitv : it ∈ v) (hle : g ≤ it.spans)
+theorem minSpan_eq_coe_intro {v : List (SpanRule n F)} {g : Fin n}
+    {it : SpanRule n F} (hitv : it ∈ v) (hle : g ≤ it.spans)
     (hlb : ∀ jt ∈ v, g ≤ jt.spans → it.spans ≤ jt.spans) :
     minSpan v g = ↑it.spans := by
   rw [minSpan, List.minimum_eq_coe_iff]
@@ -133,14 +133,14 @@ theorem minSpan_eq_coe_intro {v : List (ExponenceRule n F)} {g : Fin n}
 
 /-- The key transfer lemma, dual to `maxThreshold_eq_coe_of_between`: a
 winning span persists upward as long as the grade stays inside it. -/
-theorem minSpan_eq_coe_of_between {v : List (ExponenceRule n F)} {g g' m : Fin n}
+theorem minSpan_eq_coe_of_between {v : List (SpanRule n F)} {g g' m : Fin n}
     (h : minSpan v g = ↑m) (hg : g ≤ g') (hm : g' ≤ m) : minSpan v g' = ↑m := by
   obtain ⟨it, hitv, hsp, -⟩ := exists_of_minSpan_eq_coe h
   subst hsp
   exact minSpan_eq_coe_intro hitv hm
     (λ jt hjv hjle => le_spans_of_minSpan_eq_coe h hjv (le_trans hg hjle))
 
-theorem minSpan_eq_top_of_le {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem minSpan_eq_top_of_le {v : List (SpanRule n F)} {g g' : Fin n}
     (h : minSpan v g = ⊤) (hg : g ≤ g') : minSpan v g' = ⊤ := by
   rw [minSpan_eq_top_iff] at h ⊢
   rw [List.eq_nil_iff_forall_not_mem] at h ⊢
@@ -150,21 +150,21 @@ theorem minSpan_eq_top_of_le {v : List (ExponenceRule n F)} {g g' : Fin n}
 
 /-- The spellout winner at grade `g`: the first entry attaining the
 least matching span. -/
-def spelloutWinner (v : List (ExponenceRule n F)) (g : Fin n) :
-    Option (ExponenceRule n F) :=
+def spelloutWinner (v : List (SpanRule n F)) (g : Fin n) :
+    Option (SpanRule n F) :=
   (minSpan v g).recTopCoe none (λ m => v.find? (λ it => it.spans == m))
 
-theorem spelloutWinner_eq_none_of_top {v : List (ExponenceRule n F)} {g : Fin n}
+theorem spelloutWinner_eq_none_of_top {v : List (SpanRule n F)} {g : Fin n}
     (h : minSpan v g = ⊤) : spelloutWinner v g = none := by
   rw [spelloutWinner, h]; rfl
 
-theorem spelloutWinner_of_coe {v : List (ExponenceRule n F)} {g m : Fin n}
+theorem spelloutWinner_of_coe {v : List (SpanRule n F)} {g m : Fin n}
     (h : minSpan v g = ↑m) :
     spelloutWinner v g = v.find? (λ it => it.spans == m) := by
   rw [spelloutWinner, h]; rfl
 
-theorem spelloutWinner_spec {v : List (ExponenceRule n F)} {g : Fin n}
-    {it : ExponenceRule n F} (h : spelloutWinner v g = some it) :
+theorem spelloutWinner_spec {v : List (SpanRule n F)} {g : Fin n}
+    {it : SpanRule n F} (h : spelloutWinner v g = some it) :
     it ∈ v ∧ minSpan v g = ↑it.spans := by
   cases hms : minSpan v g with
   | top => rw [spelloutWinner_eq_none_of_top hms] at h; exact absurd h (by simp)
@@ -173,7 +173,7 @@ theorem spelloutWinner_spec {v : List (ExponenceRule n F)} {g : Fin n}
     have hsp : it.spans = m := by simpa using List.find?_some h
     exact ⟨List.mem_of_find?_eq_some h, by rw [hsp]⟩
 
-theorem exists_spelloutWinner_of_coe {v : List (ExponenceRule n F)} {g m : Fin n}
+theorem exists_spelloutWinner_of_coe {v : List (SpanRule n F)} {g m : Fin n}
     (h : minSpan v g = ↑m) : ∃ it, spelloutWinner v g = some it := by
   rw [spelloutWinner_of_coe h]
   obtain ⟨it, hitv, hsp, -⟩ := exists_of_minSpan_eq_coe h
@@ -183,7 +183,7 @@ theorem exists_spelloutWinner_of_coe {v : List (ExponenceRule n F)} {g m : Fin n
     rw [List.find?_eq_none] at hf
     exact absurd (by simp [hsp] : (it.spans == m) = true) (by simpa using hf it hitv)
 
-theorem spelloutWinner_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
+theorem spelloutWinner_eq_none_iff {v : List (SpanRule n F)} {g : Fin n} :
     spelloutWinner v g = none ↔ minSpan v g = ⊤ := by
   refine ⟨λ h => ?_, spelloutWinner_eq_none_of_top⟩
   cases hms : minSpan v g with
@@ -193,7 +193,7 @@ theorem spelloutWinner_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
     rw [hit] at h
     exact absurd h (by simp)
 
-theorem spelloutWinner_congr {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem spelloutWinner_congr {v : List (SpanRule n F)} {g g' : Fin n}
     (h : minSpan v g = minSpan v g') : spelloutWinner v g = spelloutWinner v g' := by
   rw [spelloutWinner, spelloutWinner, h]
 
@@ -201,15 +201,15 @@ theorem spelloutWinner_congr {v : List (ExponenceRule n F)} {g g' : Fin n}
 exponent (`none` when no entry contains the structure — a spellout
 gap; full nanosyntax would attempt rescue operations before declaring
 ineffability). -/
-def spellout (v : List (ExponenceRule n F)) : Paradigm n (Option F) :=
-  λ g => (spelloutWinner v g).map ExponenceRule.exponent
+def spellout (v : List (SpanRule n F)) : Paradigm n (Option F) :=
+  λ g => (spelloutWinner v g).map SpanRule.exponent
 
-theorem spellout_congr {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem spellout_congr {v : List (SpanRule n F)} {g g' : Fin n}
     (h : minSpan v g = minSpan v g') : spellout v g = spellout v g' := by
   show (spelloutWinner v g).map _ = (spelloutWinner v g').map _
   rw [spelloutWinner_congr h]
 
-theorem spellout_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
+theorem spellout_eq_none_iff {v : List (SpanRule n F)} {g : Fin n} :
     spellout v g = none ↔ minSpan v g = ⊤ := by
   rw [← spelloutWinner_eq_none_iff]
   unfold spellout
@@ -218,7 +218,7 @@ theorem spellout_eq_none_iff {v : List (ExponenceRule n F)} {g : Fin n} :
 /-- Spellout gaps propagate upward: an entry matching a higher grade
 would match the lower one too, so a gap at `g` forces gaps at every
 `g' ≥ g` — [dekier-2021]'s paradigm-gap monotonicity for indefinites. -/
-theorem spellout_eq_none_of_le {v : List (ExponenceRule n F)} {g g' : Fin n}
+theorem spellout_eq_none_of_le {v : List (SpanRule n F)} {g g' : Fin n}
     (h : spellout v g = none) (hg : g ≤ g') : spellout v g' = none :=
   spellout_eq_none_iff.mpr
     (minSpan_eq_top_of_le (spellout_eq_none_iff.mp h) hg)
@@ -232,7 +232,7 @@ the winner's exponent injective — so spellout fibers are convex. This
 is the nanosyntax derivation of *ABA ([caha-2009]), run on the same
 vocabulary type as the DM derivation. -/
 
-theorem isContiguous_spellout {v : List (ExponenceRule n F)}
+theorem isContiguous_spellout {v : List (SpanRule n F)}
     (hAH : Antihomophonous v) : IsContiguous (spellout v) := by
   intro i j k hij hjk heq
   cases hwi : spelloutWinner v i with
@@ -287,11 +287,11 @@ theorem lastOcc_congr {p : Paradigm n F} {g g' : Fin n} (h : p g = p g') :
 
 /-- The canonical nanosyntax lexicon of a pattern: one context-free
 entry per form, storing the form's largest constituent. -/
-def spelloutOfPattern (p : Paradigm n F) : List (ExponenceRule n F) :=
+def spelloutOfPattern (p : Paradigm n F) : List (SpanRule n F) :=
   (List.finRange n).filterMap (λ s =>
     if lastOcc p s = s then some ⟨p s, s, none⟩ else none)
 
-theorem mem_spelloutOfPattern {p : Paradigm n F} {it : ExponenceRule n F} :
+theorem mem_spelloutOfPattern {p : Paradigm n F} {it : SpanRule n F} :
     it ∈ spelloutOfPattern p ↔
       ∃ s : Fin n, lastOcc p s = s ∧ it = ⟨p s, s, none⟩ := by
   simp only [spelloutOfPattern, List.mem_filterMap, List.mem_finRange, true_and]
@@ -323,11 +323,11 @@ theorem spellout_spelloutOfPattern {p : Paradigm n F} (hp : IsContiguous p)
     (g : Fin n) : spellout (spelloutOfPattern p) g = some (p g) := by
   have hll : lastOcc p (lastOcc p g) = lastOcc p g :=
     lastOcc_congr (apply_lastOcc p g)
-  have hitem : (⟨p (lastOcc p g), lastOcc p g, none⟩ : ExponenceRule n F)
+  have hitem : (⟨p (lastOcc p g), lastOcc p g, none⟩ : SpanRule n F)
       ∈ spelloutOfPattern p :=
     mem_spelloutOfPattern.mpr ⟨lastOcc p g, hll, rfl⟩
   have hlb : ∀ jt ∈ spelloutOfPattern p, g ≤ jt.spans →
-      (⟨p (lastOcc p g), lastOcc p g, none⟩ : ExponenceRule n F).spans ≤ jt.spans := by
+      (⟨p (lastOcc p g), lastOcc p g, none⟩ : SpanRule n F).spans ≤ jt.spans := by
     intro jt hjv hjle
     obtain ⟨t, htlo, rfl⟩ := mem_spelloutOfPattern.mp hjv
     show lastOcc p g ≤ t
@@ -346,7 +346,7 @@ theorem spellout_spelloutOfPattern {p : Paradigm n F} (hp : IsContiguous p)
   obtain ⟨t, htlo, rfl⟩ := mem_spelloutOfPattern.mp hwv
   have : t = lastOcc p g := hwsp
   subst this
-  show (spelloutWinner (spelloutOfPattern p) g).map ExponenceRule.exponent
+  show (spelloutWinner (spelloutOfPattern p) g).map SpanRule.exponent
       = some (p g)
   rw [hw, Option.map_some]
   exact congrArg some (apply_lastOcc p g)
@@ -356,7 +356,7 @@ end Completeness
 /-- A pattern is **Superset-spellable**: some context-free
 antihomophonous lexicon spells it out in full. -/
 def SupersetSpellable (p : Paradigm n F) : Prop :=
-  ∃ v : List (ExponenceRule n F), ContextFree v ∧ Antihomophonous v ∧
+  ∃ v : List (SpanRule n F), ContextFree v ∧ Antihomophonous v ∧
     ∀ g, spellout v g = some (p g)
 
 /-- **Spellable = contiguous**: a fully realized pattern arises from
@@ -399,10 +399,10 @@ gap under Elsewhere insertion. This is nanosyntax's characteristic
 prediction — overspecified entries double as defaults for smaller
 structures — against DM's characteristic gaps. -/
 
-example : spellout [(⟨"gwell", 1, none⟩ : ExponenceRule 3 String)] 0
+example : spellout [(⟨"gwell", 1, none⟩ : SpanRule 3 String)] 0
     = some "gwell" := by decide
 
-example : realize [(⟨"gwell", 1, none⟩ : ExponenceRule 3 String)] 0
+example : realize [(⟨"gwell", 1, none⟩ : SpanRule 3 String)] 0
     = none := by decide
 
 /-! ### Antihomophony is necessary for *ABA
@@ -415,7 +415,7 @@ syncretism (one item over a contiguous span); the `Antihomophonous`
 hypothesis of `isContiguous_spellout` is exactly that distinction. -/
 
 /-- Accidental homophony: "A" stored at two non-adjacent grades. -/
-private def homophonous : List (ExponenceRule 3 String) :=
+private def homophonous : List (SpanRule 3 String) :=
   [⟨"A", 0, none⟩, ⟨"B", 1, none⟩, ⟨"A", 2, none⟩]
 
 example : ¬ Antihomophonous homophonous := by decide
@@ -428,7 +428,7 @@ example :
 /-! ### The shared exponence core
 
 One carrier, two `RuleLike` views: the Subset reading on
-`ExponenceRule` (`Morphology/Exponence/Hierarchy.lean`) and the Superset
+`SpanRule` (`Morphology/Exponence/Hierarchy.lean`) and the Superset
 reading on the `SupersetRule` synonym below install the shared core with
 dual applicability conditions and opposite derived-specificity orders, à
 la `OrderDual`. -/
@@ -439,23 +439,23 @@ open Morphology.Exponence
 
 /-- The **Superset** reading of an exponence rule: an entry spells out
 grade `g` when its stored constituent contains `g` (the down-set
-`Set.Iic spans`), dually to the Subset reading of `ExponenceRule`. A
+`Set.Iic spans`), dually to the Subset reading of `SpanRule`. A
 distinct type synonym so the two readings can carry different `RuleLike`
 instances on one carrier, mirroring `OrderDual`. -/
-def SupersetRule (n : ℕ) (F : Type*) := ExponenceRule n F
+def SupersetRule (n : ℕ) (F : Type*) := SpanRule n F
 
 instance : RuleLike (SupersetRule n F) (Fin n) F :=
-  ⟨ExponenceRule.exponent, fun it => Set.Iic (ExponenceRule.spans it)⟩
+  ⟨SpanRule.exponent, fun it => Set.Iic (SpanRule.spans it)⟩
 
 instance : Preorder (SupersetRule n F) := RuleLike.toPreorder
 
 /-- Read an exponence rule under the Superset reading. -/
-def ExponenceRule.superset (it : ExponenceRule n F) : SupersetRule n F := it
+def SpanRule.superset (it : SpanRule n F) : SupersetRule n F := it
 
 /-- Minimize Junk is the Superset reading's specificity order: smaller
 span = more specific. -/
 theorem SupersetRule.le_iff {it jt : SupersetRule n F} :
-    it ≤ jt ↔ ExponenceRule.spans it ≤ ExponenceRule.spans jt :=
+    it ≤ jt ↔ SpanRule.spans it ≤ SpanRule.spans jt :=
   Set.Iic_subset_Iic
 
 /-- **Subset/Superset duality** over context-free vocabularies (the
@@ -463,12 +463,12 @@ nanosyntax idealization): DM-style Subset specificity of `it` over `jt`
 is Superset specificity of `jt` over `it`. With contextual restrictions
 the Subset order compares thresholds, not spans, and the duality is
 only one-directional. -/
-theorem ExponenceRule.subset_le_iff_superset_le {it jt : ExponenceRule n F}
+theorem SpanRule.subset_le_iff_superset_le {it jt : SpanRule n F}
     (hit : it.context = none) (hjt : jt.context = none) :
     it ≤ jt ↔ jt.superset ≤ it.superset := by
-  rw [ExponenceRule.le_iff, ExponenceRule.moreSpecific_iff_threshold_le,
+  rw [SpanRule.le_iff, SpanRule.moreSpecific_iff_threshold_le,
     SupersetRule.le_iff]
-  unfold ExponenceRule.threshold ExponenceRule.superset
+  unfold SpanRule.threshold SpanRule.superset
   rw [hit, hjt]
   simp
 
@@ -476,10 +476,10 @@ theorem ExponenceRule.subset_le_iff_superset_le {it jt : ExponenceRule n F}
 under the Superset reading — with no side conditions: over a linear
 hierarchy the span order is total, so the least-span match is maximally
 specific. -/
-theorem spelloutWinner_isElsewhereWinner {v : List (ExponenceRule n F)}
-    {g : Fin n} {it : ExponenceRule n F}
+theorem spelloutWinner_isElsewhereWinner {v : List (SpanRule n F)}
+    {g : Fin n} {it : SpanRule n F}
     (h : spelloutWinner v g = some it) :
-    Exponence.IsElsewhereWinner (v.map ExponenceRule.superset) g it.superset := by
+    Exponence.IsElsewhereWinner (v.map SpanRule.superset) g it.superset := by
   obtain ⟨hmem, hms⟩ := spelloutWinner_spec h
   obtain ⟨-, -, -, hle⟩ := exists_of_minSpan_eq_coe hms
   refine ⟨⟨List.mem_map_of_mem hmem, hle⟩, ?_⟩

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -121,7 +121,7 @@ where
     relation ([taraldsen-et-al-2018] (35)).
 
     For 1D chains: a chain of depth n contains all chains of depth
-    k ≤ n, matching `ExponenceRule.Matches` (`chain_contains_iff_le`). -/
+    k ≤ n, matching `SpanRule.Matches` (`chain_contains_iff_le`). -/
 inductive Contains : NanoTree F → NanoTree F → Prop
   | refl (t : NanoTree F) : Contains t t
   | child {f : F} {cs : List (NanoTree F)} {c target : NanoTree F} :
@@ -242,7 +242,7 @@ end NanoTree
     fragments). The tree encodes the full feature geometry that the
     morpheme lexicalizes.
 
-    Contrast with `ExponenceRule` (`Morphology/Exponence/Hierarchy.lean`)
+    Contrast with `SpanRule` (`Morphology/Exponence/Hierarchy.lean`)
     which stores only a span (depth on a 1D functional sequence). -/
 structure TreeLexEntry (F : Type*) (α : Type*) where
   /-- The stored feature tree. -/
@@ -365,7 +365,7 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (tree : NanoTree F) :
     `chainTree feat 1 = node (feat 1) [leaf (feat 0)]`
     `chainTree feat n = node (feat n) [chainTree feat (n-1)]`
 
-    A chain of depth n is isomorphic to an `ExponenceRule` spanning
+    A chain of depth n is isomorphic to an `SpanRule` spanning
     grade n in the 1D nanosyntax. -/
 def chainTree (feat : Nat → F) : Nat → NanoTree F
   | 0 => .leaf (feat 0)
@@ -403,7 +403,7 @@ theorem chainTree_injective (feat : Nat → F) :
 /-- For right-branching chains, tree containment reduces to rank
     comparison: a chain of depth re contains a chain of depth r iff
     r ≤ re. This is exactly the matching condition of the rank-based
-    `ExponenceRule.Matches`, establishing that tree-based spellout
+    `SpanRule.Matches`, establishing that tree-based spellout
     generalizes (not replaces) rank-based spellout.
 
     Unlike the previous Bool formulation, no injectivity of `feat` is

--- a/Linglib/Studies/Bobaljik2012.lean
+++ b/Linglib/Studies/Bobaljik2012.lean
@@ -265,7 +265,7 @@ theorem latin_all_three_patterns :
 /-! ### The Realizational Derivation: the Book's Worked Vocabularies -/
 
 /-! The engine of `Morphology/Exponence/Hierarchy.lean` run on the
-vocabularies [bobaljik-2012] actually writes down. `ExponenceRule`s record
+vocabularies [bobaljik-2012] actually writes down. `SpanRule`s record
 exponent, exponed span, and conditioning context; `realize` runs
 Elsewhere insertion; `degreeShape` reads the root-suppletion class off
 the realized cells. The hypotheses of the engine's theorems
@@ -279,7 +279,7 @@ open Morphology.Containment Morphology.DM
 
 /-- Czech BAD ([bobaljik-2012] (39)): root allomorph `hor-` conditioned
     by CMPR, elsewhere `špatn-`. -/
-def czechBad : List (ExponenceRule 3 String) :=
+def czechBad : List (SpanRule 3 String) :=
   [⟨"špatn", 0, none⟩, ⟨"hor", 0, some 1⟩]
 
 /-- Elsewhere insertion realizes *špatn-ý, hor-ší, nej-hor-ší*: ABB. -/
@@ -290,7 +290,7 @@ theorem czech_bad_abb : degreeShape (realize czechBad) = abb := by decide
 
 /-- English GOOD ([bobaljik-2012] (203)): `bett- / __]CMPR]`, elsewhere
     `good`. Terminal and adjacent, so the plateau applies. -/
-def englishGood : List (ExponenceRule 3 String) :=
+def englishGood : List (SpanRule 3 String) :=
   [⟨"good", 0, none⟩, ⟨"bett", 0, some 1⟩]
 
 theorem english_good_abb : degreeShape (realize englishGood) = abb := by decide
@@ -298,14 +298,14 @@ theorem english_good_abb : degreeShape (realize englishGood) = abb := by decide
 /-- English BAD ([bobaljik-2012] (194)): `worse` as a √ROOT+CMPR
     portmanteau, elsewhere `bad`. ABB arises on the portmanteau route
     too — `worse` simply realizes the whole comparative node. -/
-def englishBad : List (ExponenceRule 3 String) :=
+def englishBad : List (SpanRule 3 String) :=
   [⟨"bad", 0, none⟩, ⟨"worse", 1, none⟩]
 
 theorem english_bad_abb : degreeShape (realize englishBad) = abb := by decide
 
 /-- Welsh GOOD ([bobaljik-2012] (198)): `gor- / __]SPRL]` and `gwell`,
     both √ROOT+CMPR portmanteaux, elsewhere `da`. -/
-def welshGood : List (ExponenceRule 3 String) :=
+def welshGood : List (SpanRule 3 String) :=
   [⟨"da", 0, none⟩, ⟨"gwell", 1, none⟩, ⟨"gor", 1, some 2⟩]
 
 /-- *da, gwell, gor-au*: ABC, generable because the C-exponent is a
@@ -317,7 +317,7 @@ theorem welsh_good_abc : degreeShape (realize welshGood) = abc := by decide
     elsewhere `bon`. The span structure also explains *\*opt-ior-imus*:
     `opt-` swallows the CMPR cell, so regular `-ior` has nothing to
     realize. -/
-def latinBonus : List (ExponenceRule 3 String) :=
+def latinBonus : List (SpanRule 3 String) :=
   [⟨"bon", 0, none⟩, ⟨"mel", 0, some 1⟩, ⟨"opt", 1, some 2⟩]
 
 /-- *bon-us, mel-ior, opt-imus*: the engine derives the book's star
@@ -356,7 +356,7 @@ theorem latin_sprl_needs_portmanteau :
     `Morphology/Nanosyntax/Superset.lean`): context-free entries
     storing successively larger constituents, competing under the
     Superset Principle. -/
-def latinBonusNS : List (ExponenceRule 3 String) :=
+def latinBonusNS : List (SpanRule 3 String) :=
   [⟨"bon", 0, none⟩, ⟨"mel", 1, none⟩, ⟨"opt", 2, none⟩]
 
 theorem latin_ns_contextFree : ContextFree latinBonusNS := by decide
@@ -378,7 +378,7 @@ theorem latin_ns_eq_dm : spellout latinBonusNS = realize latinBonus :=
     restricted to the superlative with no comparative-level
     counterpart. It generates the unattested AAB shape
     (*\*da – da-ch – gor-au*)... -/
-def welshAAB : List (ExponenceRule 3 String) :=
+def welshAAB : List (SpanRule 3 String) :=
   [⟨"da", 0, none⟩, ⟨"gor", 1, some 2⟩]
 
 theorem welshAAB_realizes_aab : degreeShape (realize welshAAB) = aab := by decide
@@ -397,7 +397,7 @@ theorem welshAAB_blocked : ¬ (Antihomophonous welshAAB ∧ Grounded welshAAB) :
 /-- The homophonous-ABC loophole ([bobaljik-2012] (44) discussion):
     without Antihomophony, surface ABA is generable — a superlative
     root allomorph accidentally homophonous with the positive. -/
-def fakeAba : List (ExponenceRule 3 String) :=
+def fakeAba : List (SpanRule 3 String) :=
   [⟨"A", 0, none⟩, ⟨"B", 0, some 1⟩, ⟨"A", 0, some 2⟩]
 
 theorem fakeAba_realizes_aba : degreeShape (realize fakeAba) = aba := by decide

--- a/Linglib/Studies/Bubnov2026.lean
+++ b/Linglib/Studies/Bubnov2026.lean
@@ -212,10 +212,10 @@ theorem diachronic_weakening_grounded
 /-- Nanosyntax + Dekier: losing entry A (rank 0, NS-only) makes entry B
     (rank 1, SU) cover NS too via Superset Principle.
     Predicts SU → epistemic (AB → BB), but NOT NS → epistemic. -/
-def dekierInitial : List (ExponenceRule 3 String) :=
+def dekierInitial : List (SpanRule 3 String) :=
   [⟨"A", 0, none⟩, ⟨"B", 1, none⟩]
 
-def dekierAfterLoss : List (ExponenceRule 3 String) :=
+def dekierAfterLoss : List (SpanRule 3 String) :=
   [⟨"B", 1, none⟩]
 
 theorem dekier_initial_ab :

--- a/Linglib/Studies/Dekier2021.lean
+++ b/Linglib/Studies/Dekier2021.lean
@@ -83,7 +83,7 @@ open Kannada.Indefinites
     Features are ordered on a universal fseq. Each layer is characterized
     by its rank (depth). A lexical entry at rank r stores F₁...Fᵣ and
     matches any target of rank ≤ r via the Superset Principle —
-    `ExponenceRule.Matches` over the three-grade hierarchy `Fin 3`. -/
+    `SpanRule.Matches` over the three-grade hierarchy `Fin 3`. -/
 
 /-- Fseq grades for indefinite features. -/
 def nsRank : Fin 3 := 0   -- F₁P: non-specific
@@ -161,12 +161,12 @@ def gapParadigms : List ParadigmEntry :=
 /-! Each syncretism pattern corresponds to a particular lexicon
     configuration. The spellout algorithm (Superset + Minimize Junk,
     `Morphology.Containment.spellout`) derives the surface pattern from
-    the lexicon. Entries are context-free `ExponenceRule`s: an exponent
+    the lexicon. Entries are context-free `SpanRule`s: an exponent
     paired with the largest grade its stored constituent spans. -/
 
 /-- English AAA: a single entry at rank 2 covers all three layers.
     *some-* ⇔ F₃P. -/
-def englishLex : List (ExponenceRule 3 String) := [⟨"some-", 2, none⟩]
+def englishLex : List (SpanRule 3 String) := [⟨"some-", 2, none⟩]
 
 theorem english_spellout :
     spellout englishLex nsRank = some "some-" ∧
@@ -175,7 +175,7 @@ theorem english_spellout :
 
 /-- Yakut ABB: *-emeEntry* at rank 0 (F₁P), *-ereEntry* at rank 2 (F₃P).
     Elsewhere gives *-emeEntry* for NS, *-ereEntry* covers SU and SK. -/
-def yakutLex : List (ExponenceRule 3 String) := [⟨"-eme", 0, none⟩, ⟨"-ere", 2, none⟩]
+def yakutLex : List (SpanRule 3 String) := [⟨"-eme", 0, none⟩, ⟨"-ere", 2, none⟩]
 
 theorem yakut_spellout :
     spellout yakutLex nsRank = some "-eme" ∧
@@ -189,7 +189,7 @@ theorem yakut_spellout :
     Note: the nanosyntactic derivation is complex — *aliEntry-* is
     a prefix (subderivation), *-damEntry* is a suffix (constituent
     extraction). -/
-def latinLex : List (ExponenceRule 3 String) := [⟨"ali-", 1, none⟩, ⟨"-dam", 2, none⟩]
+def latinLex : List (SpanRule 3 String) := [⟨"ali-", 1, none⟩, ⟨"-dam", 2, none⟩]
 
 theorem latin_spellout :
     spellout latinLex nsRank = some "ali-" ∧
@@ -200,7 +200,7 @@ theorem latin_spellout :
     own exponent.
     *-nibudEntry'* ⇔ F₁P (suffix), *-to* ⇔ F₂P (suffix),
     *koeEntry-* ⇔ F₃P (prefix). -/
-def russianLex : List (ExponenceRule 3 String) :=
+def russianLex : List (SpanRule 3 String) :=
   [⟨"-nibud'", 0, none⟩, ⟨"-to", 1, none⟩, ⟨"koe-", 2, none⟩]
 
 theorem russian_spellout :
@@ -210,7 +210,7 @@ theorem russian_spellout :
 
 /-- Lithuanian ABC: three entries at ranks 0, 1, 2.
     [dekier-2021] Table 7. -/
-def lithuanianLex : List (ExponenceRule 3 String) :=
+def lithuanianLex : List (SpanRule 3 String) :=
   [⟨"-nors", 0, none⟩, ⟨"kaž-", 1, none⟩, ⟨"kai-", 2, none⟩]
 
 theorem lithuanian_spellout :
@@ -302,7 +302,7 @@ theorem aba_unattested_pattern :
     ABSENCE of high-rank entries. -/
 
 -- Kannada (AB-): entries at ranks 0 and 1, no rank-2 entry
-def kannadaLex : List (ExponenceRule 3 String) :=
+def kannadaLex : List (SpanRule 3 String) :=
   [⟨"-aadaruu", 0, none⟩, ⟨"-oo", 1, none⟩]
 
 theorem kannada_gap :
@@ -311,7 +311,7 @@ theorem kannada_gap :
     spellout kannadaLex skRank = none := by decide
 
 -- Chinese (A--): single entry at rank 0
-def chineseLex : List (ExponenceRule 3 String) := [⟨"wh-pron", 0, none⟩]
+def chineseLex : List (SpanRule 3 String) := [⟨"wh-pron", 0, none⟩]
 
 theorem chinese_gap :
     spellout chineseLex nsRank = some "wh-pron" ∧
@@ -319,7 +319,7 @@ theorem chinese_gap :
     spellout chineseLex skRank = none := by decide
 
 -- Empty lexicon (---): Swahili, Irish, Filipino
-def emptyLex : List (ExponenceRule 3 String) := []
+def emptyLex : List (SpanRule 3 String) := []
 
 theorem empty_gap :
     spellout emptyLex nsRank = none ∧
@@ -327,14 +327,14 @@ theorem empty_gap :
     spellout emptyLex skRank = none := by decide
 
 /-- Consequence: if NS (rank 0) has no form, nothing does. -/
-theorem no_ns_implies_no_su_sk (lex : List (ExponenceRule 3 String))
+theorem no_ns_implies_no_su_sk (lex : List (SpanRule 3 String))
     (h : spellout lex nsRank = none) :
     spellout lex suRank = none ∧ spellout lex skRank = none :=
   ⟨spellout_eq_none_of_le h (by decide),
    spellout_eq_none_of_le h (by decide)⟩
 
 /-- Consequence: if SU (rank 1) has no form, SK doesn't either. -/
-theorem no_su_implies_no_sk (lex : List (ExponenceRule 3 String))
+theorem no_su_implies_no_sk (lex : List (SpanRule 3 String))
     (h : spellout lex suRank = none) :
     spellout lex skRank = none :=
   spellout_eq_none_of_le h (by decide)

--- a/Linglib/Studies/Graf2019.lean
+++ b/Linglib/Studies/Graf2019.lean
@@ -154,7 +154,7 @@ theorem aab_feasiblyMonotone : FeasiblyMonotone aab.toParadigm := by
 /-- Under antihomophony plus the markedness condition (202), no
 vocabulary realizes an AAB pattern — the gradation-side exclusion,
 carried by the realization engine rather than by monotonicity. -/
-theorem aab_not_groundedly_realizable {v : List (ExponenceRule 3 ℕ)}
+theorem aab_not_groundedly_realizable {v : List (SpanRule 3 ℕ)}
     {a b : ℕ} (hAH : Antihomophonous v) (hG : Grounded v) (hab : a ≠ b) :
     realize v ≠ ![some a, some a, some b] := by
   intro h

--- a/Linglib/Studies/KalinBjorkmanEtAl2026.lean
+++ b/Linglib/Studies/KalinBjorkmanEtAl2026.lean
@@ -736,14 +736,14 @@ open _root_.Morphology Morphology.Containment in
     middle grade, and its pattern is contiguous by
     `isContiguous_spellout`. -/
 theorem starABA_verified :
-    spellout [(⟨"A", 0, none⟩ : ExponenceRule 3 String), ⟨"B", 2, none⟩] 0
+    spellout [(⟨"A", 0, none⟩ : SpanRule 3 String), ⟨"B", 2, none⟩] 0
       = some "A" ∧
-    spellout [(⟨"A", 0, none⟩ : ExponenceRule 3 String), ⟨"B", 2, none⟩] 1
+    spellout [(⟨"A", 0, none⟩ : SpanRule 3 String), ⟨"B", 2, none⟩] 1
       = some "B" ∧
-    spellout [(⟨"A", 0, none⟩ : ExponenceRule 3 String), ⟨"B", 2, none⟩] 2
+    spellout [(⟨"A", 0, none⟩ : SpanRule 3 String), ⟨"B", 2, none⟩] 2
       = some "B" ∧
     IsContiguous (spellout
-      [(⟨"A", 0, none⟩ : ExponenceRule 3 String), ⟨"B", 2, none⟩]) :=
+      [(⟨"A", 0, none⟩ : SpanRule 3 String), ⟨"B", 2, none⟩]) :=
   ⟨by decide, by decide, by decide, isContiguous_spellout (by decide)⟩
 
 /-! ### 4b. PFM's Paradigm Function architecture

--- a/Linglib/Studies/SmithMoskalEtAl2019.lean
+++ b/Linglib/Studies/SmithMoskalEtAl2019.lean
@@ -94,14 +94,14 @@ axioms are à la carte Props rather than baked into the rule type. -/
 /-- Elsewhere insertion under [bobaljik-2012]'s structural adjacency
     (terminal items, adjacent contexts) cannot generate a pattern whose
     CMPR cell differs from its SPRL cell. -/
-theorem dm_excludes_cmpr_sprl_distinct {v : List (ExponenceRule 3 ℕ)}
+theorem dm_excludes_cmpr_sprl_distinct {v : List (SpanRule 3 ℕ)}
     (hT : Terminal v) (hAdj : Adjacent v) :
     realize v 1 = realize v 2 :=
   realize_const_of_terminal_adjacent hT hAdj
 
 /-- Specific corollary: the AAB shape (POS = CMPR ≠ SPRL) cannot be
     generated under structural adjacency. -/
-theorem dm_excludes_aab {v : List (ExponenceRule 3 ℕ)}
+theorem dm_excludes_aab {v : List (SpanRule 3 ℕ)}
     (hT : Terminal v) (hAdj : Adjacent v) {a b : ℕ} (hab : a ≠ b) :
     realize v ≠ ![some a, some a, some b] := by
   intro h
@@ -198,7 +198,7 @@ theorem case_aab_attested_falsifies_dm :
     realization. Since Wardaman attests it, structural adjacency is the
     hypothesis that must go — the paper's §3.7 conclusion. -/
 theorem wardaman_not_generable_under_adjacency :
-    ∀ v : List (ExponenceRule 3 ℕ), Terminal v → Adjacent v →
+    ∀ v : List (SpanRule 3 ℕ), Terminal v → Adjacent v →
       realize v ≠ ![some 0, some 0, some 1] :=
   λ _ hT hA => dm_excludes_aab hT hA (by decide)
 
@@ -266,7 +266,7 @@ theorem number_aab_attested_falsifies_dm :
 /-- Number-side analog: the Yagua-shaped AAB realization is not
     generable under structural adjacency either. -/
 theorem yagua_not_generable_under_adjacency :
-    ∀ v : List (ExponenceRule 3 ℕ), Terminal v → Adjacent v →
+    ∀ v : List (SpanRule 3 ℕ), Terminal v → Adjacent v →
       realize v ≠ ![some 0, some 0, some 1] :=
   λ _ hT hA => dm_excludes_aab hT hA (by decide)
 
@@ -314,21 +314,21 @@ menu. The paper's degree/pronoun split, as theorems:
     restricted, since the AD governs what may *condition* insertion,
     not what is inserted. -/
 def DomainLocal {n : ℕ} {F : Type*} (d : Fin n)
-    (v : List (ExponenceRule n F)) : Prop :=
+    (v : List (SpanRule n F)) : Prop :=
   ∀ it ∈ v, ∀ c : Fin n, it.context = some c → c ≤ d
 
-instance {n : ℕ} {F : Type*} (d : Fin n) (v : List (ExponenceRule n F)) :
+instance {n : ℕ} {F : Type*} (d : Fin n) (v : List (SpanRule n F)) :
     Decidable (DomainLocal d v) := by
   unfold DomainLocal; infer_instance
 
 /-- Under AD locality, terminal rules have thresholds inside the
     domain. -/
 theorem threshold_le_of_terminal_domainLocal {n : ℕ} {F : Type*}
-    {d : Fin n} {v : List (ExponenceRule n F)}
+    {d : Fin n} {v : List (SpanRule n F)}
     (hT : Terminal v) (hD : DomainLocal d v)
-    {it : ExponenceRule n F} (hit : it ∈ v) : it.threshold ≤ d := by
+    {it : SpanRule n F} (hit : it ∈ v) : it.threshold ≤ d := by
   have h0 := hT it hit
-  unfold ExponenceRule.threshold
+  unfold SpanRule.threshold
   cases hc : it.context with
   | none =>
     simp only [Option.getD_none, max_self]
@@ -344,7 +344,7 @@ theorem threshold_le_of_terminal_domainLocal {n : ℕ} {F : Type*}
     adjectives with no adjacency stipulation, which is the paper's
     reconstruction of the degree facts. -/
 theorem realize_const_of_terminal_domainLocal {n : ℕ} {F : Type*}
-    {d : Fin n} {v : List (ExponenceRule n F)}
+    {d : Fin n} {v : List (SpanRule n F)}
     (hT : Terminal v) (hD : DomainLocal d v)
     {g g' : Fin n} (hg : d ≤ g) (hg' : d ≤ g') :
     realize v g = realize v g' :=
@@ -355,7 +355,7 @@ theorem realize_const_of_terminal_domainLocal {n : ℕ} {F : Type*}
     first head: the [bobaljik-2012] regime is the smallest nontrivial
     accessibility domain. -/
 theorem domainLocal_of_terminal_adjacent {n : ℕ} {F : Type*}
-    {d : Fin n} (hd : 1 ≤ (d : ℕ)) {v : List (ExponenceRule n F)}
+    {d : Fin n} (hd : 1 ≤ (d : ℕ)) {v : List (SpanRule n F)}
     (hT : Terminal v) (hA : Adjacent v) : DomainLocal d v := by
   intro it hit c hc
   have h1 := hA it hit c hc
@@ -366,7 +366,7 @@ theorem domainLocal_of_terminal_adjacent {n : ℕ} {F : Type*}
     (stated there for featural containment; transposed here to the
     3-cell structural hierarchy of §3.1): elsewhere `narnaj`,
     oblique-conditioned `gunga`. -/
-def wardamanVocab : List (ExponenceRule 3 String) :=
+def wardamanVocab : List (SpanRule 3 String) :=
   [⟨"narnaj", 0, none⟩, ⟨"gunga", 0, some 2⟩]
 
 /-- **The generability converse**: the AD-local pronoun vocabulary


### PR DESCRIPTION
The containment engine's carrier was named after the interface it implements, reading as a twin of `Exponence.Rule`. `SpanRule` names its intensional content (the exponed span) while keeping the kind-word, `MonoidHom`-style; Bobaljik's term "rule of exponence" stays in the docstring. Mechanical identifier rename, 11 files.