### PR TITLE
refactor(Morphology): remaining engines onto selectBy; weaken soundness

### DIFF
--- a/Linglib/Morphology/Exponence/Containment/Selection.lean
+++ b/Linglib/Morphology/Exponence/Containment/Selection.lean
@@ -228,8 +228,8 @@ theorem winner_isElsewhereWinner {v : List (SpanRule n F)} {g : Fin n}
     {it : SpanRule n F} (h : winner v g = some it) :
     Exponence.IsElsewhereWinner v g it :=
   Exponence.selectBy_isElsewhereWinner
-    (fun r _ s _ _ _ => (SpanRule.le_iff.trans SpanRule.moreSpecific_iff_threshold_le :
-      r ≤ s ↔ SpanRule.threshold s ≤ SpanRule.threshold r)) h
+    (fun _ _ _ _ _ _ _ hfs =>
+      (SpanRule.le_iff.trans SpanRule.moreSpecific_iff_threshold_le).mpr hfs) h
 
 /-! ### Superset reading: Minimize-Junk selection
 

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -153,16 +153,21 @@ theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
   (hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp).mpr
     (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
-/-- **Soundness**: a contravariant specificity score selects an
-Elsewhere winner. Engines discharge `hf` with their `le_iff` reflection
-lemma. -/
+/-- **Soundness**: a score reflecting specificity contravariantly on
+comparable applicable rules selects an Elsewhere winner. Only the
+conditional (`mpr`) direction is needed — argmax supplies `f s ≤ f r`
+and minimality supplies `s ≤ r`, so `hf` just closes `r ≤ s`.
+Linear-domain engines discharge `hf` from the `mpr` of their `le_iff`;
+`Finset`-support engines, where card `≤` does not imply support `⊆`,
+discharge it via `Finset.eq_of_subset_of_card_le`. -/
 theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
     (hf : ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
-      RuleLike.Applies (F := F) s c → (r ≤ s ↔ f s ≤ f r))
+      RuleLike.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : selectBy f v c = some r) : IsElsewhereWinner v c r := by
   refine ⟨⟨selectBy_mem h, selectBy_applies h⟩, ?_⟩
-  rintro s ⟨hs, hsapp⟩ -
-  exact selectBy_le_of_applies hf h hs hsapp
+  rintro s ⟨hs, hsapp⟩ hsr
+  exact hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp hsr
+    (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
 omit [Preorder R] in
 /-- Contexts with the same applicable rules select the same rule. -/
@@ -181,7 +186,7 @@ def realize (f : R → α) (v : List R) (c : Ctx) : Option F :=
 /-- A realized exponent is genuinely predicted: it is `Realizes`. -/
 theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : F}
     (hf : ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
-      RuleLike.Applies (F := F) s c → (r ≤ s ↔ f s ≤ f r))
+      RuleLike.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : realize f v c = some φ) : Realizes v c φ := by
   rw [realize, Option.map_eq_some_iff] at h
   obtain ⟨r, hr, rfl⟩ := h

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -265,13 +265,39 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
     Decidable (entry.Matches target) :=
   inferInstanceAs (Decidable (NanoTree.Contains _ _))
 
+/-! ### The shared exponence core -/
+
+open Morphology.Exponence
+
+/-- A tree lexical entry exposes the shared exponence core interface
+(`Morphology.Exponence.RuleLike`): contexts are syntactic targets,
+applicability is Superset-Principle matching. -/
+instance : RuleLike (TreeLexEntry F α) (NanoTree F) α :=
+  ⟨TreeLexEntry.exponent, fun e => {t | e.Matches t}⟩
+
+instance : Preorder (TreeLexEntry F α) := RuleLike.toPreorder
+
+instance [DecidableEq F] (target : NanoTree F) :
+    DecidablePred (fun e : TreeLexEntry F α => RuleLike.Applies (F := α) e target) :=
+  fun e => inferInstanceAs (Decidable (e.Matches target))
+
+/-- The specificity order is reverse containment of the stored trees:
+`a` is at least as specific as `b` exactly when `b`'s tree contains
+`a`'s. Tree size is therefore a faithful specificity measure
+(`Contains.size_le`), which is what licenses smallest-tree selection. -/
+theorem TreeLexEntry.le_iff {a b : TreeLexEntry F α} :
+    a ≤ b ↔ b.tree.Contains a.tree :=
+  ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
+
 /-! ### Tree spellout (Elsewhere Condition) -/
 
 /-- The matching entry with the smallest stored tree (first-listed on
-    ties): Minimize Junk over tree-generalized Superset matching. -/
+    ties): Minimize Junk over tree-generalized Superset matching, as the
+    shared core's `Exponence.selectBy` at the tree-size score dualized so
+    the smallest tree wins. -/
 def treeSelect [DecidableEq F] (entries : List (TreeLexEntry F α))
     (target : NanoTree F) : Option (TreeLexEntry F α) :=
-  (entries.filter fun e => decide (e.Matches target)).argmin (·.tree.size)
+  selectBy (fun e => OrderDual.toDual e.tree.size) entries target
 
 /-- Phrasal spellout via the tree-generalized Superset Principle:
     among entries whose tree contains the target, select the one
@@ -284,48 +310,22 @@ def treeSpellout [DecidableEq F] (entries : List (TreeLexEntry F α))
     (target : NanoTree F) : Option α :=
   (treeSelect entries target).map (·.exponent)
 
-/-! ### The shared exponence core -/
-
-section ExponenceCore
-
-open Morphology.Exponence
-
-/-- A tree lexical entry exposes the shared exponence core interface
-(`Morphology.Exponence.RuleLike`): contexts are syntactic targets,
-applicability is Superset-Principle matching. -/
-instance : RuleLike (TreeLexEntry F α) (NanoTree F) α :=
-  ⟨TreeLexEntry.exponent, fun e => {t | e.Matches t}⟩
-
-instance : Preorder (TreeLexEntry F α) := RuleLike.toPreorder
-
-/-- The specificity order is reverse containment of the stored trees:
-`a` is at least as specific as `b` exactly when `b`'s tree contains
-`a`'s. Tree size is therefore a faithful specificity measure
-(`Contains.size_le`), which is what licenses smallest-tree selection. -/
-theorem TreeLexEntry.le_iff {a b : TreeLexEntry F α} :
-    a ≤ b ↔ b.tree.Contains a.tree :=
-  ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
-
 /-- Smallest-tree selection is an Elsewhere winner of the shared core,
 with no side conditions: containment is size-antisymmetric
-(`Contains.eq_of_size_le`), so a size-minimal matching entry is
-maximally specific among the matching entries. -/
+(`Contains.eq_of_size_le`), so on comparable matching entries the
+dualized-size score reflects specificity and a size-minimal match is
+maximally specific. An instance of `selectBy_isElsewhereWinner`. -/
 theorem treeSelect_isElsewhereWinner [DecidableEq F]
     {entries : List (TreeLexEntry F α)} {target : NanoTree F}
     {e : TreeLexEntry F α} (h : treeSelect entries target = some e) :
-    IsElsewhereWinner entries target e := by
-  have hmem := List.argmin_mem h
-  rw [List.mem_filter] at hmem
-  obtain ⟨hev, hem⟩ := hmem
-  have hematch : e.Matches target := of_decide_eq_true hem
-  refine ⟨⟨hev, hematch⟩, ?_⟩
-  rintro s ⟨hs, happ⟩ hspec
-  rw [TreeLexEntry.le_iff] at hspec ⊢
-  have hble : ¬ s.tree.size < e.tree.size :=
-    List.not_lt_of_mem_argmin (f := λ e : TreeLexEntry F α => e.tree.size)
-      (List.mem_filter.mpr
-        ⟨hs, decide_eq_true (show s.Matches target from happ)⟩) h
-  exact hspec.eq_of_size_le (Nat.le_of_not_lt hble) ▸ .refl _
+    IsElsewhereWinner entries target e :=
+  selectBy_isElsewhereWinner
+    (fun r _ s _ _ _ hsr hfsr => by
+      rw [TreeLexEntry.le_iff]
+      have hsize : r.tree.size ≤ s.tree.size := OrderDual.toDual_le_toDual.mp hfsr
+      have heq : r.tree = s.tree := (TreeLexEntry.le_iff.mp hsr).eq_of_size_le hsize
+      rw [← heq]
+      exact .refl _) h
 
 /-- The spelled-out exponent is an Elsewhere winner's exponent. -/
 theorem treeSpellout_isElsewhereWinner [DecidableEq F]
@@ -334,10 +334,7 @@ theorem treeSpellout_isElsewhereWinner [DecidableEq F]
     ∃ e ∈ entries, e.exponent = x ∧
       IsElsewhereWinner entries target e := by
   obtain ⟨e, he, rfl⟩ := Option.map_eq_some_iff.mp h
-  exact ⟨e, (List.mem_filter.mp (List.argmin_mem he)).1, rfl,
-    treeSelect_isElsewhereWinner he⟩
-
-end ExponenceCore
+  exact ⟨e, selectBy_mem he, rfl, treeSelect_isElsewhereWinner he⟩
 
 /-! ### Foot Condition -/
 

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -443,7 +443,12 @@ rule a strictly higher generation probability at every shared form
 (`genProb_lt_of_ssubset`), and a likelihood-maximal rule among a
 vocabulary's generators is an Elsewhere winner
 (`maxGenProb_isElsewhereWinner`) — no nesting or comparability
-assumption needed, because card-minimality forces `⊆`-minimality. -/
+assumption needed, because card-minimality forces `⊆`-minimality. Since
+higher probability is smaller support (`genProb_le_iff_card_le`), this is
+the size principle as a specificity score in the shared core:
+`selectByCard_isElsewhereWinner` runs `Exponence.selectBy` on the
+dualized support cardinality, discharging the core's conditional
+soundness law via `Finset.eq_of_subset_of_card_le`. -/
 
 section ProbabilisticElsewhere
 
@@ -468,6 +473,20 @@ theorem genProb_lt_of_ssubset {s₁ s₂ : Finset Ctx} (h : s₂ ⊂ s₁)
   simp only [genProb, if_pos hc, if_pos hc₁]
   gcongr
 
+/-- Uniform generation probability ranks supports by cardinality at a
+shared form: a rule assigns at least as much probability iff its support
+is no larger. The monotone bridge from maximum-likelihood selection to
+the support-cardinality specificity score — maximizing probability *is*
+minimizing support cardinality. -/
+theorem genProb_le_iff_card_le {s₁ s₂ : Finset Ctx} {c : Ctx}
+    (h₁ : c ∈ s₁) (h₂ : c ∈ s₂) :
+    genProb s₁ c ≤ genProb s₂ c ↔ s₂.card ≤ s₁.card := by
+  have hs₁ : (0 : ℚ) < s₁.card := by exact_mod_cast Finset.card_pos.mpr ⟨c, h₁⟩
+  have hs₂ : (0 : ℚ) < s₂.card := by exact_mod_cast Finset.card_pos.mpr ⟨c, h₂⟩
+  simp only [genProb, if_pos h₁, if_pos h₂]
+  rw [inv_le_inv₀ hs₁ hs₂]
+  exact_mod_cast Iff.rfl
+
 /-- A finitely supported rule: an exponent with a finite set of forms
 it can generate. -/
 structure FinRule (Ctx F : Type*) where
@@ -483,10 +502,48 @@ instance : RuleLike (FinRule Ctx F) Ctx F :=
 
 instance : Preorder (FinRule Ctx F) := RuleLike.toPreorder
 
+instance (c : Ctx) :
+    DecidablePred (fun r : FinRule Ctx F => RuleLike.Applies (F := F) r c) :=
+  fun r => inferInstanceAs (Decidable (c ∈ r.supp))
+
+omit [DecidableEq Ctx] in
+/-- Support cardinality reflects specificity conditionally on the
+finitely supported rules: if `s` is at least as specific as `r` (support
+inclusion) and `r`'s support is no larger, then the two coincide, so `r`
+is at least as specific as `s`. This is the conditional reflection the
+`Finset`-support engine satisfies where the linear-order engines' `iff`
+fails — card `≤` does not imply support `⊆`, but `⊆` plus card `≤` forces
+equality (`Finset.eq_of_subset_of_card_le`). -/
+private theorem finRule_card_reflection {v : List (FinRule Ctx F)} {c : Ctx} :
+    ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
+      RuleLike.Applies (F := F) s c → s ≤ r →
+      OrderDual.toDual s.supp.card ≤ OrderDual.toDual r.supp.card → r ≤ s :=
+  fun r _ s _ _ _ hsr hcard => by
+    have hsub : s.supp ⊆ r.supp := fun x hx => hsr hx
+    have hle : r.supp.card ≤ s.supp.card := OrderDual.toDual_le_toDual.mp hcard
+    have heq : s.supp = r.supp := Finset.eq_of_subset_of_card_le hsub hle
+    exact fun x hx => show x ∈ s.supp from heq ▸ hx
+
+/-- **The size principle as a specificity score** ([odonnell-2015]
+§5.5.3): selecting the finitely supported rule of least support
+cardinality — dualized so smaller supports win the `argmax` — through
+the shared core's `Exponence.selectBy` yields an Elsewhere winner.
+Minimizing support cardinality *is* maximizing uniform generation
+probability (`genProb_le_iff_card_le`), so this is Elsewhere selection as
+maximum-likelihood inference, on record as a score. -/
+theorem selectByCard_isElsewhereWinner {v : List (FinRule Ctx F)} {c : Ctx}
+    {r : FinRule Ctx F}
+    (h : selectBy (fun s => OrderDual.toDual s.supp.card) v c = some r) :
+    IsElsewhereWinner v c r :=
+  selectBy_isElsewhereWinner finRule_card_reflection h
+
 /-- **Elsewhere selection is maximum-likelihood inference**
 ([odonnell-2015] §5.5.3): a rule maximizing uniform generation
 probability at `c` among a vocabulary's generators is an Elsewhere
-winner of the corresponding vocabulary. -/
+winner of the corresponding vocabulary. Maximizing probability is
+minimizing support cardinality (`genProb_le_iff_card_le`), whence
+card-minimality forces `⊆`-minimality — the same reasoning
+`selectByCard_isElsewhereWinner` routes through the core's score. -/
 theorem maxGenProb_isElsewhereWinner {v : List (FinRule Ctx F)} {c : Ctx}
     {r : FinRule Ctx F} (hrv : r ∈ v) (hrc : c ∈ r.supp)
     (hmax : ∀ s ∈ v, c ∈ s.supp → genProb s.supp c ≤ genProb r.supp c) :
@@ -495,15 +552,8 @@ theorem maxGenProb_isElsewhereWinner {v : List (FinRule Ctx F)} {c : Ctx}
   rintro s ⟨hsv, htc⟩ hle
   have htc' : c ∈ s.supp := htc
   have hsub : s.supp ⊆ r.supp := fun x hx => hle hx
-  have hcard : r.supp.card ≤ s.supp.card := by
-    have hp := hmax s hsv htc'
-    simp only [genProb] at hp
-    rw [if_pos htc', if_pos hrc] at hp
-    have hs₀ : (0 : ℚ) < s.supp.card := by
-      exact_mod_cast Finset.card_pos.mpr ⟨c, htc'⟩
-    have hr₀ : (0 : ℚ) < r.supp.card := by
-      exact_mod_cast Finset.card_pos.mpr ⟨c, hrc⟩
-    exact_mod_cast (inv_le_inv₀ hs₀ hr₀).mp hp
+  have hcard : r.supp.card ≤ s.supp.card :=
+    (genProb_le_iff_card_le htc' hrc).mp (hmax s hsv htc')
   have heq : s.supp = r.supp := Finset.eq_of_subset_of_card_le hsub hcard
   exact fun x hx => show x ∈ s.supp from heq ▸ hx
 


### PR DESCRIPTION
Completes the engine square on the Select core. The soundness law's hypothesis weakens to conditional reflection (all Minimal needs), keeping the strong iff only on winner-is-least; TreeSpellout drops its argmin plumbing for `selectBy` at dualized tree size; ODonnell2015 gains `selectByCard_isElsewhereWinner` — minimizing support cardinality = maximizing generation probability = Elsewhere specificity, the size principle as a specificity score. DM VocabularyInsertion audited and correctly left Prop-level (stipulated rank, not a derived measure).