### PR TITLE
refactor(Morphology/Exponence): rename RuleLike to Exponence class

### DIFF
--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -134,15 +134,15 @@ def makePersonVocab {PN : Type*} (cells : List PN) (toPhi : PN → List PhiFeatu
 
 section ExponenceCore
 
-open Morphology.Exponence
+open Morphology Morphology.Exponence
 
 /-- A vocabulary entry exposes the shared exponence core interface
-(`Morphology.Exponence.RuleLike`): contexts are (target bundle,
+(`Morphology.Exponence`): contexts are (target bundle,
 syntactic context) pairs, applicability is `Matches`. -/
-instance : RuleLike VocabEntry (FeatureBundle × Option Cat) String :=
+instance : Exponence VocabEntry (FeatureBundle × Option Cat) String :=
   ⟨VocabEntry.exponent, fun e => {tc | e.Matches tc.1 tc.2}⟩
 
-instance : Preorder VocabEntry := RuleLike.toPreorder
+instance : Preorder VocabEntry := Exponence.toPreorder
 
 /-- Derived specificity, unfolded: `e ≤ e'` iff `e'` matches wherever
 `e` does. -/
@@ -225,7 +225,7 @@ theorem VocabEntry.toVocabItem_matches (e : VocabEntry)
 where the entry does. -/
 theorem VocabEntry.toVocabItem_applies (e : VocabEntry)
     (tc : FeatureBundle × Option Cat) :
-    RuleLike.Applies e.toVocabItem tc ↔ RuleLike.Applies e tc :=
+    Exponence.Applies e.toVocabItem tc ↔ Exponence.Applies e tc :=
   e.toVocabItem_matches tc.1 tc.2
 
 /-- Specificity transfers along the embedding — the cross-engine

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -157,12 +157,12 @@ open Morphology.Exponence
 variable {Ctx Root : Type*}
 
 /-- A Vocabulary Item exposes the shared exponence core interface
-(`Morphology.Exponence.RuleLike`): contexts are (feature-context, root)
+(`Morphology.Exponence`): contexts are (feature-context, root)
 pairs, applicability is `matches`. -/
-instance : RuleLike (VocabItem Ctx Root) (Ctx × Root) String :=
+instance : Exponence (VocabItem Ctx Root) (Ctx × Root) String :=
   ⟨VocabItem.exponent, fun vi => {cr | vi.matches cr.1 cr.2 = true}⟩
 
-instance : Preorder (VocabItem Ctx Root) := RuleLike.toPreorder
+instance : Preorder (VocabItem Ctx Root) := Exponence.toPreorder
 
 /-- The stipulated `specificity` rank is **faithful** when it refines
 the derived specificity of the shared core: a strictly more specific

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -5,34 +5,48 @@ import Mathlib.Data.Set.Basic
 # Rules of exponence
 [kiparsky-1973] [halle-marantz-1993] [stump-2001] [stump-2022]
 
-A **rule of exponence** pairs an exponent with an applicability
-condition on contexts ([matthews-1991]'s term for the mapping from
-morphosyntactic content to form). `RuleLike` is the interface every
-framework engine's carrier implements: an exponent projection and an
-applicability set, ordered by set inclusion ([kiparsky-1973]'s
-Elsewhere Condition), so the most specific applicable rule has the
-smallest applicability domain. The order is [stump-2022]'s single-clause
-formulation of Pāṇini's principle — domain-subset precedence — to which
-[stump-2001]'s two-clause rule narrowness collapses when contexts pair
-expressions with their full property sets. Selection over this order — existence,
-coherence, and the framework-neutral prediction relation — lives in
-`Morphology/Exponence/Select.lean`.
+**Exponence** ([matthews-1991]'s term for the mapping from morphosyntactic
+content to form) is the class every framework engine's carrier implements:
+an exponent projection and an applicability set, ordered by set inclusion
+([kiparsky-1973]'s Elsewhere Condition), so the most specific applicable
+rule has the smallest applicability domain. The order is [stump-2022]'s
+single-clause formulation of Pāṇini's principle — domain-subset precedence
+— to which [stump-2001]'s two-clause rule narrowness collapses when
+contexts pair expressions with their full property sets. Selection over
+this order — existence, coherence, and the framework-neutral prediction
+relation — lives in `Morphology/Exponence/Select.lean`.
 
-`Rule Ctx F` is the free carrier. Framework engines (the containment
-hierarchy, DM vocabulary items, nanosyntax spellout) implement
-`RuleLike` on their own intensional carriers (thresholds, feature
-bundles, stored trees) and install `RuleLike.toPreorder` as the
+`Exponence.Rule Ctx F` is the free carrier. Framework engines (the
+containment hierarchy, DM vocabulary items, nanosyntax spellout) implement
+`Exponence` on their own intensional carriers (thresholds, feature
+bundles, stored trees) and install `Exponence.toPreorder` as the
 carrier's order, so the selection theorems apply to the native type
 with no wrapper.
 
 ## Main declarations
 
-* `Rule` — an exponent with its applicability condition
-* `RuleLike` — the exponent-plus-applicability interface;
-  `RuleLike.toPreorder` lifts applicability-set inclusion to a preorder
+* `Exponence` — the exponent-plus-applicability class;
+  `Exponence.toPreorder` lifts applicability-set inclusion to a preorder
+* `Exponence.Rule` — the free carrier: an exponent with its applicability
+  condition
 -/
 
-namespace Morphology.Exponence
+namespace Morphology
+
+/-- Carriers whose values expone: an exponent projection and an
+applicability set, à la `SetLike` minus injectivity. Distinct rules may
+share an applicability set while carrying different exponents, so there
+is no `coe_injective` and the induced order is only a preorder
+(`toPreorder`), never a partial order. Framework engines instantiate
+this on their intensional carriers and derive Elsewhere selection over
+the native type. -/
+class Exponence (R : Type*) (Ctx F : outParam Type*) where
+  /-- The exponent a rule inserts. -/
+  exponent : R → F
+  /-- The set of contexts a rule applies in. -/
+  applySet : R → Set Ctx
+
+namespace Exponence
 
 variable {Ctx F : Type*}
 
@@ -72,22 +86,7 @@ theorem le_iff {r s : Rule Ctx F} :
 
 end Rule
 
-/-- Carriers whose values expone: an exponent projection and an
-applicability set, à la `SetLike` minus injectivity. Distinct rules may
-share an applicability set while carrying different exponents, so there
-is no `coe_injective` and the induced order is only a preorder
-(`toPreorder`), never a partial order. Framework engines instantiate
-this on their intensional carriers and derive Elsewhere selection over
-the native type. -/
-class RuleLike (R : Type*) (Ctx F : outParam Type*) where
-  /-- The exponent a rule inserts. -/
-  exponent : R → F
-  /-- The set of contexts a rule applies in. -/
-  applySet : R → Set Ctx
-
-namespace RuleLike
-
-variable {R : Type*} [RuleLike R Ctx F]
+variable {R : Type*} [Exponence R Ctx F]
 
 /-- A rule applies at a context when the context is in its
 applicability set. -/
@@ -98,9 +97,8 @@ global instance — each engine installs it (or a defeq order) on its own
 carrier. -/
 @[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (F := F))
 
-end RuleLike
-
 /-- The free carrier exposes its fields as the interface. -/
-instance : RuleLike (Rule Ctx F) Ctx F := ⟨Rule.exponent, Rule.applySet⟩
+instance : Exponence (Rule Ctx F) Ctx F := ⟨Rule.exponent, Rule.applySet⟩
 
-end Morphology.Exponence
+end Exponence
+end Morphology

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -10,7 +10,7 @@ The carrier for the realizational engine of [bobaljik-2012]'s
 comparative-suppletion generalizations, over an arbitrary `n`-grade
 containment hierarchy. An `SpanRule` realizes the initial span `[0, spans]`
 of the hierarchy, optionally conditioned on a higher head. One carrier
-carries two `RuleLike` views: the **Subset** reading (`SpanRule`,
+carries two `Exponence` views: the **Subset** reading (`SpanRule`,
 applicability is threshold containment) is DM Elsewhere insertion; the
 **Superset** reading (`SupersetRule`, applicability is constituent
 containment) is nanosyntax spellout, dual à la `OrderDual`.
@@ -132,21 +132,21 @@ instance (v : List (SpanRule n F)) : Decidable (ContextFree v) := by
 
 /-! ### The Subset reading: DM Elsewhere insertion
 
-The containment engine implements `Morphology.Exponence.RuleLike`
+The containment engine implements `Morphology.Exponence`
 directly: applicability is threshold containment (the upper set
 `Set.Ici threshold`) and derived specificity is threshold comparison. -/
 
-instance : RuleLike (SpanRule n F) (Fin n) F :=
+instance : Exponence (SpanRule n F) (Fin n) F :=
   ⟨SpanRule.exponent, fun it => Set.Ici it.threshold⟩
 
-instance : Preorder (SpanRule n F) := RuleLike.toPreorder
+instance : Preorder (SpanRule n F) := Exponence.toPreorder
 
-instance (g : Fin n) : DecidablePred (fun it : SpanRule n F => RuleLike.Applies (F := F) it g) :=
+instance (g : Fin n) : DecidablePred (fun it : SpanRule n F => Exponence.Applies (F := F) it g) :=
   fun it => inferInstanceAs (Decidable (it.threshold ≤ g))
 
 /-- Subset applicability is threshold containment. -/
 @[simp] theorem SpanRule.applies_iff {it : SpanRule n F} {g : Fin n} :
-    RuleLike.Applies (F := F) it g ↔ it.threshold ≤ g :=
+    Exponence.Applies (F := F) it g ↔ it.threshold ≤ g :=
   Iff.rfl
 
 /-- Containment specificity is the shared core's specificity order. -/
@@ -160,7 +160,7 @@ One carrier, a dual view: the entry can spell out grade `g` when its
 stored constituent contains `g` (the down-set `Set.Iic spans`), and
 smallest-match selection is Pāṇinian specificity under superset
 matching. A distinct type synonym so the two readings carry different
-`RuleLike` instances on one carrier, mirroring `OrderDual`. -/
+`Exponence` instances on one carrier, mirroring `OrderDual`. -/
 
 /-- The **Superset Principle** ([starke-2009]): an entry can spell out
 grade `g` when the constituent it stores contains grade `g`'s
@@ -189,13 +189,13 @@ grade `g` when its stored constituent contains `g` (the down-set
 `Set.Iic spans`), dually to the Subset reading of `SpanRule`. -/
 def SupersetRule (n : ℕ) (F : Type*) := SpanRule n F
 
-instance : RuleLike (SupersetRule n F) (Fin n) F :=
+instance : Exponence (SupersetRule n F) (Fin n) F :=
   ⟨SpanRule.exponent, fun it => Set.Iic (SpanRule.spans it)⟩
 
-instance : Preorder (SupersetRule n F) := RuleLike.toPreorder
+instance : Preorder (SupersetRule n F) := Exponence.toPreorder
 
 instance (g : Fin n) :
-    DecidablePred (fun it : SupersetRule n F => RuleLike.Applies (F := F) it g) :=
+    DecidablePred (fun it : SupersetRule n F => Exponence.Applies (F := F) it g) :=
   fun it => inferInstanceAs (Decidable (g ≤ SpanRule.spans it))
 
 /-- Read an exponence rule under the Superset reading. -/
@@ -203,7 +203,7 @@ def SpanRule.superset (it : SpanRule n F) : SupersetRule n F := it
 
 /-- Superset applicability is constituent containment. -/
 @[simp] theorem SupersetRule.applies_iff {it : SupersetRule n F} {g : Fin n} :
-    RuleLike.Applies (F := F) it g ↔ g ≤ SpanRule.spans it :=
+    Exponence.Applies (F := F) it g ↔ g ≤ SpanRule.spans it :=
   Iff.rfl
 
 /-- Minimize Junk is the Superset reading's specificity order: smaller

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -34,7 +34,7 @@ per-block winners into the paradigm function ([stump-2001]).
 
 namespace Morphology.Exponence
 
-variable {Ctx F : Type*} {R : Type*} [Preorder R] [RuleLike R Ctx F]
+variable {Ctx F : Type*} {R : Type*} [Preorder R] [Exponence R Ctx F]
 
 /-! ### Elsewhere winners -/
 
@@ -42,13 +42,13 @@ variable {Ctx F : Type*} {R : Type*} [Preorder R] [RuleLike R Ctx F]
 `≤`-minimal applicable member of `v` — no applicable rule in `v` is
 strictly more specific. -/
 def IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
-  Minimal (fun s => s ∈ v ∧ RuleLike.Applies (F := F) s c) r
+  Minimal (fun s => s ∈ v ∧ Exponence.Applies (F := F) s c) r
 
 /-- A winner is at least as specific as any applicable member of the
 vocabulary that is at least as specific as it. -/
 theorem IsElsewhereWinner.le_of_le {v : List R} {c : Ctx} {r s : R}
     (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
-    (happ : RuleLike.Applies (F := F) s c) (h : s ≤ r) : r ≤ s :=
+    (happ : Exponence.Applies (F := F) s c) (h : s ≤ r) : r ≤ s :=
   Minimal.le_of_le hr ⟨hs, happ⟩ h
 
 /-! ### Coherence and uniqueness -/
@@ -68,21 +68,21 @@ order-theoretically). Incomparable competitors are tolerated, where
 [stump-2001]'s Pāṇinian Determinism Hypothesis forbids them. -/
 def Coherent (v : List R) : Prop :=
   ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
-    RuleLike.exponent (F := F) r = RuleLike.exponent (F := F) s
+    Exponence.exponent (F := F) r = Exponence.exponent (F := F) s
 
 /-- Over a coherent vocabulary, comparable winners select the same
 exponent: Elsewhere selection is well defined up to incomparability. -/
 theorem IsElsewhereWinner.exponent_eq {v : List R} {c : Ctx} {r s : R}
     (hv : Coherent v) (hr : IsElsewhereWinner v c r)
     (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
-    RuleLike.exponent (F := F) r = RuleLike.exponent (F := F) s :=
+    Exponence.exponent (F := F) r = Exponence.exponent (F := F) s :=
   hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
 
 /-- A vocabulary with an applicable rule has an Elsewhere winner —
 proved, where [stump-2001] guarantees existence by stipulating a
 bottom-element Identity Function Default. -/
 theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
-    (h : ∃ r ∈ v, RuleLike.Applies (F := F) r c) : ∃ r, IsElsewhereWinner v c r :=
+    (h : ∃ r ∈ v, Exponence.Applies (F := F) r c) : ∃ r, IsElsewhereWinner v c r :=
   (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
 
 /-! ### The prediction relation -/
@@ -90,7 +90,7 @@ theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
 /-- The framework-neutral prediction: `φ` is realized at `c` when some
 Elsewhere winner carries it. -/
 def Realizes (v : List R) (c : Ctx) (φ : F) : Prop :=
-  ∃ r, IsElsewhereWinner v c r ∧ RuleLike.exponent (F := F) r = φ
+  ∃ r, IsElsewhereWinner v c r ∧ Exponence.exponent (F := F) r = φ
 
 /-- Over a coherent vocabulary whose winners are comparable, the
 prediction is unique. -/
@@ -108,15 +108,15 @@ picks the applicable rule of greatest score. Engines whose score is
 minimized (span, tree size, `Finsupp`-support card) pass it through
 `OrderDual α`. -/
 
-variable [∀ c : Ctx, DecidablePred (fun r : R => RuleLike.Applies (F := F) r c)]
+variable [∀ c : Ctx, DecidablePred (fun r : R => Exponence.Applies (F := F) r c)]
 
 /-- The rules of `v` applicable at `c`, in vocabulary order. -/
 def applicable (v : List R) (c : Ctx) : List R :=
-  v.filter (fun r => RuleLike.Applies (F := F) r c)
+  v.filter (fun r => Exponence.Applies (F := F) r c)
 
 omit [Preorder R] in
 @[simp] theorem mem_applicable {v : List R} {c : Ctx} {r : R} :
-    r ∈ applicable v c ↔ r ∈ v ∧ RuleLike.Applies (F := F) r c := by
+    r ∈ applicable v c ↔ r ∈ v ∧ Exponence.Applies (F := F) r c := by
   simp only [applicable, List.mem_filter, decide_eq_true_eq]
 
 variable {α : Type*} [LinearOrder α]
@@ -134,7 +134,7 @@ theorem selectBy_mem {f : R → α} {v : List R} {c : Ctx} {r : R}
 
 omit [Preorder R] in
 theorem selectBy_applies {f : R → α} {v : List R} {c : Ctx} {r : R}
-    (h : selectBy f v c = some r) : RuleLike.Applies (F := F) r c :=
+    (h : selectBy f v c = some r) : Exponence.Applies (F := F) r c :=
   (mem_applicable.mp (List.argmax_mem h)).2
 
 omit [Preorder R] in
@@ -146,10 +146,10 @@ theorem selectBy_eq_none_iff {f : R → α} {v : List R} {c : Ctx} :
 rules, the selection is at least as specific as every applicable rule
 — it is `≤` all of them, no comparability assumed. -/
 theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
-    (hf : ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
-      RuleLike.Applies (F := F) s c → (r ≤ s ↔ f s ≤ f r))
+    (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
+      Exponence.Applies (F := F) s c → (r ≤ s ↔ f s ≤ f r))
     (h : selectBy f v c = some r) (hs : s ∈ v)
-    (hsapp : RuleLike.Applies (F := F) s c) : r ≤ s :=
+    (hsapp : Exponence.Applies (F := F) s c) : r ≤ s :=
   (hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp).mpr
     (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
@@ -161,8 +161,8 @@ Linear-domain engines discharge `hf` from the `mpr` of their `le_iff`;
 `Finset`-support engines, where card `≤` does not imply support `⊆`,
 discharge it via `Finset.eq_of_subset_of_card_le`. -/
 theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
-    (hf : ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
-      RuleLike.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
+    (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
+      Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : selectBy f v c = some r) : IsElsewhereWinner v c r := by
   refine ⟨⟨selectBy_mem h, selectBy_applies h⟩, ?_⟩
   rintro s ⟨hs, hsapp⟩ hsr
@@ -181,12 +181,12 @@ theorem selectBy_congr {f : R → α} {v : List R} {c c' : Ctx}
 /-- The realized exponent: the score-selected winner's exponent
 (`none` when no rule applies). -/
 def realize (f : R → α) (v : List R) (c : Ctx) : Option F :=
-  (selectBy f v c).map (RuleLike.exponent (F := F))
+  (selectBy f v c).map (Exponence.exponent (F := F))
 
 /-- A realized exponent is genuinely predicted: it is `Realizes`. -/
 theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : F}
-    (hf : ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
-      RuleLike.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
+    (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
+      Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : realize f v c = some φ) : Realizes v c φ := by
   rw [realize, Option.map_eq_some_iff] at h
   obtain ⟨r, hr, rfl⟩ := h

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -26,7 +26,7 @@ uses containment as the simpler equivalent formulation.
 - `TreeLexEntry`: a stored tree paired with an exponent; `TreeLexEntry.Matches`
 - `treeSelect`, `treeSpellout`: Superset Principle + Elsewhere Condition
 - `treeSelect_isElsewhereWinner`: the engine as an instance of the shared
-  exponence core (`RuleLike`) — derived specificity is reverse tree
+  exponence core (`Exponence`) — derived specificity is reverse tree
   containment (`TreeLexEntry.le_iff`), and smallest-tree selection is an
   Elsewhere winner with no side conditions
 - `FootConditionMet`: [taraldsen-et-al-2018]'s constraint on backtracking
@@ -270,15 +270,15 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
 open Morphology.Exponence
 
 /-- A tree lexical entry exposes the shared exponence core interface
-(`Morphology.Exponence.RuleLike`): contexts are syntactic targets,
+(`Morphology.Exponence`): contexts are syntactic targets,
 applicability is Superset-Principle matching. -/
-instance : RuleLike (TreeLexEntry F α) (NanoTree F) α :=
+instance : Exponence (TreeLexEntry F α) (NanoTree F) α :=
   ⟨TreeLexEntry.exponent, fun e => {t | e.Matches t}⟩
 
-instance : Preorder (TreeLexEntry F α) := RuleLike.toPreorder
+instance : Preorder (TreeLexEntry F α) := Exponence.toPreorder
 
 instance [DecidableEq F] (target : NanoTree F) :
-    DecidablePred (fun e : TreeLexEntry F α => RuleLike.Applies (F := α) e target) :=
+    DecidablePred (fun e : TreeLexEntry F α => Exponence.Applies (F := α) e target) :=
   fun e => inferInstanceAs (Decidable (e.Matches target))
 
 /-- The specificity order is reverse containment of the stored trees:

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -452,7 +452,7 @@ soundness law via `Finset.eq_of_subset_of_card_le`. -/
 
 section ProbabilisticElsewhere
 
-open Morphology.Exponence
+open Morphology Morphology.Exponence
 
 variable {Ctx F : Type*} [DecidableEq Ctx]
 
@@ -496,14 +496,14 @@ structure FinRule (Ctx F : Type*) where
   supp : Finset Ctx
 
 /-- A finitely supported rule exposes the shared exponence core interface
-(`Morphology.Exponence.RuleLike`): applicability is support membership. -/
-instance : RuleLike (FinRule Ctx F) Ctx F :=
+(`Morphology.Exponence`): applicability is support membership. -/
+instance : Exponence (FinRule Ctx F) Ctx F :=
   ⟨FinRule.exponent, fun r => {c | c ∈ r.supp}⟩
 
-instance : Preorder (FinRule Ctx F) := RuleLike.toPreorder
+instance : Preorder (FinRule Ctx F) := Exponence.toPreorder
 
 instance (c : Ctx) :
-    DecidablePred (fun r : FinRule Ctx F => RuleLike.Applies (F := F) r c) :=
+    DecidablePred (fun r : FinRule Ctx F => Exponence.Applies (F := F) r c) :=
   fun r => inferInstanceAs (Decidable (c ∈ r.supp))
 
 omit [DecidableEq Ctx] in
@@ -515,8 +515,8 @@ is at least as specific as `s`. This is the conditional reflection the
 fails — card `≤` does not imply support `⊆`, but `⊆` plus card `≤` forces
 equality (`Finset.eq_of_subset_of_card_le`). -/
 private theorem finRule_card_reflection {v : List (FinRule Ctx F)} {c : Ctx} :
-    ∀ r ∈ v, ∀ s ∈ v, RuleLike.Applies (F := F) r c →
-      RuleLike.Applies (F := F) s c → s ≤ r →
+    ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
+      Exponence.Applies (F := F) s c → s ≤ r →
       OrderDual.toDual s.supp.card ≤ OrderDual.toDual r.supp.card → r ≤ s :=
   fun r _ s _ _ _ hsr hcard => by
     have hsub : s.supp ⊆ r.supp := fun x hx => hsr hx


### PR DESCRIPTION
The interface class takes the field's own name for its concept, on the Filter pattern: `class Morphology.Exponence` declared at the parent level, the existing `Morphology.Exponence` namespace becomes the class's namespace, `Morphology/Exponence/` the area directory (cf. `Order/Filter/`). Kills the `-Like` suffix's injectivity over-promise — the class is deliberately SetLike-minus-injectivity and now says so without borrowing the brand. Mechanical rename across the core and five engine sites.