### PR TITLE
feat(Morphology): allosemy on the Exponence core; Harley 2014 study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2261,6 +2261,7 @@ import Linglib.Studies.Harbour2014
 import Linglib.Studies.Harbour2016
 import Linglib.Studies.HardingGerstenbergIcard2025
 import Linglib.Studies.HarizanovGribanova2019
+import Linglib.Studies.Harley2014
 import Linglib.Studies.HarrisPotts2009
 import Linglib.Studies.HartmannZimmermann2004
 import Linglib.Studies.HartmannZimmermann2007

--- a/Linglib/Fragments/Poko/Tone.lean
+++ b/Linglib/Fragments/Poko/Tone.lean
@@ -1,6 +1,7 @@
 import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.Autosegmental.Melody
+import Linglib.Morphology.MorphWord
 
 /-!
 # Poko Tonal Fragment
@@ -25,12 +26,13 @@ a fuller fragment when a second Poko paper arrives.
 * `Poko.Syll.melody` — each stem's lexical melody: tones, TBU, and
   pre-linking ([rolle-2018] §2.1; the floating H of `/M^H/` stems is
   the unlinked element).
-* `Poko.Form` — autosegmental forms (`FloatingForm Syll TRN`).
+* `Poko.Form` — autosegmental forms (`FloatingForm Syll TRN Morpheme`).
 -/
 
 namespace Poko
 
 open Autosegmental
+open Morphology.WordStructure (Morpheme)
 open Tone (TRN)
 
 /-! ### Syllables -/
@@ -74,7 +76,7 @@ def Syll.morpheme : Syll → Morpheme
 /-- Each stem's lexical melody ([mcpherson-lamont-2026] ex. 3): tones
     over the stem's single TBU, with the lexical pre-linking — the H of
     an `/M^H/` stem is the sole unlinked (floating) element. -/
-def Syll.melody (s : Syll) : FloatingForm Syll TRN :=
+def Syll.melody (s : Syll) : FloatingForm Syll TRN Morpheme :=
   match s with
   | .kak => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
   | .ri  => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
@@ -87,10 +89,10 @@ def Syll.melody (s : Syll) : FloatingForm Syll TRN :=
 
 /-- The underlying form of a stem sequence: melodies concatenated
     left-to-right. -/
-def word (ss : List Syll) : FloatingForm Syll TRN :=
+def word (ss : List Syll) : FloatingForm Syll TRN Morpheme :=
   .concatInputs (ss.map Syll.melody)
 
-/-- Poko autosegmental forms: syllable backbone, `TRN` tone tier. -/
-abbrev Form := FloatingForm Syll TRN
+/-- Poko autosegmental forms: syllable backbone, `TRN` tone tier, morpheme sponsor. -/
+abbrev Form := FloatingForm Syll TRN Morpheme
 
 end Poko

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -1,5 +1,6 @@
 import Linglib.Morphology.DM.Categorizer
 import Linglib.Morphology.DM.CategorizerSemantics
+import Linglib.Morphology.Exponence.Select
 import Linglib.Semantics.Verb.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Voice
 
@@ -36,6 +37,18 @@ multiple context-dependent meanings. The module then instantiates
 this for v (critical for [benz-2025] Ch. 3 on nominalizations)
 and retroactively classifies existing n and Voice types as allosemy.
 
+## The List-2 / List-3 symmetry, by construction
+
+`AllosemicEntry` is an `Morphology.Exponence` instance
+(`SyntacticContext.matches` as applicability, denotation as exponent),
+just as `DM.VI.VocabItem` is. So DM's List 2 (form) and List 3 (meaning)
+are resolved by **one** selection engine: `Exponence.selectBy` on the
+non-wildcard-field score, whose winner is the Elsewhere winner
+(`selectBy_score_isElsewhereWinner`). `VoiceAlloseme.fromComplement` is a
+worked List-3 competition over that engine. `readingFromAllosemes` is a
+different object — the List-3 *composition* of two already-selected
+allosemes (v ⊕ n), not a single-head competition — so it stays a table.
+
 -/
 
 namespace Morphology.DM.Allosemy
@@ -64,7 +77,83 @@ structure SyntacticContext where
   aboveCat : Option Categorizer := none
   /-- Does the complement denote an event? -/
   complementIsEventive : Bool := false
+  /-- Does the complement denote a state? ([kratzer-1996] §2.3: the
+      stative-vs-dynamic split conditions the Voice alloseme.) -/
+  complementIsStative : Bool := false
   deriving DecidableEq, Repr
+
+/-- A partial context specification `spec` **matches** a fully-specified
+query context `c` when every non-wildcard field of `spec` agrees with
+`c`. A field at its default (`none` / `false`) is a **wildcard**,
+constraining nothing; a set field must agree. More specified contexts
+match strictly fewer queries — the applicability-set inclusion that
+orders exponence rules ([kiparsky-1973]). -/
+def SyntacticContext.matches (spec c : SyntacticContext) : Bool :=
+  (spec.belowCat == none || spec.belowCat == c.belowCat) &&
+  (spec.aboveCat == none || spec.aboveCat == c.aboveCat) &&
+  (!spec.complementIsEventive || c.complementIsEventive) &&
+  (!spec.complementIsStative || c.complementIsStative)
+
+/-- The specificity **score**: the number of non-wildcard fields. Higher
+score = more specified = strictly smaller applicability set, so the score
+reflects the specificity preorder contravariantly
+(`SyntacticContext.specificity_le_of_matches_subset`). -/
+def SyntacticContext.specificity (c : SyntacticContext) : Nat :=
+  (if c.belowCat.isSome then 1 else 0) + (if c.aboveCat.isSome then 1 else 0)
+    + (if c.complementIsEventive then 1 else 0) + (if c.complementIsStative then 1 else 0)
+
+@[simp] theorem SyntacticContext.matches_self (c : SyntacticContext) : c.matches c = true := by
+  simp [SyntacticContext.matches]
+
+/-- A broader specification (matched by every query the narrower one is)
+has no more non-wildcard fields: the score reflects applicability-set
+inclusion contravariantly. -/
+theorem SyntacticContext.specificity_le_of_matches_subset {r s : SyntacticContext}
+    (h : ∀ q, s.matches q = true → r.matches q = true) :
+    r.specificity ≤ s.specificity := by
+  have hrs : r.matches s = true := h s (SyntacticContext.matches_self s)
+  simp only [SyntacticContext.matches, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq] at hrs
+  obtain ⟨⟨⟨hb, ha⟩, he⟩, hst⟩ := hrs
+  simp only [SyntacticContext.specificity]
+  have b : (if r.belowCat.isSome then 1 else 0) ≤ (if s.belowCat.isSome then (1 : ℕ) else 0) := by
+    rcases hb with hb | hb <;> simp [hb]
+  have a : (if r.aboveCat.isSome then 1 else 0) ≤ (if s.aboveCat.isSome then (1 : ℕ) else 0) := by
+    rcases ha with ha | ha <;> simp [ha]
+  have e : (if r.complementIsEventive then 1 else 0) ≤
+      (if s.complementIsEventive then (1 : ℕ) else 0) := by
+    cases hr : r.complementIsEventive <;> cases hsc : s.complementIsEventive <;> simp_all
+  have t : (if r.complementIsStative then 1 else 0) ≤
+      (if s.complementIsStative then (1 : ℕ) else 0) := by
+    cases hr : r.complementIsStative <;> cases hsc : s.complementIsStative <;> simp_all
+  omega
+
+/-- Equal-score inclusion is equality: if every query matching `s` also
+matches `r` and the two carry the same number of non-wildcard fields, the
+specifications coincide. -/
+theorem SyntacticContext.eq_of_matches_subset_of_specificity_eq {r s : SyntacticContext}
+    (h : ∀ q, s.matches q = true → r.matches q = true)
+    (hs : r.specificity = s.specificity) : r = s := by
+  have hrs : r.matches s = true := h s (SyntacticContext.matches_self s)
+  simp only [SyntacticContext.matches, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq] at hrs
+  obtain ⟨⟨⟨hb, ha⟩, he⟩, hst⟩ := hrs
+  simp only [SyntacticContext.specificity] at hs
+  have b : (if r.belowCat.isSome then 1 else 0) ≤ (if s.belowCat.isSome then (1 : ℕ) else 0) := by
+    rcases hb with h | h <;> simp [h]
+  have a : (if r.aboveCat.isSome then 1 else 0) ≤ (if s.aboveCat.isSome then (1 : ℕ) else 0) := by
+    rcases ha with h | h <;> simp [h]
+  have e : (if r.complementIsEventive then 1 else 0) ≤
+      (if s.complementIsEventive then (1 : ℕ) else 0) := by
+    cases hr : r.complementIsEventive <;> cases hsc : s.complementIsEventive <;> simp_all
+  have t : (if r.complementIsStative then 1 else 0) ≤
+      (if s.complementIsStative then (1 : ℕ) else 0) := by
+    cases hr : r.complementIsStative <;> cases hsc : s.complementIsStative <;> simp_all
+  obtain ⟨rb, ra, rc, rd⟩ := r
+  obtain ⟨sb, sa, sc, sd⟩ := s
+  have eqb : rb = sb := by cases rb <;> cases sb <;> simp_all; all_goals omega
+  have eqa : ra = sa := by cases ra <;> cases sa <;> simp_all; all_goals omega
+  have eqc : rc = sc := by cases rc <;> cases sc <;> simp_all; all_goals omega
+  have eqd : rd = sd := by cases rd <;> cases sd <;> simp_all
+  subst eqb eqa eqc eqd; rfl
 
 /-- A single alloseme: a labeled meaning available in a particular context. -/
 structure AllosemicEntry (Sem : Type) where
@@ -91,6 +180,64 @@ structure AllosemicHead (Sem : Type) where
 /-- Number of distinct meanings available for this head. -/
 def AllosemicHead.allosemeCount {Sem : Type} (h : AllosemicHead Sem) : Nat :=
   h.entries.length
+
+/-! ### Allosemy on the exponence core
+
+An `AllosemicEntry` is a rule of exponence (`Morphology/Exponence/`): its
+denotation is the exponent, its context's `matches` predicate the
+applicability set. So the very engine that resolves DM's List 2
+(`DM/VocabularyInsertion.lean`) resolves List 3 — LF competition among
+allosemes — with no new machinery. `AllosemicEntry.score` is the
+non-wildcard-field count of the entry's context; `score_reflects` shows
+it reflects the specificity preorder, discharging
+`selectBy_isElsewhereWinner`'s conditional-reflection hypothesis, so
+`selectBy score` is Elsewhere selection (`selectBy_score_isElsewhereWinner`). -/
+
+section Exponence
+
+open Morphology.Exponence
+
+variable {Sem : Type}
+
+/-- An `AllosemicEntry` exposes the shared exponence interface: contexts
+are `SyntacticContext`s, applicability is `matches`, the exponent is the
+denotation. -/
+instance : Exponence (AllosemicEntry Sem) SyntacticContext Sem :=
+  ⟨AllosemicEntry.denotation, fun e => {c | e.context.matches c = true}⟩
+
+instance : Preorder (AllosemicEntry Sem) := Exponence.toPreorder
+
+instance (c : SyntacticContext) :
+    DecidablePred (fun e : AllosemicEntry Sem => Exponence.Applies e c) :=
+  fun e => inferInstanceAs (Decidable (e.context.matches c = true))
+
+/-- The specificity score of an alloseme: the non-wildcard-field count of
+its conditioning context. -/
+def AllosemicEntry.score (e : AllosemicEntry Sem) : Nat := e.context.specificity
+
+/-- The score reflects the specificity preorder: a strictly broader
+alloseme scores strictly lower, so score selection agrees with the
+applicability order. This is the conditional-reflection hypothesis of
+`selectBy_isElsewhereWinner` in its weak form. -/
+theorem score_reflects {r s : AllosemicEntry Sem} (hsr : s ≤ r)
+    (hscore : AllosemicEntry.score s ≤ AllosemicEntry.score r) : r ≤ s := by
+  have hsub : ∀ q, s.context.matches q = true → r.context.matches q = true := hsr
+  have hle : r.context.specificity ≤ s.context.specificity :=
+    SyntacticContext.specificity_le_of_matches_subset hsub
+  have heq : r.context.specificity = s.context.specificity := le_antisymm hle hscore
+  have : r.context = s.context :=
+    SyntacticContext.eq_of_matches_subset_of_specificity_eq hsub heq
+  show ∀ q, r.context.matches q = true → s.context.matches q = true
+  rw [this]; exact fun _ h => h
+
+/-- Score selection over an alloseme vocabulary is Elsewhere selection:
+the winner is `≤`-minimal among the applicable allosemes. -/
+theorem selectBy_score_isElsewhereWinner {v : List (AllosemicEntry Sem)}
+    {c : SyntacticContext} {r : AllosemicEntry Sem}
+    (h : selectBy AllosemicEntry.score v c = some r) : IsElsewhereWinner v c r :=
+  selectBy_isElsewhereWinner (fun _ _ _ _ _ _ hsr hscore => score_reflects hsr hscore) h
+
+end Exponence
 
 -- ════════════════════════════════════════════════════
 -- § 2. v Allosemy (Ch. 3)
@@ -293,18 +440,44 @@ def VoiceAlloseme.assignsTheta : VoiceAlloseme → Bool
   | .engineer => true
   | .expletive => false
 
+/-- The Voice allosemes as a competing exponence vocabulary
+    ([myler-2016] (98a–d)): engineer for a saturated eventive VoiceP
+    complement (most specified), holder for a stative one, expletive
+    elsewhere (the all-wildcard, `⊥`-specificity default). -/
+def voiceVocabulary : List (AllosemicEntry VoiceAlloseme) :=
+  [ { label := "Voice_engineer", denotation := .engineer
+    , context := { belowCat := some .v, complementIsEventive := true } },
+    { label := "Voice_holder", denotation := .holder
+    , context := { complementIsStative := true } },
+    { label := "Voice_expletive", denotation := .expletive
+    , context := {} } ]
+
 /-- Voice alloseme selection from complement properties.
 
-    [myler-2016] table (100): the alloseme is determined by
-    the nature of *have*'s complement and whether the VP is eventive.
-    Engineer is the most specific: it requires a saturated eventive
-    VoiceP as complement. The elsewhere case is expletive (identity). -/
+    [myler-2016] table (100): the alloseme is determined by the nature of
+    *have*'s complement and whether the VP is eventive. This is Elsewhere
+    competition over `voiceVocabulary`, resolved by the shared exponence
+    engine (`Exponence.selectBy` on the non-wildcard-field score): engineer
+    is most specific (saturated eventive VoiceP), expletive is the elsewhere
+    default. -/
 def VoiceAlloseme.fromComplement
     (complementIsEventiveVoiceP : Prop) [Decidable complementIsEventiveVoiceP]
     (complementIsStative : Prop) [Decidable complementIsStative] : VoiceAlloseme :=
-  if complementIsEventiveVoiceP then .engineer
-  else if complementIsStative then .holder
-  else .expletive
+  let q : SyntacticContext :=
+    { belowCat := if complementIsEventiveVoiceP then some .v else none
+      complementIsEventive := decide complementIsEventiveVoiceP
+      complementIsStative := decide complementIsStative }
+  ((Exponence.selectBy AllosemicEntry.score voiceVocabulary q).map
+    AllosemicEntry.denotation).getD .expletive
+
+/-- Eventive-VoiceP complement selects engineer ([myler-2016]). -/
+example : VoiceAlloseme.fromComplement True False = .engineer := by decide
+
+/-- Stative complement (non-eventive) selects holder ([kratzer-1996]). -/
+example : VoiceAlloseme.fromComplement False True = .holder := by decide
+
+/-- Neither condition met selects the elsewhere expletive. -/
+example : VoiceAlloseme.fromComplement False False = .expletive := by decide
 
 /-- Bridge: Voice allosemes to syntactic `Flavor`.
 

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -26,7 +26,7 @@ roots in DM:
    the first categorizer (evidence: multiply derived words like *editorial*,
    *classifieds*, *nationalize*). Voice is the phase head.
 
-## DM Three-Lists Architecture ([marantz-1997], [harley-2014] §5)
+## DM Three-Lists Architecture ([marantz-1997], [harley-2014] §2.4)
 
 - **List 1**: Root terminal nodes — syntactic atoms with opaque indices
 - **List 2**: Vocabulary Items — phonological realizations competing for insertion

--- a/Linglib/Phonology/Autosegmental/Floating.lean
+++ b/Linglib/Phonology/Autosegmental/Floating.lean
@@ -3,9 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Morphology.MorphWord
 import Linglib.Core.CategoryTheory.Monoidal.LabeledTuple
-import Linglib.Phonology.Autosegmental.NonCrossing
 import Linglib.Phonology.Autosegmental.NonCrossing
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Image
@@ -29,10 +27,11 @@ chooses other `T` values.
 ## Main definitions
 
 * `Link` — an autosegmental link `(tier-index, backbone-index)`.
-* `TierSpec T`, `SegSpec S` — tier and backbone elements carrying
-  morpheme membership via `Morphology.WordStructure.Morpheme`
-  (re-exported into this namespace).
-* `FloatingForm S T` — autosegmental form with underlying/surface
+* `TierSpec T M`, `SegSpec S M` — tier and backbone elements carrying
+  membership in a **sponsor** of opaque type `M` — the morpheme
+  identity, kept abstract so the phonology imports nothing from the
+  morphology (Morphology instantiates `M := Morpheme` at its call sites).
+* `FloatingForm S T M` — autosegmental form with underlying/surface
   split.
 * `FloatingForm.IsAlive`, `IsLinked`, `IsFloating`, `IsTautomorphemic`,
   `Crosses` — decidable predicates on tier elements and links.
@@ -65,10 +64,6 @@ link is **tautomorphemic** when its tier element and backbone share a morpheme
 
 namespace Autosegmental
 
--- Re-export `Morpheme` so autosegmental consumers see it unqualified
--- after `open Autosegmental`.
-export Morphology.WordStructure (Morpheme)
-
 /-! ### Tier and link primitives -/
 
 /-- Index into the upper tier. -/
@@ -81,26 +76,29 @@ abbrev SegIdx := ℕ
     backbone-position `snd`. -/
 abbrev Link := TierIdx × SegIdx
 
-/-- An autosegmental tier element: a value of type `T` plus morpheme
-    membership. Generalises [goldsmith-1976]'s tonal-tier element
-    to arbitrary tier-value types (tones, segments, features). -/
-structure TierSpec (T : Type*) where
+/-- An autosegmental tier element: a value of type `T` plus its
+    sponsoring morpheme identity `M`. Generalises [goldsmith-1976]'s
+    tonal-tier element to arbitrary tier-value types (tones, segments,
+    features) and an opaque sponsor. -/
+structure TierSpec (T M : Type*) where
   /-- The tier value (tone, segment, feature, ...). -/
   value : T
-  morpheme : Morpheme
+  /-- The sponsoring morpheme identity (opaque). -/
+  morpheme : M
   deriving DecidableEq, Repr
 
-/-- A segmental backbone element: segment plus morpheme membership.
-    Generic over the segment type `S`. -/
-structure SegSpec (S : Type*) where
+/-- A segmental backbone element: segment plus its sponsoring morpheme
+    identity. Generic over the segment type `S` and sponsor type `M`. -/
+structure SegSpec (S M : Type*) where
   seg : S
-  morpheme : Morpheme
+  /-- The sponsoring morpheme identity (opaque). -/
+  morpheme : M
   deriving DecidableEq, Repr
 
 /-! ### `FloatingForm`
 
-`FloatingForm S T` is an autosegmental form with segmental backbone
-of type `S` and tier-value type `T`. Tonal use chooses `T := TRN`;
+`FloatingForm S T M` is an autosegmental form with segmental backbone
+of type `S`, tier-value type `T`, and sponsor type `M`. Tonal use chooses `T := TRN`;
 non-tonal autosegmental work chooses other `T` values
 ([laoide-kemp-2026], [lieber-1983]). The OT-style
 bookkeeping (`deletedTier`, `surfaceLinks` vs underlying `links`) is
@@ -110,11 +108,11 @@ language-independent.
 /-- An autosegmental form: an underlying two-tier presentation (tones over
     segments, with association links) plus OT-style surface bookkeeping —
     `deletedTier` and `surfaceLinks` track the surface state separately. -/
-structure FloatingForm (S T : Type*) where
+structure FloatingForm (S T M : Type*) where
   /-- The tonal tier (underlying). -/
-  upper : LabeledTuple (TierSpec T)
+  upper : LabeledTuple (TierSpec T M)
   /-- The segmental backbone (underlying). -/
-  lower : LabeledTuple (SegSpec S)
+  lower : LabeledTuple (SegSpec S M)
   /-- The underlying association links. -/
   links : Finset Link
   /-- SURFACE deletion set on the upper tier (current state). -/
@@ -127,13 +125,13 @@ structure FloatingForm (S T : Type*) where
 
 /-- Hides the `Finset` fields (mathlib's `Finset.Repr` is `unsafe`) and
     prints only segments and underlying tier elements; debug-only. -/
-instance {S T : Type*} [Repr S] [Repr T] : Repr (FloatingForm S T) where
+instance {S T M : Type*} [Repr S] [Repr T] [Repr M] : Repr (FloatingForm S T M) where
   reprPrec f _ :=
     f!"⟨lower={repr (f.lower.toList.map SegSpec.seg)}, upper={repr f.upper.toList}⟩"
 
 namespace FloatingForm
 
-variable {S T : Type*} [DecidableEq S] [DecidableEq T] (f : FloatingForm S T)
+variable {S T M : Type*} [DecidableEq S] [DecidableEq T] [DecidableEq M] (f : FloatingForm S T M)
 
 /-! ### Surface graph (derived view) -/
 
@@ -145,8 +143,8 @@ abbrev SurfaceIsPlanar : Prop := IsNonCrossing f.surfaceLinks
 
 /-- Construct an input form: surface state mirrors underlying state,
     nothing deleted, all underlying links intact. -/
-def mkInput (lower : List (SegSpec S)) (upper : List (TierSpec T))
-    (links : Finset Link) : FloatingForm S T :=
+def mkInput (lower : List (SegSpec S M)) (upper : List (TierSpec T M))
+    (links : Finset Link) : FloatingForm S T M :=
   { lower := .ofList lower
     upper := .ofList upper
     links := links
@@ -156,13 +154,13 @@ def mkInput (lower : List (SegSpec S)) (upper : List (TierSpec T))
 /-! ### Morphemic structure -/
 
 /-- The morpheme of the `k`-th upper-tier element, or `none` if out of range. -/
-def upperMorpheme? (k : TierIdx) : Option Morpheme := (f.upper.get? (k)).map TierSpec.morpheme
+def upperMorpheme? (k : TierIdx) : Option M := (f.upper.get? (k)).map TierSpec.morpheme
 
 /-- The morpheme of the `i`-th lower-tier element, or `none` if out of range. -/
-def lowerMorpheme? (i : SegIdx) : Option Morpheme := (f.lower.get? (i)).map SegSpec.morpheme
+def lowerMorpheme? (i : SegIdx) : Option M := (f.lower.get? (i)).map SegSpec.morpheme
 
 /-- Every morpheme occurring on either tier. -/
-def morphemes : Finset Morpheme :=
+def morphemes : Finset M :=
   (f.lower.toList.map SegSpec.morpheme).toFinset ∪ (f.upper.toList.map TierSpec.morpheme).toFinset
 
 /-! ### Predicates on tier elements and links -/
@@ -212,7 +210,7 @@ instance [DecidableEq S] [DecidableEq T] : Decidable f.InBounds :=
 
 /-- Concatenation of underlying input states ([jardine-heinz-2015]): tier
     juxtaposition with index-shifted links, surface mirroring underlying. -/
-def hconcat (g : FloatingForm S T) : FloatingForm S T :=
+def hconcat (g : FloatingForm S T M) : FloatingForm S T M :=
   let ls := f.links ∪ g.links.image (shiftLink f.upper.len f.lower.len)
   { upper := f.upper.concat g.upper
     lower := f.lower.concat g.lower
@@ -220,37 +218,37 @@ def hconcat (g : FloatingForm S T) : FloatingForm S T :=
     deletedTier := ∅
     surfaceLinks := ls }
 
-@[simp] theorem hconcat_upper (g : FloatingForm S T) :
+@[simp] theorem hconcat_upper (g : FloatingForm S T M) :
     (f.hconcat g).upper = f.upper.concat g.upper := rfl
 
-@[simp] theorem hconcat_lower (g : FloatingForm S T) :
+@[simp] theorem hconcat_lower (g : FloatingForm S T M) :
     (f.hconcat g).lower = f.lower.concat g.lower := rfl
 
-@[simp] theorem hconcat_links (g : FloatingForm S T) :
+@[simp] theorem hconcat_links (g : FloatingForm S T M) :
     (f.hconcat g).links = f.links ∪ g.links.image (shiftLink f.upper.len f.lower.len) := rfl
 
-@[simp] theorem hconcat_surfaceLinks (g : FloatingForm S T) :
+@[simp] theorem hconcat_surfaceLinks (g : FloatingForm S T M) :
     (f.hconcat g).surfaceLinks
       = f.links ∪ g.links.image (shiftLink f.upper.len f.lower.len) := rfl
 
-@[simp] theorem hconcat_deletedTier (g : FloatingForm S T) :
+@[simp] theorem hconcat_deletedTier (g : FloatingForm S T M) :
     (f.hconcat g).deletedTier = ∅ := rfl
 
 /-! ### Atomic GEN operations -/
 
 /-- Delete the underlying upper-tier element at index `k`. Cascades to remove
     any surface link referencing it. -/
-def deleteTierElem (k : TierIdx) : FloatingForm S T :=
+def deleteTierElem (k : TierIdx) : FloatingForm S T M :=
   { f with
     deletedTier := insert k f.deletedTier
     surfaceLinks := f.surfaceLinks.filter (λ l => l.fst ≠ k) }
 
 /-- Insert a surface link `(k, i)`. -/
-def insertLink (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
+def insertLink (k : TierIdx) (i : SegIdx) : FloatingForm S T M :=
   { f with surfaceLinks := insert (k, i) f.surfaceLinks }
 
 /-- Delete the surface link `(k, i)`. -/
-def deleteLink (k : TierIdx) (i : SegIdx) : FloatingForm S T :=
+def deleteLink (k : TierIdx) (i : SegIdx) : FloatingForm S T M :=
   { f with surfaceLinks := f.surfaceLinks.erase (k, i) }
 
 /-! ### Well-formedness: no crossing lines -/
@@ -271,7 +269,7 @@ abbrev Crosses (k : TierIdx) (i : SegIdx) : Prop :=
     insert-and-associate and shift). The no-crossing filter ([goldsmith-1976])
     enforces well-formedness: without it a floating tone could dock across an
     intervening linked tone. -/
-def gen : Finset (FloatingForm S T) :=
+def gen : Finset (FloatingForm S T M) :=
   let aliveIdxs := (Finset.range f.upper.len).filter (λ k => f.IsAlive k)
   let floatIdxs := aliveIdxs.filter (λ k => ¬ f.IsLinked k)
   let segIdxs := Finset.range f.lower.len
@@ -326,7 +324,7 @@ def aliveTierIdxs : List TierIdx :=
 
 /-- Lower-tier (backbone) indices belonging to morpheme `m`, in order.
     Out-of-range indices are excluded by construction. -/
-def segsOfMorpheme (m : Morpheme) : List SegIdx :=
+def segsOfMorpheme (m : M) : List SegIdx :=
   (List.range f.lower.len).filter (λ i => f.lowerMorpheme? i = some m)
 
 /-! ### Position counts -/
@@ -341,11 +339,11 @@ def countLower (p : SegIdx → Prop) [DecidablePred p] : ℕ :=
   (List.range f.lower.len).countP (λ i => decide (p i))
 
 /-- The empty input. -/
-def emptyInput : FloatingForm S T :=
+def emptyInput : FloatingForm S T M :=
   { upper := .empty, lower := .empty, links := ∅, deletedTier := ∅, surfaceLinks := ∅ }
 
 /-- Left-to-right concatenation of a list of input states. -/
-def concatInputs (gs : List (FloatingForm S T)) : FloatingForm S T :=
+def concatInputs (gs : List (FloatingForm S T M)) : FloatingForm S T M :=
   gs.foldr hconcat emptyInput
 
 end FloatingForm

--- a/Linglib/Phonology/Autosegmental/Melody.lean
+++ b/Linglib/Phonology/Autosegmental/Melody.lean
@@ -32,16 +32,16 @@ term, [bye-svenonius-2012]'s programmatic statement; survey:
 
 namespace Autosegmental
 
-variable {S T : Type*}
+variable {S T M : Type*}
 
 namespace FloatingForm
 
-variable (m : Morpheme) (tones : List T) (tbus : List S) (links : Finset Link)
+variable (m : M) (tones : List T) (tbus : List S) (links : Finset Link)
 
 /-- One morpheme's underlying autosegmental contribution ([rolle-2018]
     §2.1 Def 1): `tones` over `tbus`, every element sponsored by `m`,
     pre-linked by `links` in melody-local coordinates; an input state. -/
-def melody : FloatingForm S T :=
+def melody : FloatingForm S T M :=
   mkInput (tbus.map fun s => { seg := s, morpheme := m })
     (tones.map fun t => { value := t, morpheme := m }) links
 
@@ -72,8 +72,8 @@ end FloatingForm
 /-- **Consistency of Exponence** ([zimmermann-2024] §4): GEN never alters
     morphemic affiliation — every one-step candidate carries its input's
     sponsors on both tiers. -/
-theorem FloatingForm.gen_preserves_morphemes [DecidableEq S] [DecidableEq T]
-    (f : FloatingForm S T) : ∀ g ∈ f.gen,
+theorem FloatingForm.gen_preserves_morphemes [DecidableEq S] [DecidableEq T] [DecidableEq M]
+    (f : FloatingForm S T M) : ∀ g ∈ f.gen,
     g.upperMorpheme? = f.upperMorpheme? ∧ g.lowerMorpheme? = f.lowerMorpheme? := by
   intro g hg
   simp only [FloatingForm.gen, Finset.mem_insert, Finset.mem_union, Finset.mem_image,

--- a/Linglib/Phonology/Tone/Constraints.lean
+++ b/Linglib/Phonology/Tone/Constraints.lean
@@ -10,9 +10,9 @@ import Linglib.Phonology.Constraints.Defs
 /-!
 # Tonal constraints
 
-OT/HS constraint constructors over the `FloatingForm S TRN` autosegmental
+OT/HS constraint constructors over the `FloatingForm S TRN M` autosegmental
 representation (`Phonology/Autosegmental/Floating.lean`), generic over the segment
-type `S`. Each is a canonical `Constraints.Constraint` — a scalar `· → ℕ` violation
+type `S` and the opaque sponsor type `M`. Each is a canonical `Constraints.Constraint` — a scalar `· → ℕ` violation
 count. Equation numbers below are [mcpherson-lamont-2026]'s.
 
 ## Main definitions
@@ -52,7 +52,7 @@ open Autosegmental
 open Tone (TRN)
 open Constraints
 
-variable {S : Type*} [DecidableEq S] (f : FloatingForm S TRN)
+variable {S M : Type*} [DecidableEq S] [DecidableEq M] (f : FloatingForm S TRN M)
 
 /-! ### Tone-value predicate
 
@@ -72,30 +72,30 @@ abbrev ToneHasValue (k : TierIdx) (t : TRN) : Prop :=
     directional EVAL is recovered as the canonical lex order over this block
     ([lamont-2022b]). `k` is the underlying tone count `f.upper.len`, invariant under
     GEN, so it is a fixed literal per tableau. -/
-def starFloatBlock (k : ℕ) : List (Constraint (FloatingForm S TRN)) :=
+def starFloatBlock (k : ℕ) : List (Constraint (FloatingForm S TRN M)) :=
   (List.range k).map (fun i => fun g => if g.IsFloating i then 1 else 0)
 
 /-- `*FLOAT^←` (right-to-left): `starFloatBlock` laid out in reverse position order. -/
-def starFloatBlockRev (k : ℕ) : List (Constraint (FloatingForm S TRN)) :=
+def starFloatBlockRev (k : ℕ) : List (Constraint (FloatingForm S TRN M)) :=
   (starFloatBlock k).reverse
 
 /-- `*FLOAT (count)`: the parallel/count variant — the total floating-tone count as a
     single scalar constraint (the degree collapse of `starFloatBlock`). -/
-def starFloatCount : Constraint (FloatingForm S TRN) :=
+def starFloatCount : Constraint (FloatingForm S TRN M) :=
   fun f => f.floatIndicator.sum
 
 /-! ### *TAUTDOCK -/
 
 /-- `*TAUTDOCK` (paper, eq. 15, after [wolf-2007]): one violation
     per GEN-inserted tautomorphemic surface link. -/
-def starTautDock : Constraint (FloatingForm S TRN) :=
+def starTautDock : Constraint (FloatingForm S TRN M) :=
   fun f => (f.surfaceLinks.filter (fun l => f.IsInsertedLink l ∧ f.IsTautomorphemic l)).card
 
 /-! ### *CROWD (per-morpheme tone count) -/
 
 /-- The tone indices counting toward morpheme `m`'s tonal mass: surviving
     underlying tones of `m`, plus tones surface-linked to TBUs of `m`. -/
-def tonesForMorpheme (m : Morpheme) : Finset TierIdx :=
+def tonesForMorpheme (m : M) : Finset TierIdx :=
   let ownAlive := (Finset.range f.upper.len).filter fun k =>
     f.IsAlive k ∧ f.upperMorpheme? k = some m
   let docked := (f.surfaceLinks.filter fun l => f.lowerMorpheme? l.snd = some m).image Prod.fst
@@ -104,7 +104,7 @@ def tonesForMorpheme (m : Morpheme) : Finset TierIdx :=
 /-- `*CROWD` (paper eq. 5): one violation per morpheme with more than `threshold`
     tones (default 2), counting its surviving underlying tones plus tones docked onto
     its TBUs from other morphemes. -/
-def starCrowd (threshold : Nat := 2) : Constraint (FloatingForm S TRN) :=
+def starCrowd (threshold : Nat := 2) : Constraint (FloatingForm S TRN M) :=
   fun f => (f.morphemes.filter (fun m => threshold < (tonesForMorpheme f m).card)).card
 
 /-! ### *FALL (falling contours on multi-linked TBUs) -/
@@ -129,7 +129,7 @@ instance decidableHasFall : (ts : List TRN) → Decidable (HasFall ts)
 
 /-- `*FALL` (paper eq. 23): one violation per syllable with a falling contour
     (HM, HL, ML). -/
-def starFall : Constraint (FloatingForm S TRN) :=
+def starFall : Constraint (FloatingForm S TRN M) :=
   fun f => f.countLower (fun i => HasFall (f.tierValues i))
 
 /-! ### *M<L (M-then-L adjacency on the tier) -/
@@ -137,7 +137,7 @@ def starFall : Constraint (FloatingForm S TRN) :=
 /-- `*M<L` (paper eq. 29): one violation per M tone immediately preceding an L on the
     tonal tier — adjacency measured over the surviving (non-deleted) tones in `ulTier`
     order (deletions skip positions). -/
-def starMlessL : Constraint (FloatingForm S TRN) :=
+def starMlessL : Constraint (FloatingForm S TRN M) :=
   fun f =>
     let aliveValues : List TRN :=
       f.aliveTierIdxs.filterMap (fun k => (f.upper.get? k).map TierSpec.value)
@@ -147,32 +147,32 @@ def starMlessL : Constraint (FloatingForm S TRN) :=
 
 /-- `HAVETONE` (paper, eq. 17): one violation per syllable not
     associated to any tone. -/
-def haveTone : Constraint (FloatingForm S TRN) :=
+def haveTone : Constraint (FloatingForm S TRN M) :=
   fun f => f.countLower (fun i => (f.linksTo i).isEmpty = true)
 
 /-! ### Faithfulness — Generic over Tone Value -/
 
 /-- `MAX(T)` (paper, eq. 7c): one violation per underlying tone of
     value `t` deleted by GEN. -/
-def maxTone (t : TRN) : Constraint (FloatingForm S TRN) :=
+def maxTone (t : TRN) : Constraint (FloatingForm S TRN M) :=
   fun f => f.countUpper (fun k => f.IsDeleted k ∧ ToneHasValue f k t)
 
 /-- `DEP(link)/T` (paper, eq. 7a): one violation per surface link
     inserted by GEN whose linked tone has value `t`. -/
-def depLinkTone (t : TRN) : Constraint (FloatingForm S TRN) :=
+def depLinkTone (t : TRN) : Constraint (FloatingForm S TRN M) :=
   fun f => (f.surfaceLinks.filter (fun l => f.IsInsertedLink l ∧ ToneHasValue f l.fst t)).card
 
 /-- `MAX(link)/T` (paper, eq. 7b): one violation per underlying link of
     value `t` deleted by GEN. -/
-def maxLinkTone (t : TRN) : Constraint (FloatingForm S TRN) :=
+def maxLinkTone (t : TRN) : Constraint (FloatingForm S TRN M) :=
   fun f => (f.links.filter (fun l => f.IsDeletedLink l ∧ ToneHasValue f l.fst t)).card
 
 /-- `INTEGRITY` ([mccarthy-prince-1995]; [akinbo-fwangwar-2026]): no input tone has
     multiple output correspondents — here, alive `ulTier` entries sharing tone value `t`
     and morpheme `m`. Spreading (one multi-linked entry) → 0; copying (`n` such entries)
     → `n - 1` violations. -/
-def integrityTone (m : Morpheme) (t : TRN) :
-    Constraint (FloatingForm S TRN) :=
+def integrityTone (m : M) (t : TRN) :
+    Constraint (FloatingForm S TRN M) :=
   fun f => f.countUpper (fun k => f.IsAlive k ∧ f.upperMorpheme? k = some m ∧ ToneHasValue f k t) - 1
 
 end Tone

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -1,6 +1,7 @@
 import Linglib.Fragments.Mwaghavul.Basic
 import Linglib.Pragmatics.Expressives.Basic
 import Linglib.Morphology.DM.Categorizer
+import Linglib.Morphology.MorphWord
 import Linglib.Studies.Rolle2018
 import Linglib.Phonology.Autosegmental.Floating
 import Linglib.Phonology.OptimalityTheory.Cophonology
@@ -41,7 +42,7 @@ grammatical tones targeting ideophones in Mwaghavul. *Natural Language
 
 ## Substrate
 
-The OT analysis is built on `Autosegmental.FloatingForm Syl TRN`
+The OT analysis is built on `Autosegmental.FloatingForm Syl TRN Morpheme`
 (Goldsmith-style autosegmental representation; built originally for
 [mcpherson-lamont-2026]). Each `ulTier` entry is one
 autosegment; `surfaceLinks` records associations between tier and
@@ -73,6 +74,7 @@ namespace AkinboFwangwar2026
 open OptimalityTheory
 open Constraints
 open Autosegmental
+open Morphology.WordStructure (Morpheme)
 open Tone (TRN)
 open Tone (integrityTone)
 open Mwaghavul
@@ -82,7 +84,7 @@ open Mwaghavul
 -- ============================================================================
 
 /-- The Mwaghavul-instantiated autosegmental form. -/
-abbrev MwaghavulForm := FloatingForm Syl TRN
+abbrev MwaghavulForm := FloatingForm Syl TRN Morpheme
 
 /-- The ideophone root (wùlàʃ in Tableau 24, háŋláyáp in Tableau 25).
     Both single-root tableaux share this morpheme. -/
@@ -100,28 +102,28 @@ def rootRedMorph : Morpheme := { morph := .root "root-red" }
 def rootBaseMorph : Morpheme := { morph := .root "root-base" }
 
 /-- Wrap a Mwaghavul syllable as a TBU of the (single) ideophone root. -/
-def rootSeg (s : Syl) : SegSpec Syl := { seg := s, morpheme := rootMorph }
+def rootSeg (s : Syl) : SegSpec Syl Morpheme := { seg := s, morpheme := rootMorph }
 
 /-- Wrap a syllable as a TBU of the reduplicant (Tableau 26). -/
-def redSeg (s : Syl) : SegSpec Syl := { seg := s, morpheme := rootRedMorph }
+def redSeg (s : Syl) : SegSpec Syl Morpheme := { seg := s, morpheme := rootRedMorph }
 
 /-- Wrap a syllable as a TBU of the base (Tableau 26). -/
-def baseSeg (s : Syl) : SegSpec Syl := { seg := s, morpheme := rootBaseMorph }
+def baseSeg (s : Syl) : SegSpec Syl Morpheme := { seg := s, morpheme := rootBaseMorph }
 
 /-- L tone of the (single) ideophone root. -/
-def rootL : TierSpec TRN := { value := TRN.L, morpheme := rootMorph }
+def rootL : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootMorph }
 
 /-- M tone of the verbaliser. -/
-def vbzM : TierSpec TRN := { value := TRN.M, morpheme := vbzMorph }
+def vbzM : TierSpec TRN Morpheme := { value := TRN.M, morpheme := vbzMorph }
 
 /-- H tone of the verbaliser. -/
-def vbzH : TierSpec TRN := { value := TRN.H, morpheme := vbzMorph }
+def vbzH : TierSpec TRN Morpheme := { value := TRN.H, morpheme := vbzMorph }
 
 /-- L tone of the reduplicant root (Tableau 26). -/
-def lRed : TierSpec TRN := { value := TRN.L, morpheme := rootRedMorph }
+def lRed : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootRedMorph }
 
 /-- L tone of the base root (Tableau 26). -/
-def lBase : TierSpec TRN := { value := TRN.L, morpheme := rootBaseMorph }
+def lBase : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootBaseMorph }
 
 -- ============================================================================
 -- §2: Constraints over `MwaghavulForm`

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Morphology.DM.VocabularyInsertion
+import Linglib.Morphology.DM.Allosemy
+
+/-!
+# Harley (2014): roots as abstract indices
+[harley-2014] [marantz-1997] [halle-marantz-1993] [bobaljik-2008]
+
+[harley-2014] "On the identity of roots" argues that a root terminal
+(DM's List 1) is neither phonologically nor semantically individuated: it
+is an **abstract index**, a syntactic atom identified only by its position
+in the vocabulary, with its form supplied by List 2 (Vocabulary Insertion)
+and its meaning by List 3 (the Encyclopedia). The argument is negative on
+both flanks:
+
+* **Phonological identification fails** (§2.1–2.2). Hiaki has suppletive
+  roots — one root, two phonologically unrelated forms competing under the
+  Elsewhere Condition. If a root were identified by its phonology (√kæt),
+  root suppletion would be incoherent.
+* **Semantic identification fails** (§2.3–2.4). Cran-morphs (*cahoot*) have
+  a meaning only inside one licensing frame and none elsewhere, so a root
+  cannot be a Fodorian atomic concept either.
+
+What survives is the **index**: `RootIndex := ℕ` here, a `√322`-style
+meaningless tag. Distinctness of roots is then true by typing — distinct
+indices are distinct roots — which is exactly what lets `√tenne` block
+`√vuite` at *its* index without blocking a different intransitive root
+(§2.1, Marantz's thought experiment).
+
+## This file
+
+* `vocabulary` — the Hiaki suppletive List-2 entries ([harley-2014] (3),
+  (26), (27)), keyed by `RootIndex`, resolved by the shared DM engine
+  `Morphology.DM.VI.vocabularyInsert`.
+* Selection theorems — the engine picks the attested form per context.
+* `suppletion_ignores_ergative` — the §3.3 ergative-absolutive
+  generalization: suppletion tracks the **internal (absolutive)**
+  argument's number and is blind to the external (ergative) argument.
+* `run_index_two_forms` — one index, two exponents: phonological
+  individuation would split the root (§2.1–2.2).
+* `cahoot_no_elsewhere` — the cran-morph has an interpretation only in its
+  licensing context and none elsewhere (§2.3), stated on the LF side with
+  the allosemy exponence engine (`selectBy`, `no Elsewhere` = `none`).
+
+## The `vuite`/`tenne` Elsewhere direction (fn. 16)
+
+The paper's first pass (7) writes the plural `tenne` as the *conditioned*
+form (`/ [DP-pl]`) and `vuite` as Elsewhere. Footnote 16 corrects this: in
+the Hiaki impersonal passive the sole argument is syntactically absent and
+so number-unspecified, and the root then surfaces as `tenne`, **not** as
+singular `vuite`. So `tenne` is the true Elsewhere form and `vuite` is
+conditioned by a singular internal argument. We encode the considered (fn.
+16) analysis: `vuite / [absolutive-sg]`, `tenne` elsewhere (plural *and*
+number-unspecified).
+-/
+
+namespace Harley2014
+
+open Morphology.DM.VI
+open Morphology.DM.Allosemy (SyntacticContext AllosemicEntry)
+open Morphology.Exponence (selectBy realize)
+
+/-! ### List 1: roots as abstract indices -/
+
+/-- A List-1 root index: a meaningless `√`-style tag ([harley-2014] §2.4).
+Individuation is by index alone — distinct indices, distinct roots — so
+the phonological form (List 2) and the interpretation (List 3) are free to
+vary without identifying the root. -/
+abbrev RootIndex := ℕ
+
+/-- `√322`: the Hiaki root realized `vuite`/`tenne` 'run' ([harley-2014] (14)). -/
+def runRoot : RootIndex := 322
+/-- `√401`: the root realized `weye`/`kaate` 'walk' ([harley-2014] (26)). -/
+def walkRoot : RootIndex := 401
+/-- `√402`: the root realized `mea`/`sua` 'kill' ([harley-2014] (27)). -/
+def killRoot : RootIndex := 402
+/-- `√500`: a non-suppletive intransitive root ('sing', *bwiika*), used to
+show the suppletive rules do not block insertion at other indices. -/
+def singRoot : RootIndex := 500
+
+/-! ### The conditioning context
+
+Suppletion is conditioned by number, but — crucially for §3.3 — by the
+number of the **absolutive** (internal) argument: the sole argument of an
+intransitive, the object of a transitive. The ergative (external) argument
+never conditions it. -/
+
+/-- Grammatical number of an argument. `unspecified` is the number-neutral
+case of [harley-2014] fn. 16 (the impersonal passive), which surfaces as
+the Elsewhere form. -/
+inductive Number where
+  | sg
+  | pl
+  | unspecified
+  deriving DecidableEq, Repr
+
+/-- The morphosyntactic context a suppletive root is spelled out in: the
+number of its absolutive (internal) argument, plus — for a transitive —
+the number of its ergative (external) argument, which is never consulted. -/
+structure Ctx where
+  /-- Number of the absolutive (internal) argument — the conditioning one. -/
+  absNumber : Number
+  /-- Number of the ergative (external) argument, `none` if intransitive.
+      Never conditions suppletion (§3.3). -/
+  ergNumber : Option Number := none
+  deriving DecidableEq, Repr
+
+/-! ### List 2: the suppletive Vocabulary Items
+
+Each root index has a singular-conditioned entry (specificity 1) and an
+Elsewhere entry (specificity 0); the DM engine's Elsewhere resolution
+(`vocabularyInsert`) selects the more specific matching rule. -/
+
+/-- A singular-conditioned suppletive entry for `idx`. -/
+private def sgEntry (form : String) (idx : RootIndex) : VocabItem Ctx RootIndex where
+  exponent := form
+  contextMatch := fun c => decide (c.absNumber = Number.sg)
+  rootMatch := some (· == idx)
+  specificity := 1
+
+/-- An Elsewhere suppletive entry for `idx` (matches any context). -/
+private def elseEntry (form : String) (idx : RootIndex) : VocabItem Ctx RootIndex where
+  exponent := form
+  contextMatch := fun _ => true
+  rootMatch := some (· == idx)
+  specificity := 0
+
+/-- The Hiaki suppletive vocabulary ([harley-2014] (3), (26), (27)): three
+suppletive roots, each an sg-conditioned form competing with an Elsewhere
+form, all keyed by `RootIndex`. -/
+def vocabulary : List (VocabItem Ctx RootIndex) :=
+  [ sgEntry "vuite" runRoot,  elseEntry "tenne" runRoot,
+    sgEntry "weye"  walkRoot, elseEntry "kaate" walkRoot,
+    sgEntry "mea"   killRoot, elseEntry "sua"   killRoot ]
+
+instance (c : Ctx × RootIndex) :
+    DecidablePred (fun vi : VocabItem Ctx RootIndex => Morphology.Exponence.Applies vi c) :=
+  fun vi => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
+
+/-- Spell out root `idx` in context `ctx` by Elsewhere competition over
+`vocabulary`, resolved by the shared exponence engine (`Exponence.realize`
+on the `VocabItem` specificity score) — the same selection engine as the
+allosemy LF side below. -/
+def insert (ctx : Ctx) (idx : RootIndex) : Option String :=
+  realize VocabItem.specificity vocabulary (ctx, idx)
+
+/-! ### Selection: the engine picks the attested form -/
+
+/-- Singular subject → `vuite` ([harley-2014] (1a)). -/
+theorem run_sg : insert ⟨.sg, none⟩ runRoot = some "vuite" := by decide
+
+/-- Plural subject → `tenne` ([harley-2014] (1b)). -/
+theorem run_pl : insert ⟨.pl, none⟩ runRoot = some "tenne" := by decide
+
+/-- Number-unspecified (impersonal passive) → `tenne`, the true Elsewhere
+form ([harley-2014] fn. 16): the diagnostic that `tenne`, not `vuite`, is
+Elsewhere. -/
+theorem run_impersonal : insert ⟨.unspecified, none⟩ runRoot = some "tenne" := by decide
+
+/-- Singular subject → `weye` ([harley-2014] (26a)). -/
+theorem walk_sg : insert ⟨.sg, none⟩ walkRoot = some "weye" := by decide
+
+/-- Plural subject → `kaate` ([harley-2014] (26b)). -/
+theorem walk_pl : insert ⟨.pl, none⟩ walkRoot = some "kaate" := by decide
+
+/-- Singular object → `mea`, regardless of the (plural) subject
+([harley-2014] (27a)). -/
+theorem kill_sgObj : insert ⟨.sg, some .pl⟩ killRoot = some "mea" := by decide
+
+/-- Plural object → `sua`, regardless of the (singular) subject
+([harley-2014] (27b)). -/
+theorem kill_plObj : insert ⟨.pl, some .sg⟩ killRoot = some "sua" := by decide
+
+/-! ### §3.3 The ergative-absolutive conditioning generalization -/
+
+/-- **Suppletion tracks the absolutive argument** ([harley-2014] §3.3): the
+selected form depends only on the internal (absolutive) argument's number;
+the external (ergative) argument's number is never consulted. This is the
+ergative-absolutive distribution of suppletive agreement — the challenge to
+[bobaljik-2008]'s marked-case generalization the paper raises. -/
+theorem suppletion_ignores_ergative (n : Number) (e e' : Option Number) (i : RootIndex) :
+    insert ⟨n, e⟩ i = insert ⟨n, e'⟩ i := rfl
+
+/-! ### §2.1 Individuation is not phonological -/
+
+/-- **One index, two forms.** The single root `√322` is realized by two
+phonologically unrelated exponents (`vuite` vs `tenne`). Any identification
+of the root by its phonological form would split it in two, making
+suppletion incoherent ([harley-2014] §2.2, contra Borer 2009). -/
+theorem run_index_two_forms :
+    insert ⟨.sg, none⟩ runRoot ≠ insert ⟨.pl, none⟩ runRoot := by decide
+
+/-- **The suppletive rule is index-local** ([harley-2014] §2.1, Marantz's
+thought experiment): `tenne` competes only at `√322`, so it does not block
+insertion at a different intransitive root — a non-suppletive `√500`
+(*bwiika* 'sing') gets no exponent from this vocabulary. This is why List-1
+roots must be individuated (as indices) before spell-out. -/
+theorem suppletive_rule_index_local (n : Number) :
+    insert ⟨n, none⟩ singRoot = none := by
+  cases n <;> decide
+
+/-! ### §2.3 Individuation is not semantic: the cran-morph on the LF side
+
+The mirror argument on List 3. A cran-morph (*cahoot*) has an interpretation
+only inside its licensing frame (`in [ [ √ n ] -PL ]`) and — unlike an
+ordinary root — **no Elsewhere interpretation** ([harley-2014] (16)). We
+state this with the allosemy exponence engine (`AllosemicEntry` as an
+`Morphology.Exponence` instance): `selectBy` returns a meaning in the
+licensed context and `none` outside it. -/
+
+/-- `√548` *cahoot*: a single LF entry, licensed only under `n` (the idiom
+frame), with no Elsewhere alloseme ([harley-2014] (16)). -/
+def cahootLF : List (AllosemicEntry String) :=
+  [ { label := "cahoot", denotation := "a conspiracy", context := { belowCat := some .n } } ]
+
+/-- In its licensing context the cran-morph is interpreted. -/
+theorem cahoot_licensed :
+    (selectBy AllosemicEntry.score cahootLF { belowCat := some .n }).isSome = true := by decide
+
+/-- **No Elsewhere interpretation** ([harley-2014] (16)): outside the
+licensing frame the cran-morph receives no meaning at all — the LF engine
+returns `none`, the semantic analogue of a phonological gap. A Fodorian
+atomic concept could not behave this way, so the root is not semantically
+individuated. -/
+theorem cahoot_no_elsewhere :
+    (selectBy AllosemicEntry.score cahootLF { }).isNone = true := by decide
+
+/-! ### The surviving individuation: the index -/
+
+/-- Individuation by index is true by typing: distinct suppletive roots are
+distinct `RootIndex` values ([harley-2014] §2.4). Neither the shared
+Elsewhere-form shape nor the shared interpretation-frame identifies them. -/
+example : runRoot ≠ walkRoot ∧ walkRoot ≠ killRoot ∧ runRoot ≠ killRoot := by decide
+
+end Harley2014

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.Floating
 import Linglib.Phonology.Autosegmental.Junction
+import Linglib.Morphology.MorphWord
 
 /-!
 # Laoide-Kemp (2026): Irish preverbal *d'* as a floating segment
@@ -111,6 +112,7 @@ is modelled as a genuine floating melodic segment (`Segment.dPrime`).
 namespace LaoideKemp2026
 
 open Autosegmental
+open Morphology.WordStructure (Morpheme)
 
 /-! ## §1 Segment inventory and CV skeleton
 
@@ -185,7 +187,7 @@ private def mImpers : Morpheme := { morph := .pref "", gloss := "PST.IMPERS" }
 
 /-! ## §3 Verb stems as `FloatingForm`s
 
-A verb stem is a `FloatingForm CVKind Segment`: the **upper** tier is
+A verb stem is a `FloatingForm CVKind Segment Morpheme`: the **upper** tier is
 the segmental melody (`Segment`), the **lower** tier is the CV
 skeleton (`CVKind`), and association lines `(k, j)` link melody
 element `k` to skeleton position `j`. The surface state mirrors the
@@ -193,23 +195,23 @@ underlying state on input (`FloatingForm.mkInput`).
 -/
 
 /-- A melodic tier element bearing morpheme `m`. -/
-private def mel (s : Segment) (m : Morpheme) : TierSpec Segment := ⟨s, m⟩
+private def mel (s : Segment) (m : Morpheme) : TierSpec Segment Morpheme := ⟨s, m⟩
 
 /-- A skeletal backbone slot bearing morpheme `m`. -/
-private def slot (c : CVKind) (m : Morpheme) : SegSpec CVKind := ⟨c, m⟩
+private def slot (c : CVKind) (m : Morpheme) : SegSpec CVKind Morpheme := ⟨c, m⟩
 
 /-- Build a single-morpheme verb stem from its CV skeleton, melody,
     and association lines. -/
 private def stemForm (name : String) (skeleton : List CVKind)
     (melody : List Segment) (links : Finset (Nat × Nat)) :
-    FloatingForm CVKind Segment :=
+    FloatingForm CVKind Segment Morpheme :=
   let m := mStem name
   FloatingForm.mkInput (skeleton.map (slot · m)) (melody.map (mel · m)) links
 
 /-- The verb `bog` 'soft', the C-initial example in [laoide-kemp-2026]
     Fig. 1a. Melody = [b, o, g]; skeleton = [C, V, C]; identity
     associations. -/
-def bog : FloatingForm CVKind Segment :=
+def bog : FloatingForm CVKind Segment Morpheme :=
   stemForm "bog" [.C, .V, .C] [.b, .o, .g] {(0, 0), (1, 1), (2, 2)}
 
 /-- The verb `ól` 'drink', the V-initial example in
@@ -217,7 +219,7 @@ def bog : FloatingForm CVKind Segment :=
     [C, V, C, V]; the initial C-slot has no melodic association.
     This is the key structural property: the underlying form has an
     empty C-slot at position 0. -/
-def ól : FloatingForm CVKind Segment :=
+def ól : FloatingForm CVKind Segment Morpheme :=
   stemForm "ol" [.C, .V, .C, .V] [.ó, .l] {(0, 1), (1, 2)}
 
 /-- The verb `fág` 'leave', the *f*-initial example in
@@ -225,7 +227,7 @@ def ól : FloatingForm CVKind Segment :=
     [C, V, C]; identity associations. Under lenition, the `f`
     segmental content deletes, leaving an empty C₁-slot — exactly
     the configuration that licenses `(d)`-docking. -/
-def fág : FloatingForm CVKind Segment :=
+def fág : FloatingForm CVKind Segment Morpheme :=
   stemForm "fag" [.C, .V, .C] [.f, .á, .g] {(0, 0), (1, 1), (2, 2)}
 
 /-! ## §4 The exponents and morpheme composition
@@ -240,7 +242,7 @@ association lines by the prefix's tier lengths.
 
 /-- The historic-tense exponent: a floating `(d)` melodic segment,
     no skeleton, no associations ([laoide-kemp-2026] Fig. 1). -/
-def historicExponent : FloatingForm CVKind Segment where
+def historicExponent : FloatingForm CVKind Segment Morpheme where
   upper := .ofList [mel .dPrime mHist]
   lower := .empty
   links := ∅
@@ -250,7 +252,7 @@ def historicExponent : FloatingForm CVKind Segment where
 /-- The past-tense impersonal exponent: an empty CV unit (`[C, V]`
     skeleton), no melody, no associations ([laoide-kemp-2026] §6.2,
     Fig. 5). -/
-def impersonalExponent : FloatingForm CVKind Segment where
+def impersonalExponent : FloatingForm CVKind Segment Morpheme where
   upper := .empty
   lower := .ofList [slot .C mImpers, slot .V mImpers]
   links := ∅
@@ -259,13 +261,13 @@ def impersonalExponent : FloatingForm CVKind Segment where
 
 /-- Prefix the historic-tense exponent onto a stem (Fig. 1): floating
     `(d)` becomes melody index 0; the stem's melody shifts right by one. -/
-def withHist (stem : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
+def withHist (stem : FloatingForm CVKind Segment Morpheme) : FloatingForm CVKind Segment Morpheme :=
   historicExponent.hconcat stem
 
 /-- Prefix the empty-CV impersonal exponent onto a stem (Fig. 5): the
     stem's skeleton shifts right by two, so the left edge is an empty
     `C₀V₀` unit. -/
-def withImpers (stem : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
+def withImpers (stem : FloatingForm CVKind Segment Morpheme) : FloatingForm CVKind Segment Morpheme :=
   impersonalExponent.hconcat stem
 
 /-! ## §5 Lenition: the `{L}` deletion rule for *f*
@@ -289,14 +291,14 @@ so `{L}` cannot reach it and the *f* stays unmutated.
 
 /-- The melody index of the consonant linked to the leftmost skeletal
     slot (skeleton position 0), if any — the target of `{L}`. -/
-def initialConsonantIdx (f : FloatingForm CVKind Segment) : Option Nat :=
+def initialConsonantIdx (f : FloatingForm CVKind Segment Morpheme) : Option Nat :=
   (List.range f.upper.len).find? (fun k => (k, 0) ∈ f.surfaceLinks)
 
 /-- Apply lenition: if the consonant on the leftmost skeletal slot is
     `f`, delete its melodic content on the surface (leaving the slot
     surface-empty). All other surface effects of lenition (b → v, etc.)
     are out of scope for the *d'* distribution question. -/
-def lenite (f : FloatingForm CVKind Segment) : FloatingForm CVKind Segment :=
+def lenite (f : FloatingForm CVKind Segment Morpheme) : FloatingForm CVKind Segment Morpheme :=
   match initialConsonantIdx f with
   | some k => if (f.upper.get? k).map TierSpec.value = some .f then f.deleteTierElem k else f
   | none   => f
@@ -312,36 +314,36 @@ linking convention.
 -/
 
 /-- Skeleton position `j` is a C-slot. -/
-def isCSlot (f : FloatingForm CVKind Segment) (j : Nat) : Prop :=
+def isCSlot (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Prop :=
   (f.lower.get? j).map SegSpec.seg = some .C
 
-instance (f : FloatingForm CVKind Segment) (j : Nat) : Decidable (isCSlot f j) :=
+instance (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Decidable (isCSlot f j) :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- Skeleton position `j` is a V-slot. -/
-def isVSlot (f : FloatingForm CVKind Segment) (j : Nat) : Prop :=
+def isVSlot (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Prop :=
   (f.lower.get? j).map SegSpec.seg = some .V
 
-instance (f : FloatingForm CVKind Segment) (j : Nat) : Decidable (isVSlot f j) :=
+instance (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Decidable (isVSlot f j) :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- The configuration that licenses `(d)`-docking, evaluated on the
     surface graph: position 0 is an empty C-slot, position 1 is a
     non-empty V-slot. The structural predicate at the heart of the
     paper's analysis ([laoide-kemp-2026] §4.1). -/
-def dDockable (f : FloatingForm CVKind Segment) : Prop :=
+def dDockable (f : FloatingForm CVKind Segment Morpheme) : Prop :=
   isCSlot f 0 ∧ ¬ f.SurfaceLinkedLower 0 ∧
     isVSlot f 1 ∧ f.SurfaceLinkedLower 1
 
-instance (f : FloatingForm CVKind Segment) : Decidable (dDockable f) :=
+instance (f : FloatingForm CVKind Segment Morpheme) : Decidable (dDockable f) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _))
 
 /-- `(d)` surfaces in the historic-tense form `f` iff the post-lenition
     surface form is `(d)`-dockable. [laoide-kemp-2026] §4.1. -/
-def dPrimeSurfaces (f : FloatingForm CVKind Segment) : Prop :=
+def dPrimeSurfaces (f : FloatingForm CVKind Segment Morpheme) : Prop :=
   dDockable (lenite f)
 
-instance (f : FloatingForm CVKind Segment) : Decidable (dPrimeSurfaces f) :=
+instance (f : FloatingForm CVKind Segment Morpheme) : Decidable (dPrimeSurfaces f) :=
   inferInstanceAs (Decidable (dDockable _))
 
 /-! ## §7 Worked examples (paper Figs. 1a, 1b, 1c)
@@ -436,21 +438,21 @@ dissolved). -/
     content of "morphosyntax *concatenates* the floating morpheme"
     ([bermudez-otero-2012]'s strict modularity) — not a non-local
     insertion rule. -/
-theorem withHist_eq_concat (stem : FloatingForm CVKind Segment) :
+theorem withHist_eq_concat (stem : FloatingForm CVKind Segment Morpheme) :
     withHist stem = historicExponent.hconcat stem := rfl
 
 /-- Composing the historic-tense morpheme preserves autosegmental
     well-formedness — a direct consequence of the No-Crossing
     Constraint being morpheme-modular. The floating `(d)` shifts the
     stem's links monotonically, never creating a crossing line. -/
-theorem withHist_isPlanar (stem : FloatingForm CVKind Segment)
+theorem withHist_isPlanar (stem : FloatingForm CVKind Segment Morpheme)
     (hP : IsNonCrossing stem.links) : IsNonCrossing (withHist stem).links := by
   rw [withHist_eq_concat, FloatingForm.hconcat_links]
   simp only [historicExponent, Finset.empty_union]
   exact hP.image_monotone (ρ := (· + 1)) fun _ _ h => Nat.add_le_add_right h 1
 
 /-- A concrete suffix used to probe right-insensitivity. -/
-private def someSuffix : FloatingForm CVKind Segment :=
+private def someSuffix : FloatingForm CVKind Segment Morpheme :=
   stemForm "ma" [.C, .V] [.m, .a] {(0, 0), (1, 1)}
 
 /-- **Left-edge locality (no look-ahead), concrete witness.** Appending
@@ -478,7 +480,7 @@ alone — the formal content of strict modularity (no look-ahead). -/
 /-- Surface-linkedness of skeletal slot `j` on a historic-tense form
     reduces to the stem having an underlying link to `j`: the floating
     `(d)` shifts melody indices only, never skeletal ones. -/
-private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment) (j : Nat) :
+private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment Morpheme) (j : Nat) :
     (withHist X).SurfaceLinkedLower j ↔ ∃ a, (a, j) ∈ X.links := by
   have hlinks : (withHist X).surfaceLinks = X.links.image (shiftLink 1 0) := by
     rw [withHist_eq_concat, FloatingForm.hconcat_surfaceLinks]
@@ -501,7 +503,7 @@ private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment) (j : Na
 /-- A link to a low skeletal slot (`j < stem.lower.len`) is unaffected
     by appending a suffix: the suffix's links are shifted to slots
     `≥ stem.lower.len`, never reaching `j`. -/
-private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment) {j : Nat}
+private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment Morpheme) {j : Nat}
     (hj : j < stem.lower.len) :
     (∃ a, (a, j) ∈ (stem.hconcat suffix).links) ↔
       ∃ a, (a, j) ∈ stem.links := by
@@ -522,14 +524,14 @@ private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment) {j
 
 /-- The skeletal (lower) tier of a historic form is the stem's — the
     floating `(d)` contributes no skeletal slot. -/
-private theorem withHist_lower (Y : FloatingForm CVKind Segment) :
+private theorem withHist_lower (Y : FloatingForm CVKind Segment Morpheme) :
     (withHist Y).lower = Y.lower := by
   rw [withHist_eq_concat, FloatingForm.hconcat_lower]
   exact LabeledTuple.empty_concat Y.lower
 
 /-- The melodic (upper) tier of a historic form is `(d)` concatenated with the
     stem's — used to compute upper-tier lengths in the locality proofs. -/
-private theorem withHist_upper (Y : FloatingForm CVKind Segment) :
+private theorem withHist_upper (Y : FloatingForm CVKind Segment Morpheme) :
     (withHist Y).upper = historicExponent.upper.concat Y.upper := by
   rw [withHist_eq_concat, FloatingForm.hconcat_upper]
 
@@ -542,7 +544,7 @@ private theorem withHist_upper (Y : FloatingForm CVKind Segment) :
     `dPrimeSurfaces` additionally requires `{L}`-docking to be left-local,
     which holds for in-bounds stems; this is the configuration-level
     statement, on which it rests.) -/
-theorem dDockable_withHist_concat_right (stem suffix : FloatingForm CVKind Segment)
+theorem dDockable_withHist_concat_right (stem suffix : FloatingForm CVKind Segment Morpheme)
     (h2 : 2 ≤ stem.lower.len) :
     dDockable (withHist ((stem.hconcat suffix))) ↔
       dDockable (withHist stem) := by
@@ -576,7 +578,7 @@ range, and `lenite` could target different indices. -/
     present in the suffixed form iff present in the stem's — the
     pointwise (per `(k, j)`) version of `linked_concat_low`, used both
     for `initialConsonantIdx` and after `deleteTierElem`. -/
-private theorem mem_surfaceLinks_concat (stem suffix : FloatingForm CVKind Segment)
+private theorem mem_surfaceLinks_concat (stem suffix : FloatingForm CVKind Segment Morpheme)
     {k j : Nat} (hj : j < stem.lower.len) :
     (k, j) ∈ (withHist ((stem.hconcat suffix))).surfaceLinks ↔
       (k, j) ∈ (withHist stem).surfaceLinks := by
@@ -621,7 +623,7 @@ private theorem find?_range_stable {p : Nat → Bool} {m n : Nat} (hmn : m ≤ n
     the slot-0 search predicate agrees (`mem_surfaceLinks_concat`) and,
     by `InBounds`, the stem's slot-0 links sit inside its own melody
     range, so the longer suffixed search finds no extra match. -/
-private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Segment)
+private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Segment Morpheme)
     (h2 : 2 ≤ stem.lower.len) (hib : stem.InBounds) :
     initialConsonantIdx (withHist ((stem.hconcat suffix)))
       = initialConsonantIdx (withHist stem) := by
@@ -658,7 +660,7 @@ private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Se
 /-- The docking configuration is right-local even after `lenite` deletes
     melody index `k`: `deleteTierElem k` only filters `surfaceLinks` and
     leaves the lower tier, so the slot-0/1 agreement survives. -/
-private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKind Segment)
+private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKind Segment Morpheme)
     (h2 : 2 ≤ stem.lower.len) (k : Nat) :
     dDockable ((withHist ((stem.hconcat suffix))).deleteTierElem k) ↔
       dDockable ((withHist stem).deleteTierElem k) := by
@@ -698,7 +700,7 @@ private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKi
     `InBounds`) are left-local, so the full predicate is too. This is
     the paper's central claim, in full: preverbal *d'* never looks
     rightward past the word it attaches to. -/
-theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind Segment)
+theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind Segment Morpheme)
     (h2 : 2 ≤ stem.lower.len) (hib : stem.InBounds) :
     dPrimeSurfaces (withHist ((stem.hconcat suffix))) ↔
       dPrimeSurfaces (withHist stem) := by
@@ -753,10 +755,10 @@ extensional content (no look-ahead) is fully captured by
     representations: one floating `(d)` melody node, no skeleton, no links. -/
 def historicExponentRep :
     AR (Sigma.fst :
-      ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) :=
+      ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool) :=
   AR.ofData
     (fun b => match b with
-      | true => ([mel .dPrime mHist] : List (TwoTier (TierSpec Segment) (SegSpec CVKind) true))
+      | true => ([mel .dPrime mHist] : List (TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) true))
       | false => [])
     ⊥
 
@@ -768,9 +770,9 @@ open CategoryTheory MonoidalCategory in
     preverbal particle. -/
 def withHistFunctor :
     AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) ⥤
+        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool) ⥤
     AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool) :=
+        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool) :=
   tensorLeft historicExponentRep
 
 open CategoryTheory MonoidalCategory in
@@ -778,7 +780,7 @@ open CategoryTheory MonoidalCategory in
     the exponent with the stem. -/
 theorem withHistFunctor_obj
     (X : AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool)) :
+        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool)) :
     withHistFunctor.obj X = historicExponentRep ⊗ X := rfl
 
 open CategoryTheory MonoidalCategory in
@@ -790,7 +792,7 @@ open CategoryTheory MonoidalCategory in
     load-bearing rather than decorative. -/
 noncomputable def prefixAssoc
     (X : AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment) (SegSpec CVKind) b) → Bool)) :
+        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool)) :
     tensorLeft (historicExponentRep ⊗ X) ≅
       tensorLeft X ⋙ tensorLeft historicExponentRep :=
   tensorLeftTensor historicExponentRep X

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -428,10 +428,11 @@ end McPhersonLamont2026
 namespace Autosegmental
 
 open Tone (TBU TRN)
+open Morphology.WordStructure (Morpheme)
 
 /-- Embed a `tonalOverwrite` output into `FloatingForm`: one morpheme `m`, links `(i, i)`. -/
 def FloatingForm.ofTBUList {S : Type*} (host : List (TBU S)) (m : Morpheme) :
-    FloatingForm S TRN where
+    FloatingForm S TRN Morpheme where
   lower := .ofList (host.map (fun tbu => { seg := tbu.seg, morpheme := m }))
   upper := .ofList (host.map (fun tbu => { value := tbu.tone, morpheme := m }))
   links := ((List.range host.length).map (fun i => (i, i))).toFinset
@@ -467,7 +468,7 @@ theorem FloatingForm.ofTBUList_linksTo_subsingleton {S : Type*}
 
 /-- A `FloatingForm` with two surface tones on one TBU — unreachable by `ofTBUList`. -/
 theorem FloatingForm.exists_multi_tone_TBU :
-    ∃ f : FloatingForm Unit TRN, ∃ i : SegIdx, 2 ≤ (f.linksTo i).length := by
+    ∃ f : FloatingForm Unit TRN Morpheme, ∃ i : SegIdx, 2 ≤ (f.linksTo i).length := by
   refine ⟨?_, 0, ?_⟩
   · exact
     { lower := .ofList [{ seg := (), morpheme := { morph := .root "m" } }]

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19633,11 +19633,12 @@
   journal   = {Theoretical Linguistics},
   volume    = {40},
   number    = {3--4},
+  pages     = {225--276},
   doi       = {10.1515/tl-2014-0010},
   subfield  = {morphology},
   validated = {true},
   role      = {formalized},
-  sources   = {Morphology/DM/Categorizer.lean}
+  sources   = {Morphology/DM/Categorizer.lean;Studies/Harley2014.lean}
 }
 @article{hewett-2026,
   author    = {Hewett, Matthew},


### PR DESCRIPTION
Three edges of the interface-parity program. The autosegmental sponsor becomes an opaque type parameter (Phonology now imports nothing from Morphology); `AllosemicEntry` becomes the sixth `Exponence` instance with specificity = non-wildcard count and `fromComplement` recast as `selectBy` (the hand-rolled cascade's own docstring said "most specific … elsewhere"); `readingFromAllosemes` stays a table, documented as List-3 *composition* of two selected allosemes — selection competes, composition doesn't. New `Studies/Harley2014.lean`: roots as abstract indices, Hiaki suppletion per fn. 16 (tenne as true Elsewhere), suppletion conditioned by the absolutive argument only (`suppletion_ignores_ergative`), cran-morphs as no-Elsewhere vocabularies. Categorizer miscite fixed (§5 → §2.4).