### PR TITLE
refactor(Morphology): bickel-nichols-2007 key fix; Turkish templates on AffixTemplate

### DIFF
--- a/Linglib/Features/Person/Decomposition.lean
+++ b/Linglib/Features/Person/Decomposition.lean
@@ -434,11 +434,11 @@ theorem singular_features_match :
   rintro c (rfl | rfl | rfl) <;> rfl
 
 -- ============================================================================
--- § 11: Epistemic Authority ([bickel-nichols-2001])
+-- § 11: Epistemic Authority ([bickel-nichols-2007])
 -- ============================================================================
 
 /-- Epistemic authority marking on verb agreement.
-    [bickel-nichols-2001]
+    [bickel-nichols-2007]
 
     Some languages (Akhvakh, Kathmandu Newari, Tibetan) mark whether the
     speaker has direct epistemic authority over the event. The morphological

--- a/Linglib/Fragments/Arabic/Egyptian/Morph.lean
+++ b/Linglib/Fragments/Arabic/Egyptian/Morph.lean
@@ -2,7 +2,7 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Arabic (Egyptian) Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
 WALS-derived profile for Egyptian Arabic (ISO `arz`, WALS code `aeg`).
 WALS F20A codes Arabic as `ablautConcatenative`, mapping to the local

--- a/Linglib/Fragments/English/Morph.lean
+++ b/Linglib/Fragments/English/Morph.lean
@@ -2,11 +2,11 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # English Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for English (ISO `eng`). B&N 2001 places English
+WALS-derived profile for English (ISO `eng`). B&N 2007 places English
 in the "agglutinating" cell (concatenative + nonflexive + separative)
-despite its small inflectional inventory; cf. [bickel-nichols-2001].
+despite its small inflectional inventory; cf. [bickel-nichols-2007].
 -/
 
 namespace English
@@ -23,7 +23,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "eng" ∧ morphProfile.language = "English" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places English in the "agglutinating" cell. -/
+/-- B&N 2007 places English in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end English

--- a/Linglib/Fragments/Finnish/Morph.lean
+++ b/Linglib/Fragments/Finnish/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Finnish Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Finnish (ISO `fin`). B&N 2001 places Finnish in the
+WALS-derived profile for Finnish (ISO `fin`). B&N 2007 places Finnish in the
 "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "fin" ∧ morphProfile.language = "Finnish" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Finnish in the "agglutinating" cell. -/
+/-- B&N 2007 places Finnish in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Finnish

--- a/Linglib/Fragments/Georgian/Morph.lean
+++ b/Linglib/Fragments/Georgian/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Georgian Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Georgian (ISO `kat`). B&N 2001 places Georgian
+WALS-derived profile for Georgian (ISO `kat`). B&N 2007 places Georgian
 in the "fusional" cell (concatenative + flexive + cumulative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "kat" ∧ morphProfile.language = "Georgian" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Georgian in the "fusional" cell. -/
+/-- B&N 2007 places Georgian in the "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Georgian

--- a/Linglib/Fragments/German/Morph.lean
+++ b/Linglib/Fragments/German/Morph.lean
@@ -2,12 +2,12 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # German Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
 WALS-derived profile (Ch 20A–29A, 21B, 62A, 79A/B, 80A) for German (ISO `deu`,
-WALS code `ger`). The B&N 2001 parameters (`flexivity := flexive`,
+WALS code `ger`). The B&N 2007 parameters (`flexivity := flexive`,
 `bnExponence := cumulative`) are not derivable from any WALS chapter and are
-paper-stipulated per [bickel-nichols-2001]; together with the WALS-derived
+paper-stipulated per [bickel-nichols-2007]; together with the WALS-derived
 `fusion := concatenative` they place German in the traditional "fusional" cell.
 
 WALS F20A's `exclusivelyConcatenative` verdict samples a small set of formatives
@@ -22,7 +22,7 @@ open Morphology
 
 /-- German: WALS-derived `MorphProfile` via `MorphProfile.fromWALS`. Required-field
     fallbacks match WALS values (lookup wins when present); `flexivity` and
-    `bnExponence` are stipulated per B&N 2001. -/
+    `bnExponence` are stipulated per B&N 2007. -/
 def morphProfile : MorphProfile :=
   .fromWALS "German" "deu"
     (fusionFb        := .concatenative)
@@ -33,7 +33,7 @@ def morphProfile : MorphProfile :=
 /-- Typo sentry for the ISO and language label. -/
 example : morphProfile.iso = "deu" ∧ morphProfile.language = "German" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places German in the "fusional" cell. Bridge theorem made local
+/-- B&N 2007 places German in the "fusional" cell. Bridge theorem made local
     so the per-language commitment is visible here, not only inside
     `BickelNichols2013.lean`'s 18-language aggregate. -/
 example : morphProfile.IsFusional := by decide

--- a/Linglib/Fragments/Hindi/Morph.lean
+++ b/Linglib/Fragments/Hindi/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Hindi-Urdu Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Hindi-Urdu (ISO `hin`). B&N 2001 places Hindi-Urdu
+WALS-derived profile for Hindi-Urdu (ISO `hin`). B&N 2007 places Hindi-Urdu
 in the "fusional" cell (concatenative + flexive + cumulative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "hin" ∧ morphProfile.language = "Hindi-Urdu" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Hindi-Urdu in the "fusional" cell. -/
+/-- B&N 2007 places Hindi-Urdu in the "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Hindi

--- a/Linglib/Fragments/Hungarian/Morph.lean
+++ b/Linglib/Fragments/Hungarian/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Hungarian Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Hungarian (ISO `hun`). B&N 2001 places Hungarian
+WALS-derived profile for Hungarian (ISO `hun`). B&N 2007 places Hungarian
 in the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "hun" ∧ morphProfile.language = "Hungarian" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Hungarian in the "agglutinating" cell. -/
+/-- B&N 2007 places Hungarian in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Hungarian

--- a/Linglib/Fragments/Indonesian/Morph.lean
+++ b/Linglib/Fragments/Indonesian/Morph.lean
@@ -2,7 +2,7 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Indonesian Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
 WALS-derived profile for Indonesian (ISO `ind`). WALS F20A codes Indonesian
 as `exclusivelyIsolating`, which the local 3-way `Fusion` enum maps to

--- a/Linglib/Fragments/Japanese/Morph.lean
+++ b/Linglib/Fragments/Japanese/Morph.lean
@@ -4,9 +4,9 @@ import Linglib.Morphology.Template
 
 /-!
 # Japanese Morphological Profile
-[wals-2013] [bickel-nichols-2001] [kaiser-yamamoto-2013]
+[wals-2013] [bickel-nichols-2007] [kaiser-yamamoto-2013]
 
-WALS-derived profile for Japanese (ISO `jpn`). B&N 2001 places Japanese
+WALS-derived profile for Japanese (ISO `jpn`). B&N 2007 places Japanese
 in the "agglutinating" cell (concatenative + nonflexive + separative).
 
 The verb suffix template (`verbAffixTemplate`) follows [kaiser-yamamoto-2013]
@@ -37,7 +37,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "jpn" ∧ morphProfile.language = "Japanese" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Japanese in the "agglutinating" cell. -/
+/-- B&N 2007 places Japanese in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 /-- Japanese verb suffix template, stem-outward ([kaiser-yamamoto-2013], UD

--- a/Linglib/Fragments/Korean/Morph.lean
+++ b/Linglib/Fragments/Korean/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Korean Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Korean (ISO `kor`). B&N 2001 places Korean
+WALS-derived profile for Korean (ISO `kor`). B&N 2007 places Korean
 in the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "kor" ∧ morphProfile.language = "Korean" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Korean in the "agglutinating" cell. -/
+/-- B&N 2007 places Korean in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Korean

--- a/Linglib/Fragments/Mandarin/Morph.lean
+++ b/Linglib/Fragments/Mandarin/Morph.lean
@@ -7,7 +7,7 @@ import Linglib.Morphology.FusionTypology
 WALS-derived profile for Mandarin Chinese (ISO `cmn`). WALS F20A codes
 Mandarin as `isolatingConcatenative`, a mixed type the local 3-way `Fusion`
 enum cannot represent — `walsFusion` returns `none` and the fallback
-`.isolating` is exercised. B&N 2001 flexivity/bnExponence are not stipulated
+`.isolating` is exercised. B&N 2007 flexivity/bnExponence are not stipulated
 because the largely isolating typology renders them inapplicable.
 -/
 

--- a/Linglib/Fragments/Quechua/Morph.lean
+++ b/Linglib/Fragments/Quechua/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Quechua (Imbabura) Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Imbabura Quechua (ISO `qvi`). B&N 2001 places
+WALS-derived profile for Imbabura Quechua (ISO `qvi`). B&N 2007 places
 Quechua in the "agglutinating" cell (concatenative + nonflexive + separative).
 Consistent with the Imbabura data used in the Negation and PolarityItems
 fragments in this directory.
@@ -25,7 +25,7 @@ def morphProfile : MorphProfile :=
 example : morphProfile.iso = "qvi" ∧ morphProfile.language = "Quechua (Imbabura)" :=
   ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Quechua in the "agglutinating" cell. -/
+/-- B&N 2007 places Quechua in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Quechua

--- a/Linglib/Fragments/Slavic/Russian/Morph.lean
+++ b/Linglib/Fragments/Slavic/Russian/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Russian Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Russian (ISO `rus`). B&N 2001 places Russian in the
+WALS-derived profile for Russian (ISO `rus`). B&N 2007 places Russian in the
 canonical "fusional" cell (concatenative + flexive + cumulative); the genitive
 singular *-ī ~ -ae ~ -ūs* class-conditioned allomorphy pattern cited by
 B&N as the diagnostic for flexivity is the same pattern Russian instantiates
@@ -25,7 +25,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "rus" ∧ morphProfile.language = "Russian" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Russian in the canonical "fusional" cell. -/
+/-- B&N 2007 places Russian in the canonical "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Russian

--- a/Linglib/Fragments/Spanish/Morph.lean
+++ b/Linglib/Fragments/Spanish/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Spanish Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Spanish (ISO `spa`). B&N 2001 places Spanish in
+WALS-derived profile for Spanish (ISO `spa`). B&N 2007 places Spanish in
 the "fusional" cell (concatenative + flexive + cumulative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "spa" ∧ morphProfile.language = "Spanish" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Spanish in the "fusional" cell. -/
+/-- B&N 2007 places Spanish in the "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Spanish

--- a/Linglib/Fragments/Swahili/Morph.lean
+++ b/Linglib/Fragments/Swahili/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Swahili Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Swahili (ISO `swh`). B&N 2001 places Swahili in the
+WALS-derived profile for Swahili (ISO `swh`). B&N 2007 places Swahili in the
 "agglutinating" cell (concatenative + nonflexive + separative); Swahili is
 unusual among the 18-language sample in being weakly prefixing rather than
 suffixing.
@@ -24,7 +24,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "swh" ∧ morphProfile.language = "Swahili" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Swahili in the "agglutinating" cell. -/
+/-- B&N 2007 places Swahili in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Swahili

--- a/Linglib/Fragments/Tagalog/Morph.lean
+++ b/Linglib/Fragments/Tagalog/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Tagalog Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Tagalog (ISO `tgl`). B&N 2001 places Tagalog in
+WALS-derived profile for Tagalog (ISO `tgl`). B&N 2007 places Tagalog in
 the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
@@ -22,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "tgl" ∧ morphProfile.language = "Tagalog" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Tagalog in the "agglutinating" cell. -/
+/-- B&N 2007 places Tagalog in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Tagalog

--- a/Linglib/Fragments/Thai/Morph.lean
+++ b/Linglib/Fragments/Thai/Morph.lean
@@ -8,7 +8,7 @@ WALS-derived profile for Thai (ISO `tha`). WALS F20A codes Thai as
 `isolatingConcatenative`, a mixed type the local 3-way `Fusion` enum cannot
 represent — `walsFusion` returns `none` and the fallback `.isolating` is
 exercised. F21A returns `noCase`, mapping to `none`; the local `.noCase`
-fallback is exercised. B&N 2001 flexivity/bnExponence are not stipulated.
+fallback is exercised. B&N 2007 flexivity/bnExponence are not stipulated.
 -/
 
 namespace Thai

--- a/Linglib/Fragments/Turkish/Morph.lean
+++ b/Linglib/Fragments/Turkish/Morph.lean
@@ -2,9 +2,9 @@ import Linglib.Morphology.FusionTypology
 
 /-!
 # Turkish Morphological Profile
-[wals-2013] [bickel-nichols-2001]
+[wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Turkish (ISO `tur`). B&N 2001 places Turkish in
+WALS-derived profile for Turkish (ISO `tur`). B&N 2007 places Turkish in
 the canonical "agglutinating" cell (concatenative + nonflexive + separative);
 Turkish is the textbook example of rule-governed (vowel-harmony) suffix
 allomorphy with no class-conditioned variation.
@@ -24,7 +24,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "tur" ∧ morphProfile.language = "Turkish" := ⟨rfl, rfl⟩
 
-/-- B&N 2001 places Turkish in the canonical "agglutinating" cell. -/
+/-- B&N 2007 places Turkish in the canonical "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Turkish

--- a/Linglib/Fragments/Turkish/SuffixTemplate.lean
+++ b/Linglib/Fragments/Turkish/SuffixTemplate.lean
@@ -1,34 +1,22 @@
-import Linglib.Fragments.Turkish.TAM
-import Linglib.Fragments.Turkish.VowelHarmony
+import Linglib.Morphology.Template
 
 /-!
-# Turkish Suffix Template
+# Turkish Suffix Templates
 [goksel-kerslake-2005]
 
-Turkish is strictly suffixing ([goksel-kerslake-2005] Ch 6). Suffixes
-attach in a fixed order determined by a **positional template**.
+Turkish is strictly suffixing ([goksel-kerslake-2005] Ch 6): suffixes
+attach in a fixed order determined by a positional template. The verbal
+(Ch 6, 8, 13) and nominal (Ch 6, 8, 14) templates live here as Fragment
+data over `Morphology.AffixTemplate`; ordering predictions are checked in
+`Studies/GokselKerslake2005.lean`.
 
-## Verbal template (Ch 6, 8, 13)
-
-  Root -> Voice -> Negation -> TAM -> Copula -> Agreement -> Question
-
-## Nominal template (Ch 6, 8, 14)
-
-  Root -> Derivational -> Plural -> Possessive -> Case
-
-## Key properties
-
-1. **Strict ordering**: suffixes from later slots never precede earlier ones
-2. **At most one per slot**: each slot filled at most once (voice can stack:
-   e.g., *yap-tır-ıl-* 'be made to do' = CAUS + PASS)
-3. **Monoexponential**: each suffix realizes a single morphosyntactic feature
-   (WALS F21A: monoexponential case)
+Voice suffixes can stack within their slot (*yap-tır-ıl-* 'be made to
+do' = CAUS + PASS); slots are position classes, not token counts.
 -/
 
 namespace Turkish.SuffixTemplate
 
-/-- Verbal suffix slots, ordered innermost to outermost.
-    [goksel-kerslake-2005] Ch 6, 8, 13. -/
+/-- Verbal suffix slots. [goksel-kerslake-2005] Ch 6, 8, 13. -/
 inductive VerbSlot where
   | voice         -- causative -DIr, passive -(I)l, reflexive -(I)n, reciprocal -(I)ş
   | negation      -- -mA
@@ -38,8 +26,7 @@ inductive VerbSlot where
   | question      -- mI
   deriving DecidableEq, Repr
 
-/-- Nominal suffix slots, ordered innermost to outermost.
-    [goksel-kerslake-2005] Ch 6, 8, 14. -/
+/-- Nominal suffix slots. [goksel-kerslake-2005] Ch 6, 8, 14. -/
 inductive NounSlot where
   | derivational  -- denominal/deadjectival suffixes
   | plural        -- -lAr
@@ -47,83 +34,14 @@ inductive NounSlot where
   | case          -- -(y)I, -(y)A, -DA, -DAn, -(n)In, zero
   deriving DecidableEq, Repr
 
-def VerbSlot.rank : VerbSlot → Nat
-  | .voice => 0 | .negation => 1 | .tam => 2
-  | .copula => 3 | .agreement => 4 | .question => 5
+/-- The verbal template, stem-outward:
+`Root - Voice - Negation - TAM - Copula - Agreement - Question`. -/
+def verbTemplate : Morphology.AffixTemplate VerbSlot where
+  suffixSlots := [.voice, .negation, .tam, .copula, .agreement, .question]
 
-def NounSlot.rank : NounSlot → Nat
-  | .derivational => 0 | .plural => 1 | .possessive => 2 | .case => 3
-
--- ============================================================================
--- § Ordering verification
--- ============================================================================
-
-theorem voice_before_neg : VerbSlot.voice.rank < VerbSlot.negation.rank := by decide
-theorem neg_before_tam : VerbSlot.negation.rank < VerbSlot.tam.rank := by decide
-theorem tam_before_cop : VerbSlot.tam.rank < VerbSlot.copula.rank := by decide
-theorem cop_before_agr : VerbSlot.copula.rank < VerbSlot.agreement.rank := by decide
-theorem agr_before_q : VerbSlot.agreement.rank < VerbSlot.question.rank := by decide
-
-theorem plural_before_poss : NounSlot.plural.rank < NounSlot.possessive.rank := by decide
-theorem poss_before_case : NounSlot.possessive.rank < NounSlot.case.rank := by decide
-
-/-- Negation cannot follow TAM (reversed order). -/
-theorem neg_not_after_tam :
-    ¬(VerbSlot.tam.rank < VerbSlot.negation.rank) := by decide
-
-/-- Case cannot precede possessive (reversed order). -/
-theorem case_not_before_poss :
-    ¬(NounSlot.case.rank < NounSlot.possessive.rank) := by decide
-
-/-- Voice suffixes can stack (two voice entries at rank 0 is well-formed).
-    Example: *yap-tır-ıl-* (do-CAUS-PASS). -/
-theorem voice_stacking_ok :
-    VerbSlot.voice.rank ≤ VerbSlot.voice.rank := Nat.le_refl _
-
--- ============================================================================
--- § Cross-file bridges: TAM and negation fill template slots
--- ============================================================================
-
-/-- All 8 TAM categories fill the .tam slot (slot rank 2). -/
-theorem tam_entries_fill_tam_slot :
-    TAM.entries.length = 8 ∧ VerbSlot.tam.rank = 2 := ⟨by decide, rfl⟩
-
-/-- Negation (-mA-) occupies slot rank 1, strictly before TAM (slot rank 2).
-    This matches the surface order: gel-**me**-**di** (stem-NEG-PST). -/
-theorem negation_precedes_tam :
-    VerbSlot.negation.rank < VerbSlot.tam.rank := by decide
-
-/-- The question particle mI fills the outermost verbal slot (rank 5).
-    It follows agreement, yielding: gel-di-**m** **mi**? (come-PST-1SG Q). -/
-theorem question_is_outermost :
-    VerbSlot.question.rank = 5 ∧
-    ∀ s : VerbSlot, s.rank ≤ VerbSlot.question.rank := by
-  constructor
-  · rfl
-  · intro s; cases s <;> simp [VerbSlot.rank] <;> omega
-
--- ============================================================================
--- § End-to-end: VH resolves TAM suffix vowels
--- ============================================================================
-
-open VowelHarmony in
-/-- The archiphonemic I in progressive -Iyor resolves to 4 surface vowels
-    depending on stem harmony. This connects VowelHarmony to TAM:
-    - back+unround stem (kol): -ıyor (resolveI true false = ı)
-    - front+unround stem (gel): -iyor (resolveI false false = i)
-    - back+round stem (kol): -uyor (resolveI true true = u)
-    - front+round stem (göz): -üyor (resolveI false true = ü) -/
-theorem progressive_I_resolution :
-    resolveI true  false = ı_vowel ∧
-    resolveI false false = i_vowel ∧
-    resolveI true  true  = u_vowel ∧
-    resolveI false true  = ü_vowel := ⟨rfl, rfl, rfl, rfl⟩
-
-open VowelHarmony in
-/-- The archiphonemic A in future -(y)AcAK resolves to a/e by palatal harmony.
-    back stem (kol): -(y)acak; front stem (gel): -(y)ecek. -/
-theorem future_A_resolution :
-    resolveA true  = a_vowel ∧
-    resolveA false = e_vowel := ⟨rfl, rfl⟩
+/-- The nominal template, stem-outward:
+`Root - Derivational - Plural - Possessive - Case`. -/
+def nounTemplate : Morphology.AffixTemplate NounSlot where
+  suffixSlots := [.derivational, .plural, .possessive, .case]
 
 end Turkish.SuffixTemplate

--- a/Linglib/Morphology/Formative.lean
+++ b/Linglib/Morphology/Formative.lean
@@ -1,6 +1,6 @@
 /-!
 # Form status of morphemes
-[zwicky-pullum-1983] [bickel-nichols-2001]
+[zwicky-pullum-1983] [bickel-nichols-2007]
 
 Typological classification of bound and free formatives by attachment
 position, host selectivity, and syntactic independence.
@@ -24,7 +24,7 @@ inductive AttachmentSide where
   deriving DecidableEq, Repr
 
 /-- Typological position classification for formatives.
-    [bickel-nichols-2001] Table 2.
+    [bickel-nichols-2007] Table 2.
 
     Superset of `AttachmentSide`: adds simulfixation (process morphology),
     detached formatives (Wackernagel clitics, free auxiliaries), and
@@ -82,7 +82,7 @@ inductive MorphStatus where
   | freeWord
   /-- Simple clitic: phonologically bound form that can attach to
       hosts of virtually any syntactic category.
-      [bickel-nichols-2001]: defined primarily by low selectivity
+      [bickel-nichols-2007]: defined primarily by low selectivity
       (categorical freedom) + phonological dependence, not necessarily
       by being a reduced variant of a free word. Many simple clitics
       have no free-word counterpart (Latin *-que*). English contracted

--- a/Linglib/Morphology/FusionTypology.lean
+++ b/Linglib/Morphology/FusionTypology.lean
@@ -4,7 +4,7 @@ import Linglib.Data.WALS.Features.F21A
 /-!
 # Fusion Typology
 
-The Bickel & Nichols fusion/flexivity typology [bickel-nichols-2001]
+The Bickel & Nichols fusion/flexivity typology [bickel-nichols-2007]
 [bickel-nichols-2013a]: framework-agnostic classification types (`Fusion`,
 `Flexivity`, `CaseExponence`, `ExponenceScope`), the per-language `MorphProfile`
 record, WALS grounding functions, and the traditional agglutinating/fusional
@@ -12,7 +12,7 @@ predicates with their mutual-exclusion theorems.
 
 The `fusion` and `exponence` fields are derived from WALS Chapters 20 and 21;
 the orthogonal `flexivity` and `bnExponence` parameters are paper-stipulated
-per [bickel-nichols-2001] and not derivable from WALS.
+per [bickel-nichols-2007] and not derivable from WALS.
 -/
 
 namespace Morphology
@@ -28,7 +28,7 @@ namespace Morphology
     "agglutinating" and "fusional" conflate fusion with *flexivity*
     (see `Flexivity` below). Both `concatenative + nonflexive` (Turkish)
     and `concatenative + flexive` (Russian) map to `.concatenative` here.
-    [bickel-nichols-2001] -/
+    [bickel-nichols-2007] -/
 inductive Fusion where
   | isolating
   | concatenative
@@ -37,7 +37,7 @@ inductive Fusion where
 
 /-- Whether inflectional formatives show item-based allomorphic variation.
 
-    [bickel-nichols-2001] argue this is the crucial parameter that
+    [bickel-nichols-2007] argue this is the crucial parameter that
     the traditional typology conflates with fusion:
     - **nonflexive** ("agglutinating"): formatives have invariant or
       rule-governed shape (Turkish *-ler* ~ *-lar* is vowel-harmony,
@@ -60,7 +60,7 @@ inductive Flexivity where
 
     Distinct from `ExponenceScope` (B&N's broader cumulative/separative
     parameter which applies to all morphological categories, not just case).
-    [bickel-nichols-2001] -/
+    [bickel-nichols-2007] -/
 inductive CaseExponence where
   | monoexponential
   | polyexponential
@@ -71,7 +71,7 @@ inductive CaseExponence where
     simultaneously (cumulative) or each formative expresses exactly one
     category (separative).
 
-    [bickel-nichols-2001]: this is a general morphological parameter
+    [bickel-nichols-2007]: this is a general morphological parameter
     applying across all category pairs, not limited to case+number (cf.
     WALS Ch 21 `Exponence`). Latin *-ō* (1sg.pres.act.ind) is cumulative;
     Turkish verb suffixes are separative (each suffix = one category). -/
@@ -87,7 +87,7 @@ inductive ExponenceScope where
 /-- A language's morphological profile in the B&N fusion typology. The
     `fusion` and `exponence` fields are derived from WALS where possible;
     the orthogonal `flexivity` and `bnExponence` parameters are populated
-    when [bickel-nichols-2001] stipulates them. -/
+    when [bickel-nichols-2007] stipulates them. -/
 structure MorphProfile where
   language : String
   iso : String
@@ -95,11 +95,11 @@ structure MorphProfile where
   fusion : Fusion
   /-- Ch 21: Exponence type -/
   exponence : CaseExponence
-  /-- [bickel-nichols-2001]: Flexivity — whether inflectional formatives
+  /-- [bickel-nichols-2007]: Flexivity — whether inflectional formatives
       show item-based allomorphic variation (flexive) or are phonologically
       invariant (nonflexive). Orthogonal to `fusion`. Not derivable from WALS. -/
   flexivity : Option Flexivity := none
-  /-- [bickel-nichols-2001]: Exponence scope — whether single formatives
+  /-- [bickel-nichols-2007]: Exponence scope — whether single formatives
       bundle multiple categories (cumulative) or each expresses one (separative).
       Broader than WALS Ch 21 `exponence` (which is case-specific). -/
   bnExponence : Option ExponenceScope := none
@@ -158,9 +158,9 @@ def walsExponence (iso : String) : Option CaseExponence :=
     enum and yields `none`). When WALS has data the lookup wins; the fallback
     is exercised only when WALS is silent.
 
-    The B&N 2001 parameters `flexivity` and `bnExponence` are NOT derivable
+    The B&N 2007 parameters `flexivity` and `bnExponence` are NOT derivable
     from any WALS chapter — they are paper-stipulated per
-    [bickel-nichols-2001] and must be passed explicitly when known. -/
+    [bickel-nichols-2007] and must be passed explicitly when known. -/
 def MorphProfile.fromWALS
     (language iso : String)
     (fusionFb : Fusion)
@@ -228,7 +228,7 @@ instance : DecidablePred IsSeparative :=
   fun p => decidable_of_iff _ (isSeparative_iff p).symm
 
 /-- Traditional "agglutinating" = concatenative + nonflexive + separative.
-    [bickel-nichols-2001] decomposition of the traditional typology. -/
+    [bickel-nichols-2007] decomposition of the traditional typology. -/
 def IsAgglutinating (p : MorphProfile) : Prop :=
   p.IsConcatenative ∧ p.IsNonflexive ∧ p.IsSeparative
 @[simp] theorem isAgglutinating_iff (p : MorphProfile) :
@@ -238,7 +238,7 @@ instance : DecidablePred IsAgglutinating :=
   fun p => decidable_of_iff _ (isAgglutinating_iff p).symm
 
 /-- Traditional "fusional" = concatenative + flexive + cumulative.
-    [bickel-nichols-2001] decomposition of the traditional typology. -/
+    [bickel-nichols-2007] decomposition of the traditional typology. -/
 def IsFusional (p : MorphProfile) : Prop :=
   p.IsConcatenative ∧ p.IsFlexive ∧ p.IsCumulative
 @[simp] theorem isFusional_iff (p : MorphProfile) :

--- a/Linglib/Studies/BickelNichols2013.lean
+++ b/Linglib/Studies/BickelNichols2013.lean
@@ -21,12 +21,12 @@ import Linglib.Fragments.Spanish.Morph
 /-!
 # BickelNichols2013
 [bickel-nichols-2013a] [bickel-nichols-2013b] [bickel-nichols-2013c]
-[bickel-nichols-2001]
+[bickel-nichols-2007]
 
 Cross-linguistic analyses anchored on Bickel & Nichols's WALS chapters
 (Ch 20 fusion, Ch 21 exponence, Ch 22 inflectional synthesis) and their
-2001 paper on the orthogonality of fusion and flexivity. The 18-language
-`MorphProfile` sample is the testbed.
+Shopen-volume chapter on the orthogonality of fusion and flexivity. The
+18-language `MorphProfile` sample is the testbed.
 
 ## Bickel & Nichols's central insight
 
@@ -112,7 +112,7 @@ theorem morph_iso_unique :
 -- §2. B&N Orthogonality and Cell-Population Theorems
 -- ============================================================================
 
-/-! [bickel-nichols-2001] argue fusion and flexivity are orthogonal,
+/-! [bickel-nichols-2007] argue fusion and flexivity are orthogonal,
     and that the four cells of the (concatenative ∪ nonlinear ∪ isolating)
     × (flexive ∪ nonflexive ∪ none) space are independently attested. The
     theorems below witness the cells the sample populates. -/

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -279,7 +279,7 @@ open Agreement (Target)
     or by referential meaning (semantic).
 
     Distinct from the grammatical-vs-pronominal split
-    ([bickel-nichols-2001]), which is about whether the agreement
+    ([bickel-nichols-2007]), which is about whether the agreement
     marker has referential autonomy. This type is about what *controls*
     agreement — the formal features of the controller or its semantic
     content. -/

--- a/Linglib/Studies/GokselKerslake2005.lean
+++ b/Linglib/Studies/GokselKerslake2005.lean
@@ -1,5 +1,7 @@
 import Linglib.Semantics.Tense.Evidential
 import Linglib.Fragments.Turkish.TAM
+import Linglib.Fragments.Turkish.SuffixTemplate
+import Linglib.Fragments.Turkish.VowelHarmony
 
 /-!
 # Göksel & Kerslake 2005: Turkish Evidential TAM
@@ -55,17 +57,67 @@ theorem same_tense_different_evidence :
     diUP = mişUP ∧ diEP ≠ mişEP := by
   exact ⟨rfl, by decide⟩
 
-/-- Both -DI and -mIş occupy the TAM slot in the Turkish suffix template.
-    They are in complementary distribution: you cannot have both. -/
-theorem di_miş_same_slot :
-    let di := (entries.filter (·.category == .pastDef)).head!
-    let miş := (entries.filter (·.category == .evidential)).head!
-    di.category != miş.category = true := by native_decide
-
 /-- -DI is the only category with contemporaneous EP (direct witness). -/
 theorem di_unique_direct : diEP = .contemporaneous := rfl
 
 /-- -mIş EP is strictly downstream — evidence comes after the event. -/
 theorem miş_indirect : mişEP = .strictDownstream := rfl
+
+-- ============================================================================
+-- § 3: The suffix template (Ch 6, 8, 13-14)
+-- ============================================================================
+
+/-! Ordering predictions derived from the Fragment templates
+(`Turkish.SuffixTemplate.verbTemplate`/`nounTemplate`), checked as
+slot-position facts rather than re-typed rank tables. -/
+
+open Turkish.SuffixTemplate
+
+/-- The verbal template has a single TAM slot, so -DI and -mIş — both
+TAM-category suffixes — are in complementary distribution: a simplex
+verb form cannot carry both. -/
+theorem tam_slot_unique :
+    verbTemplate.suffixSlots.count .tam = 1 := by decide
+
+/-- Negation strictly precedes TAM in the template, matching the surface
+order stem-NEG-TAM: every symmetric negative in the TAM inventory spells
+NEG before the TAM suffix (gel-**me**-**di** 'come-NEG-PST'). -/
+theorem negation_precedes_tam :
+    verbTemplate.suffixSlots.idxOf .negation < verbTemplate.suffixSlots.idxOf .tam ∧
+    ∀ e ∈ entries, e.isNegSymmetric → e.negSuffix.data.take 2 = ['-', 'm'] := by decide
+
+/-- The question particle mI fills the outermost verbal slot, following
+agreement: gel-di-**m** **mi**? (come-PST-1SG Q). -/
+theorem question_is_outermost :
+    ∀ s ∈ verbTemplate.suffixSlots,
+      verbTemplate.suffixSlots.idxOf s ≤ verbTemplate.suffixSlots.idxOf .question := by
+  decide
+
+/-- Nominal ordering: plural before possessive before case
+(ev-**ler**-**im**-**de** 'house-PL-1SG.POSS-LOC'). -/
+theorem noun_slot_order :
+    nounTemplate.suffixSlots.idxOf .plural < nounTemplate.suffixSlots.idxOf .possessive ∧
+    nounTemplate.suffixSlots.idxOf .possessive < nounTemplate.suffixSlots.idxOf .case := by
+  decide
+
+-- ============================================================================
+-- § 4: Vowel harmony resolves TAM suffix vowels
+-- ============================================================================
+
+open Turkish.VowelHarmony
+
+/-- The archiphonemic I in progressive -Iyor resolves to 4 surface vowels
+by stem harmony: kol → -ıyor, gel → -iyor, kork → -uyor, göz → -üyor. -/
+theorem progressive_I_resolution :
+    resolveI true  false = ı_vowel ∧
+    resolveI false false = i_vowel ∧
+    resolveI true  true  = u_vowel ∧
+    resolveI false true  = ü_vowel := ⟨rfl, rfl, rfl, rfl⟩
+
+/-- The archiphonemic A in future -(y)AcAK resolves to a/e by palatal
+harmony: kol → -(y)acak, gel → -(y)ecek. -/
+theorem future_A_resolution :
+    resolveA true  = a_vowel ∧
+    resolveA false = e_vowel := ⟨rfl, rfl⟩
 
 end GokselKerslake2005

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -21856,7 +21856,7 @@
   role      = {cited},
   sources   = {Studies/Haspelmath2007.lean;Fragments/Hausa/Coordination.lean}
 }
-@incollection{bickel-nichols-2001,
+@incollection{bickel-nichols-2007,
   author    = {Bickel, Balthasar and Nichols, Johanna},
   year      = {2007},
   title     = {Inflectional Morphology},
@@ -21869,7 +21869,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Corbett2000.lean;Studies/BickelNichols2013.lean;Morphology/MorphProfile.lean;Morphology/MorphRule.lean}
+  sources   = {Studies/Corbett2000.lean;Studies/BickelNichols2013.lean;Morphology/FusionTypology.lean;Morphology/Formative.lean}
 }
 @incollection{bickel-nichols-2013a,
   author    = {Bickel, Balthasar and Nichols, Johanna},


### PR DESCRIPTION
Two follow-ups from the stray-file cleanse (#1524):

- Rename `bickel-nichols-2001` → `bickel-nichols-2007` (entry was always the 2007 Shopen ch. 3; publisher page verified) across 21 files + bib; prose years updated.
- Fold `Fragments/Turkish/SuffixTemplate.lean` onto `Morphology.AffixTemplate` (pure data); ordering facts move to `Studies/GokselKerslake2005.lean` as slot-position predictions, replacing a `native_decide`.