### PR TITLE
refactor(Morphology): align B&N typology and carriers with primary sources

### DIFF
--- a/Linglib/Fragments/Arabic/Egyptian/Morph.lean
+++ b/Linglib/Fragments/Arabic/Egyptian/Morph.lean
@@ -5,11 +5,13 @@ import Linglib.Morphology.FusionTypology
 [wals-2013] [bickel-nichols-2007]
 
 WALS-derived profile for Egyptian Arabic (ISO `arz`, WALS code `aeg`).
-WALS F20A codes Arabic as `ablautConcatenative`, mapping to the local
-`.nonlinear` `Fusion` value. B&N flexive + cumulative are stipulated, but
-the language is NOT in the "fusional" cell because that requires
-`.concatenative` fusion — Arabic root-and-pattern templatic morphology
-is the canonical non-concatenative case.
+WALS F20A codes Arabic as `ablautConcatenative` — a mixed category the
+converter refuses — so `fusion` comes from the fallback `.nonlinear`:
+root-and-pattern morphology is predominantly nonlinear, though person and
+number inflection is concatenative ([bickel-nichols-2007] p. 183). The
+flexive + cumulative values are textbook-consensus summary stipulations
+(Semitic is [bickel-nichols-2007]'s flexive-nonlinear "introflexive"
+type, p. 186; the chapter types formatives, not whole languages).
 -/
 
 namespace Arabic.Egyptian
@@ -27,13 +29,11 @@ def morphProfile : MorphProfile :=
 example : morphProfile.iso = "arz" ∧ morphProfile.language = "Arabic (Egyptian)" :=
   ⟨rfl, rfl⟩
 
-/-- Arabic is NOT in the "fusional" cell despite being flexive + cumulative,
-    because templatic root-and-pattern morphology is `.nonlinear`, not
-    `.concatenative`. The `IsFusional` predicate correctly excludes it. -/
-example : ¬ morphProfile.IsFusional := by decide
-
-/-- Arabic is also not "agglutinating" — the same templatic morphology
-    fails the concatenative requirement. -/
-example : ¬ morphProfile.IsAgglutinating := by decide
+/-- Arabic is the "introflexive" type — flexive + nonlinear, the label
+    [bickel-nichols-2007] p. 186 reserve for exactly this combination —
+    hence neither agglutinating nor fusional (both require concatenative
+    fusion). -/
+example : morphProfile.IsIntroflexive ∧
+    ¬ morphProfile.IsFusional ∧ ¬ morphProfile.IsAgglutinating := by decide
 
 end Arabic.Egyptian

--- a/Linglib/Fragments/English/Morph.lean
+++ b/Linglib/Fragments/English/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # English Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for English (ISO `eng`). B&N 2007 places English
-in the "agglutinating" cell (concatenative + nonflexive + separative)
+WALS-derived profile for English (ISO `eng`). Textbook-consensus classification: English falls in the "agglutinating" cell (concatenative + nonflexive + separative)
 despite its small inflectional inventory; cf. [bickel-nichols-2007].
 -/
 
@@ -23,7 +22,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "eng" ∧ morphProfile.language = "English" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places English in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: English falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end English

--- a/Linglib/Fragments/Finnish/Morph.lean
+++ b/Linglib/Fragments/Finnish/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Finnish Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Finnish (ISO `fin`). B&N 2007 places Finnish in the
-"agglutinating" cell (concatenative + nonflexive + separative).
+WALS-derived profile for Finnish (ISO `fin`). Textbook-consensus classification: Finnish falls in the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
 namespace Finnish
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "fin" ∧ morphProfile.language = "Finnish" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Finnish in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Finnish falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Finnish

--- a/Linglib/Fragments/Georgian/Morph.lean
+++ b/Linglib/Fragments/Georgian/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Georgian Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Georgian (ISO `kat`). B&N 2007 places Georgian
-in the "fusional" cell (concatenative + flexive + cumulative).
+WALS-derived profile for Georgian (ISO `kat`). Textbook-consensus classification: Georgian falls in the "fusional" cell (concatenative + flexive + cumulative).
 -/
 
 namespace Georgian
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "kat" ∧ morphProfile.language = "Georgian" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Georgian in the "fusional" cell. -/
+/-- Textbook-consensus classification: Georgian falls in the "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Georgian

--- a/Linglib/Fragments/German/Morph.lean
+++ b/Linglib/Fragments/German/Morph.lean
@@ -5,10 +5,14 @@ import Linglib.Morphology.FusionTypology
 [wals-2013] [bickel-nichols-2007]
 
 WALS-derived profile (Ch 20A–29A, 21B, 62A, 79A/B, 80A) for German (ISO `deu`,
-WALS code `ger`). The B&N 2007 parameters (`flexivity := flexive`,
-`bnExponence := cumulative`) are not derivable from any WALS chapter and are
-paper-stipulated per [bickel-nichols-2007]; together with the WALS-derived
-`fusion := concatenative` they place German in the traditional "fusional" cell.
+WALS code `ger`). The `flexivity := flexive` and `bnExponence := cumulative`
+values are not derivable from any WALS chapter; they are textbook-consensus
+summary stipulations (strong-verb ablaut is [bickel-nichols-2007]'s own
+stem-flexivity example, p. 184 — though the same chapter's Table 3.5 puts
+Germanic *weak* verbs in the no-stem-allomorphy row, so the language-level
+bit summarizes a split system). Together with the WALS-derived
+`fusion := concatenative` they place German in the traditional "fusional"
+cell.
 
 WALS F20A's `exclusivelyConcatenative` verdict samples a small set of formatives
 and systematically under-weights ablaut (`singen` ~ `sang` ~ `gesungen`) and
@@ -22,7 +26,7 @@ open Morphology
 
 /-- German: WALS-derived `MorphProfile` via `MorphProfile.fromWALS`. Required-field
     fallbacks match WALS values (lookup wins when present); `flexivity` and
-    `bnExponence` are stipulated per B&N 2007. -/
+    `bnExponence` are textbook-consensus stipulations (see header). -/
 def morphProfile : MorphProfile :=
   .fromWALS "German" "deu"
     (fusionFb        := .concatenative)
@@ -33,7 +37,7 @@ def morphProfile : MorphProfile :=
 /-- Typo sentry for the ISO and language label. -/
 example : morphProfile.iso = "deu" ∧ morphProfile.language = "German" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places German in the "fusional" cell. Bridge theorem made local
+/-- Textbook-consensus classification: German falls in the "fusional" cell. Bridge theorem made local
     so the per-language commitment is visible here, not only inside
     `BickelNichols2013.lean`'s 18-language aggregate. -/
 example : morphProfile.IsFusional := by decide

--- a/Linglib/Fragments/Hindi/Morph.lean
+++ b/Linglib/Fragments/Hindi/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Hindi-Urdu Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Hindi-Urdu (ISO `hin`). B&N 2007 places Hindi-Urdu
-in the "fusional" cell (concatenative + flexive + cumulative).
+WALS-derived profile for Hindi-Urdu (ISO `hin`). Textbook-consensus classification: Hindi-Urdu falls in the "fusional" cell (concatenative + flexive + cumulative).
 -/
 
 namespace Hindi
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "hin" ∧ morphProfile.language = "Hindi-Urdu" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Hindi-Urdu in the "fusional" cell. -/
+/-- Textbook-consensus classification: Hindi-Urdu falls in the "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Hindi

--- a/Linglib/Fragments/Hungarian/Morph.lean
+++ b/Linglib/Fragments/Hungarian/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Hungarian Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Hungarian (ISO `hun`). B&N 2007 places Hungarian
-in the "agglutinating" cell (concatenative + nonflexive + separative).
+WALS-derived profile for Hungarian (ISO `hun`). Textbook-consensus classification: Hungarian falls in the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
 namespace Hungarian
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "hun" ∧ morphProfile.language = "Hungarian" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Hungarian in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Hungarian falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Hungarian

--- a/Linglib/Fragments/Japanese/Morph.lean
+++ b/Linglib/Fragments/Japanese/Morph.lean
@@ -6,8 +6,7 @@ import Linglib.Morphology.Template
 # Japanese Morphological Profile
 [wals-2013] [bickel-nichols-2007] [kaiser-yamamoto-2013]
 
-WALS-derived profile for Japanese (ISO `jpn`). B&N 2007 places Japanese
-in the "agglutinating" cell (concatenative + nonflexive + separative).
+WALS-derived profile for Japanese (ISO `jpn`). Textbook-consensus classification: Japanese falls in the "agglutinating" cell (concatenative + nonflexive + separative).
 
 The verb suffix template (`verbAffixTemplate`) follows [kaiser-yamamoto-2013]
 and the UD segmentation: seven slots, stem-outward.
@@ -37,7 +36,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "jpn" ∧ morphProfile.language = "Japanese" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Japanese in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Japanese falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 /-- Japanese verb suffix template, stem-outward ([kaiser-yamamoto-2013], UD

--- a/Linglib/Fragments/Korean/Morph.lean
+++ b/Linglib/Fragments/Korean/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Korean Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Korean (ISO `kor`). B&N 2007 places Korean
-in the "agglutinating" cell (concatenative + nonflexive + separative).
+WALS-derived profile for Korean (ISO `kor`). Textbook-consensus classification: Korean falls in the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
 namespace Korean
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "kor" ∧ morphProfile.language = "Korean" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Korean in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Korean falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Korean

--- a/Linglib/Fragments/Mandarin/Morph.lean
+++ b/Linglib/Fragments/Mandarin/Morph.lean
@@ -7,8 +7,10 @@ import Linglib.Morphology.FusionTypology
 WALS-derived profile for Mandarin Chinese (ISO `cmn`). WALS F20A codes
 Mandarin as `isolatingConcatenative`, a mixed type the local 3-way `Fusion`
 enum cannot represent — `walsFusion` returns `none` and the fallback
-`.isolating` is exercised. B&N 2007 flexivity/bnExponence are not stipulated
-because the largely isolating typology renders them inapplicable.
+`.isolating` is exercised. flexivity/bnExponence are left uncoded (`none`)
+here — not because isolating voids them ([bickel-nichols-2007] pp. 186-187
+attest both flexive-isolating and nonflexive-isolating formatives) but
+because no consensus language-level value is stipulated for Mandarin.
 -/
 
 namespace Mandarin

--- a/Linglib/Fragments/Quechua/Morph.lean
+++ b/Linglib/Fragments/Quechua/Morph.lean
@@ -4,8 +4,9 @@ import Linglib.Morphology.FusionTypology
 # Quechua (Imbabura) Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Imbabura Quechua (ISO `qvi`). B&N 2007 places
-Quechua in the "agglutinating" cell (concatenative + nonflexive + separative).
+WALS-derived profile for Imbabura Quechua (ISO `qvi`). Textbook-consensus
+classification: Quechua falls in the "agglutinating" cell (concatenative +
+nonflexive + separative).
 Consistent with the Imbabura data used in the Negation and PolarityItems
 fragments in this directory.
 -/
@@ -25,7 +26,7 @@ def morphProfile : MorphProfile :=
 example : morphProfile.iso = "qvi" ∧ morphProfile.language = "Quechua (Imbabura)" :=
   ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Quechua in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Quechua falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Quechua

--- a/Linglib/Fragments/Slavic/Russian/Morph.lean
+++ b/Linglib/Fragments/Slavic/Russian/Morph.lean
@@ -4,11 +4,13 @@ import Linglib.Morphology.FusionTypology
 # Russian Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Russian (ISO `rus`). B&N 2007 places Russian in the
-canonical "fusional" cell (concatenative + flexive + cumulative); the genitive
-singular *-ī ~ -ae ~ -ūs* class-conditioned allomorphy pattern cited by
-B&N as the diagnostic for flexivity is the same pattern Russian instantiates
-across declension classes.
+WALS-derived profile for Russian (ISO `rus`). Textbook-consensus
+classification: Russian falls in the "fusional" cell (concatenative +
+flexive + cumulative). [bickel-nichols-2007] p. 187: "Russian case
+desinences are mostly dependent on lexical declension classes and are
+therefore ﬂexive" — *mostly*: the same page notes the dative, instrumental,
+and locative plural formatives are invariant, so the language-level bit
+summarizes a split system.
 -/
 
 namespace Russian
@@ -25,7 +27,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "rus" ∧ morphProfile.language = "Russian" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Russian in the canonical "fusional" cell. -/
+/-- Textbook-consensus classification: Russian falls in the canonical "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Russian

--- a/Linglib/Fragments/Spanish/Morph.lean
+++ b/Linglib/Fragments/Spanish/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Spanish Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Spanish (ISO `spa`). B&N 2007 places Spanish in
-the "fusional" cell (concatenative + flexive + cumulative).
+WALS-derived profile for Spanish (ISO `spa`). Textbook-consensus classification: Spanish falls in the "fusional" cell (concatenative + flexive + cumulative).
 -/
 
 namespace Spanish
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "spa" ∧ morphProfile.language = "Spanish" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Spanish in the "fusional" cell. -/
+/-- Textbook-consensus classification: Spanish falls in the "fusional" cell. -/
 example : morphProfile.IsFusional := by decide
 
 end Spanish

--- a/Linglib/Fragments/Swahili/Morph.lean
+++ b/Linglib/Fragments/Swahili/Morph.lean
@@ -4,10 +4,9 @@ import Linglib.Morphology.FusionTypology
 # Swahili Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Swahili (ISO `swh`). B&N 2007 places Swahili in the
-"agglutinating" cell (concatenative + nonflexive + separative); Swahili is
-unusual among the 18-language sample in being weakly prefixing rather than
-suffixing.
+WALS-derived profile for Swahili (ISO `swh`). Textbook-consensus classification: Swahili falls in the "agglutinating" cell (concatenative + nonflexive + separative); Swahili is
+the sample's one weakly prefixing (rather than suffixing) member — the
+18-language sample is linglib's own, not B&N's.
 -/
 
 namespace Swahili
@@ -24,7 +23,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "swh" ∧ morphProfile.language = "Swahili" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Swahili in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Swahili falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Swahili

--- a/Linglib/Fragments/Tagalog/Morph.lean
+++ b/Linglib/Fragments/Tagalog/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Tagalog Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Tagalog (ISO `tgl`). B&N 2007 places Tagalog in
-the "agglutinating" cell (concatenative + nonflexive + separative).
+WALS-derived profile for Tagalog (ISO `tgl`). Textbook-consensus classification: Tagalog falls in the "agglutinating" cell (concatenative + nonflexive + separative).
 -/
 
 namespace Tagalog
@@ -22,7 +21,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "tgl" ∧ morphProfile.language = "Tagalog" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Tagalog in the "agglutinating" cell. -/
+/-- Textbook-consensus classification: Tagalog falls in the "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Tagalog

--- a/Linglib/Fragments/Thai/Morph.lean
+++ b/Linglib/Fragments/Thai/Morph.lean
@@ -8,7 +8,8 @@ WALS-derived profile for Thai (ISO `tha`). WALS F20A codes Thai as
 `isolatingConcatenative`, a mixed type the local 3-way `Fusion` enum cannot
 represent — `walsFusion` returns `none` and the fallback `.isolating` is
 exercised. F21A returns `noCase`, mapping to `none`; the local `.noCase`
-fallback is exercised. B&N 2007 flexivity/bnExponence are not stipulated.
+fallback is exercised. flexivity/bnExponence are left uncoded (`none`): no
+consensus language-level value is stipulated for Thai.
 -/
 
 namespace Thai

--- a/Linglib/Fragments/Turkish/Morph.lean
+++ b/Linglib/Fragments/Turkish/Morph.lean
@@ -4,8 +4,7 @@ import Linglib.Morphology.FusionTypology
 # Turkish Morphological Profile
 [wals-2013] [bickel-nichols-2007]
 
-WALS-derived profile for Turkish (ISO `tur`). B&N 2007 places Turkish in
-the canonical "agglutinating" cell (concatenative + nonflexive + separative);
+WALS-derived profile for Turkish (ISO `tur`). Textbook-consensus classification: Turkish falls in the canonical "agglutinating" cell (concatenative + nonflexive + separative);
 Turkish is the textbook example of rule-governed (vowel-harmony) suffix
 allomorphy with no class-conditioned variation.
 -/
@@ -24,7 +23,7 @@ def morphProfile : MorphProfile :=
 
 example : morphProfile.iso = "tur" ∧ morphProfile.language = "Turkish" := ⟨rfl, rfl⟩
 
-/-- B&N 2007 places Turkish in the canonical "agglutinating" cell. -/
+/-- Textbook-consensus classification: Turkish falls in the canonical "agglutinating" cell. -/
 example : morphProfile.IsAgglutinating := by decide
 
 end Turkish

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -9,7 +9,10 @@ import Mathlib.Data.Set.Basic
 content to form) is the class every framework engine's carrier implements:
 an exponent projection and an applicability set, ordered by set inclusion
 ([kiparsky-1973]'s Elsewhere Condition), so the most specific applicable
-rule has the smallest applicability domain. The order is [stump-2022]'s
+rule has the smallest applicability domain. The class is selection-side
+only: the phonological substance of exponents (additive vs
+transformational vs templatic, [trommer-zimmermann-2015]) is opaque in
+`F` and lives in `Phonology/`. The order is [stump-2022]'s
 single-clause formulation of Pāṇini's principle — domain-subset precedence
 — to which [stump-2001]'s two-clause rule narrowness collapses when
 contexts pair expressions with their full property sets. Selection over

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -20,7 +20,12 @@ theorem from that engine's score-reflection lemma. The order/select/realize
 triad: `Basic` orders rules by specificity, `selectBy` selects the optimal
 applicable rule, `realize` reads off its exponent. The theory models
 selection within a single rule block; realizational frameworks compose
-per-block winners into the paradigm function ([stump-2001]).
+per-block winners into the paradigm function ([stump-2001]). Since
+`Realizes.eq` makes the per-block prediction unique, *optional* multiple
+exponence within a block (free co-realization variants, Jubba Maay —
+[trommer-zimmermann-2015] p. 60) is outside scope, not merely a
+multi-block composition matter; deterministic symbiotic co-exponence
+composes across blocks as usual.
 
 ## Main declarations
 

--- a/Linglib/Morphology/Formative.lean
+++ b/Linglib/Morphology/Formative.lean
@@ -24,18 +24,25 @@ inductive AttachmentSide where
   deriving DecidableEq, Repr
 
 /-- Typological position classification for formatives.
-    [bickel-nichols-2007] Table 2.
+    [bickel-nichols-2007] Table 3.2 (p. 198), flattened: the table crosses
+    five positions (Prae/In/Post/Simul/Detached) with formative types; this
+    enum keeps the positions, promoting circumfixation (the table's common
+    Simul subtype) and endoclisis (an In subtype) to their own cases.
 
-    Superset of `AttachmentSide`: adds simulfixation (process morphology),
-    detached formatives (Wackernagel clitics, free auxiliaries), and
-    endoclisis (clitic insertion inside a word). -/
+    Superset of `AttachmentSide`: adds simulfixation, detached formatives
+    (Wackernagel clitics, free auxiliaries), and endoclisis (clitic
+    insertion inside a word). -/
 inductive FormativePosition where
   | praefixed     -- formative precedes host (= `AttachmentSide.prefix`)
   | postfixed     -- formative follows host (= `AttachmentSide.suffix`)
   | infixed       -- formative inserted within host (= `AttachmentSide.infix`)
   | circumfixed   -- formative wraps host (= `AttachmentSide.circumfix`)
-  | simultaneous  -- non-segmental: ablaut, umlaut, tonal change, reduplication
-  | detached      -- syntactically free formative (auxiliary, Wackernagel clitic)
+  /-- Several tokens of one morpheme realized at different places in the
+  word ([bickel-nichols-2007] p. 200, after Hagège) — NOT process
+  morphology: bare ablaut, substitution, and subtraction are In-position
+  formatives, reduplication is Prae/Post, in the source table. -/
+  | simultaneous
+  | detached      -- not attached to its host (may still be phonologically bound)
   | endoclitic    -- clitic inserted inside a word (Udi, European Portuguese)
   deriving DecidableEq, Repr
 

--- a/Linglib/Morphology/FusionTypology.lean
+++ b/Linglib/Morphology/FusionTypology.lean
@@ -11,8 +11,12 @@ record, WALS grounding functions, and the traditional agglutinating/fusional
 predicates with their mutual-exclusion theorems.
 
 The `fusion` and `exponence` fields are derived from WALS Chapters 20 and 21;
-the orthogonal `flexivity` and `bnExponence` parameters are paper-stipulated
-per [bickel-nichols-2007] and not derivable from WALS.
+the orthogonal `flexivity` and `bnExponence` parameters are not derivable from
+WALS and are stipulated per language in the Fragments as textbook-consensus
+summary values. [bickel-nichols-2007] themselves type *formatives*, not
+languages ("it clearly makes little sense to talk about concatenative or
+nonlinear languages per se", p. 183); a profile's value summarizes the
+language's dominant formative type.
 -/
 
 namespace Morphology
@@ -39,16 +43,22 @@ inductive Fusion where
 
     [bickel-nichols-2007] argue this is the crucial parameter that
     the traditional typology conflates with fusion:
-    - **nonflexive** ("agglutinating"): formatives have invariant or
-      rule-governed shape (Turkish *-ler* ~ *-lar* is vowel-harmony,
+    - **nonflexive**: formatives "are invariant across the lexicon"
+      (p. 185) or vary by rule (Turkish *-ler* ~ *-lar* is vowel-harmony,
       not item-based allomorphy)
-    - **flexive** ("fusional"): formatives vary unpredictably by
-      inflectional class (Latin *-ī* ~ *-ae* ~ *-ūs* for genitive
-      singular depending on declension class)
+    - **flexive**: formatives "come in sets of variants called allomorphs
+      ... selected on lexical, i.e. item-based, principles" (p. 184;
+      Latin nominative singular *-s* ~ *-m* ~ zero by declension class).
+      Traditionally "(in)ﬂecting" (German *flektierend*); B&N's fn. 9
+      (p. 184) rejects Comrie's "fusional" for this parameter as
+      conflating flexivity with phonological fusion.
 
-    Orthogonal to `Fusion`: a language can be concatenative + nonflexive
-    (Turkish), concatenative + flexive (Russian), nonlinear + flexive
-    (Arabic), or isolating (flexivity N/A). -/
+    "Flexivity is orthogonal to fusion, and all possible combinations of
+    values on the two parameters are attested" (p. 186) — all SIX cells
+    of the 3 × 2 space, including flexive-isolating (Yidiɲ) and
+    nonflexive-isolating (Lai Chin, p. 187). A `none` value in
+    `MorphProfile.flexivity` therefore means *not coded here*, never
+    "inapplicable because isolating". -/
 inductive Flexivity where
   | nonflexive   -- formatives phonologically invariant / rule-governed
   | flexive      -- formatives show item-based (class-conditioned) allomorphy
@@ -59,8 +69,9 @@ inductive Flexivity where
     bundle number, TAM, etc.
 
     Distinct from `ExponenceScope` (B&N's broader cumulative/separative
-    parameter which applies to all morphological categories, not just case).
-    [bickel-nichols-2007] -/
+    parameter which applies to all morphological categories, not just
+    case). The mono/polyexponential value labels are WALS Ch 21's
+    ([bickel-nichols-2013b]), not the chapter's. -/
 inductive CaseExponence where
   | monoexponential
   | polyexponential
@@ -109,13 +120,20 @@ structure MorphProfile where
 -- §3. WALS Converter Functions
 -- ============================================================================
 
-/-- Convert WALS 20A fusion type to the local three-way `Fusion` classification.
-    Returns `none` for mixed categories that do not map cleanly. -/
+/-- Convert WALS 20A fusion type to the local three-way `Fusion`
+    classification. Every mixed WALS category (`ablautConcatenative`,
+    `tonalIsolating`, `tonalConcatenative`, `isolatingConcatenative`)
+    returns `none`: WALS 20A itself refuses a pure whole-language value
+    for these, and collapsing a mixture to one pole is a per-language
+    analytic judgment that belongs in the Fragment's fallback with its
+    own docstring (e.g. Arabic: predominantly nonlinear, though person
+    and number inflection is concatenative — [bickel-nichols-2007]
+    p. 183). -/
 def fromWALS20A : Data.WALS.F20A.FusionType → Option Fusion
   | .exclusivelyConcatenative => some .concatenative
   | .exclusivelyIsolating     => some .isolating
   | .exclusivelyTonal         => some .nonlinear
-  | .ablautConcatenative      => some .nonlinear
+  | .ablautConcatenative      => none
   | .tonalIsolating           => none
   | .tonalConcatenative       => none
   | .isolatingConcatenative   => none
@@ -158,9 +176,11 @@ def walsExponence (iso : String) : Option CaseExponence :=
     enum and yields `none`). When WALS has data the lookup wins; the fallback
     is exercised only when WALS is silent.
 
-    The B&N 2007 parameters `flexivity` and `bnExponence` are NOT derivable
-    from any WALS chapter — they are paper-stipulated per
-    [bickel-nichols-2007] and must be passed explicitly when known. -/
+    The `flexivity` and `bnExponence` parameters are NOT derivable from any
+    WALS chapter and must be passed explicitly when known. They are
+    per-language textbook-consensus summary values supplied by the Fragments
+    — [bickel-nichols-2007] themselves type formatives, not languages
+    (p. 183), and stipulate no per-language table. -/
 def MorphProfile.fromWALS
     (language iso : String)
     (fusionFb : Fusion)
@@ -227,24 +247,42 @@ def IsSeparative (p : MorphProfile) : Prop := p.bnExponence = some .separative
 instance : DecidablePred IsSeparative :=
   fun p => decidable_of_iff _ (isSeparative_iff p).symm
 
-/-- Traditional "agglutinating" = concatenative + nonflexive + separative.
-    [bickel-nichols-2007] decomposition of the traditional typology. -/
+/-- Traditional "agglutinative" = concatenative + nonflexive: "When
+    nonﬂexive formatives are concatenative, they are traditionally called
+    agglutinative" ([bickel-nichols-2007] p. 187). Exponence is *not* part
+    of the definition — separative exponence is a defeasible tendency of
+    this type, not a criterion (p. 189: Turkish 1pl *-k* cumulates person
+    and number yet is "clearly nonﬂexive"). -/
 def IsAgglutinating (p : MorphProfile) : Prop :=
-  p.IsConcatenative ∧ p.IsNonflexive ∧ p.IsSeparative
+  p.IsConcatenative ∧ p.IsNonflexive
 @[simp] theorem isAgglutinating_iff (p : MorphProfile) :
-    p.IsAgglutinating ↔ p.IsConcatenative ∧ p.IsNonflexive ∧ p.IsSeparative :=
+    p.IsAgglutinating ↔ p.IsConcatenative ∧ p.IsNonflexive :=
   Iff.rfl
 instance : DecidablePred IsAgglutinating :=
   fun p => decidable_of_iff _ (isAgglutinating_iff p).symm
 
-/-- Traditional "fusional" = concatenative + flexive + cumulative.
-    [bickel-nichols-2007] decomposition of the traditional typology. -/
+/-- Traditional "fusional" (textbook label) = concatenative + flexive:
+    "the traditional notion of ﬂexive or '(in)ﬂecting' is often restricted
+    to just this combination" ([bickel-nichols-2007] p. 186; the chapter
+    itself avoids "fusional" — fn. 9 rejects it as conflating flexivity
+    with fusion). Cumulative exponence is a tendency of this type, not a
+    criterion (p. 189). -/
 def IsFusional (p : MorphProfile) : Prop :=
-  p.IsConcatenative ∧ p.IsFlexive ∧ p.IsCumulative
+  p.IsConcatenative ∧ p.IsFlexive
 @[simp] theorem isFusional_iff (p : MorphProfile) :
-    p.IsFusional ↔ p.IsConcatenative ∧ p.IsFlexive ∧ p.IsCumulative := Iff.rfl
+    p.IsFusional ↔ p.IsConcatenative ∧ p.IsFlexive := Iff.rfl
 instance : DecidablePred IsFusional :=
   fun p => decidable_of_iff _ (isFusional_iff p).symm
+
+/-- "Introflexive" = nonlinear + flexive: "the label introﬂexive for just
+    this combination" ([bickel-nichols-2007] p. 186) — the classic Semitic
+    root-and-pattern profile. -/
+def IsIntroflexive (p : MorphProfile) : Prop :=
+  p.IsNonlinear ∧ p.IsFlexive
+@[simp] theorem isIntroflexive_iff (p : MorphProfile) :
+    p.IsIntroflexive ↔ p.IsNonlinear ∧ p.IsFlexive := Iff.rfl
+instance : DecidablePred IsIntroflexive :=
+  fun p => decidable_of_iff _ (isIntroflexive_iff p).symm
 
 end MorphProfile
 
@@ -277,7 +315,7 @@ theorem cumulative_separative_exclusive (p : MorphProfile) :
     flexivity values (nonflexive vs flexive). Follows from the B&N
     decomposition; not an empirical observation. -/
 theorem agglutinating_fusional_exclusive (p : MorphProfile) :
-    ¬(p.IsAgglutinating ∧ p.IsFusional) := fun ⟨⟨_, hnf, _⟩, _, hf, _⟩ =>
+    ¬(p.IsAgglutinating ∧ p.IsFusional) := fun ⟨⟨_, hnf⟩, _, hf⟩ =>
   nonflexive_flexive_exclusive p ⟨hnf, hf⟩
 
 end MorphProfile

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -6,14 +6,22 @@ import Mathlib.Tactic.DeriveFintype
 
 The form-side carrier of the morphology layer, following
 [haspelmath-2020]'s proposal: a **morph** is a minimal linguistic form —
-a minimal pairing of syntacticosemantic content with a continuous string
-of phonological segments. Morphs are never zero and never discontinuous
+[haspelmath-2020] defines it as a minimal pairing of syntacticosemantic
+content with a continuous string of phonological segments, but the
+carrier stores only the form side, which is what keeps empty and
+superfluous morphs (Cree connective *-t-*, [anderson-2015] p. 19)
+representable. Morphs are never zero and never discontinuous
 (a "circumfix" is a construction containing a prefix and a suffix, not a
 single morph); zero and discontinuity live one level up, in the
-**exponent** — a possibly empty sequence of morphs. Nonconcatenative
-exponence (apophony, reduplication, tone) is a process, not a form, and
-is out of this carrier's scope (`Morphology/MorphWord.lean` and the
-autosegmental machinery cover it).
+**exponent** — a possibly empty sequence of morphs. `[]` means *no
+segmental exponent*, not *unmarked*: a cell whose sole marker is a
+process (North Saami gradation-only genitives, [anderson-2015] p. 22)
+also renders as `[]` here. Nonconcatenative exponence (apophony,
+reduplication, tone, subtraction) is a process, not a form, and is out
+of this carrier's scope — `MorphWord`'s tree constructors cover
+reduplication and conversion, the autosegmental machinery covers tone;
+the rest of the process catalogue ([anderson-2015] pp. 21-24), like
+overlapping morphs (Breton mutation, p. 20), currently has no carrier.
 
 `Morph.Kind` records the attachment classification that descriptive
 notation itself encodes — `X-` prefix, `-X` suffix, `X=` proclitic,
@@ -110,8 +118,9 @@ def Exponent.toString : Exponent → String
 
 /-- The class of the following segment — the commonest conditioning
 environment for selecting among a morph's variant shapes
-(pre-consonantal vs pre-vocalic allomorph pairs; the phonological
-conditioning of [haspelmath-2020] §7). -/
+(pre-consonantal vs pre-vocalic pairs; phonological conditioning in
+[haspelmath-2020]'s sense, which cross-cuts the variant-vs-suppletive
+split of their §§6-8). -/
 inductive Following where
   | consonant | vowel
   deriving DecidableEq, Repr, Fintype

--- a/Linglib/Morphology/MorphWord.lean
+++ b/Linglib/Morphology/MorphWord.lean
@@ -30,7 +30,7 @@ positions are implicit between adjacent morphemes in the flattened list.
 | `circumfixed`  | circumfix wrapping            | German *ge-mach-t*            |
 | `compound`     | compounding                   | *desk* + *lamp*               |
 | `reduplicated` | total or partial reduplication| Warlpiri *kijikiji*           |
-| `converted`    | zero affixation / conversion  | noun *telephone* → verb       |
+| `converted`    | conversion                    | noun *telephone* → verb       |
 
 -/
 
@@ -62,7 +62,7 @@ structure CircumfixExponence where
 def CircumfixExponence.realize (c : CircumfixExponence) : String :=
   c.prefix_ ++ c.stem ++ c.suffix_
 
-/-- A circumfix as a two-morph construction. [haspelmath-2020] (p. 123)
+/-- A circumfix as a two-morph construction. [haspelmath-2020] §4
 treats a circumfix not as one discontinuous morph but as a construction
 containing a prefix and a suffix; this realizes that reading as the
 prefix/suffix `Morph`s of `Morphology/Morph.lean` (the stem is not part
@@ -111,7 +111,9 @@ open Morphology.Circumfix (CircumfixExponence)
 -- §1: Morpheme
 -- ============================================================================
 
-/-- A morpheme: the minimal meaningful unit (Hayes §5.1).
+/-- A morpheme: the classical "minimal meaningful unit" ([hayes-2009];
+[anderson-2015] problematizes the classical definition — this carrier
+keeps it as the descriptive convenience both textbooks use).
 
 Carries its form as a `Morph` (`Morphology/Morph.lean`), an optional
 gloss, and its morphological `status`. `status` (`MorphStatus`) and
@@ -131,7 +133,7 @@ def Morpheme.surface (m : Morpheme) : String := m.morph.form
 -- §2: Reduplication Type
 -- ============================================================================
 
-/-- Type of reduplication (Hayes §5.2).
+/-- Type of reduplication ([hayes-2009]).
 
 - `total`: copies the entire base (Warlpiri *kijikiji* from *kiji*)
 - `partialCopy copied`: copies a prosodic template; the copied material is
@@ -150,27 +152,28 @@ inductive RedupType where
 /-- Hierarchical word structure as a tree of morphemes.
 
 Each constructor corresponds to a morphological operation from
-Hayes §5.2–5.5. The tree structure captures the derivational
-history and word-internal constituency. -/
+[hayes-2009]'s survey — the item-and-arrangement tree-of-morphemes
+lineage ([anderson-2015] pp. 28-29), with `reduplicated`/`converted` as
+process-constructor exceptions. The tree structure captures the
+derivational history and word-internal constituency. -/
 inductive MorphWord where
   /-- Leaf node: a single morpheme (free or bound). -/
   | root : Morpheme → MorphWord
-  /-- Hayes §5.2: attach morpheme before base. -/
+  /-- Attach morpheme before base. -/
   | prefixed : Morpheme → MorphWord → MorphWord
-  /-- Hayes §5.2: attach morpheme after base. -/
+  /-- Attach morpheme after base. -/
   | suffixed : MorphWord → Morpheme → MorphWord
-  /-- Hayes §5.2: insert morpheme at position `pos` within base's
+  /-- Insert morpheme at position `pos` within base's
       surface form. Example: Tagalog *-um-* in *s⟨um⟩ulat*. -/
   | infixed : MorphWord → Morpheme → Nat → MorphWord
-  /-- Hayes §5.2: wrap base with a prefix and suffix.
+  /-- Wrap base with a prefix and suffix.
       Example: German *ge-mach-t*. -/
   | circumfixed : Morpheme → MorphWord → Morpheme → MorphWord
-  /-- Hayes §5.4: two stems joined. Example: *desk* + *lamp*. -/
+  /-- Two stems joined. Example: *desk* + *lamp*. -/
   | compound : MorphWord → MorphWord → MorphWord
-  /-- Hayes §5.2: total or partial reduplication. -/
+  /-- Total or partial reduplication. -/
   | reduplicated : RedupType → MorphWord → MorphWord
-  /-- Hayes §5.2: zero affixation / conversion.
-      Example: noun *telephone* → verb *to telephone*. -/
+  /-- Conversion. Example: noun *telephone* → verb *to telephone*. -/
   | converted : MorphWord → MorphWord
   deriving Repr
 
@@ -206,9 +209,7 @@ def MorphWord.morphemes : MorphWord → List Morpheme
   | .prefixed afx base => afx :: base.morphemes
   | .suffixed base afx => base.morphemes ++ [afx]
   | .infixed base afx _ => base.morphemes ++ [afx]
-  | .circumfixed pre base suf =>
-    ⟨pre.morph, pre.gloss, .inflAffix⟩ :: base.morphemes
-      ++ [⟨suf.morph, suf.gloss, .inflAffix⟩]
+  | .circumfixed pre base suf => pre :: base.morphemes ++ [suf]
   | .compound left right => left.morphemes ++ right.morphemes
   | .reduplicated _ base => base.morphemes
   | .converted base => base.morphemes
@@ -219,7 +220,7 @@ def MorphWord.morphemeCount (w : MorphWord) : Nat := w.morphemes.length
 /-- Positions of morpheme boundaries in the surface string.
 Each `Nat` is a character offset where one morpheme ends and
 the next begins. Phonological rules can reference these
-positions (Hayes Chs 6–8). -/
+positions ([hayes-2009]). -/
 def MorphWord.boundaryPositions : MorphWord → List Nat
   | .root _ => []
   | .prefixed afx base =>
@@ -281,7 +282,7 @@ def MorphWord.IsReduplicated : MorphWord → Prop
 instance : DecidablePred MorphWord.IsReduplicated := fun w => by
   cases w <;> unfold MorphWord.IsReduplicated <;> infer_instance
 
-/-- Is this word derived by conversion (zero affixation)? -/
+/-- Is this word derived by conversion? -/
 def MorphWord.IsConverted : MorphWord → Prop
   | .converted _ => True
   | _ => False

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -2,10 +2,12 @@ import Mathlib.Logic.Function.Basic
 
 /-!
 # Paradigm linkage: content paradigms, form paradigms, and correspondence
-[stump-2016]
+[stump-2016] [stump-2006]
 
-The paradigm-linkage hypothesis ([stump-2016] Ch. 7) splits a lexeme's
-realizations into three corresponding paradigms:
+The paradigm-linkage hypothesis ([stump-2016] Ch. 7; the content/form
+paradigm split originates with [stump-2006], introduced in part to
+describe heteroclisis) splits a lexeme's realizations into three
+corresponding paradigms:
 
 * the **content paradigm** — cells `⟨L, σ⟩` pairing a lexeme `L` with a
   morphosyntactic property set `σ`; the interface with syntax and semantics;

--- a/Linglib/Morphology/Paradigm/Morphome.lean
+++ b/Linglib/Morphology/Paradigm/Morphome.lean
@@ -24,6 +24,16 @@ instantiation, supplied by the consumer (see `Studies/Herce2023.lean`).
 Systematicity — recurrence of the pattern under more than one exponent or
 allomorph — is a separate criterion the consumer establishes.
 
+Two limitations, per [baerman-2015]'s three-way analysis space for
+syncretism (morphosyntactic identity / underspecification / morphological
+stipulation, p. 146): an **elsewhere** form's fiber is typically also
+nontrivial and non-natural (one specified cell, the default covers the
+unnatural rest — Skou, p. 145), so `IsMorphome` is necessary but not
+sufficient for stipulation-hood; distinguishing the two needs opposition
+structure or the systematicity criterion above. And **directional**
+syncretism (a cell wearing another cell's form "in place of the expected"
+one, p. 142) is invisible to the symmetric kernel.
+
 The vocabulary here is deliberately just "morphome": [herce-2023] rejects
 Round's rhizomorphome ~ metamorphome ~ meromorphome subdivision as needless
 jargon, and "metasyncretism" does not appear in the book.

--- a/Linglib/Morphology/Periphrasis.lean
+++ b/Linglib/Morphology/Periphrasis.lean
@@ -1,23 +1,31 @@
 import Linglib.Morphology.RelevanceHierarchy
 
 /-!
-# Inflectional distribution in periphrasis
-[anderson-2006] [bybee-1985]
+# Inflectional distribution in auxiliary verb constructions
+[anderson-2006] [spencer-popova-2015]
 
-The split of inflectional categories between the two elements of a
-periphrastic construction.
+The split of inflectional categories between the two elements of an
+auxiliary verb construction. Possessing such a distribution is neutral on
+periphrasis-hood: serial-verb and light-verb constructions distribute
+inflection too, and periphrasis proper requires paradigm-cell integration
+([spencer-popova-2015] pp. 200, 204). The distribution data is the raw
+material for the distributed-exponence criterion the periphrasis
+literature states over it.
 -/
 
 namespace Morphology
 
-/-- Distribution of inflectional categories between two elements of a
-    periphrastic construction (e.g., auxiliary and lexical verb in an AVC).
-    [anderson-2006] [bybee-1985]
+/-- Distribution of inflectional categories between the two elements of an
+    auxiliary verb construction. The category vocabulary is
+    `MorphCategory` ([bybee-1985]'s relevance hierarchy); the pattern
+    taxonomy is [anderson-2006]'s AVC classification:
 
-    In an aux-headed AVC, `onLex` is minimal (stem only or empty).
-    In a lex-headed AVC, `onAux` is empty.
-    In a split AVC, `onAux` and `onLex` host different category types.
-    In a doubled AVC, `onAux` and `onLex` overlap. -/
+    - aux-headed: `onLex` minimal (stem only or empty).
+    - lex-headed: `onAux` empty or minimal (e.g. tonal subject person,
+      Doyayo — [anderson-2006] p. 120).
+    - split: `onAux` and `onLex` host different category types.
+    - doubled: `onAux` and `onLex` coincide.
+    - split/doubled: some category doubled on both, others split. -/
 structure InflDistribution where
   onAux : List MorphCategory
   onLex : List MorphCategory

--- a/Linglib/Morphology/Template.lean
+++ b/Linglib/Morphology/Template.lean
@@ -6,9 +6,14 @@ import Mathlib.Tactic.TypeStar
 A **template** stipulates a word's positional skeleton directly — the
 word-skeletal answer to where affix order comes from, rival to the
 rule-combining answer on which templates are emergent patterns of rule
-composition ([stump-2022]). `AffixTemplate` is the position-class species
-(a prosodic/CV species would be its sibling); the rivalry itself is study
-content, not settled here.
+composition ([stump-2022]). The layered-vs-templatic *typological*
+contrast and its diagnostics (long-distance slot dependencies,
+non-functional slot assignment) are [bickel-nichols-2007] §6, with the
+caveat that templatic vs layered properties "are likely to hold of
+individual formatives rather than of the entire string" (p. 219).
+`AffixTemplate` is the position-class species (a prosodic/CV species
+would be its sibling); the rivalry itself is study content, not settled
+here.
 
 A word's affix template: the ordered position-class slots of its prefix and
 suffix strings, parameterized by the slot type `Slot` — so the order lives

--- a/Linglib/Morphology/UsageBased/Network.lean
+++ b/Linglib/Morphology/UsageBased/Network.lean
@@ -6,11 +6,11 @@ import Mathlib.Tactic.DeriveFintype
 
 This file formalizes the substrate of Bybee 1985 Ch 5 ("Two Principles in
 a Dynamic Model of Lexical Representation," pp. 111-135). It is a peer-
-framework directory alongside `Morphology/{DM, PFM, WP,
-Nanosyntax, FragmentGrammars}/` — Bybee's network model is *the*
-usage-based competitor to the realisational and generative camps, and the
-audit (4-agent, 0.230.453) flagged its absence as the most important
-architectural gap in linglib's morphology layer.
+framework directory alongside `Morphology/{DM, Nanosyntax,
+FragmentGrammars}/` — Bybee's network model is *the* usage-based
+competitor to the realisational and generative camps. Not to be confused
+with Network Morphology (Corbett & Fraser's DATR-based default-inheritance
+framework), which shares only the word "network".
 
 ## The Two Principles
 
@@ -46,6 +46,10 @@ forms (*don't*, *won't* — Zwicky-Pullum 1983).
 
 ## What this file does NOT cover
 
+- The frequency–connection interaction: Bybee's closeness factor (c) has
+  high-frequency items forming *more distant* connections (autonomy), but
+  `strength` here is monotone in `tokenFreq` and no connection weakens
+  with frequency — the autonomy half of the model is not yet encoded
 - Ch 5 §10 morphological classes as emergent from network connection
   density — deferred to a future `SchemaInduction.lean` sibling
 - Ch 5 §11 productivity from class size + variance — deferred

--- a/Linglib/Studies/BickelNichols2013.lean
+++ b/Linglib/Studies/BickelNichols2013.lean
@@ -30,13 +30,16 @@ Shopen-volume chapter on the orthogonality of fusion and flexivity. The
 
 ## Bickel & Nichols's central insight
 
-The traditional 1D typological scale `isolating > agglutinating > fusional
-> polysynthetic` conflates two orthogonal parameters: **fusion** (whether
-formatives are concatenative, nonlinear, or isolating) and **flexivity**
-(whether classes are predictable from form vs. arbitrary). Both
-"agglutinating" (`concatenative + nonflexive`) and "fusional"
-(`concatenative + flexive`) are attested in the sample, demonstrating the
-two parameters are independent.
+The traditional 1D typological scale — "isolating > agglutinative >
+ﬂexive > nonlinear (or introﬂexive)" with prototypes Chinese > Turkish >
+Latin > Arabic ([bickel-nichols-2007] p. 185) — conflates two orthogonal
+parameters: **fusion** (whether formatives are isolating, concatenative,
+or nonlinear) and **flexivity** (whether formatives show item-based,
+class-conditioned allomorphy or vary only by general rule). All six cells
+of the 3 × 2 space are attested cross-linguistically (pp. 186-187);
+within the sample, both "agglutinative" (`concatenative + nonflexive`)
+and "fusional" (`concatenative + flexive`) cells are populated,
+demonstrating the independence on the concatenative row.
 
 ## Contents
 
@@ -112,10 +115,11 @@ theorem morph_iso_unique :
 -- §2. B&N Orthogonality and Cell-Population Theorems
 -- ============================================================================
 
-/-! [bickel-nichols-2007] argue fusion and flexivity are orthogonal,
-    and that the four cells of the (concatenative ∪ nonlinear ∪ isolating)
-    × (flexive ∪ nonflexive ∪ none) space are independently attested. The
-    theorems below witness the cells the sample populates. -/
+/-! [bickel-nichols-2007] argue fusion and flexivity are orthogonal: "all
+    possible combinations of values on the two parameters are attested"
+    (p. 186) — six cells, including flexive-isolating (Yidiɲ) and
+    nonflexive-isolating (Lai Chin) which this sample does not populate.
+    The theorems below witness the cells the sample does. -/
 
 /-- Key orthogonality test: among concatenative languages, both flexive
     and nonflexive are attested. This refutes the traditional 1D scale's
@@ -125,17 +129,11 @@ theorem concatenative_admits_both_flexivities :
     (concats.filter (fun p => decide p.IsFlexive)).length > 0 ∧
     (concats.filter (fun p => decide p.IsNonflexive)).length > 0 := by decide
 
-/-- Nonlinear cell witnessed by Arabic root-and-pattern morphology. The
-    sample's only nonlinear member is also flexive and cumulative — the
-    classic templatic profile. -/
-theorem arabic_nonlinear_flexive :
-    arabicMorph.IsNonlinear ∧ arabicMorph.IsFlexive ∧ arabicMorph.IsCumulative := by
-  decide
-
-/-- Isolating cell (Mandarin, Thai) has no flexivity / no exponence
-    marking — the B&N parameters do not apply to isolating typology. -/
-theorem isolating_no_flexivity :
-    mandarinMorph.flexivity = none ∧ thaiMorph.flexivity = none := by decide
+/-- Flexive-nonlinear ("introﬂexive", [bickel-nichols-2007] p. 186) cell
+    witnessed by Arabic root-and-pattern morphology; the sample's only
+    nonlinear member is also cumulative — the classic templatic profile. -/
+theorem arabic_introflexive :
+    arabicMorph.IsIntroflexive ∧ arabicMorph.IsCumulative := by decide
 
 /-- WALS Exponence (Ch 21A, case-specific) and B&N ExponenceScope (general)
     are independent: both poly+sep (Finnish, Tagalog) and mono+cum (Hindi,
@@ -148,10 +146,11 @@ theorem exponence_scope_independent :
   decide
 
 set_option maxRecDepth 2000 in
-/-- B&N decomposition is exhaustive on the concatenative dimension: every
-    concatenative language in the sample is either agglutinating
-    (concatenative + nonflexive + separative) or fusional (concatenative +
-    flexive + cumulative). -/
+/-- Every concatenative language in the sample has a stipulated flexivity
+    value, so falls in the agglutinative (concatenative + nonflexive) or
+    fusional (concatenative + flexive) cell. A sample fact about coding
+    completeness, not a B&N prediction — a concatenative language with
+    unstipulated flexivity would fall outside both. -/
 theorem concatenative_partition :
     ∀ p ∈ allMorphProfiles, p.IsConcatenative →
       p.IsAgglutinating ∨ p.IsFusional := by decide

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -37008,3 +37008,63 @@
   role      = {cited},
   sources   = {Studies/Arka2013.lean}
 }
+@incollection{anderson-2015,
+  author    = {Anderson, Stephen R.},
+  year      = {2015},
+  title     = {The Morpheme: Its Nature and Use},
+  booktitle = {The Oxford Handbook of Inflection},
+  editor    = {Baerman, Matthew},
+  publisher = {Oxford University Press},
+  pages     = {11--33},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Morphology/Morph.lean;Morphology/MorphWord.lean}
+}
+@incollection{trommer-zimmermann-2015,
+  author    = {Trommer, Jochen and Zimmermann, Eva},
+  year      = {2015},
+  title     = {Inflectional Exponence},
+  booktitle = {The Oxford Handbook of Inflection},
+  editor    = {Baerman, Matthew},
+  publisher = {Oxford University Press},
+  pages     = {47--83},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Morphology/Exponence/Basic.lean}
+}
+@incollection{spencer-popova-2015,
+  author    = {Spencer, Andrew and Popova, Gergana},
+  year      = {2015},
+  title     = {Periphrasis and Inflection},
+  booktitle = {The Oxford Handbook of Inflection},
+  editor    = {Baerman, Matthew},
+  publisher = {Oxford University Press},
+  pages     = {197--230},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Morphology/Periphrasis.lean}
+}
+@incollection{baerman-2015,
+  author    = {Baerman, Matthew},
+  year      = {2015},
+  title     = {Paradigmatic Deviations},
+  booktitle = {The Oxford Handbook of Inflection},
+  editor    = {Baerman, Matthew},
+  publisher = {Oxford University Press},
+  pages     = {141--159},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Morphology/Paradigm/Morphome.lean}
+}
+@article{stump-2006,
+  author    = {Stump, Gregory T.},
+  year      = {2006},
+  title     = {Heteroclisis and Paradigm Linkage},
+  journal   = {Language},
+  volume    = {82},
+  number    = {2},
+  pages     = {279--322},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Morphology/Paradigm/Linkage.lean}
+}


### PR DESCRIPTION
Primary-source audit of Bickel & Nichols 2007 (print + circulated 2001 draft) plus a six-reader pass over the Oxford Handbook of Inflection, executed as docstring/definition corrections:

- `IsAgglutinating`/`IsFusional` reduced to the chapter's two-parameter definitions (exponence conjunct was a tendency, not a criterion; p. 189); new `IsIntroflexive` with Arabic witness; isolating-voids-flexivity convention removed (pp. 186–187 attest both isolating cells).
- 18 per-language cell placements de-attributed to textbook consensus (the chapter types formatives, not languages — p. 183); `fromWALS20A` now refuses all mixed WALS categories consistently.
- Draft-artifact citations fixed (Formative "Table 2" → print Table 3.2; `simultaneous` gloss corrected); MorphWord circumfix status-retag bug fixed; Periphrasis retitled to AVC inflectional distribution; Morphome elsewhere-confound documented; five verified bib entries added (handbook chapters + stump-2006).