### PR TITLE
refactor(Morphology/Exponence): Applies as class primitive; drop free Rule carrier

### DIFF
--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -60,7 +60,7 @@ structure DiagOp where
 
 instance instExponence : Exponence DiagOp Root String where
   exponent := DiagOp.exponent
-  applySet op := {r | op.Applies r}
+  Applies := DiagOp.Applies
 
 instance (r : Root) :
     DecidablePred (fun op : DiagOp => Exponence.Applies (F := String) op r) :=

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -203,7 +203,7 @@ variable {Sem : Type}
 are `SyntacticContext`s, applicability is `matches`, the exponent is the
 denotation. -/
 instance : Exponence (AllosemicEntry Sem) SyntacticContext Sem :=
-  ⟨AllosemicEntry.denotation, fun e => {c | e.context.matches c = true}⟩
+  ⟨AllosemicEntry.denotation, fun e c => e.context.matches c = true⟩
 
 instance : Preorder (AllosemicEntry Sem) := Exponence.toPreorder
 

--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -140,7 +140,7 @@ open Morphology Morphology.Exponence
 (`Morphology.Exponence`): contexts are (target bundle,
 syntactic context) pairs, applicability is `Matches`. -/
 instance : Exponence VocabEntry (FeatureBundle × Option Cat) String :=
-  ⟨VocabEntry.exponent, fun e => {tc | e.Matches tc.1 tc.2}⟩
+  ⟨VocabEntry.exponent, fun e tc => e.Matches tc.1 tc.2⟩
 
 instance : Preorder VocabEntry := Exponence.toPreorder
 

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -160,7 +160,7 @@ variable {Ctx Root : Type*}
 (`Morphology.Exponence`): contexts are (feature-context, root)
 pairs, applicability is `matches`. -/
 instance : Exponence (VocabItem Ctx Root) (Ctx × Root) String :=
-  ⟨VocabItem.exponent, fun vi => {cr | vi.matches cr.1 cr.2 = true}⟩
+  ⟨VocabItem.exponent, fun vi cr => vi.matches cr.1 cr.2 = true⟩
 
 instance : Preorder (VocabItem Ctx Root) := Exponence.toPreorder
 

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -19,89 +19,53 @@ contexts pair expressions with their full property sets. Selection over
 this order — existence, coherence, and the framework-neutral prediction
 relation — lives in `Morphology/Exponence/Select.lean`.
 
-`Exponence.Rule Ctx F` is the free carrier. Framework engines (the
-containment hierarchy, DM vocabulary items, nanosyntax spellout) implement
-`Exponence` on their own intensional carriers (thresholds, feature
-bundles, stored trees) and install `Exponence.toPreorder` as the
-carrier's order, so the selection theorems apply to the native type
-with no wrapper.
+Framework engines (the containment hierarchy, DM vocabulary items,
+nanosyntax spellout) implement `Exponence` on their own intensional
+carriers (thresholds, feature bundles, stored trees) and install
+`Exponence.toPreorder` as the carrier's order, so the selection theorems
+apply to the native type with no wrapper.
 
 ## Main declarations
 
 * `Exponence` — the exponent-plus-applicability class;
   `Exponence.toPreorder` lifts applicability-set inclusion to a preorder
-* `Exponence.Rule` — the free carrier: an exponent with its applicability
-  condition
 -/
 
 namespace Morphology
 
 /-- Carriers whose values expone: an exponent projection and an
-applicability set, à la `SetLike` minus injectivity. Distinct rules may
-share an applicability set while carrying different exponents, so there
-is no `coe_injective` and the induced order is only a preorder
-(`toPreorder`), never a partial order. Framework engines instantiate
-this on their intensional carriers and derive Elsewhere selection over
-the native type. -/
+applicability condition, à la `SetLike` minus injectivity — conceptually
+a coercion to applicability sets (`applySet`), though the primitive is
+the predicate, which is what engines define and what decidability
+instances attach to. Distinct rules may share an applicability condition
+while carrying different exponents, so there is no `coe_injective` and
+the induced order is only a preorder (`toPreorder`), never a partial
+order. Framework engines instantiate this on their intensional carriers
+and derive Elsewhere selection over the native type. -/
 class Exponence (R : Type*) (Ctx F : outParam Type*) where
   /-- The exponent a rule inserts. -/
   exponent : R → F
-  /-- The set of contexts a rule applies in. -/
-  applySet : R → Set Ctx
+  /-- The condition on contexts under which a rule applies. -/
+  Applies : R → Ctx → Prop
 
 namespace Exponence
 
-variable {Ctx F : Type*}
+variable {Ctx F : Type*} {R : Type*} [Exponence R Ctx F]
 
-/-- A **rule of exponence**: an exponent paired with the condition on
-contexts under which the rule applies. Framework engines specialize
-`Ctx` and recover applicability from intensional specifications
-(thresholds, feature bundles, stored trees). -/
-structure Rule (Ctx : Type*) (F : Type*) where
-  /-- The exponent the rule inserts. -/
-  exponent : F
-  /-- The contexts in which the rule applies. -/
-  Applies : Ctx → Prop
+/-- A rule's applicability set: the contexts its condition holds in. -/
+def applySet (r : R) : Set Ctx := {c | Applies (F := F) r c}
 
-namespace Rule
-
-/-- The set of contexts a rule applies in. -/
-def applySet (r : Rule Ctx F) : Set Ctx := {c | r.Applies c}
-
-@[simp] theorem mem_applySet {r : Rule Ctx F} {c : Ctx} :
-    c ∈ r.applySet ↔ r.Applies c :=
+@[simp] theorem mem_applySet {r : R} {c : Ctx} :
+    c ∈ applySet (F := F) r ↔ Applies (F := F) r c :=
   Iff.rfl
 
-/-- Rules are preordered by applicability-set inclusion: `r ≤ s` when
-`r` applies in a subset of the contexts `s` applies in, i.e. `r` is at
-least as specific as `s`. Only a preorder — rules with the same
-applicability but different exponents are equivalent, not equal. -/
-instance : Preorder (Rule Ctx F) := .lift applySet
-
-theorem le_def {r s : Rule Ctx F} : r ≤ s ↔ r.applySet ⊆ s.applySet :=
-  Iff.rfl
-
-/-- Derived Pāṇinian specificity, unfolded: `r ≤ s` iff `s` applies
-wherever `r` does. -/
-theorem le_iff {r s : Rule Ctx F} :
-    r ≤ s ↔ ∀ ⦃c⦄, r.Applies c → s.Applies c :=
-  Iff.rfl
-
-end Rule
-
-variable {R : Type*} [Exponence R Ctx F]
-
-/-- A rule applies at a context when the context is in its
-applicability set. -/
-def Applies (r : R) (c : Ctx) : Prop := c ∈ applySet (F := F) r
-
-/-- The preorder a carrier opts into: applicability-set inclusion. Not a
+/-- The preorder a carrier opts into: applicability-set inclusion (`r ≤ s`
+when `r` applies in a subset of the contexts `s` applies in, i.e. `r` is
+at least as specific as `s`). Only a preorder — rules with the same
+applicability but different exponents are equivalent, not equal. Not a
 global instance — each engine installs it (or a defeq order) on its own
 carrier. -/
 @[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (F := F))
-
-/-- The free carrier exposes its fields as the interface. -/
-instance : Exponence (Rule Ctx F) Ctx F := ⟨Rule.exponent, Rule.applySet⟩
 
 end Exponence
 end Morphology

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -137,7 +137,7 @@ directly: applicability is threshold containment (the upper set
 `Set.Ici threshold`) and derived specificity is threshold comparison. -/
 
 instance : Exponence (SpanRule n F) (Fin n) F :=
-  ⟨SpanRule.exponent, fun it => Set.Ici it.threshold⟩
+  ⟨SpanRule.exponent, fun it i => it.threshold ≤ i⟩
 
 instance : Preorder (SpanRule n F) := Exponence.toPreorder
 
@@ -190,7 +190,7 @@ grade `g` when its stored constituent contains `g` (the down-set
 def SupersetRule (n : ℕ) (F : Type*) := SpanRule n F
 
 instance : Exponence (SupersetRule n F) (Fin n) F :=
-  ⟨SpanRule.exponent, fun it => Set.Iic (SpanRule.spans it)⟩
+  ⟨SpanRule.exponent, fun it i => i ≤ SpanRule.spans it⟩
 
 instance : Preorder (SupersetRule n F) := Exponence.toPreorder
 

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -273,7 +273,7 @@ open Morphology.Exponence
 (`Morphology.Exponence`): contexts are syntactic targets,
 applicability is Superset-Principle matching. -/
 instance : Exponence (TreeLexEntry F α) (NanoTree F) α :=
-  ⟨TreeLexEntry.exponent, fun e => {t | e.Matches t}⟩
+  ⟨TreeLexEntry.exponent, fun e t => e.Matches t⟩
 
 instance : Preorder (TreeLexEntry F α) := Exponence.toPreorder
 

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -434,8 +434,8 @@ support properly includes another's "must assign lower probability to
 each of those forms, on average" (conservation of belief), and
 conditioning preserves the preference. The book quotes
 [kiparsky-1973]'s formulation — prefer `r₂` when
-`Inputs(r₂) ⊂ Inputs(r₁)` — which is the specificity order of
-`Morphology.Exponence.Rule` (applicability-set inclusion).
+`Inputs(r₂) ⊂ Inputs(r₁)` — which is `Morphology.Exponence`'s
+specificity order (applicability-set inclusion, `Exponence.toPreorder`).
 
 Formalized in the uniform-generation case, where the preference is
 pointwise rather than on average: nested supports give the narrower
@@ -498,7 +498,7 @@ structure FinRule (Ctx F : Type*) where
 /-- A finitely supported rule exposes the shared exponence core interface
 (`Morphology.Exponence`): applicability is support membership. -/
 instance : Exponence (FinRule Ctx F) Ctx F :=
-  ⟨FinRule.exponent, fun r => {c | c ∈ r.supp}⟩
+  ⟨FinRule.exponent, fun r c => c ∈ r.supp⟩
 
 instance : Preorder (FinRule Ctx F) := Exponence.toPreorder
 


### PR DESCRIPTION
Two fixes to the same clunk (interface and free carrier as near-identical twins):

- Class primitive flips from `applySet : R → Set Ctx` to `Applies : R → Ctx → Prop` — the predicate is what engines define and what decidability attaches to; `applySet` becomes a derived def (order statements unchanged). Nobody consumed the Set-ness (the SetLike coercion tax without the Membership payoff). All 9 instances lose their `{c | ...}` wrappers; downstream call sites unchanged since `Exponence.Applies` was already the universal spelling.
- `Exponence.Rule` deleted — zero code consumers; every real consumer has its own intensional carrier. Resurrects when an actual consumer wants an anonymous rule.