### PR TITLE
fix(Studies): import Fintype deriving handler in Herce2023

### DIFF
--- a/Linglib/Studies/Herce2023.lean
+++ b/Linglib/Studies/Herce2023.lean
@@ -2,6 +2,7 @@ import Linglib.Morphology.Paradigm.Morphome
 import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.Fintype.Option
 import Mathlib.Data.Finset.Card
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # The typological diversity of morphomes


### PR DESCRIPTION
Restores main CI: #1537's deletion of Morphology/Realization dropped the transitive Mathlib.Tactic.DeriveFintype edge that Herce2023's deriving Fintype clauses relied on; import the handler directly.