### PR TITLE
feat(Morphology/Paradigm): PFM1 paradigm-function engine

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1281,6 +1281,7 @@ import Linglib.Morphology.Paradigm.Case
 import Linglib.Morphology.Paradigm.Complexity
 import Linglib.Morphology.Paradigm.Contiguity
 import Linglib.Morphology.Paradigm.Degree
+import Linglib.Morphology.Paradigm.Function
 import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Morphology.Paradigm.OfCells
@@ -1974,6 +1975,7 @@ import Linglib.Studies.Blutner2000
 import Linglib.Studies.Bobaljik2012
 import Linglib.Studies.Bochnak2015
 import Linglib.Studies.Bohnemeyer2004
+import Linglib.Studies.BonamiStump2016
 import Linglib.Studies.Bondarenko2022
 import Linglib.Studies.BondarenkoElliott2026
 import Linglib.Studies.BonehDoron2013

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -209,4 +209,66 @@ theorem realize_congr {f : R → α} {v : List R} {c c' : Ctx}
     realize f v c = realize f v c' := by
   rw [realize, realize, selectBy_congr h]
 
+/-! ### Order selection
+
+Where `selectBy` optimizes a linear specificity **score**, `selectMinimal`
+selects directly over the specificity preorder: the first applicable rule that
+no applicable rule strictly undercuts. This is the order-driven dual of
+`selectBy`, for engines whose specificity is a genuine preorder rather than a
+linear score (the PFM narrowness order, `Morphology/Paradigm/Function.lean`,
+where an intensionally finer class/property order has no faithful score). -/
+
+variable [DecidableRel (· < · : R → R → Prop)]
+
+/-- Selection by specificity order: the first applicable rule of `v` at `c`
+that no applicable rule strictly undercuts (`none` when nothing applies). -/
+def selectMinimal (v : List R) (c : Ctx) : Option R :=
+  (applicable v c).find? (fun r => (applicable v c).all (fun s => decide (¬ s < r)))
+
+theorem selectMinimal_mem {v : List R} {c : Ctx} {r : R}
+    (h : selectMinimal v c = some r) : r ∈ v :=
+  (mem_applicable.mp (List.mem_of_find?_eq_some h)).1
+
+theorem selectMinimal_applies {v : List R} {c : Ctx} {r : R}
+    (h : selectMinimal v c = some r) : Exponence.Applies (F := F) r c :=
+  (mem_applicable.mp (List.mem_of_find?_eq_some h)).2
+
+/-- A selected rule is an Elsewhere winner: applicable and `≤`-minimal. The
+all-check discharges minimality — no applicable rule strictly undercuts it. -/
+theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
+    (h : selectMinimal v c = some r) : IsElsewhereWinner v c r := by
+  refine ⟨mem_applicable.mp (List.mem_of_find?_eq_some h), ?_⟩
+  have hall := List.find?_some h
+  rw [List.all_eq_true] at hall
+  rintro s ⟨hsv, hsapp⟩ hsr
+  by_contra hrs
+  have hns := hall s (mem_applicable.mpr ⟨hsv, hsapp⟩)
+  rw [decide_eq_true_eq] at hns
+  exact hns (lt_of_le_not_ge hsr hrs)
+
+/-- A vocabulary with an applicable rule selects one — the order-selection
+counterpart of `exists_isElsewhereWinner`, the winner witnessing `find?`
+succeeds. -/
+theorem selectMinimal_isSome_of_exists_applicable {v : List R} {c : Ctx}
+    (h : ∃ r ∈ v, Exponence.Applies (F := F) r c) : (selectMinimal v c).isSome := by
+  obtain ⟨r, hr⟩ := exists_isElsewhereWinner h
+  rw [Option.isSome_iff_ne_none]
+  intro hnone
+  rw [selectMinimal, List.find?_eq_none] at hnone
+  refine hnone r (mem_applicable.mpr ⟨hr.1.1, hr.1.2⟩) ?_
+  rw [List.all_eq_true]
+  intro s hs
+  rw [decide_eq_true_eq]
+  intro hlt
+  exact absurd (hr.2 (mem_applicable.mp hs) hlt.le) (not_le_of_gt hlt)
+
+theorem selectMinimal_eq_none_iff {v : List R} {c : Ctx} :
+    selectMinimal v c = none ↔ applicable v c = [] := by
+  refine ⟨fun h => ?_, fun h => by rw [selectMinimal, h]; rfl⟩
+  by_contra hne
+  obtain ⟨r, hr⟩ := List.exists_mem_of_ne_nil _ hne
+  have happ := mem_applicable.mp hr
+  have hs := selectMinimal_isSome_of_exists_applicable ⟨r, happ.1, happ.2⟩
+  rw [h] at hs; simp at hs
+
 end Morphology.Exponence

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -1,0 +1,283 @@
+import Linglib.Morphology.Exponence.Select
+import Linglib.Morphology.Paradigm.Linkage
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+
+/-!
+# The PFM1 paradigm function
+[stump-2001] [stump-2016] [bonami-stump-2016] [kiparsky-1973]
+
+The standard Paradigm Function Morphology engine ([bonami-stump-2016]'s
+streamlined PFM1, after [stump-2001]): a paradigm function is a set of
+**realization rules** organized into ordered **blocks**. A rule
+`⟨klass, props, payload⟩` applies to a cell `⟨L, σ⟩` when the lexeme `L`
+belongs to `klass` and the property set `props` is contained in `σ`; among the
+applicable rules of a block, the narrowest wins ([kiparsky-1973]'s Elsewhere
+Condition, PFM's Pāṇinian Determinism). A single payload-polymorphic carrier
+`Rule L P F` serves all three rule types: rules of exponence and referral take
+`F := Action Z P`, rules of basic stem choice take `F := Z`; stem-choice
+conflicts are arbitrated by the same narrowness order.
+
+Narrowness (`Rule`'s `≤`) is [stump-2001]'s two clauses: same class with a
+larger property set, or a properly smaller class. It is **intensional** — for
+same-class rules it collapses to applicability-set inclusion (`applySet_mono`),
+but across classes a smaller class outranks a larger one whatever the property
+sets, so the order is strictly finer than the extensional
+[stump-2016]/[stump-2022] domain-subset order of `Exponence/Basic.lean`.
+
+The **Identity Function Default** — every block has a rule leaving the stem
+unchanged — is assumed as a universal principle in PFM; here it is a definition
+(`identityDefault`) and its consequences are theorems (it is `≤`-maximal, and a
+block containing it always selects). Two implicative devices are kept distinct
+([bonami-stump-2016]): a **rule of referral** (`Action.referral`) models
+block-confined syncretism, competing inside its block; whole-word syncretism is
+a clause of the paradigm function, outside any block. Overabundance (one cell,
+several forms) is out of scope: the realized paradigm is function-valued, one
+form per cell. Morphophonological metageneralizations (the `-a`-loss and umlaut
+rules of the Icelandic fragment) are phonological substance and live in
+`Phonology/`; here stem alternants like *köll* enter as data-level stem values,
+not string operations.
+
+Because payloads are functions, `Exponence.Coherent` and `Realizes` over
+`Action Z P` are `funext` propositions rather than decidable checks; a study
+decides realized **values**, not payload equality.
+
+## Main declarations
+
+* `Action`, `Rule` — the payload (exponence or referral) and the
+  payload-polymorphic realization rule
+* `Rule`'s `Exponence` and `Preorder` instances — applicability and two-clause
+  narrowness; `Rule.applies_iff`, `Rule.le_iff`, `Rule.applySet_mono`
+* `identityDefault`, `le_identityDefault`,
+  `selectMinimal_isSome_of_mem_identityDefault` — the IFD and its consequences
+* `evalBlock`, `paradigmFunction`, `stemChoiceOf` — narrowest-rule block
+  evaluation and the block cascade
+* `evalPortmanteau`, `evalPortmanteau_eq_comp_of_not_applies` — portmanteau
+  blocks and the Function Composition Default
+* `Linkage.realize_eq_paradigmFunction` — the PFM2 realization of a linkage's
+  block cascade is this paradigm function
+-/
+
+namespace Morphology.PFM
+
+open Morphology Morphology.Exponence
+
+variable {L Z P F : Type*}
+
+/-- The payload of a realization rule: a rule of **exponence** carries a form
+operation `f : Z → Z`, a rule of **referral** carries a property-set retargeting
+`P → P` whose block is re-consulted at the retargeted cell. -/
+inductive Action (Z P : Type*)
+  | expo (f : Z → Z)
+  | referral (retarget : P → P)
+
+/-- A realization rule in [bonami-stump-2016]'s format `⟨klass, props, payload⟩`
+(the chapter's `n, X_C, τ → f(X)`), payload-polymorphic à la
+`Containment.SpanRule`: rules of exponence and referral instantiate
+`F := Action Z P`, rules of basic stem choice `F := Z`. `klass` is the lexeme
+class `C`, `props` the realized property set `τ`. -/
+structure Rule (L P F : Type*) where
+  /-- The lexeme class the rule applies in. -/
+  klass : Finset L
+  /-- The property set the rule realizes. -/
+  props : P
+  /-- The form operation (exponence/referral) or stem the rule supplies. -/
+  payload : F
+
+section Narrowness
+variable [PartialOrder P]
+
+/-- Applicability ([bonami-stump-2016]'s rule format): a rule applies to a cell
+`⟨L, σ⟩` when `L` is in its class and its property set is contained in `σ`. -/
+instance : Exponence (Rule L P F) (L × P) F where
+  exponent := Rule.payload
+  Applies r c := c.1 ∈ r.klass ∧ r.props ≤ c.2
+
+@[simp] theorem Rule.applies_iff {r : Rule L P F} {c : L × P} :
+    Exponence.Applies (F := F) r c ↔ c.1 ∈ r.klass ∧ r.props ≤ c.2 :=
+  Iff.rfl
+
+/-- Two-clause Pāṇinian narrowness ([stump-2001]) as the carrier's order: `r` is
+at least as narrow as `s` when either they share a class and `s` realizes a
+subset of `r`'s properties, or `r`'s class is properly smaller. Intensional —
+strictly finer than applicability-set inclusion (see `Rule.applySet_mono`; the
+converse fails). -/
+instance : Preorder (Rule L P F) where
+  le r s := (r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass
+  le_refl _ := Or.inl ⟨rfl, le_refl _⟩
+  le_trans r s t hrs hst := by
+    rcases hrs with ⟨hk, hp⟩ | hk <;> rcases hst with ⟨hk', hp'⟩ | hk'
+    · exact Or.inl ⟨hk.trans hk', hp'.trans hp⟩
+    · exact Or.inr (hk ▸ hk')
+    · exact Or.inr (hk' ▸ hk)
+    · exact Or.inr (hk.trans hk')
+
+theorem Rule.le_iff {r s : Rule L P F} :
+    r ≤ s ↔ (r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass :=
+  Iff.rfl
+
+/-- For same-class rules, narrowness is applicability-set inclusion: the narrower
+rule applies in a subset of the contexts — [stump-2001]'s two-clause narrowness
+collapsing to [stump-2016]'s single-clause domain-subset precedence. Across
+classes the order is strictly intensional (a smaller class outranks a larger one
+whatever the property sets), so a class hypothesis is required. -/
+theorem Rule.applySet_mono {r s : Rule L P F} (hk : r.klass = s.klass) (h : r ≤ s) :
+    Exponence.applySet (F := F) r ⊆ Exponence.applySet (F := F) s := by
+  rcases h with ⟨_, hp⟩ | hlt
+  · intro c hc
+    rw [Exponence.mem_applySet] at hc ⊢
+    exact ⟨hk ▸ hc.1, hp.trans hc.2⟩
+  · exact absurd hk hlt.ne
+
+end Narrowness
+
+/-! ### Selection over the narrowness order -/
+
+section Selection
+variable [PartialOrder P] [DecidableEq L] [DecidableLE P]
+
+instance (c : L × P) :
+    DecidablePred (fun r : Rule L P F => Exponence.Applies (F := F) r c) :=
+  fun r => inferInstanceAs (Decidable (c.1 ∈ r.klass ∧ r.props ≤ c.2))
+
+instance : DecidableLE (Rule L P F) := fun r s =>
+  inferInstanceAs (Decidable ((r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass))
+
+instance : DecidableLT (Rule L P F) := fun r s =>
+  inferInstanceAs (Decidable (r ≤ s ∧ ¬ s ≤ r))
+
+/-! ### The Identity Function Default -/
+
+section IdentityDefault
+variable [Fintype L] [OrderBot P]
+
+/-- The **Identity Function Default** ([bonami-stump-2016]): the rule applying to
+every lexeme and every property set, changing nothing. PFM assumes a rule of
+this form in every block as a universal principle; here it is a definition whose
+consequences are theorems. -/
+def identityDefault : Rule L P (Action Z P) where
+  klass := Finset.univ
+  props := ⊥
+  payload := .expo id
+
+omit [DecidableEq L] [DecidableLE P] in
+theorem identityDefault_applies (c : L × P) :
+    Exponence.Applies (F := Action Z P) (identityDefault (L := L) (Z := Z) (P := P)) c :=
+  ⟨Finset.mem_univ _, bot_le⟩
+
+omit [DecidableLE P] in
+/-- The IFD is `≤`-maximal: every rule is at least as narrow. It is a top element
+of the narrowness order without an `OrderTop` instance (which would force
+`Fintype`/`OrderBot` globally). -/
+theorem le_identityDefault (r : Rule L P (Action Z P)) :
+    r ≤ identityDefault (Z := Z) (P := P) := by
+  by_cases h : r.klass = Finset.univ
+  · exact Or.inl ⟨h, bot_le⟩
+  · exact Or.inr (Finset.ssubset_univ_iff.mpr h)
+
+/-- A block containing the IFD always selects a rule — the totality of Nar
+([bonami-stump-2016]'s (14)) that [stump-2001] secures by stipulating the IFD. -/
+theorem selectMinimal_isSome_of_mem_identityDefault
+    {v : List (Rule L P (Action Z P))} {c : L × P}
+    (h : identityDefault (Z := Z) (P := P) ∈ v) : (selectMinimal v c).isSome :=
+  selectMinimal_isSome_of_exists_applicable
+    ⟨identityDefault (P := P), h, identityDefault_applies c⟩
+
+end IdentityDefault
+
+/-! ### Blocks and the paradigm function -/
+
+/-- A **rule block** ([bonami-stump-2016]): rules of exponence and referral in
+paradigmatic opposition, only the narrowest applying. -/
+abbrev Block (L Z P : Type*) := List (Rule L P (Action Z P))
+
+/-- The rules of exponence in a block (referral rules dropped), the target of a
+referral's re-selection. -/
+def expoFragment (b : Block L Z P) : Block L Z P :=
+  b.filter (fun r => r.payload matches .expo _)
+
+/-- The form produced by evaluating a block at a cell: select the narrowest
+applicable rule; an exponence rule applies its form operation, a referral rule
+re-selects among the block's exponence rules at the retargeted property set (one
+hop). The stem is left unchanged when nothing applies. -/
+def evalBlockForm (Lindex : Z → L) (b : Block L Z P) (wσ : Z × P) : Z :=
+  match selectMinimal b (Lindex wσ.1, wσ.2) with
+  | some r =>
+    match r.payload with
+    | .expo f => f wσ.1
+    | .referral retarget =>
+      match selectMinimal (expoFragment b) (Lindex wσ.1, retarget wσ.2) with
+      | some s =>
+        match s.payload with
+        | .expo g => g wσ.1
+        | .referral _ => wσ.1
+      | none => wσ.1
+  | none => wσ.1
+
+/-- Evaluate a block at a form-state, keeping the property set ([bonami-stump-2016]'s
+rule format outputs `⟨f(W), σ⟩`). -/
+def evalBlock (Lindex : Z → L) (b : Block L Z P) (wσ : Z × P) : Z × P :=
+  (evalBlockForm Lindex b wσ, wσ.2)
+
+@[simp] theorem evalBlock_snd (Lindex : Z → L) (b : Block L Z P) (wσ : Z × P) :
+    (evalBlock Lindex b wσ).2 = wσ.2 :=
+  rfl
+
+/-- Thread a form-state through a block cascade (blocks listed inner-first). -/
+def blocksEval (Lindex : Z → L) (blocks : List (Block L Z P)) (wσ : Z × P) : Z × P :=
+  blocks.foldl (fun w b => evalBlock Lindex b w) wσ
+
+@[simp] theorem blocksEval_snd (Lindex : Z → L) (blocks : List (Block L Z P))
+    (wσ : Z × P) : (blocksEval Lindex blocks wσ).2 = wσ.2 := by
+  induction blocks generalizing wσ with
+  | nil => rfl
+  | cons b bs ih => exact (ih (evalBlock Lindex b wσ)).trans (evalBlock_snd Lindex b wσ)
+
+/-- The **paradigm function** ([bonami-stump-2016]'s (13)): basic stem choice,
+then the stipulated block cascade. `blocks` are listed inner-first, so
+`[I, II, III]` realizes `[iii : [ii : [i : Stem]]]`. `Lindex : Z → L` recovers a
+stem's covert lexemic index (fn. 7); L-index persistence holds by construction,
+since selection threads a fixed lexeme through `L × P`. -/
+def paradigmFunction (Lindex : Z → L) (stemChoice : L × P → Z)
+    (blocks : List (Block L Z P)) (c : L × P) : Z × P :=
+  blocksEval Lindex blocks (stemChoice c, c.2)
+
+/-- Basic stem choice ([bonami-stump-2016]'s (7)) as narrowest-rule selection over
+stem-choice rules (`payload := Z`), falling back to a per-lexeme default. Rule
+conflicts (the chapter's `greip`/`grip`/`gríp`) are resolved by the same
+narrowness order. -/
+def stemChoiceOf (sv : List (Rule L P Z)) (default : L → Z) : L × P → Z :=
+  fun c => ((selectMinimal sv c).map Rule.payload).getD (default c.1)
+
+/-- A **portmanteau block** `[m, n]` ([bonami-stump-2016]'s (20)–(24)): its rules
+compete with the composition of blocks `m` and `n`; when none applies, the
+**Function Composition Default** falls back to that composition. -/
+def evalPortmanteau (Lindex : Z → L) (bmn bm bn : Block L Z P) (wσ : Z × P) : Z × P :=
+  if (applicable bmn (Lindex wσ.1, wσ.2)).isEmpty
+  then evalBlock Lindex bm (evalBlock Lindex bn wσ)
+  else evalBlock Lindex bmn wσ
+
+/-- The **Function Composition Default** ([bonami-stump-2016]'s (24)): where no
+portmanteau rule applies, the portmanteau block is the composition of its
+component blocks. -/
+theorem evalPortmanteau_eq_comp_of_not_applies (Lindex : Z → L) (bmn bm bn : Block L Z P)
+    (wσ : Z × P) (h : applicable bmn (Lindex wσ.1, wσ.2) = []) :
+    evalPortmanteau Lindex bmn bm bn wσ = evalBlock Lindex bm (evalBlock Lindex bn wσ) := by
+  simp [evalPortmanteau, h]
+
+/-- With property-preserving property mapping and PFM1 basic stem choice, the
+PFM2 realization of a paradigm linkage's block cascade ([stump-2016]'s
+`PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`) is this paradigm function — `Linkage.realize`'s
+form-realization hole filled true by construction. -/
+theorem Linkage.realize_eq_paradigmFunction (ℓ : Linkage L Z P) (Lindex : Z → L)
+    (stemChoice : L × P → Z) (blocks : List (Block L Z P)) (l : L) (σ : P)
+    (h : ℓ.IsPropertyPreserving) (hstem : ∀ l σ, ℓ.stem l σ = stemChoice (l, σ)) :
+    ℓ.realize (fun z τ => (blocksEval Lindex blocks (z, τ)).1) l σ
+      = paradigmFunction Lindex stemChoice blocks (l, σ) := by
+  have hpm : ℓ.pm σ = σ := h σ
+  simp only [Linkage.realize, Linkage.corr, hpm, hstem, paradigmFunction]
+  exact Prod.ext rfl (blocksEval_snd Lindex blocks (stemChoice (l, σ), σ)).symm
+
+end Selection
+
+end Morphology.PFM

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -23,15 +23,19 @@ larger property set, or a properly smaller class. It is **intensional** — for
 same-class rules it collapses to applicability-set inclusion (`applySet_mono`),
 but across classes a smaller class outranks a larger one whatever the property
 sets, so the order is strictly finer than the extensional
-[stump-2016]/[stump-2022] domain-subset order of `Exponence/Basic.lean`.
+[stump-2016]/[stump-2022] domain-subset order of `Exponence/Basic.lean`
+([stump-2020] likewise glosses "narrowest" extensionally, as the smaller
+domain of application).
 
 The **Identity Function Default** — every block has a rule leaving the stem
 unchanged — is assumed as a universal principle in PFM; here it is a definition
 (`identityDefault`) and its consequences are theorems (it is `≤`-maximal, and a
 block containing it always selects). Two implicative devices are kept distinct
 ([bonami-stump-2016]): a **rule of referral** (`Action.referral`) models
-block-confined syncretism, competing inside its block; whole-word syncretism is
-a clause of the paradigm function, outside any block. Overabundance (one cell,
+block-confined syncretism, competing inside its block; whole-word syncretism
+lives a layer up, as a many-to-one property mapping in `Linkage.pm`
+(`Linkage.realize_eq_of_corr_eq`), where [stump-2020] relocates it —
+paradigm-function-level override clauses are not modeled. Overabundance (one cell,
 several forms) is out of scope: the realized paradigm is function-valued, one
 form per cell. Morphophonological metageneralizations (the `-a`-loss and umlaut
 rules of the Icelandic fragment) are phonological substance and live in
@@ -249,15 +253,19 @@ narrowness order. -/
 def stemChoiceOf (sv : List (Rule L P Z)) (default : L → Z) : L × P → Z :=
   fun c => ((selectMinimal sv c).map Rule.payload).getD (default c.1)
 
-/-- A **portmanteau block** `[m, n]` ([bonami-stump-2016]'s (20)–(24)): its rules
-compete with the composition of blocks `m` and `n`; when none applies, the
-**Function Composition Default** falls back to that composition. -/
+/-- A **portmanteau block** `[m, n]` ([bonami-stump-2016]): its rules compete
+with the composition of blocks `m` and `n`; when none applies, the **Function
+Composition Default** falls back to that composition. This is the handbook's
+block-straddling device; [stump-2020] supersedes it with **rule conflation** (a
+portmanteau rule as the conflation of two rules, sitting in a single block and
+winning by ordinary narrowness), the route [stump-2022] develops — kept here as
+the faithfully pre-conflation account. -/
 def evalPortmanteau (Lindex : Z → L) (bmn bm bn : Block L Z P) (wσ : Z × P) : Z × P :=
   if (applicable bmn (Lindex wσ.1, wσ.2)).isEmpty
   then evalBlock Lindex bm (evalBlock Lindex bn wσ)
   else evalBlock Lindex bmn wσ
 
-/-- The **Function Composition Default** ([bonami-stump-2016]'s (24)): where no
+/-- The **Function Composition Default** ([bonami-stump-2016]): where no
 portmanteau rule applies, the portmanteau block is the composition of its
 component blocks. -/
 theorem evalPortmanteau_eq_comp_of_not_applies (Lindex : Z → L) (bmn bm bn : Block L Z P)

--- a/Linglib/Studies/BonamiStump2016.lean
+++ b/Linglib/Studies/BonamiStump2016.lean
@@ -1,0 +1,195 @@
+import Linglib.Morphology.Paradigm.Function
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# PFM1 worked fragments: Icelandic verbs and Sanskrit nominals
+[bonami-stump-2016] [stump-2001] [kiparsky-1973]
+
+Worked fragments for the PFM1 engine of `Morphology/Paradigm/Function.lean`,
+transcribing [bonami-stump-2016]'s own examples.
+
+* **Icelandic verbs** (their Table 17.1/17.3): the paradigm function derives
+  `PF(⟨KALLA, {ind pst 2sg}⟩) = kallaðir` by pure suffixation `-a`, `-ði`, `-r`
+  through Blocks I–III. Basic stem choice resolves the `greip`/`grip`/`gríp`
+  conflict for `GRÍPA` by narrowness (the three-cell rule beats the twelve- and
+  twenty-seven-cell rules); a strong verb's Block I falls through to the
+  Identity Function Default. Umlaut (`kall` ~ `köll`) and the other
+  morphophonological metageneralizations are phonological substance and are not
+  modelled here, so only umlaut-free cells are decided.
+* **Sanskrit** (their Table 17.5, (17)): the portmanteau `-āna` of a
+  consonant-final ninth-conjugation root overrides the `-nī`/`-hi` sequence,
+  while a vowel-final root defaults to their composition (the Function
+  Composition Default); the vocative refers to the nominative's Block-i
+  exponent (block-confined syncretism), a schematic case fragment.
+
+All predictions are `decide`-checked realized values; payload equality is never
+decided (payloads are form operations).
+-/
+
+namespace BonamiStump2016
+
+open Morphology Morphology.Exponence Morphology.PFM
+
+/-! ### Icelandic verbs (Table 17.1, Table 17.3) -/
+
+section Icelandic
+
+/-- The four verbs of the fragment: `KALLA` weak.4.a, `ÆTLA` weak.4.b, `GRÍPA`
+strong.1.a, `FLJÚGA` strong.2.b. -/
+inductive Verb | kalla | aetla | gripa | fljuga
+  deriving DecidableEq, Fintype
+
+/-- Morphosyntactic features (decomposed: person and number separate). -/
+inductive Feat | ind | sbjv | imp | prs | pst | p1 | p2 | p3 | sg | pl
+  deriving DecidableEq, Fintype
+
+open Verb Feat
+
+/-- Weak conjugation 4 (here all weak verbs of the fragment). -/
+def weak : Finset Verb := {kalla, aetla}
+/-- Weak conjugation 4.b. -/
+def weak4b : Finset Verb := {aetla}
+/-- Strong conjugation. -/
+def strong : Finset Verb := {gripa, fljuga}
+
+local notation "IFD" => (identityDefault : Rule Verb (Finset Feat) (Action String (Finset Feat)))
+
+/-- Block I: theme-vowel exponence ([bonami-stump-2016]'s Table 17.3). -/
+def blockI : Block Verb String (Finset Feat) :=
+  [ ⟨weak, {pst, pl}, .expo (· ++ "u")⟩,
+    ⟨Finset.univ, {sbjv, prs}, .expo (· ++ "i")⟩,
+    ⟨weak, {}, .expo (· ++ "a")⟩,
+    IFD ]
+
+/-- Block II: past-tense exponence. -/
+def blockII : Block Verb String (Finset Feat) :=
+  [ ⟨weak, {pst, sg}, .expo (· ++ "ði")⟩,
+    ⟨weak, {pst, pl}, .expo (· ++ "ðu")⟩,
+    IFD ]
+
+/-- Block III: agreement exponence. -/
+def blockIII : Block Verb String (Finset Feat) :=
+  [ ⟨weak4b, {imp, p2, sg}, .expo (· ++ "ðu")⟩,
+    ⟨Finset.univ, {imp, p2, sg}, .expo id⟩,
+    ⟨Finset.univ, {p2, sg}, .expo (· ++ "r")⟩,
+    ⟨Finset.univ, {ind, prs, p3, sg}, .expo (· ++ "r")⟩,
+    ⟨Finset.univ, {p1, pl}, .expo (· ++ "um")⟩,
+    ⟨Finset.univ, {p2, pl}, .expo (· ++ "ið")⟩,
+    ⟨Finset.univ, {ind, prs, p3, pl}, .expo (· ++ "a")⟩,
+    ⟨strong, {ind, pst, p2, sg}, .expo (· ++ "st")⟩,
+    IFD ]
+
+/-- Rules of basic stem choice ([bonami-stump-2016]'s (7)); the `GRÍPA` and
+`FLJÚGA` alternants list the umlaut/ablaut stems as data, not string
+operations. -/
+def iceStems : List (Rule Verb (Finset Feat) String) :=
+  [ ⟨{kalla}, {}, "kall"⟩,
+    ⟨{aetla}, {}, "ætl"⟩,
+    ⟨{gripa}, {ind, pst, sg}, "greip"⟩,
+    ⟨{gripa}, {pst}, "grip"⟩,
+    ⟨{gripa}, {}, "gríp"⟩,
+    ⟨{fljuga}, {ind, pst, sg}, "flaug"⟩,
+    ⟨{fljuga}, {ind, pst}, "flug"⟩,
+    ⟨{fljuga}, {pst}, "flyg"⟩,
+    ⟨{fljuga}, {ind, prs, sg}, "flýg"⟩,
+    ⟨{fljuga}, {}, "fljúg"⟩ ]
+
+/-- Within one lexeme's paradigm the covert lexemic index is constant. -/
+def iceStem : Finset Feat → Verb := fun _ => kalla
+
+/-- **Flagship** ([bonami-stump-2016]'s (4a), derived through (6)): the second
+person singular indicative past of `KALLA` is `kallaðir`, `kall` + `-a` + `-ði`
++ `-r` through Blocks I–III. -/
+example :
+    paradigmFunction (fun _ => kalla) (stemChoiceOf iceStems (fun _ => ""))
+      [blockI, blockII, blockIII] (kalla, {ind, pst, p2, sg})
+      = ("kallaðir", {ind, pst, p2, sg}) := by decide
+
+/-- **Stem-choice narrowness** ([bonami-stump-2016]'s discussion of (7)): at
+`⟨GRÍPA, {ind pst 1sg}⟩` the three-cell rule for `greip` overrides the
+twelve-cell `grip` and twenty-seven-cell `gríp` rules. -/
+example : stemChoiceOf iceStems (fun _ => "") (gripa, {ind, pst, p1, sg}) = "greip" := by decide
+
+/-- **Identity Function Default fires**: a strong verb's Block I has no
+applicable exponence rule, so the IFD leaves the stem unchanged
+(`gríp`, first singular present indicative of `GRÍPA`). -/
+example : evalBlock (fun _ => gripa) blockI ("gríp", {ind, prs, p1, sg})
+    = ("gríp", {ind, prs, p1, sg}) := by decide
+
+end Icelandic
+
+/-! ### Sanskrit portmanteau and Function Composition Default (Table 17.5) -/
+
+section SanskritPortmanteau
+
+/-- Two ninth-conjugation roots: `AŚ` (consonant-final), `KRĪ` (vowel-final). -/
+inductive Root | as | kri
+  deriving DecidableEq, Fintype
+
+/-- Features of the second-person singular imperative active. -/
+inductive SF | p2 | sg | imp | act
+  deriving DecidableEq, Fintype
+
+open Root SF
+
+/-- Block i: ninth-conjugation `-nī` ([bonami-stump-2016]'s (20a)). -/
+def blockNi : Block Root String (Finset SF) :=
+  [ ⟨Finset.univ, {}, .expo (· ++ "nī")⟩ ]
+
+/-- Block ii: subject-agreement `-hi` ([bonami-stump-2016]'s (20b)). -/
+def blockHi : Block Root String (Finset SF) :=
+  [ ⟨Finset.univ, {p2, sg, imp, act}, .expo (· ++ "hi")⟩ ]
+
+/-- Portmanteau Block [ii,i]: consonant-final `-āna` ([bonami-stump-2016]'s
+(20c)); consonant-finality is carried by the singleton class `{AŚ}`. -/
+def blockAna : Block Root String (Finset SF) :=
+  [ ⟨{as}, {p2, sg, imp, act}, .expo (· ++ "āna")⟩ ]
+
+/-- The consonant-final root `AŚ` takes the portmanteau `-āna`, overriding the
+`-nī`/`-hi` sequence ([bonami-stump-2016]'s (22)). -/
+example : evalPortmanteau (fun _ => as) blockAna blockHi blockNi ("aś", {p2, sg, imp, act})
+    = ("aśāna", {p2, sg, imp, act}) := by decide
+
+/-- The vowel-final root `KRĪ` has no portmanteau rule, so Block [ii,i] defaults
+to the composition of Blocks ii and i (the Function Composition Default),
+yielding `krīnīhi` ([bonami-stump-2016]'s (23)). -/
+example : evalPortmanteau (fun _ => kri) blockAna blockHi blockNi ("krī", {p2, sg, imp, act})
+    = ("krīnīhi", {p2, sg, imp, act}) := by decide
+
+end SanskritPortmanteau
+
+/-! ### Sanskrit vocative referral (schematic, (17)) -/
+
+section SanskritReferral
+
+/-- A schematic nominal declension. -/
+inductive Noun | dana
+  deriving DecidableEq, Fintype
+
+/-- Case and number features. -/
+inductive NF | nom | voc | du
+  deriving DecidableEq, Fintype
+
+open Noun NF
+
+/-- Retarget a vocative property set to the corresponding nominative. -/
+def vocToNom (σ : Finset NF) : Finset NF := insert nom (σ.erase voc)
+
+/-- The case block: a nominative exponence rule and a vocative rule of referral
+([bonami-stump-2016]'s (17)), the referral re-consulting the block at the
+nominative cell. -/
+def caseBlock : Block Noun String (Finset NF) :=
+  [ ⟨Finset.univ, {nom}, .expo (· ++ "e")⟩,
+    ⟨Finset.univ, {voc}, .referral vocToNom⟩ ]
+
+/-- The vocative dual takes the nominative dual's Block-i exponent: a
+block-confined syncretism (`dāne`), distinct from a whole-word paradigm-function
+clause. -/
+example : evalBlock (fun _ => dana) caseBlock ("dān", {voc, du}) = ("dāne", {voc, du}) := by decide
+
+/-- The nominative dual it refers to. -/
+example : evalBlock (fun _ => dana) caseBlock ("dān", {nom, du}) = ("dāne", {nom, du}) := by decide
+
+end SanskritReferral
+
+end BonamiStump2016

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26379,6 +26379,20 @@
   role      = {formalized},
   sources   = {Morphology/Paradigm/Linkage.lean;Studies/Stump2016.lean;Studies/KalinBjorkmanEtAl2026.lean}
 }
+@incollection{stump-2020,
+  author    = {Stump, Gregory},
+  year      = {2020},
+  title     = {Paradigm Function Morphology: Assumptions and Innovations},
+  booktitle = {Oxford Research Encyclopedia of Linguistics},
+  editor    = {Aronoff, Mark},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  doi       = {10.1093/acrefore/9780199384655.013.578},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Morphology/Paradigm/Function.lean}
+}
 @article{embick-noyer-2001,
   author    = {Embick, David and Noyer, Rolf},
   year      = {2001},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26340,6 +26340,20 @@
   validated = {true},
   sources   = {}
 }
+@incollection{bonami-stump-2016,
+  author    = {Bonami, Olivier and Stump, Gregory T.},
+  year      = {2017},
+  title     = {Paradigm Function Morphology},
+  booktitle = {The Cambridge Handbook of Morphology},
+  editor    = {Hippisley, Andrew and Stump, Gregory},
+  pages     = {449--481},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  doi       = {10.1017/9781139814720.017},
+  subfield  = {morphology},
+  role      = {formalized},
+  sources   = {Morphology/Paradigm/Function.lean;Studies/BonamiStump2016.lean}
+}
 @book{stump-2001,
   author    = {Stump, Gregory T.},
   year      = {2001},


### PR DESCRIPTION
The streamlined PFM1 engine of [bonami-stump-2016]: a payload-polymorphic realization rule with two-clause Pāṇinian narrowness, block evaluation, the paradigm function, portmanteau/FCD, and the Identity Function Default as theorems. Adds `selectMinimal` (order-driven dual of `selectBy`) to Exponence/Select. Worked fragments in `Studies/BonamiStump2016` decide the Icelandic `kallaðir` derivation, stem-choice narrowness, the Sanskrit `-āna` portmanteau, and vocative referral.