### PR TITLE
docs(Morphology): mathlib-register docstrings for Morph.lean

### DIFF
--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -1,71 +1,68 @@
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# The morph: minimal segmental form
-[haspelmath-2020]
+# Morphs and exponents
 
-The form-side carrier of the morphology layer, following
-[haspelmath-2020]'s proposal: a **morph** is a minimal linguistic form —
-[haspelmath-2020] defines it as a minimal pairing of syntacticosemantic
-content with a continuous string of phonological segments, but the
-carrier stores only the form side, which is what keeps empty and
-superfluous morphs (Cree connective *-t-*, [anderson-2015] p. 19)
-representable. Morphs are never zero and never discontinuous
-(a "circumfix" is a construction containing a prefix and a suffix, not a
-single morph); zero and discontinuity live one level up, in the
-**exponent** — a possibly empty sequence of morphs. `[]` means *no
-segmental exponent*, not *unmarked*: a cell whose sole marker is a
-process (North Saami gradation-only genitives, [anderson-2015] p. 22)
-also renders as `[]` here. Nonconcatenative exponence (apophony,
-reduplication, tone, subtraction) is a process, not a form, and is out
-of this carrier's scope — `Word.Structure`'s tree constructors cover
-reduplication and conversion, the autosegmental machinery covers tone;
-the rest of the process catalogue ([anderson-2015] pp. 21-24), like
-overlapping morphs (Breton mutation, p. 20), currently has no carrier.
-
-`Morph.Kind` records the attachment classification that descriptive
-notation itself encodes — `X-` prefix, `-X` suffix, `X=` proclitic,
-`=X` enclitic, bare free form — plus `root`.
-`Morph.toString`/`Exponent.toString` reproduce that notation, so the
-display convention is derived, not data.
+A **morph** is a minimal segmental form together with its attachment kind:
+root, prefix, suffix, proclitic, enclitic, or free form ([haspelmath-2020]).
+An **exponent** is a possibly empty sequence of morphs realizing a paradigm
+cell. Morphs are never zero and never discontinuous: zero exponence is the
+empty exponent, and a discontinuous realization is a multi-morph exponent.
 
 ## Main declarations
 
-* `Morph` with `Morph.Kind` — a segmental form with its attachment kind
+* `Morph`, `Morph.Kind` — a segmental form with its attachment kind
 * `Exponent` — a sequence of morphs; `[]` is zero exponence
 * `Morph.toString`, `Exponent.toString` — descriptive-notation display
-* `Following` — following-segment environment for pre-consonantal vs
-  pre-vocalic variant selection
+  (`X-`, `-X`, `X=`, `=X`; `∅` for zero exponence)
+* `Following` — following-segment environment for variant selection
+
+## Implementation notes
+
+[haspelmath-2020] defines a morph as a minimal pairing of content with a
+continuous string of segments; the carrier stores only the form side, so
+empty and superfluous morphs (Cree connective *-t-*, [anderson-2015] p. 19)
+remain representable. `[]` means *no segmental exponent*, not *unmarked*: a
+cell whose sole marker is a process (North Saami gradation-only genitives,
+[anderson-2015] p. 22) also renders as `[]`. Nonconcatenative exponence
+(apophony, reduplication, tone, subtraction) is a process, not a form, and
+is out of scope here: `Word.Structure` covers reduplication and conversion,
+the autosegmental machinery covers tone.
+
+Boundary notation (`X-`, `-X`, `X=`, `=X`) is display, not data: `Morph.form`
+is bare segmental material, and `Morph.toString` reproduces the descriptive
+convention from `Morph.Kind`.
 -/
 
 namespace Morphology
 
-/-- The attachment kind of a morph, as descriptive notation encodes it:
-`X-` prefix, `-X` suffix, `X=` proclitic, `=X` enclitic, bare form.
-`root` follows [haspelmath-2020]'s definitional criterion (a morph
-denoting a thing, an action, or a property); `free` covers free
-non-root morphs (particles, plural words, auxiliaries) — the class
-[haspelmath-2020] notes has no established general name. -/
+/-- The ways a morph attaches. -/
 inductive Morph.Kind where
-  | root | pref | suff | procl | encl | free
+  /-- A root is a morph denoting a thing, an action, or a property. -/
+  | root
+  /-- A prefix (`X-`). -/
+  | pref
+  /-- A suffix (`-X`). -/
+  | suff
+  /-- A proclitic (`X=`). -/
+  | procl
+  /-- An enclitic (`=X`). -/
+  | encl
+  /-- A free non-root morph, such as a particle or an auxiliary. -/
+  | free
   deriving DecidableEq, Repr, Fintype
 
-/-- A **morph**: a minimal segmental form with its attachment kind,
-following [haspelmath-2020]'s proposal. `form` is the bare segmental
-material as sources print it, with no boundary notation — hyphens and
-clitic signs are display, produced by `Morph.toString`. -/
+/-- A **morph** is a minimal segmental form with its attachment kind. -/
 structure Morph where
-  /-- Attachment kind, per the source's notation. -/
+  /-- How the morph attaches. -/
   kind : Morph.Kind
-  /-- Bare segmental material, boundary-notation-free. -/
+  /-- The bare segmental material, with no boundary notation. -/
   form : String
   deriving DecidableEq, Repr
 
 /-- An **exponent**: the possibly empty sequence of morphs realizing a
-paradigm cell. `[]` is zero exponence — a form cannot be zero, so there
-is no zero morph; a discontinuous realization (Q'anjob'al *s-…heb'*) is
-a two-morph exponent, [haspelmath-2020]'s "construction containing both
-a prefix and a suffix". Segmental exponence only. -/
+paradigm cell. `[]` is zero exponence; a discontinuous realization
+(Q'anjob'al *s-…heb'*) is a two-morph exponent. -/
 abbrev Exponent := List Morph
 
 namespace Morph
@@ -88,13 +85,13 @@ def free (s : String) : Morph := ⟨.free, s⟩
 /-- A root morph. -/
 def root (s : String) : Morph := ⟨.root, s⟩
 
-/-- Prefixes and suffixes are affixes. -/
+/-- A morph is an **affix** if it is a prefix or a suffix. -/
 def IsAffix (m : Morph) : Prop := m.kind = .pref ∨ m.kind = .suff
 
 instance (m : Morph) : Decidable m.IsAffix :=
   inferInstanceAs (Decidable (_ ∨ _))
 
-/-- Proclitics and enclitics are clitics. -/
+/-- A morph is a **clitic** if it is a proclitic or an enclitic. -/
 def IsClitic (m : Morph) : Prop := m.kind = .procl ∨ m.kind = .encl
 
 instance (m : Morph) : Decidable m.IsClitic :=
@@ -110,19 +107,20 @@ def toString : Morph → String
 
 end Morph
 
-/-- Display an exponent in descriptive notation: `∅` for zero
-exponence, `…` linking the parts of a discontinuous realization. -/
+/-- Display an exponent in descriptive notation: `∅` for zero exponence,
+`…` linking the parts of a discontinuous realization. -/
 def Exponent.toString : Exponent → String
   | [] => "∅"
   | ms => String.intercalate "…" (ms.map Morph.toString)
 
-/-- The class of the following segment — the commonest conditioning
-environment for selecting among a morph's variant shapes
-(pre-consonantal vs pre-vocalic pairs; phonological conditioning in
-[haspelmath-2020]'s sense, which cross-cuts the variant-vs-suppletive
-split of their §§6-8). -/
+/-- The class of the following segment: the commonest phonological
+environment conditioning the choice among a morph's variant shapes
+(pre-consonantal vs pre-vocalic). -/
 inductive Following where
-  | consonant | vowel
+  /-- The next segment is a consonant. -/
+  | consonant
+  /-- The next segment is a vowel. -/
+  | vowel
   deriving DecidableEq, Repr, Fintype
 
 end Morphology


### PR DESCRIPTION
Docstring-only register cleanse of the core form carrier: terse declarative sentences, per-constructor docs, citations consolidated into the module docstring's implementation notes. No code changes.