### PR TITLE
feat(Morphology/Paradigm): derive FCD; Studies/Stump2020

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2648,6 +2648,7 @@ import Linglib.Studies.Storme2026
 import Linglib.Studies.Storment2026
 import Linglib.Studies.Sudo2016
 import Linglib.Studies.Stump2016
+import Linglib.Studies.Stump2020
 import Linglib.Studies.SumersEtAl2023
 import Linglib.Studies.SuttonFilip2021
 import Linglib.Studies.TaraldsenEtAl2018

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -58,6 +58,12 @@ decides realized **values**, not payload equality.
   evaluation and the block cascade
 * `evalPortmanteau`, `evalPortmanteau_eq_comp_of_not_applies` — portmanteau
   blocks and the Function Composition Default
+* `selectMinimal_append_maximal` — appending a maximal always-applicable rule
+  is elsewhere-only: the mechanism behind `identityDefault` and the FCD
+* `functionCompositionDefault`, `le_functionCompositionDefault`,
+  `evalPortmanteau_eq_functionCompositionDefault` — the FCD as a derived
+  `≤`-maximal rule, and the stipulated portmanteau evaluation equals its
+  appended-block form
 * `Linkage.realize_eq_paradigmFunction` — the PFM2 realization of a linkage's
   block cascade is this paradigm function
 -/
@@ -69,11 +75,22 @@ open Morphology Morphology.Exponence
 variable {L Z P F : Type*}
 
 /-- The payload of a realization rule: a rule of **exponence** carries a form
-operation `f : Z → Z`, a rule of **referral** carries a property-set retargeting
-`P → P` whose block is re-consulted at the retargeted cell. -/
+operation `f : P → Z → Z` that may consult the realized property set, a rule of
+**referral** carries a property-set retargeting `P → P` whose block is
+re-consulted at the retargeted cell. The property argument makes the form
+operation σ-sensitive, as [stump-2020]'s rule format allows (his conditional
+affixation operator for ambifixal classes consults σ), and lets the Function
+Composition Default carry a rule whose action is "evaluate two blocks at the
+current cell". -/
 inductive Action (Z P : Type*)
-  | expo (f : Z → Z)
+  | expo (f : P → Z → Z)
   | referral (retarget : P → P)
+
+/-- A **property-insensitive** rule of exponence: a form operation `f : Z → Z`
+applied regardless of the property set — the special case of `Action.expo`
+before [stump-2020]'s σ-sensitive rule format, and the shape of every exponent
+in [bonami-stump-2016]'s worked fragments. -/
+def Action.const (f : Z → Z) : Action Z P := .expo (fun _ => f)
 
 /-- A realization rule in [bonami-stump-2016]'s format `⟨klass, props, payload⟩`
 (the chapter's `n, X_C, τ → f(X)`), payload-polymorphic à la
@@ -162,7 +179,7 @@ consequences are theorems. -/
 def identityDefault : Rule L P (Action Z P) where
   klass := Finset.univ
   props := ⊥
-  payload := .expo id
+  payload := .const id
 
 omit [DecidableEq L] [DecidableLE P] in
 theorem identityDefault_applies (c : L × P) :
@@ -208,12 +225,12 @@ def evalBlockForm (Lindex : Z → L) (b : Block L Z P) (wσ : Z × P) : Z :=
   match selectMinimal b (Lindex wσ.1, wσ.2) with
   | some r =>
     match r.payload with
-    | .expo f => f wσ.1
+    | .expo f => f wσ.2 wσ.1
     | .referral retarget =>
       match selectMinimal (expoFragment b) (Lindex wσ.1, retarget wσ.2) with
       | some s =>
         match s.payload with
-        | .expo g => g wσ.1
+        | .expo g => g (retarget wσ.2) wσ.1
         | .referral _ => wσ.1
       | none => wσ.1
   | none => wσ.1
@@ -272,6 +289,105 @@ theorem evalPortmanteau_eq_comp_of_not_applies (Lindex : Z → L) (bmn bm bn : B
     (wσ : Z × P) (h : applicable bmn (Lindex wσ.1, wσ.2) = []) :
     evalPortmanteau Lindex bmn bm bn wσ = evalBlock Lindex bm (evalBlock Lindex bn wσ) := by
   simp [evalPortmanteau, h]
+
+/-- Appending a `≤`-maximal always-applicable rule to a block leaves narrowest-rule
+selection unchanged when the block already selects, and picks that rule otherwise:
+a maximal rule is preempted by any genuine competitor and fires only in the
+elsewhere. The mechanism shared by `identityDefault` and
+`functionCompositionDefault`. -/
+theorem selectMinimal_append_maximal {v : List (Rule L P F)} {c : L × P}
+    {top : Rule L P F} (hmax : ∀ r, r ≤ top)
+    (htop : Exponence.Applies (F := F) top c) :
+    selectMinimal (v ++ [top]) c = (selectMinimal v c).or (some top) := by
+  have htop' : c.1 ∈ top.klass ∧ top.props ≤ c.2 := htop
+  have happl : applicable (v ++ [top]) c = applicable v c ++ [top] := by
+    simp [applicable, List.filter_append, htop']
+  have hpred : (fun r : Rule L P F => (applicable (v ++ [top]) c).all (fun s => decide (¬ s < r)))
+      = (fun r : Rule L P F => (applicable v c).all (fun s => decide (¬ s < r))) := by
+    funext r
+    have : ¬ top < r := fun hlt => absurd (hmax r) (not_le_of_gt hlt)
+    rw [happl]; simp [List.all_append, this]
+  have hfold : List.find? (fun r => (applicable v c).all (fun s => decide (¬ s < r)))
+      (applicable v c) = selectMinimal v c := rfl
+  rw [selectMinimal, hpred, happl, List.find?_append, hfold]
+  rcases hs : selectMinimal v c with _ | r
+  · have hnil : applicable v c = [] := selectMinimal_eq_none_iff.mp hs
+    rw [Option.none_or, hnil]
+    simp
+  · rfl
+
+/-! ### The Function Composition Default as a derived rule -/
+
+section FunctionCompositionDefault
+variable [Fintype L] [OrderBot P]
+
+/-- The **Function Composition Default** as a derived rule ([spencer-2013]): the
+rule of a portmanteau block `[m, n]` whose σ-sensitive action evaluates blocks
+`m` then `n` at the current cell. Like `identityDefault` it applies everywhere
+(`klass = univ`, `props = ⊥`) and is `≤`-maximal, so any explicit portmanteau
+rule — being narrower — preempts it by ordinary Pāṇinian narrowness. [spencer-2013]
+observes that an explicit portmanteau rule is by definition more specific than
+the FCD, so ordinary narrowness suffices to order them; this derives what
+`evalPortmanteau` stipulates, the same stipulate-to-derive upgrade
+`identityDefault` gives the Identity Function Default. -/
+def functionCompositionDefault (Lindex : Z → L) (bm bn : Block L Z P) :
+    Rule L P (Action Z P) where
+  klass := Finset.univ
+  props := ⊥
+  payload := .expo (fun σ z => (evalBlock Lindex bm (evalBlock Lindex bn (z, σ))).1)
+
+theorem functionCompositionDefault_applies (Lindex : Z → L) (bm bn : Block L Z P)
+    (c : L × P) : Exponence.Applies (F := Action Z P)
+      (functionCompositionDefault Lindex bm bn) c :=
+  ⟨Finset.mem_univ _, bot_le⟩
+
+/-- The FCD is `≤`-maximal: every rule is at least as narrow, so an explicit
+portmanteau rule always preempts it ([spencer-2013]). Same shape as
+`le_identityDefault`. -/
+theorem le_functionCompositionDefault (Lindex : Z → L) (bm bn : Block L Z P)
+    (r : Rule L P (Action Z P)) : r ≤ functionCompositionDefault Lindex bm bn := by
+  by_cases h : r.klass = Finset.univ
+  · exact Or.inl ⟨h, bot_le⟩
+  · exact Or.inr (Finset.ssubset_univ_iff.mpr h)
+
+/-- **FCD-as-derived-default**: for a portmanteau block `bmn` of rules of
+exponence, the stipulated `evalPortmanteau` equals the block `bmn ++ [fcd]`
+evaluated as an ordinary block. Where a portmanteau rule applies it wins by
+narrowness (`le_functionCompositionDefault`, via `selectMinimal_append_maximal`);
+where none does, the appended FCD fires and evaluates `bm ∘ bn` at the cell. This
+certifies the stipulated Function Composition Default as [stump-2020]'s
+single-block rule-conflation reading of [bonami-stump-2016]'s block-straddling
+device. The exponence-only hypothesis on `bmn` is what a portmanteau block *is*
+in PFM — referral, a separate syncretism device, re-selects over the block's
+`expoFragment`, which the appended (exponence-shaped) FCD would perturb. -/
+theorem evalPortmanteau_eq_functionCompositionDefault (Lindex : Z → L)
+    (bmn bm bn : Block L Z P) (wσ : Z × P)
+    (hbmn : ∀ r ∈ bmn, ∃ f, r.payload = Action.expo f) :
+    evalPortmanteau Lindex bmn bm bn wσ
+      = evalBlock Lindex (bmn ++ [functionCompositionDefault Lindex bm bn]) wσ := by
+  have hsel := selectMinimal_append_maximal (v := bmn)
+    (c := (Lindex wσ.1, wσ.2)) (le_functionCompositionDefault Lindex bm bn)
+    (functionCompositionDefault_applies Lindex bm bn (Lindex wσ.1, wσ.2))
+  unfold evalPortmanteau
+  by_cases h : (applicable bmn (Lindex wσ.1, wσ.2)).isEmpty = true
+  · rw [if_pos h]
+    rw [List.isEmpty_iff] at h
+    rw [selectMinimal_eq_none_iff.mpr h, Option.none_or] at hsel
+    conv_rhs => rw [evalBlock, evalBlockForm, hsel]
+    simp only [functionCompositionDefault, Prod.mk.eta]
+    refine Prod.ext rfl ?_
+    simp only [evalBlock_snd]
+  · rw [if_neg h]
+    rw [List.isEmpty_iff] at h
+    obtain ⟨r, hr⟩ := List.exists_mem_of_ne_nil _ h
+    obtain ⟨r', hr'⟩ := Option.isSome_iff_exists.mp
+      (selectMinimal_isSome_of_exists_applicable
+        ⟨r, (mem_applicable.mp hr).1, (mem_applicable.mp hr).2⟩)
+    obtain ⟨f, hf⟩ := hbmn r' (selectMinimal_mem hr')
+    rw [hr', Option.some_or] at hsel
+    simp only [evalBlock, evalBlockForm, hsel, hr', hf]
+
+end FunctionCompositionDefault
 
 /-- With property-preserving property mapping and PFM1 basic stem choice, the
 PFM2 realization of a paradigm linkage's block cascade ([stump-2016]'s

--- a/Linglib/Studies/BonamiStump2016.lean
+++ b/Linglib/Studies/BonamiStump2016.lean
@@ -56,27 +56,27 @@ local notation "IFD" => (identityDefault : Rule Verb (Finset Feat) (Action Strin
 
 /-- Block I: theme-vowel exponence ([bonami-stump-2016]'s Table 17.3). -/
 def blockI : Block Verb String (Finset Feat) :=
-  [ ⟨weak, {pst, pl}, .expo (· ++ "u")⟩,
-    ⟨Finset.univ, {sbjv, prs}, .expo (· ++ "i")⟩,
-    ⟨weak, {}, .expo (· ++ "a")⟩,
+  [ ⟨weak, {pst, pl}, .const (· ++ "u")⟩,
+    ⟨Finset.univ, {sbjv, prs}, .const (· ++ "i")⟩,
+    ⟨weak, {}, .const (· ++ "a")⟩,
     IFD ]
 
 /-- Block II: past-tense exponence. -/
 def blockII : Block Verb String (Finset Feat) :=
-  [ ⟨weak, {pst, sg}, .expo (· ++ "ði")⟩,
-    ⟨weak, {pst, pl}, .expo (· ++ "ðu")⟩,
+  [ ⟨weak, {pst, sg}, .const (· ++ "ði")⟩,
+    ⟨weak, {pst, pl}, .const (· ++ "ðu")⟩,
     IFD ]
 
 /-- Block III: agreement exponence. -/
 def blockIII : Block Verb String (Finset Feat) :=
-  [ ⟨weak4b, {imp, p2, sg}, .expo (· ++ "ðu")⟩,
-    ⟨Finset.univ, {imp, p2, sg}, .expo id⟩,
-    ⟨Finset.univ, {p2, sg}, .expo (· ++ "r")⟩,
-    ⟨Finset.univ, {ind, prs, p3, sg}, .expo (· ++ "r")⟩,
-    ⟨Finset.univ, {p1, pl}, .expo (· ++ "um")⟩,
-    ⟨Finset.univ, {p2, pl}, .expo (· ++ "ið")⟩,
-    ⟨Finset.univ, {ind, prs, p3, pl}, .expo (· ++ "a")⟩,
-    ⟨strong, {ind, pst, p2, sg}, .expo (· ++ "st")⟩,
+  [ ⟨weak4b, {imp, p2, sg}, .const (· ++ "ðu")⟩,
+    ⟨Finset.univ, {imp, p2, sg}, .const id⟩,
+    ⟨Finset.univ, {p2, sg}, .const (· ++ "r")⟩,
+    ⟨Finset.univ, {ind, prs, p3, sg}, .const (· ++ "r")⟩,
+    ⟨Finset.univ, {p1, pl}, .const (· ++ "um")⟩,
+    ⟨Finset.univ, {p2, pl}, .const (· ++ "ið")⟩,
+    ⟨Finset.univ, {ind, prs, p3, pl}, .const (· ++ "a")⟩,
+    ⟨strong, {ind, pst, p2, sg}, .const (· ++ "st")⟩,
     IFD ]
 
 /-- Rules of basic stem choice ([bonami-stump-2016]'s (7)); the `GRÍPA` and
@@ -134,16 +134,16 @@ open Root SF
 
 /-- Block i: ninth-conjugation `-nī` ([bonami-stump-2016]'s (20a)). -/
 def blockNi : Block Root String (Finset SF) :=
-  [ ⟨Finset.univ, {}, .expo (· ++ "nī")⟩ ]
+  [ ⟨Finset.univ, {}, .const (· ++ "nī")⟩ ]
 
 /-- Block ii: subject-agreement `-hi` ([bonami-stump-2016]'s (20b)). -/
 def blockHi : Block Root String (Finset SF) :=
-  [ ⟨Finset.univ, {p2, sg, imp, act}, .expo (· ++ "hi")⟩ ]
+  [ ⟨Finset.univ, {p2, sg, imp, act}, .const (· ++ "hi")⟩ ]
 
 /-- Portmanteau Block [ii,i]: consonant-final `-āna` ([bonami-stump-2016]'s
 (20c)); consonant-finality is carried by the singleton class `{AŚ}`. -/
 def blockAna : Block Root String (Finset SF) :=
-  [ ⟨{as}, {p2, sg, imp, act}, .expo (· ++ "āna")⟩ ]
+  [ ⟨{as}, {p2, sg, imp, act}, .const (· ++ "āna")⟩ ]
 
 /-- The consonant-final root `AŚ` takes the portmanteau `-āna`, overriding the
 `-nī`/`-hi` sequence ([bonami-stump-2016]'s (22)). -/
@@ -179,7 +179,7 @@ def vocToNom (σ : Finset NF) : Finset NF := insert nom (σ.erase voc)
 ([bonami-stump-2016]'s (17)), the referral re-consulting the block at the
 nominative cell. -/
 def caseBlock : Block Noun String (Finset NF) :=
-  [ ⟨Finset.univ, {nom}, .expo (· ++ "e")⟩,
+  [ ⟨Finset.univ, {nom}, .const (· ++ "e")⟩,
     ⟨Finset.univ, {voc}, .referral vocToNom⟩ ]
 
 /-- The vocative dual takes the nominative dual's Block-i exponent: a

--- a/Linglib/Studies/Stump2016.lean
+++ b/Linglib/Studies/Stump2016.lean
@@ -1,29 +1,38 @@
-import Linglib.Morphology.Paradigm.Linkage
+import Linglib.Morphology.Paradigm.Function
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Stump 2016: Latin deponency as a voice-flipping paradigm linkage
+# Stump 2016: paradigm-linkage deviations — deponency and morphomic tense
 [stump-2016]
 
-Latin deponent verbs are [stump-2016]'s central argument for the
-paradigm-linkage hypothesis (Ch. 12): their active forms "inflect by means of
-the morphology that ordinarily serves to express a verb's passive forms"
-(§12.1). Deponent *cōnārī* 'try' realizes its active content cells —
+Two deviations from the canonical content-to-form isomorphism argued for in
+[stump-2016], run on the paradigm-linkage model of
+`Morphology/Paradigm/Linkage.lean`.
+
+**Latin deponency** (Ch. 12): deponent verbs "inflect by means of the morphology
+that ordinarily serves to express a verb's passive forms" (§12.1). Deponent
+*cōnārī* 'try' realizes its active content cells —
 *cōnor, cōnāris, cōnātur, cōnāmur, cōnāminī, cōnantur* (imperfective present
 indicative, Table 12.2) — with the passive personal endings
 (-or, -ris, -tur, -mur, -minī, -ntur) that a regular verb like *parāre*
 'prepare' uses only for its passive (*paror, parāris, parātur, …*, Table 12.1);
-*cōnārī* lacks passive-meaning forms entirely.
-
-In the paradigm-linkage architecture (`Morphology/Paradigm/Linkage.lean`) this
-is a property mapping that crosses the voice axis. A regular verb is subject to
-the canonical `pmc(σ) = σ ∪ {c}` (property-set preserving on the contentful
-features); a deponent is subject to `pm2c(σ:{active}) = σ[active/passive] ∪ {c}`
+*cōnārī* lacks passive-meaning forms entirely. This is a property mapping that
+crosses the voice axis: a regular verb is subject to the canonical
+`pmc(σ) = σ ∪ {c}`, a deponent to `pm2c(σ:{active}) = σ[active/passive] ∪ {c}`
 (§12.1), replacing active with passive. Abstracting away the inflection-class
-index `c` (which is orthogonal to the voice mismatch), the deponent linkage's
-property mapping flips voice while the regular verb's preserves it. The
-theorems below show *cōnārī*'s linkage deviates from `IsCanonical` on every
-active cell — its form correspondents are all passive — while sharing the
-content-cell space with the regular verb.
+index `c`, the deponent linkage flips voice while the regular verb's preserves
+it — *cōnārī*'s linkage deviates from `IsCanonical` on every active cell.
+
+**Kashmiri morphomic tense** (Ch. 8, pp. 217ff): the recent, indefinite, and
+remote preterites of intransitive Conjugations II and III are realized through
+four morphomic properties 'past a'–'past d' via a non-identity property mapping.
+`WUP` (Conj II) and `WUPH` (Conj III) inflect alike in the 'past b' cells —
+`wupyōs` (indefinite) and `wuphyōs` (recent) — because `pmII` and `pmIII` send
+different tenses to the same morphome. The composition exercises the PFM1 block
+cascade of `Morphology/Paradigm/Function.lean` as the form-cell realization, with
+`pm ≠ id`, so `Linkage.realize_eq_paradigmFunction` (which needs `pm = id`) does
+not apply. Forms are transcribed from Grierson's paradigms as displayed by
+[stump-2016]; block rules are read off the stem+suffix segmentation.
 
 ## Main declarations
 
@@ -36,6 +45,10 @@ content-cell space with the regular verb.
   correspondent is passive (the deponency claim)
 * `depon_vs_regular` — same active content cell: regular → active form,
   deponent → passive form
+* `pmII`, `pmIII`, `linkII`, `linkIII` — the two Kashmiri conjugation linkages,
+  their tense-to-morphome property mappings differing by one morphome
+* `kashmiri_inflect_alike` — WUP's indefinite past and WUPH's recent past share
+  the 'past b' form correspondent, the morphomic content-to-form mismatch
 -/
 
 namespace Stump2016
@@ -132,5 +145,108 @@ theorem depon_vs_regular (σ : Cell) (h : σ.voice = .active) :
     (parareLinkage.corr .parare σ).2.voice = .active ∧
       (conariLinkage.corr .conari σ).2.voice = .passive :=
   ⟨h, rfl⟩
+
+/-! ### Kashmiri morphomic tense (Ch. 8, pp. 217ff) -/
+
+section Kashmiri
+
+open Morphology.Exponence Morphology.PFM
+
+/-- The two intransitive verbs: `WUP` 'burn inside' (Conj II) and `WUPH` 'fly'
+(Conj III). -/
+inductive KVerb | wup | wuph
+  deriving DecidableEq, Fintype
+
+/-- Content tenses (recent, indefinite, remote preterite), morphomic form
+properties ('past a'–'past d'), and 1sg masculine agreement. -/
+inductive KFeat
+  | recentPast | indefPast | remotePast
+  | pastA | pastB | pastC | pastD
+  | p1 | sg | masc
+  deriving DecidableEq, Fintype
+
+open KVerb KFeat
+
+/-- The stem of each verb. -/
+def stemOf : KVerb → String
+  | wup => "wup"
+  | wuph => "wuph"
+
+/-- **Property mapping for Conjugation II** ([stump-2016] Ch. 8): recent →
+'past a', indefinite → 'past b', remote → 'past c'. -/
+def pmII (σ : Finset KFeat) : Finset KFeat :=
+  if recentPast ∈ σ then insert pastA (σ.erase recentPast)
+  else if indefPast ∈ σ then insert pastB (σ.erase indefPast)
+  else if remotePast ∈ σ then insert pastC (σ.erase remotePast)
+  else σ
+
+/-- **Property mapping for Conjugation III** ([stump-2016] Ch. 8): recent →
+'past b', indefinite → 'past c', remote → 'past d'. The one-morphome shift from
+`pmII` is what makes the two conjugations' preterites interleave. -/
+def pmIII (σ : Finset KFeat) : Finset KFeat :=
+  if recentPast ∈ σ then insert pastB (σ.erase recentPast)
+  else if indefPast ∈ σ then insert pastC (σ.erase indefPast)
+  else if remotePast ∈ σ then insert pastD (σ.erase remotePast)
+  else σ
+
+/-- The form paradigm: 1sg masculine exponents for each morphome, read off the
+stem+suffix segmentation (`wupus`, `wupyōs`, `wupyās`, `wuphiyās`). -/
+def formBlock : Block KVerb String (Finset KFeat) :=
+  [ ⟨Finset.univ, {pastA, p1, sg, masc}, .const (· ++ "us")⟩,
+    ⟨Finset.univ, {pastB, p1, sg, masc}, .const (· ++ "yōs")⟩,
+    ⟨Finset.univ, {pastC, p1, sg, masc}, .const (· ++ "yās")⟩,
+    ⟨Finset.univ, {pastD, p1, sg, masc}, .const (· ++ "iyās")⟩,
+    (identityDefault : Rule KVerb (Finset KFeat) (Action String (Finset KFeat))) ]
+
+/-- Realization of a form cell `⟨Z, τ⟩`: the PFM1 paradigm function on the stem
+`Z` at the morphomic property set `τ`. -/
+def realizeForm (z : String) (τ : Finset KFeat) : String :=
+  (paradigmFunction (fun _ => wup) (fun _ => z) [formBlock] (wup, τ)).1
+
+/-- Conjugation II linkage: the single stem, mapped by `pmII`. -/
+def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmII⟩
+
+/-- Conjugation III linkage: the single stem, mapped by `pmIII`. -/
+def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmIII⟩
+
+/-- WUP recent past ('past a'): `wupus`. -/
+example : linkII.realize realizeForm wup {recentPast, p1, sg, masc}
+    = ("wupus", {pastA, p1, sg, masc}) := by decide
+
+/-- WUP indefinite past ('past b'): `wupyōs`. -/
+example : linkII.realize realizeForm wup {indefPast, p1, sg, masc}
+    = ("wupyōs", {pastB, p1, sg, masc}) := by decide
+
+/-- WUP remote past ('past c'): `wupyās`. -/
+example : linkII.realize realizeForm wup {remotePast, p1, sg, masc}
+    = ("wupyās", {pastC, p1, sg, masc}) := by decide
+
+/-- WUPH recent past ('past b'): `wuphyōs`. -/
+example : linkIII.realize realizeForm wuph {recentPast, p1, sg, masc}
+    = ("wuphyōs", {pastB, p1, sg, masc}) := by decide
+
+/-- WUPH indefinite past ('past c'): `wuphyās`. -/
+example : linkIII.realize realizeForm wuph {indefPast, p1, sg, masc}
+    = ("wuphyās", {pastC, p1, sg, masc}) := by decide
+
+/-- WUPH remote past ('past d'): `wuphiyās`. -/
+example : linkIII.realize realizeForm wuph {remotePast, p1, sg, masc}
+    = ("wuphiyās", {pastD, p1, sg, masc}) := by decide
+
+/-- **The morphomic mediation** ([stump-2016] Ch. 8): WUP's indefinite past and
+WUPH's recent past have the same form correspondent property set — both 'past b',
+1sg masc — even though their tenses differ. This is why they inflect alike
+(`-yōs`), the content-to-form mismatch the paradigm-linkage model captures. -/
+theorem kashmiri_inflect_alike :
+    (linkII.corr wup {indefPast, p1, sg, masc}).2
+      = (linkIII.corr wuph {recentPast, p1, sg, masc}).2 := by decide
+
+/-- The second interleaving: WUP's remote past and WUPH's indefinite past share
+the 'past c' correspondent, inflecting alike (`-yās`). -/
+theorem kashmiri_inflect_alike_pastC :
+    (linkII.corr wup {remotePast, p1, sg, masc}).2
+      = (linkIII.corr wuph {indefPast, p1, sg, masc}).2 := by decide
+
+end Kashmiri
 
 end Stump2016

--- a/Linglib/Studies/Stump2020.lean
+++ b/Linglib/Studies/Stump2020.lean
@@ -2,33 +2,25 @@ import Linglib.Morphology.Paradigm.Function
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Old English HIERAN and Kashmiri morphomic tense
-[stump-2020] [bonami-stump-2016] [stump-2016]
+# Old English HIERAN
+[stump-2020] [bonami-stump-2016]
 
-Two fragments from [stump-2020]'s survey of Paradigm Function Morphology, run on
-the PFM1 engine of `Morphology/Paradigm/Function.lean` and the paradigm-linkage
-model of `Morphology/Paradigm/Linkage.lean`.
+The finite paradigm of the Old English weak verb HIERAN 'hear' (§2.2, Table 3)
+from [stump-2020]'s survey of Paradigm Function Morphology, run on the PFM1
+engine of `Morphology/Paradigm/Function.lean`. The paradigm's exploded
+segmentation is captured by three affix blocks — past `-d-`, theme vowel,
+agreement — with the Identity Function Default filling empty positions; the bare
+imperative `hīer` is the IFD firing through every block. Only the past cells and
+the agreement-suffixed present plural are decided; the present theme-vowel
+conditioning across the full paradigm needs the block rules (10), which the
+source figure does not legibly give. Forms are transcribed from Table 3; block
+rules are read off the exploded segmentation, never recalled.
 
-* **Old English HIERAN 'hear'** (§2.2, Table 3): the finite paradigm's exploded
-  segmentation into three affix blocks — past `-d-`, theme vowel, agreement — the
-  Identity Function Default filling empty positions. The bare imperative `hīer`
-  is the IFD firing through every block. Only the past cells and the
-  agreement-suffixed present plural are decided; the present theme-vowel
-  conditioning across the full paradigm needs the block rules (10), which the
-  source figure does not legibly give.
-* **Kashmiri tense** (§3.1, Table 4): the recent, indefinite, and remote
-  preterites of Conjugations II and III are realized through four morphomic
-  properties 'past a'–'past d' via a non-identity property mapping `pm`. `WUP`
-  (Conj II) and `WUPH` (Conj III) inflect alike in the 'past b' cells —
-  `wupyōs` (indefinite) and `wuphyōs` (recent) — because `pmII` and `pmIII` send
-  different tenses to the same morphome. The composition exercises PFM2's
-  content-to-form linkage over PFM1's block cascade, with `pm ≠ id`, so
-  `Linkage.realize_eq_paradigmFunction` (which needs `pm = id`) does not apply.
-
-Forms are transcribed from the article's tables; block rules are read off the
-exploded segmentations, never recalled. §3.2's rule conflation (the Swahili si-
-portmanteau) is out of scope for this fragment; the affirmative `nitasoma` is
-included as the plain block cascade that a conflated si- rule would override.
+The article's other fragments are anchored to their originating work: §3.1's
+Kashmiri morphomic tense (attributed by the article to [stump-2016] Ch. 8) is
+formalized in `Studies/Stump2016.lean`, and §3.2's rule conflation (the Swahili
+si- portmanteau) is the successor direction the portmanteau note in
+`Morphology/Paradigm/Function.lean` points to, left to future work.
 -/
 
 namespace Stump2020
@@ -98,136 +90,5 @@ the bare stem `hīer`, no block contributing an exponent. -/
 example : hieranPF {imp, p2, sg} = ("hīer", {imp, p2, sg}) := by decide
 
 end OldEnglish
-
-/-! ### Kashmiri morphomic tense (§3.1, Table 4) -/
-
-section Kashmiri
-
-/-- The two intransitive verbs: `WUP` 'burn inside' (Conj II) and `WUPH` 'fly'
-(Conj III). -/
-inductive KVerb | wup | wuph
-  deriving DecidableEq, Fintype
-
-/-- Content tenses (recent, indefinite, remote preterite), morphomic form
-properties ('past a'–'past d'), and 1sg masculine agreement. -/
-inductive KFeat
-  | recentPast | indefPast | remotePast
-  | pastA | pastB | pastC | pastD
-  | p1 | sg | masc
-  deriving DecidableEq, Fintype
-
-open KVerb KFeat
-
-/-- The stem of each verb. -/
-def stemOf : KVerb → String
-  | wup => "wup"
-  | wuph => "wuph"
-
-/-- **Property mapping for Conjugation II** ([stump-2020]'s (15)): recent →
-'past a', indefinite → 'past b', remote → 'past c'. -/
-def pmII (σ : Finset KFeat) : Finset KFeat :=
-  if recentPast ∈ σ then insert pastA (σ.erase recentPast)
-  else if indefPast ∈ σ then insert pastB (σ.erase indefPast)
-  else if remotePast ∈ σ then insert pastC (σ.erase remotePast)
-  else σ
-
-/-- **Property mapping for Conjugation III** ([stump-2020]'s (15)): recent →
-'past b', indefinite → 'past c', remote → 'past d'. The one-morphome shift from
-`pmII` is what makes the two conjugations' preterites interleave. -/
-def pmIII (σ : Finset KFeat) : Finset KFeat :=
-  if recentPast ∈ σ then insert pastB (σ.erase recentPast)
-  else if indefPast ∈ σ then insert pastC (σ.erase indefPast)
-  else if remotePast ∈ σ then insert pastD (σ.erase remotePast)
-  else σ
-
-/-- The form paradigm: 1sg masculine exponents for each morphome, read off
-Table 4's stem+suffix segmentation (`wupus`, `wupyōs`, `wupyās`, `wuphiyās`). -/
-def formBlock : Block KVerb String (Finset KFeat) :=
-  [ ⟨Finset.univ, {pastA, p1, sg, masc}, .const (· ++ "us")⟩,
-    ⟨Finset.univ, {pastB, p1, sg, masc}, .const (· ++ "yōs")⟩,
-    ⟨Finset.univ, {pastC, p1, sg, masc}, .const (· ++ "yās")⟩,
-    ⟨Finset.univ, {pastD, p1, sg, masc}, .const (· ++ "iyās")⟩,
-    (identityDefault : Rule KVerb (Finset KFeat) (Action String (Finset KFeat))) ]
-
-/-- Realization of a form cell `⟨Z, τ⟩`: the PFM1 paradigm function on the stem
-`Z` at the morphomic property set `τ`. -/
-def realizeForm (z : String) (τ : Finset KFeat) : String :=
-  (paradigmFunction (fun _ => wup) (fun _ => z) [formBlock] (wup, τ)).1
-
-/-- Conjugation II linkage: the single stem, mapped by `pmII`. -/
-def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmII⟩
-
-/-- Conjugation III linkage: the single stem, mapped by `pmIII`. -/
-def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmIII⟩
-
-/-- WUP recent past ('past a'): `wupus`. -/
-example : linkII.realize realizeForm wup {recentPast, p1, sg, masc}
-    = ("wupus", {pastA, p1, sg, masc}) := by decide
-
-/-- WUP indefinite past ('past b'): `wupyōs`. -/
-example : linkII.realize realizeForm wup {indefPast, p1, sg, masc}
-    = ("wupyōs", {pastB, p1, sg, masc}) := by decide
-
-/-- WUP remote past ('past c'): `wupyās`. -/
-example : linkII.realize realizeForm wup {remotePast, p1, sg, masc}
-    = ("wupyās", {pastC, p1, sg, masc}) := by decide
-
-/-- WUPH recent past ('past b'): `wuphyōs`. -/
-example : linkIII.realize realizeForm wuph {recentPast, p1, sg, masc}
-    = ("wuphyōs", {pastB, p1, sg, masc}) := by decide
-
-/-- WUPH indefinite past ('past c'): `wuphyās`. -/
-example : linkIII.realize realizeForm wuph {indefPast, p1, sg, masc}
-    = ("wuphyās", {pastC, p1, sg, masc}) := by decide
-
-/-- WUPH remote past ('past d'): `wuphiyās`. -/
-example : linkIII.realize realizeForm wuph {remotePast, p1, sg, masc}
-    = ("wuphiyās", {pastD, p1, sg, masc}) := by decide
-
-/-- **The morphomic mediation** ([stump-2020] §3.1): WUP's indefinite past and
-WUPH's recent past have the same form correspondent property set — both 'past b',
-1sg masc — even though their tenses differ. This is why they inflect alike
-(`-yōs`), the content-to-form mismatch the paradigm-linkage model captures. -/
-example : (linkII.corr wup {indefPast, p1, sg, masc}).2
-    = (linkIII.corr wuph {recentPast, p1, sg, masc}).2 := by decide
-
-/-- The second interleaving: WUP's remote past and WUPH's indefinite past share
-the 'past c' correspondent, inflecting alike (`-yās`). -/
-example : (linkII.corr wup {remotePast, p1, sg, masc}).2
-    = (linkIII.corr wuph {indefPast, p1, sg, masc}).2 := by decide
-
-end Kashmiri
-
-/-! ### Swahili affirmative future (§3.2, Table 5) -/
-
-section Swahili
-
-/-- The verb SOMA 'read'. -/
-inductive SwVerb | soma
-  deriving DecidableEq, Fintype
-
-/-- Tense, person, and number features. -/
-inductive SwFeat | fut | s1 | sg
-  deriving DecidableEq, Fintype
-
-open SwVerb SwFeat
-
-/-- Block −2 (tense): the future prefix `ta-`. -/
-def tenseBlock : Block SwVerb String (Finset SwFeat) :=
-  [ ⟨Finset.univ, {fut}, .const ("ta" ++ ·)⟩,
-    (identityDefault : Rule SwVerb (Finset SwFeat) (Action String (Finset SwFeat))) ]
-
-/-- Block −3 (subject concord): the 1sg prefix `ni-`. -/
-def subjBlock : Block SwVerb String (Finset SwFeat) :=
-  [ ⟨Finset.univ, {s1, sg}, .const ("ni" ++ ·)⟩,
-    (identityDefault : Rule SwVerb (Finset SwFeat) (Action String (Finset SwFeat))) ]
-
-/-- **The plain affirmative cascade**: `soma` prefixed by tense then subject
-concord gives `nitasoma` 'I will read'. §3.2's negative `sitasoma` overrides this
-by a conflated si- rule, the [stump-2020] direction left to future work. -/
-example : paradigmFunction (fun _ => soma) (fun _ => "soma") [tenseBlock, subjBlock]
-    (soma, {fut, s1, sg}) = ("nitasoma", {fut, s1, sg}) := by decide
-
-end Swahili
 
 end Stump2020

--- a/Linglib/Studies/Stump2020.lean
+++ b/Linglib/Studies/Stump2020.lean
@@ -1,0 +1,233 @@
+import Linglib.Morphology.Paradigm.Function
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# Old English HIERAN and Kashmiri morphomic tense
+[stump-2020] [bonami-stump-2016] [stump-2016]
+
+Two fragments from [stump-2020]'s survey of Paradigm Function Morphology, run on
+the PFM1 engine of `Morphology/Paradigm/Function.lean` and the paradigm-linkage
+model of `Morphology/Paradigm/Linkage.lean`.
+
+* **Old English HIERAN 'hear'** (§2.2, Table 3): the finite paradigm's exploded
+  segmentation into three affix blocks — past `-d-`, theme vowel, agreement — the
+  Identity Function Default filling empty positions. The bare imperative `hīer`
+  is the IFD firing through every block. Only the past cells and the
+  agreement-suffixed present plural are decided; the present theme-vowel
+  conditioning across the full paradigm needs the block rules (10), which the
+  source figure does not legibly give.
+* **Kashmiri tense** (§3.1, Table 4): the recent, indefinite, and remote
+  preterites of Conjugations II and III are realized through four morphomic
+  properties 'past a'–'past d' via a non-identity property mapping `pm`. `WUP`
+  (Conj II) and `WUPH` (Conj III) inflect alike in the 'past b' cells —
+  `wupyōs` (indefinite) and `wuphyōs` (recent) — because `pmII` and `pmIII` send
+  different tenses to the same morphome. The composition exercises PFM2's
+  content-to-form linkage over PFM1's block cascade, with `pm ≠ id`, so
+  `Linkage.realize_eq_paradigmFunction` (which needs `pm = id`) does not apply.
+
+Forms are transcribed from the article's tables; block rules are read off the
+exploded segmentations, never recalled. §3.2's rule conflation (the Swahili si-
+portmanteau) is out of scope for this fragment; the affirmative `nitasoma` is
+included as the plain block cascade that a conflated si- rule would override.
+-/
+
+namespace Stump2020
+
+open Morphology Morphology.Exponence Morphology.PFM
+
+/-! ### Old English HIERAN 'hear' (§2.2, Table 3) -/
+
+section OldEnglish
+
+/-- The weak verb HIERAN. -/
+inductive Verb | hieran
+  deriving DecidableEq, Fintype
+
+/-- Mood, tense, person, and number features (decomposed). -/
+inductive Feat | ind | sbj | imp | pres | past | p1 | p2 | p3 | sg | pl
+  deriving DecidableEq, Fintype
+
+open Verb Feat
+
+local notation "IFD" => (identityDefault : Rule Verb (Finset Feat) (Action String (Finset Feat)))
+
+/-- Block I (position i): the past-tense formative `-d-`. -/
+def blockI : Block Verb String (Finset Feat) :=
+  [ ⟨Finset.univ, {past}, .const (· ++ "d")⟩,
+    IFD ]
+
+/-- Block II (position ii): the theme vowel — `-o-` in the past plural,
+`-e-` elsewhere in the past (the present-tense conditioning is not modelled). -/
+def blockII : Block Verb String (Finset Feat) :=
+  [ ⟨Finset.univ, {past, pl}, .const (· ++ "o")⟩,
+    ⟨Finset.univ, {past}, .const (· ++ "e")⟩,
+    IFD ]
+
+/-- Block III (position iii): agreement and mood — `-st` (2sg indicative,
+[stump-2020]'s rule (7)), `-þ` (3sg present indicative), `-aþ` (present plural),
+`-n` (past plural). -/
+def blockIII : Block Verb String (Finset Feat) :=
+  [ ⟨Finset.univ, {ind, p2, sg}, .const (· ++ "st")⟩,
+    ⟨Finset.univ, {ind, pres, p3, sg}, .const (· ++ "þ")⟩,
+    ⟨Finset.univ, {pres, pl}, .const (· ++ "aþ")⟩,
+    ⟨Finset.univ, {past, pl}, .const (· ++ "n")⟩,
+    IFD ]
+
+/-- The HIERAN paradigm function: stem `hīer` through Blocks I–III. -/
+def hieranPF (σ : Finset Feat) : String × Finset Feat :=
+  paradigmFunction (fun _ => hieran) (fun _ => "hīer") [blockI, blockII, blockIII] (hieran, σ)
+
+/-- 1sg past indicative: `hīer` + `-d-` + `-e-` = `hīerde`. -/
+example : hieranPF {ind, past, p1, sg} = ("hīerde", {ind, past, p1, sg}) := by decide
+
+/-- 3sg past indicative: `hīerde` (theme `-e-`, no agreement suffix). -/
+example : hieranPF {ind, past, p3, sg} = ("hīerde", {ind, past, p3, sg}) := by decide
+
+/-- 2sg past indicative: `hīer` + `-d-` + `-e-` + `-st` = `hīerdest`. -/
+example : hieranPF {ind, past, p2, sg} = ("hīerdest", {ind, past, p2, sg}) := by decide
+
+/-- Plural past indicative: `hīer` + `-d-` + `-o-` + `-n` = `hīerdon`. -/
+example : hieranPF {ind, past, pl} = ("hīerdon", {ind, past, pl}) := by decide
+
+/-- Plural present indicative: `hīer` + `-aþ` = `hīeraþ` (the theme vowel is
+elided; elision is phonological and not modelled). -/
+example : hieranPF {ind, pres, pl} = ("hīeraþ", {ind, pres, pl}) := by decide
+
+/-- **The Identity Function Default through every block**: the 2sg imperative is
+the bare stem `hīer`, no block contributing an exponent. -/
+example : hieranPF {imp, p2, sg} = ("hīer", {imp, p2, sg}) := by decide
+
+end OldEnglish
+
+/-! ### Kashmiri morphomic tense (§3.1, Table 4) -/
+
+section Kashmiri
+
+/-- The two intransitive verbs: `WUP` 'burn inside' (Conj II) and `WUPH` 'fly'
+(Conj III). -/
+inductive KVerb | wup | wuph
+  deriving DecidableEq, Fintype
+
+/-- Content tenses (recent, indefinite, remote preterite), morphomic form
+properties ('past a'–'past d'), and 1sg masculine agreement. -/
+inductive KFeat
+  | recentPast | indefPast | remotePast
+  | pastA | pastB | pastC | pastD
+  | p1 | sg | masc
+  deriving DecidableEq, Fintype
+
+open KVerb KFeat
+
+/-- The stem of each verb. -/
+def stemOf : KVerb → String
+  | wup => "wup"
+  | wuph => "wuph"
+
+/-- **Property mapping for Conjugation II** ([stump-2020]'s (15)): recent →
+'past a', indefinite → 'past b', remote → 'past c'. -/
+def pmII (σ : Finset KFeat) : Finset KFeat :=
+  if recentPast ∈ σ then insert pastA (σ.erase recentPast)
+  else if indefPast ∈ σ then insert pastB (σ.erase indefPast)
+  else if remotePast ∈ σ then insert pastC (σ.erase remotePast)
+  else σ
+
+/-- **Property mapping for Conjugation III** ([stump-2020]'s (15)): recent →
+'past b', indefinite → 'past c', remote → 'past d'. The one-morphome shift from
+`pmII` is what makes the two conjugations' preterites interleave. -/
+def pmIII (σ : Finset KFeat) : Finset KFeat :=
+  if recentPast ∈ σ then insert pastB (σ.erase recentPast)
+  else if indefPast ∈ σ then insert pastC (σ.erase indefPast)
+  else if remotePast ∈ σ then insert pastD (σ.erase remotePast)
+  else σ
+
+/-- The form paradigm: 1sg masculine exponents for each morphome, read off
+Table 4's stem+suffix segmentation (`wupus`, `wupyōs`, `wupyās`, `wuphiyās`). -/
+def formBlock : Block KVerb String (Finset KFeat) :=
+  [ ⟨Finset.univ, {pastA, p1, sg, masc}, .const (· ++ "us")⟩,
+    ⟨Finset.univ, {pastB, p1, sg, masc}, .const (· ++ "yōs")⟩,
+    ⟨Finset.univ, {pastC, p1, sg, masc}, .const (· ++ "yās")⟩,
+    ⟨Finset.univ, {pastD, p1, sg, masc}, .const (· ++ "iyās")⟩,
+    (identityDefault : Rule KVerb (Finset KFeat) (Action String (Finset KFeat))) ]
+
+/-- Realization of a form cell `⟨Z, τ⟩`: the PFM1 paradigm function on the stem
+`Z` at the morphomic property set `τ`. -/
+def realizeForm (z : String) (τ : Finset KFeat) : String :=
+  (paradigmFunction (fun _ => wup) (fun _ => z) [formBlock] (wup, τ)).1
+
+/-- Conjugation II linkage: the single stem, mapped by `pmII`. -/
+def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmII⟩
+
+/-- Conjugation III linkage: the single stem, mapped by `pmIII`. -/
+def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmIII⟩
+
+/-- WUP recent past ('past a'): `wupus`. -/
+example : linkII.realize realizeForm wup {recentPast, p1, sg, masc}
+    = ("wupus", {pastA, p1, sg, masc}) := by decide
+
+/-- WUP indefinite past ('past b'): `wupyōs`. -/
+example : linkII.realize realizeForm wup {indefPast, p1, sg, masc}
+    = ("wupyōs", {pastB, p1, sg, masc}) := by decide
+
+/-- WUP remote past ('past c'): `wupyās`. -/
+example : linkII.realize realizeForm wup {remotePast, p1, sg, masc}
+    = ("wupyās", {pastC, p1, sg, masc}) := by decide
+
+/-- WUPH recent past ('past b'): `wuphyōs`. -/
+example : linkIII.realize realizeForm wuph {recentPast, p1, sg, masc}
+    = ("wuphyōs", {pastB, p1, sg, masc}) := by decide
+
+/-- WUPH indefinite past ('past c'): `wuphyās`. -/
+example : linkIII.realize realizeForm wuph {indefPast, p1, sg, masc}
+    = ("wuphyās", {pastC, p1, sg, masc}) := by decide
+
+/-- WUPH remote past ('past d'): `wuphiyās`. -/
+example : linkIII.realize realizeForm wuph {remotePast, p1, sg, masc}
+    = ("wuphiyās", {pastD, p1, sg, masc}) := by decide
+
+/-- **The morphomic mediation** ([stump-2020] §3.1): WUP's indefinite past and
+WUPH's recent past have the same form correspondent property set — both 'past b',
+1sg masc — even though their tenses differ. This is why they inflect alike
+(`-yōs`), the content-to-form mismatch the paradigm-linkage model captures. -/
+example : (linkII.corr wup {indefPast, p1, sg, masc}).2
+    = (linkIII.corr wuph {recentPast, p1, sg, masc}).2 := by decide
+
+/-- The second interleaving: WUP's remote past and WUPH's indefinite past share
+the 'past c' correspondent, inflecting alike (`-yās`). -/
+example : (linkII.corr wup {remotePast, p1, sg, masc}).2
+    = (linkIII.corr wuph {indefPast, p1, sg, masc}).2 := by decide
+
+end Kashmiri
+
+/-! ### Swahili affirmative future (§3.2, Table 5) -/
+
+section Swahili
+
+/-- The verb SOMA 'read'. -/
+inductive SwVerb | soma
+  deriving DecidableEq, Fintype
+
+/-- Tense, person, and number features. -/
+inductive SwFeat | fut | s1 | sg
+  deriving DecidableEq, Fintype
+
+open SwVerb SwFeat
+
+/-- Block −2 (tense): the future prefix `ta-`. -/
+def tenseBlock : Block SwVerb String (Finset SwFeat) :=
+  [ ⟨Finset.univ, {fut}, .const ("ta" ++ ·)⟩,
+    (identityDefault : Rule SwVerb (Finset SwFeat) (Action String (Finset SwFeat))) ]
+
+/-- Block −3 (subject concord): the 1sg prefix `ni-`. -/
+def subjBlock : Block SwVerb String (Finset SwFeat) :=
+  [ ⟨Finset.univ, {s1, sg}, .const ("ni" ++ ·)⟩,
+    (identityDefault : Rule SwVerb (Finset SwFeat) (Action String (Finset SwFeat))) ]
+
+/-- **The plain affirmative cascade**: `soma` prefixed by tense then subject
+concord gives `nitasoma` 'I will read'. §3.2's negative `sitasoma` overrides this
+by a conflated si- rule, the [stump-2020] direction left to future work. -/
+example : paradigmFunction (fun _ => soma) (fun _ => "soma") [tenseBlock, subjBlock]
+    (soma, {fut, s1, sg}) = ("nitasoma", {fut, s1, sg}) := by decide
+
+end Swahili
+
+end Stump2020

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26389,6 +26389,19 @@
   address   = {Oxford},
   doi       = {10.1093/acrefore/9780199384655.013.578},
   subfield  = {morphology},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Morphology/Paradigm/Function.lean;Studies/Stump2020.lean}
+}
+@book{spencer-2013,
+  author    = {Spencer, Andrew},
+  year      = {2013},
+  title     = {Lexical Relatedness: A Paradigm-Based Model},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  isbn      = {9780199679928},
+  doi       = {10.1093/acprof:oso/9780199679928.001.0001},
+  subfield  = {morphology},
   role      = {cited},
   validated = {true},
   sources   = {Morphology/Paradigm/Function.lean}


### PR DESCRIPTION
Derives the Function Composition Default as a `≤`-maximal rule appended to the portmanteau block (`functionCompositionDefault`, `evalPortmanteau_eq_functionCompositionDefault`), generalizing `Action.expo` to σ-sensitive `P → Z → Z`. Adds `Studies/Stump2020.lean` (Old English HIERAN) as the second consumer of the PFM1 engine, and grows `Studies/Stump2016.lean` with the Kashmiri morphomic-tense fragment on non-identity property mappings (anchored to [stump-2016] Ch. 8, where the article attributes the analysis).