### PR TITLE
refactor(Morphology): Morph.lean cleanse; SegmentClass to Phonology

### DIFF
--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -178,7 +178,7 @@ def absIntranSInNonFinite : Bool := false
     VA §4.2; the exclusive paradigm with `=l(oj)oñ` is a per-language
     refinement not exposed by the canonical φ-cell substrate) and the
     suffix `-ob` for 3pl. -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "k"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "i"]),

--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 import Linglib.Fragments.Mayan.Params
@@ -177,7 +178,7 @@ def absIntranSInNonFinite : Bool := false
     VA §4.2; the exclusive paradigm with `=l(oj)oñ` is a per-language
     refinement not exposed by the canonical φ-cell substrate) and the
     suffix `-ob` for 3pl. -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "k"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "i"]),

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 
@@ -66,7 +67,7 @@ def absPosition : Mayan.ABSPosition := .high
     the standard K'ichean reading (cognate with the verified K'iche'
     paradigm, [mondloch-2017]). 3sg pre-consonantal *ru-* has a
     dialectal variant *u-* (Preminger's "r(u)/u-"). -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "n"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "ru"]), (.pn .first .Plur, [.pref "qa"]),

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -67,7 +67,7 @@ def absPosition : Mayan.ABSPosition := .high
     the standard K'ichean reading (cognate with the verified K'iche'
     paradigm, [mondloch-2017]). 3sg pre-consonantal *ru-* has a
     dialectal variant *u-* (Preminger's "r(u)/u-"). -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "n"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "ru"]), (.pn .first .Plur, [.pref "qa"]),

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -335,7 +335,7 @@ def setBLinearity : MarkerLinearity := .prefixal
 /-- Canonical Set A exponent table (informal) by following-segment
     environment, keyed on the canonical φ-cell `Agreement.Cell` for
     cross-Mayan consumption. -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, setAPreC (phi .first  .singular)),
      (.pn .second .Sing, setAPreC (phi .second .singular)),

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -82,7 +82,7 @@ abbrev phi (p : Person) (n : Number) : PhiFeatures :=
     These are verbal prefixes (or postverbal particles for formal forms)
     that cross-reference S (intransitive subject) and P (transitive
     object). [mondloch-2017] Lessons 9, 15. -/
-def setBMarker : PhiFeatures → Morphology.Exponent
+def setBMarker : PhiFeatures → List Morphology.Morph
   | ⟨.first,  .singular, .informal⟩ => [.pref "in"]
   | ⟨.second, .singular, .informal⟩ => [.pref "at"]
   | ⟨.third,  .singular, .informal⟩ => []
@@ -105,7 +105,7 @@ def setBMarker : PhiFeatures → Morphology.Exponent
     These cross-reference A (transitive subject) and are identical to
     possessive pronouns before consonant-initial nouns.
     [mondloch-2017] Lessons 7, 15. -/
-def setAPreC : PhiFeatures → Morphology.Exponent
+def setAPreC : PhiFeatures → List Morphology.Morph
   | ⟨.first,  .singular, .informal⟩ => [.pref "nu"]
   | ⟨.second, .singular, .informal⟩ => [.pref "a"]
   | ⟨.third,  .singular, .informal⟩ => [.pref "u"]
@@ -123,7 +123,7 @@ def setAPreC : PhiFeatures → Morphology.Exponent
 
 /-- Set A (ergative) markers before vowel-initial roots.
     [mondloch-2017] Lesson 8. -/
-def setAPreV : PhiFeatures → Morphology.Exponent
+def setAPreV : PhiFeatures → List Morphology.Morph
   | ⟨.first,  .singular, .informal⟩ => [.pref "w"]
   | ⟨.second, .singular, .informal⟩ => [.pref "aw"]
   | ⟨.third,  .singular, .informal⟩ => [.pref "r"]

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
 import Linglib.Features.Prominence
@@ -334,7 +335,7 @@ def setBLinearity : MarkerLinearity := .prefixal
 /-- Canonical Set A exponent table (informal) by following-segment
     environment, keyed on the canonical φ-cell `Agreement.Cell` for
     cross-Mayan consumption. -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, setAPreC (phi .first  .singular)),
      (.pn .second .Sing, setAPreC (phi .second .singular)),

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Mam.Pronouns
 import Linglib.Fragments.Mayan.Params
@@ -77,7 +78,7 @@ open Features.Prominence (ArgumentRole)
     syncretic for 2/3SG, ky- for 2/3PL. Scott: 1SG is the sole Set A
     allomorphy — pre-consonantal `n-`, pre-vocalic `w-` (exx. (28)-(29));
     the other markers do not alternate. -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "n"]), (.pn .second .Sing, [.pref "t"]),
      (.pn .third .Sing, [.pref "t"]), (.pn .first .Plur, [.pref "q"]),

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -78,7 +78,7 @@ open Features.Prominence (ArgumentRole)
     syncretic for 2/3SG, ky- for 2/3PL. Scott: 1SG is the sole Set A
     allomorphy — pre-consonantal `n-`, pre-vocalic `w-` (exx. (28)-(29));
     the other markers do not alternate. -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "n"]), (.pn .second .Sing, [.pref "t"]),
      (.pn .third .Sing, [.pref "t"]), (.pn .first .Plur, [.pref "q"]),

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -106,7 +106,7 @@ def setBSpecificCells : List Cell :=
 
 /-- The Elsewhere Set B marker, surfacing in transitives when Infl's
     probe is blocked and for 2/3SG intransitive S. -/
-def defaultSetB : Morphology.Exponent := [.procl "tz'"]
+def defaultSetB : List Morphology.Morph := [.procl "tz'"]
 
 /-! ### Argument positions and agreement status -/
 

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -353,14 +353,16 @@ def VerbForm.agreementSlots (f : VerbForm) : Nat :=
 
 /-- An exponent table: a descriptive agreement paradigm over canonical φ-cells
     (`Agreement.Cell`), mapping each person/number cell to its
-    `Morphology.Exponent` — a possibly empty sequence of `Morphology.Morph`s.
+    `List Morphology.Morph` — a possibly empty sequence of `Morphology.Morph`s.
     Zero exponence is `[]`; a discontinuous realization (person marker plus a
     separate plural word, e.g. Q'anjob'al *s-…heb'*) is a two-morph exponent.
-    Per-language `setAExponent`/`setBExponent` populate this; cross-Mayan
-    typology theorems quantify over it. Tables with pre-consonantal vs
-    pre-vocalic variant shapes are `Phonology.Segment.Class → ExponentTable`
-    functions, with `.consonant` the citation point. -/
-abbrev ExponentTable := Agreement.Paradigm Morphology.Exponent
+    `[]` means *no segmental exponent*, not *unmarked*: a cell whose sole
+    marker is a process also renders as `[]`. Per-language
+    `setAExponent`/`setBExponent` populate this; cross-Mayan typology
+    theorems quantify over it. Tables with pre-consonantal vs pre-vocalic
+    variant shapes are `Phonology.Segment.Class → ExponentTable` functions,
+    with `.consonant` the citation point. -/
+abbrev ExponentTable := Agreement.Paradigm (List Morphology.Morph)
 
 /-- Decidable predicate: the third-person singular Set B slot has zero
     exponence. An invariant of the standard Mayan branches per

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -358,7 +358,7 @@ def VerbForm.agreementSlots (f : VerbForm) : Nat :=
     separate plural word, e.g. Q'anjob'al *s-…heb'*) is a two-morph exponent.
     Per-language `setAExponent`/`setBExponent` populate this; cross-Mayan
     typology theorems quantify over it. Tables with pre-consonantal vs
-    pre-vocalic variant shapes are `Phonology.SegmentClass → ExponentTable`
+    pre-vocalic variant shapes are `Phonology.Segment.Class → ExponentTable`
     functions, with `.consonant` the citation point. -/
 abbrev ExponentTable := Agreement.Paradigm Morphology.Exponent
 

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Syntax.Case.Alignment
@@ -357,7 +358,7 @@ def VerbForm.agreementSlots (f : VerbForm) : Nat :=
     separate plural word, e.g. Q'anjob'al *s-…heb'*) is a two-morph exponent.
     Per-language `setAExponent`/`setBExponent` populate this; cross-Mayan
     typology theorems quantify over it. Tables with pre-consonantal vs
-    pre-vocalic variant shapes are `Morphology.Following → ExponentTable`
+    pre-vocalic variant shapes are `Phonology.SegmentClass → ExponentTable`
     functions, with `.consonant` the citation point. -/
 abbrev ExponentTable := Agreement.Paradigm Morphology.Exponent
 

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -88,7 +88,7 @@ def absPosition : Mayan.ABSPosition := .high
     environment ([coon-mateo-pedro-preminger-2014] table (13)). The 3pl
     cells are discontinuous exponents: person prefix plus the free
     plural word *heb'*. -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "hin"]), (.pn .second .Sing, [.pref "ha"]),
      (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "ko"]),

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Fragments.Mayan.Params
 
 /-!
@@ -87,7 +88,7 @@ def absPosition : Mayan.ABSPosition := .high
     environment ([coon-mateo-pedro-preminger-2014] table (13)). The 3pl
     cells are discontinuous exponents: person prefix plus the free
     plural word *heb'*. -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "hin"]), (.pn .second .Sing, [.pref "ha"]),
      (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "ko"]),

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Fragments.Mayan.Tseltalan
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 
@@ -88,7 +89,7 @@ def setBLinearity : MarkerLinearity := .suffixal
     `j-`/`a-`/`s-` pre-consonantally, `k-`/`aw-`/`y-` pre-vocalically
     (person is not distinguished by number in Set A; plural is marked
     by separate suffixes not part of the person marker). -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "j"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "j"]),

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -89,7 +89,7 @@ def setBLinearity : MarkerLinearity := .suffixal
     `j-`/`a-`/`s-` pre-consonantally, `k-`/`aw-`/`y-` pre-vocalically
     (person is not distinguished by number in Set A; plural is marked
     by separate suffixes not part of the person marker). -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "j"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "j"]),

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -88,7 +88,7 @@ def setBLinearity : MarkerLinearity := .either
     possessed noun (GEN) — `j-`/`a-`/`s-` pre-consonantally,
     `k-`/`av-`/`y-` pre-vocalically (same orientation as Tseltal; an
     earlier revision reversed the 1st-person pair). -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "j"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "j"]),

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Fragments.Mayan.Tseltalan
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 
@@ -87,7 +88,7 @@ def setBLinearity : MarkerLinearity := .either
     possessed noun (GEN) — `j-`/`a-`/`s-` pre-consonantally,
     `k-`/`av-`/`y-` pre-vocalically (same orientation as Tseltal; an
     earlier revision reversed the 1st-person pair). -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "j"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "s"]), (.pn .first .Plur, [.pref "j"]),

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 
@@ -52,7 +53,7 @@ def absPosition : Mayan.ABSPosition := .low
     Table 24.8, where the pre-vocalic glide is parenthesized:
     *in(w)-*, *a(w)-*, *u(y)-*). 2pl/3pl are discontinuous: person
     prefix plus the plural suffixes *-e'ex*/*-o'ob'*. -/
-def setAExponent : Morphology.Following → ExponentTable
+def setAExponent : Phonology.SegmentClass → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "in"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "u"]), (.pn .first .Plur, [.pref "k"]),

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -53,7 +53,7 @@ def absPosition : Mayan.ABSPosition := .low
     Table 24.8, where the pre-vocalic glide is parenthesized:
     *in(w)-*, *a(w)-*, *u(y)-*). 2pl/3pl are discontinuous: person
     prefix plus the plural suffixes *-e'ex*/*-o'ob'*. -/
-def setAExponent : Phonology.SegmentClass → ExponentTable
+def setAExponent : Phonology.Segment.Class → ExponentTable
   | .consonant =>
     [(.pn .first .Sing, [.pref "in"]), (.pn .second .Sing, [.pref "a"]),
      (.pn .third .Sing, [.pref "u"]), (.pn .first .Plur, [.pref "k"]),

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -73,17 +73,12 @@ structure Morph where
   form : String
   deriving DecidableEq, Repr
 
-/-- An **exponent**: the possibly empty sequence of morphs realizing a
-paradigm cell. `[]` is zero exponence; a discontinuous realization
-(Q'anjob'al *s-…heb'*) is a two-morph exponent. -/
-abbrev Exponent := List Morph
+namespace Morph
 
 /-- The boundary sign of an attachment: `-` for affixes, `=` for clitics. -/
-def Morph.Attachment.sign : Morph.Attachment → String
+def Attachment.sign : Attachment → String
   | .affix => "-"
   | .clitic => "="
-
-namespace Morph
 
 /-- A prefix morph. -/
 def pref (s : String) : Morph := ⟨.bound .before .affix, s⟩
@@ -117,6 +112,11 @@ def toString (m : Morph) : String :=
   | .root | .free => m.form
 
 end Morph
+
+/-- An **exponent**: the possibly empty sequence of morphs realizing a
+paradigm cell. `[]` is zero exponence; a discontinuous realization
+(Q'anjob'al *s-…heb'*) is a two-morph exponent. -/
+abbrev Exponent := List Morph
 
 /-- Display an exponent in descriptive notation: `∅` for zero exponence,
 `…` linking the parts of a discontinuous realization. -/

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -16,7 +16,7 @@ empty exponent, and a discontinuous realization is a multi-morph exponent.
 * `Morph`, `Morph.Kind` — a segmental form with its attachment kind,
   factored as side × attachment for bound morphs
 * `Exponent` — a sequence of morphs; `[]` is zero exponence
-* `Morph.toString`, `Exponent.toString` — descriptive-notation display
+* the `ToString Morph` instance, `Exponent.toString` — descriptive-notation display
   (`X-`, `-X`, `X=`, `=X`; `∅` for zero exponence)
 * `Following` — following-segment environment for variant selection
 
@@ -33,8 +33,8 @@ is out of scope here: `Word.Structure` covers reduplication and conversion,
 the autosegmental machinery covers tone.
 
 Boundary notation (`X-`, `-X`, `X=`, `=X`) is display, not data: `Morph.form`
-is bare segmental material, and `Morph.toString` reproduces the descriptive
-convention from `Morph.Kind`.
+is bare segmental material, and the `ToString` instance reproduces the
+descriptive convention from `Morph.Kind`.
 -/
 
 namespace Morphology
@@ -98,31 +98,25 @@ def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
 
-/-- The boundary sign of an attachment: `-` for affixes, `=` for clitics. -/
-def Attachment.sign : Attachment → String
-  | .affix => "-"
-  | .clitic => "="
-
-/-- Display in descriptive notation: the attachment's sign on the side of
-the host — `X-`, `-X`, `X=`, `=X` — and bare for roots and free forms. -/
-def toString (m : Morph) : String :=
-  match m.kind with
-  | .bound .before a => m.form ++ a.sign
-  | .bound .after a => a.sign ++ m.form
-  | .root | .free => m.form
-
-instance : ToString Morph := ⟨toString⟩
+/-- Descriptive boundary notation: `X-`, `-X`, `X=`, `=X`; bare for roots
+and free forms. -/
+instance : ToString Morph :=
+  ⟨fun m => match m.kind with
+    | .bound .before .affix => m.form ++ "-"
+    | .bound .after .affix => "-" ++ m.form
+    | .bound .before .clitic => m.form ++ "="
+    | .bound .after .clitic => "=" ++ m.form
+    | .root | .free => m.form⟩
 
 end Morph
 
 /-- An **exponent** is the sequence of morphs realizing a paradigm cell. -/
 abbrev Exponent := List Morph
 
-/-- Display an exponent in descriptive notation: `∅` for zero exponence,
-`…` linking the parts of a discontinuous realization. -/
+/-- Descriptive notation for an exponent: `∅` if empty, parts linked by `…`. -/
 def Exponent.toString : Exponent → String
   | [] => "∅"
-  | ms => String.intercalate "…" (ms.map Morph.toString)
+  | ms => String.intercalate "…" (ms.map toString)
 
 /-- The class of the following segment: the commonest phonological
 environment conditioning the choice among a morph's variant shapes

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -16,7 +16,6 @@ empty exponent, and a discontinuous realization is a multi-morph exponent.
 * `Morph` — a segmental form with its attachment kind, factored as
   side × attachment for bound morphs
 * `Exponent` — a sequence of morphs; `[]` is zero exponence
-* `Following` — following-segment environment for variant selection
 
 ## Implementation notes
 
@@ -92,8 +91,6 @@ def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
 
-/-- Descriptive boundary notation: `X-`, `-X`, `X=`, `=X`; bare for roots
-and free forms. -/
 instance : ToString Morph :=
   ⟨fun m => match m.kind with
     | .bound .before .affix => m.form ++ "-"
@@ -107,19 +104,9 @@ end Morph
 /-- An **exponent** is the sequence of morphs realizing a paradigm cell. -/
 abbrev Exponent := List Morph
 
-/-- Descriptive notation for an exponent: `∅` if empty, parts linked by `…`. -/
-def Exponent.toString : Exponent → String
-  | [] => "∅"
-  | ms => String.intercalate "…" (ms.map ToString.toString)
-
-/-- The class of the following segment: the commonest phonological
-environment conditioning the choice among a morph's variant shapes
-(pre-consonantal vs pre-vocalic). -/
-inductive Following where
-  /-- The next segment is a consonant. -/
-  | consonant
-  /-- The next segment is a vowel. -/
-  | vowel
-  deriving DecidableEq, Repr, Fintype
+instance : ToString Exponent :=
+  ⟨fun
+    | [] => "∅"
+    | ms => String.intercalate "…" (ms.map toString)⟩
 
 end Morphology

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -13,8 +13,8 @@ empty exponent, and a discontinuous realization is a multi-morph exponent.
 
 ## Main declarations
 
-* `Morph`, `Morph.Kind` — a segmental form with its attachment kind,
-  factored as side × attachment for bound morphs
+* `Morph` — a segmental form with its attachment kind, factored as
+  side × attachment for bound morphs
 * `Exponent` — a sequence of morphs; `[]` is zero exponence
 * the `ToString Morph` instance, `Exponent.toString` — descriptive-notation display
   (`X-`, `-X`, `X=`, `=X`; `∅` for zero exponence)
@@ -31,10 +31,6 @@ cell whose sole marker is a process (North Saami gradation-only genitives,
 (apophony, reduplication, tone, subtraction) is a process, not a form, and
 is out of scope here: `Word.Structure` covers reduplication and conversion,
 the autosegmental machinery covers tone.
-
-Boundary notation (`X-`, `-X`, `X=`, `=X`) is display, not data: `Morph.form`
-is bare segmental material, and the `ToString` instance reproduces the
-descriptive convention from `Morph.Kind`.
 -/
 
 namespace Morphology
@@ -116,7 +112,7 @@ abbrev Exponent := List Morph
 /-- Descriptive notation for an exponent: `∅` if empty, parts linked by `…`. -/
 def Exponent.toString : Exponent → String
   | [] => "∅"
-  | ms => String.intercalate "…" (ms.map toString)
+  | ms => String.intercalate "…" (ms.map ToString.toString)
 
 /-- The class of the following segment: the commonest phonological
 environment conditioning the choice among a morph's variant shapes

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -113,9 +113,7 @@ def toString (m : Morph) : String :=
 
 end Morph
 
-/-- An **exponent**: the possibly empty sequence of morphs realizing a
-paradigm cell. `[]` is zero exponence; a discontinuous realization
-(Q'anjob'al *s-…heb'*) is a two-morph exponent. -/
+/-- An **exponent** is the sequence of morphs realizing a paradigm cell. -/
 abbrev Exponent := List Morph
 
 /-- Display an exponent in descriptive notation: `∅` for zero exponence,

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -16,8 +16,6 @@ empty exponent, and a discontinuous realization is a multi-morph exponent.
 * `Morph` — a segmental form with its attachment kind, factored as
   side × attachment for bound morphs
 * `Exponent` — a sequence of morphs; `[]` is zero exponence
-* the `ToString Morph` instance, `Exponent.toString` — descriptive-notation display
-  (`X-`, `-X`, `X=`, `=X`; `∅` for zero exponence)
 * `Following` — following-segment environment for variant selection
 
 ## Implementation notes

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -75,11 +75,6 @@ structure Morph where
 
 namespace Morph
 
-/-- The boundary sign of an attachment: `-` for affixes, `=` for clitics. -/
-def Attachment.sign : Attachment → String
-  | .affix => "-"
-  | .clitic => "="
-
 /-- A prefix morph. -/
 def pref (s : String) : Morph := ⟨.bound .before .affix, s⟩
 
@@ -103,6 +98,11 @@ def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
 
+/-- The boundary sign of an attachment: `-` for affixes, `=` for clitics. -/
+def Attachment.sign : Attachment → String
+  | .affix => "-"
+  | .clitic => "="
+
 /-- Display in descriptive notation: the attachment's sign on the side of
 the host — `X-`, `-X`, `X=`, `=X` — and bare for roots and free forms. -/
 def toString (m : Morph) : String :=
@@ -110,6 +110,8 @@ def toString (m : Morph) : String :=
   | .bound .before a => m.form ++ a.sign
   | .bound .after a => a.sign ++ m.form
   | .root | .free => m.form
+
+instance : ToString Morph := ⟨toString⟩
 
 end Morph
 

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -7,27 +7,17 @@ import Mathlib.Data.Fintype.Sum
 
 A **morph** is a minimal segmental form together with its attachment kind:
 root, prefix, suffix, proclitic, enclitic, or free form ([haspelmath-2020]).
-An **exponent** is a possibly empty sequence of morphs realizing a paradigm
-cell. Morphs are never zero and never discontinuous: zero exponence is the
-empty exponent, and a discontinuous realization is a multi-morph exponent.
-
-## Main declarations
-
-* `Morph` — a segmental form with its attachment kind, factored as
-  side × attachment for bound morphs
-* `Exponent` — a sequence of morphs; `[]` is zero exponence
+Morphs are never zero and never discontinuous.
 
 ## Implementation notes
 
 [haspelmath-2020] defines a morph as a minimal pairing of content with a
 continuous string of segments; the carrier stores only the form side, so
 empty and superfluous morphs (Cree connective *-t-*, [anderson-2015] p. 19)
-remain representable. `[]` means *no segmental exponent*, not *unmarked*: a
-cell whose sole marker is a process (North Saami gradation-only genitives,
-[anderson-2015] p. 22) also renders as `[]`. Nonconcatenative exponence
-(apophony, reduplication, tone, subtraction) is a process, not a form, and
-is out of scope here: `Word.Structure` covers reduplication and conversion,
-the autosegmental machinery covers tone.
+remain representable. Nonconcatenative exponence (apophony, reduplication,
+tone, subtraction) is a process, not a form, and is out of scope here:
+`Word.Structure` covers reduplication and conversion, the autosegmental
+machinery covers tone.
 -/
 
 namespace Morphology
@@ -101,10 +91,7 @@ instance : ToString Morph :=
 
 end Morph
 
-/-- An **exponent** is the sequence of morphs realizing a paradigm cell. -/
-abbrev Exponent := List Morph
-
-instance : ToString Exponent :=
+instance : ToString (List Morph) :=
   ⟨fun
     | [] => "∅"
     | ms => String.intercalate "…" (ms.map toString)⟩

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -108,18 +108,6 @@ def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
 
-/-- A morph is an **affix** if it is bound as an affix. -/
-def IsAffix (m : Morph) : Prop := m.attachment? = some .affix
-
-instance (m : Morph) : Decidable m.IsAffix :=
-  inferInstanceAs (Decidable (_ = _))
-
-/-- A morph is a **clitic** if it is bound as a clitic. -/
-def IsClitic (m : Morph) : Prop := m.attachment? = some .clitic
-
-instance (m : Morph) : Decidable m.IsClitic :=
-  inferInstanceAs (Decidable (_ = _))
-
 /-- Display in descriptive notation: the attachment's sign on the side of
 the host — `X-`, `-X`, `X=`, `=X` — and bare for roots and free forms. -/
 def toString (m : Morph) : String :=

--- a/Linglib/Morphology/Word/Structure.lean
+++ b/Linglib/Morphology/Word/Structure.lean
@@ -302,12 +302,12 @@ theorem Word.Structure.stem_suffixed_deriv (b : Word.Structure) (afx : Morpheme)
 -- ============================================================================
 
 /-- Project concatenative word structure to its `Morph` sequence
-(`Exponent`). **Partial**: `none` on infixation, circumfixation, and
+(a `Morph` list). **Partial**: `none` on infixation, circumfixation, and
 reduplication — [haspelmath-2020]'s thesis that morphs are continuous
 and segmental, so discontinuous and process morphology are
 constructions, not morph sequences. Conversion is morph-vacuous and
 projects through. -/
-def Word.Structure.toExponent : Word.Structure → Option Exponent
+def Word.Structure.toExponent : Word.Structure → Option (List Morph)
   | .root m => some [m.morph]
   | .prefixed afx b _ => (b.toExponent).map (afx.morph :: ·)
   | .suffixed b afx _ => (b.toExponent).map (· ++ [afx.morph])

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -218,6 +218,20 @@ def fillFromContext (f : Feature) (ctx : Segment) : Segment :=
 
 end Segment
 
+/-- The coarse two-way classification of a segment, the commonest conditioning
+environment for morph-variant selection (pre-consonantal vs pre-vocalic). -/
+inductive SegmentClass where
+  /-- A consonant. -/
+  | consonant
+  /-- A vowel. -/
+  | vowel
+  deriving DecidableEq, Repr, Fintype
+
+/-- A segment's coarse class: vowels are [+syllabic]; everything else classes
+as a consonant. -/
+def Segment.toSegmentClass (s : Segment) : SegmentClass :=
+  if s.IsVowel then .vowel else .consonant
+
 /-! ### Sonority -/
 
 /-- The abstract sonority hierarchy ([clements-1990]): what the synchronic grammar

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -220,7 +220,7 @@ end Segment
 
 /-- The coarse two-way classification of a segment, the commonest conditioning
 environment for morph-variant selection (pre-consonantal vs pre-vocalic). -/
-inductive SegmentClass where
+inductive Segment.Class where
   /-- A consonant. -/
   | consonant
   /-- A vowel. -/
@@ -229,7 +229,7 @@ inductive SegmentClass where
 
 /-- A segment's coarse class: vowels are [+syllabic]; everything else classes
 as a consonant. -/
-def Segment.toSegmentClass (s : Segment) : SegmentClass :=
+def Segment.toClass (s : Segment) : Segment.Class :=
   if s.IsVowel then .vowel else .consonant
 
 /-! ### Sonority -/

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -164,7 +164,7 @@ private def cellBundle (c : Agreement.Cell) : FeatureBundle :=
 def setAVocab : Vocabulary :=
   makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
     (fun c => (((setAExponent .consonant).realize c).map
-      Morphology.Exponent.toString).getD "") (some .v)
+      toString).getD "") (some .v)
 
 /-- Set B as DM Vocabulary entries, contextualized to Infl/T: specific
     entries for the five overt cells, plus the Elsewhere ∅ entry
@@ -174,7 +174,7 @@ def setBVocab : Vocabulary :=
   makePersonVocab (Agreement.Cell.pnCells.filter (· != .pn .third .Sing))
     Agreement.Cell.toPhiFeatures
     (fun c => ((setBExponent.realize c).map
-      Morphology.Exponent.toString).getD "") (some .T) ++
+      toString).getD "") (some .T) ++
   [{ features := ⊥, exponent := "∅", context := some .T }]
 
 /-- Vocabulary insertion recovers the fragment's paradigms: spelling
@@ -184,9 +184,9 @@ def setBVocab : Vocabulary :=
 theorem spellout_matches_paradigm :
     ∀ c ∈ Agreement.Cell.pnCells,
       spellout setAVocab (cellBundle c) (some .v) =
-        ((setAExponent .consonant).realize c).map Morphology.Exponent.toString ∧
+        ((setAExponent .consonant).realize c).map toString ∧
       spellout setBVocab (cellBundle c) (some .T) =
-        (setBExponent.realize c).map Morphology.Exponent.toString := by
+        (setBExponent.realize c).map toString := by
   decide
 
 /-! ### Two-probe relativized probing ([bejar-rezac-2003], applied per §4.4) -/
@@ -277,7 +277,7 @@ def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
 def afMarker (subj obj : Agreement.Cell) : Option String :=
   if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgPosition × Agreement.Cell)) then
     ((afAgreementTarget subj obj).bind
-      (fun t => (setBExponent.realize t).map Morphology.Exponent.toString)) <|>
+      (fun t => (setBExponent.realize t).map toString)) <|>
       spellout setBVocab ⊥ (some .T)
   else none
 

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -183,7 +183,7 @@ open Agreement
 def setAVocab : Vocabulary :=
   makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
     (fun c => (((setAExponent .consonant).realize c).map
-      Morphology.Exponent.toString).getD "") (some .v)
+      toString).getD "") (some .v)
 
 /-- Set B (ABS) vocabulary entries: φ-features on Infl (.T)
     yield the morphological exponent ([scott-2023] Table 3.5).
@@ -194,8 +194,8 @@ def setAVocab : Vocabulary :=
 def setBVocab : Vocabulary :=
   makePersonVocab setBSpecificCells Agreement.Cell.toPhiFeatures
     (fun c => ((setBExponent.realize c).map
-      Morphology.Exponent.toString).getD "") (some .T) ++
-    [{ features := ⊥, exponent := Morphology.Exponent.toString defaultSetB, context := some .T }]
+      toString).getD "") (some .T) ++
+    [{ features := ⊥, exponent := toString defaultSetB, context := some .T }]
 
 /-- Which Minimalist head φ-Agrees with each argument position.
     Ditransitive R/T default to none (not modeled). -/


### PR DESCRIPTION
Follow-ups to the #1540/#1541 register cleanse, user-reviewed: drop zero-consumer IsAffix/IsClitic (attachment? stays); object-ordered layout; display machinery inlined into ToString instances (named defs and helpers cut); the C/V conditioning enum moves to Phonology/Segmental/Defs.lean as SegmentClass beside IsVowel/IsConsonant, with a Segment.toSegmentClass bridge — Morph.lean no longer hosts a phonological concept. 12 consumers swept.