### PR TITLE
feat(Morphology/Paradigm): four-axis linkage canonicity; Studies/Stump2012

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2647,6 +2647,7 @@ import Linglib.Studies.Stojkovic2026
 import Linglib.Studies.Storme2026
 import Linglib.Studies.Storment2026
 import Linglib.Studies.Sudo2016
+import Linglib.Studies.Stump2012
 import Linglib.Studies.Stump2016
 import Linglib.Studies.Stump2020
 import Linglib.Studies.SumersEtAl2023

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -395,12 +395,15 @@ PFM2 realization of a paradigm linkage's block cascade ([stump-2016]'s
 form-realization hole filled true by construction. -/
 theorem Linkage.realize_eq_paradigmFunction (ℓ : Linkage L Z P) (Lindex : Z → L)
     (stemChoice : L × P → Z) (blocks : List (Block L Z P)) (l : L) (σ : P)
-    (h : ℓ.IsPropertyPreserving) (hstem : ∀ l σ, ℓ.stem l σ = stemChoice (l, σ)) :
+    (h : ℓ.IsPropertyPreserving)
+    (hstem : ∀ l σ, ℓ.stem l σ = some (stemChoice (l, σ))) :
     ℓ.realize (fun z τ => (blocksEval Lindex blocks (z, τ)).1) l σ
-      = paradigmFunction Lindex stemChoice blocks (l, σ) := by
-  have hpm : ℓ.pm σ = σ := h σ
-  simp only [Linkage.realize, Linkage.corr, hpm, hstem, paradigmFunction]
-  exact Prod.ext rfl (blocksEval_snd Lindex blocks (stemChoice (l, σ), σ)).symm
+      = some (paradigmFunction Lindex stemChoice blocks (l, σ)) := by
+  have hpm : ℓ.pm l σ = σ := h l σ
+  simp only [Linkage.realize, Linkage.corr, hpm, hstem, Option.map_some,
+    paradigmFunction]
+  exact congrArg some
+    (Prod.ext rfl (blocksEval_snd Lindex blocks (stemChoice (l, σ), σ)).symm)
 
 end Selection
 

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -1,116 +1,203 @@
-import Mathlib.Logic.Function.Basic
+import Mathlib.Data.Set.Function
 
 /-!
 # Paradigm linkage: content paradigms, form paradigms, and correspondence
-[stump-2016] [stump-2006]
+[stump-2012-mmm8]
 
-The paradigm-linkage hypothesis ([stump-2016] Ch. 7; the content/form
-paradigm split originates with [stump-2006], introduced in part to
-describe heteroclisis) splits a lexeme's realizations into three
-corresponding paradigms:
+Inflectional morphology relates three levels of representation ([stump-2012-mmm8];
+the book-length apparatus is [stump-2016]): a lexeme's **content paradigm** of
+cells `⟨L, σ⟩` pairing a lexeme with a syntacticosemantic property set, a stem's
+**form paradigm** of cells `⟨Z, τ⟩` pairing a stem with a property set it inflects
+for, and the **realized paradigm** of word forms. A content cell is realized by
+being linked to a **form correspondent**, whose realization it shares. The
+correspondence factors into a stem selection `stem : L → P → Option Z` and a
+lexeme-sensitive property mapping `pm : L → P → P`. Both partiality and lexeme
+sensitivity are load-bearing: a gap in the stem specification is the seat of
+defectiveness, and functor-argument reversal computes a form correspondent's
+property set from the lexeme.
 
-* the **content paradigm** — cells `⟨L, σ⟩` pairing a lexeme `L` with a
-  morphosyntactic property set `σ`; the interface with syntax and semantics;
-* the **form paradigm** — cells `⟨Z, τ⟩` pairing a stem `Z` from `L`'s stem
-  set with a property set `τ` for which `Z` inflects; the basis for inflection;
-* the **realized paradigm** — cells `⟨w, τ⟩` pairing a word form `w` with the
-  property set it realizes.
-
-Each content cell is realized by being linked to a **form correspondent** — a
-form cell whose realization it shares. The correspondence function `Corr`
-decomposes (§7.2) as a **stem selection** and a **property mapping** `pm`:
-`Corr(⟨L, σ⟩) = ⟨Stem(⟨L, σ⟩), pm(σ)⟩`, and the paradigm function factors as
-`PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`. Canonically `pm` is the identity and each
-lexeme has a single stem, so content and form paradigms are isomorphic; the
-book's later chapters catalogue the deviation modes — morphomic properties
-(Ch. 8), defectiveness/overabundance (Ch. 9), syncretism as many-to-one `Corr`
-(Ch. 10), suppletion/heteroclisis (Ch. 11), deponency as a voice-flipping `pm`
-(Ch. 12, formalized in `Studies/Stump2016.lean`), and polyfunctionality
-(Ch. 13).
+Canonical paradigm linkage is the typological extreme against which deviations
+are calibrated, characterized by four independent axes. `IsTotal`: every content
+cell has a form correspondent. `IsStemInvariant`: one stem realizes all of a
+lexeme's cells. `IsInjective`: no two content cells share a form correspondent.
+`IsPropertyPreserving`: a form correspondent carries the content cell's own
+property set. Each named noncanonical phenomenon is the failure of exactly one
+axis — defectiveness negates totality, suppletion stem invariance, syncretism
+injectivity, and deponency and functor-argument reversal property preservation.
 
 ## Main declarations
 
-* `Linkage L Z P` — a lexeme-level linkage: stem selection `Stem` plus
-  property mapping `pm`
-* `Linkage.corr` — the form-correspondence function `Corr = ⟨Stem, pm⟩`
-* `Linkage.realize` — the realized paradigm `PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`
-* `Linkage.IsCanonical` — cell-level canonical linkage: property-set
-  preservation (`pm = id`, §7.1 (2a)) and stem invariance (§7.1 (2b))
-* `Linkage.canonical` / `canonical_isCanonical` — the canonical one-stem linkage
-* `Linkage.realize_eq_of_corr_eq` — a many-to-one `Corr` forces content-side
-  syncretism (the Ch. 10 deviation mode)
+* `Linkage L Z P` — a lexeme-level linkage: partial stem selection and
+  lexeme-sensitive property mapping
+* `Linkage.corr`, `Linkage.realize` — the form-correspondence function and the
+  realized paradigm, both partial
+* `Linkage.IsTotal`, `IsStemInvariant`, `IsInjective`, `IsPropertyPreserving` —
+  the four axes of canonical linkage; `IsCanonical` conjoins them
+* `Linkage.IsDefective`, `IsSuppletive`, `IsSyncretic`, `IsUnfaithful` — the four
+  deviation predicates, each negating one axis (`IsCanonical.not_isDefective`,
+  …), with `isSyncretic_iff_not_isInjective`
+* `Linkage.IsVirtual` — a form cell no content cell corresponds to
+* `Linkage.canonical` / `canonical_isCanonical` — the total, lexeme-blind,
+  one-stem linkage, canonical on all four axes
+* `Linkage.realize_eq_of_corr_eq` — a shared form correspondent forces a shared
+  realization
 -/
 
 namespace Morphology
 
-/-- A **paradigm linkage** ([stump-2016] §7.2), presented from the vantage of a
-single lexeme: the two components of the form-correspondence function `Corr`.
-`stem` is the stem selection `Stem(⟨L, σ⟩)` picking the stem that realizes a
-content cell; `pm` is the property mapping `σ ↦ τ`. Canonically `pm` is the
-identity and `stem` is constant in the property set (one stem per lexeme). -/
+/-- A **paradigm linkage** ([stump-2012-mmm8]) from the vantage of a single
+lexeme: the two components of the form-correspondence function. `stem` selects
+the stem realizing a content cell, or `none` where the stem specification has a
+gap; `pm` carries a content cell's property set to its form correspondent's, and
+may consult the lexeme. Canonically `stem` is total and constant in the property
+set and `pm` is the identity. -/
 structure Linkage (L Z P : Type*) where
-  /-- Stem selection `Stem(⟨L, σ⟩)`: the stem realizing the content cell. -/
-  stem : L → P → Z
-  /-- The property mapping `pm : σ ↦ τ` carrying a content cell's property set
-  to its form correspondent's. -/
-  pm : P → P
+  /-- The stem realizing a content cell `⟨l, σ⟩`, or `none` where the stem
+  specification has a gap. -/
+  stem : L → P → Option Z
+  /-- The property mapping carrying a content cell's property set to its form
+  correspondent's, consulting the lexeme for functor-argument reversal. -/
+  pm : L → P → P
 
 namespace Linkage
 
 variable {L Z P W : Type*} (ℓ : Linkage L Z P)
 
-/-- The **form-correspondence function** `Corr(⟨L, σ⟩) = ⟨Stem(⟨L, σ⟩), pm(σ)⟩`
-([stump-2016] §7.2): the form cell realizing content cell `⟨l, σ⟩`. -/
-def corr (l : L) (σ : P) : Z × P := (ℓ.stem l σ, ℓ.pm σ)
+/-- The **form correspondent** of a content cell `⟨l, σ⟩`: the stem paired with
+its mapped property set, or `none` where the stem specification has a gap. -/
+def corr (l : L) (σ : P) : Option (Z × P) := (ℓ.stem l σ).map (·, ℓ.pm l σ)
 
-/-- The **realized paradigm** on content cells: `PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`.
-Given the form-cell realization `realizeForm` (the rules of exponence, `PF` on
-form cells), the content cell `⟨l, σ⟩` realizes as `⟨w, τ⟩` where `⟨Z, τ⟩` is
-its form correspondent and `w` is `Z`'s realization at `τ`. -/
-def realize (realizeForm : Z → P → W) (l : L) (σ : P) : W × P :=
-  (realizeForm (ℓ.corr l σ).1 (ℓ.corr l σ).2, (ℓ.corr l σ).2)
+/-- The **realized paradigm** on content cells: a content cell realizes as its
+form correspondent does. `realizeForm` supplies the form-cell realization; the
+result is `none` exactly where the form correspondent is. -/
+def realize (realizeForm : Z → P → W) (l : L) (σ : P) : Option (W × P) :=
+  (ℓ.corr l σ).map fun zτ => (realizeForm zτ.1 zτ.2, zτ.2)
 
-/-- **Property-set preservation** ([stump-2016] §7.1, canonical characteristic
-(2a)): the property mapping is the identity, so a content cell and its form
-correspondent share a property set. -/
-def IsPropertyPreserving : Prop := ∀ σ, ℓ.pm σ = σ
+/-- **Totality**: every content cell has a form correspondent. Defectiveness is
+the failure. -/
+def IsTotal : Prop := ∀ l σ, (ℓ.stem l σ).isSome
 
-/-- **Stem invariance** ([stump-2016] §7.1, canonical characteristic (2b)): each
-lexeme has a single stem realizing all of its cells. -/
-def IsStemInvariant : Prop := ∀ l, ∃ z, ∀ σ, ℓ.stem l σ = z
+/-- **Stem invariance**: a lexeme's cells that have a stem all share one, so its
+correspondents come from a single form paradigm. Stem suppletion is the failure.
+Independent of totality — undefined cells impose no constraint. -/
+def IsStemInvariant : Prop :=
+  ∀ l ⦃σ₁ σ₂⦄ ⦃z₁ z₂⦄, ℓ.stem l σ₁ = some z₁ → ℓ.stem l σ₂ = some z₂ → z₁ = z₂
 
-/-- **Canonical paradigm linkage** at the cell level ([stump-2016] §7.1):
-property-set preservation together with stem invariance. The remaining
-canonical characteristics — unambiguity and isomorphism within/across syntactic
-categories (2c–e) — quantify over sets of paradigms, not a single linkage. -/
-def IsCanonical : Prop := ℓ.IsPropertyPreserving ∧ ℓ.IsStemInvariant
+/-- **Injectivity**: no two content cells of a lexeme share a form correspondent,
+over the cells that have one. Syncretism is the failure. -/
+def IsInjective : Prop := ∀ l, Set.InjOn (ℓ.corr l) {σ | (ℓ.corr l σ).isSome}
 
-/-- Under property-set preservation, each content cell's form correspondent
-carries the content cell's own property set — the canonical, mismatch-free
-alignment of content and form. -/
-theorem corr_snd_eq_of_propertyPreserving (h : ℓ.IsPropertyPreserving)
-    (l : L) (σ : P) : (ℓ.corr l σ).2 = σ := h σ
+/-- **Property preservation**: a form correspondent carries the content cell's
+own property set. Deponency, functor-argument reversal, and directional
+syncretism are failures. -/
+def IsPropertyPreserving : Prop := ∀ l σ, ℓ.pm l σ = σ
 
-/-- **A many-to-one `Corr` forces content-side syncretism**: content cells with
-a common form correspondent share their realization ([stump-2016] Ch. 10's
-syncretism deviation mode). -/
+/-- **Canonical paradigm linkage** ([stump-2012-mmm8]): all four axes. -/
+def IsCanonical : Prop :=
+  ℓ.IsTotal ∧ ℓ.IsStemInvariant ∧ ℓ.IsInjective ∧ ℓ.IsPropertyPreserving
+
+/-! ### Deviations from canonical linkage
+
+Each noncanonical phenomenon negates exactly one axis. -/
+
+/-- **Defectiveness**: some content cell lacks a form correspondent
+([stump-2012-mmm8] §3.1). Negates totality. -/
+def IsDefective : Prop := ∃ l σ, ℓ.stem l σ = none
+
+/-- **Suppletion**: a lexeme's correspondents draw on more than one stem
+([stump-2012-mmm8] §3.4). Negates stem invariance. -/
+def IsSuppletive : Prop := ¬ ℓ.IsStemInvariant
+
+/-- **Syncretism**: two distinct content cells share a form correspondent
+([stump-2012-mmm8] §3.2). Negates injectivity; the `isSome` requirement excludes
+cells vacuously agreeing at `none`. -/
+def IsSyncretic : Prop :=
+  ∃ l σ₁ σ₂, σ₁ ≠ σ₂ ∧ ℓ.corr l σ₁ = ℓ.corr l σ₂ ∧ (ℓ.corr l σ₁).isSome
+
+/-- **Unfaithfulness**: some content cell's form correspondent carries a
+different property set — deponency and functor-argument reversal
+([stump-2012-mmm8] §3.3). Negates property preservation. -/
+def IsUnfaithful : Prop := ∃ l σ, ℓ.pm l σ ≠ σ
+
+theorem IsCanonical.not_isDefective (h : ℓ.IsCanonical) : ¬ ℓ.IsDefective := by
+  rintro ⟨l, σ, hnone⟩; simpa [hnone] using h.1 l σ
+
+theorem IsCanonical.not_isSuppletive (h : ℓ.IsCanonical) : ¬ ℓ.IsSuppletive :=
+  not_not.mpr h.2.1
+
+theorem IsCanonical.not_isSyncretic (h : ℓ.IsCanonical) : ¬ ℓ.IsSyncretic := by
+  rintro ⟨l, σ₁, σ₂, hne, heq, hsome⟩
+  have hsome₂ : (ℓ.corr l σ₂).isSome = true := by rw [← heq]; exact hsome
+  exact hne (h.2.2.1 l hsome hsome₂ heq)
+
+theorem IsCanonical.not_isUnfaithful (h : ℓ.IsCanonical) : ¬ ℓ.IsUnfaithful := by
+  rintro ⟨l, σ, hne⟩; exact hne (h.2.2.2 l σ)
+
+/-- Syncretism is exactly the failure of injectivity — the one deviation whose
+predicate is not a definitional negation of its axis. -/
+theorem isSyncretic_iff_not_isInjective : ℓ.IsSyncretic ↔ ¬ ℓ.IsInjective := by
+  constructor
+  · rintro ⟨l, σ₁, σ₂, hne, heq, hsome⟩ hinj
+    have hsome₂ : (ℓ.corr l σ₂).isSome = true := by rw [← heq]; exact hsome
+    exact hne (hinj l hsome hsome₂ heq)
+  · intro h
+    simp only [IsInjective, not_forall] at h
+    obtain ⟨l, hl⟩ := h
+    unfold Set.InjOn at hl
+    push Not at hl
+    obtain ⟨σ₁, hσ₁, σ₂, hσ₂, heq, hne⟩ := hl
+    exact ⟨l, σ₁, σ₂, hne, heq, hσ₁⟩
+
+/-- A **virtual cell**: a form cell no content cell corresponds to
+([stump-2012-mmm8] §4). Realization rules still define a value there, which
+language change can release by suppressing a linkage override. -/
+def IsVirtual (zτ : Z × P) : Prop := ∀ l σ, ℓ.corr l σ ≠ some zτ
+
+/-- A shared form correspondent forces a shared realization ([stump-2012-mmm8]
+§3.2): the mechanism of syncretism. -/
 theorem realize_eq_of_corr_eq (realizeForm : Z → P → W) {l : L} {σ₁ σ₂ : P}
     (h : ℓ.corr l σ₁ = ℓ.corr l σ₂) :
     ℓ.realize realizeForm l σ₁ = ℓ.realize realizeForm l σ₂ := by
   simp only [realize, h]
 
-/-- The **canonical one-stem linkage**: the identity property mapping together
-with a designated stem `st l` for each lexeme. -/
+/-! ### The canonical linkage -/
+
+/-- The **canonical one-stem linkage**: a total, lexeme-blind stem selection with
+the identity property mapping. Recovers the pre-deviation content-form
+isomorphism. -/
 def canonical (st : L → Z) : Linkage L Z P where
-  stem := fun l _ => st l
-  pm := id
+  stem := fun l _ => some (st l)
+  pm := fun _ σ => σ
 
-@[simp] theorem canonical_pm (st : L → Z) (σ : P) :
-    (canonical (P := P) st).pm σ = σ := rfl
+@[simp] theorem canonical_stem (st : L → Z) (l : L) (σ : P) :
+    (canonical (P := P) st).stem l σ = some (st l) := rfl
 
+@[simp] theorem canonical_pm (st : L → Z) (l : L) (σ : P) :
+    (canonical (P := P) st).pm l σ = σ := rfl
+
+@[simp] theorem canonical_corr (st : L → Z) (l : L) (σ : P) :
+    (canonical (P := P) st).corr l σ = some (st l, σ) := rfl
+
+@[simp] theorem canonical_realize (st : L → Z) (realizeForm : Z → P → W)
+    (l : L) (σ : P) :
+    (canonical (P := P) st).realize realizeForm l σ = some (realizeForm (st l) σ, σ) :=
+  rfl
+
+@[simp] theorem corr_eq_some {l : L} {σ : P} {zτ : Z × P} :
+    ℓ.corr l σ = some zτ ↔ ∃ z, ℓ.stem l σ = some z ∧ (z, ℓ.pm l σ) = zτ := by
+  simp [corr]
+
+@[simp] theorem corr_isSome (l : L) (σ : P) :
+    (ℓ.corr l σ).isSome = (ℓ.stem l σ).isSome := by
+  simp [corr]
+
+/-- The canonical linkage is canonical on all four axes. -/
 theorem canonical_isCanonical (st : L → Z) :
     (canonical (P := P) st).IsCanonical :=
-  ⟨fun _ => rfl, fun l => ⟨st l, fun _ => rfl⟩⟩
+  ⟨fun _ _ => rfl,
+   fun _ _ _ _ _ h₁ h₂ => (Option.some.inj h₁).symm.trans (Option.some.inj h₂),
+   fun _ _ _ _ _ heq => congrArg Prod.snd (Option.some.inj heq),
+   fun _ _ => rfl⟩
 
 end Linkage
 

--- a/Linglib/Studies/KalinBjorkmanEtAl2026.lean
+++ b/Linglib/Studies/KalinBjorkmanEtAl2026.lean
@@ -100,10 +100,10 @@ deponency or heteroclisis would require a non-identity `pm` or multiple stems
 theorem ParadigmFunction.apply_eq_linkage_realize {Feature : Type} [BEq Feature]
     (pf : ParadigmFunction Feature) (lex : Lexeme)
     (σ : MorphPropertySet Feature) :
-    pf.apply σ lex
-      = ((Morphology.Linkage.canonical (Z := Lexeme)
-            (P := MorphPropertySet Feature) id).realize
-          (fun l τ => pf.apply τ l) lex σ).1 :=
+    ((Morphology.Linkage.canonical (Z := Lexeme)
+          (P := MorphPropertySet Feature) id).realize
+        (fun l τ => pf.apply τ l) lex σ).map Prod.fst
+      = some (pf.apply σ lex) :=
   rfl
 
 /-- The linkage PFM instantiates is canonical ([stump-2016] §7.1): identity

--- a/Linglib/Studies/Stump2012.lean
+++ b/Linglib/Studies/Stump2012.lean
@@ -1,0 +1,478 @@
+import Linglib.Morphology.Paradigm.Linkage
+import Mathlib.Tactic.DeriveFintype
+import Mathlib.Data.Fintype.Sigma
+import Mathlib.Data.Fintype.Sum
+
+/-!
+# Stump 2012: canonical paradigm linkage and its deviations
+[stump-2012-mmm8]
+
+The four axes of canonical paradigm linkage of `Morphology/Paradigm/Linkage.lean`
+([stump-2012-mmm8]), each anchored by the paper's own witness: a near-canonical
+baseline and one deviation per axis, plus the two compound cases that show the
+axes are independent. Content and form paradigms, the correspondence relation,
+and the deviation typology are the paper's; the forms are transcribed from its
+numbered tables.
+
+* **Breton HERVEZ** (Table (2)) — the near-canonical baseline: total, stem-invariant,
+  injective, property-preserving.
+* **Latin COEPISSE** ((17)–(19)) — defectiveness: a present-system stem gap, yet a
+  single stem, so defective without being suppletive.
+* **Latin BELLUM** ((22)–(26)) — syncretism: neuter nominative patterning after the
+  accusative (directional) and a merged dative/ablative cell (nondirectional).
+* **Latin HORTĀRĪ** ((27)–(31), §4) — deponency: active content cells with passive
+  form correspondents, compounded with defectiveness on the passive cells, and a
+  virtual active form cell.
+* **Hungarian ÉN** ((33)–(38)) — functor-argument reversal: a form correspondent's
+  property set computed from the lexeme.
+* **Latin FERRE** ((41)–(43)) — suppletion under the default rule: two stems in
+  complementary distribution, yet property-preserving.
+* **Old Icelandic ÞURFA** ((44)–(46)) — a compound deviation: suppletion and
+  deponent tense mapping in one linkage.
+-/
+
+namespace Stump2012
+
+open Morphology
+
+/-- Person-number agreement, the six cells shared across the Latin verb paradigms. -/
+inductive Agr | s1 | s2 | s3 | p1 | p2 | p3
+  deriving DecidableEq, Fintype, Repr
+
+/-- The Latin tense-system split: present-system versus perfect-system cells. -/
+inductive System | pres | perf
+  deriving DecidableEq, Fintype, Repr
+
+/-! ### Breton HERVEZ: the near-canonical baseline (Table (2)) -/
+
+section Breton
+
+/-- The inflecting preposition HERVEZ 'according to'. -/
+inductive HervezLex | hervez
+  deriving DecidableEq, Fintype, Repr
+
+/-- Its sole stem `hervez[Cl.1]`. -/
+inductive HervezStem | hervez
+  deriving DecidableEq, Fintype, Repr
+
+/-- HERVEZ's linkage: one stem, identity property mapping — the canonical pattern.
+Its realizations `hervezon, hervezout, hervezi, hervezomp, hervezo` are based on
+the single stem with the content cell's own property set. -/
+def hervezLinkage : Linkage HervezLex HervezStem Agr :=
+  Linkage.canonical (fun _ => .hervez)
+
+/-- HERVEZ is canonical on all four axes ([stump-2012-mmm8] Table (2)). -/
+theorem hervez_isCanonical : hervezLinkage.IsCanonical :=
+  Linkage.canonical_isCanonical _
+
+theorem hervez_not_defective : ¬ hervezLinkage.IsDefective :=
+  hervez_isCanonical.not_isDefective
+theorem hervez_not_suppletive : ¬ hervezLinkage.IsSuppletive :=
+  hervez_isCanonical.not_isSuppletive
+theorem hervez_not_syncretic : ¬ hervezLinkage.IsSyncretic :=
+  hervez_isCanonical.not_isSyncretic
+theorem hervez_not_unfaithful : ¬ hervezLinkage.IsUnfaithful :=
+  hervez_isCanonical.not_isUnfaithful
+
+end Breton
+
+/-! ### Latin COEPISSE: defectiveness ((17)–(19))
+
+The present-system cells lack a stem, so they lack form correspondents and
+realizations; the perfect-system cells have the stem `coep`. Defectiveness sits
+in the stem specification, and COEPISSE keeps a single stem — defective without
+being suppletive. -/
+
+section Coepisse
+
+inductive CoepLex | coepisse
+  deriving DecidableEq, Fintype, Repr
+inductive CoepStem | coep
+  deriving DecidableEq, Fintype, Repr
+
+/-- A COEPISSE content cell: a tense system and an agreement feature. -/
+structure CoepCell where
+  sys : System
+  agr : Agr
+  deriving DecidableEq, Fintype, Repr
+
+/-- COEPISSE's linkage: `coep` on perfect-system cells, no stem on present-system
+cells ([stump-2012-mmm8] (18)). -/
+def coepisseLinkage : Linkage CoepLex CoepStem CoepCell where
+  stem := fun _ σ => match σ.sys with | .perf => some .coep | .pres => none
+  pm := fun _ σ => σ
+
+/-- The perfect-system realizations `coepī, coepistī, coepit, coepimus,
+coepistis, coepērunt` ([stump-2012-mmm8] (17)). -/
+def coepRealize : CoepStem → CoepCell → String
+  | _, σ => "coep" ++ (match σ.agr with
+      | .s1 => "i" | .s2 => "isti" | .s3 => "it"
+      | .p1 => "imus" | .p2 => "istis" | .p3 => "erunt")
+
+/-- COEPISSE is defective: the present-system cells lack a stem ([stump-2012-mmm8]
+§3.1). -/
+theorem coepisse_defective : coepisseLinkage.IsDefective :=
+  ⟨.coepisse, ⟨.pres, .s1⟩, rfl⟩
+
+/-- A present-system content cell has no realization. -/
+theorem coepisse_present_no_realization :
+    coepisseLinkage.realize coepRealize .coepisse ⟨.pres, .s3⟩ = none := rfl
+
+/-- A perfect-system content cell realizes through its `coep` correspondent
+(`coepit`, 3sg). -/
+theorem coepisse_perfect_realized :
+    coepisseLinkage.realize coepRealize .coepisse ⟨.perf, .s3⟩
+      = some ("coepit", ⟨.perf, .s3⟩) := rfl
+
+/-- COEPISSE keeps a single stem, so it is stem-invariant. -/
+theorem coepisse_stemInvariant : coepisseLinkage.IsStemInvariant := by
+  intro _ _ _ z₁ z₂ _ _; cases z₁; cases z₂; rfl
+
+/-- Defectiveness without suppletion: COEPISSE deviates on totality alone
+([stump-2012-mmm8] §3.1). -/
+theorem coepisse_defective_not_suppletive :
+    coepisseLinkage.IsDefective ∧ ¬ coepisseLinkage.IsSuppletive :=
+  ⟨coepisse_defective, not_not.mpr coepisse_stemInvariant⟩
+
+end Coepisse
+
+/-! ### Latin BELLUM: syncretism ((22)–(26))
+
+Two content cells share a form correspondent. The neuter nominative patterns
+after the accusative (directional), and the dative and ablative share one form
+cell (nondirectional). The merged dative/ablative form cell is a coarsening of
+the form-property space; it is modeled here by the dative as its representative,
+with both content cells mapped there. -/
+
+section Bellum
+
+inductive BellumLex | bellum
+  deriving DecidableEq, Fintype, Repr
+inductive BellumStem | bell
+  deriving DecidableEq, Fintype, Repr
+inductive Case | nom | gen | dat | acc | abl
+  deriving DecidableEq, Fintype, Repr
+inductive Num | sg | pl
+  deriving DecidableEq, Fintype, Repr
+
+/-- A BELLUM content cell: a case and a number. -/
+structure BellumCell where
+  case : Case
+  num : Num
+  deriving DecidableEq, Fintype, Repr
+
+/-- The property mapping: nominative to accusative (directional neuter
+syncretism, (24)) and ablative to dative as the merged `{dat/abl}` representative
+(nondirectional, (25)). -/
+def bellumPm (σ : BellumCell) : BellumCell :=
+  match σ.case with
+  | .nom => { σ with case := .acc }
+  | .abl => { σ with case := .dat }
+  | _ => σ
+
+/-- BELLUM's linkage: one stem, the syncretizing property mapping. -/
+def bellumLinkage : Linkage BellumLex BellumStem BellumCell where
+  stem := fun _ _ => some .bell
+  pm := fun _ σ => bellumPm σ
+
+/-- The realizations `bellum, bellī, bellō, bella, bellōrum, bellīs` on the form
+cells ([stump-2012-mmm8] (22)). -/
+def bellRealize : BellumStem → BellumCell → String
+  | _, σ => match σ.case, σ.num with
+      | .acc, .sg => "bellum" | .gen, .sg => "belli" | .dat, .sg => "bello"
+      | .acc, .pl => "bella" | .gen, .pl => "bellorum" | .dat, .pl => "bellis"
+      | _, _ => "bell"
+
+/-- Directional syncretism: nominative and accusative singular share a form
+correspondent ([stump-2012-mmm8] (24)). -/
+theorem bellum_nom_acc_syncretic : bellumLinkage.IsSyncretic :=
+  ⟨.bellum, ⟨.nom, .sg⟩, ⟨.acc, .sg⟩, by decide, by decide, by decide⟩
+
+/-- Nondirectional syncretism: dative and ablative singular share a form
+correspondent ([stump-2012-mmm8] (25)). -/
+theorem bellum_dat_abl_syncretic : bellumLinkage.IsSyncretic :=
+  ⟨.bellum, ⟨.dat, .sg⟩, ⟨.abl, .sg⟩, by decide, by decide, by decide⟩
+
+/-- The shared form correspondent forces a shared realization: nominative and
+accusative singular both realize as `bellum` ([stump-2012-mmm8] (26)). -/
+theorem bellum_nom_acc_realize_eq :
+    bellumLinkage.realize bellRealize .bellum ⟨.nom, .sg⟩
+      = bellumLinkage.realize bellRealize .bellum ⟨.acc, .sg⟩ :=
+  bellumLinkage.realize_eq_of_corr_eq bellRealize (by decide)
+
+theorem bellum_nom_realizes_bellum :
+    bellumLinkage.realize bellRealize .bellum ⟨.nom, .sg⟩
+      = some ("bellum", ⟨.acc, .sg⟩) := rfl
+
+/-- Syncretism is the failure of injectivity. -/
+theorem bellum_not_injective : ¬ bellumLinkage.IsInjective :=
+  (bellumLinkage.isSyncretic_iff_not_isInjective).mp bellum_nom_acc_syncretic
+
+end Bellum
+
+/-! ### Latin HORTĀRĪ: deponency, defectiveness, and virtual cells ((27)–(31), §4)
+
+The active content cells have passive form correspondents (deponency); the
+passive content cells have none (defectiveness). No content cell corresponds to
+an active form cell, so an active form cell is virtual — the seat of the
+[stump-2012-mmm8] §4 point that later Latin *hortābat* releases by suppressing
+the deponent override ([hippisley-2010]). -/
+
+section Hortari
+
+inductive HortariLex | hortari
+  deriving DecidableEq, Fintype, Repr
+inductive HortariStem | horta
+  deriving DecidableEq, Fintype, Repr
+inductive Voice | active | passive
+  deriving DecidableEq, Fintype, Repr
+
+/-- A HORTĀRĪ content cell: a voice and an agreement feature. -/
+structure VCell where
+  voice : Voice
+  agr : Agr
+  deriving DecidableEq, Fintype, Repr
+
+/-- HORTĀRĪ's linkage: a stem on the active cells only, and the voice-flipping
+property mapping ([stump-2012-mmm8] (29)–(30)). -/
+def hortariLinkage : Linkage HortariLex HortariStem VCell where
+  stem := fun _ σ => match σ.voice with | .active => some .horta | .passive => none
+  pm := fun _ σ => { σ with voice := .passive }
+
+/-- The passive-morphology realizations of the active content cells (`hortor,
+…, hortantur`, (28)). -/
+def hoRealize : HortariStem → VCell → String
+  | _, σ => match σ.agr with
+      | .s1 => "hortor" | .s2 => "hortaris" | .s3 => "hortatur"
+      | .p1 => "hortamur" | .p2 => "hortamini" | .p3 => "hortantur"
+
+/-- Deponency: the active content cells' property mapping is unfaithful, flipping
+to passive ([stump-2012-mmm8] §3.3.1). -/
+theorem hortari_unfaithful : hortariLinkage.IsUnfaithful :=
+  ⟨.hortari, ⟨.active, .s1⟩, by decide⟩
+
+/-- Every active content cell has a passive form correspondent. -/
+theorem hortari_active_realized_by_passive (σ : VCell) :
+    (hortariLinkage.corr .hortari ⟨.active, σ.agr⟩).map (·.2.voice) = some .passive :=
+  rfl
+
+/-- The active content cell `1sg` realizes as `hortor` through its passive
+correspondent. -/
+theorem hortari_realizes_hortor :
+    hortariLinkage.realize hoRealize .hortari ⟨.active, .s1⟩
+      = some ("hortor", ⟨.passive, .s1⟩) := rfl
+
+/-- Deponency compounds with defectiveness: the passive content cells lack a
+stem ([stump-2012-mmm8] (30a)). -/
+theorem hortari_defective : hortariLinkage.IsDefective :=
+  ⟨.hortari, ⟨.passive, .s1⟩, rfl⟩
+
+/-- The active form cell `⟨horta, {1sg active}⟩` is virtual: no content cell
+corresponds to it, since active content maps to passive form and passive content
+has no correspondent ([stump-2012-mmm8] §4). -/
+theorem hortari_active_form_virtual :
+    hortariLinkage.IsVirtual (.horta, ⟨.active, .s1⟩) := by
+  unfold Linkage.IsVirtual; decide
+
+end Hortari
+
+/-! ### Hungarian ÉN: functor-argument reversal ((33)–(38))
+
+The form correspondent of a pronominal oblique-case cell pairs the case stem with
+the pronoun's own person-number properties — `⟨f(σ), g(L)⟩` with the property set
+computed from the lexeme ([stump-2012-mmm8] (37)). The inessive of ÉN '1sg' is
+inflected as the 1sg form of the inessive stem `benn`. -/
+
+section Hungarian
+
+/-- The personal pronouns ÉN '1sg' and TE '2sg'. -/
+inductive Pron | en | te
+  deriving DecidableEq, Fintype, Repr
+
+/-- The oblique cases marked by inflected postpositions. -/
+inductive HuCase | dative | inessive | superessive
+  deriving DecidableEq, Fintype, Repr
+
+/-- The pronominal person-number properties the form cell carries. -/
+inductive PersNum | p1sg | p2sg
+  deriving DecidableEq, Fintype, Repr
+
+/-- A Hungarian property set: either a content-side case or a form-side
+person-number set. -/
+inductive HuProp | case (c : HuCase) | agr (pn : PersNum)
+  deriving DecidableEq, Fintype, Repr
+
+/-- The case postposition stems `nek, benn, rajt`. -/
+inductive CaseStem | nek | benn | rajt
+  deriving DecidableEq, Fintype, Repr
+
+/-- The stem selection: the case picks the postpositional stem ([stump-2012-mmm8]
+(37)). -/
+def enStem : Pron → HuProp → Option CaseStem
+  | _, .case .dative => some .nek
+  | _, .case .inessive => some .benn
+  | _, .case .superessive => some .rajt
+  | _, _ => none
+
+/-- The property mapping computes the form property set from the *lexeme* — the
+functor-argument reversal ([stump-2012-mmm8] (32), (37)). -/
+def enPm : Pron → HuProp → HuProp
+  | .en, _ => .agr .p1sg
+  | .te, _ => .agr .p2sg
+
+/-- ÉN's linkage: case-driven stem, lexeme-driven property mapping. -/
+def enLinkage : Linkage Pron CaseStem HuProp where
+  stem := enStem
+  pm := enPm
+
+/-- The realizations `nekem, bennem, rajtam` (1sg) and `neked, benned, rajtad`
+(2sg) ([stump-2012-mmm8] (36)). -/
+def enRealize : CaseStem → HuProp → String
+  | .nek, .agr .p1sg => "nekem" | .nek, .agr .p2sg => "neked"
+  | .benn, .agr .p1sg => "bennem" | .benn, .agr .p2sg => "benned"
+  | .rajt, .agr .p1sg => "rajtam" | .rajt, .agr .p2sg => "rajtad"
+  | _, _ => ""
+
+/-- The inessive of ÉN corresponds to the 1sg form of `benn` ([stump-2012-mmm8]
+(38)). -/
+theorem en_inessive_corr :
+    enLinkage.corr .en (.case .inessive) = some (.benn, .agr .p1sg) := rfl
+
+/-- The correspondent's property set is the pronoun's, not the case's — the
+reversal is unfaithful ([stump-2012-mmm8] (37)). -/
+theorem en_functor_argument_reversal : enLinkage.IsUnfaithful :=
+  ⟨.en, .case .inessive, by decide⟩
+
+/-- The property mapping consults the lexeme: ÉN and TE send the same inessive
+content cell to different form property sets. -/
+theorem en_pm_lexeme_sensitive :
+    enLinkage.pm .en (.case .inessive) ≠ enLinkage.pm .te (.case .inessive) := by
+  decide
+
+/-- The nekem/bennem row of (38): the dative and inessive of ÉN realize as
+`nekem` and `bennem`. -/
+theorem en_realizes_nekem_bennem :
+    enLinkage.realize enRealize .en (.case .dative)
+        = some ("nekem", .agr .p1sg) ∧
+      enLinkage.realize enRealize .en (.case .inessive)
+        = some ("bennem", .agr .p1sg) :=
+  ⟨rfl, rfl⟩
+
+end Hungarian
+
+/-! ### Latin FERRE: suppletion under the default rule ((41)–(43))
+
+Present-system cells take the stem `fer`, perfect-system cells the stem `tul`,
+in complementary distribution under the default linkage rule — no override. The
+linkage is suppletive yet property-preserving, showing the two axes are
+independent. -/
+
+section Ferre
+
+inductive FerreLex | ferre
+  deriving DecidableEq, Fintype, Repr
+inductive FerreStem | fer | tul
+  deriving DecidableEq, Fintype, Repr
+
+/-- A FERRE content cell: a tense system and an agreement feature. -/
+structure FerreCell where
+  sys : System
+  agr : Agr
+  deriving DecidableEq, Fintype, Repr
+
+/-- FERRE's linkage: two suppletive stems in complementary distribution, identity
+property mapping ([stump-2012-mmm8] (42)). -/
+def ferreLinkage : Linkage FerreLex FerreStem FerreCell where
+  stem := fun _ σ => match σ.sys with | .pres => some .fer | .perf => some .tul
+  pm := fun _ σ => σ
+
+/-- The realizations `ferō, fers, fert, …` and `tulī, …, tulit, …`
+([stump-2012-mmm8] (41)). -/
+def ferRealize : FerreStem → FerreCell → String
+  | .fer, σ => "fer" ++ (match σ.agr with
+      | .s1 => "o" | .s2 => "s" | .s3 => "t"
+      | .p1 => "imus" | .p2 => "tis" | .p3 => "unt")
+  | .tul, σ => "tul" ++ (match σ.agr with
+      | .s1 => "i" | .s2 => "isti" | .s3 => "it"
+      | .p1 => "imus" | .p2 => "istis" | .p3 => "erunt")
+
+/-- FERRE is suppletive: the present- and perfect-system cells draw on different
+stems ([stump-2012-mmm8] §3.4). -/
+theorem ferre_suppletive : ferreLinkage.IsSuppletive := fun h =>
+  absurd (h .ferre (σ₁ := ⟨.pres, .s1⟩) (σ₂ := ⟨.perf, .s1⟩) rfl rfl) (by decide)
+
+/-- FERRE is property-preserving: no override, the default rule preserves the
+content cell's property set. -/
+theorem ferre_propertyPreserving : ferreLinkage.IsPropertyPreserving :=
+  fun _ _ => rfl
+
+/-- The independence showcase: suppletive yet property-preserving
+([stump-2012-mmm8] §3.4). -/
+theorem ferre_suppletive_yet_faithful :
+    ferreLinkage.IsSuppletive ∧ ferreLinkage.IsPropertyPreserving :=
+  ⟨ferre_suppletive, ferre_propertyPreserving⟩
+
+theorem ferre_present_realized :
+    ferreLinkage.realize ferRealize .ferre ⟨.pres, .s3⟩
+      = some ("fert", ⟨.pres, .s3⟩) := rfl
+theorem ferre_perfect_realized :
+    ferreLinkage.realize ferRealize .ferre ⟨.perf, .s3⟩
+      = some ("tulit", ⟨.perf, .s3⟩) := rfl
+
+end Ferre
+
+/-! ### Old Icelandic ÞURFA: a compound deviation ((44)–(46))
+
+A preterite-present verb forms its present as a strong verb forms its past
+(deponent tense mapping) and its past with a separate weak stem (suppletion).
+Suppletion and unfaithfulness coincide in a single linkage. -/
+
+section Thurfa
+
+inductive ThurfaLex | thurfa
+  deriving DecidableEq, Fintype, Repr
+inductive ThurfaStem | strong | weak
+  deriving DecidableEq, Fintype, Repr
+inductive Tense | pres | past
+  deriving DecidableEq, Fintype, Repr
+
+/-- A ÞURFA content cell: a tense and an agreement feature. -/
+structure TCell where
+  tense : Tense
+  agr : Agr
+  deriving DecidableEq, Fintype, Repr
+
+/-- ÞURFA's linkage: the strong stem for the present, the weak stem for the past
+(suppletion), and a property mapping sending every cell to the past
+(deponent tense) ([stump-2012-mmm8] (45)–(46)). -/
+def thurfaLinkage : Linkage ThurfaLex ThurfaStem TCell where
+  stem := fun _ σ => match σ.tense with | .pres => some .strong | .past => some .weak
+  pm := fun _ σ => { σ with tense := .past }
+
+/-- ÞURFA is suppletive: present and past draw on different stems. -/
+theorem thurfa_suppletive : thurfaLinkage.IsSuppletive := fun h =>
+  absurd (h .thurfa (σ₁ := ⟨.pres, .s1⟩) (σ₂ := ⟨.past, .s1⟩) rfl rfl) (by decide)
+
+/-- ÞURFA is unfaithful: the present content cell maps to a past form cell. -/
+theorem thurfa_unfaithful : thurfaLinkage.IsUnfaithful :=
+  ⟨.thurfa, ⟨.pres, .s1⟩, by decide⟩
+
+/-- The compound deviation: suppletion and deponent tense mapping in one linkage
+([stump-2012-mmm8] §3.4). -/
+theorem thurfa_suppletive_and_unfaithful :
+    thurfaLinkage.IsSuppletive ∧ thurfaLinkage.IsUnfaithful :=
+  ⟨thurfa_suppletive, thurfa_unfaithful⟩
+
+/-- The present content cell's form correspondent is the strong stem at the past
+property set ([stump-2012-mmm8] (46)). -/
+theorem thurfa_pres_corr :
+    thurfaLinkage.corr .thurfa ⟨.pres, .s1⟩ = some (.strong, ⟨.past, .s1⟩) := rfl
+
+/-- The past content cell's form correspondent is the weak stem at the past
+property set ([stump-2012-mmm8] (46)). -/
+theorem thurfa_past_corr :
+    thurfaLinkage.corr .thurfa ⟨.past, .s1⟩ = some (.weak, ⟨.past, .s1⟩) := rfl
+
+end Thurfa
+
+end Stump2012

--- a/Linglib/Studies/Stump2016.lean
+++ b/Linglib/Studies/Stump2016.lean
@@ -92,14 +92,14 @@ inductive LatinStem where
 property mapping `pm2c` ([stump-2016] §12.1), which sends an active content cell
 to a passive form cell. -/
 def conariLinkage : Linkage LatinVerb LatinStem Cell where
-  stem := fun _ _ => .cona
-  pm := fun σ => { σ with voice := .passive }
+  stem := fun _ _ => some .cona
+  pm := fun _ σ => { σ with voice := .passive }
 
 /-- The **regular linkage** of *parāre*: a single stem and the identity property
 mapping, canonical on the voice axis ([stump-2016] §7.1). -/
 def parareLinkage : Linkage LatinVerb LatinStem Cell where
-  stem := fun _ _ => .para
-  pm := id
+  stem := fun _ _ => some .para
+  pm := fun _ σ => σ
 
 /-- *cōnārī*'s six active content cells ([stump-2016] Table 12.2). -/
 def conariContentCells : List Cell :=
@@ -109,42 +109,45 @@ def conariContentCells : List Cell :=
 /-- The regular verb's linkage is canonical: property-set preserving (`pm = id`)
 and stem invariant ([stump-2016] §7.1, characteristics (2a)–(2b)). -/
 theorem parareLinkage_isCanonical : parareLinkage.IsCanonical :=
-  ⟨fun _ => rfl, fun _ => ⟨.para, fun _ => rfl⟩⟩
+  ⟨fun _ _ => rfl,
+   fun _ _ _ _ _ h₁ h₂ => (Option.some.inj h₁).symm.trans (Option.some.inj h₂),
+   fun _ _ _ _ _ heq => congrArg Prod.snd (Option.some.inj heq),
+   fun _ _ => rfl⟩
 
 /-- The deponent property mapping flips voice on every active cell. -/
-theorem conari_pm_flips_voice (σ : Cell) :
-    (conariLinkage.pm σ).voice = .passive := rfl
+theorem conari_pm_flips_voice (l : LatinVerb) (σ : Cell) :
+    (conariLinkage.pm l σ).voice = .passive := rfl
 
 /-- The deponent linkage deviates from the canonical isomorphism on every active
 content cell: its property mapping moves the cell off its own property set. -/
-theorem conari_deviates_on_every_active_cell (σ : Cell) (h : σ.voice = .active) :
-    conariLinkage.pm σ ≠ σ := by
+theorem conari_deviates_on_every_active_cell (l : LatinVerb) (σ : Cell)
+    (h : σ.voice = .active) : conariLinkage.pm l σ ≠ σ := by
   intro heq
   have : Voice.passive = Voice.active := h ▸ congrArg Cell.voice heq
   exact absurd this (by decide)
 
 /-- Hence the deponent linkage is not property-preserving, so not canonical. -/
 theorem conariLinkage_not_canonical : ¬ conariLinkage.IsCanonical := by
-  rintro ⟨hpp, -⟩
-  exact conari_deviates_on_every_active_cell ⟨.s1, .active⟩ rfl (hpp _)
+  rintro ⟨-, -, -, hpp⟩
+  exact conari_deviates_on_every_active_cell .conari ⟨.s1, .active⟩ rfl (hpp _ _)
 
 /-- **The deponency claim**: every active content cell of *cōnārī* has a
 *passive* form correspondent — active content realized by passive morphology
 ([stump-2016] §12.1). -/
 theorem conari_active_realized_by_passive_form (l : LatinVerb) (σ : Cell) :
-    (conariLinkage.corr l σ).2.voice = .passive := rfl
+    (conariLinkage.corr l σ).map (·.2.voice) = some .passive := rfl
 
 /-- Every one of *cōnārī*'s six active content cells crosses the voice axis. -/
 theorem conari_all_cells_cross_voice :
-    ∀ σ ∈ conariContentCells, conariLinkage.pm σ ≠ σ := by decide
+    ∀ σ ∈ conariContentCells, conariLinkage.pm .conari σ ≠ σ := by decide
 
 /-- The crisp contrast: on the *same* active content cell, the regular verb's
 form correspondent stays active while the deponent's becomes passive — deviation
 without any difference in the content-cell space. -/
 theorem depon_vs_regular (σ : Cell) (h : σ.voice = .active) :
-    (parareLinkage.corr .parare σ).2.voice = .active ∧
-      (conariLinkage.corr .conari σ).2.voice = .passive :=
-  ⟨h, rfl⟩
+    (parareLinkage.corr .parare σ).map (·.2.voice) = some .active ∧
+      (conariLinkage.corr .conari σ).map (·.2.voice) = some .passive :=
+  ⟨congrArg some h, rfl⟩
 
 /-! ### Kashmiri morphomic tense (Ch. 8, pp. 217ff) -/
 
@@ -204,48 +207,48 @@ def realizeForm (z : String) (τ : Finset KFeat) : String :=
   (paradigmFunction (fun _ => wup) (fun _ => z) [formBlock] (wup, τ)).1
 
 /-- Conjugation II linkage: the single stem, mapped by `pmII`. -/
-def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmII⟩
+def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => some (stemOf l), fun _ => pmII⟩
 
 /-- Conjugation III linkage: the single stem, mapped by `pmIII`. -/
-def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => stemOf l, pmIII⟩
+def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => some (stemOf l), fun _ => pmIII⟩
 
 /-- WUP recent past ('past a'): `wupus`. -/
 example : linkII.realize realizeForm wup {recentPast, p1, sg, masc}
-    = ("wupus", {pastA, p1, sg, masc}) := by decide
+    = some ("wupus", {pastA, p1, sg, masc}) := by decide
 
 /-- WUP indefinite past ('past b'): `wupyōs`. -/
 example : linkII.realize realizeForm wup {indefPast, p1, sg, masc}
-    = ("wupyōs", {pastB, p1, sg, masc}) := by decide
+    = some ("wupyōs", {pastB, p1, sg, masc}) := by decide
 
 /-- WUP remote past ('past c'): `wupyās`. -/
 example : linkII.realize realizeForm wup {remotePast, p1, sg, masc}
-    = ("wupyās", {pastC, p1, sg, masc}) := by decide
+    = some ("wupyās", {pastC, p1, sg, masc}) := by decide
 
 /-- WUPH recent past ('past b'): `wuphyōs`. -/
 example : linkIII.realize realizeForm wuph {recentPast, p1, sg, masc}
-    = ("wuphyōs", {pastB, p1, sg, masc}) := by decide
+    = some ("wuphyōs", {pastB, p1, sg, masc}) := by decide
 
 /-- WUPH indefinite past ('past c'): `wuphyās`. -/
 example : linkIII.realize realizeForm wuph {indefPast, p1, sg, masc}
-    = ("wuphyās", {pastC, p1, sg, masc}) := by decide
+    = some ("wuphyās", {pastC, p1, sg, masc}) := by decide
 
 /-- WUPH remote past ('past d'): `wuphiyās`. -/
 example : linkIII.realize realizeForm wuph {remotePast, p1, sg, masc}
-    = ("wuphiyās", {pastD, p1, sg, masc}) := by decide
+    = some ("wuphiyās", {pastD, p1, sg, masc}) := by decide
 
 /-- **The morphomic mediation** ([stump-2016] Ch. 8): WUP's indefinite past and
 WUPH's recent past have the same form correspondent property set — both 'past b',
 1sg masc — even though their tenses differ. This is why they inflect alike
 (`-yōs`), the content-to-form mismatch the paradigm-linkage model captures. -/
 theorem kashmiri_inflect_alike :
-    (linkII.corr wup {indefPast, p1, sg, masc}).2
-      = (linkIII.corr wuph {recentPast, p1, sg, masc}).2 := by decide
+    (linkII.corr wup {indefPast, p1, sg, masc}).map Prod.snd
+      = (linkIII.corr wuph {recentPast, p1, sg, masc}).map Prod.snd := by decide
 
 /-- The second interleaving: WUP's remote past and WUPH's indefinite past share
 the 'past c' correspondent, inflecting alike (`-yās`). -/
 theorem kashmiri_inflect_alike_pastC :
-    (linkII.corr wup {remotePast, p1, sg, masc}).2
-      = (linkIII.corr wuph {indefPast, p1, sg, masc}).2 := by decide
+    (linkII.corr wup {remotePast, p1, sg, masc}).map Prod.snd
+      = (linkIII.corr wuph {indefPast, p1, sg, masc}).map Prod.snd := by decide
 
 end Kashmiri
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -26365,6 +26365,36 @@
   validated = {true},
   sources   = {Morphology/TheorySpace.lean;Studies/KalinBjorkmanEtAl2026.lean;Morphology/Containment/Vocabulary.lean}
 }
+@incollection{stump-2012-mmm8,
+  author    = {Stump, Gregory T.},
+  year      = {2012},
+  title     = {The formal and functional architecture of inflectional morphology},
+  booktitle = {On-Line Proceedings of the 8th Mediterranean Morphology Meeting (MMM8)},
+  pages     = {255--271},
+  publisher = {University of Patras},
+  address   = {Patras},
+  doi       = {10.26220/mmm.2435},
+  subfield  = {morphology},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Morphology/Paradigm/Linkage.lean;Studies/Stump2012.lean}
+}
+@incollection{hippisley-2010,
+  author    = {Hippisley, Andrew},
+  year      = {2010},
+  title     = {Paradigmatic realignment and morphological change: Diachronic deponency in Network Morphology},
+  booktitle = {Variation and Change in Morphology},
+  editor    = {Rainer, Franz and Dressler, Wolfgang U. and Kastovsky, Dieter and Luschützky, Hans Christian},
+  series    = {Current Issues in Linguistic Theory},
+  volume    = {310},
+  pages     = {107--128},
+  publisher = {John Benjamins},
+  address   = {Amsterdam},
+  doi       = {10.1075/cilt.310.06hip},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Studies/Stump2012.lean}
+}
 @book{stump-2016,
   author    = {Stump, Gregory T.},
   year      = {2016},


### PR DESCRIPTION
Refine `Morphology/Paradigm/Linkage` to partial, lexeme-sensitive linkage with four independent canonicity axes (totality, stem invariance, injectivity, property preservation), one deviation predicate per axis. New `Studies/Stump2012` anchors each axis with the paper's own witnesses (Breton HERVEZ, Latin COEPISSE/BELLUM/HORTĀRĪ/FERRE, Hungarian ÉN, Old Icelandic ÞURFA).