### PR TITLE
refactor(Morphology/Word): parameterize Structure; dissolve Morpheme

### DIFF
--- a/Linglib/Fragments/Poko/Tone.lean
+++ b/Linglib/Fragments/Poko/Tone.lean
@@ -26,13 +26,13 @@ a fuller fragment when a second Poko paper arrives.
 * `Poko.Syll.melody` — each stem's lexical melody: tones, TBU, and
   pre-linking ([rolle-2018] §2.1; the floating H of `/M^H/` stems is
   the unlinked element).
-* `Poko.Form` — autosegmental forms (`FloatingForm Syll TRN Morpheme`).
+* `Poko.Form` — autosegmental forms (`FloatingForm Syll TRN Morph`).
 -/
 
 namespace Poko
 
 open Autosegmental
-open Morphology (Morpheme)
+open Morphology (Morph)
 open Tone (TRN)
 
 /-! ### Syllables -/
@@ -63,20 +63,20 @@ inductive Syll
 /-! ### Morphemes and melodies -/
 
 /-- Stable morpheme per stem, keyed by the syllable's surface form. -/
-def Syll.morpheme : Syll → Morpheme
-  | .kak => { morph := .root "kak" }
-  | .ri  => { morph := .root "ri" }
-  | .do  => { morph := .root "do" }
-  | .nan => { morph := .root "nan" }
-  | .na  => { morph := .root "na" }
-  | .ka  => { morph := .root "ka" }
-  | .ili => { morph := .root "ili" }
-  | .ne  => { morph := .root "ne" }
+def Syll.morpheme : Syll → Morph
+  | .kak => .root "kak"
+  | .ri  => .root "ri"
+  | .do  => .root "do"
+  | .nan => .root "nan"
+  | .na  => .root "na"
+  | .ka  => .root "ka"
+  | .ili => .root "ili"
+  | .ne  => .root "ne"
 
 /-- Each stem's lexical melody ([mcpherson-lamont-2026] ex. 3): tones
     over the stem's single TBU, with the lexical pre-linking — the H of
     an `/M^H/` stem is the sole unlinked (floating) element. -/
-def Syll.melody (s : Syll) : FloatingForm Syll TRN Morpheme :=
+def Syll.melody (s : Syll) : FloatingForm Syll TRN Morph :=
   match s with
   | .kak => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
   | .ri  => .melody s.morpheme [.M, .H] [s] {(0, 0)}          -- /M^H/
@@ -89,10 +89,10 @@ def Syll.melody (s : Syll) : FloatingForm Syll TRN Morpheme :=
 
 /-- The underlying form of a stem sequence: melodies concatenated
     left-to-right. -/
-def word (ss : List Syll) : FloatingForm Syll TRN Morpheme :=
+def word (ss : List Syll) : FloatingForm Syll TRN Morph :=
   .concatInputs (ss.map Syll.melody)
 
 /-- Poko autosegmental forms: syllable backbone, `TRN` tone tier, morpheme sponsor. -/
-abbrev Form := FloatingForm Syll TRN Morpheme
+abbrev Form := FloatingForm Syll TRN Morph
 
 end Poko

--- a/Linglib/Fragments/Tigrinya/ClausePrefixes.lean
+++ b/Linglib/Fragments/Tigrinya/ClausePrefixes.lean
@@ -103,23 +103,23 @@ def ay_n : ClausePrefixEntry where
 /-- All four clausal prefix entries. -/
 def allPrefixes : List ClausePrefixEntry := [zi, ki, kemzi, ay_n]
 
-/-- The negative circumfix as word structure: the verb stem wrapped by
-*ʔay-* and *-n* (an inflectional circumfixation, [haspelmath-2020]'s
-prefix-plus-suffix construction reading). -/
-def negCircumfix (verbStem : String) : Word.Structure :=
-  .circumfixed ⟨Morph.pref ay_n.form, ay_n.gloss⟩
-    (.root ⟨Morph.free verbStem, ""⟩)
-    ⟨Morph.suff ay_n.suffix_, ay_n.gloss⟩
+/-- The negative circumfix as word structure over glossed morphs: the
+verb stem wrapped by *ʔay-* and *-n* (an inflectional circumfixation,
+[haspelmath-2020]'s prefix-plus-suffix construction reading). -/
+def negCircumfix (verbStem : String) : Word.Structure (Morph × String) :=
+  .circumfixed (Morph.pref ay_n.form, ay_n.gloss)
+    (.root (Morph.free verbStem, ""))
+    (Morph.suff ay_n.suffix_, ay_n.gloss)
     .inflectional
 
 /-- The negative circumfix surfaces correctly. -/
 theorem neg_circumfix_example :
-    (negCircumfix "mäs'ə").surface = "ʔay-mäs'ə-n" := rfl
+    String.join ((negCircumfix "mäs'ə").toList.map (·.1.form)) = "ʔay-mäs'ə-n" := rfl
 
 /-- Discontinuous exponence: the circumfixed structure has no
-morph-sequence projection (`toExponent = none`) — the circumfix is a
-construction, not a morph ([haspelmath-2020]). -/
+payload-sequence projection — the circumfix is a construction, not a
+morph ([haspelmath-2020]). -/
 theorem neg_circumfix_no_exponent (s : String) :
-    (negCircumfix s).toExponent = none := rfl
+    (negCircumfix s).toSequence? = none := rfl
 
 end Tigrinya.ClausePrefixes

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Tactic.DeriveFintype
 import Mathlib.Data.Fintype.Sigma
 import Mathlib.Data.Fintype.Sum

--- a/Linglib/Morphology/Word/Structure.lean
+++ b/Linglib/Morphology/Word/Structure.lean
@@ -8,13 +8,20 @@ import Linglib.Morphology.Morph
 /-!
 # Word-internal structure
 
-A `Word.Structure` is a tree of morphemes whose constructors are the
-morphological operations: affixation, compounding, reduplication, and
-conversion ([hayes-2009]). Affixation carries an `AffixKind` tag, which
-makes [booij-2012]'s relational notions computable as the accessors
-`base`, `stem`, and `roots`. The partial fold `toExponent` projects
-concatenative structure to a `Morph` sequence.
+A `Word.Structure M` is an operation-typed tree with leaves and affixal
+payloads in `M`: each constructor is a word-formation operation with its
+own arity and payload ([hayes-2009]). The tree records derivational
+history and word-internal constituency — what applying the operations as
+functions would forget. [booij-2012]'s relational notions are the
+accessors `base`, `stem`, and `roots`; `toList` linearizes the payloads
+and `toSequence?` projects the concatenative fragment to its payload
+sequence. The tree does not evaluate to surface strings: concatenative
+surface forms are `String.join` over `toList`, and the surface effect of
+process constructors (infixation, reduplication) belongs to the process
+theories, not to string simulation here.
 
+The theory layer instantiates `M := Morph`; fragments that annotate
+their morphs (glosses) instantiate `M` with their own richer leaf type.
 The token type (`Morphology.Word`, `Word/Basic.lean`) is deliberately
 separate: the token is what syntax sees, the tree is how morphology
 built it.
@@ -22,31 +29,16 @@ built it.
 
 namespace Morphology
 
-/-! ### Morphemes -/
-
-/-- A morpheme: the classical "minimal meaningful unit", kept as the
-descriptive convenience the textbooks use. Carries its form as a `Morph`
-and an optional gloss; attachment is `morph.kind`. Finer wordhood
-classification (the clitic–affix cline) is diagnostic, derived in
-`Studies/ZwickyPullum1983.lean`, not stored here. -/
-structure Morpheme where
-  morph  : Morph
-  gloss  : String := ""
-  deriving DecidableEq, Repr
-
-/-- The surface string of a morpheme: its morph's segmental form. -/
-def Morpheme.surface (m : Morpheme) : String := m.morph.form
-
 /-! ### Reduplication and affix kinds -/
 
 /-- The type of a reduplication step. -/
 inductive RedupType where
   /-- Copies the entire base (Warlpiri *kijikiji* from *kiji*). -/
   | total
-  /-- Copies a prosodic template; the copied material is stored explicitly
-  since it depends on prosodic shape, determined at construction time
-  (Ilokano *ag-tráb-trabáho*, partial copy *trab*). -/
-  | partialCopy (copied : String)
+  /-- Copies a prosodic template (Ilokano *ag-tráb-trabáho*); the copied
+  material is determined by prosodic shape, which is process-theory
+  content, not tree data. -/
+  | partialCopy
   deriving DecidableEq, Repr
 
 /-- Whether an affixation step is inflectional or derivational — the tag
@@ -58,169 +50,86 @@ inductive AffixKind where
 
 /-! ### The structure tree -/
 
-/-- Hierarchical word structure as an operation-typed tree of morphemes:
-each constructor is a word-formation operation with its own arity and
-payload. The tree records derivational history and word-internal
-constituency — what applying the operations as functions would forget. -/
-inductive Word.Structure where
-  /-- Leaf node: a single morpheme (free or bound). -/
-  | root : Morpheme → Word.Structure
-  /-- Attach morpheme before base. -/
-  | prefixed : Morpheme → Word.Structure → optParam AffixKind .derivational → Word.Structure
-  /-- Attach morpheme after base. -/
-  | suffixed : Word.Structure → Morpheme → optParam AffixKind .derivational → Word.Structure
-  /-- Insert morpheme at position `pos` within base's
-      surface form. Example: Tagalog *-um-* in *s⟨um⟩ulat*. -/
-  | infixed : Word.Structure → Morpheme → Nat → optParam AffixKind .derivational → Word.Structure
-  /-- Wrap base with a prefix and suffix.
+/-- Hierarchical word structure as an operation-typed tree with payloads
+in `M`: each constructor is a word-formation operation with its own
+arity and payload. The tree records derivational history and
+word-internal constituency. -/
+inductive Word.Structure (M : Type*) where
+  /-- Leaf node: a single element (free or bound). -/
+  | root : M → Word.Structure M
+  /-- Attach a payload before the base. -/
+  | prefixed : M → Word.Structure M → optParam AffixKind .derivational → Word.Structure M
+  /-- Attach a payload after the base. -/
+  | suffixed : Word.Structure M → M → optParam AffixKind .derivational → Word.Structure M
+  /-- Insert a payload within the base (Tagalog *-um-* in *s⟨um⟩ulat*);
+      the insertion site is prosodically determined and is process-theory
+      content, not tree data. -/
+  | infixed : Word.Structure M → M → optParam AffixKind .derivational → Word.Structure M
+  /-- Wrap the base with a prefix and a suffix.
       Example: German *ge-mach-t*. -/
-  | circumfixed : Morpheme → Word.Structure → Morpheme → optParam AffixKind .derivational → Word.Structure
+  | circumfixed : M → Word.Structure M → M → optParam AffixKind .derivational → Word.Structure M
   /-- Two stems joined. Example: *desk* + *lamp*. -/
-  | compound : Word.Structure → Word.Structure → Word.Structure
+  | compound : Word.Structure M → Word.Structure M → Word.Structure M
   /-- Total or partial reduplication. -/
-  | reduplicated : RedupType → Word.Structure → Word.Structure
+  | reduplicated : RedupType → Word.Structure M → Word.Structure M
   /-- Conversion. Example: noun *telephone* → verb *to telephone*. -/
-  | converted : Word.Structure → Word.Structure
+  | converted : Word.Structure M → Word.Structure M
   deriving Repr
 
 namespace Word.Structure
 
-/-! ### Surface form -/
+variable {M : Type*}
 
-/-- The flat surface string of the morphological tree. -/
-def surface : Word.Structure → String
-  | .root m => m.surface
-  | .prefixed afx base _ => afx.surface ++ base.surface
-  | .suffixed base afx _ => base.surface ++ afx.surface
-  | .infixed base afx pos _ =>
-    let s := base.surface
-    String.ofList (s.toList.take pos) ++ afx.surface ++ String.ofList (s.toList.drop pos)
-  | .circumfixed pre base suf _ => pre.surface ++ base.surface ++ suf.surface
-  | .compound left right => left.surface ++ right.surface
-  | .reduplicated rt base =>
-    match rt with
-    | .total => base.surface ++ base.surface
-    | .partialCopy copied => copied ++ base.surface
-  | .converted base => base.surface
+/-! ### Payload linearization -/
 
-/-- Conversion preserves the surface form. -/
-theorem surface_converted (w : Word.Structure) :
-    (converted w).surface = w.surface := rfl
-
-/-- The surface form of a compound is the concatenation of its parts. -/
-theorem surface_compound (l r : Word.Structure) :
-    (compound l r).surface = l.surface ++ r.surface := rfl
-
-/-- Total reduplication doubles the surface form. -/
-theorem surface_reduplicated_total (w : Word.Structure) :
-    (reduplicated .total w).surface = w.surface ++ w.surface := rfl
-
-/-! ### Morpheme linearization and boundaries -/
-
-/-- Flatten the morphological tree into a list of morphemes. The order
-is left-to-right surface order for concatenative structure; an infix is
-appended after its base's morphemes (its *surface* position is `pos`,
-not its list position), and reduplicative copies contribute no morpheme.
-Morpheme boundaries are implicit: they fall between adjacent elements. -/
-def morphemes : Word.Structure → List Morpheme
+/-- All payloads of the tree in left-to-right surface order for
+concatenative structure; an infix is appended after its base's payloads
+(its surface position is prosodic, not positional), and reduplicative
+copies contribute nothing. -/
+def toList : Word.Structure M → List M
   | .root m => [m]
-  | .prefixed afx base _ => afx :: base.morphemes
-  | .suffixed base afx _ => base.morphemes ++ [afx]
-  | .infixed base afx _ _ => base.morphemes ++ [afx]
-  | .circumfixed pre base suf _ => pre :: base.morphemes ++ [suf]
-  | .compound left right => left.morphemes ++ right.morphemes
-  | .reduplicated _ base => base.morphemes
-  | .converted base => base.morphemes
+  | .prefixed afx base _ => afx :: base.toList
+  | .suffixed base afx _ => base.toList ++ [afx]
+  | .infixed base afx _ => base.toList ++ [afx]
+  | .circumfixed pre base suf _ => pre :: base.toList ++ [suf]
+  | .compound left right => left.toList ++ right.toList
+  | .reduplicated _ base => base.toList
+  | .converted base => base.toList
 
-/-- The number of morphemes in the word. -/
-def morphemeCount (w : Word.Structure) : Nat := w.morphemes.length
+/-- The payload sequence of the concatenative fragment. **Partial**:
+`none` on infixation, circumfixation, and reduplication — discontinuous
+and process morphology are constructions, not payload sequences.
+Conversion is payload-vacuous and projects through. -/
+def toSequence? : Word.Structure M → Option (List M)
+  | .root m => some [m]
+  | .prefixed afx b _ => (b.toSequence?).map (afx :: ·)
+  | .suffixed b afx _ => (b.toSequence?).map (· ++ [afx])
+  | .compound l r => do pure ((← l.toSequence?) ++ (← r.toSequence?))
+  | .converted b => b.toSequence?
+  | .infixed .. => none
+  | .circumfixed .. => none
+  | .reduplicated .. => none
 
-/-- A bare root contains exactly one morpheme. -/
-theorem morphemeCount_root (m : Morpheme) : (root m).morphemeCount = 1 := rfl
+/-- The projection is total exactly on the concatenative fragment: a
+circumfixed word has no payload-sequence projection. -/
+theorem toSequence?_circumfixed (pre suf : M) (b : Word.Structure M)
+    (k : AffixKind) : (circumfixed pre b suf k).toSequence? = none := rfl
 
-/-- Positions of morpheme boundaries in the surface string. Each `Nat`
-is a character offset where one morpheme ends and the next begins;
-phonological rules can reference these positions. -/
-def boundaryPositions : Word.Structure → List Nat
-  | .root _ => []
-  | .prefixed afx base _ =>
-    let offset := afx.surface.length
-    offset :: base.boundaryPositions.map (· + offset)
-  | .suffixed base afx _ =>
-    let baseLen := base.surface.length
-    base.boundaryPositions ++ [baseLen, baseLen + afx.surface.length]
-  | .infixed base afx pos _ =>
-    let afxLen := afx.surface.length
-    let baseBounds := base.boundaryPositions
-    let shifted := baseBounds.map (λ b => if b ≥ pos then b + afxLen else b)
-    (shifted ++ [pos, pos + afxLen]).mergeSort (· ≤ ·) |>.eraseDups
-  | .circumfixed pre base _suf _ =>
-    let preLen := pre.surface.length
-    let baseLen := base.surface.length
-    preLen :: (base.boundaryPositions.map (· + preLen)
-      ++ [preLen + baseLen])
-  | .compound left right =>
-    let leftLen := left.surface.length
-    left.boundaryPositions ++ [leftLen]
-      ++ right.boundaryPositions.map (· + leftLen)
-  | .reduplicated rt base =>
-    match rt with
-    | .total =>
-      let baseLen := base.surface.length
-      base.boundaryPositions ++ [baseLen]
-        ++ base.boundaryPositions.map (· + baseLen)
-    | .partialCopy copied =>
-      let copiedLen := copied.length
-      copiedLen :: base.boundaryPositions.map (· + copiedLen)
-  | .converted base => base.boundaryPositions
-
-/-! ### Structural predicates -/
-
-/-- A word is simple if it is a bare root. -/
-def IsSimple : Word.Structure → Prop
-  | .root _ => True
-  | _ => False
-
-instance : DecidablePred IsSimple := fun w => by
-  cases w <;> unfold IsSimple <;> infer_instance
-
-/-- A word is a compound if its outermost operation joins two stems. -/
-def IsCompound : Word.Structure → Prop
-  | .compound _ _ => True
-  | _ => False
-
-instance : DecidablePred IsCompound := fun w => by
-  cases w <;> unfold IsCompound <;> infer_instance
-
-/-- A word is reduplicated if its outermost operation is reduplication. -/
-def IsReduplicated : Word.Structure → Prop
-  | .reduplicated _ _ => True
-  | _ => False
-
-instance : DecidablePred IsReduplicated := fun w => by
-  cases w <;> unfold IsReduplicated <;> infer_instance
-
-/-- A word is converted if its outermost operation is conversion. -/
-def IsConverted : Word.Structure → Prop
-  | .converted _ => True
-  | _ => False
-
-instance : DecidablePred IsConverted := fun w => by
-  cases w <;> unfold IsConverted <;> infer_instance
+/-! ### Structural measures -/
 
 /-- Morphological depth: the number of operations above the deepest root. -/
-def depth : Word.Structure → Nat
+def depth : Word.Structure M → Nat
   | .root _ => 0
   | .prefixed _ base _ => 1 + base.depth
   | .suffixed base _ _ => 1 + base.depth
-  | .infixed base _ _ _ => 1 + base.depth
+  | .infixed base _ _ => 1 + base.depth
   | .circumfixed _ base _ _ => 1 + base.depth
   | .compound l r => 1 + max l.depth r.depth
   | .reduplicated _ base => 1 + base.depth
   | .converted base => 1 + base.depth
 
 /-- A bare root has depth zero. -/
-theorem depth_root (m : Morpheme) : (root m).depth = 0 := rfl
+theorem depth_root (m : M) : (root m).depth = 0 := rfl
 
 /-! ### Relational accessors
 
@@ -232,11 +141,11 @@ leaves. -/
 /-- The immediate base of the outermost operation: the daughter tree for
 affixation, reduplication, and conversion; `none` for a bare root and
 for compounds (which have two constituents, not a base). -/
-def base : Word.Structure → Option Word.Structure
+def base : Word.Structure M → Option (Word.Structure M)
   | .root _ => none
   | .prefixed _ b _ => some b
   | .suffixed b _ _ => some b
-  | .infixed b _ _ _ => some b
+  | .infixed b _ _ => some b
   | .circumfixed _ b _ _ => some b
   | .compound _ _ => none
   | .reduplicated _ b => some b
@@ -245,58 +154,35 @@ def base : Word.Structure → Option Word.Structure
 /-- The stem: the tree with outer *inflectional* affixation stripped.
 Derivational structure, compounding, reduplication, and conversion are
 part of the stem. -/
-def stem : Word.Structure → Word.Structure
+def stem : Word.Structure M → Word.Structure M
   | .prefixed _ b .inflectional => b.stem
   | .suffixed b _ .inflectional => b.stem
-  | .infixed b _ _ .inflectional => b.stem
+  | .infixed b _ .inflectional => b.stem
   | .circumfixed _ b _ .inflectional => b.stem
   | w => w
 
-/-- The root morphemes: the leaves of the tree. A simplex word has one;
+/-- The root payloads: the leaves of the tree. A simplex word has one;
 a compound has one per constituent. -/
-def roots : Word.Structure → List Morpheme
+def roots : Word.Structure M → List M
   | .root m => [m]
   | .prefixed _ b _ => b.roots
   | .suffixed b _ _ => b.roots
-  | .infixed b _ _ _ => b.roots
+  | .infixed b _ _ => b.roots
   | .circumfixed _ b _ _ => b.roots
   | .compound l r => l.roots ++ r.roots
   | .reduplicated _ b => b.roots
   | .converted b => b.roots
 
 /-- A word with no inflection is its own stem. -/
-theorem stem_root (m : Morpheme) : (root m).stem = root m := rfl
+theorem stem_root (m : M) : (root m).stem = root m := rfl
 
 /-- Stripping inflection strips through stacked inflectional suffixes. -/
-theorem stem_suffixed_infl (b : Word.Structure) (afx : Morpheme) :
+theorem stem_suffixed_infl (b : Word.Structure M) (afx : M) :
     (suffixed b afx .inflectional).stem = b.stem := rfl
 
 /-- Derivational affixation is stem-internal. -/
-theorem stem_suffixed_deriv (b : Word.Structure) (afx : Morpheme) :
+theorem stem_suffixed_deriv (b : Word.Structure M) (afx : M) :
     (suffixed b afx .derivational).stem = suffixed b afx .derivational := rfl
-
-/-! ### The partial fold to morphs -/
-
-/-- Project concatenative word structure to its `Morph` sequence.
-**Partial**: `none` on infixation, circumfixation, and reduplication —
-morphs are continuous and segmental, so discontinuous and process
-morphology are constructions, not morph sequences. Conversion is
-morph-vacuous and projects through. -/
-def toExponent : Word.Structure → Option (List Morph)
-  | .root m => some [m.morph]
-  | .prefixed afx b _ => (b.toExponent).map (afx.morph :: ·)
-  | .suffixed b afx _ => (b.toExponent).map (· ++ [afx.morph])
-  | .compound l r => do pure ((← l.toExponent) ++ (← r.toExponent))
-  | .converted b => b.toExponent
-  | .infixed .. => none
-  | .circumfixed .. => none
-  | .reduplicated .. => none
-
-/-- The fold is total exactly on the concatenative fragment: a
-circumfixed word has no morph-sequence projection. -/
-theorem toExponent_circumfixed (pre suf : Morpheme)
-    (b : Word.Structure) (k : AffixKind) :
-    (circumfixed pre b suf k).toExponent = none := rfl
 
 end Word.Structure
 

--- a/Linglib/Morphology/Word/Structure.lean
+++ b/Linglib/Morphology/Word/Structure.lean
@@ -58,9 +58,10 @@ inductive AffixKind where
 
 /-! ### The structure tree -/
 
-/-- Hierarchical word structure as a tree of morphemes. Each constructor
-is a morphological operation; the tree records derivational history and
-word-internal constituency. -/
+/-- Hierarchical word structure as an operation-typed tree of morphemes:
+each constructor is a word-formation operation with its own arity and
+payload. The tree records derivational history and word-internal
+constituency — what applying the operations as functions would forget. -/
 inductive Word.Structure where
   /-- Leaf node: a single morpheme (free or bound). -/
   | root : Morpheme → Word.Structure

--- a/Linglib/Morphology/Word/Structure.lean
+++ b/Linglib/Morphology/Word/Structure.lean
@@ -7,26 +7,17 @@ import Linglib.Morphology.Morph
 
 /-!
 # Word-internal structure
-[hayes-2009] [booij-2012]
 
-Hierarchical representation of word-internal structure via the
-`Word.Structure` inductive type: a tree of morphemes where affixation,
-compounding, reduplication, and conversion are structural operations —
-the item-and-arrangement tree-of-morphemes lineage ([anderson-2015]
-pp. 28-29), with `reduplicated`/`converted` as process-constructor
-exceptions. Affixation constructors carry an `AffixKind` tag
-(inflectional vs derivational), which is what makes [booij-2012]'s
-relational notions computable as accessors: `base` (the immediate
-daughter), `stem` (the tree with outer inflectional affixation
-stripped), and `roots` (the leaf morphemes). The partial fold
-`toExponent` projects concatenative structure to a `Morph` sequence and
-is undefined on infixation, circumfixation, and reduplication — the
-partiality is [haspelmath-2020]'s thesis that discontinuous and
-process morphology are constructions, not morphs.
+A `Word.Structure` is a tree of morphemes whose constructors are the
+morphological operations: affixation, compounding, reduplication, and
+conversion ([hayes-2009]). Affixation carries an `AffixKind` tag, which
+makes [booij-2012]'s relational notions computable as the accessors
+`base`, `stem`, and `roots`. The partial fold `toExponent` projects
+concatenative structure to a `Morph` sequence.
 
-The token type (`Morphology.Word`, `Word/Basic.lean`) and this tree are
-deliberately separate: the token is what syntax sees, the tree is how
-morphology built it.
+The token type (`Morphology.Word`, `Word/Basic.lean`) is deliberately
+separate: the token is what syntax sees, the tree is how morphology
+built it.
 -/
 
 namespace Morphology

--- a/Linglib/Morphology/Word/Structure.lean
+++ b/Linglib/Morphology/Word/Structure.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Morphology.Morph
 
 /-!
@@ -24,26 +29,14 @@ deliberately separate: the token is what syntax sees, the tree is how
 morphology built it.
 -/
 
-
-
--- ============================================================================
--- Morphological Word Structure
--- ============================================================================
-
 namespace Morphology
 
+/-! ### Morphemes -/
 
--- ============================================================================
--- §1: Morpheme
--- ============================================================================
-
-/-- A morpheme: the classical "minimal meaningful unit" ([hayes-2009];
-[anderson-2015] problematizes the classical definition — this carrier
-keeps it as the descriptive convenience both textbooks use).
-
-Carries its form as a `Morph` (`Morphology/Morph.lean`) and an optional
-gloss; attachment is `morph.kind`. Finer wordhood classification
-(the [zwicky-pullum-1983] clitic–affix cline) is diagnostic, derived in
+/-- A morpheme: the classical "minimal meaningful unit", kept as the
+descriptive convenience the textbooks use. Carries its form as a `Morph`
+and an optional gloss; attachment is `morph.kind`. Finer wordhood
+classification (the clitic–affix cline) is diagnostic, derived in
 `Studies/ZwickyPullum1983.lean`, not stored here. -/
 structure Morpheme where
   morph  : Morph
@@ -53,41 +46,30 @@ structure Morpheme where
 /-- The surface string of a morpheme: its morph's segmental form. -/
 def Morpheme.surface (m : Morpheme) : String := m.morph.form
 
--- ============================================================================
--- §2: Reduplication Type
--- ============================================================================
+/-! ### Reduplication and affix kinds -/
 
-/-- Type of reduplication ([hayes-2009]).
-
-- `total`: copies the entire base (Warlpiri *kijikiji* from *kiji*)
-- `partialCopy copied`: copies a prosodic template; the copied material is
-  stored explicitly since it depends on prosodic shape (determined at
-  construction time, not derivable from strings alone).
-  Example: Ilokano *ag-tráb-trabáho* (partial copy *trab*). -/
+/-- The type of a reduplication step. -/
 inductive RedupType where
+  /-- Copies the entire base (Warlpiri *kijikiji* from *kiji*). -/
   | total
+  /-- Copies a prosodic template; the copied material is stored explicitly
+  since it depends on prosodic shape, determined at construction time
+  (Ilokano *ag-tráb-trabáho*, partial copy *trab*). -/
   | partialCopy (copied : String)
   deriving DecidableEq, Repr
 
--- ============================================================================
--- §3: Word.Structure — Hierarchical Word Structure
--- ============================================================================
-
-/-- Whether an affixation step is inflectional or derivational — the
-tag [booij-2012] requires on word-formation operations so that stems
-(inflection stripped) are computable from the tree. -/
+/-- Whether an affixation step is inflectional or derivational — the tag
+that makes stems (inflection stripped) computable from the tree. -/
 inductive AffixKind where
   | inflectional
   | derivational
   deriving DecidableEq, Repr
 
-/-- Hierarchical word structure as a tree of morphemes.
+/-! ### The structure tree -/
 
-Each constructor corresponds to a morphological operation from
-[hayes-2009]'s survey — the item-and-arrangement tree-of-morphemes
-lineage ([anderson-2015] pp. 28-29), with `reduplicated`/`converted` as
-process-constructor exceptions. The tree structure captures the
-derivational history and word-internal constituency. -/
+/-- Hierarchical word structure as a tree of morphemes. Each constructor
+is a morphological operation; the tree records derivational history and
+word-internal constituency. -/
 inductive Word.Structure where
   /-- Leaf node: a single morpheme (free or bound). -/
   | root : Morpheme → Word.Structure
@@ -109,12 +91,12 @@ inductive Word.Structure where
   | converted : Word.Structure → Word.Structure
   deriving Repr
 
--- ============================================================================
--- §4: Surface Form
--- ============================================================================
+namespace Word.Structure
 
-/-- Extract the flat surface string from the morphological tree. -/
-def Word.Structure.surface : Word.Structure → String
+/-! ### Surface form -/
+
+/-- The flat surface string of the morphological tree. -/
+def surface : Word.Structure → String
   | .root m => m.surface
   | .prefixed afx base _ => afx.surface ++ base.surface
   | .suffixed base afx _ => base.surface ++ afx.surface
@@ -129,16 +111,26 @@ def Word.Structure.surface : Word.Structure → String
     | .partialCopy copied => copied ++ base.surface
   | .converted base => base.surface
 
--- ============================================================================
--- §5: Morpheme Linearization & Boundaries
--- ============================================================================
+/-- Conversion preserves the surface form. -/
+theorem surface_converted (w : Word.Structure) :
+    (converted w).surface = w.surface := rfl
+
+/-- The surface form of a compound is the concatenation of its parts. -/
+theorem surface_compound (l r : Word.Structure) :
+    (compound l r).surface = l.surface ++ r.surface := rfl
+
+/-- Total reduplication doubles the surface form. -/
+theorem surface_reduplicated_total (w : Word.Structure) :
+    (reduplicated .total w).surface = w.surface ++ w.surface := rfl
+
+/-! ### Morpheme linearization and boundaries -/
 
 /-- Flatten the morphological tree into a list of morphemes. The order
 is left-to-right surface order for concatenative structure; an infix is
 appended after its base's morphemes (its *surface* position is `pos`,
 not its list position), and reduplicative copies contribute no morpheme.
 Morpheme boundaries are implicit: they fall between adjacent elements. -/
-def Word.Structure.morphemes : Word.Structure → List Morpheme
+def morphemes : Word.Structure → List Morpheme
   | .root m => [m]
   | .prefixed afx base _ => afx :: base.morphemes
   | .suffixed base afx _ => base.morphemes ++ [afx]
@@ -148,14 +140,16 @@ def Word.Structure.morphemes : Word.Structure → List Morpheme
   | .reduplicated _ base => base.morphemes
   | .converted base => base.morphemes
 
-/-- Number of morphemes in the word. -/
-def Word.Structure.morphemeCount (w : Word.Structure) : Nat := w.morphemes.length
+/-- The number of morphemes in the word. -/
+def morphemeCount (w : Word.Structure) : Nat := w.morphemes.length
 
-/-- Positions of morpheme boundaries in the surface string.
-Each `Nat` is a character offset where one morpheme ends and
-the next begins. Phonological rules can reference these
-positions ([hayes-2009]). -/
-def Word.Structure.boundaryPositions : Word.Structure → List Nat
+/-- A bare root contains exactly one morpheme. -/
+theorem morphemeCount_root (m : Morpheme) : (root m).morphemeCount = 1 := rfl
+
+/-- Positions of morpheme boundaries in the surface string. Each `Nat`
+is a character offset where one morpheme ends and the next begins;
+phonological rules can reference these positions. -/
+def boundaryPositions : Word.Structure → List Nat
   | .root _ => []
   | .prefixed afx base _ =>
     let offset := afx.surface.length
@@ -188,44 +182,42 @@ def Word.Structure.boundaryPositions : Word.Structure → List Nat
       copiedLen :: base.boundaryPositions.map (· + copiedLen)
   | .converted base => base.boundaryPositions
 
--- ============================================================================
--- §6: Structural Predicates
--- ============================================================================
+/-! ### Structural predicates -/
 
-/-- Is this word a bare root (single morpheme)? -/
-def Word.Structure.IsSimple : Word.Structure → Prop
+/-- A word is simple if it is a bare root. -/
+def IsSimple : Word.Structure → Prop
   | .root _ => True
   | _ => False
 
-instance : DecidablePred Word.Structure.IsSimple := fun w => by
-  cases w <;> unfold Word.Structure.IsSimple <;> infer_instance
+instance : DecidablePred IsSimple := fun w => by
+  cases w <;> unfold IsSimple <;> infer_instance
 
-/-- Is this word a compound? -/
-def Word.Structure.IsCompound : Word.Structure → Prop
+/-- A word is a compound if its outermost operation joins two stems. -/
+def IsCompound : Word.Structure → Prop
   | .compound _ _ => True
   | _ => False
 
-instance : DecidablePred Word.Structure.IsCompound := fun w => by
-  cases w <;> unfold Word.Structure.IsCompound <;> infer_instance
+instance : DecidablePred IsCompound := fun w => by
+  cases w <;> unfold IsCompound <;> infer_instance
 
-/-- Does this word involve reduplication? -/
-def Word.Structure.IsReduplicated : Word.Structure → Prop
+/-- A word is reduplicated if its outermost operation is reduplication. -/
+def IsReduplicated : Word.Structure → Prop
   | .reduplicated _ _ => True
   | _ => False
 
-instance : DecidablePred Word.Structure.IsReduplicated := fun w => by
-  cases w <;> unfold Word.Structure.IsReduplicated <;> infer_instance
+instance : DecidablePred IsReduplicated := fun w => by
+  cases w <;> unfold IsReduplicated <;> infer_instance
 
-/-- Is this word derived by conversion? -/
-def Word.Structure.IsConverted : Word.Structure → Prop
+/-- A word is converted if its outermost operation is conversion. -/
+def IsConverted : Word.Structure → Prop
   | .converted _ => True
   | _ => False
 
-instance : DecidablePred Word.Structure.IsConverted := fun w => by
-  cases w <;> unfold Word.Structure.IsConverted <;> infer_instance
+instance : DecidablePred IsConverted := fun w => by
+  cases w <;> unfold IsConverted <;> infer_instance
 
-/-- Morphological depth: number of derivational steps from the root(s). -/
-def Word.Structure.depth : Word.Structure → Nat
+/-- Morphological depth: the number of operations above the deepest root. -/
+def depth : Word.Structure → Nat
   | .root _ => 0
   | .prefixed _ base _ => 1 + base.depth
   | .suffixed base _ _ => 1 + base.depth
@@ -235,20 +227,20 @@ def Word.Structure.depth : Word.Structure → Nat
   | .reduplicated _ base => 1 + base.depth
   | .converted base => 1 + base.depth
 
+/-- A bare root has depth zero. -/
+theorem depth_root (m : Morpheme) : (root m).depth = 0 := rfl
 
--- ============================================================================
--- §7: Booij relational accessors
--- ============================================================================
+/-! ### Relational accessors
 
-/-! [booij-2012] treats root, stem, and base as *relational* notions over
-word structure, not stored lexical fields: the base is what an operation
-applied to, the stem is the word minus its inflection, roots are the
-unanalyzable leaves. -/
+Root, stem, and base are *relational* notions over word structure, not
+stored lexical fields: the base is what an operation applied to, the
+stem is the word minus its inflection, roots are the unanalyzable
+leaves. -/
 
-/-- The immediate base of the outermost operation ([booij-2012]): the
-daughter tree for affixation, reduplication, and conversion; `none` for
-a bare root and for compounds (which have two constituents, not a base). -/
-def Word.Structure.base : Word.Structure → Option Word.Structure
+/-- The immediate base of the outermost operation: the daughter tree for
+affixation, reduplication, and conversion; `none` for a bare root and
+for compounds (which have two constituents, not a base). -/
+def base : Word.Structure → Option Word.Structure
   | .root _ => none
   | .prefixed _ b _ => some b
   | .suffixed b _ _ => some b
@@ -258,19 +250,19 @@ def Word.Structure.base : Word.Structure → Option Word.Structure
   | .reduplicated _ b => some b
   | .converted b => some b
 
-/-- The stem ([booij-2012]): the tree with outer *inflectional*
-affixation stripped. Derivational structure, compounding, reduplication,
-and conversion are part of the stem. -/
-def Word.Structure.stem : Word.Structure → Word.Structure
+/-- The stem: the tree with outer *inflectional* affixation stripped.
+Derivational structure, compounding, reduplication, and conversion are
+part of the stem. -/
+def stem : Word.Structure → Word.Structure
   | .prefixed _ b .inflectional => b.stem
   | .suffixed b _ .inflectional => b.stem
   | .infixed b _ _ .inflectional => b.stem
   | .circumfixed _ b _ .inflectional => b.stem
   | w => w
 
-/-- The root morphemes ([booij-2012]): the leaves of the tree. A simplex
-word has one; a compound has one per constituent. -/
-def Word.Structure.roots : Word.Structure → List Morpheme
+/-- The root morphemes: the leaves of the tree. A simplex word has one;
+a compound has one per constituent. -/
+def roots : Word.Structure → List Morpheme
   | .root m => [m]
   | .prefixed _ b _ => b.roots
   | .suffixed b _ _ => b.roots
@@ -281,29 +273,24 @@ def Word.Structure.roots : Word.Structure → List Morpheme
   | .converted b => b.roots
 
 /-- A word with no inflection is its own stem. -/
-theorem Word.Structure.stem_root (m : Morpheme) :
-    (Word.Structure.root m).stem = .root m := rfl
+theorem stem_root (m : Morpheme) : (root m).stem = root m := rfl
 
 /-- Stripping inflection strips through stacked inflectional suffixes. -/
-theorem Word.Structure.stem_suffixed_infl (b : Word.Structure) (afx : Morpheme) :
-    (Word.Structure.suffixed b afx .inflectional).stem = b.stem := rfl
+theorem stem_suffixed_infl (b : Word.Structure) (afx : Morpheme) :
+    (suffixed b afx .inflectional).stem = b.stem := rfl
 
 /-- Derivational affixation is stem-internal. -/
-theorem Word.Structure.stem_suffixed_deriv (b : Word.Structure) (afx : Morpheme) :
-    (Word.Structure.suffixed b afx .derivational).stem
-      = .suffixed b afx .derivational := rfl
+theorem stem_suffixed_deriv (b : Word.Structure) (afx : Morpheme) :
+    (suffixed b afx .derivational).stem = suffixed b afx .derivational := rfl
 
--- ============================================================================
--- §8: The partial fold to exponents
--- ============================================================================
+/-! ### The partial fold to morphs -/
 
-/-- Project concatenative word structure to its `Morph` sequence
-(a `Morph` list). **Partial**: `none` on infixation, circumfixation, and
-reduplication — [haspelmath-2020]'s thesis that morphs are continuous
-and segmental, so discontinuous and process morphology are
-constructions, not morph sequences. Conversion is morph-vacuous and
-projects through. -/
-def Word.Structure.toExponent : Word.Structure → Option (List Morph)
+/-- Project concatenative word structure to its `Morph` sequence.
+**Partial**: `none` on infixation, circumfixation, and reduplication —
+morphs are continuous and segmental, so discontinuous and process
+morphology are constructions, not morph sequences. Conversion is
+morph-vacuous and projects through. -/
+def toExponent : Word.Structure → Option (List Morph)
   | .root m => some [m.morph]
   | .prefixed afx b _ => (b.toExponent).map (afx.morph :: ·)
   | .suffixed b afx _ => (b.toExponent).map (· ++ [afx.morph])
@@ -315,42 +302,10 @@ def Word.Structure.toExponent : Word.Structure → Option (List Morph)
 
 /-- The fold is total exactly on the concatenative fragment: a
 circumfixed word has no morph-sequence projection. -/
-theorem Word.Structure.toExponent_circumfixed (pre suf : Morpheme)
+theorem toExponent_circumfixed (pre suf : Morpheme)
     (b : Word.Structure) (k : AffixKind) :
-    (Word.Structure.circumfixed pre b suf k).toExponent = none := rfl
+    (circumfixed pre b suf k).toExponent = none := rfl
 
--- ============================================================================
--- §9: Verification Theorems
--- ============================================================================
-
--- Surface form
-
-/-- Conversion preserves the surface form. -/
-theorem conversion_preserves_surface (w : Word.Structure) :
-    (Word.Structure.converted w).surface = w.surface := by
-  simp only [Word.Structure.surface]
-
-/-- The surface form of a compound is the concatenation of its parts. -/
-theorem compound_surface (l r : Word.Structure) :
-    (Word.Structure.compound l r).surface = l.surface ++ r.surface := by
-  simp only [Word.Structure.surface]
-
-/-- Total reduplication doubles the surface form. -/
-theorem total_redup_surface (w : Word.Structure) :
-    (Word.Structure.reduplicated .total w).surface
-      = w.surface ++ w.surface := by
-  simp only [Word.Structure.surface]
-
--- Structure
-
-/-- A bare root has depth zero. -/
-theorem root_depth_zero (m : Morpheme) :
-    (Word.Structure.root m).depth = 0 := by
-  simp only [Word.Structure.depth]
-
-/-- A bare root contains exactly one morpheme. -/
-theorem root_morphemeCount_one (m : Morpheme) :
-    (Word.Structure.root m).morphemeCount = 1 := by
-  simp only [Word.Structure.morphemeCount, Word.Structure.morphemes, List.length]
+end Word.Structure
 
 end Morphology

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -42,7 +42,7 @@ grammatical tones targeting ideophones in Mwaghavul. *Natural Language
 
 ## Substrate
 
-The OT analysis is built on `Autosegmental.FloatingForm Syl TRN Morpheme`
+The OT analysis is built on `Autosegmental.FloatingForm Syl TRN Morph`
 (Goldsmith-style autosegmental representation; built originally for
 [mcpherson-lamont-2026]). Each `ulTier` entry is one
 autosegment; `surfaceLinks` records associations between tier and
@@ -74,7 +74,7 @@ namespace AkinboFwangwar2026
 open OptimalityTheory
 open Constraints
 open Autosegmental
-open Morphology (Morpheme)
+open Morphology (Morph)
 open Tone (TRN)
 open Tone (integrityTone)
 open Mwaghavul
@@ -84,46 +84,46 @@ open Mwaghavul
 -- ============================================================================
 
 /-- The Mwaghavul-instantiated autosegmental form. -/
-abbrev MwaghavulForm := FloatingForm Syl TRN Morpheme
+abbrev MwaghavulForm := FloatingForm Syl TRN Morph
 
 /-- The ideophone root (wùlàʃ in Tableau 24, háŋláyáp in Tableau 25).
     Both single-root tableaux share this morpheme. -/
-def rootMorph : Morpheme := { morph := .root "root" }
+def rootMorph : Morph := .root "root"
 
 /-- The verbaliser. The M-tone verbaliser (Tableau 24) and the M-H
     verbaliser (Tableaux 25/26) share this morpheme — they're suppletive
     allomorphs of the same verbaliser per paper p. 20 eq. (17). -/
-def vbzMorph : Morpheme := { morph := .root "vbz" }
+def vbzMorph : Morph := .root "vbz"
 
 /-- The reduplicant root in pluractional Tableau 26. -/
-def rootRedMorph : Morpheme := { morph := .root "root-red" }
+def rootRedMorph : Morph := .root "root-red"
 
 /-- The base root in pluractional Tableau 26. -/
-def rootBaseMorph : Morpheme := { morph := .root "root-base" }
+def rootBaseMorph : Morph := .root "root-base"
 
 /-- Wrap a Mwaghavul syllable as a TBU of the (single) ideophone root. -/
-def rootSeg (s : Syl) : SegSpec Syl Morpheme := { seg := s, morpheme := rootMorph }
+def rootSeg (s : Syl) : SegSpec Syl Morph := { seg := s, morpheme := rootMorph }
 
 /-- Wrap a syllable as a TBU of the reduplicant (Tableau 26). -/
-def redSeg (s : Syl) : SegSpec Syl Morpheme := { seg := s, morpheme := rootRedMorph }
+def redSeg (s : Syl) : SegSpec Syl Morph := { seg := s, morpheme := rootRedMorph }
 
 /-- Wrap a syllable as a TBU of the base (Tableau 26). -/
-def baseSeg (s : Syl) : SegSpec Syl Morpheme := { seg := s, morpheme := rootBaseMorph }
+def baseSeg (s : Syl) : SegSpec Syl Morph := { seg := s, morpheme := rootBaseMorph }
 
 /-- L tone of the (single) ideophone root. -/
-def rootL : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootMorph }
+def rootL : TierSpec TRN Morph := { value := TRN.L, morpheme := rootMorph }
 
 /-- M tone of the verbaliser. -/
-def vbzM : TierSpec TRN Morpheme := { value := TRN.M, morpheme := vbzMorph }
+def vbzM : TierSpec TRN Morph := { value := TRN.M, morpheme := vbzMorph }
 
 /-- H tone of the verbaliser. -/
-def vbzH : TierSpec TRN Morpheme := { value := TRN.H, morpheme := vbzMorph }
+def vbzH : TierSpec TRN Morph := { value := TRN.H, morpheme := vbzMorph }
 
 /-- L tone of the reduplicant root (Tableau 26). -/
-def lRed : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootRedMorph }
+def lRed : TierSpec TRN Morph := { value := TRN.L, morpheme := rootRedMorph }
 
 /-- L tone of the base root (Tableau 26). -/
-def lBase : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootBaseMorph }
+def lBase : TierSpec TRN Morph := { value := TRN.L, morpheme := rootBaseMorph }
 
 -- ============================================================================
 -- §2: Constraints over `MwaghavulForm`
@@ -142,20 +142,20 @@ def lBase : TierSpec TRN Morpheme := { value := TRN.L, morpheme := rootBaseMorph
 section SingleRoot
 
 /-- Does TBU `i` bear a tone of value `t` from morpheme `m`? -/
-def isGramTbu (t : TRN) (m : Morpheme) (f : MwaghavulForm) (i : SegIdx) : Bool :=
+def isGramTbu (t : TRN) (m : Morph) (f : MwaghavulForm) (i : SegIdx) : Bool :=
   (f.linksTo i).any fun k =>
     (f.upper.get? k).any fun ts => decide (ts.value = t ∧ ts.morpheme = m)
 
 /-- L-ANCHOR-`t`-from-`m`: number of TBUs (in tier order) before the
     leftmost gram-`t`-from-`m` TBU. If no such TBU exists, every TBU
     counts (full TBU count). -/
-def lAnchTone (t : TRN) (m : Morpheme) (f : MwaghavulForm) : Nat :=
+def lAnchTone (t : TRN) (m : Morph) (f : MwaghavulForm) : Nat :=
   match (List.range f.lower.len).findIdx? (isGramTbu t m f) with
   | some i => i
   | none   => f.lower.len
 
 /-- R-ANCHOR-`t`-from-`m`: counted from the right edge. -/
-def rAnchTone (t : TRN) (m : Morpheme) (f : MwaghavulForm) : Nat :=
+def rAnchTone (t : TRN) (m : Morph) (f : MwaghavulForm) : Nat :=
   match (List.range f.lower.len).reverse.findIdx? (isGramTbu t m f) with
   | some i => i
   | none   => f.lower.len
@@ -166,11 +166,11 @@ def maxToneAuto (f : MwaghavulForm) : Nat :=
   f.countUpper f.IsDeleted
 
 /-- L-ANCHOR-Mᵥ as a `Constraint`. -/
-def lAnchToneC (t : TRN) (m : Morpheme) : Constraint MwaghavulForm :=
+def lAnchToneC (t : TRN) (m : Morph) : Constraint MwaghavulForm :=
   lAnchTone t m
 
 /-- R-ANCHOR-Mᵥ as a `Constraint`. -/
-def rAnchToneC (t : TRN) (m : Morpheme) : Constraint MwaghavulForm :=
+def rAnchToneC (t : TRN) (m : Morph) : Constraint MwaghavulForm :=
   rAnchTone t m
 
 /-- MAX-Tone as a `Constraint`. -/
@@ -199,14 +199,14 @@ section PerRoot
 
 /-- A gram-`t`-from-`m` tone is realised on root `rm` iff some TBU of
     `rm` bears one. -/
-def isRealisedOnRoot (t : TRN) (m : Morpheme) (rm : Morpheme)
+def isRealisedOnRoot (t : TRN) (m : Morph) (rm : Morph)
     (f : MwaghavulForm) : Bool :=
   (f.segsOfMorpheme rm).any (isGramTbu t m f)
 
 /-- L-ANCHOR scoped to root `rm`. 0 if `t`-from-`m` not realised on
     `rm` (per paper p. 28: "no violation to the other root morpheme");
     else count TBUs of `rm` before the leftmost gram-`t` TBU of `rm`. -/
-def lAnchTonePerRoot (t : TRN) (m : Morpheme) (rm : Morpheme)
+def lAnchTonePerRoot (t : TRN) (m : Morph) (rm : Morph)
     (f : MwaghavulForm) : Nat :=
   if isRealisedOnRoot t m rm f then
     match (f.segsOfMorpheme rm).findIdx? (isGramTbu t m f) with
@@ -215,7 +215,7 @@ def lAnchTonePerRoot (t : TRN) (m : Morpheme) (rm : Morpheme)
   else 0
 
 /-- R-ANCHOR scoped to root `rm`. -/
-def rAnchTonePerRoot (t : TRN) (m : Morpheme) (rm : Morpheme)
+def rAnchTonePerRoot (t : TRN) (m : Morph) (rm : Morph)
     (f : MwaghavulForm) : Nat :=
   if isRealisedOnRoot t m rm f then
     match (f.segsOfMorpheme rm).reverse.findIdx? (isGramTbu t m f) with
@@ -226,7 +226,7 @@ def rAnchTonePerRoot (t : TRN) (m : Morpheme) (rm : Morpheme)
 /-- L-ANCHOR summed across a list of root morphemes. If the gram tone
     is not realised on ANY of the roots, paper p. 28 assigns one
     violation per TBU of every targeted root (not 0). -/
-def lAnchToneAcrossRoots (t : TRN) (m : Morpheme) (rms : List Morpheme)
+def lAnchToneAcrossRoots (t : TRN) (m : Morph) (rms : List Morph)
     (f : MwaghavulForm) : Nat :=
   if rms.any (fun rm => isRealisedOnRoot t m rm f) then
     rms.foldl (fun acc rm => acc + lAnchTonePerRoot t m rm f) 0
@@ -234,7 +234,7 @@ def lAnchToneAcrossRoots (t : TRN) (m : Morpheme) (rms : List Morpheme)
     rms.foldl (fun acc rm => acc + (f.segsOfMorpheme rm).length) 0
 
 /-- R-ANCHOR summed across a list of root morphemes. -/
-def rAnchToneAcrossRoots (t : TRN) (m : Morpheme) (rms : List Morpheme)
+def rAnchToneAcrossRoots (t : TRN) (m : Morph) (rms : List Morph)
     (f : MwaghavulForm) : Nat :=
   if rms.any (fun rm => isRealisedOnRoot t m rm f) then
     rms.foldl (fun acc rm => acc + rAnchTonePerRoot t m rm f) 0
@@ -242,12 +242,12 @@ def rAnchToneAcrossRoots (t : TRN) (m : Morpheme) (rms : List Morpheme)
     rms.foldl (fun acc rm => acc + (f.segsOfMorpheme rm).length) 0
 
 /-- L-ANCHOR-`t`-from-`m`-across-roots as a `Constraint`. -/
-def lAnchToneCAcross (t : TRN) (m : Morpheme) (rms : List Morpheme) :
+def lAnchToneCAcross (t : TRN) (m : Morph) (rms : List Morph) :
     Constraint MwaghavulForm :=
   lAnchToneAcrossRoots t m rms
 
 /-- R-ANCHOR across roots as a `Constraint`. -/
-def rAnchToneCAcross (t : TRN) (m : Morpheme) (rms : List Morpheme) :
+def rAnchToneCAcross (t : TRN) (m : Morph) (rms : List Morph) :
     Constraint MwaghavulForm :=
   rAnchToneAcrossRoots t m rms
 

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -283,11 +283,11 @@ theorem manipulative_selects_ki :
 
 /-- The negative circumfix surfaces correctly for a sample verb. -/
 theorem neg_circumfix_realize :
-    (negCircumfix "mäs'ə").surface = "ʔay-mäs'ə-n" := rfl
+    String.join ((negCircumfix "mäs'ə").toList.map (·.1.form)) = "ʔay-mäs'ə-n" := rfl
 
 /-- The circumfix parts' glosses derive from the fragment entry. -/
 theorem neg_circumfix_from_neg :
-    ((negCircumfix "mäs'ə").morphemes.map Morphology.Morpheme.gloss)
+    ((negCircumfix "mäs'ə").toList.map Prod.snd)
       = [ay_n.gloss, "", ay_n.gloss] := rfl
 
 /-- All four prefix heads are in the verbal extended projection. -/

--- a/Linglib/Studies/LaoideKemp2026.lean
+++ b/Linglib/Studies/LaoideKemp2026.lean
@@ -46,7 +46,7 @@ Segment` — the project's floating-autosegmental substrate, which
 [laoide-kemp-2026]'s floating consonants are a named motivating
 consumer of. Three substrate features carry the analysis directly:
 
-* **Morpheme membership** on every tier/backbone element distinguishes
+* **Morph membership** on every tier/backbone element distinguishes
   the historic-tense `(d)`, the verb stem, and the past-tense
   impersonal exponent.
 * The **underlying/surface split** (`links` vs `surfaceLinks`) models
@@ -112,7 +112,7 @@ is modelled as a genuine floating melodic segment (`Segment.dPrime`).
 namespace LaoideKemp2026
 
 open Autosegmental
-open Morphology (Morpheme)
+open Morphology (Morph)
 
 /-! ## §1 Segment inventory and CV skeleton
 
@@ -176,18 +176,18 @@ the verb stem (a free word), the historic-tense exponent `HIST`
 -/
 
 /-- The verb-stem morpheme (a free word), keyed by orthographic form. -/
-private def mStem (s : String) : Morpheme := { morph := .root s, gloss := "" }
+private def mStem (s : String) : Morph := .root s
 
 /-- The historic-tense exponent, bearing floating `(d)` and `{L}`. -/
-private def mHist : Morpheme := { morph := .pref "d'", gloss := "HIST" }
+private def mHist : Morph := .pref "d'"
 
 /-- The past-tense impersonal exponent: an empty CV unit at the left
     edge ([laoide-kemp-2026] §6.2, Fig. 5). -/
-private def mImpers : Morpheme := { morph := .pref "", gloss := "PST.IMPERS" }
+private def mImpers : Morph := .pref ""
 
 /-! ## §3 Verb stems as `FloatingForm`s
 
-A verb stem is a `FloatingForm CVKind Segment Morpheme`: the **upper** tier is
+A verb stem is a `FloatingForm CVKind Segment Morph`: the **upper** tier is
 the segmental melody (`Segment`), the **lower** tier is the CV
 skeleton (`CVKind`), and association lines `(k, j)` link melody
 element `k` to skeleton position `j`. The surface state mirrors the
@@ -195,23 +195,23 @@ underlying state on input (`FloatingForm.mkInput`).
 -/
 
 /-- A melodic tier element bearing morpheme `m`. -/
-private def mel (s : Segment) (m : Morpheme) : TierSpec Segment Morpheme := ⟨s, m⟩
+private def mel (s : Segment) (m : Morph) : TierSpec Segment Morph := ⟨s, m⟩
 
 /-- A skeletal backbone slot bearing morpheme `m`. -/
-private def slot (c : CVKind) (m : Morpheme) : SegSpec CVKind Morpheme := ⟨c, m⟩
+private def slot (c : CVKind) (m : Morph) : SegSpec CVKind Morph := ⟨c, m⟩
 
 /-- Build a single-morpheme verb stem from its CV skeleton, melody,
     and association lines. -/
 private def stemForm (name : String) (skeleton : List CVKind)
     (melody : List Segment) (links : Finset (Nat × Nat)) :
-    FloatingForm CVKind Segment Morpheme :=
+    FloatingForm CVKind Segment Morph :=
   let m := mStem name
   FloatingForm.mkInput (skeleton.map (slot · m)) (melody.map (mel · m)) links
 
 /-- The verb `bog` 'soft', the C-initial example in [laoide-kemp-2026]
     Fig. 1a. Melody = [b, o, g]; skeleton = [C, V, C]; identity
     associations. -/
-def bog : FloatingForm CVKind Segment Morpheme :=
+def bog : FloatingForm CVKind Segment Morph :=
   stemForm "bog" [.C, .V, .C] [.b, .o, .g] {(0, 0), (1, 1), (2, 2)}
 
 /-- The verb `ól` 'drink', the V-initial example in
@@ -219,7 +219,7 @@ def bog : FloatingForm CVKind Segment Morpheme :=
     [C, V, C, V]; the initial C-slot has no melodic association.
     This is the key structural property: the underlying form has an
     empty C-slot at position 0. -/
-def ól : FloatingForm CVKind Segment Morpheme :=
+def ól : FloatingForm CVKind Segment Morph :=
   stemForm "ol" [.C, .V, .C, .V] [.ó, .l] {(0, 1), (1, 2)}
 
 /-- The verb `fág` 'leave', the *f*-initial example in
@@ -227,7 +227,7 @@ def ól : FloatingForm CVKind Segment Morpheme :=
     [C, V, C]; identity associations. Under lenition, the `f`
     segmental content deletes, leaving an empty C₁-slot — exactly
     the configuration that licenses `(d)`-docking. -/
-def fág : FloatingForm CVKind Segment Morpheme :=
+def fág : FloatingForm CVKind Segment Morph :=
   stemForm "fag" [.C, .V, .C] [.f, .á, .g] {(0, 0), (1, 1), (2, 2)}
 
 /-! ## §4 The exponents and morpheme composition
@@ -242,7 +242,7 @@ association lines by the prefix's tier lengths.
 
 /-- The historic-tense exponent: a floating `(d)` melodic segment,
     no skeleton, no associations ([laoide-kemp-2026] Fig. 1). -/
-def historicExponent : FloatingForm CVKind Segment Morpheme where
+def historicExponent : FloatingForm CVKind Segment Morph where
   upper := .ofList [mel .dPrime mHist]
   lower := .empty
   links := ∅
@@ -252,7 +252,7 @@ def historicExponent : FloatingForm CVKind Segment Morpheme where
 /-- The past-tense impersonal exponent: an empty CV unit (`[C, V]`
     skeleton), no melody, no associations ([laoide-kemp-2026] §6.2,
     Fig. 5). -/
-def impersonalExponent : FloatingForm CVKind Segment Morpheme where
+def impersonalExponent : FloatingForm CVKind Segment Morph where
   upper := .empty
   lower := .ofList [slot .C mImpers, slot .V mImpers]
   links := ∅
@@ -261,13 +261,13 @@ def impersonalExponent : FloatingForm CVKind Segment Morpheme where
 
 /-- Prefix the historic-tense exponent onto a stem (Fig. 1): floating
     `(d)` becomes melody index 0; the stem's melody shifts right by one. -/
-def withHist (stem : FloatingForm CVKind Segment Morpheme) : FloatingForm CVKind Segment Morpheme :=
+def withHist (stem : FloatingForm CVKind Segment Morph) : FloatingForm CVKind Segment Morph :=
   historicExponent.hconcat stem
 
 /-- Prefix the empty-CV impersonal exponent onto a stem (Fig. 5): the
     stem's skeleton shifts right by two, so the left edge is an empty
     `C₀V₀` unit. -/
-def withImpers (stem : FloatingForm CVKind Segment Morpheme) : FloatingForm CVKind Segment Morpheme :=
+def withImpers (stem : FloatingForm CVKind Segment Morph) : FloatingForm CVKind Segment Morph :=
   impersonalExponent.hconcat stem
 
 /-! ## §5 Lenition: the `{L}` deletion rule for *f*
@@ -291,14 +291,14 @@ so `{L}` cannot reach it and the *f* stays unmutated.
 
 /-- The melody index of the consonant linked to the leftmost skeletal
     slot (skeleton position 0), if any — the target of `{L}`. -/
-def initialConsonantIdx (f : FloatingForm CVKind Segment Morpheme) : Option Nat :=
+def initialConsonantIdx (f : FloatingForm CVKind Segment Morph) : Option Nat :=
   (List.range f.upper.len).find? (fun k => (k, 0) ∈ f.surfaceLinks)
 
 /-- Apply lenition: if the consonant on the leftmost skeletal slot is
     `f`, delete its melodic content on the surface (leaving the slot
     surface-empty). All other surface effects of lenition (b → v, etc.)
     are out of scope for the *d'* distribution question. -/
-def lenite (f : FloatingForm CVKind Segment Morpheme) : FloatingForm CVKind Segment Morpheme :=
+def lenite (f : FloatingForm CVKind Segment Morph) : FloatingForm CVKind Segment Morph :=
   match initialConsonantIdx f with
   | some k => if (f.upper.get? k).map TierSpec.value = some .f then f.deleteTierElem k else f
   | none   => f
@@ -314,36 +314,36 @@ linking convention.
 -/
 
 /-- Skeleton position `j` is a C-slot. -/
-def isCSlot (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Prop :=
+def isCSlot (f : FloatingForm CVKind Segment Morph) (j : Nat) : Prop :=
   (f.lower.get? j).map SegSpec.seg = some .C
 
-instance (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Decidable (isCSlot f j) :=
+instance (f : FloatingForm CVKind Segment Morph) (j : Nat) : Decidable (isCSlot f j) :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- Skeleton position `j` is a V-slot. -/
-def isVSlot (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Prop :=
+def isVSlot (f : FloatingForm CVKind Segment Morph) (j : Nat) : Prop :=
   (f.lower.get? j).map SegSpec.seg = some .V
 
-instance (f : FloatingForm CVKind Segment Morpheme) (j : Nat) : Decidable (isVSlot f j) :=
+instance (f : FloatingForm CVKind Segment Morph) (j : Nat) : Decidable (isVSlot f j) :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- The configuration that licenses `(d)`-docking, evaluated on the
     surface graph: position 0 is an empty C-slot, position 1 is a
     non-empty V-slot. The structural predicate at the heart of the
     paper's analysis ([laoide-kemp-2026] §4.1). -/
-def dDockable (f : FloatingForm CVKind Segment Morpheme) : Prop :=
+def dDockable (f : FloatingForm CVKind Segment Morph) : Prop :=
   isCSlot f 0 ∧ ¬ f.SurfaceLinkedLower 0 ∧
     isVSlot f 1 ∧ f.SurfaceLinkedLower 1
 
-instance (f : FloatingForm CVKind Segment Morpheme) : Decidable (dDockable f) :=
+instance (f : FloatingForm CVKind Segment Morph) : Decidable (dDockable f) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _))
 
 /-- `(d)` surfaces in the historic-tense form `f` iff the post-lenition
     surface form is `(d)`-dockable. [laoide-kemp-2026] §4.1. -/
-def dPrimeSurfaces (f : FloatingForm CVKind Segment Morpheme) : Prop :=
+def dPrimeSurfaces (f : FloatingForm CVKind Segment Morph) : Prop :=
   dDockable (lenite f)
 
-instance (f : FloatingForm CVKind Segment Morpheme) : Decidable (dPrimeSurfaces f) :=
+instance (f : FloatingForm CVKind Segment Morph) : Decidable (dPrimeSurfaces f) :=
   inferInstanceAs (Decidable (dDockable _))
 
 /-! ## §7 Worked examples (paper Figs. 1a, 1b, 1c)
@@ -438,21 +438,21 @@ dissolved). -/
     content of "morphosyntax *concatenates* the floating morpheme"
     ([bermudez-otero-2012]'s strict modularity) — not a non-local
     insertion rule. -/
-theorem withHist_eq_concat (stem : FloatingForm CVKind Segment Morpheme) :
+theorem withHist_eq_concat (stem : FloatingForm CVKind Segment Morph) :
     withHist stem = historicExponent.hconcat stem := rfl
 
 /-- Composing the historic-tense morpheme preserves autosegmental
     well-formedness — a direct consequence of the No-Crossing
     Constraint being morpheme-modular. The floating `(d)` shifts the
     stem's links monotonically, never creating a crossing line. -/
-theorem withHist_isPlanar (stem : FloatingForm CVKind Segment Morpheme)
+theorem withHist_isPlanar (stem : FloatingForm CVKind Segment Morph)
     (hP : IsNonCrossing stem.links) : IsNonCrossing (withHist stem).links := by
   rw [withHist_eq_concat, FloatingForm.hconcat_links]
   simp only [historicExponent, Finset.empty_union]
   exact hP.image_monotone (ρ := (· + 1)) fun _ _ h => Nat.add_le_add_right h 1
 
 /-- A concrete suffix used to probe right-insensitivity. -/
-private def someSuffix : FloatingForm CVKind Segment Morpheme :=
+private def someSuffix : FloatingForm CVKind Segment Morph :=
   stemForm "ma" [.C, .V] [.m, .a] {(0, 0), (1, 1)}
 
 /-- **Left-edge locality (no look-ahead), concrete witness.** Appending
@@ -480,7 +480,7 @@ alone — the formal content of strict modularity (no look-ahead). -/
 /-- Surface-linkedness of skeletal slot `j` on a historic-tense form
     reduces to the stem having an underlying link to `j`: the floating
     `(d)` shifts melody indices only, never skeletal ones. -/
-private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment Morpheme) (j : Nat) :
+private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment Morph) (j : Nat) :
     (withHist X).SurfaceLinkedLower j ↔ ∃ a, (a, j) ∈ X.links := by
   have hlinks : (withHist X).surfaceLinks = X.links.image (shiftLink 1 0) := by
     rw [withHist_eq_concat, FloatingForm.hconcat_surfaceLinks]
@@ -503,7 +503,7 @@ private theorem isLinkedLower_withHist (X : FloatingForm CVKind Segment Morpheme
 /-- A link to a low skeletal slot (`j < stem.lower.len`) is unaffected
     by appending a suffix: the suffix's links are shifted to slots
     `≥ stem.lower.len`, never reaching `j`. -/
-private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment Morpheme) {j : Nat}
+private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment Morph) {j : Nat}
     (hj : j < stem.lower.len) :
     (∃ a, (a, j) ∈ (stem.hconcat suffix).links) ↔
       ∃ a, (a, j) ∈ stem.links := by
@@ -524,14 +524,14 @@ private theorem linked_concat_low (stem suffix : FloatingForm CVKind Segment Mor
 
 /-- The skeletal (lower) tier of a historic form is the stem's — the
     floating `(d)` contributes no skeletal slot. -/
-private theorem withHist_lower (Y : FloatingForm CVKind Segment Morpheme) :
+private theorem withHist_lower (Y : FloatingForm CVKind Segment Morph) :
     (withHist Y).lower = Y.lower := by
   rw [withHist_eq_concat, FloatingForm.hconcat_lower]
   exact LabeledTuple.empty_concat Y.lower
 
 /-- The melodic (upper) tier of a historic form is `(d)` concatenated with the
     stem's — used to compute upper-tier lengths in the locality proofs. -/
-private theorem withHist_upper (Y : FloatingForm CVKind Segment Morpheme) :
+private theorem withHist_upper (Y : FloatingForm CVKind Segment Morph) :
     (withHist Y).upper = historicExponent.upper.concat Y.upper := by
   rw [withHist_eq_concat, FloatingForm.hconcat_upper]
 
@@ -544,7 +544,7 @@ private theorem withHist_upper (Y : FloatingForm CVKind Segment Morpheme) :
     `dPrimeSurfaces` additionally requires `{L}`-docking to be left-local,
     which holds for in-bounds stems; this is the configuration-level
     statement, on which it rests.) -/
-theorem dDockable_withHist_concat_right (stem suffix : FloatingForm CVKind Segment Morpheme)
+theorem dDockable_withHist_concat_right (stem suffix : FloatingForm CVKind Segment Morph)
     (h2 : 2 ≤ stem.lower.len) :
     dDockable (withHist ((stem.hconcat suffix))) ↔
       dDockable (withHist stem) := by
@@ -578,7 +578,7 @@ range, and `lenite` could target different indices. -/
     present in the suffixed form iff present in the stem's — the
     pointwise (per `(k, j)`) version of `linked_concat_low`, used both
     for `initialConsonantIdx` and after `deleteTierElem`. -/
-private theorem mem_surfaceLinks_concat (stem suffix : FloatingForm CVKind Segment Morpheme)
+private theorem mem_surfaceLinks_concat (stem suffix : FloatingForm CVKind Segment Morph)
     {k j : Nat} (hj : j < stem.lower.len) :
     (k, j) ∈ (withHist ((stem.hconcat suffix))).surfaceLinks ↔
       (k, j) ∈ (withHist stem).surfaceLinks := by
@@ -623,7 +623,7 @@ private theorem find?_range_stable {p : Nat → Bool} {m n : Nat} (hmn : m ≤ n
     the slot-0 search predicate agrees (`mem_surfaceLinks_concat`) and,
     by `InBounds`, the stem's slot-0 links sit inside its own melody
     range, so the longer suffixed search finds no extra match. -/
-private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Segment Morpheme)
+private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Segment Morph)
     (h2 : 2 ≤ stem.lower.len) (hib : stem.InBounds) :
     initialConsonantIdx (withHist ((stem.hconcat suffix)))
       = initialConsonantIdx (withHist stem) := by
@@ -660,7 +660,7 @@ private theorem initialConsonantIdx_concat (stem suffix : FloatingForm CVKind Se
 /-- The docking configuration is right-local even after `lenite` deletes
     melody index `k`: `deleteTierElem k` only filters `surfaceLinks` and
     leaves the lower tier, so the slot-0/1 agreement survives. -/
-private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKind Segment Morpheme)
+private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKind Segment Morph)
     (h2 : 2 ≤ stem.lower.len) (k : Nat) :
     dDockable ((withHist ((stem.hconcat suffix))).deleteTierElem k) ↔
       dDockable ((withHist stem).deleteTierElem k) := by
@@ -700,7 +700,7 @@ private theorem dDockable_deleteTierElem_concat (stem suffix : FloatingForm CVKi
     `InBounds`) are left-local, so the full predicate is too. This is
     the paper's central claim, in full: preverbal *d'* never looks
     rightward past the word it attaches to. -/
-theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind Segment Morpheme)
+theorem dPrimeSurfaces_withHist_concat_right (stem suffix : FloatingForm CVKind Segment Morph)
     (h2 : 2 ≤ stem.lower.len) (hib : stem.InBounds) :
     dPrimeSurfaces (withHist ((stem.hconcat suffix))) ↔
       dPrimeSurfaces (withHist stem) := by
@@ -755,10 +755,10 @@ extensional content (no look-ahead) is fully captured by
     representations: one floating `(d)` melody node, no skeleton, no links. -/
 def historicExponentRep :
     AR (Sigma.fst :
-      ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool) :=
+      ((b : Bool) × TwoTier (TierSpec Segment Morph) (SegSpec CVKind Morph) b) → Bool) :=
   AR.ofData
     (fun b => match b with
-      | true => ([mel .dPrime mHist] : List (TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) true))
+      | true => ([mel .dPrime mHist] : List (TwoTier (TierSpec Segment Morph) (SegSpec CVKind Morph) true))
       | false => [])
     ⊥
 
@@ -770,9 +770,9 @@ open CategoryTheory MonoidalCategory in
     preverbal particle. -/
 def withHistFunctor :
     AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool) ⥤
+        ((b : Bool) × TwoTier (TierSpec Segment Morph) (SegSpec CVKind Morph) b) → Bool) ⥤
     AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool) :=
+        ((b : Bool) × TwoTier (TierSpec Segment Morph) (SegSpec CVKind Morph) b) → Bool) :=
   tensorLeft historicExponentRep
 
 open CategoryTheory MonoidalCategory in
@@ -780,7 +780,7 @@ open CategoryTheory MonoidalCategory in
     the exponent with the stem. -/
 theorem withHistFunctor_obj
     (X : AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool)) :
+        ((b : Bool) × TwoTier (TierSpec Segment Morph) (SegSpec CVKind Morph) b) → Bool)) :
     withHistFunctor.obj X = historicExponentRep ⊗ X := rfl
 
 open CategoryTheory MonoidalCategory in
@@ -792,7 +792,7 @@ open CategoryTheory MonoidalCategory in
     load-bearing rather than decorative. -/
 noncomputable def prefixAssoc
     (X : AR (Sigma.fst :
-        ((b : Bool) × TwoTier (TierSpec Segment Morpheme) (SegSpec CVKind Morpheme) b) → Bool)) :
+        ((b : Bool) × TwoTier (TierSpec Segment Morph) (SegSpec CVKind Morph) b) → Bool)) :
     tensorLeft (historicExponentRep ⊗ X) ≅
       tensorLeft X ⋙ tensorLeft historicExponentRep :=
   tensorLeftTensor historicExponentRep X
@@ -968,7 +968,7 @@ non-modular alternatives:
 * **Readjustment rules triggered by module-transcending
   diacritics** ([harley-noyer-1999]).
 * **Co-phonologies** ([anttila-2002], [inkelas-zoll-2007]).
-* **Morpheme-specific phonological constraints**
+* **Morph-specific phonological constraints**
   ([pater-2000], [pater-2009]).
 
 The autosegmental approach with floating phonologically-defective

--- a/Linglib/Studies/Tay2024.lean
+++ b/Linglib/Studies/Tay2024.lean
@@ -316,24 +316,22 @@ semantic relation is idiosyncratic and must be listed in the lexicon
 ([tay-2024], Ch. 3 §3.1). -/
 
 /-- Morphological structure of dǎ-sǐ "hit-die". -/
-def dasi_morph : Word.Structure :=
-  .compound (.root { morph := .root "da", gloss := "hit" }) (.root { morph := .root "si", gloss := "die" })
-
-/-- V-V compounds are recognized as compounds by `IsCompound`. -/
-theorem dasi_is_compound : dasi_morph.IsCompound := by decide
+def dasi_morph : Word.Structure Morphology.Morph :=
+  .compound (.root (.root "da")) (.root (.root "si"))
 
 /-- Surface form is concatenation of V1 + V2. -/
-theorem dasi_surface : dasi_morph.surface = "dasi" := rfl
+theorem dasi_surface :
+    String.join (dasi_morph.toList.map Morphology.Morph.form) = "dasi" := rfl
 
-/-- V-V compounds have exactly 2 morphemes. -/
-theorem dasi_morpheme_count : dasi_morph.morphemeCount = 2 := rfl
+/-- V-V compounds have exactly 2 morphs. -/
+theorem dasi_morph_count : dasi_morph.toList.length = 2 := rfl
 
 /-- Morphological structure of kū-lèi "cry-tired" (subject-oriented). -/
-def kulei_morph : Word.Structure :=
-  .compound (.root { morph := .root "ku", gloss := "cry" }) (.root { morph := .root "lei", gloss := "tired" })
+def kulei_morph : Word.Structure Morphology.Morph :=
+  .compound (.root (.root "ku")) (.root (.root "lei"))
 
-theorem kulei_is_compound : kulei_morph.IsCompound := by decide
-theorem kulei_surface : kulei_morph.surface = "kulei" := rfl
+theorem kulei_surface :
+    String.join (kulei_morph.toList.map Morphology.Morph.form) = "kulei" := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 5. Causal Models (V2 BoolSEM)
@@ -516,7 +514,7 @@ theorem vv_compound_architecture :
     -- Tight causation (direct, single edge)
     completesForEffect Dasi.model Valuation.empty .hitting true false .death true ∧
     -- Morphological compound
-    dasi_morph.IsCompound ∧
+    (dasi_morph matches Word.Structure.compound _ _) = true ∧
     -- Subject-oriented resultatives exist (no DOR)
     (allCompounds.any (·.orientation == .subjectOriented)) = true ∧
     -- V-V is opaque, V-de is transparent


### PR DESCRIPTION
Word/Structure.lean redesigned to the mathlib standard, user-driven: the tree is now Word.Structure M (leaf-parameterized, term algebra over the word-formation signature); Morpheme dissolved (thin Morph+gloss wrapper — glosses were write-only in all but one consumer, which now instantiates M := Morph × String); surface deleted (its process cases simulated unconsumed operations stringly; concatenative surface = String.join over toList); zero-consumer API cut (boundaryPositions, IsSimple/IsCompound/IsReduplicated/IsConverted, morphemeCount, infixed's char-offset pos, partialCopy's stored string); toExponent renamed toSequence?. Plus the register cleanse and copyright headers from earlier commits. Six consumers migrated; cone green (2868 jobs).