### PR TITLE
refactor(Morphology): Boundness enum to Kind.IsBound

### DIFF
--- a/Linglib/Fragments/Dargwa/Coordination.lean
+++ b/Linglib/Fragments/Dargwa/Coordination.lean
@@ -42,7 +42,7 @@ namespace Dargwa.Coordination
     This is a MU particle. -/
 def ra : Coordinator :=
   { form := "=ra", gloss := "and, also, too; ADD"
-  , role := .mu, boundness := .bound
+  , role := .mu, kind := .bound .after .clitic
   , alsoAdditive := true
   , note := "repeated after each conjunct" }
 
@@ -51,14 +51,14 @@ def ra : Coordinator :=
     With negation: 'neither A nor B'. -/
 def ja : Coordinator :=
   { form := "ja", gloss := "or; neither...nor (with NEG)"
-  , role := .disj, boundness := .free
+  , role := .disj, kind := .free
   , note := "repeated before each disjunct" }
 
 /-- *=nu* — contrastive/causal particle.
     Marks contrast between clauses or causal relation. -/
 def nu : Coordinator :=
   { form := "=nu", gloss := "but; because"
-  , role := .advers, boundness := .bound }
+  , role := .advers, kind := .bound .after .clitic }
 
 def allEntries : List Coordinator := [ra, ja, nu]
 
@@ -79,7 +79,7 @@ theorem mu_is_additive :
 
 /-- The MU particle is bound (enclitic). -/
 theorem mu_is_bound :
-    (allEntries.filter (·.role == .mu)).all (·.boundness == .bound) = true := by
+    (allEntries.filter (·.role == .mu)).all (fun e => decide e.kind.IsBound) = true := by
   decide
 
 end Dargwa.Coordination

--- a/Linglib/Fragments/English/Coordination.lean
+++ b/Linglib/Fragments/English/Coordination.lean
@@ -22,25 +22,25 @@ namespace English.Coordination
 /-- *and* — primary conjunction, J particle. Free, prepositive. -/
 def and_ : Coordinator :=
   { form := "and", gloss := "and"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , correlative := true
   , note := "correlative use as 'both…and'" }
 
 /-- *or* — disjunction. Free, prepositive; correlative as 'either…or'. -/
 def or_ : Coordinator :=
   { form := "or", gloss := "or"
-  , role := .disj, boundness := .free
+  , role := .disj, kind := .free
   , correlative := true }
 
 /-- *but* — adversative. Free, prepositive. -/
 def but_ : Coordinator :=
   { form := "but", gloss := "but"
-  , role := .advers, boundness := .free }
+  , role := .advers, kind := .free }
 
 /-- *nor* — negative disjunction; correlative 'neither…nor'. -/
 def nor_ : Coordinator :=
   { form := "nor", gloss := "nor"
-  , role := .negDisj, boundness := .free
+  , role := .negDisj, kind := .free
   , correlative := true }
 
 def allEntries : List Coordinator := [and_, or_, but_, nor_]

--- a/Linglib/Fragments/Farsi/Coordination.lean
+++ b/Linglib/Fragments/Farsi/Coordination.lean
@@ -17,13 +17,13 @@ namespace Farsi.Coordination
 /-- *va* — J particle (Arabic loan; colloquial enclitic *o*). Free, prepositive. -/
 def va : Coordinator :=
   { form := "va", gloss := "and"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , note := "Arabic-origin loan; colloquial enclitic 'o'" }
 
 /-- *ham* — MU particle, also additive. Free, used bisyndetically. -/
 def ham : Coordinator :=
   { form := "ham", gloss := "also, too; and (MU)"
-  , role := .mu, boundness := .free, alsoAdditive := true
+  , role := .mu, kind := .free, alsoAdditive := true
   , correlative := true }
 
 def allEntries : List Coordinator := [va, ham]

--- a/Linglib/Fragments/Finnish/Coordination.lean
+++ b/Linglib/Fragments/Finnish/Coordination.lean
@@ -18,13 +18,13 @@ namespace Finnish.Coordination
 /-- *ja* — J particle. Free, prepositive medial. -/
 def ja : Coordinator :=
   { form := "ja", gloss := "and"
-  , role := .j, boundness := .free }
+  , role := .j, kind := .free }
 
 /-- *-kin* — MU particle, also additive. Bound, postpositive on each
     coordinand for the bisyndetic 'both…and' pattern. -/
 def kin : Coordinator :=
   { form := "-kin", gloss := "also, too; and (MU)"
-  , role := .mu, boundness := .bound, alsoAdditive := true }
+  , role := .mu, kind := .bound .after .clitic, alsoAdditive := true }
 
 def allEntries : List Coordinator := [ja, kin]
 

--- a/Linglib/Fragments/Georgian/Coordination.lean
+++ b/Linglib/Fragments/Georgian/Coordination.lean
@@ -32,7 +32,7 @@ namespace Georgian.Coordination
     "nino da giorgi" = "Nino and Giorgi". -/
 def da : Coordinator :=
   { form := "da", gloss := "and"
-  , role := .j, boundness := .free }
+  , role := .j, kind := .free }
 
 /-- *-c* — MU particle / additive focus particle. Bound clitic, postpositive.
     Conjunction: "nino-c giorgi-c" = "both Nino and Giorgi".
@@ -40,20 +40,20 @@ def da : Coordinator :=
     The bound status of -c contrasts with Hungarian free "is". -/
 def c_ : Coordinator :=
   { form := "-c", gloss := "also, too; and (MU)"
-  , role := .mu, boundness := .bound
+  , role := .mu, kind := .bound .after .clitic
   , alsoAdditive := true }
 
 /-- *an* — disjunction. Free, prepositive.
     "nino an giorgi" = "Nino or Giorgi". -/
 def an : Coordinator :=
   { form := "an", gloss := "or"
-  , role := .disj, boundness := .free }
+  , role := .disj, kind := .free }
 
 /-- *magram* — adversative conjunction.
     "lamazia magram dzviri" = "beautiful but expensive". -/
 def magram : Coordinator :=
   { form := "magram", gloss := "but"
-  , role := .advers, boundness := .free }
+  , role := .advers, kind := .free }
 
 def allEntries : List Coordinator :=
   [da, c_, an, magram]
@@ -64,12 +64,12 @@ def allEntries : List Coordinator :=
 
 /-- Georgian has exactly one bound morpheme: the MU clitic -c. -/
 theorem one_bound :
-    (allEntries.filter (·.boundness == .bound)).length = 1 := by
+    (allEntries.filter (fun e => decide e.kind.IsBound)).length = 1 := by
   decide
 
 /-- The bound morpheme is the MU particle. -/
 theorem bound_is_mu :
-    (allEntries.filter (·.boundness == .bound)).all (·.role == .mu) = true := by
+    (allEntries.filter (fun e => decide e.kind.IsBound)).all (·.role == .mu) = true := by
   decide
 
 /-- The MU particle -c also serves as an additive particle. -/

--- a/Linglib/Fragments/German/Coordination.lean
+++ b/Linglib/Fragments/German/Coordination.lean
@@ -24,28 +24,28 @@ def und : Coordinator where
   form := "und"
   gloss := "and"
   role := .j
-  boundness := .free
+  kind := .free
 
 /-- *oder* — disjunction. -/
 def oder : Coordinator where
   form := "oder"
   gloss := "or"
   role := .disj
-  boundness := .free
+  kind := .free
 
 /-- *aber* — adversative ("but", contrastive). -/
 def aber : Coordinator where
   form := "aber"
   gloss := "but"
   role := .advers
-  boundness := .free
+  kind := .free
 
 /-- *sondern* — adversative ("but rather", corrective; requires negation). -/
 def sondern : Coordinator where
   form := "sondern"
   gloss := "but.rather"
   role := .advers
-  boundness := .free
+  kind := .free
   note := "corrective; requires negation in first conjunct"
 
 /-- German uses a J-only conjunction strategy. -/

--- a/Linglib/Fragments/Hausa/Coordination.lean
+++ b/Linglib/Fragments/Hausa/Coordination.lean
@@ -20,7 +20,7 @@ namespace Hausa
     Diachronic source: comitative ('with') → coordinator ('and'). -/
 def da : Coordinator :=
   { form := "da", gloss := "and; with"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , note := "comitative-derived; identical form for 'with' and 'and'" }
 
 def allEntries : List Coordinator := [da]

--- a/Linglib/Fragments/HindiUrdu/Coordination.lean
+++ b/Linglib/Fragments/HindiUrdu/Coordination.lean
@@ -20,13 +20,13 @@ namespace HindiUrdu.Coordination
 /-- *aur* — J particle. Free, prepositive medial. -/
 def aur : Coordinator :=
   { form := "aur", gloss := "and"
-  , role := .j, boundness := .free }
+  , role := .j, kind := .free }
 
 /-- *bhii* — MU particle, also additive ('also/too').
     Free, used bisyndetically: "A bhii B bhii". -/
 def bhii : Coordinator :=
   { form := "bhii", gloss := "also, too; and (MU)"
-  , role := .mu, boundness := .free, alsoAdditive := true
+  , role := .mu, kind := .free, alsoAdditive := true
   , correlative := true }
 
 def allEntries : List Coordinator := [aur, bhii]

--- a/Linglib/Fragments/Hungarian/Coordination.lean
+++ b/Linglib/Fragments/Hungarian/Coordination.lean
@@ -32,7 +32,7 @@ namespace Hungarian.Coordination
     "Peter es Mari" = "Peter and Mari". -/
 def es : Coordinator :=
   { form := "és", gloss := "and"
-  , role := .j, boundness := .free }
+  , role := .j, kind := .free }
 
 /-- *is* — MU particle / additive focus particle. Free, postpositive.
     Conjunction: "Peter is Mari is" = "both Peter and Mari".
@@ -40,20 +40,20 @@ def es : Coordinator :=
     One of the key pieces of evidence for M&S's MU = additive particle claim. -/
 def is_ : Coordinator :=
   { form := "is", gloss := "also, too; and (MU)"
-  , role := .mu, boundness := .free
+  , role := .mu, kind := .free
   , alsoAdditive := true }
 
 /-- *vagy* — disjunction. Free, prepositive.
     "Peter vagy Mari" = "Peter or Mari". -/
 def vagy : Coordinator :=
   { form := "vagy", gloss := "or"
-  , role := .disj, boundness := .free }
+  , role := .disj, kind := .free }
 
 /-- *de* — adversative conjunction.
     "szep de draga" = "beautiful but expensive". -/
 def de : Coordinator :=
   { form := "de", gloss := "but"
-  , role := .advers, boundness := .free }
+  , role := .advers, kind := .free }
 
 def allEntries : List Coordinator :=
   [es, is_, vagy, de]
@@ -67,7 +67,7 @@ def allEntries : List Coordinator :=
     [bill-etal-2025] speculate this difference may explain why
     Georgian children found MU harder than Hungarian children did. -/
 theorem all_free :
-    allEntries.all (·.boundness == .free) = true := by
+    allEntries.all (fun e => decide (e.kind = .free)) = true := by
   decide
 
 /-- The MU particle *is* also serves as an additive particle. -/

--- a/Linglib/Fragments/Irish/Coordination.lean
+++ b/Linglib/Fragments/Irish/Coordination.lean
@@ -23,27 +23,27 @@ namespace Irish.Coordination
     "Sean agus Maire" = "Sean and Maire". -/
 def agus : Coordinator :=
   { form := "agus", gloss := "and"
-  , role := .j, boundness := .free }
+  , role := .j, kind := .free }
 
 /-- *no* — disjunction. Free, prepositive.
     "Sean no Maire" = "Sean or Maire". -/
 def no_ : Coordinator :=
   { form := "nó", gloss := "or"
-  , role := .disj, boundness := .free }
+  , role := .disj, kind := .free }
 
 /-- *na* — negative disjunction / comparative particle.
     "ni Sean na Maire" = "neither Sean nor Maire".
     Also used in comparatives: "nios mo na" = "bigger than". -/
 def na_ : Coordinator :=
   { form := "ná", gloss := "nor, than"
-  , role := .negDisj, boundness := .free
+  , role := .negDisj, kind := .free
   , note := "also comparative particle" }
 
 /-- *ach* — adversative conjunction.
     "Ta se fuar ach tirim" = "It is cold but dry". -/
 def ach : Coordinator :=
   { form := "ach", gloss := "but"
-  , role := .advers, boundness := .free }
+  , role := .advers, kind := .free }
 
 def allEntries : List Coordinator :=
   [agus, no_, na_, ach]
@@ -54,7 +54,7 @@ def allEntries : List Coordinator :=
 
 /-- All Irish coordination morphemes are free (no bound clitics). -/
 theorem all_free :
-    allEntries.all (·.boundness == .free) = true := by
+    allEntries.all (fun e => decide (e.kind = .free)) = true := by
   decide
 
 /-- Irish has exactly one conjunction morpheme (J-only, no MU). -/

--- a/Linglib/Fragments/Japanese/Coordination.lean
+++ b/Linglib/Fragments/Japanese/Coordination.lean
@@ -56,7 +56,7 @@ namespace Japanese.Coordination
     in WALS Ch 63 (`andIdenticalToWith`). -/
 def to_ : Coordinator :=
   { form := "to", gloss := "and; with"
-  , role := .j, boundness := .bound }
+  , role := .j, kind := .bound .after .clitic }
 
 /-- *mo* (も) — MU particle. Bound, postpositive on each conjunct.
     Conjunction: "Taroo-mo Hanako-mo neta" = "both Taro and Hanako slept".
@@ -67,7 +67,7 @@ def to_ : Coordinator :=
     finite meet (∧) in Boolean algebra. -/
 def mo : Coordinator :=
   { form := "mo", gloss := "also, too; and (MU); every"
-  , role := .mu, boundness := .bound
+  , role := .mu, kind := .bound .after .clitic
   , alsoAdditive := true, alsoQuantifier := true }
 
 /-- *ka* (か) — Disjunction particle. Bound, postpositive.
@@ -78,7 +78,7 @@ def mo : Coordinator :=
     "ka" marks finite joins (∨). -/
 def ka : Coordinator :=
   { form := "ka", gloss := "or; question; some"
-  , role := .disj, boundness := .bound
+  , role := .disj, kind := .bound .after .clitic
   , alsoQuantifier := true }
 
 def allEntries : List Coordinator :=
@@ -90,7 +90,7 @@ def allEntries : List Coordinator :=
 
 /-- All Japanese coordination particles are bound (postpositive). -/
 theorem all_bound :
-    allEntries.all (·.boundness == .bound) = true := by
+    allEntries.all (fun e => decide e.kind.IsBound) = true := by
   decide
 
 /-- The MU particle "mo" also serves as an additive particle. -/

--- a/Linglib/Fragments/Kannada/Coordination.lean
+++ b/Linglib/Fragments/Kannada/Coordination.lean
@@ -20,7 +20,7 @@ namespace Kannada.Coordination
     on each coordinand giving the bisyndetic A-co B-co pattern. -/
 def u : Coordinator :=
   { form := "-u", gloss := "and; also"
-  , role := .mu, boundness := .bound, alsoAdditive := true
+  , role := .mu, kind := .bound .after .clitic, alsoAdditive := true
   , note := "bisyndetic postpositive enclitic; Dravidian additive particle" }
 
 def allEntries : List Coordinator := [u]

--- a/Linglib/Fragments/Korean/Coordination.lean
+++ b/Linglib/Fragments/Korean/Coordination.lean
@@ -21,14 +21,14 @@ namespace Korean.Coordination
 /-- *-(i)rang* — J particle, informal register. Bound, postpositive. -/
 def irang : Coordinator :=
   { form := "-(i)rang", gloss := "and"
-  , role := .j, boundness := .bound
+  , role := .j, kind := .bound .after .clitic
   , note := "informal register; -kwa/-hako are more formal alternatives" }
 
 /-- *-to* — MU particle, additive. Bound, postpositive on each conjunct.
     Doubles as the additive focus particle ("also/too"). -/
 def to_ : Coordinator :=
   { form := "-to", gloss := "also, too; and (MU)"
-  , role := .mu, boundness := .bound, alsoAdditive := true }
+  , role := .mu, kind := .bound .after .clitic, alsoAdditive := true }
 
 def allEntries : List Coordinator := [irang, to_]
 

--- a/Linglib/Fragments/Lango/Coordination.lean
+++ b/Linglib/Fragments/Lango/Coordination.lean
@@ -20,7 +20,7 @@ namespace Lango.Coordination
     Diachronic source: comitative ('with') → coordinator ('and'). -/
 def kede : Coordinator :=
   { form := "kèdè", gloss := "and; with"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , note := "comitative-derived; identical form for 'with' and 'and'" }
 
 def allEntries : List Coordinator := [kede]

--- a/Linglib/Fragments/Latin/Coordination.lean
+++ b/Linglib/Fragments/Latin/Coordination.lean
@@ -31,7 +31,7 @@ namespace Latin.Coordination
     Also used correlatively: "et A et B" = "both A and B". -/
 def et : Coordinator :=
   { form := "et", gloss := "and"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , correlative := true }
 
 /-- *-que* — enclitic conjunction, MU particle. Bound, postpositive.
@@ -39,7 +39,7 @@ def et : Coordinator :=
     Historically connected to the additive/inclusive particle. -/
 def que : Coordinator :=
   { form := "-que", gloss := "and (enclitic)"
-  , role := .mu, boundness := .bound
+  , role := .mu, kind := .bound .after .clitic
   , alsoAdditive := true
   , note := "postpositive enclitic; archaic/formal register" }
 
@@ -48,7 +48,7 @@ def que : Coordinator :=
     "atque" < *ad-que (lit. "and to that"). -/
 def atque : Coordinator :=
   { form := "atque/ac", gloss := "and also, and moreover"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , note := "ac before consonants; emphatic variant of et" }
 
 /-- *neque* / *nec* — negative coordination.
@@ -56,7 +56,7 @@ def atque : Coordinator :=
     Morphologically ne + -que (negation + MU enclitic). -/
 def neque : Coordinator :=
   { form := "neque/nec", gloss := "and not, neither...nor"
-  , role := .negCoord, boundness := .free
+  , role := .negCoord, kind := .free
   , correlative := true
   , note := "ne + -que; always correlative for 'neither...nor'" }
 
@@ -64,21 +64,21 @@ def neque : Coordinator :=
     "aut A aut B" = "either A or B (but not both)". -/
 def aut : Coordinator :=
   { form := "aut", gloss := "or (exclusive)"
-  , role := .disj, boundness := .free
+  , role := .disj, kind := .free
   , correlative := true }
 
 /-- *vel* — inclusive/weak disjunction.
     "vel A vel B" = "A or B (or both)". -/
 def vel : Coordinator :=
   { form := "vel", gloss := "or (inclusive)"
-  , role := .disj, boundness := .free
+  , role := .disj, kind := .free
   , correlative := true }
 
 /-- *sed* — adversative conjunction.
     "non A sed B" = "not A but B". -/
 def sed : Coordinator :=
   { form := "sed", gloss := "but"
-  , role := .advers, boundness := .free }
+  , role := .advers, kind := .free }
 
 def allEntries : List Coordinator :=
   [et, que, atque, neque, aut, vel, sed]
@@ -89,12 +89,12 @@ def allEntries : List Coordinator :=
 
 /-- Latin has exactly one bound morpheme: -que. -/
 theorem one_bound_morpheme :
-    (allEntries.filter (·.boundness == .bound)).length = 1 := by
+    (allEntries.filter (fun e => decide e.kind.IsBound)).length = 1 := by
   decide
 
 /-- The bound morpheme is the MU particle -que. -/
 theorem bound_is_mu :
-    (allEntries.filter (·.boundness == .bound)).all (·.role == .mu) = true := by
+    (allEntries.filter (fun e => decide e.kind.IsBound)).all (·.role == .mu) = true := by
   decide
 
 /-- Latin has correlative uses of J, disjunction, and negative coordination. -/

--- a/Linglib/Fragments/Tibetan/Coordination.lean
+++ b/Linglib/Fragments/Tibetan/Coordination.lean
@@ -21,7 +21,7 @@ namespace Tibetan.Coordination
     postpositive on the first coordinand giving A-co B pattern. -/
 def dang : Coordinator :=
   { form := "-daŋ", gloss := "and; with"
-  , role := .j, boundness := .bound
+  , role := .j, kind := .bound .after .clitic
   , note := "Classical; comitative-derived; medial postpositive on first conjunct" }
 
 def allEntries : List Coordinator := [dang]

--- a/Linglib/Fragments/Turkish/Coordination.lean
+++ b/Linglib/Fragments/Turkish/Coordination.lean
@@ -23,7 +23,7 @@ namespace Turkish.Coordination
 /-- *ve* — J particle (Arabic loan). Free, prepositive medial. -/
 def ve : Coordinator :=
   { form := "ve", gloss := "and"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , note := "Arabic-origin loan" }
 
 /-- *de* — MU clitic, also additive. Bound enclitic on first word of
@@ -31,7 +31,7 @@ def ve : Coordinator :=
     a marked emphatic variant. -/
 def de : Coordinator :=
   { form := "de", gloss := "also; and (MU)"
-  , role := .mu, boundness := .bound, alsoAdditive := true
+  , role := .mu, kind := .bound .after .clitic, alsoAdditive := true
   , note := "enclitic per Kornfilt 1997; also vowel-harmony variant 'da'" }
 
 def allEntries : List Coordinator := [ve, de]

--- a/Linglib/Fragments/Yoruba/Coordination.lean
+++ b/Linglib/Fragments/Yoruba/Coordination.lean
@@ -17,7 +17,7 @@ namespace Yoruba.Coordination
 /-- *àtí* — J particle, used bisyndetically: "àtí A àtí B". Free, prepositive. -/
 def ati : Coordinator :=
   { form := "àtí", gloss := "and"
-  , role := .j, boundness := .free
+  , role := .j, kind := .free
   , correlative := true
   , note := "bisyndetic prepositive (co-A co-B pattern)" }
 

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -44,18 +44,22 @@ inductive Morph.Kind where
   | free
   deriving DecidableEq, Repr, Fintype
 
-/-- Morphological boundness: the coarse two-way cut of the wordhood scale,
-read across domains — acquisition ([clark-2017]: free morphemes are acquired
-more readily than bound ones) and coordination typology
-([mitrovic-sauerland-2016]). `Morph.Kind` refines the cut for morphs (`bound`
-against `root` and `free`); no projection is provided, since a root morph may
-itself be bound and `Kind` does not record it. -/
-inductive Boundness where
-  /-- Independent word (Hungarian *is*, English *and*). -/
-  | free
-  /-- Clitic or suffix (Georgian *-c*, Latin *-que*). -/
-  | bound
-  deriving DecidableEq, Repr, BEq
+/-- A morph is **bound** when its recorded `Kind` is `bound` — attaching on a
+side of its host as an affix or clitic; roots and free forms are not.
+
+The coarse two-way cut is read across domains: acquisition ([clark-2017]: free
+morphemes are acquired more readily than bound ones) and coordination typology
+([mitrovic-sauerland-2016]). `IsBound` reflects the *recorded* attachment: a
+root morph may itself be bound in a language, but `Kind` does not record it, so
+`(Kind.root).IsBound` is `False` by definition, not by claim. -/
+def Morph.Kind.IsBound : Morph.Kind → Prop
+  | .bound .. => True
+  | .root | .free => False
+
+instance : DecidablePred Morph.Kind.IsBound := fun k =>
+  match k with
+  | .bound .. => .isTrue trivial
+  | .root | .free => .isFalse (fun h => h)
 
 /-- A **morph** is a minimal segmental form with its attachment kind. -/
 structure Morph where
@@ -89,6 +93,11 @@ def root (s : String) : Morph := ⟨.root, s⟩
 def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
+
+/-- A morph is bound when its `kind` is; roots and free forms are not. -/
+def IsBound (m : Morph) : Prop := m.kind.IsBound
+
+instance : DecidablePred IsBound := fun m => inferInstanceAs (Decidable m.kind.IsBound)
 
 instance : ToString Morph :=
   ⟨fun m => match m.kind with

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -47,8 +47,10 @@ inductive Morph.Kind where
 /-- A morph is **bound** when its recorded `Kind` is `bound` — attaching on a
 side of its host as an affix or clitic; roots and free forms are not.
 
-The coarse two-way cut is read across domains: acquisition ([clark-2017]: free
-morphemes are acquired more readily than bound ones) and coordination typology
+This is *morphosyntactic* boundness; prosodic boundness belongs to the prosodic
+word (`Phonology/Prosody`). The coarse two-way cut is read across domains:
+acquisition ([clark-2017]: free morphemes are acquired more readily than bound
+ones) and coordination typology
 ([mitrovic-sauerland-2016]). `IsBound` reflects the *recorded* attachment: a
 root morph may itself be bound in a language, but `Kind` does not record it, so
 `(Kind.root).IsBound` is `False` by definition, not by claim. -/

--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -18,7 +18,7 @@ simply *words*. The split is descriptive, not a Lexicalist commitment: ms-words 
 `Word` completes Morphology's word inventory: `Word.Structure` (`Word/Structure.lean`) is word-*internal* structure,
 `Paradigm/Linkage` carries the word-forming correspondence (stem selection + realization), `Word` is the resulting *token* —
 form + UD category + one `UD.MorphFeatures` bundle, i.e. a CoNLL-U row. The
-ms- vs p-boundness typology relating the two word notions ([kalin-bjorkman-etal-2026]
+ms-word vs p-word typology relating the two word notions ([kalin-bjorkman-etal-2026]
 Table 3) is formalized in `Studies/KalinBjorkmanEtAl2026.lean`.
 
 ## Main declarations

--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Data.UD.Basic
 import Linglib.Features.Case.Capabilities
 import Linglib.Features.Number.Capabilities
@@ -8,8 +13,10 @@ import Linglib.Features.Person.Capabilities
 [kalin-bjorkman-etal-2026]
 
 The surface token: the unit that (morpho)syntax treats as a word. Wordhood minimally
-splits into the **ms-word** (this type) and the **p-word** (the prosodic word,
-`Phonology/Prosodic/Word.lean`) — the "one area of robust consensus" on the wordhood
+splits into the **ms-word** (which this type approximates: a CoNLL-U token is an
+orthographic unit, and orthography does not reliably track the ms-word) and the
+**p-word** (the prosodic word, `Phonology/Prosody/Word.lean`) — the "one area of
+robust consensus" on the wordhood
 problem ([kalin-bjorkman-etal-2026] §3.2); we follow the Element in calling ms-words
 simply *words*. The split is descriptive, not a Lexicalist commitment: ms-words are
 "crucial for lexicalist theories" but used descriptively by non-lexicalist ones too
@@ -42,8 +49,11 @@ set_option autoImplicit false
     engine reads it off the token's *own* data; otherwise it lives on the typed lexical
     carrier (`Pronoun`, `NounEntry`, `Verb`, …) or on the consuming framework's own
     structures (e.g. DG subcategorization premises live on `DepTree.frames`, not here).
-    Identity caveat: `BEq` is form + category, so homographs collapse; a CoNLL-U
-    `lemma` field is the known fix, deferred until a consumer needs it. -/
+    Identity caveat: `BEq` is form + category, so homographs collapse — correct
+    surface behavior. Theoretical word identity (which tokens share a lexeme, the
+    Same Verb Problem) is relational and owned by the lexeme layer of
+    `Paradigm/Linkage`; a CoNLL-U `lemma` field would be corpus disambiguation
+    only, added if a corpus consumer needs it. -/
 structure Word where
   form : String
   cat : UD.UPOS

--- a/Linglib/Semantics/Coordination/Defs.lean
+++ b/Linglib/Semantics/Coordination/Defs.lean
@@ -75,8 +75,8 @@ structure Coordinator where
   gloss : String
   /-- Which Boolean operation it denotes. -/
   role : Coordinator.Role
-  /-- Free word vs bound clitic/suffix. -/
-  boundness : Morphology.Boundness
+  /-- Full attachment kind; the free-vs-bound cut is `Morph.Kind.IsBound`. -/
+  kind : Morphology.Morph.Kind
   /-- Does this morpheme also serve as an additive/focus particle? -/
   alsoAdditive : Bool := false
   /-- Does this morpheme also serve as a quantifier particle?
@@ -87,4 +87,4 @@ structure Coordinator where
   correlative : Bool := false
   /-- Notes on usage or distribution. -/
   note : String := ""
-  deriving DecidableEq, Repr, BEq
+  deriving DecidableEq, Repr

--- a/Linglib/Studies/BillEtAl2025.lean
+++ b/Linglib/Studies/BillEtAl2025.lean
@@ -580,22 +580,22 @@ theorem ms_universality_challenged :
   refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
 
 open Haspelmath2007 (georgian hungarian) in
-open Syntax.Coordination (ConjunctionSystem.muBoundness) in
+open Syntax.Coordination (ConjunctionSystem.muKind) in
 /--
-**The boundness confound.**
+**The bound-status confound.**
 
 Georgian MU (-c) is bound; Hungarian MU (is) is free. Hungarian children
 showed no significant sentence-type effect on either accuracy or replays.
-This raises the possibility that morphological boundness — not the M&S
+This raises the possibility that morphological bound status — not the M&S
 decomposition itself — drives the Georgian difficulty.
 
-If boundness is the real factor, then M&S categories (J, MU, J-MU) are
+If bound status is the real factor, then M&S categories (J, MU, J-MU) are
 not the right level of analysis for acquisition predictions.
 -/
-theorem boundness_confound :
-    -- Georgian MU is bound, Hungarian MU is free
-    georgian.muBoundness = some Morphology.Boundness.bound ∧
-    hungarian.muBoundness = some Morphology.Boundness.free ∧
+theorem bound_status_confound :
+    -- Georgian MU is a bound enclitic, Hungarian MU is free
+    georgian.muKind = some (.bound .after .clitic) ∧
+    hungarian.muKind = some .free ∧
     -- Georgian children found J-MU significantly harder
     georgianChild_j_vs_jmu.significant = true ∧
     -- Hungarian: no significant sentence-type effect on replays

--- a/Linglib/Studies/Haspelmath2007.lean
+++ b/Linglib/Studies/Haspelmath2007.lean
@@ -159,7 +159,7 @@ def korean : ConjunctionSystem :=
 def slovenian : ConjunctionSystem :=
   { language := "Slovenian"
   , morphemes :=
-    [ { entry := { form := "in", gloss := "and", role := .j, boundness := .free } } ]
+    [ { entry := { form := "in", gloss := "and", role := .j, kind := .free } } ]
   , strategies := [.jOnly]
   , patterns := [.a_co_b]
   , iso := "slv" }
@@ -215,7 +215,8 @@ def kannada : ConjunctionSystem :=
 def martuthunira : ConjunctionSystem :=
   { language := "Martuthunira"
   , morphemes :=
-    [ { entry := { form := "-thurti", gloss := "and", role := .j, boundness := .bound } } ]
+    -- UNVERIFIED: attachment — postpositive on each coordinand ([dench-1995]); clitic vs affix not stated here
+    [ { entry := { form := "-thurti", gloss := "and", role := .j, kind := .bound .after .clitic } } ]
   , strategies := [.jOnly]
   , patterns := [.a'co_b'co]
   , iso := "vma" }

--- a/Linglib/Studies/MitrovicSauerland2016.lean
+++ b/Linglib/Studies/MitrovicSauerland2016.lean
@@ -33,7 +33,7 @@ heads are overtly pronounced; the predictions are:
   show triadic exponency; the paper's own sample uses SE Macedonian, Avar,
   Hungarian (none of SE Macedonian / Avar / SerBo-Croatian is encoded here,
   so the formalised claim is restricted to the M&S focus sub-sample).
-* `mu_boundness_asymmetry` — Georgian μ is bound, Hungarian μ is free; [bill-etal-2025]
+* `mu_kind_asymmetry` — Georgian μ is bound, Hungarian μ is free; [bill-etal-2025]
   link this morphological asymmetry to acquisition difficulty.
 
 ## Implementation notes
@@ -88,13 +88,13 @@ theorem all_three_is_rare :
       hasAllThreeStrategies sys ↔ sys.iso = "kat" ∨ sys.iso = "hun" := by
   decide
 
-/-- **MU boundness asymmetry.** Georgian MU (*-c*) is bound; Hungarian MU
-    (*is*) is free. [bill-etal-2025] (with [mitrovic-2021])
+/-- **MU attachment asymmetry.** Georgian MU (*-c*) is a bound enclitic;
+    Hungarian MU (*is*) is free. [bill-etal-2025] (with [mitrovic-2021])
     propose this morphological difference may explain the acquisition
     asymmetry: bound morphemes are harder to segment. -/
-theorem mu_boundness_asymmetry :
-    georgian.muBoundness = some .bound ∧
-    hungarian.muBoundness = some .free := by
+theorem mu_kind_asymmetry :
+    georgian.muKind = some (.bound .after .clitic) ∧
+    hungarian.muKind = some .free := by
   decide
 
 end MitrovicSauerland2016

--- a/Linglib/Studies/ZwickyPullum1983.lean
+++ b/Linglib/Studies/ZwickyPullum1983.lean
@@ -94,11 +94,12 @@ def MorphStatus.IsClitic (s : MorphStatus) : Prop :=
 instance : DecidablePred MorphStatus.IsClitic :=
   fun _ => inferInstanceAs (Decidable (_ ∨ _))
 
-/-- The coarse boundness of a morph status: free words are free,
-clitics and affixes are bound. -/
-def MorphStatus.boundness : MorphStatus → Morphology.Boundness
-  | .freeWord => .free
-  | _ => .bound
+/-- A morph status is bound unless it is a free word: clitics and affixes
+are bound. -/
+def MorphStatus.IsBound (s : MorphStatus) : Prop := s ≠ .freeWord
+
+instance : DecidablePred MorphStatus.IsBound :=
+  fun _ => inferInstanceAs (Decidable (_ ≠ _))
 
 structure CliticAffixProfile where
   morpheme : String

--- a/Linglib/Syntax/Coordination.lean
+++ b/Linglib/Syntax/Coordination.lean
@@ -36,8 +36,8 @@ language WALS sample).
 * `SourcedEntry`, `ConjunctionSystem` — per-language structs.
 * `CoordinationProfile` — WALS profile bundle.
 * `ConjunctionSystem.hasStrategy`, `muIsAdditive`, `hasSource`,
-  `hasMonosyndetic`, `hasBisyndetic`, `muBoundness` — `Prop`-valued
-  decidable predicates.
+  `hasMonosyndetic`, `hasBisyndetic` — `Prop`-valued decidable predicates.
+* `ConjunctionSystem.muKind` — the MU particle's `Morph.Kind`, if any.
 
 ## Implementation notes
 
@@ -288,9 +288,9 @@ def ConjunctionSystem.hasBisyndetic (sys : ConjunctionSystem) : Prop :=
 instance (sys : ConjunctionSystem) : Decidable sys.hasBisyndetic := by
   unfold ConjunctionSystem.hasBisyndetic; infer_instance
 
-/-- The boundness of a language's MU particle, if it has one. -/
-def ConjunctionSystem.muBoundness (sys : ConjunctionSystem) : Option Morphology.Boundness :=
-  (sys.morphemes.find? fun m => m.entry.role == .mu).map (·.entry.boundness)
+/-- The `Morph.Kind` of a language's MU particle, if it has one. -/
+def ConjunctionSystem.muKind (sys : ConjunctionSystem) : Option Morphology.Morph.Kind :=
+  (sys.morphemes.find? fun m => m.entry.role == .mu).map (·.entry.kind)
 
 /-! ### Coordinate-structure symmetry -/
 


### PR DESCRIPTION
Morphs and coordination morphemes now store `Morph.Kind` (side + affix/clitic attachment); the free-vs-bound cut reads off `Kind.IsBound`.

The two-case `Boundness` enum discarded attachment data the fragments' own prose already states; `Kind` storage recovers it.