### PR TITLE
refactor(Morphology): drop IsBound wrappers; sites check .bound directly

### DIFF
--- a/Linglib/Fragments/Dargwa/Coordination.lean
+++ b/Linglib/Fragments/Dargwa/Coordination.lean
@@ -79,7 +79,7 @@ theorem mu_is_additive :
 
 /-- The MU particle is bound (enclitic). -/
 theorem mu_is_bound :
-    (allEntries.filter (·.role == .mu)).all (fun e => decide e.kind.IsBound) = true := by
+    (allEntries.filter (·.role == .mu)).all (fun e => e.kind matches .bound ..) = true := by
   decide
 
 end Dargwa.Coordination

--- a/Linglib/Fragments/Georgian/Coordination.lean
+++ b/Linglib/Fragments/Georgian/Coordination.lean
@@ -64,12 +64,12 @@ def allEntries : List Coordinator :=
 
 /-- Georgian has exactly one bound morpheme: the MU clitic -c. -/
 theorem one_bound :
-    (allEntries.filter (fun e => decide e.kind.IsBound)).length = 1 := by
+    (allEntries.filter (fun e => e.kind matches .bound ..)).length = 1 := by
   decide
 
 /-- The bound morpheme is the MU particle. -/
 theorem bound_is_mu :
-    (allEntries.filter (fun e => decide e.kind.IsBound)).all (·.role == .mu) = true := by
+    (allEntries.filter (fun e => e.kind matches .bound ..)).all (·.role == .mu) = true := by
   decide
 
 /-- The MU particle -c also serves as an additive particle. -/

--- a/Linglib/Fragments/Japanese/Coordination.lean
+++ b/Linglib/Fragments/Japanese/Coordination.lean
@@ -90,7 +90,7 @@ def allEntries : List Coordinator :=
 
 /-- All Japanese coordination particles are bound (postpositive). -/
 theorem all_bound :
-    allEntries.all (fun e => decide e.kind.IsBound) = true := by
+    allEntries.all (fun e => e.kind matches .bound ..) = true := by
   decide
 
 /-- The MU particle "mo" also serves as an additive particle. -/

--- a/Linglib/Fragments/Latin/Coordination.lean
+++ b/Linglib/Fragments/Latin/Coordination.lean
@@ -89,12 +89,12 @@ def allEntries : List Coordinator :=
 
 /-- Latin has exactly one bound morpheme: -que. -/
 theorem one_bound_morpheme :
-    (allEntries.filter (fun e => decide e.kind.IsBound)).length = 1 := by
+    (allEntries.filter (fun e => e.kind matches .bound ..)).length = 1 := by
   decide
 
 /-- The bound morpheme is the MU particle -que. -/
 theorem bound_is_mu :
-    (allEntries.filter (fun e => decide e.kind.IsBound)).all (·.role == .mu) = true := by
+    (allEntries.filter (fun e => e.kind matches .bound ..)).all (·.role == .mu) = true := by
   decide
 
 /-- Latin has correlative uses of J, disjunction, and negative coordination. -/

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -44,16 +44,8 @@ inductive Morph.Kind where
   | free
   deriving DecidableEq, Repr, Fintype
 
-/-- A morph is **bound** when its recorded `Kind` is `bound` — attaching on a
-side of its host as an affix or clitic; roots and free forms are not.
-
-This is *morphosyntactic* boundness; prosodic boundness belongs to the prosodic
-word (`Phonology/Prosody`). The coarse two-way cut is read across domains:
-acquisition ([clark-2017]: free morphemes are acquired more readily than bound
-ones) and coordination typology
-([mitrovic-sauerland-2016]). `IsBound` reflects the *recorded* attachment: a
-root morph may itself be bound in a language, but `Kind` does not record it, so
-`(Kind.root).IsBound` is `False` by definition, not by claim. -/
+/-- A morph is **bound** when it attaches on a side of its host, as an affix or
+a clitic. -/
 def Morph.Kind.IsBound : Morph.Kind → Prop
   | .bound .. => True
   | .root | .free => False
@@ -96,7 +88,7 @@ def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
 
-/-- A morph is bound when its `kind` is; roots and free forms are not. -/
+/-- A morph is bound when its `kind` is. -/
 def IsBound (m : Morph) : Prop := m.kind.IsBound
 
 instance : DecidablePred IsBound := fun m => inferInstanceAs (Decidable m.kind.IsBound)

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -44,17 +44,6 @@ inductive Morph.Kind where
   | free
   deriving DecidableEq, Repr, Fintype
 
-/-- A morph is **bound** when it attaches on a side of its host, as an affix or
-a clitic. -/
-def Morph.Kind.IsBound : Morph.Kind → Prop
-  | .bound .. => True
-  | .root | .free => False
-
-instance : DecidablePred Morph.Kind.IsBound := fun k =>
-  match k with
-  | .bound .. => .isTrue trivial
-  | .root | .free => .isFalse (fun h => h)
-
 /-- A **morph** is a minimal segmental form with its attachment kind. -/
 structure Morph where
   /-- How the morph attaches. -/

--- a/Linglib/Morphology/Morph.lean
+++ b/Linglib/Morphology/Morph.lean
@@ -88,11 +88,6 @@ def attachment? : Morph → Option Attachment
   | ⟨.bound _ a, _⟩ => some a
   | _ => none
 
-/-- A morph is bound when its `kind` is. -/
-def IsBound (m : Morph) : Prop := m.kind.IsBound
-
-instance : DecidablePred IsBound := fun m => inferInstanceAs (Decidable m.kind.IsBound)
-
 instance : ToString Morph :=
   ⟨fun m => match m.kind with
     | .bound .before .affix => m.form ++ "-"

--- a/Linglib/Semantics/Coordination/Defs.lean
+++ b/Linglib/Semantics/Coordination/Defs.lean
@@ -75,7 +75,7 @@ structure Coordinator where
   gloss : String
   /-- Which Boolean operation it denotes. -/
   role : Coordinator.Role
-  /-- Full attachment kind; the free-vs-bound cut is `Morph.Kind.IsBound`. -/
+  /-- Full attachment kind. -/
   kind : Morphology.Morph.Kind
   /-- Does this morpheme also serve as an additive/focus particle? -/
   alsoAdditive : Bool := false

--- a/Linglib/Studies/ZwickyPullum1983.lean
+++ b/Linglib/Studies/ZwickyPullum1983.lean
@@ -94,13 +94,6 @@ def MorphStatus.IsClitic (s : MorphStatus) : Prop :=
 instance : DecidablePred MorphStatus.IsClitic :=
   fun _ => inferInstanceAs (Decidable (_ ∨ _))
 
-/-- A morph status is bound unless it is a free word: clitics and affixes
-are bound. -/
-def MorphStatus.IsBound (s : MorphStatus) : Prop := s ≠ .freeWord
-
-instance : DecidablePred MorphStatus.IsBound :=
-  fun _ => inferInstanceAs (Decidable (_ ≠ _))
-
 structure CliticAffixProfile where
   morpheme : String
   selection : SelectionDegree


### PR DESCRIPTION
Boundness predicates were unconsumed indirection: every real use site holds a Kind and checks `matches .bound ..` directly. Cuts Kind.IsBound, the Morph delegate, and ZP1983 MorphStatus.IsBound (all zero-consumer); the bound-root Kind extension is minted if a cranberry-type consumer ever arrives.