### PR TITLE
refactor(Syntax/Binding): Word.Agree moves to its owning engine

### DIFF
--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -32,7 +32,6 @@ Table 3) is formalized in `Studies/KalinBjorkmanEtAl2026.lean`.
 
 * `Word` — the token, with its **admission rule** (see the declaration docstring).
 * `Word.phi` — the φ-feature projection (person/number/gender).
-* `Word.Agree` — φ-agreement: a reflexive, symmetric, non-transitive tolerance relation.
 * `Word.asPassive` — passive variant (voice morphology only; valence effects are
   `DepTree.frames`-level facts).
 -/
@@ -69,58 +68,12 @@ def Word.phi (w : Word) : UD.MorphFeatures :=
   { person := w.features.person, number := w.features.number,
     gender := w.features.gender }
 
-/-- φ-agreement between two words: their person/number/gender features are
-    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
-    *tolerance* relation on `Word` (not transitive), decided by the shared
-    `UD.MorphFeatures.compatible`. This is the feature-based agreement primitive
-    binding and concord consumers share — no surface-form gender lookup. -/
-def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
-
-instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
-  unfold Word.Agree; infer_instance
-
-@[refl] theorem Word.Agree.refl (w : Word) : Word.Agree w w :=
-  UD.MorphFeatures.compatible_self w.phi
-
-/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation", as a
-    theorem. -/
-@[symm] theorem Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) : Word.Agree w2 w1 := by
-  unfold Word.Agree at h ⊢
-  rwa [UD.MorphFeatures.compatible_comm]
-
-/-- φ-agreement is *not* transitive: an unspecified feature is a wildcard, so
-    underspecified *they* agrees with both *she* and *he* while *she ≁ he*. -/
-theorem Word.Agree.not_transitive :
-    ¬ ∀ w1 w2 w3 : Word, Word.Agree w1 w2 → Word.Agree w2 w3 → Word.Agree w1 w3 := by
-  intro h
-  exact absurd
-    (h ⟨"she", .PRON, { person := some .third, number := some .Sing, gender := some .Fem }⟩
-       ⟨"they", .PRON, { person := some .third }⟩
-       ⟨"he", .PRON, { person := some .third, number := some .Sing, gender := some .Masc }⟩
-       (by decide) (by decide))
-    (by decide)
-
 /-- A word bears the number its UD morphology ingests (`Number.fromUD`). -/
 instance : HasNumber Word := ⟨fun w => w.features.number.bind Number.fromUD⟩
 
 instance : HasPerson Word := ⟨fun w => w.features.person.map Person.fromUD⟩
 
 instance : HasCase Word := ⟨fun w => w.features.case_.map Case.fromUD⟩
-
-/-- The φ-projection preserves `numberOf`: a word and its `phi` bundle bear
-    the same number — the defeq `Word.Agree.hasNumber_compatible` relies on. -/
-@[simp] theorem Word.numberOf_phi (w : Word) :
-    HasNumber.numberOf w.phi = HasNumber.numberOf w := rfl
-
-/-- φ-agreement entails number compatibility: the `HasNumber` mixin never
-    diverges from the agreement engine on `Word`. -/
-theorem Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
-    HasNumber.Compatible w1 w2 :=
-  UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h
-
--- `reflex` is deliberately not an agreement feature: a reflexive-marked token still
--- agrees with an unmarked one (the φ-projection drops it).
-example : Word.Agree ⟨"sich", .PRON, { reflex := true }⟩ ⟨"Kind", .NOUN, {}⟩ := by decide
 
 /-- Derive a passive variant: sets voice to passive. The valence change
     (detransitivization) is a frame-level fact carried by the passive analysis on

--- a/Linglib/Studies/WechslerZlatic2000.lean
+++ b/Linglib/Studies/WechslerZlatic2000.lean
@@ -35,7 +35,7 @@ the seven a-priori possibilities, all attested (their §9, n. 3).
 * `concordAgrees`/`indexAgrees` — target checking through the
   `HasX.Compatible` mixins, with the *deca* paradigm (exs. 41–42)
 * `no_single_phi_bundle_for_deca` — the §3.3 single-bundle "illusion" as
-  a refutation against `Word.Agree`
+  a refutation of the single-bundle view (`phiAgree`)
 * `indexReaders_lowerSet` — the Agreement Hierarchy skeleton over
   `Agreement.Target`, robust to the open predicate position
 
@@ -461,15 +461,22 @@ theorem regular_nouns_mask_the_split (n : Noun) (hn : ConInd n)
   simp only [HasNumber.Compatible, Noun.indexTarget, Noun.concordAt,
     HasNumber.numberOf, hnum]
 
-/-- The single-φ-bundle view (`Word.phi`/`Word.Agree`) cannot host
-    *deca*: its CONCORD-bearing attributive (f.sg) and its INDEX-bearing
-    pronoun (nt.pl) do not `Word.Agree`, so they cannot both copy one
-    fully-valued source bundle. This is §3.3's "illusion", as a
-    refutation against the library's one-bundle primitive — note a
-    *featureless* word would tolerate both (wildcards), so the claim is
-    about the two specified surface forms, not about compatibility. -/
+/-- The **single-φ-bundle view** of agreement the study refutes: one bundle per
+    word, agreement as pairwise compatibility of the `Word.phi` projections
+    (an unspecified feature is a wildcard). -/
+def phiAgree (w₁ w₂ : Word) : Prop := w₁.phi.compatible w₂.phi
+
+instance (w₁ w₂ : Word) : Decidable (phiAgree w₁ w₂) := by
+  unfold phiAgree; infer_instance
+
+/-- The single-φ-bundle view cannot host *deca*: its CONCORD-bearing
+    attributive (f.sg) and its INDEX-bearing pronoun (nt.pl) do not
+    `phiAgree`, so they cannot both copy one fully-valued source bundle.
+    This is §3.3's "illusion" — note a *featureless* word would tolerate
+    both (wildcards), so the claim is about the two specified surface
+    forms, not about compatibility. -/
 theorem no_single_phi_bundle_for_deca :
-    ¬ Word.Agree
+    ¬ phiAgree
         ⟨"dobra", .ADJ, { gender := some .Fem, number := some .Sing }⟩
         ⟨"ona", .PRON, { gender := some .Neut, number := some .Plur }⟩ := by
   decide

--- a/Linglib/Syntax/Binding/Basic.lean
+++ b/Linglib/Syntax/Binding/Basic.lean
@@ -46,6 +46,48 @@ A language (English, …) supplies the classifier; a framework supplies the
 command relation; a study combines them.
 -/
 
+/-- φ-agreement between two words: their person/number/gender features are
+    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
+    *tolerance* relation on `Word` (not transitive), decided by the shared
+    `UD.MorphFeatures.compatible`. The feature-based agreement check binding
+    and concord consumers share — no surface-form gender lookup. -/
+def Morphology.Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
+
+instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
+  unfold Morphology.Word.Agree; infer_instance
+
+@[refl] theorem Morphology.Word.Agree.refl (w : Word) : Word.Agree w w :=
+  UD.MorphFeatures.compatible_self w.phi
+
+/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation",
+    as a theorem. -/
+@[symm] theorem Morphology.Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) :
+    Word.Agree w2 w1 := by
+  unfold Morphology.Word.Agree at h ⊢
+  rwa [UD.MorphFeatures.compatible_comm]
+
+/-- φ-agreement is *not* transitive: an unspecified feature is a wildcard, so
+    underspecified *they* agrees with both *she* and *he* while *she ≁ he*. -/
+theorem Morphology.Word.Agree.not_transitive :
+    ¬ ∀ w1 w2 w3 : Word, Word.Agree w1 w2 → Word.Agree w2 w3 → Word.Agree w1 w3 := by
+  intro h
+  exact absurd
+    (h ⟨"she", .PRON, { person := some .third, number := some .Sing, gender := some .Fem }⟩
+       ⟨"they", .PRON, { person := some .third }⟩
+       ⟨"he", .PRON, { person := some .third, number := some .Sing, gender := some .Masc }⟩
+       (by decide) (by decide))
+    (by decide)
+
+/-- φ-agreement entails number compatibility: the `HasNumber` mixin never
+    diverges from the agreement check on `Word`. -/
+theorem Morphology.Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
+    HasNumber.Compatible w1 w2 :=
+  UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h
+
+-- `reflex` is deliberately not an agreement feature: a reflexive-marked token still
+-- agrees with an unmarked one (the φ-projection drops it).
+example : Word.Agree ⟨"sich", .PRON, { reflex := true }⟩ ⟨"Kind", .NOUN, {}⟩ := by decide
+
 namespace Binding
 
 


### PR DESCRIPTION
The φ-agreement check and its laws leave the morphology token file for Syntax/Binding/Basic (its real consumer: the neutral binding engine; HPSG/DG cross-reference it there); WechslerZlatic2000 gets a study-local phiAgree foil for its refutation. Word/Basic is now the pure token. Cut numberOf_phi (zero consumers).