### PR TITLE
feat(Morphology/Word): DecidableEq; sweep title cite-blocks

### DIFF
--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -6,7 +6,6 @@ import Linglib.Syntax.Minimalist.Verbal.Voice
 
 /-!
 # Allosemy: Contextual Meaning Variation of Functional Heads
-[benz-2025] [wood-2023] [kratzer-1996]
 
 [benz-2025] "Structure and Interpretation Across Categories" examines allosemy — the
 meaning-side analog of allomorphy in Distributed Morphology. Where

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -4,9 +4,7 @@ import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Verbal.Voice
 
 /-!
-# Categorizing Heads (Distributed Morphology) [harley-2014]
-[embick-2004] [marantz-1997]
-[kramer-2015]
+# Categorizing heads
 
 [harley-2014] "On the identity of roots" addresses three questions about
 roots in DM:

--- a/Linglib/Morphology/DM/DomainLocality.lean
+++ b/Linglib/Morphology/DM/DomainLocality.lean
@@ -1,9 +1,7 @@
 import Linglib.Morphology.Paradigm.Contiguity
 
 /-!
-# Domain-Relativized Contiguity
-[moskal-2015a-dissertation] [moskal-2015]
-[smith-moskal-xu-kang-bobaljik-2019]
+# Domain-relativized contiguity
 
 A domain partition assigns each grade of a containment hierarchy a
 *domain tag* — abstractly representing the grade's locality unit

--- a/Linglib/Morphology/DM/Impoverishment.lean
+++ b/Linglib/Morphology/DM/Impoverishment.lean
@@ -2,7 +2,6 @@ import Linglib.Syntax.Minimalist.Features
 
 /-!
 # Impoverishment (Distributed Morphology)
-[halle-marantz-1993] [bonet-1991]
 
 Impoverishment is a postsyntactic operation that deletes features from
 a terminal node before Vocabulary Insertion. It is the DM mechanism for

--- a/Linglib/Morphology/DM/Merger.lean
+++ b/Linglib/Morphology/DM/Merger.lean
@@ -4,7 +4,6 @@ import Mathlib.Logic.Relation
 
 /-!
 # Synthetic and analytic realization: Merger over a containment hierarchy
-[bobaljik-2012]
 
 [bobaljik-2012] ch. 3 treats the synthetic/analytic distinction as
 structural: a grade is realized synthetically when Merger has bundled

--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -6,7 +6,6 @@ import Mathlib.Data.List.MinMax
 
 /-!
 # VocabSimple: Minimalist-specific Vocabulary Insertion
-[halle-marantz-1993] [kiparsky-1973] [elkins-torrence-brown-2026]
 
 A concrete Minimalist specialization of Vocabulary Insertion.
 `VocabEntry` carries `features : FeatureBundle` (the Minimalist

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -3,7 +3,6 @@ import Linglib.Morphology.Exponence.Select
 
 /-!
 # Vocabulary Insertion (Distributed Morphology)
-[halle-marantz-1993] [bobaljik-2000]
 
 Vocabulary Insertion is the mechanism by which syntactic terminal nodes
 receive phonological exponents in Distributed Morphology. It is the

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -3,7 +3,6 @@ import Mathlib.Data.Set.Basic
 
 /-!
 # Rules of exponence
-[kiparsky-1973] [halle-marantz-1993] [stump-2001] [stump-2022]
 
 **Exponence** ([matthews-1991]'s term for the mapping from morphosyntactic
 content to form) is the class every framework engine's carrier implements:

--- a/Linglib/Morphology/Exponence/Containment/Contiguity.lean
+++ b/Linglib/Morphology/Exponence/Containment/Contiguity.lean
@@ -3,7 +3,6 @@ import Linglib.Morphology.Paradigm.Contiguity
 
 /-!
 # Containment hierarchies: contiguity and the suppletion generalizations
-[bobaljik-2012] [starke-2009] [caha-2009] [declercq-vandenwyngaerd-2017]
 
 The *ABA generalization and its refinements, over the score selection of
 `Containment/Selection.lean`. Both engines are *ABA-free (`isContiguous_realize`,

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -4,7 +4,6 @@ import Mathlib.Order.Fin.Basic
 
 /-!
 # Vocabularies over containment hierarchies: rules and specificity
-[bobaljik-2012] [starke-2009] [caha-2009] [kiparsky-1973]
 
 The carrier for the realizational engine of [bobaljik-2012]'s
 comparative-suppletion generalizations, over an arbitrary `n`-grade

--- a/Linglib/Morphology/Exponence/Containment/Selection.lean
+++ b/Linglib/Morphology/Exponence/Containment/Selection.lean
@@ -6,7 +6,6 @@ import Mathlib.Data.Finset.Max
 
 /-!
 # Containment hierarchies: score selection
-[bobaljik-2012] [starke-2009] [caha-2009] [kiparsky-1973]
 
 Elsewhere insertion and Superset spellout. The DM `winner` maximizes
 `threshold` as an instantiation of the core's `Exponence.selectBy`, so

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -6,7 +6,6 @@ import Mathlib.Data.List.MinMax
 
 /-!
 # Elsewhere selection over rules of exponence
-[kiparsky-1973] [halle-marantz-1993] [stump-2001] [caha-2009]
 
 Selection over the specificity preorder of `Morphology/Exponence/Basic.lean`.
 An **Elsewhere winner** is a `≤`-minimal applicable rule; over a coherent

--- a/Linglib/Morphology/Morphotactics/RelevanceHierarchy.lean
+++ b/Linglib/Morphology/Morphotactics/RelevanceHierarchy.lean
@@ -4,7 +4,6 @@ import Mathlib.Data.List.Sort
 
 /-!
 # Bybee's relevance hierarchy
-[bybee-1985]
 
 [bybee-1985]'s comparative inventory of verbal inflectional categories,
 ordered by semantic relevance to the stem, and the stem-outward

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -4,7 +4,6 @@ import Mathlib.Data.List.MinMax
 
 /-!
 # Nanosyntax: Tree-Based Spellout
-[taraldsen-et-al-2018] [caha-2009] [starke-2009]
 
 Extension of rank-based Superset spellout
 (`Morphology/Exponence/Containment/Contiguity.lean`) to tree-structured spellout. Implements the Superset Principle (SP) for trees: a lexical

--- a/Linglib/Morphology/Paradigm/Basic.lean
+++ b/Linglib/Morphology/Paradigm/Basic.lean
@@ -2,7 +2,6 @@ import Mathlib.Data.Rat.Defs
 
 /-!
 # Paradigms: forms over ordered cells
-[ackerman-malouf-2013] [bobaljik-2012]
 
 The morphologist's primary observable: a **paradigm** assigns a surface
 form to each of `n` linearly ordered cells. One type serves both

--- a/Linglib/Morphology/Paradigm/Case.lean
+++ b/Linglib/Morphology/Paradigm/Case.lean
@@ -2,7 +2,6 @@ import Linglib.Morphology.Paradigm.Contiguity
 
 /-!
 # Case paradigms
-[caha-2009] [bobaljik-2012]
 
 Framework-neutral substrate for allomorphy patterns over the four core
 cases (NOM, ACC, GEN, DAT): the n = 4 specialization of

--- a/Linglib/Morphology/Paradigm/Complexity.lean
+++ b/Linglib/Morphology/Paradigm/Complexity.lean
@@ -3,7 +3,6 @@ import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
 
 /-!
 # Paradigm complexity: entropy and implicative structure over cells
-[ackerman-malouf-2013] [bonami-beniamine-2016] [rathi-hahn-futrell-2026]
 
 Two views of the Paradigm Cell Filling Problem over a `ParadigmSystem`.
 The **quantitative** layer measures cell distributions: Shannon entropy

--- a/Linglib/Morphology/Paradigm/Contiguity.lean
+++ b/Linglib/Morphology/Paradigm/Contiguity.lean
@@ -5,7 +5,6 @@ import Mathlib.Data.Finset.Image
 
 /-!
 # Paradigm contiguity: the *ABA generalization
-[bobaljik-2012] [caha-2009] [graf-2019]
 
 Across graded paradigms — degree (positive < comparative < superlative,
 [bobaljik-2012]), case (NOM < ACC < GEN < DAT, [caha-2009]), path roles

--- a/Linglib/Morphology/Paradigm/Degree.lean
+++ b/Linglib/Morphology/Paradigm/Degree.lean
@@ -2,7 +2,6 @@ import Linglib.Morphology.Paradigm.Contiguity
 
 /-!
 # Degree paradigms
-[bobaljik-2012]
 
 Framework-neutral substrate for the three-grade degree hierarchy
 (positive, comparative, superlative) and the *ABA generalization over

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -5,7 +5,6 @@ import Mathlib.Data.Fintype.Basic
 
 /-!
 # The PFM1 paradigm function
-[stump-2001] [stump-2016] [bonami-stump-2016] [kiparsky-1973]
 
 The standard Paradigm Function Morphology engine ([bonami-stump-2016]'s
 streamlined PFM1, after [stump-2001]): a paradigm function is a set of

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -2,7 +2,6 @@ import Mathlib.Data.Set.Function
 
 /-!
 # Paradigm linkage: content paradigms, form paradigms, and correspondence
-[stump-2012-mmm8]
 
 Inflectional morphology relates three levels of representation ([stump-2012-mmm8];
 the book-length apparatus is [stump-2016]): a lexeme's **content paradigm** of

--- a/Linglib/Morphology/Paradigm/Morphome.lean
+++ b/Linglib/Morphology/Paradigm/Morphome.lean
@@ -4,7 +4,6 @@ import Mathlib.Data.Set.Subsingleton
 
 /-!
 # Morphomes: syncretism classes with no natural characterization
-[herce-2023] [aronoff-1994]
 
 A realization map `p : Cell → F` assigns a form to each paradigm cell. Its
 **syncretism** relation — cells receiving the same form — is exactly

--- a/Linglib/Morphology/Paradigm/OfCells.lean
+++ b/Linglib/Morphology/Paradigm/OfCells.lean
@@ -3,7 +3,6 @@ import Linglib.Syntax.Agreement.Paradigm
 
 /-!
 # Agreement tables as ordered-cell paradigms
-[corbett-1998] [bobaljik-2012]
 
 The descriptive agreement table (`Agreement.Paradigm`, keyed by
 person/number/gender cells) and the theoretical ordered-cell object

--- a/Linglib/Morphology/Paradigm/ToTree.lean
+++ b/Linglib/Morphology/Paradigm/ToTree.lean
@@ -8,9 +8,9 @@ import Linglib.Morphology.Paradigm.Function
 
 /-!
 # The paradigm function into word trees
-[bonami-stump-2016] [spencer-2013]
 
-The engine's state type `Z` is unconstrained, so the paradigm function runs at
+The engine's state type `Z` is unconstrained ([bonami-stump-2016]'s PFM1,
+`Paradigm/Function.lean`), so the paradigm function runs at
 `Z := Word.Tree M` as readily as at material sequences. An affix-transparent
 vocabulary interprets into both, and `toList` intertwines the two runs
 (`toList_paradigmFunction_tree`); the emitted tree's stem is the chosen leaf

--- a/Linglib/Morphology/Root/Basic.lean
+++ b/Linglib/Morphology/Root/Basic.lean
@@ -2,7 +2,6 @@ import Linglib.Phonology.OCP
 
 /-!
 # Consonantal roots
-[mccarthy-1981] [faust-2026]
 
 A **consonantal root** is an ordered melody of segments stored independently
 of vocalization or template — the nonconcatenative counterpart of a linear

--- a/Linglib/Morphology/Root/Family.lean
+++ b/Linglib/Morphology/Root/Family.lean
@@ -1,6 +1,5 @@
 /-!
 # Root families: category-changing morphology
-[marantz-1997]
 
 A root family records the word forms a single (sub-morphemic) root projects
 across lexical categories — the [marantz-1997] uncategorised-roots pattern:

--- a/Linglib/Morphology/UsageBased/Network.lean
+++ b/Linglib/Morphology/UsageBased/Network.lean
@@ -1,10 +1,9 @@
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Bybee 1985 Ch 5: Dynamic Network Model of Lexical Representation
-[bybee-1985]
+# The dynamic network model
 
-This file formalizes the substrate of Bybee 1985 Ch 5 ("Two Principles in
+The substrate of [bybee-1985] Ch 5 ("Two Principles in
 a Dynamic Model of Lexical Representation," pp. 111-135). It is a peer-
 framework directory alongside `Morphology/{DM, Nanosyntax,
 FragmentGrammars}/` — Bybee's network model is *the* usage-based

--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -39,7 +39,7 @@ structure Word where
   cat : UD.UPOS
   /-- The UD morphological features. -/
   features : UD.MorphFeatures := {}
-  deriving Repr
+  deriving Repr, DecidableEq
 
 /-- Convenience constructor for a featureless word (form + category only). -/
 def Word.mk' (form : String) (cat : UD.UPOS) : Word := { form := form, cat := cat }

--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -10,7 +10,6 @@ import Linglib.Features.Person.Capabilities
 
 /-!
 # Word — the morphosyntactic word (ms-word) token
-[kalin-bjorkman-etal-2026]
 
 The surface token: the unit (morpho)syntax treats as a word, approximating the
 ms-word of the ms-word/p-word split ([kalin-bjorkman-etal-2026]; the p-word is

--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -9,7 +9,7 @@ import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person.Capabilities
 
 /-!
-# Word — the morphosyntactic word (ms-word) token
+# Word tokens
 
 The surface token: the unit (morpho)syntax treats as a word, approximating the
 ms-word of the ms-word/p-word split ([kalin-bjorkman-etal-2026]; the p-word is


### PR DESCRIPTION
Structural equality for the token, plus the Morphology-wide register sweep: title cite-blocks dropped (all keys already inline or moved into prose); un-mathlib-y titles renamed.