### PR TITLE
feat(Morphology): Haspelmath root API; melody to ConsonantalRoot; DM/Root

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1261,6 +1261,7 @@ import Linglib.Morphology.DM.Fission
 import Linglib.Morphology.DM.Impoverishment
 import Linglib.Morphology.DM.Merger
 import Linglib.Morphology.DM.NominalStructure
+import Linglib.Morphology.DM.Root
 import Linglib.Morphology.DM.VocabSimple
 import Linglib.Morphology.DM.VocabularyInsertion
 import Linglib.Morphology.Exponence.Basic
@@ -1289,7 +1290,8 @@ import Linglib.Morphology.Paradigm.Function
 import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Morphology.Paradigm.OfCells
-import Linglib.Morphology.Root
+import Linglib.Morphology.Root.Basic
+import Linglib.Morphology.Root.Consonantal
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Paradigm.ToTree
 import Linglib.Morphology.Word.Tree

--- a/Linglib/Fragments/Amharic/ConsonantalRoots.lean
+++ b/Linglib/Fragments/Amharic/ConsonantalRoots.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.Root
+import Linglib.Morphology.Root.Consonantal
 import Linglib.Phonology.Constraints.Basic
 
 /-!
@@ -33,23 +33,23 @@ open Morphology
     nominal forms (gerund, INF), the feminine /t/ intrudes — *not* as
     a default consonant but as the n[+gen] exponent ([faust-2026]
     (7)–(8), (11)–(12)). -/
-def fdj : Root String := ⟨["f", "d", "j"]⟩
+def fdj : ConsonantalRoot String := ⟨["f", "d", "j"]⟩
 
 /-- √hid — base of [hed-ä] `go` PFV.3MSG, INF [mäh(i)d].
     A "hollow" root in the standard analysis: the medial radical /i/
     is non-consonantal and merges with the vocalization
     ([faust-2026] (12e), (13c)). -/
-def hid : Root String := ⟨["h", "i", "d"]⟩
+def hid : ConsonantalRoot String := ⟨["h", "i", "d"]⟩
 
 /-- √sma — base of [sämm-a] `hear` PFV.3MSG, INF [mäsmat]
     ([faust-2026] (12c), (13a)). The non-consonantal final radical
     /a/ merges with the vocalization. -/
-def sma : Root String := ⟨["s", "m", "a"]⟩
+def sma : ConsonantalRoot String := ⟨["s", "m", "a"]⟩
 
 /-- √sam — base of [sam-ä] `kiss` PFV.3MSG, INF [mäsam]
     ([faust-2026] (12d), (13b)). The non-consonantal medial
     radical /a/ merges with the vocalization. -/
-def sam : Root String := ⟨["s", "a", "m"]⟩
+def sam : ConsonantalRoot String := ⟨["s", "a", "m"]⟩
 
 -- ============================================================================
 -- § 2: True triradical (control) and Faust's biradical reanalysis
@@ -58,7 +58,7 @@ def sam : Root String := ⟨["s", "a", "m"]⟩
 /-- √sbr — base of [säbbär-ä] `break` PFV.3MSG, INF [mäsbär]
     ([faust-2026] (5a), (12a)). A canonical type-A triradical
     with three distinct surface consonants. -/
-def sbr : Root String := ⟨["s", "b", "r"]⟩
+def sbr : ConsonantalRoot String := ⟨["s", "b", "r"]⟩
 
 /-- √wd — base of [wäddäd-ä] `liked` PFV.3MSG ([faust-2026] (5b),
     page 432). Both [broselow-1984] and [faust-2026] agree
@@ -68,7 +68,7 @@ def sbr : Root String := ⟨["s", "b", "r"]⟩
     OCP at the root level, since /w/ ≠ /d/ — even though it surfaces
     with adjacent identical [d][d] in [wäddäd-ä]. The surface gemination
     is a template-spreading effect, not a root-level identity. -/
-def wd : Root String := ⟨["w", "d"]⟩
+def wd : ConsonantalRoot String := ⟨["w", "d"]⟩
 
 -- ============================================================================
 -- § 3: Sanity properties

--- a/Linglib/Fragments/Hebrew/ConsonantalRoots.lean
+++ b/Linglib/Fragments/Hebrew/ConsonantalRoots.lean
@@ -1,9 +1,9 @@
-import Linglib.Morphology.Root
+import Linglib.Morphology.Root.Consonantal
 
 /-!
 # Modern Hebrew Consonantal Roots
 
-A small inventory of Modern Hebrew consonantal roots, stored as `Root String`
+A small inventory of Modern Hebrew consonantal roots, stored as `ConsonantalRoot String`
 (IPA-symbol segments). Used by templatic-morphology studies, in particular
 [faust-2026]'s analysis of the QaTaT–QaTa problem and templatic intrusion.
 
@@ -25,13 +25,13 @@ open Morphology
     [kaluj] passive participle. The third radical is the glide [j],
     which fails to associate to the [+c]-specified final C-slot of
     the verbal template ([faust-2026] (4)). -/
-def klj : Root String := ⟨["k", "l", "j"]⟩
+def klj : ConsonantalRoot String := ⟨["k", "l", "j"]⟩
 
 /-- √klt — base of [kalat] PST.3MSG `receive`, [klita] action noun,
     [kalut] passive participle ([faust-2026] (3a)). The full
     triradical control case: every radical surfaces in every form,
     no glide-related issue arises. -/
-def klt : Root String := ⟨["k", "l", "t"]⟩
+def klt : ConsonantalRoot String := ⟨["k", "l", "t"]⟩
 
 /-- √kll — base of [kalal] PST.3MSG `include`, [klila] action noun,
     [kalul] passive participle ([faust-2026] (3b)). The
@@ -39,15 +39,15 @@ def klt : Root String := ⟨["k", "l", "t"]⟩
     root segment, so its association to the template-final C-slot
     does NOT violate \*Misalignment. This is the QaTaT pattern that
     contrasts with the QaTa pattern of (3c) under the same template. -/
-def kll : Root String := ⟨["k", "l", "l"]⟩
+def kll : ConsonantalRoot String := ⟨["k", "l", "l"]⟩
 
 /-- √dmj — base of nominal [dimuj] `simile` and the taQTiL noun
     [tadmit] `(public) image` ([faust-2026] (9b)). -/
-def dmj : Root String := ⟨["d", "m", "j"]⟩
+def dmj : ConsonantalRoot String := ⟨["d", "m", "j"]⟩
 
 /-- √bnj — base of passive participle [banuj] `built` and the
     taQTiL nouns [tavnit] `mold` (and similar). Third radical [j]. -/
-def bnj : Root String := ⟨["b", "n", "j"]⟩
+def bnj : ConsonantalRoot String := ⟨["b", "n", "j"]⟩
 
 -- ============================================================================
 -- § 2: Non-glide-final triradicals (control class)
@@ -56,11 +56,11 @@ def bnj : Root String := ⟨["b", "n", "j"]⟩
 /-- √ktv — base of [katav] PST.3MSG `wrote`, [katuv] passive
     participle `written`. Final radical [v], a true consonant; the
     QaTaT–QaTa problem does not arise. -/
-def ktv : Root String := ⟨["k", "t", "v"]⟩
+def ktv : ConsonantalRoot String := ⟨["k", "t", "v"]⟩
 
 /-- √sbr — base of [ʃavar] PST.3MSG `broke` (Faust uses this in the
     Amharic comparison; Hebrew cognate). -/
-def sbr : Root String := ⟨["ʃ", "b", "r"]⟩
+def sbr : ConsonantalRoot String := ⟨["ʃ", "b", "r"]⟩
 
 -- ============================================================================
 -- § 3: Sanity properties

--- a/Linglib/Fragments/Tigre/Phonology.lean
+++ b/Linglib/Fragments/Tigre/Phonology.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Morphology.Root
+import Linglib.Morphology.Root.Consonantal
 import Linglib.Fragments.Tigrinya.Phonology
 
 /-!
@@ -78,45 +78,45 @@ abbrev Guttural := Tigrinya.Phonology.Guttural
 /-- √mzn — 'weigh'. Tigre. Paper 2-JUSS [ti-mazzɨn] / IMP [mazzɨn]
     (eq. 5a) — non-guttural triradical, control case for the [ɨ]
     epenthesis in initial-cluster position. -/
-def weigh : Root String := ⟨["m", "z", "n"]⟩
+def weigh : ConsonantalRoot String := ⟨["m", "z", "n"]⟩
 
 /-- √fgr — 'leave'. Tigre. Paper PRF-3MSG [fagr-a] / 2-JUSS
     [ti-fgʌr] (eq. 6a, 5b). Non-guttural triradical baseline. -/
-def leave : Root String := ⟨["f", "g", "r"]⟩
+def leave : ConsonantalRoot String := ⟨["f", "g", "r"]⟩
 
 /-- √ħtʕb — 'wash'. Tigre. Paper PRF-3MSG [ħatʔb-a] / 2-JUSS
     [ti-hitʔʕab] (eq. 6b) — the bold [i] in 2-JUSS marks epenthetic
     [ɨ] inserted to license the medial pharyngeal codas. -/
-def wash : Root String := ⟨["ħ", "t", "ʕ", "b"]⟩
+def wash : ConsonantalRoot String := ⟨["ħ", "t", "ʕ", "b"]⟩
 
 /-- √hrb — 'flee'. Tigre. Paper PRF-3MSG [harb-a] / 2-JUSS
     [ti-hirʌb] (eq. 6c), where the bold [i] marks the epenthetic
     [ɨ] licensing the initial guttural. -/
-def flee : Root String := ⟨["h", "r", "b"]⟩
+def flee : ConsonantalRoot String := ⟨["h", "r", "b"]⟩
 
 /-- √knʕ — 'get up'. Tigre. Paper 2-JUSS [ti-kʔnʌʕ] / IMP [kʔɨnʌʕ]
     (eq. 5c). Quadri-radical (k, ʔ, n, ʕ) — illustrates how an
     initial-cluster epenthetic [ɨ] interacts with a final guttural. -/
-def getUp : Root String := ⟨["k", "ʔ", "n", "ʕ"]⟩
+def getUp : ConsonantalRoot String := ⟨["k", "ʔ", "n", "ʕ"]⟩
 
 /-- √fgr — 'whip'. Tigre. Paper 2-IMP.M [(ti-)fʌggɨr] (eq. 12a) —
     the regular Tigre imperfective with medial geminate, baseline
     for eq. (12)'s /CʌGV/ → CGV in Tigre imperfectives discussion. -/
-def whip : Root String := ⟨["f", "g", "r"]⟩
+def whip : ConsonantalRoot String := ⟨["f", "g", "r"]⟩
 
 /-- √sʔl — 'ask'. Tigre. Paper 2-IMP.M [ti-sʔil] (eq. 12b). Same
     root as Tigrinya. The bold [i] marks epenthetic [ɨ]. -/
-def ask : Root String := ⟨["s", "ʔ", "l"]⟩
+def ask : ConsonantalRoot String := ⟨["s", "ʔ", "l"]⟩
 
 /-- √tʔʕn — 'load'. Tigre. Paper 2-IMP.M [ti-tʔʕin] (eq. 12c).
     Quadri-radical (t, ʔ, ʕ, n) with medial pharyngeal /ʕ/. -/
-def load : Root String := ⟨["t", "ʔ", "ʕ", "n"]⟩
+def load : ConsonantalRoot String := ⟨["t", "ʔ", "ʕ", "n"]⟩
 
 /-- √shk — 'uncover'. Tigre. Paper 2-IMP.M [ti-shik] (eq. 12d). -/
-def uncoverTigre : Root String := ⟨["s", "h", "k"]⟩
+def uncoverTigre : ConsonantalRoot String := ⟨["s", "h", "k"]⟩
 
 /-- √sħb — 'pull'. Tigre version of Tigrinya √sħb. Paper Tigre form
     [ti-sħib] from /tisʌħib/ (eq. 26d). -/
-def pull : Root String := ⟨["s", "ħ", "b"]⟩
+def pull : ConsonantalRoot String := ⟨["s", "ħ", "b"]⟩
 
 end Tigre.Phonology

--- a/Linglib/Fragments/Tigrinya/Phonology.lean
+++ b/Linglib/Fragments/Tigrinya/Phonology.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Morphology.Root
+import Linglib.Morphology.Root.Consonantal
 
 /-!
 # Tigrinya Phonological Inventory and Verbal Roots
@@ -73,7 +73,7 @@ scenarios its analysis treats:
 * roots with weak |I|-final radicals (the bi-morphemic /iIu/ → [ju]
   syneresis case)
 
-Roots are stored as `Morphology.Root String` per the existing
+Roots are stored as `Morphology.ConsonantalRoot String` per the existing
 Hebrew/Amharic pattern.
 -/
 
@@ -222,25 +222,25 @@ end Guttural
 /-- √grf — 'whip'. Triradical, no gutturals. The control case for
     syneresis: paper PRF [gʌrif-e] (eq. 8a), no syncope across V-initial
     suffixes. Used throughout the paper as the non-guttural baseline. -/
-def whip : Root String := ⟨["g", "r", "f"]⟩
+def whip : ConsonantalRoot String := ⟨["g", "r", "f"]⟩
 
 /-- √smʕ — 'hear'. Triradical, final-position pharyngeal /ʕ/. Paper
     DEP.PRF [sʌmaʕ-] (eq. 4b), IMP.M [simaʕ] vs IMP.F [simʕ-i] (eq.
     10c) — syneresis applies when /ʌ/ + /ʕ/ are open-syllable
     adjacent before a vowel-initial suffix. -/
-def hear : Root String := ⟨["s", "m", "ʕ"]⟩
+def hear : ConsonantalRoot String := ⟨["s", "m", "ʕ"]⟩
 
 /-- √sħb — 'pull'. Triradical, medial-position pharyngeal /ħ/. Paper
     DEP.PRF row in eq. 4d shows `saħab` (no hyphen on this row); eq.
     15d shows the variant `sahab- (~ sɨħab-)`. The opaque-syneresis
     case (paper §2.3 eq. 16): /sʌħʌb/ → fusion + lowering → /s_ħab/
     → epenthesis [siħab] or trans-guttural harmony [sahab]. -/
-def pull : Root String := ⟨["s", "ħ", "b"]⟩
+def pull : ConsonantalRoot String := ⟨["s", "ħ", "b"]⟩
 
 /-- √ʔsr — 'arrest'. Triradical, initial-position glottal stop. Paper
     DEP.PRF [ʔasʌr-] (eq. 4c), PRF [ʔasir-] — illustrates how the
     initial guttural interacts with stem vocalization. -/
-def arrest : Root String := ⟨["ʔ", "s", "r"]⟩
+def arrest : ConsonantalRoot String := ⟨["ʔ", "s", "r"]⟩
 
 /-- √stI — 'drink'. Bi-morphemic weak-final root: the third radical is
     the element /I/, which surfaces as [j] before vowels (paper eq.
@@ -249,37 +249,37 @@ def arrest : Root String := ⟨["ʔ", "s", "r"]⟩
     glide surfaces). The parallel motivating the paper's |A|-syneresis
     analysis. The capital "I" in the third position marks it as the
     underlying ET element (not a vowel /i/). -/
-def drink : Root String := ⟨["s", "t", "I"]⟩
+def drink : ConsonantalRoot String := ⟨["s", "t", "I"]⟩
 
 /-- √mhr — 'teach'. Triradical, medial-position glottal /h/. Paper IMP
     [mahar] (eq. 7e); PASS-PRF [ti-mihir] ~ [ti-mɨhir] (eq. 17c) —
     the latter shows the unexpected /CʌGV/ → [CɨGV] pattern of eq.
     (17), where the V-position is retained as epenthetic [ɨ]. -/
-def teach : Root String := ⟨["m", "h", "r"]⟩
+def teach : ConsonantalRoot String := ⟨["m", "h", "r"]⟩
 
 /-- √hrd — 'slaughter'. Triradical, initial /h/. Paper 2-PRF
     [ta-harrid] (eq. 7b) — the initial guttural triggers TGH so the
     prefix vowel surfaces as [a] instead of [i]. -/
-def slaughter : Root String := ⟨["h", "r", "d"]⟩
+def slaughter : ConsonantalRoot String := ⟨["h", "r", "d"]⟩
 
 /-- √hdm — 'escape'. Paper 2-PRF [ta-hadim] (eq. 7c) — same TGH
     pattern as `slaughter`. -/
-def escape : Root String := ⟨["h", "d", "m"]⟩
+def escape : ConsonantalRoot String := ⟨["h", "d", "m"]⟩
 
 /-- √sʔl — 'ask'. Triradical, medial /ʔ/. Paper IMP [saʔal] (eq. 7f)
     + 2-IMPRF [ti-siʔil] / PASS-PRF [tisiʔil ~ ti-sɨʔil] (eq. 17d) —
     the [ɨ] alternant in PASS-PRF is the eq. (17) retention pattern. -/
-def ask : Root String := ⟨["s", "ʔ", "l"]⟩
+def ask : ConsonantalRoot String := ⟨["s", "ʔ", "l"]⟩
 
 /-- √glh — 'uncover'. Triradical, final-position /h/. Paper IMP.M
     [gilah] / IMP.F [gilh-i] (eq. 10d) — final-guttural syneresis case. -/
-def uncover : Root String := ⟨["g", "l", "h"]⟩
+def uncover : ConsonantalRoot String := ⟨["g", "l", "h"]⟩
 
 /-- √nbħ — 'bark'. Triradical, final-position /ħ/. Paper IMP.M
     [niβah] / IMP.F [nibh-i] (eq. 10b) — the IMP.M shows the
     lowering of the underlying /ʌ/ to [a] before the final guttural,
     while IMP.F shows syneresis (the /ʌ/ vacates V₂). -/
-def bark : Root String := ⟨["n", "b", "ħ"]⟩
+def bark : ConsonantalRoot String := ⟨["n", "b", "ħ"]⟩
 
 /-- √brk — 'bless'. Triradical, no guttural. Type-C verb (paper p.
     12, with [a] after first radical throughout the inflection).
@@ -289,6 +289,6 @@ def bark : Root String := ⟨["n", "b", "ħ"]⟩
     /a/ replaced by [ɨ] in the gerund — and the paper notes this is
     NOT phonotactically motivated since *[mibrak] would not pose a
     phonotactic problem (page 12). -/
-def bless : Root String := ⟨["b", "r", "k"]⟩
+def bless : ConsonantalRoot String := ⟨["b", "r", "k"]⟩
 
 end Tigrinya.Phonology

--- a/Linglib/Morphology/DM/Root.lean
+++ b/Linglib/Morphology/DM/Root.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+
+/-!
+# Roots in Distributed Morphology
+
+The abstract Root: a syntactic atom individuated by an arbitrary index,
+with no phonological or semantic content ([harley-2014] §2,
+[marantz-1997]). It is acategorial — it enters the syntax only by merging
+with a categorizing head (the Categorization Assumption; the categorizer
+inventory and `RootLicense` interface are `DM/Categorizer.lean`, whose
+`RootIdx` parameter this type instantiates) — and receives its form at
+Vocabulary Insertion (`DM/VocabularyInsertion.lean`).
+
+This is a different object from the comparative-concept root of
+`Morphology/Root/Basic.lean`, which is a contentful *morph*: a DM Root is
+not a form but an abstract element realized by forms. Where
+[haspelmath-2025-root] treats *hammer* (noun) and *hammer* (verb) as
+heterosemous sister roots, DM derives both from one acategorial √ under
+different categorizers; that rivalry is study content, this file only
+fixes the object.
+-/
+
+namespace Morphology.DM
+
+/-- A Root terminal node, individuated by an arbitrary index alone — with
+deliberately no form or meaning fields, following [harley-2014]'s answer to
+what roots are. -/
+structure Root where
+  /-- The individuating index. -/
+  index : Nat
+  deriving DecidableEq, Repr
+
+end Morphology.DM

--- a/Linglib/Morphology/Morphotactics/CVTemplate.lean
+++ b/Linglib/Morphology/Morphotactics/CVTemplate.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Morphology.Root
+import Linglib.Morphology.Root.Consonantal
 import Linglib.Phonology.Autosegmental.NonCrossing
 
 /-!
@@ -152,7 +152,7 @@ sharing everything but `associations`; gemination is one melody index
 associated to several slots. -/
 structure TemplateMatch (α : Type*) where
   /-- The consonantal root. -/
-  root : Root α
+  root : ConsonantalRoot α
   /-- The vocalic melody. -/
   vocalism : List α := []
   /-- The affixal material. -/
@@ -214,7 +214,7 @@ instance (s : AssocSource) : Decidable (m.OrderedOn s) :=
   inferInstanceAs (Decidable (∀ a ∈ m.associations, ∀ b ∈ m.associations, _))
 
 /-- A match with no associations spells out to nothing. -/
-theorem spellout_nil (r : Root α) (t : CVTemplate) :
+theorem spellout_nil (r : ConsonantalRoot α) (t : CVTemplate) :
     (TemplateMatch.mk r [] [] t []).spellout = [] := by
   simp [spellout]
 

--- a/Linglib/Morphology/Root/Basic.lean
+++ b/Linglib/Morphology/Root/Basic.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Data.UD.Basic
+import Linglib.Morphology.Morph
+
+/-!
+# Roots
+
+[haspelmath-2025-root]'s definition (1): a **root** is a contentful morph —
+a morph denoting an action, an object or a property — that can occur as part
+of a free form without another contentful morph. A root is thus a kind of
+`Morph`, a concrete contiguous form: Semitic consonantal skeletons do not
+fall under the definition (they are `Morphology.ConsonantalRoot`), and the
+abstract acategorial Root of Distributed Morphology is a different object
+again (`Morphology/DM/Root.lean`). The qualifying clause excludes contentful
+affixes (the Japanese causative *-ase*) and neoclassical combining forms
+(*geo-*, *socio-*), which are contentful but never the sole contentful morph
+of a free form.
+
+Formally identical roots with related meanings (*hammer* the instrument,
+*hammer* the action) are heterosemous *sister roots*, not one precategorial
+root — the classification `cls` below assigns each its own class.
+
+## Main declarations
+
+* `RootClass` — action, object, and property roots.
+* `RootClass.upos` — word classes as comparative concepts: a verb is an
+  action-denoting root, a noun an object-denoting root, an adjective a
+  property-denoting root.
+* `Morph.IsRootIn` — the definition, relative to a fragment's free forms
+  and contentfulness classification.
+-/
+
+namespace Morphology
+
+/-- The three semantic root classes: roots denoting actions, objects, and
+properties. Their prototypical combinations with discourse functions —
+predication, reference, modification — need no function indicators, which
+is what makes these the crucial classes for word-class typology. -/
+inductive RootClass where
+  /-- A root denoting an action (*sing*, *open*). -/
+  | action
+  /-- A root denoting an object (*tree*, *bird*). -/
+  | object
+  /-- A root denoting a property (*good*, *small*). -/
+  | property
+  deriving DecidableEq, Repr
+
+/-- Word classes as comparative concepts: a verb is an action-denoting
+root, a noun an object-denoting root, an adjective a property-denoting
+root. -/
+def RootClass.upos : RootClass → UD.UPOS
+  | .action => .VERB
+  | .object => .NOUN
+  | .property => .ADJ
+
+/-- `m.IsRootIn freeForms cls` is [haspelmath-2025-root]'s definition (1)
+relative to a fragment: the classification `cls` assigns `m` a root class
+(it is contentful), and `m` occurs in some free form in which every other
+morph is non-contentful. Contentful affixes and neoclassical combining
+forms satisfy the first conjunct but not the second. -/
+def Morph.IsRootIn (m : Morph) (freeForms : List (List Morph))
+    (cls : Morph → Option RootClass) : Prop :=
+  (cls m).isSome ∧ ∃ w ∈ freeForms, m ∈ w ∧ ∀ m' ∈ w, m' ≠ m → cls m' = none
+
+instance (m : Morph) (freeForms : List (List Morph))
+    (cls : Morph → Option RootClass) [DecidableEq Morph] :
+    Decidable (m.IsRootIn freeForms cls) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+end Morphology

--- a/Linglib/Morphology/Root/Consonantal.lean
+++ b/Linglib/Morphology/Root/Consonantal.lean
@@ -22,12 +22,14 @@ tier).
 
 ## Namespace separation
 
-Three roots coexist, owner-relative: `Morphology.Root` (this file) is the
-*consonantal melody*; `Panagiotidis2015.RootFamily` records a
-*category-neutral lexical root* with its category-stamped derivatives;
-`Verb.Root` (`Semantics/Verb/Root/`) is the *lexical-semantic* root. No
-identification between them is substrate — homs live in the studies that
-assert them.
+Owner-relative roots coexist: the top-level root is a contentful morph
+(`Morphology/Root/Basic.lean`, under whose definition consonantal skeletons
+are explicitly *not* roots); `Morphology.ConsonantalRoot` (this file) is the
+*consonantal melody*; `Morphology.DM.Root` is the abstract acategorial
+terminal; `Panagiotidis2015.RootFamily` records a category-neutral lexical
+root with its category-stamped derivatives; `Verb.Root`
+(`Semantics/Verb/Root/`) is the *lexical-semantic* root. No identification
+between them is substrate — homs live in the studies that assert them.
 -/
 
 namespace Morphology
@@ -35,62 +37,62 @@ namespace Morphology
 /-- A consonantal root: an ordered list of segments. Polymorphic in the
 segment type so that fragments may pick the granularity they need (sonority
 class, IPA symbol, full feature matrix). -/
-structure Root (α : Type*) where
+structure ConsonantalRoot (α : Type*) where
   /-- The root segments, in order. -/
   segments : List α
   deriving Repr, DecidableEq
 
-namespace Root
+namespace ConsonantalRoot
 
 variable {α : Type*}
 
 /-- The number of root segments. -/
-def arity (r : Root α) : Nat := r.segments.length
+def arity (r : ConsonantalRoot α) : Nat := r.segments.length
 
 /-- Position `i` is the *final* root position. -/
-def IsFinal (r : Root α) (i : Nat) : Prop := i + 1 = r.arity
+def IsFinal (r : ConsonantalRoot α) (i : Nat) : Prop := i + 1 = r.arity
 
-instance (r : Root α) (i : Nat) : Decidable (r.IsFinal i) :=
+instance (r : ConsonantalRoot α) (i : Nat) : Decidable (r.IsFinal i) :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- Position `i` is *nonfinal* (some position strictly past it exists).
     Used by *Misalignment ([faust-2026] (2)). -/
-def IsNonfinal (r : Root α) (i : Nat) : Prop := i + 1 < r.arity
+def IsNonfinal (r : ConsonantalRoot α) (i : Nat) : Prop := i + 1 < r.arity
 
-instance (r : Root α) (i : Nat) : Decidable (r.IsNonfinal i) :=
+instance (r : ConsonantalRoot α) (i : Nat) : Decidable (r.IsNonfinal i) :=
   inferInstanceAs (Decidable (_ < _))
 
 /-- A root with exactly two segments (e.g. √qt → QaTaT-template
     biradicals in Hebrew, [mccarthy-1981]). -/
-def Biradical (r : Root α) : Prop := r.arity = 2
+def Biradical (r : ConsonantalRoot α) : Prop := r.arity = 2
 
 /-- A root with exactly three segments (the unmarked Semitic case). -/
-def Triradical (r : Root α) : Prop := r.arity = 3
+def Triradical (r : ConsonantalRoot α) : Prop := r.arity = 3
 
 /-- A root with exactly four segments (e.g. quadriliteral verbs). -/
-def Quadriradical (r : Root α) : Prop := r.arity = 4
+def Quadriradical (r : ConsonantalRoot α) : Prop := r.arity = 4
 
-instance (r : Root α) : Decidable r.Biradical := inferInstanceAs (Decidable (_ = _))
-instance (r : Root α) : Decidable r.Triradical := inferInstanceAs (Decidable (_ = _))
-instance (r : Root α) : Decidable r.Quadriradical := inferInstanceAs (Decidable (_ = _))
+instance (r : ConsonantalRoot α) : Decidable r.Biradical := inferInstanceAs (Decidable (_ = _))
+instance (r : ConsonantalRoot α) : Decidable r.Triradical := inferInstanceAs (Decidable (_ = _))
+instance (r : ConsonantalRoot α) : Decidable r.Quadriradical := inferInstanceAs (Decidable (_ = _))
 
 /-- The last segment of the root, if any. -/
-def finalSegment (r : Root α) : Option α := r.segments.getLast?
+def finalSegment (r : ConsonantalRoot α) : Option α := r.segments.getLast?
 
 /-- The segment at position `i`, if in range. -/
-def segmentAt (r : Root α) (i : Nat) : Option α := r.segments[i]?
+def segmentAt (r : ConsonantalRoot α) (i : Nat) : Option α := r.segments[i]?
 
 /-- **Root-level OCP** ([mccarthy-1981], [faust-2026]): a consonantal root has no two
     adjacent identical segments. Segment-level and theory-neutral — it commits to no
     tier projection or feature decomposition (stronger tier-relative variants go
     through `OCP.IsCleanOn`). Definitionally the segment tier being
     `OCP.IsClean`. -/
-def IsOCPClean [DecidableEq α] (r : Root α) : Prop :=
+def IsOCPClean [DecidableEq α] (r : ConsonantalRoot α) : Prop :=
   OCP.IsClean r.segments
 
 instance instDecidablePredIsOCPClean [DecidableEq α] :
     DecidablePred (IsOCPClean (α := α)) :=
   fun r => inferInstanceAs (Decidable (OCP.IsClean r.segments))
 
-end Root
+end ConsonantalRoot
 end Morphology

--- a/Linglib/Studies/Faust2026.lean
+++ b/Linglib/Studies/Faust2026.lean
@@ -55,7 +55,7 @@ jointly resolves three Semitic puzzles:
 
 This file consumes and exercises the shared infrastructure:
 
-- `Morphology.Root` — polymorphic consonantal-root carrier.
+- `Morphology.ConsonantalRoot` — polymorphic consonantal-root carrier.
 - `Morphology.CVTemplate`, `Morphology.TemplateMatch`
   (`Morphology/Morphotactics/CVTemplate.lean`) — skeletal templates and
   sourced association lines; this file adds the Faust-specific predicates
@@ -138,13 +138,13 @@ open Constraints OptimalityTheory
 variable {α : Type*}
 
 /-- A match with no associations is trivially not misaligned. -/
-theorem not_isMisaligned_empty (r : Root α) (t : CVTemplate) :
+theorem not_isMisaligned_empty (r : ConsonantalRoot α) (t : CVTemplate) :
     ¬ ({ root := r, template := t, associations := [] } :
         TemplateMatch α).isMisaligned := by
   simp [TemplateMatch.isMisaligned]
 
 /-- *Misalignment cannot fire from intruder associations alone. -/
-theorem not_isMisaligned_of_all_intruder (r : Root α) (t : CVTemplate)
+theorem not_isMisaligned_of_all_intruder (r : ConsonantalRoot α) (t : CVTemplate)
     (assocs : List Association)
     (h : ∀ a ∈ assocs, a.source = .affix) :
     ¬ ({ root := r, template := t, associations := assocs } :
@@ -576,26 +576,26 @@ biradicals like √wd — turn out to have *distinct* radicals after all
 (/w/ ≠ /d/), with surface gemination produced by template spreading
 rather than root identity.
 
-The `Root.IsOCPClean` predicate (in `Morphology`) makes this
+The `ConsonantalRoot.IsOCPClean` predicate (in `Morphology`) makes this
 verifiable rather than asserted. -/
 
 /-- [faust-2026] page 432: √wd has no OCP violation at the root
     level — even though [wäddäd-ä] surfaces with adjacent identical
     [d][d], the surface gemination is a template-spreading effect. -/
-theorem amharic_wd_satisfies_root_ocp : Root.IsOCPClean Amharic.wd := by decide
+theorem amharic_wd_satisfies_root_ocp : ConsonantalRoot.IsOCPClean Amharic.wd := by decide
 
 /-- [faust-2026]'s reanalysis: √fdj (the triradical analysis) has
     no OCP violation. -/
-theorem amharic_fdj_satisfies_root_ocp : Root.IsOCPClean Amharic.fdj := by decide
+theorem amharic_fdj_satisfies_root_ocp : ConsonantalRoot.IsOCPClean Amharic.fdj := by decide
 
 /-- And the Hebrew [j]-final root √klj also satisfies the OCP. -/
-theorem hebrew_klj_satisfies_root_ocp : Root.IsOCPClean Hebrew.klj := by decide
+theorem hebrew_klj_satisfies_root_ocp : ConsonantalRoot.IsOCPClean Hebrew.klj := by decide
 
 /-- Sanity: a hypothetical OCP-violating biradical √dd (which
     [broselow-1984] would have posited but [faust-2026]
     rejects) really does violate the OCP under our predicate. -/
 theorem hypothetical_dd_violates_root_ocp :
-    ¬ Root.IsOCPClean (⟨["d", "d"]⟩ : Root String) := by decide
+    ¬ ConsonantalRoot.IsOCPClean (⟨["d", "d"]⟩ : ConsonantalRoot String) := by decide
 
 /-! ### Strict CV hollow roots + NCC ([faust-2026] (12)–(13)) -/
 

--- a/Linglib/Studies/McCarthy1981.lean
+++ b/Linglib/Studies/McCarthy1981.lean
@@ -57,14 +57,14 @@ open Morphology
 /-! ### Roots -/
 
 /-- The citation root ktb "write". -/
-def ktb : Root String := ⟨["k", "t", "b"]⟩
+def ktb : ConsonantalRoot String := ⟨["k", "t", "b"]⟩
 
 /-- The biradical root sm "poison" (surface samam, sammam). -/
-def sm : Root String := ⟨["s", "m"]⟩
+def sm : ConsonantalRoot String := ⟨["s", "m"]⟩
 
 /-- The root qlq, with identical first and third radicals — unremarkable
 for the OCP, which constrains adjacent elements only. -/
-def qlq : Root String := ⟨["q", "l", "q"]⟩
+def qlq : ConsonantalRoot String := ⟨["q", "l", "q"]⟩
 
 /-! ### Templates ((13) and the schema (14a)) -/
 
@@ -165,7 +165,7 @@ left-to-right with the remaining C-slots (spreading onto leftovers),
 Erasure applies if `erase`, and the vocalism associates with the V-slots
 per rule (41). -/
 def assemble (t : CVTemplate) (affixSegs : List String) (affixSlots : List Nat)
-    (erase : Bool) (voc : List String) (r : Root String) : TemplateMatch String :=
+    (erase : Bool) (voc : List String) (r : ConsonantalRoot String) : TemplateMatch String :=
   let affixAssocs := affixSlots.zipIdx.map fun (s, k) => ⟨.affix, k, s⟩
   let rootSlots := t.cSlots.filter (· ∉ affixSlots)
   let rootAssocs := associateLR .root r.arity rootSlots
@@ -184,7 +184,7 @@ inductive Binyan where
 from the infixed w-tier rather than the root tier — the choice point
 distinguishing XIII from XII (his (30)). Given representationally: the
 affix w is doubly linked, the root associates around it. -/
-def formXIII (voc : List String) (r : Root String) : TemplateMatch String :=
+def formXIII (voc : List String) (r : ConsonantalRoot String) : TemplateMatch String :=
   { root := r, vocalism := voc, affix := ["w"], template := ccvccvc,
     associations :=
       [⟨.root, 0, 0⟩, ⟨.root, 1, 1⟩, ⟨.affix, 0, 3⟩, ⟨.affix, 0, 4⟩, ⟨.root, 2, 6⟩] ++
@@ -194,7 +194,7 @@ def formXIII (voc : List String) (r : Root String) : TemplateMatch String :=
 paper's placements — first C-slot(s) for ʔ, t, n, st ((16), (18)), second
 C-slot for the VIII reflexive after the Flop (19), medial and final slots
 for the rare XII–XV affixes (27) — and Erasure for II, V, and XII. -/
-def perfMatch (voc : List String) (r : Root String) : Binyan → TemplateMatch String
+def perfMatch (voc : List String) (r : ConsonantalRoot String) : Binyan → TemplateMatch String
   | .I => assemble cvcvc [] [] false voc r
   | .II => assemble cvccvc [] [] true voc r
   | .III => assemble cvvcvc [] [] false voc r
@@ -315,8 +315,8 @@ theorem attested_roots_ocp_clean : sm.IsOCPClean ∧ qlq.IsOCPClean := by decide
 the root-level OCP — the shapes the theory correctly excludes from the
 lexicon. -/
 theorem geminate_roots_are_biradical :
-    ¬ (⟨["s", "m", "m"]⟩ : Root String).IsOCPClean ∧
-    ¬ (⟨["d", "d", "r", "j"]⟩ : Root String).IsOCPClean := by
+    ¬ (⟨["s", "m", "m"]⟩ : ConsonantalRoot String).IsOCPClean ∧
+    ¬ (⟨["d", "d", "r", "j"]⟩ : ConsonantalRoot String).IsOCPClean := by
   decide
 
 /-! ### Stranding (his (38)) -/
@@ -340,7 +340,7 @@ def binyanList : List Binyan :=
 the fifteen binyan cells, realized by the association pipeline. The root is
 the lexeme index; each cell contributes its template, affix, and Erasure
 setting. -/
-def perfectiveActiveParadigm (r : Root String) : Paradigm 15 (List String) :=
+def perfectiveActiveParadigm (r : ConsonantalRoot String) : Paradigm 15 (List String) :=
   fun i => (perfMatch activeVoc r (binyanList.getD i .I)).spellout
 
 /-- The paradigm of ktb reads off Table 1 cell by cell. -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19883,6 +19883,31 @@
   subfield  = {morphology},
   role      = {cited},
   sources   = {Studies/Bybee1985.lean}
+}% REF: Haspelmath, M. (2025). Roots and root classes in comparative grammar. In *Exploring Structures in Languages and Language Contact*, 307-324. De Gruyter Mouton.
+@incollection{haspelmath-2025-root,
+  author    = {Haspelmath, Martin},
+  year      = {2025},
+  title     = {Roots and Root Classes in Comparative Grammar},
+  booktitle = {Exploring Structures in Languages and Language Contact},
+  editor    = {Levkovych, Nataliya and Nintemann, Julia and Vorholt, Maike},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  pages     = {307--324},
+  doi       = {10.1515/9783111496436-012},
+  subfield  = {morphology},
+  role      = {formalized},
+  sources   = {Morphology/Root/Basic.lean}
+}% REF: Qin, Y. (2025). Canonical and non-canonical roots: The diversity of roots in Mandarin Chinese. Lingua 328, 104068.
+@article{qin-2025,
+  author    = {Qin, Yang},
+  year      = {2025},
+  title     = {Canonical and Non-Canonical Roots: The Diversity of Roots in {M}andarin {C}hinese},
+  journal   = {Lingua},
+  volume    = {328},
+  pages     = {104068},
+  doi       = {10.1016/j.lingua.2025.104068},
+  subfield  = {morphology},
+  role      = {cited}
 }% REF: Sweet, H. (1882). *An Anglo-Saxon Primer*. Clarendon Press.
 @book{sweet-1882,
   author    = {Sweet, Henry},


### PR DESCRIPTION
Makes [haspelmath-2025-root]'s comparative-concept root the top-level Root API (`Morphology/Root/Basic.lean`: `RootClass`, `RootClass.upos` word-class mapping, `Morph.IsRootIn` criterion over free forms), renames the consonantal melody to `ConsonantalRoot` in `Root/Consonantal.lean` (skeletons are explicitly not roots under the definition), and adds `DM/Root.lean` (index-individuated acategorial terminal, instantiating Categorizer's `RootIdx`). Verified bib entries for haspelmath-2025-root and qin-2025.

Follow-up: Studies/Haspelmath2025Root (heterosemy-vs-RootFamily divergence) and Studies/Qin2025 (Mandarin canonical-roots space) as consumers.