### PR TITLE
feat(Morphology/Paradigm): relation-valued Linkage; Studies/Stump2006

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2653,6 +2653,7 @@ import Linglib.Studies.Stojkovic2026
 import Linglib.Studies.Storme2026
 import Linglib.Studies.Storment2026
 import Linglib.Studies.Sudo2016
+import Linglib.Studies.Stump2006
 import Linglib.Studies.Stump2012
 import Linglib.Studies.Stump2016
 import Linglib.Studies.Stump2020

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -392,16 +392,16 @@ end FunctionCompositionDefault
 PFM2 realization of a paradigm linkage's block cascade ([stump-2016]'s
 `PF(⟨L, σ⟩) = PF(Corr(⟨L, σ⟩))`) is this paradigm function — `Linkage.realize`'s
 form-realization hole filled true by construction. -/
-theorem Linkage.realize_eq_paradigmFunction (ℓ : Linkage L Z P) (Lindex : Z → L)
-    (stemChoice : L × P → Z) (blocks : List (Block L Z P)) (l : L) (σ : P)
-    (h : ℓ.IsPropertyPreserving)
-    (hstem : ∀ l σ, ℓ.stem l σ = some (stemChoice (l, σ))) :
+theorem Linkage.realize_eq_paradigmFunction [DecidableEq Z] (ℓ : Linkage L Z P)
+    (Lindex : Z → L) (stemChoice : L × P → Z) (blocks : List (Block L Z P))
+    (l : L) (σ : P) (h : ℓ.IsPropertyPreserving)
+    (hstem : ∀ l σ, ℓ.stems l σ = {stemChoice (l, σ)}) :
     ℓ.realize (fun z τ => (blocksEval Lindex blocks (z, τ)).1) l σ
-      = some (paradigmFunction Lindex stemChoice blocks (l, σ)) := by
+      = {paradigmFunction Lindex stemChoice blocks (l, σ)} := by
   have hpm : ℓ.pm l σ = σ := h l σ
-  simp only [Linkage.realize, Linkage.corr, hpm, hstem, Option.map_some,
-    paradigmFunction]
-  exact congrArg some
+  simp only [Linkage.realize, hpm, hstem, Finset.image_singleton,
+    Finset.singleton_product_singleton, paradigmFunction]
+  exact congrArg ({·})
     (Prod.ext rfl (blocksEval_snd Lindex blocks (stemChoice (l, σ), σ)).symm)
 
 end Selection

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -1,4 +1,5 @@
-import Mathlib.Data.Set.Function
+import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Finset.Card
 
 /-!
 # Paradigm linkage: content paradigms, form paradigms, and correspondence
@@ -8,206 +9,415 @@ the book-length apparatus is [stump-2016]): a lexeme's **content paradigm** of
 cells `⟨L, σ⟩` pairing a lexeme with a syntacticosemantic property set, a stem's
 **form paradigm** of cells `⟨Z, τ⟩` pairing a stem with a property set it inflects
 for, and the **realized paradigm** of word forms. A content cell is realized by
-being linked to a **form correspondent**, whose realization it shares. The
-correspondence factors into a stem selection `stem : L → P → Option Z` and a
-lexeme-sensitive property mapping `pm : L → P → P`. Both partiality and lexeme
-sensitivity are load-bearing: a gap in the stem specification is the seat of
-defectiveness, and functor-argument reversal computes a form correspondent's
-property set from the lexeme.
+being linked to its **form correspondents**, whose realizations it shares. The
+correspondence is a finite relation in factored presentation: a stem selection
+`stems : L → P → Finset Z` and a lexeme-sensitive property mapping `pm : L → P → P`.
+Canonically the relation is the graph of `⟨l, σ⟩ ↦ ⟨root l, σ⟩` ([stump-2006]'s
+universal default rule of paradigm linkage).
 
-Canonical paradigm linkage is the typological extreme against which deviations
-are calibrated, characterized by four independent axes. `IsTotal`: every content
-cell has a form correspondent. `IsStemInvariant`: one stem realizes all of a
-lexeme's cells. `IsInjective`: no two content cells share a form correspondent.
-`IsPropertyPreserving`: a form correspondent carries the content cell's own
-property set. Each named noncanonical phenomenon is the failure of exactly one
-axis — defectiveness negates totality, suppletion stem invariance, syncretism
-injectivity, and deponency and functor-argument reversal property preservation.
+Canonical linkage is the typological extreme against which deviations are
+calibrated — [corbett-2007]'s canonical-typology method, with the axes read off
+the correspondence relation's standard properties. `IsTotal`: every content cell
+has a form correspondent. `IsUnivalent`: at most one. `IsStemInvariant`: one stem
+serves all of a lexeme's cells. `IsInjective`: no two content cells share a
+correspondent. `IsPropertyPreserving`: a correspondent carries the content cell's
+own property set. Each named noncanonical phenomenon negates one axis:
+defectiveness totality ([stump-2012-mmm8] §3.1), overabundance univalence
+([thornton-2011]'s cell-mates), suppletion stem invariance (§3.4), syncretism
+injectivity (§3.2), and deponency and functor-argument reversal property
+preservation (§3.3).
+
+Stem invariance is one instance of a projection-indexed family: `InvariantAlong p`
+asks the composite `p ∘ stems` to be constant per lexeme. Instantiated at a
+consumer-supplied inflection-class projection `cls : Z → K` it yields
+**heteroclisis** — form correspondents drawn from form paradigms of two or more
+inflection classes ([stump-2006]). Because constancy transfers along any
+projection (`InvariantAlong.comp`), heteroclisis entails stem non-invariance
+(`IsHeteroclite.isSuppletive`): heteroclisis is "a kind of stem alternation" even
+when the stems are phonologically identical, [stump-2006]'s reading of Czech
+PRAMEN, whose two stems differ in class but not in form.
 
 ## Main declarations
 
-* `Linkage L Z P` — a lexeme-level linkage: partial stem selection and
-  lexeme-sensitive property mapping
-* `Linkage.corr`, `Linkage.realize` — the form-correspondence function and the
-  realized paradigm, both partial
-* `Linkage.IsTotal`, `IsStemInvariant`, `IsInjective`, `IsPropertyPreserving` —
-  the four axes of canonical linkage; `IsCanonical` conjoins them
-* `Linkage.IsDefective`, `IsSuppletive`, `IsSyncretic`, `IsUnfaithful` — the four
-  deviation predicates, each negating one axis (`IsCanonical.not_isDefective`,
-  …), with `isSyncretic_iff_not_isInjective`
+* `Linkage L Z P` — the correspondence in factored presentation: finite stem
+  selection and lexeme-sensitive property mapping
+* `Linkage.corr`, `Linkage.realize` — the form-correspondent set of a content
+  cell and the realized paradigm over it
+* `Linkage.IsTotal`, `IsUnivalent`, `IsStemInvariant`, `IsInjective`,
+  `IsPropertyPreserving` — the axes of canonical linkage; `IsCanonical` bundles
+  them; `InvariantAlong` is the projection-indexed generalization of stem
+  invariance
+* `Linkage.IsDefective`, `IsOverabundant`, `IsSuppletive`, `IsHeteroclite`,
+  `IsSyncretic`, `IsUnfaithful` — the six deviations, each an axis failure
+  (`isDefective_iff_not_isTotal`, `isOverabundant_iff_not_isUnivalent`,
+  `isSyncretic_iff_not_isInjective`, …)
+* `Linkage.IsHeteroclite.isSuppletive` — heteroclisis entails stem non-invariance
+* `Linkage.HasCellMates` — distinct realized forms at one cell; entails
+  `IsOverabundant`
 * `Linkage.IsVirtual` — a form cell no content cell corresponds to
 * `Linkage.canonical` / `canonical_isCanonical` — the total, lexeme-blind,
-  one-stem linkage, canonical on all four axes
-* `Linkage.realize_eq_of_corr_eq` — a shared form correspondent forces a shared
-  realization
-* `Linkage.realize_eq_of_corr_eq_lexeme` — the cross-lexeme companion: two
-  lexemes sharing a correspondent share their realization
+  one-stem linkage, canonical on all axes
+* `Linkage.realize_eq_of_corr_eq`, `realize_eq_of_corr_eq_lexeme` — shared
+  correspondents force shared realizations, within and across lexemes
 -/
 
 namespace Morphology
 
 /-- A **paradigm linkage** ([stump-2012-mmm8]) from the vantage of a single
-lexeme: the two components of the form-correspondence function. `stem` selects
-the stem realizing a content cell, or `none` where the stem specification has a
-gap; `pm` carries a content cell's property set to its form correspondent's, and
-may consult the lexeme. Canonically `stem` is total and constant in the property
-set and `pm` is the identity. -/
+lexeme: the two components of the form-correspondence relation. `stems` selects
+the finite set of stems realizing a content cell — empty at a gap in the stem
+specification, more than one at an overabundant cell; `pm` carries a content
+cell's property set to its form correspondents', and may consult the lexeme.
+Canonically `stems` is singleton-valued and constant in the property set and
+`pm` is the identity. -/
 structure Linkage (L Z P : Type*) where
-  /-- The stem realizing a content cell `⟨l, σ⟩`, or `none` where the stem
-  specification has a gap. -/
-  stem : L → P → Option Z
+  /-- The stems realizing a content cell `⟨l, σ⟩`: empty where the stem
+  specification has a gap, non-singleton where the cell is overabundant. -/
+  stems : L → P → Finset Z
   /-- The property mapping carrying a content cell's property set to its form
-  correspondent's, consulting the lexeme for functor-argument reversal. -/
+  correspondents', consulting the lexeme for functor-argument reversal. -/
   pm : L → P → P
 
 namespace Linkage
 
-variable {L Z P W : Type*} (ℓ : Linkage L Z P)
+variable {L Z P W X Y K : Type*} (ℓ : Linkage L Z P)
 
-/-- The **form correspondent** of a content cell `⟨l, σ⟩`: the stem paired with
-its mapped property set, or `none` where the stem specification has a gap. -/
-def corr (l : L) (σ : P) : Option (Z × P) := (ℓ.stem l σ).map (·, ℓ.pm l σ)
+/-- The **form correspondents** of a content cell `⟨l, σ⟩`: each selected stem
+paired with the mapped property set — empty where the stem specification has a
+gap. -/
+def corr (l : L) (σ : P) : Finset (Z × P) := ℓ.stems l σ ×ˢ {ℓ.pm l σ}
+
+@[simp] theorem mem_corr {l : L} {σ : P} {zτ : Z × P} :
+    zτ ∈ ℓ.corr l σ ↔ zτ.1 ∈ ℓ.stems l σ ∧ zτ.2 = ℓ.pm l σ := by
+  rw [corr, Finset.mem_product, Finset.mem_singleton]
+
+@[simp] theorem corr_nonempty (l : L) (σ : P) :
+    (ℓ.corr l σ).Nonempty ↔ (ℓ.stems l σ).Nonempty := by
+  simp [corr]
+
+@[simp] theorem card_corr (l : L) (σ : P) :
+    (ℓ.corr l σ).card = (ℓ.stems l σ).card := by
+  simp [corr]
 
 /-- The **realized paradigm** on content cells: a content cell realizes as its
-form correspondent does. `realizeForm` supplies the form-cell realization; the
-result is `none` exactly where the form correspondent is. -/
-def realize (realizeForm : Z → P → W) (l : L) (σ : P) : Option (W × P) :=
-  (ℓ.corr l σ).map fun zτ => (realizeForm zτ.1 zτ.2, zτ.2)
+form correspondents do. `realizeForm` supplies the form-cell realization; the
+result is empty exactly where the correspondent set is. -/
+def realize [DecidableEq W] (realizeForm : Z → P → W) (l : L) (σ : P) :
+    Finset (W × P) :=
+  ((ℓ.stems l σ).image fun z => realizeForm z (ℓ.pm l σ)) ×ˢ {ℓ.pm l σ}
+
+@[simp] theorem mem_realize [DecidableEq W] {realizeForm : Z → P → W} {l : L}
+    {σ : P} {wτ : W × P} :
+    wτ ∈ ℓ.realize realizeForm l σ ↔
+      ∃ z ∈ ℓ.stems l σ, wτ = (realizeForm z (ℓ.pm l σ), ℓ.pm l σ) := by
+  obtain ⟨w, τ⟩ := wτ
+  simp [realize, Prod.ext_iff, eq_comm (a := w), eq_comm (a := τ)]
+
+/-! ### The axes of canonical linkage -/
 
 /-- **Totality**: every content cell has a form correspondent. Defectiveness is
 the failure. -/
-def IsTotal : Prop := ∀ l σ, (ℓ.stem l σ).isSome
+def IsTotal : Prop := ∀ l σ, (ℓ.stems l σ).Nonempty
 
-/-- **Stem invariance**: a lexeme's cells that have a stem all share one, so its
-correspondents come from a single form paradigm. Stem suppletion is the failure.
-Independent of totality — undefined cells impose no constraint. -/
-def IsStemInvariant : Prop :=
-  ∀ l ⦃σ₁ σ₂⦄ ⦃z₁ z₂⦄, ℓ.stem l σ₁ = some z₁ → ℓ.stem l σ₂ = some z₂ → z₁ = z₂
+/-- **Univalence**: every content cell has at most one form correspondent.
+Overabundance is the failure. -/
+def IsUnivalent : Prop := ∀ l σ, (ℓ.stems l σ).card ≤ 1
 
-/-- **Injectivity**: no two content cells of a lexeme share a form correspondent,
-over the cells that have one. Syncretism is the failure. -/
-def IsInjective : Prop := ∀ l, Set.InjOn (ℓ.corr l) {σ | (ℓ.corr l σ).isSome}
+/-- **Invariance along a projection**: the composite `p ∘ stems` is constant on
+each lexeme's paradigm. At `p := id` this is stem invariance; at an
+inflection-class projection it is the axis heteroclisis negates. Undefined cells
+impose no constraint. -/
+def InvariantAlong (p : Z → X) : Prop :=
+  ∀ l ⦃σ₁ σ₂ : P⦄ ⦃z₁ z₂ : Z⦄,
+    z₁ ∈ ℓ.stems l σ₁ → z₂ ∈ ℓ.stems l σ₂ → p z₁ = p z₂
+
+/-- **Stem invariance**: one stem serves all of a lexeme's cells, so its
+correspondents come from a single form paradigm. Stem suppletion is the
+failure. -/
+def IsStemInvariant : Prop := ℓ.InvariantAlong id
+
+/-- **Injectivity**: no two content cells of a lexeme share a form
+correspondent. Syncretism is the failure. -/
+def IsInjective : Prop :=
+  ∀ l ⦃σ₁ σ₂ : P⦄, σ₁ ≠ σ₂ → Disjoint (ℓ.corr l σ₁) (ℓ.corr l σ₂)
 
 /-- **Property preservation**: a form correspondent carries the content cell's
 own property set. Deponency, functor-argument reversal, and directional
 syncretism are failures. -/
 def IsPropertyPreserving : Prop := ∀ l σ, ℓ.pm l σ = σ
 
-/-- **Canonical paradigm linkage** ([stump-2012-mmm8]): all four axes. -/
-def IsCanonical : Prop :=
-  ℓ.IsTotal ∧ ℓ.IsStemInvariant ∧ ℓ.IsInjective ∧ ℓ.IsPropertyPreserving
+/-- **Canonical paradigm linkage** ([stump-2012-mmm8], axes per [corbett-2007]'s
+canonical-typology method): all five axes at once. -/
+structure IsCanonical : Prop where
+  total : ℓ.IsTotal
+  univalent : ℓ.IsUnivalent
+  stemInvariant : ℓ.IsStemInvariant
+  injective : ℓ.IsInjective
+  propertyPreserving : ℓ.IsPropertyPreserving
+
+/-- Constancy transfers along any further projection. -/
+theorem InvariantAlong.comp {ℓ : Linkage L Z P} {p : Z → X}
+    (h : ℓ.InvariantAlong p) (q : X → Y) : ℓ.InvariantAlong (q ∘ p) :=
+  fun l _ _ _ _ h₁ h₂ => congrArg q (h l h₁ h₂)
+
+/-- A stem-invariant linkage is invariant along every projection. -/
+theorem IsStemInvariant.invariantAlong {ℓ : Linkage L Z P}
+    (h : ℓ.IsStemInvariant) (p : Z → X) : ℓ.InvariantAlong p :=
+  fun l _ _ _ _ h₁ h₂ => congrArg p (h l h₁ h₂)
 
 /-! ### Deviations from canonical linkage
 
-Each noncanonical phenomenon negates exactly one axis. -/
+Each noncanonical phenomenon negates one axis. -/
 
 /-- **Defectiveness**: some content cell lacks a form correspondent
 ([stump-2012-mmm8] §3.1). Negates totality. -/
-def IsDefective : Prop := ∃ l σ, ℓ.stem l σ = none
+def IsDefective : Prop := ∃ l σ, ℓ.stems l σ = ∅
+
+/-- **Overabundance**: some content cell has two or more form correspondents —
+[thornton-2011]'s cell-mates, at the level of the correspondence. Negates
+univalence. -/
+def IsOverabundant : Prop := ∃ l σ, 2 ≤ (ℓ.stems l σ).card
 
 /-- **Suppletion**: a lexeme's correspondents draw on more than one stem
 ([stump-2012-mmm8] §3.4). Negates stem invariance. -/
 def IsSuppletive : Prop := ¬ ℓ.IsStemInvariant
 
-/-- **Syncretism**: two distinct content cells share a form correspondent
-([stump-2012-mmm8] §3.2). Negates injectivity; the `isSome` requirement excludes
-cells vacuously agreeing at `none`. -/
-def IsSyncretic : Prop :=
-  ∃ l σ₁ σ₂, σ₁ ≠ σ₂ ∧ ℓ.corr l σ₁ = ℓ.corr l σ₂ ∧ (ℓ.corr l σ₁).isSome
+/-- **Heteroclisis**: a lexeme's correspondents draw on form paradigms of two or
+more inflection classes ([stump-2006]), the classes given by a projection
+`cls : Z → K`. Negates invariance along `cls`. -/
+def IsHeteroclite (cls : Z → K) : Prop := ¬ ℓ.InvariantAlong cls
 
-/-- **Unfaithfulness**: some content cell's form correspondent carries a
+/-- **Syncretism**: two distinct content cells share a form correspondent
+([stump-2012-mmm8] §3.2). Negates injectivity. -/
+def IsSyncretic : Prop :=
+  ∃ l σ₁ σ₂, σ₁ ≠ σ₂ ∧ ¬ Disjoint (ℓ.corr l σ₁) (ℓ.corr l σ₂)
+
+/-- **Unfaithfulness**: some content cell's form correspondents carry a
 different property set — deponency and functor-argument reversal
 ([stump-2012-mmm8] §3.3). Negates property preservation. -/
 def IsUnfaithful : Prop := ∃ l σ, ℓ.pm l σ ≠ σ
 
-theorem IsCanonical.not_isDefective (h : ℓ.IsCanonical) : ¬ ℓ.IsDefective := by
-  rintro ⟨l, σ, hnone⟩; simpa [hnone] using h.1 l σ
+/-- Defectiveness is exactly the failure of totality. -/
+theorem isDefective_iff_not_isTotal : ℓ.IsDefective ↔ ¬ ℓ.IsTotal := by
+  simp [IsDefective, IsTotal, Finset.not_nonempty_iff_eq_empty]
+
+/-- Overabundance is exactly the failure of univalence. -/
+theorem isOverabundant_iff_not_isUnivalent :
+    ℓ.IsOverabundant ↔ ¬ ℓ.IsUnivalent := by
+  simp [IsOverabundant, IsUnivalent, Nat.lt_iff_add_one_le, not_le]
+
+/-- Syncretism is exactly the failure of injectivity. -/
+theorem isSyncretic_iff_not_isInjective : ℓ.IsSyncretic ↔ ¬ ℓ.IsInjective := by
+  simp [IsSyncretic, IsInjective, not_forall]
+
+/-- Unfaithfulness is exactly the failure of property preservation. -/
+theorem isUnfaithful_iff_not_isPropertyPreserving :
+    ℓ.IsUnfaithful ↔ ¬ ℓ.IsPropertyPreserving := by
+  simp [IsUnfaithful, IsPropertyPreserving]
+
+/-- Heteroclisis entails stem non-invariance: drawing on two inflection classes
+is drawing on two stems, [stump-2006]'s "a kind of stem alternation" — even when
+the stems are phonologically identical, as in Czech PRAMEN. -/
+theorem IsHeteroclite.isSuppletive {cls : Z → K} (h : ℓ.IsHeteroclite cls) :
+    ℓ.IsSuppletive :=
+  fun hinv => h (IsStemInvariant.invariantAlong hinv cls)
+
+theorem IsCanonical.not_isDefective (h : ℓ.IsCanonical) : ¬ ℓ.IsDefective :=
+  fun hd => ℓ.isDefective_iff_not_isTotal.mp hd h.total
+
+theorem IsCanonical.not_isOverabundant (h : ℓ.IsCanonical) :
+    ¬ ℓ.IsOverabundant :=
+  fun ho => ℓ.isOverabundant_iff_not_isUnivalent.mp ho h.univalent
 
 theorem IsCanonical.not_isSuppletive (h : ℓ.IsCanonical) : ¬ ℓ.IsSuppletive :=
-  not_not.mpr h.2.1
+  not_not.mpr h.stemInvariant
 
-theorem IsCanonical.not_isSyncretic (h : ℓ.IsCanonical) : ¬ ℓ.IsSyncretic := by
-  rintro ⟨l, σ₁, σ₂, hne, heq, hsome⟩
-  have hsome₂ : (ℓ.corr l σ₂).isSome = true := by rw [← heq]; exact hsome
-  exact hne (h.2.2.1 l hsome hsome₂ heq)
+theorem IsCanonical.not_isHeteroclite (h : ℓ.IsCanonical) (cls : Z → K) :
+    ¬ ℓ.IsHeteroclite cls :=
+  not_not.mpr (IsStemInvariant.invariantAlong h.stemInvariant cls)
 
-theorem IsCanonical.not_isUnfaithful (h : ℓ.IsCanonical) : ¬ ℓ.IsUnfaithful := by
-  rintro ⟨l, σ, hne⟩; exact hne (h.2.2.2 l σ)
+theorem IsCanonical.not_isSyncretic (h : ℓ.IsCanonical) : ¬ ℓ.IsSyncretic :=
+  fun hs => ℓ.isSyncretic_iff_not_isInjective.mp hs h.injective
 
-/-- Syncretism is exactly the failure of injectivity — the one deviation whose
-predicate is not a definitional negation of its axis. -/
-theorem isSyncretic_iff_not_isInjective : ℓ.IsSyncretic ↔ ¬ ℓ.IsInjective := by
-  constructor
-  · rintro ⟨l, σ₁, σ₂, hne, heq, hsome⟩ hinj
-    have hsome₂ : (ℓ.corr l σ₂).isSome = true := by rw [← heq]; exact hsome
-    exact hne (hinj l hsome hsome₂ heq)
-  · intro h
-    simp only [IsInjective, not_forall] at h
-    obtain ⟨l, hl⟩ := h
-    unfold Set.InjOn at hl
-    push Not at hl
-    obtain ⟨σ₁, hσ₁, σ₂, hσ₂, heq, hne⟩ := hl
-    exact ⟨l, σ₁, σ₂, hne, heq, hσ₁⟩
+theorem IsCanonical.not_isUnfaithful (h : ℓ.IsCanonical) : ¬ ℓ.IsUnfaithful :=
+  fun ⟨l, σ, hne⟩ => hne (h.propertyPreserving l σ)
 
 /-- A **virtual cell**: a form cell no content cell corresponds to
 ([stump-2012-mmm8] §4). Realization rules still define a value there, which
 language change can release by suppressing a linkage override. -/
-def IsVirtual (zτ : Z × P) : Prop := ∀ l σ, ℓ.corr l σ ≠ some zτ
+def IsVirtual (zτ : Z × P) : Prop := ∀ l σ, zτ ∉ ℓ.corr l σ
 
-/-- A shared form correspondent forces a shared realization ([stump-2012-mmm8]
-§3.2): the mechanism of syncretism. -/
-theorem realize_eq_of_corr_eq (realizeForm : Z → P → W) {l : L} {σ₁ σ₂ : P}
+/-! ### Decidability
+
+Instances by `inferInstanceAs` on the definitional unfolding, so `decide`
+reduces in the kernel. -/
+
+section Decidable
+
+variable [Fintype L] [Fintype P] [Fintype Z] [DecidableEq Z] [DecidableEq P]
+
+instance : Decidable ℓ.IsTotal :=
+  inferInstanceAs (Decidable (∀ l σ, (ℓ.stems l σ).Nonempty))
+
+instance : Decidable ℓ.IsUnivalent :=
+  inferInstanceAs (Decidable (∀ l σ, (ℓ.stems l σ).card ≤ 1))
+
+instance {p : Z → X} [DecidableEq X] : Decidable (ℓ.InvariantAlong p) :=
+  inferInstanceAs (Decidable (∀ l, ∀ σ₁ σ₂ : P, ∀ z₁ z₂ : Z,
+    z₁ ∈ ℓ.stems l σ₁ → z₂ ∈ ℓ.stems l σ₂ → p z₁ = p z₂))
+
+instance : Decidable ℓ.IsStemInvariant :=
+  inferInstanceAs (Decidable (ℓ.InvariantAlong id))
+
+instance : Decidable ℓ.IsInjective :=
+  inferInstanceAs (Decidable (∀ l, ∀ σ₁ σ₂ : P,
+    σ₁ ≠ σ₂ → Disjoint (ℓ.corr l σ₁) (ℓ.corr l σ₂)))
+
+instance : Decidable ℓ.IsPropertyPreserving :=
+  inferInstanceAs (Decidable (∀ l σ, ℓ.pm l σ = σ))
+
+instance : Decidable ℓ.IsDefective :=
+  inferInstanceAs (Decidable (∃ l σ, ℓ.stems l σ = ∅))
+
+instance : Decidable ℓ.IsOverabundant :=
+  inferInstanceAs (Decidable (∃ l σ, 2 ≤ (ℓ.stems l σ).card))
+
+instance : Decidable ℓ.IsSuppletive :=
+  inferInstanceAs (Decidable (¬ ℓ.IsStemInvariant))
+
+instance {cls : Z → K} [DecidableEq K] : Decidable (ℓ.IsHeteroclite cls) :=
+  inferInstanceAs (Decidable (¬ ℓ.InvariantAlong cls))
+
+instance : Decidable ℓ.IsSyncretic :=
+  inferInstanceAs (Decidable (∃ l σ₁ σ₂,
+    σ₁ ≠ σ₂ ∧ ¬ Disjoint (ℓ.corr l σ₁) (ℓ.corr l σ₂)))
+
+instance : Decidable ℓ.IsUnfaithful :=
+  inferInstanceAs (Decidable (∃ l σ, ℓ.pm l σ ≠ σ))
+
+end Decidable
+
+/-! ### Realization -/
+
+section Realize
+
+variable [DecidableEq W] (realizeForm : Z → P → W)
+
+/-- Equal correspondent sets force equal realizations ([stump-2012-mmm8] §3.2):
+the mechanism of syncretism. -/
+theorem realize_eq_of_corr_eq {l : L} {σ₁ σ₂ : P}
     (h : ℓ.corr l σ₁ = ℓ.corr l σ₂) :
     ℓ.realize realizeForm l σ₁ = ℓ.realize realizeForm l σ₂ := by
-  simp only [realize, h]
+  rcases (ℓ.stems l σ₁).eq_empty_or_nonempty with he | ⟨z, hz⟩
+  · have he₂ : ℓ.stems l σ₂ = ∅ := by
+      by_contra hne
+      obtain ⟨z, hz⟩ := Finset.nonempty_iff_ne_empty.mpr hne
+      have : (z, ℓ.pm l σ₂) ∈ ℓ.corr l σ₁ := h ▸ ℓ.mem_corr.mpr ⟨hz, rfl⟩
+      simp [he] at this
+    simp [realize, he, he₂]
+  · have hmem : (z, ℓ.pm l σ₁) ∈ ℓ.corr l σ₂ := h ▸ ℓ.mem_corr.mpr ⟨hz, rfl⟩
+    have hpm : ℓ.pm l σ₁ = ℓ.pm l σ₂ := (ℓ.mem_corr.mp hmem).2
+    have hstems : ℓ.stems l σ₁ = ℓ.stems l σ₂ := by
+      ext x
+      constructor <;> intro hx
+      · exact (ℓ.mem_corr.mp (h ▸ ℓ.mem_corr.mpr ⟨hx, rfl⟩ :
+          (x, ℓ.pm l σ₁) ∈ ℓ.corr l σ₂)).1
+      · exact (ℓ.mem_corr.mp (h.symm ▸ ℓ.mem_corr.mpr ⟨hx, rfl⟩ :
+          (x, ℓ.pm l σ₂) ∈ ℓ.corr l σ₁)).1
+    simp [realize, hpm, hstems]
 
-/-- A form correspondent shared across two *lexemes* forces a shared realization:
+/-- Correspondent sets shared across two *lexemes* force shared realizations:
 the cross-lexeme companion of `realize_eq_of_corr_eq`. This is the mechanism
 behind [jackendoff-audring-2020]'s Same Verb solution — homophones with a shared
 morphosyntactic-form pivot inflect alike, however their distinct semantics. -/
-theorem realize_eq_of_corr_eq_lexeme (realizeForm : Z → P → W) {l₁ l₂ : L} {σ : P}
+theorem realize_eq_of_corr_eq_lexeme {l₁ l₂ : L} {σ : P}
     (h : ℓ.corr l₁ σ = ℓ.corr l₂ σ) :
     ℓ.realize realizeForm l₁ σ = ℓ.realize realizeForm l₂ σ := by
-  simp only [realize, h]
+  rcases (ℓ.stems l₁ σ).eq_empty_or_nonempty with he | ⟨z, hz⟩
+  · have he₂ : ℓ.stems l₂ σ = ∅ := by
+      by_contra hne
+      obtain ⟨z, hz⟩ := Finset.nonempty_iff_ne_empty.mpr hne
+      have : (z, ℓ.pm l₂ σ) ∈ ℓ.corr l₁ σ := h ▸ ℓ.mem_corr.mpr ⟨hz, rfl⟩
+      simp [he] at this
+    simp [realize, he, he₂]
+  · have hmem : (z, ℓ.pm l₁ σ) ∈ ℓ.corr l₂ σ := h ▸ ℓ.mem_corr.mpr ⟨hz, rfl⟩
+    have hpm : ℓ.pm l₁ σ = ℓ.pm l₂ σ := (ℓ.mem_corr.mp hmem).2
+    have hstems : ℓ.stems l₁ σ = ℓ.stems l₂ σ := by
+      ext x
+      constructor <;> intro hx
+      · exact (ℓ.mem_corr.mp (h ▸ ℓ.mem_corr.mpr ⟨hx, rfl⟩ :
+          (x, ℓ.pm l₁ σ) ∈ ℓ.corr l₂ σ)).1
+      · exact (ℓ.mem_corr.mp (h.symm ▸ ℓ.mem_corr.mpr ⟨hx, rfl⟩ :
+          (x, ℓ.pm l₂ σ) ∈ ℓ.corr l₁ σ)).1
+    simp [realize, hpm, hstems]
+
+/-- A shared form correspondent already forces a shared realized form, even when
+the full correspondent sets differ: the multi-valued syncretism mechanism. -/
+theorem not_disjoint_realize_of_not_disjoint_corr {l : L} {σ₁ σ₂ : P}
+    (h : ¬ Disjoint (ℓ.corr l σ₁) (ℓ.corr l σ₂)) :
+    ¬ Disjoint (ℓ.realize realizeForm l σ₁) (ℓ.realize realizeForm l σ₂) := by
+  obtain ⟨⟨z, τ⟩, h₁, h₂⟩ := Finset.not_disjoint_iff.mp h
+  obtain ⟨hz₁, hτ₁⟩ := ℓ.mem_corr.mp h₁
+  obtain ⟨hz₂, hτ₂⟩ := ℓ.mem_corr.mp h₂
+  exact Finset.not_disjoint_iff.mpr
+    ⟨(realizeForm z τ, τ),
+     ℓ.mem_realize.mpr ⟨z, hz₁, by rw [← hτ₁]⟩,
+     ℓ.mem_realize.mpr ⟨z, hz₂, by rw [← hτ₂]⟩⟩
+
+/-- **Cell-mates** ([thornton-2011]): some content cell realizes as two or more
+distinct word forms. -/
+def HasCellMates : Prop := ∃ l σ, 2 ≤ (ℓ.realize realizeForm l σ).card
+
+/-- Realization cannot outnumber the stems that feed it. -/
+theorem card_realize_le_card_stems (l : L) (σ : P) :
+    (ℓ.realize realizeForm l σ).card ≤ (ℓ.stems l σ).card := by
+  simpa [realize] using Finset.card_image_le
+
+/-- Cell-mates certify overabundance: distinct realized forms at one cell need
+distinct form correspondents there. The converse fails — distinct correspondents
+may realize alike. -/
+theorem HasCellMates.isOverabundant (h : ℓ.HasCellMates realizeForm) :
+    ℓ.IsOverabundant := by
+  obtain ⟨l, σ, hcard⟩ := h
+  exact ⟨l, σ, hcard.trans (ℓ.card_realize_le_card_stems realizeForm l σ)⟩
+
+end Realize
 
 /-! ### The canonical linkage -/
 
-/-- The **canonical one-stem linkage**: a total, lexeme-blind stem selection with
-the identity property mapping. Recovers the pre-deviation content-form
-isomorphism. -/
+/-- The **canonical one-stem linkage**: a total, univalent, lexeme-blind stem
+selection with the identity property mapping — the graph of [stump-2006]'s
+universal default rule of paradigm linkage. -/
 def canonical (st : L → Z) : Linkage L Z P where
-  stem := fun l _ => some (st l)
+  stems := fun l _ => {st l}
   pm := fun _ σ => σ
 
-@[simp] theorem canonical_stem (st : L → Z) (l : L) (σ : P) :
-    (canonical (P := P) st).stem l σ = some (st l) := rfl
+@[simp] theorem canonical_stems (st : L → Z) (l : L) (σ : P) :
+    (canonical (P := P) st).stems l σ = {st l} := rfl
 
 @[simp] theorem canonical_pm (st : L → Z) (l : L) (σ : P) :
     (canonical (P := P) st).pm l σ = σ := rfl
 
 @[simp] theorem canonical_corr (st : L → Z) (l : L) (σ : P) :
-    (canonical (P := P) st).corr l σ = some (st l, σ) := rfl
+    (canonical (P := P) st).corr l σ = {(st l, σ)} :=
+  Finset.singleton_product_singleton
 
-@[simp] theorem canonical_realize (st : L → Z) (realizeForm : Z → P → W)
-    (l : L) (σ : P) :
-    (canonical (P := P) st).realize realizeForm l σ = some (realizeForm (st l) σ, σ) :=
-  rfl
+@[simp] theorem canonical_realize [DecidableEq W] (st : L → Z)
+    (realizeForm : Z → P → W) (l : L) (σ : P) :
+    (canonical (P := P) st).realize realizeForm l σ
+      = {(realizeForm (st l) σ, σ)} := by
+  simp [realize]
 
-@[simp] theorem corr_eq_some {l : L} {σ : P} {zτ : Z × P} :
-    ℓ.corr l σ = some zτ ↔ ∃ z, ℓ.stem l σ = some z ∧ (z, ℓ.pm l σ) = zτ := by
-  simp [corr]
-
-@[simp] theorem corr_isSome (l : L) (σ : P) :
-    (ℓ.corr l σ).isSome = (ℓ.stem l σ).isSome := by
-  simp [corr]
-
-/-- The canonical linkage is canonical on all four axes. -/
+/-- The canonical linkage is canonical on all five axes. -/
 theorem canonical_isCanonical (st : L → Z) :
-    (canonical (P := P) st).IsCanonical :=
-  ⟨fun _ _ => rfl,
-   fun _ _ _ _ _ h₁ h₂ => (Option.some.inj h₁).symm.trans (Option.some.inj h₂),
-   fun _ _ _ _ _ heq => congrArg Prod.snd (Option.some.inj heq),
-   fun _ _ => rfl⟩
+    (canonical (P := P) st).IsCanonical where
+  total := fun l _ => ⟨st l, Finset.mem_singleton_self _⟩
+  univalent := fun _ _ => (Finset.card_singleton _).le
+  stemInvariant := fun l _ _ _ _ h₁ h₂ =>
+    (Finset.mem_singleton.mp h₁).trans (Finset.mem_singleton.mp h₂).symm
+  injective := fun l _ _ hne => by
+    simpa [canonical_corr, Finset.disjoint_singleton] using hne
+  propertyPreserving := fun _ _ => rfl
 
 end Linkage
 

--- a/Linglib/Studies/JackendoffAudring2020.lean
+++ b/Linglib/Studies/JackendoffAudring2020.lean
@@ -270,17 +270,18 @@ inductive Tense | pres | past
 /-- The paradigm linkage: both `draw` readings select the same stem, so they share
 every correspondent; `ring` and `wring` select distinct stems. -/
 def drawLinkage : Linkage DrawLex DrawStem Tense where
-  stem
-    | .drawPicture, _ => some .drawZ
-    | .drawElicit, _ => some .drawZ
-    | .ring, _ => some .ringZ
-    | .wring, _ => some .wringZ
+  stems
+    | .drawPicture, _ => {.drawZ}
+    | .drawElicit, _ => {.drawZ}
+    | .ring, _ => {.ringZ}
+    | .wring, _ => {.wringZ}
   pm := fun _ σ => σ
 
 /-- **Same Verb**: the two `draw` readings, sharing a form correspondent, realize
 identically at every cell — `drew` is forced, whatever their distinct semantics.
 Instantiates `Linkage.realize_eq_of_corr_eq_lexeme`. -/
-theorem draw_same_verb {W : Type*} (rf : DrawStem → Tense → W) (σ : Tense) :
+theorem draw_same_verb {W : Type*} [DecidableEq W] (rf : DrawStem → Tense → W)
+    (σ : Tense) :
     drawLinkage.realize rf .drawPicture σ = drawLinkage.realize rf .drawElicit σ :=
   drawLinkage.realize_eq_of_corr_eq_lexeme rf rfl
 

--- a/Linglib/Studies/KalinBjorkmanEtAl2026.lean
+++ b/Linglib/Studies/KalinBjorkmanEtAl2026.lean
@@ -102,9 +102,9 @@ theorem ParadigmFunction.apply_eq_linkage_realize {Feature : Type} [BEq Feature]
     (σ : MorphPropertySet Feature) :
     ((Morphology.Linkage.canonical (Z := Lexeme)
           (P := MorphPropertySet Feature) id).realize
-        (fun l τ => pf.apply τ l) lex σ).map Prod.fst
-      = some (pf.apply σ lex) :=
-  rfl
+        (fun l τ => pf.apply τ l) lex σ).image Prod.fst
+      = {pf.apply σ lex} := by
+  simp
 
 /-- The linkage PFM instantiates is canonical ([stump-2016] §7.1): identity
 property mapping and one stem per lexeme. -/

--- a/Linglib/Studies/Stump2006.lean
+++ b/Linglib/Studies/Stump2006.lean
@@ -1,0 +1,242 @@
+import Linglib.Morphology.Paradigm.Linkage
+import Mathlib.Tactic.DeriveFintype
+import Mathlib.Data.Fintype.Sigma
+
+/-!
+# Stump 2006: heteroclisis and paradigm linkage
+[stump-2006]
+
+Heteroclisis — a lexeme whose paradigm draws on two or more inflection classes —
+regulated by rules of paradigm linkage. The universal default rule (5) links each
+content cell `⟨L, σ⟩` to `⟨root L, σ⟩`; a heteroclite lexeme carries an override
+(the shape of the Czech rule (14)) routing part of its paradigm to a coradical of
+a different class.
+
+**Czech PRAMEN 'spring'** (Table 1, after Heim 1982): singular cells inflect
+soft-masculine (like POKOJ 'room'), plural cells hard-masculine (like MOST
+'bridge'). The two stems are phonologically identical — [stump-2006] holds that
+the paradigm still "exhibits a kind of stem alternation", the stems differing in
+class alone; footnote 5 defends class-distinct, form-identical stem alternants
+against the No Blur Principle. Formally: the linkage is invariant along the form
+projection yet heteroclite along the class projection
+(`heteroclisis_without_form_suppletion`), and heteroclisis entails stem
+non-invariance (`Linkage.IsHeteroclite.isSuppletive`).
+
+**Sanskrit HR̥D(AYA) 'heart'** (Table 4): direct-case cells are built on
+*hr̥daya* (neuter a-stem declension, like ĀSYA), oblique cells on *hr̥d*
+(neuter consonant-stem declension) — heteroclisis riding on genuine stem
+suppletion, occupying the grid cell PRAMEN leaves empty. Together the two
+lexemes witness that form-invariance and class-invariance are independent
+below stem invariance.
+
+## Main results
+
+* `realize_matches_table1` — the rule-(5)-plus-override linkage reproduces all
+  42 word forms of Table 1 for POKOJ, MOST, and PRAMEN
+* `pramen_heteroclite` / `heteroclisis_without_form_suppletion` — PRAMEN is
+  heteroclite with phonologically constant stems
+* `pramen_stem_alternation` — the entailment instance: PRAMEN's linkage is
+  suppletive in the broad sense (two stems) despite form identity
+* `hrd_heteroclite_and_form_suppletive` — HR̥D(AYA) is heteroclite *and*
+  form-suppletive
+* `soft_hard_contrast` — the two declensions PRAMEN juxtaposes ordinarily
+  contrast, so its split is detectable cell by cell
+-/
+
+namespace Stump2006
+
+open Morphology
+
+/-! ### Czech: the two masculine declensions of Table 1 -/
+
+/-- The two Czech masculine inanimate declensions Table 1 juxtaposes. -/
+inductive Decl | softMasc | hardMasc
+  deriving DecidableEq, Fintype, Repr
+
+/-- The seven Czech cases, in Table 1's row order. -/
+inductive Case | nom | gen | dat | acc | voc | loc | ins
+  deriving DecidableEq, Fintype, Repr
+
+/-- Grammatical number. -/
+inductive Num | sg | pl
+  deriving DecidableEq, Fintype, Repr
+
+/-- A content cell: case and number (masculine gender held constant). -/
+structure CzCell where
+  case : Case
+  num : Num
+  deriving DecidableEq, Fintype, Repr
+
+/-- The three lexemes of Table 1. -/
+inductive CzNoun | pokoj | most | pramen
+  deriving DecidableEq, Fintype, Repr
+
+/-- The stem inventory: one stem each for POKOJ and MOST, and PRAMEN's two
+class-distinct coradicals. `pramenS` and `pramenH` are distinct stems sharing a
+phonological form — the alternant pair of [stump-2006]'s footnote 5. -/
+inductive CzStem | pokoj | most | pramenS | pramenH
+  deriving DecidableEq, Fintype, Repr
+
+/-- A stem's phonological form. -/
+def CzStem.form : CzStem → String
+  | .pokoj => "pokoj"
+  | .most => "most"
+  | .pramenS => "pramen"
+  | .pramenH => "pramen"
+
+/-- A stem's inflection-class membership — the projection heteroclisis is stated
+along. -/
+def CzStem.decl : CzStem → Decl
+  | .pokoj => .softMasc
+  | .most => .hardMasc
+  | .pramenS => .softMasc
+  | .pramenH => .hardMasc
+
+/-- Each lexeme's root, as stipulated lexically (rule (5) reads it off). -/
+def root : CzNoun → CzStem
+  | .pokoj => .pokoj
+  | .most => .most
+  | .pramen => .pramenS
+
+/-- The linkage: the universal default rule (5) routes every cell to the root;
+PRAMEN's plural cells carry the override of the shape of rule (14), routing them
+to the hard-masculine coradical. -/
+def czLinkage : Linkage CzNoun CzStem CzCell where
+  stems
+    | .pramen, ⟨_, .pl⟩ => {.pramenH}
+    | n, _ => {root n}
+  pm := fun _ σ => σ
+
+/-- The case/number endings of the two declensions, read off Table 1's POKOJ and
+MOST columns. -/
+def ending : Decl → CzCell → String
+  | .softMasc, ⟨.nom, .sg⟩ => "" | .softMasc, ⟨.gen, .sg⟩ => "e"
+  | .softMasc, ⟨.dat, .sg⟩ => "i" | .softMasc, ⟨.acc, .sg⟩ => ""
+  | .softMasc, ⟨.voc, .sg⟩ => "i" | .softMasc, ⟨.loc, .sg⟩ => "i"
+  | .softMasc, ⟨.ins, .sg⟩ => "em"
+  | .softMasc, ⟨.nom, .pl⟩ => "e" | .softMasc, ⟨.gen, .pl⟩ => "ů"
+  | .softMasc, ⟨.dat, .pl⟩ => "ům" | .softMasc, ⟨.acc, .pl⟩ => "e"
+  | .softMasc, ⟨.voc, .pl⟩ => "e" | .softMasc, ⟨.loc, .pl⟩ => "ích"
+  | .softMasc, ⟨.ins, .pl⟩ => "i"
+  | .hardMasc, ⟨.nom, .sg⟩ => "" | .hardMasc, ⟨.gen, .sg⟩ => "u"
+  | .hardMasc, ⟨.dat, .sg⟩ => "u" | .hardMasc, ⟨.acc, .sg⟩ => ""
+  | .hardMasc, ⟨.voc, .sg⟩ => "e" | .hardMasc, ⟨.loc, .sg⟩ => "ě"
+  | .hardMasc, ⟨.ins, .sg⟩ => "em"
+  | .hardMasc, ⟨.nom, .pl⟩ => "y" | .hardMasc, ⟨.gen, .pl⟩ => "ů"
+  | .hardMasc, ⟨.dat, .pl⟩ => "ům" | .hardMasc, ⟨.acc, .pl⟩ => "y"
+  | .hardMasc, ⟨.voc, .pl⟩ => "y" | .hardMasc, ⟨.loc, .pl⟩ => "ech"
+  | .hardMasc, ⟨.ins, .pl⟩ => "y"
+
+/-- Realization of a form cell: the stem's form plus its own declension's
+ending — realization rules "are sensitive to a stem's inflection-class
+membership" ([stump-2006] §3.1). -/
+def czRealize (z : CzStem) (σ : CzCell) : String := z.form ++ ending z.decl σ
+
+/-- Table 1's forms, transcribed verbatim. -/
+def table1 : CzNoun → CzCell → String
+  | .pokoj, ⟨.nom, .sg⟩ => "pokoj" | .pokoj, ⟨.gen, .sg⟩ => "pokoje"
+  | .pokoj, ⟨.dat, .sg⟩ => "pokoji" | .pokoj, ⟨.acc, .sg⟩ => "pokoj"
+  | .pokoj, ⟨.voc, .sg⟩ => "pokoji" | .pokoj, ⟨.loc, .sg⟩ => "pokoji"
+  | .pokoj, ⟨.ins, .sg⟩ => "pokojem"
+  | .pokoj, ⟨.nom, .pl⟩ => "pokoje" | .pokoj, ⟨.gen, .pl⟩ => "pokojů"
+  | .pokoj, ⟨.dat, .pl⟩ => "pokojům" | .pokoj, ⟨.acc, .pl⟩ => "pokoje"
+  | .pokoj, ⟨.voc, .pl⟩ => "pokoje" | .pokoj, ⟨.loc, .pl⟩ => "pokojích"
+  | .pokoj, ⟨.ins, .pl⟩ => "pokoji"
+  | .most, ⟨.nom, .sg⟩ => "most" | .most, ⟨.gen, .sg⟩ => "mostu"
+  | .most, ⟨.dat, .sg⟩ => "mostu" | .most, ⟨.acc, .sg⟩ => "most"
+  | .most, ⟨.voc, .sg⟩ => "moste" | .most, ⟨.loc, .sg⟩ => "mostě"
+  | .most, ⟨.ins, .sg⟩ => "mostem"
+  | .most, ⟨.nom, .pl⟩ => "mosty" | .most, ⟨.gen, .pl⟩ => "mostů"
+  | .most, ⟨.dat, .pl⟩ => "mostům" | .most, ⟨.acc, .pl⟩ => "mosty"
+  | .most, ⟨.voc, .pl⟩ => "mosty" | .most, ⟨.loc, .pl⟩ => "mostech"
+  | .most, ⟨.ins, .pl⟩ => "mosty"
+  | .pramen, ⟨.nom, .sg⟩ => "pramen" | .pramen, ⟨.gen, .sg⟩ => "pramene"
+  | .pramen, ⟨.dat, .sg⟩ => "prameni" | .pramen, ⟨.acc, .sg⟩ => "pramen"
+  | .pramen, ⟨.voc, .sg⟩ => "prameni" | .pramen, ⟨.loc, .sg⟩ => "prameni"
+  | .pramen, ⟨.ins, .sg⟩ => "pramenem"
+  | .pramen, ⟨.nom, .pl⟩ => "prameny" | .pramen, ⟨.gen, .pl⟩ => "pramenů"
+  | .pramen, ⟨.dat, .pl⟩ => "pramenům" | .pramen, ⟨.acc, .pl⟩ => "prameny"
+  | .pramen, ⟨.voc, .pl⟩ => "prameny" | .pramen, ⟨.loc, .pl⟩ => "pramenech"
+  | .pramen, ⟨.ins, .pl⟩ => "prameny"
+
+/-- The default-plus-override linkage reproduces every form of Table 1. -/
+theorem realize_matches_table1 :
+    ∀ (n : CzNoun) (σ : CzCell),
+      czLinkage.realize czRealize n σ = {(table1 n σ, σ)} := by decide
+
+/-- The two declensions ordinarily contrast — no case/number cell has them
+merely notational variants across the whole ending inventory, and e.g. the
+genitive singular separates them outright. PRAMEN's split is therefore
+detectable ([stump-2006] on POKOJ vs MOST vs PRAMEN). -/
+theorem soft_hard_contrast :
+    ending .softMasc ⟨.gen, .sg⟩ ≠ ending .hardMasc ⟨.gen, .sg⟩ := by decide
+
+/-- **PRAMEN is heteroclite**: its correspondents draw on both declensions
+([stump-2006] Table 1, rule (14)). -/
+theorem pramen_heteroclite : czLinkage.IsHeteroclite CzStem.decl := by decide
+
+/-- **Heteroclisis without form suppletion**: the linkage is invariant along the
+form projection — every lexeme's stems are phonologically constant — yet
+heteroclite along the class projection. Form-invariance and class-invariance are
+independent ([stump-2006] fn. 5, against reading the No Blur Principle as
+excluding class-only stem alternants). -/
+theorem heteroclisis_without_form_suppletion :
+    czLinkage.InvariantAlong CzStem.form ∧ czLinkage.IsHeteroclite CzStem.decl :=
+  ⟨by decide, pramen_heteroclite⟩
+
+/-- The entailment instance: PRAMEN's class split makes the linkage suppletive
+in the broad sense — two stems — even though no form alternation is audible,
+[stump-2006]'s "a kind of stem alternation". -/
+theorem pramen_stem_alternation : czLinkage.IsSuppletive :=
+  pramen_heteroclite.isSuppletive
+
+/-! ### Sanskrit HR̥D(AYA): heteroclisis riding on stem suppletion (Table 4)
+
+Direct cases (nominative, vocative, accusative) are built on *hr̥daya*, oblique
+cases on *hr̥d*; the a-stem *hr̥daya* follows the neuter a-stem declension, the
+consonant-stem *hr̥d* the neuter consonant-stem declension. Cells are abstracted
+to the direct/oblique split the prose states. -/
+
+/-- The direct/oblique case-class split. -/
+inductive CaseClass | direct | oblique
+  deriving DecidableEq, Fintype, Repr
+
+/-- The two Sanskrit neuter declensions involved. -/
+inductive SktDecl | aStem | consStem
+  deriving DecidableEq, Fintype, Repr
+
+/-- HR̥D(AYA)'s two suppletive stems. -/
+inductive SktStem | hrdaya | hrd
+  deriving DecidableEq, Fintype, Repr
+
+/-- Stem forms (romanized without diacritics in identifiers; forms carry them). -/
+def SktStem.form : SktStem → String
+  | .hrdaya => "hr̥daya"
+  | .hrd => "hr̥d"
+
+/-- Stem class: a-stems decline as a-stems, consonant-stems as consonant-stems
+("because hr̥daya is a neuter stem ending in a … because hr̥d is a neuter stem
+ending in a consonant", [stump-2006] on Table 4). -/
+def SktStem.decl : SktStem → SktDecl
+  | .hrdaya => .aStem
+  | .hrd => .consStem
+
+/-- The single lexeme HR̥D(AYA). -/
+inductive SktNoun | hrdaya
+  deriving DecidableEq, Fintype, Repr
+
+/-- The suppletive linkage: direct cells on *hr̥daya*, oblique on *hr̥d*. -/
+def sktLinkage : Linkage SktNoun SktStem CaseClass where
+  stems := fun _ σ => match σ with | .direct => {.hrdaya} | .oblique => {.hrd}
+  pm := fun _ σ => σ
+
+/-- HR̥D(AYA) occupies the doubly-deviant grid cell: heteroclite *and*
+form-suppletive — "it is because of this stem suppletion that the paradigm of
+HR̥D(AYA) is heteroclite" ([stump-2006] on Table 4). Contrast PRAMEN, heteroclite
+with constant form. -/
+theorem hrd_heteroclite_and_form_suppletive :
+    sktLinkage.IsHeteroclite SktStem.decl ∧
+      ¬ sktLinkage.InvariantAlong SktStem.form :=
+  ⟨by decide, by decide⟩
+
+end Stump2006

--- a/Linglib/Studies/Stump2012.lean
+++ b/Linglib/Studies/Stump2012.lean
@@ -7,8 +7,9 @@ import Mathlib.Data.Fintype.Sum
 # Stump 2012: canonical paradigm linkage and its deviations
 [stump-2012-mmm8]
 
-The four axes of canonical paradigm linkage of `Morphology/Paradigm/Linkage.lean`
-([stump-2012-mmm8]), each anchored by the paper's own witness: a near-canonical
+The paper's four axes of canonical paradigm linkage — totality, stem invariance,
+injectivity, property preservation, per `Morphology/Paradigm/Linkage.lean`
+([stump-2012-mmm8]) — each anchored by the paper's own witness: a near-canonical
 baseline and one deviation per axis, plus the two compound cases that show the
 axes are independent. Content and form paradigms, the correspondence relation,
 and the deviation typology are the paper's; the forms are transcribed from its
@@ -99,7 +100,7 @@ structure CoepCell where
 /-- COEPISSE's linkage: `coep` on perfect-system cells, no stem on present-system
 cells ([stump-2012-mmm8] (18)). -/
 def coepisseLinkage : Linkage CoepLex CoepStem CoepCell where
-  stem := fun _ σ => match σ.sys with | .perf => some .coep | .pres => none
+  stems := fun _ σ => match σ.sys with | .perf => {.coep} | .pres => ∅
   pm := fun _ σ => σ
 
 /-- The perfect-system realizations `coepī, coepistī, coepit, coepimus,
@@ -116,13 +117,13 @@ theorem coepisse_defective : coepisseLinkage.IsDefective :=
 
 /-- A present-system content cell has no realization. -/
 theorem coepisse_present_no_realization :
-    coepisseLinkage.realize coepRealize .coepisse ⟨.pres, .s3⟩ = none := rfl
+    coepisseLinkage.realize coepRealize .coepisse ⟨.pres, .s3⟩ = ∅ := by decide
 
 /-- A perfect-system content cell realizes through its `coep` correspondent
 (`coepit`, 3sg). -/
 theorem coepisse_perfect_realized :
     coepisseLinkage.realize coepRealize .coepisse ⟨.perf, .s3⟩
-      = some ("coepit", ⟨.perf, .s3⟩) := rfl
+      = {("coepit", ⟨.perf, .s3⟩)} := by decide
 
 /-- COEPISSE keeps a single stem, so it is stem-invariant. -/
 theorem coepisse_stemInvariant : coepisseLinkage.IsStemInvariant := by
@@ -172,7 +173,7 @@ def bellumPm (σ : BellumCell) : BellumCell :=
 
 /-- BELLUM's linkage: one stem, the syncretizing property mapping. -/
 def bellumLinkage : Linkage BellumLex BellumStem BellumCell where
-  stem := fun _ _ => some .bell
+  stems := fun _ _ => {.bell}
   pm := fun _ σ => bellumPm σ
 
 /-- The realizations `bellum, bellī, bellō, bella, bellōrum, bellīs` on the form
@@ -186,12 +187,12 @@ def bellRealize : BellumStem → BellumCell → String
 /-- Directional syncretism: nominative and accusative singular share a form
 correspondent ([stump-2012-mmm8] (24)). -/
 theorem bellum_nom_acc_syncretic : bellumLinkage.IsSyncretic :=
-  ⟨.bellum, ⟨.nom, .sg⟩, ⟨.acc, .sg⟩, by decide, by decide, by decide⟩
+  ⟨.bellum, ⟨.nom, .sg⟩, ⟨.acc, .sg⟩, by decide, by decide⟩
 
 /-- Nondirectional syncretism: dative and ablative singular share a form
 correspondent ([stump-2012-mmm8] (25)). -/
 theorem bellum_dat_abl_syncretic : bellumLinkage.IsSyncretic :=
-  ⟨.bellum, ⟨.dat, .sg⟩, ⟨.abl, .sg⟩, by decide, by decide, by decide⟩
+  ⟨.bellum, ⟨.dat, .sg⟩, ⟨.abl, .sg⟩, by decide, by decide⟩
 
 /-- The shared form correspondent forces a shared realization: nominative and
 accusative singular both realize as `bellum` ([stump-2012-mmm8] (26)). -/
@@ -202,7 +203,7 @@ theorem bellum_nom_acc_realize_eq :
 
 theorem bellum_nom_realizes_bellum :
     bellumLinkage.realize bellRealize .bellum ⟨.nom, .sg⟩
-      = some ("bellum", ⟨.acc, .sg⟩) := rfl
+      = {("bellum", ⟨.acc, .sg⟩)} := by decide
 
 /-- Syncretism is the failure of injectivity. -/
 theorem bellum_not_injective : ¬ bellumLinkage.IsInjective :=
@@ -236,7 +237,7 @@ structure VCell where
 /-- HORTĀRĪ's linkage: a stem on the active cells only, and the voice-flipping
 property mapping ([stump-2012-mmm8] (29)–(30)). -/
 def hortariLinkage : Linkage HortariLex HortariStem VCell where
-  stem := fun _ σ => match σ.voice with | .active => some .horta | .passive => none
+  stems := fun _ σ => match σ.voice with | .active => {.horta} | .passive => ∅
   pm := fun _ σ => { σ with voice := .passive }
 
 /-- The passive-morphology realizations of the active content cells (`hortor,
@@ -253,14 +254,14 @@ theorem hortari_unfaithful : hortariLinkage.IsUnfaithful :=
 
 /-- Every active content cell has a passive form correspondent. -/
 theorem hortari_active_realized_by_passive (σ : VCell) :
-    (hortariLinkage.corr .hortari ⟨.active, σ.agr⟩).map (·.2.voice) = some .passive :=
-  rfl
+    (hortariLinkage.corr .hortari ⟨.active, σ.agr⟩).image (·.2.voice) = {.passive} := by
+  revert σ; decide
 
 /-- The active content cell `1sg` realizes as `hortor` through its passive
 correspondent. -/
 theorem hortari_realizes_hortor :
     hortariLinkage.realize hoRealize .hortari ⟨.active, .s1⟩
-      = some ("hortor", ⟨.passive, .s1⟩) := rfl
+      = {("hortor", ⟨.passive, .s1⟩)} := by decide
 
 /-- Deponency compounds with defectiveness: the passive content cells lack a
 stem ([stump-2012-mmm8] (30a)). -/
@@ -308,11 +309,11 @@ inductive CaseStem | nek | benn | rajt
 
 /-- The stem selection: the case picks the postpositional stem ([stump-2012-mmm8]
 (37)). -/
-def enStem : Pron → HuProp → Option CaseStem
-  | _, .case .dative => some .nek
-  | _, .case .inessive => some .benn
-  | _, .case .superessive => some .rajt
-  | _, _ => none
+def enStems : Pron → HuProp → Finset CaseStem
+  | _, .case .dative => {.nek}
+  | _, .case .inessive => {.benn}
+  | _, .case .superessive => {.rajt}
+  | _, _ => ∅
 
 /-- The property mapping computes the form property set from the *lexeme* — the
 functor-argument reversal ([stump-2012-mmm8] (32), (37)). -/
@@ -322,7 +323,7 @@ def enPm : Pron → HuProp → HuProp
 
 /-- ÉN's linkage: case-driven stem, lexeme-driven property mapping. -/
 def enLinkage : Linkage Pron CaseStem HuProp where
-  stem := enStem
+  stems := enStems
   pm := enPm
 
 /-- The realizations `nekem, bennem, rajtam` (1sg) and `neked, benned, rajtad`
@@ -336,7 +337,7 @@ def enRealize : CaseStem → HuProp → String
 /-- The inessive of ÉN corresponds to the 1sg form of `benn` ([stump-2012-mmm8]
 (38)). -/
 theorem en_inessive_corr :
-    enLinkage.corr .en (.case .inessive) = some (.benn, .agr .p1sg) := rfl
+    enLinkage.corr .en (.case .inessive) = {(.benn, .agr .p1sg)} := by decide
 
 /-- The correspondent's property set is the pronoun's, not the case's — the
 reversal is unfaithful ([stump-2012-mmm8] (37)). -/
@@ -353,10 +354,10 @@ theorem en_pm_lexeme_sensitive :
 `nekem` and `bennem`. -/
 theorem en_realizes_nekem_bennem :
     enLinkage.realize enRealize .en (.case .dative)
-        = some ("nekem", .agr .p1sg) ∧
+        = {("nekem", .agr .p1sg)} ∧
       enLinkage.realize enRealize .en (.case .inessive)
-        = some ("bennem", .agr .p1sg) :=
-  ⟨rfl, rfl⟩
+        = {("bennem", .agr .p1sg)} :=
+  ⟨by decide, by decide⟩
 
 end Hungarian
 
@@ -383,7 +384,7 @@ structure FerreCell where
 /-- FERRE's linkage: two suppletive stems in complementary distribution, identity
 property mapping ([stump-2012-mmm8] (42)). -/
 def ferreLinkage : Linkage FerreLex FerreStem FerreCell where
-  stem := fun _ σ => match σ.sys with | .pres => some .fer | .perf => some .tul
+  stems := fun _ σ => match σ.sys with | .pres => {.fer} | .perf => {.tul}
   pm := fun _ σ => σ
 
 /-- The realizations `ferō, fers, fert, …` and `tulī, …, tulit, …`
@@ -399,7 +400,8 @@ def ferRealize : FerreStem → FerreCell → String
 /-- FERRE is suppletive: the present- and perfect-system cells draw on different
 stems ([stump-2012-mmm8] §3.4). -/
 theorem ferre_suppletive : ferreLinkage.IsSuppletive := fun h =>
-  absurd (h .ferre (σ₁ := ⟨.pres, .s1⟩) (σ₂ := ⟨.perf, .s1⟩) rfl rfl) (by decide)
+  absurd (h .ferre (σ₁ := ⟨.pres, .s1⟩) (σ₂ := ⟨.perf, .s1⟩) (z₁ := .fer)
+    (z₂ := .tul) (by decide) (by decide)) (by decide)
 
 /-- FERRE is property-preserving: no override, the default rule preserves the
 content cell's property set. -/
@@ -414,10 +416,10 @@ theorem ferre_suppletive_yet_faithful :
 
 theorem ferre_present_realized :
     ferreLinkage.realize ferRealize .ferre ⟨.pres, .s3⟩
-      = some ("fert", ⟨.pres, .s3⟩) := rfl
+      = {("fert", ⟨.pres, .s3⟩)} := by decide
 theorem ferre_perfect_realized :
     ferreLinkage.realize ferRealize .ferre ⟨.perf, .s3⟩
-      = some ("tulit", ⟨.perf, .s3⟩) := rfl
+      = {("tulit", ⟨.perf, .s3⟩)} := by decide
 
 end Ferre
 
@@ -446,12 +448,13 @@ structure TCell where
 (suppletion), and a property mapping sending every cell to the past
 (deponent tense) ([stump-2012-mmm8] (45)–(46)). -/
 def thurfaLinkage : Linkage ThurfaLex ThurfaStem TCell where
-  stem := fun _ σ => match σ.tense with | .pres => some .strong | .past => some .weak
+  stems := fun _ σ => match σ.tense with | .pres => {.strong} | .past => {.weak}
   pm := fun _ σ => { σ with tense := .past }
 
 /-- ÞURFA is suppletive: present and past draw on different stems. -/
 theorem thurfa_suppletive : thurfaLinkage.IsSuppletive := fun h =>
-  absurd (h .thurfa (σ₁ := ⟨.pres, .s1⟩) (σ₂ := ⟨.past, .s1⟩) rfl rfl) (by decide)
+  absurd (h .thurfa (σ₁ := ⟨.pres, .s1⟩) (σ₂ := ⟨.past, .s1⟩) (z₁ := .strong)
+    (z₂ := .weak) (by decide) (by decide)) (by decide)
 
 /-- ÞURFA is unfaithful: the present content cell maps to a past form cell. -/
 theorem thurfa_unfaithful : thurfaLinkage.IsUnfaithful :=
@@ -466,12 +469,12 @@ theorem thurfa_suppletive_and_unfaithful :
 /-- The present content cell's form correspondent is the strong stem at the past
 property set ([stump-2012-mmm8] (46)). -/
 theorem thurfa_pres_corr :
-    thurfaLinkage.corr .thurfa ⟨.pres, .s1⟩ = some (.strong, ⟨.past, .s1⟩) := rfl
+    thurfaLinkage.corr .thurfa ⟨.pres, .s1⟩ = {(.strong, ⟨.past, .s1⟩)} := by decide
 
 /-- The past content cell's form correspondent is the weak stem at the past
 property set ([stump-2012-mmm8] (46)). -/
 theorem thurfa_past_corr :
-    thurfaLinkage.corr .thurfa ⟨.past, .s1⟩ = some (.weak, ⟨.past, .s1⟩) := rfl
+    thurfaLinkage.corr .thurfa ⟨.past, .s1⟩ = {(.weak, ⟨.past, .s1⟩)} := by decide
 
 end Thurfa
 

--- a/Linglib/Studies/Stump2016.lean
+++ b/Linglib/Studies/Stump2016.lean
@@ -92,13 +92,13 @@ inductive LatinStem where
 property mapping `pm2c` ([stump-2016] §12.1), which sends an active content cell
 to a passive form cell. -/
 def conariLinkage : Linkage LatinVerb LatinStem Cell where
-  stem := fun _ _ => some .cona
+  stems := fun _ _ => {.cona}
   pm := fun _ σ => { σ with voice := .passive }
 
 /-- The **regular linkage** of *parāre*: a single stem and the identity property
 mapping, canonical on the voice axis ([stump-2016] §7.1). -/
 def parareLinkage : Linkage LatinVerb LatinStem Cell where
-  stem := fun _ _ => some .para
+  stems := fun _ _ => {.para}
   pm := fun _ σ => σ
 
 /-- *cōnārī*'s six active content cells ([stump-2016] Table 12.2). -/
@@ -109,10 +109,7 @@ def conariContentCells : List Cell :=
 /-- The regular verb's linkage is canonical: property-set preserving (`pm = id`)
 and stem invariant ([stump-2016] §7.1, characteristics (2a)–(2b)). -/
 theorem parareLinkage_isCanonical : parareLinkage.IsCanonical :=
-  ⟨fun _ _ => rfl,
-   fun _ _ _ _ _ h₁ h₂ => (Option.some.inj h₁).symm.trans (Option.some.inj h₂),
-   fun _ _ _ _ _ heq => congrArg Prod.snd (Option.some.inj heq),
-   fun _ _ => rfl⟩
+  Linkage.canonical_isCanonical (fun _ : LatinVerb => LatinStem.para)
 
 /-- The deponent property mapping flips voice on every active cell. -/
 theorem conari_pm_flips_voice (l : LatinVerb) (σ : Cell) :
@@ -128,14 +125,15 @@ theorem conari_deviates_on_every_active_cell (l : LatinVerb) (σ : Cell)
 
 /-- Hence the deponent linkage is not property-preserving, so not canonical. -/
 theorem conariLinkage_not_canonical : ¬ conariLinkage.IsCanonical := by
-  rintro ⟨-, -, -, hpp⟩
+  rintro ⟨-, -, -, -, hpp⟩
   exact conari_deviates_on_every_active_cell .conari ⟨.s1, .active⟩ rfl (hpp _ _)
 
 /-- **The deponency claim**: every active content cell of *cōnārī* has a
 *passive* form correspondent — active content realized by passive morphology
 ([stump-2016] §12.1). -/
 theorem conari_active_realized_by_passive_form (l : LatinVerb) (σ : Cell) :
-    (conariLinkage.corr l σ).map (·.2.voice) = some .passive := rfl
+    (conariLinkage.corr l σ).image (·.2.voice) = {.passive} := by
+  simp [conariLinkage, Linkage.corr]
 
 /-- Every one of *cōnārī*'s six active content cells crosses the voice axis. -/
 theorem conari_all_cells_cross_voice :
@@ -145,9 +143,9 @@ theorem conari_all_cells_cross_voice :
 form correspondent stays active while the deponent's becomes passive — deviation
 without any difference in the content-cell space. -/
 theorem depon_vs_regular (σ : Cell) (h : σ.voice = .active) :
-    (parareLinkage.corr .parare σ).map (·.2.voice) = some .active ∧
-      (conariLinkage.corr .conari σ).map (·.2.voice) = some .passive :=
-  ⟨congrArg some h, rfl⟩
+    (parareLinkage.corr .parare σ).image (·.2.voice) = {.active} ∧
+      (conariLinkage.corr .conari σ).image (·.2.voice) = {.passive} :=
+  ⟨by simp [parareLinkage, Linkage.corr, h], by simp [conariLinkage, Linkage.corr]⟩
 
 /-! ### Kashmiri morphomic tense (Ch. 8, pp. 217ff) -/
 
@@ -207,48 +205,48 @@ def realizeForm (z : String) (τ : Finset KFeat) : String :=
   (paradigmFunction (fun _ => wup) (fun _ => z) [formBlock] (wup, τ)).1
 
 /-- Conjugation II linkage: the single stem, mapped by `pmII`. -/
-def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => some (stemOf l), fun _ => pmII⟩
+def linkII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => {stemOf l}, fun _ => pmII⟩
 
 /-- Conjugation III linkage: the single stem, mapped by `pmIII`. -/
-def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => some (stemOf l), fun _ => pmIII⟩
+def linkIII : Linkage KVerb String (Finset KFeat) := ⟨fun l _ => {stemOf l}, fun _ => pmIII⟩
 
 /-- WUP recent past ('past a'): `wupus`. -/
 example : linkII.realize realizeForm wup {recentPast, p1, sg, masc}
-    = some ("wupus", {pastA, p1, sg, masc}) := by decide
+    = {("wupus", {pastA, p1, sg, masc})} := by decide
 
 /-- WUP indefinite past ('past b'): `wupyōs`. -/
 example : linkII.realize realizeForm wup {indefPast, p1, sg, masc}
-    = some ("wupyōs", {pastB, p1, sg, masc}) := by decide
+    = {("wupyōs", {pastB, p1, sg, masc})} := by decide
 
 /-- WUP remote past ('past c'): `wupyās`. -/
 example : linkII.realize realizeForm wup {remotePast, p1, sg, masc}
-    = some ("wupyās", {pastC, p1, sg, masc}) := by decide
+    = {("wupyās", {pastC, p1, sg, masc})} := by decide
 
 /-- WUPH recent past ('past b'): `wuphyōs`. -/
 example : linkIII.realize realizeForm wuph {recentPast, p1, sg, masc}
-    = some ("wuphyōs", {pastB, p1, sg, masc}) := by decide
+    = {("wuphyōs", {pastB, p1, sg, masc})} := by decide
 
 /-- WUPH indefinite past ('past c'): `wuphyās`. -/
 example : linkIII.realize realizeForm wuph {indefPast, p1, sg, masc}
-    = some ("wuphyās", {pastC, p1, sg, masc}) := by decide
+    = {("wuphyās", {pastC, p1, sg, masc})} := by decide
 
 /-- WUPH remote past ('past d'): `wuphiyās`. -/
 example : linkIII.realize realizeForm wuph {remotePast, p1, sg, masc}
-    = some ("wuphiyās", {pastD, p1, sg, masc}) := by decide
+    = {("wuphiyās", {pastD, p1, sg, masc})} := by decide
 
 /-- **The morphomic mediation** ([stump-2016] Ch. 8): WUP's indefinite past and
 WUPH's recent past have the same form correspondent property set — both 'past b',
 1sg masc — even though their tenses differ. This is why they inflect alike
 (`-yōs`), the content-to-form mismatch the paradigm-linkage model captures. -/
 theorem kashmiri_inflect_alike :
-    (linkII.corr wup {indefPast, p1, sg, masc}).map Prod.snd
-      = (linkIII.corr wuph {recentPast, p1, sg, masc}).map Prod.snd := by decide
+    (linkII.corr wup {indefPast, p1, sg, masc}).image Prod.snd
+      = (linkIII.corr wuph {recentPast, p1, sg, masc}).image Prod.snd := by decide
 
 /-- The second interleaving: WUP's remote past and WUPH's indefinite past share
 the 'past c' correspondent, inflecting alike (`-yās`). -/
 theorem kashmiri_inflect_alike_pastC :
-    (linkII.corr wup {remotePast, p1, sg, masc}).map Prod.snd
-      = (linkIII.corr wuph {indefPast, p1, sg, masc}).map Prod.snd := by decide
+    (linkII.corr wup {remotePast, p1, sg, masc}).image Prod.snd
+      = (linkIII.corr wuph {indefPast, p1, sg, masc}).image Prod.snd := by decide
 
 end Kashmiri
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5324,6 +5324,34 @@
   validated = {true},
   sources   = {Syntax/Agreement/Controller.lean}
 }% REF: Fillmore, C. & Atkins, B.T.S. (2000). Describing polysemy: The case of 'crawl'. In *Polysemy*, ed. Y. Ravin & C. Leacock
+@article{corbett-2007,
+  author    = {Corbett, Greville G.},
+  year      = {2007},
+  title     = {Canonical typology, suppletion, and possible words},
+  journal   = {Language},
+  volume    = {83},
+  number    = {1},
+  pages     = {8--42},
+  doi       = {10.1353/lan.2007.0006},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Morphology/Paradigm/Linkage.lean}
+}
+@incollection{thornton-2011,
+  author    = {Thornton, Anna M.},
+  year      = {2011},
+  title     = {Overabundance (Multiple Forms Realizing the Same Cell): A Non-canonical Phenomenon in {I}talian Verb Morphology},
+  booktitle = {Morphological Autonomy: Perspectives from Romance Inflectional Morphology},
+  editor    = {Maiden, Martin and Smith, John Charles and Goldbach, Maria and Hinzelin, Marc-Olivier},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  pages     = {358--381},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Morphology/Paradigm/Linkage.lean}
+}
 @article{fox-2000,
   author    = {Fox, Danny},
   year      = {2000},


### PR DESCRIPTION
Generalizes the paradigm-linkage correspondence from Option-valued to Finset-valued (a finite relation in Stump's factored presentation), so all six canonical deviations are axis failures of one object: overabundance ([thornton-2011] cell-mates) negates the new univalence axis, and heteroclisis ([stump-2006]) negates invariance along a consumer-supplied inflection-class projection, with heteroclisis ⇒ stem non-invariance as a theorem. Adds Studies/Stump2006 (Czech PRAMEN Table 1 reproduced by decide; form/class invariance independence; Sanskrit HR̥D(AYA) contrast) and migrates the four existing linkage studies.