### PR TITLE
refactor(Morphology/Root): formal definition only; semantic layer to study

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2258,6 +2258,7 @@ import Linglib.Studies.Haspelmath1997
 import Linglib.Studies.Haspelmath2001
 import Linglib.Studies.Haspelmath2007
 import Linglib.Studies.Haspelmath2021
+import Linglib.Studies.Haspelmath2025Root
 import Linglib.Studies.HaugDalrymple2020
 import Linglib.Studies.HawkinsGweonGoodman2021
 import Linglib.Studies.HayKennedyLevin1999

--- a/Linglib/Morphology/Root/Basic.lean
+++ b/Linglib/Morphology/Root/Basic.lean
@@ -3,31 +3,27 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Data.UD.Basic
 import Linglib.Morphology.Morph
 import Mathlib.Data.List.Infix
 
 /-!
 # Roots
 
-Two definitions of roothood over `Morph`, relative to a fragment's word and
-free-form inventories. The formal one ([bloomfield-1933], the base definition
-of [qin-2025]): a morph is a core iff it occurs in a *primary word* — one with
-no free form as a proper part. The semantic one ([haspelmath-2025-root]'s
-definition (1)): a *contentful* morph — denoting an action, an object or a
-property — occurring in a free form with no other contentful morph. The two
-come apart at meaning-free cores like *-fer* (`Studies/Qin2025.lean`).
-Consonantal skeletons are `ConsonantalRoot`; DM's acategorial root is
-`Morphology/DM/Root.lean`.
+The formal definition of roothood over `Morph`, relative to a fragment's word
+and free-form inventories ([bloomfield-1933], the base definition of
+[qin-2025]): a morph is a root iff it occurs in a *primary word* — one with no
+free form as a proper part. The definition is deliberately inclusive
+(meaning-free cores like *-fer* qualify; so do free function words);
+`Studies/Qin2025.lean` grades instances by canonicity, and
+[haspelmath-2025-root]'s contentfulness-gated alternative is
+`Studies/Haspelmath2025Root.lean`. Consonantal skeletons are
+`ConsonantalRoot`; DM's acategorial root is `Morphology/DM/Root.lean`.
 
 ## Main declarations
 
-* `IsPrimaryWord`, `Morph.IsCoreIn`, `Morph.IsTypicalAffixIn` — the formal
-  layer: primary words, cores, and affixes.
-* `RootClass`, `RootClass.upos` — action, object, and property roots and
-  their word classes.
-* `Morph.IsRootIn` — the semantic layer, relative to a contentfulness
-  classification `cls`.
+* `IsPrimaryWord` — no proper contiguous part is a free form.
+* `Morph.IsCoreIn` — the root property: occurrence in a primary word.
+* `Morph.IsTypicalAffixIn` — occurrence in secondary words only.
 -/
 
 namespace Morphology
@@ -69,39 +65,5 @@ theorem Morph.isCoreIn_of_free_word {words freeForms : List (List Morph)}
     {m : Morph} (hw : [m] ∈ words) (h : [] ∉ freeForms) :
     m.IsCoreIn words freeForms :=
   ⟨[m], hw, isPrimaryWord_singleton h m, List.mem_singleton_self m⟩
-
-/-- The three semantic root classes: roots denoting actions, objects, and
-properties. Their prototypical combinations with discourse functions —
-predication, reference, modification — need no function indicators, which
-is what makes these the crucial classes for word-class typology. -/
-inductive RootClass where
-  /-- A root denoting an action (*sing*, *open*). -/
-  | action
-  /-- A root denoting an object (*tree*, *bird*). -/
-  | object
-  /-- A root denoting a property (*good*, *small*). -/
-  | property
-  deriving DecidableEq, Repr
-
-/-- Word classes as comparative concepts: a verb is an action-denoting root,
-a noun an object-denoting root, an adjective a property-denoting root. -/
-def RootClass.upos : RootClass → UD.UPOS
-  | .action => .VERB
-  | .object => .NOUN
-  | .property => .ADJ
-
-/-- `m.IsRootIn freeForms cls` is [haspelmath-2025-root]'s definition (1)
-relative to a fragment: the classification `cls` assigns `m` a root class
-(it is contentful), and `m` occurs in some free form in which every other
-morph is non-contentful. Contentful affixes and neoclassical combining
-forms satisfy the first conjunct but not the second. -/
-def Morph.IsRootIn (m : Morph) (freeForms : List (List Morph))
-    (cls : Morph → Option RootClass) : Prop :=
-  (cls m).isSome ∧ ∃ w ∈ freeForms, m ∈ w ∧ ∀ m' ∈ w, m' ≠ m → cls m' = none
-
-instance (m : Morph) (freeForms : List (List Morph))
-    (cls : Morph → Option RootClass) [DecidableEq Morph] :
-    Decidable (m.IsRootIn freeForms cls) :=
-  inferInstanceAs (Decidable (_ ∧ _))
 
 end Morphology

--- a/Linglib/Studies/Haspelmath2025Root.lean
+++ b/Linglib/Studies/Haspelmath2025Root.lean
@@ -1,0 +1,85 @@
+import Linglib.Morphology.Root.Basic
+import Linglib.Data.UD.Basic
+
+/-!
+# Haspelmath 2025: the contentfulness-gated root
+[haspelmath-2025-root]
+
+Definition (1): a **root** is a contentful morph — a morph denoting an action,
+an object or a property — that can occur as part of a free form without
+another contentful morph. Against the formal base definition of
+`Morphology/Root/Basic.lean`, contentfulness is a *gate*: the qualifying
+clause excludes contentful affixes (the Japanese causative *-ase*) and
+neoclassical combining forms (*geo-*, *socio-*), which are contentful but
+never the sole contentful morph of a free form
+(`geo_not_root`). Formally identical roots with related meanings (*hammer*
+the instrument, *hammer* the action) are heterosemous *sister roots*, not one
+precategorial root — the classification `cls` assigns each its own class; the
+paper's §6 divergence from precategorial root families is deferred content.
+
+## Main declarations
+
+* `RootClass` — action, object, and property roots; `RootClass.upos` — word
+  classes as comparative concepts.
+* `Morph.IsRootIn` — definition (1), relative to a fragment's free forms and
+  contentfulness classification.
+* `geo_not_root` — a combining form is contentful yet fails the definition.
+-/
+
+namespace Haspelmath2025Root
+
+open Morphology
+
+/-- The three semantic root classes: roots denoting actions, objects, and
+properties. Their prototypical combinations with discourse functions —
+predication, reference, modification — need no function indicators, which
+is what makes these the crucial classes for word-class typology. -/
+inductive RootClass where
+  /-- A root denoting an action (*sing*, *open*). -/
+  | action
+  /-- A root denoting an object (*tree*, *bird*). -/
+  | object
+  /-- A root denoting a property (*good*, *small*). -/
+  | property
+  deriving DecidableEq, Repr
+
+/-- Word classes as comparative concepts: a verb is an action-denoting root,
+a noun an object-denoting root, an adjective a property-denoting root. -/
+def RootClass.upos : RootClass → UD.UPOS
+  | .action => .VERB
+  | .object => .NOUN
+  | .property => .ADJ
+
+/-- `m.IsRootIn freeForms cls` is definition (1) relative to a fragment: the
+classification `cls` assigns `m` a root class (it is contentful), and `m`
+occurs in some free form in which every other morph is non-contentful. -/
+def _root_.Morphology.Morph.IsRootIn (m : Morph)
+    (freeForms : List (List Morph))
+    (cls : Morph → Option RootClass) : Prop :=
+  (cls m).isSome ∧ ∃ w ∈ freeForms, m ∈ w ∧ ∀ m' ∈ w, m' ≠ m → cls m' = none
+
+instance (m : Morph) (freeForms : List (List Morph))
+    (cls : Morph → Option RootClass) :
+    Decidable (m.IsRootIn freeForms cls) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-! ### The combining-form exclusion -/
+
+/-- The neoclassical combining form *geo-*. -/
+def geo : Morph := .root "geo"
+/-- The neoclassical combining form *-logy*. -/
+def logy : Morph := .root "logy"
+
+/-- The classification: both pieces of *geology* are contentful. -/
+def geoCls : Morph → Option RootClass
+  | m => if m = geo ∨ m = logy then some .object else none
+
+/-- *geo-* is contentful yet not a root: in *geology* it never occurs as the
+sole contentful morph of a free form — the definition's qualifying clause in
+action. Under the formal base definition it is a morphological core. -/
+theorem geo_not_root :
+    ¬ geo.IsRootIn [[geo, logy]] geoCls ∧
+      geo.IsCoreIn [[geo, logy]] [[geo, logy]] := by
+  refine ⟨by decide, by decide⟩
+
+end Haspelmath2025Root

--- a/Linglib/Studies/Qin2025.lean
+++ b/Linglib/Studies/Qin2025.lean
@@ -16,14 +16,14 @@ canonical 厂 *chǎng* to the maximally non-canonical toneless 边 *-bian* and �
 *-ge* (tonelessness diagnosing phonological deficiency in a tone language).
 
 The paper's *-fer* case makes the base definition's formal character exact:
-*-fer* is a morphological core "lacking identifiable meaning", so it fails
-[haspelmath-2025-root]'s contentfulness clause — the roothood judgment is
-"formal-based", not semantic (`fer_core`, `fer_root_not_contentful`).
+*-fer* is a morphological core despite "lacking identifiable meaning" — the
+roothood judgment is "formal-based", not semantic (`fer_core`; the
+contentfulness-gated alternative it contrasts with is
+`Studies/Haspelmath2025Root.lean`).
 
 ## Main results
 
-* `fer_core` / `fer_root_not_contentful` — *-fer* is a core with no root
-  class: the formal and semantic definitions come apart.
+* `fer_core` — *-fer* is a morphological core with no semantic input.
 * `Row`, `Row.violations`, `Row.IsCanonical` — the four-criterion space;
   `space_card`, `tier_card` — Fig. 1's 16 cells and binomial tiers.
 * `chang`, `bu`, `ba`, `xing`, `bian`, `ge` — Mandarin rows with their
@@ -49,11 +49,6 @@ def ferWords : List (List Morph) := [[re, fer], [con, fer]]
 
 /-- *-fer* is a morphological core: it occurs in the primary word *refer*. -/
 theorem fer_core : fer.IsCoreIn ferWords ferWords := by decide
-
-/-- *-fer* is not a root by [haspelmath-2025-root]'s definition (1): it
-denotes no action, object, or property. -/
-theorem fer_root_not_contentful :
-    ¬ fer.IsRootIn ferWords (fun _ => none) := by decide
 
 /-! ### The four criteria and the theoretical space -/
 


### PR DESCRIPTION
Makes the formal (Bloomfield/Qin primary-word) definition the sole substrate notion of roothood: Root/Basic.lean keeps IsPrimaryWord / Morph.IsCoreIn / Morph.IsTypicalAffixIn only. The contentfulness-gated definition, RootClass, and upos move to their owner, the new Studies/Haspelmath2025Root.lean (zero substrate consumers existed), seeded with the paper's own combining-form exclusion witness (geo- contentful yet not a root, while a morphological core formally). Qin2025 drops the cross-definition theorem in favor of the study-owned witness.