### PR TITLE
feat(Morphology/Root): Root.System with two-tier homs; engine bridges

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1292,6 +1292,7 @@ import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Morphology.Paradigm.OfCells
 import Linglib.Morphology.Root.Basic
 import Linglib.Morphology.Root.Consonantal
+import Linglib.Morphology.Root.System
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Paradigm.ToTree
 import Linglib.Morphology.Word.Tree
@@ -1987,6 +1988,7 @@ import Linglib.Studies.BonehDoron2013
 import Linglib.Studies.Booij2010
 import Linglib.Studies.Booth2022
 import Linglib.Studies.Borer2005
+import Linglib.Studies.Borer2013
 import Linglib.Studies.Boylan2023
 import Linglib.Studies.BrananErlewine2023
 import Linglib.Studies.Brandom1994

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.TypeStar
 import Linglib.Morphology.Exponence.Select
+import Linglib.Morphology.Root.System
 
 /-!
 # Vocabulary Insertion (Distributed Morphology)
@@ -228,5 +229,21 @@ theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
   omega
 
 end ExponenceCore
+
+/-! ### The root-system view -/
+
+/-- Vocabulary Insertion as a root system: roots as opaque indices, syntactic
+contexts as contexts, `none` as non-licensing — the univalent stratum. -/
+def toSystem {Ctx Root : Type*} (rules : List (VocabItem Ctx Root)) :
+    Morphology.Root.System Root Ctx String :=
+  ⟨fun r c => match vocabularyInsert rules c r with
+    | some f => {f}
+    | none => ∅⟩
+
+theorem toSystem_isUnivalent {Ctx Root : Type*}
+    (rules : List (VocabItem Ctx Root)) : (toSystem rules).IsUnivalent :=
+  fun r c => by
+    simp only [toSystem]
+    cases vocabularyInsert rules c r <;> simp
 
 end Morphology.DM.VI

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -404,6 +404,23 @@ theorem Linkage.realize_eq_paradigmFunction [DecidableEq Z] (ℓ : Linkage L Z P
   exact congrArg ({·})
     (Prod.ext rfl (blocksEval_snd Lindex blocks (stemChoice (l, σ), σ)).symm)
 
+/-- The paradigm function as a root system: lexemes as opaque indices,
+realized at every cell — total and univalent, PFM's stratum. `Lindex` is the
+seed of the lexeme-to-√ coarsening arrow between individuation grains. -/
+def paradigmSystem (Lindex : Z → L) (stemChoice : L × P → Z)
+    (blocks : List (Block L Z P)) : Root.System L P (Z × P) :=
+  ⟨fun l σ => {paradigmFunction Lindex stemChoice blocks (l, σ)}⟩
+
+theorem paradigmSystem_isTotal (Lindex : Z → L) (stemChoice : L × P → Z)
+    (blocks : List (Block L Z P)) :
+    (paradigmSystem Lindex stemChoice blocks).IsTotal :=
+  fun _ _ => Finset.singleton_nonempty _
+
+theorem paradigmSystem_isUnivalent (Lindex : Z → L) (stemChoice : L × P → Z)
+    (blocks : List (Block L Z P)) :
+    (paradigmSystem Lindex stemChoice blocks).IsUnivalent :=
+  fun _ _ => (Finset.card_singleton _).le
+
 end Selection
 
 /-! ### Payload functoriality -/

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -1,3 +1,4 @@
+import Linglib.Morphology.Root.System
 import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Finset.Card
 
@@ -418,6 +419,20 @@ theorem canonical_isCanonical (st : L → Z) :
   injective := fun l _ _ hne => by
     simpa [canonical_corr, Finset.disjoint_singleton] using hne
   propertyPreserving := fun _ _ => rfl
+
+/-! ### The root-system view -/
+
+/-- The stem selection as a root system: lexemes as indices, property sets
+as contexts, stems as forms. A lossless embedding — the linkage adds only
+the property mapping `pm` on top of it. -/
+def toSystem (ℓ : Linkage L Z P) : Root.System L P Z := ⟨ℓ.stems⟩
+
+@[simp] theorem toSystem_spellout (ℓ : Linkage L Z P) (l : L) (σ : P) :
+    ℓ.toSystem.spellout l σ = ℓ.stems l σ := rfl
+
+/-- The linkage and its root system agree on univalence. -/
+theorem toSystem_isUnivalent_iff (ℓ : Linkage L Z P) :
+    ℓ.toSystem.IsUnivalent ↔ ℓ.IsUnivalent := Iff.rfl
 
 end Linkage
 

--- a/Linglib/Morphology/Root/System.lean
+++ b/Linglib/Morphology/Root/System.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Finset.Card
+
+/-!
+# Root systems: indices with contextual realization
+
+Every realizational/separationist framework that adopts late insertion or a
+separate lexemic index factors a root into an opaque individuator plus
+context-sensitive form and (optionally) meaning maps: DM's √ individuated by
+arbitrary indices, form at Vocabulary Insertion ([harley-2014],
+[marantz-1997], [embick-2021]); [borer-2013]'s phonological indices (her form
+individuation `R ↪ F` is her instance's axiom, not the interface's); PFM's
+opaque lexeme realized at a cell ([stump-2001], [bonami-stump-2016]);
+[spencer-2013]'s lexemic index. [beard-1995]'s Separation Hypothesis grounds
+the form-side separation; the meaning-side separation is DM's List-3 move.
+`Root.System` fixes that object; sign-based lexicalism, Construction
+Morphology, and [haspelmath-2025-root]'s morph-based comparative root are
+rival ontologies its parameters measure, not instances of it (survey:
+[lohndal-2020]). The interface is agnostic about whether indices are listed
+or constructed ([blevins-2016]).
+
+`spellout` is `Finset`-valued: the empty fiber is non-licensing, a
+non-singleton an overabundant cell, matching `Paradigm/Linkage.lean`; the
+univalent and total strata are `IsUnivalent` and `IsTotal`. Frameworks
+diverge along parameters — what `R` individuates (√, lexeme, morph), what
+`Ctx` is (categorizer configuration vs paradigm cell — vs [borer-2013]'s
+headless categorial frames, a Ctx-instantiation contrast; [lohndal-2020]),
+what `F` is (`ConsonantalRoot α` is a choice of `F`), whether interpretation
+is present (`Interpreted`) — never along the core.
+
+`Hom` merges indices with a context translation that may consult the source
+index; `Interpreted.Hom` is the strict tier — root-independent context
+translation, interpretation-preserving — on which individuation disputes are
+stated: merged roots must agree contextwise in interpretation
+(`interp_eq_of_onRoot_eq`), so accidental homophones never merge, and
+heterosemy-vs-single-√ rivalries become hom-(non)existence theorems in
+studies.
+
+## Main declarations
+
+* `Root.System` — indices with contextual spellout; `IsLicensed`, `Realizes`,
+  `exponents`, `IsTotal`, `IsUnivalent`.
+* `Root.IsConstantIn` / `Root.IsVariantIn` — the constancy pair over any
+  contextual map; instantiated as `IsInvariant`/`IsSuppletive` (form) and
+  `IsIntrinsic`/`IsAllosemous` (meaning).
+* `System.SpelloutEq`, `System.IsHomophonous` — form identity vs index
+  identity.
+* `System.Hom` — index mergers with spellout tracking; `Interpreted.Hom` —
+  the strict, interpretation-preserving tier;
+  `Interpreted.Hom.interp_eq_of_onRoot_eq`.
+* `Interpreted` — the two-map extension ([marantz-1997]'s List 2 / List 3).
+-/
+
+namespace Morphology.Root
+
+variable {R Ctx F M X : Type*}
+
+/-- Constancy of a contextual map at an index: all values, across all
+contexts, coincide. -/
+def IsConstantIn (g : R → Ctx → Finset X) (r : R) : Prop :=
+  ∀ ⦃c c' : Ctx⦄, ∀ x ∈ g r c, ∀ x' ∈ g r c', x = x'
+
+/-- Variance of a contextual map at an index: two distinct values arise. -/
+def IsVariantIn (g : R → Ctx → Finset X) (r : R) : Prop :=
+  ∃ c c', ∃ x ∈ g r c, ∃ x' ∈ g r c', x ≠ x'
+
+theorem not_isConstantIn_of_isVariantIn {g : R → Ctx → Finset X} {r : R}
+    (h : IsVariantIn g r) : ¬ IsConstantIn g r := by
+  obtain ⟨c, c', x, hx, x', hx', hne⟩ := h
+  exact fun hc => hne (hc x hx x' hx')
+
+/-- A **root system**: an opaque index type realized in context. The fiber
+`spellout r c` is empty where `r` is unlicensed, non-singleton at an
+overabundant cell. -/
+structure System (R Ctx F : Type*) where
+  /-- The realization of an index in a context: Vocabulary Insertion (DM),
+  the paradigm function (PFM), spellout (nanosyntax). -/
+  spellout : R → Ctx → Finset F
+
+namespace System
+
+variable (S : System R Ctx F)
+
+/-- `r` is licensed in `c`: some realization exists. -/
+def IsLicensed (r : R) (c : Ctx) : Prop := (S.spellout r c).Nonempty
+
+/-- `f` realizes `r` in some context. -/
+def Realizes (r : R) (f : F) : Prop := ∃ c, f ∈ S.spellout r c
+
+/-- The allomorph set of a root. -/
+def exponents (r : R) : Set F := {f | S.Realizes r f}
+
+@[simp] theorem mem_exponents {r : R} {f : F} :
+    f ∈ S.exponents r ↔ S.Realizes r f := Iff.rfl
+
+/-- Every index is licensed everywhere — PFM's stratum. -/
+def IsTotal : Prop := ∀ r c, (S.spellout r c).Nonempty
+
+/-- At most one form per cell — the stratum of `Option`-shaped engine
+outputs. -/
+def IsUnivalent : Prop := ∀ r c, (S.spellout r c).card ≤ 1
+
+/-- One form wherever licensed: the classical context-free morpheme, as the
+degenerate case. -/
+def IsInvariant (r : R) : Prop := IsConstantIn S.spellout r
+
+/-- Distinct forms in distinct contexts — √GO as *go* and *went*,
+[harley-2014]'s argument that indices, not forms, individuate. -/
+def IsSuppletive (r : R) : Prop := IsVariantIn S.spellout r
+
+/-- A suppletive root is not invariant. -/
+theorem not_isInvariant_of_isSuppletive {r : R} (h : S.IsSuppletive r) :
+    ¬ S.IsInvariant r :=
+  not_isConstantIn_of_isVariantIn h
+
+/-- Contextwise identity of realization. -/
+def SpelloutEq (r r' : R) : Prop := ∀ c, S.spellout r c = S.spellout r' c
+
+theorem SpelloutEq.symm {r r' : R} (h : S.SpelloutEq r r') :
+    S.SpelloutEq r' r := fun c => (h c).symm
+
+/-- Distinct indices sharing every realization (*bank₁*/*bank₂*): spellout is
+nowhere required to be injective. -/
+def IsHomophonous (r r' : R) : Prop := r ≠ r' ∧ S.SpelloutEq r r'
+
+theorem IsHomophonous.symm {r r' : R} (h : S.IsHomophonous r r') :
+    S.IsHomophonous r' r :=
+  ⟨h.1.symm, fun c => (h.2 c).symm⟩
+
+section Decidable
+
+variable [Fintype Ctx] [DecidableEq F]
+
+instance (r : R) (c : Ctx) : Decidable (S.IsLicensed r c) :=
+  inferInstanceAs (Decidable (S.spellout r c).Nonempty)
+
+instance (r : R) (f : F) : Decidable (S.Realizes r f) :=
+  inferInstanceAs (Decidable (∃ c, f ∈ S.spellout r c))
+
+instance (r : R) : Decidable (S.IsInvariant r) :=
+  inferInstanceAs (Decidable (∀ c c' : Ctx,
+    ∀ x ∈ S.spellout r c, ∀ x' ∈ S.spellout r c', x = x'))
+
+instance (r : R) : Decidable (S.IsSuppletive r) :=
+  inferInstanceAs (Decidable (∃ c c',
+    ∃ x ∈ S.spellout r c, ∃ x' ∈ S.spellout r c', x ≠ x'))
+
+instance (r r' : R) : Decidable (S.SpelloutEq r r') :=
+  inferInstanceAs (Decidable (∀ c : Ctx, S.spellout r c = S.spellout r' c))
+
+instance [DecidableEq R] (r r' : R) : Decidable (S.IsHomophonous r r') :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+variable [Fintype R]
+
+instance : Decidable S.IsTotal :=
+  inferInstanceAs (Decidable (∀ r c, (S.spellout r c).Nonempty))
+
+instance : Decidable S.IsUnivalent :=
+  inferInstanceAs (Decidable (∀ r c, (S.spellout r c).card ≤ 1))
+
+end Decidable
+
+section Hom
+
+variable {R₁ C₁ R₂ C₂ R₃ C₃ : Type*}
+
+/-- An index merger with spellout tracking: `onRoot` may merge indices,
+`onCtx` translates contexts and may consult the source index. The transport
+tier — for adjudicating individuation disputes use `Interpreted.Hom`, whose
+root-independent context translation blocks re-encoding the source index in
+the target context. -/
+structure Hom (S : System R₁ C₁ F) (T : System R₂ C₂ F) where
+  /-- The index translation; non-injectivity is individuation coarsening. -/
+  onRoot : R₁ → R₂
+  /-- The context translation. -/
+  onCtx : R₁ → C₁ → C₂
+  /-- Realization is preserved. -/
+  spellout_eq : ∀ r c, S.spellout r c = T.spellout (onRoot r) (onCtx r c)
+
+/-- The identity hom. -/
+def Hom.id (S : System R Ctx F) : Hom S S :=
+  ⟨fun r => r, fun _ c => c, fun _ _ => rfl⟩
+
+/-- Homs compose: coarsenings chain (morph-level to lexeme-level to
+√-level). -/
+def Hom.comp {S₁ : System R₁ C₁ F} {S₂ : System R₂ C₂ F}
+    {S₃ : System R₃ C₃ F} (g : Hom S₂ S₃) (f : Hom S₁ S₂) : Hom S₁ S₃ :=
+  ⟨fun r => g.onRoot (f.onRoot r),
+   fun r c => g.onCtx (f.onRoot r) (f.onCtx r c),
+   fun r c => (f.spellout_eq r c).trans
+     (g.spellout_eq (f.onRoot r) (f.onCtx r c))⟩
+
+/-- Homs preserve licensing. -/
+theorem Hom.isLicensed {S : System R₁ C₁ F} {T : System R₂ C₂ F}
+    (φ : Hom S T) {r : R₁} {c : C₁} (h : S.IsLicensed r c) :
+    T.IsLicensed (φ.onRoot r) (φ.onCtx r c) := by
+  obtain ⟨f, hf⟩ := h
+  exact ⟨f, φ.spellout_eq r c ▸ hf⟩
+
+/-- Homs preserve realization: merging indices can only grow allomorph
+sets. -/
+theorem Hom.realizes {S : System R₁ C₁ F} {T : System R₂ C₂ F}
+    (φ : Hom S T) {r : R₁} {f : F} (h : S.Realizes r f) :
+    T.Realizes (φ.onRoot r) f := by
+  obtain ⟨c, hc⟩ := h
+  exact ⟨φ.onCtx r c, φ.spellout_eq r c ▸ hc⟩
+
+end Hom
+
+end System
+
+/-- The two-map extension ([marantz-1997]: spellout is List 2, `interp` List
+3 — allosemy, `DM/Allosemy.lean`). A [borer-2013]-style system stays a bare
+`System`; a lexicalist lexeme is an `Interpreted` system whose interpretation
+is `IsIntrinsic`. -/
+structure Interpreted (R Ctx F M : Type*) extends System R Ctx F where
+  /-- Contextual interpretation: Encyclopedia access. -/
+  interp : R → Ctx → Finset M
+
+namespace Interpreted
+
+variable (S : Interpreted R Ctx F M)
+
+/-- One meaning in every context: the lexicalist degenerate case. -/
+def IsIntrinsic (r : R) : Prop := IsConstantIn S.interp r
+
+/-- Context-dependent interpretation: DM allosemy, its failure. -/
+def IsAllosemous (r : R) : Prop := IsVariantIn S.interp r
+
+/-- An allosemous root has no intrinsic meaning. -/
+theorem not_isIntrinsic_of_isAllosemous {r : R} (h : S.IsAllosemous r) :
+    ¬ S.IsIntrinsic r :=
+  not_isConstantIn_of_isVariantIn h
+
+instance [Fintype Ctx] [DecidableEq M] (r : R) : Decidable (S.IsIntrinsic r) :=
+  inferInstanceAs (Decidable (∀ c c' : Ctx,
+    ∀ x ∈ S.interp r c, ∀ x' ∈ S.interp r c', x = x'))
+
+instance [Fintype Ctx] [DecidableEq M] (r : R) :
+    Decidable (S.IsAllosemous r) :=
+  inferInstanceAs (Decidable (∃ c c',
+    ∃ x ∈ S.interp r c, ∃ x' ∈ S.interp r c', x ≠ x'))
+
+section Hom
+
+variable {R₁ C₁ R₂ C₂ : Type*}
+
+/-- The strict tier of hom, on which individuation disputes are stated: the
+context translation is root-independent — so the target context cannot
+re-encode the source index — and interpretation is preserved alongside
+spellout. -/
+structure Hom (S : Interpreted R₁ C₁ F M) (T : Interpreted R₂ C₂ F M) where
+  /-- The index translation. -/
+  onRoot : R₁ → R₂
+  /-- The root-independent context translation. -/
+  onCtx : C₁ → C₂
+  /-- Realization is preserved. -/
+  spellout_eq : ∀ r c, S.spellout r c = T.spellout (onRoot r) (onCtx c)
+  /-- Interpretation is preserved. -/
+  interp_eq : ∀ r c, S.interp r c = T.interp (onRoot r) (onCtx c)
+
+/-- A strict hom is in particular a system hom. -/
+def Hom.toSystemHom {S : Interpreted R₁ C₁ F M} {T : Interpreted R₂ C₂ F M}
+    (φ : Hom S T) : System.Hom S.toSystem T.toSystem :=
+  ⟨φ.onRoot, fun _ c => φ.onCtx c, φ.spellout_eq⟩
+
+/-- **Merged roots agree contextwise in interpretation** — the keystone
+separating identity from accidental homophony: a strict hom identifying two
+indices forces their interpretations to coincide in every context, so
+*bank₁*/*bank₂* never merge. -/
+theorem Hom.interp_eq_of_onRoot_eq {S : Interpreted R₁ C₁ F M}
+    {T : Interpreted R₂ C₂ F M} (φ : Hom S T) {r r' : R₁}
+    (h : φ.onRoot r = φ.onRoot r') (c : C₁) :
+    S.interp r c = S.interp r' c := by
+  rw [φ.interp_eq r c, φ.interp_eq r' c, h]
+
+/-- The spellout analog of `interp_eq_of_onRoot_eq`: merged roots agree
+contextwise in realization. Unavailable for the transport tier
+`System.Hom`, whose index-dependent context translation can separate the
+merged roots' contexts. -/
+theorem Hom.spellout_eq_of_onRoot_eq {S : Interpreted R₁ C₁ F M}
+    {T : Interpreted R₂ C₂ F M} (φ : Hom S T) {r r' : R₁}
+    (h : φ.onRoot r = φ.onRoot r') (c : C₁) :
+    S.spellout r c = S.spellout r' c := by
+  rw [φ.spellout_eq r c, φ.spellout_eq r' c, h]
+
+end Hom
+
+end Interpreted
+
+end Morphology.Root

--- a/Linglib/Studies/Borer2013.lean
+++ b/Linglib/Studies/Borer2013.lean
@@ -1,0 +1,87 @@
+import Linglib.Morphology.Root.System
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# Borer 2013: categorial flexibility and the adjective asymmetry
+[borer-2013]
+
+Roots as phonological indices realized in categorial frames, with no zero
+categorizer heads: a bare root inserted in a nominal frame is N-equivalent,
+in a verbal frame V-equivalent — categorization by environment, against
+DM's merger with a (possibly null) categorizing head. On
+`Morphology.Root.System` the exoskeletal claim fixes `Ctx` as the frame
+itself, with no head in it; the DM rival puts a categorizer in `Ctx` — a
+contrast in what instantiates `Ctx`, not in the shared core.
+
+The book's categorial puzzle: noun-verb flexibility is systematic (*chair*,
+*walk* occur in both frames with no added morphology), but adjectives do not
+participate — property roots do not extend to nominal or verbal frames
+(*to red*, *to fat* are out), and the verbal uses that do exist (*to thin*,
+*to yellow*) are unpredictable and listed. Adjectives are complex and
+derived, not bare roots in frames.
+
+## Main results
+
+* `english` — a mini root system over N/V/A frames.
+* `nv_flexibility` — *chair* and *walk* are licensed in both the nominal and
+  verbal frames.
+* `adjective_rigidity` — *red* and *fat* are licensed in no frame beyond the
+  adjectival one.
+* `listedness` — *thin* and *red* are both property roots, yet only *thin*
+  has a verbal cell: no frame-level generalization predicts the difference,
+  so the verbal uses are listed.
+-/
+
+namespace Borer2013
+
+open Morphology.Root
+
+/-- The three categorial frames. -/
+inductive Frame | nFrame | vFrame | aFrame
+  deriving DecidableEq, Fintype, Repr
+
+/-- The sample roots. -/
+inductive Lex | chair | walk | red | fat | thin | yellow
+  deriving DecidableEq, Fintype, Repr
+
+/-- The mini English system: flexible *chair*/*walk*, frame-bound *red*/*fat*,
+and the listed verbal uses of *thin*/*yellow*. -/
+def english : System Lex Frame String where
+  spellout := fun r c =>
+    match r, c with
+    | .chair, .nFrame => {"chair"}
+    | .chair, .vFrame => {"chair"}
+    | .walk, .nFrame => {"walk"}
+    | .walk, .vFrame => {"walk"}
+    | .red, .aFrame => {"red"}
+    | .fat, .aFrame => {"fat"}
+    | .thin, .aFrame => {"thin"}
+    | .thin, .vFrame => {"thin"}
+    | .yellow, .aFrame => {"yellow"}
+    | .yellow, .vFrame => {"yellow"}
+    | _, _ => ∅
+
+/-- Noun-verb flexibility is systematic: the bare roots *chair* and *walk*
+are licensed in both frames, with identical spellout — no zero head, no
+added morphology. -/
+theorem nv_flexibility :
+    english.IsLicensed .chair .nFrame ∧ english.IsLicensed .chair .vFrame ∧
+      english.IsLicensed .walk .nFrame ∧ english.IsLicensed .walk .vFrame := by
+  refine ⟨by decide, by decide, by decide, by decide⟩
+
+/-- The adjective asymmetry: *red* and *fat* occur in the adjectival frame
+only — property roots do not extend to nominal or verbal frames. -/
+theorem adjective_rigidity :
+    ¬ english.IsLicensed .red .nFrame ∧ ¬ english.IsLicensed .red .vFrame ∧
+      ¬ english.IsLicensed .fat .nFrame ∧ ¬ english.IsLicensed .fat .vFrame := by
+  refine ⟨by decide, by decide, by decide, by decide⟩
+
+/-- Listedness: *thin* and *red* are both adjectival-frame roots, yet only
+*thin* has a verbal cell — the difference tracks no frame-level property, so
+the verbal uses of *to thin*, *to yellow* are listed, not generated. -/
+theorem listedness :
+    english.IsLicensed .thin .aFrame ∧ english.IsLicensed .red .aFrame ∧
+      english.IsLicensed .thin .vFrame ∧ ¬ english.IsLicensed .red .vFrame := by
+  refine ⟨by decide, by decide, by decide, by decide⟩
+
+end Borer2013

--- a/Linglib/Studies/Haspelmath2025Root.lean
+++ b/Linglib/Studies/Haspelmath2025Root.lean
@@ -1,5 +1,7 @@
 import Linglib.Morphology.Root.Basic
+import Linglib.Morphology.Root.System
 import Linglib.Data.UD.Basic
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Haspelmath 2025: the contentfulness-gated root
@@ -81,5 +83,120 @@ theorem geo_not_root :
     ¬ geo.IsRootIn [[geo, logy]] geoCls ∧
       geo.IsCoreIn [[geo, logy]] [[geo, logy]] := by
   refine ⟨by decide, by decide⟩
+
+/-! ### Sister roots vs one root, as hom-existence
+
+The paper's heterosemy claim — *hammer* the instrument and *hammer* the
+action are two sister roots, not one precategorial root — rendered on
+`Morphology.Root.System`: the sister carving (two frame-restricted indices)
+and the single-√ carving (one index, allosemous across frames) are
+**hom-incomparable** on the strict tier, so neither analysis reduces to the
+other; and accidental homophones (*bank₁*/*bank₂*) spellout-merge but never
+interp-merge into any target — the strict tier separates identity from
+homophony. -/
+
+section Individuation
+
+open Morphology.Root
+
+/-- The two categorial frames. -/
+inductive Frame | nominal | verbal
+  deriving DecidableEq, Fintype, Repr
+
+/-- The two *bank* homophones. -/
+inductive BankLex | river | money
+  deriving DecidableEq, Fintype, Repr
+
+/-- Their senses. -/
+inductive BankSense | riverside | institution
+  deriving DecidableEq, Fintype, Repr
+
+/-- The homophone system: identical spellout everywhere, distinct senses. -/
+def bankSisters : Interpreted BankLex Frame String BankSense where
+  spellout := fun _ _ => {"bank"}
+  interp := fun r _ =>
+    match r with | .river => {.riverside} | .money => {.institution}
+
+/-- The merged one-index target for the spellout level. -/
+def bankMerged : System Unit Frame String where
+  spellout := fun _ _ => {"bank"}
+
+/-- At the spellout level the homophones merge: a transport hom exists. -/
+theorem bank_spellout_merger :
+    Nonempty (System.Hom bankSisters.toSystem bankMerged) :=
+  ⟨⟨fun _ => (), fun _ c => c, fun r _ => by cases r <;> rfl⟩⟩
+
+/-- **No strict hom into any target merges the homophones**: identification
+would force their senses to coincide contextwise
+(`Interpreted.Hom.interp_eq_of_onRoot_eq`). Homophony is not identity. -/
+theorem bank_no_identity {R₂ C₂ : Type*}
+    {T : Interpreted R₂ C₂ String BankSense}
+    (φ : Interpreted.Hom bankSisters T) :
+    φ.onRoot .river ≠ φ.onRoot .money := by
+  intro h
+  have := φ.interp_eq_of_onRoot_eq h .nominal
+  simp [bankSisters] at this
+
+/-- The heterosemous senses of *hammer*. -/
+inductive HammerSense | instrument | action
+  deriving DecidableEq, Fintype, Repr
+
+/-- The paper's carving: two sister roots. -/
+inductive Sisters | hammerN | hammerV
+  deriving DecidableEq, Fintype, Repr
+
+/-- The rival carving: one acategorial root. -/
+inductive Sqrt | hammer
+  deriving DecidableEq, Fintype, Repr
+
+/-- The sister carving: each root licensed only in its own frame, with its
+own sense. -/
+def sisterCarving : Interpreted Sisters Frame String HammerSense where
+  spellout := fun r c =>
+    match r, c with
+    | .hammerN, .nominal => {"hammer"}
+    | .hammerV, .verbal => {"hammer"}
+    | _, _ => ∅
+  interp := fun r c =>
+    match r, c with
+    | .hammerN, .nominal => {.instrument}
+    | .hammerV, .verbal => {.action}
+    | _, _ => ∅
+
+/-- The single-√ carving: one root licensed in both frames, allosemous. -/
+def sqrtCarving : Interpreted Sqrt Frame String HammerSense where
+  spellout := fun _ _ => {"hammer"}
+  interp := fun _ c =>
+    match c with | .nominal => {.instrument} | .verbal => {.action}
+
+/-- No strict hom from the sister carving to the single-√ carving: the
+sisters' licensing gaps (*hammer-the-noun* has no verbal cell) cannot be
+reproduced by the total √. -/
+theorem sisters_to_sqrt_none (φ : Interpreted.Hom sisterCarving sqrtCarving) :
+    False := by
+  have h := φ.spellout_eq .hammerN .verbal
+  cases hr : φ.onRoot .hammerN
+  cases hc : φ.onCtx .verbal <;> rw [hr, hc] at h <;>
+    exact absurd h (by decide)
+
+/-- No strict hom from the single-√ carving to the sister carving either:
+the total √ must land on one frame-restricted sister, whose single licensed
+cell cannot carry both allosemes. The two carvings are hom-incomparable —
+the rivalry is between genuinely distinct systems. -/
+theorem sqrt_to_sisters_none (φ : Interpreted.Hom sqrtCarving sisterCarving) :
+    False := by
+  have hs₁ := φ.spellout_eq .hammer .nominal
+  have hs₂ := φ.spellout_eq .hammer .verbal
+  have hi₁ := φ.interp_eq .hammer .nominal
+  have hi₂ := φ.interp_eq .hammer .verbal
+  cases hr : φ.onRoot .hammer <;> cases hc₁ : φ.onCtx .nominal <;>
+    cases hc₂ : φ.onCtx .verbal <;> rw [hr, hc₁] at hs₁ hi₁ <;>
+    rw [hr, hc₂] at hs₂ hi₂ <;>
+    first
+    | exact absurd hs₁ (by decide)
+    | exact absurd hs₂ (by decide)
+    | exact absurd (hi₁.trans hi₂.symm) (by decide)
+
+end Individuation
 
 end Haspelmath2025Root

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5387,6 +5387,42 @@
   validated = {true},
   sources   = {Studies/Qin2025.lean}
 }
+@book{beard-1995,
+  author    = {Beard, Robert},
+  year      = {1995},
+  title     = {Lexeme-Morpheme Base Morphology: A General Theory of Inflection and Word Formation},
+  publisher = {SUNY Press},
+  address   = {Albany},
+  isbn      = {0-7914-2471-5},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Morphology/Root/System.lean}
+}
+@article{embick-2021,
+  author    = {Embick, David},
+  year      = {2021},
+  title     = {The Motivation for Roots in Distributed Morphology},
+  journal   = {Annual Review of Linguistics},
+  volume    = {7},
+  pages     = {69--88},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Morphology/Root/System.lean}
+}
+@incollection{lohndal-2020,
+  author    = {Lohndal, Terje},
+  year      = {2020},
+  title     = {Syntactic Categorization of Roots},
+  booktitle = {Oxford Research Encyclopedia of Linguistics},
+  publisher = {Oxford University Press},
+  doi       = {10.1093/acrefore/9780199384655.013.257},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Morphology/Root/System.lean}
+}
 @article{fox-2000,
   author    = {Fox, Danny},
   year      = {2000},


### PR DESCRIPTION
Lands the separationist root core per the three-audit synthesis (scratch/rootsystem-audit-synthesis.md): `Root.System R Ctx F` with Finset-valued spellout (empty = unlicensed, non-singleton = overabundant; IsUnivalent/IsTotal strata), the Constant/Varies pair factored over spellout and interp, and two hom tiers — the transport `System.Hom` (index-dependent context translation) and the strict `Interpreted.Hom` (root-independent onCtx, interpretation-preserving) with the keystone `interp_eq_of_onRoot_eq`.

- Engine bridges as birth certificates: `Linkage.toSystem` (lossless), PFM `paradigmSystem` (total + univalent, Lindex as the lexeme-to-√ coarsening seed), DM `VI.toSystem` (univalent).
- Consumers: Studies/Haspelmath2025Root — bank homophones spellout-merge but never interp-merge into any target; the sister and single-√ carvings of *hammer* are strict-hom incomparable in both directions. Studies/Borer2013 (new) — the adjective asymmetry (N/V flexibility systematic, *to red*/*to fat* out, *to thin*/*to yellow* listed) with the exoskeletal frames-as-Ctx reading.
- Bib: beard-1995, embick-2021, lohndal-2020 (verified fields).