### PR TITLE
refactor(Morphology): Root.System → Morphology.Realization

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1290,9 +1290,9 @@ import Linglib.Morphology.Paradigm.Function
 import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Morphology.Paradigm.OfCells
+import Linglib.Morphology.Realization
 import Linglib.Morphology.Root.Basic
 import Linglib.Morphology.Root.Consonantal
-import Linglib.Morphology.Root.System
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Paradigm.ToTree
 import Linglib.Morphology.Word.Tree

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -1,6 +1,6 @@
 import Mathlib.Tactic.TypeStar
 import Linglib.Morphology.Exponence.Select
-import Linglib.Morphology.Root.System
+import Linglib.Morphology.Realization
 
 /-!
 # Vocabulary Insertion (Distributed Morphology)
@@ -230,20 +230,21 @@ theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
 
 end ExponenceCore
 
-/-! ### The root-system view -/
+/-! ### The realization view -/
 
-/-- Vocabulary Insertion as a root system: roots as opaque indices, syntactic
+/-- Vocabulary Insertion as a realization: roots as opaque indices,
+syntactic
 contexts as contexts, `none` as non-licensing — the univalent stratum. -/
-def toSystem {Ctx Root : Type*} (rules : List (VocabItem Ctx Root)) :
-    Morphology.Root.System Root Ctx String :=
+def toRealization {Ctx Root : Type*} (rules : List (VocabItem Ctx Root)) :
+    Morphology.Realization Root Ctx String :=
   ⟨fun r c => match vocabularyInsert rules c r with
     | some f => {f}
     | none => ∅⟩
 
-theorem toSystem_isUnivalent {Ctx Root : Type*}
-    (rules : List (VocabItem Ctx Root)) : (toSystem rules).IsUnivalent :=
+theorem toRealization_isUnivalent {Ctx Root : Type*}
+    (rules : List (VocabItem Ctx Root)) : (toRealization rules).IsUnivalent :=
   fun r c => by
-    simp only [toSystem]
+    simp only [toRealization]
     cases vocabularyInsert rules c r <;> simp
 
 end Morphology.DM.VI

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -404,21 +404,21 @@ theorem Linkage.realize_eq_paradigmFunction [DecidableEq Z] (ℓ : Linkage L Z P
   exact congrArg ({·})
     (Prod.ext rfl (blocksEval_snd Lindex blocks (stemChoice (l, σ), σ)).symm)
 
-/-- The paradigm function as a root system: lexemes as opaque indices,
+/-- The paradigm function as a realization: lexemes as opaque indices,
 realized at every cell — total and univalent, PFM's stratum. `Lindex` is the
 seed of the lexeme-to-√ coarsening arrow between individuation grains. -/
-def paradigmSystem (Lindex : Z → L) (stemChoice : L × P → Z)
-    (blocks : List (Block L Z P)) : Root.System L P (Z × P) :=
+def paradigmRealization (Lindex : Z → L) (stemChoice : L × P → Z)
+    (blocks : List (Block L Z P)) : Realization L P (Z × P) :=
   ⟨fun l σ => {paradigmFunction Lindex stemChoice blocks (l, σ)}⟩
 
-theorem paradigmSystem_isTotal (Lindex : Z → L) (stemChoice : L × P → Z)
+theorem paradigmRealization_isTotal (Lindex : Z → L) (stemChoice : L × P → Z)
     (blocks : List (Block L Z P)) :
-    (paradigmSystem Lindex stemChoice blocks).IsTotal :=
+    (paradigmRealization Lindex stemChoice blocks).IsTotal :=
   fun _ _ => Finset.singleton_nonempty _
 
-theorem paradigmSystem_isUnivalent (Lindex : Z → L) (stemChoice : L × P → Z)
+theorem paradigmRealization_isUnivalent (Lindex : Z → L) (stemChoice : L × P → Z)
     (blocks : List (Block L Z P)) :
-    (paradigmSystem Lindex stemChoice blocks).IsUnivalent :=
+    (paradigmRealization Lindex stemChoice blocks).IsUnivalent :=
   fun _ _ => (Finset.card_singleton _).le
 
 end Selection

--- a/Linglib/Morphology/Paradigm/Linkage.lean
+++ b/Linglib/Morphology/Paradigm/Linkage.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.Root.System
+import Linglib.Morphology.Realization
 import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Finset.Card
 
@@ -420,19 +420,19 @@ theorem canonical_isCanonical (st : L → Z) :
     simpa [canonical_corr, Finset.disjoint_singleton] using hne
   propertyPreserving := fun _ _ => rfl
 
-/-! ### The root-system view -/
+/-! ### The realization view -/
 
-/-- The stem selection as a root system: lexemes as indices, property sets
+/-- The stem selection as a realization: lexemes as indices, property sets
 as contexts, stems as forms. A lossless embedding — the linkage adds only
 the property mapping `pm` on top of it. -/
-def toSystem (ℓ : Linkage L Z P) : Root.System L P Z := ⟨ℓ.stems⟩
+def toRealization (ℓ : Linkage L Z P) : Realization L P Z := ⟨ℓ.stems⟩
 
-@[simp] theorem toSystem_spellout (ℓ : Linkage L Z P) (l : L) (σ : P) :
-    ℓ.toSystem.spellout l σ = ℓ.stems l σ := rfl
+@[simp] theorem toRealization_realize (ℓ : Linkage L Z P) (l : L) (σ : P) :
+    ℓ.toRealization.realize l σ = ℓ.stems l σ := rfl
 
-/-- The linkage and its root system agree on univalence. -/
-theorem toSystem_isUnivalent_iff (ℓ : Linkage L Z P) :
-    ℓ.toSystem.IsUnivalent ↔ ℓ.IsUnivalent := Iff.rfl
+/-- The linkage and its realization agree on univalence. -/
+theorem toRealization_isUnivalent_iff (ℓ : Linkage L Z P) :
+    ℓ.toRealization.IsUnivalent ↔ ℓ.IsUnivalent := Iff.rfl
 
 end Linkage
 

--- a/Linglib/Morphology/Realization.lean
+++ b/Linglib/Morphology/Realization.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Finset.Card
 
 /-!
-# Root systems: indices with contextual realization
+# Root realizations: indices realized in context
 
 Every realizational/separationist framework that adopts late insertion or a
 separate lexemic index factors a root into an opaque individuator plus
@@ -17,23 +17,23 @@ individuation `R ↪ F` is her instance's axiom, not the interface's); PFM's
 opaque lexeme realized at a cell ([stump-2001], [bonami-stump-2016]);
 [spencer-2013]'s lexemic index. [beard-1995]'s Separation Hypothesis grounds
 the form-side separation; the meaning-side separation is DM's List-3 move.
-`Root.System` fixes that object; sign-based lexicalism, Construction
+`Realization` fixes that object; sign-based lexicalism, Construction
 Morphology, and [haspelmath-2025-root]'s morph-based comparative root are
 rival ontologies its parameters measure, not instances of it (survey:
 [lohndal-2020]). The interface is agnostic about whether indices are listed
 or constructed ([blevins-2016]).
 
-`spellout` is `Finset`-valued: the empty fiber is non-licensing, a
+`realize` is `Finset`-valued: the empty fiber is non-licensing, a
 non-singleton an overabundant cell, matching `Paradigm/Linkage.lean`; the
 univalent and total strata are `IsUnivalent` and `IsTotal`. Frameworks
 diverge along parameters — what `R` individuates (√, lexeme, morph), what
 `Ctx` is (categorizer configuration vs paradigm cell — vs [borer-2013]'s
 headless categorial frames, a Ctx-instantiation contrast; [lohndal-2020]),
 what `F` is (`ConsonantalRoot α` is a choice of `F`), whether interpretation
-is present (`Interpreted`) — never along the core.
+is present (`Realization.Interpreted`) — never along the core.
 
 `Hom` merges indices with a context translation that may consult the source
-index; `Interpreted.Hom` is the strict tier — root-independent context
+index; `Realization.Interpreted.Hom` is the strict tier — root-independent context
 translation, interpretation-preserving — on which individuation disputes are
 stated: merged roots must agree contextwise in interpretation
 (`interp_eq_of_onRoot_eq`), so accidental homophones never merge, and
@@ -42,20 +42,20 @@ studies.
 
 ## Main declarations
 
-* `Root.System` — indices with contextual spellout; `IsLicensed`, `Realizes`,
+* `Realization` — indices with contextual realization; `IsLicensed`, `Realizes`,
   `exponents`, `IsTotal`, `IsUnivalent`.
-* `Root.IsConstantIn` / `Root.IsVariantIn` — the constancy pair over any
+* `IsConstantIn` / `IsVariantIn` — the constancy pair over any
   contextual map; instantiated as `IsInvariant`/`IsSuppletive` (form) and
   `IsIntrinsic`/`IsAllosemous` (meaning).
-* `System.SpelloutEq`, `System.IsHomophonous` — form identity vs index
+* `Realization.RealizeEq`, `Realization.IsHomophonous` — form identity vs index
   identity.
-* `System.Hom` — index mergers with spellout tracking; `Interpreted.Hom` —
+* `Realization.Hom` — index mergers with realization tracking; `Interpreted.Hom` —
   the strict, interpretation-preserving tier;
-  `Interpreted.Hom.interp_eq_of_onRoot_eq`.
-* `Interpreted` — the two-map extension ([marantz-1997]'s List 2 / List 3).
+  `Realization.Interpreted.Hom.interp_eq_of_onRoot_eq`.
+* `Realization.Interpreted` — the two-map extension ([marantz-1997]'s List 2 / List 3).
 -/
 
-namespace Morphology.Root
+namespace Morphology
 
 variable {R Ctx F M X : Type*}
 
@@ -73,23 +73,23 @@ theorem not_isConstantIn_of_isVariantIn {g : R → Ctx → Finset X} {r : R}
   obtain ⟨c, c', x, hx, x', hx', hne⟩ := h
   exact fun hc => hne (hc x hx x' hx')
 
-/-- A **root system**: an opaque index type realized in context. The fiber
-`spellout r c` is empty where `r` is unlicensed, non-singleton at an
+/-- A **root realization**: an opaque index type realized in context. The
+fiber `realize r c` is empty where `r` is unlicensed, non-singleton at an
 overabundant cell. -/
-structure System (R Ctx F : Type*) where
+structure Realization (R Ctx F : Type*) where
   /-- The realization of an index in a context: Vocabulary Insertion (DM),
   the paradigm function (PFM), spellout (nanosyntax). -/
-  spellout : R → Ctx → Finset F
+  realize : R → Ctx → Finset F
 
-namespace System
+namespace Realization
 
-variable (S : System R Ctx F)
+variable (S : Realization R Ctx F)
 
 /-- `r` is licensed in `c`: some realization exists. -/
-def IsLicensed (r : R) (c : Ctx) : Prop := (S.spellout r c).Nonempty
+def IsLicensed (r : R) (c : Ctx) : Prop := (S.realize r c).Nonempty
 
 /-- `f` realizes `r` in some context. -/
-def Realizes (r : R) (f : F) : Prop := ∃ c, f ∈ S.spellout r c
+def Realizes (r : R) (f : F) : Prop := ∃ c, f ∈ S.realize r c
 
 /-- The allomorph set of a root. -/
 def exponents (r : R) : Set F := {f | S.Realizes r f}
@@ -98,19 +98,19 @@ def exponents (r : R) : Set F := {f | S.Realizes r f}
     f ∈ S.exponents r ↔ S.Realizes r f := Iff.rfl
 
 /-- Every index is licensed everywhere — PFM's stratum. -/
-def IsTotal : Prop := ∀ r c, (S.spellout r c).Nonempty
+def IsTotal : Prop := ∀ r c, (S.realize r c).Nonempty
 
 /-- At most one form per cell — the stratum of `Option`-shaped engine
 outputs. -/
-def IsUnivalent : Prop := ∀ r c, (S.spellout r c).card ≤ 1
+def IsUnivalent : Prop := ∀ r c, (S.realize r c).card ≤ 1
 
 /-- One form wherever licensed: the classical context-free morpheme, as the
 degenerate case. -/
-def IsInvariant (r : R) : Prop := IsConstantIn S.spellout r
+def IsInvariant (r : R) : Prop := IsConstantIn S.realize r
 
 /-- Distinct forms in distinct contexts — √GO as *go* and *went*,
 [harley-2014]'s argument that indices, not forms, individuate. -/
-def IsSuppletive (r : R) : Prop := IsVariantIn S.spellout r
+def IsSuppletive (r : R) : Prop := IsVariantIn S.realize r
 
 /-- A suppletive root is not invariant. -/
 theorem not_isInvariant_of_isSuppletive {r : R} (h : S.IsSuppletive r) :
@@ -118,14 +118,14 @@ theorem not_isInvariant_of_isSuppletive {r : R} (h : S.IsSuppletive r) :
   not_isConstantIn_of_isVariantIn h
 
 /-- Contextwise identity of realization. -/
-def SpelloutEq (r r' : R) : Prop := ∀ c, S.spellout r c = S.spellout r' c
+def RealizeEq (r r' : R) : Prop := ∀ c, S.realize r c = S.realize r' c
 
-theorem SpelloutEq.symm {r r' : R} (h : S.SpelloutEq r r') :
-    S.SpelloutEq r' r := fun c => (h c).symm
+theorem RealizeEq.symm {r r' : R} (h : S.RealizeEq r r') :
+    S.RealizeEq r' r := fun c => (h c).symm
 
 /-- Distinct indices sharing every realization (*bank₁*/*bank₂*): spellout is
 nowhere required to be injective. -/
-def IsHomophonous (r r' : R) : Prop := r ≠ r' ∧ S.SpelloutEq r r'
+def IsHomophonous (r r' : R) : Prop := r ≠ r' ∧ S.RealizeEq r r'
 
 theorem IsHomophonous.symm {r r' : R} (h : S.IsHomophonous r r') :
     S.IsHomophonous r' r :=
@@ -136,21 +136,21 @@ section Decidable
 variable [Fintype Ctx] [DecidableEq F]
 
 instance (r : R) (c : Ctx) : Decidable (S.IsLicensed r c) :=
-  inferInstanceAs (Decidable (S.spellout r c).Nonempty)
+  inferInstanceAs (Decidable (S.realize r c).Nonempty)
 
 instance (r : R) (f : F) : Decidable (S.Realizes r f) :=
-  inferInstanceAs (Decidable (∃ c, f ∈ S.spellout r c))
+  inferInstanceAs (Decidable (∃ c, f ∈ S.realize r c))
 
 instance (r : R) : Decidable (S.IsInvariant r) :=
   inferInstanceAs (Decidable (∀ c c' : Ctx,
-    ∀ x ∈ S.spellout r c, ∀ x' ∈ S.spellout r c', x = x'))
+    ∀ x ∈ S.realize r c, ∀ x' ∈ S.realize r c', x = x'))
 
 instance (r : R) : Decidable (S.IsSuppletive r) :=
   inferInstanceAs (Decidable (∃ c c',
-    ∃ x ∈ S.spellout r c, ∃ x' ∈ S.spellout r c', x ≠ x'))
+    ∃ x ∈ S.realize r c, ∃ x' ∈ S.realize r c', x ≠ x'))
 
-instance (r r' : R) : Decidable (S.SpelloutEq r r') :=
-  inferInstanceAs (Decidable (∀ c : Ctx, S.spellout r c = S.spellout r' c))
+instance (r r' : R) : Decidable (S.RealizeEq r r') :=
+  inferInstanceAs (Decidable (∀ c : Ctx, S.realize r c = S.realize r' c))
 
 instance [DecidableEq R] (r r' : R) : Decidable (S.IsHomophonous r r') :=
   inferInstanceAs (Decidable (_ ∧ _))
@@ -158,10 +158,10 @@ instance [DecidableEq R] (r r' : R) : Decidable (S.IsHomophonous r r') :=
 variable [Fintype R]
 
 instance : Decidable S.IsTotal :=
-  inferInstanceAs (Decidable (∀ r c, (S.spellout r c).Nonempty))
+  inferInstanceAs (Decidable (∀ r c, (S.realize r c).Nonempty))
 
 instance : Decidable S.IsUnivalent :=
-  inferInstanceAs (Decidable (∀ r c, (S.spellout r c).card ≤ 1))
+  inferInstanceAs (Decidable (∀ r c, (S.realize r c).card ≤ 1))
 
 end Decidable
 
@@ -171,58 +171,59 @@ variable {R₁ C₁ R₂ C₂ R₃ C₃ : Type*}
 
 /-- An index merger with spellout tracking: `onRoot` may merge indices,
 `onCtx` translates contexts and may consult the source index. The transport
-tier — for adjudicating individuation disputes use `Interpreted.Hom`, whose
+tier — for adjudicating individuation disputes use `Realization.Interpreted.Hom`, whose
 root-independent context translation blocks re-encoding the source index in
 the target context. -/
-structure Hom (S : System R₁ C₁ F) (T : System R₂ C₂ F) where
+structure Hom (S : Realization R₁ C₁ F) (T : Realization R₂ C₂ F) where
   /-- The index translation; non-injectivity is individuation coarsening. -/
   onRoot : R₁ → R₂
   /-- The context translation. -/
   onCtx : R₁ → C₁ → C₂
   /-- Realization is preserved. -/
-  spellout_eq : ∀ r c, S.spellout r c = T.spellout (onRoot r) (onCtx r c)
+  realize_eq : ∀ r c, S.realize r c = T.realize (onRoot r) (onCtx r c)
 
 /-- The identity hom. -/
-def Hom.id (S : System R Ctx F) : Hom S S :=
+def Hom.id (S : Realization R Ctx F) : Hom S S :=
   ⟨fun r => r, fun _ c => c, fun _ _ => rfl⟩
 
 /-- Homs compose: coarsenings chain (morph-level to lexeme-level to
 √-level). -/
-def Hom.comp {S₁ : System R₁ C₁ F} {S₂ : System R₂ C₂ F}
-    {S₃ : System R₃ C₃ F} (g : Hom S₂ S₃) (f : Hom S₁ S₂) : Hom S₁ S₃ :=
+def Hom.comp {S₁ : Realization R₁ C₁ F} {S₂ : Realization R₂ C₂ F}
+    {S₃ : Realization R₃ C₃ F} (g : Hom S₂ S₃) (f : Hom S₁ S₂) : Hom S₁ S₃ :=
   ⟨fun r => g.onRoot (f.onRoot r),
    fun r c => g.onCtx (f.onRoot r) (f.onCtx r c),
-   fun r c => (f.spellout_eq r c).trans
-     (g.spellout_eq (f.onRoot r) (f.onCtx r c))⟩
+   fun r c => (f.realize_eq r c).trans
+     (g.realize_eq (f.onRoot r) (f.onCtx r c))⟩
 
 /-- Homs preserve licensing. -/
-theorem Hom.isLicensed {S : System R₁ C₁ F} {T : System R₂ C₂ F}
+theorem Hom.isLicensed {S : Realization R₁ C₁ F} {T : Realization R₂ C₂ F}
     (φ : Hom S T) {r : R₁} {c : C₁} (h : S.IsLicensed r c) :
     T.IsLicensed (φ.onRoot r) (φ.onCtx r c) := by
   obtain ⟨f, hf⟩ := h
-  exact ⟨f, φ.spellout_eq r c ▸ hf⟩
+  exact ⟨f, φ.realize_eq r c ▸ hf⟩
 
 /-- Homs preserve realization: merging indices can only grow allomorph
 sets. -/
-theorem Hom.realizes {S : System R₁ C₁ F} {T : System R₂ C₂ F}
+theorem Hom.realizes {S : Realization R₁ C₁ F} {T : Realization R₂ C₂ F}
     (φ : Hom S T) {r : R₁} {f : F} (h : S.Realizes r f) :
     T.Realizes (φ.onRoot r) f := by
   obtain ⟨c, hc⟩ := h
-  exact ⟨φ.onCtx r c, φ.spellout_eq r c ▸ hc⟩
+  exact ⟨φ.onCtx r c, φ.realize_eq r c ▸ hc⟩
 
 end Hom
 
-end System
+end Realization
 
 /-- The two-map extension ([marantz-1997]: spellout is List 2, `interp` List
 3 — allosemy, `DM/Allosemy.lean`). A [borer-2013]-style system stays a bare
 `System`; a lexicalist lexeme is an `Interpreted` system whose interpretation
 is `IsIntrinsic`. -/
-structure Interpreted (R Ctx F M : Type*) extends System R Ctx F where
+structure Realization.Interpreted (R Ctx F M : Type*) extends
+    Realization R Ctx F where
   /-- Contextual interpretation: Encyclopedia access. -/
   interp : R → Ctx → Finset M
 
-namespace Interpreted
+namespace Realization.Interpreted
 
 variable (S : Interpreted R Ctx F M)
 
@@ -260,14 +261,14 @@ structure Hom (S : Interpreted R₁ C₁ F M) (T : Interpreted R₂ C₂ F M) wh
   /-- The root-independent context translation. -/
   onCtx : C₁ → C₂
   /-- Realization is preserved. -/
-  spellout_eq : ∀ r c, S.spellout r c = T.spellout (onRoot r) (onCtx c)
+  realize_eq : ∀ r c, S.realize r c = T.realize (onRoot r) (onCtx c)
   /-- Interpretation is preserved. -/
   interp_eq : ∀ r c, S.interp r c = T.interp (onRoot r) (onCtx c)
 
-/-- A strict hom is in particular a system hom. -/
-def Hom.toSystemHom {S : Interpreted R₁ C₁ F M} {T : Interpreted R₂ C₂ F M}
-    (φ : Hom S T) : System.Hom S.toSystem T.toSystem :=
-  ⟨φ.onRoot, fun _ c => φ.onCtx c, φ.spellout_eq⟩
+/-- A strict hom is in particular a realization hom. -/
+def Hom.toRealizationHom {S : Interpreted R₁ C₁ F M} {T : Interpreted R₂ C₂ F M}
+    (φ : Hom S T) : Realization.Hom S.toRealization T.toRealization :=
+  ⟨φ.onRoot, fun _ c => φ.onCtx c, φ.realize_eq⟩
 
 /-- **Merged roots agree contextwise in interpretation** — the keystone
 separating identity from accidental homophony: a strict hom identifying two
@@ -279,18 +280,18 @@ theorem Hom.interp_eq_of_onRoot_eq {S : Interpreted R₁ C₁ F M}
     S.interp r c = S.interp r' c := by
   rw [φ.interp_eq r c, φ.interp_eq r' c, h]
 
-/-- The spellout analog of `interp_eq_of_onRoot_eq`: merged roots agree
+/-- The realization analog of `interp_eq_of_onRoot_eq`: merged roots agree
 contextwise in realization. Unavailable for the transport tier
-`System.Hom`, whose index-dependent context translation can separate the
+`Realization.Hom`, whose index-dependent context translation can separate the
 merged roots' contexts. -/
-theorem Hom.spellout_eq_of_onRoot_eq {S : Interpreted R₁ C₁ F M}
+theorem Hom.realize_eq_of_onRoot_eq {S : Interpreted R₁ C₁ F M}
     {T : Interpreted R₂ C₂ F M} (φ : Hom S T) {r r' : R₁}
     (h : φ.onRoot r = φ.onRoot r') (c : C₁) :
-    S.spellout r c = S.spellout r' c := by
-  rw [φ.spellout_eq r c, φ.spellout_eq r' c, h]
+    S.realize r c = S.realize r' c := by
+  rw [φ.realize_eq r c, φ.realize_eq r' c, h]
 
 end Hom
 
-end Interpreted
+end Realization.Interpreted
 
-end Morphology.Root
+end Morphology

--- a/Linglib/Studies/Borer2013.lean
+++ b/Linglib/Studies/Borer2013.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.Root.System
+import Linglib.Morphology.Realization
 import Mathlib.Tactic.DeriveFintype
 
 /-!
@@ -9,7 +9,7 @@ Roots as phonological indices realized in categorial frames, with no zero
 categorizer heads: a bare root inserted in a nominal frame is N-equivalent,
 in a verbal frame V-equivalent — categorization by environment, against
 DM's merger with a (possibly null) categorizing head. On
-`Morphology.Root.System` the exoskeletal claim fixes `Ctx` as the frame
+`Morphology.Realization` the exoskeletal claim fixes `Ctx` as the frame
 itself, with no head in it; the DM rival puts a categorizer in `Ctx` — a
 contrast in what instantiates `Ctx`, not in the shared core.
 
@@ -22,7 +22,7 @@ derived, not bare roots in frames.
 
 ## Main results
 
-* `english` — a mini root system over N/V/A frames.
+* `english` — a mini root realization over N/V/A frames.
 * `nv_flexibility` — *chair* and *walk* are licensed in both the nominal and
   verbal frames.
 * `adjective_rigidity` — *red* and *fat* are licensed in no frame beyond the
@@ -34,7 +34,7 @@ derived, not bare roots in frames.
 
 namespace Borer2013
 
-open Morphology.Root
+open Morphology
 
 /-- The three categorial frames. -/
 inductive Frame | nFrame | vFrame | aFrame
@@ -46,8 +46,8 @@ inductive Lex | chair | walk | red | fat | thin | yellow
 
 /-- The mini English system: flexible *chair*/*walk*, frame-bound *red*/*fat*,
 and the listed verbal uses of *thin*/*yellow*. -/
-def english : System Lex Frame String where
-  spellout := fun r c =>
+def english : Realization Lex Frame String where
+  realize := fun r c =>
     match r, c with
     | .chair, .nFrame => {"chair"}
     | .chair, .vFrame => {"chair"}

--- a/Linglib/Studies/Haspelmath2025Root.lean
+++ b/Linglib/Studies/Haspelmath2025Root.lean
@@ -1,5 +1,5 @@
 import Linglib.Morphology.Root.Basic
-import Linglib.Morphology.Root.System
+import Linglib.Morphology.Realization
 import Linglib.Data.UD.Basic
 import Mathlib.Tactic.DeriveFintype
 
@@ -88,7 +88,7 @@ theorem geo_not_root :
 
 The paper's heterosemy claim — *hammer* the instrument and *hammer* the
 action are two sister roots, not one precategorial root — rendered on
-`Morphology.Root.System`: the sister carving (two frame-restricted indices)
+`Morphology.Realization`: the sister carving (two frame-restricted indices)
 and the single-√ carving (one index, allosemous across frames) are
 **hom-incomparable** on the strict tier, so neither analysis reduces to the
 other; and accidental homophones (*bank₁*/*bank₂*) spellout-merge but never
@@ -97,7 +97,7 @@ homophony. -/
 
 section Individuation
 
-open Morphology.Root
+open Morphology Morphology.Realization
 
 /-- The two categorial frames. -/
 inductive Frame | nominal | verbal
@@ -112,26 +112,26 @@ inductive BankSense | riverside | institution
   deriving DecidableEq, Fintype, Repr
 
 /-- The homophone system: identical spellout everywhere, distinct senses. -/
-def bankSisters : Interpreted BankLex Frame String BankSense where
-  spellout := fun _ _ => {"bank"}
+def bankSisters : Realization.Interpreted BankLex Frame String BankSense where
+  realize := fun _ _ => {"bank"}
   interp := fun r _ =>
     match r with | .river => {.riverside} | .money => {.institution}
 
 /-- The merged one-index target for the spellout level. -/
-def bankMerged : System Unit Frame String where
-  spellout := fun _ _ => {"bank"}
+def bankMerged : Realization Unit Frame String where
+  realize := fun _ _ => {"bank"}
 
 /-- At the spellout level the homophones merge: a transport hom exists. -/
 theorem bank_spellout_merger :
-    Nonempty (System.Hom bankSisters.toSystem bankMerged) :=
+    Nonempty (Realization.Hom bankSisters.toRealization bankMerged) :=
   ⟨⟨fun _ => (), fun _ c => c, fun r _ => by cases r <;> rfl⟩⟩
 
 /-- **No strict hom into any target merges the homophones**: identification
 would force their senses to coincide contextwise
-(`Interpreted.Hom.interp_eq_of_onRoot_eq`). Homophony is not identity. -/
+(`Realization.Interpreted.Hom.interp_eq_of_onRoot_eq`). Homophony is not identity. -/
 theorem bank_no_identity {R₂ C₂ : Type*}
-    {T : Interpreted R₂ C₂ String BankSense}
-    (φ : Interpreted.Hom bankSisters T) :
+    {T : Realization.Interpreted R₂ C₂ String BankSense}
+    (φ : Realization.Interpreted.Hom bankSisters T) :
     φ.onRoot .river ≠ φ.onRoot .money := by
   intro h
   have := φ.interp_eq_of_onRoot_eq h .nominal
@@ -151,8 +151,8 @@ inductive Sqrt | hammer
 
 /-- The sister carving: each root licensed only in its own frame, with its
 own sense. -/
-def sisterCarving : Interpreted Sisters Frame String HammerSense where
-  spellout := fun r c =>
+def sisterCarving : Realization.Interpreted Sisters Frame String HammerSense where
+  realize := fun r c =>
     match r, c with
     | .hammerN, .nominal => {"hammer"}
     | .hammerV, .verbal => {"hammer"}
@@ -164,17 +164,18 @@ def sisterCarving : Interpreted Sisters Frame String HammerSense where
     | _, _ => ∅
 
 /-- The single-√ carving: one root licensed in both frames, allosemous. -/
-def sqrtCarving : Interpreted Sqrt Frame String HammerSense where
-  spellout := fun _ _ => {"hammer"}
+def sqrtCarving : Realization.Interpreted Sqrt Frame String HammerSense where
+  realize := fun _ _ => {"hammer"}
   interp := fun _ c =>
     match c with | .nominal => {.instrument} | .verbal => {.action}
 
 /-- No strict hom from the sister carving to the single-√ carving: the
 sisters' licensing gaps (*hammer-the-noun* has no verbal cell) cannot be
 reproduced by the total √. -/
-theorem sisters_to_sqrt_none (φ : Interpreted.Hom sisterCarving sqrtCarving) :
+theorem sisters_to_sqrt_none
+    (φ : Realization.Interpreted.Hom sisterCarving sqrtCarving) :
     False := by
-  have h := φ.spellout_eq .hammerN .verbal
+  have h := φ.realize_eq .hammerN .verbal
   cases hr : φ.onRoot .hammerN
   cases hc : φ.onCtx .verbal <;> rw [hr, hc] at h <;>
     exact absurd h (by decide)
@@ -183,10 +184,11 @@ theorem sisters_to_sqrt_none (φ : Interpreted.Hom sisterCarving sqrtCarving) :
 the total √ must land on one frame-restricted sister, whose single licensed
 cell cannot carry both allosemes. The two carvings are hom-incomparable —
 the rivalry is between genuinely distinct systems. -/
-theorem sqrt_to_sisters_none (φ : Interpreted.Hom sqrtCarving sisterCarving) :
+theorem sqrt_to_sisters_none
+    (φ : Realization.Interpreted.Hom sqrtCarving sisterCarving) :
     False := by
-  have hs₁ := φ.spellout_eq .hammer .nominal
-  have hs₂ := φ.spellout_eq .hammer .verbal
+  have hs₁ := φ.realize_eq .hammer .nominal
+  have hs₂ := φ.realize_eq .hammer .verbal
   have hi₁ := φ.interp_eq .hammer .nominal
   have hi₂ := φ.interp_eq .hammer .verbal
   cases hr : φ.onRoot .hammer <;> cases hc₁ : φ.onCtx .nominal <;>

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5397,7 +5397,7 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Morphology/Root/System.lean}
+  sources   = {Morphology/Realization.lean}
 }
 @article{embick-2021,
   author    = {Embick, David},
@@ -5409,7 +5409,7 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Morphology/Root/System.lean}
+  sources   = {Morphology/Realization.lean}
 }
 @incollection{lohndal-2020,
   author    = {Lohndal, Terje},
@@ -5421,7 +5421,7 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Morphology/Root/System.lean}
+  sources   = {Morphology/Realization.lean}
 }
 @article{fox-2000,
   author    = {Fox, Danny},


### PR DESCRIPTION
Renames and re-homes #1573's core per two naming corrections: (1) "root system" is not a term of art in morphology and collides with the Lie-theoretic RootSystem — the field's umbrella term for the object is *realization* (the name of the school covering DM, PFM, and nanosyntax alike); (2) the object is grain-generic — two of its three engine bridges index by lexemes, not roots — so it lives at the top level as `Morphology.Realization`, with `Realization.Interpreted` nested and roots/lexemes/morphs as choices of `R`. Field `spellout` → `realize`; `SpelloutEq` → `RealizeEq`; bridges renamed `toRealization`/`paradigmRealization`. Content otherwise unchanged.