### PR TITLE
docs(Morphology): calibrate LaxHom glosses to the literature

### DIFF
--- a/Linglib/Morphology/Realization.lean
+++ b/Linglib/Morphology/Realization.lean
@@ -292,9 +292,10 @@ theorem Hom.realize_eq_of_onRoot_eq {S : Interpreted R₁ C₁ F M}
 
 /-- The lax tier: realization and interpretation are *included* rather than
 matched. Where a strict `Hom` merger asserts identity, a lax merger asserts
-family membership — each source index's forms and readings are among its
-image's. Pattern-bound lexemes lax-merge into a total root without ever
-strict-merging. -/
+subsumption — each source index's forms and readings are among its image's,
+as when a lexeme's listed properties are among its root's Encyclopedia entry
+([arad-2005]). Pattern-bound lexemes lax-merge into a total root without
+ever strict-merging. -/
 structure LaxHom (S : Interpreted R₁ C₁ F M) (T : Interpreted R₂ C₂ F M) where
   /-- The index translation. -/
   onRoot : R₁ → R₂

--- a/Linglib/Studies/Haspelmath2025Root.lean
+++ b/Linglib/Studies/Haspelmath2025Root.lean
@@ -200,9 +200,12 @@ theorem sqrt_to_sisters_none
     | exact absurd (hi₁.trans hi₂.symm) (by decide)
 
 /-- The sisters do lax-merge into the single √ (`Realization.Interpreted.LaxHom`):
-each sister's forms and senses are among the √'s. The graded criterion —
-lax-mergeable but not strict-mergeable — is exactly the formal content of
-*family, not identity*: heterosemy. -/
+each sister's forms and senses are among the √'s. The lax-not-strict gradient
+characterizes the relation *between the two analyses* — the precategorial
+carving subsumes the sister carving's data without being identical to it. The
+heterosemy view's own positive machinery is different: per (17b), the sisters
+are related by sister schemas ([jackendoff-audring-2020];
+`Morphology/Construction/Sister.lean`), not by a shared realization target. -/
 theorem sisters_lax_merge :
     Nonempty (Realization.Interpreted.LaxHom sisterCarving sqrtCarving) :=
   ⟨⟨fun _ => .hammer, id, by decide, by decide⟩⟩


### PR DESCRIPTION
Faithfulness pass on the lax tier's linguistic glosses. The lax-not-strict gradient correctly characterizes the relation between rival analyses (the precategorial carving subsumes the sister carving's data without identity), but it is not itself "the formal content of heterosemy": Haspelmath's (17b) locates the heterosemy view's positive machinery in sister schemas (Jackendoff & Audring — already formalized in Construction/Sister.lean), so the docstring now says that and points there. LaxHom's substrate docstring drops "family membership" for the anchored subsumption reading (a lexeme's listed properties among its root's Encyclopedia entry, per Arad). Docstrings only.