### PR TITLE
feat(Morphology/Exponence): graduate decomposition engine; chain hom

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1268,6 +1268,7 @@ import Linglib.Morphology.Exponence.Basic
 import Linglib.Morphology.Exponence.Containment.Contiguity
 import Linglib.Morphology.Exponence.Containment.Defs
 import Linglib.Morphology.Exponence.Containment.Selection
+import Linglib.Morphology.Exponence.Decomposition
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.FragmentGrammars.AdaptorGrammar
 import Linglib.Morphology.FragmentGrammars.CFGFragment

--- a/Linglib/Morphology/Exponence/Containment/Selection.lean
+++ b/Linglib/Morphology/Exponence/Containment/Selection.lean
@@ -1,8 +1,10 @@
 import Linglib.Morphology.Exponence.Containment.Defs
+import Linglib.Morphology.Exponence.Decomposition
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.Paradigm.Basic
 import Mathlib.Data.List.MinMax
 import Mathlib.Data.Finset.Max
+import Mathlib.Order.Interval.Finset.Fin
 
 /-!
 # Containment hierarchies: score selection
@@ -388,5 +390,71 @@ theorem spelloutWinner_isElsewhereWinner {v : List (SpanRule n F)}
   obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hs
   rw [SupersetRule.le_iff]
   exact le_spans_of_minSpan_eq_coe hms hjt hsapp
+
+/-! ### The chain decomposition: containment as feature decomposition
+
+The linear containment engine is the chain instance of the general
+feature-decomposition engine (`Exponence/Decomposition.lean`): decompose the
+grade space `Fin n` by initial segments `chainDecomp i = Finset.Iic i`, and a
+span rule realizing `[0, threshold]` becomes a decomposition rule specified for
+exactly those features. Threshold containment is then Subset containment
+(`applies_toDecomposition`), the specificity orders correspond
+(`SpanRule.toDecomposition_le_iff`), and the Elsewhere winner selected by
+maximizing `threshold` is the same rule the decomposition engine selects by
+maximizing `feats.card = threshold + 1` — an Elsewhere winner of the shared core
+under the decomposition reading (`winner_isElsewhereWinner_toDecomposition`). -/
+
+/-- The chain decomposition of an `n`-grade hierarchy: grade `i` carries the
+initial segment `[0, i]`. -/
+def chainDecomp {n : ℕ} : Fin n → Finset (Fin n) := Finset.Iic
+
+/-- A span rule read as a feature-decomposition rule over `chainDecomp`: its
+threshold becomes the initial-segment feature set `[0, threshold]`, the exponent
+unchanged. -/
+def SpanRule.toDecomposition (it : SpanRule n F) :
+    Decomposition.Rule (Fin n) chainDecomp F :=
+  ⟨Finset.Iic it.threshold, it.exponent⟩
+
+@[simp] theorem SpanRule.toDecomposition_feats {it : SpanRule n F} :
+    it.toDecomposition.feats = Finset.Iic it.threshold := rfl
+
+/-- **Applicability agreement**: threshold containment is Subset containment of
+initial segments. -/
+@[simp] theorem applies_toDecomposition {it : SpanRule n F} {g : Fin n} :
+    Exponence.Applies (F := F) it.toDecomposition g
+      ↔ Exponence.Applies (F := F) it g := by
+  rw [SpanRule.applies_iff]; exact Finset.Iic_subset_Iic
+
+/-- The feature count of a chain rule is one more than its threshold, so
+`feats.card`-maximization is `threshold`-maximization: the two engines optimize
+the same score. -/
+theorem SpanRule.toDecomposition_feats_card {it : SpanRule n F} :
+    it.toDecomposition.feats.card = (it.threshold : ℕ) + 1 := by
+  simp [Fin.card_Iic]
+
+/-- **Specificity agreement**: the chain map reflects the specificity preorder —
+`it` is at least as specific as `jt` under the linear threshold order iff its
+decomposition image is under Subset inclusion. -/
+theorem SpanRule.toDecomposition_le_iff {it jt : SpanRule n F} :
+    it.toDecomposition ≤ jt.toDecomposition ↔ it ≤ jt := by
+  rw [Decomposition.le_iff, SpanRule.le_iff, SpanRule.moreSpecific_iff_threshold_le]
+  simp only [applies_toDecomposition, SpanRule.applies_iff]
+  constructor
+  · intro h; exact h le_rfl
+  · intro h c hg; exact le_trans h hg
+
+/-- **Winner agreement**: the containment Elsewhere winner, read through the
+chain map, is an Elsewhere winner of the shared core under the decomposition
+reading — so `Containment.winner` (maximizing `threshold`) and
+`Decomposition.pattern` (`selectBy feats.card`) pick the same rule. -/
+theorem winner_isElsewhereWinner_toDecomposition {v : List (SpanRule n F)}
+    {g : Fin n} {it : SpanRule n F} (h : winner v g = some it) :
+    Exponence.IsElsewhereWinner (v.map SpanRule.toDecomposition) g it.toDecomposition := by
+  obtain ⟨⟨hmem, happ⟩, hmin⟩ := winner_isElsewhereWinner h
+  refine ⟨⟨List.mem_map_of_mem hmem, applies_toDecomposition.mpr happ⟩, ?_⟩
+  rintro s ⟨hsv, hsapp⟩ hsle
+  obtain ⟨jt, hjt, rfl⟩ := List.mem_map.mp hsv
+  rw [SpanRule.toDecomposition_le_iff] at hsle ⊢
+  exact hmin ⟨hjt, applies_toDecomposition.mp hsapp⟩ hsle
 
 end Morphology.Containment

--- a/Linglib/Morphology/Exponence/Decomposition.lean
+++ b/Linglib/Morphology/Exponence/Decomposition.lean
@@ -1,0 +1,103 @@
+import Linglib.Morphology.Exponence.Select
+import Mathlib.Data.Finset.Card
+
+/-!
+# Feature-decomposition exponence and the Subset Principle
+
+The realizational engine for privative **feature-decomposition** accounts of
+syncretism ([caha-2009], [bobaljik-2012]): a cell space is decomposed into
+feature sets `D : Cell → Finset K`, and a rule applies where its feature
+specification is contained in the cell's — the **Subset Principle**. Competition
+is [halle-1997]'s feature counting: the applicable rule of greatest
+specification wins, as the shared core's `selectBy` on `feats.card`.
+
+Where the linear containment engine (`Exponence/Containment/`) orders spans by a
+single threshold, this engine orders arbitrary feature *sets* by inclusion, so
+`card`-maximization is genuine specificity only when the applicable
+specifications happen to be nested; the general soundness lives in the
+`IsWinner` strict-competition predicate rather than the core's linear
+`selectBy_isElsewhereWinner`. The linear engine embeds as the chain
+decomposition `chainDecomp i = Finset.Iic i` (`Exponence/Containment/Selection.lean`).
+
+## Main declarations
+
+* `Rule` — a feature specification plus an exponent; `Applies` is Subset
+  containment
+* `pattern` — the surface exponent at each cell, `selectBy` on `feats.card`
+* `IsWinner` — strict feature-count competition
+* `noABA` — the order-theoretic *ABA exclusion for a cell triple whose
+  decomposition nests the middle cell between the outer two
+-/
+
+namespace Morphology.Decomposition
+
+open Morphology Morphology.Exponence
+
+variable {K : Type*} [DecidableEq K]
+
+/-- A rule of exponence over a feature decomposition `D`: a feature
+specification and an exponent. Applicability is the **Subset Principle** — the
+rule's features are a subset of the cell's ([halle-1997]). -/
+structure Rule (Cell : Type*) (D : Cell → Finset K) (F : Type*) where
+  /-- The rule's feature specification. -/
+  feats : Finset K
+  /-- The exponent inserted. -/
+  exponent : F
+  deriving DecidableEq
+
+variable {Cell F : Type*} {D : Cell → Finset K}
+
+instance : Exponence (Rule Cell D F) Cell F :=
+  ⟨Rule.exponent, fun r c => r.feats ⊆ D c⟩
+
+omit [DecidableEq K] in
+@[simp] theorem applies_iff {r : Rule Cell D F} {c : Cell} :
+    Exponence.Applies (F := F) r c ↔ r.feats ⊆ D c := Iff.rfl
+
+instance (c : Cell) :
+    DecidablePred (fun r : Rule Cell D F => Exponence.Applies (F := F) r c) :=
+  fun r => inferInstanceAs (Decidable (r.feats ⊆ D c))
+
+/-- The specificity preorder: applicability-set inclusion, so the engine
+participates in the shared core's Elsewhere selection theory
+(`Exponence/Select.lean`). Unlike the linear containment order this is only a
+preorder — incomparable specifications (No Case Containment) are the point. -/
+instance : Preorder (Rule Cell D F) := Exponence.toPreorder
+
+omit [DecidableEq K] in
+/-- Specificity unfolds to applicability-set inclusion: `r ≤ s` iff `r` applies
+wherever `s` does. -/
+theorem le_iff {r s : Rule Cell D F} :
+    r ≤ s ↔ ∀ ⦃c⦄, Exponence.Applies (F := F) r c → Exponence.Applies (F := F) s c :=
+  Iff.rfl
+
+/-- The surface pattern of a vocabulary: at each cell, the exponent of the most
+highly specified applicable rule — the Elsewhere Principle as `selectBy` on
+feature cardinality ([halle-1997]'s counting formulation). -/
+def pattern (v : List (Rule Cell D F)) (c : Cell) : Option F :=
+  (selectBy (fun r : Rule Cell D F => r.feats.card) v c).map Rule.exponent
+
+/-- Strict competition: `r` beats every other applicable rule on feature
+cardinality. -/
+def IsWinner (v : List (Rule Cell D F)) (c : Cell) (r : Rule Cell D F) : Prop :=
+  r ∈ v ∧ r.feats ⊆ D c ∧
+    ∀ s ∈ v, s.feats ⊆ D c → s ≠ r → s.feats.card < r.feats.card
+
+/-- ***ABA, order-theoretically**: whenever the middle cell `y` nests between
+the outer cells — `D y ⊆ D z` (appliers at `y` persist to `z`) and
+`D x ∩ D z ⊆ D y` (appliers at both outer cells reach `y`) — a rule winning both
+`x` and `z` also wins `y`, so no exponent can interrupt an A_A pattern with a
+distinct middle B. The hypotheses are the shared profile of Strong and Weak Case
+Containment; No Case Containment violates the first. -/
+theorem noABA {v : List (Rule Cell D F)} {A B : Rule Cell D F} {x y z : Cell}
+    (h1 : D y ⊆ D z) (h2 : D x ∩ D z ⊆ D y)
+    (hx : IsWinner v x A) (hz : IsWinner v z A) (hy : IsWinner v y B) : B = A := by
+  by_contra hne
+  have hAy : A.feats ⊆ D y := fun k hk =>
+    h2 (Finset.mem_inter.mpr ⟨hx.2.1 hk, hz.2.1 hk⟩)
+  have hAB : A.feats.card < B.feats.card :=
+    hy.2.2 A hx.1 hAy (fun h => hne h.symm)
+  have hBz : B.feats ⊆ D z := fun k hk => h1 (hy.2.1 hk)
+  exact absurd (hz.2.2 B hy.1 hBz hne) (Nat.lt_asymm hAB)
+
+end Morphology.Decomposition

--- a/Linglib/Studies/ChristopoulosZompi2023.lean
+++ b/Linglib/Studies/ChristopoulosZompi2023.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.Exponence.Select
+import Linglib.Morphology.Exponence.Decomposition
 import Mathlib.Tactic.DeriveFintype
 import Mathlib.Data.Fintype.Sigma
 
@@ -32,9 +32,9 @@ needs k₁ (fn. 25).
 
 ## Main results
 
-* `noABA` — under any decomposition with `D acc ⊆ D dat` and
-  `D nom ∩ D dat ⊆ D acc`, one rule winning NOM and DAT forces it to win ACC;
-  `noABA_scc` / `noABA_wcc` discharge the hypotheses by `decide`
+* `noABA_scc` / `noABA_wcc` — the generic `Decomposition.noABA` (*ABA excluded
+  under any decomposition nesting the middle cell) discharged for SCC and WCC by
+  `decide` on the order-theoretic hypotheses
 * `ncc_aba_generable` — the two-rule NCC vocabulary generating A B A
 * `scc_nom_forces_empty` — SCC has no non-elsewhere nominative rules
 * `table25_row1` … `table25_row8` — the WCC derivation table
@@ -45,7 +45,7 @@ needs k₁ (fn. 25).
 
 namespace ChristopoulosZompi2023
 
-open Morphology Morphology.Exponence
+open Morphology Morphology.Exponence Morphology.Decomposition
 
 /-- The privative features: k₀–k₃ across the three Case decompositions
 (Tables 1, 2, 24), plus number (s₀ singular, p₀ plural) and gender features
@@ -72,58 +72,15 @@ its own k₀, incomparable to ACC — no k₃. -/
 def wcc : Case3 → Finset K
   | .nom => {.k0} | .acc => {.k1} | .dat => {.k1, .k2}
 
-/-- A rule of exponence over a decomposition `D`: a feature specification and
-an exponent. Applicability is the **Subset Principle** — the rule's features
-are a subset of the cell's. -/
-structure Rule (Cell : Type*) (D : Cell → Finset K) (F : Type*) where
-  /-- The rule's Case (and φ) feature specification. -/
-  feats : Finset K
-  /-- The exponent inserted. -/
-  exponent : F
-  deriving DecidableEq
+variable {F : Type*}
 
-variable {Cell F : Type*} {D : Cell → Finset K}
+/-! ### *ABA
 
-instance : Exponence (Rule Cell D F) Cell F :=
-  ⟨Rule.exponent, fun r c => r.feats ⊆ D c⟩
-
-@[simp] theorem applies_iff {r : Rule Cell D F} {c : Cell} :
-    Exponence.Applies (F := F) r c ↔ r.feats ⊆ D c := Iff.rfl
-
-instance (c : Cell) :
-    DecidablePred (fun r : Rule Cell D F => Exponence.Applies (F := F) r c) :=
-  fun r => inferInstanceAs (Decidable (r.feats ⊆ D c))
-
-/-- The surface pattern of a vocabulary: at each cell, the exponent of the
-most highly specified applicable rule — the paper's DM implementation of the
-Elsewhere Principle, as the shared core's `selectBy` on feature cardinality. -/
-def pattern (v : List (Rule Cell D F)) (c : Cell) : Option F :=
-  (selectBy (fun r : Rule Cell D F => r.feats.card) v c).map Rule.exponent
-
-/-- Strict competition: `r` beats every other applicable rule on feature
-cardinality. -/
-def IsWinner (v : List (Rule Cell D F)) (c : Cell) (r : Rule Cell D F) : Prop :=
-  r ∈ v ∧ r.feats ⊆ D c ∧
-    ∀ s ∈ v, s.feats ⊆ D c → s ≠ r → s.feats.card < r.feats.card
-
-/-! ### *ABA -/
-
-/-- ***ABA, order-theoretically**: whenever ACC-appliers persist to DAT
-(`D acc ⊆ D dat`) and NOM∩DAT-appliers reach ACC (`D nom ∩ D dat ⊆ D acc`), a
-rule winning both NOM and DAT also wins ACC. The two hypotheses are the shared
-profile of SCC and WCC; NCC violates the first via k₃. -/
-theorem noABA {D : Case3 → Finset K} {v : List (Rule Case3 D F)}
-    {A B : Rule Case3 D F}
-    (h1 : D .acc ⊆ D .dat) (h2 : D .nom ∩ D .dat ⊆ D .acc)
-    (hnom : IsWinner v .nom A) (hdat : IsWinner v .dat A)
-    (hacc : IsWinner v .acc B) : B = A := by
-  by_contra hne
-  have hAacc : A.feats ⊆ D .acc := fun k hk =>
-    h2 (Finset.mem_inter.mpr ⟨hnom.2.1 hk, hdat.2.1 hk⟩)
-  have hAB : A.feats.card < B.feats.card :=
-    hacc.2.2 A hnom.1 hAacc (fun h => hne h.symm)
-  have hBdat : B.feats ⊆ D .dat := fun k hk => h1 (hacc.2.1 hk)
-  exact absurd (hdat.2.2 B hacc.1 hBdat hne) (Nat.lt_asymm hAB)
+The generic order-theoretic exclusion is `Decomposition.noABA`: whenever the
+middle cell nests between the outer two, a rule winning both outer cells wins the
+middle, so no distinct B can interrupt an A_A pattern. It discharges for the two
+containment decompositions by `decide` on the hypotheses; NCC violates the
+first (`ncc_aba_generable`). -/
 
 /-- *ABA under Strong Case Containment ([caha-2009],
 [smith-moskal-xu-kang-bobaljik-2019]). -/

--- a/Linglib/Studies/Zompi2023.lean
+++ b/Linglib/Studies/Zompi2023.lean
@@ -46,7 +46,7 @@ Main results:
 
 namespace Zompi2023
 
-open Morphology ChristopoulosZompi2023
+open Morphology Morphology.Decomposition ChristopoulosZompi2023
 
 /-- The inflectional dimensions the constraints are relativized to. -/
 inductive Dim | kase | num | gen


### PR DESCRIPTION
Graduate the feature-decomposition selection engine to `Morphology/Exponence/Decomposition.lean` — it now has two study consumers (ChristopoulosZompi2023, Zompi2023), which retarget onto it (their local `Rule`/`pattern`/`IsWinner`/generic `noABA` deleted). The linear containment engine embeds as the chain decomposition `chainDecomp i = Finset.Iic i`: `SpanRule.toDecomposition` with applicability agreement, score correspondence (`feats.card = threshold + 1`), specificity agreement, and winner agreement through the shared-core `IsElsewhereWinner`.