### PR TITLE
feat(Morphology/DM): wire Root index; Interpreted allosemy; Harley bridge

### DIFF
--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -1,6 +1,7 @@
 import Linglib.Morphology.DM.Categorizer
 import Linglib.Morphology.DM.CategorizerSemantics
 import Linglib.Morphology.Exponence.Select
+import Linglib.Morphology.Realization
 import Linglib.Semantics.Verb.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Voice
 
@@ -639,5 +640,39 @@ inductive AllomorphyAnalogyPosition where
 
 /-- Benz's position. -/
 def benzPosition : AllomorphyAnalogyPosition := .partialAnalogy
+
+-- ════════════════════════════════════════════════════
+-- § 7. The `Realization.Interpreted` view (List 3 on the shared carrier)
+-- ════════════════════════════════════════════════════
+
+/-! An allosemic head is a List-3 object: a single morpheme whose
+*interpretation* is resolved in context by the shared exponence engine.
+`Realization.Interpreted` is exactly that carrier — an opaque index with a
+contextual `interp` map — so the engine slots in as a view. The form side
+(`realize`) is empty (`Unit`, `∅`): allosemy is meaning-only, the List-2
+form having been resolved separately. Contextual meaning variation — Benz's
+core claim that allosemy is allomorphy's LF analogue — is then literally
+`Realization.Interpreted.IsAllosemous`. -/
+
+open Morphology.Exponence in
+/-- The allosemy engine as a `Realization.Interpreted` view: one abstract
+head (`Unit`) whose contextual interpretation is the alloseme `selectBy`
+picks (a singleton, `∅` at a semantic gap), with an empty List-2 form
+side. -/
+def AllosemicHead.toInterpreted {Sem : Type} (h : AllosemicHead Sem) :
+    Realization.Interpreted Unit SyntacticContext Unit Sem where
+  realize _ _ := ∅
+  interp _ c :=
+    match selectBy AllosemicEntry.score h.entries c with
+    | some e => {e.denotation}
+    | none => ∅
+
+/-- The verbal categorizer's meaning varies with context — eventive under
+an eventive complement, zero elsewhere — so v is `IsAllosemous` on the
+shared carrier: contextual meaning variation as non-constancy of the
+`interp` map ([benz-2025], the LF analogue of allomorphy). -/
+theorem vAllosemic_isAllosemous : vAllosemic.toInterpreted.IsAllosemous () :=
+  ⟨{ complementIsEventive := true }, { complementIsEventive := false },
+   .eventive, by decide, .zero, by decide, by decide⟩
 
 end Morphology.DM.Allosemy

--- a/Linglib/Morphology/DM/Categorizer.lean
+++ b/Linglib/Morphology/DM/Categorizer.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Gender.Interp
+import Linglib.Morphology.DM.Root
 import Linglib.Semantics.Verb.Root.Classification
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Verbal.Voice
@@ -590,9 +591,19 @@ def GenderImpoverishmentRule.apply (rule : GenderImpoverishmentRule)
 -- ============================================================================
 
 /-- A root that has been merged with a categorizing head, yielding a
-    syntactically projectable unit ([harley-2014] §2). -/
+    syntactically projectable unit ([harley-2014] §2).
+
+    `index` is DM's List-1 individuator — the acategorial atom `DM.Root`,
+    an arbitrary tag carrying no form or meaning. It is what survives
+    (re)categorization (`recategorize_preserves_index`), so it, not the
+    `root` classification, is what makes √HAMMER *one* root across
+    *hammer*/*to hammer*. `root` is the c-selection content (arity,
+    change-type) the categorizer apparatus reads (§3); unrelated roots may
+    share it, so it cannot individuate. -/
 structure CategorizedRoot where
-  /-- The acategorial root (arity, change-type, etc.) -/
+  /-- The acategorial root index — DM's List-1 individuator (`DM.Root`). -/
+  index : DM.Root
+  /-- The acategorial root's c-selection content (arity, change-type, etc.) -/
   root : Classification
   /-- The categorizing head that gives it syntactic category -/
   categorizer : Categorizer
@@ -610,9 +621,9 @@ def CategorizedRoot.category (cr : CategorizedRoot) : Cat :=
     This is the formal content of the claim that √HAMMER can surface as
     either a noun (hammer) or a verb (to hammer) — same root, different
     category, determined entirely by the categorizer ([harley-2014] §2). -/
-theorem same_root_different_category (r : Classification) (c1 c2 : Categorizer)
-    (h : c1 ≠ c2) :
-    (CategorizedRoot.mk r c1).category ≠ (CategorizedRoot.mk r c2).category := by
+theorem same_root_different_category (i : DM.Root) (r : Classification)
+    (c1 c2 : Categorizer) (h : c1 ≠ c2) :
+    (CategorizedRoot.mk i r c1).category ≠ (CategorizedRoot.mk i r c2).category := by
   simp only [CategorizedRoot.category, Categorizer.toCategory]
   cases c1 <;> cases c2 <;> simp_all
 
@@ -637,14 +648,15 @@ theorem same_root_different_category (r : Classification) (c1 c2 : Categorizer)
     3. Hiaki suppletive verbs: suppletive forms are conditioned by the
        root's complement (singular vs. plural object), showing locality
        between root and argument below the categorizer. -/
-theorem complement_selection_at_root_level (r : Classification) (c1 c2 : Categorizer) :
-    (CategorizedRoot.mk r c1).root.arity = (CategorizedRoot.mk r c2).root.arity := rfl
+theorem complement_selection_at_root_level (i : DM.Root) (r : Classification)
+    (c1 c2 : Categorizer) :
+    (CategorizedRoot.mk i r c1).root.arity = (CategorizedRoot.mk i r c2).root.arity := rfl
 
 /-- A theme-selecting root maintains its complement requirement regardless
     of whether it surfaces as a noun, verb, or adjective ([harley-2014] §3). -/
-theorem theme_selecting_root_always_selects (r : Classification) (c : Categorizer)
-    (h : r.arity = .selectsTheme) :
-    (CategorizedRoot.mk r c).root.arity.hasInternalArg = true := by
+theorem theme_selecting_root_always_selects (i : DM.Root) (r : Classification)
+    (c : Categorizer) (h : r.arity = .selectsTheme) :
+    (CategorizedRoot.mk i r c).root.arity.hasInternalArg = true := by
   simp [h, Root.Arity.hasInternalArg]
 
 -- ============================================================================
@@ -685,7 +697,7 @@ def Recategorization.target : Recategorization → Categorizer
 def CategorizedRoot.recategorize (cr : CategorizedRoot)
     (rc : Recategorization) : Option CategorizedRoot :=
   if cr.categorizer = rc.source then
-    some { root := cr.root, categorizer := rc.target }
+    some { index := cr.index, root := cr.root, categorizer := rc.target }
   else
     none
 
@@ -707,15 +719,30 @@ theorem recategorization_changes_category (cr : CategorizedRoot)
   case isTrue => simp only [Option.some.injEq] at h; rw [← h]
   case isFalse => simp at h
 
+/-- The acategorial index survives (re)categorization: the individuating
+    `DM.Root` atom is invariant under `recategorize`, so *shelf* (n) and
+    *to shelve* (v) share one List-1 root ([harley-2014] §2, §4). This is
+    the work DM's own individuator does that the `root` classification
+    cannot — arity/change-type is shared by unrelated roots, the index is
+    not — so it is the index, not the classification, that the derivational
+    history threads unchanged. -/
+theorem recategorize_preserves_index (cr cr' : CategorizedRoot)
+    (rc : Recategorization) (h : cr.recategorize rc = some cr') :
+    cr'.index = cr.index := by
+  unfold CategorizedRoot.recategorize at h
+  split at h
+  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
+  case isFalse => simp at h
+
 /-- A denominal verb and a directly verbal root yield the same syntactic
     category (V), but have different internal structure. √HAMMER + v gives
     V directly; √HAMMER + n + v also gives V but via layered derivation.
     This structural ambiguity is invisible at the category level
     ([harley-2014] §2). -/
-theorem denominal_yields_verbal (r : Classification) :
-    ∃ cr, (CategorizedRoot.mk r .n).recategorize .denominal = some cr ∧
+theorem denominal_yields_verbal (i : DM.Root) (r : Classification) :
+    ∃ cr, (CategorizedRoot.mk i r .n).recategorize .denominal = some cr ∧
           cr.category = Cat.V :=
-  ⟨⟨r, .v⟩, rfl, rfl⟩
+  ⟨⟨i, r, .v⟩, rfl, rfl⟩
 
 /-- Deadjectival derivation (a → v) connects to [embick-2004]'s result-stative
     structure ([AspP AspR [vP DP v_become √ROOT]]): in DM terms, a root first

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -61,7 +61,7 @@ number-unspecified).
 namespace Harley2014
 
 open Morphology.DM.VI
-open Morphology.DM.Allosemy (SyntacticContext AllosemicEntry)
+open Morphology.DM.Allosemy (SyntacticContext AllosemicEntry AllosemicHead)
 open Morphology.Exponence (selectBy realize)
 
 /-! ### List 1: roots as abstract indices -/
@@ -235,5 +235,59 @@ theorem cahoot_no_elsewhere :
 distinct `RootIndex` values ([harley-2014] §2.4). Neither the shared
 Elsewhere-form shape nor the shared interpretation-frame identifies them. -/
 example : runRoot ≠ walkRoot ∧ walkRoot ≠ killRoot ∧ runRoot ≠ killRoot := by decide
+
+/-! ### Both individuation-failure arguments on the shared `Realization` carrier
+
+The two negative flanks (§2.1–2.2 phonological, §2.3 semantic) are the
+constancy pair of `Morphology.Realization` at one index: form varies across
+contexts (`IsProperlySuppletive`), meaning does not vary but *gaps* (an
+empty `interp` fiber outside the cran-morph's frame, via
+`AllosemicHead.toInterpreted`). The vocabulary of §2.1 is the List-2 map,
+`cahootLF` the List-3 map.
+
+The form side wraps this file's `insert` — the shared Exponence engine
+(`Exponence.realize`, argmax) — as a `Realization`. `VI.toRealization`
+wraps the equivalent DM `vocabularyInsert`, whose `List.mergeSort` is
+well-founded-recursive and so kernel-opaque; `insert` computes, so the
+fibers reduce and the same theorem lands on the same data. -/
+
+/-- The Hiaki suppletive vocabulary as a `Realization`: index `→` its
+Elsewhere-selected exponent (`insert`) as a singleton fiber, `∅` at an
+unlicensed index — the univalent stratum ([marantz-1997]'s List 2). -/
+def realization : Morphology.Realization RootIndex Ctx String :=
+  ⟨fun r c => match insert c r with | some f => {f} | none => ∅⟩
+
+/-- **Phonological individuation fails, on the carrier** ([harley-2014]
+§2.1–2.2): the Hiaki √322 realizes two nonempty, distinct fibers
+(`vuite` / `tenne`) across two licensed contexts — `IsProperlySuppletive`,
+the exact √GO case the predicate names. A root identified by its form would
+split here. -/
+theorem run_isProperlySuppletive : realization.IsProperlySuppletive runRoot := by
+  have hsg : realization.realize runRoot ⟨.sg, none⟩ = {"vuite"} := by
+    show (match insert ⟨.sg, none⟩ runRoot with
+      | some f => ({f} : Finset String) | none => ∅) = _
+    rw [run_sg]
+  have hpl : realization.realize runRoot ⟨.pl, none⟩ = {"tenne"} := by
+    show (match insert ⟨.pl, none⟩ runRoot with
+      | some f => ({f} : Finset String) | none => ∅) = _
+    rw [run_pl]
+  refine ⟨⟨.sg, none⟩, ⟨.pl, none⟩, hsg ▸ Finset.singleton_nonempty _,
+    hpl ▸ Finset.singleton_nonempty _, ?_⟩
+  rw [hsg, hpl, ne_eq, Finset.singleton_inj]; decide
+
+/-- √548 *cahoot* as a List-3 `Realization.Interpreted` view: one head, the
+cran-morph's single alloseme. -/
+def cahootHead : AllosemicHead String := { morpheme := .n, entries := cahootLF }
+
+/-- **Semantic individuation fails, on the carrier** ([harley-2014] §2.3):
+the cran-morph is interpreted (`a conspiracy`) inside its licensing frame
+but has an empty `interp` fiber elsewhere — the meaning-side analogue of an
+empty realization fiber, a *gap* rather than contextual variation. So this
+is a licensing failure, not an `IsAllosemous` witness: unlike an ordinary
+root (whose meaning would merely vary), a Fodorian atom could not gap. -/
+theorem cahoot_interp_gap :
+    cahootHead.toInterpreted.interp () { belowCat := some .n } = {"a conspiracy"} ∧
+    cahootHead.toInterpreted.interp () { } = ∅ := by
+  refine ⟨?_, ?_⟩ <;> decide
 
 end Harley2014

--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -266,10 +266,10 @@ theorem Hkm_not_templateInvariant : ¬ templateInvariant .Hkm :=
     `complement_selection_at_root_level` in `Categorizer.lean`) but l-selection is
     not: the two kinds of selection factor differently in the grammar. -/
 theorem cSelection_vs_lSelection :
-    (∀ (r : Verb.Root.Classification) (c1 c2 : Categorizer),
-      (CategorizedRoot.mk r c1).root.arity = (CategorizedRoot.mk r c2).root.arity) ∧
+    (∀ (i : Morphology.DM.Root) (r : Verb.Root.Classification) (c1 c2 : Categorizer),
+      (CategorizedRoot.mk i r c1).root.arity = (CategorizedRoot.mk i r c2).root.arity) ∧
     (∃ r : RootLabel, ¬ templateInvariant r) :=
-  ⟨fun _ _ _ => rfl, ⟨.krh, krh_not_templateInvariant⟩⟩
+  ⟨fun _ _ _ _ => rfl, ⟨.krh, krh_not_templateInvariant⟩⟩
 
 /-! ### Verbalized roots -/
 


### PR DESCRIPTION
Consumes DM's acategorial individuator and connects the DM engines to the shared `Realization` carrier.

- `CategorizedRoot` gains an `index : DM.Root` field beside `root : Classification`; `recategorize` threads it and `recategorize_preserves_index` proves the atom survives categorization. DM.Root goes from zero consumers to load-bearing.
- Allosemy gets an `AllosemicHead.toInterpreted` view on `Realization.Interpreted` (List 3), with v-allosemy as an `IsAllosemous` witness.
- Harley2014 restates both individuation-failure arguments on the carrier: run-root `IsProperlySuppletive` (form) and the cahoot cran-morph interp gap (meaning).