### PR TITLE
docs(Morphology/Exponence): trim Basic docstrings

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1269,6 +1269,7 @@ import Linglib.Morphology.Exponence.Containment.Contiguity
 import Linglib.Morphology.Exponence.Containment.Defs
 import Linglib.Morphology.Exponence.Containment.Selection
 import Linglib.Morphology.Exponence.Decomposition
+import Linglib.Morphology.Exponence.Elsewhere
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.FragmentGrammars.AdaptorGrammar
 import Linglib.Morphology.FragmentGrammars.CFGFragment

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -52,22 +52,22 @@ open Yukatek.Roots
     (`exponent` is the suffix, `Applies` the structural condition on the
     root's entailments) with bundled decidability so applicability
     profiles compute. Selection/profile machinery comes from the
-    `Morphology.Exponence` class instance below, not re-stipulated. -/
+    `Morphology.Exponence.Rule` class instance below, not re-stipulated. -/
 structure DiagOp where
   exponent : String
   Applies : Root → Prop
   decApplies : DecidablePred Applies
 
-instance instExponence : Exponence DiagOp Root String where
+instance instExponence : Morphology.Exponence.Rule DiagOp Root String where
   exponent := DiagOp.exponent
   Applies := DiagOp.Applies
 
 instance (r : Root) :
-    DecidablePred (fun op : DiagOp => Exponence.Applies (F := String) op r) :=
+    DecidablePred (fun op : DiagOp => Exponence.Applies op r) :=
   fun op => show Decidable (op.Applies r) from op.decApplies r
 
 @[simp] theorem applies_iff (op : DiagOp) (r : Root) :
-    Exponence.Applies (F := String) op r ↔ op.Applies r := Iff.rfl
+    Exponence.Applies op r ↔ op.Applies r := Iff.rfl
 
 /-! ### The four operators -/
 

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -61,7 +61,9 @@ structure DiagOp where
 instance instExponence : Morphology.Exponence.Rule DiagOp Root String where
   exponent := DiagOp.exponent
   Applies := DiagOp.Applies
-  dec := fun r op => op.decApplies r
+
+instance : Exponence.DecidableApplies DiagOp Root :=
+  fun r op => op.decApplies r
 
 @[simp] theorem applies_iff (op : DiagOp) (r : Root) :
     Exponence.Applies op r ↔ op.Applies r := Iff.rfl

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -61,10 +61,7 @@ structure DiagOp where
 instance instExponence : Morphology.Exponence.Rule DiagOp Root String where
   exponent := DiagOp.exponent
   Applies := DiagOp.Applies
-
-instance (r : Root) :
-    DecidablePred (fun op : DiagOp => Exponence.Applies op r) :=
-  fun op => show Decidable (op.Applies r) from op.decApplies r
+  dec := fun r op => op.decApplies r
 
 @[simp] theorem applies_iff (op : DiagOp) (r : Root) :
     Exponence.Applies op r ↔ op.Applies r := Iff.rfl

--- a/Linglib/Fragments/Mayan/Yukatek/Operators.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Operators.lean
@@ -62,8 +62,8 @@ instance instExponence : Morphology.Exponence.Rule DiagOp Root String where
   exponent := DiagOp.exponent
   Applies := DiagOp.Applies
 
-instance : Exponence.DecidableApplies DiagOp Root :=
-  fun r op => op.decApplies r
+instance : DecidableRel (Exponence.Applies : DiagOp → Root → Prop) :=
+  fun op r => op.decApplies r
 
 @[simp] theorem applies_iff (op : DiagOp) (r : Root) :
     Exponence.Applies op r ↔ op.Applies r := Iff.rfl

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -188,10 +188,9 @@ denotation is the exponent, its context's `matches` predicate the
 applicability set. So the very engine that resolves DM's List 2
 (`DM/VocabularyInsertion.lean`) resolves List 3 — LF competition among
 allosemes — with no new machinery. `AllosemicEntry.score` is the
-non-wildcard-field count of the entry's context; `score_reflects` shows
-it reflects the specificity preorder, discharging
-`selectBy_isElsewhereWinner`'s conditional-reflection hypothesis, so
-`selectBy score` is Elsewhere selection (`selectBy_score_isElsewhereWinner`). -/
+non-wildcard-field count of the entry's context; `score_strictAnti` shows
+it is strictly antitone in specificity, so `selectBy score` is Elsewhere
+selection (`selectBy_score_isElsewhereWinner`). -/
 
 section Exponence
 
@@ -207,35 +206,28 @@ instance : Exponence.Rule (AllosemicEntry Sem) SyntacticContext Sem :=
 
 instance : Preorder (AllosemicEntry Sem) := Exponence.toPreorder
 
-instance (c : SyntacticContext) :
-    DecidablePred (fun e : AllosemicEntry Sem => Exponence.Applies e c) :=
-  fun e => inferInstanceAs (Decidable (e.context.matches c = true))
-
 /-- The specificity score of an alloseme: the non-wildcard-field count of
 its conditioning context. -/
 def AllosemicEntry.score (e : AllosemicEntry Sem) : Nat := e.context.specificity
 
-/-- The score reflects the specificity preorder: a strictly broader
-alloseme scores strictly lower, so score selection agrees with the
-applicability order. This is the conditional-reflection hypothesis of
-`selectBy_isElsewhereWinner` in its weak form. -/
-theorem score_reflects {r s : AllosemicEntry Sem} (hsr : s ≤ r)
-    (hscore : AllosemicEntry.score s ≤ AllosemicEntry.score r) : r ≤ s := by
-  have hsub : ∀ q, s.context.matches q = true → r.context.matches q = true := hsr
-  have hle : r.context.specificity ≤ s.context.specificity :=
-    SyntacticContext.specificity_le_of_matches_subset hsub
-  have heq : r.context.specificity = s.context.specificity := le_antisymm hle hscore
-  have : r.context = s.context :=
+/-- The score is strictly antitone in specificity: a strictly broader
+alloseme scores strictly lower. -/
+theorem score_strictAnti : StrictAnti (AllosemicEntry.score (Sem := Sem)) := by
+  intro s r hlt
+  have hsub : ∀ q, s.context.matches q = true → r.context.matches q = true := hlt.le
+  refine lt_of_le_of_ne (SyntacticContext.specificity_le_of_matches_subset hsub)
+    fun heq => not_le_of_gt hlt ?_
+  have hctx : r.context = s.context :=
     SyntacticContext.eq_of_matches_subset_of_specificity_eq hsub heq
   show ∀ q, r.context.matches q = true → s.context.matches q = true
-  rw [this]; exact fun _ h => h
+  rw [hctx]; exact fun _ h => h
 
 /-- Score selection over an alloseme vocabulary is Elsewhere selection:
 the winner is `≤`-minimal among the applicable allosemes. -/
 theorem selectBy_score_isElsewhereWinner {v : List (AllosemicEntry Sem)}
     {c : SyntacticContext} {r : AllosemicEntry Sem}
     (h : selectBy AllosemicEntry.score v c = some r) : IsElsewhereWinner v c r :=
-  selectBy_isElsewhereWinner (fun _ _ _ _ _ _ hsr hscore => score_reflects hsr hscore) h
+  selectBy_isElsewhereWinner (score_strictAnti.strictAntiOn _) h
 
 end Exponence
 

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -39,7 +39,7 @@ and retroactively classifies existing n and Voice types as allosemy.
 
 ## The List-2 / List-3 symmetry, by construction
 
-`AllosemicEntry` is an `Morphology.Exponence` instance
+`AllosemicEntry` is a `Morphology.Exponence.Rule` instance
 (`SyntacticContext.matches` as applicability, denotation as exponent),
 just as `DM.VI.VocabItem` is. So DM's List 2 (form) and List 3 (meaning)
 are resolved by **one** selection engine: `Exponence.selectBy` on the
@@ -202,7 +202,7 @@ variable {Sem : Type}
 /-- An `AllosemicEntry` exposes the shared exponence interface: contexts
 are `SyntacticContext`s, applicability is `matches`, the exponent is the
 denotation. -/
-instance : Exponence (AllosemicEntry Sem) SyntacticContext Sem :=
+instance : Exponence.Rule (AllosemicEntry Sem) SyntacticContext Sem :=
   ⟨AllosemicEntry.denotation, fun e c => e.context.matches c = true⟩
 
 instance : Preorder (AllosemicEntry Sem) := Exponence.toPreorder

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -206,6 +206,9 @@ instance : Exponence.Rule (AllosemicEntry Sem) SyntacticContext Sem :=
 
 instance : Preorder (AllosemicEntry Sem) := Exponence.toPreorder
 
+instance : DecidableRel (Applies : AllosemicEntry Sem → SyntacticContext → Prop) :=
+  fun e c => inferInstanceAs (Decidable (e.context.matches c = true))
+
 /-- The specificity score of an alloseme: the non-wildcard-field count of
 its conditioning context. -/
 def AllosemicEntry.score (e : AllosemicEntry Sem) : Nat := e.context.specificity

--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -136,9 +136,9 @@ section ExponenceCore
 open Morphology Morphology.Exponence
 
 /-- A vocabulary entry exposes the shared exponence core interface
-(`Morphology.Exponence`): contexts are (target bundle,
+(`Morphology.Exponence.Rule`): contexts are (target bundle,
 syntactic context) pairs, applicability is `Matches`. -/
-instance : Exponence VocabEntry (FeatureBundle × Option Cat) String :=
+instance : Exponence.Rule VocabEntry (FeatureBundle × Option Cat) String :=
   ⟨VocabEntry.exponent, fun e tc => e.Matches tc.1 tc.2⟩
 
 instance : Preorder VocabEntry := Exponence.toPreorder

--- a/Linglib/Morphology/DM/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DM/VocabularyInsertion.lean
@@ -157,9 +157,9 @@ open Morphology.Exponence
 variable {Ctx Root : Type*}
 
 /-- A Vocabulary Item exposes the shared exponence core interface
-(`Morphology.Exponence`): contexts are (feature-context, root)
+(`Morphology.Exponence.Rule`): contexts are (feature-context, root)
 pairs, applicability is `matches`. -/
-instance : Exponence (VocabItem Ctx Root) (Ctx × Root) String :=
+instance : Exponence.Rule (VocabItem Ctx Root) (Ctx × Root) String :=
   ⟨VocabItem.exponent, fun vi cr => vi.matches cr.1 cr.2 = true⟩
 
 instance : Preorder (VocabItem Ctx Root) := Exponence.toPreorder

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -25,6 +25,10 @@ class Rule (R : Type*) (Ctx E : outParam Type*) where
   exponent : R → E
   /-- The condition on contexts under which a rule applies. -/
   Applies : R → Ctx → Prop
+  /-- Applicability is decidable, so selection is computable. -/
+  [dec : ∀ c, DecidablePred (Applies · c)]
+
+attribute [instance] Rule.dec
 
 export Rule (exponent Applies)
 

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -64,10 +64,7 @@ def applySet (r : R) : Set Ctx := {c | Applies (F := F) r c}
     c ∈ applySet (F := F) r ↔ Applies (F := F) r c :=
   Iff.rfl
 
-/-- The specificity preorder: `r ≤ s` when `r` applies in a subset of the
-contexts `s` applies in. Only a preorder, since rules may share
-applicability without being equal; not an instance, for flexibility in
-choosing orders. -/
+/-- `r ≤ s` when `r` applies in a subset of the contexts `s` applies in. -/
 @[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (F := F))
 
 end Exponence

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -57,7 +57,7 @@ namespace Exponence
 
 variable {Ctx F : Type*} {R : Type*} [Exponence R Ctx F]
 
-/-- The applicability set of a rule: the contexts in which it applies. -/
+/-- The contexts in which a rule applies. -/
 def applySet (r : R) : Set Ctx := {c | Applies (F := F) r c}
 
 @[simp] theorem mem_applySet {r : R} {c : Ctx} :

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -43,10 +43,9 @@ after which the selection theorems of `Select.lean` apply to `MyRule`.
 
 namespace Morphology
 
-/-- `Exponence R Ctx F` states that terms of `R` are rules of exponence:
-an exponent in `F` and an applicability condition on `Ctx`. This is
-`SetLike` without injectivity: distinct rules may share a condition while
-carrying different exponents. -/
+/-- Terms of `R` are rules of exponence with an exponent in `F` and an
+applicability condition on `Ctx`. This is `SetLike` without injectivity:
+distinct rules may share a condition while carrying different exponents. -/
 class Exponence (R : Type*) (Ctx F : outParam Type*) where
   /-- The exponent a rule inserts. -/
   exponent : R → F

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -44,8 +44,7 @@ after which the selection theorems of `Select.lean` apply to `MyRule`.
 namespace Morphology
 
 /-- Terms of `R` are rules of exponence with an exponent in `F` and an
-applicability condition on `Ctx`. This is `SetLike` without injectivity:
-distinct rules may share a condition while carrying different exponents. -/
+applicability condition on `Ctx`. -/
 class Exponence (R : Type*) (Ctx F : outParam Type*) where
   /-- The exponent a rule inserts. -/
   exponent : R → F

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -4,41 +4,40 @@ import Mathlib.Data.Set.Basic
 /-!
 # Rules of exponence
 
-This file defines the `Exponence` typeclass, pairing an exponent
-`exponent : R → F` with an applicability condition `Applies : R → Ctx → Prop`
+This file defines the `Exponence.Rule` typeclass, pairing an exponent
+`exponent : R → E` with an applicability condition `Applies : R → Ctx → Prop`
 ([matthews-1991]), and the specificity preorder it induces.
 
 ## Main definitions
 
-* `Exponence`: the exponent-plus-applicability interface.
+* `Exponence.Rule`: the exponent-plus-applicability interface.
 * `Exponence.toPreorder`: the specificity preorder ([kiparsky-1973]'s
   Elsewhere Condition); not an instance — each engine installs it on its
   own carrier.
 -/
 
-namespace Morphology
+namespace Morphology.Exponence
 
-/-- Terms of `R` are rules of exponence with an exponent in `F` and an
-applicability condition on `Ctx`. -/
-class Exponence (R : Type*) (Ctx F : outParam Type*) where
+/-- `Rule R Ctx E` says that `R` is a type of rules of exponence: each rule
+carries an exponent in `E` and applies in a class of contexts in `Ctx`. -/
+class Rule (R : Type*) (Ctx E : outParam Type*) where
   /-- The exponent a rule inserts. -/
-  exponent : R → F
+  exponent : R → E
   /-- The condition on contexts under which a rule applies. -/
   Applies : R → Ctx → Prop
 
-namespace Exponence
+export Rule (exponent Applies)
 
-variable {Ctx F : Type*} {R : Type*} [Exponence R Ctx F]
+variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E]
 
 /-- The contexts in which a rule applies. -/
-def applySet (r : R) : Set Ctx := {c | Applies (F := F) r c}
+def applySet (r : R) : Set Ctx := {c | Applies r c}
 
 @[simp] theorem mem_applySet {r : R} {c : Ctx} :
-    c ∈ applySet (F := F) r ↔ Applies (F := F) r c :=
+    c ∈ applySet r ↔ Applies r c :=
   Iff.rfl
 
 /-- `r ≤ s` when `r` applies in a subset of the contexts `s` applies in. -/
-@[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (F := F))
+@[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (Ctx := Ctx) (E := E))
 
-end Exponence
-end Morphology
+end Morphology.Exponence

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -28,10 +28,6 @@ class Rule (R : Type*) (Ctx E : outParam Type*) where
 
 export Rule (exponent Applies)
 
-/-- Decidable applicability, making selection computable. -/
-abbrev DecidableApplies (R : Type*) (Ctx : Type*) {E : Type*} [Rule R Ctx E] :=
-  ∀ c : Ctx, DecidablePred (fun r : R => Applies r c)
-
 variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E]
 
 /-- The contexts in which a rule applies. -/

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -4,41 +4,16 @@ import Mathlib.Data.Set.Basic
 /-!
 # Rules of exponence
 
-A rule of exponence pairs an exponent with the class of contexts in which
-it may be inserted; exponence is [matthews-1991]'s term for the mapping
-from morphosyntactic content to form. The `Exponence` typeclass provides a
-unified interface to this shape: an exponent projection `exponent : R → F`
-and an applicability condition `Applies : R → Ctx → Prop`.
+This file defines the `Exponence` typeclass, pairing an exponent
+`exponent : R → F` with an applicability condition `Applies : R → Ctx → Prop`
+([matthews-1991]), and the specificity preorder it induces.
 
-Specificity is applicability-set inclusion: `r ≤ s` when `r` applies in a
-subset of the contexts `s` applies in. This is [kiparsky-1973]'s Elsewhere
-Condition as an order, in [stump-2022]'s single-clause formulation of
-Pāṇini's principle; [stump-2001]'s two-clause rule narrowness collapses to
-it when contexts pair expressions with their full property sets. Distinct
-rules may share an applicability condition while carrying different
-exponents, so the induced order is a preorder and not a partial order. It
-is provided as `Exponence.toPreorder` and is not an instance, for
-flexibility in choosing orders: each engine installs it, or a
-definitionally equal order, on its own carrier.
+## Main definitions
 
-The class is selection-side only: the phonological substance of exponents
-([trommer-zimmermann-2015]) is opaque in `F`. Selection over this order is
-`Morphology/Exponence/Select.lean`.
-
-A typical engine is declared as:
-```
-instance : Exponence (MyRule Ctx F) Ctx F :=
-  ⟨MyRule.exponent, fun r c => r.condition c⟩
-
-instance : Preorder (MyRule Ctx F) := Exponence.toPreorder
-```
-after which the selection theorems of `Select.lean` apply to `MyRule`.
-
-## Main declarations
-
-* `Exponence` — the exponent-plus-applicability interface.
-* `Exponence.applySet`, `Exponence.toPreorder` — a rule's applicability set
-  and the specificity preorder it induces.
+* `Exponence`: the exponent-plus-applicability interface.
+* `Exponence.toPreorder`: the specificity preorder ([kiparsky-1973]'s
+  Elsewhere Condition); not an instance — each engine installs it on its
+  own carrier.
 -/
 
 namespace Morphology

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -22,9 +22,7 @@ flexibility in choosing orders: each engine installs it, or a
 definitionally equal order, on its own carrier.
 
 The class is selection-side only: the phonological substance of exponents
-— additive, transformational, templatic ([trommer-zimmermann-2015]) — is
-opaque in `F` and lives in `Phonology/`. Selection over the specificity
-order (existence, coherence, and the prediction relation) is
+([trommer-zimmermann-2015]) is opaque in `F`. Selection over this order is
 `Morphology/Exponence/Select.lean`.
 
 A typical engine is declared as:
@@ -46,12 +44,9 @@ after which the selection theorems of `Select.lean` apply to `MyRule`.
 namespace Morphology
 
 /-- `Exponence R Ctx F` states that terms of `R` are rules of exponence:
-each carries an exponent in `F` and applies in a class of contexts in
-`Ctx`. This is `SetLike` without injectivity: the projection to
-applicability sets (`applySet`) need not be injective, since distinct
-rules may share a condition while carrying different exponents. The
-primitive is the predicate `Applies`, which is what engines define and
-what decidability instances attach to. -/
+an exponent in `F` and an applicability condition on `Ctx`. This is
+`SetLike` without injectivity: distinct rules may share a condition while
+carrying different exponents. -/
 class Exponence (R : Type*) (Ctx F : outParam Type*) where
   /-- The exponent a rule inserts. -/
   exponent : R → F
@@ -70,10 +65,9 @@ def applySet (r : R) : Set Ctx := {c | Applies (F := F) r c}
   Iff.rfl
 
 /-- The specificity preorder: `r ≤ s` when `r` applies in a subset of the
-contexts `s` applies in. Rules with the same applicability but different
-exponents are equivalent, not equal, so this is only a preorder. This is
-not an instance, for flexibility in choosing orders: each engine installs
-it, or a definitionally equal order, on its own carrier. -/
+contexts `s` applies in. Only a preorder, since rules may share
+applicability without being equal; not an instance, for flexibility in
+choosing orders. -/
 @[reducible] def toPreorder : Preorder R := Preorder.lift (applySet (F := F))
 
 end Exponence

--- a/Linglib/Morphology/Exponence/Basic.lean
+++ b/Linglib/Morphology/Exponence/Basic.lean
@@ -25,12 +25,12 @@ class Rule (R : Type*) (Ctx E : outParam Type*) where
   exponent : R → E
   /-- The condition on contexts under which a rule applies. -/
   Applies : R → Ctx → Prop
-  /-- Applicability is decidable, so selection is computable. -/
-  [dec : ∀ c, DecidablePred (Applies · c)]
-
-attribute [instance] Rule.dec
 
 export Rule (exponent Applies)
+
+/-- Decidable applicability, making selection computable. -/
+abbrev DecidableApplies (R : Type*) (Ctx : Type*) {E : Type*} [Rule R Ctx E] :=
+  ∀ c : Ctx, DecidablePred (fun r : R => Applies r c)
 
 variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E]
 

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -140,6 +140,9 @@ instance : Rule (SpanRule n F) (Fin n) F :=
 
 instance : Preorder (SpanRule n F) := Exponence.toPreorder
 
+instance : DecidableApplies (SpanRule n F) (Fin n) :=
+  fun g it => inferInstanceAs (Decidable (it.threshold ≤ g))
+
 /-- Subset applicability is threshold containment. -/
 @[simp] theorem SpanRule.applies_iff {it : SpanRule n F} {g : Fin n} :
     Exponence.Applies it g ↔ it.threshold ≤ g :=
@@ -189,6 +192,9 @@ instance : Rule (SupersetRule n F) (Fin n) F :=
   ⟨SpanRule.exponent, fun it i => i ≤ SpanRule.spans it⟩
 
 instance : Preorder (SupersetRule n F) := Exponence.toPreorder
+
+instance : DecidableApplies (SupersetRule n F) (Fin n) :=
+  fun g it => inferInstanceAs (Decidable (g ≤ SpanRule.spans it))
 
 /-- Read an exponence rule under the Superset reading. -/
 def SpanRule.superset (it : SpanRule n F) : SupersetRule n F := it

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -9,7 +9,7 @@ The carrier for the realizational engine of [bobaljik-2012]'s
 comparative-suppletion generalizations, over an arbitrary `n`-grade
 containment hierarchy. An `SpanRule` realizes the initial span `[0, spans]`
 of the hierarchy, optionally conditioned on a higher head. One carrier
-carries two `Exponence` views: the **Subset** reading (`SpanRule`,
+carries two `Exponence.Rule` views: the **Subset** reading (`SpanRule`,
 applicability is threshold containment) is DM Elsewhere insertion; the
 **Superset** reading (`SupersetRule`, applicability is constituent
 containment) is nanosyntax spellout, dual à la `OrderDual`.
@@ -131,21 +131,21 @@ instance (v : List (SpanRule n F)) : Decidable (ContextFree v) := by
 
 /-! ### The Subset reading: DM Elsewhere insertion
 
-The containment engine implements `Morphology.Exponence`
+The containment engine implements `Morphology.Exponence.Rule`
 directly: applicability is threshold containment (the upper set
 `Set.Ici threshold`) and derived specificity is threshold comparison. -/
 
-instance : Exponence (SpanRule n F) (Fin n) F :=
+instance : Rule (SpanRule n F) (Fin n) F :=
   ⟨SpanRule.exponent, fun it i => it.threshold ≤ i⟩
 
 instance : Preorder (SpanRule n F) := Exponence.toPreorder
 
-instance (g : Fin n) : DecidablePred (fun it : SpanRule n F => Exponence.Applies (F := F) it g) :=
+instance (g : Fin n) : DecidablePred (fun it : SpanRule n F => Exponence.Applies it g) :=
   fun it => inferInstanceAs (Decidable (it.threshold ≤ g))
 
 /-- Subset applicability is threshold containment. -/
 @[simp] theorem SpanRule.applies_iff {it : SpanRule n F} {g : Fin n} :
-    Exponence.Applies (F := F) it g ↔ it.threshold ≤ g :=
+    Exponence.Applies it g ↔ it.threshold ≤ g :=
   Iff.rfl
 
 /-- Containment specificity is the shared core's specificity order. -/
@@ -159,7 +159,7 @@ One carrier, a dual view: the entry can spell out grade `g` when its
 stored constituent contains `g` (the down-set `Set.Iic spans`), and
 smallest-match selection is Pāṇinian specificity under superset
 matching. A distinct type synonym so the two readings carry different
-`Exponence` instances on one carrier, mirroring `OrderDual`. -/
+`Exponence.Rule` instances on one carrier, mirroring `OrderDual`. -/
 
 /-- The **Superset Principle** ([starke-2009]): an entry can spell out
 grade `g` when the constituent it stores contains grade `g`'s
@@ -188,13 +188,13 @@ grade `g` when its stored constituent contains `g` (the down-set
 `Set.Iic spans`), dually to the Subset reading of `SpanRule`. -/
 def SupersetRule (n : ℕ) (F : Type*) := SpanRule n F
 
-instance : Exponence (SupersetRule n F) (Fin n) F :=
+instance : Rule (SupersetRule n F) (Fin n) F :=
   ⟨SpanRule.exponent, fun it i => i ≤ SpanRule.spans it⟩
 
 instance : Preorder (SupersetRule n F) := Exponence.toPreorder
 
 instance (g : Fin n) :
-    DecidablePred (fun it : SupersetRule n F => Exponence.Applies (F := F) it g) :=
+    DecidablePred (fun it : SupersetRule n F => Exponence.Applies it g) :=
   fun it => inferInstanceAs (Decidable (g ≤ SpanRule.spans it))
 
 /-- Read an exponence rule under the Superset reading. -/
@@ -202,7 +202,7 @@ def SpanRule.superset (it : SpanRule n F) : SupersetRule n F := it
 
 /-- Superset applicability is constituent containment. -/
 @[simp] theorem SupersetRule.applies_iff {it : SupersetRule n F} {g : Fin n} :
-    Exponence.Applies (F := F) it g ↔ g ≤ SpanRule.spans it :=
+    Exponence.Applies it g ↔ g ≤ SpanRule.spans it :=
   Iff.rfl
 
 /-- Minimize Junk is the Superset reading's specificity order: smaller

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -140,8 +140,8 @@ instance : Rule (SpanRule n F) (Fin n) F :=
 
 instance : Preorder (SpanRule n F) := Exponence.toPreorder
 
-instance : DecidableApplies (SpanRule n F) (Fin n) :=
-  fun g it => inferInstanceAs (Decidable (it.threshold ≤ g))
+instance : DecidableRel (Applies : SpanRule n F → Fin n → Prop) :=
+  fun it g => inferInstanceAs (Decidable (it.threshold ≤ g))
 
 /-- Subset applicability is threshold containment. -/
 @[simp] theorem SpanRule.applies_iff {it : SpanRule n F} {g : Fin n} :
@@ -193,8 +193,8 @@ instance : Rule (SupersetRule n F) (Fin n) F :=
 
 instance : Preorder (SupersetRule n F) := Exponence.toPreorder
 
-instance : DecidableApplies (SupersetRule n F) (Fin n) :=
-  fun g it => inferInstanceAs (Decidable (g ≤ SpanRule.spans it))
+instance : DecidableRel (Applies : SupersetRule n F → Fin n → Prop) :=
+  fun it g => inferInstanceAs (Decidable (g ≤ SpanRule.spans it))
 
 /-- Read an exponence rule under the Superset reading. -/
 def SpanRule.superset (it : SpanRule n F) : SupersetRule n F := it

--- a/Linglib/Morphology/Exponence/Containment/Defs.lean
+++ b/Linglib/Morphology/Exponence/Containment/Defs.lean
@@ -140,9 +140,6 @@ instance : Rule (SpanRule n F) (Fin n) F :=
 
 instance : Preorder (SpanRule n F) := Exponence.toPreorder
 
-instance (g : Fin n) : DecidablePred (fun it : SpanRule n F => Exponence.Applies it g) :=
-  fun it => inferInstanceAs (Decidable (it.threshold ≤ g))
-
 /-- Subset applicability is threshold containment. -/
 @[simp] theorem SpanRule.applies_iff {it : SpanRule n F} {g : Fin n} :
     Exponence.Applies it g ↔ it.threshold ≤ g :=
@@ -192,10 +189,6 @@ instance : Rule (SupersetRule n F) (Fin n) F :=
   ⟨SpanRule.exponent, fun it i => i ≤ SpanRule.spans it⟩
 
 instance : Preorder (SupersetRule n F) := Exponence.toPreorder
-
-instance (g : Fin n) :
-    DecidablePred (fun it : SupersetRule n F => Exponence.Applies it g) :=
-  fun it => inferInstanceAs (Decidable (g ≤ SpanRule.spans it))
 
 /-- Read an exponence rule under the Superset reading. -/
 def SpanRule.superset (it : SpanRule n F) : SupersetRule n F := it

--- a/Linglib/Morphology/Exponence/Containment/Selection.lean
+++ b/Linglib/Morphology/Exponence/Containment/Selection.lean
@@ -421,8 +421,8 @@ def SpanRule.toDecomposition (it : SpanRule n F) :
 /-- **Applicability agreement**: threshold containment is Subset containment of
 initial segments. -/
 @[simp] theorem applies_toDecomposition {it : SpanRule n F} {g : Fin n} :
-    Exponence.Applies (F := F) it.toDecomposition g
-      ↔ Exponence.Applies (F := F) it g := by
+    Exponence.Applies it.toDecomposition g
+      ↔ Exponence.Applies it g := by
   rw [SpanRule.applies_iff]; exact Finset.Iic_subset_Iic
 
 /-- The feature count of a chain rule is one more than its threshold, so

--- a/Linglib/Morphology/Exponence/Containment/Selection.lean
+++ b/Linglib/Morphology/Exponence/Containment/Selection.lean
@@ -223,14 +223,18 @@ theorem realize_eq_none_iff {v : List (SpanRule n F)} {g : Fin n} :
   show (winner v g).map _ = none ↔ _
   cases winner v g <;> simp
 
+/-- The threshold is strictly antitone in specificity. -/
+private theorem threshold_strictAnti {n : ℕ} {F : Type*} :
+    StrictAnti (SpanRule.threshold (n := n) (F := F)) := fun _ _ hlt =>
+  lt_of_not_ge fun hge => not_le_of_gt hlt
+    ((SpanRule.le_iff.trans SpanRule.moreSpecific_iff_threshold_le).mpr hge)
+
 /-- The containment engine's Elsewhere winner is an Elsewhere winner of
 the shared core — an instance of `selectBy_isElsewhereWinner`. -/
 theorem winner_isElsewhereWinner {v : List (SpanRule n F)} {g : Fin n}
     {it : SpanRule n F} (h : winner v g = some it) :
     Exponence.IsElsewhereWinner v g it :=
-  Exponence.selectBy_isElsewhereWinner
-    (fun _ _ _ _ _ _ _ hfs =>
-      (SpanRule.le_iff.trans SpanRule.moreSpecific_iff_threshold_le).mpr hfs) h
+  Exponence.selectBy_isElsewhereWinner (threshold_strictAnti.strictAntiOn _) h
 
 /-! ### Superset reading: Minimize-Junk selection
 

--- a/Linglib/Morphology/Exponence/Decomposition.lean
+++ b/Linglib/Morphology/Exponence/Decomposition.lean
@@ -50,8 +50,8 @@ variable {Cell F : Type*} {D : Cell → Finset K}
 instance : Exponence.Rule (Rule Cell D F) Cell F :=
   ⟨Rule.exponent, fun r c => r.feats ⊆ D c⟩
 
-instance : Exponence.DecidableApplies (Rule Cell D F) Cell :=
-  fun c r => inferInstanceAs (Decidable (r.feats ⊆ D c))
+instance : DecidableRel (Exponence.Applies : Rule Cell D F → Cell → Prop) :=
+  fun r c => inferInstanceAs (Decidable (r.feats ⊆ D c))
 
 omit [DecidableEq K] in
 @[simp] theorem applies_iff {r : Rule Cell D F} {c : Cell} :

--- a/Linglib/Morphology/Exponence/Decomposition.lean
+++ b/Linglib/Morphology/Exponence/Decomposition.lean
@@ -47,15 +47,15 @@ structure Rule (Cell : Type*) (D : Cell → Finset K) (F : Type*) where
 
 variable {Cell F : Type*} {D : Cell → Finset K}
 
-instance : Exponence (Rule Cell D F) Cell F :=
+instance : Exponence.Rule (Rule Cell D F) Cell F :=
   ⟨Rule.exponent, fun r c => r.feats ⊆ D c⟩
 
 omit [DecidableEq K] in
 @[simp] theorem applies_iff {r : Rule Cell D F} {c : Cell} :
-    Exponence.Applies (F := F) r c ↔ r.feats ⊆ D c := Iff.rfl
+    Exponence.Applies r c ↔ r.feats ⊆ D c := Iff.rfl
 
 instance (c : Cell) :
-    DecidablePred (fun r : Rule Cell D F => Exponence.Applies (F := F) r c) :=
+    DecidablePred (fun r : Rule Cell D F => Exponence.Applies r c) :=
   fun r => inferInstanceAs (Decidable (r.feats ⊆ D c))
 
 /-- The specificity preorder: applicability-set inclusion, so the engine
@@ -68,7 +68,7 @@ omit [DecidableEq K] in
 /-- Specificity unfolds to applicability-set inclusion: `r ≤ s` iff `r` applies
 wherever `s` does. -/
 theorem le_iff {r s : Rule Cell D F} :
-    r ≤ s ↔ ∀ ⦃c⦄, Exponence.Applies (F := F) r c → Exponence.Applies (F := F) s c :=
+    r ≤ s ↔ ∀ ⦃c⦄, Exponence.Applies r c → Exponence.Applies s c :=
   Iff.rfl
 
 /-- The surface pattern of a vocabulary: at each cell, the exponent of the most

--- a/Linglib/Morphology/Exponence/Decomposition.lean
+++ b/Linglib/Morphology/Exponence/Decomposition.lean
@@ -50,6 +50,10 @@ variable {Cell F : Type*} {D : Cell → Finset K}
 instance : Exponence.Rule (Rule Cell D F) Cell F :=
   ⟨Rule.exponent, fun r c => r.feats ⊆ D c⟩
 
+instance : Exponence.DecidableApplies (Rule Cell D F) Cell :=
+  fun c r => inferInstanceAs (Decidable (r.feats ⊆ D c))
+
+omit [DecidableEq K] in
 @[simp] theorem applies_iff {r : Rule Cell D F} {c : Cell} :
     Exponence.Applies r c ↔ r.feats ⊆ D c := Iff.rfl
 
@@ -59,6 +63,7 @@ participates in the shared core's Elsewhere selection theory
 preorder — incomparable specifications (No Case Containment) are the point. -/
 instance : Preorder (Rule Cell D F) := Exponence.toPreorder
 
+omit [DecidableEq K] in
 /-- Specificity unfolds to applicability-set inclusion: `r ≤ s` iff `r` applies
 wherever `s` does. -/
 theorem le_iff {r s : Rule Cell D F} :

--- a/Linglib/Morphology/Exponence/Decomposition.lean
+++ b/Linglib/Morphology/Exponence/Decomposition.lean
@@ -50,13 +50,8 @@ variable {Cell F : Type*} {D : Cell → Finset K}
 instance : Exponence.Rule (Rule Cell D F) Cell F :=
   ⟨Rule.exponent, fun r c => r.feats ⊆ D c⟩
 
-omit [DecidableEq K] in
 @[simp] theorem applies_iff {r : Rule Cell D F} {c : Cell} :
     Exponence.Applies r c ↔ r.feats ⊆ D c := Iff.rfl
-
-instance (c : Cell) :
-    DecidablePred (fun r : Rule Cell D F => Exponence.Applies r c) :=
-  fun r => inferInstanceAs (Decidable (r.feats ⊆ D c))
 
 /-- The specificity preorder: applicability-set inclusion, so the engine
 participates in the shared core's Elsewhere selection theory
@@ -64,7 +59,6 @@ participates in the shared core's Elsewhere selection theory
 preorder — incomparable specifications (No Case Containment) are the point. -/
 instance : Preorder (Rule Cell D F) := Exponence.toPreorder
 
-omit [DecidableEq K] in
 /-- Specificity unfolds to applicability-set inclusion: `r ≤ s` iff `r` applies
 wherever `s` does. -/
 theorem le_iff {r s : Rule Cell D F} :

--- a/Linglib/Morphology/Exponence/Elsewhere.lean
+++ b/Linglib/Morphology/Exponence/Elsewhere.lean
@@ -1,0 +1,70 @@
+import Linglib.Morphology.Exponence.Basic
+import Mathlib.Order.Antisymmetrization
+import Mathlib.Order.Preorder.Finite
+import Mathlib.Data.Set.Finite.Basic
+
+/-!
+# The Elsewhere Condition
+
+This file defines Elsewhere winners — `≤`-minimal applicable rules of
+exponence under the specificity preorder ([kiparsky-1973]) — and the
+prediction relation they induce.
+
+## Main definitions
+
+* `IsElsewhereWinner`: a `≤`-minimal applicable rule of a vocabulary at a
+  context.
+* `Coherent`: equivalent rules carry the same exponent.
+* `Realizes`: some Elsewhere winner carries the given exponent.
+-/
+
+namespace Morphology.Exponence
+
+variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E] [Preorder R]
+variable {v : List R} {c : Ctx} {r s : R} {φ : E}
+
+/-! ### Elsewhere winners -/
+
+/-- Two comparable minimal elements of the same predicate are equivalent.
+[UPSTREAM] candidate for `Mathlib/Order/Minimal.lean`. -/
+theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} {x y : α}
+    (hx : Minimal P x) (hy : Minimal P y) (h : y ≤ x ∨ x ≤ y) :
+    AntisymmRel (· ≤ ·) x y :=
+  h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
+
+/-- A `≤`-minimal applicable rule of `v` at `c`. -/
+abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
+  Minimal (fun s => s ∈ v ∧ Applies s c) r
+
+/-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
+def Coherent (v : List R) : Prop :=
+  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
+    exponent r = exponent s
+
+/-- Comparable winners of a coherent vocabulary carry the same exponent. -/
+theorem IsElsewhereWinner.exponent_eq
+    (hv : Coherent v) (hr : IsElsewhereWinner v c r)
+    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
+    exponent r = exponent s :=
+  hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
+
+/-- A vocabulary with an applicable rule has an Elsewhere winner. -/
+theorem exists_isElsewhereWinner
+    (h : ∃ r ∈ v, Applies r c) : ∃ r, IsElsewhereWinner v c r :=
+  (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
+
+/-! ### The prediction relation -/
+
+/-- `φ` is realized at `c` when some Elsewhere winner carries it. -/
+def Realizes (v : List R) (c : Ctx) (φ : E) : Prop :=
+  ∃ r, IsElsewhereWinner v c r ∧ exponent r = φ
+
+/-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
+theorem Realizes.eq {ψ : E} (hv : Coherent v)
+    (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
+    (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
+  obtain ⟨r, hr, rfl⟩ := hφ
+  obtain ⟨s, hs, rfl⟩ := hψ
+  exact hr.exponent_eq hv hs (hcmp hr hs)
+
+end Morphology.Exponence

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -7,37 +7,36 @@ import Mathlib.Data.List.MinMax
 /-!
 # Elsewhere selection over rules of exponence
 
-Selection over the specificity preorder of `Morphology/Exponence/Basic.lean`.
-An **Elsewhere winner** is a `≤`-minimal applicable rule; over a coherent
-vocabulary comparable winners select one exponent, so the prediction relation
-`Realizes` is well defined up to incomparability. `selectBy` computes a winner
-by optimizing a specificity **score** `f : R → α` into a linear order — the
-common shape of every framework engine's competition (`argmax` over the
-applicable sublist; min-scores enter via `OrderDual`). Its soundness law
-`selectBy_isElsewhereWinner` discharges each engine's winner-is-Elsewhere
-theorem from that engine's score-reflection lemma. The order/select/realize
-triad: `Basic` orders rules by specificity, `selectBy` selects the optimal
-applicable rule, `realize` reads off its exponent. The theory models
-selection within a single rule block; realizational frameworks compose
-per-block winners into the paradigm function ([stump-2001]). Since
-`Realizes.eq` makes the per-block prediction unique, *optional* multiple
-exponence within a block (free co-realization variants, Jubba Maay —
-[trommer-zimmermann-2015] p. 60) is outside scope, not merely a
-multi-block composition matter; deterministic symbiotic co-exponence
-composes across blocks as usual. That specificity is itself the Elsewhere
-criterion is not beyond question: [jackendoff-audring-2020] note for the
-overlapping `-ious` allomorph that the overlapped variant is not clearly more
-specific than the plain one, and suggest markedness or non-canonicity may be
-the operative criterion in that single case.
+This file defines Elsewhere selection over the specificity preorder of
+`Morphology/Exponence/Basic.lean`. An Elsewhere winner is a `≤`-minimal
+applicable rule. Over a coherent vocabulary, comparable winners carry one
+exponent, so the prediction relation `Realizes` is well defined up to
+incomparability.
+
+`selectBy` computes a winner by maximizing a score `f : R → α` into a
+linear order over the applicable sublist; scores that are minimized enter
+through `OrderDual`. Its soundness law `selectBy_isElsewhereWinner` reduces
+an engine's winner-is-Elsewhere theorem to that engine's score-reflection
+lemma. `selectMinimal` selects directly over the preorder, for engines
+whose specificity has no faithful score.
+
+The theory models selection within a single rule block; realizational
+frameworks compose per-block winners into the paradigm function
+([stump-2001]). Optional multiple exponence within a block (Jubba Maay,
+[trommer-zimmermann-2015]) is outside scope, since `Realizes.eq` makes the
+per-block prediction unique. Whether specificity is the Elsewhere criterion
+is itself not beyond question: [jackendoff-audring-2020] suggest markedness
+may operate in the overlapping `-ious` case.
 
 ## Main declarations
 
-* `IsElsewhereWinner`, `Coherent`, `exists_isElsewhereWinner` — the Prop
-  selection theory: minimality, coherence, existence
-* `Realizes` — the framework-neutral prediction relation
-* `selectBy`, `realize` — score selection and the realized exponent
-* `selectBy_isElsewhereWinner`, `realize_realizes` — score selection is
-  Elsewhere selection
+* `IsElsewhereWinner`, `Coherent`, `exists_isElsewhereWinner` — minimality,
+  coherence, and existence of winners.
+* `Realizes` — the framework-neutral prediction relation.
+* `selectBy`, `realize`, `selectBy_isElsewhereWinner`, `realize_realizes` —
+  score selection and its soundness.
+* `selectMinimal`, `selectMinimal_isElsewhereWinner` — order selection and
+  its soundness.
 -/
 
 namespace Morphology.Exponence
@@ -46,9 +45,8 @@ variable {Ctx F : Type*} {R : Type*} [Preorder R] [Exponence R Ctx F]
 
 /-! ### Elsewhere winners -/
 
-/-- An **Elsewhere winner** for vocabulary `v` at context `c`: a
-`≤`-minimal applicable member of `v` — no applicable rule in `v` is
-strictly more specific. -/
+/-- An Elsewhere winner for `v` at `c` is a `≤`-minimal applicable member
+of `v`: no applicable rule in `v` is strictly more specific. -/
 def IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
   Minimal (fun s => s ∈ v ∧ Exponence.Applies (F := F) s c) r
 
@@ -69,11 +67,10 @@ theorem IsElsewhereWinner.antisymmRel {v : List R} {c : Ctx} {r s : R}
   · exact ⟨hr.le_of_le hs.1.1 hs.1.2 h, h⟩
   · exact ⟨h, hs.le_of_le hr.1.1 hr.1.2 h⟩
 
-/-- A **coherent** vocabulary assigns equivalent rules the same
-exponent, so the exponent descends to the antisymmetrization of the
-specificity preorder ([caha-2009]-style antihomophony, stated
-order-theoretically). Incomparable competitors are tolerated, where
-[stump-2001]'s Pāṇinian Determinism Hypothesis forbids them. -/
+/-- A vocabulary is coherent if equivalent rules carry the same exponent,
+so that the exponent descends to the antisymmetrization of the specificity
+preorder ([caha-2009]'s antihomophony). Incomparable competitors are
+tolerated, where [stump-2001]'s Pāṇinian Determinism forbids them. -/
 def Coherent (v : List R) : Prop :=
   ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
     Exponence.exponent (F := F) r = Exponence.exponent (F := F) s
@@ -95,8 +92,7 @@ theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
 
 /-! ### The prediction relation -/
 
-/-- The framework-neutral prediction: `φ` is realized at `c` when some
-Elsewhere winner carries it. -/
+/-- `φ` is realized at `c` when some Elsewhere winner carries it. -/
 def Realizes (v : List R) (c : Ctx) (φ : F) : Prop :=
   ∃ r, IsElsewhereWinner v c r ∧ Exponence.exponent (F := F) r = φ
 
@@ -111,10 +107,9 @@ theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : F} (hv : Coherent v)
 
 /-! ### Score selection
 
-For a specificity **score** `f : R → α` into a linear order, `selectBy`
-picks the applicable rule of greatest score. Engines whose score is
-minimized (span, tree size, `Finsupp`-support card) pass it through
-`OrderDual α`. -/
+For a specificity score `f : R → α` into a linear order, `selectBy` picks
+the applicable rule of greatest score. Scores that are minimized (span,
+tree size, support card) pass through `OrderDual α`. -/
 
 variable [∀ c : Ctx, DecidablePred (fun r : R => Exponence.Applies (F := F) r c)]
 
@@ -129,9 +124,8 @@ omit [Preorder R] in
 
 variable {α : Type*} [LinearOrder α]
 
-/-- Selection by specificity score: the applicable rule of `v` at `c`
-with greatest score `f`, ties broken by vocabulary order (`⊥` when
-nothing applies). -/
+/-- The applicable rule of `v` at `c` with greatest score `f`, ties broken
+by vocabulary order, or `none` when nothing applies. -/
 def selectBy (f : R → α) (v : List R) (c : Ctx) : Option R :=
   (applicable v c).argmax f
 
@@ -161,13 +155,10 @@ theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
   (hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp).mpr
     (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
-/-- **Soundness**: a score reflecting specificity contravariantly on
-comparable applicable rules selects an Elsewhere winner. Only the
-conditional (`mpr`) direction is needed — argmax supplies `f s ≤ f r`
-and minimality supplies `s ≤ r`, so `hf` just closes `r ≤ s`.
-Linear-domain engines discharge `hf` from the `mpr` of their `le_iff`;
-`Finset`-support engines, where card `≤` does not imply support `⊆`,
-discharge it via `Finset.eq_of_subset_of_card_le`. -/
+/-- A score that reflects specificity contravariantly on comparable
+applicable rules selects an Elsewhere winner. Engines discharge `hf` from
+the `mpr` of their `le_iff`, or via `Finset.eq_of_subset_of_card_le` where
+card `≤` does not imply support `⊆`. -/
 theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
     (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
       Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
@@ -186,12 +177,12 @@ theorem selectBy_congr {f : R → α} {v : List R} {c c' : Ctx}
 
 /-! ### Realization -/
 
-/-- The realized exponent: the score-selected winner's exponent
-(`none` when no rule applies). -/
+/-- The exponent of the score-selected winner, or `none` when no rule
+applies. -/
 def realize (f : R → α) (v : List R) (c : Ctx) : Option F :=
   (selectBy f v c).map (Exponence.exponent (F := F))
 
-/-- A realized exponent is genuinely predicted: it is `Realizes`. -/
+/-- Realized exponents satisfy the prediction relation `Realizes`. -/
 theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : F}
     (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
       Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
@@ -214,17 +205,15 @@ theorem realize_congr {f : R → α} {v : List R} {c c' : Ctx}
 
 /-! ### Order selection
 
-Where `selectBy` optimizes a linear specificity **score**, `selectMinimal`
-selects directly over the specificity preorder: the first applicable rule that
-no applicable rule strictly undercuts. This is the order-driven dual of
-`selectBy`, for engines whose specificity is a genuine preorder rather than a
-linear score (the PFM narrowness order, `Morphology/Paradigm/Function.lean`,
-where an intensionally finer class/property order has no faithful score). -/
+`selectMinimal` selects directly over the specificity preorder: the first
+applicable rule that no applicable rule strictly undercuts. It serves
+engines whose specificity is a genuine preorder with no faithful score,
+such as the PFM narrowness order of `Morphology/Paradigm/Function.lean`. -/
 
 variable [DecidableRel (· < · : R → R → Prop)]
 
-/-- Selection by specificity order: the first applicable rule of `v` at `c`
-that no applicable rule strictly undercuts (`none` when nothing applies). -/
+/-- The first applicable rule of `v` at `c` that no applicable rule
+strictly undercuts, or `none` when nothing applies. -/
 def selectMinimal (v : List R) (c : Ctx) : Option R :=
   (applicable v c).find? (fun r => (applicable v c).all (fun s => decide (¬ s < r)))
 
@@ -236,8 +225,7 @@ theorem selectMinimal_applies {v : List R} {c : Ctx} {r : R}
     (h : selectMinimal v c = some r) : Exponence.Applies (F := F) r c :=
   (mem_applicable.mp (List.mem_of_find?_eq_some h)).2
 
-/-- A selected rule is an Elsewhere winner: applicable and `≤`-minimal. The
-all-check discharges minimality — no applicable rule strictly undercuts it. -/
+/-- A selected rule is an Elsewhere winner. -/
 theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
     (h : selectMinimal v c = some r) : IsElsewhereWinner v c r := by
   refine ⟨mem_applicable.mp (List.mem_of_find?_eq_some h), ?_⟩
@@ -249,9 +237,7 @@ theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
   rw [decide_eq_true_eq] at hns
   exact hns (lt_of_le_not_ge hsr hrs)
 
-/-- A vocabulary with an applicable rule selects one — the order-selection
-counterpart of `exists_isElsewhereWinner`, the winner witnessing `find?`
-succeeds. -/
+/-- A vocabulary with an applicable rule selects one. -/
 theorem selectMinimal_isSome_of_exists_applicable {v : List R} {c : Ctx}
     (h : ∃ r ∈ v, Exponence.Applies (F := F) r c) : (selectMinimal v c).isSome := by
   obtain ⟨r, hr⟩ := exists_isElsewhereWinner h

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -1,7 +1,4 @@
-import Linglib.Morphology.Exponence.Basic
-import Mathlib.Order.Antisymmetrization
-import Mathlib.Order.Preorder.Finite
-import Mathlib.Data.Set.Finite.Basic
+import Linglib.Morphology.Exponence.Elsewhere
 import Mathlib.Data.List.MinMax
 
 /-!
@@ -9,27 +6,25 @@ import Mathlib.Data.List.MinMax
 
 This file proves that selection by a specificity score (`selectBy`) and
 selection over the specificity preorder (`selectMinimal`) produce Elsewhere
-winners: `≤`-minimal applicable rules of exponence ([kiparsky-1973]).
+winners.
 
 ## Main definitions
 
-* `IsElsewhereWinner`: a `≤`-minimal applicable rule of a vocabulary at a
-  context.
-* `Realizes`: some Elsewhere winner carries the given exponent.
 * `selectBy`, `realize`: the applicable rule of greatest score, and its
   exponent.
 * `selectMinimal`: the first applicable rule that no applicable rule
   strictly undercuts.
+* `selectBy_isElsewhereWinner`, `selectMinimal_isElsewhereWinner`: both
+  selections produce Elsewhere winners.
 -/
 
 namespace Morphology.Exponence
 
 variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E]
+variable [DecidableRel (Applies : R → Ctx → Prop)]
 variable {v : List R} {c c' : Ctx} {r s : R} {φ : E}
 
 /-! ### Score selection -/
-
-variable [DecidableApplies R Ctx]
 
 /-- The rules of `v` applicable at `c`, in vocabulary order. -/
 def applicable (v : List R) (c : Ctx) : List R :=
@@ -71,53 +66,9 @@ theorem realize_congr (h : applicable v c = applicable v c') :
     realize f v c = realize f v c' :=
   congrArg (Option.map exponent) (selectBy_congr h)
 
-/-! ### Elsewhere winners -/
+/-! ### Soundness -/
 
 variable [Preorder R]
-
-/-- Two comparable minimal elements of the same predicate are equivalent.
-[UPSTREAM] candidate for `Mathlib/Order/Minimal.lean`. -/
-theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} {x y : α}
-    (hx : Minimal P x) (hy : Minimal P y) (h : y ≤ x ∨ x ≤ y) :
-    AntisymmRel (· ≤ ·) x y :=
-  h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
-
-/-- A `≤`-minimal applicable rule of `v` at `c`. -/
-abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
-  Minimal (fun s => s ∈ v ∧ Applies s c) r
-
-/-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
-def Coherent (v : List R) : Prop :=
-  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
-    exponent r = exponent s
-
-/-- Comparable winners of a coherent vocabulary carry the same exponent. -/
-theorem IsElsewhereWinner.exponent_eq
-    (hv : Coherent v) (hr : IsElsewhereWinner v c r)
-    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
-    exponent r = exponent s :=
-  hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
-
-/-- A vocabulary with an applicable rule has an Elsewhere winner. -/
-theorem exists_isElsewhereWinner
-    (h : ∃ r ∈ v, Applies r c) : ∃ r, IsElsewhereWinner v c r :=
-  (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
-
-/-! ### The prediction relation -/
-
-/-- `φ` is realized at `c` when some Elsewhere winner carries it. -/
-def Realizes (v : List R) (c : Ctx) (φ : E) : Prop :=
-  ∃ r, IsElsewhereWinner v c r ∧ exponent r = φ
-
-/-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
-theorem Realizes.eq {ψ : E} (hv : Coherent v)
-    (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
-    (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
-  obtain ⟨r, hr, rfl⟩ := hφ
-  obtain ⟨s, hs, rfl⟩ := hψ
-  exact hr.exponent_eq hv hs (hcmp hr hs)
-
-/-! ### Soundness -/
 
 /-- A score strictly antitone on the applicable rules selects an
 Elsewhere winner. -/

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -36,8 +36,7 @@ theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} 
     AntisymmRel (· ≤ ·) x y :=
   h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
 
-/-- A `≤`-minimal applicable rule of `v` at `c`. An abbreviation for `Minimal`,
-so the `Minimal` API (`le_of_le`, `not_lt`, `antisymmRel`, …) applies. -/
+/-- A `≤`-minimal applicable rule of `v` at `c`. -/
 abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
   Minimal (fun s => s ∈ v ∧ Applies s c) r
 

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -169,21 +169,19 @@ variable [DecidableRel (· < · : R → R → Prop)]
 def selectMinimal (v : List R) (c : Ctx) : Option R :=
   (applicable v c).find? (fun r => (applicable v c).all (fun s => decide (¬ s < r)))
 
-theorem selectMinimal_mem
-    (h : selectMinimal v c = some r) : r ∈ v :=
-  (mem_applicable.mp (List.mem_of_find?_eq_some h)).1
-
-theorem selectMinimal_applies
-    (h : selectMinimal v c = some r) : Applies r c :=
-  (mem_applicable.mp (List.mem_of_find?_eq_some h)).2
-
 /-- `selectMinimal` returns an Elsewhere winner. -/
 theorem selectMinimal_isElsewhereWinner
     (h : selectMinimal v c = some r) : IsElsewhereWinner v c r := by
   have hall := List.find?_some h
   simp only [List.all_eq_true, decide_eq_true_eq, mem_applicable] at hall
-  exact ⟨mem_applicable.mp (List.mem_of_find?_eq_some h),
-    fun s hs => not_lt_iff_le_imp_ge.mp (hall s hs)⟩
+  exact minimal_iff_forall_lt.mpr
+    ⟨mem_applicable.mp (List.mem_of_find?_eq_some h), fun s hlt hs => hall s hs hlt⟩
+
+theorem selectMinimal_mem (h : selectMinimal v c = some r) : r ∈ v :=
+  (selectMinimal_isElsewhereWinner h).prop.1
+
+theorem selectMinimal_applies (h : selectMinimal v c = some r) : Applies r c :=
+  (selectMinimal_isElsewhereWinner h).prop.2
 
 /-- `selectMinimal` succeeds iff some rule applies. -/
 theorem selectMinimal_isSome_iff :

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -25,28 +25,21 @@ winners: `≤`-minimal applicable rules of exponence ([kiparsky-1973]).
 namespace Morphology.Exponence
 
 variable {Ctx E : Type*} {R : Type*} [Preorder R] [Rule R Ctx E]
+variable {v : List R} {c c' : Ctx} {r s : R} {φ : E}
 
 /-! ### Elsewhere winners -/
 
-/-- A `≤`-minimal applicable rule of `v` at `c`. -/
-def IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
+/-- Two comparable minimal elements of the same predicate are equivalent.
+[UPSTREAM] candidate for `Mathlib/Order/Minimal.lean`. -/
+theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} {x y : α}
+    (hx : Minimal P x) (hy : Minimal P y) (h : y ≤ x ∨ x ≤ y) :
+    AntisymmRel (· ≤ ·) x y :=
+  h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
+
+/-- A `≤`-minimal applicable rule of `v` at `c`. An abbreviation for `Minimal`,
+so the `Minimal` API (`le_of_le`, `not_lt`, `antisymmRel`, …) applies. -/
+abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
   Minimal (fun s => s ∈ v ∧ Applies s c) r
-
-/-- A winner is below every applicable rule that is below it. -/
-theorem IsElsewhereWinner.le_of_le {v : List R} {c : Ctx} {r s : R}
-    (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
-    (happ : Applies s c) (h : s ≤ r) : r ≤ s :=
-  Minimal.le_of_le hr ⟨hs, happ⟩ h
-
-/-! ### Coherence and uniqueness -/
-
-/-- Comparable Elsewhere winners at the same context are equivalent. -/
-theorem IsElsewhereWinner.antisymmRel {v : List R} {c : Ctx} {r s : R}
-    (hr : IsElsewhereWinner v c r) (hs : IsElsewhereWinner v c s)
-    (h : s ≤ r ∨ r ≤ s) : AntisymmRel (· ≤ ·) r s := by
-  rcases h with h | h
-  · exact ⟨hr.le_of_le hs.1.1 hs.1.2 h, h⟩
-  · exact ⟨h, hs.le_of_le hr.1.1 hr.1.2 h⟩
 
 /-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
 def Coherent (v : List R) : Prop :=
@@ -54,14 +47,14 @@ def Coherent (v : List R) : Prop :=
     exponent r = exponent s
 
 /-- Comparable winners of a coherent vocabulary carry the same exponent. -/
-theorem IsElsewhereWinner.exponent_eq {v : List R} {c : Ctx} {r s : R}
+theorem IsElsewhereWinner.exponent_eq
     (hv : Coherent v) (hr : IsElsewhereWinner v c r)
     (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
     exponent r = exponent s :=
   hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
 
 /-- A vocabulary with an applicable rule has an Elsewhere winner. -/
-theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
+theorem exists_isElsewhereWinner
     (h : ∃ r ∈ v, Applies r c) : ∃ r, IsElsewhereWinner v c r :=
   (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
 
@@ -72,7 +65,7 @@ def Realizes (v : List R) (c : Ctx) (φ : E) : Prop :=
   ∃ r, IsElsewhereWinner v c r ∧ exponent r = φ
 
 /-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
-theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : E} (hv : Coherent v)
+theorem Realizes.eq {ψ : E} (hv : Coherent v)
     (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
     (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
   obtain ⟨r, hr, rfl⟩ := hφ
@@ -88,11 +81,11 @@ def applicable (v : List R) (c : Ctx) : List R :=
   v.filter (fun r => Applies r c)
 
 omit [Preorder R] in
-@[simp] theorem mem_applicable {v : List R} {c : Ctx} {r : R} :
+@[simp] theorem mem_applicable :
     r ∈ applicable v c ↔ r ∈ v ∧ Applies r c := by
   simp only [applicable, List.mem_filter, decide_eq_true_eq]
 
-variable {α : Type*} [LinearOrder α]
+variable {α : Type*} [LinearOrder α] {f : R → α}
 
 /-- The applicable rule of greatest score `f`, ties broken by vocabulary
 order; scores to be minimized pass through `OrderDual`. -/
@@ -100,23 +93,23 @@ def selectBy (f : R → α) (v : List R) (c : Ctx) : Option R :=
   (applicable v c).argmax f
 
 omit [Preorder R] in
-theorem selectBy_mem {f : R → α} {v : List R} {c : Ctx} {r : R}
+theorem selectBy_mem
     (h : selectBy f v c = some r) : r ∈ v :=
   (mem_applicable.mp (List.argmax_mem h)).1
 
 omit [Preorder R] in
-theorem selectBy_applies {f : R → α} {v : List R} {c : Ctx} {r : R}
+theorem selectBy_applies
     (h : selectBy f v c = some r) : Applies r c :=
   (mem_applicable.mp (List.argmax_mem h)).2
 
 omit [Preorder R] in
-theorem selectBy_eq_none_iff {f : R → α} {v : List R} {c : Ctx} :
+theorem selectBy_eq_none_iff :
     selectBy f v c = none ↔ applicable v c = [] :=
   List.argmax_eq_none
 
 /-- When the score reflects specificity, the selection is below every
 applicable rule. -/
-theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
+theorem selectBy_le_of_applies
     (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
       Applies s c → (r ≤ s ↔ f s ≤ f r))
     (h : selectBy f v c = some r) (hs : s ∈ v)
@@ -126,7 +119,7 @@ theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
 
 /-- When the score reflects specificity on comparable applicable rules,
 `selectBy` returns an Elsewhere winner. -/
-theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
+theorem selectBy_isElsewhereWinner
     (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
       Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : selectBy f v c = some r) : IsElsewhereWinner v c r := by
@@ -137,7 +130,7 @@ theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
 
 omit [Preorder R] in
 /-- Contexts with the same applicable rules select the same rule. -/
-theorem selectBy_congr {f : R → α} {v : List R} {c c' : Ctx}
+theorem selectBy_congr
     (h : applicable v c = applicable v c') :
     selectBy f v c = selectBy f v c' := by
   rw [selectBy, selectBy, h]
@@ -149,7 +142,7 @@ def realize (f : R → α) (v : List R) (c : Ctx) : Option E :=
   (selectBy f v c).map (exponent)
 
 /-- Realized exponents satisfy `Realizes`. -/
-theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : E}
+theorem realize_realizes
     (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
       Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : realize f v c = some φ) : Realizes v c φ := by
@@ -158,13 +151,13 @@ theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : E}
   exact ⟨r, selectBy_isElsewhereWinner hf hr, rfl⟩
 
 omit [Preorder R] in
-theorem realize_eq_none_iff {f : R → α} {v : List R} {c : Ctx} :
+theorem realize_eq_none_iff :
     realize f v c = none ↔ applicable v c = [] := by
   rw [realize, Option.map_eq_none_iff]
   exact selectBy_eq_none_iff
 
 omit [Preorder R] in
-theorem realize_congr {f : R → α} {v : List R} {c c' : Ctx}
+theorem realize_congr
     (h : applicable v c = applicable v c') :
     realize f v c = realize f v c' := by
   rw [realize, realize, selectBy_congr h]
@@ -177,16 +170,16 @@ variable [DecidableRel (· < · : R → R → Prop)]
 def selectMinimal (v : List R) (c : Ctx) : Option R :=
   (applicable v c).find? (fun r => (applicable v c).all (fun s => decide (¬ s < r)))
 
-theorem selectMinimal_mem {v : List R} {c : Ctx} {r : R}
+theorem selectMinimal_mem
     (h : selectMinimal v c = some r) : r ∈ v :=
   (mem_applicable.mp (List.mem_of_find?_eq_some h)).1
 
-theorem selectMinimal_applies {v : List R} {c : Ctx} {r : R}
+theorem selectMinimal_applies
     (h : selectMinimal v c = some r) : Applies r c :=
   (mem_applicable.mp (List.mem_of_find?_eq_some h)).2
 
 /-- `selectMinimal` returns an Elsewhere winner. -/
-theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
+theorem selectMinimal_isElsewhereWinner
     (h : selectMinimal v c = some r) : IsElsewhereWinner v c r := by
   have hall := List.find?_some h
   simp only [List.all_eq_true, decide_eq_true_eq, mem_applicable] at hall
@@ -194,14 +187,14 @@ theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
     fun s hs => not_lt_iff_le_imp_ge.mp (hall s hs)⟩
 
 /-- `selectMinimal` succeeds iff some rule applies. -/
-theorem selectMinimal_isSome_iff {v : List R} {c : Ctx} :
+theorem selectMinimal_isSome_iff :
     (selectMinimal v c).isSome ↔ ∃ r ∈ v, Applies r c := by
   rw [selectMinimal, List.find?_isSome]
   simp only [List.all_eq_true, decide_eq_true_eq, mem_applicable]
   exact ⟨fun ⟨r, hr, _⟩ => ⟨r, hr⟩, fun h => (exists_isElsewhereWinner h).imp
     fun w hw => ⟨hw.1, fun s hs => hw.not_lt hs⟩⟩
 
-theorem selectMinimal_eq_none_iff {v : List R} {c : Ctx} :
+theorem selectMinimal_eq_none_iff :
     selectMinimal v c = none ↔ applicable v c = [] := by
   rw [← Option.not_isSome_iff_eq_none, selectMinimal_isSome_iff]
   simp [applicable, List.filter_eq_nil_iff]

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -24,18 +24,18 @@ winners: `≤`-minimal applicable rules of exponence ([kiparsky-1973]).
 
 namespace Morphology.Exponence
 
-variable {Ctx F : Type*} {R : Type*} [Preorder R] [Exponence R Ctx F]
+variable {Ctx E : Type*} {R : Type*} [Preorder R] [Rule R Ctx E]
 
 /-! ### Elsewhere winners -/
 
 /-- A `≤`-minimal applicable rule of `v` at `c`. -/
 def IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
-  Minimal (fun s => s ∈ v ∧ Exponence.Applies (F := F) s c) r
+  Minimal (fun s => s ∈ v ∧ Applies s c) r
 
 /-- A winner is below every applicable rule that is below it. -/
 theorem IsElsewhereWinner.le_of_le {v : List R} {c : Ctx} {r s : R}
     (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
-    (happ : Exponence.Applies (F := F) s c) (h : s ≤ r) : r ≤ s :=
+    (happ : Applies s c) (h : s ≤ r) : r ≤ s :=
   Minimal.le_of_le hr ⟨hs, happ⟩ h
 
 /-! ### Coherence and uniqueness -/
@@ -51,28 +51,28 @@ theorem IsElsewhereWinner.antisymmRel {v : List R} {c : Ctx} {r s : R}
 /-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
 def Coherent (v : List R) : Prop :=
   ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
-    Exponence.exponent (F := F) r = Exponence.exponent (F := F) s
+    exponent r = exponent s
 
 /-- Comparable winners of a coherent vocabulary carry the same exponent. -/
 theorem IsElsewhereWinner.exponent_eq {v : List R} {c : Ctx} {r s : R}
     (hv : Coherent v) (hr : IsElsewhereWinner v c r)
     (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
-    Exponence.exponent (F := F) r = Exponence.exponent (F := F) s :=
+    exponent r = exponent s :=
   hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
 
 /-- A vocabulary with an applicable rule has an Elsewhere winner. -/
 theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
-    (h : ∃ r ∈ v, Exponence.Applies (F := F) r c) : ∃ r, IsElsewhereWinner v c r :=
+    (h : ∃ r ∈ v, Applies r c) : ∃ r, IsElsewhereWinner v c r :=
   (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
 
 /-! ### The prediction relation -/
 
 /-- `φ` is realized at `c` when some Elsewhere winner carries it. -/
-def Realizes (v : List R) (c : Ctx) (φ : F) : Prop :=
-  ∃ r, IsElsewhereWinner v c r ∧ Exponence.exponent (F := F) r = φ
+def Realizes (v : List R) (c : Ctx) (φ : E) : Prop :=
+  ∃ r, IsElsewhereWinner v c r ∧ exponent r = φ
 
 /-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
-theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : F} (hv : Coherent v)
+theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : E} (hv : Coherent v)
     (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
     (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
   obtain ⟨r, hr, rfl⟩ := hφ
@@ -81,15 +81,15 @@ theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : F} (hv : Coherent v)
 
 /-! ### Score selection -/
 
-variable [∀ c : Ctx, DecidablePred (fun r : R => Exponence.Applies (F := F) r c)]
+variable [∀ c : Ctx, DecidablePred (fun r : R => Applies r c)]
 
 /-- The rules of `v` applicable at `c`, in vocabulary order. -/
 def applicable (v : List R) (c : Ctx) : List R :=
-  v.filter (fun r => Exponence.Applies (F := F) r c)
+  v.filter (fun r => Applies r c)
 
 omit [Preorder R] in
 @[simp] theorem mem_applicable {v : List R} {c : Ctx} {r : R} :
-    r ∈ applicable v c ↔ r ∈ v ∧ Exponence.Applies (F := F) r c := by
+    r ∈ applicable v c ↔ r ∈ v ∧ Applies r c := by
   simp only [applicable, List.mem_filter, decide_eq_true_eq]
 
 variable {α : Type*} [LinearOrder α]
@@ -106,7 +106,7 @@ theorem selectBy_mem {f : R → α} {v : List R} {c : Ctx} {r : R}
 
 omit [Preorder R] in
 theorem selectBy_applies {f : R → α} {v : List R} {c : Ctx} {r : R}
-    (h : selectBy f v c = some r) : Exponence.Applies (F := F) r c :=
+    (h : selectBy f v c = some r) : Applies r c :=
   (mem_applicable.mp (List.argmax_mem h)).2
 
 omit [Preorder R] in
@@ -117,18 +117,18 @@ theorem selectBy_eq_none_iff {f : R → α} {v : List R} {c : Ctx} :
 /-- When the score reflects specificity, the selection is below every
 applicable rule. -/
 theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
-    (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
-      Exponence.Applies (F := F) s c → (r ≤ s ↔ f s ≤ f r))
+    (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
+      Applies s c → (r ≤ s ↔ f s ≤ f r))
     (h : selectBy f v c = some r) (hs : s ∈ v)
-    (hsapp : Exponence.Applies (F := F) s c) : r ≤ s :=
+    (hsapp : Applies s c) : r ≤ s :=
   (hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp).mpr
     (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
 /-- When the score reflects specificity on comparable applicable rules,
 `selectBy` returns an Elsewhere winner. -/
 theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
-    (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
-      Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
+    (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
+      Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : selectBy f v c = some r) : IsElsewhereWinner v c r := by
   refine ⟨⟨selectBy_mem h, selectBy_applies h⟩, ?_⟩
   rintro s ⟨hs, hsapp⟩ hsr
@@ -145,13 +145,13 @@ theorem selectBy_congr {f : R → α} {v : List R} {c c' : Ctx}
 /-! ### Realization -/
 
 /-- The exponent of the rule selected by `selectBy`. -/
-def realize (f : R → α) (v : List R) (c : Ctx) : Option F :=
-  (selectBy f v c).map (Exponence.exponent (F := F))
+def realize (f : R → α) (v : List R) (c : Ctx) : Option E :=
+  (selectBy f v c).map (exponent)
 
 /-- Realized exponents satisfy `Realizes`. -/
-theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : F}
-    (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
-      Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
+theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : E}
+    (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
+      Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : realize f v c = some φ) : Realizes v c φ := by
   rw [realize, Option.map_eq_some_iff] at h
   obtain ⟨r, hr, rfl⟩ := h
@@ -182,42 +182,28 @@ theorem selectMinimal_mem {v : List R} {c : Ctx} {r : R}
   (mem_applicable.mp (List.mem_of_find?_eq_some h)).1
 
 theorem selectMinimal_applies {v : List R} {c : Ctx} {r : R}
-    (h : selectMinimal v c = some r) : Exponence.Applies (F := F) r c :=
+    (h : selectMinimal v c = some r) : Applies r c :=
   (mem_applicable.mp (List.mem_of_find?_eq_some h)).2
 
 /-- `selectMinimal` returns an Elsewhere winner. -/
 theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
     (h : selectMinimal v c = some r) : IsElsewhereWinner v c r := by
-  refine ⟨mem_applicable.mp (List.mem_of_find?_eq_some h), ?_⟩
   have hall := List.find?_some h
-  rw [List.all_eq_true] at hall
-  rintro s ⟨hsv, hsapp⟩ hsr
-  by_contra hrs
-  have hns := hall s (mem_applicable.mpr ⟨hsv, hsapp⟩)
-  rw [decide_eq_true_eq] at hns
-  exact hns (lt_of_le_not_ge hsr hrs)
+  simp only [List.all_eq_true, decide_eq_true_eq, mem_applicable] at hall
+  exact ⟨mem_applicable.mp (List.mem_of_find?_eq_some h),
+    fun s hs => not_lt_iff_le_imp_ge.mp (hall s hs)⟩
 
-/-- A vocabulary with an applicable rule selects one. -/
-theorem selectMinimal_isSome_of_exists_applicable {v : List R} {c : Ctx}
-    (h : ∃ r ∈ v, Exponence.Applies (F := F) r c) : (selectMinimal v c).isSome := by
-  obtain ⟨r, hr⟩ := exists_isElsewhereWinner h
-  rw [Option.isSome_iff_ne_none]
-  intro hnone
-  rw [selectMinimal, List.find?_eq_none] at hnone
-  refine hnone r (mem_applicable.mpr ⟨hr.1.1, hr.1.2⟩) ?_
-  rw [List.all_eq_true]
-  intro s hs
-  rw [decide_eq_true_eq]
-  intro hlt
-  exact absurd (hr.2 (mem_applicable.mp hs) hlt.le) (not_le_of_gt hlt)
+/-- `selectMinimal` succeeds iff some rule applies. -/
+theorem selectMinimal_isSome_iff {v : List R} {c : Ctx} :
+    (selectMinimal v c).isSome ↔ ∃ r ∈ v, Applies r c := by
+  rw [selectMinimal, List.find?_isSome]
+  simp only [List.all_eq_true, decide_eq_true_eq, mem_applicable]
+  exact ⟨fun ⟨r, hr, _⟩ => ⟨r, hr⟩, fun h => (exists_isElsewhereWinner h).imp
+    fun w hw => ⟨hw.1, fun s hs => hw.not_lt hs⟩⟩
 
 theorem selectMinimal_eq_none_iff {v : List R} {c : Ctx} :
     selectMinimal v c = none ↔ applicable v c = [] := by
-  refine ⟨fun h => ?_, fun h => by rw [selectMinimal, h]; rfl⟩
-  by_contra hne
-  obtain ⟨r, hr⟩ := List.exists_mem_of_ne_nil _ hne
-  have happ := mem_applicable.mp hr
-  have hs := selectMinimal_isSome_of_exists_applicable ⟨r, happ.1, happ.2⟩
-  rw [h] at hs; simp at hs
+  rw [← Option.not_isSome_iff_eq_none, selectMinimal_isSome_iff]
+  simp [applicable, List.filter_eq_nil_iff]
 
 end Morphology.Exponence

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -24,10 +24,8 @@ winners: `≤`-minimal applicable rules of exponence ([kiparsky-1973]).
 
 namespace Morphology.Exponence
 
-variable {Ctx E : Type*} {R : Type*} [Preorder R] [Rule R Ctx E]
+variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E]
 variable {v : List R} {c c' : Ctx} {r s : R} {φ : E}
-
-/-! ### Elsewhere winners -/
 
 /-- Two comparable minimal elements of the same predicate are equivalent.
 [UPSTREAM] candidate for `Mathlib/Order/Minimal.lean`. -/
@@ -35,6 +33,11 @@ theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} 
     (hx : Minimal P x) (hy : Minimal P y) (h : y ≤ x ∨ x ≤ y) :
     AntisymmRel (· ≤ ·) x y :=
   h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
+
+section
+variable [Preorder R]
+
+/-! ### Elsewhere winners -/
 
 /-- A `≤`-minimal applicable rule of `v` at `c`. -/
 abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
@@ -71,6 +74,8 @@ theorem Realizes.eq {ψ : E} (hv : Coherent v)
   obtain ⟨s, hs, rfl⟩ := hψ
   exact hr.exponent_eq hv hs (hcmp hr hs)
 
+end
+
 /-! ### Score selection -/
 
 variable [∀ c : Ctx, DecidablePred (fun r : R => Applies r c)]
@@ -79,7 +84,6 @@ variable [∀ c : Ctx, DecidablePred (fun r : R => Applies r c)]
 def applicable (v : List R) (c : Ctx) : List R :=
   v.filter (fun r => Applies r c)
 
-omit [Preorder R] in
 @[simp] theorem mem_applicable :
     r ∈ applicable v c ↔ r ∈ v ∧ Applies r c := by
   simp only [applicable, List.mem_filter, decide_eq_true_eq]
@@ -91,20 +95,35 @@ order; scores to be minimized pass through `OrderDual`. -/
 def selectBy (f : R → α) (v : List R) (c : Ctx) : Option R :=
   (applicable v c).argmax f
 
-omit [Preorder R] in
-theorem selectBy_mem
-    (h : selectBy f v c = some r) : r ∈ v :=
+theorem selectBy_mem (h : selectBy f v c = some r) : r ∈ v :=
   (mem_applicable.mp (List.argmax_mem h)).1
 
-omit [Preorder R] in
-theorem selectBy_applies
-    (h : selectBy f v c = some r) : Applies r c :=
+theorem selectBy_applies (h : selectBy f v c = some r) : Applies r c :=
   (mem_applicable.mp (List.argmax_mem h)).2
 
-omit [Preorder R] in
-theorem selectBy_eq_none_iff :
-    selectBy f v c = none ↔ applicable v c = [] :=
+theorem selectBy_eq_none_iff : selectBy f v c = none ↔ applicable v c = [] :=
   List.argmax_eq_none
+
+/-- Contexts with the same applicable rules select the same rule. -/
+theorem selectBy_congr (h : applicable v c = applicable v c') :
+    selectBy f v c = selectBy f v c' := by
+  rw [selectBy, selectBy, h]
+
+/-- The exponent of the rule selected by `selectBy`. -/
+def realize (f : R → α) (v : List R) (c : Ctx) : Option E :=
+  (selectBy f v c).map exponent
+
+theorem realize_eq_none_iff : realize f v c = none ↔ applicable v c = [] :=
+  Option.map_eq_none_iff.trans selectBy_eq_none_iff
+
+theorem realize_congr (h : applicable v c = applicable v c') :
+    realize f v c = realize f v c' :=
+  congrArg (Option.map exponent) (selectBy_congr h)
+
+/-! ### Soundness -/
+
+section
+variable [Preorder R]
 
 /-- When the score reflects specificity, the selection is below every
 applicable rule. -/
@@ -127,39 +146,13 @@ theorem selectBy_isElsewhereWinner
   exact hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp hsr
     (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
-omit [Preorder R] in
-/-- Contexts with the same applicable rules select the same rule. -/
-theorem selectBy_congr
-    (h : applicable v c = applicable v c') :
-    selectBy f v c = selectBy f v c' := by
-  rw [selectBy, selectBy, h]
-
-/-! ### Realization -/
-
-/-- The exponent of the rule selected by `selectBy`. -/
-def realize (f : R → α) (v : List R) (c : Ctx) : Option E :=
-  (selectBy f v c).map (exponent)
-
 /-- Realized exponents satisfy `Realizes`. -/
 theorem realize_realizes
     (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
       Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
     (h : realize f v c = some φ) : Realizes v c φ := by
-  rw [realize, Option.map_eq_some_iff] at h
-  obtain ⟨r, hr, rfl⟩ := h
+  obtain ⟨r, hr, rfl⟩ := Option.map_eq_some_iff.mp h
   exact ⟨r, selectBy_isElsewhereWinner hf hr, rfl⟩
-
-omit [Preorder R] in
-theorem realize_eq_none_iff :
-    realize f v c = none ↔ applicable v c = [] := by
-  rw [realize, Option.map_eq_none_iff]
-  exact selectBy_eq_none_iff
-
-omit [Preorder R] in
-theorem realize_congr
-    (h : applicable v c = applicable v c') :
-    realize f v c = realize f v c' := by
-  rw [realize, realize, selectBy_congr h]
 
 /-! ### Order selection -/
 
@@ -195,5 +188,7 @@ theorem selectMinimal_eq_none_iff :
     selectMinimal v c = none ↔ applicable v c = [] := by
   rw [← Option.not_isSome_iff_eq_none, selectMinimal_isSome_iff]
   simp [applicable, List.filter_eq_nil_iff]
+
+end
 
 end Morphology.Exponence

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -29,6 +29,8 @@ variable {v : List R} {c c' : Ctx} {r s : R} {φ : E}
 
 /-! ### Score selection -/
 
+variable [DecidableApplies R Ctx]
+
 /-- The rules of `v` applicable at `c`, in vocabulary order. -/
 def applicable (v : List R) (c : Ctx) : List R :=
   v.filter (fun r => Applies r c)

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -27,55 +27,6 @@ namespace Morphology.Exponence
 variable {Ctx E : Type*} {R : Type*} [Rule R Ctx E]
 variable {v : List R} {c c' : Ctx} {r s : R} {φ : E}
 
-/-- Two comparable minimal elements of the same predicate are equivalent.
-[UPSTREAM] candidate for `Mathlib/Order/Minimal.lean`. -/
-theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} {x y : α}
-    (hx : Minimal P x) (hy : Minimal P y) (h : y ≤ x ∨ x ≤ y) :
-    AntisymmRel (· ≤ ·) x y :=
-  h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
-
-section
-variable [Preorder R]
-
-/-! ### Elsewhere winners -/
-
-/-- A `≤`-minimal applicable rule of `v` at `c`. -/
-abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
-  Minimal (fun s => s ∈ v ∧ Applies s c) r
-
-/-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
-def Coherent (v : List R) : Prop :=
-  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
-    exponent r = exponent s
-
-/-- Comparable winners of a coherent vocabulary carry the same exponent. -/
-theorem IsElsewhereWinner.exponent_eq
-    (hv : Coherent v) (hr : IsElsewhereWinner v c r)
-    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
-    exponent r = exponent s :=
-  hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
-
-/-- A vocabulary with an applicable rule has an Elsewhere winner. -/
-theorem exists_isElsewhereWinner
-    (h : ∃ r ∈ v, Applies r c) : ∃ r, IsElsewhereWinner v c r :=
-  (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
-
-/-! ### The prediction relation -/
-
-/-- `φ` is realized at `c` when some Elsewhere winner carries it. -/
-def Realizes (v : List R) (c : Ctx) (φ : E) : Prop :=
-  ∃ r, IsElsewhereWinner v c r ∧ exponent r = φ
-
-/-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
-theorem Realizes.eq {ψ : E} (hv : Coherent v)
-    (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
-    (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
-  obtain ⟨r, hr, rfl⟩ := hφ
-  obtain ⟨s, hs, rfl⟩ := hψ
-  exact hr.exponent_eq hv hs (hcmp hr hs)
-
-end
-
 /-! ### Score selection -/
 
 variable [∀ c : Ctx, DecidablePred (fun r : R => Applies r c)]
@@ -120,10 +71,53 @@ theorem realize_congr (h : applicable v c = applicable v c') :
     realize f v c = realize f v c' :=
   congrArg (Option.map exponent) (selectBy_congr h)
 
-/-! ### Soundness -/
+/-! ### Elsewhere winners -/
 
-section
 variable [Preorder R]
+
+/-- Two comparable minimal elements of the same predicate are equivalent.
+[UPSTREAM] candidate for `Mathlib/Order/Minimal.lean`. -/
+theorem _root_.Minimal.antisymmRel {α : Type*} [Preorder α] {P : α → Prop} {x y : α}
+    (hx : Minimal P x) (hy : Minimal P y) (h : y ≤ x ∨ x ≤ y) :
+    AntisymmRel (· ≤ ·) x y :=
+  h.elim (fun h => ⟨hx.le_of_le hy.1 h, h⟩) (fun h => ⟨h, hy.le_of_le hx.1 h⟩)
+
+/-- A `≤`-minimal applicable rule of `v` at `c`. -/
+abbrev IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
+  Minimal (fun s => s ∈ v ∧ Applies s c) r
+
+/-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
+def Coherent (v : List R) : Prop :=
+  ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
+    exponent r = exponent s
+
+/-- Comparable winners of a coherent vocabulary carry the same exponent. -/
+theorem IsElsewhereWinner.exponent_eq
+    (hv : Coherent v) (hr : IsElsewhereWinner v c r)
+    (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
+    exponent r = exponent s :=
+  hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
+
+/-- A vocabulary with an applicable rule has an Elsewhere winner. -/
+theorem exists_isElsewhereWinner
+    (h : ∃ r ∈ v, Applies r c) : ∃ r, IsElsewhereWinner v c r :=
+  (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
+
+/-! ### The prediction relation -/
+
+/-- `φ` is realized at `c` when some Elsewhere winner carries it. -/
+def Realizes (v : List R) (c : Ctx) (φ : E) : Prop :=
+  ∃ r, IsElsewhereWinner v c r ∧ exponent r = φ
+
+/-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
+theorem Realizes.eq {ψ : E} (hv : Coherent v)
+    (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
+    (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
+  obtain ⟨r, hr, rfl⟩ := hφ
+  obtain ⟨s, hs, rfl⟩ := hψ
+  exact hr.exponent_eq hv hs (hcmp hr hs)
+
+/-! ### Soundness -/
 
 /-- When the score reflects specificity, the selection is below every
 applicable rule. -/
@@ -188,7 +182,5 @@ theorem selectMinimal_eq_none_iff :
     selectMinimal v c = none ↔ applicable v c = [] := by
   rw [← Option.not_isSome_iff_eq_none, selectMinimal_isSome_iff]
   simp [applicable, List.filter_eq_nil_iff]
-
-end
 
 end Morphology.Exponence

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -5,38 +5,21 @@ import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.List.MinMax
 
 /-!
-# Elsewhere selection over rules of exponence
+# Elsewhere selection
 
-This file defines Elsewhere selection over the specificity preorder of
-`Morphology/Exponence/Basic.lean`. An Elsewhere winner is a `≤`-minimal
-applicable rule. Over a coherent vocabulary, comparable winners carry one
-exponent, so the prediction relation `Realizes` is well defined up to
-incomparability.
+This file proves that selection by a specificity score (`selectBy`) and
+selection over the specificity preorder (`selectMinimal`) produce Elsewhere
+winners: `≤`-minimal applicable rules of exponence ([kiparsky-1973]).
 
-`selectBy` computes a winner by maximizing a score `f : R → α` into a
-linear order over the applicable sublist; scores that are minimized enter
-through `OrderDual`. Its soundness law `selectBy_isElsewhereWinner` reduces
-an engine's winner-is-Elsewhere theorem to that engine's score-reflection
-lemma. `selectMinimal` selects directly over the preorder, for engines
-whose specificity has no faithful score.
+## Main definitions
 
-The theory models selection within a single rule block; realizational
-frameworks compose per-block winners into the paradigm function
-([stump-2001]). Optional multiple exponence within a block (Jubba Maay,
-[trommer-zimmermann-2015]) is outside scope, since `Realizes.eq` makes the
-per-block prediction unique. Whether specificity is the Elsewhere criterion
-is itself not beyond question: [jackendoff-audring-2020] suggest markedness
-may operate in the overlapping `-ious` case.
-
-## Main declarations
-
-* `IsElsewhereWinner`, `Coherent`, `exists_isElsewhereWinner` — minimality,
-  coherence, and existence of winners.
-* `Realizes` — the framework-neutral prediction relation.
-* `selectBy`, `realize`, `selectBy_isElsewhereWinner`, `realize_realizes` —
-  score selection and its soundness.
-* `selectMinimal`, `selectMinimal_isElsewhereWinner` — order selection and
-  its soundness.
+* `IsElsewhereWinner`: a `≤`-minimal applicable rule of a vocabulary at a
+  context.
+* `Realizes`: some Elsewhere winner carries the given exponent.
+* `selectBy`, `realize`: the applicable rule of greatest score, and its
+  exponent.
+* `selectMinimal`: the first applicable rule that no applicable rule
+  strictly undercuts.
 -/
 
 namespace Morphology.Exponence
@@ -45,13 +28,11 @@ variable {Ctx F : Type*} {R : Type*} [Preorder R] [Exponence R Ctx F]
 
 /-! ### Elsewhere winners -/
 
-/-- An Elsewhere winner for `v` at `c` is a `≤`-minimal applicable member
-of `v`: no applicable rule in `v` is strictly more specific. -/
+/-- A `≤`-minimal applicable rule of `v` at `c`. -/
 def IsElsewhereWinner (v : List R) (c : Ctx) (r : R) : Prop :=
   Minimal (fun s => s ∈ v ∧ Exponence.Applies (F := F) s c) r
 
-/-- A winner is at least as specific as any applicable member of the
-vocabulary that is at least as specific as it. -/
+/-- A winner is below every applicable rule that is below it. -/
 theorem IsElsewhereWinner.le_of_le {v : List R} {c : Ctx} {r s : R}
     (hr : IsElsewhereWinner v c r) (hs : s ∈ v)
     (happ : Exponence.Applies (F := F) s c) (h : s ≤ r) : r ≤ s :=
@@ -67,25 +48,19 @@ theorem IsElsewhereWinner.antisymmRel {v : List R} {c : Ctx} {r s : R}
   · exact ⟨hr.le_of_le hs.1.1 hs.1.2 h, h⟩
   · exact ⟨h, hs.le_of_le hr.1.1 hr.1.2 h⟩
 
-/-- A vocabulary is coherent if equivalent rules carry the same exponent,
-so that the exponent descends to the antisymmetrization of the specificity
-preorder ([caha-2009]'s antihomophony). Incomparable competitors are
-tolerated, where [stump-2001]'s Pāṇinian Determinism forbids them. -/
+/-- A vocabulary is coherent if equivalent rules carry the same exponent. -/
 def Coherent (v : List R) : Prop :=
   ∀ r ∈ v, ∀ s ∈ v, AntisymmRel (· ≤ ·) r s →
     Exponence.exponent (F := F) r = Exponence.exponent (F := F) s
 
-/-- Over a coherent vocabulary, comparable winners select the same
-exponent: Elsewhere selection is well defined up to incomparability. -/
+/-- Comparable winners of a coherent vocabulary carry the same exponent. -/
 theorem IsElsewhereWinner.exponent_eq {v : List R} {c : Ctx} {r s : R}
     (hv : Coherent v) (hr : IsElsewhereWinner v c r)
     (hs : IsElsewhereWinner v c s) (h : s ≤ r ∨ r ≤ s) :
     Exponence.exponent (F := F) r = Exponence.exponent (F := F) s :=
   hv r hr.1.1 s hs.1.1 (hr.antisymmRel hs h)
 
-/-- A vocabulary with an applicable rule has an Elsewhere winner —
-proved, where [stump-2001] guarantees existence by stipulating a
-bottom-element Identity Function Default. -/
+/-- A vocabulary with an applicable rule has an Elsewhere winner. -/
 theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
     (h : ∃ r ∈ v, Exponence.Applies (F := F) r c) : ∃ r, IsElsewhereWinner v c r :=
   (v.finite_toSet.subset fun _ hr => hr.1).exists_minimal h
@@ -96,8 +71,7 @@ theorem exists_isElsewhereWinner {v : List R} {c : Ctx}
 def Realizes (v : List R) (c : Ctx) (φ : F) : Prop :=
   ∃ r, IsElsewhereWinner v c r ∧ Exponence.exponent (F := F) r = φ
 
-/-- Over a coherent vocabulary whose winners are comparable, the
-prediction is unique. -/
+/-- Over a coherent vocabulary with comparable winners, the prediction is unique. -/
 theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : F} (hv : Coherent v)
     (hcmp : ∀ ⦃r s⦄, IsElsewhereWinner v c r → IsElsewhereWinner v c s → s ≤ r ∨ r ≤ s)
     (hφ : Realizes v c φ) (hψ : Realizes v c ψ) : φ = ψ := by
@@ -105,11 +79,7 @@ theorem Realizes.eq {v : List R} {c : Ctx} {φ ψ : F} (hv : Coherent v)
   obtain ⟨s, hs, rfl⟩ := hψ
   exact hr.exponent_eq hv hs (hcmp hr hs)
 
-/-! ### Score selection
-
-For a specificity score `f : R → α` into a linear order, `selectBy` picks
-the applicable rule of greatest score. Scores that are minimized (span,
-tree size, support card) pass through `OrderDual α`. -/
+/-! ### Score selection -/
 
 variable [∀ c : Ctx, DecidablePred (fun r : R => Exponence.Applies (F := F) r c)]
 
@@ -124,8 +94,8 @@ omit [Preorder R] in
 
 variable {α : Type*} [LinearOrder α]
 
-/-- The applicable rule of `v` at `c` with greatest score `f`, ties broken
-by vocabulary order, or `none` when nothing applies. -/
+/-- The applicable rule of greatest score `f`, ties broken by vocabulary
+order; scores to be minimized pass through `OrderDual`. -/
 def selectBy (f : R → α) (v : List R) (c : Ctx) : Option R :=
   (applicable v c).argmax f
 
@@ -144,9 +114,8 @@ theorem selectBy_eq_none_iff {f : R → α} {v : List R} {c : Ctx} :
     selectBy f v c = none ↔ applicable v c = [] :=
   List.argmax_eq_none
 
-/-- With the score reflecting specificity contravariantly on applicable
-rules, the selection is at least as specific as every applicable rule
-— it is `≤` all of them, no comparability assumed. -/
+/-- When the score reflects specificity, the selection is below every
+applicable rule. -/
 theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
     (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
       Exponence.Applies (F := F) s c → (r ≤ s ↔ f s ≤ f r))
@@ -155,10 +124,8 @@ theorem selectBy_le_of_applies {f : R → α} {v : List R} {c : Ctx} {r s : R}
   (hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp).mpr
     (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
 
-/-- A score that reflects specificity contravariantly on comparable
-applicable rules selects an Elsewhere winner. Engines discharge `hf` from
-the `mpr` of their `le_iff`, or via `Finset.eq_of_subset_of_card_le` where
-card `≤` does not imply support `⊆`. -/
+/-- When the score reflects specificity on comparable applicable rules,
+`selectBy` returns an Elsewhere winner. -/
 theorem selectBy_isElsewhereWinner {f : R → α} {v : List R} {c : Ctx} {r : R}
     (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
       Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
@@ -177,12 +144,11 @@ theorem selectBy_congr {f : R → α} {v : List R} {c c' : Ctx}
 
 /-! ### Realization -/
 
-/-- The exponent of the score-selected winner, or `none` when no rule
-applies. -/
+/-- The exponent of the rule selected by `selectBy`. -/
 def realize (f : R → α) (v : List R) (c : Ctx) : Option F :=
   (selectBy f v c).map (Exponence.exponent (F := F))
 
-/-- Realized exponents satisfy the prediction relation `Realizes`. -/
+/-- Realized exponents satisfy `Realizes`. -/
 theorem realize_realizes {f : R → α} {v : List R} {c : Ctx} {φ : F}
     (hf : ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
       Exponence.Applies (F := F) s c → s ≤ r → f s ≤ f r → r ≤ s)
@@ -203,17 +169,11 @@ theorem realize_congr {f : R → α} {v : List R} {c c' : Ctx}
     realize f v c = realize f v c' := by
   rw [realize, realize, selectBy_congr h]
 
-/-! ### Order selection
-
-`selectMinimal` selects directly over the specificity preorder: the first
-applicable rule that no applicable rule strictly undercuts. It serves
-engines whose specificity is a genuine preorder with no faithful score,
-such as the PFM narrowness order of `Morphology/Paradigm/Function.lean`. -/
+/-! ### Order selection -/
 
 variable [DecidableRel (· < · : R → R → Prop)]
 
-/-- The first applicable rule of `v` at `c` that no applicable rule
-strictly undercuts, or `none` when nothing applies. -/
+/-- The first applicable rule that no applicable rule strictly undercuts. -/
 def selectMinimal (v : List R) (c : Ctx) : Option R :=
   (applicable v c).find? (fun r => (applicable v c).all (fun s => decide (¬ s < r)))
 
@@ -225,7 +185,7 @@ theorem selectMinimal_applies {v : List R} {c : Ctx} {r : R}
     (h : selectMinimal v c = some r) : Exponence.Applies (F := F) r c :=
   (mem_applicable.mp (List.mem_of_find?_eq_some h)).2
 
-/-- A selected rule is an Elsewhere winner. -/
+/-- `selectMinimal` returns an Elsewhere winner. -/
 theorem selectMinimal_isElsewhereWinner {v : List R} {c : Ctx} {r : R}
     (h : selectMinimal v c = some r) : IsElsewhereWinner v c r := by
   refine ⟨mem_applicable.mp (List.mem_of_find?_eq_some h), ?_⟩

--- a/Linglib/Morphology/Exponence/Select.lean
+++ b/Linglib/Morphology/Exponence/Select.lean
@@ -29,8 +29,6 @@ variable {v : List R} {c c' : Ctx} {r s : R} {φ : E}
 
 /-! ### Score selection -/
 
-variable [∀ c : Ctx, DecidablePred (fun r : R => Applies r c)]
-
 /-- The rules of `v` applicable at `c`, in vocabulary order. -/
 def applicable (v : List R) (c : Ctx) : List R :=
   v.filter (fun r => Applies r c)
@@ -119,31 +117,19 @@ theorem Realizes.eq {ψ : E} (hv : Coherent v)
 
 /-! ### Soundness -/
 
-/-- When the score reflects specificity, the selection is below every
-applicable rule. -/
-theorem selectBy_le_of_applies
-    (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
-      Applies s c → (r ≤ s ↔ f s ≤ f r))
-    (h : selectBy f v c = some r) (hs : s ∈ v)
-    (hsapp : Applies s c) : r ≤ s :=
-  (hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp).mpr
-    (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
-
-/-- When the score reflects specificity on comparable applicable rules,
-`selectBy` returns an Elsewhere winner. -/
+/-- A score strictly antitone on the applicable rules selects an
+Elsewhere winner. -/
 theorem selectBy_isElsewhereWinner
-    (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
-      Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
+    (hf : StrictAntiOn f {r | r ∈ applicable v c})
     (h : selectBy f v c = some r) : IsElsewhereWinner v c r := by
-  refine ⟨⟨selectBy_mem h, selectBy_applies h⟩, ?_⟩
-  rintro s ⟨hs, hsapp⟩ hsr
-  exact hf r (selectBy_mem h) s hs (selectBy_applies h) hsapp hsr
-    (List.le_of_mem_argmax (mem_applicable.mpr ⟨hs, hsapp⟩) h)
+  refine ⟨mem_applicable.mp (List.argmax_mem h), fun s hs hsr => ?_⟩
+  by_contra hrs
+  exact absurd (List.le_of_mem_argmax (mem_applicable.mpr hs) h)
+    (not_le_of_gt (hf (mem_applicable.mpr hs) (List.argmax_mem h)
+      (lt_of_le_not_ge hsr hrs)))
 
 /-- Realized exponents satisfy `Realizes`. -/
-theorem realize_realizes
-    (hf : ∀ r ∈ v, ∀ s ∈ v, Applies r c →
-      Applies s c → s ≤ r → f s ≤ f r → r ≤ s)
+theorem realize_realizes (hf : StrictAntiOn f {r | r ∈ applicable v c})
     (h : realize f v c = some φ) : Realizes v c φ := by
   obtain ⟨r, hr, rfl⟩ := Option.map_eq_some_iff.mp h
   exact ⟨r, selectBy_isElsewhereWinner hf hr, rfl⟩

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -269,15 +269,15 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
 open Morphology.Exponence
 
 /-- A tree lexical entry exposes the shared exponence core interface
-(`Morphology.Exponence`): contexts are syntactic targets,
+(`Morphology.Exponence.Rule`): contexts are syntactic targets,
 applicability is Superset-Principle matching. -/
-instance : Exponence (TreeLexEntry F α) (NanoTree F) α :=
+instance : Exponence.Rule (TreeLexEntry F α) (NanoTree F) α :=
   ⟨TreeLexEntry.exponent, fun e t => e.Matches t⟩
 
 instance : Preorder (TreeLexEntry F α) := Exponence.toPreorder
 
 instance [DecidableEq F] (target : NanoTree F) :
-    DecidablePred (fun e : TreeLexEntry F α => Exponence.Applies (F := α) e target) :=
+    DecidablePred (fun e : TreeLexEntry F α => Exponence.Applies e target) :=
   fun e => inferInstanceAs (Decidable (e.Matches target))
 
 /-- The specificity order is reverse containment of the stored trees:

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -268,9 +268,6 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
 
 open Morphology.Exponence
 
-section
-variable [DecidableEq F]
-
 /-- A tree lexical entry exposes the shared exponence core interface
 (`Morphology.Exponence.Rule`): contexts are syntactic targets,
 applicability is Superset-Principle matching. -/
@@ -288,6 +285,24 @@ theorem TreeLexEntry.le_iff {a b : TreeLexEntry F α} :
   ⟨λ h => h (.refl a.tree), λ h _ hc => h.trans hc⟩
 
 /-! ### Tree spellout (Elsewhere Condition) -/
+
+/-- Dualized tree size is strictly antitone in specificity: a strictly
+containing entry has a strictly larger tree, since containment is
+size-antisymmetric (`Contains.eq_of_size_le`). -/
+private theorem size_strictAnti :
+    StrictAnti (fun e : TreeLexEntry F α => OrderDual.toDual e.tree.size) := by
+  intro s r hlt
+  have hcon := TreeLexEntry.le_iff.mp hlt.le
+  refine OrderDual.toDual_lt_toDual.mpr (lt_of_le_of_ne hcon.size_le fun heq => ?_)
+  refine not_le_of_gt hlt (TreeLexEntry.le_iff.mpr ?_)
+  rw [hcon.eq_of_size_le heq.ge]
+  exact .refl _
+
+section
+variable [DecidableEq F]
+
+instance : DecidableApplies (TreeLexEntry F α) (NanoTree F) :=
+  fun t e => inferInstanceAs (Decidable (e.Matches t))
 
 /-- The matching entry with the smallest stored tree (first-listed on
     ties): Minimize Junk over tree-generalized Superset matching, as the
@@ -307,18 +322,6 @@ def treeSelect (entries : List (TreeLexEntry F α))
 def treeSpellout (entries : List (TreeLexEntry F α))
     (target : NanoTree F) : Option α :=
   (treeSelect entries target).map (·.exponent)
-
-/-- Dualized tree size is strictly antitone in specificity: a strictly
-containing entry has a strictly larger tree, since containment is
-size-antisymmetric (`Contains.eq_of_size_le`). -/
-private theorem size_strictAnti :
-    StrictAnti (fun e : TreeLexEntry F α => OrderDual.toDual e.tree.size) := by
-  intro s r hlt
-  have hcon := TreeLexEntry.le_iff.mp hlt.le
-  refine OrderDual.toDual_lt_toDual.mpr (lt_of_le_of_ne hcon.size_le fun heq => ?_)
-  refine not_le_of_gt hlt (TreeLexEntry.le_iff.mpr ?_)
-  rw [hcon.eq_of_size_le heq.ge]
-  exact .refl _
 
 /-- Smallest-tree selection is an Elsewhere winner of the shared core:
 the dualized-size score is strictly antitone in specificity

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -268,6 +268,9 @@ instance [DecidableEq F] (entry : TreeLexEntry F α) (target : NanoTree F) :
 
 open Morphology.Exponence
 
+section
+variable [DecidableEq F]
+
 /-- A tree lexical entry exposes the shared exponence core interface
 (`Morphology.Exponence.Rule`): contexts are syntactic targets,
 applicability is Superset-Principle matching. -/
@@ -275,10 +278,6 @@ instance : Exponence.Rule (TreeLexEntry F α) (NanoTree F) α :=
   ⟨TreeLexEntry.exponent, fun e t => e.Matches t⟩
 
 instance : Preorder (TreeLexEntry F α) := Exponence.toPreorder
-
-instance [DecidableEq F] (target : NanoTree F) :
-    DecidablePred (fun e : TreeLexEntry F α => Exponence.Applies e target) :=
-  fun e => inferInstanceAs (Decidable (e.Matches target))
 
 /-- The specificity order is reverse containment of the stored trees:
 `a` is at least as specific as `b` exactly when `b`'s tree contains
@@ -294,7 +293,7 @@ theorem TreeLexEntry.le_iff {a b : TreeLexEntry F α} :
     ties): Minimize Junk over tree-generalized Superset matching, as the
     shared core's `Exponence.selectBy` at the tree-size score dualized so
     the smallest tree wins. -/
-def treeSelect [DecidableEq F] (entries : List (TreeLexEntry F α))
+def treeSelect (entries : List (TreeLexEntry F α))
     (target : NanoTree F) : Option (TreeLexEntry F α) :=
   selectBy (fun e => OrderDual.toDual e.tree.size) entries target
 
@@ -305,35 +304,42 @@ def treeSelect [DecidableEq F] (entries : List (TreeLexEntry F α))
     Parallels `Morphology.Containment.spellout`, but the matching
     relation is tree containment instead of rank comparison, and the
     specificity metric is tree size instead of rank. -/
-def treeSpellout [DecidableEq F] (entries : List (TreeLexEntry F α))
+def treeSpellout (entries : List (TreeLexEntry F α))
     (target : NanoTree F) : Option α :=
   (treeSelect entries target).map (·.exponent)
 
-/-- Smallest-tree selection is an Elsewhere winner of the shared core,
-with no side conditions: containment is size-antisymmetric
-(`Contains.eq_of_size_le`), so on comparable matching entries the
-dualized-size score reflects specificity and a size-minimal match is
-maximally specific. An instance of `selectBy_isElsewhereWinner`. -/
-theorem treeSelect_isElsewhereWinner [DecidableEq F]
+/-- Dualized tree size is strictly antitone in specificity: a strictly
+containing entry has a strictly larger tree, since containment is
+size-antisymmetric (`Contains.eq_of_size_le`). -/
+private theorem size_strictAnti :
+    StrictAnti (fun e : TreeLexEntry F α => OrderDual.toDual e.tree.size) := by
+  intro s r hlt
+  have hcon := TreeLexEntry.le_iff.mp hlt.le
+  refine OrderDual.toDual_lt_toDual.mpr (lt_of_le_of_ne hcon.size_le fun heq => ?_)
+  refine not_le_of_gt hlt (TreeLexEntry.le_iff.mpr ?_)
+  rw [hcon.eq_of_size_le heq.ge]
+  exact .refl _
+
+/-- Smallest-tree selection is an Elsewhere winner of the shared core:
+the dualized-size score is strictly antitone in specificity
+(`size_strictAnti`), so a size-minimal match is maximally specific. An
+instance of `selectBy_isElsewhereWinner`. -/
+theorem treeSelect_isElsewhereWinner
     {entries : List (TreeLexEntry F α)} {target : NanoTree F}
     {e : TreeLexEntry F α} (h : treeSelect entries target = some e) :
     IsElsewhereWinner entries target e :=
-  selectBy_isElsewhereWinner
-    (fun r _ s _ _ _ hsr hfsr => by
-      rw [TreeLexEntry.le_iff]
-      have hsize : r.tree.size ≤ s.tree.size := OrderDual.toDual_le_toDual.mp hfsr
-      have heq : r.tree = s.tree := (TreeLexEntry.le_iff.mp hsr).eq_of_size_le hsize
-      rw [← heq]
-      exact .refl _) h
+  selectBy_isElsewhereWinner (size_strictAnti.strictAntiOn _) h
 
 /-- The spelled-out exponent is an Elsewhere winner's exponent. -/
-theorem treeSpellout_isElsewhereWinner [DecidableEq F]
+theorem treeSpellout_isElsewhereWinner
     {entries : List (TreeLexEntry F α)} {target : NanoTree F} {x : α}
     (h : treeSpellout entries target = some x) :
     ∃ e ∈ entries, e.exponent = x ∧
       IsElsewhereWinner entries target e := by
   obtain ⟨e, he, rfl⟩ := Option.map_eq_some_iff.mp h
   exact ⟨e, selectBy_mem he, rfl, treeSelect_isElsewhereWinner he⟩
+
+end
 
 /-! ### Foot Condition -/
 

--- a/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
+++ b/Linglib/Morphology/Nanosyntax/TreeSpellout.lean
@@ -301,8 +301,8 @@ private theorem size_strictAnti :
 section
 variable [DecidableEq F]
 
-instance : DecidableApplies (TreeLexEntry F α) (NanoTree F) :=
-  fun t e => inferInstanceAs (Decidable (e.Matches t))
+instance : DecidableRel (Applies : TreeLexEntry F α → NanoTree F → Prop) :=
+  fun e t => inferInstanceAs (Decidable (e.Matches t))
 
 /-- The matching entry with the smallest stored tree (first-listed on
     ties): Minimize Junk over tree-generalized Superset matching, as the

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -126,8 +126,6 @@ theorem Rule.le_iff {r s : Rule L P F} :
     r ≤ s ↔ (r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass :=
   Iff.rfl
 
-variable [DecidableEq L] [DecidableLE P]
-
 /-- Applicability ([bonami-stump-2016]'s rule format): a rule applies to a cell
 `⟨L, σ⟩` when `L` is in its class and its property set is contained in `σ`. -/
 instance : Exponence.Rule (Rule L P F) (L × P) F where
@@ -158,6 +156,9 @@ end Narrowness
 section Selection
 variable [PartialOrder P] [DecidableEq L] [DecidableLE P]
 
+instance : Exponence.DecidableApplies (Rule L P F) (L × P) :=
+  fun c r => inferInstanceAs (Decidable (c.1 ∈ r.klass ∧ r.props ≤ c.2))
+
 instance : DecidableLE (Rule L P F) := fun r s =>
   inferInstanceAs (Decidable ((r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass))
 
@@ -178,6 +179,7 @@ def identityDefault : Rule L P (Action Z P) where
   props := ⊥
   payload := .const id
 
+omit [DecidableEq L] [DecidableLE P] in
 theorem identityDefault_applies (c : L × P) :
     Exponence.Applies (identityDefault (L := L) (Z := Z) (P := P)) c :=
   ⟨Finset.mem_univ _, bot_le⟩

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -156,8 +156,8 @@ end Narrowness
 section Selection
 variable [PartialOrder P] [DecidableEq L] [DecidableLE P]
 
-instance : Exponence.DecidableApplies (Rule L P F) (L × P) :=
-  fun c r => inferInstanceAs (Decidable (c.1 ∈ r.klass ∧ r.props ≤ c.2))
+instance : DecidableRel (Exponence.Applies : Rule L P F → L × P → Prop) :=
+  fun r c => inferInstanceAs (Decidable (c.1 ∈ r.klass ∧ r.props ≤ c.2))
 
 instance : DecidableLE (Rule L P F) := fun r s =>
   inferInstanceAs (Decidable ((r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass))

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -107,16 +107,6 @@ structure Rule (L P F : Type*) where
 section Narrowness
 variable [PartialOrder P]
 
-/-- Applicability ([bonami-stump-2016]'s rule format): a rule applies to a cell
-`⟨L, σ⟩` when `L` is in its class and its property set is contained in `σ`. -/
-instance : Exponence.Rule (Rule L P F) (L × P) F where
-  exponent := Rule.payload
-  Applies r c := c.1 ∈ r.klass ∧ r.props ≤ c.2
-
-@[simp] theorem Rule.applies_iff {r : Rule L P F} {c : L × P} :
-    Exponence.Applies r c ↔ c.1 ∈ r.klass ∧ r.props ≤ c.2 :=
-  Iff.rfl
-
 /-- Two-clause Pāṇinian narrowness ([stump-2001]) as the carrier's order: `r` is
 at least as narrow as `s` when either they share a class and `s` realizes a
 subset of `r`'s properties, or `r`'s class is properly smaller. Intensional —
@@ -134,6 +124,18 @@ instance : Preorder (Rule L P F) where
 
 theorem Rule.le_iff {r s : Rule L P F} :
     r ≤ s ↔ (r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass :=
+  Iff.rfl
+
+variable [DecidableEq L] [DecidableLE P]
+
+/-- Applicability ([bonami-stump-2016]'s rule format): a rule applies to a cell
+`⟨L, σ⟩` when `L` is in its class and its property set is contained in `σ`. -/
+instance : Exponence.Rule (Rule L P F) (L × P) F where
+  exponent := Rule.payload
+  Applies r c := c.1 ∈ r.klass ∧ r.props ≤ c.2
+
+@[simp] theorem Rule.applies_iff {r : Rule L P F} {c : L × P} :
+    Exponence.Applies r c ↔ c.1 ∈ r.klass ∧ r.props ≤ c.2 :=
   Iff.rfl
 
 /-- For same-class rules, narrowness is applicability-set inclusion: the narrower
@@ -156,10 +158,6 @@ end Narrowness
 section Selection
 variable [PartialOrder P] [DecidableEq L] [DecidableLE P]
 
-instance (c : L × P) :
-    DecidablePred (fun r : Rule L P F => Exponence.Applies r c) :=
-  fun r => inferInstanceAs (Decidable (c.1 ∈ r.klass ∧ r.props ≤ c.2))
-
 instance : DecidableLE (Rule L P F) := fun r s =>
   inferInstanceAs (Decidable ((r.klass = s.klass ∧ s.props ≤ r.props) ∨ r.klass ⊂ s.klass))
 
@@ -180,7 +178,6 @@ def identityDefault : Rule L P (Action Z P) where
   props := ⊥
   payload := .const id
 
-omit [DecidableEq L] [DecidableLE P] in
 theorem identityDefault_applies (c : L × P) :
     Exponence.Applies (identityDefault (L := L) (Z := Z) (P := P)) c :=
   ⟨Finset.mem_univ _, bot_le⟩

--- a/Linglib/Morphology/Paradigm/Function.lean
+++ b/Linglib/Morphology/Paradigm/Function.lean
@@ -49,7 +49,7 @@ decides realized **values**, not payload equality.
 
 * `Action`, `Rule` — the payload (exponence or referral) and the
   payload-polymorphic realization rule
-* `Rule`'s `Exponence` and `Preorder` instances — applicability and two-clause
+* `Rule`'s `Exponence.Rule` and `Preorder` instances — applicability and two-clause
   narrowness; `Rule.applies_iff`, `Rule.le_iff`, `Rule.applySet_mono`
 * `identityDefault`, `le_identityDefault`,
   `selectMinimal_isSome_of_mem_identityDefault` — the IFD and its consequences
@@ -109,12 +109,12 @@ variable [PartialOrder P]
 
 /-- Applicability ([bonami-stump-2016]'s rule format): a rule applies to a cell
 `⟨L, σ⟩` when `L` is in its class and its property set is contained in `σ`. -/
-instance : Exponence (Rule L P F) (L × P) F where
+instance : Exponence.Rule (Rule L P F) (L × P) F where
   exponent := Rule.payload
   Applies r c := c.1 ∈ r.klass ∧ r.props ≤ c.2
 
 @[simp] theorem Rule.applies_iff {r : Rule L P F} {c : L × P} :
-    Exponence.Applies (F := F) r c ↔ c.1 ∈ r.klass ∧ r.props ≤ c.2 :=
+    Exponence.Applies r c ↔ c.1 ∈ r.klass ∧ r.props ≤ c.2 :=
   Iff.rfl
 
 /-- Two-clause Pāṇinian narrowness ([stump-2001]) as the carrier's order: `r` is
@@ -142,7 +142,7 @@ collapsing to [stump-2016]'s single-clause domain-subset precedence. Across
 classes the order is strictly intensional (a smaller class outranks a larger one
 whatever the property sets), so a class hypothesis is required. -/
 theorem Rule.applySet_mono {r s : Rule L P F} (hk : r.klass = s.klass) (h : r ≤ s) :
-    Exponence.applySet (F := F) r ⊆ Exponence.applySet (F := F) s := by
+    Exponence.applySet r ⊆ Exponence.applySet s := by
   rcases h with ⟨_, hp⟩ | hlt
   · intro c hc
     rw [Exponence.mem_applySet] at hc ⊢
@@ -157,7 +157,7 @@ section Selection
 variable [PartialOrder P] [DecidableEq L] [DecidableLE P]
 
 instance (c : L × P) :
-    DecidablePred (fun r : Rule L P F => Exponence.Applies (F := F) r c) :=
+    DecidablePred (fun r : Rule L P F => Exponence.Applies r c) :=
   fun r => inferInstanceAs (Decidable (c.1 ∈ r.klass ∧ r.props ≤ c.2))
 
 instance : DecidableLE (Rule L P F) := fun r s =>
@@ -182,7 +182,7 @@ def identityDefault : Rule L P (Action Z P) where
 
 omit [DecidableEq L] [DecidableLE P] in
 theorem identityDefault_applies (c : L × P) :
-    Exponence.Applies (F := Action Z P) (identityDefault (L := L) (Z := Z) (P := P)) c :=
+    Exponence.Applies (identityDefault (L := L) (Z := Z) (P := P)) c :=
   ⟨Finset.mem_univ _, bot_le⟩
 
 omit [DecidableLE P] in
@@ -200,7 +200,7 @@ theorem le_identityDefault (r : Rule L P (Action Z P)) :
 theorem selectMinimal_isSome_of_mem_identityDefault
     {v : List (Rule L P (Action Z P))} {c : L × P}
     (h : identityDefault (Z := Z) (P := P) ∈ v) : (selectMinimal v c).isSome :=
-  selectMinimal_isSome_of_exists_applicable
+  selectMinimal_isSome_iff.mpr
     ⟨identityDefault (P := P), h, identityDefault_applies c⟩
 
 end IdentityDefault
@@ -296,7 +296,7 @@ elsewhere. The mechanism shared by `identityDefault` and
 `functionCompositionDefault`. -/
 theorem selectMinimal_append_maximal {v : List (Rule L P F)} {c : L × P}
     {top : Rule L P F} (hmax : ∀ r, r ≤ top)
-    (htop : Exponence.Applies (F := F) top c) :
+    (htop : Exponence.Applies top c) :
     selectMinimal (v ++ [top]) c = (selectMinimal v c).or (some top) := by
   have htop' : c.1 ∈ top.klass ∧ top.props ≤ c.2 := htop
   have happl : applicable (v ++ [top]) c = applicable v c ++ [top] := by
@@ -336,7 +336,7 @@ def functionCompositionDefault (Lindex : Z → L) (bm bn : Block L Z P) :
   payload := .expo (fun σ z => (evalBlock Lindex bm (evalBlock Lindex bn (z, σ))).1)
 
 theorem functionCompositionDefault_applies (Lindex : Z → L) (bm bn : Block L Z P)
-    (c : L × P) : Exponence.Applies (F := Action Z P)
+    (c : L × P) : Exponence.Applies
       (functionCompositionDefault Lindex bm bn) c :=
   ⟨Finset.mem_univ _, bot_le⟩
 
@@ -380,7 +380,7 @@ theorem evalPortmanteau_eq_functionCompositionDefault (Lindex : Z → L)
     rw [List.isEmpty_iff] at h
     obtain ⟨r, hr⟩ := List.exists_mem_of_ne_nil _ h
     obtain ⟨r', hr'⟩ := Option.isSome_iff_exists.mp
-      (selectMinimal_isSome_of_exists_applicable
+      (selectMinimal_isSome_iff.mpr
         ⟨r, (mem_applicable.mp hr).1, (mem_applicable.mp hr).2⟩)
     obtain ⟨f, hf⟩ := hbmn r' (selectMinimal_mem hr')
     rw [hr', Option.some_or] at hsel

--- a/Linglib/Studies/BonamiStump2016.lean
+++ b/Linglib/Studies/BonamiStump2016.lean
@@ -53,7 +53,7 @@ def weak4b : Finset Verb := {aetla}
 /-- Strong conjugation. -/
 def strong : Finset Verb := {gripa, fljuga}
 
-local notation "IFD" => (identityDefault : Rule Verb (Finset Feat) (Action String (Finset Feat)))
+local notation "IFD" => (identityDefault : PFM.Rule Verb (Finset Feat) (Action String (Finset Feat)))
 
 /-- Block I: theme-vowel exponence ([bonami-stump-2016]'s Table 17.3). -/
 def blockI : Block Verb String (Finset Feat) :=
@@ -83,7 +83,7 @@ def blockIII : Block Verb String (Finset Feat) :=
 /-- Rules of basic stem choice ([bonami-stump-2016]'s (7)); the `GRÍPA` and
 `FLJÚGA` alternants list the umlaut/ablaut stems as data, not string
 operations. -/
-def iceStems : List (Rule Verb (Finset Feat) String) :=
+def iceStems : List (PFM.Rule Verb (Finset Feat) String) :=
   [ ⟨{kalla}, {}, "kall"⟩,
     ⟨{aetla}, {}, "ætl"⟩,
     ⟨{gripa}, {ind, pst, sg}, "greip"⟩,

--- a/Linglib/Studies/ChristopoulosZompi2023.lean
+++ b/Linglib/Studies/ChristopoulosZompi2023.lean
@@ -115,7 +115,7 @@ theorem ncc_aba_generable :
 elsewhere rule. SCC therefore cannot write a Non-Elsewhere Nominative Stem
 (the paper's §3 problem: Doric h-stems, Latvian *pat-*, English *h-*). -/
 theorem scc_nom_forces_empty {r : Rule Case3 scc F}
-    (h : Exponence.Applies (F := F) r .nom) : r.feats = ∅ :=
+    (h : Exponence.Applies r .nom) : r.feats = ∅ :=
   Finset.subset_empty.mp h
 
 /-! ### Table 25: derivations of AAA, ABB, AAB, ABC under WCC

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -138,10 +138,6 @@ def vocabulary : List (VocabItem Ctx RootIndex) :=
     sgEntry "weye"  walkRoot, elseEntry "kaate" walkRoot,
     sgEntry "mea"   killRoot, elseEntry "sua"   killRoot ]
 
-instance (c : Ctx × RootIndex) :
-    DecidablePred (fun vi : VocabItem Ctx RootIndex => Morphology.Exponence.Applies vi c) :=
-  fun vi => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
-
 /-- Spell out root `idx` in context `ctx` by Elsewhere competition over
 `vocabulary`, resolved by the shared exponence engine (`Exponence.realize`
 on the `VocabItem` specificity score) — the same selection engine as the

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -138,6 +138,9 @@ def vocabulary : List (VocabItem Ctx RootIndex) :=
     sgEntry "weye"  walkRoot, elseEntry "kaate" walkRoot,
     sgEntry "mea"   killRoot, elseEntry "sua"   killRoot ]
 
+instance : Morphology.Exponence.DecidableApplies (VocabItem Ctx RootIndex) (Ctx × RootIndex) :=
+  fun c vi => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
+
 /-- Spell out root `idx` in context `ctx` by Elsewhere competition over
 `vocabulary`, resolved by the shared exponence engine (`Exponence.realize`
 on the `VocabItem` specificity score) — the same selection engine as the

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -210,7 +210,7 @@ The mirror argument on List 3. A cran-morph (*cahoot*) has an interpretation
 only inside its licensing frame (`in [ [ √ n ] -PL ]`) and — unlike an
 ordinary root — **no Elsewhere interpretation** ([harley-2014] (16)). We
 state this with the allosemy exponence engine (`AllosemicEntry` as an
-`Morphology.Exponence` instance): `selectBy` returns a meaning in the
+`Morphology.Exponence.Rule` instance): `selectBy` returns a meaning in the
 licensed context and `none` outside it. -/
 
 /-- `√548` *cahoot*: a single LF entry, licensed only under `n` (the idiom

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -138,8 +138,9 @@ def vocabulary : List (VocabItem Ctx RootIndex) :=
     sgEntry "weye"  walkRoot, elseEntry "kaate" walkRoot,
     sgEntry "mea"   killRoot, elseEntry "sua"   killRoot ]
 
-instance : Morphology.Exponence.DecidableApplies (VocabItem Ctx RootIndex) (Ctx × RootIndex) :=
-  fun c vi => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
+instance : DecidableRel
+    (Morphology.Exponence.Applies : VocabItem Ctx RootIndex → Ctx × RootIndex → Prop) :=
+  fun vi c => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
 
 /-- Spell out root `idx` in context `ctx` by Elsewhere competition over
 `vocabulary`, resolved by the shared exponence engine (`Exponence.realize`

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -61,7 +61,7 @@ open Yukatek.Operators
     applicable operators at `r`, in inventory order — derived from the
     `Morphology.Exponence` selection API, not re-stipulated. -/
 def profile (r : Root) : List String :=
-  (Exponence.applicable (F := String) inventory r).map DiagOp.exponent
+  (Exponence.applicable inventory r).map DiagOp.exponent
 
 /-- A root's predicted salience class: the substrate classifier
     applied to its signature and the fragment's arity assignment. -/

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -502,8 +502,8 @@ instance : Exponence.Rule (FinRule Ctx F) Ctx F :=
 
 instance : Preorder (FinRule Ctx F) := Exponence.toPreorder
 
-instance : Exponence.DecidableApplies (FinRule Ctx F) Ctx :=
-  fun c r => inferInstanceAs (Decidable (c ∈ r.supp))
+instance : DecidableRel (Exponence.Applies : FinRule Ctx F → Ctx → Prop) :=
+  fun r c => inferInstanceAs (Decidable (c ∈ r.supp))
 
 omit [DecidableEq Ctx] in
 /-- Dualized support cardinality is strictly antitone in specificity: a

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -502,27 +502,19 @@ instance : Exponence.Rule (FinRule Ctx F) Ctx F :=
 
 instance : Preorder (FinRule Ctx F) := Exponence.toPreorder
 
-instance (c : Ctx) :
-    DecidablePred (fun r : FinRule Ctx F => Exponence.Applies r c) :=
-  fun r => inferInstanceAs (Decidable (c ∈ r.supp))
-
 omit [DecidableEq Ctx] in
-/-- Support cardinality reflects specificity conditionally on the
-finitely supported rules: if `s` is at least as specific as `r` (support
-inclusion) and `r`'s support is no larger, then the two coincide, so `r`
-is at least as specific as `s`. This is the conditional reflection the
-`Finset`-support engine satisfies where the linear-order engines' `iff`
-fails — card `≤` does not imply support `⊆`, but `⊆` plus card `≤` forces
-equality (`Finset.eq_of_subset_of_card_le`). -/
-private theorem finRule_card_reflection {v : List (FinRule Ctx F)} {c : Ctx} :
-    ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies r c →
-      Exponence.Applies s c → s ≤ r →
-      OrderDual.toDual s.supp.card ≤ OrderDual.toDual r.supp.card → r ≤ s :=
-  fun r _ s _ _ _ hsr hcard => by
-    have hsub : s.supp ⊆ r.supp := fun x hx => hsr hx
-    have hle : r.supp.card ≤ s.supp.card := OrderDual.toDual_le_toDual.mp hcard
-    have heq : s.supp = r.supp := Finset.eq_of_subset_of_card_le hsub hle
-    exact fun x hx => show x ∈ s.supp from heq ▸ hx
+/-- Dualized support cardinality is strictly antitone in specificity: a
+strictly broader finitely supported rule has strictly larger support
+(card `≤` does not imply support `⊆`, so the score is not an order
+embedding — strict antitonicity is exactly what the `Finset`-support
+engine retains). -/
+private theorem finRule_card_strictAnti :
+    StrictAnti (fun r : FinRule Ctx F => OrderDual.toDual r.supp.card) := by
+  intro s r hlt
+  have hsub : s.supp ⊆ r.supp := fun x hx => hlt.le hx
+  have hns : ¬ r.supp ⊆ s.supp := fun hsub' => not_le_of_gt hlt fun x hx => hsub' hx
+  exact OrderDual.toDual_lt_toDual.mpr
+    (Finset.card_lt_card (lt_of_le_not_ge hsub hns))
 
 /-- **The size principle as a specificity score** ([odonnell-2015]
 §5.5.3): selecting the finitely supported rule of least support
@@ -535,7 +527,7 @@ theorem selectByCard_isElsewhereWinner {v : List (FinRule Ctx F)} {c : Ctx}
     {r : FinRule Ctx F}
     (h : selectBy (fun s => OrderDual.toDual s.supp.card) v c = some r) :
     IsElsewhereWinner v c r :=
-  selectBy_isElsewhereWinner finRule_card_reflection h
+  selectBy_isElsewhereWinner (finRule_card_strictAnti.strictAntiOn _) h
 
 /-- **Elsewhere selection is maximum-likelihood inference**
 ([odonnell-2015] §5.5.3): a rule maximizing uniform generation

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -434,7 +434,7 @@ support properly includes another's "must assign lower probability to
 each of those forms, on average" (conservation of belief), and
 conditioning preserves the preference. The book quotes
 [kiparsky-1973]'s formulation — prefer `r₂` when
-`Inputs(r₂) ⊂ Inputs(r₁)` — which is `Morphology.Exponence`'s
+`Inputs(r₂) ⊂ Inputs(r₁)` — which is `Morphology.Exponence.Rule`'s
 specificity order (applicability-set inclusion, `Exponence.toPreorder`).
 
 Formalized in the uniform-generation case, where the preference is
@@ -496,14 +496,14 @@ structure FinRule (Ctx F : Type*) where
   supp : Finset Ctx
 
 /-- A finitely supported rule exposes the shared exponence core interface
-(`Morphology.Exponence`): applicability is support membership. -/
-instance : Exponence (FinRule Ctx F) Ctx F :=
+(`Morphology.Exponence.Rule`): applicability is support membership. -/
+instance : Exponence.Rule (FinRule Ctx F) Ctx F :=
   ⟨FinRule.exponent, fun r c => c ∈ r.supp⟩
 
 instance : Preorder (FinRule Ctx F) := Exponence.toPreorder
 
 instance (c : Ctx) :
-    DecidablePred (fun r : FinRule Ctx F => Exponence.Applies (F := F) r c) :=
+    DecidablePred (fun r : FinRule Ctx F => Exponence.Applies r c) :=
   fun r => inferInstanceAs (Decidable (c ∈ r.supp))
 
 omit [DecidableEq Ctx] in
@@ -515,8 +515,8 @@ is at least as specific as `s`. This is the conditional reflection the
 fails — card `≤` does not imply support `⊆`, but `⊆` plus card `≤` forces
 equality (`Finset.eq_of_subset_of_card_le`). -/
 private theorem finRule_card_reflection {v : List (FinRule Ctx F)} {c : Ctx} :
-    ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies (F := F) r c →
-      Exponence.Applies (F := F) s c → s ≤ r →
+    ∀ r ∈ v, ∀ s ∈ v, Exponence.Applies r c →
+      Exponence.Applies s c → s ≤ r →
       OrderDual.toDual s.supp.card ≤ OrderDual.toDual r.supp.card → r ≤ s :=
   fun r _ s _ _ _ hsr hcard => by
     have hsub : s.supp ⊆ r.supp := fun x hx => hsr hx

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -502,6 +502,9 @@ instance : Exponence.Rule (FinRule Ctx F) Ctx F :=
 
 instance : Preorder (FinRule Ctx F) := Exponence.toPreorder
 
+instance : Exponence.DecidableApplies (FinRule Ctx F) Ctx :=
+  fun c r => inferInstanceAs (Decidable (c ∈ r.supp))
+
 omit [DecidableEq Ctx] in
 /-- Dualized support cardinality is strictly antitone in specificity: a
 strictly broader finitely supported rule has strictly larger support

--- a/Linglib/Studies/Stump2016.lean
+++ b/Linglib/Studies/Stump2016.lean
@@ -197,7 +197,7 @@ def formBlock : Block KVerb String (Finset KFeat) :=
     ⟨Finset.univ, {pastB, p1, sg, masc}, .const (· ++ "yōs")⟩,
     ⟨Finset.univ, {pastC, p1, sg, masc}, .const (· ++ "yās")⟩,
     ⟨Finset.univ, {pastD, p1, sg, masc}, .const (· ++ "iyās")⟩,
-    (identityDefault : Rule KVerb (Finset KFeat) (Action String (Finset KFeat))) ]
+    (identityDefault : PFM.Rule KVerb (Finset KFeat) (Action String (Finset KFeat))) ]
 
 /-- Realization of a form cell `⟨Z, τ⟩`: the PFM1 paradigm function on the stem
 `Z` at the morphomic property set `τ`. -/

--- a/Linglib/Studies/Stump2020.lean
+++ b/Linglib/Studies/Stump2020.lean
@@ -41,7 +41,7 @@ inductive Feat | ind | sbj | imp | pres | past | p1 | p2 | p3 | sg | pl
 
 open Verb Feat
 
-local notation "IFD" => (identityDefault : Rule Verb (Finset Feat) (Action String (Finset Feat)))
+local notation "IFD" => (identityDefault : PFM.Rule Verb (Finset Feat) (Action String (Finset Feat)))
 
 /-- Block I (position i): the past-tense formative `-d-`. -/
 def blockI : Block Verb String (Finset Feat) :=


### PR DESCRIPTION
Tightens three passages from #1581: the selection-side scope note to two sentences, the class docstring to the definition plus the one SetLike difference, and toPreorder to the order fact plus the two design notes. Docstrings only.