### PR TITLE
refactor(Features/Evidentiality): cleanse; migrate fine-grained enums

### DIFF
--- a/Linglib/Features/Evidentiality.lean
+++ b/Linglib/Features/Evidentiality.lean
@@ -1,27 +1,35 @@
+import Mathlib.Tactic.TypeStar
+
 /-!
 # Evidentiality
-[aikhenvald-2004] [cumming-2026] [von-fintel-gillies-2010]
+[willett-1988] [aikhenvald-2004] [cumming-2026] [von-fintel-gillies-2010]
 
-Framework-agnostic evidentiality vocabulary: the canonical Aikhenvald
+Framework-agnostic evidentiality vocabulary: [willett-1988]'s coarse
 three-way source taxonomy, the temporal-orientation classification of
 evidence acquisition, and a typeclass `HasEvidentialPerspective` that lets
 downstream types (semantic constraint enums, paradigm rows, modal evidence
 types) project into the perspective taxonomy uniformly.
 
-All evidential sources — direct observation, hearsay, and inference — share
-the property that the speaker's evidence is **causally downstream** of the
-described event: the event causes the perceptual state, the report, or the
-observable effects from which the inference is drawn.
+In the typologically canonical case, an evidential source — direct
+observation, report, or inference from results — is **causally downstream**
+of the described event: the event causes the perceptual state, the report,
+or the observable effects. Assumption-based inferentials and predictive
+evidentials fall outside this pattern; the `prospective` perspective and the
+`Option` codomain of the projection accommodate them.
 
-This module supplies the shared vocabulary that bridges
+This module supplies the shared vocabulary consumed by both
 [cumming-2026]'s tense evidentiality (T ≤ A = downstream evidence) and
-[von-fintel-gillies-2010] epistemic evidentiality (direct vs indirect).
-
+[von-fintel-gillies-2010]'s epistemic evidentiality (direct vs indirect).
+[aikhenvald-2004]'s finer six-way parameter carving lives with the
+evidential lexical API at `Semantics/Evidential/`.
 -/
 
 namespace Features.Evidentiality
 
-/-- Canonical three-way evidential source classification ([aikhenvald-2004]). -/
+/-- Coarse three-way evidential source classification: [willett-1988]'s
+    attested / reported / inferring tripartition. `hearsay` is the umbrella
+    for Willett's reported category (subsuming hearsay proper and quotative);
+    finer carvings ([aikhenvald-2004]) live at `Semantics/Evidential/`. -/
 inductive CoarseSource where
   /-- Direct sensory observation (seeing, hearing the event). -/
   | direct
@@ -51,7 +59,7 @@ inductive EvidentialPerspective where
     where some values (e.g. an `unconstrained` future) have no canonical
     perspective. Types with a total projection (the source taxonomy itself,
     or the perspective type) wrap the result in `some`. -/
-class HasEvidentialPerspective (α : Type) where
+class HasEvidentialPerspective (α : Type*) where
   /-- The evidential perspective of `a`, when defined. -/
   toEvidentialPerspective : α → Option EvidentialPerspective
 
@@ -64,19 +72,17 @@ export HasEvidentialPerspective (toEvidentialPerspective)
     Defined uniformly over `HasEvidentialPerspective` so that downstream
     types (constraint enums, paradigm rows, modal evidence types) inherit
     one decidable predicate instead of hand-rolling parallel definitions. -/
-def IsNonfuture {α : Type} [HasEvidentialPerspective α] (a : α) : Prop :=
+def IsNonfuture {α : Type*} [HasEvidentialPerspective α] (a : α) : Prop :=
   toEvidentialPerspective a = some .retrospective ∨
   toEvidentialPerspective a = some .contemporaneous
 
-instance {α : Type} [HasEvidentialPerspective α] :
+instance {α : Type*} [HasEvidentialPerspective α] :
     DecidablePred (@IsNonfuture α _) :=
   fun _ => inferInstanceAs (Decidable (_ ∨ _))
 
--- ════════════════════════════════════════════════════════════════
--- § Canonical instances
--- ════════════════════════════════════════════════════════════════
+/-! ### Canonical instances -/
 
-/-- The Aikhenvald source taxonomy projects to perspective by the canonical
+/-- The coarse source taxonomy projects to perspective by the canonical
     typological mapping: direct observation is contemporaneous (A = T), while
     hearsay and inference are retrospective (A ≥ T). The event causally
     precedes or coincides with evidence acquisition in all three cases.
@@ -96,60 +102,5 @@ instance : HasEvidentialPerspective CoarseSource where
 /-- The perspective type projects to itself. -/
 instance : HasEvidentialPerspective EvidentialPerspective where
   toEvidentialPerspective := some
-
-/-- Dot-notation alias for `Features.Evidentiality.IsNonfuture` on perspectives. -/
-def EvidentialPerspective.IsNonfuture (p : EvidentialPerspective) : Prop :=
-  Features.Evidentiality.IsNonfuture p
-
-instance : DecidablePred EvidentialPerspective.IsNonfuture :=
-  fun _ => inferInstanceAs (Decidable (Features.Evidentiality.IsNonfuture _))
-
--- ════════════════════════════════════════════════════════════════
--- § Simp lemmas
--- ════════════════════════════════════════════════════════════════
-
-@[simp] theorem CoarseSource.toEvidentialPerspective_direct :
-    CoarseSource.toEvidentialPerspective .direct = some .contemporaneous := rfl
-
-@[simp] theorem CoarseSource.toEvidentialPerspective_hearsay :
-    CoarseSource.toEvidentialPerspective .hearsay = some .retrospective := rfl
-
-@[simp] theorem CoarseSource.toEvidentialPerspective_inference :
-    CoarseSource.toEvidentialPerspective .inference = some .retrospective := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § Fine-grained source taxonomies (Aikhenvald 2004)
--- ════════════════════════════════════════════════════════════════
-
-/-- Sensory channel of a direct (firsthand) evidential. The visual vs
-    non-visual contrast is grammaticalized in many languages
-    (Tuyuca, Tariana, Kashaya); finer distinctions (auditory vs other
-    non-visual sensory) are grammaticalized in some (Kashaya). Languages
-    that don't grammaticalize the contrast use `.unspecified`. -/
-inductive DirectSource where
-  | unspecified
-  | visual
-  | auditory
-  | nonvisualSensory
-  | olfactory
-  deriving DecidableEq, Repr, Inhabited
-
-/-- Source-identity of a reportative evidential. Aikhenvald 2004 distinguishes
-    `hearsay` (original speaker not identified) from `quotative` (specifically
-    named source). -/
-inductive ReportativeSource where
-  | unspecified
-  | unidentified
-  | identified
-  deriving DecidableEq, Repr, Inhabited
-
-/-- Basis of an inferential evidential. Aikhenvald 2004 distinguishes
-    inference `fromResult` (observable consequences) from `fromAssumption`
-    (general knowledge / reasoning). -/
-inductive InferentialBasis where
-  | unspecified
-  | fromResult
-  | fromAssumption
-  deriving DecidableEq, Repr, Inhabited
 
 end Features.Evidentiality

--- a/Linglib/Features/Evidentiality.lean
+++ b/Linglib/Features/Evidentiality.lean
@@ -39,6 +39,15 @@ inductive CoarseSource where
   | inference
   deriving DecidableEq, Repr, Inhabited
 
+/-- A coarse source is *indirect* iff it is not direct observation. The
+    shared contrast variable of indirect-evidential operators:
+    [izvorski-1997]'s EV and [von-fintel-gillies-2010]'s *must* both
+    presuppose an indirect evidence basis. -/
+def CoarseSource.IsIndirect (s : CoarseSource) : Prop := s ≠ .direct
+
+instance : DecidablePred CoarseSource.IsIndirect := fun s =>
+  inferInstanceAs (Decidable (s ≠ .direct))
+
 /-- Evidential perspective: the temporal relation of evidence acquisition
     to the described event. [cumming-2026]'s three evidential
     orientations, named in framework-agnostic terms. -/

--- a/Linglib/Semantics/Evidential/Basic.lean
+++ b/Linglib/Semantics/Evidential/Basic.lean
@@ -25,8 +25,6 @@ set_option autoImplicit false
 
 namespace Semantics.Evidential
 
-open Features.Evidentiality (DirectSource ReportativeSource InferentialBasis)
-
 /-- A cell in [aikhenvald-2004] Ch 2's paradigm space. Each `Entry`
     covers one cell; `AikhenvaldSystem.fromInventory` then classifies a
     paradigm by inspecting which cells are filled. -/
@@ -55,7 +53,6 @@ def Entry.cell : Entry → Entry.Cell
   | .direct      ⟨_, _, .visual⟩           => .visual
   | .direct      ⟨_, _, .auditory⟩         => .auditory
   | .direct      ⟨_, _, .nonvisualSensory⟩ => .nonvisualSensory
-  | .direct      ⟨_, _, .olfactory⟩        => .nonvisualSensory
   | .inferential ⟨_, _, .unspecified⟩      => .inferred
   | .inferential ⟨_, _, .fromResult⟩       => .inferred
   | .inferential ⟨_, _, .fromAssumption⟩   => .assumed

--- a/Linglib/Semantics/Evidential/Defs.lean
+++ b/Linglib/Semantics/Evidential/Defs.lean
@@ -1,5 +1,3 @@
-import Linglib.Features.Evidentiality
-
 /-!
 # Evidential — lexical structure for evidential markers
 [aikhenvald-2004] [de-haan-2013] [murray-2017]
@@ -9,7 +7,7 @@ The evidential as a lexical object, following the Determiner-API pattern
 universal to all evidential markers — a surface `form`; each specialization
 (`DirectEvidential`, `ReportativeEvidential`, `InferentialEvidential`) adds
 its own structure: an `Exponent` (realization strategy) plus a fine-grained
-feature value drawn from `Features.Evidentiality`.
+source value ([aikhenvald-2004]'s parameter carving).
 
 A language's evidential inventory is a `List Evidential.Entry` (heterogeneous
 across the three kinds) declared in its Fragment. Typological classifications
@@ -23,6 +21,8 @@ a language's WALS cell is a theorem about its declared evidentials.
 * `DirectEvidential`, `ReportativeEvidential`, `InferentialEvidential` —
   the three Aikhenvald-coarse specializations.
 * `Evidential.Exponent` — realization-strategy enum (analysis-neutral).
+* `DirectSource`, `ReportativeSource`, `InferentialBasis` — the
+  [aikhenvald-2004] fine-grained source taxonomies the specializations carry.
 * `Evidential.Entry` — an evidential occurrence in a language's inventory.
 
 ## Implementation notes
@@ -39,10 +39,39 @@ a language's WALS cell is a theorem about its declared evidentials.
 
 set_option autoImplicit false
 
-open Features.Evidentiality
-  (DirectSource ReportativeSource InferentialBasis)
-
 namespace Semantics.Evidential
+
+/-! ### Fine-grained source taxonomies ([aikhenvald-2004]) -/
+
+/-- Sensory channel of a direct (firsthand) evidential. The visual vs
+    non-visual contrast is grammaticalized in many languages
+    (Tuyuca, Tariana, Kashaya); finer distinctions (auditory vs other
+    non-visual sensory) are grammaticalized in some (Kashaya). Languages
+    that don't grammaticalize the contrast use `.unspecified`. -/
+inductive DirectSource where
+  | unspecified
+  | visual
+  | auditory
+  | nonvisualSensory
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Source-identity of a reportative evidential. [aikhenvald-2004]
+    distinguishes hearsay (original speaker not identified) from quotative
+    (specifically named source). -/
+inductive ReportativeSource where
+  | unspecified
+  | unidentified
+  | identified
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Basis of an inferential evidential. [aikhenvald-2004] distinguishes
+    inference `fromResult` (observable consequences) from `fromAssumption`
+    (general knowledge / reasoning). -/
+inductive InferentialBasis where
+  | unspecified
+  | fromResult
+  | fromAssumption
+  deriving DecidableEq, Repr, Inhabited
 
 /-- How an evidential is morphosyntactically realized. Analysis-neutral —
     distinguishes Bulgarian-style TAM-fusion from Cuzco-Quechua-style
@@ -67,6 +96,8 @@ inductive Exponent where
   deriving DecidableEq, Repr
 
 end Semantics.Evidential
+
+open Semantics.Evidential (DirectSource ReportativeSource InferentialBasis)
 
 /-- The base evidential lexical item: only what is universal — a surface
     form. Specializations (`DirectEvidential`, `ReportativeEvidential`,

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -30,9 +30,9 @@ The key empirical contrasts establishing (8):
 
 namespace Izvorski1997
 
--- ════════════════════════════════════════════════════
--- § 1. Languages with PE
--- ════════════════════════════════════════════════════
+open Features.Evidentiality
+
+/-! ### Languages with PE -/
 
 /-- Languages exhibiting the Perfect of Evidentiality ([izvorski-1997], fn. 1).
     The paper's body text discusses Bulgarian, Turkish, and Norwegian;
@@ -41,19 +41,13 @@ inductive PELanguage where
   | bulgarian | turkish | norwegian | macedonian | albanian
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 2. Event vs. Must: Same Force, Different Base
--- ════════════════════════════════════════════════════
+/-! ### Event vs. Must: same force, different base -/
 
-/-- Binary evidence basis: Izvorski's central contrast variable.
-    The paper argues that Event and must have the same quantificational
-    force (□) but differ in whether the modal base is restricted to
-    indirect evidence only. -/
-inductive EvidenceBasis where
-  | direct | indirect
-  deriving DecidableEq, Repr
-
-/-- A data point from the Event/must paradigm.
+/-- A data point from the Event/must paradigm. The contrast variable is
+    the coarse evidence source; Izvorski's binary direct/indirect cut is
+    `CoarseSource.IsIndirect`. The paper argues that Event and must have
+    the same quantificational force (□) but differ in whether the modal
+    base is restricted to indirect evidence only.
     The paper's argument (§3, pp. 227–229):
     - (10)–(11): With indirect evidence, both Event and must are felicitous
     - (12)–(13): Event + "I have no evidence" → contradictory;
@@ -62,16 +56,17 @@ inductive EvidenceBasis where
     - Prose (p. 228): With direct evidence (speaker witnessed the event),
       Event is infelicitous; must is fine -/
 structure EvMustDatum where
-  evidenceBasis : EvidenceBasis
+  evidenceBasis : CoarseSource
   evFelicitous : Bool
   mustFelicitous : Bool
   label : String
   deriving Repr, BEq
 
 /-- Indirect evidence context: both Event and must felicitous.
-    Paper (10)–(11): "Knowing how much John likes wine..." -/
+    Paper (10)–(11): "Knowing how much John likes wine..." — inference
+    from general knowledge. -/
 def evMust_indirect : EvMustDatum where
-  evidenceBasis := .indirect
+  evidenceBasis := .inference
   evFelicitous := true
   mustFelicitous := true
   label := "(10)–(11): indirect evidence context"
@@ -88,9 +83,7 @@ def evMust_direct : EvMustDatum where
 /-- All Event/must data points. -/
 def evMustData : List EvMustDatum := [evMust_indirect, evMust_direct]
 
--- ════════════════════════════════════════════════════
--- § 3. Presupposition Diagnostics ((14)–(16))
--- ════════════════════════════════════════════════════
+/-! ### Presupposition diagnostics ((14)–(16)) -/
 
 /-- Standard presupposition diagnostics applied to the evidential. -/
 inductive PresupDiagnostic where
@@ -132,39 +125,31 @@ def presup_denial : PresupDiagnosticDatum where
 def presupData : List PresupDiagnosticDatum :=
   [presup_cancellation, presup_projection, presup_denial]
 
--- ════════════════════════════════════════════════════
--- § 4. Generalizations
--- ════════════════════════════════════════════════════
+/-! ### Generalizations -/
 
-/-- Event requires indirect evidence: felicitous with indirect, infelicitous
-    with direct. This captures (8ii). -/
-def evRequiresIndirect (d : EvMustDatum) : Bool :=
-  match d.evidenceBasis with
-  | .indirect => d.evFelicitous
-  | .direct => !d.evFelicitous
+/-- Event requires indirect evidence: felicitous exactly when the evidence
+    basis is `CoarseSource.IsIndirect`. This captures (8ii). -/
+def EvRequiresIndirect (d : EvMustDatum) : Prop :=
+  d.evFelicitous ↔ d.evidenceBasis.IsIndirect
 
-/-- Must allows both evidence bases — no presupposition on evidence type. -/
-def mustAllowsBoth (d : EvMustDatum) : Bool := d.mustFelicitous
+instance : DecidablePred EvRequiresIndirect := fun _ =>
+  inferInstanceAs (Decidable (_ ↔ _))
 
 /-- All data points satisfy the indirect-evidence generalization. -/
-theorem all_evRequiresIndirect :
-    evMustData.all evRequiresIndirect = true := by native_decide
+theorem all_evRequiresIndirect : ∀ d ∈ evMustData, EvRequiresIndirect d := by
+  decide
 
-/-- All data points satisfy the must-allows-both generalization. -/
-theorem all_mustAllowsBoth :
-    evMustData.all mustAllowsBoth = true := by native_decide
+/-- Must allows both evidence bases — no presupposition on evidence type. -/
+theorem all_mustAllowsBoth : ∀ d ∈ evMustData, d.mustFelicitous := by decide
 
 /-- All diagnostics confirm presupposition status (not implicature). -/
-theorem all_evidentialSurvives :
-    presupData.all (·.evidentialSurvives) = true := by native_decide
+theorem all_evidentialSurvives : ∀ d ∈ presupData, d.evidentialSurvives := by
+  decide
 
--- ════════════════════════════════════════════════════
--- § Bridge: EV Operator and Modal Semantics
--- ════════════════════════════════════════════════════
+/-! ### Bridge: EV operator and modal semantics -/
 
 open Semantics.Modality.Kratzer
 open Semantics.Presupposition
-open Features.Evidentiality
 open Tense.Evidential
 open Bulgarian.Evidentials
 

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Evidentiality
 import Linglib.Data.Examples.VonFintelGillies2010
+import Linglib.Studies.Izvorski1997
 
 /-!
 # von Fintel & Gillies (2010): *Must* ... Stay! Strong!
@@ -22,11 +23,13 @@ must not directly settle the prejacent.
   classification and its collapse onto the Aikhenvald taxonomy
 - `must_felicitous_iff_indirect`: over the example rows, the modalized
   member of a bare/modal minimal pair is felicitous iff the speaker's
-  evidence is not coarse-direct
+  evidence source `IsIndirect`
 - `cant_patterns_with_must`: the same biconditional restricted to the
   *can't* rows, derived from the previous theorem
 - `must_entails_prejacent`: every minimal pair records prejacent
   entailment — including the infelicitous direct-evidence rows
+- `must_evidence_matches_izvorski_ev`: *must* imposes the same
+  indirect-evidence restriction as [izvorski-1997]'s Bulgarian EV
 -/
 
 namespace VonFintelGillies2010
@@ -34,9 +37,7 @@ namespace VonFintelGillies2010
 open Features.Evidentiality
 open Data.Examples
 
--- ============================================================================
--- § 1  Evidence Types
--- ============================================================================
+/-! ### Evidence types -/
 
 /-- The type of evidence the speaker has for the prejacent. -/
 inductive EvidenceType where
@@ -67,9 +68,7 @@ theorem all_evidence_types_nonfuture (e : EvidenceType) :
     Features.Evidentiality.IsNonfuture e := by
   cases e <;> decide
 
--- ============================================================================
--- § 2  Adapters over the Example Rows
--- ============================================================================
+/-! ### Adapters over the example rows -/
 
 /-- Evidence-type adapter: the row's `evidence` feature as an
     `EvidenceType`. -/
@@ -85,18 +84,16 @@ def evidenceOf (row : LinguisticExample) : Option EvidenceType :=
 def mustPairs : List LinguisticExample :=
   Examples.all.filter (·.feature? "kind" == some "must_pair")
 
--- ============================================================================
--- § 3  The Evidential Restriction
--- ============================================================================
+/-! ### The evidential restriction -/
 
 /-- **Evidential restriction**: a *must*/*can't* sentence is felicitous
-    iff the speaker's evidence is not coarse-direct. Direct perception
+    iff the speaker's evidence source `IsIndirect`. Direct perception
     (exx. 6, 23) blocks the modal; inference — causal (exx. 7, 21, 24, 26)
     or by elimination (ex. 12) — licenses it. -/
 theorem must_felicitous_iff_indirect :
     ∀ row ∈ mustPairs,
       row.judgment = .acceptable ↔
-        (evidenceOf row).map EvidenceType.toCoarseSource ≠ some .direct := by
+        ∀ e ∈ evidenceOf row, e.toCoarseSource.IsIndirect := by
   decide
 
 /-- **Can't patterns with must**: the evidential restriction holds
@@ -105,12 +102,22 @@ theorem must_felicitous_iff_indirect :
 theorem cant_patterns_with_must :
     ∀ row ∈ mustPairs.filter (·.feature? "modal" == some "cant"),
       row.judgment = .acceptable ↔
-        (evidenceOf row).map EvidenceType.toCoarseSource ≠ some .direct :=
+        ∀ e ∈ evidenceOf row, e.toCoarseSource.IsIndirect :=
   fun row hrow => must_felicitous_iff_indirect row (List.mem_filter.mp hrow).1
 
--- ============================================================================
--- § 4  Must is Strong
--- ============================================================================
+/-- ***Must* imposes [izvorski-1997]'s EV restriction**: felicity of the
+    modalized member tracks `CoarseSource.IsIndirect` of the evidence
+    source in VF&G's *must* rows exactly as in Izvorski's Bulgarian EV
+    paradigm — the two epistemic operators presuppose the same coarse
+    indirect-evidence basis. -/
+theorem must_evidence_matches_izvorski_ev :
+    (∀ row ∈ mustPairs,
+      row.judgment = .acceptable ↔
+        ∀ e ∈ evidenceOf row, e.toCoarseSource.IsIndirect) ∧
+    ∀ d ∈ Izvorski1997.evMustData, Izvorski1997.EvRequiresIndirect d :=
+  ⟨must_felicitous_iff_indirect, Izvorski1997.all_evRequiresIndirect⟩
+
+/-! ### Must is strong -/
 
 /-- **Must is strong**: every minimal pair records that the modalized
     sentence entails its prejacent — including the direct-evidence rows

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -37386,3 +37386,17 @@
   role      = {cited},
   sources   = {Morphology/Paradigm/Linkage.lean}
 }
+@article{willett-1988,
+  author    = {Willett, Thomas},
+  year      = {1988},
+  title     = {A Cross-Linguistic Survey of the Grammaticization of Evidentiality},
+  journal   = {Studies in Language},
+  volume    = {12},
+  number    = {1},
+  pages     = {51--97},
+  doi       = {10.1075/sl.12.1.04wil},
+  subfield  = {semantics/compositional},
+  role      = {cited},
+  validated = {true},
+  sources   = {Features/Evidentiality.lean}
+}


### PR DESCRIPTION
Four-lens audit cleanse of `Features/Evidentiality.lean` plus the density fixes it surfaced.

- Re-attribute the coarse direct/hearsay/inference tripartition to Willett 1988 (new verified bib entry); hedge the causally-downstream claim; `Type` → `Type*`; `/-! ### -/` headers; delete unused simp lemmas and the dead `EvidentialPerspective.IsNonfuture` wrapper.
- Migrate `DirectSource`/`ReportativeSource`/`InferentialBasis` to their owning API at `Semantics/Evidential/Defs.lean`; drop the dead `olfactory` constructor.
- Promote `CoarseSource.IsIndirect`; re-found Izvorski1997's re-stipulated `EvidenceBasis` on it (also replacing three `native_decide`s with `decide`); restate the VF&G evidential restriction through it and add the Izvorski↔VF&G same-restriction bridge theorem.