### PR TITLE
refactor(Semantics/Evidential): dissolve Features/Evidentiality into Source

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -662,7 +662,6 @@ import Linglib.Features.Definiteness
 import Linglib.Features.Deixis
 import Linglib.Features.Dimension
 import Linglib.Features.Empathy
-import Linglib.Features.Evidentiality
 import Linglib.Features.Expressive
 import Linglib.Features.Gender.Basic
 import Linglib.Features.Gender.Capabilities
@@ -1628,6 +1627,7 @@ import Linglib.Semantics.Events.CEM
 import Linglib.Semantics.Evidential.Basic
 import Linglib.Semantics.Evidential.Defs
 import Linglib.Semantics.Evidential.Epistemicity
+import Linglib.Semantics.Evidential.Source
 import Linglib.Semantics.Exhaustification.Chain
 import Linglib.Semantics.Exhaustification.Combinators
 import Linglib.Semantics.Exhaustification.Excluder

--- a/Linglib/Features/Expressive.lean
+++ b/Linglib/Features/Expressive.lean
@@ -8,7 +8,7 @@ lexeme as expressive and record which construction class it belongs to; theories
 it a denotation (`Pragmatics.Expressives.TwoDimProp`, an outlook-indexed meaning,
 use-conditional types, …) and are judged on whether they predict its diagnostic behavior.
 
-This is **object-level data** (like `Features.Person`, `Features.Evidentiality`): a tag, not
+This is **object-level data** (like `Features.Person`): a tag, not
 a denotation. It is `Prop`-free and depends on no theory layer, so Fragments may import it
 without pulling in any account of conventional implicature. The diagnostic *fingerprint*
 (`Pragmatics.Expressives.SecondaryMeaningProperties`) and the denotations live one layer up.

--- a/Linglib/Features/Mirativity.lean
+++ b/Linglib/Features/Mirativity.lean
@@ -10,7 +10,7 @@ the two categories are often conveyed by overlapping morphology (e.g.,
 Turkish *-mIş*), but they answer distinct questions ("what is the source of
 the evidence?" vs "is the content surprising?").
 
-This module is intentionally separate from `Features.Evidentiality` to reflect
+This module is intentionally separate from `Semantics.Evidential` to reflect
 that independence; bundling structures that combine source, authority, and
 mirativity (e.g. `Semantics.Epistemicity.EpistemicProfile`) import both.
 

--- a/Linglib/Semantics/Context/Rich.lean
+++ b/Linglib/Semantics/Context/Rich.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Context.Tower
 import Linglib.Semantics.Context.Shifts
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 
 /-!
 # Rich Context
@@ -30,7 +30,7 @@ express:
 namespace Semantics.Context
 
 open Semantics.Context (KContext ContextTower ContextShift)
-open Features.Evidentiality
+open Semantics.Evidential
 
 -- ════════════════════════════════════════════════════════════════
 -- § Rich Context

--- a/Linglib/Semantics/Evidential/Basic.lean
+++ b/Linglib/Semantics/Evidential/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Evidential.Defs
+import Linglib.Semantics.Evidential.Source
 
 /-!
 # Evidential — derived properties
@@ -59,5 +60,43 @@ def Entry.cell : Entry → Entry.Cell
   | .reportative ⟨_, _, .unspecified⟩      => .reported
   | .reportative ⟨_, _, .unidentified⟩     => .reported
   | .reportative ⟨_, _, .identified⟩       => .quotative
+
+/-! ### Coarse source and perspective -/
+
+/-- Collapse an Aikhenvald cell to its [willett-1988] coarse source. -/
+def Entry.Cell.toCoarseSource : Entry.Cell → CoarseSource
+  | .firsthand | .visual | .nonvisualSensory | .auditory => .direct
+  | .inferred | .assumed => .inference
+  | .reported | .quotative => .hearsay
+
+/-- The coarse source of an entry: the three `Entry` kinds are exactly the
+    [willett-1988] tripartition. -/
+def Entry.toCoarseSource : Entry → CoarseSource
+  | .direct _      => .direct
+  | .reportative _ => .hearsay
+  | .inferential _ => .inference
+
+/-- The taxonomy tower commutes: collapsing an entry's Aikhenvald cell
+    gives its coarse source. -/
+theorem Entry.cell_toCoarseSource (e : Entry) :
+    e.cell.toCoarseSource = e.toCoarseSource := by
+  cases e with
+  | direct d => obtain ⟨_, _, s⟩ := d; cases s <;> rfl
+  | reportative d => obtain ⟨_, _, s⟩ := d; cases s <;> rfl
+  | inferential d => obtain ⟨_, _, s⟩ := d; cases s <;> rfl
+
+/-- Inventory entries declare their coarse source; the evidential
+    perspective derives via the canonical source mapping. -/
+instance : HasCoarseSource Entry where
+  toCoarseSource e := some e.toCoarseSource
+
+/-- Every inventory entry is nonfuture: all three coarse sources are
+    causally downstream of the described event (T ≤ A) under the
+    canonical mapping. -/
+theorem Entry.isNonfuture (e : Entry) : IsNonfuture e := by
+  cases e with
+  | direct _ => exact .inr rfl
+  | reportative _ => exact .inl rfl
+  | inferential _ => exact .inl rfl
 
 end Semantics.Evidential

--- a/Linglib/Semantics/Evidential/Epistemicity.lean
+++ b/Linglib/Semantics/Evidential/Epistemicity.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Linglib.Features.Mirativity
 import Linglib.Semantics.Context.Tower
 
@@ -13,7 +13,7 @@ dimensions to the model-theoretic level (`KContext` / `ContextTower`).
 ## Motivation
 
 [gawne-spronck-2024] identify 10 concept areas forming a coherent epistemic
-domain. Linglib already covers evidential source (`Features/Evidentiality.lean`),
+domain. Linglib already covers evidential source (`Semantics/Evidential/Source.lean`),
 epistemic modality (`Modality/Kernel.lean`), and mirativity (`Features/Mirativity.lean`),
 but these are scattered with no connective tissue. The main gap is **egophoricity** -- the
 dimension of WHO has privileged epistemic access (speaker vs addressee vs third
@@ -37,7 +37,7 @@ extension respectively) and are left for future work.
 
 namespace Semantics.Epistemicity
 
-open Features.Evidentiality
+open Semantics.Evidential
 open Features.Mirativity
 open Semantics.Context
 

--- a/Linglib/Semantics/Evidential/Source.lean
+++ b/Linglib/Semantics/Evidential/Source.lean
@@ -1,14 +1,15 @@
 import Mathlib.Tactic.TypeStar
 
 /-!
-# Evidentiality
+# Evidential — coarse source and perspective
 [willett-1988] [aikhenvald-2004] [cumming-2026] [von-fintel-gillies-2010]
 
 Framework-agnostic evidentiality vocabulary: [willett-1988]'s coarse
 three-way source taxonomy, the temporal-orientation classification of
-evidence acquisition, and a typeclass `HasEvidentialPerspective` that lets
-downstream types (semantic constraint enums, paradigm rows, modal evidence
-types) project into the perspective taxonomy uniformly.
+evidence acquisition, and the typeclasses `HasCoarseSource` and
+`HasEvidentialPerspective` that let downstream types (semantic constraint
+enums, paradigm rows, modal evidence types) project into the taxonomies
+uniformly.
 
 In the typologically canonical case, an evidential source — direct
 observation, report, or inference from results — is **causally downstream**
@@ -21,10 +22,10 @@ This module supplies the shared vocabulary consumed by both
 [cumming-2026]'s tense evidentiality (T ≤ A = downstream evidence) and
 [von-fintel-gillies-2010]'s epistemic evidentiality (direct vs indirect).
 [aikhenvald-2004]'s finer six-way parameter carving lives with the
-evidential lexical API at `Semantics/Evidential/`.
+evidential lexical API in the sibling `Defs`/`Basic` files.
 -/
 
-namespace Features.Evidentiality
+namespace Semantics.Evidential
 
 /-- Coarse three-way evidential source classification: [willett-1988]'s
     attested / reported / inferring tripartition. `hearsay` is the umbrella
@@ -89,6 +90,17 @@ instance {α : Type*} [HasEvidentialPerspective α] :
     DecidablePred (@IsNonfuture α _) :=
   fun _ => inferInstanceAs (Decidable (_ ∨ _))
 
+/-- Types that project to a coarse evidential source. The stronger entry
+    point into the vocabulary: declaring a source also yields a
+    perspective, via the canonical source mapping (the low-priority
+    instance below). Types whose evidence classification cross-cuts the
+    source taxonomy project partially (`none` off the shared part). -/
+class HasCoarseSource (α : Type*) where
+  /-- The coarse evidential source of `a`, when defined. -/
+  toCoarseSource : α → Option CoarseSource
+
+export HasCoarseSource (toCoarseSource)
+
 /-! ### Canonical instances -/
 
 /-- The coarse source taxonomy projects to perspective by the canonical
@@ -105,11 +117,19 @@ def CoarseSource.toEvidentialPerspective :
   | .hearsay   => some .retrospective
   | .inference => some .retrospective
 
-instance : HasEvidentialPerspective CoarseSource where
-  toEvidentialPerspective := CoarseSource.toEvidentialPerspective
+instance : HasCoarseSource CoarseSource where
+  toCoarseSource := some
+
+/-- Source-declaring types inherit their perspective through the canonical
+    mapping. Low priority: a type with its own perspective classification
+    keeps it. -/
+instance (priority := 100) {α : Type*} [HasCoarseSource α] :
+    HasEvidentialPerspective α where
+  toEvidentialPerspective a :=
+    (toCoarseSource a).bind CoarseSource.toEvidentialPerspective
 
 /-- The perspective type projects to itself. -/
 instance : HasEvidentialPerspective EvidentialPerspective where
   toEvidentialPerspective := some
 
-end Features.Evidentiality
+end Semantics.Evidential

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Tense.Compositional
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Linglib.Features.Mirativity
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Mood.Defs
@@ -42,13 +42,13 @@ The tense evidential constraint parallels [von-fintel-gillies-2010]
 `kernelMust` presupposition: both require non-direct evidence. (A formal
 bridge between the two phenomena has not been built.)
 
-## Connection to Features.Evidentiality
+## Connection to Semantics.Evidential
 
 `EPCondition` is a `HasEvidentialPerspective` instance: each of the five EP
 constraint shapes maps to (an `Option` of) the canonical `EvidentialPerspective`
-classification in `Features.Evidentiality`. `EPCondition.IsNonfuture` and
+classification in `Semantics.Evidential`. `EPCondition.IsNonfuture` and
 `TAMEEntry.IsNonfuture` are dot-notation aliases for the typeclass-derived
-`Features.Evidentiality.IsNonfuture` predicate.
+`Semantics.Evidential.IsNonfuture` predicate.
 
 -/
 
@@ -58,7 +58,7 @@ namespace Tense.Evidential
 
 open Core.Order
 open Tense
-open Features.Evidentiality
+open Semantics.Evidential
 open Features.Mirativity
 open Semantics.Presupposition
 
@@ -118,15 +118,15 @@ def EPCondition.toEvidentialPerspective : EPCondition → Option EvidentialPersp
 instance : HasEvidentialPerspective EPCondition where
   toEvidentialPerspective := EPCondition.toEvidentialPerspective
 
-/-- Dot-notation alias for the typeclass-derived `Features.Evidentiality.IsNonfuture`
+/-- Dot-notation alias for the typeclass-derived `Semantics.Evidential.IsNonfuture`
     on EP constraint shapes. Downstream, strict downstream, and contemporaneous
     all project to retrospective/contemporaneous; prospective and unconstrained
     do not. -/
 def EPCondition.IsNonfuture (e : EPCondition) : Prop :=
-  Features.Evidentiality.IsNonfuture e
+  Semantics.Evidential.IsNonfuture e
 
 instance : DecidablePred EPCondition.IsNonfuture :=
-  fun _ => inferInstanceAs (Decidable (Features.Evidentiality.IsNonfuture _))
+  fun _ => inferInstanceAs (Decidable (Semantics.Evidential.IsNonfuture _))
 
 @[simp] theorem EPCondition.toEvidentialPerspective_downstream :
     EPCondition.toEvidentialPerspective .downstream = some .retrospective := rfl
@@ -191,13 +191,13 @@ structure TAMEEntry where
 instance : HasEvidentialPerspective TAMEEntry where
   toEvidentialPerspective p := toEvidentialPerspective p.ep
 
-/-- Dot-notation alias for the typeclass-derived `Features.Evidentiality.IsNonfuture`
+/-- Dot-notation alias for the typeclass-derived `Semantics.Evidential.IsNonfuture`
     on TAME paradigm rows. A row is nonfuture iff its EP constraint is. -/
 def TAMEEntry.IsNonfuture (p : TAMEEntry) : Prop :=
-  Features.Evidentiality.IsNonfuture p
+  Semantics.Evidential.IsNonfuture p
 
 instance : DecidablePred TAMEEntry.IsNonfuture :=
-  fun _ => inferInstanceAs (Decidable (Features.Evidentiality.IsNonfuture _))
+  fun _ => inferInstanceAs (Decidable (Semantics.Evidential.IsNonfuture _))
 
 /-- The EP constraint as a predicate over `EvidentialFrame ℤ`. -/
 def TAMEEntry.epConstraint (p : TAMEEntry) :

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -312,7 +312,7 @@ theorem direct_evidence_blocks_both :
 -- ── § Epistemic authority bridge ──
 
 open Semantics.Epistemicity
-open Features.Evidentiality
+open Semantics.Evidential
 
 /-- Strong assertions (ego + direct) correspond to settling kernels.
     When the speaker has privileged access AND direct evidence, the

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Linglib.Semantics.Modality.Kratzer.Operators
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Tense.Evidential
@@ -30,7 +30,7 @@ The key empirical contrasts establishing (8):
 
 namespace Izvorski1997
 
-open Features.Evidentiality
+open Semantics.Evidential
 
 /-! ### Languages with PE -/
 

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -136,6 +136,24 @@ theorem core_count : coreData.length = 3 := rfl
 theorem triangle_predicts_all :
     coreData.all (fun d => d.evidentialFelicitous == trianglePredicts d) = true := rfl
 
+/-! ### Evidential Perspective -/
+
+open Semantics.Evidential
+
+/-- A datum's evidential perspective is read off temporal overlap:
+    overlapping learning events are contemporaneous, non-overlapping ones
+    retrospective (in Koev's PE data the learning event follows the
+    described event). -/
+instance : HasEvidentialPerspective EvidentialDatum where
+  toEvidentialPerspective d :=
+    match d.temporal with
+    | .overlapping => some .contemporaneous
+    | .nonoverlapping => some .retrospective
+
+/-- All of Koev's spatiotemporal configurations are nonfuture (T ≤ A): the
+    event-interval account agrees with the perspective taxonomy. -/
+theorem coreData_nonfuture : ∀ d ∈ coreData, IsNonfuture d := by decide
+
 /-! ### Bridge: Connecting to Linglib Infrastructure -/
 
 /-! Bridge theorems connecting [koev-2017]'s spatiotemporal distance analysis

--- a/Linglib/Studies/Kratzer2012Informational.lean
+++ b/Linglib/Studies/Kratzer2012Informational.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Modality.Kratzer.Operators
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Mathlib.Data.Fin.Basic
 
 /-!
@@ -27,7 +27,7 @@ namespace Kratzer2012Informational
 abbrev World := Fin 4
 
 open Semantics.Modality.Kratzer
-open Features.Evidentiality
+open Semantics.Evidential
 
 /-! ## Propositions -/
 

--- a/Linglib/Studies/MartinezVera2026.lean
+++ b/Linglib/Studies/MartinezVera2026.lean
@@ -1,9 +1,10 @@
 import Mathlib.Data.Set.Insert
 import Linglib.Semantics.Presupposition.ContentLayer
 import Linglib.Semantics.Highlighting
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Linglib.Discourse.Roles
 import Linglib.Semantics.Questions.Hamblin
+import Linglib.Studies.Faller2019
 import Linglib.Studies.Hohle1992
 import Linglib.Studies.RomeroHan2004
 
@@ -67,7 +68,7 @@ Three empirical signatures:
 | `Semantics/Composition/Layered` | `BiLayered W` ⟨A, N⟩ pair, three composition rules |
 | `Semantics/Highlighting` | `HighlightingContext`, `Highlighted`, `AddressesQUD` |
 | `Discourse/EvidentialIllocution` | `assert`, `present`, `EvidentialAct`, `raisedPropositions` |
-| `Features/Evidentiality` | `CoarseSource` (`direct`, `hearsay`, `inference`) |
+| `Semantics/Evidential/Source` | `CoarseSource` (`direct`, `hearsay`, `inference`) |
 | `Semantics/Questions/Hamblin` | `Question.polar` for the polar QUD |
 
 ## Methodological note
@@ -85,7 +86,7 @@ namespace MartinezVera2026
 
 open Semantics.ContentLayer (BiLayered)
 open Semantics.Highlighting (HighlightingContext Highlighted AddressesQUD addSalient)
-open Features.Evidentiality (CoarseSource)
+open Semantics.Evidential (CoarseSource)
 open Discourse (DiscourseRole)
 
 variable {W : Type*}
@@ -190,6 +191,23 @@ def IllocutionaryFlavour.ofCoarseSource :
     IllocutionaryFlavour.ofCoarseSource .hearsay = .presentFlavour := rfl
 @[simp] theorem flavour_inference :
     IllocutionaryFlavour.ofCoarseSource .inference = .presentFlavour := rfl
+
+/-- Partial collapse of [faller-2019a]'s commitment-grounds evidence types
+    onto the coarse source taxonomy: reportative and inferential evidence
+    carry a source; adequate evidence and best possible grounds are
+    commitment-strength grades that cross-cut the source taxonomy. -/
+def fallerCoarseSource : Faller2019.EvidenceType → Option CoarseSource
+  | .reportative => some .hearsay
+  | .inferential => some .inference
+  | .adequate => none
+  | .bpg => none
+
+/-- [faller-2019a]'s Cuzco Quechua reportative and the SK reportative
+    `-shka` land on the same coarse source, hence license the same
+    illocutionary flavour: `present`, not `assert`. -/
+theorem faller_reportative_flavour :
+    (fallerCoarseSource .reportative).map IllocutionaryFlavour.ofCoarseSource
+      = some .presentFlavour := rfl
 
 def applyDefault (src : CoarseSource) (s a : DiscourseRole) (β : BiLayered W) :
     EvidentialAct W :=

--- a/Linglib/Studies/Matthewson2016.lean
+++ b/Linglib/Studies/Matthewson2016.lean
@@ -1,3 +1,4 @@
+import Linglib.Semantics.Evidential.Source
 import Linglib.Semantics.Modality.Typology
 import Linglib.Semantics.Modality.EventRelativity
 import Linglib.Fragments.Gitksan.Modals
@@ -107,6 +108,23 @@ theorem gitksan_circ_factual :
     backgroundClass anookxw = .factualCircumstantial ∧
     backgroundClass sgi = .factualCircumstantial :=
   ⟨rfl, rfl, rfl⟩
+
+/-- Coarse evidential source of a modal background class in Matthewson's
+    system: factual-evidential modals are inferential, content-evidential
+    modals reportative, and factual circumstantials encode no information
+    source. -/
+def backgroundCoarseSource :
+    BackgroundClass → Option Semantics.Evidential.CoarseSource
+  | .factualEvidential => some .inference
+  | .contentEvidential => some .hearsay
+  | .factualCircumstantial => none
+
+/-- Gitksan ima('a) marks inferential evidence and gat reportative
+    evidence in the shared source taxonomy. -/
+theorem gitksan_sources :
+    backgroundCoarseSource (backgroundClass imaa) = some .inference ∧
+    backgroundCoarseSource (backgroundClass gat) = some .hearsay :=
+  ⟨rfl, rfl⟩
 
 /-- All three background classes are represented in Gitksan. -/
 theorem gitksan_three_way_split :

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -11,7 +11,7 @@ import Linglib.Semantics.Context.Tower
 import Linglib.Discourse.Roles
 import Linglib.Semantics.Mood.Defs
 import Linglib.Semantics.Evidential.Epistemicity
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Linglib.Fragments.English.Pronouns
 import Linglib.Features.Person.Basic
 
@@ -365,11 +365,11 @@ theorem rank_injective : Function.Injective SentienceProjection.rank := by
 abbrev evalPSpecifier : SAPMood → PRole := seatOfKnowledge
 
 /-- The specifier of EvidP hosts the evidence type, mapped to the
-    framework-agnostic `CoarseSource` of `Features/Evidentiality.lean`
+    framework-agnostic `CoarseSource` of `Semantics/Evidential/Source.lean`
     (direct / inference / hearsay). NB this three-way coarsening merges S&T's
     top tier (personal experience) into "direct"; the paper's full evidence
     hierarchy is personal experience ≫ direct ≫ indirect ≫ hearsay (p.327). -/
-abbrev EvidPSpecifier := Features.Evidentiality.CoarseSource
+abbrev EvidPSpecifier := Semantics.Evidential.CoarseSource
 
 /-- **Real bridge to `Semantics/Evidential/Epistemicity.lean`.** The Sentience Domain's
     two specifiers ARE the two main fields of an `EpistemicProfile`:

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Evidentiality
+import Linglib.Semantics.Evidential.Source
 import Linglib.Data.Examples.VonFintelGillies2010
 import Linglib.Studies.Izvorski1997
 
@@ -34,7 +34,7 @@ must not directly settle the prejacent.
 
 namespace VonFintelGillies2010
 
-open Features.Evidentiality
+open Semantics.Evidential
 open Data.Examples
 
 /-! ### Evidence types -/
@@ -57,15 +57,15 @@ def EvidenceType.toCoarseSource : EvidenceType → CoarseSource
   | .indirect => .inference
   | .elimination => .inference
 
-/-- VF&G evidence types inherit an evidential perspective via the
-    canonical Aikhenvald source mapping. -/
-instance : HasEvidentialPerspective EvidenceType where
-  toEvidentialPerspective e := toEvidentialPerspective e.toCoarseSource
+/-- VF&G evidence types declare their coarse source; the evidential
+    perspective derives via the canonical source mapping. -/
+instance : HasCoarseSource EvidenceType where
+  toCoarseSource e := some e.toCoarseSource
 
 /-- All VF&G evidence types are nonfuture: their perspective is always
     retrospective or contemporaneous (T ≤ A). -/
 theorem all_evidence_types_nonfuture (e : EvidenceType) :
-    Features.Evidentiality.IsNonfuture e := by
+    Semantics.Evidential.IsNonfuture e := by
   cases e <;> decide
 
 /-! ### Adapters over the example rows -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -37398,5 +37398,5 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Features/Evidentiality.lean}
+  sources   = {Semantics/Evidential/Source.lean}
 }


### PR DESCRIPTION
Completes the evidentiality audit arc (#1584): the coarse layer moves to its owning API and the typeclass tower gets its instance sweep.

- `Features/Evidentiality.lean` → `Semantics/Evidential/Source.lean` (namespace `Features.Evidentiality` → `Semantics.Evidential`); Features/ no longer hosts evidentiality.
- New `HasCoarseSource` typeclass as the stronger entry point; `HasEvidentialPerspective` now derives from it via the canonical mapping (low-priority instance), replacing per-site composition boilerplate (VF&G refactored onto it).
- Instance sweep: `Entry.toCoarseSource` + tower-commuting lemma `Entry.cell_toCoarseSource` + `Entry.isNonfuture`; Koev2017 temporal-overlap perspective instance; Matthewson2016 Gitksan background-class source adapter; MartinezVera2026 partial Faller-2019 adapter (adequate/bpg cross-cut → `none`).