### PR TITLE
docs(Semantics/Tense): verify Cumming paradigm-table refs against paper

### DIFF
--- a/Linglib/Fragments/English/Tense.lean
+++ b/Linglib/Fragments/English/Tense.lean
@@ -30,7 +30,7 @@ namespace English.Tense
 open _root_.Tense.Evidential
 
 -- ════════════════════════════════════════════════════
--- § 1. Table 20: Simple Past, Present Progressive, Future
+-- § 1. table (20): Simple Past, Present Progressive, Future
 -- ════════════════════════════════════════════════════
 
 /-- English simple past: T ≤ A (downstream), T < S (past). -/
@@ -52,7 +52,7 @@ def future : TAMEEntry where
   up := .future
 
 -- ════════════════════════════════════════════════════
--- § 2. Table 22: Will-Forms
+-- § 2. table (22): Will-Forms
 -- ════════════════════════════════════════════════════
 
 /-- English "will have V-ed": A < T (prospective), S < T (future). -/

--- a/Linglib/Fragments/Korean/Evidentials.lean
+++ b/Linglib/Fragments/Korean/Evidentials.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Tense.Evidential
 [cumming-2026]
 
 Paradigm entries for Korean tense-evidential morphology from [cumming-2026],
-Tables 18 (-te) and 19 (-ney). Korean is notable for morphologically encoding
+paradigm tables (18) (-te) and (19) (-ney). Korean is notable for morphologically encoding
 evidential perspective independently of utterance perspective.
 
 ## -te vs -ney
@@ -24,7 +24,7 @@ namespace Korean.Evidentials
 open Tense.Evidential
 
 -- ════════════════════════════════════════════════════
--- § 1. Korean -te (Table 18)
+-- § 1. Korean -te (table (18))
 -- ════════════════════════════════════════════════════
 
 /-- Korean -te PAST: T < A (strict downstream), T < S (past). -/
@@ -46,7 +46,7 @@ def teFuture : TAMEEntry where
   up := .unconstrained
 
 -- ════════════════════════════════════════════════════
--- § 2. Korean -ney (Table 19)
+-- § 2. Korean -ney (table (19))
 -- ════════════════════════════════════════════════════
 
 /-- Korean -ney PAST: T < A (strict downstream), T < S (past). -/

--- a/Linglib/Fragments/Slavic/Bulgarian/Evidentials.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/Evidentials.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Tense.Evidential
 [cumming-2026]
 
 Paradigm entries for Bulgarian tense-evidential morphology from [cumming-2026],
-Table 17. The -l participle interacts with tense to encode evidential perspective.
+table (17). The -l participle interacts with tense to encode evidential perspective.
 
 ## Entries
 

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -24,9 +24,9 @@ assertion. Nonfuture tenses (past, present) impose T ≤ A — evidence is
 
 ## Cross-linguistic Data
 
-The paper's Korean and Bulgarian paradigm tables show that Korean (-te, -ney)
-and Bulgarian (-l) tense morphology systematically interacts with evidential
-perspective. Paradigm data is in
+The paper's paradigm tables (17)–(20) and (22) show that Bulgarian (-l),
+Korean (-te, -ney), and English tense morphology systematically interacts
+with evidential perspective. Paradigm data is in
 `Fragments/{English/Tense, Korean/Evidentials, Bulgarian/Evidentials}`;
 verification theorems are in `Studies/Cumming2026.lean`.
 
@@ -78,8 +78,8 @@ structure EvidentialFrame (Time : Type*) extends ReichenbachFrame Time where
 /-! ### EP Constraint Enum -/
 
 /-- Evidential perspective constraint shapes attested across English, Korean,
-    and Bulgarian ([cumming-2026]'s paradigm tables). Each value corresponds
-    to a distinct ordering on T vs A. -/
+    and Bulgarian ([cumming-2026], paradigm tables (17)–(20) and (22)). Each
+    value corresponds to a distinct ordering on T vs A. -/
 inductive EPCondition where
   /-- T ≤ A: evidence downstream of event (English past/progressive, Bulgarian NFUT). -/
   | downstream
@@ -161,8 +161,8 @@ def UPCondition.toConstraint : UPCondition → EvidentialFrame ℤ → Prop
 
 /-- A row in a tense-aspect-mood-evidentiality paradigm table.
     Generalizes [cumming-2026]'s tense-evidential paradigm tables
-    with optional mood and mirativity fields, enabling unified TAME
-    fragment entries. Existing `{ label, ep, up }` constructions still
+    ((17)–(20), (22)) with optional mood and mirativity fields, enabling
+    unified TAME fragment entries. Existing `{ label, ep, up }` constructions still
     work because `mood` and `mirative` have default values (`none`). -/
 structure TAMEEntry where
   /-- Morphological label (e.g., "simple past", "-te PAST") -/


### PR DESCRIPTION
Verification pass against the published paper (Cumming, *Tense and evidence*, L&P 49:153–175), which is now on hand: the paradigms are numbered examples (17)–(20) and (22), not "Tables 17–22" ((21) is sentence examples). Restores precise verified refs in `Semantics/Tense/Evidential.lean` (upgrading #1586's placeholder content descriptions) and the three fragment files. `EPCondition`'s five constraint shapes and the `cumming-2026` bib fields check out against the paper exactly.