### PR TITLE
refactor(Studies/Cumming2026): deep cleanse; derive raincoat from Kernel

### DIFF
--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -3,26 +3,27 @@ import Linglib.Fragments.Korean.Evidentials
 import Linglib.Fragments.Slavic.Bulgarian.Evidentials
 import Linglib.Semantics.Modality.Kernel
 import Linglib.Semantics.Evidential.Epistemicity
-import Mathlib.Data.Fin.Basic
 
 /-!
-# [cumming-2026] Verification Theorems
+# Cumming (2026): Tense and evidence — verification theorems
 [cumming-2026]
 
-Verification theorems for the cross-linguistic nonfuture downstream
-generalization from [cumming-2026]. Paradigm data
-lives in Fragment files; this file imports them and proves the empirical
-predictions.
+Verification theorems for the cross-linguistic nonfuture-downstream
+generalization of [cumming-2026]. Paradigm data (the paper's tables
+(17)–(20) and (22)) lives in the Fragment files; this file imports them and
+proves the empirical predictions.
 
-## Key Results
+## Main results
 
-1. `nonfuture_downstream`: generic master theorem — any paradigm entry whose
-   EP constraint is nonfuture entails T ≤ A (downstream evidence)
-2. Per-entry corollaries: one-liner applications of the generic lemma
-3. Per-entry `isNonfuture` verification: breaks if EP changed
-4. `future_no_downstream`: future entries do not require downstream evidence
-5. `korean_te_ney_ep_diverge`: EP and UP factorize independently in Korean
-
+* `nonfuture_downstream`: any paradigm entry whose EP constraint is
+  nonfuture entails T ≤ A (downstream evidence), with per-entry
+  verification anchors and corollaries
+* `future_no_downstream`: future entries impose no downstream requirement
+* `korean_te_ney_up_diverge`: -te and -ney present share one EP constraint
+  but differ in UP — EP and UP factorize independently in the morphology
+* `tense_modal_evidential_parallel`: the tense constraint and
+  [von-fintel-gillies-2010]'s `kernelMust` presupposition hold jointly in
+  the [zheng-2025] raincoat scenario
 -/
 
 namespace Cumming2026
@@ -32,9 +33,7 @@ open English.Tense
 open Korean.Evidentials
 open Bulgarian.Evidentials
 
--- ════════════════════════════════════════════════════
--- § 1. Cross-Linguistic Collection
--- ════════════════════════════════════════════════════
+/-! ### Cross-linguistic collection -/
 
 /-- All paradigm entries across the three languages. -/
 def allParadigms : List TAMEEntry :=
@@ -50,9 +49,7 @@ def nonfutureParadigms : List TAMEEntry :=
 def futureParadigms : List TAMEEntry :=
   allParadigms.filter (decide ¬ ·.IsNonfuture)
 
--- ════════════════════════════════════════════════════
--- § 2. Per-Entry IsNonfuture Verification
--- ════════════════════════════════════════════════════
+/-! ### Per-entry nonfuture verification -/
 
 /-- English simple past is nonfuture (EP = downstream). -/
 theorem simplePast_nonfuture : simplePast.IsNonfuture := by decide
@@ -75,9 +72,7 @@ theorem neyPresent_nonfuture : neyPresent.IsNonfuture := by decide
 /-- Bulgarian NFUT + -l is nonfuture (EP = downstream). -/
 theorem nfutL_nonfuture : nfutL.IsNonfuture := by decide
 
--- ════════════════════════════════════════════════════
--- § 3. Master Downstream Theorem
--- ════════════════════════════════════════════════════
+/-! ### Master downstream theorem -/
 
 /-- **Generic nonfuture downstream**: any paradigm entry
     whose EP constraint is nonfuture entails T ≤ A (downstream evidence).
@@ -87,48 +82,44 @@ theorem nonfuture_downstream (p : TAMEEntry) (f : EvidentialFrame ℤ)
     downstreamEvidence f :=
   EPCondition.nonfuture_implies_downstream p.ep f h_nf h_ep
 
--- ════════════════════════════════════════════════════
--- § 4. Per-Entry Downstream Corollaries
--- ════════════════════════════════════════════════════
+/-! ### Per-entry downstream corollaries -/
 
 /-- English simple past EP entails downstream evidence. -/
 theorem simplePast_downstream (f : EvidentialFrame ℤ) :
     simplePast.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .downstream f (by decide)
+  nonfuture_downstream simplePast f simplePast_nonfuture
 
 /-- English present progressive EP entails downstream evidence. -/
 theorem presentProg_downstream (f : EvidentialFrame ℤ) :
     presentProg.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .downstream f (by decide)
+  nonfuture_downstream presentProg f presentProg_nonfuture
 
 /-- Korean -te PAST EP entails downstream evidence. -/
 theorem tePast_downstream (f : EvidentialFrame ℤ) :
     tePast.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .strictDownstream f (by decide)
+  nonfuture_downstream tePast f tePast_nonfuture
 
 /-- Korean -te PRESENT EP entails downstream evidence. -/
 theorem tePresent_downstream (f : EvidentialFrame ℤ) :
     tePresent.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .contemporaneous f (by decide)
+  nonfuture_downstream tePresent f tePresent_nonfuture
 
 /-- Korean -ney PAST EP entails downstream evidence. -/
 theorem neyPast_downstream (f : EvidentialFrame ℤ) :
     neyPast.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .strictDownstream f (by decide)
+  nonfuture_downstream neyPast f neyPast_nonfuture
 
 /-- Korean -ney PRESENT EP entails downstream evidence. -/
 theorem neyPresent_downstream (f : EvidentialFrame ℤ) :
     neyPresent.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .contemporaneous f (by decide)
+  nonfuture_downstream neyPresent f neyPresent_nonfuture
 
 /-- Bulgarian NFUT + -l EP entails downstream evidence. -/
 theorem nfutL_downstream (f : EvidentialFrame ℤ) :
     nfutL.epConstraint f → downstreamEvidence f :=
-  EPCondition.nonfuture_implies_downstream .downstream f (by decide)
+  nonfuture_downstream nfutL f nfutL_nonfuture
 
--- ════════════════════════════════════════════════════
--- § 5. Future Counterexample
--- ════════════════════════════════════════════════════
+/-! ### Future counterexample -/
 
 /-- Future entries do not require downstream evidence: the EP constraint
     is either trivially true (English bare future) or imposes A < T
@@ -139,98 +130,39 @@ theorem future_no_downstream :
   refine ⟨(Core.Order.holds_unrestricted _ _).mpr trivial, ?_⟩
   simp [downstreamEvidence]
 
--- ════════════════════════════════════════════════════
--- § 6. Korean EP/UP Factorization
--- ════════════════════════════════════════════════════
+/-! ### Korean EP/UP factorization -/
 
-/-- **Korean -te and -ney EP diverge on the same tense**:
-    for present tense, -te requires T = A (contemporaneous evidence) while
-    -ney requires T = A ∧ T = S (contemporaneous + speech-time present).
-    The UP constraints differ: -te has T < S, -ney has T = S. This shows
-    EP and UP factorize independently in the morphology. -/
-theorem korean_te_ney_ep_diverge :
-    -- -te PRES: UP requires T < S (past-shifted evidential perspective)
+/-- **-te and -ney factorize EP from UP** ([cumming-2026], tables (18)–(19)):
+    the two present-tense evidentials impose the same EP constraint (T = A)
+    but different UP constraints (-te: T < S; -ney: T = S), witnessed in
+    both directions. EP and UP vary independently in the morphology. -/
+theorem korean_te_ney_up_diverge :
+    tePresent.ep = neyPresent.ep ∧
     (∃ f : EvidentialFrame ℤ,
       tePresent.upConstraint f ∧ ¬ neyPresent.upConstraint f) ∧
-    -- -ney PRES: UP requires T = S (speech-time present)
     (∃ f : EvidentialFrame ℤ,
       neyPresent.upConstraint f ∧ ¬ tePresent.upConstraint f) := by
-  constructor
-  · -- -te PRES with T < S (e.g., T = -1, S = 0, A = -1)
-    refine ⟨⟨⟨0, 0, 0, -1⟩, -1⟩, ?_, ?_⟩
-    · show (-1 : ℤ) < 0; omega
-    · show ¬ ((-1 : ℤ) = 0); omega
-  · -- -ney PRES with T = S (e.g., T = 0, S = 0, A = 0)
-    refine ⟨⟨⟨0, 0, 0, 0⟩, 0⟩, ?_, ?_⟩
-    · show (0 : ℤ) = 0; rfl
-    · show ¬ ((0 : ℤ) < 0); omega
+  refine ⟨rfl, ⟨⟨⟨0, 0, 0, -1⟩, -1⟩, ?_, ?_⟩, ⟨⟨⟨0, 0, 0, 0⟩, 0⟩, ?_, ?_⟩⟩
+  · show (-1 : ℤ) < 0; omega
+  · show ¬ ((-1 : ℤ) = 0); omega
+  · show (0 : ℤ) = 0; rfl
+  · show ¬ ((0 : ℤ) < 0); omega
 
+/-! ### Tense-modal evidentiality bridge
 
--- ════════════════════════════════════════════════════════════════
--- § Tense-Modal Evidentiality Bridge (Cumming ↔ VF&G 2010 ↔ Zheng 2025)
--- ════════════════════════════════════════════════════════════════
-
-/-! [cumming-2026]'s tense evidential constraint and
-    [von-fintel-gillies-2010]'s kernel semantics for epistemic
-    `must` reflect the same underlying requirement: the speaker's
-    evidence is *indirect* — causally downstream of the target event
-    but not directly settling it.
-
-    | Cumming (tense)                   | VF&G (modals)                       |
-    |-----------------------------------|-------------------------------------|
-    | T ≤ A (downstream evidence)       | K doesn't settle φ                  |
-    | Nonfuture → downstream required   | must → indirectness presupposition  |
-    | Future → no constraint            | Bare assertion → no presupposition  |
-    | Direct observation → bare past ok | Direct evidence → must infelicitous |
-
-    The dripping-raincoat scenario ([zheng-2025], used in
-    `Modality/Kernel.lean`) provides a concrete bridge: the raincoat
-    evidence is causally downstream of rain (T ≤ A), and the kernel
-    {wearingRaincoat} doesn't settle isRaining. -/
-
-abbrev World := Fin 4
-
-def allWorlds : List World := [0, 1, 2, 3]
+[cumming-2026] observes that the "fake future" *will*-forms closely
+resemble epistemic *must*: both require the prejacent to follow from the
+evidence rather than being directly observed. The
+[von-fintel-gillies-2010] kernel semantics states the modal side as a
+presupposition that the kernel does not directly settle the prejacent; the
+tense side is the nonfuture downstream constraint (T ≤ A). The
+[zheng-2025] dripping-raincoat scenario (public in
+`Semantics/Modality/Kernel.lean`) witnesses both at once: the raincoat
+evidence is causally downstream of the rain, and the kernel
+`{wearingRaincoat}` does not settle `isRaining`. -/
 
 open Semantics.Modality
-open Semantics.Presupposition (PartialProp)
-
--- ── § Raincoat scenario (parallel to Kernel.lean) ──
-
-/-! The kernel defs in `Modality/Kernel.lean` are private. We redefine
-    equivalent propositions over `World4` for the bridge. World
-    interpretation: w0 = raining, w1 = sprinkler (wet but not rain),
-    w2 = dry, w3 = unknown. -/
-
-/-- Wearing a raincoat: true in w0 (rain) and w1 (sprinkler). -/
-def wearingRaincoat : World → Prop
-  | 0 => True
-  | 1 => True
-  | _ => False
-
-instance : DecidablePred wearingRaincoat := fun w =>
-  match w with
-  | 0 => inferInstanceAs (Decidable True)
-  | 1 => inferInstanceAs (Decidable True)
-  | 2 => inferInstanceAs (Decidable False)
-  | 3 => inferInstanceAs (Decidable False)
-
-/-- It is raining: true only in w0. -/
-def isRaining : World → Prop
-  | 0 => True
-  | _ => False
-
-instance : DecidablePred isRaining := fun w =>
-  match w with
-  | 0 => inferInstanceAs (Decidable True)
-  | 1 => inferInstanceAs (Decidable False)
-  | 2 => inferInstanceAs (Decidable False)
-  | 3 => inferInstanceAs (Decidable False)
-
-/-- The raincoat kernel: K = {wearingRaincoat}. -/
-def raincoatK : Kernel World := ⟨[wearingRaincoat]⟩
-
--- ── § Downstream evidence in the raincoat scenario ──
+open Intensional.Premise (propIntersection)
 
 /-- A concrete evidential frame for the raincoat scenario:
     S = 0 (speech time now), T = -2 (rain event in the past),
@@ -246,31 +178,17 @@ def raincoatFrame : EvidentialFrame ℤ where
 theorem raincoat_downstream : downstreamEvidence raincoatFrame := by
   show (-2 : ℤ) ≤ -1; omega
 
--- ── § Bridge theorems ──
-
-open Intensional.Premise (propExtension propIntersection)
-
-/-- The raincoat kernel doesn't settle isRaining: K = {wearingRaincoat},
-    and wearingRaincoat neither entails nor excludes isRaining. -/
+/-- The raincoat kernel doesn't settle isRaining — the third conjunct of
+    [zheng-2025]'s nandao-felicity theorem. -/
 theorem raincoat_not_settled :
-    ¬ directlySettlesExplicit raincoatK isRaining := by
-  rintro ⟨x, hx, hcase⟩
-  rcases List.mem_singleton.mp hx with rfl
-  cases hcase with
-  | inl h_ent =>
-    have hw1 : ((1 : World) : World) ∈ propExtension wearingRaincoat :=
-      show wearingRaincoat (1 : World) from trivial
-    have : isRaining (1 : World) := h_ent (1 : World) hw1
-    exact this
-  | inr h_exc =>
-    exact h_exc ⟨(0 : World), show wearingRaincoat (0 : World) from trivial,
-                       show isRaining (0 : World) from trivial⟩
+    ¬ directlySettlesExplicit raincoatK isRaining :=
+  raincoat_nandao_felicitous.2.2
 
 /-- **Downstream implies must-defined**: in the raincoat scenario, downstream
     evidence (T ≤ A) co-occurs with the kernel not settling the prejacent. -/
 theorem downstream_implies_must_defined :
     downstreamEvidence raincoatFrame ∧
-    (kernelMust raincoatK isRaining).presup (0 : World) :=
+    (kernelMust raincoatK isRaining).presup World.w0 :=
   ⟨raincoat_downstream, raincoat_not_settled⟩
 
 /-- **Tense-modal evidential parallel**: both Cumming's nonfuture constraint
@@ -279,15 +197,15 @@ theorem downstream_implies_must_defined :
     doesn't settle isRaining. -/
 theorem tense_modal_evidential_parallel :
     downstreamEvidence raincoatFrame ∧
-    (kernelMust raincoatK isRaining).presup (0 : World) ∧
-    ¬(kernelMust raincoatK isRaining).assertion (0 : World) := by
+    (kernelMust raincoatK isRaining).presup World.w0 ∧
+    ¬(kernelMust raincoatK isRaining).assertion World.w0 := by
   refine ⟨raincoat_downstream, raincoat_not_settled, ?_⟩
   intro hAll
-  have hw1 : ((1 : World) : World) ∈ propIntersection raincoatK.props := by
+  have hw1 : World.w1 ∈ propIntersection raincoatK.props := by
     intro p hp
     rcases List.mem_singleton.mp hp with rfl
-    exact (show wearingRaincoat (1 : World) from trivial)
-  exact (hAll hw1 : isRaining (1 : World))
+    exact show wearingRaincoat .w1 by decide
+  exact (hAll hw1 : isRaining .w1)
 
 private theorem isRaining_settles_isRaining :
     directlySettlesExplicit (⟨[isRaining]⟩ : Kernel World) isRaining := by
@@ -300,19 +218,19 @@ private theorem isRaining_settles_isRaining :
 theorem direct_evidence_blocks_both :
     let directK : Kernel World := ⟨[isRaining]⟩
     directlySettlesExplicit directK isRaining ∧
-    ¬(kernelMust directK isRaining).presup (0 : World) ∧
+    ¬(kernelMust directK isRaining).presup World.w0 ∧
     let directFrame : EvidentialFrame ℤ :=
-      { speechTime := 0, perspectiveTime := 0, referenceTime := 0, eventTime := -1, acquisitionTime := -1 }
+      { speechTime := 0, perspectiveTime := 0, referenceTime := 0,
+        eventTime := -1, acquisitionTime := -1 }
     downstreamEvidence directFrame := by
   refine ⟨isRaining_settles_isRaining, ?_, ?_⟩
   · intro h
     exact h isRaining_settles_isRaining
   · show (-1 : ℤ) ≤ -1; omega
 
--- ── § Epistemic authority bridge ──
+/-! ### Epistemic authority bridge -/
 
 open Semantics.Epistemicity
-open Semantics.Evidential
 
 /-- Strong assertions (ego + direct) correspond to settling kernels.
     When the speaker has privileged access AND direct evidence, the
@@ -332,15 +250,15 @@ theorem inferential_claim_must_profile :
     inferentialClaim.source = .inference ∧
     inferentialClaim.authority = .nonparticipant ∧
     ¬ directlySettlesExplicit raincoatK isRaining ∧
-    (kernelMust raincoatK isRaining).presup (0 : World) :=
+    (kernelMust raincoatK isRaining).presup World.w0 :=
   ⟨rfl, rfl, raincoat_not_settled, raincoat_not_settled⟩
 
-/-- Ego↔direct and nonparticipant↔indirect form natural pairs.
-    Epistemic authority and evidential source are orthogonal
-    dimensions that correlate but don't reduce. -/
+/-- Ego pairs with direct evidence and nonparticipant with inference in
+    the Epistemicity profiles. -/
 theorem authority_source_correlation :
     strongAssertion.authority = .ego ∧ strongAssertion.source = .direct ∧
-    inferentialClaim.authority = .nonparticipant ∧ inferentialClaim.source = .inference := by
-  exact ⟨rfl, rfl, rfl, rfl⟩
+    inferentialClaim.authority = .nonparticipant ∧
+    inferentialClaim.source = .inference :=
+  ⟨rfl, rfl, rfl, rfl⟩
 
 end Cumming2026


### PR DESCRIPTION
Deep cleanse of the Cumming 2026 study file, verified against the paper (evidentiality audit arc: #1584–#1587).

- Fix the mis-stated factorization theorem: `korean_te_ney_ep_diverge` proved UP divergence while its name and docstring claimed EP divergence; now `korean_te_ney_up_diverge` with the EP-identity conjunct (`tePresent.ep = neyPresent.ep`) making the factorization claim machine-checked.
- Delete the local raincoat re-stipulation (`World := Fin 4`, `wearingRaincoat`, `isRaining`, `raincoatK`, dead `allWorlds`): the scenario is public in `Semantics/Modality/Kernel.lean`, and `raincoat_not_settled` now extracts from [zheng-2025]'s `raincoat_nandao_felicitous` instead of reproving it.
- Per-entry downstream corollaries now delegate through the master theorem + per-entry nonfuture anchors; `-- ════` bars → `/-! ### -/`; docstring comparison table → prose; term proofs where trivial.