### PR TITLE
refactor(Semantics): dissolve TriggerTypology into enum + Wang2025

### DIFF
--- a/Linglib/Fragments/Cantonese/Particles.lean
+++ b/Linglib/Fragments/Cantonese/Particles.lean
@@ -19,15 +19,14 @@ trigger movement to matrix AspP_outer — lives in the Studies file.
 
 namespace Cantonese.Particles
 
-open Semantics.Presupposition.TriggerTypology
-  (PresupTrigger AltStructure PresupTriggerEntry)
+open Semantics.Presupposition.TriggerTypology (PresupTrigger)
 
 /-- A Cantonese presuppositional particle entry. -/
 structure PresupParticle where
   hanzi : String
   jyutping : String
   gloss : String
-  triggerEntry : PresupTriggerEntry
+  trigger : PresupTrigger
   notes : String := ""
   deriving Repr
 
@@ -37,7 +36,7 @@ structure PresupParticle where
     for the analysis). -/
 def jau : PresupParticle :=
   { hanzi := "又", jyutping := "jau6", gloss := "again"
-  , triggerEntry := { trigger := .iterative, altStructure := .deletion }
+  , trigger := .iterative
   , notes := "Mandarin you's counterpart; no scope-skipping per Liu&Yip2026" }
 
 /-- 再 *zoi* — preverbal 'again' (iterative, lower position). Cantonese
@@ -45,7 +44,7 @@ def jau : PresupParticle :=
     AspP_inner-associated, paralleling Mandarin *zai*. -/
 def zoi : PresupParticle :=
   { hanzi := "再", jyutping := "zoi3", gloss := "again"
-  , triggerEntry := { trigger := .iterative, altStructure := .deletion }
+  , trigger := .iterative
   , notes := "Mandarin zai's counterpart; AspP_inner-associated per Liu&Yip2026" }
 
 def all : List PresupParticle := [jau, zoi]
@@ -55,12 +54,8 @@ theorem all_membership :
     all.map (·.jyutping) = ["jau6", "zoi3"] := by decide
 
 /-- Both Cantonese preverbal *again*-elements are iterative-class
-    presupposition triggers with deletion alternatives. -/
-theorem both_iterative_deletion :
-    jau.triggerEntry.trigger = .iterative ∧
-    zoi.triggerEntry.trigger = .iterative ∧
-    jau.triggerEntry.altStructure = .deletion ∧
-    zoi.triggerEntry.altStructure = .deletion := by
-  refine ⟨rfl, rfl, rfl, rfl⟩
+    presupposition triggers. -/
+theorem both_iterative :
+    jau.trigger = .iterative ∧ zoi.trigger = .iterative := ⟨rfl, rfl⟩
 
 end Cantonese.Particles

--- a/Linglib/Fragments/Mandarin/Particles.lean
+++ b/Linglib/Fragments/Mandarin/Particles.lean
@@ -2,38 +2,28 @@ import Linglib.Semantics.Presupposition.TriggerTypology
 
 /-!
 # Mandarin Presuppositional Particles
-[wang-2025]
 
-Lexical entries for Mandarin presupposition triggers, linking Fragment-level
-lexical data to the NeoGricean trigger typology ([wang-2025] Table 4.1) and
-experimental data ([wang-2025] Experiments 1-3).
+Lexical entries for the Mandarin presupposition triggers studied
+experimentally in [wang-2025]. Entries carry consensus trigger-type
+metadata only; [wang-2025]'s alternative-structure classification and the
+competition analysis built on it live in `Studies/Wang2025.lean`.
 
-## Triggers
-
-| Particle | Gloss      | Trigger Type  | Alt Structure | Alt Form        |
-|----------|------------|---------------|---------------|-----------------|
-| 也 ye    | also       | iterative     | deletion      | ∅               |
-| 又 you   | again      | iterative     | deletion      | ∅               |
-| 仍 reng  | still      | continuative  | deletion      | ∅               |
-| 就 jiu   | only       | cleft         | none          | ∅               |
-| 知道 zhidao | know    | factive       | replacement   | believe (以为)   |
-| 不再 buzai | no longer | changeOfState | replacement   | not (不)         |
-| 开始 kaishi | start   | aspectual     | replacement   | do (做)          |
-| 反而 fan'er | instead | iterative     | replacement   | and (和)         |
-| 而 er    | instead    | iterative     | replacement   | and (和)         |
-| 还 hai   | still      | continuative  | deletion      | ∅               |
-
-## Cross-Module Connections
-
-- `Semantics.Presupposition.TriggerTypology.AltStructure`: alternative classification
-- `Semantics.Presupposition.TriggerTypology.PresupTrigger`: trigger type
-- `Wang2025`: experimental data
-
+| Particle    | Gloss      | Trigger Type  |
+|-------------|------------|---------------|
+| 也 ye       | also       | additive      |
+| 又 you      | again      | iterative     |
+| 仍 reng     | still      | continuative  |
+| 就 jiu      | only       | exclusive     |
+| 知道 zhidao | know       | factive       |
+| 不再 buzai  | no longer  | changeOfState |
+| 开始 kaishi | start      | aspectual     |
+| 反而 fan'er | instead    | contrastive   |
+| 而 er       | instead    | contrastive   |
 -/
 
 namespace Mandarin.Particles
 
-open Semantics.Presupposition.TriggerTypology (PresupTrigger AltStructure PresupTriggerEntry)
+open Semantics.Presupposition.TriggerTypology (PresupTrigger)
 
 /-- Mandarin presupposition triggers studied in [wang-2025] Experiments 1-2. -/
 inductive MandarinTrigger where
@@ -48,10 +38,7 @@ inductive MandarinTrigger where
   | er     -- 而 'instead' (contrastive, weaker)
   deriving DecidableEq, Repr
 
-/--
-A Mandarin presuppositional particle entry.
-Links surface form to trigger type and alternative structure.
--/
+/-- A Mandarin presuppositional particle entry. -/
 structure PresupParticle where
   /-- Chinese character(s) -/
   hanzi : String
@@ -59,25 +46,23 @@ structure PresupParticle where
   pinyin : String
   /-- English gloss -/
   gloss : String
-  /-- Corresponding trigger entry (type + alternative structure) -/
-  triggerEntry : PresupTriggerEntry
+  /-- Trigger type (consensus classification) -/
+  trigger : PresupTrigger
   /-- Link to experimental data trigger identifier -/
   dataTrigger : MandarinTrigger
   deriving Repr
 
-/-- 也 ye 'also' — additive particle, deletion alternative. -/
+/-- 也 ye 'also' — additive particle ([kripke-2009]'s *too*-class). -/
 def ye : PresupParticle :=
   { hanzi := "也", pinyin := "yě", gloss := "also"
-  , triggerEntry := { trigger := .iterative, altStructure := .deletion }
-  , dataTrigger := .ye }
+  , trigger := .additive, dataTrigger := .ye }
 
-/-- 又 you 'again' — repetitive, deletion alternative. -/
+/-- 又 you 'again' — repetitive iterative. -/
 def you : PresupParticle :=
   { hanzi := "又", pinyin := "yòu", gloss := "again"
-  , triggerEntry := { trigger := .iterative, altStructure := .deletion }
-  , dataTrigger := .you }
+  , trigger := .iterative, dataTrigger := .you }
 
-/-- 仍 reng 'still' — continuative, deletion alternative.
+/-- 仍 reng 'still' — continuative.
     Distinct from 又 *you* 'again' (iterative): *reng*'s presupposition is
     *uninterrupted continuation* of P throughout an interval, whereas
     *you* presupposes P-then-not-P-then-P-again. The original encoding
@@ -85,77 +70,40 @@ def you : PresupParticle :=
     `.continuative` was added to `PresupTrigger` to distinguish them. -/
 def reng : PresupParticle :=
   { hanzi := "仍", pinyin := "réng", gloss := "still"
-  , triggerEntry := { trigger := .continuative, altStructure := .deletion }
-  , dataTrigger := .reng }
+  , trigger := .continuative, dataTrigger := .reng }
 
-/-- 就 jiu 'only' — exclusive, NO structural alternative. -/
+/-- 就 jiu 'only' — exclusive; presupposes its prejacent. -/
 def jiu : PresupParticle :=
   { hanzi := "就", pinyin := "jiù", gloss := "only"
-  , triggerEntry := { trigger := .cleft, altStructure := .none }
-  , dataTrigger := .jiu }
+  , trigger := .exclusive, dataTrigger := .jiu }
 
-/-- 知道 zhidao 'know' — factive, replacement alternative (以为 yiwei 'believe'). -/
+/-- 知道 zhidao 'know' — factive (non-factive counterpart: 以为 yiwei 'believe'). -/
 def zhidao : PresupParticle :=
   { hanzi := "知道", pinyin := "zhīdào", gloss := "know"
-  , triggerEntry := { trigger := .factive, altStructure := .replacement, altForm := some "以为" }
-  , dataTrigger := .zhidao }
+  , trigger := .factive, dataTrigger := .zhidao }
 
-/-- 不再 buzai 'no longer' — cessative, replacement alternative (不 bu 'not'). -/
+/-- 不再 buzai 'no longer' — cessative change-of-state. -/
 def buzai : PresupParticle :=
   { hanzi := "不再", pinyin := "bú zài", gloss := "no longer"
-  , triggerEntry := { trigger := .changeOfState, altStructure := .replacement, altForm := some "不" }
-  , dataTrigger := .buzai }
+  , trigger := .changeOfState, dataTrigger := .buzai }
 
-/-- 开始 kaishi 'start' — inchoative, replacement alternative (做 zuo 'do'). -/
+/-- 开始 kaishi 'start' — inchoative aspectual. -/
 def kaishi : PresupParticle :=
   { hanzi := "开始", pinyin := "kāishǐ", gloss := "start"
-  , triggerEntry := { trigger := .aspectual, altStructure := .replacement, altForm := some "做" }
-  , dataTrigger := .kaishi }
+  , trigger := .aspectual, dataTrigger := .kaishi }
 
-/-- 反而 fan'er 'instead' — contrastive, replacement alternative. -/
+/-- 反而 fan'er 'instead' — contrastive. -/
 def faner : PresupParticle :=
   { hanzi := "反而", pinyin := "fǎn'ér", gloss := "instead"
-  , triggerEntry := { trigger := .iterative, altStructure := .replacement, altForm := some "和" }
-  , dataTrigger := .faner }
+  , trigger := .contrastive, dataTrigger := .faner }
 
-/-- 而 er 'instead' — weaker contrastive, replacement alternative. -/
+/-- 而 er 'instead' — weaker contrastive. -/
 def er : PresupParticle :=
   { hanzi := "而", pinyin := "ér", gloss := "instead"
-  , triggerEntry := { trigger := .iterative, altStructure := .replacement, altForm := some "和" }
-  , dataTrigger := .er }
+  , trigger := .contrastive, dataTrigger := .er }
 
 /-- All particles studied in [wang-2025]. -/
 def wang2025Particles : List PresupParticle :=
   [ye, you, reng, jiu, zhidao, buzai, kaishi, faner, er]
-
--- ============================================================================
--- Per-Datum Verification Theorems
--- ============================================================================
-
-/-- ye has deletion alternative structure. -/
-theorem ye_deletion : ye.triggerEntry.altStructure = .deletion := rfl
-
-/-- jiu has no structural alternative. -/
-theorem jiu_no_alt : jiu.triggerEntry.altStructure = .none := rfl
-
-/-- zhidao has replacement alternative. -/
-theorem zhidao_replacement : zhidao.triggerEntry.altStructure = .replacement := rfl
-
-/-- Obligatory triggers (ye, you, reng) all have deletion alternatives. -/
-theorem obligatory_all_deletion :
-    ye.triggerEntry.altStructure = .deletion ∧
-    you.triggerEntry.altStructure = .deletion ∧
-    reng.triggerEntry.altStructure = .deletion := ⟨rfl, rfl, rfl⟩
-
-/-- Blocked trigger (jiu) has no alternative — this is what predicts blocking. -/
-theorem blocked_no_alt :
-    jiu.triggerEntry.altStructure = .none := rfl
-
-/-- ye links to experimental data trigger.ye -/
-theorem ye_data_link : ye.dataTrigger = .ye := rfl
-
-/-- jiu links to experimental data trigger.jiu -/
-theorem jiu_data_link : jiu.dataTrigger = .jiu := rfl
-
 
 end Mandarin.Particles

--- a/Linglib/Semantics/Presupposition/MaximizePresupposition.lean
+++ b/Linglib/Semantics/Presupposition/MaximizePresupposition.lean
@@ -39,7 +39,8 @@ connects it to existing domain-specific implementations:
    violable constraint ranked below IC (Internal Coherence) and FP
    (Felicity Presupposition). Describes MP's position in the
    constraint hierarchy for presupposition obligatoriness
-   ([wang-2025]). Trigger typology lives in
+   ([wang-2025]). The alternative-structure typology driving it lives in
+   `Studies/Wang2025.lean`; consensus trigger types in
    `Semantics.Presupposition.TriggerTypology`.
 
 ## Core abstraction

--- a/Linglib/Semantics/Presupposition/TriggerTypology.lean
+++ b/Linglib/Semantics/Presupposition/TriggerTypology.lean
@@ -1,59 +1,31 @@
-import Linglib.Semantics.Presupposition.Basic
-import Linglib.Semantics.Entailment.Polarity
-
 /-!
-# Presupposition Trigger Typology
-[wang-2025]
+# Presupposition trigger types
 
-Cross-linguistic typology of presupposition triggers, classifying triggers
-by what non-presuppositional alternative they have. The classification
-follows [wang-2025] Table 4.1 and is consumed by:
-
-- `Studies/Wang2025.lean` — IC ≫ FP ≫ MP
-  constraint-based competition analysis
-- `Fragments/Mandarin/Particles.lean` — Mandarin trigger entries
-
-## Classification
-
-Three patterns of trigger ↔ alternative relationship:
-1. **Deletion alternatives** — trigger can be deleted (ye/also → ∅)
-2. **Replacement alternatives** — specific lexical replacement (zhidao/know → believe)
-3. **No structural alternative** — no available alternative (jiu/only)
-
-The alternative-structure axis predicts obligatoriness:
-- Deletion / replacement → trigger can be optional or obligatory
-- No alternative → trigger is mandatorily omitted under partial CommonGround support
-
-## Relation to MP infrastructure
-
-This file provides the **typology**; the constraint-based formulation of
-Maximize Presupposition lives in `MaximizePresupposition.lean`, and the
-paper-specific IC/FP/MP ranking in `Studies/Wang2025.lean`.
+Classification of presupposition triggers by hosting lexical class, the
+consensus inventory of the projection literature (cf. [zeevat-1992],
+[tonhauser-beaver-roberts-simons-2013]). Fragment lexical entries carry a
+`PresupTrigger` value as theory-neutral metadata; orthogonal classifications
+of the same inventory are the projection classes of
+`Semantics.Presupposition.ProjectiveContent` and the soft/hard distinction in
+`Semantics.Verb`.
 -/
 
 namespace Semantics.Presupposition.TriggerTypology
 
-open Semantics.Presupposition
-open Entailment
-
-/--
-Types of presupposition triggers in natural language.
-
-Each trigger type introduces a characteristic presupposition pattern.
-These are used for alternative generation in SI computation.
--/
+/-- Presupposition trigger classes, by hosting lexical item. -/
 inductive PresupTrigger where
   /-- Definite descriptions: "the X" presupposes X exists and is unique -/
   | definite
   /-- Factive predicates: "know/regret that P" presupposes P -/
   | factive
-  /-- Change-of-state predicates: "stop/start V-ing" presupposes prior state -/
+  /-- Change-of-state predicates: "stop/start V-ing" presuppose a prior state -/
   | changeOfState
   /-- Repetitive iteratives: "again" presupposes a prior occurrence.
       An intervening ¬P interval (P-then-¬P-then-P-again) is presupposed
       only for stative hosts in competition with the continuative;
-      eventive *again* (*John won again*) requires precedence only.
-      English *again*, German *wieder*, Mandarin *you* 又, Cantonese *jau*. -/
+      eventive *again* (*John won again*) requires precedence only
+      (cf. [von-stechow-1996]). English *again*, German *wieder*,
+      Mandarin *you* 又, Cantonese *jau*. -/
   | iterative
   /-- Continuatives: "still" presuppose **uninterrupted** continuation
       of P throughout an interval up to and including the reference time.
@@ -62,107 +34,20 @@ inductive PresupTrigger where
       flip). English *still*, Mandarin *reng* 仍 / *hai* 还,
       Cantonese *zung* 仲. Cf. [ippolito-2007] on *still* vs *again*. -/
   | continuative
+  /-- Additives: "too/also" presuppose that a distinct salient alternative
+      satisfies the predicate — the paradigm anaphoric trigger
+      ([kripke-2009]). English *too*, German *auch*, Mandarin *ye* 也. -/
+  | additive
+  /-- Exclusives: "only P" presupposes its prejacent P.
+      English *only*, Mandarin *jiu* 就. -/
+  | exclusive
+  /-- Contrastives: "instead"-type particles presuppose a contextually
+      salient contrary expectation. Mandarin *fan'er* 反而 / *er* 而. -/
+  | contrastive
   /-- Cleft constructions: "It was X that..." presupposes existence -/
   | cleft
   /-- Aspectual predicates: "finish", "continue" presuppose event structure -/
   | aspectual
   deriving DecidableEq, Repr
-
-/--
-A presupposition trigger occurrence in a sentence.
-
-Records the position and type of trigger, enabling compositional
-presupposition computation and alternative generation.
--/
-structure TriggerOccurrence where
-  /-- Word position in the sentence -/
-  position : Nat
-  /-- Type of trigger -/
-  trigger : PresupTrigger
-  deriving Repr
-
-
-/--
-A derivation extended with presupposition tracking.
-
-Tracks presuppositions through the derivation, enabling:
-- Presupposition projection computation
-- Interaction between presuppositions and SIs
--/
-structure PresupDerivation (W : Type*) where
-  /-- The underlying presuppositional proposition -/
-  meaning : PartialProp W
-  /-- Presupposition triggers in the sentence -/
-  triggers : List TriggerOccurrence
-  /-- Current polarity context -/
-  polarity : ContextPolarity
-  /-- Surface form (optional, for display) -/
-  surface : List String := []
-
-
--- ============================================================================
--- [wang-2025] Table 4.1: Alternative-structure typology
--- ============================================================================
-
-/--
-[wang-2025] Table 4.1: How a presupposition trigger relates to its
-non-presuppositional alternative.
--/
-inductive AltStructure where
-  /-- Alternative is obtained by deleting the trigger (ye/also → ∅, you/again → ∅) -/
-  | deletion
-  /-- Alternative is a specific lexical replacement (zhidao/know → believe) -/
-  | replacement
-  /-- No structural alternative available (jiu/only) -/
-  | none
-  deriving DecidableEq, Repr
-
-/--
-Obligatoriness pattern predicted by the alternative-structure typology.
-
-[wang-2025] derives three patterns from the interaction of trigger
-type, alternative structure, and constraint ranking:
-1. Obligatory: trigger must be used when CommonGround supports presupposition
-2. Optional: trigger may or may not be used
-3. Blocked: trigger must NOT be used (mandatorily omitted)
--/
-inductive Obligatoriness where
-  /-- Trigger is obligatory when presupposition is fully entailed by CommonGround -/
-  | obligatory
-  /-- Trigger is optional (either form is acceptable) -/
-  | optional
-  /-- Trigger is blocked (mandatorily omitted in this context) -/
-  | blocked
-  deriving DecidableEq, Repr
-
-/--
-A presupposition trigger entry with [wang-2025] alternative structure.
-
-Extends the basic trigger type with information about what non-presuppositional
-alternative exists, enabling the constraint-based competition analysis.
--/
-structure PresupTriggerEntry where
-  /-- The trigger type (from existing classification) -/
-  trigger : PresupTrigger
-  /-- Alternative structure (Wang Table 4.1) -/
-  altStructure : AltStructure
-  /-- Lexical form of the alternative (if replacement) -/
-  altForm : Option String := .none
-  deriving Repr
-
-/--
-Assign alternative structure to standard trigger types.
-
-Default mapping based on cross-linguistic generalizations.
-Language-specific entries may override (see Fragments/Mandarin/).
--/
-def PresupTrigger.defaultAltStructure : PresupTrigger → AltStructure
-  | .definite => .replacement     -- "the" → "a"
-  | .factive => .replacement      -- "know" → "believe"
-  | .changeOfState => .replacement -- "stop" → "not do"
-  | .iterative => .deletion       -- "again" → ∅
-  | .continuative => .deletion    -- "still" → ∅ (interval-internal omission)
-  | .cleft => .none               -- no obvious alternative
-  | .aspectual => .replacement    -- "start" → "do"
 
 end Semantics.Presupposition.TriggerTypology

--- a/Linglib/Studies/Heim1983.lean
+++ b/Linglib/Studies/Heim1983.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Presupposition.TriggerTypology
+import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Dynamic.Partial
 
 /-!
@@ -6,24 +6,22 @@ import Linglib.Semantics.Dynamic.Partial
 [heim-1983] [karttunen-1973]
 
 The classic King and factive-verb examples, their `PartialProp` denotations,
-NeoGricean `PresupDerivation` wrappers, and the filtering predictions derived
-from partial context change potentials.
+and the filtering predictions derived from partial context change potentials.
 
 ## Main declarations
 
 - `kingExists`, `kingBald`, `ifKingThenBald`: the King example, with
   `ifKingThenBald_no_presup` showing conditional filtering.
 - `johnKnowsRaining`: the factive example.
-- `conditional_admitted_everywhere` / `bare_consequent_not_admitted`: the
-  filtering recorded in the trigger tables, derived from `CCP.Partial`
-  admittance rather than stipulated.
+- `conditional_admitted_everywhere` / `bare_consequent_not_admitted`:
+  conditional filtering derived from `CCP.Partial` admittance rather than
+  stipulated.
 -/
 
 
 namespace Heim1983
 
 open Semantics.Presupposition
-open Semantics.Presupposition.TriggerTypology
 
 /--
 World type for the king example.
@@ -112,60 +110,13 @@ def johnKnowsRaining : PartialProp RainWorld :=
       | .notRaining => False
   }
 
-/--
-The King example as a `PresupDerivation`, adding trigger information
-for NeoGricean SI computation.
--/
-def kingBaldDerivation : PresupDerivation KingWorld :=
-  { meaning := kingBald
-  , triggers := [⟨0, .definite⟩]  -- "the" at position 0
-  , polarity := .upward
-  , surface := ["the", "king", "is", "bald"]
-  }
-
-/--
-The conditional "If the king exists, the king is bald" as a derivation.
-
-Note: No presupposition triggers project because filtering eliminates them.
--/
-def ifKingThenBaldDerivation : PresupDerivation KingWorld :=
-  { meaning := ifKingThenBald
-  , triggers := []  -- Presupposition filtered out
-  , polarity := .upward
-  , surface := ["if", "the", "king", "exists", ",", "the", "king", "is", "bald"]
-  }
-
-/--
-Factive verb example as a derivation.
--/
-def johnKnowsRainingDerivation : PresupDerivation RainWorld :=
-  { meaning := johnKnowsRaining
-  , triggers := [⟨1, .factive⟩]  -- "knows" at position 1
-  , polarity := .upward
-  , surface := ["John", "knows", "that", "it's", "raining"]
-  }
-
-/--
-Filtering affects which triggers are relevant for SI.
-
-When a presupposition is filtered (locally satisfied), the corresponding
-trigger no longer contributes to global presupposition, and alternatives
-involving that trigger may behave differently. (The `triggers := []` entry
-is *derived* below: `conditional_admitted_everywhere` proves the filtering
-from the partial-CCP semantics rather than stipulating it.)
--/
-theorem filtering_removes_trigger :
-    ifKingThenBaldDerivation.triggers = [] := rfl
-
 /-! ### Filtering derived from partial CCPs
 
 [heim-1983]'s actual machinery: sentences denote *partial* context change
 potentials (`DynamicSemantics.CCP.Partial`), and admittance does the
 projection work. The conditional's CCP is admitted by every context — the
 antecedent's update satisfies the consequent's king-presupposition — while
-the bare consequent's CCP is not admitted by the full context. The
-filtering recorded in the trigger tables above is a theorem, not a table
-entry. -/
+the bare consequent's CCP is not admitted by the full context. -/
 
 open DynamicSemantics in
 /-- Every context admits ⟦if the king exists, the king is bald⟧: the

--- a/Linglib/Studies/Wang2025.lean
+++ b/Linglib/Studies/Wang2025.lean
@@ -6,7 +6,6 @@ import Linglib.Semantics.Presupposition.Basic
 import Linglib.Features.Acceptability
 import Linglib.Fragments.Mandarin.Particles
 import Linglib.Pragmatics.Expressives.Basic
-import Linglib.Semantics.Presupposition.TriggerTypology
 
 /-!
 # [wang-2025] Presupposition, Competition, and Coherence
@@ -49,7 +48,7 @@ Presuppositional sentences `S_p` compete with non-presuppositional alternatives
    IC or FP violations.
 
 The ranking IC ≫ FP ≫ MP, together with the trigger's alternative structure
-(Wang's Table 4.1), derives three obligatoriness patterns:
+(`AltStructure`), derives three obligatoriness patterns:
 - **Obligatory** triggers (ye, you, reng): deletion alternatives — MP forces
   use of the trigger when CommonGround fully supports presupposition.
 - **Optional** triggers (buzai, kaishi): replacement alternatives — competitor
@@ -192,7 +191,6 @@ of the speaker-K operator. The Prop-valued canonical version lives in
 `Core.Logic.Modal.AccessRel`; lift via
 `fun a b => R a b = true` to bridge. -/
 abbrev BAccessRel (W : Type*) := W → W → Bool
-open Semantics.Presupposition.TriggerTypology (AltStructure Obligatoriness)
 open Pragmatics.Expressives (TwoDimProp)
 
 /--
@@ -272,6 +270,58 @@ def mpPrefers (cg : ContextSet W) (sp : PartialProp W) : Prop :=
   satisfiesFP cg sp ∧ satisfiesIC sp
 
 
+/-! ### Alternative-structure typology
+
+[wang-2025] classifies each trigger by what non-presuppositional alternative
+it has; the classification, with the constraint ranking, drives the
+obligatoriness predictions below. The cases mirror [katzir-2007]'s
+structural-alternative operations: a `deletion` competitor is
+delete-reachable, a `replacement` competitor substitute-reachable
+(cf. `Semantics.Alternatives.Structural`). -/
+
+/-- How a presupposition trigger relates to its non-presuppositional
+alternative ([wang-2025]'s alternative-structure typology). -/
+inductive AltStructure where
+  /-- Alternative obtained by deleting the trigger (*ye*/also → ∅) -/
+  | deletion
+  /-- Alternative is a specific lexical replacement (*zhidao*/know → *yiwei*/believe) -/
+  | replacement
+  /-- No structural alternative available (*jiu*/only) -/
+  | none
+  deriving DecidableEq, Repr
+
+/-- [wang-2025]'s alternative-structure classification of the Mandarin
+triggers studied in the experiments. -/
+def altStructureOf : MandarinTrigger → AltStructure
+  | .ye => .deletion
+  | .you => .deletion
+  | .reng => .deletion
+  | .jiu => .none
+  | .zhidao => .replacement
+  | .buzai => .replacement
+  | .kaishi => .replacement
+  | .faner => .replacement
+  | .er => .replacement
+
+/--
+Obligatoriness pattern predicted by the alternative-structure typology.
+
+[wang-2025] derives three patterns from the interaction of trigger
+type, alternative structure, and constraint ranking:
+1. Obligatory: trigger must be used when CommonGround supports presupposition
+2. Optional: trigger may or may not be used
+3. Blocked: trigger must NOT be used (mandatorily omitted)
+-/
+inductive Obligatoriness where
+  /-- Trigger is obligatory when presupposition is fully entailed by CommonGround -/
+  | obligatory
+  /-- Trigger is optional (either form is acceptable) -/
+  | optional
+  /-- Trigger is blocked (mandatorily omitted in this context) -/
+  | blocked
+  deriving DecidableEq, Repr
+
+
 -- ============================================================================
 -- Section 2: Obligatoriness Predictions
 -- ============================================================================
@@ -305,7 +355,7 @@ so even when the CommonGround only partially entails the presupposition, the
 presuppositional form is not blocked.
 -/
 theorem deletion_alt_partial_resolution :
-    predictObligatoriness .deletion false true = .optional := rfl
+    predictObligatoriness (altStructureOf .ye) false true = .optional := rfl
 
 /--
 Triggers with no structural alternative are blocked under partial CommonGround.
@@ -315,7 +365,7 @@ when the CommonGround doesn't fully support the presupposition, the presuppositi
 form cannot be used.
 -/
 theorem no_alt_blocked_partial :
-    predictObligatoriness .none false true = .blocked := rfl
+    predictObligatoriness (altStructureOf .jiu) false true = .blocked := rfl
 
 /--
 Full CommonGround support always yields obligatoriness (for any alternative structure).


### PR DESCRIPTION
Dissolves the theory-layer TriggerTypology file per a four-lens deep audit: no declaration met the ≥2-Studies bar, and Wang's paper-specific classification was carried as a Fragment field.

- `PresupTrigger` slims to a consensus trigger-type enum, gaining `additive`/`exclusive`/`contrastive`; Mandarin 也 ye, 就 jiu, 反而/而 retyped accordingly (ye was mistyped `.iterative`, jiu `.cleft`)
- [wang-2025]'s `AltStructure`/`Obligatoriness` and per-trigger classification move into `Studies/Wang2025.lean` (`altStructureOf`); Fragments keep consensus metadata only
- Deletes dead `defaultAltStructure`, write-only `surface`/`altForm`/`position` fields, and Heim1983's inert `PresupDerivation` wrappers (the honest filtering result was already `conditional_admitted_everywhere`)