### PR TITLE
refactor(Semantics/Presupposition): slim OntologicalPreconditions to core

### DIFF
--- a/Linglib/Semantics/Presupposition/OntologicalPreconditions.lean
+++ b/Linglib/Semantics/Presupposition/OntologicalPreconditions.lean
@@ -1,60 +1,42 @@
-/-
-# Ontological Preconditions and Projection [roberts-simons-2024]
-
-Presupposition projection based on event structure and ontological dependence.
-
-## Core Claim ([roberts-simons-2024] §2)
-
-The projective contents of three verb classes — CoS predicates, factives, and
-predicates with selectional restrictions — are NOT semantically encoded
-presuppositions. They are entailments characterizing *ontological preconditions*
-of the associated event type. Their projectivity follows from pragmatics
-(informativity), not from lexically specified contextual constraints.
-
-## Entailment Classification
-
-Not all entailments are preconditions. Three relations obtain:
-- **Precondition**: State that must hold *before* for the event to be possible.
-  Projects by pragmatic default. Diagnosed by "allows for" test.
-- **Consequence**: State resulting *from* the event. At-issue, doesn't project.
-- **Concomitant**: Mereological part or co-occurring state (e.g., "Jane shouted"
-  entails "Jane made sound"). At-issue, doesn't project.
-
-## Three Verb Classes
-
-1. **CoS predicates** (stop, start): precondition = prior state
-2. **Factives** (know, discover, regret): precondition = complement truth
-3. **Selectional restrictions** (kick → has feet): precondition = enabling property
-
-## Diagnostics
-
-Two tests from [roberts-simons-2024] §2.1:
-- "ψ, which is part of what allows/allowed for φ" — true iff ψ is precondition
-- "If not-ψ, it would not have been possible for [agent] to VP" — counterfactual
-
--/
-
+import Mathlib.Tactic.TypeStar
 import Linglib.Features.Polarity
-import Linglib.Semantics.Presupposition.Basic
-import Linglib.Semantics.Aspect.ChangeOfState
-import Linglib.Features.Aktionsart
+
+/-!
+# Ontological preconditions and projection
+
+[roberts-simons-2024]'s event-phase account of non-anaphoric presupposition:
+projective contents are entailments characterizing *ontological
+preconditions* of the event type a sentence is about, and project because
+affirmation and negation share that event reference — not because they are
+semantically encoded presuppositions.
+
+## Main declarations
+
+* `EventPhase` — an event decomposed into precondition, occurrence, and
+  consequence, with `wellFormed` (occurrence entails precondition) and the
+  telicity predicates `isTelic`/`isAtelic`.
+* `EventSentence` — a sentence as event reference (`aboutness`) plus a
+  polarity-dependent claim (`assertion`); its `presupposition` is the
+  precondition of the referenced event type, so projection through negation
+  (`presupposition_projects`) holds by construction while assertions flip
+  (`assertion_differs`).
+* `EntailmentRelation` — precondition vs consequence vs concomitant; only
+  preconditions project by pragmatic default (`projects`).
+
+The paper's verb-class instances (CoS predicates, factives, selectional
+restrictions), aspectual classification, and suppression conditions live in
+`Studies/RobertsSimons2024.lean`.
+-/
 
 namespace Semantics.Presupposition.OntologicalPreconditions
 
-open Semantics.Presupposition
-open Features.ChangeOfState
-open Features
-open Features
-
+open Features (Polarity)
 
 variable {W : Type*}
 
-/--
-An event decomposed into temporal phases:
-1. Precondition: State that must hold BEFORE for the event to be possible
-2. The event occurrence itself
-3. Consequence: State that holds AFTER the event
--/
+/-- An event decomposed into temporal phases: the state that must hold
+    *before* for the event to be possible, the occurrence itself, and the
+    state that holds *after*. -/
 structure EventPhase (W : Type*) where
   /-- Precondition: must hold before the event for it to be possible -/
   precondition : W → Prop
@@ -63,413 +45,77 @@ structure EventPhase (W : Type*) where
   /-- Consequence: holds after the event (result state) -/
   consequence : W → Prop
 
-/--
-Well-formed event: precondition enables the event.
-
-This is the ontological constraint: you can't stop smoking unless you were smoking.
--/
+/-- Well-formed event: the occurrence entails its precondition — the
+    ontological constraint (you can't stop smoking unless you were smoking). -/
 def EventPhase.wellFormed (e : EventPhase W) : Prop :=
   ∀ w, e.eventOccurs w → e.precondition w
 
+/-- An event is telic if its consequence differs from its precondition at
+    some world (a state change). -/
+def EventPhase.isTelic (e : EventPhase W) : Prop :=
+  ∃ w, e.precondition w ≠ e.consequence w
 
-/-- "Stop P" as an event phase -/
-def stopAsEventPhase (P : W → Prop) : EventPhase W where
-  precondition := P
-  eventOccurs := P
-  consequence := λ w => ¬ P w
+/-- An event is atelic if precondition and consequence coincide everywhere
+    (the state persists). -/
+def EventPhase.isAtelic (e : EventPhase W) : Prop :=
+  ∀ w, e.precondition w = e.consequence w
 
-/-- "Start P" as an event phase -/
-def startAsEventPhase (P : W → Prop) : EventPhase W where
-  precondition := λ w => ¬ P w
-  eventOccurs := λ w => ¬ P w
-  consequence := P
+/-! ### The aboutness mechanism
 
-/-- "Continue P" as an event phase -/
-def continueAsEventPhase (P : W → Prop) : EventPhase W where
-  precondition := P
-  eventOccurs := P
-  consequence := P
+Sentences refer to event types; event types have inherent preconditions;
+and "John stopped" and "John didn't stop" refer to the *same* event type —
+negation affects the claim about the event, not which event is referenced.
+Preconditions therefore project, because they are tied to event reference
+rather than to the polarity-dependent claim. -/
 
-
-/-- Event phase precondition = CoS presupposition. -/
-theorem stop_precondition_is_presup (P : W → Prop) :
-    (stopAsEventPhase P).precondition = priorStatePresup .cessation P := rfl
-
-theorem start_precondition_is_presup (P : W → Prop) :
-    (startAsEventPhase P).precondition = priorStatePresup .inception P := rfl
-
-theorem continue_precondition_is_presup (P : W → Prop) :
-    (continueAsEventPhase P).precondition = priorStatePresup .continuation P := rfl
-
-/-- Event phase consequence = CoS assertion. -/
-theorem stop_consequence_is_assertion (P : W → Prop) :
-    (stopAsEventPhase P).consequence = resultStateAssertion .cessation P := rfl
-
-theorem start_consequence_is_assertion (P : W → Prop) :
-    (startAsEventPhase P).consequence = resultStateAssertion .inception P := rfl
-
-theorem continue_consequence_is_assertion (P : W → Prop) :
-    (continueAsEventPhase P).consequence = resultStateAssertion .continuation P := rfl
-
-
-/-
-## The Aboutness Mechanism
-
-Why do preconditions project through negation? [roberts-simons-2024] argue:
-
-1. Sentences refer to event types (not just assert propositions)
-2. Event types have inherent preconditions (ontological requirements)
-3. Both "John stopped" and "John didn't stop" refer to the same event type
-4. Negation affects the claim about the event, not which event is referenced
-5. Therefore, preconditions project: they're tied to the event reference
-
-This contrasts with an assertion-only view where sentences are just truth conditions.
-Under assertion-only, there's no structural reason for shared presuppositions.
--/
-
--- Sentence polarity from Core — .positive = affirmed, .negative = negated
-open Features (Polarity)
-
-/--
-A sentence that refers to an event type and makes a claim about it.
-
-The event type referenced is independent of the claim made.
-Both affirmative and negative sentences can refer to the same event type.
--/
+/-- A sentence that refers to an event type and makes a polarity-dependent
+    claim about it. -/
 structure EventSentence (W : Type*) where
   /-- The event type this sentence is about -/
   eventType : EventPhase W
   /-- The polarity of the claim -/
   polarity : Polarity
 
-/--
-The "aboutness" of a sentence: what event type it refers to.
-
-This is independent of polarity: both "John stopped" and "John didn't stop"
-are about the same event type (the stopping).
--/
+/-- The aboutness of a sentence: the event type it refers to, independent
+    of polarity. -/
 def EventSentence.aboutness (s : EventSentence W) : EventPhase W :=
   s.eventType
 
-/--
-The assertion made by a sentence depends on polarity.
-
-- Affirmed: The event occurred (consequence holds)
-- Negated: The event didn't occur (consequence doesn't hold)
--/
+/-- The claim made: affirmed sentences assert the consequence obtains,
+    negated ones that it doesn't. -/
 def EventSentence.assertion (s : EventSentence W) : W → Prop :=
   match s.polarity with
   | .positive => s.eventType.consequence
   | .negative => λ w => ¬ s.eventType.consequence w
 
-/--
-The presupposition comes from aboutness, not from the assertion.
-
-Presuppositions are tied to event reference, not to the claim being made.
--/
+/-- The presupposition comes from aboutness, not from the assertion: it is
+    the precondition of the referenced event type. -/
 def EventSentence.presupposition (s : EventSentence W) : W → Prop :=
   s.aboutness.precondition
 
-/--
-Construct an affirmative sentence about an event type.
--/
+/-- An affirmative sentence about an event type. -/
 def affirmative (e : EventPhase W) : EventSentence W :=
   { eventType := e, polarity := .positive }
 
-/--
-Construct a negative sentence about an event type.
--/
+/-- A negative sentence about an event type. -/
 def negative (e : EventPhase W) : EventSentence W :=
   { eventType := e, polarity := .negative }
 
-/--
-Affirmative and negative sentences have the same aboutness.
-
-Both "John stopped smoking" and "John didn't stop smoking" are about
-the same event type, the stopping event. This is the structural basis
-for presupposition projection.
--/
-theorem same_aboutness (e : EventPhase W) :
-    (affirmative e).aboutness = (negative e).aboutness := rfl
-
-/--
-Presuppositions project because they come from shared aboutness.
-
-Since presuppositions are derived from aboutness, and aboutness is shared
-across polarities, presuppositions must be shared too.
--/
+/-- Presuppositions project through negation: derived from aboutness, which
+    affirmation and negation share. -/
 theorem presupposition_projects (e : EventPhase W) :
     (affirmative e).presupposition = (negative e).presupposition := rfl
 
-/--
-Assertions differ by polarity.
-
-While presuppositions are shared, assertions differ:
-the negative asserts the opposite of the affirmative.
--/
+/-- Assertions flip with polarity while presuppositions stay constant. -/
 theorem assertion_differs (e : EventPhase W) (w : W) :
     (negative e).assertion w ↔ ¬ (affirmative e).assertion w := Iff.rfl
 
-/--
-Presupposition is independent of assertion content.
-
-The presupposition depends only on the event type, not on what is asserted.
-This is what makes presuppositions "backgrounded": they're part of
-what we're talking about, not what we're saying about it.
--/
-theorem presupposition_independent_of_assertion (s : EventSentence W) :
-    s.presupposition = s.eventType.precondition := rfl
-
--- ═══════════════════════════════════════════════════════════════════════
--- Contrast with Assertion-Only View
--- ═══════════════════════════════════════════════════════════════════════
-
-/-
-## The Assertion-Only View (for contrast)
-
-Under an assertion-only view, a sentence IS its truth conditions.
-There's no notion of "event reference" or "aboutness" — just a proposition.
-
-This view cannot explain why presuppositions project, because it lacks
-the structural component (shared event reference) that would force
-affirmative and negative to share anything.
--/
-
-/--
-Under the assertion-only view, we just have truth conditions.
--/
-structure AssertionOnlyMeaning (W : Type*) where
-  truthConditions : W → Bool
-
-/--
-Under assertion-only, "stop P" just means: was P and now ¬P.
-
-Without temporal indices, this collapses to `P w ∧ ¬P w` at a single
-world — always false. This demonstrates that purely extensional
-(single-index) semantics cannot represent CoS verbs: the pre-state
-and post-state refer to different temporal indices, and flattening
-them into one evaluation point produces a contradiction.
--/
-def assertionOnly_stop (P : W → Bool) : AssertionOnlyMeaning W :=
-  { truthConditions := λ w => P w && !P w }
-
-/--
-Under assertion-only, "not stop P" just means: ¬(was P and now ¬P).
--/
-def assertionOnly_notStop (P : W → Bool) : AssertionOnlyMeaning W :=
-  { truthConditions := λ w => !(P w && !P w) }
-  -- ¬P ∨ P, a tautology
-
-/--
-Under assertion-only, the negation does not entail the precondition.
-
-The negated assertion !(P w && !P w) = !P w ∨ P w is true when P w is false.
-So we cannot infer P from the negated sentence.
-
-This demonstrates the inadequacy of the assertion-only view:
-it cannot explain why "John didn't stop smoking" presupposes he was smoking.
--/
-theorem assertionOnly_no_presupposition (P : W → Bool) (w : W)
-    (_hNotP : P w = false) :
-    (assertionOnly_notStop P).truthConditions w = true := by
-  simp [assertionOnly_notStop]
-
-/--
-Under the aboutness view, both sentences refer to the stopping event.
-The stopping event has precondition P (was smoking).
-Therefore, both sentences presuppose P.
--/
-theorem aboutness_predicts_projection (P : W → Prop) :
-    (affirmative (stopAsEventPhase P)).presupposition =
-    (negative (stopAsEventPhase P)).presupposition := rfl
-
-/--
-The shared presupposition IS the precondition of the event type.
--/
-theorem shared_presupposition_is_precondition (P : W → Prop) :
-    (affirmative (stopAsEventPhase P)).presupposition = P := rfl
-
-/--
-For "stop P", both affirmative and negative presuppose P.
-
-This is the core empirical prediction that the aboutness view explains
-and the assertion-only view cannot.
--/
-theorem stop_presupposes_P (P : W → Prop) (pol : Polarity) :
-    ({ eventType := stopAsEventPhase P, polarity := pol } : EventSentence W).presupposition = P := rfl
-
-
-/--
-Consequential event: the event entails its consequence when it occurs.
--/
-def EventPhase.hasConsequence (e : EventPhase W) : Prop :=
-  ∀ w, e.eventOccurs w → e.consequence w
-
-/--
-Consequences do not project through negation.
-
-Under "not E", the event didn't occur, so we can't infer the consequence.
-This explains why "John didn't stop smoking" doesn't entail he's not smoking.
-
-The asymmetry:
-- Preconditions: tied to event reference, so they project
-- Consequences: tied to event occurrence, so they don't project under negation
--/
-theorem consequence_requires_occurrence (e : EventPhase W)
-    (h : e.hasConsequence) (w : W) (hOccur : e.eventOccurs w) : e.consequence w :=
-  h w hOccur
-
-/--
-Structural explanation: why preconditions project and consequences don't.
-
-1. Presupposition = aboutness.precondition (comes from event reference)
-2. Assertion = depends on polarity (comes from claim about occurrence)
-3. Consequence = entailed by occurrence (part of assertion, not aboutness)
-
-Under negation:
-- Event reference is preserved → presupposition preserved
-- Occurrence is denied → consequence not entailed
--/
-theorem structural_asymmetry (e : EventPhase W) :
-    -- Presupposition comes from aboutness (reference), independent of polarity
-    (∀ p : Polarity, ({ eventType := e, polarity := p } : EventSentence W).presupposition = e.precondition) := by
-  intro p; rfl
-
-/--
-Assertions differ at any world where the consequence is definite (true or false).
-
-If the consequence is true at w, affirmative says true and negative says false.
-If the consequence is false at w, affirmative says false and negative says true.
--/
-theorem assertions_differ_at_definite_worlds (e : EventPhase W) (w : W) :
-    (negative e).assertion w ↔ ¬ (affirmative e).assertion w := Iff.rfl
-
-/--
-Presuppositions are constant across polarity; assertions vary with polarity.
-
-Presuppositions are tied to event reference (which is constant),
-not to the claim (which varies).
--/
-theorem presupposition_constant_assertion_varies (e : EventPhase W) (w : W) :
-    -- Presupposition is the same for both polarities
-    ((affirmative e).presupposition w ↔ (negative e).presupposition w) ∧
-    -- Assertion is negated
-    ((negative e).assertion w ↔ ¬ (affirmative e).assertion w) :=
-  ⟨Iff.rfl, Iff.rfl⟩
-
-
-/--
-The precondition/consequence asymmetry under negation.
-
-Under negation, precondition content survives (via presupposition) but
-consequence content is denied (via assertion). This is the structural
-basis for why preconditions are the default accommodation target
-([roberts-simons-2024] p. 721): accommodating preconditions is
-consistent with both affirming and denying the event, while
-accommodating consequences is only consistent with affirmation.
--/
-theorem negation_preserves_precondition_denies_consequence
-    (e : EventPhase W) (w : W) :
-    -- Precondition survives negation (it IS the presupposition)
-    ((negative e).presupposition w ↔ e.precondition w) ∧
-    -- Consequence is denied under negation
-    ((negative e).assertion w ↔ ¬ e.consequence w) :=
-  ⟨Iff.rfl, Iff.rfl⟩
-
-/--
-The converse: under affirmation, precondition survives AND consequence
-is asserted. Preconditions are consistent with BOTH polarities;
-consequences are consistent with only one.
--/
-theorem affirmation_preserves_precondition_asserts_consequence
-    (e : EventPhase W) (w : W) :
-    ((affirmative e).presupposition w ↔ e.precondition w) ∧
-    ((affirmative e).assertion w ↔ e.consequence w) :=
-  ⟨Iff.rfl, Iff.rfl⟩
-
-
-/--
-An event is telic if its consequence differs from its precondition.
-
-This is the existential property: there exists some world where
-precondition ≠ consequence, indicating a state change.
--/
-def EventPhase.isTelic (e : EventPhase W) : Prop :=
-  ∃ w, e.precondition w ≠ e.consequence w
-
-/--
-An event is atelic if precondition and consequence are the same.
-
-This is the universal property: in all worlds, the state persists.
--/
-def EventPhase.isAtelic (e : EventPhase W) : Prop :=
-  ∀ w, e.precondition w = e.consequence w
-
-/-- "Stop P" is telic: state changes from P to ¬P -/
-theorem stop_is_telic (P : W → Prop) (w : W) (hP : P w) :
-    (stopAsEventPhase P).precondition w ≠ (stopAsEventPhase P).consequence w := by
-  unfold stopAsEventPhase
-  intro h
-  exact (cast h hP) hP
-
-/-- "Continue P" is atelic: no state change -/
-theorem continue_is_atelic (P : W → Prop) : (continueAsEventPhase P).isAtelic := by
-  intro w; rfl
-
-/-- "Start P" is telic: state changes from ¬P to P -/
-theorem start_is_telic (P : W → Prop) (w : W) (hNotP : ¬ P w) :
-    (startAsEventPhase P).precondition w ≠ (startAsEventPhase P).consequence w := by
-  unfold startAsEventPhase
-  intro h
-  exact hNotP (cast h hNotP)
-
-
-/--
-Aspectual profile for CoS verb types.
-
-- "stop": Achievement profile (telic, punctual change to ¬P)
-- "start": Achievement profile (telic, punctual change to P)
-- "continue": Activity profile (atelic, durative persistence)
--/
-def cosTypeToAspectualProfile : CoSType → AspectualProfile
-  | .cessation => achievementProfile    -- "stop": punctual, telic
-  | .inception => achievementProfile    -- "start": punctual, telic
-  | .continuation => activityProfile    -- "continue": durative, atelic
-
-/--
-CoS verbs have specific Vendler classifications (derived from profile).
--/
-def cosTypeToVendlerClass (t : CoSType) : VendlerClass :=
-  (cosTypeToAspectualProfile t).toVendlerClass
-
-/--
-Cessation is classified as achievement (telic, punctual).
--/
-theorem cessation_is_achievement :
-    cosTypeToVendlerClass .cessation = .achievement := rfl
-
-/--
-Continuation is classified as activity (atelic, durative).
--/
-theorem continuation_is_activity :
-    cosTypeToVendlerClass .continuation = .activity := rfl
-
-/--
-The Vendler class determines the telicity correctly.
--/
-theorem cos_vendler_telicity_correct (t : CoSType) :
-    (cosTypeToVendlerClass t).telicity = match t with
-      | .cessation => .telic
-      | .inception => .telic
-      | .continuation => .atelic := by
-  cases t <;> rfl
-
--- ═══════════════════════════════════════════════════════════════════════
--- §5. Entailment Classification
--- ═══════════════════════════════════════════════════════════════════════
+/-! ### Entailment classification -/
 
 /-- Classification of entailment relations between a sentence and its
-    implied content ([roberts-simons-2024] §2.1). -/
+    implied content: only preconditions project ([roberts-simons-2024] §2.1
+    diagnostics: "ψ, which is part of what allowed for φ" and the
+    counterfactual "if not-ψ, φ would not have been possible"). -/
 inductive EntailmentRelation where
   /-- Temporally prior, enables the event. Projects by pragmatic default. -/
   | precondition
@@ -486,165 +132,5 @@ def EntailmentRelation.projects : EntailmentRelation → Bool
   | .precondition => true
   | .consequence  => false
   | .concomitant  => false
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §6. Factive Verbs as Event Phases
--- ═══════════════════════════════════════════════════════════════════════
-
-/-
-## Factive Verbs as Event Phases ([roberts-simons-2024] §2, §3.2.2)
-
-R&S extend event phase analysis beyond CoS verbs to factives.
-The complement truth of a factive verb is an ontological precondition
-of the associated eventuality — not a semantically encoded presupposition.
--/
-
-/-- "Know C" as an event phase: stative, atelic.
-    Precondition: C is true. The knowing state cannot exist without its object.
-    The state persists without change, so consequence = precondition = C. -/
-def knowAsEventPhase (BEL C : W → Prop) : EventPhase W where
-  precondition := C
-  eventOccurs := λ w => BEL w ∧ C w
-  consequence := C  -- stative: no state change
-
-/-- "Discover C" as an event phase: telic, achievement.
-    Two preconditions: C is true AND the agent was previously ignorant.
-    The discovery transitions from ignorance to knowledge.
-    Consequence: C is (still) true and the agent is no longer ignorant. -/
-def discoverAsEventPhase (IGNORANT C : W → Prop) : EventPhase W where
-  precondition := λ w => C w ∧ IGNORANT w
-  eventOccurs := λ w => C w ∧ ¬ IGNORANT w
-  consequence := λ w => C w ∧ ¬ IGNORANT w  -- post-state: knows C
-
-/-- "Regret p" as an event phase: emotive factive.
-    Precondition: agent believes p (the emotion ontologically
-    depends on the belief, not on truth directly).
-
-    [roberts-simons-2024] (p. 731): regret's factivity arises from
-    a *pragmatic default to veridicality* — in the absence of an explicit
-    claim that the agent is mistaken, emotive attitudes are taken to be
-    veridical. The ontological precondition is belief, not truth. -/
-def regretAsEventPhase (BEL : W → Prop) : EventPhase W where
-  precondition := BEL
-  eventOccurs := BEL
-  consequence := BEL
-
-/-- Know is atelic: no state change (precondition = consequence). -/
-theorem know_is_atelic (BEL C : W → Prop) : (knowAsEventPhase BEL C).isAtelic := by
-  intro w; rfl
-
-/-- Discover is telic: state change from ignorant to knowing. -/
-theorem discover_is_telic (IGNORANT C : W → Prop) (w : W)
-    (hC : C w) (hIgn : IGNORANT w) :
-    (discoverAsEventPhase IGNORANT C).precondition w ≠
-    (discoverAsEventPhase IGNORANT C).consequence w := by
-  unfold discoverAsEventPhase
-  intro h
-  have h2 : C w ∧ ¬ IGNORANT w := cast h ⟨hC, hIgn⟩
-  exact h2.2 hIgn
-
-/-- Both know and discover have C as (part of) their precondition.
-    This is the shared factivity: complement truth is ontologically required. -/
-theorem factive_precondition_entails_complement (IGNORANT C : W → Prop) (w : W) :
-    (discoverAsEventPhase IGNORANT C).precondition w → C w := by
-  intro h; exact h.1
-
-/-- Discover's precondition additionally requires prior ignorance.
-    This extra precondition (ignorance of C) explains why discover
-    has weaker projection than know in conditional antecedents:
-    in "If I discover p", the speaker's ignorance of p is salient,
-    suppressing projection of C ([roberts-simons-2024] §3.2.2). -/
-theorem discover_precondition_requires_ignorance (IGNORANT C : W → Prop) (w : W) :
-    (discoverAsEventPhase IGNORANT C).precondition w → IGNORANT w := by
-  intro h; exact h.2
-
-/-- Continue has a precondition (prior activity) but involves NO state change.
-    [roberts-simons-2024] (p. 734): "continue V-ing is atelic, without a
-    pre-state" in the CoS sense. The `CoSType.continuation` classification is
-    a convenience; the key structural fact is `isAtelic`. -/
-theorem continue_has_precondition_without_state_change (P : W → Prop) :
-    (continueAsEventPhase P).precondition = P ∧
-    (continueAsEventPhase P).isAtelic := by
-  refine ⟨rfl, ?_⟩
-  intro w; rfl
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §7. Selectional Restrictions as Preconditions
--- ═══════════════════════════════════════════════════════════════════════
-
-/-
-## Selectional Restrictions ([roberts-simons-2024] §2.1)
-
-Selectional restrictions are ontological preconditions of the same kind
-as factive and CoS projections. "The robot kicked the tree" implies
-"the robot has feet" — this is a precondition, confirmed by both
-diagnostics:
-
-(13a) "The robot has feet, which is part of what allowed for the robot
-       to kick the tree." (T)
-(14a) "If the robot did not have feet, it would not have been possible
-       for the robot to kick the tree." (T — counterfactual)
-
-This unifies selectional restrictions with the other two verb classes
-under a single mechanism: ontological precondition → pragmatic projection.
--/
-
-/-- A selectional restriction as an event phase.
-    The `requirement` is an ontological precondition of the event. -/
-def selectionalEventPhase (requirement event : W → Prop) : EventPhase W where
-  precondition := requirement
-  eventOccurs := event
-  consequence := event
-
-/-- Selectional restrictions are well-formed: the event entails the requirement. -/
-theorem selectional_wellFormed (requirement event : W → Prop)
-    (h : ∀ w, event w → requirement w) :
-    (selectionalEventPhase requirement event).wellFormed := h
-
-/-- Selectional restrictions project through negation (same aboutness mechanism). -/
-theorem selectional_projects (requirement event : W → Prop) :
-    (affirmative (selectionalEventPhase requirement event)).presupposition =
-    (negative (selectionalEventPhase requirement event)).presupposition := rfl
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §8. Pragmatic Suppression Conditions
--- ═══════════════════════════════════════════════════════════════════════
-
-/-
-## Suppression Conditions ([roberts-simons-2024] §3.2.1)
-
-Projection of preconditions is a pragmatic *default*, not an invariant.
-Three contexts suppress projection — in each, pragmatic reasoning makes
-it implausible that the speaker presumes the precondition true.
--/
-
-/-- Conditions under which projection of a precondition is suppressed.
-    When any of these obtains, the hearer does not accommodate the
-    precondition into the global context. -/
-inductive SuppressionCondition where
-  /-- Interlocutors know or believe the precondition is false or controversial.
-      Example: discussing politics with someone who denies the premise.
-      ([roberts-simons-2024] ex. 23) -/
-  | preconditionKnownFalse
-  /-- Evidence that the speaker does not believe the precondition.
-      Example: "I doubt that. Mary would divorce him if she discovered
-      he was drinking." — speaker explicitly doubts the drinking.
-      ([roberts-simons-2024] ex. 24) -/
-  | speakerNonCommitment
-  /-- The precondition is at-issue (currently under discussion).
-      Example: "Is there a decision on Jane's tenure case?" "She isn't
-      aware that there's been a decision." — decision existence is QUD.
-      ([roberts-simons-2024] ex. 25) -/
-  | preconditionAtIssue
-  deriving DecidableEq, Repr
-
-/-- When suppression applies, precondition content is merely locally entailed,
-    not globally accommodated. The content is still an entailment of the
-    trigger — it simply isn't taken to be part of the speaker's presumptions. -/
-def SuppressionCondition.globalProjection : SuppressionCondition → Bool
-  | _ => false
 
 end Semantics.Presupposition.OntologicalPreconditions

--- a/Linglib/Studies/RobertsSimons2024.lean
+++ b/Linglib/Studies/RobertsSimons2024.lean
@@ -44,6 +44,212 @@ open Features.ChangeOfState
 open Features
 open Semantics.Presupposition.ProjectiveContent
 
+variable {W : Type*}
+
+/-! ### Verb classes as event phases
+
+The paper's three verb classes instantiated as `EventPhase`s: CoS
+predicates, factives, and selectional restrictions, each with complement
+truth or prior state as ontological precondition. -/
+
+/-- "Stop P" as an event phase. -/
+def stopAsEventPhase (P : W → Prop) : EventPhase W where
+  precondition := P
+  eventOccurs := P
+  consequence := λ w => ¬ P w
+
+/-- "Start P" as an event phase. -/
+def startAsEventPhase (P : W → Prop) : EventPhase W where
+  precondition := λ w => ¬ P w
+  eventOccurs := λ w => ¬ P w
+  consequence := P
+
+/-- "Continue P" as an event phase. -/
+def continueAsEventPhase (P : W → Prop) : EventPhase W where
+  precondition := P
+  eventOccurs := P
+  consequence := P
+
+/-- Event-phase precondition = the CoS presupposition of
+    `Features.ChangeOfState`, per CoS type. -/
+theorem stop_precondition_is_presup (P : W → Prop) :
+    (stopAsEventPhase P).precondition = priorStatePresup .cessation P := rfl
+
+theorem start_precondition_is_presup (P : W → Prop) :
+    (startAsEventPhase P).precondition = priorStatePresup .inception P := rfl
+
+theorem continue_precondition_is_presup (P : W → Prop) :
+    (continueAsEventPhase P).precondition = priorStatePresup .continuation P := rfl
+
+/-- Event-phase consequence = the CoS assertion, per CoS type. -/
+theorem stop_consequence_is_assertion (P : W → Prop) :
+    (stopAsEventPhase P).consequence = resultStateAssertion .cessation P := rfl
+
+theorem start_consequence_is_assertion (P : W → Prop) :
+    (startAsEventPhase P).consequence = resultStateAssertion .inception P := rfl
+
+theorem continue_consequence_is_assertion (P : W → Prop) :
+    (continueAsEventPhase P).consequence = resultStateAssertion .continuation P := rfl
+
+/-- "Stop P" is telic: state changes from P to ¬P. -/
+theorem stop_is_telic (P : W → Prop) (w : W) (hP : P w) :
+    (stopAsEventPhase P).precondition w ≠ (stopAsEventPhase P).consequence w := by
+  unfold stopAsEventPhase
+  intro h
+  exact (cast h hP) hP
+
+/-- "Start P" is telic: state changes from ¬P to P. -/
+theorem start_is_telic (P : W → Prop) (w : W) (hNotP : ¬ P w) :
+    (startAsEventPhase P).precondition w ≠ (startAsEventPhase P).consequence w := by
+  unfold startAsEventPhase
+  intro h
+  exact hNotP (cast h hNotP)
+
+/-- "Continue P" is atelic: a precondition (prior activity) but no state
+    change ([roberts-simons-2024] p. 734). -/
+theorem continue_is_atelic (P : W → Prop) : (continueAsEventPhase P).isAtelic := by
+  intro w; rfl
+
+/-- "Know C" as an event phase: stative, atelic.
+    Precondition: C is true. The knowing state cannot exist without its object. -/
+def knowAsEventPhase (BEL C : W → Prop) : EventPhase W where
+  precondition := C
+  eventOccurs := λ w => BEL w ∧ C w
+  consequence := C
+
+/-- "Discover C" as an event phase: telic, achievement.
+    Two preconditions: C is true AND the agent was previously ignorant. -/
+def discoverAsEventPhase (IGNORANT C : W → Prop) : EventPhase W where
+  precondition := λ w => C w ∧ IGNORANT w
+  eventOccurs := λ w => C w ∧ ¬ IGNORANT w
+  consequence := λ w => C w ∧ ¬ IGNORANT w
+
+/-- "Regret p" as an event phase: emotive factive. The ontological
+    precondition is *belief*, not truth — factivity arises from a
+    pragmatic default to veridicality ([roberts-simons-2024] p. 731). -/
+def regretAsEventPhase (BEL : W → Prop) : EventPhase W where
+  precondition := BEL
+  eventOccurs := BEL
+  consequence := BEL
+
+/-- Know is atelic: no state change (precondition = consequence). -/
+theorem know_is_atelic (BEL C : W → Prop) : (knowAsEventPhase BEL C).isAtelic := by
+  intro w; rfl
+
+/-- Regret is atelic: the emotive state persists with its grounding belief. -/
+theorem regret_is_atelic (BEL : W → Prop) : (regretAsEventPhase BEL).isAtelic := by
+  intro w; rfl
+
+/-- Discover is telic: state change from ignorant to knowing. -/
+theorem discover_is_telic (IGNORANT C : W → Prop) (w : W)
+    (hC : C w) (hIgn : IGNORANT w) :
+    (discoverAsEventPhase IGNORANT C).precondition w ≠
+    (discoverAsEventPhase IGNORANT C).consequence w := by
+  unfold discoverAsEventPhase
+  intro h
+  have h2 : C w ∧ ¬ IGNORANT w := cast h ⟨hC, hIgn⟩
+  exact h2.2 hIgn
+
+/-- Both know and discover have C as (part of) their precondition: complement
+    truth is ontologically required. -/
+theorem factive_precondition_entails_complement (IGNORANT C : W → Prop) (w : W) :
+    (discoverAsEventPhase IGNORANT C).precondition w → C w := by
+  intro h; exact h.1
+
+/-- Discover's extra precondition (prior ignorance) explains its weaker
+    projection in conditional antecedents ([roberts-simons-2024] §3.2.2). -/
+theorem discover_precondition_requires_ignorance (IGNORANT C : W → Prop) (w : W) :
+    (discoverAsEventPhase IGNORANT C).precondition w → IGNORANT w := by
+  intro h; exact h.2
+
+/-- A selectional restriction as an event phase: the `requirement`
+    ("the robot has feet") is an ontological precondition of the event
+    ("the robot kicked the tree"), confirmed by both §2.1 diagnostics. -/
+def selectionalEventPhase (requirement event : W → Prop) : EventPhase W where
+  precondition := requirement
+  eventOccurs := event
+  consequence := event
+
+/-! ### Aspectual classification -/
+
+/-- Aspectual profile per CoS type: "stop"/"start" are achievements
+    (telic, punctual); "continue" is an activity (atelic, durative). -/
+def cosTypeToAspectualProfile : CoSType → AspectualProfile
+  | .cessation => achievementProfile
+  | .inception => achievementProfile
+  | .continuation => activityProfile
+
+/-- Vendler class per CoS type, derived from the aspectual profile. -/
+def cosTypeToVendlerClass (t : CoSType) : VendlerClass :=
+  (cosTypeToAspectualProfile t).toVendlerClass
+
+/-- The derived Vendler classes carry the right telicity. -/
+theorem cos_vendler_telicity_correct (t : CoSType) :
+    (cosTypeToVendlerClass t).telicity = match t with
+      | .cessation => .telic
+      | .inception => .telic
+      | .continuation => .atelic := by
+  cases t <;> rfl
+
+/-! ### The assertion-only rival
+
+Under an assertion-only view a sentence is just its truth conditions — no
+event reference, no aboutness — so nothing forces affirmative and negative
+to share content, and single-index truth conditions cannot even represent
+a CoS verb. -/
+
+/-- The assertion-only meaning: bare truth conditions. -/
+structure AssertionOnlyMeaning (W : Type*) where
+  truthConditions : W → Prop
+
+/-- Under assertion-only, "stop P" flattens pre-state and post-state into
+    one evaluation point: P ∧ ¬P. -/
+def assertionOnly_stop (P : W → Prop) : AssertionOnlyMeaning W :=
+  { truthConditions := λ w => P w ∧ ¬ P w }
+
+/-- Under assertion-only, "not stop P" is ¬(P ∧ ¬P) — a tautology. -/
+def assertionOnly_notStop (P : W → Prop) : AssertionOnlyMeaning W :=
+  { truthConditions := λ w => ¬(P w ∧ ¬ P w) }
+
+/-- Single-index truth conditions cannot represent CoS verbs: the
+    assertion-only "stop" is contradictory at every world. -/
+theorem assertionOnly_stop_contradictory (P : W → Prop) (w : W) :
+    ¬ (assertionOnly_stop P).truthConditions w :=
+  λ ⟨h, hn⟩ => hn h
+
+/-- Under assertion-only, the negated sentence is true even where P fails,
+    so "John didn't stop smoking" would not require that he smoked: the
+    view has no presupposition. -/
+theorem assertionOnly_no_presupposition (P : W → Prop) (w : W)
+    (_hNotP : ¬ P w) :
+    (assertionOnly_notStop P).truthConditions w :=
+  λ ⟨h, hn⟩ => hn h
+
+/-! ### Pragmatic suppression conditions
+
+Projection of preconditions is a pragmatic *default*, not an invariant
+([roberts-simons-2024] §3.2.1). -/
+
+/-- Contexts that suppress projection of a precondition: in each, pragmatic
+    reasoning makes it implausible that the speaker presumes the
+    precondition true. -/
+inductive SuppressionCondition where
+  /-- Interlocutors know or believe the precondition is false or
+      controversial ([roberts-simons-2024] ex. 23). -/
+  | preconditionKnownFalse
+  /-- Evidence that the speaker does not believe the precondition
+      ([roberts-simons-2024] ex. 24). -/
+  | speakerNonCommitment
+  /-- The precondition is at-issue, i.e. currently under discussion
+      ([roberts-simons-2024] ex. 25). -/
+  | preconditionAtIssue
+  deriving DecidableEq, Repr
+
+/-- Under any suppression condition, precondition content is merely locally
+    entailed, not globally accommodated. -/
+def SuppressionCondition.globalProjection : SuppressionCondition → Bool
+  | _ => false
+
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- §1. Theory Predicts Diagnostic Pattern


### PR DESCRIPTION
Per-declaration audit of `OntologicalPreconditions.lean` (650 lines, 60 decls, 2 Study consumers): only the `EventPhase`/`EventSentence`/`EntailmentRelation` core is consumed by both RobertsSimons2024 and SolstadBott2024.

- Substrate slims to that core (~135 lines); the malformed pre-import comment block becomes a proper module docstring; imports drop to `Features.Polarity` (+`TypeStar`) — the `Presupposition.Basic`/`ChangeOfState`/`Aktionsart` edges were consumed only by demoted content
- Verb instances (stop/start/continue/know/discover/regret/selectional), CoS-bridge theorems, aspectual maps, suppression conditions, and the assertion-only rival (Bool → Prop) demote into `Studies/RobertsSimons2024.lean`
- Deletes ~16 zero-consumer restatement theorems (the aboutness collapse is carried by `presupposition_projects` + `assertion_differs`); adds `assertionOnly_stop_contradictory` and `regret_is_atelic`, turning the two content-bearing dead defs into results