### PR TITLE
refactor(Semantics): EventPhase to Events API; Preconditions mechanism file

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1624,6 +1624,7 @@ import Linglib.Semantics.Entailment.StrawsonSoundness
 import Linglib.Semantics.Events.Adjacency
 import Linglib.Semantics.Events.Basic
 import Linglib.Semantics.Events.CEM
+import Linglib.Semantics.Events.Phase
 import Linglib.Semantics.Evidential.Basic
 import Linglib.Semantics.Evidential.Defs
 import Linglib.Semantics.Evidential.Epistemicity
@@ -1729,6 +1730,7 @@ import Linglib.Semantics.Possessive.Denotation
 import Linglib.Semantics.Possessive.GQ
 import Linglib.Semantics.Possessive.PronounMixing
 import Linglib.Semantics.Possessive.Relational
+import Linglib.Semantics.Presupposition.Aboutness
 import Linglib.Semantics.Presupposition.Accommodation
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Presupposition.BeliefEmbedding
@@ -1736,7 +1738,6 @@ import Linglib.Semantics.Presupposition.ContentLayer
 import Linglib.Semantics.Presupposition.Context
 import Linglib.Semantics.Presupposition.Defs
 import Linglib.Semantics.Presupposition.MaximizePresupposition
-import Linglib.Semantics.Presupposition.OntologicalPreconditions
 import Linglib.Semantics.Presupposition.PhiFeatures
 import Linglib.Semantics.Presupposition.ProjectiveContent
 import Linglib.Semantics.Presupposition.Quantified

--- a/Linglib/Features/Polarity.lean
+++ b/Linglib/Features/Polarity.lean
@@ -10,7 +10,7 @@ Note: This is distinct from other polarity-like distinctions in the library:
 - `Core.Lexical.UD.Polarity` — morphological feature (`.Pos`/`.Neg`)
 - `NaturalLogic.ContextPolarity` — monotonicity direction (`.upward`/`.downward`)
 - `Rett2015Implicature.Polarity` — adjective markedness
-- `Semantics.Presupposition.OntologicalPreconditions.Polarity` — event assertion (`.affirmed`/`.negated`)
+- `Semantics.Presupposition.Aboutness.EventSentence.polarity` — polarity of the event claim
 -/
 
 namespace Features

--- a/Linglib/Semantics/Events/Phase.lean
+++ b/Linglib/Semantics/Events/Phase.lean
@@ -1,0 +1,58 @@
+import Mathlib.Tactic.TypeStar
+
+/-!
+# Event types as phase signatures
+
+The modal signature of an event type: the world-conditions that must hold
+*before* the event is possible (`precondition`), at its occurrence, and
+*after* it (`consequence`). Originates with [roberts-simons-2024]'s account
+of non-anaphoric presupposition, where ontological preconditions are what
+project (`Semantics.Presupposition.Aboutness`).
+
+Complementary decompositions elsewhere in the event API: `Event` (a
+temporal *token* with runtime and sort), and
+`Semantics.Aspect.SubeventStructure.TemporalDecomposition` (interval-valued
+activity/result phases of a token). `EventPhase` is type-level and modal —
+phases as predicates over worlds, not intervals. For change-of-state verbs
+its precondition/consequence coincide with `Features.ChangeOfState`'s
+presupposition/assertion pair (bridged in `Studies/RobertsSimons2024.lean`).
+
+## Main declarations
+
+* `EventPhase` — precondition / occurrence / consequence over worlds.
+* `EventPhase.wellFormed` — occurrence entails precondition (the
+  ontological constraint: you can't stop smoking unless you were smoking).
+* `EventPhase.isTelic` / `EventPhase.isAtelic` — whether the consequence
+  differs from the precondition (a state change) or coincides with it.
+-/
+
+variable {W : Type*}
+
+/-- An event type decomposed into temporal phases: the state that must hold
+    *before* for the event to be possible, the occurrence itself, and the
+    state that holds *after*. -/
+structure EventPhase (W : Type*) where
+  /-- Precondition: must hold before the event for it to be possible -/
+  precondition : W → Prop
+  /-- The event actually occurs -/
+  eventOccurs : W → Prop
+  /-- Consequence: holds after the event (result state) -/
+  consequence : W → Prop
+
+namespace EventPhase
+
+/-- Well-formed event type: the occurrence entails its precondition. -/
+def wellFormed (e : EventPhase W) : Prop :=
+  ∀ w, e.eventOccurs w → e.precondition w
+
+/-- An event type is telic if its consequence differs from its precondition
+    at some world (a state change). -/
+def isTelic (e : EventPhase W) : Prop :=
+  ∃ w, e.precondition w ≠ e.consequence w
+
+/-- An event type is atelic if precondition and consequence coincide
+    everywhere (the state persists). -/
+def isAtelic (e : EventPhase W) : Prop :=
+  ∀ w, e.precondition w = e.consequence w
+
+end EventPhase

--- a/Linglib/Semantics/Presupposition/Aboutness.lean
+++ b/Linglib/Semantics/Presupposition/Aboutness.lean
@@ -1,20 +1,18 @@
-import Mathlib.Tactic.TypeStar
+import Linglib.Semantics.Events.Phase
 import Linglib.Features.Polarity
 
 /-!
-# Ontological preconditions and projection
+# The aboutness account of projection
 
-[roberts-simons-2024]'s event-phase account of non-anaphoric presupposition:
-projective contents are entailments characterizing *ontological
-preconditions* of the event type a sentence is about, and project because
-affirmation and negation share that event reference — not because they are
-semantically encoded presuppositions.
+[roberts-simons-2024]'s mechanism for non-anaphoric presupposition:
+sentences refer to event types (`EventPhase`); event types have inherent
+ontological preconditions; and "John stopped" and "John didn't stop" refer
+to the *same* event type — negation affects the claim about the event, not
+which event is referenced. Preconditions therefore project, because they
+are tied to event reference rather than to the polarity-dependent claim.
 
 ## Main declarations
 
-* `EventPhase` — an event decomposed into precondition, occurrence, and
-  consequence, with `wellFormed` (occurrence entails precondition) and the
-  telicity predicates `isTelic`/`isAtelic`.
 * `EventSentence` — a sentence as event reference (`aboutness`) plus a
   polarity-dependent claim (`assertion`); its `presupposition` is the
   precondition of the referenced event type, so projection through negation
@@ -28,45 +26,11 @@ restrictions), aspectual classification, and suppression conditions live in
 `Studies/RobertsSimons2024.lean`.
 -/
 
-namespace Semantics.Presupposition.OntologicalPreconditions
+namespace Semantics.Presupposition.Aboutness
 
 open Features (Polarity)
 
 variable {W : Type*}
-
-/-- An event decomposed into temporal phases: the state that must hold
-    *before* for the event to be possible, the occurrence itself, and the
-    state that holds *after*. -/
-structure EventPhase (W : Type*) where
-  /-- Precondition: must hold before the event for it to be possible -/
-  precondition : W → Prop
-  /-- The event actually occurs -/
-  eventOccurs : W → Prop
-  /-- Consequence: holds after the event (result state) -/
-  consequence : W → Prop
-
-/-- Well-formed event: the occurrence entails its precondition — the
-    ontological constraint (you can't stop smoking unless you were smoking). -/
-def EventPhase.wellFormed (e : EventPhase W) : Prop :=
-  ∀ w, e.eventOccurs w → e.precondition w
-
-/-- An event is telic if its consequence differs from its precondition at
-    some world (a state change). -/
-def EventPhase.isTelic (e : EventPhase W) : Prop :=
-  ∃ w, e.precondition w ≠ e.consequence w
-
-/-- An event is atelic if precondition and consequence coincide everywhere
-    (the state persists). -/
-def EventPhase.isAtelic (e : EventPhase W) : Prop :=
-  ∀ w, e.precondition w = e.consequence w
-
-/-! ### The aboutness mechanism
-
-Sentences refer to event types; event types have inherent preconditions;
-and "John stopped" and "John didn't stop" refer to the *same* event type —
-negation affects the claim about the event, not which event is referenced.
-Preconditions therefore project, because they are tied to event reference
-rather than to the polarity-dependent claim. -/
 
 /-- A sentence that refers to an event type and makes a polarity-dependent
     claim about it. -/
@@ -133,4 +97,4 @@ def EntailmentRelation.projects : EntailmentRelation → Bool
   | .consequence  => false
   | .concomitant  => false
 
-end Semantics.Presupposition.OntologicalPreconditions
+end Semantics.Presupposition.Aboutness

--- a/Linglib/Studies/RobertsSimons2024.lean
+++ b/Linglib/Studies/RobertsSimons2024.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Presupposition.OntologicalPreconditions
+import Linglib.Semantics.Presupposition.Aboutness
 import Linglib.Semantics.Aspect.ChangeOfState
 import Linglib.Features.Aktionsart
 import Linglib.Semantics.Presupposition.ProjectiveContent
@@ -31,7 +31,7 @@ non-anaphoric presupposition. *Linguistics and Philosophy* 47(4):703–748.
 ## Connection to Existing Theory
 
 This study file imports and bridges:
-- `OntologicalPreconditions` (EventPhase, entailment classification)
+- `Semantics.Events.Phase` / `Presupposition.Aboutness` (EventPhase, entailment classification)
 - `ChangeOfState.Theory` (CoS presuppositions)
 - `Features.Aktionsart` (Vendler classes, telicity)
 - `ProjectiveContent` (Tonhauser taxonomy: all three verb classes are Class C)
@@ -39,7 +39,7 @@ This study file imports and bridges:
 
 namespace RobertsSimons2024
 
-open Semantics.Presupposition.OntologicalPreconditions
+open Semantics.Presupposition.Aboutness
 open Features.ChangeOfState
 open Features
 open Semantics.Presupposition.ProjectiveContent

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Presupposition.Context
-import Linglib.Semantics.Presupposition.OntologicalPreconditions
+import Linglib.Semantics.Presupposition.Aboutness
 import Linglib.Semantics.Presupposition.ProjectiveContent
 import Linglib.Studies.SolstadBott2022
 import Linglib.Fragments.German.Predicates
@@ -56,7 +56,7 @@ resolution and symmetric filtering — "a cage of their own".
 
 namespace SolstadBott2024
 
-open Semantics.Presupposition.OntologicalPreconditions
+open Semantics.Presupposition.Aboutness
 open Semantics.Presupposition.ProjectiveContent
 open SolstadBott2022
 open German.Predicates


### PR DESCRIPTION
Homes `Event.Phase` in the Event API and reduces the R&S mechanism to a hom onto the existing presupposition carrier, per the object-API principle. Verified against the paper (full PDF read).

- `Semantics/Events/Phase.lean`: `Event.Phase` (+`wellFormed`/`isTelic`/`isAtelic`) as the type-level modal signature, namespaced per the Event API's own convention (`Event.Mereology`, `Event.Manner`), cross-referenced with `Event` (temporal token) and `Aspect.SubeventStructure.TemporalDecomposition` (interval phases)
- `Presupposition/OntologicalPreconditions.lean` → `Presupposition/Preconditions.lean`: the parallel `EventSentence` carrier collapses to `Event.Phase.toPartialProp`; the negated sentence is `PartialProp.neg`, so projection through negation is an instance of the canonical negation-is-a-hole lemma. `EntailmentRelation` (§2.1 classification) stays
- The former "aboutness" framing was the formalizer's invention — the term appears nowhere in the paper; docstrings state the actual §3.1 informativity mechanism. All location cites verified against the PDF (§2.1 diagnostics, exx. 23–25, pp. 731/734)

Follow-up flagged separately: `Aspect/ChangeOfState.lean` declares `namespace Features.ChangeOfState` (migration residue, ~10 consumers).