### PR TITLE
chore(Semantics): defProp/lint fixes; BeltramaSoltBurnett2023 rename

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1969,7 +1969,7 @@ import Linglib.Studies.Belnap1982
 import Linglib.Studies.Belth2026
 import Linglib.Studies.Beltrama2025
 import Linglib.Studies.BeltramaSchwarz2024
-import Linglib.Studies.BeltramaSoltBurnett2022
+import Linglib.Studies.BeltramaSoltBurnett2023
 import Linglib.Studies.Bennett2018
 import Linglib.Studies.Benua1997.Basic
 import Linglib.Studies.Benua1997.StratalCorr

--- a/Linglib/Semantics/Degree/Adjective.lean
+++ b/Linglib/Semantics/Degree/Adjective.lean
@@ -322,7 +322,7 @@ theorem standard_ieAdmits (g : GradableAdjective)
   | none => simp [ieAdmits]
   | some d =>
     cases hb : d.boundedness <;> cases hl : g.isLowerEndpoint <;>
-      simp [ieAdmits, interpretiveEconomy, hd, hb, hl]
+      simp [ieAdmits, interpretiveEconomy, hb]
 
 /-- Kennedy's adjective class — derived from `standard`, not stored; `.nonGradable`
     exactly when there is no `dimension` ([kennedy-2007], [kennedy-mcnally-2005]). -/

--- a/Linglib/Semantics/Mereology.lean
+++ b/Linglib/Semantics/Mereology.lean
@@ -235,9 +235,9 @@ def IsSumHom.toSupHom {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
   map_sup' := hf.map_sup
 
 /-- Every Mathlib `SupHom` satisfies `IsSumHom`. -/
-@[reducible] def SupHom.toIsSumHom {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
-    (f : SupHom α β) : IsSumHom f.toFun where
-  map_sup := f.map_sup'
+theorem SupHom.toIsSumHom {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
+    (f : SupHom α β) : IsSumHom f.toFun :=
+  ⟨f.map_sup'⟩
 
 /-- Sum homomorphisms are order-preserving (monotone).
     If x ≤ y then f(x) ≤ f(y). -/
@@ -525,7 +525,7 @@ def gHomogeneous {α : Type*} [PartialOrder α] (P : α → Prop) : Prop :=
     a fortiori every proper part has a P-part (itself). -/
 theorem div_implies_gHomogeneous {α : Type*} [PartialOrder α]
     {P : α → Prop} (hDiv : DIV P) : gHomogeneous P :=
-  fun x y hPx hlt => ⟨y, le_refl y, hDiv (le_of_lt hlt) hPx⟩
+  fun _ y hPx hlt => ⟨y, le_refl y, hDiv (le_of_lt hlt) hPx⟩
 
 def FakeMass {α : Type*} [SemilatticeSup α] (P : α → Prop) : Prop :=
   CUM P ∧ ¬ gHomogeneous P
@@ -583,7 +583,7 @@ theorem overlapPred_union_of_maxDisjoint_ne {D₁ D₂ P : Set α}
   obtain ⟨x, hx₂, hx₁⟩ | ⟨x, hx₁, hx₂⟩ :
       (∃ x, x ∈ D₂ ∧ x ∉ D₁) ∨ (∃ x, x ∈ D₁ ∧ x ∉ D₂) := by
     by_contra hcon
-    push_neg at hcon
+    push Not at hcon
     exact hne (Set.Subset.antisymm hcon.2 hcon.1)
   · exact overlapPred_mono ov
       (Set.insert_subset_iff.mpr ⟨Or.inr hx₂, fun a ha => Or.inl ha⟩)
@@ -599,7 +599,7 @@ theorem overlapPred_nullSchema {D₁ D₂ P : Set α}
     (h₁ : IsMaxDisjointIn ov D₁ P) (h₂ : IsMaxDisjointIn ov D₂ P)
     (hne : D₁ ≠ D₂) : OverlapPred ov (nullSchema ov P) :=
   overlapPred_mono ov
-    (Set.union_subset (fun a ha => ⟨D₁, h₁, ha⟩) (fun a ha => ⟨D₂, h₂, ha⟩))
+    (Set.union_subset (fun _ ha => ⟨D₁, h₁, ha⟩) (fun _ ha => ⟨D₂, h₂, ha⟩))
     (overlapPred_union_of_maxDisjoint_ne ov h₁ h₂ hne)
 
 /-- A disjoint predicate is its own unique perspective: the null schema
@@ -695,7 +695,7 @@ class MereoDim {α β : Type*} [PartialOrder α] [PartialOrder β]
   /-- The underlying strict monotonicity proof. -/
   toStrictMono : StrictMono d
 
-@[reducible] def MereoDim.ofInjSumHom {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
+theorem MereoDim.ofInjSumHom {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
     {f : α → β} [hf : IsSumHom f] (hinj : Function.Injective f) : MereoDim f :=
   ⟨hf.strictMono_of_injective hinj⟩
 
@@ -734,7 +734,7 @@ variable {Source Inter Measure : Type*}
     {f : Source → Inter} {μ : Inter → Measure}
 
 /-- The composed map is a MereoDim. -/
-@[reducible] def composed (dc : DimensionChain f μ) : MereoDim (μ ∘ f) :=
+theorem composed (dc : DimensionChain f μ) : MereoDim (μ ∘ f) :=
   MereoDim.comp dc.leg₂ dc.leg₁
 
 theorem cum_measure_unbounded {α : Type*} [SemilatticeSup α]

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -76,7 +76,7 @@ noncomputable instance instIsSumHomσ (Loc Time : Type*) [LinearOrder Time]
 
 /-- σ with injectivity is a MereoDim: the spatial dimension is a
     mereological morphism, enabling QUA pullback through spatial paths. -/
-def σ_mereoDim {Loc Time : Type*} [LinearOrder Time]
+theorem σ_mereoDim {Loc Time : Type*} [LinearOrder Time]
     [Event.Mereology Time] [ClassicalMereology (Event Time)]
     [SemilatticeSup (Path Loc)] [st : Trace Loc Time]
     (hinj : Function.Injective st.σ) :

--- a/Linglib/Studies/BeltramaSchwarz2024.lean
+++ b/Linglib/Studies/BeltramaSchwarz2024.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Quantification.Numerals.Precision
 import Linglib.Pragmatics.SocialMeaning.IndexicalField
 import Linglib.Pragmatics.SocialMeaning.SCM
 import Linglib.Pragmatics.SocialMeaning.EckertMontague
-import Linglib.Studies.BeltramaSoltBurnett2022
+import Linglib.Studies.BeltramaSoltBurnett2023
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Mathlib.Data.Sign.Defs
 import Mathlib.Tactic.NormNum
@@ -284,8 +284,8 @@ theorem roundness_gates_persona :
 /-- [beltrama-solt-burnett-2023]'s round stimulus (50) is the same kind of
     object: a round numeral whose precision resolution is under study. -/
 theorem bsb_stim_also_round :
-    impreciseReadingAvailable BeltramaSoltBurnett2022.stimRound :=
-  div10_enables_imprecision BeltramaSoltBurnett2022.stimRound (by decide)
+    impreciseReadingAvailable BeltramaSoltBurnett2023.stimRound :=
+  div10_enables_imprecision BeltramaSoltBurnett2023.stimRound (by decide)
 
 /-! ### Speaker-modulated halo
 

--- a/Linglib/Studies/BeltramaSoltBurnett2023.lean
+++ b/Linglib/Studies/BeltramaSoltBurnett2023.lean
@@ -48,7 +48,7 @@ tolerance modifier:
 
 -/
 
-namespace BeltramaSoltBurnett2022
+namespace BeltramaSoltBurnett2023
 
 open SocialMeaning.IndexicalField
 open SocialMeaning.SCM
@@ -459,4 +459,4 @@ theorem underspecified_indexes_nothing :
     bsbGroundedField.indexedProperties .underspecified = ∅ := by
   decide
 
-end BeltramaSoltBurnett2022
+end BeltramaSoltBurnett2023

--- a/Linglib/Studies/Eckert2008.lean
+++ b/Linglib/Studies/Eckert2008.lean
@@ -601,12 +601,10 @@ def ingFieldSCM : IndexicalField INGVariant SocialDimension where
 theorem ingFieldSCM_signs_match_ingField :
     (∀ d : SocialDimension, ingFieldSCM.association .velar d ≥ 0) ∧
     (∀ d : SocialDimension, ingFieldSCM.association .apical d ≤ 0) := by
-  constructor <;> intro d <;> cases d <;> native_decide
+  constructor <;> intro d <;> cases d <;> decide
 
 /-- The (ING) field grounded in the SCM property space via
-    `fromIndexicalField`. This is the same bridge used by
-    [beltrama-schwarz-2024] and [beltrama-solt-burnett-2022]
-    for round/precise number variants. -/
+    `fromIndexicalField`. -/
 def ingGroundedField : GroundedField INGVariant scmSpace :=
   fromIndexicalField ingFieldSCM
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -19442,7 +19442,7 @@
   subfield  = {sociolinguistics},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/BeltramaSoltBurnett2022.lean}
+  sources   = {Studies/BeltramaSoltBurnett2023.lean}
 }
 @article{fiske-cuddy-glick-2007,
   author    = {Fiske, Susan T. and Cuddy, Amy J. C. and Glick, Peter},


### PR DESCRIPTION
Lint debt surfaced by the Solt audit cone build (#1594 follow-up).

- Mereology/Trace: Prop-valued `def`s → `theorem` (`SupHom.toIsSumHom`, `MereoDim.ofInjSumHom`, `DimensionChain.composed`, `σ_mereoDim`); `push_neg` → `push Not`; unused binders
- Eckert2008: `native_decide` → `decide`; drop chronology-violating forward-reference with dangling `beltrama-solt-burnett-2022` key
- rename `Studies/BeltramaSoltBurnett2022.lean` → `2023` to match its validated bib key (`beltrama-solt-burnett-2023`, Language in Society 2023)