### PR TITLE
refactor(Semantics/Degree): rename Degree.Degree to Degree.Bounded

### DIFF
--- a/Linglib/Semantics/Degree/Adjective.lean
+++ b/Linglib/Semantics/Degree/Adjective.lean
@@ -200,7 +200,7 @@ The two-threshold model for contrary antonyms: the general threshold semantics o
 through a `ThresholdPair`'s two poles. -/
 
 section TwoThreshold
-variable {max : Nat} (d : Degree max)
+variable {max : Nat} (d : Bounded max)
 
 /-- Contradictory negation *not happy* — `d ≤ θ` (`Degree.notPositiveMeaning`). -/
 abbrev contradictoryNeg (θ : Threshold max) : Prop := Degree.notPositiveMeaning d θ
@@ -210,7 +210,7 @@ abbrev contraryNeg (θ_neg : Threshold max) : Prop := Degree.negativeMeaning d �
 
 /-- The gap region: `d` is neither positive nor negative (`neg ≤ d ≤ pos`). -/
 abbrev inGapRegion (tp : ThresholdPair max) : Prop :=
-  (tp.neg : Degree max) ≤ d ∧ d ≤ (tp.pos : Degree max)
+  (tp.neg : Bounded max) ≤ d ∧ d ≤ (tp.pos : Bounded max)
 
 /-- Positive form *happy* at the pair's upper threshold — `d > pos`. -/
 abbrev positiveMeaning' (tp : ThresholdPair max) : Prop :=
@@ -222,7 +222,7 @@ abbrev contraryNegMeaning (tp : ThresholdPair max) : Prop :=
 
 /-- *not unhappy* — the complement of the negative form (`neg ≤ d`). -/
 abbrev notContraryNegMeaning (tp : ThresholdPair max) : Prop :=
-  (tp.neg : Degree max) ≤ d
+  (tp.neg : Bounded max) ≤ d
 
 end TwoThreshold
 
@@ -427,27 +427,27 @@ def predictedBinding : Degree.PositiveStandard → DimensionBindingType
 
 /-! ### Degree–PolarMeasure bridge
 
-`Degree max` has `LinearOrder` and `BoundedOrder` (from `Core.MeasurementScale`), so the
+`Bounded max` has `LinearOrder` and `BoundedOrder` (from `Core.MeasurementScale`), so the
 abstract theorems in `MeasurementScale.lean` apply directly to concrete RSA degree
 computations. -/
 
-def adjMeasure {max : Nat} {W : Type*} (μ : W → Degree max)
-    (entry : GradableAdjective) : PolarMeasure (Degree max) W :=
+def adjMeasure {max : Nat} {W : Type*} (μ : W → Bounded max)
+    (entry : GradableAdjective) : PolarMeasure (Bounded max) W :=
   PolarMeasure.adjective μ entry.scaleType
 
-theorem closedAdj_licensed {max : Nat} {W : Type*} (μ : W → Degree max)
+theorem closedAdj_licensed {max : Nat} {W : Type*} (μ : W → Bounded max)
     (entry : GradableAdjective) (h : entry.scaleType = .closed) :
     (adjMeasure μ entry).IsLicensed := by
   simp [adjMeasure, PolarMeasure.adjective,
         PolarMeasure.IsLicensed, Boundedness.IsLicensed, h]
 
-theorem openAdj_blocked {max : Nat} {W : Type*} (μ : W → Degree max)
+theorem openAdj_blocked {max : Nat} {W : Type*} (μ : W → Bounded max)
     (entry : GradableAdjective) (h : entry.scaleType = .open_) :
     ¬ (adjMeasure μ entry).IsLicensed := by
   simp [adjMeasure, PolarMeasure.adjective,
         PolarMeasure.IsLicensed, Boundedness.IsLicensed, h]
 
-theorem degree_measure_is_id {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem degree_measure_is_id {max : Nat} {W : Type*} (μ : W → Bounded max) :
     (PolarMeasure.numeral μ).μ = μ :=
   rfl
 

--- a/Linglib/Semantics/Degree/Antonymy.lean
+++ b/Linglib/Semantics/Degree/Antonymy.lean
@@ -38,7 +38,7 @@ namespace Degree.Antonymy
 /-- Contradictory negation is the propositional complement of positive meaning.
     Both compute threshold comparisons: `d ≤ ↑θ` vs `↑θ < d`. -/
 @[simp] theorem contradictory_is_complement {max : Nat}
-    (d : Degree max) (θ : Threshold max) :
+    (d : Bounded max) (θ : Threshold max) :
     contradictoryNeg d θ ↔ ¬ positiveMeaning d θ := by
   simp only [contradictoryNeg, notPositiveMeaning, positiveMeaning,
     Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, id_eq, not_lt]
@@ -49,14 +49,14 @@ namespace Degree.Antonymy
     contradictory, then "not unhappy" and "happy" are synonymous —
     the puzzle that motivates pragmatic strengthening. -/
 theorem contradictory_dne {max : Nat}
-    (d : Degree max) (θ : Threshold max) :
+    (d : Bounded max) (θ : Threshold max) :
     ¬ contradictoryNeg d θ ↔ positiveMeaning d θ := by
   rw [contradictory_is_complement, not_not]
 
 /-- Under contradictory semantics, the scale is exhaustively partitioned:
     every degree is either positive or in the antonym region, with no gap. -/
 theorem contradictory_exhaustive {max : Nat}
-    (d : Degree max) (θ : Threshold max) :
+    (d : Bounded max) (θ : Threshold max) :
     positiveMeaning d θ ∨ contradictoryNeg d θ := by
   by_cases h : positiveMeaning d θ
   · exact Or.inl h
@@ -67,7 +67,7 @@ theorem contradictory_exhaustive {max : Nat}
 /-- The gap region is exactly "not unhappy" ∧ "not happy": degrees that escape
     the contrary negative without reaching the positive threshold. -/
 @[simp] theorem gap_iff_not_neg_and_not_pos {max : Nat}
-    (d : Degree max) (tp : ThresholdPair max) :
+    (d : Bounded max) (tp : ThresholdPair max) :
     inGapRegion d tp ↔ notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
   simp only [inGapRegion, notContraryNegMeaning, positiveMeaning',
              Degree.positiveMeaning, Core.Order.Comparison.mem_over,
@@ -77,8 +77,8 @@ theorem contradictory_exhaustive {max : Nat}
     "not unhappy" but NOT "happy" — double negation through contrary fails.
     Witness: the negative threshold itself (as a degree). -/
 theorem contrary_gap_exists {max : Nat} (tp : ThresholdPair max)
-    (h : (tp.neg : Degree max) < (tp.pos : Degree max)) :
-    ∃ d : Degree max, notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
+    (h : (tp.neg : Bounded max) < (tp.pos : Bounded max)) :
+    ∃ d : Bounded max, notContraryNegMeaning d tp ∧ ¬ positiveMeaning' d tp := by
   refine ⟨↑tp.neg, le_refl _, ?_⟩
   simp only [positiveMeaning', Degree.positiveMeaning,
     Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, id_eq, not_lt]
@@ -86,8 +86,8 @@ theorem contrary_gap_exists {max : Nat} (tp : ThresholdPair max)
 
 /-- The gap region is nonempty when θ_neg < θ_pos. -/
 theorem gap_nonempty {max : Nat} (tp : ThresholdPair max)
-    (h : (tp.neg : Degree max) < (tp.pos : Degree max)) :
-    ∃ d : Degree max, inGapRegion d tp := by
+    (h : (tp.neg : Bounded max) < (tp.pos : Bounded max)) :
+    ∃ d : Bounded max, inGapRegion d tp := by
   obtain ⟨d, h1, h2⟩ := contrary_gap_exists tp h
   exact ⟨d, (gap_iff_not_neg_and_not_pos d tp).mpr ⟨h1, h2⟩⟩
 
@@ -153,7 +153,7 @@ theorem AntonymForm.complexity_strictMono :
     This is the literal-semantic position [krifka-2007b] attributes to
     antonyms before pragmatic strengthening. -/
 abbrev AntonymForm.contradictoryDenot {max : Nat} (θ : Threshold max)
-    (q : AntonymForm) (d : Degree max) : Prop :=
+    (q : AntonymForm) (d : Bounded max) : Prop :=
   match q with
   | .positive    => positiveMeaning d θ      -- d > θ
   | .notPositive => ¬ positiveMeaning d θ    -- d ≤ θ
@@ -167,7 +167,7 @@ abbrev AntonymForm.contradictoryDenot {max : Nat} (θ : Threshold max)
     effective-semantic position post-pragmatic-strengthening (Krifka 2007 §4)
     or the lexically-encoded position (Alexandropoulou-Gotzner 2024). -/
 abbrev AntonymForm.strengthenedDenot {max : Nat} (tp : ThresholdPair max)
-    (q : AntonymForm) (d : Degree max) : Prop :=
+    (q : AntonymForm) (d : Bounded max) : Prop :=
   match q with
   | .positive    => positiveMeaning' d tp        -- d > tp.pos
   | .notPositive => contradictoryNeg d tp.pos    -- d ≤ tp.pos
@@ -183,7 +183,7 @@ abbrev AntonymForm.strengthenedDenot {max : Nat} (tp : ThresholdPair max)
     the formal puzzle [krifka-2007b] solves pragmatically: literal
     contradictory semantics predicts *not unhappy* ≡ *happy*. -/
 theorem contradictoryDenot_synonymy {max : Nat}
-    (θ : Threshold max) (d : Degree max) :
+    (θ : Threshold max) (d : Bounded max) :
     (AntonymForm.contradictoryDenot θ .negative d ↔
      AntonymForm.contradictoryDenot θ .notPositive d) ∧
     (AntonymForm.contradictoryDenot θ .notNegative d ↔
@@ -195,8 +195,8 @@ theorem contradictoryDenot_synonymy {max : Nat}
     degree (the negative threshold itself) where *not unhappy* holds but
     *happy* does not. This is the witness for the polarity asymmetry. -/
 theorem strengthenedDenot_breaks_synonymy {max : Nat} (tp : ThresholdPair max)
-    (h : (tp.neg : Degree max) < (tp.pos : Degree max)) :
-    ∃ d : Degree max,
+    (h : (tp.neg : Bounded max) < (tp.pos : Bounded max)) :
+    ∃ d : Bounded max,
       AntonymForm.strengthenedDenot tp .notNegative d ∧
       ¬ AntonymForm.strengthenedDenot tp .positive d :=
   Antonymy.contrary_gap_exists tp h
@@ -214,7 +214,7 @@ complementary in the Boolean algebra `Degree → Prop` — forced (it is `IsComp
 `contradictoryDenot_synonymy` (DNE collapse) is a corollary. -/
 theorem isContradictory_contradictoryDenot {max : Nat} (θ : Threshold max) :
     IsContradictory
-      (fun d : Degree max => AntonymForm.contradictoryDenot θ .positive d)
+      (fun d : Bounded max => AntonymForm.contradictoryDenot θ .positive d)
       (fun d => AntonymForm.contradictoryDenot θ .negative d) :=
   isCompl_compl
 
@@ -224,9 +224,9 @@ open Aristotelian in
 (`Disjoint`) but, by the gap `[tp.neg, tp.pos]`, not jointly exhaustive
 (`¬ Codisjoint` — `contrary_gap_exists` is the witness). -/
 theorem isContrary_strengthenedDenot {max : Nat} (tp : ThresholdPair max)
-    (h : (tp.neg : Degree max) < (tp.pos : Degree max)) :
+    (h : (tp.neg : Bounded max) < (tp.pos : Bounded max)) :
     IsContrary
-      (fun d : Degree max => AntonymForm.strengthenedDenot tp .positive d)
+      (fun d : Bounded max => AntonymForm.strengthenedDenot tp .positive d)
       (fun d => AntonymForm.strengthenedDenot tp .negative d) := by
   refine ⟨?_, ?_⟩
   · rw [disjoint_iff]

--- a/Linglib/Semantics/Degree/Discrete.lean
+++ b/Linglib/Semantics/Degree/Discrete.lean
@@ -10,7 +10,7 @@ import Mathlib.Tactic.NormNum
 
 The finite, `Fin`-backed scale carriers used by RSA fragments and
 computational Studies [kennedy-2007] [heim-2001] [kennedy-mcnally-2005]:
-`Degree max` / `Threshold max` with their order/`Fintype` instances, and
+`Bounded max` / `Threshold max` with their order/`Fintype` instances, and
 the threshold-comparison predicates (*tall* / *short* / *not tall*).
 The abstract theory works with plain measure functions `μ : E → D` into
 a preorder (`Comparative.lean`, `Extent.lean`); this module is its
@@ -18,7 +18,7 @@ decidable discretization.
 
 ## Main definitions
 
-* `Degree max`, `Threshold max` — discrete bounded scale types.
+* `Bounded max`, `Threshold max` — discrete bounded scale types.
 * `deg`, `thr` — literal constructors.
 * `positiveMeaning`, `negativeMeaning`, `notPositiveMeaning` — the three
   opposition relations as decidable threshold comparisons.
@@ -30,33 +30,33 @@ namespace Degree
 
 /-- A degree on a scale from 0 to `max` — a discretized continuous value
     (height, temperature, …). -/
-structure Degree (max : Nat) where
+structure Bounded (max : Nat) where
   value : Fin (max + 1)
   deriving Repr, DecidableEq
 
-instance {n : Nat} : Inhabited (Degree n) := ⟨⟨0, Nat.zero_lt_succ n⟩⟩
+instance {n : Nat} : Inhabited (Bounded n) := ⟨⟨0, Nat.zero_lt_succ n⟩⟩
 
-/-- `Degree max` inherits a linear order from `Fin (max + 1)`. -/
-instance {max : Nat} : LinearOrder (Degree max) :=
-  LinearOrder.lift' Degree.value (fun a b h => by cases a; cases b; simp_all)
+/-- `Bounded max` inherits a linear order from `Fin (max + 1)`. -/
+instance {max : Nat} : LinearOrder (Bounded max) :=
+  LinearOrder.lift' Bounded.value (fun a b h => by cases a; cases b; simp_all)
 
-/-- `Degree max` is bounded: 0 is the minimum, `max` the maximum. -/
-instance {max : Nat} : BoundedOrder (Degree max) where
+/-- `Bounded max` is bounded: 0 is the minimum, `max` the maximum. -/
+instance {max : Nat} : BoundedOrder (Bounded max) where
   top := ⟨Fin.last max⟩
   le_top d := Fin.le_last d.value
   bot := ⟨0, Nat.zero_lt_succ max⟩
   bot_le d := Fin.zero_le d.value
 
 /-- All degrees from 0 to `max`. -/
-def allDegrees (max : Nat) : List (Degree max) :=
+def allDegrees (max : Nat) : List (Bounded max) :=
   List.finRange (max + 1) |>.map (⟨·⟩)
 
-/-- Degree from `Nat` (clamped to `max`). -/
-def Degree.ofNat (max : Nat) (n : Nat) : Degree max :=
+/-- Bounded from `Nat` (clamped to `max`). -/
+def Bounded.ofNat (max : Nat) (n : Nat) : Bounded max :=
   ⟨⟨min n max, by omega⟩⟩
 
 /-- The numeric value of a degree. -/
-def Degree.toNat {max : Nat} (d : Degree max) : Nat := d.value.val
+def Bounded.toNat {max : Nat} (d : Bounded max) : Nat := d.value.val
 
 /-- A threshold for a gradable adjective: `x` is "tall" iff `degree x > threshold`. -/
 structure Threshold (max : Nat) where
@@ -77,21 +77,21 @@ def allThresholds (max : Nat) (_ : 0 < max := by omega) : List (Threshold max) :
 /-- The numeric value of a threshold. -/
 def Threshold.toNat {max : Nat} (t : Threshold max) : Nat := t.value.val
 
-instance {max : Nat} : Fintype (Degree max) :=
-  Fintype.ofEquiv (Fin (max + 1)) ⟨Degree.mk, Degree.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
+instance {max : Nat} : Fintype (Bounded max) :=
+  Fintype.ofEquiv (Fin (max + 1)) ⟨Bounded.mk, Bounded.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
 
 instance {max : Nat} [NeZero max] : Fintype (Threshold max) :=
   Fintype.ofEquiv (Fin max) ⟨Threshold.mk, Threshold.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩
 
-/-- Coercion: a `Threshold` embeds into `Degree` via `Fin.castSucc`. -/
-instance {max : Nat} : Coe (Threshold max) (Degree max) where
+/-- Coercion: a `Threshold` embeds into `Bounded` via `Fin.castSucc`. -/
+instance {max : Nat} : Coe (Threshold max) (Bounded max) where
   coe t := ⟨t.value.castSucc⟩
 
 theorem coe_threshold_toNat {max : Nat} (t : Threshold max) :
-    (t : Degree max).toNat = t.toNat := rfl
+    (t : Bounded max).toNat = t.toNat := rfl
 
-/-- Construct a degree by literal: `deg 5 : Degree 10`. -/
-abbrev deg (n : Nat) {max : Nat} (h : n ≤ max := by omega) : Degree max :=
+/-- Construct a degree by literal: `deg 5 : Bounded 10`. -/
+abbrev deg (n : Nat) {max : Nat} (h : n ≤ max := by omega) : Bounded max :=
   ⟨⟨n, by omega⟩⟩
 
 /-- Construct a threshold by literal: `thr 5 : Threshold 10`. -/
@@ -110,27 +110,27 @@ variable {max : Nat}
 
 /-- Positive form (*tall*): `t < d` — the strict threshold face of
 `Core.Order.Comparison.gt.over` on the discrete carrier. -/
-def positiveMeaning (d : Degree max) (t : Threshold max) : Prop :=
-  d ∈ Core.Order.Comparison.gt.over id (t : Degree max)
+def positiveMeaning (d : Bounded max) (t : Threshold max) : Prop :=
+  d ∈ Core.Order.Comparison.gt.over id (t : Bounded max)
 
 /-- Polar antonym (*short*): `d < t`, evaluated against the antonym's own
 threshold (which may sit below the positive's — see `Gradability.ThresholdPair`). -/
-def negativeMeaning (d : Degree max) (t : Threshold max) : Prop :=
-  d ∈ Core.Order.Comparison.lt.over id (t : Degree max)
+def negativeMeaning (d : Bounded max) (t : Threshold max) : Prop :=
+  d ∈ Core.Order.Comparison.lt.over id (t : Bounded max)
 
 /-- Contradictory negation (*not tall*): `d ≤ t`, the complement of
 `positiveMeaning`. Not the polar antonym — that is `negativeMeaning`. -/
-def notPositiveMeaning (d : Degree max) (t : Threshold max) : Prop :=
-  d ∈ Core.Order.Comparison.le.over id (t : Degree max)
+def notPositiveMeaning (d : Bounded max) (t : Threshold max) : Prop :=
+  d ∈ Core.Order.Comparison.le.over id (t : Bounded max)
 
-instance (d : Degree max) (t : Threshold max) : Decidable (positiveMeaning d t) :=
-  inferInstanceAs (Decidable ((t : Degree max) < d))
+instance (d : Bounded max) (t : Threshold max) : Decidable (positiveMeaning d t) :=
+  inferInstanceAs (Decidable ((t : Bounded max) < d))
 
-instance (d : Degree max) (t : Threshold max) : Decidable (negativeMeaning d t) :=
-  inferInstanceAs (Decidable (d < (t : Degree max)))
+instance (d : Bounded max) (t : Threshold max) : Decidable (negativeMeaning d t) :=
+  inferInstanceAs (Decidable (d < (t : Bounded max)))
 
-instance (d : Degree max) (t : Threshold max) : Decidable (notPositiveMeaning d t) :=
-  inferInstanceAs (Decidable (d ≤ (t : Degree max)))
+instance (d : Bounded max) (t : Threshold max) : Decidable (notPositiveMeaning d t) :=
+  inferInstanceAs (Decidable (d ≤ (t : Bounded max)))
 
 end Concrete
 

--- a/Linglib/Semantics/Degree/Intensification.lean
+++ b/Linglib/Semantics/Degree/Intensification.lean
@@ -100,11 +100,11 @@ The intensified form is the conjunction (intersection) of:
 2. The evaluative threshold: μ_eval(d) > θ_eval
 -/
 def intensifiedMeaning {max : Nat}
-    (eval : EvaluativeMeasure max) (d : Degree max) (θ_adj θ_eval : Threshold max) : Prop :=
+    (eval : EvaluativeMeasure max) (d : Bounded max) (θ_adj θ_eval : Threshold max) : Prop :=
   positiveMeaning d θ_adj ∧ eval.mu d.toNat > θ_eval.toNat
 
 instance {max : Nat} (eval : EvaluativeMeasure max)
-    (d : Degree max) (θ_adj θ_eval : Threshold max) :
+    (d : Bounded max) (θ_adj θ_eval : Threshold max) :
     Decidable (intensifiedMeaning eval d θ_adj θ_eval) := by
   unfold intensifiedMeaning; infer_instance
 
@@ -118,7 +118,7 @@ This is because the intensified meaning is a conjunction that includes
 the positive meaning as one conjunct.
 -/
 theorem intensified_implies_positive {max : Nat}
-    (eval : EvaluativeMeasure max) (d : Degree max) (θ_adj θ_eval : Threshold max)
+    (eval : EvaluativeMeasure max) (d : Bounded max) (θ_adj θ_eval : Threshold max)
     (h : intensifiedMeaning eval d θ_adj θ_eval) :
     positiveMeaning d θ_adj :=
   h.1
@@ -131,7 +131,7 @@ The horrible measure peaks at extremes: μ(max) ≥ μ(norm).
 Negative-evaluative adjectives assign highest values to extreme degrees.
 -/
 theorem muHorrible_peaks_at_extreme_10 :
-    (muHorrible 10).mu 10 ≥ (muHorrible 10).mu 5 := by simp only [muHorrible, muPleasant]; norm_num
+    (muHorrible 10).mu 10 ≥ (muHorrible 10).mu 5 := by simp only [muHorrible]; norm_num
 
 /--
 The pleasant measure peaks at norm: μ(norm) ≥ μ(max).
@@ -139,7 +139,7 @@ The pleasant measure peaks at norm: μ(norm) ≥ μ(max).
 Positive-evaluative adjectives assign highest values to moderate degrees.
 -/
 theorem muPleasant_peaks_at_norm_10 :
-    (muPleasant 10).mu 5 ≥ (muPleasant 10).mu 10 := by simp only [muHorrible, muPleasant]; norm_num
+    (muPleasant 10).mu 5 ≥ (muPleasant 10).mu 10 := by simp only [muPleasant]; norm_num
 
 /--
 Goldilocks structural theorem: at extreme degrees (d = max),

--- a/Linglib/Semantics/Degree/Noun.lean
+++ b/Linglib/Semantics/Degree/Noun.lean
@@ -23,19 +23,19 @@ degree scale. The full denotation is:
 
 namespace Degree
 
--- The file works on the 0–10 carrier `Degree 10` from `Discrete.lean`.
+-- The file works on the 0–10 carrier `Bounded 10` from `Discrete.lean`.
 
 /-- d0 is the minimum degree (from BoundedOrder). -/
-theorem d0_is_minimum : ∀ d : Degree 10, deg 0 ≤ d := λ d => bot_le (a := d)
+theorem d0_is_minimum : ∀ d : Bounded 10, deg 0 ≤ d := λ d => bot_le (a := d)
 
 
 /-- A gradable noun maps individuals to degrees: ⟦idiot⟧ = λx.ιd[x is d-idiotic]. -/
 structure GradableNoun (Entity : Type) where
   name : String
   /-- The measure function: entity -> degree. -/
-  measure : Entity → Degree 10
+  measure : Entity → Bounded 10
   /-- The contextual standard for this predicate. -/
-  standard : Degree 10
+  standard : Bounded 10
 
 /-- Apply POS to a gradable noun: λx. standard(g) < g(x).
 
@@ -53,34 +53,34 @@ inductive SizePolarity where
   deriving Repr, DecidableEq
 
 /-- Big: maps degrees to their "bigness" (identity on the degree scale). -/
-def bigness (d : Degree 10) : Degree 10 := d
+def bigness (d : Bounded 10) : Bounded 10 := d
 
 /-- Small: inverted ordering (0 maximally small, 10 minimally small). -/
-def smallness (d : Degree 10) : Degree 10 :=
-  Degree.Degree.ofNat 10 (10 - d.toNat)
+def smallness (d : Bounded 10) : Bounded 10 :=
+  Degree.Bounded.ofNat 10 (10 - d.toNat)
 
 /-- Standard for "big" (contextual, typically middling). -/
-def bigStandard : Degree 10 := deg 5
+def bigStandard : Bounded 10 := deg 5
 
 /-- Standard for "small" (contextual). -/
-def smallStandard : Degree 10 := deg 5
+def smallStandard : Bounded 10 := deg 5
 
 /-- POS applied to size adjective: λd. standard(size) ≤ size(d). -/
-def posBig (d : Degree 10) : Bool := bigStandard ≤ bigness d
-def posSmall (d : Degree 10) : Bool := smallStandard ≤ smallness d
+def posBig (d : Bounded 10) : Bool := bigStandard ≤ bigness d
+def posSmall (d : Bounded 10) : Bool := smallStandard ≤ smallness d
 
 
 section MEASN
 
 /-- Find minimum degree satisfying a predicate. -/
-def minDegree (p : Degree 10 → Bool) : Option (Degree 10) :=
+def minDegree (p : Bounded 10 → Bool) : Option (Bounded 10) :=
   (Degree.allDegrees 10).find? p
 
 /-- Simplified MEAS_N: ⟦MEAS_N⟧(g)(m)(x) = [min{d : m(d)} ≤ g(x)] ∧ [standard(g) ≤ g(x)].
     Full version (Morzycki eq. 76) has min over {d : d ∈ scale(g) ∧ m(d)}. -/
 def measN {E : Type}
     (noun : GradableNoun E)
-    (sizeAdj : Degree 10 → Bool)  -- The [POS size-adj] predicate on degrees
+    (sizeAdj : Bounded 10 → Bool)  -- The [POS size-adj] predicate on degrees
     : E → Bool :=
   λ x =>
     match minDegree sizeAdj with
@@ -89,7 +89,7 @@ def measN {E : Type}
 
 
 /-- Example: an "idiot" gradable noun with standard at d3. -/
-def idiotNoun {E : Type} (measure : E → Degree 10) : GradableNoun E :=
+def idiotNoun {E : Type} (measure : E → Bounded 10) : GradableNoun E :=
   { name := "idiot"
   , measure := measure
   , standard := deg 3
@@ -105,16 +105,16 @@ def smallIdiot {E : Type} (noun : GradableNoun E) : E → Bool :=
 
 
 /-- Minimum degree satisfying "big" is d5. -/
-theorem min_big_is_d5 : minDegree posBig = some ((deg 5 : Degree 10)) := by decide
+theorem min_big_is_d5 : minDegree posBig = some ((deg 5 : Bounded 10)) := by decide
 
 /-- Minimum degree satisfying "small" is d0 (the scale minimum). -/
-theorem min_small_is_d0 : minDegree posSmall = some ((deg 0 : Degree 10)) := by decide
+theorem min_small_is_d0 : minDegree posSmall = some ((deg 0 : Bounded 10)) := by decide
 
 /-- d0 always satisfies smallness because it is maximally small. -/
 theorem d0_satisfies_small : posSmall (deg 0) = true := by decide
 
 /-- d0 is the unique minimum for smallness. -/
-theorem d0_is_min_for_small : ∀ d : Degree 10, posSmall d → deg 0 ≤ d := by
+theorem d0_is_min_for_small : ∀ d : Bounded 10, posSmall d → deg 0 ≤ d := by
   intro d _
   exact d0_is_minimum d
 
@@ -151,7 +151,7 @@ inductive Person where
   deriving Repr, DecidableEq
 
 /-- George: d8, Sarah: d4, Floyd: d1. -/
-def idiocyMeasure : Person → Degree 10
+def idiocyMeasure : Person → Bounded 10
   | .george => deg 8
   | .sarah => deg 4
   | .floyd => deg 1

--- a/Linglib/Semantics/Quantification/Binominal.lean
+++ b/Linglib/Semantics/Quantification/Binominal.lean
@@ -154,7 +154,7 @@ property of N₂. -/
 
 section EM
 open Degree.Intensification (EvaluativeMeasure intensifiedMeaning)
-open Degree (Degree Threshold Degree.toNat Threshold.toNat)
+open Degree (Bounded Threshold Bounded.toNat Threshold.toNat)
 /-- EM semantics: N₁ as evaluative modifier of a contextual property of N₂.
 
 "a hell of a game" = the game x such that the contextually-salient
@@ -165,14 +165,14 @@ bleached to a pure evaluative function. The `contextualDegree` parameter
 represents the pragmatically-determined property being evaluated. -/
 def emSemantics {Entity : Type} {max : Nat}
     (eval : EvaluativeMeasure max)
-    (contextualDegree : Entity → Degree max)
+    (contextualDegree : Entity → Bounded max)
     (θ_eval : Threshold max)
     (n₂ : Entity → Bool) : Entity → Bool :=
   λ x => n₂ x && (eval.mu (contextualDegree x).toNat > θ_eval.toNat)
 
 /-- EM preserves the N₂ restriction. -/
 theorem em_requires_n₂ {Entity : Type} {max : Nat}
-    (eval : EvaluativeMeasure max) (cdeg : Entity → Degree max)
+    (eval : EvaluativeMeasure max) (cdeg : Entity → Bounded max)
     (θ : Threshold max) (n₂ : Entity → Bool) (x : Entity) :
     emSemantics eval cdeg θ n₂ x = true → n₂ x = true := by
   simp only [emSemantics]
@@ -198,14 +198,14 @@ This directly instantiates [nouwen-2024]'s `intensifiedMeaning`:
 the adjective's positive form AND the evaluative measure must both hold. -/
 def biSemantics {Entity : Type} {max : Nat}
     (eval : EvaluativeMeasure max)
-    (adjDegree : Entity → Degree max)
+    (adjDegree : Entity → Bounded max)
     (θ_adj θ_eval : Threshold max)
     (n₂ : Entity → Bool) : Entity → Bool :=
   λ x => n₂ x && decide (intensifiedMeaning eval (adjDegree x) θ_adj θ_eval)
 
 /-- BI preserves the N₂ restriction. -/
 theorem bi_requires_n₂ {Entity : Type} {max : Nat}
-    (eval : EvaluativeMeasure max) (adjDeg : Entity → Degree max)
+    (eval : EvaluativeMeasure max) (adjDeg : Entity → Bounded max)
     (θ_adj θ_eval : Threshold max) (n₂ : Entity → Bool) (x : Entity) :
     biSemantics eval adjDeg θ_adj θ_eval n₂ x = true → n₂ x = true := by
   simp only [biSemantics]
@@ -218,7 +218,7 @@ where the contextual property is fixed to a specific adjective, and an
 additional threshold (the adjective's standard) is imposed. BI strengthens
 EM by adding the adjective's positive form as a conjunct. -/
 theorem bi_entails_em {Entity : Type} {max : Nat}
-    (eval : EvaluativeMeasure max) (adjDeg : Entity → Degree max)
+    (eval : EvaluativeMeasure max) (adjDeg : Entity → Bounded max)
     (θ_adj θ_eval : Threshold max) (n₂ : Entity → Bool) (x : Entity) :
     biSemantics eval adjDeg θ_adj θ_eval n₂ x = true →
     emSemantics eval adjDeg θ_eval n₂ x = true := by
@@ -243,10 +243,10 @@ Uses `muHorrible 10` as the evaluative measure for *hell*:
 
 section EMBIExample
 open Degree.Intensification (muHorrible EvaluativeMeasure)
-open Degree (Degree deg thr)
+open Degree (Bounded deg thr)
 /-- Quality measure for EM: contextually-determined goodness as a doctor.
 George (9) is an outstanding doctor; Sarah (6) is decent; Floyd (3) is poor. -/
-def doctorQuality : Degree.Person → Degree 10
+def doctorQuality : Degree.Person → Bounded 10
   | .george => deg 9
   | .sarah  => deg 6
   | .floyd  => deg 3
@@ -263,7 +263,7 @@ def hellEval : EvaluativeMeasure 10 := muHorrible 10
 theorem george_hell_of_doctor :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .george = true := by
   simp only [emSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
-             Degree.Degree.toNat, Degree.Threshold.toNat]
+             Degree.Bounded.toNat, Degree.Threshold.toNat]
   norm_num
 
 /-- Sarah is not "a hell of a doctor": quality (6) yields
@@ -271,7 +271,7 @@ theorem george_hell_of_doctor :
 theorem sarah_not_hell_of_doctor :
     emSemantics hellEval doctorQuality (thr 3) isDoctorB .sarah = false := by
   simp only [emSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
-             Degree.Degree.toNat, Degree.Threshold.toNat]
+             Degree.Bounded.toNat, Degree.Threshold.toNat]
   norm_num
 
 /-- George is "a hell of a good doctor": good(9 > 5) ✓ AND
@@ -281,7 +281,7 @@ theorem george_hell_of_good_doctor :
   simp only [biSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
              Degree.Intensification.intensifiedMeaning,
              Degree.positiveMeaning,
-             Degree.Degree.toNat, Degree.Threshold.toNat,
+             Degree.Bounded.toNat, Degree.Threshold.toNat,
              Bool.and_eq_true, decide_eq_true_eq]
   refine ⟨trivial, ?_, ?_⟩
   · decide
@@ -294,7 +294,7 @@ theorem sarah_not_hell_of_good_doctor :
   simp only [biSemantics, hellEval, muHorrible, doctorQuality, isDoctorB, isDoctor,
              Degree.Intensification.intensifiedMeaning,
              Degree.positiveMeaning,
-             Degree.Degree.toNat, Degree.Threshold.toNat,
+             Degree.Bounded.toNat, Degree.Threshold.toNat,
              Bool.and_eq_false_iff, decide_eq_false_iff_not]
   right
   push Not

--- a/Linglib/Studies/AlexandropoulouGotzner2024.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024.lean
@@ -61,7 +61,7 @@ bridge theorem all live in `AlexandropoulouGotzner2024JoS.lean`.
 namespace AlexandropoulouGotzner2024
 
 open Core.Order (Boundedness)
-open Degree (Degree Threshold deg thr)
+open Degree (Bounded Threshold deg thr)
 open Degree (GradableAdjective ThresholdPair inGapRegion
   positiveMeaning' contraryNegMeaning notContraryNegMeaning)
 open Degree (positiveMeaning notPositiveMeaning)
@@ -104,7 +104,7 @@ def AdjQuadruple.isRelative (q : AdjQuadruple) : Bool :=
 
 /-- 5-degree scale (matching the 1–5 Likert response scales used in the
     Glossa experiments). -/
-abbrev Deg5 := Degree 4
+abbrev Deg5 := Bounded 4
 
 abbrev Thr5 := Threshold 4
 
@@ -126,30 +126,30 @@ def defaultTP : ThresholdPair 4 where
 
 /-- Every degree falls in at least one of {positive, gap, negative}. -/
 theorem three_region_exhaustive {max : Nat}
-    (tp : ThresholdPair max) (d : Degree max) :
+    (tp : ThresholdPair max) (d : Bounded max) :
     positiveMeaning' d tp ∨ inGapRegion d tp ∨ contraryNegMeaning d tp := by
-  by_cases h1 : (tp.pos : Degree max) < d
+  by_cases h1 : (tp.pos : Bounded max) < d
   · exact Or.inl h1
-  · by_cases h2 : d < (tp.neg : Degree max)
+  · by_cases h2 : d < (tp.neg : Bounded max)
     · exact Or.inr (Or.inr h2)
-    · push_neg at h1 h2
+    · push Not at h1 h2
       exact Or.inr (Or.inl ⟨h2, h1⟩)
 
 /-- Gap region excludes the positive region. -/
 theorem gap_not_positive {max : Nat}
-    (tp : ThresholdPair max) (d : Degree max)
+    (tp : ThresholdPair max) (d : Bounded max)
     (h : inGapRegion d tp) : ¬ positiveMeaning' d tp :=
   not_lt.mpr h.2
 
 /-- Gap region excludes the contrary-negative region. -/
 theorem gap_not_negative {max : Nat}
-    (tp : ThresholdPair max) (d : Degree max)
+    (tp : ThresholdPair max) (d : Bounded max)
     (h : inGapRegion d tp) : ¬ contraryNegMeaning d tp :=
   not_lt.mpr h.1
 
 /-- Gap holds iff the degree is neither positive nor contrary-negative. -/
 theorem gap_iff_neither {max : Nat}
-    (tp : ThresholdPair max) (d : Degree max) :
+    (tp : ThresholdPair max) (d : Bounded max) :
     inGapRegion d tp ↔ ¬ positiveMeaning' d tp ∧ ¬ contraryNegMeaning d tp := by
   constructor
   · intro h; exact ⟨gap_not_positive tp d h, gap_not_negative tp d h⟩
@@ -168,14 +168,14 @@ theorem gap_iff_neither {max : Nat}
 /-- Contradictory antonyms exhaust the scale. Delegates to the substrate
     lemma in `Antonymy.lean`. -/
 theorem contradictory_complement {max : Nat}
-    (d : Degree max) (θ : Threshold max) :
+    (d : Bounded max) (θ : Threshold max) :
     positiveMeaning d θ ∨ notPositiveMeaning d θ :=
   Degree.Antonymy.contradictory_exhaustive d θ
 
 /-- `notPositiveMeaning` is the propositional complement of `positiveMeaning`.
     Delegates to the substrate lemma in `Antonymy.lean`. -/
 theorem contradictory_is_complement {max : Nat}
-    (d : Degree max) (θ : Threshold max) :
+    (d : Bounded max) (θ : Threshold max) :
     notPositiveMeaning d θ ↔ ¬ positiveMeaning d θ :=
   Degree.Antonymy.contradictory_is_complement d θ
 

--- a/Linglib/Studies/AlexandropoulouGotzner2024JoS.lean
+++ b/Linglib/Studies/AlexandropoulouGotzner2024JoS.lean
@@ -79,7 +79,7 @@ derivation of the predictions from first principles.
 
 namespace AlexandropoulouGotzner2024JoS
 
-open Degree (Degree Threshold)
+open Degree (Bounded Threshold)
 open Features (NegationType Asymmetry)
 open Degree (GradableAdjective ThresholdPair positiveMeaning'
   contraryNegMeaning notContraryNegMeaning AntonymForm
@@ -226,7 +226,7 @@ theorem krifka_agrees_with_horn_where_committed :
     after the substrate's `def`-to-`abbrev` migration on
     `Theory.lean::contradictoryNeg`. -/
 theorem ag_negative_strengthening_eq_krifka {max : Nat}
-    (d : Degree max) (tp : ThresholdPair max) :
+    (d : Bounded max) (tp : ThresholdPair max) :
     notPositiveMeaning d tp.pos ↔
     AntonymForm.strengthenedDenot tp .notPositive d :=
   Iff.rfl
@@ -236,7 +236,7 @@ theorem ag_negative_strengthening_eq_krifka {max : Nat}
     negative / not-negative) coincides with Krifka 2007's `strengthenedQuad`
     output on the corresponding form. -/
 theorem ag_quadruplet_eq_krifka_strengthened {max : Nat}
-    (d : Degree max) (tp : ThresholdPair max) :
+    (d : Bounded max) (tp : ThresholdPair max) :
     (positiveMeaning' d tp ↔ AntonymForm.strengthenedDenot tp .positive d) ∧
     (notPositiveMeaning d tp.pos ↔ AntonymForm.strengthenedDenot tp .notPositive d) ∧
     (contraryNegMeaning d tp ↔ AntonymForm.strengthenedDenot tp .negative d) ∧

--- a/Linglib/Studies/Fine1975.lean
+++ b/Linglib/Studies/Fine1975.lean
@@ -43,7 +43,7 @@ is the existential dual of supervaluation. See
 
 namespace Fine1975
 
-open Degree (Degree Threshold Degree.toNat Threshold.toNat)
+open Degree (Bounded Threshold Bounded.toNat Threshold.toNat)
 open Degree (ThresholdPair inGapRegion)
 open Semantics.Supervaluation (SpecSpace superTrue definitely indefinite)
 
@@ -57,8 +57,8 @@ def mkSpec {max : Nat} (S : Finset (Threshold max)) (hne : S.Nonempty) :
   ⟨S, hne⟩
 
 /-- Supervaluation of a degree predicate: fix a degree, vary the threshold. -/
-def superTrueAt {max : Nat} (meaning : Degree max → Threshold max → Prop)
-    [∀ d θ, Decidable (meaning d θ)] (d : Degree max)
+def superTrueAt {max : Nat} (meaning : Bounded max → Threshold max → Prop)
+    [∀ d θ, Decidable (meaning d θ)] (d : Bounded max)
     (S : SpecSpace (Threshold max)) : Trivalent :=
   superTrue (meaning d) S
 
@@ -72,7 +72,7 @@ def superTrueAt {max : Nat} (meaning : Degree max → Threshold max → Prop)
     This captures Fine's internal penumbral connection: if Herbert is
     to be bald, then so is the man with fewer hairs (p. 276). -/
 theorem comparative_entailment {max : Nat}
-    (d₁ d₂ : Degree max) (S : SpecSpace (Threshold max))
+    (d₁ d₂ : Bounded max) (S : SpecSpace (Threshold max))
     (hgt : d₂.toNat < d₁.toNat)
     (hd₂ : superTrueAt (fun d θ => d.toNat > θ.toNat) d₂ S = Trivalent.true) :
     superTrueAt (fun d θ => d.toNat > θ.toNat) d₁ S = Trivalent.true := by
@@ -93,7 +93,7 @@ theorem comparative_entailment {max : Nat}
 
 /-- The tolerance premise fails at any threshold separating d from d'. -/
 theorem tolerance_fails_at_boundary {max : Nat}
-    (d d' : Degree max) (θ : Threshold max)
+    (d d' : Bounded max) (θ : Threshold max)
     (hd : d.toNat > θ.toNat) (hd' : ¬(d'.toNat > θ.toNat)) :
     ¬(d.toNat > θ.toNat → d'.toNat > θ.toNat) :=
   fun h => hd' (h hd)
@@ -113,21 +113,21 @@ theorem tolerance_fails_at_boundary {max : Nat}
     determines both predicates, creating the penumbral connection. -/
 
 /-- Pink: degree above the boundary (on a single color dimension). -/
-def isPink {max : Nat} (d : Degree max) (θ : Threshold max) : Prop :=
+def isPink {max : Nat} (d : Bounded max) (θ : Threshold max) : Prop :=
   d.toNat > θ.toNat
 
-instance {max : Nat} (d : Degree max) (θ : Threshold max) :
+instance {max : Nat} (d : Bounded max) (θ : Threshold max) :
     Decidable (isPink d θ) := by unfold isPink; infer_instance
 
 /-- Red: degree at or below the boundary (complementary to pink). -/
-def isRed {max : Nat} (d : Degree max) (θ : Threshold max) : Prop :=
+def isRed {max : Nat} (d : Bounded max) (θ : Threshold max) : Prop :=
   d.toNat ≤ θ.toNat
 
-instance {max : Nat} (d : Degree max) (θ : Threshold max) :
+instance {max : Nat} (d : Bounded max) (θ : Threshold max) :
     Decidable (isRed d θ) := by unfold isRed; infer_instance
 
 /-- Pink and red are complementary: nothing can be both. -/
-theorem pink_red_complementary {max : Nat} (d : Degree max) (θ : Threshold max) :
+theorem pink_red_complementary {max : Nat} (d : Bounded max) (θ : Threshold max) :
     ¬ (isPink d θ ∧ isRed d θ) := by
   unfold isPink isRed
   intro ⟨h1, h2⟩
@@ -140,7 +140,7 @@ theorem pink_red_complementary {max : Nat} (d : Degree max) (θ : Threshold max)
     This is Fine's central argument for supervaluationism over
     truth-functional three-valued logic (p. 269-270). In Strong Kleene
     logic, `indet ∧ indet = indet`; supervaluation gives `false`. -/
-theorem pink_and_red_superFalse {max : Nat} (d : Degree max)
+theorem pink_and_red_superFalse {max : Nat} (d : Bounded max)
     (S : SpecSpace (Threshold max)) :
     superTrue (fun θ => isPink d θ ∧ isRed d θ) S = Trivalent.false :=
   (Semantics.Supervaluation.superTrue_false_iff _ S).mpr
@@ -167,19 +167,19 @@ def specOfPair {max : Nat} (tp : ThresholdPair max) : SpecSpace (Threshold max) 
   ⟨{tp.neg, tp.pos}, ⟨tp.neg, Finset.mem_insert_self _ _⟩⟩
 
 /-- Extract Nat-level upper bound from `inGapRegion`. -/
-theorem inGapRegion_le_pos {max : Nat} (d : Degree max) (tp : ThresholdPair max)
+theorem inGapRegion_le_pos {max : Nat} (d : Bounded max) (tp : ThresholdPair max)
     (h : inGapRegion d tp) : d.toNat ≤ tp.pos.toNat :=
   h.2
 
 /-- Extract Nat-level lower bound from `inGapRegion`. -/
-theorem inGapRegion_ge_neg {max : Nat} (d : Degree max) (tp : ThresholdPair max)
+theorem inGapRegion_ge_neg {max : Nat} (d : Bounded max) (tp : ThresholdPair max)
     (h : inGapRegion d tp) : tp.neg.toNat ≤ d.toNat :=
   h.1
 
 /-- When a degree is strictly inside the gap, the positive-meaning
     predicate disagrees across the two thresholds: true at the negative
     threshold, false at the positive. -/
-theorem gap_implies_disagreement {max : Nat} (d : Degree max) (tp : ThresholdPair max)
+theorem gap_implies_disagreement {max : Nat} (d : Bounded max) (tp : ThresholdPair max)
     (h_in : inGapRegion d tp) (h_strict : tp.neg.toNat < d.toNat) :
     d.toNat > tp.neg.toNat ∧ ¬ d.toNat > tp.pos.toNat := by
   refine ⟨h_strict, ?_⟩

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -552,22 +552,22 @@ open Core.Order
 /-! #### Fragment → PolarMeasure licensing -/
 
 /-- "tall" (open scale) → PolarMeasure blocks degree modification. -/
-theorem tall_blocks_completely {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem tall_blocks_completely {max : Nat} {W : Type*} (μ : W → Bounded max) :
     ¬ (adjMeasure μ tall).IsLicensed :=
   openAdj_blocked μ tall rfl
 
 /-- "full" (closed scale) → PolarMeasure licenses degree modification. -/
-theorem full_licenses_completely {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem full_licenses_completely {max : Nat} {W : Type*} (μ : W → Bounded max) :
     (adjMeasure μ full).IsLicensed :=
   closedAdj_licensed μ full rfl
 
 /-- "wet" (closed scale) → PolarMeasure licenses. -/
-theorem wet_licensed {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem wet_licensed {max : Nat} {W : Type*} (μ : W → Bounded max) :
     (adjMeasure μ wet).IsLicensed :=
   closedAdj_licensed μ wet rfl
 
 /-- "dry" (closed scale) → PolarMeasure licenses. -/
-theorem dry_licensed {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem dry_licensed {max : Nat} {W : Type*} (μ : W → Bounded max) :
     (adjMeasure μ dry).IsLicensed :=
   closedAdj_licensed μ dry rfl
 
@@ -576,7 +576,7 @@ theorem dry_licensed {max : Nat} {W : Type*} (μ : W → Degree max) :
 /-- The closure puzzle is predicted by PolarMeasure:
     closed-scale adjectives license "completely", open-scale ones don't.
     Matches `closurePuzzle.worksWithClosed` / `.worksWithOpen`. -/
-theorem closurePuzzle_predicted {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem closurePuzzle_predicted {max : Nat} {W : Type*} (μ : W → Bounded max) :
     ((adjMeasure μ full).IsLicensed ↔ closurePuzzle.worksWithClosed = true) ∧
     ((adjMeasure μ tall).IsLicensed ↔ closurePuzzle.worksWithOpen = true) :=
   ⟨iff_of_true (closedAdj_licensed μ full rfl) rfl,
@@ -584,7 +584,7 @@ theorem closurePuzzle_predicted {max : Nat} {W : Type*} (μ : W → Degree max) 
 
 /-- "completely" works with AGA-max (closed) but not RGA (open).
     `adjMeasure` licensing matches `completelyModifier` fields. -/
-theorem completely_distribution {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem completely_distribution {max : Nat} {W : Type*} (μ : W → Bounded max) :
     ((adjMeasure μ full).IsLicensed ↔ completelyModifier.worksWithAGAMax = true) ∧
     ((adjMeasure μ tall).IsLicensed ↔ completelyModifier.worksWithRGA = true) :=
   ⟨iff_of_true (closedAdj_licensed μ full rfl) rfl,
@@ -609,7 +609,7 @@ theorem adj_pipeline_dry :
     LicensingPipeline.IsLicensed dry.scaleType := trivial
 
 /-- Pipeline agrees with PolarMeasure for all four test adjectives. -/
-theorem pipeline_agrees_with_measure {max : Nat} {W : Type*} (μ : W → Degree max) :
+theorem pipeline_agrees_with_measure {max : Nat} {W : Type*} (μ : W → Bounded max) :
     (LicensingPipeline.IsLicensed tall.scaleType ↔ (adjMeasure μ tall).IsLicensed) ∧
     (LicensingPipeline.IsLicensed full.scaleType ↔ (adjMeasure μ full).IsLicensed) ∧
     (LicensingPipeline.IsLicensed wet.scaleType ↔ (adjMeasure μ wet).IsLicensed) ∧

--- a/Linglib/Studies/Krifka2007.lean
+++ b/Linglib/Studies/Krifka2007.lean
@@ -66,7 +66,7 @@ set_option autoImplicit false
 
 namespace Krifka2007
 
-open Degree (Degree Threshold deg thr)
+open Degree (Bounded Threshold deg thr)
 open Degree (ThresholdPair inGapRegion
   positiveMeaning' contraryNegMeaning notContraryNegMeaning contradictoryNeg
   AntonymForm contradictoryDenot_synonymy strengthenedDenot_breaks_synonymy)
@@ -114,11 +114,11 @@ open Constraints OptimalityTheory
     substrate theorem `strengthenedDenot_breaks_synonymy`. -/
 
 -- ════════════════════════════════════════════════════
--- § 4. Concrete Scale: Happy/Unhappy on Degree 4
+-- § 4. Concrete Scale: Happy/Unhappy on Bounded 4
 -- ════════════════════════════════════════════════════
 
 /-- 5-point happiness scale (matching [tessler-franke-2019]'s model). -/
-abbrev HappyDeg := Degree 4
+abbrev HappyDeg := Bounded 4
 
 /-- Contradictory boundary at θ = 2 (the literal semantics). -/
 abbrev happyθ : Threshold 4 := thr 2
@@ -164,7 +164,7 @@ theorem gap_degrees :
     inGapRegion (deg 2 : HappyDeg) happyTP := by
   refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩ <;> decide
 
-/-- **Prediction 5**: Degree 0 is "unhappy", degree 4 is "happy". -/
+/-- **Prediction 5**: Bounded 0 is "unhappy", degree 4 is "happy". -/
 theorem extreme_degrees :
     contraryNegMeaning (deg 0 : HappyDeg) happyTP ∧
     positiveMeaning' (deg 4 : HappyDeg) happyTP :=
@@ -211,7 +211,7 @@ theorem interpretation_follows_inner_neg :
   decide
 
 private instance {max : Nat} (tp : ThresholdPair max) (q : AntonymForm)
-    (d : Degree max) : Decidable (AntonymForm.strengthenedDenot tp q d) := by
+    (d : Bounded max) : Decidable (AntonymForm.strengthenedDenot tp q d) := by
   cases q <;> dsimp [AntonymForm.strengthenedDenot] <;> infer_instance
 
 /-- **Transfer equation**: a row is judged equivalent to the bare positive iff

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -580,11 +580,11 @@ end Nouwen2024.Intensifiers
 
 namespace RSA.Nouwen2024
 
--- Local scale: n=6 (Degree 6 = Fin 7, Threshold 6 = Fin 6). Norm = 3.
+-- Local scale: n=6 (Bounded 6 = Fin 7, Threshold 6 = Fin 6). Norm = 3.
 
 instance : NeZero (6 : Nat) := ⟨by omega⟩
 
-abbrev Height := Degree.Degree 6
+abbrev Height := Degree.Bounded 6
 abbrev Threshold := Degree.Threshold 6
 
 open Degree (deg thr)
@@ -677,7 +677,7 @@ private lemma muHorrible_eq (h : Height) :
     (Degree.Intensification.muHorrible 6).mu h.toNat =
     (muHorrible h : ℚ) := by
   unfold Degree.Intensification.muHorrible muHorrible
-  fin_cases h <;> simp [Degree.Degree.toNat] <;> norm_num
+  fin_cases h <;> simp [Degree.Bounded.toNat] <;> norm_num
 
 /--
 The local horribly_warm meaning agrees with theory-layer `intensifiedMeaning`
@@ -696,7 +696,7 @@ private lemma muPleasant_eq (h : Height) :
     (Degree.Intensification.muPleasant 6).mu h.toNat =
     (muPleasant h : ℚ) := by
   unfold Degree.Intensification.muPleasant muPleasant
-  fin_cases h <;> simp [Degree.Degree.toNat] <;> norm_num
+  fin_cases h <;> simp [Degree.Bounded.toNat] <;> norm_num
 
 /--
 The local pleasantly_warm meaning agrees with theory-layer `intensifiedMeaning`
@@ -1569,9 +1569,9 @@ drops strictly; the speaker value `gval` rises strictly (informativity). -/
 theorem evalMass_one_lt_zero : evalMass 1 < evalMass 0 := by
   refine ENNReal.tsum_lt_tsum (i := deg 2) (evalMass_ne_top 1) (fun h => ?_) ?_
   · fin_cases h <;>
-      simp [evalLex, evalMeaning, muHorrible, validToThreshold, Degree.Degree.toNat,
+      simp [evalLex, evalMeaning, muHorrible, validToThreshold, Degree.Bounded.toNat,
         Degree.Threshold.toNat]
-  · simp only [evalLex, evalMeaning, muHorrible, validToThreshold, Degree.Degree.toNat,
+  · simp only [evalLex, evalMeaning, muHorrible, validToThreshold, Degree.Bounded.toNat,
       Degree.Threshold.toNat, deg]
     norm_num
     exact pos_iff_ne_zero.mpr (heightPriorPMF_pos _)

--- a/Linglib/Studies/TesslerFranke2020PMF.lean
+++ b/Linglib/Studies/TesslerFranke2020PMF.lean
@@ -31,14 +31,14 @@ set_option autoImplicit false
 namespace TesslerFranke2020.PMF
 
 open scoped ENNReal
-open Degree (Degree Threshold deg thr)
+open Degree (Bounded Threshold deg thr)
 open Features (NegationType)
 open Degree (positiveMeaning negativeMeaning)
 
 /-! ## §0. Domain types -/
 
 /-- Happiness degree: 0 (miserable) to 4 (ecstatic). -/
-abbrev HappinessDeg := Degree 4
+abbrev HappinessDeg := Bounded 4
 
 instance : NeZero (4 : Nat) := ⟨by omega⟩
 

--- a/Linglib/Studies/TesslerGoodman2019.lean
+++ b/Linglib/Studies/TesslerGoodman2019.lean
@@ -101,7 +101,7 @@ set_option autoImplicit false
 
 namespace TesslerGoodman2019
 
-open Degree (Degree Threshold deg thr allDegrees allThresholds Degree.toNat Threshold.toNat)
+open Degree (Bounded Threshold deg thr allDegrees allThresholds Bounded.toNat Threshold.toNat)
 open Degree (positiveMeaning)
 
 -- ============================================================================
@@ -110,7 +110,7 @@ open Degree (positiveMeaning)
 
 /-- Discretized prevalence: 0%, 5%, ..., 100% (21 values).
     Structurally identical to [lassiter-goodman-2017]'s Height. -/
-abbrev Prevalence := Degree 20
+abbrev Prevalence := Bounded 20
 
 instance : NeZero (20 : Nat) := ⟨by omega⟩
 
@@ -404,20 +404,20 @@ theorem generic_zero_false :
 /-- The bimodal "lays eggs" prior peaks at zero prevalence. -/
 theorem laysEggs_peaks_at_zero :
     laysEggsPrior (prevPct 0) > laysEggsPrior (prevPct 50) := by
-  norm_num [laysEggsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [laysEggsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
 
 /-- The unimodal "is female" prior peaks at 50%. -/
 theorem isFemale_peaks_at_50 :
     isFemalePrior (prevPct 50) > isFemalePrior (prevPct 0) := by
-  norm_num [isFemalePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [isFemalePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
 
-/-- Expand a sum over `Degree 20` (≃ `Fin 21`) into a `Fin 21` sum, so that
+/-- Expand a sum over `Bounded 20` (≃ `Fin 21`) into a `Fin 21` sum, so that
     concrete prior expectations evaluate by `Fin.sum_univ_succ` + `norm_num`. -/
-private theorem sum_degree20 {M : Type*} [AddCommMonoid M] (f : Degree 20 → M) :
+private theorem sum_degree20 {M : Type*} [AddCommMonoid M] (f : Bounded 20 → M) :
     ∑ w, f w = ∑ i : Fin 21, f ⟨i⟩ :=
-  (Equiv.sum_comp ⟨(⟨·⟩), Degree.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩ f).symm
+  (Equiv.sum_comp ⟨(⟨·⟩), Bounded.value, fun _ => rfl, fun ⟨_⟩ => rfl⟩ f).symm
 
 -- ============================================================================
 -- § 7. Endorsement Predictions (S1 — the paper's primary model)
@@ -504,7 +504,7 @@ theorem endorsement_iff_exceeds_expected
       ENNReal.ofReal_lt_ofReal_iff_of_nonneg (by positivity),
       expectedBin, gt_iff_lt, ← div_eq_mul_inv, ← div_eq_mul_inv,
       div_lt_div_iff₀ (by positivity) hSgen, div_lt_iff₀ hZ]
-  -- `thresholdCount .generic` is `Degree.toNat`; unify so the atoms match `expectedBin`.
+  -- `thresholdCount .generic` is `Bounded.toNat`; unify so the atoms match `expectedBin`.
   simp only [thresholdCount]
   constructor <;> intro h <;> nlinarith
 
@@ -553,7 +553,7 @@ A prior invariant under bin-reflection `k ↦ 20 − k` has its mean at the cent
 (50% prevalence). This makes the "robins are female" borderline a *theorem about
 symmetry* rather than a numerical coincidence. -/
 
-/-- The bin-reflection `k ↦ 20 − k` as a permutation of `Prevalence`. `Degree 20`
+/-- The bin-reflection `k ↦ 20 − k` as a permutation of `Prevalence`. `Bounded 20`
     wraps `Fin 21`, so reflect `Fin.rev` on the underlying `.value` field. -/
 private def reflectPrev : Equiv.Perm Prevalence where
   toFun k := ⟨Fin.rev k.value⟩
@@ -609,11 +609,11 @@ theorem bark_endorsed :
   have hp := priorR_nonneg_of barkPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR barkPrior (prevPct 95) := by
     simp only [priorR]
-    norm_num [barkPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [barkPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR barkPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, barkPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, barkPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR barkPrior) hp
@@ -621,7 +621,7 @@ theorem bark_endorsed :
       (prevPct 95) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, barkPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, barkPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -635,11 +635,11 @@ theorem laysEggs_endorsed :
   have hp := priorR_nonneg_of laysEggsPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR laysEggsPrior (prevPct 50) := by
     simp only [priorR]
-    norm_num [laysEggsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [laysEggsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR laysEggsPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, laysEggsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, laysEggsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR laysEggsPrior) hp
@@ -647,7 +647,7 @@ theorem laysEggs_endorsed :
       (prevPct 50) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, laysEggsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, laysEggsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -662,11 +662,11 @@ theorem malaria_endorsed :
   have hp := priorR_nonneg_of carriesMalariaPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR carriesMalariaPrior (prevPct 10) := by
     simp only [priorR]
-    norm_num [carriesMalariaPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [carriesMalariaPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR carriesMalariaPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, carriesMalariaPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, carriesMalariaPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR carriesMalariaPrior) hp
@@ -674,7 +674,7 @@ theorem malaria_endorsed :
       (prevPct 10) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, carriesMalariaPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, carriesMalariaPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -689,11 +689,11 @@ theorem spots_not_endorsed :
   have hp := priorR_nonneg_of haveSpotsPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR haveSpotsPrior (prevPct 10) := by
     simp only [priorR]
-    norm_num [haveSpotsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [haveSpotsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR haveSpotsPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, haveSpotsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, haveSpotsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR haveSpotsPrior) hp
@@ -701,7 +701,7 @@ theorem spots_not_endorsed :
       (prevPct 10) hpp hZ, not_lt]
   unfold expectedBin
   rw [le_div_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, haveSpotsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, haveSpotsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -716,11 +716,11 @@ theorem dontEatPeople_not_endorsed :
   have hp := priorR_nonneg_of dontEatPeoplePrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR dontEatPeoplePrior (prevPct 80) := by
     simp only [priorR]
-    norm_num [dontEatPeoplePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [dontEatPeoplePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR dontEatPeoplePrior w := by
     rw [sum_degree20]
-    norm_num [priorR, dontEatPeoplePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, dontEatPeoplePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR dontEatPeoplePrior) hp
@@ -728,7 +728,7 @@ theorem dontEatPeople_not_endorsed :
       (prevPct 80) hpp hZ, not_lt]
   unfold expectedBin
   rw [le_div_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, dontEatPeoplePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, dontEatPeoplePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -745,14 +745,14 @@ theorem isFemale_borderline :
   have hp := priorR_nonneg_of isFemalePrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR isFemalePrior (prevPct 50) := by
     simp only [priorR]
-    norm_num [isFemalePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [isFemalePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR isFemalePrior w :=
     Finset.sum_pos' (fun i _ => hp i) ⟨prevPct 50, Finset.mem_univ _, hpp⟩
   rw [endorsement_iff_exceeds_expected (priorR isFemalePrior) hp
       (meaningE_generic_ne_zero _ hp (prevPct 50) hpp (by decide)) (meaningE_silent_ne_zero _ hp hZ)
       (prevPct 50) hpp hZ, not_lt, expectedBin_of_symmetric isFemalePrior_symm hZ]
-  norm_num [Degree.toNat]
+  norm_num [Bounded.toNat]
 
 
 -- ============================================================================
@@ -942,11 +942,11 @@ theorem runs_endorsed_at_high_freq :
   have hp := priorR_nonneg_of runsPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR runsPrior (prevPct 75) := by
     simp only [priorR]
-    norm_num [runsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [runsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR runsPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, runsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, runsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR runsPrior) hp
@@ -954,7 +954,7 @@ theorem runs_endorsed_at_high_freq :
       (prevPct 75) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, runsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, runsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -966,11 +966,11 @@ theorem climbs_mountains_endorsed_at_low_freq :
   have hp := priorR_nonneg_of climbsMountainsPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR climbsMountainsPrior (prevPct 25) := by
     simp only [priorR]
-    norm_num [climbsMountainsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [climbsMountainsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR climbsMountainsPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, climbsMountainsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, climbsMountainsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR climbsMountainsPrior) hp
@@ -978,7 +978,7 @@ theorem climbs_mountains_endorsed_at_low_freq :
       (prevPct 25) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, climbsMountainsPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, climbsMountainsPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -990,11 +990,11 @@ theorem drinks_coffee_not_endorsed_at_low_freq :
   have hp := priorR_nonneg_of drinksCoffeePrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR drinksCoffeePrior (prevPct 25) := by
     simp only [priorR]
-    norm_num [drinksCoffeePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [drinksCoffeePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR drinksCoffeePrior w := by
     rw [sum_degree20]
-    norm_num [priorR, drinksCoffeePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, drinksCoffeePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR drinksCoffeePrior) hp
@@ -1002,7 +1002,7 @@ theorem drinks_coffee_not_endorsed_at_low_freq :
       (prevPct 25) hpp hZ, not_lt]
   unfold expectedBin
   rw [le_div_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, drinksCoffeePrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, drinksCoffeePrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1074,11 +1074,11 @@ theorem rareWeak_endorsed_at_20pct :
   have hp := priorR_nonneg_of rareWeakPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR rareWeakPrior (prevPct 20) := by
     simp only [priorR]
-    norm_num [rareWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [rareWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR rareWeakPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR rareWeakPrior) hp
@@ -1086,7 +1086,7 @@ theorem rareWeak_endorsed_at_20pct :
       (prevPct 20) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1099,11 +1099,11 @@ theorem commonStrong_not_endorsed_at_20pct :
   have hp := priorR_nonneg_of commonStrongPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR commonStrongPrior (prevPct 20) := by
     simp only [priorR]
-    norm_num [commonStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [commonStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR commonStrongPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR commonStrongPrior) hp
@@ -1111,7 +1111,7 @@ theorem commonStrong_not_endorsed_at_20pct :
       (prevPct 20) hpp hZ, not_lt]
   unfold expectedBin
   rw [le_div_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1123,11 +1123,11 @@ theorem rareWeak_endorsed_at_70pct :
   have hp := priorR_nonneg_of rareWeakPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR rareWeakPrior (prevPct 70) := by
     simp only [priorR]
-    norm_num [rareWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [rareWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR rareWeakPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR rareWeakPrior) hp
@@ -1135,7 +1135,7 @@ theorem rareWeak_endorsed_at_70pct :
       (prevPct 70) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, rareWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1151,11 +1151,11 @@ theorem commonStrong_not_endorsed_at_50pct :
   have hp := priorR_nonneg_of commonStrongPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR commonStrongPrior (prevPct 50) := by
     simp only [priorR]
-    norm_num [commonStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [commonStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR commonStrongPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR commonStrongPrior) hp
@@ -1163,7 +1163,7 @@ theorem commonStrong_not_endorsed_at_50pct :
       (prevPct 50) hpp hZ, not_lt]
   unfold expectedBin
   rw [le_div_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, commonStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1177,11 +1177,11 @@ theorem rareStrong_not_endorsed_at_20pct :
   have hp := priorR_nonneg_of rareStrongPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR rareStrongPrior (prevPct 20) := by
     simp only [priorR]
-    norm_num [rareStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [rareStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR rareStrongPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR rareStrongPrior) hp
@@ -1189,7 +1189,7 @@ theorem rareStrong_not_endorsed_at_20pct :
       (prevPct 20) hpp hZ, not_lt]
   unfold expectedBin
   rw [le_div_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1201,11 +1201,11 @@ theorem rareStrong_endorsed_at_70pct :
   have hp := priorR_nonneg_of rareStrongPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR rareStrongPrior (prevPct 70) := by
     simp only [priorR]
-    norm_num [rareStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [rareStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR rareStrongPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR rareStrongPrior) hp
@@ -1213,7 +1213,7 @@ theorem rareStrong_endorsed_at_70pct :
       (prevPct 70) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, rareStrongPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 
@@ -1227,11 +1227,11 @@ theorem commonWeak_endorsed_at_70pct :
   have hp := priorR_nonneg_of commonWeakPrior (mixturePrior_nonneg _ (by norm_num) (by norm_num) _ _ _ _)
   have hpp : 0 < priorR commonWeakPrior (prevPct 70) := by
     simp only [priorR]
-    norm_num [commonWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [commonWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil]
   have hZ : 0 < ∑ w : Prevalence, priorR commonWeakPrior w := by
     rw [sum_degree20]
-    norm_num [priorR, commonWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+    norm_num [priorR, commonWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
       List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
       Fin.sum_univ_succ, Fin.sum_univ_zero]
   rw [endorsement_iff_exceeds_expected (priorR commonWeakPrior) hp
@@ -1239,7 +1239,7 @@ theorem commonWeak_endorsed_at_70pct :
       (prevPct 70) hpp hZ]
   unfold expectedBin
   rw [gt_iff_lt, div_lt_iff₀ hZ, sum_degree20, sum_degree20]
-  norm_num [priorR, commonWeakPrior, mixturePrior, betaWeight, betaTotal, Degree.toNat,
+  norm_num [priorR, commonWeakPrior, mixturePrior, betaWeight, betaTotal, Bounded.toNat,
     List.range_succ, List.range_zero, List.foldl_cons, List.foldl_nil,
     Fin.sum_univ_succ, Fin.sum_univ_zero]
 

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -97,7 +97,7 @@ set_option autoImplicit false
 
 namespace TesslerGoodman2022
 
-open Degree (Degree Threshold deg thr allDegrees allThresholds Degree.toNat Threshold.toNat)
+open Degree (Bounded Threshold deg thr allDegrees allThresholds Bounded.toNat Threshold.toNat)
 open Degree (positiveMeaning negativeMeaning)
 
 -- ============================================================================
@@ -105,7 +105,7 @@ open Degree (positiveMeaning negativeMeaning)
 -- ============================================================================
 
 /-- Discretized height: 0 through 10 in discrete steps (11 values). -/
-abbrev Height := Degree 10
+abbrev Height := Bounded 10
 
 /-- Comparison classes: subordinate (the kind itself) or superordinate
     (the general population). -/

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -487,7 +487,7 @@ theorem scratch_adj_verb_scale_agree :
 
 /-- Disturbance adjectives are licensed for degree modification by the
     Kennedy pipeline, just like *full* and *clean*. -/
-theorem cracked_licensed {max : Nat} {W : Type*} (μ : W → Degree.Degree max) :
+theorem cracked_licensed {max : Nat} {W : Type*} (μ : W → Degree.Bounded max) :
     (adjMeasure μ Adjectival.cracked).IsLicensed :=
   closedAdj_licensed μ Adjectival.cracked rfl
 theorem cracked_pipeline_licensed :
@@ -624,7 +624,7 @@ theorem crack_refutes_strict_hkl_matrix :
     `Boundedness` level — both are `.closed`, hence both license degree
     modification. -/
 theorem cracked_licensing_converges_with_kennedy2007
-    {max : Nat} {W : Type*} (μ : W → Degree.Degree max) :
+    {max : Nat} {W : Type*} (μ : W → Degree.Bounded max) :
     (adjMeasure μ Adjectival.cracked).IsLicensed ↔
     (adjMeasure μ Adjectival.full).IsLicensed :=
   iff_of_true (closedAdj_licensed μ Adjectival.cracked rfl)


### PR DESCRIPTION
Resolves the `dupNamespace` lint on the discrete degree carrier (#1595 follow-up): `structure Degree` inside `namespace Degree` becomes `Degree.Bounded`, matching its `BoundedOrder` instance; 13 call sites were already forced to write the stuttering `Degree.Degree`. Mechanical rename across 16 files; two drive-by lint fixes in touched files (unused simp args in Intensification, `push_neg` in AlexandropoulouGotzner2024).