### PR TITLE
refactor(Studies): accessibility cross-framework arc + GJW1995 cleanse

### DIFF
--- a/Linglib/Studies/GroszJoshiWeinstein1995.lean
+++ b/Linglib/Studies/GroszJoshiWeinstein1995.lean
@@ -41,7 +41,7 @@ open Discourse.Centering
 
 /-- Utterance abbreviation specialized to the GJW use case
     (`String` entities, grammatical-role-ranked Cf). -/
-abbrev Utt : Type := Utterance String GrammaticalRole
+abbrev Utt := Utterance String GrammaticalRole
 
 /-! ### Discourses (1)-(2): the coherence contrast (paper §2) -/
 
@@ -212,11 +212,11 @@ theorem d16_b_to_c_shifting :
     classifyTransitionExtended D16.b D16.c D16.c.cp (cb D16.a D16.b) = .shifting := by
   decide
 
+theorem d16_c_to_d_cb : cb D16.c D16.d = some "Mike" := by decide
+
 /-- After the shift, (16d)'s pronoun realizes the new Cb Mike — Rule 1
     is satisfied exactly where (15c) violated it. -/
-theorem d16_c_to_d_satisfies_rule1 :
-    cb D16.c D16.d = some "Mike" ∧ Rule1GJW95 D16.c D16.d :=
-  ⟨by decide, by decide⟩
+theorem d16_c_to_d_satisfies_rule1 : Rule1GJW95 D16.c D16.d := by decide
 
 /-! ### Discourses (7)-(10): Cf ranking and Rule 1 (paper §5) -/
 
@@ -278,8 +278,7 @@ theorem d7_to_10_share_cb :
     cb D7_10.b D7_10.c7  = some "Susan" ∧
     cb D7_10.b D7_10.c8  = some "Susan" ∧
     cb D7_10.b D7_10.c9  = some "Susan" ∧
-    cb D7_10.b D7_10.c10 = some "Susan" := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
+    cb D7_10.b D7_10.c10 = some "Susan" := by decide
 
 /-- Variant 7 satisfies Rule 1 (Susan as Cb pronominalized). -/
 theorem d7_satisfies_rule1 :
@@ -296,18 +295,10 @@ theorem d9_violates_rule1 :
 
 /-- **Variant 10 violates Rule 1**: Betsy is pronominalized but Cb
     (Susan) is realized as a proper name. The paper calls this case
-    "completely unacceptable". -/
+    "completely unacceptable"; the Rule-1 split (7, 8 satisfy; 9, 10
+    violate) tracks the paper's acceptability ordering. -/
 theorem d10_violates_rule1 :
     ¬ Rule1GJW95 D7_10.b D7_10.c10 := by decide
-
-/-- The Rule-1 split (`d7,8 OK` vs `d9,10 violate`) tracks the paper's
-    acceptability ordering: variants 7 and 8 are acceptable, 9 and 10
-    are degraded. The framework predicts this directly from Rule 1
-    plus the subject>object Cf ranking. -/
-theorem rule1_distinguishes_variants_7_8_from_9_10 :
-    (Rule1GJW95 D7_10.b D7_10.c7 ∧ Rule1GJW95 D7_10.b D7_10.c8) ∧
-    (¬ Rule1GJW95 D7_10.b D7_10.c9 ∧ ¬ Rule1GJW95 D7_10.b D7_10.c10) := by
-  refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩ <;> decide
 
 /-! ### Discourse (20): CONTINUE / RETAIN / SHIFT (paper §7) -/
 

--- a/Linglib/Studies/GroszJoshiWeinstein1995.lean
+++ b/Linglib/Studies/GroszJoshiWeinstein1995.lean
@@ -35,8 +35,6 @@ comparison with [sidner-1983] on example (34). Examples use `String`
 entities and the substrate's `Utterance String GrammaticalRole`.
 -/
 
-set_option autoImplicit false
-
 namespace GroszJoshiWeinstein1995
 
 open Discourse.Centering

--- a/Linglib/Studies/GroszJoshiWeinstein1995.lean
+++ b/Linglib/Studies/GroszJoshiWeinstein1995.lean
@@ -28,17 +28,11 @@ of retentions, which are preferred over sequences of shifts; the
 pair-of-utterances restriction is [brennan-friedman-pollard-1987]'s
 variant, per the paper's own footnote).
 
-The key empirical contrast is between Discourses 1 and 2 (§ 1 below):
-same propositional content, different transition pattern, different
-perceived coherence. The framework predicts the difference.
-
-This file consumes the substrate types and operators from
-`Discourse/Centering/{Defs,Basic,Transition,Rule1,Rule2}.lean`
-plus the `GrammaticalRole` Cf-ranker instance from
-`Instances/GrammaticalRole.lean`. Per linglib's import-don't-restipulate
-discipline, no Centering primitives are redefined here — the file's
-contribution is the empirical-example anchor for the substrate plus
-the § 5 comparison with [sidner-1983].
+The empirical anchors are the paper's own discourses: the (1)/(2)
+coherence contrast, the (15)/(16) Rule-1 violation and repair, the
+(7)-(10) hamster variants, the (20) transition showcase, and the §9
+comparison with [sidner-1983] on example (34). Examples use `String`
+entities and the substrate's `Utterance String GrammaticalRole`.
 -/
 
 set_option autoImplicit false
@@ -47,16 +41,11 @@ namespace GroszJoshiWeinstein1995
 
 open Discourse.Centering
 
-/-! Throughout, examples use `String` entities for readability and
-    `Utterance String GrammaticalRole` from the substrate. -/
-
 /-- Utterance abbreviation specialized to the GJW use case
     (`String` entities, grammatical-role-ranked Cf). -/
 abbrev Utt : Type := Utterance String GrammaticalRole
 
--- ════════════════════════════════════════════════════
--- § 1. Discourse 1 vs Discourse 2: the coherence contrast (paper §2)
--- ════════════════════════════════════════════════════
+/-! ### Discourses (1)-(2): the coherence contrast (paper §2) -/
 
 namespace D1
 
@@ -159,9 +148,7 @@ def d2_score : Nat :=
 
 theorem discourse1_more_coherent_than_discourse2 : d1_score > d2_score := by decide
 
--- ════════════════════════════════════════════════════
--- § 2. Discourses 15-16: Rule 1 violation and shift repair (paper §7)
--- ════════════════════════════════════════════════════
+/-! ### Discourses (15)-(16): Rule 1 violation and shift repair (paper §7) -/
 
 namespace D15
 
@@ -233,9 +220,7 @@ theorem d16_c_to_d_satisfies_rule1 :
     cb D16.c D16.d = some "Mike" ∧ Rule1GJW95 D16.c D16.d :=
   ⟨by decide, by decide⟩
 
--- ════════════════════════════════════════════════════
--- § 3. Discourses 7-10: Cf ranking + Rule 1 interaction
--- ════════════════════════════════════════════════════
+/-! ### Discourses (7)-(10): Cf ranking and Rule 1 (paper §5) -/
 
 /-! [grosz-joshi-weinstein-1995] §5 examples (7)-(10). All four
     variants share utterances (a) and (b); they differ only in (c)'s
@@ -326,9 +311,7 @@ theorem rule1_distinguishes_variants_7_8_from_9_10 :
     (¬ Rule1GJW95 D7_10.b D7_10.c9 ∧ ¬ Rule1GJW95 D7_10.b D7_10.c10) := by
   refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩ <;> decide
 
--- ════════════════════════════════════════════════════
--- § 4. Discourse 20: full CONTINUE / RETAIN / SHIFT pattern (paper §7)
--- ════════════════════════════════════════════════════
+/-! ### Discourse (20): CONTINUE / RETAIN / SHIFT (paper §7) -/
 
 namespace D20
 
@@ -369,9 +352,7 @@ theorem discourse20_rule1_b_c : Rule1GJW95 D20.b D20.c := by decide
 theorem discourse20_rule1_c_d : Rule1GJW95 D20.c D20.d := by decide
 theorem discourse20_rule1_d_e : Rule1GJW95 D20.d D20.e := by decide
 
--- ════════════════════════════════════════════════════
--- § 5. Comparison with [sidner-1983]: example (34)
--- ════════════════════════════════════════════════════
+/-! ### Comparison with [sidner-1983]: example (34) (paper §9) -/
 
 /-! This section mechanizes the Sidner-comparison the paper makes in
     its own §9 (p. 222) — the example is Sidner's own, cited from her
@@ -481,9 +462,8 @@ theorem gjw_prefers_jeff : gjwPredictedHe = some "Jeff" := by decide
     GJW's Rule-2 preference (with the caveat above that GJW themselves
     don't claim uniqueness): RETAIN > SHIFT under Rule 2 ⇒ Jeff.
 
-    Stated constructively (mathlib idiom): each side commits to a
-    *named* prediction; the inequality follows by transparent
-    `decide` from the witnesses. -/
+    Each side commits to a *named* prediction; the inequality follows
+    by `decide` from the witnesses. -/
 theorem sidner_gjw_disagree_on_d34c :
     Sidner1983.D34.sidnerPredictedHe ≠ gjwPredictedHe := by
   rw [Sidner1983.D34.sidner_predicts_carl, gjw_prefers_jeff]

--- a/Linglib/Studies/GroszJoshiWeinstein1995.lean
+++ b/Linglib/Studies/GroszJoshiWeinstein1995.lean
@@ -3,15 +3,11 @@ import Linglib.Discourse.Centering.Transition
 import Linglib.Discourse.Centering.Rule1
 import Linglib.Discourse.Centering.Rule2
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
-import Linglib.Features.Accessibility
 import Linglib.Studies.Sidner1983
-import Linglib.Studies.Ariel2001
-import Linglib.Studies.KehlerRohde2013
-import Linglib.Studies.KwonLee2026
 
 /-!
 # [grosz-joshi-weinstein-1995]: Centering Theory
-[kameyama-1986] [gordon-grosz-gilliom-1993] [kehler-rohde-2013] [sidner-1983]
+[kameyama-1986] [gordon-grosz-gilliom-1993] [sidner-1983]
 
 Centering: A Framework for Modeling the Local Coherence of Discourse.
 *Computational Linguistics* 21(2): 203–225.
@@ -27,10 +23,12 @@ that Cb is the most-highly-ranked Cf.
 Two normative rules govern coherent discourse: **Rule 1**
 (pronominalization constraint — if any Cf element is pronominalized
 in the next utterance, the Cb must be); **Rule 2** (transition
-preference — continuations preferred over retentions, retentions
-over shifts).
+preference — *sequences* of continuations preferred over sequences
+of retentions, which are preferred over sequences of shifts; the
+pair-of-utterances restriction is [brennan-friedman-pollard-1987]'s
+variant, per the paper's own footnote).
 
-The key empirical contrast is between Discourses 1 and 2 (§ 4 below):
+The key empirical contrast is between Discourses 1 and 2 (§ 1 below):
 same propositional content, different transition pattern, different
 perceived coherence. The framework predicts the difference.
 
@@ -40,7 +38,7 @@ plus the `GrammaticalRole` Cf-ranker instance from
 `Instances/GrammaticalRole.lean`. Per linglib's import-don't-restipulate
 discipline, no Centering primitives are redefined here — the file's
 contribution is the empirical-example anchor for the substrate plus
-the §8 comparison with [sidner-1983].
+the § 5 comparison with [sidner-1983].
 -/
 
 set_option autoImplicit false
@@ -121,10 +119,11 @@ theorem d1_b_to_c_continuation :
 theorem d1_c_to_d_continuation :
     classifyTransitionExtended D1.c D1.d D1.d.cp (cb D1.b D1.c) = .continuation := by decide
 
-/-- Discourse 2 (a→b): the Cb is John (the only entity in `Cf(D2.a)`
-    that is realized in `D2.b`), but `Cp(D2.b) = "store"` (not John),
-    so this is a *retain* — already a less coherent transition than
-    Discourse 1's continuation. -/
+/-- Discourse 2 (a→b): both John and the store are realized in `D2.b`,
+    and John outranks the store in `Cf(D2.a)` (subject > object), so the
+    Cb is John; but `Cp(D2.b) = "store"` (not John), so this is a
+    *retain* — already a less coherent transition than Discourse 1's
+    continuation. -/
 theorem d2_a_to_b_cb : cb D2.a D2.b = some "John" := by decide
 
 theorem d2_a_to_b_retaining :
@@ -147,7 +146,10 @@ theorem d2_c_to_d_retaining :
     pattern is all continuations; Discourse 2's pattern is
     `retain, continue, retain` — a mix of weaker transitions. The sum
     of `Transition.rank`s is a coarse but theory-aligned coherence
-    measure. -/
+    measure. (The paper's prose describes Discourse 2's flips
+    informally as changes of "aboutness"; under the formal definitions
+    the Cb remains John throughout, and the incoherence surfaces as
+    retains rather than shifts.) -/
 def d1_score : Nat :=
   Transition.continuation.rank + Transition.continuation.rank
     + Transition.continuation.rank
@@ -158,7 +160,7 @@ def d2_score : Nat :=
 theorem discourse1_more_coherent_than_discourse2 : d1_score > d2_score := by decide
 
 -- ════════════════════════════════════════════════════
--- § 2. Discourse 15: Rule 1 violation
+-- § 2. Discourses 15-16: Rule 1 violation and shift repair (paper §7)
 -- ════════════════════════════════════════════════════
 
 namespace D15
@@ -190,6 +192,46 @@ theorem discourse15_violates_rule1 :
     is also pronominalized). The violation is local to the (b→c) step. -/
 theorem d15_a_to_b_satisfies_rule1 :
     Rule1GJW95 D15.a D15.b := by decide
+
+/-! Discourse (16) is the paper's minimal repair of (15): the same
+    John–Mike sequence with an intervening utterance that shifts the
+    center to Mike, "making the full sequence coherent" — Rule 1
+    "operates independently of the type of centering transition." (The
+    paper's footnote tempers the contrast: per
+    [gordon-grosz-gilliom-1993], (16d) without the intervening (c) is
+    not as bad as (15c).) -/
+
+namespace D16
+
+/-- (16a) John has been acting quite odd. -/
+def a : Utt := ⟨[⟨"John", .subject, false⟩]⟩
+
+/-- (16b) He called up Mike yesterday. ("He" = John.) -/
+def b : Utt :=
+  ⟨[⟨"John", .subject, true⟩, ⟨"Mike", .object, false⟩]⟩
+
+/-- (16c) Mike was studying for his driver's test. Mike is the only
+    `Cf(16b)` element realized here, so the center shifts to Mike. -/
+def c : Utt := ⟨[⟨"Mike", .subject, false⟩]⟩
+
+/-- (16d) He was annoyed by John's call. ("He" = Mike.) -/
+def d : Utt :=
+  ⟨[⟨"Mike", .subject, true⟩, ⟨"John", .other, false⟩]⟩
+
+end D16
+
+/-- The intervening (16c) shifts the center from John to Mike. -/
+theorem d16_b_to_c_cb : cb D16.b D16.c = some "Mike" := by decide
+
+theorem d16_b_to_c_shifting :
+    classifyTransitionExtended D16.b D16.c D16.c.cp (cb D16.a D16.b) = .shifting := by
+  decide
+
+/-- After the shift, (16d)'s pronoun realizes the new Cb Mike — Rule 1
+    is satisfied exactly where (15c) violated it. -/
+theorem d16_c_to_d_satisfies_rule1 :
+    cb D16.c D16.d = some "Mike" ∧ Rule1GJW95 D16.c D16.d :=
+  ⟨by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════
 -- § 3. Discourses 7-10: Cf ranking + Rule 1 interaction
@@ -285,7 +327,7 @@ theorem rule1_distinguishes_variants_7_8_from_9_10 :
   refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩ <;> decide
 
 -- ════════════════════════════════════════════════════
--- § 4. Discourse 20: full CONTINUE / RETAIN / SHIFT pattern
+-- § 4. Discourse 20: full CONTINUE / RETAIN / SHIFT pattern (paper §7)
 -- ════════════════════════════════════════════════════
 
 namespace D20
@@ -296,7 +338,7 @@ def a : Utt := ⟨[⟨"John", .subject, false⟩]⟩
 /-- (20b) He cannot find anyone to take over his responsibilities. -/
 def b : Utt := ⟨[⟨"John", .subject, true⟩]⟩
 
-/-- (20c) He called up Mike yesterday. -/
+/-- (20c) He called up Mike yesterday to work out a plan. -/
 def c : Utt :=
   ⟨[⟨"John", .subject, true⟩, ⟨"Mike", .object, false⟩]⟩
 
@@ -328,105 +370,12 @@ theorem discourse20_rule1_c_d : Rule1GJW95 D20.c D20.d := by decide
 theorem discourse20_rule1_d_e : Rule1GJW95 D20.d D20.e := by decide
 
 -- ════════════════════════════════════════════════════
--- § 5. Bridge to [kehler-rohde-2013] (Topichood)
--- ════════════════════════════════════════════════════
-
-/-- Centering's "highest-ranked Cf element" — the `Cp` (preferred
-    center) — corresponds to [kehler-rohde-2013]'s **topichood**
-    side of the Bayesian decomposition: the production component
-    P(pronoun | referent) is conditioned on whether the referent is
-    the topic. The Cp of an active-clause subject is precisely the
-    `default_` topichood level in [kehler-rohde-2013]'s scheme. -/
-def cpTopichood : KehlerRohde2013.TopichoodLevel :=
-  KehlerRohde2013.topichood .Act true
-
-theorem cp_is_default_topichood : cpTopichood = .default_ := rfl
-
--- ════════════════════════════════════════════════════
--- § 6. Bridge to [kwon-lee-2026] (Korean Pronouns)
--- ════════════════════════════════════════════════════
-
-/-! [kwon-lee-2026]'s Korean Exp 3 finding (null pronouns
-    strongly prefer subject antecedents) is **predicted** by Centering
-    Theory:
-
-    1. Subject is the highest-ranked Cf element (Kameyama 1986).
-    2. The subject of `U_n` typically becomes the Cb of `U_{n+1}`.
-    3. By Rule 1, the Cb is preferentially realized by a pronoun.
-    4. In Korean, the highest-accessibility marker (most preferred
-       pronominal form) is the *null* pronoun ([ariel-2001]).
-
-    Composing: subject → Cb → pronoun → null in Korean.
-
-    The derivation is anchored on a concrete two-utterance Korean
-    continuation pattern: utterance (a) introduces a subject-marked
-    referent; utterance (b) refers back to it with a null pronoun. -/
-
-namespace KoreanContinuation
-
-/-- (a) Mary often took Tom to the sea. — adapted from
-    [kwon-lee-2026] Exp 3 stimulus pattern. -/
-def utt_a : Utt :=
-  ⟨[⟨"Mary", .subject, false⟩, ⟨"Tom", .object, false⟩,
-    ⟨"sea", .other, false⟩]⟩
-
-/-- (b) [pro] achieved the dream of becoming a sea navigator.
-    Korean null subject; the realization is pronominal (the empty
-    category counts as pronominal in the Centering sense). -/
-def utt_b_null : Utt :=
-  ⟨[⟨"Mary", .subject, true⟩]⟩
-
-end KoreanContinuation
-
-/-- Step 1 of the derivation: in canonical Korean SVO, the Cb of the
-    second utterance is the prior-utterance subject. -/
-theorem korean_cb_is_prior_subject :
-    cb KoreanContinuation.utt_a KoreanContinuation.utt_b_null = some "Mary" := by
-  decide
-
-/-- Step 2: realizing the Cb pronominally satisfies Rule 1
-    (the null subject in Korean counts as pronominal). -/
-theorem korean_null_realization_satisfies_rule1 :
-    Rule1GJW95 KoreanContinuation.utt_a KoreanContinuation.utt_b_null := by
-  decide
-
-/-- Step 3: among Korean's three referential forms, the null pronoun is
-    the most accessible (top of the Korean-form linear order, derived
-    from `Ariel2001.AccessibilityLevel.rank` in `KwonLee2026`). -/
-theorem korean_null_is_top_form :
-    ∀ f : KwonLee2026.KoreanRefForm,
-      f ≤ KwonLee2026.KoreanRefForm.nullPro := by
-  intro f; cases f <;> decide
-
-/-- **Centering predicts Korean's null-subject preference**: combining
-    Rule 1 with Korean's accessibility-scale calibration. The 71%
-    empirical subject bias for null pronouns ([kwon-lee-2026] Exp
-    3) is the predicted consequence of this composition. -/
-theorem korean_subject_bias_for_null_exceeds_chance :
-    KwonLee2026.exp3_pro.subjectPercent > 50 := by decide
-
--- ════════════════════════════════════════════════════
--- § 7. Bridge to [ariel-2001] (Accessibility Marking)
--- ════════════════════════════════════════════════════
-
-open Features
-
-/-- Centering's Cb (the "currently centered" entity) corresponds to a
-    high-accessibility referent on [ariel-2001]'s scale. Rule 1
-    predicts that the Cb's realization should use a high-accessibility
-    marker — typically a pronoun. -/
-def cbExpectedAccessibility : AccessibilityLevel := .unstressedPron
-
-theorem cb_marker_is_high_accessibility :
-    cbExpectedAccessibility.rank ≥ AccessibilityLevel.shortDefDescription.rank := by
-  decide
-
--- ════════════════════════════════════════════════════
--- § 8. Comparison with [sidner-1983]: example (34)
+-- § 5. Comparison with [sidner-1983]: example (34)
 -- ════════════════════════════════════════════════════
 
 /-! This section mechanizes the Sidner-comparison the paper makes in
-    its own §9 (p. 222), on the discourse:
+    its own §9 (p. 222) — the example is Sidner's own, cited from her
+    1979 dissertation — on the discourse:
 
     (34) a. I haven't seen Jeff for several days.
          b. Carl thinks he's studying for his exams,

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -4,6 +4,7 @@ import Linglib.Discourse.Coherence
 import Linglib.Data.UD.Basic
 import Linglib.Discourse.Centering.Rule1
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
+import Linglib.Features.Accessibility
 
 /-!
 # Pronoun interpretation: coherence vs. centering [kehler-rohde-2013]
@@ -24,6 +25,9 @@ experiments with transfer-of-possession and implicit-causality verbs.
 * `topichood`, `TopichoodLevel`: voice and surface position to topichood, the
   centering-driven likelihood term.
 * `bayesianPrediction`: Bayesian inversion to `P(Subject | pronoun)` (Eq. (13)).
+* `NextMentionModel.toBias`: coarsening of the prior to the two-point
+  `Features.NextMentionBias`, with `expectancy_reversed_under_voice` refuting the
+  expectancy hypothesis the substrate's `predictedForm` encodes.
 * `cb_topichood_dissociation_under_voice`: Centering's backward-looking center is
   voice-blind where `topichood` is voice-sensitive.
 
@@ -441,6 +445,47 @@ theorem eq13_active_exceeds_passive :
   norm_num [bayesianPrediction, nmActiveNoPron, nmPassiveNoPron,
     pronActiveSubj, pronActiveNonSubj, pronPassiveSubj, pronPassiveNonSubj]
 
+/-! ### Expectancy coarsening -/
+
+/-- Coarsen a next-mention rate (a percentage) to the two-point
+    `Features.NextMentionBias` by thresholding at 50%. -/
+def biasOfRate (p : ℚ) : Features.NextMentionBias :=
+  if 50 < p then .high else .low
+
+/-- The Bayesian prior coarsened to the two-point substrate bias:
+    `Features.NextMentionBias` is the sign of `sourceBias − 50`. -/
+def NextMentionModel.toBias (m : NextMentionModel) : Features.NextMentionBias :=
+  biasOfRate m.sourceBias
+
+/-- The "Why?" mixture coarsens to `.high` (Source-biased). -/
+theorem whyModel_toBias : whyModel.toBias = .high := by
+  simp only [NextMentionModel.toBias, biasOfRate, NextMentionModel.sourceBias,
+    whyModel, sharedBias, CoherenceRelation.all, List.foldl_cons, List.foldl_nil]
+  norm_num
+
+/-- The "What next?" mixture coarsens to `.low` (Goal-biased). -/
+theorem whatNextModel_toBias : whatNextModel.toBias = .low := by
+  simp only [NextMentionModel.toBias, biasOfRate, NextMentionModel.sourceBias,
+    whatNextModel, sharedBias, CoherenceRelation.all, List.foldl_cons, List.foldl_nil]
+  norm_num
+
+/-- **Expectancy refuted at the voice manipulation.** Thresholding the
+    no-pronoun next-mention rates (Table 7, passive) gives the by-phrase
+    referent a `.high` bias and the passive subject a `.low` bias, so the
+    expectancy hypothesis — encoded in the substrate as
+    `Features.NextMentionBias.predictedForm` — predicts the by-phrase
+    referent surfaces in the *more reduced* form. The observed
+    pronominalization rates (Table 9) run the other way: 23% for the
+    by-phrase vs. 87% for the subject. Production tracks topichood
+    (`topichood_monotone`), not next-mention bias. -/
+theorem expectancy_reversed_under_voice :
+    (biasOfRate nmPassiveNoPron).predictedForm.rank >
+      (biasOfRate (100 - nmPassiveNoPron)).predictedForm.rank ∧
+    pronPassiveNonSubj < pronPassiveSubj := by
+  refine ⟨?_, by norm_num [pronPassiveNonSubj, pronPassiveSubj]⟩
+  norm_num [biasOfRate, nmPassiveNoPron, Features.NextMentionBias.predictedForm,
+    Features.AccessibilityLevel.rank]
+
 /-! ### Coherence–referent bridge -/
 
 /-- The two Goal-biased CRs (Occasion, Result) both focus on what happens *after*
@@ -479,9 +524,7 @@ is invariant under voice — both `(Amanda, SUBJ) (Brittany, OBJ)` and
 `(Amanda, SUBJ) (Brittany, OTHER-by-phrase)` make Amanda the most-preferred Cf —
 yet `topichood` distinguishes them (passive subject `.strong`, active subject
 `.default_`). The voice-induced pronominalization gradient (87% vs. 62%) lives in
-the topichood signal, not the CB signal; this dissociation is the structural
-reason `RosaArnold2017.independence_violated_bridges_to_KR` finds the Independence
-Hypothesis empirically violatable. -/
+the topichood signal, not the CB signal. -/
 
 section CenteringBridge
 

--- a/Linglib/Studies/KwonLee2026.lean
+++ b/Linglib/Studies/KwonLee2026.lean
@@ -1,5 +1,8 @@
 import Mathlib.Data.Rat.Defs
 import Mathlib.Tactic.NormNum
+import Linglib.Discourse.Centering.Basic
+import Linglib.Discourse.Centering.Rule1
+import Linglib.Discourse.Centering.Instances.GrammaticalRole
 import Linglib.Features.Accessibility
 import Linglib.Studies.Ariel2001
 import Linglib.Studies.KehlerRohde2013
@@ -631,6 +634,61 @@ def koreanSubjectTopichood : KehlerRohde2013.TopichoodLevel :=
     derive from high topichood. -/
 theorem subject_default_topichood :
     koreanSubjectTopichood = .default_ := rfl
+
+-- ════════════════════════════════════════════════════
+-- § 6a. Bridge to [grosz-joshi-weinstein-1995] (Centering)
+-- ════════════════════════════════════════════════════
+
+/-! The Exp 3 null-pronoun finding (strong subject-antecedent preference)
+    is **predicted** by Centering Theory ([grosz-joshi-weinstein-1995]):
+
+    1. Subject is the highest-ranked Cf element ([kameyama-1986]).
+    2. The subject of `U_n` typically becomes the Cb of `U_{n+1}`.
+    3. By Rule 1, the Cb is preferentially realized by a pronoun.
+    4. In Korean, the highest-accessibility marker (most preferred
+       pronominal form) is the *null* pronoun ([ariel-2001]).
+
+    Composing: subject → Cb → pronoun → null in Korean. The derivation is
+    anchored on a concrete two-utterance continuation adapted from the
+    Exp 3 stimulus pattern: (a) introduces a subject-marked referent;
+    (b) refers back to it with a null pronoun. -/
+
+section CenteringBridge
+
+open Discourse.Centering
+
+/-- (a) Mary often took Tom to the sea. -/
+def uttIntro : Utterance String GrammaticalRole :=
+  ⟨[⟨"Mary", .subject, false⟩, ⟨"Tom", .object, false⟩,
+    ⟨"sea", .other, false⟩]⟩
+
+/-- (b) [pro] achieved the dream of becoming a sea navigator. Korean null
+    subject; the empty category counts as pronominal in the Centering
+    sense. -/
+def uttNullContinuation : Utterance String GrammaticalRole :=
+  ⟨[⟨"Mary", .subject, true⟩]⟩
+
+/-- Step 1: in canonical Korean SOV, the Cb of the second utterance is the
+    prior-utterance subject. -/
+theorem cb_is_prior_subject :
+    cb uttIntro uttNullContinuation = some "Mary" := by decide
+
+/-- Step 2: realizing the Cb with the null pronoun satisfies Rule 1. -/
+theorem null_realization_satisfies_rule1 :
+    Rule1GJW95 uttIntro uttNullContinuation := by decide
+
+/-- Step 3: the null pronoun is the top of the Korean-form linear order
+    (`fullNP_lt_overt`, `overt_lt_nullPro`). -/
+theorem nullPro_top_form : ∀ f : KoreanRefForm, f ≤ .nullPro := by
+  intro f; cases f <;> decide
+
+/-- **Centering predicts the null-subject preference**: combining Rule 1
+    with Korean's accessibility-scale calibration, the 71% subject bias
+    for null pronouns (Exp 3) is the predicted consequence. -/
+theorem null_subject_bias_exceeds_chance :
+    exp3_pro.subjectPercent > 50 := by decide
+
+end CenteringBridge
 
 -- ════════════════════════════════════════════════════
 -- § 6b. Alternative Theory: Position of Antecedent Hypothesis

--- a/Linglib/Studies/KwonLee2026.lean
+++ b/Linglib/Studies/KwonLee2026.lean
@@ -675,10 +675,13 @@ theorem cb_is_prior_subject :
 theorem null_realization_satisfies_rule1 :
     Rule1GJW95 uttIntro uttNullContinuation := by decide
 
-/-- Step 3: the null pronoun is the top of the Korean-form linear order
-    (`fullNP_lt_overt`, `overt_lt_nullPro`). -/
-theorem nullPro_top_form : ∀ f : KoreanRefForm, f ≤ .nullPro := by
-  intro f; cases f <;> decide
+/-- Step 3: the null pronoun is the top of the Korean-form linear order,
+    stated as an `OrderTop` instance so `le_top` is available. -/
+instance : OrderTop KoreanRefForm where
+  top := .nullPro
+  le_top f := by cases f <;> decide
+
+@[simp] theorem top_eq_nullPro : (⊤ : KoreanRefForm) = .nullPro := rfl
 
 /-- **Centering predicts the null-subject preference**: combining Rule 1
     with Korean's accessibility-scale calibration, the 71% subject bias

--- a/Linglib/Studies/KwonLee2026.lean
+++ b/Linglib/Studies/KwonLee2026.lean
@@ -29,8 +29,6 @@ inequalities. Bridges to [kehler-rohde-2013] (topichood),
 `AccessibilityAssessment` are provided.
 -/
 
-set_option autoImplicit false
-
 namespace KwonLee2026
 
 open Features

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -172,14 +172,14 @@ def nextMention_subject_pct : Nat := 54
 /-- Goals are more predictable next-mentions than sources. -/
 theorem goals_more_predictable :
     nextMention_goal.percent > (100 - nextMention_goal.percent) := by
-  native_decide
+  decide
 
 /-- Thematic role (goal: 71%) is a stronger next-mention predictor than
     grammatical role (subject: 54%). This supports the paper's core claim
     that predictability driven by thematic roles matters for production. -/
 theorem goal_bias_stronger_than_subj_bias :
     nextMention_goal.percent > nextMention_subject_pct := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 4. Key Contrasts
@@ -191,22 +191,22 @@ theorem goal_bias_stronger_than_subj_bias :
     Exp 3: 33 vs 10 (nonsubject, same-gender — strongest interaction cell). -/
 theorem exp1_goal_gt_source_subj :
     exp1_goal_subj_diff.percent > exp1_source_subj_diff.percent := by
-  native_decide
+  decide
 
 theorem exp2_goal_gt_source_nonsub :
     exp2_goal_nonsub_diff.percent > exp2_source_nonsub_diff.percent := by
-  native_decide
+  decide
 
 /-- Exp 3 strongest cell: nonsubject same-gender shows 33% vs 10%. -/
 theorem exp3_goal_gt_source_nonsub_same :
     exp3_goal_nonsub_same.percent > exp3_source_nonsub_same.percent := by
-  native_decide
+  decide
 
 /-- Subject > Nonsubject in pronoun rate (orthogonal to thematic role).
     Exp 1: 64 vs 31 for goals. -/
 theorem exp1_subj_gt_nonsub :
     exp1_goal_subj_diff.percent > exp1_goal_nonsub_diff.percent := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 5. Coherence Relation Interaction (Exp 2)
@@ -237,7 +237,7 @@ def other_interaction : CoherenceInteraction :=
 theorem coherence_amplifies_goal_bias :
     occasionResult_interaction.goalSourceBeta >
     other_interaction.goalSourceBeta := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 6. Kehler & Rohde Two-Component Model
@@ -320,12 +320,12 @@ theorem result_is_cause_effect :
 theorem pronoun_more_reduced :
     AccessibilityLevel.unstressedPron.rank >
     AccessibilityLevel.fullName.rank := by
-  native_decide
+  decide
 
 theorem pronoun_at_most_as_heavy :
     AccessibilityLevel.typicalWeight .unstressedPron ≤
     AccessibilityLevel.typicalWeight .fullName := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════
 -- § 10. Cross-Study Bridge: [arnold-wasow-losongco-ginstrom-2000]
@@ -346,7 +346,7 @@ open ArnoldEtAl2000 Constraints
 theorem goal_more_reduced_than_source :
     (transferNextMention .goal).predictedForm.rank >
     (transferNextMention .source).predictedForm.rank := by
-  native_decide
+  decide
 
 /-- [arnold-wasow-losongco-ginstrom-2000] show that heaviness and
     newness BOTH independently predict ordering. [rosa-arnold-2017]
@@ -376,7 +376,7 @@ theorem dual_path_to_ordering :
     -- Path 2 (newness) independently predicts in Arnold et al.'s MaxEnt model
     harmonyDominates con (gW 0 1)
       (newThemeContrast, .themeLast) (newThemeContrast, .goalLast) := by
-  refine ⟨by decide, by native_decide, ?_, ?_⟩
+  refine ⟨by decide, by decide, ?_, ?_⟩
   · -- Path 1: heaviness alone, goal heavier than theme → goal-last more probable
     exact heavy_goal_predicts_goalLast
   · -- Path 2: newness alone, theme new + goal given → theme-last more probable
@@ -401,8 +401,7 @@ open KehlerRohde2013
     syntactic construction.
 
     **Substrate-level explanation**:
-    `KehlerRohde2013.cb_topichood_dissociation_under_voice` (§12 of
-    `Studies/KehlerRohde2013.lean`) exhibits the
+    `KehlerRohde2013.cb_topichood_dissociation_under_voice` exhibits the
     structural reason: under Kameyama's GR ranker, Centering's `cb` is
     voice-blind, so any pronominalization gradient between active and
     passive subjects must be carried by a signal external to `cb` —
@@ -414,7 +413,7 @@ theorem independence_violated_bridges_to_KR :
     -- Rosa & Arnold: goals get more pronouns than sources (same position)
     exp1_goal_subj_diff.percent > exp1_source_subj_diff.percent := by
   refine ⟨by norm_num [pronPassiveSubj, pronActiveSubj], ?_⟩
-  native_decide
+  decide
 
 /-- K&R's Table 2 shows that Occasion and Result are Goal-biased
     (18% and 8% Source respectively). This study's Exp 2 coherence

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -60,8 +60,6 @@ dative alternation), Rosa & Arnold (2017) study **form** (pronoun vs name).
 Both are production choices along the same NP weight/reduction dimension.
 -/
 
-set_option autoImplicit false
-
 namespace RosaArnold2017
 
 open Discourse.Coherence


### PR DESCRIPTION
Audit follow-up to #1601.

- `KehlerRohde2013`: `NextMentionModel.toBias` coarsening to the two-point `Features.NextMentionBias`, plus `expectancy_reversed_under_voice` refuting the substrate-encoded expectancy hypothesis at the Table 7/9 voice dissociation; drop forward reference to RosaArnold2017.
- Chronology fix: Centering→KwonLee derivation moved from `GroszJoshiWeinstein1995` into `KwonLee2026` (§ 6a); the trivial KR2013/Ariel forward-bridges (`cpTopichood`, `cbExpectedAccessibility`) cut.
- `RosaArnold2017`: all 12 `native_decide` → kernel `decide`.
- `GroszJoshiWeinstein1995` cleansed against the CL 21(2) paper: Rule 2 sequence qualifier restored, D2 Cb rationale corrected, (20c) text completed, Discourse (16) shift-repair added.