### PR TITLE
refactor(Discourse/Accessibility): move from Features; absorb criteria

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -619,6 +619,7 @@ import Linglib.Data.WALS.Features.F98A
 import Linglib.Data.WALS.Features.F99A
 import Linglib.Data.WALS.Features.F9A
 import Linglib.Data.WALS.Languages
+import Linglib.Discourse.Accessibility
 import Linglib.Discourse.Centering.Basic
 import Linglib.Discourse.Centering.Defs
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
@@ -640,7 +641,6 @@ import Linglib.Discourse.QUD.Issue
 import Linglib.Discourse.Roles
 import Linglib.Discourse.SpeechAct
 import Linglib.Features.Acceptability
-import Linglib.Features.Accessibility
 import Linglib.Features.Agreement
 import Linglib.Features.Aktionsart
 import Linglib.Features.AnsweringSystem

--- a/Linglib/Discourse/Accessibility.lean
+++ b/Linglib/Discourse/Accessibility.lean
@@ -7,23 +7,21 @@ import Mathlib.Tactic.DeriveFintype
 
 `AccessibilityLevel`: the 18-tier Accessibility Marking Scale of [ariel-1990],
 reproduced in [ariel-2001]'s overview (least accessible `fullNameMod` to most
-accessible `zero`), with `rank` (and the `LinearOrder` it induces), the
-coarsening `toDefLevel` to `Prominence.DefinitenessLevel`, and the
+accessible `zero`), with `rank` (and the `LinearOrder` it induces), the three
+form-function criteria (`informativity`, `rigidity`, `attenuation`), the
+coarsening `toDefinitenessLevel` to `Prominence.DefinitenessLevel`, and the
 form-correlate bridge `GivennessStatus.toAccessibility`.
 
 Accessibility and definiteness are **non-monotonically** related (full
 names are less accessible than definite descriptions, yet first/last names
 are more accessible; names are also more prominent for DOM), so they are
-separate types and `toDefLevel` is many-to-one and non-monotone.
+separate types and `toDefinitenessLevel` is many-to-one and non-monotone.
 
 Sibling of `Features/Givenness.lean` (GHZ-6): this classifies *forms*,
-`GivennessStatus` classifies *entities*. Also here: `NextMentionBias` and a
-`typicalWeight` NP-weight correlate ([arnold-wasow-losongco-ginstrom-2000]).
+`GivennessStatus` classifies *entities*. Also here: `NextMentionBias`.
 -/
 
-set_option autoImplicit false
-
-namespace Features
+namespace Discourse
 
 open Features.Prominence (DefinitenessLevel)
 
@@ -99,11 +97,61 @@ instance : LinearOrder AccessibilityLevel :=
   LinearOrder.lift' AccessibilityLevel.rank
     (fun a b h => by cases a <;> cases b <;> simp_all [AccessibilityLevel.rank])
 
+/-! ### Form-function criteria -/
+
+/-- Informativity: approximate lexical content, encoded as an ordinal
+    ranking (0–4). Anti-correlated with accessibility (more informative
+    → lower rank). Values are illustrative, encoding the relative ordering
+    described in [ariel-2001], not exact content-word counts. -/
+def AccessibilityLevel.informativity : AccessibilityLevel → Nat
+  | .fullNameMod                              => 4
+  | .fullName | .longDefDescription           => 3
+  | .shortDefDescription | .distalDemMod
+  | .proxDemMod                               => 2
+  | .lastName | .firstName | .distalDemNP
+  | .proxDemNP | .distalDem | .proxDem
+  | .stressedPronGesture | .stressedPron
+  | .unstressedPron                           => 1
+  | .cliticizedPron | .verbalAgreement | .zero => 0
+
+/-- Rigidity: the ability to uniquely pick out a referent from
+    form alone, independent of context. Anti-correlated with
+    accessibility. Proper names are rigid designators; definite
+    descriptions are descriptive but context-dependent; pronouns and
+    zeros carry only person/number/gender features and are maximally
+    non-rigid. -/
+def AccessibilityLevel.rigidity : AccessibilityLevel → Nat
+  | .fullNameMod | .fullName | .lastName | .firstName  => 2
+  | .longDefDescription | .shortDefDescription
+  | .distalDemMod | .proxDemMod
+  | .distalDemNP | .proxDemNP                          => 1
+  | .distalDem | .proxDem
+  | .stressedPronGesture | .stressedPron | .unstressedPron
+  | .cliticizedPron | .verbalAgreement | .zero          => 0
+
+/-- Attenuation: degree of phonological reduction, positively correlated
+    with accessibility (0 = full, 5 = zero). Cliticized pronouns are
+    shortened free pronouns; verbal agreement inflections are bound
+    morphemes, more reduced still; zero has no phonological material
+    ([ariel-2001]). -/
+def AccessibilityLevel.attenuation : AccessibilityLevel → Nat
+  | .fullNameMod | .fullName | .longDefDescription
+  | .shortDefDescription | .lastName | .firstName
+  | .distalDemMod | .proxDemMod                     => 0
+  | .distalDemNP | .proxDemNP | .distalDem | .proxDem
+  | .stressedPronGesture | .stressedPron              => 1
+  | .unstressedPron                                   => 2
+  | .cliticizedPron                                   => 3
+  | .verbalAgreement                                  => 4
+  | .zero                                             => 5
+
+/-! ### Definiteness coarsening -/
+
 /-- Coarsening: each accessibility level maps to one of the 5
     `DefinitenessLevel` categories used for differential argument marking.
     This is a many-to-one, **non-monotone** mapping — names are less
     accessible than definite descriptions but more prominent for DOM. -/
-def AccessibilityLevel.toDefLevel : AccessibilityLevel → DefinitenessLevel
+def AccessibilityLevel.toDefinitenessLevel : AccessibilityLevel → DefinitenessLevel
   | .fullNameMod | .fullName | .lastName | .firstName  => .properName
   | .longDefDescription | .shortDefDescription
   | .distalDemMod | .proxDemMod | .distalDemNP
@@ -134,22 +182,6 @@ def NextMentionBias.predictedForm : NextMentionBias → AccessibilityLevel
   | .high => .unstressedPron
   | .low  => .fullName
 
-/-! ### Weight bridge -/
-
-/-- Approximate word count of a typical instance of each form: the NP-weight
-    correlate of reduction ([arnold-wasow-losongco-ginstrom-2000]), connecting
-    form choice to constituent ordering (heavy-NP shift). -/
-def AccessibilityLevel.typicalWeight : AccessibilityLevel → Nat
-  | .fullNameMod | .longDefDescription        => 4
-  | .distalDemMod | .proxDemMod               => 3
-  | .fullName | .shortDefDescription
-  | .distalDemNP | .proxDemNP                 => 2
-  | .lastName | .firstName
-  | .distalDem | .proxDem
-  | .stressedPronGesture | .stressedPron
-  | .unstressedPron | .cliticizedPron         => 1
-  | .verbalAgreement | .zero                  => 0
-
 /-! ### Givenness projection -/
 
 /-- Prototypical accessibility level for each givenness status. The four
@@ -161,7 +193,8 @@ def AccessibilityLevel.typicalWeight : AccessibilityLevel → Nat
     form identity. [ariel-2001] criticizes the givenness hierarchy (no
     evidence for scalar distinctions below its top statuses) rather than
     endorsing such a projection. -/
-def GivennessStatus.toAccessibility : GivennessStatus → AccessibilityLevel
+def _root_.Features.GivennessStatus.toAccessibility :
+    Features.GivennessStatus → AccessibilityLevel
   | .inFocus              => .unstressedPron
   | .activated            => .proxDem
   | .familiar             => .distalDemNP
@@ -169,4 +202,4 @@ def GivennessStatus.toAccessibility : GivennessStatus → AccessibilityLevel
   | .referential          => .longDefDescription
   | .typeIdentifiable     => .fullNameMod
 
-end Features
+end Discourse

--- a/Linglib/Studies/AhnKocabDavidson2026.lean
+++ b/Linglib/Studies/AhnKocabDavidson2026.lean
@@ -48,7 +48,7 @@ set_option autoImplicit false
 
 namespace AhnKocabDavidson2026
 
-open Features (AccessibilityLevel)
+open Discourse (AccessibilityLevel)
 open Pragmatics.GriceanMaxims
 open Pragmatics.Expressives (TwoDimProp)
 

--- a/Linglib/Studies/Ariel2001.lean
+++ b/Linglib/Studies/Ariel2001.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Accessibility
+import Linglib.Discourse.Accessibility
 import Linglib.Syntax.Category.Pronoun.Basic
 import Linglib.Features.Givenness
 
@@ -20,10 +20,10 @@ of multiple factors.
 
 ## The Accessibility Marking Scale
 
-The 18-level `AccessibilityLevel` type (defined in `Features/Accessibility.lean`)
-encodes Ariel's ordering. This study file adds the three form-function criteria
-(informativity, rigidity, attenuation), the multi-factor accessibility assessment,
-and comparisons with competing theories.
+The 18-level `AccessibilityLevel` type and its three form-function criteria
+(informativity, rigidity, attenuation) live in `Discourse/Accessibility.lean`.
+This study file adds the multi-factor accessibility assessment and
+comparisons with competing theories.
 
 ## Form-Function Criteria
 
@@ -51,74 +51,11 @@ more comprehensive than Centering Theory (which handles only the pronoun/full-NP
 distinction, not the full range of referring expressions).
 -/
 
-set_option autoImplicit false
-
--- Extend the Features namespace with study-specific form-function criteria.
--- This enables dot notation (e.g., AccessibilityLevel.zero.informativity).
-namespace Features
-
-/-- Informativity: approximate lexical content, encoded as an ordinal
-    ranking (0–4). Anti-correlated with accessibility (more informative
-    → lower rank). Values are illustrative, encoding the relative ordering
-    described in [ariel-2001] (p. 32), not exact content-word counts. -/
-def AccessibilityLevel.informativity : AccessibilityLevel → Nat
-  | .fullNameMod                              => 4
-  | .fullName | .longDefDescription           => 3
-  | .shortDefDescription | .distalDemMod
-  | .proxDemMod                               => 2
-  | .lastName | .firstName | .distalDemNP
-  | .proxDemNP | .distalDem | .proxDem
-  | .stressedPronGesture | .stressedPron
-  | .unstressedPron                           => 1
-  | .cliticizedPron | .verbalAgreement | .zero => 0
-
-/-- Rigidity: the ability to uniquely pick out a referent from
-    form alone, independent of context. Anti-correlated with
-    accessibility (more rigid → lower accessibility).
-
-    Proper names are rigid designators (Kripke): they pick out
-    the same individual regardless of context. Definite descriptions
-    are descriptive but context-dependent. Pronouns and zeros
-    carry only person/number/gender features and are maximally
-    non-rigid. -/
-def AccessibilityLevel.rigidity : AccessibilityLevel → Nat
-  | .fullNameMod | .fullName | .lastName | .firstName  => 2
-  | .longDefDescription | .shortDefDescription
-  | .distalDemMod | .proxDemMod
-  | .distalDemNP | .proxDemNP                          => 1
-  | .distalDem | .proxDem
-  | .stressedPronGesture | .stressedPron | .unstressedPron
-  | .cliticizedPron | .verbalAgreement | .zero          => 0
-
-/-- Attenuation: degree of phonological reduction.
-    Positively correlated with accessibility. 0 = full, 5 = zero.
-    Cliticized pronouns are shortened free pronouns ([ariel-2001] note 6);
-    verbal agreement inflections are bound morphemes, more reduced
-    still; zero has no phonological material. -/
-def AccessibilityLevel.attenuation : AccessibilityLevel → Nat
-  | .fullNameMod | .fullName | .longDefDescription
-  | .shortDefDescription | .lastName | .firstName
-  | .distalDemMod | .proxDemMod                     => 0
-  | .distalDemNP | .proxDemNP | .distalDem | .proxDem
-  | .stressedPronGesture | .stressedPron              => 1
-  | .unstressedPron                                   => 2
-  | .cliticizedPron                                   => 3
-  | .verbalAgreement                                  => 4
-  | .zero                                             => 5
-
-def AccessibilityLevel.all : List AccessibilityLevel :=
-  [.fullNameMod, .fullName, .longDefDescription, .shortDefDescription,
-   .lastName, .firstName, .distalDemMod, .proxDemMod,
-   .distalDemNP, .proxDemNP, .distalDem, .proxDem,
-   .stressedPronGesture, .stressedPron, .unstressedPron,
-   .cliticizedPron, .verbalAgreement, .zero]
-
-end Features
-
 namespace Ariel2001
 
 open Features.Prominence (DefinitenessLevel)
-open Features
+open Features (GivennessStatus)
+open Discourse
 
 -- ════════════════════════════════════════════════════
 -- § 1. Form-Function Criteria
@@ -182,7 +119,7 @@ def maximallyAccessible : AccessibilityAssessment := ⟨0, 2, 0, 2⟩
 def minimallyAccessible : AccessibilityAssessment := ⟨5, 0, 3, 0⟩
 
 theorem maximal_gt_minimal :
-    maximallyAccessible.score > minimallyAccessible.score := by native_decide
+    maximallyAccessible.score > minimallyAccessible.score := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 3. Non-Equivalence with DefinitenessLevel
@@ -198,8 +135,8 @@ theorem maximal_gt_minimal :
     (more informative) but more prominent (higher on the DOM hierarchy). -/
 theorem coarsening_not_monotone :
     AccessibilityLevel.fullName.rank < AccessibilityLevel.longDefDescription.rank ∧
-    AccessibilityLevel.fullName.toDefLevel.rank >
-      AccessibilityLevel.longDefDescription.toDefLevel.rank := by
+    AccessibilityLevel.fullName.toDefinitenessLevel.rank >
+      AccessibilityLevel.longDefDescription.toDefinitenessLevel.rank := by
   decide
 
 -- ════════════════════════════════════════════════════
@@ -227,24 +164,19 @@ theorem strengthToAccessibility_antitone {a b : Strength}
 
 /-- All three pronoun strengths coarsen to the same definiteness level. -/
 theorem strength_coarsening_agrees :
-    (strengthToAccessibility .strong).toDefLevel = DefinitenessLevel.personalPronoun ∧
-    (strengthToAccessibility .weak).toDefLevel = DefinitenessLevel.personalPronoun ∧
-    (strengthToAccessibility .clitic).toDefLevel = DefinitenessLevel.personalPronoun :=
+    (strengthToAccessibility .strong).toDefinitenessLevel = DefinitenessLevel.personalPronoun ∧
+    (strengthToAccessibility .weak).toDefinitenessLevel = DefinitenessLevel.personalPronoun ∧
+    (strengthToAccessibility .clitic).toDefinitenessLevel = DefinitenessLevel.personalPronoun :=
   ⟨rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 5. Givenness Hierarchy ([gundel-hedberg-zacharski-1993])
 -- ════════════════════════════════════════════════════
 
--- `GivennessStatus`, `GivennessStatus.rank`, and the Ariel-specific
--- `GivennessStatus.toAccessibility` projection were promoted to the
--- substrate layer (`Features/Givenness.lean`,
--- `Features/Accessibility.lean`) so Centering and other substrate
--- consumers can import them. The theorems below consume the promoted
--- projection.
-
-open Features.Prominence (DefinitenessLevel)
-open Features
+-- `GivennessStatus`, `GivennessStatus.rank`, and the
+-- `GivennessStatus.toAccessibility` projection live in the substrate
+-- layer (`Features/Givenness.lean`, `Discourse/Accessibility.lean`);
+-- the theorems below consume the substrate projection.
 
 /-- The Givenness→Accessibility mapping IS monotone: higher givenness
     status maps to higher or equal accessibility rank. The Givenness
@@ -255,7 +187,7 @@ theorem givenness_coarsening_monotone :
     all.all (λ a => all.all (λ b =>
       if a.rank > b.rank then
         a.toAccessibility.rank ≥ b.toAccessibility.rank
-      else true)) = true := by native_decide
+      else true)) = true := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 6. Ariel's Critique: Coarsening Loses Distinctions
@@ -270,10 +202,10 @@ theorem givenness_coarsening_monotone :
     pattern." -/
 theorem givenness_collapses_pronominal_distinctions :
     -- All four are "in focus" on the Givenness Hierarchy (all pronominal)
-    AccessibilityLevel.unstressedPron.toDefLevel = .personalPronoun ∧
-    AccessibilityLevel.cliticizedPron.toDefLevel = .personalPronoun ∧
-    AccessibilityLevel.verbalAgreement.toDefLevel = .personalPronoun ∧
-    AccessibilityLevel.zero.toDefLevel = .personalPronoun ∧
+    AccessibilityLevel.unstressedPron.toDefinitenessLevel = .personalPronoun ∧
+    AccessibilityLevel.cliticizedPron.toDefinitenessLevel = .personalPronoun ∧
+    AccessibilityLevel.verbalAgreement.toDefinitenessLevel = .personalPronoun ∧
+    AccessibilityLevel.zero.toDefinitenessLevel = .personalPronoun ∧
     -- Yet they have four distinct accessibility ranks
     AccessibilityLevel.zero.rank > AccessibilityLevel.verbalAgreement.rank ∧
     AccessibilityLevel.verbalAgreement.rank > AccessibilityLevel.cliticizedPron.rank ∧

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -4,7 +4,7 @@ import Linglib.Discourse.Coherence
 import Linglib.Data.UD.Basic
 import Linglib.Discourse.Centering.Pronominalization
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
-import Linglib.Features.Accessibility
+import Linglib.Discourse.Accessibility
 
 /-!
 # Pronoun interpretation: coherence vs. centering [kehler-rohde-2013]
@@ -26,7 +26,7 @@ experiments with transfer-of-possession and implicit-causality verbs.
   centering-driven likelihood term.
 * `bayesianPrediction`: Bayesian inversion to `P(Subject | pronoun)` (Eq. (13)).
 * `NextMentionModel.toBias`: coarsening of the prior to the two-point
-  `Features.NextMentionBias`, with `expectancy_reversed_under_voice` refuting the
+  `Discourse.NextMentionBias`, with `expectancy_reversed_under_voice` refuting the
   expectancy hypothesis the substrate's `predictedForm` encodes.
 * `cb_topichood_dissociation_under_voice`: Centering's backward-looking center is
   voice-blind where `topichood` is voice-sensitive.
@@ -448,13 +448,13 @@ theorem eq13_active_exceeds_passive :
 /-! ### Expectancy coarsening -/
 
 /-- Coarsen a next-mention rate (a percentage) to the two-point
-    `Features.NextMentionBias` by thresholding at 50%. -/
-def biasOfRate (p : ℚ) : Features.NextMentionBias :=
+    `Discourse.NextMentionBias` by thresholding at 50%. -/
+def biasOfRate (p : ℚ) : Discourse.NextMentionBias :=
   if 50 < p then .high else .low
 
 /-- The Bayesian prior coarsened to the two-point substrate bias:
-    `Features.NextMentionBias` is the sign of `sourceBias − 50`. -/
-def NextMentionModel.toBias (m : NextMentionModel) : Features.NextMentionBias :=
+    `Discourse.NextMentionBias` is the sign of `sourceBias − 50`. -/
+def NextMentionModel.toBias (m : NextMentionModel) : Discourse.NextMentionBias :=
   biasOfRate m.sourceBias
 
 /-- The "Why?" mixture coarsens to `.high` (Source-biased). -/
@@ -473,7 +473,7 @@ theorem whatNextModel_toBias : whatNextModel.toBias = .low := by
     no-pronoun next-mention rates (Table 7, passive) gives the by-phrase
     referent a `.high` bias and the passive subject a `.low` bias, so the
     expectancy hypothesis — encoded in the substrate as
-    `Features.NextMentionBias.predictedForm` — predicts the by-phrase
+    `Discourse.NextMentionBias.predictedForm` — predicts the by-phrase
     referent surfaces in the *more reduced* form. The observed
     pronominalization rates (Table 9) run the other way: 23% for the
     by-phrase vs. 87% for the subject. Production tracks topichood
@@ -483,8 +483,8 @@ theorem expectancy_reversed_under_voice :
       (biasOfRate (100 - nmPassiveNoPron)).predictedForm.rank ∧
     pronPassiveNonSubj < pronPassiveSubj := by
   refine ⟨?_, by norm_num [pronPassiveNonSubj, pronPassiveSubj]⟩
-  norm_num [biasOfRate, nmPassiveNoPron, Features.NextMentionBias.predictedForm,
-    Features.AccessibilityLevel.rank]
+  norm_num [biasOfRate, nmPassiveNoPron, Discourse.NextMentionBias.predictedForm,
+    Discourse.AccessibilityLevel.rank]
 
 /-! ### Coherence–referent bridge -/
 

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -1,7 +1,6 @@
 import Linglib.Morphology.DM.Categorizer
 import Linglib.Morphology.DM.VocabularyInsertion
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
-import Linglib.Features.Accessibility
 import Linglib.Fragments.English.Pronouns
 
 /-!

--- a/Linglib/Studies/KwonLee2026.lean
+++ b/Linglib/Studies/KwonLee2026.lean
@@ -3,7 +3,7 @@ import Mathlib.Tactic.NormNum
 import Linglib.Discourse.Centering.Basic
 import Linglib.Discourse.Centering.Pronominalization
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
-import Linglib.Features.Accessibility
+import Linglib.Discourse.Accessibility
 import Linglib.Studies.Ariel2001
 import Linglib.Studies.KehlerRohde2013
 import Linglib.Fragments.Korean.Pronouns
@@ -31,7 +31,7 @@ inequalities. Bridges to [kehler-rohde-2013] (topichood),
 
 namespace KwonLee2026
 
-open Features
+open Discourse
 
 -- ════════════════════════════════════════════════════
 -- § 1. Korean Referential Forms

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Discourse.Coherence
-import Linglib.Features.Accessibility
+import Linglib.Discourse.Accessibility
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Studies.ArnoldEtAl2000
 import Linglib.Studies.KehlerRohde2013
@@ -63,7 +63,7 @@ Both are production choices along the same NP weight/reduction dimension.
 namespace RosaArnold2017
 
 open Discourse.Coherence
-open Features
+open Discourse
 open Features.Prominence
 
 -- ════════════════════════════════════════════════════
@@ -303,6 +303,20 @@ theorem result_is_cause_effect :
 -- ════════════════════════════════════════════════════
 -- § 9. Production–Ordering Bridge
 -- ════════════════════════════════════════════════════
+
+/-- Approximate word count of a typical instance of each form: the NP-weight
+    correlate of reduction ([arnold-wasow-losongco-ginstrom-2000]), connecting
+    form choice to constituent ordering (heavy-NP shift). -/
+def _root_.Discourse.AccessibilityLevel.typicalWeight :
+    Discourse.AccessibilityLevel → Nat
+  | .fullNameMod | .longDefDescription        => 4
+  | .distalDemMod | .proxDemMod               => 3
+  | .fullName | .shortDefDescription
+  | .distalDemNP | .proxDemNP                 => 2
+  | .lastName | .firstName | .distalDem | .proxDem
+  | .stressedPronGesture | .stressedPron
+  | .unstressedPron | .cliticizedPron         => 1
+  | .verbalAgreement | .zero                  => 0
 
 /-- The same transfer verb "give" is studied for both referential form
     ([rosa-arnold-2017]) and constituent ordering

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -16625,7 +16625,7 @@
   address   = {London},
   subfield  = {semantics/reference},
   role      = {cited},
-  sources   = {Features/Accessibility.lean}
+  sources   = {Discourse/Accessibility.lean}
 }
 @incollection{ariel-2001,
   author    = {Ariel, Mira},


### PR DESCRIPTION
Final structural PR of the Accessibility audit (#1601, #1602, #1603). `Features/Accessibility.lean` → `Discourse/Accessibility.lean` (namespace `Discourse`): all consumers are discourse-anaphora, failing the Features/ cross-domain test, but 5 consuming papers clear the theory-layer bar. `informativity`/`rigidity`/`attenuation` absorbed from Ariel2001 (KwonLee2026 is a second consumer); `toDefLevel` → `toDefinitenessLevel`; single-consumer `typicalWeight` sunk into RosaArnold2017; zero-consumer `AccessibilityLevel.all` cut; KonnellyCowper2020 dead import dropped; Ariel2001's two `native_decide` → `decide`.