### PR TITLE
style(Discourse/Centering): mathlib blank-line layout

### DIFF
--- a/Linglib/Discourse/Centering/Basic.lean
+++ b/Linglib/Discourse/Centering/Basic.lean
@@ -2,45 +2,60 @@ import Linglib.Discourse.Centering.Defs
 import Mathlib.Data.List.Perm.Basic
 import Mathlib.Data.List.MinMax
 import Mathlib.Data.List.Dedup
+
 /-!
 # Centering Theory — Cb, Cf, Cp
 [grosz-joshi-weinstein-1995]
+
 Forward- and backward-looking center operations, parameterized by
 role ranker (`[CfRankerOf E R]`) and realizes-semantics (`[Realizes U E]`).
 GJW's "unique Cb" claim is enforced by `cb`'s `Option E` return type.
 -/
+
 namespace Discourse.Centering
+
 variable {E R : Type*}
+
 /-! ### Default Realizes / Pronominalizes for Utterance -/
+
 /-- For a list-of-realizations utterance, `realizes` is existence of a
     realization whose entity is the target. -/
 instance utteranceRealizes [DecidableEq E] : Realizes (Utterance E R) E where
   Rel u e := ∃ r ∈ u.realizations, r.entity = e
   decRel _ _ := inferInstance
+
 /-- For a list-of-realizations utterance, `pronominalizes` requires a
     realization of `e` whose `isPronoun` flag is true. -/
 instance utterancePronominalizes [DecidableEq E] :
     Pronominalizes (Utterance E R) E where
   Rel u e := ∃ r ∈ u.realizations, r.entity = e ∧ r.isPronoun = true
   decRel _ _ := inferInstance
+
 /-- A flat list of entities realizes by membership (minimal
     "bag of referents" representation). -/
 instance listRealizes [DecidableEq E] : Realizes (List E) E where
   Rel es e := e ∈ es
   decRel _ _ := inferInstance
+
 @[simp] theorem realizes_list_iff [DecidableEq E] (es : List E) (e : E) :
     realizes es e ↔ e ∈ es := Iff.rfl
+
 namespace Utterance
+
 variable [DecidableEq E]
+
 /-- Existential characterization of `realizes` on a list-of-realizations
     utterance. -/
 theorem realizes_iff (u : Utterance E R) (e : E) :
     realizes u e ↔ ∃ r ∈ u.realizations, r.entity = e := Iff.rfl
+
 /-- Existential characterization of `pronominalizes` on a
     list-of-realizations utterance. -/
 theorem pronominalizes_iff (u : Utterance E R) (e : E) :
     pronominalizes u e ↔ ∃ r ∈ u.realizations, r.entity = e ∧ r.isPronoun = true := Iff.rfl
+
 /-! ### Cf, Cp via insertion sort on rank -/
+
 /-- Insert `r` into a rank-descending Cf list, after any equally-ranked
     elements (surface order as stable tiebreaker). -/
 def cfInsert [CfRankerOf E R]
@@ -51,18 +66,26 @@ def cfInsert [CfRankerOf E R]
       r :: x :: xs
     else
       x :: cfInsert r xs
+
 /-- Forward-looking centers via insertion-sort by rank (decide-reducible). -/
 def cf [CfRankerOf E R] (u : Utterance E R) : List E :=
   (u.realizations.foldr cfInsert []).map (·.entity)
+
 /-- The top-ranked Cf element ("preferred center", Cp). -/
 def cp [CfRankerOf E R] (u : Utterance E R) : Option E := u.cf.head?
+
 end Utterance
+
 /-! ### cf / cp characterization API -/
+
 namespace Utterance
+
 @[simp] theorem cf_mk_nil [CfRankerOf E R] :
     (Utterance.mk [] : Utterance E R).cf = [] := rfl
+
 @[simp] theorem cp_mk_nil [CfRankerOf E R] :
     (Utterance.mk [] : Utterance E R).cp = none := rfl
+
 /-- `cfInsert` preserves membership: every element of the result is either
     the inserted element or already in the list. -/
 theorem mem_cfInsert_iff [CfRankerOf E R] (r : Realization E R)
@@ -75,6 +98,7 @@ theorem mem_cfInsert_iff [CfRankerOf E R] (r : Realization E R)
     split
     · simp
     · simp [ih, or_left_comm]
+
 /-- `cfInsert r xs` is a permutation of `r :: xs` — insertion sort
     rearranges but doesn't drop or duplicate. -/
 theorem cfInsert_perm [CfRankerOf E R] (r : Realization E R)
@@ -87,6 +111,7 @@ theorem cfInsert_perm [CfRankerOf E R] (r : Realization E R)
     split
     · exact .refl _
     · exact (List.Perm.cons y ih).trans (.swap r y ys)
+
 /-- The internal sorted list (before mapping to entities) is a
     permutation of the surface realization list. -/
 theorem cfRealizations_perm [CfRankerOf E R] (u : Utterance E R) :
@@ -96,6 +121,7 @@ theorem cfRealizations_perm [CfRankerOf E R] (u : Utterance E R) :
   | cons r rs ih =>
     show (cfInsert r (rs.foldr cfInsert [])).Perm (r :: rs)
     exact (cfInsert_perm r _).trans (List.Perm.cons r ih)
+
 /-- **Characterization of `cf`**: an entity is in the forward-looking
     centers iff some realization in the utterance refers to it. The
     insertion-sort implementation is a permutation, so membership is
@@ -109,25 +135,31 @@ theorem mem_cf_iff [CfRankerOf E R] (u : Utterance E R) (e : E) :
     exact ⟨r, (cfRealizations_perm u).mem_iff.mp hr, rfl⟩
   · rintro ⟨r, hr, rfl⟩
     exact ⟨r, (cfRealizations_perm u).mem_iff.mpr hr, rfl⟩
+
 end Utterance
+
 /-! ### Cb (backward-looking center) -/
+
 /-- Backward-looking center: the highest-ranked element of `prev.cf`
     realized in `cur`. Polymorphic in `cur`'s type via `Realizes U E`. -/
 def cb [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     (prev : Utterance E R) (cur : U) : Option E :=
   prev.cf.find? (fun e => decide (realizes cur e))
+
 /-- Locality of Cb ([grosz-joshi-weinstein-1995]): `cb prev cur`
     is always drawn from `prev.cf`, never further back. -/
 theorem cb_mem_prev_cf [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     {prev : Utterance E R} {cur : U} {e : E} (h : cb prev cur = some e) :
     e ∈ prev.cf :=
   List.mem_of_find?_eq_some h
+
 /-- The Cb is realized in the current utterance: when `cb prev cur` is
     `some e`, `realizes cur e` holds. -/
 theorem realizes_of_cb [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     {prev : Utterance E R} {cur : U} {e : E} (h : cb prev cur = some e) :
     realizes cur e :=
   decide_eq_true_eq.mp (List.find?_eq_some_iff_append.mp h).1
+
 /-- `cb prev cur = some e` iff `e ∈ prev.cf` is realized in `cur` with
     no higher-ranked element of `prev.cf` also realized in `cur`. -/
 theorem cb_eq_some_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
@@ -140,6 +172,7 @@ theorem cb_eq_some_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U 
   rw [List.find?_eq_some_iff_append]
   simp only [decide_eq_true_eq, Bool.not_eq_true_eq_eq_false, decide_eq_false_iff_not]
   tauto
+
 /-- `cb` is `none` iff no element of `prev.cf` is realized in `cur`. -/
 theorem cb_eq_none_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     {prev : Utterance E R} {cur : U} :
@@ -147,9 +180,12 @@ theorem cb_eq_none_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U 
   unfold cb
   rw [List.find?_eq_none]
   simp only [decide_eq_true_eq]
+
 @[simp] theorem cb_empty_prev [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     (cur : U) : cb (Utterance.mk [] : Utterance E R) cur = none := rfl
+
 /-! ### cbAll (multi-CB under partial ranking) -/
+
 /-- Multi-CB: entities tied at the highest rank-among-realized,
     deduplicated. Length ≤ 1 under total rankings; can exceed 1
     under partial rankings (PSDH §5.3.4). -/
@@ -163,8 +199,10 @@ def cbAll [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
                    | none => 0
                    | some top => CfRankerOf.rank top
     ((realized.filter (fun r => CfRankerOf.rank r = topRank)).map (·.entity)).dedup
+
 @[simp] theorem cbAll_empty_prev [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     (cur : U) : cbAll (Utterance.mk [] : Utterance E R) cur = [] := rfl
+
 /-- Every entity in `cbAll prev cur` corresponds to some realization
     in `prev` realized in `cur`. -/
 theorem mem_cbAll_exists_realization [DecidableEq E] [CfRankerOf E R]
@@ -181,12 +219,14 @@ theorem mem_cbAll_exists_realization [DecidableEq E] [CfRankerOf E R]
       rw [hf]; exact hr_in_filtered
     rw [List.mem_filter] at hmem
     exact ⟨r, hmem.1, hr_eq, decide_eq_true_eq.mp hmem.2⟩
+
 /-- Every entity in `cbAll prev cur` is realized in `cur`. -/
 theorem mem_cbAll_realized [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     {prev : Utterance E R} {cur : U} {e : E} (h : e ∈ cbAll prev cur) :
     realizes cur e := by
   obtain ⟨_, _, hr_eq, hr_real⟩ := mem_cbAll_exists_realization h
   exact hr_eq ▸ hr_real
+
 /-- The multi-CB set is a subset of `prev.cf` (locality for `cbAll`). -/
 theorem mem_cbAll_mem_prev_cf [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     {prev : Utterance E R} {cur : U} {e : E} (h : e ∈ cbAll prev cur) :
@@ -194,4 +234,5 @@ theorem mem_cbAll_mem_prev_cf [DecidableEq E] [CfRankerOf E R] {U : Type*} [Real
   obtain ⟨r, hr_in, hr_eq, _⟩ := mem_cbAll_exists_realization h
   rw [Utterance.mem_cf_iff]
   exact ⟨r, hr_in, hr_eq⟩
+
 end Discourse.Centering

--- a/Linglib/Discourse/Centering/Defs.lean
+++ b/Linglib/Discourse/Centering/Defs.lean
@@ -2,20 +2,26 @@ import Mathlib.Order.Basic
 import Mathlib.Order.Nat
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.DeriveFintype
+
 /-!
 # Centering Theory — Core Definitions
 [grosz-joshi-weinstein-1995] [kameyama-1986] [sidner-1979]
+
 Theory-neutral types for Centering: realizations, utterances, and
 typeclass plug-ins for ranking schemes (`CfRanker`/`CfRankerOf`),
 realization (`Realizes`), and pronominalization (`Pronominalizes`).
 Role type `R` is a parameter; `Instances/` provides per-paper rankers.
 -/
+
 namespace Discourse.Centering
+
 /-! ### Cf Ranking Plug-In -/
+
 /-- Numeric rank over a role type for ordering forward-looking centers
     (higher rank ⇒ more prominent in Cf). -/
 class CfRanker (R : Type*) where
   rank : R → Nat
+
 /-- Lift a `CfRanker` instance to a `LinearOrder`. For finite-enum role
     types, the injectivity obligation is dischargeable by `decide`. -/
 abbrev CfRanker.toLinearOrder (R : Type*) [CfRanker R]
@@ -23,29 +29,37 @@ abbrev CfRanker.toLinearOrder (R : Type*) [CfRanker R]
     (h : ∀ a b : R, CfRanker.rank a = CfRanker.rank b → a = b := by decide) :
     LinearOrder R :=
   LinearOrder.lift' CfRanker.rank h
+
 /-! ### Realization and Utterance -/
+
 /-- A noun-phrase realization: entity, role, pronoun flag. -/
 structure Realization (E : Type*) (R : Type*) where
   entity : E
   role : R
   isPronoun : Bool
   deriving Repr, DecidableEq
+
 /-- An utterance as a list of NP realizations in surface order. -/
 structure Utterance (E : Type*) (R : Type*) where
   realizations : List (Realization E R)
   deriving Repr, DecidableEq
+
 /-! ### Generalized Cf Ranking (per-realization) -/
+
 /-- Rank a full `Realization` (not just its role). Needed by rankers
     that depend on surface position (Rambow 1993) or information status
     (Strube-Hahn 1999); `CfRanker R` lifts here via `cfRankerOf_of_role`. -/
 class CfRankerOf (E : Type*) (R : Type*) where
   rank : Realization E R → Nat
+
 /-- Default lift: rank by role only via `r.role`. Low priority so
     per-realization instances win. -/
 instance (priority := low) cfRankerOf_of_role {E R : Type*} [r : CfRanker R] :
     CfRankerOf E R where
   rank rl := r.rank rl.role
+
 /-! ### Realizes / Pronominalizes Plug-Ins -/
+
 /-- "u realizes e": the entity `e` is among the referents contributed
     by `u`. `outParam E` so typeclass search infers entity type from `U`. -/
 class Realizes (U : Type*) (E : outParam (Type*)) where
@@ -53,18 +67,24 @@ class Realizes (U : Type*) (E : outParam (Type*)) where
   Rel : U → E → Prop
   /-- The relation is pointwise decidable. -/
   decRel : ∀ u e, Decidable (Rel u e)
+
 attribute [reducible, instance] Realizes.decRel
+
 /-- "u realizes e", as a `Prop`. Ergonomic alias for `Realizes.Rel`. -/
 abbrev realizes {U : Type*} {E : Type*} [Realizes U E] (u : U) (e : E) : Prop :=
   Realizes.Rel u e
+
 /-- "u pronominalizes e": some realization of `e` in `u` is pronominal. -/
 class Pronominalizes (U : Type*) (E : outParam (Type*)) where
   /-- The predicate "u pronominalizes e". -/
   Rel : U → E → Prop
   /-- The relation is pointwise decidable. -/
   decRel : ∀ u e, Decidable (Rel u e)
+
 attribute [reducible, instance] Pronominalizes.decRel
+
 /-- "u pronominalizes e", as a `Prop`. Ergonomic alias for `Pronominalizes.Rel`. -/
 abbrev pronominalizes {U : Type*} {E : Type*} [Pronominalizes U E] (u : U) (e : E) : Prop :=
   Pronominalizes.Rel u e
+
 end Discourse.Centering

--- a/Linglib/Discourse/Centering/Pronominalization.lean
+++ b/Linglib/Discourse/Centering/Pronominalization.lean
@@ -1,14 +1,17 @@
 import Linglib.Discourse.Centering.Basic
+
 /-!
 # Centering Theory — The Pronominalization Constraint
 [grosz-joshi-weinstein-1995] [gordon-grosz-gilliom-1993]
 [poesio-stevenson-eugenio-hitzeman-2004]
+
 Two variants of the constraint on realizing the backward-looking center:
 `PronominalizationConstraint` ("Rule 1" of [grosz-joshi-weinstein-1995])
 fires only when some pronoun is used; `CbPronominalized`
 ([gordon-grosz-gilliom-1993]'s unconditional strengthening, motivated by
 the repeated-name penalty) is its consequent and so implies it.
 -/
+
 namespace Discourse.Centering
 
 variable {E R U : Type*} [DecidableEq E] [CfRankerOf E R]

--- a/Linglib/Discourse/Centering/Transition.lean
+++ b/Linglib/Discourse/Centering/Transition.lean
@@ -1,9 +1,11 @@
 import Linglib.Discourse.Centering.Basic
 import Mathlib.Order.Basic
 import Mathlib.Order.Nat
+
 /-!
 # Centering Theory — Transitions
 [grosz-joshi-weinstein-1995] [strube-1998] [brennan-friedman-pollard-1987]
+
 The three transition types (continuation / retaining / shifting), their
 classification, and their preference structure: the `LinearOrder` and
 `pairRank` ("Rule 2" of [grosz-joshi-weinstein-1995], stated over
@@ -13,8 +15,11 @@ sequences) and [strube-1998]'s cheap/expensive distinction (`isCheap`).
 the segment-initial case. The [brennan-friedman-pollard-1987] 4-way
 variant lives in `Studies/PoesioEtAl2004.lean`.
 -/
+
 namespace Discourse.Centering
+
 /-! ### Transition Type -/
+
 /-- Three transition types between consecutive utterances
     ([grosz-joshi-weinstein-1995] Def 4). -/
 inductive Transition where
@@ -22,21 +27,28 @@ inductive Transition where
   | retaining
   | shifting
   deriving DecidableEq, Repr
+
 /-- Rule 2 preference order: continuation > retaining > shifting. -/
 @[simp] def Transition.rank : Transition → Nat
   | .continuation => 2
   | .retaining    => 1
   | .shifting     => 0
+
 /-- LinearOrder via rank, exposing `<`, `≤`, `max` for Rule 2 statements. -/
 instance : LinearOrder Transition :=
   LinearOrder.lift' Transition.rank
     (fun a b h => by cases a <;> cases b <;> simp_all [Transition.rank])
+
 theorem continuation_gt_retaining :
     (Transition.continuation : Transition) > .retaining := by decide
+
 theorem retaining_gt_shifting :
     (Transition.retaining : Transition) > .shifting := by decide
+
 /-! ### Strict and Extended Classification -/
+
 variable {E R : Type*}
+
 /-- Internal classifier given both Cbs: equal Cbs continue/retain
     by Cp alignment; unequal Cbs shift. -/
 private def classifyTransitionInternal [DecidableEq E]
@@ -44,6 +56,7 @@ private def classifyTransitionInternal [DecidableEq E]
   if prevCb = curCb then
     if curCp = some curCb then .continuation else .retaining
   else .shifting
+
 /-- Strict classification (faithful to GJW Def 4): returns `none` in
     the segment-initial case where the prior Cb is undefined. -/
 def classifyTransitionStrict
@@ -54,6 +67,7 @@ def classifyTransitionStrict
   | none, _      => some .shifting
   | _, none      => none  -- segment-initial: paper Def 4 is silent
   | some curCb, some pcb => some (classifyTransitionInternal curCb curCp pcb)
+
 /-- Extended classification: applies the worked-example convention
     for the segment-initial case (treats missing prior Cb as if equal
     to current Cb). -/
@@ -65,6 +79,7 @@ def classifyTransitionExtended
   | none => .shifting
   | some curCb =>
     classifyTransitionInternal curCb curCp (prevCb.getD curCb)
+
 /-- The two classifications agree whenever the strict variant is
     defined. -/
 theorem extended_eq_strict_when_defined
@@ -86,17 +101,22 @@ theorem extended_eq_strict_when_defined
   | some _, some _ =>
     simp only [hcb] at h ⊢
     exact Option.some.inj h
+
 /-! ### Transition preference -/
+
 /-- Sequence preference ("Rule 2" of [grosz-joshi-weinstein-1995])
     compares *pairs* of transitions by sum-of-ranks. -/
 def pairRank (t₁ t₂ : Transition) : Nat := t₁.rank + t₂.rank
+
 /-- A transition is *cheap* ([strube-1998]) if `CB(U_n) = CP(U_{n-1})`:
     the previous utterance's preferred center predicts the current CB. -/
 def isCheap [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
     (prev : Utterance E R) (cur : U) (prevCp : Option E) : Prop :=
   cb prev cur = prevCp ∧ (cb prev cur).isSome
+
 instance isCheap.decidable [DecidableEq E] [CfRankerOf E R] {U : Type*}
     [Realizes U E] (prev : Utterance E R) (cur : U) (prevCp : Option E) :
     Decidable (isCheap prev cur prevCp) :=
   inferInstanceAs (Decidable (cb prev cur = prevCp ∧ (cb prev cur).isSome))
+
 end Discourse.Centering


### PR DESCRIPTION
Whitespace-only: blank lines between declarations, after module docstrings/namespaces, and around section headers across the Centering substrate (Defs, Basic, Transition, Pronominalization), matching mathlib layout. Verified whitespace-only via `git diff -w`.