### PR TITLE
refactor(Discourse/Centering): cp-internal classify; discourse scan

### DIFF
--- a/Linglib/Discourse/Centering/Basic.lean
+++ b/Linglib/Discourse/Centering/Basic.lean
@@ -18,29 +18,36 @@ variable {E R : Type*}
 
 /-! ### Default Realizes / Pronominalizes for Utterance -/
 
+section Instances
+
+variable [DecidableEq E]
+
 /-- For a list-of-realizations utterance, `realizes` is existence of a
     realization whose entity is the target. -/
-instance utteranceRealizes [DecidableEq E] : Realizes (Utterance E R) E where
+instance utteranceRealizes : Realizes (Utterance E R) E where
   Rel u e := ∃ r ∈ u.realizations, r.entity = e
   decRel _ _ := inferInstance
 
 /-- For a list-of-realizations utterance, `pronominalizes` requires a
     realization of `e` whose `isPronoun` flag is true. -/
-instance utterancePronominalizes [DecidableEq E] :
-    Pronominalizes (Utterance E R) E where
+instance utterancePronominalizes : Pronominalizes (Utterance E R) E where
   Rel u e := ∃ r ∈ u.realizations, r.entity = e ∧ r.isPronoun = true
   decRel _ _ := inferInstance
 
 /-- A flat list of entities realizes by membership (minimal
     "bag of referents" representation). -/
-instance listRealizes [DecidableEq E] : Realizes (List E) E where
+instance listRealizes : Realizes (List E) E where
   Rel es e := e ∈ es
   decRel _ _ := inferInstance
 
-@[simp] theorem realizes_list_iff [DecidableEq E] (es : List E) (e : E) :
+@[simp] theorem realizes_list_iff (es : List E) (e : E) :
     realizes es e ↔ e ∈ es := Iff.rfl
 
+end Instances
+
 namespace Utterance
+
+section Realization
 
 variable [DecidableEq E]
 
@@ -54,12 +61,18 @@ theorem realizes_iff (u : Utterance E R) (e : E) :
 theorem pronominalizes_iff (u : Utterance E R) (e : E) :
     pronominalizes u e ↔ ∃ r ∈ u.realizations, r.entity = e ∧ r.isPronoun = true := Iff.rfl
 
+end Realization
+
 /-! ### Cf, Cp via insertion sort on rank -/
+
+section Cf
+
+variable [CfRankerOf E R]
 
 /-- Insert `r` into a rank-descending Cf list, after any equally-ranked
     elements (surface order as stable tiebreaker). -/
-def cfInsert [CfRankerOf E R]
-    (r : Realization E R) : List (Realization E R) → List (Realization E R)
+def cfInsert (r : Realization E R) :
+    List (Realization E R) → List (Realization E R)
   | []      => [r]
   | x :: xs =>
     if CfRankerOf.rank x < CfRankerOf.rank r then
@@ -68,27 +81,24 @@ def cfInsert [CfRankerOf E R]
       x :: cfInsert r xs
 
 /-- Forward-looking centers via insertion-sort by rank (decide-reducible). -/
-def cf [CfRankerOf E R] (u : Utterance E R) : List E :=
+def cf (u : Utterance E R) : List E :=
   (u.realizations.foldr cfInsert []).map (·.entity)
 
 /-- The top-ranked Cf element ("preferred center", Cp). -/
-def cp [CfRankerOf E R] (u : Utterance E R) : Option E := u.cf.head?
+def cp (u : Utterance E R) : Option E := u.cf.head?
 
-end Utterance
+@[simp] theorem cf_mk_nil : (Utterance.mk [] : Utterance E R).cf = [] := rfl
 
-/-! ### cf / cp characterization API -/
+@[simp] theorem cp_mk_nil : (Utterance.mk [] : Utterance E R).cp = none := rfl
 
-namespace Utterance
-
-@[simp] theorem cf_mk_nil [CfRankerOf E R] :
-    (Utterance.mk [] : Utterance E R).cf = [] := rfl
-
-@[simp] theorem cp_mk_nil [CfRankerOf E R] :
-    (Utterance.mk [] : Utterance E R).cp = none := rfl
+/-- The preferred center, when defined, is a forward-looking center. -/
+theorem cp_mem_cf {u : Utterance E R} {e : E} (h : u.cp = some e) :
+    e ∈ u.cf :=
+  List.mem_of_mem_head? (Option.mem_def.mpr h)
 
 /-- `cfInsert` preserves membership: every element of the result is either
     the inserted element or already in the list. -/
-theorem mem_cfInsert_iff [CfRankerOf E R] (r : Realization E R)
+theorem mem_cfInsert_iff (r : Realization E R)
     (xs : List (Realization E R)) (x : Realization E R) :
     x ∈ cfInsert r xs ↔ x = r ∨ x ∈ xs := by
   induction xs with
@@ -101,7 +111,7 @@ theorem mem_cfInsert_iff [CfRankerOf E R] (r : Realization E R)
 
 /-- `cfInsert r xs` is a permutation of `r :: xs` — insertion sort
     rearranges but doesn't drop or duplicate. -/
-theorem cfInsert_perm [CfRankerOf E R] (r : Realization E R)
+theorem cfInsert_perm (r : Realization E R)
     (xs : List (Realization E R)) :
     (cfInsert r xs).Perm (r :: xs) := by
   induction xs with
@@ -114,7 +124,7 @@ theorem cfInsert_perm [CfRankerOf E R] (r : Realization E R)
 
 /-- The internal sorted list (before mapping to entities) is a
     permutation of the surface realization list. -/
-theorem cfRealizations_perm [CfRankerOf E R] (u : Utterance E R) :
+theorem cfRealizations_perm (u : Utterance E R) :
     (u.realizations.foldr cfInsert []).Perm u.realizations := by
   induction u.realizations with
   | nil => exact .refl _
@@ -126,7 +136,7 @@ theorem cfRealizations_perm [CfRankerOf E R] (u : Utterance E R) :
     centers iff some realization in the utterance refers to it. The
     insertion-sort implementation is a permutation, so membership is
     preserved. -/
-theorem mem_cf_iff [CfRankerOf E R] (u : Utterance E R) (e : E) :
+theorem mem_cf_iff (u : Utterance E R) (e : E) :
     e ∈ u.cf ↔ ∃ r ∈ u.realizations, r.entity = e := by
   unfold cf
   rw [List.mem_map]
@@ -136,34 +146,36 @@ theorem mem_cf_iff [CfRankerOf E R] (u : Utterance E R) (e : E) :
   · rintro ⟨r, hr, rfl⟩
     exact ⟨r, (cfRealizations_perm u).mem_iff.mpr hr, rfl⟩
 
+end Cf
+
 end Utterance
 
 /-! ### Cb (backward-looking center) -/
 
+section Cb
+
+variable [CfRankerOf E R] {U : Type*} [Realizes U E]
+
 /-- Backward-looking center: the highest-ranked element of `prev.cf`
     realized in `cur`. Polymorphic in `cur`'s type via `Realizes U E`. -/
-def cb [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) : Option E :=
+def cb (prev : Utterance E R) (cur : U) : Option E :=
   prev.cf.find? (fun e => decide (realizes cur e))
+
+variable {prev : Utterance E R} {cur : U} {e : E}
 
 /-- Locality of Cb ([grosz-joshi-weinstein-1995]): `cb prev cur`
     is always drawn from `prev.cf`, never further back. -/
-theorem cb_mem_prev_cf [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} {e : E} (h : cb prev cur = some e) :
-    e ∈ prev.cf :=
+theorem cb_mem_prev_cf (h : cb prev cur = some e) : e ∈ prev.cf :=
   List.mem_of_find?_eq_some h
 
 /-- The Cb is realized in the current utterance: when `cb prev cur` is
     `some e`, `realizes cur e` holds. -/
-theorem realizes_of_cb [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} {e : E} (h : cb prev cur = some e) :
-    realizes cur e :=
+theorem realizes_of_cb (h : cb prev cur = some e) : realizes cur e :=
   decide_eq_true_eq.mp (List.find?_eq_some_iff_append.mp h).1
 
 /-- `cb prev cur = some e` iff `e ∈ prev.cf` is realized in `cur` with
     no higher-ranked element of `prev.cf` also realized in `cur`. -/
-theorem cb_eq_some_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} {e : E} :
+theorem cb_eq_some_iff :
     cb prev cur = some e ↔
       ∃ l₁ l₂, prev.cf = l₁ ++ e :: l₂ ∧
         (∀ e' ∈ l₁, ¬ realizes cur e') ∧
@@ -174,65 +186,55 @@ theorem cb_eq_some_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U 
   tauto
 
 /-- `cb` is `none` iff no element of `prev.cf` is realized in `cur`. -/
-theorem cb_eq_none_iff [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} :
+theorem cb_eq_none_iff :
     cb prev cur = none ↔ ∀ e ∈ prev.cf, ¬ realizes cur e := by
   unfold cb
   rw [List.find?_eq_none]
   simp only [decide_eq_true_eq]
 
-@[simp] theorem cb_empty_prev [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (cur : U) : cb (Utterance.mk [] : Utterance E R) cur = none := rfl
+@[simp] theorem cb_empty_prev (u : U) :
+    cb (Utterance.mk [] : Utterance E R) u = none := rfl
 
 /-! ### cbAll (multi-CB under partial ranking) -/
+
+variable [DecidableEq E]
 
 /-- Multi-CB: entities tied at the highest rank-among-realized,
     deduplicated. Length ≤ 1 under total rankings; can exceed 1
     under partial rankings (PSDH §5.3.4). -/
-def cbAll [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) : List E :=
+def cbAll (prev : Utterance E R) (cur : U) : List E :=
   let realized := prev.realizations.filter (fun r => decide (realizes cur r.entity))
-  match realized with
-  | [] => []
-  | _ :: _ =>
-    let topRank := match realized.argmax (fun r => CfRankerOf.rank r) with
-                   | none => 0
-                   | some top => CfRankerOf.rank top
-    ((realized.filter (fun r => CfRankerOf.rank r = topRank)).map (·.entity)).dedup
+  match realized.argmax (fun r => CfRankerOf.rank r) with
+  | none => []
+  | some top =>
+    ((realized.filter (fun r => CfRankerOf.rank r = CfRankerOf.rank top)).map
+      (·.entity)).dedup
 
-@[simp] theorem cbAll_empty_prev [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (cur : U) : cbAll (Utterance.mk [] : Utterance E R) cur = [] := rfl
+@[simp] theorem cbAll_empty_prev (u : U) :
+    cbAll (Utterance.mk [] : Utterance E R) u = [] := rfl
 
 /-- Every entity in `cbAll prev cur` corresponds to some realization
     in `prev` realized in `cur`. -/
-theorem mem_cbAll_exists_realization [DecidableEq E] [CfRankerOf E R]
-    {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} {e : E} (h : e ∈ cbAll prev cur) :
+theorem mem_cbAll_exists_realization (h : e ∈ cbAll prev cur) :
     ∃ r ∈ prev.realizations, r.entity = e ∧ realizes cur r.entity := by
-  unfold cbAll at h
-  cases hf : prev.realizations.filter (fun r => decide (realizes cur r.entity)) with
-  | nil => simp [hf] at h
-  | cons head tail =>
-    simp only [hf, List.mem_dedup, List.mem_map, List.mem_filter] at h
-    obtain ⟨r, ⟨hr_in_filtered, _⟩, hr_eq⟩ := h
-    have hmem : r ∈ prev.realizations.filter (fun r => decide (realizes cur r.entity)) := by
-      rw [hf]; exact hr_in_filtered
-    rw [List.mem_filter] at hmem
-    exact ⟨r, hmem.1, hr_eq, decide_eq_true_eq.mp hmem.2⟩
+  simp only [cbAll] at h
+  split at h
+  · simp at h
+  · simp only [List.mem_dedup, List.mem_map, List.mem_filter] at h
+    obtain ⟨r, ⟨⟨hr_mem, hr_real⟩, _⟩, hr_eq⟩ := h
+    exact ⟨r, hr_mem, hr_eq, decide_eq_true_eq.mp hr_real⟩
 
 /-- Every entity in `cbAll prev cur` is realized in `cur`. -/
-theorem mem_cbAll_realized [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} {e : E} (h : e ∈ cbAll prev cur) :
-    realizes cur e := by
+theorem mem_cbAll_realized (h : e ∈ cbAll prev cur) : realizes cur e := by
   obtain ⟨_, _, hr_eq, hr_real⟩ := mem_cbAll_exists_realization h
   exact hr_eq ▸ hr_real
 
 /-- The multi-CB set is a subset of `prev.cf` (locality for `cbAll`). -/
-theorem mem_cbAll_mem_prev_cf [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    {prev : Utterance E R} {cur : U} {e : E} (h : e ∈ cbAll prev cur) :
-    e ∈ prev.cf := by
+theorem mem_cbAll_mem_prev_cf (h : e ∈ cbAll prev cur) : e ∈ prev.cf := by
   obtain ⟨r, hr_in, hr_eq, _⟩ := mem_cbAll_exists_realization h
   rw [Utterance.mem_cf_iff]
   exact ⟨r, hr_in, hr_eq⟩
+
+end Cb
 
 end Discourse.Centering

--- a/Linglib/Discourse/Centering/Pronominalization.lean
+++ b/Linglib/Discourse/Centering/Pronominalization.lean
@@ -14,8 +14,7 @@ the repeated-name penalty) is its consequent and so implies it.
 
 namespace Discourse.Centering
 
-variable {E R U : Type*} [DecidableEq E] [CfRankerOf E R]
-  [Realizes U E] [Pronominalizes U E]
+variable {E R U : Type*} [CfRankerOf E R] [Realizes U E] [Pronominalizes U E]
 
 /-- The backward-looking center of `cur` (after `prev`), if defined, is
     realized by a pronoun — [gordon-grosz-gilliom-1993]'s unconditional

--- a/Linglib/Discourse/Centering/Transition.lean
+++ b/Linglib/Discourse/Centering/Transition.lean
@@ -7,7 +7,8 @@ import Mathlib.Order.Nat
 [grosz-joshi-weinstein-1995] [strube-1998] [brennan-friedman-pollard-1987]
 
 The three transition types (continuation / retaining / shifting), their
-classification, and their preference structure: the `LinearOrder` and
+classification, the discourse-level scan (`transitions`, `cbs`,
+`coherenceScore`), and their preference structure: the `LinearOrder` and
 `pairRank` ("Rule 2" of [grosz-joshi-weinstein-1995], stated over
 sequences) and [strube-1998]'s cheap/expensive distinction (`isCheap`).
 `classifyTransitionStrict` is faithful to GJW Def 4;
@@ -47,47 +48,43 @@ theorem retaining_gt_shifting :
 
 /-! ### Strict and Extended Classification -/
 
-variable {E R : Type*}
+variable {E R : Type*} [DecidableEq E]
 
 /-- Internal classifier given both Cbs: equal Cbs continue/retain
     by Cp alignment; unequal Cbs shift. -/
-private def classifyTransitionInternal [DecidableEq E]
+private def classifyTransitionInternal
     (curCb : E) (curCp : Option E) (prevCb : E) : Transition :=
   if prevCb = curCb then
     if curCp = some curCb then .continuation else .retaining
   else .shifting
 
+variable [CfRankerOf E R]
+
 /-- Strict classification (faithful to GJW Def 4): returns `none` in
     the segment-initial case where the prior Cb is undefined. -/
 def classifyTransitionStrict
-    [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) (curCp : Option E)
-    (prevCb : Option E) : Option Transition :=
+    (prev cur : Utterance E R) (prevCb : Option E) : Option Transition :=
   match cb prev cur, prevCb with
   | none, _      => some .shifting
   | _, none      => none  -- segment-initial: paper Def 4 is silent
-  | some curCb, some pcb => some (classifyTransitionInternal curCb curCp pcb)
+  | some curCb, some pcb => some (classifyTransitionInternal curCb cur.cp pcb)
 
 /-- Extended classification: applies the worked-example convention
     for the segment-initial case (treats missing prior Cb as if equal
     to current Cb). -/
 def classifyTransitionExtended
-    [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) (curCp : Option E)
-    (prevCb : Option E) : Transition :=
+    (prev cur : Utterance E R) (prevCb : Option E) : Transition :=
   match cb prev cur with
   | none => .shifting
   | some curCb =>
-    classifyTransitionInternal curCb curCp (prevCb.getD curCb)
+    classifyTransitionInternal curCb cur.cp (prevCb.getD curCb)
 
 /-- The two classifications agree whenever the strict variant is
     defined. -/
 theorem extended_eq_strict_when_defined
-    [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) (curCp : Option E)
-    (prevCb : Option E) (t : Transition)
-    (h : classifyTransitionStrict prev cur curCp prevCb = some t) :
-    classifyTransitionExtended prev cur curCp prevCb = t := by
+    (prev cur : Utterance E R) (prevCb : Option E) (t : Transition)
+    (h : classifyTransitionStrict prev cur prevCb = some t) :
+    classifyTransitionExtended prev cur prevCb = t := by
   unfold classifyTransitionStrict at h
   unfold classifyTransitionExtended
   match hcb : cb prev cur, prevCb with
@@ -102,6 +99,31 @@ theorem extended_eq_strict_when_defined
     simp only [hcb] at h ⊢
     exact Option.some.inj h
 
+/-! ### Discourse-level scan -/
+
+/-- The backward-looking center of each adjacent pair along a discourse. -/
+def cbs : List (Utterance E R) → List (Option E)
+  | u₁ :: u₂ :: rest => cb u₁ u₂ :: cbs (u₂ :: rest)
+  | _ => []
+
+/-- Transition sequence along a discourse from a given prior Cb, threading
+    each pair's Cb as the next pair's prior Cb. -/
+def transitionsFrom (prevCb : Option E) :
+    List (Utterance E R) → List Transition
+  | u₁ :: u₂ :: rest =>
+      classifyTransitionExtended u₁ u₂ prevCb :: transitionsFrom (cb u₁ u₂) (u₂ :: rest)
+  | _ => []
+
+/-- Transition sequence of a discourse segment (segment-initial prior Cb
+    undefined). -/
+def transitions (d : List (Utterance E R)) : List Transition :=
+  transitionsFrom none d
+
+/-- Sum-of-ranks coherence measure over a discourse's transition sequence —
+    the sequence form of "Rule 2" ([grosz-joshi-weinstein-1995]). -/
+def coherenceScore (d : List (Utterance E R)) : Nat :=
+  ((transitions d).map Transition.rank).sum
+
 /-! ### Transition preference -/
 
 /-- Sequence preference ("Rule 2" of [grosz-joshi-weinstein-1995])
@@ -110,12 +132,12 @@ def pairRank (t₁ t₂ : Transition) : Nat := t₁.rank + t₂.rank
 
 /-- A transition is *cheap* ([strube-1998]) if `CB(U_n) = CP(U_{n-1})`:
     the previous utterance's preferred center predicts the current CB. -/
-def isCheap [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
+def isCheap {U : Type*} [Realizes U E]
     (prev : Utterance E R) (cur : U) (prevCp : Option E) : Prop :=
   cb prev cur = prevCp ∧ (cb prev cur).isSome
 
-instance isCheap.decidable [DecidableEq E] [CfRankerOf E R] {U : Type*}
-    [Realizes U E] (prev : Utterance E R) (cur : U) (prevCp : Option E) :
+instance isCheap.decidable {U : Type*} [Realizes U E]
+    (prev : Utterance E R) (cur : U) (prevCp : Option E) :
     Decidable (isCheap prev cur prevCp) :=
   inferInstanceAs (Decidable (cb prev cur = prevCp ∧ (cb prev cur).isSome))
 

--- a/Linglib/Studies/GroszJoshiWeinstein1995.lean
+++ b/Linglib/Studies/GroszJoshiWeinstein1995.lean
@@ -86,64 +86,43 @@ def d : Utt :=
 
 end D2
 
-/-! ### Per-pair transition predictions
+/-! ### Transition predictions
 
-    For each adjacent pair, the Cb (computed from the prior utterance)
-    and the transition type follow from the substrate definitions. -/
+    The Cb and transition sequences of both discourses follow from the
+    substrate's discourse-level scan. -/
 
-/-- Discourse 1 (a→b): John continues as Cb. -/
-theorem d1_a_to_b_cb : cb D1.a D1.b = some "John" := by decide
+/-- Discourse 1: John is the Cb throughout. -/
+theorem d1_cbs :
+    cbs [D1.a, D1.b, D1.c, D1.d] = [some "John", some "John", some "John"] := by
+  decide
 
-theorem d1_a_to_b_continuation :
-    classifyTransitionExtended D1.a D1.b D1.b.cp none = .continuation := by decide
+/-- Discourse 1 is all continuations. -/
+theorem d1_transitions :
+    transitions [D1.a, D1.b, D1.c, D1.d] =
+      [.continuation, .continuation, .continuation] := by decide
 
-/-- Discourse 1 (b→c): John continues. -/
-theorem d1_b_to_c_continuation :
-    classifyTransitionExtended D1.b D1.c D1.c.cp (cb D1.a D1.b) = .continuation := by decide
+/-- Discourse 2: the Cb is also John throughout. At (a→b), both John and
+    the store are realized in `D2.b` and John outranks the store in
+    `Cf(D2.a)` (subject > object). -/
+theorem d2_cbs :
+    cbs [D2.a, D2.b, D2.c, D2.d] = [some "John", some "John", some "John"] := by
+  decide
 
-/-- Discourse 1 (c→d): John continues. -/
-theorem d1_c_to_d_continuation :
-    classifyTransitionExtended D1.c D1.d D1.d.cp (cb D1.b D1.c) = .continuation := by decide
+/-- Discourse 2 is `retain, continue, retain`: at (a→b) and (c→d) the
+    store is `Cp` while John stays Cb. (The paper's prose describes the
+    flips informally as changes of "aboutness"; under the formal
+    definitions the Cb remains John throughout, and the incoherence
+    surfaces as retains rather than shifts.) -/
+theorem d2_transitions :
+    transitions [D2.a, D2.b, D2.c, D2.d] =
+      [.retaining, .continuation, .retaining] := by decide
 
-/-- Discourse 2 (a→b): both John and the store are realized in `D2.b`,
-    and John outranks the store in `Cf(D2.a)` (subject > object), so the
-    Cb is John; but `Cp(D2.b) = "store"` (not John), so this is a
-    *retain* — already a less coherent transition than Discourse 1's
-    continuation. -/
-theorem d2_a_to_b_cb : cb D2.a D2.b = some "John" := by decide
-
-theorem d2_a_to_b_retaining :
-    classifyTransitionExtended D2.a D2.b D2.b.cp none = .retaining := by decide
-
-/-- Discourse 2 (b→c): John re-emerges as Cb (it was object in D2.b);
-    in D2.c, John is also `Cp` — so this would be a continuation.
-    Rule 1 is also fine here. -/
-theorem d2_b_to_c_cb : cb D2.b D2.c = some "John" := by decide
-
-theorem d2_b_to_c_continuation :
-    classifyTransitionExtended D2.b D2.c D2.c.cp (cb D2.a D2.b) = .continuation := by decide
-
-/-- Discourse 2 (c→d): John remains Cb (was subject in D2.c, object
-    in D2.d), but `Cp(D2.d) = "store"`. RETAIN, not continuation. -/
-theorem d2_c_to_d_retaining :
-    classifyTransitionExtended D2.c D2.d D2.d.cp (cb D2.b D2.c) = .retaining := by decide
-
-/-- **The coherence contrast (paper §2)**: Discourse 1's transition
-    pattern is all continuations; Discourse 2's pattern is
-    `retain, continue, retain` — a mix of weaker transitions. The sum
-    of `Transition.rank`s is a coarse but theory-aligned coherence
-    measure. (The paper's prose describes Discourse 2's flips
-    informally as changes of "aboutness"; under the formal definitions
-    the Cb remains John throughout, and the incoherence surfaces as
-    retains rather than shifts.) -/
-def d1_score : Nat :=
-  Transition.continuation.rank + Transition.continuation.rank
-    + Transition.continuation.rank
-def d2_score : Nat :=
-  Transition.retaining.rank + Transition.continuation.rank
-    + Transition.retaining.rank
-
-theorem discourse1_more_coherent_than_discourse2 : d1_score > d2_score := by decide
+/-- **The coherence contrast (paper §2)**: Discourse 1's all-continuation
+    sequence outscores Discourse 2's mixed sequence under the
+    sum-of-ranks measure (the sequence form of Rule 2). -/
+theorem discourse1_more_coherent_than_discourse2 :
+    coherenceScore [D1.a, D1.b, D1.c, D1.d] >
+      coherenceScore [D2.a, D2.b, D2.c, D2.d] := by decide
 
 /-! ### Discourses (15)-(16): Rule 1 violation and shift repair (paper §7) -/
 
@@ -204,14 +183,15 @@ def d : Utt :=
 
 end D16
 
-/-- The intervening (16c) shifts the center from John to Mike. -/
-theorem d16_b_to_c_cb : cb D16.b D16.c = some "Mike" := by decide
+/-- The intervening (16c) shifts the center from John to Mike, who then
+    stays Cb through (16d). -/
+theorem d16_cbs :
+    cbs [D16.a, D16.b, D16.c, D16.d] =
+      [some "John", some "Mike", some "Mike"] := by decide
 
-theorem d16_b_to_c_shifting :
-    classifyTransitionExtended D16.b D16.c D16.c.cp (cb D16.a D16.b) = .shifting := by
-  decide
-
-theorem d16_c_to_d_cb : cb D16.c D16.d = some "Mike" := by decide
+theorem d16_transitions :
+    transitions [D16.a, D16.b, D16.c, D16.d] =
+      [.continuation, .shifting, .continuation] := by decide
 
 /-- After the shift, (16d)'s pronoun realizes the new Cb Mike — Rule 1
     is satisfied exactly where (15c) violated it. -/
@@ -323,16 +303,11 @@ def e : Utt :=
 
 end D20
 
-/-- The paper-stipulated transition labels b→c, c→d, d→e:
-    CONTINUE, RETAIN, SHIFT. -/
-theorem discourse20_b_to_c_continuation :
-    classifyTransitionExtended D20.b D20.c D20.c.cp (cb D20.a D20.b) = .continuation := by decide
-
-theorem discourse20_c_to_d_retaining :
-    classifyTransitionExtended D20.c D20.d D20.d.cp (cb D20.b D20.c) = .retaining := by decide
-
-theorem discourse20_d_to_e_shifting :
-    classifyTransitionExtended D20.d D20.e D20.e.cp (cb D20.c D20.d) = .shifting := by decide
+/-- The paper-annotated transition labels b→c, c→d, d→e — CONTINUE,
+    RETAIN, SHIFT — preceded by an unannotated a→b continuation. -/
+theorem discourse20_transitions :
+    transitions [D20.a, D20.b, D20.c, D20.d, D20.e] =
+      [.continuation, .continuation, .retaining, .shifting] := by decide
 
 /-- Rule 1 holds throughout Discourse 20 (the paper's claim). -/
 theorem discourse20_rule1_a_b : PronominalizationConstraint D20.a D20.b := by decide
@@ -408,13 +383,13 @@ theorem d34_cb_c_carl : cb D34.b D34.c_he_is_carl = some "Carl" := by decide
 /-- Jeff-resolution: Cb stable (Jeff → Jeff), but the matrix "I"
     becomes the new Cp, so this is a RETAIN, not a CONTINUE. -/
 theorem d34_jeff_retaining :
-    classifyTransitionExtended D34.b D34.c_he_is_jeff D34.c_he_is_jeff.cp
-      (cb D34.a D34.b) = .retaining := by decide
+    classifyTransitionExtended D34.b D34.c_he_is_jeff (cb D34.a D34.b) =
+      .retaining := by decide
 
 /-- Carl-resolution: Cb shifts from Jeff to Carl. -/
 theorem d34_carl_shift :
-    classifyTransitionExtended D34.b D34.c_he_is_carl D34.c_he_is_carl.cp
-      (cb D34.a D34.b) = .shifting := by decide
+    classifyTransitionExtended D34.b D34.c_he_is_carl (cb D34.a D34.b) =
+      .shifting := by decide
 
 /-- **GJW prediction for (34c)**: by Rule 2 (RETAIN outranks SHIFT
     here), the Jeff-resolution is preferred. Returns `Option String`:
@@ -432,10 +407,8 @@ theorem d34_carl_shift :
     1995 as published. The headline disagreement theorem is honest
     about this gap — see its docstring. -/
 def gjwPredictedHe : Option String :=
-  let jeffTrans := classifyTransitionExtended D34.b D34.c_he_is_jeff
-                     D34.c_he_is_jeff.cp (cb D34.a D34.b)
-  let carlTrans := classifyTransitionExtended D34.b D34.c_he_is_carl
-                     D34.c_he_is_carl.cp (cb D34.a D34.b)
+  let jeffTrans := classifyTransitionExtended D34.b D34.c_he_is_jeff (cb D34.a D34.b)
+  let carlTrans := classifyTransitionExtended D34.b D34.c_he_is_carl (cb D34.a D34.b)
   if jeffTrans.rank > carlTrans.rank then some "Jeff"
   else if carlTrans.rank > jeffTrans.rank then some "Carl"
   else none

--- a/Linglib/Studies/Sidner1983.lean
+++ b/Linglib/Studies/Sidner1983.lean
@@ -117,7 +117,7 @@ inductive SentenceForm where
 /-- A noun-phrase slot in a sentence. Carries the entity, its
     thematic position, its syntactic position (agent or non-agent),
     and whether the surface form is pronominal. -/
-structure Phrase (E : Type) where
+structure Phrase (E : Type*) where
   entity : E
   thematic : ThematicSlot
   position : Position
@@ -128,7 +128,7 @@ structure Phrase (E : Type) where
     The simplification mirrors the GJW substrate's
     `Discourse.Centering.Utterance`: we elide the syntactic tree and
     keep the slots that the focusing algorithm actually consults. -/
-structure Sentence (E : Type) where
+structure Sentence (E : Type*) where
   form : SentenceForm
   phrases : List (Phrase E)
   deriving Repr
@@ -148,7 +148,7 @@ structure Sentence (E : Type) where
     The two slots are *independently* updated and queried — this is
     the architectural point that distinguishes Sidner from
     [grosz-joshi-weinstein-1995]'s single-Cb account. -/
-structure FocusState (E : Type) where
+structure FocusState (E : Type*) where
   discourseFocus : Option E
   actorFocus : Option E
   deriving Repr, DecidableEq
@@ -156,7 +156,7 @@ structure FocusState (E : Type) where
 namespace FocusState
 
 /-- The empty focus state, used as the discourse-initial state. -/
-def empty {E : Type} : FocusState E := ⟨none, none⟩
+def empty {E : Type*} : FocusState E := ⟨none, none⟩
 
 end FocusState
 
@@ -172,7 +172,7 @@ end FocusState
     * Otherwise: the phrase with minimal DEF rank
       (`theme > other-non-agent > agent > verbPhrase`). Implemented
       via `List.argmin` from mathlib. -/
-def expectedDiscourseFocus {E : Type} (s : Sentence E) : Option E :=
+def expectedDiscourseFocus {E : Type*} (s : Sentence E) : Option E :=
   match s.form with
   | .isaOrThereInsertion =>
     (s.phrases.find? (fun p => p.position = .agent)).map (·.entity)
@@ -184,7 +184,7 @@ def expectedDiscourseFocus {E : Type} (s : Sentence E) : Option E :=
     realizing `e`, and `p`'s thematic rank is at most every other
     phrase's. (The "at most" — vs. "less than" — is `argmin`'s
     tie-breaking convention: ties are resolved by surface order.) -/
-theorem expectedDiscourseFocus_normal_le {E : Type}
+theorem expectedDiscourseFocus_normal_le {E : Type*}
     {s : Sentence E} {e : E} (hform : s.form = .normal)
     (h : expectedDiscourseFocus s = some e) :
     ∃ p ∈ s.phrases, p.entity = e ∧
@@ -199,7 +199,7 @@ theorem expectedDiscourseFocus_normal_le {E : Type}
 /-- The expected actor focus, by the analogous algorithm to the
     discourse-focus one but selecting the agent ([sidner-1983]
     §5.2.3 p. 287, second algorithm sketch). -/
-def expectedActorFocus {E : Type} (s : Sentence E) : Option E :=
+def expectedActorFocus {E : Type*} (s : Sentence E) : Option E :=
   (s.phrases.find? (fun p => p.position = .agent)).map (·.entity)
 
 /-- Update the focus state after a sentence. The discourse focus moves
@@ -211,7 +211,7 @@ def expectedActorFocus {E : Type} (s : Sentence E) : Option E :=
     ([sidner-1983] §5.2.6 pp. 292-294). It captures the
     discourse-initial step and the basic "movement on each new
     sentence" pattern, sufficient for the (34) example. -/
-def updateState {E : Type} (state : FocusState E) (s : Sentence E) :
+def updateState {E : Type*} (state : FocusState E) (s : Sentence E) :
     FocusState E :=
   { discourseFocus := (expectedDiscourseFocus s).orElse (fun _ => state.discourseFocus)
     actorFocus := (expectedActorFocus s).orElse (fun _ => state.actorFocus) }
@@ -233,7 +233,7 @@ def updateState {E : Type} (state : FocusState E) (s : Sentence E) :
     discourse focus. The function takes a `Position` directly (the
     pronoun's syntactic slot) rather than a full `Phrase`, since the
     pronoun's putative entity is exactly the answer being computed. -/
-def resolvePronounAt {E : Type} (state : FocusState E) (pos : Position) :
+def resolvePronounAt {E : Type*} (state : FocusState E) (pos : Position) :
     Option E :=
   match pos with
   | .agent => state.actorFocus


### PR DESCRIPTION
Centering audit PR C. `classifyTransitionStrict`/`Extended` specialize `cur` to `Utterance E R` and compute `cur.cp` internally (the `{U} [Realizes U E]` polymorphism was illusory — `cp` is an `Utterance` operation; every call site passed `cur.cp`). New discourse-level scan `cbs`/`transitions`/`coherenceScore` threads the prior Cb, collapsing GJW1995's 12 hand-threaded per-pair theorems into one `cbs` + one `transitions` theorem per discourse and deriving the coherence contrast from the fold. Also: signatures lifted to scoped `variable` blocks, which exposed that `cb` never needed `[DecidableEq E]` (dropped there and in Pronominalization); `cp_mem_cf` lemma added; `cbAll` dead argmax branch removed; Sidner1983 `Type` → `Type*`.