### PR TITLE
refactor(Studies/Kennedy1999): promote extent algebra, JSON-ground data

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2926,3 +2926,4 @@ import Linglib.Syntax.WordGrammar.Inheritance.Default
 import Linglib.Syntax.WordGrammar.Inheritance.Order
 import Linglib.Syntax.WordGrammar.LexicalRules
 import Linglib.Syntax.WordGrammar.Network
+import Linglib.Data.Examples.Kennedy1999

--- a/Linglib/Data/Examples/Kennedy1999.json
+++ b/Linglib/Data/Examples/Kennedy1999.json
@@ -1,0 +1,282 @@
+[
+  {
+    "id": "kennedy1999_cpa_long_short",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(15), §3.1.3" },
+    "language": "stan1293",
+    "primaryText": "#The Brothers Karamazov is longer than The Idiot is short",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#The Brothers Karamazov is longer than The Idiot is short",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "positive"],
+      ["standard_polarity", "negative"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Cross-polar anomaly: positive matrix adjective, negative subdeletion standard, same scale (length)."
+  },
+  {
+    "id": "kennedy1999_cpa_short_long",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(16), §3.1.3" },
+    "language": "stan1293",
+    "primaryText": "#The Idiot is shorter than The Brothers Karamazov is long",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#The Idiot is shorter than The Brothers Karamazov is long",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "negative"],
+      ["standard_polarity", "positive"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Cross-polar anomaly with the polarities reversed."
+  },
+  {
+    "id": "kennedy1999_subdel_pos_pos",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(19), §3.1.3" },
+    "language": "stan1293",
+    "primaryText": "Carmen's Cadillac is wider than Mike's Fiat is long",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Carmen's Cadillac is wider than Mike's Fiat is long",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "positive"],
+      ["standard_polarity", "positive"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Same-polarity subdeletion control: both adjectives positive on the shared scale of linear extent."
+  },
+  {
+    "id": "kennedy1999_subdel_neg_neg",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(20), §3.1.3" },
+    "language": "stan1293",
+    "primaryText": "Fortunately, the ficus was shorter than the ceiling was low, so we were able to get it into the room",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Fortunately, the ficus was shorter than the ceiling was low, so we were able to get it into the room",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "negative"],
+      ["standard_polarity", "negative"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Same-polarity subdeletion control with two negative adjectives."
+  },
+  {
+    "id": "kennedy1999_ficus_tall_high",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(61), §3.1.7" },
+    "language": "stan1293",
+    "primaryText": "Unfortunately, the ficus turned out to be taller than the ceiling was high",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Unfortunately, the ficus turned out to be taller than the ceiling was high",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "positive"],
+      ["standard_polarity", "positive"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Minimal quadruple (61)-(64): cross-polar anomaly generalizes beyond antonym pairs to any polarity mismatch."
+  },
+  {
+    "id": "kennedy1999_ficus_tall_low",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(62), §3.1.7" },
+    "language": "stan1293",
+    "primaryText": "#Unfortunately, the ficus turned out to be taller than the ceiling was low",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#Unfortunately, the ficus turned out to be taller than the ceiling was low",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "positive"],
+      ["standard_polarity", "negative"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "tall and low are not antonyms, yet the polarity mismatch is anomalous."
+  },
+  {
+    "id": "kennedy1999_ficus_short_low",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(63), §3.1.7" },
+    "language": "stan1293",
+    "primaryText": "Luckily, the ficus turned out to be shorter than the doorway was low",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Luckily, the ficus turned out to be shorter than the doorway was low",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "negative"],
+      ["standard_polarity", "negative"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Same-polarity (negative-negative) member of the quadruple."
+  },
+  {
+    "id": "kennedy1999_ficus_short_high",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(64), §3.1.7" },
+    "language": "stan1293",
+    "primaryText": "#Luckily, the ficus turned out to be shorter than the doorway was high",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#Luckily, the ficus turned out to be shorter than the doorway was high",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "negative"],
+      ["standard_polarity", "positive"],
+      ["shared_scale", "true"]
+    ],
+    "comment": "Polarity-mismatch member of the quadruple with the negative adjective in the matrix."
+  },
+  {
+    "id": "kennedy1999_incomm_tall_clever",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(25), §3.1.4" },
+    "language": "stan1293",
+    "primaryText": "#Mike is taller than Carmen is clever",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#Mike is taller than Carmen is clever",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "positive"],
+      ["standard_polarity", "positive"],
+      ["shared_scale", "false"]
+    ],
+    "comment": "Incommensurability: same polarity but distinct scales (height vs cleverness)."
+  },
+  {
+    "id": "kennedy1999_incomm_tragic_heavy",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(26), §3.1.4" },
+    "language": "stan1293",
+    "primaryText": "#The Idiot is more tragic than my copy of The Brothers Karamazov is heavy",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#The Idiot is more tragic than my copy of The Brothers Karamazov is heavy",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["matrix_polarity", "positive"],
+      ["standard_polarity", "positive"],
+      ["shared_scale", "false"]
+    ],
+    "comment": "Incommensurability with two positive adjectives on distinct scales."
+  },
+  {
+    "id": "kennedy1999_mp_cadillac",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(69), §3.1.8" },
+    "language": "stan1293",
+    "primaryText": "My Cadillac is 8 feet long",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "My Cadillac is 8 feet long",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["polarity", "positive"],
+      ["construction", "absolute"]
+    ],
+    "comment": "Measure phrase with a positive adjective: positive extents are bounded, so the ordering is defined."
+  },
+  {
+    "id": "kennedy1999_mp_fiat",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(70), §3.1.8" },
+    "language": "stan1293",
+    "primaryText": "#My Fiat is 5 feet short",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#My Fiat is 5 feet short",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["polarity", "negative"],
+      ["construction", "absolute"]
+    ],
+    "comment": "Measure phrase with a negative adjective: negative extents are unbounded above, so the ordering is undefined."
+  },
+  {
+    "id": "kennedy1999_mp_fiat_comparative",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(73), §3.1.8" },
+    "language": "stan1293",
+    "primaryText": "My fiat is shorter than 8 feet",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "My fiat is shorter than 8 feet",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["polarity", "negative"],
+      ["construction", "comparative"]
+    ],
+    "comment": "Phrasal comparative contrast to (70): the standard is derived by applying short to the measure phrase, not by the measure phrase directly."
+  },
+  {
+    "id": "kennedy1999_mp_reich",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(79), §3.1.9" },
+    "language": "stan1293",
+    "primaryText": "#Mr. Reich is 5 feet short",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#Mr. Reich is 5 feet short",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["polarity", "negative"],
+      ["construction", "absolute"]
+    ],
+    "comment": "Negative adjectives reject overt measure phrases; cited in the argument that sharp-flat pairs are both positive."
+  },
+  {
+    "id": "kennedy1999_mp_slow",
+    "source": { "bibkey": "kennedy-1999", "paperLabel": "(80), §3.1.9" },
+    "language": "stan1293",
+    "primaryText": "#Maureen was driving 14 mph slow",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "#Maureen was driving 14 mph slow",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["polarity", "negative"],
+      ["construction", "absolute"]
+    ],
+    "comment": "Adverbial counterpart of the measure-phrase restriction."
+  }
+]

--- a/Linglib/Data/Examples/Kennedy1999.lean
+++ b/Linglib/Data/Examples/Kennedy1999.lean
@@ -1,0 +1,288 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Kennedy1999` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Kennedy1999.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Kennedy1999.Examples`.
+-/
+
+namespace Kennedy1999.Examples
+
+open Data.Examples
+
+def cpa_long_short : LinguisticExample :=
+  { id := "kennedy1999_cpa_long_short"
+    source := ⟨"kennedy-1999", "(15), §3.1.3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#The Brothers Karamazov is longer than The Idiot is short"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#The Brothers Karamazov is longer than The Idiot is short"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "positive"), ("standard_polarity", "negative"), ("shared_scale", "true")]
+    comment := "Cross-polar anomaly: positive matrix adjective, negative subdeletion standard, same scale (length)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def cpa_short_long : LinguisticExample :=
+  { id := "kennedy1999_cpa_short_long"
+    source := ⟨"kennedy-1999", "(16), §3.1.3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#The Idiot is shorter than The Brothers Karamazov is long"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#The Idiot is shorter than The Brothers Karamazov is long"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "negative"), ("standard_polarity", "positive"), ("shared_scale", "true")]
+    comment := "Cross-polar anomaly with the polarities reversed."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def subdel_pos_pos : LinguisticExample :=
+  { id := "kennedy1999_subdel_pos_pos"
+    source := ⟨"kennedy-1999", "(19), §3.1.3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Carmen's Cadillac is wider than Mike's Fiat is long"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Carmen's Cadillac is wider than Mike's Fiat is long"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "positive"), ("standard_polarity", "positive"), ("shared_scale", "true")]
+    comment := "Same-polarity subdeletion control: both adjectives positive on the shared scale of linear extent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def subdel_neg_neg : LinguisticExample :=
+  { id := "kennedy1999_subdel_neg_neg"
+    source := ⟨"kennedy-1999", "(20), §3.1.3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Fortunately, the ficus was shorter than the ceiling was low, so we were able to get it into the room"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Fortunately, the ficus was shorter than the ceiling was low, so we were able to get it into the room"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "negative"), ("standard_polarity", "negative"), ("shared_scale", "true")]
+    comment := "Same-polarity subdeletion control with two negative adjectives."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ficus_tall_high : LinguisticExample :=
+  { id := "kennedy1999_ficus_tall_high"
+    source := ⟨"kennedy-1999", "(61), §3.1.7"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Unfortunately, the ficus turned out to be taller than the ceiling was high"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Unfortunately, the ficus turned out to be taller than the ceiling was high"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "positive"), ("standard_polarity", "positive"), ("shared_scale", "true")]
+    comment := "Minimal quadruple (61)-(64): cross-polar anomaly generalizes beyond antonym pairs to any polarity mismatch."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ficus_tall_low : LinguisticExample :=
+  { id := "kennedy1999_ficus_tall_low"
+    source := ⟨"kennedy-1999", "(62), §3.1.7"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#Unfortunately, the ficus turned out to be taller than the ceiling was low"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#Unfortunately, the ficus turned out to be taller than the ceiling was low"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "positive"), ("standard_polarity", "negative"), ("shared_scale", "true")]
+    comment := "tall and low are not antonyms, yet the polarity mismatch is anomalous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ficus_short_low : LinguisticExample :=
+  { id := "kennedy1999_ficus_short_low"
+    source := ⟨"kennedy-1999", "(63), §3.1.7"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Luckily, the ficus turned out to be shorter than the doorway was low"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Luckily, the ficus turned out to be shorter than the doorway was low"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "negative"), ("standard_polarity", "negative"), ("shared_scale", "true")]
+    comment := "Same-polarity (negative-negative) member of the quadruple."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ficus_short_high : LinguisticExample :=
+  { id := "kennedy1999_ficus_short_high"
+    source := ⟨"kennedy-1999", "(64), §3.1.7"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#Luckily, the ficus turned out to be shorter than the doorway was high"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#Luckily, the ficus turned out to be shorter than the doorway was high"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "negative"), ("standard_polarity", "positive"), ("shared_scale", "true")]
+    comment := "Polarity-mismatch member of the quadruple with the negative adjective in the matrix."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def incomm_tall_clever : LinguisticExample :=
+  { id := "kennedy1999_incomm_tall_clever"
+    source := ⟨"kennedy-1999", "(25), §3.1.4"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#Mike is taller than Carmen is clever"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#Mike is taller than Carmen is clever"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "positive"), ("standard_polarity", "positive"), ("shared_scale", "false")]
+    comment := "Incommensurability: same polarity but distinct scales (height vs cleverness)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def incomm_tragic_heavy : LinguisticExample :=
+  { id := "kennedy1999_incomm_tragic_heavy"
+    source := ⟨"kennedy-1999", "(26), §3.1.4"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#The Idiot is more tragic than my copy of The Brothers Karamazov is heavy"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#The Idiot is more tragic than my copy of The Brothers Karamazov is heavy"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("matrix_polarity", "positive"), ("standard_polarity", "positive"), ("shared_scale", "false")]
+    comment := "Incommensurability with two positive adjectives on distinct scales."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def mp_cadillac : LinguisticExample :=
+  { id := "kennedy1999_mp_cadillac"
+    source := ⟨"kennedy-1999", "(69), §3.1.8"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "My Cadillac is 8 feet long"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "My Cadillac is 8 feet long"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("polarity", "positive"), ("construction", "absolute")]
+    comment := "Measure phrase with a positive adjective: positive extents are bounded, so the ordering is defined."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def mp_fiat : LinguisticExample :=
+  { id := "kennedy1999_mp_fiat"
+    source := ⟨"kennedy-1999", "(70), §3.1.8"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#My Fiat is 5 feet short"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#My Fiat is 5 feet short"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("polarity", "negative"), ("construction", "absolute")]
+    comment := "Measure phrase with a negative adjective: negative extents are unbounded above, so the ordering is undefined."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def mp_fiat_comparative : LinguisticExample :=
+  { id := "kennedy1999_mp_fiat_comparative"
+    source := ⟨"kennedy-1999", "(73), §3.1.8"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "My fiat is shorter than 8 feet"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "My fiat is shorter than 8 feet"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("polarity", "negative"), ("construction", "comparative")]
+    comment := "Phrasal comparative contrast to (70): the standard is derived by applying short to the measure phrase, not by the measure phrase directly."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def mp_reich : LinguisticExample :=
+  { id := "kennedy1999_mp_reich"
+    source := ⟨"kennedy-1999", "(79), §3.1.9"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#Mr. Reich is 5 feet short"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#Mr. Reich is 5 feet short"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("polarity", "negative"), ("construction", "absolute")]
+    comment := "Negative adjectives reject overt measure phrases; cited in the argument that sharp-flat pairs are both positive."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def mp_slow : LinguisticExample :=
+  { id := "kennedy1999_mp_slow"
+    source := ⟨"kennedy-1999", "(80), §3.1.9"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "#Maureen was driving 14 mph slow"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "#Maureen was driving 14 mph slow"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("polarity", "negative"), ("construction", "absolute")]
+    comment := "Adverbial counterpart of the measure-phrase restriction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [cpa_long_short, cpa_short_long, subdel_pos_pos, subdel_neg_neg, ficus_tall_high, ficus_tall_low, ficus_short_low, ficus_short_high, incomm_tall_clever, incomm_tragic_heavy, mp_cadillac, mp_fiat, mp_fiat_comparative, mp_reich, mp_slow]
+
+end Kennedy1999.Examples

--- a/Linglib/Semantics/Degree/Basic.lean
+++ b/Linglib/Semantics/Degree/Basic.lean
@@ -6,7 +6,7 @@ import Linglib.Core.Order.Boundedness
 
 /-!
 # Degree comparison: the point-standard core
-[rett-2026] [schwarzschild-2008] [von-stechow-1984] [hoeksema-1983]
+[kennedy-1999] [rett-2026] [schwarzschild-2008] [von-stechow-1984] [hoeksema-1983]
 
 Comparative semantics shared across all degree frameworks: the binary
 `comparativeSem` / `equativeSem`, antonymy as scale reversal, and
@@ -38,6 +38,9 @@ consumers in `Studies/Hoeksema1983.lean`.
   with the unique-witness collapse `maxComparative_unique`.
 * `taller_shorter_antonymy` — antonymy is argument swap plus direction reversal.
 * `comparative_iff_Iic_ssubset` — comparison as extent inclusion ([kennedy-1999]).
+* `antonymy_biconditional` / `not_crossExtentInclusion` — the antonymy
+  biconditional derived from extent complementarity, and cross-polar anomaly
+  as unsatisfiable extent inclusion ([kennedy-1999]).
 -/
 
 namespace Degree
@@ -50,8 +53,9 @@ open Core.Order (ScalePolarity Comparison maxOnScale maxOnScale_singleton maxOnS
 section Direct
 variable {Entity : Type*} {α : Type*} [Preorder α]
 
-/-- Comparative semantics ([rett-2026], [schwarzschild-2008]): "A is Adj-er
-than B" iff `μ a` exceeds `μ b` on the directed scale. Only `[Preorder α]`
+/-- Comparative semantics over a measure function ([kennedy-1999];
+[rett-2026], [schwarzschild-2008]): "A is Adj-er than B" iff `μ a` exceeds
+`μ b` on the directed scale. Only `[Preorder α]`
 — connectedness-agnostic background orderings (CSW confidence states)
 are in scope. -/
 def comparativeSem (μ : Entity → α) (a b : Entity) (dir : ScalePolarity) : Prop :=
@@ -124,9 +128,19 @@ end Boundary
 Kennedy's positive/negative extents are `Set.Iic (μ x)` / `Set.Ioi (μ x)`
 directly ([kennedy-1999]); the binary comparator equals strict extent
 inclusion, and antonymy follows from extent complementarity rather than
-being stipulated. -/
+being stipulated. Boundary convention: the paper's eqs (30)–(31) define both
+extents with `≤` (a cover); the strict `Ioi` here is a strict partition, and
+the antonymy biconditional (eq (54)) is convention-independent. -/
 
 section Extent
+
+/-- Cross-polar inclusion: one entity's positive extent inside another's
+negative extent — the LF a cross-polar equative ("as tall as Lee is short")
+would assign ([kennedy-1999]). -/
+def crossExtentInclusion {Entity D : Type*} [Preorder D]
+    (μ : Entity → D) (a b : Entity) : Prop :=
+  Set.Iic (μ a) ⊆ Set.Ioi (μ b)
+
 variable {Entity D : Type*} [LinearOrder D]
 
 /-- Bridge: the atomic S-comparative `Comparison.gt.overSet μ {μ b}` coincides with
@@ -148,6 +162,23 @@ theorem comparative_iff_Iic_ssubset (μ : Entity → D) (a b : Entity) :
 theorem comparative_iff_Ioi_ssubset (μ : Entity → D) (a b : Entity) :
     comparativeSem μ a b .positive ↔ Set.Ioi (μ a) ⊂ Set.Ioi (μ b) :=
   Set.Ioi_ssubset_Ioi_iff.symm
+
+/-- Antonymy biconditional ([kennedy-1999] eq (54)): "A is taller than B" iff
+"B is shorter than A", derived from extent complementarity. -/
+theorem antonymy_biconditional (μ : Entity → D) (a b : Entity) :
+    Set.Iic (μ b) ⊂ Set.Iic (μ a) ↔ Set.Ioi (μ a) ⊂ Set.Ioi (μ b) :=
+  (comparative_iff_Iic_ssubset μ a b).symm.trans (comparative_iff_Ioi_ssubset μ a b)
+
+/-- Weak-inclusion antonymy: the Galois-antitone face of the biconditional. -/
+theorem extent_galois_antitone (μ : Entity → D) (a b : Entity) :
+    Set.Iic (μ a) ⊆ Set.Iic (μ b) ↔ Set.Ioi (μ b) ⊆ Set.Ioi (μ a) :=
+  Set.Iic_subset_Iic.trans Set.Ioi_subset_Ioi_iff.symm
+
+/-- Cross-polar inclusion never holds on a linear order — the lattice-algebraic
+shadow of [kennedy-1999]'s sortal cross-polar anomaly argument (§3.1.7). -/
+theorem not_crossExtentInclusion (μ : Entity → D) (a b : Entity) :
+    ¬ crossExtentInclusion μ a b :=
+  fun h => absurd (h (min_le_left (μ a) (μ b))) (not_lt.mpr (min_le_right _ _))
 
 end Extent
 
@@ -186,6 +217,12 @@ iff every degree B has (`Set.Iic (μ b)`), A also has. -/
 theorem equativeSem_iff_Iic_subset [LinearOrder D] (μ : Entity → D) (a b : Entity) :
     equativeSem μ a b .positive ↔ Set.Iic (μ b) ⊆ Set.Iic (μ a) :=
   Set.Iic_subset_Iic.symm
+
+/-- Equative antonymy on negative extents: "A is as tall as B" iff "B is as
+short as A" (`Set.Ioi` inclusion in the reversed direction). -/
+theorem equativeSem_iff_Ioi_subset [LinearOrder D] (μ : Entity → D) (a b : Entity) :
+    equativeSem μ a b .positive ↔ Set.Ioi (μ a) ⊆ Set.Ioi (μ b) :=
+  (equativeSem_iff_Iic_subset μ a b).trans (extent_galois_antitone μ b a)
 
 /-- Negated equative as strict extent inclusion: B has strictly more degrees
 than A. -/

--- a/Linglib/Semantics/Degree/Hom.lean
+++ b/Linglib/Semantics/Degree/Hom.lean
@@ -9,7 +9,7 @@ import Linglib.Semantics.Degree.Measure.Dimensioned
 
 /-!
 # Morphisms between gradability representations
-[kamp-1975] [klein-1980] [kennedy-2007] [scontras-2014] [bale-schwarz-2022]
+[kamp-1975] [klein-1980] [kennedy-1999] [kennedy-2007] [scontras-2014] [bale-schwarz-2022]
 
 The maps between the three framework objects for gradable predicates,
 with their faithfulness theorems — the degree-semantic analogue of the
@@ -18,7 +18,7 @@ representation maps in `Phonology/Autosegmental` (AR ↔ tone strings):
 ```
 Klein (Delineation)          — most general
   ↑ measureDelineation
-Kennedy (threshold degrees)  — specialization: single linear scale
+Kennedy (measure functions)  — specialization: single linear scale
   ↑ DimensionedMeasure.apply
 Scontras / Bale & Schwarz (typed measurement)
 ```
@@ -64,8 +64,8 @@ bare degree function by the `DimensionedMeasure.apply` projection
 ([scontras-2014]'s insight that measure terms and CARD are one
 degree-assigning operation), and any degree function `μ` over a linear
 order induces a Klein delineation via `Degree.Delineation.measureDelineation`
-— the embedding of [kennedy-2007]-style degree semantics into
-[klein-1980]'s framework. The embedding is faithful
+— the embedding of measure-function degree semantics ([kennedy-1999],
+developed in [kennedy-2007]) into [klein-1980]'s framework. The embedding is faithful
 (`ordering_iff_degree`: Klein's ordering under the induced delineation
 is exactly degree comparison) and lands in the monotone, linear
 fragment (`measureDelineation_monotone`, `measureDelineation_is_linear`).

--- a/Linglib/Studies/Bresnan1973.lean
+++ b/Linglib/Studies/Bresnan1973.lean
@@ -60,8 +60,7 @@ clausal" claim, the `so → such` transformation.
 
 ## Connection to Kennedy 1999
 
-The existing `Kennedy1999.lean` cites [bresnan-1973] for morphological
-distribution data and phrasal/clausal examples. This file formalizes
+This file formalizes
 Bresnan's own proposals: the QP structure, the derivation rules, and the
 four introductory puzzles that motivated the analysis. Bridge theorems
 connect the QP inventory to `Head` and verify suppletion outputs
@@ -310,8 +309,8 @@ def puzzleC : List PuzzleDatum :=
     modifiers (`*How short is he? — five feet short`), so the QP identity
     condition in the clause cannot be satisfied.
 
-    Bridge: this connects to `measurePhrase_positive_only` in `Kennedy1999.lean`
-    and `AdmitsMeasurePhrase` in `MeasurePhrase.lean`. -/
+    Bridge: this connects to `Kennedy1999.measurePhraseAbsoluteRows` and
+    `AdmitsMeasurePhrase` in `MeasurePhrase.lean`. -/
 def puzzleD : List PuzzleDatum :=
   [ { sentence := "Mary is more than six feet tall"
     , acceptable := true
@@ -452,7 +451,7 @@ def measurePhraseConstraintData : List MeasurePhraseConstraintDatum :=
     correlates with positive polarity.
 
     This is the formal content behind puzzle (D) and connects to
-    `measurePhrase_positive_only` in `Kennedy1999.lean`. -/
+    `Kennedy1999.measurePhraseAbsoluteRows`. -/
 theorem measurePhrase_polarity_correlation :
     ∀ d ∈ measurePhraseConstraintData,
       d.polarity = .negative → d.measurePhraseOk = false := by

--- a/Linglib/Studies/Buring2007.lean
+++ b/Linglib/Studies/Buring2007.lean
@@ -1,7 +1,6 @@
 import Linglib.Semantics.Degree.Basic
 import Mathlib.Order.Interval.Basic
 import Linglib.Studies.VonStechow1984
-import Linglib.Studies.Kennedy1999
 
 /-!
 # Büring 2007: Cross-Polar Nomalies
@@ -55,7 +54,7 @@ disambiguate the two, favoring Analysis 1.
   connecting to [kennedy-1999]'s extent algebra in `Degree`.
 - **Cross-polar anomaly = algebraic impossibility**: same-dimension
   cross-polar comparison requires `crossExtentInclusion`, which
-  `crossExtent_always_false` proves is impossible on any linear order.
+  `Degree.not_crossExtentInclusion` proves is impossible on any linear order.
 - **Cross-polar nomaly = subcomparative**: different-dimension comparison
   is `subcomparative` from [schwarzschild-wilkinson-2002].
 - **Klein limitation bridge**: [von-stechow-1984]'s Klein limitation 3
@@ -99,9 +98,8 @@ theorem little_reverses_comparison {Entity α : Type*} [LinearOrder α]
     comparativeSem μ a b .positive ↔ comparativeSem μ b a .negative :=
   taller_shorter_antonymy μ a b
 
-open Degree (comparativeSem taller_shorter_antonymy)
-open Degree (subcomparative)
-open Kennedy1999 (crossExtentInclusion crossExtent_always_false)
+open Degree (comparativeSem taller_shorter_antonymy subcomparative
+  crossExtentInclusion not_crossExtentInclusion)
 
 /-- Schwarzschild-style positive interval `[⊥, μ x]` — the bundled
     (`NonemptyInterval`) face of `Set.Iic (μ x)`. -/
@@ -140,7 +138,7 @@ theorem little_positive_to_negative {Entity D : Type*}
     with a negative extent on the same dimension.
 
     "?*John is shorter than Mary is tall" requires Iic(μ Mary) ⊆
-    Ioi(μ John), but `crossExtent_always_false` from
+    Ioi(μ John), but `Degree.not_crossExtentInclusion` from
     [kennedy-1999]'s extent algebra proves this is impossible on
     any linear order: the boundary degree μ(a) belongs to the positive
     extent but not the negative one, so the inclusion always fails.
@@ -153,7 +151,7 @@ theorem little_positive_to_negative {Entity D : Type*}
 theorem crossPolar_anomaly_impossible {Entity D : Type*} [LinearOrder D]
     (μ : Entity → D) (a b : Entity) :
     ¬ crossExtentInclusion μ a b :=
-  crossExtent_always_false μ a b
+  not_crossExtentInclusion μ a b
 
 /-! ### Cross-Polar Pattern (Data) -/
 

--- a/Linglib/Studies/Heim2001.lean
+++ b/Linglib/Studies/Heim2001.lean
@@ -1,4 +1,3 @@
-import Linglib.Studies.Kennedy1999
 import Linglib.Semantics.Degree.Quantifier
 import Linglib.Syntax.Minimalist.Movement.DegreeMovement
 import Mathlib.Order.ConditionallyCompleteLattice.Basic

--- a/Linglib/Studies/Kennedy1999.lean
+++ b/Linglib/Studies/Kennedy1999.lean
@@ -1,411 +1,119 @@
+import Linglib.Data.Examples.Kennedy1999
 import Linglib.Syntax.Category.Degree.Basic
-import Linglib.Semantics.Degree.Quantifier
-import Linglib.Semantics.Degree.Discrete
 
 /-!
 # Kennedy 1999: Projecting the Adjective
-[kennedy-1999] [bresnan-1973] [bhatt-pancheva-2004] [kennedy-2007] [lechner-2004] [rett-2020] [schwarzschild-2008]
 
-[kennedy-1999] "Projecting the Adjective" (dissertation, UC Santa Cruz;
-published 1999, Garland). The foundational argument that gradable adjectives
-denote **measure functions** (Entity → Degree), with degree morphemes (-er,
-as, -est, too, enough) as functional heads of a DegP projection that bind
-the degree argument.
+Study file for [kennedy-1999], the dissertation arguing that gradable
+adjectives denote measure functions (⟦tall⟧ = λx. height(x)) whose relational
+⟨d,⟨e,t⟩⟩ type is derived by degree morphology, and that positive and negative
+*extents* of the same scale (POSδ and NEGδ, eqs (30)–(31)) derive antonymy and
+cross-polar anomaly rather than stipulating them. The extent algebra is
+formalised in `Semantics/Degree/Basic.lean`: extents are `Set.Iic (μ x)` /
+`Set.Ioi (μ x)`, comparison is extent inclusion
+(`Degree.comparative_iff_Iic_ssubset`), the antonymy biconditional (54) is
+`Degree.antonymy_biconditional`, and cross-polar anomaly (§3.1.7) is
+`Degree.not_crossExtentInclusion`. The embedding of measure functions into
+[klein-1980]'s rival degree-free delineation semantics is in
+`Semantics/Degree/Hom.lean` (`Degree.delineation_strictly_more_general`).
 
-## Core Contributions
+The judgment data live in `Data/Examples/Kennedy1999.json`: the cross-polar
+and incommensurability comparatives of §3.1.3–§3.1.7 (including the ficus
+quadruple (61)–(64) showing the anomaly generalizes beyond antonym pairs) and
+the measure-phrase restriction of §3.1.8–§3.1.9. Kennedy's account defines
+comparison exactly when the compared extents are of the same sort on a shared
+scale; `comparison_defined_iff` and `measurePhrase_positive_iff` check the
+predicted judgment patterns row by row.
 
-1. **Adjectives as measure functions**: ⟦tall⟧ = λx. height(x), not
-   λd.λx. height(x) ≥ d. The relational type ⟨d,⟨e,t⟩⟩ is derived by
-   combining with degree morphology, not lexical.
-
-2. **Extent functions**: pos-ext and neg-ext partition the scale into degrees
-   an entity "has" and "lacks". Negative adjectives access the *negative*
-   extent of the same scale as their positive counterpart.
-
-3. **Cross-polar anomaly**: "Kim is as tall as Lee is short" is anomalous
-   because the equative tries to compare a positive extent with a negative
-   extent — structurally incompatible (proved always-false in
-   `crossExtent_always_false`).
-
-4. **Antonymy biconditional**: "BK is longer than The Idiot iff The Idiot is
-   shorter than BK" is DERIVED from extent complementarity, not stipulated
-   as a lexical property (proved in `Degree.antonymy_biconditional`).
-
-5. **DegP projection**: Degree morphemes head their own syntactic phrase.
-   This has been refined by [heim-2001] (sentential operator approach)
-   and subsequent work. The core insight — that degree binding is syntactic,
-   not lexical — is consensus.
-
-6. **Comparative subdeletion**: "The table is longer than it is wide"
-   requires clausal standards and cross-dimensional commensurability.
-
-## What Is Current vs. Historical
-
-The measure function denotation and extent functions (§ 1–4) are current
-consensus — they underlie all subsequent degree-semantic work including
-[kennedy-2007] and [schwarzschild-2008].
-
-The specific DegP syntax (§ 5) has been refined: [heim-2001]'s
-sentential operator approach is now co-standard, and the two make
-different scope predictions. This study file records both the data and
-the 1999-era analysis.
-
-## Additional Data
-
-This file also collects comparison construction data from
-[bresnan-1973] (phrasal/clausal comparatives, morphological
-distribution), [bhatt-pancheva-2004] and [lechner-2004]
-(subcomparatives), and [kennedy-2007] and [rett-2020]
-(equative constructions).
-
+Pending relocation to their own study files: subcomparative typology
+([bhatt-pancheva-2004]) and equative data ([kennedy-2007], [rett-2020]).
 -/
 
 namespace Kennedy1999
 
-open Degree (comparativeSem equativeSem
-  comparative_iff_Iic_ssubset comparative_iff_Ioi_ssubset
-  equativeSem_iff_Iic_subset)
+open Data.Examples (LinguisticExample)
 
-/-! ### Extents (Ch. 3)
+/-! ### Cross-polar anomaly (§3.1.3–§3.1.7) -/
 
-Kennedy's positive/negative extents are `Set.Iic (μ x)` / `Set.Ioi (μ x)`.
-Boundary convention: eqs (30)–(31) define POSδ and NEGδ both with `≤`
-(a cover; eqs (52)–(53) state their join-complementarity); we use strict
-`Ioi` for the negative extent, a strict partition. The antonymy
-biconditional (eq (54)) is convention-independent;
-`crossExtent_always_false` is convention-specific, and models the
-lattice-algebraic shadow of the paper's own *sortal* cross-polar anomaly
-argument (§3.1.7), not the sortal analysis itself. -/
+/-- The two compared adjectives have the same scale polarity. -/
+def samePolarity (e : LinguisticExample) : Prop :=
+  e.feature? "matrix_polarity" = e.feature? "standard_polarity"
 
-/-- Antonymy biconditional (eq (54)): "A is taller than B" iff "B is
-    shorter than A", derived from extent algebra. -/
-theorem antonymy_biconditional {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) :
-    Set.Iic (μ b) ⊂ Set.Iic (μ a) ↔ Set.Ioi (μ a) ⊂ Set.Ioi (μ b) := by
-  rw [Set.Iic_ssubset_Iic, Set.Ioi_ssubset_Ioi_iff]
+instance (e : LinguisticExample) : Decidable (samePolarity e) :=
+  inferInstanceAs (Decidable (_ = _))
 
-/-- Weak-inclusion antonymy: the Galois-antitone face of eq (54). -/
-theorem extent_galois_antitone {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) :
-    Set.Iic (μ a) ⊆ Set.Iic (μ b) ↔ Set.Ioi (μ b) ⊆ Set.Ioi (μ a) := by
-  rw [Set.Iic_subset_Iic, Set.Ioi_subset_Ioi_iff]
+/-- The two compared adjectives project onto a shared scale. -/
+def sharedScale (e : LinguisticExample) : Prop :=
+  e.feature? "shared_scale" = some "true"
 
-/-- Cross-polar inclusion: one entity's positive extent inside another's
-    negative extent — the LF a cross-polar equative would assign. -/
-abbrev crossExtentInclusion {Entity D : Type*} [Preorder D]
-    (μ : Entity → D) (a b : Entity) : Prop :=
-  Set.Iic (μ a) ⊆ Set.Ioi (μ b)
+instance (e : LinguisticExample) : Decidable (sharedScale e) :=
+  inferInstanceAs (Decidable (_ = _))
 
-/-- Cross-polar non-inclusion (convention-specific; see the section note). -/
-theorem crossExtent_always_false {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) : ¬ crossExtentInclusion μ a b :=
-  fun h => absurd (h (min_le_left (μ a) (μ b))) (not_lt.mpr (min_le_right _ _))
+/-- The subdeletion comparatives of §3.1.3–§3.1.7: cross-polar anomalies,
+same-polarity controls, the ficus quadruple, and the incommensurability
+cases. -/
+def crossPolarRows : List LinguisticExample :=
+  [ Examples.cpa_long_short, Examples.cpa_short_long
+  , Examples.subdel_pos_pos, Examples.subdel_neg_neg
+  , Examples.ficus_tall_high, Examples.ficus_tall_low
+  , Examples.ficus_short_low, Examples.ficus_short_high
+  , Examples.incomm_tall_clever, Examples.incomm_tragic_heavy ]
 
-/-! ### Cross-Polar Anomaly Data -/
+/-- A subdeletion comparative is acceptable exactly when the compared extents
+are of the same sort on a shared scale — sortal cross-polar anomaly and
+incommensurability under one condition. `Degree.not_crossExtentInclusion` is
+the lattice-algebraic shadow of the polarity half. -/
+theorem comparison_defined_iff :
+    ∀ e ∈ crossPolarRows,
+      e.judgment = .acceptable ↔ (samePolarity e ∧ sharedScale e) := by
+  decide
 
-/-- A cross-polar anomaly judgment. -/
-structure CrossPolarDatum where
-  sentence : String
-  acceptable : Bool
-  /-- Does this compare same-polarity or cross-polarity extents? -/
-  samePolarity : Bool
-  /-- Is this an equative ("as...as") or comparative ("-er...than")? -/
-  isEquative : Bool
-  note : String := ""
-  deriving Repr
+/-! ### Measure phrase distribution (§3.1.8–§3.1.9)
 
-/-- Cross-polar anomaly data from [kennedy-1999]. -/
-def crossPolarData : List CrossPolarDatum :=
-  [ { sentence := "Kim is as tall as Lee"
-    , acceptable := true, samePolarity := true, isEquative := true
-    , note := "same polarity: pos-ext(height, Kim) ⊇ pos-ext(height, Lee)" }
-  , { sentence := "Kim is as short as Lee"
-    , acceptable := true, samePolarity := true, isEquative := true
-    , note := "same polarity: neg-ext(height, Kim) ⊇ neg-ext(height, Lee)" }
-  , { sentence := "??Kim is as tall as Lee is short"
-    , acceptable := false, samePolarity := false, isEquative := true
-    , note := "cross-polar: pos-ext(height, Kim) vs neg-ext(height, Lee)" }
-  , { sentence := "??Kim is as short as Lee is tall"
-    , acceptable := false, samePolarity := false, isEquative := true
-    , note := "cross-polar: neg-ext(height, Kim) vs pos-ext(height, Lee)" }
-  , { sentence := "??Kim is taller than Lee is short"
-    , acceptable := false, samePolarity := false, isEquative := false
-    , note := "cross-polar anomaly: direct antonyms on same dimension ([buring-2007] §1, ex. 1b)" }
-  ]
+Measure phrases denote bounded extents. On a scale with a minimum, positive
+extents are bounded but negative extents are not, so an absolute construction
+composing a measure phrase with a negative adjective is undefined — (69) "My
+Cadillac is 8 feet long" vs (70) "#My Fiat is 5 feet short". The phrasal
+comparative (73) "My fiat is shorter than 8 feet" is the paper's contrast:
+there the standard is derived by applying the adjective to the measure
+phrase. -/
 
-/-- Cross-polar = unacceptable for both equatives and comparatives
-    when the adjectives are direct antonyms on the same dimension.
-    [buring-2007] shows this holds uniformly (§1, ex. 1). -/
-theorem crossPolar_iff_unacceptable :
-    ∀ d ∈ crossPolarData,
-      (d.acceptable = false ↔ d.samePolarity = false) := by
-  intro d hd
-  simp [crossPolarData] at hd
-  rcases hd with rfl | rfl | rfl | rfl | rfl <;> simp_all
+/-- The absolute measure-phrase constructions of §3.1.8–§3.1.9. -/
+def measurePhraseAbsoluteRows : List LinguisticExample :=
+  [ Examples.mp_cadillac, Examples.mp_fiat
+  , Examples.mp_reich, Examples.mp_slow ]
 
--- ════════════════════════════════════════════════════
--- § 2. Cross-Polar Anomaly: Theory Bridge
--- ════════════════════════════════════════════════════
+/-- An absolute measure-phrase construction is acceptable exactly with a
+positive adjective, whose extents are bounded. -/
+theorem measurePhrase_positive_iff :
+    ∀ e ∈ measurePhraseAbsoluteRows,
+      e.judgment = .acceptable ↔ e.feature? "polarity" = some "positive" := by
+  decide
 
-/-- The cross-polar anomaly is predicted by extent function algebra:
-    cross-extent inclusion is always false on any linear order.
-    This is the formal content behind the unacceptability of
-    "Kim is as tall as Lee is short". -/
-theorem crossPolar_predicted {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (kim lee : Entity) :
-    ¬ crossExtentInclusion μ kim lee :=
-  crossExtent_always_false μ kim lee
+/-! ### DegP projection
 
--- ════════════════════════════════════════════════════
--- § 3. Equative = Extent Inclusion
--- ════════════════════════════════════════════════════
+Degree morphemes are functional heads taking AdjP as complement:
+`[DegP [Deg° -er, as, -est, too, enough] [AdjP tall]]` (ch. 2, the extended
+projection of A). The head inventory is `Degree.Head`. -/
 
-/-- Same-polarity equatives are well-defined: "as tall as" checks
-    that the standard's positive extent is included in the subject's.
-    This reduces to μ(subject) ≥ μ(standard). -/
-theorem samePolar_equative_welldefined {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) :
-    equativeSem μ a b .positive ↔ Set.Iic (μ b) ⊆ Set.Iic (μ a) :=
-  equativeSem_iff_Iic_subset μ a b
-
--- ════════════════════════════════════════════════════
--- § 4. Comparative = Strict Extent Inclusion
--- ════════════════════════════════════════════════════
-
-/-- "A is taller than B" iff B's positive extent is strictly contained
-    in A's. Bridges the consensus comparative to the algebraic
-    `Set.Iic_ssubset_Iic`. -/
-theorem comparative_extent_bridge {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) :
-    comparativeSem μ a b .positive ↔ Set.Iic (μ b) ⊂ Set.Iic (μ a) :=
-  comparative_iff_Iic_ssubset μ a b
-
--- ════════════════════════════════════════════════════
--- § 5. Antonymy Biconditional
--- ════════════════════════════════════════════════════
-
-/-- **Central theorem of [kennedy-1999] Ch. 3**: antonymy
-    equivalence is DERIVED from the complementarity of positive and
-    negative extents, not stipulated as a lexical property.
-
-    "BK is longer than The Idiot" iff "The Idiot is shorter than BK"
-
-    Formally: posExt(b) ⊂ posExt(a) ↔ negExt(a) ⊂ negExt(b).
-    The positive comparative and the negative comparative have the
-    same truth conditions because positive and negative extents are
-    complementary projections of the same scale point. -/
-theorem antonymy_derived {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) :
-    comparativeSem μ a b .positive ↔ Set.Ioi (μ a) ⊂ Set.Ioi (μ b) :=
-  comparative_iff_Ioi_ssubset μ a b
-
-/-- The antonymy biconditional also holds for equatives:
-    "A is as tall as B" iff "B is as short as A" — extent inclusion
-    in one polarity implies extent inclusion in the other
-    (`extent_galois_antitone`). -/
-theorem equative_antonymy_extent {Entity D : Type*} [LinearOrder D]
-    (μ : Entity → D) (a b : Entity) :
-    equativeSem μ a b .positive ↔ Set.Ioi (μ a) ⊆ Set.Ioi (μ b) := by
-  rw [equativeSem_iff_Iic_subset, extent_galois_antitone]
-
--- ════════════════════════════════════════════════════
--- § 6. Historical: DegP Projection
--- ════════════════════════════════════════════════════
-
-/-- [kennedy-1999]'s DegP projection: degree morphemes are
-    functional heads taking AdjP as complement.
-
-    `[DegP [Deg° -er, as, -est, too, enough] [AdjP tall]]`
-
-    This specific syntactic structure was refined by [heim-2001],
-    who treats -er as a sentential operator rather than a DegP head.
-    Both agree that degree binding is syntactic.
-
-    Note: the degree head inventory matches `Degree.Head`
-    from `Degree/Defs.lean`, which is the current consensus enumeration.
-    This historical structure records Kennedy's specific proposal that
-    these heads project a full DegP phrase. -/
+/-- A degree head with its adjective complement. -/
 structure HistoricalDegP where
   head : Degree.Head
   adjective : String
   deriving Repr
 
-/-- Example DegP constructions from [kennedy-1999]. -/
+/-- DegP constructions from the paper. -/
 def exampleDegPs : List HistoricalDegP :=
-  [ { head := .comparative, adjective := "tall" }   -- "taller"
+  [ { head := .comparative, adjective := "tall" }    -- "taller"
   , { head := .equative, adjective := "tall" }       -- "as tall"
   , { head := .superlative, adjective := "tall" }    -- "tallest"
   , { head := .excessive, adjective := "expensive" } -- "too expensive"
   , { head := .sufficiency, adjective := "old" }     -- "old enough"
   ]
 
--- ════════════════════════════════════════════════════
--- § 7. Measure Phrase Distribution
--- ════════════════════════════════════════════════════
+/-! ### Subcomparative typology (pending relocation, [bhatt-pancheva-2004]) -/
 
-/-- [kennedy-1999] §3.1.8 observes that measure phrases are acceptable
-    with positive adjectives but not negative ones:
-
-    (69) "My Cadillac is 8 feet long."     ✓
-    (70) "#My Fiat is 5 feet short."       ✗
-
-    Kennedy's explanation: measure phrases denote bounded extents. On scales
-    with a minimum, positive extents are bounded (anchored at ⊥), but negative
-    extents are not (they extend to ∞). So the ordering relation between a
-    measure phrase (bounded extent) and a negative extent is undefined. -/
-structure MeasurePhraseDatum where
-  sentence : String
-  acceptable : Bool
-  isPositiveAdj : Bool
-  deriving Repr
-
-def measurePhraseData : List MeasurePhraseDatum :=
-  [ { sentence := "My Cadillac is 8 feet long", acceptable := true, isPositiveAdj := true }
-  , { sentence := "#My Fiat is 5 feet short", acceptable := false, isPositiveAdj := false }
-  , { sentence := "The kitchen is 50 degrees warmer than the basement"
-    , acceptable := true, isPositiveAdj := true }
-  , { sentence := "#Mr. Reich is 5 feet short", acceptable := false, isPositiveAdj := false }
-  ]
-
-/-- Measure phrases are acceptable with positive adjectives only. -/
-theorem measurePhrase_positive_only :
-    ∀ d ∈ measurePhraseData, (d.acceptable = true ↔ d.isPositiveAdj = true) := by
-  intro d hd
-  simp [measurePhraseData] at hd
-  rcases hd with rfl | rfl | rfl | rfl <;> simp_all
-
--- ════════════════════════════════════════════════════
--- § 8. Comparative Construction Data
--- ════════════════════════════════════════════════════
-
-/-- An acceptability judgment for a comparative construction.
-    [bresnan-1973] [kennedy-1999] [lechner-2004] -/
-structure ComparativeJudgment where
-  /-- The example sentence -/
-  sentence : String
-  /-- Whether the sentence is acceptable -/
-  acceptable : Bool
-  /-- Phrasal or clausal standard? -/
-  standardType : String
-  /-- Notes on the reading or restriction -/
-  note : String := ""
-  deriving Repr
-
-/-- Phrasal comparatives — DP complement of *than*. -/
-def phrasalExamples : List ComparativeJudgment :=
-  [ { sentence := "Kim is taller than Lee"
-    , acceptable := true
-    , standardType := "phrasal" }
-  , { sentence := "Kim bought more books than Lee"
-    , acceptable := true
-    , standardType := "phrasal"
-    , note := "nominal comparative" }
-  , { sentence := "Kim ran faster than Lee"
-    , acceptable := true
-    , standardType := "phrasal"
-    , note := "adverbial comparative" }
-  ]
-
-/-- Clausal comparatives — CP complement of *than*. -/
-def clausalExamples : List ComparativeJudgment :=
-  [ { sentence := "Kim is taller than Lee is"
-    , acceptable := true
-    , standardType := "clausal" }
-  , { sentence := "Kim is taller than Lee is wide"
-    , acceptable := true
-    , standardType := "clausal"
-    , note := "subcomparative — different dimension" }
-  , { sentence := "Kim bought more books than Lee bought records"
-    , acceptable := true
-    , standardType := "clausal"
-    , note := "nominal subcomparative" }
-  ]
-
-/-- Synthetic vs. analytic comparative distribution in English.
-    The generalization: monosyllabic adjectives prefer synthetic (-er),
-    polysyllabic prefer analytic (more), disyllabic varies. -/
-structure MorphDistributionDatum where
-  adjective : String
-  syllables : Nat
-  syntheticOk : Bool   -- "-er" form acceptable?
-  analyticOk : Bool    -- "more" form acceptable?
-  deriving Repr
-
-def morphDistribution : List MorphDistributionDatum :=
-  [ { adjective := "tall", syllables := 1, syntheticOk := true, analyticOk := false }
-  , { adjective := "smart", syllables := 1, syntheticOk := true, analyticOk := false }
-  , { adjective := "happy", syllables := 2, syntheticOk := true, analyticOk := true }
-  , { adjective := "clever", syllables := 2, syntheticOk := true, analyticOk := true }
-  , { adjective := "beautiful", syllables := 3, syntheticOk := false, analyticOk := true }
-  , { adjective := "expensive", syllables := 3, syntheticOk := false, analyticOk := true }
-  ]
-
-/-- Bare comparative data: the standard of comparison may be
-    implicitly recovered from context.
-
-    "Kim is taller" — standard = contextually supplied comparison class.
-    This connects to the evaluative/positive reading of bare gradable
-    adjectives (Gradability/).
-
-    Note: "bare comparative" = comparative without an explicit standard.
-    This is NOT "comparative deletion" in [bresnan-1973]'s sense
-    (= identity-based deletion of a clause constituent from the
-    than-clause). -/
-structure BareComparativeDatum where
-  sentence : String
-  /-- Is the standard explicitly present? -/
-  explicitStandard : Bool
-  /-- Available readings -/
-  readings : List String
-  deriving Repr
-
-def bareComparativeExamples : List BareComparativeDatum :=
-  [ { sentence := "Kim is taller"
-    , explicitStandard := false
-    , readings := ["comparative to contextual standard"] }
-  , { sentence := "Kim is taller than Lee"
-    , explicitStandard := true
-    , readings := ["comparative to Lee"] }
-  ]
-
--- ════════════════════════════════════════════════════
--- § 9. Subcomparative Data
--- ════════════════════════════════════════════════════
-
-/-- A subcomparative judgment.
-    [bhatt-pancheva-2004] [kennedy-1999] [lechner-2004] [schwarzschild-2008] -/
-structure SubcomparativeDatum where
-  sentence : String
-  acceptable : Bool
-  /-- The matrix predicate (e.g., "long") -/
-  matrixPredicate : String
-  /-- The embedded predicate (e.g., "wide") -/
-  embeddedPredicate : String
-  /-- Are the dimensions commensurable? -/
-  commensurable : Bool
-  deriving Repr
-
-def subcomparativeExamples : List SubcomparativeDatum :=
-  [ { sentence := "The table is longer than the desk is wide"
-    , acceptable := true
-    , matrixPredicate := "long", embeddedPredicate := "wide"
-    , commensurable := true }
-  , { sentence := "The building is taller than the field is wide"
-    , acceptable := true
-    , matrixPredicate := "tall", embeddedPredicate := "wide"
-    , commensurable := true }
-  , { sentence := "??The soup is hotter than the dress is expensive"
-    , acceptable := false
-    , matrixPredicate := "hot", embeddedPredicate := "expensive"
-    , commensurable := false }
-  , { sentence := "More students passed than professors failed"
-    , acceptable := true
-    , matrixPredicate := "many (students)", embeddedPredicate := "many (professors)"
-    , commensurable := true }
-  ]
-
-/-- Cross-linguistic variation in subcomparative availability.
-    [bhatt-pancheva-2004] -/
+/-- Cross-linguistic availability of clausal subcomparatives. -/
 structure SubcomparativeTypologyDatum where
   language : String
   available : Bool
@@ -422,47 +130,44 @@ def subcomparativeTypology : List SubcomparativeTypologyDatum :=
     , note := "Exceed-type comparatives don't support subcomparatives" }
   ]
 
--- ════════════════════════════════════════════════════
--- § 10. Equative Construction Data
--- ════════════════════════════════════════════════════
+/-! ### Equative construction data (pending relocation, [kennedy-2007], [rett-2020]) -/
 
-/-- An equative judgment.
-    [kennedy-2007] [rett-2020] -/
+/-- An equative judgment with its available readings ("at_least",
+"exactly", "strict_less"). -/
 structure EquativeJudgment where
   sentence : String
-  acceptable : Bool
-  /-- "at_least" or "exactly" -/
+  judgment : Features.Judgment
   availableReadings : List String
   note : String := ""
   deriving Repr
 
 def equativeExamples : List EquativeJudgment :=
   [ { sentence := "Kim is as tall as Lee"
-    , acceptable := true
+    , judgment := .acceptable
     , availableReadings := ["at_least", "exactly"] }
   , { sentence := "Kim is as tall as Lee, if not taller"
-    , acceptable := true
+    , judgment := .acceptable
     , availableReadings := ["at_least"]
     , note := "'if not taller' cancels the exactly implicature" }
   , { sentence := "Kim is not as tall as Lee"
-    , acceptable := true
+    , judgment := .acceptable
     , availableReadings := ["strict_less"]
     , note := "negated equative = strict inequality" }
   , { sentence := "Kim ran as fast as Lee"
-    , acceptable := true
+    , judgment := .acceptable
     , availableReadings := ["at_least", "exactly"]
     , note := "adverbial equative" }
   ]
 
-/-- Equative encoding strategy. [rett-2020] -/
+/-- Equative encoding strategy ([rett-2020]). -/
 inductive EquativeStrategy where
-  | parameterMarker  -- "as...as" (English, German)
-  | reach            -- "tall reaching/to X" (many West African languages)
-  | similative       -- "tall like X" (French "aussi...que", many languages)
-  | exceed           -- "not exceed X in height" (Mandarin, Japanese)
+  | parameterMarker
+  | reach
+  | similative
+  | exceed
   deriving DecidableEq, Repr
 
-/-- Cross-linguistic equative strategy datum. -/
+/-- A language's equative strategy with an example form. -/
 structure EquativeTypologyDatum where
   language : String
   strategy : EquativeStrategy


### PR DESCRIPTION
Four-lens audit rework of the Kennedy 1999 study file (verdict: rework-in-place).

- Promote the extent-algebra theorems (`antonymy_biconditional`, `extent_galois_antitone`, `crossExtentInclusion`, `not_crossExtentInclusion`, `equativeSem_iff_Ioi_subset`) into `Semantics/Degree/Basic.lean` (Büring 2007 already consumed them from the study namespace) and delete the study file's substrate re-exports; credit the measure-function ontology to kennedy-1999 in `Degree/Basic`/`Hom`.
- Replace the hand-typed data tables with `Data/Examples/Kennedy1999.json` (15 rows) using the paper's actual examples, verified against the published text — (15)/(16), (19)/(20), the ficus quadruple (61)–(64), (25)/(26), and measure phrases (69)/(70)/(73)/(79)/(80) — with `comparison_defined_iff` / `measurePhrase_positive_iff` over the generated rows; cut Bresnan-anchored tables that `Bresnan1973.lean` owns.

Follow-up PR relocates the subcomparative-typology and equative blocks to their own study files.