### PR TITLE
refactor(Studies): move equative+subcomparative typology out of Kennedy1999

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1958,6 +1958,7 @@ import Linglib.Studies.BeaversKoontzGarboden2020
 import Linglib.Studies.BeaversUdayana2022
 import Linglib.Studies.BeaversZubair2013
 import Linglib.Studies.Beck2001
+import Linglib.Studies.BeckOdaSugisaki2004
 import Linglib.Studies.BeckerEtAl2025
 import Linglib.Studies.BeckmanPierrehumbert1986
 import Linglib.Studies.BejarRezac2003
@@ -2563,6 +2564,7 @@ import Linglib.Studies.ReesReksnesRohde2026
 import Linglib.Studies.Reinhart1976
 import Linglib.Studies.Rett2015
 import Linglib.Studies.Rett2020
+import Linglib.Studies.Rett2020Equatives
 import Linglib.Studies.Rett2026
 import Linglib.Studies.RitchieSchiller2024
 import Linglib.Studies.Roberts2012
@@ -2927,3 +2929,4 @@ import Linglib.Syntax.WordGrammar.Inheritance.Order
 import Linglib.Syntax.WordGrammar.LexicalRules
 import Linglib.Syntax.WordGrammar.Network
 import Linglib.Data.Examples.Kennedy1999
+import Linglib.Data.Examples.BeckOdaSugisaki2004

--- a/Linglib/Data/Examples/BeckOdaSugisaki2004.json
+++ b/Linglib/Data/Examples/BeckOdaSugisaki2004.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "beckodasugisaki2004_amount_yori",
+    "source": { "bibkey": "beck-oda-sugisaki-2004", "paperLabel": "(3-a), p. 290" },
+    "language": "nucl1643",
+    "primaryText": "Taroo-wa [Hanako-ga katta yori (mo)] takusan(-no) kasa-o katta",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Taroo bought more umbrellas than Hanako did",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "amount_comparative"],
+      ["standard_requires_degree_abstraction", "false"]
+    ],
+    "comment": "Amount yori-comparative; judgment from Ishii 1991. Gloss: Taroo-Top [Hanako-Nom bought YORI (mo)] many(-Gen) umbrella-Acc bought."
+  },
+  {
+    "id": "beckodasugisaki2004_degree_yori",
+    "source": { "bibkey": "beck-oda-sugisaki-2004", "paperLabel": "(4-a), p. 290" },
+    "language": "nucl1643",
+    "primaryText": "?Taroo-wa [Hanako-ga katta yori (mo)] nagai kasa-o katta",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Taroo bought a longer umbrella than Hanako did",
+    "context": "",
+    "judgment": "questionable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "degree_comparative"],
+      ["standard_requires_degree_abstraction", "false"]
+    ],
+    "comment": "Degree yori-comparative: Ishii 1991 reports ?*; the authors' consultants range from ? to ??. The variability itself is an explanandum for the contextual analysis."
+  },
+  {
+    "id": "beckodasugisaki2004_subcomp_ja",
+    "source": { "bibkey": "beck-oda-sugisaki-2004", "paperLabel": "(5-a), p. 290" },
+    "language": "nucl1643",
+    "primaryText": "*Kono tana-wa [ano doa-ga hiroi yori (mo)] (motto) takai",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "This shelf is taller than that door is wide",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "subcomparative"],
+      ["standard_requires_degree_abstraction", "true"]
+    ],
+    "comment": "Japanese lacks subcomparatives (observed by Snyder, Wexler & Das 1995). Gloss: this shelf-Top [that door-Nom wide YORI (mo)] (more) tall."
+  },
+  {
+    "id": "beckodasugisaki2004_subcomp_en",
+    "source": { "bibkey": "beck-oda-sugisaki-2004", "paperLabel": "(5-b), p. 290" },
+    "language": "stan1293",
+    "primaryText": "This shelf is taller than that door is wide",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "This shelf is taller than that door is wide",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "subcomparative"],
+      ["standard_requires_degree_abstraction", "true"]
+    ],
+    "comment": "English subcomparative control for (5-a)."
+  },
+  {
+    "id": "beckodasugisaki2004_negisland_ja",
+    "source": { "bibkey": "beck-oda-sugisaki-2004", "paperLabel": "(6-a), p. 290" },
+    "language": "nucl1643",
+    "primaryText": "John-wa [dare-mo kawa-naka-tta no yori] takai hon-o katta",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John bought a book that is more expensive than the book that nobody bought",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "negative_island"],
+      ["standard_requires_degree_abstraction", "false"]
+    ],
+    "comment": "Well-formed, with the individual-comparing interpretation of the paper's (6'): the yori-clause denotes the (unique) book nobody bought, not a degree set. Gloss: John-Top [anyone buy-Neg-Past NO YORI] expensive book-Acc bought."
+  },
+  {
+    "id": "beckodasugisaki2004_negisland_en",
+    "source": { "bibkey": "beck-oda-sugisaki-2004", "paperLabel": "(6-b), p. 290" },
+    "language": "stan1293",
+    "primaryText": "*John bought a more expensive book than nobody did",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "*John bought a more expensive book than nobody did",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "negative_island"],
+      ["standard_requires_degree_abstraction", "true"]
+    ],
+    "comment": "English negative-island effect: no maximal degree such that nobody bought a that-expensive book (Rullmann 1995 undefinedness)."
+  }
+]

--- a/Linglib/Data/Examples/BeckOdaSugisaki2004.lean
+++ b/Linglib/Data/Examples/BeckOdaSugisaki2004.lean
@@ -1,0 +1,126 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `BeckOdaSugisaki2004` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/BeckOdaSugisaki2004.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace BeckOdaSugisaki2004.Examples`.
+-/
+
+namespace BeckOdaSugisaki2004.Examples
+
+open Data.Examples
+
+def amount_yori : LinguisticExample :=
+  { id := "beckodasugisaki2004_amount_yori"
+    source := ⟨"beck-oda-sugisaki-2004", "(3-a), p. 290"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Taroo-wa [Hanako-ga katta yori (mo)] takusan(-no) kasa-o katta"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Taroo bought more umbrellas than Hanako did"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "amount_comparative"), ("standard_requires_degree_abstraction", "false")]
+    comment := "Amount yori-comparative; judgment from Ishii 1991. Gloss: Taroo-Top [Hanako-Nom bought YORI (mo)] many(-Gen) umbrella-Acc bought."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def degree_yori : LinguisticExample :=
+  { id := "beckodasugisaki2004_degree_yori"
+    source := ⟨"beck-oda-sugisaki-2004", "(4-a), p. 290"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "?Taroo-wa [Hanako-ga katta yori (mo)] nagai kasa-o katta"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Taroo bought a longer umbrella than Hanako did"
+    context := ""
+    judgment := .questionable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "degree_comparative"), ("standard_requires_degree_abstraction", "false")]
+    comment := "Degree yori-comparative: Ishii 1991 reports ?*; the authors' consultants range from ? to ??. The variability itself is an explanandum for the contextual analysis."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def subcomp_ja : LinguisticExample :=
+  { id := "beckodasugisaki2004_subcomp_ja"
+    source := ⟨"beck-oda-sugisaki-2004", "(5-a), p. 290"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "*Kono tana-wa [ano doa-ga hiroi yori (mo)] (motto) takai"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This shelf is taller than that door is wide"
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "subcomparative"), ("standard_requires_degree_abstraction", "true")]
+    comment := "Japanese lacks subcomparatives (observed by Snyder, Wexler & Das 1995). Gloss: this shelf-Top [that door-Nom wide YORI (mo)] (more) tall."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def subcomp_en : LinguisticExample :=
+  { id := "beckodasugisaki2004_subcomp_en"
+    source := ⟨"beck-oda-sugisaki-2004", "(5-b), p. 290"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This shelf is taller than that door is wide"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This shelf is taller than that door is wide"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "subcomparative"), ("standard_requires_degree_abstraction", "true")]
+    comment := "English subcomparative control for (5-a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def negisland_ja : LinguisticExample :=
+  { id := "beckodasugisaki2004_negisland_ja"
+    source := ⟨"beck-oda-sugisaki-2004", "(6-a), p. 290"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "John-wa [dare-mo kawa-naka-tta no yori] takai hon-o katta"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John bought a book that is more expensive than the book that nobody bought"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "negative_island"), ("standard_requires_degree_abstraction", "false")]
+    comment := "Well-formed, with the individual-comparing interpretation of the paper's (6'): the yori-clause denotes the (unique) book nobody bought, not a degree set. Gloss: John-Top [anyone buy-Neg-Past NO YORI] expensive book-Acc bought."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def negisland_en : LinguisticExample :=
+  { id := "beckodasugisaki2004_negisland_en"
+    source := ⟨"beck-oda-sugisaki-2004", "(6-b), p. 290"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "*John bought a more expensive book than nobody did"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "*John bought a more expensive book than nobody did"
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "negative_island"), ("standard_requires_degree_abstraction", "true")]
+    comment := "English negative-island effect: no maximal degree such that nobody bought a that-expensive book (Rullmann 1995 undefinedness)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [amount_yori, degree_yori, subcomp_ja, subcomp_en, negisland_ja, negisland_en]
+
+end BeckOdaSugisaki2004.Examples

--- a/Linglib/Semantics/Degree/Basic.lean
+++ b/Linglib/Semantics/Degree/Basic.lean
@@ -183,7 +183,7 @@ theorem not_crossExtentInclusion (μ : Entity → D) (a b : Entity) :
 end Extent
 
 /-! ### Strengthened, negated, and extent-theoretic equatives
-[kennedy-2007] [rett-2020] [schwarzschild-2008] [thomas-deo-2020]
+[kennedy-2007] [rett-2020-equatives] [schwarzschild-2008] [thomas-deo-2020]
 
 The literal equative is "at least as" (`equativeSem .positive`); the "exactly
 as" reading is derived by scalar implicature (choosing *as tall as* over the

--- a/Linglib/Studies/BeckOdaSugisaki2004.lean
+++ b/Linglib/Studies/BeckOdaSugisaki2004.lean
@@ -1,0 +1,59 @@
+import Linglib.Data.Examples.BeckOdaSugisaki2004
+import Linglib.Semantics.Degree.Basic
+
+/-!
+# Beck, Oda & Sugisaki 2004: Parametric Variation in the Semantics of Comparison
+
+[beck-oda-sugisaki-2004] argue that Japanese *yori*-constructions are not
+English-style degree comparatives: the *yori*-constituent is a free relative
+denoting an individual ((34): ⟦John-ga kaita⟧ = what John wrote), which sets
+the context for a positive or contextual comparative in the main clause,
+rather than a *than*-clause denoting a set of degrees. Japanese, they
+conjecture, lacks binding of degree variables in the syntax — their Degree
+Abstraction Parameter — while English has it. Three empirical differences
+follow, recorded in `Data/Examples/BeckOdaSugisaki2004.json`: variable
+acceptability of degree (vs amount) *yori*-comparatives ((3)–(4)), the absence
+of subcomparatives ((5-a) vs (5-b) — the English side is
+`Degree.subcomparative`), and the absence of English-like negative-island
+effects ((6)).
+-/
+
+namespace BeckOdaSugisaki2004
+
+open Data.Examples (LinguisticExample)
+
+/-- The standard clause of this construction only has a well-formed LF if the
+language abstracts over degree variables in the syntax. -/
+def standardRequiresAbstraction (e : LinguisticExample) : Prop :=
+  e.feature? "standard_requires_degree_abstraction" = some "true"
+
+instance (e : LinguisticExample) : Decidable (standardRequiresAbstraction e) :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-- The Japanese rows of (3)–(6). -/
+def japaneseRows : List LinguisticExample :=
+  [ Examples.amount_yori, Examples.subcomp_ja, Examples.negisland_ja ]
+
+/-- The paper's parameter at work in Japanese: a construction whose standard
+clause requires syntactic degree abstraction is ungrammatical, and every
+other recorded construction is acceptable. The degraded-but-not-star (4-a)
+is excluded — its variability is the paper's separate explanandum. -/
+theorem japanese_lacks_degree_abstraction :
+    ∀ e ∈ japaneseRows,
+      e.judgment = .ungrammatical ↔ standardRequiresAbstraction e := by
+  decide
+
+/-- The English controls: both degree-abstraction constructions are
+well-formed LFs, and (6-b)'s ungrammaticality is instead Rullmann-style
+maximality failure over the degree set — undefined, not unbuildable. -/
+def englishRows : List LinguisticExample :=
+  [ Examples.subcomp_en, Examples.negisland_en ]
+
+/-- English has degree abstraction: the subcomparative (5-b) is acceptable
+even though its standard requires it. -/
+theorem english_subcomparative_available :
+    Examples.subcomp_en.judgment = .acceptable ∧
+      standardRequiresAbstraction Examples.subcomp_en := by
+  decide
+
+end BeckOdaSugisaki2004

--- a/Linglib/Studies/Kennedy1999.lean
+++ b/Linglib/Studies/Kennedy1999.lean
@@ -24,9 +24,6 @@ the measure-phrase restriction of §3.1.8–§3.1.9. Kennedy's account defines
 comparison exactly when the compared extents are of the same sort on a shared
 scale; `comparison_defined_iff` and `measurePhrase_positive_iff` check the
 predicted judgment patterns row by row.
-
-Pending relocation to their own study files: subcomparative typology
-([bhatt-pancheva-2004]) and equative data ([kennedy-2007], [rett-2020]).
 -/
 
 namespace Kennedy1999
@@ -109,82 +106,6 @@ def exampleDegPs : List HistoricalDegP :=
   , { head := .superlative, adjective := "tall" }    -- "tallest"
   , { head := .excessive, adjective := "expensive" } -- "too expensive"
   , { head := .sufficiency, adjective := "old" }     -- "old enough"
-  ]
-
-/-! ### Subcomparative typology (pending relocation, [bhatt-pancheva-2004]) -/
-
-/-- Cross-linguistic availability of clausal subcomparatives. -/
-structure SubcomparativeTypologyDatum where
-  language : String
-  available : Bool
-  note : String := ""
-  deriving Repr
-
-def subcomparativeTypology : List SubcomparativeTypologyDatum :=
-  [ { language := "English", available := true }
-  , { language := "German", available := true }
-  , { language := "French", available := true }
-  , { language := "Japanese", available := false
-    , note := "No clausal comparatives of this type" }
-  , { language := "Mandarin", available := false
-    , note := "Exceed-type comparatives don't support subcomparatives" }
-  ]
-
-/-! ### Equative construction data (pending relocation, [kennedy-2007], [rett-2020]) -/
-
-/-- An equative judgment with its available readings ("at_least",
-"exactly", "strict_less"). -/
-structure EquativeJudgment where
-  sentence : String
-  judgment : Features.Judgment
-  availableReadings : List String
-  note : String := ""
-  deriving Repr
-
-def equativeExamples : List EquativeJudgment :=
-  [ { sentence := "Kim is as tall as Lee"
-    , judgment := .acceptable
-    , availableReadings := ["at_least", "exactly"] }
-  , { sentence := "Kim is as tall as Lee, if not taller"
-    , judgment := .acceptable
-    , availableReadings := ["at_least"]
-    , note := "'if not taller' cancels the exactly implicature" }
-  , { sentence := "Kim is not as tall as Lee"
-    , judgment := .acceptable
-    , availableReadings := ["strict_less"]
-    , note := "negated equative = strict inequality" }
-  , { sentence := "Kim ran as fast as Lee"
-    , judgment := .acceptable
-    , availableReadings := ["at_least", "exactly"]
-    , note := "adverbial equative" }
-  ]
-
-/-- Equative encoding strategy ([rett-2020]). -/
-inductive EquativeStrategy where
-  | parameterMarker
-  | reach
-  | similative
-  | exceed
-  deriving DecidableEq, Repr
-
-/-- A language's equative strategy with an example form. -/
-structure EquativeTypologyDatum where
-  language : String
-  strategy : EquativeStrategy
-  exampleForm : String
-  deriving Repr
-
-def equativeTypology : List EquativeTypologyDatum :=
-  [ { language := "English", strategy := .parameterMarker
-    , exampleForm := "as tall as" }
-  , { language := "German", strategy := .parameterMarker
-    , exampleForm := "so groß wie" }
-  , { language := "French", strategy := .similative
-    , exampleForm := "aussi grand que" }
-  , { language := "Mandarin", strategy := .exceed
-    , exampleForm := "跟...一样高 (gēn...yíyàng gāo)" }
-  , { language := "Japanese", strategy := .exceed
-    , exampleForm := "...と同じぐらい高い (...to onaji gurai takai)" }
   ]
 
 end Kennedy1999

--- a/Linglib/Studies/Rett2020Equatives.lean
+++ b/Linglib/Studies/Rett2020Equatives.lean
@@ -1,0 +1,187 @@
+import Linglib.Semantics.Degree.Basic
+
+/-!
+# Rett 2020: Separate but Equal — A Typology of Equative Constructions
+
+[rett-2020-equatives] replicates the descriptive and theoretical typologies of
+comparatives for equatives. Descriptively (§3, after Henkelmann 2006 and
+Haspelmath & Buchholz 1998), languages mark equatives by relative strategies
+(a degree-relativizer standard marker, with or without a parameter marker),
+predicate strategies (a main predicate 'equal' or an adverbial 'equally'),
+conjoined clauses, case-marked standards, or dedicated morphemes.
+Theoretically (Figure 3), predicative equatives lack weak "at least" readings;
+non-predicative equatives split into explicit (parameter-marked) and implicit
+(unmarked, evaluative) — and explicit equatives split again (§4.3) into
+sufficientive parameter markers (English *as*, degree quantifiers, modifiable
+by *twice*) and degree-demonstrative parameter markers (Italian *tanto*,
+unmodifiable).
+
+Only the sufficientive strategy involves degree quantification (§5); its
+set-based ⟦as⟧ ((5-b)) relates degree sets by inclusion, which at extent sets
+is exactly the point-standard equative (`setBasedAs_iff_equativeSem`).
+-/
+
+namespace Rett2020Equatives
+
+/-! ### Descriptive strategies (§3) -/
+
+/-- An equative-marking strategy: the descriptive classes of §3, with
+parameter-marked relatives split per §4.3 and the Appendix. -/
+inductive Strategy where
+  /-- Relativizer standard marker only ("Jane is tall like Bill";
+  Italian *come*, Serbo-Croatian *kao*). -/
+  | relativeSMOnly
+  /-- Degree-demonstrative parameter marker plus relativizer standard marker
+  (Italian *tanto...quanto*, Spanish *tan...como*). -/
+  | relativeDemonstrative
+  /-- Sufficientive parameter marker plus relativizer standard marker
+  (English *as...as*, German *so...wie*). -/
+  | relativeSufficientive
+  /-- Main predicate meaning 'equal' (Nkore-Kiga *-ingana*). -/
+  | predicateMain
+  /-- Adverbial meaning 'equally, to the same extent' (Mandarin *yíyàng*). -/
+  | predicateAdverbial
+  /-- Conjoined parallel clauses, often with an additive particle
+  (Mangarayi). -/
+  | conjoined
+  /-- Case marker or preposition as standard marker (Japanese, Greenlandic). -/
+  | caseMarkedStandard
+  /-- Construction-specific markers with no transparent etymology (Welsh). -/
+  | dedicated
+  deriving DecidableEq, Repr
+
+/-- Theoretical classes (Figure 3). -/
+inductive TheoreticalClass where
+  | predicative
+  | explicitSufficientive
+  | explicitDemonstrative
+  | implicit
+  deriving DecidableEq, Repr
+
+/-- Figure 3's classification. Predicate subtypes pattern together (fn. 11);
+SM-only relatives and conjoined equatives are implicit by the §4.1
+diagnostics; case-marked and dedicated strategies are left for future
+research (§5). -/
+def Strategy.theoretical : Strategy → Option TheoreticalClass
+  | .relativeSMOnly => some .implicit
+  | .relativeDemonstrative => some .explicitDemonstrative
+  | .relativeSufficientive => some .explicitSufficientive
+  | .predicateMain => some .predicative
+  | .predicateAdverbial => some .predicative
+  | .conjoined => some .implicit
+  | .caseMarkedStandard => none
+  | .dedicated => none
+
+/-- A language's equative strategy with the paper's example form and
+location. -/
+structure TypologyDatum where
+  language : String
+  strategy : Strategy
+  form : String
+  /-- Example number or Appendix row. -/
+  source : String
+  deriving Repr
+
+/-- Per-language strategies; a language may use several (English (50)). -/
+def typology : List TypologyDatum :=
+  [ { language := "English", strategy := .relativeSufficientive
+    , form := "as ... as", source := "(50-a), Appendix" }
+  , { language := "English", strategy := .relativeSMOnly
+    , form := "tall like Bill", source := "(50-b)" }
+  , { language := "English", strategy := .predicateMain
+    , form := "equals Bill in height", source := "(50-d)" }
+  , { language := "German", strategy := .relativeSufficientive
+    , form := "so ... wie", source := "Appendix" }
+  , { language := "French", strategy := .relativeSufficientive
+    , form := "aussi ... que", source := "Appendix" }
+  , { language := "Dutch", strategy := .relativeSufficientive
+    , form := "zo ... als", source := "(63)" }
+  , { language := "Swedish", strategy := .relativeSufficientive
+    , form := "så ... som", source := "(67)" }
+  , { language := "Italian", strategy := .relativeSMOnly
+    , form := "come", source := "(61)" }
+  , { language := "Italian", strategy := .relativeDemonstrative
+    , form := "tanto ... quanto", source := "(70)" }
+  , { language := "Spanish", strategy := .relativeDemonstrative
+    , form := "tan ... como", source := "(73)" }
+  , { language := "Croatian", strategy := .relativeSMOnly
+    , form := "kao", source := "(58)" }
+  , { language := "Mandarin", strategy := .predicateAdverbial
+    , form := "gēn ... yíyàng gāo", source := "(37)" }
+  , { language := "Japanese", strategy := .caseMarkedStandard
+    , form := "", source := "§3.4 language list" }
+  , { language := "Nkore-Kiga", strategy := .predicateMain
+    , form := "-ingana ... oburaingwa", source := "(33)" }
+  , { language := "Mangarayi", strategy := .conjoined
+    , form := "ŋa-balayi ... wadij ña-balayi", source := "(42)" }
+  , { language := "Welsh", strategy := .dedicated
+    , form := "cyn ... â", source := "(47)" }
+  ]
+
+/-! ### Diagnostics for explicit equatives (Figure 2) -/
+
+/-- A row of Figure 2: a parameter-marked relative equative with its subtype
+and diagnostic values. `none` records the paper's uncertain cells. -/
+structure ExplicitDiagnostics where
+  language : String
+  pm : String
+  subtype : Strategy
+  modifiable : Option Bool
+  evaluative : Option Bool
+  weakReading : Option Bool
+  deriving Repr
+
+/-- Figure 2's table. Slovenian's uncertain cells and Spanish's uncertain
+modifiability (the consultants' "unnatural" vs Italian's ungrammatical, fn. 15
+and surrounding text) are `none`. -/
+def figure2 : List ExplicitDiagnostics :=
+  [ { language := "English", pm := "as", subtype := .relativeSufficientive
+    , modifiable := some true, evaluative := some false, weakReading := some true }
+  , { language := "Dutch", pm := "zo", subtype := .relativeSufficientive
+    , modifiable := some true, evaluative := some false, weakReading := some true }
+  , { language := "German", pm := "so", subtype := .relativeSufficientive
+    , modifiable := some true, evaluative := some false, weakReading := some true }
+  , { language := "Korean", pm := "mankhum", subtype := .relativeSufficientive
+    , modifiable := some true, evaluative := some false, weakReading := some true }
+  , { language := "Swedish", pm := "så", subtype := .relativeSufficientive
+    , modifiable := some true, evaluative := some false, weakReading := some true }
+  , { language := "Catalan", pm := "tan", subtype := .relativeDemonstrative
+    , modifiable := some false, evaluative := some false, weakReading := some true }
+  , { language := "Italian", pm := "tanto", subtype := .relativeDemonstrative
+    , modifiable := some false, evaluative := some false, weakReading := some true }
+  , { language := "Romanian", pm := "tot", subtype := .relativeDemonstrative
+    , modifiable := some false, evaluative := some false, weakReading := some true }
+  , { language := "Slovenian", pm := "tako", subtype := .relativeDemonstrative
+    , modifiable := some false, evaluative := none, weakReading := none }
+  , { language := "Spanish", pm := "tan", subtype := .relativeDemonstrative
+    , modifiable := none, evaluative := some false, weakReading := some true }
+  ]
+
+/-- Figure 2's generalization: among explicit equatives, factor-modifiability
+holds exactly of the sufficientive parameter markers — the diagnostic that
+splits explicit equatives into two subtypes. -/
+theorem sufficientive_iff_modifiable :
+    ∀ r ∈ figure2, r.modifiable = some true ↔ r.subtype = .relativeSufficientive := by
+  decide
+
+/-- Explicit equatives of both subtypes are non-evaluative wherever Figure 2
+records a value. -/
+theorem explicit_not_evaluative :
+    ∀ r ∈ figure2, r.evaluative = some true → False := by
+  decide
+
+/-! ### The sufficientive equative as a degree quantifier -/
+
+/-- The set-based sufficientive ⟦as⟧ ((5-b)): the standard's degree set is
+included in the target's. -/
+def setBasedAs {D : Type*} (std tgt : Set D) : Prop := std ⊆ tgt
+
+/-- At extent sets, the set-based ⟦as⟧ is the point-standard equative: the
+degree-quantificational sufficientive strategy coincides with
+`Degree.equativeSem` over a measure function. -/
+theorem setBasedAs_iff_equativeSem {Entity D : Type*} [LinearOrder D]
+    (μ : Entity → D) (a b : Entity) :
+    setBasedAs (Set.Iic (μ b)) (Set.Iic (μ a)) ↔ Degree.equativeSem μ a b .positive :=
+  (Degree.equativeSem_iff_Iic_subset μ a b).symm
+
+end Rett2020Equatives

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -37464,3 +37464,34 @@
   validated = {true},
   sources   = {Syntax/Category/Degree/Basic.lean}
 }
+
+@incollection{rett-2020-equatives,
+  author    = {Rett, Jessica},
+  year      = {2020},
+  title     = {Separate but Equal: A Typology of Equative Constructions},
+  booktitle = {Interactions of Degree and Quantification},
+  editor    = {Hallman, Peter},
+  publisher = {Brill},
+  address   = {Leiden},
+  pages     = {163--204},
+  doi       = {10.1163/9789004431515_006},
+  subfield  = {semantics/degree},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Studies/Rett2020Equatives.lean}
+}
+
+@article{beck-oda-sugisaki-2004,
+  author    = {Beck, Sigrid and Oda, Toshiko and Sugisaki, Koji},
+  year      = {2004},
+  title     = {Parametric Variation in the Semantics of Comparison: {Japanese} vs.\ {English}},
+  journal   = {Journal of East Asian Linguistics},
+  volume    = {13},
+  number    = {4},
+  pages     = {289--344},
+  doi       = {10.1007/s10831-004-1289-0},
+  subfield  = {semantics/degree},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Studies/BeckOdaSugisaki2004.lean}
+}


### PR DESCRIPTION
Chronology-rule relocations from the Kennedy 1999 audit (follow-up to #1607).

- New `Studies/Rett2020Equatives.lean` ([rett-2020-equatives], verified against the chapter PDF): the equative-strategy enum rebuilt on Rett's actual §3 classes — the old rows misclassified Mandarin/Japanese as exceed and French as similative; correct classes are sufficientive relative (English/German/French), adverbial predicate (Mandarin (37)), case-marked standard (Japanese). Includes the Figure 2 diagnostics table with `sufficientive_iff_modifiable` and a bridge from the set-based ⟦as⟧ to `Degree.equativeSem`.
- New `Studies/BeckOdaSugisaki2004.lean` + `Data/Examples/BeckOdaSugisaki2004.json` ((3)–(6) verified against the paper): subcomparative unavailability re-attributed from Bhatt–Pancheva to Beck–Oda–Sugisaki; the unattributable Mandarin row and the constructed equative-readings rows are dropped.
- Two verified bib entries (Crossref DOIs); `Degree/Basic`'s equative section repointed from the colliding `rett-2020` key to `rett-2020-equatives`.