### PR TITLE
fix(Data/Examples): re-home LNC examples to Lassiter2025

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -322,7 +322,6 @@ import Linglib.Data.Examples.ArreguiKusumoto1998
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015
 import Linglib.Data.Examples.Bondarenko2022
-import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Data.Examples.Charlow2014
 import Linglib.Data.Examples.ChatzikyriakidisEtAl2025
 import Linglib.Data.Examples.ChungMascarenhas2024
@@ -2930,3 +2929,4 @@ import Linglib.Syntax.WordGrammar.LexicalRules
 import Linglib.Syntax.WordGrammar.Network
 import Linglib.Data.Examples.Kennedy1999
 import Linglib.Data.Examples.BeckOdaSugisaki2004
+import Linglib.Data.Examples.Lassiter2025

--- a/Linglib/Data/Examples/Lassiter2025.json
+++ b/Linglib/Data/Examples/Lassiter2025.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "cwl2025_gibbard",
+    "id": "lass2025_gibbard",
     "source": {"bibkey": "gibbard-1981", "paperLabel": "UNVERIFIED"},
-    "reportedIn": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (4)"},
+    "reportedIn": {"bibkey": "lassiter-2025", "paperLabel": "(4)"},
     "language": "stan1293",
     "primaryText": "If Kripke was there if Strawson was, Anscomb was there",
     "glossedTokens": [],
@@ -19,8 +19,8 @@
     "comment": "Gibbard's classic left-nested conditional, odd out of the blue."
   },
   {
-    "id": "cwl2025_ex11",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (11)"},
+    "id": "lass2025_ex11",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (11)"},
     "language": "stan1293",
     "primaryText": "If the fish will die if you don't change the water, you should change the water",
     "glossedTokens": [],
@@ -37,8 +37,8 @@
     "comment": "Decontextualized bare LNC is marginal."
   },
   {
-    "id": "cwl2025_ex12",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (12)"},
+    "id": "lass2025_ex12",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (12)"},
     "language": "stan1293",
     "primaryText": "If the fish will die if you don't change the water, you should change the water",
     "glossedTokens": [],
@@ -55,8 +55,8 @@
     "comment": "Same LNC as (11), good with a discourse anchor for the inner conditional."
   },
   {
-    "id": "cwl2025_ex13",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (13)"},
+    "id": "lass2025_ex13",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (13)"},
     "language": "stan1293",
     "primaryText": "If this phone will break if you drop it, you'd better be careful",
     "glossedTokens": [],
@@ -73,8 +73,8 @@
     "comment": "Contextualized LNC echoing a prior warning."
   },
   {
-    "id": "cwl2025_ex14",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (14)"},
+    "id": "lass2025_ex14",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (14)"},
     "language": "stan1293",
     "primaryText": "Given that the fish will die if you don't change the water, you should change the water",
     "glossedTokens": [],
@@ -91,8 +91,8 @@
     "comment": "'Given that' paraphrase of (12) confirms the premise-conditional reading."
   },
   {
-    "id": "cwl2025_ex15",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (15)"},
+    "id": "lass2025_ex15",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (15)"},
     "language": "nucl1643",
     "primaryText": "Strawson-ga kite-ita nara Kripke-ga kite-ita nara, Anscomb-ga kite-ita",
     "glossedTokens": [],
@@ -110,8 +110,8 @@
     "comment": "Japanese nara can mark premise conditionals, so the LNC is acceptable."
   },
   {
-    "id": "cwl2025_ex16",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (16)"},
+    "id": "lass2025_ex16",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (16)"},
     "language": "nucl1643",
     "primaryText": "Strawson-ga kite-ita-ra Kripke-ga kite-ita-ra, Anscomb-ga kite-ita",
     "glossedTokens": [],
@@ -129,8 +129,8 @@
     "comment": "Japanese -ra is HC-only, so the LNC is blocked."
   },
   {
-    "id": "cwl2025_ex17",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (17)"},
+    "id": "lass2025_ex17",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (17)"},
     "language": "nucl1643",
     "primaryText": "Sou nara, Anscomb-mo kite-ita",
     "glossedTokens": [],
@@ -148,8 +148,8 @@
     "comment": "'Sou nara' ('if so') echoes A's conditional assertion."
   },
   {
-    "id": "cwl2025_ex20",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (20)"},
+    "id": "lass2025_ex20",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (20)"},
     "language": "stan1295",
     "primaryText": "Wenn Strawson da war, wenn Kripke da war, war Anscomb da",
     "glossedTokens": [],
@@ -167,8 +167,8 @@
     "comment": "German wenn can mark premise conditionals, so the LNC is acceptable."
   },
   {
-    "id": "cwl2025_ex21",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (21)"},
+    "id": "lass2025_ex21",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (21)"},
     "language": "stan1295",
     "primaryText": "Falls Strawson da war, falls Kripke da war, war Anscomb da",
     "glossedTokens": [],
@@ -186,8 +186,8 @@
     "comment": "German falls is HC-only, so the LNC is degraded."
   },
   {
-    "id": "cwl2025_ex22",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (22)"},
+    "id": "lass2025_ex22",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (22)"},
     "language": "stan1295",
     "primaryText": "Falls der Fisch sterben würde, falls du das Wasser nicht wechselst, solltest du es wechseln",
     "glossedTokens": [],
@@ -205,8 +205,8 @@
     "comment": "Modal content allows an HC reading, rescuing falls in an LNC."
   },
   {
-    "id": "cwl2025_ex29",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (29)"},
+    "id": "lass2025_ex29",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (29)"},
     "language": "stan1293",
     "primaryText": "If John helped someone if asked, we're in good shape",
     "glossedTokens": [],
@@ -224,8 +224,8 @@
     "comment": "PPI 'someone' licensed in the embedded consequent (B position)."
   },
   {
-    "id": "cwl2025_ex30",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (30)"},
+    "id": "lass2025_ex30",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (30)"},
     "language": "stan1293",
     "primaryText": "If John helped anyone if asked, we're in good shape",
     "glossedTokens": [],
@@ -243,8 +243,8 @@
     "comment": "NPI 'anyone' blocked in the embedded consequent (PC does not license NPIs)."
   },
   {
-    "id": "cwl2025_ex31",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (31)"},
+    "id": "lass2025_ex31",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (31)"},
     "language": "stan1293",
     "primaryText": "If Mary talked to someone if prompted, the experiment succeeded",
     "glossedTokens": [],
@@ -262,8 +262,8 @@
     "comment": "PPI 'someone' fine in the embedded consequent."
   },
   {
-    "id": "cwl2025_ex32",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (32)"},
+    "id": "lass2025_ex32",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (32)"},
     "language": "stan1293",
     "primaryText": "If Mary talked to anyone if prompted, the experiment succeeded",
     "glossedTokens": [],
@@ -281,8 +281,8 @@
     "comment": "NPI 'anyone' blocked in the embedded consequent."
   },
   {
-    "id": "cwl2025_ex33",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (33)"},
+    "id": "lass2025_ex33",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (33)"},
     "language": "stan1293",
     "primaryText": "If you're hungry and if you want some food, there are biscuits",
     "glossedTokens": [],
@@ -299,8 +299,8 @@
     "comment": "Regular hypothetical conditionals can coordinate."
   },
   {
-    "id": "cwl2025_ex34",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (34)"},
+    "id": "lass2025_ex34",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (34)"},
     "language": "stan1293",
     "primaryText": "If Mary left if John did and if Sue is upset, we have a problem",
     "glossedTokens": [],
@@ -317,8 +317,8 @@
     "comment": "LNC (premise conditional) resists coordination with a regular conditional."
   },
   {
-    "id": "cwl2025_ex35",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (35)"},
+    "id": "lass2025_ex35",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (35)"},
     "language": "stan1293",
     "primaryText": "If the fish will die if you don't change the water and if you care about the fish, change the water",
     "glossedTokens": [],
@@ -335,8 +335,8 @@
     "comment": "Coordination constraint persists even with discourse support."
   },
   {
-    "id": "cwl2025_ex36",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (36)"},
+    "id": "lass2025_ex36",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (36)"},
     "language": "stan1293",
     "primaryText": "Only if you leave will I stay",
     "glossedTokens": [],
@@ -353,8 +353,8 @@
     "comment": "Regular hypothetical conditional allows only + subject-aux inversion."
   },
   {
-    "id": "cwl2025_ex37",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (37)"},
+    "id": "lass2025_ex37",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (37)"},
     "language": "stan1293",
     "primaryText": "Only if Mary left if John did will we have a problem",
     "glossedTokens": [],
@@ -371,8 +371,8 @@
     "comment": "LNC (premise conditional) blocks only + subject-aux inversion."
   },
   {
-    "id": "cwl2025_ex38",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (38)"},
+    "id": "lass2025_ex38",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (38)"},
     "language": "stan1293",
     "primaryText": "We will have a problem only if Mary left if John did",
     "glossedTokens": [],
@@ -389,8 +389,8 @@
     "comment": "Same LNC fine without inversion."
   },
   {
-    "id": "cwl2025_ex40",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (40)"},
+    "id": "lass2025_ex40",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (40)"},
     "language": "stan1293",
     "primaryText": "If the fish would die if you didn't change the water, you should change it",
     "glossedTokens": [],
@@ -407,8 +407,8 @@
     "comment": "Modal 'would' in the inner conditional allows an HC reading without discourse support."
   },
   {
-    "id": "cwl2025_ex41",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (41)"},
+    "id": "lass2025_ex41",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (41)"},
     "language": "stan1293",
     "primaryText": "If a car usually starts if you turn the key, it's probably reliable",
     "glossedTokens": [],
@@ -425,8 +425,8 @@
     "comment": "Quantificational adverb 'usually' provides object-level content."
   },
   {
-    "id": "cwl2025_ex42",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (42)"},
+    "id": "lass2025_ex42",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (42)"},
     "language": "stan1293",
     "primaryText": "If dogs bark if provoked, we should keep them away from the children",
     "glossedTokens": [],
@@ -443,8 +443,8 @@
     "comment": "Generic interpretation allows an HC reading."
   },
   {
-    "id": "cwl2025_ex43",
-    "source": {"bibkey": "cao-white-lassiter-2025", "paperLabel": "UNVERIFIED (43)"},
+    "id": "lass2025_ex43",
+    "source": {"bibkey": "lassiter-2025", "paperLabel": "UNVERIFIED (43)"},
     "language": "stan1293",
     "primaryText": "If John cries if scolded, we shouldn't be too hard on him",
     "glossedTokens": [],

--- a/Linglib/Data/Examples/Lassiter2025.lean
+++ b/Linglib/Data/Examples/Lassiter2025.lean
@@ -1,22 +1,22 @@
 import Linglib.Data.Examples.Schema
 
 /-!
-# `CaoWhiteLassiter2025` — typed example data
+# `Lassiter2025` — typed example data
 
-Auto-generated from `Linglib/Data/Examples/CaoWhiteLassiter2025.json` by
+Auto-generated from `Linglib/Data/Examples/Lassiter2025.json` by
 `scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
 the generator. Consumers (the paper's study file, test-suite hubs) import
-this module; declarations live in `namespace CaoWhiteLassiter2025.Examples`.
+this module; declarations live in `namespace Lassiter2025.Examples`.
 -/
 
-namespace CaoWhiteLassiter2025.Examples
+namespace Lassiter2025.Examples
 
 open Data.Examples
 
-def cwl2025_gibbard : LinguisticExample :=
-  { id := "cwl2025_gibbard"
+def lass2025_gibbard : LinguisticExample :=
+  { id := "lass2025_gibbard"
     source := ⟨"gibbard-1981", "UNVERIFIED"⟩
-    reportedIn := some ⟨"cao-white-lassiter-2025", "UNVERIFIED (4)"⟩
+    reportedIn := some ⟨"lassiter-2025", "(4)"⟩
     language := "stan1293"
     primaryText := "If Kripke was there if Strawson was, Anscomb was there"
     discourseSegments := []
@@ -31,9 +31,9 @@ def cwl2025_gibbard : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex11 : LinguisticExample :=
-  { id := "cwl2025_ex11"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (11)"⟩
+def lass2025_ex11 : LinguisticExample :=
+  { id := "lass2025_ex11"
+    source := ⟨"lassiter-2025", "UNVERIFIED (11)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If the fish will die if you don't change the water, you should change the water"
@@ -49,9 +49,9 @@ def cwl2025_ex11 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex12 : LinguisticExample :=
-  { id := "cwl2025_ex12"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (12)"⟩
+def lass2025_ex12 : LinguisticExample :=
+  { id := "lass2025_ex12"
+    source := ⟨"lassiter-2025", "UNVERIFIED (12)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If the fish will die if you don't change the water, you should change the water"
@@ -67,9 +67,9 @@ def cwl2025_ex12 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex13 : LinguisticExample :=
-  { id := "cwl2025_ex13"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (13)"⟩
+def lass2025_ex13 : LinguisticExample :=
+  { id := "lass2025_ex13"
+    source := ⟨"lassiter-2025", "UNVERIFIED (13)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If this phone will break if you drop it, you'd better be careful"
@@ -85,9 +85,9 @@ def cwl2025_ex13 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex14 : LinguisticExample :=
-  { id := "cwl2025_ex14"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (14)"⟩
+def lass2025_ex14 : LinguisticExample :=
+  { id := "lass2025_ex14"
+    source := ⟨"lassiter-2025", "UNVERIFIED (14)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "Given that the fish will die if you don't change the water, you should change the water"
@@ -103,9 +103,9 @@ def cwl2025_ex14 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex15 : LinguisticExample :=
-  { id := "cwl2025_ex15"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (15)"⟩
+def lass2025_ex15 : LinguisticExample :=
+  { id := "lass2025_ex15"
+    source := ⟨"lassiter-2025", "UNVERIFIED (15)"⟩
     reportedIn := none
     language := "nucl1643"
     primaryText := "Strawson-ga kite-ita nara Kripke-ga kite-ita nara, Anscomb-ga kite-ita"
@@ -121,9 +121,9 @@ def cwl2025_ex15 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex16 : LinguisticExample :=
-  { id := "cwl2025_ex16"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (16)"⟩
+def lass2025_ex16 : LinguisticExample :=
+  { id := "lass2025_ex16"
+    source := ⟨"lassiter-2025", "UNVERIFIED (16)"⟩
     reportedIn := none
     language := "nucl1643"
     primaryText := "Strawson-ga kite-ita-ra Kripke-ga kite-ita-ra, Anscomb-ga kite-ita"
@@ -139,9 +139,9 @@ def cwl2025_ex16 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex17 : LinguisticExample :=
-  { id := "cwl2025_ex17"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (17)"⟩
+def lass2025_ex17 : LinguisticExample :=
+  { id := "lass2025_ex17"
+    source := ⟨"lassiter-2025", "UNVERIFIED (17)"⟩
     reportedIn := none
     language := "nucl1643"
     primaryText := "Sou nara, Anscomb-mo kite-ita"
@@ -157,9 +157,9 @@ def cwl2025_ex17 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex20 : LinguisticExample :=
-  { id := "cwl2025_ex20"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (20)"⟩
+def lass2025_ex20 : LinguisticExample :=
+  { id := "lass2025_ex20"
+    source := ⟨"lassiter-2025", "UNVERIFIED (20)"⟩
     reportedIn := none
     language := "stan1295"
     primaryText := "Wenn Strawson da war, wenn Kripke da war, war Anscomb da"
@@ -175,9 +175,9 @@ def cwl2025_ex20 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex21 : LinguisticExample :=
-  { id := "cwl2025_ex21"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (21)"⟩
+def lass2025_ex21 : LinguisticExample :=
+  { id := "lass2025_ex21"
+    source := ⟨"lassiter-2025", "UNVERIFIED (21)"⟩
     reportedIn := none
     language := "stan1295"
     primaryText := "Falls Strawson da war, falls Kripke da war, war Anscomb da"
@@ -193,9 +193,9 @@ def cwl2025_ex21 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex22 : LinguisticExample :=
-  { id := "cwl2025_ex22"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (22)"⟩
+def lass2025_ex22 : LinguisticExample :=
+  { id := "lass2025_ex22"
+    source := ⟨"lassiter-2025", "UNVERIFIED (22)"⟩
     reportedIn := none
     language := "stan1295"
     primaryText := "Falls der Fisch sterben würde, falls du das Wasser nicht wechselst, solltest du es wechseln"
@@ -211,9 +211,9 @@ def cwl2025_ex22 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex29 : LinguisticExample :=
-  { id := "cwl2025_ex29"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (29)"⟩
+def lass2025_ex29 : LinguisticExample :=
+  { id := "lass2025_ex29"
+    source := ⟨"lassiter-2025", "UNVERIFIED (29)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If John helped someone if asked, we're in good shape"
@@ -229,9 +229,9 @@ def cwl2025_ex29 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex30 : LinguisticExample :=
-  { id := "cwl2025_ex30"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (30)"⟩
+def lass2025_ex30 : LinguisticExample :=
+  { id := "lass2025_ex30"
+    source := ⟨"lassiter-2025", "UNVERIFIED (30)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If John helped anyone if asked, we're in good shape"
@@ -247,9 +247,9 @@ def cwl2025_ex30 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex31 : LinguisticExample :=
-  { id := "cwl2025_ex31"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (31)"⟩
+def lass2025_ex31 : LinguisticExample :=
+  { id := "lass2025_ex31"
+    source := ⟨"lassiter-2025", "UNVERIFIED (31)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If Mary talked to someone if prompted, the experiment succeeded"
@@ -265,9 +265,9 @@ def cwl2025_ex31 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex32 : LinguisticExample :=
-  { id := "cwl2025_ex32"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (32)"⟩
+def lass2025_ex32 : LinguisticExample :=
+  { id := "lass2025_ex32"
+    source := ⟨"lassiter-2025", "UNVERIFIED (32)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If Mary talked to anyone if prompted, the experiment succeeded"
@@ -283,9 +283,9 @@ def cwl2025_ex32 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex33 : LinguisticExample :=
-  { id := "cwl2025_ex33"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (33)"⟩
+def lass2025_ex33 : LinguisticExample :=
+  { id := "lass2025_ex33"
+    source := ⟨"lassiter-2025", "UNVERIFIED (33)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If you're hungry and if you want some food, there are biscuits"
@@ -301,9 +301,9 @@ def cwl2025_ex33 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex34 : LinguisticExample :=
-  { id := "cwl2025_ex34"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (34)"⟩
+def lass2025_ex34 : LinguisticExample :=
+  { id := "lass2025_ex34"
+    source := ⟨"lassiter-2025", "UNVERIFIED (34)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If Mary left if John did and if Sue is upset, we have a problem"
@@ -319,9 +319,9 @@ def cwl2025_ex34 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex35 : LinguisticExample :=
-  { id := "cwl2025_ex35"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (35)"⟩
+def lass2025_ex35 : LinguisticExample :=
+  { id := "lass2025_ex35"
+    source := ⟨"lassiter-2025", "UNVERIFIED (35)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If the fish will die if you don't change the water and if you care about the fish, change the water"
@@ -337,9 +337,9 @@ def cwl2025_ex35 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex36 : LinguisticExample :=
-  { id := "cwl2025_ex36"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (36)"⟩
+def lass2025_ex36 : LinguisticExample :=
+  { id := "lass2025_ex36"
+    source := ⟨"lassiter-2025", "UNVERIFIED (36)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "Only if you leave will I stay"
@@ -355,9 +355,9 @@ def cwl2025_ex36 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex37 : LinguisticExample :=
-  { id := "cwl2025_ex37"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (37)"⟩
+def lass2025_ex37 : LinguisticExample :=
+  { id := "lass2025_ex37"
+    source := ⟨"lassiter-2025", "UNVERIFIED (37)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "Only if Mary left if John did will we have a problem"
@@ -373,9 +373,9 @@ def cwl2025_ex37 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex38 : LinguisticExample :=
-  { id := "cwl2025_ex38"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (38)"⟩
+def lass2025_ex38 : LinguisticExample :=
+  { id := "lass2025_ex38"
+    source := ⟨"lassiter-2025", "UNVERIFIED (38)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "We will have a problem only if Mary left if John did"
@@ -391,9 +391,9 @@ def cwl2025_ex38 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex40 : LinguisticExample :=
-  { id := "cwl2025_ex40"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (40)"⟩
+def lass2025_ex40 : LinguisticExample :=
+  { id := "lass2025_ex40"
+    source := ⟨"lassiter-2025", "UNVERIFIED (40)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If the fish would die if you didn't change the water, you should change it"
@@ -409,9 +409,9 @@ def cwl2025_ex40 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex41 : LinguisticExample :=
-  { id := "cwl2025_ex41"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (41)"⟩
+def lass2025_ex41 : LinguisticExample :=
+  { id := "lass2025_ex41"
+    source := ⟨"lassiter-2025", "UNVERIFIED (41)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If a car usually starts if you turn the key, it's probably reliable"
@@ -427,9 +427,9 @@ def cwl2025_ex41 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex42 : LinguisticExample :=
-  { id := "cwl2025_ex42"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (42)"⟩
+def lass2025_ex42 : LinguisticExample :=
+  { id := "lass2025_ex42"
+    source := ⟨"lassiter-2025", "UNVERIFIED (42)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If dogs bark if provoked, we should keep them away from the children"
@@ -445,9 +445,9 @@ def cwl2025_ex42 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def cwl2025_ex43 : LinguisticExample :=
-  { id := "cwl2025_ex43"
-    source := ⟨"cao-white-lassiter-2025", "UNVERIFIED (43)"⟩
+def lass2025_ex43 : LinguisticExample :=
+  { id := "lass2025_ex43"
+    source := ⟨"lassiter-2025", "UNVERIFIED (43)"⟩
     reportedIn := none
     language := "stan1293"
     primaryText := "If John cries if scolded, we shouldn't be too hard on him"
@@ -463,6 +463,6 @@ def cwl2025_ex43 : LinguisticExample :=
     metaLanguage := "stan1293"
     lgrConformance := "" }
 
-def all : List LinguisticExample := [cwl2025_gibbard, cwl2025_ex11, cwl2025_ex12, cwl2025_ex13, cwl2025_ex14, cwl2025_ex15, cwl2025_ex16, cwl2025_ex17, cwl2025_ex20, cwl2025_ex21, cwl2025_ex22, cwl2025_ex29, cwl2025_ex30, cwl2025_ex31, cwl2025_ex32, cwl2025_ex33, cwl2025_ex34, cwl2025_ex35, cwl2025_ex36, cwl2025_ex37, cwl2025_ex38, cwl2025_ex40, cwl2025_ex41, cwl2025_ex42, cwl2025_ex43]
+def all : List LinguisticExample := [lass2025_gibbard, lass2025_ex11, lass2025_ex12, lass2025_ex13, lass2025_ex14, lass2025_ex15, lass2025_ex16, lass2025_ex17, lass2025_ex20, lass2025_ex21, lass2025_ex22, lass2025_ex29, lass2025_ex30, lass2025_ex31, lass2025_ex32, lass2025_ex33, lass2025_ex34, lass2025_ex35, lass2025_ex36, lass2025_ex37, lass2025_ex38, lass2025_ex40, lass2025_ex41, lass2025_ex42, lass2025_ex43]
 
-end CaoWhiteLassiter2025.Examples
+end Lassiter2025.Examples

--- a/Linglib/Studies/Lassiter2025.lean
+++ b/Linglib/Studies/Lassiter2025.lean
@@ -1,13 +1,13 @@
-import Linglib.Data.Examples.CaoWhiteLassiter2025
+import Linglib.Data.Examples.Lassiter2025
 import Linglib.Fragments.Japanese.Conditionals
 import Linglib.Fragments.German.Conditionals
 
 /-!
 # Left-Nested Conditionals: Bridge
-[lassiter-2025] [cao-white-lassiter-2025]
+[lassiter-2025]
 
-Connects the LNC data from [cao-white-lassiter-2025]
-(`Data/Examples/CaoWhiteLassiter2025.json`) to the conditional marker
+Connects the LNC data from [lassiter-2025]
+(`Data/Examples/Lassiter2025.json`) to the conditional marker
 typology in `Fragments/{Language}/Conditionals.lean`.
 
 ## Main declarations
@@ -22,7 +22,6 @@ typology in `Fragments/{Language}/Conditionals.lean`.
 namespace Lassiter2025
 
 open Data.Examples
-open CaoWhiteLassiter2025
 open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
 
 /-- Marker adapter: the Fragment entry for the row's conditional marker. -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -10132,8 +10132,8 @@
   booktitle = {Proceedings of Sinn und Bedeutung 29},
   url       = {https://ojs.ub.uni-konstanz.de/sub/index.php/sub/article/view/1248/1202},
   subfield  = {semantics/conditionals},
-  role      = {cited},
-  sources   = {Studies/Lassiter2025.lean}
+  role      = {formalized},
+  sources   = {Studies/Lassiter2025.lean;Data/Examples/Lassiter2025.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 
 @article{evcen-bale-barner-2026,


### PR DESCRIPTION
The left-nested-conditional stimuli in `Data/Examples/CaoWhiteLassiter2025.json` (Gibbard's Kripke/Strawson sentence = ex. (4), PC/HC diagnostics, Japanese nara/-ra pairs) belong to [lassiter-2025] (SuB 29, "Sorting out left-nested conditionals"), not the ELM graded-causatives paper — verified against both PDFs. Renames the JSON + generated module, re-keys `reportedIn`, and drops the stray citation from `Studies/Lassiter2025.lean`.