### PR TITLE
fix(Studies/CaoWhiteLassiter2025): correct profiles to paper's models

### DIFF
--- a/Linglib/Features/Causation.lean
+++ b/Linglib/Features/Causation.lean
@@ -96,20 +96,18 @@ inductive Causative where
 
 namespace Causative
 
-/-- Does this variant assert causal sufficiency (N&L Def 23)?
+/-- Does this variant assert causal sufficiency ([nadathur-lauer-2020]'s
+    definition (23))?
 
-    DERIVED: true for variants whose `toSemantics` maps to `causallySufficient`.
-
-    UNVERIFIED: Nadathur & Lauer Def 23 reference cited from memory. -/
+    DERIVED: true for variants whose `toSemantics` maps to `causallySufficient`. -/
 def assertsSufficiency : Causative → Bool
   | .make | .force | .enable => true
   | .cause | .prevent => false
 
-/-- Does this variant assert causal necessity (N&L Def 24)?
+/-- Does this variant assert causal necessity ([nadathur-lauer-2020]'s
+    definition (24))?
 
-    DERIVED: true only for `.cause`, whose `toSemantics` maps to `causeSem`.
-
-    UNVERIFIED: Nadathur & Lauer Def 24 reference cited from memory. -/
+    DERIVED: true only for `.cause`, whose `toSemantics` maps to `causeSem`. -/
 def assertsNecessity : Causative → Bool
   | .cause => true
   | _ => false

--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -154,11 +154,12 @@ noncomputable instance (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterminist
     prediction (and contradicting "Rewind, Revise, Re-run" without
     selective regeneration). -/
 
+omit [Fintype V] [DecidableValuation α] in
 /-- **Counterfactual seed** ([lassiter-2017-probabilistic-language] RRR): the partial valuation that
     `counterfactualSimulate` feeds to `develop`. Sets `antecedent := xAnt`,
     leaves descendants of antecedent undetermined (to be regenerated),
     preserves `observed` values for causally-independent vertices. -/
-noncomputable def cfSeed [DecidableEq V]
+noncomputable def cfSeed
     (M : SEM V α) (observed : Valuation α)
     (antecedent : V) (xAnt : α antecedent) : Valuation α := fun v =>
   if h : v = antecedent then some (h ▸ xAnt)
@@ -166,6 +167,18 @@ noncomputable def cfSeed [DecidableEq V]
     haveI : Decidable (M.graph.IsStrictAncestor antecedent v) := Classical.dec _
     if M.graph.IsStrictAncestor antecedent v then none
     else observed.get v
+
+omit [Fintype V] [DecidableValuation α] in
+/-- At the empty context, `cfSeed` reduces to a plain `extend`: with nothing
+    observed, abduction preserves nothing and the counterfactual seed merely
+    sets the antecedent. -/
+theorem cfSeed_empty (M : SEM V α) (antecedent : V) (xAnt : α antecedent) :
+    cfSeed M Valuation.empty antecedent xAnt =
+      (Valuation.empty (α := α)).extend antecedent xAnt := by
+  funext v
+  by_cases h : v = antecedent
+  · subst h; simp [cfSeed, Valuation.extend]
+  · simp [cfSeed, Valuation.extend, Valuation.empty, h]
 
 /-- **Pearl 3-step counterfactual via Lassiter RRR**, PMF-valued. Given
     actually-observed `observed` and a counterfactual intervention
@@ -178,12 +191,10 @@ noncomputable def cfSeed [DecidableEq V]
     Subsumes (with appropriate derived predicates):
     - `whetherCause` ([beller-gerstenberg-2025] Eq 1, graded)
     - `sufficientCause` ([beller-gerstenberg-2025] Eq 3, graded)
-    - `CaoWhiteLassiter2025.probSufficiency` — [cao-white-lassiter-2025]'s
-      SUF, i.e. Pearl's probability of sufficiency ([pearl-2019]): the
-      counterfactual probability of the effect under intervening the cause,
-      via abduction–action–prediction (not plain interventional probability)
+    - `probSufficiency` — Pearl's probability of sufficiency ([pearl-2019]),
+      the SUF measure of [cao-white-lassiter-2025] (graded)
     - Lassiter probabilistic counterfactuals with overt probability operators -/
-noncomputable def counterfactualSimulate [Fintype V] [DecidableEq V] [DecidableValuation α]
+noncomputable def counterfactualSimulate
     (M : SEM V α) [CausalGraph.IsDAG M.graph]
     (observed : Valuation α) (antecedent : V) (xAnt : α antecedent) :
     PMF (Valuation α) :=
@@ -202,7 +213,7 @@ noncomputable def counterfactualSimulate [Fintype V] [DecidableEq V] [DecidableV
 
     For deterministic SEMs, collapses to a {0,1} indicator (see
     `whetherCause_eq_indicator_of_deterministic`). -/
-noncomputable def whetherCause [Fintype V] [DecidableEq V] [DecidableValuation α]
+noncomputable def whetherCause
     (M : SEM V α) [CausalGraph.IsDAG M.graph]
     (observed : Valuation α) (antecedent : V) (xAnt_alt : α antecedent)
     (effect : V) (xEff_actual : α effect) : ENNReal :=
@@ -221,11 +232,27 @@ noncomputable def whetherCause [Fintype V] [DecidableEq V] [DecidableValuation �
     siblings of `antecedent` set to their absent values. The substrate
     doesn't currently provide a `removeAlternatives` constructor; callers
     build it explicitly via `s.extend altᵢ xAbsentᵢ` chains. -/
-noncomputable def sufficientCause [Fintype V] [DecidableEq V] [DecidableValuation α]
+noncomputable def sufficientCause
     (M : SEM V α) [CausalGraph.IsDAG M.graph]
     (alternativesRemoved : Valuation α) (antecedent : V) (xAnt_alt : α antecedent)
     (effect : V) (xEff_actual : α effect) : ENNReal :=
   whetherCause M alternativesRemoved antecedent xAnt_alt effect xEff_actual
+
+/-- **Probability of sufficiency** ([pearl-2019]), the SUF measure of
+    [cao-white-lassiter-2025]: the counterfactual probability that
+    intervening `cause := xC` yields `effect = xE`, evaluated against the
+    factual context `observed` — Pearl's three-step
+    abduction–action–prediction, via `counterfactualSimulate`.
+
+    Distinct from plain interventional probability `P(effect | do(cause))`:
+    causally-independent parents of `effect` recorded in `observed` are
+    *preserved* rather than re-sampled — the oxygen-vs-match contrast
+    [pearl-2019] uses to motivate the measure. -/
+noncomputable def probSufficiency
+    (M : SEM V α) [CausalGraph.IsDAG M.graph]
+    (observed : Valuation α) (cause : V) (xC : α cause)
+    (effect : V) (xE : α effect) : ENNReal :=
+  (counterfactualSimulate M observed cause xC).probOfSet {v | v.hasValue effect xE}
 
 -- ════════════════════════════════════════════════════
 -- § Bridge theorems: deterministic collapse
@@ -259,6 +286,21 @@ theorem whetherCause_eq_indicator_of_deterministic
   simp only [PMF.probOfSet, PMF.toOuterMeasure_pure_apply, Set.mem_setOf_eq]
   by_cases h : (M.developDet (cfSeed M observed antecedent xAnt_alt)).hasValue effect xEff_actual <;>
     simp [h]
+
+/-- Bridge: under `IsDeterministic`, `probSufficiency` collapses to the {0,1}
+    indicator of whether the counterfactual development hits `effect = xE` —
+    the deterministic limit in which [cao-white-lassiter-2025]'s graded SUF
+    recovers a categorical sufficiency judgment. -/
+theorem probSufficiency_eq_indicator_of_deterministic
+    (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterministic M]
+    (observed : Valuation α) (cause : V) (xC : α cause)
+    (effect : V) (xE : α effect) :
+    probSufficiency M observed cause xC effect xE =
+      if (M.developDet (cfSeed M observed cause xC)).hasValue effect xE then 1 else 0 := by
+  unfold probSufficiency
+  rw [counterfactualSimulate_eq_pure_of_deterministic]
+  simp only [PMF.probOfSet, PMF.toOuterMeasure_pure_apply, Set.mem_setOf_eq]
+  by_cases h : (M.developDet (cfSeed M observed cause xC)).hasValue effect xE <;> simp [h]
 
 end Causation.SEM
 

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -1,172 +1,64 @@
-/-
-# Graded Causative Verb Semantics
-[cao-white-lassiter-2025]
-
-Causative verbs *cause*, *make*, and *force* encode not just sufficiency
-or necessity but a **unique blend of three graded measures**:
-
-| Measure | Definition | Source |
-|---------|-----------|--------|
-| SUF | Probability of sufficiency | [pearl-2019] |
-| INT | Degree of intention | |
-| ALT | Number of causee alternatives | |
-
-## Key Finding
-
-No single measure determines verb choice. Each verb has a unique
-**interaction profile** (Table 1):
-
-| Interaction | *caused* | *made* | *forced* |
-|---|---|---|---|
-| SUF×INT | - | **+** | - |
-| SUF×ALT | + | + | + |
-| INT×ALT | + | + | + |
-| SUF×INT×ALT | - | - | - |
-
-Notably, *make* uniquely has a reliable SUF×INT interaction, which
-distinguishes it from both *cause* and *force*.
-
-## SUF as Pearl's probability of sufficiency
-
-SUF is Pearl's **probability of sufficiency** ([pearl-2019]): the
-*counterfactual* probability that intervening to set the cause would
-produce the effect, evaluated against a factual context in which the
-cause took some other value and the effect did not already obtain. It is
-a genuine probability (`ENNReal`-valued), not a 0/1 indicator.
-
-Following [pearl-2019]'s three-step abduction–action–prediction, `SUF`
-(`probSufficiency`) is built on the substrate's `counterfactualSimulate`
-(`develop` of `cfSeed`): abduction preserves causally-independent
-observations and regenerates descendants (the high-stability reduction,
-[lassiter-2017-probabilistic-language], [lucas-kemp-2015]); action sets
-the cause; prediction reads off the effect's probability via the canonical
-`PMF.probOfSet`. This distinguishes SUF from plain interventional
-probability `P(effect | do(cause))`: causally-independent parents of the
-effect that were observed are *preserved* rather than re-sampled from
-their priors — the oxygen-vs-match contrast [pearl-2019] uses to motivate
-the measure.
-
-In the deterministic limit `SUF` collapses to a {0,1} indicator
-(`probSufficiency_of_deterministic`); at the vacuous (empty) context,
-where abduction is trivial, it reduces to the [nadathur-lauer-2020]
-Def-23 sufficiency predicate `causallySufficient`
-(`probSufficiency_empty_eq_deterministicSuf`).
-
--/
-
-import Mathlib.Data.Rat.Defs
 import Mathlib.Data.NNReal.Basic
 import Mathlib.Probability.ProbabilityMassFunction.Constructions
-import Mathlib.Tactic.NormNum
-import Linglib.Core.Probability.Finite
-import Linglib.Semantics.Causation.CoerciveImplication
-import Linglib.Semantics.Intensional.WorldTimeIndex
-import Linglib.Semantics.Causation.SEM.Counterfactual
 import Linglib.Semantics.Causation.Interpretation
+import Linglib.Semantics.Causation.SEM.Counterfactual
+
+/-!
+# Cao, White & Lassiter 2025: graded causative verb semantics
+[cao-white-lassiter-2025]
+
+*Cause*, *make*, and *force* are graded causatives: acceptability tracks
+three causal-model measures rather than a categorical sufficiency or
+necessity condition — SUF, Pearl's probability of sufficiency
+([pearl-2019], `Causation.SEM.probSufficiency`); INT, the causer's degree
+of intention (after [halpern-kleiman-weiner-2018], normalized to [0,1]);
+and ALT, the number of alternative actions available to the causee.
+
+## Main results
+
+- `interactionProfile`: the reliable interaction terms of each verb's
+  per-verb regression model. Each tested verb's profile is distinct
+  (`profiles_pairwise_distinct` — the paper's headline), and the three-way
+  SUF×INT×ALT term is reliably negative for all three
+  (`shared_negative_sufIntAlt`).
+- `probSufficiency_empty_eq_deterministicSuf`: at the empty context,
+  Pearl's counterfactual SUF collapses to [nadathur-lauer-2020]'s
+  categorical sufficiency (their definition (23), `deterministicSuf`) —
+  "interventional = counterfactual at a vacuous context" as a theorem.
+- `make_force_same_semantics_different_profiles`: the force-dynamic
+  dispatch (`Causative.toSemantics`) assigns *make* and *force* literally
+  identical truth conditions, yet their graded interaction profiles
+  differ — the graded data cut where the categorical semantics cannot.
+- `ProbabilisticExample`: a Bernoulli-mechanism SEM witnessing that
+  `probSufficiency` requires no determinism.
+
+In the full regression (model I) *made* uniquely carries a reliable
+positive SUF×INT interaction (0.45, CI [0.02, 0.87]); no verb's SUF×INT
+is reliable in the per-verb models. Main effects (model I): SUF
+residualized on ALT +1.19, INT +0.54, ALT −0.82 (SUF and ALT
+anticorrelate at −0.81, hence the residualization).
+-/
 
 namespace CaoWhiteLassiter2025
 
-open Intensional (WorldTimeIndex)
 open Causation (BoolSEM CausalGraph Valuation Mechanism SEM DecidableValuation)
 open Causation.Mechanism (const)
-open Causation.SEM (counterfactualSimulate counterfactualSimulate_eq_pure_of_deterministic cfSeed)
-open Causation.CoerciveImplication (ActionType)
-open Features (Causative)
+open Causation.SEM (probSufficiency probSufficiency_eq_indicator_of_deterministic cfSeed
+  cfSeed_empty)
 open Features
 
-/-! ## The Three Measures
+/-! ### Deterministic limit
 
-All three are defined within structural causal models.
-SUF is continuous ∈ [0,1], INT is continuous ∈ [0,1], ALT is ℕ. -/
+In the deterministic limit, SUF collapses to a {0,1} indicator
+(`Causation.SEM.probSufficiency_eq_indicator_of_deterministic`). At the
+vacuous (empty) context this is exactly [nadathur-lauer-2020]'s causal
+sufficiency (their definition (23)): with nothing observed, Pearl's
+counterfactual degenerates to the bare interventional development of
+`cause := true`. -/
 
-/-- The three causal measures that jointly predict causative verb acceptability.
-
-- `suf`: Probability of sufficiency ([pearl-2019]). Continuous [0,1].
-  Computed via `probSufficiency` over a (possibly probabilistic) `SEM V α`.
-- `int`: Degree of intention. Continuous [0,1].
-  How much the causer intended the outcome relative to alternatives.
-- `alt`: Number of alternative actions available to the causee. ℕ.
-  Fewer alternatives → stronger causal influence. -/
-structure CausalMeasures where
-  suf : ℚ
-  int : ℚ
-  alt : ℕ
-  deriving Repr, DecidableEq
-
-/-! ## SUF: Pearl's probability of sufficiency
-
-[pearl-2019]'s probability of sufficiency — the counterfactual probability
-that intervening to set `cause := xC` produces `effect = xE`, against a
-factual context `observed` (cause took some other value, effect did not
-obtain). Built on the substrate's `counterfactualSimulate`
-(Pearl 3-step abduction–action–prediction, via the high-stability
-reduction in `cfSeed`) and the canonical `PMF.probOfSet`. -/
-
-section PearlSufficiency
-
-variable {V : Type*} {α : V → Type*}
-  [Fintype V] [DecidableEq V] [DecidableValuation α]
-
-/-- **Probability of sufficiency** ([pearl-2019]), the SUF measure of
-    [cao-white-lassiter-2025]: the counterfactual probability that
-    intervening `cause := xC` yields `effect = xE`, evaluated against the
-    factual context `observed`.
-
-    Pearl's three-step abduction–action–prediction, expressed via the
-    substrate's `counterfactualSimulate` (`develop` of `cfSeed`): abduction
-    preserves causally-independent observations and regenerates descendants
-    (the high-stability reduction, [lassiter-2017-probabilistic-language],
-    [lucas-kemp-2015]); action sets `cause := xC`; prediction reads off the
-    probability of `effect = xE` via `PMF.probOfSet`.
-
-    Distinct from plain interventional probability `P(effect | do(cause))`:
-    causally-independent parents of `effect` recorded in `observed` are
-    *preserved* rather than re-sampled — the oxygen-vs-match contrast
-    [pearl-2019] uses to motivate the measure. -/
-noncomputable def probSufficiency
-    (M : SEM V α) [CausalGraph.IsDAG M.graph]
-    (observed : Valuation α) (cause : V) (xC : α cause)
-    (effect : V) (xE : α effect) : ENNReal :=
-  (counterfactualSimulate M observed cause xC).probOfSet {v | v.hasValue effect xE}
-
-/-- Under `IsDeterministic`, `probSufficiency` collapses to the {0,1}
-    indicator of whether the counterfactual development hits `effect = xE`.
-    Follows from `counterfactualSimulate_eq_pure_of_deterministic` plus
-    `PMF.toOuterMeasure_pure_apply`. -/
-theorem probSufficiency_of_deterministic
-    (M : SEM V α) [CausalGraph.IsDAG M.graph] [Causation.SEM.IsDeterministic M]
-    (observed : Valuation α) (cause : V) (xC : α cause)
-    (effect : V) (xE : α effect) :
-    probSufficiency M observed cause xC effect xE =
-      if (M.developDet (cfSeed M observed cause xC)).hasValue effect xE then 1 else 0 := by
-  unfold probSufficiency
-  rw [counterfactualSimulate_eq_pure_of_deterministic]
-  simp only [PMF.probOfSet, PMF.toOuterMeasure_pure_apply, Set.mem_setOf_eq]
-  congr 1
-
-omit [Fintype V] [DecidableValuation α] in
-/-- At the empty (vacuous-abduction) context, `cfSeed` reduces to a plain
-    `extend`: with nothing observed, abduction preserves nothing and the
-    counterfactual seed merely sets the cause. -/
-theorem cfSeed_empty (M : SEM V α) (cause : V) (xC : α cause) :
-    cfSeed M Valuation.empty cause xC = (Valuation.empty (α := α)).extend cause xC := by
-  funext v
-  by_cases h : v = cause
-  · subst h; simp [cfSeed, Valuation.extend]
-  · simp [cfSeed, Valuation.extend, Valuation.empty, h]
-
-end PearlSufficiency
-
-/-! ## Deterministic limit
-
-In the deterministic limit (every mechanism a Dirac), SUF collapses to a
-{0,1} indicator. At the vacuous (empty) context this is exactly the
-[nadathur-lauer-2020] Def-23 sufficiency predicate `causallySufficient` —
-with nothing observed, Pearl's counterfactual degenerates to the bare
-interventional development of `cause := true`. -/
-
-/-- Deterministic SUF as a {0,1} indicator over a `BoolSEM`: the
-    [nadathur-lauer-2020] Def-23 sufficiency predicate `causallySufficient`. -/
+/-- Deterministic SUF as a {0,1} indicator over a `BoolSEM`:
+    [nadathur-lauer-2020]'s causal sufficiency (their definition (23)),
+    `causallySufficient`. -/
 noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
     [Causation.SEM.IsDeterministic M]
@@ -176,7 +68,7 @@ noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
 
 /-- **Grounding theorem**: at the empty context (vacuous abduction), the
     counterfactual `probSufficiency` reduces to the deterministic {0,1}
-    indicator `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s Def-23
+    indicator `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s causal
     sufficiency. Makes "interventional = counterfactual at a vacuous
     context" a theorem rather than a conflation. -/
 theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
@@ -184,36 +76,23 @@ theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [Decid
     [Causation.SEM.IsDeterministic M] (c e : V) :
     probSufficiency M Valuation.empty c true e true
       = deterministicSuf M Valuation.empty c e := by
-  rw [probSufficiency_of_deterministic, cfSeed_empty]
+  rw [probSufficiency_eq_indicator_of_deterministic, cfSeed_empty]
   unfold deterministicSuf Causation.BoolSEM.causallySufficient
     Causation.SEM.causallySufficient Causation.SEM.developsToValue
-  by_cases h : (M.developDet ((Valuation.empty (α := fun _ : V => Bool)).extend c true)).hasValue e true <;>
+  by_cases h :
+      (M.developDet ((Valuation.empty (α := fun _ : V => Bool)).extend c true)).hasValue e true <;>
     simp [h]
 
-/-! ## ALT → ActionType Bridge
+/-! ### Interaction profiles
 
-Cao et al.'s continuous ALT measure generalizes the binary
-Volitional/NonVolitional distinction in `CoerciveImplication`. -/
+The core empirical finding: no single measure determines verb choice, and
+each verb has a unique set of reliable interaction terms among SUF, INT,
+and ALT in its per-verb regression model. Only the reliable terms
+(credible interval excluding 0) are encoded; the paper's summary table
+also reports unreliable trends, which are not data. -/
 
-/-- Map ALT count to the categorical ActionType from CoerciveImplication.
-
-- ALT = 0: causee had no choice → NonVolitional (forced action)
-- ALT > 0: causee could have done otherwise → Volitional -/
-def altToActionType (alt : ℕ) : ActionType :=
-  if alt > 0 then .Volitional else .NonVolitional
-
-theorem alt_zero_nonvolitional : altToActionType 0 = .NonVolitional := rfl
-
-theorem alt_positive_volitional (n : ℕ) (h : n > 0) :
-    altToActionType n = .Volitional := by
-  simp [altToActionType, h]
-
-/-! ## Interaction Profiles
-
-The core empirical finding: each verb has a unique set of
-reliable interaction terms among SUF, INT, and ALT. -/
-
-/-- Two-way and three-way interaction terms from the regression model. -/
+/-- Two-way and three-way interaction terms among the SUF, INT, and ALT
+    predictors. -/
 inductive InteractionTerm where
   | sufInt
   | sufAlt
@@ -221,84 +100,53 @@ inductive InteractionTerm where
   | sufIntAlt
   deriving DecidableEq, Repr
 
-/-- A verb's interaction profile: which interaction terms reliably
-predict its acceptability. -/
+/-- A verb's interaction profile: the interaction terms that reliably
+    predict its acceptability, by sign. -/
 structure InteractionProfile where
-  verb : String
-  reliablePositive : List InteractionTerm
-  reliableNegative : List InteractionTerm
-  deriving Repr
+  /-- Terms with a reliably positive coefficient. -/
+  reliablePositive : Finset InteractionTerm
+  /-- Terms with a reliably negative coefficient. -/
+  reliableNegative : Finset InteractionTerm
+  deriving DecidableEq
 
-def causeProfile : InteractionProfile :=
-  { verb := "caused"
-  , reliablePositive := [.sufAlt, .intAlt]
-  , reliableNegative := [.sufIntAlt] }
+/-- Reliable interaction terms of each verb's per-verb model
+    ([cao-white-lassiter-2025] models V–VII); `none` for causatives the
+    paper did not test. -/
+def interactionProfile : Causative → Option InteractionProfile
+  | .cause => some ⟨{.sufAlt, .intAlt}, {.sufIntAlt}⟩
+  | .make => some ⟨{.sufAlt}, {.sufIntAlt}⟩
+  | .force => some ⟨∅, {.sufIntAlt}⟩
+  | .enable | .prevent => none
 
-def makeProfile : InteractionProfile :=
-  { verb := "made"
-  , reliablePositive := [.sufInt, .sufAlt, .intAlt]
-  , reliableNegative := [.sufIntAlt] }
+/-- The three-way SUF×INT×ALT interaction is reliably negative for every
+    verb tested: high values on all three measures together *depress*
+    acceptability. -/
+theorem shared_negative_sufIntAlt :
+    ∀ v ∈ [Causative.cause, .make, .force], ∀ p ∈ interactionProfile v,
+      InteractionTerm.sufIntAlt ∈ p.reliableNegative := by decide
 
-def forceProfile : InteractionProfile :=
-  { verb := "forced"
-  , reliablePositive := [.sufAlt, .intAlt]
-  , reliableNegative := [.sufIntAlt] }
+/-- Each tested verb has a distinct interaction profile — the paper's
+    headline finding that no single measure (nor shared measure blend)
+    determines causative verb choice. -/
+theorem profiles_pairwise_distinct :
+    interactionProfile .cause ≠ interactionProfile .make ∧
+    interactionProfile .cause ≠ interactionProfile .force ∧
+    interactionProfile .make ≠ interactionProfile .force := by decide
 
-/-- *make* uniquely has a reliable SUF×INT interaction. -/
-theorem make_has_unique_sufInt :
-    makeProfile.reliablePositive.contains .sufInt = true ∧
-    causeProfile.reliablePositive.contains .sufInt = false ∧
-    forceProfile.reliablePositive.contains .sufInt = false ∧
-    causeProfile.reliableNegative.contains .sufInt = false ∧
-    forceProfile.reliableNegative.contains .sufInt = false := by decide
+/-- The force-dynamic dispatch collapses *make* and *force* to literally
+    identical truth conditions ([nadathur-lauer-2020] via
+    `Causative.toSemantics`), but their graded interaction profiles
+    differ — the graded measures cut where the categorical semantics
+    cannot. -/
+theorem make_force_same_semantics_different_profiles
+    {V : Type*} {α : V → Type*} [Fintype V] [DecidableEq V] [DecidableValuation α]
+    [∀ v, Fintype (α v)] (M : SEM V α) [CausalGraph.IsDAG M.graph]
+    [Causation.SEM.IsDeterministic M] :
+    Causative.toSemantics M .make = Causative.toSemantics M .force ∧
+    interactionProfile .make ≠ interactionProfile .force :=
+  ⟨rfl, by decide⟩
 
-/-- All three verbs share the SUF×ALT and INT×ALT interactions. -/
-theorem shared_interactions :
-    causeProfile.reliablePositive.contains .sufAlt = true ∧
-    makeProfile.reliablePositive.contains .sufAlt = true ∧
-    forceProfile.reliablePositive.contains .sufAlt = true ∧
-    causeProfile.reliablePositive.contains .intAlt = true ∧
-    makeProfile.reliablePositive.contains .intAlt = true ∧
-    forceProfile.reliablePositive.contains .intAlt = true := by decide
-
-/-- *make* and *force* both assert sufficiency at the enum level but have
-    different interaction profiles. -/
-theorem make_force_both_assert_sufficiency_different_profiles :
-    Causative.make.assertsSufficiency = true ∧
-    Causative.force.assertsSufficiency = true ∧
-    (makeProfile.reliablePositive ≠ forceProfile.reliablePositive) := by
-  refine ⟨rfl, rfl, ?_⟩
-  decide
-
-/-! ## Main Effects
-
-The regression coefficients for the main effects, showing the
-direction and relative magnitude of each measure's contribution. -/
-
-/-- Main effect coefficients from the Bayesian regression.
-
--- UNVERIFIED: coefficient values (+1.19, +0.54, -0.82) need verification -/
-structure MainEffects where
-  sufResidAlt : ℚ
-  int : ℚ
-  alt : ℚ
-  deriving Repr
-
-def modelIMainEffects : MainEffects :=
-  { sufResidAlt := 119/100
-  , int := 54/100
-  , alt := -82/100 }
-
-theorem suf_largest_main_effect :
-    modelIMainEffects.sufResidAlt > modelIMainEffects.int ∧
-    modelIMainEffects.sufResidAlt > -modelIMainEffects.alt := by
-  simp [modelIMainEffects]; norm_num
-
-theorem alt_negative_effect :
-    modelIMainEffects.alt < 0 := by
-  simp [modelIMainEffects]; norm_num
-
-/-! ## Probabilistic example: genuinely fractional SUF
+/-! ### Probabilistic example: genuinely fractional SUF
 
 A 2-vertex SEM whose `effect` mechanism is `PMF.bernoulli p` —
 genuinely probabilistic, not Dirac. Demonstrates that `probSufficiency`
@@ -335,8 +183,9 @@ def vDepth : V → ℕ
 instance : CausalGraph.IsDAG graph :=
   CausalGraph.IsDAG.of_depth graph vDepth (by
     intro u v h
-    cases v <;> simp [graph, CausalGraph.parents] at h <;>
-      subst h <;> decide)
+    cases v <;> simp [graph] at h
+    subst h
+    decide)
 
 instance (p : ℝ≥0) (h : p ≤ 1) : CausalGraph.IsDAG (model p h).graph :=
   inferInstanceAs (CausalGraph.IsDAG graph)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -9814,6 +9814,16 @@
   doi       = {10.1515/jci-2019-0026},
   subfield  = {semantics/causation},
   role      = {referenced}
+}
+@inproceedings{halpern-kleiman-weiner-2018,
+  author    = {Halpern, Joseph Y. and Kleiman-Weiner, Max},
+  year      = {2018},
+  title     = {Towards Formal Definitions of Blameworthiness, Intention, and Moral Responsibility},
+  booktitle = {Proceedings of the Thirty-Second AAAI Conference on Artificial Intelligence},
+  doi       = {10.1609/aaai.v32i1.11557},
+  subfield  = {semantics/causation},
+  role      = {referenced},
+  sources   = {Studies/CaoWhiteLassiter2025.lean}
 }% REF: Frankfurt, H. G. (1969). Alternate possibilities and moral responsibility.
 @article{karttunen-1971,
   author    = {Karttunen, Lauri},


### PR DESCRIPTION
Four-lens audit rework of the graded-causatives study, checked against the ELM paper.

- Correct the interaction profiles to the per-verb models' reliable terms (*made*: only SUF×ALT positive; *force*: none; the old `shared_interactions` was false of the paper), re-keyed on `Features.Causative` with `Finset`/`∈` Props instead of String + `List.contains`; regression coefficients (verified exact vs Table 2) demoted to docstring prose; dead `CausalMeasures`/`MainEffects`/`altToActionType` cut.
- Graduate `probSufficiency` (+ `cfSeed_empty`, deterministic-indicator lemma) into `Semantics/Causation/SEM/Counterfactual.lean` beside `whetherCause`/`sufficientCause`, fixing that file's upward docstring reference; new divergence theorem: the force-dynamic dispatch gives *make* = *force* identical truth conditions (`rfl`) while their graded profiles differ.
- Verify Nadathur & Lauer's definitions (23)/(24) against the Glossa text (clears the UNVERIFIED flags in `Features/Causation.lean`); add verified `halpern-kleiman-weiner-2018` for INT.