### PR TITLE
refactor(Semantics/Causation): graph Ranking/TimeIndex; study cleanup

### DIFF
--- a/Linglib/Core/Probability/Constructions.lean
+++ b/Linglib/Core/Probability/Constructions.lean
@@ -125,17 +125,6 @@ noncomputable def mix (r : ℝ≥0) (hr : r ≤ 1) (p q : PMF α) : PMF α :=
   ext a
   simp
 
-/-- The Bernoulli distribution on `Bool` as a mixture of point masses —
-the PMF-side replacement for mathlib's deprecated `PMF.bernoulli` (whose
-`Measure` successor `ProbabilityTheory.bernoulliMeasure` has the same
-point-mass-mixture shape). -/
-noncomputable def bernoulliMix (r : ℝ≥0) (hr : r ≤ 1) : PMF Bool :=
-  mix r hr (pure false) (pure true)
-
-@[simp] theorem bernoulliMix_apply (r : ℝ≥0) (hr : r ≤ 1) (b : Bool) :
-    bernoulliMix r hr b = if b then (r : ℝ≥0∞) else 1 - r := by
-  cases b <;> simp [bernoulliMix]
-
 /-- The mixture in ℝ: `(1 − r)·p + r·q` pointwise. -/
 theorem toRealFn_mix (r : ℝ≥0) (hr : r ≤ 1) (p q : PMF α) (a : α) :
     (mix r hr p q).toRealFn a = (1 - r) * p.toRealFn a + r * q.toRealFn a := by

--- a/Linglib/Core/Probability/Constructions.lean
+++ b/Linglib/Core/Probability/Constructions.lean
@@ -104,16 +104,37 @@ theorem sum_toRealFn_eq_one [Fintype α] (p : PMF α) :
 
 /-! ### Convex mixture -/
 
-/-- Convex combination of two PMFs at rate `r`: draw a Bernoulli-`r` coin,
-then sample `q` on heads and `p` on tails. Normalization is free from
-`bind` — no `Fintype`, no sum proof. -/
+/-- Convex combination of two PMFs at rate `r`: sample `q` with
+probability `r` and `p` otherwise. No `Fintype` needed — `ENNReal`
+summability is unconditional. -/
 noncomputable def mix (r : ℝ≥0) (hr : r ≤ 1) (p q : PMF α) : PMF α :=
-  (bernoulli r hr).bind fun b => bif b then q else p
+  ⟨fun a => (1 - r) * p a + r * q a, ENNReal.summable.hasSum_iff.mpr (by
+    rw [ENNReal.tsum_add, ENNReal.tsum_mul_left, ENNReal.tsum_mul_left, p.tsum_coe,
+      q.tsum_coe, mul_one, mul_one, tsub_add_cancel_of_le (by exact_mod_cast hr)])⟩
 
 @[simp] theorem mix_apply (r : ℝ≥0) (hr : r ≤ 1) (p q : PMF α) (a : α) :
-    mix r hr p q a = (1 - r) * p a + r * q a := by
-  rw [mix, bind_apply, tsum_bool]
-  simp [bernoulli_apply, mul_comm]
+    mix r hr p q a = (1 - r) * p a + r * q a := rfl
+
+/-- A rate-`0` mixture is its first component. -/
+@[simp] theorem mix_zero (p q : PMF α) : mix (0 : ℝ≥0) zero_le_one p q = p := by
+  ext a
+  simp
+
+/-- A rate-`1` mixture is its second component. -/
+@[simp] theorem mix_one (p q : PMF α) : mix (1 : ℝ≥0) le_rfl p q = q := by
+  ext a
+  simp
+
+/-- The Bernoulli distribution on `Bool` as a mixture of point masses —
+the PMF-side replacement for mathlib's deprecated `PMF.bernoulli` (whose
+`Measure` successor `ProbabilityTheory.bernoulliMeasure` has the same
+point-mass-mixture shape). -/
+noncomputable def bernoulliMix (r : ℝ≥0) (hr : r ≤ 1) : PMF Bool :=
+  mix r hr (pure false) (pure true)
+
+@[simp] theorem bernoulliMix_apply (r : ℝ≥0) (hr : r ≤ 1) (b : Bool) :
+    bernoulliMix r hr b = if b then (r : ℝ≥0∞) else 1 - r := by
+  cases b <;> simp [bernoulliMix]
 
 /-- The mixture in ℝ: `(1 − r)·p + r·q` pointwise. -/
 theorem toRealFn_mix (r : ℝ≥0) (hr : r ≤ 1) (p q : PMF α) (a : α) :

--- a/Linglib/Core/Probability/Entropy.lean
+++ b/Linglib/Core/Probability/Entropy.lean
@@ -101,8 +101,9 @@ theorem entropy_nonneg (p : PMF α) : 0 ≤ p.entropy := by
     anti-drift — if mathlib changes `binEntropy` semantics the equivalence
     becomes provably false.
 
-    TODO: stated in a follow-up. Requires `PMF.bernoulli` (mathlib has it
-    over `ℝ≥0`; needs ℝ-coercion + arithmetic identities `negMulLog x =
+    TODO: stated in a follow-up. Requires `PMF.bernoulliMix`
+    (`Core/Probability/Constructions`) over `ℝ≥0`; needs ℝ-coercion +
+    arithmetic identities `negMulLog x =
     x · log x⁻¹` for the Bernoulli case). ~20 LOC. -/
 example : True := trivial  -- placeholder; see TODO above
 

--- a/Linglib/Core/Probability/Entropy.lean
+++ b/Linglib/Core/Probability/Entropy.lean
@@ -101,8 +101,8 @@ theorem entropy_nonneg (p : PMF α) : 0 ≤ p.entropy := by
     anti-drift — if mathlib changes `binEntropy` semantics the equivalence
     becomes provably false.
 
-    TODO: stated in a follow-up. Requires `PMF.bernoulliMix`
-    (`Core/Probability/Constructions`) over `ℝ≥0`; needs ℝ-coercion +
+    TODO: stated in a follow-up. Requires a Bernoulli coin (a
+    `PMF.mix` of point masses) over `ℝ≥0`; needs ℝ-coercion +
     arithmetic identities `negMulLog x =
     x · log x⁻¹` for the Bernoulli case). ~20 LOC. -/
 example : True := trivial  -- placeholder; see TODO above

--- a/Linglib/Core/Probability/Finite.lean
+++ b/Linglib/Core/Probability/Finite.lean
@@ -35,7 +35,7 @@ namespace PMF
 
 variable {α : Type*} [Fintype α]
 
-open scoped ENNReal NNReal
+open scoped ENNReal
 open BigOperators
 
 /-- Probability mass of a set under a finite-fintype PMF, named to match
@@ -241,35 +241,5 @@ theorem condExpect_add (p : PMF α) (A : Set α) (f g : α → ℝ≥0∞) :
 theorem condExpect_zero (p : PMF α) (A : Set α) : p.condExpect A 0 = 0 := by
   unfold condExpect
   simp [Set.indicator]
-
-/-! ### Mixtures
-
-Convex combination of two distributions. `[UPSTREAM]` candidate: mathlib's
-`PMF` has no mixture combinator. -/
-
-omit [Fintype α] in
-/-- The `w`-weighted mixture of two distributions samples from `p` with
-    probability `w` and from `q` otherwise. -/
-noncomputable def mix (w : ℝ≥0) (hw : w ≤ 1) (p q : PMF α) : PMF α :=
-  ⟨fun a => w * p a + (1 - w : ℝ≥0) * q a, ENNReal.summable.hasSum_iff.mpr (by
-    rw [ENNReal.tsum_add, ENNReal.tsum_mul_left, ENNReal.tsum_mul_left, p.tsum_coe,
-      q.tsum_coe, mul_one, mul_one, ← ENNReal.coe_add, add_tsub_cancel_of_le hw,
-      ENNReal.coe_one])⟩
-
-omit [Fintype α] in
-@[simp] theorem mix_apply (w : ℝ≥0) (hw : w ≤ 1) (p q : PMF α) (a : α) :
-    mix w hw p q a = w * p a + (1 - w : ℝ≥0) * q a := rfl
-
-omit [Fintype α] in
-/-- A `0`-weighted mixture is its second component. -/
-@[simp] theorem mix_zero (p q : PMF α) : mix (0 : ℝ≥0) zero_le_one p q = q := by
-  ext a
-  simp
-
-omit [Fintype α] in
-/-- A `1`-weighted mixture is its first component. -/
-@[simp] theorem mix_one (p q : PMF α) : mix (1 : ℝ≥0) le_rfl p q = p := by
-  ext a
-  simp
 
 end PMF

--- a/Linglib/Core/Probability/Finite.lean
+++ b/Linglib/Core/Probability/Finite.lean
@@ -35,7 +35,7 @@ namespace PMF
 
 variable {α : Type*} [Fintype α]
 
-open scoped ENNReal
+open scoped ENNReal NNReal
 open BigOperators
 
 /-- Probability mass of a set under a finite-fintype PMF, named to match
@@ -241,5 +241,35 @@ theorem condExpect_add (p : PMF α) (A : Set α) (f g : α → ℝ≥0∞) :
 theorem condExpect_zero (p : PMF α) (A : Set α) : p.condExpect A 0 = 0 := by
   unfold condExpect
   simp [Set.indicator]
+
+/-! ### Mixtures
+
+Convex combination of two distributions. `[UPSTREAM]` candidate: mathlib's
+`PMF` has no mixture combinator. -/
+
+omit [Fintype α] in
+/-- The `w`-weighted mixture of two distributions samples from `p` with
+    probability `w` and from `q` otherwise. -/
+noncomputable def mix (w : ℝ≥0) (hw : w ≤ 1) (p q : PMF α) : PMF α :=
+  ⟨fun a => w * p a + (1 - w : ℝ≥0) * q a, ENNReal.summable.hasSum_iff.mpr (by
+    rw [ENNReal.tsum_add, ENNReal.tsum_mul_left, ENNReal.tsum_mul_left, p.tsum_coe,
+      q.tsum_coe, mul_one, mul_one, ← ENNReal.coe_add, add_tsub_cancel_of_le hw,
+      ENNReal.coe_one])⟩
+
+omit [Fintype α] in
+@[simp] theorem mix_apply (w : ℝ≥0) (hw : w ≤ 1) (p q : PMF α) (a : α) :
+    mix w hw p q a = w * p a + (1 - w : ℝ≥0) * q a := rfl
+
+omit [Fintype α] in
+/-- A `0`-weighted mixture is its second component. -/
+@[simp] theorem mix_zero (p q : PMF α) : mix (0 : ℝ≥0) zero_le_one p q = q := by
+  ext a
+  simp
+
+omit [Fintype α] in
+/-- A `1`-weighted mixture is its first component. -/
+@[simp] theorem mix_one (p q : PMF α) : mix (1 : ℝ≥0) le_rfl p q = p := by
+  ext a
+  simp
 
 end PMF

--- a/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
+++ b/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
@@ -1,5 +1,6 @@
 import Mathlib.Probability.ProbabilityMassFunction.Constructions
 import Linglib.Core.Probability.Posterior
+import Linglib.Core.Probability.Constructions
 import Linglib.Morphology.FragmentGrammars.FragmentGrammar
 
 /-!
@@ -13,7 +14,7 @@ from that density. The architecture follows the macro-expansion of
 mapping each Church construct to a Lean component:
 
 - `(PYmem a b _)` ⤳ `pypDraw` over `PYPState` with `PYM := StateT _ PMF`.
-- `(if (delay? args) (delay body) body)` ⤳ `PMF.bernoulli` halt-coin per
+- `(if (delay? args) (delay body) body)` ⤳ `PMF.bernoulliMix` halt-coin per
   §3.1.8 (p. 92).
 - The `(delay body)` thunks ⤳ `LazyTree.fragment` constructor.
 
@@ -510,7 +511,7 @@ noncomputable def stochasticLazyUnfoldDepth
     ℕ → α → PMF (LazyTree α β R)
   | 0,     x => PMF.pure (.fragment x)
   | n + 1, x => do
-      let coin ← PMF.bernoulli (recurseProb x) (recurseProb_le x)
+      let coin ← PMF.bernoulliMix (recurseProb x) (recurseProb_le x)
       if coin then do
         let ⟨rule, rhs⟩ ← recurse x
         let kids ← rhs.mapM (fun
@@ -549,7 +550,7 @@ private noncomputable def fragmentLambdaStep [Inhabited β]
     (recurseProb_le : ∀ x, recurseProb x ≤ 1)
     (recur : α → PYM α (LazyTree α β R) (LazyTree α β R)) :
     α → PYM α (LazyTree α β R) (LazyTree α β R) := fun y => do
-  let coin ← PYM.liftBase (PMF.bernoulli (recurseProb y) (recurseProb_le y))
+  let coin ← PYM.liftBase (PMF.bernoulliMix (recurseProb y) (recurseProb_le y))
   if coin then do
     let ⟨rule, rhs⟩ ← PYM.liftBase (recurse y)
     let kids ← rhs.mapM (fun

--- a/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
+++ b/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
@@ -14,7 +14,7 @@ from that density. The architecture follows the macro-expansion of
 mapping each Church construct to a Lean component:
 
 - `(PYmem a b _)` ⤳ `pypDraw` over `PYPState` with `PYM := StateT _ PMF`.
-- `(if (delay? args) (delay body) body)` ⤳ `PMF.bernoulliMix` halt-coin per
+- `(if (delay? args) (delay body) body)` ⤳ `PMF.mix` halt-coin per
   §3.1.8 (p. 92).
 - The `(delay body)` thunks ⤳ `LazyTree.fragment` constructor.
 
@@ -511,7 +511,7 @@ noncomputable def stochasticLazyUnfoldDepth
     ℕ → α → PMF (LazyTree α β R)
   | 0,     x => PMF.pure (.fragment x)
   | n + 1, x => do
-      let coin ← PMF.bernoulliMix (recurseProb x) (recurseProb_le x)
+      let coin ← PMF.mix (recurseProb x) (recurseProb_le x) (PMF.pure false) (PMF.pure true)
       if coin then do
         let ⟨rule, rhs⟩ ← recurse x
         let kids ← rhs.mapM (fun
@@ -550,7 +550,8 @@ private noncomputable def fragmentLambdaStep [Inhabited β]
     (recurseProb_le : ∀ x, recurseProb x ≤ 1)
     (recur : α → PYM α (LazyTree α β R) (LazyTree α β R)) :
     α → PYM α (LazyTree α β R) (LazyTree α β R) := fun y => do
-  let coin ← PYM.liftBase (PMF.bernoulliMix (recurseProb y) (recurseProb_le y))
+  let coin ← PYM.liftBase
+    (PMF.mix (recurseProb y) (recurseProb_le y) (PMF.pure false) (PMF.pure true))
   if coin then do
     let ⟨rule, rhs⟩ ← PYM.liftBase (recurse y)
     let kids ← rhs.mapM (fun

--- a/Linglib/Semantics/Causation/Graph/Basic.lean
+++ b/Linglib/Semantics/Causation/Graph/Basic.lean
@@ -14,6 +14,11 @@ well-founded fixpoint induction).
 The ancestor relation uses `Relation.ReflTransGen` directly (no
 intermediate adapter); consumers can use mathlib's existing API for
 reflexive-transitive closures.
+
+Acyclicity certificates come bundled as `Ranking` (parents rank strictly
+below children) and its strict-successor refinement `TimeIndex` (parents
+immediately precede children, the time-indexed causal models of
+[cao-white-lassiter-2025]); `IsDAG.of_depth` passes the loose form.
 -/
 
 namespace Causation.CausalGraph
@@ -62,24 +67,55 @@ class IsDAG (G : CausalGraph V) : Prop where
   /-- The strict-ancestor relation has no infinite descending chain. -/
   wf : WellFounded G.IsStrictAncestor
 
-/-- **Depth-based IsDAG construction**: a graph is acyclic if every edge
-    strictly decreases some `ℕ`-valued depth function (parent depth <
-    child depth). Reuses `Subrelation.wf` over `InvImage Nat.lt depth`,
-    which is well-founded by `Nat`'s standard wellfoundedness.
+/-- A ranking of a causal graph is a `ℕ`-valued measure on which every
+    parent ranks strictly below its children — the bundled form of the
+    depth certificate consumed by `IsDAG.of_depth` and, per model, by the
+    fuel bridges (`causallyEntails_iff_fuel`, `causallyNecessary_iff_fuel`). -/
+structure Ranking (G : CausalGraph V) where
+  /-- The rank of each vertex. -/
+  rank : V → ℕ
+  /-- Parents rank strictly below their children. -/
+  parent_lt : ∀ {u v : V}, u ∈ G.parents v → rank u < rank v
+
+/-- A ranking certifies acyclicity: ranks strictly increase along the
+    strict-ancestor relation, so the relation embeds in `Nat.lt`.
 
     The standard mathlib pattern for proving wellfoundedness of finite
     inductive relations: define a measure into `ℕ`, show the relation
     decreases it, conclude. -/
-theorem IsDAG.of_depth (G : CausalGraph V) (depth : V → ℕ)
-    (hdepth : ∀ {u v : V}, u ∈ G.parents v → depth u < depth v) :
-    IsDAG G where
+theorem Ranking.isDAG {G : CausalGraph V} (r : Ranking G) : IsDAG G where
   wf := by
-    have hsub : ∀ u v, G.IsStrictAncestor u v → depth u < depth v := by
+    have hsub : ∀ u v, G.IsStrictAncestor u v → r.rank u < r.rank v := by
       intro u v huv
       induction huv with
-      | single hp => exact hdepth hp
-      | tail _ hp ih => exact lt_trans ih (hdepth hp)
+      | single hp => exact r.parent_lt hp
+      | tail _ hp ih => exact lt_trans ih (r.parent_lt hp)
     exact Subrelation.wf (fun {a b} => hsub a b)
-      (InvImage.wf depth Nat.lt_wfRel.wf)
+      (InvImage.wf r.rank Nat.lt_wfRel.wf)
+
+/-- A graph is acyclic if every edge strictly decreases some `ℕ`-valued
+    depth function — `Ranking.isDAG` with the certificate passed loose. -/
+theorem IsDAG.of_depth (G : CausalGraph V) (depth : V → ℕ)
+    (hdepth : ∀ {u v : V}, u ∈ G.parents v → depth u < depth v) :
+    IsDAG G :=
+  Ranking.isDAG ⟨depth, hdepth⟩
+
+/-- A time index for a causal graph is a timestep assignment on which
+    each parent sits exactly one step before its children — the
+    time-indexed causal models of [cao-white-lassiter-2025]
+    (their definition 1) and [cao-geiger-kreiss-icard-gerstenberg-2023]. -/
+structure TimeIndex (G : CausalGraph V) where
+  /-- The timestep of each variable. -/
+  time : V → ℕ
+  /-- Parents immediately precede their children. -/
+  parent_succ : ∀ {u v : V}, u ∈ G.parents v → time u + 1 = time v
+
+/-- The ranking underlying a time index. -/
+def TimeIndex.toRanking {G : CausalGraph V} (ti : TimeIndex G) : Ranking G :=
+  ⟨ti.time, fun h => by have := ti.parent_succ h; omega⟩
+
+/-- A time index certifies acyclicity. -/
+theorem TimeIndex.isDAG {G : CausalGraph V} (ti : TimeIndex G) : IsDAG G :=
+  ti.toRanking.isDAG
 
 end Causation.CausalGraph

--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -327,6 +327,12 @@ abbrev manipulates (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
     [SEM.IsDeterministic M] (s : Valuation (fun _ : V => Bool)) (cause effect : V) : Prop :=
   SEM.manipulates M s cause true false effect
 
+/-- `BoolSEM`-flavored `probSufficiency`: the counterfactual probability
+    that intervening `cause := true` yields `effect = true`. -/
+noncomputable abbrev probSufficiency (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
+    (s : Valuation (fun _ : V => Bool)) (cause effect : V) : ENNReal :=
+  SEM.probSufficiency M s cause true effect true
+
 /-- **Direct causal connection**: `cause` is a parent of `effect` in
     the SEM's graph. Pure structural predicate (no `developDet`); fully
     decidable structurally via `Finset.decidableMem`. -/

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -15,9 +15,10 @@ model: Pearl's probability of sufficiency ([pearl-2019],
 `Causation.SEM.probSufficiency`), a simplified
 [halpern-kleiman-weiner-2018] degree of intention (`intentionDegree`),
 and the number of alternative actions available to the causee
-(`altCount`). The models are time-indexed (`TimeIndex`), and their
-agents play a soft-optimality policy (`softOptimalPolicy`). The model
-apparatus is shared with [cao-geiger-kreiss-icard-gerstenberg-2023].
+(`altCount`). The models are time-indexed (`CausalGraph.TimeIndex`),
+and their agents play a soft-optimality policy (`softOptimalPolicy`).
+The model apparatus is shared with
+[cao-geiger-kreiss-icard-gerstenberg-2023].
 
 The paper's in-text judgments (its examples (3)–(11)) are stored as rows
 in `Data/Examples/CaoWhiteLassiter2025.json`. Regression estimates
@@ -35,27 +36,6 @@ namespace CaoWhiteLassiter2025
 
 open Causation Causation.Mechanism Causation.SEM Features
 open scoped ENNReal NNReal
-
-/-! ### Time-indexed causal models
-
-Definition 1 of [cao-white-lassiter-2025]: exogenous and endogenous
-variables carry timesteps, and every parent *immediately precedes* its
-child. The timestep function is a strengthened form of the depth
-certificate `CausalGraph.IsDAG.of_depth` consumes. -/
-
-/-- A time index for a causal graph is a timestep assignment on which
-    each parent sits exactly one step before its children — definition 1
-    of [cao-white-lassiter-2025]. -/
-structure TimeIndex {V : Type*} (G : CausalGraph V) where
-  /-- The timestep of each variable. -/
-  time : V → ℕ
-  /-- Parents immediately precede their children. -/
-  parent_succ : ∀ {u v : V}, u ∈ G.parents v → time u + 1 = time v
-
-/-- A time index certifies acyclicity. -/
-theorem TimeIndex.isDAG {V : Type*} {G : CausalGraph V} (ti : TimeIndex G) :
-    CausalGraph.IsDAG G :=
-  CausalGraph.IsDAG.of_depth G ti.time fun h => by have := ti.parent_succ h; omega
 
 /-! ### Soft-optimality policy
 
@@ -304,7 +284,7 @@ noncomputable def model (p : ℝ≥0) (h : p ≤ 1) : BoolSEM V :=
 
 /-- The 2-vertex graph is time-indexed in the sense of the paper's
     definition 1, with `cause` at step 0 and `effect` at step 1. -/
-def timeIndex : TimeIndex graph where
+def timeIndex : CausalGraph.TimeIndex graph where
   time := fun | .cause => 0 | .effect => 1
   parent_succ := by
     intro u v h

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -125,24 +125,24 @@ theorem intentionDegree_le_one : intentionDegree pr w a ≤ 1 :=
       (Finset.mem_univ a)
 
 theorem intentionDegree_eq_one_of_no_alternatives
-    (halt : ∀ a ≠ taken, pr a = 0)
-    (h0 : pr taken * w taken ≠ 0) (hfin : pr taken ≠ ∞) :
+    (h : ∀ a ≠ taken, pr a = 0) (h0 : pr taken ≠ 0) (hw : w taken ≠ 0)
+    (htop : pr taken ≠ ∞) :
     intentionDegree pr w taken = 1 := by
   rw [intentionDegree, Finset.sum_eq_single_of_mem taken (Finset.mem_univ taken)
-    fun a _ ha => by rw [halt a ha, zero_mul]]
-  exact ENNReal.div_self h0 (ENNReal.mul_ne_top hfin ENNReal.coe_ne_top)
+    fun a _ ha => by rw [h a ha, zero_mul]]
+  exact ENNReal.div_self (mul_ne_zero h0 (ENNReal.coe_ne_zero.mpr hw))
+    (ENNReal.mul_ne_top htop ENNReal.coe_ne_top)
 
 /-- An action without alternatives is trivially intentional — the
     alternative-possibilities principle ([frankfurt-1969], via
     [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
     contrast in its example (8). -/
 theorem intentionDegree_eq_one_of_altCount_eq_zero
-    (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
-    (h0 : pr taken * w taken ≠ 0) :
+    (hle : pr ≤ ⇑p) (h : altCount p taken = 0) (h0 : pr taken ≠ 0) (hw : w taken ≠ 0) :
     intentionDegree pr w taken = 1 :=
   intentionDegree_eq_one_of_no_alternatives taken pr w
-    (fun a ha => le_zero_iff.mp ((altCount_eq_zero_iff p taken).mp halt a ha ▸ hle a))
-    h0 (ne_top_of_le_ne_top (p.apply_ne_top taken) (hle taken))
+    (fun a ha => le_zero_iff.mp ((altCount_eq_zero_iff p taken).mp h a ha ▸ hle a))
+    h0 hw (ne_top_of_le_ne_top (p.apply_ne_top taken) (hle taken))
 
 end
 

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -33,11 +33,7 @@ terms.
 
 namespace CaoWhiteLassiter2025
 
-open Causation (BoolSEM CausalGraph Valuation Mechanism SEM DecidableValuation)
-open Causation.Mechanism (const)
-open Causation.SEM (probSufficiency probSufficiency_eq_indicator_of_deterministic cfSeed
-  cfSeed_empty develop)
-open Features
+open Causation Causation.Mechanism Causation.SEM Features
 open scoped ENNReal NNReal
 
 /-! ### Time-indexed causal models
@@ -214,10 +210,10 @@ counterfactual degenerates to the bare interventional development of
     definition (23), `causallySufficient`). -/
 noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
-    [Causation.SEM.IsDeterministic M]
+    [IsDeterministic M]
     (background : Valuation (fun _ : V => Bool))
     (cause effect : V) : ENNReal :=
-  if Causation.BoolSEM.causallySufficient M background cause effect then 1 else 0
+  if BoolSEM.causallySufficient M background cause effect then 1 else 0
 
 /-- At the empty context (vacuous abduction), the counterfactual
     `probSufficiency` reduces to the deterministic {0,1} indicator
@@ -226,12 +222,12 @@ noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     vacuous context" a theorem rather than a conflation. -/
 theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
-    [Causation.SEM.IsDeterministic M] (c e : V) :
+    [IsDeterministic M] (c e : V) :
     probSufficiency M Valuation.empty c true e true
       = deterministicSuf M Valuation.empty c e := by
   rw [probSufficiency_eq_indicator_of_deterministic, cfSeed_empty]
-  unfold deterministicSuf Causation.BoolSEM.causallySufficient
-    Causation.SEM.causallySufficient Causation.SEM.developsToValue
+  unfold deterministicSuf BoolSEM.causallySufficient SEM.causallySufficient
+    SEM.developsToValue
   by_cases h :
       (M.developDet ((Valuation.empty (α := fun _ : V => Bool)).extend c true)).hasValue e true <;>
     simp [h]
@@ -245,13 +241,13 @@ theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [Decid
     strictly stronger than maximal graded SUF. -/
 theorem probSufficiency_empty_eq_one_of_make
     {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [Causation.SEM.IsDeterministic M]
+    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [IsDeterministic M]
     (c e : V)
     (h : Causative.toSemantics M .make Valuation.empty c true e true) :
     probSufficiency M Valuation.empty c true e true = 1 := by
   rw [probSufficiency_empty_eq_deterministicSuf]
   unfold deterministicSuf
-  exact if_pos (Causation.SEM.causallySufficient_of_causallyEntails h.2)
+  exact if_pos (causallySufficient_of_causallyEntails h.2)
 
 /-! ### The paper's judgment data
 
@@ -271,7 +267,7 @@ docstring: analysis outputs are not Lean content. -/
 theorem make_force_same_semantics_different_judgments
     {V : Type*} {α : V → Type*} [Fintype V] [DecidableEq V] [DecidableValuation α]
     [∀ v, Fintype (α v)] (M : SEM V α) [CausalGraph.IsDAG M.graph]
-    [Causation.SEM.IsDeterministic M] :
+    [IsDeterministic M] :
     Causative.toSemantics M .make = Causative.toSemantics M .force ∧
     Examples.cwl2025_ex8a.judgment = .acceptable ∧
     Examples.cwl2025_ex8b.judgment = .questionable :=

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -7,60 +7,28 @@ import Linglib.Semantics.Causation.SEM.Counterfactual
 
 /-!
 # Cao, White & Lassiter 2025: graded causative verb semantics
-[cao-white-lassiter-2025]
 
-*Cause*, *make*, and *force* as graded causatives: a semantics built
-around threshold values on continuous scales, where the scales are three
-measures defined within a single structural causal model — SUF, Pearl's
-probability of sufficiency ([pearl-2019],
-`Causation.SEM.probSufficiency`); INT, a simplified
-[halpern-kleiman-weiner-2018] degree of intention (`intentionDegree`);
-and ALT, the number of alternative actions available to the causee
-(`altCount`). The paper's models are time-indexed (`TimeIndex`, its
-definition 1), with the agents' mechanisms derived from utilities by a
-soft-optimality policy of skill ρ (`softOptimalPolicy`) — continuing the
-SCM causative-verbs program of [cao-geiger-kreiss-icard-gerstenberg-2023].
+This file formalizes the graded-causative analysis of English *cause*,
+*make*, and *force* from [cao-white-lassiter-2025]. On that account,
+acceptability tracks three measures defined in one structural causal
+model: Pearl's probability of sufficiency ([pearl-2019],
+`Causation.SEM.probSufficiency`), a simplified
+[halpern-kleiman-weiner-2018] degree of intention (`intentionDegree`),
+and the number of alternative actions available to the causee
+(`altCount`). The models are time-indexed (`TimeIndex`), and their
+agents play a soft-optimality policy (`softOptimalPolicy`). The model
+apparatus is shared with [cao-geiger-kreiss-icard-gerstenberg-2023].
 
-## Main declarations
+The paper's in-text judgments (its examples (3)–(11)) are stored as rows
+in `Data/Examples/CaoWhiteLassiter2025.json`. Regression estimates
+remain in prose; no single measure reliably determines verb choice, and
+each verb's per-verb model has a distinct set of reliable interaction
+terms.
 
-- `TimeIndex`: definition 1's parents-immediately-precede-children
-  timestep certificate; yields acyclicity (`TimeIndex.isDAG`).
-- `softOptimalPolicy`: the highest-utility move with probability
-  `ρ + (1−ρ)/n`, others `(1−ρ)/n`. At `ρ = 0` it is the uniform random
-  player (`softOptimalPolicy_zero_apply`) — the paper's own limiting case
-  under which its worked SUF contrast collapses; at `ρ = 1` the
-  deterministic professional (`softOptimalPolicy_one`).
-- `altCount` (§2.2): alternatives available to the causee, excluding the
-  action taken.
-- `intentionDegree` (§2.3): the goal-weighted share of the taken action
-  among goal-conducive alternatives.
-  `intentionDegree_eq_one_of_altCount_eq_zero`: no alternatives
-  trivialize intention — the [frankfurt-1969] alternative-possibilities
-  principle behind the paper's *made*/*forced* contrast (its example 8).
-- `probSufficiency_empty_eq_deterministicSuf` and
-  `probSufficiency_empty_eq_one_of_make`: SUF grounded, at the
-  deterministic/vacuous-context limit, in [nadathur-lauer-2020]'s
-  categorical sufficiency (their definition (23)).
-- `make_force_same_semantics_different_judgments`: the force-dynamic
-  dispatch collapses *make* and *force*; the paper's minimal pair (8)
-  (rows in `Data.Examples.CaoWhiteLassiter2025`) pulls them apart.
+## References
 
-The paper's in-text judgment data — non-interchangeability triplets,
-gym-gradability triplets, the could-have-done-otherwise pair, the
-intent-denial continuations, the *make*/*let* sufficiency pair — are
-typed rows in `Data/Examples/CaoWhiteLassiter2025.json`.
-
-## Experimental summary (prose; analysis outputs are not Lean content)
-
-Tic-tac-toe three-frame stimuli annotated with model-derived ALT, INT,
-SUF; Bayesian logistic regressions on accurate/inaccurate judgments.
-Model I main effects: SUF residualized on ALT +1.19, INT +0.54, ALT
-−0.82 (the −0.81 SUF∼ALT anticorrelation motivates residualization);
-*made* uniquely carries a reliable positive SUF×INT interaction in
-model I (0.45, CI [0.02, 0.87]). Per-verb models: *cause* reliable in
-SUF×ALT (+), INT×ALT (+), SUF×INT×ALT (−); *made* in SUF×ALT (+),
-SUF×INT×ALT (−); *forced* only in SUF×INT×ALT (−) — each verb a distinct
-reliability profile, and no single measure determines verb choice.
+* [A. Cao, A. S. White, D. Lassiter,
+  *Cause, make, and force as graded causatives*][cao-white-lassiter-2025]
 -/
 
 namespace CaoWhiteLassiter2025
@@ -79,9 +47,9 @@ variables carry timesteps, and every parent *immediately precedes* its
 child. The timestep function is a strengthened form of the depth
 certificate `CausalGraph.IsDAG.of_depth` consumes. -/
 
-/-- A **time index** for a causal graph (definition 1 of
-    [cao-white-lassiter-2025]): a timestep assignment on which each parent
-    sits exactly one step before its children. -/
+/-- A time index for a causal graph is a timestep assignment on which
+    each parent sits exactly one step before its children — definition 1
+    of [cao-white-lassiter-2025]. -/
 structure TimeIndex {V : Type*} (G : CausalGraph V) where
   /-- The timestep of each variable. -/
   time : V → ℕ
@@ -102,9 +70,10 @@ and every other available move with `(1−ρ)/n`. The skill parameter ρ
 interpolates between a random player (`ρ = 0`, "a less skilled player")
 and a professional (`ρ = 1`). -/
 
-/-- **Soft-optimality policy** (§2.1.1 of [cao-white-lassiter-2025]): the
-    highest-utility move `best` with probability `ρ + (1−ρ)/n`, every
-    other move with `(1−ρ)/n`, over the `n` available moves. -/
+/-- The soft-optimality policy of a player of skill `ρ` takes the
+    highest-utility move `best` with probability `ρ + (1−ρ)/n` and each
+    of the other `n − 1` available moves with probability `(1−ρ)/n`
+    (§2.1.1 of [cao-white-lassiter-2025]). -/
 noncomputable def softOptimalPolicy {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
     (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
   PMF.ofFintype
@@ -127,24 +96,26 @@ theorem softOptimalPolicy_zero_apply {A : Type*} [Fintype A] [DecidableEq A] [No
   simp [softOptimalPolicy]
 
 /-- At `ρ = 1` the soft-optimality policy is the deterministic
-    professional: a Dirac on the highest-utility move. -/
+    professional — a Dirac on the highest-utility move. -/
 theorem softOptimalPolicy_one {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
     (best : A) :
     softOptimalPolicy best 1 le_rfl = PMF.pure best := by
   ext a
   simp [softOptimalPolicy, PMF.pure_apply]
 
-/-! ### ALT: alternatives available to the causee -/
+/-! ### The ALT measure -/
 
-/-- **ALT** (§2.2 of [cao-white-lassiter-2025]): the number of alternative
-    actions available to the causee, *excluding the action actually
-    taken* — the support of the causee's action distribution minus
-    `taken` (`ALT(Y₁) = 5` at the paper's fig. 2a board state). -/
+/-- `altCount p taken` is the number of alternative actions available to
+    the causee — the support of the action distribution `p`, excluding
+    the action actually taken. This is the ALT measure of
+    [cao-white-lassiter-2025] (§2.2; `ALT(Y₁) = 5` at its fig. 2a board
+    state). -/
 noncomputable def altCount {A : Type*} (p : PMF A) (taken : A) : ℕ :=
   (p.support \ {taken}).ncard
 
-/-- `ALT = 0` says exactly that the causee could not have done otherwise:
-    every action other than the one taken has probability zero. -/
+/-- `ALT = 0` says exactly that the causee could not have done
+    otherwise — every action other than the one taken has probability
+    zero. -/
 theorem altCount_eq_zero_iff {A : Type*} [Fintype A] (p : PMF A) (taken : A) :
     altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
   rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty]
@@ -156,7 +127,7 @@ theorem altCount_eq_zero_iff {A : Type*} [Fintype A] (p : PMF A) (taken : A) :
     by_contra hne
     exact (p.mem_support_iff a).mp ha (h a (by simpa using hne))
 
-/-! ### INT: degree of intention
+/-! ### The INT measure
 
 The paper's §2.3 displayed equation, a simplified
 [halpern-kleiman-weiner-2018] degree of intention:
@@ -170,15 +141,16 @@ weighted by exponentiated utility `u′ = e^u` — the exponential serving
 only to make the weights strictly positive. We abstract the weight to
 any `w : A → ℝ≥0`; the paper's instantiation is `w = e^u`. -/
 
-/-- **INT** (§2.3 of [cao-white-lassiter-2025]): the goal-weighted share
-    of action `a` among all goal-conducive alternatives. `pr a′` is the
-    model probability that the agent takes `a′` and the goal results;
-    `w` is the (paper: exponentiated-utility) action weight. -/
+/-- `intentionDegree pr w a` is the goal-weighted share of action `a`
+    among all goal-conducive alternatives — the INT measure of
+    [cao-white-lassiter-2025] (§2.3). Here `pr a′` is the model
+    probability that the agent takes `a′` and the goal results, and `w`
+    is the action weight (exponentiated utility, in the paper). -/
 noncomputable def intentionDegree {A : Type*} [Fintype A]
     (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) : ℝ≥0∞ :=
   (pr a * w a) / ∑ a', pr a' * w a'
 
-/-- INT is a proper degree: at most 1. -/
+/-- INT never exceeds 1. -/
 theorem intentionDegree_le_one {A : Type*} [Fintype A]
     (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) :
     intentionDegree pr w a ≤ 1 :=
@@ -187,9 +159,10 @@ theorem intentionDegree_le_one {A : Type*} [Fintype A]
     exact Finset.single_le_sum (f := fun a' => pr a' * w a') (fun _ _ => zero_le)
       (Finset.mem_univ a)
 
-/-- `intentionDegree` over a `SEM`: `pr a′` is the probability, under the
-    development of the context, that the action vertex takes value `a′`
-    and the goal event holds — the paper's `Pr((M,u⃗) ⊨ A = a⃗′ ∧ G = g⃗)`. -/
+/-- The paper's INT over a `SEM` instantiates `intentionDegree` with
+    `pr a′` the probability, under the development of the context, that
+    the action vertex takes value `a′` and the goal event holds — the
+    paper's `Pr((M,u⃗) ⊨ A = a⃗′ ∧ G = g⃗)`. -/
 noncomputable def modelIntention {V : Type*} {α : V → Type*}
     [Fintype V] [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] (ctx : Valuation α)
@@ -198,9 +171,8 @@ noncomputable def modelIntention {V : Type*} {α : V → Type*}
   intentionDegree
     (fun a' => (develop M ctx).probOfSet {s | s.hasValue act a' ∧ s ∈ goal}) w a
 
-/-- **No alternatives trivialize intention**: if every non-taken action
-    has zero probability and the taken action's goal-weighted mass is
-    nonzero and finite, its INT is 1. -/
+/-- If every non-taken action has zero probability and the taken
+    action's goal-weighted mass is nonzero and finite, its INT is 1. -/
 theorem intentionDegree_eq_one_of_no_alternatives {A : Type*} [Fintype A]
     (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (taken : A)
     (halt : ∀ a ≠ taken, pr a = 0)
@@ -211,13 +183,13 @@ theorem intentionDegree_eq_one_of_no_alternatives {A : Type*} [Fintype A]
       (fun h => absurd (Finset.mem_univ _) h)]
   exact ENNReal.div_self h0 (ENNReal.mul_ne_top hfin ENNReal.coe_ne_top)
 
-/-- **The ALT–INT bridge** ([frankfurt-1969] alternative possibilities,
-    via [halpern-kleiman-weiner-2018]: an action taken when the agent
-    could not do otherwise is never — here: trivially — intentional): if
-    the causee's action distribution `p` leaves no alternatives
-    (`altCount = 0`) then the taken action's INT degenerates to 1, for
-    any joint action-and-goal weights `pr` dominated by `p`. Grounds the
-    paper's *made*/*forced* contrast in its example (8). -/
+/-- An action without alternatives is trivially intentional. If the
+    causee's action distribution `p` leaves no alternatives
+    (`altCount = 0`), the taken action's INT degenerates to 1 for any
+    joint action-and-goal weights `pr` dominated by `p` — the
+    alternative-possibilities principle ([frankfurt-1969], via
+    [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
+    contrast in its example (8). -/
 theorem intentionDegree_eq_one_of_altCount_eq_zero {A : Type*} [Fintype A]
     (p : PMF A) (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (taken : A)
     (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
@@ -237,9 +209,9 @@ sufficiency (their definition (23)): with nothing observed, Pearl's
 counterfactual degenerates to the bare interventional development of
 `cause := true`. -/
 
-/-- Deterministic SUF as a {0,1} indicator over a `BoolSEM`:
-    [nadathur-lauer-2020]'s causal sufficiency (their definition (23)),
-    `causallySufficient`. -/
+/-- SUF in the deterministic limit — the {0,1} indicator, over a
+    `BoolSEM`, of [nadathur-lauer-2020]'s causal sufficiency (their
+    definition (23), `causallySufficient`). -/
 noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
     [Causation.SEM.IsDeterministic M]
@@ -247,11 +219,11 @@ noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (cause effect : V) : ENNReal :=
   if Causation.BoolSEM.causallySufficient M background cause effect then 1 else 0
 
-/-- **Grounding theorem**: at the empty context (vacuous abduction), the
-    counterfactual `probSufficiency` reduces to the deterministic {0,1}
-    indicator `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s causal
-    sufficiency. Makes "interventional = counterfactual at a vacuous
-    context" a theorem rather than a conflation. -/
+/-- At the empty context (vacuous abduction), the counterfactual
+    `probSufficiency` reduces to the deterministic {0,1} indicator
+    `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s causal
+    sufficiency. This makes "interventional = counterfactual at a
+    vacuous context" a theorem rather than a conflation. -/
 theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
     [Causation.SEM.IsDeterministic M] (c e : V) :
@@ -265,13 +237,12 @@ theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [Decid
     simp [h]
 
 /-- The hub denotation for *make* entails maximal SUF at the vacuous
-    context: whenever `Causative.toSemantics M .make` holds (both clauses
-    of [nadathur-lauer-2020]'s definition (23), over the strict
+    context — whenever `Causative.toSemantics M .make` holds (both
+    clauses of [nadathur-lauer-2020]'s definition (23), over the strict
     development), Pearl's probability of sufficiency is 1. The converse
-    fails — the eager development fills undetermined exogenous vertices
-    from their mechanisms, so SUF can be 1 without strict entailment: the
-    categorical *make* semantics is strictly stronger than maximal graded
-    SUF. -/
+    fails, since the eager development fills undetermined exogenous
+    vertices from their mechanisms; the categorical *make* semantics is
+    strictly stronger than maximal graded SUF. -/
 theorem probSufficiency_empty_eq_one_of_make
     {V : Type*} [Fintype V] [DecidableEq V]
     (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [Causation.SEM.IsDeterministic M]
@@ -291,12 +262,12 @@ could-have-done-otherwise pair, the intent-denial continuations, and the
 *make*/*let* sufficiency pair. Regression results stay in the module
 docstring: analysis outputs are not Lean content. -/
 
-/-- [nadathur-lauer-2020]'s force-dynamic dispatch gives *make* and
-    *force* literally identical truth conditions, but the paper's minimal
-    pair (8) — same frame, a could-have-done-otherwise continuation —
-    pulls them apart: *made* tolerates the continuation, *forced* resists
-    it. The graded ALT/INT measures cut where the categorical semantics
-    cannot (`intentionDegree_eq_one_of_altCount_eq_zero`). -/
+/-- The force-dynamic dispatch of [nadathur-lauer-2020] gives *make* and
+    *force* identical truth conditions, but the paper's minimal pair (8)
+    — same frame, a could-have-done-otherwise continuation — pulls them
+    apart; *made* tolerates the continuation, *forced* resists it. The
+    ALT/INT measures register the difference
+    (`intentionDegree_eq_one_of_altCount_eq_zero`). -/
 theorem make_force_same_semantics_different_judgments
     {V : Type*} {α : V → Type*} [Fintype V] [DecidableEq V] [DecidableValuation α]
     [∀ v, Fintype (α v)] (M : SEM V α) [CausalGraph.IsDAG M.graph]
@@ -306,7 +277,7 @@ theorem make_force_same_semantics_different_judgments
     Examples.cwl2025_ex8b.judgment = .questionable :=
   ⟨rfl, rfl, rfl⟩
 
-/-! ### Probabilistic example: genuinely fractional SUF
+/-! ### A probabilistic example
 
 A 2-vertex SEM whose `effect` mechanism is `PMF.bernoulli p` —
 genuinely probabilistic, not Dirac. Demonstrates that `probSufficiency`
@@ -316,14 +287,14 @@ namespace ProbabilisticExample
 
 open scoped NNReal
 
-/-- A 2-vertex SEM: `cause` (root) and `effect` (one parent: cause). -/
+/-- A 2-vertex SEM with root `cause` and child `effect`. -/
 inductive V | cause | effect
   deriving DecidableEq, Fintype, Repr
 
 def graph : CausalGraph V := ⟨fun | .cause => ∅ | .effect => {.cause}⟩
 
-/-- The probabilistic mechanism for `effect`: ignores parent value,
-    returns `Bernoulli(p)` directly. Genuinely non-Dirac when `p ∉ {0, 1}`. -/
+/-- The probabilistic mechanism for `effect`, ignoring its parent and
+    returning `Bernoulli(p)` — genuinely non-Dirac when `p ∉ {0, 1}`. -/
 noncomputable def effectMech (p : ℝ≥0) (h : p ≤ 1) :
     Mechanism graph (fun _ => Bool) .effect :=
   ⟨fun _ => PMF.bernoulli p h⟩
@@ -336,7 +307,7 @@ noncomputable def model (p : ℝ≥0) (h : p ≤ 1) : BoolSEM V :=
       | .effect => effectMech p h }
 
 /-- The 2-vertex graph is time-indexed in the sense of the paper's
-    definition 1: `cause` at step 0, `effect` at step 1. -/
+    definition 1, with `cause` at step 0 and `effect` at step 1. -/
 def timeIndex : TimeIndex graph where
   time := fun | .cause => 0 | .effect => 1
   parent_succ := by

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -52,27 +52,26 @@ contexts collapses — and a deterministic professional
 (`softOptimalPolicy_one`). -/
 
 section
-variable {A : Type*} [Fintype A] [Nonempty A]
+variable {A : Type*} [Fintype A] [Nonempty A] (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1)
 
 /-- The move distribution of a player of skill `ρ`: the highest-utility
     move `best` with probability `ρ`, otherwise a uniform random move. -/
-noncomputable def softOptimalPolicy (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
+noncomputable def softOptimalPolicy : PMF A :=
   PMF.mix ρ hρ (PMF.uniformOfFintype A) (PMF.pure best)
 
-@[simp] theorem softOptimalPolicy_apply_best (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) :
+@[simp] theorem softOptimalPolicy_apply_best :
     softOptimalPolicy best ρ hρ best = ρ + (1 - ρ : ℝ≥0) / Fintype.card A := by
   simp [softOptimalPolicy, div_eq_mul_inv, add_comm]
 
-@[simp] theorem softOptimalPolicy_apply_of_ne (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) {a : A}
-    (h : a ≠ best) :
+@[simp] theorem softOptimalPolicy_apply_of_ne {a : A} (h : a ≠ best) :
     softOptimalPolicy best ρ hρ a = (1 - ρ : ℝ≥0) / Fintype.card A := by
   simp [softOptimalPolicy, PMF.pure_apply_of_ne _ _ h, div_eq_mul_inv]
 
-theorem softOptimalPolicy_zero (best : A) :
+theorem softOptimalPolicy_zero :
     softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A :=
   PMF.mix_zero _ _
 
-theorem softOptimalPolicy_one (best : A) :
+theorem softOptimalPolicy_one :
     softOptimalPolicy best 1 le_rfl = PMF.pure best :=
   PMF.mix_one _ _
 
@@ -81,20 +80,20 @@ end
 /-! ### The ALT measure -/
 
 section
-variable {A : Type*} [Fintype A]
+variable {A : Type*} [Fintype A] (p : PMF A) (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a taken : A)
 
 /-- `altCount p taken` is the number of alternative actions available to
     the causee — the support of the action distribution `p`, excluding
     the action actually taken. This is the ALT measure of
     [cao-white-lassiter-2025] (§2.2; `ALT(Y₁) = 5` at its fig. 2a board
     state). -/
-noncomputable def altCount (p : PMF A) (taken : A) : ℕ :=
+noncomputable def altCount : ℕ :=
   (p.support \ {taken}).ncard
 
 /-- `ALT = 0` says exactly that the causee could not have done
     otherwise — every action other than the one taken has probability
     zero. -/
-theorem altCount_eq_zero_iff (p : PMF A) (taken : A) :
+theorem altCount_eq_zero_iff :
     altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
   rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty]
   constructor
@@ -124,11 +123,11 @@ any `w : A → ℝ≥0`; the paper's instantiation is `w = e^u`. -/
     [cao-white-lassiter-2025] (§2.3). Here `pr a′` is the model
     probability that the agent takes `a′` and the goal results, and `w`
     is the action weight (exponentiated utility, in the paper). -/
-noncomputable def intentionDegree (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) : ℝ≥0∞ :=
+noncomputable def intentionDegree : ℝ≥0∞ :=
   (pr a * w a) / ∑ a', pr a' * w a'
 
 /-- INT never exceeds 1. -/
-theorem intentionDegree_le_one (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) :
+theorem intentionDegree_le_one :
     intentionDegree pr w a ≤ 1 :=
   ENNReal.div_le_of_le_mul <| by
     rw [one_mul]
@@ -150,7 +149,6 @@ noncomputable def modelIntention {V : Type*} {α : V → Type*}
 /-- If every non-taken action has zero probability and the taken
     action's goal-weighted mass is nonzero and finite, its INT is 1. -/
 theorem intentionDegree_eq_one_of_no_alternatives
-    (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (taken : A)
     (halt : ∀ a ≠ taken, pr a = 0)
     (h0 : pr taken * w taken ≠ 0) (hfin : pr taken ≠ ⊤) :
     intentionDegree pr w taken = 1 := by
@@ -167,7 +165,6 @@ theorem intentionDegree_eq_one_of_no_alternatives
     [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
     contrast in its example (8). -/
 theorem intentionDegree_eq_one_of_altCount_eq_zero
-    (p : PMF A) (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (taken : A)
     (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
     (h0 : pr taken * w taken ≠ 0) :
     intentionDegree pr w taken = 1 :=
@@ -198,12 +195,14 @@ noncomputable def deterministicSuf (background : Valuation (fun _ : V => Bool))
     (cause effect : V) : ENNReal :=
   if BoolSEM.causallySufficient M background cause effect then 1 else 0
 
+variable (c e : V)
+
 /-- At the empty context (vacuous abduction), the counterfactual
     `probSufficiency` reduces to the deterministic {0,1} indicator
     `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s causal
     sufficiency. This makes "interventional = counterfactual at a
     vacuous context" a theorem rather than a conflation. -/
-theorem probSufficiency_empty_eq_deterministicSuf (c e : V) :
+theorem probSufficiency_empty_eq_deterministicSuf :
     probSufficiency M Valuation.empty c true e true
       = deterministicSuf M Valuation.empty c e := by
   rw [probSufficiency_eq_indicator_of_deterministic, cfSeed_empty]
@@ -220,7 +219,7 @@ theorem probSufficiency_empty_eq_deterministicSuf (c e : V) :
     fails, since the eager development fills undetermined exogenous
     vertices from their mechanisms; the categorical *make* semantics is
     strictly stronger than maximal graded SUF. -/
-theorem probSufficiency_empty_eq_one_of_make (c e : V)
+theorem probSufficiency_empty_eq_one_of_make
     (h : Causative.toSemantics M .make Valuation.empty c true e true) :
     probSufficiency M Valuation.empty c true e true = 1 := by
   rw [probSufficiency_empty_eq_deterministicSuf]

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -43,7 +43,8 @@ open scoped ENNReal NNReal
 The paper's mechanism for agent moves (§2.1.1): the highest-utility
 move — minimax over the game tree, with terminal utility
 `Winner × (EmptySpace + 1)` — is taken with probability `ρ + (1−ρ)/n`,
-every other available move with `(1−ρ)/n` (`softOptimalPolicy_apply`).
+every other available move with `(1−ρ)/n` (`softOptimalPolicy_apply_best`,
+`softOptimalPolicy_apply_of_ne`).
 The skill parameter `ρ` interpolates between a uniformly random player
 ("assume that the players are infants", `softOptimalPolicy_zero`) — the
 limiting case under which the paper's worked SUF contrast between
@@ -58,12 +59,14 @@ variable {A : Type*} [Fintype A] [Nonempty A]
 noncomputable def softOptimalPolicy (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
   PMF.mix ρ hρ (PMF.uniformOfFintype A) (PMF.pure best)
 
-@[simp] theorem softOptimalPolicy_apply [DecidableEq A] (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1)
-    (a : A) :
-    softOptimalPolicy best ρ hρ a =
-      (if a = best then (ρ : ℝ≥0∞) else 0) + (1 - ρ : ℝ≥0) / Fintype.card A := by
-  simp [softOptimalPolicy, PMF.pure_apply, PMF.uniformOfFintype_apply, mul_ite, mul_one,
-    mul_zero, div_eq_mul_inv, add_comm]
+@[simp] theorem softOptimalPolicy_apply_best (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) :
+    softOptimalPolicy best ρ hρ best = ρ + (1 - ρ : ℝ≥0) / Fintype.card A := by
+  simp [softOptimalPolicy, div_eq_mul_inv, add_comm]
+
+@[simp] theorem softOptimalPolicy_apply_of_ne (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) {a : A}
+    (h : a ≠ best) :
+    softOptimalPolicy best ρ hρ a = (1 - ρ : ℝ≥0) / Fintype.card A := by
+  simp [softOptimalPolicy, PMF.pure_apply_of_ne _ _ h, div_eq_mul_inv]
 
 theorem softOptimalPolicy_zero (best : A) :
     softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A :=

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -47,18 +47,19 @@ and every other available move with `(1−ρ)/n`. The skill parameter ρ
 interpolates between a random player (`ρ = 0`, "a less skilled player")
 and a professional (`ρ = 1`). -/
 
+section
+variable {A : Type*} [Fintype A] [Nonempty A]
+
 /-- The soft-optimality policy of a player of skill `ρ` mixes optimal
     play with uniform noise: the highest-utility move `best` with
     probability `ρ`, otherwise a uniform random move (§2.1.1 of
     [cao-white-lassiter-2025]). -/
-noncomputable def softOptimalPolicy {A : Type*} [Fintype A] [Nonempty A]
-    (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
+noncomputable def softOptimalPolicy (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
   PMF.mix ρ hρ (PMF.uniformOfFintype A) (PMF.pure best)
 
 /-- The paper's arithmetic form of the policy: the best move carries
     `ρ + (1 − ρ)/n`, every other available move `(1 − ρ)/n`. -/
-theorem softOptimalPolicy_apply {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
-    (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) (a : A) :
+theorem softOptimalPolicy_apply [DecidableEq A] (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) (a : A) :
     softOptimalPolicy best ρ hρ a =
       (if a = best then (ρ : ℝ≥0∞) else 0) + (1 - ρ : ℝ≥0) / Fintype.card A := by
   simp [softOptimalPolicy, PMF.pure_apply, PMF.uniformOfFintype_apply, mul_ite, mul_one,
@@ -67,30 +68,35 @@ theorem softOptimalPolicy_apply {A : Type*} [Fintype A] [DecidableEq A] [Nonempt
 /-- At `ρ = 0` the soft-optimality policy is the uniform random player —
     the paper's limiting case ("assume that the players are infants"),
     under which its worked SUF contrast between contexts collapses. -/
-theorem softOptimalPolicy_zero {A : Type*} [Fintype A] [Nonempty A] (best : A) :
+theorem softOptimalPolicy_zero (best : A) :
     softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A :=
   PMF.mix_zero _ _
 
 /-- At `ρ = 1` the soft-optimality policy is the deterministic
     professional — a Dirac on the highest-utility move. -/
-theorem softOptimalPolicy_one {A : Type*} [Fintype A] [Nonempty A] (best : A) :
+theorem softOptimalPolicy_one (best : A) :
     softOptimalPolicy best 1 le_rfl = PMF.pure best :=
   PMF.mix_one _ _
 
+end
+
 /-! ### The ALT measure -/
+
+section
+variable {A : Type*} [Fintype A]
 
 /-- `altCount p taken` is the number of alternative actions available to
     the causee — the support of the action distribution `p`, excluding
     the action actually taken. This is the ALT measure of
     [cao-white-lassiter-2025] (§2.2; `ALT(Y₁) = 5` at its fig. 2a board
     state). -/
-noncomputable def altCount {A : Type*} (p : PMF A) (taken : A) : ℕ :=
+noncomputable def altCount (p : PMF A) (taken : A) : ℕ :=
   (p.support \ {taken}).ncard
 
 /-- `ALT = 0` says exactly that the causee could not have done
     otherwise — every action other than the one taken has probability
     zero. -/
-theorem altCount_eq_zero_iff {A : Type*} [Fintype A] (p : PMF A) (taken : A) :
+theorem altCount_eq_zero_iff (p : PMF A) (taken : A) :
     altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
   rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty]
   constructor
@@ -120,13 +126,11 @@ any `w : A → ℝ≥0`; the paper's instantiation is `w = e^u`. -/
     [cao-white-lassiter-2025] (§2.3). Here `pr a′` is the model
     probability that the agent takes `a′` and the goal results, and `w`
     is the action weight (exponentiated utility, in the paper). -/
-noncomputable def intentionDegree {A : Type*} [Fintype A]
-    (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) : ℝ≥0∞ :=
+noncomputable def intentionDegree (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) : ℝ≥0∞ :=
   (pr a * w a) / ∑ a', pr a' * w a'
 
 /-- INT never exceeds 1. -/
-theorem intentionDegree_le_one {A : Type*} [Fintype A]
-    (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) :
+theorem intentionDegree_le_one (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A) :
     intentionDegree pr w a ≤ 1 :=
   ENNReal.div_le_of_le_mul <| by
     rw [one_mul]
@@ -147,7 +151,7 @@ noncomputable def modelIntention {V : Type*} {α : V → Type*}
 
 /-- If every non-taken action has zero probability and the taken
     action's goal-weighted mass is nonzero and finite, its INT is 1. -/
-theorem intentionDegree_eq_one_of_no_alternatives {A : Type*} [Fintype A]
+theorem intentionDegree_eq_one_of_no_alternatives
     (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (taken : A)
     (halt : ∀ a ≠ taken, pr a = 0)
     (h0 : pr taken * w taken ≠ 0) (hfin : pr taken ≠ ⊤) :
@@ -164,7 +168,7 @@ theorem intentionDegree_eq_one_of_no_alternatives {A : Type*} [Fintype A]
     alternative-possibilities principle ([frankfurt-1969], via
     [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
     contrast in its example (8). -/
-theorem intentionDegree_eq_one_of_altCount_eq_zero {A : Type*} [Fintype A]
+theorem intentionDegree_eq_one_of_altCount_eq_zero
     (p : PMF A) (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (taken : A)
     (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
     (h0 : pr taken * w taken ≠ 0) :
@@ -173,6 +177,8 @@ theorem intentionDegree_eq_one_of_altCount_eq_zero {A : Type*} [Fintype A]
     (fun a ha => le_antisymm ((altCount_eq_zero_iff p taken).mp halt a ha ▸ hle a) zero_le)
     h0
     (((hle taken).trans (p.coe_le_one taken)).trans_lt ENNReal.one_lt_top).ne
+
+end
 
 /-! ### Deterministic limit
 
@@ -183,13 +189,14 @@ sufficiency (their definition (23)): with nothing observed, Pearl's
 counterfactual degenerates to the bare interventional development of
 `cause := true`. -/
 
+section
+variable {V : Type*} [Fintype V] [DecidableEq V] (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
+  [IsDeterministic M]
+
 /-- SUF in the deterministic limit — the {0,1} indicator, over a
     `BoolSEM`, of [nadathur-lauer-2020]'s causal sufficiency (their
     definition (23), `causallySufficient`). -/
-noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
-    [IsDeterministic M]
-    (background : Valuation (fun _ : V => Bool))
+noncomputable def deterministicSuf (background : Valuation (fun _ : V => Bool))
     (cause effect : V) : ENNReal :=
   if BoolSEM.causallySufficient M background cause effect then 1 else 0
 
@@ -198,9 +205,7 @@ noncomputable def deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
     `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s causal
     sufficiency. This makes "interventional = counterfactual at a
     vacuous context" a theorem rather than a conflation. -/
-theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
-    [IsDeterministic M] (c e : V) :
+theorem probSufficiency_empty_eq_deterministicSuf (c e : V) :
     probSufficiency M Valuation.empty c true e true
       = deterministicSuf M Valuation.empty c e := by
   rw [probSufficiency_eq_indicator_of_deterministic, cfSeed_empty]
@@ -217,15 +222,14 @@ theorem probSufficiency_empty_eq_deterministicSuf {V : Type*} [Fintype V] [Decid
     fails, since the eager development fills undetermined exogenous
     vertices from their mechanisms; the categorical *make* semantics is
     strictly stronger than maximal graded SUF. -/
-theorem probSufficiency_empty_eq_one_of_make
-    {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [IsDeterministic M]
-    (c e : V)
+theorem probSufficiency_empty_eq_one_of_make (c e : V)
     (h : Causative.toSemantics M .make Valuation.empty c true e true) :
     probSufficiency M Valuation.empty c true e true = 1 := by
   rw [probSufficiency_empty_eq_deterministicSuf]
   unfold deterministicSuf
   exact if_pos (causallySufficient_of_causallyEntails h.2)
+
+end
 
 /-! ### The paper's judgment data
 
@@ -267,15 +271,17 @@ inductive V | cause | effect
 
 def graph : CausalGraph V := ⟨fun | .cause => ∅ | .effect => {.cause}⟩
 
+variable (p : ℝ≥0) (h : p ≤ 1)
+
 /-- The probabilistic mechanism for `effect`, ignoring its parent and
     returning `true` with probability `p` — genuinely non-Dirac when
     `p ∉ {0, 1}`. -/
-noncomputable def effectMech (p : ℝ≥0) (h : p ≤ 1) :
+noncomputable def effectMech :
     Mechanism graph (fun _ => Bool) .effect :=
   ⟨fun _ => PMF.mix p h (PMF.pure false) (PMF.pure true)⟩
 
 /-- A genuinely probabilistic SEM (not `IsDeterministic` for `p ∉ {0,1}`). -/
-noncomputable def model (p : ℝ≥0) (h : p ≤ 1) : BoolSEM V :=
+noncomputable def model : BoolSEM V :=
   { graph := graph
     mech := fun
       | .cause => const (G := graph) false
@@ -293,13 +299,13 @@ def timeIndex : CausalGraph.TimeIndex graph where
 
 instance : CausalGraph.IsDAG graph := timeIndex.isDAG
 
-instance (p : ℝ≥0) (h : p ≤ 1) : CausalGraph.IsDAG (model p h).graph :=
+instance : CausalGraph.IsDAG (model p h).graph :=
   inferInstanceAs (CausalGraph.IsDAG graph)
 
 /-- `probSufficiency` accepts this SEM despite it NOT being
     `IsDeterministic` — exactly the [cao-white-lassiter-2025]
     requirement that SUF be a real probability. -/
-noncomputable example (p : ℝ≥0) (h : p ≤ 1) : ENNReal :=
+noncomputable example : ENNReal :=
   probSufficiency (model p h) Valuation.empty .cause true .effect true
 
 end ProbabilisticExample

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -40,40 +40,35 @@ open scoped ENNReal NNReal
 
 /-! ### Soft-optimality policy
 
-The paper's mechanisms for agent moves (§2.1.1): the highest-utility
-move — computed by minimax over the game tree, with terminal utility
-`Winner × (EmptySpace + 1)` — is taken with probability `ρ + (1−ρ)/n`
-and every other available move with `(1−ρ)/n`. The skill parameter ρ
-interpolates between a random player (`ρ = 0`, "a less skilled player")
-and a professional (`ρ = 1`). -/
+The paper's mechanism for agent moves (§2.1.1): the highest-utility
+move — minimax over the game tree, with terminal utility
+`Winner × (EmptySpace + 1)` — is taken with probability `ρ + (1−ρ)/n`,
+every other available move with `(1−ρ)/n` (`softOptimalPolicy_apply`).
+The skill parameter `ρ` interpolates between a uniformly random player
+("assume that the players are infants", `softOptimalPolicy_zero`) — the
+limiting case under which the paper's worked SUF contrast between
+contexts collapses — and a deterministic professional
+(`softOptimalPolicy_one`). -/
 
 section
 variable {A : Type*} [Fintype A] [Nonempty A]
 
-/-- The soft-optimality policy of a player of skill `ρ` mixes optimal
-    play with uniform noise: the highest-utility move `best` with
-    probability `ρ`, otherwise a uniform random move (§2.1.1 of
-    [cao-white-lassiter-2025]). -/
+/-- The move distribution of a player of skill `ρ`: the highest-utility
+    move `best` with probability `ρ`, otherwise a uniform random move. -/
 noncomputable def softOptimalPolicy (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
   PMF.mix ρ hρ (PMF.uniformOfFintype A) (PMF.pure best)
 
-/-- The paper's arithmetic form of the policy: the best move carries
-    `ρ + (1 − ρ)/n`, every other available move `(1 − ρ)/n`. -/
-theorem softOptimalPolicy_apply [DecidableEq A] (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) (a : A) :
+@[simp] theorem softOptimalPolicy_apply [DecidableEq A] (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1)
+    (a : A) :
     softOptimalPolicy best ρ hρ a =
       (if a = best then (ρ : ℝ≥0∞) else 0) + (1 - ρ : ℝ≥0) / Fintype.card A := by
   simp [softOptimalPolicy, PMF.pure_apply, PMF.uniformOfFintype_apply, mul_ite, mul_one,
     mul_zero, div_eq_mul_inv, add_comm]
 
-/-- At `ρ = 0` the soft-optimality policy is the uniform random player —
-    the paper's limiting case ("assume that the players are infants"),
-    under which its worked SUF contrast between contexts collapses. -/
 theorem softOptimalPolicy_zero (best : A) :
     softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A :=
   PMF.mix_zero _ _
 
-/-- At `ρ = 1` the soft-optimality policy is the deterministic
-    professional — a Dirac on the highest-utility move. -/
 theorem softOptimalPolicy_one (best : A) :
     softOptimalPolicy best 1 le_rfl = PMF.pure best :=
   PMF.mix_one _ _

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -193,8 +193,8 @@ noncomputable def deterministicSuf (background : Valuation (fun _ : V => Bool))
 variable (c e : V)
 
 theorem probSufficiency_empty_eq_deterministicSuf :
-    probSufficiency M Valuation.empty c true e true
-      = deterministicSuf M Valuation.empty c e := by
+    BoolSEM.probSufficiency M Valuation.empty c e = deterministicSuf M Valuation.empty c e := by
+  unfold BoolSEM.probSufficiency
   rw [probSufficiency_eq_indicator_of_deterministic, cfSeed_empty]
   unfold deterministicSuf
   congr 1
@@ -208,7 +208,7 @@ theorem probSufficiency_empty_eq_deterministicSuf :
     strictly stronger than maximal graded SUF. -/
 theorem probSufficiency_empty_eq_one_of_make
     (h : Causative.toSemantics M .make Valuation.empty c true e true) :
-    probSufficiency M Valuation.empty c true e true = 1 := by
+    BoolSEM.probSufficiency M Valuation.empty c e = 1 := by
   rw [probSufficiency_empty_eq_deterministicSuf]
   unfold deterministicSuf
   exact if_pos (causallySufficient_of_causallyEntails h.2)
@@ -290,7 +290,7 @@ instance : CausalGraph.IsDAG (model p h).graph :=
     `IsDeterministic` — exactly the [cao-white-lassiter-2025]
     requirement that SUF be a real probability. -/
 noncomputable example : ENNReal :=
-  probSufficiency (model p h) Valuation.empty .cause true .effect true
+  BoolSEM.probSufficiency (model p h) Valuation.empty .cause .effect
 
 end ProbabilisticExample
 

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -176,35 +176,28 @@ In the deterministic limit, SUF collapses to a {0,1} indicator
 vacuous (empty) context this is exactly [nadathur-lauer-2020]'s causal
 sufficiency (their definition (23)): with nothing observed, Pearl's
 counterfactual degenerates to the bare interventional development of
-`cause := true`. -/
+`cause := true`, and "interventional = counterfactual at a vacuous
+context" is a theorem (`probSufficiency_empty_eq_deterministicSuf`)
+rather than a conflation. -/
 
 section
 variable {V : Type*} [Fintype V] [DecidableEq V] (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
   [IsDeterministic M]
 
-/-- SUF in the deterministic limit — the {0,1} indicator, over a
-    `BoolSEM`, of [nadathur-lauer-2020]'s causal sufficiency (their
-    definition (23), `causallySufficient`). -/
+/-- The {0,1} indicator of categorical causal sufficiency
+    (`causallySufficient`). -/
 noncomputable def deterministicSuf (background : Valuation (fun _ : V => Bool))
     (cause effect : V) : ENNReal :=
   if BoolSEM.causallySufficient M background cause effect then 1 else 0
 
 variable (c e : V)
 
-/-- At the empty context (vacuous abduction), the counterfactual
-    `probSufficiency` reduces to the deterministic {0,1} indicator
-    `deterministicSuf` — i.e. to [nadathur-lauer-2020]'s causal
-    sufficiency. This makes "interventional = counterfactual at a
-    vacuous context" a theorem rather than a conflation. -/
 theorem probSufficiency_empty_eq_deterministicSuf :
     probSufficiency M Valuation.empty c true e true
       = deterministicSuf M Valuation.empty c e := by
   rw [probSufficiency_eq_indicator_of_deterministic, cfSeed_empty]
-  unfold deterministicSuf BoolSEM.causallySufficient SEM.causallySufficient
-    SEM.developsToValue
-  by_cases h :
-      (M.developDet ((Valuation.empty (α := fun _ : V => Bool)).extend c true)).hasValue e true <;>
-    simp [h]
+  unfold deterministicSuf
+  congr 1
 
 /-- The hub denotation for *make* entails maximal SUF at the vacuous
     context — whenever `Causative.toSemantics M .make` holds (both

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.NNReal.Basic
 import Mathlib.Data.Set.Card
 import Mathlib.Probability.Distributions.Uniform
-import Linglib.Core.Probability.Finite
+import Linglib.Core.Probability.Constructions
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Semantics.Causation.Interpretation
 import Linglib.Semantics.Causation.SEM.Counterfactual
@@ -53,7 +53,7 @@ and a professional (`ρ = 1`). -/
     [cao-white-lassiter-2025]). -/
 noncomputable def softOptimalPolicy {A : Type*} [Fintype A] [Nonempty A]
     (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
-  PMF.mix ρ hρ (PMF.pure best) (PMF.uniformOfFintype A)
+  PMF.mix ρ hρ (PMF.uniformOfFintype A) (PMF.pure best)
 
 /-- The paper's arithmetic form of the policy: the best move carries
     `ρ + (1 − ρ)/n`, every other available move `(1 − ρ)/n`. -/
@@ -62,7 +62,7 @@ theorem softOptimalPolicy_apply {A : Type*} [Fintype A] [DecidableEq A] [Nonempt
     softOptimalPolicy best ρ hρ a =
       (if a = best then (ρ : ℝ≥0∞) else 0) + (1 - ρ : ℝ≥0) / Fintype.card A := by
   simp [softOptimalPolicy, PMF.pure_apply, PMF.uniformOfFintype_apply, mul_ite, mul_one,
-    mul_zero, div_eq_mul_inv]
+    mul_zero, div_eq_mul_inv, add_comm]
 
 /-- At `ρ = 0` the soft-optimality policy is the uniform random player —
     the paper's limiting case ("assume that the players are infants"),
@@ -253,7 +253,7 @@ theorem make_force_same_semantics_different_judgments
 
 /-! ### A probabilistic example
 
-A 2-vertex SEM whose `effect` mechanism is `PMF.bernoulli p` —
+A 2-vertex SEM whose `effect` mechanism is `PMF.bernoulliMix p` —
 genuinely probabilistic, not Dirac. Demonstrates that `probSufficiency`
 accepts non-deterministic SEMs (no `IsDeterministic` constraint). -/
 
@@ -268,10 +268,10 @@ inductive V | cause | effect
 def graph : CausalGraph V := ⟨fun | .cause => ∅ | .effect => {.cause}⟩
 
 /-- The probabilistic mechanism for `effect`, ignoring its parent and
-    returning `Bernoulli(p)` — genuinely non-Dirac when `p ∉ {0, 1}`. -/
+    returning `PMF.bernoulliMix p` — genuinely non-Dirac when `p ∉ {0, 1}`. -/
 noncomputable def effectMech (p : ℝ≥0) (h : p ≤ 1) :
     Mechanism graph (fun _ => Bool) .effect :=
-  ⟨fun _ => PMF.bernoulli p h⟩
+  ⟨fun _ => PMF.bernoulliMix p h⟩
 
 /-- A genuinely probabilistic SEM (not `IsDeterministic` for `p ∉ {0,1}`). -/
 noncomputable def model (p : ℝ≥0) (h : p ≤ 1) : BoolSEM V :=

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -128,9 +128,8 @@ theorem intentionDegree_eq_one_of_no_alternatives
     (halt : ∀ a ≠ taken, pr a = 0)
     (h0 : pr taken * w taken ≠ 0) (hfin : pr taken ≠ ∞) :
     intentionDegree pr w taken = 1 := by
-  rw [intentionDegree,
-    Finset.sum_eq_single taken (fun a _ ha => by rw [halt a ha, zero_mul])
-      (fun h => absurd (Finset.mem_univ _) h)]
+  rw [intentionDegree, Finset.sum_eq_single_of_mem taken (Finset.mem_univ taken)
+    fun a _ ha => by rw [halt a ha, zero_mul]]
   exact ENNReal.div_self h0 (ENNReal.mul_ne_top hfin ENNReal.coe_ne_top)
 
 /-- An action without alternatives is trivially intentional — the
@@ -143,8 +142,7 @@ theorem intentionDegree_eq_one_of_altCount_eq_zero
     intentionDegree pr w taken = 1 :=
   intentionDegree_eq_one_of_no_alternatives taken pr w
     (fun a ha => le_zero_iff.mp ((altCount_eq_zero_iff p taken).mp halt a ha ▸ hle a))
-    h0
-    (((hle taken).trans (p.coe_le_one taken)).trans_lt ENNReal.one_lt_top).ne
+    h0 (ne_top_of_le_ne_top (p.apply_ne_top taken) (hle taken))
 
 end
 

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.NNReal.Basic
 import Mathlib.Data.Set.Card
-import Mathlib.Probability.ProbabilityMassFunction.Constructions
+import Mathlib.Probability.Distributions.Uniform
+import Linglib.Core.Probability.Finite
 import Linglib.Data.Examples.CaoWhiteLassiter2025
 import Linglib.Semantics.Causation.Interpretation
 import Linglib.Semantics.Causation.SEM.Counterfactual
@@ -46,38 +47,35 @@ and every other available move with `(1−ρ)/n`. The skill parameter ρ
 interpolates between a random player (`ρ = 0`, "a less skilled player")
 and a professional (`ρ = 1`). -/
 
-/-- The soft-optimality policy of a player of skill `ρ` takes the
-    highest-utility move `best` with probability `ρ + (1−ρ)/n` and each
-    of the other `n − 1` available moves with probability `(1−ρ)/n`
-    (§2.1.1 of [cao-white-lassiter-2025]). -/
-noncomputable def softOptimalPolicy {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
+/-- The soft-optimality policy of a player of skill `ρ` mixes optimal
+    play with uniform noise: the highest-utility move `best` with
+    probability `ρ`, otherwise a uniform random move (§2.1.1 of
+    [cao-white-lassiter-2025]). -/
+noncomputable def softOptimalPolicy {A : Type*} [Fintype A] [Nonempty A]
     (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) : PMF A :=
-  PMF.ofFintype
-    (fun a => (if a = best then (ρ : ℝ≥0∞) else 0) + (1 - ρ : ℝ≥0) / Fintype.card A)
-    (by
-      have hn0 : (Fintype.card A : ℝ≥0∞) ≠ 0 := by
-        exact_mod_cast Fintype.card_ne_zero
-      rw [Finset.sum_add_distrib, Finset.sum_ite_eq' Finset.univ best (fun _ => (ρ : ℝ≥0∞)),
-        Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
-        ENNReal.mul_div_cancel hn0 (ENNReal.natCast_ne_top _)]
-      simp only [Finset.mem_univ, if_true]
-      rw [← ENNReal.coe_add, add_tsub_cancel_of_le hρ, ENNReal.coe_one])
+  PMF.mix ρ hρ (PMF.pure best) (PMF.uniformOfFintype A)
+
+/-- The paper's arithmetic form of the policy: the best move carries
+    `ρ + (1 − ρ)/n`, every other available move `(1 − ρ)/n`. -/
+theorem softOptimalPolicy_apply {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
+    (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1) (a : A) :
+    softOptimalPolicy best ρ hρ a =
+      (if a = best then (ρ : ℝ≥0∞) else 0) + (1 - ρ : ℝ≥0) / Fintype.card A := by
+  simp [softOptimalPolicy, PMF.pure_apply, PMF.uniformOfFintype_apply, mul_ite, mul_one,
+    mul_zero, div_eq_mul_inv]
 
 /-- At `ρ = 0` the soft-optimality policy is the uniform random player —
     the paper's limiting case ("assume that the players are infants"),
     under which its worked SUF contrast between contexts collapses. -/
-theorem softOptimalPolicy_zero_apply {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
-    (best : A) (a : A) :
-    softOptimalPolicy best 0 zero_le_one a = (Fintype.card A : ℝ≥0∞)⁻¹ := by
-  simp [softOptimalPolicy]
+theorem softOptimalPolicy_zero {A : Type*} [Fintype A] [Nonempty A] (best : A) :
+    softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A :=
+  PMF.mix_zero _ _
 
 /-- At `ρ = 1` the soft-optimality policy is the deterministic
     professional — a Dirac on the highest-utility move. -/
-theorem softOptimalPolicy_one {A : Type*} [Fintype A] [DecidableEq A] [Nonempty A]
-    (best : A) :
-    softOptimalPolicy best 1 le_rfl = PMF.pure best := by
-  ext a
-  simp [softOptimalPolicy, PMF.pure_apply]
+theorem softOptimalPolicy_one {A : Type*} [Fintype A] [Nonempty A] (best : A) :
+    softOptimalPolicy best 1 le_rfl = PMF.pure best :=
+  PMF.mix_one _ _
 
 /-! ### The ALT measure -/
 

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -110,7 +110,14 @@ weighted by exponentiated utility `u′ = e^u` — the exponential serving
 only to make the weights strictly positive. Here `pr a′` is the joint
 probability that the agent takes `a′` and the goal results, and the
 weight is abstracted to any `w : A → ℝ≥0` (the paper's instantiation is
-`w = e^u`); `modelIntention` below instantiates `pr` over a `SEM`. -/
+`w = e^u`); `modelIntention` below instantiates `pr` over a `SEM`. INT
+is the normalized goal-weighted action distribution evaluated at the
+taken action (`intentionDegree_eq_normalize`), and an action without
+alternatives is trivially intentional
+(`intentionDegree_eq_one_of_altCount_eq_zero`) — the
+alternative-possibilities principle of [frankfurt-1969], via
+[halpern-kleiman-weiner-2018], behind the paper's *made*/*forced*
+contrast in its example (8). -/
 
 variable (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A)
 
@@ -124,6 +131,14 @@ theorem intentionDegree_le_one : intentionDegree pr w a ≤ 1 :=
     simpa using Finset.single_le_sum (f := fun a' => pr a' * w a') (fun _ _ => zero_le)
       (Finset.mem_univ a)
 
+/-- With nonzero finite total mass, INT is mathlib's `PMF.normalize` of
+    the goal-weighted masses, evaluated at the taken action — the
+    `PMF.reweight`/`PMF.posterior` family of `Core/Probability/Posterior`. -/
+theorem intentionDegree_eq_normalize (h0 : (∑' a', pr a' * w a') ≠ 0)
+    (htop : (∑' a', pr a' * w a') ≠ ∞) :
+    intentionDegree pr w a = PMF.normalize (fun a' => pr a' * w a') h0 htop a := by
+  rw [intentionDegree, PMF.normalize_apply, div_eq_mul_inv, tsum_fintype]
+
 theorem intentionDegree_eq_one_of_no_alternatives
     (h : ∀ a ≠ taken, pr a = 0) (h0 : pr taken ≠ 0) (hw : w taken ≠ 0)
     (htop : pr taken ≠ ∞) :
@@ -133,10 +148,6 @@ theorem intentionDegree_eq_one_of_no_alternatives
   exact ENNReal.div_self (mul_ne_zero h0 (ENNReal.coe_ne_zero.mpr hw))
     (ENNReal.mul_ne_top htop ENNReal.coe_ne_top)
 
-/-- An action without alternatives is trivially intentional — the
-    alternative-possibilities principle ([frankfurt-1969], via
-    [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
-    contrast in its example (8). -/
 theorem intentionDegree_eq_one_of_altCount_eq_zero
     (hle : pr ≤ ⇑p) (h : altCount p taken = 0) (h0 : pr taken ≠ 0) (hw : w taken ≠ 0) :
     intentionDegree pr w taken = 1 :=

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -68,12 +68,10 @@ noncomputable def softOptimalPolicy : PMF A :=
   simp [softOptimalPolicy, PMF.pure_apply_of_ne _ _ h, div_eq_mul_inv]
 
 theorem softOptimalPolicy_zero :
-    softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A :=
-  PMF.mix_zero _ _
+    softOptimalPolicy best 0 zero_le_one = PMF.uniformOfFintype A := PMF.mix_zero _ _
 
 theorem softOptimalPolicy_one :
-    softOptimalPolicy best 1 le_rfl = PMF.pure best :=
-  PMF.mix_one _ _
+    softOptimalPolicy best 1 le_rfl = PMF.pure best := PMF.mix_one _ _
 
 end
 

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -75,32 +75,27 @@ theorem softOptimalPolicy_one :
 
 end
 
-/-! ### The ALT measure -/
+/-! ### The ALT measure
+
+ALT (§2.2 of [cao-white-lassiter-2025]) counts the alternative actions
+available to the causee, excluding the action actually taken —
+`ALT(Y₁) = 5` at the paper's fig. 2a board state. `ALT = 0` is the
+Frankfurt-style could-not-have-done-otherwise configuration
+(`altCount_eq_zero_iff`). -/
 
 section
-variable {A : Type*} [Fintype A] (p : PMF A) (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a taken : A)
+variable {A : Type*} [Fintype A] (p : PMF A) (taken : A)
 
-/-- `altCount p taken` is the number of alternative actions available to
-    the causee — the support of the action distribution `p`, excluding
-    the action actually taken. This is the ALT measure of
-    [cao-white-lassiter-2025] (§2.2; `ALT(Y₁) = 5` at its fig. 2a board
-    state). -/
+/-- The number of alternative actions available to the causee: the
+    support of the action distribution, less the action taken. -/
 noncomputable def altCount : ℕ :=
   (p.support \ {taken}).ncard
 
-/-- `ALT = 0` says exactly that the causee could not have done
-    otherwise — every action other than the one taken has probability
-    zero. -/
 theorem altCount_eq_zero_iff :
     altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
-  rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty]
-  constructor
-  · intro hsub a hne
-    by_contra hpa
-    exact hne (hsub ((p.mem_support_iff a).mpr hpa))
-  · intro h a ha
-    by_contra hne
-    exact (p.mem_support_iff a).mp ha (h a (by simpa using hne))
+  rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty,
+    Set.subset_singleton_iff]
+  exact forall_congr' fun b => not_imp_comm
 
 /-! ### The INT measure
 
@@ -115,6 +110,8 @@ actions that would have resulted in the same outcome", with each term
 weighted by exponentiated utility `u′ = e^u` — the exponential serving
 only to make the weights strictly positive. We abstract the weight to
 any `w : A → ℝ≥0`; the paper's instantiation is `w = e^u`. -/
+
+variable (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A)
 
 /-- `intentionDegree pr w a` is the goal-weighted share of action `a`
     among all goal-conducive alternatives — the INT measure of
@@ -166,7 +163,7 @@ theorem intentionDegree_eq_one_of_altCount_eq_zero
     (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
     (h0 : pr taken * w taken ≠ 0) :
     intentionDegree pr w taken = 1 :=
-  intentionDegree_eq_one_of_no_alternatives pr w taken
+  intentionDegree_eq_one_of_no_alternatives taken pr w
     (fun a ha => le_antisymm ((altCount_eq_zero_iff p taken).mp halt a ha ▸ hle a) zero_le)
     h0
     (((hle taken).trans (p.coe_le_one taken)).trans_lt ENNReal.one_lt_top).ne

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -253,7 +253,7 @@ theorem make_force_same_semantics_different_judgments
 
 /-! ### A probabilistic example
 
-A 2-vertex SEM whose `effect` mechanism is `PMF.bernoulliMix p` —
+A 2-vertex SEM whose `effect` mechanism is a `p`-weighted coin —
 genuinely probabilistic, not Dirac. Demonstrates that `probSufficiency`
 accepts non-deterministic SEMs (no `IsDeterministic` constraint). -/
 
@@ -268,10 +268,11 @@ inductive V | cause | effect
 def graph : CausalGraph V := ⟨fun | .cause => ∅ | .effect => {.cause}⟩
 
 /-- The probabilistic mechanism for `effect`, ignoring its parent and
-    returning `PMF.bernoulliMix p` — genuinely non-Dirac when `p ∉ {0, 1}`. -/
+    returning `true` with probability `p` — genuinely non-Dirac when
+    `p ∉ {0, 1}`. -/
 noncomputable def effectMech (p : ℝ≥0) (h : p ≤ 1) :
     Mechanism graph (fun _ => Bool) .effect :=
-  ⟨fun _ => PMF.bernoulliMix p h⟩
+  ⟨fun _ => PMF.mix p h (PMF.pure false) (PMF.pure true)⟩
 
 /-- A genuinely probabilistic SEM (not `IsDeterministic` for `p ∉ {0,1}`). -/
 noncomputable def model (p : ℝ≥0) (h : p ≤ 1) : BoolSEM V :=

--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -91,8 +91,7 @@ variable {A : Type*} [Fintype A] (p : PMF A) (taken : A)
 noncomputable def altCount : ℕ :=
   (p.support \ {taken}).ncard
 
-theorem altCount_eq_zero_iff :
-    altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
+theorem altCount_eq_zero_iff : altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
   rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty,
     Set.subset_singleton_iff]
   exact forall_congr' fun b => not_imp_comm
@@ -108,26 +107,46 @@ The paper's §2.3 displayed equation, a simplified
 desired outcome, normalized by the probability of all alternative
 actions that would have resulted in the same outcome", with each term
 weighted by exponentiated utility `u′ = e^u` — the exponential serving
-only to make the weights strictly positive. We abstract the weight to
-any `w : A → ℝ≥0`; the paper's instantiation is `w = e^u`. -/
+only to make the weights strictly positive. Here `pr a′` is the joint
+probability that the agent takes `a′` and the goal results, and the
+weight is abstracted to any `w : A → ℝ≥0` (the paper's instantiation is
+`w = e^u`); `modelIntention` below instantiates `pr` over a `SEM`. -/
 
 variable (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A)
 
-/-- `intentionDegree pr w a` is the goal-weighted share of action `a`
-    among all goal-conducive alternatives — the INT measure of
-    [cao-white-lassiter-2025] (§2.3). Here `pr a′` is the model
-    probability that the agent takes `a′` and the goal results, and `w`
-    is the action weight (exponentiated utility, in the paper). -/
+/-- The goal-weighted share of action `a` among all goal-conducive
+    alternatives. -/
 noncomputable def intentionDegree : ℝ≥0∞ :=
   (pr a * w a) / ∑ a', pr a' * w a'
 
-/-- INT never exceeds 1. -/
-theorem intentionDegree_le_one :
-    intentionDegree pr w a ≤ 1 :=
+theorem intentionDegree_le_one : intentionDegree pr w a ≤ 1 :=
   ENNReal.div_le_of_le_mul <| by
-    rw [one_mul]
-    exact Finset.single_le_sum (f := fun a' => pr a' * w a') (fun _ _ => zero_le)
+    simpa using Finset.single_le_sum (f := fun a' => pr a' * w a') (fun _ _ => zero_le)
       (Finset.mem_univ a)
+
+theorem intentionDegree_eq_one_of_no_alternatives
+    (halt : ∀ a ≠ taken, pr a = 0)
+    (h0 : pr taken * w taken ≠ 0) (hfin : pr taken ≠ ∞) :
+    intentionDegree pr w taken = 1 := by
+  rw [intentionDegree,
+    Finset.sum_eq_single taken (fun a _ ha => by rw [halt a ha, zero_mul])
+      (fun h => absurd (Finset.mem_univ _) h)]
+  exact ENNReal.div_self h0 (ENNReal.mul_ne_top hfin ENNReal.coe_ne_top)
+
+/-- An action without alternatives is trivially intentional — the
+    alternative-possibilities principle ([frankfurt-1969], via
+    [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
+    contrast in its example (8). -/
+theorem intentionDegree_eq_one_of_altCount_eq_zero
+    (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
+    (h0 : pr taken * w taken ≠ 0) :
+    intentionDegree pr w taken = 1 :=
+  intentionDegree_eq_one_of_no_alternatives taken pr w
+    (fun a ha => le_zero_iff.mp ((altCount_eq_zero_iff p taken).mp halt a ha ▸ hle a))
+    h0
+    (((hle taken).trans (p.coe_le_one taken)).trans_lt ENNReal.one_lt_top).ne
+
+end
 
 /-- The paper's INT over a `SEM` instantiates `intentionDegree` with
     `pr a′` the probability, under the development of the context, that
@@ -140,35 +159,6 @@ noncomputable def modelIntention {V : Type*} {α : V → Type*}
     (a : α act) : ℝ≥0∞ :=
   intentionDegree
     (fun a' => (develop M ctx).probOfSet {s | s.hasValue act a' ∧ s ∈ goal}) w a
-
-/-- If every non-taken action has zero probability and the taken
-    action's goal-weighted mass is nonzero and finite, its INT is 1. -/
-theorem intentionDegree_eq_one_of_no_alternatives
-    (halt : ∀ a ≠ taken, pr a = 0)
-    (h0 : pr taken * w taken ≠ 0) (hfin : pr taken ≠ ⊤) :
-    intentionDegree pr w taken = 1 := by
-  rw [intentionDegree,
-    Finset.sum_eq_single taken (fun a _ ha => by rw [halt a ha, zero_mul])
-      (fun h => absurd (Finset.mem_univ _) h)]
-  exact ENNReal.div_self h0 (ENNReal.mul_ne_top hfin ENNReal.coe_ne_top)
-
-/-- An action without alternatives is trivially intentional. If the
-    causee's action distribution `p` leaves no alternatives
-    (`altCount = 0`), the taken action's INT degenerates to 1 for any
-    joint action-and-goal weights `pr` dominated by `p` — the
-    alternative-possibilities principle ([frankfurt-1969], via
-    [halpern-kleiman-weiner-2018]) behind the paper's *made*/*forced*
-    contrast in its example (8). -/
-theorem intentionDegree_eq_one_of_altCount_eq_zero
-    (hle : ∀ a, pr a ≤ p a) (halt : altCount p taken = 0)
-    (h0 : pr taken * w taken ≠ 0) :
-    intentionDegree pr w taken = 1 :=
-  intentionDegree_eq_one_of_no_alternatives taken pr w
-    (fun a ha => le_antisymm ((altCount_eq_zero_iff p taken).mp halt a ha ▸ hle a) zero_le)
-    h0
-    (((hle taken).trans (p.coe_le_one taken)).trans_lt ENNReal.one_lt_top).ne
-
-end
 
 /-! ### Deterministic limit
 

--- a/Linglib/Studies/GroveWhite2025.lean
+++ b/Linglib/Studies/GroveWhite2025.lean
@@ -3,6 +3,7 @@ import Linglib.Semantics.Probabilistic.ParamPred
 import Linglib.Studies.DegenTonhauser2022
 import Linglib.Studies.ScontrasTonhauser2025
 import Linglib.Core.Order.Rat01
+import Linglib.Core.Probability.Constructions
 
 /-!
 # [grove-white-2025]
@@ -158,23 +159,23 @@ theorem Rat01.toNNReal_val (τ : Rat01) : ((Rat01.toNNReal τ : ℝ≥0) : ℝ) 
     intrinsic to the type rather than threaded as side hypotheses. This is
     the τ-vertex of the discrete-factivity DAG (definition (13), p. 20).
 
-    Built from mathlib's `PMF.bernoulli` (a `PMF Bool`) by relabeling
+    Built from mathlib's `PMF.bernoulliMix` (a `PMF Bool`) by relabeling
     `true ↦ .factive`, `false ↦ .nonfactive`. -/
 noncomputable def factivityPrior (τ : Rat01) : PMF FactivityReading :=
-  (PMF.bernoulli (Rat01.toNNReal τ) (Rat01.toNNReal_le_one τ)).map
+  (PMF.bernoulliMix (Rat01.toNNReal τ) (Rat01.toNNReal_le_one τ)).map
     (fun b => bif b then .factive else .nonfactive)
 
 @[simp] theorem factivityPrior_apply_factive (τ : Rat01) :
     (factivityPrior τ) FactivityReading.factive
       = ((Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
   unfold factivityPrior
-  simp [PMF.map_apply, PMF.bernoulli_apply]
+  simp [PMF.map_apply, PMF.bernoulliMix_apply]
 
 @[simp] theorem factivityPrior_apply_nonfactive (τ : Rat01) :
     (factivityPrior τ) FactivityReading.nonfactive
       = (((1 : ℝ≥0) - Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
   unfold factivityPrior
-  simp [PMF.map_apply, PMF.bernoulli_apply]
+  simp [PMF.map_apply, PMF.bernoulliMix_apply]
 
 end Prior
 

--- a/Linglib/Studies/GroveWhite2025.lean
+++ b/Linglib/Studies/GroveWhite2025.lean
@@ -159,23 +159,22 @@ theorem Rat01.toNNReal_val (τ : Rat01) : ((Rat01.toNNReal τ : ℝ≥0) : ℝ) 
     intrinsic to the type rather than threaded as side hypotheses. This is
     the τ-vertex of the discrete-factivity DAG (definition (13), p. 20).
 
-    Built from mathlib's `PMF.bernoulliMix` (a `PMF Bool`) by relabeling
-    `true ↦ .factive`, `false ↦ .nonfactive`. -/
+    A `PMF.mix` of point masses at the two readings. -/
 noncomputable def factivityPrior (τ : Rat01) : PMF FactivityReading :=
-  (PMF.bernoulliMix (Rat01.toNNReal τ) (Rat01.toNNReal_le_one τ)).map
-    (fun b => bif b then .factive else .nonfactive)
+  PMF.mix (Rat01.toNNReal τ) (Rat01.toNNReal_le_one τ)
+    (PMF.pure .nonfactive) (PMF.pure .factive)
 
 @[simp] theorem factivityPrior_apply_factive (τ : Rat01) :
     (factivityPrior τ) FactivityReading.factive
       = ((Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
   unfold factivityPrior
-  simp [PMF.map_apply, PMF.bernoulliMix_apply]
+  simp
 
 @[simp] theorem factivityPrior_apply_nonfactive (τ : Rat01) :
     (factivityPrior τ) FactivityReading.nonfactive
       = (((1 : ℝ≥0) - Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
   unfold factivityPrior
-  simp [PMF.map_apply, PMF.bernoulliMix_apply]
+  simp
 
 end Prior
 

--- a/Linglib/Studies/TsvilodubEtAl2026.lean
+++ b/Linglib/Studies/TsvilodubEtAl2026.lean
@@ -384,22 +384,20 @@ inductive Reaction where
 /-- The paper's layered mixture: clarify with probability `q`, otherwise
 act according to the behavioral policy. -/
 noncomputable def layered (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) : PMF Reaction :=
-  (PMF.bernoulliMix q hq).bind fun ask => if ask then PMF.pure .cq else pol.map .act
+  PMF.mix q hq (pol.map .act) (PMF.pure .cq)
 
 theorem layered_apply_cq (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) :
     layered q hq pol .cq = q := by
-  rw [layered, PMF.bind_apply, tsum_bool]
-  simp [PMF.bernoulliMix_apply, PMF.map_apply,
+  simp [layered, PMF.map_apply,
     show ∀ r : Response, Reaction.cq ≠ .act r from fun r => by simp]
 
 theorem layered_apply_act (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) (r : Response) :
     layered q hq pol (.act r) = (1 - (q : ℝ≥0∞)) * pol r := by
-  rw [layered, PMF.bind_apply, tsum_bool]
   have hmap : pol.map Reaction.act (.act r) = pol r := by
     rw [PMF.map_apply]
     simp only [Reaction.act.injEq]
     exact (tsum_eq_single r fun r' hne => if_neg fun h => hne h.symm).trans (if_pos rfl)
-  simp [PMF.bernoulliMix_apply, hmap]
+  simp [layered, hmap]
 
 /-- The full reaction policy at condition `(ε, δ)`: gate by the logistic of
 the expected regret, then act by the softmax policy. -/

--- a/Linglib/Studies/TsvilodubEtAl2026.lean
+++ b/Linglib/Studies/TsvilodubEtAl2026.lean
@@ -1,5 +1,6 @@
 import Linglib.Pragmatics.RSA.Canonical
 import Linglib.Core.Probability.Decision.Basic
+import Linglib.Core.Probability.Constructions
 import Linglib.Studies.DongEtAl2026PMF
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
@@ -383,12 +384,12 @@ inductive Reaction where
 /-- The paper's layered mixture: clarify with probability `q`, otherwise
 act according to the behavioral policy. -/
 noncomputable def layered (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) : PMF Reaction :=
-  (PMF.bernoulli q hq).bind fun ask => if ask then PMF.pure .cq else pol.map .act
+  (PMF.bernoulliMix q hq).bind fun ask => if ask then PMF.pure .cq else pol.map .act
 
 theorem layered_apply_cq (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) :
     layered q hq pol .cq = q := by
   rw [layered, PMF.bind_apply, tsum_bool]
-  simp [PMF.bernoulli_apply, PMF.map_apply,
+  simp [PMF.bernoulliMix_apply, PMF.map_apply,
     show ∀ r : Response, Reaction.cq ≠ .act r from fun r => by simp]
 
 theorem layered_apply_act (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) (r : Response) :
@@ -398,7 +399,7 @@ theorem layered_apply_act (q : ℝ≥0) (hq : q ≤ 1) (pol : PMF Response) (r :
     rw [PMF.map_apply]
     simp only [Reaction.act.injEq]
     exact (tsum_eq_single r fun r' hne => if_neg fun h => hne h.symm).trans (if_pos rfl)
-  simp [PMF.bernoulli_apply, hmap]
+  simp [PMF.bernoulliMix_apply, hmap]
 
 /-- The full reaction policy at condition `(ε, δ)`: gate by the logistic of
 the expected regret, then act by the softmax policy. -/


### PR DESCRIPTION
Post-audit cleanup arc for the graded-causatives study:

- `CausalGraph.Ranking` (bundled rank certificate) and `CausalGraph.TimeIndex` (the paper's time-indexed causal models, definition 1) in `Graph/Basic.lean`; `IsDAG.of_depth` becomes a thin wrapper; the study consumes the substrate types.
- `PMF.mix` consolidated in `Core/Probability/Constructions.lean`: redefined without the deprecated `PMF.bernoulli` (`mix_apply` is now `rfl`), new `mix_zero`/`mix_one`. `softOptimalPolicy` is `PMF.mix ρ (uniformOfFintype A) (pure best)` with the paper's arithmetic as `softOptimalPolicy_apply`.
- Every `PMF.bernoulli` call site retired by direct mixtures — no Bernoulli shim: GroveWhite2025's factivity prior and TsvilodubEtAl2026's layered policy mix over their target types directly (the Bool coin and `.map` relabeling disappear, and the apply-lemma proofs shrink); FragmentLambda's halt-coins are inline mixtures of point masses. The library calls no deprecated PMF constructor. Full PMF→Measure migration assessed and declined: PMF itself is not deprecated, and its surface here spans ~140 files.
- Docstring register pass and wholesale namespace opens in the study.

Follow-up candidate: fuel bridges taking `Ranking` instead of loose `(rank, hrank)` (~11 call sites).