### PR TITLE
refactor(Semantics/Causation): Valuation order as PartialOrder instance

### DIFF
--- a/Linglib/Semantics/Causation/Graph/Basic.lean
+++ b/Linglib/Semantics/Causation/Graph/Basic.lean
@@ -4,7 +4,7 @@ import Mathlib.Order.RelClasses
 import Mathlib.Logic.Relation
 
 /-!
-# CausalGraph: Acyclicity, Ancestor Relation (V2)
+# CausalGraph: Acyclicity, Ancestor Relation
 
 `IsDAG` is a `Prop` mixin class on `CausalGraph V` (mirroring
 `IsMarkovKernel` from `Mathlib/Probability/Kernel/Defs.lean`): required

--- a/Linglib/Semantics/Causation/Graph/Defs.lean
+++ b/Linglib/Semantics/Causation/Graph/Defs.lean
@@ -3,7 +3,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Basic
 
 /-!
-# CausalGraph: Bare Directed Graph over a Vertex Type (V2)
+# CausalGraph: Bare Directed Graph over a Vertex Type
 
 A `CausalGraph V` is the underlying DAG topology of a structural causal
 model: just `parents : V → Finset V`. No mechanisms, no value types, no

--- a/Linglib/Semantics/Causation/Implicative.lean
+++ b/Linglib/Semantics/Causation/Implicative.lean
@@ -45,9 +45,7 @@ open Features (Implicative)
 open Features
 open Causation (SEM CausalGraph Valuation DecidableValuation)
 
--- ════════════════════════════════════════════════════
--- § Prerequisite Types ([nadathur-2023-implicatives])
--- ════════════════════════════════════════════════════
+/-! ### Prerequisite Types ([nadathur-2023-implicatives]) -/
 
 /-- Lexically-specified prerequisite types for implicative verbs.
 
@@ -70,9 +68,7 @@ def Prerequisite.isSpecific : Prerequisite → Bool
   | .unspecified => false
   | _ => true
 
--- ════════════════════════════════════════════════════
--- § V2 Polymorphic Semantics
--- ════════════════════════════════════════════════════
+/-! ### V2 Polymorphic Semantics -/
 
 /-- V2 manage-sem ([nadathur-2023-implicatives] Definition 10a with the
     Definition 10 preamble, over the strict T_D development):
@@ -124,9 +120,7 @@ abbrev necessityPresup {V : Type*} {α : V → Type*}
     (complement : V) (xC : α complement) : Prop :=
   SEM.causallyNecessary M background prerequisite xP complement xC
 
--- ════════════════════════════════════════════════════
--- § Characteristic entailments (Facts B–C)
--- ════════════════════════════════════════════════════
+/-! ### Characteristic entailments (Facts B–C) -/
 
 /-! [nadathur-2023-implicatives] (pp. 316–317) takes Facts A–C as the
 class-level data any account of implicatives must derive. On the
@@ -211,7 +205,7 @@ theorem complement_iff_prerequisite
           rw [SEM.causallyEntails, SEM.developDetVtx?_exogenous M hgp hexo] at hEntP
           simp at hEntP
     -- s' consistently extends background + prerequisite
-    have hle : (background.extend p xP).le s' := by
+    have hle : background.extend p xP ≤ s' := by
       intro v x hv
       by_cases hvp : v = p
       · subst hvp
@@ -255,9 +249,7 @@ theorem twoWay_entailment_profile
 
 end CharacteristicEntailments
 
--- ════════════════════════════════════════════════════
--- § Directionality
--- ════════════════════════════════════════════════════
+/-! ### Directionality -/
 
 /-- Directionality of complement entailment ([nadathur-2023-implicatives]).
 
@@ -268,9 +260,7 @@ inductive Directionality where
   | twoWay
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § ImplicativeClass
--- ════════════════════════════════════════════════════
+/-! ### ImplicativeClass -/
 
 /-- The full lexical signature of an implicative verb ([nadathur-2023-implicatives]). -/
 structure ImplicativeClass where
@@ -358,9 +348,7 @@ theorem specific_vs_bleached :
 
 end Causation.Implicative
 
--- ════════════════════════════════════════════════════
--- § `Features.Implicative.toSemantics` dispatch (V2 polymorphic)
--- ════════════════════════════════════════════════════
+/-! ### `Features.Implicative.toSemantics` dispatch (V2 polymorphic) -/
 
 /-! Lives here rather than in `Features/Causation.lean` because the
 dispatch needs `Causation.SEM` + the `Implicative.manageSem`/`failSem`

--- a/Linglib/Semantics/Causation/Interpretation.lean
+++ b/Linglib/Semantics/Causation/Interpretation.lean
@@ -41,9 +41,7 @@ mapping exists; both dispatches coexist as named functions and the
 disagreement is theorem-provable.
 -/
 
--- ════════════════════════════════════════════════════
--- § Methods on `Features.Causative`
--- ════════════════════════════════════════════════════
+/-! ### Methods on `Features.Causative` -/
 
 /-! Methods on `Features.Causative` that depend on heavy semantic
 machinery (`Causation.SEM`, `CausalGraph`, the `Necessity`/
@@ -83,9 +81,7 @@ noncomputable def toSemantics {V : Type*} {α : V → Type*}
 
 end Features.Causative
 
--- ════════════════════════════════════════════════════
--- § Derivation theorems (substrate-independent)
--- ════════════════════════════════════════════════════
+/-! ### Derivation theorems (substrate-independent) -/
 
 namespace Causation.Interpretation
 
@@ -102,9 +98,7 @@ theorem make_enable_distinguished_by_permissivity :
     Causative.make.isPermissive = false ∧
     Causative.enable.isPermissive = true := ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § Bridge to CC-Selection
--- ════════════════════════════════════════════════════
+/-! ### Bridge to CC-Selection -/
 
 /-! `Causative` encodes force-dynamic mechanisms; `CCSelectionMode`
 ([baglini-bar-asher-siegal-2025]) encodes which element of a causal

--- a/Linglib/Semantics/Causation/Mechanism/Defs.lean
+++ b/Linglib/Semantics/Causation/Mechanism/Defs.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Causation.Valuation
 import Mathlib.Probability.ProbabilityMassFunction.Monad
 
 /-!
-# Mechanism: PMF-Valued Structural Equation per Vertex (V2)
+# Mechanism: PMF-Valued Structural Equation per Vertex
 
 A `Mechanism G α v` is the structural equation at vertex `v`: it takes
 a value assignment to `v`'s parents and returns a `PMF (α v)` — a

--- a/Linglib/Semantics/Causation/Mechanism/Deterministic.lean
+++ b/Linglib/Semantics/Causation/Mechanism/Deterministic.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Causation.Mechanism.Defs
 
 /-!
-# Mechanism.deterministic: Deterministic-as-Dirac Constructor (V2)
+# Mechanism.deterministic: Deterministic-as-Dirac Constructor
 
 The deterministic mechanism induced by an honest function over parents
 is built as a Dirac PMF — the exact mathlib pattern from

--- a/Linglib/Semantics/Causation/Morphological.lean
+++ b/Linglib/Semantics/Causation/Morphological.lean
@@ -77,9 +77,7 @@ open Verb
 open Causation.Psych (CausalSource)
 open ArgumentStructure (Agentivity)
 
--- ════════════════════════════════════════════════════
--- § 1. Causer Type ([hafeez-2025], [comrie-1989])
--- ════════════════════════════════════════════════════
+/-! ### Causer Type ([hafeez-2025], [comrie-1989]) -/
 
 /-- Causer type distinguished by intentionality and ontological category.
 
@@ -108,9 +106,7 @@ inductive CauseeAffecteeType where
   | inanimate           -- InanCEAF: no volition
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 2. Agentivity Degree ([hafeez-2025] Ch. 7)
--- ════════════════════════════════════════════════════
+/-! ### Agentivity Degree ([hafeez-2025] Ch. 7) -/
 
 /-- Degree of agentivity, decomposed from intentionality × control.
 
@@ -136,9 +132,7 @@ def CauseeAffecteeType.hasInducedAgentivity : CauseeAffecteeType → Bool
   | .controllingHuman => true
   | _                 => false
 
--- ════════════════════════════════════════════════════
--- § 3. Mediation ([comrie-1989], directness chapter)
--- ════════════════════════════════════════════════════
+/-! ### Mediation ([comrie-1989], directness chapter) -/
 
 /-- Directness of causal mediation between causer and result.
 
@@ -158,9 +152,7 @@ def Mediation.rank : Mediation → Nat
   | .direct   => 0
   | .indirect => 1
 
--- ════════════════════════════════════════════════════
--- § 4. Causative Complexity ([comrie-1989], morphological typology)
--- ════════════════════════════════════════════════════
+/-! ### Causative Complexity ([comrie-1989], morphological typology) -/
 
 /-- Morphological complexity of a causative construction.
 
@@ -198,9 +190,7 @@ instance : LinearOrder CausativeComplexity :=
   LinearOrder.lift' CausativeComplexity.toNat
     (fun a b h => by cases a <;> cases b <;> simp_all [CausativeComplexity.toNat])
 
--- ════════════════════════════════════════════════════
--- § 5. Causative Construction
--- ════════════════════════════════════════════════════
+/-! ### Causative Construction -/
 
 /-- A causative construction bundles morphological complexity with
     semantic parameters that govern its use.
@@ -218,9 +208,7 @@ structure CausativeConstruction where
   causeeRestriction : Option CauseeAffecteeType
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 6. Semantic Prototype
--- ════════════════════════════════════════════════════
+/-! ### Semantic Prototype -/
 
 /-- A semantic prototype specifies the combination of semantic variables
     under which a construction receives its peak acceptability rating or
@@ -247,9 +235,7 @@ structure SemanticPrototype where
   requiresMediation : Option Bool
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 7. Comrie's Generalization
--- ════════════════════════════════════════════════════
+/-! ### Comrie's Generalization -/
 
 /-- **Comrie's monotonicity** ([comrie-1989]): within a single
     language, if construction A is morphologically more compact than
@@ -261,9 +247,7 @@ structure SemanticPrototype where
 def comrie_monotone (c1 c2 : CausativeConstruction) : Prop :=
   c1.complexity < c2.complexity → c1.mediation.rank ≤ c2.mediation.rank
 
--- ════════════════════════════════════════════════════
--- § 7b. Causee Marking Hierarchy ([comrie-1989], Ch 8)
--- ════════════════════════════════════════════════════
+/-! ### Causee Marking Hierarchy ([comrie-1989], Ch 8) -/
 
 /-- Grammatical relation slots available for causee assignment,
     ordered from highest to lowest on the hierarchy.
@@ -311,9 +295,7 @@ theorem causee_demotion_monotone :
     (causeeDemotion v2.val).rank ≤ (causeeDemotion v1.val).rank := by
   decide
 
--- ════════════════════════════════════════════════════
--- § 8. Bridges to Existing Infrastructure
--- ════════════════════════════════════════════════════
+/-! ### Bridges to Existing Infrastructure -/
 
 /-- All causer types are "external" in [kim-2024]'s sense.
 
@@ -340,9 +322,7 @@ def CauserType.toAgentivity : CauserType → Agentivity
   | .accidentalHuman  => .mk false true true false  -- S+I (sentient but not volitional)
   | .naturalForce     => .mk false false true false  -- I only
 
--- ════════════════════════════════════════════════════
--- § 9. Bridge Theorems
--- ════════════════════════════════════════════════════
+/-! ### Bridge Theorems -/
 
 /-- Intentional human causers have maximal agentivity among causer types. -/
 theorem intentional_max_agentivity :
@@ -384,9 +364,7 @@ theorem inanimate_no_induced :
 theorem physImpact_no_induced :
     CauseeAffecteeType.hasInducedAgentivity .physImpactHuman = false := rfl
 
--- ════════════════════════════════════════════════════
--- § 10. Intransitivization Type ([krejci-2012])
--- ════════════════════════════════════════════════════
+/-! ### Intransitivization Type ([krejci-2012]) -/
 
 /-- How an alternating verb forms its intransitive variant.
 

--- a/Linglib/Semantics/Causation/Progressive.lean
+++ b/Linglib/Semantics/Causation/Progressive.lean
@@ -38,9 +38,7 @@ namespace Causation.Progressive
 open Intensional (WorldTimeIndex)
 open Causation Causation.Mechanism Causation.SEM
 
--- ════════════════════════════════════════════════════
--- § 1. Causal Process (V2)
--- ════════════════════════════════════════════════════
+/-! ### Causal Process -/
 
 /-- A causal process for telic predicates, parameterized over a vertex type `V`.
 
@@ -66,9 +64,7 @@ namespace CausalProcess
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
--- ════════════════════════════════════════════════════
--- § 2. Progressive vs Perfective Semantics
--- ════════════════════════════════════════════════════
+/-! ### Progressive vs Perfective Semantics -/
 
 /-- Type-level sufficiency: the causal trajectory from initiator to
     result exists. The progressive asserts this — no commitment to the
@@ -117,9 +113,7 @@ noncomputable instance (proc : CausalProcess V)
 
 end CausalProcess
 
--- ════════════════════════════════════════════════════
--- § 3. Imperfective Paradox: maryOpening
--- ════════════════════════════════════════════════════
+/-! ### Imperfective Paradox: maryOpening -/
 
 /-! Example: "Mary was opening the door" / "Mary opened the door."
     Simple model: Mary's action → door opens. -/
@@ -179,9 +173,7 @@ theorem perfective_entails_progressive {V : Type*} [Fintype V] [DecidableEq V]
     (h : proc.perfectiveTrue) :
     proc.progressiveTrue := h.1
 
--- ════════════════════════════════════════════════════
--- § 4. Imperfective Paradox: overdetermination witness
--- ════════════════════════════════════════════════════
+/-! ### Imperfective Paradox: overdetermination witness -/
 
 /-! Witness for `progressive ∧ ¬ perfective`: an overdetermination model
     where the type-level process exists but the actual outcome would
@@ -246,9 +238,7 @@ theorem progressive_not_entails_perfective :
     overdetProc.progressiveTrue ∧ ¬ overdetProc.perfectiveTrue :=
   ⟨overdet_progressive, overdet_not_perfective⟩
 
--- ════════════════════════════════════════════════════
--- § 5. Type-level = development under inertia (Dowty 1979)
--- ════════════════════════════════════════════════════
+/-! ### Type-level = development under inertia (Dowty 1979) -/
 
 /-- [dowty-1979]: the progressive is true iff the outcome holds in
     all inertia worlds (normal continuations). The causal model account
@@ -262,9 +252,7 @@ theorem typeLevelHolds_is_develop {V : Type*} [Fintype V] [DecidableEq V]
       (proc.enablingConditions.extend proc.initiator true)).hasValue proc.result true :=
   Iff.rfl
 
--- ════════════════════════════════════════════════════
--- § 6. Bridge to Temporal Decomposition
--- ════════════════════════════════════════════════════
+/-! ### Bridge to Temporal Decomposition -/
 
 /-- A causally grounded telic event: bridges `CausalProcess` (causal
     explanation) with `SubeventPhases` (temporal realization).

--- a/Linglib/Semantics/Causation/Psych.lean
+++ b/Linglib/Semantics/Causation/Psych.lean
@@ -80,9 +80,7 @@ def CausalSource.isEventive : CausalSource → Bool
   | .external => true
   | .internal => false
 
--- ════════════════════════════════════════════════════
--- § Stimulus Subtype ([pesetsky-1995])
--- ════════════════════════════════════════════════════
+/-! ### Stimulus Subtype ([pesetsky-1995]) -/
 
 /-- [pesetsky-1995]'s subdivision of the stimulus role.
 
@@ -121,9 +119,7 @@ def StimulusType.conflictsWithCause : StimulusType → Bool
   | .target        => false
   | .subjectMatter => true
 
--- ════════════════════════════════════════════════════
--- § CausalSource → StimulusType Derivation
--- ════════════════════════════════════════════════════
+/-! ### CausalSource → StimulusType Derivation -/
 
 /-- Derive stimulus subtype from causal source.
 

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -40,9 +40,7 @@ open Causation.Psych (CausalSource)
 open Core.Order (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
--- ════════════════════════════════════════════════════
--- § 1. PsychCausalLink
--- ════════════════════════════════════════════════════
+/-! ### PsychCausalLink -/
 
 /-- A causal link between two eventualities in psych verb semantics.
 
@@ -61,9 +59,7 @@ structure PsychCausalLink (Time : Type*) [LinearOrder Time] where
   /-- Temporal constraint on the runtimes of cause and effect -/
   temporalConstraint : NonemptyInterval Time → NonemptyInterval Time → Prop
 
--- ════════════════════════════════════════════════════
--- § 2. Eventive and Maintenance Links
--- ════════════════════════════════════════════════════
+/-! ### Eventive and Maintenance Links -/
 
 /-- Eventive causation: an external percept/event CAUSES a change of
     mental state. The cause temporally precedes the effect.
@@ -95,9 +91,7 @@ def maintenanceLink (Time : Type*) [LinearOrder Time] : PsychCausalLink Time :=
     involvesTransition := false
     temporalConstraint := NonemptyInterval.overlaps }
 
--- ════════════════════════════════════════════════════
--- § 3. CausalSource → PsychCausalLink
--- ════════════════════════════════════════════════════
+/-! ### CausalSource → PsychCausalLink -/
 
 /-- Ground `CausalSource` (a two-constructor enum) in the richer
     `PsychCausalLink` structure. External source = eventive causation;
@@ -107,9 +101,7 @@ def CausalSource.toLink (Time : Type*) [LinearOrder Time] :
   | .external => eventiveLink Time
   | .internal => maintenanceLink Time
 
--- ════════════════════════════════════════════════════
--- § 4. Temporal Theorems
--- ════════════════════════════════════════════════════
+/-! ### Temporal Theorems -/
 
 /-- Maintenance is temporally symmetric: if cause overlaps effect,
     effect overlaps cause. Delegates to `NonemptyInterval.overlaps_symm`. -/
@@ -137,9 +129,7 @@ theorem precedes_excludes_overlap {Time : Type*} [LinearOrder Time]
     ¬ (maintenanceLink Time).temporalConstraint i₁ i₂ :=
   NonemptyInterval.precedes_not_overlaps h
 
--- ════════════════════════════════════════════════════
--- § 5. Event Sort Properties
--- ════════════════════════════════════════════════════
+/-! ### Event Sort Properties -/
 
 /-- Maintenance relates two states ([kim-2024] property (a)). -/
 theorem maintenance_both_states {Time : Type*} [LinearOrder Time] :
@@ -167,9 +157,7 @@ theorem flavors_differ_on_all_dimensions {Time : Type*} [LinearOrder Time] :
     (maintenanceLink Time).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 6. Counterfactual Predicates
--- ════════════════════════════════════════════════════
+/-! ### Counterfactual Predicates -/
 
 /-- Counterfactual dependence: in the closest worlds where the cause
     doesn't hold, the effect doesn't hold either.
@@ -238,9 +226,7 @@ theorem dependent_excludes_persistent {W : Type*} [DecidableEq W] [Fintype W]
   obtain ⟨x, hx⟩ := hNonempty
   exact (hDep x hx) (hall x hx)
 
--- ════════════════════════════════════════════════════
--- § 7. [kim-2024]: Three Properties of Maintenance
--- ════════════════════════════════════════════════════
+/-! ### [kim-2024]: Three Properties of Maintenance -/
 
 /-- The three defining properties of maintenance causation from
     [kim-2024], formalized using existing infrastructure:

--- a/Linglib/Semantics/Causation/SEM/Basic.lean
+++ b/Linglib/Semantics/Causation/SEM/Basic.lean
@@ -5,7 +5,7 @@ import Mathlib.Logic.Function.Iterate
 import Mathlib.Probability.ProbabilityMassFunction.Constructions
 
 /-!
-# SEM: Forward Propagation, Intervention, Fixpoint (V2)
+# SEM: Forward Propagation, Intervention, Fixpoint
 
 - **`intervene`** (Pearl `do(v := x)`): replace the mechanism for `v`
   with `Mechanism.const x`.
@@ -46,9 +46,7 @@ namespace Causation.SEM
 
 variable {V : Type*} {α : V → Type*}
 
--- ════════════════════════════════════════════════════
--- § Intervention (Pearl do(v := x))
--- ════════════════════════════════════════════════════
+/-! ### Intervention (Pearl do(v := x)) -/
 
 /-- **Pearl's `do(v := x)` intervention**: replace the mechanism for `v`
     with the constant Dirac-PMF mechanism returning `x`. Other vertices'
@@ -89,9 +87,7 @@ noncomputable instance [DecidableEq V] (M : SEM V α) [IsDeterministic M]
     · simp [intervene, h]
       exact IsDeterministic.mech_det w
 
--- ════════════════════════════════════════════════════
--- § Forward propagation: ready, parentAssignment
--- ════════════════════════════════════════════════════
+/-! ### Forward propagation: ready, parentAssignment -/
 
 /-- A vertex is **ready** in a valuation when all its parents have
     determined values. Required precondition for firing the mechanism. -/
@@ -108,9 +104,7 @@ def parentAssignment (M : SEM V α) (s : Valuation α) (v : V)
     (h : ready M s v) : ∀ u : M.graph.parents v, α u.val :=
   fun u => (s.get u.val).get (h u.val u.property)
 
--- ════════════════════════════════════════════════════
--- § Forward propagation: singleStepAtDet + stepOnceDetOn (computable)
--- ════════════════════════════════════════════════════
+/-! ### Forward propagation: singleStepAtDet + stepOnceDetOn (computable) -/
 
 /-- Per-vertex step of `stepOnceDet`. Computable. Three structural cases
     surfaced via simp lemmas (`singleStepAtDet_extend`, `_skip_determined`,
@@ -166,9 +160,7 @@ def stepOnceDetOn [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [IsDeterministic M] (v : V) (vs : List V) (s : Valuation α) :
     stepOnceDetOn M (v :: vs) s = stepOnceDetOn M vs (singleStepAtDet M s v) := rfl
 
--- ════════════════════════════════════════════════════
--- § Computational specialization: developDetOn (explicit list)
--- ════════════════════════════════════════════════════
+/-! ### Computational specialization: developDetOn (explicit list) -/
 
 /-! The canonical `developDet` (per-vertex, via `IsDAG.wf.fix`) lives in
     `PerVertex.lean`. Below is the **computational specialization**:
@@ -213,9 +205,7 @@ theorem developDetOn_succ [DecidableEq V] [DecidableValuation α]
     developDetOn M vs (n + 1) s = developDetOn M vs n (stepOnceDetOn M vs s) := by
   simp [developDetOn, Function.iterate_succ_apply]
 
--- ════════════════════════════════════════════════════
--- § Bridge: developDetOn ↦ developDet (soundness)
--- ════════════════════════════════════════════════════
+/-! ### Bridge: developDetOn ↦ developDet (soundness) -/
 
 /-! Soundness bridge connecting the iteration form (`developDetOn`,
     computable, `decide`-friendly) to the canonical per-vertex form
@@ -240,7 +230,7 @@ theorem developDetOn_succ [DecidableEq V] [DecidableValuation α]
 private def isConsistentDev [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterministic M]
     (s s' : Valuation α) : Prop :=
-  s.le s' ∧ ∀ v x, s'.get v = some x → developDetVtx M s v = x
+  s ≤ s' ∧ ∀ v x, s'.get v = some x → developDetVtx M s v = x
 
 /-- The starting valuation is consistent with itself. -/
 private lemma isConsistentDev_self [DecidableEq V] [DecidableValuation α]
@@ -286,7 +276,7 @@ private lemma isConsistentDev_singleStepAtDet [DecidableEq V] [DecidableValuatio
         -- hReadyU : (s'.get u.val).isSome
         exact hCons u.val ((s'.get u.val).get hReadyU) (Option.some_get hReadyU).symm |>.symm
       refine ⟨?_, ?_⟩
-      · -- s.le (s'.extend v newVal)
+      · -- s ≤ s'.extend v newVal
         intro w x hwx
         have h1 : s'.hasValue w x := hLe w x hwx
         by_cases hwv : w = v
@@ -358,9 +348,7 @@ theorem developDet_hasValue_of_developDetOn_hasValue [DecidableEq V] [DecidableV
   rw [developDet_hasValue_iff]
   exact developDetVtx_of_developDetOn_hasValue h
 
--- ════════════════════════════════════════════════════
--- § Bridge: developDet ↦ developDetOn (completeness)
--- ════════════════════════════════════════════════════
+/-! ### Bridge: developDet ↦ developDetOn (completeness) -/
 
 /-! Completeness counterpart to the soundness bridge above. For a
     `Fintype V + IsDAG + IsDeterministic` SEM, `Fintype.card V`
@@ -368,7 +356,7 @@ theorem developDet_hasValue_of_developDetOn_hasValue [DecidableEq V] [DecidableV
     `V` produce the canonical answer at every vertex.
 
     Proof outline:
-    1. Monotonicity: `s.le (singleStepAtDet M s v)`, etc.
+    1. Monotonicity: `s ≤ singleStepAtDet M s v`, etc.
     2. Single-step progress: undetermined+ready ⇒ determined after step.
     3. IsDAG min: nonempty undetermined set has a `WellFounded.has_min`
        member whose strict ancestors (and so parents) are all determined,
@@ -383,7 +371,7 @@ variable (M : SEM V α) [IsDeterministic M]
 
 /-- `singleStepAtDet` only extends the valuation. -/
 private lemma singleStepAtDet_le (s : Valuation α) (v : V) :
-    s.le (singleStepAtDet M s v) := by
+    s ≤ singleStepAtDet M s v := by
   intro w x hwx
   by_cases hSome : (s.get v).isSome
   · rw [singleStepAtDet_skip_determined M s v hSome]; exact hwx
@@ -397,35 +385,29 @@ private lemma singleStepAtDet_le (s : Valuation α) (v : V) :
       · rw [Valuation.hasValue, Valuation.extend_get_ne hwv]; exact hwx
     · rw [singleStepAtDet_skip_not_ready M s v hR]; exact hwx
 
-omit [DecidableEq V] [DecidableValuation α] in
-/-- `Valuation.le` is transitive. -/
-private lemma Valuation.le_trans {s₁ s₂ s₃ : Valuation α}
-    (h₁₂ : s₁.le s₂) (h₂₃ : s₂.le s₃) : s₁.le s₃ :=
-  fun w x hwx => h₂₃ w x (h₁₂ w x hwx)
-
 /-- `stepOnceDetOn` only extends the valuation. -/
 private lemma stepOnceDetOn_le (s : Valuation α) (vs : List V) :
-    s.le (stepOnceDetOn M vs s) := by
+    s ≤ stepOnceDetOn M vs s := by
   unfold stepOnceDetOn
   induction vs generalizing s with
   | nil => intro w x h; exact h
   | cons v vs ih =>
     simp only [List.foldl_cons]
-    exact Valuation.le_trans (singleStepAtDet_le M s v) (ih (singleStepAtDet M s v))
+    exact (singleStepAtDet_le M s v).trans (ih (singleStepAtDet M s v))
 
 /-- `developDetOn` only extends the valuation. -/
 private lemma developDetOn_le (s : Valuation α) (vs : List V) (n : ℕ) :
-    s.le (developDetOn M vs n s) := by
+    s ≤ developDetOn M vs n s := by
   induction n generalizing s with
   | zero => intro w x h; exact h
   | succ n ih =>
     rw [developDetOn_succ]
-    exact Valuation.le_trans (stepOnceDetOn_le M s vs) (ih (stepOnceDetOn M vs s))
+    exact (stepOnceDetOn_le M s vs).trans (ih (stepOnceDetOn M vs s))
 
 omit [DecidableEq V] [DecidableValuation α] [IsDeterministic M] in
 /-- `ready` is monotone in the valuation: extending a valuation only
     determines more parents, preserving readiness. -/
-private lemma ready_mono {s s' : Valuation α} (hLe : s.le s') (v : V)
+private lemma ready_mono {s s' : Valuation α} (hLe : s ≤ s') (v : V)
     (hR : ready M s v) : ready M s' v := by
   intro u hu
   have hSome : (s.get u).isSome := hR u hu
@@ -519,7 +501,7 @@ private def undetCount [Fintype V] (s : Valuation α) : ℕ :=
 omit [DecidableValuation α] [IsDeterministic M] in
 /-- Pointwise progress at any vertex strictly decreases `undetCount`. -/
 private lemma undetCount_lt_of_progress [Fintype V]
-    {s s' : Valuation α} (hLe : s.le s') (v : V)
+    {s s' : Valuation α} (hLe : s ≤ s') (v : V)
     (hN : (s.get v).isNone) (hS : (s'.get v).isSome) :
     undetCount s' < undetCount s := by
   unfold undetCount
@@ -744,9 +726,7 @@ theorem developDet_intervene_eq_developDet_extend
         funext u
         exact ih u.val (Relation.TransGen.single u.property)
 
--- ════════════════════════════════════════════════════
--- § PMF-valued forward propagation (canonical)
--- ════════════════════════════════════════════════════
+/-! ### PMF-valued forward propagation (canonical) -/
 
 /-! Mathlib pattern: `develop` is PMF-valued unconditionally — the
 mathematical object that doesn't presuppose deterministic mechanisms.

--- a/Linglib/Semantics/Causation/SEM/Bool.lean
+++ b/Linglib/Semantics/Causation/SEM/Bool.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Causation.SEM.Defs
 
 /-!
-# BoolSEM: Legacy Binary-Substrate Convenience Alias (V2)
+# BoolSEM: Legacy Binary-Substrate Convenience Alias
 
 `BoolSEM V := SEM V (fun _ => Bool)`. Convenience for consumers that
 work in the SBH 2009 deterministic-binary substrate (the special case

--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Causation.SEM.Bool
 import Linglib.Semantics.Causation.SEM.Deterministic
 
 /-!
-# SEM: Causal Counterfactual Predicates (V2)
+# SEM: Causal Counterfactual Predicates
 
 Polymorphic counterfactual predicates over a `SEM V α`, plus `BoolSEM`-flavored
 aliases for legacy SBH-style binary semantics.
@@ -54,9 +54,7 @@ namespace Causation.SEM
 variable {V : Type*} {α : V → Type*}
 variable [Fintype V] [DecidableEq V] [DecidableValuation α]
 
--- ════════════════════════════════════════════════════
--- § Polymorphic counterfactual predicates
--- ════════════════════════════════════════════════════
+/-! ### Polymorphic counterfactual predicates -/
 
 /-- After developing the SEM against `s`, vertex `v` has the value `x`.
 
@@ -89,9 +87,7 @@ noncomputable instance (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterminist
     Decidable (causallySufficient M s cause xC effect xE) :=
   Classical.dec _
 
--- ════════════════════════════════════════════════════
--- § Basic API lemmas (polymorphic)
--- ════════════════════════════════════════════════════
+/-! ### Basic API lemmas (polymorphic) -/
 
 omit [Fintype V] [DecidableEq V] [DecidableValuation α] in
 /-- `developsToValue` unfolds to `(developDet M s).hasValue v x`. -/
@@ -123,9 +119,7 @@ noncomputable instance (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterminist
     Decidable (manipulates M s cause xC1 xC2 effect) :=
   Classical.dec _
 
--- ════════════════════════════════════════════════════
--- § Unified counterfactual primitive (PMF-canonical)
--- ════════════════════════════════════════════════════
+/-! ### Unified counterfactual primitive (PMF-canonical) -/
 
 /-! Pearl-style counterfactual simulation via Lassiter's RRR heuristic
     ([lassiter-2017-probabilistic-language]): "Rewind to the
@@ -200,9 +194,7 @@ noncomputable def counterfactualSimulate
     PMF (Valuation α) :=
   develop M (cfSeed M observed antecedent xAnt)
 
--- ════════════════════════════════════════════════════
--- § Derived graded predicates (B&G 2025 W/H/S, etc.)
--- ════════════════════════════════════════════════════
+/-! ### Derived graded predicates (B&G 2025 W/H/S, etc.) -/
 
 /-- **Whether-causation** ([beller-gerstenberg-2025] Eq 1):
     `W(A → e) = P(e' ≠ e | s, remove(A))`. Probability that the counterfactual
@@ -260,9 +252,7 @@ noncomputable def probSufficiency
     (effect : V) (xE : α effect) : ENNReal :=
   probOfValue (counterfactualSimulate M observed cause xC) effect xE
 
--- ════════════════════════════════════════════════════
--- § Bridge theorems: deterministic collapse
--- ════════════════════════════════════════════════════
+/-! ### Bridge theorems: deterministic collapse -/
 
 /-- Bridge: under `IsDeterministic`, `counterfactualSimulate` is the Dirac
     of the per-vertex counterfactual valuation `developDet M (cfSeed ...)`.
@@ -310,9 +300,7 @@ theorem probSufficiency_eq_indicator_of_deterministic
 
 end Causation.SEM
 
--- ════════════════════════════════════════════════════
--- § BoolSEM specializations (legacy SBH-style binary semantics)
--- ════════════════════════════════════════════════════
+/-! ### BoolSEM specializations (legacy SBH-style binary semantics) -/
 
 namespace Causation.BoolSEM
 
@@ -359,9 +347,7 @@ removed: they leaked the vertex list and fuel into theorem statements, and
 their negations asserted facts about an iteration trace rather than the
 causal notion. -/
 
--- ════════════════════════════════════════════════════
--- § Bridges: manipulates from developDetOn computation
--- ════════════════════════════════════════════════════
+/-! ### Bridges: manipulates from developDetOn computation -/
 
 omit [Fintype V] in
 /-- **Positive `manipulates` bridge**: if `developDetOn` produces different
@@ -465,7 +451,7 @@ theorem causallyEntails_unique [DecidableEq V] {M : SEM V α}
 def isConsistentSuper [DecidableEq V] [DecidableValuation α] (M : SEM V α)
     [CausalGraph.IsDAG M.graph] [IsDeterministic M]
     (base s' : Valuation α) : Prop :=
-  base.le s' ∧
+  base ≤ s' ∧
   ∀ (x : V) (xv : α x), base.get x = none → s'.get x = some xv →
     ∀ yv : α x, yv ≠ xv → ¬ causallyEntails M base x yv
 
@@ -546,12 +532,12 @@ theorem causallyEntails_mono [DecidableEq V] [DecidableValuation α]
     this definition makes that reading explicit. -/
 def IsExogenousSettlement [DecidableValuation α] (M : SEM V α)
     (base s' : Valuation α) : Prop :=
-  base.le s' ∧
+  base ≤ s' ∧
   ∀ v : V, base.get v = none → (s'.get v).isSome → M.graph.parents v = ∅
 
 /-- Information order, executable characterization. -/
 theorem Valuation.le_iff_forall [DecidableValuation α] {s₁ s₂ : Valuation α} :
-    s₁.le s₂ ↔ ∀ v : V, (s₁.get v).isSome → s₁.get v = s₂.get v := by
+    s₁ ≤ s₂ ↔ ∀ v : V, (s₁.get v).isSome → s₁.get v = s₂.get v := by
   constructor
   · intro h v hv
     obtain ⟨x, hx⟩ := Option.isSome_iff_exists.mp hv
@@ -561,7 +547,7 @@ theorem Valuation.le_iff_forall [DecidableValuation α] {s₁ s₂ : Valuation �
     rw [hx] at this; exact this.symm
 
 instance [DecidableEq V] [Fintype V] [DecidableValuation α] (s₁ s₂ : Valuation α) :
-    Decidable (s₁.le s₂) :=
+    Decidable (s₁ ≤ s₂) :=
   decidable_of_iff _ Valuation.le_iff_forall.symm
 
 instance [DecidableEq V] [Fintype V] [DecidableValuation α] (M : SEM V α)
@@ -575,7 +561,7 @@ theorem IsExogenousSettlement.of_extend [DecidableEq V] [DecidableValuation α]
     (hexo : M.graph.parents p = ∅) (hp : s.get p = none)
     (h : IsExogenousSettlement M (s.extend p xP) s') :
     IsExogenousSettlement M s s' := by
-  refine ⟨Valuation.le_trans (Valuation.le_extend xP hp) h.1, fun v hv hsv => ?_⟩
+  refine ⟨(Valuation.le_extend xP hp).trans h.1, fun v hv hsv => ?_⟩
   by_cases hvp : v = p
   · subst hvp; exact hexo
   · exact h.2 v (by rw [Valuation.extend_get_ne hvp]; exact hv) hsv
@@ -671,9 +657,7 @@ noncomputable instance [DecidableEq V] [DecidableValuation α]
     (s : Valuation α) (cause : V) (xC : α cause) (effect : V) (xE : α effect) :
     Decidable (causallyNecessary M s cause xC effect xE) := Classical.dec _
 
--- ════════════════════════════════════════════════════
--- § Executable Def 10b (fuel form) and decidability
--- ════════════════════════════════════════════════════
+/-! ### Executable Def 10b (fuel form) and decidability -/
 
 /-- Executable mirror of `causallyNecessary` at fuel `n`: every
     `causallyEntails` clause replaced by its `developDetVtxFuel` form.

--- a/Linglib/Semantics/Causation/SEM/Defs.lean
+++ b/Linglib/Semantics/Causation/SEM/Defs.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Causation.Mechanism.Defs
 import Linglib.Semantics.Causation.Valuation
 
 /-!
-# SEM: Bundled Structural Equation Model (V2)
+# SEM: Bundled Structural Equation Model
 
 A `SEM V α` is a `CausalGraph V` together with a `Mechanism` for every
 vertex. Replaces the old `CausalDynamics` (which conflated the implicit

--- a/Linglib/Semantics/Causation/SEM/Deterministic.lean
+++ b/Linglib/Semantics/Causation/SEM/Deterministic.lean
@@ -98,9 +98,7 @@ noncomputable def developDet (M : SEM V α) [CausalGraph.IsDAG M.graph]
     [SEM.IsDeterministic M] (s : Valuation α) : Valuation α :=
   fun v => some (developDetVtx M s v)
 
--- ════════════════════════════════════════════════════
--- § Structural unfolding lemmas
--- ════════════════════════════════════════════════════
+/-! ### Structural unfolding lemmas -/
 
 /-- Step lemma: one layer of `WellFounded.fix_eq` unfolding. Use with
     `rw` to open `developDetVtx M s v` in proofs. -/
@@ -146,9 +144,7 @@ theorem developDet_hasValue_iff (M : SEM V α) [CausalGraph.IsDAG M.graph]
     (M.developDet s).hasValue v x ↔ developDetVtx M s v = x :=
   Option.some_inj
 
--- ════════════════════════════════════════════════════
--- § Partial development (strict T_D dynamics)
--- ════════════════════════════════════════════════════
+/-! ### Partial development (strict T_D dynamics) -/
 
 /-! The strict Schulz/Nadathur development relation T_D ([schulz-2011];
     [nadathur-2023-implicatives] Defs 4–5) never assigns values to
@@ -268,9 +264,7 @@ theorem developDetVtx_eq_of_developDetVtx?_eq_some
 
 end PartialDevelopment
 
--- ════════════════════════════════════════════════════
--- § Fuel mirror (computable, kernel-reducible)
--- ════════════════════════════════════════════════════
+/-! ### Fuel mirror (computable, kernel-reducible) -/
 
 /-- Fuel-indexed computable mirror of `developDetVtx?`. Structural
     recursion on fuel, so concrete claims reduce in the kernel and

--- a/Linglib/Semantics/Causation/Valuation.lean
+++ b/Linglib/Semantics/Causation/Valuation.lean
@@ -3,7 +3,7 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.List.Basic
 
 /-!
-# Valuation: Pi-Typed Partial Variable Assignment (V2)
+# Valuation: Pi-Typed Partial Variable Assignment
 
 Replaces the old `Situation` (which fixed `Variable → Option Bool`).
 A `Valuation α` is a Π-type partial valuation where each vertex `v`
@@ -60,38 +60,29 @@ def extend [DecidableEq V] (s : Valuation α) (v : V) (x : α v) :
 def remove [DecidableEq V] (s : Valuation α) (v : V) : Valuation α := fun w =>
   if w = v then none else s w
 
-/-- Information ordering: every value defined in `s₁` matches in `s₂`. -/
-def le (s₁ s₂ : Valuation α) : Prop :=
-  ∀ v x, s₁.hasValue v x → s₂.hasValue v x
-
-theorem le_refl (s : Valuation α) : s.le s :=
-  fun _ _ h => h
-
-theorem le_trans {s₁ s₂ s₃ : Valuation α}
-    (h₁ : s₁.le s₂) (h₂ : s₂.le s₃) : s₁.le s₃ :=
-  fun v x h => h₂ v x (h₁ v x h)
-
-theorem le_antisymm {s₁ s₂ : Valuation α}
-    (h₁ : s₁.le s₂) (h₂ : s₂.le s₁) : s₁ = s₂ := by
-  funext v
-  show s₁.get v = s₂.get v
-  cases h : s₁.get v with
-  | some x => exact (h₁ v x h).symm
-  | none =>
-      cases h' : s₂.get v with
-      | none => rfl
-      | some y =>
-          have hy : s₁.get v = some y := h₂ v y h'
-          rw [h] at hy
-          simp at hy
-
-/-- The information order is a partial order (mathlib `Finset`-style
-    instance; `s₁.le s₂` and `s₁ ≤ s₂` are definitionally equal). -/
+/-- The information order: `s₁ ≤ s₂` iff every value determined in `s₁`
+    is determined identically in `s₂`. -/
 instance : PartialOrder (Valuation α) where
-  le s₁ s₂ := s₁.le s₂
-  le_refl := le_refl
-  le_trans _ _ _ := le_trans
-  le_antisymm _ _ := le_antisymm
+  le s₁ s₂ := ∀ v x, s₁.hasValue v x → s₂.hasValue v x
+  le_refl _ _ _ h := h
+  le_trans _ _ _ h₁ h₂ v x h := h₂ v x (h₁ v x h)
+  le_antisymm s₁ s₂ h₁ h₂ := by
+    funext v
+    show s₁.get v = s₂.get v
+    cases h : s₁.get v with
+    | some x => exact (h₁ v x h).symm
+    | none =>
+        cases h' : s₂.get v with
+        | none => rfl
+        | some y =>
+            have hy : s₁.get v = some y := h₂ v y h'
+            rw [h] at hy
+            simp at hy
+
+/-- The information order unfolds to pointwise preservation of
+    determined values. -/
+theorem le_def {s₁ s₂ : Valuation α} :
+    s₁ ≤ s₂ ↔ ∀ v x, s₁.hasValue v x → s₂.hasValue v x := Iff.rfl
 
 @[simp] theorem extend_get_same [DecidableEq V]
     (s : Valuation α) (v : V) (x : α v) :
@@ -105,7 +96,7 @@ theorem extend_get_ne [DecidableEq V]
 
 /-- Extending at an undetermined vertex only adds information. -/
 theorem le_extend [DecidableEq V] {s : Valuation α}
-    {v : V} (x : α v) (h : s.get v = none) : s.le (s.extend v x) := by
+    {v : V} (x : α v) (h : s.get v = none) : s ≤ s.extend v x := by
   intro w y hw
   by_cases hwv : w = v
   · subst hwv; rw [Valuation.hasValue, h] at hw; exact absurd hw (by simp)


### PR DESCRIPTION
First of two PRs from the Causation-API mathlib review.

- `Valuation.le` (custom def + standalone `le_refl`/`le_trans`/`le_antisymm`) becomes the `PartialOrder` instance it was always describing — the previously dead instance now IS the definition, consumers use `≤`/`.trans`, and `SEM/Basic.lean`'s duplicate private `le_trans` is deleted. `le_def` provides the unfolding characterization; `le_extend`/`le_iff_forall` restated over `≤`. ~24 sites in 4 files; zero study churn (the instance is application-transparent, so existing intro/apply proofs survive).
- Style sweep across the Causation tree: `-- ═══`/`-- §` banner comments → `/-! ### -/` section headers (16 files), section-number prefixes dropped, `(V2)` migration markers stripped from all module titles.

Second PR to follow: fuel bridges take `CausalGraph.Ranking` (~43 study call sites). Declined per review: Sigma-packing the vertex-value pairs (poisons the decide idiom), `Mechanism` restructure (no law to bundle).