### PR TITLE
refactor(Semantics/Causation/SEM): fuel bridges take Ranking

### DIFF
--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -37,8 +37,9 @@ The canonical predicates are noncomputable (`WellFounded.fix`); `Decidable`
 instances on them are `Classical.dec` and do **not** support `decide`.
 Concrete claims go through the fuel bridge instead: `causallyEntails_iff_fuel`
 and `causallyNecessary_iff_fuel` rewrite to the kernel-reducible
-`developDetVtxFuel` / `causallyNecessaryFuel` forms given a per-model rank
-certificate (the depth function already supplied to `IsDAG.of_depth`), after
+`developDetVtxFuel` / `causallyNecessaryFuel` forms given a per-model
+`CausalGraph.Ranking` (the same certificate that yields `IsDAG` via
+`Ranking.isDAG`), after
 which `decide` evaluates them — including the Def 10b supersituation
 quantifiers, which range over the finite valuation space. Study idiom:
 
@@ -418,10 +419,10 @@ noncomputable instance [DecidableEq V] (M : SEM V α) [CausalGraph.IsDAG M.graph
     `(causallyEntails_iff_fuel M rank @hrank hn s v x).mpr (by decide)`. -/
 theorem causallyEntails_iff_fuel [DecidableEq V] (M : SEM V α)
     [CausalGraph.IsDAG M.graph] [IsDeterministic M]
-    (rank : V → ℕ) (hrank : ∀ {u v : V}, u ∈ M.graph.parents v → rank u < rank v)
-    {n : ℕ} {v : V} (hn : rank v < n) (s : Valuation α) (x : α v) :
+    (r : CausalGraph.Ranking M.graph)
+    {n : ℕ} {v : V} (hn : r.rank v < n) (s : Valuation α) (x : α v) :
     causallyEntails M s v x ↔ developDetVtxFuel M s n v = some x := by
-  rw [causallyEntails, ← developDetVtxFuel_eq_developDetVtx? M rank hrank s hn]
+  rw [causallyEntails, ← developDetVtxFuel_eq_developDetVtx? M r s hn]
 
 /-- Strict causal entailment of the extended background implies the bare
     eager-total sufficiency predicate (`causallySufficient`): the partial
@@ -688,14 +689,14 @@ instance [Fintype V] [DecidableEq V] [DecidableValuation α] [∀ v, Fintype (α
     `(causallyNecessary_iff_fuel M rank @hrank hn s …).mpr (by decide)`. -/
 theorem causallyNecessary_iff_fuel [Fintype V] [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterministic M]
-    (rank : V → ℕ) (hrank : ∀ {u v : V}, u ∈ M.graph.parents v → rank u < rank v)
-    {n : ℕ} (hn : ∀ v : V, rank v < n)
+    (r : CausalGraph.Ranking M.graph)
+    {n : ℕ} (hn : ∀ v : V, r.rank v < n)
     (s : Valuation α) (cause : V) (xC : α cause) (effect : V) (xE : α effect) :
     causallyNecessary M s cause xC effect xE ↔
       causallyNecessaryFuel M n s cause xC effect xE := by
   have hpt : ∀ (t : Valuation α) (v : V) (x : α v),
       causallyEntails M t v x ↔ developDetVtxFuel M t n v = some x :=
-    fun t v x => causallyEntails_iff_fuel M rank @hrank (hn v) t x
+    fun t v x => causallyEntails_iff_fuel M r (hn v) t x
   unfold causallyNecessary causallyNecessary.precondition
     causallyNecessary.achievable causallyNecessary.noAlternative
     causallyNecessaryFuel

--- a/Linglib/Semantics/Causation/SEM/Deterministic.lean
+++ b/Linglib/Semantics/Causation/SEM/Deterministic.lean
@@ -294,9 +294,8 @@ variable (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
     supplies to `CausalGraph.IsDAG.of_depth`), the fuel mirror computes
     the strict fixed point. Soundness and completeness in one equation. -/
 theorem developDetVtxFuel_eq_developDetVtx?
-    (rank : V → ℕ) (hrank : ∀ {u v : V}, u ∈ M.graph.parents v → rank u < rank v)
-    (s : Valuation α) :
-    ∀ {n : ℕ} {v : V}, rank v < n →
+    (r : CausalGraph.Ranking M.graph) (s : Valuation α) :
+    ∀ {n : ℕ} {v : V}, r.rank v < n →
       developDetVtxFuel M s n v = developDetVtx? M s v := by
   intro n
   induction n with
@@ -320,7 +319,7 @@ theorem developDetVtxFuel_eq_developDetVtx?
       · simp [hPar]
       · have hpt : ∀ u : M.graph.parents v,
             developDetVtxFuel M s n u.val = developDetVtx? M s u.val :=
-          fun u => ih (by have := hrank u.property; omega)
+          fun u => ih (by have := r.parent_lt u.property; omega)
         simp only [hPar, if_false]
         by_cases hAll : ∀ u : M.graph.parents v, (developDetVtx? M s u.val).isSome
         · have hAll' : ∀ u : M.graph.parents v,
@@ -336,13 +335,13 @@ theorem developDetVtxFuel_eq_developDetVtx?
 
 /-- Transfer a concrete fuel computation to the canonical strict fixed
     point. The usual study idiom:
-    `developDetVtx?_eq_of_fuel M rank (by intro u v h; revert h; decide) (by omega) (by decide)`. -/
+    `developDetVtx?_eq_of_fuel M ⟨rank, by intro u v h; revert h; decide⟩ (by omega) (by decide)`. -/
 theorem developDetVtx?_eq_of_fuel
-    (rank : V → ℕ) (hrank : ∀ {u v : V}, u ∈ M.graph.parents v → rank u < rank v)
-    {s : Valuation α} {n : ℕ} {v : V} {o : Option (α v)} (hn : rank v < n)
+    (r : CausalGraph.Ranking M.graph)
+    {s : Valuation α} {n : ℕ} {v : V} {o : Option (α v)} (hn : r.rank v < n)
     (h : developDetVtxFuel M s n v = o) :
     developDetVtx? M s v = o :=
-  (developDetVtxFuel_eq_developDetVtx? M rank hrank s hn).symm.trans h
+  (developDetVtxFuel_eq_developDetVtx? M r s hn).symm.trans h
 
 end FuelBridge
 

--- a/Linglib/Studies/BellerGerstenberg2025.lean
+++ b/Linglib/Studies/BellerGerstenberg2025.lean
@@ -751,11 +751,12 @@ def bgDepth : BGVar → ℕ
   | .intermediate => 1
   | .effect => 2
 
-instance soloGraph_isDAG : CausalGraph.IsDAG soloGraph :=
-  CausalGraph.IsDAG.of_depth soloGraph bgDepth (by
-    intro u v h
-    cases v <;> simp [soloGraph, CausalGraph.parents] at h <;>
-      subst h <;> decide)
+/-- The ranking certificate for the solo graph, consumed by the `IsDAG`
+    instance and the fuel bridges. -/
+def soloRanking : CausalGraph.Ranking soloGraph :=
+  ⟨bgDepth, fun {u v} h => by revert h; cases u <;> cases v <;> decide⟩
+
+instance soloGraph_isDAG : CausalGraph.IsDAG soloGraph := soloRanking.isDAG
 
 instance overdetGraph_isDAG : CausalGraph.IsDAG overdetGraph :=
   CausalGraph.IsDAG.of_depth overdetGraph bgDepth (by
@@ -856,22 +857,17 @@ open Causation.ProductionDependence (causationType)
 open Causation Causation.SEM
 open Causation.BoolSEM (causallySufficient causallyNecessary hasDirectLaw)
 
-private lemma bgDepth_lt_solo :
-    ∀ {u v : BGVar}, u ∈ soloGraph.parents v → bgDepth u < bgDepth v := by
-  intro u v h; revert h; cases u <;> cases v <;> decide
-
 private lemma solo_entails_iff {s : Valuation (fun _ : BGVar => Bool)}
     {v : BGVar} {x : Bool} :
     SEM.causallyEntails soloModel s v x ↔
       SEM.developDetVtxFuel soloModel s 3 v = some x :=
-  SEM.causallyEntails_iff_fuel soloModel bgDepth bgDepth_lt_solo
-    (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel soloModel soloRanking (by cases v <;> decide) s x
 
 private lemma solo_necessary_iff {bg : Valuation (fun _ : BGVar => Bool)}
     {c e : BGVar} :
     causallyNecessary soloModel bg c e ↔
       SEM.causallyNecessaryFuel soloModel 3 bg c true e true :=
-  SEM.causallyNecessary_iff_fuel soloModel bgDepth bgDepth_lt_solo
+  SEM.causallyNecessary_iff_fuel soloModel soloRanking
     (by intro v; cases v <;> decide) bg c true e true
 
 set_option maxRecDepth 100000 in

--- a/Linglib/Studies/Nadathur2023.lean
+++ b/Linglib/Studies/Nadathur2023.lean
@@ -70,8 +70,9 @@ def depth : V → ℕ := fun
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Dreyfus SEM, with the negative `¬BRK` precondition encoded directly in
     the COM mechanism. -/
@@ -114,12 +115,12 @@ theorem dare_semantics_via_manageSem :
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails dreyfusSEM s v x ↔
       developDetVtxFuel dreyfusSEM s 4 v = some x :=
-  SEM.causallyEntails_iff_fuel dreyfusSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel dreyfusSEM ranking (by cases v <;> decide) s x
 
 private lemma necessary_iff {s : Valuation (fun _ : V => Bool)} {c e : V} :
     Implicative.necessityPresup dreyfusSEM s c true e true ↔
       SEM.causallyNecessaryFuel dreyfusSEM 4 s c true e true :=
-  SEM.causallyNecessary_iff_fuel dreyfusSEM depth depth_lt
+  SEM.causallyNecessary_iff_fuel dreyfusSEM ranking
     (by intro v; cases v <;> decide) s c true e true
 
 /-- Sufficiency presupposition (32iii) for (34a): NRV is causally

--- a/Linglib/Studies/NadathurLauer2020.lean
+++ b/Linglib/Studies/NadathurLauer2020.lean
@@ -92,8 +92,9 @@ def depth : V → ℕ := fun | .P => 0 | .D => 0 | .L => 0 | .G => 1 | .F => 2
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Fire dynamics: G := D (inflammability tracks drought); F := G ∧ P ∧ L
     (fire ignites only when grass inflammable, power on, line touching). -/
@@ -128,7 +129,7 @@ noncomputable def s_b1 : Valuation (fun _ : V => Bool) := s_b.extend .L true
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails fireSEM s v x ↔
       SEM.developDetVtxFuel fireSEM s 3 v = some x :=
-  SEM.causallyEntails_iff_fuel fireSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel fireSEM ranking (by cases v <;> decide) s x
 
 /-- (31a) `#Restoring power made the field catch fire.` Make-side: P=true
     is NOT sufficient for F=true relative to s_b. With L undetermined,
@@ -171,8 +172,9 @@ def depth : V → ℕ := fun | .Vis => 0 | .Tr => 0 | .Rn => 0 | .Bk => 1 | .Bs 
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Bus dynamics: Bk := Vis ∧ Tr (bike taken when Ava visits AND trains);
     Bs := Rn ∨ Bk (bus taken when rain OR bike gone). The OR for Bs
@@ -208,12 +210,12 @@ noncomputable def s_b : Valuation (fun _ : V => Bool) :=
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails busSEM s v x ↔
       SEM.developDetVtxFuel busSEM s 3 v = some x :=
-  SEM.causallyEntails_iff_fuel busSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel busSEM ranking (by cases v <;> decide) s x
 
 private lemma necessary_iff {s : Valuation (fun _ : V => Bool)} {c e : V} :
     BoolSEM.causallyNecessary busSEM s c e ↔
       SEM.causallyNecessaryFuel busSEM 3 s c true e true :=
-  SEM.causallyNecessary_iff_fuel busSEM depth depth_lt
+  SEM.causallyNecessary_iff_fuel busSEM ranking
     (by intro v; cases v <;> decide) s c true e true
 
 /-- (33a) `Ava's training made Lia take the bus to work.` Make-side:
@@ -262,8 +264,9 @@ def depth : V → ℕ := fun | .Q => 0 | .S => 0 | .L => 1
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Lighthouse dynamics: L := Q ∧ S (collapse requires both
     earthquake-induced foundation damage AND extreme storms). -/
@@ -301,7 +304,7 @@ def validBackgroundFor (idx : V → Nat) (t : Nat)
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails lighthouseSEM s v x ↔
       developDetVtxFuel lighthouseSEM s 2 v = some x :=
-  SEM.causallyEntails_iff_fuel lighthouseSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel lighthouseSEM ranking (by cases v <;> decide) s x
 
 /-- (35d) `The storms made the tower collapse.` Felicitous: with
     background fixing Q=true (the earlier necessary cause), S=true
@@ -409,8 +412,9 @@ def depth : V → ℕ := fun | .WD => 0 | .G => 0 | .D => 1
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Permission dynamics (Fig 5): D := W_D ∧ G. Both desire AND
     permission needed for dancing. -/
@@ -444,7 +448,7 @@ def intentions : IntentionMap V := fun
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails permissionSEM s v x ↔
       developDetVtxFuel permissionSEM s 2 v = some x :=
-  SEM.causallyEntails_iff_fuel permissionSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel permissionSEM ranking (by cases v <;> decide) s x
 
 /-- Bare sufficiency holds: G:=true is sufficient for D=true given W_D=true. -/
 theorem permission_makeSem :
@@ -507,8 +511,9 @@ def depth : V → ℕ := fun | .WD => 0 | .G => 0 | .D => 1
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Command dynamics (Fig 6): D := W_D ∨ G. Either authority alone OR
     independent desire suffices for dancing. -/
@@ -536,7 +541,7 @@ def intentions : IntentionMap V := fun
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails commandSEM s v x ↔
       developDetVtxFuel commandSEM s 2 v = some x :=
-  SEM.causallyEntails_iff_fuel commandSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel commandSEM ranking (by cases v <;> decide) s x
 
 /-- (41) context: the children are independently eager (W_D = 1). -/
 noncomputable def bgEager : Valuation (fun _ : V => Bool) :=
@@ -604,8 +609,9 @@ def depth : V → ℕ := fun | .G => 0 | .WD => 1 | .D => 2
 private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
   intro u v h; revert h; cases u <;> cases v <;> decide
 
-instance : CausalGraph.IsDAG graph :=
-  CausalGraph.IsDAG.of_depth graph depth (fun h => depth_lt h)
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
 
 /-- Persuasion dynamics (Fig 7): W_D := G (Gurung's action shapes
     desires); D := W_D (children dance iff they want to). -/
@@ -631,7 +637,7 @@ def intentions : IntentionMap V := fun
 private lemma entails_iff {s : Valuation (fun _ : V => Bool)} {v : V} {x : Bool} :
     SEM.causallyEntails persuasionSEM s v x ↔
       developDetVtxFuel persuasionSEM s 3 v = some x :=
-  SEM.causallyEntails_iff_fuel persuasionSEM depth depth_lt (by cases v <;> decide) s x
+  SEM.causallyEntails_iff_fuel persuasionSEM ranking (by cases v <;> decide) s x
 
 /-- Bare sufficiency: G:=true forces W_D=true forces D=true. -/
 theorem persuasion_makeSem :


### PR DESCRIPTION
Second PR from the Causation-API review: the four fuel-bridge lemmas (`developDetVtxFuel_eq_developDetVtx?`, `developDetVtx?_eq_of_fuel`, `causallyEntails_iff_fuel`, `causallyNecessary_iff_fuel`) take a `CausalGraph.Ranking` instead of loose `(rank, hrank)` arguments. Per-model study certificates consolidate: each model now defines one `ranking` consumed by both `Ranking.isDAG` (replacing the `of_depth` instance) and the bridges — 7 models across NadathurLauer2020/Nadathur2023/BellerGerstenberg2025, 11 call sites; BellerGerstenberg's duplicated inline solo-graph certificate is deleted. `IsDAG.of_depth` remains as the loose-form convenience for models without fuel bridges.