### PR TITLE
refactor(Semantics/Causation/Graph): dissolve Ranking and IsDAG into mathlib

### DIFF
--- a/Linglib/Semantics/Causation/Graph/Basic.lean
+++ b/Linglib/Semantics/Causation/Graph/Basic.lean
@@ -52,46 +52,26 @@ instance IsStrictAncestor.decidable [Fintype V] [DecidableEq V] (G : CausalGraph
   Relation.ReflTransGen.decidable_TransGen_of_fintype_step G.children
     (fun a b => by simp [G.mem_children_iff]) u v
 
-/-- **Acyclicity mixin**: the strict-ancestor relation is well-founded —
-    no infinite chain of parents. Required by `topologicalOrder`,
-    `develop` fixpoint, and well-founded recursion over the parent
-    relation.
+/-- **Acyclicity**: the strict-ancestor relation is well-founded — no
+    infinite chain of parents. An `abbrev` for mathlib's `IsWellFounded`
+    class, so its API (`IsWellFounded.wf`, induction, `fix`) applies
+    directly; required by the `develop` fixpoint and well-founded
+    recursion over the parent relation. -/
+abbrev IsDAG (G : CausalGraph V) : Prop :=
+  IsWellFounded V G.IsStrictAncestor
 
-    Mathlib analogue: `IsMarkovKernel` from
-    `Mathlib.Probability.Kernel.Defs` — a `Prop` class on a value of a
-    structure, marking a property consumers may require.
+/-- A ranking of a causal graph is a relation homomorphism from the
+    parent relation into `<` on `ℕ` — mathlib's `RelHom`, so the bundled
+    form of the depth certificate consumed by `IsDAG.of_depth` and, per
+    model, by the fuel bridges. -/
+abbrev Ranking (G : CausalGraph V) : Type _ :=
+  (· ∈ G.parents ·) →r ((· < ·) : ℕ → ℕ → Prop)
 
-    A `Std.Irrefl` instance for `IsStrictAncestor` follows from
-    well-foundedness; deferred until a consumer needs it. -/
-class IsDAG (G : CausalGraph V) : Prop where
-  /-- The strict-ancestor relation has no infinite descending chain. -/
-  wf : WellFounded G.IsStrictAncestor
-
-/-- A ranking of a causal graph is a `ℕ`-valued measure on which every
-    parent ranks strictly below its children — the bundled form of the
-    depth certificate consumed by `IsDAG.of_depth` and, per model, by the
-    fuel bridges (`causallyEntails_iff_fuel`, `causallyNecessary_iff_fuel`). -/
-structure Ranking (G : CausalGraph V) where
-  /-- The rank of each vertex. -/
-  rank : V → ℕ
-  /-- Parents rank strictly below their children. -/
-  parent_lt : ∀ {u v : V}, u ∈ G.parents v → rank u < rank v
-
-/-- A ranking certifies acyclicity: ranks strictly increase along the
-    strict-ancestor relation, so the relation embeds in `Nat.lt`.
-
-    The standard mathlib pattern for proving wellfoundedness of finite
-    inductive relations: define a measure into `ℕ`, show the relation
-    decreases it, conclude. -/
-theorem Ranking.isDAG {G : CausalGraph V} (r : Ranking G) : IsDAG G where
-  wf := by
-    have hsub : ∀ u v, G.IsStrictAncestor u v → r.rank u < r.rank v := by
-      intro u v huv
-      induction huv with
-      | single hp => exact r.parent_lt hp
-      | tail _ hp ih => exact lt_trans ih (r.parent_lt hp)
-    exact Subrelation.wf (fun {a b} => hsub a b)
-      (InvImage.wf r.rank Nat.lt_wfRel.wf)
+/-- A ranking certifies acyclicity: well-foundedness transfers along the
+    homomorphism (`RelHomClass.wellFounded`) and lifts to the transitive
+    closure (`WellFounded.transGen`). -/
+theorem Ranking.isDAG {G : CausalGraph V} (r : Ranking G) : IsDAG G :=
+  ⟨(RelHomClass.wellFounded r wellFounded_lt).transGen⟩
 
 /-- A graph is acyclic if every edge strictly decreases some `ℕ`-valued
     depth function — `Ranking.isDAG` with the certificate passed loose. -/

--- a/Linglib/Semantics/Causation/Graph/Defs.lean
+++ b/Linglib/Semantics/Causation/Graph/Defs.lean
@@ -24,6 +24,12 @@ structure CausalGraph (V : Type*) where
   /-- The set of parents of each vertex. -/
   parents : V → Finset V
 
+/- `CausalGraph` deliberately carries `Finset`-valued parents rather than
+mathlib's Prop-adjacency `Digraph`: mechanisms, `ready`, `developDet`,
+and the study `decide` proofs all enumerate parents computationally. The
+Prop-adjacency view, if a consumer ever needs mathlib's `Digraph` API,
+is `⟨(· ∈ ·.parents ·)⟩`. -/
+
 namespace CausalGraph
 
 variable {V : Type*}

--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -420,7 +420,7 @@ noncomputable instance [DecidableEq V] (M : SEM V α) [CausalGraph.IsDAG M.graph
 theorem causallyEntails_iff_fuel [DecidableEq V] (M : SEM V α)
     [CausalGraph.IsDAG M.graph] [IsDeterministic M]
     (r : CausalGraph.Ranking M.graph)
-    {n : ℕ} {v : V} (hn : r.rank v < n) (s : Valuation α) (x : α v) :
+    {n : ℕ} {v : V} (hn : r v < n) (s : Valuation α) (x : α v) :
     causallyEntails M s v x ↔ developDetVtxFuel M s n v = some x := by
   rw [causallyEntails, ← developDetVtxFuel_eq_developDetVtx? M r s hn]
 
@@ -475,7 +475,7 @@ theorem causallyEntails_mono [DecidableEq V] [DecidableValuation α]
     {s s' : Valuation α} (hcons : isConsistentSuper M s s')
     {v : V} {x : α v} (h : causallyEntails M s v x) :
     causallyEntails M s' v x := by
-  induction v using (CausalGraph.IsDAG.wf (G := M.graph)).induction with
+  induction v using (IsWellFounded.wf (r := M.graph.IsStrictAncestor)).induction with
   | _ v ih =>
     cases hs'v : s'.get v with
     | some z =>
@@ -690,7 +690,7 @@ instance [Fintype V] [DecidableEq V] [DecidableValuation α] [∀ v, Fintype (α
 theorem causallyNecessary_iff_fuel [Fintype V] [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterministic M]
     (r : CausalGraph.Ranking M.graph)
-    {n : ℕ} (hn : ∀ v : V, r.rank v < n)
+    {n : ℕ} (hn : ∀ v : V, r v < n)
     (s : Valuation α) (cause : V) (xC : α cause) (effect : V) (xE : α effect) :
     causallyNecessary M s cause xC effect xE ↔
       causallyNecessaryFuel M n s cause xC effect xE := by

--- a/Linglib/Semantics/Causation/SEM/Deterministic.lean
+++ b/Linglib/Semantics/Causation/SEM/Deterministic.lean
@@ -242,7 +242,7 @@ theorem developDetVtx?_inner_none {s : Valuation α} {v : V}
 theorem developDetVtx_eq_of_developDetVtx?_eq_some
     {s : Valuation α} {v : V} {x : α v}
     (h : developDetVtx? M s v = some x) : developDetVtx M s v = x := by
-  induction v using (CausalGraph.IsDAG.wf (G := M.graph)).induction with
+  induction v using (IsWellFounded.wf (r := M.graph.IsStrictAncestor)).induction with
   | _ v ih =>
     rw [developDetVtx?_unfold] at h
     rw [developDetVtx_unfold]
@@ -295,7 +295,7 @@ variable (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
     the strict fixed point. Soundness and completeness in one equation. -/
 theorem developDetVtxFuel_eq_developDetVtx?
     (r : CausalGraph.Ranking M.graph) (s : Valuation α) :
-    ∀ {n : ℕ} {v : V}, r.rank v < n →
+    ∀ {n : ℕ} {v : V}, r v < n →
       developDetVtxFuel M s n v = developDetVtx? M s v := by
   intro n
   induction n with
@@ -319,7 +319,7 @@ theorem developDetVtxFuel_eq_developDetVtx?
       · simp [hPar]
       · have hpt : ∀ u : M.graph.parents v,
             developDetVtxFuel M s n u.val = developDetVtx? M s u.val :=
-          fun u => ih (by have := r.parent_lt u.property; omega)
+          fun u => ih (by have := r.map_rel u.property; omega)
         simp only [hPar, if_false]
         by_cases hAll : ∀ u : M.graph.parents v, (developDetVtx? M s u.val).isSome
         · have hAll' : ∀ u : M.graph.parents v,
@@ -338,7 +338,7 @@ theorem developDetVtxFuel_eq_developDetVtx?
     `developDetVtx?_eq_of_fuel M ⟨rank, by intro u v h; revert h; decide⟩ (by omega) (by decide)`. -/
 theorem developDetVtx?_eq_of_fuel
     (r : CausalGraph.Ranking M.graph)
-    {s : Valuation α} {n : ℕ} {v : V} {o : Option (α v)} (hn : r.rank v < n)
+    {s : Valuation α} {n : ℕ} {v : V} {o : Option (α v)} (hn : r v < n)
     (h : developDetVtxFuel M s n v = o) :
     developDetVtx? M s v = o :=
   (developDetVtxFuel_eq_developDetVtx? M r s hn).symm.trans h


### PR DESCRIPTION
Boutique-minimization pass on the graph layer:

- `Ranking G` is now an `abbrev` for mathlib's `RelHom`: `(· ∈ G.parents ·) →r (· < ·)` — the structure was a reinvention. `Ranking.isDAG` collapses from a 9-line induction to `⟨(RelHomClass.wellFounded r wellFounded_lt).transGen⟩`; accessors become the FunLike coercion and `map_rel`. All anonymous-constructor call sites (studies' `⟨depth, depth_lt⟩`) and `by decide` fuel arguments survive unchanged.
- `IsDAG G` is now an `abbrev` for mathlib's `IsWellFounded V G.IsStrictAncestor` — the boutique class had the same field, so instance declarations and `hDag.wf` consumers are untouched; mathlib's `IsWellFounded` API (induction, `fix`) applies directly.
- `CausalGraph` vs mathlib `Digraph` assessed and documented in `Graph/Defs.lean`: `Digraph` is Prop-adjacency with a ~20-declaration API (no acyclicity/reachability), while the `Finset`-valued `parents` is load-bearing for mechanisms, `developDet`, and every study `decide` proof; the one-line Prop-adjacency view is recorded for future consumers.