### PR TITLE
refactor(Fragments/Ga): audit cleanse and Allotey 2021 data fixes

### DIFF
--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -13,13 +13,14 @@ clause typology.
 
 ## Coverage
 
-- Subject proclitics (person × number)
-- TAM prefixes (future, progressive, perfect) and the irrealis,
-  realized as high tone on the embedded-clause subject pronoun
+- Subject proclitics (person × number; the paper's Table 3)
+- TAM prefixes (future, progressive, perfective) and the irrealis
+  marker `á`, realized in embedded control clauses as high tone on
+  the subject pronoun
 - Complementizer inventory (`akɛ`, `kɛji`, `ni`) with finite vs.
   irrealis distinction; `ni` is optionally overt with some
-  control verbs (e.g. *tao* 'want', [allotey-2021] ex 2a) and
-  obligatory with others (*hiɛ-ka-nɔ* 'hope', ex 16)
+  control verbs (*tao* 'want', [allotey-2021] ex 34) and
+  obligatory with others (*hiɛ-kã-nɔ* 'hope', ex 35)
 - Embedded clause typology (three-way: `finiteAke`, `finiteKeji`,
   `irrealisNi`)
 - Pro-drop profile
@@ -33,25 +34,30 @@ preserved in the corresponding `String` value.
 
 ## What is NOT covered (deliberately)
 
-Verbal negation morphology and the V-to-T raising claim. Both rely on
-independent morphological argumentation ([pollock-1989]'s
-diagnostic requires a free Neg head; Gã `-ee` and `-ko` appear
-suffixal) that is orthogonal to the OC story.
+The verb-movement/negation-placement diagnostic ([allotey-2021]'s fifth
+non-finiteness argument, after [pollock-1989]: finite verbs raise past
+the suffixal negation `-ee`, `-ko`, while irrealis embedded clauses show
+a free preverbal negator `ka`, her exx 120–125). Formalizing the raising
+argument needs phrase-structure substrate beyond this fragment's
+clause-typology schema; the finiteness split it diagnoses is already
+carried by `ClauseProperties.unrestrictedTAM`.
 -/
 
 namespace Ga
 
 /-! ### Pronoun paradigm -/
 
-/-- Subject proclitic forms (plain series), on the canonical person/number
-    inventory; `none` for cells outside Gã's 3 × 2 paradigm.
+/-- Subject proclitic forms (plain subjective series, [allotey-2021]
+    Table 3), on the canonical person/number inventory; `none` for cells
+    outside Gã's 3 × 2 paradigm. Not covered: the clipped past-tense 1SG
+    variant *ĩ* and the impersonal subject pronoun *a*.
 
     Gã subject pronouns are proclitics on the inflected verb. In
     [allotey-2021]'s OC examples, the embedded subject of a controlled
     `ni`-clause is realized as an overt subject proclitic (ex 3a: `e-` for
     a 3SG controllee) — the embedded subject position cannot be silent.
-    Under irrealis high tone the 1SG proclitic surfaces as *ma* (ex 2a)
-    rather than plain *mi*. -/
+    Merged with the irrealis marker `á` the 1SG proclitic surfaces as the
+    portmanteau *má* (ex 34) rather than plain *mi*. -/
 def subjectProclitic : Person → Number → Option String
   | .first,  .singular => some "mi"
   | .second, .singular => some "o"
@@ -63,30 +69,35 @@ def subjectProclitic : Person → Number → Option String
 
 /-! ### TAM marking -/
 
-/-- Prefixal TAM categories of the Gã verb.
+/-- Prefixal TAM categories of the Gã verb (bare root = default past).
 
-    [allotey-2021] uses the future, progressive, and perfect prefixes to
-    argue that embedded clauses introduced by `akɛ` and `kɛji` allow the
-    full TAM paradigm (finite), while clauses introduced by `ni` prohibit
-    tense/aspect marking of any kind and are restricted to irrealis. -/
+    [allotey-2021] uses the future, progressive, and perfective prefixes
+    to argue that embedded clauses introduced by `akɛ` and `kɛji` allow
+    the full TAM paradigm (finite), while clauses introduced by `ni`
+    prohibit tense/aspect marking of any kind and are restricted to
+    irrealis (her exx 119, tense-restriction diagnostic). -/
 inductive TAM where
-  /-- Future prefix `baa-` -/
+  /-- Future prefix `baa-` (historically the ingressive deictic `bà`
+      plus the irrealis marker `á`) -/
   | future
   /-- Progressive prefix `mii-` -/
   | progressive
-  /-- Perfect prefix `é-` (high tone) -/
-  | perfect
-  /-- Irrealis: no verbal prefix; realized as high tone on the
-      embedded-clause subject pronoun ([allotey-2021]) -/
+  /-- Perfective prefix `é-` (high tone) -/
+  | perfective
+  /-- Irrealis marker `á`: no independent verbal prefix in embedded
+      control clauses; realized as high tone on the subject pronoun
+      (portmanteau *má* for 1SG). True subjunctives double it — high
+      tone on pronoun AND verb ([allotey-2021] Table 4). -/
   | irrealis
   deriving DecidableEq, Repr
 
 /-- Segmental exponent of a TAM category; `none` for the irrealis, whose
-    marking is tonal (on the subject pronoun) rather than prefixal. -/
+    marking in embedded control clauses is tonal (on the subject
+    pronoun) rather than prefixal. -/
 def TAM.exponent : TAM → Option String
   | .future      => some "baa-"
   | .progressive => some "mii-"
-  | .perfect     => some "é-"
+  | .perfective  => some "é-"
   | .irrealis    => none
 
 /-- Whether this TAM is part of the unrestricted (finite) paradigm.
@@ -108,10 +119,11 @@ inductive Complementizer where
   /-- `kɛji` — finite complementizer for conditional and
       conditional-like complements -/
   | keji
-  /-- `ni` — irrealis complementizer; introduces controlled clauses.
-      Optionally overt with some control verbs (*tao* 'want',
-      [allotey-2021] ex 2a) and obligatory with others
-      (*hiɛ-ka-nɔ* 'hope', ex 16). -/
+  /-- `ni` — irrealis complementizer; introduces controlled clauses
+      (a weak CP: no focus fronting, no independent tense,
+      [allotey-2021] exx 107–109). Optionally overt with some control
+      verbs (*tao* 'want', ex 34) and obligatory with others
+      (*hiɛ-kã-nɔ* 'hope', ex 35). -/
   | ni
   deriving DecidableEq, Repr
 

--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -1,34 +1,35 @@
 import Linglib.Features.Number.Basic
-import Linglib.Features.Gender.Basic
-import Linglib.Features.Person.Decomposition
+import Linglib.Features.Person.Basic
 
 /-!
 # Gã Fragment
 [allotey-2021]
 
 Language data for Gã (ISO: gaa), a Kwa (Niger-Congo) language spoken in
-Greater Accra, Ghana. The data here covers what is needed to formalize
-the obligatory control facts in [allotey-2021]: pronoun paradigm,
-TAM marking, complementizer inventory, and embedded clause typology.
+Greater Accra, Ghana, covering what [allotey-2021] ("Overt Pronouns of
+Infinitival Predicates of Gã") needs for the obligatory-control facts:
+pronoun paradigm, TAM marking, complementizer inventory, and embedded
+clause typology.
 
 ## Coverage
 
-- Pronoun paradigm (subject proclitics, person × number)
-- TAM prefixes (future, progressive, perfect) and irrealis tone
+- Subject proclitics (person × number)
+- TAM prefixes (future, progressive, perfect) and the irrealis,
+  realized as high tone on the embedded-clause subject pronoun
 - Complementizer inventory (`akɛ`, `kɛji`, `ni`) with finite vs.
-  irrealis distinction; `ni` is recorded as optionally-overt because
-  [allotey-2021] ex 34 shows it dropping in some controlled
-  clauses while ex 35–38 show it obligatorily present
+  irrealis distinction; `ni` is optionally overt with some
+  control verbs (e.g. *tao* 'want', [allotey-2021] ex 2a) and
+  obligatory with others (*hiɛ-ka-nɔ* 'hope', ex 16)
 - Embedded clause typology (three-way: `finiteAke`, `finiteKeji`,
   `irrealisNi`)
-- Pro-drop / overt-subject profile
+- Pro-drop profile
 
 ## Identifier policy
 
 Lean 4 does not accept the IPA characters `ɛ` (U+025B) or `ŋ` (U+014B)
-as identifier characters. Constructor and definition names use the
-plain Latin orthography (`ake`, `keji`, `nye`, `kpleno`, `kpang`),
-while the IPA form is preserved in the corresponding `String` value.
+as identifier characters. Constructor and definition names use plain
+Latin orthography (`ake`, `keji`, `nye`), while the IPA form is
+preserved in the corresponding `String` value.
 
 ## What is NOT covered (deliberately)
 
@@ -40,57 +41,34 @@ suffixal) that is orthogonal to the OC story.
 
 namespace Ga
 
--- ════════════════════════════════════════════════════════════════
--- § 1: Person and Number
--- ════════════════════════════════════════════════════════════════
+/-! ### Pronoun paradigm -/
 
-inductive Person where | first | second | third
-  deriving DecidableEq, Repr
-
-/-- Ga's three-way person in the canonical inventory. -/
-def Person.toPerson : Person → _root_.Person
-  | .first => .first
-  | .second => .second
-  | .third => .third
-
-inductive Number where | sg | pl
-  deriving DecidableEq, Repr
-
-/-- Ga's two-value system in the canonical inventory. -/
-def Number.toNumber : Number → _root_.Number
-  | .sg => .singular
-  | .pl => .plural
-
--- ════════════════════════════════════════════════════════════════
--- § 2: Pronoun Paradigm
--- ════════════════════════════════════════════════════════════════
-
-/-- Subject proclitic forms.
+/-- Subject proclitic forms (plain series), on the canonical person/number
+    inventory; `none` for cells outside Gã's 3 × 2 paradigm.
 
     Gã subject pronouns are proclitics on the inflected verb. In
-    [allotey-2021]'s OC examples, the embedded subject of a
-    controlled `ni`-clause is realized as an overt subject proclitic
-    (e.g., `e-` for 3SG controllees) — the embedded subject position
-    cannot be silent. -/
-def subjectProclitic : Person → Number → String
-  | .first,  .sg => "mi"
-  | .second, .sg => "o"
-  | .third,  .sg => "e"
-  | .first,  .pl => "wɔ"
-  | .second, .pl => "nyɛ"
-  | .third,  .pl => "amɛ"
+    [allotey-2021]'s OC examples, the embedded subject of a controlled
+    `ni`-clause is realized as an overt subject proclitic (ex 3a: `e-` for
+    a 3SG controllee) — the embedded subject position cannot be silent.
+    Under irrealis high tone the 1SG proclitic surfaces as *ma* (ex 2a)
+    rather than plain *mi*. -/
+def subjectProclitic : Person → Number → Option String
+  | .first,  .singular => some "mi"
+  | .second, .singular => some "o"
+  | .third,  .singular => some "e"
+  | .first,  .plural   => some "wɔ"
+  | .second, .plural   => some "nyɛ"
+  | .third,  .plural   => some "amɛ"
+  | _,       _         => none
 
--- ════════════════════════════════════════════════════════════════
--- § 3: TAM Marking
--- ════════════════════════════════════════════════════════════════
+/-! ### TAM marking -/
 
 /-- Prefixal TAM categories of the Gã verb.
 
-    [allotey-2021] uses the future, progressive, and perfect
-    prefixes to argue that embedded clauses introduced by `akɛ` and
-    `kɛji` allow the full TAM paradigm (finite), while clauses
-    introduced by `ni` are restricted to irrealis (no future,
-    progressive, or perfect prefix). -/
+    [allotey-2021] uses the future, progressive, and perfect prefixes to
+    argue that embedded clauses introduced by `akɛ` and `kɛji` allow the
+    full TAM paradigm (finite), while clauses introduced by `ni` prohibit
+    tense/aspect marking of any kind and are restricted to irrealis. -/
 inductive TAM where
   /-- Future prefix `baa-` -/
   | future
@@ -98,15 +76,18 @@ inductive TAM where
   | progressive
   /-- Perfect prefix `é-` (high tone) -/
   | perfect
-  /-- Irrealis: no overt prefix; marked by stem high tone (`á`) -/
+  /-- Irrealis: no verbal prefix; realized as high tone on the
+      embedded-clause subject pronoun ([allotey-2021]) -/
   | irrealis
   deriving DecidableEq, Repr
 
-def TAM.exponent : TAM → String
-  | .future      => "baa-"
-  | .progressive => "mii-"
-  | .perfect     => "é-"
-  | .irrealis    => "á"
+/-- Segmental exponent of a TAM category; `none` for the irrealis, whose
+    marking is tonal (on the subject pronoun) rather than prefixal. -/
+def TAM.exponent : TAM → Option String
+  | .future      => some "baa-"
+  | .progressive => some "mii-"
+  | .perfect     => some "é-"
+  | .irrealis    => none
 
 /-- Whether this TAM is part of the unrestricted (finite) paradigm.
 
@@ -117,9 +98,7 @@ def TAM.isFinite : TAM → Bool
   | .irrealis => false
   | _         => true
 
--- ════════════════════════════════════════════════════════════════
--- § 4: Complementizers
--- ════════════════════════════════════════════════════════════════
+/-! ### Complementizers -/
 
 /-- The three complementizers [allotey-2021] discusses. -/
 inductive Complementizer where
@@ -130,8 +109,9 @@ inductive Complementizer where
       conditional-like complements -/
   | keji
   /-- `ni` — irrealis complementizer; introduces controlled clauses.
-      Allotey ex 34 shows `ni` is optional in some controlled clauses
-      while ex 35–38 show it obligatorily present. -/
+      Optionally overt with some control verbs (*tao* 'want',
+      [allotey-2021] ex 2a) and obligatory with others
+      (*hiɛ-ka-nɔ* 'hope', ex 16). -/
   | ni
   deriving DecidableEq, Repr
 
@@ -145,9 +125,7 @@ def Complementizer.isFinite : Complementizer → Bool
   | .ni   => false
   | _     => true
 
--- ════════════════════════════════════════════════════════════════
--- § 5: Embedded Clause Typology
--- ════════════════════════════════════════════════════════════════
+/-! ### Embedded clause typology -/
 
 /-- Three embedded clause types in Gã, distinguished by complementizer
     and TAM properties ([allotey-2021]).
@@ -161,9 +139,9 @@ inductive EmbeddedClauseType where
   /-- Finite `kɛji`-clause: full TAM, free subject reference, no OC -/
   | finiteKeji
   /-- Irrealis `ni`-clause: irrealis only, obligatory coreference, OC.
-      The complementizer `ni` itself may be optional (Allotey ex 34) or
-      obligatory (ex 35–38) depending on the matrix verb; the irrealis
-      tone marking and OC behavior are constant. -/
+      The complementizer `ni` itself may be optional or obligatory
+      depending on the matrix verb; the irrealis tone marking and OC
+      behavior are constant. -/
   | irrealisNi
   deriving DecidableEq, Repr
 
@@ -193,20 +171,10 @@ theorem complementizer_isFinite_eq_finiteFlag (c : EmbeddedClauseType) :
     (clauseComplementizer c).isFinite = (clauseProperties c).finiteComplementizer := by
   cases c <;> rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 6: Typological Profile
--- ════════════════════════════════════════════════════════════════
+/-! ### Typological profile -/
 
 /-- Gã does NOT allow null pronominal subjects in matrix clauses:
     every clause requires an overt subject proclitic ([allotey-2021]). -/
 def allowsProDrop : Bool := false
-
-/-- Gã has SVO basic order. -/
-def basicWordOrder : String := "SVO"
-
-/-- Controlled subjects in `irrealisNi` clauses must be OVERT proclitics
-    ([allotey-2021]'s central empirical observation). Null PRO is
-    ungrammatical in this position. -/
-def controlledSubjectMustBeOvert : Bool := true
 
 end Ga

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -6,16 +6,10 @@ import Linglib.Fragments.Ga.Basic
 
 Inventory of Gã verbs that take embedded clausal complements, classified
 by the clause type they select and (for `ni`-clause selectors) whether
-they induce subject or object control.
-
-Entries attested in the accessible portion of [allotey-2021] are cited
-by example number (*tao* 'want' ex 2a, *hiɛ-ka-nɔ* 'hope' ex 16); the
-remaining entries are UNVERIFIED against the paper's own verb list
-(its complement-selection sections are not in the available galley) and
-are flagged in their docstrings. `kee` 'say' is the standard `akɛ`-clause
-exemplar the paper uses in passing rather than a member of its CTP
-inventory; it is kept because without at least one finite-complement
-verb the OC-vs-non-OC contrast cannot be exhibited end-to-end.
+they induce subject or object control. All entries are attested in
+[allotey-2021]'s example data, cited by example number. `kee` 'say' is
+the standard `akɛ`-clause exemplar the paper uses throughout (exx 47–49)
+rather than a member of its control-predicate inventory.
 
 ## Identifier policy
 
@@ -44,47 +38,75 @@ structure CTP where
 /-! ### Subject-control verbs (irrealis `ni`-clause) -/
 
 /-- 'want' — subject control; `ni` optionally overt
-    ([allotey-2021] ex 2a: *Mi tao (ni) ma na bo* 'I want to see you'). -/
+    ([allotey-2021] ex 34: *Mi-i tao (ni) ma na bo* 'I want to see you'). -/
 def tao : CTP := ⟨"tao", "want", .irrealisNi, some .subject⟩
 
 /-- 'hope' (lit. 'face-place-upon') — subject control; `ni` obligatory
-    ([allotey-2021] ex 16: *Mi hiɛ-ka-nɔ ni ma ya skul gbi ko*
+    ([allotey-2021] ex 35: *Mi hiɛ-kã-nɔ ni ma ya skul gbi ko*
     'I hope to go to school one day'). -/
-def hiekano : CTP := ⟨"hiɛ-ka-nɔ", "hope", .irrealisNi, some .subject⟩
+def hiekano : CTP := ⟨"hiɛ-kã-nɔ", "hope", .irrealisNi, some .subject⟩
 
-/-- 'manage / be able to' — subject control.
-    UNVERIFIED against [allotey-2021]'s verb list. -/
+/-- 'forget' (lit. 'face-stop-upon') — subject control; `ni` obligatory
+    ([allotey-2021] exx 37–38: *O hiɛ-kpa-nɔ ni o kɔ aspaatere lɛ*
+    'You forgot to pick up the shoe'). -/
+def hiekpano : CTP := ⟨"hiɛ-kpa-nɔ", "forget", .irrealisNi, some .subject⟩
+
+/-- 'try' (lit. 'squeeze-my-face') — subject control; `ni` obligatory
+    ([allotey-2021] ex 36: 'I tried to close the door'). -/
+def miamihie : CTP := ⟨"mia-mi-hiɛ", "try", .irrealisNi, some .subject⟩
+
+/-- 'remember' — subject control ([allotey-2021] ex 43: *Mi kai ni ma he
+    wolo* 'I remembered to buy a book'). With `akɛ` instead of `ni` the
+    complement is finite 'remember that' (ex 89a); implicative in the
+    control use, so the embedded irrealis marker is suppressed
+    (*mi*, not *má*; the paper's §5.2.3 asymmetry). -/
+def kai : CTP := ⟨"kai", "remember", .irrealisNi, some .subject⟩
+
+/-- 'manage / be able to' — subject control; `ni` optionally overt
+    ([allotey-2021] ex 39: 'The children managed to buy a home').
+    Implicative like `kai`: the embedded irrealis marker is suppressed
+    (ex 89b *mi/\*má*). -/
 def nye : CTP := ⟨"nyɛ", "manage", .irrealisNi, some .subject⟩
 
-/-- 'agree' — subject control. UNVERIFIED against [allotey-2021]'s verb list. -/
+/-- 'agree' — subject control ([allotey-2021] ex 52; ex 89c shows the
+    embedded irrealis marker obligatory: *\*mi/má*). With `akɛ` it takes
+    a finite subjunctive complement instead ('agree that…', ex 105). -/
 def kpleno : CTP := ⟨"kplɛnɔ", "agree", .irrealisNi, some .subject⟩
 
-/-- 'plan' — subject control. UNVERIFIED against [allotey-2021]'s verb list. -/
+/-- 'plan / decide' — subject control ([allotey-2021] exx 89d, 106; the
+    embedded irrealis marker is obligatory, and only `ni` — never `akɛ`
+    or `kɛji` — introduces the complement). -/
 def kpang : CTP := ⟨"kpaŋ", "plan", .irrealisNi, some .subject⟩
 
 /-! ### Object-control verbs (irrealis `ni`-clause) -/
 
-/-- 'urge' — object control. UNVERIFIED against [allotey-2021]'s verb list. -/
-def kenya : CTP := ⟨"kenya", "urge", .irrealisNi, some .object⟩
-
-/-- 'persuade' — object control. UNVERIFIED against [allotey-2021]'s verb list. -/
-def laka : CTP := ⟨"laka", "persuade", .irrealisNi, some .object⟩
-
-/-- 'force' — object control. UNVERIFIED against [allotey-2021]'s verb list. -/
-def dai : CTP := ⟨"dai", "force", .irrealisNi, some .object⟩
-
-/-- 'help' — object control. UNVERIFIED against [allotey-2021]'s verb list
-    (Gã 'help' is commonly *bua*; *wa* is 'be strong/hard'). -/
+/-- 'help' — object control ([allotey-2021] ex 54: *Mi wa Ama ni e-ya
+    skul* 'I helped Ama to go to school'). -/
 def wa : CTP := ⟨"wa", "help", .irrealisNi, some .object⟩
 
-/-! ### Finite-complement verb (`akɛ`-clause) -/
+/-- 'urge / encourage' — object control ([allotey-2021] ex 55). -/
+def kenya : CTP := ⟨"kenya", "urge", .irrealisNi, some .object⟩
 
-/-- 'say' — utterance verb, finite `akɛ`-clause.
+/-- 'force' — object control ([allotey-2021] ex 56). -/
+def dai : CTP := ⟨"dai", "force", .irrealisNi, some .object⟩
 
-    Not part of [allotey-2021]'s CTP inventory, but used in passing as
-    the canonical `akɛ`-clause selector (the cross-Kwa standard
-    utterance verb). Kept so the library can exhibit the OC-vs-non-OC
-    contrast end-to-end. -/
+/-- 'persuade / coax / deceive' (context-dependent, the paper's fn 4) —
+    object control ([allotey-2021] exx 57–58). -/
+def laka : CTP := ⟨"laka", "persuade", .irrealisNi, some .object⟩
+
+/-- 'ask' — object control ([allotey-2021] ex 59: 'I asked Ayele to
+    tell me a story'). -/
+def bi : CTP := ⟨"bi", "ask", .irrealisNi, some .object⟩
+
+/-! ### Finite-complement verbs (`akɛ`- and `kɛji`-clauses) -/
+
+/-- 'say' — utterance verb, finite `akɛ`-clause ([allotey-2021]
+    exx 47–49: *Jojo kɛɛ akɛ …* 'Jojo said that …'). -/
 def kee : CTP := ⟨"kɛɛ", "say", .finiteAke, none⟩
+
+/-- 'know' — selects a finite `kɛji`-clause for if/whether complements
+    ([allotey-2021] exx 104, 108: 'know if they will be coming',
+    'doesn't know whether you or he bought the book'). -/
+def le : CTP := ⟨"le", "know", .finiteKeji, none⟩
 
 end Ga

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -1,30 +1,21 @@
 import Linglib.Fragments.Ga.Basic
-import Linglib.Studies.Landau2015
 
 /-!
 # Gã Complement-Taking Predicates
 [allotey-2021]
 
 Inventory of Gã verbs that take embedded clausal complements, classified
-by the clause type they select and (where the semantic class is clear)
-their [landau-2015] predicate class.
+by the clause type they select and (for `ni`-clause selectors) whether
+they induce subject or object control.
 
-All entries here are attested in [allotey-2021]'s example data
-(the only verb-list source). The single exception is `kee` 'say', which
-the paper uses in passing as the standard `akɛ`-clause exemplar but
-does not pull out as part of its CTP inventory; it is kept because
-without at least one finite-complement verb the OC-vs-non-OC contrast
-cannot be exhibited end-to-end. The docstring on `kee` records this.
-
-## Coverage
-
-- Subject-control verbs selecting irrealis `ni`-clauses: `tao` 'want',
-  `nye` 'manage/be.able', `kpleno` 'agree', `kpang` 'plan',
-  `hiekpano` 'forget' (Allotey ex 37–38)
-- Object-control verbs selecting irrealis `ni`-clauses: `kenya` 'urge',
-  `dai` 'force', `laka` 'persuade', `wa` 'help'
-- Finite-clause verb selecting `akɛ`-clauses: `kee` 'say' (standard
-  exemplar; see note above)
+Entries attested in the accessible portion of [allotey-2021] are cited
+by example number (*tao* 'want' ex 2a, *hiɛ-ka-nɔ* 'hope' ex 16); the
+remaining entries are UNVERIFIED against the paper's own verb list
+(its complement-selection sections are not in the available galley) and
+are flagged in their docstrings. `kee` 'say' is the standard `akɛ`-clause
+exemplar the paper uses in passing rather than a member of its CTP
+inventory; it is kept because without at least one finite-complement
+verb the OC-vs-non-OC contrast cannot be exhibited end-to-end.
 
 ## Identifier policy
 
@@ -34,132 +25,66 @@ See `Fragments/Ga/Basic.lean` for rationale.
 
 namespace Ga
 
-open Landau2015 (LandauPredicateClass ControlTier)
-
-/-- Whether a Gã CTP induces subject control or object control over the
-    embedded `ni`-clause subject. `none` for finite-complement verbs
-    that are not control verbs. -/
+/-- Which matrix argument controls the embedded `ni`-clause subject. -/
 inductive Control where
-  | subjectControl
-  | objectControl
-  | noneControl
+  | subject
+  | object
   deriving DecidableEq, Repr
 
-/-- A Gã complement-taking predicate.
-
-    The Landau predicate class is recorded for verbs whose semantic
-    classification is clear; for verbs like `wa` 'help' (no clean fit
-    in any of Landau's eight classes), it is left as `none` —
-    paralleling the treatment of English `try` in
-    `Landau2015.try_unclassifiable`. -/
+/-- A Gã complement-taking predicate: form, gloss, selected embedded
+    clause type, and (for `ni`-clause selectors) its control type;
+    `none` for finite-complement verbs that are not control verbs. -/
 structure CTP where
-  form         : String
-  gloss        : String
-  selects      : EmbeddedClauseType
-  control      : Control
-  landauClass  : Option LandauPredicateClass
+  form    : String
+  gloss   : String
+  selects : EmbeddedClauseType
+  control : Option Control
   deriving Repr, DecidableEq
 
-/-- The control tier induced by a Gã CTP, derived from its Landau class.
-    Returns `none` for unclassifiable verbs and finite-complement verbs. -/
-def CTP.controlTier (c : CTP) : Option ControlTier :=
-  c.landauClass.map (·.controlTier)
+/-! ### Subject-control verbs (irrealis `ni`-clause) -/
 
--- ════════════════════════════════════════════════════════════════
--- § 1: Subject-Control Verbs (irrealis `ni`-clause)
--- ════════════════════════════════════════════════════════════════
+/-- 'want' — subject control; `ni` optionally overt
+    ([allotey-2021] ex 2a: *Mi tao (ni) ma na bo* 'I want to see you'). -/
+def tao : CTP := ⟨"tao", "want", .irrealisNi, some .subject⟩
 
-/-- 'want' — desiderative, subject control. Logophoric tier. -/
-def tao : CTP :=
-  ⟨"tao", "want", .irrealisNi, .subjectControl, some .desiderative⟩
+/-- 'hope' (lit. 'face-place-upon') — subject control; `ni` obligatory
+    ([allotey-2021] ex 16: *Mi hiɛ-ka-nɔ ni ma ya skul gbi ko*
+    'I hope to go to school one day'). -/
+def hiekano : CTP := ⟨"hiɛ-ka-nɔ", "hope", .irrealisNi, some .subject⟩
 
-/-- 'agree' — desiderative, subject control. Logophoric tier. -/
-def kpleno : CTP :=
-  ⟨"kplɛnɔ", "agree", .irrealisNi, .subjectControl, some .desiderative⟩
+/-- 'manage / be able to' — subject control.
+    UNVERIFIED against [allotey-2021]'s verb list. -/
+def nye : CTP := ⟨"nyɛ", "manage", .irrealisNi, some .subject⟩
 
-/-- 'plan' — desiderative, subject control. Logophoric tier. -/
-def kpang : CTP :=
-  ⟨"kpaŋ", "plan", .irrealisNi, .subjectControl, some .desiderative⟩
+/-- 'agree' — subject control. UNVERIFIED against [allotey-2021]'s verb list. -/
+def kpleno : CTP := ⟨"kplɛnɔ", "agree", .irrealisNi, some .subject⟩
 
-/-- 'forget' — implicative (negative), subject control. Predicative tier.
-    Allotey ex 37–38: *e-hiɛ-kpa-nɔ akɛ è-fee shi̇kpɔ̃ɔ̃ lε* 'he forgot
-    to do that work'. Like English `forget` ([karttunen-1971]):
-    failure entails the complement. -/
-def hiekpano : CTP :=
-  ⟨"hiɛ-kpa-nɔ", "forget", .irrealisNi, .subjectControl, some .implicative⟩
+/-- 'plan' — subject control. UNVERIFIED against [allotey-2021]'s verb list. -/
+def kpang : CTP := ⟨"kpaŋ", "plan", .irrealisNi, some .subject⟩
 
-/-- 'manage / be able to' — implicative (modal-flavored), subject control.
-    Predicative tier. Allotey treats it as a modal/implicative verb;
-    the semantics parallels English `manage`. -/
-def nye : CTP :=
-  ⟨"nyɛ", "manage", .irrealisNi, .subjectControl, some .implicative⟩
+/-! ### Object-control verbs (irrealis `ni`-clause) -/
 
--- ════════════════════════════════════════════════════════════════
--- § 2: Object-Control Verbs (irrealis `ni`-clause)
--- ════════════════════════════════════════════════════════════════
+/-- 'urge' — object control. UNVERIFIED against [allotey-2021]'s verb list. -/
+def kenya : CTP := ⟨"kenya", "urge", .irrealisNi, some .object⟩
 
-/-- 'urge' — desiderative, object control. Logophoric tier. -/
-def kenya : CTP :=
-  ⟨"kenya", "urge", .irrealisNi, .objectControl, some .desiderative⟩
+/-- 'persuade' — object control. UNVERIFIED against [allotey-2021]'s verb list. -/
+def laka : CTP := ⟨"laka", "persuade", .irrealisNi, some .object⟩
 
-/-- 'persuade' — desiderative, object control. Logophoric tier. -/
-def laka : CTP :=
-  ⟨"laka", "persuade", .irrealisNi, .objectControl, some .desiderative⟩
+/-- 'force' — object control. UNVERIFIED against [allotey-2021]'s verb list. -/
+def dai : CTP := ⟨"dai", "force", .irrealisNi, some .object⟩
 
-/-- 'force' — implicative causative, object control. Predicative tier.
-    Treated like English `force` per [landau-2015]'s (4a):
-    coercive causatives pattern as implicatives. -/
-def dai : CTP :=
-  ⟨"dai", "force", .irrealisNi, .objectControl, some .implicative⟩
+/-- 'help' — object control. UNVERIFIED against [allotey-2021]'s verb list
+    (Gã 'help' is commonly *bua*; *wa* is 'be strong/hard'). -/
+def wa : CTP := ⟨"wa", "help", .irrealisNi, some .object⟩
 
-/-- 'help' — object control. Landau class left unspecified
-    (`help` does not fit any of Landau's eight classes cleanly). -/
-def wa : CTP :=
-  ⟨"wa", "help", .irrealisNi, .objectControl, none⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 3: Finite-Complement Verb (`akɛ`-clause)
--- ════════════════════════════════════════════════════════════════
+/-! ### Finite-complement verb (`akɛ`-clause) -/
 
 /-- 'say' — utterance verb, finite `akɛ`-clause.
 
-    Not pulled out as a CTP entry by [allotey-2021], but used in
-    passing as the canonical example of an `akɛ`-clause selector
-    (the cross-Kwa standard utterance verb). Kept here so that the
-    library can exhibit the OC-vs-non-OC contrast end-to-end. -/
-def kee : CTP :=
-  ⟨"kɛɛ", "say", .finiteAke, .noneControl, some .propositional⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 4: Per-Verb Verification Theorems
--- ════════════════════════════════════════════════════════════════
-
--- Subject-control verbs select irrealis `ni`-clauses.
-theorem tao_irrealisNi      : tao.selects      = .irrealisNi := rfl
-theorem hiekpano_irrealisNi : hiekpano.selects = .irrealisNi := rfl
-theorem nye_irrealisNi      : nye.selects      = .irrealisNi := rfl
-theorem kpleno_irrealisNi   : kpleno.selects   = .irrealisNi := rfl
-theorem kpang_irrealisNi    : kpang.selects    = .irrealisNi := rfl
-
--- Object-control verbs select irrealis `ni`-clauses.
-theorem kenya_irrealisNi : kenya.selects = .irrealisNi := rfl
-theorem laka_irrealisNi  : laka.selects  = .irrealisNi := rfl
-theorem dai_irrealisNi   : dai.selects   = .irrealisNi := rfl
-theorem wa_irrealisNi    : wa.selects    = .irrealisNi := rfl
-
--- Finite-complement verb selects `akɛ`-clauses.
-theorem kee_finiteAke : kee.selects = .finiteAke := rfl
-
--- Landau control tier: implicative verbs are predicative, desiderative
--- verbs are logophoric. Direct application of `LandauPredicateClass.controlTier`.
-theorem hiekpano_predicative : hiekpano.controlTier = some .predicative := rfl
-theorem nye_predicative      : nye.controlTier      = some .predicative := rfl
-theorem dai_predicative      : dai.controlTier      = some .predicative := rfl
-
-theorem tao_logophoric    : tao.controlTier    = some .logophoric := rfl
-theorem kpleno_logophoric : kpleno.controlTier = some .logophoric := rfl
-theorem kpang_logophoric  : kpang.controlTier  = some .logophoric := rfl
-theorem kenya_logophoric  : kenya.controlTier  = some .logophoric := rfl
-theorem laka_logophoric   : laka.controlTier   = some .logophoric := rfl
+    Not part of [allotey-2021]'s CTP inventory, but used in passing as
+    the canonical `akɛ`-clause selector (the cross-Kwa standard
+    utterance verb). Kept so the library can exhibit the OC-vs-non-OC
+    contrast end-to-end. -/
+def kee : CTP := ⟨"kɛɛ", "say", .finiteAke, none⟩
 
 end Ga

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -2,10 +2,9 @@ import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Fragments.Ga.Predicates
 import Linglib.Syntax.NullSubject
 import Linglib.Studies.Landau2015
-import Linglib.Features.Complementation
 
 /-!
-# Allotey (2021): Overt Pronouns of Infinitival Predicates in Gã
+# Allotey (2021): Overt Pronouns of Infinitival Predicates of Gã
 [allotey-2021]
 
 Western Papers in Linguistics / Cahiers linguistiques de Western 4.
@@ -13,17 +12,18 @@ Western Papers in Linguistics / Cahiers linguistiques de Western 4.
 Gã (Kwa, Niger-Congo; spoken in Greater Accra, Ghana) shows obligatory
 control over the embedded subject of irrealis `ni`-clauses, where the
 controlled subject is realized as an OVERT subject proclitic — null PRO
-is ungrammatical. This is the same pattern [ostrove-2026] analyzes
-for SMPM and [sulemana-2021] analyzes for Büli, and falls under the
-[kratzer-2009] / [safir-2014] / [landau-2015] minimal
-pronoun framework: Gã simply lacks a null vocabulary item for the
-controlled subject position.
+is ungrammatical. Under the [kratzer-2009] / [safir-2014] /
+[landau-2015] minimal pronoun framework, Gã simply lacks a null
+vocabulary item for the controlled subject position.
 
-[allotey-2021] herself adopts [szabolcsi-2009]'s Long Distance
-Agree (LDA) Hypothesis (building on [satik-2019]). The minimal
+[allotey-2021] weighs two analyses of overt infinitival subjects — the
+Long Distance Agree (LDA) Hypothesis of [szabolcsi-2009] and the
+Movement Theory of Control (the derivation she illustrates from
+[satik-2019]) — and adopts LDA: her analysis puts the matrix subject in
+a Long-Distance relation with the embedded pronoun subject. The minimal
 pronoun framework and LDA are compatible — LDA is the syntactic
-mechanism that values the unvalued φ-features of the minimal pronoun
-in the embedded subject position. We wire both perspectives in below.
+mechanism that values the unvalued φ-features of the minimal pronoun in
+the embedded subject position. We wire both perspectives in below.
 
 ## Core Contributions
 
@@ -33,18 +33,16 @@ in the embedded subject position. We wire both perspectives in below.
 2. **OC over an overt subject**: irrealis `ni`-clauses show the OC
    signature despite carrying an overt subject proclitic.
 3. **Subject and object control** are both attested with `ni`-clause
-   complements (subject-control: `tao` 'want', `hiɛ-kpa-nɔ` 'forget';
-   object-control: `kenya` 'urge', `dai` 'force').
-4. **Irrealis ≠ subjunctive**: Allotey argues against
-   [dakubu-2004] and [campbell-2017], who classify the
-   high-tone marker as subjunctive. The diagnostic she offers
-   (controlled-clause obviation) is formalized below.
+   complements (subject-control: `tao` 'want' ex 2a, `hiɛ-ka-nɔ` 'hope'
+   ex 16).
+4. **Irrealis ≠ subjunctive**: Allotey argues that the high-tone marker
+   on the embedded-clause subject pronoun is irrealis, not subjunctive
+   (against the subjunctive classification in the Gã descriptive
+   literature, [dakubu-2004], [campbell-2017]): it does not show the
+   obviation that defines subjunctives (formalized below).
 5. **Long Distance Agree analysis**: the embedded overt pronoun is a
    minimal pronoun whose φ-features are valued by LDA from the matrix
-   controller ([szabolcsi-2009], [satik-2019]).
-6. **Cross-linguistic pattern**: Gã joins SMPM and Büli as a third
-   language with obligatory pronominal copy control under the
-   [ostrove-2026] typology.
+   controller ([szabolcsi-2009]).
 
 ## Out of scope
 
@@ -64,29 +62,9 @@ open Landau2015
 open NullSubject (ProDropProfile)
 open Ga (EmbeddedClauseType clauseProperties clauseComplementizer
                    complementizer_isFinite_eq_finiteFlag
-                   Complementizer Control CTP)
+                   Complementizer CTP)
 
--- ════════════════════════════════════════════════════════════════
--- § 1: Clause Type Verification
--- ════════════════════════════════════════════════════════════════
-
-theorem finiteAke_unrestricted_tam :
-    (clauseProperties .finiteAke).unrestrictedTAM = true := rfl
-theorem finiteKeji_unrestricted_tam :
-    (clauseProperties .finiteKeji).unrestrictedTAM = true := rfl
-theorem irrealisNi_restricted_tam :
-    (clauseProperties .irrealisNi).unrestrictedTAM = false := rfl
-
-theorem finiteAke_allows_noncoreferential :
-    (clauseProperties .finiteAke).noncoreferentialSubject = true := rfl
-theorem finiteKeji_allows_noncoreferential :
-    (clauseProperties .finiteKeji).noncoreferentialSubject = true := rfl
-theorem irrealisNi_no_noncoreferential :
-    (clauseProperties .irrealisNi).noncoreferentialSubject = false := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 2: OC Diagnostics — derived from clauseProperties
--- ════════════════════════════════════════════════════════════════
+/-! ### OC diagnostics — derived from clause properties -/
 
 /-- OC signature derived from clause properties.
 
@@ -101,50 +79,33 @@ theorem irrealisNi_no_noncoreferential :
 def gaOCSignature (c : EmbeddedClauseType) : OCSignature :=
   if (clauseProperties c).noncoreferentialSubject then ocNone else ocFull
 
-theorem irrealisNi_is_OC :
-    (gaOCSignature .irrealisNi).isOC = true := rfl
-
-theorem finiteAke_not_OC :
-    (gaOCSignature .finiteAke).isOC = false := rfl
-
-theorem finiteKeji_not_OC :
-    (gaOCSignature .finiteKeji).isOC = false := rfl
-
 /-- The general derivation: lack of noncoreferential subjects iff OC. -/
 theorem oc_iff_no_noncoreferential (c : EmbeddedClauseType) :
     (gaOCSignature c).isOC = !(clauseProperties c).noncoreferentialSubject := by
   cases c <;> rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 3: Irrealis vs. Subjunctive Diagnostic
--- ════════════════════════════════════════════════════════════════
+/-- Universal: every Gã CTP whose complement is `irrealisNi` shows OC,
+    and every CTP whose complement is finite does not. The clause type
+    determines OC, regardless of the verb's own control type. -/
+theorem oc_determined_by_clause_type (c : CTP) :
+    (gaOCSignature c.selects).isOC = !(clauseComplementizer c.selects).isFinite := by
+  cases h : c.selects <;> rfl
 
-/-- A clause type passes the **subjunctive diagnostic** iff it permits
-    a noncoreferential embedded subject. Romance subjunctives display
-    obviation effects (the embedded subject must NOT corefer with the
-    matrix subject) — i.e., they license noncoreference. An irrealis
-    OC clause license the opposite: obligatory coreference.
+/-! ### Irrealis vs. subjunctive -/
 
-    [allotey-2021] argues that the high-tone marker on Gã verbs
-    is **irrealis**, not subjunctive (contra [dakubu-2004],
-    [campbell-2017]). The diagnostic below confirms her claim
-    on the noncoreference test: `irrealisNi` fails the subjunctive
-    diagnostic. -/
-def isSubjunctiveLike (c : EmbeddedClauseType) : Bool :=
-  (clauseProperties c).noncoreferentialSubject
+/-- [allotey-2021] argues the high-tone marker on the embedded-clause
+    pronoun is **irrealis**, not subjunctive (against the subjunctive
+    classification of the Gã descriptive literature, [dakubu-2004],
+    [campbell-2017]). Her diagnostic is obviation: Romance subjunctives
+    force the embedded subject to be DISJOINT from the matrix subject,
+    while Gã `ni`-clauses force coreference — the opposite. The fragment
+    encodes only the coreference dimension, so we record the Gã half:
+    `irrealisNi` requires a coreferential subject, which no obviative
+    subjunctive allows. -/
+theorem irrealisNi_forces_coreference :
+    (clauseProperties .irrealisNi).noncoreferentialSubject = false := rfl
 
-theorem irrealisNi_not_subjunctive :
-    isSubjunctiveLike .irrealisNi = false := rfl
-
-theorem finiteAke_subjunctive_test_passes :
-    isSubjunctiveLike .finiteAke = true := rfl
-
-theorem finiteKeji_subjunctive_test_passes :
-    isSubjunctiveLike .finiteKeji = true := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 4: Landau Bridge
--- ════════════════════════════════════════════════════════════════
+/-! ### Landau bridge -/
 
 /-- Map Gã clause types to [landau-2004]'s finiteness scale.
 
@@ -171,12 +132,10 @@ def gaToLandau : EmbeddedClauseType → LandauClauseClass
 def gaAgr (c : EmbeddedClauseType) : Bool :=
   (clauseProperties c).finiteComplementizer
 
-/-- Cross-check: `gaAgr` agrees with the complementizer's finiteness flag,
-    via `complementizer_isFinite_eq_finiteFlag`. -/
+/-- Cross-check: `gaAgr` agrees with the complementizer's finiteness flag. -/
 theorem gaAgr_eq_complementizer_isFinite (c : EmbeddedClauseType) :
-    gaAgr c = (clauseComplementizer c).isFinite := by
-  unfold gaAgr
-  rw [complementizer_isFinite_eq_finiteFlag]
+    gaAgr c = (clauseComplementizer c).isFinite :=
+  (complementizer_isFinite_eq_finiteFlag c).symm
 
 /-- The Landau classification predicts Gã control properties for all
     three clause types, taking Agr status into account. -/
@@ -184,40 +143,7 @@ theorem landau_predicts_control (c : EmbeddedClauseType) :
     (gaOCSignature c).isOC = (gaToLandau c).hasOCWithAgr (gaAgr c) := by
   cases c <;> rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 5: Per-Verb Control Verification
--- ════════════════════════════════════════════════════════════════
-
-open Ga (tao kpleno kpang hiekpano nye kenya laka dai wa kee)
-
-/-- Each subject-control verb selects an `irrealisNi` clause whose
-    OC signature is the full one. -/
-theorem tao_OC      : (gaOCSignature tao.selects).isOC      = true := rfl
-theorem hiekpano_OC : (gaOCSignature hiekpano.selects).isOC = true := rfl
-theorem nye_OC      : (gaOCSignature nye.selects).isOC      = true := rfl
-theorem kpleno_OC   : (gaOCSignature kpleno.selects).isOC   = true := rfl
-theorem kpang_OC    : (gaOCSignature kpang.selects).isOC    = true := rfl
-
-/-- Each object-control verb selects an `irrealisNi` clause whose
-    OC signature is the full one. -/
-theorem kenya_OC : (gaOCSignature kenya.selects).isOC = true := rfl
-theorem laka_OC  : (gaOCSignature laka.selects).isOC  = true := rfl
-theorem dai_OC   : (gaOCSignature dai.selects).isOC   = true := rfl
-theorem wa_OC    : (gaOCSignature wa.selects).isOC    = true := rfl
-
-/-- The finite-complement verb does not show OC. -/
-theorem kee_no_OC : (gaOCSignature kee.selects).isOC = false := rfl
-
-/-- Universal: every Gã CTP whose complement is `irrealisNi` shows OC,
-    and every CTP whose complement is finite does not. The clause type
-    determines OC, regardless of the verb's own control flavor. -/
-theorem oc_determined_by_clause_type (c : CTP) :
-    (gaOCSignature c.selects).isOC = !(clauseComplementizer c.selects).isFinite := by
-  cases h : c.selects <;> rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 6: Long-Distance Agree Analysis (Allotey's syntactic mechanism)
--- ════════════════════════════════════════════════════════════════
+/-! ### Long-Distance Agree analysis (Allotey's syntactic mechanism) -/
 
 /-- Long Distance Agree configuration ([szabolcsi-2009]): a matrix probe
     values an embedded goal's unvalued φ across a non-defective C. Folded
@@ -243,7 +169,7 @@ def LDAConfig.licenses (cfg : LDAConfig) : Bool :=
 /-- [allotey-2021]'s syntactic analysis: the embedded overt
     pronoun in a controlled `ni`-clause is a minimal pronoun whose
     unvalued φ-features are valued by Long Distance Agree from the
-    matrix controller ([szabolcsi-2009], [satik-2019]).
+    matrix controller ([szabolcsi-2009]).
 
     The probe (matrix v/T) has valued φ; the goal (embedded D[uφ])
     has unvalued φ; the intervening `ni` C head is non-defective for
@@ -256,24 +182,11 @@ def gaLDAConfig : LDAConfig where
 theorem ga_satisfies_LDA :
     LDAConfig.licenses gaLDAConfig = true := rfl
 
-/-- Bridge: the LDA configuration is exactly what's required to value
-    the φ-features of a minimal pronoun in the embedded subject position.
-    This is the syntactic mechanism that complements the morphological
-    minimal-pronoun analysis (Section 7). -/
-theorem ga_LDA_implies_OC :
-    LDAConfig.licenses gaLDAConfig = true →
-    (gaOCSignature .irrealisNi).isOC = true := by
-  intro _; rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 7: Minimal Pronoun Inventory
--- ════════════════════════════════════════════════════════════════
+/-! ### Minimal pronoun inventory -/
 
 open PronForm
 
-/-- Gã vocabulary items.
-
-    Like SMPM and Büli: lacks a null allomorph for controlled subjects.
+/-- Gã vocabulary items: no null allomorph for controlled subjects.
     The controlled subject of an `irrealisNi` clause surfaces as the
     elsewhere (pronoun) form — i.e., the same subject proclitic used
     for referential pronouns. -/
@@ -291,17 +204,16 @@ theorem ga_overt_pro :
 theorem ga_has_reflexive :
     gaInventory.realize .locallyBound = .reflexive := rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 8: Pro-Drop / Overt-PRO Universal ([ostrove-2026] 54)
--- ════════════════════════════════════════════════════════════════
+/-! ### Pro-drop / overt-PRO universal -/
 
 /-- Gã profile derived from fragment data and inventory. -/
 def gaProfile : ProDropProfile :=
   { allowsProDrop := Ga.allowsProDrop
   , hasOvertPRO   := decide gaInventory.hasOvertPRO }
 
-/-- Gã satisfies the implicational universal — overt PRO + non-*pro*-drop
-    means the consequent is true. -/
+/-- Gã satisfies the pro-drop/overt-PRO implicational universal
+    (`ProDropProfile.Satisfies`) — overt PRO + non-*pro*-drop means the
+    consequent is true. -/
 theorem ga_satisfies_universal : gaProfile.Satisfies := by decide
 
 /-- Contrapositive concretization: were Gã *pro*-drop, it could not have
@@ -311,31 +223,5 @@ theorem ga_prodrop_would_exclude_overt_pro
     (h : gaProfile.allowsProDrop = true) :
     gaProfile.hasOvertPRO = false :=
   ProDropProfile.prodrop_excludes_overt_pro gaProfile ga_satisfies_universal h
-
--- ════════════════════════════════════════════════════════════════
--- § 9: Noonan Complementation Bridge
--- ════════════════════════════════════════════════════════════════
-
-/-- Map Gã clause types to [noonan-2007]'s complement typology.
-
-    All three Gã clause types are "balanced" in Noonan's sense: they
-    are inflected for TAM and carry overt subject morphology. There is
-    no "deranked" (infinitival/nominalized/participial) complement
-    type in Gã.
-
-    - `finiteAke` → indicative (full TAM, free reference)
-    - `finiteKeji` → indicative (full TAM, free reference; conditional flavor)
-    - `irrealisNi` → subjunctive (irrealis only, obligatory coreference)
-
-    Note: Noonan's `subjunctive` category is the typological-typology
-    label for "finite irrealis-marked complement"; it is *not* the
-    generative-grammar subjunctive Allotey is arguing against
-    (cf. `irrealisNi_not_subjunctive` above). The Noonan label and the
-    Dakubu/Campbell label happen to share a word but track different
-    properties. -/
-def gaToNoonan : EmbeddedClauseType → NoonanCompType
-  | .finiteAke  => .indicative
-  | .finiteKeji => .indicative
-  | .irrealisNi => .subjunctive
 
 end Allotey2021

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -14,45 +14,60 @@ control over the embedded subject of irrealis `ni`-clauses, where the
 controlled subject is realized as an OVERT subject proclitic — null PRO
 is ungrammatical. Under the [kratzer-2009] / [safir-2014] /
 [landau-2015] minimal pronoun framework, Gã simply lacks a null
-vocabulary item for the controlled subject position.
+vocabulary item for the controlled subject position; Allotey's own
+explanation for the overtness is morphophonological — PRO must be
+lexicalized to provide a segmental host for the obligatory irrealis
+high tone of the embedded clause.
 
-[allotey-2021] weighs two analyses of overt infinitival subjects — the
-Long Distance Agree (LDA) Hypothesis of [szabolcsi-2009] and the
-Movement Theory of Control (the derivation she illustrates from
-[satik-2019]) — and adopts LDA: her analysis puts the matrix subject in
-a Long-Distance relation with the embedded pronoun subject. The minimal
-pronoun framework and LDA are compatible — LDA is the syntactic
-mechanism that values the unvalued φ-features of the minimal pronoun in
-the embedded subject position. We wire both perspectives in below.
+[allotey-2021] weighs three analyses of overt infinitival subjects: the
+Long Distance Agree (LDA) Hypothesis of [szabolcsi-2009], the Movement
+Theory of Control, and the left-periphery-bound-pronoun analysis of
+[satik-2019] (whose Ewe overt-PRO evidence she builds on). She adopts
+LDA — the matrix subject values the embedded pronoun in person and
+number across the `ni` C head — and rejects the other two: MTC predicts
+an embedded lexical-DP copy that is ungrammatical, and Ewe-style LPBP
+cannot capture the φ-covariance of the Gã pronoun. The minimal pronoun
+framework and LDA are compatible — LDA is the syntactic mechanism that
+values the unvalued φ-features of the minimal pronoun in the embedded
+subject position. We wire both perspectives in below.
 
 ## Core Contributions
 
 1. **Three-way clause typology** distinguished by complementizer:
    `akɛ`-clauses (finite declarative), `kɛji`-clauses (finite
-   conditional), `ni`-clauses (irrealis, OC).
-2. **OC over an overt subject**: irrealis `ni`-clauses show the OC
-   signature despite carrying an overt subject proclitic.
+   conditional/interrogative), `ni`-clauses (irrealis, OC; a weak CP).
+2. **OC over an overt subject**: irrealis `ni`-clauses show the full
+   [landau-2013] OC signature (her Table 2) despite carrying an overt
+   subject proclitic, which she argues is a subject in Spec TP, not an
+   agreement marker.
 3. **Subject and object control** are both attested with `ni`-clause
-   complements (subject-control: `tao` 'want' ex 2a, `hiɛ-ka-nɔ` 'hope'
-   ex 16).
-4. **Irrealis ≠ subjunctive**: Allotey argues that the high-tone marker
-   on the embedded-clause subject pronoun is irrealis, not subjunctive
-   (against the subjunctive classification in the Gã descriptive
-   literature, [dakubu-2004], [campbell-2017]): it does not show the
-   obviation that defines subjunctives (formalized below).
-5. **Long Distance Agree analysis**: the embedded overt pronoun is a
-   minimal pronoun whose φ-features are valued by LDA from the matrix
-   controller ([szabolcsi-2009]).
+   complements (subject-control: `tao` 'want' ex 34, `hiɛ-kã-nɔ` 'hope'
+   ex 35, `hiɛ-kpa-nɔ` 'forget' exx 37–38; object-control exx 54–59).
+4. **Irrealis ≠ subjunctive**: Gã has BOTH a true subjunctive (irrealis
+   marker doubled: high tone on pronoun and verb) and an irrealis
+   marker `á` (high tone on the embedded pronoun only). The embedded
+   control clauses carry the latter, against the subjunctive
+   classification in the Gã descriptive literature ([dakubu-2004],
+   [campbell-2017]): they force coreference where subjunctives show
+   obviation (her exx 90–92, formalized below).
+5. **Non-finiteness of `ni`-clauses**, by five diagnostics: CP-head
+   selection, subject tonal asymmetries, NPI licensing across the
+   clause boundary, tense restrictions, and negation placement.
+6. **Long Distance Agree analysis**: the embedded overt pronoun is
+   valued by LDA from the matrix controller ([szabolcsi-2009]).
 
 ## Out of scope
 
-The paper also discusses Gã verbal negation and an analogy to French
-V-movement past `pas` ([pollock-1989]). That analogy depends on
-treating Gã `-ee` and `-ko` as a free Neg head (Pollock's diagnostic
-crucially relies on negation occupying a fixed structural position
-rather than being a verbal suffix). The morphological argument that
-would license that step is outside Allotey's data, so we do not
-formalize the V-to-T claim here.
+The verb-movement/negation-placement diagnostic (her fifth
+non-finiteness argument, after [pollock-1989]: finite verbs raise past
+suffixal `-ee`/`-ko` negation while irrealis clauses show free
+preverbal `ka`, exx 120–125) — formalizing the raising argument needs
+phrase-structure substrate; the finiteness split it diagnoses is
+already carried by the clause typology. Also unformalized: the §5.2.3
+implicative asymmetry (implicative `kai` 'remember' and `nyɛ` 'manage'
+suppress the embedded irrealis marker that non-implicative `kplɛnɔ`
+'agree' and `kpaŋ` 'plan' require) — a natural future refinement once
+the fragment carries an implicativity classification.
 -/
 
 namespace Allotey2021
@@ -96,12 +111,12 @@ theorem oc_determined_by_clause_type (c : CTP) :
 /-- [allotey-2021] argues the high-tone marker on the embedded-clause
     pronoun is **irrealis**, not subjunctive (against the subjunctive
     classification of the Gã descriptive literature, [dakubu-2004],
-    [campbell-2017]). Her diagnostic is obviation: Romance subjunctives
-    force the embedded subject to be DISJOINT from the matrix subject,
-    while Gã `ni`-clauses force coreference — the opposite. The fragment
-    encodes only the coreference dimension, so we record the Gã half:
-    `irrealisNi` requires a coreferential subject, which no obviative
-    subjunctive allows. -/
+    [campbell-2017]). One diagnostic is obviation (her exx 90–92):
+    Romance subjunctives force the embedded subject to be DISJOINT from
+    the matrix subject, while Gã `ni`-clauses force coreference — the
+    opposite. The fragment encodes only the coreference dimension, so we
+    record the Gã half: `irrealisNi` requires a coreferential subject,
+    which no obviative subjunctive allows. -/
 theorem irrealisNi_forces_coreference :
     (clauseProperties .irrealisNi).noncoreferentialSubject = false := rfl
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -8426,11 +8426,11 @@
   validated = {true},
   role      = {formalized},
   sources   = {Studies/Ostrove2026.lean}
-}% REF: Allotey, D. (2021). Overt pronouns of infinitival predicates in Gã.
+}% REF: Allotey, D. (2021). Overt pronouns of infinitival predicates of Gã.
 @article{allotey-2021,
   author    = {Allotey, Deborah},
   year      = {2021},
-  title     = {Overt Pronouns of Infinitival Predicates in {Gã}},
+  title     = {Overt Pronouns of Infinitival Predicates of {Gã}},
   journal   = {Western Papers in Linguistics / Cahiers linguistiques de Western},
   volume    = {4},
   url       = {https://ojs.lib.uwo.ca/index.php/wpl_clw/article/view/13693},
@@ -8460,14 +8460,18 @@
   subfield  = {syntax},
   role      = {cited},
   sources   = {Studies/Allotey2021.lean}
-}% REF: Dakubu, M. E. K. (2004). Gã grammar work. Cited by Allotey (2021) for
-%      the subjunctive analysis of the high-tone marker that Allotey argues
-%      against. Exact title/venue unverified.
-@misc{dakubu-2004,
-  author    = {Dakubu, M. E. Kropp},
+}% REF: Kropp Dakubu, M. E. (2004). Ga clauses without syntactic subjects. JALL 25(1).
+%      Cited by Allotey (2021) as "Dakubu (2004a, 2004b)" among her Gã grammar and
+%      corpus sources (the descriptive tradition whose subjunctive label for the
+%      high-tone marker Allotey argues against).
+@article{dakubu-2004,
+  author    = {Kropp Dakubu, Mary Esther},
   year      = {2004},
-  title     = {The {Gã} High-Tone Verbal Marker as Subjunctive},
-  note      = {Cited by @cite{allotey-2021}; exact title/venue unverified},
+  title     = {Ga Clauses without Syntactic Subjects},
+  journal   = {Journal of African Languages and Linguistics},
+  volume    = {25},
+  number    = {1},
+  note      = {Cited by @cite{allotey-2021} as Dakubu (2004a,b)},
   subfield  = {comparative},
   role      = {cited},
   sources   = {Studies/Allotey2021.lean}

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -8439,24 +8439,25 @@
   role      = {formalized},
   sources   = {Fragments/Ga/Basic.lean;Fragments/Ga/Predicates.lean;Studies/Allotey2021.lean}
 }% REF: Szabolcsi, A. (2009). Overt nominative subjects in infinitival complements
-%      cross-linguistically. Source of the Long Distance Agree analysis adopted by
-%      Allotey (2021). Venue/page numbers unverified — included as a stub.
+%      cross-linguistically. NYU WPL 2, 1-55. Source of the LDA analysis adopted
+%      by Allotey (2021); verified against Allotey's reference list.
 @article{szabolcsi-2009,
   author    = {Szabolcsi, Anna},
   year      = {2009},
   title     = {Overt Nominative Subjects in Infinitival Complements Cross-Linguistically: Data, Diagnostics, and Preliminary Analyses},
   journal   = {NYU Working Papers in Linguistics},
   volume    = {2},
+  pages     = {1--55},
   subfield  = {syntax},
   role      = {cited},
   sources   = {Studies/Allotey2021.lean}
-}% REF: Satik, D. (2019). Cited by Allotey (2021) for the LDA analysis of
-%      infinitival overt pronouns. Exact venue/title unverified.
+}% REF: Satik, D. (2019). Control is not Movement: evidence of overt PRO in Ewe.
+%      Ms., Harvard University. Verified against Allotey (2021)'s reference list.
 @misc{satik-2019,
   author    = {Satik, Deniz},
   year      = {2019},
-  title     = {Long Distance Agree and Infinitival Overt Subjects},
-  note      = {Cited by @cite{allotey-2021}; exact venue unverified},
+  title     = {Control Is Not Movement: Evidence of Overt {PRO} in {Ewe}},
+  note      = {Ms., Harvard University},
   subfield  = {syntax},
   role      = {cited},
   sources   = {Studies/Allotey2021.lean}
@@ -8471,17 +8472,19 @@
   journal   = {Journal of African Languages and Linguistics},
   volume    = {25},
   number    = {1},
-  note      = {Cited by @cite{allotey-2021} as Dakubu (2004a,b)},
+  pages     = {1--40},
+  note      = {Cited by @cite{allotey-2021} as Dakubu (2004a)},
   subfield  = {comparative},
   role      = {cited},
   sources   = {Studies/Allotey2021.lean}
-}% REF: Campbell, A. (2017). A Grammar of Gã. Cited by Allotey (2021) alongside
-%      Dakubu for the subjunctive analysis. Title approximate.
+}% REF: Campbell, A. A. (2017). A Grammar of Gã. Rice University dissertation.
+%      Verified against Allotey (2021)'s reference list (incl. handle URL).
 @phdthesis{campbell-2017,
-  author    = {Campbell, Akua},
+  author    = {Campbell, Akua Asantewaa},
   year      = {2017},
   title     = {A Grammar of {Gã}},
-  note      = {Cited by @cite{allotey-2021}; thesis institution unverified},
+  school    = {Rice University},
+  url       = {https://hdl.handle.net/1911/102269},
   subfield  = {comparative},
   role      = {cited},
   sources   = {Studies/Allotey2021.lean}


### PR DESCRIPTION
Four-lens audit of the Ga cluster, then full verification against Allotey 2021 (complete PDF).

- delete ~36 rfl-unfolding theorems, dead local Person/Number enums + bridges, `basicWordOrder`, vacuous `ga_LDA_implies_OC`, unconsumed Noonan bridge; drop Fragment→Studies import by removing paper-specific `landauClass` from the CTP schema
- paper-verified corrections: title is "…of Gã"; irrealis high tone sits on the embedded-clause pronoun (portmanteau `má`), not the verb stem; perfective (not perfect) `é-`; `hiɛ-kã-nɔ` 'hope' and `hiɛ-kpa-nɔ` 'forget' are distinct verbs (exx 35, 37–38); verb inventory now fully example-cited incl. new `mia-mi-hiɛ` 'try', `kai` 'remember', `bi` 'ask', `le` 'know' (the kɛji-selector); bib fixes: fabricated `dakubu-2004` and `satik-2019` titles replaced with verified ones, `campbell-2017` = Rice dissertation, `szabolcsi-2009` completed