### PR TITLE
refactor(Syntax/Control): graduate control substrate from Studies/Landau2015

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2824,6 +2824,8 @@ import Linglib.Syntax.ConstructionGrammar.IdiomTypology
 import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Syntax.ConstructionGrammar.Licensing
 import Linglib.Syntax.ConstructionGrammar.Resultatives
+import Linglib.Syntax.Control.Basic
+import Linglib.Syntax.Control.CopyControl
 import Linglib.Syntax.Coordination
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Syntax.DependencyGrammar.Coordination

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -1,7 +1,8 @@
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Fragments.Ga.Predicates
 import Linglib.Syntax.NullSubject
-import Linglib.Studies.Landau2015
+import Linglib.Syntax.Control.Basic
+import Linglib.Syntax.Control.CopyControl
 
 /-!
 # Allotey (2021): Overt Pronouns of Infinitival Predicates of Gã
@@ -73,7 +74,7 @@ the fragment carries an implicativity classification.
 namespace Allotey2021
 
 open Minimalist.MinimalPronoun
-open Landau2015
+open Control
 open NullSubject (ProDropProfile)
 open Ga (EmbeddedClauseType clauseProperties clauseComplementizer
                    complementizer_isFinite_eq_finiteFlag
@@ -89,15 +90,17 @@ open Ga (EmbeddedClauseType clauseProperties clauseComplementizer
     `irrealisNi` falls in the former group.
 
     This is *derived* from `clauseProperties.noncoreferentialSubject`
-    rather than stipulated per clause — changing the noncoreferential
-    flag in `Fragments/Ga/Basic.lean` automatically propagates here. -/
+    via `OCSignature.ofNoncoreferential` (shared with
+    `Ostrove2026.smpmOCSignature`) rather than stipulated per clause —
+    changing the noncoreferential flag in `Fragments/Ga/Basic.lean`
+    automatically propagates here. -/
 def gaOCSignature (c : EmbeddedClauseType) : OCSignature :=
-  if (clauseProperties c).noncoreferentialSubject then ocNone else ocFull
+  .ofNoncoreferential (clauseProperties c).noncoreferentialSubject
 
 /-- The general derivation: lack of noncoreferential subjects iff OC. -/
 theorem oc_iff_no_noncoreferential (c : EmbeddedClauseType) :
-    (gaOCSignature c).isOC = !(clauseProperties c).noncoreferentialSubject := by
-  cases c <;> rfl
+    (gaOCSignature c).isOC = !(clauseProperties c).noncoreferentialSubject :=
+  OCSignature.ofNoncoreferential_isOC _
 
 /-- Universal: every Gã CTP whose complement is `irrealisNi` shows OC,
     and every CTP whose complement is finite does not. The clause type
@@ -133,7 +136,7 @@ theorem irrealisNi_forces_coreference :
     Gã has no F-subjunctive correspondent: there is no morphologically
     distinct tensed-but-controlled clause class — `ni`-clauses are all
     irrealis and OC; `akɛ`/`kɛji`-clauses are all finite and non-OC. -/
-def gaToLandau : EmbeddedClauseType → LandauClauseClass
+def gaToLandau : EmbeddedClauseType → Control.ClauseClass
   | .irrealisNi => .cSubjunctive
   | .finiteAke  => .finite
   | .finiteKeji => .finite
@@ -196,6 +199,26 @@ def gaLDAConfig : LDAConfig where
 
 theorem ga_satisfies_LDA :
     LDAConfig.licenses gaLDAConfig = true := rfl
+
+/-! ### Against the Movement Theory of Control -/
+
+/-- [allotey-2021] §3.6.2 rejects [hornstein-1999]'s Movement Theory of
+    Control for Gã: under movement the pronounced embedded element is a
+    copy of the matrix DP, so a lexical-DP controller predicts a
+    lexical-DP embedded copy — but Gã forbids lexical DPs in the
+    controlled position (her exx 42b, 64). The LDA analysis
+    base-generates the minimal pronoun instead. Same pole as SMPM
+    (`Ostrove2026.smpm_supports_basegeneration`, via exempt anaphors). -/
+def gaControlDerivation : Derivation := .baseGeneration
+
+/-- Gã forbids embedded lexical-DP copies (exx 42b, 64). -/
+def gaEmbeddedLexicalCopyAvailable : Bool := false
+
+/-- The Gã ban on embedded lexical DPs matches base-generation and
+    refutes movement. -/
+theorem ga_supports_basegeneration :
+    gaEmbeddedLexicalCopyAvailable
+      = Derivation.predictsEmbeddedLexicalCopy gaControlDerivation := rfl
 
 /-! ### Minimal pronoun inventory -/
 

--- a/Linglib/Studies/Chierchia1984.lean
+++ b/Linglib/Studies/Chierchia1984.lean
@@ -574,7 +574,7 @@ precisely on attitude verbs. -/
 open Landau2015
 
 /-- Map Chierchia's control classes to Landau's control tiers. -/
-def chierchiaToLandauTier : ChierchiaControlClass → Landau2015.ControlTier
+def chierchiaToLandauTier : ChierchiaControlClass → Control.Tier
   | .obligatory     => .predicative
   | .semiObligatory => .predicative
   | .prominence     => .logophoric
@@ -593,7 +593,7 @@ theorem cp_requires_syntactic_controller (c : ChierchiaControlClass)
     (h : c.hasCP = true) :
     (chierchiaToLandauTier c).requiresSyntacticController = true := by
   cases c <;> simp_all [ChierchiaControlClass.hasCP,
-    chierchiaToLandauTier, Landau2015.ControlTier.requiresSyntacticController]
+    chierchiaToLandauTier, Control.Tier.requiresSyntacticController]
 
 -- ── Per-verb cross-system consistency ──
 

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.MinimalPronoun
+import Linglib.Syntax.Control.Basic
 import Linglib.Semantics.Verb.Basic
 import Linglib.Data.Complementation.Noonan2007
 import Linglib.Fragments.English.Predicates.Verbal
@@ -9,354 +9,35 @@ import Linglib.Fragments.English.Predicates.Verbal
 
 MIT Press. ISBN 978-0-262-02885-1.
 
-OC in complement clauses divides into two subtypes:
-- **Predicative control**: nonattitude complements, PRO moves to Spec,Fin,
-  control via syntactic predication
-- **Logophoric control**: attitude complements, C^OC projects a perspectival
-  coordinate, control via predication + variable binding
+The TTC framework itself — `Control.Tier`, `Control.PredicateClass`,
+`Control.ClauseClass`, the Feature Transmission asymmetry, and the OC-NC
+generalization — lives in `Syntax/Control/Basic.lean`. This file holds
+the book's empirical engagement: the table (80) contrasts, the
+*de se*/*de te* split in object control (table (36)), the derivation of
+predicate classes from English Fragment verb entries, and the
+consilience bridge to [noonan-2007]'s CTP classification.
 
-## Key Definitions
+## Main results
 
-- `ControlTier`: The two tiers of control (predicative vs. logophoric)
-- `LandauPredicateClass`: Eight predicate classes mapped to control tiers
-- `LandauClauseClass`: Finiteness scale (C-subjunctive, F-subjunctive, finite)
-- `FeatureTransmissionAsymmetry`: The mechanism deriving `agrBlocksControl`
-- `agrBlocksControl`: The OC-NC generalization — [+Agr] blocks logophoric
-  control but not predicative control (70)
-- `TTCContrast`: The six empirical contrasts between the two tiers (table (80))
-- `derivedLandauClass`: Maps Verb fields to Landau predicate classes
-- `DeSeReading`: Object control *de se*/*de te* distinction (table (36))
-
-## Core Claims
-
-1. OC splits into predicative (nonattitude, EC) and logophoric (attitude, PC)
-2. Predicative control: predication only; logophoric: predication + variable binding
-3. [+Agr] blocks logophoric control but not predicative control (the OC-NC
-   generalization, (70))
-4. Feature Transmission asymmetry: predication is NOT contingent on feature
-   matching (60a); variable binding IS (60b)
-5. Six empirical contrasts systematically align with the predicative/logophoric
-   divide (table (80)): inflected complements, [−human] PRO, implicit control,
-   control shift, partial control, split control
+- `ttcContrasts` + `ttcContrasts_consistent`: the six empirical
+  contrasts of table (80), each derived from `Control.Tier` properties
+- `objectControlReading`: psychological → *de se*, communicative →
+  *de te* (table (36))
+- `derivedLandauClass` / `derivedControlTier`: predicate classes derived
+  from Fragment verb fields rather than stored
+- `ctpToControlTier` / `ctpToLandauClass`: Noonan CTP classes mapped to
+  the TTC, with the tier-consistency theorem
 -/
 
 namespace Landau2015
 
-open Minimalist.MinimalPronoun
+open Control
 open Features (Attitude)
 
--- ════════════════════════════════════════════════════════════════
--- § 1: The Two-Tiered Theory of Control
--- ════════════════════════════════════════════════════════════════
+/-! ### Table (80): empirical contrasts -/
 
-/-- The two tiers of obligatory control (table (119) of [landau-2015]).
-
-    Predicative control (EC complements):
-    - Selected by nonattitude predicates (implicative, aspectual, modal, evaluative)
-    - PRO moves to Spec,Fin → control via syntactic predication
-    - Forces exhaustive control (EC)
-    - Complement head: transitive Fin_{[uD]}
-
-    Logophoric control (PC complements):
-    - Selected by attitude predicates (factive, propositional, desiderative,
-      interrogative)
-    - C^OC projects a perspectival coordinate → control via predication +
-      variable binding
-    - Allows partial control (PC)
-    - Complement head: transitive C^OC_{[uD]}
-    - Associated with obligatory *de se* interpretation -/
-inductive ControlTier where
-  /-- Predicative control: nonattitude, predication only -/
-  | predicative
-  /-- Logophoric control: attitude, predication + variable binding -/
-  | logophoric
-  deriving DecidableEq, Repr
-
-/-- Logophoric control corresponds to attitude complements. -/
-def ControlTier.isAttitude : ControlTier → Bool
-  | .predicative => false
-  | .logophoric  => true
-
-/-- Condition on syntactic predication ((90) in [landau-2015]):
-    "The argument predicated of must be syntactically represented."
-
-    In predicative control, the controller must be syntactically present
-    because predication is a syntactic relation requiring two syntactically
-    represented terms (the referential argument and the predicate).
-
-    In logophoric control, the AUTHOR/ADDRESSEE coordinate is
-    discourse-anchored, not predication-dependent, so the controller
-    may remain implicit. -/
-def ControlTier.requiresSyntacticController : ControlTier → Bool
-  | .predicative => true
-  | .logophoric  => false
-
-/-- [−human] PRO is compatible with predicative control but
-    incompatible with logophoric control ((81) in [landau-2015]).
-
-    In predicative control, PRO is bound by a simple λ-operator;
-    neither the binder nor the bindee carries any inherent semantic
-    feature. In logophoric control, PRO is bound by pro_x/pro_y,
-    which is mapped to the AUTHOR/ADDRESSEE function; since the
-    latter is only defined for humans, the former will be too.
-
-    This is the negation of `isAttitude`: only logophoric control
-    (attitude contexts) imposes a humanness requirement. -/
-def ControlTier.allowsNonhumanPRO : ControlTier → Bool
-  | .predicative => true
-  | .logophoric  => false
-
-/-! Five properties of control are all unified by the logophoric tier.
-    Partial control, obligatory *de se*, control shift, implicit control,
-    and split control are all available under logophoric control and blocked
-    under predicative control. This reflects the paper's central claim that
-    these five properties derive from the same underlying mechanism:
-    variable binding of a perspectival coordinate.
-
-    Rather than defining five identical functions, we derive each as
-    `isAttitude` and prove they agree. -/
-
-/-- Partial control is available only under logophoric control.
-    Predicative control forces exhaustive control (EC).
-    [landau-2015] Ch 5, §5.1 -/
-def ControlTier.allowsPartialControl := ControlTier.isAttitude
-
-/-- Obligatory *de se* arises only under logophoric control.
-    Predicative contexts are free of the *de se* entailment.
-    [landau-2015] §3.4 -/
-def ControlTier.obligatoryDeSe := ControlTier.isAttitude
-
-/-- Control shift (from subject to object controller) is available
-    only under logophoric control. Predicative control enters a biunique
-    predication relation that no other DP can saturate.
-    [landau-2015] §4.3 -/
-def ControlTier.allowsControlShift := ControlTier.isAttitude
-
-/-- Implicit control is the complement of requiring a syntactic controller.
-    Derived from the condition on syntactic predication (90). -/
-def ControlTier.allowsImplicitControl := ControlTier.isAttitude
-
-/-- Split control (two arguments jointly control PRO) is available
-    only under logophoric control.
-    [landau-2015] Ch 5, §5.2 -/
-def ControlTier.allowsSplitControl := ControlTier.isAttitude
-
-/-- Implicit control derives from condition (90): predicative control
-    requires a syntactically present controller, so `allowsImplicitControl`
-    is the negation of `requiresSyntacticController`. -/
-theorem implicit_control_from_predication_condition (tier : ControlTier) :
-    tier.allowsImplicitControl = !tier.requiresSyntacticController := by
-  cases tier <;> rfl
-
-/-- [−human] PRO derives from the logophoric mechanism:
-    `allowsNonhumanPRO` is the negation of `isAttitude`. -/
-theorem nonhuman_pro_from_attitude (tier : ControlTier) :
-    tier.allowsNonhumanPRO = !tier.isAttitude := by
-  cases tier <;> rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 2: Predicate Classification
--- ════════════════════════════════════════════════════════════════
-
-/-- [landau-2015]'s predicate classification by complement type.
-
-    (4) Predicates selecting untensed complements [−T] → nonattitude:
-      (a) Implicative: avoid, dare, manage, remember, ...
-      (b) Aspectual: begin, continue, finish, start, stop
-      (c) Modal: have, is able, may, must, need, should
-      (d) Evaluative: bold, crazy, kind, rude, silly, smart
-
-    (5) Predicates selecting tensed complements [+T] → attitude:
-      (a) Factive: dislike, glad, hate, regret, sorry, ...
-      (b) Propositional: affirm, believe, claim, declare, say, think
-      (c) Desiderative: agree, choose, decide, hope, intend, want, ...
-      (d) Interrogative: ask, guess, inquire, know, wonder
-
-    Under the TTC, (4) maps to predicative control and (5) to logophoric.
-
-    Note: (4d) evaluative predicates are *adjectives*, not verbs. No
-    evaluative verbs exist in the English Fragment; this class is currently
-    unreachable via `derivedLandauClass`. -/
-inductive LandauPredicateClass where
-  | implicative    -- (4a) nonattitude, EC
-  | aspectual      -- (4b) nonattitude, EC
-  | modal          -- (4c) nonattitude, EC
-  | evaluative     -- (4d) nonattitude, EC (adjectives only)
-  | factive        -- (5a) attitude, PC
-  | propositional  -- (5b) attitude, PC
-  | desiderative   -- (5c) attitude, PC
-  | interrogative  -- (5d) attitude, PC
-  deriving DecidableEq, Repr
-
-/-- Map predicate class to control tier. -/
-def LandauPredicateClass.controlTier : LandauPredicateClass → ControlTier
-  | .implicative | .aspectual | .modal | .evaluative => .predicative
-  | .factive | .propositional | .desiderative | .interrogative => .logophoric
-
-/-- Nonattitude predicates force exhaustive control. -/
-theorem implicative_ec :
-    LandauPredicateClass.implicative.controlTier.allowsPartialControl = false := rfl
-theorem aspectual_ec :
-    LandauPredicateClass.aspectual.controlTier.allowsPartialControl = false := rfl
-
-/-- Attitude predicates allow partial control. -/
-theorem desiderative_pc :
-    LandauPredicateClass.desiderative.controlTier.allowsPartialControl = true := rfl
-theorem propositional_pc :
-    LandauPredicateClass.propositional.controlTier.allowsPartialControl = true := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 3: Feature Transmission Asymmetry (60)
--- ════════════════════════════════════════════════════════════════
-
-/-- The Feature Transmission asymmetry ((60) in [landau-2015]).
-
-    This is the single most important mechanism in the TTC. It is the
-    reason why [+Agr] blocks logophoric control but not predicative
-    control (the OC-NC generalization).
-
-    (60a) The formation of a predication relation is *not* contingent
-          on feature matching between the subject and the predicate.
-    (60b) The formation of a variable binding relation *is* contingent
-          on feature matching between the binder and the pronominal variable.
-
-    The asymmetry is independently motivated: predication tolerates
-    φ-feature mismatches (Icelandic quirky constructions, (63)), while
-    variable binding requires φ-agreement between binder and bindee
-    ([heim-2008], [kratzer-2009]). -/
-structure FeatureTransmissionAsymmetry where
-  /-- (60a): Predication does NOT require feature matching. -/
-  predicationContingentOnFeatureMatch : Bool
-  /-- (60b): Variable binding DOES require feature matching. -/
-  variableBindingContingentOnFeatureMatch : Bool
-
-/-- The empirically motivated Feature Transmission asymmetry. -/
-def ftAsymmetry : FeatureTransmissionAsymmetry where
-  predicationContingentOnFeatureMatch := false
-  variableBindingContingentOnFeatureMatch := true
-
--- ════════════════════════════════════════════════════════════════
--- § 4: The OC-NC Generalization (derived)
--- ════════════════════════════════════════════════════════════════
-
-/-- The OC-NC generalization ((70) in [landau-2015]):
-
-    "[+Agr] blocks logophoric control but not predicative control."
-
-    This is now DERIVED from the Feature Transmission asymmetry (60):
-    - Predicative control uses predication → not contingent on feature
-      matching (60a) → [+Agr] cannot block it
-    - Logophoric control uses variable binding → contingent on feature
-      matching (60b) → [+Agr] preempts Feature Transmission → blocks it -/
-def agrBlocksControl : ControlTier → Bool
-  | .predicative => ftAsymmetry.predicationContingentOnFeatureMatch
-  | .logophoric  => ftAsymmetry.variableBindingContingentOnFeatureMatch
-
-/-- Predicative control survives in inflected complements. -/
-theorem predicative_survives_agr :
-    agrBlocksControl .predicative = false := rfl
-
-/-- Logophoric control is blocked by inflected complements. -/
-theorem logophoric_blocked_by_agr :
-    agrBlocksControl .logophoric = true := rfl
-
-/-- The OC-NC generalization is derived from the Feature Transmission
-    asymmetry, not stipulated. -/
-theorem agr_blocks_derived_from_ft :
-    (agrBlocksControl .predicative = ftAsymmetry.predicationContingentOnFeatureMatch)
-    ∧ (agrBlocksControl .logophoric = ftAsymmetry.variableBindingContingentOnFeatureMatch) :=
-  ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 5: Clause Classes
--- ════════════════════════════════════════════════════════════════
-
-/-- [landau-2004]'s finiteness scale, as recast in [landau-2015].
-
-    The [±T] distinction is subsumed by the attitude/nonattitude distinction:
-    - C-subjunctives (untensed, [−T]) → nonattitude → predicative control
-    - F-subjunctives (tensed, [+T,−Agr]) → attitude → logophoric control
-    - Fully finite ([+T,+Agr]) → no control (OC-NC generalization)
-
-    F-subjunctives DO permit OC (logophoric). Whether OC is realized
-    depends on [±Agr]: [+Agr] blocks logophoric control per the OC-NC
-    generalization. Greek controlled subjunctives ([+T,−Agr]) show OC;
-    Greek indicatives ([+T,+Agr]) do not. -/
-inductive LandauClauseClass where
-  | cSubjunctive   -- Untensed nonfinite, predicative control
-  | fSubjunctive   -- Tensed nonfinite, logophoric control
-  | finite          -- Fully finite, no control
-  deriving DecidableEq, Repr
-
-/-- Map clause class to control tier (when control obtains). -/
-def LandauClauseClass.controlTier : LandauClauseClass → Option ControlTier
-  | .cSubjunctive => some .predicative
-  | .fSubjunctive => some .logophoric
-  | .finite       => none
-
-/-- Whether a clause class structurally permits OC.
-
-    Both C-subjunctives and F-subjunctives permit OC. F-subjunctives
-    permit logophoric OC when [−Agr]; this OC is blocked by [+Agr]
-    per the OC-NC generalization. Fully finite clauses ([+T,+Agr])
-    never permit OC.
-
-    See `hasOCWithAgr` for the Agr-sensitive version. -/
-def LandauClauseClass.permitsOC : LandauClauseClass → Bool
-  | .cSubjunctive => true
-  | .fSubjunctive => true   -- logophoric OC, blocked only by [+Agr]
-  | .finite       => false
-
-/-- Whether OC is realized given Agr status.
-
-    Composes the clause class with the OC-NC generalization:
-    - C-subjunctives: always OC (predicative, Agr-independent)
-    - F-subjunctives [−Agr]: OC (logophoric)
-    - F-subjunctives [+Agr]: no OC (logophoric blocked by Agr)
-    - Fully finite: no OC -/
-def LandauClauseClass.hasOCWithAgr (c : LandauClauseClass) (hasAgr : Bool) : Bool :=
-  match c.controlTier with
-  | none => false
-  | some tier => c.permitsOC && (!hasAgr || !agrBlocksControl tier)
-
-/-- C-subjunctives have OC regardless of Agr. -/
-theorem cSubjunctive_oc_any_agr (agr : Bool) :
-    LandauClauseClass.cSubjunctive.hasOCWithAgr agr = true := by
-  cases agr <;> rfl
-
-/-- F-subjunctives have OC when [−Agr]. -/
-theorem fSubjunctive_oc_without_agr :
-    LandauClauseClass.fSubjunctive.hasOCWithAgr false = true := rfl
-
-/-- F-subjunctives lose OC when [+Agr] (the OC-NC generalization). -/
-theorem fSubjunctive_no_oc_with_agr :
-    LandauClauseClass.fSubjunctive.hasOCWithAgr true = false := rfl
-
-/-- Fully finite clauses never have OC. -/
-theorem finite_no_oc (agr : Bool) :
-    LandauClauseClass.finite.hasOCWithAgr agr = false := by
-  cases agr <;> rfl
-
--- ════════════════════════════════════════════════════════════════
--- § 6: Table (80) — Empirical Contrasts
--- ════════════════════════════════════════════════════════════════
-
-/-- The six empirical contrasts between the two types of control
-    (table (80) in [landau-2015]).
-
-    Each contrast shows a property that aligns with exactly one
-    control tier. The "✓" entries indicate the tier where the
-    property is available; the "*" entries indicate the tier where
-    it is blocked.
-
-    | Property               | Predicative | Logophoric |
-    |------------------------|:-----------:|:----------:|
-    | Inflected complement   |     ✓       |     *      |
-    | [−human] PRO           |     ✓       |     *      |
-    | Implicit control       |     *       |     ✓      |
-    | Control shift          |     *       |     ✓      |
-    | Partial control        |     *       |     ✓      |
-    | Split control          |     *       |     ✓      | -/
+/-- One row of the empirical contrast table (80) of [landau-2015]:
+    a property available under exactly one control tier. -/
 structure TTCContrast where
   name : String
   /-- Available under predicative control? -/
@@ -374,216 +55,36 @@ def ttcContrasts : List TTCContrast :=
   , ⟨"partial control",      false, true⟩
   , ⟨"split control",        false, true⟩ ]
 
-/-- Every contrast in table (80) is derived from `ControlTier` properties. -/
-theorem inflected_complement_predicative :
-    (agrBlocksControl .predicative = false) ∧ (agrBlocksControl .logophoric = true) :=
-  ⟨rfl, rfl⟩
-
-theorem nonhuman_pro_predicative :
-    ControlTier.allowsNonhumanPRO .predicative = true
-    ∧ ControlTier.allowsNonhumanPRO .logophoric = false := ⟨rfl, rfl⟩
-
-theorem implicit_control_logophoric :
-    ControlTier.allowsImplicitControl .predicative = false
-    ∧ ControlTier.allowsImplicitControl .logophoric = true := ⟨rfl, rfl⟩
-
-theorem control_shift_logophoric :
-    ControlTier.allowsControlShift .predicative = false
-    ∧ ControlTier.allowsControlShift .logophoric = true := ⟨rfl, rfl⟩
-
-theorem partial_control_logophoric :
-    ControlTier.allowsPartialControl .predicative = false
-    ∧ ControlTier.allowsPartialControl .logophoric = true := ⟨rfl, rfl⟩
-
-theorem split_control_logophoric :
-    ControlTier.allowsSplitControl .predicative = false
-    ∧ ControlTier.allowsSplitControl .logophoric = true := ⟨rfl, rfl⟩
-
-/-- The `ttcContrasts` data agrees with the derived `ControlTier` properties.
-    Each contrast's Bool pair matches the corresponding tier function. -/
+/-- The `ttcContrasts` data agrees with the derived `Control.Tier`
+    properties, row by row. -/
 theorem ttcContrasts_consistent :
-    -- Row 0: inflected complement ↔ ¬agrBlocksControl
     ((!agrBlocksControl .predicative) = (ttcContrasts[0]!.predicative))
     ∧ ((!agrBlocksControl .logophoric) = (ttcContrasts[0]!.logophoric))
-    -- Row 1: [−human] PRO ↔ allowsNonhumanPRO
-    ∧ (ControlTier.allowsNonhumanPRO .predicative = ttcContrasts[1]!.predicative)
-    ∧ (ControlTier.allowsNonhumanPRO .logophoric = ttcContrasts[1]!.logophoric)
-    -- Row 2: implicit control ↔ allowsImplicitControl
-    ∧ (ControlTier.allowsImplicitControl .predicative = ttcContrasts[2]!.predicative)
-    ∧ (ControlTier.allowsImplicitControl .logophoric = ttcContrasts[2]!.logophoric)
-    -- Row 3: control shift ↔ allowsControlShift
-    ∧ (ControlTier.allowsControlShift .predicative = ttcContrasts[3]!.predicative)
-    ∧ (ControlTier.allowsControlShift .logophoric = ttcContrasts[3]!.logophoric)
-    -- Row 4: partial control ↔ allowsPartialControl
-    ∧ (ControlTier.allowsPartialControl .predicative = ttcContrasts[4]!.predicative)
-    ∧ (ControlTier.allowsPartialControl .logophoric = ttcContrasts[4]!.logophoric)
-    -- Row 5: split control ↔ allowsSplitControl
-    ∧ (ControlTier.allowsSplitControl .predicative = ttcContrasts[5]!.predicative)
-    ∧ (ControlTier.allowsSplitControl .logophoric = ttcContrasts[5]!.logophoric) := by
+    ∧ (Tier.allowsNonhumanPRO .predicative = ttcContrasts[1]!.predicative)
+    ∧ (Tier.allowsNonhumanPRO .logophoric = ttcContrasts[1]!.logophoric)
+    ∧ (Tier.allowsImplicitControl .predicative = ttcContrasts[2]!.predicative)
+    ∧ (Tier.allowsImplicitControl .logophoric = ttcContrasts[2]!.logophoric)
+    ∧ (Tier.allowsControlShift .predicative = ttcContrasts[3]!.predicative)
+    ∧ (Tier.allowsControlShift .logophoric = ttcContrasts[3]!.logophoric)
+    ∧ (Tier.allowsPartialControl .predicative = ttcContrasts[4]!.predicative)
+    ∧ (Tier.allowsPartialControl .logophoric = ttcContrasts[4]!.logophoric)
+    ∧ (Tier.allowsSplitControl .predicative = ttcContrasts[5]!.predicative)
+    ∧ (Tier.allowsSplitControl .logophoric = ttcContrasts[5]!.logophoric) := by
   exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
-/-- All six contrasts are systematically derived from the TTC:
-    the first two are predicative-only, the last four are logophoric-only.
-    This is the central empirical prediction of the book. -/
-theorem all_contrasts_derived :
-    -- predicative-only properties
-    (agrBlocksControl .predicative = false ∧ agrBlocksControl .logophoric = true)
-    ∧ (ControlTier.allowsNonhumanPRO .predicative = true
-       ∧ ControlTier.allowsNonhumanPRO .logophoric = false)
-    -- logophoric-only properties
-    ∧ (ControlTier.allowsImplicitControl .predicative = false
-       ∧ ControlTier.allowsImplicitControl .logophoric = true)
-    ∧ (ControlTier.allowsControlShift .predicative = false
-       ∧ ControlTier.allowsControlShift .logophoric = true)
-    ∧ (ControlTier.allowsPartialControl .predicative = false
-       ∧ ControlTier.allowsPartialControl .logophoric = true)
-    ∧ (ControlTier.allowsSplitControl .predicative = false
-       ∧ ControlTier.allowsSplitControl .logophoric = true) :=
-  ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
-
-/-- EC verbs resist impersonal passives ((98) in [landau-2015]).
-
-    This is a direct consequence of (90): predicative control requires a
-    syntactically present controller, and impersonal passives suppress the
-    external argument. PC verbs allow impersonal passives because logophoric
-    control does not require a syntactically present controller.
-
-    Cross-linguistic evidence: Hebrew (99), German (96a, 100), Dutch (101),
-    Russian (102). -/
+/-- EC verbs resist impersonal passives ((98) in [landau-2015]): a
+    direct consequence of condition (90), since impersonal passives
+    suppress the external argument that predicative control needs.
+    Cross-linguistic evidence: Hebrew, German, Dutch, Russian. -/
 theorem ec_resists_impersonal_passives :
-    ControlTier.requiresSyntacticController .predicative = true
-    ∧ ControlTier.requiresSyntacticController .logophoric = false := ⟨rfl, rfl⟩
+    Tier.requiresSyntacticController .predicative = true
+    ∧ Tier.requiresSyntacticController .logophoric = false := ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 7: Cross-Linguistic BVA Syncretism
--- ════════════════════════════════════════════════════════════════
-
-/-- Cross-linguistic syncretism among BVA forms.
-
-    Records whether each BVA context uses the same form as the
-    referential (free) pronoun. "=" means syncretic with the referential
-    pronoun; "×" means a distinct form is used.
-
-    Used by [ostrove-2026] (table 92) and grounded in the minimal
-    pronoun approach of [kratzer-2009] and [safir-2014]. -/
-structure BVASyncretism where
-  language : String
-  /-- Is the reflexive form identical to the referential pronoun? -/
-  reflexiveEqReferential : Bool
-  /-- Is the controlled subject form identical to the referential pronoun? -/
-  controlledEqReferential : Bool
-  /-- Is the bound variable pronoun identical to the referential pronoun? -/
-  boundVarEqReferential : Bool
-  deriving DecidableEq, Repr
-
-/-- Derive syncretism from a vocabulary item inventory.
-
-    A context is syncretic with the referential pronoun iff its
-    realized form equals the elsewhere (pronoun) form — i.e., no
-    context-specific vocabulary item overrides the default. -/
-def syncretismFromInventory {Form : Type} [BEq Form]
-    (inv : MinPronInventory Form) (lang : String := "") : BVASyncretism where
-  language := lang
-  reflexiveEqReferential := inv.realize .locallyBound == inv.elsewhere
-  controlledEqReferential := inv.realize .controlledSubject == inv.elsewhere
-  boundVarEqReferential := inv.realize .boundVariable == inv.elsewhere
-
--- ════════════════════════════════════════════════════════════════
--- § 8: Copy Control Typology
--- ════════════════════════════════════════════════════════════════
-
-/-- Types of copy control ([polinsky-potsdam-2006]).
-
-    Copy control: the subject of a control clause is a phonologically
-    overt copy of its controller. Four subtypes are distinguished by
-    the nature of the copy and its distribution. -/
-inductive CopyControlType where
-  /-- Full copy: PRO is a full DP copy of the controller.
-      Attested in San Lucas Quievaní Zapotec, Copala Triqui. -/
-  | fullCopy
-  /-- Logophoric pronominal: PRO is a pronoun, occurs only in
-      attitude reports. Attested in Gengbe, Mandarin. -/
-  | logophoricPronominal
-  /-- Scope-sensitive pronominal: PRO is a pronoun, triggered by
-      scope-taking operators (focus). Attested in Italian, Hungarian,
-      European Portuguese. -/
-  | scopeSensitivePronominal
-  /-- Obligatory pronominal: PRO is an overt clitic pronoun in all
-      control contexts, showing the full OC signature. Attested in
-      SMPM, Gã, Büli. -/
-  | obligatoryPronominal
-  deriving DecidableEq, Repr
-
-/-- Properties distinguishing copy control types. -/
-structure CopyControlProfile where
-  controlType : CopyControlType
-  /-- Does the copy show the full OC signature (bound variable, exhaustive)? -/
-  showsOC : Bool
-  /-- Is the copy restricted to attitude report contexts? -/
-  attitudeOnly : Bool
-  /-- Does the copy require a scope-taking operator (focus, only)? -/
-  requiresScopeOperator : Bool
-  /-- Can the copy bear focus? -/
-  copyCanBearFocus : Bool
-  deriving DecidableEq, Repr
-
-/-- Profile for each copy control type. -/
-def copyControlProfile : CopyControlType → CopyControlProfile
-  | .fullCopy                 => ⟨.fullCopy,                 false, false, false, true⟩
-  | .logophoricPronominal     => ⟨.logophoricPronominal,     false, true,  false, true⟩
-  | .scopeSensitivePronominal => ⟨.scopeSensitivePronominal, false, false, true,  true⟩
-  | .obligatoryPronominal     => ⟨.obligatoryPronominal,     true,  false, false, false⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 9: Exempt Anaphors
--- ════════════════════════════════════════════════════════════════
-
-/-- Exempt anaphors ([pollard-sag-1992]): reflexive forms used
-    outside their canonical binding domain (Condition A domain).
-
-    Key constraint: exempt anaphors cannot have quantified antecedents. -/
-structure ExemptAnaphorProfile where
-  /-- Exempt anaphors available in this language -/
-  hasExemptAnaphors : Bool
-  /-- Can exempt anaphors have quantified antecedents? -/
-  allowsQuantifiedAntecedent : Bool
-  deriving DecidableEq, Repr
-
--- ════════════════════════════════════════════════════════════════
--- § 10: Control Derivation
--- ════════════════════════════════════════════════════════════════
-
-/-- The two analyses of obligatory control derivation. -/
-inductive ControlDerivation where
-  /-- Controller base-generated in matrix; PRO base-generated in
-      embedded clause. Two distinct syntactic positions, linked by
-      variable binding. -/
-  | baseGeneration
-  /-- Controller enters derivation in embedded subject position and
-      moves to matrix position. One DP, two copies. -/
-  | movement
-  deriving DecidableEq, Repr
-
-/-- Movement predicts exempt anaphors are UNAVAILABLE with quantified
-    controllers. Base-generation predicts they ARE available. -/
-def predictsExemptWithQuantifiedController : ControlDerivation → Bool
-  | .baseGeneration => true
-  | .movement       => false
-
--- ════════════════════════════════════════════════════════════════
--- § 11: De Se / De Te in Object Control (table (36))
--- ════════════════════════════════════════════════════════════════
+/-! ### De se / de te in object control (table (36)) -/
 
 /-- The two logophoric readings of OC PRO under attitude predicates
-    (table (36) in [landau-2015]).
-
-    Under logophoric control, PRO is bound by a projected coordinate
-    of the embedded context of evaluation. Which coordinate is
-    projected depends on the object control verb subclass:
-    - Psychological verbs (*convince*, *persuade*, *tempt*) project
-      the AUTHOR coordinate → obligatory *de se*
-    - Communicative verbs (*tell*, *ask*, *recommend*) project
-      the ADDRESSEE coordinate → obligatory *de te* -/
+    (table (36) of [landau-2015]): which coordinate of the embedded
+    context is projected depends on the object control verb subclass. -/
 inductive DeSeReading where
   /-- PRO = AUTHOR(i'): attitude holder's identification of self -/
   | deSe
@@ -599,8 +100,7 @@ inductive ObjectControlSubclass where
   | communicative
   deriving DecidableEq, Repr
 
-/-- Map object control subclass to its logophoric reading.
-    Psychological verbs bind the AUTHOR coordinate (*de se*);
+/-- Psychological verbs bind the AUTHOR coordinate (*de se*);
     communicative verbs bind the ADDRESSEE coordinate (*de te*). -/
 def objectControlReading : ObjectControlSubclass → DeSeReading
   | .psychological => .deSe
@@ -612,30 +112,20 @@ theorem psychological_deSe :
 theorem communicative_deTe :
     objectControlReading .communicative = .deTe := rfl
 
--- ════════════════════════════════════════════════════════════════
--- § 12: Derived Landau Class from Verb
--- ════════════════════════════════════════════════════════════════
+/-! ### Derived Landau class from Verb -/
 
-/-- Derive [landau-2015]'s predicate class from Verb fields.
+/-- Derive [landau-2015]'s predicate class from Verb fields — a bridge
+    from Fragment verb entries to the TTC deriving the classification
+    from existing semantic fields rather than storing it independently.
+    Returns `none` when the classification cannot be determined from the
+    available fields (e.g., `try` has no `implicative`, `attitude`, or
+    `cosType`).
 
-    This creates a bridge from Fragment verb entries to the TTC by
-    deriving the predicate classification from existing semantic fields
-    rather than storing it independently.
-
-    Returns `none` when the classification cannot be determined from
-    the available fields (e.g., `try` has no `implicative`,
-    `attitude`, or `cosType`).
-
-    Mapping:
-    - `cosType` present → `.aspectual` (begin, stop, continue, ...)
-    - `implicative` present → `.implicative` (manage, fail, ...)
-    - `causative` present → `.implicative` (force, cause — implicative
-      causatives in Landau's (4a))
-    - `factivePresup` and attitude → `.factive` (regret, know, ...)
-    - `attitude.doxastic` → `.propositional` (believe, think, ...)
-    - `attitude.preferential` → `.desiderative` (want, hope, ...)
-    - `takesQuestionBase` without attitude → `.interrogative` (wonder, ask) -/
-def derivedLandauClass (v : Verb) : Option LandauPredicateClass :=
+    Mapping: `cosType` → aspectual; `implicative`/`causative` →
+    implicative; `factivePresup` → factive; question-embedding without
+    attitude → interrogative; doxastic → propositional; preferential →
+    desiderative. -/
+def derivedLandauClass (v : Verb) : Option PredicateClass :=
   if v.cosType.isSome then some .aspectual
   else if v.implicative.isSome then some .implicative
   else if v.causative.isSome then some .implicative
@@ -646,28 +136,20 @@ def derivedLandauClass (v : Verb) : Option LandauPredicateClass :=
     | some (.preferential _) => some .desiderative
     | none                   => none
 
-/-- Derive control tier from Verb fields.
-
-    A verb induces logophoric control iff it selects an attitude
-    complement — detected by the presence of `attitude`,
-    `factivePresup`, or `takesQuestionBase`. Otherwise it induces
-    predicative control.
-
-    Returns `none` for verbs that are not control verbs. -/
-def derivedControlTier (v : Verb) : Option ControlTier :=
+/-- Derive control tier from Verb fields: a control verb induces
+    logophoric control iff it selects an attitude complement (detected
+    via `attitude`, `factivePresup`, or `takesQuestionBase`); otherwise
+    predicative. Returns `none` for non-control verbs. -/
+def derivedControlTier (v : Verb) : Option Tier :=
   if v.controlType == ControlType.none && v.altControlType == ControlType.none then Option.none
   else match derivedLandauClass v with
-    | some cls => some cls.controlTier
+    | some cls => some cls.tier
     | none =>
-      -- Fallback: if we can't determine the Landau class but the verb
-      -- is a control verb, check for attitude markers directly
       if v.attitude.isSome || v.factivePresup || v.takesQuestionBase
       then some .logophoric
       else some .predicative
 
--- ════════════════════════════════════════════════════════════════
--- § 13: Per-Verb Verification Theorems
--- ════════════════════════════════════════════════════════════════
+/-! ### Per-verb verification -/
 
 section VerbVerification
 open English.Predicates.Verbal
@@ -726,9 +208,8 @@ theorem hope_desiderative :
 theorem promise_desiderative :
     derivedLandauClass promise.toVerb = some .desiderative := rfl
 
-/-- "persuade" (preferential attitude, object control) → desiderative → logophoric.
-    Previously unclassified; fixed by adding `attitude` per
-    [landau-2015] table (36). -/
+/-- "persuade" (preferential attitude, object control) → desiderative →
+    logophoric, per [landau-2015] table (36). -/
 theorem persuade_desiderative :
     derivedLandauClass persuade.toVerb = some .desiderative := rfl
 
@@ -755,8 +236,8 @@ theorem wonder_interrogative :
 -- Negative test: verbs that should NOT be classifiable
 
 /-- "try" has no cosType, implicative, causative, factivePresup,
-    takesQuestionBase, or attitude. It cannot be classified by
-    `derivedLandauClass`. This is correct: "try" is not implicative (trying
+    takesQuestionBase, or attitude, so `derivedLandauClass` cannot
+    classify it. This is correct: "try" is not implicative (trying
     doesn't entail succeeding) and not clearly attitudinal. -/
 theorem try_unclassifiable :
     derivedLandauClass try_.toVerb = none := rfl
@@ -764,58 +245,39 @@ theorem try_unclassifiable :
 -- Control tier verification: derived tier matches expected tier
 
 theorem stop_predicative_tier :
-    (derivedLandauClass stop.toVerb).map (·.controlTier) = some .predicative := rfl
+    (derivedLandauClass stop.toVerb).map (·.tier) = some .predicative := rfl
 
 theorem manage_predicative_tier :
-    (derivedLandauClass manage.toVerb).map (·.controlTier) = some .predicative := rfl
+    (derivedLandauClass manage.toVerb).map (·.tier) = some .predicative := rfl
 
 theorem want_logophoric_tier :
-    (derivedLandauClass want.toVerb).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass want.toVerb).map (·.tier) = some .logophoric := rfl
 
 theorem regret_logophoric_tier :
-    (derivedLandauClass regret.toVerb).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass regret.toVerb).map (·.tier) = some .logophoric := rfl
 
 theorem believe_logophoric_tier :
-    (derivedLandauClass believe.toVerb).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass believe.toVerb).map (·.tier) = some .logophoric := rfl
 
 theorem wonder_logophoric_tier :
-    (derivedLandauClass wonder.toVerb).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass wonder.toVerb).map (·.tier) = some .logophoric := rfl
 
 theorem promise_logophoric_tier :
-    (derivedLandauClass promise.toVerb).map (·.controlTier) = some .logophoric := rfl
+    (derivedLandauClass promise.toVerb).map (·.tier) = some .logophoric := rfl
 
 theorem persuade_logophoric_tier :
-    (derivedLandauClass persuade.toVerb).map (·.controlTier) = some .logophoric := rfl
-
--- Object control de se/de te: per-verb bridge
-
-/-- "persuade" is a psychological object control verb → de se (table (36)). -/
-theorem persuade_psychological_deSe :
-    objectControlReading .psychological = .deSe := rfl
+    (derivedLandauClass persuade.toVerb).map (·.tier) = some .logophoric := rfl
 
 end VerbVerification
 
--- ════════════════════════════════════════════════════════════════
--- § 14: Noonan CTP → Landau Tier Bridge
--- ════════════════════════════════════════════════════════════════
+/-! ### Noonan CTP → Landau tier bridge -/
 
-/-- Map [noonan-2007]'s CTP classes to [landau-2015]'s
-    control tiers.
-
-    Noonan's twelve CTP classes partition into nonattitude (predicative)
-    and attitude (logophoric) under the TTC:
-
-    Predicative (nonattitude):
-    - modal, phasal, achievement, negative → Landau's (4a-d)
-
-    Logophoric (attitude):
-    - utterance, propAttitude, commentative, knowledge,
-      desiderative, manipulative → Landau's (5a-d)
-
-    Remaining:
-    - pretence: ambiguous (often nonattitude in control contexts)
-    - perception: typically does not take controlled complements -/
-def ctpToControlTier : CTPClass → Option ControlTier
+/-- Map [noonan-2007]'s CTP classes to [landau-2015]'s control tiers:
+    modal/phasal/achievement/negative are nonattitude (predicative);
+    utterance/propAttitude/commentative/knowledge/desiderative/
+    manipulative are attitude (logophoric); pretence is ambiguous and
+    perception typically takes no controlled complement. -/
+def ctpToControlTier : CTPClass → Option Tier
   | .modal        => some .predicative
   | .phasal       => some .predicative
   | .achievement  => some .predicative
@@ -826,23 +288,12 @@ def ctpToControlTier : CTPClass → Option ControlTier
   | .knowledge    => some .logophoric
   | .desiderative => some .logophoric
   | .manipulative => some .logophoric
-  | .pretence     => none   -- ambiguous
-  | .perception   => none   -- typically no control complement
+  | .pretence     => none
+  | .perception   => none
 
-/-- Predicative CTP classes map to predicative control. -/
-theorem phasal_predicative : ctpToControlTier .phasal = some .predicative := rfl
-theorem achievement_predicative : ctpToControlTier .achievement = some .predicative := rfl
-theorem modal_ctp_predicative : ctpToControlTier .modal = some .predicative := rfl
-
-/-- Attitude CTP classes map to logophoric control. -/
-theorem desiderative_ctp_logophoric : ctpToControlTier .desiderative = some .logophoric := rfl
-theorem propAttitude_logophoric : ctpToControlTier .propAttitude = some .logophoric := rfl
-theorem utterance_logophoric : ctpToControlTier .utterance = some .logophoric := rfl
-theorem manipulative_logophoric : ctpToControlTier .manipulative = some .logophoric := rfl
-
-/-- Map [noonan-2007]'s CTP classes to [landau-2015]'s
-    predicate classes (where the mapping is unambiguous). -/
-def ctpToLandauClass : CTPClass → Option LandauPredicateClass
+/-- Map [noonan-2007]'s CTP classes to [landau-2015]'s predicate classes
+    (where the mapping is unambiguous). -/
+def ctpToLandauClass : CTPClass → Option PredicateClass
   | .modal        => some .modal
   | .phasal       => some .aspectual
   | .achievement  => some .implicative
@@ -860,26 +311,18 @@ def ctpToLandauClass : CTPClass → Option LandauPredicateClass
 theorem ctp_tier_consistent (c : CTPClass)
     (hTier : (ctpToControlTier c).isSome = true)
     (hClass : (ctpToLandauClass c).isSome = true) :
-    ctpToControlTier c = (ctpToLandauClass c).map (·.controlTier) := by
-  cases c <;> simp_all [ctpToControlTier, ctpToLandauClass, LandauPredicateClass.controlTier]
+    ctpToControlTier c = (ctpToLandauClass c).map (·.tier) := by
+  cases c <;> simp_all [ctpToControlTier, ctpToLandauClass, PredicateClass.tier]
 
--- ════════════════════════════════════════════════════════════════
--- § Bridge to [noonan-2007]: equi-deletion → predicative tier
--- ════════════════════════════════════════════════════════════════
-
-/-! [noonan-2007]'s equi-deletion criterion (§2.1) and
-    [landau-2015]'s control tiers (Ch 2, table (119)) classify the
-    same English verbs by independent properties: equi-deletion via
-    coreferential subject erasure, predicative tier via complement
-    head-feature ([uD]). The two should agree on `manage`-class verbs:
-    `english_manage` is `.achievement` per Noonan, `hasEquiDeletion = true`,
-    and Landau's `ctpToControlTier .achievement = some .predicative` holds
-    by `rfl`. The bridge theorem makes the consilience kernel-checked. -/
+/-! [noonan-2007]'s equi-deletion criterion (§2.1) and [landau-2015]'s
+    control tiers classify the same English verbs by independent
+    properties; the bridge theorem makes the consilience kernel-checked,
+    witnessed by `manage`. -/
 
 open Data.Complementation.Noonan2007 (english_manage)
 
 /-- Cross-paper consilience: Noonan-equi on the achievement class
-    coincides with Landau's predicative tier. Witnessed by `manage`. -/
+    coincides with Landau's predicative tier. -/
 theorem manage_equi_implies_predicative :
     english_manage.hasEquiDeletion = true →
     ctpToControlTier english_manage.ctpClass = some .predicative := by

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -76,8 +76,8 @@ import Linglib.Fragments.Cantonese.ResultativeComplements
 §11 below documents divergences with HPSG (lexical-rule analysis of
 "you-skipping"), Dependency Grammar (no AspP, no ICH), CCG (forward
 composition), `Fragments/Italian/Modals.lean`'s [hacquard-2006]
-restructuring substrate, `Studies/Landau2015.lean`'s
-`ControlTier`, and `Syntax/Minimalist/Phase.lean`. The
+restructuring substrate, `Syntax/Control/Basic.lean`'s
+`Control.Tier`, and `Syntax/Minimalist/Phase.lean`. The
 [cinque-2006] vs. [wurmbrand-2001] restructuring rivalry is made
 explicit in §10 as a refutation theorem candidate.
 -/
@@ -447,7 +447,7 @@ have Studies-level Chinese formalizations they currently lack):
   productive next step but is deferred (the Italian file currently has
   no Wurmbrand-truncation bridge of its own).
 
-- **`Studies/Landau2015.lean`** has `ControlTier`
+- **`Syntax/Control/Basic.lean`** has `Control.Tier`
   (predicative vs logophoric) cross-classifying CTPs along an axis the
   [wurmbrand-lohninger-2023] ICH `ComplementClass`
   (event/situation/proposition) parallels. A bridge theorem

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -2,7 +2,9 @@ import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Fragments.Mixtec.SMPM.Basic
 import Linglib.Syntax.NullSubject
-import Linglib.Studies.Landau2015
+import Linglib.Syntax.Control.Basic
+import Linglib.Syntax.Control.CopyControl
+import Linglib.Studies.Allotey2021
 import Linglib.Features.Complementation
 
 /-!
@@ -58,7 +60,7 @@ infinitival classification.
 namespace Ostrove2026
 
 open Minimalist.MinimalPronoun
-open Landau2015
+open Control
 open Minimalist (InfinitivalTenseClass)
 open Mixtec.SMPM (EmbeddedClauseType clauseProperties)
 open NullSubject (ProDropProfile)
@@ -93,7 +95,10 @@ theorem finite_no_restructuring :
 -- § 2: OC Diagnostics (§4)
 -- ════════════════════════════════════════════════════════════════
 
-/-- OC signature for each SMPM clause type.
+/-- OC signature for each SMPM clause type, derived from
+    `clauseProperties.noncoreferentialSubject` via
+    `OCSignature.ofNoncoreferential` — the same derivation
+    `Allotey2021.gaOCSignature` uses for Gã.
 
     Untensed subjunctives show the full OC signature (§4):
     - Sloppy-only under VPE (33)
@@ -104,10 +109,8 @@ theorem finite_no_restructuring :
     these properties: they allow strict readings under VPE (30, 32),
     nonexhaustive binding (tensed subj., fn. 16), and non-local
     antecedents (43, 45). -/
-def smpmOCSignature : EmbeddedClauseType → OCSignature
-  | .untensedSubjunctive => ocFull
-  | .tensedSubjunctive   => ocNone
-  | .finiteEmbedded      => ocNone
+def smpmOCSignature (c : EmbeddedClauseType) : OCSignature :=
+  .ofNoncoreferential (clauseProperties c).noncoreferentialSubject
 
 theorem untensed_is_OC :
     (smpmOCSignature .untensedSubjunctive).isOC = true := rfl
@@ -172,7 +175,7 @@ theorem wurmbrand_propositional_no_correspondent :
     | C-subjunctive   | untensed subjunctive   | Yes |
     | F-subjunctive   | tensed subjunctive     | No  |
     | finite          | finite embedded        | No  | -/
-def landauToSMPM : LandauClauseClass → EmbeddedClauseType
+def landauToSMPM : Control.ClauseClass → EmbeddedClauseType
   | .cSubjunctive => .untensedSubjunctive
   | .fSubjunctive => .tensedSubjunctive
   | .finite       => .finiteEmbedded
@@ -188,7 +191,7 @@ def landauToSMPM : LandauClauseClass → EmbeddedClauseType
     [+Agr] blocks logophoric control. This is why SMPM tensed subjunctives
     (F-subjunctives with [+Agr]) show no OC despite structurally permitting
     logophoric control. -/
-def smpmLandauAgr : LandauClauseClass → Bool
+def smpmLandauAgr : Control.ClauseClass → Bool
   | .cSubjunctive => false
   | .fSubjunctive => true
   | .finite       => true
@@ -199,7 +202,7 @@ def smpmLandauAgr : LandauClauseClass → Bool
     - C-subjunctive [−Agr]: predicative OC (Agr-independent) → OC ✓
     - F-subjunctive [+Agr]: logophoric OC blocked by Agr → no OC ✓
     - Finite [+Agr]: no control tier → no OC ✓ -/
-theorem landau_predicts_control (c : LandauClauseClass) :
+theorem landau_predicts_control (c : Control.ClauseClass) :
     (smpmOCSignature (landauToSMPM c)).isOC = c.hasOCWithAgr (smpmLandauAgr c) := by
   cases c <;> rfl
 
@@ -419,14 +422,14 @@ theorem smpm_no_quantified_exempt :
 def smpmExemptAvailableWithQuantifiedController : Bool := true
 
 theorem movement_incorrectly_predicts :
-    predictsExemptWithQuantifiedController .movement = false := rfl
+    Derivation.predictsExemptWithQuantifiedController .movement = false := rfl
 
 theorem basegeneration_correctly_predicts :
-    predictsExemptWithQuantifiedController .baseGeneration = true := rfl
+    Derivation.predictsExemptWithQuantifiedController .baseGeneration = true := rfl
 
 theorem smpm_supports_basegeneration :
     smpmExemptAvailableWithQuantifiedController
-    = predictsExemptWithQuantifiedController .baseGeneration := rfl
+    = Derivation.predictsExemptWithQuantifiedController .baseGeneration := rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10: Implicational Universal (54)
@@ -527,5 +530,51 @@ theorem utterance_is_realis :
 
 theorem propAttitude_is_realis :
     ctpRealityStatus .propAttitude = .realis := rfl
+
+-- ════════════════════════════════════════════════════════════════
+-- § 12: Gã Joins the Typology ([allotey-2021])
+-- ════════════════════════════════════════════════════════════════
+
+/-! [ostrove-2026] groups SMPM with Gã ([allotey-2021]) and Büli
+    ([sulemana-2021]) as obligatory-pronominal copy control languages.
+    The Gã fragment and study predate this paper, so the cross-language
+    bridges live here (chronology: the later paper draws the
+    comparison), consuming `Studies/Allotey2021.lean`. -/
+
+/-- Gã instantiates obligatory pronominal copy control: the controlled
+    subject of an irrealis `ni`-clause is always an overt subject
+    proclitic showing the full OC signature ([allotey-2021]). -/
+def gaCopyControlType : CopyControlType := .obligatoryPronominal
+
+theorem ga_shows_oc :
+    (copyControlProfile gaCopyControlType).showsOC = true := rfl
+
+/-- Gã and SMPM occupy the same copy-control cell. -/
+theorem ga_same_copy_type_as_smpm :
+    gaCopyControlType = smpmCopyControlType := rfl
+
+/-- Gã syncretism row, derived from the Allotey2021 inventory:
+    reflexive ×, controlled =, bound variable = . -/
+def gaSyncretism : BVASyncretism :=
+  syncretismFromInventory Allotey2021.gaInventory "Gã"
+
+/-- Gã patterns with SMPM in the syncretism typology: distinct
+    reflexive, but controlled subjects and bound variables syncretic
+    with the referential pronoun. -/
+theorem ga_syncretism_matches_smpm :
+    (gaSyncretism.reflexiveEqReferential,
+     gaSyncretism.controlledEqReferential,
+     gaSyncretism.boundVarEqReferential)
+    = (smpmSyncretism.reflexiveEqReferential,
+       smpmSyncretism.controlledEqReferential,
+       smpmSyncretism.boundVarEqReferential) := rfl
+
+/-- Gã lands in the same cell of the pro-drop/overt-PRO typology as
+    SMPM and Büli: overt PRO, no *pro*-drop. -/
+theorem ga_classified :
+    Allotey2021.gaProfile.classify = .overtPRONoProDrop := by decide
+
+theorem ga_same_cell_as_smpm :
+    Allotey2021.gaProfile.classify = smpmProfile.classify := by decide
 
 end Ostrove2026

--- a/Linglib/Syntax/Control/Basic.lean
+++ b/Linglib/Syntax/Control/Basic.lean
@@ -1,0 +1,224 @@
+/-!
+# Control Theory: Tiers, Predicate Classes, Clause Classes
+
+The Two-Tiered Theory of Control ([landau-2015]): obligatory control in
+complement clauses divides into **predicative** control (nonattitude
+complements, syntactic predication) and **logophoric** control (attitude
+complements, predication + variable binding of a perspectival
+coordinate). The [landau-2004] finiteness scale classifies complement
+clauses, and the Feature Transmission asymmetry derives the OC-NC
+generalization — `[+Agr]` blocks logophoric but not predicative control.
+
+Originates with [landau-2015]; graduated to the theory layer as substrate
+for the paper-anchored control studies (`Studies/Landau2015.lean`,
+`Studies/Ostrove2026.lean`, `Studies/Chierchia1984.lean`,
+`Studies/Allotey2021.lean`).
+
+## Main definitions
+
+- `Control.Tier`: predicative vs. logophoric control
+- `Control.PredicateClass`: the eight predicate classes, mapped to tiers
+- `Control.ClauseClass`: the finiteness scale (C-subjunctive,
+  F-subjunctive, finite) with the Agr-sensitive `hasOCWithAgr`
+- `Control.ftAsymmetry`, `Control.agrBlocksControl`: the Feature
+  Transmission asymmetry and the OC-NC generalization derived from it
+-/
+
+namespace Control
+
+/-! ### The two tiers -/
+
+/-- The two tiers of obligatory control ([landau-2015]).
+
+    Predicative control (EC complements): selected by nonattitude
+    predicates; PRO moves to Spec,Fin and control is syntactic
+    predication; forces exhaustive control.
+
+    Logophoric control (PC complements): selected by attitude
+    predicates; C^OC projects a perspectival coordinate and control is
+    predication + variable binding; allows partial control and forces
+    *de se* interpretation. -/
+inductive Tier where
+  /-- Predicative control: nonattitude, predication only -/
+  | predicative
+  /-- Logophoric control: attitude, predication + variable binding -/
+  | logophoric
+  deriving DecidableEq, Repr
+
+/-- Logophoric control corresponds to attitude complements. -/
+def Tier.isAttitude : Tier → Bool
+  | .predicative => false
+  | .logophoric  => true
+
+/-- Condition on syntactic predication ([landau-2015] (90)): the argument
+    predicated of must be syntactically represented. Predicative control
+    therefore requires a syntactically present controller; the logophoric
+    AUTHOR/ADDRESSEE coordinate is discourse-anchored and does not. -/
+def Tier.requiresSyntacticController : Tier → Bool
+  | .predicative => true
+  | .logophoric  => false
+
+/-- [−human] PRO is compatible with predicative control only
+    ([landau-2015] (81)): the logophoric binder is mapped to the
+    AUTHOR/ADDRESSEE function, which is defined only for humans. -/
+def Tier.allowsNonhumanPRO : Tier → Bool
+  | .predicative => true
+  | .logophoric  => false
+
+/-! Partial control, obligatory *de se*, control shift, implicit control,
+    and split control are all available under logophoric control and
+    blocked under predicative control — one underlying mechanism
+    (variable binding of a perspectival coordinate), so each is derived
+    as `isAttitude` rather than restipulated. -/
+
+/-- Partial control is available only under logophoric control;
+    predicative control forces exhaustive control. -/
+def Tier.allowsPartialControl := Tier.isAttitude
+
+/-- Obligatory *de se* arises only under logophoric control. -/
+def Tier.obligatoryDeSe := Tier.isAttitude
+
+/-- Control shift is available only under logophoric control:
+    predicative control enters a biunique predication relation. -/
+def Tier.allowsControlShift := Tier.isAttitude
+
+/-- Implicit control is the complement of requiring a syntactic
+    controller (condition (90)). -/
+def Tier.allowsImplicitControl := Tier.isAttitude
+
+/-- Split control is available only under logophoric control. -/
+def Tier.allowsSplitControl := Tier.isAttitude
+
+/-- Implicit control derives from the condition on syntactic predication:
+    `allowsImplicitControl` is the negation of
+    `requiresSyntacticController`. -/
+theorem implicit_control_from_predication_condition (tier : Tier) :
+    tier.allowsImplicitControl = !tier.requiresSyntacticController := by
+  cases tier <;> rfl
+
+/-- [−human] PRO derives from the logophoric mechanism:
+    `allowsNonhumanPRO` is the negation of `isAttitude`. -/
+theorem nonhuman_pro_from_attitude (tier : Tier) :
+    tier.allowsNonhumanPRO = !tier.isAttitude := by
+  cases tier <;> rfl
+
+/-! ### Predicate classification -/
+
+/-- [landau-2015]'s predicate classification by complement type:
+    classes (4a–d) select untensed complements (nonattitude →
+    predicative control); classes (5a–d) select tensed complements
+    (attitude → logophoric control). -/
+inductive PredicateClass where
+  /-- avoid, dare, manage, remember, … (nonattitude) -/
+  | implicative
+  /-- begin, continue, finish, start, stop (nonattitude) -/
+  | aspectual
+  /-- have, is able, may, must, need, should (nonattitude) -/
+  | modal
+  /-- bold, crazy, kind, rude, silly, smart (nonattitude; adjectives) -/
+  | evaluative
+  /-- dislike, glad, hate, regret, sorry, … (attitude) -/
+  | factive
+  /-- affirm, believe, claim, declare, say, think (attitude) -/
+  | propositional
+  /-- agree, choose, decide, hope, intend, want, … (attitude) -/
+  | desiderative
+  /-- ask, guess, inquire, know, wonder (attitude) -/
+  | interrogative
+  deriving DecidableEq, Repr
+
+/-- Map predicate class to control tier. -/
+def PredicateClass.tier : PredicateClass → Tier
+  | .implicative | .aspectual | .modal | .evaluative => .predicative
+  | .factive | .propositional | .desiderative | .interrogative => .logophoric
+
+/-! ### The Feature Transmission asymmetry and the OC-NC generalization -/
+
+/-- The Feature Transmission asymmetry ([landau-2015] (60)): predication
+    is not contingent on feature matching between subject and predicate
+    (60a), while variable binding is contingent on feature matching
+    between binder and pronominal variable (60b). Independently
+    motivated: predication tolerates φ-mismatches (Icelandic quirky
+    constructions), variable binding requires φ-agreement ([heim-2008],
+    [kratzer-2009]). -/
+structure FeatureTransmissionAsymmetry where
+  /-- (60a): Predication does NOT require feature matching. -/
+  predicationContingentOnFeatureMatch : Bool
+  /-- (60b): Variable binding DOES require feature matching. -/
+  variableBindingContingentOnFeatureMatch : Bool
+
+/-- The empirically motivated Feature Transmission asymmetry. -/
+def ftAsymmetry : FeatureTransmissionAsymmetry where
+  predicationContingentOnFeatureMatch := false
+  variableBindingContingentOnFeatureMatch := true
+
+/-- The OC-NC generalization ([landau-2015] (70)): `[+Agr]` blocks
+    logophoric control but not predicative control — derived from the
+    Feature Transmission asymmetry, not stipulated: predication is not
+    contingent on feature matching (60a), variable binding is (60b). -/
+def agrBlocksControl : Tier → Bool
+  | .predicative => ftAsymmetry.predicationContingentOnFeatureMatch
+  | .logophoric  => ftAsymmetry.variableBindingContingentOnFeatureMatch
+
+/-- Predicative control survives in inflected complements. -/
+theorem predicative_survives_agr : agrBlocksControl .predicative = false := rfl
+
+/-- Logophoric control is blocked by inflected complements. -/
+theorem logophoric_blocked_by_agr : agrBlocksControl .logophoric = true := rfl
+
+/-! ### Clause classes -/
+
+/-- [landau-2004]'s finiteness scale, as recast in [landau-2015]: the
+    [±T] distinction is subsumed by attitude/nonattitude. C-subjunctives
+    (untensed) take predicative control; F-subjunctives (tensed,
+    `[−Agr]`) take logophoric control, blocked by `[+Agr]` per the OC-NC
+    generalization; fully finite clauses take no control. -/
+inductive ClauseClass where
+  /-- Untensed nonfinite; predicative control -/
+  | cSubjunctive
+  /-- Tensed nonfinite; logophoric control -/
+  | fSubjunctive
+  /-- Fully finite; no control -/
+  | finite
+  deriving DecidableEq, Repr
+
+/-- Map clause class to control tier (when control obtains). -/
+def ClauseClass.tier : ClauseClass → Option Tier
+  | .cSubjunctive => some .predicative
+  | .fSubjunctive => some .logophoric
+  | .finite       => none
+
+/-- Whether a clause class structurally permits OC (F-subjunctive OC is
+    logophoric and hence blocked only by `[+Agr]`; see `hasOCWithAgr`). -/
+def ClauseClass.permitsOC : ClauseClass → Bool
+  | .cSubjunctive => true
+  | .fSubjunctive => true
+  | .finite       => false
+
+/-- Whether OC is realized given Agr status: composes the clause class
+    with the OC-NC generalization. C-subjunctives are OC regardless of
+    Agr; F-subjunctives are OC only when `[−Agr]`; finite clauses never. -/
+def ClauseClass.hasOCWithAgr (c : ClauseClass) (hasAgr : Bool) : Bool :=
+  match c.tier with
+  | none => false
+  | some tier => c.permitsOC && (!hasAgr || !agrBlocksControl tier)
+
+/-- C-subjunctives have OC regardless of Agr. -/
+theorem cSubjunctive_oc_any_agr (agr : Bool) :
+    ClauseClass.cSubjunctive.hasOCWithAgr agr = true := by
+  cases agr <;> rfl
+
+/-- F-subjunctives have OC when `[−Agr]`. -/
+theorem fSubjunctive_oc_without_agr :
+    ClauseClass.fSubjunctive.hasOCWithAgr false = true := rfl
+
+/-- F-subjunctives lose OC when `[+Agr]` (the OC-NC generalization). -/
+theorem fSubjunctive_no_oc_with_agr :
+    ClauseClass.fSubjunctive.hasOCWithAgr true = false := rfl
+
+/-- Fully finite clauses never have OC. -/
+theorem finite_no_oc (agr : Bool) :
+    ClauseClass.finite.hasOCWithAgr agr = false := by
+  cases agr <;> rfl
+
+end Control

--- a/Linglib/Syntax/Control/CopyControl.lean
+++ b/Linglib/Syntax/Control/CopyControl.lean
@@ -1,0 +1,108 @@
+/-!
+# Copy Control and Control Derivation
+
+Copy control ([polinsky-potsdam-2006]): the subject of a control clause
+is a phonologically overt copy of its controller. The typology of copy
+types, the movement vs. base-generation opposition for deriving
+obligatory control, and the exempt-anaphor apparatus
+([pollard-sag-1992]) that adjudicates between them.
+
+Substrate for the overt-PRO studies (`Studies/Ostrove2026.lean`,
+`Studies/Allotey2021.lean`).
+
+## Main definitions
+
+- `Control.CopyControlType` / `Control.copyControlProfile`: the four
+  copy-control types and their distinguishing properties
+- `Control.Derivation`: base-generation vs. movement, with the
+  predictions (`predictsExemptWithQuantifiedController`,
+  `predictsEmbeddedLexicalCopy`) that separate them empirically
+- `Control.ExemptAnaphorProfile`: per-language exempt-anaphor facts
+-/
+
+namespace Control
+
+/-! ### Copy control typology -/
+
+/-- Types of copy control ([polinsky-potsdam-2006]), distinguished by
+    the nature of the overt copy and its distribution. -/
+inductive CopyControlType where
+  /-- Full copy: PRO is a full DP copy of the controller.
+      Attested in San Lucas Quiaviní Zapotec, Copala Triqui. -/
+  | fullCopy
+  /-- Logophoric pronominal: PRO is a pronoun, occurs only in
+      attitude reports. Attested in Gengbe, Mandarin. -/
+  | logophoricPronominal
+  /-- Scope-sensitive pronominal: PRO is a pronoun, triggered by
+      scope-taking operators (focus). Attested in Italian, Hungarian,
+      European Portuguese. -/
+  | scopeSensitivePronominal
+  /-- Obligatory pronominal: PRO is an overt pronoun in all control
+      contexts, showing the full OC signature. Attested in SMPM
+      ([ostrove-2026]), Gã ([allotey-2021]), Büli ([sulemana-2021]). -/
+  | obligatoryPronominal
+  deriving DecidableEq, Repr
+
+/-- Properties distinguishing copy control types. -/
+structure CopyControlProfile where
+  controlType : CopyControlType
+  /-- Does the copy show the full OC signature (bound variable, exhaustive)? -/
+  showsOC : Bool
+  /-- Is the copy restricted to attitude report contexts? -/
+  attitudeOnly : Bool
+  /-- Does the copy require a scope-taking operator (focus, only)? -/
+  requiresScopeOperator : Bool
+  /-- Can the copy bear focus? -/
+  copyCanBearFocus : Bool
+  deriving DecidableEq, Repr
+
+/-- Profile for each copy control type. -/
+def copyControlProfile : CopyControlType → CopyControlProfile
+  | .fullCopy                 => ⟨.fullCopy,                 false, false, false, true⟩
+  | .logophoricPronominal     => ⟨.logophoricPronominal,     false, true,  false, true⟩
+  | .scopeSensitivePronominal => ⟨.scopeSensitivePronominal, false, false, true,  true⟩
+  | .obligatoryPronominal     => ⟨.obligatoryPronominal,     true,  false, false, false⟩
+
+/-! ### Exempt anaphors -/
+
+/-- Exempt anaphors ([pollard-sag-1992]): reflexive forms used outside
+    their canonical binding (Condition A) domain. Key constraint: exempt
+    anaphors cannot have quantified antecedents. -/
+structure ExemptAnaphorProfile where
+  /-- Exempt anaphors available in this language -/
+  hasExemptAnaphors : Bool
+  /-- Can exempt anaphors have quantified antecedents? -/
+  allowsQuantifiedAntecedent : Bool
+  deriving DecidableEq, Repr
+
+/-! ### Control derivation -/
+
+/-- The two analyses of obligatory control derivation. -/
+inductive Derivation where
+  /-- Controller base-generated in matrix; PRO base-generated in the
+      embedded clause. Two distinct syntactic positions, linked by
+      variable binding. -/
+  | baseGeneration
+  /-- Controller enters the derivation in embedded subject position and
+      moves to the matrix position ([hornstein-1999]-style Movement
+      Theory of Control). One DP, two copies. -/
+  | movement
+  deriving DecidableEq, Repr
+
+/-- Movement predicts exempt anaphors are UNAVAILABLE with quantified
+    controllers (the embedded copy IS the quantifier); base-generation
+    predicts they ARE available (the embedded element is a genuine
+    pronoun). -/
+def Derivation.predictsExemptWithQuantifiedController : Derivation → Bool
+  | .baseGeneration => true
+  | .movement       => false
+
+/-- Under movement the overt embedded element is a copy of the
+    controller, so a lexical-DP controller predicts a lexical-DP
+    embedded copy; under base-generation the embedded element is an
+    independent pronoun and a lexical DP is not expected. -/
+def Derivation.predictsEmbeddedLexicalCopy : Derivation → Bool
+  | .baseGeneration => false
+  | .movement       => true
+
+end Control

--- a/Linglib/Syntax/Minimalist/MinimalPronoun.lean
+++ b/Linglib/Syntax/Minimalist/MinimalPronoun.lean
@@ -175,4 +175,44 @@ def ocNone : OCSignature where
 def OCSignature.isOC (sig : OCSignature) : Bool :=
   sig.controllerCodependent && sig.boundVariable
 
+/-- OC signature determined by whether a clause type licenses
+    noncoreferential embedded subjects: free reference means no OC;
+    obligatory coreference forces the full [landau-2013] signature.
+    The shared derivation behind the per-language OC tables of
+    [ostrove-2026] (SMPM) and [allotey-2021] (Gã). -/
+def OCSignature.ofNoncoreferential (noncoreferential : Bool) : OCSignature :=
+  if noncoreferential then ocNone else ocFull
+
+@[simp] theorem OCSignature.ofNoncoreferential_isOC (b : Bool) :
+    (ofNoncoreferential b).isOC = !b := by cases b <;> rfl
+
+-- ════════════════════════════════════════════════════════════════
+-- § 5: Cross-Linguistic BVA Syncretism
+-- ════════════════════════════════════════════════════════════════
+
+/-- Cross-linguistic syncretism among BVA forms: whether each BVA
+    context uses the same form as the referential (free) pronoun.
+    Used by [ostrove-2026]'s syncretism typology and grounded in the
+    minimal pronoun approach of [kratzer-2009] and [safir-2014]. -/
+structure BVASyncretism where
+  language : String
+  /-- Is the reflexive form identical to the referential pronoun? -/
+  reflexiveEqReferential : Bool
+  /-- Is the controlled subject form identical to the referential pronoun? -/
+  controlledEqReferential : Bool
+  /-- Is the bound variable pronoun identical to the referential pronoun? -/
+  boundVarEqReferential : Bool
+  deriving DecidableEq, Repr
+
+/-- Derive syncretism from a vocabulary item inventory: a context is
+    syncretic with the referential pronoun iff its realized form equals
+    the elsewhere (pronoun) form — no context-specific vocabulary item
+    overrides the default. -/
+def syncretismFromInventory {Form : Type} [BEq Form]
+    (inv : MinPronInventory Form) (lang : String := "") : BVASyncretism where
+  language := lang
+  reflexiveEqReferential := inv.realize .locallyBound == inv.elsewhere
+  controlledEqReferential := inv.realize .controlledSubject == inv.elsewhere
+  boundVarEqReferential := inv.realize .boundVariable == inv.elsewhere
+
 end Minimalist.MinimalPronoun

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -16924,6 +16924,21 @@
   role      = {cited},
   sources   = {}
 }
+% REF: Hornstein, N. (1999). Movement and control. Linguistic Inquiry 30(1), 69-96.
+%      The Movement Theory of Control; verified against Allotey (2021)'s reference
+%      list and the LI publication.
+@article{hornstein-1999,
+  author    = {Hornstein, Norbert},
+  year      = {1999},
+  title     = {Movement and Control},
+  journal   = {Linguistic Inquiry},
+  volume    = {30},
+  number    = {1},
+  pages     = {69--96},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Syntax/Control/CopyControl.lean}
+}
 @article{pollock-1989,
   author    = {Pollock, Jean-Yves},
   year      = {1989},


### PR DESCRIPTION
The TTC machinery in Studies/Landau2015.lean had become de-facto substrate (consumed by Ostrove2026, Chierchia1984, Allotey2021); this graduates it per the ≥2-consumer rule and wires the Gã↔SMPM unification the Ga audit queued.

- new `Syntax/Control/Basic.lean` (`Control.Tier`/`PredicateClass`/`ClauseClass`, FT asymmetry, OC-NC generalization) and `Syntax/Control/CopyControl.lean` (copy-control typology, `Control.Derivation` with its two discriminating predictions, exempt anaphors); `BVASyncretism` + `OCSignature.ofNoncoreferential` move into `MinimalPronoun`
- `smpmOCSignature` and `gaOCSignature` now both derive from `OCSignature.ofNoncoreferential` (previously stipulated in one file, derived in the other); Gã bridges authored in Ostrove2026 per chronology (`gaCopyControlType`, syncretism row, `ga_classified` same-cell theorems); Allotey2021 gains the base-generation/MTC-rejection wiring (`ga_supports_basegeneration`, paper §3.6.2)
- `Studies/Landau2015.lean` keeps the book's own content (table 80, de se/de te, English-fragment derivation, Noonan consilience); verified `hornstein-1999` bib entry added