### PR TITLE
feat(Studies/Allotey2021): derive LDA via Probe; implicative asymmetry

### DIFF
--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -26,87 +26,97 @@ inductive Control where
   deriving DecidableEq, Repr
 
 /-- A Gã complement-taking predicate: form, gloss, selected embedded
-    clause type, and (for `ni`-clause selectors) its control type;
-    `none` for finite-complement verbs that are not control verbs. -/
+    clause type, (for `ni`-clause selectors) its control type — `none`
+    for finite-complement verbs that are not control verbs — and its
+    positive-implicativity ([karttunen-1971]: does the matrix assertion
+    entail the complement event was realized?). Positive implicativity
+    has a grammatical reflex in Gã: it suppresses the embedded irrealis
+    marker ([allotey-2021]'s asymmetry, formalized in
+    `Studies/Allotey2021.lean`). -/
 structure CTP where
   form    : String
   gloss   : String
   selects : EmbeddedClauseType
   control : Option Control
+  /-- Positive (Karttunen) implicative: the complement is entailed
+      realized. `false` for negative implicatives (*forget*) and
+      non-implicatives alike. -/
+  positiveImplicative : Bool
   deriving Repr, DecidableEq
 
 /-! ### Subject-control verbs (irrealis `ni`-clause) -/
 
 /-- 'want' — subject control; `ni` optionally overt
     ([allotey-2021] ex 34: *Mi-i tao (ni) ma na bo* 'I want to see you'). -/
-def tao : CTP := ⟨"tao", "want", .irrealisNi, some .subject⟩
+def tao : CTP := ⟨"tao", "want", .irrealisNi, some .subject, false⟩
 
 /-- 'hope' (lit. 'face-place-upon') — subject control; `ni` obligatory
     ([allotey-2021] ex 35: *Mi hiɛ-kã-nɔ ni ma ya skul gbi ko*
     'I hope to go to school one day'). -/
-def hiekano : CTP := ⟨"hiɛ-kã-nɔ", "hope", .irrealisNi, some .subject⟩
+def hiekano : CTP := ⟨"hiɛ-kã-nɔ", "hope", .irrealisNi, some .subject, false⟩
 
 /-- 'forget' (lit. 'face-stop-upon') — subject control; `ni` obligatory
     ([allotey-2021] exx 37–38: *O hiɛ-kpa-nɔ ni o kɔ aspaatere lɛ*
     'You forgot to pick up the shoe'). -/
-def hiekpano : CTP := ⟨"hiɛ-kpa-nɔ", "forget", .irrealisNi, some .subject⟩
+def hiekpano : CTP := ⟨"hiɛ-kpa-nɔ", "forget", .irrealisNi, some .subject, false⟩
 
 /-- 'try' (lit. 'squeeze-my-face') — subject control; `ni` obligatory
     ([allotey-2021] ex 36: 'I tried to close the door'). -/
-def miamihie : CTP := ⟨"mia-mi-hiɛ", "try", .irrealisNi, some .subject⟩
+def miamihie : CTP := ⟨"mia-mi-hiɛ", "try", .irrealisNi, some .subject, false⟩
 
 /-- 'remember' — subject control ([allotey-2021] ex 43: *Mi kai ni ma he
     wolo* 'I remembered to buy a book'). With `akɛ` instead of `ni` the
     complement is finite 'remember that' (ex 89a); implicative in the
     control use, so the embedded irrealis marker is suppressed
     (*mi*, not *má*; the paper's §5.2.3 asymmetry). -/
-def kai : CTP := ⟨"kai", "remember", .irrealisNi, some .subject⟩
+def kai : CTP := ⟨"kai", "remember", .irrealisNi, some .subject, true⟩
 
 /-- 'manage / be able to' — subject control; `ni` optionally overt
     ([allotey-2021] ex 39: 'The children managed to buy a home').
     Implicative like `kai`: the embedded irrealis marker is suppressed
     (ex 89b *mi/\*má*). -/
-def nye : CTP := ⟨"nyɛ", "manage", .irrealisNi, some .subject⟩
+def nye : CTP := ⟨"nyɛ", "manage", .irrealisNi, some .subject, true⟩
 
 /-- 'agree' — subject control ([allotey-2021] ex 52; ex 89c shows the
     embedded irrealis marker obligatory: *\*mi/má*). With `akɛ` it takes
     a finite subjunctive complement instead ('agree that…', ex 105). -/
-def kpleno : CTP := ⟨"kplɛnɔ", "agree", .irrealisNi, some .subject⟩
+def kpleno : CTP := ⟨"kplɛnɔ", "agree", .irrealisNi, some .subject, false⟩
 
 /-- 'plan / decide' — subject control ([allotey-2021] exx 89d, 106; the
     embedded irrealis marker is obligatory, and only `ni` — never `akɛ`
     or `kɛji` — introduces the complement). -/
-def kpang : CTP := ⟨"kpaŋ", "plan", .irrealisNi, some .subject⟩
+def kpang : CTP := ⟨"kpaŋ", "plan", .irrealisNi, some .subject, false⟩
 
 /-! ### Object-control verbs (irrealis `ni`-clause) -/
 
 /-- 'help' — object control ([allotey-2021] ex 54: *Mi wa Ama ni e-ya
     skul* 'I helped Ama to go to school'). -/
-def wa : CTP := ⟨"wa", "help", .irrealisNi, some .object⟩
+def wa : CTP := ⟨"wa", "help", .irrealisNi, some .object, false⟩
 
 /-- 'urge / encourage' — object control ([allotey-2021] ex 55). -/
-def kenya : CTP := ⟨"kenya", "urge", .irrealisNi, some .object⟩
+def kenya : CTP := ⟨"kenya", "urge", .irrealisNi, some .object, false⟩
 
-/-- 'force' — object control ([allotey-2021] ex 56). -/
-def dai : CTP := ⟨"dai", "force", .irrealisNi, some .object⟩
+/-- 'force' — object control ([allotey-2021] ex 56); coercive
+    causatives are positive implicatives ([karttunen-1971]). -/
+def dai : CTP := ⟨"dai", "force", .irrealisNi, some .object, true⟩
 
 /-- 'persuade / coax / deceive' (context-dependent, the paper's fn 4) —
     object control ([allotey-2021] exx 57–58). -/
-def laka : CTP := ⟨"laka", "persuade", .irrealisNi, some .object⟩
+def laka : CTP := ⟨"laka", "persuade", .irrealisNi, some .object, false⟩
 
 /-- 'ask' — object control ([allotey-2021] ex 59: 'I asked Ayele to
     tell me a story'). -/
-def bi : CTP := ⟨"bi", "ask", .irrealisNi, some .object⟩
+def bi : CTP := ⟨"bi", "ask", .irrealisNi, some .object, false⟩
 
 /-! ### Finite-complement verbs (`akɛ`- and `kɛji`-clauses) -/
 
 /-- 'say' — utterance verb, finite `akɛ`-clause ([allotey-2021]
     exx 47–49: *Jojo kɛɛ akɛ …* 'Jojo said that …'). -/
-def kee : CTP := ⟨"kɛɛ", "say", .finiteAke, none⟩
+def kee : CTP := ⟨"kɛɛ", "say", .finiteAke, none, false⟩
 
 /-- 'know' — selects a finite `kɛji`-clause for if/whether complements
     ([allotey-2021] exx 104, 108: 'know if they will be coming',
     'doesn't know whether you or he bought the book'). -/
-def le : CTP := ⟨"le", "know", .finiteKeji, none⟩
+def le : CTP := ⟨"le", "know", .finiteKeji, none, false⟩
 
 end Ga

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -3,6 +3,7 @@ import Linglib.Fragments.Ga.Predicates
 import Linglib.Syntax.NullSubject
 import Linglib.Syntax.Control.Basic
 import Linglib.Syntax.Control.CopyControl
+import Linglib.Syntax.Minimalist.Probe.Basic
 
 /-!
 # Allotey (2021): Overt Pronouns of Infinitival Predicates of Gã
@@ -123,6 +124,30 @@ theorem oc_determined_by_clause_type (c : CTP) :
 theorem irrealisNi_forces_coreference :
     (clauseProperties .irrealisNi).noncoreferentialSubject = false := rfl
 
+/-! ### The irrealis marker under implicative verbs -/
+
+/-- [allotey-2021] §5.2.3: the irrealis marker `á` on the embedded
+    pronoun is absent under positive implicative verbs — their
+    complements are entailed realized ([karttunen-1971]), incompatible
+    with irrealis marking — and present otherwise. Rows record (verb,
+    whether the embedded pronoun carries the marker): *kai* 'remember'
+    and *nyɛ* 'manage' suppress it (exx 89a–b, *mi/\*má*), *kplɛnɔ*
+    'agree' and *kpaŋ* 'plan' require it (exx 89c–d, *\*mi/má*), and
+    negative-implicative *hiɛ-kpa-nɔ* 'forget' — whose complement is
+    entailed UNrealized — carries it (exx 102–103, *ó/é*). -/
+def irrealisMarkerData : List (Ga.CTP × Bool) :=
+  [ (Ga.kai,      false)
+  , (Ga.nye,      false)
+  , (Ga.kpleno,   true)
+  , (Ga.kpang,    true)
+  , (Ga.hiekpano, true) ]
+
+/-- The marker's distribution follows from the fragment's implicativity
+    classification: the embedded irrealis marker appears exactly on the
+    complements of non-positive-implicative verbs. -/
+theorem irrealis_marker_iff_not_positive_implicative :
+    ∀ p ∈ irrealisMarkerData, p.2 = !p.1.positiveImplicative := by decide
+
 /-! ### Landau bridge -/
 
 /-- Map Gã clause types to [landau-2004]'s finiteness scale.
@@ -164,11 +189,11 @@ theorem landau_predicts_control (c : EmbeddedClauseType) :
 /-! ### Long-Distance Agree analysis (Allotey's syntactic mechanism) -/
 
 /-- Long Distance Agree configuration ([szabolcsi-2009]): a matrix probe
-    values an embedded goal's unvalued φ across a non-defective C. Folded
-    in from the former single-consumer `Minimalist/LongDistanceAgree.lean`.
-    The contentful dimension is `cIsDefectiveBlocker` — the cross-clausal
-    locality that the `Probe`/defective-intervention vocabulary
-    (`Studies/Halpert2019.lean`) derives rather than stipulates. -/
+    values an embedded goal's unvalued φ across a non-defective C. The
+    contentful dimension is `cIsDefectiveBlocker` — cross-clausal
+    locality, derived from the shared `Minimalist.Probe` search kernel
+    by `licenses_iff_agree` below (the same kernel
+    `Studies/Halpert2019.lean` runs defective intervention through). -/
 structure LDAConfig where
   /-- The probe (matrix v/T/Asp) carries valued φ-features. -/
   probeHasValuedPhi : Bool
@@ -199,6 +224,37 @@ def gaLDAConfig : LDAConfig where
 
 theorem ga_satisfies_LDA :
     LDAConfig.licenses gaLDAConfig = true := rfl
+
+/-- The two positions the matrix φ-probe searches in the LDA
+    configuration, in structural order: the intervening C head, then
+    the embedded subject pronoun. -/
+inductive LDAGoal where
+  | complementizer
+  | embeddedSubject
+  deriving DecidableEq, Repr
+
+/-- The LDA configuration as a `Minimalist.Probe`: a blocking C head is
+    a visible-but-inactive goal — it halts the search without valuing
+    (defective intervention, `Probe.agree_eq_none_of_inactive`); the
+    embedded subject is visible iff it carries unvalued φ and valuable
+    iff the probe has valued φ to transmit. -/
+def LDAConfig.probe (cfg : LDAConfig) : Minimalist.Probe LDAGoal where
+  vis
+    | .complementizer => cfg.cIsDefectiveBlocker
+    | .embeddedSubject => cfg.goalHasUnvaluedPhi
+  act
+    | .complementizer => false
+    | .embeddedSubject => cfg.probeHasValuedPhi
+
+/-- `LDAConfig.licenses` is not a stipulation: it coincides with the
+    canonical relativized search reaching the embedded subject across
+    the C head. -/
+theorem LDAConfig.licenses_iff_agree (cfg : LDAConfig) :
+    cfg.licenses = true ↔
+      cfg.probe.agree [.complementizer, .embeddedSubject]
+        = some .embeddedSubject := by
+  rcases cfg with ⟨p, g, c⟩
+  cases p <;> cases g <;> cases c <;> decide
 
 /-! ### Against the Movement Theory of Control -/
 


### PR DESCRIPTION
Final Ga-audit PR: ground the two remaining stipulations in shared substrate and the full paper.

- `LDAConfig.licenses_iff_agree`: LDA licensing coincides with the canonical `Minimalist.Probe` search reaching the embedded subject, with the blocking `ni` C head as a visible-but-inactive absorber (defective intervention) — the reconciliation `Probe/Basic.lean`'s TODO prescribes
- Allotey §5.2.3 formalized: CTP gains a consensus `positiveImplicative` field ([karttunen-1971]); the embedded irrealis marker's distribution (exx 89a–d, 102–103, incl. the negative-implicative 'forget' contrast) is proved to track it