### PR TITLE
refactor(Syntax/Control): diagnostic prediction table for Derivation

### DIFF
--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -86,8 +86,12 @@ theorem irrealis_marker_iff_not_positive_implicative :
 /-! ### Landau bridge
 
 `ni`-clauses are C-subjunctives on [landau-2004]'s finiteness scale;
-`akɛ`/`kɛji`-clauses are fully finite. Gã has no F-subjunctive: no
-tensed-but-controlled clause class. -/
+`akɛ`/`kɛji`-clauses are fully finite. Gã has no F-subjunctive — no
+tensed-but-controlled clause class — so the entire control system rides
+on the single finiteness bit: OC status, LDA reachability, and Agr are
+each `isFinite` up to negation. Contrast SMPM
+(`Studies/Ostrove2026.lean`), whose tensed subjunctives pull TAM
+restriction and noncoreference apart. -/
 
 def gaToLandau : EmbeddedClauseType → Control.ClauseClass
   | .irrealisNi => .cSubjunctive
@@ -153,23 +157,20 @@ theorem lda_reaches_iff_oc (c : EmbeddedClauseType) :
 §3.6.2: under movement ([hornstein-1999]) the pronounced embedded
 element is a copy of the matrix DP, predicting an embedded lexical DP
 where Gã allows only a pronoun (exx 42b, 64) — so control is
-base-generated, the pole `Ostrove2026.smpm_supports_basegeneration`
+base-generated (refuting movement is free:
+`Derivation.eq_supportedBy_of_predicts` says the supported derivation
+is unique). The pole `Ostrove2026.smpm_supports_basegeneration`
 reaches via exempt anaphors. -/
-
-def gaControlDerivation : Derivation := .baseGeneration
 
 /-- Gã forbids embedded lexical-DP copies (exx 42b, 64). -/
 def gaEmbeddedLexicalCopyAvailable : Bool := false
 
-/-- The observed ban matches base-generation's prediction. -/
-theorem ga_supports_basegeneration :
-    gaEmbeddedLexicalCopyAvailable
-      = Derivation.predictsEmbeddedLexicalCopy gaControlDerivation := rfl
+/-- The derivation the lexical-copy observation supports. -/
+def gaControlDerivation : Derivation :=
+  Derivation.supportedBy .embeddedLexicalCopy gaEmbeddedLexicalCopyAvailable
 
-/-- The observed ban refutes movement's prediction. -/
-theorem ga_refutes_movement :
-    gaEmbeddedLexicalCopyAvailable
-      ≠ Derivation.predictsEmbeddedLexicalCopy .movement := by decide
+theorem ga_supports_basegeneration :
+    gaControlDerivation = .baseGeneration := rfl
 
 /-! ### Minimal pronoun inventory
 

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -421,15 +421,14 @@ theorem smpm_no_quantified_exempt :
     This matches the base-generation prediction. -/
 def smpmExemptAvailableWithQuantifiedController : Bool := true
 
-theorem movement_incorrectly_predicts :
-    Derivation.predictsExemptWithQuantifiedController .movement = false := rfl
-
-theorem basegeneration_correctly_predicts :
-    Derivation.predictsExemptWithQuantifiedController .baseGeneration = true := rfl
+/-- The derivation the exempt-anaphor observation supports
+    (`Derivation.eq_supportedBy_of_predicts`: it is the only one). -/
+def smpmControlDerivation : Derivation :=
+  Derivation.supportedBy .exemptAnaphorWithQuantifiedController
+    smpmExemptAvailableWithQuantifiedController
 
 theorem smpm_supports_basegeneration :
-    smpmExemptAvailableWithQuantifiedController
-    = Derivation.predictsExemptWithQuantifiedController .baseGeneration := rfl
+    smpmControlDerivation = .baseGeneration := rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10: Implicational Universal (54)

--- a/Linglib/Syntax/Control/CopyControl.lean
+++ b/Linglib/Syntax/Control/CopyControl.lean
@@ -15,8 +15,8 @@ Substrate for the overt-PRO studies (`Studies/Ostrove2026.lean`,
 - `Control.CopyControlType` / `Control.copyControlProfile`: the four
   copy-control types and their distinguishing properties
 - `Control.Derivation`: base-generation vs. movement, with the
-  predictions (`predictsExemptWithQuantifiedController`,
-  `predictsEmbeddedLexicalCopy`) that separate them empirically
+  diagnostic prediction table (`Derivation.predicts`) and the unique
+  derivation an observation supports (`Derivation.supportedBy`)
 - `Control.ExemptAnaphorProfile`: per-language exempt-anaphor facts
 -/
 
@@ -89,20 +89,43 @@ inductive Derivation where
   | movement
   deriving DecidableEq, Repr
 
-/-- Movement predicts exempt anaphors are UNAVAILABLE with quantified
-    controllers (the embedded copy IS the quantifier); base-generation
-    predicts they ARE available (the embedded element is a genuine
-    pronoun). -/
-def Derivation.predictsExemptWithQuantifiedController : Derivation → Bool
-  | .baseGeneration => true
-  | .movement       => false
+namespace Derivation
 
-/-- Under movement the overt embedded element is a copy of the
-    controller, so a lexical-DP controller predicts a lexical-DP
-    embedded copy; under base-generation the embedded element is an
-    independent pronoun and a lexical DP is not expected. -/
-def Derivation.predictsEmbeddedLexicalCopy : Derivation → Bool
-  | .baseGeneration => false
-  | .movement       => true
+/-- Observable diagnostics that separate the two derivations. -/
+inductive Diagnostic where
+  /-- Is an exempt anaphor available with a quantified controller? -/
+  | exemptAnaphorWithQuantifiedController
+  /-- Can the pronounced embedded element be a lexical-DP copy of the
+      controller? -/
+  | embeddedLexicalCopy
+  deriving DecidableEq, Repr
+
+/-- What each derivation predicts for each diagnostic. Under movement
+    the embedded element is a copy of the controller: a quantified
+    controller leaves no pronoun to antecede an exempt anaphor, and a
+    lexical-DP controller should reappear as a lexical-DP copy. Under
+    base-generation the embedded element is an independent pronoun. -/
+def predicts : Derivation → Diagnostic → Bool
+  | .baseGeneration, .exemptAnaphorWithQuantifiedController => true
+  | .baseGeneration, .embeddedLexicalCopy                   => false
+  | .movement,       .exemptAnaphorWithQuantifiedController => false
+  | .movement,       .embeddedLexicalCopy                   => true
+
+/-- The unique derivation consistent with an observed diagnostic value. -/
+def supportedBy (d : Diagnostic) (obs : Bool) : Derivation :=
+  if Derivation.baseGeneration.predicts d = obs then .baseGeneration else .movement
+
+/-- The supported derivation predicts the observation. -/
+@[simp] theorem predicts_supportedBy (d : Diagnostic) (obs : Bool) :
+    (supportedBy d obs).predicts d = obs := by
+  cases d <;> cases obs <;> rfl
+
+/-- Only the supported derivation predicts the observation: every
+    diagnostic discriminates between the two derivations. -/
+theorem eq_supportedBy_of_predicts {dv : Derivation} {d : Diagnostic}
+    {obs : Bool} (h : dv.predicts d = obs) : dv = supportedBy d obs := by
+  cases dv <;> cases d <;> subst h <;> rfl
+
+end Derivation
 
 end Control


### PR DESCRIPTION
Replaces `Derivation`'s two parallel prediction functions with one table: `Derivation.Diagnostic` (exempt-anaphor-with-quantified-controller, embedded-lexical-copy), `Derivation.predicts`, and `Derivation.supportedBy` with `eq_supportedBy_of_predicts` proving every diagnostic discriminates — an observation picks its derivation uniquely, so per-study refutation theorems come for free. Gã and SMPM both now derive `xControlDerivation := supportedBy …` from their observations instead of stipulating the pole.