### PR TITLE
refactor(Definiteness): rename determiner licensing to realization

### DIFF
--- a/Linglib/Features/Definiteness.lean
+++ b/Linglib/Features/Definiteness.lean
@@ -41,8 +41,8 @@ def demonstrativePresupType : DefPresupType := .familiarity
 
 /-- The kinds of nominal description an inventory can realize — the Frame-free
 skeleton of `Semantics.Definiteness.Description` (one case per constructor,
-payload erased). Lexical-availability questions (licensing, marking typology)
-depend only on this kind, so they are stated over it rather than over the
+payload erased). Inventory questions (realization, marking typology) depend
+only on this kind, so they are stated over it rather than over the
 entity/index-parameterized `Description`. -/
 inductive DescriptionKind where
   | bare

--- a/Linglib/Semantics/Definiteness/Description.lean
+++ b/Linglib/Semantics/Definiteness/Description.lean
@@ -118,8 +118,8 @@ namespace Description
 variable {E W : Type}
 
 /-- The Frame-free kind of a description: its constructor with payload erased
-    (`Features.Definiteness.DescriptionKind`). Lexical-availability questions
-    (`Determiner.licenses`, marking typology) depend only on this. -/
+    (`Features.Definiteness.DescriptionKind`). Inventory questions
+    (`Determiner.Realizes`, marking typology) depend only on this. -/
 def kind : Description E W → Features.Definiteness.DescriptionKind
   | .bare _           => .bare
   | .indefinite _     => .indefinite

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -145,16 +145,16 @@ def _root_.Article.toDescriptions (a : Article)
     (R : DenotGS E W .et) (idx : Nat) : List (Description E W) :=
   a.presupTypes.map (Description.ofPresupType · R idx)
 
-/-- An article licenses the kind of each of its own possible descriptions:
+/-- An article realizes the kind of each of its own possible descriptions:
 the denotation pipeline (`ofPresupType`) and the inventory pipeline
-(`Determiner.licenses`) coincide through `kind_ofPresupType` and
-`licenses_toKind`. -/
-theorem _root_.Determiner.licenses_of_mem_toDescriptions (a : Article)
+(`Determiner.Realizes`) coincide through `kind_ofPresupType` and
+`realizes_toKind`. -/
+theorem _root_.Determiner.realizes_of_mem_toDescriptions (a : Article)
     (R : DenotGS E W .et) (idx : Nat) (k : Description E W)
     (hk : k ∈ a.toDescriptions R idx) :
-    Determiner.licenses [.article a] k.kind := by
+    Determiner.Realizes [.article a] k.kind := by
   obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hk
-  rw [Description.kind_ofPresupType, Determiner.licenses_toKind]
+  rw [Description.kind_ofPresupType, Determiner.realizes_toKind]
   exact (Article.mem_presupTypes_iff_marksPresup a p).mp hp
 
 /-- An article's possible denotations: the `NominalDenot`s of its admissible
@@ -167,15 +167,15 @@ noncomputable def _root_.Article.denotations (a : Article)
   (a.toDescriptions R idx).map Description.denote
 
 /-- Every denotation of an article arises from a description whose kind the
-article licenses — the denotational pipeline and the licensing pipeline agree. -/
-theorem Article.denotations_licensed (a : Article)
+article realizes — the denotational pipeline and the inventory pipeline agree. -/
+theorem Article.denotations_realized (a : Article)
     (R : DenotGS E W .et) (idx : Nat)
     (nd : NominalDenot (Assignment E × SitAssignment W) PUnit E)
     (h : nd ∈ a.denotations R idx) :
     ∃ k : Description E W,
-      Determiner.licenses [.article a] k.kind ∧ nd = k.denote := by
+      Determiner.Realizes [.article a] k.kind ∧ nd = k.denote := by
   obtain ⟨k, hk, rfl⟩ := List.mem_map.mp h
-  exact ⟨k, Determiner.licenses_of_mem_toDescriptions a R idx k hk, rfl⟩
+  exact ⟨k, Determiner.realizes_of_mem_toDescriptions a R idx k hk, rfl⟩
 
 /-! ### The possessive determiner's denotation -/
 
@@ -205,12 +205,12 @@ theorem Possessive.denote_selector (p : Possessive)
     (p.denote R possessor rel).selector (g, gs) w =
       interpret (.possessive R possessor rel) g gs := rfl
 
-/-- A possessive determiner licenses the kind of its own denotation — the
-denotational pipeline and the licensing pipeline agree, parallel to
-`Article.denotations_licensed`. -/
-theorem Possessive.denote_licensed (p : Possessive)
+/-- A possessive determiner realizes the kind of its own denotation — the
+denotational pipeline and the inventory pipeline agree, parallel to
+`Article.denotations_realized`. -/
+theorem Possessive.denote_realized (p : Possessive)
     (R : DenotGS E W .et) (possessor : DenotGS E W .e) (rel : DenotGS E W .eet) :
-    Determiner.licenses [.possessive p] (Description.possessive R possessor rel).kind :=
+    Determiner.Realizes [.possessive p] (Description.possessive R possessor rel).kind :=
   ⟨.possessive p, List.mem_singleton_self _, trivial⟩
 
 /-! ### Unification with the possessive carrier API

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -100,31 +100,31 @@ theorem mandarin_cantonese_distinct_cells :
   rw [mandarin_jenks_cell, cantonese_jenks_cell]; decide
 
 -- ════════════════════════════════════════════════════════════════
--- §2: Inventory-Licensing Predictions (paper §3)
+-- §2: Inventory-Realization Predictions (paper §3)
 -- ════════════════════════════════════════════════════════════════
 
 variable {E W : Type}
 
-/-- Bare N is universally licensed by the article inventory; in
+/-- Bare N needs no determiner, so every inventory realizes it; in
     Mandarin it serves unique definites (paper §3.1 examples 10–11:
     `yueliang sheng shang lai le` 'the moon has risen';
     `Hufei he-wan-le tang` 'Hufei finished the soup';
     `Gou yao guo malu` 'the dog wants to cross the road'). -/
-theorem bare_licensed : Determiner.licenses mandarinDets .bare := trivial
+theorem bare_realized : Determiner.Realizes mandarinDets .bare := trivial
 
-/-- The anaphoric kind is licensed in Mandarin via the demonstrative
+/-- The anaphoric kind is realized in Mandarin via the demonstrative
     paradigm (paper §3.2: anaphoric definites surface as Dem-Clf-N
-    constructions). The licensing holds because the demonstrative
+    constructions). The realization holds because the demonstrative
     obligatorily expones a familiarity (anaphoric) use, so
     `Determiner.MarksPresup mandarinDets .familiarity`. -/
-theorem anaphoric_licensed : Determiner.licenses mandarinDets .anaphoric := by
+theorem anaphoric_realized : Determiner.Realizes mandarinDets .anaphoric := by
   decide
 
-/-- Mandarin demonstratives are licensed (the *na*/*zhe* paradigm —
+/-- Mandarin realizes the demonstrative kind (the *na*/*zhe* paradigm —
     paper fn. 8: speakers prefer *na* 'that' to *zhe* 'this' in most
     simple anaphoric environments). -/
-theorem demonstrative_licensed :
-    Determiner.licenses mandarinDets .demonstrative := by
+theorem demonstrative_realized :
+    Determiner.Realizes mandarinDets .demonstrative := by
   decide
 
 /-- A Mandarin bare definite and its `.unique` counterpart over the

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -661,8 +661,8 @@ records the morphological inventory directly (the `Article`/`Demonstrative`/
 
 This section verifies that the determiner-derived classifications agree
 with the parameters used in §7 for all four languages, and connects the
-licensing predicate `Determiner.licenses` to Moroney's central empirical
-finding: Shan licenses anaphoric definiteness without any anaphoric article. -/
+realization predicate `Determiner.Realizes` to Moroney's central empirical
+finding: Shan expresses anaphoric definiteness without any anaphoric article. -/
 
 open Intensional
 open Intensional.Variables
@@ -698,39 +698,39 @@ theorem mandarin_in_markedAnaphoric :
   Mandarin.Definiteness.marking
 
 /-- Moroney's central observation, stated against the determiner set:
-    Shan has *no* determiner that licenses the anaphoric kind, yet
+    Shan has *no* determiner realizing the anaphoric kind, yet
     expresses anaphoric definiteness through bare nouns and optional
-    demonstratives. The licensing predicate makes this morphologically
-    visible — `.anaphoric` is not licensed (no determiner expones a
+    demonstratives. The realization predicate makes this morphologically
+    visible — `.anaphoric` has no realizing form (no determiner expones a
     familiarity use). -/
-theorem shan_anaphoric_not_licensed_via_article :
-    ¬ Determiner.licenses shanDets .anaphoric := by
+theorem shan_anaphoric_not_realized_via_article :
+    ¬ Determiner.Realizes shanDets .anaphoric := by
   decide
 
-/-- Bare nominals are licensed for Shan (and every language) — this is the
-    morphological substrate for Moroney's analysis: Shan's anaphoric
-    definites surface as bare nouns. -/
-theorem shan_bare_licensed : Determiner.licenses shanDets .bare := trivial
+/-- Bare nominals need no determiner (realized in Shan and every language) —
+    this is the morphological substrate for Moroney's analysis: Shan's
+    anaphoric definites surface as bare nouns. -/
+theorem shan_bare_realized : Determiner.Realizes shanDets .bare := trivial
 
-/-- Demonstratives are licensed in Shan (the *nâj*/*nân* paradigm).
-    Combined with `shan_bare_licensed`, this gives the morphological
+/-- Shan realizes the demonstrative kind (the *nâj*/*nân* paradigm).
+    Combined with `shan_bare_realized`, this gives the morphological
     inventory of strategies Shan deploys for definite reference. -/
-theorem shan_demonstrative_licensed :
-    Determiner.licenses shanDets .demonstrative := by
+theorem shan_demonstrative_realized :
+    Determiner.Realizes shanDets .demonstrative := by
   decide
 
-/-- English licenses `.anaphoric` via the syncretic *the* (which expones a
+/-- English realizes `.anaphoric` via the syncretic *the* (which expones a
     familiarity use), *without* an independent strong article. Contrasts with
-    Shan (no licensing form at all) and German (independent strong form). -/
-theorem english_anaphoric_licensed_via_syncretism :
-    Determiner.licenses englishDets .anaphoric := by
+    Shan (no realizing form at all) and German (independent strong form). -/
+theorem english_anaphoric_realized_via_syncretism :
+    Determiner.Realizes englishDets .anaphoric := by
   decide
 
-/-- German licenses `.anaphoric` via its independent strong article (no
+/-- German realizes `.anaphoric` via its independent strong article (no
     syncretism). The unique vs anaphoric distinction is morphologically
     marked. -/
-theorem german_anaphoric_licensed_via_strong_article :
-    Determiner.licenses germanDets .anaphoric := by
+theorem german_anaphoric_realized_via_strong_article :
+    Determiner.Realizes germanDets .anaphoric := by
   decide
 
 /-- The English and Mandarin determiner sets both collapse to

--- a/Linglib/Syntax/Category/Determiner/Basic.lean
+++ b/Linglib/Syntax/Category/Determiner/Basic.lean
@@ -31,8 +31,8 @@ localized to a single declaration.
 * `Determiner.Entry` — a determiner occurrence in a language's inventory.
 * `Determiner.markingStrategy` — derives the [moroney-2021] 4-cell typology
   from a declared `List Determiner.Entry`.
-* `Determiner.licenses` — lexical availability: the declared inventory carries
-  a form for a given `DescriptionKind`.
+* `Determiner.Realizes` — morphological realization: the declared inventory
+  carries a form for a given `DescriptionKind`.
 
 ## Implementation notes
 
@@ -189,7 +189,7 @@ def markingStrategy (ds : List Entry) : DefMarkingStrategy :=
 def articleType (ds : List Entry) : ArticleType :=
   strategyToArticleType (markingStrategy ds)
 
-/-! ### Kind predicates over an inventory (for licensing) -/
+/-! ### Kind predicates over an inventory (for realization) -/
 
 /-- The occurrence is an indefinite article. -/
 def Entry.IsIndefiniteArticle : Entry → Prop
@@ -215,19 +215,22 @@ def Entry.IsPossessive : Entry → Prop
 instance : DecidablePred Entry.IsPossessive := fun e => by
   cases e <;> unfold Entry.IsPossessive <;> infer_instance
 
-/-! ### Licensing: lexical availability of description kinds -/
+/-! ### Realization: which description kinds the inventory has forms for -/
 
-/-- Does the declared determiner set have the surface form needed to realize a
-given kind of nominal description? Bare nominals are always licensed; unique and
-anaphoric definites need a determiner exponing the corresponding presupposition
-type (`MarksPresup`); indefinite/demonstrative/possessive need a determiner of
-that kind.
+/-- Morphological realization: the declared determiner inventory contains a
+form for the given kind of nominal description. Bare nominals need no
+determiner, so `.bare` is vacuously realized; unique and anaphoric definites
+need a determiner exponing the corresponding presupposition type
+(`MarksPresup`); indefinite/demonstrative/possessive need a determiner of that
+kind.
 
-`licenses` is *availability* — the inventory carries a form for this kind — not
-*choice*: which licensed form a context selects (type-shift blocking, Index!,
-Maximize Presupposition) is downstream pragmatics ([jenks-2018]'s competition
-principle, `Studies/Jenks2018.lean`). -/
-def licenses (ds : List Entry) : DescriptionKind → Prop
+This is inventory data, not syntactic licensing — no structural relation
+between a licensor and licensee is modeled — and not expressibility or
+felicity: a kind can be *expressed* without a determiner realizing it (Shan
+anaphoric definites surface as bare nouns, [moroney-2021]), and which realized
+form a context *selects* (type-shift blocking, Index!, Maximize Presupposition)
+is downstream pragmatics ([jenks-2018], `Studies/Jenks2018.lean`). -/
+def Realizes (ds : List Entry) : DescriptionKind → Prop
   | .bare          => True
   | .indefinite    => ∃ e ∈ ds, e.IsIndefiniteArticle
   | .unique        => MarksPresup ds .uniqueness
@@ -235,14 +238,14 @@ def licenses (ds : List Entry) : DescriptionKind → Prop
   | .demonstrative => ∃ e ∈ ds, e.IsDemonstrative
   | .possessive    => ∃ e ∈ ds, e.IsPossessive
 
-instance (ds : List Entry) : DecidablePred (licenses ds) := fun k => by
-  cases k <;> unfold licenses <;> infer_instance
+instance (ds : List Entry) : DecidablePred (Realizes ds) := fun k => by
+  cases k <;> unfold Realizes <;> infer_instance
 
-/-- Licensing an article strength's kind is exactly marking that strength: the
+/-- Realizing an article strength's kind is exactly marking that strength: the
 description-kind pipeline (`DefPresupType.toKind`) and the inventory pipeline
 (`MarksPresup`) coincide by construction. -/
-theorem licenses_toKind (ds : List Entry) (p : DefPresupType) :
-    licenses ds p.toKind ↔ MarksPresup ds p := by
+theorem realizes_toKind (ds : List Entry) (p : DefPresupType) :
+    Realizes ds p.toKind ↔ MarksPresup ds p := by
   cases p <;> exact Iff.rfl
 
 /-! ### Cell coverage: the derivation reproduces all four Moroney cells -/


### PR DESCRIPTION
`Determiner.licenses` → `Determiner.Realizes` (with `realizes_toKind`, `realizes_of_mem_toDescriptions`, `Article.denotations_realized`, study theorem renames): "licensing" is a syntactician's term for a structural licensor–licensee relation, which this inventory predicate does not model — it is morphological realization. Docstring now states the tri-distinction (realization ≠ syntactic licensing ≠ expressibility/choice); "licensed" in Jenks2018 survives only in the paper's own felicity sense. Capitalized `Realizes` matches the `MarksPresup`/`IsSyncretic` house pattern.