### PR TITLE
refactor(Definiteness): classifiers live on DescriptionKind

### DIFF
--- a/Linglib/Features/Definiteness.lean
+++ b/Linglib/Features/Definiteness.lean
@@ -61,6 +61,62 @@ def DefPresupType.toKind : DefPresupType → DescriptionKind
   | .uniqueness  => .unique
   | .familiarity => .anaphoric
 
+namespace DescriptionKind
+
+/-- The kind is a definite description (in the broad sense — uniqueness,
+familiarity, demonstrative, or possessive). -/
+def IsDefinite : DescriptionKind → Prop
+  | .bare | .indefinite => False
+  | .unique | .anaphoric | .demonstrative | .possessive => True
+
+instance : DecidablePred IsDefinite := fun k => by
+  cases k <;> unfold IsDefinite <;> infer_instance
+
+/-- The kind requires a discourse antecedent: anaphoric and demonstrative do;
+unique, possessive, bare, and indefinite do not. -/
+def IsAnaphoric : DescriptionKind → Prop
+  | .anaphoric | .demonstrative => True
+  | _ => False
+
+instance : DecidablePred IsAnaphoric := fun k => by
+  cases k <;> unfold IsAnaphoric <;> infer_instance
+
+/-- The kind binds a structural situation pronoun: Coppock–Beaver uniqueness
+and demonstratives do (resource situation for maximality and the deictic
+check); the other kinds do not. -/
+def UsesSituationPronoun : DescriptionKind → Prop
+  | .unique | .demonstrative => True
+  | _ => False
+
+instance : DecidablePred UsesSituationPronoun := fun k => by
+  cases k <;> unfold UsesSituationPronoun <;> infer_instance
+
+/-- The [schwarz-2009]–[schwarz-2013] presupposition type a kind expresses,
+where applicable. Bare and indefinite return `none` because they are not (in
+themselves) definites. -/
+def presupType : DescriptionKind → Option DefPresupType
+  | .bare | .indefinite         => none
+  | .unique | .possessive       => some .uniqueness
+  | .anaphoric | .demonstrative => some .familiarity
+
+/-- Definites are exactly the kinds with a presupposition type. -/
+theorem isDefinite_iff_presupType_isSome (k : DescriptionKind) :
+    k.IsDefinite ↔ k.presupType.isSome = true := by
+  cases k <;> simp [IsDefinite, presupType]
+
+/-- Anaphoric kinds all carry the familiarity presupposition type. -/
+theorem IsAnaphoric.presupType_familiarity {k : DescriptionKind}
+    (h : k.IsAnaphoric) : k.presupType = some .familiarity := by
+  cases k <;> simp_all [IsAnaphoric, presupType]
+
+/-- `toKind` recovers its strength through `presupType`: the round-trip of
+`DefPresupType.toKind`. -/
+theorem presupType_toKind (p : DefPresupType) :
+    p.toKind.presupType = some p := by
+  cases p <;> rfl
+
+end DescriptionKind
+
 -- ============================================================================
 -- §2: Article Types ([schwarz-2009])
 -- ============================================================================

--- a/Linglib/Semantics/Definiteness/Description.lean
+++ b/Linglib/Semantics/Definiteness/Description.lean
@@ -56,7 +56,8 @@ unified `Denot E W` machinery rather than ad-hoc `E → Bool` predicates.
   Shan/English/Latin/German fragments share the same enum.
 
 - **No semantic interpretation here.** This file only declares the type and
-  a handful of classification predicates. The interpretation function lives
+  its Frame-free `kind` projection (classification predicates live on
+  `Features.Definiteness.DescriptionKind`). The interpretation function lives
   in `Semantics/Definiteness/Interpret.lean`.
 -/
 
@@ -110,7 +111,7 @@ inductive Description (E W : Type) where
       (relation : DenotGS E W .eet)
 
 -- ════════════════════════════════════════════════════════════════
--- § Classification Predicates (derivable, no semantics yet)
+-- § The Frame-free kind and the strength section
 -- ════════════════════════════════════════════════════════════════
 
 namespace Description
@@ -128,68 +129,12 @@ def kind : Description E W → Features.Definiteness.DescriptionKind
   | .demonstrative .. => .demonstrative
   | .possessive ..    => .possessive
 
-/-- Is this a definite description (in the broad sense — uniqueness,
-    familiarity, demonstrative, or possessive)? -/
-def isDefinite : Description E W → Prop
-  | .bare _              => False
-  | .indefinite _        => False
-  | .unique _ _          => True
-  | .anaphoric _ _       => True
-  | .demonstrative ..    => True
-  | .possessive ..       => True
-
-instance : DecidablePred (@isDefinite E W) := fun n => by
-  cases n <;> unfold isDefinite <;> infer_instance
-
-/-- Does this description require a discourse antecedent? Anaphoric and
-    demonstrative do; unique/possessive/bare/indefinite do not. -/
-def isAnaphoric : Description E W → Prop
-  | .anaphoric _ _       => True
-  | .demonstrative ..    => True
-  | _                    => False
-
-instance : DecidablePred (@isAnaphoric E W) := fun n => by
-  cases n <;> unfold isAnaphoric <;> infer_instance
-
-/-- Does this description bind a structural situation pronoun? Coppock–Beaver
-    uniqueness and demonstratives do (resource situation for maximality and
-    deictic check); the other constructors do not. -/
-def usesSituationPronoun : Description E W → Bool
-  | .unique _ _          => true
-  | .demonstrative ..    => true
-  | _                    => false
-
-/-- Map each `Description` flavor to the [schwarz-2009]–[schwarz-2013]
-    presupposition type it expresses, where applicable. Bare and indefinite
-    return `none` because they are not (in themselves) definites. -/
-def expectedPresupType :
-    Description E W → Option Features.Definiteness.DefPresupType
-  | .bare _              => none
-  | .indefinite _        => none
-  | .unique _ _          => some .uniqueness
-  | .anaphoric _ _       => some .familiarity
-  | .demonstrative ..    => some .familiarity
-  | .possessive ..       => some .uniqueness
-
-/-- Definites are exactly those flavors with a non-`none` expected
-    presupposition type. By construction. -/
-theorem isDefinite_iff_expectedPresup_some (n : Description E W) :
-    n.isDefinite ↔ n.expectedPresupType.isSome = true := by
-  cases n <;> simp [isDefinite, expectedPresupType]
-
-/-- Anaphoric flavors all carry the familiarity presupposition type. -/
-theorem isAnaphoric_implies_familiarity (n : Description E W)
-    (h : n.isAnaphoric) :
-    n.expectedPresupType = some .familiarity := by
-  cases n <;> simp [isAnaphoric] at h
-  all_goals rfl
-
 /-- The definite description for a [schwarz-2009] presupposition type: the
     **weak** article (uniqueness) is `unique`, the **strong** article (familiarity)
-    is `anaphoric`. A section of `expectedPresupType` over the two article
-    strengths, so any item carrying a `DefPresupType` — a determiner, a definite,
+    is `anaphoric`. Any item carrying a `DefPresupType` — a determiner, a definite,
     or (per [patel-grosz-grosz-2017]) a personal/demonstrative pronoun —
-    denotes by `ofPresupType` and recovers its strength via `expectedPresupType`.
+    denotes by `ofPresupType` and recovers its strength through the Frame-free
+    kind (`kind_ofPresupType` + `DescriptionKind.presupType_toKind`).
 
     `idx` is the strong article's anaphoric/discourse index; for the weak article
     it fills the situation-pronoun slot, which `interpret` discards
@@ -199,12 +144,6 @@ def ofPresupType (p : Features.Definiteness.DefPresupType)
   match p with
   | .uniqueness  => .unique restrictor idx
   | .familiarity => .anaphoric restrictor idx
-
-/-- `ofPresupType` is a section of `expectedPresupType`: the strength round-trips. -/
-theorem expectedPresupType_ofPresupType
-    (p : Features.Definiteness.DefPresupType) (R : DenotGS E W .et) (idx : Nat) :
-    (ofPresupType p R idx).expectedPresupType = some p := by
-  cases p <;> rfl
 
 /-- `ofPresupType` constructs the description whose kind is the strength's kind
     (`DefPresupType.toKind`) — the Frame-aware and Frame-free realization maps

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -149,7 +149,7 @@ def _root_.Article.toDescriptions (a : Article)
 the denotation pipeline (`ofPresupType`) and the inventory pipeline
 (`Determiner.Inventory.Realizes`) coincide through `kind_ofPresupType` and
 `realizes_toKind`. -/
-theorem _root_.Determiner.realizes_of_mem_toDescriptions (a : Article)
+theorem _root_.Article.realizes_of_mem_toDescriptions (a : Article)
     (R : DenotGS E W .et) (idx : Nat) (k : Description E W)
     (hk : k ∈ a.toDescriptions R idx) :
     Determiner.Inventory.Realizes [.article a] k.kind := by
@@ -175,7 +175,7 @@ theorem Article.denotations_realized (a : Article)
     ∃ k : Description E W,
       Determiner.Inventory.Realizes [.article a] k.kind ∧ nd = k.denote := by
   obtain ⟨k, hk, rfl⟩ := List.mem_map.mp h
-  exact ⟨k, Determiner.realizes_of_mem_toDescriptions a R idx k hk, rfl⟩
+  exact ⟨k, Article.realizes_of_mem_toDescriptions a R idx k hk, rfl⟩
 
 /-! ### The possessive determiner's denotation -/
 

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -129,7 +129,7 @@ PER (*er*) the **weak** article (`Description.ofPresupType .uniqueness` = `.uniq
 "DEM" (*der*) the **strong** article (`…ofPresupType .familiarity` = `.anaphoric`,
 the weak description plus an anaphoric index). PG&G's "DEM = PER + index" is the
 weak/strong refinement `Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`;
-the strength round-trips through `expectedPresupType`. The extra layer is that index,
+the strength round-trips through `DescriptionKind.presupType`. The extra layer is that index,
 **not** spatial deixis (footnote 1) — *der* is a strong *personal* pronoun, not a
 separate type; genuine deictic demonstratives are `Description.demonstrative`.
 

--- a/Linglib/Studies/Hanink2021.lean
+++ b/Linglib/Studies/Hanink2021.lean
@@ -39,7 +39,7 @@ We additionally verify:
    extensions under different `gs`.
 2. **Index-record discipline** — the surface interpretation function
    ignores the index (it just records *which* pronoun is bound, the
-   `gs` does the work), but the `usesSituationPronoun` classifier
+   `gs` does the work), but the `DescriptionKind.UsesSituationPronoun` classifier
    correctly flags `unique` and `demonstrative` as the binders.
 3. **Anaphoric vs. unique split** — anaphoric definites consult the
    *entity* assignment (the antecedent index), so the situation
@@ -52,6 +52,7 @@ namespace Hanink2021
 open Intensional
 open Intensional.Variables
 open Semantics.Definiteness
+open Features.Definiteness (DescriptionKind)
 
 -- ════════════════════════════════════════════════════════════════
 -- §1: A two-room frame for the resource-situation diagnostic
@@ -164,18 +165,16 @@ theorem unique_index_does_not_alter_referent_directly :
       = interpret (E := Item) (W := Room) (.unique tableAtSit0 7) g₀ gsKitchen :=
   interpret_unique_index_irrelevant _ _ _ _ _
 
-/-- Among `Description` constructors, exactly `unique` and
-    `demonstrative` are flagged as binding a structural situation
-    pronoun. Anaphoric definites do not — they consult the entity
-    assignment for an antecedent, not the situation assignment. -/
-theorem situation_binders_classified
-    (R : DenotGS Item Room .et) (deictic : Features.Deixis.Feature) (sIdx d : Nat) :
-    (Description.unique R sIdx).usesSituationPronoun = true ∧
-    (Description.demonstrative R deictic sIdx d).usesSituationPronoun = true ∧
-    (Description.anaphoric R d).usesSituationPronoun = false ∧
-    (Description.bare R).usesSituationPronoun = false ∧
-    (Description.indefinite R).usesSituationPronoun = false := by
-  refine ⟨rfl, rfl, rfl, rfl, rfl⟩
+/-- Among description kinds, exactly `unique` and `demonstrative` are
+    flagged as binding a structural situation pronoun. Anaphoric definites
+    do not — they consult the entity assignment for an antecedent, not the
+    situation assignment. -/
+theorem situation_binders_classified :
+    DescriptionKind.unique.UsesSituationPronoun ∧
+    DescriptionKind.demonstrative.UsesSituationPronoun ∧
+    ¬ DescriptionKind.anaphoric.UsesSituationPronoun ∧
+    ¬ DescriptionKind.bare.UsesSituationPronoun ∧
+    ¬ DescriptionKind.indefinite.UsesSituationPronoun := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- §5: Anaphoric vs. unique — orthogonal binding

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -654,32 +654,15 @@ theorem shan_clf_is_atomization {α : Type*} [PartialOrder α]
 -- §14: Integration with the Semantics.Definiteness API
 -- ============================================================================
 
-/-! The §1–§7 derivation works at the level of `DefMarkingParams` (three
-booleans). The declared `Determiner.Entry` list is the upstream object — it
-records the morphological inventory directly (the `Article`/`Demonstrative`/
-`Possessive` occurrences) and *derives* the `DefMarkingParams` reading.
-
-This section verifies that the determiner-derived classifications agree
-with the parameters used in §7 for all four languages, and connects the
-realization predicate `Determiner.Inventory.Realizes` to Moroney's central empirical
-finding: Shan expresses anaphoric definiteness without any anaphoric article. -/
+/-! The declared `{Lang}.Determiners.inventory` is the canonical upstream
+object — §7's `derive_all_languages` computes each language's Moroney cell
+from it. This section connects the realization predicate
+`Determiner.Inventory.Realizes` to Moroney's central empirical finding: Shan
+expresses anaphoric definiteness without any anaphoric article. -/
 
 open Intensional
 open Intensional.Variables
 open Semantics.Definiteness (Description)
-
-/-- Inventory-derived strategies match §7's `derive_all_languages` for the
-    four Table 4.4 languages. The inventory subsumes the params layer
-    (the §7 `*Params` defs are now `inv.toMarkingParams` projections, so
-    the agreement theorem that previously lived here is `rfl`-tautological
-    and has been removed). -/
-theorem inventory_derives_all_languages :
-    English.Determiners.inventory.markingStrategy = .generallyMarked ∧
-    German.Determiners.inventory.markingStrategy = .bipartite ∧
-    Thai.Determiners.inventory.markingStrategy = .markedAnaphoric ∧
-    Shan.Determiners.inventory.markingStrategy = .unmarked :=
-  ⟨English.Determiners.marking, German.Definiteness.marking,
-   Thai.Definiteness.marking, Shan.Definiteness.marking⟩
 
 /-- Mandarin is in `.markedAnaphoric` — same cell as Thai. (Not part of
     Moroney's Table 4.4 but anchors the Jenks 2018 typological backdrop.) -/

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -34,7 +34,7 @@ The contributions are made *true by construction* on shared substrate:
   pick the same referent exactly when the indexed entity is the unique satisfier —
   off that, DEM is anaphoric in a way PER is not. Both denote via
   `Description.ofPresupType`, with the strength round-tripping through
-  `expectedPresupType` (`Description.expectedPresupType_ofPresupType`); the
+  the Frame-free kind (`Description.kind_ofPresupType`, `DescriptionKind.presupType_toKind`); the
   off-uniqueness **divergence** — DEM and PER picking *different* referents — is
   `der_er_can_diverge`, reusing [schwarz-2009] §8's two-satisfier scenario.
 * The **two-series ↔ two-article** correlation (§4) is read off the determiner

--- a/Linglib/Studies/Schwarz2009.lean
+++ b/Linglib/Studies/Schwarz2009.lean
@@ -37,7 +37,7 @@ The split is operationalized in the Core layer by:
   `.anaphoric` (strong) constructors, with different argument shapes
   (`.unique` carries a *situation* index for resource-situation binding;
   `.anaphoric` carries a *discourse* index for antecedent lookup).
-- **`Semantics.Definiteness.Description.expectedPresupType`** — projects each kind
+- **`Features.Definiteness.DescriptionKind.presupType`** — projects each kind
   to the [schwarz-2009] presupposition type it expresses.
 - **`Semantics.Definiteness.Determiner`** — the declared determiner set records the
   morphological inventory; `Determiner.Inventory.IsSyncretic` is the predicate that
@@ -96,25 +96,21 @@ theorem presup_types_exhaustive :
 
 variable {E W : Type}
 
-/-- The weak article (`.unique` in the Core sum type) projects to the
-    uniqueness presupposition. -/
-theorem unique_is_uniqueness (R : DenotGS E W .et) (sIdx : Nat) :
-    (Description.unique R sIdx).expectedPresupType = some .uniqueness := rfl
+/-- The weak article (the `unique` kind) projects to the uniqueness
+    presupposition. -/
+theorem unique_is_uniqueness :
+    DescriptionKind.unique.presupType = some .uniqueness := rfl
 
-/-- The strong article (`.anaphoric` in the Core sum type) projects to the
-    familiarity presupposition. -/
-theorem anaphoric_is_familiarity (R : DenotGS E W .et) (d : Nat) :
-    (Description.anaphoric R d).expectedPresupType = some .familiarity := rfl
+/-- The strong article (the `anaphoric` kind) projects to the familiarity
+    presupposition. -/
+theorem anaphoric_is_familiarity :
+    DescriptionKind.anaphoric.presupType = some .familiarity := rfl
 
 /-- The two articles project to distinct presupposition types — the
     central [schwarz-2009] contrast at the type level. -/
-theorem unique_anaphoric_presup_distinct
-    (R : DenotGS E W .et) (sIdx d : Nat) :
-    (Description.unique R sIdx).expectedPresupType ≠
-      (Description.anaphoric R d).expectedPresupType := by
-  rw [unique_is_uniqueness, anaphoric_is_familiarity]
-  intro h
-  exact two_presup_types_distinct (Option.some_inj.mp h)
+theorem unique_anaphoric_presup_distinct :
+    DescriptionKind.unique.presupType ≠ DescriptionKind.anaphoric.presupType := by
+  decide
 
 -- ════════════════════════════════════════════════════════════════
 -- §3: Different argument shapes — situation vs discourse binding
@@ -148,14 +144,13 @@ theorem strong_article_consults_entity_assignment
       (letI := Classical.dec (R g gs (g d))
        if R g gs (g d) then some (g d) else none) := rfl
 
-/-- The classifier `usesSituationPronoun` correctly flags the weak article
-    as a structural binder of the resource situation; the strong article
-    is not. This is the structural correlate of the [schwarz-2009]
+/-- The classifier `DescriptionKind.UsesSituationPronoun` correctly flags the
+    weak article as a structural binder of the resource situation; the strong
+    article is not. This is the structural correlate of the [schwarz-2009]
     claim that uniqueness is *situational* and familiarity is *anaphoric*. -/
-theorem situation_binding_classifies_articles
-    (R : DenotGS E W .et) (sIdx d : Nat) :
-    (Description.unique R sIdx).usesSituationPronoun = true ∧
-    (Description.anaphoric R d).usesSituationPronoun = false := ⟨rfl, rfl⟩
+theorem situation_binding_classifies_articles :
+    DescriptionKind.unique.UsesSituationPronoun ∧
+    ¬ DescriptionKind.anaphoric.UsesSituationPronoun := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- §4: Morphological correlate — German bipartite vs English syncretic
@@ -253,7 +248,7 @@ Table 4.4 for the parallel pattern with anaphoric definites):
     article forms.
 
     The article system (`articleSystem`) is *derived* from the language's
-    fragment-level `determiners`, not stipulated independently — the
+    fragment-level `Determiners.inventory`, not stipulated independently — the
     declared `Determiner.Entry` list is the single source of truth. -/
 structure DonkeyArticleDatum where
   language : String
@@ -262,31 +257,31 @@ structure DonkeyArticleDatum where
   form : String
   /-- Declared determiner set (single source of truth from which
       `articleSystem` is derived). -/
-  determiners : Determiner.Inventory
+  inventory : Determiner.Inventory
 
-/-- Schwarz `ArticleType` classification, derived from `determiners`. -/
+/-- Schwarz `ArticleType` classification, derived from `inventory`. -/
 def DonkeyArticleDatum.articleSystem (d : DonkeyArticleDatum) : ArticleType :=
-  d.determiners.articleType
+  d.inventory.articleType
 
 def germanDonkey : DonkeyArticleDatum :=
   { language := "German", isoCode := "deu"
     form := "strong article (von dem)"
-    determiners := German.Determiners.inventory }
+    inventory := German.Determiners.inventory }
 
 def thaiDonkey : DonkeyArticleDatum :=
   { language := "Thai", isoCode := "tha"
     form := "demonstrative"
-    determiners := Thai.Determiners.inventory }
+    inventory := Thai.Determiners.inventory }
 
 def mandarinDonkey : DonkeyArticleDatum :=
   { language := "Mandarin", isoCode := "cmn"
     form := "demonstrative"
-    determiners := Mandarin.Determiners.inventory }
+    inventory := Mandarin.Determiners.inventory }
 
 def shanDonkey : DonkeyArticleDatum :=
   { language := "Shan", isoCode := "shn"
     form := "bare noun"
-    determiners := Shan.Determiners.inventory }
+    inventory := Shan.Determiners.inventory }
 
 /-- All cross-linguistic donkey article data. -/
 def donkeyArticleData : List DonkeyArticleDatum :=


### PR DESCRIPTION
The classification predicates (`isDefinite`, `isAnaphoric`, `usesSituationPronoun`, `expectedPresupType`) were payload-blind but stated over `Description E W` — move them to `Features.Definiteness.DescriptionKind` as `IsDefinite`/`IsAnaphoric`/`UsesSituationPronoun` (now `Prop`, fixing a `Bool`-predicate) and `presupType`, leaving `Description.lean` with only the Frame-dependent core (type, `kind`, `ofPresupType`). Schwarz2009/Hanink2021 classifier theorems become binder-free `decide` facts. Also: delete Moroney §14's `inventory_derives_all_languages` (verbatim duplicate of §7's `derive_all_languages` after #1632) and its stale `DefMarkingParams` prose; rename `Determiner.realizes_of_mem_toDescriptions` → `Article.realizes_of_mem_toDescriptions`; rename witness-struct `determiners` fields to `inventory`.