### PR TITLE
refactor(Subregular/Function): upstream-polish LetterSubsequential

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -67,6 +67,7 @@ import Linglib.Core.Computability.ContextFreeGrammar.Pumping
 import Linglib.Core.Computability.ContextFreeGrammar.Tree
 import Linglib.Core.Computability.ContextFreeGrammar.Weighted
 import Linglib.Core.Computability.Lens
+import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.NonContextFree.AmBnCmDn
 import Linglib.Core.Computability.NonContextFree.AnBnCn
 import Linglib.Core.Computability.NonContextFree.AnBnCnDn

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -12,7 +12,7 @@ import Mathlib.Logic.Equiv.Defs
 A Mealy machine [mealy-1955] is a deterministic transducer which reads its input left to
 right and emits exactly one output symbol per input symbol, so the function it computes
 is length-preserving by construction. Output coordinate `i` of the run is the step
-output at the state reached after the length-`i` input prefix (`Mealy.run_getElem?`),
+output at the state reached after the length-`i` input prefix (`Mealy.getElem?_run`),
 so the output is prefix-determined at every coordinate.
 
 Note that this definition allows for machines with infinite states; a `Fintype`
@@ -21,17 +21,17 @@ instance must be supplied for true finite-state machines.
 ## Main definitions
 
 * `Mealy σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet `β`
-* `Mealy.run`: the function `List α → List β` computed by the machine
+* `Mealy.run`, `Mealy.runRight`: the left-to-right and right-to-left passes
 * `Mealy.ofFlag`: the one-bit machine tracking whether an earlier symbol satisfies `p`
 * `Mealy.transferEquiv`: transport of a machine along a state equivalence
 
 ## Main theorems
 
-* `Mealy.run_getElem?`: output coordinate `i` is the step output at the state reached
+* `Mealy.getElem?_run`: output coordinate `i` is the step output at the state reached
   after the length-`i` input prefix
-* `Mealy.ofFlag_run_getElem?`, `Mealy.ofFlag_run_reverse_getElem?`: each coordinate of
-  a flag machine sees the flag over its strict prefix (its strict suffix, when the
-  machine is run right to left)
+* `Mealy.getElem?_ofFlag_run`, `Mealy.getElem?_ofFlag_runRight`: each coordinate of a
+  flag machine sees the flag over its strict prefix (its strict suffix, for the
+  right-to-left pass)
 
 [UPSTREAM] candidate: `Mathlib.Computability.Mealy`.
 -/
@@ -55,17 +55,22 @@ namespace Mealy
 
 variable (T : Mealy σ α β)
 
-/-- State reached after consuming a prefix. -/
+/-- `T.stateAfter s x` is the state reached from `s` after consuming the input `x`. -/
 def stateAfter (s : σ) : List α → σ :=
   List.foldl (fun s x => (T.step s x).1) s
 
-/-- Run from a state: one output symbol per input symbol. -/
+/-- `T.runFrom s x` runs `T` on the input `x` starting from the state `s`, emitting one
+output symbol per input symbol. -/
 def runFrom : σ → List α → List β
   | _, [] => []
   | s, x :: xs => (T.step s x).2 :: runFrom (T.step s x).1 xs
 
-/-- Run from the initial state. -/
+/-- `T.run x` runs `T` on the input `x` starting from the state `T.initial`. -/
 def run : List α → List β := T.runFrom T.initial
+
+/-- `T.runRight x` runs `T` right-to-left: reverse the input, run, reverse the
+output. -/
+def runRight (xs : List α) : List β := (T.run xs.reverse).reverse
 
 @[simp] theorem runFrom_nil (s : σ) : T.runFrom s [] = [] := rfl
 @[simp] theorem runFrom_cons (s : σ) (x : α) (xs : List α) :
@@ -86,11 +91,17 @@ theorem stateAfter_append (s : σ) (xs ys : List α) :
 @[simp] theorem length_run (xs : List α) :
     (T.run xs).length = xs.length := T.length_runFrom T.initial xs
 
-/-- **The coordinate characterization**: output `i` is the step output at
-`(state after the prefix [0..i-1], input i)`. -/
-theorem runFrom_getElem? (s : σ) (xs : List α) (i : ℕ) :
+@[simp] theorem length_runRight (xs : List α) :
+    (T.runRight xs).length = xs.length := by simp [runRight]
+
+@[simp] theorem runRight_reverse (xs : List α) :
+    T.runRight xs.reverse = (T.run xs).reverse := by simp [runRight]
+
+/-- Output coordinate `i` of the run is the step output at the state reached after the
+first `i` input symbols. -/
+theorem getElem?_runFrom (s : σ) (xs : List α) (i : ℕ) :
     (T.runFrom s xs)[i]?
-      = (xs[i]?).map (fun x => (T.step (T.stateAfter s (xs.take i)) x).2) := by
+      = xs[i]?.map fun x => (T.step (T.stateAfter s (xs.take i)) x).2 := by
   induction xs generalizing s i with
   | nil => simp
   | cons x xs ih =>
@@ -98,18 +109,19 @@ theorem runFrom_getElem? (s : σ) (xs : List α) (i : ℕ) :
     | zero => simp
     | succ j => simp [ih, List.take_succ_cons]
 
-/-- The coordinate characterization from the initial state. -/
-theorem run_getElem? (xs : List α) (i : ℕ) :
+/-- Output coordinate `i` of `T.run` is the step output at the state reached after the
+first `i` input symbols. -/
+theorem getElem?_run (xs : List α) (i : ℕ) :
     (T.run xs)[i]?
-      = (xs[i]?).map (fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2) :=
-  T.runFrom_getElem? T.initial xs i
+      = xs[i]?.map fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2 :=
+  T.getElem?_runFrom T.initial xs i
 
 /-! ### Flag machines
 
 The recurring one-sided-trigger shape: the state is the one-bit "some earlier symbol
 satisfies `p`" flag, so `stateAfter` computes `List.any` and each output cell sees the
-flag over its strict prefix. Scanned right-to-left (reverse, run, reverse), the cell
-sees the flag over its strict suffix (`ofFlag_run_reverse_getElem?`). -/
+flag over its strict prefix. Under the right-to-left pass `runRight`, the cell sees the
+flag over its strict suffix (`getElem?_ofFlag_runRight`). -/
 
 variable (p : α → Bool) (out : Bool → α → β)
 
@@ -130,18 +142,20 @@ def ofFlag : Mealy Bool α β where
   | nil => simp
   | cons x xs ih => simp [ih, Bool.or_assoc]
 
-theorem ofFlag_run_getElem? (xs : List α) (i : ℕ) :
+/-- Each coordinate of a flag machine sees the flag over its strict prefix. -/
+theorem getElem?_ofFlag_run (xs : List α) (i : ℕ) :
     ((ofFlag p out).run xs)[i]? = xs[i]?.map fun a => out ((xs.take i).any p) a := by
-  simp [run_getElem?]
+  simp [getElem?_run]
 
-/-- Coordinates of a flag machine scanned right-to-left: cell `i` sees the flag over its
-strict suffix. -/
-theorem ofFlag_run_reverse_getElem? (xs : List α) (i : ℕ) :
-    (((ofFlag p out).run xs.reverse).reverse)[i]?
+/-- Each coordinate of a flag machine run right-to-left sees the flag over its strict
+suffix. -/
+theorem getElem?_ofFlag_runRight (xs : List α) (i : ℕ) :
+    ((ofFlag p out).runRight xs)[i]?
       = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
+  unfold runRight
   by_cases hi : i < xs.length
   · rw [List.getElem?_reverse (by simpa using hi),
-      (ofFlag p out).length_run, List.length_reverse, ofFlag_run_getElem?,
+      (ofFlag p out).length_run, List.length_reverse, getElem?_ofFlag_run,
       List.getElem?_reverse (by omega),
       show xs.length - 1 - (xs.length - 1 - i) = i from by omega,
       List.take_reverse, show xs.length - (xs.length - 1 - i) = i + 1 from by omega,
@@ -153,9 +167,10 @@ theorem ofFlag_run_reverse_getElem? (xs : List α) (i : ℕ) :
 
 variable {τ : Type*}
 
-/-- Transfer a `Mealy` along a state-space equivalence `σ ≃ τ`, preserving `run`. The
-use case is bringing a `Type*` finite state down to `Fin (Fintype.card σ) : Type 0` so
-a universe-polymorphic machine can witness a `Type 0`-state existential. -/
+/-- `T.transferEquiv e` transports `T` along the state equivalence `e`, preserving
+`run`. The use case is bringing a `Type*` finite state down to
+`Fin (Fintype.card σ) : Type 0` so a universe-polymorphic machine can witness a
+`Type 0`-state existential. -/
 def transferEquiv (e : σ ≃ τ) : Mealy τ α β where
   initial := e T.initial
   step t x := (e (T.step (e.symm t) x).1, (T.step (e.symm t) x).2)

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.Basic
+import Mathlib.Logic.Equiv.Defs
+
+/-!
+# Mealy machines
+
+A Mealy machine [mealy-1955] is a deterministic transducer which reads its input left to
+right and emits exactly one output symbol per input symbol, so the function it computes
+is length-preserving by construction. Output coordinate `i` of the run is the step
+output at the state reached after the length-`i` input prefix (`Mealy.run_getElem?`),
+so the output is prefix-determined at every coordinate.
+
+Note that this definition allows for machines with infinite states; the finite-state
+class `IsLetterLeftSubsequential` (`LetterSubsequential.lean`) supplies a `Fintype`
+instance.
+
+## Main definitions
+
+* `Mealy σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet `β`
+* `Mealy.run`: the function `List α → List β` computed by the machine
+* `Mealy.ofFlag`: the one-bit machine tracking whether an earlier symbol satisfies `p`
+* `Mealy.transferEquiv`: transport of a machine along a state equivalence
+
+## Main theorems
+
+* `Mealy.run_getElem?`: output coordinate `i` is the step output at the state reached
+  after the length-`i` input prefix
+* `Mealy.ofFlag_run_getElem?`, `Mealy.ofFlag_run_reverse_getElem?`: each coordinate of
+  a flag machine sees the flag over its strict prefix (its strict suffix, when the
+  machine is run right to left)
+
+[UPSTREAM] candidate: `Mathlib.Computability.Mealy`.
+-/
+
+namespace Subregular
+
+variable {σ α β : Type*}
+
+/-- A Mealy machine is a set of states (`σ`), a starting state (`initial`) and a
+transition function from a state and an input symbol to the successor state and one
+output symbol (`step`); it is synchronous, emitting exactly one output symbol per
+input symbol. -/
+structure Mealy (σ α β : Type*) where
+  /-- Starting state. -/
+  initial : σ
+  /-- Transition function from a state and an input symbol to the successor state and
+  the emitted output symbol. -/
+  step : σ → α → σ × β
+
+namespace Mealy
+
+variable (T : Mealy σ α β)
+
+/-- State reached after consuming a prefix. -/
+def stateAfter : σ → List α → σ
+  | s, [] => s
+  | s, x :: xs => stateAfter (T.step s x).1 xs
+
+/-- Run from a state: one output symbol per input symbol. -/
+def runFrom : σ → List α → List β
+  | _, [] => []
+  | s, x :: xs => (T.step s x).2 :: runFrom (T.step s x).1 xs
+
+/-- Run from the initial state. -/
+def run : List α → List β := T.runFrom T.initial
+
+@[simp] theorem runFrom_nil (s : σ) : T.runFrom s [] = [] := rfl
+@[simp] theorem runFrom_cons (s : σ) (x : α) (xs : List α) :
+    T.runFrom s (x :: xs) = (T.step s x).2 :: T.runFrom (T.step s x).1 xs := rfl
+@[simp] theorem stateAfter_nil (s : σ) : T.stateAfter s [] = s := rfl
+@[simp] theorem stateAfter_cons (s : σ) (x : α) (xs : List α) :
+    T.stateAfter s (x :: xs) = T.stateAfter (T.step s x).1 xs := rfl
+
+theorem stateAfter_append (s : σ) (xs ys : List α) :
+    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys := by
+  induction xs generalizing s with
+  | nil => rfl
+  | cons x xs ih => simp [ih]
+
+/-- The run is length-preserving (one output symbol per input symbol). -/
+theorem runFrom_length (s : σ) (xs : List α) :
+    (T.runFrom s xs).length = xs.length := by
+  induction xs generalizing s with
+  | nil => rfl
+  | cons x xs ih => simp [ih]
+
+theorem run_length (xs : List α) :
+    (T.run xs).length = xs.length := T.runFrom_length T.initial xs
+
+/-- **The coordinate characterization**: output `i` is the step output at
+`(state after the prefix [0..i-1], input i)`. -/
+theorem runFrom_getElem? (s : σ) (xs : List α) (i : ℕ) :
+    (T.runFrom s xs)[i]?
+      = (xs[i]?).map (fun x => (T.step (T.stateAfter s (xs.take i)) x).2) := by
+  induction xs generalizing s i with
+  | nil => simp
+  | cons x xs ih =>
+    cases i with
+    | zero => simp
+    | succ j => simp [ih, List.take_succ_cons]
+
+/-- The coordinate characterization from the initial state. -/
+theorem run_getElem? (xs : List α) (i : ℕ) :
+    (T.run xs)[i]?
+      = (xs[i]?).map (fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2) :=
+  T.runFrom_getElem? T.initial xs i
+
+/-! ### Flag machines
+
+The recurring one-sided-trigger shape: the state is the one-bit "some earlier symbol
+satisfies `p`" flag, so `stateAfter` computes `List.any` and each output cell sees the
+flag over its strict prefix. Scanned right-to-left (reverse, run, reverse), the cell
+sees the flag over its strict suffix (`ofFlag_run_reverse_getElem?`). -/
+
+variable (p : α → Bool) (out : Bool → α → β)
+
+/-- The Mealy machine whose state is the monotone flag "a symbol satisfying `p` has
+occurred". -/
+def ofFlag : Mealy Bool α β where
+  initial := false
+  step b a := (b || p a, out b a)
+
+@[simp] theorem ofFlag_initial : (ofFlag p out).initial = false := rfl
+
+@[simp] theorem ofFlag_step (b : Bool) (a : α) :
+    (ofFlag p out).step b a = (b || p a, out b a) := rfl
+
+@[simp] theorem ofFlag_stateAfter (b : Bool) (xs : List α) :
+    (ofFlag p out).stateAfter b xs = (b || xs.any p) := by
+  induction xs generalizing b with
+  | nil => simp
+  | cons x xs ih => simp [ih, Bool.or_assoc]
+
+theorem ofFlag_run_getElem? (xs : List α) (i : ℕ) :
+    ((ofFlag p out).run xs)[i]? = xs[i]?.map fun a => out ((xs.take i).any p) a := by
+  simp [run_getElem?]
+
+/-- Coordinates of a flag machine scanned right-to-left: cell `i` sees the flag over its
+strict suffix. -/
+theorem ofFlag_run_reverse_getElem? (xs : List α) (i : ℕ) :
+    (((ofFlag p out).run xs.reverse).reverse)[i]?
+      = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
+  by_cases hi : i < xs.length
+  · rw [List.getElem?_reverse (by rw [(ofFlag p out).run_length]; simpa using hi),
+      (ofFlag p out).run_length, List.length_reverse, ofFlag_run_getElem?,
+      List.getElem?_reverse (by omega),
+      show xs.length - 1 - (xs.length - 1 - i) = i from by omega,
+      List.take_reverse, show xs.length - (xs.length - 1 - i) = i + 1 from by omega,
+      List.any_reverse]
+  · rw [List.getElem?_eq_none
+        (by rw [List.length_reverse, (ofFlag p out).run_length, List.length_reverse]; omega),
+      List.getElem?_eq_none (Nat.le_of_not_lt hi), Option.map_none]
+
+/-! ### Transport along a state equivalence -/
+
+variable {τ : Type*}
+
+/-- Transfer a `Mealy` along a state-space equivalence `σ ≃ τ`, preserving `run`. The
+use case is bringing a `Type*` finite state down to `Fin (Fintype.card σ) : Type 0` so
+a universe-polymorphic machine can witness a `Type 0`-state existential. -/
+def transferEquiv (e : σ ≃ τ) : Mealy τ α β where
+  initial := e T.initial
+  step t x := (e (T.step (e.symm t) x).1, (T.step (e.symm t) x).2)
+
+theorem transferEquiv_runFrom (e : σ ≃ τ) (s : σ) (xs : List α) :
+    (T.transferEquiv e).runFrom (e s) xs = T.runFrom s xs := by
+  induction xs generalizing s with
+  | nil => rfl
+  | cons x xs ih =>
+    show (T.step (e.symm (e s)) x).2
+            :: (T.transferEquiv e).runFrom (e (T.step (e.symm (e s)) x).1) xs
+         = (T.step s x).2 :: T.runFrom (T.step s x).1 xs
+    rw [e.symm_apply_apply, ih]
+
+/-- The transferred machine computes the same string function. -/
+@[simp] theorem transferEquiv_run (e : σ ≃ τ) :
+    (T.transferEquiv e).run = T.run := by
+  funext xs; exact T.transferEquiv_runFrom e T.initial xs
+
+end Mealy
+
+end Subregular

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -123,12 +123,7 @@ theorem getElem?_run (xs : List α) (i : ℕ) :
     (T.run xs)[i]? = xs[i]?.map fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2 :=
   T.getElem?_runFrom T.initial xs i
 
-/-! ### Flag machines
-
-The recurring one-sided-trigger shape: the state is the one-bit "some earlier symbol
-satisfies `p`" flag, so `stateAfter` computes `List.any` and each output cell sees the
-flag over its strict prefix. Under the right-to-left pass `runRight`, the cell sees the
-flag over its strict suffix (`getElem?_ofFlag_runRight`). -/
+/-! ### Flag machines -/
 
 variable (p : α → Bool) (out : Bool → α → β)
 

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -24,7 +24,7 @@ instance must be supplied for true finite-state machines.
 * `Mealy σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet `β`
 * `Mealy.run`, `Mealy.runRight`: the left-to-right and right-to-left passes
 * `Mealy.ofFlag`: the one-bit machine tracking whether an earlier symbol satisfies `p`
-* `Mealy.transferEquiv`: transport of a machine along a state equivalence
+* `Mealy.reindex`: lifts an equivalence on states to an equivalence on machines
 
 ## Main theorems
 
@@ -160,32 +160,40 @@ theorem getElem?_ofFlag_runRight (xs : List α) (i : ℕ) :
   | nil => simp
   | cons x xs ih => cases i <;> simp [*]
 
-/-! ### Transport along a state equivalence -/
+/-! ### Reindexing states -/
 
 variable {τ : Type*}
 
-/-- `T.transferEquiv e` transports `T` along the state equivalence `e`, preserving
-`run`. The use case is bringing a `Type*` finite state down to
-`Fin (Fintype.card σ) : Type 0` so a universe-polymorphic machine can witness a
-`Type 0`-state existential. -/
-def transferEquiv (e : σ ≃ τ) : Mealy τ α β where
-  initial := e T.initial
-  step t x := (e (T.step (e.symm t) x).1, (T.step (e.symm t) x).2)
+/-- Lifts an equivalence on states to an equivalence on Mealy machines. -/
+@[simps apply_initial apply_step]
+def reindex (g : σ ≃ τ) : Mealy σ α β ≃ Mealy τ α β where
+  toFun T := {
+    initial := g T.initial
+    step := fun t x => (g (T.step (g.symm t) x).1, (T.step (g.symm t) x).2)
+  }
+  invFun T := {
+    initial := g.symm T.initial
+    step := fun s x => (g.symm (T.step (g s) x).1, (T.step (g s) x).2)
+  }
+  left_inv T := by simp
+  right_inv T := by simp
 
-theorem transferEquiv_runFrom (e : σ ≃ τ) (s : σ) (xs : List α) :
-    (T.transferEquiv e).runFrom (e s) xs = T.runFrom s xs := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih =>
-    show (T.step (e.symm (e s)) x).2
-            :: (T.transferEquiv e).runFrom (e (T.step (e.symm (e s)) x).1) xs
-         = (T.step s x).2 :: T.runFrom (T.step s x).1 xs
-    rw [e.symm_apply_apply, ih]
+@[simp] theorem reindex_refl : reindex (Equiv.refl σ) T = T := rfl
 
-/-- The transferred machine computes the same string function. -/
-@[simp] theorem transferEquiv_run (e : σ ≃ τ) :
-    (T.transferEquiv e).run = T.run := by
-  funext xs; exact T.transferEquiv_runFrom e T.initial xs
+@[simp] theorem symm_reindex (g : σ ≃ τ) :
+    (reindex (α := α) (β := β) g).symm = reindex g.symm := rfl
+
+@[simp] theorem stateAfter_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (reindex g T).stateAfter t xs = g (T.stateAfter (g.symm t) xs) := by
+  induction xs generalizing t <;> simp [*]
+
+@[simp] theorem runFrom_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (reindex g T).runFrom t xs = T.runFrom (g.symm t) xs := by
+  induction xs generalizing t <;> simp [*]
+
+/-- The reindexed machine computes the same string function. -/
+@[simp] theorem run_reindex (g : σ ≃ τ) : (reindex g T).run = T.run := by
+  funext xs; simp [run]
 
 end Mealy
 

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -102,12 +102,7 @@ first `i` input symbols. -/
 theorem getElem?_runFrom (s : σ) (xs : List α) (i : ℕ) :
     (T.runFrom s xs)[i]?
       = xs[i]?.map fun x => (T.step (T.stateAfter s (xs.take i)) x).2 := by
-  induction xs generalizing s i with
-  | nil => simp
-  | cons x xs ih =>
-    cases i with
-    | zero => simp
-    | succ j => simp [ih, List.take_succ_cons]
+  induction xs generalizing s i <;> cases i <;> simp [*]
 
 /-- Output coordinate `i` of `T.run` is the step output at the state reached after the
 first `i` input symbols. -/

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -100,15 +100,13 @@ theorem stateAfter_append (s : σ) (xs ys : List α) :
 /-- Output coordinate `i` of the run is the step output at the state reached after the
 first `i` input symbols. -/
 theorem getElem?_runFrom (s : σ) (xs : List α) (i : ℕ) :
-    (T.runFrom s xs)[i]?
-      = xs[i]?.map fun x => (T.step (T.stateAfter s (xs.take i)) x).2 := by
+    (T.runFrom s xs)[i]? = xs[i]?.map fun x => (T.step (T.stateAfter s (xs.take i)) x).2 := by
   induction xs generalizing s i <;> cases i <;> simp [*]
 
 /-- Output coordinate `i` of `T.run` is the step output at the state reached after the
 first `i` input symbols. -/
 theorem getElem?_run (xs : List α) (i : ℕ) :
-    (T.run xs)[i]?
-      = xs[i]?.map fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2 :=
+    (T.run xs)[i]? = xs[i]?.map fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2 :=
   T.getElem?_runFrom T.initial xs i
 
 /-! ### Flag machines
@@ -145,8 +143,7 @@ theorem getElem?_ofFlag_run (xs : List α) (i : ℕ) :
 /-- Each coordinate of a flag machine run right-to-left sees the flag over its strict
 suffix. -/
 theorem getElem?_ofFlag_runRight (xs : List α) (i : ℕ) :
-    ((ofFlag p out).runRight xs)[i]?
-      = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
+    ((ofFlag p out).runRight xs)[i]? = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
   unfold runRight
   by_cases hi : i < xs.length
   · rw [List.getElem?_reverse (by simpa using hi),

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.List.Basic
 import Mathlib.Logic.Equiv.Defs
+import Linglib.Core.Data.List.Fold
 
 /-!
 # Mealy machines
@@ -131,9 +132,7 @@ def ofFlag : Mealy Bool α β where
 
 @[simp] theorem ofFlag_stateAfter (b : Bool) (xs : List α) :
     (ofFlag p out).stateAfter b xs = (b || xs.any p) := by
-  induction xs generalizing b with
-  | nil => simp
-  | cons x xs ih => simp [ih, Bool.or_assoc]
+  simp [stateAfter, List.foldl_or]
 
 /-- Each coordinate of a flag machine sees the flag over its strict prefix. -/
 theorem getElem?_ofFlag_run (xs : List α) (i : ℕ) :
@@ -152,7 +151,7 @@ theorem getElem?_ofFlag_runRight (xs : List α) (i : ℕ) :
       show xs.length - 1 - (xs.length - 1 - i) = i from by omega,
       List.take_reverse, show xs.length - (xs.length - 1 - i) = i + 1 from by omega,
       List.any_reverse]
-  · rw [List.getElem?_eq_none (by simp; omega),
+  · rw [List.getElem?_eq_none (by simpa using hi),
       List.getElem?_eq_none (Nat.le_of_not_lt hi), Option.map_none]
 
 /-! ### Transport along a state equivalence -/

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -56,9 +56,8 @@ namespace Mealy
 variable (T : Mealy σ α β)
 
 /-- State reached after consuming a prefix. -/
-def stateAfter : σ → List α → σ
-  | s, [] => s
-  | s, x :: xs => stateAfter (T.step s x).1 xs
+def stateAfter (s : σ) : List α → σ :=
+  List.foldl (fun s x => (T.step s x).1) s
 
 /-- Run from a state: one output symbol per input symbol. -/
 def runFrom : σ → List α → List β
@@ -76,10 +75,8 @@ def run : List α → List β := T.runFrom T.initial
     T.stateAfter s (x :: xs) = T.stateAfter (T.step s x).1 xs := rfl
 
 theorem stateAfter_append (s : σ) (xs ys : List α) :
-    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih => simp [ih]
+    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys :=
+  List.foldl_append
 
 /-- The run is length-preserving (one output symbol per input symbol). -/
 theorem runFrom_length (s : σ) (xs : List α) :

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -84,6 +84,10 @@ theorem stateAfter_append (s : σ) (xs ys : List α) :
     T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys :=
   List.foldl_append
 
+theorem runFrom_append (s : σ) (xs ys : List α) :
+    T.runFrom s (xs ++ ys) = T.runFrom s xs ++ T.runFrom (T.stateAfter s xs) ys := by
+  induction xs generalizing s <;> simp [*]
+
 /-- The run is length-preserving (one output symbol per input symbol). -/
 @[simp] theorem length_runFrom (s : σ) (xs : List α) :
     (T.runFrom s xs).length = xs.length := by
@@ -97,6 +101,15 @@ theorem stateAfter_append (s : σ) (xs ys : List α) :
 
 @[simp] theorem runRight_reverse (xs : List α) :
     T.runRight xs.reverse = (T.run xs).reverse := by simp [runRight]
+
+@[simp] theorem runRight_nil : T.runRight [] = [] := rfl
+
+/-- The right-to-left pass emits the head output at the state reached over the entire
+reversed tail: the right scan reads the future. -/
+@[simp] theorem runRight_cons (x : α) (xs : List α) :
+    T.runRight (x :: xs)
+      = (T.step (T.stateAfter T.initial xs.reverse) x).2 :: T.runRight xs := by
+  simp [runRight, run, runFrom_append]
 
 /-- Output coordinate `i` of the run is the step output at the state reached after the
 first `i` input symbols. -/
@@ -143,16 +156,9 @@ theorem getElem?_ofFlag_run (xs : List α) (i : ℕ) :
 suffix. -/
 theorem getElem?_ofFlag_runRight (xs : List α) (i : ℕ) :
     ((ofFlag p out).runRight xs)[i]? = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
-  unfold runRight
-  by_cases hi : i < xs.length
-  · rw [List.getElem?_reverse (by simpa using hi),
-      (ofFlag p out).length_run, List.length_reverse, getElem?_ofFlag_run,
-      List.getElem?_reverse (by omega),
-      show xs.length - 1 - (xs.length - 1 - i) = i from by omega,
-      List.take_reverse, show xs.length - (xs.length - 1 - i) = i + 1 from by omega,
-      List.any_reverse]
-  · rw [List.getElem?_eq_none (by simpa using hi),
-      List.getElem?_eq_none (Nat.le_of_not_lt hi), Option.map_none]
+  induction xs generalizing i with
+  | nil => simp
+  | cons x xs ih => cases i <;> simp [*]
 
 /-! ### Transport along a state equivalence -/
 

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -15,9 +15,8 @@ is length-preserving by construction. Output coordinate `i` of the run is the st
 output at the state reached after the length-`i` input prefix (`Mealy.run_getElem?`),
 so the output is prefix-determined at every coordinate.
 
-Note that this definition allows for machines with infinite states; the finite-state
-class `IsLetterLeftSubsequential` (`LetterSubsequential.lean`) supplies a `Fintype`
-instance.
+Note that this definition allows for machines with infinite states; a `Fintype`
+instance must be supplied for true finite-state machines.
 
 ## Main definitions
 

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -79,14 +79,12 @@ theorem stateAfter_append (s : σ) (xs ys : List α) :
   List.foldl_append
 
 /-- The run is length-preserving (one output symbol per input symbol). -/
-theorem runFrom_length (s : σ) (xs : List α) :
+@[simp] theorem length_runFrom (s : σ) (xs : List α) :
     (T.runFrom s xs).length = xs.length := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih => simp [ih]
+  induction xs generalizing s <;> simp [*]
 
-theorem run_length (xs : List α) :
-    (T.run xs).length = xs.length := T.runFrom_length T.initial xs
+@[simp] theorem length_run (xs : List α) :
+    (T.run xs).length = xs.length := T.length_runFrom T.initial xs
 
 /-- **The coordinate characterization**: output `i` is the step output at
 `(state after the prefix [0..i-1], input i)`. -/
@@ -142,14 +140,13 @@ theorem ofFlag_run_reverse_getElem? (xs : List α) (i : ℕ) :
     (((ofFlag p out).run xs.reverse).reverse)[i]?
       = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
   by_cases hi : i < xs.length
-  · rw [List.getElem?_reverse (by rw [(ofFlag p out).run_length]; simpa using hi),
-      (ofFlag p out).run_length, List.length_reverse, ofFlag_run_getElem?,
+  · rw [List.getElem?_reverse (by simpa using hi),
+      (ofFlag p out).length_run, List.length_reverse, ofFlag_run_getElem?,
       List.getElem?_reverse (by omega),
       show xs.length - 1 - (xs.length - 1 - i) = i from by omega,
       List.take_reverse, show xs.length - (xs.length - 1 - i) = i + 1 from by omega,
       List.any_reverse]
-  · rw [List.getElem?_eq_none
-        (by rw [List.length_reverse, (ofFlag p out).run_length, List.length_reverse]; omega),
+  · rw [List.getElem?_eq_none (by simp; omega),
       List.getElem?_eq_none (Nat.le_of_not_lt hi), Option.map_none]
 
 /-! ### Transport along a state equivalence -/

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -99,7 +99,7 @@ theorem run_getElem? (x : List α) (i : ℕ) :
 variable {L' R' : Type*}
 
 /-- Transfer a bimachine along state-space equivalences `L ≃ L'` and `R ≃ R'`,
-preserving `run`. Mirrors `SFST.transferEquiv`/`Mealy.transferEquiv`; the use case is
+preserving `run`. Mirrors `SFST.transferEquiv`/`Mealy.reindex`; the use case is
 bringing `Type*` finite states down to `Fin (Fintype.card ·) : Type 0` so a
 universe-polymorphic machine can witness the `Type 0`-state existentials of
 `IsBimachineComputable`/`IsBimachineWeaklyDeterministic`. -/

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -81,14 +81,6 @@ variable {α : Type*} [DecidableEq α]
 private theorem unite_default_right (cL a : α) : unite cL a a = cL := by
   unfold unite; split_ifs <;> simp_all
 
-omit [DecidableEq α] in
-private theorem mealy_stateAfter_eq_foldl {σ : Type*} (T : Mealy σ α α)
-    (s : σ) (pre : List α) :
-    T.stateAfter s pre = pre.foldl (fun l a => (T.step l a).1) s := by
-  induction pre generalizing s with
-  | nil => rfl
-  | cons x xs ih => simp only [Mealy.stateAfter, List.foldl_cons, ih]
-
 /-- **Subsequential ⊆ weakly deterministic.** A synchronous left-subsequential function is
 computed by a non-interacting bimachine: the left automaton *is* the transducer, the right
 automaton is trivial, so the cell output is a one-sided rule (`ωR` is the identity). -/
@@ -102,11 +94,8 @@ theorem IsBimachineWeaklyDeterministic.of_letterLeftSubsequential {f : List α �
     funext xs
     apply List.ext_getElem?
     intro i
-    rw [Bimachine.run_getElem?]
-    show (xs[i]?).map
-        (fun a => (T.step ((xs.take i).foldl (fun l a => (T.step l a).1) T.initial) a).2)
-      = (T.run xs)[i]?
-    rw [T.run_getElem?, mealy_stateAfter_eq_foldl]
+    rw [Bimachine.run_getElem?, T.run_getElem?]
+    rfl
   have hni : B.IsNonInteracting :=
     ⟨fun l a => (T.step l a).2, fun _ a => a, fun l a r => (unite_default_right _ _).symm⟩
   exact hrun ▸ isBimachineWeaklyDeterministic B hni

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -106,8 +106,7 @@ theorem IsBimachineWeaklyDeterministic.of_letterLeftSubsequential {f : List α �
     show (xs[i]?).map
         (fun a => (T.step ((xs.take i).foldl (fun l a => (T.step l a).1) T.initial) a).2)
       = (T.run xs)[i]?
-    rw [show T.run xs = T.runFrom T.initial xs from rfl, T.runFrom_getElem?,
-        mealy_stateAfter_eq_foldl]
+    rw [T.run_getElem?, mealy_stateAfter_eq_foldl]
   have hni : B.IsNonInteracting :=
     ⟨fun l a => (T.step l a).2, fun _ a => a, fun l a r => (unite_default_right _ _).symm⟩
   exact hrun ▸ isBimachineWeaklyDeterministic B hni

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -94,7 +94,7 @@ theorem IsBimachineWeaklyDeterministic.of_letterLeftSubsequential {f : List α �
     funext xs
     apply List.ext_getElem?
     intro i
-    rw [Bimachine.run_getElem?, T.run_getElem?]
+    rw [Bimachine.run_getElem?, T.getElem?_run]
     rfl
   have hni : B.IsNonInteracting :=
     ⟨fun l a => (T.step l a).2, fun _ a => a, fun l a r => (unite_default_right _ _).symm⟩

--- a/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
@@ -59,13 +59,13 @@ def IsLetterLeftSubsequential (f : List α → List β) : Prop :=
 
 /-- Every finite-state `Mealy` witnesses `IsLetterLeftSubsequential` for its `run`.
 The state `σ` is accepted at arbitrary `Type*` and brought down to
-`Fin (Fintype.card σ) : Type 0` via `transferEquiv` and `Fintype.equivFin`, so
+`Fin (Fintype.card σ) : Type 0` via `Mealy.reindex` and `Fintype.equivFin`, so
 bounded-window states at the alphabet's universe can witness the predicate (mirrors
 `SFST.isLeftSubsequential`). -/
 theorem Mealy.isLetterLeftSubsequential {σ : Type*} [Fintype σ]
     (T : Mealy σ α β) : IsLetterLeftSubsequential T.run :=
-  ⟨Fin (Fintype.card σ), inferInstance, T.transferEquiv (Fintype.equivFin σ),
-   T.transferEquiv_run _⟩
+  ⟨Fin (Fintype.card σ), inferInstance, Mealy.reindex (Fintype.equivFin σ) T,
+   T.run_reindex _⟩
 
 /-- A letter-left-subsequential map is left-determined at every coordinate — output `i`
 depends only on the prefix `{k | k ≤ i}`. (The *block* `IsLeftSubsequential` lacks

--- a/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
@@ -57,27 +57,27 @@ variable {α β : Type*}
 def IsLetterLeftSubsequential (f : List α → List β) : Prop :=
   ∃ (σ : Type) (_ : Fintype σ) (T : Mealy σ α β), T.run = f
 
-/-- **Constructor lemma**: every finite-state `Mealy` witnesses
-`IsLetterLeftSubsequential` for its `run`. The state `σ` is accepted at arbitrary
-`Type*` and brought down to `Fin (Fintype.card σ) : Type 0` via `transferEquiv` and
-`Fintype.equivFin`, so bounded-window states at the alphabet's universe can witness
-the predicate (mirrors `SFST.isLeftSubsequential`). -/
+/-- Every finite-state `Mealy` witnesses `IsLetterLeftSubsequential` for its `run`.
+The state `σ` is accepted at arbitrary `Type*` and brought down to
+`Fin (Fintype.card σ) : Type 0` via `transferEquiv` and `Fintype.equivFin`, so
+bounded-window states at the alphabet's universe can witness the predicate (mirrors
+`SFST.isLeftSubsequential`). -/
 theorem Mealy.isLetterLeftSubsequential {σ : Type*} [Fintype σ]
     (T : Mealy σ α β) : IsLetterLeftSubsequential T.run :=
   ⟨Fin (Fintype.card σ), inferInstance, T.transferEquiv (Fintype.equivFin σ),
    T.transferEquiv_run _⟩
 
-/-- **Forward footprint bridge.** A letter-left-subsequential map is left-determined at
-every coordinate — output `i` depends only on the prefix `{k | k ≤ i}`. (The *block*
-`IsLeftSubsequential` lacks this, by delayed output.) -/
+/-- A letter-left-subsequential map is left-determined at every coordinate — output `i`
+depends only on the prefix `{k | k ≤ i}`. (The *block* `IsLeftSubsequential` lacks
+this, by delayed output.) -/
 theorem IsLetterLeftSubsequential.leftDetermined {f : List α → List β}
     (hf : IsLetterLeftSubsequential f) (i : ℕ) : LeftDetermined f i := by
   obtain ⟨σ, _, T, rfl⟩ := hf
   intro u v hlen hag
-  rw [T.run_getElem? u, T.run_getElem? v, hag i (Set.mem_setOf.mpr le_rfl),
+  rw [T.getElem?_run u, T.getElem?_run v, hag i (Set.mem_setOf.mpr le_rfl),
     take_eq_of_agree fun k hk => hag k (Set.mem_setOf.mpr hk.le)]
 
-/-- A synchronous left-subsequential map is **right-myopic** — it has no look-ahead. -/
+/-- A synchronous left-subsequential map is right-myopic: it has no look-ahead. -/
 theorem IsLetterLeftSubsequential.isRightMyopic {f : List α → List β}
     (hf : IsLetterLeftSubsequential f) : IsMyopicTowards f .right :=
   IsMyopicTowards.right_of_leftDetermined hf.leftDetermined
@@ -90,9 +90,9 @@ prefix-congruence's quotient; `δ`/`out` are the induced transition and output. 
 natural Nerode congruence, when of finite index, is one such summary — that
 instantiation, and the necessity direction, are the TODO above.) -/
 
-/-- **Myhill–Nerode, sufficiency.** A length-preserving `f` with a finite
-`state : List α → σ` that is left-congruent (`hδ`) and determines `f`'s output at each
-position (`hout`) is letter-left-subsequential. -/
+/-- A length-preserving `f` with a finite `state : List α → σ` that is left-congruent
+(`hδ`) and determines `f`'s output at each position (`hout`) is
+letter-left-subsequential — the sufficiency half of Myhill–Nerode. -/
 theorem isLetterLeftSubsequential_of_stateSummary
     {f : List α → List β} {σ : Type} [Fintype σ]
     (state : List α → σ) (δ : σ → α → σ) (out : σ → α → β)
@@ -110,7 +110,7 @@ theorem isLetterLeftSubsequential_of_stateSummary
   funext xs
   apply List.ext_getElem?
   intro i
-  rw [T.run_getElem? xs i, hstate]
+  rw [T.getElem?_run xs i, hstate]
   rcases lt_or_ge i xs.length with hi | hi
   · have key := hout (xs.take i) xs[i] (xs.drop (i + 1))
     rw [List.length_take_of_le hi.le, ← List.drop_eq_getElem_cons hi,

--- a/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
@@ -4,196 +4,54 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Data.Fintype.EquivFin
+import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 
 /-!
 # Synchronous (letter) left-subsequential functions
 
-A `Mealy` machine [mealy-1955] is a deterministic left-to-right transducer emitting
-exactly one output symbol per input symbol — the synchronous case, length-preserving by
-construction. Its output coordinate `i` is a function of the input prefix `[0..i]`, so
-the class is cleanly characterised by the `OutputDependsOn` footprint
-(`SideDeterminacy.lean`): `IsLetterLeftSubsequential f → ∀ i, LeftDetermined f i`, hence
-right-myopic (no look-ahead).
+`IsLetterLeftSubsequential f` states that `f` is computed by a finite-state `Mealy`
+machine. Output coordinate `i` of such a function depends only on the input prefix
+`[0..i]`, so the class is characterized by its dependency footprint
+(`OutputDependsOn`): letter-left-subsequential functions are prefix-determined at
+every coordinate, hence have no look-ahead.
 
-This is the characterisation the *block* `IsLeftSubsequential` (`Subsequential.lean`)
-lacks: a length-preserving block transducer can delay output (emit `[]` then `[x,y]`),
-so output coordinate `0` depends on input position `1` — not prefix-determined. The
-synchronous restriction is what makes the dependency-footprint view line up with the
-machine view.
+The *block* class `IsLeftSubsequential` lacks this characterization: a
+length-preserving block transducer can delay output (emit `[]` then `[x, y]`), so its
+output coordinate `0` can depend on input position `1`. The synchronous restriction is
+what makes the dependency-footprint view coincide with the machine view.
 
 ## Main definitions
 
-* `Mealy` — synchronous one-symbol-per-step transducer; `run` is length-preserving.
-* `Mealy.ofFlag` — the one-bit machine tracking "some earlier symbol satisfies `p`".
-* `Mealy.transferEquiv` — transport along a state equivalence, preserving `run`.
-* `IsLetterLeftSubsequential` — computed by a finite-state `Mealy`.
+* `IsLetterLeftSubsequential f`: `f` is computed by some finite-state `Mealy`
 
-## Main results
+## Main theorems
 
-* `Mealy.run_getElem?` — output `i` is `(step (state-after-prefix) (input i)).2`.
-* `IsLetterLeftSubsequential.leftDetermined` / `.isRightMyopic` — synchronous
-  left-subsequential maps are prefix-determined, hence right-myopic.
-* `isLetterLeftSubsequential_of_stateSummary` — Myhill–Nerode, sufficiency direction:
-  a finite left-congruent state summary determining the output yields a `Mealy`.
+* `IsLetterLeftSubsequential.leftDetermined`, `.isRightMyopic`:
+  letter-left-subsequential functions are prefix-determined, hence right-myopic
+* `isLetterLeftSubsequential_of_stateSummary`: the sufficiency half of Myhill–Nerode —
+  a finite left-congruent state summary determining the output yields a machine
 
 ## Implementation notes
 
-In the transducer literature [mohri-1997] *subsequential* machines carry a state-final
-output emitted at end of input; `Mealy` has none, so strictly it computes the
-letter-to-letter *sequential* class. Length preservation forces the final output empty,
-so the two classes coincide here; the name keeps the parallel with the block
-`IsLeftSubsequential`.
-
-[UPSTREAM] candidate (the `Mealy` API): `Mathlib.Computability.Mealy`.
+In the transducer literature [mohri-1997] a *subsequential* machine additionally
+carries a state-final output emitted at the end of the input; `Mealy` has none, so
+strictly it computes the letter-to-letter *sequential* class. Length preservation
+forces the final output to be empty, so the two classes coincide here; the name keeps
+the parallel with the block class `IsLeftSubsequential`.
 
 ## TODO
 
 * Instantiate `isLetterLeftSubsequential_of_stateSummary` at the natural Nerode prefix
   congruence, and prove the necessity direction: a letter-left-subsequential function
-  has a finite-index prefix congruence [choffrut-1977].
-* Composition closure (state-product `Mealy`) and the right-scan mirror
+  has a prefix congruence of finite index [choffrut-1977].
+* Composition closure (state-product machine) and the right-scan mirror
   `IsLetterRightSubsequential` via reverse conjugation.
 -/
 
 namespace Subregular
 
-variable {σ α β : Type*}
-
-/-- A synchronous letter-to-letter left-to-right transducer: exactly one output symbol
-per input symbol (length-preserving by construction). -/
-structure Mealy (σ α β : Type*) where
-  initial : σ
-  step : σ → α → σ × β
-
-namespace Mealy
-
-/-- State reached after consuming a prefix. -/
-def stateAfter (T : Mealy σ α β) : σ → List α → σ
-  | s, [] => s
-  | s, x :: xs => T.stateAfter (T.step s x).1 xs
-
-/-- Run from a state: one output symbol per input symbol. -/
-def runFrom (T : Mealy σ α β) : σ → List α → List β
-  | _, [] => []
-  | s, x :: xs => (T.step s x).2 :: T.runFrom (T.step s x).1 xs
-
-/-- Run from the initial state. -/
-def run (T : Mealy σ α β) : List α → List β := T.runFrom T.initial
-
-@[simp] theorem runFrom_nil (T : Mealy σ α β) (s : σ) : T.runFrom s [] = [] := rfl
-@[simp] theorem runFrom_cons (T : Mealy σ α β) (s : σ) (x : α) (xs : List α) :
-    T.runFrom s (x :: xs) = (T.step s x).2 :: T.runFrom (T.step s x).1 xs := rfl
-@[simp] theorem stateAfter_nil (T : Mealy σ α β) (s : σ) : T.stateAfter s [] = s := rfl
-@[simp] theorem stateAfter_cons (T : Mealy σ α β) (s : σ) (x : α) (xs : List α) :
-    T.stateAfter s (x :: xs) = T.stateAfter (T.step s x).1 xs := rfl
-
-theorem stateAfter_append (T : Mealy σ α β) (s : σ) (xs ys : List α) :
-    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih => simp [ih]
-
-/-- The run is length-preserving (one output symbol per input symbol). -/
-theorem runFrom_length (T : Mealy σ α β) (s : σ) (xs : List α) :
-    (T.runFrom s xs).length = xs.length := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih => simp [ih]
-
-theorem run_length (T : Mealy σ α β) (xs : List α) :
-    (T.run xs).length = xs.length := T.runFrom_length T.initial xs
-
-/-- **The coordinate characterization**: output `i` is the step output at
-`(state after the prefix [0..i-1], input i)`. -/
-theorem runFrom_getElem? (T : Mealy σ α β) (s : σ) (xs : List α) (i : ℕ) :
-    (T.runFrom s xs)[i]?
-      = (xs[i]?).map (fun x => (T.step (T.stateAfter s (xs.take i)) x).2) := by
-  induction xs generalizing s i with
-  | nil => simp
-  | cons x xs ih =>
-    cases i with
-    | zero => simp
-    | succ j => simp [ih, List.take_succ_cons]
-
-/-- The coordinate characterization from the initial state. -/
-theorem run_getElem? (T : Mealy σ α β) (xs : List α) (i : ℕ) :
-    (T.run xs)[i]?
-      = (xs[i]?).map (fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2) :=
-  T.runFrom_getElem? T.initial xs i
-
-/-! ### Flag machines
-
-The recurring one-sided-trigger shape (the `Mealy` counterpart of `Bimachine.ofFlags`):
-the state is the one-bit "some earlier symbol satisfies `p`" flag, so `stateAfter`
-computes `List.any` and each output cell sees the flag over its strict prefix. Scanned
-right-to-left (reverse, run, reverse), the cell sees the flag over its strict suffix
-(`ofFlag_run_reverse_getElem?`). -/
-
-/-- The Mealy machine whose state is the monotone flag "a symbol satisfying `p` has
-occurred". -/
-def ofFlag (p : α → Bool) (out : Bool → α → β) : Mealy Bool α β where
-  initial := false
-  step b a := (b || p a, out b a)
-
-@[simp] theorem ofFlag_initial (p : α → Bool) (out : Bool → α → β) :
-    (ofFlag p out).initial = false := rfl
-
-@[simp] theorem ofFlag_step (p : α → Bool) (out : Bool → α → β) (b : Bool) (a : α) :
-    (ofFlag p out).step b a = (b || p a, out b a) := rfl
-
-@[simp] theorem ofFlag_stateAfter (p : α → Bool) (out : Bool → α → β) (b : Bool)
-    (xs : List α) : (ofFlag p out).stateAfter b xs = (b || xs.any p) := by
-  induction xs generalizing b with
-  | nil => simp
-  | cons x xs ih => simp [ih, Bool.or_assoc]
-
-theorem ofFlag_run_getElem? (p : α → Bool) (out : Bool → α → β) (xs : List α) (i : ℕ) :
-    ((ofFlag p out).run xs)[i]? = xs[i]?.map fun a => out ((xs.take i).any p) a := by
-  simp [run_getElem?]
-
-/-- Coordinates of a flag machine scanned right-to-left: cell `i` sees the flag over its
-strict suffix. -/
-theorem ofFlag_run_reverse_getElem? (p : α → Bool) (out : Bool → α → β) (xs : List α)
-    (i : ℕ) :
-    (((ofFlag p out).run xs.reverse).reverse)[i]?
-      = xs[i]?.map fun a => out ((xs.drop (i + 1)).any p) a := by
-  by_cases hi : i < xs.length
-  · rw [List.getElem?_reverse (by rw [(ofFlag p out).run_length]; simpa using hi),
-      (ofFlag p out).run_length, List.length_reverse, ofFlag_run_getElem?,
-      List.getElem?_reverse (by omega),
-      show xs.length - 1 - (xs.length - 1 - i) = i from by omega,
-      List.take_reverse, show xs.length - (xs.length - 1 - i) = i + 1 from by omega,
-      List.any_reverse]
-  · rw [List.getElem?_eq_none
-        (by rw [List.length_reverse, (ofFlag p out).run_length, List.length_reverse]; omega),
-      List.getElem?_eq_none (le_of_not_gt hi), Option.map_none]
-
-/-- Transfer a `Mealy` along a state-space equivalence `σ ≃ τ`, preserving `run`.
-Mirrors `SFST.transferEquiv`; the use case is bringing a `Type*` finite state down to
-`Fin (Fintype.card σ) : Type 0` so a universe-polymorphic machine can witness the
-`Type 0`-state existential of `IsLetterLeftSubsequential`. -/
-def transferEquiv {τ : Type*} (T : Mealy σ α β) (e : σ ≃ τ) : Mealy τ α β where
-  initial := e T.initial
-  step t x := (e (T.step (e.symm t) x).1, (T.step (e.symm t) x).2)
-
-theorem transferEquiv_runFrom {τ : Type*} (T : Mealy σ α β) (e : σ ≃ τ)
-    (s : σ) (xs : List α) :
-    (T.transferEquiv e).runFrom (e s) xs = T.runFrom s xs := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih =>
-    show (T.step (e.symm (e s)) x).2
-            :: (T.transferEquiv e).runFrom (e (T.step (e.symm (e s)) x).1) xs
-         = (T.step s x).2 :: T.runFrom (T.step s x).1 xs
-    rw [e.symm_apply_apply, ih]
-
-/-- The transferred machine computes the same string function. -/
-@[simp] theorem transferEquiv_run {τ : Type*} (T : Mealy σ α β) (e : σ ≃ τ) :
-    (T.transferEquiv e).run = T.run := by
-  funext xs; exact T.transferEquiv_runFrom e T.initial xs
-
-end Mealy
+variable {α β : Type*}
 
 /-- The synchronous left-subsequential class: computed by a finite-state `Mealy`. -/
 def IsLetterLeftSubsequential (f : List α → List β) : Prop :=
@@ -202,9 +60,9 @@ def IsLetterLeftSubsequential (f : List α → List β) : Prop :=
 /-- **Constructor lemma**: every finite-state `Mealy` witnesses
 `IsLetterLeftSubsequential` for its `run`. The state `σ` is accepted at arbitrary
 `Type*` and brought down to `Fin (Fintype.card σ) : Type 0` via `transferEquiv` and
-`Fintype.equivFin`, so bounded-window ISL/OSL states at the alphabet's universe can
-witness the predicate (mirrors `SFST.isLeftSubsequential`). -/
-theorem Mealy.isLetterLeftSubsequential {σ : Type*} [Fintype σ] {α β : Type*}
+`Fintype.equivFin`, so bounded-window states at the alphabet's universe can witness
+the predicate (mirrors `SFST.isLeftSubsequential`). -/
+theorem Mealy.isLetterLeftSubsequential {σ : Type*} [Fintype σ]
     (T : Mealy σ α β) : IsLetterLeftSubsequential T.run :=
   ⟨Fin (Fintype.card σ), inferInstance, T.transferEquiv (Fintype.equivFin σ),
    T.transferEquiv_run _⟩
@@ -216,10 +74,8 @@ theorem IsLetterLeftSubsequential.leftDetermined {f : List α → List β}
     (hf : IsLetterLeftSubsequential f) (i : ℕ) : LeftDetermined f i := by
   obtain ⟨σ, _, T, rfl⟩ := hf
   intro u v hlen hag
-  have hi : u[i]? = v[i]? := hag i (by simp)
-  have htake : u.take i = v.take i :=
-    take_eq_of_agree fun k hk => hag k (by simp only [Set.mem_setOf_eq]; omega)
-  rw [T.run_getElem? u, T.run_getElem? v, hi, htake]
+  rw [T.run_getElem? u, T.run_getElem? v, hag i (Set.mem_setOf.mpr le_rfl),
+    take_eq_of_agree fun k hk => hag k (Set.mem_setOf.mpr hk.le)]
 
 /-- A synchronous left-subsequential map is **right-myopic** — it has no look-ahead. -/
 theorem IsLetterLeftSubsequential.isRightMyopic {f : List α → List β}
@@ -244,8 +100,8 @@ theorem isLetterLeftSubsequential_of_stateSummary
     (hout : ∀ u x w, (f (u ++ x :: w))[u.length]? = some (out (state u) x))
     (hlen : ∀ xs, (f xs).length = xs.length) :
     IsLetterLeftSubsequential f := by
-  refine ⟨σ, inferInstance, { initial := state [], step := fun s x => (δ s x, out s x) }, ?_⟩
-  set T : Mealy σ α β := { initial := state [], step := fun s x => (δ s x, out s x) }
+  refine ⟨σ, inferInstance, ⟨state [], fun s x => (δ s x, out s x)⟩, ?_⟩
+  set T : Mealy σ α β := ⟨state [], fun s x => (δ s x, out s x)⟩
   have hstate : ∀ ps : List α, T.stateAfter T.initial ps = state ps := by
     intro ps
     induction ps using List.reverseRecOn with
@@ -256,11 +112,9 @@ theorem isLetterLeftSubsequential_of_stateSummary
   intro i
   rw [T.run_getElem? xs i, hstate]
   rcases lt_or_ge i xs.length with hi | hi
-  · have hdecomp : xs.take i ++ xs[i] :: xs.drop (i + 1) = xs := by
-      rw [← List.drop_eq_getElem_cons hi, List.take_append_drop]
-    have htlen : (xs.take i).length = i := by rw [List.length_take, Nat.min_eq_left hi.le]
-    have key := hout (xs.take i) (xs[i]) (xs.drop (i + 1))
-    rw [htlen, hdecomp] at key
+  · have key := hout (xs.take i) xs[i] (xs.drop (i + 1))
+    rw [List.length_take_of_le hi.le, ← List.drop_eq_getElem_cons hi,
+      List.take_append_drop] at key
     rw [List.getElem?_eq_getElem hi, Option.map_some, key]
   · rw [List.getElem?_eq_none hi, List.getElem?_eq_none (by rw [hlen]; exact hi)]
     simp
@@ -269,6 +123,6 @@ theorem isLetterLeftSubsequential_of_stateSummary
 example : IsLetterLeftSubsequential (id : List α → List α) :=
   isLetterLeftSubsequential_of_stateSummary
     (fun _ => ()) (fun _ _ => ()) (fun _ x => x)
-    (fun _ _ => rfl) (fun u x w => by simp) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ _ => by simp) (fun _ => rfl)
 
 end Subregular

--- a/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
@@ -27,6 +27,7 @@ what makes the dependency-footprint view coincide with the machine view.
 
 ## Main theorems
 
+* `isLetterLeftSubsequential_iff`: the universe-polymorphic characterization
 * `IsLetterLeftSubsequential.leftDetermined`, `.isRightMyopic`:
   letter-left-subsequential functions are prefix-determined, hence right-myopic
 * `isLetterLeftSubsequential_of_stateSummary`: the sufficiency half of Myhill–Nerode —
@@ -42,9 +43,10 @@ the parallel with the block class `IsLeftSubsequential`.
 
 ## TODO
 
-* Instantiate `isLetterLeftSubsequential_of_stateSummary` at the natural Nerode prefix
-  congruence, and prove the necessity direction: a letter-left-subsequential function
-  has a prefix congruence of finite index [choffrut-1977].
+* The full Myhill–Nerode characterization [choffrut-1977] in the style of
+  `Mathlib.Computability.MyhillNerode`: define the residual map of a length-preserving
+  function, build the canonical machine on `Set.range` of residuals, and prove
+  `IsLetterLeftSubsequential f ↔ (Set.range f.residual).Finite`.
 * Composition closure (state-product machine) and the right-scan mirror
   `IsLetterRightSubsequential` via reverse conjugation.
 -/
@@ -57,15 +59,22 @@ variable {α β : Type*}
 def IsLetterLeftSubsequential (f : List α → List β) : Prop :=
   ∃ (σ : Type) (_ : Fintype σ) (T : Mealy σ α β), T.run = f
 
-/-- Every finite-state `Mealy` witnesses `IsLetterLeftSubsequential` for its `run`.
-The state `σ` is accepted at arbitrary `Type*` and brought down to
-`Fin (Fintype.card σ) : Type 0` via `Mealy.reindex` and `Fintype.equivFin`, so
-bounded-window states at the alphabet's universe can witness the predicate (mirrors
+/-- `f` is letter-left-subsequential if and only if it is computed by a finite-state
+`Mealy` machine. This is more general than using the definition of
+`IsLetterLeftSubsequential` directly, as the state type `σ` is universe-polymorphic. -/
+theorem isLetterLeftSubsequential_iff.{v} {f : List α → List β} :
+    IsLetterLeftSubsequential f
+      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : Mealy σ α β), T.run = f :=
+  ⟨fun ⟨σ, _, T, h⟩ => ⟨ULift σ, inferInstance, Mealy.reindex Equiv.ulift.symm T,
+    h ▸ T.run_reindex _⟩,
+   fun ⟨σ, _, T, h⟩ => ⟨Fin (Fintype.card σ), inferInstance,
+    Mealy.reindex (Fintype.equivFin σ) T, h ▸ T.run_reindex _⟩⟩
+
+/-- Every finite-state `Mealy` computes a letter-left-subsequential function (mirrors
 `SFST.isLeftSubsequential`). -/
 theorem Mealy.isLetterLeftSubsequential {σ : Type*} [Fintype σ]
     (T : Mealy σ α β) : IsLetterLeftSubsequential T.run :=
-  ⟨Fin (Fintype.card σ), inferInstance, Mealy.reindex (Fintype.equivFin σ) T,
-   T.run_reindex _⟩
+  isLetterLeftSubsequential_iff.mpr ⟨σ, inferInstance, T, rfl⟩
 
 /-- A letter-left-subsequential map is left-determined at every coordinate — output `i`
 depends only on the prefix `{k | k ≤ i}`. (The *block* `IsLeftSubsequential` lacks
@@ -74,8 +83,9 @@ theorem IsLetterLeftSubsequential.leftDetermined {f : List α → List β}
     (hf : IsLetterLeftSubsequential f) (i : ℕ) : LeftDetermined f i := by
   obtain ⟨σ, _, T, rfl⟩ := hf
   intro u v hlen hag
-  rw [T.getElem?_run u, T.getElem?_run v, hag i (Set.mem_setOf.mpr le_rfl),
-    take_eq_of_agree fun k hk => hag k (Set.mem_setOf.mpr hk.le)]
+  simp only [Set.mem_setOf_eq] at hag
+  rw [T.getElem?_run u, T.getElem?_run v, hag i le_rfl,
+    take_eq_of_agree fun k hk => hag k hk.le]
 
 /-- A synchronous left-subsequential map is right-myopic: it has no look-ahead. -/
 theorem IsLetterLeftSubsequential.isRightMyopic {f : List α → List β}
@@ -116,11 +126,11 @@ theorem isLetterLeftSubsequential_of_stateSummary
     rw [List.length_take_of_le hi.le, ← List.drop_eq_getElem_cons hi,
       List.take_append_drop] at key
     rw [List.getElem?_eq_getElem hi, Option.map_some, key]
-  · rw [List.getElem?_eq_none hi, List.getElem?_eq_none (by rw [hlen]; exact hi)]
-    simp
+  · rw [List.getElem?_eq_none hi, List.getElem?_eq_none ((hlen xs).le.trans hi),
+      Option.map_none]
 
-/-- Non-vacuity: the identity is letter-left-subsequential via a one-state summary. -/
-example : IsLetterLeftSubsequential (id : List α → List α) :=
+/-- The identity is letter-left-subsequential, via a one-state summary. -/
+theorem isLetterLeftSubsequential_id : IsLetterLeftSubsequential (id : List α → List α) :=
   isLetterLeftSubsequential_of_stateSummary
     (fun _ => ()) (fun _ _ => ()) (fun _ x => x)
     (fun _ _ => rfl) (fun _ _ _ => by simp) (fun _ => rfl)

--- a/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/LetterSubsequential.lean
@@ -9,12 +9,12 @@ import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 /-!
 # Synchronous (letter) left-subsequential functions
 
-A `Mealy` machine is a deterministic left-to-right transducer emitting exactly one
-output symbol per input symbol — the synchronous case, length-preserving by
+A `Mealy` machine [mealy-1955] is a deterministic left-to-right transducer emitting
+exactly one output symbol per input symbol — the synchronous case, length-preserving by
 construction. Its output coordinate `i` is a function of the input prefix `[0..i]`, so
 the class is cleanly characterised by the `OutputDependsOn` footprint
 (`SideDeterminacy.lean`): `IsLetterLeftSubsequential f → ∀ i, LeftDetermined f i`, hence
-right-myopic.
+right-myopic (no look-ahead).
 
 This is the characterisation the *block* `IsLeftSubsequential` (`Subsequential.lean`)
 lacks: a length-preserving block transducer can delay output (emit `[]` then `[x,y]`),
@@ -25,18 +25,35 @@ machine view.
 ## Main definitions
 
 * `Mealy` — synchronous one-symbol-per-step transducer; `run` is length-preserving.
+* `Mealy.ofFlag` — the one-bit machine tracking "some earlier symbol satisfies `p`".
+* `Mealy.transferEquiv` — transport along a state equivalence, preserving `run`.
 * `IsLetterLeftSubsequential` — computed by a finite-state `Mealy`.
 
 ## Main results
 
-* `Mealy.runFrom_getElem?` — output `i` is `(step (state-after-prefix) (input i)).2`.
+* `Mealy.run_getElem?` — output `i` is `(step (state-after-prefix) (input i)).2`.
 * `IsLetterLeftSubsequential.leftDetermined` / `.isRightMyopic` — synchronous
   left-subsequential maps are prefix-determined, hence right-myopic.
+* `isLetterLeftSubsequential_of_stateSummary` — Myhill–Nerode, sufficiency direction:
+  a finite left-congruent state summary determining the output yields a `Mealy`.
 
-## Todo
+## Implementation notes
 
-* The Myhill–Nerode *converse*: `(∀ i, LeftDetermined f i) ∧ finite prefix-congruence ⟹
-  IsLetterLeftSubsequential f` (build the transducer from the prefix-congruence quotient).
+In the transducer literature [mohri-1997] *subsequential* machines carry a state-final
+output emitted at end of input; `Mealy` has none, so strictly it computes the
+letter-to-letter *sequential* class. Length preservation forces the final output empty,
+so the two classes coincide here; the name keeps the parallel with the block
+`IsLeftSubsequential`.
+
+[UPSTREAM] candidate (the `Mealy` API): `Mathlib.Computability.Mealy`.
+
+## TODO
+
+* Instantiate `isLetterLeftSubsequential_of_stateSummary` at the natural Nerode prefix
+  congruence, and prove the necessity direction: a letter-left-subsequential function
+  has a finite-index prefix congruence [choffrut-1977].
+* Composition closure (state-product `Mealy`) and the right-scan mirror
+  `IsLetterRightSubsequential` via reverse conjugation.
 -/
 
 namespace Subregular
@@ -71,6 +88,12 @@ def run (T : Mealy σ α β) : List α → List β := T.runFrom T.initial
 @[simp] theorem stateAfter_cons (T : Mealy σ α β) (s : σ) (x : α) (xs : List α) :
     T.stateAfter s (x :: xs) = T.stateAfter (T.step s x).1 xs := rfl
 
+theorem stateAfter_append (T : Mealy σ α β) (s : σ) (xs ys : List α) :
+    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys := by
+  induction xs generalizing s with
+  | nil => rfl
+  | cons x xs ih => simp [ih]
+
 /-- The run is length-preserving (one output symbol per input symbol). -/
 theorem runFrom_length (T : Mealy σ α β) (s : σ) (xs : List α) :
     (T.runFrom s xs).length = xs.length := by
@@ -93,6 +116,12 @@ theorem runFrom_getElem? (T : Mealy σ α β) (s : σ) (xs : List α) (i : ℕ) 
     | zero => simp
     | succ j => simp [ih, List.take_succ_cons]
 
+/-- The coordinate characterization from the initial state. -/
+theorem run_getElem? (T : Mealy σ α β) (xs : List α) (i : ℕ) :
+    (T.run xs)[i]?
+      = (xs[i]?).map (fun x => (T.step (T.stateAfter T.initial (xs.take i)) x).2) :=
+  T.runFrom_getElem? T.initial xs i
+
 /-! ### Flag machines
 
 The recurring one-sided-trigger shape (the `Mealy` counterpart of `Bimachine.ofFlags`):
@@ -107,23 +136,21 @@ def ofFlag (p : α → Bool) (out : Bool → α → β) : Mealy Bool α β where
   initial := false
   step b a := (b || p a, out b a)
 
+@[simp] theorem ofFlag_initial (p : α → Bool) (out : Bool → α → β) :
+    (ofFlag p out).initial = false := rfl
+
+@[simp] theorem ofFlag_step (p : α → Bool) (out : Bool → α → β) (b : Bool) (a : α) :
+    (ofFlag p out).step b a = (b || p a, out b a) := rfl
+
 @[simp] theorem ofFlag_stateAfter (p : α → Bool) (out : Bool → α → β) (b : Bool)
     (xs : List α) : (ofFlag p out).stateAfter b xs = (b || xs.any p) := by
   induction xs generalizing b with
   | nil => simp
-  | cons x xs ih =>
-    rw [stateAfter_cons, show ((ofFlag p out).step b x).1 = (b || p x) from rfl, ih]
-    simp [Bool.or_assoc]
+  | cons x xs ih => simp [ih, Bool.or_assoc]
 
 theorem ofFlag_run_getElem? (p : α → Bool) (out : Bool → α → β) (xs : List α) (i : ℕ) :
     ((ofFlag p out).run xs)[i]? = xs[i]?.map fun a => out ((xs.take i).any p) a := by
-  rw [show (ofFlag p out).run xs = (ofFlag p out).runFrom (ofFlag p out).initial xs from rfl,
-    runFrom_getElem?]
-  cases xs[i]? with
-  | none => rfl
-  | some a =>
-    rw [ofFlag_stateAfter, show (ofFlag p out).initial = false from rfl, Bool.false_or]
-    rfl
+  simp [run_getElem?]
 
 /-- Coordinates of a flag machine scanned right-to-left: cell `i` sees the flag over its
 strict suffix. -/
@@ -192,24 +219,22 @@ theorem IsLetterLeftSubsequential.leftDetermined {f : List α → List β}
   have hi : u[i]? = v[i]? := hag i (by simp)
   have htake : u.take i = v.take i :=
     take_eq_of_agree fun k hk => hag k (by simp only [Set.mem_setOf_eq]; omega)
-  show (T.runFrom T.initial u)[i]? = (T.runFrom T.initial v)[i]?
-  rw [Mealy.runFrom_getElem? T T.initial u i,
-      Mealy.runFrom_getElem? T T.initial v i, hi, htake]
+  rw [T.run_getElem? u, T.run_getElem? v, hi, htake]
 
 /-- A synchronous left-subsequential map is **right-myopic** — it has no look-ahead. -/
 theorem IsLetterLeftSubsequential.isRightMyopic {f : List α → List β}
     (hf : IsLetterLeftSubsequential f) : IsMyopicTowards f .right :=
   IsMyopicTowards.right_of_leftDetermined hf.leftDetermined
 
-/-! ### Myhill–Nerode converse
+/-! ### Myhill–Nerode: the sufficiency direction
 
 `f` is letter-left-subsequential as soon as it admits a *finite-state, left-congruent
-summary that determines its output* — the constructive direction of Myhill–Nerode. The
-finite `state` plays the role of the prefix-congruence's quotient; `δ`/`out` are the
-induced transition and output. (The natural Nerode congruence, when of finite index, is
-one such summary — that instantiation is the Todo above.) -/
+summary that determines its output*. The finite `state` plays the role of the
+prefix-congruence's quotient; `δ`/`out` are the induced transition and output. (The
+natural Nerode congruence, when of finite index, is one such summary — that
+instantiation, and the necessity direction, are the TODO above.) -/
 
-/-- **Myhill–Nerode converse (constructive).** A length-preserving `f` with a finite
+/-- **Myhill–Nerode, sufficiency.** A length-preserving `f` with a finite
 `state : List α → σ` that is left-congruent (`hδ`) and determines `f`'s output at each
 position (`hout`) is letter-left-subsequential. -/
 theorem isLetterLeftSubsequential_of_stateSummary
@@ -221,22 +246,15 @@ theorem isLetterLeftSubsequential_of_stateSummary
     IsLetterLeftSubsequential f := by
   refine ⟨σ, inferInstance, { initial := state [], step := fun s x => (δ s x, out s x) }, ?_⟩
   set T : Mealy σ α β := { initial := state [], step := fun s x => (δ s x, out s x) }
-  have hstate : ∀ (p₀ ps : List α), T.stateAfter (state p₀) ps = state (p₀ ++ ps) := by
-    intro p₀ ps
-    induction ps generalizing p₀ with
-    | nil => simp
-    | cons x xs ih =>
-      rw [Mealy.stateAfter_cons]
-      show T.stateAfter (δ (state p₀) x) xs = state (p₀ ++ x :: xs)
-      rw [← hδ p₀ x, ih (p₀ ++ [x])]
-      simp
+  have hstate : ∀ ps : List α, T.stateAfter T.initial ps = state ps := by
+    intro ps
+    induction ps using List.reverseRecOn with
+    | nil => rfl
+    | append_singleton ps x ih => rw [T.stateAfter_append, ih, hδ]; rfl
   funext xs
   apply List.ext_getElem?
   intro i
-  show (T.runFrom T.initial xs)[i]? = (f xs)[i]?
-  rw [Mealy.runFrom_getElem? T T.initial xs i]
-  show (xs[i]?).map (fun x => out (T.stateAfter (state []) (xs.take i)) x) = (f xs)[i]?
-  rw [hstate [] (xs.take i), List.nil_append]
+  rw [T.run_getElem? xs i, hstate]
   rcases lt_or_ge i xs.length with hi | hi
   · have hdecomp : xs.take i ++ xs[i] :: xs.drop (i + 1) = xs := by
       rw [← List.drop_eq_getElem_cons hi, List.take_append_drop]

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -154,12 +154,12 @@ def resolveRight : Mealy Bool Mark TBU :=
   .ofFlag (· == .H) fun r a =>
     match a with | .H => .H | .O => .O | .Q => if r then .H else .O
 
-/-- The right pass as a right-to-left string function: reverse, run, reverse. -/
-def resolve (x : List Mark) : List TBU := (resolveRight.run x.reverse).reverse
+/-- The right pass as a right-to-left string function (`Mealy.runRight`). -/
+def resolve (x : List Mark) : List TBU := resolveRight.runRight x
 
 private theorem markLeft_run_H_iff (w : List TBU) (j : ℕ) :
     (markLeft.run w)[j]? = some Mark.H ↔ w[j]? = some TBU.H := by
-  rw [markLeft, Mealy.ofFlag_run_getElem?]
+  rw [markLeft, Mealy.getElem?_ofFlag_run]
   cases hv : w[j]? with
   | none => simp
   | some a => cases a <;> simp [ite_eq_iff]
@@ -169,9 +169,9 @@ theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w
   have hmark : ∀ i : ℕ, Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) :=
     fun i => by simp only [List.mem_drop_iff, markLeft_run_H_iff]
   refine List.ext_getElem? fun i => ?_
-  rw [utp.map_getElem?, resolve, resolveRight, Mealy.ofFlag_run_reverse_getElem?]
+  rw [utp.map_getElem?, resolve, resolveRight, Mealy.getElem?_ofFlag_runRight]
   simp only [List.any_beq', List.contains_eq_mem, decide_eq_decide.mpr (hmark i)]
-  rw [markLeft, Mealy.ofFlag_run_getElem?, Option.map_map]
+  rw [markLeft, Mealy.getElem?_ofFlag_run, Option.map_map]
   simp only [List.any_beq', List.contains_eq_mem]
   cases ha : w[i]? with
   | none => rfl
@@ -193,7 +193,7 @@ theorem utp_markup_decomposition :
     funext utp_eq_resolve_mark⟩
   rw [isRightSubsequential_iff_left_reverse]
   have heq : (fun xs : List Mark => (resolve xs.reverse).reverse) = resolveRight.run := by
-    funext xs; rw [resolve, List.reverse_reverse, List.reverse_reverse]
+    funext xs; simp [resolve]
   exact heq ▸ resolveRight.isLetterLeftSubsequential.isLeftSubsequential
 
 /-! ### The autosegmental grounding ((40), §4.4)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30281,7 +30281,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/LetterSubsequential.lean}
+  sources   = {Core/Computability/Mealy.lean}
 }
 
 @article{choffrut-1977,

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30269,6 +30269,36 @@
 % REF: Mohri (1997). Finite-State Transducers in Language and Speech
 % Processing. Computational Linguistics 23(2):269-311. ACL Anthology J97-2003.
 % Foundational subsequential FST reference.
+@article{mealy-1955,
+  author    = {Mealy, George H.},
+  year      = {1955},
+  title     = {A Method for Synthesizing Sequential Circuits},
+  journal   = {The Bell System Technical Journal},
+  volume    = {34},
+  number    = {5},
+  pages     = {1045--1079},
+  doi       = {10.1002/j.1538-7305.1955.tb03788.x},
+  subfield  = {phonology/subregular},
+  role      = {foundational},
+  validated = {true},
+  sources   = {Core/Computability/Subregular/Function/LetterSubsequential.lean}
+}
+
+@article{choffrut-1977,
+  author    = {Choffrut, Christian},
+  year      = {1977},
+  title     = {Une caract\'erisation des fonctions s\'equentielles et des fonctions sous-s\'equentielles en tant que relations rationnelles},
+  journal   = {Theoretical Computer Science},
+  volume    = {5},
+  number    = {3},
+  pages     = {325--337},
+  doi       = {10.1016/0304-3975(77)90049-4},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Computability/Subregular/Function/LetterSubsequential.lean}
+}
+
 @article{mohri-1997,
   author    = {Mohri, Mehryar},
   year      = {1997},


### PR DESCRIPTION
Audit-driven polish of the Mealy/letter-subsequential substrate toward mathlib-upstreamable quality: module docstring rewritten (verified citations [mealy-1955]/[mohri-1997]/[choffrut-1977], sequential-vs-subsequential terminology note, [UPSTREAM] marker, stale Todo narrowed to the Nerode instantiation), new `run_getElem?`/`stateAfter_append`/`ofFlag` projection lemmas, and proof golf (converse's `hstate` via `reverseRecOn`, `show … from rfl` boilerplate collapsed here and in Hierarchy).