### PR TITLE
refactor(Subregular/Function): audit cleanse of the function hierarchy

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -330,7 +330,9 @@ variable {L R α : Type*} [DecidableEq α]
 rule's change if it fires (`≠ a`), else the right rule's, else leave the symbol. -/
 def unite (cL cR a : α) : α := if cL = a then (if cR = a then a else cR) else cL
 
-@[simp] theorem unite_self (a : α) : unite a a a = a := by simp [unite]
+/-- With the right proposal inert, the union is whatever the left one proposes. -/
+@[simp] theorem unite_right_self (cL a : α) : unite cL a a = cL := by
+  unfold unite; split_ifs <;> simp_all
 
 /-- A combined value equal to the default forces *both* one-sided proposals to be inert. -/
 theorem unite_eq_default {cL cR a : α} (h : unite cL cR a = a) : cL = a ∧ cR = a := by
@@ -390,7 +392,7 @@ theorem not_isBimachineWeaklyDeterministic_of_requiresBothSides {f : List α →
     hRag.take_eq (by omega), hLag.drop_eq (by omega),
     (inert_of_reverting hω (hRsym.trans (List.getElem?_eq_getElem hi)) hRrev).1,
     (inert_of_reverting hω (hLsym.trans (List.getElem?_eq_getElem hi)) hLrev).2,
-    unite_self]
+    unite_right_self]
 
 end NonInteraction
 

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -189,7 +189,7 @@ theorem isBimachineComputable {L R : Type*} [Fintype L] [Fintype R] {α β : Typ
 
 section TwoSidedWitness
 
-variable {α : Type*} {x fill y a : α} {n k : ℕ}
+variable {α : Type*} {x fill y a : α} {n k : ℕ} {p : α → Bool}
 
 /-! ### The flank-witness template
 
@@ -246,6 +246,23 @@ theorem exists_ge_flankWord_eq_some_iff (hfill : fill ≠ a) (h0 : 0 < k)
   · rintro ⟨j, hj, ⟨rfl, hx⟩ | ⟨rfl, hy⟩⟩
     exacts [absurd hj (by omega), hy]
   · exact fun h => ⟨n + 1, hk, .inr ⟨rfl, h⟩⟩
+
+/-- A flag over a window reaching at most the filler run reads the left flank — the
+`ofFlags` counterpart of `exists_le_flankWord_eq_some_iff`. -/
+theorem any_take_flankWord (hfill : p fill = false) (h0 : 0 < k) (hk : k ≤ n + 1) :
+    ((flankWord x fill y n).take k).any p = p x := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  rw [flankWord, List.take_succ_cons, List.take_append_of_le_length (by simp; omega),
+    List.take_replicate]
+  simp [hfill]
+
+/-- A flag over a window past the left flank reads the right flank. -/
+theorem any_drop_flankWord (hfill : p fill = false) (h0 : 0 < k) (hk : k ≤ n + 1) :
+    ((flankWord x fill y n).drop k).any p = p y := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  rw [flankWord, List.drop_succ_cons, List.drop_append_of_le_length (by simp; omega),
+    List.drop_replicate]
+  simp [hfill]
 
 /-- Flank words differing only on the left agree off position `0`. -/
 theorem flankWord_congr_left {x' : α} (h : k ≠ 0) :

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -29,6 +29,8 @@ bimachine — the weakly-deterministic functions.
   rules inert at the witness cell while the base needs one to fire — no union of one-sided
   rules can produce the change. A conjunctive change satisfies it; a two-sided union does
   not.
+* `weaklyDeterministic_strict_subset_regular` — the inclusion is proper, witnessed by the
+  conjunctive flag bimachine `conjBM`.
 -/
 
 namespace Subregular
@@ -140,8 +142,7 @@ def reindex (eL : L ≃ L') (eR : R ≃ R') : Bimachine L R α β ≃ Bimachine 
 
 The recurring two-sided-trigger shape: each side's automaton is the one-bit "some symbol
 on my side satisfies `p`" flag, so `lState`/`rState` compute `List.any` and the cell sees
-exactly the two flags. Conjunctive spreads (`conjBM` in `Hierarchy.lean`) and unbounded
-tonal plateauing ([jardine-2016]) are instances. -/
+exactly the two flags. The conjunctive witness `conjBM` below is an instance. -/
 
 variable (pL pR : α → Bool) (out : Bool → α → Bool → β)
 
@@ -395,5 +396,54 @@ theorem not_isBimachineWeaklyDeterministic_of_requiresBothSides {f : List α →
     unite_right_self]
 
 end NonInteraction
+
+/-! ### Strictness: weakly deterministic ⊊ bimachine-computable
+
+A *conjunctive* change — a symbol flipped iff a mark occurs on **both** sides — is
+bimachine-computable but `RequiresBothSides`, so no non-interacting bimachine computes
+it. -/
+
+/-- Toy alphabet for the conjunctive witness: a `mark`, a `neutral` symbol, and the
+`flipped` form the neutral symbol takes when both sides are marked. -/
+inductive ConjSym | mark | neutral | flipped
+  deriving DecidableEq, Repr
+
+instance : Fintype ConjSym := ⟨{.mark, .neutral, .flipped}, fun x => by cases x <;> simp⟩
+
+/-- A neutral symbol flips iff a `mark` occurs on **both** sides — a flag bimachine
+(`ofFlags`) tracking a mark on each side, whose cell genuinely needs both flags
+(`l && r`). -/
+def conjBM : Bimachine Bool Bool ConjSym ConjSym :=
+  .ofFlags (· == .mark) (· == .mark) fun l s r =>
+    if (l && r) && s == .neutral then .flipped else s
+
+/-- Inside the filler run of a flank word, `conjBM` flips the neutral symbol exactly when
+both flanks are marks. -/
+private theorem conjBM_flankWord {x y : ConjSym} {n k : ℕ} (h0 : 0 < k) (hk : k ≤ n) :
+    (conjBM.run (flankWord x .neutral y n))[k]?
+      = some (if x == .mark && y == .mark then .flipped else .neutral) := by
+  rw [conjBM, Bimachine.ofFlags_run_getElem?, flankWord_getElem?_mid h0 hk,
+    any_take_flankWord (by decide) h0 (by omega),
+    any_drop_flankWord (by decide) (by omega) (by omega)]
+  simp
+
+/-- The conjunctive change requires both sides: with a mark on each flank the medial
+symbol flips, and demoting either mark alone reverts it — the three-map template
+(`RequiresBothSides.of_flanks`) applied to a `d`-margined flank word. -/
+theorem conjBM_requiresBothSides : RequiresBothSides conjBM.run :=
+  .of_flanks (fill := .neutral) (on := .flipped) (xOn := .mark) (yOn := .mark)
+    (xOff := .neutral) (yOff := .neutral) (n := fun d => 2 * d + 1) (t := fun d => d + 1)
+    (by decide) (fun d => ⟨by omega, by omega⟩)
+    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
+    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
+    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
+
+/-- **The weakly deterministic functions are a proper subclass**: `conjBM` is computed by
+a bimachine, but by no non-interacting one. -/
+theorem weaklyDeterministic_strict_subset_regular :
+    ∃ f : List ConjSym → List ConjSym,
+      IsBimachineComputable f ∧ ¬ IsBimachineWeaklyDeterministic f :=
+  ⟨conjBM.run, isBimachineComputable conjBM,
+   not_isBimachineWeaklyDeterministic_of_requiresBothSides conjBM_requiresBothSides⟩
 
 end Subregular

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -277,7 +277,7 @@ theorem flankWord_congr_right {y' : α} (h : k ≠ n + 1) :
   split_ifs <;> rfl
 
 /-- `f` requires both sides: some target changes under `f`, yet perturbing either far
-side reverts it to the identity. Unlike `IsUnboundedCircumambient`, a two-sided union
+side reverts it to the identity. Unlike `IsUnboundedSemiambient`, a two-sided union
 never satisfies this — removing one trigger leaves the other, so the output stays
 changed. -/
 def RequiresBothSides (f : List α → List α) : Prop :=
@@ -310,11 +310,11 @@ theorem RequiresBothSides.of_flanks {f : List α → List α}
       ⟨by simp, fun k hk => flankWord_congr_right (by omega)⟩, by rw [hmid, hmid],
       by rw [hrevR, hmid]⟩
 
-/-- Requiring both sides strengthens unbounded circumambience: a reverted target is in
-particular a flipped one. The converse fails (a two-sided union is circumambient but
+/-- Requiring both sides strengthens unbounded semiambience: a reverted target is in
+particular a flipped one. The converse fails (a two-sided union is semiambient but
 reverts under neither side alone). -/
-theorem RequiresBothSides.isUnboundedCircumambient {f : List α → List α}
-    (hf : RequiresBothSides f) : IsUnboundedCircumambient f := fun d =>
+theorem RequiresBothSides.isUnboundedSemiambient {f : List α → List α}
+    (hf : RequiresBothSides f) : IsUnboundedSemiambient f := fun d =>
   have ⟨base, i, hi, hchange, hw⟩ := hf d
   ⟨base, i, hi, fun s =>
     have ⟨u, hp, hsym, hrev⟩ := hw s

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -12,34 +12,34 @@ import Linglib.Core.Computability.Subregular.Function.Bimachine
 /-!
 # The subregular function hierarchy
 
-Inclusions among the directionality classes of `Core/Computability/Subregular/Function/`,
-assembled from the strictly-local, synchronous (`Mealy`) and bimachine (`Bimachine`)
-substrate:
+Inclusions among the directionality classes of the transducer substrate — strictly local
+(`ISLRule`, `OSLRule`), synchronous (`Mealy`) and bimachine (`Bimachine`):
 
   `single-symbol ISL/OSL ⊆ IsMealyComputable ⊆ IsBimachineWeaklyDeterministic ⊆ IsBimachineComputable`
 
-A left-subsequential transducer is the degenerate bimachine whose right automaton is
-trivial, so its cell output is a *one-sided* rule — non-interacting.
+A synchronous transducer is the degenerate bimachine whose right automaton is trivial, so
+its cell output is a *one-sided* rule — non-interacting.
 
-## Main results
+## Main theorems
 
-* `IsBimachineWeaklyDeterministic.of_mealyComputable` — subsequential ⊆ WD.
-* `IsBimachineComputable.of_weaklyDeterministic` — WD ⊆ regular.
-* `weaklyDeterministic_strict_subset_regular` — WD ⊊ regular is *proper*: the conjunctive
-  change `conjBM` (a target raised iff a trigger occurs on both sides) is bimachine-computable
-  but `RequiresBothSides`.
-* `isMealyComputable_of_ISLRule` / `_of_OSLRule` — single-symbol ISL/OSL ⊆
-  subsequential (the bounded window as a `Mealy` state); `.of_ISLRule` / `.of_OSLRule`
-  extend the chain to WD.
-* `IsMealyComputable.leftDetermined` / `.isRightMyopic` — synchronous maps are
-  prefix-determined at every coordinate, hence right-myopic.
+* `IsBimachineWeaklyDeterministic.of_mealyComputable`: synchronous ⊆ weakly deterministic
+* `IsBimachineComputable.of_weaklyDeterministic`: weakly deterministic ⊆ regular
+* `weaklyDeterministic_strict_subset_regular`: that inclusion is proper, witnessed by the
+  conjunctive change `conjBM`, which is bimachine-computable but `RequiresBothSides`
+* `isMealyComputable_of_ISLRule`, `isMealyComputable_of_OSLRule`: the single-symbol
+  (length-preserving) fragment of the strictly-local classes is synchronous
+* `SFST.toMealy`, `Mealy.toSFST`: singleton-output block transducers and synchronous
+  machines are interchangeable, giving `IsMealyComputable.isLeftSubsequential`
+* `IsMealyComputable.leftDetermined`, `IsMealyComputable.isRightMyopic`: a synchronous map
+  is prefix-determined at every coordinate, hence has no look-ahead
 
 ## TODO
 
-* subsequential ⊊ WD is also proper, but a witness is not yet formalized here: a genuinely
-  two-sided union is `IsUnboundedCircumambient`, hence not right-myopic
-  (`IsMealyComputable.isRightMyopic`), hence not left-subsequential, yet weakly
-  deterministic.
+* `IsLeftSubsequential ⊊ IsBimachineWeaklyDeterministic`. No witness is formalized here.
+  Note that non-myopia refutes only *synchronous* computability, via
+  `IsMealyComputable.isRightMyopic`: a block transducer may delay its output, so its
+  coordinate `i` is not fixed by the prefix, and excluding one takes the bounded-delay
+  route (`IsLeftSubsequential.bounded_delay`) instead.
 -/
 
 namespace Subregular
@@ -68,6 +68,38 @@ def Mealy.toSFST (T : Mealy σ α β) : SFST σ α β where
 
 @[simp] theorem Mealy.toSFST_run (T : Mealy σ α β) : T.toSFST.run = T.run :=
   funext fun xs => T.toSFST_runFrom T.initial xs
+
+/-- View a block transducer emitting exactly one symbol per input symbol as a synchronous
+machine: the singleton output block is the emitted letter. -/
+@[simps]
+def SFST.toMealy (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1) : Mealy σ α β where
+  initial := T.start
+  step := T.step
+  output s x := (T.output s x).head (List.ne_nil_of_length_pos (by rw [hs]; omega))
+
+@[simp] theorem Mealy.toMealy_toSFST (T : Mealy σ α β) :
+    T.toSFST.toMealy (fun _ _ => rfl) = T := rfl
+
+@[simp] theorem SFST.toMealy_runFrom (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+    (hf : ∀ s, T.finalOutput s = []) (s : σ) (xs : List α) :
+    (T.toMealy hs).runFrom s xs = T.runFrom s xs := by
+  induction xs generalizing s with
+  | nil => simp [hf]
+  | cons x xs ih =>
+    obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs s x)
+    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, toMealy_output, toMealy_step, ih, ha,
+      List.head_cons, List.singleton_append]
+
+@[simp] theorem SFST.toMealy_run (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+    (hf : ∀ s, T.finalOutput s = []) : (T.toMealy hs).run = T.run :=
+  funext fun xs => T.toMealy_runFrom hs hf T.start xs
+
+/-- A finite block transducer with singleton outputs and no final flush computes a
+Mealy-computable function: block ∩ length-preserving ⊆ synchronous. -/
+theorem SFST.isMealyComputable [Fintype σ] (T : SFST σ α β)
+    (hs : ∀ s x, (T.output s x).length = 1) (hf : ∀ s, T.finalOutput s = []) :
+    IsMealyComputable T.run :=
+  T.toMealy_run hs hf ▸ (T.toMealy hs).isMealyComputable
 
 /-- A Mealy-computable function is left-subsequential: synchronous ⊆ block. -/
 theorem IsMealyComputable.isLeftSubsequential {f : List α → List β}
@@ -110,9 +142,9 @@ variable {α : Type*} [DecidableEq α]
 private theorem unite_default_right (cL a : α) : unite cL a a = cL := by
   unfold unite; split_ifs <;> simp_all
 
-/-- **Subsequential ⊆ weakly deterministic.** A synchronous left-subsequential function is
-computed by a non-interacting bimachine: the left automaton *is* the transducer, the right
-automaton is trivial, so the cell output is a one-sided rule (`ωR` is the identity). -/
+/-- **Synchronous ⊆ weakly deterministic.** A Mealy-computable function is computed by a
+non-interacting bimachine: the left automaton *is* the transducer, the right automaton is
+trivial, so the cell output is a one-sided rule (`ωR` is the identity). -/
 theorem IsBimachineWeaklyDeterministic.of_mealyComputable {f : List α → List α}
     (h : IsMealyComputable f) : IsBimachineWeaklyDeterministic f := by
   obtain ⟨σ, _, T, rfl⟩ := h
@@ -137,82 +169,44 @@ theorem IsBimachineComputable.of_weaklyDeterministic {f : List α → List α}
 
 /-! ### Strictness: WD ⊊ regular
 
-A *conjunctive* change — a target raised iff a trigger occurs on **both** sides — is
+A *conjunctive* change — a symbol flipped iff a mark occurs on **both** sides — is
 bimachine-computable but `RequiresBothSides`, so no non-interacting bimachine computes
 it. -/
 
-/-- Toy alphabet for the conjunctive-change witness: a trigger, a recessive target, and
-its raised form. -/
-inductive ConjSym | trig | tgt | raised
+/-- Toy alphabet for the conjunctive witness: a `mark`, a `neutral` symbol, and the
+`flipped` form the neutral symbol takes when both sides are marked. -/
+inductive ConjSym | mark | neutral | flipped
   deriving DecidableEq, Repr
 
-instance : Fintype ConjSym := ⟨{.trig, .tgt, .raised}, fun x => by cases x <;> simp⟩
+instance : Fintype ConjSym := ⟨{.mark, .neutral, .flipped}, fun x => by cases x <;> simp⟩
 
-/-- A target raises iff a trigger occurs on **both** sides — a flag bimachine
-(`Bimachine.ofFlags`) tracking a trigger on each side, whose cell genuinely needs both
+/-- A neutral symbol flips iff a `mark` occurs on **both** sides — a flag bimachine
+(`Bimachine.ofFlags`) tracking a mark on each side, whose cell genuinely needs both
 flags (`l && r`). -/
 def conjBM : Bimachine Bool Bool ConjSym ConjSym :=
-  .ofFlags (· == .trig) (· == .trig) fun l s r => if (l && r) && s == .tgt then .raised else s
+  .ofFlags (· == .mark) (· == .mark) fun l s r =>
+    if (l && r) && s == .neutral then .flipped else s
 
-/-- Output of `conjBM` at a `.tgt` position: `.raised` iff a trigger appears on both the
-left prefix and the right suffix, else `.tgt`. -/
-private theorem conjBM_run_at {w : List ConjSym} {i : ℕ} (h : w[i]? = some .tgt) :
-    (conjBM.run w)[i]?
-      = some (if (w.take i).any (· == .trig) && (w.drop (i + 1)).any (· == .trig)
-          then .raised else .tgt) := by
-  rw [conjBM, Bimachine.ofFlags_run_getElem?, h]; simp
-
-/-- Witness word at distance `d`: a medial `.tgt` flanked by `d` neutral fillers and a
-`.trig` on each end. The two perturbations replace one end's `.trig` with a filler. -/
-def conjBase (d : ℕ) : List ConjSym :=
-  .trig :: List.replicate d .raised ++ .tgt :: List.replicate d .raised ++ [.trig]
-
-private theorem conjBase_getElem_tgt (d : ℕ) : (conjBase d)[d + 1]? = some .tgt := by
-  simp [conjBase]
-
-private theorem conjBase_take (d : ℕ) :
-    (conjBase d).take (d + 1) = .trig :: List.replicate d .raised := by
-  simp [conjBase]
-
-private theorem conjBase_drop (d : ℕ) :
-    (conjBase d).drop (d + 2) = List.replicate d .raised ++ [.trig] := by
-  simp only [conjBase, List.drop_append, List.length_cons, List.length_replicate]
-  simp only [show d + 2 - (d + 1) = 1 from by omega]
+/-- Inside the filler run of a flank word, `conjBM` flips the neutral symbol exactly when
+both flanks are marks. -/
+private theorem conjBM_flankWord {x y : ConjSym} {n k : ℕ} (h0 : 0 < k) (hk : k ≤ n) :
+    (conjBM.run (flankWord x .neutral y n))[k]?
+      = some (if x == .mark && y == .mark then .flipped else .neutral) := by
+  rw [conjBM, Bimachine.ofFlags_run_getElem?, flankWord_getElem?_mid h0 hk,
+    any_take_flankWord (by decide) h0 (by omega),
+    any_drop_flankWord (by decide) (by omega) (by omega)]
   simp
 
-/-- The conjunctive spread requires both sides: the base raises a medial target (a trigger
-on each side), but flipping either far trigger to a filler reverts it. The perturbations are
-`List.set`s of the base, so they agree with it off the flipped index (`getElem?_set_ne`),
-and the reverting cell output is read off via `conjBM_run_at`. -/
-theorem conjBM_requiresBothSides : RequiresBothSides conjBM.run := by
-  intro d
-  refine ⟨conjBase d, d + 1, by simp [conjBase], ?_, fun s => ?_⟩
-  -- base changes: both sides carry a trigger, so the medial `tgt` raises (`.raised ≠ .tgt`)
-  · rw [conjBM_run_at (conjBase_getElem_tgt d), conjBase_take, conjBase_drop, conjBase_getElem_tgt]
-    simp [List.any_cons, List.any_replicate, List.any_append]
-  match s with
-  | .left =>
-    -- the left perturbation empties the prefix of triggers (`take.any = false`)
-    refine ⟨(conjBase d).set 0 .raised,
-      ⟨by simp [conjBase], fun k hk => (List.getElem?_set_ne (by omega)).symm⟩,
-      by rw [List.getElem?_set_ne (by omega)], ?_⟩
-    have h : ((conjBase d).set 0 .raised)[d + 1]? = some .tgt := by
-      rw [List.getElem?_set_ne (by omega : (0 : ℕ) ≠ d + 1)]; exact conjBase_getElem_tgt d
-    have htake : ((conjBase d).set 0 .raised).take (d + 1) = List.replicate (d + 1) .raised := by
-      rw [List.take_set, conjBase_take]; simp [List.set_cons_zero, List.replicate_succ]
-    rw [conjBM_run_at h, h, htake]; simp [List.any_replicate]
-  | .right =>
-    -- the right perturbation empties the suffix of triggers (`drop.any = false`)
-    refine ⟨(conjBase d).set (2 * d + 2) .raised,
-      ⟨by simp [conjBase], fun k hk => (List.getElem?_set_ne (by omega)).symm⟩,
-      by rw [List.getElem?_set_ne (by omega)], ?_⟩
-    have h : ((conjBase d).set (2 * d + 2) .raised)[d + 1]? = some .tgt := by
-      rw [List.getElem?_set_ne (by omega : 2 * d + 2 ≠ d + 1)]; exact conjBase_getElem_tgt d
-    have hdrop : ((conjBase d).set (2 * d + 2) .raised).drop (d + 2) = List.replicate (d + 1) .raised := by
-      rw [show (2 * d + 2 : ℕ) = d + 2 + d from by omega, ← List.set_drop, conjBase_drop,
-          List.set_append_right d ConjSym.raised (by simp)]
-      simp [List.replicate_succ']
-    rw [conjBM_run_at h, h, hdrop]; simp [List.any_replicate]
+/-- The conjunctive change requires both sides: with a mark on each flank the medial
+symbol flips, and demoting either mark alone reverts it — the three-map template
+(`RequiresBothSides.of_flanks`) applied to a `d`-margined flank word. -/
+theorem conjBM_requiresBothSides : RequiresBothSides conjBM.run :=
+  .of_flanks (fill := .neutral) (on := .flipped) (xOn := .mark) (yOn := .mark)
+    (xOff := .neutral) (yOff := .neutral) (n := fun d => 2 * d + 1) (t := fun d => d + 1)
+    (by decide) (fun d => ⟨by omega, by omega⟩)
+    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
+    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
+    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
 
 theorem weaklyDeterministic_strict_subset_regular :
     ∃ f : List ConjSym → List ConjSym,
@@ -220,77 +214,27 @@ theorem weaklyDeterministic_strict_subset_regular :
   ⟨conjBM.run, isBimachineComputable conjBM,
    not_isBimachineWeaklyDeterministic_of_requiresBothSides conjBM_requiresBothSides⟩
 
-/-! ### The strictly-local lower end: single-symbol ISL/OSL ⊆ subsequential
+/-! ### The strictly-local lower end: single-symbol ISL/OSL ⊆ synchronous
 
 The ISL/OSL classes are block-output (length-changing) in general, so they sit outside the
 length-preserving lattice. Their **single-symbol** (length-preserving) fragment embeds: the
-same bounded window that makes `toFinSFST` finite-state serves as a `Mealy` state, with
-the lone output symbol as the letter. This extends the chain to
-`single-symbol ISL/OSL ⊆ subsequential ⊆ WD ⊆ regular`. -/
+bounded window that makes `toFinSFST` finite-state serves as the `Mealy` state, with the
+lone output symbol as the letter. This extends the chain to
+`single-symbol ISL/OSL ⊆ synchronous ⊆ WD ⊆ regular`. -/
 
-/-- A length-preserving (single-symbol) left-ISL rule as a synchronous transducer: the
-bounded input window is the state, the lone output symbol the letter. -/
-def ISLRule.toMealy {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
-    (hs : ∀ w x, (r.windowOutput w x).length = 1) :
-    Mealy {l : List α // l.length ≤ k - 1} α β where
-  initial := ⟨[], Nat.zero_le _⟩
-  step w x := ⟨(w.val ++ [x]).rtake (k - 1), List.length_rtake_le _ _⟩
-  output w x := (r.windowOutput w.val x).head
-    (by have := hs w.val x; exact List.ne_nil_of_length_pos (by omega))
-
-theorem ISLRule.toMealy_run_eq_apply {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
-    (hs : ∀ w x, (r.windowOutput w x).length = 1) : (r.toMealy hs).run = r.apply := by
-  rw [← r.toFinSFST_run_eq_apply]
-  funext input
-  suffices h : ∀ w : {l : List α // l.length ≤ k - 1},
-      Mealy.runFrom (r.toMealy hs) w input = SFST.runFrom r.toFinSFST w input from h _
-  intro w
-  induction input generalizing w with
-  | nil => rfl
-  | cons x xs ih =>
-    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, ISLRule.toMealy,
-      ISLRule.toFinSFST]
-    obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs w.val x)
-    simp only [ha, List.head_cons, List.singleton_append]
-    exact congrArg (a :: ·) (ih _)
-
-/-- **Single-symbol left-ISL ⊆ left-subsequential.** -/
+/-- **Single-symbol left-ISL ⊆ synchronous**: the bounded input window that makes
+`ISLRule.toFinSFST` finite-state is already the `Mealy` state. -/
 theorem isMealyComputable_of_ISLRule {α β : Type*} {k : ℕ} [Fintype α] (r : ISLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) : IsMealyComputable r.apply :=
-  by rw [← r.toMealy_run_eq_apply hs]; exact (r.toMealy hs).isMealyComputable
+  r.toFinSFST_run_eq_apply ▸ r.toFinSFST.isMealyComputable (fun w x => hs w.val x) fun _ => rfl
 
-/-- A length-preserving (single-symbol) left-OSL rule as a synchronous transducer: the
-bounded output window is the state. -/
-def OSLRule.toMealy {α β : Type*} {k : ℕ} (r : OSLRule k α β)
-    (hs : ∀ w x, (r.windowOutput w x).length = 1) :
-    Mealy {l : List β // l.length ≤ k - 1} α β where
-  initial := ⟨[], Nat.zero_le _⟩
-  step w x := ⟨(w.val ++ r.windowOutput w.val x).rtake (k - 1), List.length_rtake_le _ _⟩
-  output w x := (r.windowOutput w.val x).head
-    (by have := hs w.val x; exact List.ne_nil_of_length_pos (by omega))
-
-theorem OSLRule.toMealy_run_eq_apply {α β : Type*} {k : ℕ} [Fintype β] (r : OSLRule k α β)
-    (hs : ∀ w x, (r.windowOutput w x).length = 1) : (r.toMealy hs).run = r.apply := by
-  rw [← r.toFinSFST_run_eq_apply]
-  funext input
-  suffices h : ∀ w : {l : List β // l.length ≤ k - 1},
-      Mealy.runFrom (r.toMealy hs) w input = SFST.runFrom r.toFinSFST w input from h _
-  intro w
-  induction input generalizing w with
-  | nil => rfl
-  | cons x xs ih =>
-    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, OSLRule.toMealy,
-      OSLRule.toFinSFST]
-    obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs w.val x)
-    simp only [ha, List.head_cons, List.singleton_append]
-    exact congrArg (a :: ·) (ih _)
-
-/-- **Single-symbol left-OSL ⊆ left-subsequential.** -/
+/-- **Single-symbol left-OSL ⊆ synchronous**, with the bounded output window as the state. -/
 theorem isMealyComputable_of_OSLRule {α β : Type*} {k : ℕ} [Fintype β] (r : OSLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) : IsMealyComputable r.apply :=
-  by rw [← r.toMealy_run_eq_apply hs]; exact (r.toMealy hs).isMealyComputable
+  r.toFinSFST_run_eq_apply ▸ r.toFinSFST.isMealyComputable (fun w x => hs w.val x) fun _ => rfl
 
-/-- **Single-symbol left-ISL ⊆ WD** — extends the lattice down through subsequential. -/
+/-- **Single-symbol left-ISL ⊆ WD** — extends the lattice down through the synchronous
+class. -/
 theorem IsBimachineWeaklyDeterministic.of_ISLRule {α : Type*} {k : ℕ} [Fintype α] [DecidableEq α]
     (r : ISLRule k α α) (hs : ∀ w x, (r.windowOutput w x).length = 1) :
     IsBimachineWeaklyDeterministic r.apply :=

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
 import Linglib.Core.Computability.Mealy
+import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 
@@ -118,17 +119,25 @@ depend on input position `1`. -/
 
 section Footprint
 
-variable {α β : Type*}
+variable {σ α β : Type*}
 
-/-- A Mealy-computable map is left-determined at every coordinate — output `i` depends
-only on the prefix `{k | k ≤ i}`. -/
-theorem IsMealyComputable.leftDetermined {f : List α → List β}
-    (hf : IsMealyComputable f) (i : ℕ) : LeftDetermined f i := by
-  obtain ⟨σ, _, T, rfl⟩ := hf
+/-- A synchronous machine is left-determined at every coordinate — output `i` depends only
+on the prefix `{k | k ≤ i}`. Finiteness is irrelevant, so this is stated for the machine. -/
+theorem Mealy.leftDetermined (T : Mealy σ α β) (i : ℕ) : LeftDetermined T.run i := by
   intro u v hlen hag
   simp only [Set.mem_setOf_eq] at hag
   rw [T.getElem?_run u, T.getElem?_run v, hag i le_rfl,
     take_eq_of_agree fun k hk => hag k hk.le]
+
+/-- A synchronous machine is right-myopic: it has no look-ahead. -/
+theorem Mealy.isRightMyopic (T : Mealy σ α β) : IsMyopicTowards T.run .right :=
+  IsMyopicTowards.right_of_leftDetermined T.leftDetermined
+
+/-- A Mealy-computable map is left-determined at every coordinate. -/
+theorem IsMealyComputable.leftDetermined {f : List α → List β}
+    (hf : IsMealyComputable f) (i : ℕ) : LeftDetermined f i := by
+  obtain ⟨σ, _, T, rfl⟩ := hf
+  exact T.leftDetermined i
 
 /-- A Mealy-computable map is right-myopic: it has no look-ahead. -/
 theorem IsMealyComputable.isRightMyopic {f : List α → List β}

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -148,27 +148,20 @@ end Footprint
 
 variable {α : Type*} [DecidableEq α]
 
-private theorem unite_default_right (cL a : α) : unite cL a a = cL := by
-  unfold unite; split_ifs <;> simp_all
-
 /-- **Synchronous ⊆ weakly deterministic.** A Mealy-computable function is computed by a
 non-interacting bimachine: the left automaton *is* the transducer, the right automaton is
 trivial, so the cell output is a one-sided rule (`ωR` is the identity). -/
 theorem IsBimachineWeaklyDeterministic.of_mealyComputable {f : List α → List α}
     (h : IsMealyComputable f) : IsBimachineWeaklyDeterministic f := by
   obtain ⟨σ, _, T, rfl⟩ := h
-  set B : Bimachine σ Unit α α :=
+  let B : Bimachine σ Unit α α :=
     { lInit := T.initial, lStep := T.step,
-      rInit := (), rStep := fun _ _ => (), out := fun l a _ => T.output l a } with hB
-  have hrun : B.run = T.run := by
-    funext xs
-    apply List.ext_getElem?
-    intro i
-    rw [Bimachine.run_getElem?, T.getElem?_run]
-    rfl
-  have hni : B.IsNonInteracting :=
-    ⟨T.output, fun _ a => a, fun l a r => (unite_default_right _ _).symm⟩
-  exact hrun ▸ isBimachineWeaklyDeterministic B hni
+      rInit := (), rStep := fun _ _ => (), out := fun l a _ => T.output l a }
+  have hrun : B.run = T.run :=
+    funext fun xs => List.ext_getElem? fun i => by
+      rw [Bimachine.run_getElem?, T.getElem?_run]; rfl
+  exact hrun ▸ isBimachineWeaklyDeterministic B
+    ⟨T.output, fun _ a => a, fun l a r => (unite_right_self _ _).symm⟩
 
 /-- **Weakly deterministic ⊆ regular.** A non-interacting bimachine is a bimachine. -/
 theorem IsBimachineComputable.of_weaklyDeterministic {f : List α → List α}

--- a/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Hierarchy.lean
@@ -21,18 +21,19 @@ Inclusions among the directionality classes of the transducer substrate — stri
 A synchronous transducer is the degenerate bimachine whose right automaton is trivial, so
 its cell output is a *one-sided* rule — non-interacting.
 
+Each file states the facts internal to its own classes; this one holds only the edges
+between them. The properness of `IsBimachineWeaklyDeterministic ⊆ IsBimachineComputable`
+is in `Bimachine.lean`, with the machine conversions in `Subsequential.lean`.
+
 ## Main theorems
 
+* `IsMealyComputable.isLeftSubsequential`: synchronous ⊆ block subsequential
 * `IsBimachineWeaklyDeterministic.of_mealyComputable`: synchronous ⊆ weakly deterministic
 * `IsBimachineComputable.of_weaklyDeterministic`: weakly deterministic ⊆ regular
-* `weaklyDeterministic_strict_subset_regular`: that inclusion is proper, witnessed by the
-  conjunctive change `conjBM`, which is bimachine-computable but `RequiresBothSides`
 * `isMealyComputable_of_ISLRule`, `isMealyComputable_of_OSLRule`: the single-symbol
   (length-preserving) fragment of the strictly-local classes is synchronous
-* `SFST.toMealy`, `Mealy.toSFST`: singleton-output block transducers and synchronous
-  machines are interchangeable, giving `IsMealyComputable.isLeftSubsequential`
-* `IsMealyComputable.leftDetermined`, `IsMealyComputable.isRightMyopic`: a synchronous map
-  is prefix-determined at every coordinate, hence has no look-ahead
+* `Mealy.leftDetermined`, `Mealy.isRightMyopic`: a synchronous map is prefix-determined at
+  every coordinate, hence has no look-ahead
 
 ## TODO
 
@@ -45,64 +46,11 @@ its cell output is a *one-sided* rule — non-interacting.
 
 namespace Subregular
 
-/-! ### Synchronous ⊆ block subsequential
-
-A `Mealy` machine is an `SFST` emitting singleton blocks with an empty final flush, so
-the synchronous class embeds in the block class scanning the same direction. -/
-
 section MealyBlock
 
-variable {σ α β : Type*}
+variable {α β : Type*}
 
-/-- View a synchronous transducer as a block `SFST`: singleton outputs, empty flush. -/
-def Mealy.toSFST (T : Mealy σ α β) : SFST σ α β where
-  start := T.initial
-  step := T.step
-  output s x := [T.output s x]
-  finalOutput _ := []
-
-@[simp] theorem Mealy.toSFST_runFrom (T : Mealy σ α β) (s : σ) (xs : List α) :
-    T.toSFST.runFrom s xs = T.runFrom s xs := by
-  induction xs generalizing s with
-  | nil => rfl
-  | cons x xs ih => rw [SFST.runFrom_cons, Mealy.runFrom_cons, ih]; rfl
-
-@[simp] theorem Mealy.toSFST_run (T : Mealy σ α β) : T.toSFST.run = T.run :=
-  funext fun xs => T.toSFST_runFrom T.initial xs
-
-/-- View a block transducer emitting exactly one symbol per input symbol as a synchronous
-machine: the singleton output block is the emitted letter. -/
-@[simps]
-def SFST.toMealy (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1) : Mealy σ α β where
-  initial := T.start
-  step := T.step
-  output s x := (T.output s x).head (List.ne_nil_of_length_pos (by rw [hs]; omega))
-
-@[simp] theorem Mealy.toMealy_toSFST (T : Mealy σ α β) :
-    T.toSFST.toMealy (fun _ _ => rfl) = T := rfl
-
-@[simp] theorem SFST.toMealy_runFrom (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
-    (hf : ∀ s, T.finalOutput s = []) (s : σ) (xs : List α) :
-    (T.toMealy hs).runFrom s xs = T.runFrom s xs := by
-  induction xs generalizing s with
-  | nil => simp [hf]
-  | cons x xs ih =>
-    obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs s x)
-    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, toMealy_output, toMealy_step, ih, ha,
-      List.head_cons, List.singleton_append]
-
-@[simp] theorem SFST.toMealy_run (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
-    (hf : ∀ s, T.finalOutput s = []) : (T.toMealy hs).run = T.run :=
-  funext fun xs => T.toMealy_runFrom hs hf T.start xs
-
-/-- A finite block transducer with singleton outputs and no final flush computes a
-Mealy-computable function: block ∩ length-preserving ⊆ synchronous. -/
-theorem SFST.isMealyComputable [Fintype σ] (T : SFST σ α β)
-    (hs : ∀ s x, (T.output s x).length = 1) (hf : ∀ s, T.finalOutput s = []) :
-    IsMealyComputable T.run :=
-  T.toMealy_run hs hf ▸ (T.toMealy hs).isMealyComputable
-
-/-- A Mealy-computable function is left-subsequential: synchronous ⊆ block. -/
+/-- **Synchronous ⊆ block subsequential**, via the `Mealy.toSFST` view. -/
 theorem IsMealyComputable.isLeftSubsequential {f : List α → List β}
     (hf : IsMealyComputable f) : IsLeftSubsequential f := by
   obtain ⟨σ, _, T, rfl⟩ := hf
@@ -168,53 +116,6 @@ theorem IsBimachineComputable.of_weaklyDeterministic {f : List α → List α}
     (h : IsBimachineWeaklyDeterministic f) : IsBimachineComputable f := by
   obtain ⟨L, R, _, _, B, rfl, _⟩ := h
   exact isBimachineComputable B
-
-/-! ### Strictness: WD ⊊ regular
-
-A *conjunctive* change — a symbol flipped iff a mark occurs on **both** sides — is
-bimachine-computable but `RequiresBothSides`, so no non-interacting bimachine computes
-it. -/
-
-/-- Toy alphabet for the conjunctive witness: a `mark`, a `neutral` symbol, and the
-`flipped` form the neutral symbol takes when both sides are marked. -/
-inductive ConjSym | mark | neutral | flipped
-  deriving DecidableEq, Repr
-
-instance : Fintype ConjSym := ⟨{.mark, .neutral, .flipped}, fun x => by cases x <;> simp⟩
-
-/-- A neutral symbol flips iff a `mark` occurs on **both** sides — a flag bimachine
-(`Bimachine.ofFlags`) tracking a mark on each side, whose cell genuinely needs both
-flags (`l && r`). -/
-def conjBM : Bimachine Bool Bool ConjSym ConjSym :=
-  .ofFlags (· == .mark) (· == .mark) fun l s r =>
-    if (l && r) && s == .neutral then .flipped else s
-
-/-- Inside the filler run of a flank word, `conjBM` flips the neutral symbol exactly when
-both flanks are marks. -/
-private theorem conjBM_flankWord {x y : ConjSym} {n k : ℕ} (h0 : 0 < k) (hk : k ≤ n) :
-    (conjBM.run (flankWord x .neutral y n))[k]?
-      = some (if x == .mark && y == .mark then .flipped else .neutral) := by
-  rw [conjBM, Bimachine.ofFlags_run_getElem?, flankWord_getElem?_mid h0 hk,
-    any_take_flankWord (by decide) h0 (by omega),
-    any_drop_flankWord (by decide) (by omega) (by omega)]
-  simp
-
-/-- The conjunctive change requires both sides: with a mark on each flank the medial
-symbol flips, and demoting either mark alone reverts it — the three-map template
-(`RequiresBothSides.of_flanks`) applied to a `d`-margined flank word. -/
-theorem conjBM_requiresBothSides : RequiresBothSides conjBM.run :=
-  .of_flanks (fill := .neutral) (on := .flipped) (xOn := .mark) (yOn := .mark)
-    (xOff := .neutral) (yOff := .neutral) (n := fun d => 2 * d + 1) (t := fun d => d + 1)
-    (by decide) (fun d => ⟨by omega, by omega⟩)
-    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
-    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
-    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
-
-theorem weaklyDeterministic_strict_subset_regular :
-    ∃ f : List ConjSym → List ConjSym,
-      IsBimachineComputable f ∧ ¬ IsBimachineWeaklyDeterministic f :=
-  ⟨conjBM.run, isBimachineComputable conjBM,
-   not_isBimachineWeaklyDeterministic_of_requiresBothSides conjBM_requiresBothSides⟩
 
 /-! ### The strictly-local lower end: single-symbol ISL/OSL ⊆ synchronous
 

--- a/Linglib/Core/Computability/Subregular/Function/ISL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/ISL.lean
@@ -33,7 +33,7 @@ function-level subregular hierarchy.
 * `isRightInputStrictlyLocal_iff_left_reverse` — the right class is the
   reverse-conjugate of the left class.
 * `isLeftInputStrictlyLocal_left_subsequential` — every Left-ISL
-  function is Left-Subsequential, witnessed by `ISLRule.toSFST`.
+  function is Left-Subsequential, witnessed by `ISLRule.toFinSFST`.
 * `flatMap_isLeftInputStrictlyLocal_one`,
   `filterMap_isLeftInputStrictlyLocal_one` — letterwise homomorphisms and
   erasing (tier) projections are the `k = 1` specialisation.

--- a/Linglib/Core/Computability/Subregular/Function/OSL.lean
+++ b/Linglib/Core/Computability/Subregular/Function/OSL.lean
@@ -32,7 +32,7 @@ ISL ⊊ OSL ⊊ Subsequential.
 * `isRightOutputStrictlyLocal_iff_left_reverse` — Right-OSL is the
   reverse-conjugate of Left-OSL.
 * `isLeftOutputStrictlyLocal_left_subsequential` — Left-OSL ⊆
-  Left-Subsequential, via `OSLRule.toSFST`.
+  Left-Subsequential, via `OSLRule.toFinSFST`.
 
 ## Implementation notes
 
@@ -43,10 +43,6 @@ OSL window is over **already-emitted output** — each step truncates
 `outputWindow ++ windowOutput outputWindow x` to the last `k - 1`
 symbols before recursing. The `k` parameter is a type-level annotation;
 window-length truncation in `applyAux` is what enforces it semantically.
-
-`OSLRule.toSFST` deliberately repeats `r.windowOutput outputWindow x`
-in the two tuple components of `step` rather than `let`-binding it, so
-that `(step ow x).2` reduces definitionally for `toSFST_run_eq_apply`.
 -/
 
 namespace Subregular

--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Set.Basic
 import Linglib.Core.Computability.Subregular.Function.Defs
 
 /-!
-# Side-determinacy: myopia and unbounded circumambience
+# Side-determinacy: myopia and unbounded semiambience
 
 Locality predicates on string functions for the function-level subregular hierarchy.
 The kernel `OutputDependsOn f i K` says output coordinate `i` of `f` is fixed by the
@@ -16,8 +16,8 @@ input positions in `K`. Two notions are instances:
 
 * **Myopia** (the "no look-ahead" condition): a side's influence on the output is
   *bounded*.
-* **Unbounded circumambience**: some target depends on input *arbitrarily far on both
-  sides at once*.
+* **Unbounded semiambience**: some target is swayed from *either* side, arbitrarily far
+  away — each side alone suffices, so no *one* side determines the target.
 
 ## Main definitions
 
@@ -25,24 +25,24 @@ input positions in `K`. Two notions are instances:
 * `UnboundedDependence f s` — for every distance `d`, some output flips under a
   perturbation strictly beyond `d` on side `s`.
 * `IsMyopicTowards f s` — the negation: dependence on side `s` is bounded.
-* `IsUnboundedCircumambient` — co-located form: for every `d`, ONE base word with a
-  target that flips under both a far-left and a far-right perturbation.
+* `IsUnboundedSemiambient` — co-located form: for every `d`, ONE base word with a
+  target that flips under a far-left perturbation and under a far-right one.
 
 ## Implementation notes
 
 The predicates are **distance-based** (`∀ d, ∃ word + target`), not fixed-index. A
 fixed target index has only finitely many positions to its left, so a fixed-index
 "unbounded left dependence" is unsatisfiable; the unbounded distance must be witnessed
-by ever-longer words. The co-located `IsUnboundedCircumambient` keeps both
+by ever-longer words. The co-located `IsUnboundedSemiambient` keeps both
 perturbations on a single shared base, so any computing automaton hits one context
 where neither side alone fixes the output.
 
-Circumambience is *not* the weak-determinism boundary: a map can be
-`IsUnboundedCircumambient` yet weakly deterministic (a two-sided *union* spread is
-perturbed at one output by either side, but neither side alone reverts it). The
+Semiambience is *not* the weak-determinism boundary: a map can be
+`IsUnboundedSemiambient` yet weakly deterministic (a two-sided *union* is perturbed at
+one output by either side, but neither side alone reverts it). The
 not-weakly-deterministic classification is driven by the strictly stronger
 `RequiresBothSides` (in `Bimachine.lean`), where perturbing either far side reverts
-the target to the identity.
+the target to the identity — *both* sides are needed at once, which is the boundary.
 -/
 
 namespace Subregular
@@ -112,33 +112,34 @@ def IsFarPerturbation (base u : List α) (i d : ℕ) (s : Direction) : Prop :=
     | .left => AgreeFrom base u (i - d)
     | .right => AgreeUpto base u (i + d)
 
-/-- **Unbounded circumambience**, co-located: for every `d`, one base word with a
-target `i` whose output flips under a far perturbation on either side. Co-location
-keeps both flips on a single base (one automaton context). -/
-def IsUnboundedCircumambient (f : List α → List β) : Prop :=
+/-- **Unbounded semiambience**, co-located: for every `d`, one base word with a target
+`i` whose output flips under a far perturbation on either side. Co-location keeps both
+flips on a single base (one automaton context). Each side alone sways the target, so
+this is weaker than needing both at once (`RequiresBothSides`). -/
+def IsUnboundedSemiambient (f : List α → List β) : Prop :=
   ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧
     ∀ s, ∃ u, IsFarPerturbation base u i d s ∧ (f base)[i]? ≠ (f u)[i]?
 
-/-- Co-located circumambience yields unbounded dependence on the left. -/
-theorem IsUnboundedCircumambient.left {f : List α → List β}
-    (h : IsUnboundedCircumambient f) : UnboundedDependence f .left := by
+/-- Co-located semiambience yields unbounded dependence on the left. -/
+theorem IsUnboundedSemiambient.left {f : List α → List β}
+    (h : IsUnboundedSemiambient f) : UnboundedDependence f .left := by
   intro d
   obtain ⟨base, i, hi, hw⟩ := h d
   obtain ⟨uL, ⟨hlen, hag⟩, hne⟩ := hw .left
   exact ⟨base, uL, i, hlen.symm, hi, hag, hne⟩
 
 /-- …and on the right. -/
-theorem IsUnboundedCircumambient.right {f : List α → List β}
-    (h : IsUnboundedCircumambient f) : UnboundedDependence f .right := by
+theorem IsUnboundedSemiambient.right {f : List α → List β}
+    (h : IsUnboundedSemiambient f) : UnboundedDependence f .right := by
   intro d
   obtain ⟨base, i, hi, hw⟩ := h d
   obtain ⟨uR, ⟨hlen, hag⟩, hne⟩ := hw .right
   exact ⟨base, uR, i, hlen.symm, hi, hag, hne⟩
 
-/-- **Circumambient ⟹ not myopic** (either side): a real consequence, since
-circumambience exhibits unbounded dependence on each side. -/
-theorem IsUnboundedCircumambient.not_myopic {f : List α → List β}
-    (h : IsUnboundedCircumambient f) (s : Direction) : ¬ IsMyopicTowards f s := by
+/-- **Semiambient ⟹ not myopic** (either side): a real consequence, since semiambience
+exhibits unbounded dependence on each side. -/
+theorem IsUnboundedSemiambient.not_myopic {f : List α → List β}
+    (h : IsUnboundedSemiambient f) (s : Direction) : ¬ IsMyopicTowards f s := by
   cases s with
   | left => exact not_not_intro h.left
   | right => exact not_not_intro h.right

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.Finset.Lattice.Fold
+import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.Defs
 
 /-!
@@ -27,6 +28,8 @@ isomorphic under input/output reversal (`f` is right-subsequential iff
 * `SFST.run`, `SFST.runRight`: the left-to-right and right-to-left passes
 * `SFST.comp`: the product machine, computing the composite function
 * `SFST.reindex`: lifts an equivalence on states to an equivalence on machines
+* `Mealy.toSFST`, `SFST.toMealy`: the synchronous and block machine views of each
+  other, mutually inverse on singleton-output transducers with no final flush
 * `IsLeftSubsequential f`, `IsRightSubsequential f`, `IsSubsequential d f`: `f` is
   computed by some finite-state `SFST` scanning in the given direction
 
@@ -219,6 +222,66 @@ def comp : SFST (σ' × σ) α γ where
 end Comp
 
 end SFST
+
+/-! ### Synchronous machines as block transducers
+
+A `Mealy` machine is an `SFST` emitting singleton blocks with an empty final flush; a
+block transducer of that shape is a `Mealy` machine. The two views are mutually
+inverse. -/
+
+section Synchronous
+
+variable {σ α β : Type*}
+
+/-- View a synchronous transducer as a block `SFST`: singleton outputs, empty flush. -/
+def Mealy.toSFST (T : Mealy σ α β) : SFST σ α β where
+  start := T.initial
+  step := T.step
+  output s x := [T.output s x]
+  finalOutput _ := []
+
+@[simp] theorem Mealy.toSFST_runFrom (T : Mealy σ α β) (s : σ) (xs : List α) :
+    T.toSFST.runFrom s xs = T.runFrom s xs := by
+  induction xs generalizing s with
+  | nil => rfl
+  | cons x xs ih => rw [SFST.runFrom_cons, Mealy.runFrom_cons, ih]; rfl
+
+@[simp] theorem Mealy.toSFST_run (T : Mealy σ α β) : T.toSFST.run = T.run :=
+  funext fun xs => T.toSFST_runFrom T.initial xs
+
+/-- View a block transducer emitting exactly one symbol per input symbol as a synchronous
+machine: the singleton output block is the emitted letter. -/
+@[simps]
+def SFST.toMealy (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1) : Mealy σ α β where
+  initial := T.start
+  step := T.step
+  output s x := (T.output s x).head (List.ne_nil_of_length_pos (by rw [hs]; omega))
+
+@[simp] theorem Mealy.toMealy_toSFST (T : Mealy σ α β) :
+    T.toSFST.toMealy (fun _ _ => rfl) = T := rfl
+
+@[simp] theorem SFST.toMealy_runFrom (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+    (hf : ∀ s, T.finalOutput s = []) (s : σ) (xs : List α) :
+    (T.toMealy hs).runFrom s xs = T.runFrom s xs := by
+  induction xs generalizing s with
+  | nil => simp [hf]
+  | cons x xs ih =>
+    obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs s x)
+    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, toMealy_output, toMealy_step, ih, ha,
+      List.head_cons, List.singleton_append]
+
+@[simp] theorem SFST.toMealy_run (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+    (hf : ∀ s, T.finalOutput s = []) : (T.toMealy hs).run = T.run :=
+  funext fun xs => T.toMealy_runFrom hs hf T.start xs
+
+/-- A finite block transducer with singleton outputs and no final flush computes a
+Mealy-computable function: block ∩ length-preserving ⊆ synchronous. -/
+theorem SFST.isMealyComputable [Fintype σ] (T : SFST σ α β)
+    (hs : ∀ s x, (T.output s x).length = 1) (hf : ∀ s, T.finalOutput s = []) :
+    IsMealyComputable T.run :=
+  T.toMealy_run hs hf ▸ (T.toMealy hs).isMealyComputable
+
+end Synchronous
 
 /-! ### Subsequential classification predicates -/
 

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -26,9 +26,9 @@ definition H-linkedness of timing node `i` in the output representation `plateau
 derived `utp.surfaces_def`. The map is `utp.map`, the surfacing set `plateau`.
 
 The map is the flagship *unbounded circumambient* process: whether a position changes
-depends on unboundedly distant material on **both** sides
-(`utp.isUnboundedCircumambient`), and in the strong witness form
-`utp.requiresBothSides` — perturbing either far side alone reverts the change — which
+depends on unboundedly distant material on **both** sides, in the strong witness form
+`utp.requiresBothSides` — perturbing either far side alone reverts the change — with
+the weaker `utp.isUnboundedSemiambient` as a corollary, which
 feeds the weak-determinism exclusion theorems of `Studies/Jardine2016Tone` (bimachine
 rendering) and `Studies/Yolyan2025` (BMRS rendering).
 
@@ -559,9 +559,10 @@ conjunction, so deleting either flanking H reverts the plateau target. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map :=
   utp.requiresBothSides_of_surfaces_iff fun _ _ => utp.surfaces_iff
 
-/-- UTP is an unbounded circumambient process: whether a position changes depends on
+/-- UTP is unbounded semiambient, a corollary of its circumambience: whether a position
+changes depends on
 unboundedly distant material on both sides. -/
-theorem utp.isUnboundedCircumambient : IsUnboundedCircumambient utp.map :=
-  utp.requiresBothSides.isUnboundedCircumambient
+theorem utp.isUnboundedSemiambient : IsUnboundedSemiambient utp.map :=
+  utp.requiresBothSides.isUnboundedSemiambient
 
 end Tone.Plateauing

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -26,7 +26,7 @@ representation (§4.1: `H` a H-toned TBU, `O` the paper's Ø).
 
 The map itself and its plateau/circumambience API live in `Phonology/Tone/Plateauing`
 (the rule set (36) as `utp.map_toneless`/`utp.map_single`/`utp.map_plateau`; definition (2) as
-`utp.isUnboundedCircumambient`); this file keeps the paper's theorems about it.
+`utp.isUnboundedSemiambient`); this file keeps the paper's theorems about it.
 
 ## Main definitions
 
@@ -51,8 +51,9 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
 * `utp_fullyRegular` — §7: UTP is regular but neither subsequential nor weakly
   deterministic.
 
-Contrast `Studies/MeinhardtEtAl2024`: ATR spreading is circumambient as covariation yet
-weakly deterministic; UTP's `RequiresBothSides` pushes it above that bound.
+Contrast `Studies/MeinhardtEtAl2024`: Maasai ATR spreading is unbounded *semiambient*
+yet weakly deterministic; UTP's `RequiresBothSides` — circumambience proper — pushes it
+above that bound.
 -/
 
 namespace Jardine2016Tone

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -38,12 +38,13 @@ is myopic; Tutrugbu is the segmental case the myopic-side replies do not dissolv
 
 `Seg` is a toy alphabet (prefix vowels ±high × ±ATR-surface; root ±ATR). `tutrugbuATR`
 implements the conditional-blocking rule faithfully; the paper's exx. (3)-(8) are
-decide-checked as stimulus contrasts. `tutrugbu_isUnboundedCircumambient` and
-`tutrugbu_nonmyopic` connect it to the substrate predicates in `SideDeterminacy.lean`.
+decide-checked as stimulus contrasts. `tutrugbu_isUnboundedSemiambient` and
+`tutrugbu_nonmyopic` connect it to the substrate predicates in `SideDeterminacy.lean`,
+and `tutrugbu_requiresBothSides` is the circumambience proper — both sides needed at
+once, which semiambience alone does not give.
 
 The machine-level classification (circumambient ⟹ non-deterministic, *not* weakly
-deterministic) needs bimachine substrate and is deferred; the co-located
-circumambience proved here is exactly what that argument consumes.
+deterministic) is what that witness feeds.
 -/
 
 namespace McCollumEtAl2020
@@ -247,12 +248,13 @@ theorem baseR_get_target (d : ℕ) : (tutrugbuATR (baseR d))[d + 1]? = some .vLo
   rw [tutrugbuATR_baseR]
   simp [baseR, pre]
 
-/-- **Tutrugbu ATR harmony is unbounded circumambient**
-([mccollum-bakovic-mai-meinhardt-2020] §3, def. 13). At the medial target (index
-`d+1`): the base harmonises it ([+ATR]); flipping the initial-σ height `d` syllables
-to the left blocks it; flipping the root `d` syllables to the right removes the
-trigger — both from the one base word. -/
-theorem tutrugbu_isUnboundedCircumambient : IsUnboundedCircumambient tutrugbuATR := by
+/-- **Tutrugbu ATR harmony is unbounded semiambient**
+([mccollum-bakovic-mai-meinhardt-2020] §3, def. 13) — the weaker two-sided diagnostic;
+full circumambience is `tutrugbu_requiresBothSides`. At the medial target (index `d+1`):
+the base harmonises it ([+ATR]); flipping the initial-σ height `d` syllables to the left
+blocks it; flipping the root `d` syllables to the right removes the trigger — both from
+the one base word. -/
+theorem tutrugbu_isUnboundedSemiambient : IsUnboundedSemiambient tutrugbuATR := by
   intro d
   refine ⟨base d, d + 1, ?_, fun s => ?_⟩
   · -- the target is in-domain: d + 1 < (base d).length  (= 2d+3)
@@ -290,7 +292,7 @@ theorem tutrugbu_isUnboundedCircumambient : IsUnboundedCircumambient tutrugbuATR
 the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
 nonmyopic side argued by [walker-2010]. -/
 theorem tutrugbu_nonmyopic (s : Direction) : ¬ IsMyopicTowards tutrugbuATR s :=
-  tutrugbu_isUnboundedCircumambient.not_myopic s
+  tutrugbu_isUnboundedSemiambient.not_myopic s
 
 /-- The input symbol at the target index is the recessive `.vLo` (for any initial and
 root): the prefix sequence places a `[−high]` vowel there. -/

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -27,14 +27,14 @@ class. Their thesis:
 * **Bidirectional** iterative ATR harmony in Maasai and Turkana (Eastern
   Nilotic) is *attested* and **WD** — a composition of two subsequential
   FSTs reading from opposite directions, where the two passes do not
-  interact in the technical sense the paper formalises (§5).
+  interact in the technical sense the paper formalises (§4.2).
 * Hypothetical *unbounded-circumambient* "sour grapes" patterns
   ([wilson-2003]; [wilson-2006]) are *unattested* and
   **non-deterministic** — the inner and outer passes interact, placing
   the function strictly above WD in the hierarchy (Fig. 1).
 * The original Heinz-Lai 2013 WD definition was too permissive,
   admitting some unattested patterns; Meinhardt et al. patch it by
-  formalising the *interaction* condition explicitly (§§5–6).
+  formalising the *interaction* condition explicitly (§4).
 
 ## Maasai dominant/recessive harmony (paper §3.1, p. 1203)
 
@@ -65,8 +65,9 @@ Per CLAUDE.md "stimulus contrasts" discipline for Studies files:
    formaliser-invented alphabet from the previous version of this file
    (which conflated [+ATR] with the spreading trigger) is replaced.
 2. Encodes the **rightward [+ATR] spreading** half of Maasai harmony
-   as both a `SFST` and an `OSLRule`. Per paper §5.4 (p. 45), single-
-   direction iterative spreading is **Output-Strictly-Local** — the
+   as both a `SFST` and an `OSLRule`. Single-direction iterative
+   spreading is **Output-Strictly-Local** ([chandlee-eyraud-heinz-2015],
+   the result [meinhardt-mai-bakovic-mccollum-2024] builds on) — the
    output decision at each position depends on whether the immediately
    preceding **output** symbol is +ATR. The OSL classification is
    tighter than Left-Subsequential and is what the paper actually
@@ -181,10 +182,10 @@ phonological maps). Rule logic:
   (spread continues).
 * Current input is `recL` otherwise → emit `recL` (no spread to here).
 
-Per paper §5.4 (p. 45): single-direction iterative spreading patterns
-are OSL but not ISL, because the output decision genuinely depends on
-the *output* history (how spread has propagated) rather than the *input*
-history alone. -/
+Single-direction iterative spreading patterns are OSL but not ISL
+([chandlee-eyraud-heinz-2015]), because the output decision genuinely
+depends on the *output* history (how spread has propagated) rather than
+the *input* history alone. -/
 def rightwardATR_osl : OSLRule 2 Seg Seg where
   windowOutput outputWindow currentInput :=
     match currentInput, outputWindow with
@@ -260,8 +261,9 @@ example : rightwardATR.run [.dom, .recL, .a, .recL]
 -- ============================================================================
 
 /-- **Rightward [+ATR] spreading is Left-Output-Strictly-Local**
-([chandlee-eyraud-heinz-2015]; [meinhardt-mai-bakovic-mccollum-2024]
-§5.4). Witness: the OSL rule `rightwardATR_osl` defined above.
+([chandlee-eyraud-heinz-2015], the result
+[meinhardt-mai-bakovic-mccollum-2024] builds on). Witness: the OSL rule
+`rightwardATR_osl` defined above.
 
 This is the **tighter** classification per the paper — single-direction
 iterative spreading patterns are properly contained in OSL, strictly

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -75,9 +75,9 @@ Per CLAUDE.md "stimulus contrasts" discipline for Studies files:
    ex 1a-ii from the paper (encoded in the toy alphabet).
 4. Proves the **bidirectional** dominant-recessive map `maasai` is
    **weakly deterministic** (`maasai_weaklyDeterministic`) via a
-   non-interacting bimachine, yet unbounded-circumambient *as
-   covariation* (`maasai_isUnboundedCircumambient`) — the same predicate
-   Tutrugbu satisfies — while *not* `RequiresBothSides`
+   non-interacting bimachine, and unbounded *semiambient*
+   (`maasai_isUnboundedSemiambient`) — a predicate Tutrugbu also
+   satisfies — while *not* `RequiresBothSides`
    (`maasai_not_requiresBothSides`). That asymmetry is the WD/ND boundary
    [meinhardt-mai-bakovic-mccollum-2024] draws.
 
@@ -291,10 +291,10 @@ to `recH` iff the word contains a dominant vowel anywhere (`maasai`). This is a 
 of two independent spreading passes, so it is **weakly deterministic**
 ([meinhardt-mai-bakovic-mccollum-2024], unbounded *semiambient*): the bimachine `maasaiBM`
 tracks a dominant seen on each side and its output is literally a `unite` of one-sided
-rules. Yet — like Tutrugbu — a recessive's surface ATR co-varies with information
-unboundedly far on either side, so `maasai` *also* satisfies `IsUnboundedCircumambient`.
-The contrast is exactly the WD/ND boundary the paper draws: both maps are circumambient
-*as covariation*, but only Tutrugbu `RequiresBothSides` (suppression/conjunction). -/
+rules. A recessive's surface ATR still co-varies with information unboundedly far on
+either side, so `maasai` satisfies `IsUnboundedSemiambient` — as does Tutrugbu. The
+contrast is exactly the WD/ND boundary the paper draws: only Tutrugbu is *circumambient*,
+needing both sides at once (`RequiresBothSides`), which Maasai never does. -/
 
 open Subregular
 
@@ -377,11 +377,12 @@ the bidirectional dominant-recessive spread is a non-interacting bimachine. -/
 theorem maasai_weaklyDeterministic : IsBimachineWeaklyDeterministic maasai :=
   maasaiBM_run ▸ isBimachineWeaklyDeterministic maasaiBM maasaiBM_isNonInteracting
 
-/-- **Maasai is unbounded-circumambient *as covariation*** — at every distance, a medial
-recessive's ATR flips under a dominant placed far to the left *or* far to the right. The
-same predicate Tutrugbu satisfies (`tutrugbu_isUnboundedCircumambient`); the difference is
-that Maasai does *not* `RequiresBothSides`. -/
-theorem maasai_isUnboundedCircumambient : IsUnboundedCircumambient maasai := by
+/-- **Maasai is unbounded semiambient** — at every distance, a medial recessive's ATR
+flips under a dominant placed far to the left *or* far to the right, each side alone
+sufficing. Tutrugbu satisfies this too (`tutrugbu_isUnboundedSemiambient`); the
+difference is that Maasai does *not* `RequiresBothSides`, so it stays weakly
+deterministic. -/
+theorem maasai_isUnboundedSemiambient : IsUnboundedSemiambient maasai := by
   intro d
   refine ⟨List.replicate (2 * d + 3) .recL, d + 1, by simp; omega, fun s => ?_⟩
   match s with
@@ -414,11 +415,11 @@ theorem maasai_not_requiresBothSides : ¬ RequiresBothSides maasai := fun h =>
 /-- Strictness witness `synchronous ⊊ WD`: Maasai is weakly deterministic yet not
 Mealy-computable. A Mealy-computable map is right-myopic
 (`IsMealyComputable.isRightMyopic`), but Maasai's bidirectional spread is not
-(`maasai_isUnboundedCircumambient`). The stronger `¬ IsLeftSubsequential maasai` (the
+(`maasai_isUnboundedSemiambient`). The stronger `¬ IsLeftSubsequential maasai` (the
 *block* class) is not yet formalized: a block transducer can delay output, so it
 needs the bounded-delay route (`IsLeftSubsequential.bounded_delay`) rather than the
 myopia shortcut — see the TODO in `Function/Hierarchy.lean`. -/
 theorem maasai_not_mealyComputable : ¬ IsMealyComputable maasai := fun h =>
-  maasai_isUnboundedCircumambient.not_myopic .right h.isRightMyopic
+  maasai_isUnboundedSemiambient.not_myopic .right h.isRightMyopic
 
 end MeinhardtEtAl2024

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30355,7 +30355,7 @@
   booktitle = {Proceedings of the 13th Meeting on the Mathematics of Language (MoL 13)},
   pages     = {52--63},
   publisher = {Association for Computational Linguistics},
-  url       = {https://aclanthology.org/W13-3007/},
+  url       = {https://aclanthology.org/W13-3006/},
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},


### PR DESCRIPTION
Four-lens audit of `Hierarchy.lean`, executed. No theorem was false; the fixes are duplication, prose, one misnamed predicate, and two bad citations.

- `IsUnboundedCircumambient` → `IsUnboundedSemiambient` (6 files). The predicate is [meinhardt-mai-bakovic-mccollum-2024]'s Def. 3, not their Def. 2, so the Maasai theorem asserted what that paper explicitly denies; `RequiresBothSides` is the circumambience.
- `SFST.toMealy` and the existing `RequiresBothSides.of_flanks` template replace two hand-rolled duplicates; the WD ⊊ regular separation and the Mealy↔SFST conversions move to the files that own them.
- `heinz-lai-2013` pointed at W13-3007, a different paper; `MeinhardtEtAl2024` cited a §5.4 that does not exist.